### PR TITLE
TreeDB: share scalar_u8 quantized assets in prepared search

### DIFF
--- a/TreeDB/collections/collection_vector_index_prepared_search_cache.go
+++ b/TreeDB/collections/collection_vector_index_prepared_search_cache.go
@@ -3,6 +3,7 @@ package collections
 import (
 	"errors"
 	"fmt"
+	"runtime"
 	"sync"
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
@@ -52,6 +53,7 @@ type collectionVectorIndexPreparedSearch struct {
 	quantizedReadersMu        sync.Mutex
 	quantizedReaders          []*columnVectorGraphPhysicalRowReader
 	quantizedAvailableReaders []int
+	sharedQuantizedAssets     map[string]columnVectorGraphQuantizedAssetLoadStatus
 
 	routeStats vectorIndexSearchRouteStats
 	closed     bool
@@ -436,7 +438,7 @@ func (c *Collection) openCollectionVectorIndexPreparedQuantizedSearch(opts Vecto
 		return nil, response, fmt.Errorf("%w: vector index %q SearchVectorIndexWithBuffer quantized mode requires valid vector-index document-id state for no-document result IDs; rebuild the vector index", ErrVectorIndexSearchUnavailable, def.Name)
 	}
 
-	reader, err := c.openColumnVectorGraphPhysicalRowReaderAtSnapshot(def.Name, snap, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: opts.MaxDecodedBlocks})
+	reader, err := c.openColumnVectorGraphPhysicalRowReaderAtSnapshot(def.Name, snap, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: opts.MaxDecodedBlocks, UseResourceQuantizedAssets: true, ForceQuantizedAssetHeapCopy: collectionVectorIndexPreparedScalarU8QuantizedAssetForceHeapCopy()})
 	if err != nil {
 		status, statusErr := c.columnGraphVectorIndexStatusAtSnapshot(def.Name, snap)
 		if statusErr != nil {
@@ -472,6 +474,7 @@ func (c *Collection) openCollectionVectorIndexPreparedQuantizedSearch(opts Vecto
 		return nil, response, err
 	}
 	key = collectionVectorIndexPreparedSearchSnapshotCacheKey(key, snapshotCommitSeq(snap), snapshotSystemRoot(snap))
+	sharedQuantizedAssets := promoteCollectionVectorIndexPreparedScalarU8QuantizedAssets(reader)
 	searcher := &VectorIndexSearcher{
 		collection: c,
 		indexName:  response.IndexName,
@@ -496,6 +499,7 @@ func (c *Collection) openCollectionVectorIndexPreparedQuantizedSearch(opts Vecto
 		searcher:                  searcher,
 		quantizedReaders:          []*columnVectorGraphPhysicalRowReader{reader},
 		quantizedAvailableReaders: []int{0},
+		sharedQuantizedAssets:     sharedQuantizedAssets,
 		routeStats:                routeStats,
 	}, response, nil
 }
@@ -534,6 +538,66 @@ func collectionVectorIndexPreparedQuantizedValidationStats(reader *columnVectorG
 	stats := vectorIndexSearchStatsFromInternal(internal, columnPhysicalRowReaderStats{})
 	routeStats.apply(&stats)
 	return stats
+}
+
+func promoteCollectionVectorIndexPreparedScalarU8QuantizedAssets(reader *columnVectorGraphPhysicalRowReader) map[string]columnVectorGraphQuantizedAssetLoadStatus {
+	if reader == nil || len(reader.quantizedAssetStatus) == 0 {
+		return nil
+	}
+	var out map[string]columnVectorGraphQuantizedAssetLoadStatus
+	for name, status := range reader.quantizedAssetStatus {
+		if !collectionVectorIndexPreparedQuantizedAssetShareable(status) {
+			continue
+		}
+		if out == nil {
+			out = make(map[string]columnVectorGraphQuantizedAssetLoadStatus, 1)
+		}
+		shared := status
+		shared.ownsResource = true
+		attached := status
+		attached.ownsResource = false
+		reader.quantizedAssetStatus[name] = attached
+		out[name] = shared
+	}
+	return out
+}
+
+func collectionVectorIndexPreparedQuantizedAssetShareable(status columnVectorGraphQuantizedAssetLoadStatus) bool {
+	return status.Definition.Codec == QuantizedVectorCodecScalarU8 && status.Prepared != nil && status.Err == nil && status.resource != nil
+}
+
+func collectionVectorIndexPreparedScalarU8QuantizedAssetForceHeapCopy() bool {
+	// On Apple silicon, mmap-backed scalar_u8 random row scoring was measured as a
+	// material regression versus heap bytes. Use one shared resource-managed heap
+	// copy for prepared collection readers on that platform; other mmap-capable
+	// platforms can still use direct mapped views.
+	return runtime.GOOS == "darwin" && runtime.GOARCH == "arm64"
+}
+
+func (p *collectionVectorIndexPreparedSearch) hasSharedQuantizedAsset(name string) bool {
+	if p == nil || name == "" || len(p.sharedQuantizedAssets) == 0 {
+		return false
+	}
+	status, ok := p.sharedQuantizedAssets[name]
+	return ok && collectionVectorIndexPreparedQuantizedAssetShareable(status)
+}
+
+func (p *collectionVectorIndexPreparedSearch) attachSharedQuantizedAssets(reader *columnVectorGraphPhysicalRowReader) error {
+	if p == nil || reader == nil || len(p.sharedQuantizedAssets) == 0 {
+		return nil
+	}
+	if reader.quantizedAssetStatus == nil {
+		reader.quantizedAssetStatus = make(map[string]columnVectorGraphQuantizedAssetLoadStatus, len(p.sharedQuantizedAssets))
+	}
+	for name, status := range p.sharedQuantizedAssets {
+		if !collectionVectorIndexPreparedQuantizedAssetShareable(status) {
+			return fmt.Errorf("%w: quantized asset %q shared prepared resource is closed", errColumnVectorGraphQuantizedAssetClosed, name)
+		}
+		attached := status
+		attached.ownsResource = false
+		reader.quantizedAssetStatus[name] = attached
+	}
+	return nil
 }
 
 func collectionVectorIndexPreparedQuantizedSearchCacheKey(collection string, namespace string, def VectorIndexDefinition, graph columnVectorGraphManifestSnapshot, state columnVectorIndexStateSnapshot, quantizedIndexName string, maxDecodedBlocks int) (string, error) {
@@ -810,9 +874,22 @@ func (p *collectionVectorIndexPreparedSearch) openCollectionVectorIndexPreparedQ
 	if p == nil || p.searcher == nil || p.searcher.collection == nil || p.searcher.snapshot == nil {
 		return nil, collectionVectorIndexPreparedQuantizedValidationStats(nil, vectorIndexSearchRouteStats{}, opts.QuantizedIndexName, queryMode), backenddb.ErrClosed
 	}
-	reader, err := p.searcher.collection.openColumnVectorGraphPhysicalRowReaderAtSnapshot(p.indexName, p.searcher.snapshot, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: opts.MaxDecodedBlocks})
+	readerOpts := columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: opts.MaxDecodedBlocks, UseResourceQuantizedAssets: true, ForceQuantizedAssetHeapCopy: collectionVectorIndexPreparedScalarU8QuantizedAssetForceHeapCopy()}
+	if p.hasSharedQuantizedAsset(opts.QuantizedIndexName) {
+		readerOpts.SkipQuantizedAssets = true
+	}
+	reader, err := p.searcher.collection.openColumnVectorGraphPhysicalRowReaderAtSnapshot(p.indexName, p.searcher.snapshot, readerOpts)
 	if err != nil {
 		return nil, collectionVectorIndexPreparedQuantizedValidationStats(nil, p.routeStats, opts.QuantizedIndexName, queryMode), err
+	}
+	if readerOpts.SkipQuantizedAssets {
+		if err := p.attachSharedQuantizedAssets(reader); err != nil {
+			_ = reader.Close()
+			stats := collectionVectorIndexPreparedQuantizedValidationStats(nil, p.routeStats, opts.QuantizedIndexName, queryMode)
+			stats.QuantizedAssetUnavailable = 1
+			stats.QuantizedAssetClosed = 1
+			return nil, stats, fmt.Errorf("%w: vector index %q SearchVectorIndexWithBuffer quantized mode shared quantized asset is closed: %w", ErrVectorIndexSearchUnavailable, p.indexName, err)
+		}
 	}
 	if !collectionVectorIndexPreparedQuantizedReaderReady(reader) {
 		stats := collectionVectorIndexPreparedQuantizedValidationStats(reader, p.routeStats, opts.QuantizedIndexName, queryMode)
@@ -860,6 +937,10 @@ func (p *collectionVectorIndexPreparedSearch) Close() error {
 	p.quantizedReaders = nil
 	p.quantizedAvailableReaders = nil
 	p.quantizedReadersMu.Unlock()
+	if p.sharedQuantizedAssets != nil {
+		err = errors.Join(err, closeColumnVectorGraphQuantizedAssetLoadStatuses(p.sharedQuantizedAssets))
+		p.sharedQuantizedAssets = nil
+	}
 	if p.searcher != nil {
 		err = errors.Join(err, p.searcher.Close())
 		p.searcher = nil
@@ -893,8 +974,9 @@ func (p *collectionVectorIndexPreparedSearch) stats() mappedresource.Stats {
 	}
 	p.quantizedReadersMu.Lock()
 	seenSharedPrepared := make(map[*columnVectorGraphSharedPreparedSearch]struct{})
+	seenQuantizedResources := make(map[*columnVectorGraphQuantizedAssetResource]struct{})
 	for _, reader := range p.quantizedReaders {
-		addCollectionVectorIndexPreparedQuantizedAssetStats(&out, reader, p.quantizedIndexName)
+		addCollectionVectorIndexPreparedQuantizedAssetStats(&out, reader, p.quantizedIndexName, seenQuantizedResources)
 		if reader == nil {
 			continue
 		}
@@ -912,13 +994,19 @@ func (p *collectionVectorIndexPreparedSearch) stats() mappedresource.Stats {
 	return out
 }
 
-func addCollectionVectorIndexPreparedQuantizedAssetStats(out *mappedresource.Stats, reader *columnVectorGraphPhysicalRowReader, quantizedIndexName string) {
+func addCollectionVectorIndexPreparedQuantizedAssetStats(out *mappedresource.Stats, reader *columnVectorGraphPhysicalRowReader, quantizedIndexName string, seen map[*columnVectorGraphQuantizedAssetResource]struct{}) {
 	if out == nil || reader == nil || quantizedIndexName == "" {
 		return
 	}
 	status, ok := reader.quantizedAssetStatus[quantizedIndexName]
 	if !ok {
 		return
+	}
+	if status.resource != nil && seen != nil {
+		if _, ok := seen[status.resource]; ok {
+			return
+		}
+		seen[status.resource] = struct{}{}
 	}
 	out.ActiveHandles += status.ActiveHandles
 	out.ActiveMappedBytes += int64(status.MappedBytes)

--- a/TreeDB/collections/collection_vector_index_prepared_search_cache.go
+++ b/TreeDB/collections/collection_vector_index_prepared_search_cache.go
@@ -3,7 +3,6 @@ package collections
 import (
 	"errors"
 	"fmt"
-	"runtime"
 	"sync"
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
@@ -438,7 +437,7 @@ func (c *Collection) openCollectionVectorIndexPreparedQuantizedSearch(opts Vecto
 		return nil, response, fmt.Errorf("%w: vector index %q SearchVectorIndexWithBuffer quantized mode requires valid vector-index document-id state for no-document result IDs; rebuild the vector index", ErrVectorIndexSearchUnavailable, def.Name)
 	}
 
-	reader, err := c.openColumnVectorGraphPhysicalRowReaderAtSnapshot(def.Name, snap, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: opts.MaxDecodedBlocks, UseResourceQuantizedAssets: true, ForceQuantizedAssetHeapCopy: collectionVectorIndexPreparedScalarU8QuantizedAssetForceHeapCopy()})
+	reader, err := c.openColumnVectorGraphPhysicalRowReaderAtSnapshot(def.Name, snap, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: opts.MaxDecodedBlocks, UseResourceQuantizedAssets: true})
 	if err != nil {
 		status, statusErr := c.columnGraphVectorIndexStatusAtSnapshot(def.Name, snap)
 		if statusErr != nil {
@@ -564,14 +563,6 @@ func promoteCollectionVectorIndexPreparedScalarU8QuantizedAssets(reader *columnV
 
 func collectionVectorIndexPreparedQuantizedAssetShareable(status columnVectorGraphQuantizedAssetLoadStatus) bool {
 	return status.Definition.Codec == QuantizedVectorCodecScalarU8 && status.Prepared != nil && status.Err == nil && status.resource != nil
-}
-
-func collectionVectorIndexPreparedScalarU8QuantizedAssetForceHeapCopy() bool {
-	// On Apple silicon, mmap-backed scalar_u8 random row scoring was measured as a
-	// material regression versus heap bytes. Use one shared resource-managed heap
-	// copy for prepared collection readers on that platform; other mmap-capable
-	// platforms can still use direct mapped views.
-	return runtime.GOOS == "darwin" && runtime.GOARCH == "arm64"
 }
 
 func (p *collectionVectorIndexPreparedSearch) hasSharedQuantizedAsset(name string) bool {
@@ -874,7 +865,7 @@ func (p *collectionVectorIndexPreparedSearch) openCollectionVectorIndexPreparedQ
 	if p == nil || p.searcher == nil || p.searcher.collection == nil || p.searcher.snapshot == nil {
 		return nil, collectionVectorIndexPreparedQuantizedValidationStats(nil, vectorIndexSearchRouteStats{}, opts.QuantizedIndexName, queryMode), backenddb.ErrClosed
 	}
-	readerOpts := columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: opts.MaxDecodedBlocks, UseResourceQuantizedAssets: true, ForceQuantizedAssetHeapCopy: collectionVectorIndexPreparedScalarU8QuantizedAssetForceHeapCopy()}
+	readerOpts := columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: opts.MaxDecodedBlocks, UseResourceQuantizedAssets: true}
 	if p.hasSharedQuantizedAsset(opts.QuantizedIndexName) {
 		readerOpts.SkipQuantizedAssets = true
 	}

--- a/TreeDB/collections/column_vector_graph_quantized_asset.go
+++ b/TreeDB/collections/column_vector_graph_quantized_asset.go
@@ -4,10 +4,13 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/snissn/gomap/TreeDB/internal/brq"
 	"github.com/snissn/gomap/TreeDB/internal/columnsemantics"
+	"github.com/snissn/gomap/TreeDB/internal/mappedresource"
 	"github.com/snissn/gomap/TreeDB/internal/quantizedasset"
 	"github.com/snissn/gomap/TreeDB/internal/rabitq"
 	"github.com/snissn/gomap/TreeDB/internal/typedcolumn"
@@ -52,6 +55,47 @@ var (
 	errColumnVectorGraphQuantizedAssetClosed  = errors.New("collections: column_graph quantized asset closed")
 )
 
+func (r *columnVectorGraphQuantizedAssetResource) close() error {
+	if r == nil {
+		return nil
+	}
+	r.mu.Lock()
+	if r.closed {
+		r.mu.Unlock()
+		return nil
+	}
+	r.closed = true
+	handle := r.handle
+	r.handle = nil
+	readCache := r.readCache
+	r.readCache = nil
+	r.mu.Unlock()
+	var closeErr error
+	if handle != nil {
+		closeErr = errors.Join(closeErr, handle.Release())
+	}
+	if readCache != nil {
+		closeErr = errors.Join(closeErr, readCache.close())
+	}
+	return closeErr
+}
+
+func (s columnVectorGraphQuantizedAssetLoadStatus) close() error {
+	if !s.ownsResource || s.resource == nil {
+		return nil
+	}
+	return s.resource.close()
+}
+
+func closeColumnVectorGraphQuantizedAssetLoadStatuses(statuses map[string]columnVectorGraphQuantizedAssetLoadStatus) error {
+	var closeErr error
+	for name, status := range statuses {
+		closeErr = errors.Join(closeErr, status.close())
+		delete(statuses, name)
+	}
+	return closeErr
+}
+
 type columnVectorGraphQuantizedAssetLoadStatus struct {
 	Definition    QuantizedVectorIndexDefinition
 	Asset         columnVectorIndexStateAssetSnapshot
@@ -64,7 +108,20 @@ type columnVectorGraphQuantizedAssetLoadStatus struct {
 	MappedBytes   uint64
 	HeapCopyBytes uint64
 	ActiveHandles int64
+
+	resource     *columnVectorGraphQuantizedAssetResource
+	ownsResource bool
 }
+
+type columnVectorGraphQuantizedAssetResource struct {
+	mu        sync.Mutex
+	closed    bool
+	manager   *mappedresource.Manager
+	handle    *mappedresource.Handle
+	readCache *columnPhysicalAssetReadCache
+}
+
+var columnVectorGraphQuantizedAssetForceReadAtFallbackForTest atomic.Bool
 
 func columnVectorGraphQuantizedAssetID(q QuantizedVectorIndexDefinition) string {
 	switch q.Codec {
@@ -728,13 +785,13 @@ func validateColumnVectorGraphQuantizedStateAssets(collection string, cfg Column
 }
 
 func (c *Collection) prepareColumnVectorGraphQuantizedAssetsForReader(graphReader *columnVectorGraphPhysicalRowReader, view columnPhysicalScanSnapshotView) {
-	if c == nil || c.db == nil || graphReader == nil || graphReader.catalog == nil || graphReader.catalog.meta.Options.ColumnStore == nil || len(graphReader.def.QuantizedIndexes) == 0 || !view.VectorIndexStateFound {
+	if c == nil || c.db == nil || graphReader == nil || graphReader.skipQuantizedAssets || graphReader.catalog == nil || graphReader.catalog.meta.Options.ColumnStore == nil || len(graphReader.def.QuantizedIndexes) == 0 || !view.VectorIndexStateFound {
 		return
 	}
-	graphReader.quantizedAssetStatus = loadColumnVectorGraphQuantizedAssetsForReader(c.db.ColumnAssetRootDir(), graphReader.catalog.meta.Name, *graphReader.catalog.meta.Options.ColumnStore, graphReader.def, graphReader.graph, view.VectorIndexState)
+	graphReader.quantizedAssetStatus = loadColumnVectorGraphQuantizedAssetsForReader(c.db.ColumnAssetRootDir(), graphReader.catalog.meta.Name, *graphReader.catalog.meta.Options.ColumnStore, graphReader.def, graphReader.graph, view.VectorIndexState, graphReader.useResourceQuantizedAssets, graphReader.forceQuantizedAssetHeapCopy)
 }
 
-func loadColumnVectorGraphQuantizedAssetsForReader(rootDir, collection string, cfg ColumnStoreConfig, def VectorIndexDefinition, graph columnVectorGraphManifestSnapshot, state columnVectorIndexStateSnapshot) map[string]columnVectorGraphQuantizedAssetLoadStatus {
+func loadColumnVectorGraphQuantizedAssetsForReader(rootDir, collection string, cfg ColumnStoreConfig, def VectorIndexDefinition, graph columnVectorGraphManifestSnapshot, state columnVectorIndexStateSnapshot, useResourceScalarU8 bool, forceScalarU8HeapCopy bool) map[string]columnVectorGraphQuantizedAssetLoadStatus {
 	if len(def.QuantizedIndexes) == 0 {
 		return nil
 	}
@@ -751,42 +808,52 @@ func loadColumnVectorGraphQuantizedAssetsForReader(rootDir, collection string, c
 		}
 		status.Asset = asset
 		start := time.Now()
-		prepared, err := loadColumnVectorGraphQuantizedAsset(rootDir, collection, cfg, def, graph, q, asset)
-		status.OpenNanos = uint64(time.Since(start).Nanoseconds())
-		if err != nil {
-			status.Err = err
-			status.Health = columnVectorGraphQuantizedAssetHealthFromError(err)
-		} else {
-			status.Prepared = prepared
-			switch q.Codec {
-			case rabitq.CodecName:
-				plan, planErr := rabitq.NewPlan(def.Dimensions, rabitq.DefaultConfig())
-				if planErr != nil {
-					status.Prepared = nil
-					status.Err = fmt.Errorf("%w: quantized asset %q rabitq_1bit plan: %v", errColumnVectorGraphQuantizedAssetInvalid, q.Name, planErr)
-					status.Health = columnVectorGraphQuantizedAssetHealthInvalid
-					out[q.Name] = status
-					continue
-				}
-				status.RabitQPlan = plan
-			case brq.CodecName:
-				plan, planErr := brq.NewPlan(def.Dimensions, brq.DefaultConfig())
-				if planErr != nil {
-					status.Prepared = nil
-					status.Err = fmt.Errorf("%w: quantized asset %q brq_1bit plan: %v", errColumnVectorGraphQuantizedAssetInvalid, q.Name, planErr)
-					status.Health = columnVectorGraphQuantizedAssetHealthInvalid
-					out[q.Name] = status
-					continue
-				}
-				status.BRQPlan = plan
+		if q.Codec == QuantizedVectorCodecScalarU8 && useResourceScalarU8 {
+			loaded, err := loadColumnVectorGraphQuantizedAssetResourceStatus(rootDir, collection, cfg, def, graph, q, asset, forceScalarU8HeapCopy)
+			status = loaded
+			status.OpenNanos = uint64(time.Since(start).Nanoseconds())
+			if err != nil {
+				out[q.Name] = status
+				continue
 			}
-			status.Health = columnVectorGraphQuantizedAssetHealthHeapCopy
-			if asset.AssetBytes > 0 {
-				status.HeapCopyBytes = uint64(asset.AssetBytes)
-			} else if prepared != nil {
-				fp := prepared.Footprint()
-				if fp.AssetBytes > 0 {
-					status.HeapCopyBytes = uint64(fp.AssetBytes)
+		} else {
+			prepared, err := loadColumnVectorGraphQuantizedAsset(rootDir, collection, cfg, def, graph, q, asset)
+			status.OpenNanos = uint64(time.Since(start).Nanoseconds())
+			if err != nil {
+				status.Err = err
+				status.Health = columnVectorGraphQuantizedAssetHealthFromError(err)
+			} else {
+				status.Prepared = prepared
+				switch q.Codec {
+				case rabitq.CodecName:
+					plan, planErr := rabitq.NewPlan(def.Dimensions, rabitq.DefaultConfig())
+					if planErr != nil {
+						status.Prepared = nil
+						status.Err = fmt.Errorf("%w: quantized asset %q rabitq_1bit plan: %v", errColumnVectorGraphQuantizedAssetInvalid, q.Name, planErr)
+						status.Health = columnVectorGraphQuantizedAssetHealthInvalid
+						out[q.Name] = status
+						continue
+					}
+					status.RabitQPlan = plan
+				case brq.CodecName:
+					plan, planErr := brq.NewPlan(def.Dimensions, brq.DefaultConfig())
+					if planErr != nil {
+						status.Prepared = nil
+						status.Err = fmt.Errorf("%w: quantized asset %q brq_1bit plan: %v", errColumnVectorGraphQuantizedAssetInvalid, q.Name, planErr)
+						status.Health = columnVectorGraphQuantizedAssetHealthInvalid
+						out[q.Name] = status
+						continue
+					}
+					status.BRQPlan = plan
+				}
+				status.Health = columnVectorGraphQuantizedAssetHealthHeapCopy
+				if asset.AssetBytes > 0 {
+					status.HeapCopyBytes = uint64(asset.AssetBytes)
+				} else if prepared != nil {
+					fp := prepared.Footprint()
+					if fp.AssetBytes > 0 {
+						status.HeapCopyBytes = uint64(fp.AssetBytes)
+					}
 				}
 			}
 		}
@@ -889,23 +956,30 @@ func recordColumnVectorGraphQuantizedAssetErrorStats(stats *columnVectorGraphNat
 	recordColumnVectorGraphQuantizedAssetUnavailable(stats, columnVectorGraphQuantizedAssetHealthFromError(err))
 }
 
-func loadColumnVectorGraphQuantizedAsset(rootDir, collection string, cfg ColumnStoreConfig, def VectorIndexDefinition, graph columnVectorGraphManifestSnapshot, q QuantizedVectorIndexDefinition, asset columnVectorIndexStateAssetSnapshot) (*quantizedasset.Prepared, error) {
+func validateColumnVectorGraphQuantizedAssetLoadInputs(rootDir, collection string, cfg ColumnStoreConfig, def VectorIndexDefinition, graph columnVectorGraphManifestSnapshot, q QuantizedVectorIndexDefinition, asset columnVectorIndexStateAssetSnapshot) error {
 	wantLogical, wantEncoding := columnVectorGraphQuantizedAssetStateType(q)
 	if asset.LogicalType != wantLogical || asset.PhysicalEncoding != wantEncoding {
-		return nil, fmt.Errorf("%w: quantized asset %q type/encoding=(%q,%q) want (%q,%q)", errColumnVectorGraphQuantizedAssetStale, q.Name, asset.LogicalType, asset.PhysicalEncoding, wantLogical, wantEncoding)
+		return fmt.Errorf("%w: quantized asset %q type/encoding=(%q,%q) want (%q,%q)", errColumnVectorGraphQuantizedAssetStale, q.Name, asset.LogicalType, asset.PhysicalEncoding, wantLogical, wantEncoding)
 	}
 	sourceCfg, err := columnVectorGraphQuantizedCodesColumnStoreConfig(collection, cfg, def, q)
 	if err != nil {
-		return nil, fmt.Errorf("%w: quantized asset %q config: %v", errColumnVectorGraphQuantizedAssetInvalid, q.Name, err)
+		return fmt.Errorf("%w: quantized asset %q config: %v", errColumnVectorGraphQuantizedAssetInvalid, q.Name, err)
 	}
 	if asset.SourceSchemaHash != sourceCfg.SchemaHash {
-		return nil, fmt.Errorf("%w: quantized asset %q schema_hash=%d want %d", errColumnVectorGraphQuantizedAssetStale, q.Name, asset.SourceSchemaHash, sourceCfg.SchemaHash)
+		return fmt.Errorf("%w: quantized asset %q schema_hash=%d want %d", errColumnVectorGraphQuantizedAssetStale, q.Name, asset.SourceSchemaHash, sourceCfg.SchemaHash)
 	}
 	if asset.RowCount != graph.RowCount {
-		return nil, fmt.Errorf("%w: quantized asset %q row_count=%d want graph row_count=%d", errColumnVectorGraphQuantizedAssetStale, q.Name, asset.RowCount, graph.RowCount)
+		return fmt.Errorf("%w: quantized asset %q row_count=%d want graph row_count=%d", errColumnVectorGraphQuantizedAssetStale, q.Name, asset.RowCount, graph.RowCount)
 	}
 	if err := validateColumnVectorIndexStateAssetRefAvailable(rootDir, asset); err != nil {
-		return nil, fmt.Errorf("%w: quantized asset %q unavailable: %v", errColumnVectorGraphQuantizedAssetMissing, q.Name, err)
+		return fmt.Errorf("%w: quantized asset %q unavailable: %v", errColumnVectorGraphQuantizedAssetMissing, q.Name, err)
+	}
+	return nil
+}
+
+func loadColumnVectorGraphQuantizedAsset(rootDir, collection string, cfg ColumnStoreConfig, def VectorIndexDefinition, graph columnVectorGraphManifestSnapshot, q QuantizedVectorIndexDefinition, asset columnVectorIndexStateAssetSnapshot) (*quantizedasset.Prepared, error) {
+	if err := validateColumnVectorGraphQuantizedAssetLoadInputs(rootDir, collection, cfg, def, graph, q, asset); err != nil {
+		return nil, err
 	}
 	raw, err := readColumnPhysicalAssetFromManager(rootDir, asset.Ref)
 	if err != nil {
@@ -915,6 +989,10 @@ func loadColumnVectorGraphQuantizedAsset(rootDir, collection string, cfg ColumnS
 	if err != nil {
 		return nil, fmt.Errorf("%w: quantized asset %q parse typed-column image: %v", errColumnVectorGraphQuantizedAssetInvalid, q.Name, err)
 	}
+	return prepareColumnVectorGraphQuantizedAssetFromImage(def, graph, q, asset, image)
+}
+
+func prepareColumnVectorGraphQuantizedAssetFromImage(def VectorIndexDefinition, graph columnVectorGraphManifestSnapshot, q QuantizedVectorIndexDefinition, asset columnVectorIndexStateAssetSnapshot, image typedcolumn.ColumnPartImage) (*quantizedasset.Prepared, error) {
 	ref := columnVectorGraphQuantizedAssetRefIdentity(asset.Ref)
 	schema, err := columnVectorGraphQuantizedAssetSchema(def, graph, q, asset, ref)
 	if err != nil {
@@ -942,6 +1020,103 @@ func loadColumnVectorGraphQuantizedAsset(rootDir, collection string, cfg ColumnS
 		return nil, fmt.Errorf("%w: quantized asset %q validate: %v", errColumnVectorGraphQuantizedAssetInvalid, q.Name, err)
 	}
 	return prepared, nil
+}
+
+func loadColumnVectorGraphQuantizedAssetResourceStatus(rootDir, collection string, cfg ColumnStoreConfig, def VectorIndexDefinition, graph columnVectorGraphManifestSnapshot, q QuantizedVectorIndexDefinition, asset columnVectorIndexStateAssetSnapshot, forceHeapCopy bool) (columnVectorGraphQuantizedAssetLoadStatus, error) {
+	status := columnVectorGraphQuantizedAssetLoadStatus{Definition: q, Asset: asset}
+	if err := validateColumnVectorGraphQuantizedAssetLoadInputs(rootDir, collection, cfg, def, graph, q, asset); err != nil {
+		status.Err = err
+		status.Health = columnVectorGraphQuantizedAssetHealthFromError(err)
+		return status, err
+	}
+	raw, resource, source, err := readColumnVectorGraphQuantizedAssetResourceBytes(rootDir, asset.Ref, forceHeapCopy)
+	if err != nil {
+		status.Err = fmt.Errorf("%w: quantized asset %q read: %v", errColumnVectorGraphQuantizedAssetInvalid, q.Name, err)
+		status.Health = columnVectorGraphQuantizedAssetHealthInvalid
+		return status, status.Err
+	}
+	status.resource = resource
+	status.ownsResource = true
+	defer func() {
+		if status.Err != nil && status.resource != nil {
+			_ = status.resource.close()
+			status.resource = nil
+			status.ownsResource = false
+		}
+	}()
+	image, err := typedcolumn.ParseColumnPartImage(raw)
+	if err != nil {
+		status.Err = fmt.Errorf("%w: quantized asset %q parse typed-column image: %v", errColumnVectorGraphQuantizedAssetInvalid, q.Name, err)
+		status.Health = columnVectorGraphQuantizedAssetHealthInvalid
+		return status, status.Err
+	}
+	prepared, err := prepareColumnVectorGraphQuantizedAssetFromImage(def, graph, q, asset, image)
+	if err != nil {
+		status.Err = err
+		status.Health = columnVectorGraphQuantizedAssetHealthFromError(err)
+		return status, err
+	}
+	status.Prepared = prepared
+	stats := resource.manager.Stats()
+	status.ActiveHandles = stats.ActiveHandles
+	status.MappedBytes = uint64(stats.ActiveMappedBytes)
+	status.HeapCopyBytes = uint64(stats.ActiveHeapCopyBytes)
+	if source == mappedresource.SourceMapped {
+		status.Health = columnVectorGraphQuantizedAssetHealthMmapDirect
+	} else {
+		status.Health = columnVectorGraphQuantizedAssetHealthHeapCopy
+	}
+	return status, nil
+}
+
+func readColumnVectorGraphQuantizedAssetResourceBytes(rootDir string, ref ColumnAssetRef, forceHeapCopy bool) ([]byte, *columnVectorGraphQuantizedAssetResource, mappedresource.Source, error) {
+	readCache, err := newColumnPhysicalAssetReadCache(rootDir, ref.Namespace)
+	if err != nil {
+		return nil, nil, "", err
+	}
+	readCache.returnViews = true
+	readCache.forceReadAtFallback = forceHeapCopy || columnVectorGraphQuantizedAssetForceReadAtFallbackForTest.Load()
+	reader, err := readCache.fileForRef(ref)
+	if err != nil {
+		_ = readCache.close()
+		return nil, nil, "", err
+	}
+	manager := mappedresource.NewManager()
+	scope := mappedresource.Scope{Kind: mappedresource.ScopePreparedSearch, ID: fmt.Sprintf("column-graph-quantized-%s-%d-%d-%d", ref.Namespace, ref.Generation, ref.PartID, ref.FileID), Namespace: ref.Namespace, Generation: ref.Generation, Reason: "column_graph quantized asset"}
+	key := mappedResourceKeyForColumnAssetRef(ref)
+	opts := mappedresource.AcquireOptions{Reason: "column_graph quantized asset", ValidationMode: mappedResourceValidationModeForColumnAssetIntegrity(ColumnAssetReadIntegrityVerify), ResourceRoot: rootDir}
+	if raw, ok, err := reader.readView(ref); err != nil {
+		_ = readCache.close()
+		return nil, nil, "", err
+	} else if ok {
+		if err := readCache.verifyReadChecksum(raw, ref, reader); err != nil {
+			_ = readCache.close()
+			return nil, nil, "", err
+		}
+		handle, err := manager.AcquireBytes(key, scope, mappedresource.SourceMapped, raw, opts)
+		if err != nil {
+			_ = readCache.close()
+			return nil, nil, "", err
+		}
+		return raw, &columnVectorGraphQuantizedAssetResource{manager: manager, handle: handle, readCache: &readCache}, mappedresource.SourceMapped, nil
+	}
+	raw, err := readColumnPhysicalAssetFromFileWithChecksum(reader.file, ref, nil, false)
+	if err != nil {
+		_ = readCache.close()
+		return nil, nil, "", err
+	}
+	if err := readCache.verifyReadChecksum(raw, ref, reader); err != nil {
+		_ = readCache.close()
+		return nil, nil, "", err
+	}
+	if err := readCache.close(); err != nil {
+		return nil, nil, "", err
+	}
+	handle, err := manager.AcquireBytes(key, scope, mappedresource.SourceHeapCopy, raw, opts)
+	if err != nil {
+		return nil, nil, "", err
+	}
+	return raw, &columnVectorGraphQuantizedAssetResource{manager: manager, handle: handle}, mappedresource.SourceHeapCopy, nil
 }
 
 func columnVectorGraphQuantizedRequiredRoles(q QuantizedVectorIndexDefinition) []quantizedasset.Role {

--- a/TreeDB/collections/column_vector_graph_quantized_asset.go
+++ b/TreeDB/collections/column_vector_graph_quantized_asset.go
@@ -788,10 +788,10 @@ func (c *Collection) prepareColumnVectorGraphQuantizedAssetsForReader(graphReade
 	if c == nil || c.db == nil || graphReader == nil || graphReader.skipQuantizedAssets || graphReader.catalog == nil || graphReader.catalog.meta.Options.ColumnStore == nil || len(graphReader.def.QuantizedIndexes) == 0 || !view.VectorIndexStateFound {
 		return
 	}
-	graphReader.quantizedAssetStatus = loadColumnVectorGraphQuantizedAssetsForReader(c.db.ColumnAssetRootDir(), graphReader.catalog.meta.Name, *graphReader.catalog.meta.Options.ColumnStore, graphReader.def, graphReader.graph, view.VectorIndexState, graphReader.useResourceQuantizedAssets, graphReader.forceQuantizedAssetHeapCopy)
+	graphReader.quantizedAssetStatus = loadColumnVectorGraphQuantizedAssetsForReader(c.db.ColumnAssetRootDir(), graphReader.catalog.meta.Name, *graphReader.catalog.meta.Options.ColumnStore, graphReader.def, graphReader.graph, view.VectorIndexState, graphReader.useResourceQuantizedAssets)
 }
 
-func loadColumnVectorGraphQuantizedAssetsForReader(rootDir, collection string, cfg ColumnStoreConfig, def VectorIndexDefinition, graph columnVectorGraphManifestSnapshot, state columnVectorIndexStateSnapshot, useResourceScalarU8 bool, forceScalarU8HeapCopy bool) map[string]columnVectorGraphQuantizedAssetLoadStatus {
+func loadColumnVectorGraphQuantizedAssetsForReader(rootDir, collection string, cfg ColumnStoreConfig, def VectorIndexDefinition, graph columnVectorGraphManifestSnapshot, state columnVectorIndexStateSnapshot, useResourceScalarU8 bool) map[string]columnVectorGraphQuantizedAssetLoadStatus {
 	if len(def.QuantizedIndexes) == 0 {
 		return nil
 	}
@@ -809,7 +809,7 @@ func loadColumnVectorGraphQuantizedAssetsForReader(rootDir, collection string, c
 		status.Asset = asset
 		start := time.Now()
 		if q.Codec == QuantizedVectorCodecScalarU8 && useResourceScalarU8 {
-			loaded, err := loadColumnVectorGraphQuantizedAssetResourceStatus(rootDir, collection, cfg, def, graph, q, asset, forceScalarU8HeapCopy)
+			loaded, err := loadColumnVectorGraphQuantizedAssetResourceStatus(rootDir, collection, cfg, def, graph, q, asset)
 			status = loaded
 			status.OpenNanos = uint64(time.Since(start).Nanoseconds())
 			if err != nil {
@@ -1022,14 +1022,14 @@ func prepareColumnVectorGraphQuantizedAssetFromImage(def VectorIndexDefinition, 
 	return prepared, nil
 }
 
-func loadColumnVectorGraphQuantizedAssetResourceStatus(rootDir, collection string, cfg ColumnStoreConfig, def VectorIndexDefinition, graph columnVectorGraphManifestSnapshot, q QuantizedVectorIndexDefinition, asset columnVectorIndexStateAssetSnapshot, forceHeapCopy bool) (columnVectorGraphQuantizedAssetLoadStatus, error) {
+func loadColumnVectorGraphQuantizedAssetResourceStatus(rootDir, collection string, cfg ColumnStoreConfig, def VectorIndexDefinition, graph columnVectorGraphManifestSnapshot, q QuantizedVectorIndexDefinition, asset columnVectorIndexStateAssetSnapshot) (columnVectorGraphQuantizedAssetLoadStatus, error) {
 	status := columnVectorGraphQuantizedAssetLoadStatus{Definition: q, Asset: asset}
 	if err := validateColumnVectorGraphQuantizedAssetLoadInputs(rootDir, collection, cfg, def, graph, q, asset); err != nil {
 		status.Err = err
 		status.Health = columnVectorGraphQuantizedAssetHealthFromError(err)
 		return status, err
 	}
-	raw, resource, source, err := readColumnVectorGraphQuantizedAssetResourceBytes(rootDir, asset.Ref, forceHeapCopy)
+	raw, resource, source, err := readColumnVectorGraphQuantizedAssetResourceBytes(rootDir, asset.Ref)
 	if err != nil {
 		status.Err = fmt.Errorf("%w: quantized asset %q read: %v", errColumnVectorGraphQuantizedAssetInvalid, q.Name, err)
 		status.Health = columnVectorGraphQuantizedAssetHealthInvalid
@@ -1069,13 +1069,13 @@ func loadColumnVectorGraphQuantizedAssetResourceStatus(rootDir, collection strin
 	return status, nil
 }
 
-func readColumnVectorGraphQuantizedAssetResourceBytes(rootDir string, ref ColumnAssetRef, forceHeapCopy bool) ([]byte, *columnVectorGraphQuantizedAssetResource, mappedresource.Source, error) {
+func readColumnVectorGraphQuantizedAssetResourceBytes(rootDir string, ref ColumnAssetRef) ([]byte, *columnVectorGraphQuantizedAssetResource, mappedresource.Source, error) {
 	readCache, err := newColumnPhysicalAssetReadCache(rootDir, ref.Namespace)
 	if err != nil {
 		return nil, nil, "", err
 	}
 	readCache.returnViews = true
-	readCache.forceReadAtFallback = forceHeapCopy || columnVectorGraphQuantizedAssetForceReadAtFallbackForTest.Load()
+	readCache.forceReadAtFallback = columnVectorGraphQuantizedAssetForceReadAtFallbackForTest.Load()
 	reader, err := readCache.fileForRef(ref)
 	if err != nil {
 		_ = readCache.close()

--- a/TreeDB/collections/column_vector_graph_quantized_asset_test.go
+++ b/TreeDB/collections/column_vector_graph_quantized_asset_test.go
@@ -94,7 +94,7 @@ func TestColumnGraphScalarU8QuantizedAssetRebuildPrepareReopen1926(t *testing.T)
 		t.Fatalf("row2 codes=%v ok=%v", row2, ok)
 	}
 
-	reader, err := col.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
+	reader, err := col.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1, UseResourceQuantizedAssets: true})
 	if err != nil {
 		t.Fatalf("open reader: %v", err)
 	}
@@ -102,6 +102,15 @@ func TestColumnGraphScalarU8QuantizedAssetRebuildPrepareReopen1926(t *testing.T)
 	if loaded.Prepared == nil || loaded.Err != nil {
 		_ = reader.Close()
 		t.Fatalf("reader quantized status=%+v", loaded)
+	}
+	if columnVectorGraphQuantizedAssetMmapExpectedForTest2621() {
+		if loaded.Health != columnVectorGraphQuantizedAssetHealthMmapDirect || loaded.MappedBytes == 0 || loaded.HeapCopyBytes != 0 {
+			_ = reader.Close()
+			t.Fatalf("reader scalar_u8 status=%+v want mmap/direct without heap copy", loaded)
+		}
+	} else if loaded.Health != columnVectorGraphQuantizedAssetHealthHeapCopy || loaded.HeapCopyBytes == 0 {
+		_ = reader.Close()
+		t.Fatalf("reader scalar_u8 status=%+v want heap-copy fallback", loaded)
 	}
 	if err := reader.Close(); err != nil {
 		t.Fatalf("reader Close: %v", err)
@@ -119,7 +128,7 @@ func TestColumnGraphScalarU8QuantizedAssetRebuildPrepareReopen1926(t *testing.T)
 	if err != nil {
 		t.Fatalf("OpenCollection reopen: %v", err)
 	}
-	reopenedReader, err := reopenedCol.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
+	reopenedReader, err := reopenedCol.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1, UseResourceQuantizedAssets: true})
 	if err != nil {
 		t.Fatalf("open reader reopen: %v", err)
 	}
@@ -127,6 +136,13 @@ func TestColumnGraphScalarU8QuantizedAssetRebuildPrepareReopen1926(t *testing.T)
 	reopenedStatus := reopenedReader.quantizedAssetStatus[def.QuantizedIndexes[0].Name]
 	if reopenedStatus.Prepared == nil || reopenedStatus.Err != nil {
 		t.Fatalf("reopened reader quantized status=%+v", reopenedStatus)
+	}
+	if columnVectorGraphQuantizedAssetMmapExpectedForTest2621() {
+		if reopenedStatus.Health != columnVectorGraphQuantizedAssetHealthMmapDirect || reopenedStatus.MappedBytes == 0 || reopenedStatus.HeapCopyBytes != 0 {
+			t.Fatalf("reopened scalar_u8 status=%+v want mmap/direct without heap copy", reopenedStatus)
+		}
+	} else if reopenedStatus.Health != columnVectorGraphQuantizedAssetHealthHeapCopy || reopenedStatus.HeapCopyBytes == 0 {
+		t.Fatalf("reopened scalar_u8 status=%+v want heap-copy fallback", reopenedStatus)
 	}
 	quantized, err := reopenedCol.SearchVectorIndex(VectorIndexSearchOptions{IndexName: def.Name, Query: []float32{1, 0, 0}, QueryMode: VectorIndexQueryModeQuantizedOnly, QuantizedIndexName: def.QuantizedIndexes[0].Name, TopK: 1, EfSearch: len(rows), MaxDecodedBlocks: 1})
 	if err != nil {

--- a/TreeDB/collections/column_vector_graph_row_reader.go
+++ b/TreeDB/collections/column_vector_graph_row_reader.go
@@ -20,11 +20,6 @@ type columnVectorGraphPhysicalRowReaderOptions struct {
 	// latency of the existing single heap-copy path on platforms where mmap-backed
 	// random row access is slower.
 	UseResourceQuantizedAssets bool
-	// ForceQuantizedAssetHeapCopy keeps the resource-backed scalar_u8 asset in one
-	// shared heap copy instead of an mmap/direct view. Prepared collection search
-	// uses this on platforms where direct mmap random-row scoring regresses the hot
-	// path while still avoiding per-reader heap copies.
-	ForceQuantizedAssetHeapCopy bool
 	// SkipQuantizedAssets lets a prepared collection search attach an already
 	// validated shared scalar_u8 asset instead of re-opening one per reader.
 	SkipQuantizedAssets bool
@@ -73,7 +68,6 @@ type columnVectorGraphPhysicalRowReader struct {
 	documentIDStateFallbackReason       typeddecode.Reason
 	quantizedAssetStatus                map[string]columnVectorGraphQuantizedAssetLoadStatus
 	useResourceQuantizedAssets          bool
-	forceQuantizedAssetHeapCopy         bool
 	skipQuantizedAssets                 bool
 	hnswSearchPack                      *columnHNSWSearchPackPreparedView
 	hnswSearchPackStatus                columnHNSWSearchPackPreparedStatus
@@ -141,14 +135,13 @@ func (c *Collection) openColumnVectorGraphPhysicalRowReaderAtSnapshot(name strin
 		}
 	}
 	graphReader := &columnVectorGraphPhysicalRowReader{
-		def:                         def,
-		graph:                       graph,
-		catalog:                     catalog,
-		reader:                      reader,
-		quantizedAssetStatus:        make(map[string]columnVectorGraphQuantizedAssetLoadStatus),
-		useResourceQuantizedAssets:  opts.UseResourceQuantizedAssets,
-		forceQuantizedAssetHeapCopy: opts.ForceQuantizedAssetHeapCopy,
-		skipQuantizedAssets:         opts.SkipQuantizedAssets,
+		def:                        def,
+		graph:                      graph,
+		catalog:                    catalog,
+		reader:                     reader,
+		quantizedAssetStatus:       make(map[string]columnVectorGraphQuantizedAssetLoadStatus),
+		useResourceQuantizedAssets: opts.UseResourceQuantizedAssets,
+		skipQuantizedAssets:        opts.SkipQuantizedAssets,
 	}
 	if !columnVectorGraphManifestHasPhysicalAsset(graph) && graph.RowCount > 0 && catalog != nil && view.VectorIndexStateFound && view.AssetNamespace != "" {
 		key, keyErr := columnVectorGraphSharedPreparedSearchCacheKey(catalog.meta.Name, view.AssetNamespace, def, graph, view.VectorIndexState)

--- a/TreeDB/collections/column_vector_graph_row_reader.go
+++ b/TreeDB/collections/column_vector_graph_row_reader.go
@@ -13,6 +13,21 @@ type columnVectorGraphPhysicalRowReaderOptions struct {
 	// MaxDecodedBlocks is the maximum number of decoded column blocks retained
 	// in the reader cache. Zero uses the underlying row reader default.
 	MaxDecodedBlocks int
+	// UseResourceQuantizedAssets loads scalar_u8 quantized assets through a
+	// mapped-resource-backed handle so prepared collection readers can share one
+	// immutable asset instead of retaining one heap copy per reader. Standalone
+	// OpenVectorIndexSearcher readers leave this off to preserve the hot search
+	// latency of the existing single heap-copy path on platforms where mmap-backed
+	// random row access is slower.
+	UseResourceQuantizedAssets bool
+	// ForceQuantizedAssetHeapCopy keeps the resource-backed scalar_u8 asset in one
+	// shared heap copy instead of an mmap/direct view. Prepared collection search
+	// uses this on platforms where direct mmap random-row scoring regresses the hot
+	// path while still avoiding per-reader heap copies.
+	ForceQuantizedAssetHeapCopy bool
+	// SkipQuantizedAssets lets a prepared collection search attach an already
+	// validated shared scalar_u8 asset instead of re-opening one per reader.
+	SkipQuantizedAssets bool
 	// detachCatalog copies immutable catalog metadata for readers returned after
 	// their assembly snapshot closes.
 	detachCatalog bool
@@ -57,6 +72,9 @@ type columnVectorGraphPhysicalRowReader struct {
 	documentIDSource                    *columnVectorGraphDocumentIDStateSource
 	documentIDStateFallbackReason       typeddecode.Reason
 	quantizedAssetStatus                map[string]columnVectorGraphQuantizedAssetLoadStatus
+	useResourceQuantizedAssets          bool
+	forceQuantizedAssetHeapCopy         bool
+	skipQuantizedAssets                 bool
 	hnswSearchPack                      *columnHNSWSearchPackPreparedView
 	hnswSearchPackStatus                columnHNSWSearchPackPreparedStatus
 	hnswSearchPackOpenNanos             uint64
@@ -123,11 +141,14 @@ func (c *Collection) openColumnVectorGraphPhysicalRowReaderAtSnapshot(name strin
 		}
 	}
 	graphReader := &columnVectorGraphPhysicalRowReader{
-		def:                  def,
-		graph:                graph,
-		catalog:              catalog,
-		reader:               reader,
-		quantizedAssetStatus: make(map[string]columnVectorGraphQuantizedAssetLoadStatus),
+		def:                         def,
+		graph:                       graph,
+		catalog:                     catalog,
+		reader:                      reader,
+		quantizedAssetStatus:        make(map[string]columnVectorGraphQuantizedAssetLoadStatus),
+		useResourceQuantizedAssets:  opts.UseResourceQuantizedAssets,
+		forceQuantizedAssetHeapCopy: opts.ForceQuantizedAssetHeapCopy,
+		skipQuantizedAssets:         opts.SkipQuantizedAssets,
 	}
 	if !columnVectorGraphManifestHasPhysicalAsset(graph) && graph.RowCount > 0 && catalog != nil && view.VectorIndexStateFound && view.AssetNamespace != "" {
 		key, keyErr := columnVectorGraphSharedPreparedSearchCacheKey(catalog.meta.Name, view.AssetNamespace, def, graph, view.VectorIndexState)
@@ -136,7 +157,7 @@ func (c *Collection) openColumnVectorGraphPhysicalRowReaderAtSnapshot(name strin
 			return nil, keyErr
 		}
 		shared, err := c.acquireColumnVectorGraphSharedPreparedSearch(key, func() (*columnVectorGraphSharedPreparedSearch, error) {
-			buildReader := &columnVectorGraphPhysicalRowReader{def: def, graph: graph, catalog: catalog, quantizedAssetStatus: make(map[string]columnVectorGraphQuantizedAssetLoadStatus)}
+			buildReader := &columnVectorGraphPhysicalRowReader{def: def, graph: graph, catalog: catalog, quantizedAssetStatus: make(map[string]columnVectorGraphQuantizedAssetLoadStatus), skipQuantizedAssets: true}
 			success := false
 			defer func() {
 				if !success {
@@ -169,7 +190,9 @@ func (c *Collection) openColumnVectorGraphPhysicalRowReaderAtSnapshot(name strin
 			_ = graphReader.Close()
 			return nil, errors.Join(err, releaseErr)
 		}
-		c.prepareColumnVectorGraphQuantizedAssetsForReader(graphReader, view)
+		if !graphReader.skipQuantizedAssets {
+			c.prepareColumnVectorGraphQuantizedAssetsForReader(graphReader, view)
+		}
 		return graphReader, nil
 	}
 	if err := c.prepareColumnVectorGraphPhysicalRowReaderSourcesAtSnapshot(graphReader, snap, view); err != nil {
@@ -276,7 +299,9 @@ func (c *Collection) prepareColumnVectorGraphPhysicalRowReaderSourcesAtSnapshot(
 		if packErr != nil {
 			graphReader.hnswSearchPackStatus = columnHNSWSearchPackPreparedStatusInvalid
 		}
-		c.prepareColumnVectorGraphQuantizedAssetsForReader(graphReader, view)
+		if !graphReader.skipQuantizedAssets {
+			c.prepareColumnVectorGraphQuantizedAssetsForReader(graphReader, view)
+		}
 	}
 	if !columnVectorGraphManifestHasPhysicalAsset(graph) && graph.RowCount > 0 {
 		if graphReader.invNormSource == nil {
@@ -498,6 +523,12 @@ func (r *columnVectorGraphPhysicalRowReader) Close() error {
 		r.hnswSearchPack = nil
 	}
 	r.preparedSearch = nil
+	if r.quantizedAssetStatus != nil {
+		if err := closeColumnVectorGraphQuantizedAssetLoadStatuses(r.quantizedAssetStatus); closeErr == nil && err != nil {
+			closeErr = err
+		}
+		r.quantizedAssetStatus = nil
+	}
 	if r.adjacencyLayerSources != nil {
 		if err := r.adjacencyLayerSources.Close(); closeErr == nil && err != nil {
 			closeErr = err

--- a/TreeDB/collections/typed_storage_naming_test.go
+++ b/TreeDB/collections/typed_storage_naming_test.go
@@ -465,7 +465,7 @@ var typedStorageLegacyNameAllowlist = []typedStorageLegacyNameAllowlistEntry{
 	{path: "TreeDB/collections/typed_storage_naming_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 33, occurrences: 33},
 	{path: "TreeDB/collections/text_catalog.go", classification: typedStorageLegacyCompatibility, matchingLines: 1, occurrences: 1},
 	{path: "TreeDB/collections/vector_index.go", classification: typedStorageLegacyDerived, matchingLines: 1, occurrences: 1},
-	{path: "TreeDB/collections/column_vector_graph_quantized_asset.go", classification: typedStorageLegacyDerived, matchingLines: 75, occurrences: 82},
+	{path: "TreeDB/collections/column_vector_graph_quantized_asset.go", classification: typedStorageLegacyDerived, matchingLines: 77, occurrences: 84},
 	{path: "TreeDB/collections/column_vector_graph_rabitq_quantized_asset_test.go", classification: typedStorageLegacyDerived, matchingLines: 15, occurrences: 17},
 	{path: "TreeDB/collections/vector_index_metadata_test.go", classification: typedStorageLegacyDerived, matchingLines: 9, occurrences: 11},
 	{path: "TreeDB/collections/vector_usearch_bench_test.go", classification: typedStorageLegacyDerived, matchingLines: 1, occurrences: 2},

--- a/TreeDB/collections/vector_index_search_test.go
+++ b/TreeDB/collections/vector_index_search_test.go
@@ -746,6 +746,130 @@ func TestSearchVectorIndexWithBufferQuantizedOnlyAndRerank2415(t *testing.T) {
 	}
 }
 
+func TestSearchVectorIndexWithBufferScalarU8PreparedReadersShareQuantizedAsset2621(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		forceHeap bool
+	}{
+		{name: "mmap_or_platform_fallback"},
+		{name: "forced_heap_fallback", forceHeap: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.forceHeap {
+				columnVectorGraphQuantizedAssetForceReadAtFallbackForTest.Store(true)
+				defer columnVectorGraphQuantizedAssetForceReadAtFallbackForTest.Store(false)
+			}
+			rows := []columnGraphRebuildInputRowV2A{
+				{id: "doc-a", vector: []float32{1, 0, 0}},
+				{id: "doc-b", vector: []float32{0.9, 0.1, 0}},
+				{id: "doc-c", vector: []float32{0, 1, 0}},
+				{id: "doc-d", vector: []float32{0, 0, 1}},
+				{id: "doc-e", vector: []float32{0.4, 0.6, 0}},
+			}
+			_, d, col, def := openColumnGraphQuantizedGuardrailTestCollection1926(t, rows)
+			defer func() { _ = d.Close() }()
+			if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+				t.Fatalf("RebuildVectorIndex: %v", err)
+			}
+
+			qName := def.QuantizedIndexes[0].Name
+			opts := VectorIndexSearchOptions{IndexName: def.Name, Query: []float32{0.8, 0.2, 0}, QueryMode: VectorIndexQueryModeQuantizedOnly, QuantizedIndexName: qName, TopK: 3, EfSearch: len(rows), MaxDecodedBlocks: 1, StatsMode: VectorIndexSearchStatsModeProduction}
+			var buffer VectorIndexSearchBuffer
+			warm, err := col.SearchVectorIndexWithBuffer(opts, &buffer)
+			if err != nil {
+				t.Fatalf("warm SearchVectorIndexWithBuffer: %v", err)
+			}
+			assertCollectionBufferedQuantizedRouteStats2415(t, warm.Stats, columnVectorGraphNativeSearchQueryModeQuantizedOnly, opts, def.Dimensions)
+			expectMmapDirect := !tc.forceHeap && columnVectorGraphQuantizedAssetMmapExpectedForTest2621() && !collectionVectorIndexPreparedScalarU8QuantizedAssetForceHeapCopy()
+			if expectMmapDirect {
+				if warm.Stats.QuantizedAssetMmapDirect != 1 || warm.Stats.QuantizedAssetHeapCopy != 0 || warm.Stats.QuantizedAssetMappedBytes == 0 || warm.Stats.QuantizedAssetHeapCopyBytes != 0 {
+					t.Fatalf("warm scalar_u8 stats=%+v want mmap/direct quantized asset", warm.Stats)
+				}
+			} else if warm.Stats.QuantizedAssetHeapCopy != 1 || warm.Stats.QuantizedAssetMmapDirect != 0 || warm.Stats.QuantizedAssetHeapCopyBytes == 0 {
+				t.Fatalf("warm scalar_u8 stats=%+v want one heap-copy fallback quantized asset", warm.Stats)
+			}
+
+			queryMode, err := normalizeVectorIndexSearchQueryMode(opts.QueryMode, opts.QuantizedIndexName, opts.QuantizedRerankCandidates, opts.TopK)
+			if err != nil {
+				t.Fatalf("normalize query mode: %v", err)
+			}
+			prepared, _, _, err := col.acquireCollectionVectorIndexPreparedSearch(opts)
+			if err != nil {
+				t.Fatalf("acquire prepared search: %v", err)
+			}
+			checkedOut := make([]int, 0, 8)
+			defer func() {
+				for _, idx := range checkedOut {
+					prepared.returnCollectionVectorIndexPreparedQuantizedReader(idx)
+				}
+				if err := col.closeCollectionVectorIndexPreparedSearchCache(); err != nil {
+					t.Fatalf("close prepared cache: %v", err)
+				}
+				if snap := col.collectionVectorIndexPreparedSearchCacheSnapshot(); snap.Entries != 0 || snap.ActiveHandles != 0 || snap.ActiveHeapCopyBytes != 0 || snap.ActiveMappedBytes != 0 {
+					t.Fatalf("cache after close=%+v want released quantized/shared handles", snap)
+				}
+			}()
+
+			for i := 0; i < 8; i++ {
+				reader, idx, stats, err := prepared.checkoutCollectionVectorIndexPreparedQuantizedReader(opts, queryMode)
+				if err != nil {
+					t.Fatalf("checkout reader %d stats=%+v err=%v", i, stats, err)
+				}
+				if reader == nil {
+					t.Fatalf("checkout reader %d returned nil", i)
+				}
+				checkedOut = append(checkedOut, idx)
+			}
+			if got := len(prepared.quantizedReaders); got != 8 {
+				t.Fatalf("prepared quantized readers=%d want 8", got)
+			}
+
+			var shared *columnVectorGraphQuantizedAssetResource
+			var assetBytes int64
+			for i, reader := range prepared.quantizedReaders {
+				status, ok := reader.quantizedAssetStatus[qName]
+				if !ok || status.Prepared == nil || status.Err != nil || status.resource == nil {
+					t.Fatalf("reader %d scalar_u8 status=%+v ok=%v want shared healthy resource", i, status, ok)
+				}
+				if status.ownsResource {
+					t.Fatalf("reader %d owns shared scalar_u8 resource; prepared cache owner should hold the resource", i)
+				}
+				if shared == nil {
+					shared = status.resource
+				} else if status.resource != shared {
+					t.Fatalf("reader %d scalar_u8 resource=%p want shared %p", i, status.resource, shared)
+				}
+				if status.Asset.AssetBytes > assetBytes {
+					assetBytes = status.Asset.AssetBytes
+				}
+			}
+			if assetBytes <= 0 {
+				t.Fatalf("scalar_u8 asset bytes=%d want positive", assetBytes)
+			}
+			snap := col.collectionVectorIndexPreparedSearchCacheSnapshot()
+			if snap.Entries != 1 || snap.ActiveHandles == 0 {
+				t.Fatalf("prepared cache snapshot=%+v want one active quantized entry", snap)
+			}
+			if expectMmapDirect {
+				if snap.ActiveHeapCopyBytes != 0 || snap.ActiveMappedBytes < assetBytes {
+					t.Fatalf("prepared cache snapshot=%+v asset_bytes=%d want mmap/direct scalar_u8 with no heap copy", snap, assetBytes)
+				}
+			} else if snap.ActiveHeapCopyBytes <= 0 || snap.ActiveHeapCopyBytes > assetBytes {
+				t.Fatalf("prepared cache snapshot=%+v asset_bytes=%d want at most one shared heap scalar_u8 asset", snap, assetBytes)
+			}
+		})
+	}
+}
+
+func columnVectorGraphQuantizedAssetMmapExpectedForTest2621() bool {
+	switch runtime.GOOS {
+	case "darwin", "linux", "freebsd", "netbsd", "openbsd":
+		return true
+	default:
+		return false
+	}
+}
+
 func TestScalarU8QuantizedPreparedTraversalPackRouteWhenAdjacencyClosed2586(t *testing.T) {
 	rows := []columnGraphRebuildInputRowV2A{
 		{id: "doc-a", vector: []float32{1, 0, 0}},

--- a/TreeDB/collections/vector_index_search_test.go
+++ b/TreeDB/collections/vector_index_search_test.go
@@ -751,7 +751,7 @@ func TestSearchVectorIndexWithBufferScalarU8PreparedReadersShareQuantizedAsset26
 		name      string
 		forceHeap bool
 	}{
-		{name: "mmap_or_platform_fallback"},
+		{name: "default_mmap_direct_when_supported"},
 		{name: "forced_heap_fallback", forceHeap: true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -780,7 +780,7 @@ func TestSearchVectorIndexWithBufferScalarU8PreparedReadersShareQuantizedAsset26
 				t.Fatalf("warm SearchVectorIndexWithBuffer: %v", err)
 			}
 			assertCollectionBufferedQuantizedRouteStats2415(t, warm.Stats, columnVectorGraphNativeSearchQueryModeQuantizedOnly, opts, def.Dimensions)
-			expectMmapDirect := !tc.forceHeap && columnVectorGraphQuantizedAssetMmapExpectedForTest2621() && !collectionVectorIndexPreparedScalarU8QuantizedAssetForceHeapCopy()
+			expectMmapDirect := !tc.forceHeap && columnVectorGraphQuantizedAssetMmapExpectedForTest2621()
 			if expectMmapDirect {
 				if warm.Stats.QuantizedAssetMmapDirect != 1 || warm.Stats.QuantizedAssetHeapCopy != 0 || warm.Stats.QuantizedAssetMappedBytes == 0 || warm.Stats.QuantizedAssetHeapCopyBytes != 0 {
 					t.Fatalf("warm scalar_u8 stats=%+v want mmap/direct quantized asset", warm.Stats)

--- a/TreeDB/collections/vector_index_search_test.go
+++ b/TreeDB/collections/vector_index_search_test.go
@@ -825,6 +825,7 @@ func TestSearchVectorIndexWithBufferScalarU8PreparedReadersShareQuantizedAsset26
 			}
 
 			var shared *columnVectorGraphQuantizedAssetResource
+			var sharedStatus columnVectorGraphQuantizedAssetLoadStatus
 			var assetBytes int64
 			for i, reader := range prepared.quantizedReaders {
 				status, ok := reader.quantizedAssetStatus[qName]
@@ -836,12 +837,16 @@ func TestSearchVectorIndexWithBufferScalarU8PreparedReadersShareQuantizedAsset26
 				}
 				if shared == nil {
 					shared = status.resource
+					sharedStatus = status
 				} else if status.resource != shared {
 					t.Fatalf("reader %d scalar_u8 resource=%p want shared %p", i, status.resource, shared)
 				}
 				if status.Asset.AssetBytes > assetBytes {
 					assetBytes = status.Asset.AssetBytes
 				}
+			}
+			if shared == nil || shared.manager == nil {
+				t.Fatalf("shared scalar_u8 resource=%p want resource manager", shared)
 			}
 			if assetBytes <= 0 {
 				t.Fatalf("scalar_u8 asset bytes=%d want positive", assetBytes)
@@ -850,12 +855,24 @@ func TestSearchVectorIndexWithBufferScalarU8PreparedReadersShareQuantizedAsset26
 			if snap.Entries != 1 || snap.ActiveHandles == 0 {
 				t.Fatalf("prepared cache snapshot=%+v want one active quantized entry", snap)
 			}
+			scalarStats := shared.manager.Stats()
+			if scalarStats.ActiveHandles != 1 {
+				t.Fatalf("shared scalar_u8 manager stats=%+v want one active scalar asset handle", scalarStats)
+			}
 			if expectMmapDirect {
-				if snap.ActiveHeapCopyBytes != 0 || snap.ActiveMappedBytes < assetBytes {
-					t.Fatalf("prepared cache snapshot=%+v asset_bytes=%d want mmap/direct scalar_u8 with no heap copy", snap, assetBytes)
+				if sharedStatus.Health != columnVectorGraphQuantizedAssetHealthMmapDirect || sharedStatus.MappedBytes < uint64(assetBytes) || sharedStatus.HeapCopyBytes != 0 {
+					t.Fatalf("shared scalar_u8 status=%+v asset_bytes=%d want mmap/direct scalar_u8 with no heap copy", sharedStatus, assetBytes)
 				}
-			} else if snap.ActiveHeapCopyBytes <= 0 || snap.ActiveHeapCopyBytes > assetBytes {
-				t.Fatalf("prepared cache snapshot=%+v asset_bytes=%d want at most one shared heap scalar_u8 asset", snap, assetBytes)
+				if scalarStats.ActiveMappedBytes < assetBytes || scalarStats.ActiveHeapCopyBytes != 0 {
+					t.Fatalf("shared scalar_u8 manager stats=%+v asset_bytes=%d want mmap/direct scalar_u8 with no heap copy", scalarStats, assetBytes)
+				}
+			} else {
+				if sharedStatus.Health != columnVectorGraphQuantizedAssetHealthHeapCopy || sharedStatus.HeapCopyBytes < uint64(assetBytes) || sharedStatus.MappedBytes != 0 {
+					t.Fatalf("shared scalar_u8 status=%+v asset_bytes=%d want one shared heap-copy scalar_u8 asset", sharedStatus, assetBytes)
+				}
+				if scalarStats.ActiveHeapCopyBytes < assetBytes || scalarStats.ActiveMappedBytes != 0 {
+					t.Fatalf("shared scalar_u8 manager stats=%+v asset_bytes=%d want one shared heap-copy scalar_u8 asset", scalarStats, assetBytes)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
## Objective

Fix #2621 by stopping prepared collection `scalar_u8` quantized search from retaining one quantized-code asset heap copy per prepared reader/concurrency lane, while keeping healthy prepared collection assets mmap/direct on this host.

## Context

The 10k x 768 `scalar_u8` collection qonly c=8 path retained ~64.7 MB of duplicate scalar_u8 code assets in the prepared cache. That scales with query concurrency and can OOM larger shapes even though the hot search rows stay `0 B/op`.

## Non-goals

- No scalar_u8 encoding/scoring/identity changes.
- No exact fallback for quantized modes.
- No RaBitQ/BRQ format or route changes.
- No on-disk format migration.

## Design

- `scalar_u8` quantized asset loads can now use a resource-backed load status that owns a closeable `mappedresource` handle.
- Prepared collection quantized cache promotes the first healthy `scalar_u8` resource to a cache-owned shared asset; subsequent prepared readers skip reloading and attach the shared immutable status.
- Prepared collection `scalar_u8` uses mmap/direct when the asset can be mapped. There is no darwin/arm64 shared-heap override in the prepared collection default path.
- Resource stats dedupe shared scalar_u8 assets across prepared readers.
- Standalone `OpenVectorIndexSearcher` keeps the existing single heap-copy path.
- Fail-closed behavior is preserved for missing/stale/invalid/closed quantized assets.

## Scope

- Includes:
  - `TreeDB/collections/column_vector_graph_quantized_asset.go`
  - `TreeDB/collections/collection_vector_index_prepared_search_cache.go`
  - `TreeDB/collections/column_vector_graph_row_reader.go`
  - scalar_u8 prepared-reader sharing tests and typed-storage allowlist update.
- Excludes:
  - quantized asset durable format changes
  - RaBitQ/BRQ codec behavior changes
  - exact FP32 route changes

## Correctness

Latest test-only follow-up `9ece65e5b` relaxes the Windows heap-fallback assertion to validate the shared scalar_u8 resource's own manager/status bytes instead of bounding total prepared-cache heap bytes. Focused test rerun locally on Apple M3 / darwin arm64:

```sh
GOMAXPROCS=8 GOWORK=off go test ./TreeDB/collections \
  -run '^TestSearchVectorIndexWithBufferScalarU8PreparedReadersShareQuantizedAsset2621$' \
  -count=1
```

Result: PASS (`ok ... 1.026s`).

Earlier focused tests run locally on Apple M3 / darwin arm64:

```sh
GOMAXPROCS=8 GOWORK=off go test ./TreeDB/collections \
  -run 'Test(ColumnGraphScalarU8QuantizedAssetRebuildPrepareReopen1926|SearchVectorIndexWithBufferScalarU8PreparedReadersShareQuantizedAsset2621|SearchVectorIndexWithBufferQuantizedOnlyAndRerank2415|VectorIndexSearcherQuantizedAssetUnavailableCounters2416|SearchVectorIndexWithBufferQuantizedAssetUnavailableFailClosed2415)' \
  -count=1
```

Result: PASS (`ok ... 1.134s`).

Coordinator also reran the latest-head full package collection suite:

```sh
GOMAXPROCS=8 GOWORK=off go test ./TreeDB/collections -count=1
```

Result: PASS (`ok ... 48.123s`) on latest head `9ece65e5b`.

Earlier pre-follow-up guardrails also passed on this PR branch:

```sh
GOMAXPROCS=8 GOWORK=off go test ./TreeDB/collections \
  -run 'Test(CollectionSearchVectorIndexWithBufferRabitQQuantized2452|CollectionSearchVectorIndexWithBufferRabitQConcurrentPreparedPack2587|VectorIndexSearcherRabitQQuantizedSearchWithBuffer2451|VectorIndexSearcherBRQQuantizedSearchWithBuffer2481|ColumnHNSWSearchPackExactRouteAndQuantizedFailClosed2585|ColumnVectorGraphPreparedExactIndexedScoringEquivalence2098)' \
  -count=1

GOMAXPROCS=8 GOWORK=off go test ./TreeDB/collections -count=1
```

## Direct mmap counter smoke

Quick direct-mmap counter smoke from the direct-mmap production-code head (latest `9ece65e5b` is test-only):

```sh
TREEDB_COLUMN_GRAPH_QUANTIZED_BENCH_SHAPE=10k_x_768 \
GOMAXPROCS=8 GOWORK=off \
go test ./TreeDB/collections \
  -run '^$' \
  -bench '^BenchmarkCollectionSearchVectorIndexWithBufferColumnGraphScalarU8Quantized2415/route=quantized_only/c=8$' \
  -benchmem -benchtime=100x -count=1
```

Artifact: `/tmp/scalar_u8_mmap_direct_smoke_20260611_130920/collection_qonly_c8_smoke.txt`.

Key smoke counters on Apple M3 / darwin arm64:

| Metric | Latest head |
|---|---:|
| `collection_prepared_heap_copy_B` | 0 |
| `collection_prepared_mapped_B` | 73,827,024 |
| `quantized_asset_heap_copy/search` | 0 |
| `quantized_asset_heap_copy_B` | 0 |
| `quantized_asset_mmap_direct/search` | 1 |
| `quantized_asset_mapped_B` | 8,082,224 |
| `B/op` | 0 |
| `allocs/op` | 0 |

Smoke row also reported `10201 ns/op` and `98027 ops/sec`; this was a focused counter/alloc smoke before the coordinator full before/after matrix below.

## Rollout / Toggle Plan

- Default behavior is automatic for prepared collection `scalar_u8` quantized search.
- Rollback is to stop using resource-backed/shared scalar_u8 assets in the prepared collection quantized cache.
- Counters expose the active path: `quantized_asset_heap_copy/search`, `quantized_asset_mmap_direct/search`, active handles, mapped bytes, and heap-copy bytes.

## Coordinator full 10k x 768 matrix

After the direct-mmap follow-up, coordinator reran the same-host before/after 10k x 768 matrix against base `d6683e8517dd6b64d1986058fe6358211e224801`:

```sh
TREEDB_COLUMN_GRAPH_QUANTIZED_BENCH_SHAPE=10k_x_768 \
GOMAXPROCS=8 GOWORK=off \
go test ./TreeDB/collections -run '^$' \
  -bench '^(BenchmarkCollectionSearchVectorIndexWithBufferColumnGraphScalarU8Quantized2415|BenchmarkVectorIndexSearcherColumnGraphScalarU8QuantizedSearchWithBuffer2414)' \
  -benchmem -benchtime=100000x -count=5
```

Artifacts: `/tmp/scalar_u8_mmap_2621_coordinator_final_20260611_131305/{before.txt,after.txt,benchstat.txt}`.

Key result: sec/op geomean `8.578µ -> 8.209µ` (`-4.31%`). All collection search rows remained statistically noise (`~`, p>=0.103), and all rows retained `0 B/op`, `0 allocs/op`. The collection c=8 rows now report `collection_prepared_heap_copy_B=0`, `quantized_asset_heap_copy/search=0`, `quantized_asset_mmap_direct/search=1`, and one shared scalar_u8 mapped asset (`quantized_asset_mapped_B=8,082,224`).

## Follow-ups

- If mmap/direct random-row scoring needs further platform-specific optimization, handle it without reintroducing a prepared collection heap-copy default.

## AI Review Loop / CI

- Codex latest-head review: requested after green CI; Codex reported no major issues.
- Copilot latest-head review: requested after green CI; no Copilot response was available before merge readiness.
- CodeRabbit: automatic review was rate-limited/usage-limited; no actionable findings reported.
- Review threads: none.
- CI: latest head `9ece65e5b` passed all checks, including Windows rerun of the fallback expectation fix.





