### PR TITLE
TreeDB documentservice: cache vector-index search handles

### DIFF
--- a/TreeDB/collections/collection_vector_index_prepared_search_cache.go
+++ b/TreeDB/collections/collection_vector_index_prepared_search_cache.go
@@ -111,6 +111,49 @@ func collectionVectorIndexPreparedSearchCacheSlotForOptions(opts VectorIndexSear
 	return collectionVectorIndexPreparedSearchCacheSlot{family: collectionVectorIndexPreparedSearchFamilyExactHNSWPack, indexName: opts.IndexName}
 }
 
+// WarmVectorIndexPreparedSearch opens and retains the collection-level prepared
+// vector-index search state for opts without executing a query. It is intended
+// for service lifecycle boundaries, such as optimize, that need the first
+// request after a rebuild to reuse already-prepared no-document search assets.
+func (c *Collection) WarmVectorIndexPreparedSearch(opts VectorIndexSearchOptions) (VectorIndexSearchResponse, error) {
+	var response VectorIndexSearchResponse
+	if opts.IncludeDocuments {
+		return response, errors.New("collections: vector index WarmVectorIndexPreparedSearch does not support IncludeDocuments")
+	}
+	if documentFetchOptionsHasProjection(opts.DocumentFetchOptions) {
+		return response, errors.New("collections: vector index warm prepared search document projection requires IncludeDocuments")
+	}
+	if c == nil {
+		return response, errCollectionNil
+	}
+	if c.db == nil {
+		return response, errCollectionDBNil
+	}
+	if err := c.flushBufferedWrites(); err != nil {
+		return response, err
+	}
+	statsMode, err := columnVectorGraphNativeSearchStatsModeFromPublic(opts.StatsMode)
+	if err != nil {
+		return response, err
+	}
+	queryMode, err := normalizeVectorIndexSearchQueryMode(opts.QueryMode, opts.QuantizedIndexName, opts.QuantizedRerankCandidates, opts.TopK)
+	if err != nil {
+		return response, err
+	}
+	if queryMode == columnVectorGraphNativeSearchQueryModeExact && !columnHNSWSearchPackStatsModeSupportedForSearch(statsMode) {
+		return response, fmt.Errorf("%w: vector index %q WarmVectorIndexPreparedSearch requires the exact no-document hnsw_search_pack_v1 route for the selected stats mode", ErrVectorIndexSearchUnavailable, opts.IndexName)
+	}
+	prepared, response, acquireStats, err := c.acquireCollectionVectorIndexPreparedSearch(opts)
+	if err != nil {
+		acquireStats.apply(&response.Stats)
+		return response, err
+	}
+	response = prepared.responseForSearch()
+	prepared.routeStats.apply(&response.Stats)
+	acquireStats.apply(&response.Stats)
+	return response, nil
+}
+
 func (c *Collection) acquireCollectionVectorIndexPreparedSearch(opts VectorIndexSearchOptions) (*collectionVectorIndexPreparedSearch, VectorIndexSearchResponse, collectionVectorIndexPreparedSearchAcquireStats, error) {
 	var response VectorIndexSearchResponse
 	var acquireStats collectionVectorIndexPreparedSearchAcquireStats
@@ -960,6 +1003,14 @@ func (c *Collection) hasCollectionVectorIndexPreparedSearchCacheEntries() bool {
 	c.vectorBufferedSearchMu.Lock()
 	defer c.vectorBufferedSearchMu.Unlock()
 	return len(c.vectorBufferedSearch) > 0
+}
+
+// CloseVectorIndexPreparedSearchCache releases prepared no-document vector-index
+// search state retained by this collection handle. Callers that cache collection
+// handles across requests should use it when invalidating the handle for a
+// service-level lifecycle boundary.
+func (c *Collection) CloseVectorIndexPreparedSearchCache() error {
+	return c.closeCollectionVectorIndexPreparedSearchCache()
 }
 
 func (c *Collection) closeCollectionVectorIndexPreparedSearchCache() error {

--- a/TreeDB/documentservice/service.go
+++ b/TreeDB/documentservice/service.go
@@ -491,6 +491,9 @@ func (s *Service) ResetIndex(ctx context.Context, index string, req ResetIndexRe
 
 // OptimizeIndex rebuilds service vector assets after a benchmark load phase.
 func (s *Service) OptimizeIndex(ctx context.Context, index string, req OptimizeIndexRequest) (OptimizeIndexResponse, error) {
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+
 	col, info, err := s.openIndex(ctx, index, req.ExpectedGeneration)
 	if err != nil {
 		return OptimizeIndexResponse{}, err
@@ -503,8 +506,6 @@ func (s *Service) OptimizeIndex(ctx context.Context, index string, req OptimizeI
 		return OptimizeIndexResponse{}, serviceErrorf(CodeInvalidRequest, "unsupported vector_index_name %q", req.VectorIndexName)
 	}
 
-	s.writeMu.Lock()
-	defer s.writeMu.Unlock()
 	if err := s.invalidateBenchmarkSearchCache(index); err != nil {
 		return OptimizeIndexResponse{}, wrapServiceError(CodeInternal, "invalidate benchmark vector search cache before optimize failed", err)
 	}

--- a/TreeDB/documentservice/service.go
+++ b/TreeDB/documentservice/service.go
@@ -21,11 +21,65 @@ const maxServiceScanDocuments = int(^uint(0) >> 1)
 type Service struct {
 	manager *collections.CollectionManager
 	writeMu sync.Mutex
+
+	benchmarkSearchCacheMu sync.RWMutex
+	benchmarkSearchCache   map[string]*serviceBenchmarkSearchCacheEntry
+	closed                 bool
+}
+
+type serviceBenchmarkSearchCacheEntry struct {
+	collection *collections.Collection
+	info       IndexInfo
 }
 
 // New returns a document/search service backed by manager.
 func New(manager *collections.CollectionManager) *Service {
 	return &Service{manager: manager}
+}
+
+// Close releases service-owned cached search resources and marks the service
+// unavailable. The underlying collection manager and database remain owned by
+// the caller.
+func (s *Service) Close() error {
+	if s == nil {
+		return nil
+	}
+	var entries []*serviceBenchmarkSearchCacheEntry
+	s.benchmarkSearchCacheMu.Lock()
+	if s.closed {
+		s.benchmarkSearchCacheMu.Unlock()
+		return nil
+	}
+	s.closed = true
+	for _, entry := range s.benchmarkSearchCache {
+		if entry != nil {
+			entries = append(entries, entry)
+		}
+	}
+	s.benchmarkSearchCache = nil
+	s.benchmarkSearchCacheMu.Unlock()
+
+	var closeErr error
+	for _, entry := range entries {
+		if entry.collection != nil {
+			closeErr = errors.Join(closeErr, entry.collection.CloseVectorIndexPreparedSearchCache())
+		}
+	}
+	return closeErr
+}
+
+func (s *Service) isClosed() bool {
+	if s == nil {
+		return false
+	}
+	s.benchmarkSearchCacheMu.RLock()
+	closed := s.closed
+	s.benchmarkSearchCacheMu.RUnlock()
+	return closed
+}
+
+func serviceClosedError() error {
+	return serviceError(CodeIndexUnavailable, "document service is closed")
 }
 
 // CreateIndex creates or opens a compatible document service index.
@@ -35,6 +89,9 @@ func (s *Service) CreateIndex(ctx context.Context, req CreateIndexRequest) (Inde
 	}
 	if s == nil || s.manager == nil {
 		return IndexInfo{}, serviceError(CodeIndexUnavailable, "document service has no collection manager")
+	}
+	if s.isClosed() {
+		return IndexInfo{}, serviceClosedError()
 	}
 	if err := collections.ValidateCollectionName(req.Name); err != nil {
 		return IndexInfo{}, wrapServiceError(CodeInvalidRequest, "invalid index name", err)
@@ -88,6 +145,9 @@ func (s *Service) CreateIndex(ctx context.Context, req CreateIndexRequest) (Inde
 			return IndexInfo{}, wrapServiceError(CodeConflict, fmt.Sprintf("index %q already exists with an incompatible schema", req.Name), err)
 		}
 		return IndexInfo{}, wrapServiceError(CodeInternal, "create index failed", err)
+	}
+	if err := s.invalidateBenchmarkSearchCache(req.Name); err != nil {
+		return IndexInfo{}, wrapServiceError(CodeInternal, "invalidate benchmark vector search cache after create index failed", err)
 	}
 	return indexInfoFromMeta(*created)
 }
@@ -175,10 +235,17 @@ func (s *Service) UpsertDocuments(ctx context.Context, index string, req UpsertD
 			updated++
 		}
 	}
+	var rebuildErr error
 	if inserted > 0 && updated == 0 && !req.DeferVectorIndexRebuild {
-		if err := rebuildServiceVectorIndex(ctx, col); err != nil {
-			return UpsertDocumentsResponse{}, err
+		rebuildErr = rebuildServiceVectorIndex(ctx, col)
+	}
+	if inserted+updated > 0 {
+		if err := s.invalidateBenchmarkSearchCache(index); err != nil && rebuildErr == nil {
+			return UpsertDocumentsResponse{}, wrapServiceError(CodeInternal, "invalidate benchmark vector search cache after upsert failed", err)
 		}
+	}
+	if rebuildErr != nil {
+		return UpsertDocumentsResponse{}, rebuildErr
 	}
 	return UpsertDocumentsResponse{Index: info, Upserted: len(prepared), Inserted: inserted, Updated: updated, IDs: ids}, nil
 }
@@ -222,6 +289,11 @@ func (s *Service) DeleteDocuments(ctx context.Context, index string, req DeleteD
 	deleted, err := col.DeleteBatch(deleteIDs)
 	if err != nil {
 		return DeleteDocumentsResponse{}, wrapServiceError(CodeInternal, "delete documents failed", err)
+	}
+	if deleted > 0 {
+		if err := s.invalidateBenchmarkSearchCache(index); err != nil {
+			return DeleteDocumentsResponse{}, wrapServiceError(CodeInternal, "invalidate benchmark vector search cache after delete failed", err)
+		}
 	}
 	return DeleteDocumentsResponse{Index: info, Deleted: deleted, IDs: ids}, nil
 }
@@ -411,6 +483,9 @@ func (s *Service) ResetIndex(ctx context.Context, index string, req ResetIndexRe
 	if err != nil {
 		return ResetIndexResponse{}, err
 	}
+	if err := s.invalidateBenchmarkSearchCache(index); err != nil {
+		return ResetIndexResponse{}, wrapServiceError(CodeInternal, "invalidate benchmark vector search cache after reset failed", err)
+	}
 	return ResetIndexResponse{Index: info, Created: false, Reset: true, DropOld: req.DropOld, DroppedDocuments: len(ids)}, nil
 }
 
@@ -427,21 +502,38 @@ func (s *Service) OptimizeIndex(ctx context.Context, index string, req OptimizeI
 	if vectorIndexName != info.VectorIndexName {
 		return OptimizeIndexResponse{}, serviceErrorf(CodeInvalidRequest, "unsupported vector_index_name %q", req.VectorIndexName)
 	}
+
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	if err := s.invalidateBenchmarkSearchCache(index); err != nil {
+		return OptimizeIndexResponse{}, wrapServiceError(CodeInternal, "invalidate benchmark vector search cache before optimize failed", err)
+	}
 	status, err := col.RebuildVectorIndex(vectorIndexName)
 	if err != nil {
 		return OptimizeIndexResponse{}, mapCollectionMaintenanceError("optimize vector index", err)
 	}
-	return OptimizeIndexResponse{Index: info, VectorIndexName: vectorIndexName, Status: vectorIndexMaintenanceStatus(status)}, nil
+	maintenance := vectorIndexMaintenanceStatus(status)
+	if info.Capabilities.NoDocumentVectorSearch && maintenance.Loaded && !maintenance.RebuildNeeded {
+		if err := s.primeBenchmarkSearchCache(index, col, info); err != nil {
+			return OptimizeIndexResponse{}, wrapServiceError(CodeInternal, "prime benchmark vector search cache after optimize failed", err)
+		}
+		if err := s.warmBenchmarkSearchCache(ctx, index, info, vectorIndexName); err != nil {
+			_ = s.invalidateBenchmarkSearchCache(index)
+			return OptimizeIndexResponse{}, err
+		}
+	}
+	return OptimizeIndexResponse{Index: info, VectorIndexName: vectorIndexName, Status: maintenance}, nil
 }
 
 // SearchBenchmarkVector runs fail-closed no-document vector-index benchmark
 // search. It never materializes documents and never falls back to exact dense
 // document scanning.
 func (s *Service) SearchBenchmarkVector(ctx context.Context, index string, req BenchmarkVectorSearchRequest) (BenchmarkVectorSearchResponse, error) {
-	col, info, err := s.openIndex(ctx, index, req.ExpectedGeneration)
+	col, info, release, err := s.acquireBenchmarkSearchIndex(ctx, index, req.ExpectedGeneration)
 	if err != nil {
 		return BenchmarkVectorSearchResponse{}, err
 	}
+	defer release()
 	if !info.Capabilities.NoDocumentVectorSearch {
 		return BenchmarkVectorSearchResponse{}, serviceError(CodeIndexUnavailable, "no-document vector-index search requires a cosine column_graph index")
 	}
@@ -627,12 +719,143 @@ func (s *Service) SearchHybrid(ctx context.Context, index string, req HybridSear
 	return response, nil
 }
 
+func (s *Service) acquireBenchmarkSearchIndex(ctx context.Context, name string, expectedGeneration uint64) (*collections.Collection, IndexInfo, func(), error) {
+	if err := ctxErr(ctx); err != nil {
+		return nil, IndexInfo{}, nil, err
+	}
+	if s == nil || s.manager == nil {
+		return nil, IndexInfo{}, nil, serviceError(CodeIndexUnavailable, "document service has no collection manager")
+	}
+	if err := collections.ValidateCollectionName(name); err != nil {
+		return nil, IndexInfo{}, nil, wrapServiceError(CodeInvalidRequest, "invalid index name", err)
+	}
+	for {
+		s.benchmarkSearchCacheMu.RLock()
+		if s.closed {
+			s.benchmarkSearchCacheMu.RUnlock()
+			return nil, IndexInfo{}, nil, serviceClosedError()
+		}
+		entry := s.benchmarkSearchCache[name]
+		if entry != nil && entry.collection != nil {
+			info := entry.info
+			if expectedGeneration != 0 && expectedGeneration != info.Generation {
+				s.benchmarkSearchCacheMu.RUnlock()
+				return nil, IndexInfo{}, nil, serviceErrorf(CodeIndexStale, "index %q generation %d does not match expected_generation %d", name, info.Generation, expectedGeneration)
+			}
+			return entry.collection, info, s.benchmarkSearchCacheMu.RUnlock, nil
+		}
+		s.benchmarkSearchCacheMu.RUnlock()
+
+		col, info, err := s.openIndex(ctx, name, expectedGeneration)
+		if err != nil {
+			return nil, IndexInfo{}, nil, err
+		}
+		entry = &serviceBenchmarkSearchCacheEntry{collection: col, info: info}
+		var closeCol *collections.Collection
+		s.benchmarkSearchCacheMu.Lock()
+		if s.closed {
+			closeCol = col
+		} else {
+			if s.benchmarkSearchCache == nil {
+				s.benchmarkSearchCache = make(map[string]*serviceBenchmarkSearchCacheEntry)
+			}
+			if existing := s.benchmarkSearchCache[name]; existing != nil && existing.collection != nil {
+				closeCol = col
+			} else {
+				s.benchmarkSearchCache[name] = entry
+			}
+		}
+		s.benchmarkSearchCacheMu.Unlock()
+		if closeCol != nil {
+			_ = closeCol.CloseVectorIndexPreparedSearchCache()
+			if s.isClosed() {
+				return nil, IndexInfo{}, nil, serviceClosedError()
+			}
+		}
+	}
+}
+
+func (s *Service) primeBenchmarkSearchCache(name string, col *collections.Collection, info IndexInfo) error {
+	if s == nil || col == nil {
+		return nil
+	}
+	var closeCol *collections.Collection
+	s.benchmarkSearchCacheMu.Lock()
+	if s.closed {
+		s.benchmarkSearchCacheMu.Unlock()
+		return serviceClosedError()
+	}
+	if s.benchmarkSearchCache == nil {
+		s.benchmarkSearchCache = make(map[string]*serviceBenchmarkSearchCacheEntry)
+	}
+	if existing := s.benchmarkSearchCache[name]; existing != nil && existing.collection != nil && existing.collection != col {
+		closeCol = existing.collection
+	}
+	s.benchmarkSearchCache[name] = &serviceBenchmarkSearchCacheEntry{collection: col, info: info}
+	s.benchmarkSearchCacheMu.Unlock()
+	if closeCol != nil {
+		return closeCol.CloseVectorIndexPreparedSearchCache()
+	}
+	return nil
+}
+
+func (s *Service) invalidateBenchmarkSearchCache(name string) error {
+	if s == nil {
+		return nil
+	}
+	var closeCol *collections.Collection
+	s.benchmarkSearchCacheMu.Lock()
+	if entry := s.benchmarkSearchCache[name]; entry != nil {
+		closeCol = entry.collection
+		delete(s.benchmarkSearchCache, name)
+	}
+	s.benchmarkSearchCacheMu.Unlock()
+	if closeCol != nil {
+		return closeCol.CloseVectorIndexPreparedSearchCache()
+	}
+	return nil
+}
+
+func (s *Service) warmBenchmarkSearchCache(ctx context.Context, index string, info IndexInfo, vectorIndexName string) error {
+	col, _, release, err := s.acquireBenchmarkSearchIndex(ctx, index, info.Generation)
+	if err != nil {
+		return err
+	}
+	defer release()
+	response, err := col.WarmVectorIndexPreparedSearch(collections.VectorIndexSearchOptions{
+		IndexName: vectorIndexName,
+		QueryMode: collections.VectorIndexQueryModeExact,
+		TopK:      1,
+		EfSearch:  info.VectorEfSearch,
+		StatsMode: collections.VectorIndexSearchStatsModeProduction,
+	})
+	if err != nil {
+		return mapVectorIndexSearchError("warm benchmark vector search cache", err)
+	}
+	if err := validateBenchmarkVectorSearchRoute(BenchmarkVectorQueryModeExact, BenchmarkVectorSearchRequest{}, response); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *Service) benchmarkSearchCacheSizeForTest() int {
+	if s == nil {
+		return 0
+	}
+	s.benchmarkSearchCacheMu.RLock()
+	defer s.benchmarkSearchCacheMu.RUnlock()
+	return len(s.benchmarkSearchCache)
+}
+
 func (s *Service) openIndex(ctx context.Context, name string, expectedGeneration uint64) (*collections.Collection, IndexInfo, error) {
 	if err := ctxErr(ctx); err != nil {
 		return nil, IndexInfo{}, err
 	}
 	if s == nil || s.manager == nil {
 		return nil, IndexInfo{}, serviceError(CodeIndexUnavailable, "document service has no collection manager")
+	}
+	if s.isClosed() {
+		return nil, IndexInfo{}, serviceClosedError()
 	}
 	if err := collections.ValidateCollectionName(name); err != nil {
 		return nil, IndexInfo{}, wrapServiceError(CodeInvalidRequest, "invalid index name", err)

--- a/TreeDB/documentservice/service_benchmark_cache_test.go
+++ b/TreeDB/documentservice/service_benchmark_cache_test.go
@@ -1,0 +1,216 @@
+package documentservice
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/collections"
+)
+
+func TestServiceBenchmarkVectorSearchCacheWarmOnOptimizeAndReuse(t *testing.T) {
+	svc, db := newTestService(t)
+	defer db.Close()
+	ctx := context.Background()
+	createBenchmarkColumnGraphIndex(t, svc, "bench_cache")
+	loadBenchmarkDocsDeferred(t, svc, "bench_cache", []Document{
+		{ID: "a", Content: "alpha", Embedding: []float32{1, 0}},
+		{ID: "b", Content: "beta", Embedding: []float32{0, 1}},
+	})
+	if got := svc.benchmarkSearchCacheSizeForTest(); got != 0 {
+		t.Fatalf("cache size before optimize=%d want 0", got)
+	}
+	if _, err := svc.OptimizeIndex(ctx, "bench_cache", OptimizeIndexRequest{}); err != nil {
+		t.Fatalf("OptimizeIndex: %v", err)
+	}
+	if got := svc.benchmarkSearchCacheSizeForTest(); got != 1 {
+		t.Fatalf("cache size after optimize=%d want 1", got)
+	}
+
+	first, err := svc.SearchBenchmarkVector(ctx, "bench_cache", BenchmarkVectorSearchRequest{QueryEmbedding: []float32{1, 0}, TopK: 2, EfSearch: 8})
+	if err != nil {
+		t.Fatalf("SearchBenchmarkVector first: %v", err)
+	}
+	assertBenchmarkCacheHit(t, first, "first search after optimize")
+	if first.Diagnostics.Route != collections.VectorIndexSearchRouteExactHNSWSearchPackV1 || !first.NoDocuments || first.Stats.DocumentsFetched != 0 {
+		t.Fatalf("first search left exact no-document route: response=%+v stats=%+v diagnostics=%+v", first, first.Stats, first.Diagnostics)
+	}
+
+	second, err := svc.SearchBenchmarkVector(ctx, "bench_cache", BenchmarkVectorSearchRequest{QueryEmbedding: []float32{0, 1}, TopK: 2, EfSearch: 8})
+	if err != nil {
+		t.Fatalf("SearchBenchmarkVector second: %v", err)
+	}
+	assertBenchmarkCacheHit(t, second, "second search")
+}
+
+func TestServiceBenchmarkVectorSearchCacheConcurrentReuse(t *testing.T) {
+	svc, db := newTestService(t)
+	defer db.Close()
+	ctx := context.Background()
+	createBenchmarkColumnGraphIndex(t, svc, "bench_concurrent")
+	loadBenchmarkDocsDeferred(t, svc, "bench_concurrent", []Document{
+		{ID: "a", Content: "alpha", Embedding: []float32{1, 0}},
+		{ID: "b", Content: "beta", Embedding: []float32{0, 1}},
+	})
+	if _, err := svc.OptimizeIndex(ctx, "bench_concurrent", OptimizeIndexRequest{}); err != nil {
+		t.Fatalf("OptimizeIndex: %v", err)
+	}
+
+	const workers = 16
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	errs := make(chan error, workers)
+	for i := 0; i < workers; i++ {
+		i := i
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			query := []float32{1, 0}
+			if i%2 == 1 {
+				query = []float32{0, 1}
+			}
+			res, err := svc.SearchBenchmarkVector(ctx, "bench_concurrent", BenchmarkVectorSearchRequest{QueryEmbedding: query, TopK: 2, EfSearch: 8})
+			if err != nil {
+				errs <- err
+				return
+			}
+			if res.Stats.HNSWSearchPackCacheHits != 1 || res.Stats.HNSWSearchPackCacheMisses != 0 || res.Stats.HNSWSearchPackCacheBuilds != 0 || res.Stats.DocumentsFetched != 0 {
+				errs <- serviceErrorf(CodeInternal, "unexpected concurrent cache stats: hits=%d misses=%d builds=%d docs=%d", res.Stats.HNSWSearchPackCacheHits, res.Stats.HNSWSearchPackCacheMisses, res.Stats.HNSWSearchPackCacheBuilds, res.Stats.DocumentsFetched)
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Fatalf("concurrent search error: %v", err)
+	}
+}
+
+func TestServiceBenchmarkVectorSearchCacheInvalidatesOnLifecycleEvents(t *testing.T) {
+	svc, db := newTestService(t)
+	defer db.Close()
+	ctx := context.Background()
+	createBenchmarkColumnGraphIndex(t, svc, "bench_lifecycle")
+	loadBenchmarkDocsDeferred(t, svc, "bench_lifecycle", []Document{
+		{ID: "a", Content: "alpha", Embedding: []float32{1, 0}},
+		{ID: "b", Content: "beta", Embedding: []float32{0, 1}},
+	})
+	if _, err := svc.OptimizeIndex(ctx, "bench_lifecycle", OptimizeIndexRequest{}); err != nil {
+		t.Fatalf("OptimizeIndex: %v", err)
+	}
+	if got := svc.benchmarkSearchCacheSizeForTest(); got != 1 {
+		t.Fatalf("cache size after optimize=%d want 1", got)
+	}
+
+	if _, err := svc.UpsertDocuments(ctx, "bench_lifecycle", UpsertDocumentsRequest{Documents: []Document{{ID: "a", Content: "alpha updated", Embedding: []float32{1, 0}}}}); err != nil {
+		t.Fatalf("UpsertDocuments non-deferred: %v", err)
+	}
+	if got := svc.benchmarkSearchCacheSizeForTest(); got != 0 {
+		t.Fatalf("cache size after non-deferred upsert=%d want 0", got)
+	}
+
+	col, info, err := svc.openIndex(ctx, "bench_lifecycle", 0)
+	if err != nil {
+		t.Fatalf("open bench_lifecycle: %v", err)
+	}
+	if err := svc.primeBenchmarkSearchCache("schema_create", col, info); err != nil {
+		t.Fatalf("prime schema_create cache: %v", err)
+	}
+	if got := svc.benchmarkSearchCacheSizeForTest(); got != 1 {
+		t.Fatalf("cache size after schema_create prime=%d want 1", got)
+	}
+	if _, err := svc.ResetIndex(ctx, "schema_create", ResetIndexRequest{Dimension: 2, Metric: MetricCosine, DropOld: true, VectorIndexOptions: benchmarkColumnGraphOptions()}); err != nil {
+		t.Fatalf("ResetIndex schema_create: %v", err)
+	}
+	if got := svc.benchmarkSearchCacheSizeForTest(); got != 0 {
+		t.Fatalf("cache size after create/index schema boundary=%d want 0", got)
+	}
+}
+
+func TestServiceBenchmarkVectorSearchCacheInvalidatesOnDeleteResetAndClose(t *testing.T) {
+	svc, db := newTestService(t)
+	defer db.Close()
+	ctx := context.Background()
+	createBenchmarkColumnGraphIndex(t, svc, "bench_delete")
+	loadBenchmarkDocsDeferred(t, svc, "bench_delete", []Document{
+		{ID: "a", Content: "alpha", Embedding: []float32{1, 0}},
+		{ID: "b", Content: "beta", Embedding: []float32{0, 1}},
+	})
+	if _, err := svc.OptimizeIndex(ctx, "bench_delete", OptimizeIndexRequest{}); err != nil {
+		t.Fatalf("OptimizeIndex: %v", err)
+	}
+	if got := svc.benchmarkSearchCacheSizeForTest(); got != 1 {
+		t.Fatalf("cache size after optimize=%d want 1", got)
+	}
+	if _, err := svc.DeleteDocuments(ctx, "bench_delete", DeleteDocumentsRequest{IDs: []string{"b"}}); err != nil {
+		t.Fatalf("DeleteDocuments: %v", err)
+	}
+	if got := svc.benchmarkSearchCacheSizeForTest(); got != 0 {
+		t.Fatalf("cache size after delete=%d want 0", got)
+	}
+
+	if _, err := svc.ResetIndex(ctx, "native_reset", ResetIndexRequest{Dimension: 2, Metric: MetricCosine, DropOld: true, VectorIndexOptions: &BenchmarkVectorIndexOptions{Strategy: collections.VectorIndexStrategyNativeRuntime}}); err != nil {
+		t.Fatalf("ResetIndex native create: %v", err)
+	}
+	col, info, err := svc.openIndex(ctx, "native_reset", 0)
+	if err != nil {
+		t.Fatalf("open native_reset: %v", err)
+	}
+	if err := svc.primeBenchmarkSearchCache("native_reset", col, info); err != nil {
+		t.Fatalf("prime native cache: %v", err)
+	}
+	if got := svc.benchmarkSearchCacheSizeForTest(); got != 1 {
+		t.Fatalf("cache size after native prime=%d want 1", got)
+	}
+	if _, err := svc.ResetIndex(ctx, "native_reset", ResetIndexRequest{Dimension: 2, Metric: MetricCosine, DropOld: true, VectorIndexOptions: &BenchmarkVectorIndexOptions{Strategy: collections.VectorIndexStrategyNativeRuntime}}); err != nil {
+		t.Fatalf("ResetIndex native existing: %v", err)
+	}
+	if got := svc.benchmarkSearchCacheSizeForTest(); got != 0 {
+		t.Fatalf("cache size after reset=%d want 0", got)
+	}
+
+	createBenchmarkColumnGraphIndex(t, svc, "bench_close")
+	loadBenchmarkDocsDeferred(t, svc, "bench_close", []Document{{ID: "a", Content: "alpha", Embedding: []float32{1, 0}}})
+	if _, err := svc.OptimizeIndex(ctx, "bench_close", OptimizeIndexRequest{}); err != nil {
+		t.Fatalf("OptimizeIndex bench_close: %v", err)
+	}
+	if got := svc.benchmarkSearchCacheSizeForTest(); got != 1 {
+		t.Fatalf("cache size before close=%d want 1", got)
+	}
+	if err := svc.Close(); err != nil {
+		t.Fatalf("Service.Close: %v", err)
+	}
+	if got := svc.benchmarkSearchCacheSizeForTest(); got != 0 {
+		t.Fatalf("cache size after close=%d want 0", got)
+	}
+	if _, err := svc.SearchBenchmarkVector(ctx, "bench_close", BenchmarkVectorSearchRequest{QueryEmbedding: []float32{1, 0}, TopK: 1}); ErrorCodeOf(err) != CodeIndexUnavailable {
+		t.Fatalf("search after close err=%v code=%s, want index_unavailable", err, ErrorCodeOf(err))
+	}
+}
+
+func benchmarkColumnGraphOptions() *BenchmarkVectorIndexOptions {
+	return &BenchmarkVectorIndexOptions{Strategy: collections.VectorIndexStrategyColumnGraph, M: 4, EfSearch: 8}
+}
+
+func createBenchmarkColumnGraphIndex(t *testing.T, svc *Service, index string) {
+	t.Helper()
+	if _, err := svc.ResetIndex(context.Background(), index, ResetIndexRequest{Dimension: 2, Metric: MetricCosine, DropOld: true, VectorIndexOptions: benchmarkColumnGraphOptions()}); err != nil {
+		t.Fatalf("ResetIndex %s create: %v", index, err)
+	}
+}
+
+func loadBenchmarkDocsDeferred(t *testing.T, svc *Service, index string, docs []Document) {
+	t.Helper()
+	if _, err := svc.UpsertDocuments(context.Background(), index, UpsertDocumentsRequest{Documents: docs, DeferVectorIndexRebuild: true}); err != nil {
+		t.Fatalf("UpsertDocuments %s deferred: %v", index, err)
+	}
+}
+
+func assertBenchmarkCacheHit(t *testing.T, response BenchmarkVectorSearchResponse, label string) {
+	t.Helper()
+	if response.Stats.HNSWSearchPackCacheHits != 1 || response.Stats.HNSWSearchPackCacheMisses != 0 || response.Stats.HNSWSearchPackCacheBuilds != 0 {
+		t.Fatalf("%s cache stats hits=%d misses=%d builds=%d waits=%d, want one hit and no miss/build", label, response.Stats.HNSWSearchPackCacheHits, response.Stats.HNSWSearchPackCacheMisses, response.Stats.HNSWSearchPackCacheBuilds, response.Stats.HNSWSearchPackCacheWaits)
+	}
+}

--- a/cmd/treedb-document-service/main.go
+++ b/cmd/treedb-document-service/main.go
@@ -45,7 +45,9 @@ func main() {
 	defer func() { _ = cleanup() }()
 
 	manager := collections.NewCollectionManager(database)
-	handler := documentservice.NewHandler(documentservice.New(manager))
+	service := documentservice.New(manager)
+	defer func() { _ = service.Close() }()
+	handler := documentservice.NewHandler(service)
 	server := &http.Server{Addr: *addr, Handler: handler, ReadHeaderTimeout: 5 * time.Second}
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)


### PR DESCRIPTION
## Objective

Optimize the TreeDB document-service exact FP32 `/v1/indexes/{index}/search/vector-index` hot path by keeping a stable service-owned collection handle/cache across requests, so the collection-level prepared HNSW search-pack cache survives request boundaries.

Refs #2618, parent tracker #2616. The PR now has full-size before/after service-path and VDBBench evidence for the exact FP32 lane; latest head is `07d49e6b6f2d13e6b9ec061a94f32c6c2da89a62`.

## Context

#2617 attributed the service-path QPS gap to `SearchBenchmarkVector` calling `openIndex()` per request. `CollectionManager.OpenCollection()` returns a fresh `Collection` handle, so every request lost the collection-owned prepared search-pack cache and remapped ~318MB of `hnsw_search_pack_v1` assets.

## Non-goals

- Do not change `/v1/indexes/{index}/search/vector` exact dense document scoring semantics.
- Do not broaden into scalar_u8 rerank/OOM work (#2619).
- Do not change durable storage cleanup/WAL semantics or benchmark public claims.
- Do not broaden benchmark claims beyond the exact FP32 evidence captured here; scalar_u8 remains #2619 and final comparator campaign remains #2620.

## Design

- Add a service-owned benchmark vector search cache keyed by index name.
- `/search/vector-index` acquires a cached `Collection` handle under a service cache read lock, preserving the collection-owned `SearchVectorIndexWithBuffer` prepared-search cache across requests.
- `OptimizeIndex` invalidates any old entry, rebuilds vector assets, primes the service cache with the optimized collection, and warms exact no-document prepared state.
- Invalidation is conservative:
  - `CreateIndex` success invalidates schema/index cache state.
  - `OptimizeIndex` invalidates before rebuild and re-primes only after loaded/clean status.
  - `UpsertDocuments` invalidates after successful mutation, including non-deferred rebuild attempts.
  - `DeleteDocuments` invalidates after successful deletion.
  - `ResetIndex` invalidates after successful reset.
  - `Service.Close` and `cmd/treedb-document-service` shutdown close cached prepared-search resources.
- Fail-closed behavior remains delegated to collection guardrails; route validation still rejects fallback/document materialization.

## Scope

- Includes:
  - `TreeDB/documentservice/service.go`
  - `TreeDB/documentservice/service_benchmark_cache_test.go`
  - `TreeDB/collections/collection_vector_index_prepared_search_cache.go`
  - `cmd/treedb-document-service/main.go`
- Excludes:
  - scalar_u8/rerank memory behavior
  - `/search/vector` dense scoring implementation
  - VDBBench adapter/client changes

## Correctness

Tests run locally:

```sh
go test ./TreeDB/documentservice -run 'BenchmarkVectorSearchCache|BenchmarkLifecycle|BenchmarkVectorFailClosed|HTTPBenchmarkLifecycle' -count=1
go test ./TreeDB/collections -run 'SearchVectorIndexWithBuffer|ColumnHNSWSearchPack|PreparedSearch' -count=1
go test ./TreeDB/documentservice -count=1
go test ./TreeDB/documentservice ./TreeDB/collections -count=1
go test ./cmd/treedb-document-service -count=1
go test ./TreeDB/documentservice ./TreeDB/collections ./cmd/treedb-document-service -count=1
go test -race ./TreeDB/documentservice -run TestServiceBenchmarkVectorSearchCacheConcurrentReuse -count=1
```

Coverage added:

- warm-on-optimize cache reuse with exact no-document route proof counters;
- concurrent repeated benchmark-route searches reuse cache hits;
- invalidation on non-deferred upsert, delete, reset/create boundary, and service close;
- shutdown path closes service-owned cache resources.

## Performance

Full-size after-fix evidence captured on `mikers@192.168.0.185` using `Performance1536D50K`, cosine, `k=10`, `ef_search=128`, `50K x 1536D`.

### Same-loaded service/HTTP before vs after

Before evidence is from #2617 on the same loaded index, where every service request rebuilt/remapped the ~318MB HNSW search pack (`cache_misses=1`, `cache_builds=1`, `cache_hits=0`). Primary after evidence was captured on `638c34f78451b84bbeb50ba235051ef777210123`; after the final CodeRabbit synchronization fix, service-direct route/QPS was recaptured on latest head `07d49e6b6f2d13e6b9ec061a94f32c6c2da89a62`.

| Boundary | Before c1/c8/c32 QPS | After c1/c8/c32 QPS | Improvement | Artifact |
| --- | ---: | ---: | ---: | --- |
| Go direct `documentservice.SearchBenchmarkVector` | `7.6 / 34.8 / 41.2` | `1016.0 / 2709.2 / 2768.0` | up to `~134x / 78x / 67x` | `/mnt/fast4tb/tmp/treedb_vdbbench_2618_cache_evidence_20260611_222457` |
| Go HTTP `/search/vector-index` | `7.6 / 36.0 / 41.4` | `452.7 / 1561.2 / 1733.9` | up to `~60x / 43x / 42x` | `/mnt/fast4tb/tmp/treedb_vdbbench_2618_http_evidence_20260611_214515` |

After route/counter proof:

- exact no-document route: `exact_hnsw_search_pack_v1`
- `documents_fetched=0`
- first cold request: `cache_misses=1`, `cache_builds=1`
- repeated requests: `cache_hits=1`, no per-request miss/build

### VectorDBBench exact FP32 service row

Full fresh VDBBench exact FP32 run captured before the final optimize-open serialization fix; the final commit does not change the search hot path and latest-head service-direct evidence is listed above:

- Artifact: `/mnt/fast4tb/tmp/treedb_vdbbench_2618_vdbbench_full_exact_serial_20260611_215802`
- gomap head: `638c34f78451b84bbeb50ba235051ef777210123` (latest search-path recapture: `07d49e6b6f2d13e6b9ec061a94f32c6c2da89a62`)
- vectordbbench head: `537d74bd4ec7630d766d5483f147d0d4d87558d6`
- VDBBench label: `:)`
- Dataset: `Performance1536D50K`, cosine, `k=10`, concurrency `1,8,32`, duration `10s`
- Recall/NDCG: `0.9954 / 0.9961`
- c1/c8/c32 QPS: `258.8955 / 998.2649 / 1501.6758`
- p95: `0.0066s / 0.0152s / 0.0386s`
- p99: `0.0099s / 0.0205s / 0.0513s`
- Load: insert `141.9794s`, optimize `201.1149s`, total `343.0942s`

Before comparable VDBBench exact FP32 diagnostic row from #2617 was `7.3795 / 34.3233 / 37.4448 QPS` with the same `:)` label but skipped serial recall for that diagnostic rerun; the earlier full exact row with serial recall was in the same low-QPS band (`7.3992 / 33.8872 / 36.0825`). This PR removes the service-path cache-churn bottleneck by over an order of magnitude in the actual VDBBench service boundary.

Regression assessment: no material search-path regression remains. The final synchronization fix takes `writeMu` before `OptimizeIndex` opens the collection; focused tests and latest-head service-direct evidence passed. Load timings are not used as before/after proof for this PR because the measured change is search-cache lifetime; the implementation only adds conservative cache invalidation and one warm exact no-document prepared open after optimize.

## Rollout / Toggle Plan

- Default behavior: enabled for document-service `/search/vector-index`; dense `/search/vector` is unchanged.
- Disable/revert: revert this PR to restore per-request `openIndex()` behavior.
- Observability: response stats/diagnostics expose `hnsw_search_pack_cache_hits`, `cache_misses`, and `cache_builds`.

## Follow-ups

- #2619 can consume the service cache contract after this PR merges/revalidates: exact service cache is service-owned, invalidated on optimize/reset/delete/mutation/schema changes, and closed on service shutdown.
- #2620 should use the final merged commit for quiet-host comparator reruns.

## AI Review Loop

- Codex latest-head review: pass on `07d49e6b6f` (`Didn't find any major issues`).
- Copilot latest-head review: requested on `07d49e6b6f`; no blocking response observed.
- CodeRabbit latest-head review: first finding fixed in `07d49e6b6`; follow-up acknowledged the synchronization fix and route/QPS evidence; CodeRabbit check passing.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to warm vector-index search caches for optimized performance
  * Implemented automatic caching and reuse of vector search results with intelligent invalidation on document changes

* **Tests**
  * Added comprehensive test suite validating cache behavior across optimization, concurrent access, and lifecycle events

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

