### PR TITLE
zipper: own in-flight leaf-ref cache bytes

### DIFF
--- a/TreeDB/db/compact_storage.go
+++ b/TreeDB/db/compact_storage.go
@@ -206,6 +206,8 @@ func (db *DB) compactStorage(ctx context.Context, opts CompactStorageOptions) (C
 		if err := db.commandWALPoisonedError(); err != nil {
 			return stats, err
 		}
+		restoreLeafPageReadCache := db.disableLeafPageReadCacheForMaintenance()
+		defer restoreLeafPageReadCache()
 	}
 	maintenanceLocked := false
 	if !opts.DryRun {

--- a/TreeDB/db/compact_storage.go
+++ b/TreeDB/db/compact_storage.go
@@ -206,14 +206,14 @@ func (db *DB) compactStorage(ctx context.Context, opts CompactStorageOptions) (C
 		if err := db.commandWALPoisonedError(); err != nil {
 			return stats, err
 		}
-		restoreLeafPageReadCache := db.disableLeafPageReadCacheForMaintenance()
-		defer restoreLeafPageReadCache()
 	}
 	maintenanceLocked := false
 	if !opts.DryRun {
 		db.maintenanceMu.Lock()
 		maintenanceLocked = true
 		defer db.maintenanceMu.Unlock()
+		restoreLeafPageReadCache := db.disableLeafPageReadCacheForMaintenance()
+		defer restoreLeafPageReadCache()
 	}
 
 	before, err := compactStorageUsage(db.dir)

--- a/TreeDB/db/leaf_page_read_cache.go
+++ b/TreeDB/db/leaf_page_read_cache.go
@@ -135,6 +135,8 @@ type leafPageReadCache struct {
 	buckets []leafPageReadCacheBucket
 	ways    int
 
+	disabled atomic.Bool
+
 	hits      atomic.Uint64
 	misses    atomic.Uint64
 	stores    atomic.Uint64
@@ -206,7 +208,7 @@ func (c *leafPageReadCache) store(ptr page.LeafLogPtr, leafPage []byte) {
 }
 
 func (c *leafPageReadCache) storeWithRecordChecksumState(ptr page.LeafLogPtr, leafPage []byte, recordChecksumVerified bool) {
-	if c == nil || len(c.slots) == 0 || len(c.buckets) == 0 || len(leafPage) != page.PageSize {
+	if c == nil || c.disabled.Load() || len(c.slots) == 0 || len(c.buckets) == 0 || len(leafPage) != page.PageSize {
 		return
 	}
 	key := newLeafPageReadCacheKey(ptr)
@@ -226,7 +228,7 @@ func (c *leafPageReadCache) storeWithRecordChecksumState(ptr page.LeafLogPtr, le
 // evicting recently-written leaves that are likely to be reused during
 // publish/apply.
 func (c *leafPageReadCache) storeReadMiss(ptr page.LeafLogPtr, leafPage []byte, recordChecksumVerified bool) bool {
-	if c == nil || len(c.slots) == 0 || len(c.buckets) == 0 || len(leafPage) != page.PageSize {
+	if c == nil || c.disabled.Load() || len(c.slots) == 0 || len(c.buckets) == 0 || len(leafPage) != page.PageSize {
 		return false
 	}
 	key := newLeafPageReadCacheKey(ptr)
@@ -576,7 +578,7 @@ func (c *leafPageReadCache) recordReadMissAdmissionLockSkip() {
 }
 
 func (c *leafPageReadCache) get(ptr page.LeafLogPtr) ([]byte, bool) {
-	if c == nil || len(c.slots) == 0 || len(c.buckets) == 0 {
+	if c == nil || c.disabled.Load() || len(c.slots) == 0 || len(c.buckets) == 0 {
 		return nil, false
 	}
 	key := newLeafPageReadCacheKey(ptr)
@@ -615,7 +617,7 @@ type leafPageReadCacheState struct {
 }
 
 func (c *leafPageReadCache) getToWithState(ptr page.LeafLogPtr, dst []byte) ([]byte, bool, leafPageReadCacheState, bool) {
-	if c == nil || len(c.slots) == 0 || len(c.buckets) == 0 {
+	if c == nil || c.disabled.Load() || len(c.slots) == 0 || len(c.buckets) == 0 {
 		return nil, false, leafPageReadCacheState{}, false
 	}
 	key := newLeafPageReadCacheKey(ptr)
@@ -656,7 +658,7 @@ func (c *leafPageReadCache) getViewLocked(ptr page.LeafLogPtr) ([]byte, *leafPag
 }
 
 func (c *leafPageReadCache) getViewLockedWithState(ptr page.LeafLogPtr) ([]byte, *leafPageReadCacheSlot, leafPageReadCacheState, bool) {
-	if c == nil || len(c.slots) == 0 || len(c.buckets) == 0 {
+	if c == nil || c.disabled.Load() || len(c.slots) == 0 || len(c.buckets) == 0 {
 		return nil, nil, leafPageReadCacheState{}, false
 	}
 	key := newLeafPageReadCacheKey(ptr)
@@ -690,7 +692,7 @@ func (c *leafPageReadCache) recordHitState(state leafPageReadCacheState) {
 }
 
 func (c *leafPageReadCache) markPageChecksumVerified(ptr page.LeafLogPtr) bool {
-	if c == nil || len(c.slots) == 0 || len(c.buckets) == 0 {
+	if c == nil || c.disabled.Load() || len(c.slots) == 0 || len(c.buckets) == 0 {
 		return false
 	}
 	key := newLeafPageReadCacheKey(ptr)
@@ -829,6 +831,16 @@ func (db *DB) leafPageReader(fallback zipper.LeafPageReader) zipper.LeafPageRead
 		return newCachedLeafPageReader(db.leafPageReadCache, fallback)
 	}
 	return fallback
+}
+
+func (db *DB) disableLeafPageReadCacheForMaintenance() func() {
+	if db == nil || db.leafPageReadCache == nil {
+		return func() {}
+	}
+	prev := db.leafPageReadCache.disabled.Swap(true)
+	return func() {
+		db.leafPageReadCache.disabled.Store(prev)
+	}
 }
 
 func (r *cachedLeafPageReader) ReadUnsafe(ptr page.ValuePtr) ([]byte, error) {

--- a/TreeDB/db/leaf_page_read_cache.go
+++ b/TreeDB/db/leaf_page_read_cache.go
@@ -135,6 +135,9 @@ type leafPageReadCache struct {
 	buckets []leafPageReadCacheBucket
 	ways    int
 
+	// disabled temporarily bypasses all cache reads and writes during storage
+	// maintenance/compaction so stale leaf-log pages are not served while value-log
+	// rewrite/GC and leaf-generation pack/GC mutate underlying storage.
 	disabled atomic.Bool
 
 	hits      atomic.Uint64

--- a/TreeDB/db/leaf_page_read_cache_test.go
+++ b/TreeDB/db/leaf_page_read_cache_test.go
@@ -99,6 +99,36 @@ func TestCachedLeafPageReaderHitAvoidsFallback(t *testing.T) {
 	}
 }
 
+func TestCachedLeafPageReaderDisabledBypassesCache(t *testing.T) {
+	cache := newLeafPageReadCache(8)
+	ptr := page.LeafLogPtr{FileID: 7, Offset: 128, RecordLengthHint: 4096}
+	cachedLeaf := bytes.Repeat([]byte{0x42}, page.PageSize)
+	fallbackLeaf := bytes.Repeat([]byte{0x24}, page.PageSize)
+	cache.store(ptr, cachedLeaf)
+	cache.disabled.Store(true)
+
+	fallback := &leafPageCacheTestFallback{data: fallbackLeaf}
+	reader := newCachedLeafPageReader(cache, fallback)
+
+	dst := make([]byte, 0, page.PageSize)
+	got, usedDst, cacheHit, err := reader.ReadUnsafeToWithCacheHit(ptr.ValuePtr(), dst)
+	if err != nil {
+		t.Fatalf("ReadUnsafeToWithCacheHit: %v", err)
+	}
+	if cacheHit {
+		t.Fatal("cacheHit=true, want disabled cache bypass")
+	}
+	if !usedDst {
+		t.Fatalf("expected fallback to copy into caller dst")
+	}
+	if !bytes.Equal(got, fallbackLeaf) {
+		t.Fatalf("got cached data while cache disabled")
+	}
+	if fallback.readUnsafeToCalls != 1 {
+		t.Fatalf("fallback ReadUnsafeTo calls=%d want 1", fallback.readUnsafeToCalls)
+	}
+}
+
 func TestCachedLeafPageReaderReadUnsafeToWithCacheHitReportsHit(t *testing.T) {
 	cache := newLeafPageReadCache(8)
 	ptr := page.LeafLogPtr{FileID: 7, Offset: 128, RecordLengthHint: 4096}

--- a/TreeDB/db/ordered_root_publish.go
+++ b/TreeDB/db/ordered_root_publish.go
@@ -334,6 +334,32 @@ func (db *DB) orderedRootZipperForOptionsWithAllocator(idx *indexGen, opts order
 	return z, nil
 }
 
+func (db *DB) orderedRootRewriteZipperForOptionsWithAllocator(idx *indexGen, opts orderedRootPublishOptions, alloc zipper.PageAllocator, state *DBState) (*zipper.Zipper, error) {
+	z, err := db.orderedRootZipperForOptionsWithAllocator(idx, opts, alloc)
+	if err != nil {
+		return nil, err
+	}
+	if idx != nil && z == idx.zipper {
+		// Value-log rewrite walks and rewrites leaf-log-backed trees while leaf-log
+		// segments may be replaced/GCed. Do not let the process-wide leaf page read
+		// cache feed stale entries back into the rewrite zipper; use an uncached
+		// state-pinned reader for the duration of the maintenance apply instead.
+		z = idx.zipper.CloneWithAllocator(alloc)
+	}
+	z.SetLeafPageReader(db.rewriteLeafPageReaderForState(state))
+	return z, nil
+}
+
+func (db *DB) rewriteLeafPageReaderForState(state *DBState) zipper.LeafPageReader {
+	if state != nil && state.ValueLogSet != nil {
+		return newValueReader(state.ValueLogSet)
+	}
+	if db != nil && db.valueLogManager != nil {
+		return db.valueLogManager
+	}
+	return nil
+}
+
 func (db *DB) orderedRootOptionsUseDefaultZipper(opts orderedRootPublishOptions) bool {
 	if db == nil {
 		return false

--- a/TreeDB/db/vlog_rewrite.go
+++ b/TreeDB/db/vlog_rewrite.go
@@ -2629,7 +2629,7 @@ func (db *DB) applyRewriteSwapsToRootLocked(idx *indexGen, state *DBState, rootI
 	}
 	noteRewriteSwapTouchedSegments(b, swaps)
 	touched := append([]uint32(nil), b.TouchedValueLogSegments()...)
-	rootZipper, err := db.orderedRootZipperForOptions(idx, opts)
+	rootZipper, err := db.orderedRootRewriteZipperForOptionsWithAllocator(idx, opts, idx.allocator, state)
 	if err != nil {
 		releaseValueLogRefDelta(vlogRefDelta)
 		return rootID, nil, metrics, nil, nil, false, err
@@ -2751,6 +2751,7 @@ func (db *DB) applyRewriteSwapBatchOptimistic(swaps []rewriteSwap, sync bool) (b
 
 	tracker := newAllocTracker(idx.allocator)
 	z := idx.zipper.CloneWithAllocator(tracker)
+	z.SetLeafPageReader(db.rewriteLeafPageReaderForState(state))
 	newRoot, retired, metrics, err := z.Apply(rootID, b)
 	if err != nil {
 		freeErr := tracker.FreeAll()
@@ -2841,7 +2842,9 @@ func (db *DB) applyRewriteSwapBatchSerialized(swaps []rewriteSwap, sync bool) er
 	noteRewriteSwapTouchedSegments(b, swaps)
 	touchedValueLogSegments := b.TouchedValueLogSegments()
 
-	newRoot, retired, metrics, err := idx.zipper.Apply(rootID, b)
+	z := idx.zipper.CloneWithAllocator(idx.allocator)
+	z.SetLeafPageReader(db.rewriteLeafPageReaderForState(state))
+	newRoot, retired, metrics, err := z.Apply(rootID, b)
 	if err != nil {
 		return err
 	}

--- a/TreeDB/zipper/zipper.go
+++ b/TreeDB/zipper/zipper.go
@@ -1532,7 +1532,14 @@ func (z *Zipper) persistLeafPageBatchDataTo(leafPages [][]byte, refs []page.Chil
 func (z *Zipper) cachePersistedLeafPage(ptr page.LeafLogPtr, leafPage []byte) {
 	z.leafRefCacheMu.Lock()
 	if z.leafRefCache != nil {
-		z.leafRefCache[ptr] = leafPage
+		// Persist paths often hand us builder/scratch buffers that are reused later
+		// in the same Apply call (for example when split leaves are batched before
+		// parent internals are built). The in-flight leaf-ref cache must own the
+		// bytes it serves; otherwise a later scratch reuse can turn a cached leaf
+		// into an internal page and make maintenance rewrites fail validation.
+		owned := make([]byte, len(leafPage))
+		copy(owned, leafPage)
+		z.leafRefCache[ptr] = owned
 	}
 	z.leafRefCacheMu.Unlock()
 }

--- a/TreeDB/zipper/zipper_test.go
+++ b/TreeDB/zipper/zipper_test.go
@@ -328,6 +328,59 @@ func TestZipperLeafRefCacheAvoidsUnflushedReads(t *testing.T) {
 	}
 }
 
+func TestZipperLeafRefCacheOwnsPersistedLeafBytes(t *testing.T) {
+	dir := t.TempDir()
+	p, err := pager.Open(filepath.Join(dir, "index.db"), 65536)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer p.Close()
+
+	alloc := &MockAllocator{p: p}
+	z := New(p, alloc)
+	z.SetOuterLeavesInValueLog(true)
+	z.SetLeafPageLog(&stubLeafPageLog{})
+	z.SetLeafPageReader(&countingLeafPageReader{})
+	z.leafRefCache = make(map[page.LeafLogPtr][]byte)
+
+	data := make([]byte, page.PageSize)
+	b := node.NewBuilder(data, page.PageTypeLeaf)
+	b.SetPageID(0)
+	if err := b.AddLeafEntry([]byte("k"), []byte("v"), node.FlagInline, page.ValuePtr{}); err != nil {
+		t.Fatalf("AddLeafEntry: %v", err)
+	}
+	b.FinishNoNode()
+
+	leafID, err := z.persistLeafPage(b)
+	if err != nil {
+		t.Fatalf("persistLeafPage: %v", err)
+	}
+
+	// Simulate the scratch/builder backing buffer being reused for a non-leaf
+	// page after the leaf is persisted. loadNodeRef must still see the original
+	// cached leaf bytes, not the mutated caller buffer.
+	mutated := node.NewNode(data)
+	mutated.SetType(page.PageTypeInternal)
+	mutated.UpdateChecksum()
+
+	loaded, fromPager, leafScratch, leafScratchRef, loadSource, err := z.loadNodeRef(leafID, nil)
+	if err != nil {
+		t.Fatalf("loadNodeRef after caller buffer reuse: %v", err)
+	}
+	if leafScratchRef {
+		putLeafPageScratch(leafScratch)
+	}
+	if fromPager {
+		t.Fatalf("fromPager=%t want false", fromPager)
+	}
+	if loadSource != zipperNodeLoadLeafLogCache {
+		t.Fatalf("loadSource=%d want leaf-log cache", loadSource)
+	}
+	if got := loaded.Type(); got != page.PageTypeLeaf {
+		t.Fatalf("loaded.Type()=%d want %d", got, page.PageTypeLeaf)
+	}
+}
+
 func TestZipperLoadNodeRefAttributesLeafPageReaderCacheHit(t *testing.T) {
 	dir := t.TempDir()
 	p, err := pager.Open(filepath.Join(dir, "index.db"), 65536)


### PR DESCRIPTION
## Summary

Fix Hoodi maintenance blockers found while executing #2637 storage compaction on fresh TreeDB geth copies:

- make the zipper's in-flight leaf-ref cache own/cloned persisted leaf page bytes instead of retaining caller scratch/builder buffers;
- force `CompactStorage` mutation phases to temporarily bypass the process-wide leaf page read cache, avoiding stale cached leaf-log pages while value-log rewrite/GC and leaf-generation pack/GC replace storage;
- make value-log rewrite apply paths use state-pinned uncached leaf readers;
- add regression coverage for owned in-flight cache bytes and cache-disabled fallback behavior.

## Why

The #2637 Hoodi storage pass found that full compaction can materially reduce the TreeDB hot DB footprint, but the first safe-copy compaction attempt failed during `value-log-rewrite` with cache-fed invalid leaf pages:

```text
zipper: leaf-page reader cache invalid leaf-log page: zipper: leafref resolved to non-leaf page
```

After bypassing the cache for rewrite applies, a later cache-enabled attempt hit a stale cached checksum mismatch. Running the same compaction with `TREEDB_LEAF_PAGE_CACHE_ENTRIES=0` succeeded, confirming the process-wide leaf page cache was unsafe across mutating storage maintenance. This PR makes that bypass an internal compaction behavior instead of an operator workaround.

## Validation

Local:

- `go test ./TreeDB/zipper -run 'TestZipperLeafRefCache|TestZipperLoadNodeRefAttributesLeafPageReaderCacheHit|TestZipperLoadNodeRefAnnotates' -count=1`
- `go test ./TreeDB/zipper -count=1`
- `go test ./TreeDB/db -run 'TestCachedLeafPageReaderDisabledBypassesCache|TestValueLogRewrite|TestCompactStorage' -count=1`
- `go test ./TreeDB/db -count=1`
- `go test ./TreeDB/...`

Hoodi safe-copy validation:

- Baseline artifact: `/mnt/fast4tb/tmp/geth-treedb-exp/hoodi_treedb_fixed_2636_20260612T064202Z`
- Pre-fix cache-enabled compact failed: `logs/compact_full64.log`
- Cache-disabled workaround compact succeeded: `compact_full64_cache0_stats.json`
- PR #2650 cache-enabled compact succeeded with `gomap 6aca38bc4`:
  - command: `treemap_6aca38b compact .../treedb_geth_compact_full64_pr2650/geth/chaindata -rw -json -mode full -leaf-pack-max-passes 64`
  - rc: `0`
  - wall: `1:28:50`, max RSS: `22,570,920 KB`
  - before maindb: `109,683,930,812` bytes; after maindb: `54,001,261,831` bytes
  - leaf_vlog: `101,902,210,846` -> `48,950,303,291` bytes
  - normalized engine after compact/reopen: `54,006,984,712` bytes (`50.30 GiB`), vs Pebble reference `61,466,050,475` bytes (`57.24 GiB`)
  - compacted copy reopen: pprof `1s`, RPC `0s`, `eth_syncing=false`, clean negative grep

This remains bounded diagnostic evidence only; it does not claim full public-testnet readiness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a data integrity issue in leaf page caching from internal buffer reuse.

* **Tests**
  * Added tests for leaf page cache ownership and disabled cache bypass behavior.

* **Improvements**
  * Leaf page cache is now managed during database maintenance operations.
  * Improved consistency in value-log segment rewriting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->