### PR TITLE
TreeDB text v2: implement compressed posting blocks

### DIFF
--- a/TreeDB/collections/text_backfill.go
+++ b/TreeDB/collections/text_backfill.go
@@ -1093,6 +1093,9 @@ func inspectTextV2Root(snap *backenddb.Snapshot, catalog *collectionCatalog, def
 			if block.BlockStart != postingKey.BlockStart || block.BlockID != postingKey.BlockID {
 				return errMalformedTextStorage("text-v2 posting block key/value mismatch")
 			}
+			if len(block.Summary.MaxFieldTermFrequencies) != len(def.Fields) {
+				return errMalformedTextStorage("text-v2 posting block field lanes mismatch")
+			}
 			for _, entry := range block.Entries {
 				if entry.Ordinal >= status.NextOrdinal || entry.Generation > status.RootGeneration {
 					return errMalformedTextStorage("text-v2 posting block entry outside status snapshot")

--- a/TreeDB/collections/text_backfill.go
+++ b/TreeDB/collections/text_backfill.go
@@ -47,6 +47,7 @@ type TextIndexStorageStats struct {
 	Version           TextIndexVersion
 	V2DocIDEntries    uint64
 	V2DocMapBlocks    uint64
+	V2PostingBlocks   uint64
 	V2NormBlocks      uint64
 	V2TermStats       uint64
 	V2FormatRecords   uint64
@@ -1080,6 +1081,24 @@ func inspectTextV2Root(snap *backenddb.Snapshot, catalog *collectionCatalog, def
 				}
 			}
 			stats.V2NormBlocks++
+		case family == textV2RootFamilyPostingBlocks:
+			postingKey, err := decodeTextV2PostingBlockKey(key)
+			if err != nil {
+				return err
+			}
+			block, err := decodeTextV2PostingBlockValue(value)
+			if err != nil {
+				return err
+			}
+			if block.BlockStart != postingKey.BlockStart || block.BlockID != postingKey.BlockID {
+				return errMalformedTextStorage("text-v2 posting block key/value mismatch")
+			}
+			for _, entry := range block.Entries {
+				if entry.Ordinal >= status.NextOrdinal || entry.Generation > status.RootGeneration {
+					return errMalformedTextStorage("text-v2 posting block entry outside status snapshot")
+				}
+			}
+			stats.V2PostingBlocks++
 		case family == textV2RootFamilyTerms:
 			statsKey, err := decodeTextV2StatsKey(key)
 			if err != nil {
@@ -1126,7 +1145,7 @@ func inspectTextV2Root(snap *backenddb.Snapshot, catalog *collectionCatalog, def
 			}
 			stats.V2TermStats++
 			stats.StatsEntries++
-		case family == textV2RootFamilyPostingBlocks || family == textV2RootFamilyPositions || family == textV2RootFamilyGenerations:
+		case family == textV2RootFamilyPositions || family == textV2RootFamilyGenerations:
 			return errMalformedTextStorage("unsupported text-v2 root %q entry key %x", rootName, key)
 		default:
 			return errMalformedTextStorage("unsupported text-v2 root %q family %s", rootName, family)

--- a/TreeDB/collections/text_v2_posting_blocks.go
+++ b/TreeDB/collections/text_v2_posting_blocks.go
@@ -1,0 +1,728 @@
+package collections
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"math"
+	"slices"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+)
+
+const (
+	textV2KeyKindPostingBlock byte = 0x21
+
+	textV2PostingBlockValueVersion byte = 1
+
+	// textV2PostingBlockTargetPostings keeps ordinary sealed blocks small enough
+	// to stay cache-local in B-tree leaves. The root storage policy still owns the
+	// physical inline-vs-value-log-leaf decision; oversized values remain ordinary
+	// root values and therefore visible to existing TreeDB maintenance scanning.
+	textV2PostingBlockTargetPostings    uint32 = 128
+	textV2PostingBlockMicroPostings     uint32 = 32
+	textV2PostingBlockMaxPostings       uint32 = 64 * 1024
+	textV2PostingBlockMaxFieldCount     uint32 = 1024
+	textV2PostingBlockInlineTargetBytes        = 16 << 10
+	textV2PostingBlockMaxValueBytes            = 4 << 20
+
+	textV2PostingBlockValueSupportedFlags byte = 0
+	textV2PostingBlockEntrySupportedFlags byte = 0
+
+	textV2PostingUpperBoundKindBM25FLaneMax byte = 1
+)
+
+type textV2PostingBlockKind byte
+
+const (
+	textV2PostingBlockKindSealed textV2PostingBlockKind = iota + 1
+	textV2PostingBlockKindDelta
+	textV2PostingBlockKindMicro
+)
+
+func (k textV2PostingBlockKind) String() string {
+	switch k {
+	case textV2PostingBlockKindSealed:
+		return "sealed"
+	case textV2PostingBlockKindDelta:
+		return "delta"
+	case textV2PostingBlockKindMicro:
+		return "micro"
+	default:
+		return fmt.Sprintf("unknown(%d)", byte(k))
+	}
+}
+
+type textV2PostingBlockKey struct {
+	Term       string
+	BlockStart uint64
+	BlockID    uint64
+}
+
+type textV2PostingBlockSummary struct {
+	FirstOrdinal            uint64
+	LastOrdinal             uint64
+	DocCount                uint32
+	MaxTermFrequency        uint32
+	MaxFieldTermFrequencies []uint32
+	UpperBoundKind          byte
+}
+
+type textV2PostingBlockEntry struct {
+	Ordinal          uint64
+	Generation       uint64
+	TermFrequency    uint32
+	FieldFrequencies []uint32
+	Flags            byte
+}
+
+type textV2PostingBlockValue struct {
+	FormatVersion uint32
+	Kind          textV2PostingBlockKind
+	Flags         byte
+	BlockStart    uint64
+	BlockID       uint64
+	Summary       textV2PostingBlockSummary
+	Entries       []textV2PostingBlockEntry
+}
+
+type textV2PostingBlockKV struct {
+	Key   []byte
+	Value []byte
+	Block textV2PostingBlockValue
+}
+
+type textV2PostingBlockBuildOptions struct {
+	Kind              textV2PostingBlockKind
+	TargetPostings    uint32
+	BlockIDStart      uint64
+	InlineTargetBytes int
+}
+
+func textV2PostingBlockStoragePolicy(def TextIndexDefinition) (backenddb.OrderedRootStoragePolicy, error) {
+	return backendRootStoragePolicy(def.StoragePolicy)
+}
+
+func encodeTextV2PostingBlockTermPrefix(term string) []byte {
+	out := make([]byte, 0, 2+binary.MaxVarintLen64+len(term))
+	out = append(out, textV2KeyVersion, textV2KeyKindPostingBlock)
+	out = appendTextString(out, term)
+	return out
+}
+
+func encodeTextV2PostingBlockKey(term string, blockStart, blockID uint64) []byte {
+	out := encodeTextV2PostingBlockTermPrefix(term)
+	var buf [16]byte
+	binary.BigEndian.PutUint64(buf[0:8], blockStart)
+	binary.BigEndian.PutUint64(buf[8:16], blockID)
+	out = append(out, buf[:]...)
+	return out
+}
+
+func decodeTextV2PostingBlockKey(raw []byte) (textV2PostingBlockKey, error) {
+	if len(raw) < 2 {
+		return textV2PostingBlockKey{}, errMalformedTextStorage("short text-v2 posting block key")
+	}
+	if raw[0] != textV2KeyVersion {
+		return textV2PostingBlockKey{}, errUnsupportedTextStorageVersion("text-v2 posting block key", raw[0])
+	}
+	if raw[1] != textV2KeyKindPostingBlock {
+		return textV2PostingBlockKey{}, errMalformedTextStorage("text-v2 posting block key kind %d", raw[1])
+	}
+	cur := textCursor{buf: raw[2:]}
+	term, err := cur.readString()
+	if err != nil {
+		return textV2PostingBlockKey{}, errMalformedTextStorage("text-v2 posting block key term: %v", err)
+	}
+	if cur.remaining() != 16 {
+		return textV2PostingBlockKey{}, errMalformedTextStorage("text-v2 posting block key suffix length %d", cur.remaining())
+	}
+	blockStart := binary.BigEndian.Uint64(cur.buf[cur.pos : cur.pos+8])
+	blockID := binary.BigEndian.Uint64(cur.buf[cur.pos+8 : cur.pos+16])
+	if blockStart == 0 || blockID == 0 {
+		return textV2PostingBlockKey{}, errMalformedTextStorage("text-v2 posting block key blockStart/blockID cannot be zero")
+	}
+	return textV2PostingBlockKey{Term: term, BlockStart: blockStart, BlockID: blockID}, nil
+}
+
+func decodeTextV2PostingBlockKeyForPrefix(raw, prefix []byte) (textV2PostingBlockKey, error) {
+	if !bytes.HasPrefix(raw, prefix) {
+		return textV2PostingBlockKey{}, errMalformedTextStorage("text-v2 posting block key outside requested term prefix")
+	}
+	return decodeTextV2PostingBlockKey(raw)
+}
+
+func encodeTextV2PostingBlockValue(value textV2PostingBlockValue) []byte {
+	entries := cloneTextV2PostingBlockEntries(value.Entries)
+	slices.SortFunc(entries, func(a, b textV2PostingBlockEntry) int {
+		return compareUint64(a.Ordinal, b.Ordinal)
+	})
+	fieldCount := uint32(len(value.Summary.MaxFieldTermFrequencies))
+	out := make([]byte, 0, estimateTextV2PostingBlockValueLen(value, entries, fieldCount))
+	out = append(out, textV2PostingBlockValueVersion)
+	out = appendTextUvarint(out, uint64(value.FormatVersion))
+	out = append(out, byte(value.Kind), value.Flags)
+	out = appendTextUvarint(out, value.BlockStart)
+	out = appendTextUvarint(out, value.BlockID)
+	out = appendTextUvarint(out, value.Summary.FirstOrdinal)
+	out = appendTextUvarint(out, value.Summary.LastOrdinal)
+	out = appendTextUvarint(out, uint64(value.Summary.DocCount))
+	out = appendTextUvarint(out, uint64(value.Summary.MaxTermFrequency))
+	out = appendTextUvarint(out, uint64(fieldCount))
+	for _, maxTF := range value.Summary.MaxFieldTermFrequencies {
+		out = appendTextUvarint(out, uint64(maxTF))
+	}
+	out = append(out, value.Summary.UpperBoundKind)
+	out = appendTextUvarint(out, uint64(len(entries)))
+	prev := value.BlockStart - 1
+	for _, entry := range entries {
+		gap := entry.Ordinal - prev
+		out = appendTextUvarint(out, gap)
+		out = appendTextUvarint(out, entry.Generation)
+		out = append(out, entry.Flags)
+		out = appendTextUvarint(out, uint64(entry.TermFrequency))
+		for _, freq := range entry.FieldFrequencies {
+			out = appendTextUvarint(out, uint64(freq))
+		}
+		prev = entry.Ordinal
+	}
+	return out
+}
+
+func decodeTextV2PostingBlockValue(raw []byte) (textV2PostingBlockValue, error) {
+	scanner, err := newTextV2PostingBlockEntryScanner(raw, nil)
+	if err != nil {
+		return textV2PostingBlockValue{}, err
+	}
+	value := scanner.block
+	value.Entries = make([]textV2PostingBlockEntry, 0, scanner.block.Summary.DocCount)
+	var entry textV2PostingBlockEntry
+	for scanner.Next(&entry) {
+		value.Entries = append(value.Entries, textV2PostingBlockEntry{
+			Ordinal:          entry.Ordinal,
+			Generation:       entry.Generation,
+			TermFrequency:    entry.TermFrequency,
+			FieldFrequencies: append([]uint32(nil), entry.FieldFrequencies...),
+			Flags:            entry.Flags,
+		})
+	}
+	if err := scanner.Err(); err != nil {
+		return textV2PostingBlockValue{}, err
+	}
+	return value, nil
+}
+
+func buildTextV2PostingBlockKVs(term string, entries []textV2PostingBlockEntry, fieldCount uint32, opts textV2PostingBlockBuildOptions) ([]textV2PostingBlockKV, error) {
+	if len(entries) == 0 {
+		return nil, nil
+	}
+	if fieldCount == 0 || fieldCount > textV2PostingBlockMaxFieldCount {
+		return nil, errMalformedTextStorage("text-v2 posting block builder invalid field count %d", fieldCount)
+	}
+	kind := opts.Kind
+	if kind == 0 {
+		kind = textV2PostingBlockKindSealed
+	}
+	if !isSupportedTextV2PostingBlockKind(kind) {
+		return nil, errMalformedTextStorage("text-v2 posting block builder unsupported kind %d", byte(kind))
+	}
+	target := opts.TargetPostings
+	if target == 0 {
+		if kind == textV2PostingBlockKindMicro {
+			target = textV2PostingBlockMicroPostings
+		} else {
+			target = textV2PostingBlockTargetPostings
+		}
+	}
+	if target > textV2PostingBlockMaxPostings {
+		target = textV2PostingBlockMaxPostings
+	}
+	inlineTarget := opts.InlineTargetBytes
+	if inlineTarget <= 0 {
+		inlineTarget = textV2PostingBlockInlineTargetBytes
+	}
+	blockID := opts.BlockIDStart
+	if blockID == 0 {
+		blockID = 1
+	}
+	sorted := cloneTextV2PostingBlockEntries(entries)
+	slices.SortFunc(sorted, func(a, b textV2PostingBlockEntry) int { return compareUint64(a.Ordinal, b.Ordinal) })
+	out := make([]textV2PostingBlockKV, 0, (len(sorted)+int(target)-1)/int(target))
+	for start := 0; start < len(sorted); {
+		chunkLen := min(int(target), len(sorted)-start)
+		var block textV2PostingBlockValue
+		var encoded []byte
+		for {
+			candidate, err := newTextV2PostingBlockValue(kind, sorted[start:start+chunkLen], fieldCount, blockID)
+			if err != nil {
+				return nil, err
+			}
+			encoded = encodeTextV2PostingBlockValue(candidate)
+			if len(encoded) <= textV2PostingBlockMaxValueBytes && (len(encoded) <= inlineTarget || chunkLen == 1) {
+				block = candidate
+				break
+			}
+			if chunkLen == 1 {
+				return nil, errMalformedTextStorage("text-v2 posting block encoded bytes %d exceed max %d", len(encoded), textV2PostingBlockMaxValueBytes)
+			}
+			chunkLen = max(1, chunkLen/2)
+		}
+		out = append(out, textV2PostingBlockKV{
+			Key:   encodeTextV2PostingBlockKey(term, block.BlockStart, block.BlockID),
+			Value: encoded,
+			Block: block,
+		})
+		start += chunkLen
+		if blockID == math.MaxUint64 {
+			return nil, errMalformedTextStorage("text-v2 posting block id overflow")
+		}
+		blockID++
+	}
+	return out, nil
+}
+
+type textV2PostingBlockEntryScanner struct {
+	block           textV2PostingBlockValue
+	cur             textCursor
+	remaining       uint32
+	seen            uint32
+	prevOrdinal     uint64
+	fieldScratch    []uint32
+	computed        textV2PostingBlockSummary
+	computedFieldTF []uint32
+	err             error
+	finished        bool
+}
+
+func newTextV2PostingBlockEntryScanner(raw []byte, scratch []uint32) (*textV2PostingBlockEntryScanner, error) {
+	if len(raw) == 0 {
+		return nil, errMalformedTextStorage("empty text-v2 posting block value")
+	}
+	if len(raw) > textV2PostingBlockMaxValueBytes {
+		return nil, errMalformedTextStorage("text-v2 posting block value bytes %d exceed max %d", len(raw), textV2PostingBlockMaxValueBytes)
+	}
+	if raw[0] != textV2PostingBlockValueVersion {
+		return nil, errUnsupportedTextStorageVersion("text-v2 posting block value", raw[0])
+	}
+	cur := textCursor{buf: raw[1:]}
+	formatVersion, err := cur.readUvarint()
+	if err != nil {
+		return nil, errMalformedTextStorage("text-v2 posting block format version: %v", err)
+	}
+	if formatVersion != uint64(textV2FormatVersion) {
+		return nil, errMalformedTextStorage("unsupported text-v2 posting block format version %d", formatVersion)
+	}
+	if cur.remaining() < 2 {
+		return nil, errMalformedTextStorage("text-v2 posting block missing kind/flags")
+	}
+	kind := textV2PostingBlockKind(cur.buf[cur.pos])
+	cur.pos++
+	if !isSupportedTextV2PostingBlockKind(kind) {
+		return nil, errMalformedTextStorage("text-v2 posting block unsupported kind %d", byte(kind))
+	}
+	flags := cur.buf[cur.pos]
+	cur.pos++
+	if flags&^textV2PostingBlockValueSupportedFlags != 0 {
+		return nil, errMalformedTextStorage("text-v2 posting block unsupported flags 0x%x", flags)
+	}
+	blockStart, err := cur.readUvarint()
+	if err != nil {
+		return nil, errMalformedTextStorage("text-v2 posting block start: %v", err)
+	}
+	blockID, err := cur.readUvarint()
+	if err != nil {
+		return nil, errMalformedTextStorage("text-v2 posting block id: %v", err)
+	}
+	first, err := cur.readUvarint()
+	if err != nil {
+		return nil, errMalformedTextStorage("text-v2 posting block first ordinal: %v", err)
+	}
+	last, err := cur.readUvarint()
+	if err != nil {
+		return nil, errMalformedTextStorage("text-v2 posting block last ordinal: %v", err)
+	}
+	docCountRaw, err := cur.readUvarint()
+	if err != nil {
+		return nil, errMalformedTextStorage("text-v2 posting block doc count: %v", err)
+	}
+	maxTFRaw, err := cur.readUvarint()
+	if err != nil {
+		return nil, errMalformedTextStorage("text-v2 posting block max term frequency: %v", err)
+	}
+	fieldCountRaw, err := cur.readUvarint()
+	if err != nil {
+		return nil, errMalformedTextStorage("text-v2 posting block field count: %v", err)
+	}
+	fieldCount := checkedTextUint32(fieldCountRaw)
+	docCount := checkedTextUint32(docCountRaw)
+	maxTF := checkedTextUint32(maxTFRaw)
+	if blockStart == 0 || blockID == 0 || first == 0 || last == 0 {
+		return nil, errMalformedTextStorage("text-v2 posting block zero block id or ordinal")
+	}
+	if first != blockStart || first > last {
+		return nil, errMalformedTextStorage("text-v2 posting block invalid ordinal range [%d,%d] for start %d", first, last, blockStart)
+	}
+	if uint64(docCount) != docCountRaw || docCount == 0 || docCount > textV2PostingBlockMaxPostings {
+		return nil, errMalformedTextStorage("text-v2 posting block doc count invalid")
+	}
+	if uint64(maxTF) != maxTFRaw || maxTF == 0 {
+		return nil, errMalformedTextStorage("text-v2 posting block max term frequency invalid")
+	}
+	if uint64(fieldCount) != fieldCountRaw || fieldCount == 0 || fieldCount > textV2PostingBlockMaxFieldCount {
+		return nil, errMalformedTextStorage("text-v2 posting block field count invalid")
+	}
+	maxFieldTF := make([]uint32, 0, fieldCount)
+	for i := uint32(0); i < fieldCount; i++ {
+		fieldTF, err := cur.readUvarint()
+		if err != nil {
+			return nil, errMalformedTextStorage("text-v2 posting block max field frequency[%d]: %v", i, err)
+		}
+		if uint64(checkedTextUint32(fieldTF)) != fieldTF {
+			return nil, errMalformedTextStorage("text-v2 posting block max field frequency[%d] overflows uint32", i)
+		}
+		maxFieldTF = append(maxFieldTF, uint32(fieldTF))
+	}
+	if cur.remaining() == 0 {
+		return nil, errMalformedTextStorage("text-v2 posting block missing upper-bound kind")
+	}
+	upperBoundKind := cur.buf[cur.pos]
+	cur.pos++
+	if upperBoundKind != textV2PostingUpperBoundKindBM25FLaneMax {
+		return nil, errMalformedTextStorage("text-v2 posting block unsupported upper-bound kind %d", upperBoundKind)
+	}
+	entryCount, err := cur.readUvarint()
+	if err != nil {
+		return nil, errMalformedTextStorage("text-v2 posting block entry count: %v", err)
+	}
+	if entryCount != uint64(docCount) {
+		return nil, errMalformedTextStorage("text-v2 posting block doc count %d does not match entry count %d", docCount, entryCount)
+	}
+	if entryCount > uint64(cur.remaining()+1) {
+		return nil, errMalformedTextStorage("text-v2 posting block entry count too large")
+	}
+	if cap(scratch) < int(fieldCount) {
+		scratch = make([]uint32, fieldCount)
+	}
+	return &textV2PostingBlockEntryScanner{
+		block: textV2PostingBlockValue{
+			FormatVersion: uint32(formatVersion),
+			Kind:          kind,
+			Flags:         flags,
+			BlockStart:    blockStart,
+			BlockID:       blockID,
+			Summary: textV2PostingBlockSummary{
+				FirstOrdinal:            first,
+				LastOrdinal:             last,
+				DocCount:                docCount,
+				MaxTermFrequency:        maxTF,
+				MaxFieldTermFrequencies: maxFieldTF,
+				UpperBoundKind:          upperBoundKind,
+			},
+		},
+		cur:             cur,
+		remaining:       docCount,
+		prevOrdinal:     blockStart - 1,
+		fieldScratch:    scratch[:fieldCount],
+		computedFieldTF: make([]uint32, fieldCount),
+	}, nil
+}
+
+func (s *textV2PostingBlockEntryScanner) Summary() textV2PostingBlockSummary {
+	if s == nil {
+		return textV2PostingBlockSummary{}
+	}
+	return cloneTextV2PostingBlockSummary(s.block.Summary)
+}
+
+func (s *textV2PostingBlockEntryScanner) Block() textV2PostingBlockValue {
+	if s == nil {
+		return textV2PostingBlockValue{}
+	}
+	block := s.block
+	block.Summary = cloneTextV2PostingBlockSummary(block.Summary)
+	return block
+}
+
+func (s *textV2PostingBlockEntryScanner) Next(dst *textV2PostingBlockEntry) bool {
+	if s == nil || s.err != nil || s.finished {
+		return false
+	}
+	if s.remaining == 0 {
+		s.finish()
+		return false
+	}
+	gap, err := s.cur.readUvarint()
+	if err != nil {
+		s.err = errMalformedTextStorage("text-v2 posting block entry[%d] ordinal delta: %v", s.seen, err)
+		return false
+	}
+	if gap == 0 || gap > math.MaxUint64-s.prevOrdinal {
+		s.err = errMalformedTextStorage("text-v2 posting block entry[%d] invalid ordinal delta", s.seen)
+		return false
+	}
+	ordinal := s.prevOrdinal + gap
+	generation, err := s.cur.readUvarint()
+	if err != nil {
+		s.err = errMalformedTextStorage("text-v2 posting block entry[%d] generation: %v", s.seen, err)
+		return false
+	}
+	if s.cur.remaining() == 0 {
+		s.err = errMalformedTextStorage("text-v2 posting block entry[%d] missing flags", s.seen)
+		return false
+	}
+	flags := s.cur.buf[s.cur.pos]
+	s.cur.pos++
+	if flags&^textV2PostingBlockEntrySupportedFlags != 0 {
+		s.err = errMalformedTextStorage("text-v2 posting block entry[%d] unsupported flags 0x%x", s.seen, flags)
+		return false
+	}
+	tfRaw, err := s.cur.readUvarint()
+	if err != nil {
+		s.err = errMalformedTextStorage("text-v2 posting block entry[%d] term frequency: %v", s.seen, err)
+		return false
+	}
+	tf := checkedTextUint32(tfRaw)
+	if ordinal == 0 || generation == 0 || uint64(tf) != tfRaw || tf == 0 {
+		s.err = errMalformedTextStorage("text-v2 posting block entry[%d] invalid ordinal/generation/frequency", s.seen)
+		return false
+	}
+	var fieldSum uint64
+	for i := range s.fieldScratch {
+		fieldTFRaw, err := s.cur.readUvarint()
+		if err != nil {
+			s.err = errMalformedTextStorage("text-v2 posting block entry[%d] field[%d] frequency: %v", s.seen, i, err)
+			return false
+		}
+		fieldTF := checkedTextUint32(fieldTFRaw)
+		if uint64(fieldTF) != fieldTFRaw {
+			s.err = errMalformedTextStorage("text-v2 posting block entry[%d] field[%d] frequency overflows uint32", s.seen, i)
+			return false
+		}
+		s.fieldScratch[i] = fieldTF
+		fieldSum += uint64(fieldTF)
+	}
+	if fieldSum != uint64(tf) {
+		s.err = errMalformedTextStorage("text-v2 posting block entry[%d] field frequencies sum %d does not match term frequency %d", s.seen, fieldSum, tf)
+		return false
+	}
+	if s.seen == 0 {
+		s.computed.FirstOrdinal = ordinal
+	} else if ordinal <= s.prevOrdinal {
+		s.err = errMalformedTextStorage("text-v2 posting block entry[%d] ordinal not strictly increasing", s.seen)
+		return false
+	}
+	s.computed.LastOrdinal = ordinal
+	s.computed.DocCount++
+	if tf > s.computed.MaxTermFrequency {
+		s.computed.MaxTermFrequency = tf
+	}
+	for i, fieldTF := range s.fieldScratch {
+		if fieldTF > s.computedFieldTF[i] {
+			s.computedFieldTF[i] = fieldTF
+		}
+	}
+	s.prevOrdinal = ordinal
+	s.seen++
+	s.remaining--
+	if dst != nil {
+		dst.Ordinal = ordinal
+		dst.Generation = generation
+		dst.TermFrequency = tf
+		dst.FieldFrequencies = s.fieldScratch
+		dst.Flags = flags
+	}
+	return true
+}
+
+func (s *textV2PostingBlockEntryScanner) Err() error {
+	if s == nil {
+		return nil
+	}
+	if s.err != nil {
+		return s.err
+	}
+	if !s.finished && s.remaining == 0 {
+		s.finish()
+	}
+	return s.err
+}
+
+func (s *textV2PostingBlockEntryScanner) finish() {
+	if s.finished {
+		return
+	}
+	s.finished = true
+	if s.cur.remaining() != 0 {
+		s.err = errMalformedTextStorage("text-v2 posting block trailing bytes")
+		return
+	}
+	s.computed.UpperBoundKind = s.block.Summary.UpperBoundKind
+	s.computed.MaxFieldTermFrequencies = append([]uint32(nil), s.computedFieldTF...)
+	if !textV2PostingBlockSummaryEqual(s.computed, s.block.Summary) {
+		s.err = errMalformedTextStorage("text-v2 posting block summary/upper-bound metadata mismatch")
+	}
+}
+
+func scanTextV2PostingBlocksForTerm(
+	snap *backenddb.Snapshot,
+	catalog *collectionCatalog,
+	rootName string,
+	term string,
+	fn func(key textV2PostingBlockKey, summary textV2PostingBlockSummary, entries *textV2PostingBlockEntryScanner) error,
+) error {
+	prefix := encodeTextV2PostingBlockTermPrefix(term)
+	it, err := collectionIteratorAtCatalogRoot(snap, catalog, rootName, prefix, textSearchPrefixEnd(prefix), true)
+	if err != nil || it == nil {
+		return err
+	}
+	defer func() { _ = it.Close() }()
+	var scratch []uint32
+	for it.Valid() {
+		keyBytes := it.UnsafeKey()
+		if !bytes.HasPrefix(keyBytes, prefix) {
+			break
+		}
+		if it.IsDeleted() {
+			it.Next()
+			continue
+		}
+		key, err := decodeTextV2PostingBlockKeyForPrefix(keyBytes, prefix)
+		if err != nil {
+			return err
+		}
+		scanner, err := newTextV2PostingBlockEntryScanner(it.UnsafeValue(), scratch)
+		if err != nil {
+			return err
+		}
+		if scanner.block.BlockStart != key.BlockStart || scanner.block.BlockID != key.BlockID {
+			return errMalformedTextStorage("text-v2 posting block key/value identity mismatch")
+		}
+		if err := fn(key, scanner.Summary(), scanner); err != nil {
+			return err
+		}
+		var entry textV2PostingBlockEntry
+		for scanner.Next(&entry) {
+		}
+		if err := scanner.Err(); err != nil {
+			return err
+		}
+		scratch = scanner.fieldScratch
+		it.Next()
+	}
+	return it.Error()
+}
+
+func newTextV2PostingBlockValue(kind textV2PostingBlockKind, entries []textV2PostingBlockEntry, fieldCount uint32, blockID uint64) (textV2PostingBlockValue, error) {
+	if len(entries) == 0 {
+		return textV2PostingBlockValue{}, errMalformedTextStorage("text-v2 posting block cannot be empty")
+	}
+	if uint64(len(entries)) > uint64(textV2PostingBlockMaxPostings) {
+		return textV2PostingBlockValue{}, errMalformedTextStorage("text-v2 posting block entries exceed max")
+	}
+	if fieldCount == 0 || fieldCount > textV2PostingBlockMaxFieldCount {
+		return textV2PostingBlockValue{}, errMalformedTextStorage("text-v2 posting block invalid field count %d", fieldCount)
+	}
+	if blockID == 0 {
+		return textV2PostingBlockValue{}, errMalformedTextStorage("text-v2 posting block id cannot be zero")
+	}
+	if !isSupportedTextV2PostingBlockKind(kind) {
+		return textV2PostingBlockValue{}, errMalformedTextStorage("text-v2 posting block unsupported kind %d", byte(kind))
+	}
+	cloned := cloneTextV2PostingBlockEntries(entries)
+	slices.SortFunc(cloned, func(a, b textV2PostingBlockEntry) int { return compareUint64(a.Ordinal, b.Ordinal) })
+	summary := textV2PostingBlockSummary{
+		FirstOrdinal:            cloned[0].Ordinal,
+		LastOrdinal:             cloned[len(cloned)-1].Ordinal,
+		DocCount:                uint32(len(cloned)),
+		MaxFieldTermFrequencies: make([]uint32, fieldCount),
+		UpperBoundKind:          textV2PostingUpperBoundKindBM25FLaneMax,
+	}
+	var prev uint64
+	for i, entry := range cloned {
+		if entry.Ordinal == 0 || entry.Generation == 0 || entry.TermFrequency == 0 {
+			return textV2PostingBlockValue{}, errMalformedTextStorage("text-v2 posting block entry[%d] invalid ordinal/generation/frequency", i)
+		}
+		if entry.Flags&^textV2PostingBlockEntrySupportedFlags != 0 {
+			return textV2PostingBlockValue{}, errMalformedTextStorage("text-v2 posting block entry[%d] unsupported flags 0x%x", i, entry.Flags)
+		}
+		if i > 0 && entry.Ordinal <= prev {
+			return textV2PostingBlockValue{}, errMalformedTextStorage("text-v2 posting block entry[%d] duplicate or out-of-order ordinal", i)
+		}
+		if len(entry.FieldFrequencies) != int(fieldCount) {
+			return textV2PostingBlockValue{}, errMalformedTextStorage("text-v2 posting block entry[%d] field count %d want %d", i, len(entry.FieldFrequencies), fieldCount)
+		}
+		var fieldSum uint64
+		for j, fieldTF := range entry.FieldFrequencies {
+			fieldSum += uint64(fieldTF)
+			if fieldTF > summary.MaxFieldTermFrequencies[j] {
+				summary.MaxFieldTermFrequencies[j] = fieldTF
+			}
+		}
+		if fieldSum != uint64(entry.TermFrequency) {
+			return textV2PostingBlockValue{}, errMalformedTextStorage("text-v2 posting block entry[%d] field frequencies sum %d does not match term frequency %d", i, fieldSum, entry.TermFrequency)
+		}
+		if entry.TermFrequency > summary.MaxTermFrequency {
+			summary.MaxTermFrequency = entry.TermFrequency
+		}
+		prev = entry.Ordinal
+	}
+	return textV2PostingBlockValue{
+		FormatVersion: textV2FormatVersion,
+		Kind:          kind,
+		BlockStart:    summary.FirstOrdinal,
+		BlockID:       blockID,
+		Summary:       summary,
+		Entries:       cloned,
+	}, nil
+}
+
+func isSupportedTextV2PostingBlockKind(kind textV2PostingBlockKind) bool {
+	switch kind {
+	case textV2PostingBlockKindSealed, textV2PostingBlockKindDelta, textV2PostingBlockKindMicro:
+		return true
+	default:
+		return false
+	}
+}
+
+func estimateTextV2PostingBlockValueLen(value textV2PostingBlockValue, entries []textV2PostingBlockEntry, fieldCount uint32) int {
+	n := 1 + 2 + 10*10 + int(fieldCount)*binary.MaxVarintLen64
+	for _, entry := range entries {
+		n += 3*binary.MaxVarintLen64 + 1 + len(entry.FieldFrequencies)*binary.MaxVarintLen64
+	}
+	return n + len(value.Summary.MaxFieldTermFrequencies)
+}
+
+func cloneTextV2PostingBlockEntries(entries []textV2PostingBlockEntry) []textV2PostingBlockEntry {
+	out := make([]textV2PostingBlockEntry, len(entries))
+	for i, entry := range entries {
+		out[i] = textV2PostingBlockEntry{
+			Ordinal:          entry.Ordinal,
+			Generation:       entry.Generation,
+			TermFrequency:    entry.TermFrequency,
+			FieldFrequencies: append([]uint32(nil), entry.FieldFrequencies...),
+			Flags:            entry.Flags,
+		}
+	}
+	return out
+}
+
+func cloneTextV2PostingBlockSummary(summary textV2PostingBlockSummary) textV2PostingBlockSummary {
+	return textV2PostingBlockSummary{
+		FirstOrdinal:            summary.FirstOrdinal,
+		LastOrdinal:             summary.LastOrdinal,
+		DocCount:                summary.DocCount,
+		MaxTermFrequency:        summary.MaxTermFrequency,
+		MaxFieldTermFrequencies: append([]uint32(nil), summary.MaxFieldTermFrequencies...),
+		UpperBoundKind:          summary.UpperBoundKind,
+	}
+}
+
+func textV2PostingBlockSummaryEqual(a, b textV2PostingBlockSummary) bool {
+	return a.FirstOrdinal == b.FirstOrdinal &&
+		a.LastOrdinal == b.LastOrdinal &&
+		a.DocCount == b.DocCount &&
+		a.MaxTermFrequency == b.MaxTermFrequency &&
+		a.UpperBoundKind == b.UpperBoundKind &&
+		slices.Equal(a.MaxFieldTermFrequencies, b.MaxFieldTermFrequencies)
+}

--- a/TreeDB/collections/text_v2_posting_blocks.go
+++ b/TreeDB/collections/text_v2_posting_blocks.go
@@ -247,6 +247,9 @@ func buildTextV2PostingBlockKVs(term string, entries []textV2PostingBlockEntry, 
 	}
 	sorted := cloneTextV2PostingBlockEntries(entries)
 	slices.SortFunc(sorted, func(a, b textV2PostingBlockEntry) int { return compareUint64(a.Ordinal, b.Ordinal) })
+	if err := validateTextV2PostingBlockBuilderEntries(sorted, fieldCount); err != nil {
+		return nil, err
+	}
 	out := make([]textV2PostingBlockKV, 0, (len(sorted)+int(target)-1)/int(target))
 	for start := 0; start < len(sorted); {
 		chunkLen := min(int(target), len(sorted)-start)
@@ -610,6 +613,30 @@ func scanTextV2PostingBlocksForTerm(
 		it.Next()
 	}
 	return it.Error()
+}
+
+func validateTextV2PostingBlockBuilderEntries(entries []textV2PostingBlockEntry, fieldCount uint32) error {
+	var prev uint64
+	for i, entry := range entries {
+		if entry.Ordinal == 0 || entry.Generation == 0 || entry.TermFrequency == 0 {
+			return errMalformedTextStorage("text-v2 posting block entry[%d] invalid ordinal/generation/frequency", i)
+		}
+		if i > 0 && entry.Ordinal == prev {
+			return errMalformedTextStorage("text-v2 posting block duplicate ordinal %d", entry.Ordinal)
+		}
+		if len(entry.FieldFrequencies) != int(fieldCount) {
+			return errMalformedTextStorage("text-v2 posting block entry[%d] field count %d want %d", i, len(entry.FieldFrequencies), fieldCount)
+		}
+		var fieldSum uint64
+		for _, fieldTF := range entry.FieldFrequencies {
+			fieldSum += uint64(fieldTF)
+		}
+		if fieldSum != uint64(entry.TermFrequency) {
+			return errMalformedTextStorage("text-v2 posting block entry[%d] field frequencies sum %d does not match term frequency %d", i, fieldSum, entry.TermFrequency)
+		}
+		prev = entry.Ordinal
+	}
+	return nil
 }
 
 func newTextV2PostingBlockValue(kind textV2PostingBlockKind, entries []textV2PostingBlockEntry, fieldCount uint32, blockID uint64) (textV2PostingBlockValue, error) {

--- a/TreeDB/collections/text_v2_posting_blocks_test.go
+++ b/TreeDB/collections/text_v2_posting_blocks_test.go
@@ -117,15 +117,15 @@ func TestTextV2PostingBlockIteratorOrderAcrossTerms2625(t *testing.T) {
 	col := createTextV2PostingBlockCollection2625(t, d, 4, RootStorageFast)
 	rootName := collectionTextV2PostingBlocksRootName("docs", "lexical")
 	refundEntries := []textV2PostingBlockEntry{
-		{Ordinal: 1, Generation: 1, TermFrequency: 2, FieldFrequencies: []uint32{2}},
-		{Ordinal: 2, Generation: 1, TermFrequency: 1, FieldFrequencies: []uint32{1}},
-		{Ordinal: 4, Generation: 1, TermFrequency: 3, FieldFrequencies: []uint32{3}},
+		{Ordinal: 1, Generation: 1, TermFrequency: 2, FieldFrequencies: []uint32{2, 0}},
+		{Ordinal: 2, Generation: 1, TermFrequency: 1, FieldFrequencies: []uint32{1, 0}},
+		{Ordinal: 4, Generation: 1, TermFrequency: 3, FieldFrequencies: []uint32{3, 0}},
 	}
-	refundBlocks, err := buildTextV2PostingBlockKVs("refund", refundEntries, 1, textV2PostingBlockBuildOptions{TargetPostings: 1})
+	refundBlocks, err := buildTextV2PostingBlockKVs("refund", refundEntries, 2, textV2PostingBlockBuildOptions{TargetPostings: 1})
 	if err != nil {
 		t.Fatalf("build refund blocks: %v", err)
 	}
-	shippingBlocks, err := buildTextV2PostingBlockKVs("shipping", []textV2PostingBlockEntry{{Ordinal: 3, Generation: 1, TermFrequency: 1, FieldFrequencies: []uint32{1}}}, 1, textV2PostingBlockBuildOptions{})
+	shippingBlocks, err := buildTextV2PostingBlockKVs("shipping", []textV2PostingBlockEntry{{Ordinal: 3, Generation: 1, TermFrequency: 1, FieldFrequencies: []uint32{1, 0}}}, 2, textV2PostingBlockBuildOptions{})
 	if err != nil {
 		t.Fatalf("build shipping blocks: %v", err)
 	}
@@ -272,12 +272,58 @@ func TestTextV2PostingBlocksReachValueLogMaintenance2625(t *testing.T) {
 	}
 }
 
-func TestTextV2PostingBlockStorageFailsClosedOnCorruption2625(t *testing.T) {
+func TestTextV2PostingBlocksNotEmittedByBackfillOrMutationsBeforeM32625(t *testing.T) {
+	d := openTextV2PostingBlockDB2625(t, t.TempDir(), false)
+	defer func() { _ = d.Close() }()
+	col := createTextV2PostingBlockCollection2625(t, d, 2, RootStorageFast)
+	stats, err := col.TextIndexStorageStats("lexical")
+	if err != nil {
+		t.Fatalf("TextIndexStorageStats after backfill: %v", err)
+	}
+	if stats.V2PostingBlocks != 0 {
+		t.Fatalf("v2 posting blocks after M2 backfill=%d want 0 until M3", stats.V2PostingBlocks)
+	}
+	if _, _, err := col.Update([]byte("doc-000001"), func([]byte) ([]byte, bool, error) {
+		return []byte(`{"body":"refund updated","title":"updated"}`), true, nil
+	}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if deleted, err := col.DeleteBatch([][]byte{[]byte("doc-000002")}); err != nil || deleted != 1 {
+		t.Fatalf("DeleteBatch deleted=%d err=%v", deleted, err)
+	}
+	if _, err := col.Insert([]byte("doc-000003"), []byte(`{"body":"refund new","title":"new"}`)); err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+	stats, err = col.TextIndexStorageStats("lexical")
+	if err != nil {
+		t.Fatalf("TextIndexStorageStats after mutations: %v", err)
+	}
+	if stats.V2PostingBlocks != 0 {
+		t.Fatalf("v2 posting blocks after M2 mutations=%d want 0 until M3", stats.V2PostingBlocks)
+	}
+}
+
+func TestTextV2PostingBlockStorageFailsClosedOnFieldLaneMismatch2625(t *testing.T) {
 	d := openTextV2PostingBlockDB2625(t, t.TempDir(), false)
 	defer func() { _ = d.Close() }()
 	col := createTextV2PostingBlockCollection2625(t, d, 2, RootStorageFast)
 	rootName := collectionTextV2PostingBlocksRootName("docs", "lexical")
 	block, err := newTextV2PostingBlockValue(textV2PostingBlockKindSealed, []textV2PostingBlockEntry{{Ordinal: 1, Generation: 1, TermFrequency: 1, FieldFrequencies: []uint32{1}}}, 1, 1)
+	if err != nil {
+		t.Fatalf("new block: %v", err)
+	}
+	corruptTextRootValue(t, d, "docs", rootName, encodeTextV2PostingBlockKey("refund", block.BlockStart, block.BlockID), encodeTextV2PostingBlockValue(block))
+	if _, err := col.TextIndexStorageStats("lexical"); !errors.Is(err, ErrTextIndexStorageCorrupt) {
+		t.Fatalf("field-lane mismatch stats err=%v want ErrTextIndexStorageCorrupt", err)
+	}
+}
+
+func TestTextV2PostingBlockStorageFailsClosedOnCorruption2625(t *testing.T) {
+	d := openTextV2PostingBlockDB2625(t, t.TempDir(), false)
+	defer func() { _ = d.Close() }()
+	col := createTextV2PostingBlockCollection2625(t, d, 2, RootStorageFast)
+	rootName := collectionTextV2PostingBlocksRootName("docs", "lexical")
+	block, err := newTextV2PostingBlockValue(textV2PostingBlockKindSealed, []textV2PostingBlockEntry{{Ordinal: 1, Generation: 1, TermFrequency: 1, FieldFrequencies: []uint32{1, 0}}}, 2, 1)
 	if err != nil {
 		t.Fatalf("new block: %v", err)
 	}

--- a/TreeDB/collections/text_v2_posting_blocks_test.go
+++ b/TreeDB/collections/text_v2_posting_blocks_test.go
@@ -111,6 +111,15 @@ func TestTextV2PostingBlockCodecRoundTripAndFailClosed2625(t *testing.T) {
 	}
 }
 
+func TestTextV2PostingBlockBuilderRejectsDuplicateOrdinalAcrossDefaultBoundary2625(t *testing.T) {
+	entries := syntheticTextV2PostingEntries2625(int(textV2PostingBlockTargetPostings)+1, 2)
+	entries[textV2PostingBlockTargetPostings].Ordinal = uint64(textV2PostingBlockTargetPostings)
+	_, err := buildTextV2PostingBlockKVs("refund", entries, 2, textV2PostingBlockBuildOptions{})
+	if !errors.Is(err, ErrTextIndexStorageCorrupt) {
+		t.Fatalf("duplicate boundary ordinal err=%v want ErrTextIndexStorageCorrupt", err)
+	}
+}
+
 func TestTextV2PostingBlockIteratorOrderAcrossTerms2625(t *testing.T) {
 	d := openTextV2PostingBlockDB2625(t, t.TempDir(), false)
 	defer func() { _ = d.Close() }()

--- a/TreeDB/collections/text_v2_posting_blocks_test.go
+++ b/TreeDB/collections/text_v2_posting_blocks_test.go
@@ -1,0 +1,540 @@
+package collections
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"slices"
+	"strings"
+	"testing"
+
+	treedb "github.com/snissn/gomap/TreeDB"
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+)
+
+var textV2PostingBlockBenchSink2625 uint64
+
+type textV2PostingParityPosting2625 struct {
+	tf     uint32
+	fields []uint32
+}
+
+func TestTextV2PostingBlockCodecRoundTripAndFailClosed2625(t *testing.T) {
+	for _, term := range []string{"", strings.Repeat("term", 512)} {
+		key := encodeTextV2PostingBlockKey(term, 1, 7)
+		decoded, err := decodeTextV2PostingBlockKey(key)
+		if err != nil {
+			t.Fatalf("decode key term len=%d: %v", len(term), err)
+		}
+		if decoded.Term != term || decoded.BlockStart != 1 || decoded.BlockID != 7 {
+			t.Fatalf("decoded key=%+v want term len=%d start=1 id=7", decoded, len(term))
+		}
+		prefix := encodeTextV2PostingBlockTermPrefix(term)
+		decoded, err = decodeTextV2PostingBlockKeyForPrefix(key, prefix)
+		if err != nil || decoded.Term != term {
+			t.Fatalf("decode key for prefix=%+v err=%v", decoded, err)
+		}
+	}
+	if _, err := decodeTextV2PostingBlockKey([]byte{textV2KeyVersion, textV2KeyKindPostingBlock, 0}); !errors.Is(err, ErrTextIndexStorageCorrupt) {
+		t.Fatalf("short key err=%v want ErrTextIndexStorageCorrupt", err)
+	}
+	if _, err := decodeTextV2PostingBlockKey(encodeTextV2PostingBlockKey("refund", 0, 1)); !errors.Is(err, ErrTextIndexStorageCorrupt) {
+		t.Fatalf("zero blockStart err=%v want ErrTextIndexStorageCorrupt", err)
+	}
+
+	entries := []textV2PostingBlockEntry{
+		{Ordinal: 1, Generation: 1, TermFrequency: 3, FieldFrequencies: []uint32{2, 1}},
+		{Ordinal: 1<<40 + 9, Generation: 7, TermFrequency: math.MaxUint32, FieldFrequencies: []uint32{math.MaxUint32, 0}},
+		{Ordinal: 1<<40 + 29, Generation: 8, TermFrequency: 5, FieldFrequencies: []uint32{2, 3}},
+	}
+	for _, kind := range []textV2PostingBlockKind{textV2PostingBlockKindSealed, textV2PostingBlockKindDelta, textV2PostingBlockKindMicro} {
+		block, err := newTextV2PostingBlockValue(kind, entries, 2, 5)
+		if err != nil {
+			t.Fatalf("new block kind=%s: %v", kind, err)
+		}
+		encoded := encodeTextV2PostingBlockValue(block)
+		decoded, err := decodeTextV2PostingBlockValue(encoded)
+		if err != nil {
+			t.Fatalf("decode kind=%s: %v", kind, err)
+		}
+		if decoded.Kind != kind || decoded.BlockStart != 1 || decoded.BlockID != 5 || decoded.Summary.DocCount != 3 || decoded.Summary.MaxTermFrequency != math.MaxUint32 || !slices.Equal(decoded.Summary.MaxFieldTermFrequencies, []uint32{math.MaxUint32, 3}) {
+			t.Fatalf("decoded block=%+v", decoded)
+		}
+		if len(decoded.Entries) != len(entries) || decoded.Entries[1].Ordinal != entries[1].Ordinal || !slices.Equal(decoded.Entries[2].FieldFrequencies, []uint32{2, 3}) {
+			t.Fatalf("decoded entries=%+v want %+v", decoded.Entries, entries)
+		}
+	}
+
+	block, err := newTextV2PostingBlockValue(textV2PostingBlockKindSealed, entries, 2, 5)
+	if err != nil {
+		t.Fatalf("new block: %v", err)
+	}
+	encoded := encodeTextV2PostingBlockValue(block)
+	malformed := []struct {
+		name string
+		raw  []byte
+	}{
+		{name: "value version", raw: mutatePostingBlockRaw2625(encoded, 0, 99)},
+		{name: "format version", raw: mutatePostingBlockRaw2625(encoded, 1, 99)},
+		{name: "kind", raw: mutatePostingBlockRaw2625(encoded, 2, 99)},
+		{name: "value flags", raw: mutatePostingBlockRaw2625(encoded, 3, 1)},
+		{name: "summary doc count", raw: encodeTextV2PostingBlockValue(func() textV2PostingBlockValue { b := block; b.Summary.DocCount = 2; return b }())},
+		{name: "summary max tf", raw: encodeTextV2PostingBlockValue(func() textV2PostingBlockValue { b := block; b.Summary.MaxTermFrequency = 3; return b }())},
+		{name: "summary field max", raw: encodeTextV2PostingBlockValue(func() textV2PostingBlockValue {
+			b := block
+			b.Summary.MaxFieldTermFrequencies = []uint32{2, 3}
+			return b
+		}())},
+		{name: "unsupported upper bound", raw: encodeTextV2PostingBlockValue(func() textV2PostingBlockValue { b := block; b.Summary.UpperBoundKind = 99; return b }())},
+		{name: "entry flags", raw: encodeTextV2PostingBlockValue(func() textV2PostingBlockValue {
+			b := block
+			b.Entries = cloneTextV2PostingBlockEntries(block.Entries)
+			b.Entries[0].Flags = 1
+			return b
+		}())},
+		{name: "field sum mismatch", raw: encodeTextV2PostingBlockValue(func() textV2PostingBlockValue {
+			b := block
+			b.Entries = cloneTextV2PostingBlockEntries(block.Entries)
+			b.Entries[0].FieldFrequencies[0] = 1
+			return b
+		}())},
+	}
+	for _, tc := range malformed {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := decodeTextV2PostingBlockValue(tc.raw)
+			if !errors.Is(err, ErrTextIndexStorageCorrupt) {
+				t.Fatalf("err=%v want ErrTextIndexStorageCorrupt", err)
+			}
+		})
+	}
+}
+
+func TestTextV2PostingBlockIteratorOrderAcrossTerms2625(t *testing.T) {
+	d := openTextV2PostingBlockDB2625(t, t.TempDir(), false)
+	defer func() { _ = d.Close() }()
+	col := createTextV2PostingBlockCollection2625(t, d, 4, RootStorageFast)
+	rootName := collectionTextV2PostingBlocksRootName("docs", "lexical")
+	refundEntries := []textV2PostingBlockEntry{
+		{Ordinal: 1, Generation: 1, TermFrequency: 2, FieldFrequencies: []uint32{2}},
+		{Ordinal: 2, Generation: 1, TermFrequency: 1, FieldFrequencies: []uint32{1}},
+		{Ordinal: 4, Generation: 1, TermFrequency: 3, FieldFrequencies: []uint32{3}},
+	}
+	refundBlocks, err := buildTextV2PostingBlockKVs("refund", refundEntries, 1, textV2PostingBlockBuildOptions{TargetPostings: 1})
+	if err != nil {
+		t.Fatalf("build refund blocks: %v", err)
+	}
+	shippingBlocks, err := buildTextV2PostingBlockKVs("shipping", []textV2PostingBlockEntry{{Ordinal: 3, Generation: 1, TermFrequency: 1, FieldFrequencies: []uint32{1}}}, 1, textV2PostingBlockBuildOptions{})
+	if err != nil {
+		t.Fatalf("build shipping blocks: %v", err)
+	}
+	for _, kv := range append(refundBlocks, shippingBlocks...) {
+		corruptTextRootValue(t, d, "docs", rootName, kv.Key, kv.Value)
+	}
+
+	var blockStarts []uint64
+	var ordinals []uint64
+	withTextCatalog(t, d, "docs", func(snap *backenddb.Snapshot, catalog *collectionCatalog) {
+		err = scanTextV2PostingBlocksForTerm(snap, catalog, rootName, "refund", func(key textV2PostingBlockKey, summary textV2PostingBlockSummary, scanner *textV2PostingBlockEntryScanner) error {
+			blockStarts = append(blockStarts, key.BlockStart)
+			if key.Term != "refund" || summary.FirstOrdinal != key.BlockStart || summary.DocCount != 1 {
+				return fmt.Errorf("bad block key=%+v summary=%+v", key, summary)
+			}
+			var entry textV2PostingBlockEntry
+			for scanner.Next(&entry) {
+				ordinals = append(ordinals, entry.Ordinal)
+			}
+			return scanner.Err()
+		})
+	})
+	if err != nil {
+		t.Fatalf("scan refund: %v", err)
+	}
+	if !slices.Equal(blockStarts, []uint64{1, 2, 4}) || !slices.Equal(ordinals, []uint64{1, 2, 4}) {
+		t.Fatalf("blockStarts=%v ordinals=%v want refund blocks only in ordinal order", blockStarts, ordinals)
+	}
+	stats, err := col.TextIndexStorageStats("lexical")
+	if err != nil {
+		t.Fatalf("TextIndexStorageStats: %v", err)
+	}
+	if stats.V2PostingBlocks != 4 {
+		t.Fatalf("posting blocks=%d want 4", stats.V2PostingBlocks)
+	}
+}
+
+func TestTextV2PostingBlocksReconstructV1EquivalentPostings2625(t *testing.T) {
+	def := TextIndexDefinition{Name: "lexical", Fields: []TextIndexField{{Field: "body"}, {Field: "title", Weight: 2}}}
+	docs := [][]byte{
+		[]byte(`{"body":"refund refund policy","title":"Refund"}`),
+		[]byte(`{"body":"shipping policy","title":"Policy"}`),
+		[]byte(`{"body":"refund shipping refund","title":"Shipping refund"}`),
+		[]byte(`{"body":"other","title":""}`),
+	}
+	want := make(map[string]map[uint64]textV2PostingParityPosting2625)
+	byTerm := make(map[string][]textV2PostingBlockEntry)
+	for i, doc := range docs {
+		analysis, err := analyzeTextIndexDocument(def, doc)
+		if err != nil {
+			t.Fatalf("analyze doc %d: %v", i, err)
+		}
+		ordinal := uint64(i + 1)
+		perDoc := make(map[string]*textV2PostingBlockEntry)
+		for fieldIndex, field := range analysis.Fields {
+			for term, analyzed := range field.Terms {
+				entry := perDoc[term]
+				if entry == nil {
+					entry = &textV2PostingBlockEntry{Ordinal: ordinal, Generation: 1, FieldFrequencies: make([]uint32, len(def.Fields))}
+					perDoc[term] = entry
+				}
+				entry.TermFrequency += analyzed.Frequency
+				entry.FieldFrequencies[fieldIndex] += analyzed.Frequency
+			}
+		}
+		for term, entry := range perDoc {
+			byTerm[term] = append(byTerm[term], *entry)
+			if want[term] == nil {
+				want[term] = make(map[uint64]textV2PostingParityPosting2625)
+			}
+			want[term][ordinal] = textV2PostingParityPosting2625{tf: entry.TermFrequency, fields: append([]uint32(nil), entry.FieldFrequencies...)}
+		}
+	}
+	for term, entries := range byTerm {
+		blocks, err := buildTextV2PostingBlockKVs(term, entries, uint32(len(def.Fields)), textV2PostingBlockBuildOptions{TargetPostings: 2})
+		if err != nil {
+			t.Fatalf("build term %q: %v", term, err)
+		}
+		got := make(map[uint64]textV2PostingParityPosting2625)
+		for _, kv := range blocks {
+			scanner, err := newTextV2PostingBlockEntryScanner(kv.Value, nil)
+			if err != nil {
+				t.Fatalf("scanner term %q: %v", term, err)
+			}
+			var entry textV2PostingBlockEntry
+			for scanner.Next(&entry) {
+				got[entry.Ordinal] = textV2PostingParityPosting2625{tf: entry.TermFrequency, fields: append([]uint32(nil), entry.FieldFrequencies...)}
+			}
+			if err := scanner.Err(); err != nil {
+				t.Fatalf("scan term %q: %v", term, err)
+			}
+		}
+		if !postingParityEqual2625(got, want[term]) {
+			t.Fatalf("term %q got=%+v want=%+v", term, got, want[term])
+		}
+	}
+}
+
+func TestTextV2PostingBlocksReachValueLogMaintenance2625(t *testing.T) {
+	dir := t.TempDir()
+	d, closeDB := openTextV2PostingBlockCompressedDB2625(t, dir)
+	col := createTextV2PostingBlockCollection2625(t, d, 32, RootStorageCompressed)
+	rootName := collectionTextV2PostingBlocksRootName("docs", "lexical")
+	entries := make([]textV2PostingBlockEntry, 0, 32)
+	for i := uint64(1); i <= 32; i++ {
+		entries = append(entries, textV2PostingBlockEntry{Ordinal: i, Generation: 1, TermFrequency: 3, FieldFrequencies: []uint32{2, 1}})
+	}
+	blocks, err := buildTextV2PostingBlockKVs("refund", entries, 2, textV2PostingBlockBuildOptions{TargetPostings: 64})
+	if err != nil {
+		t.Fatalf("build blocks: %v", err)
+	}
+	if len(blocks) != 1 {
+		t.Fatalf("blocks=%d want 1", len(blocks))
+	}
+	corruptTextRootValue(t, d, "docs", rootName, blocks[0].Key, blocks[0].Value)
+	before := textV2ReadRootBytes2624(t, d, "docs", rootName, blocks[0].Key)
+	if stats, err := col.TextIndexStorageStats("lexical"); err != nil || stats.V2PostingBlocks != 1 {
+		t.Fatalf("TextIndexStorageStats before GC=%+v err=%v want one posting block", stats, err)
+	}
+	if _, err := d.ValueLogGC(context.Background(), backenddb.ValueLogGCOptions{}); err != nil {
+		t.Fatalf("ValueLogGC: %v", err)
+	}
+	if after := textV2ReadRootBytes2624(t, d, "docs", rootName, blocks[0].Key); !bytes.Equal(after, before) {
+		t.Fatalf("posting block changed after ValueLogGC")
+	}
+	if err := closeDB(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	reopened, closeReopened := openTextV2PostingBlockCompressedDB2625(t, dir)
+	defer func() { _ = closeReopened() }()
+	if after := textV2ReadRootBytes2624(t, reopened, "docs", rootName, blocks[0].Key); !bytes.Equal(after, before) {
+		t.Fatalf("posting block not reachable after reopen/GC")
+	}
+	reopenedCol, err := NewCollectionManager(reopened).OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("OpenCollection reopened: %v", err)
+	}
+	stats, err := reopenedCol.TextIndexStorageStats("lexical")
+	if err != nil {
+		t.Fatalf("reopened TextIndexStorageStats: %v", err)
+	}
+	if stats.V2PostingBlocks != 1 {
+		t.Fatalf("reopened posting blocks=%d want 1", stats.V2PostingBlocks)
+	}
+}
+
+func TestTextV2PostingBlockStorageFailsClosedOnCorruption2625(t *testing.T) {
+	d := openTextV2PostingBlockDB2625(t, t.TempDir(), false)
+	defer func() { _ = d.Close() }()
+	col := createTextV2PostingBlockCollection2625(t, d, 2, RootStorageFast)
+	rootName := collectionTextV2PostingBlocksRootName("docs", "lexical")
+	block, err := newTextV2PostingBlockValue(textV2PostingBlockKindSealed, []textV2PostingBlockEntry{{Ordinal: 1, Generation: 1, TermFrequency: 1, FieldFrequencies: []uint32{1}}}, 1, 1)
+	if err != nil {
+		t.Fatalf("new block: %v", err)
+	}
+	bad := block
+	bad.Summary.MaxTermFrequency = 0
+	corruptTextRootValue(t, d, "docs", rootName, encodeTextV2PostingBlockKey("refund", block.BlockStart, block.BlockID), encodeTextV2PostingBlockValue(bad))
+	if _, err := col.TextIndexStorageStats("lexical"); !errors.Is(err, ErrTextIndexStorageCorrupt) {
+		t.Fatalf("corrupt posting block stats err=%v want ErrTextIndexStorageCorrupt", err)
+	}
+}
+
+func BenchmarkTextV2PostingBlockCodec2625(b *testing.B) {
+	entries := syntheticTextV2PostingEntries2625(128, 2)
+	block, err := newTextV2PostingBlockValue(textV2PostingBlockKindSealed, entries, 2, 1)
+	if err != nil {
+		b.Fatalf("new block: %v", err)
+	}
+	encoded := encodeTextV2PostingBlockValue(block)
+	b.Run("encode_128", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ReportMetric(float64(len(encoded))/float64(len(entries)), "bytes/posting")
+		for i := 0; i < b.N; i++ {
+			textV2PostingBlockBenchSink2625 += uint64(len(encodeTextV2PostingBlockValue(block)))
+		}
+	})
+	b.Run("decode_128", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ReportMetric(float64(len(encoded))/float64(len(entries)), "bytes/posting")
+		for i := 0; i < b.N; i++ {
+			decoded, err := decodeTextV2PostingBlockValue(encoded)
+			if err != nil {
+				b.Fatal(err)
+			}
+			textV2PostingBlockBenchSink2625 += uint64(len(decoded.Entries))
+		}
+	})
+	b.Run("scan_128_reused_entry", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ReportMetric(float64(len(encoded))/float64(len(entries)), "bytes/posting")
+		for i := 0; i < b.N; i++ {
+			scanner, err := newTextV2PostingBlockEntryScanner(encoded, nil)
+			if err != nil {
+				b.Fatal(err)
+			}
+			var entry textV2PostingBlockEntry
+			var count uint64
+			for scanner.Next(&entry) {
+				count += uint64(entry.TermFrequency)
+			}
+			if err := scanner.Err(); err != nil {
+				b.Fatal(err)
+			}
+			textV2PostingBlockBenchSink2625 += count
+		}
+	})
+}
+
+func BenchmarkTextV2PostingBlockRangeScanVsV1Synthetic2625(b *testing.B) {
+	for _, docs := range []int{8, 10_000} {
+		name := "rare"
+		if docs > 100 {
+			name = "common"
+		}
+		v1 := syntheticTextV1PostingRows2625("refund", docs)
+		v2Blocks, err := buildTextV2PostingBlockKVs("refund", syntheticTextV2PostingEntries2625(docs, 2), 2, textV2PostingBlockBuildOptions{})
+		if err != nil {
+			b.Fatalf("build v2 docs=%d: %v", docs, err)
+		}
+		var v2Bytes int
+		for _, kv := range v2Blocks {
+			v2Bytes += len(kv.Key) + len(kv.Value)
+		}
+		b.Run(fmt.Sprintf("%s_%d/v1_per_doc_decode", name, docs), func(b *testing.B) {
+			b.ReportAllocs()
+			b.ReportMetric(float64(len(v1)), "postings/op")
+			for i := 0; i < b.N; i++ {
+				var sum uint64
+				prefix := encodeTextPostingTermPrefix("refund")
+				for _, row := range v1 {
+					if _, err := decodeTextPostingKeyDocumentIDForPrefix(row.key, prefix); err != nil {
+						b.Fatal(err)
+					}
+					posting, err := decodeTextPostingValueForSearch(row.value, []string{"body", "title"})
+					if err != nil {
+						b.Fatal(err)
+					}
+					sum += uint64(posting.TermFrequency)
+				}
+				textV2PostingBlockBenchSink2625 += sum
+			}
+		})
+		b.Run(fmt.Sprintf("%s_%d/v2_block_scan", name, docs), func(b *testing.B) {
+			b.ReportAllocs()
+			b.ReportMetric(float64(docs), "postings/op")
+			b.ReportMetric(float64(len(v2Blocks)), "blocks/op")
+			b.ReportMetric(float64(v2Bytes)/float64(docs), "bytes/posting")
+			for i := 0; i < b.N; i++ {
+				var sum uint64
+				var scratch []uint32
+				for _, kv := range v2Blocks {
+					scanner, err := newTextV2PostingBlockEntryScanner(kv.Value, scratch)
+					if err != nil {
+						b.Fatal(err)
+					}
+					var entry textV2PostingBlockEntry
+					for scanner.Next(&entry) {
+						sum += uint64(entry.TermFrequency)
+					}
+					if err := scanner.Err(); err != nil {
+						b.Fatal(err)
+					}
+					scratch = scanner.fieldScratch
+				}
+				textV2PostingBlockBenchSink2625 += sum
+			}
+		})
+	}
+}
+
+func BenchmarkTextV2PostingBlockEncodeUpdate2625(b *testing.B) {
+	const docs = 100_000
+	initial, err := buildTextV2PostingBlockKVs("refund", syntheticTextV2PostingEntries2625(docs, 2), 2, textV2PostingBlockBuildOptions{})
+	if err != nil {
+		b.Fatalf("build initial: %v", err)
+	}
+	var initialBytes int
+	for _, kv := range initial {
+		initialBytes += len(kv.Key) + len(kv.Value)
+	}
+	b.Run("build_sealed_100k", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ReportMetric(float64(docs), "postings/op")
+		b.ReportMetric(float64(len(initial)), "blocks_emitted/op")
+		b.ReportMetric(float64(initialBytes)/float64(docs), "bytes/posting")
+		for i := 0; i < b.N; i++ {
+			blocks, err := buildTextV2PostingBlockKVs("refund", syntheticTextV2PostingEntries2625(docs, 2), 2, textV2PostingBlockBuildOptions{})
+			if err != nil {
+				b.Fatal(err)
+			}
+			textV2PostingBlockBenchSink2625 += uint64(len(blocks))
+		}
+	})
+	b.Run("append_microblock_one_doc", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ReportMetric(1, "blocks_emitted/update")
+		b.ReportMetric(1, "postings_reencoded/update")
+		b.ReportMetric(float64(docs), "prior_df/not_reencoded")
+		for i := 0; i < b.N; i++ {
+			entry := textV2PostingBlockEntry{Ordinal: uint64(docs + 1 + i), Generation: 1, TermFrequency: 2, FieldFrequencies: []uint32{1, 1}}
+			blocks, err := buildTextV2PostingBlockKVs("refund", []textV2PostingBlockEntry{entry}, 2, textV2PostingBlockBuildOptions{Kind: textV2PostingBlockKindMicro, TargetPostings: 1, BlockIDStart: uint64(i) + 1_000_000})
+			if err != nil {
+				b.Fatal(err)
+			}
+			textV2PostingBlockBenchSink2625 += uint64(len(blocks[0].Value))
+		}
+	})
+}
+
+func mutatePostingBlockRaw2625(raw []byte, offset int, value byte) []byte {
+	out := bytes.Clone(raw)
+	out[offset] = value
+	return out
+}
+
+func openTextV2PostingBlockDB2625(t *testing.T, dir string, forcePointers bool) *backenddb.DB {
+	t.Helper()
+	return openTextV2TestDB(t, dir, forcePointers)
+}
+
+func openTextV2PostingBlockCompressedDB2625(t *testing.T, dir string) (*backenddb.DB, func() error) {
+	t.Helper()
+	opts := treedb.Options{
+		Dir:                        dir,
+		DisableBackgroundPrune:     true,
+		IndexOuterLeavesInValueLog: true,
+		ValueLog: treedb.ValueLogOptions{
+			PointerThreshold: 1,
+			ForcePointers:    true,
+		},
+	}
+	d, cleanup, err := treedb.OpenBackendWithCachedLeafLog(opts)
+	if err != nil {
+		t.Fatalf("open compressed db: %v", err)
+	}
+	return d, cleanup
+}
+
+func createTextV2PostingBlockCollection2625(t *testing.T, d *backenddb.DB, docs int, storage RootStoragePolicy) *Collection {
+	t.Helper()
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "docs"}); err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	col, err := mgr.OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("OpenCollection: %v", err)
+	}
+	ids := make([][]byte, docs)
+	values := make([][]byte, docs)
+	for i := range ids {
+		ids[i] = []byte(fmt.Sprintf("doc-%06d", i+1))
+		values[i] = []byte(fmt.Sprintf(`{"body":"refund policy shipping %d","title":"ticket refund %d"}`, i, i))
+	}
+	if _, err := col.InsertBatch(ids, values); err != nil {
+		t.Fatalf("InsertBatch: %v", err)
+	}
+	if _, _, err := col.CreateTextIndex(TextIndexDefinition{Name: "lexical", Version: TextIndexVersionV2, Fields: []TextIndexField{{Field: "body"}, {Field: "title"}}, StoragePolicy: storage}); err != nil {
+		t.Fatalf("CreateTextIndex v2: %v", err)
+	}
+	return col
+}
+
+func postingParityEqual2625(a, b map[uint64]textV2PostingParityPosting2625) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for ordinal, av := range a {
+		bv, ok := b[ordinal]
+		if !ok || av.tf != bv.tf || !slices.Equal(av.fields, bv.fields) {
+			return false
+		}
+	}
+	return true
+}
+
+type textV1SyntheticPostingRow2625 struct {
+	key   []byte
+	value []byte
+}
+
+func syntheticTextV1PostingRows2625(term string, docs int) []textV1SyntheticPostingRow2625 {
+	rows := make([]textV1SyntheticPostingRow2625, 0, docs)
+	for i := 0; i < docs; i++ {
+		docID := []byte(fmt.Sprintf("doc-%08d", i+1))
+		body := uint32(1 + i%3)
+		title := uint32(i % 2)
+		rows = append(rows, textV1SyntheticPostingRow2625{
+			key: encodeTextPostingKey(term, docID),
+			value: encodeTextPostingValue(textPostingValue{TermFrequency: body + title, Fields: []textPostingFieldValue{
+				{Field: "body", Frequency: body},
+				{Field: "title", Frequency: title},
+			}}),
+		})
+	}
+	return rows
+}
+
+func syntheticTextV2PostingEntries2625(docs int, fieldCount uint32) []textV2PostingBlockEntry {
+	entries := make([]textV2PostingBlockEntry, 0, docs)
+	for i := 0; i < docs; i++ {
+		fields := make([]uint32, fieldCount)
+		var tf uint32
+		for j := range fields {
+			fields[j] = uint32((i+j)%3 + 1)
+			tf += fields[j]
+		}
+		entries = append(entries, textV2PostingBlockEntry{Ordinal: uint64(i + 1), Generation: 1, TermFrequency: tf, FieldFrequencies: fields})
+	}
+	return entries
+}

--- a/TreeDB/docs/spec/collection-text-v2-contract.md
+++ b/TreeDB/docs/spec/collection-text-v2-contract.md
@@ -120,7 +120,7 @@ M1 root contents:
 | `text-v2-docid` | documentID key -> `{ordinal,generation,flags}`; tombstone flag marks deleted/currently non-ranking documentIDs. |
 | `text-v2-docmap` | ordinal block key -> sorted ordinal-to-documentID entries with generation/tombstone flags for final ID materialization and stale-generation checks. |
 | `text-v2-terms` | corpus stats, field stats for BM25F average length, and term stats shell (`df`, `ttf`, posting block count placeholder). |
-| `text-v2-posting-blocks` | format-only in M1; #2625 owns posting block payloads. |
+| `text-v2-posting-blocks` | M2 posting-block keys are `(term, blockStartOrdinal, blockID)` under the normal collection root; values contain compressed scoring postings and block summaries. |
 | `text-v2-norm-blocks` | ordinal block key -> packed per-field token lengths with generation/tombstone flags, sufficient for BM25F field-length/norm inputs without per-candidate text-state lookup. |
 | `text-v2-positions` | format-only in M1; later lazy detail/position milestones own payloads. |
 | `text-v2-generations` | index status record: root/stats/docmap/norm/term generations, next ordinal, live documents, deleted/tombstoned ordinals. |
@@ -133,6 +133,61 @@ status generation and live document count, while per-term stats carry a
 non-zero generation bounded by the term/status generation so unchanged terms can
 remain valid across root-state updates. BM25F average-length inputs are read
 from one published root set.
+
+## M2 posting block format (#2625)
+
+M2 assigns the compressed scoring-block contract for the reserved
+`text-v2-posting-blocks` root. Posting blocks are still ordinary B-tree records
+inside that collection root; there are no external posting files, typed assets,
+legacy large-value side stores, or private text-block GC records. The root uses
+the text index storage policy: cache-local blocks are targeted at about 128
+postings and <=16 KiB
+encoded payloads, while unusually large values use the existing TreeDB
+value-log/leaf-log pointer path when the root policy selects it. Those pointers
+remain reachable through the collection root descriptor and normal maintenance
+root scanning.
+
+Posting block keys have a term prefix plus block identity:
+
+```text
+textV2KeyVersion | postingBlockKind | len(term) | term | big-endian blockStartOrdinal | big-endian blockID
+```
+
+`blockStartOrdinal` is the first document ordinal in the value and `blockID` is
+non-zero. The ordering lets iterators range-scan one term with a prefix and see
+blocks in increasing ordinal/block identity order. `blockID` gives later M3/M7
+writers room for append-only delta/micro blocks and rewrite generations without
+rewriting one giant high-df value. Expected lifecycle: sealed blocks are the
+stable compact representation, micro/delta blocks absorb small writes for
+high-df terms, and later merge/rewrite tooling replaces old block keys through
+ordinary collection-root deltas so physical reclamation remains normal TreeDB
+root/value-log/leaf maintenance.
+
+Posting block values are versioned and fail closed. Each value stores:
+
+- block kind: sealed, delta, or micro;
+- block identity (`blockStartOrdinal`, `blockID`) repeated for key/value
+  validation;
+- exact summary: first/last ordinal, doc count, max total term frequency, and
+  max per-field term-frequency lanes;
+- `UpperBoundKind=BM25FLaneMax`, meaning the per-field maxima are admissible
+  BM25F upper-bound inputs for non-negative BM25F weights. A later scorer may
+  combine those maxima with term IDF and the most favorable valid norm/length
+  assumptions to get a safe (possibly loose) block upper bound. If a future
+  scorer cannot compute or validate such an admissible bound for a query, it
+  must treat the block as unskippable and fall back to exhaustive scoring;
+- entries encoded as strictly-increasing document-ordinal deltas, document
+  generation, term frequency, and one term-frequency lane per indexed field.
+
+Positions and offsets are deliberately absent from the scoring block. Future
+lazy match-detail/position lanes belong in `text-v2-positions` or another
+explicit format, not in the hot scoring value.
+
+M2 provides codecs, builders, storage validation, and streaming/range iterators
+that reuse entry scratch while scanning a block. It does not route
+`SearchText`/`SearchHybrid` through v2 posting blocks and does not make ordinary
+v2 backfill/mutations emit active posting blocks before the M3 streaming write
+pipeline can maintain update/delete/tombstone correctness.
 
 ## Current v1 path inventory
 

--- a/TreeDB/docs/spec/storage-format.md
+++ b/TreeDB/docs/spec/storage-format.md
@@ -141,6 +141,98 @@ Collection document payload encodings are defined separately in
 template-v1 collections store compact `TD1D` primary documents and persist the
 template ID map in the collection-local `<collection>/templates` ordered root.
 
+## 3.3 Collection Text Index Root Payloads
+
+Collection text-index roots are ordinary ordered roots whose keys and values are
+stored inline in B-tree leaves or, when the root storage policy selects it, as
+existing value-log/split-leaf-log pointer-backed leaf values. Text roots do not
+own a separate physical file class or GC domain.
+
+The v1 text root payload contract is documented in
+`collection-text-search.md`. The v2 production contract and rollout boundaries
+are documented in `collection-text-v2-contract.md`; this section records the
+canonical durable key/value bytes that have landed for the M2 posting-block
+family. All integer varints below are Go `binary.PutUvarint` encodings unless
+noted otherwise.
+
+Text-v2 posting-block root name:
+
+```text
+<collection>/text-v2-posting-blocks/<indexName>
+```
+
+Posting-block keys sort by term, then first ordinal, then block identity:
+
+```text
+u8  KeyVersion = 2
+u8  KeyKind    = 0x21  // text-v2 posting block
+uvarint TermLen
+bytes Term[TermLen]
+u64 BlockStartOrdinalBE
+u64 BlockIDBE
+```
+
+`BlockStartOrdinalBE` and `BlockIDBE` are non-zero. The key prefix through the
+term bytes is the range-scan prefix for a single term. `BlockStartOrdinalBE` is
+the first document ordinal stored in the value. `BlockIDBE` is non-zero and lets
+future delta/micro-block writers and rewrite tooling publish multiple ordinary
+root records for the same high-document-frequency term without rewriting one
+large value per mutation.
+
+Posting-block values contain scoring postings only; positions and offsets are
+absent and belong to a separate positions lane if enabled by a later format.
+
+```text
+u8      ValueVersion  = 1
+uvarint FormatVersion = 1
+u8      BlockKind     // 1=sealed, 2=delta, 3=micro
+u8      Flags         // currently 0
+uvarint BlockStartOrdinal
+uvarint BlockID
+
+// exact summary / upper-bound metadata
+uvarint FirstOrdinal
+uvarint LastOrdinal
+uvarint DocCount
+uvarint MaxTermFrequency
+uvarint FieldCount
+uvarint MaxFieldTermFrequency[FieldCount]
+u8      UpperBoundKind // 1=BM25F lane maxima
+uvarint EntryCount
+
+// repeated EntryCount times
+uvarint OrdinalDelta  // from previous ordinal; previous starts at BlockStartOrdinal-1
+uvarint Generation
+u8      EntryFlags    // currently 0
+uvarint TermFrequency
+uvarint FieldTermFrequency[FieldCount]
+```
+
+Required validation/fail-closed invariants:
+
+- `FormatVersion`, `ValueVersion`, key version, known kinds, and zero flags must
+  be checked before use.
+- `BlockStartOrdinal`, `BlockID`, `FirstOrdinal`, `LastOrdinal`, `DocCount`,
+  `EntryCount`, and every entry `Generation`/`TermFrequency` are non-zero.
+- key `(BlockStartOrdinal, BlockID)` must match the value identity.
+- `FirstOrdinal == BlockStartOrdinal`, ordinals are strictly increasing, and a
+  builder must reject duplicate document ordinals globally before splitting
+  postings into blocks so duplicates cannot straddle block boundaries.
+- `DocCount == EntryCount` and must not exceed the implementation maximum
+  posting count per block.
+- `FieldCount` is the text index field count. Every posting has exactly that
+  many field-frequency lanes, and the lane sum equals `TermFrequency`.
+- `MaxTermFrequency`, `MaxFieldTermFrequency`, first/last ordinal, and doc count
+  must exactly summarize the decoded entries.
+- `UpperBoundKind=1` records per-field lane maxima that are admissible BM25F
+  upper-bound inputs for non-negative BM25F weights. A future scorer that cannot
+  compute/validate an admissible block bound for a query must treat the block as
+  unskippable and score exhaustively.
+- Unsupported versions, flags, kinds, malformed varints, trailing bytes,
+  key/value identity mismatches, field-count mismatches, corrupt summaries, or
+  status generation/ordinal bounds violations make the root corrupt for text-v2
+  inspection and must fail closed.
+
 ## 4. Value Pointer Encoding (`page.ValuePtr`)
 
 Base struct:


### PR DESCRIPTION
## Linked issues

- Child: closes #2625
- Parent tracker: #2622
- Predecessor: #2624 / PR #2646 merged at `cda934b04a4f59d66bb4401483f4f9c97c9e49ae`

## Scope

Implements the M2 text-v2 posting-block format layer only:

- Adds `text-v2-posting-blocks` key shape: `(term, blockStartOrdinal, blockID)` under the reserved collection-root B-tree.
- Adds versioned compressed posting-block values with sealed/delta/micro kinds, doc-ordinal deltas, generation, term frequency, and one per-field TF lane per indexed field.
- Stores exact summaries and BM25F-admissible lane-max upper-bound metadata; malformed/lower-bound-corrupt summaries fail closed.
- Adds builders and streaming/range iterators that scan a term without materializing per-posting heap objects.
- Extends text-v2 storage inspection to validate posting blocks as ordinary root values.
- Documents the canonical durable posting-block key/value bytes in `TreeDB/docs/spec/storage-format.md` and the higher-level text-v2 contract in `collection-text-v2-contract.md`.

## Non-goals / boundaries

- Does **not** route `SearchText` or `SearchHybrid` through v2 posting blocks.
- Does **not** implement WAND/BMW traversal.
- Does **not** implement the M3 streaming write pipeline.
- Ordinary v2 backfill/mutations still emit zero posting blocks before M3, so no stale active v2 ranking state is exposed.
- No external posting files/assets, no separate GC domain; pointer-backed blocks remain reachable through normal collection roots and value-log/leaf-log maintenance.

## Review blocker fixes

- Codex P1: added the durable text-v2 posting-block key/value format and fail-closed invariants to canonical `TreeDB/docs/spec/storage-format.md`.
- Codex P2: builder now validates globally sorted postings before chunking and rejects duplicate document ordinals, including duplicates straddling the default 128-posting block boundary. Added regression test `TestTextV2PostingBlockBuilderRejectsDuplicateOrdinalAcrossDefaultBoundary2625`.

## Start-phase baseline / measured boundary

Base/head for this PR:

- Base: `origin/main` @ `cda934b04a4f59d66bb4401483f4f9c97c9e49ae`
- Latest head after blocker fixes: `a41b12f0d`

This PR adds a new M2 format/iterator layer and does not switch production v1 search/write hot paths. The range-scan comparison is therefore a synthetic v1-equivalent scanner over current v1 posting key/value codecs versus the new v2 block scanner.

Artifacts:

- `/tmp/gomap_2625_posting_blocks/bench_codec_range_100x_after_blockers.txt`
- `/tmp/gomap_2625_posting_blocks/bench_encode_update_1x_after_blockers.txt`

## Tests

```sh
GOWORK=off go test ./TreeDB/collections -run 'TestTextV2PostingBlock|TestTextV2PostingBlocks'
GOWORK=off go test ./TreeDB/docs
GOWORK=off go test ./TreeDB/collections ./TreeDB/docs
git diff --check
```

Internal high-thinking reviewer passed after the field-lane validation fix. Coordinator/Codex blocker fixes were applied in `a41b12f0d`.

## Benchmarks

Hardware/context from Go benchmark output: `goos: darwin`, `goarch: arm64`, `cpu: Apple M3`.

Command:

```sh
GOWORK=off go test ./TreeDB/collections -run '^$' \
  -bench '^(BenchmarkTextV2PostingBlockCodec2625|BenchmarkTextV2PostingBlockRangeScanVsV1Synthetic2625)$' \
  -benchmem -benchtime=100x -count=1
```

| Row | ns/op | ops/sec | B/op | allocs/op | Notes |
| --- | ---: | ---: | ---: | ---: | --- |
| encode_128 | 8,180 | 122,249 | 16,000 | 130 | 6.141 bytes/posting |
| decode_128 | 4,372 | 228,728 | 9,536 | 134 | full materializing decode |
| scan_128_reused_entry | 2,345 | 426,439 | 320 | 5 | streaming scan; allocation is per block, not per posting |
| rare_8/v1_per_doc_decode | 440.8 | 2,268,603 | 24 | 1 | synthetic v1 equivalent |
| rare_8/v2_block_scan | 420.8 | 2,376,426 | 320 | 5 | 1 block, 8 postings |
| common_10000/v1_per_doc_decode | 511,836 | 1,954 | 24 | 1 | synthetic v1 equivalent |
| common_10000/v2_block_scan | 188,439 | 5,307 | 24,656 | 317 | 79 blocks, 10k postings; allocations scale with blocks, not postings |

Command:

```sh
GOWORK=off go test ./TreeDB/collections -run '^$' \
  -bench '^BenchmarkTextV2PostingBlockEncodeUpdate2625$' \
  -benchmem -benchtime=1x -count=1
```

| Row | ns/op | ops/sec | B/op | allocs/op | Domain counters |
| --- | ---: | ---: | ---: | ---: | --- |
| build_sealed_100k | 12,974,500 | 77 | 32,692,208 | 404,695 | 100k postings, 782 blocks, 6.378 bytes/posting |
| append_microblock_one_doc | 58,166 | 17,192 | 632 | 11 | 1 block/update, 1 posting reencoded/update, prior df=100k not reencoded |

## Regression assessment

- v1 search/write routing is not touched; v1 guardrail rows are not applicable beyond the synthetic scanner comparison above.
- New block scanner avoids per-posting heap churn; benchmark allocations scale with block count.
- Builder rejects duplicate ordinals globally before chunking, so a term/doc duplicate cannot straddle block boundaries.
- Storage inspection now fails closed on posting-block key/value mismatch, unsupported versions/flags/kinds, corrupt summary/upper-bound metadata, status ordinal/generation bounds, and field-lane count mismatch.

## Review status

- Internal high-thinking reviewer: PASS after fix `c38eb155e`; prior blocker was missing field-lane count validation.
- Codex/Copilot/CodeRabbit: re-requested after blocker-fix head per stack policy. Latest-head CI is running for `a41b12f0d`.

## Known caveats / deferrals

- Upper bounds are lane-max admissible inputs; future M5 scoring must fall back to exhaustive scoring for any query where it cannot compute/validate an admissible BM25F block bound.
- M3 owns production streaming writes/update/delete posting-block emission.
- M4/M5 own search routing/scoring/skipping.
