### PR TITLE
Pack retained Template-v1 value-log appends

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -5046,9 +5046,15 @@ type collectionPointerizedRunEntry struct {
 }
 
 const (
-	collectionPointerizeBatchMaxValues = 1024
-	collectionPointerizeBatchMaxBytes  = 4 << 20
+	collectionPointerizeBatchMaxValues           = 1024
+	collectionPointerizeBatchMaxBytes            = 4 << 20
+	collectionRetainedTemplatePackMinBatchValues = 16
 )
+
+type collectionPointerizeOptions struct {
+	inlineThresholdForKey        func([]byte) int
+	packRetainedTemplateV1Values bool
+}
 
 func collectionRunTableHasStableUnsafeSlices(table memtable.Table) bool {
 	stable, ok := table.(memtable.StableUnsafeIteratorTable)
@@ -5056,11 +5062,14 @@ func collectionRunTableHasStableUnsafeSlices(table memtable.Table) bool {
 }
 
 func pointerizeCollectionRunTableValues(db *backenddb.DB, table memtable.Table) (memtable.Table, bool, error) {
-	return pointerizeCollectionRunTableValuesWithResolver(db, table, nil)
+	return pointerizeCollectionRunTableValuesWithOptions(db, table, collectionPointerizeOptions{})
 }
 
 func pointerizeCollectionRunTableValuesForRoot(db *backenddb.DB, meta CollectionMeta, rootName string, table memtable.Table) (memtable.Table, bool, error) {
-	return pointerizeCollectionRunTableValuesWithResolver(db, table, collectionValueLogInlineThresholdResolverForRoot(db, meta, rootName))
+	return pointerizeCollectionRunTableValuesWithOptions(db, table, collectionPointerizeOptions{
+		inlineThresholdForKey:        collectionValueLogInlineThresholdResolverForRoot(db, meta, rootName),
+		packRetainedTemplateV1Values: collectionRootStoresRetainedPayloadBodies(meta, rootName) && columnStoreRetainedPayloadUsesTemplateV1(meta.Options.ColumnStore),
+	})
 }
 
 func collectionValueLogInlineThresholdResolverForRoot(db *backenddb.DB, meta CollectionMeta, rootName string) func([]byte) int {
@@ -5096,10 +5105,11 @@ func collectionRootStoresRetainedPayloadBodies(meta CollectionMeta, rootName str
 	}
 }
 
-func pointerizeCollectionRunTableValuesWithResolver(db *backenddb.DB, table memtable.Table, inlineThresholdForKey func([]byte) int) (memtable.Table, bool, error) {
+func pointerizeCollectionRunTableValuesWithOptions(db *backenddb.DB, table memtable.Table, opts collectionPointerizeOptions) (memtable.Table, bool, error) {
 	if db == nil || table == nil || !db.HasValueLogAppender() {
 		return table, false, nil
 	}
+	inlineThresholdForKey := opts.inlineThresholdForKey
 	if inlineThresholdForKey == nil {
 		inlineThresholdForKey = db.InlineThresholdForKey
 	}
@@ -5138,7 +5148,7 @@ func pointerizeCollectionRunTableValuesWithResolver(db *backenddb.DB, table memt
 		if len(batchValues) == 0 {
 			return nil
 		}
-		ptrs, err := db.AppendValueLogValues(batchValues)
+		ptrs, err := appendCollectionPointerizedBatchValues(db, batchValues, opts.packRetainedTemplateV1Values)
 		if err != nil {
 			return err
 		}
@@ -5209,6 +5219,78 @@ func pointerizeCollectionRunTableValuesWithResolver(db *backenddb.DB, table memt
 	}
 	out.Freeze()
 	return out, true, nil
+}
+
+func appendCollectionPointerizedBatchValues(db *backenddb.DB, values [][]byte, packRetainedTemplateV1 bool) ([]page.ValuePtr, error) {
+	if !packRetainedTemplateV1 || len(values) < collectionRetainedTemplatePackMinBatchValues {
+		return db.AppendValueLogValues(values)
+	}
+	order, ok := collectionRetainedTemplateV1PackOrder(values)
+	if !ok {
+		return db.AppendValueLogValues(values)
+	}
+	packed := make([][]byte, len(values))
+	for i, sourceIdx := range order {
+		packed[i] = values[sourceIdx]
+	}
+	packedPtrs, err := db.AppendValueLogValues(packed)
+	if err != nil {
+		return nil, err
+	}
+	if len(packedPtrs) != len(values) {
+		return packedPtrs, nil
+	}
+	ptrs := make([]page.ValuePtr, len(values))
+	for packedIdx, sourceIdx := range order {
+		ptrs[sourceIdx] = packedPtrs[packedIdx]
+	}
+	return ptrs, nil
+}
+
+func collectionRetainedTemplateV1PackOrder(values [][]byte) ([]int, bool) {
+	if len(values) < 2 {
+		return nil, false
+	}
+	type valueTemplate struct {
+		index      int
+		templateID uint64
+	}
+	order := make([]valueTemplate, len(values))
+	distinct := false
+	var firstID uint64
+	for i, value := range values {
+		root, err := parseTemplateV1StoredDocument(value)
+		if err != nil {
+			return nil, false
+		}
+		if i == 0 {
+			firstID = root.templateID
+		} else if root.templateID != firstID {
+			distinct = true
+		}
+		order[i] = valueTemplate{
+			index:      i,
+			templateID: root.templateID,
+		}
+	}
+	if !distinct {
+		return nil, false
+	}
+	sort.SliceStable(order, func(i, j int) bool {
+		return order[i].templateID < order[j].templateID
+	})
+	out := make([]int, len(order))
+	changed := false
+	for i := range order {
+		out[i] = order[i].index
+		if out[i] != i {
+			changed = true
+		}
+	}
+	if !changed {
+		return nil, false
+	}
+	return out, true
 }
 
 func pointerizeInsertBatchPlanDataRuns(db *backenddb.DB, meta CollectionMeta, plan *insertBatchPlan) ([]memtable.Table, error) {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -5238,7 +5238,7 @@ func appendCollectionPointerizedBatchValues(db *backenddb.DB, values [][]byte, p
 		return nil, err
 	}
 	if len(packedPtrs) != len(values) {
-		return packedPtrs, nil
+		return nil, fmt.Errorf("collections: retained template-v1 packed append returned %d ptrs for %d values", len(packedPtrs), len(values))
 	}
 	ptrs := make([]page.ValuePtr, len(values))
 	for packedIdx, sourceIdx := range order {

--- a/TreeDB/collections/column_retained_vlog_placement_test.go
+++ b/TreeDB/collections/column_retained_vlog_placement_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -203,6 +204,117 @@ func TestColumnRetainedPayloadLeafLogSyntheticShrink(t *testing.T) {
 	t.Logf("synthetic leaf_vlog bytes: retained=%d row_baseline=%d shrink=%.1f%%", retainedLeafBytes, rowLeafBytes, 100*(1-float64(retainedLeafBytes)/float64(rowLeafBytes)))
 }
 
+func TestColumnRetainedPayloadTemplateV1PointerizePacksByTemplateID(t *testing.T) {
+	const docs = 32
+	stored := retainedPlacementTemplateV1StoredDocuments(t, docs)
+	table := newCollectionRunTable(docs)
+	for i := 0; i < docs; i++ {
+		table.SetEntrySteal([]byte(fmt.Sprintf("doc-%06d", i)), bytes.Clone(stored[i]), page.ValuePtr{}, node.FlagInline)
+	}
+	table.Freeze()
+
+	db := &backenddb.DB{}
+	appender := &retainedPlacementTemplatePackAppender{}
+	db.SetValueLogAppender(appender)
+	defer db.SetValueLogAppender(nil)
+
+	cfg := &ColumnStoreConfig{
+		Enabled:                 true,
+		RetainedPayload:         ColumnRetainedPayloadNonColumn,
+		RetainedPayloadEncoding: ColumnRetainedPayloadEncodingTemplateV1,
+		Reconstruction:          ColumnReconstructionRetainedPayloadAndColumns,
+	}
+	meta := CollectionMeta{Name: "events", Options: CollectionOptions{DocumentFormat: DocumentFormatJSON, ColumnStore: cfg}}
+	out, pointerized, err := pointerizeCollectionRunTableValuesForRoot(db, meta, collectionPrimaryRootName("events"), table)
+	if err != nil {
+		t.Fatalf("pointerizeCollectionRunTableValuesForRoot: %v", err)
+	}
+	if !pointerized {
+		t.Fatalf("pointerizeCollectionRunTableValuesForRoot did not pointerize retained payloads")
+	}
+	if len(appender.values) != docs {
+		t.Fatalf("appended values=%d want %d", len(appender.values), docs)
+	}
+
+	lastTemplateID := uint64(0)
+	transitions := 0
+	for i, value := range appender.values {
+		root, err := parseTemplateV1StoredDocument(value)
+		if err != nil {
+			t.Fatalf("appended value %d parse template-v1 stored document: %v", i, err)
+		}
+		if i > 0 && root.templateID != lastTemplateID {
+			transitions++
+			if root.templateID < lastTemplateID {
+				t.Fatalf("appended template ids are not grouped/sorted at %d: got %d after %d", i, root.templateID, lastTemplateID)
+			}
+		}
+		lastTemplateID = root.templateID
+	}
+	if transitions != 1 {
+		t.Fatalf("template packing transitions=%d want 1 for two alternating templates", transitions)
+	}
+
+	ptrOffsetByDocument := make(map[int]uint64, docs)
+	for appendedIdx, value := range appender.values {
+		sourceIdx := -1
+		for i := range stored {
+			if bytes.Equal(value, stored[i]) {
+				sourceIdx = i
+				break
+			}
+		}
+		if sourceIdx < 0 {
+			t.Fatalf("appended value %d did not match any source document", appendedIdx)
+		}
+		ptrOffsetByDocument[sourceIdx] = uint64(appendedIdx + 1)
+	}
+	for i := 0; i < docs; i++ {
+		key := []byte(fmt.Sprintf("doc-%06d", i))
+		value, ptr, flags, found := out.GetEntry(key)
+		if !found {
+			t.Fatalf("pointerized table missing %q", key)
+		}
+		if len(value) != 0 || flags&node.FlagPointer == 0 {
+			t.Fatalf("pointerized entry %q value_len=%d flags=%#x want pointer-only", key, len(value), flags)
+		}
+		if ptr.Offset != ptrOffsetByDocument[i] {
+			t.Fatalf("pointerized entry %q offset=%d want appended offset %d", key, ptr.Offset, ptrOffsetByDocument[i])
+		}
+	}
+}
+
+func TestColumnRetainedPayloadTemplateV1PackingImprovesGroupedBlockStorage(t *testing.T) {
+	const docs = 128
+	stored := retainedPlacementTemplateV1CompressibleStoredDocuments(t, docs)
+	order, ok := collectionRetainedTemplateV1PackOrder(stored)
+	if !ok {
+		t.Fatalf("collectionRetainedTemplateV1PackOrder returned no packing order for interleaved templates")
+	}
+	packed := make([][]byte, len(stored))
+	for packedIdx, sourceIdx := range order {
+		packed[packedIdx] = stored[sourceIdx]
+	}
+
+	mixedStats := retainedPlacementTemplateV1BlockFrameStats(t, stored)
+	packedStats := retainedPlacementTemplateV1BlockFrameStats(t, packed)
+	if !mixedStats.Kept || !packedStats.Kept {
+		t.Fatalf("block compression not kept: mixed=%+v packed=%+v", mixedStats, packedStats)
+	}
+	if packedStats.RawPayloadBytes != mixedStats.RawPayloadBytes {
+		t.Fatalf("raw payload bytes changed: mixed=%d packed=%d", mixedStats.RawPayloadBytes, packedStats.RawPayloadBytes)
+	}
+	if packedStats.StoredPayloadBytes >= mixedStats.StoredPayloadBytes {
+		t.Fatalf("packed template-v1 frame stored bytes=%d want below mixed=%d", packedStats.StoredPayloadBytes, mixedStats.StoredPayloadBytes)
+	}
+	shrinkPct := 100 * (1 - float64(packedStats.StoredPayloadBytes)/float64(mixedStats.StoredPayloadBytes))
+	if shrinkPct < 2 {
+		t.Fatalf("packed template-v1 frame shrink %.2f%% below guardrail: mixed=%d packed=%d", shrinkPct, mixedStats.StoredPayloadBytes, packedStats.StoredPayloadBytes)
+	}
+	t.Logf("template-v1 retained grouped-block bytes: mixed=%d packed=%d shrink=%.2f%%",
+		mixedStats.StoredPayloadBytes, packedStats.StoredPayloadBytes, shrinkPct)
+}
+
 func enableColumnRetainedPlacementCommandWAL(t testing.TB, dir string) {
 	t.Helper()
 	if err := backenddb.SaveFormatConfig(dir, backenddb.FormatConfig{RequiredFeatures: []string{backenddb.RequiredFeatureCommandWALV1}}); err != nil {
@@ -371,4 +483,128 @@ func filesUnderDirContain(t testing.TB, dir string, needle []byte) bool {
 		t.Fatalf("walk %s: %v", dir, err)
 	}
 	return found
+}
+
+type retainedPlacementTemplatePackAppender struct {
+	values [][]byte
+}
+
+func (a *retainedPlacementTemplatePackAppender) AppendValues(values [][]byte) ([]page.ValuePtr, error) {
+	ptrs := make([]page.ValuePtr, len(values))
+	for i, value := range values {
+		a.values = append(a.values, bytes.Clone(value))
+		ptrs[i] = page.ValuePtr{
+			Offset: uint64(len(a.values)),
+			Length: uint32(len(value)),
+			FileID: page.ValueLogFileID(1),
+		}
+	}
+	return ptrs, nil
+}
+
+func (*retainedPlacementTemplatePackAppender) Flush() error { return nil }
+
+func (*retainedPlacementTemplatePackAppender) Sync() error { return nil }
+
+func (*retainedPlacementTemplatePackAppender) CurrentValueLogSegment() (string, uint32, bool) {
+	return "", 0, false
+}
+
+func retainedPlacementTemplateV1StoredDocuments(t testing.TB, count int) [][]byte {
+	t.Helper()
+	encoded := make([][]byte, count)
+	for i := 0; i < count; i++ {
+		var raw []byte
+		if i%2 == 0 {
+			raw = []byte(fmt.Sprintf(`{"payload":"even-%06d","shape_even":%d}`, i, i))
+		} else {
+			raw = []byte(fmt.Sprintf(`{"payload":"odd-%06d","shape_odd":%d,"extra":"%s"}`, i, i, strings.Repeat("x", i%5+1)))
+		}
+		doc, err := EncodeTemplateV1DocumentJSON(raw)
+		if err != nil {
+			t.Fatalf("EncodeTemplateV1DocumentJSON %d: %v", i, err)
+		}
+		encoded[i] = doc
+	}
+	prepared, _, _, _, err := prepareTemplateV1InsertDocuments(encoded, nil, false, false)
+	if err != nil {
+		t.Fatalf("prepareTemplateV1InsertDocuments: %v", err)
+	}
+	if len(prepared) != count {
+		t.Fatalf("prepared documents=%d want %d", len(prepared), count)
+	}
+	return prepared
+}
+
+func retainedPlacementTemplateV1CompressibleStoredDocuments(t testing.TB, count int) [][]byte {
+	t.Helper()
+	encoded := make([][]byte, count)
+	for i := 0; i < count; i++ {
+		var raw []byte
+		switch i % 4 {
+		case 0:
+			raw = []byte(fmt.Sprintf(
+				`{"tenant":"store-a","event":"checkout","cart":"%s","amount":%d,"sku":"sku-a-%03d","coupon":"%s"}`,
+				strings.Repeat("cart-line-price-tax-", 28),
+				1000+i,
+				i%11,
+				strings.Repeat("save-a-", 10),
+			))
+		case 1:
+			raw = []byte(fmt.Sprintf(
+				`{"tenant":"store-b","event":"impression","campaign":"%s","slot":%d,"creative":"creative-b-%03d","visible":%t}`,
+				strings.Repeat("homepage-banner-source-", 26),
+				i%13,
+				i%7,
+				i%3 == 0,
+			))
+		case 2:
+			raw = []byte(fmt.Sprintf(
+				`{"tenant":"store-c","event":"fulfillment","route":"%s","warehouse":"wh-c-%02d","items":%d,"late":%t}`,
+				strings.Repeat("zone-carrier-sort-", 30),
+				i%5,
+				i%19,
+				i%4 == 0,
+			))
+		default:
+			raw = []byte(fmt.Sprintf(
+				`{"tenant":"store-d","event":"support","case":"case-d-%06d","topic":"%s","priority":%d,"agent":"agent-d-%02d"}`,
+				i,
+				strings.Repeat("refund-chat-transcript-", 24),
+				i%4,
+				i%9,
+			))
+		}
+		doc, err := EncodeTemplateV1DocumentJSON(raw)
+		if err != nil {
+			t.Fatalf("EncodeTemplateV1DocumentJSON compressible %d: %v", i, err)
+		}
+		encoded[i] = doc
+	}
+	prepared, _, _, _, err := prepareTemplateV1InsertDocuments(encoded, nil, false, false)
+	if err != nil {
+		t.Fatalf("prepareTemplateV1InsertDocuments compressible: %v", err)
+	}
+	if len(prepared) != count {
+		t.Fatalf("prepared compressible documents=%d want %d", len(prepared), count)
+	}
+	return prepared
+}
+
+func retainedPlacementTemplateV1BlockFrameStats(t testing.TB, values [][]byte) valuelog.FrameStats {
+	t.Helper()
+	records := make([]valuelog.Record, len(values))
+	for i, value := range values {
+		records[i] = valuelog.Record{RID: uint64(i + 1), Value: value}
+	}
+	writer := valuelog.NewWriterWithSink(io.Discard, page.ValueLogFileID(1))
+	writer.SetBlockCompression(valuelog.BlockCodecZSTD, true)
+	_, stats, err := writer.AppendFrameWithStats(0, nil, records)
+	if err != nil {
+		t.Fatalf("AppendFrameWithStats: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("Close frame writer: %v", err)
+	}
+	return stats
 }

--- a/TreeDB/collections/column_retained_vlog_placement_test.go
+++ b/TreeDB/collections/column_retained_vlog_placement_test.go
@@ -315,6 +315,26 @@ func TestColumnRetainedPayloadTemplateV1PackingImprovesGroupedBlockStorage(t *te
 		mixedStats.StoredPayloadBytes, packedStats.StoredPayloadBytes, shrinkPct)
 }
 
+func TestColumnRetainedPayloadTemplateV1PackedAppendMismatchFailsClosed(t *testing.T) {
+	const docs = 32
+	stored := retainedPlacementTemplateV1StoredDocuments(t, docs)
+	db := &backenddb.DB{}
+	appender := &retainedPlacementTemplatePackMismatchedAppender{}
+	db.SetValueLogAppender(appender)
+	defer db.SetValueLogAppender(nil)
+
+	ptrs, err := appendCollectionPointerizedBatchValues(db, stored, true)
+	if err == nil {
+		t.Fatalf("appendCollectionPointerizedBatchValues returned nil error for mismatched pointer count")
+	}
+	if len(ptrs) != 0 {
+		t.Fatalf("appendCollectionPointerizedBatchValues returned %d ptrs on mismatch", len(ptrs))
+	}
+	if len(appender.values) != docs {
+		t.Fatalf("appended values=%d want %d", len(appender.values), docs)
+	}
+}
+
 func enableColumnRetainedPlacementCommandWAL(t testing.TB, dir string) {
 	t.Helper()
 	if err := backenddb.SaveFormatConfig(dir, backenddb.FormatConfig{RequiredFeatures: []string{backenddb.RequiredFeatureCommandWALV1}}); err != nil {
@@ -508,6 +528,18 @@ func (*retainedPlacementTemplatePackAppender) Sync() error { return nil }
 
 func (*retainedPlacementTemplatePackAppender) CurrentValueLogSegment() (string, uint32, bool) {
 	return "", 0, false
+}
+
+type retainedPlacementTemplatePackMismatchedAppender struct {
+	retainedPlacementTemplatePackAppender
+}
+
+func (a *retainedPlacementTemplatePackMismatchedAppender) AppendValues(values [][]byte) ([]page.ValuePtr, error) {
+	ptrs, err := a.retainedPlacementTemplatePackAppender.AppendValues(values)
+	if err != nil || len(ptrs) == 0 {
+		return ptrs, err
+	}
+	return ptrs[:len(ptrs)-1], nil
 }
 
 func retainedPlacementTemplateV1StoredDocuments(t testing.TB, count int) [][]byte {

--- a/TreeDB/collections/typed_storage_naming_test.go
+++ b/TreeDB/collections/typed_storage_naming_test.go
@@ -331,7 +331,7 @@ type typedStorageLegacyNameAllowlistEntry struct {
 }
 
 var typedStorageLegacyNameAllowlist = []typedStorageLegacyNameAllowlistEntry{
-	{path: "TreeDB/collections/api.go", classification: typedStorageLegacyCompatibility, matchingLines: 47, occurrences: 53},
+	{path: "TreeDB/collections/api.go", classification: typedStorageLegacyCompatibility, matchingLines: 48, occurrences: 54},
 	{path: "TreeDB/collections/column_aggregate_metadata_asset.go", classification: typedStorageLegacyDerived, matchingLines: 16, occurrences: 19},
 	{path: "TreeDB/collections/column_aggregate_metadata_predicate.go", classification: typedStorageLegacyDerived, matchingLines: 6, occurrences: 6},
 	{path: "TreeDB/collections/column_aggregate_metadata_predicate_1951_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 15, occurrences: 16},
@@ -383,7 +383,7 @@ var typedStorageLegacyNameAllowlist = []typedStorageLegacyNameAllowlistEntry{
 	{path: "TreeDB/collections/column_reconstruction_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 27, occurrences: 31},
 	{path: "TreeDB/collections/column_retained_payload_audit.go", classification: typedStorageLegacyCompatibility, matchingLines: 8, occurrences: 8},
 	{path: "TreeDB/collections/column_retained_payload_audit_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 25, occurrences: 26},
-	{path: "TreeDB/collections/column_retained_vlog_placement_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 11, occurrences: 11},
+	{path: "TreeDB/collections/column_retained_vlog_placement_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 13, occurrences: 13},
 	{path: "TreeDB/collections/column_semantics.go", classification: typedStorageLegacyCompatibility, matchingLines: 34, occurrences: 34},
 	{path: "TreeDB/collections/dense_numeric_vector.go", classification: typedStorageLegacyCompatibility, matchingLines: 32, occurrences: 41},
 	{path: "TreeDB/collections/dense_numeric_vector_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 35, occurrences: 38},


### PR DESCRIPTION
## Summary

- Implements the #1462-approved storage-first #2395 retained-remainder strategy by grouping retained Template-v1 payloads by template ID before the persistent value-log append.
- Keeps the published collection run table in key order by remapping returned value-log pointers back to the original document-key positions.
- Adds retained-path regression coverage for append ordering, pointer remapping, and real grouped-block ZSTD storage bytes.

## #2395 storage semantics

Strategy: this is the retained-specific value-log packing variant from the #1462 plan: improve physical `value_vlog` locality for retained Template-v1 remainder bytes without changing logical collection keys or introducing a new on-disk format.

On disk: retained remainder bytes still live in persistent `value_vlog/` records as normal grouped block frames. The primary collection root still stores `ValuePtr`s. There is no slab path and no treatment of value-log data as WAL.

Accounting: #2359 storage accounting should continue to count `value_vlog/`, `leaf_vlog/`, indexes, manifests, column assets, and control bytes, while excluding only command WAL. This change targets the `value_vlog` retained-remainder byte class, specifically the current `grouped_block_zstd` retained payload frames. It does not claim the #2396 typed-column section-compaction bytes.

Correctness: no persisted pointer representation changes. The value-log appender returns ordinary persistent pointers for the packed physical order, and collection pointerization remaps them back to original key order before publishing. Existing value-log rewrite, GC, checkpoint/reopen, and canonical reconstruction paths still see normal `ValuePtr`s.

Expected byte class shrink: the #2395 baseline has `value_vlog` raw/stored `256,756,041 / 107,168,508` bytes with `grouped_block_zstd`. The focused regression test exercises the exact value-log ZSTD block-frame path and shows interleaved retained Template-v1 frame bytes moving from `913` to `815` stored bytes, a `10.73%` reduction on that synthetic mixed-template workload. Full 1M JSONBench storage proof is still planned after #2396 per the #1462 execution sequence.

Performance risk: this adds Template-v1 parsing plus a stable sort for retained Template-v1 pointerization batches with at least 16 values. Non-retained roots, non-Template-v1 retained payloads, single-template batches, already grouped batches, and small batches use the existing append path. Read/query behavior is unchanged.

## Tests

- `go test ./TreeDB/collections -run 'TestColumnRetainedPayloadTemplateV1(PointerizePacksByTemplateID|PackingImprovesGroupedBlockStorage)' -count=1 -v`
  - `template-v1 retained grouped-block bytes: mixed=913 packed=815 shrink=10.73%`
- `go test ./TreeDB/collections -count=1`
- `go test ./TreeDB/caching -count=1`
- `go test ./TreeDB/caching -run 'TestAppendValueLog_AutoBalancedCompactRetainedTemplateBatchUsesBlockFrames|TestAppendValueLog_AutoForcePointerMediumPayloadUsesGroupedBlockFrame|TestAppendValueLogOne_AutoForcePointerRetainedPayloadResetsBlockBackoff' -count=1`
- `go test ./experiments/colgranule/cmd/jsonbench_compare -run 'TestRemainingTemplateV1MeasurementStorageReconstructsJSONBenchRows|TestWriteMarkdownRawTreeDBJSONReclaimText' -count=1`

Refs #2395
Refs #1462
