### PR TITLE
treedb: audit semantic-stream retained block layout

### DIFF
--- a/TreeDB/collections/column_retained_payload_audit.go
+++ b/TreeDB/collections/column_retained_payload_audit.go
@@ -92,6 +92,10 @@ type ColumnRetainedPayloadCollectionAuditOptions struct {
 	IncludeSemanticStreams  bool
 	SemanticStreamMaxDepth  int
 	SemanticStreamMaxPaths  int
+	// IncludeSemanticStreamBlockLayout parses semantic-stream-v1 side-root
+	// blocks directly. It is only valid for semantic-stream-v1 collections.
+	IncludeSemanticStreamBlockLayout bool
+	SemanticStreamBlockMaxPaths      int
 }
 
 type ColumnRetainedPayloadCollectionPathViolation struct {
@@ -166,28 +170,29 @@ type ColumnRetainedPayloadSemanticStreamStat struct {
 }
 
 type ColumnRetainedPayloadCollectionAuditResult struct {
-	Collection                              string                                         `json:"collection"`
-	Status                                  string                                         `json:"status"`
-	RetainedPayloadPolicy                   ColumnRetainedPayloadPolicy                    `json:"retained_payload_policy"`
-	RetainedPayloadEncoding                 string                                         `json:"retained_payload_encoding"`
-	RetainedPayloadEncodingStatus           string                                         `json:"retained_payload_encoding_status"`
-	RetainedPayloadCompression              string                                         `json:"retained_payload_compression"`
-	RetainedPayloadCompressionPolicy        string                                         `json:"retained_payload_compression_policy"`
-	RetainedPayloadCompressionStatus        string                                         `json:"retained_payload_compression_status"`
-	DeclaredPaths                           []string                                       `json:"declared_paths"`
-	CheckedRows                             int                                            `json:"checked_rows"`
-	RetainedPayloadBytes                    int64                                          `json:"retained_payload_bytes"`
-	RetainedPayloadShape                    []ColumnRetainedPayloadShapePathStat           `json:"retained_payload_shape,omitempty"`
-	RetainedPayloadShapeTruncated           bool                                           `json:"retained_payload_shape_truncated,omitempty"`
-	RetainedPayloadValueFamilies            []ColumnRetainedPayloadValueFamilyStat         `json:"retained_payload_value_families,omitempty"`
-	RetainedPayloadValueFamiliesTruncated   bool                                           `json:"retained_payload_value_families_truncated,omitempty"`
-	RetainedPayloadSemanticStreams          []ColumnRetainedPayloadSemanticStreamStat      `json:"retained_payload_semantic_streams,omitempty"`
-	RetainedPayloadSemanticStreamsTruncated bool                                           `json:"retained_payload_semantic_streams_truncated,omitempty"`
-	RetainedPayloadSemanticStreamInputBytes int64                                          `json:"retained_payload_semantic_stream_input_bytes,omitempty"`
-	RetainedPayloadSemanticStreamZSTDBytes  int64                                          `json:"retained_payload_semantic_stream_zstd_bytes,omitempty"`
-	Truncated                               bool                                           `json:"truncated,omitempty"`
-	Violations                              []ColumnRetainedPayloadCollectionPathViolation `json:"violations,omitempty"`
-	Errors                                  []string                                       `json:"errors,omitempty"`
+	Collection                               string                                          `json:"collection"`
+	Status                                   string                                          `json:"status"`
+	RetainedPayloadPolicy                    ColumnRetainedPayloadPolicy                     `json:"retained_payload_policy"`
+	RetainedPayloadEncoding                  string                                          `json:"retained_payload_encoding"`
+	RetainedPayloadEncodingStatus            string                                          `json:"retained_payload_encoding_status"`
+	RetainedPayloadCompression               string                                          `json:"retained_payload_compression"`
+	RetainedPayloadCompressionPolicy         string                                          `json:"retained_payload_compression_policy"`
+	RetainedPayloadCompressionStatus         string                                          `json:"retained_payload_compression_status"`
+	DeclaredPaths                            []string                                        `json:"declared_paths"`
+	CheckedRows                              int                                             `json:"checked_rows"`
+	RetainedPayloadBytes                     int64                                           `json:"retained_payload_bytes"`
+	RetainedPayloadShape                     []ColumnRetainedPayloadShapePathStat            `json:"retained_payload_shape,omitempty"`
+	RetainedPayloadShapeTruncated            bool                                            `json:"retained_payload_shape_truncated,omitempty"`
+	RetainedPayloadValueFamilies             []ColumnRetainedPayloadValueFamilyStat          `json:"retained_payload_value_families,omitempty"`
+	RetainedPayloadValueFamiliesTruncated    bool                                            `json:"retained_payload_value_families_truncated,omitempty"`
+	RetainedPayloadSemanticStreams           []ColumnRetainedPayloadSemanticStreamStat       `json:"retained_payload_semantic_streams,omitempty"`
+	RetainedPayloadSemanticStreamsTruncated  bool                                            `json:"retained_payload_semantic_streams_truncated,omitempty"`
+	RetainedPayloadSemanticStreamInputBytes  int64                                           `json:"retained_payload_semantic_stream_input_bytes,omitempty"`
+	RetainedPayloadSemanticStreamZSTDBytes   int64                                           `json:"retained_payload_semantic_stream_zstd_bytes,omitempty"`
+	RetainedPayloadSemanticStreamBlockLayout *ColumnRetainedSemanticStreamV1BlockLayoutAudit `json:"retained_payload_semantic_stream_block_layout,omitempty"`
+	Truncated                                bool                                            `json:"truncated,omitempty"`
+	Violations                               []ColumnRetainedPayloadCollectionPathViolation  `json:"violations,omitempty"`
+	Errors                                   []string                                        `json:"errors,omitempty"`
 }
 
 // AuditColumnRetainedPayloadPathsAbsent verifies that declared typed JSON paths
@@ -275,9 +280,12 @@ func (c *Collection) AuditRetainedPayloadDeclaredPathsAbsent(opts ColumnRetained
 		result.Status = "inactive_no_retained_payload"
 		return result, nil
 	}
-	if len(result.DeclaredPaths) == 0 {
+	if len(result.DeclaredPaths) == 0 && !opts.IncludeSemanticStreamBlockLayout {
 		result.Status = "no_declared_paths"
 		return result, nil
+	}
+	if opts.IncludeSemanticStreamBlockLayout && !columnStoreRetainedPayloadUsesSemanticStreamV1(&cfg) {
+		return retainedPayloadCollectionAuditError(result, fmt.Errorf("collections: semantic-stream-v1 block layout audit requires retained encoding %q", ColumnRetainedPayloadEncodingSemanticStreamV1))
 	}
 
 	it, err := collectionIteratorAtCatalogRoot(snap, catalog, collectionPrimaryRootName(catalog.meta.Name), nil, nil, false)
@@ -292,6 +300,9 @@ func (c *Collection) AuditRetainedPayloadDeclaredPathsAbsent(opts ColumnRetained
 
 	resolver := columnRetainedPayloadTemplateResolver(snap, catalog)
 	includeDecodedStats := opts.IncludeShapeStats || opts.IncludeValueFamilyStats || opts.IncludeSemanticStreams
+	semanticBlockLayoutOnly := opts.IncludeSemanticStreamBlockLayout &&
+		columnStoreRetainedPayloadUsesSemanticStreamV1(&cfg) &&
+		!includeDecodedStats
 	var shape *columnRetainedPayloadShapeCollector
 	if opts.IncludeShapeStats {
 		shape = newColumnRetainedPayloadShapeCollector(opts.ShapeMaxDepth)
@@ -323,6 +334,15 @@ func (c *Collection) AuditRetainedPayloadDeclaredPathsAbsent(opts ColumnRetained
 		}
 		result.CheckedRows++
 		result.RetainedPayloadBytes += int64(len(retained))
+		if semanticBlockLayoutOnly {
+			if _, _, ok, err := parseColumnRetainedSemanticStreamV1Locator(retained); err != nil {
+				return retainedPayloadCollectionAuditError(result, fmt.Errorf("collections: retained payload audit %q: %w", documentID, err))
+			} else if !ok {
+				return retainedPayloadCollectionAuditError(result, fmt.Errorf("collections: retained payload audit %q: semantic-stream-v1 primary value is not a locator", documentID))
+			}
+			it.Next()
+			continue
+		}
 		decodedRetained, err := resolveColumnRetainedPayloadAtSnapshot(snap, catalog, cfg, retained)
 		if err != nil {
 			return retainedPayloadCollectionAuditError(result, fmt.Errorf("collections: retained payload audit %q: %w", documentID, err))
@@ -369,6 +389,28 @@ func (c *Collection) AuditRetainedPayloadDeclaredPathsAbsent(opts ColumnRetained
 	}
 	if err := it.Error(); err != nil {
 		return retainedPayloadCollectionAuditError(result, err)
+	}
+	if opts.IncludeSemanticStreamBlockLayout {
+		blockLayout, blockPaths, err := c.auditRetainedSemanticStreamV1BlockLayoutAtSnapshot(snap, catalog, opts.SemanticStreamBlockMaxPaths)
+		if err != nil {
+			return retainedPayloadCollectionAuditError(result, err)
+		}
+		blockLayout.Rows = result.CheckedRows
+		blockLayout.PrimaryLocatorBytes = result.RetainedPayloadBytes
+		result.RetainedPayloadSemanticStreamBlockLayout = &blockLayout
+		violatedPaths := make([]string, 0)
+		for _, path := range result.DeclaredPaths {
+			if _, ok := blockPaths[path]; ok {
+				result.Violations = append(result.Violations, ColumnRetainedPayloadCollectionPathViolation{
+					DocumentID: "semantic-stream-v1-blocks",
+					Path:       path,
+				})
+				violatedPaths = append(violatedPaths, path)
+			}
+		}
+		if len(result.Violations) > 0 {
+			return retainedPayloadCollectionAuditError(result, fmt.Errorf("collections: retained semantic-stream-v1 blocks contain declared typed paths: %s", strings.Join(violatedPaths, ", ")))
+		}
 	}
 	if opts.IncludeShapeStats {
 		result.RetainedPayloadShape, result.RetainedPayloadShapeTruncated = shape.result(opts.ShapeMaxPaths)

--- a/TreeDB/collections/column_retained_payload_audit.go
+++ b/TreeDB/collections/column_retained_payload_audit.go
@@ -338,7 +338,16 @@ func (c *Collection) AuditRetainedPayloadDeclaredPathsAbsent(opts ColumnRetained
 			if _, _, ok, err := parseColumnRetainedSemanticStreamV1Locator(retained); err != nil {
 				return retainedPayloadCollectionAuditError(result, fmt.Errorf("collections: retained payload audit %q: %w", documentID, err))
 			} else if !ok {
-				return retainedPayloadCollectionAuditError(result, fmt.Errorf("collections: retained payload audit %q: semantic-stream-v1 primary value is not a locator", documentID))
+				payloadAudit, auditErr := auditColumnRetainedPayloadPathsAbsentWithResolver(cfg, retained, result.DeclaredPaths, resolver)
+				if auditErr != nil {
+					for _, path := range payloadAudit.Violations {
+						result.Violations = append(result.Violations, ColumnRetainedPayloadCollectionPathViolation{
+							DocumentID: documentID,
+							Path:       path,
+						})
+					}
+					return retainedPayloadCollectionAuditError(result, auditErr)
+				}
 			}
 			it.Next()
 			continue
@@ -390,7 +399,7 @@ func (c *Collection) AuditRetainedPayloadDeclaredPathsAbsent(opts ColumnRetained
 	if err := it.Error(); err != nil {
 		return retainedPayloadCollectionAuditError(result, err)
 	}
-	if opts.IncludeSemanticStreamBlockLayout {
+	if opts.IncludeSemanticStreamBlockLayout && !result.Truncated {
 		blockLayout, blockPaths, err := c.auditRetainedSemanticStreamV1BlockLayoutAtSnapshot(snap, catalog, opts.SemanticStreamBlockMaxPaths)
 		if err != nil {
 			return retainedPayloadCollectionAuditError(result, err)

--- a/TreeDB/collections/column_retained_payload_audit.go
+++ b/TreeDB/collections/column_retained_payload_audit.go
@@ -403,6 +403,16 @@ func (c *Collection) AuditRetainedPayloadDeclaredPathsAbsent(opts ColumnRetained
 	if err := it.Error(); err != nil {
 		return retainedPayloadCollectionAuditError(result, err)
 	}
+	if opts.IncludeSemanticStreamBlockLayout && result.Truncated && semanticBlockLayoutOnly {
+		blockPaths, err := c.auditRetainedSemanticStreamV1BlockLayoutPathsAtSnapshot(snap, catalog, semanticBlockLayoutLocatorRows)
+		if err != nil {
+			return retainedPayloadCollectionAuditError(result, err)
+		}
+		violatedPaths := appendColumnRetainedPayloadBlockLayoutViolations(&result, "semantic-stream-v1-sampled-blocks", blockPaths)
+		if len(violatedPaths) > 0 {
+			return retainedPayloadCollectionAuditError(result, fmt.Errorf("collections: retained semantic-stream-v1 sampled blocks contain declared typed paths: %s", strings.Join(violatedPaths, ", ")))
+		}
+	}
 	if opts.IncludeSemanticStreamBlockLayout && !result.Truncated {
 		blockLayout, blockPaths, err := c.auditRetainedSemanticStreamV1BlockLayoutAtSnapshot(snap, catalog, opts.SemanticStreamBlockMaxPaths)
 		if err != nil {
@@ -411,17 +421,8 @@ func (c *Collection) AuditRetainedPayloadDeclaredPathsAbsent(opts ColumnRetained
 		blockLayout.Rows = result.CheckedRows
 		blockLayout.PrimaryLocatorBytes = result.RetainedPayloadBytes
 		result.RetainedPayloadSemanticStreamBlockLayout = &blockLayout
-		violatedPaths := make([]string, 0)
-		for _, path := range result.DeclaredPaths {
-			if _, ok := blockPaths[path]; ok {
-				result.Violations = append(result.Violations, ColumnRetainedPayloadCollectionPathViolation{
-					DocumentID: "semantic-stream-v1-blocks",
-					Path:       path,
-				})
-				violatedPaths = append(violatedPaths, path)
-			}
-		}
-		if len(result.Violations) > 0 {
+		violatedPaths := appendColumnRetainedPayloadBlockLayoutViolations(&result, "semantic-stream-v1-blocks", blockPaths)
+		if len(violatedPaths) > 0 {
 			return retainedPayloadCollectionAuditError(result, fmt.Errorf("collections: retained semantic-stream-v1 blocks contain declared typed paths: %s", strings.Join(violatedPaths, ", ")))
 		}
 	}
@@ -452,6 +453,23 @@ func (c *Collection) AuditRetainedPayloadDeclaredPathsAbsent(opts ColumnRetained
 		result.Status = "passed"
 	}
 	return result, nil
+}
+
+func appendColumnRetainedPayloadBlockLayoutViolations(result *ColumnRetainedPayloadCollectionAuditResult, source string, blockPaths map[string]struct{}) []string {
+	if result == nil || len(blockPaths) == 0 {
+		return nil
+	}
+	violatedPaths := make([]string, 0)
+	for _, path := range result.DeclaredPaths {
+		if _, ok := blockPaths[path]; ok {
+			result.Violations = append(result.Violations, ColumnRetainedPayloadCollectionPathViolation{
+				DocumentID: source,
+				Path:       path,
+			})
+			violatedPaths = append(violatedPaths, path)
+		}
+	}
+	return violatedPaths
 }
 
 func retainedPayloadCollectionAuditError(result ColumnRetainedPayloadCollectionAuditResult, err error) (ColumnRetainedPayloadCollectionAuditResult, error) {

--- a/TreeDB/collections/column_retained_payload_audit.go
+++ b/TreeDB/collections/column_retained_payload_audit.go
@@ -315,6 +315,10 @@ func (c *Collection) AuditRetainedPayloadDeclaredPathsAbsent(opts ColumnRetained
 	if opts.IncludeSemanticStreams {
 		semanticStreams = newColumnRetainedPayloadSemanticStreamCollector(opts.SemanticStreamMaxDepth)
 	}
+	var semanticBlockLayoutLocatorRows map[string]uint64
+	if semanticBlockLayoutOnly {
+		semanticBlockLayoutLocatorRows = make(map[string]uint64)
+	}
 	for it.Valid() {
 		if opts.MaxDocuments > 0 && result.CheckedRows >= opts.MaxDocuments {
 			result.Truncated = true
@@ -335,7 +339,7 @@ func (c *Collection) AuditRetainedPayloadDeclaredPathsAbsent(opts ColumnRetained
 		result.CheckedRows++
 		result.RetainedPayloadBytes += int64(len(retained))
 		if semanticBlockLayoutOnly {
-			if _, _, ok, err := parseColumnRetainedSemanticStreamV1Locator(retained); err != nil {
+			if ok, err := validateColumnRetainedSemanticStreamV1LocatorAtSnapshot(snap, catalog, retained, semanticBlockLayoutLocatorRows); err != nil {
 				return retainedPayloadCollectionAuditError(result, fmt.Errorf("collections: retained payload audit %q: %w", documentID, err))
 			} else if !ok {
 				payloadAudit, auditErr := auditColumnRetainedPayloadPathsAbsentWithResolver(cfg, retained, result.DeclaredPaths, resolver)

--- a/TreeDB/collections/column_retained_payload_audit.go
+++ b/TreeDB/collections/column_retained_payload_audit.go
@@ -316,7 +316,8 @@ func (c *Collection) AuditRetainedPayloadDeclaredPathsAbsent(opts ColumnRetained
 		semanticStreams = newColumnRetainedPayloadSemanticStreamCollector(opts.SemanticStreamMaxDepth)
 	}
 	var semanticBlockLayoutLocatorRows map[string]uint64
-	if semanticBlockLayoutOnly {
+	var semanticBlockLayoutPrimaryLocatorBytes int64
+	if opts.IncludeSemanticStreamBlockLayout {
 		semanticBlockLayoutLocatorRows = make(map[string]uint64)
 	}
 	for it.Valid() {
@@ -338,10 +339,17 @@ func (c *Collection) AuditRetainedPayloadDeclaredPathsAbsent(opts ColumnRetained
 		}
 		result.CheckedRows++
 		result.RetainedPayloadBytes += int64(len(retained))
-		if semanticBlockLayoutOnly {
+		semanticBlockLayoutLocator := false
+		if opts.IncludeSemanticStreamBlockLayout {
 			if ok, err := validateColumnRetainedSemanticStreamV1LocatorAtSnapshot(snap, catalog, retained, semanticBlockLayoutLocatorRows); err != nil {
 				return retainedPayloadCollectionAuditError(result, fmt.Errorf("collections: retained payload audit %q: %w", documentID, err))
-			} else if !ok {
+			} else if ok {
+				semanticBlockLayoutLocator = true
+				semanticBlockLayoutPrimaryLocatorBytes += int64(len(retained))
+			}
+		}
+		if semanticBlockLayoutOnly {
+			if !semanticBlockLayoutLocator {
 				payloadAudit, auditErr := auditColumnRetainedPayloadPathsAbsentWithResolver(cfg, retained, result.DeclaredPaths, resolver)
 				if auditErr != nil {
 					for _, path := range payloadAudit.Violations {
@@ -403,7 +411,7 @@ func (c *Collection) AuditRetainedPayloadDeclaredPathsAbsent(opts ColumnRetained
 	if err := it.Error(); err != nil {
 		return retainedPayloadCollectionAuditError(result, err)
 	}
-	if opts.IncludeSemanticStreamBlockLayout && result.Truncated && semanticBlockLayoutOnly {
+	if opts.IncludeSemanticStreamBlockLayout && result.Truncated {
 		blockPaths, err := c.auditRetainedSemanticStreamV1BlockLayoutPathsAtSnapshot(snap, catalog, semanticBlockLayoutLocatorRows)
 		if err != nil {
 			return retainedPayloadCollectionAuditError(result, err)
@@ -419,7 +427,7 @@ func (c *Collection) AuditRetainedPayloadDeclaredPathsAbsent(opts ColumnRetained
 			return retainedPayloadCollectionAuditError(result, err)
 		}
 		blockLayout.Rows = result.CheckedRows
-		blockLayout.PrimaryLocatorBytes = result.RetainedPayloadBytes
+		blockLayout.PrimaryLocatorBytes = semanticBlockLayoutPrimaryLocatorBytes
 		result.RetainedPayloadSemanticStreamBlockLayout = &blockLayout
 		violatedPaths := appendColumnRetainedPayloadBlockLayoutViolations(&result, "semantic-stream-v1-blocks", blockPaths)
 		if len(violatedPaths) > 0 {
@@ -461,7 +469,8 @@ func appendColumnRetainedPayloadBlockLayoutViolations(result *ColumnRetainedPayl
 	}
 	violatedPaths := make([]string, 0)
 	for _, path := range result.DeclaredPaths {
-		if _, ok := blockPaths[path]; ok {
+		pathKey := columnRetainedSemanticStreamPathKey(strings.Split(path, "."))
+		if _, ok := blockPaths[pathKey]; ok {
 			result.Violations = append(result.Violations, ColumnRetainedPayloadCollectionPathViolation{
 				DocumentID: source,
 				Path:       path,

--- a/TreeDB/collections/column_retained_payload_audit_test.go
+++ b/TreeDB/collections/column_retained_payload_audit_test.go
@@ -548,6 +548,40 @@ func TestAuditCollectionRetainedPayloadSemanticStreamBlockLayout2662(t *testing.
 	if _, ok := retainedSemanticStreamV1PathLayoutStat2662(layout.Paths, "kind"); ok {
 		t.Fatalf("declared kind leaked into block layout paths: %+v", layout.Paths)
 	}
+
+	limited, err := col.AuditRetainedPayloadDeclaredPathsAbsent(ColumnRetainedPayloadCollectionAuditOptions{
+		IncludeSemanticStreamBlockLayout: true,
+		MaxDocuments:                     1,
+	})
+	if err != nil {
+		t.Fatalf("limited semantic-stream-v1 block layout audit: %v audit=%+v", err, limited)
+	}
+	if !limited.Truncated || limited.CheckedRows != 1 || limited.RetainedPayloadSemanticStreamBlockLayout != nil {
+		t.Fatalf("limited audit=%+v want truncated one row without mixed full-block layout", limited)
+	}
+}
+
+func TestAuditCollectionRetainedPayloadSemanticStreamBlockLayoutAllowsInlineRows2662(t *testing.T) {
+	cfg := jsonbenchRetainedPayloadAuditConfig2382(true)
+	cfg.RetainedPayloadEncoding = ColumnRetainedPayloadEncodingSemanticStreamV1
+	col, closeDB := openRetainedPayloadAuditCollection2382(t, cfg, [][]byte{
+		[]byte(`{"time_us":1,"kind":"commit","did":"did:plc:one","commit":{"operation":"create","collection":"app.bsky.feed.post","rkey":"r-0001","record":{"text":"hello"}},"payload":"same"}`),
+	})
+	defer closeDB()
+
+	audit, err := col.AuditRetainedPayloadDeclaredPathsAbsent(ColumnRetainedPayloadCollectionAuditOptions{
+		IncludeSemanticStreamBlockLayout: true,
+	})
+	if err != nil {
+		t.Fatalf("inline semantic-stream-v1 block layout audit: %v audit=%+v", err, audit)
+	}
+	if audit.Status != "passed" || audit.CheckedRows != 1 {
+		t.Fatalf("audit=%+v want passed one inline row", audit)
+	}
+	layout := audit.RetainedPayloadSemanticStreamBlockLayout
+	if layout == nil || layout.BlockCount != 0 || layout.RawBlockBytes != 0 || layout.PrimaryLocatorBytes != audit.RetainedPayloadBytes {
+		t.Fatalf("inline block layout=%+v audit=%+v", layout, audit)
+	}
 }
 
 func TestAuditCollectionRetainedPayloadDeclaredPathsAbsentFailsClosed2382(t *testing.T) {

--- a/TreeDB/collections/column_retained_payload_audit_test.go
+++ b/TreeDB/collections/column_retained_payload_audit_test.go
@@ -460,6 +460,96 @@ func TestAuditCollectionRetainedPayloadSemanticStreamStats2662(t *testing.T) {
 	}
 }
 
+func TestColumnRetainedSemanticStreamV1BlockLayoutAudit2662(t *testing.T) {
+	cfg := jsonbenchRetainedPayloadAuditConfig2382(true)
+	cfg.RetainedPayloadEncoding = ColumnRetainedPayloadEncodingSemanticStreamV1
+	docs := [][]byte{
+		[]byte(`{"time_us":1,"kind":"commit","did":"did:plc:one","commit":{"operation":"create","collection":"app.bsky.feed.post","rkey":"r-0001","record":{"text":"hello"}},"payload":"same"}`),
+		[]byte(`{"time_us":2,"kind":"commit","did":"did:plc:two","commit":{"operation":"update","collection":"app.bsky.feed.post","rkey":"r-0002","record":{"text":"world"}},"payload":"same"}`),
+	}
+	accounting, err := ColumnRetainedSemanticStreamV1StorageAccountingFromJSONDocuments(*cfg, docs)
+	if err != nil {
+		t.Fatalf("ColumnRetainedSemanticStreamV1StorageAccountingFromJSONDocuments: %v", err)
+	}
+	audit, err := ColumnRetainedSemanticStreamV1BlockLayoutAuditFromJSONDocuments(*cfg, docs, 0)
+	if err != nil {
+		t.Fatalf("ColumnRetainedSemanticStreamV1BlockLayoutAuditFromJSONDocuments: %v", err)
+	}
+	if audit.Rows != len(docs) || audit.BlockRows != columnRetainedSemanticStreamV1BlockRows || audit.BlockCount != 1 {
+		t.Fatalf("unexpected block layout row/block counters: %+v", audit)
+	}
+	if audit.PrimaryLocatorBytes != accounting.PrimaryLocatorBytes || audit.RawBlockBytes != accounting.BlockBytes {
+		t.Fatalf("audit/accounting mismatch audit=%+v accounting=%+v", audit, accounting)
+	}
+	if audit.RawBlockBytes != audit.BlockHeaderBytes+audit.PathMetadataBytes+audit.EntryMetadataBytes+audit.ScalarValueBytes {
+		t.Fatalf("block byte attribution mismatch: %+v", audit)
+	}
+	if audit.PathStreamCount < 3 || audit.ValueCount < 6 || audit.PathZSTDInputBytes <= 0 || audit.PathZSTDEncodedBytes <= 0 {
+		t.Fatalf("missing stream counters: %+v", audit)
+	}
+	rkey, ok := retainedSemanticStreamV1PathLayoutStat2662(audit.Paths, "commit.rkey")
+	if !ok {
+		t.Fatalf("missing commit.rkey block path stat: %+v", audit.Paths)
+	}
+	if rkey.Occurrences != 2 || rkey.Blocks != 1 {
+		t.Fatalf("commit.rkey occurrence counters=%+v", rkey)
+	}
+	if got, want := rkey.ScalarValueBytes, int64(len(`"r-0001"`)+len(`"r-0002"`)); got != want {
+		t.Fatalf("commit.rkey scalar bytes=%d want %d stat=%+v", got, want, rkey)
+	}
+	if rkey.TotalBytes != rkey.PathMetadataBytes+rkey.EntryMetadataBytes+rkey.ScalarValueBytes || rkey.ZSTDBytes <= 0 || rkey.ZSTDToTotalRatio <= 0 {
+		t.Fatalf("commit.rkey byte accounting=%+v", rkey)
+	}
+	for _, codec := range []string{"snappy", "lz4", "zstd"} {
+		stat, ok := retainedSemanticStreamV1CodecStat2662(audit.BlockCodecStats, codec)
+		if !ok {
+			t.Fatalf("missing %s block codec stat: %+v", codec, audit.BlockCodecStats)
+		}
+		if stat.Blocks != 1 || stat.RawBytes != audit.RawBlockBytes || stat.StoredBytes <= 0 || stat.StoredToRawRatio <= 0 {
+			t.Fatalf("%s codec stat=%+v audit=%+v", codec, stat, audit)
+		}
+	}
+
+	limited, err := ColumnRetainedSemanticStreamV1BlockLayoutAuditFromJSONDocuments(*cfg, docs, 1)
+	if err != nil {
+		t.Fatalf("limited block layout audit: %v", err)
+	}
+	if !limited.PathsTruncated || len(limited.Paths) != 1 || limited.RawBlockBytes != audit.RawBlockBytes {
+		t.Fatalf("limited paths=%+v truncated=%v raw=%d want truncated one raw %d", limited.Paths, limited.PathsTruncated, limited.RawBlockBytes, audit.RawBlockBytes)
+	}
+}
+
+func TestAuditCollectionRetainedPayloadSemanticStreamBlockLayout2662(t *testing.T) {
+	cfg := jsonbenchRetainedPayloadAuditConfig2382(true)
+	cfg.RetainedPayloadEncoding = ColumnRetainedPayloadEncodingSemanticStreamV1
+	col, closeDB := openRetainedPayloadAuditCollection2382(t, cfg, [][]byte{
+		[]byte(`{"time_us":1,"kind":"commit","did":"did:plc:one","commit":{"operation":"create","collection":"app.bsky.feed.post","rkey":"r-0001","record":{"text":"hello"}},"payload":"same"}`),
+		[]byte(`{"time_us":2,"kind":"commit","did":"did:plc:two","commit":{"operation":"update","collection":"app.bsky.feed.post","rkey":"r-0002","record":{"text":"world"}},"payload":"same"}`),
+	})
+	defer closeDB()
+
+	audit, err := col.AuditRetainedPayloadDeclaredPathsAbsent(ColumnRetainedPayloadCollectionAuditOptions{
+		IncludeSemanticStreamBlockLayout: true,
+		SemanticStreamBlockMaxPaths:      1,
+	})
+	if err != nil {
+		t.Fatalf("AuditRetainedPayloadDeclaredPathsAbsent semantic-stream-v1 block layout: %v audit=%+v", err, audit)
+	}
+	if audit.Status != "passed" || audit.CheckedRows != 2 {
+		t.Fatalf("audit=%+v want passed two rows", audit)
+	}
+	if audit.RetainedPayloadSemanticStreamBlockLayout == nil {
+		t.Fatalf("missing semantic stream block layout: %+v", audit)
+	}
+	layout := audit.RetainedPayloadSemanticStreamBlockLayout
+	if layout.BlockCount != 1 || layout.RawBlockBytes <= 0 || len(layout.BlockCodecStats) == 0 || len(layout.Paths) != 1 || !layout.PathsTruncated {
+		t.Fatalf("unexpected block layout: %+v", layout)
+	}
+	if _, ok := retainedSemanticStreamV1PathLayoutStat2662(layout.Paths, "kind"); ok {
+		t.Fatalf("declared kind leaked into block layout paths: %+v", layout.Paths)
+	}
+}
+
 func TestAuditCollectionRetainedPayloadDeclaredPathsAbsentFailsClosed2382(t *testing.T) {
 	cfg := jsonbenchRetainedPayloadAuditConfig2382(false)
 	col, closeDB := openRetainedPayloadAuditCollection2382(t, cfg, [][]byte{
@@ -591,6 +681,24 @@ func retainedPayloadSemanticStreamStat2662(stats []ColumnRetainedPayloadSemantic
 		}
 	}
 	return ColumnRetainedPayloadSemanticStreamStat{}, false
+}
+
+func retainedSemanticStreamV1PathLayoutStat2662(stats []ColumnRetainedSemanticStreamV1PathLayoutStat, path string) (ColumnRetainedSemanticStreamV1PathLayoutStat, bool) {
+	for _, stat := range stats {
+		if stat.Path == path {
+			return stat, true
+		}
+	}
+	return ColumnRetainedSemanticStreamV1PathLayoutStat{}, false
+}
+
+func retainedSemanticStreamV1CodecStat2662(stats []ColumnRetainedSemanticStreamV1CodecStat, codec string) (ColumnRetainedSemanticStreamV1CodecStat, bool) {
+	for _, stat := range stats {
+		if stat.Codec == codec {
+			return stat, true
+		}
+	}
+	return ColumnRetainedSemanticStreamV1CodecStat{}, false
 }
 
 func retainedPayloadValueFamilyBucketCount2662(buckets []ColumnRetainedPayloadLengthBucket, name string) int64 {

--- a/TreeDB/collections/column_retained_payload_audit_test.go
+++ b/TreeDB/collections/column_retained_payload_audit_test.go
@@ -1,6 +1,8 @@
 package collections
 
 import (
+	"crypto/sha256"
+	"encoding/binary"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -8,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/pierrec/lz4/v4"
 	backenddb "github.com/snissn/gomap/TreeDB/db"
 )
 
@@ -517,6 +520,55 @@ func TestColumnRetainedSemanticStreamV1BlockLayoutAudit2662(t *testing.T) {
 	if !limited.PathsTruncated || len(limited.Paths) != 1 || limited.RawBlockBytes != audit.RawBlockBytes {
 		t.Fatalf("limited paths=%+v truncated=%v raw=%d want truncated one raw %d", limited.Paths, limited.PathsTruncated, limited.RawBlockBytes, audit.RawBlockBytes)
 	}
+}
+
+func TestColumnRetainedSemanticStreamV1BlockCodecLZ4RawFallback2662(t *testing.T) {
+	collector, err := newColumnRetainedSemanticStreamV1BlockLayoutCollector()
+	if err != nil {
+		t.Fatalf("new block layout collector: %v", err)
+	}
+	defer collector.close()
+
+	raw := incompressibleLZ4Fixture2662(t)
+	encodedBytes, ok := collector.encodeBlockCodec("lz4", raw)
+	if !ok || encodedBytes != 0 {
+		t.Fatalf("lz4 fixture encodedBytes=%d ok=%v want valid raw fallback", encodedBytes, ok)
+	}
+	collector.observeBlockCodec("lz4", raw)
+
+	stat := collector.codecs["lz4"]
+	if stat == nil {
+		t.Fatal("missing lz4 codec stat")
+	}
+	if stat.Blocks != 1 || stat.RawBytes != int64(len(raw)) || stat.EncodedBytes != 0 || stat.StoredBytes != int64(len(raw)) || stat.RawFallbackBlocks != 1 || stat.KeptBlocks != 0 || stat.EncodeErrors != 0 {
+		t.Fatalf("lz4 raw fallback stat=%+v raw=%d", stat, len(raw))
+	}
+}
+
+func incompressibleLZ4Fixture2662(t *testing.T) []byte {
+	t.Helper()
+	for seed := uint64(1); seed <= 64; seed++ {
+		raw := make([]byte, 64*1024)
+		var counter uint64
+		for off := 0; off < len(raw); {
+			var input [16]byte
+			binary.LittleEndian.PutUint64(input[:8], seed)
+			binary.LittleEndian.PutUint64(input[8:], counter)
+			sum := sha256.Sum256(input[:])
+			off += copy(raw[off:], sum[:])
+			counter++
+		}
+		dst := make([]byte, len(raw))
+		n, err := lz4.CompressBlock(raw, dst, nil)
+		if err != nil {
+			t.Fatalf("lz4 fixture probe seed=%d: %v", seed, err)
+		}
+		if n == 0 {
+			return raw
+		}
+	}
+	t.Fatal("could not build deterministic incompressible lz4 fixture")
+	return nil
 }
 
 func TestAuditCollectionRetainedPayloadSemanticStreamBlockLayout2662(t *testing.T) {

--- a/TreeDB/collections/column_retained_payload_audit_test.go
+++ b/TreeDB/collections/column_retained_payload_audit_test.go
@@ -561,6 +561,31 @@ func TestAuditCollectionRetainedPayloadSemanticStreamBlockLayout2662(t *testing.
 	}
 }
 
+func TestAuditCollectionRetainedPayloadSemanticStreamBlockLayoutSampledFailsClosed2662(t *testing.T) {
+	cfg := jsonbenchRetainedPayloadAuditConfig2382(true)
+	cfg.RetainedPayloadEncoding = ColumnRetainedPayloadEncodingSemanticStreamV1
+	col, closeDB := openRetainedPayloadAuditCollection2382(t, cfg, [][]byte{
+		[]byte(`{"time_us":1,"kind":"commit","did":"did:plc:one","commit":{"operation":"create","collection":"app.bsky.feed.post","rkey":"r-0001","record":{"text":"hello"}},"payload":"same"}`),
+		[]byte(`{"time_us":2,"kind":"commit","did":"did:plc:two","commit":{"operation":"update","collection":"app.bsky.feed.post","rkey":"r-0002","record":{"text":"world"}},"payload":"same"}`),
+	})
+	defer closeDB()
+
+	audit, err := col.AuditRetainedPayloadDeclaredPathsAbsent(ColumnRetainedPayloadCollectionAuditOptions{
+		Paths:                            []string{"payload"},
+		IncludeSemanticStreamBlockLayout: true,
+		MaxDocuments:                     1,
+	})
+	if err == nil || !strings.Contains(err.Error(), "payload") {
+		t.Fatalf("sampled semantic-stream-v1 block layout err=%v audit=%+v want payload violation", err, audit)
+	}
+	if audit.Status != "failed" || !audit.Truncated || audit.CheckedRows != 1 || audit.RetainedPayloadSemanticStreamBlockLayout != nil {
+		t.Fatalf("sampled semantic-stream-v1 block layout audit=%+v want failed truncated one row without emitted layout", audit)
+	}
+	if len(audit.Violations) != 1 || audit.Violations[0].DocumentID != "semantic-stream-v1-sampled-blocks" || audit.Violations[0].Path != "payload" {
+		t.Fatalf("sampled semantic-stream-v1 block layout violations=%+v want sampled-block payload", audit.Violations)
+	}
+}
+
 func TestAuditCollectionRetainedPayloadSemanticStreamBlockLayoutAllowsInlineRows2662(t *testing.T) {
 	cfg := jsonbenchRetainedPayloadAuditConfig2382(true)
 	cfg.RetainedPayloadEncoding = ColumnRetainedPayloadEncodingSemanticStreamV1

--- a/TreeDB/collections/column_retained_payload_audit_test.go
+++ b/TreeDB/collections/column_retained_payload_audit_test.go
@@ -638,6 +638,32 @@ func TestAuditCollectionRetainedPayloadSemanticStreamBlockLayoutSampledFailsClos
 	}
 }
 
+func TestAuditCollectionRetainedPayloadSemanticStreamBlockLayoutSampledDecodedStatsFailsClosed2662(t *testing.T) {
+	cfg := jsonbenchRetainedPayloadAuditConfig2382(true)
+	cfg.RetainedPayloadEncoding = ColumnRetainedPayloadEncodingSemanticStreamV1
+	col, closeDB := openRetainedPayloadAuditCollection2382(t, cfg, [][]byte{
+		[]byte(`{"time_us":1,"kind":"commit","did":"did:plc:one","commit":{"operation":"create","collection":"app.bsky.feed.post","rkey":"r-0001","record":{"text":"hello"}}}`),
+		[]byte(`{"time_us":2,"kind":"commit","did":"did:plc:two","commit":{"operation":"update","collection":"app.bsky.feed.post","rkey":"r-0002","record":{"text":"world"}},"payload":"same"}`),
+	})
+	defer closeDB()
+
+	audit, err := col.AuditRetainedPayloadDeclaredPathsAbsent(ColumnRetainedPayloadCollectionAuditOptions{
+		Paths:                            []string{"payload"},
+		IncludeShapeStats:                true,
+		IncludeSemanticStreamBlockLayout: true,
+		MaxDocuments:                     1,
+	})
+	if err == nil || !strings.Contains(err.Error(), "payload") {
+		t.Fatalf("sampled semantic-stream-v1 decoded stats block layout err=%v audit=%+v want payload violation", err, audit)
+	}
+	if audit.Status != "failed" || !audit.Truncated || audit.CheckedRows != 1 || audit.RetainedPayloadSemanticStreamBlockLayout != nil {
+		t.Fatalf("sampled semantic-stream-v1 decoded stats audit=%+v want failed truncated one row without emitted layout", audit)
+	}
+	if len(audit.Violations) != 1 || audit.Violations[0].DocumentID != "semantic-stream-v1-sampled-blocks" || audit.Violations[0].Path != "payload" {
+		t.Fatalf("sampled semantic-stream-v1 decoded stats violations=%+v want sampled-block payload", audit.Violations)
+	}
+}
+
 func TestAuditCollectionRetainedPayloadSemanticStreamBlockLayoutAllowsInlineRows2662(t *testing.T) {
 	cfg := jsonbenchRetainedPayloadAuditConfig2382(true)
 	cfg.RetainedPayloadEncoding = ColumnRetainedPayloadEncodingSemanticStreamV1
@@ -656,8 +682,42 @@ func TestAuditCollectionRetainedPayloadSemanticStreamBlockLayoutAllowsInlineRows
 		t.Fatalf("audit=%+v want passed one inline row", audit)
 	}
 	layout := audit.RetainedPayloadSemanticStreamBlockLayout
-	if layout == nil || layout.BlockCount != 0 || layout.RawBlockBytes != 0 || layout.PrimaryLocatorBytes != audit.RetainedPayloadBytes {
+	if layout == nil || layout.BlockCount != 0 || layout.RawBlockBytes != 0 || layout.PrimaryLocatorBytes != 0 || audit.RetainedPayloadBytes <= 0 {
 		t.Fatalf("inline block layout=%+v audit=%+v", layout, audit)
+	}
+}
+
+func TestAuditCollectionRetainedPayloadSemanticStreamBlockLayoutLiteralDottedKey2662(t *testing.T) {
+	cfg := &ColumnStoreConfig{
+		Enabled:                 true,
+		RetainedPayload:         ColumnRetainedPayloadNonColumn,
+		RetainedPayloadEncoding: ColumnRetainedPayloadEncodingSemanticStreamV1,
+		Reconstruction:          ColumnReconstructionRetainedPayloadAndColumns,
+		Columns: []ColumnStoreColumn{
+			{Name: "nested", Path: "a.b", ValueType: ColumnStoreValueString, Nullable: true},
+		},
+	}
+	col, closeDB := openRetainedPayloadAuditCollection2382(t, cfg, [][]byte{
+		[]byte(`{"a.b":"literal-one","other":1}`),
+		[]byte(`{"a.b":"literal-two","other":2}`),
+	})
+	defer closeDB()
+
+	audit, err := col.AuditRetainedPayloadDeclaredPathsAbsent(ColumnRetainedPayloadCollectionAuditOptions{
+		IncludeSemanticStreamBlockLayout: true,
+	})
+	if err != nil {
+		t.Fatalf("literal dotted key block layout audit: %v audit=%+v", err, audit)
+	}
+	if audit.Status != "passed" || len(audit.Violations) != 0 {
+		t.Fatalf("literal dotted key audit=%+v want passed without nested a.b violation", audit)
+	}
+	layout := audit.RetainedPayloadSemanticStreamBlockLayout
+	if layout == nil {
+		t.Fatalf("literal dotted key missing block layout: %+v", audit)
+	}
+	if _, ok := retainedSemanticStreamV1PathLayoutStat2662(layout.Paths, "a.b"); !ok {
+		t.Fatalf("literal dotted key path missing from layout paths: %+v", layout.Paths)
 	}
 }
 

--- a/TreeDB/collections/column_retained_payload_audit_test.go
+++ b/TreeDB/collections/column_retained_payload_audit_test.go
@@ -584,6 +584,53 @@ func TestAuditCollectionRetainedPayloadSemanticStreamBlockLayoutAllowsInlineRows
 	}
 }
 
+func TestAuditCollectionRetainedPayloadSemanticStreamBlockLayoutValidatesLocators2662(t *testing.T) {
+	cfg := jsonbenchRetainedPayloadAuditConfig2382(true)
+	cfg.RetainedPayloadEncoding = ColumnRetainedPayloadEncodingSemanticStreamV1
+	col, closeDB := openRetainedPayloadAuditCollection2382(t, cfg, [][]byte{
+		[]byte(`{"time_us":1,"kind":"commit","did":"did:plc:one","commit":{"operation":"create","collection":"app.bsky.feed.post","rkey":"r-0001","record":{"text":"hello"}},"payload":"same"}`),
+		[]byte(`{"time_us":2,"kind":"commit","did":"did:plc:two","commit":{"operation":"update","collection":"app.bsky.feed.post","rkey":"r-0002","record":{"text":"world"}},"payload":"same"}`),
+	})
+	defer closeDB()
+
+	snap := col.db.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("AcquireSnapshot returned nil")
+	}
+	defer func() { _ = snap.Close() }()
+	catalog, err := col.catalogForSnapshot(snap)
+	if err != nil {
+		t.Fatalf("catalogForSnapshot: %v", err)
+	}
+	retained, found, err := collectionGetAppendAtCatalogRoot(snap, catalog, collectionPrimaryRootName(catalog.meta.Name), []byte("doc-000000"), nil)
+	if err != nil || !found {
+		t.Fatalf("collectionGetAppendAtCatalogRoot primary: found=%v err=%v", found, err)
+	}
+	blockKey, row, ok, err := parseColumnRetainedSemanticStreamV1Locator(retained)
+	if err != nil || !ok {
+		t.Fatalf("parse semantic-stream locator ok=%v err=%v retained=%x", ok, err, retained)
+	}
+	rowCache := make(map[string]uint64)
+	if ok, err := validateColumnRetainedSemanticStreamV1LocatorAtSnapshot(snap, catalog, retained, rowCache); !ok || err != nil {
+		t.Fatalf("validate live locator ok=%v err=%v", ok, err)
+	}
+	if len(rowCache) != 1 {
+		t.Fatalf("row cache entries=%d want one", len(rowCache))
+	}
+
+	missingKey := append([]byte(nil), blockKey...)
+	missingKey[0] ^= 0xff
+	missingLocator := encodeColumnRetainedSemanticStreamV1Locator(missingKey, row)
+	if ok, err := validateColumnRetainedSemanticStreamV1LocatorAtSnapshot(snap, catalog, missingLocator, nil); !ok || err == nil || !strings.Contains(err.Error(), "missing") {
+		t.Fatalf("missing locator ok=%v err=%v want missing-block failure", ok, err)
+	}
+
+	outOfRangeLocator := encodeColumnRetainedSemanticStreamV1Locator(blockKey, 2)
+	if ok, err := validateColumnRetainedSemanticStreamV1LocatorAtSnapshot(snap, catalog, outOfRangeLocator, nil); !ok || err == nil || !strings.Contains(err.Error(), "outside block rows") {
+		t.Fatalf("out-of-range locator ok=%v err=%v want row-range failure", ok, err)
+	}
+}
+
 func TestAuditCollectionRetainedPayloadDeclaredPathsAbsentFailsClosed2382(t *testing.T) {
 	cfg := jsonbenchRetainedPayloadAuditConfig2382(false)
 	col, closeDB := openRetainedPayloadAuditCollection2382(t, cfg, [][]byte{

--- a/TreeDB/collections/column_retained_semantic_stream.go
+++ b/TreeDB/collections/column_retained_semantic_stream.go
@@ -9,7 +9,11 @@ import (
 	"fmt"
 	"sort"
 	"strconv"
+	"strings"
 
+	"github.com/golang/snappy"
+	"github.com/pierrec/lz4/v4"
+	"github.com/snissn/compress/zstd"
 	backenddb "github.com/snissn/gomap/TreeDB/db"
 	"github.com/snissn/gomap/TreeDB/internal/memtable"
 	"github.com/snissn/gomap/TreeDB/node"
@@ -40,6 +44,54 @@ type ColumnRetainedSemanticStreamV1StorageAccounting struct {
 	BlockBytes          int64
 	BlockCount          int
 	TotalBytes          int64
+}
+
+// ColumnRetainedSemanticStreamV1BlockLayoutAudit reports exact raw byte
+// attribution for semantic-stream-v1 side-root blocks plus payload-only codec
+// oracles. It intentionally excludes value-log frame/index overhead.
+type ColumnRetainedSemanticStreamV1BlockLayoutAudit struct {
+	Rows                 int                                            `json:"rows,omitempty"`
+	BlockRows            int                                            `json:"block_rows"`
+	BlockCount           int                                            `json:"block_count"`
+	PrimaryLocatorBytes  int64                                          `json:"primary_locator_bytes,omitempty"`
+	RawBlockBytes        int64                                          `json:"raw_block_bytes"`
+	BlockHeaderBytes     int64                                          `json:"block_header_bytes"`
+	PathStreamCount      int64                                          `json:"path_stream_count"`
+	ValueCount           int64                                          `json:"value_count"`
+	PathMetadataBytes    int64                                          `json:"path_metadata_bytes"`
+	EntryMetadataBytes   int64                                          `json:"entry_metadata_bytes"`
+	ScalarValueBytes     int64                                          `json:"scalar_value_bytes"`
+	BlockCodecStats      []ColumnRetainedSemanticStreamV1CodecStat      `json:"block_codec_stats,omitempty"`
+	Paths                []ColumnRetainedSemanticStreamV1PathLayoutStat `json:"paths,omitempty"`
+	PathsTruncated       bool                                           `json:"paths_truncated,omitempty"`
+	PathZSTDInputBytes   int64                                          `json:"path_zstd_input_bytes,omitempty"`
+	PathZSTDEncodedBytes int64                                          `json:"path_zstd_encoded_bytes,omitempty"`
+}
+
+type ColumnRetainedSemanticStreamV1CodecStat struct {
+	Codec             string  `json:"codec"`
+	Blocks            int     `json:"blocks"`
+	RawBytes          int64   `json:"raw_bytes"`
+	EncodedBytes      int64   `json:"encoded_bytes,omitempty"`
+	StoredBytes       int64   `json:"stored_bytes"`
+	KeptBlocks        int     `json:"kept_blocks,omitempty"`
+	RawFallbackBlocks int     `json:"raw_fallback_blocks,omitempty"`
+	EncodeErrors      int     `json:"encode_errors,omitempty"`
+	EncodedToRawRatio float64 `json:"encoded_to_raw_ratio,omitempty"`
+	StoredToRawRatio  float64 `json:"stored_to_raw_ratio,omitempty"`
+}
+
+type ColumnRetainedSemanticStreamV1PathLayoutStat struct {
+	Path                string  `json:"path"`
+	Blocks              int64   `json:"blocks"`
+	Occurrences         int64   `json:"occurrences"`
+	TotalBytes          int64   `json:"total_bytes"`
+	PathMetadataBytes   int64   `json:"path_metadata_bytes"`
+	EntryMetadataBytes  int64   `json:"entry_metadata_bytes"`
+	ScalarValueBytes    int64   `json:"scalar_value_bytes"`
+	MaxScalarValueBytes int     `json:"max_scalar_value_bytes,omitempty"`
+	ZSTDBytes           int64   `json:"zstd_bytes,omitempty"`
+	ZSTDToTotalRatio    float64 `json:"zstd_to_total_ratio,omitempty"`
 }
 
 // ColumnRetainedSemanticStreamV1StorageAccountingFromJSONDocuments applies the
@@ -75,6 +127,85 @@ func ColumnRetainedSemanticStreamV1StorageAccountingFromJSONDocuments(cfg Column
 	}
 	out.TotalBytes = out.PrimaryLocatorBytes + out.BlockBytes
 	return out, nil
+}
+
+// ColumnRetainedSemanticStreamV1BlockLayoutAuditFromJSONDocuments applies the
+// InsertBatch semantic-stream-v1 transform and audits the resulting side-root
+// block layout. maxPaths limits emitted path rows; zero emits all paths.
+func ColumnRetainedSemanticStreamV1BlockLayoutAuditFromJSONDocuments(cfg ColumnStoreConfig, documents [][]byte, maxPaths int) (ColumnRetainedSemanticStreamV1BlockLayoutAudit, error) {
+	if !columnStoreRetainedPayloadUsesSemanticStreamV1(&cfg) {
+		return ColumnRetainedSemanticStreamV1BlockLayoutAudit{}, fmt.Errorf("collections: semantic-stream-v1 block layout audit requires retained encoding %q", ColumnRetainedPayloadEncodingSemanticStreamV1)
+	}
+	prepared, err := prepareColumnRetainedPayloadInsertBatchStorageDocuments(cfg, documents, nil)
+	if err != nil {
+		return ColumnRetainedSemanticStreamV1BlockLayoutAudit{}, err
+	}
+	if prepared.semanticStreamBlocks != nil {
+		defer resetCollectionRunTable(prepared.semanticStreamBlocks)
+	}
+
+	collector, err := newColumnRetainedSemanticStreamV1BlockLayoutCollector()
+	if err != nil {
+		return ColumnRetainedSemanticStreamV1BlockLayoutAudit{}, err
+	}
+	for _, document := range prepared.documents {
+		collector.primaryLocatorBytes += int64(len(document))
+	}
+	if prepared.semanticStreamBlocks != nil {
+		iter := prepared.semanticStreamBlocks.NewIterator(nil, nil)
+		defer func() { _ = iter.Close() }()
+		for ; iter.Valid(); iter.Next() {
+			if err := collector.addBlock(iter.UnsafeValue()); err != nil {
+				return ColumnRetainedSemanticStreamV1BlockLayoutAudit{}, err
+			}
+		}
+		if err := iter.Error(); err != nil {
+			return ColumnRetainedSemanticStreamV1BlockLayoutAudit{}, err
+		}
+	}
+	return collector.result(len(documents), maxPaths)
+}
+
+func (c *Collection) auditRetainedSemanticStreamV1BlockLayoutAtSnapshot(snap *backenddb.Snapshot, catalog *collectionCatalog, maxPaths int) (ColumnRetainedSemanticStreamV1BlockLayoutAudit, map[string]struct{}, error) {
+	collector, err := newColumnRetainedSemanticStreamV1BlockLayoutCollector()
+	if err != nil {
+		return ColumnRetainedSemanticStreamV1BlockLayoutAudit{}, nil, err
+	}
+	rootName := collectionRetainedSemanticStreamRootName(catalog.meta.Name)
+	it, err := collectionIteratorAtCatalogRoot(snap, catalog, rootName, nil, nil, false)
+	if err != nil {
+		return ColumnRetainedSemanticStreamV1BlockLayoutAudit{}, nil, err
+	}
+	if it != nil {
+		defer func() { _ = it.Close() }()
+		for ; it.Valid(); it.Next() {
+			if it.IsDeleted() {
+				continue
+			}
+			block := it.ValueCopy(nil)
+			if err := it.Error(); err != nil {
+				return ColumnRetainedSemanticStreamV1BlockLayoutAudit{}, nil, fmt.Errorf("collections: semantic-stream-v1 block layout audit read %x: %w", it.UnsafeKey(), err)
+			}
+			if !it.Valid() {
+				return ColumnRetainedSemanticStreamV1BlockLayoutAudit{}, nil, fmt.Errorf("collections: semantic-stream-v1 block layout audit iterator invalid after reading %x", it.UnsafeKey())
+			}
+			if err := collector.addBlock(block); err != nil {
+				return ColumnRetainedSemanticStreamV1BlockLayoutAudit{}, nil, fmt.Errorf("collections: semantic-stream-v1 block layout audit %x: %w", it.UnsafeKey(), err)
+			}
+		}
+		if err := it.Error(); err != nil {
+			return ColumnRetainedSemanticStreamV1BlockLayoutAudit{}, nil, err
+		}
+	}
+	paths := make(map[string]struct{}, len(collector.paths))
+	for path := range collector.paths {
+		paths[path] = struct{}{}
+	}
+	out, err := collector.result(0, maxPaths)
+	if err != nil {
+		return ColumnRetainedSemanticStreamV1BlockLayoutAudit{}, nil, err
+	}
+	return out, paths, nil
 }
 
 func prepareColumnRetainedPayloadInsertBatchStorageDocuments(cfg ColumnStoreConfig, documents [][]byte, fallback templateV1Resolver) (columnRetainedPayloadStorageDocuments, error) {
@@ -568,4 +699,302 @@ func setColumnRetainedSemanticStreamPathValue(root map[string]any, path []string
 	}
 	current[path[len(path)-1]] = value
 	return nil
+}
+
+type columnRetainedSemanticStreamV1BlockLayoutCollector struct {
+	primaryLocatorBytes int64
+	blockHeaderBytes    int64
+	rawBlockBytes       int64
+	pathMetadataBytes   int64
+	entryMetadataBytes  int64
+	scalarValueBytes    int64
+	pathStreamCount     int64
+	valueCount          int64
+	blockCount          int
+	codecs              map[string]*ColumnRetainedSemanticStreamV1CodecStat
+	paths               map[string]*columnRetainedSemanticStreamV1PathLayoutCollector
+	zstdEncoder         *zstd.Encoder
+}
+
+type columnRetainedSemanticStreamV1PathLayoutCollector struct {
+	stat        ColumnRetainedSemanticStreamV1PathLayoutStat
+	zstdCounter columnRetainedPayloadCountingWriter
+	zstdWriter  *zstd.Encoder
+}
+
+func newColumnRetainedSemanticStreamV1BlockLayoutCollector() (*columnRetainedSemanticStreamV1BlockLayoutCollector, error) {
+	enc, err := zstd.NewWriter(nil,
+		zstd.WithEncoderLevel(zstd.SpeedFastest),
+		zstd.WithEncoderCRC(false),
+		zstd.WithEncoderConcurrency(1),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("collections: create semantic-stream-v1 block zstd oracle: %w", err)
+	}
+	return &columnRetainedSemanticStreamV1BlockLayoutCollector{
+		codecs: map[string]*ColumnRetainedSemanticStreamV1CodecStat{
+			"snappy": {Codec: "snappy"},
+			"lz4":    {Codec: "lz4"},
+			"zstd":   {Codec: "zstd"},
+		},
+		paths:       make(map[string]*columnRetainedSemanticStreamV1PathLayoutCollector),
+		zstdEncoder: enc,
+	}, nil
+}
+
+func (c *columnRetainedSemanticStreamV1BlockLayoutCollector) addBlock(block []byte) error {
+	if c == nil {
+		return nil
+	}
+	if !bytes.HasPrefix(block, columnRetainedSemanticStreamV1BlockMagic) {
+		return errors.New("collections: retained block is not semantic-stream-v1 encoded")
+	}
+	off := len(columnRetainedSemanticStreamV1BlockMagic)
+	rows, n, err := readColumnRetainedSemanticStreamV1Uvarint(block, off, "row count")
+	if err != nil {
+		return err
+	}
+	off += n
+	if rows == 0 {
+		return errors.New("collections: malformed semantic-stream-v1 retained block zero rows")
+	}
+	pathCount, n, err := readColumnRetainedSemanticStreamV1Uvarint(block, off, "path count")
+	if err != nil {
+		return err
+	}
+	off += n
+	blockHeaderBytes := off
+
+	c.blockCount++
+	c.rawBlockBytes += int64(len(block))
+	c.blockHeaderBytes += int64(blockHeaderBytes)
+	c.observeBlockCodec("snappy", block)
+	c.observeBlockCodec("lz4", block)
+	c.observeBlockCodec("zstd", block)
+
+	for pathOrdinal := uint64(0); pathOrdinal < pathCount; pathOrdinal++ {
+		pathStart := off
+		segmentCount, n, err := readColumnRetainedSemanticStreamV1Uvarint(block, off, "path segment count")
+		if err != nil {
+			return err
+		}
+		off += n
+		if segmentCount > uint64(int(^uint(0)>>1)) {
+			return errors.New("collections: semantic-stream-v1 retained block path too large")
+		}
+		if segmentCount > uint64(len(block)-off) {
+			return errors.New("collections: semantic-stream-v1 retained block path segment count exceeds remaining bytes")
+		}
+		segments := make([]string, 0, segmentCount)
+		for segmentOrdinal := uint64(0); segmentOrdinal < segmentCount; segmentOrdinal++ {
+			segmentLen, n, err := readColumnRetainedSemanticStreamV1Uvarint(block, off, "path segment length")
+			if err != nil {
+				return err
+			}
+			off += n
+			if segmentLen > uint64(len(block)-off) {
+				return errors.New("collections: truncated semantic-stream-v1 retained block path segment")
+			}
+			segment := string(block[off : off+int(segmentLen)])
+			segments = append(segments, segment)
+			off += int(segmentLen)
+		}
+		pathMetadataBytes := off - pathStart
+		entryCount, n, err := readColumnRetainedSemanticStreamV1Uvarint(block, off, "entry count")
+		if err != nil {
+			return err
+		}
+		off += n
+		entryMetadataBytes := n
+		var scalarValueBytes int64
+		var maxScalarValueBytes int
+		for entryOrdinal := uint64(0); entryOrdinal < entryCount; entryOrdinal++ {
+			if _, n, err = readColumnRetainedSemanticStreamV1Uvarint(block, off, "row delta"); err != nil {
+				return err
+			}
+			off += n
+			entryMetadataBytes += n
+			valueLen, n, err := readColumnRetainedSemanticStreamV1Uvarint(block, off, "value length")
+			if err != nil {
+				return err
+			}
+			off += n
+			entryMetadataBytes += n
+			if valueLen > uint64(len(block)-off) {
+				return errors.New("collections: truncated semantic-stream-v1 retained block value")
+			}
+			scalarValueBytes += int64(valueLen)
+			if int(valueLen) > maxScalarValueBytes {
+				maxScalarValueBytes = int(valueLen)
+			}
+			off += int(valueLen)
+		}
+		pathRaw := block[pathStart:off]
+		path := strings.Join(segments, ".")
+		if err := c.observePath(path, int64(pathMetadataBytes), int64(entryMetadataBytes), scalarValueBytes, int64(entryCount), maxScalarValueBytes, pathRaw); err != nil {
+			return err
+		}
+	}
+	if off != len(block) {
+		return errors.New("collections: trailing semantic-stream-v1 retained block bytes")
+	}
+	return nil
+}
+
+func (c *columnRetainedSemanticStreamV1BlockLayoutCollector) observeBlockCodec(codec string, raw []byte) {
+	stat := c.codecs[codec]
+	if stat == nil {
+		stat = &ColumnRetainedSemanticStreamV1CodecStat{Codec: codec}
+		c.codecs[codec] = stat
+	}
+	stat.Blocks++
+	stat.RawBytes += int64(len(raw))
+	encodedBytes, ok := c.encodeBlockCodec(codec, raw)
+	if !ok || encodedBytes <= 0 {
+		stat.EncodeErrors++
+		stat.StoredBytes += int64(len(raw))
+		stat.RawFallbackBlocks++
+		return
+	}
+	stat.EncodedBytes += int64(encodedBytes)
+	if encodedBytes < len(raw) {
+		stat.StoredBytes += int64(encodedBytes)
+		stat.KeptBlocks++
+	} else {
+		stat.StoredBytes += int64(len(raw))
+		stat.RawFallbackBlocks++
+	}
+}
+
+func (c *columnRetainedSemanticStreamV1BlockLayoutCollector) encodeBlockCodec(codec string, raw []byte) (int, bool) {
+	switch codec {
+	case "snappy":
+		return len(snappy.Encode(nil, raw)), true
+	case "lz4":
+		dst := make([]byte, lz4.CompressBlockBound(len(raw)))
+		n, err := lz4.CompressBlock(raw, dst, nil)
+		if err != nil || n <= 0 {
+			return 0, false
+		}
+		return n, true
+	case "zstd":
+		if c.zstdEncoder == nil {
+			return 0, false
+		}
+		return len(c.zstdEncoder.EncodeAll(raw, nil)), true
+	default:
+		return 0, false
+	}
+}
+
+func (c *columnRetainedSemanticStreamV1BlockLayoutCollector) observePath(path string, pathMetadataBytes, entryMetadataBytes, scalarValueBytes, occurrences int64, maxScalarValueBytes int, raw []byte) error {
+	stream := c.paths[path]
+	if stream == nil {
+		stream = &columnRetainedSemanticStreamV1PathLayoutCollector{
+			stat: ColumnRetainedSemanticStreamV1PathLayoutStat{Path: path},
+		}
+		zstdWriter, err := zstd.NewWriter(&stream.zstdCounter,
+			zstd.WithEncoderLevel(zstd.SpeedFastest),
+			zstd.WithEncoderCRC(false),
+			zstd.WithEncoderConcurrency(1),
+		)
+		if err != nil {
+			return fmt.Errorf("collections: create semantic-stream-v1 path zstd oracle for path %q: %w", path, err)
+		}
+		stream.zstdWriter = zstdWriter
+		c.paths[path] = stream
+	}
+	stream.stat.Blocks++
+	stream.stat.Occurrences += occurrences
+	stream.stat.PathMetadataBytes += pathMetadataBytes
+	stream.stat.EntryMetadataBytes += entryMetadataBytes
+	stream.stat.ScalarValueBytes += scalarValueBytes
+	stream.stat.TotalBytes += int64(len(raw))
+	if maxScalarValueBytes > stream.stat.MaxScalarValueBytes {
+		stream.stat.MaxScalarValueBytes = maxScalarValueBytes
+	}
+	if _, err := stream.zstdWriter.Write(raw); err != nil {
+		return fmt.Errorf("collections: write semantic-stream-v1 path zstd oracle for path %q: %w", path, err)
+	}
+	c.pathMetadataBytes += pathMetadataBytes
+	c.entryMetadataBytes += entryMetadataBytes
+	c.scalarValueBytes += scalarValueBytes
+	c.pathStreamCount++
+	c.valueCount += occurrences
+	return nil
+}
+
+func (c *columnRetainedSemanticStreamV1BlockLayoutCollector) result(rows, maxPaths int) (ColumnRetainedSemanticStreamV1BlockLayoutAudit, error) {
+	out := ColumnRetainedSemanticStreamV1BlockLayoutAudit{
+		Rows:                rows,
+		BlockRows:           columnRetainedSemanticStreamV1BlockRows,
+		BlockCount:          c.blockCount,
+		PrimaryLocatorBytes: c.primaryLocatorBytes,
+		RawBlockBytes:       c.rawBlockBytes,
+		BlockHeaderBytes:    c.blockHeaderBytes,
+		PathStreamCount:     c.pathStreamCount,
+		ValueCount:          c.valueCount,
+		PathMetadataBytes:   c.pathMetadataBytes,
+		EntryMetadataBytes:  c.entryMetadataBytes,
+		ScalarValueBytes:    c.scalarValueBytes,
+	}
+	codecNames := []string{"snappy", "lz4", "zstd"}
+	for _, name := range codecNames {
+		stat := c.codecs[name]
+		if stat == nil {
+			continue
+		}
+		stat.EncodedToRawRatio = columnRetainedPayloadAuditRatio(stat.EncodedBytes, stat.RawBytes)
+		stat.StoredToRawRatio = columnRetainedPayloadAuditRatio(stat.StoredBytes, stat.RawBytes)
+		out.BlockCodecStats = append(out.BlockCodecStats, *stat)
+	}
+	paths := make([]ColumnRetainedSemanticStreamV1PathLayoutStat, 0, len(c.paths))
+	for path, stream := range c.paths {
+		if stream.zstdWriter != nil {
+			if err := stream.zstdWriter.Close(); err != nil {
+				return ColumnRetainedSemanticStreamV1BlockLayoutAudit{}, fmt.Errorf("collections: close semantic-stream-v1 path zstd oracle for path %q: %w", path, err)
+			}
+			stream.zstdWriter = nil
+		}
+		stat := stream.stat
+		stat.ZSTDBytes = stream.zstdCounter.n
+		stat.ZSTDToTotalRatio = columnRetainedPayloadAuditRatio(stat.ZSTDBytes, stat.TotalBytes)
+		out.PathZSTDInputBytes += stat.TotalBytes
+		out.PathZSTDEncodedBytes += stat.ZSTDBytes
+		paths = append(paths, stat)
+	}
+	sort.Slice(paths, func(i, j int) bool {
+		if paths[i].TotalBytes != paths[j].TotalBytes {
+			return paths[i].TotalBytes > paths[j].TotalBytes
+		}
+		if paths[i].Occurrences != paths[j].Occurrences {
+			return paths[i].Occurrences > paths[j].Occurrences
+		}
+		return paths[i].Path < paths[j].Path
+	})
+	if maxPaths > 0 && len(paths) > maxPaths {
+		out.Paths = paths[:maxPaths]
+		out.PathsTruncated = true
+	} else {
+		out.Paths = paths
+	}
+	if c.zstdEncoder != nil {
+		c.zstdEncoder.Close()
+		c.zstdEncoder = nil
+	}
+	if out.RawBlockBytes != out.BlockHeaderBytes+out.PathMetadataBytes+out.EntryMetadataBytes+out.ScalarValueBytes {
+		return ColumnRetainedSemanticStreamV1BlockLayoutAudit{}, errors.New("collections: semantic-stream-v1 block layout byte accounting mismatch")
+	}
+	return out, nil
+}
+
+func readColumnRetainedSemanticStreamV1Uvarint(block []byte, off int, context string) (uint64, int, error) {
+	if off < 0 || off >= len(block) {
+		return 0, 0, fmt.Errorf("collections: malformed semantic-stream-v1 retained block %s", context)
+	}
+	value, n := binary.Uvarint(block[off:])
+	if n <= 0 {
+		return 0, 0, fmt.Errorf("collections: malformed semantic-stream-v1 retained block %s", context)
+	}
+	return value, n, nil
 }

--- a/TreeDB/collections/column_retained_semantic_stream.go
+++ b/TreeDB/collections/column_retained_semantic_stream.go
@@ -210,6 +210,38 @@ func (c *Collection) auditRetainedSemanticStreamV1BlockLayoutAtSnapshot(snap *ba
 	return out, paths, nil
 }
 
+func (c *Collection) auditRetainedSemanticStreamV1BlockLayoutPathsAtSnapshot(snap *backenddb.Snapshot, catalog *collectionCatalog, blockRows map[string]uint64) (map[string]struct{}, error) {
+	collector, err := newColumnRetainedSemanticStreamV1BlockLayoutCollector()
+	if err != nil {
+		return nil, err
+	}
+	defer collector.close()
+	rootName := collectionRetainedSemanticStreamRootName(catalog.meta.Name)
+	keys := make([]string, 0, len(blockRows))
+	for key := range blockRows {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		blockKey := []byte(key)
+		block, found, err := collectionGetAppendAtCatalogRoot(snap, catalog, rootName, blockKey, nil)
+		if err != nil {
+			return nil, fmt.Errorf("collections: semantic-stream-v1 sampled block layout audit read %x: %w", blockKey, err)
+		}
+		if !found {
+			return nil, fmt.Errorf("collections: semantic-stream-v1 retained block %x missing", blockKey)
+		}
+		if err := collector.addBlock(block); err != nil {
+			return nil, fmt.Errorf("collections: semantic-stream-v1 sampled block layout audit %x: %w", blockKey, err)
+		}
+	}
+	paths := make(map[string]struct{}, len(collector.paths))
+	for path := range collector.paths {
+		paths[path] = struct{}{}
+	}
+	return paths, nil
+}
+
 func prepareColumnRetainedPayloadInsertBatchStorageDocuments(cfg ColumnStoreConfig, documents [][]byte, fallback templateV1Resolver) (columnRetainedPayloadStorageDocuments, error) {
 	if cfg.RetainedPayload == ColumnRetainedPayloadNonColumn &&
 		columnRetainedPayloadEffectiveEncoding(&cfg) == ColumnRetainedPayloadEncodingSemanticStreamV1 &&

--- a/TreeDB/collections/column_retained_semantic_stream.go
+++ b/TreeDB/collections/column_retained_semantic_stream.go
@@ -947,14 +947,14 @@ func (c *columnRetainedSemanticStreamV1BlockLayoutCollector) observeBlockCodec(c
 	stat.Blocks++
 	stat.RawBytes += int64(len(raw))
 	encodedBytes, ok := c.encodeBlockCodec(codec, raw)
-	if !ok || encodedBytes <= 0 {
+	if !ok {
 		stat.EncodeErrors++
 		stat.StoredBytes += int64(len(raw))
 		stat.RawFallbackBlocks++
 		return
 	}
 	stat.EncodedBytes += int64(encodedBytes)
-	if encodedBytes < len(raw) {
+	if encodedBytes > 0 && encodedBytes < len(raw) {
 		stat.StoredBytes += int64(encodedBytes)
 		stat.KeptBlocks++
 	} else {
@@ -968,9 +968,9 @@ func (c *columnRetainedSemanticStreamV1BlockLayoutCollector) encodeBlockCodec(co
 	case "snappy":
 		return len(snappy.Encode(nil, raw)), true
 	case "lz4":
-		dst := make([]byte, lz4.CompressBlockBound(len(raw)))
+		dst := make([]byte, len(raw))
 		n, err := lz4.CompressBlock(raw, dst, nil)
-		if err != nil || n <= 0 {
+		if err != nil {
 			return 0, false
 		}
 		return n, true

--- a/TreeDB/collections/column_retained_semantic_stream.go
+++ b/TreeDB/collections/column_retained_semantic_stream.go
@@ -465,6 +465,53 @@ func resolveColumnRetainedPayloadAtSnapshot(snap *backenddb.Snapshot, catalog *c
 	return decodeColumnRetainedSemanticStreamV1BlockRowJSON(block, row)
 }
 
+func validateColumnRetainedSemanticStreamV1LocatorAtSnapshot(snap *backenddb.Snapshot, catalog *collectionCatalog, retained []byte, blockRows map[string]uint64) (bool, error) {
+	blockKey, row, ok, err := parseColumnRetainedSemanticStreamV1Locator(retained)
+	if err != nil || !ok {
+		return ok, err
+	}
+	if snap == nil || catalog == nil {
+		return true, errors.New("collections: semantic-stream-v1 retained payload requires snapshot catalog")
+	}
+	cacheKey := string(blockKey)
+	rows, cached := blockRows[cacheKey]
+	if !cached {
+		block, found, err := collectionGetAppendAtCatalogRoot(snap, catalog, collectionRetainedSemanticStreamRootName(catalog.meta.Name), blockKey, nil)
+		if err != nil {
+			return true, err
+		}
+		if !found {
+			return true, fmt.Errorf("collections: semantic-stream-v1 retained block %x missing", blockKey)
+		}
+		rows, err = columnRetainedSemanticStreamV1BlockRowCount(block)
+		if err != nil {
+			return true, err
+		}
+		if blockRows != nil {
+			blockRows[cacheKey] = rows
+		}
+	}
+	if row >= rows {
+		return true, fmt.Errorf("collections: semantic-stream-v1 row %d outside block rows %d", row, rows)
+	}
+	return true, nil
+}
+
+func columnRetainedSemanticStreamV1BlockRowCount(block []byte) (uint64, error) {
+	if !bytes.HasPrefix(block, columnRetainedSemanticStreamV1BlockMagic) {
+		return 0, errors.New("collections: retained block is not semantic-stream-v1 encoded")
+	}
+	off := len(columnRetainedSemanticStreamV1BlockMagic)
+	rows, _, err := readColumnRetainedSemanticStreamV1Uvarint(block, off, "row count")
+	if err != nil {
+		return 0, err
+	}
+	if rows == 0 {
+		return 0, errors.New("collections: malformed semantic-stream-v1 retained block zero rows")
+	}
+	return rows, nil
+}
+
 func encodeColumnRetainedSemanticStreamV1Block(documents [][]byte) ([]byte, error) {
 	streams := make(map[string]*columnRetainedSemanticStreamPath)
 	for row, document := range documents {

--- a/TreeDB/collections/column_retained_semantic_stream.go
+++ b/TreeDB/collections/column_retained_semantic_stream.go
@@ -112,7 +112,11 @@ func ColumnRetainedSemanticStreamV1StorageAccountingFromJSONDocuments(cfg Column
 	var out ColumnRetainedSemanticStreamV1StorageAccounting
 	out.Rows = len(documents)
 	for _, document := range prepared.documents {
-		out.PrimaryLocatorBytes += int64(len(document))
+		if _, _, ok, err := parseColumnRetainedSemanticStreamV1Locator(document); err != nil {
+			return ColumnRetainedSemanticStreamV1StorageAccounting{}, err
+		} else if ok {
+			out.PrimaryLocatorBytes += int64(len(document))
+		}
 	}
 	if prepared.semanticStreamBlocks != nil {
 		iter := prepared.semanticStreamBlocks.NewIterator(nil, nil)
@@ -150,7 +154,11 @@ func ColumnRetainedSemanticStreamV1BlockLayoutAuditFromJSONDocuments(cfg ColumnS
 	}
 	defer collector.close()
 	for _, document := range prepared.documents {
-		collector.primaryLocatorBytes += int64(len(document))
+		if _, _, ok, err := parseColumnRetainedSemanticStreamV1Locator(document); err != nil {
+			return ColumnRetainedSemanticStreamV1BlockLayoutAudit{}, err
+		} else if ok {
+			collector.primaryLocatorBytes += int64(len(document))
+		}
 	}
 	if prepared.semanticStreamBlocks != nil {
 		iter := prepared.semanticStreamBlocks.NewIterator(nil, nil)
@@ -211,10 +219,7 @@ func (c *Collection) auditRetainedSemanticStreamV1BlockLayoutAtSnapshot(snap *ba
 }
 
 func (c *Collection) auditRetainedSemanticStreamV1BlockLayoutPathsAtSnapshot(snap *backenddb.Snapshot, catalog *collectionCatalog, blockRows map[string]uint64) (map[string]struct{}, error) {
-	collector, err := newColumnRetainedSemanticStreamV1BlockLayoutCollector()
-	if err != nil {
-		return nil, err
-	}
+	collector := newColumnRetainedSemanticStreamV1PathCollector()
 	defer collector.close()
 	rootName := collectionRetainedSemanticStreamRootName(catalog.meta.Name)
 	keys := make([]string, 0, len(blockRows))
@@ -236,8 +241,8 @@ func (c *Collection) auditRetainedSemanticStreamV1BlockLayoutPathsAtSnapshot(sna
 		}
 	}
 	paths := make(map[string]struct{}, len(collector.paths))
-	for path := range collector.paths {
-		paths[path] = struct{}{}
+	for pathKey := range collector.paths {
+		paths[pathKey] = struct{}{}
 	}
 	return paths, nil
 }
@@ -795,6 +800,7 @@ type columnRetainedSemanticStreamV1BlockLayoutCollector struct {
 	codecs              map[string]*ColumnRetainedSemanticStreamV1CodecStat
 	paths               map[string]*columnRetainedSemanticStreamV1PathLayoutCollector
 	zstdEncoder         *zstd.Encoder
+	pathOnly            bool
 }
 
 type columnRetainedSemanticStreamV1PathLayoutCollector struct {
@@ -821,6 +827,13 @@ func newColumnRetainedSemanticStreamV1BlockLayoutCollector() (*columnRetainedSem
 		paths:       make(map[string]*columnRetainedSemanticStreamV1PathLayoutCollector),
 		zstdEncoder: enc,
 	}, nil
+}
+
+func newColumnRetainedSemanticStreamV1PathCollector() *columnRetainedSemanticStreamV1BlockLayoutCollector {
+	return &columnRetainedSemanticStreamV1BlockLayoutCollector{
+		paths:    make(map[string]*columnRetainedSemanticStreamV1PathLayoutCollector),
+		pathOnly: true,
+	}
 }
 
 func (c *columnRetainedSemanticStreamV1BlockLayoutCollector) close() {
@@ -862,12 +875,14 @@ func (c *columnRetainedSemanticStreamV1BlockLayoutCollector) addBlock(block []by
 	off += n
 	blockHeaderBytes := off
 
-	c.blockCount++
-	c.rawBlockBytes += int64(len(block))
-	c.blockHeaderBytes += int64(blockHeaderBytes)
-	c.observeBlockCodec("snappy", block)
-	c.observeBlockCodec("lz4", block)
-	c.observeBlockCodec("zstd", block)
+	if !c.pathOnly {
+		c.blockCount++
+		c.rawBlockBytes += int64(len(block))
+		c.blockHeaderBytes += int64(blockHeaderBytes)
+		c.observeBlockCodec("snappy", block)
+		c.observeBlockCodec("lz4", block)
+		c.observeBlockCodec("zstd", block)
+	}
 
 	for pathOrdinal := uint64(0); pathOrdinal < pathCount; pathOrdinal++ {
 		pathStart := off
@@ -928,7 +943,8 @@ func (c *columnRetainedSemanticStreamV1BlockLayoutCollector) addBlock(block []by
 		}
 		pathRaw := block[pathStart:off]
 		path := strings.Join(segments, ".")
-		if err := c.observePath(path, int64(pathMetadataBytes), int64(entryMetadataBytes), scalarValueBytes, int64(entryCount), maxScalarValueBytes, pathRaw); err != nil {
+		pathKey := columnRetainedSemanticStreamPathKey(segments)
+		if err := c.observePath(pathKey, path, int64(pathMetadataBytes), int64(entryMetadataBytes), scalarValueBytes, int64(entryCount), maxScalarValueBytes, pathRaw); err != nil {
 			return err
 		}
 	}
@@ -984,22 +1000,27 @@ func (c *columnRetainedSemanticStreamV1BlockLayoutCollector) encodeBlockCodec(co
 	}
 }
 
-func (c *columnRetainedSemanticStreamV1BlockLayoutCollector) observePath(path string, pathMetadataBytes, entryMetadataBytes, scalarValueBytes, occurrences int64, maxScalarValueBytes int, raw []byte) error {
-	stream := c.paths[path]
+func (c *columnRetainedSemanticStreamV1BlockLayoutCollector) observePath(pathKey, path string, pathMetadataBytes, entryMetadataBytes, scalarValueBytes, occurrences int64, maxScalarValueBytes int, raw []byte) error {
+	stream := c.paths[pathKey]
 	if stream == nil {
 		stream = &columnRetainedSemanticStreamV1PathLayoutCollector{
 			stat: ColumnRetainedSemanticStreamV1PathLayoutStat{Path: path},
 		}
-		zstdWriter, err := zstd.NewWriter(&stream.zstdCounter,
-			zstd.WithEncoderLevel(zstd.SpeedFastest),
-			zstd.WithEncoderCRC(false),
-			zstd.WithEncoderConcurrency(1),
-		)
-		if err != nil {
-			return fmt.Errorf("collections: create semantic-stream-v1 path zstd oracle for path %q: %w", path, err)
+		if !c.pathOnly {
+			zstdWriter, err := zstd.NewWriter(&stream.zstdCounter,
+				zstd.WithEncoderLevel(zstd.SpeedFastest),
+				zstd.WithEncoderCRC(false),
+				zstd.WithEncoderConcurrency(1),
+			)
+			if err != nil {
+				return fmt.Errorf("collections: create semantic-stream-v1 path zstd oracle for path %q: %w", path, err)
+			}
+			stream.zstdWriter = zstdWriter
 		}
-		stream.zstdWriter = zstdWriter
-		c.paths[path] = stream
+		c.paths[pathKey] = stream
+	}
+	if c.pathOnly {
+		return nil
 	}
 	stream.stat.Blocks++
 	stream.stat.Occurrences += occurrences
@@ -1045,11 +1066,15 @@ func (c *columnRetainedSemanticStreamV1BlockLayoutCollector) result(rows, maxPat
 		stat.StoredToRawRatio = columnRetainedPayloadAuditRatio(stat.StoredBytes, stat.RawBytes)
 		out.BlockCodecStats = append(out.BlockCodecStats, *stat)
 	}
-	paths := make([]ColumnRetainedSemanticStreamV1PathLayoutStat, 0, len(c.paths))
-	for path, stream := range c.paths {
+	type pathLayoutResult struct {
+		key  string
+		stat ColumnRetainedSemanticStreamV1PathLayoutStat
+	}
+	paths := make([]pathLayoutResult, 0, len(c.paths))
+	for pathKey, stream := range c.paths {
 		if stream.zstdWriter != nil {
 			if err := stream.zstdWriter.Close(); err != nil {
-				return ColumnRetainedSemanticStreamV1BlockLayoutAudit{}, fmt.Errorf("collections: close semantic-stream-v1 path zstd oracle for path %q: %w", path, err)
+				return ColumnRetainedSemanticStreamV1BlockLayoutAudit{}, fmt.Errorf("collections: close semantic-stream-v1 path zstd oracle for path %q: %w", stream.stat.Path, err)
 			}
 			stream.zstdWriter = nil
 		}
@@ -1058,22 +1083,29 @@ func (c *columnRetainedSemanticStreamV1BlockLayoutCollector) result(rows, maxPat
 		stat.ZSTDToTotalRatio = columnRetainedPayloadAuditRatio(stat.ZSTDBytes, stat.TotalBytes)
 		out.PathZSTDInputBytes += stat.TotalBytes
 		out.PathZSTDEncodedBytes += stat.ZSTDBytes
-		paths = append(paths, stat)
+		paths = append(paths, pathLayoutResult{key: pathKey, stat: stat})
 	}
 	sort.Slice(paths, func(i, j int) bool {
-		if paths[i].TotalBytes != paths[j].TotalBytes {
-			return paths[i].TotalBytes > paths[j].TotalBytes
+		if paths[i].stat.TotalBytes != paths[j].stat.TotalBytes {
+			return paths[i].stat.TotalBytes > paths[j].stat.TotalBytes
 		}
-		if paths[i].Occurrences != paths[j].Occurrences {
-			return paths[i].Occurrences > paths[j].Occurrences
+		if paths[i].stat.Occurrences != paths[j].stat.Occurrences {
+			return paths[i].stat.Occurrences > paths[j].stat.Occurrences
 		}
-		return paths[i].Path < paths[j].Path
+		if paths[i].stat.Path != paths[j].stat.Path {
+			return paths[i].stat.Path < paths[j].stat.Path
+		}
+		return paths[i].key < paths[j].key
 	})
+	outPaths := make([]ColumnRetainedSemanticStreamV1PathLayoutStat, 0, len(paths))
+	for _, path := range paths {
+		outPaths = append(outPaths, path.stat)
+	}
 	if maxPaths > 0 && len(paths) > maxPaths {
-		out.Paths = paths[:maxPaths]
+		out.Paths = outPaths[:maxPaths]
 		out.PathsTruncated = true
 	} else {
-		out.Paths = paths
+		out.Paths = outPaths
 	}
 	if c.zstdEncoder != nil {
 		c.zstdEncoder.Close()

--- a/TreeDB/collections/column_retained_semantic_stream.go
+++ b/TreeDB/collections/column_retained_semantic_stream.go
@@ -148,6 +148,7 @@ func ColumnRetainedSemanticStreamV1BlockLayoutAuditFromJSONDocuments(cfg ColumnS
 	if err != nil {
 		return ColumnRetainedSemanticStreamV1BlockLayoutAudit{}, err
 	}
+	defer collector.close()
 	for _, document := range prepared.documents {
 		collector.primaryLocatorBytes += int64(len(document))
 	}
@@ -171,6 +172,7 @@ func (c *Collection) auditRetainedSemanticStreamV1BlockLayoutAtSnapshot(snap *ba
 	if err != nil {
 		return ColumnRetainedSemanticStreamV1BlockLayoutAudit{}, nil, err
 	}
+	defer collector.close()
 	rootName := collectionRetainedSemanticStreamRootName(catalog.meta.Name)
 	it, err := collectionIteratorAtCatalogRoot(snap, catalog, rootName, nil, nil, false)
 	if err != nil {
@@ -740,6 +742,22 @@ func newColumnRetainedSemanticStreamV1BlockLayoutCollector() (*columnRetainedSem
 		paths:       make(map[string]*columnRetainedSemanticStreamV1PathLayoutCollector),
 		zstdEncoder: enc,
 	}, nil
+}
+
+func (c *columnRetainedSemanticStreamV1BlockLayoutCollector) close() {
+	if c == nil {
+		return
+	}
+	if c.zstdEncoder != nil {
+		c.zstdEncoder.Close()
+		c.zstdEncoder = nil
+	}
+	for _, stream := range c.paths {
+		if stream.zstdWriter != nil {
+			_ = stream.zstdWriter.Close()
+			stream.zstdWriter = nil
+		}
+	}
 }
 
 func (c *columnRetainedSemanticStreamV1BlockLayoutCollector) addBlock(block []byte) error {

--- a/TreeDB/collections/typed_storage_naming_test.go
+++ b/TreeDB/collections/typed_storage_naming_test.go
@@ -383,7 +383,7 @@ var typedStorageLegacyNameAllowlist = []typedStorageLegacyNameAllowlistEntry{
 	{path: "TreeDB/collections/column_reconstruction_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 27, occurrences: 31},
 	{path: "TreeDB/collections/column_retained_payload_audit.go", classification: typedStorageLegacyCompatibility, matchingLines: 8, occurrences: 8},
 	{path: "TreeDB/collections/column_retained_payload_audit_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 25, occurrences: 26},
-	{path: "TreeDB/collections/column_retained_semantic_stream.go", classification: typedStorageLegacyCompatibility, matchingLines: 5, occurrences: 5},
+	{path: "TreeDB/collections/column_retained_semantic_stream.go", classification: typedStorageLegacyCompatibility, matchingLines: 6, occurrences: 6},
 	{path: "TreeDB/collections/column_retained_vlog_placement_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 18, occurrences: 18},
 	{path: "TreeDB/collections/column_semantics.go", classification: typedStorageLegacyCompatibility, matchingLines: 34, occurrences: 34},
 	{path: "TreeDB/collections/dense_numeric_vector.go", classification: typedStorageLegacyCompatibility, matchingLines: 32, occurrences: 41},

--- a/TreeDB/collections/typed_storage_naming_test.go
+++ b/TreeDB/collections/typed_storage_naming_test.go
@@ -382,7 +382,7 @@ var typedStorageLegacyNameAllowlist = []typedStorageLegacyNameAllowlistEntry{
 	{path: "TreeDB/collections/column_reconstruction.go", classification: typedStorageLegacyCompatibility, matchingLines: 56, occurrences: 71},
 	{path: "TreeDB/collections/column_reconstruction_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 27, occurrences: 31},
 	{path: "TreeDB/collections/column_retained_payload_audit.go", classification: typedStorageLegacyCompatibility, matchingLines: 8, occurrences: 8},
-	{path: "TreeDB/collections/column_retained_payload_audit_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 25, occurrences: 26},
+	{path: "TreeDB/collections/column_retained_payload_audit_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 28, occurrences: 29},
 	{path: "TreeDB/collections/column_retained_semantic_stream.go", classification: typedStorageLegacyCompatibility, matchingLines: 6, occurrences: 6},
 	{path: "TreeDB/collections/column_retained_vlog_placement_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 18, occurrences: 18},
 	{path: "TreeDB/collections/column_semantics.go", classification: typedStorageLegacyCompatibility, matchingLines: 34, occurrences: 34},

--- a/cmd/treedb_retained_payload_audit/main.go
+++ b/cmd/treedb_retained_payload_audit/main.go
@@ -31,6 +31,8 @@ func run() (code int) {
 	var semanticStreamStats bool
 	var semanticStreamMaxDepth int
 	var semanticStreamMaxPaths int
+	var semanticStreamBlockLayout bool
+	var semanticStreamBlockMaxPaths int
 	defer func() {
 		if recovered := recover(); recovered != nil {
 			code = writeFailure(collectionName, fmt.Errorf("retained payload audit panic: %v", recovered))
@@ -50,6 +52,8 @@ func run() (code int) {
 	flag.BoolVar(&semanticStreamStats, "semantic-stream-stats", false, "Include decoded retained-payload scalar semantic stream oracle stats")
 	flag.IntVar(&semanticStreamMaxDepth, "semantic-stream-max-depth", 8, "Maximum retained-payload semantic stream traversal depth; zero means unlimited")
 	flag.IntVar(&semanticStreamMaxPaths, "semantic-stream-max-paths", 128, "Maximum retained-payload semantic stream path/kind rows to emit; zero means unlimited")
+	flag.BoolVar(&semanticStreamBlockLayout, "semantic-stream-block-layout", false, "Include semantic-stream-v1 side-root block layout and codec audit; avoids row reconstruction when used without decoded stats")
+	flag.IntVar(&semanticStreamBlockMaxPaths, "semantic-stream-block-max-paths", 128, "Maximum semantic-stream-v1 block path rows to emit; zero means unlimited")
 	flag.Parse()
 
 	if strings.TrimSpace(dbDir) == "" {
@@ -85,18 +89,20 @@ func run() (code int) {
 		return writeFailure(collectionName, fmt.Errorf("open collection: %w", err))
 	}
 	result, err := col.AuditRetainedPayloadDeclaredPathsAbsent(collections.ColumnRetainedPayloadCollectionAuditOptions{
-		Paths:                   splitCSV(pathsCSV),
-		MaxDocuments:            maxDocuments,
-		IncludeShapeStats:       shapeStats,
-		ShapeMaxDepth:           shapeMaxDepth,
-		ShapeMaxPaths:           shapeMaxPaths,
-		IncludeValueFamilyStats: valueFamilyStats,
-		ValueFamilyMaxDepth:     valueFamilyMaxDepth,
-		ValueFamilyMaxPaths:     valueFamilyMaxPaths,
-		ValueFamilyMaxUnique:    valueFamilyMaxUnique,
-		IncludeSemanticStreams:  semanticStreamStats,
-		SemanticStreamMaxDepth:  semanticStreamMaxDepth,
-		SemanticStreamMaxPaths:  semanticStreamMaxPaths,
+		Paths:                            splitCSV(pathsCSV),
+		MaxDocuments:                     maxDocuments,
+		IncludeShapeStats:                shapeStats,
+		ShapeMaxDepth:                    shapeMaxDepth,
+		ShapeMaxPaths:                    shapeMaxPaths,
+		IncludeValueFamilyStats:          valueFamilyStats,
+		ValueFamilyMaxDepth:              valueFamilyMaxDepth,
+		ValueFamilyMaxPaths:              valueFamilyMaxPaths,
+		ValueFamilyMaxUnique:             valueFamilyMaxUnique,
+		IncludeSemanticStreams:           semanticStreamStats,
+		SemanticStreamMaxDepth:           semanticStreamMaxDepth,
+		SemanticStreamMaxPaths:           semanticStreamMaxPaths,
+		IncludeSemanticStreamBlockLayout: semanticStreamBlockLayout,
+		SemanticStreamBlockMaxPaths:      semanticStreamBlockMaxPaths,
 	})
 	if err != nil {
 		writeResult(result)


### PR DESCRIPTION
## Summary

Supports #2662 under the #2353 storage-parity umbrella and feeds the #2359 current-head evidence gate.

This adds a fast semantic-stream-v1 retained-payload block layout audit. It parses the side-root block format directly, attributes raw block bytes to headers/path metadata/entry metadata/scalar values, and reports payload-only codec oracles plus per-path byte mass. It is diagnostic/evidence infrastructure, not a storage-parity claim by itself.

## Why

The ClickHouse audit in #2680 showed the parity target needs format-level decisions, not only generic store tuning. For retained `value_vlog`, the next decision needs to know whether current bytes are wrapper overhead, block compression, or semantic payload families. This PR makes that directly measurable on current JSONBench DB artifacts.

## Evidence from 1M current artifact

Command:

```sh
GOTOOLCHAIN=go1.26.4 GOFLAGS=-mod=mod go run ./cmd/treedb_retained_payload_audit \
  -db-dir /tmp/jsonbench_2663_row_asset_v7_1m_full_latest_20260613_092629/1m_column-store-full-prepared_json_full_all_compacted/db/maindb \
  -semantic-stream-block-layout \
  -semantic-stream-block-max-paths 50 \
  > /tmp/retained_semantic_stream_block_layout_after_2715_1m.json
```

Result highlights:

- `checked_rows`: 1,000,000
- primary semantic-stream locator bytes: 42,968,000
- side-root logical raw block bytes: 264,359,324
- byte attribution: 3,000 block headers, 553,445 path metadata, 13,823,187 entry metadata, 249,979,692 scalar bytes
- whole-block codec oracles:
  - snappy: 156,983,487 bytes, ratio 0.594
  - lz4: 152,191,598 bytes, ratio 0.576
  - zstd: 97,294,293 bytes, ratio 0.368
- per-path zstd oracle: 93,568,494 bytes
- largest retained paths by logical bytes include `commit.cid`, `commit.record.subject.uri`, `commit.record.subject.cid`, `commit.record.createdAt`, `commit.record.$type`, and `commit.record.text`

Interpretation: the current retained side-root value-log footprint is already close to whole-block zstd. The next #2662 slice should focus on semantic encodings for CID/URI/timestamp/type/text families rather than another generic block-compression pass.

## Changes

- Add `ColumnRetainedSemanticStreamV1BlockLayoutAudit` and `ColumnRetainedSemanticStreamV1BlockLayoutAuditFromJSONDocuments`.
- Add persisted collection audit support for semantic-stream-v1 side-root block-layout measurement.
- Add a fast audit path that validates primary locators and parses side-root blocks without row-by-row retained payload reconstruction when decoded stats are not requested.
- Add CLI flags:
  - `-semantic-stream-block-layout`
  - `-semantic-stream-block-max-paths`
- Add focused unit coverage for block attribution, codec stats, path truncation, and collection-level persisted audit output.

## Validation

```sh
GOTOOLCHAIN=go1.26.4 GOFLAGS=-mod=mod go test ./TreeDB/collections -run 'TestColumnRetainedSemanticStreamV1BlockLayoutAudit2662|TestAuditCollectionRetainedPayloadSemanticStreamBlockLayout2662|TestAuditCollectionRetainedPayloadSemanticStreamStats2662|TestAuditCollectionRetainedPayloadDeclaredPathsAbsentSemanticStreamV12662' -count=1
GOTOOLCHAIN=go1.26.4 GOFLAGS=-mod=mod go test ./cmd/treedb_retained_payload_audit -count=1
GOTOOLCHAIN=go1.26.4 GOFLAGS=-mod=mod go test ./TreeDB/collections -count=1

git diff --check HEAD~1 HEAD
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added semantic-stream-v1 block-layout auditing for retained payloads with configurable path-sampling and truncation options.
  * Audit results now include optional block-layout statistics and per-codec byte accounting.

* **Tests**
  * Added extensive tests validating block-layout parsing, per-path/block byte accounting, codec behaviors, and truncation/sampling cases.

* **Chores**
  * CLI audit tool updated with new flags to enable and limit block-layout auditing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->