### PR TITLE
TreeDB: audit retained semantic scalar streams

### DIFF
--- a/TreeDB/collections/column_retained_payload_audit.go
+++ b/TreeDB/collections/column_retained_payload_audit.go
@@ -84,6 +84,9 @@ type ColumnRetainedPayloadCollectionAuditOptions struct {
 	ValueFamilyMaxDepth     int
 	ValueFamilyMaxPaths     int
 	ValueFamilyMaxUnique    int
+	IncludeSemanticStreams  bool
+	SemanticStreamMaxDepth  int
+	SemanticStreamMaxPaths  int
 }
 
 type ColumnRetainedPayloadCollectionPathViolation struct {
@@ -138,25 +141,48 @@ type ColumnRetainedPayloadValueFamilyStat struct {
 	ZSTDToInputRatio      float64                             `json:"zstd_to_input_ratio,omitempty"`
 }
 
+// ColumnRetainedPayloadSemanticStreamStat estimates the scalar stream bytes a
+// ClickHouse-like semantic retained payload layout would need by path and kind.
+// It is an oracle over decoded values, not a claim about the current on-disk
+// format: object shape/presence metadata and reconstruction layout are separate
+// format choices.
+type ColumnRetainedPayloadSemanticStreamStat struct {
+	Path             string  `json:"path"`
+	ValueKind        string  `json:"value_kind"`
+	Occurrences      int64   `json:"occurrences"`
+	Documents        int64   `json:"documents"`
+	JSONBytes        int64   `json:"json_bytes"`
+	StringBytes      int64   `json:"string_bytes,omitempty"`
+	StreamInputBytes int64   `json:"stream_input_bytes"`
+	MinStreamBytes   int     `json:"min_stream_bytes"`
+	MaxStreamBytes   int     `json:"max_stream_bytes"`
+	ZSTDBytes        int64   `json:"zstd_bytes,omitempty"`
+	ZSTDToInputRatio float64 `json:"zstd_to_input_ratio,omitempty"`
+}
+
 type ColumnRetainedPayloadCollectionAuditResult struct {
-	Collection                            string                                         `json:"collection"`
-	Status                                string                                         `json:"status"`
-	RetainedPayloadPolicy                 ColumnRetainedPayloadPolicy                    `json:"retained_payload_policy"`
-	RetainedPayloadEncoding               string                                         `json:"retained_payload_encoding"`
-	RetainedPayloadEncodingStatus         string                                         `json:"retained_payload_encoding_status"`
-	RetainedPayloadCompression            string                                         `json:"retained_payload_compression"`
-	RetainedPayloadCompressionPolicy      string                                         `json:"retained_payload_compression_policy"`
-	RetainedPayloadCompressionStatus      string                                         `json:"retained_payload_compression_status"`
-	DeclaredPaths                         []string                                       `json:"declared_paths"`
-	CheckedRows                           int                                            `json:"checked_rows"`
-	RetainedPayloadBytes                  int64                                          `json:"retained_payload_bytes"`
-	RetainedPayloadShape                  []ColumnRetainedPayloadShapePathStat           `json:"retained_payload_shape,omitempty"`
-	RetainedPayloadShapeTruncated         bool                                           `json:"retained_payload_shape_truncated,omitempty"`
-	RetainedPayloadValueFamilies          []ColumnRetainedPayloadValueFamilyStat         `json:"retained_payload_value_families,omitempty"`
-	RetainedPayloadValueFamiliesTruncated bool                                           `json:"retained_payload_value_families_truncated,omitempty"`
-	Truncated                             bool                                           `json:"truncated,omitempty"`
-	Violations                            []ColumnRetainedPayloadCollectionPathViolation `json:"violations,omitempty"`
-	Errors                                []string                                       `json:"errors,omitempty"`
+	Collection                              string                                         `json:"collection"`
+	Status                                  string                                         `json:"status"`
+	RetainedPayloadPolicy                   ColumnRetainedPayloadPolicy                    `json:"retained_payload_policy"`
+	RetainedPayloadEncoding                 string                                         `json:"retained_payload_encoding"`
+	RetainedPayloadEncodingStatus           string                                         `json:"retained_payload_encoding_status"`
+	RetainedPayloadCompression              string                                         `json:"retained_payload_compression"`
+	RetainedPayloadCompressionPolicy        string                                         `json:"retained_payload_compression_policy"`
+	RetainedPayloadCompressionStatus        string                                         `json:"retained_payload_compression_status"`
+	DeclaredPaths                           []string                                       `json:"declared_paths"`
+	CheckedRows                             int                                            `json:"checked_rows"`
+	RetainedPayloadBytes                    int64                                          `json:"retained_payload_bytes"`
+	RetainedPayloadShape                    []ColumnRetainedPayloadShapePathStat           `json:"retained_payload_shape,omitempty"`
+	RetainedPayloadShapeTruncated           bool                                           `json:"retained_payload_shape_truncated,omitempty"`
+	RetainedPayloadValueFamilies            []ColumnRetainedPayloadValueFamilyStat         `json:"retained_payload_value_families,omitempty"`
+	RetainedPayloadValueFamiliesTruncated   bool                                           `json:"retained_payload_value_families_truncated,omitempty"`
+	RetainedPayloadSemanticStreams          []ColumnRetainedPayloadSemanticStreamStat      `json:"retained_payload_semantic_streams,omitempty"`
+	RetainedPayloadSemanticStreamsTruncated bool                                           `json:"retained_payload_semantic_streams_truncated,omitempty"`
+	RetainedPayloadSemanticStreamInputBytes int64                                          `json:"retained_payload_semantic_stream_input_bytes,omitempty"`
+	RetainedPayloadSemanticStreamZSTDBytes  int64                                          `json:"retained_payload_semantic_stream_zstd_bytes,omitempty"`
+	Truncated                               bool                                           `json:"truncated,omitempty"`
+	Violations                              []ColumnRetainedPayloadCollectionPathViolation `json:"violations,omitempty"`
+	Errors                                  []string                                       `json:"errors,omitempty"`
 }
 
 // AuditColumnRetainedPayloadPathsAbsent verifies that declared typed JSON paths
@@ -260,7 +286,7 @@ func (c *Collection) AuditRetainedPayloadDeclaredPathsAbsent(opts ColumnRetained
 	defer func() { _ = it.Close() }()
 
 	resolver := columnRetainedPayloadTemplateResolver(snap, catalog)
-	includeDecodedStats := opts.IncludeShapeStats || opts.IncludeValueFamilyStats
+	includeDecodedStats := opts.IncludeShapeStats || opts.IncludeValueFamilyStats || opts.IncludeSemanticStreams
 	var shape *columnRetainedPayloadShapeCollector
 	if opts.IncludeShapeStats {
 		shape = newColumnRetainedPayloadShapeCollector(opts.ShapeMaxDepth)
@@ -268,6 +294,10 @@ func (c *Collection) AuditRetainedPayloadDeclaredPathsAbsent(opts ColumnRetained
 	var valueFamilies *columnRetainedPayloadValueFamilyCollector
 	if opts.IncludeValueFamilyStats {
 		valueFamilies = newColumnRetainedPayloadValueFamilyCollector(opts.ValueFamilyMaxDepth, opts.ValueFamilyMaxUnique)
+	}
+	var semanticStreams *columnRetainedPayloadSemanticStreamCollector
+	if opts.IncludeSemanticStreams {
+		semanticStreams = newColumnRetainedPayloadSemanticStreamCollector(opts.SemanticStreamMaxDepth)
 	}
 	for it.Valid() {
 		if opts.MaxDocuments > 0 && result.CheckedRows >= opts.MaxDocuments {
@@ -308,6 +338,9 @@ func (c *Collection) AuditRetainedPayloadDeclaredPathsAbsent(opts ColumnRetained
 			if auditErr == nil && valueFamilies != nil {
 				auditErr = valueFamilies.addDocumentObject(obj)
 			}
+			if auditErr == nil && semanticStreams != nil {
+				auditErr = semanticStreams.addDocumentObject(obj)
+			}
 			if auditErr != nil {
 				auditErr = fmt.Errorf("collections: retained payload audit %q: %w", documentID, auditErr)
 			}
@@ -338,6 +371,16 @@ func (c *Collection) AuditRetainedPayloadDeclaredPathsAbsent(opts ColumnRetained
 		}
 		result.RetainedPayloadValueFamilies = valueFamilyStats
 		result.RetainedPayloadValueFamiliesTruncated = truncated
+	}
+	if opts.IncludeSemanticStreams {
+		semanticStreamStats, truncated, inputBytes, zstdBytes, err := semanticStreams.result(opts.SemanticStreamMaxPaths)
+		if err != nil {
+			return retainedPayloadCollectionAuditError(result, err)
+		}
+		result.RetainedPayloadSemanticStreams = semanticStreamStats
+		result.RetainedPayloadSemanticStreamsTruncated = truncated
+		result.RetainedPayloadSemanticStreamInputBytes = inputBytes
+		result.RetainedPayloadSemanticStreamZSTDBytes = zstdBytes
 	}
 	if result.Truncated {
 		result.Status = "passed_sampled"
@@ -525,6 +568,167 @@ func (c *columnRetainedPayloadShapeCollector) result(maxPaths int) ([]ColumnReta
 		return out[:maxPaths], true
 	}
 	return out, false
+}
+
+type columnRetainedPayloadSemanticStreamKey struct {
+	path string
+	kind string
+}
+
+type columnRetainedPayloadSemanticStreamCollector struct {
+	byKey    map[columnRetainedPayloadSemanticStreamKey]*columnRetainedPayloadSemanticStreamPath
+	maxDepth int
+}
+
+type columnRetainedPayloadSemanticStreamPath struct {
+	stat        ColumnRetainedPayloadSemanticStreamStat
+	zstdCounter columnRetainedPayloadCountingWriter
+	zstdWriter  *zstd.Encoder
+}
+
+func newColumnRetainedPayloadSemanticStreamCollector(maxDepth int) *columnRetainedPayloadSemanticStreamCollector {
+	return &columnRetainedPayloadSemanticStreamCollector{
+		byKey:    make(map[columnRetainedPayloadSemanticStreamKey]*columnRetainedPayloadSemanticStreamPath),
+		maxDepth: maxDepth,
+	}
+}
+
+func (c *columnRetainedPayloadSemanticStreamCollector) addDocumentObject(obj map[string]any) error {
+	if c == nil || obj == nil {
+		return nil
+	}
+	seen := make(map[columnRetainedPayloadSemanticStreamKey]struct{})
+	keys := make([]string, 0, len(obj))
+	for key := range obj {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		if err := c.addValue(key, obj[key], 1, seen); err != nil {
+			return err
+		}
+	}
+	for key := range seen {
+		c.byKey[key].stat.Documents++
+	}
+	return nil
+}
+
+func (c *columnRetainedPayloadSemanticStreamCollector) addValue(path string, value any, depth int, seen map[columnRetainedPayloadSemanticStreamKey]struct{}) error {
+	if kind, ok := columnRetainedPayloadScalarStreamValueKind(value); ok {
+		if err := c.addScalar(path, kind, value); err != nil {
+			return err
+		}
+		seen[columnRetainedPayloadSemanticStreamKey{path: path, kind: kind}] = struct{}{}
+	}
+	if c.maxDepth > 0 && depth >= c.maxDepth {
+		return nil
+	}
+	switch typed := value.(type) {
+	case map[string]any:
+		keys := make([]string, 0, len(typed))
+		for key := range typed {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		for _, key := range keys {
+			if err := c.addValue(path+"."+key, typed[key], depth+1, seen); err != nil {
+				return err
+			}
+		}
+	case []any:
+		childPath := path + "[]"
+		for _, child := range typed {
+			if err := c.addValue(childPath, child, depth+1, seen); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (c *columnRetainedPayloadSemanticStreamCollector) addScalar(path, kind string, value any) error {
+	key := columnRetainedPayloadSemanticStreamKey{path: path, kind: kind}
+	stream := c.byKey[key]
+	if stream == nil {
+		stream = &columnRetainedPayloadSemanticStreamPath{
+			stat: ColumnRetainedPayloadSemanticStreamStat{Path: path, ValueKind: kind},
+		}
+		zstdWriter, err := zstd.NewWriter(&stream.zstdCounter,
+			zstd.WithEncoderLevel(zstd.SpeedFastest),
+			zstd.WithEncoderCRC(false),
+			zstd.WithEncoderConcurrency(1),
+		)
+		if err != nil {
+			return fmt.Errorf("create semantic-stream zstd oracle for path %q kind %q: %w", path, kind, err)
+		}
+		stream.zstdWriter = zstdWriter
+		c.byKey[key] = stream
+	}
+
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return fmt.Errorf("marshal semantic-stream path %q kind %q: %w", path, kind, err)
+	}
+	streamBytes := len(encoded) + 1
+	stream.stat.Occurrences++
+	stream.stat.JSONBytes += int64(len(encoded))
+	stream.stat.StreamInputBytes += int64(streamBytes)
+	if stream.stat.Occurrences == 1 || streamBytes < stream.stat.MinStreamBytes {
+		stream.stat.MinStreamBytes = streamBytes
+	}
+	if streamBytes > stream.stat.MaxStreamBytes {
+		stream.stat.MaxStreamBytes = streamBytes
+	}
+	if s, ok := value.(string); ok {
+		stream.stat.StringBytes += int64(len(s))
+	}
+	if _, err := stream.zstdWriter.Write(encoded); err != nil {
+		return fmt.Errorf("write semantic-stream zstd oracle for path %q kind %q: %w", path, kind, err)
+	}
+	if _, err := stream.zstdWriter.Write([]byte{'\n'}); err != nil {
+		return fmt.Errorf("write semantic-stream zstd oracle separator for path %q kind %q: %w", path, kind, err)
+	}
+	return nil
+}
+
+func (c *columnRetainedPayloadSemanticStreamCollector) result(maxPaths int) ([]ColumnRetainedPayloadSemanticStreamStat, bool, int64, int64, error) {
+	if c == nil || len(c.byKey) == 0 {
+		return nil, false, 0, 0, nil
+	}
+	out := make([]ColumnRetainedPayloadSemanticStreamStat, 0, len(c.byKey))
+	var totalInputBytes int64
+	var totalZSTDBytes int64
+	for key, stream := range c.byKey {
+		if stream.zstdWriter != nil {
+			if err := stream.zstdWriter.Close(); err != nil {
+				return nil, false, 0, 0, fmt.Errorf("close semantic-stream zstd oracle for path %q kind %q: %w", key.path, key.kind, err)
+			}
+			stream.zstdWriter = nil
+		}
+		stat := stream.stat
+		stat.ZSTDBytes = stream.zstdCounter.n
+		stat.ZSTDToInputRatio = columnRetainedPayloadAuditRatio(stat.ZSTDBytes, stat.StreamInputBytes)
+		totalInputBytes += stat.StreamInputBytes
+		totalZSTDBytes += stat.ZSTDBytes
+		out = append(out, stat)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].StreamInputBytes != out[j].StreamInputBytes {
+			return out[i].StreamInputBytes > out[j].StreamInputBytes
+		}
+		if out[i].Occurrences != out[j].Occurrences {
+			return out[i].Occurrences > out[j].Occurrences
+		}
+		if out[i].Path != out[j].Path {
+			return out[i].Path < out[j].Path
+		}
+		return out[i].ValueKind < out[j].ValueKind
+	})
+	if maxPaths > 0 && len(out) > maxPaths {
+		return out[:maxPaths], true, totalInputBytes, totalZSTDBytes, nil
+	}
+	return out, false, totalInputBytes, totalZSTDBytes, nil
 }
 
 type columnRetainedPayloadValueFamilyCollector struct {
@@ -832,5 +1036,20 @@ func columnRetainedPayloadShapeValueKind(value any) string {
 		return "array"
 	default:
 		return "unknown"
+	}
+}
+
+func columnRetainedPayloadScalarStreamValueKind(value any) (string, bool) {
+	switch value.(type) {
+	case nil:
+		return "null", true
+	case bool:
+		return "bool", true
+	case string:
+		return "string", true
+	case float32, float64, int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64, json.Number:
+		return "number", true
+	default:
+		return "", false
 	}
 }

--- a/TreeDB/collections/column_retained_payload_audit_test.go
+++ b/TreeDB/collections/column_retained_payload_audit_test.go
@@ -322,6 +322,81 @@ func TestAuditCollectionRetainedPayloadValueFamilyStats2662(t *testing.T) {
 	}
 }
 
+func TestAuditCollectionRetainedPayloadSemanticStreamStats2662(t *testing.T) {
+	col, closeDB := openRetainedPayloadAuditCollection2382(t, jsonbenchRetainedPayloadAuditConfig2382(true), [][]byte{
+		[]byte(`{"time_us":1,"kind":"commit","did":"did:plc:one","commit":{"operation":"create","collection":"app.bsky.feed.post","rkey":"r-0001","record":{"subject":{"uri":"at://did:plc:alice/app.bsky.feed.post/3aaa"},"likeCount":7,"repost":false}},"tags":["alpha","beta"],"empty":null}`),
+		[]byte(`{"time_us":2,"kind":"commit","did":"did:plc:two","commit":{"operation":"update","collection":"app.bsky.feed.post","rkey":"r-0002","record":{"subject":{"uri":"at://did:plc:bob/app.bsky.feed.post/3bbb"},"likeCount":8,"repost":true}},"tags":["alpha"],"empty":null}`),
+	})
+	defer closeDB()
+
+	audit, err := col.AuditRetainedPayloadDeclaredPathsAbsent(ColumnRetainedPayloadCollectionAuditOptions{
+		IncludeSemanticStreams: true,
+		SemanticStreamMaxDepth: 8,
+	})
+	if err != nil {
+		t.Fatalf("AuditRetainedPayloadDeclaredPathsAbsent semantic streams: %v audit=%+v", err, audit)
+	}
+	if audit.Status != "passed" || audit.CheckedRows != 2 {
+		t.Fatalf("audit=%+v want passed two rows", audit)
+	}
+	if len(audit.RetainedPayloadSemanticStreams) == 0 || audit.RetainedPayloadSemanticStreamsTruncated {
+		t.Fatalf("semantic streams=%+v truncated=%v", audit.RetainedPayloadSemanticStreams, audit.RetainedPayloadSemanticStreamsTruncated)
+	}
+	if audit.RetainedPayloadSemanticStreamInputBytes <= 0 || audit.RetainedPayloadSemanticStreamZSTDBytes <= 0 {
+		t.Fatalf("semantic stream total bytes missing: input=%d zstd=%d audit=%+v", audit.RetainedPayloadSemanticStreamInputBytes, audit.RetainedPayloadSemanticStreamZSTDBytes, audit)
+	}
+
+	rkey, ok := retainedPayloadSemanticStreamStat2662(audit.RetainedPayloadSemanticStreams, "commit.rkey", "string")
+	if !ok {
+		t.Fatalf("missing commit.rkey semantic stream: %+v", audit.RetainedPayloadSemanticStreams)
+	}
+	if rkey.Occurrences != 2 || rkey.Documents != 2 || rkey.StringBytes != int64(len("r-0001")+len("r-0002")) {
+		t.Fatalf("commit.rkey semantic stream=%+v", rkey)
+	}
+	if rkey.JSONBytes != 16 || rkey.StreamInputBytes != 18 || rkey.MinStreamBytes != 9 || rkey.MaxStreamBytes != 9 {
+		t.Fatalf("commit.rkey semantic stream byte counters=%+v", rkey)
+	}
+	if rkey.ZSTDBytes <= 0 || rkey.ZSTDToInputRatio <= 0 {
+		t.Fatalf("commit.rkey semantic stream zstd counters=%+v", rkey)
+	}
+	tags, ok := retainedPayloadSemanticStreamStat2662(audit.RetainedPayloadSemanticStreams, "tags[]", "string")
+	if !ok || tags.Occurrences != 3 || tags.Documents != 2 || tags.StringBytes != int64(len("alpha")+len("beta")+len("alpha")) {
+		t.Fatalf("tags semantic stream=%+v ok=%v", tags, ok)
+	}
+	likes, ok := retainedPayloadSemanticStreamStat2662(audit.RetainedPayloadSemanticStreams, "commit.record.likeCount", "number")
+	if !ok || likes.Occurrences != 2 || likes.Documents != 2 || likes.JSONBytes != 2 || likes.StreamInputBytes != 4 {
+		t.Fatalf("likeCount semantic stream=%+v ok=%v", likes, ok)
+	}
+	repost, ok := retainedPayloadSemanticStreamStat2662(audit.RetainedPayloadSemanticStreams, "commit.record.repost", "bool")
+	if !ok || repost.Occurrences != 2 || repost.Documents != 2 || repost.JSONBytes != 9 || repost.StreamInputBytes != 11 {
+		t.Fatalf("repost semantic stream=%+v ok=%v", repost, ok)
+	}
+	empty, ok := retainedPayloadSemanticStreamStat2662(audit.RetainedPayloadSemanticStreams, "empty", "null")
+	if !ok || empty.Occurrences != 2 || empty.Documents != 2 || empty.JSONBytes != 8 || empty.StreamInputBytes != 10 {
+		t.Fatalf("empty null semantic stream=%+v ok=%v", empty, ok)
+	}
+	if _, ok := retainedPayloadSemanticStreamStat2662(audit.RetainedPayloadSemanticStreams, "kind", "string"); ok {
+		t.Fatalf("declared kind path leaked into semantic streams: %+v", audit.RetainedPayloadSemanticStreams)
+	}
+	if _, ok := retainedPayloadSemanticStreamStat2662(audit.RetainedPayloadSemanticStreams, "commit.operation", "string"); ok {
+		t.Fatalf("declared commit.operation path leaked into semantic streams: %+v", audit.RetainedPayloadSemanticStreams)
+	}
+
+	limited, err := col.AuditRetainedPayloadDeclaredPathsAbsent(ColumnRetainedPayloadCollectionAuditOptions{
+		IncludeSemanticStreams: true,
+		SemanticStreamMaxPaths: 1,
+	})
+	if err != nil {
+		t.Fatalf("AuditRetainedPayloadDeclaredPathsAbsent path-limited semantic streams: %v audit=%+v", err, limited)
+	}
+	if !limited.RetainedPayloadSemanticStreamsTruncated || len(limited.RetainedPayloadSemanticStreams) != 1 {
+		t.Fatalf("path-limited semantic streams=%+v truncated=%v want one truncated row", limited.RetainedPayloadSemanticStreams, limited.RetainedPayloadSemanticStreamsTruncated)
+	}
+	if limited.RetainedPayloadSemanticStreamInputBytes != audit.RetainedPayloadSemanticStreamInputBytes {
+		t.Fatalf("limited semantic input bytes=%d want full total %d", limited.RetainedPayloadSemanticStreamInputBytes, audit.RetainedPayloadSemanticStreamInputBytes)
+	}
+}
+
 func TestAuditCollectionRetainedPayloadDeclaredPathsAbsentFailsClosed2382(t *testing.T) {
 	cfg := jsonbenchRetainedPayloadAuditConfig2382(false)
 	col, closeDB := openRetainedPayloadAuditCollection2382(t, cfg, [][]byte{
@@ -444,6 +519,15 @@ func retainedPayloadValueFamilyStat2662(stats []ColumnRetainedPayloadValueFamily
 		}
 	}
 	return ColumnRetainedPayloadValueFamilyStat{}, false
+}
+
+func retainedPayloadSemanticStreamStat2662(stats []ColumnRetainedPayloadSemanticStreamStat, path, kind string) (ColumnRetainedPayloadSemanticStreamStat, bool) {
+	for _, stat := range stats {
+		if stat.Path == path && stat.ValueKind == kind {
+			return stat, true
+		}
+	}
+	return ColumnRetainedPayloadSemanticStreamStat{}, false
 }
 
 func retainedPayloadValueFamilyBucketCount2662(buckets []ColumnRetainedPayloadLengthBucket, name string) int64 {

--- a/TreeDB/collections/column_retained_payload_audit_test.go
+++ b/TreeDB/collections/column_retained_payload_audit_test.go
@@ -323,9 +323,10 @@ func TestAuditCollectionRetainedPayloadValueFamilyStats2662(t *testing.T) {
 }
 
 func TestAuditCollectionRetainedPayloadSemanticStreamStats2662(t *testing.T) {
+	compressibleBody := strings.Repeat("semantic-stream-compressible-", 32)
 	col, closeDB := openRetainedPayloadAuditCollection2382(t, jsonbenchRetainedPayloadAuditConfig2382(true), [][]byte{
-		[]byte(`{"time_us":1,"kind":"commit","did":"did:plc:one","commit":{"operation":"create","collection":"app.bsky.feed.post","rkey":"r-0001","record":{"subject":{"uri":"at://did:plc:alice/app.bsky.feed.post/3aaa"},"likeCount":7,"repost":false}},"tags":["alpha","beta"],"empty":null}`),
-		[]byte(`{"time_us":2,"kind":"commit","did":"did:plc:two","commit":{"operation":"update","collection":"app.bsky.feed.post","rkey":"r-0002","record":{"subject":{"uri":"at://did:plc:bob/app.bsky.feed.post/3bbb"},"likeCount":8,"repost":true}},"tags":["alpha"],"empty":null}`),
+		[]byte(`{"time_us":1,"kind":"commit","did":"did:plc:one","commit":{"operation":"create","collection":"app.bsky.feed.post","rkey":"r-0001","record":{"subject":{"uri":"at://did:plc:alice/app.bsky.feed.post/3aaa"},"likeCount":7,"repost":false,"body":"` + compressibleBody + `"}},"tags":["alpha","beta"],"empty":null}`),
+		[]byte(`{"time_us":2,"kind":"commit","did":"did:plc:two","commit":{"operation":"update","collection":"app.bsky.feed.post","rkey":"r-0002","record":{"subject":{"uri":"at://did:plc:bob/app.bsky.feed.post/3bbb"},"likeCount":8,"repost":true,"body":"` + compressibleBody + `"}},"tags":["alpha"],"empty":null}`),
 	})
 	defer closeDB()
 
@@ -345,6 +346,9 @@ func TestAuditCollectionRetainedPayloadSemanticStreamStats2662(t *testing.T) {
 	if audit.RetainedPayloadSemanticStreamInputBytes <= 0 || audit.RetainedPayloadSemanticStreamZSTDBytes <= 0 {
 		t.Fatalf("semantic stream total bytes missing: input=%d zstd=%d audit=%+v", audit.RetainedPayloadSemanticStreamInputBytes, audit.RetainedPayloadSemanticStreamZSTDBytes, audit)
 	}
+	if audit.RetainedPayloadSemanticStreamInputBytes > 512 && audit.RetainedPayloadSemanticStreamZSTDBytes >= audit.RetainedPayloadSemanticStreamInputBytes {
+		t.Fatalf("semantic stream zstd oracle did not reduce compressible aggregate input: input=%d zstd=%d", audit.RetainedPayloadSemanticStreamInputBytes, audit.RetainedPayloadSemanticStreamZSTDBytes)
+	}
 
 	rkey, ok := retainedPayloadSemanticStreamStat2662(audit.RetainedPayloadSemanticStreams, "commit.rkey", "string")
 	if !ok {
@@ -353,7 +357,12 @@ func TestAuditCollectionRetainedPayloadSemanticStreamStats2662(t *testing.T) {
 	if rkey.Occurrences != 2 || rkey.Documents != 2 || rkey.StringBytes != int64(len("r-0001")+len("r-0002")) {
 		t.Fatalf("commit.rkey semantic stream=%+v", rkey)
 	}
-	if rkey.JSONBytes != 16 || rkey.StreamInputBytes != 18 || rkey.MinStreamBytes != 9 || rkey.MaxStreamBytes != 9 {
+	const (
+		rkeyJSONBytes      = 16 // `"r-0001"` and `"r-0002"` are 8 JSON bytes each.
+		rkeyStreamBytes    = 18 // Each 8-byte JSON token gets one newline separator.
+		rkeyEntryByteWidth = 9
+	)
+	if rkey.JSONBytes != rkeyJSONBytes || rkey.StreamInputBytes != rkeyStreamBytes || rkey.MinStreamBytes != rkeyEntryByteWidth || rkey.MaxStreamBytes != rkeyEntryByteWidth {
 		t.Fatalf("commit.rkey semantic stream byte counters=%+v", rkey)
 	}
 	if rkey.ZSTDBytes <= 0 || rkey.ZSTDToInputRatio <= 0 {
@@ -364,15 +373,27 @@ func TestAuditCollectionRetainedPayloadSemanticStreamStats2662(t *testing.T) {
 		t.Fatalf("tags semantic stream=%+v ok=%v", tags, ok)
 	}
 	likes, ok := retainedPayloadSemanticStreamStat2662(audit.RetainedPayloadSemanticStreams, "commit.record.likeCount", "number")
-	if !ok || likes.Occurrences != 2 || likes.Documents != 2 || likes.JSONBytes != 2 || likes.StreamInputBytes != 4 {
+	const (
+		likeJSONBytes   = 2 // `7` and `8`.
+		likeStreamBytes = 4 // Two one-byte numbers plus two newline separators.
+	)
+	if !ok || likes.Occurrences != 2 || likes.Documents != 2 || likes.JSONBytes != likeJSONBytes || likes.StreamInputBytes != likeStreamBytes {
 		t.Fatalf("likeCount semantic stream=%+v ok=%v", likes, ok)
 	}
 	repost, ok := retainedPayloadSemanticStreamStat2662(audit.RetainedPayloadSemanticStreams, "commit.record.repost", "bool")
-	if !ok || repost.Occurrences != 2 || repost.Documents != 2 || repost.JSONBytes != 9 || repost.StreamInputBytes != 11 {
+	const (
+		repostJSONBytes   = 9  // `false` plus `true`.
+		repostStreamBytes = 11 // The two boolean tokens plus two newline separators.
+	)
+	if !ok || repost.Occurrences != 2 || repost.Documents != 2 || repost.JSONBytes != repostJSONBytes || repost.StreamInputBytes != repostStreamBytes {
 		t.Fatalf("repost semantic stream=%+v ok=%v", repost, ok)
 	}
 	empty, ok := retainedPayloadSemanticStreamStat2662(audit.RetainedPayloadSemanticStreams, "empty", "null")
-	if !ok || empty.Occurrences != 2 || empty.Documents != 2 || empty.JSONBytes != 8 || empty.StreamInputBytes != 10 {
+	const (
+		nullJSONBytes   = 8  // Two `null` tokens.
+		nullStreamBytes = 10 // Two `null` tokens plus two newline separators.
+	)
+	if !ok || empty.Occurrences != 2 || empty.Documents != 2 || empty.JSONBytes != nullJSONBytes || empty.StreamInputBytes != nullStreamBytes {
 		t.Fatalf("empty null semantic stream=%+v ok=%v", empty, ok)
 	}
 	if _, ok := retainedPayloadSemanticStreamStat2662(audit.RetainedPayloadSemanticStreams, "kind", "string"); ok {

--- a/cmd/treedb_retained_payload_audit/main.go
+++ b/cmd/treedb_retained_payload_audit/main.go
@@ -28,6 +28,9 @@ func run() (code int) {
 	var valueFamilyMaxDepth int
 	var valueFamilyMaxPaths int
 	var valueFamilyMaxUnique int
+	var semanticStreamStats bool
+	var semanticStreamMaxDepth int
+	var semanticStreamMaxPaths int
 	defer func() {
 		if recovered := recover(); recovered != nil {
 			code = writeFailure(collectionName, fmt.Errorf("retained payload audit panic: %v", recovered))
@@ -44,6 +47,9 @@ func run() (code int) {
 	flag.IntVar(&valueFamilyMaxDepth, "value-family-max-depth", 8, "Maximum retained-payload value-family traversal depth; zero means unlimited")
 	flag.IntVar(&valueFamilyMaxPaths, "value-family-max-paths", 64, "Maximum retained-payload value-family rows to emit; zero means unlimited")
 	flag.IntVar(&valueFamilyMaxUnique, "value-family-max-unique", 200000, "Maximum unique strings tracked per path; zero means unlimited")
+	flag.BoolVar(&semanticStreamStats, "semantic-stream-stats", false, "Include decoded retained-payload scalar semantic stream oracle stats")
+	flag.IntVar(&semanticStreamMaxDepth, "semantic-stream-max-depth", 8, "Maximum retained-payload semantic stream traversal depth; zero means unlimited")
+	flag.IntVar(&semanticStreamMaxPaths, "semantic-stream-max-paths", 128, "Maximum retained-payload semantic stream path/kind rows to emit; zero means unlimited")
 	flag.Parse()
 
 	if strings.TrimSpace(dbDir) == "" {
@@ -88,6 +94,9 @@ func run() (code int) {
 		ValueFamilyMaxDepth:     valueFamilyMaxDepth,
 		ValueFamilyMaxPaths:     valueFamilyMaxPaths,
 		ValueFamilyMaxUnique:    valueFamilyMaxUnique,
+		IncludeSemanticStreams:  semanticStreamStats,
+		SemanticStreamMaxDepth:  semanticStreamMaxDepth,
+		SemanticStreamMaxPaths:  semanticStreamMaxPaths,
 	})
 	if err != nil {
 		writeResult(result)

--- a/scripts/treedb_jsonbench_storage_audit.py
+++ b/scripts/treedb_jsonbench_storage_audit.py
@@ -1079,6 +1079,10 @@ def run_retained_payload_audit(
         command.extend(["-value-family-max-depth", str(int(getattr(args, "retained_payload_value_family_max_depth", 8) or 0))])
         command.extend(["-value-family-max-paths", str(int(getattr(args, "retained_payload_value_family_max_paths", 64) or 0))])
         command.extend(["-value-family-max-unique", str(int(getattr(args, "retained_payload_value_family_max_unique", 200000) or 0))])
+    if getattr(args, "retained_payload_semantic_stream_stats", False):
+        command.append("-semantic-stream-stats")
+        command.extend(["-semantic-stream-max-depth", str(int(getattr(args, "retained_payload_semantic_stream_max_depth", 8) or 0))])
+        command.extend(["-semantic-stream-max-paths", str(int(getattr(args, "retained_payload_semantic_stream_max_paths", 128) or 0))])
 
     try:
         completed = subprocess.run(command, cwd=cwd, check=False, text=True, capture_output=True)
@@ -1331,6 +1335,9 @@ def main() -> int:
     parser.add_argument("--retained-payload-value-family-max-depth", type=int, default=8, help="Maximum retained-payload value-family traversal depth; zero means unlimited")
     parser.add_argument("--retained-payload-value-family-max-paths", type=int, default=64, help="Maximum retained-payload value-family rows to emit; zero means unlimited")
     parser.add_argument("--retained-payload-value-family-max-unique", type=int, default=200000, help="Maximum unique strings tracked per path; zero means unlimited")
+    parser.add_argument("--retained-payload-semantic-stream-stats", action="store_true", help="Include decoded retained-payload scalar semantic stream oracle stats")
+    parser.add_argument("--retained-payload-semantic-stream-max-depth", type=int, default=8, help="Maximum retained-payload semantic stream traversal depth; zero means unlimited")
+    parser.add_argument("--retained-payload-semantic-stream-max-paths", type=int, default=128, help="Maximum retained-payload semantic stream path/kind rows to emit; zero means unlimited")
     parser.add_argument("--skip-retained-payload-audit", action="store_true", help="Skip the path-aware retained-payload audit")
     args = parser.parse_args()
 

--- a/scripts/treedb_jsonbench_storage_audit_test.py
+++ b/scripts/treedb_jsonbench_storage_audit_test.py
@@ -355,6 +355,9 @@ class StorageAuditTest(unittest.TestCase):
                     "retained_payload_value_family_max_depth": 7,
                     "retained_payload_value_family_max_paths": 19,
                     "retained_payload_value_family_max_unique": 23,
+                    "retained_payload_semantic_stream_stats": True,
+                    "retained_payload_semantic_stream_max_depth": 6,
+                    "retained_payload_semantic_stream_max_paths": 29,
                     "skip_retained_payload_audit": False,
                 },
             )()
@@ -370,11 +373,14 @@ class StorageAuditTest(unittest.TestCase):
         self.assertEqual(retained["command"][db_dir_index], str(main.resolve()))
         self.assertIn("-shape-stats", retained["command"])
         self.assertIn("-value-family-stats", retained["command"])
+        self.assertIn("-semantic-stream-stats", retained["command"])
         self.assertEqual(retained["command"][retained["command"].index("-shape-max-depth") + 1], "9")
         self.assertEqual(retained["command"][retained["command"].index("-shape-max-paths") + 1], "17")
         self.assertEqual(retained["command"][retained["command"].index("-value-family-max-depth") + 1], "7")
         self.assertEqual(retained["command"][retained["command"].index("-value-family-max-paths") + 1], "19")
         self.assertEqual(retained["command"][retained["command"].index("-value-family-max-unique") + 1], "23")
+        self.assertEqual(retained["command"][retained["command"].index("-semantic-stream-max-depth") + 1], "6")
+        self.assertEqual(retained["command"][retained["command"].index("-semantic-stream-max-paths") + 1], "29")
 
     def test_retained_payload_audit_runs_without_collection_metadata(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
Refs #2662. Feeds #2359.

## Summary
- adds opt-in retained-payload semantic scalar stream oracle stats to `AuditRetainedPayloadDeclaredPathsAbsent`
- exposes `cmd/treedb_retained_payload_audit -semantic-stream-*` flags
- wires `scripts/treedb_jsonbench_storage_audit.py --retained-payload-semantic-stream-*` so evidence runs can carry the oracle in retained audit artifacts

This is measurement-only. It estimates per-path/per-kind decoded scalar stream bytes and ZSTD oracle bytes. It does not change the current on-disk retained payload format and does not claim full reconstructable semantic-storage parity, because object shape/presence metadata and the final reconstruction layout remain separate #2662 decisions.

## 10k Evidence
Baseline DB: `/tmp/jsonbench_2662_vlog_policy_baseline_10k_20260613_022025/rows10000_column-store-full-prepared_json_full_all_compacted/db/maindb`

Direct retained audit artifact: `/tmp/retained_semantic_stream_oracle_10k_20260613_2662.json`
Wrapper artifact: `/tmp/retained_semantic_stream_storage_audit_10k_20260613_2662/compression_audit.json`

Key retained audit results:
- status: `passed`
- checked rows: `10000`
- current retained payload bytes: `2553078`
- semantic scalar stream input bytes: `2510727`
- semantic scalar stream ZSTD oracle bytes: `904079`
- current 10k `value_vlog` filesystem bytes from the same baseline run: `1170727`

Top semantic streams by input bytes:

| path | kind | stream input | zstd bytes | zstd/input |
|---|---:|---:|---:|---:|
| `commit.cid` | string | 595324 | 317574 | 0.5334 |
| `commit.record.subject.uri` | string | 366385 | 92481 | 0.2524 |
| `commit.record.subject.cid` | string | 311178 | 141700 | 0.4554 |
| `commit.record.createdAt` | string | 259190 | 38690 | 0.1493 |
| `commit.record.$type` | string | 214402 | 10418 | 0.0486 |
| `commit.rev` | string | 158960 | 49307 | 0.3102 |
| `commit.rkey` | string | 157970 | 53814 | 0.3407 |
| `commit.record.subject` | string | 127739 | 54424 | 0.4261 |

Interpretation for #2662: the ClickHouse-shaped scalar-stream hint is viable enough to measure in #2359, but it is not yet a production format. The next storage PR should decide and implement how retained shape/presence metadata is encoded with these scalar streams, then compare actual durable bytes against the `value_vlog` target.

## Validation
- `GOTOOLCHAIN=go1.26.0 GOFLAGS=-mod=mod go test ./TreeDB/collections -run 'TestAuditCollectionRetainedPayload(ShapeStatsTemplateV12662|ValueFamilyStats2662|SemanticStreamStats2662)$' -count=1`\n- `python3 scripts/treedb_jsonbench_storage_audit_test.py`\n- `GOTOOLCHAIN=go1.26.0 GOFLAGS=-mod=mod go test ./cmd/treedb_retained_payload_audit -count=1`\n- `GOTOOLCHAIN=go1.26.0 GOFLAGS=-mod=mod go test ./TreeDB/collections -run 'TestAudit(ColumnRetainedPayload|CollectionRetainedPayload)|TestColumnRetainedPayloadCompressionStatus' -count=1`\n- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Retained-payload audits now support semantic-stream analysis with configurable depth and path-limit controls.
  * Audit results include semantic-stream statistics: per-path/kind compression metrics and aggregate byte totals.
  * New CLI flags enable and configure semantic-stream auditing parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->