### PR TITLE
TreeDB: audit retained value families

### DIFF
--- a/TreeDB/collections/column_retained_payload_audit.go
+++ b/TreeDB/collections/column_retained_payload_audit.go
@@ -1,11 +1,15 @@
 package collections
 
 import (
+	"bytes"
+	"compress/gzip"
 	"encoding/json"
 	"fmt"
 	"sort"
 	"strings"
+	"unicode/utf8"
 
+	"github.com/snissn/compress/zstd"
 	backenddb "github.com/snissn/gomap/TreeDB/db"
 )
 
@@ -72,11 +76,15 @@ type ColumnRetainedPayloadPath struct {
 // ColumnRetainedPayloadCollectionAuditOptions controls the retained-payload
 // path audit over the collection's persisted primary rows.
 type ColumnRetainedPayloadCollectionAuditOptions struct {
-	Paths             []string
-	MaxDocuments      int
-	IncludeShapeStats bool
-	ShapeMaxDepth     int
-	ShapeMaxPaths     int
+	Paths                   []string
+	MaxDocuments            int
+	IncludeShapeStats       bool
+	ShapeMaxDepth           int
+	ShapeMaxPaths           int
+	IncludeValueFamilyStats bool
+	ValueFamilyMaxDepth     int
+	ValueFamilyMaxPaths     int
+	ValueFamilyMaxUnique    int
 }
 
 type ColumnRetainedPayloadCollectionPathViolation struct {
@@ -97,23 +105,59 @@ type ColumnRetainedPayloadShapePathStat struct {
 	MaxJSONBytes int    `json:"max_json_bytes,omitempty"`
 }
 
+type ColumnRetainedPayloadLengthBucket struct {
+	Bucket string `json:"bucket"`
+	Count  int64  `json:"count"`
+}
+
+// ColumnRetainedPayloadValueFamilyStat summarizes decoded retained-payload
+// string leaves by path. Compression oracles encode one JSON string per line,
+// so OracleInputBytes includes one separator byte per occurrence.
+type ColumnRetainedPayloadValueFamilyStat struct {
+	Path                  string                              `json:"path"`
+	Occurrences           int64                               `json:"occurrences"`
+	Documents             int64                               `json:"documents"`
+	JSONBytes             int64                               `json:"json_bytes"`
+	StringBytes           int64                               `json:"string_bytes"`
+	OracleInputBytes      int64                               `json:"oracle_input_bytes"`
+	MinLength             int                                 `json:"min_length,omitempty"`
+	MaxLength             int                                 `json:"max_length,omitempty"`
+	MeanLength            float64                             `json:"mean_length,omitempty"`
+	TrackedUniqueValues   int64                               `json:"tracked_unique_values"`
+	UniqueValuesTruncated bool                                `json:"unique_values_truncated,omitempty"`
+	RepeatedValues        int64                               `json:"repeated_values,omitempty"`
+	CommonPrefix          string                              `json:"common_prefix,omitempty"`
+	CommonPrefixBytes     int                                 `json:"common_prefix_bytes,omitempty"`
+	CommonPrefixTruncated bool                                `json:"common_prefix_truncated,omitempty"`
+	CommonSuffix          string                              `json:"common_suffix,omitempty"`
+	CommonSuffixBytes     int                                 `json:"common_suffix_bytes,omitempty"`
+	CommonSuffixTruncated bool                                `json:"common_suffix_truncated,omitempty"`
+	LengthBuckets         []ColumnRetainedPayloadLengthBucket `json:"length_buckets,omitempty"`
+	GzipBytes             int64                               `json:"gzip_bytes,omitempty"`
+	GzipToInputRatio      float64                             `json:"gzip_to_input_ratio,omitempty"`
+	ZSTDBytes             int64                               `json:"zstd_bytes,omitempty"`
+	ZSTDToInputRatio      float64                             `json:"zstd_to_input_ratio,omitempty"`
+}
+
 type ColumnRetainedPayloadCollectionAuditResult struct {
-	Collection                       string                                         `json:"collection"`
-	Status                           string                                         `json:"status"`
-	RetainedPayloadPolicy            ColumnRetainedPayloadPolicy                    `json:"retained_payload_policy"`
-	RetainedPayloadEncoding          string                                         `json:"retained_payload_encoding"`
-	RetainedPayloadEncodingStatus    string                                         `json:"retained_payload_encoding_status"`
-	RetainedPayloadCompression       string                                         `json:"retained_payload_compression"`
-	RetainedPayloadCompressionPolicy string                                         `json:"retained_payload_compression_policy"`
-	RetainedPayloadCompressionStatus string                                         `json:"retained_payload_compression_status"`
-	DeclaredPaths                    []string                                       `json:"declared_paths"`
-	CheckedRows                      int                                            `json:"checked_rows"`
-	RetainedPayloadBytes             int64                                          `json:"retained_payload_bytes"`
-	RetainedPayloadShape             []ColumnRetainedPayloadShapePathStat           `json:"retained_payload_shape,omitempty"`
-	RetainedPayloadShapeTruncated    bool                                           `json:"retained_payload_shape_truncated,omitempty"`
-	Truncated                        bool                                           `json:"truncated,omitempty"`
-	Violations                       []ColumnRetainedPayloadCollectionPathViolation `json:"violations,omitempty"`
-	Errors                           []string                                       `json:"errors,omitempty"`
+	Collection                            string                                         `json:"collection"`
+	Status                                string                                         `json:"status"`
+	RetainedPayloadPolicy                 ColumnRetainedPayloadPolicy                    `json:"retained_payload_policy"`
+	RetainedPayloadEncoding               string                                         `json:"retained_payload_encoding"`
+	RetainedPayloadEncodingStatus         string                                         `json:"retained_payload_encoding_status"`
+	RetainedPayloadCompression            string                                         `json:"retained_payload_compression"`
+	RetainedPayloadCompressionPolicy      string                                         `json:"retained_payload_compression_policy"`
+	RetainedPayloadCompressionStatus      string                                         `json:"retained_payload_compression_status"`
+	DeclaredPaths                         []string                                       `json:"declared_paths"`
+	CheckedRows                           int                                            `json:"checked_rows"`
+	RetainedPayloadBytes                  int64                                          `json:"retained_payload_bytes"`
+	RetainedPayloadShape                  []ColumnRetainedPayloadShapePathStat           `json:"retained_payload_shape,omitempty"`
+	RetainedPayloadShapeTruncated         bool                                           `json:"retained_payload_shape_truncated,omitempty"`
+	RetainedPayloadValueFamilies          []ColumnRetainedPayloadValueFamilyStat         `json:"retained_payload_value_families,omitempty"`
+	RetainedPayloadValueFamiliesTruncated bool                                           `json:"retained_payload_value_families_truncated,omitempty"`
+	Truncated                             bool                                           `json:"truncated,omitempty"`
+	Violations                            []ColumnRetainedPayloadCollectionPathViolation `json:"violations,omitempty"`
+	Errors                                []string                                       `json:"errors,omitempty"`
 }
 
 // AuditColumnRetainedPayloadPathsAbsent verifies that declared typed JSON paths
@@ -217,7 +261,15 @@ func (c *Collection) AuditRetainedPayloadDeclaredPathsAbsent(opts ColumnRetained
 	defer func() { _ = it.Close() }()
 
 	resolver := columnRetainedPayloadTemplateResolver(snap, catalog)
-	shape := newColumnRetainedPayloadShapeCollector(opts.ShapeMaxDepth)
+	includeDecodedStats := opts.IncludeShapeStats || opts.IncludeValueFamilyStats
+	var shape *columnRetainedPayloadShapeCollector
+	if opts.IncludeShapeStats {
+		shape = newColumnRetainedPayloadShapeCollector(opts.ShapeMaxDepth)
+	}
+	var valueFamilies *columnRetainedPayloadValueFamilyCollector
+	if opts.IncludeValueFamilyStats {
+		valueFamilies = newColumnRetainedPayloadValueFamilyCollector(opts.ValueFamilyMaxDepth, opts.ValueFamilyMaxUnique)
+	}
 	for it.Valid() {
 		if opts.MaxDocuments > 0 && result.CheckedRows >= opts.MaxDocuments {
 			result.Truncated = true
@@ -239,7 +291,7 @@ func (c *Collection) AuditRetainedPayloadDeclaredPathsAbsent(opts ColumnRetained
 		result.RetainedPayloadBytes += int64(len(retained))
 		var payloadAudit ColumnRetainedPayloadPathAudit
 		var auditErr error
-		if opts.IncludeShapeStats {
+		if includeDecodedStats {
 			var obj map[string]any
 			obj, auditErr = decodeColumnRetainedPayloadObject(cfg, retained, resolver)
 			if auditErr == nil {
@@ -251,8 +303,11 @@ func (c *Collection) AuditRetainedPayloadDeclaredPathsAbsent(opts ColumnRetained
 				}
 				payloadAudit, auditErr = auditColumnRetainedPayloadObjectPathsAbsent(payloadAudit, obj, result.DeclaredPaths)
 			}
-			if auditErr == nil {
+			if auditErr == nil && shape != nil {
 				auditErr = shape.addDocumentObject(obj)
+			}
+			if auditErr == nil && valueFamilies != nil {
+				auditErr = valueFamilies.addDocumentObject(obj)
 			}
 			if auditErr != nil {
 				auditErr = fmt.Errorf("collections: retained payload audit %q: %w", documentID, auditErr)
@@ -276,6 +331,14 @@ func (c *Collection) AuditRetainedPayloadDeclaredPathsAbsent(opts ColumnRetained
 	}
 	if opts.IncludeShapeStats {
 		result.RetainedPayloadShape, result.RetainedPayloadShapeTruncated = shape.result(opts.ShapeMaxPaths)
+	}
+	if opts.IncludeValueFamilyStats {
+		valueFamilyStats, truncated, err := valueFamilies.result(opts.ValueFamilyMaxPaths)
+		if err != nil {
+			return retainedPayloadCollectionAuditError(result, err)
+		}
+		result.RetainedPayloadValueFamilies = valueFamilyStats
+		result.RetainedPayloadValueFamiliesTruncated = truncated
 	}
 	if result.Truncated {
 		result.Status = "passed_sampled"
@@ -463,6 +526,286 @@ func (c *columnRetainedPayloadShapeCollector) result(maxPaths int) ([]ColumnReta
 		return out[:maxPaths], true
 	}
 	return out, false
+}
+
+type columnRetainedPayloadValueFamilyCollector struct {
+	byPath    map[string]*columnRetainedPayloadValueFamilyPath
+	maxDepth  int
+	maxUnique int
+}
+
+type columnRetainedPayloadValueFamilyPath struct {
+	stat         ColumnRetainedPayloadValueFamilyStat
+	unique       map[string]struct{}
+	commonPrefix string
+	commonSuffix string
+	initialized  bool
+	buckets      [7]int64
+	gzipBuf      bytes.Buffer
+	gzipWriter   *gzip.Writer
+	zstdBuf      bytes.Buffer
+	zstdWriter   *zstd.Encoder
+}
+
+func newColumnRetainedPayloadValueFamilyCollector(maxDepth, maxUnique int) *columnRetainedPayloadValueFamilyCollector {
+	return &columnRetainedPayloadValueFamilyCollector{
+		byPath:    make(map[string]*columnRetainedPayloadValueFamilyPath),
+		maxDepth:  maxDepth,
+		maxUnique: maxUnique,
+	}
+}
+
+func (c *columnRetainedPayloadValueFamilyCollector) addDocumentObject(obj map[string]any) error {
+	if c == nil || obj == nil {
+		return nil
+	}
+	seen := make(map[string]struct{})
+	keys := make([]string, 0, len(obj))
+	for key := range obj {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		if err := c.addValue(key, obj[key], 1, seen); err != nil {
+			return err
+		}
+	}
+	for path := range seen {
+		c.byPath[path].stat.Documents++
+	}
+	return nil
+}
+
+func (c *columnRetainedPayloadValueFamilyCollector) addValue(path string, value any, depth int, seen map[string]struct{}) error {
+	if s, ok := value.(string); ok {
+		if err := c.addString(path, s); err != nil {
+			return err
+		}
+		seen[path] = struct{}{}
+	}
+	if c.maxDepth > 0 && depth >= c.maxDepth {
+		return nil
+	}
+	switch typed := value.(type) {
+	case map[string]any:
+		keys := make([]string, 0, len(typed))
+		for key := range typed {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		for _, key := range keys {
+			if err := c.addValue(path+"."+key, typed[key], depth+1, seen); err != nil {
+				return err
+			}
+		}
+	case []any:
+		childPath := path + "[]"
+		for _, child := range typed {
+			if err := c.addValue(childPath, child, depth+1, seen); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (c *columnRetainedPayloadValueFamilyCollector) addString(path, value string) error {
+	stat := c.byPath[path]
+	if stat == nil {
+		stat = &columnRetainedPayloadValueFamilyPath{
+			stat: ColumnRetainedPayloadValueFamilyStat{Path: path},
+		}
+		stat.gzipWriter = gzip.NewWriter(&stat.gzipBuf)
+		zstdWriter, err := zstd.NewWriter(&stat.zstdBuf,
+			zstd.WithEncoderLevel(zstd.SpeedFastest),
+			zstd.WithEncoderCRC(false),
+			zstd.WithEncoderConcurrency(1),
+		)
+		if err != nil {
+			return fmt.Errorf("create zstd oracle for path %q: %w", path, err)
+		}
+		stat.zstdWriter = zstdWriter
+		stat.unique = make(map[string]struct{})
+		c.byPath[path] = stat
+	}
+
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return fmt.Errorf("marshal string path %q: %w", path, err)
+	}
+	stat.stat.Occurrences++
+	stat.stat.JSONBytes += int64(len(encoded))
+	stat.stat.StringBytes += int64(len(value))
+	stat.stat.OracleInputBytes += int64(len(encoded) + 1)
+	length := len(value)
+	if stat.stat.Occurrences == 1 || length < stat.stat.MinLength {
+		stat.stat.MinLength = length
+	}
+	if length > stat.stat.MaxLength {
+		stat.stat.MaxLength = length
+	}
+	stat.buckets[columnRetainedPayloadLengthBucketIndex(length)]++
+
+	if _, ok := stat.unique[value]; !ok && !stat.stat.UniqueValuesTruncated {
+		if c.maxUnique <= 0 || len(stat.unique) < c.maxUnique {
+			stat.unique[value] = struct{}{}
+		} else {
+			stat.stat.UniqueValuesTruncated = true
+		}
+	}
+	if !stat.initialized {
+		stat.commonPrefix = value
+		stat.commonSuffix = value
+		stat.initialized = true
+	} else {
+		stat.commonPrefix = columnRetainedPayloadCommonPrefix(stat.commonPrefix, value)
+		stat.commonSuffix = columnRetainedPayloadCommonSuffix(stat.commonSuffix, value)
+	}
+
+	if _, err := stat.gzipWriter.Write(encoded); err != nil {
+		return fmt.Errorf("write gzip oracle for path %q: %w", path, err)
+	}
+	if _, err := stat.gzipWriter.Write([]byte{'\n'}); err != nil {
+		return fmt.Errorf("write gzip oracle separator for path %q: %w", path, err)
+	}
+	if _, err := stat.zstdWriter.Write(encoded); err != nil {
+		return fmt.Errorf("write zstd oracle for path %q: %w", path, err)
+	}
+	if _, err := stat.zstdWriter.Write([]byte{'\n'}); err != nil {
+		return fmt.Errorf("write zstd oracle separator for path %q: %w", path, err)
+	}
+	return nil
+}
+
+func (c *columnRetainedPayloadValueFamilyCollector) result(maxPaths int) ([]ColumnRetainedPayloadValueFamilyStat, bool, error) {
+	if c == nil || len(c.byPath) == 0 {
+		return nil, false, nil
+	}
+	out := make([]ColumnRetainedPayloadValueFamilyStat, 0, len(c.byPath))
+	for path, internal := range c.byPath {
+		if internal.gzipWriter != nil {
+			if err := internal.gzipWriter.Close(); err != nil {
+				return nil, false, fmt.Errorf("close gzip oracle for path %q: %w", path, err)
+			}
+			internal.gzipWriter = nil
+		}
+		if internal.zstdWriter != nil {
+			if err := internal.zstdWriter.Close(); err != nil {
+				return nil, false, fmt.Errorf("close zstd oracle for path %q: %w", path, err)
+			}
+			internal.zstdWriter = nil
+		}
+		stat := internal.stat
+		if stat.Occurrences > 0 {
+			stat.MeanLength = float64(stat.StringBytes) / float64(stat.Occurrences)
+		}
+		stat.TrackedUniqueValues = int64(len(internal.unique))
+		if !stat.UniqueValuesTruncated {
+			stat.RepeatedValues = stat.Occurrences - stat.TrackedUniqueValues
+		}
+		stat.CommonPrefixBytes = len(internal.commonPrefix)
+		stat.CommonPrefix, stat.CommonPrefixTruncated = columnRetainedPayloadAuditClipString(internal.commonPrefix, 128)
+		stat.CommonSuffixBytes = len(internal.commonSuffix)
+		stat.CommonSuffix, stat.CommonSuffixTruncated = columnRetainedPayloadAuditClipString(internal.commonSuffix, 128)
+		stat.LengthBuckets = columnRetainedPayloadLengthBuckets(internal.buckets)
+		stat.GzipBytes = int64(internal.gzipBuf.Len())
+		stat.GzipToInputRatio = columnRetainedPayloadAuditRatio(stat.GzipBytes, stat.OracleInputBytes)
+		stat.ZSTDBytes = int64(internal.zstdBuf.Len())
+		stat.ZSTDToInputRatio = columnRetainedPayloadAuditRatio(stat.ZSTDBytes, stat.OracleInputBytes)
+		out = append(out, stat)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].JSONBytes != out[j].JSONBytes {
+			return out[i].JSONBytes > out[j].JSONBytes
+		}
+		if out[i].Occurrences != out[j].Occurrences {
+			return out[i].Occurrences > out[j].Occurrences
+		}
+		return out[i].Path < out[j].Path
+	})
+	if maxPaths > 0 && len(out) > maxPaths {
+		return out[:maxPaths], true, nil
+	}
+	return out, false, nil
+}
+
+func columnRetainedPayloadLengthBucketIndex(length int) int {
+	switch {
+	case length <= 8:
+		return 0
+	case length <= 16:
+		return 1
+	case length <= 32:
+		return 2
+	case length <= 64:
+		return 3
+	case length <= 128:
+		return 4
+	case length <= 256:
+		return 5
+	default:
+		return 6
+	}
+}
+
+func columnRetainedPayloadLengthBuckets(counts [7]int64) []ColumnRetainedPayloadLengthBucket {
+	names := [...]string{"le_8", "le_16", "le_32", "le_64", "le_128", "le_256", "gt_256"}
+	out := make([]ColumnRetainedPayloadLengthBucket, 0, len(counts))
+	for i, count := range counts {
+		if count == 0 {
+			continue
+		}
+		out = append(out, ColumnRetainedPayloadLengthBucket{Bucket: names[i], Count: count})
+	}
+	return out
+}
+
+func columnRetainedPayloadCommonPrefix(a, b string) string {
+	n := len(a)
+	if len(b) < n {
+		n = len(b)
+	}
+	i := 0
+	for i < n && a[i] == b[i] {
+		i++
+	}
+	return a[:i]
+}
+
+func columnRetainedPayloadCommonSuffix(a, b string) string {
+	n := len(a)
+	if len(b) < n {
+		n = len(b)
+	}
+	i := 0
+	for i < n && a[len(a)-1-i] == b[len(b)-1-i] {
+		i++
+	}
+	return a[len(a)-i:]
+}
+
+func columnRetainedPayloadAuditClipString(value string, maxBytes int) (string, bool) {
+	if maxBytes <= 0 {
+		return value, false
+	}
+	limit := len(value)
+	truncated := false
+	if limit > maxBytes {
+		limit = maxBytes
+		truncated = true
+	}
+	for limit > 0 && !utf8.ValidString(value[:limit]) {
+		limit--
+		truncated = true
+	}
+	return value[:limit], truncated
+}
+
+func columnRetainedPayloadAuditRatio(num, denom int64) float64 {
+	if denom <= 0 {
+		return 0
+	}
+	return float64(num) / float64(denom)
 }
 
 func columnRetainedPayloadShapeValueKind(value any) string {

--- a/TreeDB/collections/column_retained_payload_audit.go
+++ b/TreeDB/collections/column_retained_payload_audit.go
@@ -1,7 +1,6 @@
 package collections
 
 import (
-	"bytes"
 	"compress/gzip"
 	"encoding/json"
 	"fmt"
@@ -541,10 +540,19 @@ type columnRetainedPayloadValueFamilyPath struct {
 	commonSuffix string
 	initialized  bool
 	buckets      [7]int64
-	gzipBuf      bytes.Buffer
+	gzipCounter  columnRetainedPayloadCountingWriter
 	gzipWriter   *gzip.Writer
-	zstdBuf      bytes.Buffer
+	zstdCounter  columnRetainedPayloadCountingWriter
 	zstdWriter   *zstd.Encoder
+}
+
+type columnRetainedPayloadCountingWriter struct {
+	n int64
+}
+
+func (w *columnRetainedPayloadCountingWriter) Write(p []byte) (int, error) {
+	w.n += int64(len(p))
+	return len(p), nil
 }
 
 func newColumnRetainedPayloadValueFamilyCollector(maxDepth, maxUnique int) *columnRetainedPayloadValueFamilyCollector {
@@ -615,8 +623,8 @@ func (c *columnRetainedPayloadValueFamilyCollector) addString(path, value string
 		stat = &columnRetainedPayloadValueFamilyPath{
 			stat: ColumnRetainedPayloadValueFamilyStat{Path: path},
 		}
-		stat.gzipWriter = gzip.NewWriter(&stat.gzipBuf)
-		zstdWriter, err := zstd.NewWriter(&stat.zstdBuf,
+		stat.gzipWriter = gzip.NewWriter(&stat.gzipCounter)
+		zstdWriter, err := zstd.NewWriter(&stat.zstdCounter,
 			zstd.WithEncoderLevel(zstd.SpeedFastest),
 			zstd.WithEncoderCRC(false),
 			zstd.WithEncoderConcurrency(1),
@@ -708,9 +716,9 @@ func (c *columnRetainedPayloadValueFamilyCollector) result(maxPaths int) ([]Colu
 		stat.CommonSuffixBytes = len(internal.commonSuffix)
 		stat.CommonSuffix, stat.CommonSuffixTruncated = columnRetainedPayloadAuditClipString(internal.commonSuffix, 128)
 		stat.LengthBuckets = columnRetainedPayloadLengthBuckets(internal.buckets)
-		stat.GzipBytes = int64(internal.gzipBuf.Len())
+		stat.GzipBytes = internal.gzipCounter.n
 		stat.GzipToInputRatio = columnRetainedPayloadAuditRatio(stat.GzipBytes, stat.OracleInputBytes)
-		stat.ZSTDBytes = int64(internal.zstdBuf.Len())
+		stat.ZSTDBytes = internal.zstdCounter.n
 		stat.ZSTDToInputRatio = columnRetainedPayloadAuditRatio(stat.ZSTDBytes, stat.OracleInputBytes)
 		out = append(out, stat)
 	}

--- a/TreeDB/collections/column_retained_payload_audit.go
+++ b/TreeDB/collections/column_retained_payload_audit.go
@@ -120,9 +120,9 @@ type ColumnRetainedPayloadValueFamilyStat struct {
 	JSONBytes             int64                               `json:"json_bytes"`
 	StringBytes           int64                               `json:"string_bytes"`
 	OracleInputBytes      int64                               `json:"oracle_input_bytes"`
-	MinLength             int                                 `json:"min_length,omitempty"`
-	MaxLength             int                                 `json:"max_length,omitempty"`
-	MeanLength            float64                             `json:"mean_length,omitempty"`
+	MinLength             int                                 `json:"min_length"`
+	MaxLength             int                                 `json:"max_length"`
+	MeanLength            float64                             `json:"mean_length"`
 	TrackedUniqueValues   int64                               `json:"tracked_unique_values"`
 	UniqueValuesTruncated bool                                `json:"unique_values_truncated,omitempty"`
 	RepeatedValues        int64                               `json:"repeated_values,omitempty"`

--- a/TreeDB/collections/column_retained_payload_audit_test.go
+++ b/TreeDB/collections/column_retained_payload_audit_test.go
@@ -224,6 +224,92 @@ func TestAuditCollectionRetainedPayloadShapeStatsTemplateV12662(t *testing.T) {
 	}
 }
 
+func TestAuditCollectionRetainedPayloadValueFamilyStats2662(t *testing.T) {
+	col, closeDB := openRetainedPayloadAuditCollection2382(t, jsonbenchRetainedPayloadAuditConfig2382(true), [][]byte{
+		[]byte(`{"time_us":1,"kind":"commit","did":"did:plc:one","commit":{"operation":"create","collection":"app.bsky.feed.post","rkey":"r-0001","record":{"subject":{"uri":"at://did:plc:alice/app.bsky.feed.post/3aaa"}}},"payload":"same"}`),
+		[]byte(`{"time_us":2,"kind":"commit","did":"did:plc:two","commit":{"operation":"update","collection":"app.bsky.feed.post","rkey":"r-0002","record":{"subject":{"uri":"at://did:plc:bob/app.bsky.feed.post/3bbb"}}},"payload":"same"}`),
+	})
+	defer closeDB()
+
+	audit, err := col.AuditRetainedPayloadDeclaredPathsAbsent(ColumnRetainedPayloadCollectionAuditOptions{
+		IncludeValueFamilyStats: true,
+		ValueFamilyMaxDepth:     8,
+		ValueFamilyMaxUnique:    10,
+	})
+	if err != nil {
+		t.Fatalf("AuditRetainedPayloadDeclaredPathsAbsent value family stats: %v audit=%+v", err, audit)
+	}
+	if audit.Status != "passed" || audit.CheckedRows != 2 {
+		t.Fatalf("audit=%+v want passed two rows", audit)
+	}
+	if len(audit.RetainedPayloadValueFamilies) == 0 || audit.RetainedPayloadValueFamiliesTruncated {
+		t.Fatalf("value families=%+v truncated=%v", audit.RetainedPayloadValueFamilies, audit.RetainedPayloadValueFamiliesTruncated)
+	}
+	rkey, ok := retainedPayloadValueFamilyStat2662(audit.RetainedPayloadValueFamilies, "commit.rkey")
+	if !ok {
+		t.Fatalf("missing commit.rkey value-family stat: %+v", audit.RetainedPayloadValueFamilies)
+	}
+	if rkey.Occurrences != 2 || rkey.Documents != 2 || rkey.StringBytes != int64(len("r-0001")+len("r-0002")) {
+		t.Fatalf("commit.rkey stat=%+v", rkey)
+	}
+	if rkey.JSONBytes <= rkey.StringBytes || rkey.OracleInputBytes != rkey.JSONBytes+rkey.Occurrences {
+		t.Fatalf("commit.rkey encoded byte counters=%+v", rkey)
+	}
+	if rkey.MinLength != 6 || rkey.MaxLength != 6 || rkey.MeanLength != 6 {
+		t.Fatalf("commit.rkey lengths=%+v", rkey)
+	}
+	if rkey.TrackedUniqueValues != 2 || rkey.UniqueValuesTruncated || rkey.RepeatedValues != 0 {
+		t.Fatalf("commit.rkey unique counters=%+v", rkey)
+	}
+	if rkey.CommonPrefix != "r-000" || rkey.CommonPrefixBytes != len("r-000") {
+		t.Fatalf("commit.rkey common prefix=%q/%d", rkey.CommonPrefix, rkey.CommonPrefixBytes)
+	}
+	if retainedPayloadValueFamilyBucketCount2662(rkey.LengthBuckets, "le_8") != 2 {
+		t.Fatalf("commit.rkey length buckets=%+v", rkey.LengthBuckets)
+	}
+	if rkey.GzipBytes <= 0 || rkey.GzipToInputRatio <= 0 || rkey.ZSTDBytes <= 0 || rkey.ZSTDToInputRatio <= 0 {
+		t.Fatalf("commit.rkey compression oracle counters=%+v", rkey)
+	}
+
+	payload, ok := retainedPayloadValueFamilyStat2662(audit.RetainedPayloadValueFamilies, "payload")
+	if !ok || payload.TrackedUniqueValues != 1 || payload.RepeatedValues != 1 || payload.CommonPrefix != "same" || payload.CommonSuffix != "same" {
+		t.Fatalf("payload repeated-family stat=%+v ok=%v", payload, ok)
+	}
+	subjectURI, ok := retainedPayloadValueFamilyStat2662(audit.RetainedPayloadValueFamilies, "commit.record.subject.uri")
+	if !ok || subjectURI.CommonPrefix != "at://did:plc:" || subjectURI.CommonPrefixBytes != len("at://did:plc:") {
+		t.Fatalf("subject uri family stat=%+v ok=%v", subjectURI, ok)
+	}
+	if _, ok := retainedPayloadValueFamilyStat2662(audit.RetainedPayloadValueFamilies, "kind"); ok {
+		t.Fatalf("declared kind path leaked into value-family stats: %+v", audit.RetainedPayloadValueFamilies)
+	}
+	if _, ok := retainedPayloadValueFamilyStat2662(audit.RetainedPayloadValueFamilies, "commit.operation"); ok {
+		t.Fatalf("declared commit.operation path leaked into value-family stats: %+v", audit.RetainedPayloadValueFamilies)
+	}
+
+	uniqueLimited, err := col.AuditRetainedPayloadDeclaredPathsAbsent(ColumnRetainedPayloadCollectionAuditOptions{
+		IncludeValueFamilyStats: true,
+		ValueFamilyMaxUnique:    1,
+	})
+	if err != nil {
+		t.Fatalf("AuditRetainedPayloadDeclaredPathsAbsent unique-limited value families: %v audit=%+v", err, uniqueLimited)
+	}
+	rkeyLimited, ok := retainedPayloadValueFamilyStat2662(uniqueLimited.RetainedPayloadValueFamilies, "commit.rkey")
+	if !ok || rkeyLimited.TrackedUniqueValues != 1 || !rkeyLimited.UniqueValuesTruncated {
+		t.Fatalf("unique-limited commit.rkey stat=%+v ok=%v", rkeyLimited, ok)
+	}
+
+	pathLimited, err := col.AuditRetainedPayloadDeclaredPathsAbsent(ColumnRetainedPayloadCollectionAuditOptions{
+		IncludeValueFamilyStats: true,
+		ValueFamilyMaxPaths:     1,
+	})
+	if err != nil {
+		t.Fatalf("AuditRetainedPayloadDeclaredPathsAbsent path-limited value families: %v audit=%+v", err, pathLimited)
+	}
+	if !pathLimited.RetainedPayloadValueFamiliesTruncated || len(pathLimited.RetainedPayloadValueFamilies) != 1 {
+		t.Fatalf("path-limited value families=%+v truncated=%v want one truncated row", pathLimited.RetainedPayloadValueFamilies, pathLimited.RetainedPayloadValueFamiliesTruncated)
+	}
+}
+
 func TestAuditCollectionRetainedPayloadDeclaredPathsAbsentFailsClosed2382(t *testing.T) {
 	cfg := jsonbenchRetainedPayloadAuditConfig2382(false)
 	col, closeDB := openRetainedPayloadAuditCollection2382(t, cfg, [][]byte{
@@ -337,6 +423,24 @@ func retainedPayloadShapeStat2382(stats []ColumnRetainedPayloadShapePathStat, pa
 		}
 	}
 	return ColumnRetainedPayloadShapePathStat{}, false
+}
+
+func retainedPayloadValueFamilyStat2662(stats []ColumnRetainedPayloadValueFamilyStat, path string) (ColumnRetainedPayloadValueFamilyStat, bool) {
+	for _, stat := range stats {
+		if stat.Path == path {
+			return stat, true
+		}
+	}
+	return ColumnRetainedPayloadValueFamilyStat{}, false
+}
+
+func retainedPayloadValueFamilyBucketCount2662(buckets []ColumnRetainedPayloadLengthBucket, name string) int64 {
+	for _, bucket := range buckets {
+		if bucket.Bucket == name {
+			return bucket.Count
+		}
+	}
+	return 0
 }
 
 func jsonbenchRetainedPayloadAuditConfig2382(includeOperation bool) *ColumnStoreConfig {

--- a/TreeDB/collections/column_retained_payload_audit_test.go
+++ b/TreeDB/collections/column_retained_payload_audit_test.go
@@ -1,6 +1,7 @@
 package collections
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -226,8 +227,8 @@ func TestAuditCollectionRetainedPayloadShapeStatsTemplateV12662(t *testing.T) {
 
 func TestAuditCollectionRetainedPayloadValueFamilyStats2662(t *testing.T) {
 	col, closeDB := openRetainedPayloadAuditCollection2382(t, jsonbenchRetainedPayloadAuditConfig2382(true), [][]byte{
-		[]byte(`{"time_us":1,"kind":"commit","did":"did:plc:one","commit":{"operation":"create","collection":"app.bsky.feed.post","rkey":"r-0001","record":{"subject":{"uri":"at://did:plc:alice/app.bsky.feed.post/3aaa"}}},"payload":"same"}`),
-		[]byte(`{"time_us":2,"kind":"commit","did":"did:plc:two","commit":{"operation":"update","collection":"app.bsky.feed.post","rkey":"r-0002","record":{"subject":{"uri":"at://did:plc:bob/app.bsky.feed.post/3bbb"}}},"payload":"same"}`),
+		[]byte(`{"time_us":1,"kind":"commit","did":"did:plc:one","commit":{"operation":"create","collection":"app.bsky.feed.post","rkey":"r-0001","record":{"subject":{"uri":"at://did:plc:alice/app.bsky.feed.post/3aaa"}}},"payload":"same","empty":""}`),
+		[]byte(`{"time_us":2,"kind":"commit","did":"did:plc:two","commit":{"operation":"update","collection":"app.bsky.feed.post","rkey":"r-0002","record":{"subject":{"uri":"at://did:plc:bob/app.bsky.feed.post/3bbb"}}},"payload":"same","empty":""}`),
 	})
 	defer closeDB()
 
@@ -278,6 +279,17 @@ func TestAuditCollectionRetainedPayloadValueFamilyStats2662(t *testing.T) {
 	subjectURI, ok := retainedPayloadValueFamilyStat2662(audit.RetainedPayloadValueFamilies, "commit.record.subject.uri")
 	if !ok || subjectURI.CommonPrefix != "at://did:plc:" || subjectURI.CommonPrefixBytes != len("at://did:plc:") {
 		t.Fatalf("subject uri family stat=%+v ok=%v", subjectURI, ok)
+	}
+	empty, ok := retainedPayloadValueFamilyStat2662(audit.RetainedPayloadValueFamilies, "empty")
+	if !ok || empty.MinLength != 0 || empty.MaxLength != 0 || empty.MeanLength != 0 || empty.StringBytes != 0 {
+		t.Fatalf("empty string family stat=%+v ok=%v", empty, ok)
+	}
+	emptyJSON, err := json.Marshal(empty)
+	if err != nil {
+		t.Fatalf("marshal empty string family stat: %v", err)
+	}
+	if !strings.Contains(string(emptyJSON), `"min_length":0`) || !strings.Contains(string(emptyJSON), `"max_length":0`) || !strings.Contains(string(emptyJSON), `"mean_length":0`) {
+		t.Fatalf("empty string family JSON omitted zero length fields: %s", emptyJSON)
 	}
 	if _, ok := retainedPayloadValueFamilyStat2662(audit.RetainedPayloadValueFamilies, "kind"); ok {
 		t.Fatalf("declared kind path leaked into value-family stats: %+v", audit.RetainedPayloadValueFamilies)

--- a/cmd/treedb_retained_payload_audit/main.go
+++ b/cmd/treedb_retained_payload_audit/main.go
@@ -24,6 +24,10 @@ func run() (code int) {
 	var shapeStats bool
 	var shapeMaxDepth int
 	var shapeMaxPaths int
+	var valueFamilyStats bool
+	var valueFamilyMaxDepth int
+	var valueFamilyMaxPaths int
+	var valueFamilyMaxUnique int
 	defer func() {
 		if recovered := recover(); recovered != nil {
 			code = writeFailure(collectionName, fmt.Errorf("retained payload audit panic: %v", recovered))
@@ -36,6 +40,10 @@ func run() (code int) {
 	flag.BoolVar(&shapeStats, "shape-stats", false, "Include decoded retained-payload path/value shape stats")
 	flag.IntVar(&shapeMaxDepth, "shape-max-depth", 8, "Maximum retained-payload shape traversal depth; zero means unlimited")
 	flag.IntVar(&shapeMaxPaths, "shape-max-paths", 128, "Maximum retained-payload shape path/kind rows to emit; zero means unlimited")
+	flag.BoolVar(&valueFamilyStats, "value-family-stats", false, "Include decoded retained-payload string value-family stats")
+	flag.IntVar(&valueFamilyMaxDepth, "value-family-max-depth", 8, "Maximum retained-payload value-family traversal depth; zero means unlimited")
+	flag.IntVar(&valueFamilyMaxPaths, "value-family-max-paths", 64, "Maximum retained-payload value-family rows to emit; zero means unlimited")
+	flag.IntVar(&valueFamilyMaxUnique, "value-family-max-unique", 200000, "Maximum unique strings tracked per path; zero means unlimited")
 	flag.Parse()
 
 	if strings.TrimSpace(dbDir) == "" {
@@ -71,11 +79,15 @@ func run() (code int) {
 		return writeFailure(collectionName, fmt.Errorf("open collection: %w", err))
 	}
 	result, err := col.AuditRetainedPayloadDeclaredPathsAbsent(collections.ColumnRetainedPayloadCollectionAuditOptions{
-		Paths:             splitCSV(pathsCSV),
-		MaxDocuments:      maxDocuments,
-		IncludeShapeStats: shapeStats,
-		ShapeMaxDepth:     shapeMaxDepth,
-		ShapeMaxPaths:     shapeMaxPaths,
+		Paths:                   splitCSV(pathsCSV),
+		MaxDocuments:            maxDocuments,
+		IncludeShapeStats:       shapeStats,
+		ShapeMaxDepth:           shapeMaxDepth,
+		ShapeMaxPaths:           shapeMaxPaths,
+		IncludeValueFamilyStats: valueFamilyStats,
+		ValueFamilyMaxDepth:     valueFamilyMaxDepth,
+		ValueFamilyMaxPaths:     valueFamilyMaxPaths,
+		ValueFamilyMaxUnique:    valueFamilyMaxUnique,
 	})
 	if err != nil {
 		writeResult(result)

--- a/scripts/treedb_jsonbench_storage_audit.py
+++ b/scripts/treedb_jsonbench_storage_audit.py
@@ -1070,6 +1070,15 @@ def run_retained_payload_audit(
     limit = int(getattr(args, "retained_payload_audit_limit", 0) or 0)
     if limit > 0:
         command.extend(["-max-documents", str(limit)])
+    if getattr(args, "retained_payload_shape_stats", False):
+        command.append("-shape-stats")
+        command.extend(["-shape-max-depth", str(int(getattr(args, "retained_payload_shape_max_depth", 8) or 0))])
+        command.extend(["-shape-max-paths", str(int(getattr(args, "retained_payload_shape_max_paths", 128) or 0))])
+    if getattr(args, "retained_payload_value_family_stats", False):
+        command.append("-value-family-stats")
+        command.extend(["-value-family-max-depth", str(int(getattr(args, "retained_payload_value_family_max_depth", 8) or 0))])
+        command.extend(["-value-family-max-paths", str(int(getattr(args, "retained_payload_value_family_max_paths", 64) or 0))])
+        command.extend(["-value-family-max-unique", str(int(getattr(args, "retained_payload_value_family_max_unique", 200000) or 0))])
 
     try:
         completed = subprocess.run(command, cwd=cwd, check=False, text=True, capture_output=True)
@@ -1315,6 +1324,13 @@ def main() -> int:
     parser.add_argument("--skip-column-section-audit", action="store_true", help="Skip section-aware column-store audit and report filesystem gzip headroom only")
     parser.add_argument("--retained-payload-audit-cmd", help="Command used to run the retained-payload audit; defaults to go run ./cmd/treedb_retained_payload_audit")
     parser.add_argument("--retained-payload-audit-limit", type=int, default=0, help="Maximum retained rows to audit; zero audits all rows")
+    parser.add_argument("--retained-payload-shape-stats", action="store_true", help="Include decoded retained-payload shape stats")
+    parser.add_argument("--retained-payload-shape-max-depth", type=int, default=8, help="Maximum retained-payload shape traversal depth; zero means unlimited")
+    parser.add_argument("--retained-payload-shape-max-paths", type=int, default=128, help="Maximum retained-payload shape path/kind rows to emit; zero means unlimited")
+    parser.add_argument("--retained-payload-value-family-stats", action="store_true", help="Include decoded retained-payload string value-family stats")
+    parser.add_argument("--retained-payload-value-family-max-depth", type=int, default=8, help="Maximum retained-payload value-family traversal depth; zero means unlimited")
+    parser.add_argument("--retained-payload-value-family-max-paths", type=int, default=64, help="Maximum retained-payload value-family rows to emit; zero means unlimited")
+    parser.add_argument("--retained-payload-value-family-max-unique", type=int, default=200000, help="Maximum unique strings tracked per path; zero means unlimited")
     parser.add_argument("--skip-retained-payload-audit", action="store_true", help="Skip the path-aware retained-payload audit")
     args = parser.parse_args()
 

--- a/scripts/treedb_jsonbench_storage_audit_test.py
+++ b/scripts/treedb_jsonbench_storage_audit_test.py
@@ -348,6 +348,13 @@ class StorageAuditTest(unittest.TestCase):
                     "db_dir": str(Path(tmp) / "db"),
                     "retained_payload_audit_cmd": str(script),
                     "retained_payload_audit_limit": 0,
+                    "retained_payload_shape_stats": True,
+                    "retained_payload_shape_max_depth": 9,
+                    "retained_payload_shape_max_paths": 17,
+                    "retained_payload_value_family_stats": True,
+                    "retained_payload_value_family_max_depth": 7,
+                    "retained_payload_value_family_max_paths": 19,
+                    "retained_payload_value_family_max_unique": 23,
                     "skip_retained_payload_audit": False,
                 },
             )()
@@ -361,6 +368,13 @@ class StorageAuditTest(unittest.TestCase):
         self.assertIn("-paths", retained["command"])
         db_dir_index = retained["command"].index("-db-dir") + 1
         self.assertEqual(retained["command"][db_dir_index], str(main.resolve()))
+        self.assertIn("-shape-stats", retained["command"])
+        self.assertIn("-value-family-stats", retained["command"])
+        self.assertEqual(retained["command"][retained["command"].index("-shape-max-depth") + 1], "9")
+        self.assertEqual(retained["command"][retained["command"].index("-shape-max-paths") + 1], "17")
+        self.assertEqual(retained["command"][retained["command"].index("-value-family-max-depth") + 1], "7")
+        self.assertEqual(retained["command"][retained["command"].index("-value-family-max-paths") + 1], "19")
+        self.assertEqual(retained["command"][retained["command"].index("-value-family-max-unique") + 1], "23")
 
     def test_retained_payload_audit_runs_without_collection_metadata(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary
- Adds opt-in retained-payload string value-family stats to the collection audit: per-path occurrences/documents, string and JSON bytes, bounded/exact unique tracking, common prefix/suffix, length buckets, and gzip/ZSTD stream-oracle ratios.
- Extends `cmd/treedb_retained_payload_audit` with `-value-family-*` flags.
- Wires `scripts/treedb_jsonbench_storage_audit.py` so #2359 storage-audit runs can emit shape and value-family stats in `retained_payload_audit.json`.

## 100k smoke evidence
Existing retained DB: `/tmp/jsonbench_2662_origin_main_100k_20260613_0000/rows100000_column-store-full-prepared_json_full_all_compacted/db`.

Artifacts:
- Direct CLI: `/tmp/retained_value_family_audit_100k_20260613_2662.json`
- Storage wrapper: `/tmp/retained_value_family_storage_audit_100k_20260613_2662/compression_audit.json`

Top retained string families from the 100k wrapper run:
- `commit.cid`: 5,659,693 string bytes, 95,872 tracked unique values, ZSTD/input 0.5329
- `commit.record.subject.uri`: 3,564,605 string bytes, 32,669 tracked unique values, common prefix `at://did:plc:`, ZSTD/input 0.2309
- `commit.record.subject.cid`: 3,004,398 string bytes, 32,669 tracked unique values, ZSTD/input 0.4353
- `commit.record.createdAt`: 2,300,226 string bytes, 74,068 tracked unique values, ZSTD/input 0.1587
- `commit.record.$type`: 1,848,309 string bytes, 13 tracked unique values, ZSTD/input 0.0489

This supports the post-compact-string decision: the next retained reduction should preserve/strengthen cross-row compression by family instead of shortening individual per-document values in isolation.

## Validation
- `go test ./TreeDB/collections -run TestAuditCollectionRetainedPayloadValueFamilyStats2662 -count=1`
- `go test ./TreeDB/collections ./cmd/treedb_retained_payload_audit -count=1`
- `python3 -m unittest scripts.treedb_jsonbench_storage_audit_test`
- `git diff --check`
- `python3 scripts/treedb_jsonbench_storage_audit.py --db-dir /tmp/jsonbench_2662_origin_main_100k_20260613_0000/rows100000_column-store-full-prepared_json_full_all_compacted/db --result-json /tmp/jsonbench_2662_origin_main_100k_20260613_0000/rows100000_column-store-full-prepared_json_full_all_compacted/result.json --out-dir /tmp/retained_value_family_storage_audit_100k_20260613_2662 --retained-payload-shape-stats --retained-payload-shape-max-paths 24 --retained-payload-value-family-stats --retained-payload-value-family-max-paths 24 --retained-payload-value-family-max-unique 0`

Refs #2662 #2359 #2353.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added value-family statistics to retained-payload auditing, providing detailed analysis of string distributions including length metrics, uniqueness counts, and compression measurements.
  * New CLI configuration flags for controlling value-family statistics collection parameters.

* **Tests**
  * Added comprehensive test coverage for the new value-family statistics auditing capability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->