### PR TITLE
treemap: add read-only TreeDB audit summary

### DIFF
--- a/TreeDB/cmd/treemap/audit_summary.go
+++ b/TreeDB/cmd/treemap/audit_summary.go
@@ -1,0 +1,925 @@
+package main
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	treedb "github.com/snissn/gomap/TreeDB"
+	treedbdb "github.com/snissn/gomap/TreeDB/db"
+)
+
+const auditSummarySchemaVersion = 1
+
+type auditSummaryCollectOptions struct {
+	CompactMode        treedbdb.CompactStorageMode
+	FrameStats         bool
+	FrameTopLengths    int
+	TopSegments        int
+	TopGenerations     int
+	GzipSamples        int
+	GzipSampleMaxBytes int64
+}
+
+type auditSummaryReportOptions struct {
+	CompactMode        string `json:"compact_mode"`
+	FrameStats         bool   `json:"frame_stats"`
+	FrameTopLengths    int    `json:"frame_top_lengths"`
+	TopSegments        int    `json:"top_segments"`
+	TopGenerations     int    `json:"top_generations"`
+	GzipSamples        int    `json:"gzip_samples"`
+	GzipSampleMaxBytes int64  `json:"gzip_sample_max_bytes"`
+}
+
+type auditSummaryReport struct {
+	SchemaVersion int                       `json:"schema_version"`
+	Command       string                    `json:"command"`
+	Dir           string                    `json:"dir"`
+	RootDir       string                    `json:"root_dir"`
+	MainDir       string                    `json:"main_dir"`
+	Options       auditSummaryReportOptions `json:"options"`
+
+	Storage        auditSummaryStorage        `json:"storage"`
+	CompactPlan    auditSummaryCompactPlan    `json:"compact_plan"`
+	ValueLog       auditSummaryValueLog       `json:"value_log"`
+	LeafGeneration auditSummaryLeafGeneration `json:"leaf_generation"`
+	LogFamilies    []auditSummaryLogFamily    `json:"log_families"`
+}
+
+type auditSummaryStorage struct {
+	Domains []auditSummaryStorageDomain `json:"domains"`
+}
+
+type auditSummaryStorageDomain struct {
+	Name          string `json:"name"`
+	Path          string `json:"path"`
+	Exists        bool   `json:"exists"`
+	Bytes         int64  `json:"bytes"`
+	Files         int    `json:"files"`
+	ZeroByteFiles int    `json:"zero_byte_files"`
+}
+
+type auditSummaryCompactPlan struct {
+	Mode                 string                      `json:"mode"`
+	DryRun               bool                        `json:"dry_run"`
+	FullyCompacted       bool                        `json:"fully_compacted"`
+	PolicyFullyCompacted bool                        `json:"policy_fully_compacted"`
+	ByteMinimized        bool                        `json:"byte_minimized"`
+	StorageBefore        []auditSummaryStorageDomain `json:"storage_before"`
+	StorageAfter         []auditSummaryStorageDomain `json:"storage_after"`
+	RemainingDebt        auditSummaryDebt            `json:"remaining_debt"`
+}
+
+type auditSummaryDebt struct {
+	ValueLogRewriteSegments int   `json:"value_log_rewrite_segments"`
+	ValueLogRewriteBytes    int64 `json:"value_log_rewrite_bytes"`
+	ValueLogGCSegments      int   `json:"value_log_gc_segments"`
+	ValueLogGCBytes         int64 `json:"value_log_gc_bytes"`
+	LeafPackGenerations     int   `json:"leaf_pack_generations"`
+	LeafPackBytes           int64 `json:"leaf_pack_bytes"`
+	LeafGCGenerations       int   `json:"leaf_gc_generations"`
+	LeafGCBytes             int64 `json:"leaf_gc_bytes"`
+	ZeroByteValueLogFiles   int   `json:"zero_byte_value_log_files"`
+}
+
+type auditSummaryValueLog struct {
+	RewritePlan auditSummaryValueLogRewritePlan `json:"rewrite_plan"`
+	GCDryRun    auditSummaryValueLogGC          `json:"gc_dry_run"`
+}
+
+type auditSummaryValueLogRewritePlan struct {
+	SegmentsTotal      int      `json:"segments_total"`
+	SegmentsSelected   int      `json:"segments_selected"`
+	BytesTotal         int64    `json:"bytes_total"`
+	BytesLive          int64    `json:"bytes_live"`
+	BytesStale         int64    `json:"bytes_stale"`
+	SelectedBytesTotal int64    `json:"selected_bytes_total"`
+	SelectedBytesLive  int64    `json:"selected_bytes_live"`
+	SelectedBytesStale int64    `json:"selected_bytes_stale"`
+	AgeBlockedSegments int      `json:"age_blocked_segments"`
+	AgeBlockedBytes    int64    `json:"age_blocked_bytes"`
+	SourceFileIDs      []uint32 `json:"source_file_ids,omitempty"`
+}
+
+type auditSummaryValueLogGC struct {
+	SegmentsTotal      int   `json:"segments_total"`
+	SegmentsReferenced int   `json:"segments_referenced"`
+	SegmentsActive     int   `json:"segments_active"`
+	SegmentsProtected  int   `json:"segments_protected"`
+	SegmentsEligible   int   `json:"segments_eligible"`
+	BytesTotal         int64 `json:"bytes_total"`
+	BytesReferenced    int64 `json:"bytes_referenced"`
+	BytesActive        int64 `json:"bytes_active"`
+	BytesProtected     int64 `json:"bytes_protected"`
+	BytesEligible      int64 `json:"bytes_eligible"`
+}
+
+type auditSummaryLeafGeneration struct {
+	Admission                       string                          `json:"admission"`
+	CurrentCommitSeq                uint64                          `json:"current_commit_seq"`
+	CurrentGenerationID             uint64                          `json:"current_generation_id"`
+	GenerationsTotal                int                             `json:"generations_total"`
+	Candidates                      int                             `json:"candidates"`
+	CandidateBytesTotal             int64                           `json:"candidate_bytes_total"`
+	CandidateBytesLive              int64                           `json:"candidate_bytes_live"`
+	CandidateBytesDead              int64                           `json:"candidate_bytes_dead"`
+	CandidateBytesToCopy            int64                           `json:"candidate_bytes_to_copy"`
+	ExpectedReclaimBytes            int64                           `json:"expected_reclaim_bytes"`
+	ExpectedReclaimRatioPPM         int                             `json:"expected_reclaim_ratio_ppm"`
+	ExpectedReclaimPerByteCopiedPPM int                             `json:"expected_reclaim_per_byte_copied_ppm"`
+	CompactSelectedGenerations      int                             `json:"compact_selected_generations"`
+	CompactSelectedReclaimBytes     int64                           `json:"compact_selected_reclaim_bytes"`
+	GCDryRun                        auditSummaryLeafGenerationGC    `json:"gc_dry_run"`
+	TopGenerationsByDeadBytes       []auditSummaryLeafGenerationRow `json:"top_generations_by_dead_bytes,omitempty"`
+}
+
+type auditSummaryLeafGenerationGC struct {
+	GenerationsTotal    int   `json:"generations_total"`
+	GenerationsWritable int   `json:"generations_writable"`
+	GenerationsLive     int   `json:"generations_live"`
+	GenerationsRetiring int   `json:"generations_retiring"`
+	GenerationsEligible int   `json:"generations_eligible"`
+	BytesEligible       int64 `json:"bytes_eligible"`
+}
+
+type auditSummaryLeafGenerationRow struct {
+	GenerationID              uint64 `json:"generation_id"`
+	State                     string `json:"state"`
+	FileCount                 int    `json:"file_count"`
+	BytesTotal                int64  `json:"bytes_total"`
+	BytesLive                 int64  `json:"bytes_live"`
+	BytesDead                 int64  `json:"bytes_dead"`
+	BytesToCopy               int64  `json:"bytes_to_copy"`
+	LivePages                 int    `json:"live_pages"`
+	AgeCommits                uint64 `json:"age_commits"`
+	PinnedCount               uint64 `json:"pinned_count"`
+	DeadRatioPPM              int    `json:"dead_ratio_ppm"`
+	LiveRatioPPM              int    `json:"live_ratio_ppm"`
+	WholeGenerationGCEligible bool   `json:"whole_generation_gc_eligible"`
+	Eligible                  bool   `json:"eligible"`
+	SkipReason                string `json:"skip_reason,omitempty"`
+}
+
+type auditSummaryLogFamily struct {
+	Name                string                   `json:"name"`
+	Path                string                   `json:"path"`
+	Exists              bool                     `json:"exists"`
+	Segments            int                      `json:"segments"`
+	Bytes               int64                    `json:"bytes"`
+	ZeroByteSegments    int                      `json:"zero_byte_segments"`
+	LargestSegmentBytes int64                    `json:"largest_segment_bytes"`
+	TopSegmentsByBytes  []auditSummarySegment    `json:"top_segments_by_bytes,omitempty"`
+	FrameScan           *auditSummaryFrameScan   `json:"frame_scan,omitempty"`
+	GzipSamples         []auditSummaryGzipSample `json:"gzip_samples,omitempty"`
+}
+
+type auditSummarySegment struct {
+	Name  string `json:"name"`
+	Path  string `json:"path"`
+	Bytes int64  `json:"bytes"`
+}
+
+type auditSummaryFrameScan struct {
+	RecordsTotal               int64                   `json:"records_total"`
+	UngroupedRecords           int64                   `json:"ungrouped_records"`
+	UngroupedBytes             int64                   `json:"ungrouped_bytes"`
+	GroupedFrames              int64                   `json:"grouped_frames"`
+	GroupedSubrecords          int64                   `json:"grouped_subrecords"`
+	GroupedRawPayloadBytes     int64                   `json:"grouped_raw_payload_bytes"`
+	GroupedStoredPayloadBytes  int64                   `json:"grouped_stored_payload_bytes"`
+	RawPayloadBytes            int64                   `json:"raw_payload_bytes"`
+	StoredPayloadBytes         int64                   `json:"stored_payload_bytes"`
+	StoredRawRatio             float64                 `json:"stored_raw_ratio"`
+	GroupedStoredRawRatio      float64                 `json:"grouped_stored_raw_ratio"`
+	PageLike4096Records        int64                   `json:"page_like_4096_records"`
+	PageLike4096Bytes          int64                   `json:"page_like_4096_bytes"`
+	PageLike4096StoredBytes    int64                   `json:"page_like_4096_stored_bytes"`
+	PageLike4096StoredRawRatio float64                 `json:"page_like_4096_stored_raw_ratio"`
+	Large40To48KRecords        int64                   `json:"large_40_to_48k_records"`
+	Large40To48KBytes          int64                   `json:"large_40_to_48k_bytes"`
+	Large40To48KStoredBytes    int64                   `json:"large_40_to_48k_stored_bytes"`
+	Large40To48KStoredRawRatio float64                 `json:"large_40_to_48k_stored_raw_ratio"`
+	TruncatedSegments          int                     `json:"truncated_segments,omitempty"`
+	Modes                      []auditSummaryFrameMode `json:"modes,omitempty"`
+	TopRecordLengthsByBytes    []auditSummaryRecordLen `json:"top_record_lengths_by_bytes,omitempty"`
+}
+
+type auditSummaryFrameMode struct {
+	Mode               string  `json:"mode"`
+	Frames             int64   `json:"frames"`
+	Subrecords         int64   `json:"subrecords"`
+	RawPayloadBytes    int64   `json:"raw_payload_bytes"`
+	StoredPayloadBytes int64   `json:"stored_payload_bytes"`
+	StoredRawRatio     float64 `json:"stored_raw_ratio"`
+}
+
+type auditSummaryRecordLen struct {
+	Length         int     `json:"length"`
+	Records        int64   `json:"records"`
+	Bytes          int64   `json:"bytes"`
+	StoredBytes    int64   `json:"stored_bytes"`
+	StoredRawRatio float64 `json:"stored_raw_ratio"`
+}
+
+type auditSummaryGzipSample struct {
+	Sample     string  `json:"sample"`
+	Name       string  `json:"name"`
+	Path       string  `json:"path"`
+	FileBytes  int64   `json:"file_bytes"`
+	InputBytes int64   `json:"input_bytes"`
+	GzipBytes  int64   `json:"gzip_bytes"`
+	GzipRatio  float64 `json:"gzip_ratio"`
+	Truncated  bool    `json:"truncated,omitempty"`
+}
+
+func runAuditSummary(dir string, args []string) {
+	fs := flag.NewFlagSet("audit-summary", flag.ExitOnError)
+	jsonOut := fs.Bool("json", false, "Emit machine-readable JSON instead of Markdown")
+	mode := fs.String("mode", "full", "Compaction plan mode: full|quick|exhaustive")
+	frameStats := fs.Bool("frame-stats", false, "Scan value_vlog and leaf_vlog records and report frame compression stats")
+	frameTopLengths := fs.Int("frame-top-lengths", 12, "Number of top record lengths to include when -frame-stats is set")
+	topSegments := fs.Int("top-segments", 12, "Number of largest segments to include per log family (0=none)")
+	topGenerations := fs.Int("top-generations", 12, "Number of leaf generations by dead bytes to include (0=none)")
+	gzipSamples := fs.Int("gzip-samples", 0, "Number of deterministic gzip sample files per log family (0=disabled; first,last,largest,then next-largest)")
+	gzipSampleMaxBytes := fs.Int64("gzip-sample-max-bytes", 0, "Maximum bytes to gzip from each sample file (0=entire file)")
+	_ = fs.Parse(args)
+
+	if *frameTopLengths < 0 {
+		fatalf("audit-summary -frame-top-lengths must be >= 0")
+	}
+	if *topSegments < 0 {
+		fatalf("audit-summary -top-segments must be >= 0")
+	}
+	if *topGenerations < 0 {
+		fatalf("audit-summary -top-generations must be >= 0")
+	}
+	if *gzipSamples < 0 {
+		fatalf("audit-summary -gzip-samples must be >= 0")
+	}
+	if *gzipSampleMaxBytes < 0 {
+		fatalf("audit-summary -gzip-sample-max-bytes must be >= 0")
+	}
+
+	report, err := collectAuditSummary(dir, auditSummaryCollectOptions{
+		CompactMode:        parseCompactStorageModeFlag("audit-summary", *mode),
+		FrameStats:         *frameStats,
+		FrameTopLengths:    *frameTopLengths,
+		TopSegments:        *topSegments,
+		TopGenerations:     *topGenerations,
+		GzipSamples:        *gzipSamples,
+		GzipSampleMaxBytes: *gzipSampleMaxBytes,
+	})
+	if err != nil {
+		fatalf("Audit summary error: %v", err)
+	}
+
+	if *jsonOut {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(report); err != nil {
+			fatalf("json encode: %v", err)
+		}
+		return
+	}
+	fmt.Print(renderAuditSummaryMarkdown(report))
+}
+
+func collectAuditSummary(dir string, opts auditSummaryCollectOptions) (auditSummaryReport, error) {
+	cleanDir := filepath.Clean(dir)
+	mainDir, err := resolveTreemapMainDir(cleanDir)
+	if err != nil {
+		return auditSummaryReport{}, err
+	}
+	rootDir := resolveTreemapRootDir(cleanDir, mainDir)
+	if opts.CompactMode == "" {
+		opts.CompactMode = treedbdb.CompactStorageFull
+	}
+	if opts.FrameTopLengths <= 0 {
+		opts.FrameTopLengths = 10
+	}
+
+	report := auditSummaryReport{
+		SchemaVersion: auditSummarySchemaVersion,
+		Command:       "treemap audit-summary",
+		Dir:           cleanDir,
+		RootDir:       rootDir,
+		MainDir:       mainDir,
+		Options: auditSummaryReportOptions{
+			CompactMode:        string(opts.CompactMode),
+			FrameStats:         opts.FrameStats,
+			FrameTopLengths:    opts.FrameTopLengths,
+			TopSegments:        opts.TopSegments,
+			TopGenerations:     opts.TopGenerations,
+			GzipSamples:        opts.GzipSamples,
+			GzipSampleMaxBytes: opts.GzipSampleMaxBytes,
+		},
+	}
+
+	report.Storage, err = collectAuditSummaryStorage(cleanDir, rootDir, mainDir)
+	if err != nil {
+		return report, err
+	}
+
+	backend, cleanup, err := treedb.OpenBackend(treedb.Options{Dir: rootDir, ReadOnly: true})
+	if err != nil {
+		return report, err
+	}
+	defer cleanup()
+
+	compactStats, err := backend.CompactStoragePlan(context.Background(), treedbdb.CompactStorageOptions{Mode: opts.CompactMode})
+	if err != nil {
+		return report, err
+	}
+	report.CompactPlan = summarizeAuditCompactPlan(compactStats)
+	report.ValueLog = summarizeAuditValueLog(compactStats.ValueLogRewritePlan, compactStats.ValueLogGC)
+	report.LeafGeneration = summarizeAuditLeafGeneration(compactStats.LeafGenerationPlan, compactStats.LeafGenerationGC, compactStats.RemainingDebt, opts.TopGenerations)
+
+	valueFamily, err := collectAuditSummaryLogFamily("value_vlog", treedbdb.ValueLogDirPath(mainDir), opts)
+	if err != nil {
+		return report, err
+	}
+	leafFamily, err := collectAuditSummaryLogFamily("leaf_vlog", treedbdb.LeafLogDirPath(mainDir), opts)
+	if err != nil {
+		return report, err
+	}
+	report.LogFamilies = []auditSummaryLogFamily{valueFamily, leafFamily}
+
+	return report, nil
+}
+
+func collectAuditSummaryStorage(inputDir, rootDir, mainDir string) (auditSummaryStorage, error) {
+	domainPaths := []struct {
+		name string
+		path string
+	}{
+		{name: "input", path: inputDir},
+		{name: "root", path: rootDir},
+		{name: "ancient", path: filepath.Join(rootDir, "ancient")},
+		{name: "maindb", path: mainDir},
+		{name: "index_db", path: filepath.Join(mainDir, "index.db")},
+		{name: "value_vlog", path: treedbdb.ValueLogDirPath(mainDir)},
+		{name: "leaf_vlog", path: treedbdb.LeafLogDirPath(mainDir)},
+		{name: "dictdb", path: filepath.Join(rootDir, "dictdb")},
+		{name: "wal", path: filepath.Join(mainDir, "wal")},
+	}
+	out := auditSummaryStorage{Domains: make([]auditSummaryStorageDomain, 0, len(domainPaths))}
+	for _, domain := range domainPaths {
+		usage, err := auditPathUsage(domain.name, domain.path)
+		if err != nil {
+			return out, err
+		}
+		out.Domains = append(out.Domains, usage)
+	}
+	return out, nil
+}
+
+func auditPathUsage(name, path string) (auditSummaryStorageDomain, error) {
+	out := auditSummaryStorageDomain{Name: name, Path: path}
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return out, nil
+		}
+		return out, err
+	}
+	out.Exists = true
+	if !info.IsDir() {
+		out.Files = 1
+		out.Bytes = info.Size()
+		if info.Size() == 0 {
+			out.ZeroByteFiles = 1
+		}
+		return out, nil
+	}
+	err = filepath.WalkDir(path, func(p string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		if !info.Mode().IsRegular() {
+			return nil
+		}
+		out.Files++
+		out.Bytes += info.Size()
+		if info.Size() == 0 {
+			out.ZeroByteFiles++
+		}
+		return nil
+	})
+	return out, err
+}
+
+func collectAuditSummaryLogFamily(name, dir string, opts auditSummaryCollectOptions) (auditSummaryLogFamily, error) {
+	family := auditSummaryLogFamily{Name: name, Path: dir}
+	if info, err := os.Stat(dir); err == nil && info.IsDir() {
+		family.Exists = true
+	} else if err != nil && !os.IsNotExist(err) {
+		return family, err
+	}
+
+	segments, bytesOnDisk, err := listValueLogSegments(dir)
+	if err != nil {
+		return family, err
+	}
+	family.Segments = len(segments)
+	family.Bytes = bytesOnDisk
+	for _, seg := range segments {
+		if seg.Bytes == 0 {
+			family.ZeroByteSegments++
+		}
+		if seg.Bytes > family.LargestSegmentBytes {
+			family.LargestSegmentBytes = seg.Bytes
+		}
+	}
+	family.TopSegmentsByBytes = summarizeAuditTopSegments(segments, opts.TopSegments)
+
+	if opts.FrameStats && len(segments) > 0 {
+		frameScan, err := scanValueLogFrames(segments, valueLogFrameScanAuditOptions{Enabled: true, TopLengths: opts.FrameTopLengths})
+		if err != nil {
+			return family, err
+		}
+		family.FrameScan = summarizeAuditFrameScan(frameScan)
+	}
+	if opts.GzipSamples > 0 && len(segments) > 0 {
+		samples, err := gzipAuditSamples(segments, opts.GzipSamples, opts.GzipSampleMaxBytes)
+		if err != nil {
+			return family, err
+		}
+		family.GzipSamples = samples
+	}
+	return family, nil
+}
+
+func summarizeAuditCompactPlan(stats treedbdb.CompactStorageStats) auditSummaryCompactPlan {
+	return auditSummaryCompactPlan{
+		Mode:                 string(stats.Mode),
+		DryRun:               stats.DryRun,
+		FullyCompacted:       stats.FullyCompacted,
+		PolicyFullyCompacted: stats.PolicyFullyCompacted,
+		ByteMinimized:        stats.ByteMinimized,
+		StorageBefore:        summarizeCompactUsages(stats.Before),
+		StorageAfter:         summarizeCompactUsages(stats.After),
+		RemainingDebt:        summarizeAuditDebt(stats.RemainingDebt),
+	}
+}
+
+func summarizeCompactUsages(usages []treedbdb.CompactStorageUsage) []auditSummaryStorageDomain {
+	out := make([]auditSummaryStorageDomain, 0, len(usages))
+	for _, usage := range usages {
+		out = append(out, auditSummaryStorageDomain{
+			Name:          usage.Name,
+			Path:          usage.Path,
+			Exists:        true,
+			Bytes:         usage.Bytes,
+			Files:         usage.Files,
+			ZeroByteFiles: usage.ZeroByteFiles,
+		})
+	}
+	return out
+}
+
+func summarizeAuditDebt(debt treedbdb.CompactStorageDebt) auditSummaryDebt {
+	return auditSummaryDebt{
+		ValueLogRewriteSegments: debt.ValueLogRewriteSegments,
+		ValueLogRewriteBytes:    debt.ValueLogRewriteBytes,
+		ValueLogGCSegments:      debt.ValueLogGCSegments,
+		ValueLogGCBytes:         debt.ValueLogGCBytes,
+		LeafPackGenerations:     debt.LeafPackGenerations,
+		LeafPackBytes:           debt.LeafPackBytes,
+		LeafGCGenerations:       debt.LeafGCGenerations,
+		LeafGCBytes:             debt.LeafGCBytes,
+		ZeroByteValueLogFiles:   debt.ZeroByteValueLogFiles,
+	}
+}
+
+func summarizeAuditValueLog(plan treedbdb.ValueLogRewritePlan, gc treedbdb.ValueLogGCStats) auditSummaryValueLog {
+	ids := append([]uint32(nil), plan.SourceFileIDs...)
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+	return auditSummaryValueLog{
+		RewritePlan: auditSummaryValueLogRewritePlan{
+			SegmentsTotal:      plan.SegmentsTotal,
+			SegmentsSelected:   plan.SegmentsSelected,
+			BytesTotal:         plan.BytesTotal,
+			BytesLive:          plan.BytesLive,
+			BytesStale:         plan.BytesStale,
+			SelectedBytesTotal: plan.SelectedBytesTotal,
+			SelectedBytesLive:  plan.SelectedBytesLive,
+			SelectedBytesStale: plan.SelectedBytesStale,
+			AgeBlockedSegments: plan.AgeBlockedSegments,
+			AgeBlockedBytes:    plan.AgeBlockedBytesTotal,
+			SourceFileIDs:      ids,
+		},
+		GCDryRun: auditSummaryValueLogGC{
+			SegmentsTotal:      gc.SegmentsTotal,
+			SegmentsReferenced: gc.SegmentsReferenced,
+			SegmentsActive:     gc.SegmentsActive,
+			SegmentsProtected:  gc.SegmentsProtected,
+			SegmentsEligible:   gc.SegmentsEligible,
+			BytesTotal:         gc.BytesTotal,
+			BytesReferenced:    gc.BytesReferenced,
+			BytesActive:        gc.BytesActive,
+			BytesProtected:     gc.BytesProtected,
+			BytesEligible:      gc.BytesEligible,
+		},
+	}
+}
+
+func summarizeAuditLeafGeneration(plan treedbdb.LeafGenerationPlan, gc treedbdb.LeafGenerationGCStats, debt treedbdb.CompactStorageDebt, topN int) auditSummaryLeafGeneration {
+	return auditSummaryLeafGeneration{
+		Admission:                       plan.Admission,
+		CurrentCommitSeq:                plan.CurrentCommitSeq,
+		CurrentGenerationID:             plan.CurrentGenerationID,
+		GenerationsTotal:                len(plan.Generations),
+		Candidates:                      len(plan.Candidates),
+		CandidateBytesTotal:             plan.CandidateBytesTotal,
+		CandidateBytesLive:              plan.CandidateBytesLive,
+		CandidateBytesDead:              plan.CandidateBytesDead,
+		CandidateBytesToCopy:            plan.CandidateBytesToCopy,
+		ExpectedReclaimBytes:            plan.ExpectedReclaimBytes,
+		ExpectedReclaimRatioPPM:         plan.ExpectedReclaimRatioPPM,
+		ExpectedReclaimPerByteCopiedPPM: plan.ExpectedReclaimPerByteCopiedPPM,
+		CompactSelectedGenerations:      debt.LeafPackGenerations,
+		CompactSelectedReclaimBytes:     debt.LeafPackBytes,
+		GCDryRun: auditSummaryLeafGenerationGC{
+			GenerationsTotal:    gc.GenerationsTotal,
+			GenerationsWritable: gc.GenerationsWritable,
+			GenerationsLive:     gc.GenerationsLive,
+			GenerationsRetiring: gc.GenerationsRetiring,
+			GenerationsEligible: gc.GenerationsEligible,
+			BytesEligible:       gc.BytesEligible,
+		},
+		TopGenerationsByDeadBytes: summarizeAuditLeafGenerations(plan.Generations, topN),
+	}
+}
+
+func summarizeAuditLeafGenerations(generations []treedbdb.LeafGenerationPlanGeneration, topN int) []auditSummaryLeafGenerationRow {
+	if topN <= 0 || len(generations) == 0 {
+		return nil
+	}
+	ordered := append([]treedbdb.LeafGenerationPlanGeneration(nil), generations...)
+	sort.Slice(ordered, func(i, j int) bool {
+		if ordered[i].BytesDead == ordered[j].BytesDead {
+			return ordered[i].GenerationID < ordered[j].GenerationID
+		}
+		return ordered[i].BytesDead > ordered[j].BytesDead
+	})
+	if len(ordered) > topN {
+		ordered = ordered[:topN]
+	}
+	out := make([]auditSummaryLeafGenerationRow, 0, len(ordered))
+	for _, gen := range ordered {
+		out = append(out, auditSummaryLeafGenerationRow{
+			GenerationID:              gen.GenerationID,
+			State:                     gen.State,
+			FileCount:                 gen.FileCount,
+			BytesTotal:                gen.BytesTotal,
+			BytesLive:                 gen.BytesLive,
+			BytesDead:                 gen.BytesDead,
+			BytesToCopy:               gen.BytesToCopy,
+			LivePages:                 gen.LivePages,
+			AgeCommits:                gen.AgeCommits,
+			PinnedCount:               gen.PinnedCount,
+			DeadRatioPPM:              gen.DeadRatioPPM,
+			LiveRatioPPM:              gen.LiveRatioPPM,
+			WholeGenerationGCEligible: gen.WholeGenerationGCEligible,
+			Eligible:                  gen.Eligible,
+			SkipReason:                gen.SkipReason,
+		})
+	}
+	return out
+}
+
+func summarizeAuditTopSegments(segments []valueLogSegmentAudit, topN int) []auditSummarySegment {
+	if topN <= 0 || len(segments) == 0 {
+		return nil
+	}
+	ordered := append([]valueLogSegmentAudit(nil), segments...)
+	sort.Slice(ordered, func(i, j int) bool {
+		if ordered[i].Bytes == ordered[j].Bytes {
+			return ordered[i].Path < ordered[j].Path
+		}
+		return ordered[i].Bytes > ordered[j].Bytes
+	})
+	if len(ordered) > topN {
+		ordered = ordered[:topN]
+	}
+	out := make([]auditSummarySegment, 0, len(ordered))
+	for _, seg := range ordered {
+		out = append(out, auditSummarySegment{Name: seg.Name, Path: seg.Path, Bytes: seg.Bytes})
+	}
+	return out
+}
+
+func summarizeAuditFrameScan(scan *valueLogFrameScanAudit) *auditSummaryFrameScan {
+	if scan == nil {
+		return nil
+	}
+	rawTotal := scan.UngroupedBytes + scan.GroupedRawPayloadBytes
+	storedTotal := scan.UngroupedBytes + scan.GroupedStoredPayload
+	out := &auditSummaryFrameScan{
+		RecordsTotal:               scan.RecordsTotal,
+		UngroupedRecords:           scan.UngroupedRecords,
+		UngroupedBytes:             scan.UngroupedBytes,
+		GroupedFrames:              scan.GroupedFrames,
+		GroupedSubrecords:          scan.GroupedSubrecords,
+		GroupedRawPayloadBytes:     scan.GroupedRawPayloadBytes,
+		GroupedStoredPayloadBytes:  scan.GroupedStoredPayload,
+		RawPayloadBytes:            rawTotal,
+		StoredPayloadBytes:         storedTotal,
+		StoredRawRatio:             floatRatio(storedTotal, rawTotal),
+		GroupedStoredRawRatio:      floatRatio(scan.GroupedStoredPayload, scan.GroupedRawPayloadBytes),
+		PageLike4096Records:        scan.PageLike4096Records,
+		PageLike4096Bytes:          scan.PageLike4096Bytes,
+		PageLike4096StoredBytes:    scan.PageLike4096StoredBytes,
+		PageLike4096StoredRawRatio: floatRatio(scan.PageLike4096StoredBytes, scan.PageLike4096Bytes),
+		Large40To48KRecords:        scan.Large40To48KRecords,
+		Large40To48KBytes:          scan.Large40To48KBytes,
+		Large40To48KStoredBytes:    scan.Large40To48KStoredBytes,
+		Large40To48KStoredRawRatio: floatRatio(scan.Large40To48KStoredBytes, scan.Large40To48KBytes),
+		TruncatedSegments:          scan.TruncatedSegments,
+	}
+	if len(scan.Modes) > 0 {
+		keys := make([]string, 0, len(scan.Modes))
+		for key := range scan.Modes {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		out.Modes = make([]auditSummaryFrameMode, 0, len(keys))
+		for _, key := range keys {
+			mode := scan.Modes[key]
+			out.Modes = append(out.Modes, auditSummaryFrameMode{
+				Mode:               key,
+				Frames:             mode.Frames,
+				Subrecords:         mode.Subrecords,
+				RawPayloadBytes:    mode.RawPayloadBytes,
+				StoredPayloadBytes: mode.StoredPayloadBytes,
+				StoredRawRatio:     floatRatio(mode.StoredPayloadBytes, mode.RawPayloadBytes),
+			})
+		}
+	}
+	for _, row := range scan.TopRecordLengthsByBytes {
+		out.TopRecordLengthsByBytes = append(out.TopRecordLengthsByBytes, auditSummaryRecordLen{
+			Length:         row.Length,
+			Records:        row.Records,
+			Bytes:          row.Bytes,
+			StoredBytes:    row.StoredBytes,
+			StoredRawRatio: floatRatio(row.StoredBytes, row.Bytes),
+		})
+	}
+	return out
+}
+
+type gzipSampleCandidate struct {
+	seg   valueLogSegmentAudit
+	roles []string
+}
+
+func gzipAuditSamples(segments []valueLogSegmentAudit, sampleCount int, maxBytes int64) ([]auditSummaryGzipSample, error) {
+	candidates := selectGzipSampleCandidates(segments, sampleCount)
+	out := make([]auditSummaryGzipSample, 0, len(candidates))
+	for _, candidate := range candidates {
+		inputBytes, gzipBytes, err := gzipFilePrefix(candidate.seg.Path, maxBytes)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, auditSummaryGzipSample{
+			Sample:     strings.Join(candidate.roles, "+"),
+			Name:       candidate.seg.Name,
+			Path:       candidate.seg.Path,
+			FileBytes:  candidate.seg.Bytes,
+			InputBytes: inputBytes,
+			GzipBytes:  gzipBytes,
+			GzipRatio:  floatRatio(gzipBytes, inputBytes),
+			Truncated:  maxBytes > 0 && inputBytes < candidate.seg.Bytes,
+		})
+	}
+	return out, nil
+}
+
+func selectGzipSampleCandidates(segments []valueLogSegmentAudit, sampleCount int) []gzipSampleCandidate {
+	if sampleCount <= 0 || len(segments) == 0 {
+		return nil
+	}
+	byName := append([]valueLogSegmentAudit(nil), segments...)
+	sort.Slice(byName, func(i, j int) bool {
+		if byName[i].Name == byName[j].Name {
+			return byName[i].Path < byName[j].Path
+		}
+		return byName[i].Name < byName[j].Name
+	})
+	bySize := append([]valueLogSegmentAudit(nil), segments...)
+	sort.Slice(bySize, func(i, j int) bool {
+		if bySize[i].Bytes == bySize[j].Bytes {
+			if bySize[i].Name == bySize[j].Name {
+				return bySize[i].Path < bySize[j].Path
+			}
+			return bySize[i].Name < bySize[j].Name
+		}
+		return bySize[i].Bytes > bySize[j].Bytes
+	})
+
+	selected := make([]gzipSampleCandidate, 0, sampleCount)
+	byPath := make(map[string]int)
+	add := func(role string, seg valueLogSegmentAudit) {
+		if idx, ok := byPath[seg.Path]; ok {
+			if !stringSliceContains(selected[idx].roles, role) {
+				selected[idx].roles = append(selected[idx].roles, role)
+			}
+			return
+		}
+		if len(selected) >= sampleCount {
+			return
+		}
+		byPath[seg.Path] = len(selected)
+		selected = append(selected, gzipSampleCandidate{seg: seg, roles: []string{role}})
+	}
+	add("first", byName[0])
+	add("last", byName[len(byName)-1])
+	add("largest", bySize[0])
+	for i := 1; len(selected) < sampleCount && i < len(bySize); i++ {
+		add(fmt.Sprintf("largest_%d", i+1), bySize[i])
+	}
+	return selected
+}
+
+func gzipFilePrefix(path string, maxBytes int64) (int64, int64, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return 0, 0, err
+	}
+	defer f.Close()
+
+	var counter countingWriter
+	zw := gzip.NewWriter(&counter)
+	var reader io.Reader = f
+	if maxBytes > 0 {
+		reader = &io.LimitedReader{R: f, N: maxBytes}
+	}
+	inputBytes, copyErr := io.Copy(zw, reader)
+	closeErr := zw.Close()
+	if copyErr != nil {
+		return 0, 0, copyErr
+	}
+	if closeErr != nil {
+		return 0, 0, closeErr
+	}
+	return inputBytes, counter.N, nil
+}
+
+type countingWriter struct {
+	N int64
+}
+
+func (w *countingWriter) Write(p []byte) (int, error) {
+	w.N += int64(len(p))
+	return len(p), nil
+}
+
+func stringSliceContains(values []string, needle string) bool {
+	for _, value := range values {
+		if value == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func renderAuditSummaryMarkdown(report auditSummaryReport) string {
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "# TreeDB audit summary\n\n")
+	fmt.Fprintf(&buf, "- command: `%s`\n", report.Command)
+	fmt.Fprintf(&buf, "- dir: `%s`\n", report.Dir)
+	fmt.Fprintf(&buf, "- root_dir: `%s`\n", report.RootDir)
+	fmt.Fprintf(&buf, "- main_dir: `%s`\n", report.MainDir)
+	fmt.Fprintf(&buf, "- compact_mode: `%s`\n", report.Options.CompactMode)
+	fmt.Fprintf(&buf, "- frame_stats: `%t`\n", report.Options.FrameStats)
+	fmt.Fprintf(&buf, "- gzip_samples_per_family: `%d`\n\n", report.Options.GzipSamples)
+
+	fmt.Fprintf(&buf, "## Storage breakdown\n\n")
+	fmt.Fprintf(&buf, "| domain | exists | bytes | files | zero-byte files | path |\n")
+	fmt.Fprintf(&buf, "| --- | ---: | ---: | ---: | ---: | --- |\n")
+	for _, domain := range report.Storage.Domains {
+		fmt.Fprintf(&buf, "| `%s` | %t | %d | %d | %d | `%s` |\n",
+			markdownCell(domain.Name), domain.Exists, domain.Bytes, domain.Files, domain.ZeroByteFiles, markdownCell(domain.Path))
+	}
+	fmt.Fprintf(&buf, "\n")
+
+	debt := report.CompactPlan.RemainingDebt
+	fmt.Fprintf(&buf, "## Compact plan / current debt\n\n")
+	fmt.Fprintf(&buf, "| metric | value |\n| --- | ---: |\n")
+	fmt.Fprintf(&buf, "| dry_run | %t |\n", report.CompactPlan.DryRun)
+	fmt.Fprintf(&buf, "| fully_compacted | %t |\n", report.CompactPlan.FullyCompacted)
+	fmt.Fprintf(&buf, "| policy_fully_compacted | %t |\n", report.CompactPlan.PolicyFullyCompacted)
+	fmt.Fprintf(&buf, "| byte_minimized | %t |\n", report.CompactPlan.ByteMinimized)
+	fmt.Fprintf(&buf, "| value_log_rewrite_segments | %d |\n", debt.ValueLogRewriteSegments)
+	fmt.Fprintf(&buf, "| value_log_rewrite_bytes | %d |\n", debt.ValueLogRewriteBytes)
+	fmt.Fprintf(&buf, "| value_log_gc_segments | %d |\n", debt.ValueLogGCSegments)
+	fmt.Fprintf(&buf, "| value_log_gc_bytes | %d |\n", debt.ValueLogGCBytes)
+	fmt.Fprintf(&buf, "| leaf_pack_generations | %d |\n", debt.LeafPackGenerations)
+	fmt.Fprintf(&buf, "| leaf_pack_bytes | %d |\n", debt.LeafPackBytes)
+	fmt.Fprintf(&buf, "| leaf_gc_generations | %d |\n", debt.LeafGCGenerations)
+	fmt.Fprintf(&buf, "| leaf_gc_bytes | %d |\n", debt.LeafGCBytes)
+	fmt.Fprintf(&buf, "| zero_byte_value_log_files | %d |\n\n", debt.ZeroByteValueLogFiles)
+
+	fmt.Fprintf(&buf, "## Value-log audit summary\n\n")
+	rewrite := report.ValueLog.RewritePlan
+	gc := report.ValueLog.GCDryRun
+	fmt.Fprintf(&buf, "| metric | value |\n| --- | ---: |\n")
+	fmt.Fprintf(&buf, "| rewrite_segments_total | %d |\n", rewrite.SegmentsTotal)
+	fmt.Fprintf(&buf, "| rewrite_segments_selected | %d |\n", rewrite.SegmentsSelected)
+	fmt.Fprintf(&buf, "| rewrite_bytes_total | %d |\n", rewrite.BytesTotal)
+	fmt.Fprintf(&buf, "| rewrite_bytes_live | %d |\n", rewrite.BytesLive)
+	fmt.Fprintf(&buf, "| rewrite_bytes_stale | %d |\n", rewrite.BytesStale)
+	fmt.Fprintf(&buf, "| rewrite_selected_bytes_stale | %d |\n", rewrite.SelectedBytesStale)
+	fmt.Fprintf(&buf, "| gc_segments_total | %d |\n", gc.SegmentsTotal)
+	fmt.Fprintf(&buf, "| gc_segments_eligible | %d |\n", gc.SegmentsEligible)
+	fmt.Fprintf(&buf, "| gc_bytes_total | %d |\n", gc.BytesTotal)
+	fmt.Fprintf(&buf, "| gc_bytes_eligible | %d |\n\n", gc.BytesEligible)
+
+	leaf := report.LeafGeneration
+	fmt.Fprintf(&buf, "## Leaf-generation audit summary\n\n")
+	fmt.Fprintf(&buf, "| metric | value |\n| --- | ---: |\n")
+	fmt.Fprintf(&buf, "| admission | %s |\n", markdownCell(leaf.Admission))
+	fmt.Fprintf(&buf, "| generations_total | %d |\n", leaf.GenerationsTotal)
+	fmt.Fprintf(&buf, "| candidates | %d |\n", leaf.Candidates)
+	fmt.Fprintf(&buf, "| candidate_bytes_total | %d |\n", leaf.CandidateBytesTotal)
+	fmt.Fprintf(&buf, "| candidate_bytes_live | %d |\n", leaf.CandidateBytesLive)
+	fmt.Fprintf(&buf, "| candidate_bytes_dead | %d |\n", leaf.CandidateBytesDead)
+	fmt.Fprintf(&buf, "| candidate_bytes_to_copy | %d |\n", leaf.CandidateBytesToCopy)
+	fmt.Fprintf(&buf, "| expected_reclaim_bytes | %d |\n", leaf.ExpectedReclaimBytes)
+	fmt.Fprintf(&buf, "| expected_reclaim_ratio_ppm | %d |\n", leaf.ExpectedReclaimRatioPPM)
+	fmt.Fprintf(&buf, "| compact_selected_generations | %d |\n", leaf.CompactSelectedGenerations)
+	fmt.Fprintf(&buf, "| compact_selected_reclaim_bytes | %d |\n", leaf.CompactSelectedReclaimBytes)
+	fmt.Fprintf(&buf, "| gc_generations_eligible | %d |\n", leaf.GCDryRun.GenerationsEligible)
+	fmt.Fprintf(&buf, "| gc_bytes_eligible | %d |\n\n", leaf.GCDryRun.BytesEligible)
+
+	if len(leaf.TopGenerationsByDeadBytes) > 0 {
+		fmt.Fprintf(&buf, "### Top leaf generations by dead bytes\n\n")
+		fmt.Fprintf(&buf, "| generation | state | files | total bytes | live bytes | dead bytes | to-copy bytes | eligible | gc eligible | skip |\n")
+		fmt.Fprintf(&buf, "| ---: | --- | ---: | ---: | ---: | ---: | ---: | --- | --- | --- |\n")
+		for _, row := range leaf.TopGenerationsByDeadBytes {
+			fmt.Fprintf(&buf, "| %d | `%s` | %d | %d | %d | %d | %d | %t | %t | `%s` |\n",
+				row.GenerationID, markdownCell(row.State), row.FileCount, row.BytesTotal, row.BytesLive, row.BytesDead,
+				row.BytesToCopy, row.Eligible, row.WholeGenerationGCEligible, markdownCell(row.SkipReason))
+		}
+		fmt.Fprintf(&buf, "\n")
+	}
+
+	fmt.Fprintf(&buf, "## Log families\n\n")
+	for _, family := range report.LogFamilies {
+		fmt.Fprintf(&buf, "### `%s`\n\n", markdownCell(family.Name))
+		fmt.Fprintf(&buf, "- path: `%s`\n", markdownCell(family.Path))
+		fmt.Fprintf(&buf, "- exists: `%t`\n", family.Exists)
+		fmt.Fprintf(&buf, "- segments: `%d`\n", family.Segments)
+		fmt.Fprintf(&buf, "- bytes: `%d`\n", family.Bytes)
+		fmt.Fprintf(&buf, "- zero_byte_segments: `%d`\n", family.ZeroByteSegments)
+		fmt.Fprintf(&buf, "- largest_segment_bytes: `%d`\n\n", family.LargestSegmentBytes)
+		if family.FrameScan != nil {
+			fmt.Fprintf(&buf, "Frame scan: records=%d raw_bytes=%d stored_bytes=%d stored/raw=%.6f grouped_frames=%d grouped_subrecords=%d\n\n",
+				family.FrameScan.RecordsTotal, family.FrameScan.RawPayloadBytes, family.FrameScan.StoredPayloadBytes,
+				family.FrameScan.StoredRawRatio, family.FrameScan.GroupedFrames, family.FrameScan.GroupedSubrecords)
+		} else if report.Options.FrameStats {
+			fmt.Fprintf(&buf, "Frame scan: no segments scanned.\n\n")
+		} else {
+			fmt.Fprintf(&buf, "Frame scan: omitted (pass `-frame-stats` to include).\n\n")
+		}
+		if len(family.TopSegmentsByBytes) > 0 {
+			fmt.Fprintf(&buf, "Top segments by bytes:\n\n")
+			fmt.Fprintf(&buf, "| name | bytes | path |\n| --- | ---: | --- |\n")
+			for _, seg := range family.TopSegmentsByBytes {
+				fmt.Fprintf(&buf, "| `%s` | %d | `%s` |\n", markdownCell(seg.Name), seg.Bytes, markdownCell(seg.Path))
+			}
+			fmt.Fprintf(&buf, "\n")
+		}
+		if len(family.GzipSamples) > 0 {
+			fmt.Fprintf(&buf, "Gzip samples:\n\n")
+			fmt.Fprintf(&buf, "| sample | name | file bytes | input bytes | gzip bytes | gzip/input | truncated |\n")
+			fmt.Fprintf(&buf, "| --- | --- | ---: | ---: | ---: | ---: | --- |\n")
+			for _, sample := range family.GzipSamples {
+				fmt.Fprintf(&buf, "| `%s` | `%s` | %d | %d | %d | %.6f | %t |\n",
+					markdownCell(sample.Sample), markdownCell(sample.Name), sample.FileBytes, sample.InputBytes,
+					sample.GzipBytes, sample.GzipRatio, sample.Truncated)
+			}
+			fmt.Fprintf(&buf, "\n")
+		}
+	}
+	return buf.String()
+}
+
+func markdownCell(s string) string {
+	return strings.ReplaceAll(s, "|", "\\|")
+}

--- a/TreeDB/cmd/treemap/audit_summary.go
+++ b/TreeDB/cmd/treemap/audit_summary.go
@@ -483,13 +483,28 @@ func summarizeCompactUsages(usages []treedbdb.CompactStorageUsage) []auditSummar
 		out = append(out, auditSummaryStorageDomain{
 			Name:          usage.Name,
 			Path:          usage.Path,
-			Exists:        true,
+			Exists:        compactUsageExists(usage),
 			Bytes:         usage.Bytes,
 			Files:         usage.Files,
 			ZeroByteFiles: usage.ZeroByteFiles,
 		})
 	}
 	return out
+}
+
+func compactUsageExists(usage treedbdb.CompactStorageUsage) bool {
+	if usage.Bytes != 0 || usage.Files != 0 || usage.ZeroByteFiles != 0 {
+		return true
+	}
+	if strings.TrimSpace(usage.Path) == "" {
+		return false
+	}
+	if _, err := os.Stat(usage.Path); err == nil {
+		return true
+	} else if os.IsNotExist(err) {
+		return false
+	}
+	return true
 }
 
 func summarizeAuditDebt(debt treedbdb.CompactStorageDebt) auditSummaryDebt {
@@ -770,14 +785,15 @@ func gzipFilePrefix(path string, maxBytes int64) (int64, int64, error) {
 		reader = &io.LimitedReader{R: f, N: maxBytes}
 	}
 	inputBytes, copyErr := io.Copy(zw, reader)
-	closeErr := zw.Close()
-	if copyErr != nil {
+	closeErr := zw.Close() // Always close, even when io.Copy fails; copyErr still wins below.
+	switch {
+	case copyErr != nil:
 		return 0, 0, copyErr
-	}
-	if closeErr != nil {
+	case closeErr != nil:
 		return 0, 0, closeErr
+	default:
+		return inputBytes, counter.N, nil
 	}
-	return inputBytes, counter.N, nil
 }
 
 type countingWriter struct {

--- a/TreeDB/cmd/treemap/audit_summary.go
+++ b/TreeDB/cmd/treemap/audit_summary.go
@@ -771,7 +771,7 @@ func selectGzipSampleCandidates(segments []valueLogSegmentAudit, sampleCount int
 	return selected
 }
 
-func gzipFilePrefix(path string, maxBytes int64) (int64, int64, error) {
+func gzipFilePrefix(path string, maxBytes int64) (inputBytes int64, gzipBytes int64, err error) {
 	f, err := os.Open(path)
 	if err != nil {
 		return 0, 0, err
@@ -780,20 +780,29 @@ func gzipFilePrefix(path string, maxBytes int64) (int64, int64, error) {
 
 	var counter countingWriter
 	zw := gzip.NewWriter(&counter)
+	defer func() {
+		closeErr := zw.Close()
+		if err != nil {
+			return
+		}
+		if closeErr != nil {
+			inputBytes = 0
+			gzipBytes = 0
+			err = closeErr
+			return
+		}
+		gzipBytes = counter.N
+	}()
+
 	var reader io.Reader = f
 	if maxBytes > 0 {
 		reader = &io.LimitedReader{R: f, N: maxBytes}
 	}
-	inputBytes, copyErr := io.Copy(zw, reader)
-	closeErr := zw.Close() // Always close, even when io.Copy fails; copyErr still wins below.
-	switch {
-	case copyErr != nil:
-		return 0, 0, copyErr
-	case closeErr != nil:
-		return 0, 0, closeErr
-	default:
-		return inputBytes, counter.N, nil
+	inputBytes, err = io.Copy(zw, reader)
+	if err != nil {
+		return 0, 0, err
 	}
+	return inputBytes, 0, nil
 }
 
 type countingWriter struct {

--- a/TreeDB/cmd/treemap/audit_summary_test.go
+++ b/TreeDB/cmd/treemap/audit_summary_test.go
@@ -1,0 +1,306 @@
+package main
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	treedb "github.com/snissn/gomap/TreeDB"
+)
+
+func TestAuditSummaryUsageExposesReadOnlyCommand(t *testing.T) {
+	if !strings.Contains(usageText, "audit-summary   Summarize storage, compaction debt, log frames, and gzip samples (read-only)") {
+		t.Fatalf("usageText missing audit-summary read-only command: %q", usageText)
+	}
+}
+
+func TestAuditSummaryJSONOutputShape(t *testing.T) {
+	dir := buildAuditSummaryFixture(t)
+
+	out := captureStdout(t, func() {
+		runAuditSummary(dir, []string{
+			"-json",
+			"-frame-stats",
+			"-frame-top-lengths", "4",
+			"-top-segments", "3",
+			"-top-generations", "3",
+			"-gzip-samples", "3",
+			"-gzip-sample-max-bytes", "4096",
+		})
+	})
+
+	var report auditSummaryReport
+	if err := json.Unmarshal([]byte(out), &report); err != nil {
+		t.Fatalf("decode audit-summary json: %v\n%s", err, out)
+	}
+	if report.SchemaVersion != auditSummarySchemaVersion {
+		t.Fatalf("schema_version=%d want %d", report.SchemaVersion, auditSummarySchemaVersion)
+	}
+	if report.Command != "treemap audit-summary" {
+		t.Fatalf("command=%q", report.Command)
+	}
+	if report.Dir != filepath.Clean(dir) || report.RootDir != filepath.Clean(dir) || report.MainDir != filepath.Join(filepath.Clean(dir), "maindb") {
+		t.Fatalf("unexpected dirs: dir=%q root=%q main=%q", report.Dir, report.RootDir, report.MainDir)
+	}
+	if !report.Options.FrameStats || report.Options.GzipSamples != 3 || report.Options.GzipSampleMaxBytes != 4096 {
+		t.Fatalf("unexpected options: %+v", report.Options)
+	}
+	assertAuditStorageDomain(t, report.Storage.Domains, "maindb", true)
+	assertAuditStorageDomain(t, report.Storage.Domains, "index_db", true)
+	assertAuditStorageDomain(t, report.Storage.Domains, "value_vlog", true)
+	assertAuditStorageDomain(t, report.Storage.Domains, "leaf_vlog", true)
+
+	if !report.CompactPlan.DryRun {
+		t.Fatalf("compact plan must be dry-run: %+v", report.CompactPlan)
+	}
+	if report.ValueLog.RewritePlan.SegmentsTotal == 0 {
+		t.Fatalf("expected value-log rewrite plan to see segments: %+v", report.ValueLog.RewritePlan)
+	}
+	if report.ValueLog.GCDryRun.SegmentsTotal == 0 {
+		t.Fatalf("expected value-log GC dry-run to see segments: %+v", report.ValueLog.GCDryRun)
+	}
+	if report.LeafGeneration.GenerationsTotal == 0 {
+		t.Fatalf("expected leaf-generation summary, got %+v", report.LeafGeneration)
+	}
+	if len(report.LogFamilies) != 2 {
+		t.Fatalf("log family count=%d want 2", len(report.LogFamilies))
+	}
+	families := auditFamiliesByName(report.LogFamilies)
+	for _, name := range []string{"value_vlog", "leaf_vlog"} {
+		family := families[name]
+		if family.Name == "" {
+			t.Fatalf("missing log family %q in %+v", name, report.LogFamilies)
+		}
+		if !family.Exists || family.Segments == 0 || family.Bytes == 0 {
+			t.Fatalf("family %s missing segment inventory: %+v", name, family)
+		}
+		if len(family.TopSegmentsByBytes) == 0 || len(family.TopSegmentsByBytes) > 3 {
+			t.Fatalf("family %s top segment shape invalid: %+v", name, family.TopSegmentsByBytes)
+		}
+		if family.FrameScan == nil || family.FrameScan.RecordsTotal == 0 || family.FrameScan.StoredPayloadBytes == 0 {
+			t.Fatalf("family %s frame scan missing: %+v", name, family.FrameScan)
+		}
+		if len(family.GzipSamples) == 0 || len(family.GzipSamples) > 3 {
+			t.Fatalf("family %s gzip sample count invalid: %+v", name, family.GzipSamples)
+		}
+		for _, sample := range family.GzipSamples {
+			if sample.InputBytes == 0 || sample.GzipBytes == 0 || sample.GzipRatio <= 0 {
+				t.Fatalf("family %s invalid gzip sample: %+v", name, sample)
+			}
+			if sample.InputBytes > 4096 {
+				t.Fatalf("family %s gzip sample ignored max bytes: %+v", name, sample)
+			}
+		}
+	}
+}
+
+func TestAuditSummaryMarkdownOutputShape(t *testing.T) {
+	dir := buildAuditSummaryFixture(t)
+
+	out := captureStdout(t, func() {
+		runAuditSummary(dir, []string{
+			"-top-segments", "2",
+			"-top-generations", "2",
+			"-gzip-samples", "1",
+			"-gzip-sample-max-bytes", "1024",
+		})
+	})
+
+	for _, want := range []string{
+		"# TreeDB audit summary",
+		"## Storage breakdown",
+		"## Compact plan / current debt",
+		"## Value-log audit summary",
+		"## Leaf-generation audit summary",
+		"## Log families",
+		"### `value_vlog`",
+		"### `leaf_vlog`",
+		"Frame scan: omitted",
+		"Gzip samples:",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("markdown output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestAuditSummaryReadOnlyDoesNotMutateFiles(t *testing.T) {
+	dir := buildAuditSummaryFixture(t)
+	before := snapshotRegularFiles(t, dir)
+
+	_ = captureStdout(t, func() {
+		runAuditSummary(dir, []string{
+			"-json",
+			"-frame-stats",
+			"-gzip-samples", "2",
+			"-gzip-sample-max-bytes", "2048",
+		})
+	})
+
+	after := snapshotRegularFiles(t, dir)
+	if !reflect.DeepEqual(before, after) {
+		t.Fatalf("audit-summary mutated regular files:\nbefore=%#v\nafter=%#v", before, after)
+	}
+}
+
+func TestGzipAuditSamplesReportsRatiosAndRoles(t *testing.T) {
+	dir := t.TempDir()
+	files := map[string][]byte{
+		"value-l0-000001.log": bytes.Repeat([]byte("a"), 256),
+		"value-l0-000002.log": bytes.Repeat([]byte("b"), 1024),
+		"value-l0-000003.log": bytes.Repeat([]byte("c"), 512),
+	}
+	for name, payload := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), payload, 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+	segments, _, err := listValueLogSegments(dir)
+	if err != nil {
+		t.Fatalf("listValueLogSegments: %v", err)
+	}
+	samples, err := gzipAuditSamples(segments, 3, 128)
+	if err != nil {
+		t.Fatalf("gzipAuditSamples: %v", err)
+	}
+	if len(samples) != 3 {
+		t.Fatalf("samples=%d want 3: %+v", len(samples), samples)
+	}
+	roles := strings.Join([]string{samples[0].Sample, samples[1].Sample, samples[2].Sample}, ",")
+	for _, want := range []string{"first", "last", "largest"} {
+		if !strings.Contains(roles, want) {
+			t.Fatalf("sample roles %q missing %q", roles, want)
+		}
+	}
+	for _, sample := range samples {
+		if sample.InputBytes == 0 || sample.InputBytes > 128 || sample.GzipBytes == 0 || sample.GzipRatio <= 0 {
+			t.Fatalf("invalid gzip sample: %+v", sample)
+		}
+		if sample.FileBytes > 128 && !sample.Truncated {
+			t.Fatalf("expected truncated sample for %+v", sample)
+		}
+	}
+}
+
+func buildAuditSummaryFixture(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	opts := treedb.Options{
+		Dir:                        dir,
+		Durability:                 treedb.DurabilityWALOffRelaxed,
+		IndexOuterLeavesInValueLog: true,
+		ValueLog: treedb.ValueLogOptions{
+			PointerThreshold: 1,
+			ForcePointers:    true,
+		},
+	}
+	opts.BackgroundCheckpointInterval = -1
+	opts.BackgroundCheckpointIdleDuration = -1
+	opts.BackgroundIndexVacuumInterval = -1
+	opts.MaxWALBytes = -1
+
+	db, err := treedb.Open(opts)
+	if err != nil {
+		t.Fatalf("open fixture: %v", err)
+	}
+	for i := 0; i < 768; i++ {
+		key := []byte(fmt.Sprintf("audit-key-%06d", i))
+		val := bytes.Repeat([]byte{byte(i % 251)}, 512)
+		if err := db.Set(key, val); err != nil {
+			_ = db.Close()
+			t.Fatalf("set fixture key %d: %v", i, err)
+		}
+	}
+	if err := db.Checkpoint(); err != nil {
+		_ = db.Close()
+		t.Fatalf("checkpoint fixture: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close fixture: %v", err)
+	}
+	assertLogFamilyHasData(t, filepath.Join(dir, "maindb", "value_vlog"))
+	assertLogFamilyHasData(t, filepath.Join(dir, "maindb", "leaf_vlog"))
+	return dir
+}
+
+func assertLogFamilyHasData(t *testing.T, dir string) {
+	t.Helper()
+	segments, bytesOnDisk, err := listValueLogSegments(dir)
+	if err != nil {
+		t.Fatalf("list %s: %v", dir, err)
+	}
+	if len(segments) == 0 || bytesOnDisk == 0 {
+		t.Fatalf("expected log family data under %s, segments=%d bytes=%d", dir, len(segments), bytesOnDisk)
+	}
+}
+
+func assertAuditStorageDomain(t *testing.T, domains []auditSummaryStorageDomain, name string, wantBytes bool) {
+	t.Helper()
+	for _, domain := range domains {
+		if domain.Name != name {
+			continue
+		}
+		if !domain.Exists {
+			t.Fatalf("storage domain %s does not exist: %+v", name, domain)
+		}
+		if wantBytes && domain.Bytes == 0 {
+			t.Fatalf("storage domain %s has zero bytes: %+v", name, domain)
+		}
+		return
+	}
+	t.Fatalf("missing storage domain %s in %+v", name, domains)
+}
+
+func auditFamiliesByName(families []auditSummaryLogFamily) map[string]auditSummaryLogFamily {
+	out := make(map[string]auditSummaryLogFamily, len(families))
+	for _, family := range families {
+		out[family.Name] = family
+	}
+	return out
+}
+
+type fileSnapshot struct {
+	Size   int64
+	SHA256 string
+}
+
+func snapshotRegularFiles(t *testing.T, root string) map[string]fileSnapshot {
+	t.Helper()
+	out := make(map[string]fileSnapshot)
+	if err := filepath.WalkDir(root, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		if !info.Mode().IsRegular() {
+			return nil
+		}
+		payload, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		sum := sha256.Sum256(payload)
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		out[rel] = fileSnapshot{Size: info.Size(), SHA256: hex.EncodeToString(sum[:])}
+		return nil
+	}); err != nil {
+		t.Fatalf("snapshot files under %s: %v", root, err)
+	}
+	return out
+}

--- a/TreeDB/cmd/treemap/audit_summary_test.go
+++ b/TreeDB/cmd/treemap/audit_summary_test.go
@@ -102,6 +102,60 @@ func TestAuditSummaryJSONOutputShape(t *testing.T) {
 	}
 }
 
+func TestAuditSummaryMainDBDirWithAncientSiblingUsesParentRoot(t *testing.T) {
+	root := t.TempDir()
+	opts := treedb.Options{
+		Dir:        root,
+		Durability: treedb.DurabilityWALOffRelaxed,
+		ValueLog: treedb.ValueLogOptions{
+			PointerThreshold: 1,
+			ForcePointers:    true,
+		},
+	}
+	opts.BackgroundCheckpointInterval = -1
+	opts.BackgroundCheckpointIdleDuration = -1
+	opts.BackgroundIndexVacuumInterval = -1
+	opts.MaxWALBytes = -1
+
+	db, err := treedb.Open(opts)
+	if err != nil {
+		t.Fatalf("open root fixture: %v", err)
+	}
+	if err := db.Set([]byte("root-key"), bytes.Repeat([]byte("v"), 512)); err != nil {
+		_ = db.Close()
+		t.Fatalf("set root fixture: %v", err)
+	}
+	if err := db.Checkpoint(); err != nil {
+		_ = db.Close()
+		t.Fatalf("checkpoint root fixture: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close root fixture: %v", err)
+	}
+	_ = os.RemoveAll(filepath.Join(root, "dictdb"))
+	_ = os.RemoveAll(filepath.Join(root, "templatedb"))
+	ancientDir := filepath.Join(root, "ancient")
+	if err := os.Mkdir(ancientDir, 0o755); err != nil {
+		t.Fatalf("mkdir ancient sibling: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(ancientDir, "freezer.dat"), bytes.Repeat([]byte("a"), 123), 0o644); err != nil {
+		t.Fatalf("write ancient sibling file: %v", err)
+	}
+
+	mainDir := filepath.Join(root, "maindb")
+	report, err := collectAuditSummary(mainDir, auditSummaryCollectOptions{CompactMode: treedbdb.CompactStorageFull})
+	if err != nil {
+		t.Fatalf("collectAuditSummary(root maindb): %v", err)
+	}
+	if report.RootDir != root {
+		t.Fatalf("RootDir=%q want root %q", report.RootDir, root)
+	}
+	ancient := auditStorageDomainsByName(report.Storage.Domains)["ancient"]
+	if !ancient.Exists || ancient.Path != ancientDir || ancient.Bytes != 123 {
+		t.Fatalf("ancient domain not reported from root sibling: %+v", ancient)
+	}
+}
+
 func TestAuditSummaryFlatMainDBDirNamedMainDBUsesInputAsRoot(t *testing.T) {
 	parent := t.TempDir()
 	flatDir := filepath.Join(parent, "maindb")

--- a/TreeDB/cmd/treemap/audit_summary_test.go
+++ b/TreeDB/cmd/treemap/audit_summary_test.go
@@ -102,6 +102,20 @@ func TestAuditSummaryJSONOutputShape(t *testing.T) {
 	}
 }
 
+func TestAuditSummaryMainDBDirWithSiblingSideStoreUsesParentRoot(t *testing.T) {
+	root := t.TempDir()
+	mainDir := filepath.Join(root, "maindb")
+	if err := os.Mkdir(mainDir, 0o755); err != nil {
+		t.Fatalf("mkdir maindb: %v", err)
+	}
+	if err := os.Mkdir(filepath.Join(root, "dictdb"), 0o755); err != nil {
+		t.Fatalf("mkdir dictdb: %v", err)
+	}
+	if got := resolveTreemapRootDir(mainDir, mainDir); got != root {
+		t.Fatalf("resolveTreemapRootDir(mainDir with sibling side store)=%q want %q", got, root)
+	}
+}
+
 func TestAuditSummaryMainDBDirWithAncientSiblingUsesParentRoot(t *testing.T) {
 	root := t.TempDir()
 	opts := treedb.Options{

--- a/TreeDB/cmd/treemap/audit_summary_test.go
+++ b/TreeDB/cmd/treemap/audit_summary_test.go
@@ -13,10 +13,11 @@ import (
 	"testing"
 
 	treedb "github.com/snissn/gomap/TreeDB"
+	treedbdb "github.com/snissn/gomap/TreeDB/db"
 )
 
 func TestAuditSummaryUsageExposesReadOnlyCommand(t *testing.T) {
-	if !strings.Contains(usageText, "audit-summary   Summarize storage, compaction debt, log frames, and gzip samples (read-only)") {
+	if !strings.Contains(usageText, "audit-summary") || !strings.Contains(usageText, "read-only") {
 		t.Fatalf("usageText missing audit-summary read-only command: %q", usageText)
 	}
 }
@@ -98,6 +99,30 @@ func TestAuditSummaryJSONOutputShape(t *testing.T) {
 				t.Fatalf("family %s gzip sample ignored max bytes: %+v", name, sample)
 			}
 		}
+	}
+}
+
+func TestSummarizeCompactUsagesPreservesMissingDomainExists(t *testing.T) {
+	dir := t.TempDir()
+	existingEmpty := filepath.Join(dir, "empty")
+	if err := os.Mkdir(existingEmpty, 0o755); err != nil {
+		t.Fatalf("mkdir existing empty domain: %v", err)
+	}
+	missing := filepath.Join(dir, "missing")
+	rows := summarizeCompactUsages([]treedbdb.CompactStorageUsage{
+		{Name: "missing", Path: missing},
+		{Name: "empty", Path: existingEmpty},
+		{Name: "nonzero", Path: missing, Bytes: 7},
+	})
+	byName := auditStorageDomainsByName(rows)
+	if byName["missing"].Exists {
+		t.Fatalf("missing zero-valued domain reported exists: %+v", byName["missing"])
+	}
+	if !byName["empty"].Exists {
+		t.Fatalf("existing empty domain reported missing: %+v", byName["empty"])
+	}
+	if !byName["nonzero"].Exists {
+		t.Fatalf("nonzero usage domain reported missing: %+v", byName["nonzero"])
 	}
 }
 
@@ -262,6 +287,14 @@ func auditFamiliesByName(families []auditSummaryLogFamily) map[string]auditSumma
 	out := make(map[string]auditSummaryLogFamily, len(families))
 	for _, family := range families {
 		out[family.Name] = family
+	}
+	return out
+}
+
+func auditStorageDomainsByName(domains []auditSummaryStorageDomain) map[string]auditSummaryStorageDomain {
+	out := make(map[string]auditSummaryStorageDomain, len(domains))
+	for _, domain := range domains {
+		out[domain.Name] = domain
 	}
 	return out
 }

--- a/TreeDB/cmd/treemap/audit_summary_test.go
+++ b/TreeDB/cmd/treemap/audit_summary_test.go
@@ -102,6 +102,59 @@ func TestAuditSummaryJSONOutputShape(t *testing.T) {
 	}
 }
 
+func TestAuditSummaryFlatMainDBDirNamedMainDBUsesInputAsRoot(t *testing.T) {
+	parent := t.TempDir()
+	flatDir := filepath.Join(parent, "maindb")
+	opts := treedb.Options{
+		Dir:               flatDir,
+		DisableSideStores: true,
+		Durability:        treedb.DurabilityWALOffRelaxed,
+		ValueLog: treedb.ValueLogOptions{
+			PointerThreshold: 1,
+			ForcePointers:    true,
+		},
+	}
+	opts.BackgroundCheckpointInterval = -1
+	opts.BackgroundCheckpointIdleDuration = -1
+	opts.BackgroundIndexVacuumInterval = -1
+	opts.MaxWALBytes = -1
+
+	db, err := treedb.Open(opts)
+	if err != nil {
+		t.Fatalf("open flat fixture: %v", err)
+	}
+	if err := db.Set([]byte("flat-key"), bytes.Repeat([]byte("v"), 512)); err != nil {
+		_ = db.Close()
+		t.Fatalf("set flat fixture: %v", err)
+	}
+	if err := db.Checkpoint(); err != nil {
+		_ = db.Close()
+		t.Fatalf("checkpoint flat fixture: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close flat fixture: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(parent, "unrelated.bin"), bytes.Repeat([]byte("x"), 4096), 0o644); err != nil {
+		t.Fatalf("write unrelated sibling: %v", err)
+	}
+
+	report, err := collectAuditSummary(flatDir, auditSummaryCollectOptions{CompactMode: treedbdb.CompactStorageFull})
+	if err != nil {
+		t.Fatalf("collectAuditSummary(flat maindb): %v", err)
+	}
+	if report.RootDir != flatDir {
+		t.Fatalf("RootDir=%q want flat dir %q", report.RootDir, flatDir)
+	}
+	rootDomain := auditStorageDomainsByName(report.Storage.Domains)["root"]
+	expectedRoot, err := auditPathUsage("root", flatDir)
+	if err != nil {
+		t.Fatalf("auditPathUsage(flat root): %v", err)
+	}
+	if rootDomain.Path != flatDir || rootDomain.Bytes != expectedRoot.Bytes || rootDomain.Files != expectedRoot.Files {
+		t.Fatalf("root domain includes wrong path/usage: got=%+v want=%+v", rootDomain, expectedRoot)
+	}
+}
+
 func TestSummarizeCompactUsagesPreservesMissingDomainExists(t *testing.T) {
 	dir := t.TempDir()
 	existingEmpty := filepath.Join(dir, "empty")

--- a/TreeDB/cmd/treemap/main.go
+++ b/TreeDB/cmd/treemap/main.go
@@ -39,6 +39,7 @@ Commands:
   checkpoint       Force a durable checkpoint (requires -rw)
   checkpoint-bench Write workload then checkpoint (requires -rw)
   compact-plan    Preview full storage compaction debt without mutating storage
+  audit-summary   Summarize storage, compaction debt, log frames, and gzip samples (read-only)
   compact         Run full storage compaction (requires -rw; use -scope=index for legacy index-only compaction)
   vacuum          Rebuild index.db via swap (shrinks file; requires -rw)
   vlog-audit      Advanced: audit value-log filesystem, GC, and rewrite-plan state (read-only by default)
@@ -97,6 +98,8 @@ func main() {
 		runCheckpointBench(dir, args)
 	case "compact-plan":
 		runCompactPlan(dir, args)
+	case "audit-summary":
+		runAuditSummary(dir, args)
 	case "compact":
 		runCompact(dir, args)
 	case "vacuum":

--- a/TreeDB/cmd/treemap/main_test.go
+++ b/TreeDB/cmd/treemap/main_test.go
@@ -260,12 +260,18 @@ func captureStdout(t *testing.T, fn func()) string {
 		os.Stdout = old
 	}()
 
+	var buf bytes.Buffer
+	readErr := make(chan error, 1)
+	go func() {
+		_, err := io.Copy(&buf, r)
+		readErr <- err
+	}()
+
 	fn()
 	if err := w.Close(); err != nil {
 		t.Fatalf("close stdout pipe writer: %v", err)
 	}
-	var buf bytes.Buffer
-	if _, err := io.Copy(&buf, r); err != nil {
+	if err := <-readErr; err != nil {
 		t.Fatalf("read stdout pipe: %v", err)
 	}
 	if err := r.Close(); err != nil {

--- a/TreeDB/cmd/treemap/vlog_audit.go
+++ b/TreeDB/cmd/treemap/vlog_audit.go
@@ -649,8 +649,14 @@ func resolveTreemapMainDir(dir string) (string, error) {
 
 func resolveTreemapRootDir(inputDir, mainDir string) string {
 	clean := filepath.Clean(inputDir)
-	if filepath.Base(clean) == "maindb" {
-		return filepath.Dir(mainDir)
+	if filepath.Base(clean) != "maindb" {
+		return clean
+	}
+	parent := filepath.Dir(mainDir)
+	for _, sideStore := range []string{"dictdb", "templatedb"} {
+		if info, err := os.Stat(filepath.Join(parent, sideStore)); err == nil && info.IsDir() {
+			return parent
+		}
 	}
 	return clean
 }

--- a/TreeDB/cmd/treemap/vlog_audit.go
+++ b/TreeDB/cmd/treemap/vlog_audit.go
@@ -653,8 +653,8 @@ func resolveTreemapRootDir(inputDir, mainDir string) string {
 		return clean
 	}
 	parent := filepath.Dir(mainDir)
-	for _, sideStore := range []string{"dictdb", "templatedb"} {
-		if info, err := os.Stat(filepath.Join(parent, sideStore)); err == nil && info.IsDir() {
+	for _, rootSibling := range []string{"dictdb", "templatedb", "ancient"} {
+		if info, err := os.Stat(filepath.Join(parent, rootSibling)); err == nil && info.IsDir() {
 			return parent
 		}
 	}


### PR DESCRIPTION
## Objective

Add a first-class read-only TreeDB audit summary command so Sepolia/Hoodi storage reports can use a stable JSON/Markdown contract instead of ad-hoc shell sampling.

Fixes #2633. Part of #2631.

## Context

#2632 found the Sepolia hot DB was dominated by `leaf_vlog`, with distinct compact-plan debt, leaf-generation candidate debt, value-log rewrite/GC debt, frame compression stats, and gzip smoke ratios spread across multiple commands/scripts. This PR consolidates those diagnostics for future reports.

## Design

New command:

```sh
treemap audit-summary <db-dir> [flags]
```

Key flags:

- `-json`: emit stable machine-readable JSON; default emits Markdown.
- `-mode full|quick|exhaustive`: mode passed to read-only `CompactStoragePlan` (default `full`).
- `-frame-stats`: scan `value_vlog` and `leaf_vlog` records for frame compression stats.
- `-gzip-samples N`: deterministically gzip first/last/largest/next-largest segment samples per log family.
- `-gzip-sample-max-bytes N`: cap sample bytes per file; `0` means whole file.
- `-top-segments N`, `-top-generations N`, `-frame-top-lengths N`: output bounds.

JSON top-level fields include:

- `storage.domains[]` for root/ancient/maindb/index/value_vlog/leaf_vlog/dictdb/wal sizing.
- `compact_plan.remaining_debt` for value rewrite/GC, leaf pack/GC, and zero-byte segment debt.
- `value_log.rewrite_plan` and `value_log.gc_dry_run` summaries.
- `leaf_generation` plan/GC summaries and top dead-byte generations.
- `log_families[]` entries for `value_vlog` and `leaf_vlog`, with segment inventory plus optional `frame_scan` and `gzip_samples`.

Invariants:

- No `-rw` flag is accepted by this command.
- Backend open uses `treedb.OpenBackend(... ReadOnly: true)` and dry-run `CompactStoragePlan`.
- Gzip/frame paths only read segment files.
- Geth does not import or depend on this diagnostic path.

## Scope

Includes:

- `TreeDB/cmd/treemap/audit_summary.go`
- `TreeDB/cmd/treemap/audit_summary_test.go`
- `TreeDB/cmd/treemap/main.go` command wiring/usage

Excludes:

- Rewrite/GC policy tuning (#2635).
- Geth integration.
- Destructive maintenance behavior.
- Large-scale Sepolia/Hoodi validation runs.

## Correctness

Tests run:

```sh
go test -count=1 ./TreeDB/cmd/treemap
```

Smoke run:

```sh
go run ./TreeDB/cmd/treemap audit-summary "$SMOKE_DIR" \
  -json -frame-stats -gzip-samples 1 -gzip-sample-max-bytes 1024
```

Smoke JSON was parsed successfully and contained `schema_version=1` and both log families.

Focused coverage added:

- usage exposes the read-only command;
- JSON output shape includes storage, compact debt, value-log, leaf-generation, frame, and gzip fields;
- Markdown output includes expected sections;
- read-only command does not mutate regular DB files (SHA-256 snapshot before/after);
- gzip sample roles/ratios/truncation are deterministic.

## Performance / Overhead

No hot geth/TreeDB read/write path is touched. Runtime cost is operator-invoked only:

- Default `audit-summary` runs storage walks plus read-only `CompactStoragePlan`, so geth-scale cost should be expected to be in the same class as the existing compact-plan audit. In #2632 Sepolia evidence, compact-plan took ~40m51s / 18.6GiB RSS on the copied DB.
- `-frame-stats` adds a full `value_vlog` + `leaf_vlog` record scan; #2632 Sepolia `vlog-audit -frame-stats` took ~13m18s / 14.3GiB RSS.
- `-gzip-samples` reads only selected sample files, bounded by `-gzip-sample-max-bytes` when set.

Large-scale validation on Sepolia/Hoodi is deferred to #2635/#2636; #2635 can safely rely on the JSON fields listed above as the summary contract.

## Rollout / Toggle Plan

- Default behavior is read-only Markdown output.
- Optional expensive scans are behind explicit `-frame-stats` / `-gzip-samples` flags.
- Disable by not invoking the diagnostic command; no runtime geth integration.

## Follow-ups

- #2635 should consume the summary fields for rewrite/GC/generation/compression tuning.
- #2636 can use the command for Hoodi matched-run report artifacts.

## AI Review Loop

- Codex latest-head review: pending after PR creation.
- Copilot latest-head review: pending after PR creation.
- CodeRabbit latest-head review: pending after PR creation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an audit-summary read-only command producing JSON or Markdown reports (storage usage, compaction before/after/debt, value/leaf log summaries, frame stats, top‑N dead‑bytes lists, and optional gzip samples).

* **User-facing changes**
  * CLI usage now documents the new audit-summary command; input-directory resolution when given a main DB directory was clarified.

* **Tests**
  * Added comprehensive tests validating JSON/Markdown output shape, read-only behavior, samples, and frame/gzip reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->