### PR TITLE
TreeDB text v2 default: switch new text indexes to v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,8 @@ Source:
 
 The #2589 optimized context rows use the #2564 fixture on an active Apple M3 laptop:
 `256` JSON documents, scalar indexes on `tenant`/`region`, a `lexical`
-title/body text index, and an exact cosine column graph (`dims=16`, `M=8`). The
+title/body text index (new text indexes default to text-v2; v1 is explicit
+compatibility), and an exact cosine column graph (`dims=16`, `M=8`). The
 insert row times `InsertBatch` + `Flush` + `RebuildVectorIndex`; search rows
 build/index the fixture before timing and then time the search API call only.
 Original #2564 rows remain in the linked runbook for context; treat these as

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -2946,40 +2946,23 @@ func (m *CollectionManager) createCollectionWithCommandWALIntent(normalized Coll
 		if len(rootIDs) != len(plan.rootNames) {
 			return nil, unexpectedOrderedRootCountError(normalized.Name, len(plan.rootNames), len(rootIDs))
 		}
-		current := m.db.AcquireSnapshot()
-		if current == nil {
-			return nil, backenddb.ErrClosed
-		}
-		defer func() { _ = current.Close() }()
-		existing, err := loadCollectionCatalog(current, normalized.Name)
-		if err != nil {
-			return nil, err
-		}
-		if existing != nil {
-			if !sameCollectionMeta(existing.meta, normalized) {
-				return nil, fmt.Errorf("collections: existing schema for %q is incompatible", normalized.Name)
-			}
-			return nil, errCreateCollectionNoopExistingSchema
-		}
 		return buildSystemDeltaIterator(createCollectionSystemUpdates(normalized.Name, encoded, plan.rootNames, rootIDs))
 	}
+	preflight := m.createCollectionExistingSchemaPreflight(normalized)
 	if m.db.CommandWALEnabled() || commandWALIntent != nil {
 		intent, err := m.newCatalogCreateCollectionCommandWALIntent(normalized, commandWALIntent)
 		if err != nil {
 			return nil, err
 		}
 		err = m.withCommandWALPublishCoordinator(func() error {
-			_, _, err = m.db.PublishOrderedRootDeltaGroupWithCommandWALAndSystemDeltaBuilder(ordered, intent, buildSystemDelta)
-			return err
-		})
-		if errors.Is(err, errCreateCollectionNoopExistingSchema) {
-			if intent != nil {
-				if noopErr := m.publishCommandWALNoop(intent, false); noopErr != nil {
-					return nil, noopErr
-				}
+			_, _, publishErr := m.db.PublishOrderedRootDeltaGroupWithPreflightCommandWALContextAndSystemDeltaBuilder(ordered, preflight, intent, func(_ backenddb.CommandWALPublishContext, rootIDs []uint64) (iterator.UnsafeIterator, error) {
+				return buildSystemDelta(rootIDs)
+			})
+			if errors.Is(publishErr, errCreateCollectionNoopExistingSchema) {
+				return m.db.PublishCommandWALNoop(intent, false)
 			}
-			return normalized.copy(), nil
-		}
+			return publishErr
+		})
 		if err != nil {
 			return nil, err
 		}
@@ -3005,7 +2988,7 @@ func (m *CollectionManager) createCollectionWithCommandWALIntent(normalized Coll
 			return buildSystemTargetIterator(current, createCollectionSystemUpdates(normalized.Name, encoded, nil, nil))
 		})
 	} else {
-		_, _, err = m.db.PublishOrderedRootDeltaGroupWithSystemBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+		_, _, err = m.db.PublishOrderedRootDeltaGroupWithPreflightAndSystemDeltaBuilder(ordered, preflight, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
 			if len(rootIDs) != len(plan.rootNames) {
 				return nil, unexpectedOrderedRootCountError(normalized.Name, len(plan.rootNames), len(rootIDs))
 			}
@@ -3014,16 +2997,6 @@ func (m *CollectionManager) createCollectionWithCommandWALIntent(normalized Coll
 				return nil, backenddb.ErrClosed
 			}
 			defer func() { _ = current.Close() }()
-			existing, err := loadCollectionCatalog(current, normalized.Name)
-			if err != nil {
-				return nil, err
-			}
-			if existing != nil {
-				if !sameCollectionMeta(existing.meta, normalized) {
-					return nil, fmt.Errorf("collections: existing schema for %q is incompatible", normalized.Name)
-				}
-				return nil, errCreateCollectionNoopExistingSchema
-			}
 			return buildSystemTargetIterator(current, createCollectionSystemUpdates(normalized.Name, encoded, plan.rootNames, rootIDs))
 		})
 	}
@@ -3034,6 +3007,30 @@ func (m *CollectionManager) createCollectionWithCommandWALIntent(normalized Coll
 		return nil, err
 	}
 	return normalized.copy(), nil
+}
+
+func (m *CollectionManager) createCollectionExistingSchemaPreflight(normalized CollectionMeta) backenddb.OrderedRootGroupPreflight {
+	return func() error {
+		if m == nil || m.db == nil {
+			return errCollectionDBNil
+		}
+		current := m.db.AcquireSnapshot()
+		if current == nil {
+			return backenddb.ErrClosed
+		}
+		defer func() { _ = current.Close() }()
+		existing, err := loadCollectionCatalog(current, normalized.Name)
+		if err != nil {
+			return err
+		}
+		if existing == nil {
+			return nil
+		}
+		if !sameCollectionMeta(existing.meta, normalized) {
+			return fmt.Errorf("collections: existing schema for %q is incompatible", normalized.Name)
+		}
+		return errCreateCollectionNoopExistingSchema
+	}
 }
 
 func (m *CollectionManager) buildCreateCollectionInitialTextV2Plan(meta CollectionMeta) (*createTextIndexBackfillPlan, error) {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -110,6 +110,7 @@ var (
 	errUpdateBatchHasSecondaryUniqueIndex      = errors.New("collections: update batch has secondary unique index")
 	errUpdateBatchChangesSecondaryUniqueIndex  = errors.New("collections: update batch changes secondary unique index")
 	errIndexedFlushLostOwnership               = errors.New("collections: async indexed publish lost ownership of in-flight flush units")
+	errCreateCollectionNoopExistingSchema      = errors.New("collections: create collection no-op existing schema")
 	errUpdateCombinerStopped                   = errors.New("collections: update combiner stopped before DB update completed; callback may have been invoked")
 	indexedAsyncFlushPprofLabels               = pprof.Labels(
 		collectionPprofComponentKey, collectionPprofIndexedAsyncFlush,
@@ -2952,7 +2953,7 @@ func (m *CollectionManager) createCollectionWithCommandWALIntent(normalized Coll
 			if !sameCollectionMeta(existing.meta, normalized) {
 				return nil, fmt.Errorf("collections: existing schema for %q is incompatible", normalized.Name)
 			}
-			return buildSystemDeltaIterator(nil)
+			return nil, errCreateCollectionNoopExistingSchema
 		}
 		return buildSystemDeltaIterator(createCollectionSystemUpdates(normalized.Name, encoded, plan.rootNames, rootIDs))
 	}
@@ -2965,6 +2966,14 @@ func (m *CollectionManager) createCollectionWithCommandWALIntent(normalized Coll
 			_, _, err = m.db.PublishOrderedRootDeltaGroupWithCommandWALAndSystemDeltaBuilder(ordered, intent, buildSystemDelta)
 			return err
 		})
+		if errors.Is(err, errCreateCollectionNoopExistingSchema) {
+			if intent != nil {
+				if noopErr := m.publishCommandWALNoop(intent, false); noopErr != nil {
+					return nil, noopErr
+				}
+			}
+			return normalized.copy(), nil
+		}
 		if err != nil {
 			return nil, err
 		}
@@ -2985,7 +2994,7 @@ func (m *CollectionManager) createCollectionWithCommandWALIntent(normalized Coll
 				if !sameCollectionMeta(existing.meta, normalized) {
 					return nil, fmt.Errorf("collections: existing schema for %q is incompatible", normalized.Name)
 				}
-				return buildSystemTargetIterator(current, nil)
+				return nil, errCreateCollectionNoopExistingSchema
 			}
 			return buildSystemTargetIterator(current, createCollectionSystemUpdates(normalized.Name, encoded, nil, nil))
 		})
@@ -3007,10 +3016,13 @@ func (m *CollectionManager) createCollectionWithCommandWALIntent(normalized Coll
 				if !sameCollectionMeta(existing.meta, normalized) {
 					return nil, fmt.Errorf("collections: existing schema for %q is incompatible", normalized.Name)
 				}
-				return buildSystemTargetIterator(current, nil)
+				return nil, errCreateCollectionNoopExistingSchema
 			}
 			return buildSystemTargetIterator(current, createCollectionSystemUpdates(normalized.Name, encoded, plan.rootNames, rootIDs))
 		})
+	}
+	if errors.Is(err, errCreateCollectionNoopExistingSchema) {
+		return normalized.copy(), nil
 	}
 	if err != nil {
 		return nil, err

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -135,6 +135,15 @@ type testInsertBatchPlanningHook struct {
 	fn func()
 }
 
+var testBeforeCreateCollectionPublishHook struct {
+	installMu sync.Mutex
+	ptr       atomic.Pointer[testCreateCollectionPublishHook]
+}
+
+type testCreateCollectionPublishHook struct {
+	fn func(CollectionMeta)
+}
+
 // CommitAmbiguousError reports that a collection mutation reached its logical
 // commit point before a later visibility, flush, checkpoint, response, or
 // bookkeeping step failed. The operation may already be visible or recoverable;
@@ -2923,6 +2932,9 @@ func (m *CollectionManager) createCollectionWithCommandWALIntent(normalized Coll
 			StoragePolicy: plan.policies[i],
 		})
 	}
+	if hook := testBeforeCreateCollectionPublishHook.ptr.Load(); hook != nil && hook.fn != nil {
+		hook.fn(normalized)
+	}
 	buildSystemDelta := func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
 		if len(rootIDs) != len(plan.rootNames) {
 			return nil, unexpectedOrderedRootCountError(normalized.Name, len(plan.rootNames), len(rootIDs))
@@ -2936,8 +2948,11 @@ func (m *CollectionManager) createCollectionWithCommandWALIntent(normalized Coll
 		if err != nil {
 			return nil, err
 		}
-		if existing != nil && !sameCollectionMeta(existing.meta, normalized) {
-			return nil, fmt.Errorf("collections: existing schema for %q is incompatible", normalized.Name)
+		if existing != nil {
+			if !sameCollectionMeta(existing.meta, normalized) {
+				return nil, fmt.Errorf("collections: existing schema for %q is incompatible", normalized.Name)
+			}
+			return buildSystemDeltaIterator(nil)
 		}
 		return buildSystemDeltaIterator(createCollectionSystemUpdates(normalized.Name, encoded, plan.rootNames, rootIDs))
 	}
@@ -2966,8 +2981,11 @@ func (m *CollectionManager) createCollectionWithCommandWALIntent(normalized Coll
 			if err != nil {
 				return nil, err
 			}
-			if existing != nil && !sameCollectionMeta(existing.meta, normalized) {
-				return nil, fmt.Errorf("collections: existing schema for %q is incompatible", normalized.Name)
+			if existing != nil {
+				if !sameCollectionMeta(existing.meta, normalized) {
+					return nil, fmt.Errorf("collections: existing schema for %q is incompatible", normalized.Name)
+				}
+				return buildSystemTargetIterator(current, nil)
 			}
 			return buildSystemTargetIterator(current, createCollectionSystemUpdates(normalized.Name, encoded, nil, nil))
 		})
@@ -2985,8 +3003,11 @@ func (m *CollectionManager) createCollectionWithCommandWALIntent(normalized Coll
 			if err != nil {
 				return nil, err
 			}
-			if existing != nil && !sameCollectionMeta(existing.meta, normalized) {
-				return nil, fmt.Errorf("collections: existing schema for %q is incompatible", normalized.Name)
+			if existing != nil {
+				if !sameCollectionMeta(existing.meta, normalized) {
+					return nil, fmt.Errorf("collections: existing schema for %q is incompatible", normalized.Name)
+				}
+				return buildSystemTargetIterator(current, nil)
 			}
 			return buildSystemTargetIterator(current, createCollectionSystemUpdates(normalized.Name, encoded, plan.rootNames, rootIDs))
 		})

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -2868,9 +2868,6 @@ func (m *CollectionManager) CreateCollection(meta *CollectionMeta) (*CollectionM
 	if err != nil {
 		return nil, err
 	}
-	if err := rejectCreateCollectionTextV2Indexes(normalized); err != nil {
-		return nil, err
-	}
 	return m.createCollectionWithCommandWALIntent(normalized, nil)
 }
 
@@ -2905,7 +2902,31 @@ func (m *CollectionManager) createCollectionWithCommandWALIntent(normalized Coll
 	if err != nil {
 		return nil, err
 	}
-	buildSystemDelta := func([]uint64) (iterator.UnsafeIterator, error) {
+	plan, err := m.buildCreateCollectionInitialTextV2Plan(normalized)
+	if err != nil {
+		return nil, err
+	}
+	iterators := make([]iterator.UnsafeIterator, 0, len(plan.rootNames))
+	defer func() {
+		for _, it := range iterators {
+			_ = it.Close()
+		}
+		resetCollectionTables(plan.tables)
+	}()
+	ordered := make([]backenddb.OrderedRootDeltaPublishInput, 0, len(plan.rootNames))
+	for i, rootName := range plan.rootNames {
+		iter := plan.tables[i].NewIterator(nil, nil)
+		iterators = append(iterators, iter)
+		ordered = append(ordered, backenddb.OrderedRootDeltaPublishInput{
+			BaseRoot:      plan.baseRootIDs[rootName],
+			Iter:          iter,
+			StoragePolicy: plan.policies[i],
+		})
+	}
+	buildSystemDelta := func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+		if len(rootIDs) != len(plan.rootNames) {
+			return nil, unexpectedOrderedRootCountError(normalized.Name, len(plan.rootNames), len(rootIDs))
+		}
 		current := m.db.AcquireSnapshot()
 		if current == nil {
 			return nil, backenddb.ErrClosed
@@ -2918,13 +2939,7 @@ func (m *CollectionManager) createCollectionWithCommandWALIntent(normalized Coll
 		if existing != nil && !sameCollectionMeta(existing.meta, normalized) {
 			return nil, fmt.Errorf("collections: existing schema for %q is incompatible", normalized.Name)
 		}
-		iter, err := buildSystemDeltaIterator(map[string][]byte{
-			systemCollectionMetaKey(normalized.Name): encoded,
-		})
-		if err != nil {
-			return nil, err
-		}
-		return iter, nil
+		return buildSystemDeltaIterator(createCollectionSystemUpdates(normalized.Name, encoded, plan.rootNames, rootIDs))
 	}
 	if m.db.CommandWALEnabled() || commandWALIntent != nil {
 		intent, err := m.newCatalogCreateCollectionCommandWALIntent(normalized, commandWALIntent)
@@ -2932,7 +2947,7 @@ func (m *CollectionManager) createCollectionWithCommandWALIntent(normalized Coll
 			return nil, err
 		}
 		err = m.withCommandWALPublishCoordinator(func() error {
-			_, _, err = m.db.PublishOrderedRootDeltaGroupWithCommandWALAndSystemDeltaBuilder(nil, intent, buildSystemDelta)
+			_, _, err = m.db.PublishOrderedRootDeltaGroupWithCommandWALAndSystemDeltaBuilder(ordered, intent, buildSystemDelta)
 			return err
 		})
 		if err != nil {
@@ -2940,31 +2955,101 @@ func (m *CollectionManager) createCollectionWithCommandWALIntent(normalized Coll
 		}
 		return normalized.copy(), nil
 	}
-	_, _, err = m.db.PublishOrderedRootGroupWithSystemBuilder(nil, func([]uint64) (iterator.UnsafeIterator, error) {
-		current := m.db.AcquireSnapshot()
-		if current == nil {
-			return nil, backenddb.ErrClosed
-		}
-		defer func() { _ = current.Close() }()
-		existing, err := loadCollectionCatalog(current, normalized.Name)
-		if err != nil {
-			return nil, err
-		}
-		if existing != nil && !sameCollectionMeta(existing.meta, normalized) {
-			return nil, fmt.Errorf("collections: existing schema for %q is incompatible", normalized.Name)
-		}
-		iter, err := buildSystemTargetIterator(current, map[string][]byte{
-			systemCollectionMetaKey(normalized.Name): encoded,
+	if len(ordered) == 0 {
+		_, _, err = m.db.PublishOrderedRootGroupWithSystemBuilder(nil, func([]uint64) (iterator.UnsafeIterator, error) {
+			current := m.db.AcquireSnapshot()
+			if current == nil {
+				return nil, backenddb.ErrClosed
+			}
+			defer func() { _ = current.Close() }()
+			existing, err := loadCollectionCatalog(current, normalized.Name)
+			if err != nil {
+				return nil, err
+			}
+			if existing != nil && !sameCollectionMeta(existing.meta, normalized) {
+				return nil, fmt.Errorf("collections: existing schema for %q is incompatible", normalized.Name)
+			}
+			return buildSystemTargetIterator(current, createCollectionSystemUpdates(normalized.Name, encoded, nil, nil))
 		})
-		if err != nil {
-			return nil, err
-		}
-		return iter, nil
-	})
+	} else {
+		_, _, err = m.db.PublishOrderedRootDeltaGroupWithSystemBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+			if len(rootIDs) != len(plan.rootNames) {
+				return nil, unexpectedOrderedRootCountError(normalized.Name, len(plan.rootNames), len(rootIDs))
+			}
+			current := m.db.AcquireSnapshot()
+			if current == nil {
+				return nil, backenddb.ErrClosed
+			}
+			defer func() { _ = current.Close() }()
+			existing, err := loadCollectionCatalog(current, normalized.Name)
+			if err != nil {
+				return nil, err
+			}
+			if existing != nil && !sameCollectionMeta(existing.meta, normalized) {
+				return nil, fmt.Errorf("collections: existing schema for %q is incompatible", normalized.Name)
+			}
+			return buildSystemTargetIterator(current, createCollectionSystemUpdates(normalized.Name, encoded, plan.rootNames, rootIDs))
+		})
+	}
 	if err != nil {
 		return nil, err
 	}
 	return normalized.copy(), nil
+}
+
+func (m *CollectionManager) buildCreateCollectionInitialTextV2Plan(meta CollectionMeta) (*createTextIndexBackfillPlan, error) {
+	plan := &createTextIndexBackfillPlan{baseRootIDs: make(map[string]uint64)}
+	if len(meta.TextIndexes) == 0 {
+		return plan, nil
+	}
+	hasV2 := false
+	for _, idx := range meta.TextIndexes {
+		if idx.Version == TextIndexVersionV2 {
+			hasV2 = true
+			break
+		}
+	}
+	if !hasV2 {
+		return plan, nil
+	}
+	snap := m.db.AcquireSnapshot()
+	if snap == nil {
+		return nil, backenddb.ErrClosed
+	}
+	defer func() { _ = snap.Close() }()
+	opts, err := collectionPlannerOptionsForDB(m.db, meta)
+	if err != nil {
+		return nil, err
+	}
+	catalog := &collectionCatalog{meta: meta, roots: map[string]uint64{}}
+	for _, idx := range meta.TextIndexes {
+		if idx.Version != TextIndexVersionV2 {
+			continue
+		}
+		idxPlan, err := buildCreateTextV2IndexBackfillPlan(snap, catalog, idx, opts)
+		if err != nil {
+			resetCollectionTables(plan.tables)
+			return nil, err
+		}
+		for rootName, baseRootID := range idxPlan.baseRootIDs {
+			if _, ok := plan.baseRootIDs[rootName]; !ok {
+				plan.baseRootIDs[rootName] = baseRootID
+			}
+		}
+		plan.rootNames = append(plan.rootNames, idxPlan.rootNames...)
+		plan.tables = append(plan.tables, idxPlan.tables...)
+		plan.policies = append(plan.policies, idxPlan.policies...)
+	}
+	return plan, nil
+}
+
+func createCollectionSystemUpdates(collection string, encodedMeta []byte, rootNames []string, rootIDs []uint64) map[string][]byte {
+	updates := make(map[string][]byte, 1+len(rootNames))
+	updates[systemCollectionMetaKey(collection)] = encodedMeta
+	for i, rootName := range rootNames {
+		updates[systemCollectionRootKey(rootName)] = encodeRootID(rootIDs[i])
+	}
+	return updates
 }
 
 func (m *CollectionManager) OpenCollection(name string) (*Collection, error) {
@@ -20549,13 +20634,22 @@ func decodeCollectionMeta(raw []byte) (CollectionMeta, error) {
 	if disk.Version != collectionMetaVersion {
 		return CollectionMeta{}, fmt.Errorf("collections: unsupported collection metadata version %d", disk.Version)
 	}
-	return normalizeCollectionMeta(CollectionMeta{
+	meta := CollectionMeta{
 		Name:          disk.Name,
 		Options:       disk.Options,
 		Indexes:       disk.Indexes,
 		VectorIndexes: disk.VectorIndexes,
 		TextIndexes:   disk.TextIndexes,
-	})
+	}
+	// Metadata written before the text-index version field may omit `version`
+	// while still owning v1 roots. Preserve those existing on-disk indexes as v1;
+	// only new API declarations use the current default (v2).
+	for i := range meta.TextIndexes {
+		if meta.TextIndexes[i].Version == TextIndexVersionDefault {
+			meta.TextIndexes[i].Version = TextIndexVersionV1
+		}
+	}
+	return normalizeCollectionMeta(meta)
 }
 
 func normalizeCollectionMeta(meta CollectionMeta) (CollectionMeta, error) {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -2888,6 +2888,12 @@ func (m *CollectionManager) createCollectionWithCommandWALIntent(normalized Coll
 			return nil, err
 		}
 	}
+	unlockSchema := func() {}
+	if coord := collectionSchemaCoordinatorForDBCollection(m.db, normalized.Name); coord != nil {
+		coord.schemaMu.Lock()
+		unlockSchema = coord.schemaMu.Unlock
+	}
+	defer unlockSchema()
 	snap := m.db.AcquireSnapshot()
 	if snap == nil {
 		return nil, backenddb.ErrClosed

--- a/TreeDB/collections/hybrid_search_executor_test.go
+++ b/TreeDB/collections/hybrid_search_executor_test.go
@@ -492,7 +492,7 @@ func openHybridScalarSearchExecutorFixture2505(tb testing.TB, rows []hybridSearc
 		_ = d.Close()
 		tb.Fatalf("CreateIndex score: %v", err)
 	}
-	if _, _, err := col.CreateTextIndex(TextIndexDefinition{Name: "lexical", Fields: []TextIndexField{{Field: "title", Weight: 3}, {Field: "body"}}, StorePositions: true}); err != nil {
+	if _, _, err := col.CreateTextIndex(TextIndexDefinition{Name: "lexical", Version: TextIndexVersionV1, Fields: []TextIndexField{{Field: "title", Weight: 3}, {Field: "body"}}, StorePositions: true}); err != nil {
 		_ = d.Close()
 		tb.Fatalf("CreateTextIndex: %v", err)
 	}

--- a/TreeDB/collections/index_insert_search_bench_test.go
+++ b/TreeDB/collections/index_insert_search_bench_test.go
@@ -327,7 +327,8 @@ func openIndexInsertSearchInsertedFixture2564(tb testing.TB, docs, dims, m int) 
 func openIndexInsertSearchEmptyFixture2564(tb testing.TB, dir string, docs, dims, m int) indexInsertSearchFixture2564 {
 	tb.Helper()
 	textDef := TextIndexDefinition{
-		Name: hybridCloseoutTextIndexName2506,
+		Name:    hybridCloseoutTextIndexName2506,
+		Version: TextIndexVersionV1,
 		Fields: []TextIndexField{
 			{Field: "title", Weight: 3},
 			{Field: "body"},

--- a/TreeDB/collections/text_catalog.go
+++ b/TreeDB/collections/text_catalog.go
@@ -8,10 +8,11 @@ import (
 )
 
 // CreateTextIndex adds a collection-native text index and backfills persistent
-// roots from the current documents. V1 indexes backfill postings, text-state,
-// and text-stats roots. Explicit v2 indexes backfill document ordinals, docmap,
-// term/stat shells, posting blocks, packed norms, optional positions, and
-// status/format roots for v2 BM25F serving.
+// roots from the current documents. Explicit v1 indexes backfill postings,
+// text-state, and text-stats roots. V2 indexes (the default for new text index
+// declarations) backfill document ordinals, docmap, term/stat shells, posting
+// blocks, packed norms, optional positions, and status/format roots for v2 BM25F
+// serving.
 func (c *Collection) CreateTextIndex(def TextIndexDefinition) (*CollectionMeta, TextIndexBackfillStats, error) {
 	var emptyStats TextIndexBackfillStats
 	if c == nil {

--- a/TreeDB/collections/text_index.go
+++ b/TreeDB/collections/text_index.go
@@ -23,10 +23,11 @@ const (
 	TextAnalyzerSimple TextAnalyzer = "simple"
 )
 
-// TextIndexVersion selects the physical text-index contract. The zero value
-// normalizes to TextIndexVersionV1. TextIndexVersionV2 is an explicit opt-in to
-// the B-tree-native root format; unsupported v2 read/rollout behavior fails
-// closed rather than silently falling back to v1.
+// TextIndexVersion selects the physical text-index contract. For new text
+// index declarations, the zero value normalizes to TextIndexVersionV2. Existing
+// persisted v1 metadata remains v1, and callers that need the legacy root format
+// can still set TextIndexVersionV1 explicitly. Unsupported versions fail closed
+// rather than silently falling back to another format.
 type TextIndexVersion string
 
 const (
@@ -83,10 +84,10 @@ func normalizeTextAnalyzer(analyzer TextAnalyzer) (TextAnalyzer, error) {
 
 func normalizeTextIndexVersion(version TextIndexVersion) (TextIndexVersion, error) {
 	switch version {
-	case TextIndexVersionDefault, TextIndexVersionV1:
-		return TextIndexVersionV1, nil
-	case TextIndexVersionV2:
+	case TextIndexVersionDefault, TextIndexVersionV2:
 		return TextIndexVersionV2, nil
+	case TextIndexVersionV1:
+		return TextIndexVersionV1, nil
 	default:
 		return "", fmt.Errorf("unsupported text index version %q", version)
 	}
@@ -198,15 +199,6 @@ func findTextIndex(indexes []TextIndexDefinition, name string) (TextIndexDefinit
 	return TextIndexDefinition{}, false
 }
 
-func rejectCreateCollectionTextV2Indexes(meta CollectionMeta) error {
-	for _, idx := range meta.TextIndexes {
-		if idx.Version == TextIndexVersionV2 {
-			return fmt.Errorf("%w: CreateCollection with text index version %q requires CreateTextIndex so v2 root descriptors and status records are published atomically", ErrTextIndexUnavailable, idx.Version)
-		}
-	}
-	return nil
-}
-
 func collectionTextIndexRootName(collection, indexName string) string {
 	return collection + "/text-index/" + indexName
 }
@@ -230,7 +222,7 @@ func collectionTextRootNames(collection, indexName string) []string {
 func collectionTextRootNamesForDefinition(collection string, def TextIndexDefinition) []string {
 	version := def.Version
 	if version == TextIndexVersionDefault {
-		version = TextIndexVersionV1
+		version = TextIndexVersionV2
 	}
 	if version == TextIndexVersionV2 {
 		return collectionTextV2RootNames(collection, def.Name)
@@ -340,7 +332,7 @@ func (c *Collection) TextIndexStatus(indexName string) (TextIndexStatus, error) 
 func textIndexStatusForDefinition(collection string, def TextIndexDefinition) TextIndexStatus {
 	version := def.Version
 	if version == TextIndexVersionDefault {
-		version = TextIndexVersionV1
+		version = TextIndexVersionV2
 	}
 	rollout := def.Rollout
 	if rollout == TextIndexRolloutDefault {

--- a/TreeDB/collections/text_index_test.go
+++ b/TreeDB/collections/text_index_test.go
@@ -56,7 +56,8 @@ func TestCollectionTextIndexMetadataValidateAndReopen(t *testing.T) {
 	meta, err := mgr.CreateCollection(&CollectionMeta{
 		Name: "docs",
 		TextIndexes: []TextIndexDefinition{{
-			Name: "lexical",
+			Name:    "lexical",
+			Version: TextIndexVersionV1,
 			Fields: []TextIndexField{
 				{Field: "body"},
 				{Field: "title", Weight: 2.5},
@@ -198,8 +199,9 @@ func TestCollectionTextRootNames(t *testing.T) {
 	meta, err := normalizeCollectionMeta(CollectionMeta{
 		Name: "docs",
 		TextIndexes: []TextIndexDefinition{{
-			Name:   "lexical",
-			Fields: []TextIndexField{{Field: "body"}},
+			Name:    "lexical",
+			Version: TextIndexVersionV1,
+			Fields:  []TextIndexField{{Field: "body"}},
 		}},
 	})
 	if err != nil {
@@ -225,8 +227,9 @@ func TestCollectionTextV2RootNamesAndStatusContract2623(t *testing.T) {
 	meta, err := normalizeCollectionMeta(CollectionMeta{
 		Name: "docs",
 		TextIndexes: []TextIndexDefinition{{
-			Name:   "lexical",
-			Fields: []TextIndexField{{Field: "body"}},
+			Name:    "lexical",
+			Version: TextIndexVersionV1,
+			Fields:  []TextIndexField{{Field: "body"}},
 		}},
 	})
 	if err != nil {
@@ -275,7 +278,7 @@ func TestCollectionTextIndexStatusAPI2623(t *testing.T) {
 	mgr := NewCollectionManager(d)
 	if _, err := mgr.CreateCollection(&CollectionMeta{
 		Name:        "docs",
-		TextIndexes: []TextIndexDefinition{{Name: "lexical", Fields: []TextIndexField{{Field: "body"}}}},
+		TextIndexes: []TextIndexDefinition{{Name: "lexical", Version: TextIndexVersionV1, Fields: []TextIndexField{{Field: "body"}}}},
 	}); err != nil {
 		t.Fatalf("CreateCollection: %v", err)
 	}
@@ -323,8 +326,8 @@ func TestCollectionTextIndexStatusUsesCurrentCatalog2623(t *testing.T) {
 	if err != nil {
 		t.Fatalf("stale handle TextIndexStatus after create: %v", err)
 	}
-	if !status.Ready || status.Name != "lexical" || len(status.ActiveRootNames) != 3 {
-		t.Fatalf("status after create=%+v want current ready index", status)
+	if !status.Ready || status.Name != "lexical" || status.Version != TextIndexVersionV2 || len(status.ActiveRootNames) != len(collectionTextV2RootNames("docs", "lexical")) {
+		t.Fatalf("status after create=%+v want current ready default-v2 index", status)
 	}
 	if _, err := freshCol.DropTextIndex("lexical"); err != nil {
 		t.Fatalf("DropTextIndex: %v", err)
@@ -342,6 +345,7 @@ func TestCollectionTextRootStoragePolicies(t *testing.T) {
 		},
 		TextIndexes: []TextIndexDefinition{{
 			Name:          "lexical",
+			Version:       TextIndexVersionV1,
 			Fields:        []TextIndexField{{Field: "body"}},
 			StoragePolicy: RootStorageCompressed,
 		}},
@@ -436,8 +440,9 @@ func TestCollectionTextIndexedWritesMaintainStorageAndSearchRanks(t *testing.T) 
 	if _, err := mgr.CreateCollection(&CollectionMeta{
 		Name: "docs",
 		TextIndexes: []TextIndexDefinition{{
-			Name:   "lexical",
-			Fields: []TextIndexField{{Field: "body"}},
+			Name:    "lexical",
+			Version: TextIndexVersionV1,
+			Fields:  []TextIndexField{{Field: "body"}},
 		}},
 	}); err != nil {
 		t.Fatalf("create collection: %v", err)

--- a/TreeDB/collections/text_maintenance_test.go
+++ b/TreeDB/collections/text_maintenance_test.go
@@ -177,7 +177,7 @@ func TestTextIndexMaintenanceBufferedCreateFlushCheckpointReopen(t *testing.T) {
 	} else if got != nil {
 		t.Fatalf("expected setup insert to remain buffered before CreateTextIndex, got %q", got)
 	}
-	if _, _, err := creator.CreateTextIndex(TextIndexDefinition{Name: "lexical", Fields: []TextIndexField{{Field: "body"}}, StorePositions: true}); err != nil {
+	if _, _, err := creator.CreateTextIndex(TextIndexDefinition{Name: "lexical", Version: TextIndexVersionV1, Fields: []TextIndexField{{Field: "body"}}, StorePositions: true}); err != nil {
 		t.Fatalf("CreateTextIndex: %v", err)
 	}
 	if _, err := writer.Insert([]byte("after"), []byte(`{"body":"after create durable"}`)); err != nil {
@@ -356,7 +356,7 @@ func createTextMaintenanceBenchCollection(b *testing.B, d *backenddb.DB) *Collec
 	if err != nil {
 		b.Fatalf("OpenCollection: %v", err)
 	}
-	if _, _, err := col.CreateTextIndex(TextIndexDefinition{Name: "lexical", Fields: []TextIndexField{{Field: "title"}, {Field: "body"}}, StorePositions: true}); err != nil {
+	if _, _, err := col.CreateTextIndex(TextIndexDefinition{Name: "lexical", Version: TextIndexVersionV1, Fields: []TextIndexField{{Field: "title"}, {Field: "body"}}, StorePositions: true}); err != nil {
 		b.Fatalf("CreateTextIndex: %v", err)
 	}
 	return col
@@ -372,7 +372,7 @@ func createTextMaintenanceCollection(t *testing.T, d *backenddb.DB) *Collection 
 	if err != nil {
 		t.Fatalf("OpenCollection: %v", err)
 	}
-	if _, _, err := col.CreateTextIndex(TextIndexDefinition{Name: "lexical", Fields: []TextIndexField{{Field: "body"}}, StorePositions: true}); err != nil {
+	if _, _, err := col.CreateTextIndex(TextIndexDefinition{Name: "lexical", Version: TextIndexVersionV1, Fields: []TextIndexField{{Field: "body"}}, StorePositions: true}); err != nil {
 		t.Fatalf("CreateTextIndex: %v", err)
 	}
 	return col

--- a/TreeDB/collections/text_search_m4_test.go
+++ b/TreeDB/collections/text_search_m4_test.go
@@ -279,7 +279,7 @@ func BenchmarkSearchTextM4(b *testing.B) {
 	if err != nil {
 		b.Fatalf("OpenCollection: %v", err)
 	}
-	if _, _, err := col.CreateTextIndex(TextIndexDefinition{Name: "lexical", Fields: []TextIndexField{{Field: "title", Weight: 3}, {Field: "body"}}, StorePositions: true}); err != nil {
+	if _, _, err := col.CreateTextIndex(TextIndexDefinition{Name: "lexical", Version: TextIndexVersionV1, Fields: []TextIndexField{{Field: "title", Weight: 3}, {Field: "body"}}, StorePositions: true}); err != nil {
 		b.Fatalf("CreateTextIndex: %v", err)
 	}
 	ids := make([][]byte, docCount)
@@ -362,7 +362,7 @@ func createTextSearchM4Collection(t *testing.T, d *backenddb.DB, fields []TextIn
 	if err != nil {
 		t.Fatalf("OpenCollection: %v", err)
 	}
-	if _, _, err := col.CreateTextIndex(TextIndexDefinition{Name: "lexical", Fields: fields, StorePositions: true}); err != nil {
+	if _, _, err := col.CreateTextIndex(TextIndexDefinition{Name: "lexical", Version: TextIndexVersionV1, Fields: fields, StorePositions: true}); err != nil {
 		t.Fatalf("CreateTextIndex: %v", err)
 	}
 	return col

--- a/TreeDB/collections/text_storage_test.go
+++ b/TreeDB/collections/text_storage_test.go
@@ -240,6 +240,7 @@ func TestCollectionCreateTextIndexBackfillsReopensAndReportsStorage(t *testing.T
 
 	meta, backfill, err := col.CreateTextIndex(TextIndexDefinition{
 		Name:           "lexical",
+		Version:        TextIndexVersionV1,
 		Fields:         []TextIndexField{{Field: "body"}, {Field: "title", Weight: 2}, {Field: "tags"}},
 		StorePositions: true,
 		StoreOffsets:   true,
@@ -325,7 +326,7 @@ func TestCollectionDropTextIndexClearsMetadataRootsAndWriteGuard(t *testing.T) {
 	if _, err := col.InsertBatch([][]byte{[]byte("d1")}, [][]byte{[]byte(`{"body":"refund policy"}`)}); err != nil {
 		t.Fatalf("InsertBatch: %v", err)
 	}
-	if _, _, err := col.CreateTextIndex(TextIndexDefinition{Name: "lexical", Fields: []TextIndexField{{Field: "body"}}}); err != nil {
+	if _, _, err := col.CreateTextIndex(TextIndexDefinition{Name: "lexical", Version: TextIndexVersionV1, Fields: []TextIndexField{{Field: "body"}}}); err != nil {
 		t.Fatalf("CreateTextIndex: %v", err)
 	}
 	staleMgr := NewCollectionManager(d)
@@ -384,7 +385,7 @@ func TestCreateTextIndexFlushesBufferedWritesFromOtherManagers(t *testing.T) {
 		t.Fatalf("setup write was already published; expected buffered write from separate manager, got %q", got)
 	}
 
-	_, backfill, err := creator.CreateTextIndex(TextIndexDefinition{Name: "lexical", Fields: []TextIndexField{{Field: "body"}}})
+	_, backfill, err := creator.CreateTextIndex(TextIndexDefinition{Name: "lexical", Version: TextIndexVersionV1, Fields: []TextIndexField{{Field: "body"}}})
 	if err != nil {
 		t.Fatalf("CreateTextIndex: %v", err)
 	}
@@ -436,7 +437,7 @@ func TestCreateTextIndexMaintainsWritesFromStaleHandles(t *testing.T) {
 	if _, err := stale.Insert([]byte("d1"), []byte(`{"body":"before text"}`)); err != nil {
 		t.Fatalf("stale setup Insert: %v", err)
 	}
-	if _, _, err := fresh.CreateTextIndex(TextIndexDefinition{Name: "lexical", Fields: []TextIndexField{{Field: "body"}}}); err != nil {
+	if _, _, err := fresh.CreateTextIndex(TextIndexDefinition{Name: "lexical", Version: TextIndexVersionV1, Fields: []TextIndexField{{Field: "body"}}}); err != nil {
 		t.Fatalf("CreateTextIndex: %v", err)
 	}
 	if _, err := stale.Insert([]byte("d2"), []byte(`{"body":"maintained stale handle"}`)); err != nil {
@@ -465,7 +466,7 @@ func TestTextIndexStorageStatsFailsClosedOnMalformedRoot(t *testing.T) {
 	if _, err := col.InsertBatch([][]byte{[]byte("d1")}, [][]byte{[]byte(`{"body":"refund policy"}`)}); err != nil {
 		t.Fatalf("InsertBatch: %v", err)
 	}
-	if _, _, err := col.CreateTextIndex(TextIndexDefinition{Name: "lexical", Fields: []TextIndexField{{Field: "body"}}}); err != nil {
+	if _, _, err := col.CreateTextIndex(TextIndexDefinition{Name: "lexical", Version: TextIndexVersionV1, Fields: []TextIndexField{{Field: "body"}}}); err != nil {
 		t.Fatalf("CreateTextIndex: %v", err)
 	}
 	corruptTextRootValue(t, d, "docs", collectionTextStatsRootName("docs", "lexical"), encodeTextStatsCorpusKey(), []byte{99})
@@ -498,7 +499,7 @@ func BenchmarkCreateTextIndexBackfill(b *testing.B) {
 			b.Fatalf("InsertBatch setup: %v", err)
 		}
 		b.StartTimer()
-		_, stats, err := col.CreateTextIndex(TextIndexDefinition{Name: "lexical", Fields: []TextIndexField{{Field: "title"}, {Field: "body"}}, StorePositions: true})
+		_, stats, err := col.CreateTextIndex(TextIndexDefinition{Name: "lexical", Version: TextIndexVersionV1, Fields: []TextIndexField{{Field: "title"}, {Field: "body"}}, StorePositions: true})
 		b.StopTimer()
 		if err != nil {
 			b.Fatalf("CreateTextIndex: %v", err)

--- a/TreeDB/collections/text_v2_contract_bench_test.go
+++ b/TreeDB/collections/text_v2_contract_bench_test.go
@@ -888,7 +888,8 @@ func createTextV2ContractCollection2623(tb testing.TB, d *backenddb.DB, withText
 
 func textV2ContractIndexDefinition2623() TextIndexDefinition {
 	return TextIndexDefinition{
-		Name: textV2ContractIndexName2623,
+		Name:    textV2ContractIndexName2623,
+		Version: TextIndexVersionV1,
 		Fields: []TextIndexField{
 			{Field: "title", Weight: 3},
 			{Field: "body"},

--- a/TreeDB/collections/text_v2_default_test.go
+++ b/TreeDB/collections/text_v2_default_test.go
@@ -3,7 +3,9 @@ package collections
 import (
 	"bytes"
 	"encoding/json"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
 	"github.com/snissn/gomap/TreeDB/internal/iterator"
@@ -32,6 +34,84 @@ func TestTextIndexDefaultCreateCollectionPublishesV2RootsStatus2690(t *testing.T
 		t.Fatalf("OpenCollection: %v", err)
 	}
 	assertDefaultV2StatusAndEmptyRoots2690(t, d, col, "lexical")
+}
+
+func TestTextIndexDefaultCreateCollectionNoopDoesNotReplaceRacedV2Roots2690(t *testing.T) {
+	d := openTextV2TestDB(t, t.TempDir(), false)
+	defer func() { _ = d.Close() }()
+	meta := &CollectionMeta{
+		Name: "docs",
+		TextIndexes: []TextIndexDefinition{{
+			Name:   "lexical",
+			Fields: []TextIndexField{{Field: "body"}},
+		}},
+	}
+
+	blocked := make(chan struct{})
+	release := make(chan struct{})
+	var blockedOnce atomic.Bool
+	testBeforeCreateCollectionPublishHook.installMu.Lock()
+	testBeforeCreateCollectionPublishHook.ptr.Store(&testCreateCollectionPublishHook{fn: func(got CollectionMeta) {
+		if got.Name != "docs" || !blockedOnce.CompareAndSwap(false, true) {
+			return
+		}
+		close(blocked)
+		<-release
+	}})
+	defer func() {
+		testBeforeCreateCollectionPublishHook.ptr.Store(nil)
+		testBeforeCreateCollectionPublishHook.installMu.Unlock()
+	}()
+
+	firstErr := make(chan error, 1)
+	go func() {
+		_, err := NewCollectionManager(d).CreateCollection(meta)
+		firstErr <- err
+	}()
+	select {
+	case <-blocked:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for first CreateCollection to block before publish")
+	}
+
+	if _, err := NewCollectionManager(d).CreateCollection(meta); err != nil {
+		t.Fatalf("second CreateCollection: %v", err)
+	}
+	col, err := NewCollectionManager(d).OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("OpenCollection after second create: %v", err)
+	}
+	if _, err := col.Insert([]byte("d1"), []byte(`{"body":"refund policy"}`)); err != nil {
+		t.Fatalf("Insert after second create: %v", err)
+	}
+	before, err := col.SearchText(TextSearchOptions{IndexName: "lexical", Query: "refund", TopK: 10, ResultMode: TextSearchResultModeScoreOnly})
+	if err != nil {
+		t.Fatalf("SearchText before releasing first create: %v", err)
+	}
+	assertSearchIDs2690(t, before, []string{"d1"})
+
+	close(release)
+	select {
+	case err := <-firstErr:
+		if err != nil {
+			t.Fatalf("first CreateCollection: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for first CreateCollection to finish")
+	}
+	after, err := col.SearchText(TextSearchOptions{IndexName: "lexical", Query: "refund", TopK: 10, ResultMode: TextSearchResultModeScoreOnly})
+	if err != nil {
+		t.Fatalf("SearchText after raced no-op create: %v", err)
+	}
+	assertSearchIDs2690(t, after, []string{"d1"})
+	assertZeroDocV2SearchStats2690(t, after.Stats)
+	status, err := col.TextIndexStatus("lexical")
+	if err != nil {
+		t.Fatalf("TextIndexStatus after raced no-op create: %v", err)
+	}
+	if status.Version != TextIndexVersionV2 || !slicesEqualStrings(status.ActiveRootNames, collectionTextV2RootNames("docs", "lexical")) {
+		t.Fatalf("status after raced no-op create=%+v want default-v2 roots preserved", status)
+	}
 }
 
 func TestTextIndexDefaultCreateTextIndexBackfillUpdateDeleteReopenSearch2690(t *testing.T) {

--- a/TreeDB/collections/text_v2_default_test.go
+++ b/TreeDB/collections/text_v2_default_test.go
@@ -1,0 +1,317 @@
+package collections
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+	"github.com/snissn/gomap/TreeDB/internal/iterator"
+)
+
+func TestTextIndexDefaultCreateCollectionPublishesV2RootsStatus2690(t *testing.T) {
+	d := openTextV2TestDB(t, t.TempDir(), false)
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	meta, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "docs",
+		TextIndexes: []TextIndexDefinition{{
+			Name:   "lexical",
+			Fields: []TextIndexField{{Field: "body"}, {Field: "title", Weight: 2}},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	if len(meta.TextIndexes) != 1 || meta.TextIndexes[0].Version != TextIndexVersionV2 {
+		t.Fatalf("metadata text indexes=%+v want default v2", meta.TextIndexes)
+	}
+	col, err := mgr.OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("OpenCollection: %v", err)
+	}
+	assertDefaultV2StatusAndEmptyRoots2690(t, d, col, "lexical")
+}
+
+func TestTextIndexDefaultCreateTextIndexBackfillUpdateDeleteReopenSearch2690(t *testing.T) {
+	dir := t.TempDir()
+	d := openTextV2TestDB(t, dir, false)
+	firstClosed := false
+	defer func() {
+		if !firstClosed {
+			_ = d.Close()
+		}
+	}()
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "docs"}); err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	col, err := mgr.OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("OpenCollection: %v", err)
+	}
+	if _, err := col.InsertBatch([][]byte{[]byte("d1"), []byte("d2"), []byte("d3")}, [][]byte{
+		[]byte(`{"title":"Refund","body":"refund policy"}`),
+		[]byte(`{"title":"Refund","body":"refund delayed"}`),
+		[]byte(`{"title":"Policy","body":"refund policy"}`),
+	}); err != nil {
+		t.Fatalf("InsertBatch setup: %v", err)
+	}
+	meta, backfill, err := col.CreateTextIndex(TextIndexDefinition{Name: "lexical", Fields: []TextIndexField{{Field: "title", Weight: 3}, {Field: "body"}}, StorePositions: true})
+	if err != nil {
+		t.Fatalf("CreateTextIndex default v2: %v", err)
+	}
+	if len(meta.TextIndexes) != 1 || meta.TextIndexes[0].Version != TextIndexVersionV2 {
+		t.Fatalf("metadata text indexes=%+v want default v2", meta.TextIndexes)
+	}
+	if backfill.DocumentsScanned != 3 || backfill.V2DocIDEntries != 3 || backfill.V2StatusRecords != 1 || backfill.V2FormatRecords != len(collectionTextV2RootNames("docs", "lexical")) || backfill.StateEntries != 0 || backfill.PostingEntries != 0 {
+		t.Fatalf("backfill stats=%+v want v2 backfill roots/status and no v1 entries", backfill)
+	}
+
+	before, err := col.SearchText(TextSearchOptions{IndexName: "lexical", Query: "refund", TopK: 10, ResultMode: TextSearchResultModeScoreOnly})
+	if err != nil {
+		t.Fatalf("SearchText before mutations: %v", err)
+	}
+	assertSearchIDs2690(t, before, []string{"d1", "d2", "d3"})
+	assertZeroDocV2SearchStats2690(t, before.Stats)
+
+	matched, modified, err := col.Update([]byte("d1"), func(current []byte) ([]byte, bool, error) {
+		return []byte(`{"title":"Shipping","body":"shipping only"}`), true, nil
+	})
+	if err != nil || !matched || !modified {
+		t.Fatalf("Update d1 matched=%v modified=%v err=%v", matched, modified, err)
+	}
+	deleted, err := col.DeleteDocument([]byte("d2"))
+	if err != nil || !deleted {
+		t.Fatalf("DeleteDocument d2 deleted=%v err=%v", deleted, err)
+	}
+	after, err := col.SearchText(TextSearchOptions{IndexName: "lexical", Query: "refund", TopK: 10, ResultMode: TextSearchResultModeScoreOnly})
+	if err != nil {
+		t.Fatalf("SearchText after mutations: %v", err)
+	}
+	assertSearchIDs2690(t, after, []string{"d3"})
+	assertZeroDocV2SearchStats2690(t, after.Stats)
+
+	if err := d.Checkpoint(); err != nil {
+		t.Fatalf("Checkpoint: %v", err)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	firstClosed = true
+	reopened := openTextV2TestDB(t, dir, false)
+	defer func() { _ = reopened.Close() }()
+	reopenedCol, err := NewCollectionManager(reopened).OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("OpenCollection reopened: %v", err)
+	}
+	reopenedStatus, err := reopenedCol.TextIndexStatus("lexical")
+	if err != nil {
+		t.Fatalf("TextIndexStatus reopened: %v", err)
+	}
+	if reopenedStatus.Version != TextIndexVersionV2 || !reopenedStatus.Ready || !reopenedStatus.Readable || !reopenedStatus.Writable {
+		t.Fatalf("reopened status=%+v want ready default v2", reopenedStatus)
+	}
+	reopenedSearch, err := reopenedCol.SearchText(TextSearchOptions{IndexName: "lexical", Query: "refund", TopK: 10, ResultMode: TextSearchResultModeScoreOnly})
+	if err != nil {
+		t.Fatalf("SearchText reopened: %v", err)
+	}
+	assertSearchIDs2690(t, reopenedSearch, []string{"d3"})
+	assertZeroDocV2SearchStats2690(t, reopenedSearch.Stats)
+}
+
+func TestTextIndexExplicitV1AndDefaultV2Coexist2690(t *testing.T) {
+	d := openTextV2TestDB(t, t.TempDir(), false)
+	defer func() { _ = d.Close() }()
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "docs"}); err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	col, err := mgr.OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("OpenCollection: %v", err)
+	}
+	if _, err := col.InsertBatch([][]byte{[]byte("d1"), []byte("d2")}, [][]byte{[]byte(`{"body":"refund policy"}`), []byte(`{"body":"shipping policy"}`)}); err != nil {
+		t.Fatalf("InsertBatch: %v", err)
+	}
+	if _, _, err := col.CreateTextIndex(TextIndexDefinition{Name: "legacy", Version: TextIndexVersionV1, Fields: []TextIndexField{{Field: "body"}}, StorePositions: true}); err != nil {
+		t.Fatalf("CreateTextIndex explicit v1: %v", err)
+	}
+	if _, _, err := col.CreateTextIndex(TextIndexDefinition{Name: "lexical", Fields: []TextIndexField{{Field: "body"}}, StorePositions: true}); err != nil {
+		t.Fatalf("CreateTextIndex default v2: %v", err)
+	}
+	legacyStatus, err := col.TextIndexStatus("legacy")
+	if err != nil {
+		t.Fatalf("TextIndexStatus legacy: %v", err)
+	}
+	defaultStatus, err := col.TextIndexStatus("lexical")
+	if err != nil {
+		t.Fatalf("TextIndexStatus lexical: %v", err)
+	}
+	if legacyStatus.Version != TextIndexVersionV1 || !slicesEqualStrings(legacyStatus.ActiveRootNames, collectionTextRootNames("docs", "legacy")) {
+		t.Fatalf("legacy status=%+v want explicit v1 roots", legacyStatus)
+	}
+	if defaultStatus.Version != TextIndexVersionV2 || !slicesEqualStrings(defaultStatus.ActiveRootNames, collectionTextV2RootNames("docs", "lexical")) {
+		t.Fatalf("default status=%+v want default v2 roots", defaultStatus)
+	}
+	legacySearch, err := col.SearchText(TextSearchOptions{IndexName: "legacy", Query: "refund", TopK: 10, ResultMode: TextSearchResultModeScoreOnly})
+	if err != nil {
+		t.Fatalf("SearchText legacy: %v", err)
+	}
+	defaultSearch, err := col.SearchText(TextSearchOptions{IndexName: "lexical", Query: "refund", TopK: 10, ResultMode: TextSearchResultModeScoreOnly})
+	if err != nil {
+		t.Fatalf("SearchText default v2: %v", err)
+	}
+	assertSearchIDs2690(t, legacySearch, []string{"d1"})
+	assertSearchIDs2690(t, defaultSearch, []string{"d1"})
+	if defaultSearch.Stats.TextStateLookups != 0 || defaultSearch.Stats.DocumentsFetched != 0 || defaultSearch.Stats.FullDocumentScanFallbacks != 0 {
+		t.Fatalf("default v2 stats=%+v want no v1 state/doc fallback", defaultSearch.Stats)
+	}
+}
+
+func TestHybridTextCandidatesDefaultV2ZeroDocumentWork2690(t *testing.T) {
+	d := openTextV2TestDB(t, t.TempDir(), false)
+	defer func() { _ = d.Close() }()
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "docs"}); err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	col, err := mgr.OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("OpenCollection: %v", err)
+	}
+	if _, _, err := col.CreateTextIndex(TextIndexDefinition{Name: "lexical", Fields: []TextIndexField{{Field: "title", Weight: 3}, {Field: "body"}}, StorePositions: true}); err != nil {
+		t.Fatalf("CreateTextIndex default v2: %v", err)
+	}
+	if _, err := col.InsertBatch([][]byte{[]byte("d1"), []byte("d2"), []byte("d3")}, [][]byte{
+		[]byte(`{"title":"refund","body":"refund policy"}`),
+		[]byte(`{"title":"plain","body":"refund policy"}`),
+		[]byte(`{"title":"shipping","body":"policy"}`),
+	}); err != nil {
+		t.Fatalf("InsertBatch: %v", err)
+	}
+	status, err := col.TextIndexStatus("lexical")
+	if err != nil {
+		t.Fatalf("TextIndexStatus: %v", err)
+	}
+	if status.Version != TextIndexVersionV2 {
+		t.Fatalf("status=%+v want default v2", status)
+	}
+	got, err := col.SearchHybridTextCandidates(HybridTextQuery{IndexName: "lexical", Query: "refund", CandidateLimit: 2})
+	if err != nil {
+		t.Fatalf("SearchHybridTextCandidates: %v", err)
+	}
+	if len(got.Candidates) != 2 || string(got.Candidates[0].ID) != "d1" {
+		t.Fatalf("candidates=%+v want two ranked v2 text candidates headed by d1", got.Candidates)
+	}
+	if got.Stats.DocumentsFetched != 0 || got.Stats.FullDocumentScanFallbacks != 0 || got.Stats.TextStateLookups != 0 || got.Stats.TextMatchDetailsBuilt != 0 || got.Stats.FailClosed != 0 {
+		t.Fatalf("hybrid stats=%+v want default v2 score-only zero-doc candidate generation", got.Stats)
+	}
+}
+
+func TestLegacyDiskTextIndexMissingVersionDecodesAsV12690(t *testing.T) {
+	dir := t.TempDir()
+	d := openTextV2TestDB(t, dir, false)
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "docs"}); err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	col, err := mgr.OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("OpenCollection: %v", err)
+	}
+	if _, err := col.Insert([]byte("d1"), []byte(`{"body":"refund policy"}`)); err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+	if _, _, err := col.CreateTextIndex(TextIndexDefinition{Name: "legacy", Version: TextIndexVersionV1, Fields: []TextIndexField{{Field: "body"}}, StorePositions: true}); err != nil {
+		t.Fatalf("CreateTextIndex explicit v1: %v", err)
+	}
+	legacyMeta := col.Meta()
+	legacyMeta.TextIndexes[0].Version = TextIndexVersionDefault
+	legacyMeta.TextIndexes[0].Rollout = TextIndexRolloutDefault
+	raw, err := json.Marshal(collectionMetaDisk{
+		Version:       collectionMetaVersion,
+		Name:          legacyMeta.Name,
+		Options:       legacyMeta.Options,
+		Indexes:       legacyMeta.Indexes,
+		VectorIndexes: legacyMeta.VectorIndexes,
+		TextIndexes:   legacyMeta.TextIndexes,
+	})
+	if err != nil {
+		t.Fatalf("marshal legacy metadata: %v", err)
+	}
+	if _, _, err := d.PublishOrderedRootGroupWithSystemBuilder(nil, func([]uint64) (iterator.UnsafeIterator, error) {
+		snap := d.AcquireSnapshot()
+		if snap == nil {
+			return nil, backenddb.ErrClosed
+		}
+		defer func() { _ = snap.Close() }()
+		return buildSystemTargetIterator(snap, map[string][]byte{systemCollectionMetaKey("docs"): raw})
+	}); err != nil {
+		t.Fatalf("publish legacy metadata: %v", err)
+	}
+	if err := d.Checkpoint(); err != nil {
+		t.Fatalf("Checkpoint: %v", err)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	reopened := openTextV2TestDB(t, dir, false)
+	defer func() { _ = reopened.Close() }()
+	reopenedCol, err := NewCollectionManager(reopened).OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("OpenCollection reopened: %v", err)
+	}
+	reopenedMeta := reopenedCol.Meta()
+	if len(reopenedMeta.TextIndexes) != 1 || reopenedMeta.TextIndexes[0].Version != TextIndexVersionV1 {
+		t.Fatalf("reopened metadata=%+v want missing disk version preserved as v1", reopenedMeta.TextIndexes)
+	}
+	got, err := reopenedCol.SearchText(TextSearchOptions{IndexName: "legacy", Query: "refund", TopK: 10, ResultMode: TextSearchResultModeScoreOnly})
+	if err != nil {
+		t.Fatalf("SearchText reopened legacy v1: %v", err)
+	}
+	assertSearchIDs2690(t, got, []string{"d1"})
+}
+
+func assertDefaultV2StatusAndEmptyRoots2690(t *testing.T, d *backenddb.DB, col *Collection, indexName string) {
+	t.Helper()
+	status, err := col.TextIndexStatus(indexName)
+	if err != nil {
+		t.Fatalf("TextIndexStatus: %v", err)
+	}
+	if status.Version != TextIndexVersionV2 || !status.Ready || !status.Readable || !status.Writable || status.FailClosed || !slicesEqualStrings(status.ActiveRootNames, collectionTextV2RootNames("docs", indexName)) {
+		t.Fatalf("status=%+v want ready default v2", status)
+	}
+	stats, err := col.TextIndexStorageStats(indexName)
+	if err != nil {
+		t.Fatalf("TextIndexStorageStats: %v", err)
+	}
+	if stats.Version != TextIndexVersionV2 || stats.V2FormatRecords != uint64(len(collectionTextV2RootNames("docs", indexName))) || stats.V2StatusRecords != 1 || stats.V2NextOrdinal != 1 || stats.V2LiveDocuments != 0 || stats.V2DocIDEntries != 0 || stats.V2PostingBlocks != 0 {
+		t.Fatalf("storage stats=%+v want empty v2 roots/status", stats)
+	}
+	for _, rootName := range collectionTextV2RootNames("docs", indexName) {
+		if rootID := requireCollectionRootDescriptor2624(t, d, rootName); rootID == 0 {
+			t.Fatalf("root %q descriptor is zero", rootName)
+		}
+	}
+}
+
+func assertSearchIDs2690(t *testing.T, got TextSearchResponse, want []string) {
+	t.Helper()
+	if len(got.Results) != len(want) {
+		t.Fatalf("results=%+v want ids %q", got.Results, want)
+	}
+	for i := range want {
+		if !bytes.Equal(got.Results[i].DocumentID, []byte(want[i])) {
+			t.Fatalf("result[%d]=%+v want id %q; all results=%+v", i, got.Results[i], want[i], got.Results)
+		}
+	}
+}
+
+func assertZeroDocV2SearchStats2690(t *testing.T, stats TextSearchStats) {
+	t.Helper()
+	if stats.DocumentsFetched != 0 || stats.FullDocumentScanFallbacks != 0 || stats.TextStateLookups != 0 || stats.TextMatchDetailsBuilt != 0 || stats.FailClosed != 0 {
+		t.Fatalf("stats=%+v want v2 score-only search with zero docs/state/details/fail-closed", stats)
+	}
+}

--- a/TreeDB/collections/text_v2_default_test.go
+++ b/TreeDB/collections/text_v2_default_test.go
@@ -3,6 +3,7 @@ package collections
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -137,6 +138,70 @@ func TestTextIndexDefaultCreateCollectionNoopDoesNotReplaceRacedV2Roots2690(t *t
 	if status.Version != TextIndexVersionV2 || !slicesEqualStrings(status.ActiveRootNames, collectionTextV2RootNames("docs", "lexical")) {
 		t.Fatalf("status after raced no-op create=%+v want default-v2 roots preserved", status)
 	}
+}
+
+func TestTextIndexDefaultCreateCollectionPreflightSkipsStaleV2Plan2690(t *testing.T) {
+	d := openTextV2TestDB(t, t.TempDir(), false)
+	defer func() { _ = d.Close() }()
+	mgr := NewCollectionManager(d)
+	meta := CollectionMeta{
+		Name: "docs",
+		TextIndexes: []TextIndexDefinition{{
+			Name:   "lexical",
+			Fields: []TextIndexField{{Field: "body"}},
+		}},
+	}
+	normalized, err := mgr.CreateCollection(&meta)
+	if err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	col, err := mgr.OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("OpenCollection: %v", err)
+	}
+	if _, err := col.Insert([]byte("d1"), []byte(`{"body":"refund policy"}`)); err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+	stateBefore := d.State()
+	if stateBefore == nil {
+		t.Fatal("db state before stale preflight publish is nil")
+	}
+
+	plan, err := mgr.buildCreateCollectionInitialTextV2Plan(*normalized)
+	if err != nil {
+		t.Fatalf("buildCreateCollectionInitialTextV2Plan: %v", err)
+	}
+	defer resetCollectionTables(plan.tables)
+	if len(plan.rootNames) == 0 {
+		t.Fatal("stale default-v2 create plan has no roots")
+	}
+	ordered := make([]backenddb.OrderedRootDeltaPublishInput, 0, len(plan.rootNames))
+	for i, rootName := range plan.rootNames {
+		ordered = append(ordered, backenddb.OrderedRootDeltaPublishInput{
+			BaseRoot:      plan.baseRootIDs[rootName],
+			Iter:          plan.tables[i].NewIterator(nil, nil),
+			StoragePolicy: plan.policies[i],
+		})
+	}
+	_, _, err = d.PublishOrderedRootDeltaGroupWithPreflightAndSystemDeltaBuilder(ordered, mgr.createCollectionExistingSchemaPreflight(*normalized), func([]uint64) (iterator.UnsafeIterator, error) {
+		t.Fatal("system builder called after no-op create preflight")
+		return nil, nil
+	})
+	if !errors.Is(err, errCreateCollectionNoopExistingSchema) {
+		t.Fatalf("stale preflight publish err=%v want errCreateCollectionNoopExistingSchema", err)
+	}
+	stateAfter := d.State()
+	if stateAfter == nil {
+		t.Fatal("db state after stale preflight publish is nil")
+	}
+	if stateAfter.CommitSeq != stateBefore.CommitSeq {
+		t.Fatalf("stale preflight publish advanced commit seq from %d to %d; want no root apply/finalize", stateBefore.CommitSeq, stateAfter.CommitSeq)
+	}
+	got, err := col.SearchText(TextSearchOptions{IndexName: "lexical", Query: "refund", TopK: 10, ResultMode: TextSearchResultModeScoreOnly})
+	if err != nil {
+		t.Fatalf("SearchText after stale preflight publish: %v", err)
+	}
+	assertSearchIDs2690(t, got, []string{"d1"})
 }
 
 func TestTextIndexDefaultCreateTextIndexBackfillUpdateDeleteReopenSearch2690(t *testing.T) {

--- a/TreeDB/collections/text_v2_default_test.go
+++ b/TreeDB/collections/text_v2_default_test.go
@@ -89,6 +89,11 @@ func TestTextIndexDefaultCreateCollectionNoopDoesNotReplaceRacedV2Roots2690(t *t
 		t.Fatalf("SearchText before releasing first create: %v", err)
 	}
 	assertSearchIDs2690(t, before, []string{"d1"})
+	stateBeforeRelease := d.State()
+	if stateBeforeRelease == nil {
+		t.Fatal("db state before releasing first create is nil")
+	}
+	commitSeqBeforeRelease := stateBeforeRelease.CommitSeq
 
 	close(release)
 	select {
@@ -105,6 +110,13 @@ func TestTextIndexDefaultCreateCollectionNoopDoesNotReplaceRacedV2Roots2690(t *t
 	}
 	assertSearchIDs2690(t, after, []string{"d1"})
 	assertZeroDocV2SearchStats2690(t, after.Stats)
+	stateAfterRelease := d.State()
+	if stateAfterRelease == nil {
+		t.Fatal("db state after releasing first create is nil")
+	}
+	if stateAfterRelease.CommitSeq != commitSeqBeforeRelease {
+		t.Fatalf("raced no-op CreateCollection advanced commit seq from %d to %d; want no orphan root publish", commitSeqBeforeRelease, stateAfterRelease.CommitSeq)
+	}
 	status, err := col.TextIndexStatus("lexical")
 	if err != nil {
 		t.Fatalf("TextIndexStatus after raced no-op create: %v", err)

--- a/TreeDB/collections/text_v2_default_test.go
+++ b/TreeDB/collections/text_v2_default_test.go
@@ -74,26 +74,16 @@ func TestTextIndexDefaultCreateCollectionNoopDoesNotReplaceRacedV2Roots2690(t *t
 		t.Fatal("timed out waiting for first CreateCollection to block before publish")
 	}
 
-	if _, err := NewCollectionManager(d).CreateCollection(meta); err != nil {
-		t.Fatalf("second CreateCollection: %v", err)
+	secondErr := make(chan error, 1)
+	go func() {
+		_, err := NewCollectionManager(d).CreateCollection(meta)
+		secondErr <- err
+	}()
+	select {
+	case err := <-secondErr:
+		t.Fatalf("second CreateCollection completed before first publish err=%v; want schema serialization", err)
+	case <-time.After(50 * time.Millisecond):
 	}
-	col, err := NewCollectionManager(d).OpenCollection("docs")
-	if err != nil {
-		t.Fatalf("OpenCollection after second create: %v", err)
-	}
-	if _, err := col.Insert([]byte("d1"), []byte(`{"body":"refund policy"}`)); err != nil {
-		t.Fatalf("Insert after second create: %v", err)
-	}
-	before, err := col.SearchText(TextSearchOptions{IndexName: "lexical", Query: "refund", TopK: 10, ResultMode: TextSearchResultModeScoreOnly})
-	if err != nil {
-		t.Fatalf("SearchText before releasing first create: %v", err)
-	}
-	assertSearchIDs2690(t, before, []string{"d1"})
-	stateBeforeRelease := d.State()
-	if stateBeforeRelease == nil {
-		t.Fatal("db state before releasing first create is nil")
-	}
-	commitSeqBeforeRelease := stateBeforeRelease.CommitSeq
 
 	close(release)
 	select {
@@ -104,19 +94,42 @@ func TestTextIndexDefaultCreateCollectionNoopDoesNotReplaceRacedV2Roots2690(t *t
 	case <-time.After(5 * time.Second):
 		t.Fatal("timed out waiting for first CreateCollection to finish")
 	}
+	select {
+	case err := <-secondErr:
+		if err != nil {
+			t.Fatalf("second CreateCollection: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for second CreateCollection to finish")
+	}
+
+	col, err := NewCollectionManager(d).OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("OpenCollection after raced creates: %v", err)
+	}
+	stateBeforeIdempotent := d.State()
+	if stateBeforeIdempotent == nil {
+		t.Fatal("db state before idempotent create is nil")
+	}
+	if _, err := NewCollectionManager(d).CreateCollection(meta); err != nil {
+		t.Fatalf("idempotent CreateCollection after raced creates: %v", err)
+	}
+	stateAfterIdempotent := d.State()
+	if stateAfterIdempotent == nil {
+		t.Fatal("db state after idempotent create is nil")
+	}
+	if stateAfterIdempotent.CommitSeq != stateBeforeIdempotent.CommitSeq {
+		t.Fatalf("idempotent CreateCollection advanced commit seq from %d to %d; want no orphan root publish", stateBeforeIdempotent.CommitSeq, stateAfterIdempotent.CommitSeq)
+	}
+	if _, err := col.Insert([]byte("d1"), []byte(`{"body":"refund policy"}`)); err != nil {
+		t.Fatalf("Insert after raced creates: %v", err)
+	}
 	after, err := col.SearchText(TextSearchOptions{IndexName: "lexical", Query: "refund", TopK: 10, ResultMode: TextSearchResultModeScoreOnly})
 	if err != nil {
 		t.Fatalf("SearchText after raced no-op create: %v", err)
 	}
 	assertSearchIDs2690(t, after, []string{"d1"})
 	assertZeroDocV2SearchStats2690(t, after.Stats)
-	stateAfterRelease := d.State()
-	if stateAfterRelease == nil {
-		t.Fatal("db state after releasing first create is nil")
-	}
-	if stateAfterRelease.CommitSeq != commitSeqBeforeRelease {
-		t.Fatalf("raced no-op CreateCollection advanced commit seq from %d to %d; want no orphan root publish", commitSeqBeforeRelease, stateAfterRelease.CommitSeq)
-	}
 	status, err := col.TextIndexStatus("lexical")
 	if err != nil {
 		t.Fatalf("TextIndexStatus after raced no-op create: %v", err)

--- a/TreeDB/collections/text_v2_rewrite_test.go
+++ b/TreeDB/collections/text_v2_rewrite_test.go
@@ -414,8 +414,8 @@ func TestTextV2CoexistenceAndDefaultSelection2630(t *testing.T) {
 	if _, err := col.InsertBatch([][]byte{[]byte("d1"), []byte("d2")}, [][]byte{[]byte(`{"body":"refund policy"}`), []byte(`{"body":"shipping policy"}`)}); err != nil {
 		t.Fatalf("InsertBatch: %v", err)
 	}
-	if _, _, err := col.CreateTextIndex(TextIndexDefinition{Name: "lexical_v1", Fields: []TextIndexField{{Field: "body"}}}); err != nil {
-		t.Fatalf("CreateTextIndex v1 default: %v", err)
+	if _, _, err := col.CreateTextIndex(TextIndexDefinition{Name: "lexical_v1", Version: TextIndexVersionV1, Fields: []TextIndexField{{Field: "body"}}}); err != nil {
+		t.Fatalf("CreateTextIndex explicit v1: %v", err)
 	}
 	if _, _, err := col.CreateTextIndex(TextIndexDefinition{Name: "lexical_v2", Version: TextIndexVersionV2, Fields: []TextIndexField{{Field: "body"}}}); err != nil {
 		t.Fatalf("CreateTextIndex explicit v2: %v", err)
@@ -429,7 +429,7 @@ func TestTextV2CoexistenceAndDefaultSelection2630(t *testing.T) {
 		t.Fatalf("TextIndexStatus v2: %v", err)
 	}
 	if v1Status.Version != TextIndexVersionV1 || !v1Status.Ready || !slicesEqualStrings(v1Status.ActiveRootNames, collectionTextRootNames("docs", "lexical_v1")) {
-		t.Fatalf("v1 status=%+v want default v1 roots", v1Status)
+		t.Fatalf("v1 status=%+v want explicit v1 roots", v1Status)
 	}
 	if v2Status.Version != TextIndexVersionV2 || !v2Status.Ready || v2Status.RewriteMergeState != TextIndexRewriteMergeStateReady || !slicesEqualStrings(v2Status.ActiveRootNames, collectionTextV2RootNames("docs", "lexical_v2")) {
 		t.Fatalf("v2 status=%+v want explicit v2 roots", v2Status)

--- a/TreeDB/collections/text_v2_storage_test.go
+++ b/TreeDB/collections/text_v2_storage_test.go
@@ -145,10 +145,11 @@ func TestTextV2StorageCodecsRoundTripAndFailClosed2624(t *testing.T) {
 	}
 }
 
-func TestCreateCollectionRejectsInlineTextV2MetadataWithoutRootState2624(t *testing.T) {
+func TestCreateCollectionInlineTextV2PublishesRootState2624(t *testing.T) {
 	d := openTextV2TestDB(t, t.TempDir(), false)
 	defer func() { _ = d.Close() }()
-	_, err := NewCollectionManager(d).CreateCollection(&CollectionMeta{
+	mgr := NewCollectionManager(d)
+	meta, err := mgr.CreateCollection(&CollectionMeta{
 		Name: "docs",
 		TextIndexes: []TextIndexDefinition{{
 			Name:    "lexical",
@@ -156,9 +157,17 @@ func TestCreateCollectionRejectsInlineTextV2MetadataWithoutRootState2624(t *test
 			Fields:  []TextIndexField{{Field: "body"}},
 		}},
 	})
-	if !errors.Is(err, ErrTextIndexUnavailable) {
-		t.Fatalf("CreateCollection v2 metadata err=%v want ErrTextIndexUnavailable", err)
+	if err != nil {
+		t.Fatalf("CreateCollection v2 metadata: %v", err)
 	}
+	if len(meta.TextIndexes) != 1 || meta.TextIndexes[0].Version != TextIndexVersionV2 {
+		t.Fatalf("metadata text indexes=%+v want v2", meta.TextIndexes)
+	}
+	col, err := mgr.OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("OpenCollection: %v", err)
+	}
+	assertDefaultV2StatusAndEmptyRoots2690(t, d, col, "lexical")
 }
 
 func TestCollectionCreateTextV2IndexBackfillsOrdinalsNormsStatsAndReopens2624(t *testing.T) {

--- a/TreeDB/docs/guides/hybrid-search.md
+++ b/TreeDB/docs/guides/hybrid-search.md
@@ -25,10 +25,7 @@ vector typed-column placement is covered by
 | Vector-only (`SearchVectorIndex` / `SearchHybrid` with only `Vector`) | Semantic nearest-neighbor recall is the main signal. | Keep vector route choices (`exact`, `quantized_only`, `quantized_rerank`) and their recall/storage caveats separate from hybrid claims. |
 | Hybrid (`SearchHybrid` with `Text` + `Vector`) | You need both lexical precision and semantic candidates, usually with a metadata/scalar filter and final materialized documents. | Default fusion is rank-based RRF, not learned relevance. Caller/future layers own reranking/cross-encoder/LLM scoring. |
 
-Hybrid candidate generation must not fetch full documents. Text candidates are
-score-only by default; set `HybridTextQuery.IncludeTextMatches=true` only when a
-bounded compact field/term summary is needed. Documents are fetched only after
-fusion/filtering and are bounded by final `TopK` when `IncludeDocuments` is true.
+Hybrid candidate generation must not fetch full documents. Newly-created text indexes use text-v2 by default; set `TextIndexDefinition.Version: TextIndexVersionV1` only for the legacy compatibility path. Text candidates are score-only by default; set `HybridTextQuery.IncludeTextMatches=true` only when a bounded compact field/term summary is needed. Documents are fetched only after fusion/filtering and are bounded by final `TopK` when `IncludeDocuments` is true.
 
 ## Index creation sketch
 

--- a/TreeDB/docs/spec/collection-text-search.md
+++ b/TreeDB/docs/spec/collection-text-search.md
@@ -19,17 +19,16 @@ matrix are defined in `TreeDB/docs/spec/collection-text-v2-contract.md`.
     uses `CollectionOptions.IndexStateStoragePolicy`.
 - `simple` analyzer: Unicode lowercase tokenization over letters, digits, and
   `_` so code-ish identifiers such as `HTTP_500` remain searchable.
-- `CreateTextIndex` backfills persistent v1 postings/text-state/text-stats roots
-  or explicit v2 doc ordinal/docmap/term-stat/norm/status roots over existing
-  documents and publishes roots plus metadata atomically.
+- `CreateTextIndex` backfills persistent v2 doc ordinal/docmap/term-stat/norm/status roots by default, or v1 postings/text-state/text-stats roots when callers explicitly set `TextIndexVersionV1`; roots plus metadata are published atomically.
+- `CreateCollection` with text indexes now bootstraps empty default-v2 root descriptors, format records, and status records in the same catalog publish. Explicit v1 collection text indexes remain metadata-compatible and create/maintain v1 roots on writes.
 - `DropTextIndex` removes metadata and clears all v1 and v2 text root
   descriptors for that index, including v1 postings/text-state/text-stats roots
-  and explicit v2 doc ordinal/docmap/term-stat/norm/status roots.
+  and v2 doc ordinal/docmap/term-stat/norm/status roots.
 - `TextIndexStorageStats` validates storage versions and returns root accounting.
-- Insert, delete, update, and batch write paths maintain v1 postings/text-state
-  and stats for v1 text indexes. For explicit v2 indexes, current milestones
-  maintain ordinals/generations, tombstones, docmap/norm blocks, stats metadata,
-  compressed scoring posting blocks, and optional lazy position/detail payloads.
+- Insert, delete, update, and batch write paths maintain ordinals/generations,
+  tombstones, docmap/norm blocks, stats metadata, compressed scoring posting
+  blocks, and optional lazy position/detail payloads for default-v2 text indexes.
+  Explicit v1 indexes continue to maintain v1 postings/text-state and stats.
 - `SearchText(TextSearchOptions)` executes bounded postings range scans, applies
   simple term `AND`/`OR` semantics, scores candidates with BM25F-style field
   weighting from persisted stats/text-state or v2 norm blocks, and fetches
@@ -71,13 +70,7 @@ Validation rules:
   non-negative.
 - Analyzer `""` normalizes to `"simple"`; other analyzers fail closed until
   implemented.
-- Version `""` normalizes to `"v1"`; `"v2"` explicitly selects the #2624
-  B-tree-native root format. V2 root state is created with `CreateTextIndex`;
-  declaring v2 text indexes directly in `CreateCollection` is rejected to avoid
-  metadata without root descriptors/status records. V2 root state can be
-  maintained, but `TextIndexStatus` remains non-readable/non-writable for the
-  full v2 path and v2 search remains fail-closed until the later executor/write
-  pipeline milestones.
+- Version `""` normalizes to `"v2"` for new declarations. `"v2"` is the default B-tree-native root format and is readable/writable for BM25F serving, scalar-pruned hybrid candidates, lazy match details, rewrite/merge, and normal TreeDB physical maintenance. `"v1"` remains an explicit compatibility/opt-out path for callers that need the legacy per-`(term, documentID)` roots or existing v1 on-disk indexes.
 - Rollout `""` normalizes to `"primary"`; `"shadow"`, `"dual_write"`, and
   `"disabled"` are reserved and currently fail closed until the matching v2
   rollout implementation lands.
@@ -169,18 +162,19 @@ Values use `u8 value_version=1` followed by:
 `CreateTextIndex` is a schema barrier: pending writes from all registered
 collection managers/write domains for the collection are drained before the
 backfill snapshot is taken, new document writes wait behind the barrier, the
-primary root is scanned, analyzed text is encoded into the three text roots,
-and root IDs plus metadata are published in one commit. It rejects command-WAL
-catalog mutation mode until text-index catalog commands are added.
+primary root is scanned, analyzed text is encoded into v2 roots by default (or
+three v1 roots when `TextIndexVersionV1` is explicit), and root IDs plus metadata
+are published in one commit. It rejects command-WAL catalog mutation mode until
+text-index catalog commands are added.
 
 Backfill extracts string fields and arrays of strings from JSON-materialized
 documents. Non-string text fields are skipped. Collections with retained column
 payloads that omit requested text fields are rejected for now rather than
 backfilling incomplete text.
 
-`DropTextIndex` removes the text index metadata and clears all three text root
-descriptors. It does not delete historical root pages immediately; normal TreeDB
-root reachability/GC handles unreachable pages.
+`DropTextIndex` removes the text index metadata and clears both the legacy v1
+and v2 text root descriptors for that index. It does not delete historical root
+pages immediately; normal TreeDB root reachability/GC handles unreachable pages.
 
 ## Query shape
 
@@ -202,13 +196,14 @@ The parser accepts whitespace-separated terms and optional explicit `AND` or
 `OR` separators. Mixed `AND`/`OR`, phrases, and grouped syntax fail closed. Query
 terms are analyzed with the declared index analyzer.
 
-`SearchText` normalizes duplicate analyzed terms, range-scans the postings root
-by encoded term prefix, builds a bounded unique-document candidate set, and
-scores candidates from postings + text-state + text-stats. It does not scan or
-rank all collection documents. If candidate or postings budgets are exceeded, it
-returns `ErrTextIndexUnavailable` with truncation/fail-closed counters rather
-than returning silently incomplete rankings. Empty analyzed queries return an
-empty result set.
+`SearchText` normalizes duplicate analyzed terms and serves the declared index
+version. Default/v2 indexes range-scan posting blocks, score from packed norms
+and term/field stats, and materialize document IDs from docmap blocks; explicit
+v1 indexes range-scan the legacy postings root and score from postings +
+text-state + text-stats. Neither path scans or ranks all collection documents.
+If candidate or postings budgets are exceeded, it returns `ErrTextIndexUnavailable`
+with truncation/fail-closed counters rather than returning silently incomplete
+rankings. Empty analyzed queries return an empty result set.
 
 Results expose response-owned document IDs, source index name, one-based lexical
 rank, higher-is-better BM25F score, score kind `bm25f`, optional matched
@@ -224,8 +219,8 @@ benchmark/status vocabulary is `postings_scanned`, `posting_blocks_visited`,
 `posting_blocks_skipped`, `candidates_scored`, `state_lookups`, `norm_lookups`,
 `docs_fetched`, `match_details_built`, `scalar_filter_selectivity`,
 `fail_closed`, `write_amplification`, `index_bytes_per_doc`, and
-`rewrite_merge_state`; v1 reports posting-block counters as zero and v2 PRs must
-populate them. Additional runtime diagnostics include `documents_missing`,
+`rewrite_merge_state`; explicit v1 reports posting-block counters as zero and
+v2/default rows populate them. Additional runtime diagnostics include `documents_missing`,
 `full_document_scan_fallbacks`, `truncated`, and `fail_closed_reason`. The Go
 stats struct also carries text-source fields for hybrid adapters, plus text-only
 aliases and scan/score/fetch timing fields.
@@ -235,13 +230,13 @@ TopK truncation.
 
 ## Mutation maintenance
 
-Text-indexed insert paths analyze the stored document, set one text-state entry,
-set one posting per `(term, documentID)`, and increment corpus/term/field stats.
-Delete paths load the text-state entry, delete the document's postings and
-state, and decrement stats. Update paths load old text-state, analyze the new
-stored document, replace postings/state, and apply a stats delta. Stats entries
-whose counts drop to zero are deleted; the corpus stats entry remains with the
-current document count.
+Default/v2 text-indexed insert paths analyze the stored document, assign or
+reuse ordinals/generations, update docID/docmap/norm blocks, write compressed
+posting blocks, optional position/detail payloads, and corpus/term/field stats.
+Deletes tombstone current docID/docmap/norm generations and update live stats;
+updates keep the ordinal, advance generation, write fresh current state, and
+leave stale posting blocks for rewrite/merge. Explicit v1 insert/delete/update
+paths keep the legacy text-state/postings/stats behavior.
 
 M3 keeps text-indexed writes on immediate root-publish paths rather than staging
 new text deltas in buffered write domains. Existing buffered writes are drained

--- a/TreeDB/docs/spec/collection-text-v2-contract.md
+++ b/TreeDB/docs/spec/collection-text-v2-contract.md
@@ -39,7 +39,7 @@ type TextIndexDefinition struct {
     Name    string
     Fields  []TextIndexField
     Analyzer TextAnalyzer
-    Version TextIndexVersion     // "v1" default today, explicit "v2" supports v2 BM25F reads
+    Version TextIndexVersion     // "v2" default for new indexes; explicit "v1" is compatibility/opt-out
     Rollout TextIndexRolloutMode // "primary" default today
     // existing position/offset/storage/schema fields...
 }
@@ -47,23 +47,12 @@ type TextIndexDefinition struct {
 
 `TextIndexVersion` values:
 
-- `""` / `"v1"`: current per-`(term, documentID)` text index.
-- `"v2"`: explicit v2 physical contract. M1-M3 root-state creation and
-  writable posting/norm/docmap maintenance are supported. As of M4/M5, explicit
-  v2 indexes are readable for score-only BM25F serving over posting blocks and
-  packed norms with exact single-term block-max skipping. As of M6 (#2629),
-  `SearchText` can lazily materialize compact/detailed field-term summaries for
-  returned final results without v1 text-state lookups or full-document fetch.
-  Unsupported future rollout modes still fail closed and v2 must not silently
-  fall back to v1.
+- `""` / `"v2"`: default B-tree-native v2 physical contract for newly-created text indexes. Root-state creation, writable posting/norm/docmap maintenance, exact BM25F serving over posting blocks, scalar-pruned hybrid candidates, block-max skipping, lazy compact/detailed field-term summaries, rewrite/merge, and normal TreeDB physical maintenance are supported.
+- `"v1"`: explicit compatibility/opt-out path for the legacy per-`(term, documentID)` text index and existing v1 on-disk indexes. V1 remains readable/writable, but new default-sensitive callers must request it explicitly.
 
 `TextIndexRolloutMode` values:
 
-- `""` / `"primary"`: active production read/write path. V1 remains the default
-  readable/searchable path. Explicit v2 indexes are writable as of M3 and
-  readable as of M4/M5 for BM25F serving over v2 posting/norm/docmap roots.
-  M6 adds lazy compact/detailed field-term summaries for final results and an
-  optional positions/offset payload lane for `StorePositions` indexes.
+- `""` / `"primary"`: active production read/write path. V2 is the default readable/searchable path for newly-created text indexes. Explicit v1 indexes remain readable/writable for compatibility. V2 serves BM25F from posting/norm/docmap roots, supports scalar-pruned hybrid candidate generation, and builds lazy compact/detailed field-term summaries for final results with an optional positions/offset payload lane for `StorePositions` indexes.
 - `"shadow"`: future v2 build/validate without serving reads.
 - `"dual_write"`: future v1+v2 mutation maintenance with explicit read choice.
 - `"disabled"`: future metadata-present but non-serving/non-writing state.
@@ -77,9 +66,9 @@ status, benchmark, and downgrade/fail-closed tests.
 - version and rollout mode;
 - ready/readable/writable booleans;
 - fail-closed reason when unavailable;
-- active v1 roots and reserved v2 roots;
+- active root names (v2 by default, v1 for explicit compatibility indexes) and reserved v2 roots;
 - required counter names;
-- lightweight rewrite/merge readiness (`ready` for explicit v2) and TreeDB
+- lightweight rewrite/merge readiness (`ready` for v2) and TreeDB
   physical reclamation path. Full storage validation and detailed
   `rewrite_merge_pending`/`compacted` state are reported by
   `TextIndexStorageStats` so health/status calls do not scan large roots.
@@ -105,17 +94,18 @@ text asset store.
 ## M1 root/key/value format (#2624)
 
 M1 assigns the first concrete v2 root format. Every v2 root contains a versioned
-format record. Explicit `TextIndexVersionV2` creation through `CreateTextIndex`
+format record. Default `TextIndexVersionV2` creation through `CreateTextIndex`
 publishes all seven v2 root descriptors through the normal collection-root
-system records. Declaring a v2 text index directly in `CreateCollection` is
-rejected because it would create metadata without the required root status
-records. After M3, explicit v2 indexes maintain durable v2 roots and posting
-blocks for create/backfill/insert/update/delete. As of M4, `TextIndexStatus`
-reports `readable=true` and `writable=true` for explicit v2 indexes: query
-routing serves BM25F from v2 posting blocks, packed norm blocks, and docmap
-blocks. As of M6, score-only result mode still carries only document ID, rank,
-score, and score kind; compact/detailed modes build field-term summaries only
-for returned final results. There is no fallback to v1 for requested v2.
+system records. `CreateCollection` with default-v2 text indexes bootstraps empty
+v2 root descriptors, format records, corpus/field-stat shells, and the status
+record atomically with collection metadata, so a newly-declared text index is not
+left as metadata without roots. V2 indexes maintain durable v2 roots and posting
+blocks for create/backfill/insert/update/delete. `TextIndexStatus` reports
+`readable=true` and `writable=true` for v2 indexes: query routing serves BM25F
+from v2 posting blocks, packed norm blocks, and docmap blocks. Score-only result
+mode carries only document ID, rank, score, and score kind; compact/detailed
+modes build field-term summaries only for returned final results. There is no
+fallback to v1 for requested/default v2.
 
 Stable M1 ordinal semantics:
 
@@ -229,7 +219,7 @@ root values and continue to use existing value-log/leaf maintenance paths.
 
 ## M4 score-only search executor (#2627)
 
-M4 enables explicit v2 indexes for exhaustive score-only BM25F serving. The
+M4 enabled v2 indexes for exhaustive score-only BM25F serving. The
 executor analyzes query terms through the streaming analyzer sink, de-duplicates
 and deterministically orders v2 terms, opens posting-block iterators for every
 query term under one TreeDB snapshot, scans posting-block entries, and scores
@@ -331,7 +321,7 @@ field/term summaries for the bounded requested text candidate set; default hybri
 candidate generation emits no `TextMatches` and keeps `docs_fetched=0`,
 `state_lookups=0`, and `match_details_built=0`.
 
-## M7 rewrite/merge hardening and rollout decision (#2630)
+## M7 rewrite/merge hardening and default switch (#2630/#2690)
 
 M7 adds explicit logical rewrite/merge maintenance for text-v2 indexes through
 `Collection.RewriteTextIndex(indexName, TextIndexRewriteOptions)`. The rewrite
@@ -399,20 +389,11 @@ collection root descriptors throughout this sequence; stale roots become normal
 unreferenced root/value-log/leaf payloads and must not require a standalone
 text-block GC.
 
-Default-selection decision for #2630: v2 remains an explicit opt-in
-(`TextIndexVersionV2`) while the production default stays v1. The reason is not a
-storage blocker—v2 roots now have rewrite/merge lifecycle tooling and normal
-TreeDB reclamation participation—but rollout still lacks an atomic
-`CreateCollection` inline-v2 bootstrap/default-switch path and final full-matrix
-acceptance under coordinator policy. The old per-`(term,documentID)` v1 path is
-therefore retained as the compatibility/default path; explicit v2 indexes are the
-B-tree-native production candidate path. A future default-switch PR must update
-`normalizeTextIndexVersion`, `CreateCollection` root bootstrap, docs, and the
-benchmark matrix together.
+Default-selection decision for #2690: v2 is now the production default for newly-created TreeDB collection text indexes. The switch includes `normalizeTextIndexVersion`, `CreateCollection` empty-v2 root/status bootstrap, explicit v1 compatibility tests, v1/v2 coexistence tests, and the final clean-load matrix. The old per-`(term,documentID)` v1 path is retained as an explicit compatibility/opt-out path and existing v1 on-disk indexes remain readable/usable.
 
-## Current v1 path inventory
+## Explicit v1 compatibility path inventory
 
-Current write/backfill hot path:
+Explicit v1 write/backfill hot path:
 
 - metadata/backfill: `CreateTextIndex`, `buildCreateTextIndexBackfillPlan`,
   `analyzeTextIndexDocument`, `analyzeTextIndexField`, `addTextPostingsForDocument`,
@@ -423,7 +404,7 @@ Current write/backfill hot path:
 - storage/codecs: `encodeTextPostingKey`, `encodeTextPostingValue`,
   `encodeTextDocumentStateValue`, `encodeTextStats*`.
 
-Current search/hybrid hot path:
+Explicit v1 search/hybrid hot path:
 
 - `SearchHybridTextCandidates` adapts `SearchText` into hybrid candidates;
 - `SearchText` / `executeTextSearchAtSnapshot` reads stats, range-scans postings,
@@ -444,8 +425,7 @@ Related issues that v2 should absorb or supersede with production evidence:
 ## Required counters
 
 Every text-v2 performance PR must expose and benchmark these counters where the
-row applies. Current v1 rows now report compatible zero/legacy values so later
-PRs can compare one vocabulary.
+row applies. Explicit v1 rows report compatible zero/legacy values so v1/v2 comparisons use one vocabulary.
 
 | Counter | Required meaning |
 | --- | --- |
@@ -489,7 +469,7 @@ Required query and serving shapes:
   rows; M6 detailed-match rows must prove `match_details_built` is bounded by
   returned top-K/requested final results while score-only rows keep it zero;
 - isolated text write, backfill, update, and delete rows with `-benchmem`;
-- current #2589 indexed insert/search guardrail matrix on the latest base;
+- current #2589/#2564 indexed insert/search guardrail matrix on the latest base, including v1, v2, vector, and hybrid rows;
 - M6 lazy detail rows comparing score-only versus detailed top-K materialization;
 - concurrent serving/load row with reader concurrency, p50/p95/p99 latency,
   steady-state memory, cache warm/cold boundary, and optional mixed write or
@@ -522,6 +502,6 @@ coordinator explicitly accepts them with profile-backed rationale.
   document fetch remains a separate post-ranking phase.
 - M5 block skipping must be exact: upper bounds are admissible and results match
   exhaustive scoring. Approximate ranking requires a separate mode/tracker.
-- M7 default-switch or old-path retirement must include v1/v2 coexistence,
+- Any future old-path retirement must include v1/v2 coexistence,
   downgrade/fail-closed behavior, rewrite/merge state, vacuum/GC/rewrite, and
   `CompactStorage` evidence.

--- a/TreeDB/docs/spec/hybrid-search-contract.md
+++ b/TreeDB/docs/spec/hybrid-search-contract.md
@@ -128,8 +128,10 @@ Final `HybridSearchResult` values carry:
   true and only after top-k fusion.
 
 Candidate-generation paths MUST produce response-owned/caller-safe document IDs
-at the API boundary. They MUST NOT require fetching full documents to discover
-IDs during normal candidate generation.
+at the API boundary. Newly-created collection text indexes use the text-v2
+candidate path by default, while explicit v1 indexes remain supported for
+compatibility. Neither path may require fetching full documents to discover IDs
+during normal candidate generation.
 
 ## Score orientation and rank semantics
 

--- a/TreeDB/docs/spec/storage-format.md
+++ b/TreeDB/docs/spec/storage-format.md
@@ -148,11 +148,11 @@ stored inline in B-tree leaves or, when the root storage policy selects it, as
 existing value-log/split-leaf-log pointer-backed leaf values. Text roots do not
 own a separate physical file class or GC domain.
 
-The v1 text root payload contract is documented in
-`collection-text-search.md`. The v2 production contract and rollout boundaries
-are documented in `collection-text-v2-contract.md`; this section records the
-canonical durable key/value bytes that have landed for the M2 posting-block
-family. All integer varints below are Go `binary.PutUvarint` encodings unless
+The explicit-v1 text root payload contract is documented in
+`collection-text-search.md`. The default-v2 production contract, v1 compatibility
+boundary, and rollout rules are documented in `collection-text-v2-contract.md`;
+this section records the canonical durable key/value bytes that have landed for
+the M2 posting-block family. All integer varints below are Go `binary.PutUvarint` encodings unless
 noted otherwise.
 
 Text-v2 posting-block root name:

--- a/docs/benchmarks/treedb_index_insert_search_benchmarks.md
+++ b/docs/benchmarks/treedb_index_insert_search_benchmarks.md
@@ -14,10 +14,12 @@ The benchmark has two timing boundaries:
 
 1. `indexed_insert_batch_flush_vector_rebuild` times `InsertBatch`, `Flush`, and `RebuildVectorIndex` for one prepared batch. It excludes database/collection creation and JSON fixture generation. This row is a lifecycle/index-readiness row, not only an append/write row.
 2. Search rows build and index the fixture before `ResetTimer`, then time only the search API call:
-   - `search_text_candidates_no_docs` uses `SearchHybridTextCandidates`;
+   - `search_text_candidates_no_docs` uses the explicit v1 compatibility text index;
+   - `search_text_v2_candidates_no_docs` uses the v2/default text index;
    - `search_vector_candidates_no_docs` uses `SearchHybridVectorCandidates`;
-   - `search_hybrid_no_docs_scalar_filter` uses `SearchHybrid` without final document fetch;
-   - `search_hybrid_fetch_topk_scalar_filter` uses `SearchHybrid` with bounded final fetch and `embedding` excluded from returned documents.
+   - `search_hybrid_no_docs_scalar_filter` uses the explicit v1 compatibility text index plus vector/scalar filtering without final document fetch;
+   - `search_hybrid_v2_no_docs_scalar_filter` uses the v2/default text index plus vector/scalar filtering without final document fetch;
+   - `search_hybrid_fetch_topk_scalar_filter` uses bounded final fetch and excludes `embedding` from returned documents.
 
 Candidate-generation rows must keep `docs_fetched/search=0` and `full_doc_fallbacks/search=0`. The final-fetch hybrid row must keep `docs_fetched/search <= topk/search`.
 
@@ -31,7 +33,7 @@ Default fixture knobs:
 | vector dimensions | 16 | `TREEDB_INDEX_BENCH_DIMS` |
 | vector graph `M` | 8 | `TREEDB_INDEX_BENCH_M` |
 | scalar indexes | `tenant`, `region` | code change only |
-| text index | `lexical` over `title` (weight 3) and `body` | code change only |
+| text index | v2/default `lexical` over `title` (weight 3) and `body`; explicit v1 rows use the same fields | code change only |
 | vector route | exact cosine column graph | code change only |
 | search query | text `refund policy`; vector query near refund docs | code change only |
 | scalar filter | `tenant-rare-06pct` (~6.25% at default shape) | code change only |
@@ -157,5 +159,5 @@ When updating this benchmark or publishing a new row, include:
 - fixture shape and timing boundary;
 - `ns/op`, `ops/sec`, `B/op`, `allocs/op`;
 - insertion metrics (`docs/op`, derived docs/sec, `insert_batch_ns/doc`, `flush_ns/doc`, `vector_rebuild_ns/doc`);
-- search metrics (`text_candidates/search`, `text_postings/search`, `posting_blocks_visited/search`, `posting_blocks_skipped/search`, `text_state_lookups/search`, `text_norm_lookups/search`, `text_match_details/search`, `vector_candidates/search`, `candidates_fused/search`, `docs_fetched/search`, scalar counters, fallback/fail/truncation counters);
+- search metrics for both explicit-v1 and default/v2 rows (`text_candidates/search`, `text_postings/search`, `posting_blocks_visited/search`, `posting_blocks_skipped/search`, `blockmax_fallbacks/search`, `text_state_lookups/search`, `text_norm_lookups/search`, `text_match_details/search`, `vector_candidates/search`, `candidates_fused/search`, `docs_fetched/search`, scalar counters, fallback/fail/truncation counters);
 - caveats for local/context-only runs.

--- a/docs/benchmarks/treedb_text_v2_contract_benchmarks.md
+++ b/docs/benchmarks/treedb_text_v2_contract_benchmarks.md
@@ -57,10 +57,7 @@ GOWORK=off go test ./TreeDB/collections \
   | tee "$OUT/index_insert_search_guardrail.txt"
 ```
 
-M4 also exposes explicit-v2 #2564-shape score-only rows. The v2 text rows use the
-same synthetic #2564 documents and scalar distribution but create the v2 text
-index after insert, because inline v2 metadata is intentionally rejected; the
-existing command-WAL/vector guardrail rows remain the vector no-regression lane.
+The #2564 matrix also exposes v2/default-v2 score-only rows. The v2 text rows use the same synthetic #2564 documents and scalar distribution and create the v2 text index after insert so v1/v2 guardrails remain directly comparable; the existing command-WAL/vector guardrail rows remain the vector no-regression lane.
 
 ```sh
 GOWORK=off go test ./TreeDB/collections \
@@ -94,19 +91,19 @@ Measured boundaries:
   indexes; setup excludes DB/collection creation.
 - `insert_batch_text_indexed`: v1 `InsertBatch` with a declared text index;
   setup excludes DB/collection creation.
-- `insert_batch_text_v2_indexed`: explicit v2 `InsertBatch` after empty-index
+- `insert_batch_text_v2_indexed`: v2/default-v2 `InsertBatch` after empty-index
   `CreateTextIndex` setup; setup excludes DB/collection/index creation.
 - `create_text_index_backfill`: v1 `CreateTextIndex` over already inserted
   primary documents; setup excludes primary insert.
-- `create_text_v2_index_backfill`: explicit v2 `CreateTextIndex` over already
+- `create_text_v2_index_backfill`: v2/default-v2 `CreateTextIndex` over already
   inserted primary documents; setup excludes primary insert.
 - `update_batch_text_indexed`: v1 `UpdateBatch` replacements with maintained
   text roots; setup excludes initial insert.
-- `update_batch_text_v2_indexed`: explicit v2 `UpdateBatch` replacements with
+- `update_batch_text_v2_indexed`: v2/default-v2 `UpdateBatch` replacements with
   maintained micro-block/docmap/norm roots; setup excludes initial insert.
 - `delete_batch_text_indexed`: v1 `DeleteBatch` with maintained text roots;
   setup excludes initial insert.
-- `delete_batch_text_v2_indexed`: explicit v2 `DeleteBatch` with generation and
+- `delete_batch_text_v2_indexed`: v2/default-v2 `DeleteBatch` with generation and
   tombstone maintenance; setup excludes initial insert.
 
 Small/default command:
@@ -203,7 +200,7 @@ Report text search counters:
 - `match_details/search`;
 - `docs_fetched/search`, `full_doc_fallbacks/search`, `fail_closed/search`.
 
-M4 (#2627) adds an explicit v2 score-only search benchmark with the same corpus
+M4 (#2627) adds a v2 score-only search benchmark with the same corpus
 and query cases. It creates a v2 index with `CreateTextIndex`, scans compressed
 posting blocks under one snapshot, scores from norm/docmap blocks, and asserts
 `state_lookups=0`, `match_details=0`, and `docs_fetched=0`. As of M5 (#2628),
@@ -239,7 +236,7 @@ go test ./TreeDB/collections \
 
 Benchmark name: `BenchmarkTextV2BlockMaxCommonTerm2628`.
 
-This row runs the M5 exact single-term common top-K path against the explicit v2
+This row runs the M5 exact single-term common top-K path against the v2
 fixture and includes an in-process `exhaustive_common_topk` comparison with
 block-max disabled. The measured boundary is `SearchText` score-only candidate
 generation: no full documents, no v1 text-state lookups, and no match-detail
@@ -363,7 +360,7 @@ non-zero `posting_blocks_skipped/search` in the warm stats or fail the benchmark
 
 Benchmark name: `BenchmarkTextV2RewriteMerge2630`.
 
-This row creates an explicit v2 text index, applies updates and deletes to create
+This row creates a v2 text index, applies updates and deletes to create
 micro blocks, stale generations, and deleted-document tombstones, then measures
 only `Collection.RewriteTextIndex`. Setup, primary writes, index creation,
 updates, and deletes are outside the timed boundary. The row reports rewrite
@@ -410,10 +407,7 @@ Maintenance-budget interpretation for default-readiness PRs:
   `ValueLogGC`, value-log rewrite when the rewrite plan shows stale source
   bytes, leaf maintenance/index vacuum, or `CompactStorage`.
 
-Default selection after #2630 remains explicit v2 opt-in unless the final matrix
-and rollout/default-bootstrap work are accepted in the same PR. If v1 remains the
-default, PR evidence must state that the old per-`(term,documentID)` path is the
-compatibility/default path and link the default-switch follow-up.
+Default selection after #2690 is v2 for newly-created TreeDB collection text indexes. PR evidence should state when a row uses the explicit v1 compatibility path versus the default/v2 path, and should preserve v1/v2/vector/hybrid guardrails when changing this runbook or benchmark harness.
 
 ## Profiles for current v1 hot spots and M5 block-max path
 


### PR DESCRIPTION
Closes #2690.
Part of #2681.

## Summary

- Switch new TreeDB collection text-index declarations (`Version: ""`) to normalize to `TextIndexVersionV2`.
- Allow inline v2 text indexes in `CreateCollection` and publish empty v2 root descriptors, status records, format records, and stats shells atomically with collection metadata.
- Preserve compatibility: explicit `TextIndexVersionV1` still creates/serves legacy roots, and persisted metadata missing `version` is decoded as v1 so existing DBs remain readable.
- Keep default-v2 search/hybrid paths zero-doc for candidate generation and update docs/runbooks/benchmark wording to describe the new default and explicit v1 opt-out.
- Addressed Codex review feedback by serializing same-collection creates and adding ordered-root preflight coverage, so racing/idempotent creates cannot replace or orphan v2 roots.

## Tests

Latest pushed head: `6b56ec048bb851808cf72c2457b9b54c207e1d88`.

- `GOWORK=off go test ./TreeDB/collections -count=1` ✅
- `GOWORK=off go test ./TreeDB/docs -count=1` ✅
- `GOWORK=off go test ./TreeDB/... -count=1` ✅

Added coverage in `TreeDB/collections/text_v2_default_test.go` for:

- default-v2 `CreateCollection` roots/status bootstrap;
- raced same-schema `CreateCollection` serialization;
- stale v2 create preflight abort before ordered roots are applied/finalized;
- idempotent no-op not advancing commit seq;
- default-v2 `CreateTextIndex` backfill, update/delete, reopen, and search;
- explicit-v1 plus default-v2 coexistence;
- hybrid text candidate zero-doc behavior with default v2;
- legacy on-disk missing-version metadata decoding as v1.

## Benchmark / performance evidence

Context: Apple M3, `go1.26.0 darwin/arm64`, head `6b56ec048bb851808cf72c2457b9b54c207e1d88`. Benchmarks use fresh temp DB fixtures and `-count=1` guardrail rows; raw logs are under `/tmp/gomap_2690_text_v2_default_20260612_205300` on the runner.

No correctness counter regressions observed: default-v2/search-v2 rows keep `docs_fetched/search=0`, `full_doc_fallbacks/search=0`, `fail_closed/search=0`, and v2 score-only rows keep state lookups at 0.

<details>
<summary>Benchmark commands</summary>

- `env GOWORK=off TREEDB_INDEX_BENCH_DOCS=10000 go test ./TreeDB/collections -run ^$ -bench ^BenchmarkIndexInsertSearch2564/(search_text_candidates_no_docs|search_text_v2_candidates_no_docs|search_vector_candidates_no_docs|search_hybrid_no_docs_scalar_filter|search_hybrid_v2_no_docs_scalar_filter|search_hybrid_fetch_topk_scalar_filter)$ -benchmem -benchtime=1x -count=1`
- `env GOWORK=off TREEDB_INDEX_BENCH_DOCS=256 go test ./TreeDB/collections -run ^$ -bench ^BenchmarkIndexInsertSearch2564/(search_text_candidates_no_docs|search_text_v2_candidates_no_docs|search_vector_candidates_no_docs|search_hybrid_no_docs_scalar_filter|search_hybrid_v2_no_docs_scalar_filter|search_hybrid_fetch_topk_scalar_filter)$ -benchmem -benchtime=2x -count=1`
- `env GOWORK=off TREEDB_TEXT_V2_BLOCKMAX_DOCS=100000 go test ./TreeDB/collections -run ^$ -bench ^BenchmarkTextV2BlockMaxCommonTerm2628/(blockmax_common_topk|exhaustive_common_topk)$ -benchmem -benchtime=1x -count=1`
- `env GOWORK=off TREEDB_TEXT_V2_BLOCKMAX_DOCS=10000 go test ./TreeDB/collections -run ^$ -bench ^BenchmarkTextV2BlockMaxCommonTerm2628/(blockmax_common_topk|exhaustive_common_topk)$ -benchmem -benchtime=1x -count=1`
- `env GOWORK=off TREEDB_TEXT_V2_BLOCKMAX_CONCURRENT_DOCS=100000 TREEDB_TEXT_V2_BLOCKMAX_CONCURRENT_READERS=4 go test ./TreeDB/collections -run ^$ -bench ^BenchmarkTextV2BlockMaxConcurrentServing2628$ -benchmem -benchtime=1x -count=1`
- `env GOWORK=off TREEDB_TEXT_V2_BLOCKMAX_CONCURRENT_DOCS=10000 TREEDB_TEXT_V2_BLOCKMAX_CONCURRENT_READERS=4 go test ./TreeDB/collections -run ^$ -bench ^BenchmarkTextV2BlockMaxConcurrentServing2628$ -benchmem -benchtime=1x -count=1`
- `env GOWORK=off TREEDB_TEXT_V2_LAZY_DETAILS_DOCS=100000 go test ./TreeDB/collections -run ^$ -bench ^BenchmarkTextV2LazyDetails2629/(score_only|detailed_topk)$ -benchmem -benchtime=1x -count=1`
- `env GOWORK=off TREEDB_TEXT_V2_LAZY_DETAILS_DOCS=10000 go test ./TreeDB/collections -run ^$ -bench ^BenchmarkTextV2LazyDetails2629/(score_only|detailed_topk)$ -benchmem -benchtime=1x -count=1`
- `env GOWORK=off TREEDB_TEXT_V2_REWRITE_DOCS=10000 go test ./TreeDB/collections -run ^$ -bench ^BenchmarkTextV2RewriteMerge2630$ -benchmem -benchtime=1x -count=1`
- `env GOWORK=off TREEDB_TEXT_V2_REWRITE_DOCS=512 go test ./TreeDB/collections -run ^$ -bench ^BenchmarkTextV2RewriteMerge2630$ -benchmem -benchtime=1x -count=1`
- `env GOWORK=off TREEDB_TEXT_V2_SEARCH_DOCS=100000 go test ./TreeDB/collections -run ^$ -bench ^BenchmarkTextV2ScoreSearchScale2627/docs_100000/(score_only_common_no_docs|detailed_common_no_docs|rare_no_docs|multi_term_and_no_docs)$ -benchmem -benchtime=1x -count=1`
- `env GOWORK=off TREEDB_TEXT_V2_SEARCH_DOCS=10000 go test ./TreeDB/collections -run ^$ -bench ^BenchmarkTextV2ScoreSearchScale2627/docs_10000/(score_only_common_no_docs|detailed_common_no_docs|rare_no_docs|multi_term_and_no_docs)$ -benchmem -benchtime=1x -count=1`
- `env GOWORK=off TREEDB_TEXT_V2_WRITE_DOCS=256 go test ./TreeDB/collections -run ^$ -bench ^BenchmarkTextV2ContractWritePaths2623/(insert_batch_no_text|insert_batch_text_indexed|insert_batch_text_v2_indexed|create_text_index_backfill|create_text_v2_index_backfill|update_batch_text_indexed|update_batch_text_v2_indexed|delete_batch_text_indexed|delete_batch_text_v2_indexed)$ -benchmem -benchtime=1x -count=1`

</details>

<details open>
<summary>Benchmark matrix summary</summary>

### Index 256 (`bench_index_256_final4.txt`)
| row | ns/op | ops/s | B/op | allocs/op | docs_fixture | docs_fetched/search | full_doc_fallbacks/search | fail_closed/search | text_state_lookups/search | posting_blocks_visited/search |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| search_text_candidates_no_docs | 120270 | 8,315 | 89792 | 623 | 256.0 | 0 | 0 | 0 | 128.0 | 0 |
| search_text_v2_candidates_no_docs | 82771 | 12,082 | 99560 | 455 | 256.0 | 0 | 0 | 0 | 0 | 2.000 |
| search_hybrid_v2_no_docs_scalar_filter | 46084 | 21,700 | 63880 | 315 | 256.0 | 0 | 0 | 0 | 0 | 2.000 |
| search_vector_candidates_no_docs | 20625 | 48,485 | 41272 | 83 | 256.0 | 0 | 0 | 0 | 0 | 0 |
| search_hybrid_no_docs_scalar_filter | 147166 | 6,795 | 182784 | 803 | 256.0 | 0 | 0 | 0 | 128.0 | 0 |
| search_hybrid_fetch_topk_scalar_filter | 361334 | 2,768 | 241744 | 1788 | 256.0 | 10.00 | 0 | 0 | 128.0 | 0 |

### Index 10k (`bench_index_10k_final4.txt`)
| row | ns/op | ops/s | B/op | allocs/op | docs_fixture | docs_fetched/search | full_doc_fallbacks/search | fail_closed/search | text_state_lookups/search | posting_blocks_visited/search |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| search_text_candidates_no_docs | 4761708 | 210.01 | 2657464 | 20146 | 10000 | 0 | 0 | 0 | 5000 | 0 |
| search_text_v2_candidates_no_docs | 4230625 | 236.37 | 2969248 | 11181 | 10000 | 0 | 0 | 0 | 0 | 80.00 |
| search_hybrid_v2_no_docs_scalar_filter | 1214292 | 823.53 | 1749904 | 5027 | 10000 | 0 | 0 | 0 | 0 | 80.00 |
| search_vector_candidates_no_docs | 42209 | 23,692 | 149816 | 83 | 10000 | 0 | 0 | 0 | 0 | 0 |
| search_hybrid_no_docs_scalar_filter | 5855375 | 170.78 | 2926120 | 21554 | 10000 | 0 | 0 | 0 | 5000 | 0 |
| search_hybrid_fetch_topk_scalar_filter | 5230125 | 191.20 | 2982096 | 22472 | 10000 | 10.00 | 0 | 0 | 5000 | 0 |

### Text v2 score 10k (`bench_textv2_score_10k_final4.txt`)
| row | ns/op | ops/s | B/op | allocs/op | docs_fixture | docs_fetched/search | full_doc_fallbacks/search | fail_closed/search | state_lookups/search | match_details/search | posting_blocks_visited/search |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| docs_10000/score_only_common_no_docs | 2541500 | 393.47 | 2067104 | 1141 | 10000 | 0 | 0 | 0 | 0 | 0 | 79.00 |
| docs_10000/detailed_common_no_docs | 2746958 | 364.04 | 2071192 | 1195 | 10000 | 0 | 0 | 0 | 0 | 10.00 | 79.00 |
| docs_10000/rare_no_docs | 378917 | 2,639 | 1455144 | 682 | 10000 | 0 | 0 | 0 | 0 | 0 | 1.000 |
| docs_10000/multi_term_and_no_docs | 3173417 | 315.12 | 2138584 | 1573 | 10000 | 0 | 0 | 0 | 0 | 0 | 158.0 |

### Text v2 score 100k (`bench_textv2_score_100k_final4.txt`)
| row | ns/op | ops/s | B/op | allocs/op | docs_fixture | docs_fetched/search | full_doc_fallbacks/search | fail_closed/search | state_lookups/search | match_details/search | posting_blocks_visited/search |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| docs_100000/score_only_common_no_docs | 25113375 | 39.82 | 19468840 | 10044 | 100000 | 0 | 0 | 0 | 0 | 0 | 782.0 |
| docs_100000/detailed_common_no_docs | 25811667 | 38.74 | 19470744 | 10096 | 100000 | 0 | 0 | 0 | 0 | 10.00 | 782.0 |
| docs_100000/rare_no_docs | 5081000 | 196.81 | 14559288 | 5659 | 100000 | 0 | 0 | 0 | 0 | 0 | 9.000 |
| docs_100000/multi_term_and_no_docs | 35531625 | 28.14 | 19762952 | 13987 | 100000 | 0 | 0 | 0 | 0 | 0 | 1564 |

### Block-max common 10k (`bench_textv2_blockmax_common_10k_final4.txt`)
| row | ns/op | ops/s | B/op | allocs/op | docs_fixture | posting_blocks_skipped/search | posting_blocks_visited/search | docs_fetched/search | fail_closed/search |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| blockmax_common_topk | 301708 | 3,314 | 279600 | 518 | 10000 | 69.00 | 10.00 | 0 | 0 |
| exhaustive_common_topk | 5944542 | 168.22 | 4631200 | 21149 | 10000 | 0 | 79.00 | 0 | 0 |

### Block-max common 100k (`bench_textv2_blockmax_common_100k_final4.txt`)
| row | ns/op | ops/s | B/op | allocs/op | docs_fixture | posting_blocks_skipped/search | posting_blocks_visited/search | docs_fetched/search | fail_closed/search |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| blockmax_common_topk | 3149042 | 317.56 | 2557792 | 4105 | 100000 | 684.0 | 98.00 | 0 | 0 |
| exhaustive_common_topk | 80806542 | 12.38 | 45249952 | 210047 | 100000 | 0 | 782.0 | 0 | 0 |

### Block-max concurrent 10k (`bench_textv2_blockmax_concurrent_10k_final4.txt`)
| row | ns/op | ops/s | B/op | allocs/op | docs_fixture | p50_ns/search | p99_ns/search | steady_heap_bytes |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| TextV2BlockMaxConcurrentServing2628 | 824542 | 1,213 | 281968 | 530 | 10000 | 773166 | 773166 | 10075912 |

### Block-max concurrent 100k (`bench_textv2_blockmax_concurrent_100k_final4.txt`)
| row | ns/op | ops/s | B/op | allocs/op | docs_fixture | p50_ns/search | p99_ns/search | steady_heap_bytes |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| TextV2BlockMaxConcurrentServing2628 | 3196667 | 312.83 | 2560160 | 4117 | 100000 | 3169375 | 3169375 | 80063976 |

### Lazy details 10k (`bench_textv2_lazy_details_10k_final4.txt`)
| row | ns/op | ops/s | B/op | allocs/op | docs_fixture | match_details/search | docs_fetched/search | fail_closed/search | posting_blocks_skipped/search |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| score_only | 317042 | 3,154 | 279600 | 518 | 10000 | 0 | 0 | 0 | 69.00 |
| detailed_topk | 319000 | 3,135 | 281360 | 568 | 10000 | 10.00 | 0 | 0 | 69.00 |

### Lazy details 100k (`bench_textv2_lazy_details_100k_final4.txt`)
| row | ns/op | ops/s | B/op | allocs/op | docs_fixture | match_details/search | docs_fetched/search | fail_closed/search | posting_blocks_skipped/search |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| score_only | 3107875 | 321.76 | 2557792 | 4105 | 100000 | 0 | 0 | 0 | 684.0 |
| detailed_topk | 3245125 | 308.15 | 2561896 | 4159 | 100000 | 10.00 | 0 | 0 | 684.0 |

### Write paths 256 (`bench_textv2_write_paths_256_final4.txt`)
| row | ns/op | ops/s | B/op | allocs/op | docs/op | write_amp_entries/doc | index_entries/doc |
|---|---:|---:|---:|---:|---:|---:|---:|
| insert_batch_no_text | 498041 | 2,008 | 363536 | 330 | 256.0 |  |  |
| insert_batch_text_indexed | 4634209 | 215.79 | 3670408 | 24401 | 256.0 | 13.18 | 13.18 |
| insert_batch_text_v2_indexed | 2396499 | 417.28 | 3326872 | 23221 | 256.0 | 5.523 | 5.562 |
| create_text_index_backfill | 2869417 | 348.50 | 3790136 | 23769 | 256.0 | 13.18 | 13.18 |
| create_text_v2_index_backfill | 2117833 | 472.18 | 3067784 | 21511 | 256.0 | 5.398 | 5.398 |
| update_batch_text_indexed | 3658625 | 273.33 | 3654664 | 33597 | 256.0 | 24.19 | 13.18 |
| update_batch_text_v2_indexed | 2825792 | 353.88 | 3907456 | 32134 | 256.0 | 5.527 | 7.914 |
| delete_batch_text_indexed | 2936208 | 340.58 | 1898944 | 19131 | 256.0 | 13.18 | 0.003906 |
| delete_batch_text_v2_indexed | 1522958 | 656.62 | 1763664 | 17450 | 256.0 | 3.176 | 5.562 |

### Rewrite merge 512 (`bench_textv2_rewrite_512_final4.txt`)
| row | ns/op | ops/s | B/op | allocs/op | posting_blocks_read/op | posting_blocks_written/op | posting_blocks_deleted/op | stale_postings_purged/op | tombstones_purged/op |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| TextV2RewriteMerge2630 | 914792 | 1,093 | 1556328 | 8844 | 235.0 | 44.00 | 233.0 | 384.0 | 32.00 |

### Rewrite merge 10k (`bench_textv2_rewrite_10k_final4.txt`)
| row | ns/op | ops/s | B/op | allocs/op | posting_blocks_read/op | posting_blocks_written/op | posting_blocks_deleted/op | stale_postings_purged/op | tombstones_purged/op |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| TextV2RewriteMerge2630 | 20683084 | 48.35 | 34792824 | 142701 | 4080 | 315.0 | 4060 | 7500 | 625.0 |


</details>

## AI review status

- Codex raised P2 comments about racing/idempotent `CreateCollection` replacing or orphaning v2 roots. Fixed with schema serialization, preflight, and regression coverage; review threads were replied to and resolved. Re-review requested on latest head.
- CodeRabbit reports review completed with no actionable findings after `@coderabbitai review`.
- Copilot review was requested; no actionable comments were posted at the time of this update.

## Notes / risks

- TreeDB is pre-alpha; this intentionally changes the default for newly-created text indexes while preserving explicit v1 and old persisted v1 readability.
- No direct merge performed by this agent.
