### PR TITLE
TreeDB text v2 score-only BM25F search

### DIFF
--- a/TreeDB/collections/index_insert_search_bench_test.go
+++ b/TreeDB/collections/index_insert_search_bench_test.go
@@ -117,6 +117,71 @@ func BenchmarkIndexInsertSearch2564(b *testing.B) {
 		indexInsertSearchCandidateSink2564 = sink
 	})
 
+	b.Run("search_text_v2_candidates_no_docs", func(b *testing.B) {
+		v2Fixture := openIndexInsertSearchInsertedTextV2Fixture2564(b, docs, dims, m)
+		defer func() { _ = v2Fixture.db.Close() }()
+		opts := HybridTextQuery{IndexName: hybridCloseoutTextIndexName2506, Query: "refund policy", CandidateLimit: 64}
+		warm, err := v2Fixture.col.SearchHybridTextCandidates(opts)
+		if err != nil {
+			b.Fatalf("warm v2 SearchHybridTextCandidates: %v", err)
+		}
+		if warm.Stats.DocumentsFetched != 0 || warm.Stats.FullDocumentScanFallbacks != 0 || warm.Stats.FailClosed != 0 || warm.Stats.TextStateLookups != 0 || warm.Stats.TextMatchDetailsBuilt != 0 {
+			b.Fatalf("warm v2 text stats=%+v want score-only no document/state/match-detail work", warm.Stats)
+		}
+		b.ReportAllocs()
+		b.ResetTimer()
+		var sink HybridCandidateResponse
+		for i := 0; i < b.N; i++ {
+			got, err := v2Fixture.col.SearchHybridTextCandidates(opts)
+			if err != nil {
+				b.Fatalf("v2 SearchHybridTextCandidates: %v", err)
+			}
+			if got.Stats.DocumentsFetched != 0 || got.Stats.FullDocumentScanFallbacks != 0 || got.Stats.FailClosed != 0 || got.Stats.TextStateLookups != 0 || got.Stats.TextMatchDetailsBuilt != 0 {
+				b.Fatalf("v2 text stats=%+v want score-only no document/state/match-detail work", got.Stats)
+			}
+			sink = got
+		}
+		b.StopTimer()
+		indexInsertSearchReportFixtureMetrics2564(b, docs, dims, 64, 10)
+		indexInsertSearchReportCandidateStats2564(b, sink)
+		indexInsertSearchCandidateSink2564 = sink
+	})
+
+	b.Run("search_hybrid_v2_no_docs_scalar_filter", func(b *testing.B) {
+		v2Fixture := openIndexInsertSearchInsertedTextV2Fixture2564(b, docs, dims, m)
+		defer func() { _ = v2Fixture.db.Close() }()
+		opts := HybridSearchOptions{
+			TopK:         10,
+			Text:         &HybridTextQuery{IndexName: hybridCloseoutTextIndexName2506, Query: "refund policy", CandidateLimit: 64},
+			ScalarFilter: &HybridScalarFilter{IndexName: hybridCloseoutTenantIndexName2506, Value: "tenant-rare-06pct"},
+		}
+		warm, err := v2Fixture.col.SearchHybrid(opts)
+		if err != nil {
+			b.Fatalf("warm v2 SearchHybrid: %v", err)
+		}
+		if warm.Stats.FailClosed != 0 || warm.Stats.FullDocumentScanFallbacks != 0 || warm.Stats.DocumentsFetched != 0 || warm.Stats.TextStateLookups != 0 || warm.Stats.TextMatchDetailsBuilt != 0 {
+			b.Fatalf("warm v2 hybrid stats=%+v want no-doc score-only text path", warm.Stats)
+		}
+		b.ReportAllocs()
+		b.ResetTimer()
+		var sink HybridSearchResponse
+		for i := 0; i < b.N; i++ {
+			got, err := v2Fixture.col.SearchHybrid(opts)
+			if err != nil {
+				b.Fatalf("v2 SearchHybrid: %v", err)
+			}
+			if got.Stats.FailClosed != 0 || got.Stats.FullDocumentScanFallbacks != 0 || got.Stats.DocumentsFetched != 0 || got.Stats.TextStateLookups != 0 || got.Stats.TextMatchDetailsBuilt != 0 {
+				b.Fatalf("v2 hybrid stats=%+v want no-doc score-only text path", got.Stats)
+			}
+			sink = got
+		}
+		b.StopTimer()
+		indexInsertSearchReportFixtureMetrics2564(b, docs, dims, 64, opts.TopK)
+		b.ReportMetric(hybridCloseoutTenantSelectivity2506(v2Fixture.rows, "tenant-rare-06pct"), "filter_selectivity_pct")
+		hybridCloseoutReportStats2506(b, sink)
+		indexInsertSearchHybridSink2564 = sink
+	})
+
 	b.Run("search_vector_candidates_no_docs", func(b *testing.B) {
 		opts := HybridVectorQuery{IndexName: searchFixture.def.Name, Query: queryVector, CandidateLimit: 64, EfSearch: 128, QueryMode: VectorIndexQueryModeExact}
 		warm, err := searchFixture.col.SearchHybridVectorCandidates(opts)
@@ -261,13 +326,35 @@ func openIndexInsertSearchInsertedFixture2564(tb testing.TB, docs, dims, m int) 
 
 func openIndexInsertSearchEmptyFixture2564(tb testing.TB, dir string, docs, dims, m int) indexInsertSearchFixture2564 {
 	tb.Helper()
+	textDef := TextIndexDefinition{
+		Name: hybridCloseoutTextIndexName2506,
+		Fields: []TextIndexField{
+			{Field: "title", Weight: 3},
+			{Field: "body"},
+		},
+		StorePositions: true,
+	}
+	return openIndexInsertSearchEmptyFixtureWithTextDefinition2564(tb, dir, docs, dims, m, &textDef, true)
+}
+
+func openIndexInsertSearchEmptyFixtureWithTextDefinition2564(tb testing.TB, dir string, docs, dims, m int, textDef *TextIndexDefinition, commandWAL bool) indexInsertSearchFixture2564 {
+	tb.Helper()
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		tb.Fatalf("MkdirAll: %v", err)
 	}
-	if err := backenddb.SaveFormatConfig(dir, backenddb.FormatConfig{RequiredFeatures: []string{backenddb.RequiredFeatureCommandWALV1}}); err != nil {
-		tb.Fatalf("SaveFormatConfig: %v", err)
+	var db *backenddb.DB
+	if commandWAL {
+		if err := backenddb.SaveFormatConfig(dir, backenddb.FormatConfig{RequiredFeatures: []string{backenddb.RequiredFeatureCommandWALV1}}); err != nil {
+			tb.Fatalf("SaveFormatConfig: %v", err)
+		}
+		db = openCollectionCommandWALDB(tb, dir)
+	} else {
+		var err error
+		db, err = backenddb.Open(backenddb.Options{Dir: dir})
+		if err != nil {
+			tb.Fatalf("open db: %v", err)
+		}
 	}
-	db := openCollectionCommandWALDB(tb, dir)
 	def := columnGraphRebuildVectorIndexDefinitionV2A(dims, m)
 	cfg := columnGraphRebuildColumnStoreConfigV2A(dims)
 	cfg.RetainedPayload = ColumnRetainedPayloadFull
@@ -283,14 +370,9 @@ func openIndexInsertSearchEmptyFixture2564(tb testing.TB, dir string, docs, dims
 			{Name: "region", Field: "region", ValueType: IndexValueString},
 		},
 		VectorIndexes: []VectorIndexDefinition{def},
-		TextIndexes: []TextIndexDefinition{{
-			Name: hybridCloseoutTextIndexName2506,
-			Fields: []TextIndexField{
-				{Field: "title", Weight: 3},
-				{Field: "body"},
-			},
-			StorePositions: true,
-		}},
+	}
+	if textDef != nil {
+		meta.TextIndexes = []TextIndexDefinition{*textDef}
 	}
 	if _, err := NewCollectionManager(db).CreateCollection(&meta); err != nil {
 		_ = db.Close()
@@ -304,6 +386,61 @@ func openIndexInsertSearchEmptyFixture2564(tb testing.TB, dir string, docs, dims
 	rows := makeHybridCloseoutRows2506(docs, dims)
 	ids, rawDocs := indexInsertSearchRawDocs2564(tb, rows)
 	return indexInsertSearchFixture2564{db: db, col: col, def: def, rows: rows, ids: ids, rawDocs: rawDocs}
+}
+
+func openIndexInsertSearchInsertedTextV2Fixture2564(tb testing.TB, docs, dims, m int) indexInsertSearchFixture2564 {
+	tb.Helper()
+	dir := tb.TempDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		tb.Fatalf("MkdirAll: %v", err)
+	}
+	db, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		tb.Fatalf("open db: %v", err)
+	}
+	meta := CollectionMeta{
+		Name: "docs",
+		Options: CollectionOptions{
+			DocumentFormat: DocumentFormatJSON,
+		},
+		Indexes: []IndexDefinition{
+			{Name: hybridCloseoutTenantIndexName2506, Field: "tenant", ValueType: IndexValueString},
+			{Name: "region", Field: "region", ValueType: IndexValueString},
+		},
+	}
+	if _, err := NewCollectionManager(db).CreateCollection(&meta); err != nil {
+		_ = db.Close()
+		tb.Fatalf("CreateCollection: %v", err)
+	}
+	col, err := NewCollectionManager(db).OpenCollection("docs")
+	if err != nil {
+		_ = db.Close()
+		tb.Fatalf("OpenCollection: %v", err)
+	}
+	rows := makeHybridCloseoutRows2506(docs, dims)
+	ids, rawDocs := indexInsertSearchRawDocs2564(tb, rows)
+	fixture := indexInsertSearchFixture2564{db: db, col: col, rows: rows, ids: ids, rawDocs: rawDocs}
+	if _, err := fixture.col.InsertBatch(fixture.ids, fixture.rawDocs); err != nil {
+		_ = fixture.db.Close()
+		tb.Fatalf("InsertBatch: %v", err)
+	}
+	textDef := TextIndexDefinition{
+		Name:    hybridCloseoutTextIndexName2506,
+		Version: TextIndexVersionV2,
+		Fields: []TextIndexField{
+			{Field: "title", Weight: 3},
+			{Field: "body"},
+		},
+	}
+	if _, _, err := fixture.col.CreateTextIndex(textDef); err != nil {
+		_ = fixture.db.Close()
+		tb.Fatalf("CreateTextIndex v2: %v", err)
+	}
+	if err := fixture.col.Flush(); err != nil {
+		_ = fixture.db.Close()
+		tb.Fatalf("Flush: %v", err)
+	}
+	return fixture
 }
 
 func indexInsertSearchRawDocs2564(tb testing.TB, rows []hybridCloseoutFixtureRow2506) ([][]byte, [][]byte) {

--- a/TreeDB/collections/text_index.go
+++ b/TreeDB/collections/text_index.go
@@ -362,9 +362,8 @@ func textIndexStatusForDefinition(collection string, def TextIndexDefinition) Te
 	}
 	if version == TextIndexVersionV2 {
 		status.Ready = true
+		status.Readable = true
 		status.Writable = true
-		status.FailClosed = true
-		status.FailClosedReason = "text_v2_search_unavailable"
 		status.ActiveRootNames = collectionTextV2RootNames(collection, def.Name)
 		return status
 	}

--- a/TreeDB/collections/text_index_test.go
+++ b/TreeDB/collections/text_index_test.go
@@ -258,8 +258,8 @@ func TestCollectionTextV2RootNamesAndStatusContract2623(t *testing.T) {
 		}
 	}
 	v2Status := textIndexStatusForDefinition("docs", TextIndexDefinition{Name: "lexical", Version: TextIndexVersionV2, Rollout: TextIndexRolloutPrimary})
-	if !v2Status.FailClosed || !v2Status.Ready || v2Status.Readable || !v2Status.Writable || v2Status.FailClosedReason != "text_v2_search_unavailable" {
-		t.Fatalf("v2 status=%+v want root-ready/writable/search-fail-closed v2", v2Status)
+	if v2Status.FailClosed || !v2Status.Ready || !v2Status.Readable || !v2Status.Writable || v2Status.FailClosedReason != "" {
+		t.Fatalf("v2 status=%+v want root-ready/readable/writable score-only v2", v2Status)
 	}
 	if !slices.Equal(v2Status.ActiveRootNames, wantV2) {
 		t.Fatalf("v2 active roots=%q want %q", v2Status.ActiveRootNames, wantV2)

--- a/TreeDB/collections/text_search.go
+++ b/TreeDB/collections/text_search.go
@@ -229,15 +229,16 @@ func (c *Collection) searchText(opts TextSearchOptions, resultMode textSearchRes
 		return response, ErrIndexNotFound
 	}
 	response.IndexName = idx.Name
-	if idx.Version == TextIndexVersionV2 {
-		return textSearchFailClosed(response, textSearchFailClosedV2Unavailable, ErrTextIndexUnavailable)
-	}
 
 	terms, operator, err := parseTextSearchQuery(idx.Analyzer, opts.Query, opts.Operator)
 	if err != nil {
 		return response, err
 	}
-	terms = uniqueTextSearchTerms(terms)
+	if idx.Version == TextIndexVersionV2 {
+		terms = uniqueSortedTextSearchTerms(terms)
+	} else {
+		terms = uniqueTextSearchTerms(terms)
+	}
 	response.Stats.QueryTerms = len(terms)
 	if len(terms) == 0 {
 		response.Results = []TextSearchResult{}
@@ -246,6 +247,9 @@ func (c *Collection) searchText(opts TextSearchOptions, resultMode textSearchRes
 	candidateLimit := normalizeTextSearchCandidateLimit(opts.TopK, opts.CandidateLimit)
 	maxPostingsScanned := normalizeTextSearchMaxPostingsScanned(candidateLimit, len(terms), opts.MaxPostingsScanned)
 	response.Stats.TextCandidatesRequested = uint64(candidateLimit)
+	if idx.Version == TextIndexVersionV2 {
+		return executeTextV2SearchAtSnapshot(c, snap, catalog, idx, opts, terms, operator, candidateLimit, maxPostingsScanned, resultMode, response)
+	}
 
 	return executeTextSearchAtSnapshot(c, snap, catalog, idx, opts, terms, operator, candidateLimit, maxPostingsScanned, resultMode, response)
 }
@@ -740,6 +744,14 @@ func uniqueTextSearchTerms(terms []string) []string {
 	return out
 }
 
+func uniqueSortedTextSearchTerms(terms []string) []string {
+	out := uniqueTextSearchTerms(terms)
+	if len(out) > 1 {
+		sort.Strings(out)
+	}
+	return out
+}
+
 func orderTextSearchScanTerms(terms []string, operator TextSearchOperator, stats map[string]textStatsTermValue) []string {
 	out := append([]string(nil), terms...)
 	if operator == TextSearchOperatorAND {
@@ -812,15 +824,15 @@ func parseTextSearchQuery(analyzer TextAnalyzer, query string, requested TextSea
 			expectTerm = true
 			continue
 		}
-		tokens, err := AnalyzeText(analyzer, part)
-		if err != nil {
+		before := len(terms)
+		if err := AnalyzeTextToSink(analyzer, part, TextTokenSinkFunc(func(token TextToken) error {
+			terms = append(terms, token.Term)
+			return nil
+		})); err != nil {
 			return nil, "", err
 		}
-		if len(tokens) == 0 {
+		if len(terms) == before {
 			continue
-		}
-		for _, token := range tokens {
-			terms = append(terms, token.Term)
 		}
 		expectTerm = false
 	}

--- a/TreeDB/collections/text_v2_contract_bench_test.go
+++ b/TreeDB/collections/text_v2_contract_bench_test.go
@@ -460,6 +460,49 @@ func BenchmarkTextV2ContractSearchScale2623(b *testing.B) {
 	}
 }
 
+func BenchmarkTextV2ScoreSearchScale2627(b *testing.B) {
+	for _, docs := range textV2ContractSearchCorpusSizes2623() {
+		docs := docs
+		b.Run(fmt.Sprintf("docs_%d", docs), func(b *testing.B) {
+			if docs >= 100_000 && !textV2ContractLargeCorpusEnabled2623() {
+				b.Skip("set TREEDB_TEXT_V2_RUN_100K=1 or TREEDB_TEXT_V2_SEARCH_DOCS to run the >=100k local artifact row")
+			}
+			d, col := openTextV2ContractV2SearchFixture2627(b, docs)
+			defer func() { _ = d.Close() }()
+			for _, tc := range textV2ContractSearchCases2623(docs) {
+				tc := tc
+				b.Run(tc.name, func(b *testing.B) {
+					warm, err := textV2ContractRunSearch2623(col, tc)
+					if err != nil {
+						b.Fatalf("warm v2 search: %v", err)
+					}
+					if warm.Stats.DocumentsFetched != 0 || warm.Stats.FullDocumentScanFallbacks != 0 || warm.Stats.FailClosed != 0 || warm.Stats.TextStateLookups != 0 || warm.Stats.TextMatchDetailsBuilt != 0 {
+						b.Fatalf("warm v2 stats=%+v want score-only zero-doc/no-state/no-match search", warm.Stats)
+					}
+					b.ReportAllocs()
+					b.ResetTimer()
+					var sink TextSearchResponse
+					for i := 0; i < b.N; i++ {
+						got, err := textV2ContractRunSearch2623(col, tc)
+						if err != nil {
+							b.Fatalf("v2 SearchText: %v", err)
+						}
+						if got.Stats.DocumentsFetched != 0 || got.Stats.FullDocumentScanFallbacks != 0 || got.Stats.FailClosed != 0 || got.Stats.TextStateLookups != 0 || got.Stats.TextMatchDetailsBuilt != 0 {
+							b.Fatalf("v2 stats=%+v want score-only zero-doc/no-state/no-match search", got.Stats)
+						}
+						sink = got
+					}
+					b.StopTimer()
+					b.ReportMetric(float64(docs), "docs_fixture")
+					b.ReportMetric(float64(tc.candidateLimit), "candidate_budget/search")
+					b.ReportMetric(float64(tc.maxPostings), "max_postings/search")
+					textV2ContractReportTextStats2623(b, sink)
+				})
+			}
+		})
+	}
+}
+
 func BenchmarkTextV2ContractConcurrentServing2623(b *testing.B) {
 	docs := textV2ContractEnvInt2623("TREEDB_TEXT_V2_CONCURRENT_DOCS", 256)
 	readers := textV2ContractEnvInt2623("TREEDB_TEXT_V2_CONCURRENT_READERS", 4)
@@ -574,6 +617,22 @@ func openTextV2ContractSearchFixture2623(tb testing.TB, docs int) (*backenddb.DB
 	if _, err := col.InsertBatch(ids, rawDocs); err != nil {
 		_ = d.Close()
 		tb.Fatalf("InsertBatch fixture: %v", err)
+	}
+	return d, col
+}
+
+func openTextV2ContractV2SearchFixture2627(tb testing.TB, docs int) (*backenddb.DB, *Collection) {
+	tb.Helper()
+	d := openTextV2ContractDB2623(tb)
+	col := createTextV2ContractCollection2623(tb, d, false)
+	ids, rawDocs := textV2ContractDocuments2623(docs, "search")
+	if _, err := col.InsertBatch(ids, rawDocs); err != nil {
+		_ = d.Close()
+		tb.Fatalf("InsertBatch v2 fixture: %v", err)
+	}
+	if _, _, err := col.CreateTextIndex(textV2ContractV2IndexDefinition2626()); err != nil {
+		_ = d.Close()
+		tb.Fatalf("CreateTextIndex v2 fixture: %v", err)
 	}
 	return d, col
 }

--- a/TreeDB/collections/text_v2_contract_bench_test.go
+++ b/TreeDB/collections/text_v2_contract_bench_test.go
@@ -479,6 +479,7 @@ func BenchmarkTextV2ScoreSearchScale2627(b *testing.B) {
 					if warm.Stats.DocumentsFetched != 0 || warm.Stats.FullDocumentScanFallbacks != 0 || warm.Stats.FailClosed != 0 || warm.Stats.TextStateLookups != 0 || warm.Stats.TextMatchDetailsBuilt != 0 {
 						b.Fatalf("warm v2 stats=%+v want score-only zero-doc/no-state/no-match search", warm.Stats)
 					}
+					textV2ContractAssertSearchHit2627(b, "warm", warm)
 					b.ReportAllocs()
 					b.ResetTimer()
 					var sink TextSearchResponse
@@ -490,6 +491,7 @@ func BenchmarkTextV2ScoreSearchScale2627(b *testing.B) {
 						if got.Stats.DocumentsFetched != 0 || got.Stats.FullDocumentScanFallbacks != 0 || got.Stats.FailClosed != 0 || got.Stats.TextStateLookups != 0 || got.Stats.TextMatchDetailsBuilt != 0 {
 							b.Fatalf("v2 stats=%+v want score-only zero-doc/no-state/no-match search", got.Stats)
 						}
+						textV2ContractAssertSearchHit2627(b, "timed", got)
 						sink = got
 					}
 					b.StopTimer()
@@ -579,6 +581,13 @@ func BenchmarkTextV2ContractConcurrentServing2623(b *testing.B) {
 	var ms runtime.MemStats
 	runtime.ReadMemStats(&ms)
 	b.ReportMetric(float64(ms.HeapAlloc), "steady_heap_bytes")
+}
+
+func textV2ContractAssertSearchHit2627(b *testing.B, phase string, response TextSearchResponse) {
+	b.Helper()
+	if len(response.Results) == 0 && response.Stats.TextCandidatesScored == 0 {
+		b.Fatalf("%s v2 search returned no hits: %+v", phase, response.Stats)
+	}
 }
 
 func textV2ContractRunSearch2623(col *Collection, tc textV2ContractSearchCase2623) (TextSearchResponse, error) {

--- a/TreeDB/collections/text_v2_search.go
+++ b/TreeDB/collections/text_v2_search.go
@@ -184,11 +184,12 @@ func executeTextV2SearchAtSnapshot(
 	}
 
 	candidates := make(map[uint64]*textV2SearchCandidate)
+	cache := textV2SearchBlockCache{}
 	scanTerms := orderTextV2SearchScanTerms(terms, operator, ctx.termStats)
 	scanStart := time.Now()
 	for i, term := range scanTerms {
 		allowNewCandidates := operator != TextSearchOperatorAND || i == 0
-		truncated, err := scanTextV2SearchPostingBlocksTerm(snap, catalog, ctx, term, candidates, allowNewCandidates, candidateLimit, maxPostingsScanned, &response.Stats)
+		truncated, err := scanTextV2SearchPostingBlocksTerm(snap, catalog, ctx, &cache, term, candidates, allowNewCandidates, candidateLimit, maxPostingsScanned, &response.Stats)
 		if err != nil {
 			return textSearchFailClosed(response, textSearchFailClosedStorageCorrupt, err)
 		}
@@ -211,7 +212,6 @@ func executeTextV2SearchAtSnapshot(
 	}
 
 	scoreStart := time.Now()
-	cache := textV2SearchBlockCache{}
 	scored := make([]*textV2SearchCandidate, 0, len(candidates))
 	for _, candidate := range candidates {
 		norm, ok, err := cache.normEntry(snap, catalog, ctx, candidate.ordinal, &response.Stats)
@@ -399,6 +399,7 @@ func scanTextV2SearchPostingBlocksTerm(
 	snap *backenddb.Snapshot,
 	catalog *collectionCatalog,
 	ctx *textV2SearchContext,
+	cache *textV2SearchBlockCache,
 	term string,
 	candidates map[uint64]*textV2SearchCandidate,
 	allowNewCandidates bool,
@@ -467,10 +468,17 @@ func scanTextV2SearchPostingBlocksTerm(
 				return false, errMalformedTextStorage("text-v2 posting entry outside status snapshot")
 			}
 			candidate := candidates[entry.Ordinal]
+			if candidate == nil && !allowNewCandidates {
+				continue
+			}
+			current, err := textV2SearchPostingEntryCurrent(snap, catalog, ctx, cache, entry, stats)
+			if err != nil {
+				return false, err
+			}
+			if !current {
+				continue
+			}
 			if candidate == nil {
-				if !allowNewCandidates {
-					continue
-				}
 				if candidateLimit > 0 && len(candidates) >= candidateLimit {
 					stats.Truncated = true
 					stats.FailClosedReason = textSearchFailClosedCandidateLimit
@@ -496,6 +504,20 @@ func scanTextV2SearchPostingBlocksTerm(
 		return false, errMalformedTextStorage("text-v2 term %q posting block count %d does not match scanned blocks %d", term, termStats.PostingBlockCount, blocksVisited)
 	}
 	return false, nil
+}
+
+func textV2SearchPostingEntryCurrent(snap *backenddb.Snapshot, catalog *collectionCatalog, ctx *textV2SearchContext, cache *textV2SearchBlockCache, entry textV2PostingBlockEntry, stats *TextSearchStats) (bool, error) {
+	if cache == nil {
+		return false, errMalformedTextStorage("text-v2 search cache is nil")
+	}
+	norm, ok, err := cache.normEntry(snap, catalog, ctx, entry.Ordinal, stats)
+	if err != nil || !ok {
+		return false, err
+	}
+	if norm.tombstoned() || norm.Generation != entry.Generation {
+		return false, nil
+	}
+	return true, nil
 }
 
 func pruneTextV2SearchANDCandidates(candidates map[uint64]*textV2SearchCandidate, term string) {

--- a/TreeDB/collections/text_v2_search.go
+++ b/TreeDB/collections/text_v2_search.go
@@ -1,0 +1,813 @@
+package collections
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"slices"
+	"sort"
+	"time"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+)
+
+type textV2SearchContext struct {
+	collectionName        string
+	indexName             string
+	termsRootName         string
+	postingBlocksRootName string
+	normBlocksRootName    string
+	docMapRootName        string
+	status                textV2IndexStatusValue
+	corpus                textV2CorpusStatsValue
+	termStats             map[string]textV2TermStatsValue
+	fieldStats            []textV2FieldStatsValue
+	fieldWeights          []float64
+	fieldNames            []string
+}
+
+type textV2SearchCandidatePosting struct {
+	term  string
+	value textV2SearchPostingValue
+}
+
+type textV2SearchPostingValue struct {
+	generation    uint64
+	termFrequency uint32
+	fieldCount    int
+	inlineFields  [4]uint32
+	fields        []uint32
+}
+
+func (p textV2SearchPostingValue) fieldFrequency(i int) uint32 {
+	if i < 0 || i >= p.fieldCount {
+		return 0
+	}
+	if p.fieldCount <= len(p.inlineFields) {
+		return p.inlineFields[i]
+	}
+	return p.fields[i]
+}
+
+type textV2SearchCandidate struct {
+	ordinal    uint64
+	documentID []byte
+	postings   [2]textV2SearchCandidatePosting
+	overflow   []textV2SearchCandidatePosting
+	postingsN  int
+	score      float64
+}
+
+func (c *textV2SearchCandidate) postingCount() int {
+	if c == nil {
+		return 0
+	}
+	return c.postingsN
+}
+
+func (c *textV2SearchCandidate) postingAt(i int) textV2SearchCandidatePosting {
+	if i < len(c.postings) {
+		return c.postings[i]
+	}
+	return c.overflow[i-len(c.postings)]
+}
+
+func (c *textV2SearchCandidate) postingForTerm(term string) (textV2SearchPostingValue, bool) {
+	if c == nil {
+		return textV2SearchPostingValue{}, false
+	}
+	for i := 0; i < c.postingsN; i++ {
+		posting := c.postingAt(i)
+		if posting.term == term {
+			return posting.value, true
+		}
+	}
+	return textV2SearchPostingValue{}, false
+}
+
+func (c *textV2SearchCandidate) addPosting(term string, entry textV2PostingBlockEntry, fieldCount int) error {
+	if c == nil {
+		return nil
+	}
+	value := textV2SearchPostingValue{generation: entry.Generation, termFrequency: entry.TermFrequency, fieldCount: fieldCount}
+	if len(entry.FieldFrequencies) != fieldCount {
+		return errMalformedTextStorage("text-v2 posting entry field count %d want %d", len(entry.FieldFrequencies), fieldCount)
+	}
+	if fieldCount <= len(value.inlineFields) {
+		copy(value.inlineFields[:], entry.FieldFrequencies)
+	} else {
+		value.fields = append(value.fields, entry.FieldFrequencies...)
+	}
+	for i := 0; i < c.postingsN; i++ {
+		posting := c.postingAt(i)
+		if posting.term != term {
+			continue
+		}
+		if posting.value.generation == entry.Generation {
+			return errMalformedTextStorage("duplicate text-v2 posting for term %q ordinal %d generation %d", term, c.ordinal, entry.Generation)
+		}
+		if entry.Generation > posting.value.generation {
+			if i < len(c.postings) {
+				c.postings[i].value = value
+			} else {
+				c.overflow[i-len(c.postings)].value = value
+			}
+		}
+		return nil
+	}
+	posting := textV2SearchCandidatePosting{term: term, value: value}
+	if c.postingsN < len(c.postings) {
+		c.postings[c.postingsN] = posting
+	} else {
+		c.overflow = append(c.overflow, posting)
+	}
+	c.postingsN++
+	return nil
+}
+
+type textV2SearchBlockCache struct {
+	normBlocks   map[uint64]textV2SearchNormBlock
+	docMapBlocks map[uint64]textV2SearchDocMapBlock
+}
+
+type textV2SearchNormBlock struct {
+	BlockStart   uint64
+	BlockSize    uint32
+	FieldCount   uint32
+	Entries      []textV2SearchNormEntry
+	FieldLengths []uint32
+}
+
+type textV2SearchNormEntry struct {
+	Ordinal      uint64
+	Generation   uint64
+	Flags        byte
+	FieldLengths []uint32
+}
+
+func (e textV2SearchNormEntry) tombstoned() bool { return e.Flags&textV2DocFlagTombstone != 0 }
+
+type textV2SearchDocMapBlock struct {
+	BlockStart uint64
+	BlockSize  uint32
+	Entries    []textV2SearchDocMapEntry
+}
+
+type textV2SearchDocMapEntry struct {
+	Ordinal    uint64
+	Generation uint64
+	Flags      byte
+	DocumentID []byte
+}
+
+func (e textV2SearchDocMapEntry) tombstoned() bool { return e.Flags&textV2DocFlagTombstone != 0 }
+
+func executeTextV2SearchAtSnapshot(
+	c *Collection,
+	snap *backenddb.Snapshot,
+	catalog *collectionCatalog,
+	idx TextIndexDefinition,
+	opts TextSearchOptions,
+	terms []string,
+	operator TextSearchOperator,
+	candidateLimit, maxPostingsScanned int,
+	resultMode textSearchResultMode,
+	response TextSearchResponse,
+) (TextSearchResponse, error) {
+	ctx, err := newTextV2SearchContext(snap, catalog, idx, terms)
+	if err != nil {
+		return textSearchFailClosed(response, textSearchFailClosedStorageCorrupt, err)
+	}
+	if ctx.corpus.DocumentCount == 0 {
+		response.Results = []TextSearchResult{}
+		return response, nil
+	}
+
+	candidates := make(map[uint64]*textV2SearchCandidate)
+	scanTerms := orderTextV2SearchScanTerms(terms, operator, ctx.termStats)
+	scanStart := time.Now()
+	for i, term := range scanTerms {
+		allowNewCandidates := operator != TextSearchOperatorAND || i == 0
+		truncated, err := scanTextV2SearchPostingBlocksTerm(snap, catalog, ctx, term, candidates, allowNewCandidates, candidateLimit, maxPostingsScanned, &response.Stats)
+		if err != nil {
+			return textSearchFailClosed(response, textSearchFailClosedStorageCorrupt, err)
+		}
+		if truncated {
+			response.Stats.PostingsScanNanos += uint64(time.Since(scanStart).Nanoseconds())
+			return textSearchFailClosed(response, response.Stats.FailClosedReason, fmt.Errorf("%w: collection %q text-v2 index %q exceeded bounded candidate generation", ErrTextIndexUnavailable, catalog.meta.Name, idx.Name))
+		}
+		if operator == TextSearchOperatorAND {
+			pruneTextV2SearchANDCandidates(candidates, term)
+			if len(candidates) == 0 {
+				break
+			}
+		}
+	}
+	response.Stats.PostingsScanNanos += uint64(time.Since(scanStart).Nanoseconds())
+	response.Stats.PostingsScanned = response.Stats.TextPostingsScanned
+	if len(candidates) == 0 {
+		response.Results = []TextSearchResult{}
+		return response, nil
+	}
+
+	scoreStart := time.Now()
+	cache := textV2SearchBlockCache{}
+	scored := make([]*textV2SearchCandidate, 0, len(candidates))
+	for _, candidate := range candidates {
+		norm, ok, err := cache.normEntry(snap, catalog, ctx, candidate.ordinal, &response.Stats)
+		if err != nil {
+			return textSearchFailClosed(response, textSearchFailClosedStorageCorrupt, err)
+		}
+		if !ok {
+			continue
+		}
+		docMap, ok, err := cache.docMapEntry(snap, catalog, ctx, candidate.ordinal)
+		if err != nil {
+			return textSearchFailClosed(response, textSearchFailClosedStorageCorrupt, err)
+		}
+		if !ok {
+			continue
+		}
+		if norm.Generation != docMap.Generation || norm.Flags != docMap.Flags {
+			return textSearchFailClosed(response, textSearchFailClosedStorageCorrupt, errMalformedTextStorage("text-v2 norm/docmap generation mismatch for ordinal %d", candidate.ordinal))
+		}
+		if norm.tombstoned() || docMap.tombstoned() {
+			continue
+		}
+		currentPostings := countTextV2CurrentPostings(candidate, terms, norm.Generation)
+		if operator == TextSearchOperatorAND && currentPostings != len(terms) {
+			continue
+		}
+		if currentPostings == 0 {
+			continue
+		}
+		score, err := scoreTextV2SearchCandidate(candidate, terms, ctx, norm)
+		if err != nil {
+			return textSearchFailClosed(response, textSearchFailClosedStorageCorrupt, err)
+		}
+		candidate.documentID = append(candidate.documentID[:0], docMap.DocumentID...)
+		candidate.score = score
+		scored = append(scored, candidate)
+	}
+	response.Stats.CandidateScoreNanos += uint64(time.Since(scoreStart).Nanoseconds())
+	response.Stats.TextCandidatesScored = uint64(len(scored))
+	response.Stats.CandidatesScored = response.Stats.TextCandidatesScored
+
+	if len(scored) == 0 {
+		response.Results = []TextSearchResult{}
+		return response, nil
+	}
+	sort.Slice(scored, func(i, j int) bool {
+		if scored[i].score != scored[j].score {
+			return scored[i].score > scored[j].score
+		}
+		return bytes.Compare(scored[i].documentID, scored[j].documentID) < 0
+	})
+	if len(scored) > opts.TopK {
+		scored = scored[:opts.TopK]
+	}
+	response.Stats.TextCandidatesReturned = uint64(len(scored))
+	response.Results = make([]TextSearchResult, len(scored))
+	_ = resultMode // v2 detailed match materialization is deferred to #2629; M4 returns score-only rows.
+	for i, candidate := range scored {
+		id := append([]byte(nil), candidate.documentID...)
+		response.Results[i] = TextSearchResult{
+			DocumentID: id,
+			IndexName:  idx.Name,
+			Rank:       i + 1,
+			Score:      candidate.score,
+			ScoreKind:  HybridScoreKindBM25F,
+		}
+	}
+	if opts.IncludeDocuments && len(response.Results) > 0 {
+		if err := fetchTextSearchResultDocuments(c, snap, catalog, opts, &response); err != nil {
+			return textSearchFailClosed(response, textSearchFailClosedDocumentFetch, err)
+		}
+	}
+	return response, nil
+}
+
+func newTextV2SearchContext(snap *backenddb.Snapshot, catalog *collectionCatalog, idx TextIndexDefinition, terms []string) (*textV2SearchContext, error) {
+	if snap == nil {
+		return nil, backenddb.ErrClosed
+	}
+	if catalog == nil {
+		return nil, errCollectionNotFound
+	}
+	fieldNames := textV2FieldNames(idx)
+	for _, rootName := range collectionTextV2RootNames(catalog.meta.Name, idx.Name) {
+		family, ok := textV2RootFamilyForName(catalog.meta.Name, idx.Name, rootName)
+		if !ok {
+			return nil, errMalformedTextStorage("unknown text-v2 root %q", rootName)
+		}
+		if err := validateTextV2SearchRootFormat(snap, catalog, rootName, family, fieldNames); err != nil {
+			return nil, err
+		}
+	}
+	generationsRootName := collectionTextV2GenerationsRootName(catalog.meta.Name, idx.Name)
+	status, ok, err := readTextV2StatusAtRoot(snap, catalog, generationsRootName)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, errMalformedTextStorage("missing text-v2 status for collection %q index %q", catalog.meta.Name, idx.Name)
+	}
+	termsRootName := collectionTextV2TermsRootName(catalog.meta.Name, idx.Name)
+	corpus, err := readTextV2CorpusStatsAtRoot(snap, catalog, termsRootName)
+	if err != nil {
+		return nil, err
+	}
+	if corpus.StatsGeneration != status.StatsGeneration || corpus.DocumentCount != status.LiveDocuments {
+		return nil, errMalformedTextStorage("text-v2 corpus stats/status mismatch")
+	}
+	ctx := &textV2SearchContext{
+		collectionName:        catalog.meta.Name,
+		indexName:             idx.Name,
+		termsRootName:         termsRootName,
+		postingBlocksRootName: collectionTextV2PostingBlocksRootName(catalog.meta.Name, idx.Name),
+		normBlocksRootName:    collectionTextV2NormBlocksRootName(catalog.meta.Name, idx.Name),
+		docMapRootName:        collectionTextV2DocMapRootName(catalog.meta.Name, idx.Name),
+		status:                status,
+		corpus:                corpus,
+		termStats:             make(map[string]textV2TermStatsValue, len(terms)),
+		fieldStats:            make([]textV2FieldStatsValue, 0, len(idx.Fields)),
+		fieldWeights:          make([]float64, 0, len(idx.Fields)),
+		fieldNames:            fieldNames,
+	}
+	for _, field := range idx.Fields {
+		stats, err := readTextV2FieldStatsAtRoot(snap, catalog, termsRootName, field.Field)
+		if err != nil {
+			return nil, err
+		}
+		if stats.StatsGeneration != status.StatsGeneration || stats.DocumentCount > status.LiveDocuments {
+			return nil, errMalformedTextStorage("text-v2 field stats/status mismatch for %q", field.Field)
+		}
+		ctx.fieldStats = append(ctx.fieldStats, stats)
+		weight := field.Weight
+		if weight == 0 {
+			weight = 1
+		}
+		ctx.fieldWeights = append(ctx.fieldWeights, weight)
+	}
+	for _, term := range terms {
+		stats, err := readTextV2TermStatsAtRoot(snap, catalog, termsRootName, term)
+		if err != nil {
+			return nil, err
+		}
+		if stats.StatsGeneration > status.TermGeneration {
+			return nil, errMalformedTextStorage("text-v2 term %q stats generation exceeds status", term)
+		}
+		if stats.DocumentFrequency > status.LiveDocuments || stats.DocumentFrequency > corpus.DocumentCount {
+			return nil, errMalformedTextStorage("text-v2 term %q document frequency outside corpus", term)
+		}
+		if stats.DocumentFrequency == 0 && stats.TotalTermFrequency != 0 {
+			return nil, errMalformedTextStorage("text-v2 term %q has zero df and non-zero tf", term)
+		}
+		if stats.DocumentFrequency != 0 && stats.TotalTermFrequency == 0 {
+			return nil, errMalformedTextStorage("text-v2 term %q has non-zero df and zero tf", term)
+		}
+		ctx.termStats[term] = stats
+	}
+	return ctx, nil
+}
+
+func validateTextV2SearchRootFormat(snap *backenddb.Snapshot, catalog *collectionCatalog, rootName string, family textV2RootFamily, fieldNames []string) error {
+	raw, ok, err := collectionGetAppendAtCatalogRoot(snap, catalog, rootName, encodeTextV2FormatKey(), nil)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return errMalformedTextStorage("missing text-v2 root %q format record", rootName)
+	}
+	format, err := decodeTextV2RootFormatValue(raw)
+	if err != nil {
+		return err
+	}
+	if format.Family != family {
+		return errMalformedTextStorage("text-v2 root %q format family=%s want %s", rootName, format.Family, family)
+	}
+	if format.DocMapBlockSize != textV2DefaultDocMapBlockSize || format.NormBlockSize != textV2DefaultNormBlockSize {
+		return errMalformedTextStorage("text-v2 root %q format block sizes mismatch", rootName)
+	}
+	if !slices.Equal(format.Fields, fieldNames) {
+		return errMalformedTextStorage("text-v2 root %q format fields mismatch", rootName)
+	}
+	return nil
+}
+
+func scanTextV2SearchPostingBlocksTerm(
+	snap *backenddb.Snapshot,
+	catalog *collectionCatalog,
+	ctx *textV2SearchContext,
+	term string,
+	candidates map[uint64]*textV2SearchCandidate,
+	allowNewCandidates bool,
+	candidateLimit, maxPostingsScanned int,
+	stats *TextSearchStats,
+) (bool, error) {
+	termStats := ctx.termStats[term]
+	if termStats.DocumentFrequency == 0 {
+		// M3/M7 retain historical posting blocks after updates/deletes. Term stats
+		// are the live search contract, so a zero-df term cannot produce live
+		// candidates and stale blocks must not consume candidate or posting budget.
+		return false, nil
+	}
+	if termStats.PostingBlockCount == 0 {
+		return false, errMalformedTextStorage("text-v2 term %q document frequency %d has no posting blocks", term, termStats.DocumentFrequency)
+	}
+	prefix := encodeTextV2PostingBlockTermPrefix(term)
+	it, err := collectionIteratorAtCatalogRoot(snap, catalog, ctx.postingBlocksRootName, prefix, textSearchPrefixEnd(prefix), true)
+	if err != nil {
+		return false, err
+	}
+	if it == nil {
+		return false, errMalformedTextStorage("text-v2 term %q has posting block count %d but missing posting root", term, termStats.PostingBlockCount)
+	}
+	defer func() { _ = it.Close() }()
+	var scratch []uint32
+	var blocksVisited uint64
+	fieldCount := len(ctx.fieldNames)
+	for it.Valid() {
+		keyBytes := it.UnsafeKey()
+		if !bytes.HasPrefix(keyBytes, prefix) {
+			break
+		}
+		if it.IsDeleted() {
+			it.Next()
+			continue
+		}
+		key, err := decodeTextV2PostingBlockKeyForPrefix(keyBytes, prefix)
+		if err != nil {
+			return false, err
+		}
+		scanner, err := newTextV2PostingBlockEntryScanner(it.UnsafeValue(), scratch)
+		if err != nil {
+			return false, err
+		}
+		if scanner.block.BlockStart != key.BlockStart || scanner.block.BlockID != key.BlockID {
+			return false, errMalformedTextStorage("text-v2 posting block key/value identity mismatch")
+		}
+		if len(scanner.block.Summary.MaxFieldTermFrequencies) != fieldCount {
+			return false, errMalformedTextStorage("text-v2 posting block field count %d want %d", len(scanner.block.Summary.MaxFieldTermFrequencies), fieldCount)
+		}
+		blocksVisited++
+		stats.TextPostingBlocksVisited++
+		var entry textV2PostingBlockEntry
+		for scanner.remaining > 0 {
+			if maxPostingsScanned > 0 && stats.TextPostingsScanned >= uint64(maxPostingsScanned) {
+				stats.Truncated = true
+				stats.FailClosedReason = textSearchFailClosedPostingsLimit
+				return true, nil
+			}
+			if !scanner.Next(&entry) {
+				break
+			}
+			stats.TextPostingsScanned++
+			if entry.Ordinal >= ctx.status.NextOrdinal || entry.Generation > ctx.status.RootGeneration {
+				return false, errMalformedTextStorage("text-v2 posting entry outside status snapshot")
+			}
+			candidate := candidates[entry.Ordinal]
+			if candidate == nil {
+				if !allowNewCandidates {
+					continue
+				}
+				if candidateLimit > 0 && len(candidates) >= candidateLimit {
+					stats.Truncated = true
+					stats.FailClosedReason = textSearchFailClosedCandidateLimit
+					return true, nil
+				}
+				candidate = &textV2SearchCandidate{ordinal: entry.Ordinal}
+				candidates[entry.Ordinal] = candidate
+			}
+			if err := candidate.addPosting(term, entry, fieldCount); err != nil {
+				return false, err
+			}
+		}
+		if err := scanner.Err(); err != nil {
+			return false, err
+		}
+		scratch = scanner.fieldScratch
+		it.Next()
+	}
+	if err := it.Error(); err != nil {
+		return false, err
+	}
+	if blocksVisited != termStats.PostingBlockCount {
+		return false, errMalformedTextStorage("text-v2 term %q posting block count %d does not match scanned blocks %d", term, termStats.PostingBlockCount, blocksVisited)
+	}
+	return false, nil
+}
+
+func pruneTextV2SearchANDCandidates(candidates map[uint64]*textV2SearchCandidate, term string) {
+	for ordinal, candidate := range candidates {
+		if _, ok := candidate.postingForTerm(term); !ok {
+			delete(candidates, ordinal)
+		}
+	}
+}
+
+func countTextV2CurrentPostings(candidate *textV2SearchCandidate, terms []string, generation uint64) int {
+	count := 0
+	for _, term := range terms {
+		posting, ok := candidate.postingForTerm(term)
+		if ok && posting.generation == generation {
+			count++
+		}
+	}
+	return count
+}
+
+func scoreTextV2SearchCandidate(candidate *textV2SearchCandidate, terms []string, ctx *textV2SearchContext, norm textV2SearchNormEntry) (float64, error) {
+	if ctx.corpus.DocumentCount == 0 {
+		return 0, errMalformedTextStorage("text-v2 corpus document count is zero with search candidates")
+	}
+	if len(norm.FieldLengths) != len(ctx.fieldNames) {
+		return 0, errMalformedTextStorage("text-v2 norm field count %d want %d", len(norm.FieldLengths), len(ctx.fieldNames))
+	}
+	corpusDocuments := float64(ctx.corpus.DocumentCount)
+	var score float64
+	for _, term := range terms {
+		posting, ok := candidate.postingForTerm(term)
+		if !ok || posting.generation != norm.Generation {
+			continue
+		}
+		stats := ctx.termStats[term]
+		if stats.DocumentFrequency == 0 || stats.DocumentFrequency > ctx.corpus.DocumentCount {
+			return 0, errMalformedTextStorage("text-v2 term %q document frequency %d outside corpus %d", term, stats.DocumentFrequency, ctx.corpus.DocumentCount)
+		}
+		df := float64(stats.DocumentFrequency)
+		idf := math.Log(1 + (corpusDocuments-df+0.5)/(df+0.5))
+		var combinedTF float64
+		for fieldIdx := range ctx.fieldNames {
+			fieldTF := float64(posting.fieldFrequency(fieldIdx))
+			if fieldTF <= 0 {
+				continue
+			}
+			statsValue := ctx.fieldStats[fieldIdx]
+			if statsValue.DocumentCount == 0 || statsValue.TotalTokenCount == 0 {
+				return 0, errMalformedTextStorage("missing text-v2 field accounting for %q", ctx.fieldNames[fieldIdx])
+			}
+			avgLength := float64(statsValue.TotalTokenCount) / float64(statsValue.DocumentCount)
+			if avgLength <= 0 {
+				return 0, errMalformedTextStorage("invalid average text-v2 field length for %q", ctx.fieldNames[fieldIdx])
+			}
+			normalizedTF := fieldTF / (1 - textSearchBM25B + textSearchBM25B*(float64(norm.FieldLengths[fieldIdx])/avgLength))
+			combinedTF += ctx.fieldWeights[fieldIdx] * normalizedTF
+		}
+		if combinedTF > 0 {
+			score += idf * ((combinedTF * (textSearchBM25K1 + 1)) / (combinedTF + textSearchBM25K1))
+		}
+	}
+	return score, nil
+}
+
+func decodeTextV2SearchNormBlock(raw []byte) (textV2SearchNormBlock, error) {
+	cur, err := textV2ValueCursor(raw, textV2NormBlockValueVersion, "norm block")
+	if err != nil {
+		return textV2SearchNormBlock{}, err
+	}
+	blockStart, err := cur.readUvarint()
+	if err != nil {
+		return textV2SearchNormBlock{}, errMalformedTextStorage("text-v2 norm block start: %v", err)
+	}
+	blockSizeRaw, err := cur.readUvarint()
+	if err != nil {
+		return textV2SearchNormBlock{}, errMalformedTextStorage("text-v2 norm block size: %v", err)
+	}
+	fieldCountRaw, err := cur.readUvarint()
+	if err != nil {
+		return textV2SearchNormBlock{}, errMalformedTextStorage("text-v2 norm field count: %v", err)
+	}
+	entryCount, err := cur.readUvarint()
+	if err != nil {
+		return textV2SearchNormBlock{}, errMalformedTextStorage("text-v2 norm entry count: %v", err)
+	}
+	if entryCount > uint64(cur.remaining()+1) {
+		return textV2SearchNormBlock{}, errMalformedTextStorage("text-v2 norm entry count too large")
+	}
+	blockSize := checkedTextUint32(blockSizeRaw)
+	fieldCount := checkedTextUint32(fieldCountRaw)
+	if err := validateTextV2BlockHeader(blockStart, blockSizeRaw, blockSize, "norm"); err != nil {
+		return textV2SearchNormBlock{}, err
+	}
+	if uint64(fieldCount) != fieldCountRaw || fieldCount == 0 {
+		return textV2SearchNormBlock{}, errMalformedTextStorage("text-v2 norm field count invalid")
+	}
+	if entryCount > 0 && fieldCountRaw > 0 && entryCount > uint64(cur.remaining())/fieldCountRaw {
+		return textV2SearchNormBlock{}, errMalformedTextStorage("text-v2 norm field count exceeds remaining payload")
+	}
+	if entryCount > uint64(int(^uint(0)>>1)) || entryCount*fieldCountRaw > uint64(int(^uint(0)>>1)) {
+		return textV2SearchNormBlock{}, errMalformedTextStorage("text-v2 norm block too large")
+	}
+	block := textV2SearchNormBlock{
+		BlockStart:   blockStart,
+		BlockSize:    blockSize,
+		FieldCount:   fieldCount,
+		Entries:      make([]textV2SearchNormEntry, 0, int(entryCount)),
+		FieldLengths: make([]uint32, 0, int(entryCount*fieldCountRaw)),
+	}
+	var prev uint64
+	for i := uint64(0); i < entryCount; i++ {
+		ordinal, err := cur.readUvarint()
+		if err != nil {
+			return textV2SearchNormBlock{}, errMalformedTextStorage("text-v2 norm entry[%d] ordinal: %v", i, err)
+		}
+		generation, err := cur.readUvarint()
+		if err != nil {
+			return textV2SearchNormBlock{}, errMalformedTextStorage("text-v2 norm entry[%d] generation: %v", i, err)
+		}
+		if cur.remaining() == 0 {
+			return textV2SearchNormBlock{}, errMalformedTextStorage("text-v2 norm entry[%d] missing flags", i)
+		}
+		flags := cur.buf[cur.pos]
+		cur.pos++
+		if err := validateTextV2BlockEntry(blockStart, blockSize, ordinal, generation, flags, prev, i, "norm"); err != nil {
+			return textV2SearchNormBlock{}, err
+		}
+		fieldOffset := len(block.FieldLengths)
+		for j := uint32(0); j < fieldCount; j++ {
+			length, err := cur.readUvarint()
+			if err != nil {
+				return textV2SearchNormBlock{}, errMalformedTextStorage("text-v2 norm entry[%d] field[%d] length: %v", i, j, err)
+			}
+			if uint64(checkedTextUint32(length)) != length {
+				return textV2SearchNormBlock{}, errMalformedTextStorage("text-v2 norm entry[%d] field[%d] length overflows uint32", i, j)
+			}
+			block.FieldLengths = append(block.FieldLengths, uint32(length))
+		}
+		block.Entries = append(block.Entries, textV2SearchNormEntry{Ordinal: ordinal, Generation: generation, Flags: flags, FieldLengths: block.FieldLengths[fieldOffset : fieldOffset+int(fieldCount)]})
+		prev = ordinal
+	}
+	if cur.remaining() != 0 {
+		return textV2SearchNormBlock{}, errMalformedTextStorage("text-v2 norm trailing bytes")
+	}
+	return block, nil
+}
+
+func (b textV2SearchNormBlock) find(ordinal uint64) (textV2SearchNormEntry, bool) {
+	i := sort.Search(len(b.Entries), func(i int) bool { return b.Entries[i].Ordinal >= ordinal })
+	if i < len(b.Entries) && b.Entries[i].Ordinal == ordinal {
+		return b.Entries[i], true
+	}
+	return textV2SearchNormEntry{}, false
+}
+
+func decodeTextV2SearchDocMapBlock(raw []byte) (textV2SearchDocMapBlock, error) {
+	cur, err := textV2ValueCursor(raw, textV2DocMapValueVersion, "docmap block")
+	if err != nil {
+		return textV2SearchDocMapBlock{}, err
+	}
+	blockStart, err := cur.readUvarint()
+	if err != nil {
+		return textV2SearchDocMapBlock{}, errMalformedTextStorage("text-v2 docmap block start: %v", err)
+	}
+	blockSizeRaw, err := cur.readUvarint()
+	if err != nil {
+		return textV2SearchDocMapBlock{}, errMalformedTextStorage("text-v2 docmap block size: %v", err)
+	}
+	entryCount, err := cur.readUvarint()
+	if err != nil {
+		return textV2SearchDocMapBlock{}, errMalformedTextStorage("text-v2 docmap entry count: %v", err)
+	}
+	if entryCount > uint64(cur.remaining()+1) {
+		return textV2SearchDocMapBlock{}, errMalformedTextStorage("text-v2 docmap entry count too large")
+	}
+	blockSize := checkedTextUint32(blockSizeRaw)
+	if err := validateTextV2BlockHeader(blockStart, blockSizeRaw, blockSize, "docmap"); err != nil {
+		return textV2SearchDocMapBlock{}, err
+	}
+	if entryCount > uint64(int(^uint(0)>>1)) {
+		return textV2SearchDocMapBlock{}, errMalformedTextStorage("text-v2 docmap block too large")
+	}
+	block := textV2SearchDocMapBlock{BlockStart: blockStart, BlockSize: blockSize, Entries: make([]textV2SearchDocMapEntry, 0, int(entryCount))}
+	var prev uint64
+	for i := uint64(0); i < entryCount; i++ {
+		ordinal, err := cur.readUvarint()
+		if err != nil {
+			return textV2SearchDocMapBlock{}, errMalformedTextStorage("text-v2 docmap entry[%d] ordinal: %v", i, err)
+		}
+		generation, err := cur.readUvarint()
+		if err != nil {
+			return textV2SearchDocMapBlock{}, errMalformedTextStorage("text-v2 docmap entry[%d] generation: %v", i, err)
+		}
+		if cur.remaining() == 0 {
+			return textV2SearchDocMapBlock{}, errMalformedTextStorage("text-v2 docmap entry[%d] missing flags", i)
+		}
+		flags := cur.buf[cur.pos]
+		cur.pos++
+		documentID, err := cur.readBytes()
+		if err != nil {
+			return textV2SearchDocMapBlock{}, errMalformedTextStorage("text-v2 docmap entry[%d] document id: %v", i, err)
+		}
+		if err := validateTextV2BlockEntry(blockStart, blockSize, ordinal, generation, flags, prev, i, "docmap"); err != nil {
+			return textV2SearchDocMapBlock{}, err
+		}
+		if len(documentID) == 0 {
+			return textV2SearchDocMapBlock{}, errMalformedTextStorage("text-v2 docmap entry[%d] missing document id", i)
+		}
+		block.Entries = append(block.Entries, textV2SearchDocMapEntry{Ordinal: ordinal, Generation: generation, Flags: flags, DocumentID: documentID})
+		prev = ordinal
+	}
+	if cur.remaining() != 0 {
+		return textV2SearchDocMapBlock{}, errMalformedTextStorage("text-v2 docmap trailing bytes")
+	}
+	return block, nil
+}
+
+func (b textV2SearchDocMapBlock) find(ordinal uint64) (textV2SearchDocMapEntry, bool) {
+	i := sort.Search(len(b.Entries), func(i int) bool { return b.Entries[i].Ordinal >= ordinal })
+	if i < len(b.Entries) && b.Entries[i].Ordinal == ordinal {
+		return b.Entries[i], true
+	}
+	return textV2SearchDocMapEntry{}, false
+}
+
+func (cache *textV2SearchBlockCache) normEntry(snap *backenddb.Snapshot, catalog *collectionCatalog, ctx *textV2SearchContext, ordinal uint64, stats *TextSearchStats) (textV2SearchNormEntry, bool, error) {
+	blockStart := textV2OrdinalBlockStart(ordinal, textV2DefaultNormBlockSize)
+	if blockStart == 0 {
+		return textV2SearchNormEntry{}, false, errMalformedTextStorage("text-v2 invalid norm ordinal %d", ordinal)
+	}
+	if cache.normBlocks == nil {
+		cache.normBlocks = make(map[uint64]textV2SearchNormBlock)
+	}
+	block, ok := cache.normBlocks[blockStart]
+	if !ok {
+		raw, found, err := collectionGetAppendAtCatalogRoot(snap, catalog, ctx.normBlocksRootName, encodeTextV2BlockKey(blockStart), nil)
+		if err != nil {
+			return textV2SearchNormEntry{}, false, err
+		}
+		stats.TextNormLookups++
+		if !found {
+			return textV2SearchNormEntry{}, false, errMalformedTextStorage("missing text-v2 norm block %d", blockStart)
+		}
+		decoded, err := decodeTextV2SearchNormBlock(raw)
+		if err != nil {
+			return textV2SearchNormEntry{}, false, err
+		}
+		if decoded.BlockStart != blockStart || decoded.BlockSize != textV2DefaultNormBlockSize || decoded.FieldCount != uint32(len(ctx.fieldNames)) {
+			return textV2SearchNormEntry{}, false, errMalformedTextStorage("text-v2 norm block key/value mismatch")
+		}
+		cache.normBlocks[blockStart] = decoded
+		block = decoded
+	}
+	entry, found := block.find(ordinal)
+	if !found {
+		return textV2SearchNormEntry{}, false, errMalformedTextStorage("missing text-v2 norm entry for ordinal %d", ordinal)
+	}
+	if entry.Ordinal >= ctx.status.NextOrdinal || entry.Generation > ctx.status.NormGeneration {
+		return textV2SearchNormEntry{}, false, errMalformedTextStorage("text-v2 norm entry outside status snapshot")
+	}
+	return entry, true, nil
+}
+
+func (cache *textV2SearchBlockCache) docMapEntry(snap *backenddb.Snapshot, catalog *collectionCatalog, ctx *textV2SearchContext, ordinal uint64) (textV2SearchDocMapEntry, bool, error) {
+	blockStart := textV2OrdinalBlockStart(ordinal, textV2DefaultDocMapBlockSize)
+	if blockStart == 0 {
+		return textV2SearchDocMapEntry{}, false, errMalformedTextStorage("text-v2 invalid docmap ordinal %d", ordinal)
+	}
+	if cache.docMapBlocks == nil {
+		cache.docMapBlocks = make(map[uint64]textV2SearchDocMapBlock)
+	}
+	block, ok := cache.docMapBlocks[blockStart]
+	if !ok {
+		raw, found, err := collectionGetAppendAtCatalogRoot(snap, catalog, ctx.docMapRootName, encodeTextV2BlockKey(blockStart), nil)
+		if err != nil {
+			return textV2SearchDocMapEntry{}, false, err
+		}
+		if !found {
+			return textV2SearchDocMapEntry{}, false, errMalformedTextStorage("missing text-v2 docmap block %d", blockStart)
+		}
+		decoded, err := decodeTextV2SearchDocMapBlock(raw)
+		if err != nil {
+			return textV2SearchDocMapEntry{}, false, err
+		}
+		if decoded.BlockStart != blockStart || decoded.BlockSize != textV2DefaultDocMapBlockSize {
+			return textV2SearchDocMapEntry{}, false, errMalformedTextStorage("text-v2 docmap block key/value mismatch")
+		}
+		cache.docMapBlocks[blockStart] = decoded
+		block = decoded
+	}
+	entry, found := block.find(ordinal)
+	if !found {
+		return textV2SearchDocMapEntry{}, false, errMalformedTextStorage("missing text-v2 docmap entry for ordinal %d", ordinal)
+	}
+	if entry.Ordinal >= ctx.status.NextOrdinal || entry.Generation > ctx.status.DocMapGeneration {
+		return textV2SearchDocMapEntry{}, false, errMalformedTextStorage("text-v2 docmap entry outside status snapshot")
+	}
+	return entry, true, nil
+}
+
+func orderTextV2SearchScanTerms(terms []string, operator TextSearchOperator, stats map[string]textV2TermStatsValue) []string {
+	out := append([]string(nil), terms...)
+	if operator == TextSearchOperatorAND {
+		sort.SliceStable(out, func(i, j int) bool {
+			left := stats[out[i]].DocumentFrequency
+			right := stats[out[j]].DocumentFrequency
+			if left != right {
+				return left < right
+			}
+			return out[i] < out[j]
+		})
+	}
+	return out
+}

--- a/TreeDB/collections/text_v2_search_test.go
+++ b/TreeDB/collections/text_v2_search_test.go
@@ -1,0 +1,264 @@
+package collections
+
+import (
+	"bytes"
+	"errors"
+	"math"
+	"testing"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+)
+
+func TestTextV2SearchScoreParity2627(t *testing.T) {
+	d := openTextV2TestDB(t, t.TempDir(), false)
+	defer func() { _ = d.Close() }()
+	fields := []TextIndexField{{Field: "title", Weight: 3}, {Field: "body"}}
+	ids := [][]byte{[]byte("d1"), []byte("d2"), []byte("d3"), []byte("d4")}
+	docs := [][]byte{
+		[]byte(`{"title":"refund policy","body":"refund refund chargeback"}`),
+		[]byte(`{"title":"policy","body":"refund shipping"}`),
+		[]byte(`{"title":"refund","body":"shipping"}`),
+		[]byte(`{"title":"other","body":"policy policy"}`),
+	}
+	v1 := createTextSearchCollection2627(t, d, "docs_v1", TextIndexDefinition{Name: "lexical", Fields: fields}, ids, docs)
+	v2 := createTextSearchCollection2627(t, d, "docs_v2", TextIndexDefinition{Name: "lexical", Version: TextIndexVersionV2, Fields: fields}, ids, docs)
+
+	cases := []TextSearchOptions{
+		{IndexName: "lexical", Query: "refund", TopK: 4, CandidateLimit: 16, MaxPostingsScanned: 64},
+		{IndexName: "lexical", Query: "refund AND policy", Operator: TextSearchOperatorAND, TopK: 4, CandidateLimit: 16, MaxPostingsScanned: 64},
+		{IndexName: "lexical", Query: "shipping OR policy", TopK: 4, CandidateLimit: 16, MaxPostingsScanned: 64},
+	}
+	for _, opts := range cases {
+		t.Run(opts.Query, func(t *testing.T) {
+			want, err := v1.searchText(opts, textSearchResultScoreOnly)
+			if err != nil {
+				t.Fatalf("v1 search: %v", err)
+			}
+			got, err := v2.searchText(opts, textSearchResultScoreOnly)
+			if err != nil {
+				t.Fatalf("v2 search: %v", err)
+			}
+			assertTextSearchParity2627(t, got, want)
+			if got.Stats.TextPostingBlocksVisited == 0 || got.Stats.TextPostingsScanned == 0 || got.Stats.TextNormLookups == 0 {
+				t.Fatalf("v2 stats=%+v want posting block scans and norm-block lookups", got.Stats)
+			}
+			if got.Stats.TextStateLookups != 0 || got.Stats.TextMatchDetailsBuilt != 0 || got.Stats.DocumentsFetched != 0 || got.Stats.FullDocumentScanFallbacks != 0 {
+				t.Fatalf("v2 stats=%+v want score-only/no-doc/no-state path", got.Stats)
+			}
+		})
+	}
+}
+
+func TestTextV2HybridTextCandidatesNoDocCounters2627(t *testing.T) {
+	d := openTextV2TestDB(t, t.TempDir(), false)
+	defer func() { _ = d.Close() }()
+	col := createTextSearchCollection2627(t, d, "docs", TextIndexDefinition{Name: "lexical", Version: TextIndexVersionV2, Fields: []TextIndexField{{Field: "title", Weight: 4}, {Field: "body"}}}, [][]byte{[]byte("d1"), []byte("d2"), []byte("d3")}, [][]byte{
+		[]byte(`{"title":"refund","body":"refund refund policy","city":"sea"}`),
+		[]byte(`{"title":"plain","body":"refund policy","city":"pdx"}`),
+		[]byte(`{"title":"shipping","body":"policy","city":"sea"}`),
+	})
+
+	got, err := col.SearchHybridTextCandidates(HybridTextQuery{IndexName: "lexical", Query: "refund", CandidateLimit: 2})
+	if err != nil {
+		t.Fatalf("SearchHybridTextCandidates v2: %v", err)
+	}
+	if len(got.Candidates) != 2 || string(got.Candidates[0].ID) != "d1" || string(got.Candidates[1].ID) != "d2" {
+		t.Fatalf("candidates=%+v want d1,d2", got.Candidates)
+	}
+	if got.Candidates[0].Score <= got.Candidates[1].Score {
+		t.Fatalf("candidates=%+v want d1 higher score", got.Candidates)
+	}
+	for i, candidate := range got.Candidates {
+		if len(candidate.TextMatches) != 0 {
+			t.Fatalf("candidate[%d] matches=%+v want score-only v2 candidate", i, candidate.TextMatches)
+		}
+	}
+	stats := got.Stats
+	if stats.DocumentsFetched != 0 || stats.DocumentsMissing != 0 || stats.FullDocumentScanFallbacks != 0 || stats.FailClosed != 0 {
+		t.Fatalf("stats=%+v want no documents/fallback/fail-closed", stats)
+	}
+	if stats.TextStateLookups != 0 || stats.TextMatchDetailsBuilt != 0 {
+		t.Fatalf("stats=%+v want zero state lookups and match-detail builds", stats)
+	}
+	if stats.TextPostingBlocksVisited == 0 || stats.TextPostingsScanned == 0 || stats.TextCandidatesScored == 0 || stats.TextNormLookups == 0 {
+		t.Fatalf("stats=%+v want v2 block/norm/scoring counters", stats)
+	}
+}
+
+func TestTextV2SearchSkipsStaleGenerationsAndTombstones2627(t *testing.T) {
+	d := openTextV2TestDB(t, t.TempDir(), false)
+	defer func() { _ = d.Close() }()
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "docs"}); err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	col, err := mgr.OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("OpenCollection: %v", err)
+	}
+	if _, _, err := col.CreateTextIndex(TextIndexDefinition{Name: "lexical", Version: TextIndexVersionV2, Fields: []TextIndexField{{Field: "body"}}}); err != nil {
+		t.Fatalf("CreateTextIndex: %v", err)
+	}
+	if _, err := col.InsertBatch([][]byte{[]byte("d1"), []byte("d2")}, [][]byte{[]byte(`{"body":"refund policy"}`), []byte(`{"body":"refund shipping"}`)}); err != nil {
+		t.Fatalf("InsertBatch: %v", err)
+	}
+	if _, _, err := col.Update([]byte("d1"), func([]byte) ([]byte, bool, error) {
+		return []byte(`{"body":"updated only"}`), true, nil
+	}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if deleted, err := col.DeleteBatch([][]byte{[]byte("d2")}); err != nil || deleted != 1 {
+		t.Fatalf("DeleteBatch deleted=%d err=%v", deleted, err)
+	}
+
+	refund, err := col.searchText(TextSearchOptions{IndexName: "lexical", Query: "refund", TopK: 10, CandidateLimit: 1, MaxPostingsScanned: 1}, textSearchResultScoreOnly)
+	if err != nil {
+		t.Fatalf("refund search with stale-only blocks and low budgets: %v", err)
+	}
+	if len(refund.Results) != 0 || refund.Stats.TextPostingsScanned != 0 || refund.Stats.TextPostingBlocksVisited != 0 || refund.Stats.TextCandidatesScored != 0 || refund.Stats.FailClosed != 0 {
+		t.Fatalf("refund response=%+v want stale zero-df blocks ignored without consuming budget", refund)
+	}
+	updated, err := col.searchText(TextSearchOptions{IndexName: "lexical", Query: "updated", TopK: 10, CandidateLimit: 10, MaxPostingsScanned: 64}, textSearchResultScoreOnly)
+	if err != nil {
+		t.Fatalf("updated search: %v", err)
+	}
+	if len(updated.Results) != 1 || string(updated.Results[0].DocumentID) != "d1" {
+		t.Fatalf("updated results=%+v want live updated d1", updated.Results)
+	}
+}
+
+func TestTextV2SearchFailClosedOnMissingAndCorruptRoots2627(t *testing.T) {
+	t.Run("missing docmap descriptor", func(t *testing.T) {
+		d := openTextV2TestDB(t, t.TempDir(), false)
+		defer func() { _ = d.Close() }()
+		col := createTextSearchCollection2627(t, d, "docs", TextIndexDefinition{Name: "lexical", Version: TextIndexVersionV2, Fields: []TextIndexField{{Field: "body"}}}, [][]byte{[]byte("d1")}, [][]byte{[]byte(`{"body":"refund policy"}`)})
+		clearTextRootDescriptor2624(t, d, collectionTextV2DocMapRootName("docs", "lexical"))
+		got, err := col.searchText(TextSearchOptions{IndexName: "lexical", Query: "refund", TopK: 1}, textSearchResultScoreOnly)
+		if !errors.Is(err, ErrTextIndexUnavailable) || !errors.Is(err, ErrTextIndexStorageCorrupt) {
+			t.Fatalf("SearchText err=%v want unavailable/storage corrupt", err)
+		}
+		if got.Stats.FailClosed != 1 || got.Stats.FailClosedReason != textSearchFailClosedStorageCorrupt || got.Stats.DocumentsFetched != 0 {
+			t.Fatalf("stats=%+v want storage fail-closed without docs", got.Stats)
+		}
+	})
+	t.Run("corrupt posting block", func(t *testing.T) {
+		d := openTextV2TestDB(t, t.TempDir(), false)
+		defer func() { _ = d.Close() }()
+		col := createTextSearchCollection2627(t, d, "docs", TextIndexDefinition{Name: "lexical", Version: TextIndexVersionV2, Fields: []TextIndexField{{Field: "body"}}}, [][]byte{[]byte("d1")}, [][]byte{[]byte(`{"body":"refund policy"}`)})
+		rootName := collectionTextV2PostingBlocksRootName("docs", "lexical")
+		blockKey := firstTextV2PostingBlockKeyForTerm2626(t, d, "docs", rootName, "refund")
+		corruptTextRootValue(t, d, "docs", rootName, blockKey, []byte{99})
+		got, err := col.searchText(TextSearchOptions{IndexName: "lexical", Query: "refund", TopK: 1}, textSearchResultScoreOnly)
+		if !errors.Is(err, ErrTextIndexUnavailable) || !errors.Is(err, ErrTextIndexStorageCorrupt) {
+			t.Fatalf("SearchText err=%v want unavailable/storage corrupt", err)
+		}
+		if got.Stats.FailClosed != 1 || got.Stats.FailClosedReason != textSearchFailClosedStorageCorrupt || got.Stats.DocumentsFetched != 0 {
+			t.Fatalf("stats=%+v want storage fail-closed without docs", got.Stats)
+		}
+	})
+}
+
+func TestTextV2SearchSnapshotBindingAndReopen2627(t *testing.T) {
+	dir := t.TempDir()
+	d := openTextV2TestDB(t, dir, false)
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "docs"}); err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	col, err := mgr.OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("OpenCollection: %v", err)
+	}
+	if _, err := col.InsertBatch([][]byte{[]byte("d1"), []byte("d2")}, [][]byte{[]byte(`{"body":"refund policy"}`), []byte(`{"body":"shipping"}`)}); err != nil {
+		t.Fatalf("InsertBatch: %v", err)
+	}
+	if _, _, err := col.CreateTextIndex(TextIndexDefinition{Name: "lexical", Version: TextIndexVersionV2, Fields: []TextIndexField{{Field: "body"}}}); err != nil {
+		t.Fatalf("CreateTextIndex: %v", err)
+	}
+	before, err := col.searchText(TextSearchOptions{IndexName: "lexical", Query: "refund", TopK: 10}, textSearchResultScoreOnly)
+	if err != nil || len(before.Results) != 1 || string(before.Results[0].DocumentID) != "d1" {
+		t.Fatalf("before response=%+v err=%v want d1", before, err)
+	}
+	snap := d.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("snapshot nil")
+	}
+	catalog, err := col.catalogForSnapshot(snap)
+	if err != nil {
+		_ = snap.Close()
+		t.Fatalf("catalog: %v", err)
+	}
+	idx, ok := findTextIndex(catalog.meta.TextIndexes, "lexical")
+	if !ok {
+		_ = snap.Close()
+		t.Fatal("missing lexical index")
+	}
+	if _, _, err := col.Update([]byte("d1"), func([]byte) ([]byte, bool, error) {
+		return []byte(`{"body":"updated only"}`), true, nil
+	}); err != nil {
+		_ = snap.Close()
+		t.Fatalf("Update: %v", err)
+	}
+	currentRefund, err := col.searchText(TextSearchOptions{IndexName: "lexical", Query: "refund", TopK: 10}, textSearchResultScoreOnly)
+	if err != nil || len(currentRefund.Results) != 0 {
+		_ = snap.Close()
+		t.Fatalf("current refund response=%+v err=%v want no live refund", currentRefund, err)
+	}
+	oldResponse := TextSearchResponse{IndexName: "lexical"}
+	oldResponse.Stats.QueryTerms = 1
+	oldResponse.Stats.TextCandidatesRequested = 10
+	old, err := executeTextV2SearchAtSnapshot(col, snap, catalog, idx, TextSearchOptions{IndexName: "lexical", Query: "refund", TopK: 10}, []string{"refund"}, TextSearchOperatorOR, 10, 64, textSearchResultScoreOnly, oldResponse)
+	if closeErr := snap.Close(); closeErr != nil {
+		t.Fatalf("snapshot close: %v", closeErr)
+	}
+	if err != nil || len(old.Results) != 1 || string(old.Results[0].DocumentID) != "d1" {
+		t.Fatalf("old snapshot response=%+v err=%v want original d1", old, err)
+	}
+	if err := d.Checkpoint(); err != nil {
+		t.Fatalf("Checkpoint: %v", err)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	reopened := openTextV2TestDB(t, dir, false)
+	defer func() { _ = reopened.Close() }()
+	reopenedCol, err := NewCollectionManager(reopened).OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("OpenCollection reopened: %v", err)
+	}
+	after, err := reopenedCol.searchText(TextSearchOptions{IndexName: "lexical", Query: "updated", TopK: 10}, textSearchResultScoreOnly)
+	if err != nil || len(after.Results) != 1 || string(after.Results[0].DocumentID) != "d1" {
+		t.Fatalf("after reopen response=%+v err=%v want updated d1", after, err)
+	}
+}
+
+func createTextSearchCollection2627(t *testing.T, d *backenddb.DB, collection string, def TextIndexDefinition, ids, docs [][]byte) *Collection {
+	t.Helper()
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: collection}); err != nil {
+		t.Fatalf("CreateCollection %s: %v", collection, err)
+	}
+	col, err := mgr.OpenCollection(collection)
+	if err != nil {
+		t.Fatalf("OpenCollection %s: %v", collection, err)
+	}
+	if _, err := col.InsertBatch(ids, docs); err != nil {
+		t.Fatalf("InsertBatch %s: %v", collection, err)
+	}
+	if _, _, err := col.CreateTextIndex(def); err != nil {
+		t.Fatalf("CreateTextIndex %s: %v", collection, err)
+	}
+	return col
+}
+
+func assertTextSearchParity2627(t *testing.T, got, want TextSearchResponse) {
+	t.Helper()
+	if len(got.Results) != len(want.Results) {
+		t.Fatalf("result length got=%d want=%d got=%+v want=%+v", len(got.Results), len(want.Results), got.Results, want.Results)
+	}
+	for i := range want.Results {
+		if !bytes.Equal(got.Results[i].DocumentID, want.Results[i].DocumentID) || got.Results[i].Rank != want.Results[i].Rank || math.Abs(got.Results[i].Score-want.Results[i].Score) > 1e-12 {
+			t.Fatalf("result[%d] got=%+v want=%+v", i, got.Results[i], want.Results[i])
+		}
+	}
+}

--- a/TreeDB/collections/text_v2_search_test.go
+++ b/TreeDB/collections/text_v2_search_test.go
@@ -127,6 +127,31 @@ func TestTextV2SearchSkipsStaleGenerationsAndTombstones2627(t *testing.T) {
 	}
 }
 
+func TestTextV2SearchStalePostingsDoNotConsumeCandidateBudget2627(t *testing.T) {
+	d := openTextV2TestDB(t, t.TempDir(), false)
+	defer func() { _ = d.Close() }()
+	col := createTextSearchCollection2627(t, d, "docs", TextIndexDefinition{Name: "lexical", Version: TextIndexVersionV2, Fields: []TextIndexField{{Field: "body"}}}, [][]byte{[]byte("d1"), []byte("d2")}, [][]byte{
+		[]byte(`{"body":"refund stale"}`),
+		[]byte(`{"body":"refund live"}`),
+	})
+	if _, _, err := col.Update([]byte("d1"), func([]byte) ([]byte, bool, error) {
+		return []byte(`{"body":"updated only"}`), true, nil
+	}); err != nil {
+		t.Fatalf("Update d1 away from refund: %v", err)
+	}
+
+	got, err := col.searchText(TextSearchOptions{IndexName: "lexical", Query: "refund", TopK: 10, CandidateLimit: 1, MaxPostingsScanned: 64}, textSearchResultScoreOnly)
+	if err != nil {
+		t.Fatalf("refund search with stale-before-live posting and candidateLimit=1: %v", err)
+	}
+	if len(got.Results) != 1 || string(got.Results[0].DocumentID) != "d2" {
+		t.Fatalf("results=%+v want only live d2", got.Results)
+	}
+	if got.Stats.FailClosed != 0 || got.Stats.TextCandidatesScored != 1 || got.Stats.TextCandidatesReturned != 1 {
+		t.Fatalf("stats=%+v want one scored/returned candidate without fail-closed", got.Stats)
+	}
+}
+
 func TestTextV2SearchFailClosedOnMissingAndCorruptRoots2627(t *testing.T) {
 	t.Run("missing docmap descriptor", func(t *testing.T) {
 		d := openTextV2TestDB(t, t.TempDir(), false)

--- a/TreeDB/collections/text_v2_search_test.go
+++ b/TreeDB/collections/text_v2_search_test.go
@@ -85,6 +85,36 @@ func TestTextV2HybridTextCandidatesNoDocCounters2627(t *testing.T) {
 	}
 }
 
+func TestTextV2SearchIncludeDocumentsFetchesOnlyTopK2627(t *testing.T) {
+	d := openTextV2TestDB(t, t.TempDir(), false)
+	defer func() { _ = d.Close() }()
+	col := createTextSearchCollection2627(t, d, "docs", TextIndexDefinition{Name: "lexical", Version: TextIndexVersionV2, Fields: []TextIndexField{{Field: "title", Weight: 4}, {Field: "body"}}}, [][]byte{[]byte("d1"), []byte("d2"), []byte("d3")}, [][]byte{
+		[]byte(`{"title":"refund","body":"refund policy"}`),
+		[]byte(`{"title":"plain","body":"refund"}`),
+		[]byte(`{"title":"shipping","body":"policy"}`),
+	})
+
+	got, err := col.SearchText(TextSearchOptions{IndexName: "lexical", Query: "refund", TopK: 1, CandidateLimit: 8, IncludeDocuments: true})
+	if err != nil {
+		t.Fatalf("SearchText IncludeDocuments v2: %v", err)
+	}
+	if len(got.Results) != 1 || len(got.Results[0].Document) == 0 {
+		t.Fatalf("results=%+v want one materialized topK document", got.Results)
+	}
+	if !bytes.Contains(got.Results[0].Document, []byte("refund")) {
+		t.Fatalf("document=%s want fetched refund document", got.Results[0].Document)
+	}
+	if len(got.Results[0].TextMatches) != 0 || len(got.Results[0].MatchedTerms) != 0 || len(got.Results[0].MatchedFields) != 0 {
+		t.Fatalf("result=%+v want v2 M4 score-only match details", got.Results[0])
+	}
+	if got.Stats.DocumentsFetched == 0 || got.Stats.DocumentsFetched > uint64(len(got.Results)) || got.Stats.DocumentsFetched > 1 || got.Stats.FullDocumentScanFallbacks != 0 || got.Stats.FailClosed != 0 {
+		t.Fatalf("stats=%+v want bounded topK document fetch only", got.Stats)
+	}
+	if got.Stats.TextStateLookups != 0 || got.Stats.TextMatchDetailsBuilt != 0 {
+		t.Fatalf("stats=%+v want score-only v2 search despite final fetch", got.Stats)
+	}
+}
+
 func TestTextV2SearchSkipsStaleGenerationsAndTombstones2627(t *testing.T) {
 	d := openTextV2TestDB(t, t.TempDir(), false)
 	defer func() { _ = d.Close() }()

--- a/TreeDB/collections/text_v2_storage_test.go
+++ b/TreeDB/collections/text_v2_storage_test.go
@@ -192,8 +192,8 @@ func TestCollectionCreateTextV2IndexBackfillsOrdinalsNormsStatsAndReopens2624(t 
 	if err != nil {
 		t.Fatalf("TextIndexStatus: %v", err)
 	}
-	if status.Version != TextIndexVersionV2 || !status.Ready || status.Readable || !status.Writable || status.FailClosedReason != "text_v2_search_unavailable" {
-		t.Fatalf("status=%+v want v2 root-ready/writable/search fail-closed", status)
+	if status.Version != TextIndexVersionV2 || !status.Ready || !status.Readable || !status.Writable || status.FailClosed || status.FailClosedReason != "" {
+		t.Fatalf("status=%+v want v2 root-ready/readable/writable score-only", status)
 	}
 	if !slices.Equal(status.ActiveRootNames, collectionTextV2RootNames("docs", "lexical")) {
 		t.Fatalf("active roots=%q", status.ActiveRootNames)
@@ -234,8 +234,12 @@ func TestCollectionCreateTextV2IndexBackfillsOrdinalsNormsStatsAndReopens2624(t 
 			t.Fatalf("refund term=%+v want df=1 tf=3", term)
 		}
 	})
-	if _, err := col.SearchText(TextSearchOptions{IndexName: "lexical", Query: "refund", TopK: 10}); !errors.Is(err, ErrTextIndexUnavailable) {
-		t.Fatalf("v2 SearchText err=%v want ErrTextIndexUnavailable", err)
+	search, err := col.SearchText(TextSearchOptions{IndexName: "lexical", Query: "refund", TopK: 10})
+	if err != nil {
+		t.Fatalf("v2 SearchText: %v", err)
+	}
+	if len(search.Results) != 1 || string(search.Results[0].DocumentID) != "d1" || len(search.Results[0].TextMatches) != 0 || search.Stats.TextMatchDetailsBuilt != 0 || search.Stats.TextStateLookups != 0 {
+		t.Fatalf("v2 SearchText response=%+v want score-only d1 without match/state work", search)
 	}
 	if err := d.Close(); err != nil {
 		t.Fatalf("close: %v", err)

--- a/TreeDB/docs/spec/collection-text-v2-contract.md
+++ b/TreeDB/docs/spec/collection-text-v2-contract.md
@@ -38,7 +38,7 @@ type TextIndexDefinition struct {
     Name    string
     Fields  []TextIndexField
     Analyzer TextAnalyzer
-    Version TextIndexVersion     // "v1" default today, "v2" reserved
+    Version TextIndexVersion     // "v1" default today, explicit "v2" supports M4 score-only reads
     Rollout TextIndexRolloutMode // "primary" default today
     // existing position/offset/storage/schema fields...
 }
@@ -318,8 +318,9 @@ Required fixture scales:
 
 Required query and serving shapes:
 
-- common-term, rare-term, multi-term AND/OR, scalar-filtered, score-only, and
-  detailed-match rows;
+- common-term, rare-term, multi-term AND/OR, scalar-filtered, and score-only
+  rows; detailed-match rows are required once #2629 enables v2 detail
+  materialization, while M4 rows must assert empty match-detail output;
 - isolated text write, backfill, update, and delete rows with `-benchmem`;
 - current #2589 indexed insert/search guardrail matrix on the latest base;
 - concurrent serving/load row with reader concurrency, p50/p95/p99 latency,
@@ -347,8 +348,10 @@ coordinator explicitly accepts them with profile-backed rationale.
   root publication, and value-log reachability tests.
 - M2/M3 must prove posting/norm/docmap payloads remain ordinary B-tree values or
   existing `value_vlog` pointers reachable from collection root descriptors.
-- M4+ search must be score-only by default for candidate generation and must
-  materialize match details only when requested/final.
+- M4 search must be score-only for candidate generation and public v2
+  `SearchText` rows, with optional bounded final document fetch only. #2629 owns
+  any later detailed match/position materialization; until then detailed modes
+  remain intentionally empty/fail-closed rather than falling back to v1.
 - M5 block skipping must be exact: upper bounds are admissible and results match
   exhaustive scoring. Approximate ranking requires a separate mode/tracker.
 - M7 default-switch or old-path retirement must include v1/v2 coexistence,

--- a/TreeDB/docs/spec/collection-text-v2-contract.md
+++ b/TreeDB/docs/spec/collection-text-v2-contract.md
@@ -47,15 +47,18 @@ type TextIndexDefinition struct {
 `TextIndexVersion` values:
 
 - `""` / `"v1"`: current per-`(term, documentID)` text index.
-- `"v2"`: explicit v2 physical contract. M1 root-state creation is supported,
-  but v2 search/rollout behavior remains fail-closed until later milestones; it
-  must not silently fall back to v1.
+- `"v2"`: explicit v2 physical contract. M1-M3 root-state creation and
+  writable posting/norm/docmap maintenance are supported. As of M4 (#2627),
+  explicit v2 indexes are readable for exhaustive score-only BM25F serving over
+  posting blocks and packed norms; unsupported future rollout/detailed modes
+  still fail closed and v2 must not silently fall back to v1.
 
 `TextIndexRolloutMode` values:
 
 - `""` / `"primary"`: active production read/write path. V1 remains the default
-  readable/searchable path. Explicit v2 indexes are writable as of M3, but v2
-  search remains fail-closed/non-readable until the v2 executor milestones land.
+  readable/searchable path. Explicit v2 indexes are writable as of M3 and
+  readable as of M4 for score-only BM25F serving over v2 posting/norm/docmap
+  roots. Match details/positions remain deferred to #2629.
 - `"shadow"`: future v2 build/validate without serving reads.
 - `"dual_write"`: future v1+v2 mutation maintenance with explicit read choice.
 - `"disabled"`: future metadata-present but non-serving/non-writing state.
@@ -98,11 +101,14 @@ format record. Explicit `TextIndexVersionV2` creation through `CreateTextIndex`
 publishes all seven v2 root descriptors through the normal collection-root
 system records. Declaring a v2 text index directly in `CreateCollection` is
 rejected because it would create metadata without the required root status
-records. V2 search is still fail-closed until the later executor milestones.
-After M3, `TextIndexStatus` reports `readable=false` and `writable=true` for
-explicit v2 indexes: create/backfill/insert/update/delete maintain durable v2
-roots and posting blocks, but query routing still does not serve from v2. There
-is no fallback to v1 for requested v2.
+records. After M3, explicit v2 indexes maintain durable v2 roots and posting
+blocks for create/backfill/insert/update/delete. As of M4, `TextIndexStatus`
+reports `readable=true` and `writable=true` for explicit v2 indexes: query
+routing serves exhaustive score-only BM25F from v2 posting blocks, packed norm
+blocks, and docmap blocks. Detailed match/position materialization is not yet
+implemented; v2 result rows intentionally carry document ID, rank, score, and
+score kind only unless the caller explicitly asks for bounded final document
+fetch. There is no fallback to v1 for requested v2.
 
 Stable M1 ordinal semantics:
 
@@ -190,9 +196,9 @@ that reuse entry scratch while scanning a block. It does not route
 
 ## M3 streaming write path (#2626)
 
-M3 makes explicit `TextIndexVersionV2` indexes writable while keeping v2 search
-fail-closed until #2627. The write path uses a streaming analyzer sink and
-compact per-field/per-document term accumulators, avoiding the previous token
+M3 makes explicit `TextIndexVersionV2` indexes writable. The write path uses a
+streaming analyzer sink and compact per-field/per-document term accumulators,
+avoiding the previous token
 slice allocation in the hot analyzer path. Backfill emits sealed posting blocks;
 maintained insert/update writes emit append-friendly micro blocks with
 `blockID` in a mutation-generation namespace (currently the high-bit block ID
@@ -210,6 +216,34 @@ retain zero live `df`/`ttf` with non-zero historical posting blocks until normal
 TreeDB root maintenance and later text rewrite/merge remove stale blocks. All
 posting, norm, docmap, docID, term, and status records remain ordinary collection
 root values and continue to use existing value-log/leaf maintenance paths.
+
+## M4 score-only search executor (#2627)
+
+M4 enables explicit v2 indexes for exhaustive score-only BM25F serving. The
+executor analyzes query terms through the streaming analyzer sink, de-duplicates
+and deterministically orders v2 terms, opens posting-block iterators for every
+query term under one TreeDB snapshot, scans posting-block entries, and scores
+current candidates using packed norm blocks and term/field stats from the same
+published v2 root set. It performs no per-candidate v1 text-state root lookup in
+the normal path.
+
+Visibility is generation-based: posting entries whose `(ordinal,generation)` do
+not match the current norm/docmap generation or that map to tombstoned ordinals
+are ignored, so append-only historical blocks from updates/deletes are safe until
+later rewrite/merge compacts them. Doc IDs for ranking tie-breaks and final IDs
+come from v2 docmap blocks. Snapshot-local norm/docmap caches are bounded by the
+number of ordinal blocks touched by the query and are discarded after the search;
+no shared cross-snapshot cache is introduced.
+
+M4 is deliberately exhaustive. It reports `posting_blocks_visited`, keeps
+`posting_blocks_skipped=0`, and does not implement WAND/BMW or scalar pruning;
+those are owned by #2628. V2 candidate generation reports
+`docs_fetched=0`, `match_details_built=0`, `state_lookups=0`, norm-block read
+counts, postings decoded, blocks visited, and candidates scored. Detailed match
+and position materialization remains deferred to #2629. Public v2 `SearchText`
+rows therefore return score-only text results (document ID, rank, score, score
+kind, and optional bounded final documents when `IncludeDocuments` is true), with
+empty match-detail fields by contract.
 
 ## Current v1 path inventory
 

--- a/docs/benchmarks/treedb_text_v2_contract_benchmarks.md
+++ b/docs/benchmarks/treedb_text_v2_contract_benchmarks.md
@@ -56,6 +56,21 @@ GOWORK=off go test ./TreeDB/collections \
   | tee "$OUT/index_insert_search_guardrail.txt"
 ```
 
+M4 also exposes explicit-v2 #2564-shape score-only rows. The v2 text rows use the
+same synthetic #2564 documents and scalar distribution but create the v2 text
+index after insert, because inline v2 metadata is intentionally rejected; the
+existing command-WAL/vector guardrail rows remain the vector no-regression lane.
+
+```sh
+GOWORK=off go test ./TreeDB/collections \
+  -run '^$' \
+  -bench '^BenchmarkIndexInsertSearch2564/(search_text_v2_candidates_no_docs|search_hybrid_v2_no_docs_scalar_filter|search_vector_candidates_no_docs)$' \
+  -benchmem \
+  -benchtime=5x \
+  -count=3 \
+  | tee "$OUT/index_insert_search_v2_guardrail.txt"
+```
+
 Indexed insert/readiness row:
 
 ```sh
@@ -166,11 +181,41 @@ go test ./TreeDB/collections \
 Report text search counters:
 
 - `postings_scanned/search`;
-- `posting_blocks_visited/search` and `posting_blocks_skipped/search` (v1 = 0);
+- `posting_blocks_visited/search` and `posting_blocks_skipped/search` (v1 = 0; M4 v2 exhaustive search reports visited blocks and skipped=0);
 - `candidates_scored/search`;
 - `state_lookups/search` and `norm_lookups/search`;
 - `match_details/search`;
 - `docs_fetched/search`, `full_doc_fallbacks/search`, `fail_closed/search`.
+
+M4 (#2627) adds an explicit v2 score-only search benchmark with the same corpus
+and query cases. It creates a v2 index with `CreateTextIndex`, scans compressed
+posting blocks under one snapshot, scores from norm/docmap blocks, and asserts
+`state_lookups=0`, `match_details=0`, and `docs_fetched=0`:
+
+```sh
+GOWORK=off \
+go test ./TreeDB/collections \
+  -run '^$' \
+  -bench '^BenchmarkTextV2ScoreSearchScale2627/docs_(256|10000)/' \
+  -benchmem \
+  -benchtime=3x \
+  -count=3 \
+  | tee "$OUT/text_v2_score_search_scale_256_10k.txt"
+```
+
+>=100k local artifact:
+
+```sh
+GOWORK=off \
+TREEDB_TEXT_V2_RUN_100K=1 \
+go test ./TreeDB/collections \
+  -run '^$' \
+  -bench '^BenchmarkTextV2ScoreSearchScale2627/docs_100000/' \
+  -benchmem \
+  -benchtime=1x \
+  -count=1 \
+  | tee "$OUT/text_v2_score_search_scale_100k.txt"
+```
 
 ## Concurrent serving/load row
 


### PR DESCRIPTION
Closes #2627.
Parent tracker: #2622.

## Scope

- Enables explicit `TextIndexVersionV2` indexes for exhaustive score-only BM25F serving over v2 posting blocks, packed norm blocks, docmap blocks, and v2 term/field stats.
- Keeps v2 storage B-tree-native: no external assets, no standalone posting files, no separate GC, no vector internals changes.
- Adds snapshot-local norm/docmap block caches; no shared cross-snapshot cache.
- Preserves v1 search behavior and keeps v2 detailed match/position materialization deferred to #2629.

## Contract / behavior

- `TextIndexStatus` for explicit v2 primary indexes is now `ready=true`, `readable=true`, `writable=true` for score-only serving.
- V2 `SearchText` result rows are score-only by contract until #2629: document ID, rank, score, score kind, and optional bounded final documents when `IncludeDocuments=true`; match fields/details are empty.
- `SearchHybridTextCandidates` over v2 returns score-only text candidates with `docs_fetched=0`, `text_state_lookups=0`, and `text_match_details=0`.
- M4 remains exhaustive: `posting_blocks_visited` is reported, `posting_blocks_skipped=0`; WAND/BMW and scalar pruning are #2628.
- Live `df=0` terms skip retained stale posting blocks so historical update/delete blocks do not consume candidate/posting budget.

## Tests

Latest head `fe518f4f5f7bb78d6251e4e948f6f26d40022e0a`:

```sh
git diff --check
GOWORK=off go test ./TreeDB/collections
GOWORK=off go test ./TreeDB/docs
GOWORK=off go test ./TreeDB/...
```

Focused coverage added:

- v1/v2 score and rank parity for deterministic fixtures.
- v2 hybrid no-doc counter guardrails.
- stale generation/tombstone filtering, including stale-only low-budget retained blocks and stale-before-live postings that must not consume `CandidateLimit`.
- missing/corrupt v2 root fail-closed behavior.
- snapshot binding and reopen durability.
- scalar filter smoke through v2 text-only hybrid no-doc row.
- bounded v2 `SearchText(IncludeDocuments=true)` final fetch while preserving score-only match details.
- benchmark guardrail that fails if v2 score-search returns no positive signal.

## Benchmarks / profiles

Artifact root: `/tmp/gomap_2627_v2_search_evidence_20260612_014415`

Context: Apple M3, Go `go1.26.0 darwin/arm64`, local laptop load noted in `context.txt`.

Commands/artifacts:

```sh
# Base e5f4cfccd existing #2564 rows
(cd /tmp/gomap_2627_base_e5f4 && GOWORK=off go test ./TreeDB/collections \
  -run '^$' \
  -bench '^BenchmarkIndexInsertSearch2564/(search_text_candidates_no_docs|search_hybrid_no_docs_scalar_filter|search_vector_candidates_no_docs)$' \
  -benchmem -benchtime=5x -count=3) \
  | tee base_index_insert_search_guardrail.txt

# Candidate latest #2564 rows including explicit-v2 rows
GOWORK=off go test ./TreeDB/collections \
  -run '^$' \
  -bench '^BenchmarkIndexInsertSearch2564/(search_text_candidates_no_docs|search_text_v2_candidates_no_docs|search_hybrid_no_docs_scalar_filter|search_hybrid_v2_no_docs_scalar_filter|search_vector_candidates_no_docs)$' \
  -benchmem -benchtime=5x -count=1 \
  | tee candidate_latest_index_insert_search_guardrail.txt

# v2 rare/common/multi-term scale rows
GOWORK=off go test ./TreeDB/collections \
  -run '^$' \
  -bench '^BenchmarkTextV2ScoreSearchScale2627/docs_(256|10000)/(score_only_common_no_docs|rare_no_docs|multi_term_and_no_docs)$' \
  -benchmem -benchtime=1x -count=1 \
  | tee candidate_text_v2_score_search_scale_256_10k.txt

GOWORK=off TREEDB_TEXT_V2_RUN_100K=1 go test ./TreeDB/collections \
  -run '^$' \
  -bench '^BenchmarkTextV2ScoreSearchScale2627/docs_100000/(rare_no_docs|score_only_common_no_docs|multi_term_and_no_docs)$' \
  -benchmem -benchtime=1x -count=1
```

Representative latest #2564 rows:

| Row | ns/op | B/op | allocs/op | docs | match details | state lookups | norm lookups | posting blocks | postings | scored |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| v1 `search_text_candidates_no_docs` | 141,708 | 109,259 | 879 | 0 | 64 | 128 | 128 | 0 | 256 | 128 |
| v2 `search_text_v2_candidates_no_docs` | 77,950 | 99,459 | 453 | 0 | 0 | 0 | 2 | 2 | 256 | 128 |
| v1 hybrid no-doc scalar+vector | 168,117 | 202,481 | 1,080 | 0 | 64 | 128 | 128 | 0 | 256 | 128 |
| v2 hybrid no-doc scalar text-only guardrail | 77,900 | 122,259 | 537 | 0 | 0 | 0 | 2 | 2 | 256 | 128 |
| vector candidate no-doc guardrail | 18,675 | 40,504 | 83 | 0 | 0 | 0 | 0 | 0 | 0 | 0 |

100k v2 exhaustive rows are intentionally O(df) in M4; #2628 owns WAND/BMW/block-max skipping. All v2 rows keep `docs_fetched=0`, `full_doc_fallbacks=0`, `state_lookups=0`, `match_details=0`.

Profiles:

- `text_v2_2564_cpu.pprof`, `text_v2_2564_cpu_top.txt`
- `text_v2_2564_mem.pprof`, `text_v2_2564_mem_top.txt`

## Review / AI status

- Internal xhigh review passed after one blocking stale-budget finding was fixed.
- Codex reviewed latest head `fe518f4f5` with no major issues.
- CodeRabbit findings were addressed/resolved; latest status is passing.
- Copilot was requested on the mature latest head; no blocking Copilot feedback was posted.

## Risks / deferrals

- V2 match details and positions are intentionally empty/deferred to #2629.
- M4 is exhaustive and does not skip blocks; common-term large-corpus rows remain O(df) until #2628.
- Explicit v2 #2564 rows create the v2 text index after insert because inline v2 metadata remains intentionally rejected; command-WAL/vector guardrail rows stay on existing v1 fixture for vector no-regression evidence.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Text V2 indexes now readable and operational for score-only search, replacing previous fail-closed behavior.
  * Implemented full text V2 search execution with BM25F scoring across indexed documents.

* **Tests**
  * Added comprehensive test coverage for V2 text search including score parity, error handling, and snapshot isolation.

* **Documentation**
  * Updated collection text V2 contract spec with M4 score-only search executor requirements and behavior.
  * Extended benchmarking runbook with V2 performance guardrails and search metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
