### PR TITLE
TreeDB text v2: tighten write and maintenance budgets

### DIFF
--- a/TreeDB/collections/text_catalog.go
+++ b/TreeDB/collections/text_catalog.go
@@ -194,8 +194,9 @@ func (c *Collection) DropTextIndex(name string) (*CollectionMeta, error) {
 }
 
 // TextIndexStorageStats validates and summarizes persistent text roots for a
-// declared text index. It is a storage/accounting helper for the roots that
-// SearchText also validates while scanning and scoring.
+// declared text index. It scans durable text roots and is intended for
+// maintenance/accounting/benchmark use; serving health paths should prefer the
+// lightweight TextIndexStatus.
 func (c *Collection) TextIndexStorageStats(indexName string) (TextIndexStorageStats, error) {
 	var stats TextIndexStorageStats
 	if err := ValidateIndexName(indexName); err != nil {

--- a/TreeDB/collections/text_v2_posting_blocks.go
+++ b/TreeDB/collections/text_v2_posting_blocks.go
@@ -92,7 +92,6 @@ type textV2PostingBlockValue struct {
 type textV2PostingBlockKV struct {
 	Key   []byte
 	Value []byte
-	Block textV2PostingBlockValue
 }
 
 type textV2PostingBlockBuildOptions struct {
@@ -161,6 +160,10 @@ func encodeTextV2PostingBlockValue(value textV2PostingBlockValue) []byte {
 	slices.SortFunc(entries, func(a, b textV2PostingBlockEntry) int {
 		return compareUint64(a.Ordinal, b.Ordinal)
 	})
+	return encodeTextV2PostingBlockValueFromSorted(value, entries)
+}
+
+func encodeTextV2PostingBlockValueFromSorted(value textV2PostingBlockValue, entries []textV2PostingBlockEntry) []byte {
 	fieldCount := uint32(len(value.Summary.MaxFieldTermFrequencies))
 	out := make([]byte, 0, estimateTextV2PostingBlockValueLen(value, entries, fieldCount))
 	out = append(out, textV2PostingBlockValueVersion)
@@ -252,7 +255,7 @@ func buildTextV2PostingBlockKVs(term string, entries []textV2PostingBlockEntry, 
 	if blockID == 0 {
 		blockID = 1
 	}
-	sorted := cloneTextV2PostingBlockEntries(entries)
+	sorted := cloneTextV2PostingBlockEntryHeaders(entries)
 	slices.SortFunc(sorted, func(a, b textV2PostingBlockEntry) int { return compareUint64(a.Ordinal, b.Ordinal) })
 	if err := validateTextV2PostingBlockBuilderEntries(sorted, fieldCount); err != nil {
 		return nil, err
@@ -263,11 +266,11 @@ func buildTextV2PostingBlockKVs(term string, entries []textV2PostingBlockEntry, 
 		var block textV2PostingBlockValue
 		var encoded []byte
 		for {
-			candidate, err := newTextV2PostingBlockValue(kind, sorted[start:start+chunkLen], fieldCount, blockID)
+			candidate, err := newTextV2PostingBlockValueFromSorted(kind, sorted[start:start+chunkLen], fieldCount, blockID)
 			if err != nil {
 				return nil, err
 			}
-			encoded = encodeTextV2PostingBlockValue(candidate)
+			encoded = encodeTextV2PostingBlockValueFromSorted(candidate, candidate.Entries)
 			if len(encoded) <= textV2PostingBlockMaxValueBytes && (len(encoded) <= inlineTarget || chunkLen == 1) {
 				block = candidate
 				break
@@ -280,7 +283,6 @@ func buildTextV2PostingBlockKVs(term string, entries []textV2PostingBlockEntry, 
 		out = append(out, textV2PostingBlockKV{
 			Key:   encodeTextV2PostingBlockKey(term, block.BlockStart, block.BlockID),
 			Value: encoded,
-			Block: block,
 		})
 		start += chunkLen
 		if !opts.FixedBlockID {
@@ -670,6 +672,16 @@ func validateTextV2PostingBlockBuilderEntries(entries []textV2PostingBlockEntry,
 }
 
 func newTextV2PostingBlockValue(kind textV2PostingBlockKind, entries []textV2PostingBlockEntry, fieldCount uint32, blockID uint64) (textV2PostingBlockValue, error) {
+	cloned := cloneTextV2PostingBlockEntries(entries)
+	slices.SortFunc(cloned, func(a, b textV2PostingBlockEntry) int { return compareUint64(a.Ordinal, b.Ordinal) })
+	return newTextV2PostingBlockValueFromSorted(kind, cloned, fieldCount, blockID)
+}
+
+// newTextV2PostingBlockValueFromSorted builds metadata around caller-owned
+// entries that are already sorted by ordinal. Callers that retain the returned
+// block must pass owned entries; encoding-only callers can pass a transient
+// shallow copy to avoid per-entry field-frequency clones.
+func newTextV2PostingBlockValueFromSorted(kind textV2PostingBlockKind, entries []textV2PostingBlockEntry, fieldCount uint32, blockID uint64) (textV2PostingBlockValue, error) {
 	if len(entries) == 0 {
 		return textV2PostingBlockValue{}, errMalformedTextStorage("text-v2 posting block cannot be empty")
 	}
@@ -685,17 +697,15 @@ func newTextV2PostingBlockValue(kind textV2PostingBlockKind, entries []textV2Pos
 	if !isSupportedTextV2PostingBlockKind(kind) {
 		return textV2PostingBlockValue{}, errMalformedTextStorage("text-v2 posting block unsupported kind %d", byte(kind))
 	}
-	cloned := cloneTextV2PostingBlockEntries(entries)
-	slices.SortFunc(cloned, func(a, b textV2PostingBlockEntry) int { return compareUint64(a.Ordinal, b.Ordinal) })
 	summary := textV2PostingBlockSummary{
-		FirstOrdinal:            cloned[0].Ordinal,
-		LastOrdinal:             cloned[len(cloned)-1].Ordinal,
-		DocCount:                uint32(len(cloned)),
+		FirstOrdinal:            entries[0].Ordinal,
+		LastOrdinal:             entries[len(entries)-1].Ordinal,
+		DocCount:                uint32(len(entries)),
 		MaxFieldTermFrequencies: make([]uint32, fieldCount),
 		UpperBoundKind:          textV2PostingUpperBoundKindBM25FLaneMax,
 	}
 	var prev uint64
-	for i, entry := range cloned {
+	for i, entry := range entries {
 		if entry.Ordinal == 0 || entry.Generation == 0 || entry.TermFrequency == 0 {
 			return textV2PostingBlockValue{}, errMalformedTextStorage("text-v2 posting block entry[%d] invalid ordinal/generation/frequency", i)
 		}
@@ -729,7 +739,7 @@ func newTextV2PostingBlockValue(kind textV2PostingBlockKind, entries []textV2Pos
 		BlockStart:    summary.FirstOrdinal,
 		BlockID:       blockID,
 		Summary:       summary,
-		Entries:       cloned,
+		Entries:       entries,
 	}, nil
 }
 
@@ -748,6 +758,12 @@ func estimateTextV2PostingBlockValueLen(value textV2PostingBlockValue, entries [
 		n += 3*binary.MaxVarintLen64 + 1 + len(entry.FieldFrequencies)*binary.MaxVarintLen64
 	}
 	return n + len(value.Summary.MaxFieldTermFrequencies) + textV2PostingBlockChecksumBytes
+}
+
+func cloneTextV2PostingBlockEntryHeaders(entries []textV2PostingBlockEntry) []textV2PostingBlockEntry {
+	// Used by block builders that only need to sort and encode immediately; the
+	// field-frequency slices remain read-only and are not retained in output KVs.
+	return append([]textV2PostingBlockEntry(nil), entries...)
 }
 
 func cloneTextV2PostingBlockEntries(entries []textV2PostingBlockEntry) []textV2PostingBlockEntry {

--- a/TreeDB/collections/text_v2_rewrite.go
+++ b/TreeDB/collections/text_v2_rewrite.go
@@ -375,13 +375,7 @@ func (p *textV2RewritePlan) processRewriteTerm(
 	p.stats.StalePostingsPurged += term.stale
 	live := make([]textV2PostingBlockEntry, 0, len(term.liveByOrd))
 	for _, entry := range term.liveByOrd {
-		live = append(live, textV2PostingBlockEntry{
-			Ordinal:          entry.Ordinal,
-			Generation:       entry.Generation,
-			TermFrequency:    entry.TermFrequency,
-			FieldFrequencies: append([]uint32(nil), entry.FieldFrequencies...),
-			Flags:            entry.Flags,
-		})
+		live = append(live, entry)
 	}
 	sort.Slice(live, func(i, j int) bool { return live[i].Ordinal < live[j].Ordinal })
 	p.stats.LivePostingsRetained += uint64(len(live))

--- a/TreeDB/collections/text_v2_rewrite_test.go
+++ b/TreeDB/collections/text_v2_rewrite_test.go
@@ -352,6 +352,15 @@ func TestTextV2RewriteStorageMaintenanceAndValueLogGC2630(t *testing.T) {
 		_ = snap.Close()
 		t.Fatalf("old snapshot micro ok=%v len=%d err=%v want pinned old payload", ok, len(raw), err)
 	}
+	pinnedLeafGC, err := d.LeafGenerationGC(context.Background(), backenddb.LeafGenerationGCOptions{})
+	if err != nil {
+		_ = snap.Close()
+		t.Fatalf("LeafGenerationGC while text-v2 snapshot pinned: %v", err)
+	}
+	if pinnedLeafGC.GenerationsDeleted != 0 || pinnedLeafGC.BytesDeleted != 0 {
+		_ = snap.Close()
+		t.Fatalf("LeafGenerationGC deleted pinned text-v2 roots: %+v", pinnedLeafGC)
+	}
 	if err := snap.Close(); err != nil {
 		t.Fatalf("snapshot close: %v", err)
 	}
@@ -361,8 +370,15 @@ func TestTextV2RewriteStorageMaintenanceAndValueLogGC2630(t *testing.T) {
 	if _, err := d.ValueLogGC(context.Background(), backenddb.ValueLogGCOptions{}); err != nil {
 		t.Fatalf("ValueLogGC: %v", err)
 	}
-	if _, err := d.CompactStorage(context.Background(), backenddb.CompactStorageOptions{}); err != nil {
+	compactStats, err := d.CompactStorage(context.Background(), backenddb.CompactStorageOptions{
+		LeafPackMinExpectedReclaimBytes: 1,
+		LeafPackMinReclaimPerCopyPPM:    1,
+	})
+	if err != nil {
 		t.Fatalf("CompactStorage: %v", err)
+	}
+	if !compactStats.FullyCompacted {
+		t.Fatalf("CompactStorage left text-v2 maintenance debt after snapshot release: leaf_gc=%+v remaining=%+v", compactStats.LeafGenerationGC, compactStats.RemainingDebt)
 	}
 	if got, err := col.SearchText(TextSearchOptions{IndexName: "lexical", Query: "updated", TopK: 10, ResultMode: TextSearchResultModeScoreOnly}); err != nil || len(got.Results) != 8 {
 		t.Fatalf("post-maintenance updated response=%+v err=%v want 8", got, err)

--- a/TreeDB/docs/spec/collection-text-v2-contract.md
+++ b/TreeDB/docs/spec/collection-text-v2-contract.md
@@ -367,6 +367,38 @@ roots:
 sealed/delta/micro posting-block counts, and fail-closes on malformed v2 storage
 instead of declaring the inspected state ready.
 
+## Default-rollout write and maintenance budget guidance (#2689)
+
+The default-rollout maintenance contract is budgeted through the normal text-v2
+counters rather than a private text GC. Operators and benchmark PRs SHOULD use
+`TextIndexStorageStats` as the offline/maintenance inspection tool, not as a
+per-request health check: it scans the durable v2 roots to validate counts,
+`V2RewriteMergeState`, `V2SealedPostingBlocks`, `V2DeltaPostingBlocks`,
+`V2MicroPostingBlocks`, `V2DeletedDocs`, and `EncodedBytes`. Lightweight serving
+status remains `TextIndexStatus`.
+
+`RewriteTextIndex` SHOULD be scheduled when `TextIndexStorageStats` reports
+`rewrite_merge_pending`, especially when micro/delta posting blocks materially
+exceed the sealed-block baseline for the workload, deleted/tombstoned ordinals
+accumulate, or `posting_blocks/doc` / `write_amp_entries/doc` grows far beyond a
+fresh backfill row. The production default `TargetPostingsPerBlock=0` uses the
+text-v2 block target (currently 128 postings, cache-local encoded values);
+smaller targets are primarily for tests, tiny fixtures, or intentionally more
+frequent block splitting. A rewrite is logical maintenance only: it publishes new
+ordinary collection roots, removes stale posting keys and tombstones from the
+live root set, and reports `posting_blocks_read`, `posting_blocks_written`,
+`posting_blocks_deleted`, `stale_postings_purged`, and tombstones purged so the
+next physical maintenance pass has auditable work.
+
+Physical cleanup MUST remain on TreeDB maintenance paths. After a rewrite (and
+after old snapshots have released), callers SHOULD use the usual sequence for
+their deployment: checkpoint, `ValueLogGC`, value-log rewrite when the value-log
+rewrite plan shows stale source bytes, leaf-generation pack/GC or
+`CompactStorage`, and index vacuum. Live v2 roots must remain reachable through
+collection root descriptors throughout this sequence; stale roots become normal
+unreferenced root/value-log/leaf payloads and must not require a standalone
+text-block GC.
+
 Default-selection decision for #2630: v2 remains an explicit opt-in
 (`TextIndexVersionV2`) while the production default stays v1. The reason is not a
 storage blocker—v2 roots now have rewrite/merge lifecycle tooling and normal

--- a/docs/benchmarks/treedb_text_v2_contract_benchmarks.md
+++ b/docs/benchmarks/treedb_text_v2_contract_benchmarks.md
@@ -109,7 +109,7 @@ Measured boundaries:
 - `delete_batch_text_v2_indexed`: explicit v2 `DeleteBatch` with generation and
   tombstone maintenance; setup excludes initial insert.
 
-Command:
+Small/default command:
 
 ```sh
 GOWORK=off \
@@ -121,6 +121,20 @@ go test ./TreeDB/collections \
   -benchtime=5x \
   -count=3 \
   | tee "$OUT/text_v2_write_paths.txt"
+```
+
+Larger local write-budget row for default-readiness PRs:
+
+```sh
+GOWORK=off \
+TREEDB_TEXT_V2_WRITE_DOCS=1024 \
+go test ./TreeDB/collections \
+  -run '^$' \
+  -bench '^BenchmarkTextV2ContractWritePaths2623/(insert_batch_text_v2_indexed|create_text_v2_index_backfill|update_batch_text_v2_indexed|delete_batch_text_v2_indexed)$' \
+  -benchmem \
+  -benchtime=3x \
+  -count=3 \
+  | tee "$OUT/text_v2_write_paths_1024_v2.txt"
 ```
 
 Report text write counters:
@@ -375,9 +389,26 @@ Report:
   `posting_blocks_deleted/op`;
 - `stale_postings_purged/op` and `tombstones_purged/op`;
 - post-rewrite search rows proving no hidden latency/allocation regression;
+- `TextIndexStorageStats` before/after state: `rewrite_merge_pending` should
+  become `compacted`, with micro/delta blocks and deleted-document tombstones
+  purged from the live root set;
 - storage maintenance evidence showing live posting/norm/docmap/positions values
   survive `ValueLogGC`/`CompactStorage`, while old root payloads are unreachable
   after snapshots release.
+
+Maintenance-budget interpretation for default-readiness PRs:
+
+- `TextIndexStorageStats` is a scanning validation/audit tool. Use it in
+  maintenance, tests, and benchmark setup/teardown; do not place it in serving
+  health paths.
+- Treat `rewrite_merge_pending` as logical maintenance debt. Schedule
+  `RewriteTextIndex` when micro/delta posting blocks, deleted ordinals,
+  `posting_blocks/doc`, or `write_amp_entries/doc` materially drift above the
+  fresh backfill/write rows for the workload.
+- `RewriteTextIndex` is logical root maintenance only. Physical reclamation must
+  remain a normal TreeDB sequence after old snapshots release: checkpoint,
+  `ValueLogGC`, value-log rewrite when the rewrite plan shows stale source
+  bytes, leaf maintenance/index vacuum, or `CompactStorage`.
 
 Default selection after #2630 remains explicit v2 opt-in unless the final matrix
 and rollout/default-bootstrap work are accepted in the same PR. If v1 remains the


### PR DESCRIPTION
## Summary

Fixes #2689 (parent #2681).

This PR closes the text-v2 write/backfill/rewrite/maintenance budget gap without touching the #2687/#2688 search/default-switch scope:

- reduces avoidable posting-block write/rewrite allocation by reusing sorted/encoded posting-block data and avoiding per-entry field-frequency clones in the batch/rewrite builder path;
- keeps `newTextV2PostingBlockValue`'s owned/deep-copy behavior for retained block values while adding sorted/encoding-only helpers for hot builders;
- tightens maintenance coverage so pinned text-v2 roots survive `LeafGenerationGC`, then become fully compactable after snapshot release + checkpoint + `ValueLogGC` + `CompactStorage`;
- documents default-rollout budget guidance for `TextIndexStorageStats`, `RewriteTextIndex`, and normal TreeDB physical maintenance paths.

No default switch, BM25F semantics change, candidate-generation change, or standalone text GC subsystem is included.

## Tests

Artifact root: `/tmp/gomap_2689_20260612_131510`

Latest-head local tests after rebasing onto `origin/main` (`29662a3b2`):

```sh
GOWORK=off go test ./TreeDB/collections -run 'TestTextV2Rewrite|TestTextV2Storage|TestCollectionCompactStorage' -count=1
GOWORK=off go test ./TreeDB/collections -count=1
GOWORK=off go test ./TreeDB/... -count=1
```

All passed. I also reran the changed posting/rewrite tests during development:

```sh
GOWORK=off go test ./TreeDB/collections -run 'TestTextV2PostingBlock|TestTextV2Rewrite' -count=1
```

## Benchmarks

Before baselines were captured from the issue start base (`4e208786c`); final after rows use this PR's code. Full benchstat artifacts are in the artifact root.

### 256-doc write/backfill/update/delete matrix

Command:

```sh
GOWORK=off TREEDB_TEXT_V2_WRITE_DOCS=256 \
  go test ./TreeDB/collections -run '^$' \
  -bench '^BenchmarkTextV2ContractWritePaths2623$' \
  -benchmem -benchtime=5x -count=5
```

| row | sec/op before -> after | ops/sec after | B/op before -> after | allocs/op before -> after | storage counters |
| --- | ---: | ---: | ---: | ---: | --- |
| insert_batch_text_v2_indexed | 4.227 ms -> 2.614 ms (-38.2%) | ~383 batch/s | 3.429 MiB -> 2.949 MiB (-14.0%) | 32.10k -> 23.21k (-27.7%) | unchanged: 289.4 index_bytes/doc, 5.523 write_amp_entries/doc |
| create_text_v2_index_backfill | 10.670 ms -> 2.754 ms (-74.2%) | ~363 batch/s | 3.085 MiB -> 2.650 MiB (-14.1%) | 30.30k -> 21.49k (-29.1%) | unchanged: 261.0 index_bytes/doc, 5.398 write_amp_entries/doc |
| update_batch_text_v2_indexed | 13.838 ms -> 3.532 ms (-74.5%) | ~283 batch/s | 4.197 MiB -> 3.824 MiB (-8.9%) | 41.03k -> 32.14k (-21.7%) | unchanged: 480.3 index_bytes/doc, 5.527 write_amp_entries/doc |
| delete_batch_text_v2_indexed | 3.440 ms -> 1.741 ms (-49.4%) | ~574 batch/s | ~flat | ~flat | unchanged |

### 1024-doc v2 write/backfill/update/delete matrix

Command:

```sh
GOWORK=off TREEDB_TEXT_V2_WRITE_DOCS=1024 \
  go test ./TreeDB/collections -run '^$' \
  -bench '^BenchmarkTextV2ContractWritePaths2623/(insert_batch_text_v2_indexed|create_text_v2_index_backfill|update_batch_text_v2_indexed|delete_batch_text_v2_indexed)$' \
  -benchmem -benchtime=3x -count=3
```

Geomean: 14.48 ms -> 9.855 ms (-31.9%, ~101 batch/s after), 10.35 MiB -> 9.280 MiB (-10.3%), 101.7k -> 79.25k allocs/op (-22.1%). Storage counters (index bytes/doc, write amp, posting blocks/doc) were unchanged.

### Rewrite/maintenance benchmark

Command:

```sh
GOWORK=off go test ./TreeDB/collections -run '^$' \
  -bench '^BenchmarkTextV2RewriteMerge2630$' \
  -benchmem -benchtime=20x -count=5
```

`BenchmarkTextV2RewriteMerge2630`: 2.114 ms -> 1.146 ms (-45.8%, ~873 rewrites/s after), 1.774 MiB -> 1.487 MiB (-16.2%), 16.365k -> 8.851k allocs/op (-45.9%). Rewrite counters were unchanged: 235 blocks read, 44 written, 233 deleted, 384 stale postings purged, 32 tombstones purged.

### Search guardrail

Command:

```sh
GOWORK=off TREEDB_TEXT_V2_SEARCH_DOCS=1024 \
  go test ./TreeDB/collections -run '^$' \
  -bench '^BenchmarkTextV2ScoreSearchScale2627/docs_1024/score_only_common_no_docs$' \
  -benchmem -benchtime=10x -count=3
```

Score-only common-term guardrail stayed zero-doc/no-state/no-fallback: `docs_fetched=0`, `state_lookups=0`, `full_doc_fallbacks=0`, `fail_closed=0`, `match_details=0`, `blockmax_fallbacks=0`; median about 0.239 ms/search (~4.2k searches/s), 228 KiB/op, 212 allocs/op.

## Notes / scope boundaries

- No separate text-block GC was added; physical cleanup remains checkpoint + value-log/leaf/index maintenance or `CompactStorage` after old snapshots release.
- Multi-term candidate-generation/block-max fallback work remains owned by #2688.
- The final v2 default switch remains owned by #2690 after #2687/#2688/#2689 are accepted.
