### PR TITLE
TreeDB text v2: add exact block-max and scalar pruning

### DIFF
--- a/TreeDB/collections/hybrid_executor.go
+++ b/TreeDB/collections/hybrid_executor.go
@@ -47,7 +47,11 @@ func (c *Collection) searchHybrid(opts HybridSearchOptions) (HybridSearchRespons
 		return hybridSearchFailClosed(response, HybridFailClosedReasonSnapshotMismatch, err)
 	}
 
-	candidates, candidateStats, err := c.hybridSearchCandidates(plan)
+	candidateAllowSet := allowSet
+	if plan.scalarFilterStrategy == HybridScalarFilterStrategyPostfilter {
+		candidateAllowSet = nil
+	}
+	candidates, candidateStats, err := c.hybridSearchCandidates(plan, candidateAllowSet)
 	hybridMergeStats(&response.Stats, candidateStats)
 	if err != nil {
 		return hybridSearchFailClosed(response, hybridStatsFailClosedReason(candidateStats, hybridCandidateErrorFailClosedReason(err)), err)
@@ -305,14 +309,14 @@ func (c *Collection) hybridScalarIndexExists(indexName string) (bool, error) {
 	return ok, nil
 }
 
-func (c *Collection) hybridSearchCandidates(plan hybridSearchExecutionPlan) ([]HybridSearchCandidate, HybridSearchStats, error) {
+func (c *Collection) hybridSearchCandidates(plan hybridSearchExecutionPlan, allowSet hybridScalarAllowSet) ([]HybridSearchCandidate, HybridSearchStats, error) {
 	var out []HybridSearchCandidate
 	var stats HybridSearchStats
 	runText := func() error {
 		if plan.text == nil {
 			return nil
 		}
-		response, err := c.SearchHybridTextCandidates(*plan.text)
+		response, err := c.searchHybridTextCandidates(*plan.text, allowSet)
 		hybridMergeStats(&stats, response.Stats)
 		if err != nil {
 			return hybridCandidateSourceError{source: HybridCandidateSourceText, err: err}
@@ -483,6 +487,8 @@ func hybridMergeStats(dst *HybridSearchStats, src HybridSearchStats) {
 	dst.TextPostingsScanned += src.TextPostingsScanned
 	dst.TextPostingBlocksVisited += src.TextPostingBlocksVisited
 	dst.TextPostingBlocksSkipped += src.TextPostingBlocksSkipped
+	dst.TextBlockMaxFallbacks += src.TextBlockMaxFallbacks
+	dst.TextBlockMaxThresholds += src.TextBlockMaxThresholds
 	dst.TextCandidatesScored += src.TextCandidatesScored
 	dst.TextStateLookups += src.TextStateLookups
 	dst.TextNormLookups += src.TextNormLookups

--- a/TreeDB/collections/hybrid_executor.go
+++ b/TreeDB/collections/hybrid_executor.go
@@ -47,9 +47,9 @@ func (c *Collection) searchHybrid(opts HybridSearchOptions) (HybridSearchRespons
 		return hybridSearchFailClosed(response, HybridFailClosedReasonSnapshotMismatch, err)
 	}
 
-	candidateAllowSet := allowSet
-	if plan.scalarFilterStrategy == HybridScalarFilterStrategyPostfilter {
-		candidateAllowSet = nil
+	var candidateAllowSet hybridScalarAllowSet
+	if plan.scalarFilterStrategy == HybridScalarFilterStrategyPrefilter {
+		candidateAllowSet = allowSet
 	}
 	candidates, candidateStats, err := c.hybridSearchCandidates(plan, candidateAllowSet)
 	hybridMergeStats(&response.Stats, candidateStats)

--- a/TreeDB/collections/hybrid_search.go
+++ b/TreeDB/collections/hybrid_search.go
@@ -234,6 +234,8 @@ type HybridSearchStats struct {
 	TextPostingsScanned        uint64                 `json:"text_postings_scanned,omitempty"`
 	TextPostingBlocksVisited   uint64                 `json:"text_posting_blocks_visited,omitempty"`
 	TextPostingBlocksSkipped   uint64                 `json:"text_posting_blocks_skipped,omitempty"`
+	TextBlockMaxFallbacks      uint64                 `json:"text_block_max_fallbacks,omitempty"`
+	TextBlockMaxThresholds     uint64                 `json:"text_block_max_thresholds,omitempty"`
 	TextCandidatesScored       uint64                 `json:"text_candidates_scored,omitempty"`
 	TextStateLookups           uint64                 `json:"text_state_lookups,omitempty"`
 	TextNormLookups            uint64                 `json:"text_norm_lookups,omitempty"`

--- a/TreeDB/collections/hybrid_text_candidates.go
+++ b/TreeDB/collections/hybrid_text_candidates.go
@@ -12,6 +12,10 @@ import (
 // match attribution, and fails closed if the backing text path reports any full
 // document materialization or scan fallback.
 func (c *Collection) SearchHybridTextCandidates(query HybridTextQuery) (HybridCandidateResponse, error) {
+	return c.searchHybridTextCandidates(query, nil)
+}
+
+func (c *Collection) searchHybridTextCandidates(query HybridTextQuery, allowSet hybridScalarAllowSet) (HybridCandidateResponse, error) {
 	if c == nil {
 		return HybridCandidateResponse{}, errCollectionNil
 	}
@@ -27,10 +31,11 @@ func (c *Collection) SearchHybridTextCandidates(query HybridTextQuery) (HybridCa
 	}
 
 	textResponse, err := c.searchText(TextSearchOptions{
-		IndexName:        query.IndexName,
-		Query:            query.Query,
-		TopK:             requested,
-		IncludeDocuments: false,
+		IndexName:                query.IndexName,
+		Query:                    query.Query,
+		TopK:                     requested,
+		IncludeDocuments:         false,
+		textV2AllowedDocumentIDs: allowSet,
 	}, textSearchResultTextMatchesOnly)
 	if err != nil {
 		response := HybridCandidateResponse{Stats: hybridTextCandidateStatsFromSearch(requested, textResponse.Stats, 0)}
@@ -100,6 +105,8 @@ func hybridTextCandidateStatsFromSearch(requested int, textStats TextSearchStats
 		TextPostingsScanned:       hybridMaxUint64(textStats.TextPostingsScanned, textStats.PostingsScanned),
 		TextPostingBlocksVisited:  textStats.TextPostingBlocksVisited,
 		TextPostingBlocksSkipped:  textStats.TextPostingBlocksSkipped,
+		TextBlockMaxFallbacks:     textStats.TextBlockMaxFallbacks,
+		TextBlockMaxThresholds:    textStats.TextBlockMaxThresholds,
 		TextCandidatesScored:      textCandidatesScored,
 		TextStateLookups:          textStats.TextStateLookups,
 		TextNormLookups:           textStats.TextNormLookups,

--- a/TreeDB/collections/index_insert_search_bench_test.go
+++ b/TreeDB/collections/index_insert_search_bench_test.go
@@ -484,6 +484,8 @@ func indexInsertSearchReportCandidateStats2564(b *testing.B, response HybridCand
 	b.ReportMetric(float64(response.Stats.TextPostingsScanned), "text_postings/search")
 	b.ReportMetric(float64(response.Stats.TextPostingBlocksVisited), "posting_blocks_visited/search")
 	b.ReportMetric(float64(response.Stats.TextPostingBlocksSkipped), "posting_blocks_skipped/search")
+	b.ReportMetric(float64(response.Stats.TextBlockMaxFallbacks), "blockmax_fallbacks/search")
+	b.ReportMetric(float64(response.Stats.TextBlockMaxThresholds), "threshold_updates/search")
 	b.ReportMetric(float64(response.Stats.TextCandidatesScored), "text_scored/search")
 	b.ReportMetric(float64(response.Stats.TextStateLookups), "text_state_lookups/search")
 	b.ReportMetric(float64(response.Stats.TextNormLookups), "text_norm_lookups/search")

--- a/TreeDB/collections/text_index.go
+++ b/TreeDB/collections/text_index.go
@@ -384,6 +384,8 @@ func TextIndexV2RequiredCounterNames() []string {
 		"postings_scanned",
 		"posting_blocks_visited",
 		"posting_blocks_skipped",
+		"blockmax_fallbacks",
+		"threshold_updates",
 		"candidates_scored",
 		"state_lookups",
 		"norm_lookups",

--- a/TreeDB/collections/text_search.go
+++ b/TreeDB/collections/text_search.go
@@ -53,6 +53,13 @@ type TextSearchOptions struct {
 	MaxPostingsScanned   int
 	IncludeDocuments     bool
 	DocumentFetchOptions DocumentFetchOptions
+
+	// textV2AllowedDocumentIDs is an internal, snapshot-bound scalar prefilter
+	// allow-set used by hybrid search. It is intentionally unexported so public
+	// text search cannot accidentally bind to a scalar index outside the hybrid
+	// snapshot checks.
+	textV2AllowedDocumentIDs hybridScalarAllowSet
+	textV2DisableBlockMax    bool
 }
 
 // TextSearchMatch carries matched field/term attribution for a lexical result.
@@ -86,6 +93,8 @@ type TextSearchStats struct {
 	TextPostingsScanned       uint64
 	TextPostingBlocksVisited  uint64
 	TextPostingBlocksSkipped  uint64
+	TextBlockMaxFallbacks     uint64
+	TextBlockMaxThresholds    uint64
 	TextCandidatesScored      uint64
 	TextStateLookups          uint64
 	TextNormLookups           uint64

--- a/TreeDB/collections/text_v2_blockmax_test.go
+++ b/TreeDB/collections/text_v2_blockmax_test.go
@@ -1,0 +1,224 @@
+package collections
+
+import (
+	"errors"
+	"fmt"
+	"math/rand"
+	"strings"
+	"testing"
+)
+
+func TestTextV2BlockMaxSingleTermExactParityAndSkips2628(t *testing.T) {
+	d := openTextV2TestDB(t, t.TempDir(), false)
+	defer func() { _ = d.Close() }()
+	ids, docs := textV2BlockMaxFixtureDocs2628(384, 16)
+	col := createTextSearchCollection2627(t, d, "docs", TextIndexDefinition{
+		Name:    "lexical",
+		Version: TextIndexVersionV2,
+		Fields:  []TextIndexField{{Field: "title", Weight: 5}, {Field: "body"}},
+	}, ids, docs)
+
+	opts := TextSearchOptions{IndexName: "lexical", Query: "refund", TopK: 5, CandidateLimit: len(ids), MaxPostingsScanned: len(ids) * 2}
+	exhaustiveOpts := opts
+	exhaustiveOpts.textV2DisableBlockMax = true
+	exhaustive, err := col.searchText(exhaustiveOpts, textSearchResultScoreOnly)
+	if err != nil {
+		t.Fatalf("exhaustive v2 search: %v", err)
+	}
+	got, err := col.searchText(opts, textSearchResultScoreOnly)
+	if err != nil {
+		t.Fatalf("block-max v2 search: %v", err)
+	}
+	assertTextSearchParity2627(t, got, exhaustive)
+	if got.Stats.TextPostingBlocksSkipped == 0 || got.Stats.TextBlockMaxThresholds == 0 {
+		t.Fatalf("stats=%+v want block skips and threshold updates", got.Stats)
+	}
+	if got.Stats.TextPostingsScanned >= exhaustive.Stats.TextPostingsScanned || got.Stats.TextCandidatesScored >= exhaustive.Stats.TextCandidatesScored {
+		t.Fatalf("block-max stats=%+v exhaustive=%+v want fewer decoded/scored postings", got.Stats, exhaustive.Stats)
+	}
+	if got.Stats.TextStateLookups != 0 || got.Stats.TextMatchDetailsBuilt != 0 || got.Stats.DocumentsFetched != 0 {
+		t.Fatalf("stats=%+v want score-only zero-doc v2 path", got.Stats)
+	}
+}
+
+func TestTextV2BlockMaxRandomizedExactnessAndFallbacks2628(t *testing.T) {
+	for seed := int64(1); seed <= 5; seed++ {
+		seed := seed
+		t.Run(fmt.Sprintf("seed_%d", seed), func(t *testing.T) {
+			rng := rand.New(rand.NewSource(seed))
+			d := openTextV2TestDB(t, t.TempDir(), false)
+			defer func() { _ = d.Close() }()
+			fields := []TextIndexField{{Field: "title", Weight: 1 + float64(seed%4)}, {Field: "body", Weight: 0.5 + float64(seed%3)}}
+			ids := make([][]byte, 192)
+			docs := make([][]byte, 192)
+			rareIDs := make(hybridScalarAllowSet)
+			for i := range ids {
+				ids[i] = []byte(fmt.Sprintf("doc-%03d", i))
+				tenant := "tenant-broad"
+				if i%37 == 0 {
+					tenant = "tenant-rare"
+					rareIDs[string(ids[i])] = struct{}{}
+				}
+				titleTerms := textV2RandomTerms2628(rng, []string{"refund", "policy", "shipping", "chargeback"}, 1+rng.Intn(5))
+				bodyTerms := textV2RandomTerms2628(rng, []string{"refund", "policy", "support", "invoice", "common"}, 2+rng.Intn(9))
+				docs[i] = []byte(fmt.Sprintf(`{"title":"%s","body":"%s","tenant":"%s"}`, titleTerms, bodyTerms, tenant))
+			}
+			col := createTextSearchCollection2627(t, d, "docs", TextIndexDefinition{Name: "lexical", Version: TextIndexVersionV2, Fields: fields}, ids, docs)
+			cases := []struct {
+				name     string
+				opts     TextSearchOptions
+				wantFall bool
+			}{
+				{name: "single_top1", opts: TextSearchOptions{IndexName: "lexical", Query: "refund", TopK: 1, CandidateLimit: len(ids), MaxPostingsScanned: len(ids) * 4}},
+				{name: "single_top7_rare_filter", opts: TextSearchOptions{IndexName: "lexical", Query: "policy", TopK: 7, CandidateLimit: len(ids), MaxPostingsScanned: len(ids) * 4, textV2AllowedDocumentIDs: rareIDs}},
+				{name: "and_fallback", opts: TextSearchOptions{IndexName: "lexical", Query: "refund AND policy", Operator: TextSearchOperatorAND, TopK: 10, CandidateLimit: len(ids), MaxPostingsScanned: len(ids) * 8}, wantFall: true},
+				{name: "or_fallback_filtered", opts: TextSearchOptions{IndexName: "lexical", Query: "refund OR shipping", TopK: 10, CandidateLimit: len(ids), MaxPostingsScanned: len(ids) * 8, textV2AllowedDocumentIDs: rareIDs}, wantFall: true},
+			}
+			for _, tc := range cases {
+				t.Run(tc.name, func(t *testing.T) {
+					exhaustiveOpts := tc.opts
+					exhaustiveOpts.textV2DisableBlockMax = true
+					exhaustive, err := col.searchText(exhaustiveOpts, textSearchResultScoreOnly)
+					if err != nil {
+						t.Fatalf("exhaustive: %v", err)
+					}
+					got, err := col.searchText(tc.opts, textSearchResultScoreOnly)
+					if err != nil {
+						t.Fatalf("block-max/fallback: %v", err)
+					}
+					assertTextSearchParity2627(t, got, exhaustive)
+					if tc.wantFall && got.Stats.TextBlockMaxFallbacks == 0 {
+						t.Fatalf("stats=%+v want exact exhaustive fallback counter", got.Stats)
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestTextV2ScalarFilterPruningEmptyRareBroad2628(t *testing.T) {
+	d := openTextV2TestDB(t, t.TempDir(), false)
+	defer func() { _ = d.Close() }()
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name:    "docs",
+		Indexes: []IndexDefinition{{Name: "tenant", Field: "tenant", ValueType: IndexValueString}},
+	}); err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	col, err := mgr.OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("OpenCollection: %v", err)
+	}
+	ids, docs := textV2BlockMaxScalarDocs2628(384)
+	if _, err := col.InsertBatch(ids, docs); err != nil {
+		t.Fatalf("InsertBatch: %v", err)
+	}
+	if _, _, err := col.CreateTextIndex(TextIndexDefinition{Name: "lexical", Version: TextIndexVersionV2, Fields: []TextIndexField{{Field: "title", Weight: 5}, {Field: "body"}}}); err != nil {
+		t.Fatalf("CreateTextIndex: %v", err)
+	}
+
+	empty, err := col.SearchHybrid(HybridSearchOptions{TopK: 5, Text: &HybridTextQuery{IndexName: "lexical", Query: "refund", CandidateLimit: len(ids)}, ScalarFilter: &HybridScalarFilter{IndexName: "tenant", Value: "tenant-missing"}})
+	if err != nil {
+		t.Fatalf("empty scalar SearchHybrid: %v", err)
+	}
+	if len(empty.Results) != 0 || empty.Stats.TextPostingsScanned != 0 || empty.Stats.FailClosed != 0 {
+		t.Fatalf("empty response=%+v want no text traversal", empty)
+	}
+
+	rare, err := col.SearchHybrid(HybridSearchOptions{TopK: 5, Text: &HybridTextQuery{IndexName: "lexical", Query: "refund", CandidateLimit: len(ids)}, ScalarFilter: &HybridScalarFilter{IndexName: "tenant", Value: "tenant-rare"}})
+	if err != nil {
+		t.Fatalf("rare scalar SearchHybrid: %v", err)
+	}
+	if len(rare.Results) == 0 || rare.Stats.TextPostingBlocksSkipped == 0 || rare.Stats.TextPostingsScanned >= uint64(len(ids)) || rare.Stats.FailClosed != 0 {
+		t.Fatalf("rare response=%+v want scalar block pruning", rare)
+	}
+	rareIDs := map[string]struct{}{"doc-000000": {}, "doc-000001": {}, "doc-000002": {}, "doc-000003": {}}
+	for _, result := range rare.Results {
+		if _, ok := rareIDs[string(result.ID)]; !ok {
+			t.Fatalf("rare result id=%q outside rare tenant set", result.ID)
+		}
+	}
+
+	broad, err := col.SearchHybrid(HybridSearchOptions{TopK: 5, Text: &HybridTextQuery{IndexName: "lexical", Query: "refund", CandidateLimit: len(ids)}, ScalarFilter: &HybridScalarFilter{IndexName: "tenant", Value: "tenant-broad"}})
+	if err != nil {
+		t.Fatalf("broad scalar SearchHybrid: %v", err)
+	}
+	if len(broad.Results) == 0 || broad.Stats.FailClosed != 0 || broad.Stats.ScalarFilterSelectivityPPM == 0 {
+		t.Fatalf("broad response=%+v want successful broad indexed filter", broad)
+	}
+	if rare.Stats.TextPostingsScanned >= broad.Stats.TextPostingsScanned {
+		t.Fatalf("rare stats=%+v broad stats=%+v want rare filter to decode fewer postings", rare.Stats, broad.Stats)
+	}
+}
+
+func TestTextV2BlockMaxCorruptMetadataFailsClosed2628(t *testing.T) {
+	d := openTextV2TestDB(t, t.TempDir(), false)
+	defer func() { _ = d.Close() }()
+	ids, docs := textV2BlockMaxFixtureDocs2628(160, 8)
+	col := createTextSearchCollection2627(t, d, "docs", TextIndexDefinition{Name: "lexical", Version: TextIndexVersionV2, Fields: []TextIndexField{{Field: "title", Weight: 5}, {Field: "body"}}}, ids, docs)
+	rootName := collectionTextV2PostingBlocksRootName("docs", "lexical")
+	blockKey := firstTextV2PostingBlockKeyForTerm2626(t, d, "docs", rootName, "refund")
+	raw := textV2ReadRootBytes2624(t, d, "docs", rootName, blockKey)
+	if len(raw) < textV2PostingBlockChecksumBytes+1 {
+		t.Fatalf("posting block raw too short: %d", len(raw))
+	}
+	corrupt := append([]byte(nil), raw...)
+	corrupt[len(corrupt)-1] ^= 0x7f
+	corruptTextRootValue(t, d, "docs", rootName, blockKey, corrupt)
+
+	got, err := col.searchText(TextSearchOptions{IndexName: "lexical", Query: "refund", TopK: 5, CandidateLimit: len(ids), MaxPostingsScanned: len(ids) * 2}, textSearchResultScoreOnly)
+	if !errors.Is(err, ErrTextIndexUnavailable) || !errors.Is(err, ErrTextIndexStorageCorrupt) {
+		t.Fatalf("SearchText err=%v want unavailable/storage corrupt", err)
+	}
+	if got.Stats.FailClosed != 1 || got.Stats.FailClosedReason != textSearchFailClosedStorageCorrupt || got.Stats.DocumentsFetched != 0 {
+		t.Fatalf("stats=%+v want metadata fail-closed without docs", got.Stats)
+	}
+}
+
+func textV2BlockMaxFixtureDocs2628(count, highDocs int) ([][]byte, [][]byte) {
+	ids := make([][]byte, count)
+	docs := make([][]byte, count)
+	for i := 0; i < count; i++ {
+		ids[i] = []byte(fmt.Sprintf("doc-%06d", i))
+		title := "refund"
+		body := "refund"
+		if i < highDocs {
+			title = strings.Repeat("refund ", 80)
+			body = strings.Repeat("refund ", 160)
+		}
+		docs[i] = []byte(fmt.Sprintf(`{"title":"%s","body":"%s","tenant":"tenant-broad"}`, strings.TrimSpace(title), strings.TrimSpace(body)))
+	}
+	return ids, docs
+}
+
+func textV2BlockMaxScalarDocs2628(count int) ([][]byte, [][]byte) {
+	ids := make([][]byte, count)
+	docs := make([][]byte, count)
+	for i := 0; i < count; i++ {
+		ids[i] = []byte(fmt.Sprintf("doc-%06d", i))
+		tenant := "tenant-broad"
+		if i < 4 {
+			tenant = "tenant-rare"
+		}
+		title := "refund"
+		body := "refund policy support"
+		if i < 8 {
+			title = strings.Repeat("refund ", 80)
+			body = strings.Repeat("refund ", 160)
+		}
+		docs[i] = []byte(fmt.Sprintf(`{"title":"%s","body":"%s","tenant":"%s"}`, strings.TrimSpace(title), strings.TrimSpace(body), tenant))
+	}
+	return ids, docs
+}
+
+func textV2RandomTerms2628(rng *rand.Rand, terms []string, count int) string {
+	out := make([]string, count)
+	for i := range out {
+		out[i] = terms[rng.Intn(len(terms))]
+		if rng.Intn(11) == 0 {
+			out[i] += " " + terms[rng.Intn(len(terms))]
+		}
+	}
+	return strings.Join(out, " ")
+}

--- a/TreeDB/collections/text_v2_blockmax_test.go
+++ b/TreeDB/collections/text_v2_blockmax_test.go
@@ -3,6 +3,7 @@ package collections
 import (
 	"errors"
 	"fmt"
+	"math"
 	"math/rand"
 	"strings"
 	"testing"
@@ -152,6 +153,86 @@ func TestTextV2ScalarFilterPruningEmptyRareBroad2628(t *testing.T) {
 	}
 }
 
+func TestTextV2HybridUnionFusionPreservesUnfilteredTextRanks2628(t *testing.T) {
+	d := openTextV2TestDB(t, t.TempDir(), false)
+	defer func() { _ = d.Close() }()
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name:    "docs",
+		Indexes: []IndexDefinition{{Name: "tenant", Field: "tenant", ValueType: IndexValueString}},
+	}); err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	col, err := mgr.OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("OpenCollection: %v", err)
+	}
+	ids, docs := textV2HybridUnionFusionDocs2628(384)
+	if _, err := col.InsertBatch(ids, docs); err != nil {
+		t.Fatalf("InsertBatch: %v", err)
+	}
+	if _, _, err := col.CreateTextIndex(TextIndexDefinition{Name: "lexical", Version: TextIndexVersionV2, Fields: []TextIndexField{{Field: "title"}}}); err != nil {
+		t.Fatalf("CreateTextIndex: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+
+	textQuery := HybridTextQuery{IndexName: "lexical", Query: "refund", CandidateLimit: 4}
+	unfilteredText, err := col.SearchHybridTextCandidates(textQuery)
+	if err != nil {
+		t.Fatalf("SearchHybridTextCandidates unfiltered: %v", err)
+	}
+	unfilteredRank := hybridCandidateSourceRank2628(t, unfilteredText.Candidates, "doc-000002", HybridCandidateSourceText)
+	if unfilteredRank != 3 {
+		t.Fatalf("unfiltered text candidates=%+v want doc-000002 at source rank 3", unfilteredText.Candidates)
+	}
+
+	baseOpts := HybridSearchOptions{
+		TopK: 1,
+		Text: &textQuery,
+		ScalarFilter: &HybridScalarFilter{
+			IndexName: "tenant",
+			Value:     "tenant-rare",
+		},
+	}
+	unionOpts := baseOpts
+	unionOpts.ScalarFilterStrategy = HybridScalarFilterStrategyUnionFusion
+	union, err := col.SearchHybrid(unionOpts)
+	if err != nil {
+		t.Fatalf("SearchHybrid union_fusion scalar: %v", err)
+	}
+	if union.Plan.ScalarFilterStrategy != HybridScalarFilterStrategyUnionFusion || len(union.Results) != 1 || string(union.Results[0].ID) != "doc-000002" {
+		t.Fatalf("union_fusion response=%+v want rare doc with explicit union_fusion", union)
+	}
+	unionText := hybridResultSourceContribution2628(t, union.Results[0], HybridCandidateSourceText)
+	if unionText.SourceRank != unfilteredRank {
+		t.Fatalf("union_fusion text source rank=%d want unfiltered rank %d; result=%+v", unionText.SourceRank, unfilteredRank, union.Results[0])
+	}
+	wantTextFusion := 1 / float64(HybridFusionDefaultRRFK+unfilteredRank)
+	if math.Abs(unionText.FusionScore-wantTextFusion) > 1e-12 {
+		t.Fatalf("union_fusion text contribution=%+v want fusion score %.12f", unionText, wantTextFusion)
+	}
+	if math.Abs(union.Results[0].FusedScore-wantTextFusion) > 1e-12 {
+		t.Fatalf("union_fusion fused score=%.12f want %.12f from unfiltered text rank result=%+v", union.Results[0].FusedScore, wantTextFusion, union.Results[0])
+	}
+
+	prefilter, err := col.SearchHybrid(baseOpts)
+	if err != nil {
+		t.Fatalf("SearchHybrid default prefilter scalar: %v", err)
+	}
+	if prefilter.Plan.ScalarFilterStrategy != HybridScalarFilterStrategyPrefilter || len(prefilter.Results) != 1 || string(prefilter.Results[0].ID) != "doc-000002" {
+		t.Fatalf("prefilter response=%+v want rare doc with default prefilter", prefilter)
+	}
+	prefilterText := hybridResultSourceContribution2628(t, prefilter.Results[0], HybridCandidateSourceText)
+	if prefilterText.SourceRank != 1 {
+		t.Fatalf("prefilter text source rank=%d want rank within scalar-pruned text source; result=%+v", prefilterText.SourceRank, prefilter.Results[0])
+	}
+	if prefilter.Stats.ScalarPrefilterIDs != 1 || prefilter.Stats.TextPostingBlocksSkipped == 0 || prefilter.Stats.TextCandidatesScored != 1 || prefilter.Stats.TextCandidatesScored >= union.Stats.TextCandidatesScored {
+		t.Fatalf("prefilter stats=%+v union stats=%+v want scalar text pruning counters only for prefilter", prefilter.Stats, union.Stats)
+	}
+}
+
 func TestTextV2BlockMaxCorruptMetadataFailsClosed2628(t *testing.T) {
 	d := openTextV2TestDB(t, t.TempDir(), false)
 	defer func() { _ = d.Close() }()
@@ -210,6 +291,52 @@ func textV2BlockMaxScalarDocs2628(count int) ([][]byte, [][]byte) {
 		docs[i] = []byte(fmt.Sprintf(`{"title":"%s","body":"%s","tenant":"%s"}`, strings.TrimSpace(title), strings.TrimSpace(body), tenant))
 	}
 	return ids, docs
+}
+
+func textV2HybridUnionFusionDocs2628(count int) ([][]byte, [][]byte) {
+	ids := make([][]byte, count)
+	docs := make([][]byte, count)
+	for i := 0; i < count; i++ {
+		ids[i] = []byte(fmt.Sprintf("doc-%06d", i))
+		tenant := "tenant-broad"
+		if i == 2 {
+			tenant = "tenant-rare"
+		}
+		titleRepeats := 1
+		switch i {
+		case 0:
+			titleRepeats = 48
+		case 1:
+			titleRepeats = 24
+		case 2:
+			titleRepeats = 6
+		}
+		title := strings.TrimSpace(strings.Repeat("refund ", titleRepeats))
+		docs[i] = []byte(fmt.Sprintf(`{"title":%q,"tenant":%q}`, title, tenant))
+	}
+	return ids, docs
+}
+
+func hybridCandidateSourceRank2628(tb testing.TB, candidates []HybridSearchCandidate, id string, source HybridCandidateSource) int {
+	tb.Helper()
+	for _, candidate := range candidates {
+		if string(candidate.ID) == id && candidate.Source == source {
+			return candidate.SourceRank
+		}
+	}
+	tb.Fatalf("missing %s candidate %q in %+v", source, id, candidates)
+	return 0
+}
+
+func hybridResultSourceContribution2628(tb testing.TB, result HybridSearchResult, source HybridCandidateSource) HybridSourceContribution {
+	tb.Helper()
+	for _, contribution := range result.Sources {
+		if contribution.Source == source {
+			return contribution
+		}
+	}
+	tb.Fatalf("missing %s contribution in result %+v", source, result)
+	return HybridSourceContribution{}
 }
 
 func textV2RandomTerms2628(rng *rand.Rand, terms []string, count int) string {

--- a/TreeDB/collections/text_v2_contract_bench_test.go
+++ b/TreeDB/collections/text_v2_contract_bench_test.go
@@ -47,6 +47,8 @@ func TestTextV2ContractBenchmarkMatrix2623(t *testing.T) {
 		"postings_scanned",
 		"posting_blocks_visited",
 		"posting_blocks_skipped",
+		"blockmax_fallbacks",
+		"threshold_updates",
 		"candidates_scored",
 		"state_lookups",
 		"norm_lookups",
@@ -505,6 +507,155 @@ func BenchmarkTextV2ScoreSearchScale2627(b *testing.B) {
 	}
 }
 
+func BenchmarkTextV2BlockMaxCommonTerm2628(b *testing.B) {
+	docs := textV2ContractEnvInt2623("TREEDB_TEXT_V2_BLOCKMAX_DOCS", 10_000)
+	if docs < int(textV2PostingBlockTargetPostings)*3 {
+		docs = int(textV2PostingBlockTargetPostings) * 3
+	}
+	d, col := openTextV2BlockMaxBenchFixture2628(b, docs)
+	defer func() { _ = d.Close() }()
+	opts := TextSearchOptions{IndexName: textV2ContractIndexName2623, Query: "refund", TopK: 10, CandidateLimit: docs, MaxPostingsScanned: docs * 2}
+	modes := []struct {
+		name       string
+		disableBMW bool
+	}{
+		{name: "blockmax_common_topk"},
+		{name: "exhaustive_common_topk", disableBMW: true},
+	}
+	for _, mode := range modes {
+		mode := mode
+		b.Run(mode.name, func(b *testing.B) {
+			runOpts := opts
+			runOpts.textV2DisableBlockMax = mode.disableBMW
+			warm, err := col.searchText(runOpts, textSearchResultScoreOnly)
+			if err != nil {
+				b.Fatalf("warm search: %v", err)
+			}
+			if len(warm.Results) == 0 || warm.Stats.DocumentsFetched != 0 || warm.Stats.FullDocumentScanFallbacks != 0 || warm.Stats.FailClosed != 0 || warm.Stats.TextStateLookups != 0 || warm.Stats.TextMatchDetailsBuilt != 0 {
+				b.Fatalf("warm stats=%+v results=%d want score-only zero-doc blockmax search", warm.Stats, len(warm.Results))
+			}
+			b.ReportAllocs()
+			b.ResetTimer()
+			var sink TextSearchResponse
+			for i := 0; i < b.N; i++ {
+				got, err := col.searchText(runOpts, textSearchResultScoreOnly)
+				if err != nil {
+					b.Fatalf("SearchText: %v", err)
+				}
+				if len(got.Results) == 0 || got.Stats.DocumentsFetched != 0 || got.Stats.FullDocumentScanFallbacks != 0 || got.Stats.FailClosed != 0 || got.Stats.TextStateLookups != 0 || got.Stats.TextMatchDetailsBuilt != 0 {
+					b.Fatalf("stats=%+v results=%d want score-only zero-doc blockmax search", got.Stats, len(got.Results))
+				}
+				sink = got
+			}
+			b.StopTimer()
+			b.ReportMetric(float64(docs), "docs_fixture")
+			b.ReportMetric(float64(opts.TopK), "topk/search")
+			textV2ContractReportTextStats2623(b, sink)
+		})
+	}
+}
+
+func BenchmarkTextV2BlockMaxConcurrentServing2628(b *testing.B) {
+	docs := textV2ContractEnvInt2623("TREEDB_TEXT_V2_BLOCKMAX_CONCURRENT_DOCS", 10_000)
+	readers := textV2ContractEnvInt2623("TREEDB_TEXT_V2_BLOCKMAX_CONCURRENT_READERS", 4)
+	if docs < int(textV2PostingBlockTargetPostings)*3 {
+		docs = int(textV2PostingBlockTargetPostings) * 3
+	}
+	if readers < 1 {
+		readers = 1
+	}
+	d, col := openTextV2BlockMaxBenchFixture2628(b, docs)
+	defer func() { _ = d.Close() }()
+	opts := TextSearchOptions{IndexName: textV2ContractIndexName2623, Query: "refund", TopK: 10, CandidateLimit: docs, MaxPostingsScanned: docs * 2}
+	warm, err := col.searchText(opts, textSearchResultScoreOnly)
+	if err != nil {
+		b.Fatalf("warm blockmax search: %v", err)
+	}
+	if warm.Stats.TextPostingBlocksSkipped == 0 || warm.Stats.DocumentsFetched != 0 || warm.Stats.FailClosed != 0 {
+		b.Fatalf("warm stats=%+v want skipped score-only search", warm.Stats)
+	}
+	durations := make([]int64, b.N)
+	b.ReportAllocs()
+	b.ResetTimer()
+	var wg sync.WaitGroup
+	var firstErr error
+	var errMu sync.Mutex
+	next := 0
+	var nextMu sync.Mutex
+	for worker := 0; worker < readers; worker++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				nextMu.Lock()
+				idx := next
+				next++
+				nextMu.Unlock()
+				if idx >= b.N {
+					return
+				}
+				start := time.Now()
+				got, err := col.searchText(opts, textSearchResultScoreOnly)
+				durations[idx] = time.Since(start).Nanoseconds()
+				if err != nil || got.Stats.TextPostingBlocksSkipped == 0 || got.Stats.DocumentsFetched != 0 || got.Stats.FullDocumentScanFallbacks != 0 || got.Stats.FailClosed != 0 {
+					errMu.Lock()
+					if firstErr == nil {
+						if err != nil {
+							firstErr = err
+						} else {
+							firstErr = fmt.Errorf("unexpected stats: %+v", got.Stats)
+						}
+					}
+					errMu.Unlock()
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	b.StopTimer()
+	if firstErr != nil {
+		b.Fatalf("concurrent blockmax search: %v", firstErr)
+	}
+	b.ReportMetric(float64(docs), "docs_fixture")
+	b.ReportMetric(float64(readers), "readers")
+	b.ReportMetric(1, "cache_warm")
+	if len(durations) > 0 {
+		sort.Slice(durations, func(i, j int) bool { return durations[i] < durations[j] })
+		b.ReportMetric(float64(textV2ContractPercentile2623(durations, 50)), "p50_ns/search")
+		b.ReportMetric(float64(textV2ContractPercentile2623(durations, 95)), "p95_ns/search")
+		b.ReportMetric(float64(textV2ContractPercentile2623(durations, 99)), "p99_ns/search")
+	}
+	var ms runtime.MemStats
+	runtime.ReadMemStats(&ms)
+	b.ReportMetric(float64(ms.HeapAlloc), "steady_heap_bytes")
+}
+
+func openTextV2BlockMaxBenchFixture2628(tb testing.TB, docs int) (*backenddb.DB, *Collection) {
+	tb.Helper()
+	d := openTextV2ContractDB2623(tb)
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "docs"}); err != nil {
+		_ = d.Close()
+		tb.Fatalf("CreateCollection: %v", err)
+	}
+	col, err := mgr.OpenCollection("docs")
+	if err != nil {
+		_ = d.Close()
+		tb.Fatalf("OpenCollection: %v", err)
+	}
+	ids, rawDocs := textV2BlockMaxFixtureDocs2628(docs, maxTextV2ContractInt2623(16, docs/8))
+	if _, err := col.InsertBatch(ids, rawDocs); err != nil {
+		_ = d.Close()
+		tb.Fatalf("InsertBatch fixture: %v", err)
+	}
+	if _, _, err := col.CreateTextIndex(textV2ContractV2IndexDefinition2626()); err != nil {
+		_ = d.Close()
+		tb.Fatalf("CreateTextIndex v2 fixture: %v", err)
+	}
+	return d, col
+}
+
 func BenchmarkTextV2ContractConcurrentServing2623(b *testing.B) {
 	docs := textV2ContractEnvInt2623("TREEDB_TEXT_V2_CONCURRENT_DOCS", 256)
 	readers := textV2ContractEnvInt2623("TREEDB_TEXT_V2_CONCURRENT_READERS", 4)
@@ -850,6 +1001,8 @@ func textV2ContractReportTextStats2623(b *testing.B, response TextSearchResponse
 	b.ReportMetric(float64(stats.TextPostingsScanned), "postings_scanned/search")
 	b.ReportMetric(float64(stats.TextPostingBlocksVisited), "posting_blocks_visited/search")
 	b.ReportMetric(float64(stats.TextPostingBlocksSkipped), "posting_blocks_skipped/search")
+	b.ReportMetric(float64(stats.TextBlockMaxFallbacks), "blockmax_fallbacks/search")
+	b.ReportMetric(float64(stats.TextBlockMaxThresholds), "threshold_updates/search")
 	b.ReportMetric(float64(stats.TextCandidatesScored), "candidates_scored/search")
 	b.ReportMetric(float64(stats.TextStateLookups), "state_lookups/search")
 	b.ReportMetric(float64(stats.TextNormLookups), "norm_lookups/search")

--- a/TreeDB/collections/text_v2_posting_blocks.go
+++ b/TreeDB/collections/text_v2_posting_blocks.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
+	"hash/crc32"
 	"math"
 	"slices"
 
@@ -13,7 +14,9 @@ import (
 const (
 	textV2KeyKindPostingBlock byte = 0x21
 
-	textV2PostingBlockValueVersion byte = 1
+	textV2PostingBlockValueVersionV1 byte = 1
+	textV2PostingBlockValueVersion   byte = 2
+	textV2PostingBlockChecksumBytes       = 4
 
 	// textV2PostingBlockTargetPostings keeps ordinary sealed blocks small enough
 	// to stay cache-local in B-tree leaves. The root storage policy still owns the
@@ -187,6 +190,9 @@ func encodeTextV2PostingBlockValue(value textV2PostingBlockValue) []byte {
 		}
 		prev = entry.Ordinal
 	}
+	var checksum [textV2PostingBlockChecksumBytes]byte
+	binary.BigEndian.PutUint32(checksum[:], crc32.ChecksumIEEE(out))
+	out = append(out, checksum[:]...)
 	return out
 }
 
@@ -288,16 +294,17 @@ func buildTextV2PostingBlockKVs(term string, entries []textV2PostingBlockEntry, 
 }
 
 type textV2PostingBlockEntryScanner struct {
-	block           textV2PostingBlockValue
-	cur             textCursor
-	remaining       uint32
-	seen            uint32
-	prevOrdinal     uint64
-	fieldScratch    []uint32
-	computed        textV2PostingBlockSummary
-	computedFieldTF []uint32
-	err             error
-	finished        bool
+	block            textV2PostingBlockValue
+	cur              textCursor
+	remaining        uint32
+	seen             uint32
+	prevOrdinal      uint64
+	fieldScratch     []uint32
+	computed         textV2PostingBlockSummary
+	computedFieldTF  []uint32
+	checksumVerified bool
+	err              error
+	finished         bool
 }
 
 func newTextV2PostingBlockEntryScanner(raw []byte, scratch []uint32) (*textV2PostingBlockEntryScanner, error) {
@@ -307,10 +314,25 @@ func newTextV2PostingBlockEntryScanner(raw []byte, scratch []uint32) (*textV2Pos
 	if len(raw) > textV2PostingBlockMaxValueBytes {
 		return nil, errMalformedTextStorage("text-v2 posting block value bytes %d exceed max %d", len(raw), textV2PostingBlockMaxValueBytes)
 	}
-	if raw[0] != textV2PostingBlockValueVersion {
+	valueVersion := raw[0]
+	if valueVersion != textV2PostingBlockValueVersion && valueVersion != textV2PostingBlockValueVersionV1 {
 		return nil, errUnsupportedTextStorageVersion("text-v2 posting block value", raw[0])
 	}
-	cur := textCursor{buf: raw[1:]}
+	payloadEnd := len(raw)
+	checksumVerified := false
+	if valueVersion == textV2PostingBlockValueVersion {
+		if len(raw) <= textV2PostingBlockChecksumBytes {
+			return nil, errMalformedTextStorage("short text-v2 posting block checksum")
+		}
+		payloadEnd -= textV2PostingBlockChecksumBytes
+		wantChecksum := binary.BigEndian.Uint32(raw[payloadEnd:])
+		gotChecksum := crc32.ChecksumIEEE(raw[:payloadEnd])
+		if gotChecksum != wantChecksum {
+			return nil, errMalformedTextStorage("text-v2 posting block checksum mismatch")
+		}
+		checksumVerified = true
+	}
+	cur := textCursor{buf: raw[1:payloadEnd]}
 	formatVersion, err := cur.readUvarint()
 	if err != nil {
 		return nil, errMalformedTextStorage("text-v2 posting block format version: %v", err)
@@ -425,11 +447,12 @@ func newTextV2PostingBlockEntryScanner(raw []byte, scratch []uint32) (*textV2Pos
 				UpperBoundKind:          upperBoundKind,
 			},
 		},
-		cur:             cur,
-		remaining:       docCount,
-		prevOrdinal:     blockStart - 1,
-		fieldScratch:    scratch[:fieldCount],
-		computedFieldTF: make([]uint32, fieldCount),
+		cur:              cur,
+		remaining:        docCount,
+		prevOrdinal:      blockStart - 1,
+		fieldScratch:     scratch[:fieldCount],
+		computedFieldTF:  make([]uint32, fieldCount),
+		checksumVerified: checksumVerified,
 	}, nil
 }
 
@@ -447,6 +470,10 @@ func (s *textV2PostingBlockEntryScanner) Block() textV2PostingBlockValue {
 	block := s.block
 	block.Summary = cloneTextV2PostingBlockSummary(block.Summary)
 	return block
+}
+
+func (s *textV2PostingBlockEntryScanner) ChecksumVerified() bool {
+	return s != nil && s.checksumVerified
 }
 
 func (s *textV2PostingBlockEntryScanner) Next(dst *textV2PostingBlockEntry) bool {
@@ -720,7 +747,7 @@ func estimateTextV2PostingBlockValueLen(value textV2PostingBlockValue, entries [
 	for _, entry := range entries {
 		n += 3*binary.MaxVarintLen64 + 1 + len(entry.FieldFrequencies)*binary.MaxVarintLen64
 	}
-	return n + len(value.Summary.MaxFieldTermFrequencies)
+	return n + len(value.Summary.MaxFieldTermFrequencies) + textV2PostingBlockChecksumBytes
 }
 
 func cloneTextV2PostingBlockEntries(entries []textV2PostingBlockEntry) []textV2PostingBlockEntry {

--- a/TreeDB/collections/text_v2_search.go
+++ b/TreeDB/collections/text_v2_search.go
@@ -14,6 +14,7 @@ import (
 type textV2SearchContext struct {
 	collectionName        string
 	indexName             string
+	docIDRootName         string
 	termsRootName         string
 	postingBlocksRootName string
 	normBlocksRootName    string
@@ -162,6 +163,78 @@ type textV2SearchDocMapEntry struct {
 
 func (e textV2SearchDocMapEntry) tombstoned() bool { return e.Flags&textV2DocFlagTombstone != 0 }
 
+type textV2SearchOrdinalAllowSet struct {
+	ordinals map[uint64]struct{}
+	sorted   []uint64
+}
+
+func (s *textV2SearchOrdinalAllowSet) empty() bool {
+	return s != nil && len(s.sorted) == 0
+}
+
+func (s *textV2SearchOrdinalAllowSet) contains(ordinal uint64) bool {
+	if s == nil {
+		return true
+	}
+	_, ok := s.ordinals[ordinal]
+	return ok
+}
+
+func (s *textV2SearchOrdinalAllowSet) intersects(first, last uint64) bool {
+	if s == nil {
+		return true
+	}
+	if first > last || len(s.sorted) == 0 {
+		return false
+	}
+	i := sort.Search(len(s.sorted), func(i int) bool { return s.sorted[i] >= first })
+	return i < len(s.sorted) && s.sorted[i] <= last
+}
+
+type textV2SearchTopCandidate struct {
+	ordinal    uint64
+	documentID []byte
+	score      float64
+}
+
+type textV2SearchTopK struct {
+	limit      int
+	candidates []textV2SearchTopCandidate
+}
+
+func (t *textV2SearchTopK) threshold() (float64, bool) {
+	if t == nil || t.limit <= 0 || len(t.candidates) < t.limit {
+		return 0, false
+	}
+	return t.candidates[len(t.candidates)-1].score, true
+}
+
+func (t *textV2SearchTopK) add(candidate textV2SearchTopCandidate) bool {
+	if t == nil || t.limit <= 0 {
+		return false
+	}
+	if len(t.candidates) == t.limit && !textV2TopCandidateLess(candidate, t.candidates[len(t.candidates)-1]) {
+		return false
+	}
+	pos := sort.Search(len(t.candidates), func(i int) bool { return textV2TopCandidateLess(candidate, t.candidates[i]) })
+	if len(t.candidates) < t.limit {
+		t.candidates = append(t.candidates, textV2SearchTopCandidate{})
+		copy(t.candidates[pos+1:], t.candidates[pos:])
+		t.candidates[pos] = candidate
+		return len(t.candidates) == t.limit && pos < len(t.candidates)-1
+	}
+	copy(t.candidates[pos+1:], t.candidates[pos:len(t.candidates)-1])
+	t.candidates[pos] = candidate
+	return true
+}
+
+func textV2TopCandidateLess(a, b textV2SearchTopCandidate) bool {
+	if a.score != b.score {
+		return a.score > b.score
+	}
+	return bytes.Compare(a.documentID, b.documentID) < 0
+}
+
 func executeTextV2SearchAtSnapshot(
 	c *Collection,
 	snap *backenddb.Snapshot,
@@ -182,6 +255,20 @@ func executeTextV2SearchAtSnapshot(
 		response.Results = []TextSearchResult{}
 		return response, nil
 	}
+	allowSet, err := newTextV2SearchOrdinalAllowSet(snap, catalog, ctx, opts.textV2AllowedDocumentIDs)
+	if err != nil {
+		return textSearchFailClosed(response, textSearchFailClosedStorageCorrupt, err)
+	}
+	if allowSet.empty() {
+		response.Results = []TextSearchResult{}
+		return response, nil
+	}
+	if !opts.textV2DisableBlockMax && operator == TextSearchOperatorOR && len(terms) == 1 {
+		return executeTextV2BlockMaxSearchAtSnapshot(c, snap, catalog, ctx, idx, opts, terms[0], allowSet, candidateLimit, maxPostingsScanned, resultMode, response)
+	}
+	if !opts.textV2DisableBlockMax {
+		response.Stats.TextBlockMaxFallbacks++
+	}
 
 	candidates := make(map[uint64]*textV2SearchCandidate)
 	cache := textV2SearchBlockCache{}
@@ -189,7 +276,7 @@ func executeTextV2SearchAtSnapshot(
 	scanStart := time.Now()
 	for i, term := range scanTerms {
 		allowNewCandidates := operator != TextSearchOperatorAND || i == 0
-		truncated, err := scanTextV2SearchPostingBlocksTerm(snap, catalog, ctx, &cache, term, candidates, allowNewCandidates, candidateLimit, maxPostingsScanned, &response.Stats)
+		truncated, err := scanTextV2SearchPostingBlocksTerm(snap, catalog, ctx, &cache, term, candidates, allowNewCandidates, candidateLimit, maxPostingsScanned, allowSet, &response.Stats)
 		if err != nil {
 			return textSearchFailClosed(response, textSearchFailClosedStorageCorrupt, err)
 		}
@@ -323,6 +410,7 @@ func newTextV2SearchContext(snap *backenddb.Snapshot, catalog *collectionCatalog
 	ctx := &textV2SearchContext{
 		collectionName:        catalog.meta.Name,
 		indexName:             idx.Name,
+		docIDRootName:         collectionTextV2DocIDRootName(catalog.meta.Name, idx.Name),
 		termsRootName:         termsRootName,
 		postingBlocksRootName: collectionTextV2PostingBlocksRootName(catalog.meta.Name, idx.Name),
 		normBlocksRootName:    collectionTextV2NormBlocksRootName(catalog.meta.Name, idx.Name),
@@ -395,6 +483,225 @@ func validateTextV2SearchRootFormat(snap *backenddb.Snapshot, catalog *collectio
 	return nil
 }
 
+func newTextV2SearchOrdinalAllowSet(snap *backenddb.Snapshot, catalog *collectionCatalog, ctx *textV2SearchContext, allowedIDs hybridScalarAllowSet) (*textV2SearchOrdinalAllowSet, error) {
+	if allowedIDs == nil {
+		return nil, nil
+	}
+	ids := make([]string, 0, len(allowedIDs))
+	for id := range allowedIDs {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	set := &textV2SearchOrdinalAllowSet{ordinals: make(map[uint64]struct{}, len(ids)), sorted: make([]uint64, 0, len(ids))}
+	for _, id := range ids {
+		doc, ok, err := readTextV2DocIDAtRoot(snap, catalog, ctx.docIDRootName, []byte(id))
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			return nil, errMalformedTextStorage("missing text-v2 docid mapping for scalar-filtered document %q", id)
+		}
+		if doc.Ordinal >= ctx.status.NextOrdinal || doc.Generation > ctx.status.DocMapGeneration || doc.tombstoned() {
+			return nil, errMalformedTextStorage("text-v2 docid mapping for scalar-filtered document %q outside status snapshot", id)
+		}
+		if _, exists := set.ordinals[doc.Ordinal]; !exists {
+			set.ordinals[doc.Ordinal] = struct{}{}
+			set.sorted = append(set.sorted, doc.Ordinal)
+		}
+	}
+	slices.Sort(set.sorted)
+	return set, nil
+}
+
+func executeTextV2BlockMaxSearchAtSnapshot(
+	c *Collection,
+	snap *backenddb.Snapshot,
+	catalog *collectionCatalog,
+	ctx *textV2SearchContext,
+	idx TextIndexDefinition,
+	opts TextSearchOptions,
+	term string,
+	allowSet *textV2SearchOrdinalAllowSet,
+	candidateLimit, maxPostingsScanned int,
+	resultMode textSearchResultMode,
+	response TextSearchResponse,
+) (TextSearchResponse, error) {
+	termStats := ctx.termStats[term]
+	if termStats.DocumentFrequency == 0 {
+		response.Results = []TextSearchResult{}
+		return response, nil
+	}
+	if termStats.PostingBlockCount == 0 {
+		return textSearchFailClosed(response, textSearchFailClosedStorageCorrupt, errMalformedTextStorage("text-v2 term %q document frequency %d has no posting blocks", term, termStats.DocumentFrequency))
+	}
+	prefix := encodeTextV2PostingBlockTermPrefix(term)
+	it, err := collectionIteratorAtCatalogRoot(snap, catalog, ctx.postingBlocksRootName, prefix, textSearchPrefixEnd(prefix), true)
+	if err != nil {
+		return textSearchFailClosed(response, textSearchFailClosedStorageCorrupt, err)
+	}
+	if it == nil {
+		return textSearchFailClosed(response, textSearchFailClosedStorageCorrupt, errMalformedTextStorage("text-v2 term %q has posting block count %d but missing posting root", term, termStats.PostingBlockCount))
+	}
+	defer func() { _ = it.Close() }()
+
+	baseStats := response.Stats
+	cache := textV2SearchBlockCache{}
+	top := textV2SearchTopK{limit: opts.TopK, candidates: make([]textV2SearchTopCandidate, 0, opts.TopK)}
+	seenCurrent := make(map[uint64]uint64)
+	fieldCount := len(ctx.fieldNames)
+	var scratch []uint32
+	var blocksSeen uint64
+	scanStart := time.Now()
+	for it.Valid() {
+		keyBytes := it.UnsafeKey()
+		if !bytes.HasPrefix(keyBytes, prefix) {
+			break
+		}
+		if it.IsDeleted() {
+			it.Next()
+			continue
+		}
+		key, err := decodeTextV2PostingBlockKeyForPrefix(keyBytes, prefix)
+		if err != nil {
+			return textSearchFailClosed(response, textSearchFailClosedStorageCorrupt, err)
+		}
+		scanner, err := newTextV2PostingBlockEntryScanner(it.UnsafeValue(), scratch)
+		if err != nil {
+			return textSearchFailClosed(response, textSearchFailClosedStorageCorrupt, err)
+		}
+		if scanner.block.BlockStart != key.BlockStart || scanner.block.BlockID != key.BlockID {
+			return textSearchFailClosed(response, textSearchFailClosedStorageCorrupt, errMalformedTextStorage("text-v2 posting block key/value identity mismatch"))
+		}
+		if len(scanner.block.Summary.MaxFieldTermFrequencies) != fieldCount {
+			return textSearchFailClosed(response, textSearchFailClosedStorageCorrupt, errMalformedTextStorage("text-v2 posting block field count %d want %d", len(scanner.block.Summary.MaxFieldTermFrequencies), fieldCount))
+		}
+		if !scanner.ChecksumVerified() {
+			fallback := response
+			fallback.Stats = baseStats
+			fallback.Stats.TextBlockMaxFallbacks++
+			fallbackOpts := opts
+			fallbackOpts.textV2DisableBlockMax = true
+			return executeTextV2SearchAtSnapshot(c, snap, catalog, idx, fallbackOpts, []string{term}, TextSearchOperatorOR, candidateLimit, maxPostingsScanned, resultMode, fallback)
+		}
+		blocksSeen++
+		if allowSet != nil && !allowSet.intersects(scanner.block.Summary.FirstOrdinal, scanner.block.Summary.LastOrdinal) {
+			response.Stats.TextPostingBlocksSkipped++
+			it.Next()
+			continue
+		}
+		blockUpperBound, err := textV2SearchBlockUpperBound(term, scanner.block.Summary, ctx)
+		if err != nil {
+			return textSearchFailClosed(response, textSearchFailClosedStorageCorrupt, err)
+		}
+		if threshold, ok := top.threshold(); ok && blockUpperBound < threshold {
+			response.Stats.TextPostingBlocksSkipped++
+			it.Next()
+			continue
+		}
+		response.Stats.TextPostingBlocksVisited++
+		var entry textV2PostingBlockEntry
+		for scanner.remaining > 0 {
+			if maxPostingsScanned > 0 && response.Stats.TextPostingsScanned >= uint64(maxPostingsScanned) {
+				response.Stats.Truncated = true
+				response.Stats.FailClosedReason = textSearchFailClosedPostingsLimit
+				response.Stats.PostingsScanNanos += uint64(time.Since(scanStart).Nanoseconds())
+				return textSearchFailClosed(response, response.Stats.FailClosedReason, fmt.Errorf("%w: collection %q text-v2 index %q exceeded bounded candidate generation", ErrTextIndexUnavailable, catalog.meta.Name, idx.Name))
+			}
+			if !scanner.Next(&entry) {
+				break
+			}
+			response.Stats.TextPostingsScanned++
+			if entry.Ordinal >= ctx.status.NextOrdinal || entry.Generation > ctx.status.RootGeneration {
+				return textSearchFailClosed(response, textSearchFailClosedStorageCorrupt, errMalformedTextStorage("text-v2 posting entry outside status snapshot"))
+			}
+			if !allowSet.contains(entry.Ordinal) {
+				continue
+			}
+			norm, ok, err := cache.normEntry(snap, catalog, ctx, entry.Ordinal, &response.Stats)
+			if err != nil {
+				return textSearchFailClosed(response, textSearchFailClosedStorageCorrupt, err)
+			}
+			if !ok || norm.tombstoned() || norm.Generation != entry.Generation {
+				continue
+			}
+			docMap, ok, err := cache.docMapEntry(snap, catalog, ctx, entry.Ordinal)
+			if err != nil {
+				return textSearchFailClosed(response, textSearchFailClosedStorageCorrupt, err)
+			}
+			if !ok {
+				continue
+			}
+			if norm.Generation != docMap.Generation || norm.Flags != docMap.Flags {
+				return textSearchFailClosed(response, textSearchFailClosedStorageCorrupt, errMalformedTextStorage("text-v2 norm/docmap generation mismatch for ordinal %d", entry.Ordinal))
+			}
+			if docMap.tombstoned() {
+				continue
+			}
+			if prevGeneration, seen := seenCurrent[entry.Ordinal]; seen && prevGeneration == entry.Generation {
+				return textSearchFailClosed(response, textSearchFailClosedStorageCorrupt, errMalformedTextStorage("duplicate text-v2 posting for term %q ordinal %d generation %d", term, entry.Ordinal, entry.Generation))
+			}
+			seenCurrent[entry.Ordinal] = entry.Generation
+			if candidateLimit > 0 && response.Stats.TextCandidatesScored >= uint64(candidateLimit) {
+				response.Stats.Truncated = true
+				response.Stats.FailClosedReason = textSearchFailClosedCandidateLimit
+				response.Stats.PostingsScanNanos += uint64(time.Since(scanStart).Nanoseconds())
+				return textSearchFailClosed(response, response.Stats.FailClosedReason, fmt.Errorf("%w: collection %q text-v2 index %q exceeded bounded candidate generation", ErrTextIndexUnavailable, catalog.meta.Name, idx.Name))
+			}
+			posting, err := textV2SearchPostingValueFromEntry(entry, fieldCount)
+			if err != nil {
+				return textSearchFailClosed(response, textSearchFailClosedStorageCorrupt, err)
+			}
+			score, err := scoreTextV2SearchPostingValue(term, posting, ctx, norm)
+			if err != nil {
+				return textSearchFailClosed(response, textSearchFailClosedStorageCorrupt, err)
+			}
+			beforeThreshold, beforeReady := top.threshold()
+			top.add(textV2SearchTopCandidate{ordinal: entry.Ordinal, documentID: docMap.DocumentID, score: score})
+			response.Stats.TextCandidatesScored++
+			afterThreshold, afterReady := top.threshold()
+			if afterReady && (!beforeReady || afterThreshold > beforeThreshold) {
+				response.Stats.TextBlockMaxThresholds++
+			}
+		}
+		if err := scanner.Err(); err != nil {
+			return textSearchFailClosed(response, textSearchFailClosedStorageCorrupt, err)
+		}
+		scratch = scanner.fieldScratch
+		it.Next()
+	}
+	if err := it.Error(); err != nil {
+		return textSearchFailClosed(response, textSearchFailClosedStorageCorrupt, err)
+	}
+	if blocksSeen != termStats.PostingBlockCount {
+		return textSearchFailClosed(response, textSearchFailClosedStorageCorrupt, errMalformedTextStorage("text-v2 term %q posting block count %d does not match scanned blocks %d", term, termStats.PostingBlockCount, blocksSeen))
+	}
+	response.Stats.PostingsScanNanos += uint64(time.Since(scanStart).Nanoseconds())
+	response.Stats.PostingsScanned = response.Stats.TextPostingsScanned
+	response.Stats.CandidatesScored = response.Stats.TextCandidatesScored
+	if len(top.candidates) == 0 {
+		response.Results = []TextSearchResult{}
+		return response, nil
+	}
+	response.Stats.TextCandidatesReturned = uint64(len(top.candidates))
+	response.Results = make([]TextSearchResult, len(top.candidates))
+	_ = resultMode // v2 detailed match materialization is deferred to #2629; M5 remains score-only.
+	for i, candidate := range top.candidates {
+		response.Results[i] = TextSearchResult{
+			DocumentID: append([]byte(nil), candidate.documentID...),
+			IndexName:  idx.Name,
+			Rank:       i + 1,
+			Score:      candidate.score,
+			ScoreKind:  HybridScoreKindBM25F,
+		}
+	}
+	if opts.IncludeDocuments && len(response.Results) > 0 {
+		if err := fetchTextSearchResultDocuments(c, snap, catalog, opts, &response); err != nil {
+			return textSearchFailClosed(response, textSearchFailClosedDocumentFetch, err)
+		}
+	}
+	return response, nil
+}
+
 func scanTextV2SearchPostingBlocksTerm(
 	snap *backenddb.Snapshot,
 	catalog *collectionCatalog,
@@ -404,6 +711,7 @@ func scanTextV2SearchPostingBlocksTerm(
 	candidates map[uint64]*textV2SearchCandidate,
 	allowNewCandidates bool,
 	candidateLimit, maxPostingsScanned int,
+	allowSet *textV2SearchOrdinalAllowSet,
 	stats *TextSearchStats,
 ) (bool, error) {
 	termStats := ctx.termStats[term]
@@ -426,7 +734,7 @@ func scanTextV2SearchPostingBlocksTerm(
 	}
 	defer func() { _ = it.Close() }()
 	var scratch []uint32
-	var blocksVisited uint64
+	var blocksSeen uint64
 	fieldCount := len(ctx.fieldNames)
 	for it.Valid() {
 		keyBytes := it.UnsafeKey()
@@ -451,7 +759,12 @@ func scanTextV2SearchPostingBlocksTerm(
 		if len(scanner.block.Summary.MaxFieldTermFrequencies) != fieldCount {
 			return false, errMalformedTextStorage("text-v2 posting block field count %d want %d", len(scanner.block.Summary.MaxFieldTermFrequencies), fieldCount)
 		}
-		blocksVisited++
+		blocksSeen++
+		if allowSet != nil && scanner.ChecksumVerified() && !allowSet.intersects(scanner.block.Summary.FirstOrdinal, scanner.block.Summary.LastOrdinal) {
+			stats.TextPostingBlocksSkipped++
+			it.Next()
+			continue
+		}
 		stats.TextPostingBlocksVisited++
 		var entry textV2PostingBlockEntry
 		for scanner.remaining > 0 {
@@ -466,6 +779,9 @@ func scanTextV2SearchPostingBlocksTerm(
 			stats.TextPostingsScanned++
 			if entry.Ordinal >= ctx.status.NextOrdinal || entry.Generation > ctx.status.RootGeneration {
 				return false, errMalformedTextStorage("text-v2 posting entry outside status snapshot")
+			}
+			if !allowSet.contains(entry.Ordinal) {
+				continue
 			}
 			candidate := candidates[entry.Ordinal]
 			if candidate == nil && !allowNewCandidates {
@@ -500,8 +816,8 @@ func scanTextV2SearchPostingBlocksTerm(
 	if err := it.Error(); err != nil {
 		return false, err
 	}
-	if blocksVisited != termStats.PostingBlockCount {
-		return false, errMalformedTextStorage("text-v2 term %q posting block count %d does not match scanned blocks %d", term, termStats.PostingBlockCount, blocksVisited)
+	if blocksSeen != termStats.PostingBlockCount {
+		return false, errMalformedTextStorage("text-v2 term %q posting block count %d does not match scanned blocks %d", term, termStats.PostingBlockCount, blocksSeen)
 	}
 	return false, nil
 }
@@ -537,6 +853,91 @@ func countTextV2CurrentPostings(candidate *textV2SearchCandidate, terms []string
 		}
 	}
 	return count
+}
+
+func textV2SearchPostingValueFromEntry(entry textV2PostingBlockEntry, fieldCount int) (textV2SearchPostingValue, error) {
+	value := textV2SearchPostingValue{generation: entry.Generation, termFrequency: entry.TermFrequency, fieldCount: fieldCount}
+	if len(entry.FieldFrequencies) != fieldCount {
+		return textV2SearchPostingValue{}, errMalformedTextStorage("text-v2 posting entry field count %d want %d", len(entry.FieldFrequencies), fieldCount)
+	}
+	if fieldCount <= len(value.inlineFields) {
+		copy(value.inlineFields[:], entry.FieldFrequencies)
+	} else {
+		value.fields = append(value.fields, entry.FieldFrequencies...)
+	}
+	return value, nil
+}
+
+func textV2SearchBlockUpperBound(term string, summary textV2PostingBlockSummary, ctx *textV2SearchContext) (float64, error) {
+	if summary.UpperBoundKind != textV2PostingUpperBoundKindBM25FLaneMax {
+		return 0, errMalformedTextStorage("text-v2 posting block unsupported upper-bound kind %d", summary.UpperBoundKind)
+	}
+	if len(summary.MaxFieldTermFrequencies) != len(ctx.fieldNames) {
+		return 0, errMalformedTextStorage("text-v2 posting block upper-bound field count %d want %d", len(summary.MaxFieldTermFrequencies), len(ctx.fieldNames))
+	}
+	stats := ctx.termStats[term]
+	if stats.DocumentFrequency == 0 || stats.DocumentFrequency > ctx.corpus.DocumentCount {
+		return 0, errMalformedTextStorage("text-v2 term %q document frequency %d outside corpus %d", term, stats.DocumentFrequency, ctx.corpus.DocumentCount)
+	}
+	minDenominator := 1 - textSearchBM25B
+	if minDenominator <= 0 {
+		return 0, errMalformedTextStorage("invalid BM25F normalization denominator")
+	}
+	var combinedTFUpper float64
+	for fieldIdx, maxTF := range summary.MaxFieldTermFrequencies {
+		if maxTF == 0 {
+			continue
+		}
+		statsValue := ctx.fieldStats[fieldIdx]
+		if statsValue.DocumentCount == 0 || statsValue.TotalTokenCount == 0 {
+			return 0, errMalformedTextStorage("missing text-v2 field accounting for %q", ctx.fieldNames[fieldIdx])
+		}
+		combinedTFUpper += ctx.fieldWeights[fieldIdx] * (float64(maxTF) / minDenominator)
+	}
+	if combinedTFUpper <= 0 {
+		return 0, nil
+	}
+	corpusDocuments := float64(ctx.corpus.DocumentCount)
+	df := float64(stats.DocumentFrequency)
+	idf := math.Log(1 + (corpusDocuments-df+0.5)/(df+0.5))
+	return idf * ((combinedTFUpper * (textSearchBM25K1 + 1)) / (combinedTFUpper + textSearchBM25K1)), nil
+}
+
+func scoreTextV2SearchPostingValue(term string, posting textV2SearchPostingValue, ctx *textV2SearchContext, norm textV2SearchNormEntry) (float64, error) {
+	if ctx.corpus.DocumentCount == 0 {
+		return 0, errMalformedTextStorage("text-v2 corpus document count is zero with search candidates")
+	}
+	if len(norm.FieldLengths) != len(ctx.fieldNames) {
+		return 0, errMalformedTextStorage("text-v2 norm field count %d want %d", len(norm.FieldLengths), len(ctx.fieldNames))
+	}
+	stats := ctx.termStats[term]
+	if stats.DocumentFrequency == 0 || stats.DocumentFrequency > ctx.corpus.DocumentCount {
+		return 0, errMalformedTextStorage("text-v2 term %q document frequency %d outside corpus %d", term, stats.DocumentFrequency, ctx.corpus.DocumentCount)
+	}
+	corpusDocuments := float64(ctx.corpus.DocumentCount)
+	df := float64(stats.DocumentFrequency)
+	idf := math.Log(1 + (corpusDocuments-df+0.5)/(df+0.5))
+	var combinedTF float64
+	for fieldIdx := range ctx.fieldNames {
+		fieldTF := float64(posting.fieldFrequency(fieldIdx))
+		if fieldTF <= 0 {
+			continue
+		}
+		statsValue := ctx.fieldStats[fieldIdx]
+		if statsValue.DocumentCount == 0 || statsValue.TotalTokenCount == 0 {
+			return 0, errMalformedTextStorage("missing text-v2 field accounting for %q", ctx.fieldNames[fieldIdx])
+		}
+		avgLength := float64(statsValue.TotalTokenCount) / float64(statsValue.DocumentCount)
+		if avgLength <= 0 {
+			return 0, errMalformedTextStorage("invalid average text-v2 field length for %q", ctx.fieldNames[fieldIdx])
+		}
+		normalizedTF := fieldTF / (1 - textSearchBM25B + textSearchBM25B*(float64(norm.FieldLengths[fieldIdx])/avgLength))
+		combinedTF += ctx.fieldWeights[fieldIdx] * normalizedTF
+	}
+	if combinedTF <= 0 {
+		return 0, nil
+	}
+	return idf * ((combinedTF * (textSearchBM25K1 + 1)) / (combinedTF + textSearchBM25K1)), nil
 }
 
 func scoreTextV2SearchCandidate(candidate *textV2SearchCandidate, terms []string, ctx *textV2SearchContext, norm textV2SearchNormEntry) (float64, error) {

--- a/TreeDB/docs/spec/collection-text-v2-contract.md
+++ b/TreeDB/docs/spec/collection-text-v2-contract.md
@@ -170,7 +170,10 @@ high-df terms, and later merge/rewrite tooling replaces old block keys through
 ordinary collection-root deltas so physical reclamation remains normal TreeDB
 root/value-log/leaf maintenance.
 
-Posting block values are versioned and fail closed. Each value stores:
+Posting block values are versioned and fail closed. As of M5, newly written
+values include a checksum over the encoded block payload so block-max search can
+trust summary bytes before deciding to skip entry decoding; checksum mismatch is
+text-v2 storage corruption. Each value stores:
 
 - block kind: sealed, delta, or micro;
 - block identity (`blockStartOrdinal`, `blockID`) repeated for key/value
@@ -245,6 +248,47 @@ rows therefore return score-only text results (document ID, rank, score, score
 kind, and optional bounded final documents when `IncludeDocuments` is true), with
 empty match-detail fields by contract.
 
+## M5 block-max skipping and scalar pruning (#2628)
+
+M5 adds an exact block-max path for the common single-term v2 BM25F top-K shape.
+The executor maintains an exact top-K threshold while scanning posting blocks in
+term/ordinal order. A block is skipped only when all of the following hold:
+
+- the posting-block value carries the checksum-protected v2 block payload;
+- the block summary has supported `UpperBoundKind=BM25FLaneMax` metadata with one
+  max term-frequency lane per indexed field;
+- the computed block upper bound is strictly lower than the current Kth score.
+
+Strict comparison is required for deterministic tie handling: equal upper bounds
+remain unskipped because a later document with the same score but a smaller
+DocumentID could still displace the current tail.
+
+The admissible BM25F bound is intentionally conservative. Field weights are
+validated finite and non-negative. For every field with term frequency `tf`,
+BM25F normalization divides by `1-b + b*(fieldLength/avgLength)`. Since
+`fieldLength >= 0`, `avgLength > 0`, and `b=0.75`, the denominator is at least
+`1-b`. Therefore each posting's field contribution is bounded by the block's
+`maxFieldTF/(1-b)` lane, the weighted sum is an upper bound on combined TF, and
+the BM25 saturation function is monotone for non-negative combined TF. Applying
+the term IDF to that saturated combined-TF bound gives an admissible per-block
+score upper bound. Stale generations and tombstoned ordinals can only make this
+bound looser.
+
+Multi-term OR/AND queries remain exact by falling back to the M4 exhaustive
+scorer until a fuller WAND/BMW doc-at-a-time algorithm lands. Fallbacks are
+reported with `blockmax_fallbacks/search`. Threshold raises are reported with
+`threshold_updates/search`. The fallback scorer still uses scalar ordinal
+pruning where safe.
+
+M5 also threads hybrid scalar prefilters into v2 text candidate generation. The
+hybrid planner's bounded scalar-index document-ID allow-set is translated through
+the `text-v2-docid` root into an ordinal allow-set under the same snapshot
+checks. Empty filters return no text candidates without traversing postings;
+rare filters can skip posting blocks whose ordinal ranges do not intersect the
+allow-set; broad filters remain exact and may decode more blocks. This path
+fetches zero full documents and treats missing/tombstoned scalar-filtered docID
+mappings as text-v2 storage corruption.
+
 ## Current v1 path inventory
 
 Current write/backfill hot path:
@@ -285,8 +329,10 @@ PRs can compare one vocabulary.
 | Counter | Required meaning |
 | --- | --- |
 | `postings_scanned` / `text_postings/search` | postings or posting entries decoded/scanned |
-| `posting_blocks_visited` | v2 posting blocks decoded/considered |
-| `posting_blocks_skipped` | exact block-max/WAND/BMW skips; zero for v1 |
+| `posting_blocks_visited` | v2 posting blocks decoded/scored (skipped blocks are counted separately) |
+| `posting_blocks_skipped` | exact scalar-pruning or block-max/WAND/BMW skips; zero for v1 |
+| `blockmax_fallbacks` | v2 query shapes or metadata states that used exact exhaustive scoring instead of block-max skipping |
+| `threshold_updates` | top-K threshold raises observed by exact block-max/BMW serving |
 | `candidates_scored` | candidates with BM25/BM25F score computed |
 | `state_lookups` | v1 text-state lookups or v2 equivalent metadata lookups |
 | `norm_lookups` | field-length/norm lookups or block reads |

--- a/TreeDB/docs/spec/storage-format.md
+++ b/TreeDB/docs/spec/storage-format.md
@@ -183,7 +183,7 @@ Posting-block values contain scoring postings only; positions and offsets are
 absent and belong to a separate positions lane if enabled by a later format.
 
 ```text
-u8      ValueVersion  = 1
+u8      ValueVersion  = 2
 uvarint FormatVersion = 1
 u8      BlockKind     // 1=sealed, 2=delta, 3=micro
 u8      Flags         // currently 0
@@ -206,7 +206,14 @@ uvarint Generation
 u8      EntryFlags    // currently 0
 uvarint TermFrequency
 uvarint FieldTermFrequency[FieldCount]
+
+u32 PayloadCRC32BE // IEEE CRC-32 over all preceding value bytes, including ValueVersion
 ```
+
+`ValueVersion=1` blocks from the M2/M4 pre-M5 format did not carry the trailing
+checksum. Current decoders can still read them for exact exhaustive validation,
+but M5 block-max skipping requires the checksum-protected `ValueVersion=2`
+payload before trusting summary bytes for skip decisions.
 
 Required validation/fail-closed invariants:
 
@@ -222,16 +229,18 @@ Required validation/fail-closed invariants:
   posting count per block.
 - `FieldCount` is the text index field count. Every posting has exactly that
   many field-frequency lanes, and the lane sum equals `TermFrequency`.
+- `PayloadCRC32BE` must match the preceding value bytes before a reader may use
+  summary metadata for block-max skip decisions.
 - `MaxTermFrequency`, `MaxFieldTermFrequency`, first/last ordinal, and doc count
   must exactly summarize the decoded entries.
 - `UpperBoundKind=1` records per-field lane maxima that are admissible BM25F
   upper-bound inputs for non-negative BM25F weights. A future scorer that cannot
   compute/validate an admissible block bound for a query must treat the block as
   unskippable and score exhaustively.
-- Unsupported versions, flags, kinds, malformed varints, trailing bytes,
-  key/value identity mismatches, field-count mismatches, corrupt summaries, or
-  status generation/ordinal bounds violations make the root corrupt for text-v2
-  inspection and must fail closed.
+- Unsupported versions, checksum mismatches, flags, kinds, malformed varints,
+  trailing bytes, key/value identity mismatches, field-count mismatches, corrupt
+  summaries, or status generation/ordinal bounds violations make the root
+  corrupt for text-v2 inspection and must fail closed.
 
 ## 4. Value Pointer Encoding (`page.ValuePtr`)
 

--- a/docs/benchmarks/treedb_text_v2_contract_benchmarks.md
+++ b/docs/benchmarks/treedb_text_v2_contract_benchmarks.md
@@ -17,10 +17,11 @@ Include all of the following in PR bodies/issues:
 - baseline commit/branch and candidate commit/branch;
 - dataset shape and measured boundary;
 - `ns/op`, derived `ops/sec`, `B/op`, `allocs/op`, and before/after delta;
-- domain counters: postings scanned, posting blocks visited/skipped, candidates
-  scored, state/norm lookups, docs fetched, match details built, scalar filter
-  selectivity, fail-closed count/reason, write amplification, index bytes/doc,
-  and rewrite/merge state when applicable.
+- domain counters: postings scanned, posting blocks visited/skipped,
+  block-max fallbacks, threshold updates, candidates scored, state/norm lookups,
+  docs fetched, match details built, scalar filter selectivity, fail-closed
+  count/reason, write amplification, index bytes/doc, and rewrite/merge state
+  when applicable.
 
 Candidate-generation rows must keep `docs_fetched/search=0` and
 `full_doc_fallbacks/search=0`. Final-fetch rows must keep
@@ -181,7 +182,8 @@ go test ./TreeDB/collections \
 Report text search counters:
 
 - `postings_scanned/search`;
-- `posting_blocks_visited/search` and `posting_blocks_skipped/search` (v1 = 0; M4 v2 exhaustive search reports visited blocks and skipped=0);
+- `posting_blocks_visited/search` and `posting_blocks_skipped/search` (v1 = 0; M4 v2 exhaustive search reports visited blocks and skipped=0; M5 v2 block-max reports decoded versus skipped blocks);
+- `blockmax_fallbacks/search` and `threshold_updates/search`;
 - `candidates_scored/search`;
 - `state_lookups/search` and `norm_lookups/search`;
 - `match_details/search`;
@@ -190,7 +192,9 @@ Report text search counters:
 M4 (#2627) adds an explicit v2 score-only search benchmark with the same corpus
 and query cases. It creates a v2 index with `CreateTextIndex`, scans compressed
 posting blocks under one snapshot, scores from norm/docmap blocks, and asserts
-`state_lookups=0`, `match_details=0`, and `docs_fetched=0`:
+`state_lookups=0`, `match_details=0`, and `docs_fetched=0`. As of M5 (#2628),
+single-term common rows use exact block-max skipping while multi-term rows report
+exact exhaustive `blockmax_fallbacks/search`:
 
 ```sh
 GOWORK=off \
@@ -217,11 +221,54 @@ go test ./TreeDB/collections \
   | tee "$OUT/text_v2_score_search_scale_100k.txt"
 ```
 
+## M5 block-max common-term rows
+
+Benchmark name: `BenchmarkTextV2BlockMaxCommonTerm2628`.
+
+This row runs the M5 exact single-term common top-K path against the explicit v2
+fixture and includes an in-process `exhaustive_common_topk` comparison with
+block-max disabled. The measured boundary is `SearchText` score-only candidate
+generation: no full documents, no v1 text-state lookups, and no match-detail
+builds.
+
+```sh
+GOWORK=off \
+TREEDB_TEXT_V2_BLOCKMAX_DOCS=10000 \
+go test ./TreeDB/collections \
+  -run '^$' \
+  -bench '^BenchmarkTextV2BlockMaxCommonTerm2628/(blockmax_common_topk|exhaustive_common_topk)$' \
+  -benchmem \
+  -benchtime=5x \
+  -count=3 \
+  | tee "$OUT/text_v2_blockmax_common_10k.txt"
+```
+
+Required >=100k local artifact command for #2628:
+
+```sh
+GOWORK=off \
+TREEDB_TEXT_V2_BLOCKMAX_DOCS=100000 \
+go test ./TreeDB/collections \
+  -run '^$' \
+  -bench '^BenchmarkTextV2BlockMaxCommonTerm2628/(blockmax_common_topk|exhaustive_common_topk)$' \
+  -benchmem \
+  -benchtime=1x \
+  -count=1 \
+  | tee "$OUT/text_v2_blockmax_common_100k.txt"
+```
+
+Report the same text counters as the search scale rows, especially
+`postings_scanned/search`, `posting_blocks_visited/search`,
+`posting_blocks_skipped/search`, `candidates_scored/search`,
+`threshold_updates/search`, and `blockmax_fallbacks/search`.
+
 ## Concurrent serving/load row
 
-Benchmark name: `BenchmarkTextV2ContractConcurrentServing2623`.
+Benchmark names: `BenchmarkTextV2ContractConcurrentServing2623` for the M0
+contract row and `BenchmarkTextV2BlockMaxConcurrentServing2628` for the M5 v2
+block-max serving row.
 
-The row serves warmed `SearchHybridTextCandidates` calls concurrently and reports
+The rows serve warmed candidate-generation calls concurrently and report
 p50/p95/p99 latency, steady-state heap, reader concurrency, and whether mixed
 write/snapshot churn was enabled. M0's default row uses read-only snapshot churn
 `0`; later implementation PRs should add a mixed write/snapshot-churn variant
@@ -240,11 +287,27 @@ go test ./TreeDB/collections \
   | tee "$OUT/text_v2_concurrent_serving.txt"
 ```
 
+M5 v2 block-max concurrent row:
+
+```sh
+GOWORK=off \
+TREEDB_TEXT_V2_BLOCKMAX_CONCURRENT_DOCS=10000 \
+TREEDB_TEXT_V2_BLOCKMAX_CONCURRENT_READERS=8 \
+go test ./TreeDB/collections \
+  -run '^$' \
+  -bench '^BenchmarkTextV2BlockMaxConcurrentServing2628$' \
+  -benchmem \
+  -benchtime=200x \
+  -count=3 \
+  | tee "$OUT/text_v2_blockmax_concurrent_serving.txt"
+```
+
 Counters include `p50_ns/search`, `p95_ns/search`, `p99_ns/search`,
 `steady_heap_bytes`, `readers`, `cache_warm`, and
-`mixed_write_snapshot_churn`.
+`mixed_write_snapshot_churn` where the row exposes it. The M5 row must also show
+non-zero `posting_blocks_skipped/search` in the warm stats or fail the benchmark.
 
-## Profiles for current v1 hot spots
+## Profiles for current v1 hot spots and M5 block-max path
 
 Search CPU/alloc profile:
 
@@ -261,6 +324,23 @@ GOWORK=off go test ./TreeDB/collections \
   | tee "$OUT/text_search_profile_bench.txt"
 go tool pprof -top "$OUT/text_search_cpu.pprof" > "$OUT/text_search_cpu_top.txt"
 go tool pprof -top "$OUT/text_search_mem.pprof" > "$OUT/text_search_mem_top.txt"
+```
+
+M5 block-max CPU profile for common terms:
+
+```sh
+BENCH='^BenchmarkTextV2BlockMaxCommonTerm2628/blockmax_common_topk$'
+GOWORK=off TREEDB_TEXT_V2_BLOCKMAX_DOCS=100000 go test ./TreeDB/collections \
+  -run '^$' \
+  -bench "$BENCH" \
+  -benchmem \
+  -benchtime=3x \
+  -count=1 \
+  -cpuprofile "$OUT/text_v2_blockmax_cpu.pprof" \
+  -memprofile "$OUT/text_v2_blockmax_mem.pprof" \
+  | tee "$OUT/text_v2_blockmax_profile_bench.txt"
+go tool pprof -top "$OUT/text_v2_blockmax_cpu.pprof" > "$OUT/text_v2_blockmax_cpu_top.txt"
+go tool pprof -top "$OUT/text_v2_blockmax_mem.pprof" > "$OUT/text_v2_blockmax_mem_top.txt"
 ```
 
 Write CPU/alloc profile:


### PR DESCRIPTION
## Summary

Closes #2628. Parent: #2622.

Implements M5 text-v2 exact block-max/scalar pruning scope:

- adds checksum-protected posting-block values so v2 search can trust block summaries before skip decisions;
- adds exact single-term BM25F block-max topK search over v2 posting block summaries;
- falls back to exact exhaustive v2 scoring for unsupported multi-term OR/AND query shapes and reports fallback counters;
- threads hybrid scalar prefilter allow-sets into v2 text candidate generation by mapping scalar document IDs to text-v2 ordinals, enabling exact block/entry pruning without full-document fetches;
- reports `posting_blocks_skipped`, `blockmax_fallbacks`, and `threshold_updates` in text/hybrid stats and benchmark rows;
- updates text-v2 contract docs/runbook.

## Scope / non-goals

In scope: exact v2 score-only candidate generation improvements, scalar filter pruning, fail-closed corrupt metadata handling, tests/bench/docs.

Not in scope: BM25/BM25F semantic changes, approximate ranking, lazy positions/details (#2629), rollout/default switch/rewrite lifecycle (#2630), vector internals, external assets/GC/storage architecture changes.

## Exactness and upper-bound proof

Supported block-max path is single-term v2 BM25F. For a block, M2 metadata stores max per-field term-frequency lanes. Text field weights are validated finite and non-negative. BM25F field normalization divides by `1-b + b*(fieldLength/avgLength)`; with `b=0.75`, `fieldLength >= 0`, and positive average length, the denominator is at least `1-b`. Thus each field contribution is bounded by `maxFieldTF/(1-b)`. The weighted combined TF bound is fed through the monotone BM25 saturation function and positive term IDF, producing an admissible block score upper bound. Blocks are skipped only when the upper bound is strictly below the current Kth score, preserving tie ordering.

Fallbacks: multi-term OR/AND and legacy/missing checksum block metadata use exact exhaustive scoring rather than approximate pruning. Corrupt checksum/metadata fails closed as text-v2 storage corruption.

## Evidence

Artifact root: `/tmp/gomap_2628_evidence_20260612_032536` (`summary.md` has the counter table).

Focused/local validation:

```sh
git diff --check origin/main...HEAD
GOWORK=off go test ./TreeDB/collections -run 'TestTextV2BlockMax|TestTextV2ScalarFilterPruning|TestTextV2Search|TestTextV2PostingBlock|TestTextV2Contract'
GOWORK=off go test ./TreeDB/collections ./TreeDB/docs
GOWORK=off go test ./TreeDB/...
```

Benchmarks/profiles:

```sh
GOWORK=off TREEDB_TEXT_V2_BLOCKMAX_DOCS=10000 go test ./TreeDB/collections -run '^$' -bench '^BenchmarkTextV2BlockMaxCommonTerm2628/(blockmax_common_topk|exhaustive_common_topk)$' -benchmem -benchtime=3x -count=3
GOWORK=off TREEDB_TEXT_V2_BLOCKMAX_DOCS=100000 go test ./TreeDB/collections -run '^$' -bench '^BenchmarkTextV2BlockMaxCommonTerm2628/(blockmax_common_topk|exhaustive_common_topk)$' -benchmem -benchtime=1x -count=1
GOWORK=off TREEDB_TEXT_V2_BLOCKMAX_CONCURRENT_DOCS=10000 TREEDB_TEXT_V2_BLOCKMAX_CONCURRENT_READERS=8 go test ./TreeDB/collections -run '^$' -bench '^BenchmarkTextV2BlockMaxConcurrentServing2628$' -benchmem -benchtime=200x -count=1
GOWORK=off go test ./TreeDB/collections -run '^$' -bench '^BenchmarkIndexInsertSearch2564/(search_text_candidates_no_docs|search_hybrid_no_docs_scalar_filter|search_hybrid_fetch_topk_scalar_filter|search_text_v2_candidates_no_docs|search_hybrid_v2_no_docs_scalar_filter|search_vector_candidates_no_docs)$' -benchmem -benchtime=5x -count=3
```

Key 100k common-term row:

| row | ns/op | B/op | allocs/op | postings scanned | blocks visited | blocks skipped | candidates scored |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| blockmax | 2,843,792 | 2,556,736 | 4,104 | 12,544 | 98 | 684 | 12,544 |
| exhaustive | 71,901,084 | 45,257,584 | 210,049 | 100,000 | 782 | 0 | 100,000 |

Concurrent M5 row: `p50=518750ns`, `p95=2287708ns`, `p99=3288791ns`, 8 readers, 10k docs.

Profiles:

- `text_v2_blockmax_cpu_200x.pprof`, top: `text_v2_blockmax_cpu_200x_top.txt`
- `text_v2_exhaustive_cpu_10x.pprof`, top: `text_v2_exhaustive_cpu_10x_top.txt`

## Regression assessment

No material regression found in local guardrails. Existing #2564 v1 rows remain in the same envelope; v2 rows remain zero-doc/score-only. The dedicated 100k blockmax fixture reduces decoded postings, scored candidates, norm lookups, allocations, and wall time. Uniform 100k contract row also improves vs base even when block upper bounds are too loose to skip blocks.

## Review / CI status

Internal xhigh review: PASS, no blockers (review terminal `term_88d3c99e-f0fc-45eb-9141-7d5193ee52b9`).

Latest head: `c3c23b06c0c968b7843047e91c49bc8a667b8c64` (includes the `storage-format.md` ValueVersion=2/CRC docs fix and a narrow coordinator fix so only `prefilter` passes the scalar allow-set into text candidate generation; explicit `union_fusion` keeps unfiltered text source ranks/fusion scores before scalar candidate/result filtering).

Local validation after the coordinator fix:

```sh
GOWORK=off go test ./TreeDB/collections -run 'Test(SearchHybrid|Hybrid)' -count=1
GOWORK=off go test ./TreeDB/collections -run 'TestTextV2(BlockMax|ScalarFilterPruning|HybridUnionFusion)' -count=1
git diff --check origin/main...HEAD
GOWORK=off go test ./TreeDB/docs
GOWORK=off go test ./TreeDB/collections
GOWORK=off go test ./TreeDB/...
```

GitHub CI: all latest-head PR checks are green on `c3c23b06c0c968b7843047e91c49bc8a667b8c64`.

AI review status: Codex latest-head review for `c3c23b06c0` reported no major issues. CodeRabbit completed with no blocking findings (non-blocking docstring coverage warning only). Copilot was requested on the mature latest head; no blocking Copilot feedback was posted. Prior Codex storage-format thread is fixed and resolved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Hybrid search now supports scalar filtering for text-based candidate generation
  * Block-max optimization for single-term text searches
  * Data integrity checksums for search index blocks

* **Improvements**
  * Enhanced diagnostic metrics for search performance monitoring
  * Block-level pruning for optimized query execution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


