### PR TITLE
TreeDB: tune full leaf-generation pack window

### DIFF
--- a/TreeDB/db/compact_storage.go
+++ b/TreeDB/db/compact_storage.go
@@ -52,8 +52,8 @@ type CompactStorageOptions struct {
 	// preserving retained paths that are independently proven unreachable.
 	ValueLogFencedProtectedPathsFunc func() []string
 
-	// Leaf-generation pack knobs. Defaults are intentionally bounded to keep a
-	// single compaction request finite while still draining ordinary debt.
+	// Leaf-generation pack knobs. Non-exhaustive defaults keep copy bytes per
+	// pass finite while still draining ordinary debt.
 	LeafGenerationProtectedRootIDs []uint64
 	// LeafGenerationProtectedSystemRootIDs are system roots whose collection
 	// descriptors should be expanded into additional protected leaf-generation
@@ -657,7 +657,11 @@ func normalizeCompactStorageOptions(opts CompactStorageOptions) CompactStorageOp
 		case CompactStorageExhaustive:
 			opts.LeafPackMaxGenerationsPerPass = 0
 		default:
-			opts.LeafPackMaxGenerationsPerPass = 64
+			// Full compaction is already bounded by LeafPackMaxBytesToCopyPerPass.
+			// Do not add an arbitrary generation-count cap: large copied-state audits
+			// can have many small dead leaf generations where the old 64-generation
+			// cap stopped a pass before the byte budget was necessarily exhausted.
+			opts.LeafPackMaxGenerationsPerPass = 0
 		}
 	}
 	if opts.LeafPackMaxBytesToCopyPerPass < 0 {

--- a/TreeDB/db/compact_storage_test.go
+++ b/TreeDB/db/compact_storage_test.go
@@ -1457,6 +1457,49 @@ func TestCompactStorageExhaustiveRefusesExternalLeafPageLog(t *testing.T) {
 	}
 }
 
+func TestCompactStorageFullLeafPackDefaultUsesByteBudgetNotGenerationCap(t *testing.T) {
+	opts := normalizeCompactStorageOptions(CompactStorageOptions{})
+	if opts.Mode != CompactStorageFull {
+		t.Fatalf("Mode=%q want full", opts.Mode)
+	}
+	if opts.LeafPackMaxGenerationsPerPass != 0 {
+		t.Fatalf("LeafPackMaxGenerationsPerPass=%d want 0 (byte-budget only)", opts.LeafPackMaxGenerationsPerPass)
+	}
+	if opts.LeafPackMaxBytesToCopyPerPass != 1<<30 {
+		t.Fatalf("LeafPackMaxBytesToCopyPerPass=%d want %d", opts.LeafPackMaxBytesToCopyPerPass, int64(1<<30))
+	}
+
+	plan := LeafGenerationPlan{Admission: leafGenerationPlanAdmissionEligible}
+	for i := 0; i < 96; i++ {
+		plan.Candidates = append(plan.Candidates, LeafGenerationPlanGeneration{
+			GenerationID: uint64(i + 1),
+			BytesTotal:   3,
+			BytesLive:    1,
+			BytesDead:    2,
+			BytesToCopy:  1,
+			LivePages:    1,
+		})
+	}
+
+	gens, bytes, err := compactStorageLeafPackDebtFromPlan(plan, compactStorageLeafPackFromPlanOptions(opts, nil, nil))
+	if err != nil {
+		t.Fatalf("compactStorageLeafPackDebtFromPlan default: %v", err)
+	}
+	if gens != 96 || bytes != 192 {
+		t.Fatalf("default full leaf-pack debt gens=%d bytes=%d want 96/192", gens, bytes)
+	}
+
+	capped := opts
+	capped.LeafPackMaxGenerationsPerPass = 64
+	gens, bytes, err = compactStorageLeafPackDebtFromPlan(plan, compactStorageLeafPackFromPlanOptions(capped, nil, nil))
+	if err != nil {
+		t.Fatalf("compactStorageLeafPackDebtFromPlan capped: %v", err)
+	}
+	if gens != 64 || bytes != 128 {
+		t.Fatalf("explicit capped leaf-pack debt gens=%d bytes=%d want 64/128", gens, bytes)
+	}
+}
+
 func TestCompactStorageNormalizeExhaustiveForcesUnboundedLeafPack(t *testing.T) {
 	opts := normalizeCompactStorageOptions(CompactStorageOptions{Mode: CompactStorageExhaustive})
 	if opts.Mode != CompactStorageExhaustive {


### PR DESCRIPTION
## Objective

Tune the first TreeDB leaf-generation pack heuristic from the #2632 Sepolia copy audit without broad rewrite architecture work.

Fixes #2635. Part of #2631.

> [!NOTE]
> #2640 has merged. This PR is now retargeted to `main` and includes `origin/main` via merge commit `42c4192f`. Latest-head CI/AI review is in progress.

## What changed

Full-mode `CompactStorage` leaf-generation packing now defaults to a byte-budget-only per-pass selection:

- `LeafPackMaxGenerationsPerPass`: full mode default `64` -> `0` (unbounded generation count)
- `LeafPackMaxBytesToCopyPerPass`: unchanged at `1 GiB`
- quick mode remains bounded (`8` generations / `256 MiB`)
- exhaustive mode remains unbounded/forced
- explicit `LeafPackMaxGenerationsPerPass` still caps selection when callers need it

This removes an arbitrary 64-generation cap that #2632 showed was constraining the current compact-plan leaf-pack window (`64` generations / `2,126,576,374` reclaim bytes) even though the full leaf-generation candidate plan had `5,149` candidates and `32,598,107,098` expected reclaim bytes.

## Why this is the smallest tuning

The audit showed hot DB overhead was primarily `leaf_vlog`, while value-log debt was much smaller. This change targets leaf generation pack scheduling only and does **not** change:

- persistent value-log pointer semantics;
- WAL/slab behavior;
- TreeDB/geth default engine selection (Pebble remains default; TreeDB remains explicit/experimental);
- traversal depth guard;
- compression codec settings or rewrite architecture.

Runtime work per full compact pass remains bounded by the existing `1 GiB` copied-live-byte budget. With `MaxGenerations=0`, selection uses the greedy byte-budget path rather than the bounded DP path.

## Evidence

Sepolia copy audit inputs from #2632:

- hot DB dominated by `leaf_vlog` (`173.3 GB` of `216.9 GB` hot DB);
- full leaf-generation plan: `5,149` candidates, `32,598,107,098` expected reclaim bytes, `140,216,126,671` bytes to copy;
- default compact-plan current debt before this tuning: leaf pack `64` generations / `2,126,576,374` bytes;
- value-log rewrite/GC debt was smaller (~`2.19 GB` stale rewrite, ~`268 MB` GC eligible).

Synthetic focused selection evidence added in `TestCompactStorageFullLeafPackDefaultUsesByteBudgetNotGenerationCap`:

| selection | selected generations | reclaim bytes |
| --- | ---: | ---: |
| new full default (`MaxGenerations=0`, byte budget only) | 96 | 192 |
| explicit old-style cap (`MaxGenerations=64`) | 64 | 128 |

No destructive Sepolia-copy maintenance was run for this PR.

## Tests run

```sh
go test ./TreeDB/db -run 'TestCompactStorageFullLeafPackDefaultUsesByteBudgetNotGenerationCap|TestCompactStorageNormalizeExhaustiveForcesUnboundedLeafPack|TestCompactStoragePlanLeafPackDebtUsesBoundedSelection|TestCompactStorageReportsAndCompactsSelectableLeafPackDebt|TestSelectLeafGenerationPackCandidates' -count=1
go test ./TreeDB/db -run 'Test(CompactStorage|LeafGenerationPack|LeafGenerationGC|ValueLogGC_RemovesUnreferencedSegment)' -count=1
go test ./TreeDB -run 'TestReopenVerify_WALOn_(Checkpoint|WriteSync)' -count=1
go test ./TreeDB/cmd/treemap -count=1
go test ./TreeDB/db -count=1
go test ./TreeDB/caching -run 'TestLeafGenerationPackMaintenance' -count=1
go test ./TreeDB/db -run '^$' -bench '^BenchmarkLeafGenerationPlanAfterSingleKeyRootChange_Local$' -benchtime=1x -count=1
```

Benchmark smoke result on Apple M3:

```text
BenchmarkLeafGenerationPlanAfterSingleKeyRootChange_Local-8  1  148333 ns/op  1.000 subtree_misses/op  3.000 subtree_pages  17168 B/op  46 allocs/op
```

## Review / risks

Internal high-thinking review: no blocking findings. Noted residual risk that many tiny generations can increase per-pass metadata/source-ID set size under the unchanged `1 GiB` copy cap; explicit `LeafPackMaxGenerationsPerPass` remains available if a caller needs to re-cap.

## Revalidation after #2640 merge

#2640 merged as `585308117b868c8adf7e2e1dbd0cde598577aeb1`. This PR is now based on `main`; branch head is `42c4192fef4a412537c97202ec468e0923f7aa77`.

Local focused validation on the rebased/retargeted head:

```sh
go test ./TreeDB/db -run 'TestCompactStorageFullLeafPackDefaultUsesByteBudgetNotGenerationCap|TestCompactStorageNormalizeExhaustiveForcesUnboundedLeafPack|TestCompactStoragePlanLeafPackDebtUsesBoundedSelection|TestCompactStorageReportsAndCompactsSelectableLeafPackDebt|TestSelectLeafGenerationPackCandidates' -count=1
go test ./TreeDB/cmd/treemap -count=1
go test ./TreeDB/db -run 'Test(CompactStorage|LeafGenerationPack|LeafGenerationGC|ValueLogGC_RemovesUnreferencedSegment)' -count=1
go test ./TreeDB -run 'TestReopenVerify_WALOn_(Checkpoint|WriteSync)' -count=1
go test ./TreeDB/caching -run 'TestLeafGenerationPackMaintenance' -count=1
git diff --check
```

Safe Sepolia-copy dry-run evidence with this head (no destructive maintenance):

- artifact: `/mnt/fast4tb/tmp/geth-treedb-exp/sepolia_copy_audit_20260611T222431Z/dryrun/compact_plan_2635_42c4192.json`
- log: `/mnt/fast4tb/tmp/geth-treedb-exp/sepolia_copy_audit_20260611T222431Z/logs/compact_plan_2635_42c4192.log`
- command: `treemap_2635_42c4192 compact-plan <copied chaindata> -json`
- rc: `0`; wall: `39:54`; max RSS: `20,500,468 KB`
- before (#2632 / old default): leaf pack `64` generations / `2,126,576,374` bytes
- after (this PR default): leaf pack `310` generations / `9,330,250,227` bytes
- leaf GC remained `8` generations / `268,470,910` bytes

Latest-head CI/AI review must pass before merge.
