### PR TITLE
treedb: compact zero-column row assets

### DIFF
--- a/TreeDB/collections/column_physical_asset.go
+++ b/TreeDB/collections/column_physical_asset.go
@@ -24,8 +24,11 @@ const (
 	columnPhysicalAssetVersionV4 = uint16(4)
 	columnPhysicalAssetVersionV5 = uint16(5)
 	columnPhysicalAssetVersionV6 = uint16(6)
+	columnPhysicalAssetVersionV7 = uint16(7)
 	columnPhysicalAssetVersion   = columnPhysicalAssetVersionV4
 )
+
+const columnPhysicalAssetRowEncodingFixedID = "fixed_id"
 
 var ErrColumnDeclaredValueUnsupported = errors.New("collections: unsupported column declared value")
 
@@ -623,9 +626,13 @@ func encodeColumnPhysicalAsset(input columnPhysicalAssetEncodeInput) ([]byte, co
 		}
 	}
 	var b bytes.Buffer
+	fixedIDWidth, useFixedIDRows := columnPhysicalAssetFixedIDRowEncodingWidth(input)
 	version, err := columnPhysicalAssetVersionForColumns(input.Columns)
 	if err != nil {
 		return nil, columnPhysicalAssetSummary{}, err
+	}
+	if useFixedIDRows {
+		version = columnPhysicalAssetVersionV7
 	}
 	writeManifestUint32(&b, columnPhysicalAssetMagic)
 	writeManifestUint16(&b, version)
@@ -651,6 +658,19 @@ func encodeColumnPhysicalAsset(input columnPhysicalAssetEncodeInput) ([]byte, co
 		if version >= columnPhysicalAssetVersionV5 {
 			writeManifestString(&b, string(col.FixedWidthEncoding))
 		}
+	}
+	if useFixedIDRows {
+		writeManifestString(&b, columnPhysicalAssetRowEncodingFixedID)
+		writeManifestUint64(&b, uint64(fixedIDWidth))
+		for _, row := range input.Rows {
+			_, _ = b.Write(row.ID)
+		}
+		payload := b.Bytes()
+		return payload, columnPhysicalAssetSummary{
+			RowCount:     len(input.Rows),
+			ColumnCount:  len(input.Columns),
+			PayloadBytes: int64(len(payload)),
+		}, nil
 	}
 	for _, row := range input.Rows {
 		writeManifestBytes(&b, row.ID)
@@ -792,6 +812,41 @@ func decodeColumnPhysicalAsset(raw []byte) (columnPhysicalAsset, error) {
 				return columnPhysicalAsset{}, fmt.Errorf("collections: column physical asset column[%d] scalar fixed_width_encoding for value_type %q is typed_column_part-only", i, asset.Columns[i].ValueType)
 			}
 		}
+	}
+	if version >= columnPhysicalAssetVersionV7 {
+		rowEncoding := cur.string()
+		if rowEncoding != columnPhysicalAssetRowEncodingFixedID {
+			return columnPhysicalAsset{}, fmt.Errorf("collections: unsupported column physical asset row encoding %q", rowEncoding)
+		}
+		if len(asset.Columns) != 0 {
+			return columnPhysicalAsset{}, fmt.Errorf("collections: column physical asset row encoding %q requires zero columns", rowEncoding)
+		}
+		idWidth := cur.u64()
+		if idWidth == 0 || idWidth > uint64(maxCollectionInt) {
+			return columnPhysicalAsset{}, fmt.Errorf("collections: column physical asset fixed id width=%d invalid", idWidth)
+		}
+		deleted := asset.Header.Operation == ColumnPublishOperationDelete
+		if asset.Header.Operation != ColumnPublishOperationInsert && asset.Header.Operation != ColumnPublishOperationUpdate && asset.Header.Operation != ColumnPublishOperationDelete {
+			return columnPhysicalAsset{}, fmt.Errorf("collections: unsupported column physical asset operation %q", asset.Header.Operation)
+		}
+		for rowIdx := 0; rowIdx < int(rowCount); rowIdx++ {
+			if uint64(len(raw)-cur.pos) < idWidth {
+				return columnPhysicalAsset{}, errors.New("collections: short column physical asset fixed row id block")
+			}
+			row := columnDeclaredRow{
+				ID:      bytes.Clone(raw[cur.pos : cur.pos+int(idWidth)]),
+				Deleted: deleted,
+			}
+			cur.pos += int(idWidth)
+			asset.Rows = append(asset.Rows, row)
+		}
+		if cur.err != nil {
+			return columnPhysicalAsset{}, cur.err
+		}
+		if cur.pos != len(raw) {
+			return columnPhysicalAsset{}, errors.New("collections: trailing bytes in column physical asset")
+		}
+		return asset, nil
 	}
 	for rowIdx := 0; rowIdx < int(rowCount); rowIdx++ {
 		row := columnDeclaredRow{
@@ -993,11 +1048,31 @@ func validateColumnPhysicalAssetForManifest(raw []byte, ref ColumnAssetRef, cfg 
 
 func isSupportedColumnPhysicalAssetVersion(version uint16) bool {
 	switch version {
-	case columnPhysicalAssetVersionV1, columnPhysicalAssetVersionV2, columnPhysicalAssetVersionV3, columnPhysicalAssetVersionV4, columnPhysicalAssetVersionV5, columnPhysicalAssetVersionV6:
+	case columnPhysicalAssetVersionV1, columnPhysicalAssetVersionV2, columnPhysicalAssetVersionV3, columnPhysicalAssetVersionV4, columnPhysicalAssetVersionV5, columnPhysicalAssetVersionV6, columnPhysicalAssetVersionV7:
 		return true
 	default:
 		return false
 	}
+}
+
+func columnPhysicalAssetFixedIDRowEncodingWidth(input columnPhysicalAssetEncodeInput) (int, bool) {
+	if len(input.Columns) != 0 || len(input.Rows) == 0 {
+		return 0, false
+	}
+	if !isSupportedColumnPhysicalAssetOperation(input.Operation) {
+		return 0, false
+	}
+	deleted := input.Operation == ColumnPublishOperationDelete
+	width := len(input.Rows[0].ID)
+	if width == 0 || input.Rows[0].Deleted != deleted {
+		return 0, false
+	}
+	for _, row := range input.Rows[1:] {
+		if len(row.ID) != width || row.Deleted != deleted {
+			return 0, false
+		}
+	}
+	return width, true
 }
 
 func columnPhysicalAssetVersionForColumns(columns []ColumnStoreColumn) (uint16, error) {

--- a/TreeDB/collections/column_physical_row_reader.go
+++ b/TreeDB/collections/column_physical_row_reader.go
@@ -473,6 +473,9 @@ func cloneColumnPhysicalAssetScanHeader(header columnPhysicalAssetScanHeader) co
 }
 
 func (r *columnPhysicalRowReader) decodeRowFromBlock(block *columnPhysicalRowReaderBlock, ordinal, rowIndex int, scratch *columnPhysicalRowReaderScratch) (columnPhysicalRowReaderRow, error) {
+	if block.version >= columnPhysicalAssetVersionV7 {
+		return r.decodeFixedIDRowFromBlock(block, ordinal, rowIndex, scratch)
+	}
 	cur := manifestCursor{raw: block.raw, pos: block.rowOffsets[rowIndex]}
 	id := cur.bytesView()
 	deleted := false
@@ -520,9 +523,44 @@ func (r *columnPhysicalRowReader) decodeRowFromBlock(block *columnPhysicalRowRea
 	}, nil
 }
 
+func (r *columnPhysicalRowReader) decodeFixedIDRowFromBlock(block *columnPhysicalRowReaderBlock, ordinal, rowIndex int, scratch *columnPhysicalRowReaderScratch) (columnPhysicalRowReaderRow, error) {
+	if block.header.Operation != ColumnPublishOperationInsert && block.header.Operation != ColumnPublishOperationUpdate && block.header.Operation != ColumnPublishOperationDelete {
+		return columnPhysicalRowReaderRow{}, fmt.Errorf("unsupported column physical asset operation %q", block.header.Operation)
+	}
+	if block.header.ColumnCount != 0 {
+		return columnPhysicalRowReaderRow{}, fmt.Errorf("column physical asset row encoding %q requires zero columns", columnPhysicalAssetRowEncodingFixedID)
+	}
+	start := block.rowOffsets[rowIndex]
+	end := len(block.raw)
+	if next := rowIndex + 1; next < len(block.rowOffsets) {
+		end = block.rowOffsets[next]
+	}
+	if start < 0 || start > end || end > len(block.raw) {
+		return columnPhysicalRowReaderRow{}, fmt.Errorf("column physical asset fixed row[%d] offset range [%d,%d) outside len=%d", rowIndex, start, end, len(block.raw))
+	}
+	scratch.Values = scratch.Values[:0]
+	scratch.Float32Values = scratch.Float32Values[:0]
+	scratch.Uint32Values = scratch.Uint32Values[:0]
+	scratch.Bytes = scratch.Bytes[:0]
+	return columnPhysicalRowReaderRow{
+		Generation:        block.header.Generation,
+		PartID:            block.header.PartID,
+		AppliedCommandLSN: block.header.AppliedCommandLSN,
+		Operation:         block.header.Operation,
+		Ordinal:           ordinal,
+		RowIndex:          rowIndex,
+		ID:                block.raw[start:end],
+		Values:            scratch.Values,
+		Deleted:           block.header.Operation == ColumnPublishOperationDelete,
+	}, nil
+}
+
 func indexColumnPhysicalAssetReaderRows(raw []byte, version uint16, rowsOffset int, header columnPhysicalAssetScanHeader, cfg *ColumnStoreConfig) ([]int, error) {
 	if rowsOffset < 0 || rowsOffset > len(raw) {
 		return nil, fmt.Errorf("column physical asset invalid rows offset=%d len=%d", rowsOffset, len(raw))
+	}
+	if version >= columnPhysicalAssetVersionV7 {
+		return indexColumnPhysicalAssetReaderFixedIDRows(raw, rowsOffset, header)
 	}
 	offsets := make([]int, header.RowCount)
 	cur := manifestCursor{raw: raw, pos: rowsOffset}
@@ -548,6 +586,43 @@ func indexColumnPhysicalAssetReaderRows(raw []byte, version uint16, rowsOffset i
 		if err := skipColumnPhysicalRowValues(&cur, version, cfg); err != nil {
 			return nil, fmt.Errorf("row[%d]: %w", rowIdx, err)
 		}
+	}
+	if cur.err != nil {
+		return nil, cur.err
+	}
+	if cur.pos != len(raw) {
+		return nil, errors.New("trailing bytes in column physical asset")
+	}
+	return offsets, nil
+}
+
+func indexColumnPhysicalAssetReaderFixedIDRows(raw []byte, rowsOffset int, header columnPhysicalAssetScanHeader) ([]int, error) {
+	cur := manifestCursor{raw: raw, pos: rowsOffset}
+	rowEncoding := cur.string()
+	if rowEncoding != columnPhysicalAssetRowEncodingFixedID {
+		return nil, fmt.Errorf("unsupported column physical asset row encoding %q", rowEncoding)
+	}
+	if header.ColumnCount != 0 {
+		return nil, fmt.Errorf("column physical asset row encoding %q requires zero columns", rowEncoding)
+	}
+	idWidth64 := cur.u64()
+	if cur.err != nil {
+		return nil, cur.err
+	}
+	if idWidth64 == 0 || idWidth64 > uint64(maxCollectionInt) {
+		return nil, fmt.Errorf("column physical asset fixed id width=%d invalid", idWidth64)
+	}
+	if header.Operation != ColumnPublishOperationInsert && header.Operation != ColumnPublishOperationUpdate && header.Operation != ColumnPublishOperationDelete {
+		return nil, fmt.Errorf("unsupported column physical asset operation %q", header.Operation)
+	}
+	idWidth := int(idWidth64)
+	offsets := make([]int, header.RowCount)
+	for rowIdx := 0; rowIdx < header.RowCount; rowIdx++ {
+		if cur.pos > len(raw) || len(raw)-cur.pos < idWidth {
+			return nil, errors.New("short column physical asset fixed row id block")
+		}
+		offsets[rowIdx] = cur.pos
+		cur.pos += idWidth
 	}
 	if cur.err != nil {
 		return nil, cur.err

--- a/TreeDB/collections/column_physical_row_reader_test.go
+++ b/TreeDB/collections/column_physical_row_reader_test.go
@@ -175,6 +175,61 @@ func TestColumnPhysicalRowReaderBatchFetchReusesCachedBlockV1(t *testing.T) {
 	}
 }
 
+func TestColumnPhysicalRowReaderFetchesV7FixedIDRows(t *testing.T) {
+	cfg := testColumnPhysicalRowReaderFixedIDConfigV7(t)
+	root := backenddb.ColumnAssetRootDirPath(t.TempDir())
+	rows := []columnDeclaredRow{
+		{ID: []byte("doc-0000")},
+		{ID: []byte("doc-0001")},
+		{ID: []byte("doc-0002")},
+		{ID: []byte("doc-0003")},
+	}
+	ref := writeColumnPhysicalRowReaderAssetForTestV1(t, root, cfg, 19, 1, rows)
+	raw, err := readColumnPhysicalAssetFromManager(root, ref)
+	if err != nil {
+		t.Fatalf("readColumnPhysicalAssetFromManager: %v", err)
+	}
+	if _, version, _, err := parseColumnPhysicalAssetScanHeader(raw, ref, "events", cfg, ColumnPublishOperationInsert); err != nil {
+		t.Fatalf("parseColumnPhysicalAssetScanHeader: %v", err)
+	} else if version != columnPhysicalAssetVersionV7 {
+		t.Fatalf("asset version=%d want V7", version)
+	}
+
+	reader, err := newColumnPhysicalRowReaderFromSnapshotView(columnPhysicalRowReaderViewForTestV1(root, cfg, ref), columnPhysicalRowReaderOptions{
+		RequireInsertOnly: true,
+	})
+	if err != nil {
+		t.Fatalf("newColumnPhysicalRowReaderFromSnapshotView: %v", err)
+	}
+	defer func() { _ = reader.Close() }()
+	if got, want := reader.RowCount(), len(rows); got != want {
+		t.Fatalf("RowCount=%d want %d", got, want)
+	}
+
+	var scratch columnPhysicalRowReaderScratch
+	row, err := reader.FetchRow(2, &scratch)
+	if err != nil {
+		t.Fatalf("FetchRow(2): %v", err)
+	}
+	if string(row.ID) != "doc-0002" || row.Ordinal != 2 || row.RowIndex != 2 || row.Deleted || len(row.Values) != 0 {
+		t.Fatalf("row=%+v id=%q want fixed-id doc-0002 without values", row, string(row.ID))
+	}
+
+	var got []string
+	if err := reader.FetchBatch([]int{3, 1}, &scratch, func(row columnPhysicalRowReaderRow) error {
+		got = append(got, string(row.ID))
+		if row.Deleted || len(row.Values) != 0 {
+			return fmt.Errorf("row=%+v want non-deleted fixed-id row without values", row)
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("FetchBatch: %v", err)
+	}
+	if fmt.Sprint(got) != "[doc-0003 doc-0001]" {
+		t.Fatalf("batch ids=%v", got)
+	}
+}
+
 func TestColumnPhysicalRowReaderCachedBlocksOwnRawBytesV1(t *testing.T) {
 	normalized := testColumnPhysicalRowReaderConfigV1(t)
 	root := backenddb.ColumnAssetRootDirPath(t.TempDir())
@@ -837,6 +892,28 @@ func testColumnPhysicalRowReaderConfigForBenchV1(t testing.TB, dims int) *Column
 	cfg.RecoveryAuthoritativeManifest = &ColumnManifestIdentity{Generation: 1, Format: columnManifestFormatTCS1, Version: columnManifestIdentityVersion, Checksum: 1}
 	cfg.RecoveryAuthoritativeAppliedCommandLSN = 1
 	return cfg
+}
+
+func testColumnPhysicalRowReaderFixedIDConfigV7(t testing.TB) *ColumnStoreConfig {
+	t.Helper()
+	cfg, err := normalizeColumnStoreConfig("events", &ColumnStoreConfig{
+		Enabled: true,
+		Columns: []ColumnStoreColumn{
+			{Name: "kind", Path: "kind", ValueType: ColumnStoreValueString, Owner: TypedStorageOwnerColumnPart, Dictionary: true},
+		},
+		ProfileSupport: ColumnStoreProfileBenchmarkRelaxed,
+	})
+	if err != nil {
+		t.Fatalf("normalizeColumnStoreConfig: %v", err)
+	}
+	cfg.ActiveManifest = &ColumnManifestIdentity{Generation: 1, Format: columnManifestFormatTCS1, Version: columnManifestIdentityVersion, Checksum: 1}
+	cfg.RecoveryAuthoritativeManifest = &ColumnManifestIdentity{Generation: 1, Format: columnManifestFormatTCS1, Version: columnManifestIdentityVersion, Checksum: 1}
+	cfg.RecoveryAuthoritativeAppliedCommandLSN = 1
+	rowAssetConfig := columnStoreRowAssetConfig(*cfg)
+	if len(rowAssetConfig.Columns) != 0 {
+		t.Fatalf("row asset columns=%d want zero", len(rowAssetConfig.Columns))
+	}
+	return &rowAssetConfig
 }
 
 func testColumnPhysicalRowReaderRowsV1(start, count int, cfg *ColumnStoreConfig) []columnDeclaredRow {

--- a/TreeDB/collections/column_physical_scan.go
+++ b/TreeDB/collections/column_physical_scan.go
@@ -2190,6 +2190,9 @@ func scanColumnPhysicalAssetRowsWithManifestOperation(raw []byte, ref ColumnAsse
 		return columnPhysicalAssetScanSummary{}, err
 	}
 	cur := manifestCursor{raw: raw, pos: rowsOffset}
+	if version >= columnPhysicalAssetVersionV7 {
+		return scanColumnPhysicalAssetFixedIDRows(&cur, raw, header, visitor)
+	}
 	valuesBuf := projection.values
 	var summary columnPhysicalAssetScanSummary
 	for rowIdx := 0; rowIdx < header.RowCount; rowIdx++ {
@@ -2229,6 +2232,59 @@ func scanColumnPhysicalAssetRowsWithManifestOperation(raw []byte, ref ColumnAsse
 				ID:                id,
 				Deleted:           deleted,
 				Values:            rowValues,
+			}); err != nil {
+				return columnPhysicalAssetScanSummary{}, err
+			}
+		}
+	}
+	if cur.err != nil {
+		return columnPhysicalAssetScanSummary{}, cur.err
+	}
+	if cur.pos != len(raw) {
+		return columnPhysicalAssetScanSummary{}, errors.New("trailing bytes in column physical asset")
+	}
+	return summary, nil
+}
+
+func scanColumnPhysicalAssetFixedIDRows(cur *manifestCursor, raw []byte, header columnPhysicalAssetScanHeader, visitor func(columnPhysicalScanRowView) error) (columnPhysicalAssetScanSummary, error) {
+	rowEncoding := cur.string()
+	if rowEncoding != columnPhysicalAssetRowEncodingFixedID {
+		return columnPhysicalAssetScanSummary{}, fmt.Errorf("unsupported column physical asset row encoding %q", rowEncoding)
+	}
+	if header.ColumnCount != 0 {
+		return columnPhysicalAssetScanSummary{}, fmt.Errorf("column physical asset row encoding %q requires zero columns", rowEncoding)
+	}
+	idWidth := cur.u64()
+	if cur.err != nil {
+		return columnPhysicalAssetScanSummary{}, cur.err
+	}
+	if idWidth == 0 || idWidth > uint64(maxCollectionInt) {
+		return columnPhysicalAssetScanSummary{}, fmt.Errorf("column physical asset fixed id width=%d invalid", idWidth)
+	}
+	deleted := header.Operation == ColumnPublishOperationDelete
+	if header.Operation != ColumnPublishOperationInsert && header.Operation != ColumnPublishOperationUpdate && header.Operation != ColumnPublishOperationDelete {
+		return columnPhysicalAssetScanSummary{}, fmt.Errorf("unsupported column physical asset operation %q", header.Operation)
+	}
+	var summary columnPhysicalAssetScanSummary
+	for rowIdx := 0; rowIdx < header.RowCount; rowIdx++ {
+		if uint64(len(raw)-cur.pos) < idWidth {
+			return columnPhysicalAssetScanSummary{}, errors.New("short column physical asset fixed row id block")
+		}
+		id := raw[cur.pos : cur.pos+int(idWidth)]
+		cur.pos += int(idWidth)
+		summary.rows++
+		if deleted {
+			summary.deleted++
+		}
+		if visitor != nil {
+			if err := visitor(columnPhysicalScanRowView{
+				Generation:        header.Generation,
+				PartID:            header.PartID,
+				AppliedCommandLSN: header.AppliedCommandLSN,
+				Operation:         header.Operation,
+				RowIndex:          rowIdx,
+				ID:                id,
+				Deleted:           deleted,
 			}); err != nil {
 				return columnPhysicalAssetScanSummary{}, err
 			}

--- a/TreeDB/collections/column_store_physical_accounting.go
+++ b/TreeDB/collections/column_store_physical_accounting.go
@@ -2,6 +2,7 @@ package collections
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"sort"
@@ -39,6 +40,7 @@ type ColumnStorePhysicalAccounting struct {
 	GraphAssetRefs             int                                      `json:"graph_asset_refs,omitempty"`
 	Totals                     ColumnStorePhysicalAccountingTotals      `json:"totals"`
 	AssetKinds                 []ColumnStorePhysicalAssetKindAccounting `json:"asset_kinds,omitempty"`
+	RowAssets                  []ColumnStoreRowAssetAccounting          `json:"row_assets,omitempty"`
 	TypedColumnParts           []ColumnStoreTypedColumnPartAccounting   `json:"typed_column_parts,omitempty"`
 	SidecarAssets              []ColumnStorePhysicalAssetAccounting     `json:"sidecar_assets,omitempty"`
 	GraphAssets                []ColumnStorePhysicalAssetRefAccounting  `json:"graph_assets,omitempty"`
@@ -55,6 +57,7 @@ type ColumnStorePhysicalAccountingTotals struct {
 	DictionaryCodeBytes    int64                                    `json:"dictionary_code_bytes,omitempty"`
 	Int64ValueBytes        int64                                    `json:"int64_value_bytes,omitempty"`
 	GraphAssetBytes        int64                                    `json:"graph_asset_bytes,omitempty"`
+	RowAssetSections       ColumnStoreRowAssetByteAccounting        `json:"row_asset_sections"`
 	TypedColumnSections    ColumnStoreTypedColumnPartByteAccounting `json:"typed_column_sections"`
 }
 
@@ -89,6 +92,51 @@ type ColumnStorePhysicalAssetAccounting struct {
 	Reason ColumnPublishOperation                `json:"reason,omitempty"`
 	Column string                                `json:"column,omitempty"`
 	Name   string                                `json:"name,omitempty"`
+}
+
+// ColumnStoreRowAssetAccounting reports one physical row asset and its
+// serialized payload byte breakdown.
+type ColumnStoreRowAssetAccounting struct {
+	Asset   ColumnStorePhysicalAssetAccounting `json:"asset"`
+	Payload ColumnStoreRowAssetByteAccounting  `json:"payload"`
+}
+
+// ColumnStoreRowAssetByteAccounting breaks down the legacy TCPA row asset
+// envelope. RowIDStoredBytes includes the per-row length prefix; RowIDValueBytes
+// is only the document ID payload. RowValueHeaderBytes covers repeated per-value
+// type/null/present metadata, while RowValuePayloadBytes covers the encoded
+// value bodies.
+type ColumnStoreRowAssetByteAccounting struct {
+	Rows                   int                                   `json:"rows,omitempty"`
+	DeletedRows            int                                   `json:"deleted_rows,omitempty"`
+	Columns                int                                   `json:"columns,omitempty"`
+	Operation              ColumnPublishOperation                `json:"operation,omitempty"`
+	SerializedAssetBytes   int64                                 `json:"serialized_asset_bytes,omitempty"`
+	FormatHeaderBytes      int64                                 `json:"format_header_bytes,omitempty"`
+	ColumnMetadataBytes    int64                                 `json:"column_metadata_bytes,omitempty"`
+	RowEncodingHeaderBytes int64                                 `json:"row_encoding_header_bytes,omitempty"`
+	RowIDStoredBytes       int64                                 `json:"row_id_stored_bytes,omitempty"`
+	RowIDValueBytes        int64                                 `json:"row_id_value_bytes,omitempty"`
+	RowDeletedFlagBytes    int64                                 `json:"row_deleted_flag_bytes,omitempty"`
+	RowValueHeaderBytes    int64                                 `json:"row_value_header_bytes,omitempty"`
+	RowValuePayloadBytes   int64                                 `json:"row_value_payload_bytes,omitempty"`
+	TotalStoredBytes       int64                                 `json:"total_stored_bytes,omitempty"`
+	BytesPerRow            float64                               `json:"bytes_per_row,omitempty"`
+	ColumnsDetail          []ColumnStoreRowAssetColumnAccounting `json:"columns_detail,omitempty"`
+	columnNames            []string                              `json:"-"`
+}
+
+// ColumnStoreRowAssetColumnAccounting reports row-asset bytes for one row-owned
+// column.
+type ColumnStoreRowAssetColumnAccounting struct {
+	Column            string `json:"column"`
+	Type              string `json:"type"`
+	Rows              int    `json:"rows"`
+	PresentRows       int    `json:"present_rows"`
+	NullRows          int    `json:"null_rows"`
+	ValueHeaderBytes  int64  `json:"value_header_bytes"`
+	ValuePayloadBytes int64  `json:"value_payload_bytes"`
+	StoredBytes       int64  `json:"stored_bytes"`
 }
 
 // ColumnStoreTypedColumnPartAccounting reports one typed-column part image and
@@ -228,6 +276,7 @@ func physicalAccountingFromScanView(ctx context.Context, view columnPhysicalScan
 		DictionaryCodeRefs:         len(view.DictionaryCodes),
 		Int64ValueRefs:             len(view.Int64Values),
 		GraphAssetRefs:             len(view.GraphAssetRefs),
+		RowAssets:                  make([]ColumnStoreRowAssetAccounting, 0, len(view.AssetRefs)),
 		TypedColumnParts:           make([]ColumnStoreTypedColumnPartAccounting, 0, len(view.TypedColumnPartRefs)),
 	}
 	seen := make(map[ColumnAssetRef]struct{})
@@ -261,7 +310,16 @@ func physicalAccountingFromScanView(ctx context.Context, view columnPhysicalScan
 	}
 
 	for _, asset := range view.AssetRefs {
+		if err := ctx.Err(); err != nil {
+			return out, err
+		}
 		addKind(asset.Ref, asset.Rows, &out.Totals.RowAssetBytes)
+		rowAsset, err := columnStoreRowAssetAccountingFromRef(view.ColumnAssetRootDir, view.CollectionName, view.Config, asset, opts)
+		if err != nil {
+			return out, err
+		}
+		out.RowAssets = append(out.RowAssets, rowAsset)
+		addColumnStoreRowAssetByteAccounting(&out.Totals.RowAssetSections, rowAsset.Payload)
 	}
 	for _, asset := range view.TypedColumnPartRefs {
 		if err := ctx.Err(); err != nil {
@@ -307,6 +365,358 @@ func physicalAccountingFromScanView(ctx context.Context, view columnPhysicalScan
 	out.AssetKinds = columnStorePhysicalAccountingKindTotals(kinds)
 	out.Complete = true
 	return out, nil
+}
+
+func columnStoreRowAssetAccountingFromRef(rootDir string, expectedCollection string, cfg ColumnStoreConfig, asset columnManifestAssetRefForScan, opts ColumnStorePhysicalAccountingOptions) (ColumnStoreRowAssetAccounting, error) {
+	raw, err := readColumnPhysicalAssetFromManagerIntoWithIntegrity(rootDir, asset.Ref, nil, opts.ReadIntegrity)
+	if err != nil {
+		return ColumnStoreRowAssetAccounting{}, err
+	}
+	payload, err := columnStoreRowAssetPayloadAccounting(raw, asset.Ref, expectedCollection, cfg, asset.Reason, opts.DetailedSections)
+	if err != nil {
+		return ColumnStoreRowAssetAccounting{}, fmt.Errorf("collections: parse row asset generation=%d part=%d: %w", asset.Ref.Generation, asset.Ref.PartID, err)
+	}
+	if payload.Rows != asset.Rows {
+		return ColumnStoreRowAssetAccounting{}, fmt.Errorf("collections: row asset rows=%d does not match asset rows=%d", payload.Rows, asset.Rows)
+	}
+	return ColumnStoreRowAssetAccounting{
+		Asset: ColumnStorePhysicalAssetAccounting{
+			Ref:    columnStorePhysicalAssetRefAccounting(asset.Ref),
+			Rows:   asset.Rows,
+			Bytes:  positiveColumnStorePhysicalAccountingBytes(asset.Ref.Length),
+			Role:   asset.Role,
+			Reason: asset.Reason,
+		},
+		Payload: payload,
+	}, nil
+}
+
+func columnStoreRowAssetPayloadAccounting(raw []byte, ref ColumnAssetRef, expectedCollection string, cfg ColumnStoreConfig, expectedOperation ColumnPublishOperation, detailed bool) (ColumnStoreRowAssetByteAccounting, error) {
+	if ref.Kind != ColumnAssetKindTCS1PartImage {
+		return ColumnStoreRowAssetByteAccounting{}, fmt.Errorf("row asset kind=%q want %q", ref.Kind, ColumnAssetKindTCS1PartImage)
+	}
+	if int64(len(raw)) != ref.Length {
+		return ColumnStoreRowAssetByteAccounting{}, fmt.Errorf("row asset bytes=%d does not match ref length=%d", len(raw), ref.Length)
+	}
+	cur := manifestCursor{raw: raw}
+	if magic := cur.u32(); magic != columnPhysicalAssetMagic {
+		return ColumnStoreRowAssetByteAccounting{}, fmt.Errorf("bad column physical asset magic=0x%08x", magic)
+	}
+	version := cur.u16()
+	if !isSupportedColumnPhysicalAssetVersion(version) {
+		return ColumnStoreRowAssetByteAccounting{}, fmt.Errorf("unsupported column physical asset version=%d", version)
+	}
+	collection := cur.stringBytes()
+	namespace := cur.stringBytes()
+	generation := cur.u64()
+	partID := cur.u64()
+	appliedCommandLSN := cur.u64()
+	operationBytes := cur.stringBytes()
+	operation, operationOK := columnPhysicalScanOperationFromBytes(operationBytes)
+	schemaHash := cur.u64()
+	columnCount := cur.u64()
+	rowCount := cur.u64()
+	if err := cur.err; err != nil {
+		return ColumnStoreRowAssetByteAccounting{}, err
+	}
+	if columnCount > uint64(maxCollectionInt) {
+		return ColumnStoreRowAssetByteAccounting{}, fmt.Errorf("column physical asset column_count=%d overflows int max=%d", columnCount, maxCollectionInt)
+	}
+	if rowCount > uint64(maxCollectionInt) {
+		return ColumnStoreRowAssetByteAccounting{}, fmt.Errorf("column physical asset row_count=%d overflows int max=%d", rowCount, maxCollectionInt)
+	}
+	header := columnPhysicalAssetScanHeader{
+		Collection:        collection,
+		Namespace:         namespace,
+		Generation:        generation,
+		PartID:            partID,
+		AppliedCommandLSN: appliedCommandLSN,
+		Operation:         operation,
+		SchemaHash:        schemaHash,
+		ColumnCount:       int(columnCount),
+		RowCount:          int(rowCount),
+	}
+	if !operationOK {
+		return ColumnStoreRowAssetByteAccounting{}, fmt.Errorf("unsupported column physical asset operation %q", operationBytes)
+	}
+	if version == columnPhysicalAssetVersionV1 && header.Operation == ColumnPublishOperationDelete {
+		return ColumnStoreRowAssetByteAccounting{}, errors.New("legacy v1 column physical asset delete operation unsupported")
+	}
+	if err := validateColumnPhysicalAssetScanHeader(header, ref, expectedCollection, &cfg); err != nil {
+		return ColumnStoreRowAssetByteAccounting{}, err
+	}
+	if expectedOperation != "" && header.Operation != expectedOperation {
+		return ColumnStoreRowAssetByteAccounting{}, fmt.Errorf("%w: manifest reason=%q asset operation=%q", errColumnPhysicalAssetManifestOperationMismatch, expectedOperation, header.Operation)
+	}
+	if header.ColumnCount != len(cfg.Columns) {
+		return ColumnStoreRowAssetByteAccounting{}, fmt.Errorf("column physical asset columns=%d want %d", header.ColumnCount, len(cfg.Columns))
+	}
+
+	out := ColumnStoreRowAssetByteAccounting{
+		Rows:                 header.RowCount,
+		Columns:              header.ColumnCount,
+		Operation:            header.Operation,
+		SerializedAssetBytes: int64(len(raw)),
+		FormatHeaderBytes:    int64(cur.pos),
+		TotalStoredBytes:     int64(len(raw)),
+		columnNames:          make([]string, 0, header.ColumnCount),
+	}
+	columns := make([]ColumnStoreColumn, header.ColumnCount)
+	columnStart := cur.pos
+	for colIdx := 0; colIdx < header.ColumnCount; colIdx++ {
+		name := cur.stringBytes()
+		path := cur.stringBytes()
+		valueTypeBytes := cur.stringBytes()
+		nullable := cur.bool()
+		dictionary := cur.bool()
+		vectorDims := 0
+		if version >= columnPhysicalAssetVersionV4 {
+			rawVectorDims := cur.u64()
+			if rawVectorDims > uint64(maxCollectionInt) {
+				return ColumnStoreRowAssetByteAccounting{}, errors.New("column physical asset vector_dims overflows int")
+			}
+			vectorDims = int(rawVectorDims)
+		}
+		elementsPerRow := 0
+		if version >= columnPhysicalAssetVersionV6 {
+			rawElementsPerRow := cur.u64()
+			if rawElementsPerRow > uint64(maxCollectionInt) {
+				return ColumnStoreRowAssetByteAccounting{}, errors.New("column physical asset elements_per_row overflows int")
+			}
+			elementsPerRow = int(rawElementsPerRow)
+		}
+		fixedWidthEncoding := ColumnFixedWidthEncodingDefault
+		if version >= columnPhysicalAssetVersionV5 {
+			fixedWidthEncoding = ColumnFixedWidthEncoding(string(cur.stringBytes()))
+			if _, err := normalizeColumnFixedWidthEncoding(fixedWidthEncoding); err != nil {
+				return ColumnStoreRowAssetByteAccounting{}, fmt.Errorf("column physical asset column[%d] fixed_width_encoding: %w", colIdx, err)
+			}
+			if fixedWidthEncoding != ColumnFixedWidthEncodingDefault && !columnStoreValueTypeSupportsFixedWidthEncoding(ColumnStoreValueType(string(valueTypeBytes))) {
+				return ColumnStoreRowAssetByteAccounting{}, fmt.Errorf("column physical asset column[%d] fixed_width_encoding unsupported for value_type %q", colIdx, string(valueTypeBytes))
+			}
+			if fixedWidthEncoding != ColumnFixedWidthEncodingDefault && columnStoreValueTypeHasScalarFixedWidthPayload(ColumnStoreValueType(string(valueTypeBytes))) {
+				return ColumnStoreRowAssetByteAccounting{}, fmt.Errorf("column physical asset column[%d] scalar fixed_width_encoding unsupported for value_type %q", colIdx, string(valueTypeBytes))
+			}
+		}
+		if cur.err != nil {
+			return ColumnStoreRowAssetByteAccounting{}, cur.err
+		}
+		got := ColumnStoreColumn{
+			Name:               string(name),
+			Path:               string(path),
+			ValueType:          ColumnStoreValueType(string(valueTypeBytes)),
+			Nullable:           nullable,
+			Dictionary:         dictionary,
+			VectorDims:         vectorDims,
+			ElementsPerRow:     elementsPerRow,
+			FixedWidthEncoding: fixedWidthEncoding,
+		}
+		want := cfg.Columns[colIdx]
+		geometryMatches := got.VectorDims == want.VectorDims && got.ElementsPerRow == want.ElementsPerRow
+		if got.ValueType == ColumnStoreValueFloat32Vector && want.ValueType == ColumnStoreValueFloat32Vector {
+			gotWidth := columnStoreFloat32VectorElementsPerRow(got)
+			geometryMatches = gotWidth == columnStoreFloat32VectorElementsPerRow(want)
+		}
+		if got.Name != want.Name ||
+			got.Path != want.Path ||
+			got.ValueType != want.ValueType ||
+			got.Nullable != want.Nullable ||
+			got.Dictionary != want.Dictionary ||
+			!geometryMatches ||
+			got.FixedWidthEncoding != want.FixedWidthEncoding {
+			return ColumnStoreRowAssetByteAccounting{}, fmt.Errorf("column physical asset column[%d]=%+v want %+v", colIdx, got, want)
+		}
+		columns[colIdx] = got
+		out.columnNames = append(out.columnNames, got.Name)
+	}
+	out.ColumnMetadataBytes = int64(cur.pos - columnStart)
+
+	columnDetails := make([]ColumnStoreRowAssetColumnAccounting, header.ColumnCount)
+	for i, col := range columns {
+		columnDetails[i] = ColumnStoreRowAssetColumnAccounting{
+			Column: col.Name,
+			Type:   string(col.ValueType),
+		}
+	}
+	if version >= columnPhysicalAssetVersionV7 {
+		rowEncodingHeaderStart := cur.pos
+		rowEncoding := cur.string()
+		if rowEncoding != columnPhysicalAssetRowEncodingFixedID {
+			return ColumnStoreRowAssetByteAccounting{}, fmt.Errorf("unsupported column physical asset row encoding %q", rowEncoding)
+		}
+		if header.ColumnCount != 0 {
+			return ColumnStoreRowAssetByteAccounting{}, fmt.Errorf("column physical asset row encoding %q requires zero columns", rowEncoding)
+		}
+		idWidth := cur.u64()
+		if cur.err != nil {
+			return ColumnStoreRowAssetByteAccounting{}, cur.err
+		}
+		if idWidth == 0 || idWidth > uint64(maxCollectionInt) {
+			return ColumnStoreRowAssetByteAccounting{}, fmt.Errorf("column physical asset fixed id width=%d invalid", idWidth)
+		}
+		out.RowEncodingHeaderBytes = int64(cur.pos - rowEncodingHeaderStart)
+		deleted := header.Operation == ColumnPublishOperationDelete
+		if header.Operation != ColumnPublishOperationInsert && header.Operation != ColumnPublishOperationUpdate && header.Operation != ColumnPublishOperationDelete {
+			return ColumnStoreRowAssetByteAccounting{}, fmt.Errorf("unsupported column physical asset operation %q", header.Operation)
+		}
+		for rowIdx := 0; rowIdx < header.RowCount; rowIdx++ {
+			if uint64(len(raw)-cur.pos) < idWidth {
+				return ColumnStoreRowAssetByteAccounting{}, errors.New("short column physical asset fixed row id block")
+			}
+			cur.pos += int(idWidth)
+			out.RowIDStoredBytes = addColumnStorePhysicalAccountingBytes(out.RowIDStoredBytes, int64(idWidth))
+			out.RowIDValueBytes = addColumnStorePhysicalAccountingBytes(out.RowIDValueBytes, int64(idWidth))
+			if deleted {
+				out.DeletedRows++
+			}
+		}
+		if cur.err != nil {
+			return ColumnStoreRowAssetByteAccounting{}, cur.err
+		}
+		if cur.pos != len(raw) {
+			return ColumnStoreRowAssetByteAccounting{}, errors.New("trailing bytes in column physical asset")
+		}
+		if out.Rows > 0 {
+			out.BytesPerRow = float64(out.TotalStoredBytes) / float64(out.Rows)
+		}
+		return out, nil
+	}
+	for rowIdx := 0; rowIdx < header.RowCount; rowIdx++ {
+		idStart := cur.pos
+		id := cur.bytesView()
+		if cur.err != nil {
+			return ColumnStoreRowAssetByteAccounting{}, cur.err
+		}
+		out.RowIDStoredBytes = addColumnStorePhysicalAccountingBytes(out.RowIDStoredBytes, int64(cur.pos-idStart))
+		out.RowIDValueBytes = addColumnStorePhysicalAccountingBytes(out.RowIDValueBytes, int64(len(id)))
+		deleted := false
+		if version >= columnPhysicalAssetVersionV2 {
+			deletedStart := cur.pos
+			deleted = cur.bool()
+			if cur.err != nil {
+				return ColumnStoreRowAssetByteAccounting{}, cur.err
+			}
+			out.RowDeletedFlagBytes = addColumnStorePhysicalAccountingBytes(out.RowDeletedFlagBytes, int64(cur.pos-deletedStart))
+		}
+		if deleted {
+			if header.Operation != ColumnPublishOperationDelete {
+				return ColumnStoreRowAssetByteAccounting{}, fmt.Errorf("column physical asset %s row[%d] is marked deleted", header.Operation, rowIdx)
+			}
+			out.DeletedRows++
+			continue
+		}
+		if header.Operation == ColumnPublishOperationDelete {
+			return ColumnStoreRowAssetByteAccounting{}, fmt.Errorf("column physical asset delete row[%d] is not marked deleted", rowIdx)
+		}
+		for colIdx, col := range columns {
+			valueHeaderStart := cur.pos
+			typeBytes := cur.stringBytes()
+			if cur.err != nil {
+				return ColumnStoreRowAssetByteAccounting{}, cur.err
+			}
+			if !columnPhysicalBytesEqualString(typeBytes, string(col.ValueType)) {
+				return ColumnStoreRowAssetByteAccounting{}, fmt.Errorf("row[%d] column[%d] type=%q want %q", rowIdx, colIdx, string(typeBytes), col.ValueType)
+			}
+			null := cur.bool()
+			if cur.err != nil {
+				return ColumnStoreRowAssetByteAccounting{}, cur.err
+			}
+			present := true
+			if version >= columnPhysicalAssetVersionV3 {
+				present = cur.bool()
+				if cur.err != nil {
+					return ColumnStoreRowAssetByteAccounting{}, cur.err
+				}
+			}
+			valueHeaderBytes := int64(cur.pos - valueHeaderStart)
+			out.RowValueHeaderBytes = addColumnStorePhysicalAccountingBytes(out.RowValueHeaderBytes, valueHeaderBytes)
+			columnDetails[colIdx].Rows++
+			columnDetails[colIdx].ValueHeaderBytes = addColumnStorePhysicalAccountingBytes(columnDetails[colIdx].ValueHeaderBytes, valueHeaderBytes)
+			if !present {
+				if !null {
+					return ColumnStoreRowAssetByteAccounting{}, fmt.Errorf("row[%d] column[%d] absent value is not null", rowIdx, colIdx)
+				}
+				if !col.Nullable {
+					return ColumnStoreRowAssetByteAccounting{}, fmt.Errorf("row[%d] column[%d] is absent but column is not nullable", rowIdx, colIdx)
+				}
+				columnDetails[colIdx].NullRows++
+				continue
+			}
+			columnDetails[colIdx].PresentRows++
+			if null {
+				if !col.Nullable {
+					return ColumnStoreRowAssetByteAccounting{}, fmt.Errorf("row[%d] column[%d] is null but column is not nullable", rowIdx, colIdx)
+				}
+				columnDetails[colIdx].NullRows++
+				continue
+			}
+			valuePayloadStart := cur.pos
+			if err := skipColumnStoreRowAssetValuePayload(&cur, col); err != nil {
+				return ColumnStoreRowAssetByteAccounting{}, fmt.Errorf("row[%d] column[%d]: %w", rowIdx, colIdx, err)
+			}
+			valuePayloadBytes := int64(cur.pos - valuePayloadStart)
+			out.RowValuePayloadBytes = addColumnStorePhysicalAccountingBytes(out.RowValuePayloadBytes, valuePayloadBytes)
+			columnDetails[colIdx].ValuePayloadBytes = addColumnStorePhysicalAccountingBytes(columnDetails[colIdx].ValuePayloadBytes, valuePayloadBytes)
+		}
+	}
+	if cur.err != nil {
+		return ColumnStoreRowAssetByteAccounting{}, cur.err
+	}
+	if cur.pos != len(raw) {
+		return ColumnStoreRowAssetByteAccounting{}, errors.New("trailing bytes in column physical asset")
+	}
+	if out.Rows > 0 {
+		out.BytesPerRow = float64(out.TotalStoredBytes) / float64(out.Rows)
+	}
+	if detailed && len(columnDetails) != 0 {
+		for i := range columnDetails {
+			columnDetails[i].StoredBytes = addColumnStorePhysicalAccountingBytes(columnDetails[i].ValueHeaderBytes, columnDetails[i].ValuePayloadBytes)
+		}
+		out.ColumnsDetail = columnDetails
+	}
+	return out, nil
+}
+
+func skipColumnStoreRowAssetValuePayload(cur *manifestCursor, col ColumnStoreColumn) error {
+	switch col.ValueType {
+	case ColumnStoreValueBool:
+		_ = cur.bool()
+	case ColumnStoreValueInt64:
+		_ = cur.u64()
+	case ColumnStoreValueFloat32:
+		_ = cur.u32()
+	case ColumnStoreValueDouble:
+		_ = cur.u64()
+	case ColumnStoreValueString:
+		_ = cur.stringBytes()
+	case ColumnStoreValueInt8:
+		_ = cur.u8()
+	case ColumnStoreValueUint8:
+		_ = cur.u8()
+	case ColumnStoreValueInt16:
+		_ = cur.u16()
+	case ColumnStoreValueUint16:
+		_ = cur.u16()
+	case ColumnStoreValueInt32:
+		_ = cur.u32()
+	case ColumnStoreValueUint32:
+		_ = cur.u32()
+	case ColumnStoreValueUint64:
+		_ = cur.u64()
+	case ColumnStoreValueFloat16:
+		_ = cur.u16()
+	case ColumnStoreValueBFloat16:
+		_ = cur.u16()
+	case ColumnStoreValueFloat32Vector:
+		cur.skipFloat32SliceWithExpectedLength(columnStoreFloat32VectorElementsPerRow(col))
+	case ColumnStoreValueUint8Vector, ColumnStoreValueInt8Vector, ColumnStoreValueUint16Vector, ColumnStoreValueInt16Vector, ColumnStoreValueUint32Vector, ColumnStoreValueInt32Vector, ColumnStoreValueUint64Vector, ColumnStoreValueInt64Vector, ColumnStoreValueFloat16Vector, ColumnStoreValueBFloat16Vector, ColumnStoreValueFloat64Vector:
+		cur.skipDenseNumericVectorBytesWithExpectedLength(col)
+	case ColumnStoreValueUint32List, ColumnStoreValueAdjacencyList:
+		cur.skipUint32Slice()
+	default:
+		return fmt.Errorf("unsupported column physical value type %q", col.ValueType)
+	}
+	return cur.err
 }
 
 func columnStoreTypedColumnPartAccountingFromRef(rootDir string, asset columnManifestAssetRefForScan, opts ColumnStorePhysicalAccountingOptions) (ColumnStoreTypedColumnPartAccounting, error) {
@@ -513,6 +923,69 @@ func columnStoreTypedColumnPartImageColumnNames(image typedcolumn.ColumnPartImag
 	}
 	sort.Strings(out)
 	return out
+}
+
+func addColumnStoreRowAssetByteAccounting(dst *ColumnStoreRowAssetByteAccounting, src ColumnStoreRowAssetByteAccounting) {
+	if dst == nil {
+		return
+	}
+	dst.Rows = addColumnStorePhysicalAccountingRows(dst.Rows, src.Rows)
+	dst.DeletedRows = addColumnStorePhysicalAccountingRows(dst.DeletedRows, src.DeletedRows)
+	addColumnStoreRowAssetByteAccountingColumns(dst, src)
+	if dst.Operation == "" {
+		dst.Operation = src.Operation
+	} else if src.Operation != "" && dst.Operation != src.Operation {
+		dst.Operation = ""
+	}
+	dst.SerializedAssetBytes = addColumnStorePhysicalAccountingBytes(dst.SerializedAssetBytes, src.SerializedAssetBytes)
+	dst.FormatHeaderBytes = addColumnStorePhysicalAccountingBytes(dst.FormatHeaderBytes, src.FormatHeaderBytes)
+	dst.ColumnMetadataBytes = addColumnStorePhysicalAccountingBytes(dst.ColumnMetadataBytes, src.ColumnMetadataBytes)
+	dst.RowEncodingHeaderBytes = addColumnStorePhysicalAccountingBytes(dst.RowEncodingHeaderBytes, src.RowEncodingHeaderBytes)
+	dst.RowIDStoredBytes = addColumnStorePhysicalAccountingBytes(dst.RowIDStoredBytes, src.RowIDStoredBytes)
+	dst.RowIDValueBytes = addColumnStorePhysicalAccountingBytes(dst.RowIDValueBytes, src.RowIDValueBytes)
+	dst.RowDeletedFlagBytes = addColumnStorePhysicalAccountingBytes(dst.RowDeletedFlagBytes, src.RowDeletedFlagBytes)
+	dst.RowValueHeaderBytes = addColumnStorePhysicalAccountingBytes(dst.RowValueHeaderBytes, src.RowValueHeaderBytes)
+	dst.RowValuePayloadBytes = addColumnStorePhysicalAccountingBytes(dst.RowValuePayloadBytes, src.RowValuePayloadBytes)
+	dst.TotalStoredBytes = addColumnStorePhysicalAccountingBytes(dst.TotalStoredBytes, src.TotalStoredBytes)
+	if dst.Rows > 0 {
+		dst.BytesPerRow = float64(dst.TotalStoredBytes) / float64(dst.Rows)
+	}
+}
+
+func addColumnStoreRowAssetByteAccountingColumns(dst *ColumnStoreRowAssetByteAccounting, src ColumnStoreRowAssetByteAccounting) {
+	if dst == nil {
+		return
+	}
+	if len(src.columnNames) == 0 {
+		if src.Columns > dst.Columns {
+			dst.Columns = src.Columns
+		}
+		return
+	}
+	if len(dst.columnNames) == 0 && dst.Columns == 0 {
+		dst.columnNames = append(dst.columnNames[:0], src.columnNames...)
+		dst.Columns = len(dst.columnNames)
+		return
+	}
+	if len(dst.columnNames) == 0 && dst.Columns > 0 {
+		if src.Columns > dst.Columns {
+			dst.Columns = src.Columns
+		}
+		return
+	}
+	seen := make(map[string]struct{}, len(dst.columnNames)+len(src.columnNames))
+	for _, column := range dst.columnNames {
+		seen[column] = struct{}{}
+	}
+	for _, column := range src.columnNames {
+		seen[column] = struct{}{}
+	}
+	dst.columnNames = dst.columnNames[:0]
+	for column := range seen {
+		dst.columnNames = append(dst.columnNames, column)
+	}
+	sort.Strings(dst.columnNames)
+	dst.Columns = len(dst.columnNames)
 }
 
 func addColumnStoreTypedColumnPartByteAccounting(dst *ColumnStoreTypedColumnPartByteAccounting, src ColumnStoreTypedColumnPartByteAccounting) {

--- a/TreeDB/collections/column_store_physical_accounting_test.go
+++ b/TreeDB/collections/column_store_physical_accounting_test.go
@@ -33,8 +33,60 @@ func TestColumnStorePhysicalAccountingReportsTypedColumnSections2118(t *testing.
 	if got, want := accounting.TypedColumnPartRefs, 1; got != want {
 		t.Fatalf("typed part refs=%d want %d", got, want)
 	}
+	if got, want := accounting.RowAssetRefs, 1; got != want {
+		t.Fatalf("row asset refs=%d want %d", got, want)
+	}
+	if got, want := len(accounting.RowAssets), 1; got != want {
+		t.Fatalf("row assets=%d want %d", got, want)
+	}
 	if got, want := len(accounting.TypedColumnParts), 1; got != want {
 		t.Fatalf("typed parts=%d want %d", got, want)
+	}
+
+	rowAsset := accounting.RowAssets[0]
+	if rowAsset.Asset.Ref.Kind != ColumnAssetKindTCS1PartImage {
+		t.Fatalf("row asset kind=%q want %q", rowAsset.Asset.Ref.Kind, ColumnAssetKindTCS1PartImage)
+	}
+	if got, want := rowAsset.Asset.Rows, len(events); got != want {
+		t.Fatalf("row asset rows=%d want %d", got, want)
+	}
+	if rowAsset.Payload.TotalStoredBytes != rowAsset.Asset.Bytes || rowAsset.Payload.SerializedAssetBytes != rowAsset.Asset.Bytes {
+		t.Fatalf("row payload bytes=%d serialized=%d asset=%d", rowAsset.Payload.TotalStoredBytes, rowAsset.Payload.SerializedAssetBytes, rowAsset.Asset.Bytes)
+	}
+	if got, want := rowAsset.Payload.Columns, 0; got != want {
+		t.Fatalf("row asset columns=%d want %d for all-typed-column fixture", got, want)
+	}
+	if got, want := rowAsset.Payload.Rows, len(events); got != want {
+		t.Fatalf("row payload rows=%d want %d", got, want)
+	}
+	if rowAsset.Payload.FormatHeaderBytes == 0 || rowAsset.Payload.RowEncodingHeaderBytes == 0 || rowAsset.Payload.RowIDStoredBytes == 0 {
+		t.Fatalf("row payload accounting missing header/encoding/id bytes: %+v", rowAsset.Payload)
+	}
+	var wantIDValueBytes int64
+	for _, event := range events {
+		wantIDValueBytes += int64(len(event.ID))
+	}
+	if got := rowAsset.Payload.RowIDValueBytes; got != wantIDValueBytes {
+		t.Fatalf("row id value bytes=%d want %d", got, wantIDValueBytes)
+	}
+	if got, want := rowAsset.Payload.RowIDStoredBytes, wantIDValueBytes; got != want {
+		t.Fatalf("row id stored bytes=%d want %d", got, want)
+	}
+	if got, want := rowAsset.Payload.RowDeletedFlagBytes, int64(0); got != want {
+		t.Fatalf("row deleted flag bytes=%d want %d", got, want)
+	}
+	if rowAsset.Payload.RowValueHeaderBytes != 0 || rowAsset.Payload.RowValuePayloadBytes != 0 || len(rowAsset.Payload.ColumnsDetail) != 0 {
+		t.Fatalf("row value bytes/detail should be empty for zero row-owned columns: %+v", rowAsset.Payload)
+	}
+	rowCategoryBytes := rowAsset.Payload.FormatHeaderBytes +
+		rowAsset.Payload.ColumnMetadataBytes +
+		rowAsset.Payload.RowEncodingHeaderBytes +
+		rowAsset.Payload.RowIDStoredBytes +
+		rowAsset.Payload.RowDeletedFlagBytes +
+		rowAsset.Payload.RowValueHeaderBytes +
+		rowAsset.Payload.RowValuePayloadBytes
+	if rowCategoryBytes != rowAsset.Payload.TotalStoredBytes {
+		t.Fatalf("row category bytes=%d want total stored bytes %d", rowCategoryBytes, rowAsset.Payload.TotalStoredBytes)
 	}
 
 	part := accounting.TypedColumnParts[0]
@@ -92,6 +144,12 @@ func TestColumnStorePhysicalAccountingReportsTypedColumnSections2118(t *testing.
 
 	if got, want := accounting.Totals.TypedColumnPartBytes, typedRefs[0].Length; got != want {
 		t.Fatalf("typed column part total=%d want %d", got, want)
+	}
+	if got, want := accounting.Totals.RowAssetSections.TotalStoredBytes, accounting.Totals.RowAssetBytes; got != want {
+		t.Fatalf("row section total=%d want row asset bytes %d", got, want)
+	}
+	if got, want := accounting.Totals.RowAssetSections.RowIDValueBytes, wantIDValueBytes; got != want {
+		t.Fatalf("total row id value bytes=%d want %d", got, want)
 	}
 	if got, want := accounting.Totals.TypedColumnSections.TotalStoredBytes, accounting.Totals.TypedColumnPartBytes; got != want {
 		t.Fatalf("typed section total=%d want typed part bytes %d", got, want)

--- a/TreeDB/collections/typed_storage_naming_test.go
+++ b/TreeDB/collections/typed_storage_naming_test.go
@@ -367,7 +367,7 @@ var typedStorageLegacyNameAllowlist = []typedStorageLegacyNameAllowlistEntry{
 	{path: "TreeDB/collections/column_physical_typed_column_sortkey_1948_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 51, occurrences: 59},
 	{path: "TreeDB/collections/column_physical_query_test.go", classification: typedStorageLegacyDeferred, matchingLines: 175, occurrences: 198},
 	{path: "TreeDB/collections/column_physical_row_reader.go", classification: typedStorageLegacyDeferred, matchingLines: 39, occurrences: 64},
-	{path: "TreeDB/collections/column_physical_row_reader_test.go", classification: typedStorageLegacyDeferred, matchingLines: 24, occurrences: 27},
+	{path: "TreeDB/collections/column_physical_row_reader_test.go", classification: typedStorageLegacyDeferred, matchingLines: 30, occurrences: 34},
 	{path: "TreeDB/collections/column_physical_scan.go", classification: typedStorageLegacyDeferred, matchingLines: 50, occurrences: 61},
 	{path: "TreeDB/collections/column_physical_scan_test.go", classification: typedStorageLegacyDeferred, matchingLines: 36, occurrences: 43},
 	{path: "TreeDB/collections/column_physical_visibility.go", classification: typedStorageLegacyDeferred, matchingLines: 9, occurrences: 9},

--- a/TreeDB/collections/typed_storage_naming_test.go
+++ b/TreeDB/collections/typed_storage_naming_test.go
@@ -404,7 +404,7 @@ var typedStorageLegacyNameAllowlist = []typedStorageLegacyNameAllowlistEntry{
 	{path: "TreeDB/collections/column_store_compaction.go", classification: typedStorageLegacyCompatibility, matchingLines: 34, occurrences: 41},
 	{path: "TreeDB/collections/column_store_compaction_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 71, occurrences: 82},
 	{path: "TreeDB/collections/column_store_compatibility_api_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 7, occurrences: 9},
-	{path: "TreeDB/collections/column_store_physical_accounting.go", classification: typedStorageLegacyCompatibility, matchingLines: 107, occurrences: 119},
+	{path: "TreeDB/collections/column_store_physical_accounting.go", classification: typedStorageLegacyCompatibility, matchingLines: 222, occurrences: 254},
 	{path: "TreeDB/collections/column_store_physical_accounting_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 23, occurrences: 29},
 	{path: "TreeDB/collections/column_store_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 273, occurrences: 349},
 	{path: "TreeDB/collections/scalar_primitive.go", classification: typedStorageLegacyCompatibility, matchingLines: 36, occurrences: 42},

--- a/TreeDB/docs/spec/storage-format.md
+++ b/TreeDB/docs/spec/storage-format.md
@@ -689,6 +689,22 @@ row-owned fields; the matching `tcs1_typed_column_part` for the same non-delete
 generation contains authoritative scalar, fixed-dimension `float32_vector`,
 Issue #1930 dense numeric vector, and non-null variable-width `uint32_list`
 typed-column values keyed by row index.
+
+Version 7 has a compact row-locator encoding for the common
+`typed_column_part` case where the row asset has zero row-owned columns and all
+row ids in the part have the same byte width:
+
+```text
+string   RowEncoding = "fixed_id"
+u64      RowIDWidth
+bytes    RowID[RowCount]    // contiguous fixed-width row ids
+```
+
+V7 stores no per-row length prefixes and no per-row deleted flags. Insert/update
+parts are all live rows; delete/tombstone parts are all deleted rows. Assets with
+row-owned columns, mixed-width row ids, or legacy payloads continue to use the
+generic row payload.
+
 Latest-visible readers resolve document identity from the typed-row
 row/tombstone assets first, then read the typed-column part for the winning
 non-deleted generation+row. Readers validate namespace, generation, part id,

--- a/TreeDB/docs/spec/typed-column-production-jsonbench-plan.md
+++ b/TreeDB/docs/spec/typed-column-production-jsonbench-plan.md
@@ -108,6 +108,9 @@ Rows:
 Size:
 
 - variable header plus variable row/document/value payloads
+- zero-row-column parts with fixed-width document ids can use the TCPA V7
+  `fixed_id` row encoding, which stores contiguous ids and derives deleted
+  state from the asset operation
 - `ColumnPreparedAsset.Bytes` and `ColumnAssetRef.Length` are the authoritative
   stored byte counts
 

--- a/docs/TREEDB_STORAGE_FORMAT.md
+++ b/docs/TREEDB_STORAGE_FORMAT.md
@@ -73,11 +73,11 @@ row-locator `TCPA` asset and row count, while delete/tombstone generations have
 only the row-locator/tombstone part. GC/rewrite must enumerate those refs from
 manifest/control roots, not by scanning row documents.
 
-The typed-row physical part payload uses the `TCPA` envelope, version 3:
+The typed-row physical part payload uses the versioned `TCPA` envelope:
 
 ```text
 u32      Magic = "TCPA"
-u16      Version = 3
+u16      Version
 string   Collection
 string   Namespace
 u64      Generation
@@ -91,11 +91,20 @@ columns  declared column descriptors
 rows     row id + deleted flag + optional declared column values
 ```
 
-Insert and update rows must have `deleted=false` and one declared value per
-`typed_row_asset` column in the row asset. Each declared value stores its type,
-null bit, and present bit; the present bit distinguishes an omitted nullable JSON
-path from an explicit JSON `null` so retained-payload reconstruction remains
-lossless. Delete/tombstone rows must have `deleted=true` and no column values.
+Generic row payload versions store each row as length-prefixed row id bytes,
+deleted flag, and optional declared values. Insert and update rows must have
+`deleted=false` and one declared value per `typed_row_asset` column in the row
+asset. Each declared value stores its type, null bit, and present bit; the
+present bit distinguishes an omitted nullable JSON path from an explicit JSON
+`null` so retained-payload reconstruction remains lossless. Delete/tombstone
+rows must have `deleted=true` and no column values.
+
+Version 7 may be used when the row asset has zero row-owned columns and all row
+ids in the part have the same byte width. After the column descriptors it stores
+a fixed-id row encoding marker, the id width, then contiguous row id bytes.
+The deleted/tombstone state is derived from the asset operation, so insert/update
+parts are all live rows and delete parts are all tombstones.
+
 For layouts with `typed_column_part` owners, a `TCPA` row asset is still
 published for row IDs/tombstones and row-owned fields; the matching
 `tcs1_typed_column_part` for the same generation contains authoritative scalar


### PR DESCRIPTION
## Summary

- Adds TCPA V7 `fixed_id` row encoding for zero-column row assets with fixed-width row IDs.
- Updates decode, streaming scan, and physical accounting to understand V7 row assets.
- Extends storage docs/specs with the new row-locator format and row-asset accounting.

This is a partial #2663 storage slice. It does not close #2663; the remaining column-asset target work is dictionaries, pruning metadata, and declared-column density.

## Storage Evidence

Baseline:
`/tmp/jsonbench_2663_current_lz4_1m_full_20260613_083200/1m_column-store-full-prepared_json_full_all_compacted/result.json`

Candidate, latest `origin/main` merged, head `166bad61d`:
`/tmp/jsonbench_2663_row_asset_v7_1m_full_latest_20260613_092629/1m_column-store-full-prepared_json_full_all_compacted/result.json`

Command shape:

```sh
OUT_DIR=/tmp/jsonbench_2663_row_asset_v7_1m_full_latest_$(date -u +%Y%m%d_%H%M%S) \
GOMAP_REPLACE=/Users/michaelseiler/orca/workspaces/gomap/2680-clickhouse-part-audit \
DATA_DIR="$HOME/data/bluesky" \
ROWS=1000000 \
TRIES=1 \
SUITE=full \
STORAGE_LAYOUTS=column-store-full-prepared \
COMPACT_AFTER_LOAD=1 \
TREEDB_COLUMN_STORE_RETAINED_PAYLOAD_ENCODING=semantic-stream-v1 \
PROFILE=fast \
DATA_ROOT=fast \
BATCH_SIZE=16000 \
./run_columnstore_benchmark.sh
```

1M rows, full retained JSON, `column-store-full-prepared`, compacted, one try:

| metric | baseline | candidate | delta |
|---|---:|---:|---:|
| WAL-excluded durable bytes | 163,429,472 | 154,432,199 | -8,997,273 |
| column asset segments | 51,663,196 | 42,664,708 | -8,998,488 |
| row asset bytes | 17,007,056 | 8,008,568 | -8,998,488 |
| typed-column part bytes | 34,656,140 | 34,656,140 | 0 |
| value_vlog bytes | 99,553,531 | 99,553,531 | 0 |

Candidate row-asset accounting:

- rows: 1,000,000
- serialized row asset bytes: 8,008,568
- row ID stored bytes: 8,000,000
- row ID value bytes: 8,000,000
- bytes per row: 8.008568

Single-try query timings, for regression smoke only:

| query | baseline | candidate | delta |
|---|---:|---:|---:|
| q1 | 0.053939583s | 0.053346833s | -0.000592750s |
| q2 | 0.580039083s | 0.451901709s | -0.128137374s |
| q3 | 0.190131625s | 0.158348834s | -0.031782791s |
| q4 | 0.251388209s | 0.206935625s | -0.044452584s |
| q5 | 0.201990791s | 0.145871208s | -0.056119583s |

Supplemental storage audit, retained payload audit skipped:
`/tmp/treedb_2663_row_asset_v7_storage_audit_skipretained_latest_20260613_092720/compression_audit.md`

The audit reports #2663 current column assets at 42,664,708 bytes versus the 25,000,000 byte target, leaving 17,664,708 bytes of column work. #2662 is unchanged by this PR: value_vlog is still 99,553,531 bytes in the benchmark result.

## Tests

```sh
GOTOOLCHAIN=go1.26.4 GOFLAGS=-mod=mod go test ./TreeDB/collections -run 'TestColumnPhysicalJSONBenchTypedColumnPartDirectPreparedReopen1947|TestColumnStorePhysicalAccounting|TestPhysicalAccounting|TestColumnPhysicalQ4BTopKSortedLatestVisibleMutation1953|TestTypedStorageLegacyNameAllowlistIsComplete' -count=1
GOTOOLCHAIN=go1.26.4 GOFLAGS=-mod=mod go test ./cmd/treedb_column_section_audit ./cmd/unified_bench
GOTOOLCHAIN=go1.26.4 GOFLAGS=-mod=mod go test ./TreeDB/docs -run 'Test.*Storage|Test.*Format|TestTypedStorageSpecLinksResolve' -count=1
GOTOOLCHAIN=go1.26.4 GOFLAGS=-mod=mod go test ./TreeDB/collections -count=1
git diff --check
```

Refs #2663
Refs #2359
Refs #2353
Refs #1462
Refs #2680
