### PR TITLE
treedb: encode dense row asset id ranges

### DIFF
--- a/TreeDB/collections/column_physical_asset.go
+++ b/TreeDB/collections/column_physical_asset.go
@@ -25,10 +25,14 @@ const (
 	columnPhysicalAssetVersionV5 = uint16(5)
 	columnPhysicalAssetVersionV6 = uint16(6)
 	columnPhysicalAssetVersionV7 = uint16(7)
+	columnPhysicalAssetVersionV8 = uint16(8)
 	columnPhysicalAssetVersion   = columnPhysicalAssetVersionV4
 )
 
-const columnPhysicalAssetRowEncodingFixedID = "fixed_id"
+const (
+	columnPhysicalAssetRowEncodingFixedID      = "fixed_id"
+	columnPhysicalAssetRowEncodingDenseIDRange = "dense_id_range"
+)
 
 var ErrColumnDeclaredValueUnsupported = errors.New("collections: unsupported column declared value")
 
@@ -626,12 +630,15 @@ func encodeColumnPhysicalAsset(input columnPhysicalAssetEncodeInput) ([]byte, co
 		}
 	}
 	var b bytes.Buffer
+	denseIDBase, useDenseIDRows := columnPhysicalAssetDenseBigEndianUint64RangeBase(input)
 	fixedIDWidth, useFixedIDRows := columnPhysicalAssetFixedIDRowEncodingWidth(input)
 	version, err := columnPhysicalAssetVersionForColumns(input.Columns)
 	if err != nil {
 		return nil, columnPhysicalAssetSummary{}, err
 	}
-	if useFixedIDRows {
+	if useDenseIDRows {
+		version = columnPhysicalAssetVersionV8
+	} else if useFixedIDRows {
 		version = columnPhysicalAssetVersionV7
 	}
 	writeManifestUint32(&b, columnPhysicalAssetMagic)
@@ -658,6 +665,16 @@ func encodeColumnPhysicalAsset(input columnPhysicalAssetEncodeInput) ([]byte, co
 		if version >= columnPhysicalAssetVersionV5 {
 			writeManifestString(&b, string(col.FixedWidthEncoding))
 		}
+	}
+	if useDenseIDRows {
+		writeManifestString(&b, columnPhysicalAssetRowEncodingDenseIDRange)
+		writeManifestUint64(&b, denseIDBase)
+		payload := b.Bytes()
+		return payload, columnPhysicalAssetSummary{
+			RowCount:     len(input.Rows),
+			ColumnCount:  len(input.Columns),
+			PayloadBytes: int64(len(payload)),
+		}, nil
 	}
 	if useFixedIDRows {
 		writeManifestString(&b, columnPhysicalAssetRowEncodingFixedID)
@@ -815,30 +832,48 @@ func decodeColumnPhysicalAsset(raw []byte) (columnPhysicalAsset, error) {
 	}
 	if version >= columnPhysicalAssetVersionV7 {
 		rowEncoding := cur.string()
-		if rowEncoding != columnPhysicalAssetRowEncodingFixedID {
+		if rowEncoding != columnPhysicalAssetRowEncodingFixedID && rowEncoding != columnPhysicalAssetRowEncodingDenseIDRange {
 			return columnPhysicalAsset{}, fmt.Errorf("collections: unsupported column physical asset row encoding %q", rowEncoding)
 		}
 		if len(asset.Columns) != 0 {
 			return columnPhysicalAsset{}, fmt.Errorf("collections: column physical asset row encoding %q requires zero columns", rowEncoding)
 		}
-		idWidth := cur.u64()
-		if idWidth == 0 || idWidth > uint64(maxCollectionInt) {
-			return columnPhysicalAsset{}, fmt.Errorf("collections: column physical asset fixed id width=%d invalid", idWidth)
-		}
 		deleted := asset.Header.Operation == ColumnPublishOperationDelete
 		if asset.Header.Operation != ColumnPublishOperationInsert && asset.Header.Operation != ColumnPublishOperationUpdate && asset.Header.Operation != ColumnPublishOperationDelete {
 			return columnPhysicalAsset{}, fmt.Errorf("collections: unsupported column physical asset operation %q", asset.Header.Operation)
 		}
-		for rowIdx := 0; rowIdx < int(rowCount); rowIdx++ {
-			if uint64(len(raw)-cur.pos) < idWidth {
-				return columnPhysicalAsset{}, errors.New("collections: short column physical asset fixed row id block")
+		switch rowEncoding {
+		case columnPhysicalAssetRowEncodingFixedID:
+			idWidth := cur.u64()
+			if idWidth == 0 || idWidth > uint64(maxCollectionInt) {
+				return columnPhysicalAsset{}, fmt.Errorf("collections: column physical asset fixed id width=%d invalid", idWidth)
 			}
-			row := columnDeclaredRow{
-				ID:      bytes.Clone(raw[cur.pos : cur.pos+int(idWidth)]),
-				Deleted: deleted,
+			for rowIdx := 0; rowIdx < int(rowCount); rowIdx++ {
+				if uint64(len(raw)-cur.pos) < idWidth {
+					return columnPhysicalAsset{}, errors.New("collections: short column physical asset fixed row id block")
+				}
+				row := columnDeclaredRow{
+					ID:      bytes.Clone(raw[cur.pos : cur.pos+int(idWidth)]),
+					Deleted: deleted,
+				}
+				cur.pos += int(idWidth)
+				asset.Rows = append(asset.Rows, row)
 			}
-			cur.pos += int(idWidth)
-			asset.Rows = append(asset.Rows, row)
+		case columnPhysicalAssetRowEncodingDenseIDRange:
+			if version < columnPhysicalAssetVersionV8 {
+				return columnPhysicalAsset{}, fmt.Errorf("collections: column physical asset row encoding %q requires version >= %d", rowEncoding, columnPhysicalAssetVersionV8)
+			}
+			baseID := cur.u64()
+			if rowCount > 0 && baseID > ^uint64(0)-uint64(rowCount-1) {
+				return columnPhysicalAsset{}, errors.New("collections: column physical asset dense id range overflows uint64")
+			}
+			for rowIdx := 0; rowIdx < int(rowCount); rowIdx++ {
+				row := columnDeclaredRow{
+					ID:      columnPhysicalAssetBigEndianUint64ID(baseID + uint64(rowIdx)),
+					Deleted: deleted,
+				}
+				asset.Rows = append(asset.Rows, row)
+			}
 		}
 		if cur.err != nil {
 			return columnPhysicalAsset{}, cur.err
@@ -1048,7 +1083,7 @@ func validateColumnPhysicalAssetForManifest(raw []byte, ref ColumnAssetRef, cfg 
 
 func isSupportedColumnPhysicalAssetVersion(version uint16) bool {
 	switch version {
-	case columnPhysicalAssetVersionV1, columnPhysicalAssetVersionV2, columnPhysicalAssetVersionV3, columnPhysicalAssetVersionV4, columnPhysicalAssetVersionV5, columnPhysicalAssetVersionV6, columnPhysicalAssetVersionV7:
+	case columnPhysicalAssetVersionV1, columnPhysicalAssetVersionV2, columnPhysicalAssetVersionV3, columnPhysicalAssetVersionV4, columnPhysicalAssetVersionV5, columnPhysicalAssetVersionV6, columnPhysicalAssetVersionV7, columnPhysicalAssetVersionV8:
 		return true
 	default:
 		return false
@@ -1073,6 +1108,43 @@ func columnPhysicalAssetFixedIDRowEncodingWidth(input columnPhysicalAssetEncodeI
 		}
 	}
 	return width, true
+}
+
+func columnPhysicalAssetDenseBigEndianUint64RangeBase(input columnPhysicalAssetEncodeInput) (uint64, bool) {
+	if len(input.Columns) != 0 || len(input.Rows) == 0 {
+		return 0, false
+	}
+	if !isSupportedColumnPhysicalAssetOperation(input.Operation) {
+		return 0, false
+	}
+	deleted := input.Operation == ColumnPublishOperationDelete
+	base, ok := columnPhysicalAssetParseBigEndianUint64ID(input.Rows[0].ID)
+	if !ok || input.Rows[0].Deleted != deleted {
+		return 0, false
+	}
+	if len(input.Rows) > 1 && base > ^uint64(0)-uint64(len(input.Rows)-1) {
+		return 0, false
+	}
+	for i, row := range input.Rows[1:] {
+		value, ok := columnPhysicalAssetParseBigEndianUint64ID(row.ID)
+		if !ok || row.Deleted != deleted || value != base+uint64(i+1) {
+			return 0, false
+		}
+	}
+	return base, true
+}
+
+func columnPhysicalAssetParseBigEndianUint64ID(id []byte) (uint64, bool) {
+	if len(id) != 8 {
+		return 0, false
+	}
+	return binary.BigEndian.Uint64(id), true
+}
+
+func columnPhysicalAssetBigEndianUint64ID(value uint64) []byte {
+	id := make([]byte, 8)
+	binary.BigEndian.PutUint64(id, value)
+	return id
 }
 
 func columnPhysicalAssetVersionForColumns(columns []ColumnStoreColumn) (uint16, error) {

--- a/TreeDB/collections/column_physical_asset_test.go
+++ b/TreeDB/collections/column_physical_asset_test.go
@@ -2,6 +2,7 @@ package collections
 
 import (
 	"bytes"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
@@ -218,6 +219,126 @@ func TestColumnPhysicalAssetCodecRoundTripM12A(t *testing.T) {
 	ref.Namespace = normalized.AssetManager.Namespace
 	if err := validateColumnPhysicalAssetForManifest(corrupt, ref, *normalized); err == nil || !strings.Contains(err.Error(), "checksum") {
 		t.Fatalf("validate corrupt asset err=%v want checksum failure", err)
+	}
+}
+
+func TestColumnPhysicalAssetDenseIDRangeEncoding2663(t *testing.T) {
+	cfg := testColumnPhysicalRowReaderFixedIDConfigV7(t)
+	rows := []columnDeclaredRow{
+		{ID: columnPhysicalAssetBigEndianUint64ID(42)},
+		{ID: columnPhysicalAssetBigEndianUint64ID(43)},
+		{ID: columnPhysicalAssetBigEndianUint64ID(44)},
+	}
+	encoded, summary, err := encodeColumnPhysicalAsset(columnPhysicalAssetEncodeInput{
+		Collection:        "events",
+		Namespace:         cfg.AssetManager.Namespace,
+		Generation:        7,
+		PartID:            3,
+		AppliedCommandLSN: 101,
+		Operation:         ColumnPublishOperationInsert,
+		SchemaHash:        cfg.SchemaHash,
+		Columns:           cfg.Columns,
+		Rows:              rows,
+	})
+	if err != nil {
+		t.Fatalf("encodeColumnPhysicalAsset dense ids: %v", err)
+	}
+	if len(encoded) == 0 || summary.RowCount != len(rows) || summary.ColumnCount != 0 || summary.PayloadBytes != int64(len(encoded)) {
+		t.Fatalf("unexpected dense asset summary=%+v len=%d", summary, len(encoded))
+	}
+	ref := ColumnAssetRef{
+		Kind:       ColumnAssetKindTCS1PartImage,
+		Namespace:  cfg.AssetManager.Namespace,
+		Generation: 7,
+		PartID:     3,
+		FileID:     1,
+		Length:     int64(len(encoded)),
+		Checksum:   page.Checksum(encoded),
+	}
+	header, version, _, err := parseColumnPhysicalAssetScanHeader(encoded, ref, "events", cfg, ColumnPublishOperationInsert)
+	if err != nil {
+		t.Fatalf("parseColumnPhysicalAssetScanHeader dense ids: %v", err)
+	}
+	if version != columnPhysicalAssetVersionV8 || header.RowCount != len(rows) || header.ColumnCount != 0 {
+		t.Fatalf("header=%+v version=%d want V8 zero-column dense rows", header, version)
+	}
+
+	decoded, err := decodeColumnPhysicalAsset(encoded)
+	if err != nil {
+		t.Fatalf("decodeColumnPhysicalAsset dense ids: %v", err)
+	}
+	for i, row := range decoded.Rows {
+		if got, want := binary.BigEndian.Uint64(row.ID), uint64(42+i); got != want || row.Deleted || len(row.Values) != 0 {
+			t.Fatalf("decoded row[%d]=%+v id=%d want dense id %d without values", i, row, got, want)
+		}
+	}
+
+	projection, err := newColumnPhysicalScanProjection(*cfg, nil)
+	if err != nil {
+		t.Fatalf("newColumnPhysicalScanProjection: %v", err)
+	}
+	var scanned []uint64
+	scanSummary, err := scanColumnPhysicalAssetRows(encoded, ref, "events", cfg, projection, func(row columnPhysicalScanRowView) error {
+		scanned = append(scanned, binary.BigEndian.Uint64(row.ID))
+		if row.Deleted || len(row.Values) != 0 {
+			return fmt.Errorf("row=%+v want non-deleted dense-id row without values", row)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("scanColumnPhysicalAssetRows dense ids: %v", err)
+	}
+	if scanSummary.rows != len(rows) || scanSummary.deleted != 0 || fmt.Sprint(scanned) != "[42 43 44]" {
+		t.Fatalf("scan summary=%+v scanned=%v", scanSummary, scanned)
+	}
+
+	accounting, err := columnStoreRowAssetPayloadAccounting(encoded, ref, "events", *cfg, ColumnPublishOperationInsert, false)
+	if err != nil {
+		t.Fatalf("columnStoreRowAssetPayloadAccounting dense ids: %v", err)
+	}
+	if accounting.RowIDStoredBytes != 0 || accounting.RowIDValueBytes != int64(len(rows))*8 || accounting.RowEncodingHeaderBytes == 0 {
+		t.Fatalf("dense row-id accounting=%+v", accounting)
+	}
+	categoryBytes := accounting.FormatHeaderBytes +
+		accounting.ColumnMetadataBytes +
+		accounting.RowEncodingHeaderBytes +
+		accounting.RowIDStoredBytes +
+		accounting.RowDeletedFlagBytes +
+		accounting.RowValueHeaderBytes +
+		accounting.RowValuePayloadBytes
+	if categoryBytes != accounting.TotalStoredBytes || accounting.TotalStoredBytes != int64(len(encoded)) {
+		t.Fatalf("dense category bytes=%d accounting=%+v len=%d", categoryBytes, accounting, len(encoded))
+	}
+
+	gappedRows := []columnDeclaredRow{
+		{ID: columnPhysicalAssetBigEndianUint64ID(42)},
+		{ID: columnPhysicalAssetBigEndianUint64ID(44)},
+		{ID: columnPhysicalAssetBigEndianUint64ID(45)},
+	}
+	gapped, _, err := encodeColumnPhysicalAsset(columnPhysicalAssetEncodeInput{
+		Collection:        "events",
+		Namespace:         cfg.AssetManager.Namespace,
+		Generation:        7,
+		PartID:            4,
+		AppliedCommandLSN: 102,
+		Operation:         ColumnPublishOperationInsert,
+		SchemaHash:        cfg.SchemaHash,
+		Columns:           cfg.Columns,
+		Rows:              gappedRows,
+	})
+	if err != nil {
+		t.Fatalf("encodeColumnPhysicalAsset gapped ids: %v", err)
+	}
+	gappedRef := ref
+	gappedRef.PartID = 4
+	gappedRef.Length = int64(len(gapped))
+	gappedRef.Checksum = page.Checksum(gapped)
+	_, gappedVersion, _, err := parseColumnPhysicalAssetScanHeader(gapped, gappedRef, "events", cfg, ColumnPublishOperationInsert)
+	if err != nil {
+		t.Fatalf("parseColumnPhysicalAssetScanHeader gapped ids: %v", err)
+	}
+	if gappedVersion != columnPhysicalAssetVersionV7 || len(gapped) <= len(encoded) {
+		t.Fatalf("gapped version=%d len=%d dense len=%d want V7 fallback larger than dense V8", gappedVersion, len(gapped), len(encoded))
 	}
 }
 

--- a/TreeDB/collections/column_physical_row_reader.go
+++ b/TreeDB/collections/column_physical_row_reader.go
@@ -1,6 +1,7 @@
 package collections
 
 import (
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"math"
@@ -56,8 +57,9 @@ type columnPhysicalRowReaderScratch struct {
 // columnPhysicalRowReader is a bounded, row-oriented physical column reader.
 // It is intentionally generic column-store machinery: callers fetch projected
 // rows by ordinal and provide worker-local scratch. Returned IDs alias cached
-// asset bytes; returned values and vector/adjacency slices alias scratch and are
-// invalid after the next fetch using the same scratch or after reader close.
+// asset bytes or scratch for encoded row-ID ranges; returned values and
+// vector/adjacency slices alias scratch and are invalid after the next fetch
+// using the same scratch or after reader close.
 //
 // The reader is not concurrency-safe. Parallel consumers must use independent
 // readers or add synchronization above this internal contract.
@@ -96,7 +98,17 @@ type columnPhysicalRowReaderBlock struct {
 	version       uint16
 	header        columnPhysicalAssetScanHeader
 	rowOffsets    []int
+	rowEncoding   string
+	fixedIDWidth  int
+	denseIDBase   uint64
 	residentBytes int64
+}
+
+type columnPhysicalAssetReaderRowIndex struct {
+	offsets      []int
+	rowEncoding  string
+	fixedIDWidth int
+	denseIDBase  uint64
 }
 
 type columnPhysicalRowReaderRow struct {
@@ -401,7 +413,7 @@ func (r *columnPhysicalRowReader) loadBlock(rowRange columnPhysicalRowReaderRang
 			raw = dst
 		}
 	}
-	rowOffsets, err := indexColumnPhysicalAssetReaderRows(raw, rowRange.version, rowRange.rowsOffset, rowRange.header, &r.view.Config)
+	rowIndex, err := indexColumnPhysicalAssetReaderRows(raw, rowRange.version, rowRange.rowsOffset, rowRange.header, &r.view.Config)
 	if err != nil {
 		return nil, fmt.Errorf("collections: physical column row reader index generation=%d part_id=%d: %w", rowRange.ref.Generation, rowRange.ref.PartID, err)
 	}
@@ -410,7 +422,10 @@ func (r *columnPhysicalRowReader) loadBlock(rowRange columnPhysicalRowReaderRang
 		raw:          raw,
 		version:      rowRange.version,
 		header:       rowRange.header,
-		rowOffsets:   rowOffsets,
+		rowOffsets:   rowIndex.offsets,
+		rowEncoding:  rowIndex.rowEncoding,
+		fixedIDWidth: rowIndex.fixedIDWidth,
+		denseIDBase:  rowIndex.denseIDBase,
 	}
 	block.residentBytes = int64(len(block.raw)) + int64(len(block.rowOffsets))*int64(strconv.IntSize/8)
 	if err := r.evictBlocksForInsert(); err != nil {
@@ -474,7 +489,14 @@ func cloneColumnPhysicalAssetScanHeader(header columnPhysicalAssetScanHeader) co
 
 func (r *columnPhysicalRowReader) decodeRowFromBlock(block *columnPhysicalRowReaderBlock, ordinal, rowIndex int, scratch *columnPhysicalRowReaderScratch) (columnPhysicalRowReaderRow, error) {
 	if block.version >= columnPhysicalAssetVersionV7 {
-		return r.decodeFixedIDRowFromBlock(block, ordinal, rowIndex, scratch)
+		switch block.rowEncoding {
+		case columnPhysicalAssetRowEncodingFixedID:
+			return r.decodeFixedIDRowFromBlock(block, ordinal, rowIndex, scratch)
+		case columnPhysicalAssetRowEncodingDenseIDRange:
+			return r.decodeDenseIDRangeRowFromBlock(block, ordinal, rowIndex, scratch)
+		default:
+			return columnPhysicalRowReaderRow{}, fmt.Errorf("unsupported column physical asset row encoding %q", block.rowEncoding)
+		}
 	}
 	cur := manifestCursor{raw: block.raw, pos: block.rowOffsets[rowIndex]}
 	id := cur.bytesView()
@@ -555,9 +577,44 @@ func (r *columnPhysicalRowReader) decodeFixedIDRowFromBlock(block *columnPhysica
 	}, nil
 }
 
-func indexColumnPhysicalAssetReaderRows(raw []byte, version uint16, rowsOffset int, header columnPhysicalAssetScanHeader, cfg *ColumnStoreConfig) ([]int, error) {
+func (r *columnPhysicalRowReader) decodeDenseIDRangeRowFromBlock(block *columnPhysicalRowReaderBlock, ordinal, rowIndex int, scratch *columnPhysicalRowReaderScratch) (columnPhysicalRowReaderRow, error) {
+	if block.header.Operation != ColumnPublishOperationInsert && block.header.Operation != ColumnPublishOperationUpdate && block.header.Operation != ColumnPublishOperationDelete {
+		return columnPhysicalRowReaderRow{}, fmt.Errorf("unsupported column physical asset operation %q", block.header.Operation)
+	}
+	if block.header.ColumnCount != 0 {
+		return columnPhysicalRowReaderRow{}, fmt.Errorf("column physical asset row encoding %q requires zero columns", columnPhysicalAssetRowEncodingDenseIDRange)
+	}
+	if block.version < columnPhysicalAssetVersionV8 {
+		return columnPhysicalRowReaderRow{}, fmt.Errorf("column physical asset row encoding %q requires version >= %d", columnPhysicalAssetRowEncodingDenseIDRange, columnPhysicalAssetVersionV8)
+	}
+	if rowIndex < 0 || rowIndex >= block.header.RowCount || block.denseIDBase > ^uint64(0)-uint64(rowIndex) {
+		return columnPhysicalRowReaderRow{}, fmt.Errorf("column physical asset dense row[%d] outside row_count=%d", rowIndex, block.header.RowCount)
+	}
+	scratch.Values = scratch.Values[:0]
+	scratch.Float32Values = scratch.Float32Values[:0]
+	scratch.Uint32Values = scratch.Uint32Values[:0]
+	if cap(scratch.Bytes) < 8 {
+		scratch.Bytes = make([]byte, 8)
+	} else {
+		scratch.Bytes = scratch.Bytes[:8]
+	}
+	binary.BigEndian.PutUint64(scratch.Bytes, block.denseIDBase+uint64(rowIndex))
+	return columnPhysicalRowReaderRow{
+		Generation:        block.header.Generation,
+		PartID:            block.header.PartID,
+		AppliedCommandLSN: block.header.AppliedCommandLSN,
+		Operation:         block.header.Operation,
+		Ordinal:           ordinal,
+		RowIndex:          rowIndex,
+		ID:                scratch.Bytes,
+		Values:            scratch.Values,
+		Deleted:           block.header.Operation == ColumnPublishOperationDelete,
+	}, nil
+}
+
+func indexColumnPhysicalAssetReaderRows(raw []byte, version uint16, rowsOffset int, header columnPhysicalAssetScanHeader, cfg *ColumnStoreConfig) (columnPhysicalAssetReaderRowIndex, error) {
 	if rowsOffset < 0 || rowsOffset > len(raw) {
-		return nil, fmt.Errorf("column physical asset invalid rows offset=%d len=%d", rowsOffset, len(raw))
+		return columnPhysicalAssetReaderRowIndex{}, fmt.Errorf("column physical asset invalid rows offset=%d len=%d", rowsOffset, len(raw))
 	}
 	if version >= columnPhysicalAssetVersionV7 {
 		return indexColumnPhysicalAssetReaderFixedIDRows(raw, rowsOffset, header)
@@ -572,65 +629,88 @@ func indexColumnPhysicalAssetReaderRows(raw []byte, version uint16, rowsOffset i
 			deleted = cur.bool()
 		}
 		if cur.err != nil {
-			return nil, cur.err
+			return columnPhysicalAssetReaderRowIndex{}, cur.err
 		}
 		if deleted {
 			if header.Operation != ColumnPublishOperationDelete {
-				return nil, fmt.Errorf("column physical asset %s row[%d] is marked deleted", header.Operation, rowIdx)
+				return columnPhysicalAssetReaderRowIndex{}, fmt.Errorf("column physical asset %s row[%d] is marked deleted", header.Operation, rowIdx)
 			}
 			continue
 		}
 		if header.Operation == ColumnPublishOperationDelete {
-			return nil, fmt.Errorf("column physical asset delete row[%d] is not marked deleted", rowIdx)
+			return columnPhysicalAssetReaderRowIndex{}, fmt.Errorf("column physical asset delete row[%d] is not marked deleted", rowIdx)
 		}
 		if err := skipColumnPhysicalRowValues(&cur, version, cfg); err != nil {
-			return nil, fmt.Errorf("row[%d]: %w", rowIdx, err)
+			return columnPhysicalAssetReaderRowIndex{}, fmt.Errorf("row[%d]: %w", rowIdx, err)
 		}
 	}
 	if cur.err != nil {
-		return nil, cur.err
+		return columnPhysicalAssetReaderRowIndex{}, cur.err
 	}
 	if cur.pos != len(raw) {
-		return nil, errors.New("trailing bytes in column physical asset")
+		return columnPhysicalAssetReaderRowIndex{}, errors.New("trailing bytes in column physical asset")
 	}
-	return offsets, nil
+	return columnPhysicalAssetReaderRowIndex{offsets: offsets}, nil
 }
 
-func indexColumnPhysicalAssetReaderFixedIDRows(raw []byte, rowsOffset int, header columnPhysicalAssetScanHeader) ([]int, error) {
+func indexColumnPhysicalAssetReaderFixedIDRows(raw []byte, rowsOffset int, header columnPhysicalAssetScanHeader) (columnPhysicalAssetReaderRowIndex, error) {
 	cur := manifestCursor{raw: raw, pos: rowsOffset}
 	rowEncoding := cur.string()
-	if rowEncoding != columnPhysicalAssetRowEncodingFixedID {
-		return nil, fmt.Errorf("unsupported column physical asset row encoding %q", rowEncoding)
-	}
 	if header.ColumnCount != 0 {
-		return nil, fmt.Errorf("column physical asset row encoding %q requires zero columns", rowEncoding)
-	}
-	idWidth64 := cur.u64()
-	if cur.err != nil {
-		return nil, cur.err
-	}
-	if idWidth64 == 0 || idWidth64 > uint64(maxCollectionInt) {
-		return nil, fmt.Errorf("column physical asset fixed id width=%d invalid", idWidth64)
+		return columnPhysicalAssetReaderRowIndex{}, fmt.Errorf("column physical asset row encoding %q requires zero columns", rowEncoding)
 	}
 	if header.Operation != ColumnPublishOperationInsert && header.Operation != ColumnPublishOperationUpdate && header.Operation != ColumnPublishOperationDelete {
-		return nil, fmt.Errorf("unsupported column physical asset operation %q", header.Operation)
+		return columnPhysicalAssetReaderRowIndex{}, fmt.Errorf("unsupported column physical asset operation %q", header.Operation)
 	}
-	idWidth := int(idWidth64)
-	offsets := make([]int, header.RowCount)
-	for rowIdx := 0; rowIdx < header.RowCount; rowIdx++ {
-		if cur.pos > len(raw) || len(raw)-cur.pos < idWidth {
-			return nil, errors.New("short column physical asset fixed row id block")
+	switch rowEncoding {
+	case columnPhysicalAssetRowEncodingFixedID:
+		idWidth64 := cur.u64()
+		if cur.err != nil {
+			return columnPhysicalAssetReaderRowIndex{}, cur.err
 		}
-		offsets[rowIdx] = cur.pos
-		cur.pos += idWidth
+		if idWidth64 == 0 || idWidth64 > uint64(maxCollectionInt) {
+			return columnPhysicalAssetReaderRowIndex{}, fmt.Errorf("column physical asset fixed id width=%d invalid", idWidth64)
+		}
+		idWidth := int(idWidth64)
+		offsets := make([]int, header.RowCount)
+		for rowIdx := 0; rowIdx < header.RowCount; rowIdx++ {
+			if cur.pos > len(raw) || len(raw)-cur.pos < idWidth {
+				return columnPhysicalAssetReaderRowIndex{}, errors.New("short column physical asset fixed row id block")
+			}
+			offsets[rowIdx] = cur.pos
+			cur.pos += idWidth
+		}
+		if cur.err != nil {
+			return columnPhysicalAssetReaderRowIndex{}, cur.err
+		}
+		if cur.pos != len(raw) {
+			return columnPhysicalAssetReaderRowIndex{}, errors.New("trailing bytes in column physical asset")
+		}
+		return columnPhysicalAssetReaderRowIndex{
+			offsets:      offsets,
+			rowEncoding:  rowEncoding,
+			fixedIDWidth: idWidth,
+		}, nil
+	case columnPhysicalAssetRowEncodingDenseIDRange:
+		baseID := cur.u64()
+		if cur.err != nil {
+			return columnPhysicalAssetReaderRowIndex{}, cur.err
+		}
+		if header.RowCount > 0 && baseID > ^uint64(0)-uint64(header.RowCount-1) {
+			return columnPhysicalAssetReaderRowIndex{}, errors.New("column physical asset dense id range overflows uint64")
+		}
+		if cur.pos != len(raw) {
+			return columnPhysicalAssetReaderRowIndex{}, errors.New("trailing bytes in column physical asset")
+		}
+		return columnPhysicalAssetReaderRowIndex{
+			offsets:      make([]int, header.RowCount),
+			rowEncoding:  rowEncoding,
+			fixedIDWidth: 8,
+			denseIDBase:  baseID,
+		}, nil
+	default:
+		return columnPhysicalAssetReaderRowIndex{}, fmt.Errorf("unsupported column physical asset row encoding %q", rowEncoding)
 	}
-	if cur.err != nil {
-		return nil, cur.err
-	}
-	if cur.pos != len(raw) {
-		return nil, errors.New("trailing bytes in column physical asset")
-	}
-	return offsets, nil
 }
 
 func skipColumnPhysicalRowValues(cur *manifestCursor, version uint16, cfg *ColumnStoreConfig) error {

--- a/TreeDB/collections/column_physical_row_reader_test.go
+++ b/TreeDB/collections/column_physical_row_reader_test.go
@@ -2,6 +2,7 @@ package collections
 
 import (
 	"bytes"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"math"
@@ -180,9 +181,9 @@ func TestColumnPhysicalRowReaderFetchesV7FixedIDRows(t *testing.T) {
 	root := backenddb.ColumnAssetRootDirPath(t.TempDir())
 	rows := []columnDeclaredRow{
 		{ID: []byte("doc-0000")},
-		{ID: []byte("doc-0001")},
 		{ID: []byte("doc-0002")},
-		{ID: []byte("doc-0003")},
+		{ID: []byte("doc-0004")},
+		{ID: []byte("doc-0006")},
 	}
 	ref := writeColumnPhysicalRowReaderAssetForTestV1(t, root, cfg, 19, 1, rows)
 	raw, err := readColumnPhysicalAssetFromManager(root, ref)
@@ -211,8 +212,8 @@ func TestColumnPhysicalRowReaderFetchesV7FixedIDRows(t *testing.T) {
 	if err != nil {
 		t.Fatalf("FetchRow(2): %v", err)
 	}
-	if string(row.ID) != "doc-0002" || row.Ordinal != 2 || row.RowIndex != 2 || row.Deleted || len(row.Values) != 0 {
-		t.Fatalf("row=%+v id=%q want fixed-id doc-0002 without values", row, string(row.ID))
+	if string(row.ID) != "doc-0004" || row.Ordinal != 2 || row.RowIndex != 2 || row.Deleted || len(row.Values) != 0 {
+		t.Fatalf("row=%+v id=%q want fixed-id doc-0004 without values", row, string(row.ID))
 	}
 
 	var got []string
@@ -225,7 +226,59 @@ func TestColumnPhysicalRowReaderFetchesV7FixedIDRows(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("FetchBatch: %v", err)
 	}
-	if fmt.Sprint(got) != "[doc-0003 doc-0001]" {
+	if fmt.Sprint(got) != "[doc-0006 doc-0002]" {
+		t.Fatalf("batch ids=%v", got)
+	}
+}
+
+func TestColumnPhysicalRowReaderFetchesV8DenseIDRangeRows(t *testing.T) {
+	cfg := testColumnPhysicalRowReaderFixedIDConfigV7(t)
+	root := backenddb.ColumnAssetRootDirPath(t.TempDir())
+	rows := []columnDeclaredRow{
+		{ID: columnPhysicalAssetBigEndianUint64ID(900)},
+		{ID: columnPhysicalAssetBigEndianUint64ID(901)},
+		{ID: columnPhysicalAssetBigEndianUint64ID(902)},
+		{ID: columnPhysicalAssetBigEndianUint64ID(903)},
+	}
+	ref := writeColumnPhysicalRowReaderAssetForTestV1(t, root, cfg, 19, 1, rows)
+	raw, err := readColumnPhysicalAssetFromManager(root, ref)
+	if err != nil {
+		t.Fatalf("readColumnPhysicalAssetFromManager: %v", err)
+	}
+	if _, version, _, err := parseColumnPhysicalAssetScanHeader(raw, ref, "events", cfg, ColumnPublishOperationInsert); err != nil {
+		t.Fatalf("parseColumnPhysicalAssetScanHeader: %v", err)
+	} else if version != columnPhysicalAssetVersionV8 {
+		t.Fatalf("asset version=%d want V8", version)
+	}
+
+	reader, err := newColumnPhysicalRowReaderFromSnapshotView(columnPhysicalRowReaderViewForTestV1(root, cfg, ref), columnPhysicalRowReaderOptions{
+		RequireInsertOnly: true,
+	})
+	if err != nil {
+		t.Fatalf("newColumnPhysicalRowReaderFromSnapshotView: %v", err)
+	}
+	defer func() { _ = reader.Close() }()
+
+	var scratch columnPhysicalRowReaderScratch
+	row, err := reader.FetchRow(2, &scratch)
+	if err != nil {
+		t.Fatalf("FetchRow(2): %v", err)
+	}
+	if got := binary.BigEndian.Uint64(row.ID); got != 902 || row.Ordinal != 2 || row.RowIndex != 2 || row.Deleted || len(row.Values) != 0 {
+		t.Fatalf("row=%+v id=%d want dense id 902 without values", row, got)
+	}
+
+	var got []uint64
+	if err := reader.FetchBatch([]int{3, 1}, &scratch, func(row columnPhysicalRowReaderRow) error {
+		got = append(got, binary.BigEndian.Uint64(row.ID))
+		if row.Deleted || len(row.Values) != 0 {
+			return fmt.Errorf("row=%+v want non-deleted dense-id row without values", row)
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("FetchBatch: %v", err)
+	}
+	if fmt.Sprint(got) != "[903 901]" {
 		t.Fatalf("batch ids=%v", got)
 	}
 }

--- a/TreeDB/collections/column_physical_scan.go
+++ b/TreeDB/collections/column_physical_scan.go
@@ -62,7 +62,7 @@ type columnPhysicalScanRowView struct {
 	AppliedCommandLSN uint64
 	Operation         ColumnPublishOperation
 	RowIndex          int
-	// ID is passed by value but aliases the raw asset buffer; copy to retain it.
+	// ID is passed by value but aliases scanner-owned storage; copy to retain it.
 	ID []byte
 	// Values aliases scanner scratch; copy before the visitor returns to retain it.
 	Values  []columnDeclaredValue
@@ -2191,7 +2191,7 @@ func scanColumnPhysicalAssetRowsWithManifestOperation(raw []byte, ref ColumnAsse
 	}
 	cur := manifestCursor{raw: raw, pos: rowsOffset}
 	if version >= columnPhysicalAssetVersionV7 {
-		return scanColumnPhysicalAssetFixedIDRows(&cur, raw, header, visitor)
+		return scanColumnPhysicalAssetEncodedIDRows(&cur, raw, version, header, visitor)
 	}
 	valuesBuf := projection.values
 	var summary columnPhysicalAssetScanSummary
@@ -2246,24 +2246,35 @@ func scanColumnPhysicalAssetRowsWithManifestOperation(raw []byte, ref ColumnAsse
 	return summary, nil
 }
 
-func scanColumnPhysicalAssetFixedIDRows(cur *manifestCursor, raw []byte, header columnPhysicalAssetScanHeader, visitor func(columnPhysicalScanRowView) error) (columnPhysicalAssetScanSummary, error) {
+func scanColumnPhysicalAssetEncodedIDRows(cur *manifestCursor, raw []byte, version uint16, header columnPhysicalAssetScanHeader, visitor func(columnPhysicalScanRowView) error) (columnPhysicalAssetScanSummary, error) {
 	rowEncoding := cur.string()
-	if rowEncoding != columnPhysicalAssetRowEncodingFixedID {
-		return columnPhysicalAssetScanSummary{}, fmt.Errorf("unsupported column physical asset row encoding %q", rowEncoding)
-	}
 	if header.ColumnCount != 0 {
 		return columnPhysicalAssetScanSummary{}, fmt.Errorf("column physical asset row encoding %q requires zero columns", rowEncoding)
 	}
+	deleted := header.Operation == ColumnPublishOperationDelete
+	if header.Operation != ColumnPublishOperationInsert && header.Operation != ColumnPublishOperationUpdate && header.Operation != ColumnPublishOperationDelete {
+		return columnPhysicalAssetScanSummary{}, fmt.Errorf("unsupported column physical asset operation %q", header.Operation)
+	}
+	switch rowEncoding {
+	case columnPhysicalAssetRowEncodingFixedID:
+		return scanColumnPhysicalAssetFixedIDRows(cur, raw, header, deleted, visitor)
+	case columnPhysicalAssetRowEncodingDenseIDRange:
+		if version < columnPhysicalAssetVersionV8 {
+			return columnPhysicalAssetScanSummary{}, fmt.Errorf("column physical asset row encoding %q requires version >= %d", rowEncoding, columnPhysicalAssetVersionV8)
+		}
+		return scanColumnPhysicalAssetDenseIDRangeRows(cur, header, deleted, visitor)
+	default:
+		return columnPhysicalAssetScanSummary{}, fmt.Errorf("unsupported column physical asset row encoding %q", rowEncoding)
+	}
+}
+
+func scanColumnPhysicalAssetFixedIDRows(cur *manifestCursor, raw []byte, header columnPhysicalAssetScanHeader, deleted bool, visitor func(columnPhysicalScanRowView) error) (columnPhysicalAssetScanSummary, error) {
 	idWidth := cur.u64()
 	if cur.err != nil {
 		return columnPhysicalAssetScanSummary{}, cur.err
 	}
 	if idWidth == 0 || idWidth > uint64(maxCollectionInt) {
 		return columnPhysicalAssetScanSummary{}, fmt.Errorf("column physical asset fixed id width=%d invalid", idWidth)
-	}
-	deleted := header.Operation == ColumnPublishOperationDelete
-	if header.Operation != ColumnPublishOperationInsert && header.Operation != ColumnPublishOperationUpdate && header.Operation != ColumnPublishOperationDelete {
-		return columnPhysicalAssetScanSummary{}, fmt.Errorf("unsupported column physical asset operation %q", header.Operation)
 	}
 	var summary columnPhysicalAssetScanSummary
 	for rowIdx := 0; rowIdx < header.RowCount; rowIdx++ {
@@ -2295,6 +2306,42 @@ func scanColumnPhysicalAssetFixedIDRows(cur *manifestCursor, raw []byte, header 
 	}
 	if cur.pos != len(raw) {
 		return columnPhysicalAssetScanSummary{}, errors.New("trailing bytes in column physical asset")
+	}
+	return summary, nil
+}
+
+func scanColumnPhysicalAssetDenseIDRangeRows(cur *manifestCursor, header columnPhysicalAssetScanHeader, deleted bool, visitor func(columnPhysicalScanRowView) error) (columnPhysicalAssetScanSummary, error) {
+	baseID := cur.u64()
+	if cur.err != nil {
+		return columnPhysicalAssetScanSummary{}, cur.err
+	}
+	if header.RowCount > 0 && baseID > ^uint64(0)-uint64(header.RowCount-1) {
+		return columnPhysicalAssetScanSummary{}, errors.New("column physical asset dense id range overflows uint64")
+	}
+	if cur.pos != len(cur.raw) {
+		return columnPhysicalAssetScanSummary{}, errors.New("trailing bytes in column physical asset")
+	}
+	var summary columnPhysicalAssetScanSummary
+	idScratch := make([]byte, 8)
+	for rowIdx := 0; rowIdx < header.RowCount; rowIdx++ {
+		binary.BigEndian.PutUint64(idScratch, baseID+uint64(rowIdx))
+		summary.rows++
+		if deleted {
+			summary.deleted++
+		}
+		if visitor != nil {
+			if err := visitor(columnPhysicalScanRowView{
+				Generation:        header.Generation,
+				PartID:            header.PartID,
+				AppliedCommandLSN: header.AppliedCommandLSN,
+				Operation:         header.Operation,
+				RowIndex:          rowIdx,
+				ID:                idScratch,
+				Deleted:           deleted,
+			}); err != nil {
+				return columnPhysicalAssetScanSummary{}, err
+			}
+		}
 	}
 	return summary, nil
 }

--- a/TreeDB/collections/column_store_physical_accounting.go
+++ b/TreeDB/collections/column_store_physical_accounting.go
@@ -541,34 +541,52 @@ func columnStoreRowAssetPayloadAccounting(raw []byte, ref ColumnAssetRef, expect
 	if version >= columnPhysicalAssetVersionV7 {
 		rowEncodingHeaderStart := cur.pos
 		rowEncoding := cur.string()
-		if rowEncoding != columnPhysicalAssetRowEncodingFixedID {
-			return ColumnStoreRowAssetByteAccounting{}, fmt.Errorf("unsupported column physical asset row encoding %q", rowEncoding)
-		}
 		if header.ColumnCount != 0 {
 			return ColumnStoreRowAssetByteAccounting{}, fmt.Errorf("column physical asset row encoding %q requires zero columns", rowEncoding)
 		}
-		idWidth := cur.u64()
-		if cur.err != nil {
-			return ColumnStoreRowAssetByteAccounting{}, cur.err
-		}
-		if idWidth == 0 || idWidth > uint64(maxCollectionInt) {
-			return ColumnStoreRowAssetByteAccounting{}, fmt.Errorf("column physical asset fixed id width=%d invalid", idWidth)
-		}
-		out.RowEncodingHeaderBytes = int64(cur.pos - rowEncodingHeaderStart)
 		deleted := header.Operation == ColumnPublishOperationDelete
 		if header.Operation != ColumnPublishOperationInsert && header.Operation != ColumnPublishOperationUpdate && header.Operation != ColumnPublishOperationDelete {
 			return ColumnStoreRowAssetByteAccounting{}, fmt.Errorf("unsupported column physical asset operation %q", header.Operation)
 		}
-		for rowIdx := 0; rowIdx < header.RowCount; rowIdx++ {
-			if uint64(len(raw)-cur.pos) < idWidth {
-				return ColumnStoreRowAssetByteAccounting{}, errors.New("short column physical asset fixed row id block")
+		switch rowEncoding {
+		case columnPhysicalAssetRowEncodingFixedID:
+			idWidth := cur.u64()
+			if cur.err != nil {
+				return ColumnStoreRowAssetByteAccounting{}, cur.err
 			}
-			cur.pos += int(idWidth)
-			out.RowIDStoredBytes = addColumnStorePhysicalAccountingBytes(out.RowIDStoredBytes, int64(idWidth))
-			out.RowIDValueBytes = addColumnStorePhysicalAccountingBytes(out.RowIDValueBytes, int64(idWidth))
+			if idWidth == 0 || idWidth > uint64(maxCollectionInt) {
+				return ColumnStoreRowAssetByteAccounting{}, fmt.Errorf("column physical asset fixed id width=%d invalid", idWidth)
+			}
+			out.RowEncodingHeaderBytes = int64(cur.pos - rowEncodingHeaderStart)
+			for rowIdx := 0; rowIdx < header.RowCount; rowIdx++ {
+				if uint64(len(raw)-cur.pos) < idWidth {
+					return ColumnStoreRowAssetByteAccounting{}, errors.New("short column physical asset fixed row id block")
+				}
+				cur.pos += int(idWidth)
+				out.RowIDStoredBytes = addColumnStorePhysicalAccountingBytes(out.RowIDStoredBytes, int64(idWidth))
+				out.RowIDValueBytes = addColumnStorePhysicalAccountingBytes(out.RowIDValueBytes, int64(idWidth))
+				if deleted {
+					out.DeletedRows++
+				}
+			}
+		case columnPhysicalAssetRowEncodingDenseIDRange:
+			if version < columnPhysicalAssetVersionV8 {
+				return ColumnStoreRowAssetByteAccounting{}, fmt.Errorf("column physical asset row encoding %q requires version >= %d", rowEncoding, columnPhysicalAssetVersionV8)
+			}
+			baseID := cur.u64()
+			if cur.err != nil {
+				return ColumnStoreRowAssetByteAccounting{}, cur.err
+			}
+			if header.RowCount > 0 && baseID > ^uint64(0)-uint64(header.RowCount-1) {
+				return ColumnStoreRowAssetByteAccounting{}, errors.New("column physical asset dense id range overflows uint64")
+			}
+			out.RowEncodingHeaderBytes = int64(cur.pos - rowEncodingHeaderStart)
+			out.RowIDValueBytes = addColumnStorePhysicalAccountingBytes(out.RowIDValueBytes, int64(header.RowCount)*8)
 			if deleted {
-				out.DeletedRows++
+				out.DeletedRows = header.RowCount
 			}
+		default:
+			return ColumnStoreRowAssetByteAccounting{}, fmt.Errorf("unsupported column physical asset row encoding %q", rowEncoding)
 		}
 		if cur.err != nil {
 			return ColumnStoreRowAssetByteAccounting{}, cur.err

--- a/TreeDB/collections/document_materializer.go
+++ b/TreeDB/collections/document_materializer.go
@@ -708,7 +708,7 @@ func (v *CollectionReadView) loadPointRowBlock(view columnPhysicalScanSnapshotVi
 		return nil, fmt.Errorf("collections: document row point fetch header generation=%d part_id=%d: %w", assetRef.Ref.Generation, assetRef.Ref.PartID, err)
 	}
 	header = cloneColumnPhysicalAssetScanHeader(header)
-	rowOffsets, err := indexColumnPhysicalAssetReaderRows(raw, version, rowsOffset, header, &view.Config)
+	rowIndex, err := indexColumnPhysicalAssetReaderRows(raw, version, rowsOffset, header, &view.Config)
 	if err != nil {
 		return nil, fmt.Errorf("collections: document row point fetch index generation=%d part_id=%d: %w", assetRef.Ref.Generation, assetRef.Ref.PartID, err)
 	}
@@ -717,7 +717,10 @@ func (v *CollectionReadView) loadPointRowBlock(view columnPhysicalScanSnapshotVi
 		raw:           raw,
 		version:       version,
 		header:        header,
-		rowOffsets:    rowOffsets,
+		rowOffsets:    rowIndex.offsets,
+		rowEncoding:   rowIndex.rowEncoding,
+		fixedIDWidth:  rowIndex.fixedIDWidth,
+		denseIDBase:   rowIndex.denseIDBase,
 		residentBytes: int64(len(raw)),
 	}
 	if v.pointRowBlocks == nil {

--- a/TreeDB/collections/typed_storage_naming_test.go
+++ b/TreeDB/collections/typed_storage_naming_test.go
@@ -404,7 +404,7 @@ var typedStorageLegacyNameAllowlist = []typedStorageLegacyNameAllowlistEntry{
 	{path: "TreeDB/collections/column_store_compaction.go", classification: typedStorageLegacyCompatibility, matchingLines: 34, occurrences: 41},
 	{path: "TreeDB/collections/column_store_compaction_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 71, occurrences: 82},
 	{path: "TreeDB/collections/column_store_compatibility_api_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 7, occurrences: 9},
-	{path: "TreeDB/collections/column_store_physical_accounting.go", classification: typedStorageLegacyCompatibility, matchingLines: 222, occurrences: 254},
+	{path: "TreeDB/collections/column_store_physical_accounting.go", classification: typedStorageLegacyCompatibility, matchingLines: 226, occurrences: 258},
 	{path: "TreeDB/collections/column_store_physical_accounting_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 23, occurrences: 29},
 	{path: "TreeDB/collections/column_store_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 276, occurrences: 352},
 	{path: "TreeDB/collections/scalar_primitive.go", classification: typedStorageLegacyCompatibility, matchingLines: 36, occurrences: 42},

--- a/TreeDB/docs/spec/storage-format.md
+++ b/TreeDB/docs/spec/storage-format.md
@@ -705,6 +705,18 @@ parts are all live rows; delete/tombstone parts are all deleted rows. Assets wit
 row-owned columns, mixed-width row ids, or legacy payloads continue to use the
 generic row payload.
 
+Version 8 extends that zero-row-owned-column case for dense 8-byte big-endian
+unsigned document id ranges:
+
+```text
+string   RowEncoding = "dense_id_range"
+u64      BaseRowID
+```
+
+The row id for row index `i` is synthesized as `BaseRowID + i` encoded as
+8-byte big-endian `uint64`. V8 stores no per-row id bytes and derives deleted
+state from the asset operation, matching the V7 live/delete all-rows contract.
+
 Latest-visible readers resolve document identity from the typed-row
 row/tombstone assets first, then read the typed-column part for the winning
 non-deleted generation+row. Readers validate namespace, generation, part id,

--- a/TreeDB/docs/spec/typed-column-production-jsonbench-plan.md
+++ b/TreeDB/docs/spec/typed-column-production-jsonbench-plan.md
@@ -109,8 +109,11 @@ Size:
 
 - variable header plus variable row/document/value payloads
 - zero-row-column parts with fixed-width document ids can use the TCPA V7
-  `fixed_id` row encoding, which stores contiguous ids and derives deleted
+  `fixed_id` row encoding, which stores fixed-width ids and derives deleted
   state from the asset operation
+- zero-row-column parts with dense 8-byte big-endian uint64 document ids can use
+  the TCPA V8 `dense_id_range` row encoding, which stores only the base id and
+  derives every row id by ordinal
 - `ColumnPreparedAsset.Bytes` and `ColumnAssetRef.Length` are the authoritative
   stored byte counts
 


### PR DESCRIPTION
## Summary

Refs #2663, #2353, #2359.

This adds TCPA V8 `dense_id_range` row assets for zero-row-owned-column physical row assets whose document IDs are dense 8-byte big-endian `uint64` ranges. Instead of storing one 8-byte ID per row, V8 stores the base ID once and synthesizes row IDs by ordinal.

The slice updates encode/decode, row readers, point materialization, scans, physical accounting, storage-format docs, and tests. It intentionally preserves V7 `fixed_id` for non-dense/gapped fixed-width IDs.

## Storage Evidence

Canonical harness: `/Users/michaelseiler/orca/workspaces/JSONBench-1955-final-evidence/treedb` at JSONBench commit `07844fa`, using `GOMAP_REPLACE=/Users/michaelseiler/orca/workspaces/gomap/2680-clickhouse-part-audit`.

Current artifact:
`/tmp/jsonbench_2663_dense_row_id_1m_full_20260613_120016/1m_column-store-full-prepared_json_full_all_compacted/result.json`

Baseline artifact from the V7 row-asset audit:
`/tmp/jsonbench_2663_row_asset_v7_1m_full_latest_20260613_092629/1m_column-store-full-prepared_json_full_all_compacted/result.json`

| Metric | V7 baseline | V8 dense range | Delta |
| --- | ---: | ---: | ---: |
| Row asset bytes | 8,008,568 | 8,946 | -7,999,622 |
| Column asset segments | 42,664,708 | 34,665,086 | -7,999,622 |
| Typed-column part bytes | 34,656,140 | 34,656,140 | 0 |
| Logical row-ID value bytes | 8,000,000 | 8,000,000 | 0 |
| Stored row-ID bytes | 8,000,000 | 0 | -8,000,000 |

Current 1M full-prepared compacted durable storage, WAL excluded: `164,098,289` bytes. The current run's retained `value_vlog` is `118,456,968` bytes, so this PR should be judged by the row-asset/column-asset accounting above; retained-vlog parity remains owned by #2662. Column assets are improved but still above the #2663 `~25 MB` target because typed-column parts remain `34,656,140` bytes.

Current query timings from the same artifact, `TRIES=1`:

| Query | Best | Rows scanned | Result hash |
| --- | ---: | ---: | --- |
| q1 | 0.0487s | 1,000,000 | `059afea7bfbfb7d188ccc441b326301b063975713996169dfd43563420d11492` |
| q2 | 0.6387s | 1,000,000 | `b63b8e1013c918fcda7c299ef64beb20c4988854cf0671a83803b6951d795860` |
| q3 | 0.1392s | 1,000,000 | `cdb6acc4d0d990bdbdab5d2f29df85943490b2cb6b950351cbfa9bd974a182eb` |
| q4 | 0.1366s | 1,000,000 | `a815e9fbdf899f6f2cf3f59c5d73cf9264c9295d85553e972b53a3b57b9bcfb5` |
| q5 | 0.1489s | 1,000,000 | `ef6217ce9da3a74fdf600ccbebd333457f017d6012dc0c231338961533f5689c` |

## Validation

- `GOTOOLCHAIN=go1.26.4 GOFLAGS=-mod=mod go test ./TreeDB/collections -run 'TestColumnPhysicalAssetDenseIDRangeEncoding2663|TestColumnPhysicalRowReaderFetchesV8DenseIDRangeRows|TestColumnPhysicalRowReaderFetchesV7FixedIDRows' -count=1`
- `GOTOOLCHAIN=go1.26.4 GOFLAGS=-mod=mod go test ./TreeDB/collections -count=1`
- `GOTOOLCHAIN=go1.26.4 GOFLAGS=-mod=mod go test ./TreeDB/docs -count=1`
- `git diff --check`
- Smoke JSONBench full-prepared compacted reconstruction run:
  `/tmp/jsonbench_2663_dense_row_id_smoke_20260613_115949/rows6_column-store-full-prepared_json_full_all_compacted/result.json`
- 1M JSONBench full-prepared compacted reconstruction run:
  `/tmp/jsonbench_2663_dense_row_id_1m_full_20260613_120016/1m_column-store-full-prepared_json_full_all_compacted/result.json`

## Follow-up

This PR reduces #2663's row-asset component to near zero. The remaining #2663 work is typed-column part reduction from `34.656 MB` toward the `~25 MB` target. #2662 remains responsible for retained `value_vlog` reduction toward retained-payload storage parity.