### PR TITLE
TreeDB: add geth-hot-KV read instrumentation

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -28099,6 +28099,27 @@ func (db *DB) Stats() map[string]string {
 			stats["treedb.cache.vlog_mmap.read.hit_ratio"] = fmt.Sprintf("%.6f", float64(mmapHits)/float64(total))
 		}
 
+		readStats := db.valueLogReader.ReadStats()
+		stats["treedb.cache.vlog_read.crc32_checks_total"] = fmt.Sprintf("%d", readStats.RecordCRCChecks)
+
+		gStats := db.valueLogReader.GroupedFrameCacheDetailedStats()
+		stats["treedb.cache.vlog_grouped_frame_cache.hits"] = fmt.Sprintf("%d", gStats.Hits)
+		stats["treedb.cache.vlog_grouped_frame_cache.misses"] = fmt.Sprintf("%d", gStats.Misses)
+		stats["treedb.cache.vlog_grouped_frame_cache.stores"] = fmt.Sprintf("%d", gStats.Stores)
+		stats["treedb.cache.vlog_grouped_frame_cache.evictions"] = fmt.Sprintf("%d", gStats.Evictions)
+		stats["treedb.cache.vlog_grouped_frame_cache.releases"] = fmt.Sprintf("%d", gStats.Releases)
+		stats["treedb.cache.vlog_grouped_frame_cache.retained_bytes"] = fmt.Sprintf("%d", gStats.RetainedBytes)
+		stats["treedb.cache.vlog_grouped_frame_cache.budget_bytes"] = fmt.Sprintf("%d", gStats.BudgetBytes)
+		stats["treedb.cache.vlog_grouped_frame_cache.skipped_disabled"] = fmt.Sprintf("%d", gStats.SkippedDisabled)
+		stats["treedb.cache.vlog_grouped_frame_cache.skipped_oversize"] = fmt.Sprintf("%d", gStats.SkippedOversize)
+		stats["treedb.cache.vlog_grouped_frame_cache.skipped_budget"] = fmt.Sprintf("%d", gStats.SkippedBudget)
+		stats["treedb.cache.vlog_grouped_frame_cache.skipped_contention"] = fmt.Sprintf("%d", gStats.SkippedContention)
+		stats["treedb.cache.vlog_grouped_frame_cache.entries"] = fmt.Sprintf("%d", gStats.Entries)
+		stats["treedb.cache.vlog_grouped_frame_cache.capacity"] = fmt.Sprintf("%d", gStats.Capacity)
+		if total := gStats.Hits + gStats.Misses; total > 0 {
+			stats["treedb.cache.vlog_grouped_frame_cache.hit_ratio"] = fmt.Sprintf("%.6f", float64(gStats.Hits)/float64(total))
+		}
+
 		hits, misses, entries, capacity := db.valueLogReader.TemplateDefCacheStats()
 		stats["treedb.cache.vlog_template_def_cache.hits"] = fmt.Sprintf("%d", hits)
 		stats["treedb.cache.vlog_template_def_cache.misses"] = fmt.Sprintf("%d", misses)

--- a/TreeDB/db/api.go
+++ b/TreeDB/db/api.go
@@ -828,6 +828,9 @@ func (db *DB) Stats() map[string]string {
 			stats["treedb.vlog.mmap_read.hit_ratio"] = fmt.Sprintf("%.6f", float64(mmapHits)/float64(total))
 		}
 
+		readStats := db.valueLogManager.ReadStats()
+		stats["treedb.vlog.read.crc32_checks_total"] = fmt.Sprintf("%d", readStats.RecordCRCChecks)
+
 		gStats := db.valueLogManager.GroupedFrameCacheDetailedStats()
 		stats["treedb.vlog.grouped_frame_cache.hits"] = fmt.Sprintf("%d", gStats.Hits)
 		stats["treedb.vlog.grouped_frame_cache.misses"] = fmt.Sprintf("%d", gStats.Misses)

--- a/TreeDB/integration/gethethdb/adapter.go
+++ b/TreeDB/integration/gethethdb/adapter.go
@@ -50,7 +50,16 @@ type OpenOptions struct {
 	MemtableMode string
 }
 
-const defaultGethCommandWALMaxSegmentBytes int64 = 256 << 20
+const (
+	defaultGethCommandWALMaxSegmentBytes int64 = 256 << 20
+
+	// EnvReadIntegrity selects value-log read checksum verification for the geth
+	// TreeDB adapter. Empty preserves the selected profile/default. Use
+	// "unsafe-skip-checksums" only for explicitly labeled benchmark ceilings.
+	EnvReadIntegrity = "TREEDB_GETH_READ_INTEGRITY"
+	// EnvReadIntegrityFallback is a generic alias honored when EnvReadIntegrity is unset.
+	EnvReadIntegrityFallback = "TREEDB_READ_INTEGRITY"
+)
 
 // DefaultOpenOptions returns the production-oriented adapter defaults.
 func DefaultOpenOptions() OpenOptions {
@@ -87,6 +96,9 @@ func Open(path string, options *OpenOptions) (*Database, error) {
 // uses the larger cap.
 func OpenWithOptions(opts treedb.Options) (*Database, error) {
 	applyGethCommandWALDefaults(&opts)
+	if err := applyReadIntegrityEnv(&opts); err != nil {
+		return nil, err
+	}
 	if strings.TrimSpace(opts.Dir) == "" {
 		return nil, errors.New("gethethdb: TreeDB options Dir must be non-empty")
 	}
@@ -129,6 +141,9 @@ func resolveTreeDBOptions(path string, options *OpenOptions) (treedb.Options, er
 			opts.MemtableMode = strings.ToLower(mode)
 		}
 	}
+	if err := applyReadIntegrityEnv(&opts); err != nil {
+		return treedb.Options{}, err
+	}
 	if strings.TrimSpace(opts.Dir) == "" {
 		return treedb.Options{}, errors.New("gethethdb: TreeDB options Dir must be non-empty")
 	}
@@ -137,6 +152,40 @@ func resolveTreeDBOptions(path string, options *OpenOptions) (treedb.Options, er
 	}
 	applyGethCommandWALDefaults(&opts)
 	return opts, nil
+}
+
+func applyReadIntegrityEnv(opts *treedb.Options) error {
+	if opts == nil {
+		return nil
+	}
+	raw, source := readIntegrityEnvValue()
+	if strings.TrimSpace(raw) == "" {
+		return nil
+	}
+	mode, err := parseReadIntegrity(raw)
+	if err != nil {
+		return fmt.Errorf("gethethdb: invalid %s=%q: %w", source, raw, err)
+	}
+	opts.ValueLog.ReadIntegrity = mode
+	return nil
+}
+
+func readIntegrityEnvValue() (raw string, source string) {
+	if raw := os.Getenv(EnvReadIntegrity); strings.TrimSpace(raw) != "" {
+		return raw, EnvReadIntegrity
+	}
+	return os.Getenv(EnvReadIntegrityFallback), EnvReadIntegrityFallback
+}
+
+func parseReadIntegrity(raw string) (treedb.IntegrityMode, error) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "verify", "verified", "checksum-verify", "checksum-verified", "checksums", "on", "true", "1":
+		return treedb.IntegrityVerify, nil
+	case "unsafe-skip-checksums", "skip-checksums", "skip", "no-checksums", "none", "off", "false", "0":
+		return treedb.IntegritySkipChecksums, nil
+	default:
+		return treedb.IntegrityVerify, fmt.Errorf("use verify or unsafe-skip-checksums")
+	}
 }
 
 func applyGethCommandWALDefaults(opts *treedb.Options) {

--- a/TreeDB/integration/gethethdb/adapter_test.go
+++ b/TreeDB/integration/gethethdb/adapter_test.go
@@ -46,6 +46,64 @@ func TestOpenDefaultsToCommandWALDurable(t *testing.T) {
 	}
 }
 
+func TestResolveTreeDBOptionsReadIntegrityEnv(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "treedb")
+	opts, err := resolveTreeDBOptions(dir, nil)
+	if err != nil {
+		t.Fatalf("resolve default options: %v", err)
+	}
+	if got := opts.ValueLog.ReadIntegrity; got != treedb.IntegrityVerify {
+		t.Fatalf("default read integrity=%d want verify", got)
+	}
+
+	t.Setenv(EnvReadIntegrity, "unsafe-skip-checksums")
+	opts, err = resolveTreeDBOptions(dir, nil)
+	if err != nil {
+		t.Fatalf("resolve skip-checksum options: %v", err)
+	}
+	if got := opts.ValueLog.ReadIntegrity; got != treedb.IntegritySkipChecksums {
+		t.Fatalf("env read integrity=%d want skip-checksums", got)
+	}
+
+	t.Setenv(EnvReadIntegrity, "verify")
+	relaxed := treedb.OptionsFor(treedb.ProfileCommandWALRelaxed, dir)
+	opts, err = resolveTreeDBOptions(dir, &OpenOptions{Options: &relaxed})
+	if err != nil {
+		t.Fatalf("resolve verify override options: %v", err)
+	}
+	if got := opts.ValueLog.ReadIntegrity; got != treedb.IntegrityVerify {
+		t.Fatalf("env verify override read integrity=%d want verify", got)
+	}
+}
+
+func TestResolveTreeDBOptionsReadIntegrityFallbackEnv(t *testing.T) {
+	t.Setenv(EnvReadIntegrityFallback, "unsafe-skip-checksums")
+	opts, err := resolveTreeDBOptions(filepath.Join(t.TempDir(), "treedb"), nil)
+	if err != nil {
+		t.Fatalf("resolve fallback read integrity: %v", err)
+	}
+	if got := opts.ValueLog.ReadIntegrity; got != treedb.IntegritySkipChecksums {
+		t.Fatalf("fallback env read integrity=%d want skip-checksums", got)
+	}
+
+	t.Setenv(EnvReadIntegrity, "verify")
+	opts, err = resolveTreeDBOptions(filepath.Join(t.TempDir(), "treedb"), nil)
+	if err != nil {
+		t.Fatalf("resolve specific read integrity: %v", err)
+	}
+	if got := opts.ValueLog.ReadIntegrity; got != treedb.IntegrityVerify {
+		t.Fatalf("specific env read integrity=%d want verify", got)
+	}
+}
+
+func TestResolveTreeDBOptionsReadIntegrityEnvRejectsInvalid(t *testing.T) {
+	t.Setenv(EnvReadIntegrity, "fast-but-maybe-safe")
+	_, err := resolveTreeDBOptions(filepath.Join(t.TempDir(), "treedb"), nil)
+	if err == nil || !strings.Contains(err.Error(), EnvReadIntegrity) {
+		t.Fatalf("resolve invalid read integrity err=%v, want %s error", err, EnvReadIntegrity)
+	}
+}
+
 func TestOpenDefaultsUseGethSizedCommandWALSegments(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), "treedb")
 	opts, err := resolveTreeDBOptions(dir, nil)

--- a/TreeDB/integration/gethethdb/adapter_test.go
+++ b/TreeDB/integration/gethethdb/adapter_test.go
@@ -47,6 +47,7 @@ func TestOpenDefaultsToCommandWALDurable(t *testing.T) {
 }
 
 func TestResolveTreeDBOptionsReadIntegrityEnv(t *testing.T) {
+	clearReadIntegrityEnv(t)
 	dir := filepath.Join(t.TempDir(), "treedb")
 	opts, err := resolveTreeDBOptions(dir, nil)
 	if err != nil {
@@ -77,6 +78,7 @@ func TestResolveTreeDBOptionsReadIntegrityEnv(t *testing.T) {
 }
 
 func TestResolveTreeDBOptionsReadIntegrityFallbackEnv(t *testing.T) {
+	clearReadIntegrityEnv(t)
 	t.Setenv(EnvReadIntegrityFallback, "unsafe-skip-checksums")
 	opts, err := resolveTreeDBOptions(filepath.Join(t.TempDir(), "treedb"), nil)
 	if err != nil {
@@ -97,11 +99,18 @@ func TestResolveTreeDBOptionsReadIntegrityFallbackEnv(t *testing.T) {
 }
 
 func TestResolveTreeDBOptionsReadIntegrityEnvRejectsInvalid(t *testing.T) {
+	clearReadIntegrityEnv(t)
 	t.Setenv(EnvReadIntegrity, "fast-but-maybe-safe")
 	_, err := resolveTreeDBOptions(filepath.Join(t.TempDir(), "treedb"), nil)
 	if err == nil || !strings.Contains(err.Error(), EnvReadIntegrity) {
 		t.Fatalf("resolve invalid read integrity err=%v, want %s error", err, EnvReadIntegrity)
 	}
+}
+
+func clearReadIntegrityEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv(EnvReadIntegrity, "")
+	t.Setenv(EnvReadIntegrityFallback, "")
 }
 
 func TestOpenDefaultsUseGethSizedCommandWALSegments(t *testing.T) {

--- a/TreeDB/internal/valuelog/manager.go
+++ b/TreeDB/internal/valuelog/manager.go
@@ -113,6 +113,8 @@ type File struct {
 	mmapReadMissDeadMappingCap atomic.Uint64
 	// mmapReadFallbackReadAt counts reads that ultimately fall back to ReadAt.
 	mmapReadFallbackReadAt atomic.Uint64
+	// readRecordCRCChecks counts value-log record checksum computations on read paths.
+	readRecordCRCChecks atomic.Uint64
 }
 
 func (f *File) allowsCompactLeafPayload() bool {
@@ -512,7 +514,7 @@ func (f *File) Read(ptr page.ValuePtr, verifyCRC bool) ([]byte, error) {
 		}
 	}
 	f.mmapReadFallbackReadAt.Add(1)
-	return ReadAtWithDict(f.File, ptr, verifyCRC, f.dictLookup, f.templateLookup, f.templateDefCache, f.templateDecodeOpts)
+	return f.readAtWithDict(ptr, verifyCRC)
 }
 
 func (f *File) ReadUnsafe(ptr page.ValuePtr, verifyCRC bool) ([]byte, error) {
@@ -548,7 +550,7 @@ func (f *File) ReadUnsafe(ptr page.ValuePtr, verifyCRC bool) ([]byte, error) {
 			}
 		}
 		f.mmapReadFallbackReadAt.Add(1)
-		return ReadAtWithDict(f.File, ptr, verifyCRC, f.dictLookup, f.templateLookup, f.templateDefCache, f.templateDecodeOpts)
+		return f.readAtWithDict(ptr, verifyCRC)
 	}
 	// Avoid per-read Stat/lock churn once we have exhausted the dead-mapping
 	// budget: remapToFileSize won't be able to grow the mapping safely again.
@@ -570,7 +572,7 @@ func (f *File) ReadUnsafe(ptr page.ValuePtr, verifyCRC bool) ([]byte, error) {
 		f.mmapReadMissDeadMappingCap.Add(1)
 	}
 	f.mmapReadFallbackReadAt.Add(1)
-	return ReadAtWithDict(f.File, ptr, verifyCRC, f.dictLookup, f.templateLookup, f.templateDefCache, f.templateDecodeOpts)
+	return f.readAtWithDict(ptr, verifyCRC)
 }
 
 // ReadUnsafeTo is like ReadUnsafe, but it may return a slice backed by dst
@@ -630,7 +632,7 @@ func (f *File) ReadUnsafeTo(ptr page.ValuePtr, verifyCRC bool, dst []byte) ([]by
 				return val, usedDst, nil
 			}
 		}
-		return ReadAtWithDictTo(f.File, ptr, verifyCRC, f.dictLookup, f.templateLookup, f.templateDefCache, f.templateDecodeOpts, dst)
+		return f.readAtWithDictTo(ptr, verifyCRC, dst)
 	}
 	// Avoid per-read Stat/lock churn once we have exhausted the dead-mapping
 	// budget: remapToFileSize won't be able to grow the mapping safely again.
@@ -670,7 +672,7 @@ func (f *File) ReadUnsafeTo(ptr page.ValuePtr, verifyCRC bool, dst []byte) ([]by
 			return val, usedDst, nil
 		}
 	}
-	return ReadAtWithDictTo(f.File, ptr, verifyCRC, f.dictLookup, f.templateLookup, f.templateDefCache, f.templateDecodeOpts, dst)
+	return f.readAtWithDictTo(ptr, verifyCRC, dst)
 }
 
 // readGroupedCompressedFromFileTo handles grouped+compressed reads on the
@@ -981,6 +983,20 @@ func (f *File) ReadAppend(ptr page.ValuePtr, verifyCRC bool, dst []byte) ([]byte
 	return f.appendDecodedRecordTo(ptr, verifyCRC, dst)
 }
 
+func (f *File) readAtWithDict(ptr page.ValuePtr, verifyCRC bool) ([]byte, error) {
+	if verifyCRC {
+		f.noteRecordCRCCheck()
+	}
+	return ReadAtWithDict(f.File, ptr, verifyCRC, f.dictLookup, f.templateLookup, f.templateDefCache, f.templateDecodeOpts)
+}
+
+func (f *File) readAtWithDictTo(ptr page.ValuePtr, verifyCRC bool, dst []byte) ([]byte, bool, error) {
+	if verifyCRC {
+		f.noteRecordCRCCheck()
+	}
+	return ReadAtWithDictTo(f.File, ptr, verifyCRC, f.dictLookup, f.templateLookup, f.templateDefCache, f.templateDecodeOpts, dst)
+}
+
 func (f *File) appendDecodedRecordTo(ptr page.ValuePtr, verifyCRC bool, dst []byte) ([]byte, error) {
 	if f == nil || f.File == nil {
 		return nil, errors.New("valuelog: nil file")
@@ -990,7 +1006,7 @@ func (f *File) appendDecodedRecordTo(ptr page.ValuePtr, verifyCRC bool, dst []by
 	if oldLen <= cap(dst) {
 		tail = dst[oldLen:cap(dst)]
 	}
-	val, usedDst, err := ReadAtWithDictTo(f.File, ptr, verifyCRC, f.dictLookup, f.templateLookup, f.templateDefCache, f.templateDecodeOpts, tail[:0])
+	val, usedDst, err := f.readAtWithDictTo(ptr, verifyCRC, tail[:0])
 	if err != nil {
 		return nil, err
 	}

--- a/TreeDB/internal/valuelog/read_stats.go
+++ b/TreeDB/internal/valuelog/read_stats.go
@@ -1,0 +1,55 @@
+package valuelog
+
+// ReadStats captures value-log read-path counters.
+type ReadStats struct {
+	// RecordCRCChecks counts value-log record CRC32 computations performed while
+	// checksum verification is enabled. A grouped-frame read should increment this
+	// once per verified grouped record read, not once per subvalue served from a
+	// reused verified frame.
+	RecordCRCChecks uint64
+}
+
+func (st *ReadStats) add(other ReadStats) {
+	st.RecordCRCChecks += other.RecordCRCChecks
+}
+
+func (f *File) noteRecordCRCCheck() {
+	if f == nil {
+		return
+	}
+	f.readRecordCRCChecks.Add(1)
+}
+
+// ReadStats returns this file's read-path counters.
+func (f *File) ReadStats() ReadStats {
+	if f == nil {
+		return ReadStats{}
+	}
+	return ReadStats{RecordCRCChecks: f.readRecordCRCChecks.Load()}
+}
+
+// ReadStats returns aggregate read-path counters for this snapshot set.
+func (s *Set) ReadStats() ReadStats {
+	if s == nil {
+		return ReadStats{}
+	}
+	var stats ReadStats
+	for _, f := range s.Files {
+		stats.add(f.ReadStats())
+	}
+	return stats
+}
+
+// ReadStats returns aggregate read-path counters for currently tracked files.
+func (m *Manager) ReadStats() ReadStats {
+	if m == nil {
+		return ReadStats{}
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	var stats ReadStats
+	for _, f := range m.files {
+		stats.add(f.ReadStats())
+	}
+	return stats
+}

--- a/TreeDB/internal/valuelog/read_stats_test.go
+++ b/TreeDB/internal/valuelog/read_stats_test.go
@@ -1,0 +1,78 @@
+package valuelog
+
+import (
+	"bytes"
+	"path/filepath"
+	"testing"
+)
+
+func TestManagerReadStatsCountsVerifyCRCChecks(t *testing.T) {
+	dir := t.TempDir()
+	fileID, err := EncodeFileID(0, 1)
+	if err != nil {
+		t.Fatalf("encode file id: %v", err)
+	}
+	path := filepath.Join(dir, "value-l0-000001.log")
+
+	writer, err := NewWriter(path, fileID)
+	if err != nil {
+		t.Fatalf("new writer: %v", err)
+	}
+	ptr1, err := writer.Append(0, nil, 1, []byte("alpha"))
+	if err != nil {
+		_ = writer.Close()
+		t.Fatalf("append alpha: %v", err)
+	}
+	ptr2, err := writer.Append(0, nil, 2, []byte("beta"))
+	if err != nil {
+		_ = writer.Close()
+		t.Fatalf("append beta: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close writer: %v", err)
+	}
+
+	m, err := NewManager(dir)
+	if err != nil {
+		t.Fatalf("new manager: %v", err)
+	}
+	defer m.Close()
+
+	if got := m.ReadStats().RecordCRCChecks; got != 0 {
+		t.Fatalf("initial CRC checks=%d want 0", got)
+	}
+	got1, err := m.Read(ptr1)
+	if err != nil {
+		t.Fatalf("read alpha: %v", err)
+	}
+	if !bytes.Equal(got1, []byte("alpha")) {
+		t.Fatalf("read alpha=%q", got1)
+	}
+	if got := m.ReadStats().RecordCRCChecks; got != 1 {
+		t.Fatalf("CRC checks after first verified read=%d want 1", got)
+	}
+
+	got2, _, err := m.ReadUnsafeTo(ptr2, make([]byte, 0, len("beta")))
+	if err != nil {
+		t.Fatalf("read beta: %v", err)
+	}
+	if !bytes.Equal(got2, []byte("beta")) {
+		t.Fatalf("read beta=%q", got2)
+	}
+	if got := m.ReadStats().RecordCRCChecks; got != 2 {
+		t.Fatalf("CRC checks after second verified read=%d want 2", got)
+	}
+
+	m.SetDisableReadChecksum(true)
+	before := m.ReadStats().RecordCRCChecks
+	got1, err = m.Read(ptr1)
+	if err != nil {
+		t.Fatalf("read alpha checksum-disabled: %v", err)
+	}
+	if !bytes.Equal(got1, []byte("alpha")) {
+		t.Fatalf("checksum-disabled read alpha=%q", got1)
+	}
+	if got := m.ReadStats().RecordCRCChecks; got != before {
+		t.Fatalf("checksum-disabled read changed CRC checks from %d to %d", before, got)
+	}
+}

--- a/TreeDB/internal/valuelog/reader_mmap.go
+++ b/TreeDB/internal/valuelog/reader_mmap.go
@@ -580,6 +580,7 @@ func (f *File) readViaMmapView(ptr page.ValuePtr, verifyCRC bool) ([]byte, error
 
 	payload := data[start+HeaderSize : end]
 	if verifyCRC {
+		f.noteRecordCRCCheck()
 		sum := crc.ChecksumParts(header[4:], payload)
 		if sum != crcVal {
 			return nil, ErrCorrupt, true
@@ -884,6 +885,7 @@ func (f *File) readViaMmapViewTo(ptr page.ValuePtr, verifyCRC bool, dst []byte) 
 
 	payload := data[start+HeaderSize : end]
 	if verifyCRC {
+		f.noteRecordCRCCheck()
 		sum := crc.ChecksumParts(header[4:], payload)
 		if sum != crcVal {
 			return nil, false, ErrCorrupt, true
@@ -1122,6 +1124,7 @@ func (f *File) readViaMmapAppend(ptr page.ValuePtr, verifyCRC bool, dst []byte) 
 
 	payload := data[start+HeaderSize : end]
 	if verifyCRC {
+		f.noteRecordCRCCheck()
 		sum := crc.ChecksumParts(header[4:], payload)
 		if sum != crcVal {
 			return nil, ErrCorrupt, true

--- a/TreeDB/public.go
+++ b/TreeDB/public.go
@@ -149,6 +149,7 @@ type DB struct {
 	bgErrMu                         sync.Mutex
 	bgErr                           error
 	durabilityMode                  string
+	valueLogReadIntegrity           string
 	dir                             string
 	maintenance                     maintenanceCoordinator
 }
@@ -651,7 +652,7 @@ func Open(opts Options) (*DB, error) {
 	}
 
 	if opts.ReadOnly {
-		return &DB{backend: backend, dictdb: dictBackend, templateDB: templateDB, writePath: writePath, notifyError: opts.NotifyError, durabilityMode: computeDurabilityMode(opts), dir: rootDir}, nil
+		return &DB{backend: backend, dictdb: dictBackend, templateDB: templateDB, writePath: writePath, notifyError: opts.NotifyError, durabilityMode: computeDurabilityMode(opts), valueLogReadIntegrity: valueLogReadIntegrityLabel(opts), dir: rootDir}, nil
 	}
 
 	normalizeBackpressureDefaults(&opts)
@@ -755,7 +756,7 @@ func Open(opts Options) (*DB, error) {
 
 	cached.SetDictStore(dictStore)
 	cached.SetTemplateStore(templateStore)
-	out := &DB{cached: cached, backend: backend, dictdb: dictBackend, templateDB: templateDB, writePath: writePath, commandWALCached: opts.CommandWAL, notifyError: opts.NotifyError, durabilityMode: computeDurabilityMode(opts), dir: rootDir}
+	out := &DB{cached: cached, backend: backend, dictdb: dictBackend, templateDB: templateDB, writePath: writePath, commandWALCached: opts.CommandWAL, notifyError: opts.NotifyError, durabilityMode: computeDurabilityMode(opts), valueLogReadIntegrity: valueLogReadIntegrityLabel(opts), dir: rootDir}
 	if out.commandWALCached {
 		cached.SetCommandWALCheckpointCutoverHook(out.snapshotPublicCommandWALCheckpointCutover)
 		cached.SetCommandWALCheckpointPublishHook(out.preparePublicCommandWALPendingPublish)
@@ -1078,6 +1079,15 @@ func applyEnvIndexFormatOverrides(opts *Options) {
 	}
 	if v, ok := envBoolSet(envIndexAdaptiveLeafEncoding); ok {
 		opts.IndexAdaptiveLeafEncoding = v
+	}
+}
+
+func valueLogReadIntegrityLabel(opts Options) string {
+	switch opts.ValueLog.ReadIntegrity {
+	case db.IntegritySkipChecksums:
+		return "unsafe-skip-checksums"
+	default:
+		return "verify"
 	}
 }
 
@@ -1775,6 +1785,7 @@ func (db *DB) Stats() map[string]string {
 		writePathStatsInto(stats, db.writePath)
 		db.publicCommandWALLiveStatsInto(stats)
 		stats["treedb.durability_mode"] = db.durabilityMode
+		stats["treedb.vlog.read_integrity"] = db.valueLogReadIntegrity
 		bgIndexVacuumStatsInto(stats, &db.bgVac)
 		maintenanceStatsInto(stats, &db.maintenance)
 		return stats
@@ -1785,6 +1796,7 @@ func (db *DB) Stats() map[string]string {
 	}
 	writePathStatsInto(stats, db.writePath)
 	stats["treedb.durability_mode"] = db.durabilityMode
+	stats["treedb.vlog.read_integrity"] = db.valueLogReadIntegrity
 	bgIndexVacuumStatsInto(stats, &db.bgVac)
 	maintenanceStatsInto(stats, &db.maintenance)
 	return stats

--- a/TreeDB/read_integrity_stats_test.go
+++ b/TreeDB/read_integrity_stats_test.go
@@ -1,0 +1,44 @@
+package treedb
+
+import "testing"
+
+func TestStatsReportsValueLogReadIntegrityAndReadCounters(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		mode IntegrityMode
+		want string
+	}{
+		{name: "verify", mode: IntegrityVerify, want: "verify"},
+		{name: "skip", mode: IntegritySkipChecksums, want: "unsafe-skip-checksums"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := OptionsFor(ProfileCommandWALDurable, t.TempDir())
+			opts.ValueLog.ReadIntegrity = tt.mode
+			db, err := Open(opts)
+			if err != nil {
+				t.Fatalf("Open: %v", err)
+			}
+			defer db.Close()
+
+			stats := db.Stats()
+			if got := stats["treedb.vlog.read_integrity"]; got != tt.want {
+				t.Fatalf("treedb.vlog.read_integrity=%q want %q", got, tt.want)
+			}
+			if !statsHasAny(stats, "treedb.vlog.read.crc32_checks_total", "treedb.cache.vlog_read.crc32_checks_total") {
+				t.Fatalf("Stats missing value-log CRC read counter")
+			}
+			if !statsHasAny(stats, "treedb.vlog.grouped_frame_cache.hits", "treedb.cache.vlog_grouped_frame_cache.hits") {
+				t.Fatalf("Stats missing grouped-frame cache counters")
+			}
+		})
+	}
+}
+
+func statsHasAny(stats map[string]string, keys ...string) bool {
+	for _, key := range keys {
+		if _, ok := stats[key]; ok {
+			return true
+		}
+	}
+	return false
+}

--- a/benchmarks/geth_hot_kv/README.md
+++ b/benchmarks/geth_hot_kv/README.md
@@ -23,6 +23,11 @@ Workload shape:
    iterate keys/sec, DeleteRange affected-keys/sec, and on-disk size bytes.
    `size bytes` is measured before the destructive DeleteRange phase; the JSON
    and matrix also include `post_delete_size_bytes` after close/reopen.
+8. Label TreeDB value-log read integrity (`verify` or the explicitly unsafe
+   `unsafe-skip-checksums` ceiling) and iteration mode (`value` or `key-only`).
+9. For TreeDB runs, include per-phase stat deltas for value-log CRC checks,
+   grouped-frame cache activity, mmap hits, and ReadAt fallbacks where the
+   adapter exposes `Stat()`.
 
 The exact original `/tmp/treedb_nitro_soak.go` was not recovered, so the matrix
 script intentionally sweeps the uncertain knobs that may affect directionality:
@@ -42,6 +47,30 @@ go run /path/to/gomap/benchmarks/geth_hot_kv/testdata/treedb_nitro_soak.go \
   -out /tmp/treedb_soak_results.json
 ```
 
+TreeDB checksum verification is the default. The unsafe checksum-disabled mode
+is benchmark-only and must be selected explicitly:
+
+```sh
+go run /path/to/gomap/benchmarks/geth_hot_kv/testdata/treedb_nitro_soak.go \
+  -n 30000 \
+  -reads 12000 \
+  -engines treedb \
+  -treedb-read-integrity unsafe-skip-checksums \
+  -out /tmp/treedb_soak_skip_checksums.json
+```
+
+Use `-iteration-mode key-only` to measure ordered traversal without calling
+`Iterator.Value()` or materializing value-log payloads during the iterate phase:
+
+```sh
+go run /path/to/gomap/benchmarks/geth_hot_kv/testdata/treedb_nitro_soak.go \
+  -n 30000 \
+  -reads 12000 \
+  -engines treedb \
+  -iteration-mode key-only \
+  -out /tmp/treedb_soak_key_only.json
+```
+
 ## Matrix run
 
 ```sh
@@ -57,6 +86,20 @@ KEYS=1000 READS=300 \
 KEY_SHAPES=geth-mixed \
 VALUE_SIZES=128 \
 BATCH_TARGET_BYTES=102400 \
+  scripts/treedb_geth_hot_kv_matrix.sh
+```
+
+Checksum verify vs unsafe ceiling and value vs key-only split:
+
+```sh
+GETH_REPO=/path/to/go-ethereum \
+ENGINES=treedb \
+KEYS=30000 READS=12000 \
+KEY_SHAPES=geth-mixed \
+VALUE_SIZES=128 \
+BATCH_TARGET_BYTES=102400 \
+TREEDB_READ_INTEGRITIES=verify,unsafe-skip-checksums \
+ITERATION_MODES=value,key-only \
   scripts/treedb_geth_hot_kv_matrix.sh
 ```
 

--- a/benchmarks/geth_hot_kv/harness_test.go
+++ b/benchmarks/geth_hot_kv/harness_test.go
@@ -7,11 +7,7 @@ import (
 )
 
 func TestHarnessPreservesIntegratedGethWorkloadShape(t *testing.T) {
-	blob, err := os.ReadFile("testdata/treedb_nitro_soak.go")
-	if err != nil {
-		t.Fatal(err)
-	}
-	src := string(blob)
+	src := readHarnessSource(t)
 	for _, want := range []string{
 		"OpenDatabase(\"chaindata\"",
 		"DBEngine: engine",
@@ -32,4 +28,46 @@ func TestHarnessPreservesIntegratedGethWorkloadShape(t *testing.T) {
 			t.Fatalf("harness missing %q", want)
 		}
 	}
+}
+
+func TestHarnessExposesReadIntegrityIterationAndCounterLabels(t *testing.T) {
+	src := readHarnessSource(t)
+	for _, want := range []string{
+		`"treedb-read-integrity"`,
+		`"unsafe-skip-checksums"`,
+		`"iteration-mode"`,
+		`json:"treedb_read_integrity"`,
+		`json:"read_integrity"`,
+		`json:"iteration_mode"`,
+		`json:"stat_delta,omitempty"`,
+		"TreeDB read-integrity",
+		"iteration mode",
+		"treedb.vlog.read.crc32_checks_total",
+		"treedb.cache.vlog_read.crc32_checks_total",
+		"treedb.vlog.grouped_frame_cache.hits",
+		"treedb.cache.vlog_grouped_frame_cache.hits",
+	} {
+		if !strings.Contains(src, want) {
+			t.Fatalf("harness missing instrumentation label %q", want)
+		}
+	}
+}
+
+func TestHarnessKeyOnlyIterationDoesNotMaterializeValues(t *testing.T) {
+	src := readHarnessSource(t)
+	if !strings.Contains(src, "if mode == iterationModeValue {\n\t\t\t_ = it.Value()\n\t\t}") {
+		t.Fatalf("iterateData must guard Iterator.Value() behind value iteration mode")
+	}
+	if got := strings.Count(src, ".Value()"); got != 1 {
+		t.Fatalf("harness has %d Iterator.Value() calls, want exactly the guarded iterateData call", got)
+	}
+}
+
+func readHarnessSource(t *testing.T) string {
+	t.Helper()
+	blob, err := os.ReadFile("testdata/treedb_nitro_soak.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(blob)
 }

--- a/benchmarks/geth_hot_kv/testdata/treedb_nitro_soak.go
+++ b/benchmarks/geth_hot_kv/testdata/treedb_nitro_soak.go
@@ -13,6 +13,7 @@ import (
 	"runtime"
 	"runtime/pprof"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -39,6 +40,12 @@ const (
 	phaseIterate     = "iterate"
 	phaseDeleteRange = "delete_range"
 	phaseReopen      = "reopen_verify"
+
+	iterationModeValue   = "value"
+	iterationModeKeyOnly = "key-only"
+
+	readIntegrityVerify     = "verify"
+	readIntegrityUnsafeSkip = "unsafe-skip-checksums"
 )
 
 type config struct {
@@ -51,6 +58,8 @@ type config struct {
 	BatchTargetBytes     int      `json:"batch_target_bytes"`
 	DeleteRangeWidth     int      `json:"delete_range_width"`
 	DeleteRangesPerBatch int      `json:"delete_ranges_per_batch"`
+	TreeDBReadIntegrity  string   `json:"treedb_read_integrity"`
+	IterationMode        string   `json:"iteration_mode"`
 	Seed                 int64    `json:"seed"`
 	WorkDir              string   `json:"workdir"`
 	Keep                 bool     `json:"keep"`
@@ -61,9 +70,10 @@ type config struct {
 }
 
 type phaseResult struct {
-	DurationMillis int64   `json:"duration_millis"`
-	Ops            int     `json:"ops"`
-	OpsPerSec      float64 `json:"ops_per_sec"`
+	DurationMillis int64            `json:"duration_millis"`
+	Ops            int              `json:"ops"`
+	OpsPerSec      float64          `json:"ops_per_sec"`
+	StatDelta      map[string]int64 `json:"stat_delta,omitempty"`
 }
 
 type memStatsDelta struct {
@@ -83,6 +93,8 @@ type memStatsDelta struct {
 type runResult struct {
 	Engine                string                 `json:"engine"`
 	DBPath                string                 `json:"db_path"`
+	ReadIntegrity         string                 `json:"read_integrity"`
+	IterationMode         string                 `json:"iteration_mode"`
 	WriteOpsPerSec        float64                `json:"write_ops_sec"`
 	ReadOpsPerSec         float64                `json:"read_ops_sec"`
 	IterateKeysPerSec     float64                `json:"iterate_keys_sec"`
@@ -127,6 +139,8 @@ func main() {
 	flag.IntVar(&cfg.BatchTargetBytes, "batch-target-bytes", ethdb.IdealBatchSize, "flush write batches after this queued value size; <=0 writes one final batch")
 	flag.IntVar(&cfg.DeleteRangeWidth, "delete-range-width", 100, "keys covered by each DeleteRange call")
 	flag.IntVar(&cfg.DeleteRangesPerBatch, "delete-ranges-per-batch", 100, "batch DeleteRange calls per batch.Write")
+	flag.StringVar(&cfg.TreeDBReadIntegrity, "treedb-read-integrity", readIntegrityVerify, "TreeDB value-log read integrity: verify|unsafe-skip-checksums (unsafe mode is benchmark-only)")
+	flag.StringVar(&cfg.IterationMode, "iteration-mode", iterationModeValue, "iteration mode: value|key-only")
 	flag.Int64Var(&cfg.Seed, "seed", 1, "deterministic seed")
 	flag.StringVar(&cfg.WorkDir, "workdir", "", "base workdir; defaults to os.MkdirTemp")
 	flag.BoolVar(&cfg.Keep, "keep", false, "keep the workdir after completion")
@@ -140,6 +154,16 @@ func main() {
 	var err error
 	cfg.Engines = splitCSV(enginesCSV)
 	cfg.ProfileEngines = splitCSV(profileEnginesCSV)
+	if normalized, err := normalizeReadIntegrity(cfg.TreeDBReadIntegrity); err != nil {
+		fatalf("%v", err)
+	} else {
+		cfg.TreeDBReadIntegrity = normalized
+	}
+	if normalized, err := normalizeIterationMode(cfg.IterationMode); err != nil {
+		fatalf("%v", err)
+	} else {
+		cfg.IterationMode = normalized
+	}
 	if cfg.N <= 0 || cfg.Reads < 0 || cfg.ValueSize <= 0 || cfg.DeleteRangeWidth <= 0 || cfg.DeleteRangesPerBatch <= 0 {
 		fatalf("invalid non-positive benchmark parameter")
 	}
@@ -214,15 +238,17 @@ func runEngine(cfg config, engine string, data benchmarkData) (runResult, error)
 	defer opened.close()
 
 	run := runResult{
-		Engine:      engine,
-		DBPath:      filepath.Join(dbRoot, "geth", "chaindata"),
-		KeysWritten: len(data.Keys),
-		Reads:       cfg.Reads,
-		Phases:      make(map[string]phaseResult),
+		Engine:        engine,
+		DBPath:        filepath.Join(dbRoot, "geth", "chaindata"),
+		ReadIntegrity: readIntegrityForRun(cfg, engine),
+		IterationMode: cfg.IterationMode,
+		KeysWritten:   len(data.Keys),
+		Reads:         cfg.Reads,
+		Phases:        make(map[string]phaseResult),
 	}
 	profiler := phaseProfiler{cfg: cfg, engine: engine}
 
-	writePhase, err := profiler.time(phaseWrite, func() (int, error) {
+	writePhase, err := timeDBPhase(profiler, opened.db, phaseWrite, func() (int, error) {
 		return writeData(opened.db, cfg, data)
 	})
 	if err != nil {
@@ -231,7 +257,7 @@ func runEngine(cfg config, engine string, data benchmarkData) (runResult, error)
 	run.Phases[phaseWrite] = writePhase
 	run.WriteOpsPerSec = writePhase.OpsPerSec
 
-	readPhase, err := profiler.time(phaseRead, func() (int, error) {
+	readPhase, err := timeDBPhase(profiler, opened.db, phaseRead, func() (int, error) {
 		return readData(opened.db, cfg, data)
 	})
 	if err != nil {
@@ -240,8 +266,8 @@ func runEngine(cfg config, engine string, data benchmarkData) (runResult, error)
 	run.Phases[phaseRead] = readPhase
 	run.ReadOpsPerSec = readPhase.OpsPerSec
 
-	iteratePhase, err := profiler.time(phaseIterate, func() (int, error) {
-		return iterateData(opened.db, len(data.Keys))
+	iteratePhase, err := timeDBPhase(profiler, opened.db, phaseIterate, func() (int, error) {
+		return iterateData(opened.db, len(data.Keys), cfg.IterationMode)
 	})
 	if err != nil {
 		return runResult{}, err
@@ -255,7 +281,7 @@ func runEngine(cfg config, engine string, data benchmarkData) (runResult, error)
 	}
 	run.SizeBytes = loadedSize
 
-	deletePhase, err := profiler.time(phaseDeleteRange, func() (int, error) {
+	deletePhase, err := timeDBPhase(profiler, opened.db, phaseDeleteRange, func() (int, error) {
 		return deleteRanges(opened.db, cfg, data)
 	})
 	if err != nil {
@@ -269,7 +295,7 @@ func runEngine(cfg config, engine string, data benchmarkData) (runResult, error)
 		return runResult{}, err
 	}
 
-	reopenPhase, err := profiler.time(phaseReopen, func() (int, error) {
+	reopenPhase, err := timeDBPhase(profiler, nil, phaseReopen, func() (int, error) {
 		reopened, err := openEngine(dbRoot, engine, false, cfg)
 		if err != nil {
 			return 0, err
@@ -290,7 +316,57 @@ func runEngine(cfg config, engine string, data benchmarkData) (runResult, error)
 	return run, nil
 }
 
+func readIntegrityForRun(cfg config, engine string) string {
+	if !isTreeDBEngine(engine) {
+		return "n/a"
+	}
+	return cfg.TreeDBReadIntegrity
+}
+
+func isTreeDBEngine(engine string) bool {
+	return strings.EqualFold(strings.TrimSpace(engine), "treedb")
+}
+
+func applyTreeDBReadIntegrityEnv(engine, mode string) func() {
+	if !isTreeDBEngine(engine) {
+		return func() {}
+	}
+	return withEnv(map[string]string{
+		"TREEDB_GETH_READ_INTEGRITY": mode,
+		"TREEDB_READ_INTEGRITY":      mode,
+	})
+}
+
+func withEnv(values map[string]string) func() {
+	type prior struct {
+		value string
+		ok    bool
+	}
+	old := make(map[string]prior, len(values))
+	for key, value := range values {
+		prev, ok := os.LookupEnv(key)
+		old[key] = prior{value: prev, ok: ok}
+		if value == "" {
+			_ = os.Unsetenv(key)
+		} else {
+			_ = os.Setenv(key, value)
+		}
+	}
+	return func() {
+		for key, prev := range old {
+			if prev.ok {
+				_ = os.Setenv(key, prev.value)
+			} else {
+				_ = os.Unsetenv(key)
+			}
+		}
+	}
+}
+
 func openEngine(root, engine string, readonly bool, cfg config) (*openedDB, error) {
+	restoreEnv := applyTreeDBReadIntegrityEnv(engine, cfg.TreeDBReadIntegrity)
+	defer restoreEnv()
+
 	stack, err := node.New(&node.Config{
 		DataDir:  root,
 		Name:     "geth",
@@ -372,14 +448,16 @@ func readData(db ethdb.Database, cfg config, data benchmarkData) (int, error) {
 	return read, nil
 }
 
-func iterateData(db ethdb.Database, want int) (int, error) {
+func iterateData(db ethdb.Database, want int, mode string) (int, error) {
 	it := db.NewIterator(nil, nil)
 	defer it.Release()
 	count := 0
 	for it.Next() {
 		count++
 		_ = it.Key()
-		_ = it.Value()
+		if mode == iterationModeValue {
+			_ = it.Value()
+		}
 	}
 	if err := it.Error(); err != nil {
 		return count, err
@@ -648,6 +726,28 @@ func splitCSV(s string) []string {
 	return out
 }
 
+func normalizeReadIntegrity(raw string) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "", readIntegrityVerify, "verified", "checksum-verify", "checksum-verified", "checksums", "on", "true", "1":
+		return readIntegrityVerify, nil
+	case readIntegrityUnsafeSkip, "skip-checksums", "skip", "no-checksums", "none", "off", "false", "0":
+		return readIntegrityUnsafeSkip, nil
+	default:
+		return "", fmt.Errorf("unknown -treedb-read-integrity %q (use verify or unsafe-skip-checksums)", raw)
+	}
+}
+
+func normalizeIterationMode(raw string) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "", iterationModeValue, "values", "value-materialized", "value-iteration":
+		return iterationModeValue, nil
+	case iterationModeKeyOnly, "keys", "key":
+		return iterationModeKeyOnly, nil
+	default:
+		return "", fmt.Errorf("unknown -iteration-mode %q (use value or key-only)", raw)
+	}
+}
+
 func dirSize(root string) (int64, error) {
 	var total int64
 	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
@@ -665,6 +765,86 @@ func dirSize(root string) (int64, error) {
 		return nil
 	})
 	return total, err
+}
+
+type dbStatter interface {
+	Stat() (string, error)
+}
+
+var interestingStatKeys = []string{
+	"treedb.vlog.read.crc32_checks_total",
+	"treedb.cache.vlog_read.crc32_checks_total",
+	"treedb.vlog.grouped_frame_cache.hits",
+	"treedb.vlog.grouped_frame_cache.misses",
+	"treedb.vlog.grouped_frame_cache.stores",
+	"treedb.cache.vlog_grouped_frame_cache.hits",
+	"treedb.cache.vlog_grouped_frame_cache.misses",
+	"treedb.cache.vlog_grouped_frame_cache.stores",
+	"treedb.vlog.mmap_read.hits",
+	"treedb.vlog.mmap_read.fallback_readat",
+	"treedb.cache.vlog_mmap.read.hits",
+	"treedb.cache.vlog_mmap.read.fallback_readat",
+}
+
+func timeDBPhase(profiler phaseProfiler, db ethdb.Database, phase string, fn func() (int, error)) (phaseResult, error) {
+	before := statSnapshot(db)
+	result, err := profiler.time(phase, fn)
+	after := statSnapshot(db)
+	result.StatDelta = statDelta(before, after)
+	return result, err
+}
+
+func statSnapshot(db ethdb.Database) map[string]int64 {
+	statter, ok := db.(dbStatter)
+	if !ok || statter == nil {
+		return nil
+	}
+	raw, err := statter.Stat()
+	if err != nil || raw == "" {
+		return nil
+	}
+	parsed := parseKeyValueStats(raw)
+	out := make(map[string]int64, len(interestingStatKeys))
+	for _, key := range interestingStatKeys {
+		if value, ok := parsed[key]; ok {
+			out[key] = value
+		}
+	}
+	return out
+}
+
+func parseKeyValueStats(raw string) map[string]int64 {
+	out := make(map[string]int64)
+	for _, line := range strings.Split(raw, "\n") {
+		key, value, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+		if key == "" || value == "" {
+			continue
+		}
+		if n, err := strconv.ParseInt(value, 10, 64); err == nil {
+			out[key] = n
+		}
+	}
+	return out
+}
+
+func statDelta(before, after map[string]int64) map[string]int64 {
+	if len(after) == 0 {
+		return nil
+	}
+	out := make(map[string]int64, len(after))
+	for _, key := range interestingStatKeys {
+		post, ok := after[key]
+		if !ok {
+			continue
+		}
+		out[key] = post - before[key]
+	}
+	return out
 }
 
 type phaseProfiler struct {
@@ -765,14 +945,67 @@ func renderSummary(out output) string {
 	fmt.Fprintf(&sb, "- value-size: %d\n", out.Config.ValueSize)
 	fmt.Fprintf(&sb, "- batch-target-bytes: %d\n", out.Config.BatchTargetBytes)
 	fmt.Fprintf(&sb, "- delete-range-width: %d\n", out.Config.DeleteRangeWidth)
+	fmt.Fprintf(&sb, "- TreeDB read-integrity: %s\n", out.Config.TreeDBReadIntegrity)
+	fmt.Fprintf(&sb, "- iteration-mode: %s\n", out.Config.IterationMode)
 	fmt.Fprintf(&sb, "- workdir: %s\n\n", out.Config.WorkDir)
 	sb.WriteString("`size bytes` is measured after write/read/iterate and before the destructive DeleteRange phase; `post-delete bytes` is measured after close/reopen verification.\n\n")
-	sb.WriteString("| engine | write ops/sec | read ops/sec | iterate keys/sec | DeleteRange keys/sec | size bytes | post-delete bytes |\n")
-	sb.WriteString("|---|---:|---:|---:|---:|---:|---:|\n")
+	sb.WriteString("| engine | read integrity | iteration mode | write ops/sec | read ops/sec | iterate keys/sec | DeleteRange keys/sec | size bytes | post-delete bytes |\n")
+	sb.WriteString("|---|---|---|---:|---:|---:|---:|---:|---:|\n")
 	for _, run := range out.Runs {
-		fmt.Fprintf(&sb, "| %s | %.0f | %.0f | %.0f | %.0f | %d | %d |\n", run.Engine, run.WriteOpsPerSec, run.ReadOpsPerSec, run.IterateKeysPerSec, run.DeleteRangeKeysPerSec, run.SizeBytes, run.PostDeleteSizeBytes)
+		fmt.Fprintf(&sb, "| %s | %s | %s | %.0f | %.0f | %.0f | %.0f | %d | %d |\n", run.Engine, run.ReadIntegrity, run.IterationMode, run.WriteOpsPerSec, run.ReadOpsPerSec, run.IterateKeysPerSec, run.DeleteRangeKeysPerSec, run.SizeBytes, run.PostDeleteSizeBytes)
 	}
+	writeStatDeltaSummary(&sb, out.Runs)
 	return sb.String()
+}
+
+func writeStatDeltaSummary(sb *strings.Builder, runs []runResult) {
+	if !hasStatDeltas(runs) {
+		return
+	}
+	sb.WriteString("\n## TreeDB value-log read counters\n\n")
+	sb.WriteString("Per-phase deltas from TreeDB `Stat()` output. CRC counts are value-log record CRC32 computations performed by the read path; grouped-frame counters report the current grouped-frame cache behavior used by follow-up #2678.\n\n")
+	sb.WriteString("| engine | read integrity | iteration mode | phase | crc32 checks | grouped hits | grouped misses | grouped stores | mmap hits | mmap ReadAt fallbacks |\n")
+	sb.WriteString("|---|---|---|---|---:|---:|---:|---:|---:|---:|\n")
+	for _, run := range runs {
+		for _, phase := range []string{phaseWrite, phaseRead, phaseIterate, phaseDeleteRange, phaseReopen} {
+			result, ok := run.Phases[phase]
+			if !ok || len(result.StatDelta) == 0 {
+				continue
+			}
+			fmt.Fprintf(sb, "| %s | %s | %s | %s | %d | %d | %d | %d | %d | %d |\n",
+				run.Engine,
+				run.ReadIntegrity,
+				run.IterationMode,
+				phase,
+				statDeltaValue(result.StatDelta, "treedb.vlog.read.crc32_checks_total", "treedb.cache.vlog_read.crc32_checks_total"),
+				statDeltaValue(result.StatDelta, "treedb.vlog.grouped_frame_cache.hits", "treedb.cache.vlog_grouped_frame_cache.hits"),
+				statDeltaValue(result.StatDelta, "treedb.vlog.grouped_frame_cache.misses", "treedb.cache.vlog_grouped_frame_cache.misses"),
+				statDeltaValue(result.StatDelta, "treedb.vlog.grouped_frame_cache.stores", "treedb.cache.vlog_grouped_frame_cache.stores"),
+				statDeltaValue(result.StatDelta, "treedb.vlog.mmap_read.hits", "treedb.cache.vlog_mmap.read.hits"),
+				statDeltaValue(result.StatDelta, "treedb.vlog.mmap_read.fallback_readat", "treedb.cache.vlog_mmap.read.fallback_readat"),
+			)
+		}
+	}
+}
+
+func hasStatDeltas(runs []runResult) bool {
+	for _, run := range runs {
+		for _, phase := range run.Phases {
+			if len(phase.StatDelta) > 0 {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func statDeltaValue(delta map[string]int64, keys ...string) int64 {
+	for _, key := range keys {
+		if value, ok := delta[key]; ok {
+			return value
+		}
+	}
+	return 0
 }
 
 func perSec(ops int, d time.Duration) float64 {

--- a/scripts/treedb_geth_hot_kv_matrix.sh
+++ b/scripts/treedb_geth_hot_kv_matrix.sh
@@ -20,6 +20,9 @@ Environment overrides:
   VALUE_SHAPES          Comma list. Default: geth-mixed
   VALUE_SIZES           Comma list. Default: 128,512
   BATCH_TARGET_BYTES    Comma list. Default: 102400,1048576
+  TREEDB_READ_INTEGRITIES Comma list of TreeDB modes. Default: verify
+                         Values: verify, unsafe-skip-checksums (unsafe benchmark ceiling)
+  ITERATION_MODES       Comma list. Default: value. Values: value,key-only
   DELETE_RANGE_WIDTH    DeleteRange width. Default: 100
   DELETE_RANGES_PER_BATCH Batch DeleteRange calls per batch.Write. Default: 100
   PROFILE_DIR           Optional pprof output root; profiles only PROFILE_ENGINES.
@@ -38,6 +41,12 @@ Examples:
   # TreeDB profile after selecting a representative shape:
   GETH_REPO=/path/to/go-ethereum ENGINES=treedb KEY_SHAPES=geth-mixed \
     VALUE_SIZES=128 BATCH_TARGET_BYTES=102400 PROFILE_DIR=/tmp/geth_hotkv_profiles \
+    scripts/treedb_geth_hot_kv_matrix.sh
+
+  # TreeDB checksum ceiling and key-only split:
+  GETH_REPO=/path/to/go-ethereum ENGINES=treedb KEY_SHAPES=geth-mixed \
+    VALUE_SIZES=128 BATCH_TARGET_BYTES=102400 \
+    TREEDB_READ_INTEGRITIES=verify,unsafe-skip-checksums ITERATION_MODES=value,key-only \
     scripts/treedb_geth_hot_kv_matrix.sh
 USAGE
 }
@@ -118,6 +127,8 @@ key_shapes=${KEY_SHAPES:-geth-mixed,single-prefix}
 value_shapes=${VALUE_SHAPES:-geth-mixed}
 value_sizes=${VALUE_SIZES:-128,512}
 batch_targets=${BATCH_TARGET_BYTES:-102400,1048576}
+treedb_read_integrities=${TREEDB_READ_INTEGRITIES:-verify}
+iteration_modes=${ITERATION_MODES:-value}
 delete_range_width=${DELETE_RANGE_WIDTH:-100}
 delete_ranges_per_batch=${DELETE_RANGES_PER_BATCH:-100}
 profile_engines=${PROFILE_ENGINES:-treedb}
@@ -127,56 +138,62 @@ IFS=, read -r -a key_shape_arr <<< "$key_shapes"
 IFS=, read -r -a value_shape_arr <<< "$value_shapes"
 IFS=, read -r -a value_size_arr <<< "$value_sizes"
 IFS=, read -r -a batch_target_arr <<< "$batch_targets"
+IFS=, read -r -a read_integrity_arr <<< "$treedb_read_integrities"
+IFS=, read -r -a iteration_mode_arr <<< "$iteration_modes"
 
 summary_tsv="$run_dir/matrix_results.tsv"
 summary_md="$run_dir/matrix_results.md"
 : > "$summary_tsv"
-printf 'key_shape\tvalue_shape\tvalue_size\tbatch_target_bytes\tengine\twrite_ops_sec\tread_ops_sec\titerate_keys_sec\tdelete_range_keys_sec\tsize_bytes\tpost_delete_size_bytes\tjson\n' >> "$summary_tsv"
+printf 'key_shape\tvalue_shape\tvalue_size\tbatch_target_bytes\ttreedb_read_integrity\titeration_mode\tengine\tread_integrity\twrite_ops_sec\tread_ops_sec\titerate_keys_sec\tdelete_range_keys_sec\tsize_bytes\tpost_delete_size_bytes\tjson\n' >> "$summary_tsv"
 
 run_index=0
 for key_shape in "${key_shape_arr[@]}"; do
   for value_shape in "${value_shape_arr[@]}"; do
     for value_size in "${value_size_arr[@]}"; do
       for batch_target in "${batch_target_arr[@]}"; do
-        run_index=$((run_index + 1))
-        label="$(printf '%02d' "$run_index")_${key_shape}_${value_shape}_v${value_size}_b${batch_target}"
-        label=${label//[^A-Za-z0-9_.-]/_}
-        case_dir="$run_dir/$label"
-        mkdir -p "$case_dir"
-        json_out="$case_dir/results.json"
-        stdout_log="$case_dir/stdout.md"
-        stderr_log="$case_dir/stderr.log"
-        workdir="$case_dir/db"
-        args=(
-          "$harness"
-          -n "$keys"
-          -reads "$reads"
-          -engines "$engines"
-          -key-shape "$key_shape"
-          -value-shape "$value_shape"
-          -value-size "$value_size"
-          -batch-target-bytes "$batch_target"
-          -delete-range-width "$delete_range_width"
-          -delete-ranges-per-batch "$delete_ranges_per_batch"
-          -workdir "$workdir"
-          -out "$json_out"
-        )
-        if [[ "$keep" == "true" ]]; then
-          args+=( -keep )
-        fi
-        if [[ -n "$profile_dir" ]]; then
-          case_profile_dir="$profile_dir/$label"
-          mkdir -p "$case_profile_dir"
-          args+=( -profile-dir "$case_profile_dir" -profile-engines "$profile_engines" )
-        fi
-        echo "[matrix] $label" | tee -a "$run_dir/matrix.log"
-        (
-          cd "$geth_repo"
-          go run "${args[@]}"
-        ) > "$stdout_log" 2> "$stderr_log"
-        python3 - "$json_out" "$summary_tsv" "$key_shape" "$value_shape" "$value_size" "$batch_target" <<'PY'
+        for read_integrity in "${read_integrity_arr[@]}"; do
+          for iteration_mode in "${iteration_mode_arr[@]}"; do
+            run_index=$((run_index + 1))
+            label="$(printf '%02d' "$run_index")_${key_shape}_${value_shape}_v${value_size}_b${batch_target}_${read_integrity}_${iteration_mode}"
+            label=${label//[^A-Za-z0-9_.-]/_}
+            case_dir="$run_dir/$label"
+            mkdir -p "$case_dir"
+            json_out="$case_dir/results.json"
+            stdout_log="$case_dir/stdout.md"
+            stderr_log="$case_dir/stderr.log"
+            workdir="$case_dir/db"
+            args=(
+              "$harness"
+              -n "$keys"
+              -reads "$reads"
+              -engines "$engines"
+              -key-shape "$key_shape"
+              -value-shape "$value_shape"
+              -value-size "$value_size"
+              -batch-target-bytes "$batch_target"
+              -treedb-read-integrity "$read_integrity"
+              -iteration-mode "$iteration_mode"
+              -delete-range-width "$delete_range_width"
+              -delete-ranges-per-batch "$delete_ranges_per_batch"
+              -workdir "$workdir"
+              -out "$json_out"
+            )
+            if [[ "$keep" == "true" ]]; then
+              args+=( -keep )
+            fi
+            if [[ -n "$profile_dir" ]]; then
+              case_profile_dir="$profile_dir/$label"
+              mkdir -p "$case_profile_dir"
+              args+=( -profile-dir "$case_profile_dir" -profile-engines "$profile_engines" )
+            fi
+            echo "[matrix] $label" | tee -a "$run_dir/matrix.log"
+            (
+              cd "$geth_repo"
+              go run "${args[@]}"
+            ) > "$stdout_log" 2> "$stderr_log"
+            python3 - "$json_out" "$summary_tsv" "$key_shape" "$value_shape" "$value_size" "$batch_target" "$read_integrity" "$iteration_mode" <<'PY'
 import json, sys
-json_path, tsv_path, key_shape, value_shape, value_size, batch_target = sys.argv[1:]
+json_path, tsv_path, key_shape, value_shape, value_size, batch_target, treedb_read_integrity, iteration_mode = sys.argv[1:]
 with open(json_path) as f:
     doc = json.load(f)
 with open(tsv_path, 'a') as out:
@@ -186,7 +203,10 @@ with open(tsv_path, 'a') as out:
             value_shape,
             value_size,
             batch_target,
+            treedb_read_integrity,
+            iteration_mode,
             run['engine'],
+            run.get('read_integrity', 'n/a'),
             f"{run['write_ops_sec']:.0f}",
             f"{run['read_ops_sec']:.0f}",
             f"{run['iterate_keys_sec']:.0f}",
@@ -196,9 +216,11 @@ with open(tsv_path, 'a') as out:
             json_path,
         ]) + '\n')
 PY
-        if [[ "$keep" != "true" ]]; then
-          rm -rf "$workdir"
-        fi
+            if [[ "$keep" != "true" ]]; then
+              rm -rf "$workdir"
+            fi
+          done
+        done
       done
     done
   done
@@ -219,22 +241,23 @@ def fmt(n):
 
 with open(md, 'w') as out:
     out.write('# geth/Nitro hot KV matrix\n\n')
-    out.write('Integrated node.OpenDatabase / ethdb benchmark. DeleteRange keys/sec counts affected keys/sec, not range calls/sec. Size bytes is loaded DB size before destructive DeleteRange; post-delete bytes is measured after close/reopen verification.\n\n')
-    out.write('| key shape | value shape | value size | batch target bytes | engine | write ops/sec | read ops/sec | iterate keys/sec | DeleteRange keys/sec | size bytes | post-delete bytes |\n')
-    out.write('|---|---|---:|---:|---|---:|---:|---:|---:|---:|---:|\n')
+    out.write('Integrated node.OpenDatabase / ethdb benchmark. DeleteRange keys/sec counts affected keys/sec, not range calls/sec. Size bytes is loaded DB size before destructive DeleteRange; post-delete bytes is measured after close/reopen verification. TreeDB read-integrity labels identify checksum-verified runs and the explicitly unsafe checksum-disabled ceiling. Iteration mode labels distinguish value materialization from key-only traversal.\n\n')
+    out.write('| key shape | value shape | value size | batch target bytes | TreeDB read-integrity | iteration mode | engine | run read-integrity | write ops/sec | read ops/sec | iterate keys/sec | DeleteRange keys/sec | size bytes | post-delete bytes |\n')
+    out.write('|---|---|---:|---:|---|---|---|---|---:|---:|---:|---:|---:|---:|\n')
     for r in rows:
-        out.write('| {key_shape} | {value_shape} | {value_size} | {batch_target_bytes} | {engine} | {write} | {read} | {iterate} | {delete} | {size} | {post_delete} |\n'.format(
+        out.write('| {key_shape} | {value_shape} | {value_size} | {batch_target_bytes} | {treedb_read_integrity} | {iteration_mode} | {engine} | {read_integrity} | {write} | {read} | {iterate} | {delete} | {size} | {post_delete} |\n'.format(
             key_shape=r['key_shape'], value_shape=r['value_shape'], value_size=fmt(r['value_size']),
-            batch_target_bytes=fmt(r['batch_target_bytes']), engine=r['engine'], write=fmt(r['write_ops_sec']),
+            batch_target_bytes=fmt(r['batch_target_bytes']), treedb_read_integrity=r['treedb_read_integrity'],
+            iteration_mode=r['iteration_mode'], engine=r['engine'], read_integrity=r['read_integrity'], write=fmt(r['write_ops_sec']),
             read=fmt(r['read_ops_sec']), iterate=fmt(r['iterate_keys_sec']), delete=fmt(r['delete_range_keys_sec']),
             size=fmt(r['size_bytes']), post_delete=fmt(r['post_delete_size_bytes'])))
     out.write('\n## TreeDB ratios versus Pebble\n\n')
     groups = defaultdict(dict)
     for r in rows:
-        key = (r['key_shape'], r['value_shape'], r['value_size'], r['batch_target_bytes'])
+        key = (r['key_shape'], r['value_shape'], r['value_size'], r['batch_target_bytes'], r['treedb_read_integrity'], r['iteration_mode'])
         groups[key][r['engine']] = r
-    out.write('| key shape | value shape | value size | batch target bytes | write ratio | read ratio | iterate ratio | DeleteRange ratio | size ratio |\n')
-    out.write('|---|---|---:|---:|---:|---:|---:|---:|---:|\n')
+    out.write('| key shape | value shape | value size | batch target bytes | TreeDB read-integrity | iteration mode | write ratio | read ratio | iterate ratio | DeleteRange ratio | size ratio |\n')
+    out.write('|---|---|---:|---:|---|---|---:|---:|---:|---:|---:|\n')
     for key in sorted(groups):
         g = groups[key]
         if 'treedb' not in g or 'pebble' not in g:
@@ -246,8 +269,8 @@ with open(md, 'w') as out:
             if pv == 0:
                 return 'n/a'
             return f"{tv/pv:.3f}x"
-        out.write('| {} | {} | {} | {} | {} | {} | {} | {} | {} |\n'.format(
-            key[0], key[1], fmt(key[2]), fmt(key[3]), ratio('write_ops_sec'), ratio('read_ops_sec'),
+        out.write('| {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} |\n'.format(
+            key[0], key[1], fmt(key[2]), fmt(key[3]), key[4], key[5], ratio('write_ops_sec'), ratio('read_ops_sec'),
             ratio('iterate_keys_sec'), ratio('delete_range_keys_sec'), ratio('size_bytes')))
 PY
 


### PR DESCRIPTION
## Objective

Closes #2677. Adds the geth-hot-KV measurement seams needed before #2678: explicit TreeDB read-integrity mode, key-only iteration mode, labeled JSON/Markdown output, and value-log CRC/grouped-frame counters.

## Context

Parent tracker: #2676. This is instrumentation only; #2678 owns grouped-record CRC de-dupe and #2679 owns adapter batch rebuild/allocation reductions.

## Non-goals

- Does not make skip-checksum/no-read-integrity behavior the production default.
- Does not implement grouped-record CRC de-dupe.
- Does not optimize geth adapter batch rebuild/allocation behavior.

## Design / Scope

- Harness flags:
  - `-treedb-read-integrity verify|unsafe-skip-checksums` (`verify` default; unsafe mode is benchmark-only).
  - `-iteration-mode value|key-only`; key-only iteration does not call `Iterator.Value()`.
- Output labels:
  - JSON: `config.treedb_read_integrity`, `config.iteration_mode`, `runs[].read_integrity`, `runs[].iteration_mode`, `runs[].phases[phase].stat_delta`.
  - Markdown: read-integrity and iteration-mode columns plus TreeDB value-log counter table in per-run stdout.
- Counters/stat contract for #2678:
  - `treedb.vlog.read.crc32_checks_total`
  - `treedb.cache.vlog_read.crc32_checks_total`
  - `treedb.vlog.grouped_frame_cache.{hits,misses,stores,...}`
  - `treedb.cache.vlog_grouped_frame_cache.{hits,misses,stores,...}`
- Minimal gethethdb adapter hook for integrated `node.OpenDatabase` harnesses:
  - `TREEDB_GETH_READ_INTEGRITY`, fallback `TREEDB_READ_INTEGRITY`.

## Correctness / Tests

Ran locally at head `c9ebe5559e080b75546a0f42d718cfe54d344e33`:

- `go test ./TreeDB/internal/valuelog -count=1`
- `go test ./TreeDB -run 'TestStatsReportsValueLogReadIntegrityAndReadCounters' -count=1`
- `go test ./TreeDB/db ./TreeDB/caching -run '^$' -count=1`
- `(cd TreeDB/integration/gethethdb && go test ./... -count=1)`
- `go test ./benchmarks/geth_hot_kv -count=1`

Review fix rerun after isolating read-integrity env tests:

- `(cd TreeDB/integration/gethethdb && go test ./... -run 'TestResolveTreeDBOptionsReadIntegrity|TestOpenDefaults' -count=1)`
- `(cd TreeDB/integration/gethethdb && go test ./... -count=1)`

## Benchmark Evidence

Used local go-ethereum checkout with a temporary `-modfile` replacing both `github.com/snissn/gomap` and `github.com/snissn/gomap/TreeDB/integration/gethethdb` to this worktree.

Smoke artifacts:

- `/tmp/issue2677_geth_hotkv_smoke_20260612T225522Z/matrix/matrix_results.md`

Representative artifacts:

- `/tmp/issue2677_geth_hotkv_representative_20260612T225601Z/matrix/matrix_results.md`

Representative TreeDB-only 30k/12k, geth-mixed, value size 128, batch target 102400:

| read integrity | iteration mode | read ops/sec | iterate keys/sec | read CRC checks | iterate CRC checks |
|---|---|---:|---:|---:|---:|
| verify | value | 420,128 | 2,174,819 | 2,382 | 6,000 |
| verify | key-only | 450,725 | 19,559,902 | 2,382 | 0 |
| unsafe-skip-checksums | value | 1,030,474 | 15,377,715 | 0 | 0 |
| unsafe-skip-checksums | key-only | 781,793 | 25,706,941 | 0 | 0 |

Smoke TreeDB-only 500/200 confirmed the same labels/counter behavior:

| read integrity | iteration mode | read ops/sec | iterate keys/sec | read CRC checks | iterate CRC checks |
|---|---|---:|---:|---:|---:|
| verify | value | 168,670 | 3,321,354 | 42 | 100 |
| verify | key-only | 172,973 | 10,335,917 | 42 | 0 |
| unsafe-skip-checksums | value | 730,594 | 8,108,064 | 0 | 0 |
| unsafe-skip-checksums | key-only | 879,279 | 11,845,815 | 0 | 0 |

## Rollout / Toggle Plan

Default remains checksum verification. Unsafe skip-checksum is only reachable via explicit harness flag / gethethdb env override and is labeled as `unsafe-skip-checksums` in output.

## AI Review Loop

Not requested yet; PR is opened with local tests and benchmark evidence for coordinator review first.
