### PR TITLE
collections: lazily materialize text-v2 match details

### DIFF
--- a/TreeDB/collections/hybrid_search.go
+++ b/TreeDB/collections/hybrid_search.go
@@ -97,6 +97,10 @@ type HybridTextQuery struct {
 	IndexName      string `json:"index_name"`
 	Query          string `json:"query"`
 	CandidateLimit int    `json:"candidate_limit,omitempty"`
+	// IncludeTextMatches opts into compact field/term attribution on text-source
+	// candidates. The default hybrid candidate path is score-only so candidate
+	// generation does not allocate match details for non-final candidates.
+	IncludeTextMatches bool `json:"include_text_matches,omitempty"`
 }
 
 // HybridVectorQuery configures the vector candidate source. It intentionally

--- a/TreeDB/collections/hybrid_text_candidates.go
+++ b/TreeDB/collections/hybrid_text_candidates.go
@@ -8,9 +8,10 @@ import (
 // SearchHybridTextCandidates adapts collection-native ranked text search into
 // the shared hybrid candidate shape. It is candidate-only: it requests no
 // documents from SearchText, reuses response-owned result IDs for response-owned
-// HybridSearchCandidate values, assigns one-based source ranks, preserves text
-// match attribution, and fails closed if the backing text path reports any full
-// document materialization or scan fallback.
+// HybridSearchCandidate values, assigns one-based source ranks, and fails closed
+// if the backing text path reports any full document materialization or scan
+// fallback. Match attribution is opt-in through HybridTextQuery.IncludeTextMatches;
+// the default candidate path is score-only.
 func (c *Collection) SearchHybridTextCandidates(query HybridTextQuery) (HybridCandidateResponse, error) {
 	return c.searchHybridTextCandidates(query, nil)
 }
@@ -30,13 +31,17 @@ func (c *Collection) searchHybridTextCandidates(query HybridTextQuery, allowSet 
 		return response, err
 	}
 
+	resultMode := textSearchResultScoreOnly
+	if query.IncludeTextMatches {
+		resultMode = textSearchResultTextMatchesOnly
+	}
 	textResponse, err := c.searchText(TextSearchOptions{
 		IndexName:                query.IndexName,
 		Query:                    query.Query,
 		TopK:                     requested,
 		IncludeDocuments:         false,
 		textV2AllowedDocumentIDs: allowSet,
-	}, textSearchResultTextMatchesOnly)
+	}, resultMode)
 	if err != nil {
 		response := HybridCandidateResponse{Stats: hybridTextCandidateStatsFromSearch(requested, textResponse.Stats, 0)}
 		response.Stats.FailClosed = 1

--- a/TreeDB/collections/hybrid_text_candidates_test.go
+++ b/TreeDB/collections/hybrid_text_candidates_test.go
@@ -28,15 +28,26 @@ func TestSearchHybridTextCandidatesNoDocumentsStableIDs2503(t *testing.T) {
 		t.Fatalf("SearchHybridTextCandidates: %v", err)
 	}
 
-	assertHybridTextCandidateBasics2503(t, got.Candidates, "lexical")
+	assertHybridTextCandidateBasics2503(t, got.Candidates, "lexical", false)
 	if len(got.Candidates) != 2 {
 		t.Fatalf("candidates=%d want 2", len(got.Candidates))
 	}
 	if string(got.Candidates[0].ID) != "d1" || string(got.Candidates[1].ID) != "d2" || got.Candidates[0].Score <= got.Candidates[1].Score {
 		t.Fatalf("candidates=%+v want d1 above d2 by BM25F", got.Candidates)
 	}
-	if got.Candidates[0].TextMatches[0].Field != "body" || !slicesEqualStrings(got.Candidates[0].TextMatches[0].Terms, []string{"refund"}) {
-		t.Fatalf("candidate[0] matches=%+v want body/refund attribution", got.Candidates[0].TextMatches)
+	if len(got.Candidates[0].TextMatches) != 0 || got.Stats.TextMatchDetailsBuilt != 0 {
+		t.Fatalf("candidate[0] matches=%+v stats=%+v want default score-only hybrid text candidates", got.Candidates[0].TextMatches, got.Stats)
+	}
+	explicitMatches, err := col.SearchHybridTextCandidates(HybridTextQuery{IndexName: "lexical", Query: "refund", CandidateLimit: 2, IncludeTextMatches: true})
+	if err != nil {
+		t.Fatalf("SearchHybridTextCandidates IncludeTextMatches: %v", err)
+	}
+	assertHybridTextCandidateBasics2503(t, explicitMatches.Candidates, "lexical", true)
+	if explicitMatches.Candidates[0].TextMatches[0].Field != "body" || !slicesEqualStrings(explicitMatches.Candidates[0].TextMatches[0].Terms, []string{"refund"}) {
+		t.Fatalf("explicit candidate[0] matches=%+v want body/refund attribution", explicitMatches.Candidates[0].TextMatches)
+	}
+	if explicitMatches.Stats.TextMatchDetailsBuilt != uint64(len(explicitMatches.Candidates)) || explicitMatches.Stats.DocumentsFetched != 0 || explicitMatches.Stats.FullDocumentScanFallbacks != 0 {
+		t.Fatalf("explicit stats=%+v want bounded opt-in match details and no docs", explicitMatches.Stats)
 	}
 	if got.Stats.TextCandidatesRequested != uint64(opts.CandidateLimit) || got.Stats.TextCandidatesReturned != 2 || got.Stats.TextPostingsScanned != 2 || got.Stats.TextCandidatesScored != 2 {
 		t.Fatalf("stats=%+v want requested=2 returned=2 postings=2 scored=2", got.Stats)
@@ -224,7 +235,7 @@ func TestHybridTextCandidatesRejectDocumentMaterialization2503(t *testing.T) {
 	}
 }
 
-func assertHybridTextCandidateBasics2503(tb testing.TB, got []HybridSearchCandidate, indexName string) {
+func assertHybridTextCandidateBasics2503(tb testing.TB, got []HybridSearchCandidate, indexName string, wantMatches bool) {
 	tb.Helper()
 	for i, candidate := range got {
 		if candidate.Source != HybridCandidateSourceText || candidate.IndexName != indexName || candidate.SourceRank != i+1 || candidate.ScoreKind != HybridScoreKindBM25F {
@@ -236,8 +247,11 @@ func assertHybridTextCandidateBasics2503(tb testing.TB, got []HybridSearchCandid
 		if len(candidate.ID) == 0 || cap(candidate.ID) != len(candidate.ID) {
 			tb.Fatalf("candidate[%d] id len/cap=%d/%d want response-owned cap-isolated stable ID", i, len(candidate.ID), cap(candidate.ID))
 		}
-		if len(candidate.TextMatches) == 0 {
+		if wantMatches && len(candidate.TextMatches) == 0 {
 			tb.Fatalf("candidate[%d]=%+v want text match attribution", i, candidate)
+		}
+		if !wantMatches && len(candidate.TextMatches) != 0 {
+			tb.Fatalf("candidate[%d]=%+v want score-only text candidate", i, candidate)
 		}
 	}
 }

--- a/TreeDB/collections/text_backfill.go
+++ b/TreeDB/collections/text_backfill.go
@@ -27,15 +27,16 @@ type TextIndexBackfillStats struct {
 	StatsEntries     int
 	EncodedBytes     uint64
 
-	V2DocIDEntries   int
-	V2DocMapBlocks   int
-	V2PostingBlocks  int
-	V2NormBlocks     int
-	V2TermStats      int
-	V2FormatRecords  int
-	V2StatusRecords  int
-	V2NextOrdinal    uint64
-	V2RootGeneration uint64
+	V2DocIDEntries    int
+	V2DocMapBlocks    int
+	V2PostingBlocks   int
+	V2NormBlocks      int
+	V2PositionEntries int
+	V2TermStats       int
+	V2FormatRecords   int
+	V2StatusRecords   int
+	V2NextOrdinal     uint64
+	V2RootGeneration  uint64
 }
 
 // TextIndexStorageStats reports durable text-root contents after validation.
@@ -51,6 +52,7 @@ type TextIndexStorageStats struct {
 	V2DocMapBlocks    uint64
 	V2PostingBlocks   uint64
 	V2NormBlocks      uint64
+	V2PositionEntries uint64
 	V2TermStats       uint64
 	V2FormatRecords   uint64
 	V2StatusRecords   uint64
@@ -302,7 +304,6 @@ func buildCreateTextV2IndexBackfillPlan(
 	}
 
 	fieldNames := textV2FieldNames(def)
-	analysisDef := textV2ScoringAnalysisDefinition(def)
 	for _, rootName := range rootNames {
 		family, ok := textV2RootFamilyForName(catalog.meta.Name, def.Name, rootName)
 		if !ok {
@@ -327,6 +328,7 @@ func buildCreateTextV2IndexBackfillPlan(
 	termsRootName := collectionTextV2TermsRootName(catalog.meta.Name, def.Name)
 	postingBlocksRootName := collectionTextV2PostingBlocksRootName(catalog.meta.Name, def.Name)
 	normRootName := collectionTextV2NormBlocksRootName(catalog.meta.Name, def.Name)
+	positionsRootName := collectionTextV2PositionsRootName(catalog.meta.Name, def.Name)
 	generationsRootName := collectionTextV2GenerationsRootName(catalog.meta.Name, def.Name)
 	docMapBlocks := make(map[uint64]*textV2DocMapBlockValue)
 	normBlocks := make(map[uint64]*textV2NormBlockValue)
@@ -358,7 +360,7 @@ func buildCreateTextV2IndexBackfillPlan(
 					resetAll()
 					return nil, err
 				}
-				analysis, err := analyzeTextIndexDocument(analysisDef, jsonDocument)
+				analysis, err := analyzeTextIndexDocument(def, jsonDocument)
 				if err != nil {
 					resetAll()
 					return nil, err
@@ -394,6 +396,13 @@ func buildCreateTextV2IndexBackfillPlan(
 					resetAll()
 					return nil, err
 				}
+				positionEntries, positionBytes, err := addTextV2PositionEntriesForDocument(tables[positionsRootName], def, ordinal, generation, analysis)
+				if err != nil {
+					resetAll()
+					return nil, err
+				}
+				plan.stats.V2PositionEntries += positionEntries
+				plan.stats.EncodedBytes += positionBytes
 				acc.addDocument(analysis)
 				plan.stats.DocumentsScanned++
 				it.Next()
@@ -1265,7 +1274,16 @@ func inspectTextV2Root(snap *backenddb.Snapshot, catalog *collectionCatalog, def
 			}
 			stats.V2TermStats++
 			stats.StatsEntries++
-		case family == textV2RootFamilyPositions || family == textV2RootFamilyGenerations:
+		case family == textV2RootFamilyPositions:
+			position, err := decodeTextV2PositionValue(value)
+			if err != nil {
+				return err
+			}
+			if err := validateTextV2PositionEntryAtSnapshot(snap, catalog, def, key, position, status); err != nil {
+				return err
+			}
+			stats.V2PositionEntries++
+		case family == textV2RootFamilyGenerations:
 			return errMalformedTextStorage("unsupported text-v2 root %q entry key %x", rootName, key)
 		default:
 			return errMalformedTextStorage("unsupported text-v2 root %q family %s", rootName, family)

--- a/TreeDB/collections/text_index_test.go
+++ b/TreeDB/collections/text_index_test.go
@@ -259,7 +259,7 @@ func TestCollectionTextV2RootNamesAndStatusContract2623(t *testing.T) {
 	}
 	v2Status := textIndexStatusForDefinition("docs", TextIndexDefinition{Name: "lexical", Version: TextIndexVersionV2, Rollout: TextIndexRolloutPrimary})
 	if v2Status.FailClosed || !v2Status.Ready || !v2Status.Readable || !v2Status.Writable || v2Status.FailClosedReason != "" {
-		t.Fatalf("v2 status=%+v want root-ready/readable/writable score-only v2", v2Status)
+		t.Fatalf("v2 status=%+v want root-ready/readable/writable v2", v2Status)
 	}
 	if !slices.Equal(v2Status.ActiveRootNames, wantV2) {
 		t.Fatalf("v2 active roots=%q want %q", v2Status.ActiveRootNames, wantV2)

--- a/TreeDB/collections/text_maintenance.go
+++ b/TreeDB/collections/text_maintenance.go
@@ -181,13 +181,15 @@ func appendSingleTextV2IndexMutationDeltas(
 	termsRootName := collectionTextV2TermsRootName(catalog.meta.Name, def.Name)
 	postingBlocksRootName := collectionTextV2PostingBlocksRootName(catalog.meta.Name, def.Name)
 	normRootName := collectionTextV2NormBlocksRootName(catalog.meta.Name, def.Name)
+	positionsRootName := collectionTextV2PositionsRootName(catalog.meta.Name, def.Name)
 	docIDTable := newCollectionRunTable(len(orderedMutations))
 	docMapTable := newCollectionRunTable(0)
 	termsTable := newCollectionRunTable(0)
 	postingBlocksTable := newCollectionRunTable(0)
 	normTable := newCollectionRunTable(0)
+	positionsTable := newCollectionRunTable(0)
 	generationsTable := newCollectionRunTable(1)
-	deltaOwned := []memtable.Table{docIDTable, docMapTable, termsTable, postingBlocksTable, normTable, generationsTable}
+	deltaOwned := []memtable.Table{docIDTable, docMapTable, termsTable, postingBlocksTable, normTable, positionsTable, generationsTable}
 	success := false
 	defer func() {
 		if !success {
@@ -206,7 +208,6 @@ func appendSingleTextV2IndexMutationDeltas(
 	if nextGeneration == 0 {
 		return errMalformedTextStorage("text-v2 root generation overflow")
 	}
-	analysisDef := textV2ScoringAnalysisDefinition(def)
 
 	for _, mutation := range orderedMutations {
 		if len(mutation.documentID) == 0 {
@@ -228,13 +229,13 @@ func appendSingleTextV2IndexMutationDeltas(
 			if err != nil {
 				return err
 			}
-			oldState, err = analyzeTextIndexStoredDocument(analysisDef, oldDocument, opts)
+			oldState, err = analyzeTextIndexStoredDocument(def, oldDocument, opts)
 			if err != nil {
 				return err
 			}
 		}
 		if mutation.setNew {
-			newState, newAnalysis, err = analyzeTextIndexStoredDocumentWithAnalysis(analysisDef, mutation.newDocument, opts)
+			newState, newAnalysis, err = analyzeTextIndexStoredDocumentWithAnalysis(def, mutation.newDocument, opts)
 			if err != nil {
 				return err
 			}
@@ -289,8 +290,14 @@ func appendSingleTextV2IndexMutationDeltas(
 		if err := upsertTextV2NormMutation(snap, catalog, normRootName, normBlocks, nextDoc, lengths); err != nil {
 			return err
 		}
+		if mutation.deleteOld {
+			deleteTextV2PositionEntriesForDocument(positionsTable, def, current.Ordinal, oldState)
+		}
 		if mutation.setNew {
 			if err := postingBuilder.addDocument(def, nextDoc.Ordinal, nextDoc.Generation, newAnalysis); err != nil {
+				return err
+			}
+			if _, _, err := addTextV2PositionEntriesForDocument(positionsTable, def, nextDoc.Ordinal, nextDoc.Generation, newAnalysis); err != nil {
 				return err
 			}
 		}
@@ -354,6 +361,9 @@ func appendSingleTextV2IndexMutationDeltas(
 		return err
 	}
 	if err := appendIfNonEmpty(normRootName, normTable); err != nil {
+		return err
+	}
+	if err := appendIfNonEmpty(positionsRootName, positionsTable); err != nil {
 		return err
 	}
 	if err := appendIfNonEmpty(generationsRootName, generationsTable); err != nil {

--- a/TreeDB/collections/text_search.go
+++ b/TreeDB/collections/text_search.go
@@ -37,12 +37,30 @@ const (
 	textSearchBM25B  = 0.75
 )
 
+// TextSearchResultMode controls how much lexical match attribution is
+// materialized for returned results. The zero value keeps the historical
+// SearchText behavior: detailed field/term summaries for final top-K results.
+type TextSearchResultMode string
+
+const (
+	TextSearchResultModeDefault   TextSearchResultMode = ""
+	TextSearchResultModeDetailed  TextSearchResultMode = "detailed"
+	TextSearchResultModeCompact   TextSearchResultMode = "compact"
+	TextSearchResultModeScoreOnly TextSearchResultMode = "score_only"
+)
+
 // TextSearchOptions configures collection-native lexical search.
 type TextSearchOptions struct {
 	IndexName string
 	Query     string
 	Operator  TextSearchOperator
 	TopK      int
+	// ResultMode controls optional match-detail materialization. The zero value
+	// is detailed for API compatibility. Score-only returns IDs/ranks/scores
+	// without match summaries; compact returns TextMatches only; detailed returns
+	// TextMatches plus legacy MatchedTerms/MatchedFields. Document fetching remains
+	// controlled solely by IncludeDocuments.
+	ResultMode TextSearchResultMode
 	// CandidateLimit bounds the number of unique document candidates generated
 	// from postings before scoring. The zero value uses an implementation default
 	// derived from TopK. When the limit is exceeded, SearchText fails closed rather
@@ -188,10 +206,27 @@ const (
 	textSearchResultScoreOnly
 )
 
+func normalizeTextSearchResultMode(mode TextSearchResultMode) (textSearchResultMode, error) {
+	switch mode {
+	case TextSearchResultModeDefault, TextSearchResultModeDetailed:
+		return textSearchResultFull, nil
+	case TextSearchResultModeCompact:
+		return textSearchResultTextMatchesOnly, nil
+	case TextSearchResultModeScoreOnly:
+		return textSearchResultScoreOnly, nil
+	default:
+		return 0, fmt.Errorf("collections: unsupported text search result mode %q", mode)
+	}
+}
+
 // SearchText executes a bounded postings-backed lexical search for a declared
 // collection text index. It never scans/ranks all collection documents.
 func (c *Collection) SearchText(opts TextSearchOptions) (TextSearchResponse, error) {
-	return c.searchText(opts, textSearchResultFull)
+	resultMode, err := normalizeTextSearchResultMode(opts.ResultMode)
+	if err != nil {
+		return TextSearchResponse{}, err
+	}
+	return c.searchText(opts, resultMode)
 }
 
 func (c *Collection) searchText(opts TextSearchOptions, resultMode textSearchResultMode) (TextSearchResponse, error) {
@@ -602,14 +637,26 @@ func textSearchCandidateMatchDetails(candidate *textSearchCandidate, includeLega
 		entry := candidate.postingAt(postingIdx)
 		for fieldIdx := 0; fieldIdx < entry.posting.fieldCount(); fieldIdx++ {
 			field := entry.posting.fieldAt(fieldIdx)
-			if len(pairs) == cap(pairs) {
-				grown := make([]textSearchMatchPair, len(pairs), len(pairs)*2)
-				copy(grown, pairs)
-				pairs = grown
-			}
-			pairs = append(pairs, textSearchMatchPair{field: field.Field, term: entry.term})
+			pairs = appendTextSearchMatchPair(pairs, textSearchMatchPair{field: field.Field, term: entry.term})
 		}
 	}
+	return textSearchMatchDetailsFromPairs(pairs, includeLegacyLists)
+}
+
+func appendTextSearchMatchPair(pairs []textSearchMatchPair, pair textSearchMatchPair) []textSearchMatchPair {
+	if len(pairs) == cap(pairs) {
+		newCap := len(pairs) * 2
+		if newCap == 0 {
+			newCap = 4
+		}
+		grown := make([]textSearchMatchPair, len(pairs), newCap)
+		copy(grown, pairs)
+		pairs = grown
+	}
+	return append(pairs, pair)
+}
+
+func textSearchMatchDetailsFromPairs(pairs []textSearchMatchPair, includeLegacyLists bool) ([]string, []string, []TextSearchMatch) {
 	if len(pairs) == 0 {
 		return nil, nil, nil
 	}

--- a/TreeDB/collections/text_v2_contract_bench_test.go
+++ b/TreeDB/collections/text_v2_contract_bench_test.go
@@ -555,6 +555,61 @@ func BenchmarkTextV2BlockMaxCommonTerm2628(b *testing.B) {
 	}
 }
 
+func BenchmarkTextV2LazyDetails2629(b *testing.B) {
+	docs := textV2ContractEnvInt2623("TREEDB_TEXT_V2_LAZY_DETAILS_DOCS", 10_000)
+	if docs < int(textV2PostingBlockTargetPostings)*3 {
+		docs = int(textV2PostingBlockTargetPostings) * 3
+	}
+	d, col := openTextV2BlockMaxBenchFixture2628(b, docs)
+	defer func() { _ = d.Close() }()
+	opts := TextSearchOptions{IndexName: textV2ContractIndexName2623, Query: "refund", TopK: 10, CandidateLimit: docs, MaxPostingsScanned: docs * 2}
+	cases := []struct {
+		name string
+		mode textSearchResultMode
+	}{
+		{name: "score_only", mode: textSearchResultScoreOnly},
+		{name: "detailed_topk", mode: textSearchResultFull},
+	}
+	for _, tc := range cases {
+		tc := tc
+		b.Run(tc.name, func(b *testing.B) {
+			warm, err := col.searchText(opts, tc.mode)
+			if err != nil {
+				b.Fatalf("warm search: %v", err)
+			}
+			if len(warm.Results) == 0 || warm.Stats.DocumentsFetched != 0 || warm.Stats.FullDocumentScanFallbacks != 0 || warm.Stats.FailClosed != 0 || warm.Stats.TextStateLookups != 0 {
+				b.Fatalf("warm response=%+v want no-doc v2 search", warm)
+			}
+			if tc.mode == textSearchResultScoreOnly && warm.Stats.TextMatchDetailsBuilt != 0 {
+				b.Fatalf("warm stats=%+v want score-only details=0", warm.Stats)
+			}
+			if tc.mode != textSearchResultScoreOnly && warm.Stats.TextMatchDetailsBuilt != uint64(len(warm.Results)) {
+				b.Fatalf("warm stats=%+v results=%d want details bounded to returned topK", warm.Stats, len(warm.Results))
+			}
+			b.ReportAllocs()
+			b.ResetTimer()
+			var sink TextSearchResponse
+			for i := 0; i < b.N; i++ {
+				got, err := col.searchText(opts, tc.mode)
+				if err != nil {
+					b.Fatalf("search: %v", err)
+				}
+				if tc.mode == textSearchResultScoreOnly && got.Stats.TextMatchDetailsBuilt != 0 {
+					b.Fatalf("stats=%+v want score-only details=0", got.Stats)
+				}
+				if tc.mode != textSearchResultScoreOnly && got.Stats.TextMatchDetailsBuilt != uint64(len(got.Results)) {
+					b.Fatalf("stats=%+v results=%d want topK-bounded details", got.Stats, len(got.Results))
+				}
+				sink = got
+			}
+			b.StopTimer()
+			b.ReportMetric(float64(docs), "docs_fixture")
+			b.ReportMetric(float64(opts.TopK), "topk/search")
+			textV2ContractReportTextStats2623(b, sink)
+		})
+	}
+}
+
 func BenchmarkTextV2BlockMaxConcurrentServing2628(b *testing.B) {
 	docs := textV2ContractEnvInt2623("TREEDB_TEXT_V2_BLOCKMAX_CONCURRENT_DOCS", 10_000)
 	readers := textV2ContractEnvInt2623("TREEDB_TEXT_V2_BLOCKMAX_CONCURRENT_READERS", 4)
@@ -833,8 +888,8 @@ func textV2ContractIndexDefinition2623() TextIndexDefinition {
 func textV2ContractV2IndexDefinition2626() TextIndexDefinition {
 	def := textV2ContractIndexDefinition2623()
 	def.Version = TextIndexVersionV2
-	// M3 writes scoring postings/norms/docmaps only; lazy positions are owned by
-	// #2629, so the v2 write-path benchmark excludes v1 position payload work.
+	// The canonical v2 hot-path benchmark excludes optional position payload work;
+	// #2629 covers lazy positions with focused detail/positions tests and rows.
 	def.StorePositions = false
 	def.StoreOffsets = false
 	return def
@@ -871,7 +926,7 @@ func textV2ContractStorageStats2623(tb testing.TB, col *Collection) TextIndexSto
 func textV2ContractReportBackfillStats2623(b *testing.B, docs int, stats TextIndexBackfillStats) {
 	b.Helper()
 	entries := uint64(stats.PostingEntries + stats.StateEntries + stats.StatsEntries)
-	v2Entries := uint64(stats.V2DocIDEntries + stats.V2DocMapBlocks + stats.V2PostingBlocks + stats.V2NormBlocks + stats.V2TermStats + stats.V2FormatRecords + stats.V2StatusRecords)
+	v2Entries := uint64(stats.V2DocIDEntries + stats.V2DocMapBlocks + stats.V2PostingBlocks + stats.V2NormBlocks + stats.V2PositionEntries + stats.V2TermStats + stats.V2FormatRecords + stats.V2StatusRecords)
 	if v2Entries > 0 {
 		entries = v2Entries
 	}
@@ -884,6 +939,7 @@ func textV2ContractReportBackfillStats2623(b *testing.B, docs int, stats TextInd
 	b.ReportMetric(float64(stats.V2DocMapBlocks), "v2_docmap_blocks/op")
 	b.ReportMetric(float64(stats.V2PostingBlocks), "v2_posting_blocks/op")
 	b.ReportMetric(float64(stats.V2NormBlocks), "v2_norm_blocks/op")
+	b.ReportMetric(float64(stats.V2PositionEntries), "v2_position_entries/op")
 	b.ReportMetric(float64(stats.V2TermStats), "v2_term_stats/op")
 	b.ReportMetric(float64(stats.V2PostingBlocks)/docsDivisor, "posting_blocks/doc")
 	b.ReportMetric(0, "rewritten_blocks/doc")
@@ -903,6 +959,7 @@ func textV2ContractReportWriteStats2623(b *testing.B, docs int, stats TextIndexS
 	b.ReportMetric(float64(stats.V2DocMapBlocks), "v2_docmap_blocks/op")
 	b.ReportMetric(float64(stats.V2PostingBlocks), "v2_posting_blocks/op")
 	b.ReportMetric(float64(stats.V2NormBlocks), "v2_norm_blocks/op")
+	b.ReportMetric(float64(stats.V2PositionEntries), "v2_position_entries/op")
 	b.ReportMetric(float64(stats.V2TermStats), "v2_term_stats/op")
 	b.ReportMetric(float64(stats.V2PostingBlocks)/docsDivisor, "posting_blocks/doc")
 	b.ReportMetric(0, "rewritten_blocks/doc")
@@ -986,7 +1043,7 @@ func textV2ContractV2MutationRootDeltaEntries2626(docs int, before, after TextIn
 
 func textV2ContractStorageEntryCount2623(stats TextIndexStorageStats) uint64 {
 	if stats.Version == TextIndexVersionV2 || stats.V2FormatRecords > 0 {
-		return stats.V2DocIDEntries + stats.V2DocMapBlocks + stats.V2PostingBlocks + stats.V2NormBlocks + stats.V2TermStats + stats.V2FormatRecords + stats.V2StatusRecords
+		return stats.V2DocIDEntries + stats.V2DocMapBlocks + stats.V2PostingBlocks + stats.V2NormBlocks + stats.V2PositionEntries + stats.V2TermStats + stats.V2FormatRecords + stats.V2StatusRecords
 	}
 	return stats.PostingEntries + stats.StateEntries + stats.StatsEntries
 }

--- a/TreeDB/collections/text_v2_positions.go
+++ b/TreeDB/collections/text_v2_positions.go
@@ -1,0 +1,449 @@
+package collections
+
+import (
+	"bytes"
+	"encoding/binary"
+	"sort"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+	"github.com/snissn/gomap/TreeDB/internal/memtable"
+)
+
+const (
+	textV2KeyKindPosition byte = 0x22
+
+	textV2PositionValueVersion byte = 1
+)
+
+type textV2PositionFieldValue struct {
+	FieldIndex uint32
+	Frequency  uint32
+	Positions  []uint32
+	Offsets    []textTokenOffset
+}
+
+type textV2PositionValue struct {
+	FormatVersion uint32
+	Ordinal       uint64
+	Generation    uint64
+	Term          string
+	Fields        []textV2PositionFieldValue
+}
+
+func encodeTextV2PositionKey(ordinal uint64, term string) []byte {
+	out := make([]byte, 0, 2+8+binary.MaxVarintLen64+len(term))
+	out = append(out, textV2KeyVersion, textV2KeyKindPosition)
+	var buf [8]byte
+	binary.BigEndian.PutUint64(buf[:], ordinal)
+	out = append(out, buf[:]...)
+	out = appendTextString(out, term)
+	return out
+}
+
+func decodeTextV2PositionKey(raw []byte) (uint64, string, error) {
+	if len(raw) < 10 {
+		return 0, "", errMalformedTextStorage("short text-v2 position key")
+	}
+	if raw[0] != textV2KeyVersion {
+		return 0, "", errUnsupportedTextStorageVersion("text-v2 position key", raw[0])
+	}
+	if raw[1] != textV2KeyKindPosition {
+		return 0, "", errMalformedTextStorage("text-v2 position key kind %d", raw[1])
+	}
+	ordinal := binary.BigEndian.Uint64(raw[2:10])
+	if ordinal == 0 {
+		return 0, "", errMalformedTextStorage("text-v2 position key has zero ordinal")
+	}
+	cur := textCursor{buf: raw[10:]}
+	term, err := cur.readString()
+	if err != nil {
+		return 0, "", errMalformedTextStorage("text-v2 position key term: %v", err)
+	}
+	if term == "" {
+		return 0, "", errMalformedTextStorage("text-v2 position key missing term")
+	}
+	if cur.remaining() != 0 {
+		return 0, "", errMalformedTextStorage("text-v2 position key trailing bytes")
+	}
+	return ordinal, term, nil
+}
+
+func encodeTextV2PositionValue(value textV2PositionValue) []byte {
+	fields := cloneTextV2PositionFields(value.Fields)
+	sort.Slice(fields, func(i, j int) bool { return fields[i].FieldIndex < fields[j].FieldIndex })
+	out := make([]byte, 0, estimateTextV2PositionValueLen(value, fields))
+	out = append(out, textV2PositionValueVersion)
+	out = appendTextUvarint(out, uint64(value.FormatVersion))
+	out = appendTextUvarint(out, value.Ordinal)
+	out = appendTextUvarint(out, value.Generation)
+	out = appendTextString(out, value.Term)
+	out = appendTextUvarint(out, uint64(len(fields)))
+	for _, field := range fields {
+		out = appendTextUvarint(out, uint64(field.FieldIndex))
+		out = appendTextUvarint(out, uint64(field.Frequency))
+		out = appendTextUint32Slice(out, field.Positions)
+		out = appendTextOffsetSlice(out, field.Offsets)
+	}
+	return out
+}
+
+func decodeTextV2PositionValue(raw []byte) (textV2PositionValue, error) {
+	if len(raw) == 0 {
+		return textV2PositionValue{}, errMalformedTextStorage("empty text-v2 position value")
+	}
+	if raw[0] != textV2PositionValueVersion {
+		return textV2PositionValue{}, errUnsupportedTextStorageVersion("text-v2 position value", raw[0])
+	}
+	cur := textCursor{buf: raw[1:]}
+	formatVersion, err := cur.readUvarint()
+	if err != nil {
+		return textV2PositionValue{}, errMalformedTextStorage("text-v2 position format version: %v", err)
+	}
+	if formatVersion != uint64(textV2FormatVersion) {
+		return textV2PositionValue{}, errMalformedTextStorage("unsupported text-v2 position format version %d", formatVersion)
+	}
+	ordinal, err := cur.readUvarint()
+	if err != nil {
+		return textV2PositionValue{}, errMalformedTextStorage("text-v2 position ordinal: %v", err)
+	}
+	generation, err := cur.readUvarint()
+	if err != nil {
+		return textV2PositionValue{}, errMalformedTextStorage("text-v2 position generation: %v", err)
+	}
+	term, err := cur.readString()
+	if err != nil {
+		return textV2PositionValue{}, errMalformedTextStorage("text-v2 position term: %v", err)
+	}
+	fieldCount, err := cur.readUvarint()
+	if err != nil {
+		return textV2PositionValue{}, errMalformedTextStorage("text-v2 position field count: %v", err)
+	}
+	if ordinal == 0 || generation == 0 || term == "" {
+		return textV2PositionValue{}, errMalformedTextStorage("text-v2 position value missing ordinal/generation/term")
+	}
+	if fieldCount == 0 || fieldCount > uint64(textV2PostingBlockMaxFieldCount) || fieldCount > uint64(cur.remaining()+1) {
+		return textV2PositionValue{}, errMalformedTextStorage("text-v2 position field count invalid")
+	}
+	value := textV2PositionValue{FormatVersion: uint32(formatVersion), Ordinal: ordinal, Generation: generation, Term: term, Fields: make([]textV2PositionFieldValue, 0, int(fieldCount))}
+	var prevField uint32
+	for i := uint64(0); i < fieldCount; i++ {
+		fieldIndexRaw, err := cur.readUvarint()
+		if err != nil {
+			return textV2PositionValue{}, errMalformedTextStorage("text-v2 position field[%d] index: %v", i, err)
+		}
+		frequencyRaw, err := cur.readUvarint()
+		if err != nil {
+			return textV2PositionValue{}, errMalformedTextStorage("text-v2 position field[%d] frequency: %v", i, err)
+		}
+		positions, err := cur.readUint32Slice()
+		if err != nil {
+			return textV2PositionValue{}, errMalformedTextStorage("text-v2 position field[%d] positions: %v", i, err)
+		}
+		offsets, err := cur.readOffsetSlice()
+		if err != nil {
+			return textV2PositionValue{}, errMalformedTextStorage("text-v2 position field[%d] offsets: %v", i, err)
+		}
+		fieldIndex := checkedTextUint32(fieldIndexRaw)
+		frequency := checkedTextUint32(frequencyRaw)
+		if uint64(fieldIndex) != fieldIndexRaw || uint64(frequency) != frequencyRaw || frequency == 0 {
+			return textV2PositionValue{}, errMalformedTextStorage("text-v2 position field[%d] invalid index/frequency", i)
+		}
+		if i > 0 && fieldIndex <= prevField {
+			return textV2PositionValue{}, errMalformedTextStorage("text-v2 position fields not strictly increasing")
+		}
+		if uint32(len(positions)) != frequency {
+			return textV2PositionValue{}, errMalformedTextStorage("text-v2 position field[%d] position count %d does not match frequency %d", i, len(positions), frequency)
+		}
+		if len(offsets) != 0 && len(offsets) != len(positions) {
+			return textV2PositionValue{}, errMalformedTextStorage("text-v2 position field[%d] offsets/positions length mismatch", i)
+		}
+		for j := 1; j < len(positions); j++ {
+			if positions[j] <= positions[j-1] {
+				return textV2PositionValue{}, errMalformedTextStorage("text-v2 position field[%d] positions not strictly increasing", i)
+			}
+		}
+		value.Fields = append(value.Fields, textV2PositionFieldValue{FieldIndex: fieldIndex, Frequency: frequency, Positions: positions, Offsets: offsets})
+		prevField = fieldIndex
+	}
+	if cur.remaining() != 0 {
+		return textV2PositionValue{}, errMalformedTextStorage("text-v2 position trailing bytes")
+	}
+	return value, nil
+}
+
+func deleteTextV2PositionEntriesForDocument(table memtable.Table, def TextIndexDefinition, ordinal uint64, state textDocumentStateValue) int {
+	if table == nil || !def.StorePositions || ordinal == 0 {
+		return 0
+	}
+	terms := make(map[string]struct{})
+	for _, field := range state.Fields {
+		for _, term := range field.Terms {
+			if term.Term != "" {
+				terms[term.Term] = struct{}{}
+			}
+		}
+	}
+	ordered := make([]string, 0, len(terms))
+	for term := range terms {
+		ordered = append(ordered, term)
+	}
+	sort.Strings(ordered)
+	for _, term := range ordered {
+		table.DeleteSteal(encodeTextV2PositionKey(ordinal, term))
+	}
+	return len(ordered)
+}
+
+func addTextV2PositionEntriesForDocument(table memtable.Table, def TextIndexDefinition, ordinal, generation uint64, analysis textAnalyzedDocument) (int, uint64, error) {
+	if table == nil || !def.StorePositions {
+		return 0, 0, nil
+	}
+	if ordinal == 0 || generation == 0 {
+		return 0, 0, errMalformedTextStorage("text-v2 position document ordinal/generation cannot be zero")
+	}
+	byTerm := make(map[string][]textV2PositionFieldValue)
+	for _, field := range analysis.Fields {
+		fieldIndex := textV2FieldIndex(def, field.Field)
+		if fieldIndex < 0 {
+			return 0, 0, errMalformedTextStorage("text-v2 position field %q missing from definition", field.Field)
+		}
+		terms := make([]string, 0, len(field.Terms))
+		for term := range field.Terms {
+			terms = append(terms, term)
+		}
+		sort.Strings(terms)
+		for _, termName := range terms {
+			term := field.Terms[termName]
+			if term == nil || term.Frequency == 0 {
+				continue
+			}
+			if uint32(len(term.Positions)) != term.Frequency {
+				return 0, 0, errMalformedTextStorage("text-v2 position term %q field %q positions=%d frequency=%d", termName, field.Field, len(term.Positions), term.Frequency)
+			}
+			offsets := term.Offsets
+			if !def.StoreOffsets {
+				offsets = nil
+			} else if uint32(len(offsets)) != term.Frequency {
+				return 0, 0, errMalformedTextStorage("text-v2 position term %q field %q offsets=%d frequency=%d", termName, field.Field, len(offsets), term.Frequency)
+			}
+			byTerm[termName] = append(byTerm[termName], textV2PositionFieldValue{
+				FieldIndex: uint32(fieldIndex),
+				Frequency:  term.Frequency,
+				Positions:  append([]uint32(nil), term.Positions...),
+				Offsets:    append([]textTokenOffset(nil), offsets...),
+			})
+		}
+	}
+	terms := make([]string, 0, len(byTerm))
+	for term := range byTerm {
+		terms = append(terms, term)
+	}
+	sort.Strings(terms)
+	var bytesWritten uint64
+	for _, term := range terms {
+		key := encodeTextV2PositionKey(ordinal, term)
+		value := encodeTextV2PositionValue(textV2PositionValue{FormatVersion: textV2FormatVersion, Ordinal: ordinal, Generation: generation, Term: term, Fields: byTerm[term]})
+		table.SetSteal(key, value)
+		bytesWritten += uint64(len(key) + len(value))
+	}
+	return len(terms), bytesWritten, nil
+}
+
+func validateTextV2PositionEntryAtSnapshot(snap *backenddb.Snapshot, catalog *collectionCatalog, def TextIndexDefinition, key []byte, value textV2PositionValue, status textV2IndexStatusValue) error {
+	if catalog == nil {
+		return errCollectionNotFound
+	}
+	ordinal, term, err := decodeTextV2PositionKey(key)
+	if err != nil {
+		return err
+	}
+	if value.Ordinal != ordinal || value.Term != term {
+		return errMalformedTextStorage("text-v2 position key/value mismatch")
+	}
+	if value.Ordinal >= status.NextOrdinal || value.Generation > status.RootGeneration {
+		return errMalformedTextStorage("text-v2 position entry outside status snapshot")
+	}
+	if err := validateTextV2PositionValueForDefinition(value, def); err != nil {
+		return err
+	}
+	docMap, ok, err := readTextV2PositionDocMapEntryAtRoot(snap, catalog, collectionTextV2DocMapRootName(catalog.meta.Name, def.Name), value.Ordinal)
+	if err != nil {
+		return err
+	}
+	if !ok || docMap.tombstoned() || docMap.Generation != value.Generation {
+		return errMalformedTextStorage("text-v2 position entry ordinal %d generation %d is not current", value.Ordinal, value.Generation)
+	}
+	posting, ok, err := readTextV2PositionPostingAtRoot(snap, catalog, collectionTextV2PostingBlocksRootName(catalog.meta.Name, def.Name), value.Term, value.Ordinal, value.Generation, len(def.Fields))
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return errMalformedTextStorage("text-v2 position entry ordinal %d term %q has no matching scoring posting", value.Ordinal, value.Term)
+	}
+	return validateTextV2PositionValueMatchesPosting(value, def, posting)
+}
+
+func readTextV2PositionDocMapEntryAtRoot(snap *backenddb.Snapshot, catalog *collectionCatalog, rootName string, ordinal uint64) (textV2DocMapEntry, bool, error) {
+	blockStart := textV2OrdinalBlockStart(ordinal, textV2DefaultDocMapBlockSize)
+	if blockStart == 0 {
+		return textV2DocMapEntry{}, false, errMalformedTextStorage("text-v2 invalid position ordinal %d", ordinal)
+	}
+	raw, ok, err := collectionGetAppendAtCatalogRoot(snap, catalog, rootName, encodeTextV2BlockKey(blockStart), nil)
+	if err != nil || !ok {
+		return textV2DocMapEntry{}, false, err
+	}
+	block, err := decodeTextV2DocMapBlockValue(raw)
+	if err != nil {
+		return textV2DocMapEntry{}, false, err
+	}
+	if block.BlockStart != blockStart || block.BlockSize != textV2DefaultDocMapBlockSize {
+		return textV2DocMapEntry{}, false, errMalformedTextStorage("text-v2 position docmap block key/value mismatch")
+	}
+	entry, found := block.find(ordinal)
+	return entry, found, nil
+}
+
+func readTextV2PositionPostingAtRoot(snap *backenddb.Snapshot, catalog *collectionCatalog, rootName, term string, ordinal, generation uint64, fieldCount int) (textV2SearchPostingValue, bool, error) {
+	prefix := encodeTextV2PostingBlockTermPrefix(term)
+	it, err := collectionIteratorAtCatalogRoot(snap, catalog, rootName, prefix, textSearchPrefixEnd(prefix), true)
+	if err != nil || it == nil {
+		return textV2SearchPostingValue{}, false, err
+	}
+	defer func() { _ = it.Close() }()
+	var scratch []uint32
+	var found bool
+	var out textV2SearchPostingValue
+	for it.Valid() {
+		keyBytes := it.UnsafeKey()
+		if !bytes.HasPrefix(keyBytes, prefix) {
+			break
+		}
+		if it.IsDeleted() {
+			it.Next()
+			continue
+		}
+		key, err := decodeTextV2PostingBlockKeyForPrefix(keyBytes, prefix)
+		if err != nil {
+			return textV2SearchPostingValue{}, false, err
+		}
+		scanner, err := newTextV2PostingBlockEntryScanner(it.UnsafeValue(), scratch)
+		if err != nil {
+			return textV2SearchPostingValue{}, false, err
+		}
+		if scanner.block.BlockStart != key.BlockStart || scanner.block.BlockID != key.BlockID {
+			return textV2SearchPostingValue{}, false, errMalformedTextStorage("text-v2 position posting block key/value identity mismatch")
+		}
+		if ordinal < scanner.block.Summary.FirstOrdinal || ordinal > scanner.block.Summary.LastOrdinal {
+			var discard textV2PostingBlockEntry
+			for scanner.Next(&discard) {
+			}
+			if err := scanner.Err(); err != nil {
+				return textV2SearchPostingValue{}, false, err
+			}
+			scratch = scanner.fieldScratch
+			it.Next()
+			continue
+		}
+		var entry textV2PostingBlockEntry
+		for scanner.Next(&entry) {
+			if entry.Ordinal != ordinal || entry.Generation != generation {
+				continue
+			}
+			posting, err := textV2SearchPostingValueFromEntry(entry, fieldCount)
+			if err != nil {
+				return textV2SearchPostingValue{}, false, err
+			}
+			if found {
+				return textV2SearchPostingValue{}, false, errMalformedTextStorage("duplicate text-v2 scoring posting for position ordinal %d term %q generation %d", ordinal, term, generation)
+			}
+			out = posting
+			found = true
+		}
+		if err := scanner.Err(); err != nil {
+			return textV2SearchPostingValue{}, false, err
+		}
+		scratch = scanner.fieldScratch
+		it.Next()
+	}
+	if err := it.Error(); err != nil {
+		return textV2SearchPostingValue{}, false, err
+	}
+	return out, found, nil
+}
+
+func validateTextV2PositionValueForDefinition(value textV2PositionValue, def TextIndexDefinition) error {
+	if !def.StorePositions {
+		return errMalformedTextStorage("text-v2 position entry present for index without store_positions")
+	}
+	if len(value.Fields) == 0 {
+		return errMalformedTextStorage("text-v2 position value has no fields")
+	}
+	for _, field := range value.Fields {
+		if int(field.FieldIndex) >= len(def.Fields) {
+			return errMalformedTextStorage("text-v2 position field index %d outside field count %d", field.FieldIndex, len(def.Fields))
+		}
+		if uint32(len(field.Positions)) != field.Frequency {
+			return errMalformedTextStorage("text-v2 position field %d position count %d does not match frequency %d", field.FieldIndex, len(field.Positions), field.Frequency)
+		}
+		if def.StoreOffsets {
+			if uint32(len(field.Offsets)) != field.Frequency {
+				return errMalformedTextStorage("text-v2 position field %d offset count %d does not match frequency %d", field.FieldIndex, len(field.Offsets), field.Frequency)
+			}
+		} else if len(field.Offsets) != 0 {
+			return errMalformedTextStorage("text-v2 position field %d has offsets for index without store_offsets", field.FieldIndex)
+		}
+	}
+	return nil
+}
+
+func validateTextV2PositionValueMatchesPosting(value textV2PositionValue, def TextIndexDefinition, posting textV2SearchPostingValue) error {
+	if err := validateTextV2PositionValueForDefinition(value, def); err != nil {
+		return err
+	}
+	seen := make(map[uint32]struct{}, len(value.Fields))
+	for _, field := range value.Fields {
+		if _, dup := seen[field.FieldIndex]; dup {
+			return errMalformedTextStorage("text-v2 position duplicate field index %d", field.FieldIndex)
+		}
+		seen[field.FieldIndex] = struct{}{}
+		freq := posting.fieldFrequency(int(field.FieldIndex))
+		if freq == 0 {
+			return errMalformedTextStorage("text-v2 position field %d not present in scoring posting", field.FieldIndex)
+		}
+		if field.Frequency != freq {
+			return errMalformedTextStorage("text-v2 position field %d frequency %d does not match scoring frequency %d", field.FieldIndex, field.Frequency, freq)
+		}
+	}
+	for fieldIdx := 0; fieldIdx < posting.fieldCount; fieldIdx++ {
+		if posting.fieldFrequency(fieldIdx) == 0 {
+			continue
+		}
+		if _, ok := seen[uint32(fieldIdx)]; !ok {
+			return errMalformedTextStorage("text-v2 position missing field %d present in scoring posting", fieldIdx)
+		}
+	}
+	return nil
+}
+
+func cloneTextV2PositionFields(fields []textV2PositionFieldValue) []textV2PositionFieldValue {
+	if len(fields) == 0 {
+		return nil
+	}
+	out := make([]textV2PositionFieldValue, len(fields))
+	for i := range fields {
+		out[i] = fields[i]
+		out[i].Positions = append([]uint32(nil), fields[i].Positions...)
+		out[i].Offsets = append([]textTokenOffset(nil), fields[i].Offsets...)
+	}
+	return out
+}
+
+func estimateTextV2PositionValueLen(value textV2PositionValue, fields []textV2PositionFieldValue) int {
+	n := 1 + binary.MaxVarintLen64*4 + len(value.Term)
+	for _, field := range fields {
+		n += binary.MaxVarintLen64 * 2
+		n += encodedTextUint32SliceLen(field.Positions)
+		n += encodedTextOffsetSliceLen(field.Offsets)
+	}
+	return n
+}

--- a/TreeDB/collections/text_v2_search.go
+++ b/TreeDB/collections/text_v2_search.go
@@ -1010,7 +1010,7 @@ func populateTextV2SearchResultMatchesFromCandidate(snap *backenddb.Snapshot, ca
 	}
 	includeLegacy := resultMode == textSearchResultFull
 	matchedTerms, matchedFields, matches := textV2SearchCandidateMatchDetails(candidate, ctx, candidate.generation, includeLegacy)
-	if idx.StorePositions {
+	if resultMode == textSearchResultFull && idx.StorePositions {
 		for postingIdx := 0; postingIdx < candidate.postingCount(); postingIdx++ {
 			entry := candidate.postingAt(postingIdx)
 			if entry.value.generation != candidate.generation {
@@ -1039,7 +1039,7 @@ func populateTextV2SearchResultMatchesFromTopCandidate(snap *backenddb.Snapshot,
 	}
 	includeLegacy := resultMode == textSearchResultFull
 	matchedTerms, matchedFields, matches := textV2SearchPostingMatchDetails(candidate.term, candidate.posting, ctx, includeLegacy)
-	if idx.StorePositions {
+	if resultMode == textSearchResultFull && idx.StorePositions {
 		if err := validateTextV2PositionPostingAtSnapshot(snap, catalog, ctx, idx, candidate.ordinal, candidate.generation, candidate.term, candidate.posting); err != nil {
 			return err
 		}

--- a/TreeDB/collections/text_v2_search.go
+++ b/TreeDB/collections/text_v2_search.go
@@ -18,6 +18,7 @@ type textV2SearchContext struct {
 	termsRootName         string
 	postingBlocksRootName string
 	normBlocksRootName    string
+	positionsRootName     string
 	docMapRootName        string
 	status                textV2IndexStatusValue
 	corpus                textV2CorpusStatsValue
@@ -52,6 +53,7 @@ func (p textV2SearchPostingValue) fieldFrequency(i int) uint32 {
 
 type textV2SearchCandidate struct {
 	ordinal    uint64
+	generation uint64
 	documentID []byte
 	postings   [2]textV2SearchCandidatePosting
 	overflow   []textV2SearchCandidatePosting
@@ -193,8 +195,12 @@ func (s *textV2SearchOrdinalAllowSet) intersects(first, last uint64) bool {
 
 type textV2SearchTopCandidate struct {
 	ordinal    uint64
+	generation uint64
 	documentID []byte
 	score      float64
+	term       string
+	posting    textV2SearchPostingValue
+	hasPosting bool
 }
 
 type textV2SearchTopK struct {
@@ -332,6 +338,7 @@ func executeTextV2SearchAtSnapshot(
 		if err != nil {
 			return textSearchFailClosed(response, textSearchFailClosedStorageCorrupt, err)
 		}
+		candidate.generation = norm.Generation
 		candidate.documentID = append(candidate.documentID[:0], docMap.DocumentID...)
 		candidate.score = score
 		scored = append(scored, candidate)
@@ -355,16 +362,19 @@ func executeTextV2SearchAtSnapshot(
 	}
 	response.Stats.TextCandidatesReturned = uint64(len(scored))
 	response.Results = make([]TextSearchResult, len(scored))
-	_ = resultMode // v2 detailed match materialization is deferred to #2629; M4 returns score-only rows.
 	for i, candidate := range scored {
 		id := append([]byte(nil), candidate.documentID...)
-		response.Results[i] = TextSearchResult{
+		result := TextSearchResult{
 			DocumentID: id,
 			IndexName:  idx.Name,
 			Rank:       i + 1,
 			Score:      candidate.score,
 			ScoreKind:  HybridScoreKindBM25F,
 		}
+		if err := populateTextV2SearchResultMatchesFromCandidate(snap, catalog, ctx, idx, candidate, resultMode, &result, &response.Stats); err != nil {
+			return textSearchFailClosed(response, textSearchFailClosedStorageCorrupt, err)
+		}
+		response.Results[i] = result
 	}
 	if opts.IncludeDocuments && len(response.Results) > 0 {
 		if err := fetchTextSearchResultDocuments(c, snap, catalog, opts, &response); err != nil {
@@ -414,6 +424,7 @@ func newTextV2SearchContext(snap *backenddb.Snapshot, catalog *collectionCatalog
 		termsRootName:         termsRootName,
 		postingBlocksRootName: collectionTextV2PostingBlocksRootName(catalog.meta.Name, idx.Name),
 		normBlocksRootName:    collectionTextV2NormBlocksRootName(catalog.meta.Name, idx.Name),
+		positionsRootName:     collectionTextV2PositionsRootName(catalog.meta.Name, idx.Name),
 		docMapRootName:        collectionTextV2DocMapRootName(catalog.meta.Name, idx.Name),
 		status:                status,
 		corpus:                corpus,
@@ -656,7 +667,13 @@ func executeTextV2BlockMaxSearchAtSnapshot(
 				return textSearchFailClosed(response, textSearchFailClosedStorageCorrupt, err)
 			}
 			beforeThreshold, beforeReady := top.threshold()
-			top.add(textV2SearchTopCandidate{ordinal: entry.Ordinal, documentID: docMap.DocumentID, score: score})
+			topCandidate := textV2SearchTopCandidate{ordinal: entry.Ordinal, generation: entry.Generation, documentID: docMap.DocumentID, score: score}
+			if resultMode != textSearchResultScoreOnly {
+				topCandidate.term = term
+				topCandidate.posting = posting
+				topCandidate.hasPosting = true
+			}
+			top.add(topCandidate)
 			response.Stats.TextCandidatesScored++
 			afterThreshold, afterReady := top.threshold()
 			if afterReady && (!beforeReady || afterThreshold > beforeThreshold) {
@@ -684,15 +701,18 @@ func executeTextV2BlockMaxSearchAtSnapshot(
 	}
 	response.Stats.TextCandidatesReturned = uint64(len(top.candidates))
 	response.Results = make([]TextSearchResult, len(top.candidates))
-	_ = resultMode // v2 detailed match materialization is deferred to #2629; M5 remains score-only.
 	for i, candidate := range top.candidates {
-		response.Results[i] = TextSearchResult{
+		result := TextSearchResult{
 			DocumentID: append([]byte(nil), candidate.documentID...),
 			IndexName:  idx.Name,
 			Rank:       i + 1,
 			Score:      candidate.score,
 			ScoreKind:  HybridScoreKindBM25F,
 		}
+		if err := populateTextV2SearchResultMatchesFromTopCandidate(snap, catalog, ctx, idx, candidate, resultMode, &result, &response.Stats); err != nil {
+			return textSearchFailClosed(response, textSearchFailClosedStorageCorrupt, err)
+		}
+		response.Results[i] = result
 	}
 	if opts.IncludeDocuments && len(response.Results) > 0 {
 		if err := fetchTextSearchResultDocuments(c, snap, catalog, opts, &response); err != nil {
@@ -982,6 +1002,111 @@ func scoreTextV2SearchCandidate(candidate *textV2SearchCandidate, terms []string
 		}
 	}
 	return score, nil
+}
+
+func populateTextV2SearchResultMatchesFromCandidate(snap *backenddb.Snapshot, catalog *collectionCatalog, ctx *textV2SearchContext, idx TextIndexDefinition, candidate *textV2SearchCandidate, resultMode textSearchResultMode, result *TextSearchResult, stats *TextSearchStats) error {
+	if resultMode == textSearchResultScoreOnly || candidate == nil || result == nil {
+		return nil
+	}
+	includeLegacy := resultMode == textSearchResultFull
+	matchedTerms, matchedFields, matches := textV2SearchCandidateMatchDetails(candidate, ctx, candidate.generation, includeLegacy)
+	if idx.StorePositions {
+		for postingIdx := 0; postingIdx < candidate.postingCount(); postingIdx++ {
+			entry := candidate.postingAt(postingIdx)
+			if entry.value.generation != candidate.generation {
+				continue
+			}
+			if err := validateTextV2PositionPostingAtSnapshot(snap, catalog, ctx, idx, candidate.ordinal, candidate.generation, entry.term, entry.value); err != nil {
+				return err
+			}
+		}
+	}
+	result.MatchedTerms = matchedTerms
+	result.MatchedFields = matchedFields
+	result.TextMatches = matches
+	if stats != nil {
+		stats.TextMatchDetailsBuilt++
+	}
+	return nil
+}
+
+func populateTextV2SearchResultMatchesFromTopCandidate(snap *backenddb.Snapshot, catalog *collectionCatalog, ctx *textV2SearchContext, idx TextIndexDefinition, candidate textV2SearchTopCandidate, resultMode textSearchResultMode, result *TextSearchResult, stats *TextSearchStats) error {
+	if resultMode == textSearchResultScoreOnly || result == nil {
+		return nil
+	}
+	if !candidate.hasPosting || candidate.posting.generation != candidate.generation {
+		return errMalformedTextStorage("text-v2 top candidate missing detail posting for ordinal %d", candidate.ordinal)
+	}
+	includeLegacy := resultMode == textSearchResultFull
+	matchedTerms, matchedFields, matches := textV2SearchPostingMatchDetails(candidate.term, candidate.posting, ctx, includeLegacy)
+	if idx.StorePositions {
+		if err := validateTextV2PositionPostingAtSnapshot(snap, catalog, ctx, idx, candidate.ordinal, candidate.generation, candidate.term, candidate.posting); err != nil {
+			return err
+		}
+	}
+	result.MatchedTerms = matchedTerms
+	result.MatchedFields = matchedFields
+	result.TextMatches = matches
+	if stats != nil {
+		stats.TextMatchDetailsBuilt++
+	}
+	return nil
+}
+
+func textV2SearchCandidateMatchDetails(candidate *textV2SearchCandidate, ctx *textV2SearchContext, generation uint64, includeLegacyLists bool) ([]string, []string, []TextSearchMatch) {
+	var inline [8]textSearchMatchPair
+	pairs := inline[:0]
+	if candidate == nil || ctx == nil {
+		return nil, nil, nil
+	}
+	for postingIdx := 0; postingIdx < candidate.postingCount(); postingIdx++ {
+		entry := candidate.postingAt(postingIdx)
+		if entry.value.generation != generation {
+			continue
+		}
+		pairs = appendTextV2PostingMatchPairs(pairs, entry.term, entry.value, ctx)
+	}
+	return textSearchMatchDetailsFromPairs(pairs, includeLegacyLists)
+}
+
+func textV2SearchPostingMatchDetails(term string, posting textV2SearchPostingValue, ctx *textV2SearchContext, includeLegacyLists bool) ([]string, []string, []TextSearchMatch) {
+	var inline [8]textSearchMatchPair
+	pairs := appendTextV2PostingMatchPairs(inline[:0], term, posting, ctx)
+	return textSearchMatchDetailsFromPairs(pairs, includeLegacyLists)
+}
+
+func appendTextV2PostingMatchPairs(pairs []textSearchMatchPair, term string, posting textV2SearchPostingValue, ctx *textV2SearchContext) []textSearchMatchPair {
+	if ctx == nil {
+		return pairs
+	}
+	for fieldIdx, field := range ctx.fieldNames {
+		if posting.fieldFrequency(fieldIdx) == 0 {
+			continue
+		}
+		pairs = appendTextSearchMatchPair(pairs, textSearchMatchPair{field: field, term: term})
+	}
+	return pairs
+}
+
+func validateTextV2PositionPostingAtSnapshot(snap *backenddb.Snapshot, catalog *collectionCatalog, ctx *textV2SearchContext, idx TextIndexDefinition, ordinal, generation uint64, term string, posting textV2SearchPostingValue) error {
+	if ctx == nil {
+		return errMalformedTextStorage("text-v2 position validation missing search context")
+	}
+	raw, found, err := collectionGetAppendAtCatalogRoot(snap, catalog, ctx.positionsRootName, encodeTextV2PositionKey(ordinal, term), nil)
+	if err != nil {
+		return err
+	}
+	if !found {
+		return errMalformedTextStorage("missing text-v2 position entry for ordinal %d term %q", ordinal, term)
+	}
+	value, err := decodeTextV2PositionValue(raw)
+	if err != nil {
+		return err
+	}
+	if value.Ordinal != ordinal || value.Generation != generation || value.Term != term {
+		return errMalformedTextStorage("text-v2 position key/value identity mismatch for ordinal %d term %q", ordinal, term)
+	}
+	return validateTextV2PositionValueMatchesPosting(value, idx, posting)
 }
 
 func decodeTextV2SearchNormBlock(raw []byte) (textV2SearchNormBlock, error) {

--- a/TreeDB/collections/text_v2_search_test.go
+++ b/TreeDB/collections/text_v2_search_test.go
@@ -85,7 +85,7 @@ func TestTextV2HybridTextCandidatesNoDocCounters2627(t *testing.T) {
 	}
 }
 
-func TestTextV2SearchIncludeDocumentsFetchesOnlyTopK2627(t *testing.T) {
+func TestTextV2SearchIncludeDocumentsFetchesOnlyTopKAndDetailsLazy2627(t *testing.T) {
 	d := openTextV2TestDB(t, t.TempDir(), false)
 	defer func() { _ = d.Close() }()
 	col := createTextSearchCollection2627(t, d, "docs", TextIndexDefinition{Name: "lexical", Version: TextIndexVersionV2, Fields: []TextIndexField{{Field: "title", Weight: 4}, {Field: "body"}}}, [][]byte{[]byte("d1"), []byte("d2"), []byte("d3")}, [][]byte{
@@ -104,15 +104,170 @@ func TestTextV2SearchIncludeDocumentsFetchesOnlyTopK2627(t *testing.T) {
 	if !bytes.Contains(got.Results[0].Document, []byte("refund")) {
 		t.Fatalf("document=%s want fetched refund document", got.Results[0].Document)
 	}
-	if len(got.Results[0].TextMatches) != 0 || len(got.Results[0].MatchedTerms) != 0 || len(got.Results[0].MatchedFields) != 0 {
-		t.Fatalf("result=%+v want v2 M4 score-only match details", got.Results[0])
+	if len(got.Results[0].TextMatches) == 0 || !slicesEqualStrings(got.Results[0].MatchedTerms, []string{"refund"}) {
+		t.Fatalf("result=%+v want v2 lazy detailed match summary", got.Results[0])
 	}
 	if got.Stats.DocumentsFetched == 0 || got.Stats.DocumentsFetched > uint64(len(got.Results)) || got.Stats.DocumentsFetched > 1 || got.Stats.FullDocumentScanFallbacks != 0 || got.Stats.FailClosed != 0 {
 		t.Fatalf("stats=%+v want bounded topK document fetch only", got.Stats)
 	}
-	if got.Stats.TextStateLookups != 0 || got.Stats.TextMatchDetailsBuilt != 0 {
-		t.Fatalf("stats=%+v want score-only v2 search despite final fetch", got.Stats)
+	if got.Stats.TextStateLookups != 0 || got.Stats.TextMatchDetailsBuilt != uint64(len(got.Results)) || got.Stats.TextMatchDetailsBuilt > 1 {
+		t.Fatalf("stats=%+v want topK-bounded lazy detail materialization and no text-state lookup", got.Stats)
 	}
+}
+
+func TestTextV2SearchResultModesAndTopKLazyDetails2629(t *testing.T) {
+	d := openTextV2TestDB(t, t.TempDir(), false)
+	defer func() { _ = d.Close() }()
+	col := createTextSearchCollection2627(t, d, "docs", TextIndexDefinition{Name: "lexical", Version: TextIndexVersionV2, Fields: []TextIndexField{{Field: "title", Weight: 4}, {Field: "body"}}}, [][]byte{[]byte("d1"), []byte("d2"), []byte("d3")}, [][]byte{
+		[]byte(`{"title":"refund","body":"refund refund policy"}`),
+		[]byte(`{"title":"plain","body":"refund policy"}`),
+		[]byte(`{"title":"shipping","body":"refund"}`),
+	})
+
+	scoreOnly, err := col.SearchText(TextSearchOptions{IndexName: "lexical", Query: "refund", TopK: 1, CandidateLimit: 8, ResultMode: TextSearchResultModeScoreOnly})
+	if err != nil {
+		t.Fatalf("SearchText score-only: %v", err)
+	}
+	if len(scoreOnly.Results) != 1 || len(scoreOnly.Results[0].TextMatches) != 0 || len(scoreOnly.Results[0].MatchedTerms) != 0 || scoreOnly.Stats.TextMatchDetailsBuilt != 0 {
+		t.Fatalf("score-only response=%+v want no match details", scoreOnly)
+	}
+
+	detailed, err := col.SearchText(TextSearchOptions{IndexName: "lexical", Query: "refund", TopK: 1, CandidateLimit: 8})
+	if err != nil {
+		t.Fatalf("SearchText detailed: %v", err)
+	}
+	if len(detailed.Results) != 1 || !bytes.Equal(detailed.Results[0].DocumentID, scoreOnly.Results[0].DocumentID) {
+		t.Fatalf("detailed results=%+v scoreOnly=%+v want same top result", detailed.Results, scoreOnly.Results)
+	}
+	if detailed.Stats.TextCandidatesScored <= detailed.Stats.TextMatchDetailsBuilt || detailed.Stats.TextMatchDetailsBuilt != uint64(len(detailed.Results)) {
+		t.Fatalf("detailed stats=%+v want details bounded to returned topK, not all scored candidates", detailed.Stats)
+	}
+	if len(detailed.Results[0].TextMatches) == 0 || !slicesEqualStrings(detailed.Results[0].MatchedTerms, []string{"refund"}) || len(detailed.Results[0].MatchedFields) == 0 {
+		t.Fatalf("detailed result=%+v want field/term attribution", detailed.Results[0])
+	}
+
+	compact, err := col.SearchText(TextSearchOptions{IndexName: "lexical", Query: "refund", TopK: 1, CandidateLimit: 8, ResultMode: TextSearchResultModeCompact})
+	if err != nil {
+		t.Fatalf("SearchText compact: %v", err)
+	}
+	if len(compact.Results) != 1 || len(compact.Results[0].TextMatches) == 0 || len(compact.Results[0].MatchedTerms) != 0 || len(compact.Results[0].MatchedFields) != 0 {
+		t.Fatalf("compact result=%+v want TextMatches without legacy matched lists", compact.Results)
+	}
+	if compact.Stats.TextMatchDetailsBuilt != uint64(len(compact.Results)) || compact.Stats.DocumentsFetched != 0 || compact.Stats.TextStateLookups != 0 {
+		t.Fatalf("compact stats=%+v want topK detail build, no docs, no text-state", compact.Stats)
+	}
+}
+
+func TestTextV2PositionsLaneCorruptionFailsClosedOnlyForDetailedMode2629(t *testing.T) {
+	d := openTextV2TestDB(t, t.TempDir(), false)
+	defer func() { _ = d.Close() }()
+	col := createTextSearchCollection2627(t, d, "docs", TextIndexDefinition{Name: "lexical", Version: TextIndexVersionV2, StorePositions: true, StoreOffsets: true, Fields: []TextIndexField{{Field: "body"}}}, [][]byte{[]byte("d1"), []byte("d2")}, [][]byte{
+		[]byte(`{"body":"unique2629 refund"}`),
+		[]byte(`{"body":"other refund"}`),
+	})
+
+	before, err := col.SearchText(TextSearchOptions{IndexName: "lexical", Query: "unique2629", TopK: 1})
+	if err != nil {
+		t.Fatalf("SearchText before corruption: %v", err)
+	}
+	if len(before.Results) != 1 || string(before.Results[0].DocumentID) != "d1" || before.Stats.TextMatchDetailsBuilt != 1 {
+		t.Fatalf("before response=%+v want detailed d1", before)
+	}
+
+	var positionKey []byte
+	withTextCatalog(t, d, "docs", func(snap *backenddb.Snapshot, catalog *collectionCatalog) {
+		doc, ok, err := readTextV2DocIDAtRoot(snap, catalog, collectionTextV2DocIDRootName("docs", "lexical"), []byte("d1"))
+		if err != nil || !ok {
+			t.Fatalf("read docid ok=%v err=%v", ok, err)
+		}
+		positionKey = encodeTextV2PositionKey(doc.Ordinal, "unique2629")
+	})
+	raw := textV2ReadRootBytes2624(t, d, "docs", collectionTextV2PositionsRootName("docs", "lexical"), positionKey)
+	position, err := decodeTextV2PositionValue(raw)
+	if err != nil {
+		t.Fatalf("decode position value before corruption: %v", err)
+	}
+	position.Fields[0].Frequency++
+	position.Fields[0].Positions = append(position.Fields[0].Positions, position.Fields[0].Positions[len(position.Fields[0].Positions)-1]+1)
+	position.Fields[0].Offsets = append(position.Fields[0].Offsets, textTokenOffset{Start: 0, End: 1})
+	corruptTextRootValue(t, d, "docs", collectionTextV2PositionsRootName("docs", "lexical"), positionKey, encodeTextV2PositionValue(position))
+	if _, err := col.TextIndexStorageStats("lexical"); !errors.Is(err, ErrTextIndexStorageCorrupt) {
+		t.Fatalf("TextIndexStorageStats after position/scoring mismatch err=%v want storage corrupt", err)
+	}
+
+	scoreOnly, err := col.SearchText(TextSearchOptions{IndexName: "lexical", Query: "unique2629", TopK: 1, ResultMode: TextSearchResultModeScoreOnly})
+	if err != nil || len(scoreOnly.Results) != 1 || scoreOnly.Stats.TextMatchDetailsBuilt != 0 || scoreOnly.Stats.DocumentsFetched != 0 {
+		t.Fatalf("score-only after corruption response=%+v err=%v want no position-lane read", scoreOnly, err)
+	}
+	detailed, err := col.SearchText(TextSearchOptions{IndexName: "lexical", Query: "unique2629", TopK: 1, IncludeDocuments: true})
+	if !errors.Is(err, ErrTextIndexUnavailable) || !errors.Is(err, ErrTextIndexStorageCorrupt) {
+		t.Fatalf("detailed after corruption err=%v want text index storage corrupt", err)
+	}
+	if detailed.Stats.FailClosed != 1 || detailed.Stats.FailClosedReason != textSearchFailClosedStorageCorrupt || detailed.Stats.DocumentsFetched != 0 || detailed.Stats.TextMatchDetailsBuilt != 0 {
+		t.Fatalf("detailed stats=%+v want fail-closed before document fetch/detail count", detailed.Stats)
+	}
+}
+
+func TestTextV2PositionsLaneUpdateDeleteRemovesStaleEntries2629(t *testing.T) {
+	d := openTextV2TestDB(t, t.TempDir(), false)
+	defer func() { _ = d.Close() }()
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "docs"}); err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	col, err := mgr.OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("OpenCollection: %v", err)
+	}
+	if _, _, err := col.CreateTextIndex(TextIndexDefinition{Name: "lexical", Version: TextIndexVersionV2, StorePositions: true, Fields: []TextIndexField{{Field: "body"}}}); err != nil {
+		t.Fatalf("CreateTextIndex: %v", err)
+	}
+	if _, err := col.Insert([]byte("d1"), []byte(`{"body":"oldtoken2629 keep"}`)); err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+
+	oldKey := textV2PositionKeyForDocumentTerm2629(t, d, "docs", "lexical", []byte("d1"), "oldtoken2629")
+	if raw := textV2ReadRootBytes2624(t, d, "docs", collectionTextV2PositionsRootName("docs", "lexical"), oldKey); len(raw) == 0 {
+		t.Fatalf("old position entry missing before update")
+	}
+	if _, _, err := col.Update([]byte("d1"), func([]byte) ([]byte, bool, error) {
+		return []byte(`{"body":"newtoken2629 keep"}`), true, nil
+	}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	withTextCatalog(t, d, "docs", func(snap *backenddb.Snapshot, catalog *collectionCatalog) {
+		if _, ok, err := collectionGetAppendAtCatalogRoot(snap, catalog, collectionTextV2PositionsRootName("docs", "lexical"), oldKey, nil); err != nil || ok {
+			t.Fatalf("old position entry after update ok=%v err=%v want deleted", ok, err)
+		}
+	})
+	newKey := textV2PositionKeyForDocumentTerm2629(t, d, "docs", "lexical", []byte("d1"), "newtoken2629")
+	if raw := textV2ReadRootBytes2624(t, d, "docs", collectionTextV2PositionsRootName("docs", "lexical"), newKey); len(raw) == 0 {
+		t.Fatalf("new position entry missing after update")
+	}
+	if deleted, err := col.DeleteBatch([][]byte{[]byte("d1")}); err != nil || deleted != 1 {
+		t.Fatalf("DeleteBatch deleted=%d err=%v", deleted, err)
+	}
+	withTextCatalog(t, d, "docs", func(snap *backenddb.Snapshot, catalog *collectionCatalog) {
+		if _, ok, err := collectionGetAppendAtCatalogRoot(snap, catalog, collectionTextV2PositionsRootName("docs", "lexical"), newKey, nil); err != nil || ok {
+			t.Fatalf("new position entry after delete ok=%v err=%v want deleted", ok, err)
+		}
+	})
+	if _, err := col.TextIndexStorageStats("lexical"); err != nil {
+		t.Fatalf("TextIndexStorageStats after update/delete cleanup: %v", err)
+	}
+}
+
+func textV2PositionKeyForDocumentTerm2629(t *testing.T, d *backenddb.DB, collection, index string, documentID []byte, term string) []byte {
+	t.Helper()
+	var key []byte
+	withTextCatalog(t, d, collection, func(snap *backenddb.Snapshot, catalog *collectionCatalog) {
+		doc, ok, err := readTextV2DocIDAtRoot(snap, catalog, collectionTextV2DocIDRootName(collection, index), documentID)
+		if err != nil || !ok {
+			t.Fatalf("read docid %q ok=%v err=%v", string(documentID), ok, err)
+		}
+		key = encodeTextV2PositionKey(doc.Ordinal, term)
+	})
+	return key
 }
 
 func TestTextV2SearchSkipsStaleGenerationsAndTombstones2627(t *testing.T) {

--- a/TreeDB/collections/text_v2_search_test.go
+++ b/TreeDB/collections/text_v2_search_test.go
@@ -139,8 +139,8 @@ func TestTextV2SearchResultModesAndTopKLazyDetails2629(t *testing.T) {
 	if len(detailed.Results) != 1 || !bytes.Equal(detailed.Results[0].DocumentID, scoreOnly.Results[0].DocumentID) {
 		t.Fatalf("detailed results=%+v scoreOnly=%+v want same top result", detailed.Results, scoreOnly.Results)
 	}
-	if detailed.Stats.TextCandidatesScored <= detailed.Stats.TextMatchDetailsBuilt || detailed.Stats.TextMatchDetailsBuilt != uint64(len(detailed.Results)) {
-		t.Fatalf("detailed stats=%+v want details bounded to returned topK, not all scored candidates", detailed.Stats)
+	if detailed.Stats.TextMatchDetailsBuilt != uint64(len(detailed.Results)) || detailed.Stats.TextMatchDetailsBuilt > detailed.Stats.TextCandidatesScored {
+		t.Fatalf("detailed stats=%+v want details bounded to returned topK and scored candidates", detailed.Stats)
 	}
 	if len(detailed.Results[0].TextMatches) == 0 || !slicesEqualStrings(detailed.Results[0].MatchedTerms, []string{"refund"}) || len(detailed.Results[0].MatchedFields) == 0 {
 		t.Fatalf("detailed result=%+v want field/term attribution", detailed.Results[0])
@@ -198,6 +198,14 @@ func TestTextV2PositionsLaneCorruptionFailsClosedOnlyForDetailedMode2629(t *test
 	scoreOnly, err := col.SearchText(TextSearchOptions{IndexName: "lexical", Query: "unique2629", TopK: 1, ResultMode: TextSearchResultModeScoreOnly})
 	if err != nil || len(scoreOnly.Results) != 1 || scoreOnly.Stats.TextMatchDetailsBuilt != 0 || scoreOnly.Stats.DocumentsFetched != 0 {
 		t.Fatalf("score-only after corruption response=%+v err=%v want no position-lane read", scoreOnly, err)
+	}
+	compact, err := col.SearchText(TextSearchOptions{IndexName: "lexical", Query: "unique2629", TopK: 1, ResultMode: TextSearchResultModeCompact})
+	if err != nil || len(compact.Results) != 1 || len(compact.Results[0].TextMatches) == 0 || compact.Stats.TextMatchDetailsBuilt != 1 || compact.Stats.DocumentsFetched != 0 {
+		t.Fatalf("compact after corruption response=%+v err=%v want scoring-posting attribution without position-lane read", compact, err)
+	}
+	hybridCompact, err := col.SearchHybridTextCandidates(HybridTextQuery{IndexName: "lexical", Query: "unique2629", CandidateLimit: 1, IncludeTextMatches: true})
+	if err != nil || len(hybridCompact.Candidates) != 1 || len(hybridCompact.Candidates[0].TextMatches) == 0 || hybridCompact.Stats.TextMatchDetailsBuilt != 1 || hybridCompact.Stats.DocumentsFetched != 0 || hybridCompact.Stats.FullDocumentScanFallbacks != 0 {
+		t.Fatalf("hybrid compact after corruption response=%+v err=%v want zero-doc compact attribution without position-lane read", hybridCompact, err)
 	}
 	detailed, err := col.SearchText(TextSearchOptions{IndexName: "lexical", Query: "unique2629", TopK: 1, IncludeDocuments: true})
 	if !errors.Is(err, ErrTextIndexUnavailable) || !errors.Is(err, ErrTextIndexStorageCorrupt) {

--- a/TreeDB/collections/text_v2_storage_test.go
+++ b/TreeDB/collections/text_v2_storage_test.go
@@ -238,8 +238,8 @@ func TestCollectionCreateTextV2IndexBackfillsOrdinalsNormsStatsAndReopens2624(t 
 	if err != nil {
 		t.Fatalf("v2 SearchText: %v", err)
 	}
-	if len(search.Results) != 1 || string(search.Results[0].DocumentID) != "d1" || len(search.Results[0].TextMatches) != 0 || search.Stats.TextMatchDetailsBuilt != 0 || search.Stats.TextStateLookups != 0 {
-		t.Fatalf("v2 SearchText response=%+v want score-only d1 without match/state work", search)
+	if len(search.Results) != 1 || string(search.Results[0].DocumentID) != "d1" || len(search.Results[0].TextMatches) == 0 || search.Stats.TextMatchDetailsBuilt != uint64(len(search.Results)) || search.Stats.TextStateLookups != 0 {
+		t.Fatalf("v2 SearchText response=%+v want lazy detailed d1 without text-state work", search)
 	}
 	if err := d.Close(); err != nil {
 		t.Fatalf("close: %v", err)

--- a/TreeDB/docs/guides/hybrid-search.md
+++ b/TreeDB/docs/guides/hybrid-search.md
@@ -25,9 +25,10 @@ vector typed-column placement is covered by
 | Vector-only (`SearchVectorIndex` / `SearchHybrid` with only `Vector`) | Semantic nearest-neighbor recall is the main signal. | Keep vector route choices (`exact`, `quantized_only`, `quantized_rerank`) and their recall/storage caveats separate from hybrid claims. |
 | Hybrid (`SearchHybrid` with `Text` + `Vector`) | You need both lexical precision and semantic candidates, usually with a metadata/scalar filter and final materialized documents. | Default fusion is rank-based RRF, not learned relevance. Caller/future layers own reranking/cross-encoder/LLM scoring. |
 
-Hybrid candidate generation must not fetch full documents. Documents are fetched
-only after fusion/filtering and are bounded by final `TopK` when
-`IncludeDocuments` is true.
+Hybrid candidate generation must not fetch full documents. Text candidates are
+score-only by default; set `HybridTextQuery.IncludeTextMatches=true` only when a
+bounded compact field/term summary is needed. Documents are fetched only after
+fusion/filtering and are bounded by final `TopK` when `IncludeDocuments` is true.
 
 ## Index creation sketch
 

--- a/TreeDB/docs/spec/collection-text-search.md
+++ b/TreeDB/docs/spec/collection-text-search.md
@@ -1,4 +1,4 @@
-# Collection Text Search Contract (M0-M4)
+# Collection Text Search Contract (M0-M6)
 
 Status: PR4 ranked SearchText slice for issue #1764. TreeDB collections are
 pre-alpha; these text-search storage formats are versioned and may change before
@@ -27,13 +27,13 @@ matrix are defined in `TreeDB/docs/spec/collection-text-v2-contract.md`.
   and explicit v2 doc ordinal/docmap/term-stat/norm/status roots.
 - `TextIndexStorageStats` validates storage versions and returns root accounting.
 - Insert, delete, update, and batch write paths maintain v1 postings/text-state
-  and stats for v1 text indexes. For explicit v2 indexes, M1 maintains only the
-  root-state shell: ordinals/generations, tombstones, docmap/norm blocks, and
-  stats metadata. Full compressed-posting writes remain a later milestone.
+  and stats for v1 text indexes. For explicit v2 indexes, current milestones
+  maintain ordinals/generations, tombstones, docmap/norm blocks, stats metadata,
+  compressed scoring posting blocks, and optional lazy position/detail payloads.
 - `SearchText(TextSearchOptions)` executes bounded postings range scans, applies
   simple term `AND`/`OR` semantics, scores candidates with BM25F-style field
-  weighting from persisted stats/text-state, and fetches documents only for final
-  top-K results when requested.
+  weighting from persisted stats/text-state or v2 norm blocks, and fetches
+  documents only for final top-K results when requested.
 
 Not implemented yet:
 
@@ -192,6 +192,7 @@ type TextSearchOptions struct {
     TopK                 int
     CandidateLimit       int // optional candidate budget before scoring
     MaxPostingsScanned   int // optional postings scan budget
+    ResultMode          TextSearchResultMode // "", "detailed", "compact", "score_only"
     IncludeDocuments     bool
     DocumentFetchOptions DocumentFetchOptions
 }
@@ -210,9 +211,13 @@ than returning silently incomplete rankings. Empty analyzed queries return an
 empty result set.
 
 Results expose response-owned document IDs, source index name, one-based lexical
-rank, higher-is-better BM25F score, score kind `bm25f`, matched terms/fields, and
-optional final documents. Documents are fetched only after top-K ranking, so
-`DocumentsFetched <= TopK` for successful searches.
+rank, higher-is-better BM25F score, score kind `bm25f`, optional matched
+terms/fields, and optional final documents. `ResultMode=""`/`"detailed"` keeps
+historical API behavior for `SearchText`: match summaries are built only for
+returned final results. `ResultMode="compact"` returns `TextMatches` without the
+legacy `MatchedTerms`/`MatchedFields` lists. `ResultMode="score_only"` returns
+IDs/ranks/scores without match summaries. Documents are fetched only after top-K
+ranking, so `DocumentsFetched <= TopK` for successful searches.
 
 `TextSearchStats` exposes text/hybrid-compatible counters. The required
 benchmark/status vocabulary is `postings_scanned`, `posting_blocks_visited`,
@@ -245,10 +250,12 @@ maintained text roots.
 
 ## Follow-up execution plan
 
-The #2503 hybrid seam now exposes
+The #2503/#2629 hybrid seam exposes
 `Collection.SearchHybridTextCandidates(HybridTextQuery)` as a candidate-only
 adapter over `SearchText`; it requests no full documents and reuses the shared
-hybrid candidate/stat vocabulary.
+hybrid candidate/stat vocabulary. Its default text path is score-only and does
+not allocate `TextMatches`; callers that explicitly need compact field/term
+attribution set `HybridTextQuery.IncludeTextMatches=true`.
 
 Later text-search milestones will:
 

--- a/TreeDB/docs/spec/collection-text-v2-contract.md
+++ b/TreeDB/docs/spec/collection-text-v2-contract.md
@@ -1,8 +1,9 @@
 # Collection Text Index v2 Contract (M0 / #2623)
 
-Status: M0 design gate for #2622. This document fixes the production contract,
-rollout vocabulary, storage boundaries, counters, and benchmark gates that later
-text-v2 implementation PRs must satisfy before they can claim readiness.
+Status: M0 design gate plus M1-M6 landed behavior for #2622. This document fixes
+production contract, rollout vocabulary, storage boundaries, counters, and
+benchmark gates that later text-v2 implementation PRs must satisfy before they
+can claim readiness.
 
 TreeDB remains pre-alpha, so on-disk formats may change, but unsupported or
 corrupt text-v2 formats must fail closed. Later milestones may refine binary
@@ -38,7 +39,7 @@ type TextIndexDefinition struct {
     Name    string
     Fields  []TextIndexField
     Analyzer TextAnalyzer
-    Version TextIndexVersion     // "v1" default today, explicit "v2" supports M4 score-only reads
+    Version TextIndexVersion     // "v1" default today, explicit "v2" supports v2 BM25F reads
     Rollout TextIndexRolloutMode // "primary" default today
     // existing position/offset/storage/schema fields...
 }
@@ -48,17 +49,21 @@ type TextIndexDefinition struct {
 
 - `""` / `"v1"`: current per-`(term, documentID)` text index.
 - `"v2"`: explicit v2 physical contract. M1-M3 root-state creation and
-  writable posting/norm/docmap maintenance are supported. As of M4 (#2627),
-  explicit v2 indexes are readable for exhaustive score-only BM25F serving over
-  posting blocks and packed norms; unsupported future rollout/detailed modes
-  still fail closed and v2 must not silently fall back to v1.
+  writable posting/norm/docmap maintenance are supported. As of M4/M5, explicit
+  v2 indexes are readable for score-only BM25F serving over posting blocks and
+  packed norms with exact single-term block-max skipping. As of M6 (#2629),
+  `SearchText` can lazily materialize compact/detailed field-term summaries for
+  returned final results without v1 text-state lookups or full-document fetch.
+  Unsupported future rollout modes still fail closed and v2 must not silently
+  fall back to v1.
 
 `TextIndexRolloutMode` values:
 
 - `""` / `"primary"`: active production read/write path. V1 remains the default
   readable/searchable path. Explicit v2 indexes are writable as of M3 and
-  readable as of M4 for score-only BM25F serving over v2 posting/norm/docmap
-  roots. Match details/positions remain deferred to #2629.
+  readable as of M4/M5 for BM25F serving over v2 posting/norm/docmap roots.
+  M6 adds lazy compact/detailed field-term summaries for final results and an
+  optional positions/offset payload lane for `StorePositions` indexes.
 - `"shadow"`: future v2 build/validate without serving reads.
 - `"dual_write"`: future v1+v2 mutation maintenance with explicit read choice.
 - `"disabled"`: future metadata-present but non-serving/non-writing state.
@@ -104,11 +109,10 @@ rejected because it would create metadata without the required root status
 records. After M3, explicit v2 indexes maintain durable v2 roots and posting
 blocks for create/backfill/insert/update/delete. As of M4, `TextIndexStatus`
 reports `readable=true` and `writable=true` for explicit v2 indexes: query
-routing serves exhaustive score-only BM25F from v2 posting blocks, packed norm
-blocks, and docmap blocks. Detailed match/position materialization is not yet
-implemented; v2 result rows intentionally carry document ID, rank, score, and
-score kind only unless the caller explicitly asks for bounded final document
-fetch. There is no fallback to v1 for requested v2.
+routing serves BM25F from v2 posting blocks, packed norm blocks, and docmap
+blocks. As of M6, score-only result mode still carries only document ID, rank,
+score, and score kind; compact/detailed modes build field-term summaries only
+for returned final results. There is no fallback to v1 for requested v2.
 
 Stable M1 ordinal semantics:
 
@@ -129,7 +133,7 @@ M1 root contents:
 | `text-v2-terms` | corpus stats, field stats for BM25F average length, and term stats shell (`df`, `ttf`, posting block count placeholder). |
 | `text-v2-posting-blocks` | M2 posting-block keys are `(term, blockStartOrdinal, blockID)` under the normal collection root; values contain compressed scoring postings and block summaries. |
 | `text-v2-norm-blocks` | ordinal block key -> packed per-field token lengths with generation/tombstone flags, sufficient for BM25F field-length/norm inputs without per-candidate text-state lookup. |
-| `text-v2-positions` | format-only in M1; later lazy detail/position milestones own payloads. |
+| `text-v2-positions` | optional M6 lazy payload entries keyed by `(ordinal, term)` for `StorePositions` indexes; format-only when positions are disabled. |
 | `text-v2-generations` | index status record: root/stats/docmap/norm/term generations, next ordinal, live documents, deleted/tombstoned ordinals. |
 
 All v2 decoders check the key/value version, root family, block bounds, strict
@@ -189,9 +193,9 @@ text-v2 storage corruption. Each value stores:
 - entries encoded as strictly-increasing document-ordinal deltas, document
   generation, term frequency, and one term-frequency lane per indexed field.
 
-Positions and offsets are deliberately absent from the scoring block. Future
-lazy match-detail/position lanes belong in `text-v2-positions` or another
-explicit format, not in the hot scoring value.
+Positions and offsets are deliberately absent from the scoring block. M6 stores
+optional lazy position/offset payloads in `text-v2-positions` for indexes created
+with `StorePositions`; the hot scoring value remains unchanged.
 
 M2 provides codecs, builders, storage validation, and streaming/range iterators
 that reuse entry scratch while scanning a block. It does not route
@@ -240,13 +244,11 @@ no shared cross-snapshot cache is introduced.
 
 M4 is deliberately exhaustive. It reports `posting_blocks_visited`, keeps
 `posting_blocks_skipped=0`, and does not implement WAND/BMW or scalar pruning;
-those are owned by #2628. V2 candidate generation reports
+those are owned by #2628. V2 score-only candidate generation reports
 `docs_fetched=0`, `match_details_built=0`, `state_lookups=0`, norm-block read
-counts, postings decoded, blocks visited, and candidates scored. Detailed match
-and position materialization remains deferred to #2629. Public v2 `SearchText`
-rows therefore return score-only text results (document ID, rank, score, score
-kind, and optional bounded final documents when `IncludeDocuments` is true), with
-empty match-detail fields by contract.
+counts, postings decoded, blocks visited, and candidates scored. M6 later adds
+lazy compact/detailed materialization for final results; score-only mode remains
+empty by contract.
 
 ## M5 block-max skipping and scalar pruning (#2628)
 
@@ -288,6 +290,43 @@ rare filters can skip posting blocks whose ordinal ranges do not intersect the
 allow-set; broad filters remain exact and may decode more blocks. This path
 fetches zero full documents and treats missing/tombstoned scalar-filtered docID
 mappings as text-v2 storage corruption.
+
+## M6 lazy match details and positions (#2629)
+
+M6 defines result modes for `SearchText`:
+
+- `score_only`: document ID, rank, score, and score kind only;
+- `compact`: `TextMatches` field/term summaries only;
+- `detailed` / zero value: `TextMatches` plus legacy `MatchedTerms` and
+  `MatchedFields` for API compatibility.
+
+V2 match summaries are materialized after final top-K selection. The score-only
+search and hybrid candidate hot paths do not build match summaries, do not read
+v1 text-state, and do not fetch full documents. `SearchText` with
+`IncludeDocuments=true` still fetches documents only after final ranking and
+remains bounded by returned top-K.
+
+For exhaustive multi-term v2 search, final-result summaries are reconstructed
+from the already-scored final candidates' term/field-frequency lanes. For the
+single-term block-max path, compact posting detail is retained only for the
+bounded top-K heap so final summaries do not require a full posting rescan. The
+`text-v2-posting-blocks` scoring format is unchanged.
+
+If a v2 index is created with `StorePositions`, M6 writes optional
+`text-v2-positions` entries keyed by `(ordinal, term)`. Values contain the
+current document generation, term, per-field term frequency, positions, and
+optional offsets. Detailed/compact materialization validates these entries for
+returned final results and fails closed on missing, corrupt, mismatched, or
+unsupported payloads; score-only mode does not read the lane. Update/delete
+maintenance removes old position entries through ordinary root deltas before
+writing any replacement entries, so physical reclamation remains normal TreeDB
+root/value-log maintenance. There is no standalone text-block GC.
+
+`SearchHybridTextCandidates` and the text leg of `SearchHybrid` use score-only
+mode by default. `HybridTextQuery.IncludeTextMatches=true` opts into compact
+field/term summaries for the bounded requested text candidate set; default hybrid
+candidate generation emits no `TextMatches` and keeps `docs_fetched=0`,
+`state_lookups=0`, and `match_details_built=0`.
 
 ## Current v1 path inventory
 
@@ -365,10 +404,11 @@ Required fixture scales:
 Required query and serving shapes:
 
 - common-term, rare-term, multi-term AND/OR, scalar-filtered, and score-only
-  rows; detailed-match rows are required once #2629 enables v2 detail
-  materialization, while M4 rows must assert empty match-detail output;
+  rows; M6 detailed-match rows must prove `match_details_built` is bounded by
+  returned top-K/requested final results while score-only rows keep it zero;
 - isolated text write, backfill, update, and delete rows with `-benchmem`;
 - current #2589 indexed insert/search guardrail matrix on the latest base;
+- M6 lazy detail rows comparing score-only versus detailed top-K materialization;
 - concurrent serving/load row with reader concurrency, p50/p95/p99 latency,
   steady-state memory, cache warm/cold boundary, and optional mixed write or
   snapshot churn.
@@ -394,10 +434,10 @@ coordinator explicitly accepts them with profile-backed rationale.
   root publication, and value-log reachability tests.
 - M2/M3 must prove posting/norm/docmap payloads remain ordinary B-tree values or
   existing `value_vlog` pointers reachable from collection root descriptors.
-- M4 search must be score-only for candidate generation and public v2
-  `SearchText` rows, with optional bounded final document fetch only. #2629 owns
-  any later detailed match/position materialization; until then detailed modes
-  remain intentionally empty/fail-closed rather than falling back to v1.
+- M4/M5 search must keep score-only candidate generation zero-doc and
+  zero-match-detail. M6 public v2 `SearchText` detailed/compact modes must build
+  match summaries only for returned final results, and optional bounded final
+  document fetch remains a separate post-ranking phase.
 - M5 block skipping must be exact: upper bounds are admissible and results match
   exhaustive scoring. Approximate ranking requires a separate mode/tracker.
 - M7 default-switch or old-path retirement must include v1/v2 coexistence,

--- a/TreeDB/docs/spec/hybrid-search-contract.md
+++ b/TreeDB/docs/spec/hybrid-search-contract.md
@@ -60,6 +60,8 @@ depend on a scan-all-documents fallback.
   - `IndexName`: text index name.
   - `Query`: text-query string. Grammar/analyzer semantics are owned by #1764.
   - `CandidateLimit`: lexical candidate budget before fusion.
+  - `IncludeTextMatches`: optional compact field/term attribution. The zero
+    value keeps text candidate generation score-only.
 - `Vector *HybridVectorQuery`: vector candidate source.
   - `IndexName`, `Query`, `EfSearch`, `QueryMode`, `QuantizedIndexName`, and
     `QuantizedRerankCandidates` mirror the existing vector-index vocabulary.
@@ -98,8 +100,8 @@ Every `HybridSearchCandidate` MUST carry:
 - `SourceRank`: one-based rank within that source result list;
 - `Score`: source-native score after conversion to the shared orientation;
 - `ScoreKind`: `bm25`, `bm25f`, or `vector_similarity`;
-- `TextMatches`: matched text fields/terms where the lexical source can provide
-  them.
+- `TextMatches`: matched text fields/terms only when the lexical source was
+  explicitly asked to include compact match summaries.
 
 Final `HybridSearchResult` values carry:
 

--- a/TreeDB/docs/spec/storage-format.md
+++ b/TreeDB/docs/spec/storage-format.md
@@ -242,6 +242,67 @@ Required validation/fail-closed invariants:
   summaries, or status generation/ordinal bounds violations make the root
   corrupt for text-v2 inspection and must fail closed.
 
+Text-v2 optional positions root name:
+
+```text
+<collection>/text-v2-positions/<indexName>
+```
+
+The positions root is format-only unless the text index was created with
+`StorePositions=true`. It remains an ordinary ordered root using the text index
+root storage policy; inline values and value-log pointer-backed values are
+managed by normal TreeDB root/value-log maintenance. Posting scoring blocks do
+not contain positions or offsets.
+
+Position keys identify one current-or-historical document ordinal and term:
+
+```text
+u8  KeyVersion = 2
+u8  KeyKind    = 0x22  // text-v2 position/detail payload
+u64 OrdinalBE
+uvarint TermLen
+bytes Term[TermLen]
+```
+
+Position values are versioned and fail closed:
+
+```text
+u8      ValueVersion  = 1
+uvarint FormatVersion = 1
+uvarint Ordinal
+uvarint Generation
+uvarint TermLen
+bytes   Term[TermLen]
+uvarint FieldEntryCount
+
+// repeated FieldEntryCount times, sorted by field index
+uvarint FieldIndex
+uvarint FieldTermFrequency
+uvarint PositionCount
+uvarint Positions[PositionCount]
+uvarint OffsetCount
+repeated OffsetCount: uvarint Start, uvarint End
+```
+
+Validation invariants:
+
+- key/value ordinal and term must match, and ordinal/generation must be non-zero
+  and within the text-v2 status snapshot;
+- field indexes are strictly increasing and within the index field list;
+- `FieldTermFrequency` is non-zero, `PositionCount == FieldTermFrequency`, and
+  positions are strictly increasing within each field;
+- offsets are absent when `StoreOffsets=false`, or have exactly one
+  non-negative `end >= start` offset per position when `StoreOffsets=true`;
+- detailed/compact materialization validates only returned final results, while
+  score-only search does not read this lane.
+
+Unsupported versions, malformed varints, trailing bytes, missing final-result
+payloads for positions-enabled indexes, generation/key/value mismatches, field
+frequency mismatches with the scoring posting, corrupt positions/offsets, or
+entries present for an index without `StorePositions` make the text-v2 positions
+lane corrupt and must fail closed when inspected or when detailed materialization
+needs the affected payload.
+
 ## 4. Value Pointer Encoding (`page.ValuePtr`)
 
 Base struct:

--- a/docs/benchmarks/treedb_text_v2_contract_benchmarks.md
+++ b/docs/benchmarks/treedb_text_v2_contract_benchmarks.md
@@ -127,7 +127,7 @@ Report text write counters:
 
 - `posting_entries/op`, `state_entries/op`, `stats_entries/op` for v1 rows;
 - `v2_docid_entries/op`, `v2_docmap_blocks/op`, `v2_posting_blocks/op`,
-  `v2_norm_blocks/op`, and `v2_term_stats/op` for v2 rows;
+  `v2_norm_blocks/op`, `v2_position_entries/op`, and `v2_term_stats/op` for v2 rows;
 - `posting_blocks/doc`, `high_df_posting_blocks/op`,
   `high_df_posting_blocks/doc`, and `rewritten_blocks/doc` (M3 rewrite count is `0`);
 - `index_entries/doc` for live text-root entries after the operation;
@@ -262,6 +262,44 @@ Report the same text counters as the search scale rows, especially
 `posting_blocks_skipped/search`, `candidates_scored/search`,
 `threshold_updates/search`, and `blockmax_fallbacks/search`.
 
+## M6 lazy details rows
+
+Benchmark name: `BenchmarkTextV2LazyDetails2629`.
+
+This row compares the exact same explicit-v2 common-term fixture in score-only
+mode and detailed mode. The score-only subbenchmark must keep
+`match_details/search=0`, `docs_fetched/search=0`, and `state_lookups/search=0`.
+The detailed subbenchmark must keep `docs_fetched/search=0` and
+`state_lookups/search=0`, with `match_details/search == topk/search` (or the
+returned result count when fewer than top-K results exist), proving detail work is
+bounded to final results rather than all scored candidates.
+
+```sh
+GOWORK=off \
+TREEDB_TEXT_V2_LAZY_DETAILS_DOCS=10000 \
+go test ./TreeDB/collections \
+  -run '^$' \
+  -bench '^BenchmarkTextV2LazyDetails2629/(score_only|detailed_topk)$' \
+  -benchmem \
+  -benchtime=5x \
+  -count=3 \
+  | tee "$OUT/text_v2_lazy_details_10k.txt"
+```
+
+Optional larger local artifact:
+
+```sh
+GOWORK=off \
+TREEDB_TEXT_V2_LAZY_DETAILS_DOCS=100000 \
+go test ./TreeDB/collections \
+  -run '^$' \
+  -bench '^BenchmarkTextV2LazyDetails2629/(score_only|detailed_topk)$' \
+  -benchmem \
+  -benchtime=1x \
+  -count=1 \
+  | tee "$OUT/text_v2_lazy_details_100k.txt"
+```
+
 ## Concurrent serving/load row
 
 Benchmark names: `BenchmarkTextV2ContractConcurrentServing2623` for the M0
@@ -363,8 +401,11 @@ go tool pprof -top "$OUT/text_write_mem.pprof" > "$OUT/text_write_mem_top.txt"
 Known current v1 hot spots to look for include `executeTextSearchAtSnapshot`,
 `scanTextSearchPostingsTerm`, `collectionGetAppendAtCatalogRoot`,
 `decodeTextDocumentStateFieldLengths`, `textSearchCandidateMatchDetails`,
-`appendTextIndex*Deltas`, `analyzeTextIndexField`, `addTextPostingsForDocument`,
-and text posting/state/stats encoders.
+`hybridTextMatchesFromSearchResult`, `appendTextIndex*Deltas`,
+`analyzeTextIndexField`, `addTextPostingsForDocument`, and text
+posting/state/stats encoders. After M6, default hybrid candidate rows should no
+longer allocate `textSearchCandidateMatchDetails` / `hybridTextMatchesFromSearchResult`
+work unless `IncludeTextMatches` is explicitly enabled.
 
 ## Interpreting M0 rows
 


### PR DESCRIPTION
## Summary

Closes #2629.

- Add public `TextSearchOptions.ResultMode` (`detailed`/`compact`/`score_only`) while preserving historical detailed `SearchText` defaults.
- Make hybrid text candidate generation score-only by default; `HybridTextQuery.IncludeTextMatches` opts back into compact text attribution.
- Lazily materialize text-v2 match details only after final ranking/top-K, preserving score-only/blockmax hot paths.
- Add optional text-v2 positions payload lane with fail-closed validation, update/delete cleanup of stale entries, and storage inspection cross-checks against current docmap + scoring postings/frequencies.
- Update text search/v2/hybrid/storage docs and benchmark runbook.

## Tests

- `git diff --check`
- `GOWORK=off go test ./TreeDB/collections -count=1`
- `GOWORK=off go test ./TreeDB/docs -count=1`
- `GOWORK=off go test ./TreeDB/...`

## Benchmark evidence

Artifact root: `/tmp/gomap_2629_evidence_20260612_082154`  
Base: `origin/main` = `6fe181fef480276e15cbeedaacadd7561b43ed77`  
Candidate: `067fd3e8bbe1deb0040f77186b26aa88cdd0511b`  
Host: Apple M3 / darwin arm64 / Go 1.26.0

Key rows:

- `BenchmarkSearchHybridTextCandidates2503` before vs after rebased (`hybrid_text_candidates_benchstat_rebased.txt`):
  - `match_details/search`: `20 -> 0` (`-100%`, p=0.008)
  - `docs_fetched/search`: `0 -> 0`
  - `B/op`: `302.1Ki -> 296.5Ki` (`-1.86%`, p=0.008)
  - `allocs/op`: `2.199k -> 2.119k` (`-3.64%`, p=0.008)
- `BenchmarkTextV2LazyDetails2629/{score_only,detailed_topk}` (`text_v2_lazy_details_after_rebased.txt`):
  - `score_only`: `match_details=0`, `docs_fetched=0`, `state_lookups=0`, `279600 B/op`, `518 allocs/op`
  - `detailed_topk`: `match_details=10`, `docs_fetched=0`, `state_lookups=0`, ~`281360 B/op`, `568 allocs/op`
- `BenchmarkTextV2BlockMaxCommonTerm2628/blockmax_common_topk` at 100k docs (`text_v2_blockmax_common_100k_after_rebased.txt`):
  - `candidates_scored=12544`, `posting_blocks_visited=98`, `posting_blocks_skipped=684`
  - `docs_fetched=0`, `state_lookups=0`, `match_details=0`, `blockmax_fallbacks=0`
- `BenchmarkIndexInsertSearch2564/{search_text_v2_candidates_no_docs,search_hybrid_v2_no_docs_scalar_filter,search_vector_candidates_no_docs}` (`index_insert_search_guardrails_after_rebased.txt`):
  - text-v2 and hybrid rows keep `docs_fetched=0`, `full_doc_fallbacks=0`, `fail_closed=0`, `text_state_lookups=0`, `text_match_details=0`
  - vector row keeps `docs_fetched=0`, `vector_candidates=64`

## Review

- Read-only high-thinking Pi review over the rebased diff: `PASS`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Text search now supports configurable result modes: score-only (minimal data), compact (field/term summary), and detailed (full attribution) for flexible performance/detail tradeoffs.
  * Hybrid text queries now include optional compact text match attribution; score-only by default for improved efficiency.
  * Text index v2 now supports optional positional data storage for enhanced search capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## Update: compact positions-lane blocker resolution

Follow-up head: `067fd3e8bbe1deb0040f77186b26aa88cdd0511b`

Resolved coordinator/CodeRabbit blockers:

- Compact mode (`TextSearchResultModeCompact` / hybrid `IncludeTextMatches`) no longer reads or validates the text-v2 positions lane; only detailed/full mode validates positions.
- Added focused coverage proving compact SearchText and hybrid compact attribution continue to succeed when the positions lane is corrupt, while detailed mode fails closed.
- Loosened lazy-details test invariant to the actual contract: `details_built == returned_results` and `details_built <= scored_candidates`.

Additional validation after the follow-up:

- `GOWORK=off go test ./TreeDB/collections -run 'TestTextV2PositionsLaneCorruptionFailsClosedOnlyForDetailedMode2629|TestTextV2SearchResultModesAndTopKLazyDetails2629|TestSearchHybridTextCandidatesNoDocumentsStableIDs2503' -count=1`
- `GOWORK=off go test ./TreeDB/collections -count=1`
- `git diff --check`

