### PR TITLE
Protect folded collection roots during storage compaction

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -399,6 +399,12 @@ type CollectionRootOverlayCompactionStats struct {
 	OverlayRoots int
 }
 
+type collectionRootOverlayCompactionResult struct {
+	stats        CollectionRootOverlayCompactionStats
+	rootIDs      []uint64
+	systemRootID uint64
+}
+
 // StoredDocumentJSONMaterializer reuses any resources needed to materialize
 // stored collection documents as JSON.
 type StoredDocumentJSONMaterializer struct {
@@ -3692,11 +3698,17 @@ func (c *Collection) Flush() error {
 // architecture: hot writes may publish durable overlays quickly, then maintenance
 // can restore the simple one-root read shape.
 func (c *Collection) CompactRootOverlays(ctx context.Context) (CollectionRootOverlayCompactionStats, error) {
+	result, err := c.compactRootOverlays(ctx)
+	return result.stats, err
+}
+
+func (c *Collection) compactRootOverlays(ctx context.Context) (collectionRootOverlayCompactionResult, error) {
+	var result collectionRootOverlayCompactionResult
 	if c == nil {
-		return CollectionRootOverlayCompactionStats{}, errCollectionNil
+		return result, errCollectionNil
 	}
 	if c.db == nil {
-		return CollectionRootOverlayCompactionStats{}, errCollectionDBNil
+		return result, errCollectionDBNil
 	}
 	if ctx == nil {
 		ctx = context.Background()
@@ -3709,32 +3721,32 @@ func (c *Collection) CompactRootOverlays(ctx context.Context) (CollectionRootOve
 	return c.compactRootOverlaysLocked(ctx)
 }
 
-func (c *Collection) compactRootOverlaysLocked(ctx context.Context) (CollectionRootOverlayCompactionStats, error) {
-	var stats CollectionRootOverlayCompactionStats
+func (c *Collection) compactRootOverlaysLocked(ctx context.Context) (collectionRootOverlayCompactionResult, error) {
+	var result collectionRootOverlayCompactionResult
 	if err := ctx.Err(); err != nil {
-		return stats, err
+		return result, err
 	}
 	if err := c.flushBufferedWrites(); err != nil {
-		return stats, err
+		return result, err
 	}
 	if err := ctx.Err(); err != nil {
-		return stats, err
+		return result, err
 	}
 	snap := c.db.AcquireSnapshot()
 	if snap == nil {
-		return stats, backenddb.ErrClosed
+		return result, backenddb.ErrClosed
 	}
 	defer func() { _ = snap.Close() }()
 	catalog, err := c.catalogForSnapshot(snap)
 	if err != nil {
-		return stats, err
+		return result, err
 	}
 	if catalog == nil {
-		return stats, errCollectionNotFound
+		return result, errCollectionNotFound
 	}
 	rootNames := catalog.overlayRootNames()
 	if len(rootNames) == 0 {
-		return stats, nil
+		return result, nil
 	}
 	baseRootIDs := make(map[string]uint64, len(rootNames))
 	rootOverlays := make(map[string][]uint64, len(rootNames))
@@ -3749,7 +3761,7 @@ func (c *Collection) compactRootOverlaysLocked(ctx context.Context) (CollectionR
 	for _, rootName := range rootNames {
 		if err := ctx.Err(); err != nil {
 			cleanupIters()
-			return stats, err
+			return result, err
 		}
 		overlays := append([]uint64(nil), catalog.overlayRootIDs(rootName)...)
 		if len(overlays) == 0 {
@@ -3758,12 +3770,12 @@ func (c *Collection) compactRootOverlaysLocked(ctx context.Context) (CollectionR
 		policy, err := collectionRootStoragePolicyForDB(c.db, catalog.meta, rootName)
 		if err != nil {
 			cleanupIters()
-			return stats, err
+			return result, err
 		}
 		it, err := collectionIteratorAtCatalogRoot(snap, catalog, rootName, nil, nil, false)
 		if err != nil {
 			cleanupIters()
-			return stats, err
+			return result, err
 		}
 		if it == nil {
 			it = &systemTargetIterator{}
@@ -3775,11 +3787,11 @@ func (c *Collection) compactRootOverlaysLocked(ctx context.Context) (CollectionR
 			Iter:          it,
 			StoragePolicy: policy,
 		})
-		stats.Roots++
-		stats.OverlayRoots += len(overlays)
+		result.stats.Roots++
+		result.stats.OverlayRoots += len(overlays)
 	}
 	if len(ordered) == 0 {
-		return stats, nil
+		return result, nil
 	}
 	baseSystemRoot := snapshotSystemRoot(snap)
 	baseCommitSeq := snapshotCommitSeq(snap)
@@ -3788,16 +3800,18 @@ func (c *Collection) compactRootOverlaysLocked(ctx context.Context) (CollectionR
 	})
 	cleanupIters()
 	if err != nil {
-		return stats, err
+		return result, err
 	}
 	if len(rootIDs) != len(rootNames) {
-		return stats, unexpectedOrderedRootCountError(catalog.meta.Name, len(rootNames), len(rootIDs))
+		return result, unexpectedOrderedRootCountError(catalog.meta.Name, len(rootNames), len(rootIDs))
 	}
 	nextCatalog := cloneCatalogWithRootUpdates(catalog, catalog.meta, rootNames, rootIDs)
 	c.meta = catalog.meta
 	c.rememberCatalogAtSystemRoot(newSystemRoot, nextCatalog)
 	c.noteWriteDomainCatalog(newSystemRoot, nextCatalog)
-	return stats, nil
+	result.rootIDs = appendCollectionCompactStorageProtectedRootIDs(result.rootIDs, rootIDs)
+	result.systemRootID = newSystemRoot
+	return result, nil
 }
 
 func (c *Collection) insertOneNoIndexBuffered(id, document []byte) ([]byte, error) {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -4789,6 +4789,109 @@ func TestCollectionCompactRootOverlaysFoldsIntoBaseRoots(t *testing.T) {
 	}
 }
 
+func TestCollectionCompactStorageProtectsFoldedRootIDs(t *testing.T) {
+	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	mgr := NewCollectionManager(db)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			BufferedIndexedOverlayRoots:      true,
+			DisableBufferedIndexedAsyncFlush: true,
+			BufferedIndexedWriteMaxDocuments: 1,
+			BufferedIndexedWriteMaxRootRuns:  1,
+		},
+		Indexes: []IndexDefinition{
+			{Name: "city", Field: "city", ValueType: IndexValueString},
+			{Name: "email", Field: "email", ValueType: IndexValueString, Unique: true},
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.Insert([]byte("u1"), []byte(`{"email":"ada@example.com","city":"hnl"}`)); err != nil {
+		t.Fatalf("insert u1: %v", err)
+	}
+	if _, _, err := col.UpdateBatchIfNoSecondaryUniqueIndexChanges([]UpdateBatchItem{{
+		DocumentID: []byte("u1"),
+		Update: func(current []byte) ([]byte, bool, error) {
+			return []byte(`{"email":"ada@example.com","city":"sea"}`), true, nil
+		},
+	}}); err != nil {
+		t.Fatalf("update city: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush overlays: %v", err)
+	}
+
+	result, err := col.compactRootOverlays(context.Background())
+	if err != nil {
+		t.Fatalf("compact root overlays: %v", err)
+	}
+	if result.stats.Roots == 0 || result.stats.OverlayRoots == 0 {
+		t.Fatalf("compact result stats=%+v want nonzero roots and overlays", result.stats)
+	}
+	if len(result.rootIDs) == 0 {
+		t.Fatal("compact result rootIDs=0 want folded roots protected")
+	}
+	if result.systemRootID == 0 {
+		t.Fatal("compact result systemRootID=0 want published system root protected")
+	}
+
+	opts := compactStorageOptionsWithCollectionRootProtection(CompactStorageOptions{}, result)
+	for _, rootID := range result.rootIDs {
+		if got := countCompactStorageProtectedRootID(opts.LeafGenerationProtectedRootIDs, rootID); got != 0 {
+			t.Fatalf("direct protected root id %d occurrences=%d in %v want 0", rootID, got, opts.LeafGenerationProtectedRootIDs)
+		}
+	}
+	if got := countCompactStorageProtectedRootID(opts.LeafGenerationProtectedSystemRootIDs, result.systemRootID); got != 1 {
+		t.Fatalf("protected system root id %d occurrences=%d in %v want 1", result.systemRootID, got, opts.LeafGenerationProtectedSystemRootIDs)
+	}
+	if _, err := db.CompactStoragePlan(context.Background(), backenddb.CompactStorageOptions(opts)); err != nil {
+		t.Fatalf("CompactStoragePlan with folded-root protection: %v", err)
+	}
+}
+
+func TestCompactStorageOptionsWithCollectionRootProtectionMergesDistinctRoots(t *testing.T) {
+	opts := compactStorageOptionsWithCollectionRootProtection(CompactStorageOptions{
+		LeafGenerationProtectedRootIDs:       []uint64{1, 2},
+		LeafGenerationProtectedSystemRootIDs: []uint64{10},
+	},
+		collectionRootOverlayCompactionResult{
+			rootIDs:      []uint64{0, 2, 3},
+			systemRootID: 10,
+		},
+		collectionRootOverlayCompactionResult{
+			rootIDs:      []uint64{3, 4},
+			systemRootID: 11,
+		},
+		collectionRootOverlayCompactionResult{},
+	)
+	if want := []uint64{1, 2}; !reflect.DeepEqual(opts.LeafGenerationProtectedRootIDs, want) {
+		t.Fatalf("protected root ids=%v want %v", opts.LeafGenerationProtectedRootIDs, want)
+	}
+	if want := []uint64{10, 11}; !reflect.DeepEqual(opts.LeafGenerationProtectedSystemRootIDs, want) {
+		t.Fatalf("protected system root ids=%v want %v", opts.LeafGenerationProtectedSystemRootIDs, want)
+	}
+}
+
+func countCompactStorageProtectedRootID(ids []uint64, want uint64) int {
+	var count int
+	for _, id := range ids {
+		if id == want {
+			count++
+		}
+	}
+	return count
+}
+
 func TestCollectionCompactStorageFoldsRootsAndCleansStorage(t *testing.T) {
 	dir := t.TempDir()
 	opts := treedb.OptionsFor(treedb.ProfileFast, dir)

--- a/TreeDB/collections/compact_storage.go
+++ b/TreeDB/collections/compact_storage.go
@@ -41,13 +41,14 @@ func (c *Collection) CompactStorage(ctx context.Context, opts CompactStorageOpti
 		stats.Storage = storage
 		return stats, err
 	}
-	rootStats, err := c.CompactRootOverlays(ctx)
+	rootResult, err := c.compactRootOverlays(ctx)
 	if err != nil {
 		return stats, err
 	}
 	stats.RootOverlays = map[string]CollectionRootOverlayCompactionStats{
-		c.meta.Name: rootStats,
+		c.meta.Name: rootResult.stats,
 	}
+	opts = compactStorageOptionsWithCollectionRootProtection(opts, rootResult)
 	storage, err := c.db.CompactStorage(ctx, backenddb.CompactStorageOptions(opts))
 	if err != nil {
 		return stats, err
@@ -86,6 +87,7 @@ func (m *CollectionManager) CompactStorage(ctx context.Context, opts CompactStor
 		return stats, err
 	}
 	stats.RootOverlays = make(map[string]CollectionRootOverlayCompactionStats, len(metas))
+	rootResults := make([]collectionRootOverlayCompactionResult, 0, len(metas))
 	for _, meta := range metas {
 		if err := ctx.Err(); err != nil {
 			return stats, err
@@ -94,16 +96,49 @@ func (m *CollectionManager) CompactStorage(ctx context.Context, opts CompactStor
 		if err != nil {
 			return stats, err
 		}
-		rootStats, err := collection.CompactRootOverlays(ctx)
+		rootResult, err := collection.compactRootOverlays(ctx)
 		if err != nil {
 			return stats, err
 		}
-		stats.RootOverlays[meta.Name] = rootStats
+		stats.RootOverlays[meta.Name] = rootResult.stats
+		rootResults = append(rootResults, rootResult)
 	}
+	opts = compactStorageOptionsWithCollectionRootProtection(opts, rootResults...)
 	storage, err := m.db.CompactStorage(ctx, backenddb.CompactStorageOptions(opts))
 	if err != nil {
 		return stats, err
 	}
 	stats.Storage = storage
 	return stats, nil
+}
+
+func compactStorageOptionsWithCollectionRootProtection(opts CompactStorageOptions, results ...collectionRootOverlayCompactionResult) CompactStorageOptions {
+	for _, result := range results {
+		if result.systemRootID != 0 {
+			opts.LeafGenerationProtectedSystemRootIDs = appendCollectionCompactStorageProtectedRootIDs(
+				opts.LeafGenerationProtectedSystemRootIDs,
+				[]uint64{result.systemRootID},
+			)
+		}
+	}
+	return opts
+}
+
+func appendCollectionCompactStorageProtectedRootIDs(dst []uint64, src []uint64) []uint64 {
+	for _, rootID := range src {
+		if rootID == 0 {
+			continue
+		}
+		seen := false
+		for _, existing := range dst {
+			if existing == rootID {
+				seen = true
+				break
+			}
+		}
+		if !seen {
+			dst = append(dst, rootID)
+		}
+	}
+	return dst
 }


### PR DESCRIPTION
## Objective

Fixes #2665 by making collection-aware `CompactStorage` preserve the freshly published collection system root while backend storage compaction plans, packs, and GCs leaf generations.

## Context

`TestCollectionCompactStorageFoldsRootsAndCleansStorage` was reported as transient in a full `./TreeDB/collections` run, while focused reruns and later package runs passed. The vulnerable boundary is collection `CompactStorage`: it folds overlay roots, then immediately invokes backend storage compaction. The backend has explicit protected system-root expansion for collection descriptors; the collection layer was not passing the newly published system root from the fold into that protection path.

## Non-goals

- No on-disk format changes.
- No value-log or WAL semantic changes.
- No migration or benchmark milestone updates.

## Design

- Keep the public `CompactRootOverlays` API unchanged.
- Add an unexported `collectionRootOverlayCompactionResult` so collection storage compaction can retain the folded-root stats plus the newly published system root.
- Pass the published system root through `LeafGenerationProtectedSystemRootIDs` before invoking backend `CompactStorage`.
- Do not pass folded collection roots as ordinary protected root IDs; backend system-root descriptor expansion is the safe root-class boundary.

## Scope

- Includes: `TreeDB/collections/api.go`, `TreeDB/collections/compact_storage.go`, `TreeDB/collections/api_test.go`.
- Excludes: backend compaction algorithms, file formats, public APIs, benchmarks.

## Correctness

- Tests added:
  - `TestCollectionCompactStorageProtectsFoldedRootIDs`
  - `TestCompactStorageOptionsWithCollectionRootProtectionMergesDistinctRoots`
- Tests run:
  - TDD baseline failure: `go test ./TreeDB/collections -run 'TestCollectionCompactStorageProtectsFoldedRootIDs|TestCompactStorageOptionsWithCollectionRootProtectionMergesDistinctRoots' -count=1` failed before implementation because the internal folded-root protection plumbing did not exist.
  - `go test ./TreeDB/collections -run 'TestCollectionCompactStorageProtectsFoldedRootIDs|TestCompactStorageOptionsWithCollectionRootProtectionMergesDistinctRoots|TestCollectionCompactStorageFoldsRootsAndCleansStorage' -count=10`
  - `go test ./TreeDB/collections -count=1`
  - `go test ./TreeDB/db -run 'TestCompactStoragePlan_ProtectedRootIDsKeepDetachedLeafGenerationLive|TestCompactStorageLeafGenerationProtectedRootIDPairMergesSourcesOnce|TestLeafGenerationGC_ProtectedRootIDsKeepDetachedRootLive|TestLeafGenerationPlan_ProtectedOrdinaryRootDoesNotParseDescriptors|TestLeafGenerationGC_ProtectedSystemRootDescriptorsKeepCollectionRootLive' -count=1`
  - `go test ./TreeDB/... -count=1`
  - `go test ./TreeDB/mongo_gateway -run TestStandaloneServerCommandWALBSONInsertReadUpdateVisibility -count=1 -v`
  - `go test ./TreeDB/mongo_gateway -count=1`
- Local full-module note: `go test ./... -count=1` passed the touched storage packages but hit an unrelated local timeout in `TreeDB/mongo_gateway` (`TestStandaloneServerCommandWALBSONInsertReadUpdateVisibility`); the failing test and package both passed on immediate rerun.

## Performance

No benchmark run. This changes maintenance-time option plumbing only; no hot read/write path or format changed.

## Rollout / Toggle Plan

Default behavior is conservative: collection compaction protects the just-published system root during the backend compaction call. Revert is the PR commit if needed.

## Follow-ups

None currently planned.

### AI Review Loop

- Codex latest-head review: clean; no major issues on reviewed commit `129109f9f9`
- Copilot latest-head review: requested via ` review`; no findings returned
- CodeRabbit latest-head review: success context; no actionable findings
- Review comments/threads resolved or explicitly dismissed: no actionable review comments or threads
- Re-requested after final meaningful push: not needed; no post-review code changes

---

## Optimization PR Checklist (TreeDB)

### Scope
- [x] Single, clear objective for this PR (not a bundle)
- [x] Explicit include list (files/symbols touched)
- [x] Explicit exclude list (files/symbols NOT touched)
- [x] No unwanted feature reintroduction

### Safety / Correctness
- [x] Clear written-vs-durable semantics for any `*Sync` path touched: not applicable, no `*Sync` path touched
- [x] No new mmap usage on mutable/truncating files
- [x] All new length fields are capped before allocation: not applicable, no new length fields
- [x] CRC/checksum behavior is fail-closed: not applicable, no parsing/checksum change
- [x] Any concurrency change has a defined state machine and invariants: no new concurrency state

### Tests
- [x] Added deterministic regression tests for the targeted failure mode
- [x] Tests avoid sleeps where possible
- [x] Added corruption/edge-case tests when format/parsing changes: not applicable
- [x] Ran locally: see Correctness

### Benchmarks / Measurements
- [x] Added or updated a benchmark relevant to the change: not applicable, maintenance option plumbing only
- [x] Reported results in PR description: not applicable
- [x] Included incompressible results if compression is involved: not applicable

### Docs
- [x] Updated milestone docs if applicable: not applicable
- [x] Documented any new config knobs + defaults: not applicable
- [x] Called out any format change: no format change

### Rollout / Toggle Plan
- [x] Safe defaults
- [x] Clear knobs to disable/revert behavior quickly: revert this commit
- [x] Observability: existing compaction stats remain unchanged

