### PR TITLE
gethethdb: make exhausted iterators idempotent

### DIFF
--- a/TreeDB/integration/gethethdb/adapter.go
+++ b/TreeDB/integration/gethethdb/adapter.go
@@ -654,6 +654,9 @@ func (it *Iterator) Next() bool {
 		it.started = true
 		return it.inner.Valid()
 	}
+	if !it.inner.Valid() {
+		return false
+	}
 	it.inner.Next()
 	return it.inner.Valid()
 }

--- a/TreeDB/integration/gethethdb/adapter_test.go
+++ b/TreeDB/integration/gethethdb/adapter_test.go
@@ -360,6 +360,35 @@ func TestIteratorPrefixStart(t *testing.T) {
 	}
 }
 
+func TestIteratorNextAfterExhaustionIsIdempotent(t *testing.T) {
+	db := openTestDB(t)
+	for _, key := range []string{"a", "b", "c"} {
+		if err := db.Put([]byte(key), []byte("v-"+key)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	it := db.NewIterator(nil, nil)
+	got := collectIteratorKeys(it)
+	if want := []string{"a", "b", "c"}; !slices.Equal(got, want) {
+		t.Fatalf("iterator keys=%v want %v", got, want)
+	}
+	for i := 0; i < 3; i++ {
+		if it.Next() {
+			t.Fatalf("exhausted iterator Next #%d returned true", i+1)
+		}
+		if key := it.Key(); key != nil {
+			t.Fatalf("exhausted iterator Key #%d=%q want nil", i+1, key)
+		}
+		if value := it.Value(); value != nil {
+			t.Fatalf("exhausted iterator Value #%d=%q want nil", i+1, value)
+		}
+	}
+	if err := it.Error(); err != nil {
+		t.Fatalf("exhausted iterator err=%v", err)
+	}
+	it.Release()
+}
+
 func TestOperationsAfterClose(t *testing.T) {
 	db := openTestDB(t)
 	if err := db.Put([]byte("key"), []byte("value")); err != nil {

--- a/TreeDB/integration/gethethdb/adapter_test.go
+++ b/TreeDB/integration/gethethdb/adapter_test.go
@@ -368,7 +368,10 @@ func TestIteratorNextAfterExhaustionIsIdempotent(t *testing.T) {
 		}
 	}
 	it := db.NewIterator(nil, nil)
-	got := collectIteratorKeys(it)
+	var got []string
+	for it.Next() {
+		got = append(got, string(it.Key()))
+	}
 	if want := []string{"a", "b", "c"}; !slices.Equal(got, want) {
 		t.Fatalf("iterator keys=%v want %v", got, want)
 	}


### PR DESCRIPTION
## Objective

Fix a Hoodi TreeDB validation panic found in #2636.

During the matched Hoodi TreeDB run, geth crashed after reaching live head with:

```text
panic: merging iterator invalid
github.com/snissn/gomap/TreeDB/internal/merging.(*MergingIterator).Next
github.com/snissn/gomap/TreeDB/integration/gethethdb.(*Iterator).Next
github.com/ethereum/go-ethereum/core/rawdb.(*KeyLengthIterator).Next
github.com/ethereum/go-ethereum/triedb/internal.(*HoldableIterator).Next
github.com/ethereum/go-ethereum/triedb/pathdb.(*generatorContext).removeStorageBefore
```

Artifact log:
`/mnt/fast4tb/tmp/geth-treedb-exp/hoodi_matched_2636_20260612T034840Z/treedb_geth.log`

## What changed

`gethethdb.Iterator.Next` now returns `false` when the wrapped TreeDB iterator is already exhausted instead of calling `inner.Next()` again.

Geth `ethdb.Iterator` callers and wrappers may call `Next` after exhaustion; repeated exhausted calls should be idempotent and must not trip TreeDB's stricter invalid-iterator panic.

## Tests

```sh
cd TreeDB/integration/gethethdb
go test -run 'TestIteratorNextAfterExhaustionIsIdempotent|TestIteratorPrefixStart' -count=1
go test -count=1
```

## Notes

This does not change TreeDB iterator invariants internally; it adapts the geth ethdb integration boundary to geth's iterator expectations.

Follow-up validation: rerun the Hoodi TreeDB leg from a geth build that points at this gomap commit, then redo close/reopen evidence for #2636.
