### PR TITLE
collections: audit retained payload shape stats

### DIFF
--- a/TreeDB/collections/column_retained_payload_audit.go
+++ b/TreeDB/collections/column_retained_payload_audit.go
@@ -1,6 +1,7 @@
 package collections
 
 import (
+	"encoding/json"
 	"fmt"
 	"sort"
 	"strings"
@@ -71,13 +72,29 @@ type ColumnRetainedPayloadPath struct {
 // ColumnRetainedPayloadCollectionAuditOptions controls the retained-payload
 // path audit over the collection's persisted primary rows.
 type ColumnRetainedPayloadCollectionAuditOptions struct {
-	Paths        []string
-	MaxDocuments int
+	Paths             []string
+	MaxDocuments      int
+	IncludeShapeStats bool
+	ShapeMaxDepth     int
+	ShapeMaxPaths     int
 }
 
 type ColumnRetainedPayloadCollectionPathViolation struct {
 	DocumentID string `json:"document_id"`
 	Path       string `json:"path"`
+}
+
+// ColumnRetainedPayloadShapePathStat summarizes decoded retained-payload JSON
+// values by path and kind. JSONBytes is per-path encoded value size and is not
+// additive across parent and child paths.
+type ColumnRetainedPayloadShapePathStat struct {
+	Path         string `json:"path"`
+	ValueKind    string `json:"value_kind"`
+	Occurrences  int64  `json:"occurrences"`
+	Documents    int64  `json:"documents"`
+	JSONBytes    int64  `json:"json_bytes"`
+	StringBytes  int64  `json:"string_bytes,omitempty"`
+	MaxJSONBytes int    `json:"max_json_bytes,omitempty"`
 }
 
 type ColumnRetainedPayloadCollectionAuditResult struct {
@@ -92,6 +109,8 @@ type ColumnRetainedPayloadCollectionAuditResult struct {
 	DeclaredPaths                    []string                                       `json:"declared_paths"`
 	CheckedRows                      int                                            `json:"checked_rows"`
 	RetainedPayloadBytes             int64                                          `json:"retained_payload_bytes"`
+	RetainedPayloadShape             []ColumnRetainedPayloadShapePathStat           `json:"retained_payload_shape,omitempty"`
+	RetainedPayloadShapeTruncated    bool                                           `json:"retained_payload_shape_truncated,omitempty"`
 	Truncated                        bool                                           `json:"truncated,omitempty"`
 	Violations                       []ColumnRetainedPayloadCollectionPathViolation `json:"violations,omitempty"`
 	Errors                           []string                                       `json:"errors,omitempty"`
@@ -113,12 +132,14 @@ func auditColumnRetainedPayloadPathsAbsentWithResolver(cfg ColumnStoreConfig, re
 		RetainedPayloadEncodingStatus: status,
 		RetainedPayloadBytes:          len(retained),
 	}
-
 	obj, err := decodeColumnRetainedPayloadObject(cfg, retained, resolver)
 	if err != nil {
 		return audit, fmt.Errorf("collections: retained payload path audit: %w", err)
 	}
+	return auditColumnRetainedPayloadObjectPathsAbsent(audit, obj, paths)
+}
 
+func auditColumnRetainedPayloadObjectPathsAbsent(audit ColumnRetainedPayloadPathAudit, obj map[string]any, paths []string) (ColumnRetainedPayloadPathAudit, error) {
 	checked := normalizeColumnRetainedPayloadAuditPaths(paths)
 	for _, path := range checked {
 		present := columnJSONPathExists(obj, path)
@@ -196,6 +217,7 @@ func (c *Collection) AuditRetainedPayloadDeclaredPathsAbsent(opts ColumnRetained
 	defer func() { _ = it.Close() }()
 
 	resolver := columnRetainedPayloadTemplateResolver(snap, catalog)
+	shape := newColumnRetainedPayloadShapeCollector(opts.ShapeMaxDepth)
 	for it.Valid() {
 		if opts.MaxDocuments > 0 && result.CheckedRows >= opts.MaxDocuments {
 			result.Truncated = true
@@ -215,7 +237,29 @@ func (c *Collection) AuditRetainedPayloadDeclaredPathsAbsent(opts ColumnRetained
 		}
 		result.CheckedRows++
 		result.RetainedPayloadBytes += int64(len(retained))
-		payloadAudit, auditErr := auditColumnRetainedPayloadPathsAbsentWithResolver(cfg, retained, result.DeclaredPaths, resolver)
+		var payloadAudit ColumnRetainedPayloadPathAudit
+		var auditErr error
+		if opts.IncludeShapeStats {
+			var obj map[string]any
+			obj, auditErr = decodeColumnRetainedPayloadObject(cfg, retained, resolver)
+			if auditErr == nil {
+				payloadAudit = ColumnRetainedPayloadPathAudit{
+					RetainedPayloadPolicy:         result.RetainedPayloadPolicy,
+					RetainedPayloadEncoding:       result.RetainedPayloadEncoding,
+					RetainedPayloadEncodingStatus: result.RetainedPayloadEncodingStatus,
+					RetainedPayloadBytes:          len(retained),
+				}
+				payloadAudit, auditErr = auditColumnRetainedPayloadObjectPathsAbsent(payloadAudit, obj, result.DeclaredPaths)
+			}
+			if auditErr == nil {
+				auditErr = shape.addDocumentObject(obj)
+			}
+			if auditErr != nil {
+				auditErr = fmt.Errorf("collections: retained payload audit %q: %w", documentID, auditErr)
+			}
+		} else {
+			payloadAudit, auditErr = auditColumnRetainedPayloadPathsAbsentWithResolver(cfg, retained, result.DeclaredPaths, resolver)
+		}
 		if auditErr != nil {
 			for _, path := range payloadAudit.Violations {
 				result.Violations = append(result.Violations, ColumnRetainedPayloadCollectionPathViolation{
@@ -229,6 +273,9 @@ func (c *Collection) AuditRetainedPayloadDeclaredPathsAbsent(opts ColumnRetained
 	}
 	if err := it.Error(); err != nil {
 		return retainedPayloadCollectionAuditError(result, err)
+	}
+	if opts.IncludeShapeStats {
+		result.RetainedPayloadShape, result.RetainedPayloadShapeTruncated = shape.result(opts.ShapeMaxPaths)
 	}
 	if result.Truncated {
 		result.Status = "passed_sampled"
@@ -303,4 +350,136 @@ func columnJSONPathExists(obj map[string]any, path string) bool {
 		current = next
 	}
 	return false
+}
+
+type columnRetainedPayloadShapeKey struct {
+	path string
+	kind string
+}
+
+type columnRetainedPayloadShapeCollector struct {
+	byKey    map[columnRetainedPayloadShapeKey]*ColumnRetainedPayloadShapePathStat
+	maxDepth int
+}
+
+func newColumnRetainedPayloadShapeCollector(maxDepth int) *columnRetainedPayloadShapeCollector {
+	return &columnRetainedPayloadShapeCollector{
+		byKey:    make(map[columnRetainedPayloadShapeKey]*ColumnRetainedPayloadShapePathStat),
+		maxDepth: maxDepth,
+	}
+}
+
+func (c *columnRetainedPayloadShapeCollector) addDocumentObject(obj map[string]any) error {
+	if c == nil || obj == nil {
+		return nil
+	}
+	seen := make(map[columnRetainedPayloadShapeKey]struct{})
+	keys := make([]string, 0, len(obj))
+	for key := range obj {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		if err := c.addValue(key, obj[key], 1, seen); err != nil {
+			return err
+		}
+	}
+	for key := range seen {
+		c.byKey[key].Documents++
+	}
+	return nil
+}
+
+func (c *columnRetainedPayloadShapeCollector) addValue(path string, value any, depth int, seen map[columnRetainedPayloadShapeKey]struct{}) error {
+	kind := columnRetainedPayloadShapeValueKind(value)
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return fmt.Errorf("marshal path %q %s value: %w", path, kind, err)
+	}
+	key := columnRetainedPayloadShapeKey{path: path, kind: kind}
+	stat := c.byKey[key]
+	if stat == nil {
+		stat = &ColumnRetainedPayloadShapePathStat{Path: path, ValueKind: kind}
+		c.byKey[key] = stat
+	}
+	jsonBytes := len(encoded)
+	stat.Occurrences++
+	stat.JSONBytes += int64(jsonBytes)
+	if jsonBytes > stat.MaxJSONBytes {
+		stat.MaxJSONBytes = jsonBytes
+	}
+	if s, ok := value.(string); ok {
+		stat.StringBytes += int64(len(s))
+	}
+	seen[key] = struct{}{}
+
+	if c.maxDepth > 0 && depth >= c.maxDepth {
+		return nil
+	}
+	switch typed := value.(type) {
+	case map[string]any:
+		keys := make([]string, 0, len(typed))
+		for key := range typed {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		for _, key := range keys {
+			if err := c.addValue(path+"."+key, typed[key], depth+1, seen); err != nil {
+				return err
+			}
+		}
+	case []any:
+		childPath := path + "[]"
+		for _, child := range typed {
+			if err := c.addValue(childPath, child, depth+1, seen); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (c *columnRetainedPayloadShapeCollector) result(maxPaths int) ([]ColumnRetainedPayloadShapePathStat, bool) {
+	if c == nil || len(c.byKey) == 0 {
+		return nil, false
+	}
+	out := make([]ColumnRetainedPayloadShapePathStat, 0, len(c.byKey))
+	for _, stat := range c.byKey {
+		out = append(out, *stat)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].JSONBytes != out[j].JSONBytes {
+			return out[i].JSONBytes > out[j].JSONBytes
+		}
+		if out[i].Occurrences != out[j].Occurrences {
+			return out[i].Occurrences > out[j].Occurrences
+		}
+		if out[i].Path != out[j].Path {
+			return out[i].Path < out[j].Path
+		}
+		return out[i].ValueKind < out[j].ValueKind
+	})
+	if maxPaths > 0 && len(out) > maxPaths {
+		return out[:maxPaths], true
+	}
+	return out, false
+}
+
+func columnRetainedPayloadShapeValueKind(value any) string {
+	switch value.(type) {
+	case nil:
+		return "null"
+	case bool:
+		return "bool"
+	case string:
+		return "string"
+	case float32, float64, int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64, json.Number:
+		return "number"
+	case map[string]any:
+		return "object"
+	case []any:
+		return "array"
+	default:
+		return "unknown"
+	}
 }

--- a/TreeDB/collections/column_retained_payload_audit_test.go
+++ b/TreeDB/collections/column_retained_payload_audit_test.go
@@ -170,6 +170,60 @@ func TestAuditCollectionRetainedPayloadDeclaredPathsAbsentTemplateV12382(t *test
 	}
 }
 
+func TestAuditCollectionRetainedPayloadShapeStatsTemplateV12662(t *testing.T) {
+	col, closeDB := openRetainedPayloadAuditCollection2382(t, jsonbenchRetainedPayloadAuditConfig2382(true), [][]byte{
+		[]byte(`{"time_us":1,"kind":"commit","did":"did:plc:one","commit":{"operation":"create","collection":"app.bsky.feed.post","rkey":"r1"},"payload":"kept","nested":{"also":"kept","count":3}}`),
+		[]byte(`{"time_us":2,"kind":"commit","did":"did:plc:two","commit":{"operation":"update","collection":"app.bsky.feed.post","rkey":"r2"},"payload":"second","nested":{"also":"two","flag":true}}`),
+	})
+	defer closeDB()
+
+	audit, err := col.AuditRetainedPayloadDeclaredPathsAbsent(ColumnRetainedPayloadCollectionAuditOptions{
+		IncludeShapeStats: true,
+		ShapeMaxDepth:     8,
+	})
+	if err != nil {
+		t.Fatalf("AuditRetainedPayloadDeclaredPathsAbsent shape stats: %v audit=%+v", err, audit)
+	}
+	if audit.Status != "passed" || audit.CheckedRows != 2 {
+		t.Fatalf("audit=%+v want passed two rows", audit)
+	}
+	if len(audit.RetainedPayloadShape) == 0 || audit.RetainedPayloadShapeTruncated {
+		t.Fatalf("shape stats=%+v truncated=%v", audit.RetainedPayloadShape, audit.RetainedPayloadShapeTruncated)
+	}
+	payload, ok := retainedPayloadShapeStat2382(audit.RetainedPayloadShape, "payload", "string")
+	if !ok {
+		t.Fatalf("missing payload string stat: %+v", audit.RetainedPayloadShape)
+	}
+	if payload.Occurrences != 2 || payload.Documents != 2 || payload.StringBytes != int64(len("kept")+len("second")) || payload.JSONBytes <= payload.StringBytes {
+		t.Fatalf("payload stat=%+v", payload)
+	}
+	rkey, ok := retainedPayloadShapeStat2382(audit.RetainedPayloadShape, "commit.rkey", "string")
+	if !ok || rkey.Occurrences != 2 || rkey.Documents != 2 {
+		t.Fatalf("commit.rkey stat=%+v ok=%v shape=%+v", rkey, ok, audit.RetainedPayloadShape)
+	}
+	nested, ok := retainedPayloadShapeStat2382(audit.RetainedPayloadShape, "nested", "object")
+	if !ok || nested.Occurrences != 2 || nested.Documents != 2 {
+		t.Fatalf("nested object stat=%+v ok=%v shape=%+v", nested, ok, audit.RetainedPayloadShape)
+	}
+	if _, ok := retainedPayloadShapeStat2382(audit.RetainedPayloadShape, "kind", "string"); ok {
+		t.Fatalf("declared kind path leaked into shape stats: %+v", audit.RetainedPayloadShape)
+	}
+	if _, ok := retainedPayloadShapeStat2382(audit.RetainedPayloadShape, "commit.operation", "string"); ok {
+		t.Fatalf("declared commit.operation path leaked into shape stats: %+v", audit.RetainedPayloadShape)
+	}
+
+	limited, err := col.AuditRetainedPayloadDeclaredPathsAbsent(ColumnRetainedPayloadCollectionAuditOptions{
+		IncludeShapeStats: true,
+		ShapeMaxPaths:     1,
+	})
+	if err != nil {
+		t.Fatalf("AuditRetainedPayloadDeclaredPathsAbsent limited shape stats: %v audit=%+v", err, limited)
+	}
+	if !limited.RetainedPayloadShapeTruncated || len(limited.RetainedPayloadShape) != 1 {
+		t.Fatalf("limited shape=%+v truncated=%v want one truncated row", limited.RetainedPayloadShape, limited.RetainedPayloadShapeTruncated)
+	}
+}
+
 func TestAuditCollectionRetainedPayloadDeclaredPathsAbsentFailsClosed2382(t *testing.T) {
 	cfg := jsonbenchRetainedPayloadAuditConfig2382(false)
 	col, closeDB := openRetainedPayloadAuditCollection2382(t, cfg, [][]byte{
@@ -274,6 +328,15 @@ func TestAuditCollectionRetainedPayloadDeclaredPathsAbsentValueReadErrorFailsClo
 	if strings.Contains(strings.ToLower(audit.Errors[0]), "panic") {
 		t.Fatalf("audit error still reports panic: %+v", audit)
 	}
+}
+
+func retainedPayloadShapeStat2382(stats []ColumnRetainedPayloadShapePathStat, path, kind string) (ColumnRetainedPayloadShapePathStat, bool) {
+	for _, stat := range stats {
+		if stat.Path == path && stat.ValueKind == kind {
+			return stat, true
+		}
+	}
+	return ColumnRetainedPayloadShapePathStat{}, false
 }
 
 func jsonbenchRetainedPayloadAuditConfig2382(includeOperation bool) *ColumnStoreConfig {

--- a/cmd/treedb_retained_payload_audit/main.go
+++ b/cmd/treedb_retained_payload_audit/main.go
@@ -21,6 +21,9 @@ func run() (code int) {
 	var collectionName string
 	var pathsCSV string
 	var maxDocuments int
+	var shapeStats bool
+	var shapeMaxDepth int
+	var shapeMaxPaths int
 	defer func() {
 		if recovered := recover(); recovered != nil {
 			code = writeFailure(collectionName, fmt.Errorf("retained payload audit panic: %v", recovered))
@@ -30,6 +33,9 @@ func run() (code int) {
 	flag.StringVar(&collectionName, "collection", "", "Collection name; defaults to the only collection")
 	flag.StringVar(&pathsCSV, "paths", "", "Comma-separated JSON paths to require absent; defaults to collection column paths")
 	flag.IntVar(&maxDocuments, "max-documents", 0, "Maximum retained rows to audit; zero audits all rows")
+	flag.BoolVar(&shapeStats, "shape-stats", false, "Include decoded retained-payload path/value shape stats")
+	flag.IntVar(&shapeMaxDepth, "shape-max-depth", 8, "Maximum retained-payload shape traversal depth; zero means unlimited")
+	flag.IntVar(&shapeMaxPaths, "shape-max-paths", 128, "Maximum retained-payload shape path/kind rows to emit; zero means unlimited")
 	flag.Parse()
 
 	if strings.TrimSpace(dbDir) == "" {
@@ -65,8 +71,11 @@ func run() (code int) {
 		return writeFailure(collectionName, fmt.Errorf("open collection: %w", err))
 	}
 	result, err := col.AuditRetainedPayloadDeclaredPathsAbsent(collections.ColumnRetainedPayloadCollectionAuditOptions{
-		Paths:        splitCSV(pathsCSV),
-		MaxDocuments: maxDocuments,
+		Paths:             splitCSV(pathsCSV),
+		MaxDocuments:      maxDocuments,
+		IncludeShapeStats: shapeStats,
+		ShapeMaxDepth:     shapeMaxDepth,
+		ShapeMaxPaths:     shapeMaxPaths,
 	})
 	if err != nil {
 		writeResult(result)


### PR DESCRIPTION
## Summary
- Add optional retained-payload path/value shape stats to `AuditRetainedPayloadDeclaredPathsAbsent` so #2662 can target the remaining non-column retained body with evidence.
- Add `treedb_retained_payload_audit` flags for `-shape-stats`, `-shape-max-depth`, and `-shape-max-paths`.
- Cover Template-v1 retained payloads, declared-path absence, shape stats, and output truncation in focused tests.

This is an audit/evidence slice, not the final retained-format storage reduction.

Refs #2662
Refs #2359
Refs #2353

## Validation
- `go test ./TreeDB/collections -run 'TestAuditColumnRetainedPayload|TestAuditCollectionRetainedPayload|TestColumnRetainedPayloadCompressionStatus|TestTypedStorageLegacyNameAllowlistIsComplete' -count=1`\n- `go test ./cmd/treedb_retained_payload_audit -count=1`\n- `git diff --check`\n\nNote: a broad local `go test ./TreeDB/collections -count=1` rerun was terminated by the local process harness after 131s without a Go assertion failure; package-wide signal is deferred to CI.