### PR TITLE
TreeDB: serve bounded 10k hybrid text candidates

### DIFF
--- a/TreeDB/collections/hybrid_executor.go
+++ b/TreeDB/collections/hybrid_executor.go
@@ -8,7 +8,13 @@ import (
 	backenddb "github.com/snissn/gomap/TreeDB/db"
 )
 
-const hybridDefaultCandidateLimitMultiplier = 4
+const (
+	hybridDefaultCandidateLimitMultiplier = 4
+	// hybridScalarDefaultLookupLimit is the finite indexed allow-set guardrail
+	// for default scalar prefilters. Broader filters still fail closed as
+	// scalar_filter_unbounded instead of falling back to document scans.
+	hybridScalarDefaultLookupLimit = 4 * 1024
+)
 
 type hybridSearchExecutionPlan struct {
 	public HybridSearchPlan
@@ -229,7 +235,10 @@ func hybridScalarLookupLimit(plan hybridSearchExecutionPlan) int {
 		limit += plan.vector.CandidateLimit
 	}
 	if limit <= 0 {
-		return plan.topK
+		limit = plan.topK
+	}
+	if limit < hybridScalarDefaultLookupLimit {
+		limit = hybridScalarDefaultLookupLimit
 	}
 	return limit
 }

--- a/TreeDB/collections/hybrid_search_executor_test.go
+++ b/TreeDB/collections/hybrid_search_executor_test.go
@@ -200,11 +200,25 @@ func TestSearchHybridScalarFilterRangeAndFailClosed2505(t *testing.T) {
 		Text:         &HybridTextQuery{IndexName: "lexical", Query: "refund", CandidateLimit: 1},
 		ScalarFilter: &HybridScalarFilter{IndexName: "city", Value: "sea"},
 	})
-	if !errors.Is(err, ErrHybridSearchIndexUnavailable) {
-		t.Fatalf("broad scalar err=%v want ErrHybridSearchIndexUnavailable", err)
+	if err != nil {
+		t.Fatalf("SearchHybrid bounded broad scalar: %v", err)
 	}
-	if broad.Stats.FailClosed != 1 || broad.Stats.FailClosedReason != HybridFailClosedReasonScalarFilterUnbounded || broad.Stats.Truncated == 0 || broad.Stats.TextCandidatesReturned != 0 {
-		t.Fatalf("broad response=%+v want scalar unbounded before candidate generation", broad)
+	if len(broad.Results) != 1 || broad.Stats.FailClosed != 0 || broad.Stats.ScalarPrefilterIDs != 4 || broad.Stats.TextCandidatesReturned != 1 {
+		t.Fatalf("broad response=%+v want small bounded scalar allow-set to serve", broad)
+	}
+
+	forcedPlan := hybridSearchExecutionPlan{
+		topK:                 1,
+		scalarFilter:         &HybridScalarFilter{IndexName: "city", Value: "sea"},
+		scalarFilterStrategy: HybridScalarFilterStrategyPrefilter,
+		scalarLookupLimit:    1,
+	}
+	_, forcedStats, err := col.hybridScalarAllowSet(forcedPlan)
+	if !errors.Is(err, ErrHybridSearchIndexUnavailable) {
+		t.Fatalf("forced tight scalar err=%v want ErrHybridSearchIndexUnavailable", err)
+	}
+	if forcedStats.Truncated == 0 {
+		t.Fatalf("forced tight scalar stats=%+v want truncation", forcedStats)
 	}
 
 	missing, err := col.SearchHybrid(HybridSearchOptions{
@@ -217,6 +231,36 @@ func TestSearchHybridScalarFilterRangeAndFailClosed2505(t *testing.T) {
 	}
 	if missing.Stats.FailClosed != 1 || missing.Stats.FailClosedReason != HybridFailClosedReasonScalarFilterUnbounded || missing.Stats.FullDocumentScanFallbacks != 0 {
 		t.Fatalf("missing scalar response=%+v want fail-closed scalar reason and no fallback", missing)
+	}
+}
+
+func TestHybridScalarFilterDefaultLookupBudgetFailClosed2687(t *testing.T) {
+	rows := make([]hybridSearchExecutorFixtureRow2505, hybridScalarDefaultLookupLimit+1)
+	for i := range rows {
+		rows[i] = hybridSearchExecutorFixtureRow2505{
+			id:    fmt.Sprintf("doc-%05d", i),
+			title: "refund",
+			body:  "refund",
+			city:  "sea",
+			score: int64(i),
+		}
+	}
+	_, d, col := openHybridScalarSearchExecutorFixture2505(t, rows)
+	defer func() { _ = d.Close() }()
+
+	got, err := col.SearchHybrid(HybridSearchOptions{
+		TopK:         1,
+		Text:         &HybridTextQuery{IndexName: "lexical", Query: "refund", CandidateLimit: 1},
+		ScalarFilter: &HybridScalarFilter{IndexName: "city", Value: "sea"},
+	})
+	if !errors.Is(err, ErrHybridSearchIndexUnavailable) {
+		t.Fatalf("SearchHybrid over-budget scalar err=%v want ErrHybridSearchIndexUnavailable", err)
+	}
+	if got.Stats.FailClosed != 1 || got.Stats.FailClosedReason != HybridFailClosedReasonScalarFilterUnbounded || got.Stats.Truncated == 0 || got.Stats.TextCandidatesReturned != 0 {
+		t.Fatalf("response=%+v want scalar unbounded before candidate generation", got)
+	}
+	if got.Stats.DocumentsFetched != 0 || got.Stats.FullDocumentScanFallbacks != 0 {
+		t.Fatalf("stats=%+v want no document fetch/fallback on scalar fail-closed", got.Stats)
 	}
 }
 

--- a/TreeDB/collections/hybrid_text_candidates.go
+++ b/TreeDB/collections/hybrid_text_candidates.go
@@ -5,6 +5,12 @@ import (
 	"fmt"
 )
 
+// hybridTextCandidateDefaultScanCandidateLimit is the finite internal
+// postings/scoring guardrail used to produce exact top-N hybrid text candidates
+// for modest common-term corpora without changing the public returned-candidate
+// budget.
+const hybridTextCandidateDefaultScanCandidateLimit = 8 * 1024
+
 // SearchHybridTextCandidates adapts collection-native ranked text search into
 // the shared hybrid candidate shape. It is candidate-only: it requests no
 // documents from SearchText, reuses response-owned result IDs for response-owned
@@ -39,6 +45,7 @@ func (c *Collection) searchHybridTextCandidates(query HybridTextQuery, allowSet 
 		IndexName:                query.IndexName,
 		Query:                    query.Query,
 		TopK:                     requested,
+		CandidateLimit:           hybridTextCandidateScanCandidateLimit(requested),
 		IncludeDocuments:         false,
 		textV2AllowedDocumentIDs: allowSet,
 	}, resultMode)
@@ -57,6 +64,22 @@ func validateHybridTextCandidateQuery(query HybridTextQuery) error {
 		return fmt.Errorf("%w: text candidate limit must be positive", ErrHybridSearchUnsupported)
 	}
 	return nil
+}
+
+func hybridTextCandidateScanCandidateLimit(requested int) int {
+	if requested <= 0 {
+		return 0
+	}
+	limit := textSearchDefaultMinCandidateLimit
+	if requested > maxCollectionInt/64 {
+		limit = maxCollectionInt
+	} else if scaled := requested * 64; scaled > limit {
+		limit = scaled
+	}
+	if limit < hybridTextCandidateDefaultScanCandidateLimit {
+		limit = hybridTextCandidateDefaultScanCandidateLimit
+	}
+	return limit
 }
 
 func hybridTextCandidatesFromSearchResponse(requested int, textIndexName string, textResponse TextSearchResponse) (HybridCandidateResponse, error) {

--- a/TreeDB/collections/hybrid_text_candidates_test.go
+++ b/TreeDB/collections/hybrid_text_candidates_test.go
@@ -116,7 +116,7 @@ func TestSearchHybridTextCandidatesBudgetAndStorageFailClosed2503(t *testing.T) 
 		d := openTextTestDB(t)
 		defer func() { _ = d.Close() }()
 		col := createTextSearchM4Collection(t, d, []TextIndexField{{Field: "body"}})
-		ids := make([][]byte, textSearchDefaultMinCandidateLimit+1)
+		ids := make([][]byte, hybridTextCandidateDefaultScanCandidateLimit+1)
 		docs := make([][]byte, len(ids))
 		for i := range ids {
 			ids[i] = []byte(fmt.Sprintf("doc-%04d", i))

--- a/TreeDB/collections/text_v2_search_test.go
+++ b/TreeDB/collections/text_v2_search_test.go
@@ -85,6 +85,43 @@ func TestTextV2HybridTextCandidatesNoDocCounters2627(t *testing.T) {
 	}
 }
 
+func TestTextV2DefaultSafe10KCandidateAndScalarBudgets2687(t *testing.T) {
+	fixture := openIndexInsertSearchInsertedTextV2Fixture2564(t, 10000, 16, 8)
+	defer func() { _ = fixture.db.Close() }()
+
+	text, err := fixture.col.SearchHybridTextCandidates(HybridTextQuery{IndexName: hybridCloseoutTextIndexName2506, Query: "refund policy", CandidateLimit: 64})
+	if err != nil {
+		t.Fatalf("SearchHybridTextCandidates 10k v2: %v", err)
+	}
+	if len(text.Candidates) != 64 {
+		t.Fatalf("text candidates=%d want 64", len(text.Candidates))
+	}
+	if text.Stats.FailClosed != 0 || text.Stats.DocumentsFetched != 0 || text.Stats.FullDocumentScanFallbacks != 0 || text.Stats.TextStateLookups != 0 || text.Stats.TextMatchDetailsBuilt != 0 {
+		t.Fatalf("text stats=%+v want default-safe score-only no-doc path", text.Stats)
+	}
+	if text.Stats.TextCandidatesScored == 0 || text.Stats.TextCandidatesScored > hybridTextCandidateDefaultScanCandidateLimit || text.Stats.TextPostingsScanned == 0 || text.Stats.TextPostingsScanned > 10000 || text.Stats.TextBlockMaxFallbacks > 1 {
+		t.Fatalf("text stats=%+v want bounded 10k multi-term work under safe budget", text.Stats)
+	}
+
+	hybrid, err := fixture.col.SearchHybrid(HybridSearchOptions{
+		TopK:         10,
+		Text:         &HybridTextQuery{IndexName: hybridCloseoutTextIndexName2506, Query: "refund policy", CandidateLimit: 64},
+		ScalarFilter: &HybridScalarFilter{IndexName: hybridCloseoutTenantIndexName2506, Value: "tenant-rare-06pct"},
+	})
+	if err != nil {
+		t.Fatalf("SearchHybrid 10k v2 scalar: %v", err)
+	}
+	if len(hybrid.Results) != 10 {
+		t.Fatalf("hybrid results=%d want 10", len(hybrid.Results))
+	}
+	if hybrid.Stats.FailClosed != 0 || hybrid.Stats.DocumentsFetched != 0 || hybrid.Stats.FullDocumentScanFallbacks != 0 || hybrid.Stats.TextStateLookups != 0 || hybrid.Stats.TextMatchDetailsBuilt != 0 {
+		t.Fatalf("hybrid stats=%+v want no-doc score-only fail-closed-free path", hybrid.Stats)
+	}
+	if hybrid.Stats.ScalarPrefilterIDs != 625 || hybrid.Stats.TextCandidatesReturned != 64 || hybrid.Stats.TextCandidatesScored == 0 || hybrid.Stats.TextCandidatesScored > hybrid.Stats.ScalarPrefilterIDs || hybrid.Stats.TextPostingsScanned == 0 || hybrid.Stats.TextPostingsScanned > 10000 || hybrid.Stats.TextBlockMaxFallbacks > 1 {
+		t.Fatalf("hybrid stats=%+v want scalar-pruned v2 scoring under safe budgets", hybrid.Stats)
+	}
+}
+
 func TestTextV2SearchIncludeDocumentsFetchesOnlyTopKAndDetailsLazy2627(t *testing.T) {
 	d := openTextV2TestDB(t, t.TempDir(), false)
 	defer func() { _ = d.Close() }()

--- a/TreeDB/docs/spec/hybrid-search-contract.md
+++ b/TreeDB/docs/spec/hybrid-search-contract.md
@@ -89,6 +89,23 @@ Single-source text-only and vector-only user flows should continue to use their
 own APIs and benchmark rows. Candidate adapters from #2503 may still use
 `HybridSearchCandidate` as a shared internal shape.
 
+## Bounded budget defaults
+
+`HybridTextQuery.CandidateLimit` is the returned lexical source budget. The text
+adapter may use a larger internal postings/scoring guardrail so modest common
+terms can still produce an exact top-N candidate list without fetching documents.
+That internal guardrail remains finite and fail-closed: if postings or unique
+candidate work exceeds the implementation's safe budget, the query returns an
+unavailable/unsupported diagnostic rather than a partial ranking or primary scan.
+
+Scalar filters likewise build finite indexed allow-sets. The default scalar
+lookup budget is large enough for the 10k guarded rare-tenant shapes, while truly
+broad filters that exceed the bound still fail closed with
+`scalar_filter_unbounded`. v2 text search consumes scalar allow-sets during
+posting-block scans so scalar-filtered candidate generation can score only
+allowed documents while preserving the single-snapshot, zero-document-fetch
+contract.
+
 ## Candidate and result shape
 
 Every `HybridSearchCandidate` MUST carry:


### PR DESCRIPTION
## Summary

Closes #2687. Part of #2681.

This PR makes the #2564 10k bounded candidate/scalar guardrail rows serve without switching text-v2 on by default.

- Adds a finite internal hybrid text candidate scan guardrail (8,192 candidates) while preserving the public returned `HybridTextQuery.CandidateLimit`.
- Raises the default indexed scalar allow-set guardrail to 4,096 IDs so the 10k rare-tenant scalar shapes serve, while broader filters still fail closed as `scalar_filter_unbounded`.
- Preserves zero-document candidate generation (`docs_fetched/search=0`, `full_doc_fallbacks/search=0`) and v2 score-only candidate path (`text_state_lookups/search=0`, `text_match_details/search=0`).
- Adds focused tests for 10k-safe v2 text/scalar behavior and public over-budget scalar fail-closed behavior.
- Documents the bounded budget defaults in the hybrid search contract.

Non-goals: no v2 default switch (#2690), no external IR/LSM/slab path, and no general multi-term BM25F/block-max optimization (#2688). The v2 10k multi-term row still reports `blockmax_fallbacks/search=1`; this PR only makes it bounded/default-safe.

## Public contract / behavior

- `HybridTextQuery.CandidateLimit` remains the returned lexical candidate budget.
- Hybrid text candidate generation may use a larger finite internal postings/scoring budget to produce an exact top-N candidate list for modest common-term corpora.
- Scalar filters build finite indexed allow-sets. Over-budget scalar filters still fail closed before candidate generation with `scalar_filter_unbounded` and no document fetch/fallback.

## Tests

```sh
GOWORK=off go test ./TreeDB/collections -run 'TestTextV2|TestSearchHybridTextCandidates|TestHybrid' -count=1
GOWORK=off go test ./TreeDB/docs -count=1
GOWORK=off go test ./TreeDB/collections -count=1
```

All passed locally. Artifact logs:

- focused: `/tmp/2687_focused_tests3_20260612_133545.txt`
- docs: `/tmp/2687_docs_tests_20260612_132935.txt`
- collections: `/tmp/2687_collections_tests2_20260612_133558.txt`

## Benchmarks

Commands:

```sh
TREEDB_INDEX_BENCH_DOCS=10000 GOWORK=off go test ./TreeDB/collections -run '^$' -bench '^BenchmarkIndexInsertSearch2564/(search_text_candidates_no_docs|search_text_v2_candidates_no_docs|search_hybrid_no_docs_scalar_filter|search_hybrid_v2_no_docs_scalar_filter|search_vector_candidates_no_docs|search_hybrid_fetch_topk_scalar_filter)$' -benchmem -benchtime=5x -count=3

GOWORK=off go test ./TreeDB/collections -run '^$' -bench '^BenchmarkIndexInsertSearch2564/(search_text_candidates_no_docs|search_text_v2_candidates_no_docs|search_hybrid_no_docs_scalar_filter|search_hybrid_v2_no_docs_scalar_filter|search_vector_candidates_no_docs|search_hybrid_fetch_topk_scalar_filter)$' -benchmem -benchtime=5x -count=3
```

Artifacts:

- 10k before: `/tmp/2687_before_10k_20260612_131504.txt`
- 10k after: `/tmp/2687_after_10k_20260612_132344.txt`
- 256 before: `/tmp/2687_before_256_20260612_131557.txt`
- 256 after: `/tmp/2687_after_256_20260612_132328.txt`
- parsed summary: `/tmp/2687_bench_summary.txt`

### 10k guardrail

Before: the required 10k command failed closed on all text/scalar rows except vector:

| row | before failure |
| --- | --- |
| `search_text_candidates_no_docs` | text index exceeded bounded candidate generation |
| `search_text_v2_candidates_no_docs` | text-v2 index exceeded bounded candidate generation |
| `search_hybrid_v2_no_docs_scalar_filter` | scalar filter exceeded bounded lookup limit 74 |
| `search_hybrid_no_docs_scalar_filter` | scalar filter exceeded bounded lookup limit 138 |
| `search_hybrid_fetch_topk_scalar_filter` | scalar filter exceeded bounded lookup limit 138 |

After medians (`n=3`, `5x`):

| row | ns/op | ops/sec | B/op | allocs/op | key counters |
| --- | ---: | ---: | ---: | ---: | --- |
| `search_text_candidates_no_docs` | 11,444,425 | 87.4 | 2,657,457 | 20,146 | candidates=64, postings=10,000, scored=5,000, docs=0, fallbacks=0, fail_closed=0 |
| `search_text_v2_candidates_no_docs` | 13,840,900 | 72.2 | 2,969,244 | 11,181 | candidates=64, postings=10,000, blocks visited/skipped=80/0, scored=5,000, state_lookups=0, docs=0, blockmax_fallbacks=1, fail_closed=0 |
| `search_hybrid_v2_no_docs_scalar_filter` | 1,802,742 | 554.7 | 1,749,891 | 5,027 | scalar_prefilter=625, scalar_matched=64, postings=10,000, blocks visited/skipped=80/0, text_scored=625, docs=0, state_lookups=0, fail_closed=0 |
| `search_vector_candidates_no_docs` | 39,750 | 25,157 | 149,816 | 83 | vector_candidates=64, examined=269, edges=2,102, docs=0, fail_closed=0 |
| `search_hybrid_no_docs_scalar_filter` | 9,841,892 | 101.6 | 2,926,120 | 21,554 | scalar_prefilter=625, scalar_matched/rejected=17/111, text/vector candidates=64/64, docs=0, fail_closed=0 |
| `search_hybrid_fetch_topk_scalar_filter` | 21,240,783 | 47.1 | 3,035,160 | 22,467 | scalar_prefilter=625, scalar_matched/rejected=17/111, final docs_fetched=10, full_doc_fallbacks=0, fail_closed=0 |

### 256-doc guardrail

256-doc medians stayed small-shape safe; B/op, allocs/op, candidate counts, docs fetched/fallbacks, state lookups, scalar counters, and vector counters were unchanged except normal timing noise. `benchstat` did not detect significant ns/op regressions with `n=3`.

| row | before ns/op | after ns/op | before B/op | after B/op | before allocs/op | after allocs/op |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| `search_text_candidates_no_docs` | 349,458 | 314,300 | 89,793 | 89,793 | 623 | 623 |
| `search_text_v2_candidates_no_docs` | 559,983 | 197,742 | 99,592 | 99,561 | 455 | 455 |
| `search_hybrid_v2_no_docs_scalar_filter` | 83,067 | 117,658 | 63,875 | 63,875 | 315 | 315 |
| `search_vector_candidates_no_docs` | 40,533 | 49,308 | 41,272 | 41,272 | 83 | 83 |
| `search_hybrid_no_docs_scalar_filter` | 454,842 | 390,233 | 182,785 | 182,785 | 803 | 803 |
| `search_hybrid_fetch_topk_scalar_filter` | 4,282,808 | 1,093,575 | 240,592 | 240,592 | 1,780 | 1,780 |

## Review / risk notes

- Internal high-thinking review passed after adding a public over-budget scalar fail-closed test.
- Remaining risk: this PR intentionally does not solve v2 multi-term exhaustive fallback; #2688 should be able to replace that path without changing this PR's public budget contract.
- Vector path code was not touched. Vector B/op, allocs/op, and counters are unchanged; ns/op samples were noisy and not significant in the required guardrail run.
