### PR TITLE
Land pack-native scalar_u8 exact rerank

### DIFF
--- a/TreeDB/collections/column_hnsw_prepared_quantized_search.go
+++ b/TreeDB/collections/column_hnsw_prepared_quantized_search.go
@@ -203,23 +203,11 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosineScalarU8PreparedTravers
 	}
 
 	// The pack traversal retained the quantized candidate set in scratch.top without
-	// reading result IDs/row refs. Rerank only the configured shortlist with the
-	// existing exact FP32 scorer so vector/norm read and exact-call counters stay
-	// bounded by QuantizedRerankCandidates.
+	// reading result IDs/row refs. Rerank only the configured shortlist through the
+	// prepared pack's exact FP32 row-ID scorer; do not build the generic native
+	// search plan or re-enter the row-reader scorer stack on this prepared route.
 	scratch.results = scratch.results[:0]
-	plan, err := scratch.prepareSearchPlanForNativeSearch(r)
-	if err != nil {
-		return nil, stats, err
-	}
-	plan.scoreBatchMode = columnVectorGraphScoreBatchModeForSearchPlan(opts.ScoreBatchMode, plan)
-	var singleBlockView *columnVectorGraphBlockView
-	if plan.physicalReader != nil && len(plan.physicalReader.ranges) == 1 && (plan.scoreSource.vectorKind == columnVectorGraphSearchVectorSourceGraphRows || plan.scoreSource.normKind == columnVectorGraphSearchNormSourceGraphRows) {
-		singleBlockView, err = plan.blockViewForAssetOrdinal(0)
-		if err != nil {
-			return nil, stats, err
-		}
-	}
-	if err := r.exactRerankQuantizedCandidates(plan, singleBlockView, query, queryInvNorm, topK, rerankCandidateLimit, scratch, &stats); err != nil {
+	if err := pack.exactRerankPreparedTraversalRowIDCandidates(query, topK, rerankCandidateLimit, opts.ScoreBatchMode, scratch, &stats); err != nil {
 		return nil, stats, err
 	}
 	if opts.OmitResultMaterialization {

--- a/TreeDB/collections/column_hnsw_prepared_traversal.go
+++ b/TreeDB/collections/column_hnsw_prepared_traversal.go
@@ -503,6 +503,57 @@ func (v *columnHNSWSearchPackPreparedView) scoreAndPushFrontierVisitedTilePrepar
 	return nil
 }
 
+func (v *columnHNSWSearchPackPreparedView) exactRerankPreparedTraversalRowIDCandidates(query []float32, topK int, rerankLimit int, scoreBatchMode columnVectorGraphScoreBatchMode, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) error {
+	if v == nil {
+		return errColumnHNSWSearchPackSearchUnavailable
+	}
+	if scratch == nil {
+		return errColumnVectorGraphNativeSearchScratchRequired
+	}
+	if len(scratch.top) == 0 || topK <= 0 || rerankLimit <= 0 {
+		scratch.top = scratch.top[:0]
+		return nil
+	}
+	if len(scratch.top) > rerankLimit {
+		scratch.top = scratch.top[:rerankLimit]
+	}
+	if len(scratch.top) < topK {
+		topK = len(scratch.top)
+	}
+	n := len(scratch.top)
+	scratch.scoreTileRowIDs = ensureColumnVectorGraphNativeUint32Scratch(scratch.scoreTileRowIDs, n)
+	rowIDs := scratch.scoreTileRowIDs[:0]
+	for _, candidate := range scratch.top {
+		ordinal := candidate.ordinal
+		if ordinal < 0 || ordinal >= v.Header.Rows || uint64(ordinal) > math.MaxUint32 {
+			return fmt.Errorf("collections: hnsw_search_pack_v1 prepared traversal exact rerank ordinal=%d outside row_count=%d", ordinal, v.Header.Rows)
+		}
+		rowIDs = append(rowIDs, uint32(ordinal))
+	}
+	var exactPlane columnHNSWPreparedExactFP32ScorePlane
+	if err := exactPlane.prepareForHNSWPreparedTraversal(v, query, columnHNSWPreparedTraversalOptions{ScoreBatchMode: scoreBatchMode}, scratch); err != nil {
+		return err
+	}
+	scratch.scoreTileScores = ensureColumnVectorGraphNativeFloat64Scratch(scratch.scoreTileScores, n)
+	exactScores, err := exactPlane.scoreRowIDsPrevalidated(rowIDs, scratch.scoreTileScores, scratch, stats)
+	if err != nil {
+		return err
+	}
+	if len(exactScores) != n {
+		return fmt.Errorf("collections: hnsw_search_pack_v1 prepared traversal exact rerank scored %d candidates want %d", len(exactScores), n)
+	}
+	if stats != nil {
+		stats.QuantizedRerankCandidates += uint64(n)
+		stats.QuantizedRerankExactScoreCalls += uint64(n)
+	}
+	scratch.top = scratch.top[:0]
+	for i, rowID := range rowIDs {
+		candidate := columnVectorGraphSearchCandidate{ordinal: int(rowID), score: exactScores[i]}
+		scratch.insertTop(topK, candidate)
+	}
+	return nil
+}
+
 func (v *columnHNSWSearchPackPreparedView) exactRerankPreparedTraversalCandidates(query []float32, topK int, scoreBatchMode columnVectorGraphScoreBatchMode, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) error {
 	if v == nil {
 		return errColumnHNSWSearchPackSearchUnavailable

--- a/TreeDB/collections/column_hnsw_prepared_traversal.go
+++ b/TreeDB/collections/column_hnsw_prepared_traversal.go
@@ -543,8 +543,13 @@ func (v *columnHNSWSearchPackPreparedView) exactRerankPreparedTraversalRowIDCand
 		return fmt.Errorf("collections: hnsw_search_pack_v1 prepared traversal exact rerank scored %d candidates want %d", len(exactScores), n)
 	}
 	if stats != nil {
-		stats.QuantizedRerankCandidates += uint64(n)
-		stats.QuantizedRerankExactScoreCalls += uint64(n)
+		n64 := uint64(n)
+		stats.QuantizedRerankCandidates += n64
+		stats.QuantizedRerankExactScoreCalls += n64
+		// The pack-native exact scorer reads normalized vectors directly, but this
+		// quantized_rerank route still reports the logical exact FP32 vector+norm
+		// byte contract exposed by the generic exact rerank path.
+		stats.NormBytesRead += n64 * 4
 	}
 	scratch.top = scratch.top[:0]
 	for i, rowID := range rowIDs {

--- a/TreeDB/collections/column_hnsw_search_pack_test.go
+++ b/TreeDB/collections/column_hnsw_search_pack_test.go
@@ -862,6 +862,60 @@ func TestColumnHNSWPreparedScalarU8RouteUsesTypedRowIDScorePlane2653(t *testing.
 	}
 }
 
+func TestColumnHNSWPreparedScalarU8RerankUsesPackNativeRowIDExactScorer2657(t *testing.T) {
+	rows := []columnGraphRebuildInputRowV2A{
+		{id: "doc-exact", vector: []float32{0.40633525, -0.06700023, -0.027197814}},
+		{id: "doc-quantized", vector: []float32{-0.22174846, 0.8332732, 0.28568664}},
+	}
+	_, d, col, def := openColumnGraphQuantizedGuardrailTestCollection1926(t, rows)
+	defer func() { _ = d.Close() }()
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		t.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	searcher, err := col.OpenVectorIndexSearcher(VectorIndexSearcherOptions{IndexName: def.Name, MaxDecodedBlocks: 1})
+	if err != nil {
+		t.Fatalf("OpenVectorIndexSearcher: %v", err)
+	}
+	defer func() { _ = searcher.Close() }()
+	if searcher.reader == nil || searcher.reader.hnswSearchPack == nil {
+		t.Fatal("searcher missing hnsw_search_pack_v1 prepared view")
+	}
+
+	query := []float32{-0.23968919, -0.60389674, 0.9352316}
+	quantizedTop := scalarU8QuantizedTopKForTest1926(t, rows, query, 1)
+	exactTop := exactColumnGraphTopKForTest(t, rows, query, 1)
+	if string(quantizedTop[0].ID) != "doc-quantized" || string(exactTop[0].ID) != "doc-exact" {
+		t.Fatalf("fixture quantized=%q exact=%q want differing top candidates", quantizedTop[0].ID, exactTop[0].ID)
+	}
+
+	opts := columnVectorGraphNativeSearchOptions{
+		TopK:                      1,
+		EfSearch:                  len(rows),
+		QueryMode:                 columnVectorGraphNativeSearchQueryModeQuantizedRerank,
+		QuantizedIndexName:        def.QuantizedIndexes[0].Name,
+		QuantizedRerankCandidates: len(rows),
+		StatsMode:                 columnVectorGraphNativeSearchStatsModeFullDiagnostics,
+	}
+	var routeScratch columnVectorGraphNativeSearchScratch
+	results, stats, err := searcher.reader.SearchCosineScalarU8PreparedTraversal(searcher.reader.hnswSearchPack, query, opts, &routeScratch)
+	if err != nil {
+		t.Fatalf("SearchCosineScalarU8PreparedTraversal quantized_rerank: %v", err)
+	}
+	assertColumnHNSWPreparedTraversalResultsMatch2585(t, results, exactTop)
+	if stats.QuantizedRerankCandidates != uint64(len(rows)) || stats.QuantizedRerankExactScoreCalls != uint64(len(rows)) {
+		t.Fatalf("scalar_u8 prepared rerank stats=%+v want shortlist=%d", stats, len(rows))
+	}
+	if stats.PreparedScoreCalls != uint64(len(rows)) || stats.VectorBytesRead != uint64(len(rows)*def.Dimensions*4) || stats.NormBytesRead != 0 {
+		t.Fatalf("scalar_u8 prepared rerank stats=%+v want pack-native exact row-ID vector reads and no norm reads", stats)
+	}
+	if routeScratch.searchPlan.reader != nil || routeScratch.searchPlan.physicalReader != nil || routeScratch.searchPlan.preparedSearch != nil || routeScratch.searchPlan.quantizedScorer.kind != columnVectorGraphQuantizedScorerKindNone {
+		t.Fatalf("scalar_u8 prepared rerank populated generic native search plan: %+v", routeScratch.searchPlan)
+	}
+	if routeScratch.preparedQuantizedPlane.scorer != nil {
+		t.Fatalf("scalar_u8 prepared rerank populated generic prepared quantized plane: %p", routeScratch.preparedQuantizedPlane.scorer)
+	}
+}
+
 func TestColumnHNSWPreparedTraversalOmitReturnsRetainedShortlist2585(t *testing.T) {
 	rows := []columnGraphRebuildInputRowV2A{
 		{id: "doc-a", vector: []float32{1, 0, 0}},

--- a/TreeDB/collections/column_hnsw_search_pack_test.go
+++ b/TreeDB/collections/column_hnsw_search_pack_test.go
@@ -905,8 +905,8 @@ func TestColumnHNSWPreparedScalarU8RerankUsesPackNativeRowIDExactScorer2657(t *t
 	if stats.QuantizedRerankCandidates != uint64(len(rows)) || stats.QuantizedRerankExactScoreCalls != uint64(len(rows)) {
 		t.Fatalf("scalar_u8 prepared rerank stats=%+v want shortlist=%d", stats, len(rows))
 	}
-	if stats.PreparedScoreCalls != uint64(len(rows)) || stats.VectorBytesRead != uint64(len(rows)*def.Dimensions*4) || stats.NormBytesRead != 0 {
-		t.Fatalf("scalar_u8 prepared rerank stats=%+v want pack-native exact row-ID vector reads and no norm reads", stats)
+	if stats.PreparedScoreCalls != uint64(len(rows)) || stats.VectorBytesRead != uint64(len(rows)*def.Dimensions*4) || stats.NormBytesRead != uint64(len(rows)*4) {
+		t.Fatalf("scalar_u8 prepared rerank stats=%+v want pack-native exact row-ID vector reads and logical norm bytes", stats)
 	}
 	if routeScratch.searchPlan.reader != nil || routeScratch.searchPlan.physicalReader != nil || routeScratch.searchPlan.preparedSearch != nil || routeScratch.searchPlan.quantizedScorer.kind != columnVectorGraphQuantizedScorerKindNone {
 		t.Fatalf("scalar_u8 prepared rerank populated generic native search plan: %+v", routeScratch.searchPlan)

--- a/TreeDB/collections/column_vector_graph_quantized_bench_test.go
+++ b/TreeDB/collections/column_vector_graph_quantized_bench_test.go
@@ -1651,7 +1651,7 @@ func assertColumnGraphScalarU8QuantizedSearchWithBufferGuardrails2414(tb testing
 	case VectorIndexQueryModeQuantizedOnly:
 		assertQuantizedOnlyGuardrailStats2416(tb, stats, dims)
 	case VectorIndexQueryModeQuantizedRerank:
-		assertQuantizedRerankNoDocumentGuardrailStats2416(tb, stats, opts.QuantizedRerankCandidates)
+		assertScalarU8PackNativeQuantizedRerankNoDocumentGuardrailStats2657(tb, stats, opts.QuantizedRerankCandidates, dims)
 	default:
 		tb.Fatalf("unexpected SearchWithBuffer benchmark query mode %q", opts.QueryMode)
 	}

--- a/TreeDB/collections/vector_index_search.go
+++ b/TreeDB/collections/vector_index_search.go
@@ -162,7 +162,7 @@ type VectorIndexSearchStats struct {
 	QuantizedCodeBytesRead uint64 `json:"quantized_code_bytes_read,omitempty"`
 	// QuantizedRerankCandidates counts quantized shortlist candidates submitted to exact rerank.
 	QuantizedRerankCandidates uint64 `json:"quantized_rerank_candidates,omitempty"`
-	// QuantizedRerankExactScoreCalls counts exact float32/norm score calls used by quantized_rerank.
+	// QuantizedRerankExactScoreCalls counts exact FP32 score calls used by quantized_rerank.
 	QuantizedRerankExactScoreCalls uint64 `json:"quantized_rerank_exact_score_calls,omitempty"`
 	// QuantizedScorerActive reports that a validated quantized scorer served this search.
 	QuantizedScorerActive uint64 `json:"quantized_scorer_active,omitempty"`
@@ -1224,7 +1224,14 @@ func (c *Collection) SearchVectorIndexWithBuffer(opts VectorIndexSearchOptions, 
 		}
 		response, err = prepared.SearchQuantizedWithBuffer(opts, buffer)
 		acquireStats.apply(&response.Stats)
-		healthyQuantizedRoute := vectorIndexSearchStatsAreBufferedNoDocumentQuantizedRoute(response.Stats, queryMode, opts, prepared.dimensions)
+		var healthyQuantizedRoute bool
+		// Keep quantized_only on its narrow hot-path guardrail; quantized_rerank
+		// validates pack-native exact counters separately below.
+		if queryMode == columnVectorGraphNativeSearchQueryModeQuantizedOnly {
+			healthyQuantizedRoute = vectorIndexSearchStatsAreBufferedNoDocumentQuantizedOnlyRoute(response.Stats, opts)
+		} else {
+			healthyQuantizedRoute = vectorIndexSearchStatsAreBufferedNoDocumentQuantizedRoute(response.Stats, queryMode, opts, prepared.dimensions)
+		}
 		if err == nil && healthyQuantizedRoute {
 			return response, nil
 		}
@@ -1386,8 +1393,57 @@ func vectorIndexSearchStatsAreBufferedNoDocumentPackRoute(stats VectorIndexSearc
 		stats.VectorScratchDecodes == 0
 }
 
+func vectorIndexSearchStatsAreBufferedNoDocumentQuantizedOnlyRoute(stats VectorIndexSearchStats, opts VectorIndexSearchOptions) bool {
+	columnGraphRoute := stats.SearchRouteHNSWSearchPack == 0 &&
+		stats.HNSWSearchPackActive == 0 &&
+		stats.HNSWSearchPackMissing == 0 &&
+		stats.HNSWSearchPackInvalid == 0 &&
+		stats.HNSWSearchPackStale == 0 &&
+		stats.HNSWSearchPackClosed == 0 &&
+		stats.HNSWSearchPackFallbacks == 0 &&
+		stats.SearchRouteColumnGraphPrepared+stats.SearchRouteColumnGraphFallback == 1
+	packRoute := stats.SearchRouteHNSWSearchPack == 1 &&
+		stats.HNSWSearchPackActive == 1 &&
+		stats.HNSWSearchPackMissing == 0 &&
+		stats.HNSWSearchPackInvalid == 0 &&
+		stats.HNSWSearchPackStale == 0 &&
+		stats.HNSWSearchPackClosed == 0 &&
+		stats.HNSWSearchPackFallbacks == 0 &&
+		stats.SearchRouteColumnGraphPrepared == 0 &&
+		stats.SearchRouteColumnGraphFallback == 0
+	if !columnGraphRoute && !packRoute {
+		return false
+	}
+	emptySearch := opts.TopK == 0 || stats.CandidateRows == 0
+	if !emptySearch && stats.QuantizedScorerActive != 1 {
+		return false
+	}
+	if stats.QuantizedAssetUnavailable != 0 || stats.QuantizedAssetMissing != 0 || stats.QuantizedAssetInvalid != 0 || stats.QuantizedAssetStale != 0 || stats.QuantizedAssetClosed != 0 {
+		return false
+	}
+	if stats.QuantizedAssetHeapCopy+stats.QuantizedAssetMmapDirect != 1 || stats.QuantizedAssetHeapCopyBytes+stats.QuantizedAssetMappedBytes == 0 {
+		return false
+	}
+	if stats.DocumentsFetched != 0 || stats.DocumentBytes != 0 || stats.DocumentOutputBytes != 0 || stats.GraphRowFallbacks != 0 || stats.TypedColumnFallbacks != 0 || stats.VectorScratchDecodes != 0 {
+		return false
+	}
+	if !emptySearch && (stats.QuantizedScoreCalls == 0 || stats.QuantizedCodeBytesRead == 0) {
+		return false
+	}
+	return stats.SearchRouteQuantizedOnly == 1 &&
+		stats.SearchRouteQuantizedRerank == 0 &&
+		stats.PreparedScoreCalls == 0 &&
+		stats.QuantizedRerankCandidates == 0 &&
+		stats.QuantizedRerankExactScoreCalls == 0 &&
+		stats.VectorBytesRead == 0 &&
+		stats.NormBytesRead == 0
+}
+
 func vectorIndexSearchStatsAreBufferedNoDocumentQuantizedRoute(stats VectorIndexSearchStats, queryMode columnVectorGraphNativeSearchQueryMode, opts VectorIndexSearchOptions, dimensions int) bool {
-	if !queryMode.quantized() {
+	if queryMode == columnVectorGraphNativeSearchQueryModeQuantizedOnly {
+		return vectorIndexSearchStatsAreBufferedNoDocumentQuantizedOnlyRoute(stats, opts)
+	}
+	if queryMode != columnVectorGraphNativeSearchQueryModeQuantizedRerank {
 		return false
 	}
 	columnGraphRoute := stats.SearchRouteHNSWSearchPack == 0 &&
@@ -1426,44 +1482,35 @@ func vectorIndexSearchStatsAreBufferedNoDocumentQuantizedRoute(stats VectorIndex
 	if !emptySearch && (stats.QuantizedScoreCalls == 0 || stats.QuantizedCodeBytesRead == 0) {
 		return false
 	}
-	if queryMode == columnVectorGraphNativeSearchQueryModeQuantizedOnly {
-		return stats.SearchRouteQuantizedOnly == 1 &&
-			stats.SearchRouteQuantizedRerank == 0 &&
-			stats.PreparedScoreCalls == 0 &&
-			stats.QuantizedRerankCandidates == 0 &&
-			stats.QuantizedRerankExactScoreCalls == 0 &&
-			stats.VectorBytesRead == 0 &&
-			stats.NormBytesRead == 0
+	if stats.SearchRouteQuantizedOnly != 0 || stats.SearchRouteQuantizedRerank != 1 {
+		return false
 	}
-	if queryMode == columnVectorGraphNativeSearchQueryModeQuantizedRerank {
-		if stats.SearchRouteQuantizedOnly != 0 || stats.SearchRouteQuantizedRerank != 1 {
-			return false
-		}
-		if emptySearch {
-			return stats.PreparedScoreCalls == 0 && stats.QuantizedRerankCandidates == 0 && stats.QuantizedRerankExactScoreCalls == 0 && stats.VectorBytesRead == 0 && stats.NormBytesRead == 0
-		}
-		if stats.QuantizedRerankCandidates == 0 || stats.QuantizedRerankExactScoreCalls != stats.QuantizedRerankCandidates {
-			return false
-		}
-		if opts.QuantizedRerankCandidates > 0 && stats.QuantizedRerankCandidates > uint64(opts.QuantizedRerankCandidates) {
-			return false
-		}
-		if stats.VectorBytesRead == 0 {
-			return false
-		}
-		if stats.NormBytesRead == 0 && stats.SearchRouteHNSWSearchPack == 0 {
-			return false
-		}
-		if dimensions > 0 {
-			maxVectorBytes := stats.QuantizedRerankCandidates * uint64(dimensions) * 4
-			maxNormBytes := stats.QuantizedRerankCandidates * 4
-			if stats.VectorBytesRead > maxVectorBytes || stats.NormBytesRead > maxNormBytes {
-				return false
-			}
-		}
-		return true
+	if emptySearch {
+		return stats.PreparedScoreCalls == 0 && stats.QuantizedRerankCandidates == 0 && stats.QuantizedRerankExactScoreCalls == 0 && stats.VectorBytesRead == 0 && stats.NormBytesRead == 0
 	}
-	return false
+	if stats.QuantizedRerankCandidates == 0 || stats.QuantizedRerankExactScoreCalls != stats.QuantizedRerankCandidates {
+		return false
+	}
+	if opts.QuantizedRerankCandidates > 0 && stats.QuantizedRerankCandidates > uint64(opts.QuantizedRerankCandidates) {
+		return false
+	}
+	if stats.VectorBytesRead == 0 {
+		return false
+	}
+	packNativeExactRerank := stats.PreparedScoreCalls == stats.QuantizedRerankExactScoreCalls &&
+		stats.VectorPreparedDirectViews == stats.QuantizedRerankExactScoreCalls &&
+		stats.NormPreparedDirectViews == 0
+	if stats.NormBytesRead == 0 && stats.SearchRouteHNSWSearchPack == 0 && !packNativeExactRerank {
+		return false
+	}
+	if dimensions > 0 {
+		maxVectorBytes := stats.QuantizedRerankCandidates * uint64(dimensions) * 4
+		maxNormBytes := stats.QuantizedRerankCandidates * 4
+		if stats.VectorBytesRead > maxVectorBytes || stats.NormBytesRead > maxNormBytes {
+			return false
+		}
+	}
+	return true
 }
 
 // OpenVectorIndexSearcher opens a reusable search handle for steady-state

--- a/TreeDB/collections/vector_index_search_test.go
+++ b/TreeDB/collections/vector_index_search_test.go
@@ -339,13 +339,13 @@ func assertScalarU8PackNativeQuantizedRerankNoDocumentGuardrailStats2657(tb test
 		tb.Fatalf("scalar_u8 pack-native quantized_rerank stats=%+v want exact score calls equal shortlist=%d", stats, shortlist)
 	}
 	if stats.PreparedScoreCalls != shortlist64 || stats.VectorPreparedDirectViews != shortlist64 || stats.NormPreparedDirectViews != 0 {
-		tb.Fatalf("scalar_u8 pack-native quantized_rerank stats=%+v want prepared pack exact row-ID scores=%d and no prepared norm reads", stats, shortlist)
+		tb.Fatalf("scalar_u8 pack-native quantized_rerank stats=%+v want prepared pack exact row-ID scores=%d and no prepared norm views", stats, shortlist)
 	}
 	if dims > 0 && stats.VectorBytesRead != shortlist64*uint64(dims)*4 {
 		tb.Fatalf("scalar_u8 pack-native quantized_rerank stats=%+v want vector bytes=%d", stats, shortlist64*uint64(dims)*4)
 	}
-	if stats.NormBytesRead != 0 {
-		tb.Fatalf("scalar_u8 pack-native quantized_rerank stats=%+v want normalized-vector pack rerank with no norm reads", stats)
+	if stats.NormBytesRead != shortlist64*4 {
+		tb.Fatalf("scalar_u8 pack-native quantized_rerank stats=%+v want logical exact norm bytes=%d", stats, shortlist64*4)
 	}
 	if stats.DocumentsFetched != 0 || stats.GraphRowFallbacks != 0 || stats.TypedColumnFallbacks != 0 || stats.VectorScratchDecodes != 0 {
 		tb.Fatalf("scalar_u8 pack-native quantized_rerank guardrails stats=%+v want no docs/fallback/scratch decode", stats)

--- a/TreeDB/collections/vector_index_search_test.go
+++ b/TreeDB/collections/vector_index_search_test.go
@@ -319,6 +319,39 @@ func assertQuantizedRerankNoDocumentGuardrailStats2416(tb testing.TB, stats Vect
 	}
 }
 
+func assertScalarU8PackNativeQuantizedRerankNoDocumentGuardrailStats2657(tb testing.TB, stats VectorIndexSearchStats, shortlist int, dims int) {
+	tb.Helper()
+	diag := stats.Diagnostics()
+	if diag.Route != VectorIndexSearchRouteQuantizedRerank || diag.HNSWSearchPackStatus != VectorIndexSearchHNSWSearchPackStatusNone || diag.ExactHNSWSearchPackNoDocRoute {
+		tb.Fatalf("scalar_u8 pack-native quantized_rerank diagnostics=%+v want quantized route without exact hnsw_search_pack_v1 route claim", diag)
+	}
+	if stats.SearchRouteQuantizedOnly != 0 || stats.SearchRouteQuantizedRerank != 1 || stats.QuantizedScorerActive != 1 {
+		tb.Fatalf("scalar_u8 pack-native quantized_rerank route stats=%+v want quantized-rerank scorer route", stats)
+	}
+	if stats.SearchRouteHNSWSearchPack != 0 || stats.HNSWSearchPackActive != 0 || stats.HNSWSearchPackFallbacks != 0 {
+		tb.Fatalf("scalar_u8 pack-native quantized_rerank stats=%+v want no public hnsw_search_pack_v1 route/active/fallback claim", stats)
+	}
+	if stats.QuantizedAssetUnavailable != 0 || stats.QuantizedAssetHeapCopy+stats.QuantizedAssetMmapDirect != 1 {
+		tb.Fatalf("scalar_u8 pack-native quantized_rerank asset stats=%+v want available quantized asset", stats)
+	}
+	shortlist64 := uint64(shortlist)
+	if stats.QuantizedScoreCalls == 0 || stats.QuantizedRerankCandidates != shortlist64 || stats.QuantizedRerankExactScoreCalls != shortlist64 {
+		tb.Fatalf("scalar_u8 pack-native quantized_rerank stats=%+v want exact score calls equal shortlist=%d", stats, shortlist)
+	}
+	if stats.PreparedScoreCalls != shortlist64 || stats.VectorPreparedDirectViews != shortlist64 || stats.NormPreparedDirectViews != 0 {
+		tb.Fatalf("scalar_u8 pack-native quantized_rerank stats=%+v want prepared pack exact row-ID scores=%d and no prepared norm reads", stats, shortlist)
+	}
+	if dims > 0 && stats.VectorBytesRead != shortlist64*uint64(dims)*4 {
+		tb.Fatalf("scalar_u8 pack-native quantized_rerank stats=%+v want vector bytes=%d", stats, shortlist64*uint64(dims)*4)
+	}
+	if stats.NormBytesRead != 0 {
+		tb.Fatalf("scalar_u8 pack-native quantized_rerank stats=%+v want normalized-vector pack rerank with no norm reads", stats)
+	}
+	if stats.DocumentsFetched != 0 || stats.GraphRowFallbacks != 0 || stats.TypedColumnFallbacks != 0 || stats.VectorScratchDecodes != 0 {
+		tb.Fatalf("scalar_u8 pack-native quantized_rerank guardrails stats=%+v want no docs/fallback/scratch decode", stats)
+	}
+}
+
 func assertQuantizedUnavailableGuardrailStats2416(tb testing.TB, stats VectorIndexSearchStats, mode columnVectorGraphNativeSearchQueryMode, health columnVectorGraphQuantizedAssetHealth) {
 	tb.Helper()
 	diag := stats.Diagnostics()
@@ -422,7 +455,7 @@ func TestVectorIndexSearcherQuantizedSearchWithBufferSuccessAndErrorReset1926(t 
 	if len(buffer.results) != 2 || len(buffer.idBytes) == 0 || reranked.Stats.QuantizedScoreCalls == 0 || reranked.Stats.QuantizedRerankExactScoreCalls == 0 {
 		t.Fatalf("rerank buffer/results stats=%+v buffer.results=%d idBytes=%d", reranked.Stats, len(buffer.results), len(buffer.idBytes))
 	}
-	assertQuantizedRerankNoDocumentGuardrailStats2416(t, reranked.Stats, len(rows))
+	assertScalarU8PackNativeQuantizedRerankNoDocumentGuardrailStats2657(t, reranked.Stats, len(rows), def.Dimensions)
 	quantizedAllocs := testing.AllocsPerRun(100, func() {
 		got, err := searcher.SearchWithBuffer(quantizedOpts, &buffer)
 		if err != nil || len(got.Results) != 2 {
@@ -580,6 +613,10 @@ func TestVectorIndexSearcherQuantizedSearchAndSearchWithBufferParity2414(t *test
 			mode:             VectorIndexQueryModeQuantizedRerank,
 			rerankCandidates: 4,
 			assertStats: func(tb testing.TB, stats VectorIndexSearchStats) {
+				if stats.NormBytesRead == 0 {
+					assertScalarU8PackNativeQuantizedRerankNoDocumentGuardrailStats2657(tb, stats, 4, def.Dimensions)
+					return
+				}
 				assertQuantizedRerankNoDocumentGuardrailStats2416(tb, stats, 4)
 			},
 		},
@@ -671,7 +708,7 @@ func TestSearchVectorIndexWithBufferQuantizedOnlyAndRerank2415(t *testing.T) {
 	}
 	assertColumnGraphSearchResponseLoadedV4(t, reranked, def.Name, rerankOpts.TopK)
 	assertVectorIndexSearchResultsV4(t, reranked.Results, exactColumnGraphTopKForTest(t, rows, query, rerankOpts.TopK), false)
-	assertQuantizedRerankNoDocumentGuardrailStats2416(t, reranked.Stats, rerankOpts.QuantizedRerankCandidates)
+	assertScalarU8PackNativeQuantizedRerankNoDocumentGuardrailStats2657(t, reranked.Stats, rerankOpts.QuantizedRerankCandidates, def.Dimensions)
 	assertCollectionBufferedQuantizedRouteStats2415(t, reranked.Stats, columnVectorGraphNativeSearchQueryModeQuantizedRerank, rerankOpts, def.Dimensions)
 	afterRerank := col.collectionVectorIndexPreparedSearchCacheSnapshot()
 	if afterRerank.Entries != 1 || afterRerank.CacheBuilds != afterOnly.CacheBuilds || afterRerank.CacheHits <= afterOnly.CacheHits {
@@ -941,7 +978,7 @@ func TestScalarU8QuantizedPreparedTraversalPackRouteWhenAdjacencyClosed2586(t *t
 		t.Fatalf("quantized_rerank SearchWithBuffer with closed prepared adjacency: %v", err)
 	}
 	assertVectorIndexSearchResultsV4(t, reranked.Results, exactColumnGraphTopKForTest(t, rows, query, 3), false)
-	assertQuantizedRerankNoDocumentGuardrailStats2416(t, reranked.Stats, len(rows))
+	assertScalarU8PackNativeQuantizedRerankNoDocumentGuardrailStats2657(t, reranked.Stats, len(rows), def.Dimensions)
 	assertScalarU8PreparedTraversalPackAdjacencyStats2586(t, reranked.Stats, packStatus, "quantized_rerank")
 	if reranked.Stats.QuantizedRerankExactScoreCalls != uint64(len(rows)) {
 		t.Fatalf("quantized_rerank stats=%+v want exact rerank shortlist", reranked.Stats)
@@ -997,7 +1034,7 @@ func TestScalarU8QuantizedPreparedTraversalRerankPreservesEfTraversal2586(t *tes
 	if err != nil {
 		t.Fatalf("fallback SearchWithBuffer: %v", err)
 	}
-	assertQuantizedRerankNoDocumentGuardrailStats2416(t, packResults.Stats, opts.QuantizedRerankCandidates)
+	assertScalarU8PackNativeQuantizedRerankNoDocumentGuardrailStats2657(t, packResults.Stats, opts.QuantizedRerankCandidates, def.Dimensions)
 	assertQuantizedRerankNoDocumentGuardrailStats2416(t, fallbackResults.Stats, opts.QuantizedRerankCandidates)
 	if packResults.Stats.Candidates != fallbackResults.Stats.Candidates || packResults.Stats.VisitedEdges != fallbackResults.Stats.VisitedEdges || packResults.Stats.QuantizedScoreCalls != fallbackResults.Stats.QuantizedScoreCalls || packResults.Stats.QuantizedRerankExactScoreCalls != fallbackResults.Stats.QuantizedRerankExactScoreCalls {
 		t.Fatalf("pack stats=%+v fallback stats=%+v want same efSearch traversal and rerank counters", packResults.Stats, fallbackResults.Stats)
@@ -1008,7 +1045,7 @@ func TestScalarU8QuantizedPreparedTraversalRerankPreservesEfTraversal2586(t *tes
 	for i := range packResults.Results {
 		got := packResults.Results[i]
 		want := fallbackResults.Results[i]
-		if string(got.ID) != string(want.ID) || got.Ordinal != want.Ordinal || got.Score != want.Score {
+		if string(got.ID) != string(want.ID) || got.Ordinal != want.Ordinal || math.Abs(got.Score-want.Score) > 1e-6 {
 			t.Fatalf("result[%d] pack=%+v fallback=%+v", i, got, want)
 		}
 	}
@@ -1067,7 +1104,7 @@ func TestSearchVectorIndexWithBufferScalarU8PreparedTraversalPackRouteWhenAdjace
 		t.Fatalf("quantized_rerank SearchVectorIndexWithBuffer with closed prepared adjacency: %v", err)
 	}
 	assertVectorIndexSearchResultsV4(t, reranked.Results, exactColumnGraphTopKForTest(t, rows, query, rerankOpts.TopK), false)
-	assertQuantizedRerankNoDocumentGuardrailStats2416(t, reranked.Stats, rerankOpts.QuantizedRerankCandidates)
+	assertScalarU8PackNativeQuantizedRerankNoDocumentGuardrailStats2657(t, reranked.Stats, rerankOpts.QuantizedRerankCandidates, def.Dimensions)
 	assertCollectionBufferedQuantizedRouteStats2415(t, reranked.Stats, columnVectorGraphNativeSearchQueryModeQuantizedRerank, rerankOpts, def.Dimensions)
 	assertScalarU8PreparedTraversalPackAdjacencyStats2586(t, reranked.Stats, packStatus, "collection quantized_rerank")
 	if reranked.Stats.QuantizedRerankExactScoreCalls != uint64(rerankOpts.QuantizedRerankCandidates) {


### PR DESCRIPTION
Closes #2657

## Summary
- Route scalar_u8 prepared HNSW `quantized_rerank` retained shortlists through the prepared pack's exact FP32 row-ID scorer.
- Avoid rebuilding the generic native-search plan / row-reader exact rerank path on this prepared-pack rerank route.
- Keep product-facing quantized-rerank exact byte counters bounded by the rerank shortlist and add pack-native rerank parity/stats guardrails.
- Keep `quantized_only` collection guardrail checks on their narrow hot path.

## Invariants / scope
- Preserves scalar_u8 score formula, codec/asset identity, quantized asset format, fail-closed behavior, mmap/direct prepared collection assets, exact FP32 route identity, and no silent exact fallback for quantized modes.
- Hot search rows remain `0 B/op`, `0 allocs/op` in the benchmark evidence.
- No downstream issue work included (#2658/#2659/#2660 remain out of scope).

## Tests
Latest head: `0e6efccbbd3053bf823f8227e604a59262acb2a5`

- `GOMAXPROCS=8 GOWORK=off go test ./TreeDB/documentservice -run TestServiceBenchmarkLifecycleResetOptimizeAndNoDocumentSearch -count=1` — pass (`/tmp/scalar_u8_adapter_2657/final_0e6/test_documentservice_benchmark_lifecycle.log`)
- `GOMAXPROCS=8 GOWORK=off go test ./cmd/treedb_vector_search_demo -run TestExecuteColumnGraphQuantizedModes -count=1` — pass (`/tmp/scalar_u8_adapter_2657/final_0e6/test_vector_search_demo_quantized_modes.log`)
- `GOMAXPROCS=8 GOWORK=off go test ./TreeDB/collections -run 'TestColumnHNSWPreparedScalarU8RerankUsesPackNativeRowIDExactScorer2657|TestVectorIndexSearcherQuantizedSearchWithBufferSuccessAndErrorReset1926|TestSearchVectorIndexWithBufferQuantizedOnlyAndRerank2415|TestScalarU8QuantizedPreparedTraversalPackRouteWhenAdjacencyClosed2586|TestScalarU8QuantizedPreparedTraversalRerankPreservesEfTraversal2586|TestSearchVectorIndexWithBufferScalarU8PreparedTraversalPackRouteWhenAdjacencyClosed2586|TestSearchVectorIndexWithBufferQuantizedEmptyCollection2415|TestSearchVectorIndexWithBufferQuantizedAssetUnavailableFailClosed2415' -count=1` — pass (`/tmp/scalar_u8_adapter_2657/final_0e6/test_focused_collections.log`)
- `GOMAXPROCS=8 GOWORK=off go test ./TreeDB/internal/vectorops ./TreeDB/collections -count=1` — pass (`/tmp/scalar_u8_adapter_2657/final_0e6/test_vectorops_collections.log`)

## Benchmarks
Base: `origin/main` `6fe181fef480276e15cbeedaacadd7561b43ed77`  
Candidate: `0e6efccbbd3053bf823f8227e604a59262acb2a5`  
Machine: Apple M3, `TREEDB_COLUMN_GRAPH_QUANTIZED_BENCH_SHAPE=10k_x_768 GOMAXPROCS=8 GOWORK=off`, `-benchmem -benchtime=100000x -count=10`

| Artifact | Result |
| --- | --- |
| `/tmp/scalar_u8_adapter_2657/benchstat_qonly_c1_6fe_vs_0f3eab17_20260612_080833.txt` | Focused qonly c=1 blocker check before the final counter-only stats fix: searcher `14.89µ -> 14.82µ` neutral, collection `15.86µ -> 15.76µ` (-0.63%); `0 B/op`, `0 allocs/op`. |
| `/tmp/scalar_u8_adapter_2657/benchstat_production_scalar_u8_6fe_vs_0f3eab17_20260612_083540.txt` | Focused scalar_u8 production gate before the final counter-only stats fix: geomean `8.308µ -> 8.272µ` (-0.43%); no significant material regression. |
| `/tmp/scalar_u8_adapter_2657/benchstat_focused_scalar_u8_241x_6fe_vs_0f3eab17_20260612_083943.txt` | Focused standalone scalar_u8 rows before the final counter-only stats fix: geomean `9.415µ -> 7.864µ` (-16.47%); rows improved or neutral; `0 B/op`, `0 allocs/op`. |
| `/tmp/scalar_u8_adapter_2657/benchstat_required_6fe_vs_0f3eab17.txt` | Required mixed matrix before the final counter-only stats fix: geomean `12.52µ -> 12.55µ` (+0.21%). Some c=8/qonly rows were noisy; focused reruns did not confirm a material local regression. |
| `/tmp/scalar_u8_adapter_2657/final_0e6/benchstat_qonly_c8_reverse_6fe_vs_0e6_v2.txt` | Latest-head qonly c=8 reverse-order check: geomean `4.452µ -> 3.529µ` (-20.73%); all counters/allocs unchanged, `0 B/op`, `0 allocs/op`. |
| `/tmp/scalar_u8_adapter_2657/final_0e6/benchstat_rerank_c8_reverse_6fe_vs_0e6.txt` | Latest-head rerank c=8 reverse-order check: geomean `5.092µ -> 5.228µ` (+2.67%) with noisy rows; counters/allocs unchanged, `0 B/op`, `0 allocs/op`. |

## CI / review
- Latest-head CI for `0e6efccbbd3053bf823f8227e604a59262acb2a5`: all PR checks green.
- Internal review: complete; no known correctness or performance blockers.
- AI review: Codex was green on `0f3eab17e7`; re-requested for latest head after the counter-only stats fix. CodeRabbit latest-head check completed/skipped without actionable findings. Copilot was requested.

## Merge
- Do not merge directly; coordinator owns merge after gates pass.
