### PR TITLE
TreeDB collections: add retained semantic stream v1

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -5090,13 +5090,12 @@ func pointerizeCollectionRunTableValuesForRoot(db *backenddb.DB, meta Collection
 }
 
 func collectionValueLogInlineThresholdResolverForRoot(db *backenddb.DB, meta CollectionMeta, rootName string) func([]byte) int {
-	if db == nil || !collectionRootStoresRetainedPayloadBodies(meta, rootName) {
+	if db == nil || (!collectionRootStoresRetainedPayloadBodies(meta, rootName) && !collectionRootStoresRetainedSemanticStreamBlocks(meta, rootName)) {
 		return nil
 	}
 	return func([]byte) int {
-		// Retained payload bodies are the residual/original document bytes for this
-		// primary root. Keep them out of leaf pages regardless of document-body
-		// representation; empty retained bodies still remain inline.
+		// Retained payload bodies and semantic stream blocks are persistent value-log
+		// payloads. Keep them out of leaf pages; empty values still remain inline.
 		return 0
 	}
 }
@@ -5107,6 +5106,9 @@ func collectionRootStoresRetainedPayloadBodies(meta CollectionMeta, rootName str
 	}
 	cfg := meta.Options.ColumnStore
 	if cfg == nil || !cfg.Enabled {
+		return false
+	}
+	if columnStoreRetainedPayloadUsesSemanticStreamV1(cfg) {
 		return false
 	}
 	switch columnRetainedPayloadAuditPolicy(cfg) {
@@ -5120,6 +5122,12 @@ func collectionRootStoresRetainedPayloadBodies(meta CollectionMeta, rootName str
 		// out of leaf pages rather than silently inlining it.
 		return true
 	}
+}
+
+func collectionRootStoresRetainedSemanticStreamBlocks(meta CollectionMeta, rootName string) bool {
+	return rootName != "" &&
+		rootName == collectionRetainedSemanticStreamRootName(meta.Name) &&
+		columnStoreRetainedPayloadUsesSemanticStreamV1(meta.Options.ColumnStore)
 }
 
 func pointerizeCollectionRunTableValuesWithOptions(db *backenddb.DB, table memtable.Table, opts collectionPointerizeOptions) (memtable.Table, bool, error) {
@@ -5336,10 +5344,14 @@ func pointerizeInsertBatchPlanDataRuns(db *backenddb.DB, meta CollectionMeta, pl
 }
 
 func collectionDataRootNameSet(meta CollectionMeta) map[string]struct{} {
-	return map[string]struct{}{
+	out := map[string]struct{}{
 		collectionPrimaryRootName(meta.Name):  {},
 		collectionTemplateRootName(meta.Name): {},
 	}
+	if columnStoreRetainedPayloadUsesSemanticStreamV1(meta.Options.ColumnStore) {
+		out[collectionRetainedSemanticStreamRootName(meta.Name)] = struct{}{}
+	}
+	return out
 }
 
 func pointerizeCollectionDataRootDeltaTables(db *backenddb.DB, meta CollectionMeta, rootNames []string, tables []memtable.Table) ([]memtable.Table, func(), error) {
@@ -10288,17 +10300,19 @@ func (c *Collection) insertBatchNoIndex(
 
 	var retainedDocuments [][]byte
 	var retainedTemplateRecords []templateV1Record
+	var retainedSemanticStreamBlocks memtable.Table
 	if columnStoreNeedsRetainedPayloadTransform(c.meta) {
 		fullDocuments := make([][]byte, len(entries))
 		for i := range entries {
 			fullDocuments[i] = entries[i].document
 		}
-		prepared, err := prepareColumnRetainedPayloadStorageDocuments(*c.meta.Options.ColumnStore, fullDocuments, columnRetainedPayloadTemplateResolver(snap, catalog))
+		prepared, err := prepareColumnRetainedPayloadInsertBatchStorageDocuments(*c.meta.Options.ColumnStore, fullDocuments, columnRetainedPayloadTemplateResolver(snap, catalog))
 		if err != nil {
 			return nil, err
 		}
 		retainedDocuments = prepared.documents
 		retainedTemplateRecords = prepared.templateRecords
+		retainedSemanticStreamBlocks = prepared.semanticStreamBlocks
 	}
 
 	phaseStart = time.Now()
@@ -10365,6 +10379,38 @@ func (c *Collection) insertBatchNoIndex(
 				StoragePolicy: run.storagePolicy,
 			})
 		}
+	}
+	var retainedSemanticStreamTables []memtable.Table
+	var retainedSemanticStreamIters []iterator.UnsafeIterator
+	defer func() {
+		for _, it := range retainedSemanticStreamIters {
+			_ = it.Close()
+		}
+		resetCollectionTables(retainedSemanticStreamTables)
+	}()
+	if retainedSemanticStreamBlocks != nil && retainedSemanticStreamBlocks.Len() > 0 {
+		streamRootName := collectionRetainedSemanticStreamRootName(c.meta.Name)
+		streamPolicy, err := collectionRootStoragePolicyForDB(c.db, c.meta, streamRootName)
+		if err != nil {
+			return nil, err
+		}
+		streamPublishTable := retainedSemanticStreamBlocks
+		retainedSemanticStreamTables = append(retainedSemanticStreamTables, retainedSemanticStreamBlocks)
+		if pointerizedStreamTable, pointerized, err := pointerizeCollectionRunTableValuesForRoot(c.db, c.meta, streamRootName, retainedSemanticStreamBlocks); err != nil {
+			return nil, err
+		} else if pointerized {
+			streamPublishTable = pointerizedStreamTable
+			retainedSemanticStreamTables = append(retainedSemanticStreamTables, pointerizedStreamTable)
+		}
+		streamIter := streamPublishTable.NewIterator(nil, nil)
+		retainedSemanticStreamIters = append(retainedSemanticStreamIters, streamIter)
+		rootNames = append(rootNames, streamRootName)
+		baseRootIDs[streamRootName] = catalog.rootID(streamRootName)
+		ordered = append(ordered, backenddb.OrderedRootDeltaPublishInput{
+			BaseRoot:      catalog.rootID(streamRootName),
+			Iter:          streamIter,
+			StoragePolicy: streamPolicy,
+		})
 	}
 	var textTables []memtable.Table
 	var textIters []iterator.UnsafeIterator
@@ -19750,7 +19796,11 @@ func (c *Collection) scanDocumentsFuncWithColumnReconstruction(
 		if err != nil {
 			return false, err
 		}
-		_, reconstructed, err := reconstructColumnDocumentFromVisibleRowValuesProjectedIntoWithResolver(nil, columnStoreConfig, record.Document, visibleRows[visiblePos], fullValues, nil, nil, retainedTemplateResolver)
+		retainedDocument, err := resolveColumnRetainedPayloadAtSnapshot(snap, catalog, columnStoreConfig, record.Document)
+		if err != nil {
+			return false, err
+		}
+		_, reconstructed, err := reconstructColumnDocumentFromVisibleRowValuesProjectedIntoWithResolver(nil, columnStoreConfig, retainedDocument, visibleRows[visiblePos], fullValues, nil, nil, retainedTemplateResolver)
 		if err != nil {
 			return false, err
 		}
@@ -19922,6 +19972,10 @@ func collectionRootStoragePolicyForDB(db *backenddb.DB, meta CollectionMeta, roo
 	case collectionColumnManifestRootName(meta.Name):
 		if meta.Options.ColumnStore != nil {
 			return backendRootStoragePolicy(meta.Options.ColumnStore.ControlRootStoragePolicy)
+		}
+	case collectionRetainedSemanticStreamRootName(meta.Name):
+		if columnStoreRetainedPayloadUsesSemanticStreamV1(meta.Options.ColumnStore) {
+			return backendCollectionDataRootStoragePolicy(db, meta.Options.DataRootStoragePolicy)
 		}
 	}
 	for _, idx := range meta.Indexes {
@@ -20993,6 +21047,9 @@ func collectionRootNames(meta CollectionMeta) []string {
 	if meta.Options.ColumnStore != nil && meta.Options.ColumnStore.Enabled {
 		out = append(out, collectionColumnManifestRootName(meta.Name))
 	}
+	if columnStoreRetainedPayloadUsesSemanticStreamV1(meta.Options.ColumnStore) {
+		out = append(out, collectionRetainedSemanticStreamRootName(meta.Name))
+	}
 	for _, idx := range meta.Indexes {
 		out = append(out, collectionSecondaryRootName(meta.Name, idx.Name))
 	}
@@ -21019,6 +21076,10 @@ func collectionIndexStateRootName(collection string) string {
 
 func collectionColumnManifestRootName(collection string) string {
 	return collection + "/column/manifest"
+}
+
+func collectionRetainedSemanticStreamRootName(collection string) string {
+	return collection + "/retained/semantic-stream-v1"
 }
 
 func collectionSecondaryRootName(collection, indexName string) string {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -10706,9 +10706,10 @@ func (c *Collection) deleteBatchOnce(documentIDs [][]byte, commandWALIntent *bac
 	}
 
 	type existingDelete struct {
-		id       []byte
-		state    documentIndexState
-		document []byte
+		id           []byte
+		state        documentIndexState
+		document     []byte
+		primaryValue []byte
 	}
 	existing := make([]existingDelete, 0, len(documentIDs))
 	for _, documentID := range documentIDs {
@@ -10732,6 +10733,16 @@ func (c *Collection) deleteBatchOnce(documentIDs [][]byte, commandWALIntent *bac
 			continue
 		}
 		item := existingDelete{id: documentID}
+		if columnStoreRetainedPayloadUsesSemanticStreamV1(c.meta.Options.ColumnStore) {
+			primaryValue, ok, err := columnRetainedSemanticStreamV1PrimaryValueForReclaim(snap, catalog, primaryRootName, documentID, entry)
+			if err != nil {
+				_ = snap.Close()
+				return 0, err
+			}
+			if ok {
+				item.primaryValue = primaryValue
+			}
+		}
 		if len(c.meta.TextIndexes) > 0 {
 			item.document = bytes.Clone(entry.Value)
 		}
@@ -10818,6 +10829,17 @@ func (c *Collection) deleteBatchOnce(documentIDs [][]byte, commandWALIntent *bac
 			resetCollectionTables(deltaTables)
 			return 0, err
 		}
+	}
+	var semanticReclaimValues [][]byte
+	for _, item := range existing {
+		if len(item.primaryValue) != 0 {
+			semanticReclaimValues = append(semanticReclaimValues, item.primaryValue)
+		}
+	}
+	if err := appendColumnRetainedSemanticStreamV1ReclaimDeltas(c.db, snap, catalog, c.meta, deleteIDs, semanticReclaimValues, nil, &rootNames, baseRootIDs, &policies, &deltaTables); err != nil {
+		_ = snap.Close()
+		resetCollectionTables(deltaTables)
+		return 0, err
 	}
 
 	if !commandWALActive && len(c.meta.TextIndexes) == 0 {
@@ -10988,6 +11010,17 @@ func (c *Collection) deleteDocumentOnce(documentID []byte, commandWALIntent *bac
 		}
 		return false, nil
 	}
+	var semanticReclaimValue []byte
+	if columnStoreRetainedPayloadUsesSemanticStreamV1(c.meta.Options.ColumnStore) {
+		primaryValue, ok, err := columnRetainedSemanticStreamV1PrimaryValueForReclaim(snap, catalog, primaryRootName, documentID, entry)
+		if err != nil {
+			_ = snap.Close()
+			return false, err
+		}
+		if ok {
+			semanticReclaimValue = primaryValue
+		}
+	}
 	runtimes, err := catalog.cachedIndexRuntimes()
 	if err != nil {
 		_ = snap.Close()
@@ -11052,6 +11085,11 @@ func (c *Collection) deleteDocumentOnce(documentID []byte, commandWALIntent *bac
 			resetCollectionTables(deltaTables)
 			return false, err
 		}
+	}
+	if err := appendColumnRetainedSemanticStreamV1ReclaimDeltas(c.db, snap, catalog, c.meta, [][]byte{documentID}, [][]byte{semanticReclaimValue}, nil, &rootNames, baseRootIDs, &policies, &deltaTables); err != nil {
+		_ = snap.Close()
+		resetCollectionTables(deltaTables)
+		return false, err
 	}
 	if !commandWALActive && len(c.meta.TextIndexes) == 0 {
 		if buffered, err := c.bufferIndexedDeleteTablesLocked(catalog, baseCommitSeq, baseSystemRoot, rootNames, baseRootIDs, policies, deltaTables, 1); buffered || err != nil {
@@ -13548,6 +13586,15 @@ func (c *Collection) updateDocumentOnceApply(documentID []byte, update func(curr
 		return false, false, nil
 	}
 	stats.Matched = 1
+	var semanticReclaimValue []byte
+	if columnStoreRetainedPayloadUsesSemanticStreamV1(c.meta.Options.ColumnStore) {
+		if _, _, ok, err := parseColumnRetainedSemanticStreamV1Locator(currentValue); err != nil {
+			_ = snap.Close()
+			return false, false, err
+		} else if ok {
+			semanticReclaimValue = bytes.Clone(currentValue)
+		}
+	}
 	if columnStoreCanReconstructDocument(c.meta) {
 		currentValue, err = c.reconstructColumnDocumentAtSnapshot(snap, catalog, documentID, currentValue)
 		if err != nil {
@@ -13742,6 +13789,11 @@ func (c *Collection) updateDocumentOnceApply(documentID []byte, update func(curr
 	} else {
 		deltaTables = append(deltaTables, primaryTable)
 	}
+	if err := appendColumnRetainedSemanticStreamV1ReclaimDeltas(c.db, snap, catalog, c.meta, [][]byte{documentID}, [][]byte{semanticReclaimValue}, [][]byte{primaryDocument}, &rootNames, baseRootIDs, &policies, &deltaTables); err != nil {
+		_ = snap.Close()
+		resetCollectionTables(deltaTables)
+		return false, false, err
+	}
 	stats.PrimaryRunBuild += updateBatchStatsSince(detailedStats, phaseStart)
 
 	if indexStateChanged {
@@ -13925,6 +13977,7 @@ type preparedBatchUpdate struct {
 	documentID               []byte
 	document                 []byte
 	primaryDocument          []byte
+	oldPrimaryValue          []byte
 	hasPrimaryDocument       bool
 	oldState                 orderedDocumentIndexState
 	newState                 orderedDocumentIndexState
@@ -15581,6 +15634,18 @@ func (c *Collection) buildUpdateBatchPlan(items []updateBatchItem, mode updateBa
 		if !current.found {
 			continue
 		}
+		prepared := preparedBatchUpdate{
+			itemIndex:  i,
+			documentID: item.DocumentID,
+		}
+		if columnStoreRetainedPayloadUsesSemanticStreamV1(meta.Options.ColumnStore) {
+			if _, _, ok, err := parseColumnRetainedSemanticStreamV1Locator(current.value); err != nil {
+				_ = snap.Close()
+				return nil, updateBatchItemError(i, err)
+			} else if ok {
+				prepared.oldPrimaryValue = appendUpdateBatchPlanScratchDocument(scratch, current.value)
+			}
+		}
 		if columnStoreCanReconstructDocument(meta) {
 			current.value, err = c.reconstructColumnDocumentAtSnapshot(snap, catalog, item.DocumentID, current.value)
 			if err != nil {
@@ -15590,10 +15655,6 @@ func (c *Collection) buildUpdateBatchPlan(items []updateBatchItem, mode updateBa
 			current.buffered = false
 		}
 		results[i].Matched = true
-		prepared := preparedBatchUpdate{
-			itemIndex:  i,
-			documentID: item.DocumentID,
-		}
 		var currentID bsonIDSnapshot
 		var document []byte
 		var changedOne bool
@@ -15986,6 +16047,24 @@ func (c *Collection) buildUpdateBatchPlan(items []updateBatchItem, mode updateBa
 	}
 	primaryTable.Freeze()
 	deltaTables = append(deltaTables, primaryTable)
+	var semanticReclaimIDs [][]byte
+	var semanticReclaimValues [][]byte
+	var semanticReplacementValues [][]byte
+	for _, item := range changed {
+		if len(item.oldPrimaryValue) == 0 {
+			continue
+		}
+		semanticReclaimIDs = append(semanticReclaimIDs, item.documentID)
+		semanticReclaimValues = append(semanticReclaimValues, item.oldPrimaryValue)
+		semanticReplacementValues = append(semanticReplacementValues, preparedBatchUpdatePrimaryDocument(item))
+	}
+	if err := appendColumnRetainedSemanticStreamV1ReclaimDeltas(c.db, snap, catalog, meta, semanticReclaimIDs, semanticReclaimValues, semanticReplacementValues, &rootNames, baseRootIDs, &policies, &deltaTables); err != nil {
+		_ = snap.Close()
+		return nil, err
+	}
+	for len(uniqueSecondary) < len(rootNames) {
+		uniqueSecondary = append(uniqueSecondary, -1)
+	}
 	stats.PrimaryRunBuild += updateBatchStatsSince(detailedStats, phaseStart)
 
 	if len(runtimes) > 0 {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -4789,7 +4789,7 @@ func TestCollectionCompactRootOverlaysFoldsIntoBaseRoots(t *testing.T) {
 	}
 }
 
-func TestCollectionCompactStorageProtectsFoldedRootIDs(t *testing.T) {
+func TestCollectionCompactStorageFoldedRootsUseCurrentDescriptorScan(t *testing.T) {
 	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {
 		t.Fatalf("open db: %v", err)
@@ -4839,57 +4839,17 @@ func TestCollectionCompactStorageProtectsFoldedRootIDs(t *testing.T) {
 		t.Fatalf("compact result stats=%+v want nonzero roots and overlays", result.stats)
 	}
 	if len(result.rootIDs) == 0 {
-		t.Fatal("compact result rootIDs=0 want folded roots protected")
+		t.Fatal("compact result rootIDs=0 want folded roots")
 	}
 	if result.systemRootID == 0 {
-		t.Fatal("compact result systemRootID=0 want published system root protected")
+		t.Fatal("compact result systemRootID=0 want published system root")
 	}
-
-	opts := compactStorageOptionsWithCollectionRootProtection(CompactStorageOptions{}, result)
-	for _, rootID := range result.rootIDs {
-		if got := countCompactStorageProtectedRootID(opts.LeafGenerationProtectedRootIDs, rootID); got != 0 {
-			t.Fatalf("direct protected root id %d occurrences=%d in %v want 0", rootID, got, opts.LeafGenerationProtectedRootIDs)
-		}
+	if err := checkpointCollectionCompactStorageFoldedRoots(db, result); err != nil {
+		t.Fatalf("checkpoint folded roots: %v", err)
 	}
-	if got := countCompactStorageProtectedRootID(opts.LeafGenerationProtectedSystemRootIDs, result.systemRootID); got != 1 {
-		t.Fatalf("protected system root id %d occurrences=%d in %v want 1", result.systemRootID, got, opts.LeafGenerationProtectedSystemRootIDs)
+	if _, err := db.CompactStoragePlan(context.Background(), backenddb.CompactStorageOptions{}); err != nil {
+		t.Fatalf("CompactStoragePlan with current descriptor scan: %v", err)
 	}
-	if _, err := db.CompactStoragePlan(context.Background(), backenddb.CompactStorageOptions(opts)); err != nil {
-		t.Fatalf("CompactStoragePlan with folded-root protection: %v", err)
-	}
-}
-
-func TestCompactStorageOptionsWithCollectionRootProtectionMergesDistinctRoots(t *testing.T) {
-	opts := compactStorageOptionsWithCollectionRootProtection(CompactStorageOptions{
-		LeafGenerationProtectedRootIDs:       []uint64{1, 2},
-		LeafGenerationProtectedSystemRootIDs: []uint64{10},
-	},
-		collectionRootOverlayCompactionResult{
-			rootIDs:      []uint64{0, 2, 3},
-			systemRootID: 10,
-		},
-		collectionRootOverlayCompactionResult{
-			rootIDs:      []uint64{3, 4},
-			systemRootID: 11,
-		},
-		collectionRootOverlayCompactionResult{},
-	)
-	if want := []uint64{1, 2}; !reflect.DeepEqual(opts.LeafGenerationProtectedRootIDs, want) {
-		t.Fatalf("protected root ids=%v want %v", opts.LeafGenerationProtectedRootIDs, want)
-	}
-	if want := []uint64{10, 11}; !reflect.DeepEqual(opts.LeafGenerationProtectedSystemRootIDs, want) {
-		t.Fatalf("protected system root ids=%v want %v", opts.LeafGenerationProtectedSystemRootIDs, want)
-	}
-}
-
-func countCompactStorageProtectedRootID(ids []uint64, want uint64) int {
-	var count int
-	for _, id := range ids {
-		if id == want {
-			count++
-		}
-	}
-	return count
 }
 
 func TestCollectionCompactStorageFoldsRootsAndCleansStorage(t *testing.T) {

--- a/TreeDB/collections/column_reconstruction.go
+++ b/TreeDB/collections/column_reconstruction.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
+	"github.com/snissn/gomap/TreeDB/internal/memtable"
 )
 
 func columnStoreNeedsRetainedPayloadTransform(meta CollectionMeta) bool {
@@ -79,8 +80,9 @@ func columnRetainedPayloadFromJSONDocument(cfg ColumnStoreConfig, document []byt
 }
 
 type columnRetainedPayloadStorageDocuments struct {
-	documents       [][]byte
-	templateRecords []templateV1Record
+	documents            [][]byte
+	templateRecords      []templateV1Record
+	semanticStreamBlocks memtable.Table
 }
 
 func prepareColumnRetainedPayloadStorageDocuments(cfg ColumnStoreConfig, documents [][]byte, fallback templateV1Resolver) (columnRetainedPayloadStorageDocuments, error) {
@@ -150,6 +152,11 @@ func (c *Collection) reconstructColumnDocumentAtSnapshotWithDiagnostics(snap *ba
 	if cfg.RetainedPayload == ColumnRetainedPayloadFull {
 		return bytes.Clone(retained), diag, nil
 	}
+	resolvedRetained, err := resolveColumnRetainedPayloadAtSnapshot(snap, catalog, cfg, retained)
+	if err != nil {
+		return nil, diag, err
+	}
+	retained = resolvedRetained
 	if cfg.Reconstruction != ColumnReconstructionRetainedPayloadAndColumns {
 		return nil, diag, fmt.Errorf("collections: unsupported column reconstruction policy %q", cfg.Reconstruction)
 	}
@@ -286,6 +293,21 @@ func decodeColumnRetainedPayloadObject(cfg ColumnStoreConfig, retained []byte, r
 	trimmed := bytes.TrimSpace(retained)
 	if len(trimmed) == 0 {
 		return make(map[string]any), nil
+	}
+	if cfg.RetainedPayload == ColumnRetainedPayloadNonColumn && columnRetainedPayloadEffectiveEncoding(&cfg) == ColumnRetainedPayloadEncodingSemanticStreamV1 {
+		if _, _, ok, err := parseColumnRetainedSemanticStreamV1Locator(trimmed); err != nil {
+			return nil, err
+		} else if ok {
+			return nil, errors.New("collections: unresolved semantic-stream-v1 retained payload locator")
+		}
+		if hasTemplateV1Magic(trimmed, templateV1StoredMagic) || hasTemplateV1Magic(trimmed, templateV1InputMagic) || hasTemplateV1Magic(trimmed, templateV1InsertDocumentMagic) {
+			obj, err := decodeTemplateV1RetainedPayloadObject(trimmed, resolver)
+			if err != nil {
+				return nil, fmt.Errorf("collections: decode template-v1 retained payload: %w", err)
+			}
+			return obj, nil
+		}
+		return decodeColumnJSONObject(trimmed)
 	}
 	if cfg.RetainedPayload == ColumnRetainedPayloadNonColumn && columnRetainedPayloadEffectiveEncoding(&cfg) == ColumnRetainedPayloadEncodingTemplateV1 {
 		obj, err := decodeTemplateV1RetainedPayloadObject(trimmed, resolver)

--- a/TreeDB/collections/column_reconstruction.go
+++ b/TreeDB/collections/column_reconstruction.go
@@ -290,15 +290,15 @@ func mergeColumnReconstructionValuesProjectedInto(cfg ColumnStoreConfig, rowValu
 }
 
 func decodeColumnRetainedPayloadObject(cfg ColumnStoreConfig, retained []byte, resolver templateV1Resolver) (map[string]any, error) {
-	trimmed := bytes.TrimSpace(retained)
-	if len(trimmed) == 0 {
-		return make(map[string]any), nil
-	}
 	if cfg.RetainedPayload == ColumnRetainedPayloadNonColumn && columnRetainedPayloadEffectiveEncoding(&cfg) == ColumnRetainedPayloadEncodingSemanticStreamV1 {
-		if _, _, ok, err := parseColumnRetainedSemanticStreamV1Locator(trimmed); err != nil {
+		if _, _, ok, err := parseColumnRetainedSemanticStreamV1Locator(retained); err != nil {
 			return nil, err
 		} else if ok {
 			return nil, errors.New("collections: unresolved semantic-stream-v1 retained payload locator")
+		}
+		trimmed := bytes.TrimSpace(retained)
+		if len(trimmed) == 0 {
+			return make(map[string]any), nil
 		}
 		if hasTemplateV1Magic(trimmed, templateV1StoredMagic) || hasTemplateV1Magic(trimmed, templateV1InputMagic) || hasTemplateV1Magic(trimmed, templateV1InsertDocumentMagic) {
 			obj, err := decodeTemplateV1RetainedPayloadObject(trimmed, resolver)
@@ -308,6 +308,10 @@ func decodeColumnRetainedPayloadObject(cfg ColumnStoreConfig, retained []byte, r
 			return obj, nil
 		}
 		return decodeColumnJSONObject(trimmed)
+	}
+	trimmed := bytes.TrimSpace(retained)
+	if len(trimmed) == 0 {
+		return make(map[string]any), nil
 	}
 	if cfg.RetainedPayload == ColumnRetainedPayloadNonColumn && columnRetainedPayloadEffectiveEncoding(&cfg) == ColumnRetainedPayloadEncodingTemplateV1 {
 		obj, err := decodeTemplateV1RetainedPayloadObject(trimmed, resolver)

--- a/TreeDB/collections/column_retained_payload_audit.go
+++ b/TreeDB/collections/column_retained_payload_audit.go
@@ -30,6 +30,8 @@ func ColumnRetainedPayloadEncodingStatus(cfg *ColumnStoreConfig) (encoding, stat
 			return string(ColumnRetainedPayloadEncodingTemplateV1), "active_template_v1_non_column_retained_payload"
 		case ColumnRetainedPayloadEncodingJSON:
 			return string(ColumnRetainedPayloadEncodingJSON), "active_legacy_json_non_column_retained_payload"
+		case ColumnRetainedPayloadEncodingSemanticStreamV1:
+			return string(ColumnRetainedPayloadEncodingSemanticStreamV1), "active_semantic_stream_v1_non_column_retained_payload"
 		default:
 			return string(ColumnRetainedPayloadEncodingUnavailable), fmt.Sprintf("unavailable_unsupported_retained_payload_encoding_%s", cfg.RetainedPayloadEncoding)
 		}
@@ -52,6 +54,9 @@ func ColumnRetainedPayloadCompressionStatus(cfg *ColumnStoreConfig) (compression
 	case ColumnRetainedPayloadFull, "":
 		return "value_log_grouped_frame", "default_value_log_auto", "active_value_log_auto_grouped_frame_full_retained_payload"
 	case ColumnRetainedPayloadNonColumn:
+		if cfg.RetainedPayloadEncoding == ColumnRetainedPayloadEncodingSemanticStreamV1 {
+			return "semantic_stream_v1_blocks", "retained_semantic_stream_v1_side_root", "active_semantic_stream_v1_non_column_retained_payload"
+		}
 		return "value_log_grouped_frame", "default_value_log_auto_storage_first", "active_value_log_auto_grouped_frame_non_column_retained_payload"
 	default:
 		return "unavailable", "unavailable", fmt.Sprintf("unknown_retained_payload_policy_%s", policyValue)

--- a/TreeDB/collections/column_retained_payload_audit.go
+++ b/TreeDB/collections/column_retained_payload_audit.go
@@ -323,11 +323,15 @@ func (c *Collection) AuditRetainedPayloadDeclaredPathsAbsent(opts ColumnRetained
 		}
 		result.CheckedRows++
 		result.RetainedPayloadBytes += int64(len(retained))
+		decodedRetained, err := resolveColumnRetainedPayloadAtSnapshot(snap, catalog, cfg, retained)
+		if err != nil {
+			return retainedPayloadCollectionAuditError(result, fmt.Errorf("collections: retained payload audit %q: %w", documentID, err))
+		}
 		var payloadAudit ColumnRetainedPayloadPathAudit
 		var auditErr error
 		if includeDecodedStats {
 			var obj map[string]any
-			obj, auditErr = decodeColumnRetainedPayloadObject(cfg, retained, resolver)
+			obj, auditErr = decodeColumnRetainedPayloadObject(cfg, decodedRetained, resolver)
 			if auditErr == nil {
 				payloadAudit = ColumnRetainedPayloadPathAudit{
 					RetainedPayloadPolicy:         result.RetainedPayloadPolicy,
@@ -350,7 +354,7 @@ func (c *Collection) AuditRetainedPayloadDeclaredPathsAbsent(opts ColumnRetained
 				auditErr = fmt.Errorf("collections: retained payload audit %q: %w", documentID, auditErr)
 			}
 		} else {
-			payloadAudit, auditErr = auditColumnRetainedPayloadPathsAbsentWithResolver(cfg, retained, result.DeclaredPaths, resolver)
+			payloadAudit, auditErr = auditColumnRetainedPayloadPathsAbsentWithResolver(cfg, decodedRetained, result.DeclaredPaths, resolver)
 		}
 		if auditErr != nil {
 			for _, path := range payloadAudit.Violations {

--- a/TreeDB/collections/column_retained_payload_audit_test.go
+++ b/TreeDB/collections/column_retained_payload_audit_test.go
@@ -171,6 +171,48 @@ func TestAuditCollectionRetainedPayloadDeclaredPathsAbsentTemplateV12382(t *test
 	}
 }
 
+func TestAuditCollectionRetainedPayloadDeclaredPathsAbsentSemanticStreamV12662(t *testing.T) {
+	cfg := jsonbenchRetainedPayloadAuditConfig2382(true)
+	cfg.RetainedPayloadEncoding = ColumnRetainedPayloadEncodingSemanticStreamV1
+	col, closeDB := openRetainedPayloadAuditCollection2382(t, cfg, [][]byte{
+		[]byte(`{"time_us":1,"kind":"commit","did":"did:plc:one","commit":{"operation":"create","collection":"app.bsky.feed.post","rkey":"r1"},"payload":"kept"}`),
+		[]byte(`{"time_us":2,"kind":"commit","did":"did:plc:two","commit":{"operation":"update","collection":"app.bsky.feed.post","rkey":"r2"},"payload":"also kept"}`),
+	})
+	defer closeDB()
+
+	audit, err := col.AuditRetainedPayloadDeclaredPathsAbsent(ColumnRetainedPayloadCollectionAuditOptions{})
+	if err != nil {
+		t.Fatalf("AuditRetainedPayloadDeclaredPathsAbsent semantic-stream-v1: %v audit=%+v", err, audit)
+	}
+	if audit.Status != "passed" || audit.CheckedRows != 2 {
+		t.Fatalf("audit=%+v want passed two rows", audit)
+	}
+	if audit.RetainedPayloadEncoding != string(ColumnRetainedPayloadEncodingSemanticStreamV1) || audit.RetainedPayloadEncodingStatus != "active_semantic_stream_v1_non_column_retained_payload" {
+		t.Fatalf("unexpected retained encoding audit=%+v", audit)
+	}
+	if audit.RetainedPayloadCompression != "semantic_stream_v1_blocks" || audit.RetainedPayloadCompressionStatus != "active_semantic_stream_v1_non_column_retained_payload" {
+		t.Fatalf("unexpected retained compression audit=%+v", audit)
+	}
+
+	statsAudit, err := col.AuditRetainedPayloadDeclaredPathsAbsent(ColumnRetainedPayloadCollectionAuditOptions{
+		IncludeShapeStats:      true,
+		IncludeSemanticStreams: true,
+		SemanticStreamMaxDepth: 8,
+	})
+	if err != nil {
+		t.Fatalf("AuditRetainedPayloadDeclaredPathsAbsent semantic-stream-v1 stats: %v audit=%+v", err, statsAudit)
+	}
+	if statsAudit.Status != "passed" || len(statsAudit.RetainedPayloadShape) == 0 || len(statsAudit.RetainedPayloadSemanticStreams) == 0 {
+		t.Fatalf("stats audit missing decoded retained data: %+v", statsAudit)
+	}
+	if _, ok := retainedPayloadShapeStat2382(statsAudit.RetainedPayloadShape, "payload", "string"); !ok {
+		t.Fatalf("semantic-stream-v1 retained payload shape missing payload: %+v", statsAudit.RetainedPayloadShape)
+	}
+	if _, ok := retainedPayloadSemanticStreamStat2662(statsAudit.RetainedPayloadSemanticStreams, "payload", "string"); !ok {
+		t.Fatalf("semantic-stream-v1 retained semantic stream missing payload: %+v", statsAudit.RetainedPayloadSemanticStreams)
+	}
+}
+
 func TestAuditCollectionRetainedPayloadShapeStatsTemplateV12662(t *testing.T) {
 	col, closeDB := openRetainedPayloadAuditCollection2382(t, jsonbenchRetainedPayloadAuditConfig2382(true), [][]byte{
 		[]byte(`{"time_us":1,"kind":"commit","did":"did:plc:one","commit":{"operation":"create","collection":"app.bsky.feed.post","rkey":"r1"},"payload":"kept","nested":{"also":"kept","count":3}}`),

--- a/TreeDB/collections/column_retained_semantic_stream.go
+++ b/TreeDB/collections/column_retained_semantic_stream.go
@@ -1,0 +1,407 @@
+package collections
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strconv"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+)
+
+const columnRetainedSemanticStreamV1BlockRows = 4096
+
+var (
+	columnRetainedSemanticStreamV1BlockMagic   = []byte("crss1blk\x00")
+	columnRetainedSemanticStreamV1LocatorMagic = []byte("crss1loc\x00")
+)
+
+type columnRetainedSemanticStreamEntry struct {
+	row uint64
+	raw []byte
+}
+
+type columnRetainedSemanticStreamPath struct {
+	segments []string
+	entries  []columnRetainedSemanticStreamEntry
+}
+
+// ColumnRetainedSemanticStreamV1StorageAccounting reports the retained-payload
+// bytes produced by the semantic-stream-v1 InsertBatch encoding.
+type ColumnRetainedSemanticStreamV1StorageAccounting struct {
+	Rows                int
+	PrimaryLocatorBytes int64
+	BlockBytes          int64
+	BlockCount          int
+	TotalBytes          int64
+}
+
+// ColumnRetainedSemanticStreamV1StorageAccountingFromJSONDocuments applies the
+// same retained-payload transform used by InsertBatch and returns the encoded
+// primary retained bytes plus side-root block bytes.
+func ColumnRetainedSemanticStreamV1StorageAccountingFromJSONDocuments(cfg ColumnStoreConfig, documents [][]byte) (ColumnRetainedSemanticStreamV1StorageAccounting, error) {
+	if !columnStoreRetainedPayloadUsesSemanticStreamV1(&cfg) {
+		return ColumnRetainedSemanticStreamV1StorageAccounting{}, fmt.Errorf("collections: semantic-stream-v1 accounting requires retained encoding %q", ColumnRetainedPayloadEncodingSemanticStreamV1)
+	}
+	prepared, err := prepareColumnRetainedPayloadInsertBatchStorageDocuments(cfg, documents, nil)
+	if err != nil {
+		return ColumnRetainedSemanticStreamV1StorageAccounting{}, err
+	}
+	if prepared.semanticStreamBlocks != nil {
+		defer resetCollectionRunTable(prepared.semanticStreamBlocks)
+	}
+
+	var out ColumnRetainedSemanticStreamV1StorageAccounting
+	out.Rows = len(documents)
+	for _, document := range prepared.documents {
+		out.PrimaryLocatorBytes += int64(len(document))
+	}
+	if prepared.semanticStreamBlocks != nil {
+		iter := prepared.semanticStreamBlocks.NewIterator(nil, nil)
+		defer func() { _ = iter.Close() }()
+		for ; iter.Valid(); iter.Next() {
+			out.BlockCount++
+			out.BlockBytes += int64(len(iter.UnsafeValue()))
+		}
+		if err := iter.Error(); err != nil {
+			return ColumnRetainedSemanticStreamV1StorageAccounting{}, err
+		}
+	}
+	out.TotalBytes = out.PrimaryLocatorBytes + out.BlockBytes
+	return out, nil
+}
+
+func prepareColumnRetainedPayloadInsertBatchStorageDocuments(cfg ColumnStoreConfig, documents [][]byte, fallback templateV1Resolver) (columnRetainedPayloadStorageDocuments, error) {
+	if cfg.RetainedPayload == ColumnRetainedPayloadNonColumn &&
+		columnRetainedPayloadEffectiveEncoding(&cfg) == ColumnRetainedPayloadEncodingSemanticStreamV1 &&
+		len(documents) > 1 {
+		return prepareColumnRetainedSemanticStreamV1StorageDocuments(cfg, documents)
+	}
+	return prepareColumnRetainedPayloadStorageDocuments(cfg, documents, fallback)
+}
+
+func prepareColumnRetainedSemanticStreamV1StorageDocuments(cfg ColumnStoreConfig, documents [][]byte) (columnRetainedPayloadStorageDocuments, error) {
+	out := columnRetainedPayloadStorageDocuments{
+		documents: make([][]byte, len(documents)),
+	}
+	if len(documents) == 0 {
+		return out, nil
+	}
+	blockTable := newCollectionRunTable((len(documents) + columnRetainedSemanticStreamV1BlockRows - 1) / columnRetainedSemanticStreamV1BlockRows)
+	for start := 0; start < len(documents); start += columnRetainedSemanticStreamV1BlockRows {
+		end := start + columnRetainedSemanticStreamV1BlockRows
+		if end > len(documents) {
+			end = len(documents)
+		}
+		retainedJSON := make([][]byte, end-start)
+		for i := start; i < end; i++ {
+			retained, err := columnRetainedPayloadJSONFromJSONDocument(cfg, documents[i])
+			if err != nil {
+				resetCollectionRunTable(blockTable)
+				return columnRetainedPayloadStorageDocuments{}, err
+			}
+			retainedJSON[i-start] = retained
+		}
+		block, err := encodeColumnRetainedSemanticStreamV1Block(retainedJSON)
+		if err != nil {
+			resetCollectionRunTable(blockTable)
+			return columnRetainedPayloadStorageDocuments{}, err
+		}
+		sum := sha256.Sum256(block)
+		blockKey := append([]byte(nil), sum[:]...)
+		for i := range retainedJSON {
+			out.documents[start+i] = encodeColumnRetainedSemanticStreamV1Locator(blockKey, uint64(i))
+		}
+		setCollectionRunValue(blockTable, blockKey, block)
+	}
+	blockTable.Freeze()
+	out.semanticStreamBlocks = blockTable
+	return out, nil
+}
+
+func encodeColumnRetainedSemanticStreamV1Locator(blockKey []byte, row uint64) []byte {
+	out := make([]byte, 0, len(columnRetainedSemanticStreamV1LocatorMagic)+sha256.Size+binary.MaxVarintLen64)
+	out = append(out, columnRetainedSemanticStreamV1LocatorMagic...)
+	out = append(out, blockKey...)
+	out = binary.AppendUvarint(out, row)
+	return out
+}
+
+func parseColumnRetainedSemanticStreamV1Locator(raw []byte) ([]byte, uint64, bool, error) {
+	if !bytes.HasPrefix(raw, columnRetainedSemanticStreamV1LocatorMagic) {
+		return nil, 0, false, nil
+	}
+	rest := raw[len(columnRetainedSemanticStreamV1LocatorMagic):]
+	if len(rest) < sha256.Size+1 {
+		return nil, 0, true, errors.New("collections: malformed semantic-stream-v1 retained locator")
+	}
+	blockKey := append([]byte(nil), rest[:sha256.Size]...)
+	row, n := binary.Uvarint(rest[sha256.Size:])
+	if n <= 0 || sha256.Size+n != len(rest) {
+		return nil, 0, true, errors.New("collections: malformed semantic-stream-v1 retained locator row")
+	}
+	return blockKey, row, true, nil
+}
+
+func resolveColumnRetainedPayloadAtSnapshot(snap *backenddb.Snapshot, catalog *collectionCatalog, cfg ColumnStoreConfig, retained []byte) ([]byte, error) {
+	if !columnStoreRetainedPayloadUsesSemanticStreamV1(&cfg) {
+		return retained, nil
+	}
+	blockKey, row, ok, err := parseColumnRetainedSemanticStreamV1Locator(bytes.TrimSpace(retained))
+	if err != nil || !ok {
+		return retained, err
+	}
+	if snap == nil || catalog == nil {
+		return nil, errors.New("collections: semantic-stream-v1 retained payload requires snapshot catalog")
+	}
+	block, found, err := collectionGetAppendAtCatalogRoot(snap, catalog, collectionRetainedSemanticStreamRootName(catalog.meta.Name), blockKey, nil)
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return nil, fmt.Errorf("collections: semantic-stream-v1 retained block %x missing", blockKey)
+	}
+	return decodeColumnRetainedSemanticStreamV1BlockRowJSON(block, row)
+}
+
+func encodeColumnRetainedSemanticStreamV1Block(documents [][]byte) ([]byte, error) {
+	streams := make(map[string]*columnRetainedSemanticStreamPath)
+	for row, document := range documents {
+		trimmed := bytes.TrimSpace(document)
+		if len(trimmed) == 0 {
+			trimmed = []byte("{}")
+		}
+		var root json.RawMessage
+		if err := json.Unmarshal(trimmed, &root); err != nil {
+			return nil, fmt.Errorf("collections: semantic-stream-v1 retained row %d: %w", row, err)
+		}
+		if err := collectColumnRetainedSemanticStreamPaths(root, nil, uint64(row), streams); err != nil {
+			return nil, fmt.Errorf("collections: semantic-stream-v1 retained row %d: %w", row, err)
+		}
+	}
+	keys := make([]string, 0, len(streams))
+	for key := range streams {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	out := make([]byte, 0, len(columnRetainedSemanticStreamV1BlockMagic)+len(documents)*16)
+	out = append(out, columnRetainedSemanticStreamV1BlockMagic...)
+	out = binary.AppendUvarint(out, uint64(len(documents)))
+	out = binary.AppendUvarint(out, uint64(len(keys)))
+	for _, key := range keys {
+		stream := streams[key]
+		out = binary.AppendUvarint(out, uint64(len(stream.segments)))
+		for _, segment := range stream.segments {
+			out = binary.AppendUvarint(out, uint64(len(segment)))
+			out = append(out, segment...)
+		}
+		out = binary.AppendUvarint(out, uint64(len(stream.entries)))
+		var last uint64
+		for i, entry := range stream.entries {
+			if i == 0 {
+				out = binary.AppendUvarint(out, entry.row)
+			} else {
+				out = binary.AppendUvarint(out, entry.row-last)
+			}
+			last = entry.row
+			out = binary.AppendUvarint(out, uint64(len(entry.raw)))
+			out = append(out, entry.raw...)
+		}
+	}
+	return out, nil
+}
+
+func collectColumnRetainedSemanticStreamPaths(raw json.RawMessage, path []string, row uint64, streams map[string]*columnRetainedSemanticStreamPath) error {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 {
+		trimmed = []byte("null")
+	}
+	switch trimmed[0] {
+	case '{':
+		var obj map[string]json.RawMessage
+		if err := json.Unmarshal(trimmed, &obj); err != nil {
+			return err
+		}
+		if len(obj) == 0 && len(path) > 0 {
+			appendColumnRetainedSemanticStreamValue(path, row, trimmed, streams)
+			return nil
+		}
+		keys := make([]string, 0, len(obj))
+		for key := range obj {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		for _, key := range keys {
+			nextPath := append(append([]string(nil), path...), key)
+			if err := collectColumnRetainedSemanticStreamPaths(obj[key], nextPath, row, streams); err != nil {
+				return err
+			}
+		}
+	case '[':
+		if len(path) == 0 {
+			return errors.New("semantic-stream-v1 retained root must be a JSON object")
+		}
+		appendColumnRetainedSemanticStreamValue(path, row, trimmed, streams)
+	default:
+		if len(path) == 0 {
+			return errors.New("semantic-stream-v1 retained root must be a JSON object")
+		}
+		appendColumnRetainedSemanticStreamValue(path, row, trimmed, streams)
+	}
+	return nil
+}
+
+func appendColumnRetainedSemanticStreamValue(path []string, row uint64, raw []byte, streams map[string]*columnRetainedSemanticStreamPath) {
+	key := columnRetainedSemanticStreamPathKey(path)
+	stream := streams[key]
+	if stream == nil {
+		stream = &columnRetainedSemanticStreamPath{segments: append([]string(nil), path...)}
+		streams[key] = stream
+	}
+	stream.entries = append(stream.entries, columnRetainedSemanticStreamEntry{
+		row: row,
+		raw: append([]byte(nil), raw...),
+	})
+}
+
+func columnRetainedSemanticStreamPathKey(path []string) string {
+	var out []byte
+	for _, segment := range path {
+		out = strconv.AppendInt(out, int64(len(segment)), 10)
+		out = append(out, ':')
+		out = append(out, segment...)
+		out = append(out, 0)
+	}
+	return string(out)
+}
+
+func decodeColumnRetainedSemanticStreamV1BlockRowJSON(block []byte, row uint64) ([]byte, error) {
+	obj, err := decodeColumnRetainedSemanticStreamV1BlockRowObject(block, row)
+	if err != nil {
+		return nil, err
+	}
+	out, err := json.Marshal(obj)
+	if err != nil {
+		return nil, fmt.Errorf("collections: encode semantic-stream-v1 retained row: %w", err)
+	}
+	return out, nil
+}
+
+func decodeColumnRetainedSemanticStreamV1BlockRowObject(block []byte, row uint64) (map[string]any, error) {
+	if !bytes.HasPrefix(block, columnRetainedSemanticStreamV1BlockMagic) {
+		return nil, errors.New("collections: retained block is not semantic-stream-v1 encoded")
+	}
+	reader := bytes.NewReader(block[len(columnRetainedSemanticStreamV1BlockMagic):])
+	rows, err := binary.ReadUvarint(reader)
+	if err != nil {
+		return nil, errors.New("collections: malformed semantic-stream-v1 retained block row count")
+	}
+	if row >= rows {
+		return nil, fmt.Errorf("collections: semantic-stream-v1 row %d outside block rows %d", row, rows)
+	}
+	pathCount, err := binary.ReadUvarint(reader)
+	if err != nil {
+		return nil, errors.New("collections: malformed semantic-stream-v1 retained block path count")
+	}
+	obj := make(map[string]any)
+	for pathOrdinal := uint64(0); pathOrdinal < pathCount; pathOrdinal++ {
+		path, err := readColumnRetainedSemanticStreamV1Path(reader)
+		if err != nil {
+			return nil, err
+		}
+		entryCount, err := binary.ReadUvarint(reader)
+		if err != nil {
+			return nil, errors.New("collections: malformed semantic-stream-v1 retained block entry count")
+		}
+		var last uint64
+		for entryOrdinal := uint64(0); entryOrdinal < entryCount; entryOrdinal++ {
+			delta, err := binary.ReadUvarint(reader)
+			if err != nil {
+				return nil, errors.New("collections: malformed semantic-stream-v1 retained block row delta")
+			}
+			entryRow := delta
+			if entryOrdinal != 0 {
+				entryRow = last + delta
+			}
+			last = entryRow
+			valueLen, err := binary.ReadUvarint(reader)
+			if err != nil {
+				return nil, errors.New("collections: malformed semantic-stream-v1 retained block value length")
+			}
+			if valueLen > uint64(reader.Len()) {
+				return nil, errors.New("collections: truncated semantic-stream-v1 retained block value")
+			}
+			value := make([]byte, int(valueLen))
+			if _, err := reader.Read(value); err != nil {
+				return nil, err
+			}
+			if entryRow != row {
+				continue
+			}
+			var decoded any
+			if err := json.Unmarshal(value, &decoded); err != nil {
+				return nil, fmt.Errorf("collections: decode semantic-stream-v1 retained value: %w", err)
+			}
+			if err := setColumnRetainedSemanticStreamPathValue(obj, path, decoded); err != nil {
+				return nil, err
+			}
+		}
+	}
+	if reader.Len() != 0 {
+		return nil, errors.New("collections: trailing semantic-stream-v1 retained block bytes")
+	}
+	return obj, nil
+}
+
+func readColumnRetainedSemanticStreamV1Path(reader *bytes.Reader) ([]string, error) {
+	segmentCount, err := binary.ReadUvarint(reader)
+	if err != nil {
+		return nil, errors.New("collections: malformed semantic-stream-v1 retained block path segment count")
+	}
+	if segmentCount > uint64(int(^uint(0)>>1)) {
+		return nil, errors.New("collections: semantic-stream-v1 retained block path too large")
+	}
+	path := make([]string, int(segmentCount))
+	for i := range path {
+		segmentLen, err := binary.ReadUvarint(reader)
+		if err != nil {
+			return nil, errors.New("collections: malformed semantic-stream-v1 retained block path segment length")
+		}
+		if segmentLen > uint64(reader.Len()) {
+			return nil, errors.New("collections: truncated semantic-stream-v1 retained block path segment")
+		}
+		buf := make([]byte, int(segmentLen))
+		if _, err := reader.Read(buf); err != nil {
+			return nil, err
+		}
+		path[i] = string(buf)
+	}
+	return path, nil
+}
+
+func setColumnRetainedSemanticStreamPathValue(root map[string]any, path []string, value any) error {
+	if len(path) == 0 {
+		return errors.New("collections: semantic-stream-v1 retained value has empty object path")
+	}
+	current := root
+	for _, segment := range path[:len(path)-1] {
+		next, ok := current[segment]
+		if !ok {
+			child := make(map[string]any)
+			current[segment] = child
+			current = child
+			continue
+		}
+		child, ok := next.(map[string]any)
+		if !ok {
+			return fmt.Errorf("collections: semantic-stream-v1 retained path conflict at %q", segment)
+		}
+		current = child
+	}
+	current[path[len(path)-1]] = value
+	return nil
+}

--- a/TreeDB/collections/column_retained_semantic_stream.go
+++ b/TreeDB/collections/column_retained_semantic_stream.go
@@ -151,7 +151,7 @@ func resolveColumnRetainedPayloadAtSnapshot(snap *backenddb.Snapshot, catalog *c
 	if !columnStoreRetainedPayloadUsesSemanticStreamV1(&cfg) {
 		return retained, nil
 	}
-	blockKey, row, ok, err := parseColumnRetainedSemanticStreamV1Locator(bytes.TrimSpace(retained))
+	blockKey, row, ok, err := parseColumnRetainedSemanticStreamV1Locator(retained)
 	if err != nil || !ok {
 		return retained, err
 	}
@@ -342,9 +342,9 @@ func decodeColumnRetainedSemanticStreamV1BlockRowObject(block []byte, row uint64
 			if entryRow != row {
 				continue
 			}
-			var decoded any
-			if err := json.Unmarshal(value, &decoded); err != nil {
-				return nil, fmt.Errorf("collections: decode semantic-stream-v1 retained value: %w", err)
+			decoded := json.RawMessage(append([]byte(nil), value...))
+			if !json.Valid(decoded) {
+				return nil, errors.New("collections: decode semantic-stream-v1 retained value: invalid JSON")
 			}
 			if err := setColumnRetainedSemanticStreamPathValue(obj, path, decoded); err != nil {
 				return nil, err

--- a/TreeDB/collections/column_retained_semantic_stream.go
+++ b/TreeDB/collections/column_retained_semantic_stream.go
@@ -11,6 +11,8 @@ import (
 	"strconv"
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
+	"github.com/snissn/gomap/TreeDB/internal/memtable"
+	"github.com/snissn/gomap/TreeDB/node"
 )
 
 const columnRetainedSemanticStreamV1BlockRows = 4096
@@ -145,6 +147,168 @@ func parseColumnRetainedSemanticStreamV1Locator(raw []byte) ([]byte, uint64, boo
 		return nil, 0, true, errors.New("collections: malformed semantic-stream-v1 retained locator row")
 	}
 	return blockKey, row, true, nil
+}
+
+func appendColumnRetainedSemanticStreamV1ReclaimDeltas(
+	db *backenddb.DB,
+	snap *backenddb.Snapshot,
+	catalog *collectionCatalog,
+	meta CollectionMeta,
+	removedDocumentIDs [][]byte,
+	removedPrimaryValues [][]byte,
+	replacementPrimaryValues [][]byte,
+	rootNames *[]string,
+	baseRootIDs map[string]uint64,
+	policies *[]backenddb.OrderedRootStoragePolicy,
+	deltaTables *[]memtable.Table,
+) error {
+	if !columnStoreRetainedPayloadUsesSemanticStreamV1(meta.Options.ColumnStore) ||
+		len(removedDocumentIDs) == 0 ||
+		len(removedPrimaryValues) == 0 ||
+		rootNames == nil ||
+		baseRootIDs == nil ||
+		policies == nil ||
+		deltaTables == nil {
+		return nil
+	}
+	candidates, err := columnRetainedSemanticStreamV1BlockKeysFromValues(removedPrimaryValues)
+	if err != nil || len(candidates) == 0 {
+		return err
+	}
+	replacementLive, err := columnRetainedSemanticStreamV1BlockKeysFromValues(replacementPrimaryValues)
+	if err != nil {
+		return err
+	}
+	for key := range replacementLive {
+		delete(candidates, key)
+	}
+	if len(candidates) == 0 {
+		return nil
+	}
+	live, err := columnRetainedSemanticStreamV1LiveCandidateBlocks(snap, catalog, meta, candidates, removedDocumentIDs)
+	if err != nil {
+		return err
+	}
+	for key := range live {
+		delete(candidates, key)
+	}
+	if len(candidates) == 0 {
+		return nil
+	}
+	rootName := collectionRetainedSemanticStreamRootName(meta.Name)
+	baseRootID := catalog.rootID(rootName)
+	if baseRootID == 0 && len(catalog.overlayRootIDs(rootName)) == 0 {
+		return nil
+	}
+	policy, err := collectionRootStoragePolicyForDB(db, meta, rootName)
+	if err != nil {
+		return err
+	}
+	deleteKeys := make([][]byte, 0, len(candidates))
+	for _, key := range candidates {
+		deleteKeys = append(deleteKeys, key)
+	}
+	sort.Slice(deleteKeys, func(i, j int) bool {
+		return bytes.Compare(deleteKeys[i], deleteKeys[j]) < 0
+	})
+	*rootNames = append(*rootNames, rootName)
+	baseRootIDs[rootName] = baseRootID
+	*policies = append(*policies, policy)
+	*deltaTables = append(*deltaTables, buildDeleteRootDeltaTable(deleteKeys))
+	return nil
+}
+
+func columnRetainedSemanticStreamV1BlockKeysFromValues(values [][]byte) (map[string][]byte, error) {
+	if len(values) == 0 {
+		return nil, nil
+	}
+	out := make(map[string][]byte)
+	for _, value := range values {
+		blockKey, _, ok, err := parseColumnRetainedSemanticStreamV1Locator(value)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			continue
+		}
+		out[string(blockKey)] = blockKey
+	}
+	if len(out) == 0 {
+		return nil, nil
+	}
+	return out, nil
+}
+
+func columnRetainedSemanticStreamV1LiveCandidateBlocks(snap *backenddb.Snapshot, catalog *collectionCatalog, meta CollectionMeta, candidates map[string][]byte, removedDocumentIDs [][]byte) (map[string]struct{}, error) {
+	if len(candidates) == 0 {
+		return nil, nil
+	}
+	removed := make(map[string]struct{}, len(removedDocumentIDs))
+	for _, id := range removedDocumentIDs {
+		removed[string(id)] = struct{}{}
+	}
+	primaryRootName := collectionPrimaryRootName(meta.Name)
+	it, err := collectionIteratorAtCatalogRoot(snap, catalog, primaryRootName, nil, nil, false)
+	if err != nil || it == nil {
+		return nil, err
+	}
+	defer func() { _ = it.Close() }()
+	live := make(map[string]struct{})
+	for ; it.Valid(); it.Next() {
+		key := it.UnsafeKey()
+		if _, skip := removed[string(key)]; skip {
+			continue
+		}
+		value, _, flags := it.UnsafeEntry()
+		if flags&node.FlagTombstone != 0 {
+			continue
+		}
+		if flags&node.FlagPointer != 0 {
+			resolved, found, err := collectionGetAppendAtCatalogRoot(snap, catalog, primaryRootName, key, nil)
+			if err != nil {
+				return nil, err
+			}
+			if !found {
+				continue
+			}
+			value = resolved
+		}
+		blockKey, _, ok, err := parseColumnRetainedSemanticStreamV1Locator(value)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			continue
+		}
+		if _, candidate := candidates[string(blockKey)]; candidate {
+			live[string(blockKey)] = struct{}{}
+			if len(live) == len(candidates) {
+				break
+			}
+		}
+	}
+	if err := it.Error(); err != nil {
+		return nil, err
+	}
+	if len(live) == 0 {
+		return nil, nil
+	}
+	return live, nil
+}
+
+func columnRetainedSemanticStreamV1PrimaryValueForReclaim(snap *backenddb.Snapshot, catalog *collectionCatalog, primaryRootName string, documentID []byte, entry node.LeafEntry) ([]byte, bool, error) {
+	value := entry.Value
+	if entry.Flags&node.FlagPointer != 0 {
+		resolved, found, err := collectionGetAppendAtCatalogRoot(snap, catalog, primaryRootName, documentID, nil)
+		if err != nil || !found {
+			return nil, false, err
+		}
+		value = resolved
+	}
+	if _, _, ok, err := parseColumnRetainedSemanticStreamV1Locator(value); err != nil || !ok {
+		return nil, ok, err
+	}
+	return bytes.Clone(value), true, nil
 }
 
 func resolveColumnRetainedPayloadAtSnapshot(snap *backenddb.Snapshot, catalog *collectionCatalog, cfg ColumnStoreConfig, retained []byte) ([]byte, error) {

--- a/TreeDB/collections/column_retained_vlog_placement_test.go
+++ b/TreeDB/collections/column_retained_vlog_placement_test.go
@@ -3,6 +3,7 @@ package collections
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"io/fs"
@@ -345,6 +346,10 @@ func TestColumnRetainedPayloadSemanticStreamV1InsertBatchRoundTripReopen(t *test
 	if _, err := col.InsertBatch(ids, docs); err != nil {
 		t.Fatalf("InsertBatch: %v", err)
 	}
+	_, whitespaceRow, _ := requireColumnRetainedSemanticStreamLocatorAndBlockPointer(t, d, "events", ids[9])
+	if whitespaceRow != 9 {
+		t.Fatalf("semantic locator row=%d want whitespace-varint row 9", whitespaceRow)
+	}
 	blockKey, row, ptr := requireColumnRetainedSemanticStreamLocatorAndBlockPointer(t, d, "events", ids[17])
 	if len(blockKey) == 0 || row != 17 {
 		t.Fatalf("semantic locator block_key_len=%d row=%d want row 17", len(blockKey), row)
@@ -357,11 +362,16 @@ func TestColumnRetainedPayloadSemanticStreamV1InsertBatchRoundTripReopen(t *test
 	} else {
 		assertRetainedSemanticStreamDocument(t, got, 17)
 	}
+	if got, err := col.Get(ids[9]); err != nil {
+		t.Fatalf("Get semantic stream whitespace-row doc: %v", err)
+	} else {
+		assertRetainedSemanticStreamDocument(t, got, 9)
+	}
 	view, err := col.OpenCollectionReadView()
 	if err != nil {
 		t.Fatalf("OpenCollectionReadView: %v", err)
 	}
-	response, err := view.FetchDocumentsByID([][]byte{ids[17], ids[42]}, DocumentFetchOptions{})
+	response, err := view.FetchDocumentsByID([][]byte{ids[9], ids[17], ids[42]}, DocumentFetchOptions{})
 	closeErr := view.Close()
 	if err != nil {
 		t.Fatalf("FetchDocumentsByID: %v", err)
@@ -369,11 +379,12 @@ func TestColumnRetainedPayloadSemanticStreamV1InsertBatchRoundTripReopen(t *test
 	if closeErr != nil {
 		t.Fatalf("Close read view: %v", closeErr)
 	}
-	if len(response.Results) != 2 || !response.Results[0].Found || !response.Results[1].Found {
+	if len(response.Results) != 3 || !response.Results[0].Found || !response.Results[1].Found || !response.Results[2].Found {
 		t.Fatalf("FetchDocumentsByID results=%+v", response.Results)
 	}
-	assertRetainedSemanticStreamDocument(t, response.Results[0].Document, 17)
-	assertRetainedSemanticStreamDocument(t, response.Results[1].Document, 42)
+	assertRetainedSemanticStreamDocument(t, response.Results[0].Document, 9)
+	assertRetainedSemanticStreamDocument(t, response.Results[1].Document, 17)
+	assertRetainedSemanticStreamDocument(t, response.Results[2].Document, 42)
 	if err := d.Close(); err != nil {
 		t.Fatalf("Close: %v", err)
 	}
@@ -386,10 +397,56 @@ func TestColumnRetainedPayloadSemanticStreamV1InsertBatchRoundTripReopen(t *test
 	} else {
 		assertRetainedSemanticStreamDocument(t, got, 17)
 	}
+	if got, err := reopenedCol.Get(ids[9]); err != nil {
+		t.Fatalf("Get semantic stream whitespace-row doc after reopen: %v", err)
+	} else {
+		assertRetainedSemanticStreamDocument(t, got, 9)
+	}
 	_, reopenedRow, reopenedPtr := requireColumnRetainedSemanticStreamLocatorAndBlockPointer(t, reopen, "events", ids[17])
 	if reopenedRow != row || reopenedPtr != ptr {
 		t.Fatalf("semantic stream locator changed after reopen: row/ptr got %d/%+v want %d/%+v", reopenedRow, reopenedPtr, row, ptr)
 	}
+}
+
+func TestColumnRetainedPayloadSemanticStreamV1PreservesRetainedJSONNumbers(t *testing.T) {
+	dir := t.TempDir()
+	enableColumnRetainedPlacementCommandWAL(t, dir)
+
+	d := openColumnRetainedPlacementDB(t, dir, backenddb.Options{})
+	defer func() { _ = d.Close() }()
+	col := createColumnRetainedSemanticStreamCollection(t, d, "events")
+	ids := [][]byte{[]byte("doc-big"), []byte("doc-control")}
+	docs := [][]byte{
+		[]byte(`{"row_id":0,"kind":"kind-0","payload":{"big":9007199254740993,"decimal":0.100000000000000005}}`),
+		[]byte(`{"row_id":1,"kind":"kind-1","payload":{"big":9007199254740995,"decimal":0.200000000000000005}}`),
+	}
+	if _, err := col.InsertBatch(ids, docs); err != nil {
+		t.Fatalf("InsertBatch: %v", err)
+	}
+	got, err := col.Get(ids[0])
+	if err != nil {
+		t.Fatalf("Get semantic stream number doc: %v", err)
+	}
+	assertJSONNumberString(t, got, []string{"payload", "big"}, "9007199254740993")
+	assertJSONNumberString(t, got, []string{"payload", "decimal"}, "0.100000000000000005")
+
+	view, err := col.OpenCollectionReadView()
+	if err != nil {
+		t.Fatalf("OpenCollectionReadView: %v", err)
+	}
+	response, err := view.FetchDocumentsByID([][]byte{ids[1]}, DocumentFetchOptions{})
+	closeErr := view.Close()
+	if err != nil {
+		t.Fatalf("FetchDocumentsByID: %v", err)
+	}
+	if closeErr != nil {
+		t.Fatalf("Close read view: %v", closeErr)
+	}
+	if len(response.Results) != 1 || !response.Results[0].Found {
+		t.Fatalf("FetchDocumentsByID results=%+v", response.Results)
+	}
+	assertJSONNumberString(t, response.Results[0].Document, []string{"payload", "big"}, "9007199254740995")
+	assertJSONNumberString(t, response.Results[0].Document, []string{"payload", "decimal"}, "0.200000000000000005")
 }
 
 func TestColumnRetainedPayloadSemanticStreamV1SideRootRewrite(t *testing.T) {
@@ -570,6 +627,35 @@ func assertRetainedSemanticStreamDocument(t testing.TB, document []byte, row int
 			},
 		},
 	})
+}
+
+func assertJSONNumberString(t testing.TB, document []byte, path []string, want string) {
+	t.Helper()
+	decoder := json.NewDecoder(bytes.NewReader(document))
+	decoder.UseNumber()
+	var root map[string]any
+	if err := decoder.Decode(&root); err != nil {
+		t.Fatalf("document=%q is not valid JSON: %v", document, err)
+	}
+	var current any = root
+	for _, segment := range path {
+		obj, ok := current.(map[string]any)
+		if !ok {
+			t.Fatalf("path %v reached %T at segment %q in document=%s", path, current, segment, document)
+		}
+		next, ok := obj[segment]
+		if !ok {
+			t.Fatalf("path %v missing segment %q in document=%s", path, segment, document)
+		}
+		current = next
+	}
+	number, ok := current.(json.Number)
+	if !ok {
+		t.Fatalf("path %v value=%v (%T) want JSON number %q in document=%s", path, current, current, want, document)
+	}
+	if number.String() != want {
+		t.Fatalf("path %v number=%q want %q in document=%s", path, number.String(), want, document)
+	}
 }
 
 func requireColumnRetainedPlacementPointer(t testing.TB, d *backenddb.DB, collection string, documentID []byte) page.ValuePtr {

--- a/TreeDB/collections/column_retained_vlog_placement_test.go
+++ b/TreeDB/collections/column_retained_vlog_placement_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -16,6 +17,7 @@ import (
 	"github.com/snissn/gomap/TreeDB/internal/valuelog"
 	"github.com/snissn/gomap/TreeDB/node"
 	"github.com/snissn/gomap/TreeDB/page"
+	"github.com/snissn/gomap/TreeDB/tree"
 )
 
 func TestColumnRetainedPayloadValueLogPlacementReopen(t *testing.T) {
@@ -512,6 +514,97 @@ func TestColumnRetainedPayloadSemanticStreamV1SideRootRewrite(t *testing.T) {
 	}
 }
 
+func TestColumnRetainedPayloadSemanticStreamV1ReclaimsSideBlockAfterDelete(t *testing.T) {
+	dir := t.TempDir()
+	enableColumnRetainedPlacementCommandWAL(t, dir)
+
+	d := openColumnRetainedPlacementDB(t, dir, backenddb.Options{})
+	defer func() { _ = d.Close() }()
+	col := createColumnRetainedSemanticStreamCollection(t, d, "events")
+	ids, docs := retainedSemanticStreamDocuments(64)
+	if _, err := col.InsertBatch(ids, docs); err != nil {
+		t.Fatalf("InsertBatch: %v", err)
+	}
+	blockKey, _, _ := requireColumnRetainedSemanticStreamLocatorAndBlockPointer(t, d, "events", ids[0])
+
+	deleted, err := col.DeleteBatch(ids[:63])
+	if err != nil {
+		t.Fatalf("DeleteBatch partial block: %v", err)
+	}
+	if deleted != 63 {
+		t.Fatalf("DeleteBatch deleted=%d want 63", deleted)
+	}
+	liveBlockKey, _, _ := requireColumnRetainedSemanticStreamLocatorAndBlockPointer(t, d, "events", ids[63])
+	if !bytes.Equal(liveBlockKey, blockKey) {
+		t.Fatalf("live row moved to block %x want original %x", liveBlockKey, blockKey)
+	}
+	if got, err := col.Get(ids[63]); err != nil {
+		t.Fatalf("Get remaining semantic row: %v", err)
+	} else {
+		assertRetainedSemanticStreamDocument(t, got, 63)
+	}
+
+	deletedOne, err := col.DeleteDocument(ids[63])
+	if err != nil {
+		t.Fatalf("DeleteDocument final row: %v", err)
+	}
+	if !deletedOne {
+		t.Fatal("DeleteDocument final row reported deleted=false")
+	}
+	requireColumnRetainedSemanticStreamBlockDeleted(t, d, "events", blockKey)
+}
+
+func TestColumnRetainedPayloadSemanticStreamV1ReclaimsSideBlockAfterUpdateBatch(t *testing.T) {
+	dir := t.TempDir()
+	enableColumnRetainedPlacementCommandWAL(t, dir)
+
+	d := openColumnRetainedPlacementDB(t, dir, backenddb.Options{})
+	defer func() { _ = d.Close() }()
+	col := createColumnRetainedSemanticStreamCollection(t, d, "events")
+	ids, docs := retainedSemanticStreamDocuments(64)
+	if _, err := col.InsertBatch(ids, docs); err != nil {
+		t.Fatalf("InsertBatch: %v", err)
+	}
+	blockKey, _, _ := requireColumnRetainedSemanticStreamLocatorAndBlockPointer(t, d, "events", ids[8])
+
+	items := make([]UpdateBatchItem, len(ids))
+	for i := range ids {
+		row := i
+		replacement := retainedSemanticStreamUpdatedDocument(row)
+		items[i] = UpdateBatchItem{
+			DocumentID: ids[i],
+			Update: func(current []byte) ([]byte, bool, error) {
+				return replacement, true, nil
+			},
+		}
+	}
+	results, err := col.UpdateBatch(items)
+	if err != nil {
+		t.Fatalf("UpdateBatch: %v", err)
+	}
+	if len(results) != len(ids) {
+		t.Fatalf("UpdateBatch results=%d want %d", len(results), len(ids))
+	}
+	for i, result := range results {
+		if !result.Matched || !result.Modified {
+			t.Fatalf("UpdateBatch result[%d]=%+v want matched+modified", i, result)
+		}
+	}
+	requireColumnRetainedSemanticStreamBlockDeleted(t, d, "events", blockKey)
+	if got, err := col.Get(ids[8]); err != nil {
+		t.Fatalf("Get updated semantic row: %v", err)
+	} else {
+		assertJSONMapEqual1875(t, got, map[string]any{
+			"row_id":  float64(8),
+			"kind":    "updated-kind-8",
+			"payload": "updated-payload-008",
+			"commit": map[string]any{
+				"cid": "updated-cid-008",
+			},
+		})
+	}
+}
+
 func enableColumnRetainedPlacementCommandWAL(t testing.TB, dir string) {
 	t.Helper()
 	if err := backenddb.SaveFormatConfig(dir, backenddb.FormatConfig{RequiredFeatures: []string{backenddb.RequiredFeatureCommandWALV1}}); err != nil {
@@ -605,6 +698,10 @@ func retainedSemanticStreamDocumentsFrom(start, count int) ([][]byte, [][]byte) 
 		))
 	}
 	return ids, docs
+}
+
+func retainedSemanticStreamUpdatedDocument(row int) []byte {
+	return []byte(fmt.Sprintf(`{"row_id":%d,"kind":"updated-kind-%d","payload":"updated-payload-%03d","commit":{"cid":"updated-cid-%03d"}}`, row, row, row, row))
 }
 
 func assertRetainedSemanticStreamDocument(t testing.TB, document []byte, row int) {
@@ -727,6 +824,32 @@ func requireColumnRetainedSemanticStreamLocatorAndBlockPointer(t testing.TB, d *
 		t.Fatalf("semantic stream block pointer file id=%d is not a value-log file", blockEntry.ValuePtr.FileID)
 	}
 	return blockKey, row, blockEntry.ValuePtr
+}
+
+func requireColumnRetainedSemanticStreamBlockDeleted(t testing.TB, d *backenddb.DB, collection string, blockKey []byte) {
+	t.Helper()
+	snap := d.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("AcquireSnapshot returned nil")
+	}
+	defer func() { _ = snap.Close() }()
+	catalog, err := loadCollectionCatalog(snap, collection)
+	if err != nil {
+		t.Fatalf("loadCollectionCatalog: %v", err)
+	}
+	if catalog == nil {
+		t.Fatalf("collection catalog %q missing", collection)
+	}
+	entry, _, err := collectionGetEntryAtCatalogRoot(snap, catalog, collectionRetainedSemanticStreamRootName(collection), blockKey)
+	if errors.Is(err, tree.ErrKeyNotFound) {
+		return
+	}
+	if err != nil {
+		t.Fatalf("semantic stream block entry after reclaim: %v", err)
+	}
+	if entry.Flags&node.FlagTombstone == 0 {
+		t.Fatalf("semantic stream block %x flags=%#x value_len=%d want tombstone or missing", blockKey, entry.Flags, len(entry.Value))
+	}
 }
 
 func valueLogPathForFileID(t testing.TB, dir string, fileID uint32) string {

--- a/TreeDB/collections/column_retained_vlog_placement_test.go
+++ b/TreeDB/collections/column_retained_vlog_placement_test.go
@@ -335,6 +335,126 @@ func TestColumnRetainedPayloadTemplateV1PackedAppendMismatchFailsClosed(t *testi
 	}
 }
 
+func TestColumnRetainedPayloadSemanticStreamV1InsertBatchRoundTripReopen(t *testing.T) {
+	dir := t.TempDir()
+	enableColumnRetainedPlacementCommandWAL(t, dir)
+
+	d := openColumnRetainedPlacementDB(t, dir, backenddb.Options{})
+	col := createColumnRetainedSemanticStreamCollection(t, d, "events")
+	ids, docs := retainedSemanticStreamDocuments(96)
+	if _, err := col.InsertBatch(ids, docs); err != nil {
+		t.Fatalf("InsertBatch: %v", err)
+	}
+	blockKey, row, ptr := requireColumnRetainedSemanticStreamLocatorAndBlockPointer(t, d, "events", ids[17])
+	if len(blockKey) == 0 || row != 17 {
+		t.Fatalf("semantic locator block_key_len=%d row=%d want row 17", len(blockKey), row)
+	}
+	if !page.IsValueLogFileID(ptr.FileID) {
+		t.Fatalf("semantic stream block pointer file id=%d is not value-log backed", ptr.FileID)
+	}
+	if got, err := col.Get(ids[17]); err != nil {
+		t.Fatalf("Get semantic stream doc: %v", err)
+	} else {
+		assertRetainedSemanticStreamDocument(t, got, 17)
+	}
+	view, err := col.OpenCollectionReadView()
+	if err != nil {
+		t.Fatalf("OpenCollectionReadView: %v", err)
+	}
+	response, err := view.FetchDocumentsByID([][]byte{ids[17], ids[42]}, DocumentFetchOptions{})
+	closeErr := view.Close()
+	if err != nil {
+		t.Fatalf("FetchDocumentsByID: %v", err)
+	}
+	if closeErr != nil {
+		t.Fatalf("Close read view: %v", closeErr)
+	}
+	if len(response.Results) != 2 || !response.Results[0].Found || !response.Results[1].Found {
+		t.Fatalf("FetchDocumentsByID results=%+v", response.Results)
+	}
+	assertRetainedSemanticStreamDocument(t, response.Results[0].Document, 17)
+	assertRetainedSemanticStreamDocument(t, response.Results[1].Document, 42)
+	if err := d.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	reopen := openColumnRetainedPlacementDB(t, dir, backenddb.Options{})
+	defer func() { _ = reopen.Close() }()
+	reopenedCol := openColumnRetainedPlacementCollection(t, reopen, "events")
+	if got, err := reopenedCol.Get(ids[17]); err != nil {
+		t.Fatalf("Get semantic stream doc after reopen: %v", err)
+	} else {
+		assertRetainedSemanticStreamDocument(t, got, 17)
+	}
+	_, reopenedRow, reopenedPtr := requireColumnRetainedSemanticStreamLocatorAndBlockPointer(t, reopen, "events", ids[17])
+	if reopenedRow != row || reopenedPtr != ptr {
+		t.Fatalf("semantic stream locator changed after reopen: row/ptr got %d/%+v want %d/%+v", reopenedRow, reopenedPtr, row, ptr)
+	}
+}
+
+func TestColumnRetainedPayloadSemanticStreamV1SideRootRewrite(t *testing.T) {
+	dir := t.TempDir()
+	enableColumnRetainedPlacementCommandWAL(t, dir)
+
+	d := openColumnRetainedPlacementDB(t, dir, backenddb.Options{})
+	col := createColumnRetainedSemanticStreamCollection(t, d, "events")
+	ids, docs := retainedSemanticStreamDocuments(64)
+	if _, err := col.InsertBatch(ids, docs); err != nil {
+		t.Fatalf("InsertBatch first block: %v", err)
+	}
+	_, _, ptr := requireColumnRetainedSemanticStreamLocatorAndBlockPointer(t, d, "events", ids[8])
+	if err := d.Close(); err != nil {
+		t.Fatalf("Close after first block: %v", err)
+	}
+
+	d = openColumnRetainedPlacementDB(t, dir, backenddb.Options{})
+	col = openColumnRetainedPlacementCollection(t, d, "events")
+	moreIDs, moreDocs := retainedSemanticStreamDocumentsFrom(64, 8)
+	if _, err := col.InsertBatch(moreIDs, moreDocs); err != nil {
+		_ = d.Close()
+		t.Fatalf("InsertBatch second block: %v", err)
+	}
+	rewriteStats, err := d.ValueLogRewriteOnline(context.Background(), backenddb.ValueLogRewriteOnlineOptions{
+		SourceFileIDs: []uint32{ptr.FileID},
+		BatchSize:     1,
+	})
+	if err != nil {
+		_ = d.Close()
+		t.Fatalf("ValueLogRewriteOnline: %v", err)
+	}
+	if rewriteStats.RecordsCopied == 0 {
+		_ = d.Close()
+		t.Fatalf("ValueLogRewriteOnline copied no semantic stream records: %+v", rewriteStats)
+	}
+	_, _, rewrittenPtr := requireColumnRetainedSemanticStreamLocatorAndBlockPointer(t, d, "events", ids[8])
+	if rewrittenPtr.FileID == ptr.FileID {
+		_ = d.Close()
+		t.Fatalf("semantic stream block pointer still references rewrite source segment %d", ptr.FileID)
+	}
+	if got, err := col.Get(ids[8]); err != nil {
+		_ = d.Close()
+		t.Fatalf("Get semantic stream doc after rewrite: %v", err)
+	} else {
+		assertRetainedSemanticStreamDocument(t, got, 8)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("Close after rewrite: %v", err)
+	}
+
+	reopen := openColumnRetainedPlacementDB(t, dir, backenddb.Options{})
+	defer func() { _ = reopen.Close() }()
+	reopenedCol := openColumnRetainedPlacementCollection(t, reopen, "events")
+	if got, err := reopenedCol.Get(ids[8]); err != nil {
+		t.Fatalf("Get semantic stream doc after rewrite reopen: %v", err)
+	} else {
+		assertRetainedSemanticStreamDocument(t, got, 8)
+	}
+	_, _, reopenedPtr := requireColumnRetainedSemanticStreamLocatorAndBlockPointer(t, reopen, "events", ids[8])
+	if reopenedPtr != rewrittenPtr {
+		t.Fatalf("rewritten semantic stream pointer changed after reopen: got=%+v want=%+v", reopenedPtr, rewrittenPtr)
+	}
+}
+
 func enableColumnRetainedPlacementCommandWAL(t testing.TB, dir string) {
 	t.Helper()
 	if err := backenddb.SaveFormatConfig(dir, backenddb.FormatConfig{RequiredFeatures: []string{backenddb.RequiredFeatureCommandWALV1}}); err != nil {
@@ -371,6 +491,25 @@ func createColumnRetainedPlacementCollection(t testing.TB, d *backenddb.DB, name
 	return openColumnRetainedPlacementCollection(t, d, name)
 }
 
+func createColumnRetainedSemanticStreamCollection(t testing.TB, d *backenddb.DB, name string) *Collection {
+	t.Helper()
+	cfg := &ColumnStoreConfig{
+		Enabled: true,
+		Columns: []ColumnStoreColumn{
+			{Name: "row_id", Path: "row_id", ValueType: ColumnStoreValueInt64, Owner: TypedStorageOwnerRowAsset},
+			{Name: "kind", Path: "kind", ValueType: ColumnStoreValueString, Owner: TypedStorageOwnerColumnPart, Dictionary: true},
+		},
+		RetainedPayload:         ColumnRetainedPayloadNonColumn,
+		RetainedPayloadEncoding: ColumnRetainedPayloadEncodingSemanticStreamV1,
+		Reconstruction:          ColumnReconstructionRetainedPayloadAndColumns,
+	}
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: name, Options: CollectionOptions{DocumentFormat: DocumentFormatJSON, ColumnStore: cfg}}); err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	return openColumnRetainedPlacementCollection(t, d, name)
+}
+
 func openColumnRetainedPlacementCollection(t testing.TB, d *backenddb.DB, name string) *Collection {
 	t.Helper()
 	col, err := NewCollectionManager(d).OpenCollection(name)
@@ -382,6 +521,55 @@ func openColumnRetainedPlacementCollection(t testing.TB, d *backenddb.DB, name s
 
 func retainedPlacementDocument(payload string, rowID int) []byte {
 	return []byte(fmt.Sprintf(`{"row_id":%d,"kind":"kind-%d","payload":"%s"}`, rowID, rowID, strings.Repeat(payload, 10)))
+}
+
+func retainedSemanticStreamDocuments(count int) ([][]byte, [][]byte) {
+	return retainedSemanticStreamDocumentsFrom(0, count)
+}
+
+func retainedSemanticStreamDocumentsFrom(start, count int) ([][]byte, [][]byte) {
+	ids := make([][]byte, count)
+	docs := make([][]byte, count)
+	for i := 0; i < count; i++ {
+		row := start + i
+		ids[i] = []byte(fmt.Sprintf("doc-%06d", row))
+		docs[i] = []byte(fmt.Sprintf(
+			`{"row_id":%d,"kind":"kind-%d","payload":"payload-%03d","commit":{"cid":"bafy-test-%06d","rev":"3l-%06d","record":{"$type":"app.bsky.feed.post","createdAt":"2026-06-13T12:%02d:00Z","subject":{"uri":"at://did:plc:%06d/app.bsky.feed.post/%06d","cid":"bafy-subject-%06d"},"text":"semantic stream retained payload %03d"}}}`,
+			row,
+			row%7,
+			row%11,
+			row,
+			row,
+			row%60,
+			row%19,
+			row,
+			row,
+			row,
+		))
+	}
+	return ids, docs
+}
+
+func assertRetainedSemanticStreamDocument(t testing.TB, document []byte, row int) {
+	t.Helper()
+	assertJSONMapEqual1875(t, document, map[string]any{
+		"row_id":  float64(row),
+		"kind":    fmt.Sprintf("kind-%d", row%7),
+		"payload": fmt.Sprintf("payload-%03d", row%11),
+		"commit": map[string]any{
+			"cid": fmt.Sprintf("bafy-test-%06d", row),
+			"rev": fmt.Sprintf("3l-%06d", row),
+			"record": map[string]any{
+				"$type":     "app.bsky.feed.post",
+				"createdAt": fmt.Sprintf("2026-06-13T12:%02d:00Z", row%60),
+				"subject": map[string]any{
+					"uri": fmt.Sprintf("at://did:plc:%06d/app.bsky.feed.post/%06d", row%19, row),
+					"cid": fmt.Sprintf("bafy-subject-%06d", row),
+				},
+				"text": fmt.Sprintf("semantic stream retained payload %03d", row),
+			},
+		},
+	})
 }
 
 func requireColumnRetainedPlacementPointer(t testing.TB, d *backenddb.DB, collection string, documentID []byte) page.ValuePtr {
@@ -412,6 +600,47 @@ func requireColumnRetainedPlacementPointer(t testing.TB, d *backenddb.DB, collec
 		t.Fatalf("collection primary entry %q pointer file id=%d is not a value-log file", string(documentID), entry.ValuePtr.FileID)
 	}
 	return entry.ValuePtr
+}
+
+func requireColumnRetainedSemanticStreamLocatorAndBlockPointer(t testing.TB, d *backenddb.DB, collection string, documentID []byte) ([]byte, uint64, page.ValuePtr) {
+	t.Helper()
+	snap := d.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("AcquireSnapshot returned nil")
+	}
+	defer func() { _ = snap.Close() }()
+	catalog, err := loadCollectionCatalog(snap, collection)
+	if err != nil {
+		t.Fatalf("loadCollectionCatalog: %v", err)
+	}
+	if catalog == nil {
+		t.Fatalf("collection catalog %q missing", collection)
+	}
+	entry, _, err := collectionGetEntryAtCatalogRoot(snap, catalog, collectionPrimaryRootName(collection), documentID)
+	if err != nil {
+		t.Fatalf("collection primary entry %q: %v", string(documentID), err)
+	}
+	if entry.Flags&node.FlagPointer != 0 {
+		t.Fatalf("semantic stream primary entry %q flags=%#x want inline locator", string(documentID), entry.Flags)
+	}
+	blockKey, row, ok, err := parseColumnRetainedSemanticStreamV1Locator(entry.Value)
+	if err != nil {
+		t.Fatalf("parse semantic stream locator: %v", err)
+	}
+	if !ok {
+		t.Fatalf("primary entry %q value %x is not a semantic stream locator", string(documentID), entry.Value)
+	}
+	blockEntry, _, err := collectionGetEntryAtCatalogRoot(snap, catalog, collectionRetainedSemanticStreamRootName(collection), blockKey)
+	if err != nil {
+		t.Fatalf("semantic stream block entry: %v", err)
+	}
+	if blockEntry.Flags&node.FlagPointer == 0 {
+		t.Fatalf("semantic stream block flags=%#x value_len=%d want value-log pointer", blockEntry.Flags, len(blockEntry.Value))
+	}
+	if !page.IsValueLogFileID(blockEntry.ValuePtr.FileID) {
+		t.Fatalf("semantic stream block pointer file id=%d is not a value-log file", blockEntry.ValuePtr.FileID)
+	}
+	return blockKey, row, blockEntry.ValuePtr
 }
 
 func valueLogPathForFileID(t testing.TB, dir string, fileID uint32) string {

--- a/TreeDB/collections/column_store.go
+++ b/TreeDB/collections/column_store.go
@@ -136,6 +136,9 @@ const (
 	// ColumnRetainedPayloadEncodingTemplateV1 records retained payload bodies
 	// stored as Template-v1 documents with templates in the collection template root.
 	ColumnRetainedPayloadEncodingTemplateV1 = "template-v1"
+	// ColumnRetainedPayloadEncodingSemanticStreamV1 records multi-row retained
+	// payload bodies as semantic path streams in a dedicated collection root.
+	ColumnRetainedPayloadEncodingSemanticStreamV1 = "semantic-stream-v1"
 	// ColumnRetainedPayloadEncodingNone records that no retained body is active.
 	ColumnRetainedPayloadEncodingNone = "none"
 	// ColumnRetainedPayloadEncodingUnavailable is a reporting sentinel for
@@ -565,7 +568,7 @@ func validateColumnRetainedPayloadEncoding(policy ColumnRetainedPayloadPolicy, e
 		return fmt.Errorf("collections: retained payload policy %q requires encoding %q, got %q", policy, ColumnRetainedPayloadEncodingJSON, encoding)
 	case ColumnRetainedPayloadNonColumn:
 		switch encoding {
-		case ColumnRetainedPayloadEncodingJSON, ColumnRetainedPayloadEncodingTemplateV1:
+		case ColumnRetainedPayloadEncodingJSON, ColumnRetainedPayloadEncodingTemplateV1, ColumnRetainedPayloadEncodingSemanticStreamV1:
 			return nil
 		default:
 			return fmt.Errorf("collections: retained payload policy %q does not support encoding %q", policy, encoding)
@@ -587,6 +590,10 @@ func columnRetainedPayloadEffectiveEncoding(cfg *ColumnStoreConfig) ColumnRetain
 
 func columnStoreRetainedPayloadUsesTemplateV1(cfg *ColumnStoreConfig) bool {
 	return cfg != nil && cfg.Enabled && cfg.RetainedPayload == ColumnRetainedPayloadNonColumn && columnRetainedPayloadEffectiveEncoding(cfg) == ColumnRetainedPayloadEncodingTemplateV1
+}
+
+func columnStoreRetainedPayloadUsesSemanticStreamV1(cfg *ColumnStoreConfig) bool {
+	return cfg != nil && cfg.Enabled && cfg.RetainedPayload == ColumnRetainedPayloadNonColumn && columnRetainedPayloadEffectiveEncoding(cfg) == ColumnRetainedPayloadEncodingSemanticStreamV1
 }
 
 func validateColumnStoreConfig(collection string, cfg ColumnStoreConfig) error {

--- a/TreeDB/collections/compact_storage.go
+++ b/TreeDB/collections/compact_storage.go
@@ -48,7 +48,9 @@ func (c *Collection) CompactStorage(ctx context.Context, opts CompactStorageOpti
 	stats.RootOverlays = map[string]CollectionRootOverlayCompactionStats{
 		c.meta.Name: rootResult.stats,
 	}
-	opts = compactStorageOptionsWithCollectionRootProtection(opts, rootResult)
+	if err := checkpointCollectionCompactStorageFoldedRoots(c.db, rootResult); err != nil {
+		return stats, err
+	}
 	storage, err := c.db.CompactStorage(ctx, backenddb.CompactStorageOptions(opts))
 	if err != nil {
 		return stats, err
@@ -103,7 +105,9 @@ func (m *CollectionManager) CompactStorage(ctx context.Context, opts CompactStor
 		stats.RootOverlays[meta.Name] = rootResult.stats
 		rootResults = append(rootResults, rootResult)
 	}
-	opts = compactStorageOptionsWithCollectionRootProtection(opts, rootResults...)
+	if err := checkpointCollectionCompactStorageFoldedRoots(m.db, rootResults...); err != nil {
+		return stats, err
+	}
 	storage, err := m.db.CompactStorage(ctx, backenddb.CompactStorageOptions(opts))
 	if err != nil {
 		return stats, err
@@ -112,16 +116,19 @@ func (m *CollectionManager) CompactStorage(ctx context.Context, opts CompactStor
 	return stats, nil
 }
 
-func compactStorageOptionsWithCollectionRootProtection(opts CompactStorageOptions, results ...collectionRootOverlayCompactionResult) CompactStorageOptions {
+func checkpointCollectionCompactStorageFoldedRoots(db *backenddb.DB, results ...collectionRootOverlayCompactionResult) error {
+	if db == nil {
+		return errCollectionDBNil
+	}
 	for _, result := range results {
 		if result.systemRootID != 0 {
-			opts.LeafGenerationProtectedSystemRootIDs = appendCollectionCompactStorageProtectedRootIDs(
-				opts.LeafGenerationProtectedSystemRootIDs,
-				[]uint64{result.systemRootID},
-			)
+			// Backend storage compaction protects collection roots by scanning
+			// the current system-root descriptors; make the folded descriptors
+			// durable before rewrite/pack/GC phases refresh their snapshots.
+			return db.Checkpoint()
 		}
 	}
-	return opts
+	return nil
 }
 
 func appendCollectionCompactStorageProtectedRootIDs(dst []uint64, src []uint64) []uint64 {

--- a/TreeDB/collections/document_materializer.go
+++ b/TreeDB/collections/document_materializer.go
@@ -863,6 +863,12 @@ func (v *CollectionReadView) fetchRetainedPayloadsByID(ids [][]byte) (DocumentFe
 
 	foundCount := 0
 	var retainedArena []byte
+	var cfg ColumnStoreConfig
+	resolveRetained := false
+	if v.catalog != nil && v.catalog.meta.Options.ColumnStore != nil {
+		cfg = v.catalog.meta.Options.ColumnStore.copy()
+		resolveRetained = columnStoreRetainedPayloadUsesSemanticStreamV1(&cfg)
+	}
 	err := collectionGetManyViewAtCatalogRoot(v.snapshot, v.catalog, collectionPrimaryRootName(v.catalog.meta.Name), ids, func(i int, _ []byte, value []byte, found bool) error {
 		if i < 0 || i >= len(ids) {
 			return fmt.Errorf("collections: GetManyView callback index %d outside %d ids", i, len(ids))
@@ -872,6 +878,13 @@ func (v *CollectionReadView) fetchRetainedPayloadsByID(ids [][]byte) (DocumentFe
 			return nil
 		}
 		response.Results[i].Found = true
+		if resolveRetained {
+			resolved, err := resolveColumnRetainedPayloadAtSnapshot(v.snapshot, v.catalog, cfg, value)
+			if err != nil {
+				return err
+			}
+			value = resolved
+		}
 		if len(value) == 0 {
 			retained[i] = []byte{}
 		} else {

--- a/TreeDB/collections/typed_storage_naming_test.go
+++ b/TreeDB/collections/typed_storage_naming_test.go
@@ -383,6 +383,7 @@ var typedStorageLegacyNameAllowlist = []typedStorageLegacyNameAllowlistEntry{
 	{path: "TreeDB/collections/column_reconstruction_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 27, occurrences: 31},
 	{path: "TreeDB/collections/column_retained_payload_audit.go", classification: typedStorageLegacyCompatibility, matchingLines: 8, occurrences: 8},
 	{path: "TreeDB/collections/column_retained_payload_audit_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 25, occurrences: 26},
+	{path: "TreeDB/collections/column_retained_semantic_stream.go", classification: typedStorageLegacyCompatibility, matchingLines: 4, occurrences: 4},
 	{path: "TreeDB/collections/column_retained_vlog_placement_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 18, occurrences: 18},
 	{path: "TreeDB/collections/column_semantics.go", classification: typedStorageLegacyCompatibility, matchingLines: 34, occurrences: 34},
 	{path: "TreeDB/collections/dense_numeric_vector.go", classification: typedStorageLegacyCompatibility, matchingLines: 32, occurrences: 41},

--- a/TreeDB/collections/typed_storage_naming_test.go
+++ b/TreeDB/collections/typed_storage_naming_test.go
@@ -331,7 +331,7 @@ type typedStorageLegacyNameAllowlistEntry struct {
 }
 
 var typedStorageLegacyNameAllowlist = []typedStorageLegacyNameAllowlistEntry{
-	{path: "TreeDB/collections/api.go", classification: typedStorageLegacyCompatibility, matchingLines: 48, occurrences: 54},
+	{path: "TreeDB/collections/api.go", classification: typedStorageLegacyCompatibility, matchingLines: 52, occurrences: 58},
 	{path: "TreeDB/collections/column_aggregate_metadata_asset.go", classification: typedStorageLegacyDerived, matchingLines: 16, occurrences: 19},
 	{path: "TreeDB/collections/column_aggregate_metadata_predicate.go", classification: typedStorageLegacyDerived, matchingLines: 6, occurrences: 6},
 	{path: "TreeDB/collections/column_aggregate_metadata_predicate_1951_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 15, occurrences: 16},
@@ -383,11 +383,11 @@ var typedStorageLegacyNameAllowlist = []typedStorageLegacyNameAllowlistEntry{
 	{path: "TreeDB/collections/column_reconstruction_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 27, occurrences: 31},
 	{path: "TreeDB/collections/column_retained_payload_audit.go", classification: typedStorageLegacyCompatibility, matchingLines: 8, occurrences: 8},
 	{path: "TreeDB/collections/column_retained_payload_audit_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 25, occurrences: 26},
-	{path: "TreeDB/collections/column_retained_vlog_placement_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 13, occurrences: 13},
+	{path: "TreeDB/collections/column_retained_vlog_placement_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 18, occurrences: 18},
 	{path: "TreeDB/collections/column_semantics.go", classification: typedStorageLegacyCompatibility, matchingLines: 34, occurrences: 34},
 	{path: "TreeDB/collections/dense_numeric_vector.go", classification: typedStorageLegacyCompatibility, matchingLines: 32, occurrences: 41},
 	{path: "TreeDB/collections/dense_numeric_vector_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 35, occurrences: 38},
-	{path: "TreeDB/collections/document_materializer.go", classification: typedStorageLegacyCompatibility, matchingLines: 13, occurrences: 13},
+	{path: "TreeDB/collections/document_materializer.go", classification: typedStorageLegacyCompatibility, matchingLines: 16, occurrences: 16},
 	{path: "TreeDB/collections/document_materializer_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 32, occurrences: 32},
 	{path: "TreeDB/documentservice/service.go", classification: typedStorageLegacyCompatibility, matchingLines: 5, occurrences: 7},
 	{path: "TreeDB/documentservice/service_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 1, occurrences: 2},
@@ -399,7 +399,7 @@ var typedStorageLegacyNameAllowlist = []typedStorageLegacyNameAllowlistEntry{
 	{path: "TreeDB/collections/column_vector_graph_quantized_asset_test.go", classification: typedStorageLegacyDerived, matchingLines: 3, occurrences: 4},
 	{path: "TreeDB/collections/column_vector_graph_brq_quantized_asset_test.go", classification: typedStorageLegacyDerived, matchingLines: 1, occurrences: 1},
 	{path: "TreeDB/collections/column_vector_graph_quantized_bench_test.go", classification: typedStorageLegacyDerived, matchingLines: 2, occurrences: 4},
-	{path: "TreeDB/collections/column_store.go", classification: typedStorageLegacyCompatibility, matchingLines: 131, occurrences: 235},
+	{path: "TreeDB/collections/column_store.go", classification: typedStorageLegacyCompatibility, matchingLines: 132, occurrences: 236},
 	{path: "TreeDB/collections/column_store_compaction.go", classification: typedStorageLegacyCompatibility, matchingLines: 34, occurrences: 41},
 	{path: "TreeDB/collections/column_store_compaction_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 71, occurrences: 82},
 	{path: "TreeDB/collections/column_store_compatibility_api_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 7, occurrences: 9},

--- a/TreeDB/collections/typed_storage_naming_test.go
+++ b/TreeDB/collections/typed_storage_naming_test.go
@@ -331,7 +331,7 @@ type typedStorageLegacyNameAllowlistEntry struct {
 }
 
 var typedStorageLegacyNameAllowlist = []typedStorageLegacyNameAllowlistEntry{
-	{path: "TreeDB/collections/api.go", classification: typedStorageLegacyCompatibility, matchingLines: 52, occurrences: 58},
+	{path: "TreeDB/collections/api.go", classification: typedStorageLegacyCompatibility, matchingLines: 56, occurrences: 62},
 	{path: "TreeDB/collections/column_aggregate_metadata_asset.go", classification: typedStorageLegacyDerived, matchingLines: 16, occurrences: 19},
 	{path: "TreeDB/collections/column_aggregate_metadata_predicate.go", classification: typedStorageLegacyDerived, matchingLines: 6, occurrences: 6},
 	{path: "TreeDB/collections/column_aggregate_metadata_predicate_1951_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 15, occurrences: 16},
@@ -383,7 +383,7 @@ var typedStorageLegacyNameAllowlist = []typedStorageLegacyNameAllowlistEntry{
 	{path: "TreeDB/collections/column_reconstruction_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 27, occurrences: 31},
 	{path: "TreeDB/collections/column_retained_payload_audit.go", classification: typedStorageLegacyCompatibility, matchingLines: 8, occurrences: 8},
 	{path: "TreeDB/collections/column_retained_payload_audit_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 25, occurrences: 26},
-	{path: "TreeDB/collections/column_retained_semantic_stream.go", classification: typedStorageLegacyCompatibility, matchingLines: 4, occurrences: 4},
+	{path: "TreeDB/collections/column_retained_semantic_stream.go", classification: typedStorageLegacyCompatibility, matchingLines: 5, occurrences: 5},
 	{path: "TreeDB/collections/column_retained_vlog_placement_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 18, occurrences: 18},
 	{path: "TreeDB/collections/column_semantics.go", classification: typedStorageLegacyCompatibility, matchingLines: 34, occurrences: 34},
 	{path: "TreeDB/collections/dense_numeric_vector.go", classification: typedStorageLegacyCompatibility, matchingLines: 32, occurrences: 41},

--- a/cmd/unified_bench/README.md
+++ b/cmd/unified_bench/README.md
@@ -359,6 +359,12 @@ CPU/allocation profiles. Omit it, or pass `all`, for the default full
 q1-q5/q5_metadata suite. Duplicate query names are rejected so benchprof
 tables and artifact labels stay unambiguous.
 
+Use `-column-store-retained-payload-encoding semantic-stream-v1`, or set
+`TREEDB_COLUMN_STORE_RETAINED_PAYLOAD_ENCODING=semantic-stream-v1`, to run the
+opt-in retained-payload semantic stream candidate for storage-parity evidence.
+The default remains `template-v1`, and `b_tree_index_baseline` still keeps full
+retained JSON so that index-baseline comparisons remain unchanged.
+
 The suite writes:
 
 - `column_store_results.json`, `column_store_results.md`, `column_store_results.html`
@@ -400,7 +406,9 @@ named `wal/commit-l<lane>-<seq>.log` (numeric lane, non-zero sequence) from
 assets, and manifest/control bytes remain included. `retained_payload_bytes`
 reports the row/remainder payload for the selected path; physical paths that
 strip declared columns into column assets should report less retained payload
-than the source JSONBench document bytes.
+than the source JSONBench document bytes. With `semantic-stream-v1`,
+`retained_payload_bytes` includes primary locator bytes plus the retained
+semantic-stream side-root block bytes.
 
 For post-V1 production-vs-experiment attribution, use the slope harness:
 

--- a/cmd/unified_bench/suite_column_store.go
+++ b/cmd/unified_bench/suite_column_store.go
@@ -113,6 +113,7 @@ var (
 	columnStoreSuiteTypedAdaptiveTargetBytesArg = flag.Int("column-store-typed-adaptive-target-bytes", 0, "Benchmark-only typed_column_part adaptive target raw bytes per mark/granule (0 uses typedcolumn default when adaptive is enabled)")
 	columnStoreSuiteTypedAdaptiveMinRowsArg     = flag.Int("column-store-typed-adaptive-min-rows", 0, "Benchmark-only typed_column_part adaptive minimum rows (0 uses typedcolumn default when adaptive is enabled)")
 	columnStoreSuiteTypedAdaptiveMaxRowsArg     = flag.Int("column-store-typed-adaptive-max-rows", 0, "Benchmark-only typed_column_part adaptive maximum rows (0 uses rows-per-granule/default when adaptive is enabled)")
+	columnStoreSuiteRetainedPayloadEncodingArg  = flag.String("column-store-retained-payload-encoding", "", "Retained-payload encoding override for -suite column_store non-column retained payloads (default/template-v1,json,semantic-stream-v1). Can also be set with TREEDB_COLUMN_STORE_RETAINED_PAYLOAD_ENCODING; b_tree_index_baseline remains full-retained JSON.")
 
 	columnStoreSuiteAcceptedForcedPaths = []string{
 		columnStorePathRowStoreBaseline,
@@ -1004,12 +1005,34 @@ func columnStoreSuiteConfig() *collections.ColumnStoreConfig {
 		Reconstruction:  collections.ColumnReconstructionRetainedPayloadAndColumns,
 		ProfileSupport:  profileSupport,
 	}
+	if encoding, ok := columnStoreSuiteRetainedPayloadEncodingOverride(); ok {
+		cfg.RetainedPayloadEncoding = encoding
+	}
 	if typedBenchmarkPolicyActive {
 		for i := range cfg.Columns {
 			cfg.Columns[i].Owner = collections.TypedStorageOwnerColumnPart
 		}
 	}
 	return cfg
+}
+
+func columnStoreSuiteRetainedPayloadEncodingOverride() (collections.ColumnRetainedPayloadEncoding, bool) {
+	value := strings.TrimSpace(*columnStoreSuiteRetainedPayloadEncodingArg)
+	if value == "" {
+		value = strings.TrimSpace(os.Getenv("TREEDB_COLUMN_STORE_RETAINED_PAYLOAD_ENCODING"))
+	}
+	switch strings.ToLower(value) {
+	case "", "default":
+		return "", false
+	case "json":
+		return collections.ColumnRetainedPayloadEncodingJSON, true
+	case "template-v1", "template_v1", "templatev1":
+		return collections.ColumnRetainedPayloadEncodingTemplateV1, true
+	case "semantic-stream-v1", "semantic_stream_v1", "semanticstreamv1":
+		return collections.ColumnRetainedPayloadEncodingSemanticStreamV1, true
+	default:
+		return collections.ColumnRetainedPayloadEncoding(value), true
+	}
 }
 
 func columnStoreSuiteTypedBenchmarkPolicyFlagsActive() bool {
@@ -1121,6 +1144,7 @@ func columnStoreSuiteConfigForPath(path string) *collections.ColumnStoreConfig {
 		// Keep this explicit comparison baseline full-retained until that
 		// production shape is supported.
 		cfg.RetainedPayload = collections.ColumnRetainedPayloadFull
+		cfg.RetainedPayloadEncoding = collections.ColumnRetainedPayloadEncodingJSON
 	}
 	return cfg
 }
@@ -2119,6 +2143,21 @@ func columnStoreSuiteRetainedPayloadAccounting(events []columnStoreFixtureEvent,
 			return bytesTotal, "M13C b_tree_index_baseline keeps full row payload because retained-payload indexed writes remain fail-closed until secondary-index reconstruction is wired", nil
 		}
 		return bytesTotal, "full row payload retained", nil
+	}
+	if cfg.RetainedPayload == collections.ColumnRetainedPayloadNonColumn &&
+		cfg.RetainedPayloadEncoding == collections.ColumnRetainedPayloadEncodingSemanticStreamV1 &&
+		len(events) > 1 {
+		documents := make([][]byte, len(events))
+		for i := range events {
+			documents[i] = events[i].Doc
+		}
+		accounting, err := collections.ColumnRetainedSemanticStreamV1StorageAccountingFromJSONDocuments(*cfg, documents)
+		if err != nil {
+			return 0, "", err
+		}
+		return accounting.TotalBytes,
+			fmt.Sprintf("semantic-stream-v1 retained payload accounting includes %d primary locator bytes plus %d side-root block bytes across %d blocks; declared columns are reconstructed from physical column assets", accounting.PrimaryLocatorBytes, accounting.BlockBytes, accounting.BlockCount),
+			nil
 	}
 	var bytesTotal int64
 	for _, event := range events {

--- a/cmd/unified_bench/suite_column_store_test.go
+++ b/cmd/unified_bench/suite_column_store_test.go
@@ -54,6 +54,40 @@ func TestColumnStoreSuiteRetainedPayloadRejectsTrailingJSONM13C(t *testing.T) {
 	}
 }
 
+func TestColumnStoreSuiteRetainedPayloadEncodingOverrideSelectsSemanticStreamV1(t *testing.T) {
+	withColumnStoreRetainedPayloadEncodingFlag(t, "semantic-stream-v1")
+	cfg := columnStoreSuiteConfig()
+	if got, want := cfg.RetainedPayloadEncoding, collections.ColumnRetainedPayloadEncoding(collections.ColumnRetainedPayloadEncodingSemanticStreamV1); got != want {
+		t.Fatalf("retained payload encoding=%q want %q", got, want)
+	}
+
+	btreeCfg := columnStoreSuiteConfigForPath(columnStorePathBTreeIndexBaseline)
+	if got, want := btreeCfg.RetainedPayload, collections.ColumnRetainedPayloadFull; got != want {
+		t.Fatalf("btree retained payload=%q want %q", got, want)
+	}
+	if got, want := btreeCfg.RetainedPayloadEncoding, collections.ColumnRetainedPayloadEncoding(collections.ColumnRetainedPayloadEncodingJSON); got != want {
+		t.Fatalf("btree retained payload encoding=%q want %q", got, want)
+	}
+}
+
+func TestColumnStoreSuiteRetainedPayloadAccountingUsesSemanticStreamV1Blocks(t *testing.T) {
+	withColumnStoreRetainedPayloadEncodingFlag(t, "semantic-stream-v1")
+	events, _ := buildColumnStoreSyntheticFixture(32, 1)
+	cfg := columnStoreSuiteConfig()
+	got, note, err := columnStoreSuiteRetainedPayloadAccounting(events, cfg, columnStorePathSerialColumnScan)
+	if err != nil {
+		t.Fatalf("columnStoreSuiteRetainedPayloadAccounting: %v", err)
+	}
+	if got <= 0 {
+		t.Fatalf("semantic-stream-v1 accounting bytes=%d want positive", got)
+	}
+	for _, want := range []string{"semantic-stream-v1", "primary locator bytes", "side-root block bytes"} {
+		if !strings.Contains(note, want) {
+			t.Fatalf("semantic-stream-v1 accounting note %q missing %q", note, want)
+		}
+	}
+}
+
 func TestRunColumnStoreSuiteRejectsRelaxedAssetReadIntegrityWithoutUnsafeM1634(t *testing.T) {
 	for _, mode := range []string{
 		string(collections.ColumnAssetReadIntegrityCachedVerify),
@@ -2853,6 +2887,22 @@ func withColumnStoreTypedBenchmarkPolicyFlags(t *testing.T, compression, int64En
 		*columnStoreSuiteTypedAdaptiveTargetBytesArg = prevAdaptiveTargetBytes
 		*columnStoreSuiteTypedAdaptiveMinRowsArg = prevAdaptiveMinRows
 		*columnStoreSuiteTypedAdaptiveMaxRowsArg = prevAdaptiveMaxRows
+	})
+}
+
+func withColumnStoreRetainedPayloadEncodingFlag(t *testing.T, encoding string) {
+	t.Helper()
+	prevFlag := *columnStoreSuiteRetainedPayloadEncodingArg
+	prevEnv, envOK := os.LookupEnv("TREEDB_COLUMN_STORE_RETAINED_PAYLOAD_ENCODING")
+	*columnStoreSuiteRetainedPayloadEncodingArg = encoding
+	_ = os.Unsetenv("TREEDB_COLUMN_STORE_RETAINED_PAYLOAD_ENCODING")
+	t.Cleanup(func() {
+		*columnStoreSuiteRetainedPayloadEncodingArg = prevFlag
+		if envOK {
+			_ = os.Setenv("TREEDB_COLUMN_STORE_RETAINED_PAYLOAD_ENCODING", prevEnv)
+		} else {
+			_ = os.Unsetenv("TREEDB_COLUMN_STORE_RETAINED_PAYLOAD_ENCODING")
+		}
 	})
 }
 


### PR DESCRIPTION
## Summary

Refs #2662, #2353, #2359.

This adds an opt-in retained-payload encoding for column collections:

- `ColumnRetainedPayloadEncodingSemanticStreamV1` for non-column retained payloads.
- Bulk `InsertBatch` stores retained payloads as path/value semantic stream blocks in a dedicated `collection/retained/semantic-stream-v1` root and stores small inline primary locators.
- Reconstruction, scans, and `FetchDocumentsByID` resolve semantic locators through the side root.
- Semantic blocks are published as ordinary collection root values, so value-log rewrite can discover and rewrite their pointers.
- `unified_bench` gets `-column-store-retained-payload-encoding semantic-stream-v1` / `TREEDB_COLUMN_STORE_RETAINED_PAYLOAD_ENCODING=semantic-stream-v1` to run candidate storage evidence without changing defaults.

Defaults remain unchanged: the column-store suite still uses `template-v1` unless the new option is set, and `b_tree_index_baseline` remains full-retained JSON.

## Evidence

Unit/package tests:

```sh
GOWORK=off GOTOOLCHAIN=go1.26.0 GOFLAGS=-mod=mod go test ./TreeDB/collections -run 'TestColumnRetainedPayload(SemanticStreamV1|TemplateV1|ValueLogPlacement)|TestCollectionReadViewFetchDocumentsByID|TestColumnDocumentReconstruction' -count=1
GOWORK=off GOTOOLCHAIN=go1.26.0 GOFLAGS=-mod=mod go test ./cmd/unified_bench -run 'TestColumnStoreSuiteRetainedPayload(EncodingOverride|Accounting|Preserves|Rejects)|TestRunColumnStoreSuiteTypedCompressionSurfaces' -count=1
GOWORK=off GOTOOLCHAIN=go1.26.0 GOFLAGS=-mod=mod go test ./cmd/unified_bench -run 'TestColumnStoreSuite|TestRunColumnStoreSuite|TestColumnStoreJSONBench|TestColumnStoreCodec|TestColumnStoreDirUsage' -count=1
GOWORK=off GOTOOLCHAIN=go1.26.0 GOFLAGS=-mod=mod go test ./TreeDB/collections -count=1
```

All passed locally.

10k synthetic q1 storage smoke, default vs semantic-stream-v1:

```sh
/tmp/unified-bench-2662 -suite column_store -dbs treedb -profile durable -keys 10000 -batchsize 1000 -profile-dir /tmp/jsonbench_2662_default_10k_smoke -path-label native-fastpath -column-store-path serial_column_scan -column-store-query q1 -progress=false
/tmp/unified-bench-2662 -suite column_store -dbs treedb -profile durable -keys 10000 -batchsize 1000 -profile-dir /tmp/jsonbench_2662_semantic_10k_smoke -path-label native-fastpath -column-store-path serial_column_scan -column-store-query q1 -column-store-retained-payload-encoding semantic-stream-v1 -progress=false
```

- default retained payload bytes: `1,076,870`
- semantic retained payload bytes: `596,582`
- default ordinary `value_vlog`: `245,565`
- semantic ordinary `value_vlog`: `102,851`
- q1 parity: pass in both

100k synthetic q1 storage smoke, default vs semantic-stream-v1:

```sh
/tmp/unified-bench-2662 -suite column_store -dbs treedb -profile durable -keys 100000 -batchsize 5000 -profile-dir /tmp/jsonbench_2662_default_100k_smoke -path-label native-fastpath -column-store-path serial_column_scan -column-store-query q1 -progress=false
/tmp/unified-bench-2662 -suite column_store -dbs treedb -profile durable -keys 100000 -batchsize 5000 -profile-dir /tmp/jsonbench_2662_semantic_100k_smoke -path-label native-fastpath -column-store-path serial_column_scan -column-store-query q1 -column-store-retained-payload-encoding semantic-stream-v1 -progress=false
```

- default retained payload bytes: `10,768,750`
- semantic retained payload bytes: `5,966,350`
- default ordinary `value_vlog`: `2,456,060`
- semantic ordinary `value_vlog`: `997,107`
- default WAL-excluded durable bytes: `18,049,982`
- semantic WAL-excluded durable bytes: `16,816,736`
- q1 production hash matched: `10159587062137507725`
- q1 parity: pass in both

## Caveats / follow-up

This is a production storage slice, not the final storage-parity claim. It still needs the external full-data JSONBench current-head gate before #2359 can move the #2353 headline numbers. The side-root format is insert-batch oriented; row delete/update cleanup for fully unreferenced semantic blocks should be handled by a later reference-aware block cleanup pass if we want mutation-heavy GC behavior beyond the insert-only JSONBench shape.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added semantic-stream-v1 retained-payload encoding option for column storage (opt-in).
  * Enhances storage efficiency with value-log-backed locators and dedicated side-root management.
  * Preserves JSON number precision in retained payloads.

* **Tests**
  * Added comprehensive test coverage for semantic-stream-v1 encoding across insert, read, number preservation, side-root rewrite, and reclamation scenarios.

* **Documentation**
  * Updated benchmark documentation with semantic-stream-v1 configuration instructions and byte-accounting details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->