### PR TITLE
TreeDB text v2 streaming write path

### DIFF
--- a/TreeDB/collections/text_analyzer.go
+++ b/TreeDB/collections/text_analyzer.go
@@ -1,6 +1,7 @@
 package collections
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"unicode"
@@ -15,44 +16,83 @@ type TextToken struct {
 	EndOffset   int
 }
 
+// TextTokenSink receives analyzed tokens from AnalyzeTextToSink. Implementations
+// must not retain mutable scratch owned by the analyzer; TextToken values are
+// self-contained.
+type TextTokenSink interface {
+	AddTextToken(TextToken) error
+}
+
+// TextTokenSinkFunc adapts a function to TextTokenSink.
+type TextTokenSinkFunc func(TextToken) error
+
+func (f TextTokenSinkFunc) AddTextToken(token TextToken) error {
+	if f == nil {
+		return errors.New("collections: text analyzer sink function is nil")
+	}
+	return f(token)
+}
+
 // AnalyzeText runs a named collection text analyzer over text. The simple
 // analyzer lowercases Unicode letters and treats Unicode letters, Unicode
 // digits, and '_' as token characters so code-ish identifiers such as
 // "HTTP_500" remain searchable without stemming.
 func AnalyzeText(analyzer TextAnalyzer, text string) ([]TextToken, error) {
+	var tokens []TextToken
+	if err := AnalyzeTextToSink(analyzer, text, TextTokenSinkFunc(func(token TextToken) error {
+		tokens = append(tokens, token)
+		return nil
+	})); err != nil {
+		return nil, err
+	}
+	if tokens == nil {
+		return []TextToken{}, nil
+	}
+	return tokens, nil
+}
+
+// AnalyzeTextToSink streams tokens from a named analyzer directly into sink. It
+// avoids allocating the intermediate []TextToken used by AnalyzeText and is the
+// preferred API for write-path collectors.
+func AnalyzeTextToSink(analyzer TextAnalyzer, text string, sink TextTokenSink) error {
+	if sink == nil {
+		return errors.New("collections: text analyzer sink is nil")
+	}
 	normalized, err := normalizeTextAnalyzer(analyzer)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	switch normalized {
 	case TextAnalyzerSimple:
-		return analyzeSimpleText(text), nil
+		return analyzeSimpleTextToSink(text, sink)
 	default:
-		return nil, fmt.Errorf("unsupported analyzer %q", normalized)
+		return fmt.Errorf("unsupported analyzer %q", normalized)
 	}
 }
 
-func analyzeSimpleText(text string) []TextToken {
-	var tokens []TextToken
+func analyzeSimpleTextToSink(text string, sink TextTokenSink) error {
 	var builder strings.Builder
 	start := -1
 	position := 0
-	flush := func(end int) {
+	flush := func(end int) error {
 		if start < 0 {
-			return
+			return nil
 		}
 		term := builder.String()
 		if term != "" {
-			tokens = append(tokens, TextToken{
+			if err := sink.AddTextToken(TextToken{
 				Term:        term,
 				Position:    position,
 				StartOffset: start,
 				EndOffset:   end,
-			})
+			}); err != nil {
+				return err
+			}
 			position++
 		}
 		builder.Reset()
 		start = -1
+		return nil
 	}
 	for offset, r := range text {
 		if simpleTextTokenRune(r) {
@@ -62,13 +102,11 @@ func analyzeSimpleText(text string) []TextToken {
 			builder.WriteRune(unicode.ToLower(r))
 			continue
 		}
-		flush(offset)
+		if err := flush(offset); err != nil {
+			return err
+		}
 	}
-	flush(len(text))
-	if tokens == nil {
-		return []TextToken{}
-	}
-	return tokens
+	return flush(len(text))
 }
 
 func simpleTextTokenRune(r rune) bool {

--- a/TreeDB/collections/text_analyzer_test.go
+++ b/TreeDB/collections/text_analyzer_test.go
@@ -1,0 +1,65 @@
+package collections
+
+import (
+	"errors"
+	"slices"
+	"testing"
+)
+
+func TestAnalyzeTextToSinkParity2626(t *testing.T) {
+	cases := []string{
+		"",
+		"Refund REFUND http_500 café",
+		"  punctuation!!! separates--tokens 42 ",
+		"emoji🙂split snake_case MIXED_Case",
+	}
+	for _, text := range cases {
+		t.Run(text, func(t *testing.T) {
+			want, err := AnalyzeText(TextAnalyzerSimple, text)
+			if err != nil {
+				t.Fatalf("AnalyzeText: %v", err)
+			}
+			var got []TextToken
+			if err := AnalyzeTextToSink(TextAnalyzerSimple, text, TextTokenSinkFunc(func(token TextToken) error {
+				got = append(got, token)
+				return nil
+			})); err != nil {
+				t.Fatalf("AnalyzeTextToSink: %v", err)
+			}
+			if !slices.Equal(got, want) {
+				t.Fatalf("sink tokens=%+v want %+v", got, want)
+			}
+		})
+	}
+}
+
+func TestAnalyzeTextToSinkPropagatesSinkError2626(t *testing.T) {
+	want := errors.New("stop")
+	err := AnalyzeTextToSink(TextAnalyzerSimple, "refund policy", TextTokenSinkFunc(func(TextToken) error {
+		return want
+	}))
+	if !errors.Is(err, want) {
+		t.Fatalf("err=%v want %v", err, want)
+	}
+}
+
+func TestAnalyzeTextIndexFieldUsesCompactAccumulator2626(t *testing.T) {
+	var b []byte
+	for i := 0; i < textTermAccumulatorInlineTerms+4; i++ {
+		if i > 0 {
+			b = append(b, ' ')
+		}
+		b = append(b, 't', byte('a'+i))
+	}
+	field, ok, err := analyzeTextIndexField(TextIndexDefinition{Analyzer: TextAnalyzerSimple, StorePositions: true, StoreOffsets: true}, "body", string(b))
+	if err != nil || !ok {
+		t.Fatalf("analyze field ok=%v err=%v", ok, err)
+	}
+	if field.Length != uint32(textTermAccumulatorInlineTerms+4) || len(field.Terms) != textTermAccumulatorInlineTerms+4 {
+		t.Fatalf("field length=%d terms=%d", field.Length, len(field.Terms))
+	}
+	term := field.Terms["ta"]
+	if term == nil || term.Frequency != 1 || !slices.Equal(term.Positions, []uint32{0}) || len(term.Offsets) != 1 {
+		t.Fatalf("term ta=%+v", term)
+	}
+}

--- a/TreeDB/collections/text_backfill.go
+++ b/TreeDB/collections/text_backfill.go
@@ -547,19 +547,12 @@ func analyzeTextIndexDocumentJSONRootFastPath(def TextIndexDefinition, jsonDocum
 	} else {
 		values = values[:len(def.Fields)]
 	}
-	var keyScratch []byte
 	if err := jsonparser.ObjectEach(jsonDocument, func(key, value []byte, dataType jsonparser.ValueType, _ int) error {
-		matchKey := key
-		if bytes.IndexByte(key, '\\') >= 0 {
-			unescaped, err := jsonparser.Unescape(key, keyScratch[:0])
-			if err != nil {
-				return err
-			}
-			matchKey = unescaped
-			keyScratch = unescaped[:0]
-		}
+		// jsonparser.ObjectEach already returns decoded object keys. Unescaping here
+		// would treat literal backslashes as JSON escapes (for example `a\\q` ->
+		// `a\q` -> invalid `\q`) and could reject unrelated top-level fields.
 		for i, fieldDef := range def.Fields {
-			if textBytesEqualString(matchKey, fieldDef.Field) {
+			if textBytesEqualString(key, fieldDef.Field) {
 				values[i] = jsonParserIndexValue{raw: value, valueType: dataType}
 			}
 		}

--- a/TreeDB/collections/text_backfill.go
+++ b/TreeDB/collections/text_backfill.go
@@ -9,6 +9,7 @@ import (
 	"slices"
 	"sort"
 	"strings"
+	"unicode"
 
 	"github.com/buger/jsonparser"
 	backenddb "github.com/snissn/gomap/TreeDB/db"
@@ -28,6 +29,7 @@ type TextIndexBackfillStats struct {
 
 	V2DocIDEntries   int
 	V2DocMapBlocks   int
+	V2PostingBlocks  int
 	V2NormBlocks     int
 	V2TermStats      int
 	V2FormatRecords  int
@@ -82,6 +84,73 @@ type textAnalyzedTerm struct {
 	Frequency uint32
 	Positions []uint32
 	Offsets   []textTokenOffset
+}
+
+const textTermAccumulatorInlineTerms = 8
+
+type textTermAccumulator struct {
+	storePositions bool
+	storeOffsets   bool
+	length         uint32
+	inline         [textTermAccumulatorInlineTerms]textAnalyzedTerm
+	terms          []textAnalyzedTerm
+	lookup         map[string]int
+}
+
+func newTextTermAccumulator(storePositions, storeOffsets bool) textTermAccumulator {
+	acc := textTermAccumulator{storePositions: storePositions, storeOffsets: storeOffsets}
+	acc.terms = acc.inline[:0]
+	return acc
+}
+
+func (a *textTermAccumulator) AddTextToken(token TextToken) error {
+	a.addToken(token)
+	return nil
+}
+
+func (a *textTermAccumulator) addToken(token TextToken) {
+	idx := -1
+	if a.lookup != nil {
+		if found, ok := a.lookup[token.Term]; ok {
+			idx = found
+		}
+	} else {
+		for i := range a.terms {
+			if a.terms[i].Term == token.Term {
+				idx = i
+				break
+			}
+		}
+	}
+	if idx < 0 {
+		idx = len(a.terms)
+		a.terms = append(a.terms, textAnalyzedTerm{Term: token.Term})
+		if a.lookup != nil {
+			a.lookup[token.Term] = idx
+		} else if len(a.terms) > textTermAccumulatorInlineTerms {
+			a.lookup = make(map[string]int, len(a.terms)*2)
+			for i := range a.terms {
+				a.lookup[a.terms[i].Term] = i
+			}
+		}
+	}
+	term := &a.terms[idx]
+	term.Frequency++
+	if a.storePositions {
+		term.Positions = append(term.Positions, uint32(token.Position))
+	}
+	if a.storeOffsets {
+		term.Offsets = append(term.Offsets, textTokenOffset{Start: uint32(token.StartOffset), End: uint32(token.EndOffset)})
+	}
+	a.length++
+}
+
+func (a *textTermAccumulator) termsMap() map[string]*textAnalyzedTerm {
+	out := make(map[string]*textAnalyzedTerm, len(a.terms))
+	for i := range a.terms {
+		out[a.terms[i].Term] = &a.terms[i]
+	}
+	return out
 }
 
 type textBackfillStatsAccumulator struct {
@@ -233,6 +302,7 @@ func buildCreateTextV2IndexBackfillPlan(
 	}
 
 	fieldNames := textV2FieldNames(def)
+	analysisDef := textV2ScoringAnalysisDefinition(def)
 	for _, rootName := range rootNames {
 		family, ok := textV2RootFamilyForName(catalog.meta.Name, def.Name, rootName)
 		if !ok {
@@ -255,10 +325,12 @@ func buildCreateTextV2IndexBackfillPlan(
 	docIDRootName := collectionTextV2DocIDRootName(catalog.meta.Name, def.Name)
 	docMapRootName := collectionTextV2DocMapRootName(catalog.meta.Name, def.Name)
 	termsRootName := collectionTextV2TermsRootName(catalog.meta.Name, def.Name)
+	postingBlocksRootName := collectionTextV2PostingBlocksRootName(catalog.meta.Name, def.Name)
 	normRootName := collectionTextV2NormBlocksRootName(catalog.meta.Name, def.Name)
 	generationsRootName := collectionTextV2GenerationsRootName(catalog.meta.Name, def.Name)
 	docMapBlocks := make(map[uint64]*textV2DocMapBlockValue)
 	normBlocks := make(map[uint64]*textV2NormBlockValue)
+	var postingBuilder textV2PostingBatchBuilder
 	acc := textBackfillStatsAccumulator{
 		Terms:  make(map[string]*textStatsTermValue),
 		Fields: make(map[string]*textStatsFieldValue),
@@ -286,7 +358,7 @@ func buildCreateTextV2IndexBackfillPlan(
 					resetAll()
 					return nil, err
 				}
-				analysis, err := analyzeTextIndexDocument(def, jsonDocument)
+				analysis, err := analyzeTextIndexDocument(analysisDef, jsonDocument)
 				if err != nil {
 					resetAll()
 					return nil, err
@@ -318,6 +390,10 @@ func buildCreateTextV2IndexBackfillPlan(
 				}
 				normBlock.upsert(textV2NormBlockEntry{Ordinal: ordinal, Generation: generation, FieldLengths: fieldLengths})
 
+				if err := postingBuilder.addDocument(def, ordinal, generation, analysis); err != nil {
+					resetAll()
+					return nil, err
+				}
 				acc.addDocument(analysis)
 				plan.stats.DocumentsScanned++
 				it.Next()
@@ -344,7 +420,15 @@ func buildCreateTextV2IndexBackfillPlan(
 		plan.stats.EncodedBytes += uint64(len(key) + len(value))
 	}
 
-	statsEntries, statsBytes := addTextV2StatsEntries(tables[termsRootName], acc, def, 1)
+	postingBlocks, postingBytes, postingBlockCounts, err := buildTextV2PostingBatchTable(tables[postingBlocksRootName], &postingBuilder, textV2PostingBlockKindSealed, textV2PostingBlockTargetPostings, 1)
+	if err != nil {
+		resetAll()
+		return nil, err
+	}
+	plan.stats.V2PostingBlocks = postingBlocks
+	plan.stats.EncodedBytes += postingBytes
+
+	statsEntries, statsBytes := addTextV2StatsEntries(tables[termsRootName], acc, def, 1, postingBlockCounts)
 	plan.stats.V2TermStats = statsEntries
 	plan.stats.StatsEntries = statsEntries
 	plan.stats.EncodedBytes += statsBytes
@@ -463,9 +547,19 @@ func analyzeTextIndexDocumentJSONRootFastPath(def TextIndexDefinition, jsonDocum
 	} else {
 		values = values[:len(def.Fields)]
 	}
+	var keyScratch []byte
 	if err := jsonparser.ObjectEach(jsonDocument, func(key, value []byte, dataType jsonparser.ValueType, _ int) error {
+		matchKey := key
+		if bytes.IndexByte(key, '\\') >= 0 {
+			unescaped, err := jsonparser.Unescape(key, keyScratch[:0])
+			if err != nil {
+				return err
+			}
+			matchKey = unescaped
+			keyScratch = unescaped[:0]
+		}
 		for i, fieldDef := range def.Fields {
-			if string(key) == fieldDef.Field {
+			if textBytesEqualString(matchKey, fieldDef.Field) {
 				values[i] = jsonParserIndexValue{raw: value, valueType: dataType}
 			}
 		}
@@ -559,26 +653,55 @@ func textJSONParserStringBytes(raw []byte, scratch *[]byte) ([]byte, error) {
 }
 
 func analyzeTextIndexField(def TextIndexDefinition, fieldName, text string) (textAnalyzedField, bool, error) {
-	tokens, err := AnalyzeText(def.Analyzer, text)
-	if err != nil {
+	acc := newTextTermAccumulator(def.StorePositions, def.StoreOffsets)
+	if err := analyzeTextToTermAccumulator(def.Analyzer, text, &acc); err != nil {
 		return textAnalyzedField{}, false, err
 	}
-	field := textAnalyzedField{Field: fieldName, Length: uint32(len(tokens)), Terms: make(map[string]*textAnalyzedTerm)}
-	for _, token := range tokens {
-		term := field.Terms[token.Term]
-		if term == nil {
-			term = &textAnalyzedTerm{Term: token.Term}
-			field.Terms[token.Term] = term
-		}
-		term.Frequency++
-		if def.StorePositions {
-			term.Positions = append(term.Positions, uint32(token.Position))
-		}
-		if def.StoreOffsets {
-			term.Offsets = append(term.Offsets, textTokenOffset{Start: uint32(token.StartOffset), End: uint32(token.EndOffset)})
-		}
-	}
+	field := textAnalyzedField{Field: fieldName, Length: acc.length, Terms: acc.termsMap()}
 	return field, true, nil
+}
+
+func analyzeTextToTermAccumulator(analyzer TextAnalyzer, text string, acc *textTermAccumulator) error {
+	normalized, err := normalizeTextAnalyzer(analyzer)
+	if err != nil {
+		return err
+	}
+	switch normalized {
+	case TextAnalyzerSimple:
+		analyzeSimpleTextToTermAccumulator(text, acc)
+		return nil
+	default:
+		return fmt.Errorf("unsupported analyzer %q", normalized)
+	}
+}
+
+func analyzeSimpleTextToTermAccumulator(text string, acc *textTermAccumulator) {
+	var builder strings.Builder
+	start := -1
+	position := 0
+	flush := func(end int) {
+		if start < 0 {
+			return
+		}
+		term := builder.String()
+		if term != "" {
+			acc.addToken(TextToken{Term: term, Position: position, StartOffset: start, EndOffset: end})
+			position++
+		}
+		builder.Reset()
+		start = -1
+	}
+	for offset, r := range text {
+		if simpleTextTokenRune(r) {
+			if start < 0 {
+				start = offset
+			}
+			builder.WriteRune(unicode.ToLower(r))
+			continue
+		}
+		flush(offset)
+	}
+	flush(len(text))
 }
 
 func textIndexFieldText(value any) (string, bool) {
@@ -720,7 +843,7 @@ func addTextStatsEntries(table memtable.Table, acc textBackfillStatsAccumulator)
 	return entries, bytesWritten
 }
 
-func addTextV2StatsEntries(table memtable.Table, acc textBackfillStatsAccumulator, def TextIndexDefinition, generation uint64) (int, uint64) {
+func addTextV2StatsEntries(table memtable.Table, acc textBackfillStatsAccumulator, def TextIndexDefinition, generation uint64, postingBlockCounts map[string]uint64) (int, uint64) {
 	if table == nil {
 		return 0, 0
 	}
@@ -746,6 +869,7 @@ func addTextV2StatsEntries(table memtable.Table, acc textBackfillStatsAccumulato
 			StatsGeneration:    generation,
 			DocumentFrequency:  stats.DocumentFrequency,
 			TotalTermFrequency: stats.TotalTermFrequency,
+			PostingBlockCount:  postingBlockCounts[term],
 		}))
 	}
 	seenFields := make(map[string]struct{}, len(def.Fields))

--- a/TreeDB/collections/text_index.go
+++ b/TreeDB/collections/text_index.go
@@ -362,6 +362,7 @@ func textIndexStatusForDefinition(collection string, def TextIndexDefinition) Te
 	}
 	if version == TextIndexVersionV2 {
 		status.Ready = true
+		status.Writable = true
 		status.FailClosed = true
 		status.FailClosedReason = "text_v2_search_unavailable"
 		status.ActiveRootNames = collectionTextV2RootNames(collection, def.Name)

--- a/TreeDB/collections/text_index_test.go
+++ b/TreeDB/collections/text_index_test.go
@@ -258,8 +258,8 @@ func TestCollectionTextV2RootNamesAndStatusContract2623(t *testing.T) {
 		}
 	}
 	v2Status := textIndexStatusForDefinition("docs", TextIndexDefinition{Name: "lexical", Version: TextIndexVersionV2, Rollout: TextIndexRolloutPrimary})
-	if !v2Status.FailClosed || !v2Status.Ready || v2Status.Readable || v2Status.Writable || v2Status.FailClosedReason != "text_v2_search_unavailable" {
-		t.Fatalf("v2 status=%+v want root-ready/full-search-write-fail-closed v2", v2Status)
+	if !v2Status.FailClosed || !v2Status.Ready || v2Status.Readable || !v2Status.Writable || v2Status.FailClosedReason != "text_v2_search_unavailable" {
+		t.Fatalf("v2 status=%+v want root-ready/writable/search-fail-closed v2", v2Status)
 	}
 	if !slices.Equal(v2Status.ActiveRootNames, wantV2) {
 		t.Fatalf("v2 active roots=%q want %q", v2Status.ActiveRootNames, wantV2)

--- a/TreeDB/collections/text_maintenance.go
+++ b/TreeDB/collections/text_maintenance.go
@@ -18,9 +18,10 @@ type textDocumentMutation struct {
 }
 
 type textStatsDelta struct {
-	Documents int64
-	Terms     map[string]textStatsTermDelta
-	Fields    map[string]textStatsFieldDelta
+	Documents     int64
+	Terms         map[string]textStatsTermDelta
+	Fields        map[string]textStatsFieldDelta
+	PostingBlocks map[string]int64
 }
 
 type textStatsTermDelta struct {
@@ -178,13 +179,15 @@ func appendSingleTextV2IndexMutationDeltas(
 	docIDRootName := collectionTextV2DocIDRootName(catalog.meta.Name, def.Name)
 	docMapRootName := collectionTextV2DocMapRootName(catalog.meta.Name, def.Name)
 	termsRootName := collectionTextV2TermsRootName(catalog.meta.Name, def.Name)
+	postingBlocksRootName := collectionTextV2PostingBlocksRootName(catalog.meta.Name, def.Name)
 	normRootName := collectionTextV2NormBlocksRootName(catalog.meta.Name, def.Name)
 	docIDTable := newCollectionRunTable(len(orderedMutations))
 	docMapTable := newCollectionRunTable(0)
 	termsTable := newCollectionRunTable(0)
+	postingBlocksTable := newCollectionRunTable(0)
 	normTable := newCollectionRunTable(0)
 	generationsTable := newCollectionRunTable(1)
-	deltaOwned := []memtable.Table{docIDTable, docMapTable, termsTable, normTable, generationsTable}
+	deltaOwned := []memtable.Table{docIDTable, docMapTable, termsTable, postingBlocksTable, normTable, generationsTable}
 	success := false
 	defer func() {
 		if !success {
@@ -194,6 +197,7 @@ func appendSingleTextV2IndexMutationDeltas(
 
 	docMapBlocks := make(map[uint64]*textV2DocMapBlockValue)
 	normBlocks := make(map[uint64]*textV2NormBlockValue)
+	var postingBuilder textV2PostingBatchBuilder
 	statsDelta := textStatsDelta{}
 	nextOrdinal := status.NextOrdinal
 	liveDocuments := status.LiveDocuments
@@ -202,6 +206,7 @@ func appendSingleTextV2IndexMutationDeltas(
 	if nextGeneration == 0 {
 		return errMalformedTextStorage("text-v2 root generation overflow")
 	}
+	analysisDef := textV2ScoringAnalysisDefinition(def)
 
 	for _, mutation := range orderedMutations {
 		if len(mutation.documentID) == 0 {
@@ -214,6 +219,7 @@ func appendSingleTextV2IndexMutationDeltas(
 
 		var oldState textDocumentStateValue
 		var newState textDocumentStateValue
+		var newAnalysis textAnalyzedDocument
 		if mutation.deleteOld {
 			if !hasCurrent || current.tombstoned() {
 				return errMalformedTextStorage("missing live text-v2 ordinal for delete collection %q index %q document %q", catalog.meta.Name, def.Name, string(mutation.documentID))
@@ -222,13 +228,13 @@ func appendSingleTextV2IndexMutationDeltas(
 			if err != nil {
 				return err
 			}
-			oldState, err = analyzeTextIndexStoredDocument(def, oldDocument, opts)
+			oldState, err = analyzeTextIndexStoredDocument(analysisDef, oldDocument, opts)
 			if err != nil {
 				return err
 			}
 		}
 		if mutation.setNew {
-			newState, _, err = analyzeTextIndexStoredDocumentWithAnalysis(def, mutation.newDocument, opts)
+			newState, newAnalysis, err = analyzeTextIndexStoredDocumentWithAnalysis(analysisDef, mutation.newDocument, opts)
 			if err != nil {
 				return err
 			}
@@ -283,6 +289,11 @@ func appendSingleTextV2IndexMutationDeltas(
 		if err := upsertTextV2NormMutation(snap, catalog, normRootName, normBlocks, nextDoc, lengths); err != nil {
 			return err
 		}
+		if mutation.setNew {
+			if err := postingBuilder.addDocument(def, nextDoc.Ordinal, nextDoc.Generation, newAnalysis); err != nil {
+				return err
+			}
+		}
 	}
 
 	for _, blockStart := range sortedTextV2BlockStarts(docMapBlocks) {
@@ -293,6 +304,15 @@ func appendSingleTextV2IndexMutationDeltas(
 		block := normBlocks[blockStart]
 		normTable.SetSteal(encodeTextV2BlockKey(blockStart), encodeTextV2NormBlockValue(*block))
 	}
+	mutationBlockIDStart, err := textV2PostingBlockMutationBlockIDStart(nextGeneration)
+	if err != nil {
+		return err
+	}
+	_, _, postingBlockCounts, err := buildTextV2PostingBatchTable(postingBlocksTable, &postingBuilder, textV2PostingBlockKindMicro, textV2PostingBlockMicroPostings, mutationBlockIDStart)
+	if err != nil {
+		return err
+	}
+	statsDelta.addPostingBlocks(postingBlockCounts)
 	if err := buildTextV2StatsDeltaTable(snap, catalog, def, termsRootName, statsDelta, nextGeneration, termsTable); err != nil {
 		return err
 	}
@@ -328,6 +348,9 @@ func appendSingleTextV2IndexMutationDeltas(
 		return err
 	}
 	if err := appendIfNonEmpty(termsRootName, termsTable); err != nil {
+		return err
+	}
+	if err := appendIfNonEmpty(postingBlocksRootName, postingBlocksTable); err != nil {
 		return err
 	}
 	if err := appendIfNonEmpty(normRootName, normTable); err != nil {
@@ -471,11 +494,21 @@ func buildTextV2StatsDeltaTable(snap *backenddb.Snapshot, catalog *collectionCat
 		table.SetSteal(encodeTextV2FieldStatsKey(field), encodeTextV2FieldStatsValue(textV2FieldStatsValue{StatsGeneration: generation, DocumentCount: docs, TotalTokenCount: tokens}))
 	}
 
-	terms := make([]string, 0, len(delta.Terms))
+	termSet := make(map[string]struct{}, len(delta.Terms)+len(delta.PostingBlocks))
 	for term, termDelta := range delta.Terms {
 		if termDelta.DocumentFrequency == 0 && termDelta.TotalTermFrequency == 0 {
 			continue
 		}
+		termSet[term] = struct{}{}
+	}
+	for term, blockDelta := range delta.PostingBlocks {
+		if blockDelta == 0 {
+			continue
+		}
+		termSet[term] = struct{}{}
+	}
+	terms := make([]string, 0, len(termSet))
+	for term := range termSet {
 		terms = append(terms, term)
 	}
 	sort.Strings(terms)
@@ -493,11 +526,15 @@ func buildTextV2StatsDeltaTable(snap *backenddb.Snapshot, catalog *collectionCat
 		if err != nil {
 			return err
 		}
+		blocks, err := applySignedTextDelta(current.PostingBlockCount, delta.PostingBlocks[term], "text-v2 term posting block count")
+		if err != nil {
+			return err
+		}
 		key := encodeTextV2TermStatsKey(term)
-		if df == 0 && tf == 0 {
+		if df == 0 && tf == 0 && blocks == 0 {
 			table.DeleteSteal(key)
 		} else {
-			table.SetSteal(key, encodeTextV2TermStatsValue(textV2TermStatsValue{StatsGeneration: generation, DocumentFrequency: df, TotalTermFrequency: tf, PostingBlockCount: current.PostingBlockCount}))
+			table.SetSteal(key, encodeTextV2TermStatsValue(textV2TermStatsValue{StatsGeneration: generation, DocumentFrequency: df, TotalTermFrequency: tf, PostingBlockCount: blocks}))
 		}
 	}
 	return nil
@@ -638,6 +675,18 @@ func (d *textStatsDelta) addState(state textDocumentStateValue, sign int64) {
 		termDelta.DocumentFrequency += sign
 		termDelta.TotalTermFrequency += signedTextDeltaUint64(freq, sign)
 		d.Terms[term] = termDelta
+	}
+}
+
+func (d *textStatsDelta) addPostingBlocks(blockCounts map[string]uint64) {
+	if len(blockCounts) == 0 {
+		return
+	}
+	if d.PostingBlocks == nil {
+		d.PostingBlocks = make(map[string]int64, len(blockCounts))
+	}
+	for term, count := range blockCounts {
+		d.PostingBlocks[term] += signedTextDeltaUint64(count, 1)
 	}
 }
 

--- a/TreeDB/collections/text_storage_test.go
+++ b/TreeDB/collections/text_storage_test.go
@@ -159,6 +159,17 @@ func TestTextIndexAnalysisJSONFastPathAndNestedFallbackM2589(t *testing.T) {
 	if got := requireAnalyzedTermM2589(t, requireAnalyzedFieldM2589(t, escapedRoot, "body"), "escaped").Frequency; got != 1 {
 		t.Fatalf("escaped-key body frequency=%d want 1", got)
 	}
+	if _, err := analyzeTextIndexDocument(rootDef, []byte(`{"a\\q":"ignored","body":"Backslash Safe"}`)); err != nil {
+		t.Fatalf("analyze root with unrelated literal-backslash key: %v", err)
+	}
+	backslashDef := TextIndexDefinition{Name: "lexical", Fields: []TextIndexField{{Field: "a\\q"}}}
+	backslashRoot, err := analyzeTextIndexDocument(backslashDef, []byte(`{"a\\q":"Backslash Field"}`))
+	if err != nil {
+		t.Fatalf("analyze literal-backslash root key: %v", err)
+	}
+	if got := requireAnalyzedTermM2589(t, requireAnalyzedFieldM2589(t, backslashRoot, "a\\q"), "backslash").Frequency; got != 1 {
+		t.Fatalf("literal-backslash key frequency=%d want 1", got)
+	}
 
 	nestedDef := TextIndexDefinition{Name: "lexical", Fields: []TextIndexField{{Field: "nested.body"}}, StorePositions: true}
 	nested, err := analyzeTextIndexDocument(nestedDef, []byte(`{"nested":{"body":["Deep","Refund"]},"nested.body":"literal should not win"}`))

--- a/TreeDB/collections/text_storage_test.go
+++ b/TreeDB/collections/text_storage_test.go
@@ -152,6 +152,14 @@ func TestTextIndexAnalysisJSONFastPathAndNestedFallbackM2589(t *testing.T) {
 		t.Fatalf("tags length=%d want 1", got)
 	}
 
+	escapedRoot, err := analyzeTextIndexDocument(rootDef, []byte(`{"bo\u0064y":"Escaped Refund"}`))
+	if err != nil {
+		t.Fatalf("analyze escaped root key: %v", err)
+	}
+	if got := requireAnalyzedTermM2589(t, requireAnalyzedFieldM2589(t, escapedRoot, "body"), "escaped").Frequency; got != 1 {
+		t.Fatalf("escaped-key body frequency=%d want 1", got)
+	}
+
 	nestedDef := TextIndexDefinition{Name: "lexical", Fields: []TextIndexField{{Field: "nested.body"}}, StorePositions: true}
 	nested, err := analyzeTextIndexDocument(nestedDef, []byte(`{"nested":{"body":["Deep","Refund"]},"nested.body":"literal should not win"}`))
 	if err != nil {

--- a/TreeDB/collections/text_v2_contract_bench_test.go
+++ b/TreeDB/collections/text_v2_contract_bench_test.go
@@ -172,6 +172,38 @@ func BenchmarkTextV2ContractWritePaths2623(b *testing.B) {
 		textV2ContractReportWriteStats2623(b, docsPerBatch, lastStats, textV2ContractStorageEntryCount2623(lastStats))
 	})
 
+	b.Run("insert_batch_text_v2_indexed", func(b *testing.B) {
+		var lastStats TextIndexStorageStats
+		var writeAmpEntries uint64
+		var highDFBlocks uint64
+		b.ReportAllocs()
+		b.ReportMetric(float64(docsPerBatch), "docs/op")
+		b.ResetTimer()
+		b.StopTimer()
+		for i := 0; i < b.N; i++ {
+			d := openTextV2ContractDB2623(b)
+			col := createTextV2ContractCollection2623(b, d, false)
+			if _, _, err := col.CreateTextIndex(textV2ContractV2IndexDefinition2626()); err != nil {
+				b.Fatalf("CreateTextIndex v2 setup: %v", err)
+			}
+			beforeStats := textV2ContractStorageStats2623(b, col)
+			batchIDs := textV2ContractCloneIDsWithIteration2623(ids, i)
+			b.StartTimer()
+			_, err := col.InsertBatch(batchIDs, docs)
+			b.StopTimer()
+			if err != nil {
+				b.Fatalf("InsertBatch text-v2-indexed: %v", err)
+			}
+			lastStats = textV2ContractStorageStats2623(b, col)
+			highDFBlocks = textV2ContractTermPostingBlockCount2626(b, col, "refund")
+			writeAmpEntries = textV2ContractV2MutationRootDeltaEntries2626(docsPerBatch, beforeStats, lastStats, lastStats.V2TermStats)
+			_ = d.Close()
+		}
+		b.ReportMetric(float64(docsPerBatch), "docs/op")
+		textV2ContractReportWriteStats2623(b, docsPerBatch, lastStats, writeAmpEntries)
+		textV2ContractReportHighDFBlocks2626(b, docsPerBatch, highDFBlocks)
+	})
+
 	b.Run("create_text_index_backfill", func(b *testing.B) {
 		var lastStats TextIndexBackfillStats
 		b.ReportAllocs()
@@ -196,6 +228,35 @@ func BenchmarkTextV2ContractWritePaths2623(b *testing.B) {
 		}
 		b.ReportMetric(float64(docsPerBatch), "docs/op")
 		textV2ContractReportBackfillStats2623(b, docsPerBatch, lastStats)
+	})
+
+	b.Run("create_text_v2_index_backfill", func(b *testing.B) {
+		var lastStats TextIndexBackfillStats
+		var highDFBlocks uint64
+		b.ReportAllocs()
+		b.ReportMetric(float64(docsPerBatch), "docs/op")
+		b.ResetTimer()
+		b.StopTimer()
+		for i := 0; i < b.N; i++ {
+			d := openTextV2ContractDB2623(b)
+			col := createTextV2ContractCollection2623(b, d, false)
+			batchIDs := textV2ContractCloneIDsWithIteration2623(ids, i)
+			if _, err := col.InsertBatch(batchIDs, docs); err != nil {
+				b.Fatalf("InsertBatch setup: %v", err)
+			}
+			b.StartTimer()
+			_, stats, err := col.CreateTextIndex(textV2ContractV2IndexDefinition2626())
+			b.StopTimer()
+			if err != nil {
+				b.Fatalf("CreateTextIndex v2 backfill: %v", err)
+			}
+			lastStats = stats
+			highDFBlocks = textV2ContractTermPostingBlockCount2626(b, col, "refund")
+			_ = d.Close()
+		}
+		b.ReportMetric(float64(docsPerBatch), "docs/op")
+		textV2ContractReportBackfillStats2623(b, docsPerBatch, lastStats)
+		textV2ContractReportHighDFBlocks2626(b, docsPerBatch, highDFBlocks)
 	})
 
 	b.Run("update_batch_text_indexed", func(b *testing.B) {
@@ -237,6 +298,52 @@ func BenchmarkTextV2ContractWritePaths2623(b *testing.B) {
 		textV2ContractReportWriteStats2623(b, docsPerBatch, lastStats, writeAmpEntries)
 	})
 
+	b.Run("update_batch_text_v2_indexed", func(b *testing.B) {
+		_, updatedDocs := textV2ContractDocuments2623(docsPerBatch, "update")
+		var lastStats TextIndexStorageStats
+		var writeAmpEntries uint64
+		var highDFBlocks uint64
+		b.ReportAllocs()
+		b.ReportMetric(float64(docsPerBatch), "docs/op")
+		b.ResetTimer()
+		b.StopTimer()
+		for i := 0; i < b.N; i++ {
+			d := openTextV2ContractDB2623(b)
+			col := createTextV2ContractCollection2623(b, d, false)
+			if _, _, err := col.CreateTextIndex(textV2ContractV2IndexDefinition2626()); err != nil {
+				b.Fatalf("CreateTextIndex v2 setup: %v", err)
+			}
+			batchIDs := textV2ContractCloneIDsWithIteration2623(ids, i)
+			if _, err := col.InsertBatch(batchIDs, docs); err != nil {
+				b.Fatalf("InsertBatch setup: %v", err)
+			}
+			beforeStats := textV2ContractStorageStats2623(b, col)
+			updates := make([]UpdateBatchItem, docsPerBatch)
+			for j := 0; j < docsPerBatch; j++ {
+				replacement := bytes.Clone(updatedDocs[j])
+				updates[j] = UpdateBatchItem{DocumentID: batchIDs[j], Update: func(current []byte) ([]byte, bool, error) {
+					return replacement, true, nil
+				}}
+			}
+			b.StartTimer()
+			results, err := col.UpdateBatch(updates)
+			b.StopTimer()
+			if err != nil {
+				b.Fatalf("UpdateBatch text-v2-indexed: %v", err)
+			}
+			if len(results) != docsPerBatch {
+				b.Fatalf("UpdateBatch results=%d want %d", len(results), docsPerBatch)
+			}
+			lastStats = textV2ContractStorageStats2623(b, col)
+			highDFBlocks = textV2ContractTermPostingBlockCount2626(b, col, "refund")
+			writeAmpEntries = textV2ContractV2MutationRootDeltaEntries2626(docsPerBatch, beforeStats, lastStats, lastStats.V2TermStats)
+			_ = d.Close()
+		}
+		b.ReportMetric(float64(docsPerBatch), "docs/op")
+		textV2ContractReportWriteStats2623(b, docsPerBatch, lastStats, writeAmpEntries)
+		textV2ContractReportHighDFBlocks2626(b, docsPerBatch, highDFBlocks)
+	})
+
 	b.Run("delete_batch_text_indexed", func(b *testing.B) {
 		var lastStats TextIndexStorageStats
 		var writeAmpEntries uint64
@@ -267,6 +374,44 @@ func BenchmarkTextV2ContractWritePaths2623(b *testing.B) {
 		}
 		b.ReportMetric(float64(docsPerBatch), "docs/op")
 		textV2ContractReportWriteStats2623(b, docsPerBatch, lastStats, writeAmpEntries)
+	})
+
+	b.Run("delete_batch_text_v2_indexed", func(b *testing.B) {
+		var lastStats TextIndexStorageStats
+		var writeAmpEntries uint64
+		var highDFBlocks uint64
+		b.ReportAllocs()
+		b.ReportMetric(float64(docsPerBatch), "docs/op")
+		b.ResetTimer()
+		b.StopTimer()
+		for i := 0; i < b.N; i++ {
+			d := openTextV2ContractDB2623(b)
+			col := createTextV2ContractCollection2623(b, d, false)
+			if _, _, err := col.CreateTextIndex(textV2ContractV2IndexDefinition2626()); err != nil {
+				b.Fatalf("CreateTextIndex v2 setup: %v", err)
+			}
+			batchIDs := textV2ContractCloneIDsWithIteration2623(ids, i)
+			if _, err := col.InsertBatch(batchIDs, docs); err != nil {
+				b.Fatalf("InsertBatch setup: %v", err)
+			}
+			beforeStats := textV2ContractStorageStats2623(b, col)
+			b.StartTimer()
+			deleted, err := col.DeleteBatch(batchIDs)
+			b.StopTimer()
+			if err != nil {
+				b.Fatalf("DeleteBatch text-v2-indexed: %v", err)
+			}
+			if deleted != docsPerBatch {
+				b.Fatalf("DeleteBatch deleted=%d want %d", deleted, docsPerBatch)
+			}
+			lastStats = textV2ContractStorageStats2623(b, col)
+			highDFBlocks = textV2ContractTermPostingBlockCount2626(b, col, "refund")
+			writeAmpEntries = textV2ContractV2MutationRootDeltaEntries2626(docsPerBatch, beforeStats, lastStats, lastStats.V2TermStats)
+			_ = d.Close()
+		}
+		b.ReportMetric(float64(docsPerBatch), "docs/op")
+		textV2ContractReportWriteStats2623(b, docsPerBatch, lastStats, writeAmpEntries)
+		textV2ContractReportHighDFBlocks2626(b, docsPerBatch, highDFBlocks)
 	})
 }
 
@@ -464,6 +609,16 @@ func textV2ContractIndexDefinition2623() TextIndexDefinition {
 	}
 }
 
+func textV2ContractV2IndexDefinition2626() TextIndexDefinition {
+	def := textV2ContractIndexDefinition2623()
+	def.Version = TextIndexVersionV2
+	// M3 writes scoring postings/norms/docmaps only; lazy positions are owned by
+	// #2629, so the v2 write-path benchmark excludes v1 position payload work.
+	def.StorePositions = false
+	def.StoreOffsets = false
+	return def
+}
+
 func textV2ContractDocuments2623(count int, label string) ([][]byte, [][]byte) {
 	ids := make([][]byte, count)
 	docs := make([][]byte, count)
@@ -495,27 +650,103 @@ func textV2ContractStorageStats2623(tb testing.TB, col *Collection) TextIndexSto
 func textV2ContractReportBackfillStats2623(b *testing.B, docs int, stats TextIndexBackfillStats) {
 	b.Helper()
 	entries := uint64(stats.PostingEntries + stats.StateEntries + stats.StatsEntries)
+	v2Entries := uint64(stats.V2DocIDEntries + stats.V2DocMapBlocks + stats.V2PostingBlocks + stats.V2NormBlocks + stats.V2TermStats + stats.V2FormatRecords + stats.V2StatusRecords)
+	if v2Entries > 0 {
+		entries = v2Entries
+	}
+	docsDivisor := float64(maxTextV2ContractInt2623(docs, 1))
 	b.ReportMetric(float64(stats.DocumentsScanned), "docs_scanned/op")
 	b.ReportMetric(float64(stats.PostingEntries), "posting_entries/op")
 	b.ReportMetric(float64(stats.StateEntries), "state_entries/op")
 	b.ReportMetric(float64(stats.StatsEntries), "stats_entries/op")
-	b.ReportMetric(float64(entries)/float64(maxTextV2ContractInt2623(docs, 1)), "index_entries/doc")
-	b.ReportMetric(float64(entries)/float64(maxTextV2ContractInt2623(docs, 1)), "write_amp_entries/doc")
-	b.ReportMetric(float64(stats.EncodedBytes)/float64(maxTextV2ContractInt2623(docs, 1)), "index_bytes/doc")
+	b.ReportMetric(float64(stats.V2DocIDEntries), "v2_docid_entries/op")
+	b.ReportMetric(float64(stats.V2DocMapBlocks), "v2_docmap_blocks/op")
+	b.ReportMetric(float64(stats.V2PostingBlocks), "v2_posting_blocks/op")
+	b.ReportMetric(float64(stats.V2NormBlocks), "v2_norm_blocks/op")
+	b.ReportMetric(float64(stats.V2TermStats), "v2_term_stats/op")
+	b.ReportMetric(float64(stats.V2PostingBlocks)/docsDivisor, "posting_blocks/doc")
+	b.ReportMetric(0, "rewritten_blocks/doc")
+	b.ReportMetric(float64(entries)/docsDivisor, "index_entries/doc")
+	b.ReportMetric(float64(entries)/docsDivisor, "write_amp_entries/doc")
+	b.ReportMetric(float64(stats.EncodedBytes)/docsDivisor, "index_bytes/doc")
 }
 
 func textV2ContractReportWriteStats2623(b *testing.B, docs int, stats TextIndexStorageStats, writeAmpEntries uint64) {
 	b.Helper()
 	entries := textV2ContractStorageEntryCount2623(stats)
+	docsDivisor := float64(maxTextV2ContractInt2623(docs, 1))
 	b.ReportMetric(float64(stats.PostingEntries), "posting_entries/op")
 	b.ReportMetric(float64(stats.StateEntries), "state_entries/op")
 	b.ReportMetric(float64(stats.StatsEntries), "stats_entries/op")
-	b.ReportMetric(float64(entries)/float64(maxTextV2ContractInt2623(docs, 1)), "index_entries/doc")
-	b.ReportMetric(float64(writeAmpEntries)/float64(maxTextV2ContractInt2623(docs, 1)), "write_amp_entries/doc")
-	b.ReportMetric(float64(stats.EncodedBytes)/float64(maxTextV2ContractInt2623(docs, 1)), "index_bytes/doc")
+	b.ReportMetric(float64(stats.V2DocIDEntries), "v2_docid_entries/op")
+	b.ReportMetric(float64(stats.V2DocMapBlocks), "v2_docmap_blocks/op")
+	b.ReportMetric(float64(stats.V2PostingBlocks), "v2_posting_blocks/op")
+	b.ReportMetric(float64(stats.V2NormBlocks), "v2_norm_blocks/op")
+	b.ReportMetric(float64(stats.V2TermStats), "v2_term_stats/op")
+	b.ReportMetric(float64(stats.V2PostingBlocks)/docsDivisor, "posting_blocks/doc")
+	b.ReportMetric(0, "rewritten_blocks/doc")
+	b.ReportMetric(float64(entries)/docsDivisor, "index_entries/doc")
+	b.ReportMetric(float64(writeAmpEntries)/docsDivisor, "write_amp_entries/doc")
+	b.ReportMetric(float64(stats.EncodedBytes)/docsDivisor, "index_bytes/doc")
+}
+
+func textV2ContractReportHighDFBlocks2626(b *testing.B, docs int, blocks uint64) {
+	b.Helper()
+	b.ReportMetric(float64(blocks), "high_df_posting_blocks/op")
+	b.ReportMetric(float64(blocks)/float64(maxTextV2ContractInt2623(docs, 1)), "high_df_posting_blocks/doc")
+}
+
+func textV2ContractTermPostingBlockCount2626(tb testing.TB, col *Collection, term string) uint64 {
+	tb.Helper()
+	if col == nil || col.db == nil {
+		return 0
+	}
+	snap := col.db.AcquireSnapshot()
+	if snap == nil {
+		tb.Fatalf("snapshot nil")
+	}
+	defer func() { _ = snap.Close() }()
+	catalog, err := col.catalogForSnapshot(snap)
+	if err != nil {
+		tb.Fatalf("catalog snapshot: %v", err)
+	}
+	raw, ok, err := collectionGetAppendAtCatalogRoot(snap, catalog, collectionTextV2TermsRootName(catalog.meta.Name, textV2ContractIndexName2623), encodeTextV2TermStatsKey(term), nil)
+	if err != nil {
+		tb.Fatalf("term stats %q: %v", term, err)
+	}
+	if !ok {
+		return 0
+	}
+	stats, err := decodeTextV2TermStatsValue(raw)
+	if err != nil {
+		tb.Fatalf("decode term stats %q: %v", term, err)
+	}
+	return stats.PostingBlockCount
+}
+
+func textV2ContractV2MutationRootDeltaEntries2626(docs int, before, after TextIndexStorageStats, termEntries uint64) uint64 {
+	docEntries := uint64(maxTextV2ContractInt2623(docs, 0))
+	docMapBlocks := after.V2DocMapBlocks
+	if docMapBlocks == 0 {
+		docMapBlocks = before.V2DocMapBlocks
+	}
+	normBlocks := after.V2NormBlocks
+	if normBlocks == 0 {
+		normBlocks = before.V2NormBlocks
+	}
+	var postingBlocks uint64
+	if after.V2PostingBlocks > before.V2PostingBlocks {
+		postingBlocks = after.V2PostingBlocks - before.V2PostingBlocks
+	}
+	// V2 mutation writes include docID/docmap/norm roots, term-stat deltas,
+	// appended posting blocks (for inserts/updates), and the status generation.
+	return docEntries + docMapBlocks + normBlocks + postingBlocks + termEntries + 1
 }
 
 func textV2ContractStorageEntryCount2623(stats TextIndexStorageStats) uint64 {
+	if stats.Version == TextIndexVersionV2 || stats.V2FormatRecords > 0 {
+		return stats.V2DocIDEntries + stats.V2DocMapBlocks + stats.V2PostingBlocks + stats.V2NormBlocks + stats.V2TermStats + stats.V2FormatRecords + stats.V2StatusRecords
+	}
 	return stats.PostingEntries + stats.StateEntries + stats.StatsEntries
 }
 

--- a/TreeDB/collections/text_v2_contract_bench_test.go
+++ b/TreeDB/collections/text_v2_contract_bench_test.go
@@ -128,6 +128,7 @@ func BenchmarkTextV2ContractWritePaths2623(b *testing.B) {
 		docsPerBatch = 1
 	}
 	ids, docs := textV2ContractDocuments2623(docsPerBatch, "insert")
+	insertTermEntries := textV2ContractUniqueTermStatsEntries2626(b, docs)
 
 	b.Run("insert_batch_no_text", func(b *testing.B) {
 		b.ReportAllocs()
@@ -196,7 +197,7 @@ func BenchmarkTextV2ContractWritePaths2623(b *testing.B) {
 			}
 			lastStats = textV2ContractStorageStats2623(b, col)
 			highDFBlocks = textV2ContractTermPostingBlockCount2626(b, col, "refund")
-			writeAmpEntries = textV2ContractV2MutationRootDeltaEntries2626(docsPerBatch, beforeStats, lastStats, lastStats.V2TermStats)
+			writeAmpEntries = textV2ContractV2MutationRootDeltaEntries2626(docsPerBatch, beforeStats, lastStats, insertTermEntries)
 			_ = d.Close()
 		}
 		b.ReportMetric(float64(docsPerBatch), "docs/op")
@@ -300,6 +301,7 @@ func BenchmarkTextV2ContractWritePaths2623(b *testing.B) {
 
 	b.Run("update_batch_text_v2_indexed", func(b *testing.B) {
 		_, updatedDocs := textV2ContractDocuments2623(docsPerBatch, "update")
+		updateTermEntries := textV2ContractUniqueTermStatsEntries2626(b, docs, updatedDocs)
 		var lastStats TextIndexStorageStats
 		var writeAmpEntries uint64
 		var highDFBlocks uint64
@@ -336,7 +338,7 @@ func BenchmarkTextV2ContractWritePaths2623(b *testing.B) {
 			}
 			lastStats = textV2ContractStorageStats2623(b, col)
 			highDFBlocks = textV2ContractTermPostingBlockCount2626(b, col, "refund")
-			writeAmpEntries = textV2ContractV2MutationRootDeltaEntries2626(docsPerBatch, beforeStats, lastStats, lastStats.V2TermStats)
+			writeAmpEntries = textV2ContractV2MutationRootDeltaEntries2626(docsPerBatch, beforeStats, lastStats, updateTermEntries)
 			_ = d.Close()
 		}
 		b.ReportMetric(float64(docsPerBatch), "docs/op")
@@ -406,7 +408,7 @@ func BenchmarkTextV2ContractWritePaths2623(b *testing.B) {
 			}
 			lastStats = textV2ContractStorageStats2623(b, col)
 			highDFBlocks = textV2ContractTermPostingBlockCount2626(b, col, "refund")
-			writeAmpEntries = textV2ContractV2MutationRootDeltaEntries2626(docsPerBatch, beforeStats, lastStats, lastStats.V2TermStats)
+			writeAmpEntries = textV2ContractV2MutationRootDeltaEntries2626(docsPerBatch, beforeStats, lastStats, insertTermEntries)
 			_ = d.Close()
 		}
 		b.ReportMetric(float64(docsPerBatch), "docs/op")
@@ -724,7 +726,27 @@ func textV2ContractTermPostingBlockCount2626(tb testing.TB, col *Collection, ter
 	return stats.PostingBlockCount
 }
 
-func textV2ContractV2MutationRootDeltaEntries2626(docs int, before, after TextIndexStorageStats, termEntries uint64) uint64 {
+func textV2ContractUniqueTermStatsEntries2626(tb testing.TB, batches ...[][]byte) uint64 {
+	tb.Helper()
+	seen := make(map[string]struct{})
+	def := textV2ContractV2IndexDefinition2626()
+	for _, batch := range batches {
+		for _, doc := range batch {
+			analysis, err := analyzeTextIndexDocument(def, doc)
+			if err != nil {
+				tb.Fatalf("analyze benchmark document: %v", err)
+			}
+			for _, field := range analysis.Fields {
+				for term := range field.Terms {
+					seen[term] = struct{}{}
+				}
+			}
+		}
+	}
+	return uint64(len(seen))
+}
+
+func textV2ContractV2MutationRootDeltaEntries2626(docs int, before, after TextIndexStorageStats, termStatEntries uint64) uint64 {
 	docEntries := uint64(maxTextV2ContractInt2623(docs, 0))
 	docMapBlocks := after.V2DocMapBlocks
 	if docMapBlocks == 0 {
@@ -738,9 +760,9 @@ func textV2ContractV2MutationRootDeltaEntries2626(docs int, before, after TextIn
 	if after.V2PostingBlocks > before.V2PostingBlocks {
 		postingBlocks = after.V2PostingBlocks - before.V2PostingBlocks
 	}
-	// V2 mutation writes include docID/docmap/norm roots, term-stat deltas,
-	// appended posting blocks (for inserts/updates), and the status generation.
-	return docEntries + docMapBlocks + normBlocks + postingBlocks + termEntries + 1
+	// V2 mutation writes include docID/docmap/norm roots, term-stat rows touched
+	// by the mutated documents, appended posting blocks, and the status generation.
+	return docEntries + docMapBlocks + normBlocks + postingBlocks + termStatEntries + 1
 }
 
 func textV2ContractStorageEntryCount2623(stats TextIndexStorageStats) uint64 {

--- a/TreeDB/collections/text_v2_posting_blocks.go
+++ b/TreeDB/collections/text_v2_posting_blocks.go
@@ -96,6 +96,7 @@ type textV2PostingBlockBuildOptions struct {
 	Kind              textV2PostingBlockKind
 	TargetPostings    uint32
 	BlockIDStart      uint64
+	FixedBlockID      bool
 	InlineTargetBytes int
 }
 
@@ -276,10 +277,12 @@ func buildTextV2PostingBlockKVs(term string, entries []textV2PostingBlockEntry, 
 			Block: block,
 		})
 		start += chunkLen
-		if blockID == math.MaxUint64 {
-			return nil, errMalformedTextStorage("text-v2 posting block id overflow")
+		if !opts.FixedBlockID {
+			if blockID == math.MaxUint64 {
+				return nil, errMalformedTextStorage("text-v2 posting block id overflow")
+			}
+			blockID++
 		}
-		blockID++
 	}
 	return out, nil
 }

--- a/TreeDB/collections/text_v2_posting_blocks_test.go
+++ b/TreeDB/collections/text_v2_posting_blocks_test.go
@@ -167,8 +167,8 @@ func TestTextV2PostingBlockIteratorOrderAcrossTerms2625(t *testing.T) {
 	if err != nil {
 		t.Fatalf("TextIndexStorageStats: %v", err)
 	}
-	if stats.V2PostingBlocks != 4 {
-		t.Fatalf("posting blocks=%d want 4", stats.V2PostingBlocks)
+	if stats.V2PostingBlocks < 4 {
+		t.Fatalf("posting blocks=%d want at least manually inserted blocks", stats.V2PostingBlocks)
 	}
 }
 
@@ -238,26 +238,15 @@ func TestTextV2PostingBlocksReachValueLogMaintenance2625(t *testing.T) {
 	d, closeDB := openTextV2PostingBlockCompressedDB2625(t, dir)
 	col := createTextV2PostingBlockCollection2625(t, d, 32, RootStorageCompressed)
 	rootName := collectionTextV2PostingBlocksRootName("docs", "lexical")
-	entries := make([]textV2PostingBlockEntry, 0, 32)
-	for i := uint64(1); i <= 32; i++ {
-		entries = append(entries, textV2PostingBlockEntry{Ordinal: i, Generation: 1, TermFrequency: 3, FieldFrequencies: []uint32{2, 1}})
-	}
-	blocks, err := buildTextV2PostingBlockKVs("refund", entries, 2, textV2PostingBlockBuildOptions{TargetPostings: 64})
-	if err != nil {
-		t.Fatalf("build blocks: %v", err)
-	}
-	if len(blocks) != 1 {
-		t.Fatalf("blocks=%d want 1", len(blocks))
-	}
-	corruptTextRootValue(t, d, "docs", rootName, blocks[0].Key, blocks[0].Value)
-	before := textV2ReadRootBytes2624(t, d, "docs", rootName, blocks[0].Key)
-	if stats, err := col.TextIndexStorageStats("lexical"); err != nil || stats.V2PostingBlocks != 1 {
-		t.Fatalf("TextIndexStorageStats before GC=%+v err=%v want one posting block", stats, err)
+	blockKey := encodeTextV2PostingBlockKey("refund", 1, 1)
+	before := textV2ReadRootBytes2624(t, d, "docs", rootName, blockKey)
+	if stats, err := col.TextIndexStorageStats("lexical"); err != nil || stats.V2PostingBlocks == 0 {
+		t.Fatalf("TextIndexStorageStats before GC=%+v err=%v want emitted posting blocks", stats, err)
 	}
 	if _, err := d.ValueLogGC(context.Background(), backenddb.ValueLogGCOptions{}); err != nil {
 		t.Fatalf("ValueLogGC: %v", err)
 	}
-	if after := textV2ReadRootBytes2624(t, d, "docs", rootName, blocks[0].Key); !bytes.Equal(after, before) {
+	if after := textV2ReadRootBytes2624(t, d, "docs", rootName, blockKey); !bytes.Equal(after, before) {
 		t.Fatalf("posting block changed after ValueLogGC")
 	}
 	if err := closeDB(); err != nil {
@@ -265,7 +254,7 @@ func TestTextV2PostingBlocksReachValueLogMaintenance2625(t *testing.T) {
 	}
 	reopened, closeReopened := openTextV2PostingBlockCompressedDB2625(t, dir)
 	defer func() { _ = closeReopened() }()
-	if after := textV2ReadRootBytes2624(t, reopened, "docs", rootName, blocks[0].Key); !bytes.Equal(after, before) {
+	if after := textV2ReadRootBytes2624(t, reopened, "docs", rootName, blockKey); !bytes.Equal(after, before) {
 		t.Fatalf("posting block not reachable after reopen/GC")
 	}
 	reopenedCol, err := NewCollectionManager(reopened).OpenCollection("docs")
@@ -276,12 +265,12 @@ func TestTextV2PostingBlocksReachValueLogMaintenance2625(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reopened TextIndexStorageStats: %v", err)
 	}
-	if stats.V2PostingBlocks != 1 {
-		t.Fatalf("reopened posting blocks=%d want 1", stats.V2PostingBlocks)
+	if stats.V2PostingBlocks == 0 {
+		t.Fatalf("reopened posting blocks=%d want emitted blocks", stats.V2PostingBlocks)
 	}
 }
 
-func TestTextV2PostingBlocksNotEmittedByBackfillOrMutationsBeforeM32625(t *testing.T) {
+func TestTextV2PostingBlocksEmittedByBackfillAndMutations2626(t *testing.T) {
 	d := openTextV2PostingBlockDB2625(t, t.TempDir(), false)
 	defer func() { _ = d.Close() }()
 	col := createTextV2PostingBlockCollection2625(t, d, 2, RootStorageFast)
@@ -289,9 +278,10 @@ func TestTextV2PostingBlocksNotEmittedByBackfillOrMutationsBeforeM32625(t *testi
 	if err != nil {
 		t.Fatalf("TextIndexStorageStats after backfill: %v", err)
 	}
-	if stats.V2PostingBlocks != 0 {
-		t.Fatalf("v2 posting blocks after M2 backfill=%d want 0 until M3", stats.V2PostingBlocks)
+	if stats.V2PostingBlocks == 0 {
+		t.Fatalf("v2 posting blocks after M3 backfill=%d want emitted blocks", stats.V2PostingBlocks)
 	}
+	backfillBlocks := stats.V2PostingBlocks
 	if _, _, err := col.Update([]byte("doc-000001"), func([]byte) ([]byte, bool, error) {
 		return []byte(`{"body":"refund updated","title":"updated"}`), true, nil
 	}); err != nil {
@@ -307,8 +297,394 @@ func TestTextV2PostingBlocksNotEmittedByBackfillOrMutationsBeforeM32625(t *testi
 	if err != nil {
 		t.Fatalf("TextIndexStorageStats after mutations: %v", err)
 	}
-	if stats.V2PostingBlocks != 0 {
-		t.Fatalf("v2 posting blocks after M2 mutations=%d want 0 until M3", stats.V2PostingBlocks)
+	if stats.V2PostingBlocks <= backfillBlocks {
+		t.Fatalf("v2 posting blocks after M3 mutations=%d want > backfill %d", stats.V2PostingBlocks, backfillBlocks)
+	}
+}
+
+func TestTextV2WritePathBackfillPostingParity2626(t *testing.T) {
+	d := openTextV2PostingBlockDB2625(t, t.TempDir(), false)
+	defer func() { _ = d.Close() }()
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "docs"}); err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	col, err := mgr.OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("OpenCollection: %v", err)
+	}
+	ids := [][]byte{[]byte("d1"), []byte("d2"), []byte("d3")}
+	docs := [][]byte{
+		[]byte(`{"body":"refund refund policy","title":"Refund"}`),
+		[]byte(`{"body":"shipping policy","title":"Policy"}`),
+		[]byte(`{"body":"refund shipping refund","title":"Shipping refund"}`),
+	}
+	if _, err := col.InsertBatch(ids, docs); err != nil {
+		t.Fatalf("InsertBatch: %v", err)
+	}
+	if _, backfill, err := col.CreateTextIndex(TextIndexDefinition{Name: "lexical", Version: TextIndexVersionV2, Fields: []TextIndexField{{Field: "body"}, {Field: "title", Weight: 2}}}); err != nil {
+		t.Fatalf("CreateTextIndex: %v", err)
+	} else if backfill.V2PostingBlocks == 0 {
+		t.Fatalf("backfill=%+v want emitted posting blocks", backfill)
+	}
+	rootName := collectionTextV2PostingBlocksRootName("docs", "lexical")
+	got := make(map[uint64]textV2PostingParityPosting2625)
+	withTextCatalog(t, d, "docs", func(snap *backenddb.Snapshot, catalog *collectionCatalog) {
+		err = scanTextV2PostingBlocksForTerm(snap, catalog, rootName, "refund", func(key textV2PostingBlockKey, summary textV2PostingBlockSummary, scanner *textV2PostingBlockEntryScanner) error {
+			if key.Term != "refund" || summary.DocCount == 0 {
+				return fmt.Errorf("bad refund block key=%+v summary=%+v", key, summary)
+			}
+			var entry textV2PostingBlockEntry
+			for scanner.Next(&entry) {
+				got[entry.Ordinal] = textV2PostingParityPosting2625{tf: entry.TermFrequency, fields: append([]uint32(nil), entry.FieldFrequencies...)}
+			}
+			return scanner.Err()
+		})
+		termRaw := textRootValue(t, snap, catalog, collectionTextV2TermsRootName("docs", "lexical"), encodeTextV2TermStatsKey("refund"))
+		term, decodeErr := decodeTextV2TermStatsValue(termRaw)
+		if decodeErr != nil {
+			t.Fatalf("decode refund term: %v", decodeErr)
+		}
+		if term.DocumentFrequency != 2 || term.TotalTermFrequency != 6 || term.PostingBlockCount == 0 {
+			t.Fatalf("refund term=%+v want df=2 tf=6 block count", term)
+		}
+	})
+	if err != nil {
+		t.Fatalf("scan refund: %v", err)
+	}
+	want := map[uint64]textV2PostingParityPosting2625{
+		1: {tf: 3, fields: []uint32{2, 1}},
+		3: {tf: 3, fields: []uint32{2, 1}},
+	}
+	if !postingParityEqual2625(got, want) {
+		t.Fatalf("refund postings=%+v want %+v", got, want)
+	}
+}
+
+func TestTextV2WritePathMutationsAppendMicroBlocksAndReopen2626(t *testing.T) {
+	dir := t.TempDir()
+	d := openTextV2PostingBlockDB2625(t, dir, false)
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "docs"}); err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	col, err := mgr.OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("OpenCollection: %v", err)
+	}
+	def := TextIndexDefinition{Name: "lexical", Version: TextIndexVersionV2, Fields: []TextIndexField{{Field: "body"}}}
+	if _, _, err := col.CreateTextIndex(def); err != nil {
+		t.Fatalf("CreateTextIndex: %v", err)
+	}
+	if _, err := col.InsertBatch([][]byte{[]byte("d1"), []byte("d2")}, [][]byte{[]byte(`{"body":"refund policy"}`), []byte(`{"body":"refund shipping"}`)}); err != nil {
+		t.Fatalf("InsertBatch: %v", err)
+	}
+	insertStats, err := col.TextIndexStorageStats("lexical")
+	if err != nil || insertStats.V2PostingBlocks == 0 {
+		t.Fatalf("stats after insert=%+v err=%v want posting blocks", insertStats, err)
+	}
+	if _, _, err := col.Update([]byte("d1"), func([]byte) ([]byte, bool, error) {
+		return []byte(`{"body":"refund updated refund"}`), true, nil
+	}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if deleted, err := col.DeleteBatch([][]byte{[]byte("d2")}); err != nil || deleted != 1 {
+		t.Fatalf("DeleteBatch deleted=%d err=%v", deleted, err)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	reopened := openTextV2PostingBlockDB2625(t, dir, false)
+	defer func() { _ = reopened.Close() }()
+	rootName := collectionTextV2PostingBlocksRootName("docs", "lexical")
+	var generations []uint64
+	withTextCatalog(t, reopened, "docs", func(snap *backenddb.Snapshot, catalog *collectionCatalog) {
+		d1 := textV2DocIDRootValue(t, snap, catalog, "docs", "lexical", []byte("d1"))
+		d2 := textV2DocIDRootValue(t, snap, catalog, "docs", "lexical", []byte("d2"))
+		if d1.Ordinal != 1 || d1.Generation != 2 || d1.tombstoned() {
+			t.Fatalf("d1=%+v want generation 2 live", d1)
+		}
+		if d2.Ordinal != 2 || d2.Generation != 2 || !d2.tombstoned() {
+			t.Fatalf("d2=%+v want generation 2 tombstone", d2)
+		}
+		err = scanTextV2PostingBlocksForTerm(snap, catalog, rootName, "refund", func(key textV2PostingBlockKey, summary textV2PostingBlockSummary, scanner *textV2PostingBlockEntryScanner) error {
+			if key.BlockID < 2 || summary.DocCount == 0 {
+				return fmt.Errorf("bad mutation block key=%+v summary=%+v", key, summary)
+			}
+			var entry textV2PostingBlockEntry
+			for scanner.Next(&entry) {
+				if entry.Ordinal == 1 {
+					generations = append(generations, entry.Generation)
+				}
+			}
+			return scanner.Err()
+		})
+	})
+	if err != nil {
+		t.Fatalf("scan refund after reopen: %v", err)
+	}
+	slices.Sort(generations)
+	if !slices.Equal(generations, []uint64{1, 2}) {
+		t.Fatalf("d1 refund generations=%v want stale+current generations", generations)
+	}
+}
+
+func TestTextV2WritePathMutationBlockIDsDoNotOverwriteSealedBlocks2626(t *testing.T) {
+	d := openTextV2PostingBlockDB2625(t, t.TempDir(), false)
+	defer func() { _ = d.Close() }()
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "docs"}); err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	col, err := mgr.OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("OpenCollection: %v", err)
+	}
+	docs := int(textV2PostingBlockTargetPostings) + 1
+	ids := make([][]byte, docs)
+	values := make([][]byte, docs)
+	for i := range ids {
+		ids[i] = []byte(fmt.Sprintf("doc-%06d", i+1))
+		values[i] = []byte(`{"body":"refund"}`)
+	}
+	if _, err := col.InsertBatch(ids, values); err != nil {
+		t.Fatalf("InsertBatch: %v", err)
+	}
+	if _, _, err := col.CreateTextIndex(TextIndexDefinition{Name: "lexical", Version: TextIndexVersionV2, Fields: []TextIndexField{{Field: "body"}}}); err != nil {
+		t.Fatalf("CreateTextIndex: %v", err)
+	}
+	rootName := collectionTextV2PostingBlocksRootName("docs", "lexical")
+	secondBlockStart := uint64(textV2PostingBlockTargetPostings) + 1
+	sealedKey := encodeTextV2PostingBlockKey("refund", secondBlockStart, 2)
+	sealedBefore := textV2ReadRootBytes2624(t, d, "docs", rootName, sealedKey)
+	if _, _, err := col.Update(ids[textV2PostingBlockTargetPostings], func([]byte) ([]byte, bool, error) {
+		return []byte(`{"body":"refund refund changed"}`), true, nil
+	}); err != nil {
+		t.Fatalf("Update second block start doc: %v", err)
+	}
+	sealedAfter := textV2ReadRootBytes2624(t, d, "docs", rootName, sealedKey)
+	if !bytes.Equal(sealedBefore, sealedAfter) {
+		t.Fatalf("sealed posting block at second block start was overwritten by mutation")
+	}
+
+	snap := d.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("snapshot nil")
+	}
+	defer func() { _ = snap.Close() }()
+	catalog, err := loadCollectionCatalog(snap, "docs")
+	if err != nil {
+		t.Fatalf("load catalog: %v", err)
+	}
+	var refundBlocks int
+	var sawSealedSecondBlock bool
+	var sawMutationSecondBlock bool
+	if err := scanTextV2PostingBlocksForTerm(snap, catalog, rootName, "refund", func(key textV2PostingBlockKey, _ textV2PostingBlockSummary, scanner *textV2PostingBlockEntryScanner) error {
+		refundBlocks++
+		if key.BlockStart == secondBlockStart && key.BlockID == 2 {
+			sawSealedSecondBlock = true
+		}
+		if key.BlockStart == secondBlockStart && key.BlockID >= textV2PostingBlockMutationIDBase {
+			sawMutationSecondBlock = true
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("scan refund posting blocks: %v", err)
+	}
+	if !sawSealedSecondBlock || !sawMutationSecondBlock {
+		t.Fatalf("second block start sealed=%v mutation=%v refundBlocks=%d", sawSealedSecondBlock, sawMutationSecondBlock, refundBlocks)
+	}
+	termStatsRaw := textV2ReadRootBytes2624(t, d, "docs", collectionTextV2TermsRootName("docs", "lexical"), encodeTextV2TermStatsKey("refund"))
+	termStats, err := decodeTextV2TermStatsValue(termStatsRaw)
+	if err != nil {
+		t.Fatalf("decode refund term stats: %v", err)
+	}
+	if termStats.PostingBlockCount != uint64(refundBlocks) {
+		t.Fatalf("refund posting block count=%d want scanned blocks %d", termStats.PostingBlockCount, refundBlocks)
+	}
+}
+
+func TestTextV2WritePathSnapshotVisibility2626(t *testing.T) {
+	d := openTextV2PostingBlockDB2625(t, t.TempDir(), false)
+	defer func() { _ = d.Close() }()
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "docs"}); err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	col, err := mgr.OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("OpenCollection: %v", err)
+	}
+	def := TextIndexDefinition{Name: "lexical", Version: TextIndexVersionV2, Fields: []TextIndexField{{Field: "body"}}}
+	if _, _, err := col.CreateTextIndex(def); err != nil {
+		t.Fatalf("CreateTextIndex: %v", err)
+	}
+	if _, err := col.Insert([]byte("d1"), []byte(`{"body":"refund policy"}`)); err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+	snap := d.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("snapshot nil")
+	}
+	defer func() { _ = snap.Close() }()
+	catalog, err := loadCollectionCatalog(snap, "docs")
+	if err != nil {
+		t.Fatalf("load catalog before update: %v", err)
+	}
+	before, err := inspectTextV2IndexStorage(snap, catalog, def)
+	if err != nil {
+		t.Fatalf("inspect before: %v", err)
+	}
+	if _, _, err := col.Update([]byte("d1"), func([]byte) ([]byte, bool, error) {
+		return []byte(`{"body":"refund updated"}`), true, nil
+	}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	after, err := col.TextIndexStorageStats("lexical")
+	if err != nil {
+		t.Fatalf("stats after: %v", err)
+	}
+	oldView, err := inspectTextV2IndexStorage(snap, catalog, def)
+	if err != nil {
+		t.Fatalf("inspect old snapshot: %v", err)
+	}
+	if oldView.V2PostingBlocks != before.V2PostingBlocks || after.V2PostingBlocks <= before.V2PostingBlocks {
+		t.Fatalf("snapshot before=%+v old=%+v after=%+v", before, oldView, after)
+	}
+	var updatedBlocks int
+	rootName := collectionTextV2PostingBlocksRootName("docs", "lexical")
+	if err := scanTextV2PostingBlocksForTerm(snap, catalog, rootName, "updated", func(textV2PostingBlockKey, textV2PostingBlockSummary, *textV2PostingBlockEntryScanner) error {
+		updatedBlocks++
+		return nil
+	}); err != nil {
+		t.Fatalf("scan old updated term: %v", err)
+	}
+	if updatedBlocks != 0 {
+		t.Fatalf("old snapshot saw %d updated-term posting blocks", updatedBlocks)
+	}
+}
+
+func TestTextV2WritePathDeleteSnapshotVisibility2626(t *testing.T) {
+	d := openTextV2PostingBlockDB2625(t, t.TempDir(), false)
+	defer func() { _ = d.Close() }()
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "docs"}); err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	col, err := mgr.OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("OpenCollection: %v", err)
+	}
+	def := TextIndexDefinition{Name: "lexical", Version: TextIndexVersionV2, Fields: []TextIndexField{{Field: "body"}}}
+	if _, _, err := col.CreateTextIndex(def); err != nil {
+		t.Fatalf("CreateTextIndex: %v", err)
+	}
+	if _, err := col.Insert([]byte("d1"), []byte(`{"body":"refund policy"}`)); err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+	snap := d.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("snapshot nil")
+	}
+	defer func() { _ = snap.Close() }()
+	catalog, err := loadCollectionCatalog(snap, "docs")
+	if err != nil {
+		t.Fatalf("load catalog before delete: %v", err)
+	}
+	before, err := inspectTextV2IndexStorage(snap, catalog, def)
+	if err != nil {
+		t.Fatalf("inspect before: %v", err)
+	}
+	beforeDoc := textV2DocIDRootValue(t, snap, catalog, "docs", "lexical", []byte("d1"))
+	if beforeDoc.Ordinal != 1 || beforeDoc.Generation != 1 || beforeDoc.tombstoned() {
+		t.Fatalf("snapshot before doc=%+v want live generation 1", beforeDoc)
+	}
+	if deleted, err := col.DeleteBatch([][]byte{[]byte("d1")}); err != nil || deleted != 1 {
+		t.Fatalf("DeleteBatch deleted=%d err=%v", deleted, err)
+	}
+	after, err := col.TextIndexStorageStats("lexical")
+	if err != nil {
+		t.Fatalf("stats after delete: %v", err)
+	}
+	oldView, err := inspectTextV2IndexStorage(snap, catalog, def)
+	if err != nil {
+		t.Fatalf("inspect old snapshot after delete: %v", err)
+	}
+	oldDoc := textV2DocIDRootValue(t, snap, catalog, "docs", "lexical", []byte("d1"))
+	if oldView.V2LiveDocuments != before.V2LiveDocuments || oldView.V2DeletedDocs != before.V2DeletedDocs || oldDoc.tombstoned() {
+		t.Fatalf("old snapshot before=%+v old=%+v oldDoc=%+v", before, oldView, oldDoc)
+	}
+	if after.V2LiveDocuments != 0 || after.V2DeletedDocs != 1 || after.V2PostingBlocks != before.V2PostingBlocks {
+		t.Fatalf("after delete stats=%+v before=%+v want tombstone without posting rewrite", after, before)
+	}
+	withTextCatalog(t, d, "docs", func(current *backenddb.Snapshot, currentCatalog *collectionCatalog) {
+		currentDoc := textV2DocIDRootValue(t, current, currentCatalog, "docs", "lexical", []byte("d1"))
+		if currentDoc.Ordinal != 1 || currentDoc.Generation != 2 || !currentDoc.tombstoned() {
+			t.Fatalf("current doc=%+v want tombstone generation 2", currentDoc)
+		}
+	})
+}
+
+func TestTextV2WritePathPostingBlocksGCCompactReopen2626(t *testing.T) {
+	dir := t.TempDir()
+	d := openTextV2TestDB(t, dir, true)
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "docs"}); err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	col, err := mgr.OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("OpenCollection: %v", err)
+	}
+	ids := make([][]byte, 48)
+	docs := make([][]byte, 48)
+	for i := range ids {
+		ids[i] = []byte(fmt.Sprintf("doc-%03d", i+1))
+		docs[i] = []byte(fmt.Sprintf(`{"body":"refund refund policy common common %d","title":"ticket %d"}`, i, i))
+	}
+	if _, err := col.InsertBatch(ids, docs); err != nil {
+		t.Fatalf("InsertBatch: %v", err)
+	}
+	if _, _, err := col.CreateTextIndex(TextIndexDefinition{Name: "lexical", Version: TextIndexVersionV2, Fields: []TextIndexField{{Field: "body"}, {Field: "title"}}, StoragePolicy: RootStorageFast}); err != nil {
+		t.Fatalf("CreateTextIndex: %v", err)
+	}
+	rootName := collectionTextV2PostingBlocksRootName("docs", "lexical")
+	blockKey := encodeTextV2PostingBlockKey("refund", 1, 1)
+	postingBefore := textV2ReadRootBytes2624(t, d, "docs", rootName, blockKey)
+	normBefore := textV2ReadNormBlockBytes2624(t, d, "docs", "lexical", 1)
+	docMapBefore := textV2ReadRootBytes2624(t, d, "docs", collectionTextV2DocMapRootName("docs", "lexical"), encodeTextV2BlockKey(1))
+	if err := d.Checkpoint(); err != nil {
+		t.Fatalf("Checkpoint: %v", err)
+	}
+	if _, err := d.ValueLogGC(context.Background(), backenddb.ValueLogGCOptions{}); err != nil {
+		t.Fatalf("ValueLogGC: %v", err)
+	}
+	if _, err := d.CompactStorage(context.Background(), backenddb.CompactStorageOptions{}); err != nil {
+		t.Fatalf("CompactStorage: %v", err)
+	}
+	if got := textV2ReadRootBytes2624(t, d, "docs", rootName, blockKey); !bytes.Equal(got, postingBefore) {
+		t.Fatalf("posting block changed after GC/compact")
+	}
+	if got := textV2ReadNormBlockBytes2624(t, d, "docs", "lexical", 1); !bytes.Equal(got, normBefore) {
+		t.Fatalf("norm block changed after GC/compact")
+	}
+	if got := textV2ReadRootBytes2624(t, d, "docs", collectionTextV2DocMapRootName("docs", "lexical"), encodeTextV2BlockKey(1)); !bytes.Equal(got, docMapBefore) {
+		t.Fatalf("docmap block changed after GC/compact")
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	reopened := openTextV2TestDB(t, dir, true)
+	defer func() { _ = reopened.Close() }()
+	if got := textV2ReadRootBytes2624(t, reopened, "docs", rootName, blockKey); !bytes.Equal(got, postingBefore) {
+		t.Fatalf("posting block not reachable after reopen")
+	}
+	reopenedCol, err := NewCollectionManager(reopened).OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("OpenCollection reopened: %v", err)
+	}
+	if stats, err := reopenedCol.TextIndexStorageStats("lexical"); err != nil || stats.V2PostingBlocks == 0 || stats.V2NormBlocks == 0 || stats.V2DocMapBlocks == 0 {
+		t.Fatalf("reopened stats=%+v err=%v want v2 roots", stats, err)
 	}
 }
 

--- a/TreeDB/collections/text_v2_posting_blocks_test.go
+++ b/TreeDB/collections/text_v2_posting_blocks_test.go
@@ -302,6 +302,37 @@ func TestTextV2PostingBlocksEmittedByBackfillAndMutations2626(t *testing.T) {
 	}
 }
 
+func TestTextV2WritePathLiteralBackslashUnindexedRootKeyDoesNotAbort2626(t *testing.T) {
+	d := openTextV2PostingBlockDB2625(t, t.TempDir(), false)
+	defer func() { _ = d.Close() }()
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "docs"}); err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	col, err := mgr.OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("OpenCollection: %v", err)
+	}
+	if _, err := col.Insert([]byte("backfill"), []byte(`{"a\\q":"ignored","body":"refund backfill"}`)); err != nil {
+		t.Fatalf("Insert before backfill: %v", err)
+	}
+	if _, backfill, err := col.CreateTextIndex(TextIndexDefinition{Name: "lexical", Version: TextIndexVersionV2, Fields: []TextIndexField{{Field: "body"}}}); err != nil {
+		t.Fatalf("CreateTextIndex with literal-backslash unindexed key: %v", err)
+	} else if backfill.DocumentsScanned != 1 || backfill.V2PostingBlocks == 0 {
+		t.Fatalf("backfill=%+v want one scanned document and v2 posting blocks", backfill)
+	}
+	if _, err := col.Insert([]byte("write"), []byte(`{"a\\q":"ignored","body":"refund write"}`)); err != nil {
+		t.Fatalf("Insert after v2 index with literal-backslash unindexed key: %v", err)
+	}
+	stats, err := col.TextIndexStorageStats("lexical")
+	if err != nil {
+		t.Fatalf("TextIndexStorageStats: %v", err)
+	}
+	if stats.Documents != 2 || stats.V2PostingBlocks == 0 {
+		t.Fatalf("stats=%+v want two indexed documents and v2 posting blocks", stats)
+	}
+}
+
 func TestTextV2WritePathBackfillPostingParity2626(t *testing.T) {
 	d := openTextV2PostingBlockDB2625(t, t.TempDir(), false)
 	defer func() { _ = d.Close() }()

--- a/TreeDB/collections/text_v2_posting_blocks_test.go
+++ b/TreeDB/collections/text_v2_posting_blocks_test.go
@@ -504,6 +504,89 @@ func TestTextV2WritePathMutationBlockIDsDoNotOverwriteSealedBlocks2626(t *testin
 	}
 }
 
+func TestTextV2WritePathMutationMicroBlockIDsDoNotOverwritePriorMicroChunks2626(t *testing.T) {
+	d := openTextV2PostingBlockDB2625(t, t.TempDir(), false)
+	defer func() { _ = d.Close() }()
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "docs"}); err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	col, err := mgr.OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("OpenCollection: %v", err)
+	}
+	if _, _, err := col.CreateTextIndex(TextIndexDefinition{Name: "lexical", Version: TextIndexVersionV2, Fields: []TextIndexField{{Field: "body"}}}); err != nil {
+		t.Fatalf("CreateTextIndex: %v", err)
+	}
+	docs := int(2*textV2PostingBlockMicroPostings) + 1
+	ids := make([][]byte, docs)
+	values := make([][]byte, docs)
+	for i := range ids {
+		ids[i] = []byte(fmt.Sprintf("doc-%06d", i+1))
+		values[i] = []byte(`{"body":"refund"}`)
+	}
+	if _, err := col.InsertBatch(ids, values); err != nil {
+		t.Fatalf("InsertBatch: %v", err)
+	}
+	rootName := collectionTextV2PostingBlocksRootName("docs", "lexical")
+	secondMicroStart := uint64(textV2PostingBlockMicroPostings) + 1
+	firstMutationBlockID, err := textV2PostingBlockMutationBlockIDStart(2)
+	if err != nil {
+		t.Fatalf("first mutation block id: %v", err)
+	}
+	priorMicroKey := encodeTextV2PostingBlockKey("refund", secondMicroStart, firstMutationBlockID)
+	priorMicroBefore := textV2ReadRootBytes2624(t, d, "docs", rootName, priorMicroKey)
+	if _, _, err := col.Update(ids[textV2PostingBlockMicroPostings], func([]byte) ([]byte, bool, error) {
+		return []byte(`{"body":"refund refund changed"}`), true, nil
+	}); err != nil {
+		t.Fatalf("Update second micro chunk start doc: %v", err)
+	}
+	priorMicroAfter := textV2ReadRootBytes2624(t, d, "docs", rootName, priorMicroKey)
+	if !bytes.Equal(priorMicroBefore, priorMicroAfter) {
+		t.Fatalf("prior micro posting block at second chunk start was overwritten by later mutation")
+	}
+	secondMutationBlockID, err := textV2PostingBlockMutationBlockIDStart(3)
+	if err != nil {
+		t.Fatalf("second mutation block id: %v", err)
+	}
+
+	snap := d.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("snapshot nil")
+	}
+	defer func() { _ = snap.Close() }()
+	catalog, err := loadCollectionCatalog(snap, "docs")
+	if err != nil {
+		t.Fatalf("load catalog: %v", err)
+	}
+	var refundBlocks int
+	var sawPriorMicro bool
+	var sawLaterMicro bool
+	if err := scanTextV2PostingBlocksForTerm(snap, catalog, rootName, "refund", func(key textV2PostingBlockKey, _ textV2PostingBlockSummary, scanner *textV2PostingBlockEntryScanner) error {
+		refundBlocks++
+		if key.BlockStart == secondMicroStart && key.BlockID == firstMutationBlockID {
+			sawPriorMicro = true
+		}
+		if key.BlockStart == secondMicroStart && key.BlockID == secondMutationBlockID {
+			sawLaterMicro = true
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("scan refund posting blocks: %v", err)
+	}
+	if !sawPriorMicro || !sawLaterMicro {
+		t.Fatalf("second micro start prior=%v later=%v refundBlocks=%d", sawPriorMicro, sawLaterMicro, refundBlocks)
+	}
+	termStatsRaw := textV2ReadRootBytes2624(t, d, "docs", collectionTextV2TermsRootName("docs", "lexical"), encodeTextV2TermStatsKey("refund"))
+	termStats, err := decodeTextV2TermStatsValue(termStatsRaw)
+	if err != nil {
+		t.Fatalf("decode refund term stats: %v", err)
+	}
+	if termStats.PostingBlockCount != uint64(refundBlocks) {
+		t.Fatalf("refund posting block count=%d want scanned blocks %d", termStats.PostingBlockCount, refundBlocks)
+	}
+}
+
 func TestTextV2WritePathSnapshotVisibility2626(t *testing.T) {
 	d := openTextV2PostingBlockDB2625(t, t.TempDir(), false)
 	defer func() { _ = d.Close() }()

--- a/TreeDB/collections/text_v2_posting_blocks_test.go
+++ b/TreeDB/collections/text_v2_posting_blocks_test.go
@@ -238,7 +238,7 @@ func TestTextV2PostingBlocksReachValueLogMaintenance2625(t *testing.T) {
 	d, closeDB := openTextV2PostingBlockCompressedDB2625(t, dir)
 	col := createTextV2PostingBlockCollection2625(t, d, 32, RootStorageCompressed)
 	rootName := collectionTextV2PostingBlocksRootName("docs", "lexical")
-	blockKey := encodeTextV2PostingBlockKey("refund", 1, 1)
+	blockKey := firstTextV2PostingBlockKeyForTerm2626(t, d, "docs", rootName, "refund")
 	before := textV2ReadRootBytes2624(t, d, "docs", rootName, blockKey)
 	if stats, err := col.TextIndexStorageStats("lexical"); err != nil || stats.V2PostingBlocks == 0 {
 		t.Fatalf("TextIndexStorageStats before GC=%+v err=%v want emitted posting blocks", stats, err)
@@ -268,6 +268,26 @@ func TestTextV2PostingBlocksReachValueLogMaintenance2625(t *testing.T) {
 	if stats.V2PostingBlocks == 0 {
 		t.Fatalf("reopened posting blocks=%d want emitted blocks", stats.V2PostingBlocks)
 	}
+}
+
+func firstTextV2PostingBlockKeyForTerm2626(t *testing.T, d *backenddb.DB, collection, rootName, term string) []byte {
+	t.Helper()
+	stop := errors.New("posting block located")
+	var blockKey []byte
+	var scanErr error
+	withTextCatalog(t, d, collection, func(snap *backenddb.Snapshot, catalog *collectionCatalog) {
+		scanErr = scanTextV2PostingBlocksForTerm(snap, catalog, rootName, term, func(key textV2PostingBlockKey, _ textV2PostingBlockSummary, _ *textV2PostingBlockEntryScanner) error {
+			blockKey = encodeTextV2PostingBlockKey(key.Term, key.BlockStart, key.BlockID)
+			return stop
+		})
+	})
+	if scanErr != nil && !errors.Is(scanErr, stop) {
+		t.Fatalf("scan posting blocks for %q: %v", term, scanErr)
+	}
+	if len(blockKey) == 0 {
+		t.Fatalf("posting block for %q not found", term)
+	}
+	return blockKey
 }
 
 func TestTextV2PostingBlocksEmittedByBackfillAndMutations2626(t *testing.T) {
@@ -763,7 +783,7 @@ func TestTextV2WritePathPostingBlocksGCCompactReopen2626(t *testing.T) {
 		t.Fatalf("CreateTextIndex: %v", err)
 	}
 	rootName := collectionTextV2PostingBlocksRootName("docs", "lexical")
-	blockKey := encodeTextV2PostingBlockKey("refund", 1, 1)
+	blockKey := firstTextV2PostingBlockKeyForTerm2626(t, d, "docs", rootName, "refund")
 	postingBefore := textV2ReadRootBytes2624(t, d, "docs", rootName, blockKey)
 	normBefore := textV2ReadNormBlockBytes2624(t, d, "docs", "lexical", 1)
 	docMapBefore := textV2ReadRootBytes2624(t, d, "docs", collectionTextV2DocMapRootName("docs", "lexical"), encodeTextV2BlockKey(1))

--- a/TreeDB/collections/text_v2_storage_test.go
+++ b/TreeDB/collections/text_v2_storage_test.go
@@ -192,8 +192,8 @@ func TestCollectionCreateTextV2IndexBackfillsOrdinalsNormsStatsAndReopens2624(t 
 	if err != nil {
 		t.Fatalf("TextIndexStatus: %v", err)
 	}
-	if status.Version != TextIndexVersionV2 || !status.Ready || status.Readable || status.Writable || status.FailClosedReason != "text_v2_search_unavailable" {
-		t.Fatalf("status=%+v want v2 root-ready/full-search-write fail-closed", status)
+	if status.Version != TextIndexVersionV2 || !status.Ready || status.Readable || !status.Writable || status.FailClosedReason != "text_v2_search_unavailable" {
+		t.Fatalf("status=%+v want v2 root-ready/writable/search fail-closed", status)
 	}
 	if !slices.Equal(status.ActiveRootNames, collectionTextV2RootNames("docs", "lexical")) {
 		t.Fatalf("active roots=%q", status.ActiveRootNames)

--- a/TreeDB/collections/text_v2_write_path.go
+++ b/TreeDB/collections/text_v2_write_path.go
@@ -1,0 +1,175 @@
+package collections
+
+import (
+	"sort"
+
+	"github.com/snissn/gomap/TreeDB/internal/memtable"
+)
+
+const (
+	textV2DocumentPostingInlineTerms = 16
+	textV2PostingBlockMutationIDBase = uint64(1) << 63
+)
+
+func textV2PostingBlockMutationBlockIDStart(generation uint64) (uint64, error) {
+	if generation == 0 || generation >= textV2PostingBlockMutationIDBase {
+		return 0, errMalformedTextStorage("text-v2 posting block mutation generation %d cannot be encoded in block id namespace", generation)
+	}
+	return textV2PostingBlockMutationIDBase | generation, nil
+}
+
+func textV2ScoringAnalysisDefinition(def TextIndexDefinition) TextIndexDefinition {
+	def.StorePositions = false
+	def.StoreOffsets = false
+	return def
+}
+
+type textV2PostingBatchBuilder struct {
+	fieldCount uint32
+	byTerm     map[string][]textV2PostingBlockEntry
+}
+
+type textV2DocumentPostingTerm struct {
+	Term             string
+	TermFrequency    uint32
+	FieldFrequencies []uint32
+}
+
+type textV2DocumentPostingAccumulator struct {
+	fieldCount int
+	inline     [textV2DocumentPostingInlineTerms]textV2DocumentPostingTerm
+	terms      []textV2DocumentPostingTerm
+	lookup     map[string]int
+}
+
+func newTextV2DocumentPostingAccumulator(fieldCount int) textV2DocumentPostingAccumulator {
+	acc := textV2DocumentPostingAccumulator{fieldCount: fieldCount}
+	acc.terms = acc.inline[:0]
+	return acc
+}
+
+func (a *textV2DocumentPostingAccumulator) add(term string, fieldIndex int, frequency uint32) error {
+	if frequency == 0 {
+		return nil
+	}
+	if fieldIndex < 0 || fieldIndex >= a.fieldCount {
+		return errMalformedTextStorage("text-v2 posting accumulator field index %d outside field count %d", fieldIndex, a.fieldCount)
+	}
+	idx := -1
+	if a.lookup != nil {
+		if found, ok := a.lookup[term]; ok {
+			idx = found
+		}
+	} else {
+		for i := range a.terms {
+			if a.terms[i].Term == term {
+				idx = i
+				break
+			}
+		}
+	}
+	if idx < 0 {
+		idx = len(a.terms)
+		a.terms = append(a.terms, textV2DocumentPostingTerm{Term: term, FieldFrequencies: make([]uint32, a.fieldCount)})
+		if a.lookup != nil {
+			a.lookup[term] = idx
+		} else if len(a.terms) > textV2DocumentPostingInlineTerms {
+			a.lookup = make(map[string]int, len(a.terms)*2)
+			for i := range a.terms {
+				a.lookup[a.terms[i].Term] = i
+			}
+		}
+	}
+	entry := &a.terms[idx]
+	entry.TermFrequency += frequency
+	entry.FieldFrequencies[fieldIndex] += frequency
+	return nil
+}
+
+func (b *textV2PostingBatchBuilder) addDocument(def TextIndexDefinition, ordinal, generation uint64, analysis textAnalyzedDocument) error {
+	if ordinal == 0 || generation == 0 {
+		return errMalformedTextStorage("text-v2 posting document ordinal/generation cannot be zero")
+	}
+	fieldCount := len(def.Fields)
+	if fieldCount == 0 || fieldCount > int(textV2PostingBlockMaxFieldCount) {
+		return errMalformedTextStorage("text-v2 posting document field count %d invalid", fieldCount)
+	}
+	if b.fieldCount == 0 {
+		b.fieldCount = uint32(fieldCount)
+	} else if b.fieldCount != uint32(fieldCount) {
+		return errMalformedTextStorage("text-v2 posting batch field count changed from %d to %d", b.fieldCount, fieldCount)
+	}
+	if b.byTerm == nil {
+		b.byTerm = make(map[string][]textV2PostingBlockEntry)
+	}
+	acc := newTextV2DocumentPostingAccumulator(fieldCount)
+	for _, field := range analysis.Fields {
+		fieldIndex := textV2FieldIndex(def, field.Field)
+		if fieldIndex < 0 {
+			return errMalformedTextStorage("text-v2 posting field %q missing from definition", field.Field)
+		}
+		for _, term := range field.Terms {
+			if term == nil {
+				continue
+			}
+			if err := acc.add(term.Term, fieldIndex, term.Frequency); err != nil {
+				return err
+			}
+		}
+	}
+	for _, term := range acc.terms {
+		if term.TermFrequency == 0 {
+			continue
+		}
+		entry := textV2PostingBlockEntry{
+			Ordinal:          ordinal,
+			Generation:       generation,
+			TermFrequency:    term.TermFrequency,
+			FieldFrequencies: append([]uint32(nil), term.FieldFrequencies...),
+		}
+		b.byTerm[term.Term] = append(b.byTerm[term.Term], entry)
+	}
+	return nil
+}
+
+func (b *textV2PostingBatchBuilder) empty() bool {
+	return b == nil || len(b.byTerm) == 0
+}
+
+func buildTextV2PostingBatchTable(table memtable.Table, builder *textV2PostingBatchBuilder, kind textV2PostingBlockKind, targetPostings uint32, blockIDStart uint64) (int, uint64, map[string]uint64, error) {
+	if table == nil || builder == nil || len(builder.byTerm) == 0 {
+		return 0, 0, nil, nil
+	}
+	terms := make([]string, 0, len(builder.byTerm))
+	for term := range builder.byTerm {
+		terms = append(terms, term)
+	}
+	sort.Strings(terms)
+	blockCounts := make(map[string]uint64, len(terms))
+	var blocksWritten int
+	var bytesWritten uint64
+	for _, term := range terms {
+		blocks, err := buildTextV2PostingBlockKVs(term, builder.byTerm[term], builder.fieldCount, textV2PostingBlockBuildOptions{Kind: kind, TargetPostings: targetPostings, BlockIDStart: blockIDStart})
+		if err != nil {
+			return 0, 0, nil, err
+		}
+		for _, kv := range blocks {
+			table.SetSteal(kv.Key, kv.Value)
+			blocksWritten++
+			bytesWritten += uint64(len(kv.Key) + len(kv.Value))
+		}
+		if len(blocks) > 0 {
+			blockCounts[term] = uint64(len(blocks))
+		}
+	}
+	return blocksWritten, bytesWritten, blockCounts, nil
+}
+
+func textV2FieldIndex(def TextIndexDefinition, fieldName string) int {
+	for i := range def.Fields {
+		if def.Fields[i].Field == fieldName {
+			return i
+		}
+	}
+	return -1
+}

--- a/TreeDB/collections/text_v2_write_path.go
+++ b/TreeDB/collections/text_v2_write_path.go
@@ -149,7 +149,7 @@ func buildTextV2PostingBatchTable(table memtable.Table, builder *textV2PostingBa
 	var blocksWritten int
 	var bytesWritten uint64
 	for _, term := range terms {
-		blocks, err := buildTextV2PostingBlockKVs(term, builder.byTerm[term], builder.fieldCount, textV2PostingBlockBuildOptions{Kind: kind, TargetPostings: targetPostings, BlockIDStart: blockIDStart})
+		blocks, err := buildTextV2PostingBlockKVs(term, builder.byTerm[term], builder.fieldCount, textV2PostingBlockBuildOptions{Kind: kind, TargetPostings: targetPostings, BlockIDStart: blockIDStart, FixedBlockID: kind == textV2PostingBlockKindMicro})
 		if err != nil {
 			return 0, 0, nil, err
 		}

--- a/TreeDB/docs/spec/collection-text-v2-contract.md
+++ b/TreeDB/docs/spec/collection-text-v2-contract.md
@@ -53,9 +53,9 @@ type TextIndexDefinition struct {
 
 `TextIndexRolloutMode` values:
 
-- `""` / `"primary"`: active production read/write path. Today this is v1 only;
-  explicit v2 indexes can maintain M1 root-state shells, but status remains
-  fail-closed/non-readable/non-writable for the full v2 executor/write pipeline.
+- `""` / `"primary"`: active production read/write path. V1 remains the default
+  readable/searchable path. Explicit v2 indexes are writable as of M3, but v2
+  search remains fail-closed/non-readable until the v2 executor milestones land.
 - `"shadow"`: future v2 build/validate without serving reads.
 - `"dual_write"`: future v1+v2 mutation maintenance with explicit read choice.
 - `"disabled"`: future metadata-present but non-serving/non-writing state.

--- a/TreeDB/docs/spec/collection-text-v2-contract.md
+++ b/TreeDB/docs/spec/collection-text-v2-contract.md
@@ -196,8 +196,10 @@ compact per-field/per-document term accumulators, avoiding the previous token
 slice allocation in the hot analyzer path. Backfill emits sealed posting blocks;
 maintained insert/update writes emit append-friendly micro blocks with
 `blockID` in a mutation-generation namespace (currently the high-bit block ID
-range ORed with the next text-v2 root generation) so repeated updates of a
-high-document-frequency term do not rewrite or collide with old term state.
+range ORed with the next text-v2 root generation, fixed for every micro chunk
+in that generation because `blockStart` already distinguishes chunks) so
+repeated updates of a high-document-frequency term do not rewrite or collide
+with old term state.
 Deletes do not emit posting tombstone blocks; instead docID/docmap/norm
 generations and tombstone flags advance so later readers reject stale
 `(ordinal,generation)` entries until

--- a/TreeDB/docs/spec/collection-text-v2-contract.md
+++ b/TreeDB/docs/spec/collection-text-v2-contract.md
@@ -98,10 +98,11 @@ format record. Explicit `TextIndexVersionV2` creation through `CreateTextIndex`
 publishes all seven v2 root descriptors through the normal collection-root
 system records. Declaring a v2 text index directly in `CreateCollection` is
 rejected because it would create metadata without the required root status
-records. V2 search is still fail-closed until the later executor milestones;
-`TextIndexStatus` reports `readable=false` and `writable=false` for v2 so the M1
-root-state maintenance shell is not advertised as the full M3+ write pipeline.
-There is no fallback to v1 for requested v2.
+records. V2 search is still fail-closed until the later executor milestones.
+After M3, `TextIndexStatus` reports `readable=false` and `writable=true` for
+explicit v2 indexes: create/backfill/insert/update/delete maintain durable v2
+roots and posting blocks, but query routing still does not serve from v2. There
+is no fallback to v1 for requested v2.
 
 Stable M1 ordinal semantics:
 
@@ -185,9 +186,28 @@ explicit format, not in the hot scoring value.
 
 M2 provides codecs, builders, storage validation, and streaming/range iterators
 that reuse entry scratch while scanning a block. It does not route
-`SearchText`/`SearchHybrid` through v2 posting blocks and does not make ordinary
-v2 backfill/mutations emit active posting blocks before the M3 streaming write
-pipeline can maintain update/delete/tombstone correctness.
+`SearchText`/`SearchHybrid` through v2 posting blocks.
+
+## M3 streaming write path (#2626)
+
+M3 makes explicit `TextIndexVersionV2` indexes writable while keeping v2 search
+fail-closed until #2627. The write path uses a streaming analyzer sink and
+compact per-field/per-document term accumulators, avoiding the previous token
+slice allocation in the hot analyzer path. Backfill emits sealed posting blocks;
+maintained insert/update writes emit append-friendly micro blocks with
+`blockID` in a mutation-generation namespace (currently the high-bit block ID
+range ORed with the next text-v2 root generation) so repeated updates of a
+high-document-frequency term do not rewrite or collide with old term state.
+Deletes do not emit posting tombstone blocks; instead docID/docmap/norm
+generations and tombstone flags advance so later readers reject stale
+`(ordinal,generation)` entries until
+M7 rewrite/merge compacts old blocks.
+
+M3 maintains term `PostingBlockCount` alongside live `df`/`ttf` stats. A term may
+retain zero live `df`/`ttf` with non-zero historical posting blocks until normal
+TreeDB root maintenance and later text rewrite/merge remove stale blocks. All
+posting, norm, docmap, docID, term, and status records remain ordinary collection
+root values and continue to use existing value-log/leaf maintenance paths.
 
 ## Current v1 path inventory
 

--- a/docs/benchmarks/treedb_text_v2_contract_benchmarks.md
+++ b/docs/benchmarks/treedb_text_v2_contract_benchmarks.md
@@ -76,14 +76,22 @@ Measured boundaries:
 
 - `insert_batch_no_text`: `InsertBatch` on the same JSON fixture without text
   indexes; setup excludes DB/collection creation.
-- `insert_batch_text_indexed`: `InsertBatch` with a declared text index; setup
-  excludes DB/collection creation.
-- `create_text_index_backfill`: `CreateTextIndex` over already inserted primary
-  documents; setup excludes primary insert.
-- `update_batch_text_indexed`: `UpdateBatch` replacements with maintained text
-  roots; setup excludes initial insert.
-- `delete_batch_text_indexed`: `DeleteBatch` with maintained text roots; setup
-  excludes initial insert.
+- `insert_batch_text_indexed`: v1 `InsertBatch` with a declared text index;
+  setup excludes DB/collection creation.
+- `insert_batch_text_v2_indexed`: explicit v2 `InsertBatch` after empty-index
+  `CreateTextIndex` setup; setup excludes DB/collection/index creation.
+- `create_text_index_backfill`: v1 `CreateTextIndex` over already inserted
+  primary documents; setup excludes primary insert.
+- `create_text_v2_index_backfill`: explicit v2 `CreateTextIndex` over already
+  inserted primary documents; setup excludes primary insert.
+- `update_batch_text_indexed`: v1 `UpdateBatch` replacements with maintained
+  text roots; setup excludes initial insert.
+- `update_batch_text_v2_indexed`: explicit v2 `UpdateBatch` replacements with
+  maintained micro-block/docmap/norm roots; setup excludes initial insert.
+- `delete_batch_text_indexed`: v1 `DeleteBatch` with maintained text roots;
+  setup excludes initial insert.
+- `delete_batch_text_v2_indexed`: explicit v2 `DeleteBatch` with generation and
+  tombstone maintenance; setup excludes initial insert.
 
 Command:
 
@@ -101,9 +109,16 @@ go test ./TreeDB/collections \
 
 Report text write counters:
 
-- `posting_entries/op`, `state_entries/op`, `stats_entries/op`;
+- `posting_entries/op`, `state_entries/op`, `stats_entries/op` for v1 rows;
+- `v2_docid_entries/op`, `v2_docmap_blocks/op`, `v2_posting_blocks/op`,
+  `v2_norm_blocks/op`, and `v2_term_stats/op` for v2 rows;
+- `posting_blocks/doc`, `high_df_posting_blocks/op`,
+  `high_df_posting_blocks/doc`, and `rewritten_blocks/doc` (M3 rewrite count is `0`);
 - `index_entries/doc` for live text-root entries after the operation;
-- `write_amp_entries/doc` for estimated text-root entry writes emitted by the operation;
+- `write_amp_entries/doc` for estimated text-root entry writes emitted by the
+  operation. For maintained v2 insert/update/delete rows this is the emitted
+  root-delta estimate (docID/docmap/norm/term-status/posting-block deltas plus
+  the status generation), not the net post-mutation root size;
 - `index_bytes/doc`.
 
 ## New text search scale rows


### PR DESCRIPTION
## Summary

Closes #2626. Part of #2622.

Implements the M3 text-v2 write path:

- streaming analyzer sink plus compact term accumulators;
- v2 create/backfill, InsertBatch/insert, update, delete maintenance;
- v2 docID/docmap/norm/status/term-stat updates and posting-block emission;
- append-friendly mutation micro-blocks with a high-bit fixed-per-generation blockID namespace so sealed blocks and prior micro chunks are not overwritten;
- decoded JSON root-key handling for the fast path, including literal-backslash keys;
- benchmark accounting/test robustness review fixes (term-stat rows touched from generated docs, posting-block reachability keys derived from emitted blocks);
- docs/runbook updates for M3 write-path counters and evidence.

Scope boundaries preserved: v2 search remains fail-closed; no SearchText/SearchHybrid routing through v2 scoring blocks, no WAND/BMW, no default switch, no vector internals, and no separate text-block GC subsystem.

## Correctness coverage

New/updated tests cover:

- analyzer sink parity vs `AnalyzeText`, including sink error propagation;
- JSON root fast-path parity for escaped root keys and literal-backslash keys;
- v2 CreateTextIndex/backfill posting parity and BM25F stats/norm inputs;
- v2 insert/update/delete/reopen generation/tombstone semantics;
- mutation micro-block blockID collision regressions for sealed blocks and prior micro chunks;
- update and delete snapshot visibility;
- value-log GC + CompactStorage + reopen reachability for posting/norm/docmap roots;
- fail-closed posting block/storage corruption cases.

## Validation run on latest head

Head: `d6ad114dc624029e6e0726cc3fb7e6d042748480`

Commands:

```sh
GOWORK=off go test ./TreeDB/collections -run 'TestTextV2WritePath|TestTextV2PostingBlock|TestAnalyzeText|TestTextIndexAnalysisJSONFastPath'
GOWORK=off go test ./TreeDB/collections -run 'TestTextV2'
GOWORK=off go test ./TreeDB/collections
GOWORK=off go test ./TreeDB/db ./TreeDB/node
GOWORK=off go test ./TreeDB/...
GOWORK=off TREEDB_TEXT_V2_WRITE_DOCS=64 go test ./TreeDB/collections -run '^$' -bench '^BenchmarkTextV2ContractWritePaths2623/(insert_batch_text_v2_indexed|update_batch_text_v2_indexed|delete_batch_text_v2_indexed)$' -benchmem -benchtime=1x -count=1
git diff --check
```

Latest `./TreeDB/...` output saved at `/tmp/treedb_go_test_all_d6ad.txt`.

## Benchmark/profile evidence

Latest artifact root: `/private/tmp/gomap_2626_final_evidence_20260612_010406_reviewfix`.
Profile artifact root from the same implementation series: `/private/tmp/gomap_2626_final_evidence_20260612_001726` (`text_v2_write_cpu_top.txt`, `text_v2_write_mem_top.txt`).

Context: Apple M3, Go `go1.26.0 darwin/arm64`; see `context.txt`. Baseline artifact root: `/private/tmp/gomap_2626_baseline_20260611_231614`.

Commands:

```sh
GOWORK=off TREEDB_TEXT_V2_WRITE_DOCS=256 \
  go test ./TreeDB/collections -run '^$' \
  -bench '^BenchmarkTextV2ContractWritePaths2623$' \
  -benchmem -benchtime=5x -count=3

GOWORK=off \
  go test ./TreeDB/collections -run '^$' \
  -bench '^BenchmarkIndexInsertSearch2564/indexed_insert_batch_flush_vector_rebuild$' \
  -benchmem -benchtime=5x -count=3
```

Key latest rows (benchstat summaries in `benchstat_base_vs_final_write.txt`):

| row | ns/op | B/op | allocs/op | index_bytes/doc | write_amp_entries/doc | posting_blocks/doc |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| v1 insert_batch_text_indexed | 2.671 ms | 3.203 MiB | 24.38k | 674.2 | 13.18 | 0 |
| v2 insert_batch_text_v2_indexed | 2.508 ms | 3.382 MiB | 32.10k | 280.1 | 5.523 | 2.348 |
| v1 create_text_index_backfill | 2.753 ms | 3.222 MiB | 23.76k | 674.2 | 13.18 | 0 |
| v2 create_text_v2_index_backfill | 2.179 ms | 3.070 MiB | 30.30k | 252.2 | 5.398 | 2.184 |
| v1 update_batch_text_indexed | 3.565 ms | 3.333 MiB | 33.60k | 674.2 | 24.19 | 0 |
| v2 update_batch_text_v2_indexed | 3.444 ms | 4.240 MiB | 41.03k | 461.5 | 5.527 | 4.695 |
| v1 delete_batch_text_indexed | 1.919 ms | 1.984 MiB | 19.13k | 0.0156 | 13.18 | 0 |
| v2 delete_batch_text_v2_indexed | 1.390 ms | 1.661 MiB | 17.44k | 280.0 | 3.176 | 2.348 |

Notes:

- Streaming analyzer reduces current v1 allocation rows vs baseline: insert `29.00k -> 24.38k`, backfill `28.37k -> 23.76k`, update `38.21k -> 33.60k` allocs/op.
- v2 eliminates v1 per-document posting rows and state rows, and lowers maintained-write amplification. It does not claim a 3x wall-time win; remaining hotspots/profiles are in the profile artifact root (notably root publish/cache and posting-block encode/decode/inspection costs).
- #2564 guardrail: latest `71.58 ms/op` vs baseline `72.91 ms/op`, `28.53k allocs/op` vs `31.96k`; vector rebuild cost remains called out separately in benchmark counters.

## Risks / deferrals

- v2 search/scoring remains unavailable by design until the next milestone.
- M3 appends mutation micro-blocks and advances generations/tombstones; active merge/rewrite of stale blocks is deferred.
- Physical reclamation remains normal TreeDB root/value-log/leaf maintenance.
