### PR TITLE
TreeDB scalar_u8: add default-off raw-dot prepared traversal seam

### DIFF
--- a/TreeDB/collections/column_hnsw_prepared_quantized_search.go
+++ b/TreeDB/collections/column_hnsw_prepared_quantized_search.go
@@ -4,6 +4,12 @@ import "fmt"
 
 var errColumnHNSWPreparedQuantizedTraversalUnavailable = fmt.Errorf("%w: scalar_u8 hnsw prepared quantized traversal unavailable", ErrVectorIndexSearchUnavailable)
 
+// columnHNSWPreparedScalarU8RawDotTraversalEnabled gates the scalar_u8 raw-dot
+// prepared traversal seam. The seam is kept off by default until the remaining
+// adapter-overhead follow-ups can make the raw-dot path performance-neutral or
+// better across qonly/rerank production rows.
+const columnHNSWPreparedScalarU8RawDotTraversalEnabled = false
+
 type columnHNSWPreparedScalarU8ScorePlane struct {
 	scorer columnVectorGraphScalarU8QuantizedScorer
 	ready  bool
@@ -46,11 +52,32 @@ func (p *columnHNSWPreparedScalarU8ScorePlane) scoreRowIDsPrevalidated(rowIDs []
 	return p.scorer.scoreRowIDsPrevalidated(rowIDs, dst, scratch, stats)
 }
 
+func (p *columnHNSWPreparedScalarU8ScorePlane) scoreRawDotOrdinal(ordinal int, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) (int64, error) {
+	if p == nil || !p.ready {
+		return 0, errColumnHNSWPreparedTraversalScorePlaneUnavailable
+	}
+	return p.scorer.scoreRawDotOrdinal(ordinal, scratch, stats)
+}
+
+func (p *columnHNSWPreparedScalarU8ScorePlane) scoreRawDotRowIDsPrevalidated(rowIDs []uint32, dst []int64, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) ([]int64, error) {
+	if p == nil || !p.ready {
+		return dst[:0], errColumnHNSWPreparedTraversalScorePlaneUnavailable
+	}
+	return p.scorer.scoreRawDotRowIDsPrevalidated(rowIDs, dst, scratch, stats)
+}
+
 func (p *columnHNSWPreparedScalarU8ScorePlane) scoreAndPushFrontierVisitedRowIDsPrevalidated(rowIDs []uint32, topK int, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) (int, error) {
 	if p == nil || !p.ready {
 		return 0, errColumnHNSWPreparedTraversalScorePlaneUnavailable
 	}
 	return p.scorer.scoreAndPushFrontierVisitedRowIDsPrevalidated(rowIDs, topK, scratch, stats)
+}
+
+func (p *columnHNSWPreparedScalarU8ScorePlane) scoreAndPushRawDotFrontierVisitedRowIDsPrevalidated(rowIDs []uint32, topK int, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) (int, error) {
+	if p == nil || !p.ready {
+		return 0, errColumnHNSWPreparedTraversalScorePlaneUnavailable
+	}
+	return p.scorer.scoreAndPushRawDotFrontierVisitedRowIDsPrevalidated(rowIDs, topK, scratch, stats)
 }
 
 func collectionScalarU8PreparedTraversalPackForReader(reader *columnVectorGraphPhysicalRowReader, queryMode columnVectorGraphNativeSearchQueryMode, statsMode columnVectorGraphNativeSearchStatsMode, quantizedIndexName string) (*columnHNSWSearchPackPreparedView, bool) {
@@ -192,7 +219,13 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosineScalarU8PreparedTravers
 		OmitResultMaterialization:            opts.OmitResultMaterialization || queryMode == columnVectorGraphNativeSearchQueryModeQuantizedRerank,
 		SuppressOmittedResultMaterialization: queryMode == columnVectorGraphNativeSearchQueryModeQuantizedRerank,
 	}
-	results, stats, err := pack.searchCosinePreparedScorePlane(query, packOpts, scratch, &scratch.preparedScalarU8Plane)
+	var results []columnVectorGraphNativeSearchResult
+	var stats columnVectorGraphNativeSearchStats
+	if columnHNSWPreparedScalarU8RawDotTraversalEnabled {
+		results, stats, err = pack.searchCosinePreparedRawDotTraversal(query, packOpts, scratch, &scratch.preparedScalarU8Plane)
+	} else {
+		results, stats, err = pack.searchCosinePreparedScorePlane(query, packOpts, scratch, &scratch.preparedScalarU8Plane)
+	}
 	columnVectorGraphApplyQuantizedPreparedTraversalSetupStats(&stats, setupStats)
 	r.populateScalarU8PreparedTraversalSearchStats(&stats)
 	if err != nil {

--- a/TreeDB/collections/column_hnsw_prepared_raw_dot_test.go
+++ b/TreeDB/collections/column_hnsw_prepared_raw_dot_test.go
@@ -1,0 +1,231 @@
+package collections
+
+import (
+	"bytes"
+	"math"
+	"testing"
+)
+
+func TestScalarU8RawDotCandidateOrderingMatchesFloatScores2658(t *testing.T) {
+	candidates := []columnVectorGraphRawDotSearchCandidate{
+		{ordinal: 6, dot: 9},
+		{ordinal: 4, dot: 21},
+		{ordinal: 2, dot: 21},
+		{ordinal: 7, dot: -3},
+		{ordinal: 1, dot: 65025},
+		{ordinal: 3, dot: 65024},
+		{ordinal: 0, dot: 21},
+		{ordinal: 5, dot: 9},
+	}
+	const limit = 5
+	var rawTop, floatTop columnVectorGraphNativeSearchScratch
+	rawTop.prepareRawDotCandidateQueues(len(candidates), 1, limit, limit)
+	for _, raw := range candidates {
+		floatCandidate := columnVectorGraphSearchCandidate{ordinal: raw.ordinal, score: scalarU8QuantizedCosineScoreFromDot(raw.dot)}
+		rawInserted := rawTop.insertRawDotTop(limit, raw)
+		floatInserted := floatTop.insertTop(limit, floatCandidate)
+		if rawInserted != floatInserted {
+			t.Fatalf("insert raw=%+v inserted=%v floatInserted=%v", raw, rawInserted, floatInserted)
+		}
+	}
+	for _, raw := range candidates {
+		floatCandidate := columnVectorGraphSearchCandidate{ordinal: raw.ordinal, score: scalarU8QuantizedCosineScoreFromDot(raw.dot)}
+		got := columnVectorGraphLayer0RawDotSearchShouldStop(raw, rawTop.rawDot.top, limit)
+		want := columnVectorGraphLayer0SearchShouldStop(floatCandidate, floatTop.top, limit)
+		if got != want {
+			t.Fatalf("stop raw=%+v got=%v want float=%v", raw, got, want)
+		}
+	}
+	rawTop.promoteRawDotTopToFloat(limit)
+	if len(rawTop.top) != len(floatTop.top) {
+		t.Fatalf("raw top=%d float top=%d", len(rawTop.top), len(floatTop.top))
+	}
+	for i := range floatTop.top {
+		got := rawTop.top[i]
+		want := floatTop.top[i]
+		if got.ordinal != want.ordinal || got.score != want.score {
+			t.Fatalf("top[%d] raw-promoted=%+v want float=%+v", i, got, want)
+		}
+	}
+
+	var rawHeap, floatHeap columnVectorGraphNativeSearchScratch
+	rawHeap.prepareRawDotCandidateQueues(len(candidates), 1, limit, limit)
+	for _, raw := range candidates {
+		rawHeap.pushRawDotFrontier(raw)
+		floatHeap.pushFrontier(columnVectorGraphSearchCandidate{ordinal: raw.ordinal, score: scalarU8QuantizedCosineScoreFromDot(raw.dot)})
+	}
+	for i := 0; ; i++ {
+		raw, rawOK := rawHeap.popRawDotFrontier()
+		floatCandidate, floatOK := floatHeap.popFrontier()
+		if rawOK != floatOK {
+			t.Fatalf("pop %d rawOK=%v floatOK=%v", i, rawOK, floatOK)
+		}
+		if !rawOK {
+			break
+		}
+		if raw.ordinal != floatCandidate.ordinal || scalarU8QuantizedCosineScoreFromDot(raw.dot) != floatCandidate.score {
+			t.Fatalf("pop[%d] raw=%+v float=%+v", i, raw, floatCandidate)
+		}
+	}
+}
+
+func TestScalarU8PreparedTraversalRawDotQuantizedOnlyParity2658(t *testing.T) {
+	rows := []columnGraphRebuildInputRowV2A{
+		{id: "doc-a", vector: []float32{1, 0, 0}},
+		{id: "doc-b", vector: []float32{1000, 1, 0}}, // quantizes to the same scalar_u8 codes as doc-a for the query below.
+		{id: "doc-c", vector: []float32{0.8, 0.6, 0}},
+		{id: "doc-d", vector: []float32{4, 3, 0}}, // quantized tie with doc-c.
+		{id: "doc-e", vector: []float32{0, 1, 0}},
+		{id: "doc-f", vector: []float32{0, 0, 1}}, // quantized tie with doc-e; top-k boundary keeps lower ordinal.
+	}
+	_, d, col, def := openColumnGraphQuantizedGuardrailTestCollection1926(t, rows)
+	defer func() { _ = d.Close() }()
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		t.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	packSearcher, err := col.OpenVectorIndexSearcher(VectorIndexSearcherOptions{IndexName: def.Name, MaxDecodedBlocks: 1})
+	if err != nil {
+		t.Fatalf("OpenVectorIndexSearcher pack: %v", err)
+	}
+	defer func() { _ = packSearcher.Close() }()
+	fallbackSearcher, err := col.OpenVectorIndexSearcher(VectorIndexSearcherOptions{IndexName: def.Name, MaxDecodedBlocks: 1})
+	if err != nil {
+		t.Fatalf("OpenVectorIndexSearcher fallback: %v", err)
+	}
+	defer func() { _ = fallbackSearcher.Close() }()
+	if packSearcher.reader == nil || packSearcher.reader.hnswSearchPack == nil || packSearcher.reader.adjacencyLayerSources == nil {
+		t.Fatalf("pack searcher missing prepared pack or adjacency state")
+	}
+	packStatus := packSearcher.reader.hnswSearchPack.fastStatus(packSearcher.reader.hnswSearchPackStatus)
+	if packStatus != columnHNSWSearchPackPreparedStatusDirect && packStatus != columnHNSWSearchPackPreparedStatusHeap {
+		t.Fatalf("pack status=%s", packStatus)
+	}
+	packSearcher.reader.preparedSearch = nil
+	fallbackSearcher.reader.hnswSearchPack = nil
+
+	query := []float32{1, 0, 0}
+	topK := 5
+	opts := VectorIndexSearcherSearchOptions{
+		Query:              query,
+		QueryMode:          VectorIndexQueryModeQuantizedOnly,
+		QuantizedIndexName: def.QuantizedIndexes[0].Name,
+		TopK:               topK,
+		EfSearch:           len(rows),
+		StatsMode:          VectorIndexSearchStatsModeProduction,
+	}
+	var packBuffer, fallbackBuffer VectorIndexSearchBuffer
+	packResults, err := packSearcher.SearchWithBuffer(opts, &packBuffer)
+	if err != nil {
+		t.Fatalf("pack raw-dot SearchWithBuffer: %v", err)
+	}
+	fallbackResults, err := fallbackSearcher.SearchWithBuffer(opts, &fallbackBuffer)
+	if err != nil {
+		t.Fatalf("fallback float SearchWithBuffer: %v", err)
+	}
+	fixtureTop := scalarU8QuantizedTopKForTest1926(t, rows, query, topK)
+	if len(fixtureTop) < 2 || fixtureTop[0].Score != fixtureTop[1].Score || !bytes.Equal(fixtureTop[0].ID, []byte("doc-a")) || !bytes.Equal(fixtureTop[1].ID, []byte("doc-b")) {
+		t.Fatalf("test fixture top tie got=%+v want doc-a/doc-b equal-score tie", fixtureTop)
+	}
+	if len(packResults.Results) != len(fallbackResults.Results) {
+		t.Fatalf("pack results=%d fallback results=%d", len(packResults.Results), len(fallbackResults.Results))
+	}
+	assertQuantizedOnlyGuardrailStats2416(t, packResults.Stats, def.Dimensions)
+	assertScalarU8PreparedTraversalPackAdjacencyStats2586(t, packResults.Stats, packStatus, "raw-dot quantized_only")
+	if packResults.Stats.Candidates != fallbackResults.Stats.Candidates || packResults.Stats.VisitedEdges != fallbackResults.Stats.VisitedEdges || packResults.Stats.QuantizedScoreCalls != fallbackResults.Stats.QuantizedScoreCalls {
+		t.Fatalf("pack stats=%+v fallback stats=%+v want same quantized traversal counters", packResults.Stats, fallbackResults.Stats)
+	}
+	for i := range packResults.Results {
+		got := packResults.Results[i]
+		wantResult := fallbackResults.Results[i]
+		if got.Ordinal != wantResult.Ordinal || !bytes.Equal(got.ID, wantResult.ID) || math.Abs(got.Score-wantResult.Score) > 0 {
+			t.Fatalf("quantized_only result[%d] pack=%+v fallback=%+v", i, got, wantResult)
+		}
+	}
+	rawOnlyResults := searchScalarU8PreparedRawDotResultsForTest2658(t, packSearcher.reader, query, columnVectorGraphNativeSearchQueryModeQuantizedOnly, def.QuantizedIndexes[0].Name, topK, len(rows), 0)
+	assertScalarU8PreparedRawDotNativeResultsMatchPublic2658(t, rawOnlyResults, fallbackResults.Results, 0, "quantized_only raw-dot direct")
+
+	rerankOpts := opts
+	rerankOpts.QueryMode = VectorIndexQueryModeQuantizedRerank
+	rerankOpts.TopK = 3
+	rerankOpts.QuantizedRerankCandidates = 4
+	packRerank, err := packSearcher.SearchWithBuffer(rerankOpts, &packBuffer)
+	if err != nil {
+		t.Fatalf("pack raw-dot quantized_rerank SearchWithBuffer: %v", err)
+	}
+	fallbackRerank, err := fallbackSearcher.SearchWithBuffer(rerankOpts, &fallbackBuffer)
+	if err != nil {
+		t.Fatalf("fallback quantized_rerank SearchWithBuffer: %v", err)
+	}
+	assertScalarU8PackNativeQuantizedRerankNoDocumentGuardrailStats2657(t, packRerank.Stats, rerankOpts.QuantizedRerankCandidates, def.Dimensions)
+	assertQuantizedRerankNoDocumentGuardrailStats2416(t, fallbackRerank.Stats, rerankOpts.QuantizedRerankCandidates)
+	if packRerank.Stats.Candidates != fallbackRerank.Stats.Candidates || packRerank.Stats.VisitedEdges != fallbackRerank.Stats.VisitedEdges || packRerank.Stats.QuantizedScoreCalls != fallbackRerank.Stats.QuantizedScoreCalls || packRerank.Stats.QuantizedRerankExactScoreCalls != fallbackRerank.Stats.QuantizedRerankExactScoreCalls {
+		t.Fatalf("rerank pack stats=%+v fallback stats=%+v want same raw-dot traversal and rerank counters", packRerank.Stats, fallbackRerank.Stats)
+	}
+	if len(packRerank.Results) != len(fallbackRerank.Results) {
+		t.Fatalf("rerank pack results=%d fallback results=%d", len(packRerank.Results), len(fallbackRerank.Results))
+	}
+	for i := range packRerank.Results {
+		got := packRerank.Results[i]
+		wantResult := fallbackRerank.Results[i]
+		if got.Ordinal != wantResult.Ordinal || !bytes.Equal(got.ID, wantResult.ID) || math.Abs(got.Score-wantResult.Score) > 1e-6 {
+			t.Fatalf("quantized_rerank result[%d] pack=%+v fallback=%+v", i, got, wantResult)
+		}
+	}
+	rawRerankResults := searchScalarU8PreparedRawDotResultsForTest2658(t, packSearcher.reader, query, columnVectorGraphNativeSearchQueryModeQuantizedRerank, def.QuantizedIndexes[0].Name, rerankOpts.TopK, len(rows), rerankOpts.QuantizedRerankCandidates)
+	assertScalarU8PreparedRawDotNativeResultsMatchPublic2658(t, rawRerankResults, fallbackRerank.Results, 1e-6, "quantized_rerank raw-dot direct")
+}
+
+func searchScalarU8PreparedRawDotResultsForTest2658(t *testing.T, reader *columnVectorGraphPhysicalRowReader, query []float32, queryMode columnVectorGraphNativeSearchQueryMode, indexName string, topK, efSearch, rerankCandidates int) []columnVectorGraphNativeSearchResult {
+	t.Helper()
+	if reader == nil || reader.hnswSearchPack == nil {
+		t.Fatalf("raw-dot direct test requires prepared pack reader")
+	}
+	var scratch columnVectorGraphNativeSearchScratch
+	queryInvNorm, err := columnVectorGraphInvNorm(query)
+	if err != nil {
+		t.Fatalf("query norm: %v", err)
+	}
+	scorer, err := reader.prepareScalarU8QuantizedScorer(queryMode, indexName, query, queryInvNorm, &scratch)
+	if err != nil {
+		t.Fatalf("prepare scalar_u8 scorer: %v", err)
+	}
+	scratch.preparedScalarU8Plane.scorer = scorer
+	scratch.preparedScalarU8Plane.ready = true
+	packOpts := columnHNSWPreparedTraversalOptions{
+		TopK:                                 topK,
+		EfSearch:                             efSearch,
+		StatsMode:                            columnVectorGraphNativeSearchStatsModeFullDiagnostics,
+		OmitResultMaterialization:            queryMode == columnVectorGraphNativeSearchQueryModeQuantizedRerank,
+		SuppressOmittedResultMaterialization: queryMode == columnVectorGraphNativeSearchQueryModeQuantizedRerank,
+	}
+	results, stats, err := reader.hnswSearchPack.searchCosinePreparedRawDotTraversal(query, packOpts, &scratch, &scratch.preparedScalarU8Plane)
+	if err != nil {
+		t.Fatalf("raw-dot traversal: %v", err)
+	}
+	if queryMode == columnVectorGraphNativeSearchQueryModeQuantizedOnly {
+		return append([]columnVectorGraphNativeSearchResult(nil), results...)
+	}
+	if rerankCandidates == 0 {
+		rerankCandidates = efSearch
+	}
+	scratch.results = scratch.results[:0]
+	if err := reader.hnswSearchPack.exactRerankPreparedTraversalRowIDCandidates(query, topK, rerankCandidates, columnVectorGraphScoreBatchModeDefault, &scratch, &stats); err != nil {
+		t.Fatalf("raw-dot exact rerank: %v", err)
+	}
+	if err := reader.hnswSearchPack.fetchTopSearchResults(&scratch, &stats); err != nil {
+		t.Fatalf("raw-dot fetch results: %v", err)
+	}
+	return append([]columnVectorGraphNativeSearchResult(nil), scratch.results...)
+}
+
+func assertScalarU8PreparedRawDotNativeResultsMatchPublic2658(t *testing.T, got []columnVectorGraphNativeSearchResult, want []VectorIndexSearchResult, tolerance float64, label string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("%s results=%d want %d", label, len(got), len(want))
+	}
+	for i := range got {
+		if got[i].Ordinal != want[i].Ordinal || !bytes.Equal(got[i].ID, want[i].ID) || math.Abs(got[i].Score-want[i].Score) > tolerance {
+			t.Fatalf("%s result[%d] got=%+v want=%+v", label, i, got[i], want[i])
+		}
+	}
+}

--- a/TreeDB/collections/column_hnsw_prepared_raw_dot_traversal.go
+++ b/TreeDB/collections/column_hnsw_prepared_raw_dot_traversal.go
@@ -1,0 +1,263 @@
+package collections
+
+import (
+	"fmt"
+	"math"
+)
+
+func (v *columnHNSWSearchPackPreparedView) searchCosinePreparedRawDotTraversal(query []float32, opts columnHNSWPreparedTraversalOptions, scratch *columnVectorGraphNativeSearchScratch, scorePlane columnHNSWPreparedTraversalScorePlane) ([]columnVectorGraphNativeSearchResult, columnVectorGraphNativeSearchStats, error) {
+	if v == nil {
+		return nil, columnVectorGraphNativeSearchStats{}, errColumnHNSWSearchPackSearchUnavailable
+	}
+	switch status := v.fastStatus(""); status {
+	case columnHNSWSearchPackPreparedStatusDirect, columnHNSWSearchPackPreparedStatusHeap:
+	default:
+		return nil, columnVectorGraphNativeSearchStats{}, columnHNSWSearchPackStatusError(status)
+	}
+	if scratch == nil {
+		return nil, columnVectorGraphNativeSearchStats{}, errColumnVectorGraphNativeSearchScratchRequired
+	}
+	stats := &scratch.preparedTraversalStats
+	*stats = columnVectorGraphNativeSearchStats{}
+	if scorePlane == nil {
+		return nil, *stats, errColumnHNSWPreparedTraversalScorePlaneUnavailable
+	}
+	rawDotScorePlane, ok := scorePlane.(columnHNSWPreparedTraversalRawDotScorePlane)
+	if !ok {
+		return nil, *stats, errColumnHNSWPreparedTraversalScorePlaneUnavailable
+	}
+	if len(query) != v.Header.Dimensions {
+		return nil, *stats, fmt.Errorf("collections: hnsw_search_pack_v1 prepared raw-dot traversal query dims=%d want %d: %w", len(query), v.Header.Dimensions, errColumnVectorGraphNativeSearchQueryDimensionMismatch)
+	}
+	statsMode := opts.StatsMode.normalized()
+	if !columnHNSWSearchPackStatsModeSupportedForSearch(statsMode) {
+		return nil, *stats, errColumnHNSWSearchPackSearchUnsupportedMode
+	}
+	rowCount := v.Header.Rows
+	topK := opts.TopK
+	if topK < 0 {
+		return nil, *stats, errColumnVectorGraphNativeSearchTopKNegative
+	}
+	efSearch := opts.EfSearch
+	if efSearch < 0 {
+		return nil, *stats, errColumnVectorGraphNativeSearchEfSearchNegative
+	}
+	retainedCandidateLimit := opts.RetainedCandidateLimit
+	if retainedCandidateLimit < 0 {
+		return nil, *stats, fmt.Errorf("collections: hnsw_search_pack_v1 prepared raw-dot traversal retained candidates=%d cannot be negative", retainedCandidateLimit)
+	}
+	if topK == 0 || rowCount == 0 {
+		return nil, *stats, nil
+	}
+	stats.CandidateRows = uint64(rowCount)
+	if topK > rowCount {
+		topK = rowCount
+	}
+	if efSearch == 0 {
+		efSearch = v.Header.EfSearch
+	}
+	if efSearch < topK {
+		efSearch = topK
+	}
+	if efSearch > rowCount {
+		efSearch = rowCount
+	}
+	if retainedCandidateLimit == 0 {
+		retainedCandidateLimit = efSearch
+	}
+	if retainedCandidateLimit < topK {
+		return nil, *stats, fmt.Errorf("collections: hnsw_search_pack_v1 prepared raw-dot traversal retained candidates=%d below normalized top_k=%d", retainedCandidateLimit, topK)
+	}
+	if retainedCandidateLimit > rowCount {
+		retainedCandidateLimit = rowCount
+	}
+	degree := v.Header.M
+	if degree < 1 {
+		degree = 1
+	}
+	if degree <= math.MaxInt/2 {
+		degree *= 2
+	}
+	resultScratchK := topK
+	if opts.OmitResultMaterialization && !opts.SuppressOmittedResultMaterialization {
+		resultScratchK = retainedCandidateLimit
+	}
+	if err := scratch.prepareHNSWSearchPack(rowCount, v.Header.VectorStride, degree, resultScratchK, retainedCandidateLimit, degree, degree); err != nil {
+		return nil, *stats, fmt.Errorf("collections: hnsw_search_pack_v1 prepared raw-dot traversal scratch prepare: %w", err)
+	}
+	if err := scorePlane.prepareForHNSWPreparedTraversal(v, query, opts, scratch); err != nil {
+		return nil, *stats, fmt.Errorf("collections: hnsw_search_pack_v1 prepared raw-dot traversal %s score plane: %w", scorePlane.kind(), err)
+	}
+	return v.searchCosinePreparedRawDotScorePlane(rawDotScorePlane, opts, rowCount, topK, retainedCandidateLimit, degree, statsMode, scratch, stats)
+}
+
+func (v *columnHNSWSearchPackPreparedView) searchCosinePreparedRawDotScorePlane(rawDotScorePlane columnHNSWPreparedTraversalRawDotScorePlane, opts columnHNSWPreparedTraversalOptions, rowCount, topK, retainedCandidateLimit, degree int, statsMode columnVectorGraphNativeSearchStatsMode, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) ([]columnVectorGraphNativeSearchResult, columnVectorGraphNativeSearchStats, error) {
+	if rawDotScorePlane == nil {
+		return nil, *stats, errColumnHNSWPreparedTraversalScorePlaneUnavailable
+	}
+	scratch.prepareRawDotCandidateQueues(rowCount, degree, topK, retainedCandidateLimit)
+	countLoopEdges := !statsMode.minimal()
+	var loopEdgeVisits uint64
+	var visitedCandidates uint64
+	entryOrdinal := v.Header.EntryOrdinal
+	if entryOrdinal < 0 || entryOrdinal >= rowCount {
+		return nil, *stats, fmt.Errorf("collections: hnsw_search_pack_v1 prepared raw-dot traversal entry ordinal=%d outside rows=%d", entryOrdinal, rowCount)
+	}
+	maxLayer, err := v.maxLayerForOrdinal(entryOrdinal)
+	if err != nil {
+		return nil, *stats, err
+	}
+	for layer := maxLayer; layer > 0; layer-- {
+		entryOrdinal, err = v.greedyNearestAtLayerPreparedRawDotScorePlane(rawDotScorePlane, entryOrdinal, layer, scratch, stats, countLoopEdges, &loopEdgeVisits)
+		if err != nil {
+			return nil, *stats, err
+		}
+	}
+	visitMarks := scratch.visitMarks
+	visitEpoch := scratch.visitEpoch
+	visitMarks[entryOrdinal] = visitEpoch
+	if err := v.scoreAndPushRawDotFrontierVisitedPreparedScorePlane(rawDotScorePlane, entryOrdinal, retainedCandidateLimit, scratch, stats, &visitedCandidates); err != nil {
+		return nil, *stats, err
+	}
+	nextSeed := 0
+	rowCount64 := uint64(rowCount)
+	for {
+		candidate, ok := scratch.popRawDotFrontier()
+		if !ok {
+			if len(scratch.rawDot.top) >= retainedCandidateLimit {
+				break
+			}
+			seed, seedOK := columnHNSWSearchPackNextCandidateSeed(nextSeed, rowCount, visitMarks, visitEpoch)
+			if !seedOK {
+				break
+			}
+			nextSeed = seed + 1
+			visitMarks[seed] = visitEpoch
+			if err := v.scoreAndPushRawDotFrontierVisitedPreparedScorePlane(rawDotScorePlane, seed, retainedCandidateLimit, scratch, stats, &visitedCandidates); err != nil {
+				return nil, *stats, err
+			}
+			continue
+		}
+		if columnVectorGraphLayer0RawDotSearchShouldStop(candidate, scratch.rawDot.top, retainedCandidateLimit) {
+			break
+		}
+		adjacency, err := v.adjacencyLayerForOrdinal(candidate.ordinal, 0, stats)
+		if err != nil {
+			return nil, *stats, err
+		}
+		if len(adjacency) == 0 {
+			continue
+		}
+		if countLoopEdges {
+			loopEdgeVisits += uint64(len(adjacency))
+		}
+		scratch.scoreTileRowIDs = ensureColumnVectorGraphNativeUint32Scratch(scratch.scoreTileRowIDs, len(adjacency))
+		tile := scratch.scoreTileRowIDs[:0]
+		for i, neighbor := range adjacency {
+			if uint64(neighbor) >= rowCount64 {
+				return nil, *stats, fmt.Errorf("collections: hnsw_search_pack_v1 prepared raw-dot traversal ordinal=%d adjacency[%d]=%d outside row_count=%d: %w", candidate.ordinal, i, neighbor, rowCount, errColumnVectorGraphAdjacencyOrdinalOutOfBounds)
+			}
+			neighborOrdinal := int(neighbor)
+			if visitMarks[neighborOrdinal] == visitEpoch {
+				continue
+			}
+			visitMarks[neighborOrdinal] = visitEpoch
+			tile = append(tile, neighbor)
+		}
+		if len(tile) != 0 {
+			scored, err := rawDotScorePlane.scoreAndPushRawDotFrontierVisitedRowIDsPrevalidated(tile, retainedCandidateLimit, scratch, stats)
+			if err != nil {
+				return nil, *stats, err
+			}
+			visitedCandidates += uint64(scored)
+		}
+	}
+	if countLoopEdges {
+		stats.Edges = loopEdgeVisits
+		stats.VisitedEdges = loopEdgeVisits
+		stats.Candidates = visitedCandidates
+	}
+	return v.finishPreparedRawDotScorePlaneResults(topK, retainedCandidateLimit, opts, scratch, stats)
+}
+
+func (v *columnHNSWSearchPackPreparedView) greedyNearestAtLayerPreparedRawDotScorePlane(rawDotScorePlane columnHNSWPreparedTraversalRawDotScorePlane, entryOrdinal int, layer int, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats, countLoopEdges bool, loopEdgeVisits *uint64) (int, error) {
+	best := entryOrdinal
+	bestDot, err := rawDotScorePlane.scoreRawDotOrdinal(best, scratch, stats)
+	if err != nil {
+		return 0, err
+	}
+	changed := true
+	for changed {
+		changed = false
+		adjacency, err := v.adjacencyLayerForOrdinal(best, layer, stats)
+		if err != nil {
+			return 0, err
+		}
+		if len(adjacency) == 0 {
+			continue
+		}
+		if countLoopEdges && loopEdgeVisits != nil {
+			*loopEdgeVisits += uint64(len(adjacency))
+		}
+		for i, neighbor := range adjacency {
+			if uint64(neighbor) >= uint64(v.Header.Rows) {
+				return 0, fmt.Errorf("collections: hnsw_search_pack_v1 prepared raw-dot traversal ordinal=%d layer=%d adjacency[%d]=%d outside row_count=%d: %w", best, layer, i, neighbor, v.Header.Rows, errColumnVectorGraphAdjacencyOrdinalOutOfBounds)
+			}
+		}
+		scratch.scoreTileQuantizedDots = ensureColumnVectorGraphNativeInt64Scratch(scratch.scoreTileQuantizedDots, len(adjacency))
+		dots, err := rawDotScorePlane.scoreRawDotRowIDsPrevalidated(adjacency, scratch.scoreTileQuantizedDots, scratch, stats)
+		if err != nil {
+			return 0, err
+		}
+		for i, neighbor := range adjacency {
+			neighborOrdinal := int(neighbor)
+			dot := dots[i]
+			// Match the float64 traversal tie contract: lower ordinal wins exact ties.
+			if dot > bestDot || (dot == bestDot && neighborOrdinal < best) {
+				best = neighborOrdinal
+				bestDot = dot
+				changed = true
+			}
+		}
+	}
+	return best, nil
+}
+
+func (v *columnHNSWSearchPackPreparedView) scoreAndPushRawDotFrontierVisitedPreparedScorePlane(rawDotScorePlane columnHNSWPreparedTraversalRawDotScorePlane, ordinal, topK int, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats, visitedCandidates *uint64) error {
+	_ = v
+	dot, err := rawDotScorePlane.scoreRawDotOrdinal(ordinal, scratch, stats)
+	if err != nil {
+		return err
+	}
+	if visitedCandidates != nil {
+		(*visitedCandidates)++
+	}
+	candidate := columnVectorGraphRawDotSearchCandidate{ordinal: ordinal, dot: dot}
+	if scratch.insertRawDotTop(topK, candidate) {
+		scratch.pushRawDotFrontier(candidate)
+	}
+	return nil
+}
+
+func (v *columnHNSWSearchPackPreparedView) finishPreparedRawDotScorePlaneResults(topK int, retainedCandidateLimit int, opts columnHNSWPreparedTraversalOptions, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) ([]columnVectorGraphNativeSearchResult, columnVectorGraphNativeSearchStats, error) {
+	if len(scratch.rawDot.top) == 0 {
+		return scratch.results, *stats, nil
+	}
+	if opts.OmitResultMaterialization {
+		materializeLimit := retainedCandidateLimit
+		if opts.SuppressOmittedResultMaterialization {
+			scratch.promoteRawDotTopOrdinalsOnly(materializeLimit)
+			return scratch.results, *stats, nil
+		}
+		scratch.promoteRawDotTopToFloat(materializeLimit)
+		for _, candidate := range scratch.top {
+			scratch.results = append(scratch.results, columnVectorGraphNativeSearchResult{Ordinal: candidate.ordinal, Score: candidate.score})
+		}
+		return scratch.results, *stats, nil
+	}
+	scratch.promoteRawDotTopToFloat(topK)
+	if err := v.fetchTopSearchResults(scratch, stats); err != nil {
+		return nil, *stats, err
+	}
+	return scratch.results, *stats, nil
+}

--- a/TreeDB/collections/column_hnsw_prepared_traversal.go
+++ b/TreeDB/collections/column_hnsw_prepared_traversal.go
@@ -72,6 +72,16 @@ type columnHNSWPreparedTraversalRowIDScorePlane interface {
 	scoreAndPushFrontierVisitedRowIDsPrevalidated(rowIDs []uint32, topK int, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) (int, error)
 }
 
+// columnHNSWPreparedTraversalRawDotScorePlane is the scalar_u8-only ordering
+// seam for prepared traversal. It keeps raw centered dot products in the
+// frontier/top-k queues and converts to public float64 scores only when leaving
+// traversal for result materialization, exact rerank, or a generic score seam.
+type columnHNSWPreparedTraversalRawDotScorePlane interface {
+	scoreRawDotOrdinal(ordinal int, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) (int64, error)
+	scoreRawDotRowIDsPrevalidated(rowIDs []uint32, dst []int64, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) ([]int64, error)
+	scoreAndPushRawDotFrontierVisitedRowIDsPrevalidated(rowIDs []uint32, topK int, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) (int, error)
+}
+
 type columnHNSWPreparedExactFP32ScorePlane struct {
 	pack            *columnHNSWSearchPackPreparedView
 	normalizedQuery []float32

--- a/TreeDB/collections/column_vector_graph_quantized_scorer.go
+++ b/TreeDB/collections/column_vector_graph_quantized_scorer.go
@@ -226,23 +226,11 @@ func (s *columnVectorGraphScalarU8QuantizedScorer) scoreRowIDPrevalidated(rowID 
 }
 
 func (s *columnVectorGraphScalarU8QuantizedScorer) scoreRowIDPrepared(rowID uint32, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) (float64, error) {
-	if scratch == nil {
-		return 0, fmt.Errorf("collections: column_graph quantized scalar_u8 scorer: %w", errColumnVectorGraphNativeSearchScratchRequired)
+	dot, err := s.scoreRawDotRowIDPrepared(rowID, scratch, stats)
+	if err != nil {
+		return 0, err
 	}
-	scratch.scoreTileRowIDs = ensureColumnVectorGraphNativeUint32Scratch(scratch.scoreTileRowIDs, 1)
-	rowIDs := scratch.scoreTileRowIDs[:1]
-	rowIDs[0] = rowID
-	scratch.scoreTileQuantizedDots = ensureColumnVectorGraphNativeInt64Scratch(scratch.scoreTileQuantizedDots, 1)
-	dots := scratch.scoreTileQuantizedDots[:1]
-	status := vectorops.DotScalarU8CenteredIndexedPrevalidated(dots, s.codePayload, s.centeredQuery, rowIDs, s.dims)
-	if status.Invalid || status.Rows != 1 {
-		return 0, fmt.Errorf("%w: column_graph quantized index %q scalar_u8 score invalid status=%+v rows=%d want 1", ErrVectorIndexSearchUnavailable, s.indexName, status, status.Rows)
-	}
-	if stats != nil {
-		recordColumnVectorGraphScoreBatchStats(stats, status.Rows, status.Optimized, status.Fallback)
-		s.recordScoreStats(stats, status.Rows)
-	}
-	return scalarU8QuantizedCosineScoreFromDot(dots[0]), nil
+	return scalarU8QuantizedCosineScoreFromDot(dot), nil
 }
 
 func (s *columnVectorGraphScalarU8QuantizedScorer) scoreRowIDsPrevalidated(rowIDs []uint32, dst []float64, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) ([]float64, error) {
@@ -261,17 +249,79 @@ func (s *columnVectorGraphScalarU8QuantizedScorer) scoreRowIDsPrevalidated(rowID
 }
 
 func (s *columnVectorGraphScalarU8QuantizedScorer) scoreRowIDsPrepared(rowIDs []uint32, dst []float64, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) ([]float64, error) {
-	if scratch == nil {
-		return dst[:0], fmt.Errorf("collections: column_graph quantized scalar_u8 scorer: %w", errColumnVectorGraphNativeSearchScratchRequired)
+	var dotScratch []int64
+	if scratch != nil {
+		dotScratch = scratch.scoreTileQuantizedDots
 	}
-	scratch.scoreTileQuantizedDots = ensureColumnVectorGraphNativeInt64Scratch(scratch.scoreTileQuantizedDots, len(rowIDs))
-	dots := scratch.scoreTileQuantizedDots[:len(rowIDs)]
-	status := vectorops.DotScalarU8CenteredIndexedPrevalidated(dots, s.codePayload, s.centeredQuery, rowIDs, s.dims)
-	if status.Invalid || status.Rows != len(rowIDs) {
-		return dst[:0], fmt.Errorf("%w: column_graph quantized index %q scalar_u8 batch score invalid status=%+v rows=%d want %d", ErrVectorIndexSearchUnavailable, s.indexName, status, status.Rows, len(rowIDs))
+	dots, err := s.scoreRawDotRowIDsPrepared(rowIDs, dotScratch, scratch, stats)
+	if err != nil {
+		return dst[:0], err
 	}
 	for i, dot := range dots {
 		dst[i] = scalarU8QuantizedCosineScoreFromDot(dot)
+	}
+	return dst, nil
+}
+
+func (s *columnVectorGraphScalarU8QuantizedScorer) scoreRawDotOrdinal(ordinal int, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) (int64, error) {
+	if err := s.validatePrepared(); err != nil {
+		return 0, err
+	}
+	rows := s.codeRows.Rows()
+	if ordinal < 0 || ordinal >= rows || uint64(ordinal) > uint64(^uint32(0)) {
+		return 0, fmt.Errorf("%w: column_graph quantized index %q code row ordinal=%d unavailable len=0 ok=false want %d", ErrVectorIndexSearchUnavailable, s.indexName, ordinal, s.dims)
+	}
+	return s.scoreRawDotRowIDPrepared(uint32(ordinal), scratch, stats)
+}
+
+func (s *columnVectorGraphScalarU8QuantizedScorer) scoreRawDotRowIDPrepared(rowID uint32, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) (int64, error) {
+	if scratch == nil {
+		return 0, fmt.Errorf("collections: column_graph quantized scalar_u8 scorer: %w", errColumnVectorGraphNativeSearchScratchRequired)
+	}
+	scratch.scoreTileRowIDs = ensureColumnVectorGraphNativeUint32Scratch(scratch.scoreTileRowIDs, 1)
+	rowIDs := scratch.scoreTileRowIDs[:1]
+	rowIDs[0] = rowID
+	scratch.scoreTileQuantizedDots = ensureColumnVectorGraphNativeInt64Scratch(scratch.scoreTileQuantizedDots, 1)
+	dots, err := s.scoreRawDotRowIDsPrepared(rowIDs, scratch.scoreTileQuantizedDots, scratch, stats)
+	if err != nil {
+		return 0, err
+	}
+	return dots[0], nil
+}
+
+func (s *columnVectorGraphScalarU8QuantizedScorer) scoreRawDotRowIDsPrevalidated(rowIDs []uint32, dst []int64, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) ([]int64, error) {
+	if cap(dst) < len(rowIDs) {
+		if scratch != nil {
+			scratch.scoreTileQuantizedDots = ensureColumnVectorGraphNativeInt64Scratch(scratch.scoreTileQuantizedDots, len(rowIDs))
+			dst = scratch.scoreTileQuantizedDots[:len(rowIDs)]
+		} else {
+			dst = make([]int64, len(rowIDs))
+		}
+	} else {
+		dst = dst[:len(rowIDs)]
+	}
+	if len(rowIDs) == 0 {
+		return dst, nil
+	}
+	if err := s.validatePrepared(); err != nil {
+		return dst[:0], err
+	}
+	return s.scoreRawDotRowIDsPrepared(rowIDs, dst, scratch, stats)
+}
+
+func (s *columnVectorGraphScalarU8QuantizedScorer) scoreRawDotRowIDsPrepared(rowIDs []uint32, dst []int64, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) ([]int64, error) {
+	if scratch == nil {
+		return dst[:0], fmt.Errorf("collections: column_graph quantized scalar_u8 scorer: %w", errColumnVectorGraphNativeSearchScratchRequired)
+	}
+	if cap(dst) < len(rowIDs) {
+		scratch.scoreTileQuantizedDots = ensureColumnVectorGraphNativeInt64Scratch(scratch.scoreTileQuantizedDots, len(rowIDs))
+		dst = scratch.scoreTileQuantizedDots[:len(rowIDs)]
+	} else {
+		dst = dst[:len(rowIDs)]
+	}
+	status := vectorops.DotScalarU8CenteredIndexedPrevalidated(dst, s.codePayload, s.centeredQuery, rowIDs, s.dims)
+	if status.Invalid || status.Rows != len(rowIDs) {
+		return dst[:0], fmt.Errorf("%w: column_graph quantized index %q scalar_u8 batch score invalid status=%+v rows=%d want %d", ErrVectorIndexSearchUnavailable, s.indexName, status, status.Rows, len(rowIDs))
 	}
 	if stats != nil {
 		recordColumnVectorGraphScoreBatchStats(stats, status.Rows, status.Optimized, status.Fallback)
@@ -284,26 +334,39 @@ func (s *columnVectorGraphScalarU8QuantizedScorer) scoreAndPushFrontierVisitedRo
 	if len(rowIDs) == 0 {
 		return 0, nil
 	}
-	if err := s.validatePrepared(); err != nil {
+	var dotScratch []int64
+	if scratch != nil {
+		dotScratch = scratch.scoreTileQuantizedDots
+	}
+	dots, err := s.scoreRawDotRowIDsPrevalidated(rowIDs, dotScratch, scratch, stats)
+	if err != nil {
 		return 0, err
 	}
-	if scratch == nil {
-		return 0, fmt.Errorf("collections: column_graph quantized scalar_u8 scorer: %w", errColumnVectorGraphNativeSearchScratchRequired)
-	}
-	scratch.scoreTileQuantizedDots = ensureColumnVectorGraphNativeInt64Scratch(scratch.scoreTileQuantizedDots, len(rowIDs))
-	dots := scratch.scoreTileQuantizedDots[:len(rowIDs)]
-	status := vectorops.DotScalarU8CenteredIndexedPrevalidated(dots, s.codePayload, s.centeredQuery, rowIDs, s.dims)
-	if status.Invalid || status.Rows != len(rowIDs) {
-		return 0, fmt.Errorf("%w: column_graph quantized index %q scalar_u8 batch score invalid status=%+v rows=%d want %d", ErrVectorIndexSearchUnavailable, s.indexName, status, status.Rows, len(rowIDs))
-	}
-	if stats != nil {
-		recordColumnVectorGraphScoreBatchStats(stats, status.Rows, status.Optimized, status.Fallback)
-	}
-	s.recordScoreStats(stats, status.Rows)
 	for i, rowID := range rowIDs {
 		candidate := columnVectorGraphSearchCandidate{ordinal: int(rowID), score: scalarU8QuantizedCosineScoreFromDot(dots[i])}
 		if scratch.insertTop(topK, candidate) {
 			scratch.pushFrontier(candidate)
+		}
+	}
+	return len(rowIDs), nil
+}
+
+func (s *columnVectorGraphScalarU8QuantizedScorer) scoreAndPushRawDotFrontierVisitedRowIDsPrevalidated(rowIDs []uint32, topK int, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) (int, error) {
+	if len(rowIDs) == 0 {
+		return 0, nil
+	}
+	var dotScratch []int64
+	if scratch != nil {
+		dotScratch = scratch.scoreTileQuantizedDots
+	}
+	dots, err := s.scoreRawDotRowIDsPrevalidated(rowIDs, dotScratch, scratch, stats)
+	if err != nil {
+		return 0, err
+	}
+	for i, rowID := range rowIDs {
+		candidate := columnVectorGraphRawDotSearchCandidate{ordinal: int(rowID), dot: dots[i]}
+		if scratch.insertRawDotTop(topK, candidate) {
+			scratch.pushRawDotFrontier(candidate)
 		}
 	}
 	return len(rowIDs), nil

--- a/TreeDB/collections/column_vector_graph_raw_dot_search.go
+++ b/TreeDB/collections/column_vector_graph_raw_dot_search.go
@@ -1,0 +1,181 @@
+package collections
+
+// columnVectorGraphRawDotSearchCandidate is the scalar_u8-only traversal
+// candidate shape used while ordering by raw centered dot products. Public
+// results and generic search seams still use columnVectorGraphSearchCandidate
+// with float64 scores.
+type columnVectorGraphRawDotSearchCandidate struct {
+	ordinal int
+	dot     int64
+}
+
+type columnVectorGraphRawDotSearchScratch struct {
+	frontier []columnVectorGraphRawDotSearchCandidate
+	top      []columnVectorGraphRawDotSearchCandidate
+}
+
+func (s *columnVectorGraphNativeSearchScratch) prepareRawDotCandidateQueues(rowCount, degree, topK, efSearch int) {
+	raw := s.rawDot
+	if raw == nil {
+		raw = &columnVectorGraphRawDotSearchScratch{}
+		s.rawDot = raw
+	}
+	frontierCap := columnVectorGraphNativeSearchFrontierCapacity(rowCount, degree, topK, efSearch)
+	raw.frontier = resizeColumnVectorGraphRawDotCandidateScratch(raw.frontier, frontierCap)
+	topCandidateCap := efSearch
+	if topCandidateCap > rowCount {
+		topCandidateCap = rowCount
+	}
+	if topCandidateCap < topK {
+		topCandidateCap = topK
+	}
+	raw.top = resizeColumnVectorGraphRawDotCandidateScratch(raw.top, topCandidateCap)
+}
+
+func resizeColumnVectorGraphRawDotCandidateScratch(dst []columnVectorGraphRawDotSearchCandidate, target int) []columnVectorGraphRawDotSearchCandidate {
+	if cap(dst) < target || columnVectorGraphNativeScratchCapOversized(cap(dst), target) {
+		return make([]columnVectorGraphRawDotSearchCandidate, 0, target)
+	}
+	return dst[:0]
+}
+
+func (s *columnVectorGraphNativeSearchScratch) pushRawDotFrontier(candidate columnVectorGraphRawDotSearchCandidate) {
+	raw := s.rawDot
+	raw.frontier = append(raw.frontier, columnVectorGraphRawDotSearchCandidate{})
+	s.rawDotFrontierSiftUp(len(raw.frontier)-1, candidate)
+}
+
+func (s *columnVectorGraphNativeSearchScratch) popRawDotFrontier() (columnVectorGraphRawDotSearchCandidate, bool) {
+	raw := s.rawDot
+	if raw == nil || len(raw.frontier) == 0 {
+		return columnVectorGraphRawDotSearchCandidate{}, false
+	}
+	lastIdx := len(raw.frontier) - 1
+	best := raw.frontier[0]
+	last := raw.frontier[lastIdx]
+	raw.frontier = raw.frontier[:lastIdx]
+	if len(raw.frontier) > 0 {
+		s.rawDotFrontierSiftDown(0, last)
+	}
+	return best, true
+}
+
+func (s *columnVectorGraphNativeSearchScratch) rawDotFrontierSiftUp(idx int, candidate columnVectorGraphRawDotSearchCandidate) {
+	frontier := s.rawDot.frontier
+	for idx > 0 {
+		parent := (idx - 1) / columnVectorGraphNativeFrontierHeapFanout
+		parentCandidate := frontier[parent]
+		if !columnVectorGraphRawDotSearchCandidateBetter(candidate, parentCandidate) {
+			break
+		}
+		frontier[idx] = parentCandidate
+		idx = parent
+	}
+	frontier[idx] = candidate
+}
+
+func (s *columnVectorGraphNativeSearchScratch) rawDotFrontierSiftDown(idx int, candidate columnVectorGraphRawDotSearchCandidate) {
+	frontier := s.rawDot.frontier
+	n := len(frontier)
+	for {
+		firstChild := idx*columnVectorGraphNativeFrontierHeapFanout + 1
+		if firstChild >= n {
+			break
+		}
+		child := firstChild
+		childCandidate := frontier[firstChild]
+		if next := firstChild + 1; next < n && columnVectorGraphRawDotSearchCandidateBetter(frontier[next], childCandidate) {
+			child = next
+			childCandidate = frontier[next]
+		}
+		if next := firstChild + 2; next < n && columnVectorGraphRawDotSearchCandidateBetter(frontier[next], childCandidate) {
+			child = next
+			childCandidate = frontier[next]
+		}
+		if next := firstChild + 3; next < n && columnVectorGraphRawDotSearchCandidateBetter(frontier[next], childCandidate) {
+			child = next
+			childCandidate = frontier[next]
+		}
+		if !columnVectorGraphRawDotSearchCandidateBetter(childCandidate, candidate) {
+			break
+		}
+		frontier[idx] = childCandidate
+		idx = child
+	}
+	frontier[idx] = candidate
+}
+
+func (s *columnVectorGraphNativeSearchScratch) insertRawDotTop(limit int, candidate columnVectorGraphRawDotSearchCandidate) bool {
+	if limit <= 0 {
+		return false
+	}
+	raw := s.rawDot
+	top := raw.top
+	pos := len(top)
+	for pos > 0 && columnVectorGraphRawDotSearchCandidateBetter(candidate, top[pos-1]) {
+		pos--
+	}
+	if pos >= limit {
+		return false
+	}
+	if len(top) < limit {
+		top = append(top, columnVectorGraphRawDotSearchCandidate{})
+		raw.top = top
+	}
+	copy(top[pos+1:], top[pos:len(top)-1])
+	top[pos] = candidate
+	return true
+}
+
+func columnVectorGraphRawDotSearchCandidateBetter(left, right columnVectorGraphRawDotSearchCandidate) bool {
+	if left.dot == right.dot {
+		return left.ordinal < right.ordinal
+	}
+	return left.dot > right.dot
+}
+
+func columnVectorGraphLayer0RawDotSearchShouldStop(candidate columnVectorGraphRawDotSearchCandidate, top []columnVectorGraphRawDotSearchCandidate, efSearch int) bool {
+	if efSearch <= 0 || len(top) < efSearch {
+		return false
+	}
+	return candidate.dot < top[len(top)-1].dot
+}
+
+func (s *columnVectorGraphNativeSearchScratch) promoteRawDotTopToFloat(limit int) {
+	raw := s.rawDot
+	if raw == nil {
+		s.top = s.top[:0]
+		return
+	}
+	if limit < 0 {
+		limit = 0
+	}
+	if len(raw.top) > limit {
+		raw.top = raw.top[:limit]
+	}
+	s.top = ensureColumnVectorGraphNativeCandidateScratch(s.top, len(raw.top))
+	for _, candidate := range raw.top {
+		s.top = append(s.top, columnVectorGraphSearchCandidate{
+			ordinal: candidate.ordinal,
+			score:   scalarU8QuantizedCosineScoreFromDot(candidate.dot),
+		})
+	}
+}
+
+func (s *columnVectorGraphNativeSearchScratch) promoteRawDotTopOrdinalsOnly(limit int) {
+	raw := s.rawDot
+	if raw == nil {
+		s.top = s.top[:0]
+		return
+	}
+	if limit < 0 {
+		limit = 0
+	}
+	if len(raw.top) > limit {
+		raw.top = raw.top[:limit]
+	}
+	s.top = ensureColumnVectorGraphNativeCandidateScratch(s.top, len(raw.top))
+	for _, candidate := range raw.top {
+		s.top = append(s.top, columnVectorGraphSearchCandidate{ordinal: candidate.ordinal})
+	}
+}

--- a/TreeDB/collections/column_vector_graph_search.go
+++ b/TreeDB/collections/column_vector_graph_search.go
@@ -986,6 +986,7 @@ type columnVectorGraphNativeSearchScratch struct {
 	visitEpoch               uint64
 	frontier                 []columnVectorGraphSearchCandidate
 	top                      []columnVectorGraphSearchCandidate
+	rawDot                   *columnVectorGraphRawDotSearchScratch
 	results                  []columnVectorGraphNativeSearchResult
 	idBuffers                [][]byte
 	resultIDViews            [][]byte


### PR DESCRIPTION
## Objective

Closes #2658 as a **no-promote/default-off** raw-dot traversal seam for scalar_u8 prepared HNSW.

This lands the internal raw centered-dot candidate/top/frontier machinery and direct raw-dot traversal tests, while keeping the production scalar_u8 prepared route on the existing float64 score-plane path by default. Local raw-enabled benchmark runs showed scalar_u8 qonly/rerank regressions, so the seam is intentionally gated off until #2659/#2660 can make it performance-neutral or better.

## What changed

- Added scalar_u8 raw-dot traversal internals:
  - raw `int64` candidate/top/frontier queues
  - raw-dot upper/layer-0 prepared traversal
  - raw-dot score-plane methods for scalar_u8 prepared scoring
- Preserved public `float64` scores and stable ordinal tie behavior.
- Kept exact FP32 and default scalar_u8 public routes unchanged at runtime (`columnHNSWPreparedScalarU8RawDotTraversalEnabled = false`).
- Added direct raw-dot parity coverage against the current scalar_u8 float path.

## Tests

Latest-head after rebase to `origin/main` (`a55e838e4`):

```sh
GOMAXPROCS=8 GOWORK=off go test ./TreeDB/internal/vectorops ./TreeDB/collections -count=1
```

Result: PASS.

Focused raw-dot tests also passed during development:

```sh
GOMAXPROCS=8 GOWORK=off go test ./TreeDB/collections -run 'TestScalarU8RawDot|TestScalarU8PreparedTraversalRawDot' -count=1
```

## Benchmarks / performance status

Artifacts under `/tmp/scalar_u8_adapter_2658/logs/`.

Important finding: raw-dot **enabled** was not mergeable as the default path; focused runs showed scalar_u8 qonly/rerank regressions. Therefore this PR does not promote raw-dot traversal by default.

Default-off sanity runs were noisy on this workstation, but route/counter and allocation guardrails stayed intact (hot rows remain `0 B/op`, `0 allocs/op`; adjacency and fallback counters unchanged). Representative artifacts:

- `benchstat_exact_0c3_vs_b5a.txt` — exact FP32 focused sanity after removing generic raw dispatch.
- `benchstat_default_off_0c3_vs_dc03_n5.txt` — default-off focused exact/scalar sanity; noisy, counters unchanged.
- Raw-enabled regression evidence:
  - `benchstat_scalar_0c3_vs_434f.txt`
  - `benchstat_scalar_0c3_vs_b5a.txt`
  - `benchstat_scalar_0c3_vs_b5a_reverse.txt`

## Caveats / follow-up

- Raw-dot traversal is intentionally default-off in this PR.
- #2659/#2660 should use this seam as the basis for profile-gated optimization/promotion.
- No on-disk format or public API changes.

## Review notes

- Exact FP32 route is not routed through the raw-dot dispatcher.
- Quantized modes continue to fail closed; no silent exact fallback is introduced.
- `rabitq_1bit` storage/score/codec identity is untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized vector search traversal logic with a new raw-dot computation path, providing infrastructure for improved performance in quantized search operations.
  * Refactored internal dot-product scoring to separate raw-dot computation from cosine conversion, reducing redundant calculations.
  * Introduced a feature gate to control traversal implementation selection during rollout.

* **Tests**
  * Added comprehensive test coverage validating raw-dot search correctness and parity across multiple execution paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->