### PR TITLE
Instrument TreeDB DeleteRange counters for geth-hot-KV

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -7761,6 +7761,23 @@ type DB struct {
 	memtableMode                                      atomic.Uint32
 	memtableStats                                     memtableStats
 	rootDomainProbeStats                              rootDomainProbeStats
+	deleteRangeCalls                                  atomic.Uint64
+	deleteRangeBatchCalls                             atomic.Uint64
+	deleteRangeBatchWrites                            atomic.Uint64
+	deleteRangeInputRanges                            atomic.Uint64
+	deleteRangeEffectiveRanges                        atomic.Uint64
+	deleteRangeCoalescedRanges                        atomic.Uint64
+	deleteRangeIterators                              atomic.Uint64
+	deleteRangeBackendIterators                       atomic.Uint64
+	deleteRangeMemtableIterators                      atomic.Uint64
+	deleteRangeQueueIterators                         atomic.Uint64
+	deleteRangeVisitedKeys                            atomic.Uint64
+	deleteRangeTombstoneKeys                          atomic.Uint64
+	deleteRangeMaterializedKeys                       atomic.Uint64
+	deleteRangeMaterializedKeyBytes                   atomic.Uint64
+	deleteRangeFastPathClears                         atomic.Uint64
+	deleteRangeBackendDirectBatches                   atomic.Uint64
+	deleteRangeBackendDirectKeys                      atomic.Uint64
 	memtableAdaptive                                  bool
 	memtableAdaptiveObserve                           atomic.Bool
 	memtableAdaptiveBTreeMinIters                     uint64
@@ -22126,6 +22143,37 @@ func (db *DB) DeleteRangeAfterCommandWALAppend(start, end []byte, appendCommand 
 	return db.deleteRange(start, end, appendCommand)
 }
 
+func (db *DB) recordDeleteRangePlan(inputRanges, effectiveRanges int) {
+	if db == nil || inputRanges <= 0 {
+		return
+	}
+	db.deleteRangeInputRanges.Add(uint64(inputRanges))
+	if effectiveRanges > 0 {
+		db.deleteRangeEffectiveRanges.Add(uint64(effectiveRanges))
+	}
+	if inputRanges > effectiveRanges {
+		db.deleteRangeCoalescedRanges.Add(uint64(inputRanges - effectiveRanges))
+	}
+}
+
+func (db *DB) recordDeleteRangeKeys(visitedKeys, tombstoneKeys, materializedKeys, materializedKeyBytes uint64) {
+	if db == nil {
+		return
+	}
+	if visitedKeys > 0 {
+		db.deleteRangeVisitedKeys.Add(visitedKeys)
+	}
+	if tombstoneKeys > 0 {
+		db.deleteRangeTombstoneKeys.Add(tombstoneKeys)
+	}
+	if materializedKeys > 0 {
+		db.deleteRangeMaterializedKeys.Add(materializedKeys)
+	}
+	if materializedKeyBytes > 0 {
+		db.deleteRangeMaterializedKeyBytes.Add(materializedKeyBytes)
+	}
+}
+
 func (db *DB) deleteRange(start, end []byte, appendCommand func() error) (err error) {
 	if db == nil {
 		return nil
@@ -22133,6 +22181,8 @@ func (db *DB) deleteRange(start, end []byte, appendCommand func() error) (err er
 	if batch.IsDeleteRangeNoop(start, end) {
 		return nil
 	}
+	db.deleteRangeCalls.Add(1)
+	db.recordDeleteRangePlan(1, 1)
 	if appendCommand != nil && !db.disableJournal {
 		return fmt.Errorf("cachingdb: command wal range deletes require disabled cached redo log")
 	}
@@ -22166,6 +22216,8 @@ func (db *DB) deleteRange(start, end []byte, appendCommand func() error) (err er
 			return err
 		}
 		defer func() { _ = it.Close() }()
+		db.deleteRangeIterators.Add(1)
+		var visitedKeys, tombstoneKeys uint64
 
 		applyDelete := func(key []byte) error {
 			if maxMemtableBytesPerShard > 0 && int64(len(key)) > maxMemtableBytesPerShard {
@@ -22269,6 +22321,8 @@ func (db *DB) deleteRange(start, end []byte, appendCommand func() error) (err er
 			if err := applyDelete(key); err != nil {
 				return poisonApply(err)
 			}
+			visitedKeys++
+			tombstoneKeys++
 			deletedAny = true
 			it.Next()
 		}
@@ -22283,6 +22337,7 @@ func (db *DB) deleteRange(start, end []byte, appendCommand func() error) (err er
 			}
 		}
 
+		db.recordDeleteRangeKeys(visitedKeys, tombstoneKeys, 0, 0)
 		db.noteWrite()
 		db.maybeAssistFlush()
 		return nil
@@ -22310,6 +22365,9 @@ func (db *DB) deleteRange(start, end []byte, appendCommand func() error) (err er
 				return err
 			}
 			defer func() { _ = it.Close() }()
+			db.deleteRangeBackendIterators.Add(1)
+			db.deleteRangeBackendDirectBatches.Add(1)
+			var backendKeys uint64
 
 			b := db.backend.NewBatch()
 			defer func() { _ = b.Close() }()
@@ -22317,6 +22375,7 @@ func (db *DB) deleteRange(start, end []byte, appendCommand func() error) (err er
 				if err := b.Delete(it.Key()); err != nil {
 					return err
 				}
+				backendKeys++
 				it.Next()
 			}
 			if err := it.Error(); err != nil {
@@ -22324,6 +22383,10 @@ func (db *DB) deleteRange(start, end []byte, appendCommand func() error) (err er
 			}
 			if err := b.Write(); err != nil {
 				return err
+			}
+			db.recordDeleteRangeKeys(backendKeys, backendKeys, 0, 0)
+			if backendKeys > 0 {
+				db.deleteRangeBackendDirectKeys.Add(backendKeys)
 			}
 			// Best-effort: backend range can shrink; force recompute later.
 			db.mu.Lock()
@@ -22412,6 +22475,7 @@ func (db *DB) deleteRange(start, end []byte, appendCommand func() error) (err er
 				return err
 			}
 
+			db.deleteRangeFastPathClears.Add(1)
 			db.mu.Unlock()
 			db.flushMu.Unlock()
 			return nil
@@ -22486,6 +22550,10 @@ func (db *DB) deleteRange(start, end []byte, appendCommand func() error) (err er
 				return err
 			}
 			defer func() { _ = it.Close() }()
+			db.deleteRangeFastPathClears.Add(1)
+			db.deleteRangeBackendIterators.Add(1)
+			db.deleteRangeBackendDirectBatches.Add(1)
+			var backendKeys uint64
 
 			b := db.backend.NewBatch()
 			defer func() { _ = b.Close() }()
@@ -22494,6 +22562,7 @@ func (db *DB) deleteRange(start, end []byte, appendCommand func() error) (err er
 				if err := b.Delete(it.Key()); err != nil {
 					return err
 				}
+				backendKeys++
 				it.Next()
 			}
 			if err := it.Error(); err != nil {
@@ -22501,6 +22570,10 @@ func (db *DB) deleteRange(start, end []byte, appendCommand func() error) (err er
 			}
 			if err := b.Write(); err != nil {
 				return err
+			}
+			db.recordDeleteRangeKeys(backendKeys, backendKeys, 0, 0)
+			if backendKeys > 0 {
+				db.deleteRangeBackendDirectKeys.Add(backendKeys)
 			}
 
 			// Best-effort: backend range can shrink; force recompute later.
@@ -22617,9 +22690,11 @@ func (db *DB) deleteRange(start, end []byte, appendCommand func() error) (err er
 		db.mu.Unlock()
 
 		var (
-			backendIter  iterator.UnsafeIterator
-			queueIters   []iterator.UnsafeIterator
-			mutableIters []iterator.UnsafeIterator
+			backendIter   iterator.UnsafeIterator
+			queueIters    []iterator.UnsafeIterator
+			mutableIters  []iterator.UnsafeIterator
+			visitedKeys   uint64
+			tombstoneKeys uint64
 		)
 
 		if overlapsQuery(start, end, backendRange) {
@@ -22628,6 +22703,7 @@ func (db *DB) deleteRange(start, end []byte, appendCommand func() error) (err er
 				return err
 			}
 			backendIter = it
+			db.deleteRangeBackendIterators.Add(1)
 			defer func() { _ = backendIter.Close() }()
 		}
 
@@ -22642,6 +22718,7 @@ func (db *DB) deleteRange(start, end []byte, appendCommand func() error) (err er
 				it := mem.NewIterator(start, end)
 				it.Seek(start)
 				mutableIters = append(mutableIters, it)
+				db.deleteRangeMemtableIterators.Add(1)
 				defer func(it iterator.UnsafeIterator) { _ = it.Close() }(it)
 			}
 		}
@@ -22653,6 +22730,7 @@ func (db *DB) deleteRange(start, end []byte, appendCommand func() error) (err er
 			it := mem.NewIterator(start, end)
 			it.Seek(start)
 			queueIters = append(queueIters, it)
+			db.deleteRangeQueueIterators.Add(1)
 			defer func(it iterator.UnsafeIterator) { _ = it.Close() }(it)
 		}
 
@@ -22686,6 +22764,8 @@ func (db *DB) deleteRange(start, end []byte, appendCommand func() error) (err er
 						db.mu.Unlock()
 						return err
 					}
+					visitedKeys++
+					tombstoneKeys++
 				}
 				it.Next()
 			}
@@ -22701,6 +22781,8 @@ func (db *DB) deleteRange(start, end []byte, appendCommand func() error) (err er
 					db.mu.Unlock()
 					return err
 				}
+				visitedKeys++
+				tombstoneKeys++
 				backendIter.Next()
 			}
 			if err := backendIter.Error(); err != nil {
@@ -22716,6 +22798,8 @@ func (db *DB) deleteRange(start, end []byte, appendCommand func() error) (err er
 						db.mu.Unlock()
 						return err
 					}
+					visitedKeys++
+					tombstoneKeys++
 				}
 				it.Next()
 			}
@@ -22724,6 +22808,7 @@ func (db *DB) deleteRange(start, end []byte, appendCommand func() error) (err er
 				return err
 			}
 		}
+		db.recordDeleteRangeKeys(visitedKeys, tombstoneKeys, 0, 0)
 		db.mu.Unlock()
 
 		db.noteWrite()
@@ -22737,6 +22822,8 @@ func (db *DB) deleteRange(start, end []byte, appendCommand func() error) (err er
 		return err
 	}
 	defer func() { _ = it.Close() }()
+	db.deleteRangeIterators.Add(1)
+	var visitedKeys, tombstoneKeys uint64
 
 	b := db.NewBatch()
 	defer b.Close()
@@ -22744,11 +22831,14 @@ func (db *DB) deleteRange(start, end []byte, appendCommand func() error) (err er
 		if err := b.Delete(it.Key()); err != nil {
 			return err
 		}
+		visitedKeys++
+		tombstoneKeys++
 		it.Next()
 	}
 	if err := it.Error(); err != nil {
 		return err
 	}
+	db.recordDeleteRangeKeys(visitedKeys, tombstoneKeys, 0, 0)
 	return b.Write()
 }
 
@@ -26491,6 +26581,28 @@ func (db *DB) Stats() map[string]string {
 	}
 
 	stats["treedb.cache.queue_len"] = fmt.Sprintf("%d", queueLen)
+	deleteRangeSnapshotIterators := db.deleteRangeIterators.Load()
+	deleteRangeBackendIterators := db.deleteRangeBackendIterators.Load()
+	deleteRangeMemtableIterators := db.deleteRangeMemtableIterators.Load()
+	deleteRangeQueueIterators := db.deleteRangeQueueIterators.Load()
+	stats["treedb.cache.delete_range.calls_total"] = fmt.Sprintf("%d", db.deleteRangeCalls.Load())
+	stats["treedb.cache.delete_range.batch_calls_total"] = fmt.Sprintf("%d", db.deleteRangeBatchCalls.Load())
+	stats["treedb.cache.delete_range.batch_writes_total"] = fmt.Sprintf("%d", db.deleteRangeBatchWrites.Load())
+	stats["treedb.cache.delete_range.input_ranges_total"] = fmt.Sprintf("%d", db.deleteRangeInputRanges.Load())
+	stats["treedb.cache.delete_range.effective_ranges_total"] = fmt.Sprintf("%d", db.deleteRangeEffectiveRanges.Load())
+	stats["treedb.cache.delete_range.coalesced_ranges_total"] = fmt.Sprintf("%d", db.deleteRangeCoalescedRanges.Load())
+	stats["treedb.cache.delete_range.iterators_total"] = fmt.Sprintf("%d", deleteRangeSnapshotIterators+deleteRangeBackendIterators+deleteRangeMemtableIterators+deleteRangeQueueIterators)
+	stats["treedb.cache.delete_range.snapshot_iterators_total"] = fmt.Sprintf("%d", deleteRangeSnapshotIterators)
+	stats["treedb.cache.delete_range.backend_iterators_total"] = fmt.Sprintf("%d", deleteRangeBackendIterators)
+	stats["treedb.cache.delete_range.memtable_iterators_total"] = fmt.Sprintf("%d", deleteRangeMemtableIterators)
+	stats["treedb.cache.delete_range.queue_iterators_total"] = fmt.Sprintf("%d", deleteRangeQueueIterators)
+	stats["treedb.cache.delete_range.visited_keys_total"] = fmt.Sprintf("%d", db.deleteRangeVisitedKeys.Load())
+	stats["treedb.cache.delete_range.tombstone_keys_total"] = fmt.Sprintf("%d", db.deleteRangeTombstoneKeys.Load())
+	stats["treedb.cache.delete_range.materialized_keys_total"] = fmt.Sprintf("%d", db.deleteRangeMaterializedKeys.Load())
+	stats["treedb.cache.delete_range.materialized_key_bytes_total"] = fmt.Sprintf("%d", db.deleteRangeMaterializedKeyBytes.Load())
+	stats["treedb.cache.delete_range.fast_path_clears_total"] = fmt.Sprintf("%d", db.deleteRangeFastPathClears.Load())
+	stats["treedb.cache.delete_range.backend_direct_batches_total"] = fmt.Sprintf("%d", db.deleteRangeBackendDirectBatches.Load())
+	stats["treedb.cache.delete_range.backend_direct_keys_total"] = fmt.Sprintf("%d", db.deleteRangeBackendDirectKeys.Load())
 	stats["treedb.cache.mutable_bytes"] = fmt.Sprintf("%d", db.mutableBytes.Load())
 	stats["treedb.cache.flush_threshold_bytes"] = fmt.Sprintf("%d", flushThreshold)
 	stats["treedb.cache.mutable_flush_threshold_base_bytes"] = fmt.Sprintf("%d", mutableThresholdBase)
@@ -30103,6 +30215,9 @@ func (b *Batch) DeleteRange(start, end []byte) error {
 	if batch.IsDeleteRangeNoop(start, end) {
 		return nil
 	}
+	if b.db != nil {
+		b.db.deleteRangeBatchCalls.Add(1)
+	}
 	var startCopy, endCopy []byte
 	if start != nil {
 		startCopy = b.cloneKey(start)
@@ -30114,6 +30229,9 @@ func (b *Batch) DeleteRange(start, end []byte) error {
 		single := [1]batch.Entry{{Type: batch.OpDeleteRange, Key: startCopy, Value: endCopy}}
 		if err := b.backend.SetOps(single[:]); err != nil {
 			return err
+		}
+		if b.db != nil {
+			b.db.recordDeleteRangePlan(1, 1)
 		}
 		b.size += len(startCopy) + len(endCopy)
 		return nil
@@ -30498,7 +30616,15 @@ func (b *Batch) writeRangeBatch(sync bool) error {
 	if !b.hasDeleteRanges {
 		return b.write(sync)
 	}
+	inputRanges := 0
+	for _, entry := range b.entries {
+		if entry.Type == batch.OpDeleteRange && !batch.IsDeleteRangeNoop(entry.Key, entry.Value) {
+			inputRanges++
+		}
+	}
 	points, ranges := batch.BuildApplyPlanFromEntries(b.entries, true)
+	b.db.deleteRangeBatchWrites.Add(1)
+	b.db.recordDeleteRangePlan(inputRanges, len(ranges))
 	if len(points) == 0 && len(ranges) == 0 {
 		b.updateBatchEntryHint()
 		b.updateBatchCopyHint()
@@ -30522,6 +30648,10 @@ func (b *Batch) writeRangeBatch(sync bool) error {
 
 	materialized := make([]batch.Entry, 0, len(points))
 	deleteKeyBytes := 0
+	var visitedKeys, materializedKeys, materializedKeyBytes uint64
+	if len(ranges) > 0 {
+		b.db.deleteRangeIterators.Add(uint64(len(ranges)))
+	}
 	for _, r := range ranges {
 		it, err := b.db.Iterator(r.Start, r.End)
 		if err != nil {
@@ -30529,6 +30659,7 @@ func (b *Batch) writeRangeBatch(sync bool) error {
 		}
 		for it.Valid() {
 			key := it.Key()
+			visitedKeys++
 			if cachedBatchDeleteRangeMaterializeMaxEntries >= 0 && len(materialized) >= cachedBatchDeleteRangeMaterializeMaxEntries {
 				_ = it.Close()
 				return fmt.Errorf("%w: keys=%d limit=%d", ErrBatchDeleteRangeTooLarge, len(materialized)+1, cachedBatchDeleteRangeMaterializeMaxEntries)
@@ -30539,6 +30670,8 @@ func (b *Batch) writeRangeBatch(sync bool) error {
 				return fmt.Errorf("%w: key_bytes=%d limit=%d", ErrBatchDeleteRangeTooLarge, deleteKeyBytes, cachedBatchDeleteRangeMaterializeMaxKeyBytes)
 			}
 			materialized = append(materialized, batch.Entry{Type: batch.OpDelete, Key: append([]byte(nil), key...)})
+			materializedKeys++
+			materializedKeyBytes += uint64(len(key))
 			it.Next()
 		}
 		if err := it.Error(); err != nil {
@@ -30549,6 +30682,7 @@ func (b *Batch) writeRangeBatch(sync bool) error {
 			return err
 		}
 	}
+	b.db.recordDeleteRangeKeys(visitedKeys, materializedKeys, materializedKeys, materializedKeyBytes)
 	materialized = append(materialized, points...)
 
 	origEntries := b.entries

--- a/TreeDB/caching/delete_range_stats_test.go
+++ b/TreeDB/caching/delete_range_stats_test.go
@@ -1,0 +1,119 @@
+package caching
+
+import (
+	"strconv"
+	"testing"
+)
+
+func deleteRangeStatUint64(t *testing.T, stats map[string]string, key string) uint64 {
+	t.Helper()
+	raw, ok := stats[key]
+	if !ok {
+		t.Fatalf("stats missing %s", key)
+	}
+	got, err := strconv.ParseUint(raw, 10, 64)
+	if err != nil {
+		t.Fatalf("stats[%s]=%q parse: %v", key, raw, err)
+	}
+	return got
+}
+
+func TestCachingDBDeleteRangeStatsCountsVisitedTombstones(t *testing.T) {
+	db, err := Open(t.TempDir(), NewMockBackend(), Options{FlushThreshold: 1 << 20, JournalLanes: 1})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	for _, key := range []string{"a", "b", "c", "z"} {
+		if err := db.Set([]byte(key), []byte("v")); err != nil {
+			t.Fatalf("Set(%s): %v", key, err)
+		}
+	}
+	if err := db.DeleteRange([]byte("a"), []byte("d")); err != nil {
+		t.Fatalf("DeleteRange: %v", err)
+	}
+
+	stats := db.Stats()
+	if got := deleteRangeStatUint64(t, stats, "treedb.cache.delete_range.calls_total"); got != 1 {
+		t.Fatalf("calls_total=%d want 1", got)
+	}
+	if got := deleteRangeStatUint64(t, stats, "treedb.cache.delete_range.input_ranges_total"); got != 1 {
+		t.Fatalf("input_ranges_total=%d want 1", got)
+	}
+	if got := deleteRangeStatUint64(t, stats, "treedb.cache.delete_range.effective_ranges_total"); got != 1 {
+		t.Fatalf("effective_ranges_total=%d want 1", got)
+	}
+	if got := deleteRangeStatUint64(t, stats, "treedb.cache.delete_range.visited_keys_total"); got != 3 {
+		t.Fatalf("visited_keys_total=%d want 3", got)
+	}
+	if got := deleteRangeStatUint64(t, stats, "treedb.cache.delete_range.tombstone_keys_total"); got != 3 {
+		t.Fatalf("tombstone_keys_total=%d want 3", got)
+	}
+	if got := deleteRangeStatUint64(t, stats, "treedb.cache.delete_range.iterators_total"); got != 1 {
+		t.Fatalf("iterators_total=%d want 1", got)
+	}
+}
+
+func TestCachingBatchDeleteRangeStatsCoalescingAndMaterialization(t *testing.T) {
+	backend := NewMockBackend()
+	for _, key := range []string{"a", "b", "c", "d"} {
+		backend.Set([]byte(key), []byte("v"))
+	}
+	db, err := Open(t.TempDir(), backend, Options{FlushThreshold: 1 << 20, JournalLanes: 1})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	b := db.NewBatch()
+	defer b.Close()
+	for _, bounds := range []struct{ start, end string }{
+		{"a", "c"}, // [a,c)
+		{"c", "e"}, // adjacent, union [a,e)
+		{"b", "d"}, // overlap inside union
+		{"a", "c"}, // duplicate range
+	} {
+		if err := b.DeleteRange([]byte(bounds.start), []byte(bounds.end)); err != nil {
+			t.Fatalf("DeleteRange(%s,%s): %v", bounds.start, bounds.end, err)
+		}
+	}
+	if err := b.Write(); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	stats := db.Stats()
+	if got := deleteRangeStatUint64(t, stats, "treedb.cache.delete_range.batch_calls_total"); got != 4 {
+		t.Fatalf("batch_calls_total=%d want 4", got)
+	}
+	if got := deleteRangeStatUint64(t, stats, "treedb.cache.delete_range.batch_writes_total"); got != 1 {
+		t.Fatalf("batch_writes_total=%d want 1", got)
+	}
+	if got := deleteRangeStatUint64(t, stats, "treedb.cache.delete_range.input_ranges_total"); got != 4 {
+		t.Fatalf("input_ranges_total=%d want 4", got)
+	}
+	if got := deleteRangeStatUint64(t, stats, "treedb.cache.delete_range.effective_ranges_total"); got != 1 {
+		t.Fatalf("effective_ranges_total=%d want 1", got)
+	}
+	if got := deleteRangeStatUint64(t, stats, "treedb.cache.delete_range.coalesced_ranges_total"); got != 3 {
+		t.Fatalf("coalesced_ranges_total=%d want 3", got)
+	}
+	if got := deleteRangeStatUint64(t, stats, "treedb.cache.delete_range.visited_keys_total"); got != 4 {
+		t.Fatalf("visited_keys_total=%d want 4", got)
+	}
+	if got := deleteRangeStatUint64(t, stats, "treedb.cache.delete_range.materialized_keys_total"); got != 4 {
+		t.Fatalf("materialized_keys_total=%d want 4", got)
+	}
+	if got := deleteRangeStatUint64(t, stats, "treedb.cache.delete_range.materialized_key_bytes_total"); got != 4 {
+		t.Fatalf("materialized_key_bytes_total=%d want 4", got)
+	}
+	if got := deleteRangeStatUint64(t, stats, "treedb.cache.delete_range.tombstone_keys_total"); got != 4 {
+		t.Fatalf("tombstone_keys_total=%d want 4", got)
+	}
+	if got := deleteRangeStatUint64(t, stats, "treedb.cache.delete_range.snapshot_iterators_total"); got != 1 {
+		t.Fatalf("snapshot_iterators_total=%d want 1", got)
+	}
+	if got := deleteRangeStatUint64(t, stats, "treedb.cache.delete_range.iterators_total"); got != 1 {
+		t.Fatalf("iterators_total=%d want 1", got)
+	}
+}

--- a/TreeDB/delete_range_2704_test.go
+++ b/TreeDB/delete_range_2704_test.go
@@ -1,0 +1,126 @@
+package treedb
+
+import (
+	"strconv"
+	"testing"
+)
+
+func issue2704StatUint64(t *testing.T, stats map[string]string, key string) uint64 {
+	t.Helper()
+	raw, ok := stats[key]
+	if !ok {
+		t.Fatalf("stats missing %s", key)
+	}
+	got, err := strconv.ParseUint(raw, 10, 64)
+	if err != nil {
+		t.Fatalf("stats[%s]=%q parse: %v", key, raw, err)
+	}
+	return got
+}
+
+func TestDeleteRangeIssue2704BatchBoundsCoalescingValueLogPointersReopen(t *testing.T) {
+	dir := t.TempDir()
+	opts := Options{
+		Dir:                          dir,
+		Durability:                   DurabilityWALOnRelaxed,
+		CommandWAL:                   true,
+		CommandWALStatsScan:          true,
+		DisableSideStores:            true,
+		BackgroundCheckpointInterval: -1,
+	}
+	opts.ValueLog.PointerThreshold = 1
+	opts.ValueLog.ForcePointers = true
+	db, err := Open(opts)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+
+	seed := map[string]string{
+		"":  "empty-pointer-value",
+		"a": "left-pointer-value",
+		"b": "delete-b-pointer-value",
+		"c": "delete-c-pointer-value",
+		"d": "replace-d-pointer-value",
+		"e": "delete-e-pointer-value",
+		"z": "right-pointer-value",
+	}
+	for key, value := range seed {
+		if err := db.Set([]byte(key), []byte(value)); err != nil {
+			_ = db.Close()
+			t.Fatalf("Set(%q): %v", key, err)
+		}
+	}
+
+	b := db.NewBatch()
+	if err := b.DeleteRange(nil, []byte{}); err != nil { // empty lower-unbounded range: no-op
+		_ = b.Close()
+		_ = db.Close()
+		t.Fatalf("empty DeleteRange: %v", err)
+	}
+	for _, bounds := range []struct{ start, end string }{
+		{"b", "d"}, // initial range
+		{"d", "e"}, // adjacent to the previous range
+		{"c", "z"}, // overlapping extension
+		{"b", "d"}, // duplicate inside the union
+	} {
+		if err := b.DeleteRange([]byte(bounds.start), []byte(bounds.end)); err != nil {
+			_ = b.Close()
+			_ = db.Close()
+			t.Fatalf("DeleteRange(%s,%s): %v", bounds.start, bounds.end, err)
+		}
+	}
+	if err := b.Set([]byte("d"), []byte("after-range-pointer-value")); err != nil {
+		_ = b.Close()
+		_ = db.Close()
+		t.Fatalf("Set(d after range): %v", err)
+	}
+	if err := b.WriteSync(); err != nil {
+		_ = b.Close()
+		_ = db.Close()
+		t.Fatalf("WriteSync: %v", err)
+	}
+	_ = b.Close()
+
+	stats := db.Stats()
+	if got := issue2704StatUint64(t, stats, "treedb.cache.delete_range.batch_calls_total"); got != 4 {
+		_ = db.Close()
+		t.Fatalf("batch_calls_total=%d want 4", got)
+	}
+	if got := issue2704StatUint64(t, stats, "treedb.cache.delete_range.input_ranges_total"); got != 4 {
+		_ = db.Close()
+		t.Fatalf("input_ranges_total=%d want 4", got)
+	}
+	if got := issue2704StatUint64(t, stats, "treedb.cache.delete_range.effective_ranges_total"); got != 1 {
+		_ = db.Close()
+		t.Fatalf("effective_ranges_total=%d want 1", got)
+	}
+	if got := issue2704StatUint64(t, stats, "treedb.cache.delete_range.coalesced_ranges_total"); got != 3 {
+		_ = db.Close()
+		t.Fatalf("coalesced_ranges_total=%d want 3", got)
+	}
+
+	if err := db.Checkpoint(); err != nil {
+		_ = db.Close()
+		t.Fatalf("Checkpoint: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	reopen, err := Open(Options{Dir: dir, CommandWALStatsScan: true, DisableSideStores: true, BackgroundCheckpointInterval: -1})
+	if err != nil {
+		t.Fatalf("Reopen: %v", err)
+	}
+	defer func() { _ = reopen.Close() }()
+
+	requireRawKVValue(t, reopen, []byte{}, []byte("empty-pointer-value"))
+	requireRawKVValue(t, reopen, []byte("a"), []byte("left-pointer-value"))
+	requireRawKVValue(t, reopen, []byte("d"), []byte("after-range-pointer-value"))
+	requireRawKVValue(t, reopen, []byte("z"), []byte("right-pointer-value"))
+	for _, key := range []string{"b", "c", "e"} {
+		has, err := reopen.Has([]byte(key))
+		if err != nil || has {
+			t.Fatalf("Has(%s)=(%t,%v), want false,nil after reopen", key, has, err)
+		}
+	}
+}

--- a/benchmarks/geth_hot_kv/harness_test.go
+++ b/benchmarks/geth_hot_kv/harness_test.go
@@ -53,6 +53,7 @@ func TestHarnessExposesReadIntegrityIterationAndCounterLabels(t *testing.T) {
 		"treedb.cache.delete_range.batch_calls_total",
 		"treedb.cache.delete_range.coalesced_ranges_total",
 		"treedb.cache.delete_range.materialized_keys_total",
+		"treedb.cache.delete_range.backend_direct_batches_total",
 	} {
 		if !strings.Contains(src, want) {
 			t.Fatalf("harness missing instrumentation label %q", want)

--- a/benchmarks/geth_hot_kv/harness_test.go
+++ b/benchmarks/geth_hot_kv/harness_test.go
@@ -55,6 +55,8 @@ func TestHarnessExposesReadIntegrityIterationAndCounterLabels(t *testing.T) {
 		"treedb.cache.delete_range.snapshot_iterators_total",
 		"treedb.cache.delete_range.materialized_keys_total",
 		"treedb.cache.delete_range.backend_direct_batches_total",
+		"if hasReadCounterDeltas(runs) {",
+		"if !hasDeleteRangeCounterDeltas(runs) {",
 	} {
 		if !strings.Contains(src, want) {
 			t.Fatalf("harness missing instrumentation label %q", want)

--- a/benchmarks/geth_hot_kv/harness_test.go
+++ b/benchmarks/geth_hot_kv/harness_test.go
@@ -49,6 +49,10 @@ func TestHarnessExposesReadIntegrityIterationAndCounterLabels(t *testing.T) {
 		"treedb.vlog.mmap_read.miss_out_of_range",
 		"treedb.vlog.mmap_read.miss_no_mapping",
 		"treedb.vlog.mmap_read.miss_dead_mapping_cap",
+		"treedb.cache.delete_range.calls_total",
+		"treedb.cache.delete_range.batch_calls_total",
+		"treedb.cache.delete_range.coalesced_ranges_total",
+		"treedb.cache.delete_range.materialized_keys_total",
 	} {
 		if !strings.Contains(src, want) {
 			t.Fatalf("harness missing instrumentation label %q", want)

--- a/benchmarks/geth_hot_kv/testdata/treedb_nitro_soak.go
+++ b/benchmarks/geth_hot_kv/testdata/treedb_nitro_soak.go
@@ -790,6 +790,24 @@ var interestingStatKeys = []string{
 	"treedb.cache.vlog_mmap.read.miss_no_mapping",
 	"treedb.cache.vlog_mmap.read.miss_dead_mapping_cap",
 	"treedb.cache.vlog_mmap.read.fallback_readat",
+	"treedb.cache.delete_range.calls_total",
+	"treedb.cache.delete_range.batch_calls_total",
+	"treedb.cache.delete_range.batch_writes_total",
+	"treedb.cache.delete_range.input_ranges_total",
+	"treedb.cache.delete_range.effective_ranges_total",
+	"treedb.cache.delete_range.coalesced_ranges_total",
+	"treedb.cache.delete_range.iterators_total",
+	"treedb.cache.delete_range.snapshot_iterators_total",
+	"treedb.cache.delete_range.backend_iterators_total",
+	"treedb.cache.delete_range.memtable_iterators_total",
+	"treedb.cache.delete_range.queue_iterators_total",
+	"treedb.cache.delete_range.visited_keys_total",
+	"treedb.cache.delete_range.tombstone_keys_total",
+	"treedb.cache.delete_range.materialized_keys_total",
+	"treedb.cache.delete_range.materialized_key_bytes_total",
+	"treedb.cache.delete_range.fast_path_clears_total",
+	"treedb.cache.delete_range.backend_direct_batches_total",
+	"treedb.cache.delete_range.backend_direct_keys_total",
 }
 
 func timeDBPhase(profiler phaseProfiler, db ethdb.Database, phase string, fn func() (int, error)) (phaseResult, error) {
@@ -995,6 +1013,53 @@ func writeStatDeltaSummary(sb *strings.Builder, runs []runResult) {
 			)
 		}
 	}
+
+	sb.WriteString("\n## TreeDB DeleteRange counters\n\n")
+	sb.WriteString("Per-phase DeleteRange deltas from TreeDB `Stat()` output. `input ranges` counts submitted non-empty ranges; `effective ranges` counts ranges after exact adjacent/overlap coalescing in the write plan; materialized keys are copied into point tombstones by the cached fallback.\n\n")
+	sb.WriteString("| engine | read integrity | iteration mode | phase | db calls | batch calls | batch writes | input ranges | effective ranges | coalesced ranges | visited keys | materialized keys | materialized key bytes | tombstone keys | iterators | backend iters | memtable iters | queue iters | fast clears | backend direct keys |\n")
+	sb.WriteString("|---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|\n")
+	for _, run := range runs {
+		for _, phase := range []string{phaseWrite, phaseRead, phaseIterate, phaseDeleteRange, phaseReopen} {
+			result, ok := run.Phases[phase]
+			if !ok || len(result.StatDelta) == 0 {
+				continue
+			}
+			if !hasAnyStatDeltaValue(result.StatDelta,
+				"treedb.cache.delete_range.calls_total",
+				"treedb.cache.delete_range.batch_calls_total",
+				"treedb.cache.delete_range.batch_writes_total",
+				"treedb.cache.delete_range.input_ranges_total",
+				"treedb.cache.delete_range.effective_ranges_total",
+				"treedb.cache.delete_range.coalesced_ranges_total",
+				"treedb.cache.delete_range.visited_keys_total",
+				"treedb.cache.delete_range.materialized_keys_total",
+				"treedb.cache.delete_range.tombstone_keys_total") {
+				continue
+			}
+			fmt.Fprintf(sb, "| %s | %s | %s | %s | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d |\n",
+				run.Engine,
+				run.ReadIntegrity,
+				run.IterationMode,
+				phase,
+				statDeltaValue(result.StatDelta, "treedb.cache.delete_range.calls_total"),
+				statDeltaValue(result.StatDelta, "treedb.cache.delete_range.batch_calls_total"),
+				statDeltaValue(result.StatDelta, "treedb.cache.delete_range.batch_writes_total"),
+				statDeltaValue(result.StatDelta, "treedb.cache.delete_range.input_ranges_total"),
+				statDeltaValue(result.StatDelta, "treedb.cache.delete_range.effective_ranges_total"),
+				statDeltaValue(result.StatDelta, "treedb.cache.delete_range.coalesced_ranges_total"),
+				statDeltaValue(result.StatDelta, "treedb.cache.delete_range.visited_keys_total"),
+				statDeltaValue(result.StatDelta, "treedb.cache.delete_range.materialized_keys_total"),
+				statDeltaValue(result.StatDelta, "treedb.cache.delete_range.materialized_key_bytes_total"),
+				statDeltaValue(result.StatDelta, "treedb.cache.delete_range.tombstone_keys_total"),
+				statDeltaValue(result.StatDelta, "treedb.cache.delete_range.iterators_total"),
+				statDeltaValue(result.StatDelta, "treedb.cache.delete_range.backend_iterators_total"),
+				statDeltaValue(result.StatDelta, "treedb.cache.delete_range.memtable_iterators_total"),
+				statDeltaValue(result.StatDelta, "treedb.cache.delete_range.queue_iterators_total"),
+				statDeltaValue(result.StatDelta, "treedb.cache.delete_range.fast_path_clears_total"),
+				statDeltaValue(result.StatDelta, "treedb.cache.delete_range.backend_direct_keys_total"),
+			)
+		}
+	}
 }
 
 func hasStatDeltas(runs []runResult) bool {
@@ -1015,6 +1080,15 @@ func statDeltaValue(delta map[string]int64, keys ...string) int64 {
 		}
 	}
 	return 0
+}
+
+func hasAnyStatDeltaValue(delta map[string]int64, keys ...string) bool {
+	for _, key := range keys {
+		if value, ok := delta[key]; ok && value != 0 {
+			return true
+		}
+	}
+	return false
 }
 
 func perSec(ops int, d time.Duration) float64 {

--- a/benchmarks/geth_hot_kv/testdata/treedb_nitro_soak.go
+++ b/benchmarks/geth_hot_kv/testdata/treedb_nitro_soak.go
@@ -996,6 +996,18 @@ func writeStatDeltaSummary(sb *strings.Builder, runs []runResult) {
 			if !ok || len(result.StatDelta) == 0 {
 				continue
 			}
+			if !hasAnyStatDeltaValue(result.StatDelta,
+				"treedb.vlog.read.crc32_checks_total", "treedb.cache.vlog_read.crc32_checks_total",
+				"treedb.vlog.grouped_frame_cache.hits", "treedb.cache.vlog_grouped_frame_cache.hits",
+				"treedb.vlog.grouped_frame_cache.misses", "treedb.cache.vlog_grouped_frame_cache.misses",
+				"treedb.vlog.grouped_frame_cache.stores", "treedb.cache.vlog_grouped_frame_cache.stores",
+				"treedb.vlog.mmap_read.hits", "treedb.cache.vlog_mmap.read.hits",
+				"treedb.vlog.mmap_read.miss_out_of_range", "treedb.cache.vlog_mmap.read.miss_out_of_range",
+				"treedb.vlog.mmap_read.miss_no_mapping", "treedb.cache.vlog_mmap.read.miss_no_mapping",
+				"treedb.vlog.mmap_read.miss_dead_mapping_cap", "treedb.cache.vlog_mmap.read.miss_dead_mapping_cap",
+				"treedb.vlog.mmap_read.fallback_readat", "treedb.cache.vlog_mmap.read.fallback_readat") {
+				continue
+			}
 			fmt.Fprintf(sb, "| %s | %s | %s | %s | %d | %d | %d | %d | %d | %d | %d | %d | %d |\n",
 				run.Engine,
 				run.ReadIntegrity,
@@ -1016,8 +1028,8 @@ func writeStatDeltaSummary(sb *strings.Builder, runs []runResult) {
 
 	sb.WriteString("\n## TreeDB DeleteRange counters\n\n")
 	sb.WriteString("Per-phase DeleteRange deltas from TreeDB `Stat()` output. `input ranges` counts submitted non-empty ranges; `effective ranges` counts ranges after exact adjacent/overlap coalescing in the write plan; materialized keys are copied into point tombstones by the cached fallback.\n\n")
-	sb.WriteString("| engine | read integrity | iteration mode | phase | db calls | batch calls | batch writes | input ranges | effective ranges | coalesced ranges | visited keys | materialized keys | materialized key bytes | tombstone keys | iterators | backend iters | memtable iters | queue iters | fast clears | backend direct keys |\n")
-	sb.WriteString("|---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|\n")
+	sb.WriteString("| engine | read integrity | iteration mode | phase | db calls | batch calls | batch writes | input ranges | effective ranges | coalesced ranges | visited keys | materialized keys | materialized key bytes | tombstone keys | iterators | backend iters | memtable iters | queue iters | fast clears | backend direct batches | backend direct keys |\n")
+	sb.WriteString("|---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|\n")
 	for _, run := range runs {
 		for _, phase := range []string{phaseWrite, phaseRead, phaseIterate, phaseDeleteRange, phaseReopen} {
 			result, ok := run.Phases[phase]
@@ -1036,7 +1048,7 @@ func writeStatDeltaSummary(sb *strings.Builder, runs []runResult) {
 				"treedb.cache.delete_range.tombstone_keys_total") {
 				continue
 			}
-			fmt.Fprintf(sb, "| %s | %s | %s | %s | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d |\n",
+			fmt.Fprintf(sb, "| %s | %s | %s | %s | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d |\n",
 				run.Engine,
 				run.ReadIntegrity,
 				run.IterationMode,
@@ -1056,6 +1068,7 @@ func writeStatDeltaSummary(sb *strings.Builder, runs []runResult) {
 				statDeltaValue(result.StatDelta, "treedb.cache.delete_range.memtable_iterators_total"),
 				statDeltaValue(result.StatDelta, "treedb.cache.delete_range.queue_iterators_total"),
 				statDeltaValue(result.StatDelta, "treedb.cache.delete_range.fast_path_clears_total"),
+				statDeltaValue(result.StatDelta, "treedb.cache.delete_range.backend_direct_batches_total"),
 				statDeltaValue(result.StatDelta, "treedb.cache.delete_range.backend_direct_keys_total"),
 			)
 		}

--- a/benchmarks/geth_hot_kv/testdata/treedb_nitro_soak.go
+++ b/benchmarks/geth_hot_kv/testdata/treedb_nitro_soak.go
@@ -1022,41 +1022,43 @@ func renderSummary(out output) string {
 }
 
 func writeStatDeltaSummary(sb *strings.Builder, runs []runResult) {
-	if !hasReadCounterDeltas(runs) {
-		return
-	}
-	sb.WriteString("\n## TreeDB value-log read counters\n\n")
-	sb.WriteString("Per-phase deltas from TreeDB `Stat()` output. CRC counts are value-log record CRC32 computations performed by the read path; grouped-frame counters report the current grouped-frame cache behavior used by follow-up #2678. Broader write-path stat deltas remain available in the JSON output and matrix `phase_stat_deltas.tsv`.\n\n")
-	sb.WriteString("| engine | read integrity | iteration mode | phase | crc32 checks | grouped hits | grouped misses | grouped stores | mmap hits | mmap miss out-of-range | mmap miss no mapping | mmap miss dead cap | mmap ReadAt fallbacks |\n")
-	sb.WriteString("|---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|\n")
-	for _, run := range runs {
-		for _, phase := range []string{phaseWrite, phaseRead, phaseIterate, phaseDeleteRange, phaseReopen} {
-			result, ok := run.Phases[phase]
-			if !ok || len(result.StatDelta) == 0 {
-				continue
+	if hasReadCounterDeltas(runs) {
+		sb.WriteString("\n## TreeDB value-log read counters\n\n")
+		sb.WriteString("Per-phase deltas from TreeDB `Stat()` output. CRC counts are value-log record CRC32 computations performed by the read path; grouped-frame counters report the current grouped-frame cache behavior used by follow-up #2678. Broader write-path stat deltas remain available in the JSON output and matrix `phase_stat_deltas.tsv`.\n\n")
+		sb.WriteString("| engine | read integrity | iteration mode | phase | crc32 checks | grouped hits | grouped misses | grouped stores | mmap hits | mmap miss out-of-range | mmap miss no mapping | mmap miss dead cap | mmap ReadAt fallbacks |\n")
+		sb.WriteString("|---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|\n")
+		for _, run := range runs {
+			for _, phase := range []string{phaseWrite, phaseRead, phaseIterate, phaseDeleteRange, phaseReopen} {
+				result, ok := run.Phases[phase]
+				if !ok || len(result.StatDelta) == 0 {
+					continue
+				}
+				counters, ok := readCounterDeltas(result.StatDelta)
+				if !ok {
+					continue
+				}
+				fmt.Fprintf(sb, "| %s | %s | %s | %s | %d | %d | %d | %d | %d | %d | %d | %d | %d |\n",
+					run.Engine,
+					run.ReadIntegrity,
+					run.IterationMode,
+					phase,
+					counters.crc32Checks,
+					counters.groupedHits,
+					counters.groupedMisses,
+					counters.groupedStores,
+					counters.mmapHits,
+					counters.mmapMissOutOfRange,
+					counters.mmapMissNoMapping,
+					counters.mmapMissDeadCap,
+					counters.mmapFallbackReadAt,
+				)
 			}
-			counters, ok := readCounterDeltas(result.StatDelta)
-			if !ok {
-				continue
-			}
-			fmt.Fprintf(sb, "| %s | %s | %s | %s | %d | %d | %d | %d | %d | %d | %d | %d | %d |\n",
-				run.Engine,
-				run.ReadIntegrity,
-				run.IterationMode,
-				phase,
-				counters.crc32Checks,
-				counters.groupedHits,
-				counters.groupedMisses,
-				counters.groupedStores,
-				counters.mmapHits,
-				counters.mmapMissOutOfRange,
-				counters.mmapMissNoMapping,
-				counters.mmapMissDeadCap,
-				counters.mmapFallbackReadAt,
-			)
 		}
 	}
 
+	if !hasDeleteRangeCounterDeltas(runs) {
+		return
+	}
 	sb.WriteString("\n## TreeDB DeleteRange counters\n\n")
 	sb.WriteString("Per-phase DeleteRange deltas from TreeDB `Stat()` output. `input ranges` counts submitted non-empty ranges; `effective ranges` counts ranges after exact adjacent/overlap coalescing in the write plan; materialized keys are copied into point tombstones by the cached fallback.\n\n")
 	sb.WriteString("| engine | read integrity | iteration mode | phase | db calls | batch calls | batch writes | input ranges | effective ranges | coalesced ranges | visited keys | materialized keys | materialized key bytes | tombstone keys | iterators | snapshot iters | backend iters | memtable iters | queue iters | fast clears | backend direct batches | backend direct keys |\n")
@@ -1067,17 +1069,7 @@ func writeStatDeltaSummary(sb *strings.Builder, runs []runResult) {
 			if !ok || len(result.StatDelta) == 0 {
 				continue
 			}
-			if !hasAnyStatDeltaValue(result.StatDelta,
-				"treedb.cache.delete_range.calls_total",
-				"treedb.cache.delete_range.batch_calls_total",
-				"treedb.cache.delete_range.batch_writes_total",
-				"treedb.cache.delete_range.input_ranges_total",
-				"treedb.cache.delete_range.effective_ranges_total",
-				"treedb.cache.delete_range.coalesced_ranges_total",
-				"treedb.cache.delete_range.snapshot_iterators_total",
-				"treedb.cache.delete_range.visited_keys_total",
-				"treedb.cache.delete_range.materialized_keys_total",
-				"treedb.cache.delete_range.tombstone_keys_total") {
+			if !hasAnyStatDeltaValue(result.StatDelta, deleteRangeCounterKeys...) {
 				continue
 			}
 			fmt.Fprintf(sb, "| %s | %s | %s | %s | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d |\n",
@@ -1124,6 +1116,38 @@ func hasReadCounterDeltas(runs []runResult) bool {
 	for _, run := range runs {
 		for _, phase := range run.Phases {
 			if _, ok := readCounterDeltas(phase.StatDelta); ok {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+var deleteRangeCounterKeys = []string{
+	"treedb.cache.delete_range.calls_total",
+	"treedb.cache.delete_range.batch_calls_total",
+	"treedb.cache.delete_range.batch_writes_total",
+	"treedb.cache.delete_range.input_ranges_total",
+	"treedb.cache.delete_range.effective_ranges_total",
+	"treedb.cache.delete_range.coalesced_ranges_total",
+	"treedb.cache.delete_range.iterators_total",
+	"treedb.cache.delete_range.snapshot_iterators_total",
+	"treedb.cache.delete_range.backend_iterators_total",
+	"treedb.cache.delete_range.memtable_iterators_total",
+	"treedb.cache.delete_range.queue_iterators_total",
+	"treedb.cache.delete_range.visited_keys_total",
+	"treedb.cache.delete_range.tombstone_keys_total",
+	"treedb.cache.delete_range.materialized_keys_total",
+	"treedb.cache.delete_range.materialized_key_bytes_total",
+	"treedb.cache.delete_range.fast_path_clears_total",
+	"treedb.cache.delete_range.backend_direct_batches_total",
+	"treedb.cache.delete_range.backend_direct_keys_total",
+}
+
+func hasDeleteRangeCounterDeltas(runs []runResult) bool {
+	for _, run := range runs {
+		for _, phase := range run.Phases {
+			if hasAnyStatDeltaValue(phase.StatDelta, deleteRangeCounterKeys...) {
 				return true
 			}
 		}

--- a/scripts/treedb_geth_hot_kv_matrix.sh
+++ b/scripts/treedb_geth_hot_kv_matrix.sh
@@ -247,7 +247,37 @@ stat_key_groups = {
     'mmap_miss_no_mapping': ['treedb.vlog.mmap_read.miss_no_mapping', 'treedb.cache.vlog_mmap.read.miss_no_mapping'],
     'mmap_miss_dead_mapping_cap': ['treedb.vlog.mmap_read.miss_dead_mapping_cap', 'treedb.cache.vlog_mmap.read.miss_dead_mapping_cap'],
     'mmap_fallback_readat': ['treedb.vlog.mmap_read.fallback_readat', 'treedb.cache.vlog_mmap.read.fallback_readat'],
+    'delete_range_calls': ['treedb.cache.delete_range.calls_total'],
+    'delete_range_batch_calls': ['treedb.cache.delete_range.batch_calls_total'],
+    'delete_range_batch_writes': ['treedb.cache.delete_range.batch_writes_total'],
+    'delete_range_input_ranges': ['treedb.cache.delete_range.input_ranges_total'],
+    'delete_range_effective_ranges': ['treedb.cache.delete_range.effective_ranges_total'],
+    'delete_range_coalesced_ranges': ['treedb.cache.delete_range.coalesced_ranges_total'],
+    'delete_range_iterators': ['treedb.cache.delete_range.iterators_total'],
+    'delete_range_backend_iterators': ['treedb.cache.delete_range.backend_iterators_total'],
+    'delete_range_memtable_iterators': ['treedb.cache.delete_range.memtable_iterators_total'],
+    'delete_range_queue_iterators': ['treedb.cache.delete_range.queue_iterators_total'],
+    'delete_range_visited_keys': ['treedb.cache.delete_range.visited_keys_total'],
+    'delete_range_tombstone_keys': ['treedb.cache.delete_range.tombstone_keys_total'],
+    'delete_range_materialized_keys': ['treedb.cache.delete_range.materialized_keys_total'],
+    'delete_range_materialized_key_bytes': ['treedb.cache.delete_range.materialized_key_bytes_total'],
+    'delete_range_fast_path_clears': ['treedb.cache.delete_range.fast_path_clears_total'],
+    'delete_range_backend_direct_keys': ['treedb.cache.delete_range.backend_direct_keys_total'],
 }
+
+vlog_stat_names = [
+    'crc32_checks', 'grouped_hits', 'grouped_misses', 'grouped_stores',
+    'mmap_hits', 'mmap_miss_out_of_range', 'mmap_miss_no_mapping',
+    'mmap_miss_dead_mapping_cap', 'mmap_fallback_readat',
+]
+delete_range_stat_names = [
+    'delete_range_calls', 'delete_range_batch_calls', 'delete_range_batch_writes',
+    'delete_range_input_ranges', 'delete_range_effective_ranges', 'delete_range_coalesced_ranges',
+    'delete_range_iterators', 'delete_range_backend_iterators', 'delete_range_memtable_iterators',
+    'delete_range_queue_iterators', 'delete_range_visited_keys', 'delete_range_tombstone_keys',
+    'delete_range_materialized_keys', 'delete_range_materialized_key_bytes',
+    'delete_range_fast_path_clears', 'delete_range_backend_direct_keys',
+]
 
 def fmt(n):
     try:
@@ -368,12 +398,32 @@ with open(md, 'w') as out:
         out.write('| key shape | value size | batch target bytes | read-integrity | iteration mode | engine | phase | crc32 checks | grouped hits | grouped misses | grouped stores | mmap hits | mmap miss OOR | mmap miss no-map | mmap miss dead-cap | mmap ReadAt fallback |\n')
         out.write('|---|---:|---:|---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|\n')
         for r, phase, vals in phase_rows:
+            if not any(vals[name] for name in vlog_stat_names):
+                continue
             out.write('| {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} |\n'.format(
                 r['key_shape'], fmt(r['value_size']), fmt(r['batch_target_bytes']), r['read_integrity'],
                 r['iteration_mode'], r['engine'], phase,
                 fmt(vals['crc32_checks']), fmt(vals['grouped_hits']), fmt(vals['grouped_misses']), fmt(vals['grouped_stores']),
                 fmt(vals['mmap_hits']), fmt(vals['mmap_miss_out_of_range']), fmt(vals['mmap_miss_no_mapping']),
                 fmt(vals['mmap_miss_dead_mapping_cap']), fmt(vals['mmap_fallback_readat'])))
+
+    delete_phase_rows = [(r, phase, vals) for r, phase, vals in phase_rows if any(vals[name] for name in delete_range_stat_names)]
+    if delete_phase_rows:
+        out.write('\n## TreeDB DeleteRange counters\n\n')
+        out.write('Per-phase DeleteRange counters from TreeDB `Stat()`. Input ranges are submitted non-empty ranges; effective ranges are exact adjacent/overlap-coalesced write-plan ranges; materialized keys are copied into point tombstones by the cached fallback. Full machine-readable counters are in `phase_counters.tsv`.\n\n')
+        out.write('| key shape | value size | batch target bytes | read-integrity | iteration mode | engine | phase | db calls | batch calls | batch writes | input ranges | effective ranges | coalesced ranges | visited keys | materialized keys | materialized key bytes | tombstone keys | iterators | backend iters | memtable iters | queue iters | fast clears | backend direct keys |\n')
+        out.write('|---|---:|---:|---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|\n')
+        for r, phase, vals in delete_phase_rows:
+            out.write('| {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} |\n'.format(
+                r['key_shape'], fmt(r['value_size']), fmt(r['batch_target_bytes']), r['read_integrity'],
+                r['iteration_mode'], r['engine'], phase,
+                fmt(vals['delete_range_calls']), fmt(vals['delete_range_batch_calls']), fmt(vals['delete_range_batch_writes']),
+                fmt(vals['delete_range_input_ranges']), fmt(vals['delete_range_effective_ranges']), fmt(vals['delete_range_coalesced_ranges']),
+                fmt(vals['delete_range_visited_keys']), fmt(vals['delete_range_materialized_keys']),
+                fmt(vals['delete_range_materialized_key_bytes']), fmt(vals['delete_range_tombstone_keys']),
+                fmt(vals['delete_range_iterators']), fmt(vals['delete_range_backend_iterators']),
+                fmt(vals['delete_range_memtable_iterators']), fmt(vals['delete_range_queue_iterators']),
+                fmt(vals['delete_range_fast_path_clears']), fmt(vals['delete_range_backend_direct_keys'])))
 PY
 
 echo "geth hot KV matrix complete"

--- a/scripts/treedb_geth_hot_kv_matrix.sh
+++ b/scripts/treedb_geth_hot_kv_matrix.sh
@@ -416,7 +416,7 @@ with open(md, 'w') as out:
                 metric_ratio(key_only, value, 'iterate_keys_sec'), metric_ratio(key_only, value, 'delete_range_keys_sec'),
                 fmt(value_crc), fmt(key_crc), fmt(key_crc - value_crc)))
 
-    if phase_rows:
+    if any(any(vals[name] for name in vlog_stat_names) for _, _, vals in phase_rows):
         out.write('\n## TreeDB value-log read counters\n\n')
         out.write('Per-phase deltas from TreeDB `Stat()` output. CRC counts are value-log record CRC32 computations; grouped counters reflect grouped-frame cache activity; mmap columns split hits, misses, and ReadAt fallback reads. Full machine-readable read counters are in `phase_counters.tsv`; all nonzero parseable TreeDB stat deltas are in `phase_stat_deltas.tsv`.\n\n')
         out.write('| key shape | value size | batch target bytes | read-integrity | iteration mode | engine | phase | crc32 checks | grouped hits | grouped misses | grouped stores | mmap hits | mmap miss OOR | mmap miss no-map | mmap miss dead-cap | mmap ReadAt fallback |\n')

--- a/scripts/treedb_geth_hot_kv_matrix.sh
+++ b/scripts/treedb_geth_hot_kv_matrix.sh
@@ -262,6 +262,7 @@ stat_key_groups = {
     'delete_range_materialized_keys': ['treedb.cache.delete_range.materialized_keys_total'],
     'delete_range_materialized_key_bytes': ['treedb.cache.delete_range.materialized_key_bytes_total'],
     'delete_range_fast_path_clears': ['treedb.cache.delete_range.fast_path_clears_total'],
+    'delete_range_backend_direct_batches': ['treedb.cache.delete_range.backend_direct_batches_total'],
     'delete_range_backend_direct_keys': ['treedb.cache.delete_range.backend_direct_keys_total'],
 }
 
@@ -276,7 +277,7 @@ delete_range_stat_names = [
     'delete_range_iterators', 'delete_range_backend_iterators', 'delete_range_memtable_iterators',
     'delete_range_queue_iterators', 'delete_range_visited_keys', 'delete_range_tombstone_keys',
     'delete_range_materialized_keys', 'delete_range_materialized_key_bytes',
-    'delete_range_fast_path_clears', 'delete_range_backend_direct_keys',
+    'delete_range_fast_path_clears', 'delete_range_backend_direct_batches', 'delete_range_backend_direct_keys',
 ]
 
 def fmt(n):
@@ -411,10 +412,10 @@ with open(md, 'w') as out:
     if delete_phase_rows:
         out.write('\n## TreeDB DeleteRange counters\n\n')
         out.write('Per-phase DeleteRange counters from TreeDB `Stat()`. Input ranges are submitted non-empty ranges; effective ranges are exact adjacent/overlap-coalesced write-plan ranges; materialized keys are copied into point tombstones by the cached fallback. Full machine-readable counters are in `phase_counters.tsv`.\n\n')
-        out.write('| key shape | value size | batch target bytes | read-integrity | iteration mode | engine | phase | db calls | batch calls | batch writes | input ranges | effective ranges | coalesced ranges | visited keys | materialized keys | materialized key bytes | tombstone keys | iterators | backend iters | memtable iters | queue iters | fast clears | backend direct keys |\n')
-        out.write('|---|---:|---:|---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|\n')
+        out.write('| key shape | value size | batch target bytes | read-integrity | iteration mode | engine | phase | db calls | batch calls | batch writes | input ranges | effective ranges | coalesced ranges | visited keys | materialized keys | materialized key bytes | tombstone keys | iterators | backend iters | memtable iters | queue iters | fast clears | backend direct batches | backend direct keys |\n')
+        out.write('|---|---:|---:|---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|\n')
         for r, phase, vals in delete_phase_rows:
-            out.write('| {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} |\n'.format(
+            out.write('| {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} |\n'.format(
                 r['key_shape'], fmt(r['value_size']), fmt(r['batch_target_bytes']), r['read_integrity'],
                 r['iteration_mode'], r['engine'], phase,
                 fmt(vals['delete_range_calls']), fmt(vals['delete_range_batch_calls']), fmt(vals['delete_range_batch_writes']),
@@ -423,7 +424,8 @@ with open(md, 'w') as out:
                 fmt(vals['delete_range_materialized_key_bytes']), fmt(vals['delete_range_tombstone_keys']),
                 fmt(vals['delete_range_iterators']), fmt(vals['delete_range_backend_iterators']),
                 fmt(vals['delete_range_memtable_iterators']), fmt(vals['delete_range_queue_iterators']),
-                fmt(vals['delete_range_fast_path_clears']), fmt(vals['delete_range_backend_direct_keys'])))
+                fmt(vals['delete_range_fast_path_clears']), fmt(vals['delete_range_backend_direct_batches']),
+                fmt(vals['delete_range_backend_direct_keys'])))
 PY
 
 echo "geth hot KV matrix complete"


### PR DESCRIPTION
## Objective

Instrument TreeDB cached-mode `DeleteRange` work for geth-hot-KV and expose the counters through `Stats()` / geth-hot-KV phase counter reports. Closes #2704.

## Context

#2704 identified `DeleteRange` as the largest remaining geth-hot-KV structural gap after the #2676 A-lane. The key question was whether adjacent/overlap coalescing is enough or whether the hot cost is per-key materialization / iterator work.

This branch is updated onto current `origin/main` (`ca321ee94`, including #2710 / #2706). Repository rules reject force-pushes to this PR branch, so the branch contains a normal merge commit from `origin/main`; latest head is `9ad67bb9c`.

## Non-goals

- No durable checksum/default read-integrity changes.
- No range-tombstone/span on-disk format rewrite in this PR.
- No public-testnet readiness claim.
- No geth default-engine changes.

## Design

- Adds cached TreeDB `DeleteRange` counters under `treedb.cache.delete_range.*`:
  - DB calls, batch calls, batch writes
  - input/effective/coalesced ranges
  - total/snapshot/backend/memtable/queue iterator counts
  - visited keys, tombstone keys, materialized keys, materialized key bytes
  - fast-path clears and backend-direct batches/keys
- Exposes those counters through `TreeDB.Stats()` and the geth `Stat()` adapter path.
- Extends `benchmarks/geth_hot_kv/testdata/treedb_nitro_soak.go` and `scripts/treedb_geth_hot_kv_matrix.sh` so:
  - `phase_counters.tsv` includes the curated value-log + DeleteRange counter columns.
  - `phase_stat_deltas.tsv` includes all nonzero parseable TreeDB stat deltas from each phase.
  - `matrix_results.md` includes focused value-log read-counter and DeleteRange-counter tables.
  - per-run DeleteRange Markdown counters use their own predicate and are emitted even when value-log read deltas are absent.
- No new semantic coalescing was added: exact adjacent/overlap coalescing already exists in `batch.BuildApplyPlanFromEntries` / `MergeDeleteRanges`. The new counters show geth-mixed ranges do not safely coalesce because range gaps may contain valid keys.

## Scope

Includes:
- `TreeDB/caching/db.go`
- `TreeDB/caching/delete_range_stats_test.go`
- `TreeDB/delete_range_2704_test.go`
- `benchmarks/geth_hot_kv/testdata/treedb_nitro_soak.go`
- `benchmarks/geth_hot_kv/harness_test.go`
- `scripts/treedb_geth_hot_kv_matrix.sh`

Excludes:
- Backend on-disk range tombstones/spans.
- Command-WAL payload coalescing (durable replay order remains unchanged).

## Correctness

Latest-head local tests (`9ad67bb9c`):

```sh
bash -n scripts/treedb_geth_hot_kv_matrix.sh
go test ./benchmarks/geth_hot_kv -count=1
git diff --check
```

Latest-head pre-P2-fix broader local tests after rebasing/merging current main (`18bced578`, still covering unchanged TreeDB code paths):

```sh
bash -n scripts/treedb_geth_hot_kv_matrix.sh
go test ./TreeDB/caching
go test ./TreeDB
go test ./benchmarks/geth_hot_kv
(cd TreeDB/integration/gethethdb && go test ./...)
git diff --check
```

Earlier focused commands also run while developing the same change:

```sh
go test ./TreeDB/caching -run 'TestCaching.*DeleteRange.*(Stats|Materialization)|TestCachingDB_DeleteRange|TestCachingBatchDeleteRange'
go test ./TreeDB -run 'TestDeleteRangeIssue2704|TestPublicCommandWALDeleteRange|TestBatchDeleteRange|TestRawKVParity.*DeleteRange|TestDeleteRange_CheckpointConsistency_ProfileMatrix'
go test ./TreeDB/batch ./TreeDB/db -run 'TestBatchDeleteRange|TestCommandWALRawDeleteRangeReplayFrame'
```

Covered edge cases:
- empty/no-op ranges
- nil/empty bound semantics
- adjacent/overlap/duplicate ranges in one batch
- value-log pointer keys
- command-WAL cached batch reopen verification
- `Stat()` counter deltas for DB-level and batch DeleteRange paths
- DeleteRange Markdown emission when value-log read deltas are absent

## Performance / evidence

Latest-head DeleteRange-only Markdown smoke for Codex P2 (`9ad67bb9c`, fixed 8-byte inline values: no value-log read deltas, DeleteRange section still emitted in per-run and matrix Markdown):

```sh
GOFLAGS="-modfile=/tmp/geth_hotkv_2704_after.mod" \
GETH_REPO=/Users/michaelseiler/dev/snissn/go-ethereum \
RUN_DIR=/tmp/geth_hotkv_2704_dronly_fix_smoke_20260613T092203Z \
ENGINES=treedb KEYS=1000 READS=400 \
KEY_SHAPES=geth-mixed VALUE_SHAPES=fixed VALUE_SIZES=8 \
BATCH_TARGET_BYTES=102400 TREEDB_READ_INTEGRITIES=verify ITERATION_MODES=value \
  scripts/treedb_geth_hot_kv_matrix.sh
```

Evidence: `stdout.md` and `matrix_results.md` contain `## TreeDB DeleteRange counters` and no value-log read-counter rows are required; `phase_counters.tsv` reports `delete_range_calls=5`, `input_ranges=10`, `visited_keys=1000`, `materialized_keys=500`.

30k/12k smoke after main merge (`18bced578`, geth-mixed keys/values, value size 128, batch target 102400, TreeDB verify, value iteration):

```sh
GOFLAGS="-modfile=/tmp/geth_hotkv_2704_after.mod" \
GETH_REPO=/Users/michaelseiler/dev/snissn/go-ethereum \
RUN_DIR=/tmp/geth_hotkv_2704_mergehead_30k_20260613T090443Z \
ENGINES=treedb KEYS=30000 READS=12000 \
KEY_SHAPES=geth-mixed VALUE_SHAPES=geth-mixed VALUE_SIZES=128 \
BATCH_TARGET_BYTES=102400 TREEDB_READ_INTEGRITIES=verify ITERATION_MODES=value \
  scripts/treedb_geth_hot_kv_matrix.sh
```

| artifact | write ops/s | read ops/s | iterate keys/s | DeleteRange keys/s | size | post-delete |
|---|---:|---:|---:|---:|---:|---:|
| `/tmp/geth_hotkv_2704_mergehead_30k_20260613T090443Z` | 30,927 | 453,475 | 3,404,014 | 154,491 | 27,125,441 | 15,799,150 |

1M/400k evidence after main merge:

| artifact | write ops/s | read ops/s | iterate keys/s | DeleteRange keys/s | size | post-delete |
|---|---:|---:|---:|---:|---:|---:|
| `/tmp/geth_hotkv_2704_mergehead_1m_20260613T090515Z` | 227,106 | 123,342 | 2,686,174 | 597,596 | 771,304,381 | 393,933,629 |

30k DeleteRange counters after:

| calls | batch calls | batch writes | input ranges | effective ranges | coalesced | iterators | snapshot iters | backend iters | visited keys | tombstone keys | materialized keys | materialized key bytes |
|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| 150 | 150 | 2 | 300 | 300 | 0 | 300 | 150 | 150 | 30,000 | 30,000 | 15,000 | 570,000 |

1M DeleteRange counters after:

| calls | batch calls | batch writes | input ranges | effective ranges | coalesced | iterators | snapshot iters | backend iters | visited keys | tombstone keys | materialized keys | materialized key bytes |
|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| 5,000 | 5,000 | 50 | 10,000 | 10,000 | 0 | 10,000 | 5,000 | 5,000 | 1,000,000 | 1,000,000 | 500,000 | 19,000,000 |

Interpretation: exact adjacent/overlap coalescing is not the missing optimization for geth-mixed here (`effective_ranges == input_ranges`, `coalesced_ranges == 0`). The hot cost remains per-key enumeration/materialization of point tombstones by the cached fallback.

## Follow-ups

- Filed #2711 for range tombstone/span design.

## AI Review Loop

- Codex latest-head review: clean on `9ad67bb9c3`; prior P2 fixed and thread resolved.
- Copilot latest-head review: requested after `9ad67bb9c` push and CI start.
- CodeRabbit latest-head status: pass / review skipped after `9ad67bb9c`; earlier low-value docs/helper nits were explained and threads resolved.
- Latest-head CI: all checks passing on `9ad67bb9c`.
