### PR TITLE
TreeDB: compress semantic retained stream blocks as storage-first

### DIFF
--- a/TreeDB/caching/vlog_compression_selector.go
+++ b/TreeDB/caching/vlog_compression_selector.go
@@ -1,6 +1,7 @@
 package caching
 
 import (
+	"bytes"
 	"math"
 	"strconv"
 	"sync"
@@ -77,6 +78,8 @@ var (
 	vlogAutoCandidatesWithDict = [...]vlogAutoCandidate{vlogAutoCandidateOff, vlogAutoCandidateBlockSnappy, vlogAutoCandidateBlockLZ4, vlogAutoCandidateBlockZSTD, vlogAutoCandidateDict}
 	vlogSelectorBlockCodecs    = [...]valuelog.BlockCodec{valuelog.BlockCodecSnappy, valuelog.BlockCodecLZ4, valuelog.BlockCodecZSTD}
 )
+
+var valueLogRetainedSemanticStreamV1BlockMagic = []byte("crss1blk\x00")
 
 const (
 	defaultVlogHoldBytes      = 64 << 20
@@ -1836,6 +1839,8 @@ func valueLogPayloadLooksRetainedJSONLike(value []byte) bool {
 			return len(value)-i >= 4 &&
 				(value[i+1] == 'D' && value[i+2] == '1') &&
 				(value[i+3] == 'D' || value[i+3] == 'I' || value[i+3] == 'H')
+		case 'c':
+			return bytes.HasPrefix(value[i:], valueLogRetainedSemanticStreamV1BlockMagic)
 		default:
 			return false
 		}

--- a/TreeDB/caching/vlog_compression_selector_test.go
+++ b/TreeDB/caching/vlog_compression_selector_test.go
@@ -1000,6 +1000,28 @@ func TestChooseRetainedStorageFirstBlockCodec_DefaultBootstrapsZSTD(t *testing.T
 	}
 }
 
+func TestValueLogPayloadLooksRetainedLikeSemanticStreamBlock(t *testing.T) {
+	block := append([]byte("crss1blk\x00"), bytes.Repeat([]byte{0x7f}, 1024)...)
+	if !valueLogPayloadLooksRetainedJSONLike(block) {
+		t.Fatalf("semantic-stream-v1 block was not classified as retained-like")
+	}
+
+	locator := append([]byte("crss1loc\x00"), bytes.Repeat([]byte{0x7f}, 40)...)
+	if valueLogPayloadLooksRetainedJSONLike(locator) {
+		t.Fatalf("semantic-stream-v1 locator classified as retained-like; only side-root blocks should force retained storage-first compression")
+	}
+}
+
+func TestRetainedStorageFirstValueLogAutoDetectsSemanticStreamBlocks(t *testing.T) {
+	db := &DB{valueLogCompressionMode: uint8(vlogCompressionAuto)}
+	block := append([]byte("crss1blk\x00"), bytes.Repeat([]byte{0x42}, 1024)...)
+	records := []valuelog.Record{{Value: block}}
+
+	if !db.retainedStorageFirstValueLogAuto(0, 0, records) {
+		t.Fatalf("semantic-stream-v1 block did not select retained storage-first value-log compression")
+	}
+}
+
 func TestChooseRetainedStorageFirstBlockCodec_SingleConfiguredCodecHistoryKeepsZSTDBootstrap(t *testing.T) {
 	l := &lane{}
 	for i := 0; i < largePayloadBlockCodecMinSamples; i++ {


### PR DESCRIPTION
## Summary

This is a narrow #2662 retained-storage slice after the semantic-stream-v1 1M result showed the format is not yet the parity answer.

It teaches the value-log compression selector to recognize `semantic-stream-v1` side-root block payloads (`crss1blk`) as retained storage-owned payloads. Those blocks now take the retained storage-first block-compression path instead of being treated as generic binary values. Primary locators (`crss1loc`) intentionally do not match.

## Evidence

Paired JSONBench smoke, same JSONBench head (`fb8813c`), same input, same 10k compacted full-data semantic-stream cell, only gomap changed:

- patched: `/tmp/jsonbench_2662_semantic_block_compression_smoke_20260613_071018/rows10000_column-store-full-prepared_json_full_all_compacted/result.json`
- baseline: `/tmp/jsonbench_2662_semantic_block_baseline_smoke_20260613_071047/rows10000_column-store-full-prepared_json_full_all_compacted/result.json`

Storage:

| run | durable WAL-excluded bytes | value_vlog bytes | total bytes |
| --- | ---: | ---: | ---: |
| baseline | 6,441,803 | 1,565,211 | 11,378,756 |
| patched | 5,842,129 | 965,538 | 10,779,082 |

Delta:

- durable WAL-excluded: -599,674 bytes (-9.3%)
- value_vlog: -599,673 bytes (-38.3%)
- total: -599,674 bytes (-5.3%)

Query/load timings at 10k are smoke-only and noisy; this PR is justified by storage movement, not by a performance claim.

## Caveat

This does not close #2662 or claim final parity. The current semantic-stream-v1 1M result remains negative versus the template-v1 baseline and ClickHouse. This patch is a small correction to the value-log policy so the next retained-format work starts from the intended storage-first compression path.

## Tests

- `GOTOOLCHAIN=go1.26.4 GOFLAGS=-mod=mod go test ./TreeDB/caching -run 'SemanticStream|RetainedStorageFirst|RetainedLike'`
- `GOTOOLCHAIN=go1.26.4 GOFLAGS=-mod=mod go test ./TreeDB/collections -run 'ColumnRetainedPayloadSemanticStreamV1'`
- `GOTOOLCHAIN=go1.26.4 GOFLAGS=-mod=mod go test ./TreeDB/caching ./TreeDB/collections ./cmd/unified_bench`

Refs #2662.
