### PR TITLE
TreeDB documentservice: accept typed vector query payloads

### DIFF
--- a/TreeDB/documentservice/http.go
+++ b/TreeDB/documentservice/http.go
@@ -213,8 +213,8 @@ func (h *Handler) serveSearchOperation(w http.ResponseWriter, r *http.Request, i
 		}
 		writeJSON(w, http.StatusOK, res)
 	case "vector-index":
-		var req BenchmarkVectorSearchRequest
-		if !h.decodeJSON(w, r, maxBodyBytes, &req) {
+		req, ok := h.decodeBenchmarkVectorSearchRequest(w, r, maxBodyBytes)
+		if !ok {
 			return
 		}
 		res, err := h.Service.SearchBenchmarkVector(r.Context(), index, req)

--- a/TreeDB/documentservice/http_test.go
+++ b/TreeDB/documentservice/http_test.go
@@ -220,6 +220,24 @@ func TestHTTPBenchmarkVectorSearchAcceptsF32LEBase64Embedding(t *testing.T) {
 		"query_embedding_f32_le_b64": base64.StdEncoding.EncodeToString([]byte{1, 2}),
 		"top_k":                      1,
 	}, http.StatusBadRequest, nil)
+
+	for _, tc := range []struct {
+		name string
+		body string
+	}{
+		{name: "unknown field", body: `{"query_embedding_f32_le_b64":"` + encodeFloat32LEBase64ForTest([]float32{1, 0}) + `","top_k":1,"unexpected":true}`},
+		{name: "multiple JSON values", body: `{"query_embedding_f32_le_b64":"` + encodeFloat32LEBase64ForTest([]float32{1, 0}) + `","top_k":1} {}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/v1/indexes/bench_b64/search/vector-index", bytes.NewBufferString(tc.body))
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+			if rr.Code != http.StatusBadRequest {
+				t.Fatalf("status=%d body=%s", rr.Code, rr.Body.String())
+			}
+			assertHTTPErrorCode(t, rr.Body.Bytes(), CodeMalformedJSON)
+		})
+	}
 }
 
 func encodeFloat32LEBase64ForTest(values []float32) string {

--- a/TreeDB/documentservice/http_test.go
+++ b/TreeDB/documentservice/http_test.go
@@ -2,6 +2,8 @@ package documentservice
 
 import (
 	"bytes"
+	"encoding/base64"
+	"encoding/binary"
 	"encoding/json"
 	"math"
 	"net/http"
@@ -170,6 +172,57 @@ func TestHTTPBenchmarkLifecycleRoutesAndExactVectorShape(t *testing.T) {
 			t.Fatalf("exact /search/vector missing field %q in shape=%+v", required, exactShape)
 		}
 	}
+}
+
+func TestHTTPBenchmarkVectorSearchAcceptsF32LEBase64Embedding(t *testing.T) {
+	svc, db := newTestService(t)
+	defer db.Close()
+	handler := NewHandler(svc)
+
+	postJSON(t, handler, "/v1/indexes/bench_b64/reset", ResetIndexRequest{
+		Dimension: 2,
+		DropOld:   true,
+		VectorIndexOptions: &BenchmarkVectorIndexOptions{
+			Strategy: collections.VectorIndexStrategyColumnGraph,
+		},
+	}, http.StatusOK, nil)
+	postJSON(t, handler, "/v1/indexes/bench_b64/documents/upsert", UpsertDocumentsRequest{Documents: []Document{
+		{ID: "a", Content: "alpha", Embedding: []float32{1, 0}},
+		{ID: "b", Content: "beta", Embedding: []float32{0, 1}},
+	}, DeferVectorIndexRebuild: true}, http.StatusOK, nil)
+	postJSON(t, handler, "/v1/indexes/bench_b64/optimize", OptimizeIndexRequest{}, http.StatusOK, nil)
+
+	var benchmark BenchmarkVectorSearchResponse
+	postJSON(t, handler, "/v1/indexes/bench_b64/search/vector-index", map[string]any{
+		"query_embedding_f32_le_b64": encodeFloat32LEBase64ForTest([]float32{1, 0}),
+		"top_k":                      1,
+		"ef_search":                  8,
+	}, http.StatusOK, &benchmark)
+	if !benchmark.NoDocuments || len(benchmark.Results) != 1 || benchmark.Results[0].ID != "a" || benchmark.Stats.DocumentsFetched != 0 {
+		t.Fatalf("benchmark vector response=%+v stats=%+v", benchmark, benchmark.Stats)
+	}
+
+	postJSON(t, handler, "/v1/indexes/bench_b64/search/vector-index", map[string]any{
+		"query_embedding":            []float32{1, 0},
+		"query_embedding_f32_le_b64": encodeFloat32LEBase64ForTest([]float32{1, 0}),
+		"top_k":                      1,
+	}, http.StatusBadRequest, nil)
+	postJSON(t, handler, "/v1/indexes/bench_b64/search/vector-index", map[string]any{
+		"query_embedding_f32_le_b64": "not-base64",
+		"top_k":                      1,
+	}, http.StatusBadRequest, nil)
+	postJSON(t, handler, "/v1/indexes/bench_b64/search/vector-index", map[string]any{
+		"query_embedding_f32_le_b64": base64.StdEncoding.EncodeToString([]byte{1, 2}),
+		"top_k":                      1,
+	}, http.StatusBadRequest, nil)
+}
+
+func encodeFloat32LEBase64ForTest(values []float32) string {
+	raw := make([]byte, len(values)*4)
+	for i, value := range values {
+		binary.LittleEndian.PutUint32(raw[i*4:], math.Float32bits(value))
+	}
+	return base64.StdEncoding.EncodeToString(raw)
 }
 
 func postJSON(t *testing.T, handler http.Handler, path string, body any, wantStatus int, out any) {

--- a/TreeDB/documentservice/http_test.go
+++ b/TreeDB/documentservice/http_test.go
@@ -208,6 +208,11 @@ func TestHTTPBenchmarkVectorSearchAcceptsF32LEBase64Embedding(t *testing.T) {
 		"top_k":                      1,
 	}, http.StatusBadRequest, nil)
 	postJSON(t, handler, "/v1/indexes/bench_b64/search/vector-index", map[string]any{
+		"query_embedding":            []float32{},
+		"query_embedding_f32_le_b64": encodeFloat32LEBase64ForTest([]float32{1, 0}),
+		"top_k":                      1,
+	}, http.StatusBadRequest, nil)
+	postJSON(t, handler, "/v1/indexes/bench_b64/search/vector-index", map[string]any{
 		"query_embedding_f32_le_b64": "not-base64",
 		"top_k":                      1,
 	}, http.StatusBadRequest, nil)

--- a/TreeDB/documentservice/http_vector_index_bench_test.go
+++ b/TreeDB/documentservice/http_vector_index_bench_test.go
@@ -1,10 +1,8 @@
 package documentservice
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
-	"io"
 	"math"
 	"net/http"
 	"net/http/httptest"
@@ -27,7 +25,7 @@ func BenchmarkBenchmarkVectorSearchDecode(b *testing.B) {
 		b.ReportAllocs()
 		b.SetBytes(int64(len(jsonPayload)))
 		for i := 0; i < b.N; i++ {
-			req, err := decodeBenchmarkVectorSearchJSONForBenchmark(jsonPayload)
+			req, err := decodeBenchmarkVectorSearchJSONGeneric(jsonPayload)
 			if err != nil {
 				b.Fatal(err)
 			}
@@ -42,7 +40,15 @@ func BenchmarkBenchmarkVectorSearchDecode(b *testing.B) {
 			if err != nil {
 				b.Fatal(err)
 			}
-			if err := normalizeBenchmarkVectorQueryEmbedding(&req); err != nil {
+			benchmarkVectorDecodeSink = req
+		}
+	})
+	b.Run("f32_le_base64_request_generic", func(b *testing.B) {
+		b.ReportAllocs()
+		b.SetBytes(int64(len(b64Payload)))
+		for i := 0; i < b.N; i++ {
+			req, err := decodeBenchmarkVectorSearchJSONGenericForBenchmark(b64Payload)
+			if err != nil {
 				b.Fatal(err)
 			}
 			benchmarkVectorDecodeSink = req
@@ -112,17 +118,15 @@ func BenchmarkBenchmarkVectorSearchResponseEncode(b *testing.B) {
 }
 
 func decodeBenchmarkVectorSearchJSONForBenchmark(raw []byte) (BenchmarkVectorSearchRequest, error) {
-	var req BenchmarkVectorSearchRequest
-	dec := json.NewDecoder(bytes.NewReader(raw))
-	dec.UseNumber()
-	dec.DisallowUnknownFields()
-	if err := dec.Decode(&req); err != nil {
+	return decodeBenchmarkVectorSearchJSON(raw)
+}
+
+func decodeBenchmarkVectorSearchJSONGenericForBenchmark(raw []byte) (BenchmarkVectorSearchRequest, error) {
+	req, err := decodeBenchmarkVectorSearchJSONGeneric(raw)
+	if err != nil {
 		return BenchmarkVectorSearchRequest{}, err
 	}
-	if err := dec.Decode(&struct{}{}); err != io.EOF {
-		if err == nil {
-			err = fmt.Errorf("multiple JSON values in request body")
-		}
+	if err := normalizeBenchmarkVectorQueryEmbedding(&req); err != nil {
 		return BenchmarkVectorSearchRequest{}, err
 	}
 	return req, nil

--- a/TreeDB/documentservice/http_vector_index_bench_test.go
+++ b/TreeDB/documentservice/http_vector_index_bench_test.go
@@ -1,0 +1,185 @@
+package documentservice
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/collections"
+)
+
+var benchmarkVectorDecodeSink BenchmarkVectorSearchRequest
+var benchmarkVectorBytesSink []byte
+var benchmarkVectorResponseSink BenchmarkVectorSearchResponse
+
+func BenchmarkBenchmarkVectorSearchDecode(b *testing.B) {
+	query := benchmarkVectorQuery(1536)
+	jsonPayload := benchmarkVectorSearchJSONPayload(query)
+	b64Payload := benchmarkVectorSearchF32LEBase64Payload(query)
+	encoded := encodeFloat32LEBase64ForTest(query)
+
+	b.Run("json_float_array_request", func(b *testing.B) {
+		b.ReportAllocs()
+		b.SetBytes(int64(len(jsonPayload)))
+		for i := 0; i < b.N; i++ {
+			req, err := decodeBenchmarkVectorSearchJSONForBenchmark(jsonPayload)
+			if err != nil {
+				b.Fatal(err)
+			}
+			benchmarkVectorDecodeSink = req
+		}
+	})
+	b.Run("f32_le_base64_request", func(b *testing.B) {
+		b.ReportAllocs()
+		b.SetBytes(int64(len(b64Payload)))
+		for i := 0; i < b.N; i++ {
+			req, err := decodeBenchmarkVectorSearchJSONForBenchmark(b64Payload)
+			if err != nil {
+				b.Fatal(err)
+			}
+			if err := normalizeBenchmarkVectorQueryEmbedding(&req); err != nil {
+				b.Fatal(err)
+			}
+			benchmarkVectorDecodeSink = req
+		}
+	})
+	b.Run("f32_le_base64_raw", func(b *testing.B) {
+		b.ReportAllocs()
+		b.SetBytes(int64(len(encoded)))
+		for i := 0; i < b.N; i++ {
+			req := BenchmarkVectorSearchRequest{QueryEmbeddingF32LEBase64: encoded}
+			if err := normalizeBenchmarkVectorQueryEmbedding(&req); err != nil {
+				b.Fatal(err)
+			}
+			benchmarkVectorDecodeSink = req
+		}
+	})
+}
+
+func BenchmarkBenchmarkVectorSearchHTTPPredecodedRequest(b *testing.B) {
+	svc, db := newTestService(b)
+	b.Cleanup(func() { _ = db.Close() })
+	ctx := b.Context()
+	index := "bench_http_predecoded"
+	createBenchmarkColumnGraphIndex(b, svc, index)
+	loadBenchmarkDocsDeferred(b, svc, index, []Document{
+		{ID: "a", Content: "alpha", Embedding: []float32{1, 0}},
+		{ID: "b", Content: "beta", Embedding: []float32{0, 1}},
+	})
+	if _, err := svc.OptimizeIndex(ctx, index, OptimizeIndexRequest{}); err != nil {
+		b.Fatalf("OptimizeIndex: %v", err)
+	}
+	request := BenchmarkVectorSearchRequest{QueryEmbedding: []float32{1, 0}, TopK: 1, EfSearch: 8}
+	httpRequest := httptest.NewRequest(http.MethodPost, "/v1/indexes/bench_http_predecoded/search/vector-index", nil)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		rr := httptest.NewRecorder()
+		response, err := svc.SearchBenchmarkVector(httpRequest.Context(), index, request)
+		if err != nil {
+			b.Fatal(err)
+		}
+		writeJSON(rr, http.StatusOK, response)
+		if rr.Code != http.StatusOK {
+			b.Fatalf("status=%d body=%s", rr.Code, rr.Body.String())
+		}
+		benchmarkVectorResponseSink = response
+	}
+}
+
+func BenchmarkBenchmarkVectorSearchResponseEncode(b *testing.B) {
+	response := benchmarkVectorSearchResponseForEncode()
+	payload, err := json.Marshal(response)
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ReportAllocs()
+	b.SetBytes(int64(len(payload)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		payload, err := json.Marshal(response)
+		if err != nil {
+			b.Fatal(err)
+		}
+		benchmarkVectorBytesSink = payload
+	}
+}
+
+func decodeBenchmarkVectorSearchJSONForBenchmark(raw []byte) (BenchmarkVectorSearchRequest, error) {
+	var req BenchmarkVectorSearchRequest
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.UseNumber()
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&req); err != nil {
+		return BenchmarkVectorSearchRequest{}, err
+	}
+	if err := dec.Decode(&struct{}{}); err != io.EOF {
+		if err == nil {
+			err = fmt.Errorf("multiple JSON values in request body")
+		}
+		return BenchmarkVectorSearchRequest{}, err
+	}
+	return req, nil
+}
+
+func benchmarkVectorQuery(dim int) []float32 {
+	query := make([]float32, dim)
+	for i := range query {
+		query[i] = float32(math.Sin(float64(i+1)) * 0.01)
+	}
+	return query
+}
+
+func benchmarkVectorSearchJSONPayload(query []float32) []byte {
+	payload, err := json.Marshal(BenchmarkVectorSearchRequest{QueryEmbedding: query, TopK: 10, EfSearch: 128})
+	if err != nil {
+		panic(err)
+	}
+	return payload
+}
+
+func benchmarkVectorSearchF32LEBase64Payload(query []float32) []byte {
+	payload, err := json.Marshal(BenchmarkVectorSearchRequest{QueryEmbeddingF32LEBase64: encodeFloat32LEBase64ForTest(query), TopK: 10, EfSearch: 128})
+	if err != nil {
+		panic(err)
+	}
+	return payload
+}
+
+func benchmarkVectorSearchResponseForEncode() BenchmarkVectorSearchResponse {
+	results := make([]BenchmarkVectorSearchResult, 10)
+	for i := range results {
+		results[i] = BenchmarkVectorSearchResult{ID: fmt.Sprintf("doc-%06d", i), Ordinal: i + 1, Score: 1 - float64(i)*0.001}
+	}
+	return BenchmarkVectorSearchResponse{
+		Index: IndexInfo{
+			Name:            "bench",
+			Dimension:       1536,
+			Metric:          MetricCosine,
+			VectorIndexName: defaultVectorIndexName,
+			VectorStrategy:  collections.VectorIndexStrategyColumnGraph,
+		},
+		Results:         results,
+		Metric:          MetricCosine,
+		VectorIndexName: defaultVectorIndexName,
+		QueryMode:       BenchmarkVectorQueryModeExact,
+		NoDocuments:     true,
+		Stats: collections.VectorIndexSearchStats{
+			DocumentsFetched:          0,
+			HNSWSearchPackCacheHits:   1,
+			SearchRouteHNSWSearchPack: 1,
+		},
+		Diagnostics: collections.VectorIndexSearchDiagnostics{
+			Route:                         collections.VectorIndexSearchRouteExactHNSWSearchPackV1,
+			ExactHNSWSearchPackNoDocRoute: true,
+			NoDocumentGuardrailsOK:        true,
+			FallbackReason:                collections.VectorIndexSearchFallbackReasonNone,
+		},
+	}
+}

--- a/TreeDB/documentservice/http_vector_index_decode.go
+++ b/TreeDB/documentservice/http_vector_index_decode.go
@@ -1,0 +1,415 @@
+package documentservice
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+var benchmarkVectorSearchBase64FieldNeedle = []byte(`"query_embedding_f32_le_b64"`)
+
+const benchmarkVectorSearchDecodePeekBytes = 512
+
+func (h *Handler) decodeBenchmarkVectorSearchRequest(w http.ResponseWriter, r *http.Request, maxBodyBytes int64) (BenchmarkVectorSearchRequest, bool) {
+	body := http.MaxBytesReader(w, r.Body, maxBodyBytes)
+	defer func() { _ = body.Close() }()
+
+	var prefixBuf [benchmarkVectorSearchDecodePeekBytes]byte
+	n, readErr := io.ReadFull(body, prefixBuf[:])
+	if readErr != nil && readErr != io.EOF && readErr != io.ErrUnexpectedEOF {
+		writeError(w, wrapServiceError(CodeMalformedJSON, "malformed JSON request body", readErr))
+		return BenchmarkVectorSearchRequest{}, false
+	}
+	prefix := prefixBuf[:n]
+
+	var req BenchmarkVectorSearchRequest
+	var err error
+	if bytes.Contains(prefix, benchmarkVectorSearchBase64FieldNeedle) {
+		var rest []byte
+		rest, err = io.ReadAll(body)
+		if err == nil {
+			raw := make([]byte, 0, len(prefix)+len(rest))
+			raw = append(raw, prefix...)
+			raw = append(raw, rest...)
+			req, err = decodeBenchmarkVectorSearchJSON(raw)
+		}
+	} else {
+		req, err = decodeBenchmarkVectorSearchJSONGenericReader(io.MultiReader(bytes.NewReader(prefix), body))
+	}
+	if err != nil {
+		if ErrorCodeOf(err) != CodeInternal {
+			writeError(w, err)
+		} else {
+			writeError(w, wrapServiceError(CodeMalformedJSON, "malformed JSON request body", err))
+		}
+		return BenchmarkVectorSearchRequest{}, false
+	}
+	return req, true
+}
+
+func decodeBenchmarkVectorSearchJSON(raw []byte) (BenchmarkVectorSearchRequest, error) {
+	var req BenchmarkVectorSearchRequest
+	i := skipJSONSpaces(raw, 0)
+	if i >= len(raw) {
+		return req, io.EOF
+	}
+	if raw[i] != '{' {
+		_, err := decodeBenchmarkVectorSearchJSONGeneric(raw)
+		if err != nil {
+			return req, err
+		}
+		return req, fmt.Errorf("expected JSON object")
+	}
+	if !bytes.Contains(raw, benchmarkVectorSearchBase64FieldNeedle) {
+		return decodeBenchmarkVectorSearchJSONGeneric(raw)
+	}
+	i++
+	queryFromBase64 := false
+	base64Present := false
+	for {
+		i = skipJSONSpaces(raw, i)
+		if i >= len(raw) {
+			return req, io.ErrUnexpectedEOF
+		}
+		if raw[i] == '}' {
+			i++
+			break
+		}
+		if raw[i] != '"' {
+			return req, fmt.Errorf("expected JSON object key")
+		}
+		keyEnd, err := scanJSONString(raw, i)
+		if err != nil {
+			return req, err
+		}
+		var key string
+		if err := json.Unmarshal(raw[i:keyEnd], &key); err != nil {
+			return req, err
+		}
+		i = skipJSONSpaces(raw, keyEnd)
+		if i >= len(raw) || raw[i] != ':' {
+			return req, fmt.Errorf("expected ':' after JSON object key")
+		}
+		i = skipJSONSpaces(raw, i+1)
+		valueStart := i
+		valueEnd, err := scanJSONValue(raw, valueStart)
+		if err != nil {
+			return req, err
+		}
+		value := raw[valueStart:valueEnd]
+		switch key {
+		case "expected_generation":
+			err = json.Unmarshal(value, &req.ExpectedGeneration)
+		case "vector_index_name":
+			err = json.Unmarshal(value, &req.VectorIndexName)
+		case "query_embedding":
+			var query []float32
+			err = json.Unmarshal(value, &query)
+			if err == nil && query != nil {
+				if base64Present {
+					return req, serviceError(CodeInvalidRequest, "benchmark vector search accepts either query_embedding or query_embedding_f32_le_b64, not both")
+				}
+				req.QueryEmbedding = query
+				queryFromBase64 = false
+			} else if err == nil && !queryFromBase64 {
+				req.QueryEmbedding = nil
+			}
+		case "query_embedding_f32_le_b64":
+			var query []float32
+			query, base64Present, err = decodeBenchmarkVectorSearchBase64JSONValue(value)
+			if err == nil {
+				if base64Present {
+					if req.QueryEmbedding != nil && !queryFromBase64 {
+						return req, serviceError(CodeInvalidRequest, "benchmark vector search accepts either query_embedding or query_embedding_f32_le_b64, not both")
+					}
+					req.QueryEmbedding = query
+					queryFromBase64 = true
+				} else if queryFromBase64 {
+					req.QueryEmbedding = nil
+					queryFromBase64 = false
+				}
+			}
+		case "top_k":
+			err = json.Unmarshal(value, &req.TopK)
+		case "ef_search":
+			err = json.Unmarshal(value, &req.EfSearch)
+		case "query_mode":
+			err = json.Unmarshal(value, &req.QueryMode)
+		case "quantized_index_name":
+			err = json.Unmarshal(value, &req.QuantizedIndexName)
+		case "quantized_rerank_candidates":
+			err = json.Unmarshal(value, &req.QuantizedRerankCandidates)
+		case "stats_mode":
+			err = json.Unmarshal(value, &req.StatsMode)
+		default:
+			return req, fmt.Errorf("json: unknown field %q", key)
+		}
+		if err != nil {
+			return req, err
+		}
+		i = skipJSONSpaces(raw, valueEnd)
+		if i >= len(raw) {
+			return req, io.ErrUnexpectedEOF
+		}
+		switch raw[i] {
+		case ',':
+			i++
+		case '}':
+			i++
+			if err := rejectTrailingJSONValues(raw[i:]); err != nil {
+				return req, err
+			}
+			return req, nil
+		default:
+			return req, fmt.Errorf("expected ',' or '}' after JSON object field")
+		}
+	}
+	if err := rejectTrailingJSONValues(raw[i:]); err != nil {
+		return req, err
+	}
+	return req, nil
+}
+
+func decodeBenchmarkVectorSearchBase64JSONValue(value []byte) ([]float32, bool, error) {
+	trimmed := bytes.TrimSpace(value)
+	if bytes.Equal(trimmed, []byte("null")) {
+		return nil, false, nil
+	}
+	if len(trimmed) < 2 || trimmed[0] != '"' || trimmed[len(trimmed)-1] != '"' {
+		var s string
+		if err := json.Unmarshal(trimmed, &s); err != nil {
+			return nil, false, err
+		}
+		return decodeBenchmarkVectorSearchBase64String(s)
+	}
+	content := trimmed[1 : len(trimmed)-1]
+	if jsonStringNeedsUnquote(content) {
+		var s string
+		if err := json.Unmarshal(trimmed, &s); err != nil {
+			return nil, false, err
+		}
+		return decodeBenchmarkVectorSearchBase64String(s)
+	}
+	content = bytes.TrimSpace(content)
+	if len(content) == 0 {
+		return nil, false, nil
+	}
+	query, err := decodeBenchmarkVectorQueryEmbeddingF32LEBase64Bytes(content)
+	return query, true, err
+}
+
+func decodeBenchmarkVectorSearchBase64String(encoded string) ([]float32, bool, error) {
+	encoded = trimASCIIWhitespaceString(encoded)
+	if encoded == "" {
+		return nil, false, nil
+	}
+	query, err := decodeBenchmarkVectorQueryEmbeddingF32LEBase64String(encoded)
+	return query, true, err
+}
+
+func decodeBenchmarkVectorSearchJSONGeneric(raw []byte) (BenchmarkVectorSearchRequest, error) {
+	return decodeBenchmarkVectorSearchJSONGenericReader(bytes.NewReader(raw))
+}
+
+func decodeBenchmarkVectorSearchJSONGenericReader(r io.Reader) (BenchmarkVectorSearchRequest, error) {
+	var req BenchmarkVectorSearchRequest
+	dec := json.NewDecoder(r)
+	dec.UseNumber()
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&req); err != nil {
+		return BenchmarkVectorSearchRequest{}, err
+	}
+	if err := dec.Decode(&struct{}{}); err != io.EOF {
+		if err == nil {
+			err = fmt.Errorf("multiple JSON values in request body")
+		}
+		return BenchmarkVectorSearchRequest{}, err
+	}
+	return req, nil
+}
+
+func rejectTrailingJSONValues(raw []byte) error {
+	i := skipJSONSpaces(raw, 0)
+	if i >= len(raw) {
+		return nil
+	}
+	dec := json.NewDecoder(bytes.NewReader(raw[i:]))
+	dec.UseNumber()
+	if err := dec.Decode(&struct{}{}); err != io.EOF {
+		if err == nil {
+			err = fmt.Errorf("multiple JSON values in request body")
+		}
+		return err
+	}
+	return nil
+}
+
+func skipJSONSpaces(raw []byte, i int) int {
+	for i < len(raw) {
+		switch raw[i] {
+		case ' ', '\n', '\r', '\t':
+			i++
+		default:
+			return i
+		}
+	}
+	return i
+}
+
+func scanJSONValue(raw []byte, i int) (int, error) {
+	i = skipJSONSpaces(raw, i)
+	if i >= len(raw) {
+		return i, io.ErrUnexpectedEOF
+	}
+	switch raw[i] {
+	case '"':
+		return scanJSONString(raw, i)
+	case '{':
+		return scanJSONComposite(raw, i, '{', '}')
+	case '[':
+		return scanJSONComposite(raw, i, '[', ']')
+	case 't':
+		return scanJSONLiteral(raw, i, "true")
+	case 'f':
+		return scanJSONLiteral(raw, i, "false")
+	case 'n':
+		return scanJSONLiteral(raw, i, "null")
+	default:
+		if raw[i] == '-' || (raw[i] >= '0' && raw[i] <= '9') {
+			return scanJSONNumber(raw, i)
+		}
+		return i, fmt.Errorf("invalid JSON value")
+	}
+}
+
+func scanJSONString(raw []byte, i int) (int, error) {
+	if i >= len(raw) || raw[i] != '"' {
+		return i, fmt.Errorf("expected JSON string")
+	}
+	for j := i + 1; j < len(raw); j++ {
+		switch raw[j] {
+		case '"':
+			return j + 1, nil
+		case '\\':
+			j++
+			if j >= len(raw) {
+				return j, io.ErrUnexpectedEOF
+			}
+		case 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
+			16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31:
+			return j, fmt.Errorf("invalid character in JSON string")
+		}
+	}
+	return len(raw), io.ErrUnexpectedEOF
+}
+
+func scanJSONComposite(raw []byte, i int, open, close byte) (int, error) {
+	depth := 0
+	for i < len(raw) {
+		switch raw[i] {
+		case '"':
+			end, err := scanJSONString(raw, i)
+			if err != nil {
+				return end, err
+			}
+			i = end
+			continue
+		case open:
+			depth++
+		case close:
+			depth--
+			if depth == 0 {
+				return i + 1, nil
+			}
+		}
+		i++
+	}
+	return i, io.ErrUnexpectedEOF
+}
+
+func scanJSONLiteral(raw []byte, i int, literal string) (int, error) {
+	end := i + len(literal)
+	if end > len(raw) || string(raw[i:end]) != literal {
+		return i, fmt.Errorf("invalid JSON literal")
+	}
+	return end, nil
+}
+
+func scanJSONNumber(raw []byte, i int) (int, error) {
+	start := i
+	if raw[i] == '-' {
+		i++
+		if i >= len(raw) {
+			return i, io.ErrUnexpectedEOF
+		}
+	}
+	if raw[i] == '0' {
+		i++
+	} else if raw[i] >= '1' && raw[i] <= '9' {
+		for i < len(raw) && raw[i] >= '0' && raw[i] <= '9' {
+			i++
+		}
+	} else {
+		return i, fmt.Errorf("invalid JSON number")
+	}
+	if i < len(raw) && raw[i] == '.' {
+		i++
+		if i >= len(raw) || raw[i] < '0' || raw[i] > '9' {
+			return i, fmt.Errorf("invalid JSON number")
+		}
+		for i < len(raw) && raw[i] >= '0' && raw[i] <= '9' {
+			i++
+		}
+	}
+	if i < len(raw) && (raw[i] == 'e' || raw[i] == 'E') {
+		i++
+		if i < len(raw) && (raw[i] == '+' || raw[i] == '-') {
+			i++
+		}
+		if i >= len(raw) || raw[i] < '0' || raw[i] > '9' {
+			return i, fmt.Errorf("invalid JSON number")
+		}
+		for i < len(raw) && raw[i] >= '0' && raw[i] <= '9' {
+			i++
+		}
+	}
+	if i == start {
+		return i, fmt.Errorf("invalid JSON number")
+	}
+	return i, nil
+}
+
+func jsonStringNeedsUnquote(content []byte) bool {
+	for _, c := range content {
+		if c == '\\' || c < 0x20 {
+			return true
+		}
+	}
+	return false
+}
+
+func trimASCIIWhitespaceString(s string) string {
+	start := 0
+	for start < len(s) {
+		switch s[start] {
+		case ' ', '\n', '\r', '\t':
+			start++
+		default:
+			goto foundStart
+		}
+	}
+	return ""
+foundStart:
+	end := len(s)
+	for end > start {
+		switch s[end-1] {
+		case ' ', '\n', '\r', '\t':
+			end--
+		default:
+			return s[start:end]
+		}
+	}
+	return ""
+}

--- a/TreeDB/documentservice/service.go
+++ b/TreeDB/documentservice/service.go
@@ -1341,7 +1341,7 @@ func normalizeBenchmarkVectorQueryEmbedding(req *BenchmarkVectorSearchRequest) e
 	if encoded == "" {
 		return nil
 	}
-	if len(req.QueryEmbedding) > 0 {
+	if req.QueryEmbedding != nil {
 		return serviceError(CodeInvalidRequest, "benchmark vector search accepts either query_embedding or query_embedding_f32_le_b64, not both")
 	}
 	raw, err := base64.StdEncoding.DecodeString(encoded)

--- a/TreeDB/documentservice/service.go
+++ b/TreeDB/documentservice/service.go
@@ -1344,19 +1344,40 @@ func normalizeBenchmarkVectorQueryEmbedding(req *BenchmarkVectorSearchRequest) e
 	if req.QueryEmbedding != nil {
 		return serviceError(CodeInvalidRequest, "benchmark vector search accepts either query_embedding or query_embedding_f32_le_b64, not both")
 	}
+	query, err := decodeBenchmarkVectorQueryEmbeddingF32LEBase64String(encoded)
+	if err != nil {
+		return err
+	}
+	req.QueryEmbedding = query
+	return nil
+}
+
+func decodeBenchmarkVectorQueryEmbeddingF32LEBase64String(encoded string) ([]float32, error) {
 	raw, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {
-		return wrapServiceError(CodeInvalidRequest, "decode query_embedding_f32_le_b64 failed", err)
+		return nil, wrapServiceError(CodeInvalidRequest, "decode query_embedding_f32_le_b64 failed", err)
 	}
+	return decodeBenchmarkVectorQueryEmbeddingF32LERaw(raw)
+}
+
+func decodeBenchmarkVectorQueryEmbeddingF32LEBase64Bytes(encoded []byte) ([]float32, error) {
+	raw := make([]byte, base64.StdEncoding.DecodedLen(len(encoded)))
+	n, err := base64.StdEncoding.Decode(raw, encoded)
+	if err != nil {
+		return nil, wrapServiceError(CodeInvalidRequest, "decode query_embedding_f32_le_b64 failed", err)
+	}
+	return decodeBenchmarkVectorQueryEmbeddingF32LERaw(raw[:n])
+}
+
+func decodeBenchmarkVectorQueryEmbeddingF32LERaw(raw []byte) ([]float32, error) {
 	if len(raw)%4 != 0 {
-		return serviceErrorf(CodeInvalidRequest, "query_embedding_f32_le_b64 decoded byte length %d is not a multiple of 4", len(raw))
+		return nil, serviceErrorf(CodeInvalidRequest, "query_embedding_f32_le_b64 decoded byte length %d is not a multiple of 4", len(raw))
 	}
 	query := make([]float32, len(raw)/4)
 	for i := range query {
 		query[i] = math.Float32frombits(binary.LittleEndian.Uint32(raw[i*4:]))
 	}
-	req.QueryEmbedding = query
-	return nil
+	return query, nil
 }
 
 func validateBenchmarkVectorSearchRequestShape(mode BenchmarkVectorQueryMode, req BenchmarkVectorSearchRequest) error {

--- a/TreeDB/documentservice/service.go
+++ b/TreeDB/documentservice/service.go
@@ -3,6 +3,8 @@ package documentservice
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
+	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -545,6 +547,9 @@ func (s *Service) SearchBenchmarkVector(ctx context.Context, index string, req B
 		return BenchmarkVectorSearchResponse{}, serviceError(CodeInvalidRequest, "ef_search and quantized_rerank_candidates must be non-negative")
 	}
 	if err := validateBenchmarkVectorStatsMode(req.StatsMode); err != nil {
+		return BenchmarkVectorSearchResponse{}, err
+	}
+	if err := normalizeBenchmarkVectorQueryEmbedding(&req); err != nil {
 		return BenchmarkVectorSearchResponse{}, err
 	}
 	if err := validateEmbedding("query_embedding", req.QueryEmbedding, info.Dimension, info.Metric); err != nil {
@@ -1326,6 +1331,32 @@ func validateBenchmarkVectorStatsMode(mode collections.VectorIndexSearchStatsMod
 	default:
 		return serviceErrorf(CodeInvalidRequest, "unsupported benchmark vector stats_mode %q", mode)
 	}
+}
+
+func normalizeBenchmarkVectorQueryEmbedding(req *BenchmarkVectorSearchRequest) error {
+	if req == nil {
+		return nil
+	}
+	encoded := strings.TrimSpace(req.QueryEmbeddingF32LEBase64)
+	if encoded == "" {
+		return nil
+	}
+	if len(req.QueryEmbedding) > 0 {
+		return serviceError(CodeInvalidRequest, "benchmark vector search accepts either query_embedding or query_embedding_f32_le_b64, not both")
+	}
+	raw, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		return wrapServiceError(CodeInvalidRequest, "decode query_embedding_f32_le_b64 failed", err)
+	}
+	if len(raw)%4 != 0 {
+		return serviceErrorf(CodeInvalidRequest, "query_embedding_f32_le_b64 decoded byte length %d is not a multiple of 4", len(raw))
+	}
+	query := make([]float32, len(raw)/4)
+	for i := range query {
+		query[i] = math.Float32frombits(binary.LittleEndian.Uint32(raw[i*4:]))
+	}
+	req.QueryEmbedding = query
+	return nil
 }
 
 func validateBenchmarkVectorSearchRequestShape(mode BenchmarkVectorQueryMode, req BenchmarkVectorSearchRequest) error {

--- a/TreeDB/documentservice/service_benchmark_cache_test.go
+++ b/TreeDB/documentservice/service_benchmark_cache_test.go
@@ -194,14 +194,14 @@ func benchmarkColumnGraphOptions() *BenchmarkVectorIndexOptions {
 	return &BenchmarkVectorIndexOptions{Strategy: collections.VectorIndexStrategyColumnGraph, M: 4, EfSearch: 8}
 }
 
-func createBenchmarkColumnGraphIndex(t *testing.T, svc *Service, index string) {
+func createBenchmarkColumnGraphIndex(t testing.TB, svc *Service, index string) {
 	t.Helper()
 	if _, err := svc.ResetIndex(context.Background(), index, ResetIndexRequest{Dimension: 2, Metric: MetricCosine, DropOld: true, VectorIndexOptions: benchmarkColumnGraphOptions()}); err != nil {
 		t.Fatalf("ResetIndex %s create: %v", index, err)
 	}
 }
 
-func loadBenchmarkDocsDeferred(t *testing.T, svc *Service, index string, docs []Document) {
+func loadBenchmarkDocsDeferred(t testing.TB, svc *Service, index string, docs []Document) {
 	t.Helper()
 	if _, err := svc.UpsertDocuments(context.Background(), index, UpsertDocumentsRequest{Documents: docs, DeferVectorIndexRebuild: true}); err != nil {
 		t.Fatalf("UpsertDocuments %s deferred: %v", index, err)

--- a/TreeDB/documentservice/service_test.go
+++ b/TreeDB/documentservice/service_test.go
@@ -831,7 +831,7 @@ func searchMetaHasSources(meta map[string]any, sources ...string) bool {
 	return true
 }
 
-func newTestService(t *testing.T) (*Service, *backenddb.DB) {
+func newTestService(t testing.TB) (*Service, *backenddb.DB) {
 	t.Helper()
 	db, err := backenddb.Open(testBackendOptions(t.TempDir()))
 	if err != nil {

--- a/TreeDB/documentservice/types.go
+++ b/TreeDB/documentservice/types.go
@@ -246,7 +246,8 @@ const (
 type BenchmarkVectorSearchRequest struct {
 	ExpectedGeneration        uint64                                 `json:"expected_generation,omitempty"`
 	VectorIndexName           string                                 `json:"vector_index_name,omitempty"`
-	QueryEmbedding            []float32                              `json:"query_embedding"`
+	QueryEmbedding            []float32                              `json:"query_embedding,omitempty"`
+	QueryEmbeddingF32LEBase64 string                                 `json:"query_embedding_f32_le_b64,omitempty"`
 	TopK                      int                                    `json:"top_k"`
 	EfSearch                  int                                    `json:"ef_search,omitempty"`
 	QueryMode                 BenchmarkVectorQueryMode               `json:"query_mode,omitempty"`

--- a/clients/python/treedb_client/README.md
+++ b/clients/python/treedb_client/README.md
@@ -159,6 +159,9 @@ bench = client.search_vector_index(
     "bench_run_001",
     query_embedding=[0.1, 0.2, 0.3],
     top_k=1,
+    # Optional high-QPS request encoding: "f32_le_b64" sends the query as
+    # base64 little-endian float32 bytes instead of a JSON float array.
+    query_embedding_encoding="f32_le_b64",
     query_mode="quantized_rerank",
     quantized_index_name="embedding.scalar_u8.fast",
     quantized_rerank_candidates=32,

--- a/clients/python/treedb_client/src/treedb_client/client.py
+++ b/clients/python/treedb_client/src/treedb_client/client.py
@@ -482,7 +482,7 @@ def _add_optional_non_empty_string(request: dict[str, Any], key: str, value: Opt
 
 def _add_query_embedding(request: dict[str, Any], query_embedding: Sequence[float], encoding: str) -> None:
     if encoding == "json":
-        request["query_embedding"] = [float(value) for value in query_embedding]
+        request["query_embedding"] = _coerce_query_embedding_floats(query_embedding)
         return
     if encoding == "f32_le_b64":
         request["query_embedding_f32_le_b64"] = _encode_f32_le_base64(query_embedding)
@@ -490,13 +490,17 @@ def _add_query_embedding(request: dict[str, Any], query_embedding: Sequence[floa
     raise InvalidRequestError("invalid_request", "query_embedding_encoding must be 'json' or 'f32_le_b64'")
 
 
-def _encode_f32_le_base64(values: Sequence[float]) -> str:
+def _coerce_query_embedding_floats(values: Sequence[float]) -> list[float]:
     if isinstance(values, (str, bytes, bytearray)):
         raise InvalidRequestError("invalid_request", "query_embedding must be a sequence of floats")
     try:
-        floats = [float(value) for value in values]
+        return [float(value) for value in values]
     except (TypeError, ValueError) as exc:
         raise InvalidRequestError("invalid_request", "query_embedding must be a sequence of floats") from exc
+
+
+def _encode_f32_le_base64(values: Sequence[float]) -> str:
+    floats = _coerce_query_embedding_floats(values)
     payload = struct.pack(f"<{len(floats)}f", *floats) if floats else b""
     return base64.b64encode(payload).decode("ascii")
 

--- a/clients/python/treedb_client/src/treedb_client/client.py
+++ b/clients/python/treedb_client/src/treedb_client/client.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import base64
 import http.client
 import json
 import socket
+import struct
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -266,6 +268,7 @@ class TreeDBClient:
         quantized_rerank_candidates: Optional[int] = None,
         stats_mode: Optional[str] = None,
         expected_generation: Optional[int] = None,
+        query_embedding_encoding: str = "json",
     ) -> BenchmarkVectorSearchResponse:
         """Run fail-closed no-document vector-index benchmark search.
 
@@ -274,10 +277,8 @@ class TreeDBClient:
         emulated by client-side or service-side exact fallback.
         """
 
-        request: dict[str, Any] = {
-            "query_embedding": [float(value) for value in query_embedding],
-            "top_k": top_k,
-        }
+        request: dict[str, Any] = {"top_k": top_k}
+        _add_query_embedding(request, query_embedding, query_embedding_encoding)
         _add_expected_generation(request, expected_generation)
         if vector_index_name:
             request["vector_index_name"] = vector_index_name
@@ -477,6 +478,27 @@ def _add_optional_non_empty_string(request: dict[str, Any], key: str, value: Opt
     if not isinstance(value, str) or value.strip() == "":
         raise InvalidRequestError("invalid_request", f"{label} must be a non-empty string when provided")
     request[key] = value
+
+
+def _add_query_embedding(request: dict[str, Any], query_embedding: Sequence[float], encoding: str) -> None:
+    if encoding == "json":
+        request["query_embedding"] = [float(value) for value in query_embedding]
+        return
+    if encoding == "f32_le_b64":
+        request["query_embedding_f32_le_b64"] = _encode_f32_le_base64(query_embedding)
+        return
+    raise InvalidRequestError("invalid_request", "query_embedding_encoding must be 'json' or 'f32_le_b64'")
+
+
+def _encode_f32_le_base64(values: Sequence[float]) -> str:
+    if isinstance(values, (str, bytes, bytearray)):
+        raise InvalidRequestError("invalid_request", "query_embedding must be a sequence of floats")
+    try:
+        floats = [float(value) for value in values]
+    except TypeError as exc:
+        raise InvalidRequestError("invalid_request", "query_embedding must be a sequence of floats") from exc
+    payload = struct.pack(f"<{len(floats)}f", *floats) if floats else b""
+    return base64.b64encode(payload).decode("ascii")
 
 
 def _add_filter(request: dict[str, Any], filter_value: Optional[FilterLike]) -> None:

--- a/clients/python/treedb_client/src/treedb_client/client.py
+++ b/clients/python/treedb_client/src/treedb_client/client.py
@@ -495,7 +495,7 @@ def _encode_f32_le_base64(values: Sequence[float]) -> str:
         raise InvalidRequestError("invalid_request", "query_embedding must be a sequence of floats")
     try:
         floats = [float(value) for value in values]
-    except TypeError as exc:
+    except (TypeError, ValueError) as exc:
         raise InvalidRequestError("invalid_request", "query_embedding must be a sequence of floats") from exc
     payload = struct.pack(f"<{len(floats)}f", *floats) if floats else b""
     return base64.b64encode(payload).decode("ascii")

--- a/clients/python/treedb_client/tests/test_client.py
+++ b/clients/python/treedb_client/tests/test_client.py
@@ -318,6 +318,8 @@ class TreeDBClientTests(unittest.TestCase):
             client.search_vector_index("docs", [1, 0], 1, query_embedding_encoding="binary")
         with self.assertRaisesRegex(InvalidRequestError, "query_embedding"):
             client.search_vector_index("docs", ["not-a-number"], 1, query_embedding_encoding="f32_le_b64")
+        with self.assertRaisesRegex(InvalidRequestError, "query_embedding"):
+            client.search_vector_index("docs", ["not-a-number"], 1, query_embedding_encoding="json")
 
     def test_keyword_search_serializes_request_and_parses_response(self) -> None:
         route = "/v1/indexes/docs/search/keyword"

--- a/clients/python/treedb_client/tests/test_client.py
+++ b/clients/python/treedb_client/tests/test_client.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import base64
 import json
+import struct
 import threading
 import time
 import unittest
@@ -281,14 +283,25 @@ class TreeDBClientTests(unittest.TestCase):
 
             self.assertTrue(reset.created)
             self.assertTrue(optimize.status.loaded)
+            b64_search = client.search_vector_index(
+                "bench",
+                [1, 0],
+                1,
+                query_embedding_encoding="f32_le_b64",
+            )
+
             self.assertEqual(search.query_mode, "quantized_rerank")
             self.assertEqual(search.results[0].id, "doc-1")
+            self.assertEqual(b64_search.results[0].id, "doc-1")
             reset_body = json_body(server.records[0])
             self.assertNotIn("metric", reset_body)
             self.assertEqual(reset_body["vector_index_options"]["strategy"], "column_graph")
             self.assertEqual(reset_body["vector_index_options"]["quantized_indexes"][0]["codec"], "scalar_u8")
             self.assertEqual(json_body(server.records[1]), {"expected_generation": 1})
             self.assertEqual(json_body(server.records[2])["quantized_rerank_candidates"], 32)
+            b64_body = json_body(server.records[3])
+            self.assertNotIn("query_embedding", b64_body)
+            self.assertEqual(struct.unpack("<2f", base64.b64decode(b64_body["query_embedding_f32_le_b64"])), (1.0, 0.0))
 
     def test_empty_optional_benchmark_fields_fail_closed_locally(self) -> None:
         client = TreeDBClient("http://127.0.0.1:1", timeout=1)
@@ -301,6 +314,8 @@ class TreeDBClientTests(unittest.TestCase):
             client.search_vector_index("docs", [1, 0], 1, query_mode="")
         with self.assertRaisesRegex(InvalidRequestError, "stats_mode"):
             client.search_vector_index("docs", [1, 0], 1, stats_mode="")
+        with self.assertRaisesRegex(InvalidRequestError, "query_embedding_encoding"):
+            client.search_vector_index("docs", [1, 0], 1, query_embedding_encoding="binary")
 
     def test_keyword_search_serializes_request_and_parses_response(self) -> None:
         route = "/v1/indexes/docs/search/keyword"

--- a/clients/python/treedb_client/tests/test_client.py
+++ b/clients/python/treedb_client/tests/test_client.py
@@ -316,6 +316,8 @@ class TreeDBClientTests(unittest.TestCase):
             client.search_vector_index("docs", [1, 0], 1, stats_mode="")
         with self.assertRaisesRegex(InvalidRequestError, "query_embedding_encoding"):
             client.search_vector_index("docs", [1, 0], 1, query_embedding_encoding="binary")
+        with self.assertRaisesRegex(InvalidRequestError, "query_embedding"):
+            client.search_vector_index("docs", ["not-a-number"], 1, query_embedding_encoding="f32_le_b64")
 
     def test_keyword_search_serializes_request_and_parses_response(self) -> None:
         route = "/v1/indexes/docs/search/keyword"

--- a/docs/TREEDB_DOCUMENT_SERVICE_API.md
+++ b/docs/TREEDB_DOCUMENT_SERVICE_API.md
@@ -388,7 +388,7 @@ exactly one of `query_embedding` or `query_embedding_f32_le_b64`:
 
 ```json
 {
-  "query_embedding_f32_le_b64": "AACAPwAAAAAAAAAAAAA=",
+  "query_embedding_f32_le_b64": "AACAPwAAAAAAAAAA",
   "top_k": 10,
   "ef_search": 64,
   "query_mode": "exact"

--- a/docs/TREEDB_DOCUMENT_SERVICE_API.md
+++ b/docs/TREEDB_DOCUMENT_SERVICE_API.md
@@ -382,6 +382,19 @@ POST /v1/indexes/{index}/search/vector-index
 }
 ```
 
+For high-QPS clients that already hold float32 query vectors, the same route
+also accepts a typed little-endian float32 payload encoded as base64. Supply
+exactly one of `query_embedding` or `query_embedding_f32_le_b64`:
+
+```json
+{
+  "query_embedding_f32_le_b64": "AACAPwAAAAAAAAAAAAA=",
+  "top_k": 10,
+  "ef_search": 64,
+  "query_mode": "exact"
+}
+```
+
 Supported `query_mode` values are `exact`, `quantized_only`, and
 `quantized_rerank`. Quantized modes require a declared quantized index name and
 fail closed when assets are missing, invalid, stale, or unavailable. Responses


### PR DESCRIPTION
Closes #2670

Parent tracker: #2669

## Objective

Reduce `/search/vector-index` HTTP/JSON request overhead by accepting typed float32 query payloads on the existing route.

## Design

- Adds `query_embedding_f32_le_b64` to `BenchmarkVectorSearchRequest`.
- The existing `/v1/indexes/{index}/search/vector-index` route now accepts exactly one of:
  - `query_embedding`: JSON float array;
  - `query_embedding_f32_le_b64`: base64 little-endian `float32[]` bytes.
- Uses a route-specific decoder for the normal f32_b64 JSON shape so the server decodes base64 bytes directly into the query vector without the generic `json.Decoder` string-allocation path; JSON float-array requests keep the generic strict decoder.
- Keeps unknown-field and extra-top-level JSON rejection fail-closed.
- Keeps `/search/vector` exact dense document scoring unchanged.
- Keeps vector-index fail-closed route validation and no-document guardrails unchanged.
- Python client exposes an explicit `query_embedding_encoding="f32_le_b64"` option for `search_vector_index`.

## Scope

Includes:

- `TreeDB/documentservice` request type/decode validation/tests/benchmarks.
- `clients/python/treedb_client` explicit typed query encoding option.
- Document service API docs.

Excludes:

- No binary endpoint yet.
- No batch endpoint yet.
- No changes to `/search/vector` dense document route.

## Correctness / tests

Latest local rerun after decode optimization on `6374695996ec96969d7595d272455960dd39c3ad`.

- `go test ./TreeDB/documentservice -count=1`
- `go test ./cmd/treedb-document-service -count=1`
- `cd clients/python/treedb_client && uv run --with pytest pytest -q`
  - `38 passed, 1 skipped, 4 subtests passed`

## Focused benchmarks

Command:

```sh
go test ./TreeDB/documentservice -run '^$' -bench 'BenchmarkBenchmarkVectorSearch(Decode|HTTPPredecodedRequest|ResponseEncode)' -benchmem -count=5
```

Artifact: `/tmp/treedb_http_b64_bench_20260612_093716.txt`

Medians on local Apple M3, gomap `6374695996ec96969d7595d272455960dd39c3ad`:

| benchmark | median ns/op | ops/sec | B/op | allocs/op |
| --- | ---: | ---: | ---: | ---: |
| JSON float-array request decode, 1536D | 199,105 | 5,022.5 | 85,224 | 27 |
| f32_le_b64 request decode, optimized route decoder, 1536D | 13,963 | 71,617.8 | 13,248 | 14 |
| f32_le_b64 request decode, generic decoder comparator, 1536D | 36,818 | 27,160.6 | 51,792 | 15 |
| raw f32_le_b64 decode component, 1536D | 4,330 | 230,946.9 | 12,288 | 2 |
| predecoded service+response path smoke | 8,588 | 116,441.5 | 13,673 | 30 |
| response JSON encode smoke | 6,650 | 150,375.9 | 4,480 | 2 |

Comparison against the earlier issue artifact is in `/tmp/treedb_http_b64_bench_issue_vs_after_20260612_093716_benchstat.txt`; optimized f32_b64 request decode is `-67.79% sec/op` and `-74.42% B/op` vs `/tmp/treedb_http_b64_bench_20260612_064807.txt`.

Decode profile artifacts: `/tmp/treedb_http_b64_decode_profile_20260612_093651`.

## VDBBench / route validation

Latest local VDBBench validation on gomap `6374695996ec96969d7595d272455960dd39c3ad` and vectordbbench `d44d34281547777b731ec15295ee63c068c4adad`:

- Artifact: `/private/tmp/treedb_vdbbench_http_b64_exact_latest_20260612_094531`
- Command row: TreeDB exact FP32, `Performance1536D50K`, `query_embedding_encoding=f32_le_b64`, c1/c8/c32, duration 10s
- VDBBench label: `:)`
- c1/c8/c32 QPS: `613.6109 / 2021.8337 / 1304.1283`
- p95: `0.002336 / 0.006995 / 0.065159`
- p99: `0.003970 / 0.017139 / 0.106381`
- recall/NDCG: `0.9954 / 0.9961`
- insert/optimize/load: `70.3891s / 176.5783s / 246.9674s`

Latest typed request route proof on gomap `6374695996ec96969d7595d272455960dd39c3ad`:

- Artifact: `/tmp/treedb_http_b64_route_proof_20260612_095127/route_proof_exact_b64.json`
- `request_encoding=query_embedding_f32_le_b64`
- `route=exact_hnsw_search_pack_v1`
- `fallback_reason=none`
- `no_documents=true`
- `documents_fetched=0`

Previous remote validation artifact (older PR head `e4ff889839eb4f671eaf99cb8cee7130fddb18ba`): `/mnt/fast4tb/tmp/treedb_vdbbench_http_b64_exact_20260612_084659`, c1/c8/c32 `625.9383 / 2125.8858 / 2262.4396`, recall/NDCG `0.9954 / 0.9961`, route proof `query_embedding_f32_le_b64`, `exact_hnsw_search_pack_v1`, `documents_fetched=0`.

Caveat: VDBBench rows are validation evidence for this PR, not final public comparator evidence.

## Downstream / follow-ups

- VectorDBBench adapter PR: https://github.com/snissn/vectordbbench/pull/5
- Raw binary single-query endpoint belongs to #2671.
- Batch endpoints are out of scope for this PR.
