### PR TITLE
TreeDB documentservice: add raw binary vector-index search

### DIFF
--- a/TreeDB/documentservice/http.go
+++ b/TreeDB/documentservice/http.go
@@ -223,6 +223,17 @@ func (h *Handler) serveSearchOperation(w http.ResponseWriter, r *http.Request, i
 			return
 		}
 		writeJSON(w, http.StatusOK, res)
+	case "vector-index:binary":
+		req, ok := h.decodeBenchmarkVectorSearchBinaryRequest(w, r, maxBodyBytes)
+		if !ok {
+			return
+		}
+		res, err := h.Service.SearchBenchmarkVector(r.Context(), index, req)
+		if err != nil {
+			writeError(w, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, res)
 	default:
 		writeError(w, serviceErrorf(CodeInvalidRequest, "unknown search operation %q", op))
 	}

--- a/TreeDB/documentservice/http_test.go
+++ b/TreeDB/documentservice/http_test.go
@@ -279,6 +279,7 @@ func TestHTTPBenchmarkVectorSearchBinaryF32LE(t *testing.T) {
 	postBinaryVectorSearch(t, handler, "/v1/indexes/bench_binary/search/vector-index:binary?top_k=1&ef_search=8&query_mode=exact", encodeFloat32LERawForTest([]float32{1, 0, 0}), benchmarkVectorSearchBinaryContentType, http.StatusBadRequest, nil)
 	postBinaryVectorSearch(t, handler, "/v1/indexes/bench_binary/search/vector-index:binary?top_k=1&ef_search=8&query_mode=quantized_rerank", rawQuery, benchmarkVectorSearchBinaryContentType, http.StatusBadRequest, nil)
 	postBinaryVectorSearch(t, handler, "/v1/indexes/bench_binary/search/vector-index:binary?top_k=1&ef_search=8&query_mode=exact&quantized_index_name=embedding.scalar_u8.fast", rawQuery, benchmarkVectorSearchBinaryContentType, http.StatusBadRequest, nil)
+	postBinaryVectorSearchWithRawQuery(t, handler, "/v1/indexes/bench_binary/search/vector-index:binary", "top_k=1&ef_search=%zz", rawQuery, benchmarkVectorSearchBinaryContentType, http.StatusBadRequest, nil)
 	postBinaryVectorSearch(t, handler, "/v1/indexes/bench_binary/search/vector-index:binary?top_k=1&ef_search=8&query_mode=exact", nil, benchmarkVectorSearchBinaryContentType, http.StatusBadRequest, nil)
 
 	smallBodyHandler := NewHandler(svc)
@@ -327,13 +328,25 @@ func postJSON(t *testing.T, handler http.Handler, path string, body any, wantSta
 func postBinaryVectorSearch(t *testing.T, handler http.Handler, path string, body []byte, contentType string, wantStatus int, out any) {
 	t.Helper()
 	req := httptest.NewRequest(http.MethodPost, path, bytes.NewReader(body))
+	serveBinaryVectorSearchRequest(t, handler, req, path, contentType, wantStatus, out)
+}
+
+func postBinaryVectorSearchWithRawQuery(t *testing.T, handler http.Handler, path, rawQuery string, body []byte, contentType string, wantStatus int, out any) {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, path, bytes.NewReader(body))
+	req.URL.RawQuery = rawQuery
+	serveBinaryVectorSearchRequest(t, handler, req, path+"?"+rawQuery, contentType, wantStatus, out)
+}
+
+func serveBinaryVectorSearchRequest(t *testing.T, handler http.Handler, req *http.Request, label string, contentType string, wantStatus int, out any) {
+	t.Helper()
 	if contentType != "" {
 		req.Header.Set("Content-Type", contentType)
 	}
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 	if rr.Code != wantStatus {
-		t.Fatalf("POST %s status=%d want %d body=%s", path, rr.Code, wantStatus, rr.Body.String())
+		t.Fatalf("POST %s status=%d want %d body=%s", label, rr.Code, wantStatus, rr.Body.String())
 	}
 	if out != nil {
 		if err := json.Unmarshal(rr.Body.Bytes(), out); err != nil {

--- a/TreeDB/documentservice/http_test.go
+++ b/TreeDB/documentservice/http_test.go
@@ -8,6 +8,7 @@ import (
 	"math"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
 
 	"github.com/snissn/gomap/TreeDB/collections"
@@ -240,12 +241,68 @@ func TestHTTPBenchmarkVectorSearchAcceptsF32LEBase64Embedding(t *testing.T) {
 	}
 }
 
+func TestHTTPBenchmarkVectorSearchBinaryF32LE(t *testing.T) {
+	svc, db := newTestService(t)
+	defer db.Close()
+	handler := NewHandler(svc)
+
+	postJSON(t, handler, "/v1/indexes/bench_binary/reset", ResetIndexRequest{
+		Dimension: 2,
+		DropOld:   true,
+		VectorIndexOptions: &BenchmarkVectorIndexOptions{
+			Strategy: collections.VectorIndexStrategyColumnGraph,
+		},
+	}, http.StatusOK, nil)
+	postJSON(t, handler, "/v1/indexes/bench_binary/documents/upsert", UpsertDocumentsRequest{Documents: []Document{
+		{ID: "a", Content: "alpha", Embedding: []float32{1, 0}},
+		{ID: "b", Content: "beta", Embedding: []float32{0, 1}},
+	}, DeferVectorIndexRebuild: true}, http.StatusOK, nil)
+	postJSON(t, handler, "/v1/indexes/bench_binary/optimize", OptimizeIndexRequest{}, http.StatusOK, nil)
+
+	var jsonResponse BenchmarkVectorSearchResponse
+	postJSON(t, handler, "/v1/indexes/bench_binary/search/vector-index", BenchmarkVectorSearchRequest{QueryEmbedding: []float32{1, 0}, TopK: 1, EfSearch: 8}, http.StatusOK, &jsonResponse)
+	assertExactBenchmarkNoDocumentRoute(t, jsonResponse)
+
+	rawQuery := encodeFloat32LERawForTest([]float32{1, 0})
+	var binaryResponse BenchmarkVectorSearchResponse
+	postBinaryVectorSearch(t, handler, "/v1/indexes/bench_binary/search/vector-index:binary?top_k=1&ef_search=8&query_mode=exact&vector_index_name=embedding", rawQuery, benchmarkVectorSearchBinaryContentType, http.StatusOK, &binaryResponse)
+	assertExactBenchmarkNoDocumentRoute(t, binaryResponse)
+	if len(binaryResponse.Results) != 1 || len(jsonResponse.Results) != 1 || binaryResponse.Results[0].ID != jsonResponse.Results[0].ID || binaryResponse.Results[0].Score != jsonResponse.Results[0].Score {
+		t.Fatalf("binary response results=%+v, json results=%+v", binaryResponse.Results, jsonResponse.Results)
+	}
+	var binaryOptionsResponse BenchmarkVectorSearchResponse
+	postBinaryVectorSearch(t, handler, "/v1/indexes/bench_binary/search/vector-index:binary?top_k=1&ef_search=8&query_mode=exact&expected_generation="+strconv.FormatUint(jsonResponse.Index.Generation, 10)+"&stats_mode=full_diagnostics", rawQuery, benchmarkVectorSearchBinaryContentType, http.StatusOK, &binaryOptionsResponse)
+	assertExactBenchmarkNoDocumentRoute(t, binaryOptionsResponse)
+
+	postBinaryVectorSearch(t, handler, "/v1/indexes/bench_binary/search/vector-index:binary?top_k=1&ef_search=8&query_mode=exact", rawQuery, "application/octet-stream", http.StatusBadRequest, nil)
+	postBinaryVectorSearch(t, handler, "/v1/indexes/bench_binary/search/vector-index:binary?top_k=1&ef_search=8&query_mode=exact", []byte{1, 2, 3}, benchmarkVectorSearchBinaryContentType, http.StatusBadRequest, nil)
+	postBinaryVectorSearch(t, handler, "/v1/indexes/bench_binary/search/vector-index:binary?top_k=1&ef_search=8&query_mode=exact", encodeFloat32LERawForTest([]float32{1, 0, 0}), benchmarkVectorSearchBinaryContentType, http.StatusBadRequest, nil)
+	postBinaryVectorSearch(t, handler, "/v1/indexes/bench_binary/search/vector-index:binary?top_k=1&ef_search=8&query_mode=quantized_rerank", rawQuery, benchmarkVectorSearchBinaryContentType, http.StatusBadRequest, nil)
+	postBinaryVectorSearch(t, handler, "/v1/indexes/bench_binary/search/vector-index:binary?top_k=1&ef_search=8&query_mode=exact&quantized_index_name=embedding.scalar_u8.fast", rawQuery, benchmarkVectorSearchBinaryContentType, http.StatusBadRequest, nil)
+	postBinaryVectorSearch(t, handler, "/v1/indexes/bench_binary/search/vector-index:binary?top_k=1&ef_search=8&query_mode=exact", nil, benchmarkVectorSearchBinaryContentType, http.StatusBadRequest, nil)
+
+	smallBodyHandler := NewHandler(svc)
+	smallBodyHandler.MaxBodyBytes = int64(len(rawQuery) - 1)
+	postBinaryVectorSearch(t, smallBodyHandler, "/v1/indexes/bench_binary/search/vector-index:binary?top_k=1&ef_search=8&query_mode=exact", rawQuery, benchmarkVectorSearchBinaryContentType, http.StatusBadRequest, nil)
+}
+
+func assertExactBenchmarkNoDocumentRoute(t *testing.T, response BenchmarkVectorSearchResponse) {
+	t.Helper()
+	if !response.NoDocuments || response.Stats.DocumentsFetched != 0 || response.Diagnostics.Route != collections.VectorIndexSearchRouteExactHNSWSearchPackV1 || response.Diagnostics.FallbackReason != collections.VectorIndexSearchFallbackReasonNone || !response.Diagnostics.ExactHNSWSearchPackNoDocRoute || !response.Diagnostics.NoDocumentGuardrailsOK {
+		t.Fatalf("benchmark vector response left exact no-document route: no_documents=%v stats=%+v diagnostics=%+v", response.NoDocuments, response.Stats, response.Diagnostics)
+	}
+}
+
 func encodeFloat32LEBase64ForTest(values []float32) string {
+	return base64.StdEncoding.EncodeToString(encodeFloat32LERawForTest(values))
+}
+
+func encodeFloat32LERawForTest(values []float32) []byte {
 	raw := make([]byte, len(values)*4)
 	for i, value := range values {
 		binary.LittleEndian.PutUint32(raw[i*4:], math.Float32bits(value))
 	}
-	return base64.StdEncoding.EncodeToString(raw)
+	return raw
 }
 
 func postJSON(t *testing.T, handler http.Handler, path string, body any, wantStatus int, out any) {
@@ -255,6 +312,24 @@ func postJSON(t *testing.T, handler http.Handler, path string, body any, wantSta
 		t.Fatalf("marshal body: %v", err)
 	}
 	req := httptest.NewRequest(http.MethodPost, path, bytes.NewReader(raw))
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	if rr.Code != wantStatus {
+		t.Fatalf("POST %s status=%d want %d body=%s", path, rr.Code, wantStatus, rr.Body.String())
+	}
+	if out != nil {
+		if err := json.Unmarshal(rr.Body.Bytes(), out); err != nil {
+			t.Fatalf("decode response: %v body=%s", err, rr.Body.String())
+		}
+	}
+}
+
+func postBinaryVectorSearch(t *testing.T, handler http.Handler, path string, body []byte, contentType string, wantStatus int, out any) {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, path, bytes.NewReader(body))
+	if contentType != "" {
+		req.Header.Set("Content-Type", contentType)
+	}
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 	if rr.Code != wantStatus {

--- a/TreeDB/documentservice/http_vector_index_bench_test.go
+++ b/TreeDB/documentservice/http_vector_index_bench_test.go
@@ -1,6 +1,7 @@
 package documentservice
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"math"
@@ -19,6 +20,7 @@ func BenchmarkBenchmarkVectorSearchDecode(b *testing.B) {
 	query := benchmarkVectorQuery(1536)
 	jsonPayload := benchmarkVectorSearchJSONPayload(query)
 	b64Payload := benchmarkVectorSearchF32LEBase64Payload(query)
+	rawPayload := encodeFloat32LERawForTest(query)
 	encoded := encodeFloat32LEBase64ForTest(query)
 
 	b.Run("json_float_array_request", func(b *testing.B) {
@@ -65,6 +67,17 @@ func BenchmarkBenchmarkVectorSearchDecode(b *testing.B) {
 			benchmarkVectorDecodeSink = req
 		}
 	})
+	b.Run("raw_f32le_request", func(b *testing.B) {
+		b.ReportAllocs()
+		b.SetBytes(int64(len(rawPayload)))
+		for i := 0; i < b.N; i++ {
+			query, err := decodeBenchmarkVectorQueryEmbeddingF32LERawWithLabel(rawPayload, "binary vector search request body")
+			if err != nil {
+				b.Fatal(err)
+			}
+			benchmarkVectorDecodeSink = BenchmarkVectorSearchRequest{QueryEmbedding: query, TopK: 10, EfSearch: 128, QueryMode: BenchmarkVectorQueryModeExact}
+		}
+	})
 }
 
 func BenchmarkBenchmarkVectorSearchHTTPPredecodedRequest(b *testing.B) {
@@ -72,15 +85,13 @@ func BenchmarkBenchmarkVectorSearchHTTPPredecodedRequest(b *testing.B) {
 	b.Cleanup(func() { _ = db.Close() })
 	ctx := b.Context()
 	index := "bench_http_predecoded"
-	createBenchmarkColumnGraphIndex(b, svc, index)
-	loadBenchmarkDocsDeferred(b, svc, index, []Document{
-		{ID: "a", Content: "alpha", Embedding: []float32{1, 0}},
-		{ID: "b", Content: "beta", Embedding: []float32{0, 1}},
-	})
+	query := benchmarkVectorQuery(1536)
+	createBenchmarkColumnGraphIndexWithDimension(b, svc, index, len(query))
+	loadBenchmarkDocsDeferred(b, svc, index, benchmarkVectorDocumentsForQuery(query))
 	if _, err := svc.OptimizeIndex(ctx, index, OptimizeIndexRequest{}); err != nil {
 		b.Fatalf("OptimizeIndex: %v", err)
 	}
-	request := BenchmarkVectorSearchRequest{QueryEmbedding: []float32{1, 0}, TopK: 1, EfSearch: 8}
+	request := BenchmarkVectorSearchRequest{QueryEmbedding: query, TopK: 1, EfSearch: 8}
 	httpRequest := httptest.NewRequest(http.MethodPost, "/v1/indexes/bench_http_predecoded/search/vector-index", nil)
 
 	b.ReportAllocs()
@@ -97,6 +108,54 @@ func BenchmarkBenchmarkVectorSearchHTTPPredecodedRequest(b *testing.B) {
 		}
 		benchmarkVectorResponseSink = response
 	}
+}
+
+func BenchmarkBenchmarkVectorSearchHTTPHandler(b *testing.B) {
+	svc, db := newTestService(b)
+	b.Cleanup(func() { _ = db.Close() })
+	ctx := b.Context()
+	index := "bench_http_handler"
+	query := benchmarkVectorQuery(1536)
+	createBenchmarkColumnGraphIndexWithDimension(b, svc, index, len(query))
+	loadBenchmarkDocsDeferred(b, svc, index, benchmarkVectorDocumentsForQuery(query))
+	if _, err := svc.OptimizeIndex(ctx, index, OptimizeIndexRequest{}); err != nil {
+		b.Fatalf("OptimizeIndex: %v", err)
+	}
+	handler := NewHandler(svc)
+	b64Payload, err := json.Marshal(BenchmarkVectorSearchRequest{QueryEmbeddingF32LEBase64: encodeFloat32LEBase64ForTest(query), TopK: 1, EfSearch: 8})
+	if err != nil {
+		b.Fatal(err)
+	}
+	rawPayload := encodeFloat32LERawForTest(query)
+
+	b.Run("json_f32_b64", func(b *testing.B) {
+		b.ReportAllocs()
+		b.SetBytes(int64(len(b64Payload)))
+		for i := 0; i < b.N; i++ {
+			req := httptest.NewRequest(http.MethodPost, "/v1/indexes/bench_http_handler/search/vector-index", bytes.NewReader(b64Payload))
+			req.Header.Set("Content-Type", "application/json")
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+			if rr.Code != http.StatusOK {
+				b.Fatalf("status=%d body=%s", rr.Code, rr.Body.String())
+			}
+			benchmarkVectorBytesSink = rr.Body.Bytes()
+		}
+	})
+	b.Run("raw_f32le_binary", func(b *testing.B) {
+		b.ReportAllocs()
+		b.SetBytes(int64(len(rawPayload)))
+		for i := 0; i < b.N; i++ {
+			req := httptest.NewRequest(http.MethodPost, "/v1/indexes/bench_http_handler/search/vector-index:binary?top_k=1&ef_search=8&query_mode=exact", bytes.NewReader(rawPayload))
+			req.Header.Set("Content-Type", benchmarkVectorSearchBinaryContentType)
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+			if rr.Code != http.StatusOK {
+				b.Fatalf("status=%d body=%s", rr.Code, rr.Body.String())
+			}
+			benchmarkVectorBytesSink = rr.Body.Bytes()
+		}
+	})
 }
 
 func BenchmarkBenchmarkVectorSearchResponseEncode(b *testing.B) {
@@ -138,6 +197,25 @@ func benchmarkVectorQuery(dim int) []float32 {
 		query[i] = float32(math.Sin(float64(i+1)) * 0.01)
 	}
 	return query
+}
+
+func benchmarkVectorDocumentsForQuery(query []float32) []Document {
+	first := append([]float32(nil), query...)
+	second := make([]float32, len(query))
+	for i, value := range query {
+		second[i] = -value
+	}
+	return []Document{
+		{ID: "a", Content: "alpha", Embedding: first},
+		{ID: "b", Content: "beta", Embedding: second},
+	}
+}
+
+func createBenchmarkColumnGraphIndexWithDimension(t testing.TB, svc *Service, index string, dimension int) {
+	t.Helper()
+	if _, err := svc.ResetIndex(t.Context(), index, ResetIndexRequest{Dimension: dimension, Metric: MetricCosine, DropOld: true, VectorIndexOptions: benchmarkColumnGraphOptions()}); err != nil {
+		t.Fatalf("ResetIndex %s create: %v", index, err)
+	}
 }
 
 func benchmarkVectorSearchJSONPayload(query []float32) []byte {

--- a/TreeDB/documentservice/http_vector_index_decode.go
+++ b/TreeDB/documentservice/http_vector_index_decode.go
@@ -61,7 +61,7 @@ func (h *Handler) decodeBenchmarkVectorSearchBinaryRequest(w http.ResponseWriter
 		writeError(w, err)
 		return BenchmarkVectorSearchRequest{}, false
 	}
-	req, err := parseBenchmarkVectorSearchBinaryQuery(r.URL.Query())
+	req, err := parseBenchmarkVectorSearchBinaryRawQuery(r.URL.RawQuery)
 	if err != nil {
 		writeError(w, err)
 		return BenchmarkVectorSearchRequest{}, false
@@ -127,6 +127,14 @@ func readBenchmarkVectorSearchBinaryBody(w http.ResponseWriter, r *http.Request,
 		return nil, wrapServiceError(CodeInvalidRequest, "read binary vector search request body failed", err)
 	}
 	return raw, nil
+}
+
+func parseBenchmarkVectorSearchBinaryRawQuery(raw string) (BenchmarkVectorSearchRequest, error) {
+	values, err := url.ParseQuery(raw)
+	if err != nil {
+		return BenchmarkVectorSearchRequest{}, wrapServiceError(CodeInvalidRequest, "invalid binary vector search query parameters", err)
+	}
+	return parseBenchmarkVectorSearchBinaryQuery(values)
 }
 
 func parseBenchmarkVectorSearchBinaryQuery(values url.Values) (BenchmarkVectorSearchRequest, error) {

--- a/TreeDB/documentservice/http_vector_index_decode.go
+++ b/TreeDB/documentservice/http_vector_index_decode.go
@@ -3,14 +3,21 @@ package documentservice
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"mime"
 	"net/http"
+	"net/url"
+	"strconv"
+
+	"github.com/snissn/gomap/TreeDB/collections"
 )
 
 var benchmarkVectorSearchBase64FieldNeedle = []byte(`"query_embedding_f32_le_b64"`)
 
 const benchmarkVectorSearchDecodePeekBytes = 512
+const benchmarkVectorSearchBinaryContentType = "application/vnd.treedb.vector-search.f32le"
 
 func (h *Handler) decodeBenchmarkVectorSearchRequest(w http.ResponseWriter, r *http.Request, maxBodyBytes int64) (BenchmarkVectorSearchRequest, bool) {
 	body := http.MaxBytesReader(w, r.Body, maxBodyBytes)
@@ -47,6 +54,182 @@ func (h *Handler) decodeBenchmarkVectorSearchRequest(w http.ResponseWriter, r *h
 		return BenchmarkVectorSearchRequest{}, false
 	}
 	return req, true
+}
+
+func (h *Handler) decodeBenchmarkVectorSearchBinaryRequest(w http.ResponseWriter, r *http.Request, maxBodyBytes int64) (BenchmarkVectorSearchRequest, bool) {
+	if err := validateBenchmarkVectorSearchBinaryContentType(r.Header.Get("Content-Type")); err != nil {
+		writeError(w, err)
+		return BenchmarkVectorSearchRequest{}, false
+	}
+	req, err := parseBenchmarkVectorSearchBinaryQuery(r.URL.Query())
+	if err != nil {
+		writeError(w, err)
+		return BenchmarkVectorSearchRequest{}, false
+	}
+	raw, err := readBenchmarkVectorSearchBinaryBody(w, r, maxBodyBytes)
+	if err != nil {
+		writeError(w, err)
+		return BenchmarkVectorSearchRequest{}, false
+	}
+	if len(raw) == 0 {
+		writeError(w, serviceError(CodeInvalidRequest, "binary vector search request body must contain at least one float32"))
+		return BenchmarkVectorSearchRequest{}, false
+	}
+	query, err := decodeBenchmarkVectorQueryEmbeddingF32LERawWithLabel(raw, "binary vector search request body")
+	if err != nil {
+		writeError(w, err)
+		return BenchmarkVectorSearchRequest{}, false
+	}
+	req.QueryEmbedding = query
+	return req, true
+}
+
+func validateBenchmarkVectorSearchBinaryContentType(header string) error {
+	mediaType, params, err := mime.ParseMediaType(header)
+	if err != nil || mediaType != benchmarkVectorSearchBinaryContentType || len(params) != 0 {
+		return serviceErrorf(CodeInvalidRequest, "Content-Type must be %s", benchmarkVectorSearchBinaryContentType)
+	}
+	return nil
+}
+
+func readBenchmarkVectorSearchBinaryBody(w http.ResponseWriter, r *http.Request, maxBodyBytes int64) ([]byte, error) {
+	if maxBodyBytes <= 0 {
+		maxBodyBytes = defaultMaxRequestBytes
+	}
+	if r.ContentLength > maxBodyBytes {
+		return nil, serviceErrorf(CodeInvalidRequest, "binary vector search request body exceeds %d bytes", maxBodyBytes)
+	}
+	if r.ContentLength >= 0 && r.ContentLength%4 != 0 {
+		return nil, serviceErrorf(CodeInvalidRequest, "binary vector search request body byte length %d is not a multiple of 4", r.ContentLength)
+	}
+	body := http.MaxBytesReader(w, r.Body, maxBodyBytes)
+	defer func() { _ = body.Close() }()
+	if r.ContentLength >= 0 {
+		raw := make([]byte, int(r.ContentLength))
+		if len(raw) == 0 {
+			return raw, nil
+		}
+		if _, err := io.ReadFull(body, raw); err != nil {
+			var maxErr *http.MaxBytesError
+			if errors.As(err, &maxErr) {
+				return nil, serviceErrorf(CodeInvalidRequest, "binary vector search request body exceeds %d bytes", maxBodyBytes)
+			}
+			return nil, wrapServiceError(CodeInvalidRequest, "read binary vector search request body failed", err)
+		}
+		return raw, nil
+	}
+	raw, err := io.ReadAll(body)
+	if err != nil {
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
+			return nil, serviceErrorf(CodeInvalidRequest, "binary vector search request body exceeds %d bytes", maxBodyBytes)
+		}
+		return nil, wrapServiceError(CodeInvalidRequest, "read binary vector search request body failed", err)
+	}
+	return raw, nil
+}
+
+func parseBenchmarkVectorSearchBinaryQuery(values url.Values) (BenchmarkVectorSearchRequest, error) {
+	var req BenchmarkVectorSearchRequest
+	for key := range values {
+		switch key {
+		case "top_k", "ef_search", "query_mode", "vector_index_name", "expected_generation", "stats_mode":
+		default:
+			return req, serviceErrorf(CodeInvalidRequest, "unsupported binary vector search query parameter %q", key)
+		}
+	}
+	topK, ok, err := parseRequiredBenchmarkVectorSearchIntParam(values, "top_k")
+	if err != nil {
+		return req, err
+	}
+	if !ok {
+		return req, serviceError(CodeInvalidRequest, "top_k query parameter is required")
+	}
+	if topK <= 0 {
+		return req, serviceError(CodeInvalidRequest, "top_k must be positive")
+	}
+	req.TopK = topK
+	if efSearch, ok, err := parseRequiredBenchmarkVectorSearchIntParam(values, "ef_search"); err != nil {
+		return req, err
+	} else if ok {
+		if efSearch < 0 {
+			return req, serviceError(CodeInvalidRequest, "ef_search must be non-negative")
+		}
+		req.EfSearch = efSearch
+	}
+	queryMode, ok, err := singleBenchmarkVectorSearchQueryValue(values, "query_mode")
+	if err != nil {
+		return req, err
+	}
+	if ok {
+		if queryMode != string(BenchmarkVectorQueryModeExact) {
+			return req, serviceErrorf(CodeInvalidRequest, "binary vector search supports query_mode=%q only", BenchmarkVectorQueryModeExact)
+		}
+	}
+	req.QueryMode = BenchmarkVectorQueryModeExact
+	vectorIndexName, ok, err := singleBenchmarkVectorSearchQueryValue(values, "vector_index_name")
+	if err != nil {
+		return req, err
+	}
+	if ok {
+		req.VectorIndexName = vectorIndexName
+	}
+	expectedGeneration, ok, err := parseBenchmarkVectorSearchUint64Param(values, "expected_generation")
+	if err != nil {
+		return req, err
+	}
+	if ok {
+		if expectedGeneration == 0 {
+			return req, serviceError(CodeInvalidRequest, "expected_generation must be positive")
+		}
+		req.ExpectedGeneration = expectedGeneration
+	}
+	statsMode, ok, err := singleBenchmarkVectorSearchQueryValue(values, "stats_mode")
+	if err != nil {
+		return req, err
+	}
+	if ok {
+		req.StatsMode = collections.VectorIndexSearchStatsMode(statsMode)
+	}
+	return req, nil
+}
+
+func parseRequiredBenchmarkVectorSearchIntParam(values url.Values, name string) (int, bool, error) {
+	value, ok, err := singleBenchmarkVectorSearchQueryValue(values, name)
+	if err != nil || !ok {
+		return 0, ok, err
+	}
+	parsed, err := strconv.Atoi(value)
+	if err != nil {
+		return 0, true, wrapServiceError(CodeInvalidRequest, "invalid "+name+" query parameter", err)
+	}
+	return parsed, true, nil
+}
+
+func parseBenchmarkVectorSearchUint64Param(values url.Values, name string) (uint64, bool, error) {
+	value, ok, err := singleBenchmarkVectorSearchQueryValue(values, name)
+	if err != nil || !ok {
+		return 0, ok, err
+	}
+	parsed, err := strconv.ParseUint(value, 10, 64)
+	if err != nil {
+		return 0, true, wrapServiceError(CodeInvalidRequest, "invalid "+name+" query parameter", err)
+	}
+	return parsed, true, nil
+}
+
+func singleBenchmarkVectorSearchQueryValue(values url.Values, name string) (string, bool, error) {
+	items, ok := values[name]
+	if !ok {
+		return "", false, nil
+	}
+	if len(items) != 1 {
+		return "", true, serviceErrorf(CodeInvalidRequest, "%s query parameter must be supplied exactly once", name)
+	}
+	if items[0] == "" {
+		return "", true, serviceErrorf(CodeInvalidRequest, "%s query parameter must be non-empty", name)
+	}
+	return items[0], true, nil
 }
 
 func decodeBenchmarkVectorSearchJSON(raw []byte) (BenchmarkVectorSearchRequest, error) {

--- a/TreeDB/documentservice/service.go
+++ b/TreeDB/documentservice/service.go
@@ -1370,8 +1370,12 @@ func decodeBenchmarkVectorQueryEmbeddingF32LEBase64Bytes(encoded []byte) ([]floa
 }
 
 func decodeBenchmarkVectorQueryEmbeddingF32LERaw(raw []byte) ([]float32, error) {
+	return decodeBenchmarkVectorQueryEmbeddingF32LERawWithLabel(raw, "query_embedding_f32_le_b64 decoded")
+}
+
+func decodeBenchmarkVectorQueryEmbeddingF32LERawWithLabel(raw []byte, label string) ([]float32, error) {
 	if len(raw)%4 != 0 {
-		return nil, serviceErrorf(CodeInvalidRequest, "query_embedding_f32_le_b64 decoded byte length %d is not a multiple of 4", len(raw))
+		return nil, serviceErrorf(CodeInvalidRequest, "%s byte length %d is not a multiple of 4", label, len(raw))
 	}
 	query := make([]float32, len(raw)/4)
 	for i := range query {

--- a/clients/python/treedb_client/README.md
+++ b/clients/python/treedb_client/README.md
@@ -159,14 +159,25 @@ bench = client.search_vector_index(
     "bench_run_001",
     query_embedding=[0.1, 0.2, 0.3],
     top_k=1,
-    # Optional high-QPS request encoding: "f32_le_b64" sends the query as
-    # base64 little-endian float32 bytes instead of a JSON float array.
+    # Optional high-QPS JSON-compatible encoding: "f32_le_b64" sends the query
+    # as base64 little-endian float32 bytes instead of a JSON float array.
     query_embedding_encoding="f32_le_b64",
     query_mode="quantized_rerank",
     quantized_index_name="embedding.scalar_u8.fast",
     quantized_rerank_candidates=32,
 )
 print(bench.results[0].id, bench.no_documents, bench.diagnostics.get("route"))
+
+# Best-case single-query HTTP request lane: raw little-endian float32 bytes to
+# /search/vector-index:binary. This is exact-only and separate from batch APIs.
+bench_binary = client.search_vector_index(
+    "bench_run_001",
+    query_embedding=[0.1, 0.2, 0.3],
+    top_k=1,
+    query_embedding_encoding="f32_le",
+    query_mode="exact",
+)
+print(bench_binary.results[0].id, bench_binary.no_documents, bench_binary.diagnostics.get("route"))
 
 keyword = client.search_keyword(
     "docs",

--- a/clients/python/treedb_client/src/treedb_client/client.py
+++ b/clients/python/treedb_client/src/treedb_client/client.py
@@ -563,14 +563,26 @@ def _binary_vector_index_query_params(
     if quantized_index_name is not None or quantized_rerank_candidates is not None:
         raise InvalidRequestError("invalid_request", "f32_le binary vector-index search does not support quantized options")
     _validate_expected_generation(expected_generation)
-    params = [("top_k", str(int(top_k))), ("query_mode", "exact")]
+    top_k_value = _validate_binary_int_query_param(top_k, "top_k", minimum=1)
+    params = [("top_k", str(top_k_value)), ("query_mode", "exact")]
     if ef_search is not None:
-        params.append(("ef_search", str(int(ef_search))))
+        ef_search_value = _validate_binary_int_query_param(ef_search, "ef_search", minimum=0)
+        params.append(("ef_search", str(ef_search_value)))
     _add_binary_optional_non_empty_string(params, "vector_index_name", vector_index_name, "vector_index_name")
     _add_binary_optional_non_empty_string(params, "stats_mode", stats_mode, "stats_mode")
     if expected_generation is not None:
         params.append(("expected_generation", str(expected_generation)))
     return params
+
+
+def _validate_binary_int_query_param(value: Any, label: str, *, minimum: int) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise InvalidRequestError("invalid_request", f"{label} must be an integer")
+    if value < minimum:
+        if minimum == 1:
+            raise InvalidRequestError("invalid_request", f"{label} must be a positive integer")
+        raise InvalidRequestError("invalid_request", f"{label} must be a non-negative integer")
+    return value
 
 
 def _add_binary_optional_non_empty_string(params: list[tuple[str, str]], key: str, value: Optional[str], label: str) -> None:

--- a/clients/python/treedb_client/src/treedb_client/client.py
+++ b/clients/python/treedb_client/src/treedb_client/client.py
@@ -43,6 +43,7 @@ from .models import (
 
 DocumentLike = Union[Document, Mapping[str, Any]]
 VectorIndexOptionsLike = Union[BenchmarkVectorIndexOptions, Mapping[str, Any]]
+BINARY_VECTOR_SEARCH_F32LE_CONTENT_TYPE = "application/vnd.treedb.vector-search.f32le"
 _ResponseT = TypeVar("_ResponseT")
 
 
@@ -277,6 +278,27 @@ class TreeDBClient:
         emulated by client-side or service-side exact fallback.
         """
 
+        if query_embedding_encoding == "f32_le":
+            query = _encode_f32_le_bytes(query_embedding)
+            params = _binary_vector_index_query_params(
+                top_k=top_k,
+                vector_index_name=vector_index_name,
+                ef_search=ef_search,
+                query_mode=query_mode,
+                quantized_index_name=quantized_index_name,
+                quantized_rerank_candidates=quantized_rerank_candidates,
+                stats_mode=stats_mode,
+                expected_generation=expected_generation,
+            )
+            payload = self._request_bytes(
+                "POST",
+                self._index_path(index, "search") + "/vector-index:binary",
+                query,
+                BINARY_VECTOR_SEARCH_F32LE_CONTENT_TYPE,
+                query_params=params,
+            )
+            return _parse_response("benchmark vector search response", BenchmarkVectorSearchResponse.from_dict, payload)
+
         request: dict[str, Any] = {"top_k": top_k}
         _add_query_embedding(request, query_embedding, query_embedding_encoding)
         _add_expected_generation(request, expected_generation)
@@ -376,7 +398,6 @@ class TreeDBClient:
         return f"/v1/indexes/{encoded}"
 
     def _request(self, method: str, path: str, body: Optional[Mapping[str, Any]] = None) -> Any:
-        url = self.base_url + path
         data: Optional[bytes] = None
         headers = {"Accept": "application/json"}
         if body is not None:
@@ -385,7 +406,25 @@ class TreeDBClient:
             except (TypeError, ValueError) as exc:
                 raise InvalidRequestError("invalid_request", f"request payload is not JSON-serializable: {exc}") from exc
             headers["Content-Type"] = "application/json"
-        request = urllib.request.Request(url, data=data, headers=headers, method=method)
+        return self._send_request(method, path, data, headers)
+
+    def _request_bytes(
+        self,
+        method: str,
+        path: str,
+        body: bytes,
+        content_type: str,
+        *,
+        query_params: Optional[Sequence[tuple[str, str]]] = None,
+    ) -> Any:
+        if query_params:
+            path = path + "?" + urllib.parse.urlencode(query_params)
+        headers = {"Accept": "application/json", "Content-Type": content_type}
+        return self._send_request(method, path, body, headers)
+
+    def _send_request(self, method: str, path: str, data: Optional[bytes], headers: Mapping[str, str]) -> Any:
+        url = self.base_url + path
+        request = urllib.request.Request(url, data=data, headers=dict(headers), method=method)
         try:
             with self._opener.open(request, timeout=self.timeout) as response:
                 response_body = response.read()
@@ -487,7 +526,7 @@ def _add_query_embedding(request: dict[str, Any], query_embedding: Sequence[floa
     if encoding == "f32_le_b64":
         request["query_embedding_f32_le_b64"] = _encode_f32_le_base64(query_embedding)
         return
-    raise InvalidRequestError("invalid_request", "query_embedding_encoding must be 'json' or 'f32_le_b64'")
+    raise InvalidRequestError("invalid_request", "query_embedding_encoding must be 'json', 'f32_le_b64', or 'f32_le'")
 
 
 def _coerce_query_embedding_floats(values: Sequence[float]) -> list[float]:
@@ -500,9 +539,46 @@ def _coerce_query_embedding_floats(values: Sequence[float]) -> list[float]:
 
 
 def _encode_f32_le_base64(values: Sequence[float]) -> str:
+    return base64.b64encode(_encode_f32_le_bytes(values)).decode("ascii")
+
+
+def _encode_f32_le_bytes(values: Sequence[float]) -> bytes:
     floats = _coerce_query_embedding_floats(values)
-    payload = struct.pack(f"<{len(floats)}f", *floats) if floats else b""
-    return base64.b64encode(payload).decode("ascii")
+    return struct.pack(f"<{len(floats)}f", *floats) if floats else b""
+
+
+def _binary_vector_index_query_params(
+    *,
+    top_k: int,
+    vector_index_name: Optional[str],
+    ef_search: Optional[int],
+    query_mode: Optional[str],
+    quantized_index_name: Optional[str],
+    quantized_rerank_candidates: Optional[int],
+    stats_mode: Optional[str],
+    expected_generation: Optional[int],
+) -> list[tuple[str, str]]:
+    if query_mode is not None and query_mode != "exact":
+        raise InvalidRequestError("invalid_request", "f32_le binary vector-index search supports query_mode='exact' only")
+    if quantized_index_name is not None or quantized_rerank_candidates is not None:
+        raise InvalidRequestError("invalid_request", "f32_le binary vector-index search does not support quantized options")
+    _validate_expected_generation(expected_generation)
+    params = [("top_k", str(int(top_k))), ("query_mode", "exact")]
+    if ef_search is not None:
+        params.append(("ef_search", str(int(ef_search))))
+    _add_binary_optional_non_empty_string(params, "vector_index_name", vector_index_name, "vector_index_name")
+    _add_binary_optional_non_empty_string(params, "stats_mode", stats_mode, "stats_mode")
+    if expected_generation is not None:
+        params.append(("expected_generation", str(expected_generation)))
+    return params
+
+
+def _add_binary_optional_non_empty_string(params: list[tuple[str, str]], key: str, value: Optional[str], label: str) -> None:
+    if value is None:
+        return
+    if not isinstance(value, str) or value.strip() == "":
+        raise InvalidRequestError("invalid_request", f"{label} must be a non-empty string when provided")
+    params.append((key, value))
 
 
 def _add_filter(request: dict[str, Any], filter_value: Optional[FilterLike]) -> None:

--- a/clients/python/treedb_client/tests/test_client.py
+++ b/clients/python/treedb_client/tests/test_client.py
@@ -347,6 +347,14 @@ class TreeDBClientTests(unittest.TestCase):
             client.search_vector_index("docs", [1, 0], 1, query_embedding_encoding="f32_le", query_mode="quantized_rerank")
         with self.assertRaisesRegex(InvalidRequestError, "quantized"):
             client.search_vector_index("docs", [1, 0], 1, query_embedding_encoding="f32_le", quantized_index_name="embedding.scalar_u8.fast")
+        for bad_top_k in (True, 1.9, 0):
+            with self.subTest(bad_top_k=bad_top_k):
+                with self.assertRaisesRegex(InvalidRequestError, "top_k"):
+                    client.search_vector_index("docs", [1, 0], bad_top_k, query_embedding_encoding="f32_le")
+        for bad_ef_search in (True, 1.9, -1):
+            with self.subTest(bad_ef_search=bad_ef_search):
+                with self.assertRaisesRegex(InvalidRequestError, "ef_search"):
+                    client.search_vector_index("docs", [1, 0], 1, query_embedding_encoding="f32_le", ef_search=bad_ef_search)
         with self.assertRaisesRegex(InvalidRequestError, "query_embedding"):
             client.search_vector_index("docs", ["not-a-number"], 1, query_embedding_encoding="f32_le_b64")
         with self.assertRaisesRegex(InvalidRequestError, "query_embedding"):

--- a/clients/python/treedb_client/tests/test_client.py
+++ b/clients/python/treedb_client/tests/test_client.py
@@ -224,6 +224,7 @@ class TreeDBClientTests(unittest.TestCase):
         reset_route = "/v1/indexes/bench/reset"
         optimize_route = "/v1/indexes/bench/optimize"
         search_route = "/v1/indexes/bench/search/vector-index"
+        raw_search_route = "/v1/indexes/bench/search/vector-index:binary?top_k=1&query_mode=exact"
         routes = {
             ("POST", reset_route): (
                 200,
@@ -252,6 +253,20 @@ class TreeDBClientTests(unittest.TestCase):
                     "no_documents": True,
                     "stats": {"documents_fetched": 0, "quantized_rerank_exact_score_calls": 32},
                     "diagnostics": {"route": "quantized_rerank"},
+                },
+                0,
+            ),
+            ("POST", raw_search_route): (
+                200,
+                {
+                    "index": SAMPLE_INDEX,
+                    "results": [{"id": "doc-1", "ordinal": 1, "score": 0.98}],
+                    "metric": "cosine",
+                    "vector_index_name": "embedding",
+                    "query_mode": "exact",
+                    "no_documents": True,
+                    "stats": {"documents_fetched": 0},
+                    "diagnostics": {"route": "exact_hnsw_search_pack_v1"},
                 },
                 0,
             ),
@@ -289,10 +304,18 @@ class TreeDBClientTests(unittest.TestCase):
                 1,
                 query_embedding_encoding="f32_le_b64",
             )
+            raw_search = client.search_vector_index(
+                "bench",
+                [1, 0],
+                1,
+                query_embedding_encoding="f32_le",
+            )
 
             self.assertEqual(search.query_mode, "quantized_rerank")
             self.assertEqual(search.results[0].id, "doc-1")
             self.assertEqual(b64_search.results[0].id, "doc-1")
+            self.assertEqual(raw_search.query_mode, "exact")
+            self.assertEqual(raw_search.results[0].id, "doc-1")
             reset_body = json_body(server.records[0])
             self.assertNotIn("metric", reset_body)
             self.assertEqual(reset_body["vector_index_options"]["strategy"], "column_graph")
@@ -302,6 +325,10 @@ class TreeDBClientTests(unittest.TestCase):
             b64_body = json_body(server.records[3])
             self.assertNotIn("query_embedding", b64_body)
             self.assertEqual(struct.unpack("<2f", base64.b64decode(b64_body["query_embedding_f32_le_b64"])), (1.0, 0.0))
+            raw_record = server.records[4]
+            self.assertEqual(raw_record["path"], raw_search_route)
+            self.assertEqual(raw_record["headers"]["Content-Type"], "application/vnd.treedb.vector-search.f32le")
+            self.assertEqual(struct.unpack("<2f", raw_record["body"]), (1.0, 0.0))
 
     def test_empty_optional_benchmark_fields_fail_closed_locally(self) -> None:
         client = TreeDBClient("http://127.0.0.1:1", timeout=1)
@@ -316,6 +343,10 @@ class TreeDBClientTests(unittest.TestCase):
             client.search_vector_index("docs", [1, 0], 1, stats_mode="")
         with self.assertRaisesRegex(InvalidRequestError, "query_embedding_encoding"):
             client.search_vector_index("docs", [1, 0], 1, query_embedding_encoding="binary")
+        with self.assertRaisesRegex(InvalidRequestError, "query_mode='exact'"):
+            client.search_vector_index("docs", [1, 0], 1, query_embedding_encoding="f32_le", query_mode="quantized_rerank")
+        with self.assertRaisesRegex(InvalidRequestError, "quantized"):
+            client.search_vector_index("docs", [1, 0], 1, query_embedding_encoding="f32_le", quantized_index_name="embedding.scalar_u8.fast")
         with self.assertRaisesRegex(InvalidRequestError, "query_embedding"):
             client.search_vector_index("docs", ["not-a-number"], 1, query_embedding_encoding="f32_le_b64")
         with self.assertRaisesRegex(InvalidRequestError, "query_embedding"):

--- a/docs/TREEDB_DOCUMENT_SERVICE_API.md
+++ b/docs/TREEDB_DOCUMENT_SERVICE_API.md
@@ -395,7 +395,25 @@ exactly one of `query_embedding` or `query_embedding_f32_le_b64`:
 }
 ```
 
-Supported `query_mode` values are `exact`, `quantized_only`, and
+For best-case single-query HTTP request measurements, the binary endpoint
+accepts raw little-endian float32 query bytes and returns the same response shape
+as `/search/vector-index`:
+
+```http
+POST /v1/indexes/{index}/search/vector-index:binary?top_k=10&ef_search=128&query_mode=exact
+Content-Type: application/vnd.treedb.vector-search.f32le
+```
+
+Only the raw query vector is carried in the binary body. Supported query
+parameters are `top_k` (required), `ef_search`, `query_mode` (`exact` only for
+this endpoint), `vector_index_name`, `expected_generation`, and `stats_mode`.
+Unsupported or invalid query parameters fail closed. The endpoint rejects the
+wrong content type, bodies larger than the service body cap, byte lengths that
+are not a multiple of four, empty bodies, and dimension mismatches before search.
+It is a single-query HTTP lane, not a batch API, and it does not change the
+dense `/search/vector` route.
+
+Supported JSON `query_mode` values are `exact`, `quantized_only`, and
 `quantized_rerank`. Quantized modes require a declared quantized index name and
 fail closed when assets are missing, invalid, stale, or unavailable. Responses
 include result IDs/scores plus TreeDB stats/diagnostics so benchmark adapters can


### PR DESCRIPTION
## Objective

Land the single-query raw binary f32LE TreeDB vector-index HTTP endpoint for #2671, on top of the merged #2670 JSON/f32_b64 contract.

Closes #2671. Parent tracker: #2669.

## Context

This adds the best-case request lane:

```http
POST /v1/indexes/{index}/search/vector-index:binary?top_k=10&ef_search=128&query_mode=exact
Content-Type: application/vnd.treedb.vector-search.f32le
Body: raw little-endian float32[] query bytes
```

The existing `/search/vector-index` JSON route remains compatible with exactly one of `query_embedding` or `query_embedding_f32_le_b64`.

## Non-goals

- No batch endpoint.
- No dense `/v1/indexes/{index}/search/vector` binary route or behavior change.
- No VectorDBBench adapter wiring in this PR; downstream #2672 / snissn/vectordbbench#6 can consume this contract.

## Design / Contract

- New route: `POST /v1/indexes/{index}/search/vector-index:binary`.
- Required content type: `application/vnd.treedb.vector-search.f32le` with no parameters.
- Body decode:
  - rejects known oversized bodies before allocation;
  - uses `http.MaxBytesReader` for unknown/chunked bodies;
  - validates known byte-length multiple-of-4 before allocation;
  - rejects empty bodies;
  - decodes little-endian float32 safely into `query_embedding` before calling the existing no-document service path.
- Query params are explicit/fail-closed:
  - supported: `top_k` (required), `ef_search`, `query_mode` (`exact` only), `vector_index_name`, `expected_generation`, `stats_mode`;
  - malformed raw query strings and unsupported/duplicate/empty params return `invalid_request`.
- Response shape is the same `BenchmarkVectorSearchResponse` as JSON `/search/vector-index`.
- Python client adds explicit `query_embedding_encoding="f32_le"` for this raw binary endpoint; existing `json` and `f32_le_b64` encodings are unchanged.

## Scope

Includes:
- `TreeDB/documentservice/http.go`
- `TreeDB/documentservice/http_vector_index_decode.go`
- `TreeDB/documentservice/service.go`
- `TreeDB/documentservice/http_test.go`
- `TreeDB/documentservice/http_vector_index_bench_test.go`
- `clients/python/treedb_client/src/treedb_client/client.py`
- `clients/python/treedb_client/tests/test_client.py`
- `clients/python/treedb_client/README.md`
- `docs/TREEDB_DOCUMENT_SERVICE_API.md`

## Correctness

Tests run on latest head `b04470528bf8908d3166177e86d616f27c2c9e66`:

- `go test ./TreeDB/documentservice -count=1`
- `go test ./cmd/treedb-document-service -count=1`
- `cd clients/python/treedb_client && uv run --with pytest pytest -q` (`38 passed, 1 skipped, 10 subtests passed`)
- `go test ./TreeDB/documentservice ./cmd/treedb-document-service -count=1`

Latest-head CI: all checks pass on `b04470528bf8908d3166177e86d616f27c2c9e66` (`gh pr checks 2675`). Initial TreeDB collections failures in `TestCollectionCompactStorageFoldsRootsAndCleansStorage` were retried by GitHub and passed; local focused rerun `go test ./TreeDB/collections -run TestCollectionCompactStorageFoldsRootsAndCleansStorage -count=10` also passed.

Covered cases include success vs JSON route, wrong content type, invalid byte length, empty body, dimension mismatch, unsupported query mode/options, malformed raw query, body cap, expected_generation/stats_mode, and exact no-document route proof.

Route proof artifact: `/tmp/treedb_http_binary_route_proof_20260612_103107/route_proof_exact_binary.json`

- `diagnostics.route=exact_hnsw_search_pack_v1`
- `diagnostics.fallback_reason=none`
- `no_documents=true`
- `stats.documents_fetched=0`
- `diagnostics.exact_hnsw_search_pack_no_doc_route=true`

Internal review: high-thinking Orca reviewer found one blocker (malformed query params via `URL.Query()`), fixed in `b04470528`; re-review PASS with `go test ./TreeDB/documentservice -run TestHTTPBenchmarkVectorSearchBinaryF32LE`.

## Performance

Hardware/context: Apple M3, darwin/arm64. Commit: `b04470528bf8908d3166177e86d616f27c2c9e66`.

Command:

```sh
go test ./TreeDB/documentservice -run '^$' -bench 'BenchmarkBenchmarkVectorSearch(Decode|HTTPHandler|HTTPPredecodedRequest|ResponseEncode)' -benchmem -benchtime=250ms -count=5
```

Artifact: `/tmp/treedb_http_binary_bench_20260612_105521_250ms.txt`

Median-of-5:

| Benchmark | ns/op | ops/sec | B/op | allocs/op |
| --- | ---: | ---: | ---: | ---: |
| JSON float-array request decode | 201,118 | 4,972.2 | 85,224 | 27 |
| optimized JSON f32_b64 request decode | 13,590 | 73,583.5 | 13,248 | 14 |
| generic JSON f32_b64 request decode | 36,706 | 27,243.5 | 51,792 | 15 |
| raw base64 component | 4,368 | 228,937.7 | 12,288 | 2 |
| raw f32LE body decode | 1,529 | 654,022.2 | 6,144 | 1 |
| predecoded service+response | 13,157 | 76,005.2 | 25,938 | 30 |
| full HTTP handler JSON f32_b64 | 35,573 | 28,111.2 | 72,480 | 71 |
| full HTTP handler raw f32LE binary | 17,954 | 55,697.9 | 44,181 | 51 |
| response encode | 4,656 | 214,776.6 | 4,481 | 2 |

Raw binary handler path is ~1.98x the JSON f32_b64 handler throughput and remains close to the predecoded service+response ceiling. A measured local bottleneck in the initial raw body read was optimized by validating known length before allocation and preallocating the exact body size instead of `io.ReadAll` growth. Latest raw-only profile artifact: `/tmp/treedb_http_binary_profile_raw_20260612_103137` (`cpu.pprof`, `mem.pprof`, `cpu_top.txt`, `mem_top.txt`).

## Rollout / Toggle Plan

No server toggle. Clients must opt in by calling the distinct `:binary` endpoint (or Python `query_embedding_encoding="f32_le"`). Compatibility JSON route remains the default.

## Follow-ups

- #2672 / snissn/vectordbbench#6: consume raw endpoint from adapters.
- #2673: end-to-end campaign rows for JSON, JSON f32_b64, and raw binary lanes.

## AI Review Loop

- Codex latest-head review: passed/no major issues on `b04470528b`.
- Copilot latest-head review: requested after `b04470528`; no findings posted.
- CodeRabbit latest-head review: prior Python param coercion finding fixed in `b04470528`; thread resolved; status pass/review completed.
- Review comments/threads resolved or explicitly dismissed: CodeRabbit thread resolved; no unresolved review threads via GraphQL.
