### PR TITLE
Fuse scalar_u8 prepared greedy scoring

### DIFF
--- a/TreeDB/collections/column_hnsw_prepared_greedy_test.go
+++ b/TreeDB/collections/column_hnsw_prepared_greedy_test.go
@@ -1,0 +1,159 @@
+package collections
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestScalarU8PreparedTraversalGreedyUpperLayerTie2659(t *testing.T) {
+	rows := []columnGraphRebuildInputRowV2A{
+		{id: "doc-a", vector: []float32{1, 0, 0}},
+		{id: "doc-b", vector: []float32{1, 0, 0}},
+		{id: "doc-c", vector: []float32{1, 0, 0}},
+	}
+	plane := prepareScalarU8PreparedGreedyPlaneForTest2659(t, rows, []float32{1, 0, 0})
+
+	var scoreScratch columnVectorGraphNativeSearchScratch
+	lowerScore, err := plane.scoreOrdinal(1, &scoreScratch, nil)
+	if err != nil {
+		t.Fatalf("score lower ordinal: %v", err)
+	}
+	higherScore, err := plane.scoreOrdinal(2, &scoreScratch, nil)
+	if err != nil {
+		t.Fatalf("score higher ordinal: %v", err)
+	}
+	if lowerScore != higherScore {
+		t.Fatalf("fixture scores lower=%v higher=%v want exact scalar_u8 tie", lowerScore, higherScore)
+	}
+
+	for _, tc := range []struct {
+		name      string
+		entry     int
+		neighbors []uint32
+		want      int
+		changed   bool
+	}{
+		{name: "lower_neighbor_wins_equal_score", entry: 2, neighbors: []uint32{1}, want: 1, changed: true},
+		{name: "higher_neighbor_does_not_replace_lower_best", entry: 1, neighbors: []uint32{2}, want: 1, changed: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			pack := scalarU8UpperLayerGreedyPackForTest2659(len(rows), tc.entry, tc.neighbors)
+			var scratch columnVectorGraphNativeSearchScratch
+			if err := plane.prepareForHNSWPreparedTraversal(pack, []float32{1, 0, 0}, columnHNSWPreparedTraversalOptions{}, &scratch); err != nil {
+				t.Fatalf("prepare traversal plane: %v", err)
+			}
+			var stats columnVectorGraphNativeSearchStats
+			var loopEdges uint64
+			got, err := pack.greedyNearestAtLayerPreparedScorePlane(plane, plane, tc.entry, 1, &scratch, &stats, true, &loopEdges)
+			if err != nil {
+				t.Fatalf("greedy upper layer: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("greedy best=%d want %d", got, tc.want)
+			}
+			if cap(scratch.scoreTileScores) != 0 {
+				t.Fatalf("scoreTileScores cap=%d want 0; scalar_u8 greedy seam should avoid float64 score staging", cap(scratch.scoreTileScores))
+			}
+			if stats.QuantizedScoreCalls != 2 {
+				t.Fatalf("QuantizedScoreCalls=%d want 2 (entry + one upper-layer neighbor)", stats.QuantizedScoreCalls)
+			}
+			if loopEdges != 1 {
+				t.Fatalf("loopEdges=%d want 1", loopEdges)
+			}
+
+			bestScore := lowerScore
+			if tc.changed {
+				bestScore = higherScore
+			}
+			var helperScratch columnVectorGraphNativeSearchScratch
+			newBest, newBestScore, helperChanged, err := plane.scoreGreedyBestRowIDsPrevalidated(tc.neighbors, tc.entry, bestScore, &helperScratch, nil)
+			if err != nil {
+				t.Fatalf("scoreGreedyBestRowIDsPrevalidated: %v", err)
+			}
+			if newBest != tc.want || helperChanged != tc.changed {
+				t.Fatalf("direct greedy best=%d changed=%v want best=%d changed=%v", newBest, helperChanged, tc.want, tc.changed)
+			}
+			if newBestScore != lowerScore {
+				t.Fatalf("direct greedy score=%v want public scalar_u8 score=%v", newBestScore, lowerScore)
+			}
+		})
+	}
+}
+
+func TestScalarU8PreparedTraversalGreedyUpperLayerBoundsFailClosed2659(t *testing.T) {
+	rows := []columnGraphRebuildInputRowV2A{
+		{id: "doc-a", vector: []float32{1, 0, 0}},
+		{id: "doc-b", vector: []float32{1, 0, 0}},
+		{id: "doc-c", vector: []float32{1, 0, 0}},
+	}
+	plane := prepareScalarU8PreparedGreedyPlaneForTest2659(t, rows, []float32{1, 0, 0})
+	pack := scalarU8UpperLayerGreedyPackForTest2659(len(rows), 2, []uint32{uint32(len(rows))})
+	var scratch columnVectorGraphNativeSearchScratch
+	if err := plane.prepareForHNSWPreparedTraversal(pack, []float32{1, 0, 0}, columnHNSWPreparedTraversalOptions{}, &scratch); err != nil {
+		t.Fatalf("prepare traversal plane: %v", err)
+	}
+	var stats columnVectorGraphNativeSearchStats
+	_, err := pack.greedyNearestAtLayerPreparedScorePlane(plane, plane, 2, 1, &scratch, &stats, true, nil)
+	if !errors.Is(err, errColumnVectorGraphAdjacencyOrdinalOutOfBounds) {
+		t.Fatalf("greedy invalid adjacency err=%v want %v", err, errColumnVectorGraphAdjacencyOrdinalOutOfBounds)
+	}
+	if stats.QuantizedScoreCalls != 1 {
+		t.Fatalf("QuantizedScoreCalls=%d want only entry scored before fail-closed adjacency validation", stats.QuantizedScoreCalls)
+	}
+	if cap(scratch.scoreTileScores) != 0 {
+		t.Fatalf("scoreTileScores cap=%d want 0 on fail-closed greedy path", cap(scratch.scoreTileScores))
+	}
+}
+
+func prepareScalarU8PreparedGreedyPlaneForTest2659(tb testing.TB, rows []columnGraphRebuildInputRowV2A, query []float32) *columnHNSWPreparedScalarU8ScorePlane {
+	tb.Helper()
+	_, d, col, def := openColumnGraphQuantizedGuardrailTestCollection1926(tb, rows)
+	tb.Cleanup(func() { _ = d.Close() })
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		tb.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	reader, err := col.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
+	if err != nil {
+		tb.Fatalf("open reader: %v", err)
+	}
+	tb.Cleanup(func() { _ = reader.Close() })
+	queryInvNorm, err := columnVectorGraphInvNorm(query)
+	if err != nil {
+		tb.Fatalf("query inv norm: %v", err)
+	}
+	var scratch columnVectorGraphNativeSearchScratch
+	scorer, err := reader.prepareScalarU8QuantizedScorer(columnVectorGraphNativeSearchQueryModeQuantizedOnly, def.QuantizedIndexes[0].Name, query, queryInvNorm, &scratch)
+	if err != nil {
+		tb.Fatalf("prepare scalar_u8 scorer: %v", err)
+	}
+	return &columnHNSWPreparedScalarU8ScorePlane{scorer: scorer, ready: true}
+}
+
+func scalarU8UpperLayerGreedyPackForTest2659(rowCount int, adjacencyOrdinal int, neighbors []uint32) *columnHNSWSearchPackPreparedView {
+	upperOffsets := make([]uint64, rowCount+1)
+	upperNeighbors := make([]uint32, 0, len(neighbors))
+	for ordinal := 0; ordinal < rowCount; ordinal++ {
+		upperOffsets[ordinal] = uint64(len(upperNeighbors))
+		if ordinal == adjacencyOrdinal {
+			upperNeighbors = append(upperNeighbors, neighbors...)
+		}
+	}
+	upperOffsets[rowCount] = uint64(len(upperNeighbors))
+	return &columnHNSWSearchPackPreparedView{
+		Header: columnHNSWSearchPackHeader{
+			Rows:                rowCount,
+			Dimensions:          3,
+			VectorStride:        3,
+			M:                   3,
+			EfSearch:            rowCount,
+			EntryOrdinal:        adjacencyOrdinal,
+			MaxLayer:            1,
+			AdjacencyLayerCount: 2,
+		},
+		Levels: make([]uint16, rowCount),
+		AdjacencyLayers: []columnHNSWSearchPackPreparedLayer{
+			{Offsets: make([]uint64, rowCount+1)},
+			{Offsets: upperOffsets, Neighbors: upperNeighbors},
+		},
+	}
+}

--- a/TreeDB/collections/column_hnsw_prepared_quantized_search.go
+++ b/TreeDB/collections/column_hnsw_prepared_quantized_search.go
@@ -52,6 +52,13 @@ func (p *columnHNSWPreparedScalarU8ScorePlane) scoreRowIDsPrevalidated(rowIDs []
 	return p.scorer.scoreRowIDsPrevalidated(rowIDs, dst, scratch, stats)
 }
 
+func (p *columnHNSWPreparedScalarU8ScorePlane) scoreGreedyBestRowIDsPrevalidated(rowIDs []uint32, best int, bestScore float64, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) (int, float64, bool, error) {
+	if p == nil || !p.ready {
+		return best, bestScore, false, errColumnHNSWPreparedTraversalScorePlaneUnavailable
+	}
+	return p.scorer.scoreGreedyBestRowIDsPrevalidated(rowIDs, best, bestScore, scratch, stats)
+}
+
 func (p *columnHNSWPreparedScalarU8ScorePlane) scoreRawDotOrdinal(ordinal int, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) (int64, error) {
 	if p == nil || !p.ready {
 		return 0, errColumnHNSWPreparedTraversalScorePlaneUnavailable

--- a/TreeDB/collections/column_hnsw_prepared_traversal.go
+++ b/TreeDB/collections/column_hnsw_prepared_traversal.go
@@ -72,6 +72,17 @@ type columnHNSWPreparedTraversalRowIDScorePlane interface {
 	scoreAndPushFrontierVisitedRowIDsPrevalidated(rowIDs []uint32, topK int, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) (int, error)
 }
 
+// columnHNSWPreparedTraversalRowIDGreedyScorePlane is the scalar_u8 prepared
+// traversal fusion seam for upper layers. It scores already-validated adjacency
+// row IDs and updates the greedy best directly, preserving the float64 score
+// formula and lower-ordinal tie behavior without staging a float64 score slice
+// followed by a second generic compare loop. It intentionally fuses the default
+// float64 prepared traversal because the raw-dot scalar_u8 traversal remains
+// default-off/no-promote until it is separately proven neutral or faster.
+type columnHNSWPreparedTraversalRowIDGreedyScorePlane interface {
+	scoreGreedyBestRowIDsPrevalidated(rowIDs []uint32, best int, bestScore float64, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) (newBest int, newBestScore float64, changed bool, err error)
+}
+
 // columnHNSWPreparedTraversalRawDotScorePlane is the scalar_u8-only ordering
 // seam for prepared traversal. It keeps raw centered dot products in the
 // frontier/top-k queues and converts to public float64 scores only when leaving
@@ -411,6 +422,7 @@ func (v *columnHNSWSearchPackPreparedView) searchCosinePreparedScorePlane(query 
 }
 
 func (v *columnHNSWSearchPackPreparedView) greedyNearestAtLayerPreparedScorePlane(scorePlane columnHNSWPreparedTraversalScorePlane, rowIDScorePlane columnHNSWPreparedTraversalRowIDScorePlane, entryOrdinal int, layer int, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats, countLoopEdges bool, loopEdgeVisits *uint64) (int, error) {
+	greedyScorePlane, _ := rowIDScorePlane.(columnHNSWPreparedTraversalRowIDGreedyScorePlane)
 	best := entryOrdinal
 	bestScore, err := scorePlane.scoreOrdinal(best, scratch, stats)
 	if err != nil {
@@ -433,6 +445,18 @@ func (v *columnHNSWSearchPackPreparedView) greedyNearestAtLayerPreparedScorePlan
 			if uint64(neighbor) >= uint64(v.Header.Rows) {
 				return 0, fmt.Errorf("collections: hnsw_search_pack_v1 prepared traversal ordinal=%d layer=%d adjacency[%d]=%d outside row_count=%d: %w", best, layer, i, neighbor, v.Header.Rows, errColumnVectorGraphAdjacencyOrdinalOutOfBounds)
 			}
+		}
+		if greedyScorePlane != nil {
+			newBest, newBestScore, greedyChanged, err := greedyScorePlane.scoreGreedyBestRowIDsPrevalidated(adjacency, best, bestScore, scratch, stats)
+			if err != nil {
+				return 0, err
+			}
+			if greedyChanged {
+				best = newBest
+				bestScore = newBestScore
+				changed = true
+			}
+			continue
 		}
 		if rowIDScorePlane != nil {
 			scratch.scoreTileScores = ensureColumnVectorGraphNativeFloat64Scratch(scratch.scoreTileScores, len(adjacency))

--- a/TreeDB/collections/column_vector_graph_quantized_scorer.go
+++ b/TreeDB/collections/column_vector_graph_quantized_scorer.go
@@ -330,6 +330,34 @@ func (s *columnVectorGraphScalarU8QuantizedScorer) scoreRawDotRowIDsPrepared(row
 	return dst, nil
 }
 
+func (s *columnVectorGraphScalarU8QuantizedScorer) scoreGreedyBestRowIDsPrevalidated(rowIDs []uint32, best int, bestScore float64, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) (int, float64, bool, error) {
+	if len(rowIDs) == 0 {
+		return best, bestScore, false, nil
+	}
+	var dotScratch []int64
+	if scratch != nil {
+		dotScratch = scratch.scoreTileQuantizedDots
+	}
+	dots, err := s.scoreRawDotRowIDsPrevalidated(rowIDs, dotScratch, scratch, stats)
+	if err != nil {
+		return best, bestScore, false, err
+	}
+	changed := false
+	for i, rowID := range rowIDs {
+		neighborOrdinal := int(rowID)
+		score := scalarU8QuantizedCosineScoreFromDot(dots[i])
+		// Preserve the prepared traversal's public float64 score formula and
+		// exact lower-ordinal tie behavior while avoiding the intermediate
+		// float64 score tile used by the generic row-ID score seam.
+		if score > bestScore || (score == bestScore && neighborOrdinal < best) {
+			best = neighborOrdinal
+			bestScore = score
+			changed = true
+		}
+	}
+	return best, bestScore, changed, nil
+}
+
 func (s *columnVectorGraphScalarU8QuantizedScorer) scoreAndPushFrontierVisitedRowIDsPrevalidated(rowIDs []uint32, topK int, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) (int, error) {
 	if len(rowIDs) == 0 {
 		return 0, nil


### PR DESCRIPTION
## Summary

Closes #2659.

- Adds a scalar_u8 prepared traversal greedy score-plane seam for upper HNSW layers.
- Scores already-validated row IDs directly with the scalar_u8 dot scorer and updates the greedy best without staging `scratch.scoreTileScores` or running a second generic compare loop.
- Preserves public float64 score conversion and lower-ordinal tie behavior; #2658 raw-dot traversal remains default-off/no-promote.

## Correctness / invariants

- Adjacency bounds are still validated before the fused scalar_u8 greedy call.
- Exact/non-scalar prepared routes keep the existing generic row-ID/ordinal paths.
- Quantized routes remain fail-closed; no fallback-to-exact behavior is introduced.
- Hot search rows remain expected to report `0 B/op`, `0 allocs/op`.

## Local validation

Latest-head tests on `dba25b1ff` base:

```sh
GOMAXPROCS=8 GOWORK=off go test ./TreeDB/collections -run 'TestScalarU8PreparedTraversalGreedyUpperLayer.*2659' -count=1
GOMAXPROCS=8 GOWORK=off go test ./TreeDB/internal/vectorops ./TreeDB/collections -count=1
```

Artifacts:

- `/tmp/scalar_u8_adapter_2659/test_focused_2659_rebased_dba25b.log`
- `/tmp/scalar_u8_adapter_2659/test_vectorops_collections_2659_rebased_dba25b.log`

Benchmark matrix is pending a clean idle-machine run. Two baseline attempts completed but were marked invalid because unrelated TreeDB tests started during the run:

- `/tmp/scalar_u8_adapter_2659/bench_base_required_dba25b.INVALID-overlap`
- `/tmp/scalar_u8_adapter_2659/bench_base_required_dba25b_rerun2.INVALID-overlap`

Required rerun before review/merge:

```sh
TREEDB_COLUMN_GRAPH_QUANTIZED_BENCH_SHAPE=10k_x_768 GOMAXPROCS=8 GOWORK=off go test ./TreeDB/collections -run '^$' -bench 'ScalarU8Quantized.*241|CollectionVectorQuantizedProductionGate2591' -benchmem -benchtime=100000x -count=10
```
