### PR TITLE
TreeDB text v2: add document ordinals, norms, and root format

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -2862,6 +2862,9 @@ func (m *CollectionManager) CreateCollection(meta *CollectionMeta) (*CollectionM
 	if err != nil {
 		return nil, err
 	}
+	if err := rejectCreateCollectionTextV2Indexes(normalized); err != nil {
+		return nil, err
+	}
 	return m.createCollectionWithCommandWALIntent(normalized, nil)
 }
 
@@ -19836,6 +19839,15 @@ func collectionRootStoragePolicyForDB(db *backenddb.DB, meta CollectionMeta, roo
 		}
 	}
 	for _, idx := range meta.TextIndexes {
+		if idx.Version == TextIndexVersionV2 {
+			switch rootName {
+			case collectionTextV2DocMapRootName(meta.Name, idx.Name), collectionTextV2PostingBlocksRootName(meta.Name, idx.Name), collectionTextV2NormBlocksRootName(meta.Name, idx.Name), collectionTextV2PositionsRootName(meta.Name, idx.Name):
+				return backendRootStoragePolicy(idx.StoragePolicy)
+			case collectionTextV2DocIDRootName(meta.Name, idx.Name), collectionTextV2TermsRootName(meta.Name, idx.Name), collectionTextV2GenerationsRootName(meta.Name, idx.Name):
+				return backendRootStoragePolicy(meta.Options.IndexStateStoragePolicy)
+			}
+			continue
+		}
 		switch rootName {
 		case collectionTextIndexRootName(meta.Name, idx.Name):
 			return backendRootStoragePolicy(idx.StoragePolicy)
@@ -20892,7 +20904,7 @@ func collectionRootNames(meta CollectionMeta) []string {
 		out = append(out, collectionVectorIndexRootName(meta.Name, idx.Name))
 	}
 	for _, idx := range meta.TextIndexes {
-		out = append(out, collectionTextRootNames(meta.Name, idx.Name)...)
+		out = append(out, collectionTextRootNamesForDefinition(meta.Name, idx)...)
 	}
 	return out
 }

--- a/TreeDB/collections/text_backfill.go
+++ b/TreeDB/collections/text_backfill.go
@@ -979,8 +979,11 @@ func inspectTextV2Root(snap *backenddb.Snapshot, catalog *collectionCatalog, def
 	if errors.Is(err, tree.ErrKeyNotFound) {
 		return errMalformedTextStorage("missing text-v2 root %q", rootName)
 	}
-	if err != nil || it == nil {
+	if err != nil {
 		return err
+	}
+	if it == nil {
+		return errMalformedTextStorage("missing text-v2 root %q", rootName)
 	}
 	defer func() { _ = it.Close() }()
 	formatSeen := false

--- a/TreeDB/collections/text_backfill.go
+++ b/TreeDB/collections/text_backfill.go
@@ -25,6 +25,15 @@ type TextIndexBackfillStats struct {
 	PostingEntries   int
 	StatsEntries     int
 	EncodedBytes     uint64
+
+	V2DocIDEntries   int
+	V2DocMapBlocks   int
+	V2NormBlocks     int
+	V2TermStats      int
+	V2FormatRecords  int
+	V2StatusRecords  int
+	V2NextOrdinal    uint64
+	V2RootGeneration uint64
 }
 
 // TextIndexStorageStats reports durable text-root contents after validation.
@@ -34,6 +43,19 @@ type TextIndexStorageStats struct {
 	PostingEntries uint64
 	StatsEntries   uint64
 	EncodedBytes   uint64
+
+	Version           TextIndexVersion
+	V2DocIDEntries    uint64
+	V2DocMapBlocks    uint64
+	V2NormBlocks      uint64
+	V2TermStats       uint64
+	V2FormatRecords   uint64
+	V2StatusRecords   uint64
+	V2NextOrdinal     uint64
+	V2LiveDocuments   uint64
+	V2DeletedDocs     uint64
+	V2RootGeneration  uint64
+	V2StatsGeneration uint64
 }
 
 type createTextIndexBackfillPlan struct {
@@ -78,6 +100,9 @@ func buildCreateTextIndexBackfillPlan(
 	}
 	if catalog == nil {
 		return nil, errCollectionNotFound
+	}
+	if def.Version == TextIndexVersionV2 {
+		return buildCreateTextV2IndexBackfillPlan(snap, catalog, def, opts)
 	}
 	postingsRootName := collectionTextIndexRootName(catalog.meta.Name, def.Name)
 	stateRootName := collectionTextStateRootName(catalog.meta.Name, def.Name)
@@ -171,6 +196,187 @@ func buildCreateTextIndexBackfillPlan(
 		plan.policies = append(plan.policies, opts.indexStateStoragePolicy)
 	} else {
 		resetCollectionTables([]memtable.Table{statsTable})
+	}
+	return plan, nil
+}
+
+func buildCreateTextV2IndexBackfillPlan(
+	snap *backenddb.Snapshot,
+	catalog *collectionCatalog,
+	def TextIndexDefinition,
+	opts collectionOptions,
+) (*createTextIndexBackfillPlan, error) {
+	rootNames := collectionTextV2RootNames(catalog.meta.Name, def.Name)
+	plan := &createTextIndexBackfillPlan{
+		rootNames:   make([]string, 0, len(rootNames)),
+		baseRootIDs: make(map[string]uint64, len(rootNames)+1),
+		tables:      make([]memtable.Table, 0, len(rootNames)),
+		policies:    make([]backenddb.OrderedRootStoragePolicy, 0, len(rootNames)),
+	}
+	primaryRootName := collectionPrimaryRootName(catalog.meta.Name)
+	plan.baseRootIDs[primaryRootName] = catalog.rootID(primaryRootName)
+	for _, rootName := range rootNames {
+		plan.baseRootIDs[rootName] = catalog.rootID(rootName)
+	}
+
+	tables := make(map[string]memtable.Table, len(rootNames))
+	resetAll := func() {
+		owned := make([]memtable.Table, 0, len(tables))
+		for _, table := range tables {
+			owned = append(owned, table)
+		}
+		resetCollectionTables(owned)
+	}
+	for _, rootName := range rootNames {
+		tables[rootName] = newCollectionRunTable(0)
+	}
+
+	fieldNames := textV2FieldNames(def)
+	for _, rootName := range rootNames {
+		family, ok := textV2RootFamilyForName(catalog.meta.Name, def.Name, rootName)
+		if !ok {
+			resetAll()
+			return nil, fmt.Errorf("collections: unknown text-v2 root %q", rootName)
+		}
+		key := encodeTextV2FormatKey()
+		value := encodeTextV2RootFormatValue(textV2RootFormatValue{
+			FormatVersion:   textV2FormatVersion,
+			Family:          family,
+			DocMapBlockSize: textV2DefaultDocMapBlockSize,
+			NormBlockSize:   textV2DefaultNormBlockSize,
+			Fields:          fieldNames,
+		})
+		tables[rootName].SetSteal(key, value)
+		plan.stats.V2FormatRecords++
+		plan.stats.EncodedBytes += uint64(len(key) + len(value))
+	}
+
+	docIDRootName := collectionTextV2DocIDRootName(catalog.meta.Name, def.Name)
+	docMapRootName := collectionTextV2DocMapRootName(catalog.meta.Name, def.Name)
+	termsRootName := collectionTextV2TermsRootName(catalog.meta.Name, def.Name)
+	normRootName := collectionTextV2NormBlocksRootName(catalog.meta.Name, def.Name)
+	generationsRootName := collectionTextV2GenerationsRootName(catalog.meta.Name, def.Name)
+	docMapBlocks := make(map[uint64]*textV2DocMapBlockValue)
+	normBlocks := make(map[uint64]*textV2NormBlockValue)
+	acc := textBackfillStatsAccumulator{
+		Terms:  make(map[string]*textStatsTermValue),
+		Fields: make(map[string]*textStatsFieldValue),
+	}
+
+	nextOrdinal := uint64(1)
+	primaryRootID := catalog.rootID(primaryRootName)
+	if primaryRootID != 0 {
+		it, err := collectionIteratorAtCatalogRoot(snap, catalog, primaryRootName, nil, nil, false)
+		if err != nil {
+			resetAll()
+			return nil, err
+		}
+		if it != nil {
+			defer func() { _ = it.Close() }()
+			for it.Valid() {
+				if it.IsDeleted() {
+					it.Next()
+					continue
+				}
+				documentID := bytes.Clone(it.UnsafeKey())
+				document := it.ValueCopy(nil)
+				jsonDocument, err := materializeTextBackfillDocumentJSON(document, opts)
+				if err != nil {
+					resetAll()
+					return nil, err
+				}
+				analysis, err := analyzeTextIndexDocument(def, jsonDocument)
+				if err != nil {
+					resetAll()
+					return nil, err
+				}
+
+				ordinal := nextOrdinal
+				nextOrdinal++
+				generation := uint64(1)
+				docIDKey := encodeTextV2DocIDKey(documentID)
+				docIDValue := encodeTextV2DocIDValue(textV2DocIDValue{Ordinal: ordinal, Generation: generation})
+				tables[docIDRootName].SetSteal(docIDKey, docIDValue)
+				plan.stats.V2DocIDEntries++
+				plan.stats.EncodedBytes += uint64(len(docIDKey) + len(docIDValue))
+
+				docBlockStart := textV2OrdinalBlockStart(ordinal, textV2DefaultDocMapBlockSize)
+				docBlock := docMapBlocks[docBlockStart]
+				if docBlock == nil {
+					docBlock = &textV2DocMapBlockValue{BlockStart: docBlockStart, BlockSize: textV2DefaultDocMapBlockSize}
+					docMapBlocks[docBlockStart] = docBlock
+				}
+				docBlock.upsert(textV2DocMapEntry{Ordinal: ordinal, Generation: generation, DocumentID: documentID})
+
+				fieldLengths := textV2FieldLengthsFromAnalysis(def, analysis)
+				normBlockStart := textV2OrdinalBlockStart(ordinal, textV2DefaultNormBlockSize)
+				normBlock := normBlocks[normBlockStart]
+				if normBlock == nil {
+					normBlock = &textV2NormBlockValue{BlockStart: normBlockStart, BlockSize: textV2DefaultNormBlockSize, FieldCount: uint32(len(fieldNames))}
+					normBlocks[normBlockStart] = normBlock
+				}
+				normBlock.upsert(textV2NormBlockEntry{Ordinal: ordinal, Generation: generation, FieldLengths: fieldLengths})
+
+				acc.addDocument(analysis)
+				plan.stats.DocumentsScanned++
+				it.Next()
+			}
+			if err := it.Error(); err != nil {
+				resetAll()
+				return nil, err
+			}
+		}
+	}
+
+	for _, blockStart := range sortedTextV2BlockStarts(docMapBlocks) {
+		key := encodeTextV2BlockKey(blockStart)
+		value := encodeTextV2DocMapBlockValue(*docMapBlocks[blockStart])
+		tables[docMapRootName].SetSteal(key, value)
+		plan.stats.V2DocMapBlocks++
+		plan.stats.EncodedBytes += uint64(len(key) + len(value))
+	}
+	for _, blockStart := range sortedTextV2BlockStarts(normBlocks) {
+		key := encodeTextV2BlockKey(blockStart)
+		value := encodeTextV2NormBlockValue(*normBlocks[blockStart])
+		tables[normRootName].SetSteal(key, value)
+		plan.stats.V2NormBlocks++
+		plan.stats.EncodedBytes += uint64(len(key) + len(value))
+	}
+
+	statsEntries, statsBytes := addTextV2StatsEntries(tables[termsRootName], acc, def, 1)
+	plan.stats.V2TermStats = statsEntries
+	plan.stats.StatsEntries = statsEntries
+	plan.stats.EncodedBytes += statsBytes
+
+	statusKey := encodeTextV2StatusKey()
+	statusValue := encodeTextV2IndexStatusValue(textV2IndexStatusValue{
+		FormatVersion:    textV2FormatVersion,
+		RootGeneration:   1,
+		StatsGeneration:  1,
+		DocMapGeneration: 1,
+		NormGeneration:   1,
+		TermGeneration:   1,
+		NextOrdinal:      nextOrdinal,
+		LiveDocuments:    uint64(plan.stats.DocumentsScanned),
+		DeletedDocuments: 0,
+	})
+	tables[generationsRootName].SetSteal(statusKey, statusValue)
+	plan.stats.V2StatusRecords = 1
+	plan.stats.V2NextOrdinal = nextOrdinal
+	plan.stats.V2RootGeneration = 1
+	plan.stats.EncodedBytes += uint64(len(statusKey) + len(statusValue))
+
+	for _, rootName := range rootNames {
+		table := tables[rootName]
+		table.Freeze()
+		plan.rootNames = append(plan.rootNames, rootName)
+		plan.tables = append(plan.tables, table)
+		policy, err := textV2RootStoragePolicyForDefinition(catalog.meta, def, rootName)
+		if err != nil {
+			resetAll()
+			return nil, err
+		}
+		plan.policies = append(plan.policies, policy)
 	}
 	return plan, nil
 }
@@ -513,6 +719,92 @@ func addTextStatsEntries(table memtable.Table, acc textBackfillStatsAccumulator)
 	return entries, bytesWritten
 }
 
+func addTextV2StatsEntries(table memtable.Table, acc textBackfillStatsAccumulator, def TextIndexDefinition, generation uint64) (int, uint64) {
+	if table == nil {
+		return 0, 0
+	}
+	entries := 0
+	var bytesWritten uint64
+	set := func(key, value []byte) {
+		table.SetSteal(key, value)
+		entries++
+		bytesWritten += uint64(len(key) + len(value))
+	}
+	set(encodeTextV2CorpusStatsKey(), encodeTextV2CorpusStatsValue(textV2CorpusStatsValue{StatsGeneration: generation, DocumentCount: acc.Corpus.DocumentCount}))
+	terms := make([]string, 0, len(acc.Terms))
+	for term := range acc.Terms {
+		terms = append(terms, term)
+	}
+	sort.Strings(terms)
+	for _, term := range terms {
+		stats := acc.Terms[term]
+		if stats == nil {
+			continue
+		}
+		set(encodeTextV2TermStatsKey(term), encodeTextV2TermStatsValue(textV2TermStatsValue{
+			StatsGeneration:    generation,
+			DocumentFrequency:  stats.DocumentFrequency,
+			TotalTermFrequency: stats.TotalTermFrequency,
+		}))
+	}
+	seenFields := make(map[string]struct{}, len(def.Fields))
+	for _, fieldDef := range def.Fields {
+		field := fieldDef.Field
+		if _, ok := seenFields[field]; ok {
+			continue
+		}
+		seenFields[field] = struct{}{}
+		stats := acc.Fields[field]
+		value := textV2FieldStatsValue{StatsGeneration: generation}
+		if stats != nil {
+			value.DocumentCount = stats.DocumentCount
+			value.TotalTokenCount = stats.TotalTokenCount
+		}
+		set(encodeTextV2FieldStatsKey(field), encodeTextV2FieldStatsValue(value))
+	}
+	return entries, bytesWritten
+}
+
+func textV2FieldNames(def TextIndexDefinition) []string {
+	fields := make([]string, 0, len(def.Fields))
+	for _, field := range def.Fields {
+		fields = append(fields, field.Field)
+	}
+	return fields
+}
+
+func textV2FieldLengthsFromAnalysis(def TextIndexDefinition, analysis textAnalyzedDocument) []uint32 {
+	byField := make(map[string]uint32, len(analysis.Fields))
+	for _, field := range analysis.Fields {
+		byField[field.Field] = field.Length
+	}
+	lengths := make([]uint32, 0, len(def.Fields))
+	for _, field := range def.Fields {
+		lengths = append(lengths, byField[field.Field])
+	}
+	return lengths
+}
+
+func sortedTextV2BlockStarts[V any](blocks map[uint64]V) []uint64 {
+	starts := make([]uint64, 0, len(blocks))
+	for start := range blocks {
+		starts = append(starts, start)
+	}
+	slices.Sort(starts)
+	return starts
+}
+
+func textV2RootStoragePolicyForDefinition(meta CollectionMeta, def TextIndexDefinition, rootName string) (backenddb.OrderedRootStoragePolicy, error) {
+	switch rootName {
+	case collectionTextV2DocMapRootName(meta.Name, def.Name), collectionTextV2PostingBlocksRootName(meta.Name, def.Name), collectionTextV2NormBlocksRootName(meta.Name, def.Name), collectionTextV2PositionsRootName(meta.Name, def.Name):
+		return backendRootStoragePolicy(def.StoragePolicy)
+	case collectionTextV2DocIDRootName(meta.Name, def.Name), collectionTextV2TermsRootName(meta.Name, def.Name), collectionTextV2GenerationsRootName(meta.Name, def.Name):
+		return backendRootStoragePolicy(meta.Options.IndexStateStoragePolicy)
+	default:
+		return backenddb.OrderedRootStorageDefault, fmt.Errorf("collections: unknown text-v2 root %q for %q", rootName, meta.Name)
+	}
+}
+
 func mustBackendTextRootStoragePolicy(policy RootStoragePolicy) backenddb.OrderedRootStoragePolicy {
 	out, err := backendRootStoragePolicy(policy)
 	if err != nil {
@@ -528,6 +820,9 @@ func inspectTextIndexStorage(snap *backenddb.Snapshot, catalog *collectionCatalo
 	}
 	if catalog == nil {
 		return stats, errCollectionNotFound
+	}
+	if def.Version == TextIndexVersionV2 {
+		return inspectTextV2IndexStorage(snap, catalog, def)
 	}
 	postingsRootName := collectionTextIndexRootName(catalog.meta.Name, def.Name)
 	if err := inspectTextPostingsRoot(snap, catalog, postingsRootName, &stats); err != nil {
@@ -639,4 +934,221 @@ func inspectTextStatsRoot(snap *backenddb.Snapshot, catalog *collectionCatalog, 
 		it.Next()
 	}
 	return it.Error()
+}
+
+func inspectTextV2IndexStorage(snap *backenddb.Snapshot, catalog *collectionCatalog, def TextIndexDefinition) (TextIndexStorageStats, error) {
+	stats := TextIndexStorageStats{Version: TextIndexVersionV2}
+	generationsRootName := collectionTextV2GenerationsRootName(catalog.meta.Name, def.Name)
+	status, ok, err := readTextV2StatusAtRoot(snap, catalog, generationsRootName)
+	if err != nil {
+		return stats, err
+	}
+	if !ok {
+		return stats, errMalformedTextStorage("missing text-v2 status record for collection %q index %q", catalog.meta.Name, def.Name)
+	}
+	stats.Documents = status.LiveDocuments
+	stats.V2NextOrdinal = status.NextOrdinal
+	stats.V2LiveDocuments = status.LiveDocuments
+	stats.V2DeletedDocs = status.DeletedDocuments
+	stats.V2RootGeneration = status.RootGeneration
+	stats.V2StatsGeneration = status.StatsGeneration
+
+	for _, rootName := range collectionTextV2RootNames(catalog.meta.Name, def.Name) {
+		family, ok := textV2RootFamilyForName(catalog.meta.Name, def.Name, rootName)
+		if !ok {
+			return stats, errMalformedTextStorage("unknown text-v2 root %q", rootName)
+		}
+		if err := inspectTextV2Root(snap, catalog, def, rootName, family, status, &stats); err != nil {
+			return stats, err
+		}
+	}
+	return stats, nil
+}
+
+func readTextV2StatusAtRoot(snap *backenddb.Snapshot, catalog *collectionCatalog, rootName string) (textV2IndexStatusValue, bool, error) {
+	raw, ok, err := collectionGetAppendAtCatalogRoot(snap, catalog, rootName, encodeTextV2StatusKey(), nil)
+	if err != nil || !ok {
+		return textV2IndexStatusValue{}, ok, err
+	}
+	status, err := decodeTextV2IndexStatusValue(raw)
+	return status, true, err
+}
+
+func inspectTextV2Root(snap *backenddb.Snapshot, catalog *collectionCatalog, def TextIndexDefinition, rootName string, family textV2RootFamily, status textV2IndexStatusValue, stats *TextIndexStorageStats) error {
+	it, err := collectionIteratorAtCatalogRoot(snap, catalog, rootName, nil, nil, false)
+	if errors.Is(err, tree.ErrKeyNotFound) {
+		return errMalformedTextStorage("missing text-v2 root %q", rootName)
+	}
+	if err != nil || it == nil {
+		return err
+	}
+	defer func() { _ = it.Close() }()
+	formatSeen := false
+	statusSeen := false
+	corpusSeen := false
+	fieldNames := textV2FieldNames(def)
+	fieldSet := make(map[string]struct{}, len(fieldNames))
+	seenFieldStats := make(map[string]struct{}, len(fieldNames))
+	for _, field := range fieldNames {
+		fieldSet[field] = struct{}{}
+	}
+	for it.Valid() {
+		if it.IsDeleted() {
+			it.Next()
+			continue
+		}
+		key := it.UnsafeKey()
+		value := it.ValueCopy(nil)
+		switch {
+		case bytes.Equal(key, encodeTextV2FormatKey()):
+			format, err := decodeTextV2RootFormatValue(value)
+			if err != nil {
+				return err
+			}
+			if format.Family != family {
+				return errMalformedTextStorage("text-v2 root %q format family=%s want %s", rootName, format.Family, family)
+			}
+			if format.DocMapBlockSize != textV2DefaultDocMapBlockSize || format.NormBlockSize != textV2DefaultNormBlockSize {
+				return errMalformedTextStorage("text-v2 root %q format block sizes mismatch", rootName)
+			}
+			if !slices.Equal(format.Fields, fieldNames) {
+				return errMalformedTextStorage("text-v2 root %q format fields mismatch", rootName)
+			}
+			formatSeen = true
+			stats.V2FormatRecords++
+		case bytes.Equal(key, encodeTextV2StatusKey()):
+			if family != textV2RootFamilyGenerations {
+				return errMalformedTextStorage("text-v2 status key found in root family %s", family)
+			}
+			got, err := decodeTextV2IndexStatusValue(value)
+			if err != nil {
+				return err
+			}
+			if got != status {
+				return errMalformedTextStorage("text-v2 status record changed while scanning")
+			}
+			statusSeen = true
+			stats.V2StatusRecords++
+		case family == textV2RootFamilyDocID:
+			if _, err := decodeTextV2DocIDKey(key); err != nil {
+				return err
+			}
+			doc, err := decodeTextV2DocIDValue(value)
+			if err != nil {
+				return err
+			}
+			if doc.Ordinal >= status.NextOrdinal || doc.Generation > status.RootGeneration {
+				return errMalformedTextStorage("text-v2 docid ordinal/generation outside status snapshot")
+			}
+			stats.V2DocIDEntries++
+		case family == textV2RootFamilyDocMap:
+			blockStart, err := decodeTextV2BlockKey(key)
+			if err != nil {
+				return err
+			}
+			block, err := decodeTextV2DocMapBlockValue(value)
+			if err != nil {
+				return err
+			}
+			if block.BlockStart != blockStart || block.BlockSize != textV2DefaultDocMapBlockSize {
+				return errMalformedTextStorage("text-v2 docmap block key/value mismatch")
+			}
+			for _, entry := range block.Entries {
+				if entry.Ordinal >= status.NextOrdinal || entry.Generation > status.DocMapGeneration {
+					return errMalformedTextStorage("text-v2 docmap entry outside status snapshot")
+				}
+			}
+			stats.V2DocMapBlocks++
+		case family == textV2RootFamilyNormBlocks:
+			blockStart, err := decodeTextV2BlockKey(key)
+			if err != nil {
+				return err
+			}
+			block, err := decodeTextV2NormBlockValue(value)
+			if err != nil {
+				return err
+			}
+			if block.BlockStart != blockStart || block.BlockSize != textV2DefaultNormBlockSize || block.FieldCount != uint32(len(def.Fields)) {
+				return errMalformedTextStorage("text-v2 norm block key/value mismatch")
+			}
+			for _, entry := range block.Entries {
+				if entry.Ordinal >= status.NextOrdinal || entry.Generation > status.NormGeneration {
+					return errMalformedTextStorage("text-v2 norm entry outside status snapshot")
+				}
+			}
+			stats.V2NormBlocks++
+		case family == textV2RootFamilyTerms:
+			statsKey, err := decodeTextV2StatsKey(key)
+			if err != nil {
+				return err
+			}
+			switch statsKey.Kind {
+			case textV2KeyKindCorpusStats:
+				corpus, err := decodeTextV2CorpusStatsValue(value)
+				if err != nil {
+					return err
+				}
+				if corpus.StatsGeneration != status.StatsGeneration || corpus.DocumentCount != status.LiveDocuments {
+					return errMalformedTextStorage("text-v2 corpus stats/status mismatch")
+				}
+				corpusSeen = true
+			case textV2KeyKindFieldStats:
+				if _, ok := fieldSet[statsKey.Value]; !ok {
+					return errMalformedTextStorage("text-v2 field stats for undeclared field %q", statsKey.Value)
+				}
+				if _, dup := seenFieldStats[statsKey.Value]; dup {
+					return errMalformedTextStorage("duplicate text-v2 field stats for field %q", statsKey.Value)
+				}
+				seenFieldStats[statsKey.Value] = struct{}{}
+				field, err := decodeTextV2FieldStatsValue(value)
+				if err != nil {
+					return err
+				}
+				if field.StatsGeneration != status.StatsGeneration {
+					return errMalformedTextStorage("text-v2 field stats generation mismatch")
+				}
+				if field.DocumentCount > status.LiveDocuments {
+					return errMalformedTextStorage("text-v2 field stats document count exceeds live documents")
+				}
+			case textV2KeyKindTermStats:
+				term, err := decodeTextV2TermStatsValue(value)
+				if err != nil {
+					return err
+				}
+				if term.StatsGeneration > status.TermGeneration {
+					return errMalformedTextStorage("text-v2 term stats generation exceeds status")
+				}
+			default:
+				return errMalformedTextStorage("unsupported text-v2 terms key kind %d", statsKey.Kind)
+			}
+			stats.V2TermStats++
+			stats.StatsEntries++
+		case family == textV2RootFamilyPostingBlocks || family == textV2RootFamilyPositions || family == textV2RootFamilyGenerations:
+			return errMalformedTextStorage("unsupported text-v2 root %q entry key %x", rootName, key)
+		default:
+			return errMalformedTextStorage("unsupported text-v2 root %q family %s", rootName, family)
+		}
+		stats.EncodedBytes += uint64(len(key) + len(value))
+		it.Next()
+	}
+	if err := it.Error(); err != nil {
+		return err
+	}
+	if !formatSeen {
+		return errMalformedTextStorage("missing text-v2 root %q format record", rootName)
+	}
+	if family == textV2RootFamilyGenerations && !statusSeen {
+		return errMalformedTextStorage("missing text-v2 status record in root %q", rootName)
+	}
+	if family == textV2RootFamilyTerms {
+		if !corpusSeen {
+			return errMalformedTextStorage("missing text-v2 corpus stats record in root %q", rootName)
+		}
+		for _, field := range fieldNames {
+			if _, ok := seenFieldStats[field]; !ok {
+				return errMalformedTextStorage("missing text-v2 field stats for field %q", field)
+			}
+		}
+	}
+	return nil
 }

--- a/TreeDB/collections/text_catalog.go
+++ b/TreeDB/collections/text_catalog.go
@@ -8,8 +8,10 @@ import (
 )
 
 // CreateTextIndex adds a collection-native text index and backfills persistent
-// postings, text-state, and text-stats roots from the current documents. Write
-// paths maintain those roots after creation, and SearchText ranks from them.
+// roots from the current documents. V1 indexes backfill postings, text-state,
+// and text-stats roots. Explicit v2 indexes backfill document ordinals, docmap,
+// term/stat shells, packed norms, and status/format roots; SearchText remains
+// fail-closed for v2 until the v2 executor lands.
 func (c *Collection) CreateTextIndex(def TextIndexDefinition) (*CollectionMeta, TextIndexBackfillStats, error) {
 	var emptyStats TextIndexBackfillStats
 	if c == nil {
@@ -105,8 +107,8 @@ func (c *Collection) CreateTextIndex(def TextIndexDefinition) (*CollectionMeta, 
 	return newMeta.copy(), plan.stats, nil
 }
 
-// DropTextIndex removes text index metadata and clears the persistent
-// postings/text-state/text-stats root descriptors for the index.
+// DropTextIndex removes text index metadata and clears the persistent v1 and
+// v2 text root descriptors for the index.
 func (c *Collection) DropTextIndex(name string) (*CollectionMeta, error) {
 	if err := ValidateIndexName(name); err != nil {
 		return nil, err
@@ -176,7 +178,7 @@ func (c *Collection) DropTextIndex(name string) (*CollectionMeta, error) {
 	if err != nil {
 		return nil, err
 	}
-	clearedRootNames := collectionTextRootNames(baseMeta.Name, name)
+	clearedRootNames := collectionTextAllRootNames(baseMeta.Name, name)
 	newSystemRoot, _, err := c.db.PublishOrderedRootDeltaGroupWithSystemDeltaBuilder(nil, func([]uint64) (iterator.UnsafeIterator, error) {
 		return c.buildSchemaOnlySystemDeltaIterator(baseMeta, encodedMeta, clearedRootNames)
 	})

--- a/TreeDB/collections/text_index.go
+++ b/TreeDB/collections/text_index.go
@@ -24,9 +24,9 @@ const (
 )
 
 // TextIndexVersion selects the physical text-index contract. The zero value
-// normalizes to TextIndexVersionV1 until v2 roots are implemented by the text v2
-// stack. TextIndexVersionV2 is reserved by the M0 contract and currently fails
-// closed during metadata validation rather than silently falling back to v1.
+// normalizes to TextIndexVersionV1. TextIndexVersionV2 is an explicit opt-in to
+// the B-tree-native root format; unsupported v2 read/rollout behavior fails
+// closed rather than silently falling back to v1.
 type TextIndexVersion string
 
 const (
@@ -86,7 +86,7 @@ func normalizeTextIndexVersion(version TextIndexVersion) (TextIndexVersion, erro
 	case TextIndexVersionDefault, TextIndexVersionV1:
 		return TextIndexVersionV1, nil
 	case TextIndexVersionV2:
-		return "", fmt.Errorf("%w: text index version %q is reserved until text v2 roots land", ErrTextIndexUnavailable, version)
+		return TextIndexVersionV2, nil
 	default:
 		return "", fmt.Errorf("unsupported text index version %q", version)
 	}
@@ -198,6 +198,15 @@ func findTextIndex(indexes []TextIndexDefinition, name string) (TextIndexDefinit
 	return TextIndexDefinition{}, false
 }
 
+func rejectCreateCollectionTextV2Indexes(meta CollectionMeta) error {
+	for _, idx := range meta.TextIndexes {
+		if idx.Version == TextIndexVersionV2 {
+			return fmt.Errorf("%w: CreateCollection with text index version %q requires CreateTextIndex so v2 root descriptors and status records are published atomically", ErrTextIndexUnavailable, idx.Version)
+		}
+	}
+	return nil
+}
+
 func collectionTextIndexRootName(collection, indexName string) string {
 	return collection + "/text-index/" + indexName
 }
@@ -216,6 +225,22 @@ func collectionTextRootNames(collection, indexName string) []string {
 		collectionTextStateRootName(collection, indexName),
 		collectionTextStatsRootName(collection, indexName),
 	}
+}
+
+func collectionTextRootNamesForDefinition(collection string, def TextIndexDefinition) []string {
+	version := def.Version
+	if version == TextIndexVersionDefault {
+		version = TextIndexVersionV1
+	}
+	if version == TextIndexVersionV2 {
+		return collectionTextV2RootNames(collection, def.Name)
+	}
+	return collectionTextRootNames(collection, def.Name)
+}
+
+func collectionTextAllRootNames(collection, indexName string) []string {
+	roots := collectionTextRootNames(collection, indexName)
+	return append(roots, collectionTextV2RootNames(collection, indexName)...)
 }
 
 func collectionTextV2DocIDRootName(collection, indexName string) string {
@@ -330,14 +355,21 @@ func textIndexStatusForDefinition(collection string, def TextIndexDefinition) Te
 		RewriteMergeState:       TextIndexRewriteMergeStateNotApplicable,
 		PhysicalReclamationPath: TextIndexPhysicalReclamationTreeDB,
 	}
-	if version != TextIndexVersionV1 {
-		status.FailClosed = true
-		status.FailClosedReason = "text_index_version_unavailable"
-		return status
-	}
 	if rollout != TextIndexRolloutPrimary {
 		status.FailClosed = true
 		status.FailClosedReason = "text_index_rollout_mode_unavailable"
+		return status
+	}
+	if version == TextIndexVersionV2 {
+		status.Ready = true
+		status.FailClosed = true
+		status.FailClosedReason = "text_v2_search_unavailable"
+		status.ActiveRootNames = collectionTextV2RootNames(collection, def.Name)
+		return status
+	}
+	if version != TextIndexVersionV1 {
+		status.FailClosed = true
+		status.FailClosedReason = "text_index_version_unavailable"
 		return status
 	}
 	status.Ready = true

--- a/TreeDB/collections/text_index_test.go
+++ b/TreeDB/collections/text_index_test.go
@@ -144,9 +144,9 @@ func TestCollectionTextIndexMetadataRejectsInvalidDefinitions(t *testing.T) {
 			want: "store_offsets requires store_positions",
 		},
 		{
-			name: "v2 version reserved fail closed",
-			meta: CollectionMeta{Name: "docs", TextIndexes: []TextIndexDefinition{{Name: "text", Version: TextIndexVersionV2, Fields: []TextIndexField{{Field: "body"}}}}},
-			want: "text index version \"v2\" is reserved",
+			name: "bad version",
+			meta: CollectionMeta{Name: "docs", TextIndexes: []TextIndexDefinition{{Name: "text", Version: TextIndexVersion("v3"), Fields: []TextIndexField{{Field: "body"}}}}},
+			want: "unsupported text index version",
 		},
 		{
 			name: "shadow rollout reserved fail closed",
@@ -257,9 +257,12 @@ func TestCollectionTextV2RootNamesAndStatusContract2623(t *testing.T) {
 			t.Fatalf("required counters=%q missing %q", status.RequiredCounterNames, want)
 		}
 	}
-	unsupported := textIndexStatusForDefinition("docs", TextIndexDefinition{Name: "lexical", Version: TextIndexVersionV2, Rollout: TextIndexRolloutPrimary})
-	if !unsupported.FailClosed || unsupported.Ready || unsupported.Readable || unsupported.Writable || unsupported.FailClosedReason != "text_index_version_unavailable" {
-		t.Fatalf("unsupported status=%+v want fail-closed v2", unsupported)
+	v2Status := textIndexStatusForDefinition("docs", TextIndexDefinition{Name: "lexical", Version: TextIndexVersionV2, Rollout: TextIndexRolloutPrimary})
+	if !v2Status.FailClosed || !v2Status.Ready || v2Status.Readable || v2Status.Writable || v2Status.FailClosedReason != "text_v2_search_unavailable" {
+		t.Fatalf("v2 status=%+v want root-ready/full-search-write-fail-closed v2", v2Status)
+	}
+	if !slices.Equal(v2Status.ActiveRootNames, wantV2) {
+		t.Fatalf("v2 active roots=%q want %q", v2Status.ActiveRootNames, wantV2)
 	}
 }
 
@@ -332,7 +335,7 @@ func TestCollectionTextIndexStatusUsesCurrentCatalog2623(t *testing.T) {
 }
 
 func TestCollectionTextRootStoragePolicies(t *testing.T) {
-	meta, err := normalizeCollectionMeta(CollectionMeta{
+	metaV1, err := normalizeCollectionMeta(CollectionMeta{
 		Name: "docs",
 		Options: CollectionOptions{
 			IndexStateStoragePolicy: RootStorageFast,
@@ -344,32 +347,69 @@ func TestCollectionTextRootStoragePolicies(t *testing.T) {
 		}},
 	})
 	if err != nil {
-		t.Fatalf("normalize metadata: %v", err)
+		t.Fatalf("normalize v1 metadata: %v", err)
+	}
+	metaV2, err := normalizeCollectionMeta(CollectionMeta{
+		Name: "docs",
+		Options: CollectionOptions{
+			IndexStateStoragePolicy: RootStorageFast,
+		},
+		TextIndexes: []TextIndexDefinition{{
+			Name:          "lexical",
+			Version:       TextIndexVersionV2,
+			Fields:        []TextIndexField{{Field: "body"}},
+			StoragePolicy: RootStorageCompressed,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("normalize v2 metadata: %v", err)
 	}
 	cases := []struct {
 		name string
+		meta CollectionMeta
 		root string
 		want backenddb.OrderedRootStoragePolicy
 	}{
 		{
 			name: "postings honor text index storage policy",
+			meta: metaV1,
 			root: collectionTextIndexRootName("docs", "lexical"),
 			want: backenddb.OrderedRootStorageValueLogLeaves,
 		},
 		{
 			name: "state uses index state storage policy",
+			meta: metaV1,
 			root: collectionTextStateRootName("docs", "lexical"),
 			want: backenddb.OrderedRootStoragePagerLeaves,
 		},
 		{
 			name: "stats uses index state storage policy",
+			meta: metaV1,
 			root: collectionTextStatsRootName("docs", "lexical"),
+			want: backenddb.OrderedRootStoragePagerLeaves,
+		},
+		{
+			name: "v2 docmap honors text index storage policy",
+			meta: metaV2,
+			root: collectionTextV2DocMapRootName("docs", "lexical"),
+			want: backenddb.OrderedRootStorageValueLogLeaves,
+		},
+		{
+			name: "v2 norm blocks honor text index storage policy",
+			meta: metaV2,
+			root: collectionTextV2NormBlocksRootName("docs", "lexical"),
+			want: backenddb.OrderedRootStorageValueLogLeaves,
+		},
+		{
+			name: "v2 generations use index state storage policy",
+			meta: metaV2,
+			root: collectionTextV2GenerationsRootName("docs", "lexical"),
 			want: backenddb.OrderedRootStoragePagerLeaves,
 		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := collectionRootStoragePolicyForDB(nil, meta, tc.root)
+			got, err := collectionRootStoragePolicyForDB(nil, tc.meta, tc.root)
 			if err != nil {
 				t.Fatalf("collectionRootStoragePolicyForDB(%q): %v", tc.root, err)
 			}
@@ -378,8 +418,11 @@ func TestCollectionTextRootStoragePolicies(t *testing.T) {
 			}
 		})
 	}
-	if _, err := collectionRootStoragePolicyForDB(nil, meta, collectionTextIndexRootName("docs", "missing")); err == nil || !strings.Contains(err.Error(), "unknown collection root") {
+	if _, err := collectionRootStoragePolicyForDB(nil, metaV1, collectionTextIndexRootName("docs", "missing")); err == nil || !strings.Contains(err.Error(), "unknown collection root") {
 		t.Fatalf("missing text root err=%v want unknown collection root", err)
+	}
+	if _, err := collectionRootStoragePolicyForDB(nil, metaV1, collectionTextV2DocMapRootName("docs", "lexical")); err == nil || !strings.Contains(err.Error(), "unknown collection root") {
+		t.Fatalf("v1 v2-root policy err=%v want unknown collection root", err)
 	}
 }
 

--- a/TreeDB/collections/text_maintenance.go
+++ b/TreeDB/collections/text_maintenance.go
@@ -77,6 +77,9 @@ func appendSingleTextIndexMutationDeltas(
 	policies *[]backenddb.OrderedRootStoragePolicy,
 	deltaTables *[]memtable.Table,
 ) error {
+	if def.Version == TextIndexVersionV2 {
+		return appendSingleTextV2IndexMutationDeltas(snap, catalog, opts, def, mutations, rootNames, baseRootIDs, policies, deltaTables)
+	}
 	postingsRootName := collectionTextIndexRootName(catalog.meta.Name, def.Name)
 	stateRootName := collectionTextStateRootName(catalog.meta.Name, def.Name)
 	statsRootName := collectionTextStatsRootName(catalog.meta.Name, def.Name)
@@ -146,6 +149,391 @@ func appendTextRootDelta(rootNames *[]string, baseRootIDs map[string]uint64, pol
 	baseRootIDs[rootName] = baseRootID
 	*policies = append(*policies, policy)
 	*deltaTables = append(*deltaTables, table)
+}
+
+func appendSingleTextV2IndexMutationDeltas(
+	snap *backenddb.Snapshot,
+	catalog *collectionCatalog,
+	opts collectionOptions,
+	def TextIndexDefinition,
+	mutations []textDocumentMutation,
+	rootNames *[]string,
+	baseRootIDs map[string]uint64,
+	policies *[]backenddb.OrderedRootStoragePolicy,
+	deltaTables *[]memtable.Table,
+) error {
+	generationsRootName := collectionTextV2GenerationsRootName(catalog.meta.Name, def.Name)
+	status, ok, err := readTextV2StatusAtRoot(snap, catalog, generationsRootName)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return errMalformedTextStorage("missing text-v2 status for collection %q index %q", catalog.meta.Name, def.Name)
+	}
+	orderedMutations := append([]textDocumentMutation(nil), mutations...)
+	sort.Slice(orderedMutations, func(i, j int) bool {
+		return bytes.Compare(orderedMutations[i].documentID, orderedMutations[j].documentID) < 0
+	})
+
+	docIDRootName := collectionTextV2DocIDRootName(catalog.meta.Name, def.Name)
+	docMapRootName := collectionTextV2DocMapRootName(catalog.meta.Name, def.Name)
+	termsRootName := collectionTextV2TermsRootName(catalog.meta.Name, def.Name)
+	normRootName := collectionTextV2NormBlocksRootName(catalog.meta.Name, def.Name)
+	docIDTable := newCollectionRunTable(len(orderedMutations))
+	docMapTable := newCollectionRunTable(0)
+	termsTable := newCollectionRunTable(0)
+	normTable := newCollectionRunTable(0)
+	generationsTable := newCollectionRunTable(1)
+	deltaOwned := []memtable.Table{docIDTable, docMapTable, termsTable, normTable, generationsTable}
+	success := false
+	defer func() {
+		if !success {
+			resetCollectionTables(deltaOwned)
+		}
+	}()
+
+	docMapBlocks := make(map[uint64]*textV2DocMapBlockValue)
+	normBlocks := make(map[uint64]*textV2NormBlockValue)
+	statsDelta := textStatsDelta{}
+	nextOrdinal := status.NextOrdinal
+	liveDocuments := status.LiveDocuments
+	deletedDocuments := status.DeletedDocuments
+	nextGeneration := status.RootGeneration + 1
+	if nextGeneration == 0 {
+		return errMalformedTextStorage("text-v2 root generation overflow")
+	}
+
+	for _, mutation := range orderedMutations {
+		if len(mutation.documentID) == 0 {
+			return errors.New("collections: text-v2 index maintenance document id cannot be empty")
+		}
+		current, hasCurrent, err := readTextV2DocIDAtRoot(snap, catalog, docIDRootName, mutation.documentID)
+		if err != nil {
+			return err
+		}
+
+		var oldState textDocumentStateValue
+		var newState textDocumentStateValue
+		if mutation.deleteOld {
+			if !hasCurrent || current.tombstoned() {
+				return errMalformedTextStorage("missing live text-v2 ordinal for delete collection %q index %q document %q", catalog.meta.Name, def.Name, string(mutation.documentID))
+			}
+			oldDocument, err := loadTextV2StoredDocumentForMutation(snap, catalog, mutation.documentID, mutation.oldDocument)
+			if err != nil {
+				return err
+			}
+			oldState, err = analyzeTextIndexStoredDocument(def, oldDocument, opts)
+			if err != nil {
+				return err
+			}
+		}
+		if mutation.setNew {
+			newState, _, err = analyzeTextIndexStoredDocumentWithAnalysis(def, mutation.newDocument, opts)
+			if err != nil {
+				return err
+			}
+		}
+
+		var nextDoc textV2DocIDValue
+		switch {
+		case mutation.deleteOld && mutation.setNew:
+			nextDoc = textV2DocIDValue{Ordinal: current.Ordinal, Generation: current.Generation + 1}
+			if nextDoc.Generation == 0 {
+				return errMalformedTextStorage("text-v2 generation overflow for document %q", string(mutation.documentID))
+			}
+			statsDelta.addState(oldState, -1)
+			statsDelta.addState(newState, 1)
+		case mutation.deleteOld:
+			nextDoc = textV2DocIDValue{Ordinal: current.Ordinal, Generation: current.Generation + 1, Flags: textV2DocFlagTombstone}
+			if nextDoc.Generation == 0 {
+				return errMalformedTextStorage("text-v2 generation overflow for document %q", string(mutation.documentID))
+			}
+			statsDelta.addState(oldState, -1)
+			if liveDocuments == 0 {
+				return errMalformedTextStorage("text-v2 live document underflow")
+			}
+			liveDocuments--
+			deletedDocuments++
+		case mutation.setNew:
+			if hasCurrent && !current.tombstoned() {
+				return errMalformedTextStorage("live text-v2 ordinal already exists for insert collection %q index %q document %q", catalog.meta.Name, def.Name, string(mutation.documentID))
+			}
+			nextDoc = textV2DocIDValue{Ordinal: nextOrdinal, Generation: 1}
+			if nextDoc.Ordinal == 0 {
+				return errMalformedTextStorage("text-v2 ordinal overflow")
+			}
+			nextOrdinal++
+			if nextOrdinal == 0 {
+				return errMalformedTextStorage("text-v2 next ordinal overflow")
+			}
+			statsDelta.addState(newState, 1)
+			liveDocuments++
+		default:
+			continue
+		}
+
+		docIDTable.SetSteal(encodeTextV2DocIDKey(mutation.documentID), encodeTextV2DocIDValue(nextDoc))
+		if err := upsertTextV2DocMapMutation(snap, catalog, docMapRootName, docMapBlocks, nextDoc, mutation.documentID); err != nil {
+			return err
+		}
+		lengths := textV2FieldLengthsFromState(def, newState)
+		if nextDoc.tombstoned() {
+			lengths = textV2FieldLengthsFromState(def, oldState)
+		}
+		if err := upsertTextV2NormMutation(snap, catalog, normRootName, normBlocks, nextDoc, lengths); err != nil {
+			return err
+		}
+	}
+
+	for _, blockStart := range sortedTextV2BlockStarts(docMapBlocks) {
+		block := docMapBlocks[blockStart]
+		docMapTable.SetSteal(encodeTextV2BlockKey(blockStart), encodeTextV2DocMapBlockValue(*block))
+	}
+	for _, blockStart := range sortedTextV2BlockStarts(normBlocks) {
+		block := normBlocks[blockStart]
+		normTable.SetSteal(encodeTextV2BlockKey(blockStart), encodeTextV2NormBlockValue(*block))
+	}
+	if err := buildTextV2StatsDeltaTable(snap, catalog, def, termsRootName, statsDelta, nextGeneration, termsTable); err != nil {
+		return err
+	}
+	nextStatus := textV2IndexStatusValue{
+		FormatVersion:    textV2FormatVersion,
+		RootGeneration:   nextGeneration,
+		StatsGeneration:  nextGeneration,
+		DocMapGeneration: nextGeneration,
+		NormGeneration:   nextGeneration,
+		TermGeneration:   nextGeneration,
+		NextOrdinal:      nextOrdinal,
+		LiveDocuments:    liveDocuments,
+		DeletedDocuments: deletedDocuments,
+	}
+	generationsTable.SetSteal(encodeTextV2StatusKey(), encodeTextV2IndexStatusValue(nextStatus))
+
+	appendIfNonEmpty := func(rootName string, table memtable.Table) error {
+		if table == nil || table.Len() == 0 {
+			return nil
+		}
+		table.Freeze()
+		policy, err := collectionRootStoragePolicyForDB(nil, catalog.meta, rootName)
+		if err != nil {
+			return err
+		}
+		appendTextRootDelta(rootNames, baseRootIDs, policies, deltaTables, rootName, catalog.rootID(rootName), policy, table)
+		return nil
+	}
+	if err := appendIfNonEmpty(docIDRootName, docIDTable); err != nil {
+		return err
+	}
+	if err := appendIfNonEmpty(docMapRootName, docMapTable); err != nil {
+		return err
+	}
+	if err := appendIfNonEmpty(termsRootName, termsTable); err != nil {
+		return err
+	}
+	if err := appendIfNonEmpty(normRootName, normTable); err != nil {
+		return err
+	}
+	if err := appendIfNonEmpty(generationsRootName, generationsTable); err != nil {
+		return err
+	}
+	success = true
+	return nil
+}
+
+func readTextV2DocIDAtRoot(snap *backenddb.Snapshot, catalog *collectionCatalog, rootName string, documentID []byte) (textV2DocIDValue, bool, error) {
+	raw, ok, err := collectionGetAppendAtCatalogRoot(snap, catalog, rootName, encodeTextV2DocIDKey(documentID), nil)
+	if err != nil || !ok {
+		return textV2DocIDValue{}, ok, err
+	}
+	value, err := decodeTextV2DocIDValue(raw)
+	return value, true, err
+}
+
+func loadTextV2StoredDocumentForMutation(snap *backenddb.Snapshot, catalog *collectionCatalog, documentID, fallback []byte) ([]byte, error) {
+	if fallback != nil {
+		return fallback, nil
+	}
+	primaryRootName := collectionPrimaryRootName(catalog.meta.Name)
+	if catalog.primaryRootName != "" {
+		primaryRootName = catalog.primaryRootName
+	}
+	raw, ok, err := collectionGetAppendAtCatalogRoot(snap, catalog, primaryRootName, documentID, nil)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, errMalformedTextStorage("missing primary document for text-v2 mutation document %q", string(documentID))
+	}
+	return raw, nil
+}
+
+func upsertTextV2DocMapMutation(snap *backenddb.Snapshot, catalog *collectionCatalog, rootName string, blocks map[uint64]*textV2DocMapBlockValue, doc textV2DocIDValue, documentID []byte) error {
+	blockStart := textV2OrdinalBlockStart(doc.Ordinal, textV2DefaultDocMapBlockSize)
+	block, err := loadTextV2DocMapMutationBlock(snap, catalog, rootName, blocks, blockStart)
+	if err != nil {
+		return err
+	}
+	block.upsert(textV2DocMapEntry{Ordinal: doc.Ordinal, Generation: doc.Generation, Flags: doc.Flags, DocumentID: documentID})
+	return nil
+}
+
+func loadTextV2DocMapMutationBlock(snap *backenddb.Snapshot, catalog *collectionCatalog, rootName string, blocks map[uint64]*textV2DocMapBlockValue, blockStart uint64) (*textV2DocMapBlockValue, error) {
+	if block := blocks[blockStart]; block != nil {
+		return block, nil
+	}
+	block := &textV2DocMapBlockValue{BlockStart: blockStart, BlockSize: textV2DefaultDocMapBlockSize}
+	raw, ok, err := collectionGetAppendAtCatalogRoot(snap, catalog, rootName, encodeTextV2BlockKey(blockStart), nil)
+	if err != nil {
+		return nil, err
+	}
+	if ok {
+		decoded, err := decodeTextV2DocMapBlockValue(raw)
+		if err != nil {
+			return nil, err
+		}
+		block = &decoded
+	}
+	blocks[blockStart] = block
+	return block, nil
+}
+
+func upsertTextV2NormMutation(snap *backenddb.Snapshot, catalog *collectionCatalog, rootName string, blocks map[uint64]*textV2NormBlockValue, doc textV2DocIDValue, fieldLengths []uint32) error {
+	blockStart := textV2OrdinalBlockStart(doc.Ordinal, textV2DefaultNormBlockSize)
+	block, err := loadTextV2NormMutationBlock(snap, catalog, rootName, blocks, blockStart, uint32(len(fieldLengths)))
+	if err != nil {
+		return err
+	}
+	block.upsert(textV2NormBlockEntry{Ordinal: doc.Ordinal, Generation: doc.Generation, Flags: doc.Flags, FieldLengths: fieldLengths})
+	return nil
+}
+
+func loadTextV2NormMutationBlock(snap *backenddb.Snapshot, catalog *collectionCatalog, rootName string, blocks map[uint64]*textV2NormBlockValue, blockStart uint64, fieldCount uint32) (*textV2NormBlockValue, error) {
+	if block := blocks[blockStart]; block != nil {
+		return block, nil
+	}
+	block := &textV2NormBlockValue{BlockStart: blockStart, BlockSize: textV2DefaultNormBlockSize, FieldCount: fieldCount}
+	raw, ok, err := collectionGetAppendAtCatalogRoot(snap, catalog, rootName, encodeTextV2BlockKey(blockStart), nil)
+	if err != nil {
+		return nil, err
+	}
+	if ok {
+		decoded, err := decodeTextV2NormBlockValue(raw)
+		if err != nil {
+			return nil, err
+		}
+		block = &decoded
+	}
+	blocks[blockStart] = block
+	return block, nil
+}
+
+func textV2FieldLengthsFromState(def TextIndexDefinition, state textDocumentStateValue) []uint32 {
+	byField := make(map[string]uint32, len(state.Fields))
+	for _, field := range state.Fields {
+		byField[field.Field] = field.Length
+	}
+	lengths := make([]uint32, 0, len(def.Fields))
+	for _, field := range def.Fields {
+		lengths = append(lengths, byField[field.Field])
+	}
+	return lengths
+}
+
+func buildTextV2StatsDeltaTable(snap *backenddb.Snapshot, catalog *collectionCatalog, def TextIndexDefinition, rootName string, delta textStatsDelta, generation uint64, table memtable.Table) error {
+	if table == nil {
+		return nil
+	}
+	currentCorpus, err := readTextV2CorpusStatsAtRoot(snap, catalog, rootName)
+	if err != nil {
+		return err
+	}
+	nextDocuments, err := applySignedTextDelta(currentCorpus.DocumentCount, delta.Documents, "text-v2 corpus document count")
+	if err != nil {
+		return err
+	}
+	table.SetSteal(encodeTextV2CorpusStatsKey(), encodeTextV2CorpusStatsValue(textV2CorpusStatsValue{StatsGeneration: generation, DocumentCount: nextDocuments}))
+
+	for _, fieldDef := range def.Fields {
+		field := fieldDef.Field
+		current, err := readTextV2FieldStatsAtRoot(snap, catalog, rootName, field)
+		if err != nil {
+			return err
+		}
+		fieldDelta := delta.Fields[field]
+		docs, err := applySignedTextDelta(current.DocumentCount, fieldDelta.DocumentCount, "text-v2 field document count")
+		if err != nil {
+			return err
+		}
+		tokens, err := applySignedTextDelta(current.TotalTokenCount, fieldDelta.TotalTokenCount, "text-v2 field token count")
+		if err != nil {
+			return err
+		}
+		table.SetSteal(encodeTextV2FieldStatsKey(field), encodeTextV2FieldStatsValue(textV2FieldStatsValue{StatsGeneration: generation, DocumentCount: docs, TotalTokenCount: tokens}))
+	}
+
+	terms := make([]string, 0, len(delta.Terms))
+	for term, termDelta := range delta.Terms {
+		if termDelta.DocumentFrequency == 0 && termDelta.TotalTermFrequency == 0 {
+			continue
+		}
+		terms = append(terms, term)
+	}
+	sort.Strings(terms)
+	for _, term := range terms {
+		termDelta := delta.Terms[term]
+		current, err := readTextV2TermStatsAtRoot(snap, catalog, rootName, term)
+		if err != nil {
+			return err
+		}
+		df, err := applySignedTextDelta(current.DocumentFrequency, termDelta.DocumentFrequency, "text-v2 term document frequency")
+		if err != nil {
+			return err
+		}
+		tf, err := applySignedTextDelta(current.TotalTermFrequency, termDelta.TotalTermFrequency, "text-v2 term total frequency")
+		if err != nil {
+			return err
+		}
+		key := encodeTextV2TermStatsKey(term)
+		if df == 0 && tf == 0 {
+			table.DeleteSteal(key)
+		} else {
+			table.SetSteal(key, encodeTextV2TermStatsValue(textV2TermStatsValue{StatsGeneration: generation, DocumentFrequency: df, TotalTermFrequency: tf, PostingBlockCount: current.PostingBlockCount}))
+		}
+	}
+	return nil
+}
+
+func readTextV2CorpusStatsAtRoot(snap *backenddb.Snapshot, catalog *collectionCatalog, rootName string) (textV2CorpusStatsValue, error) {
+	raw, ok, err := collectionGetAppendAtCatalogRoot(snap, catalog, rootName, encodeTextV2CorpusStatsKey(), nil)
+	if err != nil {
+		return textV2CorpusStatsValue{}, err
+	}
+	if !ok {
+		return textV2CorpusStatsValue{}, errMalformedTextStorage("missing text-v2 corpus stats in root %q", rootName)
+	}
+	return decodeTextV2CorpusStatsValue(raw)
+}
+
+func readTextV2TermStatsAtRoot(snap *backenddb.Snapshot, catalog *collectionCatalog, rootName, term string) (textV2TermStatsValue, error) {
+	raw, ok, err := collectionGetAppendAtCatalogRoot(snap, catalog, rootName, encodeTextV2TermStatsKey(term), nil)
+	if err != nil {
+		return textV2TermStatsValue{}, err
+	}
+	if !ok {
+		return textV2TermStatsValue{}, nil
+	}
+	return decodeTextV2TermStatsValue(raw)
+}
+
+func readTextV2FieldStatsAtRoot(snap *backenddb.Snapshot, catalog *collectionCatalog, rootName, field string) (textV2FieldStatsValue, error) {
+	raw, ok, err := collectionGetAppendAtCatalogRoot(snap, catalog, rootName, encodeTextV2FieldStatsKey(field), nil)
+	if err != nil {
+		return textV2FieldStatsValue{}, err
+	}
+	if !ok {
+		return textV2FieldStatsValue{}, errMalformedTextStorage("missing text-v2 field stats %q in root %q", field, rootName)
+	}
+	return decodeTextV2FieldStatsValue(raw)
 }
 
 func analyzeTextIndexStoredDocument(def TextIndexDefinition, document []byte, opts collectionOptions) (textDocumentStateValue, error) {

--- a/TreeDB/collections/text_search.go
+++ b/TreeDB/collections/text_search.go
@@ -29,6 +29,7 @@ const (
 	textSearchFailClosedPostingsLimit  = "postings_scan_limit_exceeded"
 	textSearchFailClosedStorageCorrupt = "text_index_storage_corrupt"
 	textSearchFailClosedDocumentFetch  = "document_fetch_unavailable"
+	textSearchFailClosedV2Unavailable  = "text_v2_search_unavailable"
 )
 
 const (
@@ -228,6 +229,9 @@ func (c *Collection) searchText(opts TextSearchOptions, resultMode textSearchRes
 		return response, ErrIndexNotFound
 	}
 	response.IndexName = idx.Name
+	if idx.Version == TextIndexVersionV2 {
+		return textSearchFailClosed(response, textSearchFailClosedV2Unavailable, ErrTextIndexUnavailable)
+	}
 
 	terms, operator, err := parseTextSearchQuery(idx.Analyzer, opts.Query, opts.Operator)
 	if err != nil {

--- a/TreeDB/collections/text_v2_storage.go
+++ b/TreeDB/collections/text_v2_storage.go
@@ -1,0 +1,857 @@
+package collections
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"slices"
+)
+
+const (
+	textV2FormatVersion uint32 = 1
+
+	textV2KeyVersion byte = 2
+
+	textV2RootFormatValueVersion byte = 1
+	textV2StatusValueVersion     byte = 1
+	textV2DocIDValueVersion      byte = 1
+	textV2DocMapValueVersion     byte = 1
+	textV2NormBlockValueVersion  byte = 1
+	textV2StatsValueVersion      byte = 1
+
+	textV2KeyKindFormat      byte = 0x00
+	textV2KeyKindStatus      byte = 0x01
+	textV2KeyKindCorpusStats byte = 0x02
+	textV2KeyKindFieldStats  byte = 0x03
+	textV2KeyKindTermStats   byte = 0x04
+	textV2KeyKindDocID       byte = 0x10
+	textV2KeyKindBlock       byte = 0x20
+
+	textV2DefaultDocMapBlockSize uint32 = 128
+	textV2DefaultNormBlockSize   uint32 = 128
+
+	textV2DocFlagTombstone byte = 1 << 0
+)
+
+type textV2RootFamily byte
+
+const (
+	textV2RootFamilyDocID textV2RootFamily = iota + 1
+	textV2RootFamilyDocMap
+	textV2RootFamilyTerms
+	textV2RootFamilyPostingBlocks
+	textV2RootFamilyNormBlocks
+	textV2RootFamilyPositions
+	textV2RootFamilyGenerations
+)
+
+func (f textV2RootFamily) String() string {
+	switch f {
+	case textV2RootFamilyDocID:
+		return "docid"
+	case textV2RootFamilyDocMap:
+		return "docmap"
+	case textV2RootFamilyTerms:
+		return "terms"
+	case textV2RootFamilyPostingBlocks:
+		return "posting_blocks"
+	case textV2RootFamilyNormBlocks:
+		return "norm_blocks"
+	case textV2RootFamilyPositions:
+		return "positions"
+	case textV2RootFamilyGenerations:
+		return "generations"
+	default:
+		return fmt.Sprintf("unknown(%d)", byte(f))
+	}
+}
+
+func textV2RootFamilyForName(collection, indexName, rootName string) (textV2RootFamily, bool) {
+	switch rootName {
+	case collectionTextV2DocIDRootName(collection, indexName):
+		return textV2RootFamilyDocID, true
+	case collectionTextV2DocMapRootName(collection, indexName):
+		return textV2RootFamilyDocMap, true
+	case collectionTextV2TermsRootName(collection, indexName):
+		return textV2RootFamilyTerms, true
+	case collectionTextV2PostingBlocksRootName(collection, indexName):
+		return textV2RootFamilyPostingBlocks, true
+	case collectionTextV2NormBlocksRootName(collection, indexName):
+		return textV2RootFamilyNormBlocks, true
+	case collectionTextV2PositionsRootName(collection, indexName):
+		return textV2RootFamilyPositions, true
+	case collectionTextV2GenerationsRootName(collection, indexName):
+		return textV2RootFamilyGenerations, true
+	default:
+		return 0, false
+	}
+}
+
+type textV2RootFormatValue struct {
+	FormatVersion   uint32
+	Family          textV2RootFamily
+	DocMapBlockSize uint32
+	NormBlockSize   uint32
+	Fields          []string
+}
+
+type textV2IndexStatusValue struct {
+	FormatVersion    uint32
+	RootGeneration   uint64
+	StatsGeneration  uint64
+	DocMapGeneration uint64
+	NormGeneration   uint64
+	TermGeneration   uint64
+	NextOrdinal      uint64
+	LiveDocuments    uint64
+	DeletedDocuments uint64
+}
+
+type textV2DocIDValue struct {
+	Ordinal    uint64
+	Generation uint64
+	Flags      byte
+}
+
+func (v textV2DocIDValue) tombstoned() bool { return v.Flags&textV2DocFlagTombstone != 0 }
+
+type textV2DocMapBlockValue struct {
+	BlockStart uint64
+	BlockSize  uint32
+	Entries    []textV2DocMapEntry
+}
+
+type textV2DocMapEntry struct {
+	Ordinal    uint64
+	Generation uint64
+	Flags      byte
+	DocumentID []byte
+}
+
+func (e textV2DocMapEntry) tombstoned() bool { return e.Flags&textV2DocFlagTombstone != 0 }
+
+type textV2NormBlockValue struct {
+	BlockStart uint64
+	BlockSize  uint32
+	FieldCount uint32
+	Entries    []textV2NormBlockEntry
+}
+
+type textV2NormBlockEntry struct {
+	Ordinal      uint64
+	Generation   uint64
+	Flags        byte
+	FieldLengths []uint32
+}
+
+func (e textV2NormBlockEntry) tombstoned() bool { return e.Flags&textV2DocFlagTombstone != 0 }
+
+type textV2CorpusStatsValue struct {
+	StatsGeneration uint64
+	DocumentCount   uint64
+}
+
+type textV2TermStatsValue struct {
+	StatsGeneration    uint64
+	DocumentFrequency  uint64
+	TotalTermFrequency uint64
+	PostingBlockCount  uint64
+}
+
+type textV2FieldStatsValue struct {
+	StatsGeneration uint64
+	DocumentCount   uint64
+	TotalTokenCount uint64
+}
+
+type textV2StatsKey struct {
+	Kind  byte
+	Value string
+}
+
+func encodeTextV2FormatKey() []byte {
+	return []byte{textV2KeyVersion, textV2KeyKindFormat}
+}
+
+func encodeTextV2StatusKey() []byte {
+	return []byte{textV2KeyVersion, textV2KeyKindStatus}
+}
+
+func encodeTextV2DocIDKey(documentID []byte) []byte {
+	out := make([]byte, 0, 2+len(documentID))
+	out = append(out, textV2KeyVersion, textV2KeyKindDocID)
+	out = append(out, documentID...)
+	return out
+}
+
+func decodeTextV2DocIDKey(raw []byte) ([]byte, error) {
+	if len(raw) < 2 {
+		return nil, errMalformedTextStorage("short text-v2 docid key")
+	}
+	if raw[0] != textV2KeyVersion {
+		return nil, errUnsupportedTextStorageVersion("text-v2 docid key", raw[0])
+	}
+	if raw[1] != textV2KeyKindDocID {
+		return nil, errMalformedTextStorage("text-v2 docid key kind %d", raw[1])
+	}
+	if len(raw) == 2 {
+		return nil, errMalformedTextStorage("text-v2 docid key missing document id")
+	}
+	return bytes.Clone(raw[2:]), nil
+}
+
+func encodeTextV2BlockKey(blockStart uint64) []byte {
+	out := make([]byte, 10)
+	out[0] = textV2KeyVersion
+	out[1] = textV2KeyKindBlock
+	binary.BigEndian.PutUint64(out[2:], blockStart)
+	return out
+}
+
+func decodeTextV2BlockKey(raw []byte) (uint64, error) {
+	if len(raw) != 10 {
+		return 0, errMalformedTextStorage("text-v2 block key length %d", len(raw))
+	}
+	if raw[0] != textV2KeyVersion {
+		return 0, errUnsupportedTextStorageVersion("text-v2 block key", raw[0])
+	}
+	if raw[1] != textV2KeyKindBlock {
+		return 0, errMalformedTextStorage("text-v2 block key kind %d", raw[1])
+	}
+	blockStart := binary.BigEndian.Uint64(raw[2:])
+	if blockStart == 0 {
+		return 0, errMalformedTextStorage("text-v2 block key has zero block start")
+	}
+	return blockStart, nil
+}
+
+func encodeTextV2CorpusStatsKey() []byte {
+	return []byte{textV2KeyVersion, textV2KeyKindCorpusStats}
+}
+
+func encodeTextV2FieldStatsKey(field string) []byte {
+	out := []byte{textV2KeyVersion, textV2KeyKindFieldStats}
+	return appendTextString(out, field)
+}
+
+func encodeTextV2TermStatsKey(term string) []byte {
+	out := []byte{textV2KeyVersion, textV2KeyKindTermStats}
+	return appendTextString(out, term)
+}
+
+func decodeTextV2StatsKey(raw []byte) (textV2StatsKey, error) {
+	if len(raw) < 2 {
+		return textV2StatsKey{}, errMalformedTextStorage("short text-v2 stats key")
+	}
+	if raw[0] != textV2KeyVersion {
+		return textV2StatsKey{}, errUnsupportedTextStorageVersion("text-v2 stats key", raw[0])
+	}
+	key := textV2StatsKey{Kind: raw[1]}
+	cur := textCursor{buf: raw[2:]}
+	switch key.Kind {
+	case textV2KeyKindCorpusStats:
+		if cur.remaining() != 0 {
+			return textV2StatsKey{}, errMalformedTextStorage("text-v2 corpus stats key has trailing bytes")
+		}
+	case textV2KeyKindFieldStats, textV2KeyKindTermStats:
+		value, err := cur.readString()
+		if err != nil {
+			return textV2StatsKey{}, errMalformedTextStorage("text-v2 stats key value: %v", err)
+		}
+		if cur.remaining() != 0 {
+			return textV2StatsKey{}, errMalformedTextStorage("text-v2 stats key has trailing bytes")
+		}
+		key.Value = value
+	default:
+		return textV2StatsKey{}, errMalformedTextStorage("unsupported text-v2 stats key kind %d", key.Kind)
+	}
+	return key, nil
+}
+
+func encodeTextV2RootFormatValue(value textV2RootFormatValue) []byte {
+	fields := append([]string(nil), value.Fields...)
+	out := make([]byte, 0, 16+len(fields)*8)
+	out = append(out, textV2RootFormatValueVersion)
+	out = appendTextUvarint(out, uint64(value.FormatVersion))
+	out = append(out, byte(value.Family))
+	out = appendTextUvarint(out, uint64(value.DocMapBlockSize))
+	out = appendTextUvarint(out, uint64(value.NormBlockSize))
+	out = appendTextUvarint(out, uint64(len(fields)))
+	for _, field := range fields {
+		out = appendTextString(out, field)
+	}
+	return out
+}
+
+func decodeTextV2RootFormatValue(raw []byte) (textV2RootFormatValue, error) {
+	if len(raw) == 0 {
+		return textV2RootFormatValue{}, errMalformedTextStorage("empty text-v2 root format value")
+	}
+	if raw[0] != textV2RootFormatValueVersion {
+		return textV2RootFormatValue{}, errUnsupportedTextStorageVersion("text-v2 root format value", raw[0])
+	}
+	cur := textCursor{buf: raw[1:]}
+	formatVersion, err := cur.readUvarint()
+	if err != nil {
+		return textV2RootFormatValue{}, errMalformedTextStorage("text-v2 root format version: %v", err)
+	}
+	if formatVersion != uint64(textV2FormatVersion) {
+		return textV2RootFormatValue{}, errMalformedTextStorage("unsupported text-v2 format version %d", formatVersion)
+	}
+	if cur.remaining() == 0 {
+		return textV2RootFormatValue{}, errMalformedTextStorage("text-v2 root format missing family")
+	}
+	family := textV2RootFamily(cur.buf[cur.pos])
+	cur.pos++
+	docMapBlockSize, err := cur.readUvarint()
+	if err != nil {
+		return textV2RootFormatValue{}, errMalformedTextStorage("text-v2 root format docmap block size: %v", err)
+	}
+	normBlockSize, err := cur.readUvarint()
+	if err != nil {
+		return textV2RootFormatValue{}, errMalformedTextStorage("text-v2 root format norm block size: %v", err)
+	}
+	fieldCount, err := cur.readUvarint()
+	if err != nil {
+		return textV2RootFormatValue{}, errMalformedTextStorage("text-v2 root format field count: %v", err)
+	}
+	if fieldCount > uint64(cur.remaining()+1) {
+		return textV2RootFormatValue{}, errMalformedTextStorage("text-v2 root format field count too large")
+	}
+	value := textV2RootFormatValue{
+		FormatVersion:   uint32(formatVersion),
+		Family:          family,
+		DocMapBlockSize: checkedTextUint32(docMapBlockSize),
+		NormBlockSize:   checkedTextUint32(normBlockSize),
+		Fields:          make([]string, 0, fieldCount),
+	}
+	if uint64(value.DocMapBlockSize) != docMapBlockSize || value.DocMapBlockSize == 0 {
+		return textV2RootFormatValue{}, errMalformedTextStorage("text-v2 root format invalid docmap block size")
+	}
+	if uint64(value.NormBlockSize) != normBlockSize || value.NormBlockSize == 0 {
+		return textV2RootFormatValue{}, errMalformedTextStorage("text-v2 root format invalid norm block size")
+	}
+	if family < textV2RootFamilyDocID || family > textV2RootFamilyGenerations {
+		return textV2RootFormatValue{}, errMalformedTextStorage("text-v2 root format invalid family %d", byte(family))
+	}
+	for i := uint64(0); i < fieldCount; i++ {
+		field, err := cur.readString()
+		if err != nil {
+			return textV2RootFormatValue{}, errMalformedTextStorage("text-v2 root format field[%d]: %v", i, err)
+		}
+		value.Fields = append(value.Fields, field)
+	}
+	if cur.remaining() != 0 {
+		return textV2RootFormatValue{}, errMalformedTextStorage("text-v2 root format trailing bytes")
+	}
+	return value, nil
+}
+
+func encodeTextV2IndexStatusValue(value textV2IndexStatusValue) []byte {
+	out := make([]byte, 0, 80)
+	out = append(out, textV2StatusValueVersion)
+	out = appendTextUvarint(out, uint64(value.FormatVersion))
+	out = appendTextUvarint(out, value.RootGeneration)
+	out = appendTextUvarint(out, value.StatsGeneration)
+	out = appendTextUvarint(out, value.DocMapGeneration)
+	out = appendTextUvarint(out, value.NormGeneration)
+	out = appendTextUvarint(out, value.TermGeneration)
+	out = appendTextUvarint(out, value.NextOrdinal)
+	out = appendTextUvarint(out, value.LiveDocuments)
+	out = appendTextUvarint(out, value.DeletedDocuments)
+	return out
+}
+
+func decodeTextV2IndexStatusValue(raw []byte) (textV2IndexStatusValue, error) {
+	cur, err := textV2ValueCursor(raw, textV2StatusValueVersion, "status")
+	if err != nil {
+		return textV2IndexStatusValue{}, err
+	}
+	formatVersion, err := cur.readUvarint()
+	if err != nil {
+		return textV2IndexStatusValue{}, errMalformedTextStorage("text-v2 status format version: %v", err)
+	}
+	if formatVersion != uint64(textV2FormatVersion) {
+		return textV2IndexStatusValue{}, errMalformedTextStorage("unsupported text-v2 status format version %d", formatVersion)
+	}
+	rootGeneration, err := cur.readUvarint()
+	if err != nil {
+		return textV2IndexStatusValue{}, errMalformedTextStorage("text-v2 status root generation: %v", err)
+	}
+	statsGeneration, err := cur.readUvarint()
+	if err != nil {
+		return textV2IndexStatusValue{}, errMalformedTextStorage("text-v2 status stats generation: %v", err)
+	}
+	docMapGeneration, err := cur.readUvarint()
+	if err != nil {
+		return textV2IndexStatusValue{}, errMalformedTextStorage("text-v2 status docmap generation: %v", err)
+	}
+	normGeneration, err := cur.readUvarint()
+	if err != nil {
+		return textV2IndexStatusValue{}, errMalformedTextStorage("text-v2 status norm generation: %v", err)
+	}
+	termGeneration, err := cur.readUvarint()
+	if err != nil {
+		return textV2IndexStatusValue{}, errMalformedTextStorage("text-v2 status term generation: %v", err)
+	}
+	nextOrdinal, err := cur.readUvarint()
+	if err != nil {
+		return textV2IndexStatusValue{}, errMalformedTextStorage("text-v2 status next ordinal: %v", err)
+	}
+	liveDocuments, err := cur.readUvarint()
+	if err != nil {
+		return textV2IndexStatusValue{}, errMalformedTextStorage("text-v2 status live documents: %v", err)
+	}
+	deletedDocuments, err := cur.readUvarint()
+	if err != nil {
+		return textV2IndexStatusValue{}, errMalformedTextStorage("text-v2 status deleted documents: %v", err)
+	}
+	if cur.remaining() != 0 {
+		return textV2IndexStatusValue{}, errMalformedTextStorage("text-v2 status trailing bytes")
+	}
+	if rootGeneration == 0 || statsGeneration == 0 || docMapGeneration == 0 || normGeneration == 0 || termGeneration == 0 {
+		return textV2IndexStatusValue{}, errMalformedTextStorage("text-v2 status generation cannot be zero")
+	}
+	if statsGeneration > rootGeneration || docMapGeneration > rootGeneration || normGeneration > rootGeneration || termGeneration > rootGeneration {
+		return textV2IndexStatusValue{}, errMalformedTextStorage("text-v2 status component generation exceeds root generation")
+	}
+	if nextOrdinal == 0 {
+		return textV2IndexStatusValue{}, errMalformedTextStorage("text-v2 status next ordinal cannot be zero")
+	}
+	allocatedOrdinals := nextOrdinal - 1
+	if liveDocuments > allocatedOrdinals || deletedDocuments > allocatedOrdinals-liveDocuments {
+		return textV2IndexStatusValue{}, errMalformedTextStorage("text-v2 status live/deleted documents exceed allocated ordinals")
+	}
+	return textV2IndexStatusValue{
+		FormatVersion:    uint32(formatVersion),
+		RootGeneration:   rootGeneration,
+		StatsGeneration:  statsGeneration,
+		DocMapGeneration: docMapGeneration,
+		NormGeneration:   normGeneration,
+		TermGeneration:   termGeneration,
+		NextOrdinal:      nextOrdinal,
+		LiveDocuments:    liveDocuments,
+		DeletedDocuments: deletedDocuments,
+	}, nil
+}
+
+func encodeTextV2DocIDValue(value textV2DocIDValue) []byte {
+	out := make([]byte, 0, 24)
+	out = append(out, textV2DocIDValueVersion)
+	out = appendTextUvarint(out, value.Ordinal)
+	out = appendTextUvarint(out, value.Generation)
+	out = append(out, value.Flags)
+	return out
+}
+
+func decodeTextV2DocIDValue(raw []byte) (textV2DocIDValue, error) {
+	cur, err := textV2ValueCursor(raw, textV2DocIDValueVersion, "docid")
+	if err != nil {
+		return textV2DocIDValue{}, err
+	}
+	ordinal, err := cur.readUvarint()
+	if err != nil {
+		return textV2DocIDValue{}, errMalformedTextStorage("text-v2 docid ordinal: %v", err)
+	}
+	generation, err := cur.readUvarint()
+	if err != nil {
+		return textV2DocIDValue{}, errMalformedTextStorage("text-v2 docid generation: %v", err)
+	}
+	if cur.remaining() == 0 {
+		return textV2DocIDValue{}, errMalformedTextStorage("text-v2 docid missing flags")
+	}
+	flags := cur.buf[cur.pos]
+	cur.pos++
+	if cur.remaining() != 0 {
+		return textV2DocIDValue{}, errMalformedTextStorage("text-v2 docid trailing bytes")
+	}
+	if ordinal == 0 || generation == 0 {
+		return textV2DocIDValue{}, errMalformedTextStorage("text-v2 docid ordinal/generation cannot be zero")
+	}
+	if flags&^textV2DocFlagTombstone != 0 {
+		return textV2DocIDValue{}, errMalformedTextStorage("text-v2 docid unsupported flags 0x%x", flags)
+	}
+	return textV2DocIDValue{Ordinal: ordinal, Generation: generation, Flags: flags}, nil
+}
+
+func encodeTextV2DocMapBlockValue(value textV2DocMapBlockValue) []byte {
+	entries := append([]textV2DocMapEntry(nil), value.Entries...)
+	slices.SortFunc(entries, func(a, b textV2DocMapEntry) int {
+		return compareUint64(a.Ordinal, b.Ordinal)
+	})
+	out := make([]byte, 0, 24+len(entries)*24)
+	out = append(out, textV2DocMapValueVersion)
+	out = appendTextUvarint(out, value.BlockStart)
+	out = appendTextUvarint(out, uint64(value.BlockSize))
+	out = appendTextUvarint(out, uint64(len(entries)))
+	for _, entry := range entries {
+		out = appendTextUvarint(out, entry.Ordinal)
+		out = appendTextUvarint(out, entry.Generation)
+		out = append(out, entry.Flags)
+		out = appendTextBytes(out, entry.DocumentID)
+	}
+	return out
+}
+
+func decodeTextV2DocMapBlockValue(raw []byte) (textV2DocMapBlockValue, error) {
+	cur, err := textV2ValueCursor(raw, textV2DocMapValueVersion, "docmap block")
+	if err != nil {
+		return textV2DocMapBlockValue{}, err
+	}
+	blockStart, err := cur.readUvarint()
+	if err != nil {
+		return textV2DocMapBlockValue{}, errMalformedTextStorage("text-v2 docmap block start: %v", err)
+	}
+	blockSizeRaw, err := cur.readUvarint()
+	if err != nil {
+		return textV2DocMapBlockValue{}, errMalformedTextStorage("text-v2 docmap block size: %v", err)
+	}
+	entryCount, err := cur.readUvarint()
+	if err != nil {
+		return textV2DocMapBlockValue{}, errMalformedTextStorage("text-v2 docmap entry count: %v", err)
+	}
+	if entryCount > uint64(cur.remaining()+1) {
+		return textV2DocMapBlockValue{}, errMalformedTextStorage("text-v2 docmap entry count too large")
+	}
+	blockSize := checkedTextUint32(blockSizeRaw)
+	value := textV2DocMapBlockValue{BlockStart: blockStart, BlockSize: blockSize, Entries: make([]textV2DocMapEntry, 0, entryCount)}
+	if err := validateTextV2BlockHeader(blockStart, blockSizeRaw, blockSize, "docmap"); err != nil {
+		return textV2DocMapBlockValue{}, err
+	}
+	var prev uint64
+	for i := uint64(0); i < entryCount; i++ {
+		ordinal, err := cur.readUvarint()
+		if err != nil {
+			return textV2DocMapBlockValue{}, errMalformedTextStorage("text-v2 docmap entry[%d] ordinal: %v", i, err)
+		}
+		generation, err := cur.readUvarint()
+		if err != nil {
+			return textV2DocMapBlockValue{}, errMalformedTextStorage("text-v2 docmap entry[%d] generation: %v", i, err)
+		}
+		if cur.remaining() == 0 {
+			return textV2DocMapBlockValue{}, errMalformedTextStorage("text-v2 docmap entry[%d] missing flags", i)
+		}
+		flags := cur.buf[cur.pos]
+		cur.pos++
+		documentID, err := cur.readBytes()
+		if err != nil {
+			return textV2DocMapBlockValue{}, errMalformedTextStorage("text-v2 docmap entry[%d] document id: %v", i, err)
+		}
+		if err := validateTextV2BlockEntry(blockStart, blockSize, ordinal, generation, flags, prev, i, "docmap"); err != nil {
+			return textV2DocMapBlockValue{}, err
+		}
+		if len(documentID) == 0 {
+			return textV2DocMapBlockValue{}, errMalformedTextStorage("text-v2 docmap entry[%d] missing document id", i)
+		}
+		value.Entries = append(value.Entries, textV2DocMapEntry{Ordinal: ordinal, Generation: generation, Flags: flags, DocumentID: bytes.Clone(documentID)})
+		prev = ordinal
+	}
+	if cur.remaining() != 0 {
+		return textV2DocMapBlockValue{}, errMalformedTextStorage("text-v2 docmap trailing bytes")
+	}
+	return value, nil
+}
+
+func encodeTextV2NormBlockValue(value textV2NormBlockValue) []byte {
+	entries := append([]textV2NormBlockEntry(nil), value.Entries...)
+	slices.SortFunc(entries, func(a, b textV2NormBlockEntry) int {
+		return compareUint64(a.Ordinal, b.Ordinal)
+	})
+	out := make([]byte, 0, 24+len(entries)*(16+int(value.FieldCount)*2))
+	out = append(out, textV2NormBlockValueVersion)
+	out = appendTextUvarint(out, value.BlockStart)
+	out = appendTextUvarint(out, uint64(value.BlockSize))
+	out = appendTextUvarint(out, uint64(value.FieldCount))
+	out = appendTextUvarint(out, uint64(len(entries)))
+	for _, entry := range entries {
+		out = appendTextUvarint(out, entry.Ordinal)
+		out = appendTextUvarint(out, entry.Generation)
+		out = append(out, entry.Flags)
+		for _, length := range entry.FieldLengths {
+			out = appendTextUvarint(out, uint64(length))
+		}
+	}
+	return out
+}
+
+func decodeTextV2NormBlockValue(raw []byte) (textV2NormBlockValue, error) {
+	cur, err := textV2ValueCursor(raw, textV2NormBlockValueVersion, "norm block")
+	if err != nil {
+		return textV2NormBlockValue{}, err
+	}
+	blockStart, err := cur.readUvarint()
+	if err != nil {
+		return textV2NormBlockValue{}, errMalformedTextStorage("text-v2 norm block start: %v", err)
+	}
+	blockSizeRaw, err := cur.readUvarint()
+	if err != nil {
+		return textV2NormBlockValue{}, errMalformedTextStorage("text-v2 norm block size: %v", err)
+	}
+	fieldCountRaw, err := cur.readUvarint()
+	if err != nil {
+		return textV2NormBlockValue{}, errMalformedTextStorage("text-v2 norm field count: %v", err)
+	}
+	entryCount, err := cur.readUvarint()
+	if err != nil {
+		return textV2NormBlockValue{}, errMalformedTextStorage("text-v2 norm entry count: %v", err)
+	}
+	if entryCount > uint64(cur.remaining()+1) {
+		return textV2NormBlockValue{}, errMalformedTextStorage("text-v2 norm entry count too large")
+	}
+	blockSize := checkedTextUint32(blockSizeRaw)
+	fieldCount := checkedTextUint32(fieldCountRaw)
+	value := textV2NormBlockValue{BlockStart: blockStart, BlockSize: blockSize, FieldCount: fieldCount, Entries: make([]textV2NormBlockEntry, 0, entryCount)}
+	if err := validateTextV2BlockHeader(blockStart, blockSizeRaw, blockSize, "norm"); err != nil {
+		return textV2NormBlockValue{}, err
+	}
+	if uint64(fieldCount) != fieldCountRaw || fieldCount == 0 {
+		return textV2NormBlockValue{}, errMalformedTextStorage("text-v2 norm field count invalid")
+	}
+	if entryCount > 0 && fieldCountRaw > 0 && entryCount > uint64(cur.remaining())/fieldCountRaw {
+		return textV2NormBlockValue{}, errMalformedTextStorage("text-v2 norm field count exceeds remaining payload")
+	}
+	var prev uint64
+	for i := uint64(0); i < entryCount; i++ {
+		ordinal, err := cur.readUvarint()
+		if err != nil {
+			return textV2NormBlockValue{}, errMalformedTextStorage("text-v2 norm entry[%d] ordinal: %v", i, err)
+		}
+		generation, err := cur.readUvarint()
+		if err != nil {
+			return textV2NormBlockValue{}, errMalformedTextStorage("text-v2 norm entry[%d] generation: %v", i, err)
+		}
+		if cur.remaining() == 0 {
+			return textV2NormBlockValue{}, errMalformedTextStorage("text-v2 norm entry[%d] missing flags", i)
+		}
+		flags := cur.buf[cur.pos]
+		cur.pos++
+		if err := validateTextV2BlockEntry(blockStart, blockSize, ordinal, generation, flags, prev, i, "norm"); err != nil {
+			return textV2NormBlockValue{}, err
+		}
+		lengths := make([]uint32, 0, fieldCount)
+		for j := uint32(0); j < fieldCount; j++ {
+			length, err := cur.readUvarint()
+			if err != nil {
+				return textV2NormBlockValue{}, errMalformedTextStorage("text-v2 norm entry[%d] field[%d] length: %v", i, j, err)
+			}
+			if uint64(checkedTextUint32(length)) != length {
+				return textV2NormBlockValue{}, errMalformedTextStorage("text-v2 norm entry[%d] field[%d] length overflows uint32", i, j)
+			}
+			lengths = append(lengths, uint32(length))
+		}
+		value.Entries = append(value.Entries, textV2NormBlockEntry{Ordinal: ordinal, Generation: generation, Flags: flags, FieldLengths: lengths})
+		prev = ordinal
+	}
+	if cur.remaining() != 0 {
+		return textV2NormBlockValue{}, errMalformedTextStorage("text-v2 norm trailing bytes")
+	}
+	return value, nil
+}
+
+func encodeTextV2CorpusStatsValue(value textV2CorpusStatsValue) []byte {
+	out := []byte{textV2StatsValueVersion}
+	out = appendTextUvarint(out, value.StatsGeneration)
+	out = appendTextUvarint(out, value.DocumentCount)
+	return out
+}
+
+func decodeTextV2CorpusStatsValue(raw []byte) (textV2CorpusStatsValue, error) {
+	cur, err := textV2ValueCursor(raw, textV2StatsValueVersion, "corpus stats")
+	if err != nil {
+		return textV2CorpusStatsValue{}, err
+	}
+	generation, err := cur.readUvarint()
+	if err != nil {
+		return textV2CorpusStatsValue{}, errMalformedTextStorage("text-v2 corpus stats generation: %v", err)
+	}
+	documents, err := cur.readUvarint()
+	if err != nil {
+		return textV2CorpusStatsValue{}, errMalformedTextStorage("text-v2 corpus document count: %v", err)
+	}
+	if cur.remaining() != 0 {
+		return textV2CorpusStatsValue{}, errMalformedTextStorage("text-v2 corpus trailing bytes")
+	}
+	if generation == 0 {
+		return textV2CorpusStatsValue{}, errMalformedTextStorage("text-v2 corpus generation cannot be zero")
+	}
+	return textV2CorpusStatsValue{StatsGeneration: generation, DocumentCount: documents}, nil
+}
+
+func encodeTextV2TermStatsValue(value textV2TermStatsValue) []byte {
+	out := []byte{textV2StatsValueVersion}
+	out = appendTextUvarint(out, value.StatsGeneration)
+	out = appendTextUvarint(out, value.DocumentFrequency)
+	out = appendTextUvarint(out, value.TotalTermFrequency)
+	out = appendTextUvarint(out, value.PostingBlockCount)
+	return out
+}
+
+func decodeTextV2TermStatsValue(raw []byte) (textV2TermStatsValue, error) {
+	cur, err := textV2ValueCursor(raw, textV2StatsValueVersion, "term stats")
+	if err != nil {
+		return textV2TermStatsValue{}, err
+	}
+	generation, err := cur.readUvarint()
+	if err != nil {
+		return textV2TermStatsValue{}, errMalformedTextStorage("text-v2 term stats generation: %v", err)
+	}
+	df, err := cur.readUvarint()
+	if err != nil {
+		return textV2TermStatsValue{}, errMalformedTextStorage("text-v2 term document frequency: %v", err)
+	}
+	tf, err := cur.readUvarint()
+	if err != nil {
+		return textV2TermStatsValue{}, errMalformedTextStorage("text-v2 term total frequency: %v", err)
+	}
+	blocks, err := cur.readUvarint()
+	if err != nil {
+		return textV2TermStatsValue{}, errMalformedTextStorage("text-v2 term posting block count: %v", err)
+	}
+	if cur.remaining() != 0 {
+		return textV2TermStatsValue{}, errMalformedTextStorage("text-v2 term trailing bytes")
+	}
+	if generation == 0 {
+		return textV2TermStatsValue{}, errMalformedTextStorage("text-v2 term generation cannot be zero")
+	}
+	return textV2TermStatsValue{StatsGeneration: generation, DocumentFrequency: df, TotalTermFrequency: tf, PostingBlockCount: blocks}, nil
+}
+
+func encodeTextV2FieldStatsValue(value textV2FieldStatsValue) []byte {
+	out := []byte{textV2StatsValueVersion}
+	out = appendTextUvarint(out, value.StatsGeneration)
+	out = appendTextUvarint(out, value.DocumentCount)
+	out = appendTextUvarint(out, value.TotalTokenCount)
+	return out
+}
+
+func decodeTextV2FieldStatsValue(raw []byte) (textV2FieldStatsValue, error) {
+	cur, err := textV2ValueCursor(raw, textV2StatsValueVersion, "field stats")
+	if err != nil {
+		return textV2FieldStatsValue{}, err
+	}
+	generation, err := cur.readUvarint()
+	if err != nil {
+		return textV2FieldStatsValue{}, errMalformedTextStorage("text-v2 field stats generation: %v", err)
+	}
+	documents, err := cur.readUvarint()
+	if err != nil {
+		return textV2FieldStatsValue{}, errMalformedTextStorage("text-v2 field document count: %v", err)
+	}
+	tokens, err := cur.readUvarint()
+	if err != nil {
+		return textV2FieldStatsValue{}, errMalformedTextStorage("text-v2 field token count: %v", err)
+	}
+	if cur.remaining() != 0 {
+		return textV2FieldStatsValue{}, errMalformedTextStorage("text-v2 field trailing bytes")
+	}
+	if generation == 0 {
+		return textV2FieldStatsValue{}, errMalformedTextStorage("text-v2 field generation cannot be zero")
+	}
+	return textV2FieldStatsValue{StatsGeneration: generation, DocumentCount: documents, TotalTokenCount: tokens}, nil
+}
+
+func textV2ValueCursor(raw []byte, wantVersion byte, name string) (textCursor, error) {
+	if len(raw) == 0 {
+		return textCursor{}, errMalformedTextStorage("empty text-v2 %s value", name)
+	}
+	if raw[0] != wantVersion {
+		return textCursor{}, errUnsupportedTextStorageVersion("text-v2 "+name+" value", raw[0])
+	}
+	return textCursor{buf: raw[1:]}, nil
+}
+
+func validateTextV2BlockHeader(blockStart, blockSizeRaw uint64, blockSize uint32, name string) error {
+	if blockStart == 0 {
+		return errMalformedTextStorage("text-v2 %s block start cannot be zero", name)
+	}
+	if uint64(blockSize) != blockSizeRaw || blockSize == 0 {
+		return errMalformedTextStorage("text-v2 %s block size invalid", name)
+	}
+	return nil
+}
+
+func validateTextV2BlockEntry(blockStart uint64, blockSize uint32, ordinal, generation uint64, flags byte, prev uint64, entryIndex uint64, name string) error {
+	if ordinal == 0 || generation == 0 {
+		return errMalformedTextStorage("text-v2 %s entry[%d] ordinal/generation cannot be zero", name, entryIndex)
+	}
+	if flags&^textV2DocFlagTombstone != 0 {
+		return errMalformedTextStorage("text-v2 %s entry[%d] unsupported flags 0x%x", name, entryIndex, flags)
+	}
+	if ordinal < blockStart || ordinal >= blockStart+uint64(blockSize) {
+		return errMalformedTextStorage("text-v2 %s entry[%d] ordinal %d outside block [%d,%d)", name, entryIndex, ordinal, blockStart, blockStart+uint64(blockSize))
+	}
+	if entryIndex > 0 && ordinal <= prev {
+		return errMalformedTextStorage("text-v2 %s entry[%d] ordinal not strictly increasing", name, entryIndex)
+	}
+	return nil
+}
+
+func textV2OrdinalBlockStart(ordinal uint64, blockSize uint32) uint64 {
+	if ordinal == 0 || blockSize == 0 {
+		return 0
+	}
+	return ((ordinal - 1) / uint64(blockSize) * uint64(blockSize)) + 1
+}
+
+func (b *textV2DocMapBlockValue) upsert(entry textV2DocMapEntry) {
+	if b == nil {
+		return
+	}
+	entry.DocumentID = bytes.Clone(entry.DocumentID)
+	for i := range b.Entries {
+		if b.Entries[i].Ordinal == entry.Ordinal {
+			b.Entries[i] = entry
+			return
+		}
+	}
+	b.Entries = append(b.Entries, entry)
+	slices.SortFunc(b.Entries, func(a, b textV2DocMapEntry) int {
+		return compareUint64(a.Ordinal, b.Ordinal)
+	})
+}
+
+func (b textV2DocMapBlockValue) find(ordinal uint64) (textV2DocMapEntry, bool) {
+	for _, entry := range b.Entries {
+		if entry.Ordinal == ordinal {
+			return textV2DocMapEntry{Ordinal: entry.Ordinal, Generation: entry.Generation, Flags: entry.Flags, DocumentID: bytes.Clone(entry.DocumentID)}, true
+		}
+	}
+	return textV2DocMapEntry{}, false
+}
+
+func (b *textV2NormBlockValue) upsert(entry textV2NormBlockEntry) {
+	if b == nil {
+		return
+	}
+	entry.FieldLengths = append([]uint32(nil), entry.FieldLengths...)
+	for i := range b.Entries {
+		if b.Entries[i].Ordinal == entry.Ordinal {
+			b.Entries[i] = entry
+			return
+		}
+	}
+	b.Entries = append(b.Entries, entry)
+	slices.SortFunc(b.Entries, func(a, b textV2NormBlockEntry) int {
+		return compareUint64(a.Ordinal, b.Ordinal)
+	})
+}
+
+func (b textV2NormBlockValue) find(ordinal uint64) (textV2NormBlockEntry, bool) {
+	for _, entry := range b.Entries {
+		if entry.Ordinal == ordinal {
+			return textV2NormBlockEntry{Ordinal: entry.Ordinal, Generation: entry.Generation, Flags: entry.Flags, FieldLengths: append([]uint32(nil), entry.FieldLengths...)}, true
+		}
+	}
+	return textV2NormBlockEntry{}, false
+}
+
+func compareUint64(a, b uint64) int {
+	switch {
+	case a < b:
+		return -1
+	case a > b:
+		return 1
+	default:
+		return 0
+	}
+}

--- a/TreeDB/collections/text_v2_storage_test.go
+++ b/TreeDB/collections/text_v2_storage_test.go
@@ -391,6 +391,27 @@ func TestTextV2StorageFailsClosedOnVersionMismatchAndStatsNormInconsistency2624(
 	if _, err := col3.TextIndexStorageStats("lexical"); !errors.Is(err, ErrTextIndexStorageCorrupt) {
 		t.Fatalf("corrupt norm generation err=%v want ErrTextIndexStorageCorrupt", err)
 	}
+
+	d4 := openTextV2TestDB(t, t.TempDir(), false)
+	defer func() { _ = d4.Close() }()
+	mgr4 := NewCollectionManager(d4)
+	if _, err := mgr4.CreateCollection(&CollectionMeta{Name: "docs"}); err != nil {
+		t.Fatalf("CreateCollection 4: %v", err)
+	}
+	col4, err := mgr4.OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("OpenCollection 4: %v", err)
+	}
+	if _, err := col4.Insert([]byte("d1"), []byte(`{"body":"refund policy"}`)); err != nil {
+		t.Fatalf("Insert 4: %v", err)
+	}
+	if _, _, err := col4.CreateTextIndex(TextIndexDefinition{Name: "lexical", Version: TextIndexVersionV2, Fields: []TextIndexField{{Field: "body"}}}); err != nil {
+		t.Fatalf("CreateTextIndex 4: %v", err)
+	}
+	clearTextRootDescriptor2624(t, d4, collectionTextV2DocMapRootName("docs", "lexical"))
+	if _, err := col4.TextIndexStorageStats("lexical"); !errors.Is(err, ErrTextIndexStorageCorrupt) {
+		t.Fatalf("missing docmap root err=%v want ErrTextIndexStorageCorrupt", err)
+	}
 }
 
 func TestTextV2FieldStatsFailClosedOnMissingUnknownAndOutOfRange2624(t *testing.T) {
@@ -630,6 +651,23 @@ func deleteTextRootValue2624(t *testing.T, d *backenddb.DB, collection, rootName
 	}
 	if len(rootIDs) != 1 {
 		t.Fatalf("rootIDs=%d want 1", len(rootIDs))
+	}
+}
+
+func clearTextRootDescriptor2624(t *testing.T, d *backenddb.DB, rootName string) {
+	t.Helper()
+	current := d.AcquireSnapshot()
+	if current == nil {
+		t.Fatal("snapshot nil")
+	}
+	defer func() { _ = current.Close() }()
+	iter, err := buildSystemTargetIterator(current, map[string][]byte{systemCollectionRootKey(rootName): encodeRootID(0)})
+	if err != nil {
+		t.Fatalf("build cleared root descriptor %q: %v", rootName, err)
+	}
+	defer func() { _ = iter.Close() }()
+	if _, err := d.PublishSystemRootIterator(iter); err != nil {
+		t.Fatalf("publish cleared root descriptor %q: %v", rootName, err)
 	}
 }
 

--- a/TreeDB/collections/text_v2_storage_test.go
+++ b/TreeDB/collections/text_v2_storage_test.go
@@ -1,0 +1,697 @@
+package collections
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"testing"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+	"github.com/snissn/gomap/TreeDB/internal/iterator"
+)
+
+func TestTextV2StorageCodecsRoundTripAndFailClosed2624(t *testing.T) {
+	format := textV2RootFormatValue{FormatVersion: textV2FormatVersion, Family: textV2RootFamilyNormBlocks, DocMapBlockSize: textV2DefaultDocMapBlockSize, NormBlockSize: textV2DefaultNormBlockSize, Fields: []string{"body", "title"}}
+	decodedFormat, err := decodeTextV2RootFormatValue(encodeTextV2RootFormatValue(format))
+	if err != nil {
+		t.Fatalf("decode format: %v", err)
+	}
+	if decodedFormat.Family != format.Family || !slices.Equal(decodedFormat.Fields, format.Fields) {
+		t.Fatalf("format=%+v want %+v", decodedFormat, format)
+	}
+
+	status := textV2IndexStatusValue{FormatVersion: textV2FormatVersion, RootGeneration: 7, StatsGeneration: 7, DocMapGeneration: 7, NormGeneration: 7, TermGeneration: 7, NextOrdinal: 42, LiveDocuments: 39, DeletedDocuments: 2}
+	decodedStatus, err := decodeTextV2IndexStatusValue(encodeTextV2IndexStatusValue(status))
+	if err != nil {
+		t.Fatalf("decode status: %v", err)
+	}
+	if decodedStatus != status {
+		t.Fatalf("status=%+v want %+v", decodedStatus, status)
+	}
+
+	docID := []byte{'d', 0, '1'}
+	docKey := encodeTextV2DocIDKey(docID)
+	decodedDocID, err := decodeTextV2DocIDKey(docKey)
+	if err != nil || !bytes.Equal(decodedDocID, docID) {
+		t.Fatalf("docid key=%q err=%v want %q", decodedDocID, err, docID)
+	}
+	docValue := textV2DocIDValue{Ordinal: 9, Generation: 3, Flags: textV2DocFlagTombstone}
+	decodedDocValue, err := decodeTextV2DocIDValue(encodeTextV2DocIDValue(docValue))
+	if err != nil || decodedDocValue != docValue || !decodedDocValue.tombstoned() {
+		t.Fatalf("doc value=%+v err=%v want %+v", decodedDocValue, err, docValue)
+	}
+
+	blockKey := encodeTextV2BlockKey(129)
+	if blockStart, err := decodeTextV2BlockKey(blockKey); err != nil || blockStart != 129 {
+		t.Fatalf("block start=%d err=%v want 129", blockStart, err)
+	}
+	docMap := textV2DocMapBlockValue{BlockStart: 129, BlockSize: textV2DefaultDocMapBlockSize, Entries: []textV2DocMapEntry{{Ordinal: 130, Generation: 1, DocumentID: []byte("d130")}, {Ordinal: 129, Generation: 2, Flags: textV2DocFlagTombstone, DocumentID: []byte("d129")}}}
+	decodedDocMap, err := decodeTextV2DocMapBlockValue(encodeTextV2DocMapBlockValue(docMap))
+	if err != nil {
+		t.Fatalf("decode docmap: %v", err)
+	}
+	if len(decodedDocMap.Entries) != 2 || decodedDocMap.Entries[0].Ordinal != 129 || !decodedDocMap.Entries[0].tombstoned() || !bytes.Equal(decodedDocMap.Entries[1].DocumentID, []byte("d130")) {
+		t.Fatalf("docmap=%+v", decodedDocMap)
+	}
+
+	norm := textV2NormBlockValue{BlockStart: 1, BlockSize: textV2DefaultNormBlockSize, FieldCount: 2, Entries: []textV2NormBlockEntry{{Ordinal: 2, Generation: 1, FieldLengths: []uint32{3, 5}}, {Ordinal: 1, Generation: 2, Flags: textV2DocFlagTombstone, FieldLengths: []uint32{0, 0}}}}
+	decodedNorm, err := decodeTextV2NormBlockValue(encodeTextV2NormBlockValue(norm))
+	if err != nil {
+		t.Fatalf("decode norm: %v", err)
+	}
+	if len(decodedNorm.Entries) != 2 || decodedNorm.Entries[0].Ordinal != 1 || !decodedNorm.Entries[0].tombstoned() || !slices.Equal(decodedNorm.Entries[1].FieldLengths, []uint32{3, 5}) {
+		t.Fatalf("norm=%+v", decodedNorm)
+	}
+
+	corpus := textV2CorpusStatsValue{StatsGeneration: 7, DocumentCount: 39}
+	if got, err := decodeTextV2CorpusStatsValue(encodeTextV2CorpusStatsValue(corpus)); err != nil || got != corpus {
+		t.Fatalf("corpus=%+v err=%v", got, err)
+	}
+	term := textV2TermStatsValue{StatsGeneration: 7, DocumentFrequency: 11, TotalTermFrequency: 23, PostingBlockCount: 5}
+	if got, err := decodeTextV2TermStatsValue(encodeTextV2TermStatsValue(term)); err != nil || got != term {
+		t.Fatalf("term=%+v err=%v", got, err)
+	}
+	field := textV2FieldStatsValue{StatsGeneration: 7, DocumentCount: 31, TotalTokenCount: 111}
+	if got, err := decodeTextV2FieldStatsValue(encodeTextV2FieldStatsValue(field)); err != nil || got != field {
+		t.Fatalf("field=%+v err=%v", got, err)
+	}
+	for _, tc := range []struct {
+		name string
+		key  []byte
+		want textV2StatsKey
+	}{
+		{name: "corpus", key: encodeTextV2CorpusStatsKey(), want: textV2StatsKey{Kind: textV2KeyKindCorpusStats}},
+		{name: "field", key: encodeTextV2FieldStatsKey("body"), want: textV2StatsKey{Kind: textV2KeyKindFieldStats, Value: "body"}},
+		{name: "term", key: encodeTextV2TermStatsKey("refund"), want: textV2StatsKey{Kind: textV2KeyKindTermStats, Value: "refund"}},
+	} {
+		got, err := decodeTextV2StatsKey(tc.key)
+		if err != nil || got != tc.want {
+			t.Fatalf("stats key %s=%+v err=%v want %+v", tc.name, got, err, tc.want)
+		}
+	}
+
+	malformed := []struct {
+		name string
+		err  error
+	}{
+		{name: "format version", err: func() error { _, err := decodeTextV2RootFormatValue([]byte{99}); return err }()},
+		{name: "status zero generation", err: func() error {
+			raw := encodeTextV2IndexStatusValue(status)
+			raw[2] = 0
+			_, err := decodeTextV2IndexStatusValue(raw)
+			return err
+		}()},
+		{name: "status component generation exceeds root", err: func() error {
+			bad := status
+			bad.NormGeneration = bad.RootGeneration + 1
+			_, err := decodeTextV2IndexStatusValue(encodeTextV2IndexStatusValue(bad))
+			return err
+		}()},
+		{name: "docid key version", err: func() error { _, err := decodeTextV2DocIDKey([]byte{99, textV2KeyKindDocID, 'd'}); return err }()},
+		{name: "docid zero ordinal", err: func() error { _, err := decodeTextV2DocIDValue([]byte{textV2DocIDValueVersion, 0, 1, 0}); return err }()},
+		{name: "block key zero", err: func() error {
+			_, err := decodeTextV2BlockKey([]byte{textV2KeyVersion, textV2KeyKindBlock, 0, 0, 0, 0, 0, 0, 0, 0})
+			return err
+		}()},
+		{name: "docmap out of order", err: func() error {
+			_, err := decodeTextV2DocMapBlockValue([]byte{textV2DocMapValueVersion, 1, 128, 2, 2, 1, 0, 1, 'b', 1, 1, 0, 1, 'a'})
+			return err
+		}()},
+		{name: "norm truncated field lengths", err: func() error {
+			_, err := decodeTextV2NormBlockValue([]byte{textV2NormBlockValueVersion, 1, 128, 2, 1, 1, 1, 0, 3})
+			return err
+		}()},
+		{name: "norm zero field count", err: func() error {
+			_, err := decodeTextV2NormBlockValue([]byte{textV2NormBlockValueVersion, 1, 128, 0, 0})
+			return err
+		}()},
+		{name: "term zero generation", err: func() error {
+			_, err := decodeTextV2TermStatsValue([]byte{textV2StatsValueVersion, 0, 1, 1, 0})
+			return err
+		}()},
+		{name: "stats key trailing bytes", err: func() error {
+			_, err := decodeTextV2StatsKey([]byte{textV2KeyVersion, textV2KeyKindCorpusStats, 1})
+			return err
+		}()},
+	}
+	for _, tc := range malformed {
+		t.Run(tc.name, func(t *testing.T) {
+			if !errors.Is(tc.err, ErrTextIndexStorageCorrupt) {
+				t.Fatalf("err=%v want ErrTextIndexStorageCorrupt", tc.err)
+			}
+		})
+	}
+}
+
+func TestCreateCollectionRejectsInlineTextV2MetadataWithoutRootState2624(t *testing.T) {
+	d := openTextV2TestDB(t, t.TempDir(), false)
+	defer func() { _ = d.Close() }()
+	_, err := NewCollectionManager(d).CreateCollection(&CollectionMeta{
+		Name: "docs",
+		TextIndexes: []TextIndexDefinition{{
+			Name:    "lexical",
+			Version: TextIndexVersionV2,
+			Fields:  []TextIndexField{{Field: "body"}},
+		}},
+	})
+	if !errors.Is(err, ErrTextIndexUnavailable) {
+		t.Fatalf("CreateCollection v2 metadata err=%v want ErrTextIndexUnavailable", err)
+	}
+}
+
+func TestCollectionCreateTextV2IndexBackfillsOrdinalsNormsStatsAndReopens2624(t *testing.T) {
+	dir := t.TempDir()
+	d := openTextV2TestDB(t, dir, false)
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "docs"}); err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	col, err := mgr.OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("OpenCollection: %v", err)
+	}
+	ids := [][]byte{[]byte("d2"), []byte("d1"), []byte("d3")}
+	docs := [][]byte{
+		[]byte(`{"body":"shipping policy","title":"Other"}`),
+		[]byte(`{"body":"refund failed refund","title":"Refund Policy"}`),
+		[]byte(`{"body":"---","title":"Empty"}`),
+	}
+	if _, err := col.InsertBatch(ids, docs); err != nil {
+		t.Fatalf("InsertBatch: %v", err)
+	}
+	_, backfill, err := col.CreateTextIndex(TextIndexDefinition{Name: "lexical", Version: TextIndexVersionV2, Fields: []TextIndexField{{Field: "body"}, {Field: "title", Weight: 2}}, StoragePolicy: RootStorageFast})
+	if err != nil {
+		t.Fatalf("CreateTextIndex v2: %v", err)
+	}
+	if backfill.DocumentsScanned != 3 || backfill.V2DocIDEntries != 3 || backfill.V2DocMapBlocks != 1 || backfill.V2NormBlocks != 1 || backfill.V2StatusRecords != 1 || backfill.V2FormatRecords != 7 || backfill.V2NextOrdinal != 4 {
+		t.Fatalf("backfill=%+v want v2 roots/docs/next ordinal", backfill)
+	}
+	status, err := col.TextIndexStatus("lexical")
+	if err != nil {
+		t.Fatalf("TextIndexStatus: %v", err)
+	}
+	if status.Version != TextIndexVersionV2 || !status.Ready || status.Readable || status.Writable || status.FailClosedReason != "text_v2_search_unavailable" {
+		t.Fatalf("status=%+v want v2 root-ready/full-search-write fail-closed", status)
+	}
+	if !slices.Equal(status.ActiveRootNames, collectionTextV2RootNames("docs", "lexical")) {
+		t.Fatalf("active roots=%q", status.ActiveRootNames)
+	}
+	for _, rootName := range collectionTextV2RootNames("docs", "lexical") {
+		if rootID := requireCollectionRootDescriptor2624(t, d, rootName); rootID == 0 {
+			t.Fatalf("root %q descriptor is zero", rootName)
+		}
+	}
+	stats, err := col.TextIndexStorageStats("lexical")
+	if err != nil {
+		t.Fatalf("TextIndexStorageStats: %v", err)
+	}
+	if stats.Version != TextIndexVersionV2 || stats.Documents != 3 || stats.V2LiveDocuments != 3 || stats.V2DeletedDocs != 0 || stats.V2NextOrdinal != 4 || stats.V2DocIDEntries != 3 || stats.V2TermStats == 0 {
+		t.Fatalf("stats=%+v want v2 docs/stats", stats)
+	}
+	withTextCatalog(t, d, "docs", func(snap *backenddb.Snapshot, catalog *collectionCatalog) {
+		d1 := textV2DocIDRootValue(t, snap, catalog, "docs", "lexical", []byte("d1"))
+		d2 := textV2DocIDRootValue(t, snap, catalog, "docs", "lexical", []byte("d2"))
+		if d1.Ordinal != 1 || d2.Ordinal != 2 || d1.Generation != 1 || d2.Generation != 1 {
+			t.Fatalf("ordinals d1=%+v d2=%+v want primary-key order", d1, d2)
+		}
+		block := textV2NormRootBlock(t, snap, catalog, "docs", "lexical", 1)
+		entry, ok := block.find(d1.Ordinal)
+		if !ok || !slices.Equal(entry.FieldLengths, []uint32{3, 2}) {
+			t.Fatalf("d1 norm entry=%+v ok=%v want body/title lengths 3/2", entry, ok)
+		}
+		state := textDocumentStateValueFromAnalysis(mustAnalyzeTextV2Doc2624(t, TextIndexDefinition{Name: "lexical", Fields: []TextIndexField{{Field: "body"}, {Field: "title", Weight: 2}}}, docs[1]))
+		if !slices.Equal(entry.FieldLengths, textV2FieldLengthsFromState(TextIndexDefinition{Fields: []TextIndexField{{Field: "body"}, {Field: "title"}}}, state)) {
+			t.Fatalf("norm lengths=%v not equal v1 state=%+v", entry.FieldLengths, state.Fields)
+		}
+		termRaw := textRootValue(t, snap, catalog, collectionTextV2TermsRootName("docs", "lexical"), encodeTextV2TermStatsKey("refund"))
+		term, err := decodeTextV2TermStatsValue(termRaw)
+		if err != nil {
+			t.Fatalf("decode refund term: %v", err)
+		}
+		if term.DocumentFrequency != 1 || term.TotalTermFrequency != 3 {
+			t.Fatalf("refund term=%+v want df=1 tf=3", term)
+		}
+	})
+	if _, err := col.SearchText(TextSearchOptions{IndexName: "lexical", Query: "refund", TopK: 10}); !errors.Is(err, ErrTextIndexUnavailable) {
+		t.Fatalf("v2 SearchText err=%v want ErrTextIndexUnavailable", err)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	reopened := openTextV2TestDB(t, dir, false)
+	defer func() { _ = reopened.Close() }()
+	reopenedCol, err := NewCollectionManager(reopened).OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("OpenCollection reopened: %v", err)
+	}
+	reopenedStats, err := reopenedCol.TextIndexStorageStats("lexical")
+	if err != nil {
+		t.Fatalf("reopened TextIndexStorageStats: %v", err)
+	}
+	if reopenedStats != stats {
+		t.Fatalf("reopened stats=%+v want %+v", reopenedStats, stats)
+	}
+}
+
+func TestTextV2MutationsKeepOrdinalsGenerationsTombstonesAfterReopen2624(t *testing.T) {
+	dir := t.TempDir()
+	d := openTextV2TestDB(t, dir, false)
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "docs"}); err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	col, err := mgr.OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("OpenCollection: %v", err)
+	}
+	if _, err := col.InsertBatch([][]byte{[]byte("d1"), []byte("d2")}, [][]byte{[]byte(`{"body":"refund policy"}`), []byte(`{"body":"shipping policy"}`)}); err != nil {
+		t.Fatalf("InsertBatch setup: %v", err)
+	}
+	if _, _, err := col.CreateTextIndex(TextIndexDefinition{Name: "lexical", Version: TextIndexVersionV2, Fields: []TextIndexField{{Field: "body"}}}); err != nil {
+		t.Fatalf("CreateTextIndex: %v", err)
+	}
+	if _, _, err := col.Update([]byte("d1"), func([]byte) ([]byte, bool, error) {
+		return []byte(`{"body":"refund refund updated"}`), true, nil
+	}); err != nil {
+		t.Fatalf("Update d1: %v", err)
+	}
+	if deleted, err := col.DeleteBatch([][]byte{[]byte("d2")}); err != nil || deleted != 1 {
+		t.Fatalf("DeleteBatch d2 deleted=%d err=%v", deleted, err)
+	}
+	if _, err := col.Insert([]byte("d2"), []byte(`{"body":"shipping returns"}`)); err != nil {
+		t.Fatalf("reinsert d2: %v", err)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	reopened := openTextV2TestDB(t, dir, false)
+	defer func() { _ = reopened.Close() }()
+	withTextCatalog(t, reopened, "docs", func(snap *backenddb.Snapshot, catalog *collectionCatalog) {
+		d1 := textV2DocIDRootValue(t, snap, catalog, "docs", "lexical", []byte("d1"))
+		d2 := textV2DocIDRootValue(t, snap, catalog, "docs", "lexical", []byte("d2"))
+		if d1.Ordinal != 1 || d1.Generation != 2 || d1.tombstoned() {
+			t.Fatalf("d1=%+v want same ordinal generation 2 live", d1)
+		}
+		if d2.Ordinal != 3 || d2.Generation != 1 || d2.tombstoned() {
+			t.Fatalf("d2=%+v want fresh non-reused ordinal 3 live", d2)
+		}
+		oldBlock := textV2DocMapRootBlock(t, snap, catalog, "docs", "lexical", 1)
+		oldD2, ok := oldBlock.find(2)
+		if !ok || !oldD2.tombstoned() || oldD2.Generation != 2 || !bytes.Equal(oldD2.DocumentID, []byte("d2")) {
+			t.Fatalf("old d2 docmap entry=%+v ok=%v want tombstone generation 2", oldD2, ok)
+		}
+		newBlock := textV2DocMapRootBlock(t, snap, catalog, "docs", "lexical", 1)
+		newD2, ok := newBlock.find(3)
+		if !ok || newD2.tombstoned() || !bytes.Equal(newD2.DocumentID, []byte("d2")) {
+			t.Fatalf("new d2 docmap entry=%+v ok=%v want live fresh ordinal", newD2, ok)
+		}
+		status := textV2StatusRootValue(t, snap, catalog, "docs", "lexical")
+		if status.NextOrdinal != 4 || status.LiveDocuments != 2 || status.DeletedDocuments != 1 || status.RootGeneration < 4 {
+			t.Fatalf("status=%+v want next=4 live=2 deleted=1 generation advanced", status)
+		}
+		termRaw, ok, err := collectionGetAppendAtCatalogRoot(snap, catalog, collectionTextV2TermsRootName("docs", "lexical"), encodeTextV2TermStatsKey("policy"), nil)
+		if err != nil {
+			t.Fatalf("read policy term: %v", err)
+		}
+		if ok {
+			term, err := decodeTextV2TermStatsValue(termRaw)
+			if err != nil {
+				t.Fatalf("decode policy term: %v", err)
+			}
+			if term.DocumentFrequency != 0 || term.TotalTermFrequency != 0 {
+				t.Fatalf("policy term should have been removed or zero, got %+v", term)
+			}
+		}
+	})
+}
+
+func TestTextV2StorageFailsClosedOnVersionMismatchAndStatsNormInconsistency2624(t *testing.T) {
+	d := openTextV2TestDB(t, t.TempDir(), false)
+	defer func() { _ = d.Close() }()
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "docs"}); err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	col, err := mgr.OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("OpenCollection: %v", err)
+	}
+	if _, err := col.Insert([]byte("d1"), []byte(`{"body":"refund policy"}`)); err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+	if _, _, err := col.CreateTextIndex(TextIndexDefinition{Name: "lexical", Version: TextIndexVersionV2, Fields: []TextIndexField{{Field: "body"}}}); err != nil {
+		t.Fatalf("CreateTextIndex: %v", err)
+	}
+	corruptTextRootValue(t, d, "docs", collectionTextV2NormBlocksRootName("docs", "lexical"), encodeTextV2FormatKey(), []byte{99})
+	if _, err := col.TextIndexStorageStats("lexical"); !errors.Is(err, ErrTextIndexStorageCorrupt) {
+		t.Fatalf("corrupt norm format err=%v want ErrTextIndexStorageCorrupt", err)
+	}
+
+	d2 := openTextV2TestDB(t, t.TempDir(), false)
+	defer func() { _ = d2.Close() }()
+	mgr2 := NewCollectionManager(d2)
+	if _, err := mgr2.CreateCollection(&CollectionMeta{Name: "docs"}); err != nil {
+		t.Fatalf("CreateCollection 2: %v", err)
+	}
+	col2, err := mgr2.OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("OpenCollection 2: %v", err)
+	}
+	if _, err := col2.Insert([]byte("d1"), []byte(`{"body":"refund policy"}`)); err != nil {
+		t.Fatalf("Insert 2: %v", err)
+	}
+	if _, _, err := col2.CreateTextIndex(TextIndexDefinition{Name: "lexical", Version: TextIndexVersionV2, Fields: []TextIndexField{{Field: "body"}}}); err != nil {
+		t.Fatalf("CreateTextIndex 2: %v", err)
+	}
+	corruptTextRootValue(t, d2, "docs", collectionTextV2TermsRootName("docs", "lexical"), encodeTextV2CorpusStatsKey(), encodeTextV2CorpusStatsValue(textV2CorpusStatsValue{StatsGeneration: 99, DocumentCount: 1}))
+	if _, err := col2.TextIndexStorageStats("lexical"); !errors.Is(err, ErrTextIndexStorageCorrupt) {
+		t.Fatalf("corrupt stats generation err=%v want ErrTextIndexStorageCorrupt", err)
+	}
+
+	d3 := openTextV2TestDB(t, t.TempDir(), false)
+	defer func() { _ = d3.Close() }()
+	mgr3 := NewCollectionManager(d3)
+	if _, err := mgr3.CreateCollection(&CollectionMeta{Name: "docs"}); err != nil {
+		t.Fatalf("CreateCollection 3: %v", err)
+	}
+	col3, err := mgr3.OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("OpenCollection 3: %v", err)
+	}
+	if _, err := col3.Insert([]byte("d1"), []byte(`{"body":"refund policy"}`)); err != nil {
+		t.Fatalf("Insert 3: %v", err)
+	}
+	if _, _, err := col3.CreateTextIndex(TextIndexDefinition{Name: "lexical", Version: TextIndexVersionV2, Fields: []TextIndexField{{Field: "body"}}}); err != nil {
+		t.Fatalf("CreateTextIndex 3: %v", err)
+	}
+	badNorm := textV2NormBlockValue{BlockStart: 1, BlockSize: textV2DefaultNormBlockSize, FieldCount: 1, Entries: []textV2NormBlockEntry{{Ordinal: 1, Generation: 99, FieldLengths: []uint32{2}}}}
+	corruptTextRootValue(t, d3, "docs", collectionTextV2NormBlocksRootName("docs", "lexical"), encodeTextV2BlockKey(1), encodeTextV2NormBlockValue(badNorm))
+	if _, err := col3.TextIndexStorageStats("lexical"); !errors.Is(err, ErrTextIndexStorageCorrupt) {
+		t.Fatalf("corrupt norm generation err=%v want ErrTextIndexStorageCorrupt", err)
+	}
+}
+
+func TestTextV2FieldStatsFailClosedOnMissingUnknownAndOutOfRange2624(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		corrupt func(t *testing.T, d *backenddb.DB)
+	}{
+		{
+			name: "missing field stats",
+			corrupt: func(t *testing.T, d *backenddb.DB) {
+				deleteTextRootValue2624(t, d, "docs", collectionTextV2TermsRootName("docs", "lexical"), encodeTextV2FieldStatsKey("body"))
+			},
+		},
+		{
+			name: "unknown field stats",
+			corrupt: func(t *testing.T, d *backenddb.DB) {
+				corruptTextRootValue(t, d, "docs", collectionTextV2TermsRootName("docs", "lexical"), encodeTextV2FieldStatsKey("unknown"), encodeTextV2FieldStatsValue(textV2FieldStatsValue{StatsGeneration: 1, DocumentCount: 1, TotalTokenCount: 1}))
+			},
+		},
+		{
+			name: "out of range field doc count",
+			corrupt: func(t *testing.T, d *backenddb.DB) {
+				corruptTextRootValue(t, d, "docs", collectionTextV2TermsRootName("docs", "lexical"), encodeTextV2FieldStatsKey("body"), encodeTextV2FieldStatsValue(textV2FieldStatsValue{StatsGeneration: 1, DocumentCount: 2, TotalTokenCount: 1}))
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			d := openTextV2TestDB(t, t.TempDir(), false)
+			defer func() { _ = d.Close() }()
+			mgr := NewCollectionManager(d)
+			if _, err := mgr.CreateCollection(&CollectionMeta{Name: "docs"}); err != nil {
+				t.Fatalf("CreateCollection: %v", err)
+			}
+			col, err := mgr.OpenCollection("docs")
+			if err != nil {
+				t.Fatalf("OpenCollection: %v", err)
+			}
+			if _, err := col.Insert([]byte("d1"), []byte(`{"body":"refund policy"}`)); err != nil {
+				t.Fatalf("Insert: %v", err)
+			}
+			if _, _, err := col.CreateTextIndex(TextIndexDefinition{Name: "lexical", Version: TextIndexVersionV2, Fields: []TextIndexField{{Field: "body"}}}); err != nil {
+				t.Fatalf("CreateTextIndex: %v", err)
+			}
+			tc.corrupt(t, d)
+			if _, err := col.TextIndexStorageStats("lexical"); !errors.Is(err, ErrTextIndexStorageCorrupt) {
+				t.Fatalf("TextIndexStorageStats err=%v want ErrTextIndexStorageCorrupt", err)
+			}
+		})
+	}
+}
+
+func TestTextV2RootDescriptorsReachValueLogMaintenance2624(t *testing.T) {
+	dir := t.TempDir()
+	d := openTextV2TestDB(t, dir, true)
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "docs"}); err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	col, err := mgr.OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("OpenCollection: %v", err)
+	}
+	ids := make([][]byte, 32)
+	docs := make([][]byte, 32)
+	for i := range ids {
+		ids[i] = []byte(fmt.Sprintf("doc-%03d", i))
+		docs[i] = []byte(fmt.Sprintf(`{"body":"refund policy customer number %d repeated repeated repeated","title":"ticket %d"}`, i, i))
+	}
+	if _, err := col.InsertBatch(ids, docs); err != nil {
+		t.Fatalf("InsertBatch: %v", err)
+	}
+	if _, _, err := col.CreateTextIndex(TextIndexDefinition{Name: "lexical", Version: TextIndexVersionV2, Fields: []TextIndexField{{Field: "body"}, {Field: "title"}}, StoragePolicy: RootStorageFast}); err != nil {
+		t.Fatalf("CreateTextIndex: %v", err)
+	}
+	for _, rootName := range collectionTextV2RootNames("docs", "lexical") {
+		if rootID := requireCollectionRootDescriptor2624(t, d, rootName); rootID == 0 {
+			t.Fatalf("root %q descriptor zero before GC", rootName)
+		}
+	}
+	normBefore := textV2ReadNormBlockBytes2624(t, d, "docs", "lexical", 1)
+	docMapBefore := textV2ReadRootBytes2624(t, d, "docs", collectionTextV2DocMapRootName("docs", "lexical"), encodeTextV2BlockKey(1))
+	termsBefore := textV2ReadRootBytes2624(t, d, "docs", collectionTextV2TermsRootName("docs", "lexical"), encodeTextV2CorpusStatsKey())
+	if _, err := d.ValueLogGC(context.Background(), backenddb.ValueLogGCOptions{}); err != nil {
+		t.Fatalf("ValueLogGC: %v", err)
+	}
+	normAfter := textV2ReadNormBlockBytes2624(t, d, "docs", "lexical", 1)
+	docMapAfter := textV2ReadRootBytes2624(t, d, "docs", collectionTextV2DocMapRootName("docs", "lexical"), encodeTextV2BlockKey(1))
+	termsAfter := textV2ReadRootBytes2624(t, d, "docs", collectionTextV2TermsRootName("docs", "lexical"), encodeTextV2CorpusStatsKey())
+	if !bytes.Equal(normBefore, normAfter) || !bytes.Equal(docMapBefore, docMapAfter) || !bytes.Equal(termsBefore, termsAfter) {
+		t.Fatalf("v2 root values changed after ValueLogGC")
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	reopened := openTextV2TestDB(t, dir, true)
+	defer func() { _ = reopened.Close() }()
+	if got := textV2ReadNormBlockBytes2624(t, reopened, "docs", "lexical", 1); !bytes.Equal(got, normBefore) {
+		t.Fatalf("norm block not reachable after reopen/GC")
+	}
+	if got := textV2ReadRootBytes2624(t, reopened, "docs", collectionTextV2DocMapRootName("docs", "lexical"), encodeTextV2BlockKey(1)); !bytes.Equal(got, docMapBefore) {
+		t.Fatalf("docmap block not reachable after reopen/GC")
+	}
+	if got := textV2ReadRootBytes2624(t, reopened, "docs", collectionTextV2TermsRootName("docs", "lexical"), encodeTextV2CorpusStatsKey()); !bytes.Equal(got, termsBefore) {
+		t.Fatalf("terms corpus not reachable after reopen/GC")
+	}
+}
+
+func BenchmarkTextV2NormBlockCodec2624(b *testing.B) {
+	block := textV2NormBlockValue{BlockStart: 1, BlockSize: textV2DefaultNormBlockSize, FieldCount: 3, Entries: make([]textV2NormBlockEntry, 0, textV2DefaultNormBlockSize)}
+	for i := uint64(0); i < uint64(textV2DefaultNormBlockSize); i++ {
+		block.Entries = append(block.Entries, textV2NormBlockEntry{Ordinal: i + 1, Generation: 1, FieldLengths: []uint32{uint32(i % 17), uint32(i % 23), uint32(i % 31)}})
+	}
+	encoded := encodeTextV2NormBlockValue(block)
+	b.Run("encode", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ReportMetric(float64(len(encoded)), "bytes/block")
+		for i := 0; i < b.N; i++ {
+			_ = encodeTextV2NormBlockValue(block)
+		}
+	})
+	b.Run("decode", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ReportMetric(float64(len(encoded)), "bytes/block")
+		for i := 0; i < b.N; i++ {
+			if _, err := decodeTextV2NormBlockValue(encoded); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
+func BenchmarkTextV2DocIDMappingCodec2624(b *testing.B) {
+	docID := []byte("doc-000123")
+	docValue := textV2DocIDValue{Ordinal: 123, Generation: 7}
+	docMap := textV2DocMapBlockValue{BlockStart: 1, BlockSize: textV2DefaultDocMapBlockSize, Entries: make([]textV2DocMapEntry, 0, textV2DefaultDocMapBlockSize)}
+	for i := uint64(0); i < uint64(textV2DefaultDocMapBlockSize); i++ {
+		docMap.Entries = append(docMap.Entries, textV2DocMapEntry{Ordinal: i + 1, Generation: 1, DocumentID: []byte(fmt.Sprintf("doc-%06d", i+1))})
+	}
+	encodedDocMap := encodeTextV2DocMapBlockValue(docMap)
+	b.Run("docid_key_value_encode_decode", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ReportMetric(float64(len(encodeTextV2DocIDKey(docID))+len(encodeTextV2DocIDValue(docValue))), "bytes/docid_pair")
+		for i := 0; i < b.N; i++ {
+			key := encodeTextV2DocIDKey(docID)
+			if _, err := decodeTextV2DocIDKey(key); err != nil {
+				b.Fatal(err)
+			}
+			value := encodeTextV2DocIDValue(docValue)
+			if _, err := decodeTextV2DocIDValue(value); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+	b.Run("docmap_block_decode", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ReportMetric(float64(len(encodedDocMap)), "bytes/docmap_block")
+		for i := 0; i < b.N; i++ {
+			if _, err := decodeTextV2DocMapBlockValue(encodedDocMap); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
+func openTextV2TestDB(t *testing.T, dir string, forcePointers bool) *backenddb.DB {
+	t.Helper()
+	opts := backenddb.Options{Dir: dir, DisableBackgroundPrune: true}
+	if forcePointers {
+		opts.ValueLog = backenddb.ValueLogOptions{PointerThreshold: 1, ForcePointers: true}
+	}
+	d, err := backenddb.Open(opts)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	return d
+}
+
+func requireCollectionRootDescriptor2624(t *testing.T, d *backenddb.DB, rootName string) uint64 {
+	t.Helper()
+	snap := d.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("snapshot nil")
+	}
+	defer func() { _ = snap.Close() }()
+	raw, ok, err := getSystemValue(snap, systemCollectionRootKey(rootName))
+	if err != nil {
+		t.Fatalf("get root descriptor %q: %v", rootName, err)
+	}
+	if !ok {
+		t.Fatalf("missing root descriptor %q", rootName)
+	}
+	rootID, err := decodeRootID(raw)
+	if err != nil {
+		t.Fatalf("decode root descriptor %q: %v", rootName, err)
+	}
+	return rootID
+}
+
+func deleteTextRootValue2624(t *testing.T, d *backenddb.DB, collection, rootName string, key []byte) {
+	t.Helper()
+	snap := d.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("snapshot nil")
+	}
+	catalog, err := loadCollectionCatalog(snap, collection)
+	if err != nil {
+		_ = snap.Close()
+		t.Fatalf("load catalog: %v", err)
+	}
+	baseRoot := catalog.rootID(rootName)
+	policy, err := collectionRootStoragePolicyForDB(d, catalog.meta, rootName)
+	if err != nil {
+		_ = snap.Close()
+		t.Fatalf("root policy: %v", err)
+	}
+	_ = snap.Close()
+	table := newCollectionRunTable(1)
+	table.DeleteSteal(bytes.Clone(key))
+	table.Freeze()
+	defer resetCollectionRunTable(table)
+	iter := table.NewIterator(nil, nil)
+	defer func() { _ = iter.Close() }()
+	ordered := []backenddb.OrderedRootDeltaPublishInput{{BaseRoot: baseRoot, Iter: iter, StoragePolicy: policy}}
+	_, rootIDs, err := d.PublishOrderedRootDeltaGroupWithSystemBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+		if len(rootIDs) != 1 {
+			return nil, fmt.Errorf("unexpected root ids %d", len(rootIDs))
+		}
+		current := d.AcquireSnapshot()
+		if current == nil {
+			return nil, backenddb.ErrClosed
+		}
+		defer func() { _ = current.Close() }()
+		return buildSystemTargetIterator(current, map[string][]byte{systemCollectionRootKey(rootName): encodeRootID(rootIDs[0])})
+	})
+	if err != nil {
+		t.Fatalf("publish deleted root value: %v", err)
+	}
+	if len(rootIDs) != 1 {
+		t.Fatalf("rootIDs=%d want 1", len(rootIDs))
+	}
+}
+
+func textV2DocIDRootValue(t *testing.T, snap *backenddb.Snapshot, catalog *collectionCatalog, collection, index string, documentID []byte) textV2DocIDValue {
+	t.Helper()
+	raw := textRootValue(t, snap, catalog, collectionTextV2DocIDRootName(collection, index), encodeTextV2DocIDKey(documentID))
+	value, err := decodeTextV2DocIDValue(raw)
+	if err != nil {
+		t.Fatalf("decode text-v2 docid %q: %v", string(documentID), err)
+	}
+	return value
+}
+
+func textV2StatusRootValue(t *testing.T, snap *backenddb.Snapshot, catalog *collectionCatalog, collection, index string) textV2IndexStatusValue {
+	t.Helper()
+	raw := textRootValue(t, snap, catalog, collectionTextV2GenerationsRootName(collection, index), encodeTextV2StatusKey())
+	value, err := decodeTextV2IndexStatusValue(raw)
+	if err != nil {
+		t.Fatalf("decode text-v2 status: %v", err)
+	}
+	return value
+}
+
+func textV2DocMapRootBlock(t *testing.T, snap *backenddb.Snapshot, catalog *collectionCatalog, collection, index string, blockStart uint64) textV2DocMapBlockValue {
+	t.Helper()
+	raw := textRootValue(t, snap, catalog, collectionTextV2DocMapRootName(collection, index), encodeTextV2BlockKey(blockStart))
+	value, err := decodeTextV2DocMapBlockValue(raw)
+	if err != nil {
+		t.Fatalf("decode text-v2 docmap block: %v", err)
+	}
+	return value
+}
+
+func textV2NormRootBlock(t *testing.T, snap *backenddb.Snapshot, catalog *collectionCatalog, collection, index string, blockStart uint64) textV2NormBlockValue {
+	t.Helper()
+	raw := textRootValue(t, snap, catalog, collectionTextV2NormBlocksRootName(collection, index), encodeTextV2BlockKey(blockStart))
+	value, err := decodeTextV2NormBlockValue(raw)
+	if err != nil {
+		t.Fatalf("decode text-v2 norm block: %v", err)
+	}
+	return value
+}
+
+func textV2ReadNormBlockBytes2624(t *testing.T, d *backenddb.DB, collection, index string, blockStart uint64) []byte {
+	t.Helper()
+	return textV2ReadRootBytes2624(t, d, collection, collectionTextV2NormBlocksRootName(collection, index), encodeTextV2BlockKey(blockStart))
+}
+
+func textV2ReadRootBytes2624(t *testing.T, d *backenddb.DB, collection, rootName string, key []byte) []byte {
+	t.Helper()
+	var out []byte
+	withTextCatalog(t, d, collection, func(snap *backenddb.Snapshot, catalog *collectionCatalog) {
+		out = textRootValue(t, snap, catalog, rootName, key)
+	})
+	return out
+}
+
+func mustAnalyzeTextV2Doc2624(t *testing.T, def TextIndexDefinition, document []byte) textAnalyzedDocument {
+	t.Helper()
+	analysis, err := analyzeTextIndexDocument(def, document)
+	if err != nil {
+		t.Fatalf("analyze doc: %v", err)
+	}
+	return analysis
+}

--- a/TreeDB/docs/spec/collection-text-search.md
+++ b/TreeDB/docs/spec/collection-text-search.md
@@ -22,7 +22,9 @@ matrix are defined in `TreeDB/docs/spec/collection-text-v2-contract.md`.
 - `CreateTextIndex` backfills persistent v1 postings/text-state/text-stats roots
   or explicit v2 doc ordinal/docmap/term-stat/norm/status roots over existing
   documents and publishes roots plus metadata atomically.
-- `DropTextIndex` removes metadata and clears the text root descriptors.
+- `DropTextIndex` removes metadata and clears all v1 and v2 text root
+  descriptors for that index, including v1 postings/text-state/text-stats roots
+  and explicit v2 doc ordinal/docmap/term-stat/norm/status roots.
 - `TextIndexStorageStats` validates storage versions and returns root accounting.
 - Insert, delete, update, and batch write paths maintain v1 postings/text-state
   and stats for v1 text indexes. For explicit v2 indexes, M1 maintains only the

--- a/TreeDB/docs/spec/collection-text-search.md
+++ b/TreeDB/docs/spec/collection-text-search.md
@@ -19,12 +19,15 @@ matrix are defined in `TreeDB/docs/spec/collection-text-v2-contract.md`.
     uses `CollectionOptions.IndexStateStoragePolicy`.
 - `simple` analyzer: Unicode lowercase tokenization over letters, digits, and
   `_` so code-ish identifiers such as `HTTP_500` remain searchable.
-- `CreateTextIndex` backfills persistent postings/text-state/text-stats roots
-  over existing documents and publishes roots plus metadata atomically.
+- `CreateTextIndex` backfills persistent v1 postings/text-state/text-stats roots
+  or explicit v2 doc ordinal/docmap/term-stat/norm/status roots over existing
+  documents and publishes roots plus metadata atomically.
 - `DropTextIndex` removes metadata and clears the text root descriptors.
 - `TextIndexStorageStats` validates storage versions and returns root accounting.
-- Insert, delete, update, and batch write paths maintain postings, text-state,
-  and corpus/term/field stats for declared text indexes.
+- Insert, delete, update, and batch write paths maintain v1 postings/text-state
+  and stats for v1 text indexes. For explicit v2 indexes, M1 maintains only the
+  root-state shell: ordinals/generations, tombstones, docmap/norm blocks, and
+  stats metadata. Full compressed-posting writes remain a later milestone.
 - `SearchText(TextSearchOptions)` executes bounded postings range scans, applies
   simple term `AND`/`OR` semantics, scores candidates with BM25F-style field
   weighting from persisted stats/text-state, and fetches documents only for final
@@ -66,8 +69,13 @@ Validation rules:
   non-negative.
 - Analyzer `""` normalizes to `"simple"`; other analyzers fail closed until
   implemented.
-- Version `""` normalizes to `"v1"`; `"v2"` is reserved by the #2623 contract
-  and currently fails closed until text-v2 roots land.
+- Version `""` normalizes to `"v1"`; `"v2"` explicitly selects the #2624
+  B-tree-native root format. V2 root state is created with `CreateTextIndex`;
+  declaring v2 text indexes directly in `CreateCollection` is rejected to avoid
+  metadata without root descriptors/status records. V2 root state can be
+  maintained, but `TextIndexStatus` remains non-readable/non-writable for the
+  full v2 path and v2 search remains fail-closed until the later executor/write
+  pipeline milestones.
 - Rollout `""` normalizes to `"primary"`; `"shadow"`, `"dual_write"`, and
   `"disabled"` are reserved and currently fail closed until the matching v2
   rollout implementation lands.

--- a/TreeDB/docs/spec/collection-text-v2-contract.md
+++ b/TreeDB/docs/spec/collection-text-v2-contract.md
@@ -47,13 +47,15 @@ type TextIndexDefinition struct {
 `TextIndexVersion` values:
 
 - `""` / `"v1"`: current per-`(term, documentID)` text index.
-- `"v2"`: reserved v2 physical contract. Until M1+ implements v2 roots,
-  metadata validation fails closed with `ErrTextIndexUnavailable`; it must not
-  silently fall back to v1.
+- `"v2"`: explicit v2 physical contract. M1 root-state creation is supported,
+  but v2 search/rollout behavior remains fail-closed until later milestones; it
+  must not silently fall back to v1.
 
 `TextIndexRolloutMode` values:
 
-- `""` / `"primary"`: active read/write path. Today this is v1 only.
+- `""` / `"primary"`: active production read/write path. Today this is v1 only;
+  explicit v2 indexes can maintain M1 root-state shells, but status remains
+  fail-closed/non-readable/non-writable for the full v2 executor/write pipeline.
 - `"shadow"`: future v2 build/validate without serving reads.
 - `"dual_write"`: future v1+v2 mutation maintenance with explicit read choice.
 - `"disabled"`: future metadata-present but non-serving/non-writing state.
@@ -88,6 +90,49 @@ For collection `docs` and index `lexical`, v2 root descriptors are reserved as:
 M1/M2 may define the exact key/value encodings, but these roots remain normal
 TreeDB collection roots. Pointer-backed values must use `value_vlog`, not a new
 text asset store.
+
+## M1 root/key/value format (#2624)
+
+M1 assigns the first concrete v2 root format. Every v2 root contains a versioned
+format record. Explicit `TextIndexVersionV2` creation through `CreateTextIndex`
+publishes all seven v2 root descriptors through the normal collection-root
+system records. Declaring a v2 text index directly in `CreateCollection` is
+rejected because it would create metadata without the required root status
+records. V2 search is still fail-closed until the later executor milestones;
+`TextIndexStatus` reports `readable=false` and `writable=false` for v2 so the M1
+root-state maintenance shell is not advertised as the full M3+ write pipeline.
+There is no fallback to v1 for requested v2.
+
+Stable M1 ordinal semantics:
+
+- document ordinals are `uint64`, start at `1`, and are assigned in deterministic
+  documentID/primary-key order for backfill and mutation batches;
+- `0` is invalid and reserved;
+- ordinals are never reused. Reinsert after delete receives a fresh ordinal;
+- updates keep the ordinal and increment the document generation;
+- deletes increment generation and leave tombstoned docID/docmap/norm records so
+  later postings can reject stale `(ordinal,generation)` matches after reopen.
+
+M1 root contents:
+
+| Root | Key/value records |
+| --- | --- |
+| `text-v2-docid` | documentID key -> `{ordinal,generation,flags}`; tombstone flag marks deleted/currently non-ranking documentIDs. |
+| `text-v2-docmap` | ordinal block key -> sorted ordinal-to-documentID entries with generation/tombstone flags for final ID materialization and stale-generation checks. |
+| `text-v2-terms` | corpus stats, field stats for BM25F average length, and term stats shell (`df`, `ttf`, posting block count placeholder). |
+| `text-v2-posting-blocks` | format-only in M1; #2625 owns posting block payloads. |
+| `text-v2-norm-blocks` | ordinal block key -> packed per-field token lengths with generation/tombstone flags, sufficient for BM25F field-length/norm inputs without per-candidate text-state lookup. |
+| `text-v2-positions` | format-only in M1; later lazy detail/position milestones own payloads. |
+| `text-v2-generations` | index status record: root/stats/docmap/norm/term generations, next ordinal, live documents, deleted/tombstoned ordinals. |
+
+All v2 decoders check the key/value version, root family, block bounds, strict
+ordinal ordering, supported flags, field counts, status-generation bounds, and
+trailing bytes. Unsupported versions or malformed records return
+`ErrTextIndexStorageCorrupt`. Corpus and field stats are validated against the
+status generation and live document count, while per-term stats carry a
+non-zero generation bounded by the term/status generation so unchanged terms can
+remain valid across root-state updates. BM25F average-length inputs are read
+from one published root set.
 
 ## Current v1 path inventory
 
@@ -187,8 +232,8 @@ coordinator explicitly accepts them with profile-backed rationale.
 
 ## Rollout/fail-closed requirements for later milestones
 
-- M1 may enable v2 root creation only after version mismatch/corruption,
-  reopen, root publication, and value-log reachability tests land.
+- M1 enables v2 root creation only with version mismatch/corruption, reopen,
+  root publication, and value-log reachability tests.
 - M2/M3 must prove posting/norm/docmap payloads remain ordinary B-tree values or
   existing `value_vlog` pointers reachable from collection root descriptors.
 - M4+ search must be score-only by default for candidate generation and must


### PR DESCRIPTION
## Summary

Closes #2624. Part of #2622. Builds on M0 / PR #2643.

This PR lands the M1 text-v2 root-state layer:

- adds normal collection-root descriptors for the seven reserved v2 roots;
- adds versioned fail-closed codecs for v2 format/status/docID/docmap/norm/stat records;
- supports explicit `CreateTextIndex(... Version: "v2")` backfill for deterministic doc ordinals, docmap blocks, packed norm blocks, term/stat shells, and generation status;
- adds minimal v2 root-state maintenance for insert/update/delete so ordinals, generations, tombstones, docmap/norm blocks, and stat shells remain coherent after reopen;
- keeps v2 search fail-closed with no v1 fallback and reports `TextIndexStatus` as root-ready but non-readable/non-writable for the full v2 path until later milestones;
- documents the M1 root/value contract and deferrals.

## Scope / non-goals

In scope:

- root/value formats, doc ordinals, docmap/norm blocks, term/stat format shell;
- fail-closed malformed/version/snapshot validation;
- root descriptor publication through normal collection root descriptors;
- value-log/maintenance reachability via existing TreeDB roots;
- tests and codec microbenchmarks.

Out of scope / intentionally not implemented:

- compressed posting-block payloads or search (#2625+);
- WAND/BMW/block-max skipping;
- default v2 rollout or v1 retirement;
- vector internals;
- external text assets or a separate text-block GC subsystem;
- broad M3 streaming write pipeline beyond the minimal M1 root-state shell.

## Validation

Latest local head: `dfdbd53903045ef28fec548734c857f03c438179` rebased on `origin/main` `0464d7f3c1820ae69e7c356c22b4a80a1b47222c`.

| Command | Result | Log |
| --- | --- | --- |
| `GOWORK=off go test ./TreeDB/collections -run 'TestTextV2StorageFailsClosedOnVersionMismatchAndStatsNormInconsistency2624|TestTextV2|TestCollectionTextV2|TestCollectionTextRootStoragePolicies' -count=1` | pass | `/tmp/gomap_2624_go_test_coderabbit_fix_focused.log` |
| `GOWORK=off go test ./TreeDB/collections -count=1` | pass | `/tmp/gomap_2624_go_test_collections_coderabbit_fix.log` |
| `GOWORK=off go test ./TreeDB/docs -count=1` | pass | `/tmp/gomap_2624_go_test_docs_coderabbit_fix.log` |
| `git diff --check` | pass | `/tmp/gomap_2624_git_diff_check_coderabbit_fix.log` |

Coverage highlights:

- codec round-trip and malformed fail-closed checks for every M1 v2 value/key family;
- deterministic ordinal/backfill/reopen test;
- norm parity against v1 text-state field lengths;
- version/snapshot/stat/norm mismatch fail-closed tests;
- update/delete/reinsert generation and tombstone behavior after reopen;
- field/corpus stat consistency validation;
- maintenance-root reachability via root descriptor enumeration + value-log GC/reopen preservation.

## Benchmarks

### v2 codec microbenchmarks

Command:

```sh
GOWORK=off go test ./TreeDB/collections -run '^$' -bench '^BenchmarkTextV2(NormBlockCodec|DocIDMappingCodec)2624$' -benchmem -count=3
```

Log: `/tmp/gomap_2624_bench_codecs_coderabbit_fix.log`.

| Row | Median ns/op | Approx ops/sec | B/op | allocs/op | Size metric |
| --- | ---: | ---: | ---: | ---: | --- |
| `NormBlockCodec/encode` | 3,126 | ~320k | 9,600 | 2 | 776 bytes/block |
| `NormBlockCodec/decode` | 3,288 | ~304k | 8,576 | 129 | 776 bytes/block |
| `DocIDMappingCodec/docid_key_value_encode_decode` | 43.90 | ~22.8M | 40 | 2 | 16 bytes/docid_pair |
| `DocIDMappingCodec/docmap_block_decode` | 3,272 | ~306k | 8,576 | 129 | 1,799 bytes/docmap_block |

### v1 hot-path guardrail

Compared latest `origin/main` (`0464d7f3`) vs this PR (`68025e59`) with the same command:

```sh
GOWORK=off go test ./TreeDB/collections -run '^$' -bench '^BenchmarkIndexInsertSearch2564/search_text_candidates_no_docs$' -benchmem -benchtime=5x -count=3
```

Logs:

- base: `/tmp/gomap_2624_bench_v1_guardrail_base_5x3_rerun.log`
- candidate: `/tmp/gomap_2624_bench_v1_guardrail_candidate_coderabbit_fix.log`
- benchstat: `/tmp/gomap_2624_bench_v1_guardrail_benchstat_coderabbit_fix.txt`

Benchstat: `145.6µ` base vs `126.7µ` candidate, no statistically significant runtime change at n=3. Allocation/counter guardrails unchanged: ~`106.7 KiB/op`, `878 allocs/op`, `0 docs_fetched`, `0 fail_closed`, `256 text_postings`, `128 state/norm lookups`.

## CI / review status

- CI: latest-head checks pass on `dfdbd53903045ef28fec548734c857f03c438179`.
- Codex: latest-head re-review passed on `dfdbd53903`.
- CodeRabbit: findings were addressed in `dfdbd539`; latest rerun completed/skipped with no unresolved threads.
- Copilot: requested; no blocking response observed.

## Dependency-ready note for #2625

Dependency-ready for #2625 once this PR is accepted: the public root descriptor names are stable, v2 roots are normal TreeDB collection roots, and M1 docID/docmap/norm/status/stat shell codecs are versioned/fail-closed. Expected possible churn for #2625 is limited to adding compressed posting-block payloads and term block-summary metadata inside the reserved roots/codecs; root descriptor names and maintenance reachability contract should not change without an explicit follow-up.

