### PR TITLE
TreeDB geth adapter: lazily rebuild batches after write

### DIFF
--- a/TreeDB/integration/gethethdb/adapter.go
+++ b/TreeDB/integration/gethethdb/adapter.go
@@ -323,7 +323,11 @@ func (d *Database) newBatch(size int) ethdb.Batch {
 	if inner == nil {
 		return newClosedBatch(ErrClosed)
 	}
-	return &Batch{db: d, inner: inner}
+	var ops []batchOp
+	if reserve := adapterBatchOpReserveHint(size); reserve > 0 {
+		ops = make([]batchOp, 0, reserve)
+	}
+	return &Batch{db: d, inner: inner, ops: ops}
 }
 
 // NewIterator creates a binary-alphabetical iterator over keys with prefix,
@@ -393,11 +397,12 @@ func prefixUpperBound(prefix []byte) []byte {
 
 // Batch implements ethdb.Batch.
 type Batch struct {
-	db     *Database
-	inner  treedb.Batch
-	size   int
-	closed error
-	ops    []batchOp
+	db           *Database
+	inner        treedb.Batch
+	size         int
+	closed       error
+	ops          []batchOp
+	needsRebuild bool
 }
 
 var _ ethdb.Batch = (*Batch)(nil)
@@ -416,8 +421,62 @@ type batchOp struct {
 	value []byte
 }
 
+// Keep adapter op-log reserves bounded because geth-style NewBatchWithSize
+// callers often pass byte budgets, not exact operation counts.
+const (
+	adapterBatchOpHintExactEntryReserveMax = 8 * 1024
+	adapterBatchOpHintApproxBytesPerEntry  = 256
+	adapterBatchOpHintNormalizedEntryCap   = adapterBatchOpHintExactEntryReserveMax
+)
+
+func adapterBatchOpReserveHint(size int) int {
+	if size <= 0 {
+		return 0
+	}
+	if size <= adapterBatchOpHintExactEntryReserveMax {
+		return size
+	}
+	entries := size / adapterBatchOpHintApproxBytesPerEntry
+	if size%adapterBatchOpHintApproxBytesPerEntry != 0 {
+		entries++
+	}
+	if entries < 1 {
+		return 1
+	}
+	if entries > adapterBatchOpHintNormalizedEntryCap {
+		return adapterBatchOpHintNormalizedEntryCap
+	}
+	return entries
+}
+
+type batchSetViewer interface {
+	SetView(key, value []byte) error
+}
+
+type batchDeleteViewer interface {
+	DeleteView(key []byte) error
+}
+
 func (b *Batch) recordOp(op batchOp) {
 	b.ops = append(b.ops, op)
+}
+
+func (b *Batch) clearOps() {
+	if len(b.ops) == 0 {
+		return
+	}
+	clear(b.ops)
+	b.ops = b.ops[:0]
+}
+
+func (b *Batch) ensureInnerReady() error {
+	if b == nil || b.inner == nil {
+		return ErrClosed
+	}
+	if !b.needsRebuild {
+		return nil
+	}
+	return b.rebuildInnerFromOps()
 }
 
 func (b *Batch) applyOpToInner(op batchOp) error {
@@ -426,8 +485,14 @@ func (b *Batch) applyOpToInner(op batchOp) error {
 	}
 	switch op.kind {
 	case batchOpPut:
+		if setter, ok := b.inner.(batchSetViewer); ok {
+			return setter.SetView(op.key, op.value)
+		}
 		return b.inner.Set(op.key, op.value)
 	case batchOpDelete:
+		if deleter, ok := b.inner.(batchDeleteViewer); ok {
+			return deleter.DeleteView(op.key)
+		}
 		return b.inner.Delete(op.key)
 	case batchOpDeleteRange:
 		return b.inner.DeleteRange(op.key, op.value)
@@ -453,10 +518,14 @@ func (b *Batch) Put(key []byte, value []byte) error {
 		b.size += len(key) + len(value)
 		return nil
 	}
-	if err := b.inner.Set(key, value); err != nil {
+	if err := b.ensureInnerReady(); err != nil {
 		return err
 	}
-	b.recordOp(batchOp{kind: batchOpPut, key: cloneBytes(key), value: cloneBytes(value)})
+	op := batchOp{kind: batchOpPut, key: cloneBytes(key), value: cloneBytes(value)}
+	if err := b.applyOpToInner(op); err != nil {
+		return err
+	}
+	b.recordOp(op)
 	b.size += len(key) + len(value)
 	return nil
 }
@@ -471,10 +540,14 @@ func (b *Batch) Delete(key []byte) error {
 		b.size += len(key)
 		return nil
 	}
-	if err := b.inner.Delete(key); err != nil {
+	if err := b.ensureInnerReady(); err != nil {
 		return err
 	}
-	b.recordOp(batchOp{kind: batchOpDelete, key: cloneBytes(key)})
+	op := batchOp{kind: batchOpDelete, key: cloneBytes(key)}
+	if err := b.applyOpToInner(op); err != nil {
+		return err
+	}
+	b.recordOp(op)
 	b.size += len(key)
 	return nil
 }
@@ -489,10 +562,14 @@ func (b *Batch) DeleteRange(start, end []byte) error {
 		b.size += len(start) + len(end)
 		return nil
 	}
-	if err := b.inner.DeleteRange(start, end); err != nil {
+	if err := b.ensureInnerReady(); err != nil {
 		return err
 	}
-	b.recordOp(batchOp{kind: batchOpDeleteRange, key: cloneBytes(start), value: cloneBytes(end)})
+	op := batchOp{kind: batchOpDeleteRange, key: cloneBytes(start), value: cloneBytes(end)}
+	if err := b.applyOpToInner(op); err != nil {
+		return err
+	}
+	b.recordOp(op)
 	b.size += len(start) + len(end)
 	return nil
 }
@@ -517,10 +594,19 @@ func (b *Batch) Write() error {
 	if b.db == nil || b.db.closed.Load() {
 		return ErrClosed
 	}
+	if err := b.ensureInnerReady(); err != nil {
+		return err
+	}
 	if err := b.inner.Write(); err != nil {
 		return err
 	}
-	return b.rebuildInnerFromOps()
+	// TreeDB command-WAL batches reset their inner state after Write. Keep the
+	// adapter's ethdb-visible operation log, but rebuild the inner batch only if
+	// a later Write or mutation actually reuses it. The common Write+Reset path
+	// can then discard the op log without paying for a rebuild that Reset would
+	// immediately throw away.
+	b.needsRebuild = len(b.ops) > 0
+	return nil
 }
 
 func (b *Batch) rebuildInnerFromOps() error {
@@ -550,6 +636,7 @@ func (b *Batch) rebuildInnerFromOps() error {
 			return err
 		}
 	}
+	b.needsRebuild = false
 	return nil
 }
 
@@ -559,24 +646,24 @@ func (b *Batch) Reset() {
 		return
 	}
 	b.size = 0
-	b.ops = b.ops[:0]
-	if b.inner == nil {
-		return
+	b.needsRebuild = false
+	if b.inner != nil {
+		if resetter, ok := b.inner.(interface{ Reset() }); ok {
+			resetter.Reset()
+		} else {
+			_ = b.inner.Close()
+			b.inner = nil
+			if b.db == nil || b.db.closed.Load() || b.db.db == nil {
+				b.closed = ErrClosed
+			} else {
+				b.inner = b.db.db.NewBatch()
+				if b.inner == nil {
+					b.closed = ErrClosed
+				}
+			}
+		}
 	}
-	if resetter, ok := b.inner.(interface{ Reset() }); ok {
-		resetter.Reset()
-		return
-	}
-	_ = b.inner.Close()
-	b.inner = nil
-	if b.db == nil || b.db.closed.Load() || b.db.db == nil {
-		b.closed = ErrClosed
-		return
-	}
-	b.inner = b.db.db.NewBatch()
-	if b.inner == nil {
-		b.closed = ErrClosed
-	}
+	b.clearOps()
 }
 
 // Replay replays the batch contents in submitted order. TreeDB's internal
@@ -625,6 +712,7 @@ func (b *Batch) Close() {
 	}
 	_ = b.inner.Close()
 	b.inner = nil
+	b.needsRebuild = false
 	b.closed = ErrClosed
 }
 

--- a/TreeDB/integration/gethethdb/adapter_test.go
+++ b/TreeDB/integration/gethethdb/adapter_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/ethdb/dbtest"
 	treedb "github.com/snissn/gomap/TreeDB"
+	treebatch "github.com/snissn/gomap/TreeDB/batch"
 )
 
 func openTestDB(t testing.TB) *Database {
@@ -343,6 +344,223 @@ func TestBatchWriteWithoutResetPreservesContents(t *testing.T) {
 	assertMissing(t, db, []byte("b"))
 }
 
+func TestBatchWriteThenImmediateResetSkipsLazyRebuild(t *testing.T) {
+	inner := &countingTreeBatch{}
+	batch := &Batch{db: &Database{}, inner: inner}
+	if err := batch.Put([]byte("a"), []byte("1")); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	if got := inner.applyCalls(); got != 1 {
+		t.Fatalf("inner apply calls before Write=%d want 1", got)
+	}
+	if err := batch.Write(); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if !batch.needsRebuild {
+		t.Fatal("batch should mark inner rebuild as lazy after Write")
+	}
+	batch.Reset()
+	if batch.needsRebuild {
+		t.Fatal("Reset should discard lazy rebuild requirement")
+	}
+	if got := batch.ValueSize(); got != 0 {
+		t.Fatalf("ValueSize after Reset=%d want 0", got)
+	}
+	if got := len(batch.ops); got != 0 {
+		t.Fatalf("ops after Reset len=%d want 0", got)
+	}
+	if got := inner.applyCalls(); got != 1 {
+		t.Fatalf("inner apply calls after Write+Reset=%d want 1 (no rebuild)", got)
+	}
+	if inner.writeCalls != 1 {
+		t.Fatalf("inner Write calls=%d want 1", inner.writeCalls)
+	}
+	if inner.resetCalls != 1 {
+		t.Fatalf("inner Reset calls=%d want 1", inner.resetCalls)
+	}
+}
+
+func TestBatchWriteThenReplayPreservesOperations(t *testing.T) {
+	db := openTestDB(t)
+	batch := db.NewBatch()
+	if err := batch.Put([]byte("b"), []byte("1")); err != nil {
+		t.Fatal(err)
+	}
+	if err := batch.Delete([]byte("a")); err != nil {
+		t.Fatal(err)
+	}
+	if err := batch.DeleteRange([]byte("m"), []byte("z")); err != nil {
+		t.Fatal(err)
+	}
+	if err := batch.Write(); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	var rec replayRecorder
+	if err := batch.Replay(&rec); err != nil {
+		t.Fatalf("Replay after Write: %v", err)
+	}
+	want := []string{"put:b=1", "delete:a", "delete-range:m..z"}
+	if !slices.Equal(rec.ops, want) {
+		t.Fatalf("replay after Write ops=%v want %v", rec.ops, want)
+	}
+}
+
+func TestBatchClonesCallerBuffersForWriteReplayAndReuse(t *testing.T) {
+	db := openTestDB(t)
+	batch := db.NewBatch()
+	key := []byte("key-a")
+	value := []byte("value-a")
+	if err := batch.Put(key, value); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	copy(key, "key-b")
+	copy(value, "value-b")
+	if err := batch.Write(); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	assertValue(t, db, []byte("key-a"), []byte("value-a"))
+	assertMissing(t, db, []byte("key-b"))
+
+	var rec replayRecorder
+	if err := batch.Replay(&rec); err != nil {
+		t.Fatalf("Replay: %v", err)
+	}
+	if want := []string{"put:key-a=value-a"}; !slices.Equal(rec.ops, want) {
+		t.Fatalf("replay ops=%v want %v", rec.ops, want)
+	}
+
+	if err := db.Delete([]byte("key-a")); err != nil {
+		t.Fatalf("external Delete: %v", err)
+	}
+	if err := batch.Write(); err != nil {
+		t.Fatalf("repeated Write: %v", err)
+	}
+	assertValue(t, db, []byte("key-a"), []byte("value-a"))
+}
+
+func TestBatchDeleteAndDeleteRangeCloneCallerBuffersForReplayAndReuse(t *testing.T) {
+	db := openTestDB(t)
+	for _, key := range []string{"aa", "bb", "bc", "za", "zb"} {
+		if err := db.Put([]byte(key), []byte("v-"+key)); err != nil {
+			t.Fatalf("Put %s: %v", key, err)
+		}
+	}
+	batch := db.NewBatch()
+	deleteKey := []byte("aa")
+	rangeStart := []byte("bb")
+	rangeEnd := []byte("bd")
+	if err := batch.Delete(deleteKey); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if err := batch.DeleteRange(rangeStart, rangeEnd); err != nil {
+		t.Fatalf("DeleteRange: %v", err)
+	}
+	copy(deleteKey, "za")
+	copy(rangeStart, "za")
+	copy(rangeEnd, "zz")
+	if err := batch.Write(); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	for _, key := range [][]byte{[]byte("aa"), []byte("bb"), []byte("bc")} {
+		assertMissing(t, db, key)
+	}
+	for _, key := range [][]byte{[]byte("za"), []byte("zb")} {
+		assertValue(t, db, key, append([]byte("v-"), key...))
+	}
+
+	var rec replayRecorder
+	if err := batch.Replay(&rec); err != nil {
+		t.Fatalf("Replay: %v", err)
+	}
+	want := []string{"delete:aa", "delete-range:bb..bd"}
+	if !slices.Equal(rec.ops, want) {
+		t.Fatalf("replay ops=%v want %v", rec.ops, want)
+	}
+
+	for _, key := range []string{"aa", "bb", "bc"} {
+		if err := db.Put([]byte(key), []byte("again-"+key)); err != nil {
+			t.Fatalf("restore %s: %v", key, err)
+		}
+	}
+	if err := batch.Write(); err != nil {
+		t.Fatalf("repeated Write: %v", err)
+	}
+	for _, key := range [][]byte{[]byte("aa"), []byte("bb"), []byte("bc")} {
+		assertMissing(t, db, key)
+	}
+	for _, key := range [][]byte{[]byte("za"), []byte("zb")} {
+		assertValue(t, db, key, append([]byte("v-"), key...))
+	}
+}
+
+func TestBatchCloseKeepsClosedMutationCompatibility(t *testing.T) {
+	db := openTestDB(t)
+	batch := db.NewBatch()
+	if err := batch.Put([]byte("before-close"), []byte("v")); err != nil {
+		t.Fatalf("Put before close: %v", err)
+	}
+	closer, ok := batch.(interface{ Close() })
+	if !ok {
+		t.Fatal("batch does not expose Close")
+	}
+	closer.Close()
+	if err := batch.Put([]byte("after-close"), []byte("v")); err != nil {
+		t.Fatalf("Put after batch Close err=%v, want nil", err)
+	}
+	if err := batch.DeleteRange([]byte("a"), []byte("b")); err != nil {
+		t.Fatalf("DeleteRange after batch Close err=%v, want nil", err)
+	}
+	if got := batch.ValueSize(); got == 0 {
+		t.Fatal("closed batch ValueSize=0 after queued ops")
+	}
+	if err := batch.Write(); !errors.Is(err, ErrClosed) {
+		t.Fatalf("closed batch Write err=%v want ErrClosed", err)
+	}
+	batch.Reset()
+	if got := batch.ValueSize(); got != 0 {
+		t.Fatalf("closed batch ValueSize after Reset=%d want 0", got)
+	}
+	var rec replayRecorder
+	if err := batch.Replay(&rec); err != nil {
+		t.Fatalf("Replay after Reset: %v", err)
+	}
+	if len(rec.ops) != 0 {
+		t.Fatalf("Replay after Reset ops=%v want none", rec.ops)
+	}
+}
+
+func TestAdapterBatchOpReserveHint(t *testing.T) {
+	for _, tc := range []struct {
+		size int
+		want int
+	}{
+		{size: -1, want: 0},
+		{size: 0, want: 0},
+		{size: 16, want: 16},
+		{size: 8 * 1024, want: 8 * 1024},
+		{size: 102400, want: 400},
+	} {
+		if got := adapterBatchOpReserveHint(tc.size); got != tc.want {
+			t.Fatalf("adapterBatchOpReserveHint(%d)=%d want %d", tc.size, got, tc.want)
+		}
+	}
+}
+
+func TestNewBatchWithSizePreallocatesAdapterOpLogConservatively(t *testing.T) {
+	db := openTestDB(t)
+	small, ok := db.NewBatchWithSize(16).(*Batch)
+	if !ok {
+		t.Fatalf("NewBatchWithSize type=%T want *Batch", db.NewBatchWithSize(16))
+	}
+	if got := cap(small.ops); got < 16 {
+		t.Fatalf("small op log cap=%d want at least 16", got)
+	}
+	large := db.NewBatchWithSize(102400).(*Batch)
+	if got, want := cap(large.ops), adapterBatchOpReserveHint(102400); got != want {
+		t.Fatalf("large byte-hint op log cap=%d want %d", got, want)
+	}
+}
+
 func TestIteratorPrefixStart(t *testing.T) {
 	db := openTestDB(t)
 	for _, key := range []string{"ka1", "ka2", "ka3", "ka4", "ka5", "kb1"} {
@@ -482,6 +700,74 @@ func TestDBLevelDeleteRangeCallsPublicTreeDBDeleteRangeDirectly(t *testing.T) {
 	if strings.Contains(method, "NewBatch") {
 		t.Fatalf("Database.DeleteRange contains adapter-side batch path; body:\n%s", method)
 	}
+}
+
+type countingTreeBatch struct {
+	setCalls         int
+	setViewCalls     int
+	deleteCalls      int
+	deleteViewCalls  int
+	deleteRangeCalls int
+	writeCalls       int
+	writeSyncCalls   int
+	resetCalls       int
+	closeCalls       int
+}
+
+func (b *countingTreeBatch) applyCalls() int {
+	return b.setCalls + b.setViewCalls + b.deleteCalls + b.deleteViewCalls + b.deleteRangeCalls
+}
+
+func (b *countingTreeBatch) Set(_, _ []byte) error {
+	b.setCalls++
+	return nil
+}
+
+func (b *countingTreeBatch) SetView(_, _ []byte) error {
+	b.setViewCalls++
+	return nil
+}
+
+func (b *countingTreeBatch) Delete(_ []byte) error {
+	b.deleteCalls++
+	return nil
+}
+
+func (b *countingTreeBatch) DeleteView(_ []byte) error {
+	b.deleteViewCalls++
+	return nil
+}
+
+func (b *countingTreeBatch) DeleteRange(_, _ []byte) error {
+	b.deleteRangeCalls++
+	return nil
+}
+
+func (b *countingTreeBatch) Write() error {
+	b.writeCalls++
+	return nil
+}
+
+func (b *countingTreeBatch) WriteSync() error {
+	b.writeSyncCalls++
+	return nil
+}
+
+func (b *countingTreeBatch) Close() error {
+	b.closeCalls++
+	return nil
+}
+
+func (b *countingTreeBatch) Reset() {
+	b.resetCalls++
+}
+
+func (b *countingTreeBatch) Replay(func(treebatch.Entry) error) error {
+	return nil
+}
+
+func (b *countingTreeBatch) GetByteSize() (int, error) {
+	return 0, nil
 }
 
 type replayRecorder struct {

--- a/TreeDB/integration/gethethdb/bench_test.go
+++ b/TreeDB/integration/gethethdb/bench_test.go
@@ -24,6 +24,10 @@ func BenchmarkAdapterVsDirect(b *testing.B) {
 		b.Run("adapter", benchAdapterBatchWrite)
 		b.Run("direct", benchDirectBatchWrite)
 	})
+	b.Run("BatchWriteReset", func(b *testing.B) {
+		b.Run("adapter", benchAdapterBatchWriteReset)
+		b.Run("direct", benchDirectBatchWriteReset)
+	})
 	b.Run("Iterator", func(b *testing.B) {
 		b.Run("adapter", benchAdapterIterator)
 		b.Run("direct", benchDirectIterator)
@@ -123,6 +127,50 @@ func benchDirectBatchWrite(b *testing.B) {
 		if err := batch.Write(); err != nil {
 			b.Fatal(err)
 		}
+	}
+}
+
+func benchAdapterBatchWriteReset(b *testing.B) {
+	db := openBenchAdapter(b)
+	defer db.Close()
+	batch := db.NewBatchWithSize(16)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		base := i * 16
+		for j := 0; j < 16; j++ {
+			if err := batch.Put(benchKey(base+j), benchValue); err != nil {
+				b.Fatal(err)
+			}
+		}
+		if err := batch.Write(); err != nil {
+			b.Fatal(err)
+		}
+		batch.Reset()
+	}
+}
+
+func benchDirectBatchWriteReset(b *testing.B) {
+	db := openBenchTreeDB(b)
+	defer db.Close()
+	batch := db.NewBatchWithSize(16)
+	resetter, ok := batch.(interface{ Reset() })
+	if !ok {
+		b.Fatal("direct TreeDB batch does not support Reset")
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		base := i * 16
+		for j := 0; j < 16; j++ {
+			if err := batch.Set(benchKey(base+j), benchValue); err != nil {
+				b.Fatal(err)
+			}
+		}
+		if err := batch.Write(); err != nil {
+			b.Fatal(err)
+		}
+		resetter.Reset()
 	}
 }
 


### PR DESCRIPTION
## Objective

Optimize the TreeDB geth `ethdb.Batch` adapter by making the inner TreeDB batch rebuild lazy after `Batch.Write`, so write-then-reset callers do not pay for a rebuild that is immediately discarded.

Fixes #2679. Part of #2676.

## Design

- `Batch.Write` now writes the current inner batch and marks it as needing rebuild instead of immediately replaying the adapter op log into a fresh inner batch.
- `Reset` clears the adapter op log and lazy-rebuild state without rebuilding.
- Repeated `Write` or post-write mutation calls `ensureInnerReady`, rebuilding from the copied op log only when the batch is actually reused.
- Adapter op-log slices are conservatively preallocated from `NewBatchWithSize` hints and reused across `Reset`.
- Inner applies use cloned op-log buffers via `SetView`/`DeleteView` where available, preserving caller-buffer ownership semantics.

## Non-goals

- No TreeDB core batch semantics changes.
- No geth-hot-KV read-integrity/profile harness hooks.
- No value-log CRC, DeleteRange core algorithm, or command-WAL durability changes.

## Correctness

Added adapter tests for:

- `Write` followed by immediate `Reset` skipping lazy rebuild.
- `Write` followed by `Replay` preserving submitted operations/order.
- Repeated `Write` preserving point and range delete semantics.
- `ValueSize` through write/reset boundaries.
- Caller-buffer cloning for Put/Delete/DeleteRange.
- Closed batch compatibility.
- Conservative op-log reserve hints.

Tests run at latest head `b8de39a7d58d47c122f1f1e1631513c81e19d9ac`:

- `cd TreeDB/integration/gethethdb && go test ./... -count=1` ✅
- `go test ./TreeDB -count=1` ✅
- `go test ./TreeDB/mongo_gateway -count=1` ✅
- `go test ./... -count=1` ⚠️ one `TreeDB/mongo_gateway` standalone timeout; package rerun above passed.

## Performance

Hardware: Apple M3 / darwin arm64.

Baseline commit: `4e208786ca08adecd1acb99264bb91ef9adea19e` (`origin/main`; benchmark file copied from this PR only to expose the new `BatchWriteReset` benchmark).  
Candidate commit: `b8de39a7d58d47c122f1f1e1631513c81e19d9ac`.

Command:

```sh
cd TreeDB/integration/gethethdb
go test ./... -run '^$' -bench '^BenchmarkAdapterVsDirect$/^(BatchWrite|BatchWriteReset|BatchDeleteRange)$/^adapter$' -benchmem -benchtime=1000x -count=5
```

Benchstat artifact: `/tmp/gomap_2679_currentbase_before_20260612_131138/benchstat_currentbase_before_after.txt`

| benchmark | ns/op before | ns/op after | B/op before | B/op after | allocs/op before | allocs/op after |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| BatchWrite/adapter | 36.15µ | 33.40µ | 121.0Ki | 120.1Ki | 112 | 106 |
| BatchWriteReset/adapter | 35.03µ | 33.89µ | 111.5Ki | 111.4Ki | 86 | 84 |
| BatchDeleteRange/adapter | 89.67µ | 32.97µ | 49.82Ki | 36.54Ki | 182 | 171 |

Raw artifacts:

- Baseline: `/tmp/gomap_2679_currentbase_before_20260612_131138/adapter_fixed_before.txt`
- Candidate: `/tmp/gomap_2679_fixed_after_final_20260612_131035/adapter_fixed_after.txt`

## Review / CI / AI review status

- Internal high-thinking review: no blockers after coverage additions.
- Latest-head CI: green for head `b8de39a7d58d47c122f1f1e1631513c81e19d9ac` (`gh pr checks 2691`).
- Codex: requested and passed for `b8de39a7d5`.
- CodeRabbit: status context passed; no review threads.
- Copilot: requested for latest head; no blocking response/thread returned.

## Conflict/dependency notes

No dependency on #2677. This PR does not touch read-integrity mode, value-log counters, or geth-hot-KV harness plumbing.
