### PR TITLE
Optimize scalar_u8 prepared HNSW rowID scoring

### DIFF
--- a/TreeDB/collections/column_hnsw_prepared_quantized_search.go
+++ b/TreeDB/collections/column_hnsw_prepared_quantized_search.go
@@ -4,6 +4,55 @@ import "fmt"
 
 var errColumnHNSWPreparedQuantizedTraversalUnavailable = fmt.Errorf("%w: scalar_u8 hnsw prepared quantized traversal unavailable", ErrVectorIndexSearchUnavailable)
 
+type columnHNSWPreparedScalarU8ScorePlane struct {
+	scorer columnVectorGraphScalarU8QuantizedScorer
+	ready  bool
+}
+
+func (p *columnHNSWPreparedScalarU8ScorePlane) kind() columnHNSWPreparedTraversalScorePlaneKind {
+	return columnHNSWPreparedTraversalScorePlaneKindQuantized
+}
+
+func (p *columnHNSWPreparedScalarU8ScorePlane) prepareForHNSWPreparedTraversal(pack *columnHNSWSearchPackPreparedView, query []float32, opts columnHNSWPreparedTraversalOptions, scratch *columnVectorGraphNativeSearchScratch) error {
+	_ = opts
+	_ = scratch
+	if p == nil || !p.ready || pack == nil {
+		return errColumnHNSWPreparedTraversalScorePlaneUnavailable
+	}
+	if len(query) != pack.Header.Dimensions || p.scorer.dims != pack.Header.Dimensions || p.scorer.codeRows.Rows() != pack.Header.Rows {
+		return errColumnHNSWPreparedTraversalScorePlaneUnavailable
+	}
+	return p.scorer.validatePrepared()
+}
+
+func (p *columnHNSWPreparedScalarU8ScorePlane) scoreOrdinal(ordinal int, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) (float64, error) {
+	if p == nil || !p.ready {
+		return 0, errColumnHNSWPreparedTraversalScorePlaneUnavailable
+	}
+	return p.scorer.scoreOrdinal(ordinal, scratch, stats)
+}
+
+func (p *columnHNSWPreparedScalarU8ScorePlane) scoreOrdinals(ordinals []int, dst []float64, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) ([]float64, error) {
+	if p == nil || !p.ready {
+		return dst[:0], errColumnHNSWPreparedTraversalScorePlaneUnavailable
+	}
+	return p.scorer.scoreOrdinals(ordinals, dst, scratch, stats)
+}
+
+func (p *columnHNSWPreparedScalarU8ScorePlane) scoreRowIDsPrevalidated(rowIDs []uint32, dst []float64, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) ([]float64, error) {
+	if p == nil || !p.ready {
+		return dst[:0], errColumnHNSWPreparedTraversalScorePlaneUnavailable
+	}
+	return p.scorer.scoreRowIDsPrevalidated(rowIDs, dst, scratch, stats)
+}
+
+func (p *columnHNSWPreparedScalarU8ScorePlane) scoreAndPushFrontierVisitedRowIDsPrevalidated(rowIDs []uint32, topK int, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) (int, error) {
+	if p == nil || !p.ready {
+		return 0, errColumnHNSWPreparedTraversalScorePlaneUnavailable
+	}
+	return p.scorer.scoreAndPushFrontierVisitedRowIDsPrevalidated(rowIDs, topK, scratch, stats)
+}
+
 func collectionScalarU8PreparedTraversalPackForReader(reader *columnVectorGraphPhysicalRowReader, queryMode columnVectorGraphNativeSearchQueryMode, statsMode columnVectorGraphNativeSearchStatsMode, quantizedIndexName string) (*columnHNSWSearchPackPreparedView, bool) {
 	if reader == nil || !queryMode.quantized() || !columnHNSWSearchPackStatsModeSupportedForSearch(statsMode) {
 		return nil, false
@@ -115,13 +164,14 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosineScalarU8PreparedTravers
 			rerankCandidateLimit = rowCount
 		}
 	}
-	scorer, err := r.prepareQuantizedScorer(queryMode, opts.QuantizedIndexName, query, queryInvNorm, scratch)
+	scratch.preparedScalarU8Plane.ready = false
+	scorer, err := r.prepareScalarU8QuantizedScorer(queryMode, opts.QuantizedIndexName, query, queryInvNorm, scratch)
 	if err != nil {
 		recordColumnVectorGraphQuantizedAssetErrorStats(&setupStats, err)
 		return nil, setupStats, err
 	}
-	scratch.searchPlan.quantizedScorer = scorer
-	scratch.preparedQuantizedPlane.scorer = &scratch.searchPlan.quantizedScorer
+	scratch.preparedScalarU8Plane.scorer = scorer
+	scratch.preparedScalarU8Plane.ready = true
 	setupStats.QuantizedScorerActive = 1
 	if r.preparedSearch != nil && r.preparedSearch.ready() {
 		setupStats.PreparedGraphSearchViews = 1
@@ -142,7 +192,7 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosineScalarU8PreparedTravers
 		OmitResultMaterialization:            opts.OmitResultMaterialization || queryMode == columnVectorGraphNativeSearchQueryModeQuantizedRerank,
 		SuppressOmittedResultMaterialization: queryMode == columnVectorGraphNativeSearchQueryModeQuantizedRerank,
 	}
-	results, stats, err := pack.searchCosinePreparedScorePlane(query, packOpts, scratch, &scratch.preparedQuantizedPlane)
+	results, stats, err := pack.searchCosinePreparedScorePlane(query, packOpts, scratch, &scratch.preparedScalarU8Plane)
 	columnVectorGraphApplyQuantizedPreparedTraversalSetupStats(&stats, setupStats)
 	r.populateScalarU8PreparedTraversalSearchStats(&stats)
 	if err != nil {

--- a/TreeDB/collections/column_hnsw_prepared_traversal.go
+++ b/TreeDB/collections/column_hnsw_prepared_traversal.go
@@ -62,6 +62,16 @@ type columnHNSWPreparedTraversalScorePlane interface {
 	scoreOrdinals(ordinals []int, dst []float64, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) ([]float64, error)
 }
 
+// columnHNSWPreparedTraversalRowIDScorePlane is the direct row-ID scoring seam
+// for prepared-pack traversal. Callers must validate every row ID against the
+// pack row count before invoking these methods. That lets scalar_u8 mirror the
+// exact FP32 pack route by scoring adjacency []uint32 directly instead of
+// staging through []int ordinals and the codec-generic quantized scorer.
+type columnHNSWPreparedTraversalRowIDScorePlane interface {
+	scoreRowIDsPrevalidated(rowIDs []uint32, dst []float64, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) ([]float64, error)
+	scoreAndPushFrontierVisitedRowIDsPrevalidated(rowIDs []uint32, topK int, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) (int, error)
+}
+
 type columnHNSWPreparedExactFP32ScorePlane struct {
 	pack            *columnHNSWSearchPackPreparedView
 	normalizedQuery []float32
@@ -130,7 +140,25 @@ func (p *columnHNSWPreparedExactFP32ScorePlane) scoreOrdinals(ordinals []int, ds
 		}
 		rowIDs[i] = uint32(ordinal)
 	}
+	return p.scoreRowIDsPrevalidated(rowIDs, dst, scratch, stats)
+}
+
+func (p *columnHNSWPreparedExactFP32ScorePlane) scoreRowIDsPrevalidated(rowIDs []uint32, dst []float64, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) ([]float64, error) {
+	if p == nil || p.pack == nil || len(p.normalizedQuery) < p.pack.Header.VectorStride {
+		return dst[:0], errColumnHNSWPreparedTraversalScorePlaneUnavailable
+	}
 	return p.pack.scoreRowIDs(p.normalizedQuery, rowIDs, dst, p.scoreBatchMode, scratch, stats)
+}
+
+func (p *columnHNSWPreparedExactFP32ScorePlane) scoreAndPushFrontierVisitedRowIDsPrevalidated(rowIDs []uint32, topK int, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) (int, error) {
+	if p == nil || p.pack == nil || len(p.normalizedQuery) < p.pack.Header.VectorStride {
+		return 0, errColumnHNSWPreparedTraversalScorePlaneUnavailable
+	}
+	var visited uint64
+	if err := p.pack.scoreAndPushFrontierVisitedTile(p.normalizedQuery, rowIDs, topK, p.scoreBatchMode, scratch, stats, &visited); err != nil {
+		return int(visited), err
+	}
+	return int(visited), nil
 }
 
 type columnHNSWPreparedQuantizedScorePlane struct {
@@ -245,6 +273,7 @@ func (v *columnHNSWSearchPackPreparedView) searchCosinePreparedScorePlane(query 
 	if err := scorePlane.prepareForHNSWPreparedTraversal(v, query, opts, scratch); err != nil {
 		return nil, *stats, fmt.Errorf("collections: hnsw_search_pack_v1 prepared traversal %s score plane: %w", scorePlane.kind(), err)
 	}
+	rowIDScorePlane, _ := scorePlane.(columnHNSWPreparedTraversalRowIDScorePlane)
 	countLoopEdges := !statsMode.minimal()
 	var loopEdgeVisits uint64
 	var visitedCandidates uint64
@@ -257,7 +286,7 @@ func (v *columnHNSWSearchPackPreparedView) searchCosinePreparedScorePlane(query 
 		return nil, *stats, err
 	}
 	for layer := maxLayer; layer > 0; layer-- {
-		entryOrdinal, err = v.greedyNearestAtLayerPreparedScorePlane(scorePlane, entryOrdinal, layer, scratch, stats, countLoopEdges, &loopEdgeVisits)
+		entryOrdinal, err = v.greedyNearestAtLayerPreparedScorePlane(scorePlane, rowIDScorePlane, entryOrdinal, layer, scratch, stats, countLoopEdges, &loopEdgeVisits)
 		if err != nil {
 			return nil, *stats, err
 		}
@@ -299,6 +328,29 @@ func (v *columnHNSWSearchPackPreparedView) searchCosinePreparedScorePlane(query 
 		}
 		if countLoopEdges {
 			loopEdgeVisits += uint64(len(adjacency))
+		}
+		if rowIDScorePlane != nil {
+			scratch.scoreTileRowIDs = ensureColumnVectorGraphNativeUint32Scratch(scratch.scoreTileRowIDs, len(adjacency))
+			tile := scratch.scoreTileRowIDs[:0]
+			for i, neighbor := range adjacency {
+				if uint64(neighbor) >= rowCount64 {
+					return nil, *stats, fmt.Errorf("collections: hnsw_search_pack_v1 prepared traversal ordinal=%d adjacency[%d]=%d outside row_count=%d: %w", candidate.ordinal, i, neighbor, rowCount, errColumnVectorGraphAdjacencyOrdinalOutOfBounds)
+				}
+				neighborOrdinal := int(neighbor)
+				if visitMarks[neighborOrdinal] == visitEpoch {
+					continue
+				}
+				visitMarks[neighborOrdinal] = visitEpoch
+				tile = append(tile, neighbor)
+			}
+			if len(tile) != 0 {
+				scored, err := rowIDScorePlane.scoreAndPushFrontierVisitedRowIDsPrevalidated(tile, retainedCandidateLimit, scratch, stats)
+				if err != nil {
+					return nil, *stats, err
+				}
+				visitedCandidates += uint64(scored)
+			}
+			continue
 		}
 		scratch.scoreTileOrdinals = ensureColumnVectorGraphNativeIntScratch(scratch.scoreTileOrdinals, len(adjacency))
 		tile := scratch.scoreTileOrdinals[:0]
@@ -348,7 +400,7 @@ func (v *columnHNSWSearchPackPreparedView) searchCosinePreparedScorePlane(query 
 	return scratch.results, *stats, nil
 }
 
-func (v *columnHNSWSearchPackPreparedView) greedyNearestAtLayerPreparedScorePlane(scorePlane columnHNSWPreparedTraversalScorePlane, entryOrdinal int, layer int, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats, countLoopEdges bool, loopEdgeVisits *uint64) (int, error) {
+func (v *columnHNSWSearchPackPreparedView) greedyNearestAtLayerPreparedScorePlane(scorePlane columnHNSWPreparedTraversalScorePlane, rowIDScorePlane columnHNSWPreparedTraversalRowIDScorePlane, entryOrdinal int, layer int, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats, countLoopEdges bool, loopEdgeVisits *uint64) (int, error) {
 	best := entryOrdinal
 	bestScore, err := scorePlane.scoreOrdinal(best, scratch, stats)
 	if err != nil {
@@ -367,12 +419,32 @@ func (v *columnHNSWSearchPackPreparedView) greedyNearestAtLayerPreparedScorePlan
 		if countLoopEdges && loopEdgeVisits != nil {
 			*loopEdgeVisits += uint64(len(adjacency))
 		}
-		scratch.scoreTileOrdinals = ensureColumnVectorGraphNativeIntScratch(scratch.scoreTileOrdinals, len(adjacency))
-		tile := scratch.scoreTileOrdinals[:0]
 		for i, neighbor := range adjacency {
 			if uint64(neighbor) >= uint64(v.Header.Rows) {
 				return 0, fmt.Errorf("collections: hnsw_search_pack_v1 prepared traversal ordinal=%d layer=%d adjacency[%d]=%d outside row_count=%d: %w", best, layer, i, neighbor, v.Header.Rows, errColumnVectorGraphAdjacencyOrdinalOutOfBounds)
 			}
+		}
+		if rowIDScorePlane != nil {
+			scratch.scoreTileScores = ensureColumnVectorGraphNativeFloat64Scratch(scratch.scoreTileScores, len(adjacency))
+			scores, err := rowIDScorePlane.scoreRowIDsPrevalidated(adjacency, scratch.scoreTileScores, scratch, stats)
+			if err != nil {
+				return 0, err
+			}
+			for i, neighbor := range adjacency {
+				neighborOrdinal := int(neighbor)
+				score := scores[i]
+				// Keep exact-pack tie handling stable with the current route.
+				if score > bestScore || (score == bestScore && neighborOrdinal < best) {
+					best = neighborOrdinal
+					bestScore = score
+					changed = true
+				}
+			}
+			continue
+		}
+		scratch.scoreTileOrdinals = ensureColumnVectorGraphNativeIntScratch(scratch.scoreTileOrdinals, len(adjacency))
+		tile := scratch.scoreTileOrdinals[:0]
+		for _, neighbor := range adjacency {
 			tile = append(tile, int(neighbor))
 		}
 		scratch.scoreTileScores = ensureColumnVectorGraphNativeFloat64Scratch(scratch.scoreTileScores, len(tile))

--- a/TreeDB/collections/column_hnsw_search_pack_test.go
+++ b/TreeDB/collections/column_hnsw_search_pack_test.go
@@ -663,6 +663,205 @@ func TestColumnHNSWPreparedTraversalScorePlaneSeam2585(t *testing.T) {
 	}
 }
 
+type testColumnHNSWPreparedTraversalRowIDScorePlane2653 struct {
+	rows           int
+	singleCalls    int
+	genericBatches int
+	rowIDBatches   int
+	fusedBatches   int
+}
+
+func (p *testColumnHNSWPreparedTraversalRowIDScorePlane2653) kind() columnHNSWPreparedTraversalScorePlaneKind {
+	return columnHNSWPreparedTraversalScorePlaneKindQuantized
+}
+
+func (p *testColumnHNSWPreparedTraversalRowIDScorePlane2653) prepareForHNSWPreparedTraversal(pack *columnHNSWSearchPackPreparedView, query []float32, opts columnHNSWPreparedTraversalOptions, scratch *columnVectorGraphNativeSearchScratch) error {
+	_ = query
+	_ = opts
+	_ = scratch
+	if pack == nil {
+		return errColumnHNSWPreparedTraversalScorePlaneUnavailable
+	}
+	p.rows = pack.Header.Rows
+	return nil
+}
+
+func (p *testColumnHNSWPreparedTraversalRowIDScorePlane2653) scoreOrdinal(ordinal int, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) (float64, error) {
+	_ = scratch
+	_ = stats
+	p.singleCalls++
+	return p.score(uint32(ordinal)), nil
+}
+
+func (p *testColumnHNSWPreparedTraversalRowIDScorePlane2653) scoreOrdinals(ordinals []int, dst []float64, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) ([]float64, error) {
+	_ = scratch
+	_ = stats
+	p.genericBatches++
+	if cap(dst) < len(ordinals) {
+		dst = make([]float64, len(ordinals))
+	} else {
+		dst = dst[:len(ordinals)]
+	}
+	for i, ordinal := range ordinals {
+		dst[i] = p.score(uint32(ordinal))
+	}
+	return dst, nil
+}
+
+func (p *testColumnHNSWPreparedTraversalRowIDScorePlane2653) scoreRowIDsPrevalidated(rowIDs []uint32, dst []float64, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) ([]float64, error) {
+	_ = scratch
+	_ = stats
+	p.rowIDBatches++
+	if cap(dst) < len(rowIDs) {
+		dst = make([]float64, len(rowIDs))
+	} else {
+		dst = dst[:len(rowIDs)]
+	}
+	for i, rowID := range rowIDs {
+		dst[i] = p.score(rowID)
+	}
+	return dst, nil
+}
+
+func (p *testColumnHNSWPreparedTraversalRowIDScorePlane2653) scoreAndPushFrontierVisitedRowIDsPrevalidated(rowIDs []uint32, topK int, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) (int, error) {
+	_ = stats
+	p.fusedBatches++
+	for _, rowID := range rowIDs {
+		candidate := columnVectorGraphSearchCandidate{ordinal: int(rowID), score: p.score(rowID)}
+		if scratch.insertTop(topK, candidate) {
+			scratch.pushFrontier(candidate)
+		}
+	}
+	return len(rowIDs), nil
+}
+
+func (p *testColumnHNSWPreparedTraversalRowIDScorePlane2653) score(rowID uint32) float64 {
+	return float64(p.rows - int(rowID))
+}
+
+func TestColumnHNSWPreparedTraversalUsesRowIDScorePlane2653(t *testing.T) {
+	rows := []columnGraphRebuildInputRowV2A{
+		{id: "doc-a", vector: []float32{1, 0, 0}},
+		{id: "doc-b", vector: []float32{0.9, 0.1, 0}},
+		{id: "doc-c", vector: []float32{0, 1, 0}},
+		{id: "doc-d", vector: []float32{0, 0, 1}},
+		{id: "doc-e", vector: []float32{0.4, 0.6, 0}},
+	}
+	_, d, col, def := openColumnGraphQuantizedGuardrailTestCollection1926(t, rows)
+	defer func() { _ = d.Close() }()
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		t.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	searcher, err := col.OpenVectorIndexSearcher(VectorIndexSearcherOptions{IndexName: def.Name, MaxDecodedBlocks: 1})
+	if err != nil {
+		t.Fatalf("OpenVectorIndexSearcher: %v", err)
+	}
+	defer func() { _ = searcher.Close() }()
+	if searcher.reader == nil || searcher.reader.hnswSearchPack == nil {
+		t.Fatal("searcher missing hnsw_search_pack_v1 prepared view")
+	}
+	plane := &testColumnHNSWPreparedTraversalRowIDScorePlane2653{}
+	var scratch columnVectorGraphNativeSearchScratch
+	results, _, err := searcher.reader.hnswSearchPack.searchCosinePreparedScorePlane(
+		[]float32{1, 0.05, 0},
+		columnHNSWPreparedTraversalOptions{TopK: 3, EfSearch: len(rows), StatsMode: columnVectorGraphNativeSearchStatsModeFullDiagnostics},
+		&scratch,
+		plane,
+	)
+	if err != nil {
+		t.Fatalf("prepared traversal rowID score plane: %v", err)
+	}
+	if len(results) != 3 {
+		t.Fatalf("results=%d want 3: %+v", len(results), results)
+	}
+	if plane.rowIDBatches+plane.fusedBatches == 0 || plane.fusedBatches == 0 {
+		t.Fatalf("rowID score plane was not used: rowIDBatches=%d fusedBatches=%d singleCalls=%d", plane.rowIDBatches, plane.fusedBatches, plane.singleCalls)
+	}
+	if plane.genericBatches != 0 {
+		t.Fatalf("generic ordinal score plane batches=%d want 0 when rowID seam is available", plane.genericBatches)
+	}
+}
+
+func TestColumnHNSWPreparedScalarU8RouteUsesTypedRowIDScorePlane2653(t *testing.T) {
+	rows := []columnGraphRebuildInputRowV2A{
+		{id: "doc-a", vector: []float32{1, 0, 0}},
+		{id: "doc-b", vector: []float32{0.9, 0.1, 0}},
+		{id: "doc-c", vector: []float32{0, 1, 0}},
+		{id: "doc-d", vector: []float32{0, 0, 1}},
+		{id: "doc-e", vector: []float32{0.4, 0.6, 0}},
+	}
+	_, d, col, def := openColumnGraphQuantizedGuardrailTestCollection1926(t, rows)
+	defer func() { _ = d.Close() }()
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		t.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	searcher, err := col.OpenVectorIndexSearcher(VectorIndexSearcherOptions{IndexName: def.Name, MaxDecodedBlocks: 1})
+	if err != nil {
+		t.Fatalf("OpenVectorIndexSearcher: %v", err)
+	}
+	defer func() { _ = searcher.Close() }()
+	if searcher.reader == nil || searcher.reader.hnswSearchPack == nil {
+		t.Fatal("searcher missing hnsw_search_pack_v1 prepared view")
+	}
+
+	query := []float32{0.8, 0.2, 0}
+	qName := def.QuantizedIndexes[0].Name
+	opts := columnVectorGraphNativeSearchOptions{
+		TopK:               3,
+		EfSearch:           len(rows),
+		QueryMode:          columnVectorGraphNativeSearchQueryModeQuantizedOnly,
+		QuantizedIndexName: qName,
+		StatsMode:          columnVectorGraphNativeSearchStatsModeFullDiagnostics,
+	}
+	var routeScratch columnVectorGraphNativeSearchScratch
+	results, stats, err := searcher.reader.SearchCosineScalarU8PreparedTraversal(searcher.reader.hnswSearchPack, query, opts, &routeScratch)
+	if err != nil {
+		t.Fatalf("SearchCosineScalarU8PreparedTraversal: %v", err)
+	}
+	want := scalarU8QuantizedTopKForTest1926(t, rows, query, opts.TopK)
+	if len(results) != len(want) {
+		t.Fatalf("scalar_u8 route results=%d want %d: %+v", len(results), len(want), results)
+	}
+	for i := range want {
+		if !bytes.Equal(results[i].ID, want[i].ID) || math.Abs(results[i].Score-want[i].Score) > 1e-6 {
+			t.Fatalf("scalar_u8 route result[%d]=%+v want id=%q ordinal=%d score=%v", i, results[i], want[i].ID, want[i].Ordinal, want[i].Score)
+		}
+	}
+	if stats.SearchRouteQuantizedOnly != 1 || stats.SearchRouteQuantizedRerank != 0 || stats.QuantizedScorerActive != 1 || stats.PreparedScoreCalls != 0 || stats.QuantizedScoreCalls == 0 {
+		t.Fatalf("scalar_u8 route stats=%+v want typed quantized-only scoring without exact scoring", stats)
+	}
+	if !routeScratch.preparedScalarU8Plane.ready {
+		t.Fatalf("scalar_u8 route did not arm typed prepared score plane")
+	}
+	rowIDPlane, ok := any(&routeScratch.preparedScalarU8Plane).(columnHNSWPreparedTraversalRowIDScorePlane)
+	if !ok {
+		t.Fatalf("scalar_u8 prepared score plane does not implement direct rowID seam")
+	}
+	if routeScratch.preparedQuantizedPlane.scorer != nil || routeScratch.searchPlan.quantizedScorer.kind != columnVectorGraphQuantizedScorerKindNone {
+		t.Fatalf("scalar_u8 route populated generic quantized scorer scratch: prepared=%p kind=%d", routeScratch.preparedQuantizedPlane.scorer, routeScratch.searchPlan.quantizedScorer.kind)
+	}
+
+	rowIDs := []uint32{0, 1, 4}
+	ordinals := []int{0, 1, 4}
+	var rowIDScratch, ordinalScratch columnVectorGraphNativeSearchScratch
+	rowScores, err := rowIDPlane.scoreRowIDsPrevalidated(rowIDs, nil, &rowIDScratch, nil)
+	if err != nil {
+		t.Fatalf("scoreRowIDsPrevalidated: %v", err)
+	}
+	ordinalScores, err := routeScratch.preparedScalarU8Plane.scoreOrdinals(ordinals, nil, &ordinalScratch, nil)
+	if err != nil {
+		t.Fatalf("scoreOrdinals: %v", err)
+	}
+	if len(rowScores) != len(ordinalScores) {
+		t.Fatalf("rowID scores=%d ordinal scores=%d", len(rowScores), len(ordinalScores))
+	}
+	for i := range rowScores {
+		if rowScores[i] != ordinalScores[i] {
+			t.Fatalf("score[%d] rowID=%v ordinal=%v", i, rowScores[i], ordinalScores[i])
+		}
+	}
+}
+
 func TestColumnHNSWPreparedTraversalOmitReturnsRetainedShortlist2585(t *testing.T) {
 	rows := []columnGraphRebuildInputRowV2A{
 		{id: "doc-a", vector: []float32{1, 0, 0}},

--- a/TreeDB/collections/column_vector_graph_quantized_scorer.go
+++ b/TreeDB/collections/column_vector_graph_quantized_scorer.go
@@ -174,31 +174,14 @@ func (r *columnVectorGraphPhysicalRowReader) prepareScalarU8QuantizedScorer(mode
 }
 
 func (s *columnVectorGraphScalarU8QuantizedScorer) scoreOrdinal(ordinal int, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) (float64, error) {
-	if s == nil || !s.codeRows.Valid() || s.dims <= 0 || len(s.codePayload) != s.codeRows.Rows()*s.dims || !s.centeredQuery.ValidForDims(s.dims) {
-		return 0, fmt.Errorf("%w: column_graph quantized scalar_u8 scorer is unavailable", ErrVectorIndexSearchUnavailable)
-	}
-	if scratch == nil {
-		return 0, fmt.Errorf("collections: column_graph quantized scalar_u8 scorer: %w", errColumnVectorGraphNativeSearchScratchRequired)
+	if err := s.validatePrepared(); err != nil {
+		return 0, err
 	}
 	rows := s.codeRows.Rows()
 	if ordinal < 0 || ordinal >= rows || uint64(ordinal) > uint64(^uint32(0)) {
 		return 0, fmt.Errorf("%w: column_graph quantized index %q code row ordinal=%d unavailable len=0 ok=false want %d", ErrVectorIndexSearchUnavailable, s.indexName, ordinal, s.dims)
 	}
-	scratch.scoreTileRowIDs = ensureColumnVectorGraphNativeUint32Scratch(scratch.scoreTileRowIDs, 1)
-	rowIDs := scratch.scoreTileRowIDs[:1]
-	rowIDs[0] = uint32(ordinal)
-	scratch.scoreTileQuantizedDots = ensureColumnVectorGraphNativeInt64Scratch(scratch.scoreTileQuantizedDots, 1)
-	dots := scratch.scoreTileQuantizedDots[:1]
-	status := vectorops.DotScalarU8CenteredIndexedPrevalidated(dots, s.codePayload, s.centeredQuery, rowIDs, s.dims)
-	if status.Invalid || status.Rows != 1 {
-		return 0, fmt.Errorf("%w: column_graph quantized index %q scalar_u8 score invalid status=%+v rows=%d want 1", ErrVectorIndexSearchUnavailable, s.indexName, status, status.Rows)
-	}
-	score := scalarU8QuantizedCosineScoreFromDot(dots[0])
-	if stats != nil {
-		recordColumnVectorGraphScoreBatchStats(stats, status.Rows, status.Optimized, status.Fallback)
-		s.recordScoreStats(stats, status.Rows)
-	}
-	return score, nil
+	return s.scoreRowIDPrepared(uint32(ordinal), scratch, stats)
 }
 
 func (s *columnVectorGraphScalarU8QuantizedScorer) scoreOrdinals(ordinals []int, dst []float64, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) ([]float64, error) {
@@ -210,8 +193,8 @@ func (s *columnVectorGraphScalarU8QuantizedScorer) scoreOrdinals(ordinals []int,
 	if len(ordinals) == 0 {
 		return dst, nil
 	}
-	if s == nil || !s.codeRows.Valid() || s.dims <= 0 || len(s.codePayload) != s.codeRows.Rows()*s.dims || !s.centeredQuery.ValidForDims(s.dims) {
-		return dst[:0], fmt.Errorf("%w: column_graph quantized scalar_u8 scorer is unavailable", ErrVectorIndexSearchUnavailable)
+	if err := s.validatePrepared(); err != nil {
+		return dst[:0], err
 	}
 	if scratch == nil {
 		return dst[:0], fmt.Errorf("collections: column_graph quantized scalar_u8 scorer: %w", errColumnVectorGraphNativeSearchScratchRequired)
@@ -225,11 +208,67 @@ func (s *columnVectorGraphScalarU8QuantizedScorer) scoreOrdinals(ordinals []int,
 		}
 		rowIDs[i] = uint32(ordinal)
 	}
-	scratch.scoreTileQuantizedDots = ensureColumnVectorGraphNativeInt64Scratch(scratch.scoreTileQuantizedDots, len(ordinals))
-	dots := scratch.scoreTileQuantizedDots[:len(ordinals)]
+	return s.scoreRowIDsPrepared(rowIDs, dst, scratch, stats)
+}
+
+func (s *columnVectorGraphScalarU8QuantizedScorer) validatePrepared() error {
+	if s == nil || !s.codeRows.Valid() || s.dims <= 0 || len(s.codePayload) != s.codeRows.Rows()*s.dims || !s.centeredQuery.ValidForDims(s.dims) {
+		return fmt.Errorf("%w: column_graph quantized scalar_u8 scorer is unavailable", ErrVectorIndexSearchUnavailable)
+	}
+	return nil
+}
+
+func (s *columnVectorGraphScalarU8QuantizedScorer) scoreRowIDPrevalidated(rowID uint32, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) (float64, error) {
+	if err := s.validatePrepared(); err != nil {
+		return 0, err
+	}
+	return s.scoreRowIDPrepared(rowID, scratch, stats)
+}
+
+func (s *columnVectorGraphScalarU8QuantizedScorer) scoreRowIDPrepared(rowID uint32, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) (float64, error) {
+	if scratch == nil {
+		return 0, fmt.Errorf("collections: column_graph quantized scalar_u8 scorer: %w", errColumnVectorGraphNativeSearchScratchRequired)
+	}
+	scratch.scoreTileRowIDs = ensureColumnVectorGraphNativeUint32Scratch(scratch.scoreTileRowIDs, 1)
+	rowIDs := scratch.scoreTileRowIDs[:1]
+	rowIDs[0] = rowID
+	scratch.scoreTileQuantizedDots = ensureColumnVectorGraphNativeInt64Scratch(scratch.scoreTileQuantizedDots, 1)
+	dots := scratch.scoreTileQuantizedDots[:1]
 	status := vectorops.DotScalarU8CenteredIndexedPrevalidated(dots, s.codePayload, s.centeredQuery, rowIDs, s.dims)
-	if status.Invalid || status.Rows != len(ordinals) {
-		return dst[:0], fmt.Errorf("%w: column_graph quantized index %q scalar_u8 batch score invalid status=%+v rows=%d want %d", ErrVectorIndexSearchUnavailable, s.indexName, status, status.Rows, len(ordinals))
+	if status.Invalid || status.Rows != 1 {
+		return 0, fmt.Errorf("%w: column_graph quantized index %q scalar_u8 score invalid status=%+v rows=%d want 1", ErrVectorIndexSearchUnavailable, s.indexName, status, status.Rows)
+	}
+	if stats != nil {
+		recordColumnVectorGraphScoreBatchStats(stats, status.Rows, status.Optimized, status.Fallback)
+		s.recordScoreStats(stats, status.Rows)
+	}
+	return scalarU8QuantizedCosineScoreFromDot(dots[0]), nil
+}
+
+func (s *columnVectorGraphScalarU8QuantizedScorer) scoreRowIDsPrevalidated(rowIDs []uint32, dst []float64, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) ([]float64, error) {
+	if cap(dst) < len(rowIDs) {
+		dst = make([]float64, len(rowIDs))
+	} else {
+		dst = dst[:len(rowIDs)]
+	}
+	if len(rowIDs) == 0 {
+		return dst, nil
+	}
+	if err := s.validatePrepared(); err != nil {
+		return dst[:0], err
+	}
+	return s.scoreRowIDsPrepared(rowIDs, dst, scratch, stats)
+}
+
+func (s *columnVectorGraphScalarU8QuantizedScorer) scoreRowIDsPrepared(rowIDs []uint32, dst []float64, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) ([]float64, error) {
+	if scratch == nil {
+		return dst[:0], fmt.Errorf("collections: column_graph quantized scalar_u8 scorer: %w", errColumnVectorGraphNativeSearchScratchRequired)
+	}
+	scratch.scoreTileQuantizedDots = ensureColumnVectorGraphNativeInt64Scratch(scratch.scoreTileQuantizedDots, len(rowIDs))
+	dots := scratch.scoreTileQuantizedDots[:len(rowIDs)]
+	status := vectorops.DotScalarU8CenteredIndexedPrevalidated(dots, s.codePayload, s.centeredQuery, rowIDs, s.dims)
+	if status.Invalid || status.Rows != len(rowIDs) {
+		return dst[:0], fmt.Errorf("%w: column_graph quantized index %q scalar_u8 batch score invalid status=%+v rows=%d want %d", ErrVectorIndexSearchUnavailable, s.indexName, status, status.Rows, len(rowIDs))
 	}
 	for i, dot := range dots {
 		dst[i] = scalarU8QuantizedCosineScoreFromDot(dot)
@@ -239,6 +278,35 @@ func (s *columnVectorGraphScalarU8QuantizedScorer) scoreOrdinals(ordinals []int,
 	}
 	s.recordScoreStats(stats, status.Rows)
 	return dst, nil
+}
+
+func (s *columnVectorGraphScalarU8QuantizedScorer) scoreAndPushFrontierVisitedRowIDsPrevalidated(rowIDs []uint32, topK int, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) (int, error) {
+	if len(rowIDs) == 0 {
+		return 0, nil
+	}
+	if err := s.validatePrepared(); err != nil {
+		return 0, err
+	}
+	if scratch == nil {
+		return 0, fmt.Errorf("collections: column_graph quantized scalar_u8 scorer: %w", errColumnVectorGraphNativeSearchScratchRequired)
+	}
+	scratch.scoreTileQuantizedDots = ensureColumnVectorGraphNativeInt64Scratch(scratch.scoreTileQuantizedDots, len(rowIDs))
+	dots := scratch.scoreTileQuantizedDots[:len(rowIDs)]
+	status := vectorops.DotScalarU8CenteredIndexedPrevalidated(dots, s.codePayload, s.centeredQuery, rowIDs, s.dims)
+	if status.Invalid || status.Rows != len(rowIDs) {
+		return 0, fmt.Errorf("%w: column_graph quantized index %q scalar_u8 batch score invalid status=%+v rows=%d want %d", ErrVectorIndexSearchUnavailable, s.indexName, status, status.Rows, len(rowIDs))
+	}
+	if stats != nil {
+		recordColumnVectorGraphScoreBatchStats(stats, status.Rows, status.Optimized, status.Fallback)
+	}
+	s.recordScoreStats(stats, status.Rows)
+	for i, rowID := range rowIDs {
+		candidate := columnVectorGraphSearchCandidate{ordinal: int(rowID), score: scalarU8QuantizedCosineScoreFromDot(dots[i])}
+		if scratch.insertTop(topK, candidate) {
+			scratch.pushFrontier(candidate)
+		}
+	}
+	return len(rowIDs), nil
 }
 
 func (s *columnVectorGraphScalarU8QuantizedScorer) recordScoreStats(stats *columnVectorGraphNativeSearchStats, count int) {

--- a/TreeDB/collections/column_vector_graph_search.go
+++ b/TreeDB/collections/column_vector_graph_search.go
@@ -1002,6 +1002,7 @@ type columnVectorGraphNativeSearchScratch struct {
 	quantizedRabitQWorkspace rabitq.Workspace
 	quantizedBRQWorkspace    brq.Workspace
 	preparedQuantizedPlane   columnHNSWPreparedQuantizedScorePlane
+	preparedScalarU8Plane    columnHNSWPreparedScalarU8ScorePlane
 	preparedTraversalStats   columnVectorGraphNativeSearchStats
 	wavefrontCandidates      []columnVectorGraphSearchCandidate
 	searchPlan               columnVectorGraphSearchPlan


### PR DESCRIPTION
## Objective

Fixes #2653.

Land the focused `scalar_u8` prepared-HNSW route cleanup so the prepared quantized path scores HNSW pack row IDs directly and avoids generic scorer/tile adaptation where scalar_u8 semantics allow it.

## Path mismatch addressed

Before, scalar_u8 collection prepared search used the HNSW pack traversal through a codec-generic quantized score plane:

`SearchCosineScalarU8PreparedTraversal -> searchCosinePreparedScorePlane -> columnHNSWPreparedQuantizedScorePlane -> columnVectorGraphQuantizedScorer -> scalar_u8 scorer`

That staged adjacency `[]uint32` through `[]int`, switched over the generic quantized scorer kind on hot score calls, and scored into float64 tiles before the traversal pushed candidates.

This PR adds a typed scalar_u8 prepared score plane plus an optional row-ID prepared traversal seam so scalar_u8 can consume validated HNSW pack adjacency row IDs directly and fuse layer-0 score-and-push.

## What changed

- Added `columnHNSWPreparedTraversalRowIDScorePlane` for score planes that can score validated pack row IDs directly.
- Added `columnHNSWPreparedScalarU8ScorePlane` in search scratch.
- `SearchCosineScalarU8PreparedTraversal` now prepares the scalar_u8 scorer directly instead of building the codec-generic quantized scorer union.
- Prepared traversal now uses direct row-ID batch scoring and fused score-and-push when the score plane supports it.
- Factored scalar_u8 scorer validation and row-ID scoring helpers to avoid duplicate validation on hot calls.
- Added tests proving both the traversal row-ID seam and the real scalar_u8 route use the typed row-ID-capable plane, not the generic quantized scorer scratch.

## What did not change

- No scalar_u8 score formula, codec, asset identity, or quantized asset format change.
- No silent exact fallback for quantized search; unavailable assets still fail closed.
- Exact FP32 production route remains the existing HNSW search-pack route.
- Hot search rows remain `0 B/op`, `0 allocs/op`.

## Correctness / tests

Latest head: `ec4c6f50e912124f94abfd94215fcbf9533dbb20`.

Commands run locally on Apple M3 / darwin arm64:

```sh
GOMAXPROCS=8 GOWORK=off go test ./TreeDB/collections \
  -run 'TestColumnHNSWPrepared(TraversalUsesRowIDScorePlane2653|ScalarU8RouteUsesTypedRowIDScorePlane2653)|TestSearchVectorIndexWithBufferQuantizedOnlyAndRerank2415|TestSearchVectorIndexWithBufferScalarU8PreparedTraversalPackRouteWhenAdjacencyClosed2586|TestScalarU8QuantizedPreparedTraversalPackRouteWhenAdjacencyClosed2586|TestSearchVectorIndexWithBufferQuantizedAssetUnavailableFailClosed2415' \
  -count=1

GOMAXPROCS=8 GOWORK=off go test ./TreeDB/internal/vectorops ./TreeDB/collections -count=1
```

Artifacts:

- `/tmp/scalar_u8_pack_parity_2653/test_focused_scalar_u8_route_latest2.log`
- `/tmp/scalar_u8_pack_parity_2653/test_vectorops_collections_latest_head_ec4.log`

## Performance

Required matrix command:

```sh
TREEDB_COLUMN_GRAPH_QUANTIZED_BENCH_SHAPE=10k_x_768 GOMAXPROCS=8 GOWORK=off \
  go test ./TreeDB/collections -run '^$' \
  -bench 'ScalarU8Quantized.*241|CollectionVectorQuantizedProductionGate2591' \
  -benchmem -benchtime=100000x -count=10
```

Current-base comparison uses latest `origin/main` after the branch merge:

- Baseline: `c1589eda05531ae4fc2b137a09d47c081fbda781`
- Candidate: `ec4c6f50e912124f94abfd94215fcbf9533dbb20`

Selected rows from `/tmp/scalar_u8_pack_parity_2653/benchstat_required_latest_head_ec4_vs_c158.txt`:

| Row | base ns/op | cand ns/op | benchstat |
| --- | ---: | ---: | --- |
| Collection scalar_u8 qonly c=1 | 16.16µ | 15.93µ | ~ |
| Collection scalar_u8 qonly c=8 | 3.44µ | 3.88µ | ~ (focused rerun below resolves as noise) |
| Collection scalar_u8 rerank c=1 | 31.35µ | 18.86µ | -39.84% |
| Collection scalar_u8 rerank c=8 | 6.30µ | 4.61µ | -26.74% |
| Searcher scalar_u8 qonly c=8 | 3.45µ | 3.33µ | ~ |
| Searcher scalar_u8 rerank c=8 | 4.46µ | 4.42µ | ~ |
| ProdGate scalar_u8 CollectionSWB qonly c=8 | 5.10µ | 4.06µ | -20.37% |
| ProdGate scalar_u8 CollectionSWB rerank c=8 | 5.78µ | 6.00µ | ~ (focused rerun below resolves as noise) |
| ProdGate exact FP32 CollectionSWB c=1 | 21.43µ | 21.13µ | ~ |
| ProdGate exact FP32 CollectionSWB c=8 | 5.51µ | 5.23µ | ~ |

Focused c=8 blocker follow-up on latest head/current base:

```text
benchstat_suspicious_c8_latest_head_rerun.txt (count=20)
Collection scalar_u8 qonly c=8:              3.786µ -> 3.622µ, ~ (p=0.616)
ProdGate scalar_u8 CollectionSWB rerank c=8: 4.555µ -> 4.737µ, ~ (p=0.583)
ProdGate exact FP32 SWB c=8:                 4.275µ -> 4.358µ, ~ (p=0.465)
geomean:                                     +0.46%
```

So the earlier parsed c=8 regressions did not reproduce as material latest-head regressions; focused reruns show the apparent c=8 positives are benchmark noise. Hot rows stay at `0 B/op`, `0 allocs/op`.

Artifacts:

- `/tmp/scalar_u8_pack_parity_2653/baseline_latest_main_c158_required.log`
- `/tmp/scalar_u8_pack_parity_2653/candidate_latest_head_ec4_required.log`
- `/tmp/scalar_u8_pack_parity_2653/benchstat_required_latest_head_ec4_vs_c158.txt`
- `/tmp/scalar_u8_pack_parity_2653/bench_required_latest_head_ec4_summary.md`
- `/tmp/scalar_u8_pack_parity_2653/benchstat_suspicious_c8_latest_head_rerun.txt`

## Guardrails

Latest candidate benchmark counters preserve the required route/counter shape:

- scalar_u8 collection prepared route: `search_route_column_graph_prepared/search=1`, quantized route counter set, `quantized_scorer_active/search=1`.
- collection mmap/direct: `quantized_asset_mmap_direct/search=1`, `collection_prepared_heap_copy_B=0`.
- scalar_u8 qonly: `prepared_score_calls/search=0`, `quantized_score_calls/search>0`.
- exact FP32: `search_route_hnsw_search_pack/search=1`, `quantized_scorer_active/search=0`.
- hot rows: `0 B/op`, `0 allocs/op`.

## Profiles

CPU profiles captured for latest-head scalar_u8 collection qonly c=1/c=8:

- `/tmp/scalar_u8_pack_parity_2653/profiles_latest_head/scalar_u8_collection_quantized_only_c1_cpu.pprof`
- `/tmp/scalar_u8_pack_parity_2653/profiles_latest_head/scalar_u8_collection_quantized_only_c8_cpu.pprof`
- top summaries in `/tmp/scalar_u8_pack_parity_2653/profiles_latest_head/*_top.txt`

The scalar_u8 score path remains visible through `dotScalarU8CenteredIndexedARM64Int32` under `searchCosinePreparedScorePlane`; benchmark fixture/setup work also appears in these whole-benchmark CPU profiles.

## CI / AI review status

- CI: latest-head checks are green for `ec4c6f50e912124f94abfd94215fcbf9533dbb20`.
- Codex: latest-head review passed; no major issues (`ec4c6f50e9`).
- Copilot: requested for latest head; no bot response observed.
- CodeRabbit: requested; automatic attempt reported rate limiting, later command completed with no actionable findings.
- Review threads: none open.

## Rollout / follow-ups

No runtime toggle or format migration needed. This is an internal prepared traversal/scoring cleanup.
