### PR TITLE
Report TreeDB geth hot KV write profile

### DIFF
--- a/benchmarks/geth_hot_kv/README.md
+++ b/benchmarks/geth_hot_kv/README.md
@@ -26,8 +26,8 @@ Workload shape:
 8. Label TreeDB value-log read integrity (`verify` or the explicitly unsafe
    `unsafe-skip-checksums` ceiling) and iteration mode (`value` or `key-only`).
 9. For TreeDB runs, include per-phase stat deltas for value-log CRC checks,
-   grouped-frame cache activity, mmap hits, and ReadAt fallbacks where the
-   adapter exposes `Stat()`.
+   grouped-frame cache activity, mmap hits, ReadAt fallbacks, and focused
+   write-path counters where the adapter exposes `Stat()`.
 
 The exact original `/tmp/treedb_nitro_soak.go` was not recovered, so the matrix
 script intentionally sweeps the uncertain knobs that may affect directionality:
@@ -118,5 +118,8 @@ PROFILE_DIR=/tmp/geth_hotkv_profiles \
 Profile artifacts are written per phase, for example
 `cpu_write_treedb.pprof`, `memstats_read_treedb.json`,
 `allocs_cumulative_read_treedb.pprof`, `block.pprof`, and `mutex.pprof`.
-Allocation pprof files are explicitly labeled cumulative; use the `memstats_*`
-JSON files for phase-local allocation deltas.
+Matrix output also includes `phase_counters.tsv` for the headline read counters
+and `phase_stat_deltas.tsv` for all nonzero parseable TreeDB stat deltas,
+including focused write-path counters. Allocation pprof files are explicitly
+labeled cumulative; use the `memstats_*` JSON files for phase-local allocation
+deltas.

--- a/benchmarks/geth_hot_kv/testdata/treedb_nitro_soak.go
+++ b/benchmarks/geth_hot_kv/testdata/treedb_nitro_soak.go
@@ -792,6 +792,29 @@ var interestingStatKeys = []string{
 	"treedb.cache.vlog_mmap.read.fallback_readat",
 }
 
+var interestingStatPrefixes = []string{
+	"treedb.command_wal.",
+	"treedb.cache.command_wal.",
+	"treedb.cache.checkpoint.",
+	"treedb.cache.vlog_auto.",
+	"treedb.cache.vlog_block.",
+	"treedb.cache.vlog_outer_leaf_codec.",
+	"treedb.cache.vlog_payload_kind.",
+	"treedb.cache.vlog_payload_split.",
+	"treedb.cache.vlog_queue.",
+	"treedb.cache.vlog_shape.",
+	"treedb.cache.vlog_write_mode.",
+	"treedb.cache.batch_arena.",
+	"treedb.cache.memtable_adaptive.",
+	"treedb.cache.memtable_stats.",
+	"treedb.cache.memtable_view.",
+	"treedb.freelist.",
+	"treedb.graveyard.",
+	"treedb.pages.",
+	"treedb.publish.ordered_root_delta_group.",
+	"treedb.vlog.decode_buffer_grow.",
+}
+
 func timeDBPhase(profiler phaseProfiler, db ethdb.Database, phase string, fn func() (int, error)) (phaseResult, error) {
 	before := statSnapshot(db)
 	result, err := profiler.time(phase, fn)
@@ -816,7 +839,21 @@ func statSnapshot(db ethdb.Database) map[string]int64 {
 			out[key] = value
 		}
 	}
+	for key, value := range parsed {
+		if interestingStatKey(key) {
+			out[key] = value
+		}
+	}
 	return out
+}
+
+func interestingStatKey(key string) bool {
+	for _, prefix := range interestingStatPrefixes {
+		if strings.HasPrefix(key, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 func parseKeyValueStats(raw string) map[string]int64 {
@@ -843,11 +880,7 @@ func statDelta(before, after map[string]int64) map[string]int64 {
 		return nil
 	}
 	out := make(map[string]int64, len(after))
-	for _, key := range interestingStatKeys {
-		post, ok := after[key]
-		if !ok {
-			continue
-		}
+	for key, post := range after {
 		out[key] = post - before[key]
 	}
 	return out

--- a/benchmarks/geth_hot_kv/testdata/treedb_nitro_soak.go
+++ b/benchmarks/geth_hot_kv/testdata/treedb_nitro_soak.go
@@ -815,6 +815,14 @@ var interestingStatPrefixes = []string{
 	"treedb.vlog.decode_buffer_grow.",
 }
 
+var interestingStatKeySet = func() map[string]struct{} {
+	out := make(map[string]struct{}, len(interestingStatKeys))
+	for _, key := range interestingStatKeys {
+		out[key] = struct{}{}
+	}
+	return out
+}()
+
 func timeDBPhase(profiler phaseProfiler, db ethdb.Database, phase string, fn func() (int, error)) (phaseResult, error) {
 	before := statSnapshot(db)
 	result, err := profiler.time(phase, fn)
@@ -833,12 +841,7 @@ func statSnapshot(db ethdb.Database) map[string]int64 {
 		return nil
 	}
 	parsed := parseKeyValueStats(raw)
-	out := make(map[string]int64, len(interestingStatKeys))
-	for _, key := range interestingStatKeys {
-		if value, ok := parsed[key]; ok {
-			out[key] = value
-		}
-	}
+	out := make(map[string]int64, len(parsed))
 	for key, value := range parsed {
 		if interestingStatKey(key) {
 			out[key] = value
@@ -848,6 +851,9 @@ func statSnapshot(db ethdb.Database) map[string]int64 {
 }
 
 func interestingStatKey(key string) bool {
+	if _, ok := interestingStatKeySet[key]; ok {
+		return true
+	}
 	for _, prefix := range interestingStatPrefixes {
 		if strings.HasPrefix(key, prefix) {
 			return true
@@ -998,11 +1004,11 @@ func renderSummary(out output) string {
 }
 
 func writeStatDeltaSummary(sb *strings.Builder, runs []runResult) {
-	if !hasStatDeltas(runs) {
+	if !hasReadCounterDeltas(runs) {
 		return
 	}
 	sb.WriteString("\n## TreeDB value-log read counters\n\n")
-	sb.WriteString("Per-phase deltas from TreeDB `Stat()` output. CRC counts are value-log record CRC32 computations performed by the read path; grouped-frame counters report the current grouped-frame cache behavior used by follow-up #2678.\n\n")
+	sb.WriteString("Per-phase deltas from TreeDB `Stat()` output. CRC counts are value-log record CRC32 computations performed by the read path; grouped-frame counters report the current grouped-frame cache behavior used by follow-up #2678. Broader write-path stat deltas remain available in the JSON output and matrix `phase_stat_deltas.tsv`.\n\n")
 	sb.WriteString("| engine | read integrity | iteration mode | phase | crc32 checks | grouped hits | grouped misses | grouped stores | mmap hits | mmap miss out-of-range | mmap miss no mapping | mmap miss dead cap | mmap ReadAt fallbacks |\n")
 	sb.WriteString("|---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|\n")
 	for _, run := range runs {
@@ -1011,34 +1017,65 @@ func writeStatDeltaSummary(sb *strings.Builder, runs []runResult) {
 			if !ok || len(result.StatDelta) == 0 {
 				continue
 			}
+			counters, ok := readCounterDeltas(result.StatDelta)
+			if !ok {
+				continue
+			}
 			fmt.Fprintf(sb, "| %s | %s | %s | %s | %d | %d | %d | %d | %d | %d | %d | %d | %d |\n",
 				run.Engine,
 				run.ReadIntegrity,
 				run.IterationMode,
 				phase,
-				statDeltaValue(result.StatDelta, "treedb.vlog.read.crc32_checks_total", "treedb.cache.vlog_read.crc32_checks_total"),
-				statDeltaValue(result.StatDelta, "treedb.vlog.grouped_frame_cache.hits", "treedb.cache.vlog_grouped_frame_cache.hits"),
-				statDeltaValue(result.StatDelta, "treedb.vlog.grouped_frame_cache.misses", "treedb.cache.vlog_grouped_frame_cache.misses"),
-				statDeltaValue(result.StatDelta, "treedb.vlog.grouped_frame_cache.stores", "treedb.cache.vlog_grouped_frame_cache.stores"),
-				statDeltaValue(result.StatDelta, "treedb.vlog.mmap_read.hits", "treedb.cache.vlog_mmap.read.hits"),
-				statDeltaValue(result.StatDelta, "treedb.vlog.mmap_read.miss_out_of_range", "treedb.cache.vlog_mmap.read.miss_out_of_range"),
-				statDeltaValue(result.StatDelta, "treedb.vlog.mmap_read.miss_no_mapping", "treedb.cache.vlog_mmap.read.miss_no_mapping"),
-				statDeltaValue(result.StatDelta, "treedb.vlog.mmap_read.miss_dead_mapping_cap", "treedb.cache.vlog_mmap.read.miss_dead_mapping_cap"),
-				statDeltaValue(result.StatDelta, "treedb.vlog.mmap_read.fallback_readat", "treedb.cache.vlog_mmap.read.fallback_readat"),
+				counters.crc32Checks,
+				counters.groupedHits,
+				counters.groupedMisses,
+				counters.groupedStores,
+				counters.mmapHits,
+				counters.mmapMissOutOfRange,
+				counters.mmapMissNoMapping,
+				counters.mmapMissDeadCap,
+				counters.mmapFallbackReadAt,
 			)
 		}
 	}
 }
 
-func hasStatDeltas(runs []runResult) bool {
+type readCounters struct {
+	crc32Checks        int64
+	groupedHits        int64
+	groupedMisses      int64
+	groupedStores      int64
+	mmapHits           int64
+	mmapMissOutOfRange int64
+	mmapMissNoMapping  int64
+	mmapMissDeadCap    int64
+	mmapFallbackReadAt int64
+}
+
+func hasReadCounterDeltas(runs []runResult) bool {
 	for _, run := range runs {
 		for _, phase := range run.Phases {
-			if len(phase.StatDelta) > 0 {
+			if _, ok := readCounterDeltas(phase.StatDelta); ok {
 				return true
 			}
 		}
 	}
 	return false
+}
+
+func readCounterDeltas(delta map[string]int64) (readCounters, bool) {
+	counters := readCounters{
+		crc32Checks:        statDeltaValue(delta, "treedb.vlog.read.crc32_checks_total", "treedb.cache.vlog_read.crc32_checks_total"),
+		groupedHits:        statDeltaValue(delta, "treedb.vlog.grouped_frame_cache.hits", "treedb.cache.vlog_grouped_frame_cache.hits"),
+		groupedMisses:      statDeltaValue(delta, "treedb.vlog.grouped_frame_cache.misses", "treedb.cache.vlog_grouped_frame_cache.misses"),
+		groupedStores:      statDeltaValue(delta, "treedb.vlog.grouped_frame_cache.stores", "treedb.cache.vlog_grouped_frame_cache.stores"),
+		mmapHits:           statDeltaValue(delta, "treedb.vlog.mmap_read.hits", "treedb.cache.vlog_mmap.read.hits"),
+		mmapMissOutOfRange: statDeltaValue(delta, "treedb.vlog.mmap_read.miss_out_of_range", "treedb.cache.vlog_mmap.read.miss_out_of_range"),
+		mmapMissNoMapping:  statDeltaValue(delta, "treedb.vlog.mmap_read.miss_no_mapping", "treedb.cache.vlog_mmap.read.miss_no_mapping"),
+		mmapMissDeadCap:    statDeltaValue(delta, "treedb.vlog.mmap_read.miss_dead_mapping_cap", "treedb.cache.vlog_mmap.read.miss_dead_mapping_cap"),
+		mmapFallbackReadAt: statDeltaValue(delta, "treedb.vlog.mmap_read.fallback_readat", "treedb.cache.vlog_mmap.read.fallback_readat"),
+	}
+	return counters, counters != (readCounters{})
 }
 
 func statDeltaValue(delta map[string]int64, keys ...string) int64 {

--- a/docs/benchmarks/TREEDB_GETH_HOT_KV_WRITE_PROFILE_2026-06-13.md
+++ b/docs/benchmarks/TREEDB_GETH_HOT_KV_WRITE_PROFILE_2026-06-13.md
@@ -1,0 +1,196 @@
+# TreeDB geth-hot-KV write profile — 2026-06-13
+
+Issue: [#2706](https://github.com/snissn/gomap/issues/2706), parent tracker [#2676](https://github.com/snissn/gomap/issues/2676).
+
+This is a profiling/counter snapshot only. It does **not** change command-WAL durability semantics, value-log compression defaults, or page/layout behavior, and it is not public-testnet readiness evidence.
+
+## Context
+
+- gomap capture head: `866d4deb8df2eb7cd9bfaa67ebb8495ad83bedb0`
+  - Based on post-A `origin/main` `281c4eb28c3e1c0fae28e6e813b8b7a1402cdf9e`.
+  - The only code change before capture was benchmark harness/reporting surfacing of additional existing `Stat()` deltas; TreeDB write behavior was not changed.
+- go-ethereum checkout: `/Users/michaelseiler/dev/snissn/go-ethereum`
+- go-ethereum head: `6371ea5ca7502c58ece5353b0425fb5ec99a41d8`
+- Platform: Apple M3, 16 GiB RAM, Darwin arm64, Go `go1.26.0`
+- Dataset shape: `KEYS=1000000`, `READS=400000`, `KEY_SHAPES=geth-mixed`, `VALUE_SHAPES=geth-mixed`, `VALUE_SIZES=128`, `BATCH_TARGET_BYTES=102400`, `TREEDB_READ_INTEGRITIES=verify`, `ITERATION_MODES=value`, `ENGINES=treedb`.
+- go command used a temporary `-modfile` replacing both gomap modules to this worktree:
+  - `replace github.com/snissn/gomap => /Users/michaelseiler/orca/workspaces/gomap/2706-manager`
+  - `replace github.com/snissn/gomap/TreeDB/integration/gethethdb => /Users/michaelseiler/orca/workspaces/gomap/2706-manager/TreeDB/integration/gethethdb`
+
+## Commands
+
+Profile capture:
+
+```sh
+GOFLAGS='-modfile=/tmp/geth_hotkv_gomap_2706_20260613T075042Z.mod -mod=mod' \
+GETH_REPO=/Users/michaelseiler/dev/snissn/go-ethereum \
+RUN_DIR=/tmp/geth_hotkv_write_matrix_20260613T075042Z \
+PROFILE_DIR=/tmp/geth_hotkv_profiles_write_20260613T075042Z \
+ENGINES=treedb \
+KEYS=1000000 READS=400000 \
+KEY_SHAPES=geth-mixed VALUE_SHAPES=geth-mixed VALUE_SIZES=128 \
+BATCH_TARGET_BYTES=102400 \
+TREEDB_READ_INTEGRITIES=verify \
+ITERATION_MODES=value \
+  scripts/treedb_geth_hot_kv_matrix.sh
+```
+
+Same-head no-pprof control:
+
+```sh
+GOFLAGS='-modfile=/tmp/geth_hotkv_gomap_2706_20260613T075119Z.mod -mod=mod' \
+GETH_REPO=/Users/michaelseiler/dev/snissn/go-ethereum \
+RUN_DIR=/tmp/geth_hotkv_write_noprofile_20260613T075119Z \
+ENGINES=treedb \
+KEYS=1000000 READS=400000 \
+KEY_SHAPES=geth-mixed VALUE_SHAPES=geth-mixed VALUE_SIZES=128 \
+BATCH_TARGET_BYTES=102400 \
+TREEDB_READ_INTEGRITIES=verify \
+ITERATION_MODES=value \
+  scripts/treedb_geth_hot_kv_matrix.sh
+```
+
+Derived summaries:
+
+```sh
+P=/tmp/geth_hotkv_profiles_write_20260613T075042Z/01_geth-mixed_geth-mixed_v128_b102400_verify_value
+
+go tool pprof -top -nodecount=40 "$P/cpu_write_treedb.pprof" > "$P/cpu_write_top.txt"
+go tool pprof -top -cum -nodecount=60 "$P/cpu_write_treedb.pprof" > "$P/cpu_write_top_cum.txt"
+go tool pprof -top -alloc_space -nodecount=40 "$P/allocs_cumulative_write_treedb.pprof" > "$P/allocs_cumulative_write_top_alloc_space.txt"
+go tool pprof -top -alloc_objects -nodecount=40 "$P/allocs_cumulative_write_treedb.pprof" > "$P/allocs_cumulative_write_top_alloc_objects.txt"
+go tool pprof -top -nodecount=40 "$P/mutex.pprof" > "$P/mutex_top.txt"
+```
+
+## Artifacts
+
+- Profile matrix: `/tmp/geth_hotkv_write_matrix_20260613T075042Z`
+  - `matrix_results.md`, `matrix_results.tsv`
+  - `phase_counters.tsv`
+  - `phase_stat_deltas.tsv`
+  - `manifest.txt`
+- Pprof root: `/tmp/geth_hotkv_profiles_write_20260613T075042Z/01_geth-mixed_geth-mixed_v128_b102400_verify_value`
+  - `cpu_write_treedb.pprof`
+  - `cpu_write_top.txt`, `cpu_write_top_cum.txt`
+  - `allocs_cumulative_write_treedb.pprof`
+  - `memstats_write_treedb.json`
+  - `block.pprof`, `mutex.pprof`, `mutex_top.txt`
+- No-pprof control: `/tmp/geth_hotkv_write_noprofile_20260613T075119Z`
+
+## Throughput snapshot
+
+The profiled run is the CPU evidence source; the no-pprof control is included to keep throughput separate from profiling overhead/noise. Single-run numbers moved materially across local captures, so use this for bottleneck ranking rather than throughput regression claims.
+
+| run | write ops/sec | read ops/sec | iterate keys/sec | DeleteRange keys/sec | size bytes | post-delete bytes |
+|---|---:|---:|---:|---:|---:|---:|
+| profiled | 181,198 | 125,675 | 2,613,264 | 1,022,704 | 771,304,381 | 393,938,076 |
+| same-head no-pprof control | 174,126 | 61,360 | 1,183,660 | 408,225 | 771,304,381 | 393,928,903 |
+| pre-existing post-A reference from `/tmp/geth_hotkv_postmerge_1m_20260613T063345Z` | 262,270 | 84,061 | 1,033,019 | 482,376 | 771,304,381 | 393,939,065 |
+
+## `cpu_write_treedb.pprof` highlights
+
+CPU profile metadata: 5.70s duration, 3.15s total samples.
+
+Flat CPU was dominated by memory movement, GC scanning, and syscalls:
+
+| function | flat | flat % | cumulative |
+|---|---:|---:|---:|
+| `runtime.memmove` | 0.63s | 20.00% | 0.63s |
+| `runtime.madvise` | 0.33s | 10.48% | 0.33s |
+| `runtime.tryDeferToSpanScan` | 0.30s | 9.52% | 0.30s |
+| `syscall.rawsyscalln` | 0.30s | 9.52% | 0.30s |
+| `runtime.scanObject` | 0.27s | 8.57% | 0.62s |
+| `syscall.Syscall` | 0.16s | 5.08% | 0.16s |
+| `github.com/snissn/go-crc32-asm.gf2MatrixTimes` | 0.12s | 3.81% | 0.14s |
+| `github.com/snissn/gomap/TreeDB/internal/memtable.(*AppendOnly).appendEntryCoreLocked` | 0.07s | 2.22% | 0.10s |
+
+Cumulative TreeDB/application hotspots:
+
+| function group | cumulative | cumulative % | interpretation |
+|---|---:|---:|---|
+| `caching.(*DB).flushLaneOnceWithCommandPublish` | 0.82s | 26.03% | cached flush/publish dominates application CPU |
+| `zipper.(*Zipper).Apply` / `writeRecursive` | 0.62s | 19.68% | page merge/rewrite path visible |
+| `zipper.(*Zipper).mergeLeaf` | 0.60s | 19.05% | leaf merge/persist work visible |
+| `zipper.(*Zipper).mergeInternal` | 0.56s | 17.78% | internal merge work visible |
+| `gethethdb.(*Batch).Put` / `cloneBytes` | 0.55s / 0.54s | 17.46% / 17.14% | adapter ownership copies remain material |
+| `commandWALPublicBatch.write` / `caching.(*Batch).writeRegularLocked` | 0.54s | 17.14% | public batch write path |
+| `caching.(*DB).appendValueLog` | 0.52s | 16.51% | value-log append path visible but not alone dominant |
+| `leafPageLogWithRecordLengthHints.AppendLeafPages` | 0.47s | 14.92% | leaf-log page persistence visible |
+| `valuelog.(*Writer).AppendFrameWithStatsInto` / `appendBlockFrameWithStats` | 0.29s | 9.21% | value-log frame encoding/writes |
+| `commandWALPublicBatch.appendCommandWAL` / commitlog append | 0.20s | 6.35% | command-WAL append is visible but below allocation/zipper groups |
+| `commitlog.writevFull` | 0.19s | 6.03% | command-WAL writev syscall path |
+
+The mutex profile also points at the zipper leaf-page persistence/cache path (`zipper.(*Zipper).cachePersistedLeafPage`, `mergeLeaf`, and `mergeInternal`) with about 5.4s cumulative mutex delay. The block profile is dominated by idle/background goroutines and was not used for ranking.
+
+## Phase-local memstats
+
+Use these JSON files for phase-local allocation deltas. The allocation pprof files are cumulative process profiles and include setup/data-generation cost.
+
+| phase | total alloc bytes | MiB | mallocs | frees | GC cycles | pause ns |
+|---|---:|---:|---:|---:|---:|---:|
+| write | 1,372,413,840 | 1,308.8 | 3,176,690 | 2,196,191 | 2 | 4,782,040 |
+| read | 146,528,288 | 139.7 | 452,861 | 194 | 0 | 0 |
+| iterate | 6,090,184 | 5.8 | 50,823 | 75 | 0 | 0 |
+| DeleteRange | 918,607,248 | 876.1 | 2,263,582 | 1,195,865 | 1 | 116,333 |
+| reopen verify | 4,285,405,928 | 4,086.9 | 1,017,697 | 914,188 | 7 | 818,000 |
+
+The write phase remains allocation-heavy: about 1.37 GB and 3.18M mallocs for 1M writes. This matches the earlier #2676 note that write allocation pressure was still about 1.37 GiB / 3.18M mallocs after A-lane.
+
+## Relevant counters
+
+New `phase_stat_deltas.tsv` rows expose nonzero parseable TreeDB `Stat()` deltas for existing write-path counters.
+
+| counter | write delta | note |
+|---|---:|---|
+| `treedb.command_wal.frames` | 3,629 | command-WAL frames accepted during write |
+| `treedb.command_wal.live_accepted_frames` | 3,629 | live accepted frame count matches frame delta |
+| `treedb.command_wal.live_covered_frames` | 3,629 | checkpoint covered the accepted write frames |
+| `treedb.cache.checkpoint.runs` | 1 | final `SyncKeyValue`/checkpoint boundary |
+| `treedb.cache.command_wal.checkpoint_publish.piggybacked` | 1 | command-WAL checkpoint publish piggybacked |
+| `treedb.cache.vlog_write_mode.frames.off` | 1,821 | value-log auto chose `off` for these payload frames |
+| `treedb.cache.vlog_write_mode.raw_bytes.off` | 179,200,000 | value-log raw bytes in off mode |
+| `treedb.cache.vlog_write_mode.stored_bytes.off` | 179,200,000 | no compression savings for this write-mode bucket |
+| `treedb.cache.vlog_payload_split.records.single_value` | 200,000 | single-value records stored through value log |
+| `treedb.cache.vlog_shape.segments_total` | 3 | value-log segments created/active for this run |
+| `treedb.cache.vlog_shape.bytes_total` | 181,665,556 | value-log bytes after write |
+| `treedb.cache.memtable_stats.writes` | 104,468 | current exposed memtable write counter is not a full 1M op counter |
+| `treedb.cache.memtable_stats.seq_writes` | 102,007 | current exposed memtable seq counter is partial/current-state oriented |
+| `treedb.freelist.alloc_pages_total` | 782 | pages allocated during write |
+| `treedb.freelist.append_alloc_pages_total` | 752 | mostly append allocation |
+| `treedb.freelist.reuse_alloc_pages_total` | 30 | low page reuse during load |
+| `treedb.freelist.free_pages_total` | 33 | low free count during load |
+| `treedb.pages.total` | 752 | page count growth during write |
+
+DeleteRange is owned by #2704, but for context this same run reported `treedb.command_wal.frames=5,050`, `total_alloc_bytes=918,607,248`, and `mallocs=2,263,582` in the DeleteRange phase.
+
+Current command-WAL byte counters are not useful as phase deltas here (`treedb.command_wal.bytes=0`) because the stats scan observes the post-checkpoint/truncated command-WAL file set. Live frame counters are useful; byte/sync/flush counters would need dedicated live counters before changing durability behavior.
+
+## Ranked write-path bottlenecks
+
+1. **Allocation/copy/GC pressure is the top proven write bottleneck.**
+   - Evidence: write phase allocated 1.37 GB / 3.18M mallocs; flat CPU is led by `runtime.memmove` plus GC scanning/span work; cumulative allocation profile still shows `gethethdb.cloneBytes`, memtable entry materialization, batch reserve/entry slices, and leaf-page/cache scratch allocations.
+   - Next issue should target safe reductions in copies/allocations while preserving geth `ethdb.Batch` ownership/replay semantics.
+
+2. **Zipper/leaf-page persist and leaf-log rewrite work is the next structural candidate, but needs raw-KV counters before layout changes.**
+   - Evidence: `zipper.Apply`/`mergeLeaf`/`mergeInternal` are about 18–20% cumulative CPU, leaf-page log append is about 15% cumulative CPU, and mutex profile points at `zipper.cachePersistedLeafPage`/`persistLeafPageData`.
+   - Existing ordered-root delta counters stay zero for this raw-KV path, so the next implementation issue should add raw-KV zipper counters first: leaf/internal merges, pages written, leaf-log bytes written, node loads, and cache lock hold/wait.
+
+3. **Command-WAL append is visible but not the first optimization target from this run.**
+   - Evidence: 3,629 write frames for 1M puts; command-WAL append/writev is about 6% cumulative CPU in the write profile. Syscall CPU is visible, but byte/sync/flush live counters are not yet sufficient.
+   - Do not change durability semantics from this evidence. If command-WAL work is revisited, add live bytes/sync/flush counters and acceptance gates first.
+
+4. **Value-log payload compression/defaults should not be changed from this run.**
+   - Evidence: value-log auto selected `off` for the hot-KV value payload frames (`1,821` frames, `179.2 MB` raw/stored), and value-log append/frame work is below allocation/copy and zipper groups.
+   - Leaf-log block compaction/compression is visible but not dominant enough to justify changing defaults without a targeted counter/profiling issue.
+
+## Recommendation
+
+Created child implementation issue [#2709](https://github.com/snissn/gomap/issues/2709) for **TreeDB geth-hot-KV write allocation/copy pressure**, with acceptance gates based on this run:
+
+- keep command-WAL durable semantics and read-integrity defaults unchanged;
+- preserve geth `ethdb.Batch` ownership, replay, repeated `Write`, `Reset`, and closed-batch behavior;
+- reduce write-phase `memstats_write_treedb.json` totals from the 1.37 GB / 3.18M malloc baseline;
+- reduce `cpu_write_treedb.pprof` flat/cumulative `runtime.memmove`, GC scan, `gethethdb.cloneBytes`, memtable clone/materialization, and batch entry allocation shares;
+- rerun the same 1M/400k command and include `cpu_write_top`, phase-local memstats, and `phase_stat_deltas.tsv` counters.
+
+A follow-up zipper issue should be counter-first unless allocation work is already exhausted: add raw-KV leaf/internal merge/page/byte/lock counters, then use those counters to choose a specific zipper/leaf-log optimization.

--- a/scripts/treedb_geth_hot_kv_matrix.sh
+++ b/scripts/treedb_geth_hot_kv_matrix.sh
@@ -227,12 +227,13 @@ PY
 done
 
 phase_counters_tsv="$run_dir/phase_counters.tsv"
+phase_stat_deltas_tsv="$run_dir/phase_stat_deltas.tsv"
 
-python3 - "$summary_tsv" "$summary_md" "$phase_counters_tsv" <<'PY'
+python3 - "$summary_tsv" "$summary_md" "$phase_counters_tsv" "$phase_stat_deltas_tsv" <<'PY'
 import csv, json, sys
 from collections import defaultdict
 
-tsv, md, phase_tsv = sys.argv[1:]
+tsv, md, phase_tsv, phase_stat_tsv = sys.argv[1:]
 rows = list(csv.DictReader(open(tsv), delimiter='\t'))
 json_cache = {}
 phases = ['write', 'read', 'iterate', 'delete_range', 'reopen_verify']
@@ -310,6 +311,27 @@ with open(phase_tsv, 'w', newline='') as f:
             *(vals[name] for name in stat_key_groups), r['json'],
         ])
 
+with open(phase_stat_tsv, 'w', newline='') as f:
+    writer = csv.writer(f, delimiter='\t')
+    writer.writerow([
+        'key_shape', 'value_shape', 'value_size', 'batch_target_bytes', 'treedb_read_integrity',
+        'iteration_mode', 'engine', 'run_read_integrity', 'phase', 'stat_key', 'delta', 'json'
+    ])
+    for r in rows:
+        run = run_for_row(r)
+        if not run:
+            continue
+        for phase in phases:
+            delta = (run.get('phases', {}).get(phase, {}).get('stat_delta') or {})
+            for key in sorted(delta):
+                value = delta[key]
+                if not value:
+                    continue
+                writer.writerow([
+                    r['key_shape'], r['value_shape'], r['value_size'], r['batch_target_bytes'], r['treedb_read_integrity'],
+                    r['iteration_mode'], r['engine'], r['read_integrity'], phase, key, value, r['json'],
+                ])
+
 with open(md, 'w') as out:
     out.write('# geth/Nitro hot KV matrix\n\n')
     out.write('Integrated node.OpenDatabase / ethdb benchmark. DeleteRange keys/sec counts affected keys/sec, not range calls/sec. Size bytes is loaded DB size before destructive DeleteRange; post-delete bytes is measured after close/reopen verification. TreeDB read-integrity labels identify checksum-verified runs and the explicitly unsafe checksum-disabled ceiling. Iteration mode labels distinguish value materialization from key-only traversal.\n\n')
@@ -364,7 +386,7 @@ with open(md, 'w') as out:
 
     if phase_rows:
         out.write('\n## TreeDB value-log read counters\n\n')
-        out.write('Per-phase deltas from TreeDB `Stat()` output. CRC counts are value-log record CRC32 computations; grouped counters reflect grouped-frame cache activity; mmap columns split hits, misses, and ReadAt fallback reads. Full machine-readable counters are in `phase_counters.tsv`.\n\n')
+        out.write('Per-phase deltas from TreeDB `Stat()` output. CRC counts are value-log record CRC32 computations; grouped counters reflect grouped-frame cache activity; mmap columns split hits, misses, and ReadAt fallback reads. Full machine-readable read counters are in `phase_counters.tsv`; all nonzero parseable TreeDB stat deltas are in `phase_stat_deltas.tsv`.\n\n')
         out.write('| key shape | value size | batch target bytes | read-integrity | iteration mode | engine | phase | crc32 checks | grouped hits | grouped misses | grouped stores | mmap hits | mmap miss OOR | mmap miss no-map | mmap miss dead-cap | mmap ReadAt fallback |\n')
         out.write('|---|---:|---:|---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|\n')
         for r, phase, vals in phase_rows:
@@ -380,4 +402,5 @@ echo "geth hot KV matrix complete"
 echo "  run dir:         $run_dir"
 echo "  tsv:             $summary_tsv"
 echo "  phase counters:  $phase_counters_tsv"
+echo "  stat deltas:     $phase_stat_deltas_tsv"
 echo "  report:          $summary_md"


### PR DESCRIPTION
## Summary

Closes #2706. Parent tracker: #2676. Follow-up implementation issue: #2709.

- adds `phase_stat_deltas.tsv` to the geth-hot-KV matrix output so existing TreeDB `Stat()` write-path counters are available as phase-local deltas;
- documents the new artifact in the hot-KV README;
- adds `docs/benchmarks/TREEDB_GETH_HOT_KV_WRITE_PROFILE_2026-06-13.md`, a post-A write profile/counter report with commands, commits, dataset shape, CPU top functions, phase-local memstats, counters, ranked bottlenecks, and next recommendation.

This PR is profiling/reporting only. It does not change command-WAL durability semantics, compression defaults, value-log layout, or TreeDB write behavior.

## Evidence / artifacts

Profile capture:

- gomap capture head: `866d4deb8df2eb7cd9bfaa67ebb8495ad83bedb0`
- go-ethereum head: `6371ea5ca7502c58ece5353b0425fb5ec99a41d8`
- profile matrix: `/tmp/geth_hotkv_write_matrix_20260613T075042Z`
- pprof dir: `/tmp/geth_hotkv_profiles_write_20260613T075042Z/01_geth-mixed_geth-mixed_v128_b102400_verify_value`
- no-pprof control: `/tmp/geth_hotkv_write_noprofile_20260613T075119Z`

Command shape is recorded in the report and manifests. Dataset: `KEYS=1000000 READS=400000 KEY_SHAPES=geth-mixed VALUE_SHAPES=geth-mixed VALUE_SIZES=128 BATCH_TARGET_BYTES=102400 TREEDB_READ_INTEGRITIES=verify ITERATION_MODES=value ENGINES=treedb`.

Key finding: write allocation/copy/GC pressure is the top proven write bottleneck (1.37 GB / 3.18M mallocs for 1M writes; `runtime.memmove`, GC scan/span work, and geth adapter/core copy paths dominate). #2709 tracks the recommended implementation follow-up.

## Tests

- `bash -n scripts/treedb_geth_hot_kv_matrix.sh`
- `GOFLAGS='-modfile=/tmp/geth_hotkv_gomap_2706_20260613T075042Z.mod -mod=mod' GETH_REPO=/Users/michaelseiler/dev/snissn/go-ethereum RUN_DIR=/tmp/geth_hotkv_smoke_postreport_20260613T075746Z ENGINES=treedb KEYS=1000 READS=300 KEY_SHAPES=geth-mixed VALUE_SHAPES=geth-mixed VALUE_SIZES=128 BATCH_TARGET_BYTES=102400 TREEDB_READ_INTEGRITIES=verify ITERATION_MODES=value scripts/treedb_geth_hot_kv_matrix.sh`
- `GOFLAGS='-modfile=/tmp/geth_hotkv_gomap_2706_20260613T075042Z.mod -mod=mod' GETH_REPO=/Users/michaelseiler/dev/snissn/go-ethereum RUN_DIR=/tmp/geth_hotkv_smoke_reviewfix_20260613T081328Z ENGINES=treedb KEYS=1000 READS=300 KEY_SHAPES=geth-mixed VALUE_SHAPES=geth-mixed VALUE_SIZES=128 BATCH_TARGET_BYTES=102400 TREEDB_READ_INTEGRITIES=verify ITERATION_MODES=value scripts/treedb_geth_hot_kv_matrix.sh`
- `(cd TreeDB/integration/gethethdb && go test ./... -count=1)`
- `go test ./TreeDB -run 'TestReopenVerify_WALOn|TestCommandWAL' -count=1`

Note: `go test ./TreeDB/integration/gethethdb -count=1` from the root fails because `TreeDB/integration/gethethdb` is a nested module; the package passes when tested from its module directory as shown above.

## Risks / caveats

- Single-run throughput is noisy; the report ranks bottlenecks from profiles/counters and avoids regression/default-change claims.
- `phase_stat_deltas.tsv` includes nonzero parseable stat deltas; some stats are gauges rather than cumulative counters, so the report only interprets selected counters.
- Command-WAL live frame counters are useful, but byte/sync/flush live counters need a separate instrumentation issue before any command-WAL behavior work.

## AI review status

- Codex: latest-head `29c54b7a66` review reported no major issues
- Copilot: requested on initial head and after review-fix push; no review surfaced
- CodeRabbit: initial nit fixed; latest-head status passed/skipped with no unresolved threads

