### PR TITLE
treedb: compress retained semantic stream blocks

### DIFF
--- a/TreeDB/caching/vlog_compression_selector.go
+++ b/TreeDB/caching/vlog_compression_selector.go
@@ -79,7 +79,10 @@ var (
 	vlogSelectorBlockCodecs    = [...]valuelog.BlockCodec{valuelog.BlockCodecSnappy, valuelog.BlockCodecLZ4, valuelog.BlockCodecZSTD}
 )
 
-var valueLogRetainedSemanticStreamV1BlockMagic = []byte("crss1blk\x00")
+var (
+	valueLogRetainedSemanticStreamV1BlockMagic     = []byte("crss1blk\x00")
+	valueLogRetainedSemanticStreamV1BlockZSTDMagic = []byte("crss1zst\x00")
+)
 
 const (
 	defaultVlogHoldBytes      = 64 << 20
@@ -1840,7 +1843,8 @@ func valueLogPayloadLooksRetainedJSONLike(value []byte) bool {
 				(value[i+1] == 'D' && value[i+2] == '1') &&
 				(value[i+3] == 'D' || value[i+3] == 'I' || value[i+3] == 'H')
 		case 'c':
-			return bytes.HasPrefix(value[i:], valueLogRetainedSemanticStreamV1BlockMagic)
+			return bytes.HasPrefix(value[i:], valueLogRetainedSemanticStreamV1BlockMagic) ||
+				bytes.HasPrefix(value[i:], valueLogRetainedSemanticStreamV1BlockZSTDMagic)
 		default:
 			return false
 		}

--- a/TreeDB/caching/vlog_compression_selector_test.go
+++ b/TreeDB/caching/vlog_compression_selector_test.go
@@ -1005,6 +1005,10 @@ func TestValueLogPayloadLooksRetainedLikeSemanticStreamBlock(t *testing.T) {
 	if !valueLogPayloadLooksRetainedJSONLike(block) {
 		t.Fatalf("semantic-stream-v1 block was not classified as retained-like")
 	}
+	zstdBlock := append([]byte("crss1zst\x00"), bytes.Repeat([]byte{0x7f}, 1024)...)
+	if !valueLogPayloadLooksRetainedJSONLike(zstdBlock) {
+		t.Fatalf("semantic-stream-v1 zstd block was not classified as retained-like")
+	}
 
 	locator := append([]byte("crss1loc\x00"), bytes.Repeat([]byte{0x7f}, 40)...)
 	if valueLogPayloadLooksRetainedJSONLike(locator) {
@@ -1019,6 +1023,12 @@ func TestRetainedStorageFirstValueLogAutoDetectsSemanticStreamBlocks(t *testing.
 
 	if !db.retainedStorageFirstValueLogAuto(0, 0, records) {
 		t.Fatalf("semantic-stream-v1 block did not select retained storage-first value-log compression")
+	}
+
+	zstdBlock := append([]byte("crss1zst\x00"), bytes.Repeat([]byte{0x42}, 1024)...)
+	zstdRecords := []valuelog.Record{{Value: zstdBlock}}
+	if !db.retainedStorageFirstValueLogAuto(0, 0, zstdRecords) {
+		t.Fatalf("semantic-stream-v1 zstd block did not select retained storage-first value-log compression")
 	}
 }
 

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -8353,6 +8353,115 @@ func buildRootDeltaBatchPublishInputsFromTables(collectionName string, rootNames
 	return ordered, cleanup, nil
 }
 
+func coalesceCollectionRootDeltaTables(collectionName string, rootNames []string, tables []memtable.Table, policies []backenddb.OrderedRootStoragePolicy) ([]string, []memtable.Table, []backenddb.OrderedRootStoragePolicy, func(), error) {
+	if len(rootNames) != len(tables) || len(rootNames) != len(policies) {
+		return nil, nil, nil, func() {}, fmt.Errorf("collections: collection %q invalid delta lengths roots=%d tables=%d policies=%d", collectionName, len(rootNames), len(tables), len(policies))
+	}
+	if len(rootNames) < 2 {
+		return rootNames, tables, policies, func() {}, nil
+	}
+	firstByRoot := make(map[string]int, len(rootNames))
+	duplicate := false
+	for i, rootName := range rootNames {
+		if first, ok := firstByRoot[rootName]; ok {
+			if policies[i] != policies[first] {
+				return nil, nil, nil, func() {}, fmt.Errorf("collections: collection %q root %q has mismatched delta policies %d and %d", collectionName, rootName, policies[first], policies[i])
+			}
+			duplicate = true
+			continue
+		}
+		firstByRoot[rootName] = i
+	}
+	if !duplicate {
+		return rootNames, tables, policies, func() {}, nil
+	}
+
+	type rootDeltaGroup struct {
+		name    string
+		policy  backenddb.OrderedRootStoragePolicy
+		indexes []int
+	}
+	groups := make([]rootDeltaGroup, 0, len(firstByRoot))
+	groupByRoot := make(map[string]int, len(firstByRoot))
+	for i, rootName := range rootNames {
+		if groupIdx, ok := groupByRoot[rootName]; ok {
+			groups[groupIdx].indexes = append(groups[groupIdx].indexes, i)
+			continue
+		}
+		groupByRoot[rootName] = len(groups)
+		groups = append(groups, rootDeltaGroup{
+			name:    rootName,
+			policy:  policies[i],
+			indexes: []int{i},
+		})
+	}
+
+	outNames := make([]string, 0, len(groups))
+	outTables := make([]memtable.Table, 0, len(groups))
+	outPolicies := make([]backenddb.OrderedRootStoragePolicy, 0, len(groups))
+	var coalesced []memtable.Table
+	cleanup := func() {
+		resetCollectionTables(coalesced)
+	}
+	for _, group := range groups {
+		outNames = append(outNames, group.name)
+		outPolicies = append(outPolicies, group.policy)
+		if len(group.indexes) == 1 {
+			outTables = append(outTables, tables[group.indexes[0]])
+			continue
+		}
+		groupTables := make([]memtable.Table, 0, len(group.indexes))
+		for _, idx := range group.indexes {
+			groupTables = append(groupTables, tables[idx])
+		}
+		merged, err := mergeCollectionRootDeltaTables(groupTables)
+		if err != nil {
+			cleanup()
+			return nil, nil, nil, func() {}, err
+		}
+		coalesced = append(coalesced, merged)
+		outTables = append(outTables, merged)
+	}
+	return outNames, outTables, outPolicies, cleanup, nil
+}
+
+func mergeCollectionRootDeltaTables(tables []memtable.Table) (memtable.Table, error) {
+	total := 0
+	for _, table := range tables {
+		if table != nil {
+			total += table.Len()
+		}
+	}
+	merged := newCollectionRunTable(total)
+	for _, table := range tables {
+		if table == nil || table.Len() == 0 {
+			continue
+		}
+		iter := table.NewIterator(nil, nil)
+		for iter.Valid() {
+			key := bytes.Clone(iter.UnsafeKey())
+			value, ptr, flags := iter.UnsafeEntry()
+			if flags&node.FlagTombstone != 0 {
+				merged.DeleteSteal(key)
+			} else {
+				merged.SetEntrySteal(key, bytes.Clone(value), ptr, flags)
+			}
+			iter.Next()
+		}
+		if err := iter.Error(); err != nil {
+			_ = iter.Close()
+			resetCollectionRunTable(merged)
+			return nil, err
+		}
+		if err := iter.Close(); err != nil {
+			resetCollectionRunTable(merged)
+			return nil, err
+		}
+	}
+	merged.Freeze()
+	return merged, nil
+}
+
 func collectionRootDeltaPlanStatsFromOrdered(collectionName string, rootNames []string, ordered []backenddb.OrderedRootDeltaBatchPublishInput) collectionRootDeltaPlanStats {
 	var stats collectionRootDeltaPlanStats
 	for i, rootName := range rootNames {
@@ -13799,8 +13908,9 @@ func (c *Collection) updateDocumentOnceApply(documentID []byte, update func(curr
 		plannerOptions.templateResolver = templateResolver
 	}
 	var retainedPrimaryDocument []byte
+	var retainedSemanticStreamBlocks memtable.Table
 	if columnStoreNeedsRetainedPayloadTransform(c.meta) {
-		prepared, err := prepareColumnRetainedPayloadStorageDocuments(*c.meta.Options.ColumnStore, [][]byte{document}, columnRetainedPayloadTemplateResolver(snap, catalog))
+		prepared, err := prepareColumnRetainedPayloadInsertBatchStorageDocuments(*c.meta.Options.ColumnStore, [][]byte{document}, columnRetainedPayloadTemplateResolver(snap, catalog))
 		if err != nil {
 			_ = snap.Close()
 			return false, false, err
@@ -13810,6 +13920,7 @@ func (c *Collection) updateDocumentOnceApply(documentID []byte, update func(curr
 			return false, false, errors.New("collections: update retained payload prepared unexpected document count")
 		}
 		retainedPrimaryDocument = prepared.documents[0]
+		retainedSemanticStreamBlocks = prepared.semanticStreamBlocks
 		templateRecords = append(templateRecords, prepared.templateRecords...)
 	}
 
@@ -13910,6 +14021,13 @@ func (c *Collection) updateDocumentOnceApply(documentID []byte, update func(curr
 	} else {
 		deltaTables = append(deltaTables, primaryTable)
 	}
+	if err := appendColumnRetainedSemanticStreamV1BlockDeltas(c.db, catalog, c.meta, retainedSemanticStreamBlocks, &rootNames, baseRootIDs, &policies, &deltaTables); err != nil {
+		_ = snap.Close()
+		resetCollectionRunTable(retainedSemanticStreamBlocks)
+		resetCollectionTables(deltaTables)
+		return false, false, err
+	}
+	retainedSemanticStreamBlocks = nil
 	if err := appendColumnRetainedSemanticStreamV1ReclaimDeltas(c.db, snap, catalog, c.meta, [][]byte{documentID}, [][]byte{semanticReclaimValue}, [][]byte{primaryDocument}, &rootNames, baseRootIDs, &policies, &deltaTables); err != nil {
 		_ = snap.Close()
 		resetCollectionTables(deltaTables)
@@ -14016,13 +14134,23 @@ func (c *Collection) updateDocumentOnceApply(documentID []byte, update func(curr
 	defer func() {
 		resetCollectionTables(deltaTables)
 	}()
-	ordered, cleanupDeltas, err := buildRootDeltaBatchPublishInputsFromTables(c.meta.Name, rootNames, deltaTables, baseRootIDs, policies)
+	coalescedRootNames, publishDeltaTables, publishPolicies, cleanupCoalesced, err := coalesceCollectionRootDeltaTables(c.meta.Name, rootNames, deltaTables, policies)
+	if err != nil {
+		return false, false, err
+	}
+	defer cleanupCoalesced()
+	publishDeltaTables, cleanupPointerized, err := pointerizeCollectionDataRootDeltaTables(c.db, c.meta, coalescedRootNames, publishDeltaTables)
+	if err != nil {
+		return false, false, err
+	}
+	defer cleanupPointerized()
+	ordered, cleanupDeltas, err := buildRootDeltaBatchPublishInputsFromTables(c.meta.Name, coalescedRootNames, publishDeltaTables, baseRootIDs, publishPolicies)
 	if err != nil {
 		return false, false, err
 	}
 	var deltaStats collectionRootDeltaPlanStats
 	if c.writeDomain != nil {
-		deltaStats = collectionRootDeltaPlanStatsFromOrdered(c.meta.Name, rootNames, ordered)
+		deltaStats = collectionRootDeltaPlanStatsFromOrdered(c.meta.Name, coalescedRootNames, ordered)
 	}
 	preflight := func() error {
 		return c.validateMutationRootDescriptors(baseUserRoot, baseSystemRoot, baseCommitSeq)
@@ -14052,7 +14180,7 @@ func (c *Collection) updateDocumentOnceApply(documentID []byte, update func(curr
 				catalog:           catalog,
 				baseCommitSeq:     baseCommitSeq,
 				baseSystemRoot:    baseSystemRoot,
-				rootNames:         cloneColumnPublishRootNames(rootNames),
+				rootNames:         cloneColumnPublishRootNames(coalescedRootNames),
 				baseRootIDs:       cloneColumnPublishBaseRootIDs(baseRootIDs),
 				commandWALIntent:  commandWALIntent,
 				operation:         ColumnPublishOperationUpdate,
@@ -14064,9 +14192,9 @@ func (c *Collection) updateDocumentOnceApply(documentID []byte, update func(curr
 		})
 	} else {
 		publishMeta = c.meta
-		publishRootNames = rootNames
+		publishRootNames = coalescedRootNames
 		newSystemRoot, rootIDs, err = c.db.PublishOrderedRootDeltaBatchGroupWithPreflightAndSystemDeltaBuilder(ordered, preflight, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
-			return c.buildRootDescriptorSystemDeltaIterator(baseCommitSeq, baseSystemRoot, rootNames, baseRootIDs, rootIDs)
+			return c.buildRootDescriptorSystemDeltaIterator(baseCommitSeq, baseSystemRoot, coalescedRootNames, baseRootIDs, rootIDs)
 		})
 	}
 	stats.Publish += updateBatchStatsSince(detailedStats, phaseStart)
@@ -14088,7 +14216,7 @@ func (c *Collection) updateDocumentOnceApply(documentID []byte, update func(curr
 		}
 	}
 	stats.Modified = 1
-	stats.Runs = len(rootNames)
+	stats.Runs = len(publishRootNames)
 	c.setLastUpdateStats(stats)
 	return true, true, nil
 }
@@ -15910,8 +16038,9 @@ func (c *Collection) buildUpdateBatchPlan(items []updateBatchItem, mode updateBa
 		templateV1CommandWALDocuments = collectionDocumentsFromBatchUpdateDocuments(changed, changedDocuments)
 	}
 	var retainedPrimaryDocuments [][]byte
+	var retainedSemanticStreamBlocks memtable.Table
 	if columnStoreNeedsRetainedPayloadTransform(meta) {
-		prepared, err := prepareColumnRetainedPayloadStorageDocuments(*meta.Options.ColumnStore, changedDocuments, columnRetainedPayloadTemplateResolver(snap, catalog))
+		prepared, err := prepareColumnRetainedPayloadInsertBatchStorageDocuments(*meta.Options.ColumnStore, changedDocuments, columnRetainedPayloadTemplateResolver(snap, catalog))
 		if err != nil {
 			_ = snap.Close()
 			return nil, err
@@ -15921,6 +16050,7 @@ func (c *Collection) buildUpdateBatchPlan(items []updateBatchItem, mode updateBa
 			return nil, errors.New("collections: update batch retained payload prepared unexpected document count")
 		}
 		retainedPrimaryDocuments = prepared.documents
+		retainedSemanticStreamBlocks = prepared.semanticStreamBlocks
 		templateRecords = append(templateRecords, prepared.templateRecords...)
 	}
 	for i := range changed {
@@ -16026,7 +16156,8 @@ func (c *Collection) buildUpdateBatchPlan(items []updateBatchItem, mode updateBa
 	stats.UniqueIndexPreflight += updateBatchStatsSince(detailedStats, phaseStart)
 
 	success := false
-	canBufferDirectUpdateBatch := c.shouldUseDirectBufferedUpdatePlan(meta, plannerOptions, canBufferIndexedUpdateBatch, mode, secondaryIndexChanges, changed, updateBatchItemsAllHaveBSONSet(items))
+	hasRetainedSemanticStreamBlocks := retainedSemanticStreamBlocks != nil && retainedSemanticStreamBlocks.Len() > 0
+	canBufferDirectUpdateBatch := !hasRetainedSemanticStreamBlocks && c.shouldUseDirectBufferedUpdatePlan(meta, plannerOptions, canBufferIndexedUpdateBatch, mode, secondaryIndexChanges, changed, updateBatchItemsAllHaveBSONSet(items))
 	if canBufferDirectUpdateBatch {
 		phaseStart = updateBatchStatsNow(detailedStats)
 		var templateEntries []directBufferedRootEntry
@@ -16154,6 +16285,11 @@ func (c *Collection) buildUpdateBatchPlan(items []updateBatchItem, mode updateBa
 		}
 		stats.TemplateRunBuild += updateBatchStatsSince(detailedStats, phaseStart)
 	}
+
+	if err := appendColumnRetainedSemanticStreamV1BlockDeltas(c.db, catalog, meta, retainedSemanticStreamBlocks, &rootNames, baseRootIDs, &policies, &deltaTables); err != nil {
+		return nil, err
+	}
+	retainedSemanticStreamBlocks = nil
 
 	rootNames = append(rootNames, primaryRootName)
 	uniqueSecondary = append(uniqueSecondary, -1)
@@ -16355,18 +16491,23 @@ func (c *Collection) publishUpdateBatchPlanLocked(plan *updateBatchPlan, command
 		return nil, fmt.Errorf("collections: UpdateBatch collection %q invalid plan lengths roots=%d deltas=%d policies=%d", plan.meta.Name, len(plan.rootNames), len(plan.deltaTables), len(plan.policies))
 	}
 
-	publishTables, cleanupPointerized, err := pointerizeCollectionDataRootDeltaTables(c.db, plan.meta, plan.rootNames, plan.deltaTables)
+	coalescedRootNames, publishTables, publishPolicies, cleanupCoalesced, err := coalesceCollectionRootDeltaTables(plan.meta.Name, plan.rootNames, plan.deltaTables, plan.policies)
+	if err != nil {
+		return nil, err
+	}
+	defer cleanupCoalesced()
+	publishTables, cleanupPointerized, err := pointerizeCollectionDataRootDeltaTables(c.db, plan.meta, coalescedRootNames, publishTables)
 	if err != nil {
 		return nil, err
 	}
 	defer cleanupPointerized()
-	ordered, cleanupDeltas, err := buildRootDeltaBatchPublishInputsFromTables(plan.meta.Name, plan.rootNames, publishTables, plan.baseRootIDs, plan.policies)
+	ordered, cleanupDeltas, err := buildRootDeltaBatchPublishInputsFromTables(plan.meta.Name, coalescedRootNames, publishTables, plan.baseRootIDs, publishPolicies)
 	if err != nil {
 		return nil, err
 	}
 	var deltaStats collectionRootDeltaPlanStats
 	if c.writeDomain != nil {
-		deltaStats = collectionRootDeltaPlanStatsFromOrdered(plan.meta.Name, plan.rootNames, ordered)
+		deltaStats = collectionRootDeltaPlanStatsFromOrdered(plan.meta.Name, coalescedRootNames, ordered)
 	}
 	preflight := func() error {
 		return c.validateMutationRootDescriptors(plan.baseUserRoot, plan.baseSystemRoot, plan.baseCommitSeq)
@@ -16384,7 +16525,7 @@ func (c *Collection) publishUpdateBatchPlanLocked(plan *updateBatchPlan, command
 				catalog:           plan.catalog,
 				baseCommitSeq:     plan.baseCommitSeq,
 				baseSystemRoot:    plan.baseSystemRoot,
-				rootNames:         cloneColumnPublishRootNames(plan.rootNames),
+				rootNames:         cloneColumnPublishRootNames(coalescedRootNames),
 				baseRootIDs:       cloneColumnPublishBaseRootIDs(plan.baseRootIDs),
 				commandWALIntent:  commandWALIntent,
 				operation:         ColumnPublishOperationUpdate,
@@ -16416,13 +16557,13 @@ func (c *Collection) publishUpdateBatchPlanLocked(plan *updateBatchPlan, command
 	} else if commandWALIntent != nil {
 		err = c.withCommandWALPublishCoordinator(func() error {
 			newSystemRoot, rootIDs, err = c.db.PublishOrderedRootDeltaBatchGroupWithPreflightCommandWALAndSystemDeltaBuilder(ordered, preflight, commandWALIntent, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
-				return c.buildRootDescriptorSystemDeltaIteratorForMeta(plan.meta, plan.baseCommitSeq, plan.baseSystemRoot, plan.rootNames, plan.baseRootIDs, rootIDs)
+				return c.buildRootDescriptorSystemDeltaIteratorForMeta(plan.meta, plan.baseCommitSeq, plan.baseSystemRoot, coalescedRootNames, plan.baseRootIDs, rootIDs)
 			})
 			return err
 		})
 	} else {
 		newSystemRoot, rootIDs, err = c.db.PublishOrderedRootDeltaBatchGroupWithPreflightAndSystemDeltaBuilder(ordered, preflight, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
-			return c.buildRootDescriptorSystemDeltaIteratorForMeta(plan.meta, plan.baseCommitSeq, plan.baseSystemRoot, plan.rootNames, plan.baseRootIDs, rootIDs)
+			return c.buildRootDescriptorSystemDeltaIteratorForMeta(plan.meta, plan.baseCommitSeq, plan.baseSystemRoot, coalescedRootNames, plan.baseRootIDs, rootIDs)
 		})
 	}
 	cleanupDeltas()
@@ -16430,10 +16571,10 @@ func (c *Collection) publishUpdateBatchPlanLocked(plan *updateBatchPlan, command
 	if err != nil {
 		return nil, err
 	}
-	if len(rootIDs) != len(plan.rootNames) {
-		return nil, unexpectedOrderedRootCountError(plan.meta.Name, len(plan.rootNames), len(rootIDs))
+	if len(rootIDs) != len(coalescedRootNames) {
+		return nil, unexpectedOrderedRootCountError(plan.meta.Name, len(coalescedRootNames), len(rootIDs))
 	}
-	nextCatalog := cloneCatalogWithRootUpdates(plan.catalog, plan.meta, plan.rootNames, rootIDs)
+	nextCatalog := cloneCatalogWithRootUpdates(plan.catalog, plan.meta, coalescedRootNames, rootIDs)
 	c.meta = plan.meta
 	c.rememberCatalogAtSystemRoot(newSystemRoot, nextCatalog)
 	c.noteWriteDomainCatalog(newSystemRoot, nextCatalog)

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -19977,10 +19977,7 @@ func (c *Collection) scanDocumentsFuncWithColumnReconstruction(
 	if columnStoreHasTypedColumnPartOwners(columnStoreConfig) {
 		typedColumnCache = &typedColumnPartReconstructionCache{Parts: make(map[uint64]typedColumnPartDecodedValues)}
 	}
-	var retainedSemanticCache *columnRetainedSemanticStreamV1DecodeCache
-	if columnStoreRetainedPayloadUsesSemanticStreamV1(&columnStoreConfig) && len(records) >= minColumnRetainedSemanticStreamV1DecodeCacheRows {
-		retainedSemanticCache = newColumnRetainedSemanticStreamV1DecodeCache()
-	}
+	retainedSemanticCache := newColumnRetainedSemanticStreamV1DecodeCacheForDocumentRecords(&columnStoreConfig, records)
 	manifestRootID := catalog.rootID(collectionColumnManifestRootName(catalog.meta.Name))
 	typedScratch := make([]columnDeclaredValue, 0, len(columnStoreTypedColumnPartFields(columnStoreConfig)))
 	mergeScratch := make([]columnDeclaredValue, 0, len(columnStoreConfig.Columns))

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -19977,6 +19977,10 @@ func (c *Collection) scanDocumentsFuncWithColumnReconstruction(
 	if columnStoreHasTypedColumnPartOwners(columnStoreConfig) {
 		typedColumnCache = &typedColumnPartReconstructionCache{Parts: make(map[uint64]typedColumnPartDecodedValues)}
 	}
+	var retainedSemanticCache *columnRetainedSemanticStreamV1DecodeCache
+	if columnStoreRetainedPayloadUsesSemanticStreamV1(&columnStoreConfig) {
+		retainedSemanticCache = newColumnRetainedSemanticStreamV1DecodeCache()
+	}
 	manifestRootID := catalog.rootID(collectionColumnManifestRootName(catalog.meta.Name))
 	typedScratch := make([]columnDeclaredValue, 0, len(columnStoreTypedColumnPartFields(columnStoreConfig)))
 	mergeScratch := make([]columnDeclaredValue, 0, len(columnStoreConfig.Columns))
@@ -19996,7 +20000,7 @@ func (c *Collection) scanDocumentsFuncWithColumnReconstruction(
 		if err != nil {
 			return false, err
 		}
-		retainedDocument, err := resolveColumnRetainedPayloadAtSnapshot(snap, catalog, columnStoreConfig, record.Document)
+		retainedDocument, err := resolveColumnRetainedPayloadAtSnapshotWithCache(snap, catalog, columnStoreConfig, record.Document, retainedSemanticCache)
 		if err != nil {
 			return false, err
 		}

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -19978,7 +19978,7 @@ func (c *Collection) scanDocumentsFuncWithColumnReconstruction(
 		typedColumnCache = &typedColumnPartReconstructionCache{Parts: make(map[uint64]typedColumnPartDecodedValues)}
 	}
 	var retainedSemanticCache *columnRetainedSemanticStreamV1DecodeCache
-	if columnStoreRetainedPayloadUsesSemanticStreamV1(&columnStoreConfig) {
+	if columnStoreRetainedPayloadUsesSemanticStreamV1(&columnStoreConfig) && len(records) >= minColumnRetainedSemanticStreamV1DecodeCacheRows {
 		retainedSemanticCache = newColumnRetainedSemanticStreamV1DecodeCache()
 	}
 	manifestRootID := catalog.rootID(collectionColumnManifestRootName(catalog.meta.Name))

--- a/TreeDB/collections/column_physical_latest_visible_1953_test.go
+++ b/TreeDB/collections/column_physical_latest_visible_1953_test.go
@@ -665,11 +665,11 @@ func typedColumnEventDocument1953(event columnPhysicalJSONBenchParityEventP0) []
 
 func updateTypedColumnEvent1953(tb testing.TB, col *Collection, event columnPhysicalJSONBenchParityEventP0) {
 	tb.Helper()
-	_, modified, err := col.Update([]byte(event.ID), func([]byte) ([]byte, bool, error) {
+	matched, modified, err := col.Update([]byte(event.ID), func([]byte) ([]byte, bool, error) {
 		return typedColumnEventDocument1953(event), true, nil
 	})
 	if err != nil || !modified {
-		tb.Fatalf("Update %s modified=%t err=%v", event.ID, modified, err)
+		tb.Fatalf("Update %s matched=%t modified=%t err=%v stats=%+v", event.ID, matched, modified, err, col.LastUpdateStats())
 	}
 }
 

--- a/TreeDB/collections/column_physical_query_test.go
+++ b/TreeDB/collections/column_physical_query_test.go
@@ -1941,9 +1941,13 @@ func readRawRetainedPayloadJSONForTestM13C(t *testing.T, d *backenddb.DB, collec
 		t.Fatalf("collection %q not found", collection)
 	}
 	cfg := catalog.meta.Options.ColumnStore.copy()
-	obj, err := decodeColumnRetainedPayloadObject(cfg, raw, columnRetainedPayloadTemplateResolver(snap, catalog))
+	resolved, err := resolveColumnRetainedPayloadAtSnapshot(snap, catalog, cfg, raw)
 	if err != nil {
-		t.Fatalf("decode raw retained payload: %v raw=%q", err, raw)
+		t.Fatalf("resolve raw retained payload: %v raw=%q", err, raw)
+	}
+	obj, err := decodeColumnRetainedPayloadObject(cfg, resolved, columnRetainedPayloadTemplateResolver(snap, catalog))
+	if err != nil {
+		t.Fatalf("decode raw retained payload: %v raw=%q resolved=%q", err, raw, resolved)
 	}
 	out, err := json.Marshal(obj)
 	if err != nil {

--- a/TreeDB/collections/column_retained_payload_audit.go
+++ b/TreeDB/collections/column_retained_payload_audit.go
@@ -25,15 +25,15 @@ func ColumnRetainedPayloadEncodingStatus(cfg *ColumnStoreConfig) (encoding, stat
 	case ColumnRetainedPayloadFull, "":
 		return string(ColumnRetainedPayloadEncodingJSON), "active_json_full_retained_payload"
 	case ColumnRetainedPayloadNonColumn:
-		switch cfg.RetainedPayloadEncoding {
-		case ColumnRetainedPayloadEncodingTemplateV1, "":
+		switch encoding := columnRetainedPayloadEffectiveEncoding(cfg); encoding {
+		case ColumnRetainedPayloadEncodingTemplateV1:
 			return string(ColumnRetainedPayloadEncodingTemplateV1), "active_template_v1_non_column_retained_payload"
 		case ColumnRetainedPayloadEncodingJSON:
 			return string(ColumnRetainedPayloadEncodingJSON), "active_legacy_json_non_column_retained_payload"
 		case ColumnRetainedPayloadEncodingSemanticStreamV1:
 			return string(ColumnRetainedPayloadEncodingSemanticStreamV1), "active_semantic_stream_v1_non_column_retained_payload"
 		default:
-			return string(ColumnRetainedPayloadEncodingUnavailable), fmt.Sprintf("unavailable_unsupported_retained_payload_encoding_%s", cfg.RetainedPayloadEncoding)
+			return string(ColumnRetainedPayloadEncodingUnavailable), fmt.Sprintf("unavailable_unsupported_retained_payload_encoding_%s", encoding)
 		}
 	default:
 		return string(ColumnRetainedPayloadEncodingUnavailable), fmt.Sprintf("unknown_retained_payload_policy_%s", cfg.RetainedPayload)
@@ -54,7 +54,7 @@ func ColumnRetainedPayloadCompressionStatus(cfg *ColumnStoreConfig) (compression
 	case ColumnRetainedPayloadFull, "":
 		return "value_log_grouped_frame", "default_value_log_auto", "active_value_log_auto_grouped_frame_full_retained_payload"
 	case ColumnRetainedPayloadNonColumn:
-		if cfg.RetainedPayloadEncoding == ColumnRetainedPayloadEncodingSemanticStreamV1 {
+		if columnRetainedPayloadEffectiveEncoding(cfg) == ColumnRetainedPayloadEncodingSemanticStreamV1 {
 			return "semantic_stream_v1_blocks", "retained_semantic_stream_v1_side_root", "active_semantic_stream_v1_non_column_retained_payload"
 		}
 		return "value_log_grouped_frame", "default_value_log_auto_storage_first", "active_value_log_auto_grouped_frame_non_column_retained_payload"

--- a/TreeDB/collections/column_retained_payload_audit_test.go
+++ b/TreeDB/collections/column_retained_payload_audit_test.go
@@ -996,7 +996,7 @@ func TestAuditCollectionRetainedPayloadSemanticStreamBlockLayoutSampledDecodedSt
 	}
 }
 
-func TestAuditCollectionRetainedPayloadSemanticStreamBlockLayoutAllowsInlineRows2662(t *testing.T) {
+func TestAuditCollectionRetainedPayloadSemanticStreamBlockLayoutRecordsSingleRowBlock2662(t *testing.T) {
 	cfg := jsonbenchRetainedPayloadAuditConfig2382(true)
 	cfg.RetainedPayloadEncoding = ColumnRetainedPayloadEncodingSemanticStreamV1
 	col, closeDB := openRetainedPayloadAuditCollection2382(t, cfg, [][]byte{
@@ -1011,11 +1011,11 @@ func TestAuditCollectionRetainedPayloadSemanticStreamBlockLayoutAllowsInlineRows
 		t.Fatalf("inline semantic-stream-v1 block layout audit: %v audit=%+v", err, audit)
 	}
 	if audit.Status != "passed" || audit.CheckedRows != 1 {
-		t.Fatalf("audit=%+v want passed one inline row", audit)
+		t.Fatalf("audit=%+v want passed one semantic block row", audit)
 	}
 	layout := audit.RetainedPayloadSemanticStreamBlockLayout
-	if layout == nil || layout.BlockCount != 0 || layout.RawBlockBytes != 0 || layout.PrimaryLocatorBytes != 0 || audit.RetainedPayloadBytes <= 0 {
-		t.Fatalf("inline block layout=%+v audit=%+v", layout, audit)
+	if layout == nil || layout.BlockCount != 1 || layout.RawBlockBytes <= 0 || layout.StoredBlockBytes <= 0 || layout.PrimaryLocatorBytes <= 0 {
+		t.Fatalf("single-row block layout=%+v audit=%+v", layout, audit)
 	}
 }
 

--- a/TreeDB/collections/column_retained_payload_audit_test.go
+++ b/TreeDB/collections/column_retained_payload_audit_test.go
@@ -705,6 +705,86 @@ func TestColumnRetainedSemanticStreamV1RejectsOversizedRowCount2662(t *testing.T
 	}
 }
 
+func TestColumnRetainedSemanticStreamV1RejectsOutOfRangeEntryRows2662(t *testing.T) {
+	raw := append([]byte(nil), columnRetainedSemanticStreamV1BlockMagic...)
+	raw = binary.AppendUvarint(raw, 1) // block rows
+	raw = binary.AppendUvarint(raw, 1) // path count
+	raw = binary.AppendUvarint(raw, 1) // path segment count
+	raw = binary.AppendUvarint(raw, uint64(len("payload")))
+	raw = append(raw, "payload"...)
+	raw = binary.AppendUvarint(raw, 1) // entry count
+	raw = binary.AppendUvarint(raw, 1) // row delta, outside the one-row block
+	raw = binary.AppendUvarint(raw, uint64(len(`"same"`)))
+	raw = append(raw, `"same"`...)
+
+	if _, err := decodeColumnRetainedSemanticStreamV1BlockRowsJSON(raw); err == nil || !strings.Contains(err.Error(), "outside block rows") {
+		t.Fatalf("decode all rows err=%v want outside block rows", err)
+	}
+	if _, err := decodeColumnRetainedSemanticStreamV1BlockRowJSON(raw, 0); err == nil || !strings.Contains(err.Error(), "outside block rows") {
+		t.Fatalf("decode single row err=%v want outside block rows", err)
+	}
+	collector, err := newColumnRetainedSemanticStreamV1BlockLayoutCollector()
+	if err != nil {
+		t.Fatalf("new block layout collector: %v", err)
+	}
+	defer collector.close()
+	if err := collector.addBlock(raw); err == nil || !strings.Contains(err.Error(), "outside block rows") {
+		t.Fatalf("collector.addBlock err=%v want outside block rows", err)
+	}
+}
+
+func TestColumnRetainedSemanticStreamV1RejectsEntryRowDeltaOverflow2662(t *testing.T) {
+	raw := append([]byte(nil), columnRetainedSemanticStreamV1BlockMagic...)
+	raw = binary.AppendUvarint(raw, columnRetainedSemanticStreamV1BlockRows)
+	raw = binary.AppendUvarint(raw, 1) // path count
+	raw = binary.AppendUvarint(raw, 1) // path segment count
+	raw = binary.AppendUvarint(raw, uint64(len("payload")))
+	raw = append(raw, "payload"...)
+	raw = binary.AppendUvarint(raw, 2) // entry count
+	raw = binary.AppendUvarint(raw, ^uint64(0))
+	raw = binary.AppendUvarint(raw, uint64(len(`"first"`)))
+	raw = append(raw, `"first"`...)
+	raw = binary.AppendUvarint(raw, 1)
+	raw = binary.AppendUvarint(raw, uint64(len(`"second"`)))
+	raw = append(raw, `"second"`...)
+
+	if _, err := decodeColumnRetainedSemanticStreamV1BlockRowsJSON(raw); err == nil || !strings.Contains(err.Error(), "outside block rows") {
+		t.Fatalf("decode all first invalid row err=%v want outside block rows", err)
+	}
+	if _, err := decodeColumnRetainedSemanticStreamV1BlockRowJSON(raw, 0); err == nil || !strings.Contains(err.Error(), "outside block rows") {
+		t.Fatalf("decode single first invalid row err=%v want outside block rows", err)
+	}
+
+	raw = append([]byte(nil), columnRetainedSemanticStreamV1BlockMagic...)
+	raw = binary.AppendUvarint(raw, columnRetainedSemanticStreamV1BlockRows)
+	raw = binary.AppendUvarint(raw, 1) // path count
+	raw = binary.AppendUvarint(raw, 1) // path segment count
+	raw = binary.AppendUvarint(raw, uint64(len("payload")))
+	raw = append(raw, "payload"...)
+	raw = binary.AppendUvarint(raw, 2) // entry count
+	raw = binary.AppendUvarint(raw, columnRetainedSemanticStreamV1BlockRows-1)
+	raw = binary.AppendUvarint(raw, uint64(len(`"first"`)))
+	raw = append(raw, `"first"`...)
+	raw = binary.AppendUvarint(raw, ^uint64(0))
+	raw = binary.AppendUvarint(raw, uint64(len(`"second"`)))
+	raw = append(raw, `"second"`...)
+
+	if _, err := decodeColumnRetainedSemanticStreamV1BlockRowsJSON(raw); err == nil || !strings.Contains(err.Error(), "row delta overflow") {
+		t.Fatalf("decode all overflow err=%v want row delta overflow", err)
+	}
+	if _, err := decodeColumnRetainedSemanticStreamV1BlockRowJSON(raw, 0); err == nil || !strings.Contains(err.Error(), "row delta overflow") {
+		t.Fatalf("decode single overflow err=%v want row delta overflow", err)
+	}
+	collector, err := newColumnRetainedSemanticStreamV1BlockLayoutCollector()
+	if err != nil {
+		t.Fatalf("new block layout collector: %v", err)
+	}
+	defer collector.close()
+	if err := collector.addBlock(raw); err == nil || !strings.Contains(err.Error(), "row delta overflow") {
+		t.Fatalf("collector.addBlock err=%v want row delta overflow", err)
+	}
+}
+
 func TestColumnRetainedSemanticStreamV1StoredBlockZSTDFailsClosed2662(t *testing.T) {
 	raw, err := encodeColumnRetainedSemanticStreamV1RawBlock([][]byte{[]byte(`{"payload":"same"}`), []byte(`{"payload":"same"}`)})
 	if err != nil {

--- a/TreeDB/collections/column_retained_payload_audit_test.go
+++ b/TreeDB/collections/column_retained_payload_audit_test.go
@@ -640,6 +640,40 @@ func TestColumnRetainedSemanticStreamV1StoredBlockZSTDRawLimitFallback2662(t *te
 	}
 }
 
+func TestColumnRetainedSemanticStreamV1DecodeCacheDenseBlockGate2662(t *testing.T) {
+	cfg := jsonbenchRetainedPayloadAuditConfig2382(true)
+	cfg.RetainedPayloadEncoding = ColumnRetainedPayloadEncodingSemanticStreamV1
+
+	sparse := make([]DocumentRecord, 0, minColumnRetainedSemanticStreamV1DecodeCacheRowsPerBlock)
+	for i := 0; i < minColumnRetainedSemanticStreamV1DecodeCacheRowsPerBlock; i++ {
+		var blockKey [sha256.Size]byte
+		binary.BigEndian.PutUint64(blockKey[sha256.Size-8:], uint64(i+1))
+		sparse = append(sparse, DocumentRecord{Document: encodeColumnRetainedSemanticStreamV1Locator(blockKey[:], 0)})
+	}
+	if cache := newColumnRetainedSemanticStreamV1DecodeCacheForDocumentRecords(cfg, sparse); cache != nil {
+		t.Fatalf("sparse records unexpectedly enabled full-block decode cache: %+v", cache)
+	}
+
+	var denseBlockKey [sha256.Size]byte
+	denseBlockKey[0] = 0x7b
+	dense := make([]DocumentRecord, 0, minColumnRetainedSemanticStreamV1DecodeCacheRowsPerBlock)
+	for i := 0; i < minColumnRetainedSemanticStreamV1DecodeCacheRowsPerBlock; i++ {
+		dense = append(dense, DocumentRecord{Document: encodeColumnRetainedSemanticStreamV1Locator(denseBlockKey[:], uint64(i))})
+	}
+	cache := newColumnRetainedSemanticStreamV1DecodeCacheForDocumentRecords(cfg, dense)
+	if cache == nil {
+		t.Fatal("dense records did not enable full-block decode cache")
+	}
+	if !cache.shouldCacheBlock(string(denseBlockKey[:])) {
+		t.Fatal("dense block was not allowed in decode cache")
+	}
+	var otherBlockKey [sha256.Size]byte
+	otherBlockKey[0] = 0x8c
+	if cache.shouldCacheBlock(string(otherBlockKey[:])) {
+		t.Fatal("unobserved block should not be allowed in decode cache")
+	}
+}
+
 func TestColumnRetainedSemanticStreamV1StoredBlockZSTDFailsClosed2662(t *testing.T) {
 	raw, err := encodeColumnRetainedSemanticStreamV1RawBlock([][]byte{[]byte(`{"payload":"same"}`), []byte(`{"payload":"same"}`)})
 	if err != nil {

--- a/TreeDB/collections/column_retained_payload_audit_test.go
+++ b/TreeDB/collections/column_retained_payload_audit_test.go
@@ -615,6 +615,31 @@ func TestColumnRetainedSemanticStreamV1StoredBlockZSTDWrapper2662(t *testing.T) 
 	}
 }
 
+func TestColumnRetainedSemanticStreamV1StoredBlockZSTDRawLimitFallback2662(t *testing.T) {
+	raw, err := encodeColumnRetainedSemanticStreamV1RawBlock([][]byte{
+		[]byte(`{"payload":"same","commit":{"record":{"text":"same retained body"}}}`),
+		[]byte(`{"payload":"same","commit":{"record":{"text":"same retained body"}}}`),
+	})
+	if err != nil {
+		t.Fatalf("encode raw semantic-stream-v1 block: %v", err)
+	}
+
+	stored, err := encodeColumnRetainedSemanticStreamV1StoredBlockWithRawLimit(raw, len(raw)-1)
+	if err != nil {
+		t.Fatalf("encode stored semantic-stream-v1 block: %v", err)
+	}
+	if !bytes.Equal(stored, raw) {
+		t.Fatalf("stored block len=%d raw=%d want raw fallback when decoded length exceeds wrapper limit", len(stored), len(raw))
+	}
+	decoded, err := decodeColumnRetainedSemanticStreamV1StoredBlock(stored)
+	if err != nil {
+		t.Fatalf("decode raw fallback semantic-stream-v1 block: %v", err)
+	}
+	if !bytes.Equal(decoded, raw) {
+		t.Fatalf("decoded raw fallback mismatch len=%d raw=%d", len(decoded), len(raw))
+	}
+}
+
 func TestColumnRetainedSemanticStreamV1StoredBlockZSTDFailsClosed2662(t *testing.T) {
 	raw, err := encodeColumnRetainedSemanticStreamV1RawBlock([][]byte{[]byte(`{"payload":"same"}`), []byte(`{"payload":"same"}`)})
 	if err != nil {

--- a/TreeDB/collections/column_retained_payload_audit_test.go
+++ b/TreeDB/collections/column_retained_payload_audit_test.go
@@ -1,6 +1,7 @@
 package collections
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"encoding/binary"
 	"encoding/json"
@@ -11,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/pierrec/lz4/v4"
+	"github.com/snissn/compress/zstd"
 	backenddb "github.com/snissn/gomap/TreeDB/db"
 )
 
@@ -481,8 +483,11 @@ func TestColumnRetainedSemanticStreamV1BlockLayoutAudit2662(t *testing.T) {
 	if audit.Rows != len(docs) || audit.BlockRows != columnRetainedSemanticStreamV1BlockRows || audit.BlockCount != 1 {
 		t.Fatalf("unexpected block layout row/block counters: %+v", audit)
 	}
-	if audit.PrimaryLocatorBytes != accounting.PrimaryLocatorBytes || audit.RawBlockBytes != accounting.BlockBytes {
+	if audit.PrimaryLocatorBytes != accounting.PrimaryLocatorBytes || audit.StoredBlockBytes != accounting.BlockBytes {
 		t.Fatalf("audit/accounting mismatch audit=%+v accounting=%+v", audit, accounting)
+	}
+	if audit.RawBlockBytes < audit.StoredBlockBytes || audit.StoredBlockBytes <= 0 {
+		t.Fatalf("unexpected stored/raw block bytes audit=%+v accounting=%+v", audit, accounting)
 	}
 	if audit.RawBlockBytes != audit.BlockHeaderBytes+audit.PathMetadataBytes+audit.EntryMetadataBytes+audit.ScalarValueBytes {
 		t.Fatalf("block byte attribution mismatch: %+v", audit)
@@ -520,6 +525,163 @@ func TestColumnRetainedSemanticStreamV1BlockLayoutAudit2662(t *testing.T) {
 	if !limited.PathsTruncated || len(limited.Paths) != 1 || limited.RawBlockBytes != audit.RawBlockBytes {
 		t.Fatalf("limited paths=%+v truncated=%v raw=%d want truncated one raw %d", limited.Paths, limited.PathsTruncated, limited.RawBlockBytes, audit.RawBlockBytes)
 	}
+}
+
+func TestColumnRetainedSemanticStreamV1StoredBlockZSTDWrapper2662(t *testing.T) {
+	const rows = 512
+	documents := make([][]byte, rows)
+	for row := range documents {
+		documents[row] = []byte(fmt.Sprintf(
+			`{"payload":"%s","commit":{"cid":"bafy-test-%06d","record":{"$type":"app.bsky.feed.post","text":"%s"}}}`,
+			strings.Repeat("same-retained-payload-", 8),
+			row,
+			strings.Repeat("semantic stream retained zstd body ", 12),
+		))
+	}
+
+	raw, err := encodeColumnRetainedSemanticStreamV1RawBlock(documents)
+	if err != nil {
+		t.Fatalf("encode raw semantic-stream-v1 block: %v", err)
+	}
+	stored, err := encodeColumnRetainedSemanticStreamV1Block(documents)
+	if err != nil {
+		t.Fatalf("encode stored semantic-stream-v1 block: %v", err)
+	}
+	if !bytes.HasPrefix(stored, columnRetainedSemanticStreamV1BlockZSTDMagic) {
+		t.Fatalf("stored block magic=%q len=%d raw=%d want zstd wrapper", stored[:len(columnRetainedSemanticStreamV1BlockMagic)], len(stored), len(raw))
+	}
+	if len(stored) >= len(raw) {
+		t.Fatalf("stored block len=%d want below raw len=%d", len(stored), len(raw))
+	}
+	decoded, err := decodeColumnRetainedSemanticStreamV1StoredBlock(stored)
+	if err != nil {
+		t.Fatalf("decode stored semantic-stream-v1 block: %v", err)
+	}
+	if !bytes.Equal(decoded, raw) {
+		t.Fatalf("decoded stored block mismatch len=%d raw=%d", len(decoded), len(raw))
+	}
+	if legacyDecoded, err := decodeColumnRetainedSemanticStreamV1StoredBlock(raw); err != nil || !bytes.Equal(legacyDecoded, raw) {
+		t.Fatalf("decode legacy raw semantic-stream-v1 block err=%v decoded_len=%d raw=%d", err, len(legacyDecoded), len(raw))
+	}
+	rowCount, err := columnRetainedSemanticStreamV1BlockRowCount(stored)
+	if err != nil || rowCount != rows {
+		t.Fatalf("row count=%d err=%v want %d", rowCount, err, rows)
+	}
+	allRows, err := decodeColumnRetainedSemanticStreamV1BlockRowsJSON(stored)
+	if err != nil {
+		t.Fatalf("decode all stored semantic-stream-v1 rows: %v", err)
+	}
+	if len(allRows) != rows {
+		t.Fatalf("decoded rows=%d want %d", len(allRows), rows)
+	}
+	for _, row := range []int{0, 37, rows - 1} {
+		single, err := decodeColumnRetainedSemanticStreamV1BlockRowJSON(stored, uint64(row))
+		if err != nil {
+			t.Fatalf("decode single stored semantic-stream-v1 row %d: %v", row, err)
+		}
+		if !bytes.Equal(allRows[row], single) {
+			t.Fatalf("decoded row %d mismatch batch=%s single=%s", row, allRows[row], single)
+		}
+	}
+	got, err := decodeColumnRetainedSemanticStreamV1BlockRowJSON(stored, 37)
+	if err != nil {
+		t.Fatalf("decode stored semantic-stream-v1 row: %v", err)
+	}
+	assertJSONMapEqual1875(t, got, map[string]any{
+		"payload": strings.Repeat("same-retained-payload-", 8),
+		"commit": map[string]any{
+			"cid": "bafy-test-000037",
+			"record": map[string]any{
+				"$type": "app.bsky.feed.post",
+				"text":  strings.Repeat("semantic stream retained zstd body ", 12),
+			},
+		},
+	})
+
+	collector, err := newColumnRetainedSemanticStreamV1BlockLayoutCollector()
+	if err != nil {
+		t.Fatalf("new block layout collector: %v", err)
+	}
+	defer collector.close()
+	if err := collector.addBlock(stored); err != nil {
+		t.Fatalf("collector.addBlock stored wrapper: %v", err)
+	}
+	audit, err := collector.result(rows, 0)
+	if err != nil {
+		t.Fatalf("collector.result: %v", err)
+	}
+	if audit.StoredBlockBytes != int64(len(stored)) || audit.RawBlockBytes != int64(len(raw)) {
+		t.Fatalf("audit stored/raw bytes=%d/%d want %d/%d audit=%+v", audit.StoredBlockBytes, audit.RawBlockBytes, len(stored), len(raw), audit)
+	}
+}
+
+func TestColumnRetainedSemanticStreamV1StoredBlockZSTDFailsClosed2662(t *testing.T) {
+	raw, err := encodeColumnRetainedSemanticStreamV1RawBlock([][]byte{[]byte(`{"payload":"same"}`), []byte(`{"payload":"same"}`)})
+	if err != nil {
+		t.Fatalf("encode raw semantic-stream-v1 block: %v", err)
+	}
+	compressed := semanticStreamZSTDCompress2662(t, raw)
+
+	cases := []struct {
+		name string
+		raw  []byte
+		want string
+	}{
+		{
+			name: "invalid zstd",
+			raw:  semanticStreamZSTDStoredBlockWithRawLength2662(uint64(len(raw)), []byte("not-zstd")),
+			want: "decode semantic-stream-v1 retained block zstd payload",
+		},
+		{
+			name: "wrong decoded length",
+			raw:  semanticStreamZSTDStoredBlockWithRawLength2662(uint64(len(raw)+1), compressed),
+			want: "decoded length",
+		},
+		{
+			name: "decoded invalid magic",
+			raw:  semanticStreamZSTDStoredBlock2662(t, []byte("not-a-raw-semantic-block")),
+			want: "decoded to invalid block",
+		},
+		{
+			name: "oversized raw length",
+			raw:  semanticStreamZSTDStoredBlockWithRawLength2662(maxColumnRetainedSemanticStreamV1CompressedRawBlockBytes+1, []byte("x")),
+			want: "exceeds max",
+		},
+	}
+	for _, tc := range cases {
+		if _, err := decodeColumnRetainedSemanticStreamV1StoredBlock(tc.raw); err == nil || !strings.Contains(err.Error(), tc.want) {
+			t.Fatalf("%s err=%v want %q", tc.name, err, tc.want)
+		}
+	}
+}
+
+func semanticStreamZSTDStoredBlock2662(t testing.TB, raw []byte) []byte {
+	t.Helper()
+	compressed := semanticStreamZSTDCompress2662(t, raw)
+	return semanticStreamZSTDStoredBlockWithRawLength2662(uint64(len(raw)), compressed)
+}
+
+func semanticStreamZSTDCompress2662(t testing.TB, raw []byte) []byte {
+	t.Helper()
+	enc, err := zstd.NewWriter(nil,
+		zstd.WithEncoderLevel(zstd.SpeedFastest),
+		zstd.WithEncoderCRC(false),
+		zstd.WithEncoderConcurrency(1),
+	)
+	if err != nil {
+		t.Fatalf("zstd writer: %v", err)
+	}
+	compressed := enc.EncodeAll(raw, nil)
+	enc.Close()
+	return compressed
+}
+
+func semanticStreamZSTDStoredBlockWithRawLength2662(rawLen uint64, compressed []byte) []byte {
+	out := make([]byte, 0, len(columnRetainedSemanticStreamV1BlockZSTDMagic)+binary.MaxVarintLen64+len(compressed))
+	out = append(out, columnRetainedSemanticStreamV1BlockZSTDMagic...)
+	out = binary.AppendUvarint(out, rawLen)
+	out = append(out, compressed...)
+	return out
 }
 
 func TestColumnRetainedSemanticStreamV1BlockCodecLZ4RawFallback2662(t *testing.T) {

--- a/TreeDB/collections/column_retained_payload_audit_test.go
+++ b/TreeDB/collections/column_retained_payload_audit_test.go
@@ -674,6 +674,22 @@ func TestColumnRetainedSemanticStreamV1DecodeCacheDenseBlockGate2662(t *testing.
 	}
 }
 
+func TestColumnRetainedSemanticStreamV1RejectsOversizedRowCount2662(t *testing.T) {
+	raw := append([]byte(nil), columnRetainedSemanticStreamV1BlockMagic...)
+	raw = binary.AppendUvarint(raw, columnRetainedSemanticStreamV1BlockRows+1)
+	raw = binary.AppendUvarint(raw, 0)
+
+	if _, err := columnRetainedSemanticStreamV1BlockRowCount(raw); err == nil || !strings.Contains(err.Error(), "exceeds max") {
+		t.Fatalf("row count err=%v want exceeds max", err)
+	}
+	if _, err := decodeColumnRetainedSemanticStreamV1BlockRowsJSON(raw); err == nil || !strings.Contains(err.Error(), "exceeds max") {
+		t.Fatalf("decode all rows err=%v want exceeds max", err)
+	}
+	if _, err := decodeColumnRetainedSemanticStreamV1BlockRowJSON(raw, 0); err == nil || !strings.Contains(err.Error(), "exceeds max") {
+		t.Fatalf("decode single row err=%v want exceeds max", err)
+	}
+}
+
 func TestColumnRetainedSemanticStreamV1StoredBlockZSTDFailsClosed2662(t *testing.T) {
 	raw, err := encodeColumnRetainedSemanticStreamV1RawBlock([][]byte{[]byte(`{"payload":"same"}`), []byte(`{"payload":"same"}`)})
 	if err != nil {

--- a/TreeDB/collections/column_retained_payload_audit_test.go
+++ b/TreeDB/collections/column_retained_payload_audit_test.go
@@ -42,7 +42,7 @@ func TestAuditColumnRetainedPayloadPathsAbsentJSONBenchPaths2354(t *testing.T) {
 	if err != nil {
 		t.Fatalf("AuditColumnRetainedPayloadPathsAbsent: %v audit=%+v retained=%s", err, audit, retained)
 	}
-	if audit.RetainedPayloadEncoding != string(ColumnRetainedPayloadEncodingTemplateV1) || audit.RetainedPayloadEncodingStatus == "" {
+	if audit.RetainedPayloadEncoding != string(ColumnRetainedPayloadEncodingSemanticStreamV1) || audit.RetainedPayloadEncodingStatus != "active_semantic_stream_v1_non_column_retained_payload" {
 		t.Fatalf("unexpected encoding status: %+v", audit)
 	}
 	if len(audit.Paths) != 5 {
@@ -125,10 +125,21 @@ func TestColumnRetainedPayloadCompressionStatus2356(t *testing.T) {
 			wantStatus:      "active_value_log_auto_grouped_frame_full_retained_payload",
 		},
 		{
-			name: "non_column",
+			name: "non_column_default_semantic_stream",
 			cfg: &ColumnStoreConfig{
 				Enabled:         true,
 				RetainedPayload: ColumnRetainedPayloadNonColumn,
+			},
+			wantCompression: "semantic_stream_v1_blocks",
+			wantPolicy:      "retained_semantic_stream_v1_side_root",
+			wantStatus:      "active_semantic_stream_v1_non_column_retained_payload",
+		},
+		{
+			name: "non_column_explicit_template_v1",
+			cfg: &ColumnStoreConfig{
+				Enabled:                 true,
+				RetainedPayload:         ColumnRetainedPayloadNonColumn,
+				RetainedPayloadEncoding: ColumnRetainedPayloadEncodingTemplateV1,
 			},
 			wantCompression: "value_log_grouped_frame",
 			wantPolicy:      "default_value_log_auto_storage_first",
@@ -146,7 +157,9 @@ func TestColumnRetainedPayloadCompressionStatus2356(t *testing.T) {
 }
 
 func TestAuditCollectionRetainedPayloadDeclaredPathsAbsentTemplateV12382(t *testing.T) {
-	col, closeDB := openRetainedPayloadAuditCollection2382(t, jsonbenchRetainedPayloadAuditConfig2382(true), [][]byte{
+	cfg := jsonbenchRetainedPayloadAuditConfig2382(true)
+	cfg.RetainedPayloadEncoding = ColumnRetainedPayloadEncodingTemplateV1
+	col, closeDB := openRetainedPayloadAuditCollection2382(t, cfg, [][]byte{
 		[]byte(`{"time_us":1,"kind":"commit","did":"did:plc:one","commit":{"operation":"create","collection":"app.bsky.feed.post","rkey":"r1"},"payload":"kept"}`),
 		[]byte(`{"time_us":2,"kind":"commit","did":"did:plc:two","commit":{"operation":"update","collection":"app.bsky.feed.post","rkey":"r2"},"nested":{"also":"kept"}}`),
 	})
@@ -219,7 +232,9 @@ func TestAuditCollectionRetainedPayloadDeclaredPathsAbsentSemanticStreamV12662(t
 }
 
 func TestAuditCollectionRetainedPayloadShapeStatsTemplateV12662(t *testing.T) {
-	col, closeDB := openRetainedPayloadAuditCollection2382(t, jsonbenchRetainedPayloadAuditConfig2382(true), [][]byte{
+	cfg := jsonbenchRetainedPayloadAuditConfig2382(true)
+	cfg.RetainedPayloadEncoding = ColumnRetainedPayloadEncodingTemplateV1
+	col, closeDB := openRetainedPayloadAuditCollection2382(t, cfg, [][]byte{
 		[]byte(`{"time_us":1,"kind":"commit","did":"did:plc:one","commit":{"operation":"create","collection":"app.bsky.feed.post","rkey":"r1"},"payload":"kept","nested":{"also":"kept","count":3}}`),
 		[]byte(`{"time_us":2,"kind":"commit","did":"did:plc:two","commit":{"operation":"update","collection":"app.bsky.feed.post","rkey":"r2"},"payload":"second","nested":{"also":"two","flag":true}}`),
 	})

--- a/TreeDB/collections/column_retained_semantic_stream.go
+++ b/TreeDB/collections/column_retained_semantic_stream.go
@@ -699,6 +699,20 @@ func validateColumnRetainedSemanticStreamV1BlockRows(rows uint64) error {
 	return nil
 }
 
+func columnRetainedSemanticStreamV1EntryRow(last, delta, entryOrdinal, rows uint64) (uint64, error) {
+	entryRow := delta
+	if entryOrdinal != 0 {
+		if delta > ^uint64(0)-last {
+			return 0, errors.New("collections: malformed semantic-stream-v1 retained block row delta overflow")
+		}
+		entryRow = last + delta
+	}
+	if entryRow >= rows {
+		return 0, fmt.Errorf("collections: semantic-stream-v1 entry row %d outside block rows %d", entryRow, rows)
+	}
+	return entryRow, nil
+}
+
 func encodeColumnRetainedSemanticStreamV1Block(documents [][]byte) ([]byte, error) {
 	raw, err := encodeColumnRetainedSemanticStreamV1RawBlock(documents)
 	if err != nil {
@@ -948,12 +962,9 @@ func decodeColumnRetainedSemanticStreamV1BlockRowsJSON(block []byte) ([][]byte, 
 			if err != nil {
 				return nil, errors.New("collections: malformed semantic-stream-v1 retained block row delta")
 			}
-			entryRow := delta
-			if entryOrdinal != 0 {
-				entryRow = last + delta
-				if entryRow < last {
-					return nil, errors.New("collections: malformed semantic-stream-v1 retained block row delta overflow")
-				}
+			entryRow, err := columnRetainedSemanticStreamV1EntryRow(last, delta, entryOrdinal, rows)
+			if err != nil {
+				return nil, err
 			}
 			last = entryRow
 			valueLen, err := binary.ReadUvarint(reader)
@@ -966,9 +977,6 @@ func decodeColumnRetainedSemanticStreamV1BlockRowsJSON(block []byte) ([][]byte, 
 			value := make([]byte, int(valueLen))
 			if _, err := reader.Read(value); err != nil {
 				return nil, err
-			}
-			if entryRow >= rows {
-				return nil, fmt.Errorf("collections: semantic-stream-v1 entry row %d outside block rows %d", entryRow, rows)
 			}
 			decoded := json.RawMessage(value)
 			if !json.Valid(decoded) {
@@ -1037,9 +1045,9 @@ func decodeColumnRetainedSemanticStreamV1BlockRowObject(block []byte, row uint64
 			if err != nil {
 				return nil, errors.New("collections: malformed semantic-stream-v1 retained block row delta")
 			}
-			entryRow := delta
-			if entryOrdinal != 0 {
-				entryRow = last + delta
+			entryRow, err := columnRetainedSemanticStreamV1EntryRow(last, delta, entryOrdinal, rows)
+			if err != nil {
+				return nil, err
 			}
 			last = entryRow
 			valueLen, err := binary.ReadUvarint(reader)
@@ -1200,8 +1208,8 @@ func (c *columnRetainedSemanticStreamV1BlockLayoutCollector) addBlock(block []by
 		return err
 	}
 	off += n
-	if rows == 0 {
-		return errors.New("collections: malformed semantic-stream-v1 retained block zero rows")
+	if err := validateColumnRetainedSemanticStreamV1BlockRows(rows); err != nil {
+		return err
 	}
 	pathCount, n, err := readColumnRetainedSemanticStreamV1Uvarint(raw, off, "path count")
 	if err != nil {
@@ -1256,12 +1264,19 @@ func (c *columnRetainedSemanticStreamV1BlockLayoutCollector) addBlock(block []by
 		entryMetadataBytes := n
 		var scalarValueBytes int64
 		var maxScalarValueBytes int
+		var last uint64
 		for entryOrdinal := uint64(0); entryOrdinal < entryCount; entryOrdinal++ {
-			if _, n, err = readColumnRetainedSemanticStreamV1Uvarint(raw, off, "row delta"); err != nil {
+			var delta uint64
+			if delta, n, err = readColumnRetainedSemanticStreamV1Uvarint(raw, off, "row delta"); err != nil {
 				return err
 			}
 			off += n
 			entryMetadataBytes += n
+			entryRow, err := columnRetainedSemanticStreamV1EntryRow(last, delta, entryOrdinal, rows)
+			if err != nil {
+				return err
+			}
+			last = entryRow
 			valueLen, n, err := readColumnRetainedSemanticStreamV1Uvarint(raw, off, "value length")
 			if err != nil {
 				return err

--- a/TreeDB/collections/column_retained_semantic_stream.go
+++ b/TreeDB/collections/column_retained_semantic_stream.go
@@ -270,8 +270,7 @@ func (c *Collection) auditRetainedSemanticStreamV1BlockLayoutPathsAtSnapshot(sna
 
 func prepareColumnRetainedPayloadInsertBatchStorageDocuments(cfg ColumnStoreConfig, documents [][]byte, fallback templateV1Resolver) (columnRetainedPayloadStorageDocuments, error) {
 	if cfg.RetainedPayload == ColumnRetainedPayloadNonColumn &&
-		columnRetainedPayloadEffectiveEncoding(&cfg) == ColumnRetainedPayloadEncodingSemanticStreamV1 &&
-		len(documents) > 1 {
+		columnRetainedPayloadEffectiveEncoding(&cfg) == ColumnRetainedPayloadEncodingSemanticStreamV1 {
 		return prepareColumnRetainedSemanticStreamV1StorageDocuments(cfg, documents)
 	}
 	return prepareColumnRetainedPayloadStorageDocuments(cfg, documents, fallback)
@@ -353,38 +352,9 @@ func appendColumnRetainedSemanticStreamV1ReclaimDeltas(
 	policies *[]backenddb.OrderedRootStoragePolicy,
 	deltaTables *[]memtable.Table,
 ) error {
-	if !columnStoreRetainedPayloadUsesSemanticStreamV1(meta.Options.ColumnStore) ||
-		len(removedDocumentIDs) == 0 ||
-		len(removedPrimaryValues) == 0 ||
-		rootNames == nil ||
-		baseRootIDs == nil ||
-		policies == nil ||
-		deltaTables == nil {
-		return nil
-	}
-	candidates, err := columnRetainedSemanticStreamV1BlockKeysFromValues(removedPrimaryValues)
-	if err != nil || len(candidates) == 0 {
+	deleteKeys, err := columnRetainedSemanticStreamV1ReclaimDeleteKeys(snap, catalog, meta, removedDocumentIDs, removedPrimaryValues, replacementPrimaryValues)
+	if err != nil || len(deleteKeys) == 0 {
 		return err
-	}
-	replacementLive, err := columnRetainedSemanticStreamV1BlockKeysFromValues(replacementPrimaryValues)
-	if err != nil {
-		return err
-	}
-	for key := range replacementLive {
-		delete(candidates, key)
-	}
-	if len(candidates) == 0 {
-		return nil
-	}
-	live, err := columnRetainedSemanticStreamV1LiveCandidateBlocks(snap, catalog, meta, candidates, removedDocumentIDs)
-	if err != nil {
-		return err
-	}
-	for key := range live {
-		delete(candidates, key)
-	}
-	if len(candidates) == 0 {
-		return nil
 	}
 	rootName := collectionRetainedSemanticStreamRootName(meta.Name)
 	baseRootID := catalog.rootID(rootName)
@@ -395,6 +365,80 @@ func appendColumnRetainedSemanticStreamV1ReclaimDeltas(
 	if err != nil {
 		return err
 	}
+	*rootNames = append(*rootNames, rootName)
+	baseRootIDs[rootName] = baseRootID
+	*policies = append(*policies, policy)
+	*deltaTables = append(*deltaTables, buildDeleteRootDeltaTable(deleteKeys))
+	return nil
+}
+
+func appendColumnRetainedSemanticStreamV1BlockDeltas(
+	db *backenddb.DB,
+	catalog *collectionCatalog,
+	meta CollectionMeta,
+	blockTable memtable.Table,
+	rootNames *[]string,
+	baseRootIDs map[string]uint64,
+	policies *[]backenddb.OrderedRootStoragePolicy,
+	deltaTables *[]memtable.Table,
+) error {
+	if blockTable == nil ||
+		blockTable.Len() == 0 ||
+		rootNames == nil ||
+		baseRootIDs == nil ||
+		policies == nil ||
+		deltaTables == nil {
+		return nil
+	}
+	rootName := collectionRetainedSemanticStreamRootName(meta.Name)
+	policy, err := collectionRootStoragePolicyForDB(db, meta, rootName)
+	if err != nil {
+		return err
+	}
+	*rootNames = append(*rootNames, rootName)
+	baseRootIDs[rootName] = catalog.rootID(rootName)
+	*policies = append(*policies, policy)
+	*deltaTables = append(*deltaTables, blockTable)
+	return nil
+}
+
+func columnRetainedSemanticStreamV1ReclaimDeleteKeys(
+	snap *backenddb.Snapshot,
+	catalog *collectionCatalog,
+	meta CollectionMeta,
+	removedDocumentIDs [][]byte,
+	removedPrimaryValues [][]byte,
+	replacementPrimaryValues [][]byte,
+) ([][]byte, error) {
+	if !columnStoreRetainedPayloadUsesSemanticStreamV1(meta.Options.ColumnStore) ||
+		len(removedDocumentIDs) == 0 ||
+		len(removedPrimaryValues) == 0 {
+		return nil, nil
+	}
+	candidates, err := columnRetainedSemanticStreamV1BlockKeysFromValues(removedPrimaryValues)
+	if err != nil || len(candidates) == 0 {
+		return nil, err
+	}
+	replacementLive, err := columnRetainedSemanticStreamV1BlockKeysFromValues(replacementPrimaryValues)
+	if err != nil {
+		return nil, err
+	}
+	for key := range replacementLive {
+		delete(candidates, key)
+	}
+	if len(candidates) == 0 {
+		return nil, nil
+	}
+	live, err := columnRetainedSemanticStreamV1LiveCandidateBlocks(snap, catalog, meta, candidates, removedDocumentIDs)
+	if err != nil {
+		return nil, err
+	}
+	for key := range live {
+		delete(candidates, key)
+	}
+	if len(candidates) == 0 {
+		return nil, nil
+	}
 	deleteKeys := make([][]byte, 0, len(candidates))
 	for _, key := range candidates {
 		deleteKeys = append(deleteKeys, key)
@@ -402,11 +446,7 @@ func appendColumnRetainedSemanticStreamV1ReclaimDeltas(
 	sort.Slice(deleteKeys, func(i, j int) bool {
 		return bytes.Compare(deleteKeys[i], deleteKeys[j]) < 0
 	})
-	*rootNames = append(*rootNames, rootName)
-	baseRootIDs[rootName] = baseRootID
-	*policies = append(*policies, policy)
-	*deltaTables = append(*deltaTables, buildDeleteRootDeltaTable(deleteKeys))
-	return nil
+	return deleteKeys, nil
 }
 
 func columnRetainedSemanticStreamV1BlockKeysFromValues(values [][]byte) (map[string][]byte, error) {

--- a/TreeDB/collections/column_retained_semantic_stream.go
+++ b/TreeDB/collections/column_retained_semantic_stream.go
@@ -25,6 +25,10 @@ const defaultColumnRetainedSemanticStreamV1DecodeCacheBlocks = 16
 const minColumnRetainedSemanticStreamV1DecodeCacheRows = 64
 
 var (
+	// Side-root retained blocks are stored either as a decoded semantic-stream
+	// block (`crss1blk\0`) or as a zstd stored-block wrapper (`crss1zst\0`).
+	// The wrapper payload is: magic, uvarint decoded crss1blk byte length, and
+	// a zstd frame containing that complete raw crss1blk block.
 	columnRetainedSemanticStreamV1BlockMagic     = []byte("crss1blk\x00")
 	columnRetainedSemanticStreamV1BlockZSTDMagic = []byte("crss1zst\x00")
 	columnRetainedSemanticStreamV1LocatorMagic   = []byte("crss1loc\x00")
@@ -692,8 +696,15 @@ func encodeColumnRetainedSemanticStreamV1RawBlock(documents [][]byte) ([]byte, e
 }
 
 func encodeColumnRetainedSemanticStreamV1StoredBlock(raw []byte) ([]byte, error) {
+	return encodeColumnRetainedSemanticStreamV1StoredBlockWithRawLimit(raw, maxColumnRetainedSemanticStreamV1CompressedRawBlockBytes)
+}
+
+func encodeColumnRetainedSemanticStreamV1StoredBlockWithRawLimit(raw []byte, compressedRawLimit int) ([]byte, error) {
 	if !bytes.HasPrefix(raw, columnRetainedSemanticStreamV1BlockMagic) {
 		return nil, errors.New("collections: retained block is not semantic-stream-v1 encoded")
+	}
+	if compressedRawLimit > 0 && len(raw) > compressedRawLimit {
+		return raw, nil
 	}
 	enc, err := zstd.NewWriter(nil,
 		zstd.WithEncoderLevel(zstd.SpeedFastest),

--- a/TreeDB/collections/column_retained_semantic_stream.go
+++ b/TreeDB/collections/column_retained_semantic_stream.go
@@ -683,10 +683,20 @@ func columnRetainedSemanticStreamV1BlockRowCount(block []byte) (uint64, error) {
 	if err != nil {
 		return 0, err
 	}
-	if rows == 0 {
-		return 0, errors.New("collections: malformed semantic-stream-v1 retained block zero rows")
+	if err := validateColumnRetainedSemanticStreamV1BlockRows(rows); err != nil {
+		return 0, err
 	}
 	return rows, nil
+}
+
+func validateColumnRetainedSemanticStreamV1BlockRows(rows uint64) error {
+	if rows == 0 {
+		return errors.New("collections: malformed semantic-stream-v1 retained block zero rows")
+	}
+	if rows > columnRetainedSemanticStreamV1BlockRows {
+		return fmt.Errorf("collections: semantic-stream-v1 retained block row count %d exceeds max %d", rows, columnRetainedSemanticStreamV1BlockRows)
+	}
+	return nil
 }
 
 func encodeColumnRetainedSemanticStreamV1Block(documents [][]byte) ([]byte, error) {
@@ -915,6 +925,9 @@ func decodeColumnRetainedSemanticStreamV1BlockRowsJSON(block []byte) ([][]byte, 
 	if rows > uint64(int(^uint(0)>>1)) {
 		return nil, errors.New("collections: semantic-stream-v1 retained block row count too large")
 	}
+	if err := validateColumnRetainedSemanticStreamV1BlockRows(rows); err != nil {
+		return nil, err
+	}
 	pathCount, err := binary.ReadUvarint(reader)
 	if err != nil {
 		return nil, errors.New("collections: malformed semantic-stream-v1 retained block path count")
@@ -997,6 +1010,9 @@ func decodeColumnRetainedSemanticStreamV1BlockRowObject(block []byte, row uint64
 	rows, err := binary.ReadUvarint(reader)
 	if err != nil {
 		return nil, errors.New("collections: malformed semantic-stream-v1 retained block row count")
+	}
+	if err := validateColumnRetainedSemanticStreamV1BlockRows(rows); err != nil {
+		return nil, err
 	}
 	if row >= rows {
 		return nil, fmt.Errorf("collections: semantic-stream-v1 row %d outside block rows %d", row, rows)

--- a/TreeDB/collections/column_retained_semantic_stream.go
+++ b/TreeDB/collections/column_retained_semantic_stream.go
@@ -22,6 +22,7 @@ import (
 const columnRetainedSemanticStreamV1BlockRows = 4096
 const maxColumnRetainedSemanticStreamV1CompressedRawBlockBytes = 512 << 20
 const defaultColumnRetainedSemanticStreamV1DecodeCacheBlocks = 16
+const minColumnRetainedSemanticStreamV1DecodeCacheRows = 64
 
 var (
 	columnRetainedSemanticStreamV1BlockMagic     = []byte("crss1blk\x00")

--- a/TreeDB/collections/column_retained_semantic_stream.go
+++ b/TreeDB/collections/column_retained_semantic_stream.go
@@ -20,10 +20,13 @@ import (
 )
 
 const columnRetainedSemanticStreamV1BlockRows = 4096
+const maxColumnRetainedSemanticStreamV1CompressedRawBlockBytes = 512 << 20
+const defaultColumnRetainedSemanticStreamV1DecodeCacheBlocks = 16
 
 var (
-	columnRetainedSemanticStreamV1BlockMagic   = []byte("crss1blk\x00")
-	columnRetainedSemanticStreamV1LocatorMagic = []byte("crss1loc\x00")
+	columnRetainedSemanticStreamV1BlockMagic     = []byte("crss1blk\x00")
+	columnRetainedSemanticStreamV1BlockZSTDMagic = []byte("crss1zst\x00")
+	columnRetainedSemanticStreamV1LocatorMagic   = []byte("crss1loc\x00")
 )
 
 type columnRetainedSemanticStreamEntry struct {
@@ -34,6 +37,16 @@ type columnRetainedSemanticStreamEntry struct {
 type columnRetainedSemanticStreamPath struct {
 	segments []string
 	entries  []columnRetainedSemanticStreamEntry
+}
+
+type columnRetainedSemanticStreamV1DecodedBlock struct {
+	rows [][]byte
+}
+
+type columnRetainedSemanticStreamV1DecodeCache struct {
+	blocks    map[string]*columnRetainedSemanticStreamV1DecodedBlock
+	order     []string
+	maxBlocks int
 }
 
 // ColumnRetainedSemanticStreamV1StorageAccounting reports the retained-payload
@@ -54,6 +67,7 @@ type ColumnRetainedSemanticStreamV1BlockLayoutAudit struct {
 	BlockRows            int                                            `json:"block_rows"`
 	BlockCount           int                                            `json:"block_count"`
 	PrimaryLocatorBytes  int64                                          `json:"primary_locator_bytes,omitempty"`
+	StoredBlockBytes     int64                                          `json:"stored_block_bytes,omitempty"`
 	RawBlockBytes        int64                                          `json:"raw_block_bytes"`
 	BlockHeaderBytes     int64                                          `json:"block_header_bytes"`
 	PathStreamCount      int64                                          `json:"path_stream_count"`
@@ -482,6 +496,10 @@ func columnRetainedSemanticStreamV1PrimaryValueForReclaim(snap *backenddb.Snapsh
 }
 
 func resolveColumnRetainedPayloadAtSnapshot(snap *backenddb.Snapshot, catalog *collectionCatalog, cfg ColumnStoreConfig, retained []byte) ([]byte, error) {
+	return resolveColumnRetainedPayloadAtSnapshotWithCache(snap, catalog, cfg, retained, nil)
+}
+
+func resolveColumnRetainedPayloadAtSnapshotWithCache(snap *backenddb.Snapshot, catalog *collectionCatalog, cfg ColumnStoreConfig, retained []byte, cache *columnRetainedSemanticStreamV1DecodeCache) ([]byte, error) {
 	if !columnStoreRetainedPayloadUsesSemanticStreamV1(&cfg) {
 		return retained, nil
 	}
@@ -492,6 +510,9 @@ func resolveColumnRetainedPayloadAtSnapshot(snap *backenddb.Snapshot, catalog *c
 	if snap == nil || catalog == nil {
 		return nil, errors.New("collections: semantic-stream-v1 retained payload requires snapshot catalog")
 	}
+	if cache != nil {
+		return cache.rowJSONAtSnapshot(snap, catalog, blockKey, row)
+	}
 	block, found, err := collectionGetAppendAtCatalogRoot(snap, catalog, collectionRetainedSemanticStreamRootName(catalog.meta.Name), blockKey, nil)
 	if err != nil {
 		return nil, err
@@ -500,6 +521,70 @@ func resolveColumnRetainedPayloadAtSnapshot(snap *backenddb.Snapshot, catalog *c
 		return nil, fmt.Errorf("collections: semantic-stream-v1 retained block %x missing", blockKey)
 	}
 	return decodeColumnRetainedSemanticStreamV1BlockRowJSON(block, row)
+}
+
+func newColumnRetainedSemanticStreamV1DecodeCache() *columnRetainedSemanticStreamV1DecodeCache {
+	return newColumnRetainedSemanticStreamV1DecodeCacheWithMaxBlocks(defaultColumnRetainedSemanticStreamV1DecodeCacheBlocks)
+}
+
+func newColumnRetainedSemanticStreamV1DecodeCacheWithMaxBlocks(maxBlocks int) *columnRetainedSemanticStreamV1DecodeCache {
+	if maxBlocks <= 0 {
+		return nil
+	}
+	return &columnRetainedSemanticStreamV1DecodeCache{
+		blocks:    make(map[string]*columnRetainedSemanticStreamV1DecodedBlock, maxBlocks),
+		maxBlocks: maxBlocks,
+	}
+}
+
+func (c *columnRetainedSemanticStreamV1DecodeCache) rowJSONAtSnapshot(snap *backenddb.Snapshot, catalog *collectionCatalog, blockKey []byte, row uint64) ([]byte, error) {
+	if c == nil {
+		return nil, errors.New("collections: semantic-stream-v1 retained decode cache is nil")
+	}
+	cacheKey := string(blockKey)
+	decoded := c.blocks[cacheKey]
+	if decoded == nil {
+		block, found, err := collectionGetAppendAtCatalogRoot(snap, catalog, collectionRetainedSemanticStreamRootName(catalog.meta.Name), blockKey, nil)
+		if err != nil {
+			return nil, err
+		}
+		if !found {
+			return nil, fmt.Errorf("collections: semantic-stream-v1 retained block %x missing", blockKey)
+		}
+		rows, err := decodeColumnRetainedSemanticStreamV1BlockRowsJSON(block)
+		if err != nil {
+			return nil, err
+		}
+		decoded = &columnRetainedSemanticStreamV1DecodedBlock{rows: rows}
+		c.store(cacheKey, decoded)
+	}
+	return decoded.rowJSON(row)
+}
+
+func (c *columnRetainedSemanticStreamV1DecodeCache) store(cacheKey string, decoded *columnRetainedSemanticStreamV1DecodedBlock) {
+	if c == nil || c.maxBlocks <= 0 || decoded == nil {
+		return
+	}
+	if _, exists := c.blocks[cacheKey]; !exists {
+		c.order = append(c.order, cacheKey)
+	}
+	c.blocks[cacheKey] = decoded
+	for len(c.order) > c.maxBlocks {
+		evict := c.order[0]
+		copy(c.order, c.order[1:])
+		c.order = c.order[:len(c.order)-1]
+		delete(c.blocks, evict)
+	}
+}
+
+func (b *columnRetainedSemanticStreamV1DecodedBlock) rowJSON(row uint64) ([]byte, error) {
+	if b == nil {
+		return nil, errors.New("collections: semantic-stream-v1 retained decoded block is nil")
+	}
+	if row >= uint64(len(b.rows)) {
+		return nil, fmt.Errorf("collections: semantic-stream-v1 row %d outside block rows %d", row, len(b.rows))
+	}
+	return bytes.Clone(b.rows[int(row)]), nil
 }
 
 func validateColumnRetainedSemanticStreamV1LocatorAtSnapshot(snap *backenddb.Snapshot, catalog *collectionCatalog, retained []byte, blockRows map[string]uint64) (bool, error) {
@@ -535,11 +620,12 @@ func validateColumnRetainedSemanticStreamV1LocatorAtSnapshot(snap *backenddb.Sna
 }
 
 func columnRetainedSemanticStreamV1BlockRowCount(block []byte) (uint64, error) {
-	if !bytes.HasPrefix(block, columnRetainedSemanticStreamV1BlockMagic) {
-		return 0, errors.New("collections: retained block is not semantic-stream-v1 encoded")
+	raw, err := decodeColumnRetainedSemanticStreamV1StoredBlock(block)
+	if err != nil {
+		return 0, err
 	}
 	off := len(columnRetainedSemanticStreamV1BlockMagic)
-	rows, _, err := readColumnRetainedSemanticStreamV1Uvarint(block, off, "row count")
+	rows, _, err := readColumnRetainedSemanticStreamV1Uvarint(raw, off, "row count")
 	if err != nil {
 		return 0, err
 	}
@@ -550,6 +636,14 @@ func columnRetainedSemanticStreamV1BlockRowCount(block []byte) (uint64, error) {
 }
 
 func encodeColumnRetainedSemanticStreamV1Block(documents [][]byte) ([]byte, error) {
+	raw, err := encodeColumnRetainedSemanticStreamV1RawBlock(documents)
+	if err != nil {
+		return nil, err
+	}
+	return encodeColumnRetainedSemanticStreamV1StoredBlock(raw)
+}
+
+func encodeColumnRetainedSemanticStreamV1RawBlock(documents [][]byte) ([]byte, error) {
 	streams := make(map[string]*columnRetainedSemanticStreamPath)
 	for row, document := range documents {
 		trimmed := bytes.TrimSpace(document)
@@ -594,6 +688,78 @@ func encodeColumnRetainedSemanticStreamV1Block(documents [][]byte) ([]byte, erro
 		}
 	}
 	return out, nil
+}
+
+func encodeColumnRetainedSemanticStreamV1StoredBlock(raw []byte) ([]byte, error) {
+	if !bytes.HasPrefix(raw, columnRetainedSemanticStreamV1BlockMagic) {
+		return nil, errors.New("collections: retained block is not semantic-stream-v1 encoded")
+	}
+	enc, err := zstd.NewWriter(nil,
+		zstd.WithEncoderLevel(zstd.SpeedFastest),
+		zstd.WithEncoderCRC(false),
+		zstd.WithEncoderConcurrency(1),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("collections: create semantic-stream-v1 retained block zstd encoder: %w", err)
+	}
+	compressed := enc.EncodeAll(raw, nil)
+	enc.Close()
+	out := make([]byte, 0, len(columnRetainedSemanticStreamV1BlockZSTDMagic)+binary.MaxVarintLen64+len(compressed))
+	out = append(out, columnRetainedSemanticStreamV1BlockZSTDMagic...)
+	out = binary.AppendUvarint(out, uint64(len(raw)))
+	out = append(out, compressed...)
+	if len(out) >= len(raw) {
+		return raw, nil
+	}
+	return out, nil
+}
+
+func decodeColumnRetainedSemanticStreamV1StoredBlock(block []byte) ([]byte, error) {
+	if bytes.HasPrefix(block, columnRetainedSemanticStreamV1BlockMagic) {
+		return block, nil
+	}
+	if !bytes.HasPrefix(block, columnRetainedSemanticStreamV1BlockZSTDMagic) {
+		return nil, errors.New("collections: retained block is not semantic-stream-v1 encoded")
+	}
+	off := len(columnRetainedSemanticStreamV1BlockZSTDMagic)
+	rawBytes, n, err := readColumnRetainedSemanticStreamV1Uvarint(block, off, "zstd raw block length")
+	if err != nil {
+		return nil, err
+	}
+	off += n
+	if rawBytes == 0 {
+		return nil, errors.New("collections: malformed semantic-stream-v1 retained block zero zstd raw length")
+	}
+	if rawBytes > maxColumnRetainedSemanticStreamV1CompressedRawBlockBytes {
+		return nil, fmt.Errorf("collections: semantic-stream-v1 retained block zstd raw length %d exceeds max %d", rawBytes, maxColumnRetainedSemanticStreamV1CompressedRawBlockBytes)
+	}
+	if off >= len(block) {
+		return nil, errors.New("collections: truncated semantic-stream-v1 retained block zstd payload")
+	}
+	maxDecodedBytes := int(rawBytes)
+	if maxDecodedBytes < 1<<20 {
+		maxDecodedBytes = 1 << 20
+	}
+	dec, err := zstd.NewReader(nil,
+		zstd.WithDecoderConcurrency(1),
+		zstd.WithDecoderMaxMemory(uint64(maxDecodedBytes)),
+		zstd.WithDecodeAllCapLimit(true),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("collections: create semantic-stream-v1 retained block zstd decoder: %w", err)
+	}
+	raw, err := dec.DecodeAll(block[off:], make([]byte, 0, int(rawBytes)))
+	dec.Close()
+	if err != nil {
+		return nil, fmt.Errorf("collections: decode semantic-stream-v1 retained block zstd payload: %w", err)
+	}
+	if len(raw) != int(rawBytes) {
+		return nil, fmt.Errorf("collections: semantic-stream-v1 retained block zstd decoded length=%d want=%d", len(raw), rawBytes)
+	}
+	if !bytes.HasPrefix(raw, columnRetainedSemanticStreamV1BlockMagic) {
+		return nil, errors.New("collections: semantic-stream-v1 retained block zstd payload decoded to invalid block")
+	}
+	return raw, nil
 }
 
 func collectColumnRetainedSemanticStreamPaths(raw json.RawMessage, path []string, row uint64, streams map[string]*columnRetainedSemanticStreamPath) error {
@@ -672,11 +838,101 @@ func decodeColumnRetainedSemanticStreamV1BlockRowJSON(block []byte, row uint64) 
 	return out, nil
 }
 
-func decodeColumnRetainedSemanticStreamV1BlockRowObject(block []byte, row uint64) (map[string]any, error) {
-	if !bytes.HasPrefix(block, columnRetainedSemanticStreamV1BlockMagic) {
-		return nil, errors.New("collections: retained block is not semantic-stream-v1 encoded")
+func decodeColumnRetainedSemanticStreamV1BlockRowsJSON(block []byte) ([][]byte, error) {
+	raw, err := decodeColumnRetainedSemanticStreamV1StoredBlock(block)
+	if err != nil {
+		return nil, err
 	}
-	reader := bytes.NewReader(block[len(columnRetainedSemanticStreamV1BlockMagic):])
+	reader := bytes.NewReader(raw[len(columnRetainedSemanticStreamV1BlockMagic):])
+	rows, err := binary.ReadUvarint(reader)
+	if err != nil {
+		return nil, errors.New("collections: malformed semantic-stream-v1 retained block row count")
+	}
+	if rows == 0 {
+		return nil, errors.New("collections: malformed semantic-stream-v1 retained block zero rows")
+	}
+	if rows > uint64(int(^uint(0)>>1)) {
+		return nil, errors.New("collections: semantic-stream-v1 retained block row count too large")
+	}
+	pathCount, err := binary.ReadUvarint(reader)
+	if err != nil {
+		return nil, errors.New("collections: malformed semantic-stream-v1 retained block path count")
+	}
+	objects := make([]map[string]any, int(rows))
+	for pathOrdinal := uint64(0); pathOrdinal < pathCount; pathOrdinal++ {
+		path, err := readColumnRetainedSemanticStreamV1Path(reader)
+		if err != nil {
+			return nil, err
+		}
+		entryCount, err := binary.ReadUvarint(reader)
+		if err != nil {
+			return nil, errors.New("collections: malformed semantic-stream-v1 retained block entry count")
+		}
+		var last uint64
+		for entryOrdinal := uint64(0); entryOrdinal < entryCount; entryOrdinal++ {
+			delta, err := binary.ReadUvarint(reader)
+			if err != nil {
+				return nil, errors.New("collections: malformed semantic-stream-v1 retained block row delta")
+			}
+			entryRow := delta
+			if entryOrdinal != 0 {
+				entryRow = last + delta
+				if entryRow < last {
+					return nil, errors.New("collections: malformed semantic-stream-v1 retained block row delta overflow")
+				}
+			}
+			last = entryRow
+			valueLen, err := binary.ReadUvarint(reader)
+			if err != nil {
+				return nil, errors.New("collections: malformed semantic-stream-v1 retained block value length")
+			}
+			if valueLen > uint64(reader.Len()) {
+				return nil, errors.New("collections: truncated semantic-stream-v1 retained block value")
+			}
+			value := make([]byte, int(valueLen))
+			if _, err := reader.Read(value); err != nil {
+				return nil, err
+			}
+			if entryRow >= rows {
+				return nil, fmt.Errorf("collections: semantic-stream-v1 entry row %d outside block rows %d", entryRow, rows)
+			}
+			decoded := json.RawMessage(value)
+			if !json.Valid(decoded) {
+				return nil, errors.New("collections: decode semantic-stream-v1 retained value: invalid JSON")
+			}
+			obj := objects[int(entryRow)]
+			if obj == nil {
+				obj = make(map[string]any)
+				objects[int(entryRow)] = obj
+			}
+			if err := setColumnRetainedSemanticStreamPathValue(obj, path, decoded); err != nil {
+				return nil, err
+			}
+		}
+	}
+	if reader.Len() != 0 {
+		return nil, errors.New("collections: trailing semantic-stream-v1 retained block bytes")
+	}
+	out := make([][]byte, len(objects))
+	for i, obj := range objects {
+		if obj == nil {
+			obj = make(map[string]any)
+		}
+		rowJSON, err := json.Marshal(obj)
+		if err != nil {
+			return nil, fmt.Errorf("collections: encode semantic-stream-v1 retained row: %w", err)
+		}
+		out[i] = rowJSON
+	}
+	return out, nil
+}
+
+func decodeColumnRetainedSemanticStreamV1BlockRowObject(block []byte, row uint64) (map[string]any, error) {
+	raw, err := decodeColumnRetainedSemanticStreamV1StoredBlock(block)
+	if err != nil {
+		return nil, err
+	}
+	reader := bytes.NewReader(raw[len(columnRetainedSemanticStreamV1BlockMagic):])
 	rows, err := binary.ReadUvarint(reader)
 	if err != nil {
 		return nil, errors.New("collections: malformed semantic-stream-v1 retained block row count")
@@ -789,6 +1045,7 @@ func setColumnRetainedSemanticStreamPathValue(root map[string]any, path []string
 
 type columnRetainedSemanticStreamV1BlockLayoutCollector struct {
 	primaryLocatorBytes int64
+	storedBlockBytes    int64
 	blockHeaderBytes    int64
 	rawBlockBytes       int64
 	pathMetadataBytes   int64
@@ -856,11 +1113,12 @@ func (c *columnRetainedSemanticStreamV1BlockLayoutCollector) addBlock(block []by
 	if c == nil {
 		return nil
 	}
-	if !bytes.HasPrefix(block, columnRetainedSemanticStreamV1BlockMagic) {
-		return errors.New("collections: retained block is not semantic-stream-v1 encoded")
+	raw, err := decodeColumnRetainedSemanticStreamV1StoredBlock(block)
+	if err != nil {
+		return err
 	}
 	off := len(columnRetainedSemanticStreamV1BlockMagic)
-	rows, n, err := readColumnRetainedSemanticStreamV1Uvarint(block, off, "row count")
+	rows, n, err := readColumnRetainedSemanticStreamV1Uvarint(raw, off, "row count")
 	if err != nil {
 		return err
 	}
@@ -868,7 +1126,7 @@ func (c *columnRetainedSemanticStreamV1BlockLayoutCollector) addBlock(block []by
 	if rows == 0 {
 		return errors.New("collections: malformed semantic-stream-v1 retained block zero rows")
 	}
-	pathCount, n, err := readColumnRetainedSemanticStreamV1Uvarint(block, off, "path count")
+	pathCount, n, err := readColumnRetainedSemanticStreamV1Uvarint(raw, off, "path count")
 	if err != nil {
 		return err
 	}
@@ -877,16 +1135,17 @@ func (c *columnRetainedSemanticStreamV1BlockLayoutCollector) addBlock(block []by
 
 	if !c.pathOnly {
 		c.blockCount++
-		c.rawBlockBytes += int64(len(block))
+		c.storedBlockBytes += int64(len(block))
+		c.rawBlockBytes += int64(len(raw))
 		c.blockHeaderBytes += int64(blockHeaderBytes)
-		c.observeBlockCodec("snappy", block)
-		c.observeBlockCodec("lz4", block)
-		c.observeBlockCodec("zstd", block)
+		c.observeBlockCodec("snappy", raw)
+		c.observeBlockCodec("lz4", raw)
+		c.observeBlockCodec("zstd", raw)
 	}
 
 	for pathOrdinal := uint64(0); pathOrdinal < pathCount; pathOrdinal++ {
 		pathStart := off
-		segmentCount, n, err := readColumnRetainedSemanticStreamV1Uvarint(block, off, "path segment count")
+		segmentCount, n, err := readColumnRetainedSemanticStreamV1Uvarint(raw, off, "path segment count")
 		if err != nil {
 			return err
 		}
@@ -894,25 +1153,25 @@ func (c *columnRetainedSemanticStreamV1BlockLayoutCollector) addBlock(block []by
 		if segmentCount > uint64(int(^uint(0)>>1)) {
 			return errors.New("collections: semantic-stream-v1 retained block path too large")
 		}
-		if segmentCount > uint64(len(block)-off) {
+		if segmentCount > uint64(len(raw)-off) {
 			return errors.New("collections: semantic-stream-v1 retained block path segment count exceeds remaining bytes")
 		}
 		segments := make([]string, 0, segmentCount)
 		for segmentOrdinal := uint64(0); segmentOrdinal < segmentCount; segmentOrdinal++ {
-			segmentLen, n, err := readColumnRetainedSemanticStreamV1Uvarint(block, off, "path segment length")
+			segmentLen, n, err := readColumnRetainedSemanticStreamV1Uvarint(raw, off, "path segment length")
 			if err != nil {
 				return err
 			}
 			off += n
-			if segmentLen > uint64(len(block)-off) {
+			if segmentLen > uint64(len(raw)-off) {
 				return errors.New("collections: truncated semantic-stream-v1 retained block path segment")
 			}
-			segment := string(block[off : off+int(segmentLen)])
+			segment := string(raw[off : off+int(segmentLen)])
 			segments = append(segments, segment)
 			off += int(segmentLen)
 		}
 		pathMetadataBytes := off - pathStart
-		entryCount, n, err := readColumnRetainedSemanticStreamV1Uvarint(block, off, "entry count")
+		entryCount, n, err := readColumnRetainedSemanticStreamV1Uvarint(raw, off, "entry count")
 		if err != nil {
 			return err
 		}
@@ -921,18 +1180,18 @@ func (c *columnRetainedSemanticStreamV1BlockLayoutCollector) addBlock(block []by
 		var scalarValueBytes int64
 		var maxScalarValueBytes int
 		for entryOrdinal := uint64(0); entryOrdinal < entryCount; entryOrdinal++ {
-			if _, n, err = readColumnRetainedSemanticStreamV1Uvarint(block, off, "row delta"); err != nil {
+			if _, n, err = readColumnRetainedSemanticStreamV1Uvarint(raw, off, "row delta"); err != nil {
 				return err
 			}
 			off += n
 			entryMetadataBytes += n
-			valueLen, n, err := readColumnRetainedSemanticStreamV1Uvarint(block, off, "value length")
+			valueLen, n, err := readColumnRetainedSemanticStreamV1Uvarint(raw, off, "value length")
 			if err != nil {
 				return err
 			}
 			off += n
 			entryMetadataBytes += n
-			if valueLen > uint64(len(block)-off) {
+			if valueLen > uint64(len(raw)-off) {
 				return errors.New("collections: truncated semantic-stream-v1 retained block value")
 			}
 			scalarValueBytes += int64(valueLen)
@@ -941,14 +1200,14 @@ func (c *columnRetainedSemanticStreamV1BlockLayoutCollector) addBlock(block []by
 			}
 			off += int(valueLen)
 		}
-		pathRaw := block[pathStart:off]
+		pathRaw := raw[pathStart:off]
 		path := strings.Join(segments, ".")
 		pathKey := columnRetainedSemanticStreamPathKey(segments)
 		if err := c.observePath(pathKey, path, int64(pathMetadataBytes), int64(entryMetadataBytes), scalarValueBytes, int64(entryCount), maxScalarValueBytes, pathRaw); err != nil {
 			return err
 		}
 	}
-	if off != len(block) {
+	if off != len(raw) {
 		return errors.New("collections: trailing semantic-stream-v1 retained block bytes")
 	}
 	return nil
@@ -1048,6 +1307,7 @@ func (c *columnRetainedSemanticStreamV1BlockLayoutCollector) result(rows, maxPat
 		BlockRows:           columnRetainedSemanticStreamV1BlockRows,
 		BlockCount:          c.blockCount,
 		PrimaryLocatorBytes: c.primaryLocatorBytes,
+		StoredBlockBytes:    c.storedBlockBytes,
 		RawBlockBytes:       c.rawBlockBytes,
 		BlockHeaderBytes:    c.blockHeaderBytes,
 		PathStreamCount:     c.pathStreamCount,

--- a/TreeDB/collections/column_retained_semantic_stream.go
+++ b/TreeDB/collections/column_retained_semantic_stream.go
@@ -23,6 +23,7 @@ const columnRetainedSemanticStreamV1BlockRows = 4096
 const maxColumnRetainedSemanticStreamV1CompressedRawBlockBytes = 512 << 20
 const defaultColumnRetainedSemanticStreamV1DecodeCacheBlocks = 16
 const minColumnRetainedSemanticStreamV1DecodeCacheRows = 64
+const minColumnRetainedSemanticStreamV1DecodeCacheRowsPerBlock = 512
 
 var (
 	// Side-root retained blocks are stored either as a decoded semantic-stream
@@ -49,9 +50,10 @@ type columnRetainedSemanticStreamV1DecodedBlock struct {
 }
 
 type columnRetainedSemanticStreamV1DecodeCache struct {
-	blocks    map[string]*columnRetainedSemanticStreamV1DecodedBlock
-	order     []string
-	maxBlocks int
+	blocks        map[string]*columnRetainedSemanticStreamV1DecodedBlock
+	order         []string
+	maxBlocks     int
+	allowedBlocks map[string]struct{}
 }
 
 // ColumnRetainedSemanticStreamV1StorageAccounting reports the retained-payload
@@ -542,11 +544,47 @@ func newColumnRetainedSemanticStreamV1DecodeCacheWithMaxBlocks(maxBlocks int) *c
 	}
 }
 
+func newColumnRetainedSemanticStreamV1DecodeCacheForDocumentRecords(cfg *ColumnStoreConfig, records []DocumentRecord) *columnRetainedSemanticStreamV1DecodeCache {
+	if !columnStoreRetainedPayloadUsesSemanticStreamV1(cfg) || len(records) < minColumnRetainedSemanticStreamV1DecodeCacheRows {
+		return nil
+	}
+	counts := make(map[string]int)
+	for _, record := range records {
+		blockKey, _, ok, err := parseColumnRetainedSemanticStreamV1Locator(record.Document)
+		if err != nil || !ok {
+			continue
+		}
+		counts[string(blockKey)]++
+	}
+	allowed := make(map[string]struct{})
+	for blockKey, count := range counts {
+		if count >= minColumnRetainedSemanticStreamV1DecodeCacheRowsPerBlock {
+			allowed[blockKey] = struct{}{}
+		}
+	}
+	if len(allowed) == 0 {
+		return nil
+	}
+	cache := newColumnRetainedSemanticStreamV1DecodeCache()
+	cache.allowedBlocks = allowed
+	return cache
+}
+
 func (c *columnRetainedSemanticStreamV1DecodeCache) rowJSONAtSnapshot(snap *backenddb.Snapshot, catalog *collectionCatalog, blockKey []byte, row uint64) ([]byte, error) {
 	if c == nil {
 		return nil, errors.New("collections: semantic-stream-v1 retained decode cache is nil")
 	}
 	cacheKey := string(blockKey)
+	if !c.shouldCacheBlock(cacheKey) {
+		block, found, err := collectionGetAppendAtCatalogRoot(snap, catalog, collectionRetainedSemanticStreamRootName(catalog.meta.Name), blockKey, nil)
+		if err != nil {
+			return nil, err
+		}
+		if !found {
+			return nil, fmt.Errorf("collections: semantic-stream-v1 retained block %x missing", blockKey)
+		}
+		return decodeColumnRetainedSemanticStreamV1BlockRowJSON(block, row)
+	}
 	decoded := c.blocks[cacheKey]
 	if decoded == nil {
 		block, found, err := collectionGetAppendAtCatalogRoot(snap, catalog, collectionRetainedSemanticStreamRootName(catalog.meta.Name), blockKey, nil)
@@ -564,6 +602,17 @@ func (c *columnRetainedSemanticStreamV1DecodeCache) rowJSONAtSnapshot(snap *back
 		c.store(cacheKey, decoded)
 	}
 	return decoded.rowJSON(row)
+}
+
+func (c *columnRetainedSemanticStreamV1DecodeCache) shouldCacheBlock(cacheKey string) bool {
+	if c == nil {
+		return false
+	}
+	if len(c.allowedBlocks) == 0 {
+		return true
+	}
+	_, ok := c.allowedBlocks[cacheKey]
+	return ok
 }
 
 func (c *columnRetainedSemanticStreamV1DecodeCache) store(cacheKey string, decoded *columnRetainedSemanticStreamV1DecodedBlock) {

--- a/TreeDB/collections/column_retained_vlog_placement_test.go
+++ b/TreeDB/collections/column_retained_vlog_placement_test.go
@@ -600,6 +600,16 @@ func TestColumnRetainedPayloadSemanticStreamV1ReclaimsSideBlockAfterUpdateBatch(
 		}
 	}
 	requireColumnRetainedSemanticStreamBlockDeleted(t, d, "events", blockKey)
+	replacementBlockKey, replacementRow, replacementPtr := requireColumnRetainedSemanticStreamLocatorAndBlockPointer(t, d, "events", ids[8])
+	if bytes.Equal(replacementBlockKey, blockKey) {
+		t.Fatalf("updated row still references reclaimed block %x", blockKey)
+	}
+	if replacementRow != 8 {
+		t.Fatalf("updated semantic locator row=%d want 8", replacementRow)
+	}
+	if !page.IsValueLogFileID(replacementPtr.FileID) {
+		t.Fatalf("updated semantic stream block pointer file id=%d is not value-log backed", replacementPtr.FileID)
+	}
 	if got, err := col.Get(ids[8]); err != nil {
 		t.Fatalf("Get updated semantic row: %v", err)
 	} else {
@@ -609,6 +619,104 @@ func TestColumnRetainedPayloadSemanticStreamV1ReclaimsSideBlockAfterUpdateBatch(
 			"payload": "updated-payload-008",
 			"commit": map[string]any{
 				"cid": "updated-cid-008",
+			},
+		})
+	}
+}
+
+func TestColumnRetainedPayloadSemanticStreamV1UpdateWritesReplacementBlock(t *testing.T) {
+	dir := t.TempDir()
+	enableColumnRetainedPlacementCommandWAL(t, dir)
+
+	d := openColumnRetainedPlacementDB(t, dir, backenddb.Options{})
+	defer func() { _ = d.Close() }()
+	col := createColumnRetainedSemanticStreamCollection(t, d, "events")
+	ids, docs := retainedSemanticStreamDocuments(1)
+	if _, err := col.InsertBatch(ids, docs); err != nil {
+		t.Fatalf("InsertBatch: %v", err)
+	}
+	blockKey, _, _ := requireColumnRetainedSemanticStreamLocatorAndBlockPointer(t, d, "events", ids[0])
+
+	matched, modified, err := col.Update(ids[0], func(current []byte) ([]byte, bool, error) {
+		assertRetainedSemanticStreamDocument(t, current, 0)
+		return retainedSemanticStreamUpdatedDocument(0), true, nil
+	})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if !matched || !modified {
+		t.Fatalf("Update matched=%v modified=%v want true,true", matched, modified)
+	}
+	requireColumnRetainedSemanticStreamBlockDeleted(t, d, "events", blockKey)
+	replacementBlockKey, replacementRow, _ := requireColumnRetainedSemanticStreamLocatorAndBlockPointer(t, d, "events", ids[0])
+	if bytes.Equal(replacementBlockKey, blockKey) {
+		t.Fatalf("updated row still references reclaimed block %x", blockKey)
+	}
+	if replacementRow != 0 {
+		t.Fatalf("updated semantic locator row=%d want 0", replacementRow)
+	}
+	if got, err := col.Get(ids[0]); err != nil {
+		t.Fatalf("Get updated semantic row: %v", err)
+	} else {
+		assertJSONMapEqual1875(t, got, map[string]any{
+			"row_id":  float64(0),
+			"kind":    "updated-kind-0",
+			"payload": "updated-payload-000",
+			"commit": map[string]any{
+				"cid": "updated-cid-000",
+			},
+		})
+	}
+}
+
+func TestColumnRetainedPayloadSemanticStreamV1DefaultUpdateBatchWritesReplacementBlock(t *testing.T) {
+	dir := t.TempDir()
+	enableColumnRetainedPlacementCommandWAL(t, dir)
+
+	d := openColumnRetainedPlacementDB(t, dir, backenddb.Options{})
+	defer func() { _ = d.Close() }()
+	col := createColumnRetainedSemanticStreamDefaultCollection(t, d, "events")
+	ids, docs := retainedSemanticStreamDocuments(4)
+	if _, err := col.InsertBatch(ids, docs); err != nil {
+		t.Fatalf("InsertBatch: %v", err)
+	}
+	blockKey, _, _ := requireColumnRetainedSemanticStreamLocatorAndBlockPointer(t, d, "events", ids[1])
+
+	items := make([]UpdateBatchItem, len(ids))
+	for i := range ids {
+		row := i
+		replacement := retainedSemanticStreamUpdatedDocument(row)
+		items[i] = UpdateBatchItem{
+			DocumentID: ids[i],
+			Update: func(current []byte) ([]byte, bool, error) {
+				return replacement, true, nil
+			},
+		}
+	}
+	results, err := col.UpdateBatch(items)
+	if err != nil {
+		t.Fatalf("UpdateBatch: %v", err)
+	}
+	if len(results) != len(ids) {
+		t.Fatalf("UpdateBatch results=%d want %d", len(results), len(ids))
+	}
+	requireColumnRetainedSemanticStreamBlockDeleted(t, d, "events", blockKey)
+	replacementBlockKey, replacementRow, _ := requireColumnRetainedSemanticStreamLocatorAndBlockPointer(t, d, "events", ids[1])
+	if bytes.Equal(replacementBlockKey, blockKey) {
+		t.Fatalf("updated default row still references reclaimed block %x", blockKey)
+	}
+	if replacementRow != 1 {
+		t.Fatalf("updated default semantic locator row=%d want 1", replacementRow)
+	}
+	if got, err := col.Get(ids[1]); err != nil {
+		t.Fatalf("Get updated default semantic row: %v", err)
+	} else {
+		assertJSONMapEqual1875(t, got, map[string]any{
+			"row_id":  float64(1),
+			"kind":    "updated-kind-1",
+			"payload": "updated-payload-001",
+			"commit": map[string]any{
+				"cid": "updated-cid-001",
 			},
 		})
 	}
@@ -662,6 +770,24 @@ func createColumnRetainedSemanticStreamCollection(t testing.TB, d *backenddb.DB,
 		RetainedPayload:         ColumnRetainedPayloadNonColumn,
 		RetainedPayloadEncoding: ColumnRetainedPayloadEncodingSemanticStreamV1,
 		Reconstruction:          ColumnReconstructionRetainedPayloadAndColumns,
+	}
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: name, Options: CollectionOptions{DocumentFormat: DocumentFormatJSON, ColumnStore: cfg}}); err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	return openColumnRetainedPlacementCollection(t, d, name)
+}
+
+func createColumnRetainedSemanticStreamDefaultCollection(t testing.TB, d *backenddb.DB, name string) *Collection {
+	t.Helper()
+	cfg := &ColumnStoreConfig{
+		Enabled: true,
+		Columns: []ColumnStoreColumn{
+			{Name: "row_id", Path: "row_id", ValueType: ColumnStoreValueInt64, Owner: TypedStorageOwnerRowAsset},
+			{Name: "kind", Path: "kind", ValueType: ColumnStoreValueString, Owner: TypedStorageOwnerColumnPart, Dictionary: true},
+		},
+		RetainedPayload: ColumnRetainedPayloadNonColumn,
+		Reconstruction:  ColumnReconstructionRetainedPayloadAndColumns,
 	}
 	mgr := NewCollectionManager(d)
 	if _, err := mgr.CreateCollection(&CollectionMeta{Name: name, Options: CollectionOptions{DocumentFormat: DocumentFormatJSON, ColumnStore: cfg}}); err != nil {

--- a/TreeDB/collections/column_retained_vlog_placement_test.go
+++ b/TreeDB/collections/column_retained_vlog_placement_test.go
@@ -190,8 +190,9 @@ func TestColumnRetainedPayloadLeafLogSyntheticShrink(t *testing.T) {
 			{Name: "row_id", Path: "row_id", ValueType: ColumnStoreValueInt64, Owner: TypedStorageOwnerRowAsset},
 			{Name: "kind", Path: "kind", ValueType: ColumnStoreValueString, Owner: TypedStorageOwnerColumnPart, Dictionary: true},
 		},
-		RetainedPayload: ColumnRetainedPayloadNonColumn,
-		Reconstruction:  ColumnReconstructionRetainedPayloadAndColumns,
+		RetainedPayload:         ColumnRetainedPayloadNonColumn,
+		RetainedPayloadEncoding: ColumnRetainedPayloadEncodingTemplateV1,
+		Reconstruction:          ColumnReconstructionRetainedPayloadAndColumns,
 	}
 	retainedLeafBytes := writeRetainedPlacementSynthetic(t, retainedDir, "retained_docs", retainedCfg, docs, marker)
 	if filesUnderDirContain(t, backenddb.LeafLogDirPath(retainedDir), []byte(marker)) {
@@ -639,8 +640,9 @@ func createColumnRetainedPlacementCollection(t testing.TB, d *backenddb.DB, name
 			{Name: "row_id", Path: "row_id", ValueType: ColumnStoreValueInt64, Owner: TypedStorageOwnerRowAsset},
 			{Name: "kind", Path: "kind", ValueType: ColumnStoreValueString, Owner: TypedStorageOwnerColumnPart, Dictionary: true},
 		},
-		RetainedPayload: ColumnRetainedPayloadNonColumn,
-		Reconstruction:  ColumnReconstructionRetainedPayloadAndColumns,
+		RetainedPayload:         ColumnRetainedPayloadNonColumn,
+		RetainedPayloadEncoding: ColumnRetainedPayloadEncodingTemplateV1,
+		Reconstruction:          ColumnReconstructionRetainedPayloadAndColumns,
 	}
 	mgr := NewCollectionManager(d)
 	if _, err := mgr.CreateCollection(&CollectionMeta{Name: name, Options: CollectionOptions{DocumentFormat: DocumentFormatJSON, ColumnStore: cfg}}); err != nil {

--- a/TreeDB/collections/column_retained_vlog_placement_test.go
+++ b/TreeDB/collections/column_retained_vlog_placement_test.go
@@ -359,6 +359,14 @@ func TestColumnRetainedPayloadSemanticStreamV1InsertBatchRoundTripReopen(t *test
 	if !page.IsValueLogFileID(ptr.FileID) {
 		t.Fatalf("semantic stream block pointer file id=%d is not value-log backed", ptr.FileID)
 	}
+	storedBlock := requireColumnRetainedSemanticStreamStoredBlock(t, d, "events", blockKey)
+	rawBlock, err := decodeColumnRetainedSemanticStreamV1StoredBlock(storedBlock)
+	if err != nil {
+		t.Fatalf("decode stored semantic stream block: %v", err)
+	}
+	if !bytes.HasPrefix(storedBlock, columnRetainedSemanticStreamV1BlockZSTDMagic) || len(storedBlock) >= len(rawBlock) {
+		t.Fatalf("semantic stream block stored_len=%d raw_len=%d magic=%q want compressed zstd wrapper", len(storedBlock), len(rawBlock), storedBlock[:len(columnRetainedSemanticStreamV1BlockMagic)])
+	}
 	if got, err := col.Get(ids[17]); err != nil {
 		t.Fatalf("Get semantic stream doc: %v", err)
 	} else {
@@ -824,6 +832,30 @@ func requireColumnRetainedSemanticStreamLocatorAndBlockPointer(t testing.TB, d *
 		t.Fatalf("semantic stream block pointer file id=%d is not a value-log file", blockEntry.ValuePtr.FileID)
 	}
 	return blockKey, row, blockEntry.ValuePtr
+}
+
+func requireColumnRetainedSemanticStreamStoredBlock(t testing.TB, d *backenddb.DB, collection string, blockKey []byte) []byte {
+	t.Helper()
+	snap := d.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("AcquireSnapshot returned nil")
+	}
+	defer func() { _ = snap.Close() }()
+	catalog, err := loadCollectionCatalog(snap, collection)
+	if err != nil {
+		t.Fatalf("loadCollectionCatalog: %v", err)
+	}
+	if catalog == nil {
+		t.Fatalf("collection catalog %q missing", collection)
+	}
+	block, found, err := collectionGetAppendAtCatalogRoot(snap, catalog, collectionRetainedSemanticStreamRootName(collection), blockKey, nil)
+	if err != nil {
+		t.Fatalf("semantic stream block read: %v", err)
+	}
+	if !found {
+		t.Fatalf("semantic stream block %x missing", blockKey)
+	}
+	return block
 }
 
 func requireColumnRetainedSemanticStreamBlockDeleted(t testing.TB, d *backenddb.DB, collection string, blockKey []byte) {

--- a/TreeDB/collections/column_store.go
+++ b/TreeDB/collections/column_store.go
@@ -550,7 +550,7 @@ func defaultColumnRetainedPayloadEncoding(policy ColumnRetainedPayloadPolicy) Co
 	case ColumnRetainedPayloadFull:
 		return ColumnRetainedPayloadEncodingJSON
 	case ColumnRetainedPayloadNonColumn:
-		return ColumnRetainedPayloadEncodingTemplateV1
+		return ColumnRetainedPayloadEncodingSemanticStreamV1
 	default:
 		return ColumnRetainedPayloadEncodingUnavailable
 	}

--- a/TreeDB/collections/column_store.go
+++ b/TreeDB/collections/column_store.go
@@ -138,6 +138,8 @@ const (
 	ColumnRetainedPayloadEncodingTemplateV1 = "template-v1"
 	// ColumnRetainedPayloadEncodingSemanticStreamV1 records multi-row retained
 	// payload bodies as semantic path streams in a dedicated collection root.
+	// Side-root blocks may be legacy raw crss1blk blocks or crss1zst blocks
+	// containing a zstd-compressed crss1blk payload.
 	ColumnRetainedPayloadEncodingSemanticStreamV1 = "semantic-stream-v1"
 	// ColumnRetainedPayloadEncodingNone records that no retained body is active.
 	ColumnRetainedPayloadEncodingNone = "none"

--- a/TreeDB/collections/column_store_test.go
+++ b/TreeDB/collections/column_store_test.go
@@ -1239,6 +1239,9 @@ func assertNormalizedColumnStoreMeta(t *testing.T, meta CollectionMeta) {
 	if got := cfg.RetainedPayload; got != ColumnRetainedPayloadNonColumn {
 		t.Fatalf("retained payload=%q want %q", got, ColumnRetainedPayloadNonColumn)
 	}
+	if got := cfg.RetainedPayloadEncoding; got != ColumnRetainedPayloadEncodingSemanticStreamV1 {
+		t.Fatalf("retained payload encoding=%q want %q", got, ColumnRetainedPayloadEncodingSemanticStreamV1)
+	}
 	if got := cfg.Reconstruction; got != ColumnReconstructionRetainedPayloadAndColumns {
 		t.Fatalf("reconstruction=%q want %q", got, ColumnReconstructionRetainedPayloadAndColumns)
 	}

--- a/TreeDB/collections/document_materializer.go
+++ b/TreeDB/collections/document_materializer.go
@@ -872,10 +872,6 @@ func (v *CollectionReadView) fetchRetainedPayloadsByID(ids [][]byte) (DocumentFe
 		cfg = v.catalog.meta.Options.ColumnStore.copy()
 		resolveRetained = columnStoreRetainedPayloadUsesSemanticStreamV1(&cfg)
 	}
-	var retainedSemanticCache *columnRetainedSemanticStreamV1DecodeCache
-	if resolveRetained && len(ids) >= minColumnRetainedSemanticStreamV1DecodeCacheRows {
-		retainedSemanticCache = newColumnRetainedSemanticStreamV1DecodeCache()
-	}
 	err := collectionGetManyViewAtCatalogRoot(v.snapshot, v.catalog, collectionPrimaryRootName(v.catalog.meta.Name), ids, func(i int, _ []byte, value []byte, found bool) error {
 		if i < 0 || i >= len(ids) {
 			return fmt.Errorf("collections: GetManyView callback index %d outside %d ids", i, len(ids))
@@ -886,7 +882,7 @@ func (v *CollectionReadView) fetchRetainedPayloadsByID(ids [][]byte) (DocumentFe
 		}
 		response.Results[i].Found = true
 		if resolveRetained {
-			resolved, err := resolveColumnRetainedPayloadAtSnapshotWithCache(v.snapshot, v.catalog, cfg, value, retainedSemanticCache)
+			resolved, err := resolveColumnRetainedPayloadAtSnapshot(v.snapshot, v.catalog, cfg, value)
 			if err != nil {
 				return err
 			}

--- a/TreeDB/collections/document_materializer.go
+++ b/TreeDB/collections/document_materializer.go
@@ -873,7 +873,7 @@ func (v *CollectionReadView) fetchRetainedPayloadsByID(ids [][]byte) (DocumentFe
 		resolveRetained = columnStoreRetainedPayloadUsesSemanticStreamV1(&cfg)
 	}
 	var retainedSemanticCache *columnRetainedSemanticStreamV1DecodeCache
-	if resolveRetained {
+	if resolveRetained && len(ids) >= minColumnRetainedSemanticStreamV1DecodeCacheRows {
 		retainedSemanticCache = newColumnRetainedSemanticStreamV1DecodeCache()
 	}
 	err := collectionGetManyViewAtCatalogRoot(v.snapshot, v.catalog, collectionPrimaryRootName(v.catalog.meta.Name), ids, func(i int, _ []byte, value []byte, found bool) error {

--- a/TreeDB/collections/document_materializer.go
+++ b/TreeDB/collections/document_materializer.go
@@ -872,6 +872,10 @@ func (v *CollectionReadView) fetchRetainedPayloadsByID(ids [][]byte) (DocumentFe
 		cfg = v.catalog.meta.Options.ColumnStore.copy()
 		resolveRetained = columnStoreRetainedPayloadUsesSemanticStreamV1(&cfg)
 	}
+	var retainedSemanticCache *columnRetainedSemanticStreamV1DecodeCache
+	if resolveRetained {
+		retainedSemanticCache = newColumnRetainedSemanticStreamV1DecodeCache()
+	}
 	err := collectionGetManyViewAtCatalogRoot(v.snapshot, v.catalog, collectionPrimaryRootName(v.catalog.meta.Name), ids, func(i int, _ []byte, value []byte, found bool) error {
 		if i < 0 || i >= len(ids) {
 			return fmt.Errorf("collections: GetManyView callback index %d outside %d ids", i, len(ids))
@@ -882,7 +886,7 @@ func (v *CollectionReadView) fetchRetainedPayloadsByID(ids [][]byte) (DocumentFe
 		}
 		response.Results[i].Found = true
 		if resolveRetained {
-			resolved, err := resolveColumnRetainedPayloadAtSnapshot(v.snapshot, v.catalog, cfg, value)
+			resolved, err := resolveColumnRetainedPayloadAtSnapshotWithCache(v.snapshot, v.catalog, cfg, value, retainedSemanticCache)
 			if err != nil {
 				return err
 			}

--- a/TreeDB/collections/typed_storage_naming_test.go
+++ b/TreeDB/collections/typed_storage_naming_test.go
@@ -384,7 +384,7 @@ var typedStorageLegacyNameAllowlist = []typedStorageLegacyNameAllowlistEntry{
 	{path: "TreeDB/collections/column_retained_payload_audit.go", classification: typedStorageLegacyCompatibility, matchingLines: 8, occurrences: 8},
 	{path: "TreeDB/collections/column_retained_payload_audit_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 29, occurrences: 30},
 	{path: "TreeDB/collections/column_retained_semantic_stream.go", classification: typedStorageLegacyCompatibility, matchingLines: 8, occurrences: 8},
-	{path: "TreeDB/collections/column_retained_vlog_placement_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 18, occurrences: 18},
+	{path: "TreeDB/collections/column_retained_vlog_placement_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 23, occurrences: 23},
 	{path: "TreeDB/collections/column_semantics.go", classification: typedStorageLegacyCompatibility, matchingLines: 34, occurrences: 34},
 	{path: "TreeDB/collections/dense_numeric_vector.go", classification: typedStorageLegacyCompatibility, matchingLines: 32, occurrences: 41},
 	{path: "TreeDB/collections/dense_numeric_vector_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 35, occurrences: 38},

--- a/TreeDB/collections/typed_storage_naming_test.go
+++ b/TreeDB/collections/typed_storage_naming_test.go
@@ -383,7 +383,7 @@ var typedStorageLegacyNameAllowlist = []typedStorageLegacyNameAllowlistEntry{
 	{path: "TreeDB/collections/column_reconstruction_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 27, occurrences: 31},
 	{path: "TreeDB/collections/column_retained_payload_audit.go", classification: typedStorageLegacyCompatibility, matchingLines: 8, occurrences: 8},
 	{path: "TreeDB/collections/column_retained_payload_audit_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 28, occurrences: 29},
-	{path: "TreeDB/collections/column_retained_semantic_stream.go", classification: typedStorageLegacyCompatibility, matchingLines: 7, occurrences: 7},
+	{path: "TreeDB/collections/column_retained_semantic_stream.go", classification: typedStorageLegacyCompatibility, matchingLines: 8, occurrences: 8},
 	{path: "TreeDB/collections/column_retained_vlog_placement_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 18, occurrences: 18},
 	{path: "TreeDB/collections/column_semantics.go", classification: typedStorageLegacyCompatibility, matchingLines: 34, occurrences: 34},
 	{path: "TreeDB/collections/dense_numeric_vector.go", classification: typedStorageLegacyCompatibility, matchingLines: 32, occurrences: 41},

--- a/TreeDB/collections/typed_storage_naming_test.go
+++ b/TreeDB/collections/typed_storage_naming_test.go
@@ -383,7 +383,7 @@ var typedStorageLegacyNameAllowlist = []typedStorageLegacyNameAllowlistEntry{
 	{path: "TreeDB/collections/column_reconstruction_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 27, occurrences: 31},
 	{path: "TreeDB/collections/column_retained_payload_audit.go", classification: typedStorageLegacyCompatibility, matchingLines: 8, occurrences: 8},
 	{path: "TreeDB/collections/column_retained_payload_audit_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 28, occurrences: 29},
-	{path: "TreeDB/collections/column_retained_semantic_stream.go", classification: typedStorageLegacyCompatibility, matchingLines: 6, occurrences: 6},
+	{path: "TreeDB/collections/column_retained_semantic_stream.go", classification: typedStorageLegacyCompatibility, matchingLines: 7, occurrences: 7},
 	{path: "TreeDB/collections/column_retained_vlog_placement_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 18, occurrences: 18},
 	{path: "TreeDB/collections/column_semantics.go", classification: typedStorageLegacyCompatibility, matchingLines: 34, occurrences: 34},
 	{path: "TreeDB/collections/dense_numeric_vector.go", classification: typedStorageLegacyCompatibility, matchingLines: 32, occurrences: 41},

--- a/TreeDB/collections/typed_storage_naming_test.go
+++ b/TreeDB/collections/typed_storage_naming_test.go
@@ -382,7 +382,7 @@ var typedStorageLegacyNameAllowlist = []typedStorageLegacyNameAllowlistEntry{
 	{path: "TreeDB/collections/column_reconstruction.go", classification: typedStorageLegacyCompatibility, matchingLines: 56, occurrences: 71},
 	{path: "TreeDB/collections/column_reconstruction_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 27, occurrences: 31},
 	{path: "TreeDB/collections/column_retained_payload_audit.go", classification: typedStorageLegacyCompatibility, matchingLines: 8, occurrences: 8},
-	{path: "TreeDB/collections/column_retained_payload_audit_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 28, occurrences: 29},
+	{path: "TreeDB/collections/column_retained_payload_audit_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 29, occurrences: 30},
 	{path: "TreeDB/collections/column_retained_semantic_stream.go", classification: typedStorageLegacyCompatibility, matchingLines: 8, occurrences: 8},
 	{path: "TreeDB/collections/column_retained_vlog_placement_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 18, occurrences: 18},
 	{path: "TreeDB/collections/column_semantics.go", classification: typedStorageLegacyCompatibility, matchingLines: 34, occurrences: 34},

--- a/TreeDB/db/ordered_root_publish_test.go
+++ b/TreeDB/db/ordered_root_publish_test.go
@@ -3,6 +3,8 @@ package db
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/binary"
 	"errors"
 	"reflect"
 	"strconv"
@@ -3279,6 +3281,509 @@ func TestPublishOrderedRootDeltaGroupWithSystemBuilder_AcceptsLargeDeltaValueLog
 	}
 	if !bytes.Equal(entry.Value, largeValue) {
 		t.Fatalf("large value mismatch: got %d bytes want %d", len(entry.Value), len(largeValue))
+	}
+}
+
+type orderedRootMixedKeyFamily struct {
+	prefix string
+	count  int
+}
+
+var orderedRootMixedKeyFamilies = []orderedRootMixedKeyFamily{
+	{"like-", 9_000},
+	{"post-", 2_000},
+	{"graph-", 9_000},
+	{"identity-", 1_000},
+}
+
+func newOrderedRootMixedKeyFamilyTable(tb testing.TB) (memtable.Table, []byte) {
+	tb.Helper()
+	total := orderedRootMixedKeyFamilyRowCount()
+	table, values := newOrderedRootMixedKeyFamilyTableRange(tb, 0, total)
+	identityZeroValue := values["identity-0"]
+	if identityZeroValue == nil {
+		tb.Fatal("test fixture did not create identity-0")
+	}
+	return table, identityZeroValue
+}
+
+func orderedRootMixedKeyFamilyRowCount() int {
+	total := 0
+	for _, family := range orderedRootMixedKeyFamilies {
+		total += family.count
+	}
+	return total
+}
+
+func orderedRootMixedKeyFamilyRowKey(row int) string {
+	for _, family := range orderedRootMixedKeyFamilies {
+		if row < family.count {
+			return family.prefix + strconv.Itoa(row)
+		}
+		row -= family.count
+	}
+	return ""
+}
+
+func newOrderedRootMixedKeyFamilyTableRange(tb testing.TB, start, end int) (memtable.Table, map[string][]byte) {
+	tb.Helper()
+	total := orderedRootMixedKeyFamilyRowCount()
+	if start < 0 || end < start || end > total {
+		tb.Fatalf("invalid row range [%d,%d) total=%d", start, end, total)
+	}
+	table := memtable.NewAppendOnlyWithEntryCapacity(total)
+	values := make(map[string][]byte)
+	for row := start; row < end; row++ {
+		key := orderedRootMixedKeyFamilyRowKey(row)
+		if key == "" {
+			tb.Fatalf("missing key for row %d", row)
+		}
+		value := orderedRootSemanticStreamLocatorValueForTest(row)
+		if key == "identity-0" {
+			values[key] = append([]byte(nil), value...)
+		}
+		table.Set([]byte(key), value)
+	}
+	table.Freeze()
+	return table, values
+}
+
+func orderedRootSemanticStreamLocatorValueForTest(row int) []byte {
+	blockKey := sha256.Sum256([]byte("block-" + strconv.Itoa(row/4096)))
+	out := make([]byte, 0, len("crss1loc\x00")+sha256.Size+binary.MaxVarintLen64)
+	out = append(out, []byte("crss1loc\x00")...)
+	out = append(out, blockKey[:]...)
+	out = binary.AppendUvarint(out, uint64(row%4096))
+	return out
+}
+
+func TestPublishOrderedRootValueLogLeavesColdBuildSeekMixedKeyFamilies(t *testing.T) {
+	dir := t.TempDir()
+	db, err := Open(Options{Dir: dir, IndexOuterLeavesInValueLog: true})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	leafLog := newRewriteWriter(ValueLogDirPath(dir), 0, 0, 64<<20)
+	db.SetLeafPageLog(leafLog)
+	defer func() {
+		_ = leafLog.Close()
+		_ = db.Close()
+	}()
+
+	table, value := newOrderedRootMixedKeyFamilyTable(t)
+
+	_, rootIDs, err := db.PublishOrderedRootGroup(nil, []OrderedRootPublishInput{{
+		BaseRoot:      0,
+		Iter:          table.NewIterator(nil, nil),
+		StoragePolicy: OrderedRootStorageValueLogLeaves,
+	}})
+	if err != nil {
+		t.Fatalf("publish value-log root: %v", err)
+	}
+	if len(rootIDs) != 1 || rootIDs[0] == 0 {
+		t.Fatalf("rootIDs=%v want one non-zero root", rootIDs)
+	}
+
+	snap := db.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("expected snapshot")
+	}
+	defer func() { _ = snap.Close() }()
+
+	entry, err := snap.GetEntryAtRoot(rootIDs[0], []byte("identity-0"))
+	if err != nil {
+		t.Fatalf("GetEntryAtRoot(identity-0): %v", err)
+	}
+	if !bytes.Equal(entry.Value, value) {
+		t.Fatalf("identity-0 value len=%d want %d", len(entry.Value), len(value))
+	}
+
+	it, err := snap.IteratorAtRoot(rootIDs[0], []byte("identity-0"), nil)
+	if err != nil {
+		t.Fatalf("IteratorAtRoot(identity-0): %v", err)
+	}
+	defer func() { _ = it.Close() }()
+	if !it.Valid() {
+		t.Fatalf("seek identity-0 invalid: %v", it.Error())
+	}
+	if got := string(it.UnsafeKey()); got != "identity-0" {
+		t.Fatalf("seek identity-0 landed on %q", got)
+	}
+}
+
+func TestPublishOrderedRootDeltaGroupValueLogLeavesColdBuildSeekMixedKeyFamilies(t *testing.T) {
+	dir := t.TempDir()
+	db, err := Open(Options{Dir: dir, IndexOuterLeavesInValueLog: true})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	leafLog := newRewriteWriter(ValueLogDirPath(dir), 0, 0, 64<<20)
+	db.SetLeafPageLog(leafLog)
+	defer func() {
+		_ = leafLog.Close()
+		_ = db.Close()
+	}()
+
+	table, value := newOrderedRootMixedKeyFamilyTable(t)
+
+	_, rootIDs, err := db.PublishOrderedRootDeltaGroupWithSystemDeltaBuilder([]OrderedRootDeltaPublishInput{{
+		BaseRoot:      0,
+		Iter:          table.NewIterator(nil, nil),
+		StoragePolicy: OrderedRootStorageValueLogLeaves,
+	}}, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+		return mustFrozenSystemMemtable(t, "sys/root", strconv.FormatUint(rootIDs[0], 10)).NewIterator(nil, nil), nil
+	})
+	if err != nil {
+		t.Fatalf("publish value-log root: %v", err)
+	}
+	if len(rootIDs) != 1 || rootIDs[0] == 0 {
+		t.Fatalf("rootIDs=%v want one non-zero root", rootIDs)
+	}
+
+	snap := db.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("expected snapshot")
+	}
+	defer func() { _ = snap.Close() }()
+
+	entry, err := snap.GetEntryAtRoot(rootIDs[0], []byte("identity-0"))
+	if err != nil {
+		t.Fatalf("GetEntryAtRoot(identity-0): %v", err)
+	}
+	if !bytes.Equal(entry.Value, value) {
+		t.Fatalf("identity-0 value len=%d want %d", len(entry.Value), len(value))
+	}
+
+	it, err := snap.IteratorAtRoot(rootIDs[0], []byte("identity-0"), nil)
+	if err != nil {
+		t.Fatalf("IteratorAtRoot(identity-0): %v", err)
+	}
+	defer func() { _ = it.Close() }()
+	if !it.Valid() {
+		t.Fatalf("seek identity-0 invalid: %v", it.Error())
+	}
+	if got := string(it.UnsafeKey()); got != "identity-0" {
+		t.Fatalf("seek identity-0 landed on %q", got)
+	}
+}
+
+func TestPublishOrderedRootDeltaGroupCommandWALContextValueLogLeavesColdBuildSeekMixedKeyFamilies(t *testing.T) {
+	dir := t.TempDir()
+	enableCommandWALFormat(t, dir)
+	db, err := Open(Options{Dir: dir, DisableBackgroundPrune: true, IndexOuterLeavesInValueLog: true})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	if !db.HasValueLogAppender() {
+		t.Fatal("command-WAL DB did not install value-log appender")
+	}
+
+	table, value := newOrderedRootMixedKeyFamilyTable(t)
+
+	var seenContext bool
+	_, rootIDs, err := db.PublishOrderedRootDeltaGroupWithPreflightCommandWALContextRootBuilderAndSystemDeltaBuilder(
+		[]OrderedRootDeltaPublishInput{{
+			BaseRoot:      0,
+			Iter:          table.NewIterator(nil, nil),
+			StoragePolicy: OrderedRootStorageValueLogLeaves,
+		}},
+		nil,
+		mustRawKVCommandWALIntent(t, db, "cmd/root-initial", "1"),
+		func(ctx CommandWALPublishContext) ([]OrderedRootDeltaPublishInput, error) {
+			seenContext = ctx.AppliedCommandLSN != 0
+			return nil, nil
+		},
+		func(ctx CommandWALPublishContext, rootIDs []uint64) (iterator.UnsafeIterator, error) {
+			if ctx.AppliedCommandLSN == 0 {
+				t.Fatalf("AppliedCommandLSN=0 in system builder")
+			}
+			return mustFrozenSystemMemtable(t, "sys/root", strconv.FormatUint(rootIDs[0], 10)).NewIterator(nil, nil), nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("publish value-log root: %v", err)
+	}
+	if !seenContext {
+		t.Fatal("context root builder did not observe command WAL context")
+	}
+	if len(rootIDs) != 1 || rootIDs[0] == 0 {
+		t.Fatalf("rootIDs=%v want one non-zero root", rootIDs)
+	}
+
+	snap := db.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("expected snapshot")
+	}
+	defer func() { _ = snap.Close() }()
+
+	entry, err := snap.GetEntryAtRoot(rootIDs[0], []byte("identity-0"))
+	if err != nil {
+		t.Fatalf("GetEntryAtRoot(identity-0): %v", err)
+	}
+	if !bytes.Equal(entry.Value, value) {
+		t.Fatalf("identity-0 value len=%d want %d", len(entry.Value), len(value))
+	}
+
+	it, err := snap.IteratorAtRoot(rootIDs[0], []byte("identity-0"), nil)
+	if err != nil {
+		t.Fatalf("IteratorAtRoot(identity-0): %v", err)
+	}
+	defer func() { _ = it.Close() }()
+	if !it.Valid() {
+		t.Fatalf("seek identity-0 invalid: %v", it.Error())
+	}
+	if got := string(it.UnsafeKey()); got != "identity-0" {
+		t.Fatalf("seek identity-0 landed on %q", got)
+	}
+}
+
+func TestPublishOrderedRootDeltaGroupCommandWALContextValueLogLeavesSplitSeekMixedKeyFamilies(t *testing.T) {
+	dir := t.TempDir()
+	enableCommandWALFormat(t, dir)
+	db, err := Open(Options{Dir: dir, DisableBackgroundPrune: true, IndexOuterLeavesInValueLog: true})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	if !db.HasValueLogAppender() {
+		t.Fatal("command-WAL DB did not install value-log appender")
+	}
+
+	total := orderedRootMixedKeyFamilyRowCount()
+	mid := total / 2
+	first, _ := newOrderedRootMixedKeyFamilyTableRange(t, 0, mid)
+	second, values := newOrderedRootMixedKeyFamilyTableRange(t, mid, total)
+	value := values["identity-0"]
+	if value == nil {
+		t.Fatal("second split did not contain identity-0")
+	}
+
+	publish := func(baseRoot uint64, table memtable.Table, label string) uint64 {
+		t.Helper()
+		var seenContext bool
+		_, rootIDs, err := db.PublishOrderedRootDeltaGroupWithPreflightCommandWALContextRootBuilderAndSystemDeltaBuilder(
+			[]OrderedRootDeltaPublishInput{{
+				BaseRoot:      baseRoot,
+				Iter:          table.NewIterator(nil, nil),
+				StoragePolicy: OrderedRootStorageValueLogLeaves,
+			}},
+			nil,
+			mustRawKVCommandWALIntent(t, db, "cmd/"+label, "1"),
+			func(ctx CommandWALPublishContext) ([]OrderedRootDeltaPublishInput, error) {
+				seenContext = ctx.AppliedCommandLSN != 0
+				return nil, nil
+			},
+			func(ctx CommandWALPublishContext, rootIDs []uint64) (iterator.UnsafeIterator, error) {
+				if ctx.AppliedCommandLSN == 0 {
+					t.Fatalf("AppliedCommandLSN=0 in system builder")
+				}
+				return mustFrozenSystemMemtable(t, "sys/"+label, strconv.FormatUint(rootIDs[0], 10)).NewIterator(nil, nil), nil
+			},
+		)
+		if err != nil {
+			t.Fatalf("publish %s: %v", label, err)
+		}
+		if !seenContext {
+			t.Fatalf("%s context root builder did not observe command WAL context", label)
+		}
+		if len(rootIDs) != 1 || rootIDs[0] == 0 {
+			t.Fatalf("%s rootIDs=%v want one non-zero root", label, rootIDs)
+		}
+		return rootIDs[0]
+	}
+
+	rootID := publish(0, first, "split-first")
+	rootID = publish(rootID, second, "split-second")
+
+	snap := db.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("expected snapshot")
+	}
+	defer func() { _ = snap.Close() }()
+
+	entry, err := snap.GetEntryAtRoot(rootID, []byte("identity-0"))
+	if err != nil {
+		t.Fatalf("GetEntryAtRoot(identity-0): %v", err)
+	}
+	if !bytes.Equal(entry.Value, value) {
+		t.Fatalf("identity-0 value len=%d want %d", len(entry.Value), len(value))
+	}
+
+	it, err := snap.IteratorAtRoot(rootID, []byte("identity-0"), nil)
+	if err != nil {
+		t.Fatalf("IteratorAtRoot(identity-0): %v", err)
+	}
+	defer func() { _ = it.Close() }()
+	if !it.Valid() {
+		t.Fatalf("seek identity-0 invalid: %v", it.Error())
+	}
+	if got := string(it.UnsafeKey()); got != "identity-0" {
+		t.Fatalf("seek identity-0 landed on %q", got)
+	}
+}
+
+func TestPublishOrderedRootDeltaBatchValueLogLeavesColdBuildSeekMixedKeyFamilies(t *testing.T) {
+	dir := t.TempDir()
+	db, err := Open(Options{Dir: dir, IndexOuterLeavesInValueLog: true})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	leafLog := newRewriteWriter(ValueLogDirPath(dir), 0, 0, 64<<20)
+	db.SetLeafPageLog(leafLog)
+	defer func() {
+		_ = leafLog.Close()
+		_ = db.Close()
+	}()
+
+	table, value := newOrderedRootMixedKeyFamilyTable(t)
+
+	iter := table.NewIterator(nil, nil)
+	delta, err := OrderedRootDeltaBatchFromIterator(iter)
+	_ = iter.Close()
+	if err != nil {
+		t.Fatalf("OrderedRootDeltaBatchFromIterator: %v", err)
+	}
+	defer func() { _ = delta.Close() }()
+
+	_, rootIDs, err := db.PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder([]OrderedRootDeltaBatchPublishInput{{
+		BaseRoot:      0,
+		Delta:         delta,
+		StoragePolicy: OrderedRootStorageValueLogLeaves,
+	}}, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+		return mustFrozenSystemMemtable(t, "sys/root", strconv.FormatUint(rootIDs[0], 10)).NewIterator(nil, nil), nil
+	})
+	if err != nil {
+		t.Fatalf("publish value-log root: %v", err)
+	}
+	if len(rootIDs) != 1 || rootIDs[0] == 0 {
+		t.Fatalf("rootIDs=%v want one non-zero root", rootIDs)
+	}
+
+	snap := db.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("expected snapshot")
+	}
+	defer func() { _ = snap.Close() }()
+
+	entry, err := snap.GetEntryAtRoot(rootIDs[0], []byte("identity-0"))
+	if err != nil {
+		t.Fatalf("GetEntryAtRoot(identity-0): %v", err)
+	}
+	if !bytes.Equal(entry.Value, value) {
+		t.Fatalf("identity-0 value len=%d want %d", len(entry.Value), len(value))
+	}
+
+	it, err := snap.IteratorAtRoot(rootIDs[0], []byte("identity-0"), nil)
+	if err != nil {
+		t.Fatalf("IteratorAtRoot(identity-0): %v", err)
+	}
+	defer func() { _ = it.Close() }()
+	if !it.Valid() {
+		t.Fatalf("seek identity-0 invalid: %v", it.Error())
+	}
+	if got := string(it.UnsafeKey()); got != "identity-0" {
+		t.Fatalf("seek identity-0 landed on %q", got)
+	}
+}
+
+func TestPublishOrderedRootCommandWALValueLogLeavesSeekAfterMixedKeyMutations(t *testing.T) {
+	dir := t.TempDir()
+	enableCommandWALFormat(t, dir)
+	db, err := Open(Options{Dir: dir, DisableBackgroundPrune: true, IndexOuterLeavesInValueLog: true})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	if !db.HasValueLogAppender() {
+		t.Fatal("command-WAL DB did not install value-log appender")
+	}
+
+	table, value := newOrderedRootMixedKeyFamilyTable(t)
+
+	iter := table.NewIterator(nil, nil)
+	initialDelta, err := OrderedRootDeltaBatchFromIterator(iter)
+	_ = iter.Close()
+	if err != nil {
+		t.Fatalf("OrderedRootDeltaBatchFromIterator(initial): %v", err)
+	}
+	defer func() { _ = initialDelta.Close() }()
+
+	_, rootIDs, err := db.PublishOrderedRootDeltaBatchGroupWithCommandWALAndSystemDeltaBuilder([]OrderedRootDeltaBatchPublishInput{{
+		BaseRoot:      0,
+		Delta:         initialDelta,
+		StoragePolicy: OrderedRootStorageValueLogLeaves,
+	}}, mustRawKVCommandWALIntent(t, db, "cmd/root-initial", "1"), func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+		return mustFrozenSystemMemtable(t, "sys/root", strconv.FormatUint(rootIDs[0], 10)).NewIterator(nil, nil), nil
+	})
+	if err != nil {
+		t.Fatalf("publish value-log root: %v", err)
+	}
+	if len(rootIDs) != 1 || rootIDs[0] == 0 {
+		t.Fatalf("rootIDs=%v want one non-zero root", rootIDs)
+	}
+	rootID := rootIDs[0]
+
+	publishSet := func(key string, suffix byte) {
+		t.Helper()
+		deltaTable, err := memtable.NewWithCapacityMode(1, memtable.ModeHashSorted)
+		if err != nil {
+			t.Fatalf("new delta table: %v", err)
+		}
+		updated := bytes.Repeat([]byte{suffix}, 43)
+		deltaTable.Set([]byte(key), updated)
+		deltaTable.Freeze()
+		iter := deltaTable.NewIterator(nil, nil)
+		delta, err := OrderedRootDeltaBatchFromIterator(iter)
+		_ = iter.Close()
+		if err != nil {
+			t.Fatalf("OrderedRootDeltaBatchFromIterator(%s): %v", key, err)
+		}
+		defer func() { _ = delta.Close() }()
+
+		_, updatedRoots, err := db.PublishOrderedRootDeltaBatchGroupWithCommandWALAndSystemDeltaBuilder([]OrderedRootDeltaBatchPublishInput{{
+			BaseRoot:      rootID,
+			Delta:         delta,
+			StoragePolicy: OrderedRootStorageValueLogLeaves,
+		}}, mustRawKVCommandWALIntent(t, db, "cmd/"+key, "1"), func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+			return mustFrozenSystemMemtable(t, "sys/root", strconv.FormatUint(rootIDs[0], 10)).NewIterator(nil, nil), nil
+		})
+		if err != nil {
+			t.Fatalf("publish delta %s: %v", key, err)
+		}
+		if len(updatedRoots) != 1 || updatedRoots[0] == 0 {
+			t.Fatalf("updatedRoots=%v want one non-zero root", updatedRoots)
+		}
+		rootID = updatedRoots[0]
+	}
+
+	publishSet("post-0", 'p')
+	publishSet("post-1", 'q')
+
+	snap := db.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("expected snapshot")
+	}
+	defer func() { _ = snap.Close() }()
+
+	entry, err := snap.GetEntryAtRoot(rootID, []byte("identity-0"))
+	if err != nil {
+		t.Fatalf("GetEntryAtRoot(identity-0): %v", err)
+	}
+	if !bytes.Equal(entry.Value, value) {
+		t.Fatalf("identity-0 value len=%d want %d", len(entry.Value), len(value))
+	}
+
+	it, err := snap.IteratorAtRoot(rootID, []byte("identity-0"), nil)
+	if err != nil {
+		t.Fatalf("IteratorAtRoot(identity-0): %v", err)
+	}
+	defer func() { _ = it.Close() }()
+	if !it.Valid() {
+		t.Fatalf("seek identity-0 invalid: %v", it.Error())
+	}
+	if got := string(it.UnsafeKey()); got != "identity-0" {
+		t.Fatalf("seek identity-0 landed on %q", got)
 	}
 }
 

--- a/TreeDB/docs/spec/storage-format.md
+++ b/TreeDB/docs/spec/storage-format.md
@@ -141,6 +141,13 @@ Collection document payload encodings are defined separately in
 template-v1 collections store compact `TD1D` primary documents and persist the
 template ID map in the collection-local `<collection>/templates` ordered root.
 
+Column-store collections using the non-column retained-payload policy default to
+`semantic-stream-v1`. Insert-batch publication stores compact semantic-stream
+locators in the primary collection root and writes retained scalar streams into
+the collection-local retained semantic-stream side root. Explicit
+`retained_payload_encoding: "template-v1"` remains a supported compatibility
+encoding for non-column retained payloads.
+
 ## 3.3 Collection Text Index Root Payloads
 
 Collection text-index roots are ordinary ordered roots whose keys and values are

--- a/TreeDB/docs/spec/storage-format.md
+++ b/TreeDB/docs/spec/storage-format.md
@@ -148,6 +148,74 @@ the collection-local retained semantic-stream side root. Explicit
 `retained_payload_encoding: "template-v1"` remains a supported compatibility
 encoding for non-column retained payloads.
 
+Semantic-stream-v1 retained payload bytes are durable ordered-root values. All
+integer varints below use Go `binary.PutUvarint` encodings.
+
+Primary collection root value:
+
+```text
+bytes[9]   Magic = "crss1loc\0"
+bytes[32]  BlockKey = SHA-256 of the stored side-root block value bytes
+uvarint    Row = zero-based row ordinal inside that block
+```
+
+Retained semantic-stream side root:
+
+```text
+Root name: <collection>/retained/semantic-stream-v1
+Key:       BlockKey
+Value:     StoredBlock
+```
+
+The side-root block key is the SHA-256 digest of the exact stored block value,
+not necessarily the decoded raw block. Blocks contain at most 4096 retained
+documents; single-row insert/update batches still produce one side-root block
+and one primary locator per retained document.
+
+Raw side-root block value:
+
+```text
+bytes[9]  Magic = "crss1blk\0"
+uvarint   RowCount
+uvarint   PathCount
+
+repeated PathCount times:
+  uvarint   SegmentCount
+  repeated SegmentCount times:
+    uvarint   SegmentByteLength
+    bytes     UTF-8 JSON object path segment
+  uvarint   EntryCount
+  repeated EntryCount times:
+    uvarint   RowDelta
+    uvarint   ValueByteLength
+    bytes     Raw retained JSON scalar/object/array bytes for that path row
+```
+
+Paths are sorted by their dot-joined path key. Entries within each path are
+sorted by row; the first `RowDelta` is the absolute row and subsequent
+`RowDelta` values are deltas from the previous row. Retained root documents must
+be JSON objects after declared column paths are removed.
+
+Stored side-root block value:
+
+```text
+bytes[9]  Magic = "crss1blk\0"
+...       Raw block body above
+```
+
+or, when compression is smaller and the raw block is within the implementation
+compression limit:
+
+```text
+bytes[9]  Magic = "crss1zst\0"
+uvarint   DecodedRawBlockByteLength
+bytes     zstd frame for the complete raw "crss1blk\0" block
+```
+
+Decoders must accept both raw `crss1blk\0` blocks and compressed `crss1zst\0`
+wrappers. A `crss1zst\0` wrapper decodes to one complete raw block, and the
+decoded byte length must exactly match `DecodedRawBlockByteLength`.
+
 ## 3.3 Collection Text Index Root Payloads
 
 Collection text-index roots are ordinary ordered roots whose keys and values are

--- a/TreeDB/zipper/zipper.go
+++ b/TreeDB/zipper/zipper.go
@@ -2197,7 +2197,7 @@ func (z *Zipper) mergeInternal(oldNode *node.Node, builder *node.Builder, ops []
 			}
 			childOps := ops[startOpIdx:opIdx]
 			childLowKey := childLowKeyForOps(lowKey, childOps)
-			childRanges := deleteRangesForSpan(ranges, lowKey, childHigh)
+			childRanges := deleteRangesForSpan(ranges, childLowKey, childHigh)
 
 			newChildRef := curChild
 			var childSplits []Split

--- a/TreeDB/zipper/zipper.go
+++ b/TreeDB/zipper/zipper.go
@@ -2093,6 +2093,15 @@ func (z *Zipper) mergeInternal(oldNode *node.Node, builder *node.Builder, ops []
 		keyArena = append(keyArena, src...)
 		return keyArena[start : start+len(src)]
 	}
+	childLowKeyForOps := func(lowKey []byte, childOps []batch.Entry) []byte {
+		if len(lowKey) == 0 || len(childOps) == 0 {
+			return lowKey
+		}
+		if bytes.Compare(childOps[0].Key, lowKey) < 0 {
+			return childOps[0].Key
+		}
+		return lowKey
+	}
 
 	target := builder
 	appendInternalMaybeCopied := func(sourceIndex uint16, key []byte, childRef page.ChildRef, first bool, copySourceLeafLog bool) error {
@@ -2187,12 +2196,13 @@ func (z *Zipper) mergeInternal(oldNode *node.Node, builder *node.Builder, ops []
 				break
 			}
 			childOps := ops[startOpIdx:opIdx]
+			childLowKey := childLowKeyForOps(lowKey, childOps)
 			childRanges := deleteRangesForSpan(ranges, lowKey, childHigh)
 
 			newChildRef := curChild
 			var childSplits []Split
 			if len(childOps) > 0 || len(childRanges) > 0 {
-				newChildRef, childSplits, err = z.writeRecursive(curChild, childOps, childRanges, maintenance, budget, metrics, lowKey, childHigh, retired, scratch, false)
+				newChildRef, childSplits, err = z.writeRecursive(curChild, childOps, childRanges, maintenance, budget, metrics, childLowKey, childHigh, retired, scratch, false)
 				if err != nil {
 					return page.ChildRef{}, nil, err
 				}
@@ -2203,7 +2213,7 @@ func (z *Zipper) mergeInternal(oldNode *node.Node, builder *node.Builder, ops []
 					return page.ChildRef{}, nil, err
 				}
 			} else {
-				if err := appendInternal(lowKey, newChildRef, firstEntry); err != nil {
+				if err := appendInternal(childLowKey, newChildRef, firstEntry); err != nil {
 					return page.ChildRef{}, nil, err
 				}
 			}
@@ -2266,6 +2276,10 @@ func (z *Zipper) mergeInternal(oldNode *node.Node, builder *node.Builder, ops []
 			break
 		}
 		children[i].ops = ops[startOpIdx:opIdx]
+		if len(children[i].ops) > 0 {
+			children[i].low = childLowKeyForOps(children[i].low, children[i].ops)
+			children[i].key = children[i].low
+		}
 	}
 
 	activeChildren := 0

--- a/cmd/unified_bench/README.md
+++ b/cmd/unified_bench/README.md
@@ -359,11 +359,12 @@ CPU/allocation profiles. Omit it, or pass `all`, for the default full
 q1-q5/q5_metadata suite. Duplicate query names are rejected so benchprof
 tables and artifact labels stay unambiguous.
 
-Use `-column-store-retained-payload-encoding semantic-stream-v1`, or set
-`TREEDB_COLUMN_STORE_RETAINED_PAYLOAD_ENCODING=semantic-stream-v1`, to run the
-opt-in retained-payload semantic stream candidate for storage-parity evidence.
-The default remains `template-v1`, and `b_tree_index_baseline` still keeps full
-retained JSON so that index-baseline comparisons remain unchanged.
+Column-store non-column retained payloads default to `semantic-stream-v1` so the
+production storage-parity path uses retained semantic-stream side-root blocks.
+Use `-column-store-retained-payload-encoding template-v1`, or set
+`TREEDB_COLUMN_STORE_RETAINED_PAYLOAD_ENCODING=template-v1`, to run the legacy
+template-v1 retained-payload path for comparison. `b_tree_index_baseline` still
+keeps full retained JSON so that index-baseline comparisons remain unchanged.
 
 The suite writes:
 

--- a/cmd/unified_bench/suite_column_store.go
+++ b/cmd/unified_bench/suite_column_store.go
@@ -2145,8 +2145,7 @@ func columnStoreSuiteRetainedPayloadAccounting(events []columnStoreFixtureEvent,
 		return bytesTotal, "full row payload retained", nil
 	}
 	if cfg.RetainedPayload == collections.ColumnRetainedPayloadNonColumn &&
-		columnStoreSuiteEffectiveRetainedPayloadEncoding(cfg) == collections.ColumnRetainedPayloadEncodingSemanticStreamV1 &&
-		len(events) > 1 {
+		columnStoreSuiteEffectiveRetainedPayloadEncoding(cfg) == collections.ColumnRetainedPayloadEncodingSemanticStreamV1 {
 		documents := make([][]byte, len(events))
 		for i := range events {
 			documents[i] = events[i].Doc

--- a/cmd/unified_bench/suite_column_store.go
+++ b/cmd/unified_bench/suite_column_store.go
@@ -113,7 +113,7 @@ var (
 	columnStoreSuiteTypedAdaptiveTargetBytesArg = flag.Int("column-store-typed-adaptive-target-bytes", 0, "Benchmark-only typed_column_part adaptive target raw bytes per mark/granule (0 uses typedcolumn default when adaptive is enabled)")
 	columnStoreSuiteTypedAdaptiveMinRowsArg     = flag.Int("column-store-typed-adaptive-min-rows", 0, "Benchmark-only typed_column_part adaptive minimum rows (0 uses typedcolumn default when adaptive is enabled)")
 	columnStoreSuiteTypedAdaptiveMaxRowsArg     = flag.Int("column-store-typed-adaptive-max-rows", 0, "Benchmark-only typed_column_part adaptive maximum rows (0 uses rows-per-granule/default when adaptive is enabled)")
-	columnStoreSuiteRetainedPayloadEncodingArg  = flag.String("column-store-retained-payload-encoding", "", "Retained-payload encoding override for -suite column_store non-column retained payloads (default/template-v1,json,semantic-stream-v1). Can also be set with TREEDB_COLUMN_STORE_RETAINED_PAYLOAD_ENCODING; b_tree_index_baseline remains full-retained JSON.")
+	columnStoreSuiteRetainedPayloadEncodingArg  = flag.String("column-store-retained-payload-encoding", "", "Retained-payload encoding override for -suite column_store non-column retained payloads (default/semantic-stream-v1,template-v1,json). Can also be set with TREEDB_COLUMN_STORE_RETAINED_PAYLOAD_ENCODING; b_tree_index_baseline remains full-retained JSON.")
 
 	columnStoreSuiteAcceptedForcedPaths = []string{
 		columnStorePathRowStoreBaseline,
@@ -2145,7 +2145,7 @@ func columnStoreSuiteRetainedPayloadAccounting(events []columnStoreFixtureEvent,
 		return bytesTotal, "full row payload retained", nil
 	}
 	if cfg.RetainedPayload == collections.ColumnRetainedPayloadNonColumn &&
-		cfg.RetainedPayloadEncoding == collections.ColumnRetainedPayloadEncodingSemanticStreamV1 &&
+		columnStoreSuiteEffectiveRetainedPayloadEncoding(cfg) == collections.ColumnRetainedPayloadEncodingSemanticStreamV1 &&
 		len(events) > 1 {
 		documents := make([][]byte, len(events))
 		for i := range events {
@@ -2174,6 +2174,25 @@ func columnStoreSuiteRetainedPayloadAccounting(events []columnStoreFixtureEvent,
 		return bytesTotal, "M13C stores no row payload beyond an empty JSON object; declared columns are reconstructed from physical column assets", nil
 	default:
 		return 0, "", fmt.Errorf("unsupported retained-payload policy %q", cfg.RetainedPayload)
+	}
+}
+
+func columnStoreSuiteEffectiveRetainedPayloadEncoding(cfg *collections.ColumnStoreConfig) collections.ColumnRetainedPayloadEncoding {
+	if cfg == nil {
+		return collections.ColumnRetainedPayloadEncodingNone
+	}
+	if cfg.RetainedPayloadEncoding != "" {
+		return cfg.RetainedPayloadEncoding
+	}
+	switch cfg.RetainedPayload {
+	case collections.ColumnRetainedPayloadNone:
+		return collections.ColumnRetainedPayloadEncodingNone
+	case collections.ColumnRetainedPayloadFull:
+		return collections.ColumnRetainedPayloadEncodingJSON
+	case collections.ColumnRetainedPayloadNonColumn:
+		return collections.ColumnRetainedPayloadEncodingSemanticStreamV1
+	default:
+		return collections.ColumnRetainedPayloadEncodingUnavailable
 	}
 }
 

--- a/cmd/unified_bench/suite_column_store_test.go
+++ b/cmd/unified_bench/suite_column_store_test.go
@@ -72,19 +72,34 @@ func TestColumnStoreSuiteRetainedPayloadEncodingOverrideSelectsSemanticStreamV1(
 
 func TestColumnStoreSuiteRetainedPayloadAccountingUsesSemanticStreamV1Blocks(t *testing.T) {
 	withColumnStoreRetainedPayloadEncodingFlag(t, "semantic-stream-v1")
-	events, _ := buildColumnStoreSyntheticFixture(32, 1)
-	cfg := columnStoreSuiteConfig()
-	got, note, err := columnStoreSuiteRetainedPayloadAccounting(events, cfg, columnStorePathSerialColumnScan)
-	if err != nil {
-		t.Fatalf("columnStoreSuiteRetainedPayloadAccounting: %v", err)
-	}
-	if got <= 0 {
-		t.Fatalf("semantic-stream-v1 accounting bytes=%d want positive", got)
-	}
-	for _, want := range []string{"semantic-stream-v1", "primary locator bytes", "side-root block bytes"} {
-		if !strings.Contains(note, want) {
-			t.Fatalf("semantic-stream-v1 accounting note %q missing %q", note, want)
-		}
+	for _, rows := range []int{1, 32} {
+		t.Run(fmt.Sprintf("rows_%d", rows), func(t *testing.T) {
+			events, _ := buildColumnStoreSyntheticFixture(rows, 1)
+			cfg := columnStoreSuiteConfig()
+			got, note, err := columnStoreSuiteRetainedPayloadAccounting(events, cfg, columnStorePathSerialColumnScan)
+			if err != nil {
+				t.Fatalf("columnStoreSuiteRetainedPayloadAccounting: %v", err)
+			}
+			documents := make([][]byte, len(events))
+			for i := range events {
+				documents[i] = events[i].Doc
+			}
+			accounting, err := collections.ColumnRetainedSemanticStreamV1StorageAccountingFromJSONDocuments(*cfg, documents)
+			if err != nil {
+				t.Fatalf("ColumnRetainedSemanticStreamV1StorageAccountingFromJSONDocuments: %v", err)
+			}
+			if got != accounting.TotalBytes {
+				t.Fatalf("semantic-stream-v1 accounting bytes=%d want production accounting total %d", got, accounting.TotalBytes)
+			}
+			if accounting.PrimaryLocatorBytes <= 0 || accounting.BlockBytes <= 0 || accounting.BlockCount <= 0 {
+				t.Fatalf("semantic-stream-v1 accounting=%+v want locator and side block bytes", accounting)
+			}
+			for _, want := range []string{"semantic-stream-v1", "primary locator bytes", "side-root block bytes"} {
+				if !strings.Contains(note, want) {
+					t.Fatalf("semantic-stream-v1 accounting note %q missing %q", note, want)
+				}
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

Issue: #2662 under storage-parity umbrella #2353. #2662 remains open after this PR.

This PR is the retained value_vlog reduction slice. It now does two things:
- Stores semantic-stream-v1 retained side-root blocks using a persistent `crss1zst` zstd wrapper, with legacy/raw `crss1blk` decode support.
- Promotes non-column retained payloads to `semantic-stream-v1` by default so production/default JSONBench runs exercise the retained-block path without an experimental flag.

Key implementation points:
- Add fail-closed encode/decode for zstd-wrapped retained semantic-stream blocks, including row-count and decoded-size bounds.
- Add bounded decode caching for dense retained reconstruction while keeping point/small/sparse fetches on the direct single-row path.
- Update retained-payload audit/accounting to distinguish stored block bytes from decoded raw block bytes.
- Fix ordered-root child separator lowering when a rewritten child receives operations below its old low key. The production-default switch exposed this as a mixed key-family point lookup failure.
- Update docs/tests for the new default and keep explicit `template-v1` coverage for compatibility paths.

This PR productionizes the current retained reduction, but it does not satisfy the original rough `65 MB` value_vlog target. After #2680, ClickHouse’s closest comparable retained/shared JSON class is about `93.08 MB`; this PR’s current 1M retained value_vlog is `97.31 MB`, so the remaining decision is whether #2662’s target should move to ClickHouse-class retained parity or require a deeper retained representation change.

## Current-head evidence

Head: `df7ffab44e3c7a01c8f069a59c83417d006872a3`

Production-default JSONBench artifact:
- `/tmp/jsonbench_2662_semantic_default_1m_20260613_165819/1m_column-store-full-prepared_json_full_all_compacted/result.json`
- `/tmp/jsonbench_2662_semantic_default_1m_20260613_165819/report.md`
- `/tmp/jsonbench_2662_semantic_default_1m_20260613_165819/retained_semantic_block_audit.json`

Run shape:
- rows: `1,000,000`
- tries: `1`
- suite: `full`
- layout: `column-store-full-prepared`
- production/default retained encoding: `semantic-stream-v1` confirmed by audit
- compacted after load: `1`
- reconstruction validation: `1`

Storage, WAL-excluded durable basis:
- durable storage: `144,196,942` bytes
- total including WAL: `639,982,656` bytes
- WAL excluded from durable: `495,785,714` bytes
- `value_vlog`: `97,309,293` bytes
- `column_asset_segments`: `34,665,086` bytes
- `leaf_vlog`: `7,961,664` bytes
- `primary_index`: `4,194,304` bytes

Retained semantic-stream audit:
- status: `passed`
- checked rows: `1,000,000`
- retained encoding: `semantic-stream-v1`
- block count: `250`
- primary locator bytes: `42,968,000`
- stored block bytes: `97,297,293`
- raw block bytes: `264,359,324`
- path streams: `18,306`
- values: `6,829,188`
- all-path zstd encoded bytes: `93,567,616`

Comparison to #2662 baseline from #2717:
- `value_vlog`: `118,456,968 -> 97,309,293` bytes, down `21,147,675` bytes / `17.85%`
- durable WAL-excluded: `164,098,289 -> 144,196,942` bytes, down `19,901,347` bytes / `12.13%`
- remaining value_vlog gap to the original rough `65 MB` target: about `32.3 MB`

Reconstruction:
- valid: `true`
- source/stored canonical hash: `866fc7e98e6a974f5dd3bfdc745bfb336f518b9d336e950cac4618a3bd2f5ab4`

Query timings and result hashes:
- q1 best `0.049854167s`, hash `059afea7bfbfb7d188ccc441b326301b063975713996169dfd43563420d11492`
- q2 best `0.602547s`, hash `b63b8e1013c918fcda7c299ef64beb20c4988854cf0671a83803b6951d795860`
- q3 best `0.134677792s`, hash `cdb6acc4d0d990bdbdab5d2f29df85943490b2cb6b950351cbfa9bd974a182eb`
- q4 best `0.154122292s`, hash `a815e9fbdf899f6f2cf3f59c5d73cf9264c9295d85553e972b53a3b57b9bcfb5`
- q5 best `0.157402459s`, hash `ef6217ce9da3a74fdf600ccbebd333457f017d6012dc0c231338961533f5689c`

## Local validation

- `git diff --check`
- `GOTOOLCHAIN=go1.26.4 GOFLAGS=-mod=mod go test ./TreeDB/db -run 'TestPublishOrderedRoot.*MixedKeyFamilies|TestPublishOrderedRootCommandWALValueLogLeavesSeekAfterMixedKeyMutations' -count=1`
- `GOTOOLCHAIN=go1.26.4 GOFLAGS=-mod=mod go test ./TreeDB/collections -run 'TestColumnPhysicalQ4BTopKSortedLatestVisibleMutation1953|TestColumnRetainedPayloadValueLogPlacementReopen|TestColumnRetainedPayloadValueLogPlacementGCRewrite|TestColumnRetainedPayloadLeafLogSyntheticShrink|TestTypedStorageLegacyNameAllowlistIsComplete|TestColumnStoreMetadataRoundTripsReopenAndCacheIdentity|TestAuditColumnRetainedPayloadPathsAbsentJSONBenchPaths2354|TestColumnRetainedPayloadCompressionStatus2356|TestAuditCollectionRetainedPayloadDeclaredPathsAbsentTemplateV12382|TestAuditCollectionRetainedPayloadDeclaredPathsAbsentSemanticStreamV12662|TestAuditCollectionRetainedPayloadShapeStatsTemplateV12662|TestAuditCollectionRetainedPayloadValueFamilyStats2662|TestAuditCollectionRetainedPayloadSemanticStreamStats2662|TestColumnRetainedPayloadSemanticStreamV1InsertBatchRoundTripReopen|TestColumnRetainedPayloadSemanticStreamV1PreservesRetainedJSONNumbers' -count=1`
- `GOTOOLCHAIN=go1.26.4 GOFLAGS=-mod=mod go test ./cmd/unified_bench -run 'TestColumnStoreSuiteRetainedPayload|TestColumnStoreJSONBench|TestColumnStoreSuiteJSONBench' -count=1`
- `GOTOOLCHAIN=go1.26.4 GOFLAGS=-mod=mod go test ./TreeDB/db -count=1`
- `GOTOOLCHAIN=go1.26.4 GOFLAGS=-mod=mod go test ./TreeDB/collections -count=1`
- `GOTOOLCHAIN=go1.26.4 GOFLAGS=-mod=mod go test ./TreeDB/caching -count=1`
- `GOTOOLCHAIN=go1.26.4 GOFLAGS=-mod=mod go test ./cmd/unified_bench -count=1`
- `GOTOOLCHAIN=go1.26.4 GOFLAGS=-mod=mod go build -o bin/unified-bench ./cmd/unified_bench`

## Graph status

- #2680 ClickHouse on-disk part audit is closed and consumed as the format hint.
- #2662 remains open: this slice reaches about `97.31 MB` retained value_vlog on the canonical 1M run, close to ClickHouse’s comparable retained/shared JSON class but above the original rough `65 MB` target.
- #2663 is handled separately by #2719 and should compose with this after both PRs land or in the #2359 integration gate.
- #2359 remains the final current-head evidence gate and must rerun after this PR and #2719 are on the same head/base.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ZSTD compression support for retained semantic-stream blocks, reducing storage footprint when beneficial.
  * Introduced decode caching mechanism to improve performance during snapshot reads.

* **Documentation**
  * Updated storage format specification to reflect default retained-payload encoding changes.

* **Tests**
  * Expanded test coverage for ZSTD compression wrapper functionality, cache validation, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->