### PR TITLE
Add vector search work-accounting stats

### DIFF
--- a/TreeDB/collections/column_hnsw_prepared_raw_dot_traversal.go
+++ b/TreeDB/collections/column_hnsw_prepared_raw_dot_traversal.go
@@ -33,6 +33,7 @@ func (v *columnHNSWSearchPackPreparedView) searchCosinePreparedRawDotTraversal(q
 	if !columnHNSWSearchPackStatsModeSupportedForSearch(statsMode) {
 		return nil, *stats, errColumnHNSWSearchPackSearchUnsupportedMode
 	}
+	columnVectorGraphNativeSearchStartWorkAccounting(stats, statsMode)
 	rowCount := v.Header.Rows
 	topK := opts.TopK
 	if topK < 0 {
@@ -107,6 +108,7 @@ func (v *columnHNSWSearchPackPreparedView) searchCosinePreparedRawDotScorePlane(
 	if err != nil {
 		return nil, *stats, err
 	}
+	traversalStart, traversalDistanceBefore := columnVectorGraphNativeSearchStartGraphTraversal(stats)
 	for layer := maxLayer; layer > 0; layer-- {
 		entryOrdinal, err = v.greedyNearestAtLayerPreparedRawDotScorePlane(rawDotScorePlane, entryOrdinal, layer, scratch, stats, countLoopEdges, &loopEdgeVisits)
 		if err != nil {
@@ -122,7 +124,7 @@ func (v *columnHNSWSearchPackPreparedView) searchCosinePreparedRawDotScorePlane(
 	nextSeed := 0
 	rowCount64 := uint64(rowCount)
 	for {
-		candidate, ok := scratch.popRawDotFrontier()
+		candidate, ok := scratch.popRawDotFrontierAccounting(stats)
 		if !ok {
 			if len(scratch.rawDot.top) >= retainedCandidateLimit {
 				break
@@ -177,6 +179,7 @@ func (v *columnHNSWSearchPackPreparedView) searchCosinePreparedRawDotScorePlane(
 		stats.VisitedEdges = loopEdgeVisits
 		stats.Candidates = visitedCandidates
 	}
+	columnVectorGraphNativeSearchFinishGraphTraversal(stats, traversalStart, traversalDistanceBefore)
 	return v.finishPreparedRawDotScorePlaneResults(topK, retainedCandidateLimit, opts, scratch, stats)
 }
 
@@ -234,7 +237,7 @@ func (v *columnHNSWSearchPackPreparedView) scoreAndPushRawDotFrontierVisitedPrep
 	}
 	candidate := columnVectorGraphRawDotSearchCandidate{ordinal: ordinal, dot: dot}
 	if scratch.insertRawDotTop(topK, candidate) {
-		scratch.pushRawDotFrontier(candidate)
+		scratch.pushRawDotFrontierAccounting(candidate, stats)
 	}
 	return nil
 }

--- a/TreeDB/collections/column_hnsw_prepared_traversal.go
+++ b/TreeDB/collections/column_hnsw_prepared_traversal.go
@@ -239,6 +239,7 @@ func (v *columnHNSWSearchPackPreparedView) searchCosinePreparedScorePlane(query 
 	if !columnHNSWSearchPackStatsModeSupportedForSearch(statsMode) {
 		return nil, *stats, errColumnHNSWSearchPackSearchUnsupportedMode
 	}
+	columnVectorGraphNativeSearchStartWorkAccounting(stats, statsMode)
 	rowCount := v.Header.Rows
 	topK := opts.TopK
 	if topK < 0 {
@@ -306,6 +307,7 @@ func (v *columnHNSWSearchPackPreparedView) searchCosinePreparedScorePlane(query 
 	if err != nil {
 		return nil, *stats, err
 	}
+	traversalStart, traversalDistanceBefore := columnVectorGraphNativeSearchStartGraphTraversal(stats)
 	for layer := maxLayer; layer > 0; layer-- {
 		entryOrdinal, err = v.greedyNearestAtLayerPreparedScorePlane(scorePlane, rowIDScorePlane, entryOrdinal, layer, scratch, stats, countLoopEdges, &loopEdgeVisits)
 		if err != nil {
@@ -321,7 +323,7 @@ func (v *columnHNSWSearchPackPreparedView) searchCosinePreparedScorePlane(query 
 	nextSeed := 0
 	rowCount64 := uint64(rowCount)
 	for {
-		candidate, ok := scratch.popFrontier()
+		candidate, ok := scratch.popFrontierAccounting(stats)
 		if !ok {
 			if len(scratch.top) >= retainedCandidateLimit {
 				break
@@ -397,6 +399,7 @@ func (v *columnHNSWSearchPackPreparedView) searchCosinePreparedScorePlane(query 
 		stats.VisitedEdges = loopEdgeVisits
 		stats.Candidates = visitedCandidates
 	}
+	columnVectorGraphNativeSearchFinishGraphTraversal(stats, traversalStart, traversalDistanceBefore)
 	if len(scratch.top) == 0 {
 		return scratch.results, *stats, nil
 	}
@@ -510,7 +513,7 @@ func (v *columnHNSWSearchPackPreparedView) scoreAndPushFrontierVisitedPreparedSc
 	}
 	candidate := columnVectorGraphSearchCandidate{ordinal: ordinal, score: score}
 	if scratch.insertTop(topK, candidate) {
-		scratch.pushFrontier(candidate)
+		scratch.pushFrontierAccounting(candidate, stats)
 	}
 	return nil
 }
@@ -531,7 +534,7 @@ func (v *columnHNSWSearchPackPreparedView) scoreAndPushFrontierVisitedTilePrepar
 	for i, ordinal := range ordinals {
 		candidate := columnVectorGraphSearchCandidate{ordinal: ordinal, score: scores[i]}
 		if scratch.insertTop(topK, candidate) {
-			scratch.pushFrontier(candidate)
+			scratch.pushFrontierAccounting(candidate, stats)
 		}
 	}
 	return nil

--- a/TreeDB/collections/column_hnsw_search_pack_search.go
+++ b/TreeDB/collections/column_hnsw_search_pack_search.go
@@ -48,6 +48,7 @@ func (v *columnHNSWSearchPackPreparedView) searchCosine(query []float32, opts co
 	if !columnHNSWSearchPackStatsModeSupportedForSearch(statsMode) {
 		return nil, stats, errColumnHNSWSearchPackSearchUnsupportedMode
 	}
+	columnVectorGraphNativeSearchStartWorkAccounting(&stats, statsMode)
 	rowCount := v.Header.Rows
 	topK := opts.TopK
 	if topK < 0 {
@@ -105,6 +106,7 @@ func (v *columnHNSWSearchPackPreparedView) searchCosine(query []float32, opts co
 	if err != nil {
 		return nil, stats, err
 	}
+	traversalStart, traversalDistanceBefore := columnVectorGraphNativeSearchStartGraphTraversal(&stats)
 	for layer := maxLayer; layer > 0; layer-- {
 		entryOrdinal, err = v.greedyNearestAtLayer(normalizedQuery, entryOrdinal, layer, opts.ScoreBatchMode, scratch, &stats, countLoopEdges, &loopEdgeVisits)
 		if err != nil {
@@ -120,7 +122,7 @@ func (v *columnHNSWSearchPackPreparedView) searchCosine(query []float32, opts co
 	nextSeed := 0
 	rowCount64 := uint64(rowCount)
 	for {
-		candidate, ok := scratch.popFrontier()
+		candidate, ok := scratch.popFrontierAccounting(&stats)
 		if !ok {
 			if len(scratch.top) >= efSearch {
 				break
@@ -173,6 +175,7 @@ func (v *columnHNSWSearchPackPreparedView) searchCosine(query []float32, opts co
 		stats.VisitedEdges = loopEdgeVisits
 		stats.Candidates = visitedCandidates
 	}
+	columnVectorGraphNativeSearchFinishGraphTraversal(&stats, traversalStart, traversalDistanceBefore)
 	if len(scratch.top) == 0 {
 		return scratch.results, stats, nil
 	}
@@ -263,7 +266,7 @@ func (v *columnHNSWSearchPackPreparedView) scoreAndPushFrontierVisited(normalize
 	}
 	candidate := columnVectorGraphSearchCandidate{ordinal: ordinal, score: score}
 	if scratch.insertTop(topK, candidate) {
-		scratch.pushFrontier(candidate)
+		scratch.pushFrontierAccounting(candidate, stats)
 	}
 	return nil
 }
@@ -275,7 +278,9 @@ func (v *columnHNSWSearchPackPreparedView) scoreAndPushFrontierVisitedTile(norma
 	if scoreBatchMode != columnVectorGraphScoreBatchModeScalar && len(rowIDs) > 1 && scratch != nil && len(normalizedQuery) >= v.Header.VectorStride {
 		scratch.scoreTileDots = ensureColumnVectorGraphNativeFloat32Scratch(scratch.scoreTileDots, len(rowIDs))
 		dots := scratch.scoreTileDots[:len(rowIDs)]
+		scoreStart := columnVectorGraphNativeSearchStartDistanceKernel(stats)
 		status := vectorops.DotFloat32IndexedPrevalidated(dots, v.NormalizedVectors, normalizedQuery[:v.Header.VectorStride], rowIDs, v.Header.VectorStride)
+		columnVectorGraphNativeSearchFinishDistanceKernel(stats, scoreStart)
 		if !status.Invalid && status.Rows == len(rowIDs) {
 			recordColumnHNSWSearchPackScoreBatchStats(stats, len(rowIDs), status.Optimized, status.Fallback)
 			v.recordScoreStats(stats, len(rowIDs))
@@ -285,7 +290,7 @@ func (v *columnHNSWSearchPackPreparedView) scoreAndPushFrontierVisitedTile(norma
 			for i, rowID := range rowIDs {
 				candidate := columnVectorGraphSearchCandidate{ordinal: int(rowID), score: float64(dots[i])}
 				if scratch.insertTop(topK, candidate) {
-					scratch.pushFrontier(candidate)
+					scratch.pushFrontierAccounting(candidate, stats)
 				}
 			}
 			return nil
@@ -302,7 +307,7 @@ func (v *columnHNSWSearchPackPreparedView) scoreAndPushFrontierVisitedTile(norma
 	for i, rowID := range rowIDs {
 		candidate := columnVectorGraphSearchCandidate{ordinal: int(rowID), score: scores[i]}
 		if scratch.insertTop(topK, candidate) {
-			scratch.pushFrontier(candidate)
+			scratch.pushFrontierAccounting(candidate, stats)
 		}
 	}
 	return nil
@@ -318,7 +323,9 @@ func (v *columnHNSWSearchPackPreparedView) scoreOrdinal(normalizedQuery []float3
 		return 0, fmt.Errorf("collections: hnsw_search_pack_v1 vector ordinal=%d shape mismatch", ordinal)
 	}
 	vector := v.NormalizedVectors[start:end]
+	scoreStart := columnVectorGraphNativeSearchStartDistanceKernel(stats)
 	score := float64(vectorDotProductFloat32(normalizedQuery[:v.Header.Dimensions], vector))
+	columnVectorGraphNativeSearchFinishDistanceKernel(stats, scoreStart)
 	optimized := scoreBatchMode != columnVectorGraphScoreBatchModeScalar && vectorops.DotFloat32OptimizedEligible(v.Header.Dimensions)
 	recordColumnHNSWSearchPackScoreBatchStats(stats, 1, optimized, !optimized)
 	v.recordScoreStats(stats, 1)
@@ -338,7 +345,9 @@ func (v *columnHNSWSearchPackPreparedView) scoreRowIDs(normalizedQuery []float32
 	if scoreBatchMode != columnVectorGraphScoreBatchModeScalar && len(rowIDs) > 1 && scratch != nil && len(normalizedQuery) >= v.Header.VectorStride {
 		scratch.scoreTileDots = ensureColumnVectorGraphNativeFloat32Scratch(scratch.scoreTileDots, len(rowIDs))
 		dots := scratch.scoreTileDots[:len(rowIDs)]
+		scoreStart := columnVectorGraphNativeSearchStartDistanceKernel(stats)
 		status := vectorops.DotFloat32IndexedPrevalidated(dots, v.NormalizedVectors, normalizedQuery[:v.Header.VectorStride], rowIDs, v.Header.VectorStride)
+		columnVectorGraphNativeSearchFinishDistanceKernel(stats, scoreStart)
 		if !status.Invalid && status.Rows == len(rowIDs) {
 			for i := range rowIDs {
 				dst[i] = float64(dots[i])
@@ -348,13 +357,16 @@ func (v *columnHNSWSearchPackPreparedView) scoreRowIDs(normalizedQuery []float32
 			return dst, nil
 		}
 	}
+	scoreStart := columnVectorGraphNativeSearchStartDistanceKernel(stats)
 	for i, rowID := range rowIDs {
 		score, err := v.scoreOrdinal(normalizedQuery, int(rowID), scoreBatchMode, scratch, nil)
 		if err != nil {
+			columnVectorGraphNativeSearchFinishDistanceKernel(stats, scoreStart)
 			return dst[:i], err
 		}
 		dst[i] = score
 	}
+	columnVectorGraphNativeSearchFinishDistanceKernel(stats, scoreStart)
 	optimized := len(rowIDs) == 1 && scoreBatchMode != columnVectorGraphScoreBatchModeScalar && vectorops.DotFloat32OptimizedEligible(v.Header.Dimensions)
 	recordColumnHNSWSearchPackScoreBatchStats(stats, len(rowIDs), optimized, !optimized)
 	v.recordScoreStats(stats, len(rowIDs))

--- a/TreeDB/collections/column_hnsw_search_pack_search.go
+++ b/TreeDB/collections/column_hnsw_search_pack_search.go
@@ -383,6 +383,7 @@ func (v *columnHNSWSearchPackPreparedView) recordScoreStats(stats *columnVectorG
 	}
 	count64 := uint64(count)
 	stats.PreparedScoreCalls += count64
+	stats.FP32ScoreCalls += count64
 	stats.VisitedNodes += count64
 	stats.CandidateFetches += count64
 	stats.VectorBytesRead += count64 * uint64(v.Header.Dimensions) * 4

--- a/TreeDB/collections/column_hnsw_search_pack_test.go
+++ b/TreeDB/collections/column_hnsw_search_pack_test.go
@@ -342,6 +342,53 @@ func TestColumnHNSWSearchPackReopenPreservesManifestIdentity2313(t *testing.T) {
 	assertColumnHNSWSearchPackMatchesColumnGraphRoute2315(t, searcher, fullOpts, fullResponse)
 }
 
+func TestColumnHNSWSearchPackWorkAccountingStats(t *testing.T) {
+	const dims = 16
+	rows := make([]columnGraphRebuildInputRowV2A, 32)
+	for i := range rows {
+		vec := make([]float32, dims)
+		for j := range vec {
+			vec[j] = float32(((i+1)*(j+3))%17) + 1
+		}
+		rows[i] = columnGraphRebuildInputRowV2A{id: fmt.Sprintf("doc-%02d", i), vector: vec}
+	}
+	_, d, col, def := openColumnGraphRebuildTestCollectionV2A(t, dims, 4, rows)
+	defer func() { _ = d.Close() }()
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		t.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	searcher, err := col.OpenVectorIndexSearcher(VectorIndexSearcherOptions{IndexName: def.Name, MaxDecodedBlocks: 1})
+	if err != nil {
+		t.Fatalf("OpenVectorIndexSearcher: %v", err)
+	}
+	defer func() { _ = searcher.Close() }()
+	query := make([]float32, dims)
+	for i := range query {
+		query[i] = float32(i%5) + 1
+	}
+	var buf VectorIndexSearchBuffer
+	response, err := searcher.SearchWithBuffer(VectorIndexSearcherSearchOptions{Query: query, TopK: 5, EfSearch: 16, StatsMode: VectorIndexSearchStatsModeWorkAccounting}, &buf)
+	if err != nil {
+		t.Fatalf("SearchWithBuffer work accounting: %v", err)
+	}
+	stats := response.Stats
+	if stats.RouteKind() != VectorIndexSearchRouteExactHNSWSearchPackV1 || stats.WorkAccountingSearches != 1 {
+		t.Fatalf("work-accounting route/stats=%+v", stats)
+	}
+	if stats.VisitedNodes == 0 || stats.VisitedEdges == 0 || stats.PreparedScoreCalls == 0 || stats.FP32ScoreCalls != stats.PreparedScoreCalls {
+		t.Fatalf("work-accounting score/visit stats=%+v", stats)
+	}
+	if stats.QuantizedScoreCalls != 0 || stats.ExactRerankScoreCalls != 0 {
+		t.Fatalf("exact route reported quantized/rerank work stats=%+v", stats)
+	}
+	if stats.FrontierPushes == 0 || stats.FrontierPops == 0 || stats.HeapPushes != stats.FrontierPushes || stats.HeapPops != stats.FrontierPops {
+		t.Fatalf("work-accounting heap stats=%+v", stats)
+	}
+	if stats.DistanceKernelNanos == 0 || stats.GraphTraversalNanos == 0 {
+		t.Fatalf("work-accounting timers missing stats=%+v", stats)
+	}
+}
+
 func TestColumnHNSWSearchPackEmptyAndSingleRowFixtures2313(t *testing.T) {
 	for _, tc := range []struct {
 		name string

--- a/TreeDB/collections/column_vector_graph_prepared_scoring.go
+++ b/TreeDB/collections/column_vector_graph_prepared_scoring.go
@@ -254,6 +254,7 @@ func (s *columnVectorGraphSearchSource) scorePreparedOrdinal(plan *columnVectorG
 	if stats != nil {
 		recordColumnVectorGraphScoreBatchStats(stats, 1, false, true)
 		stats.PreparedScoreCalls++
+		stats.FP32ScoreCalls++
 		stats.VisitedNodes++
 		stats.CandidateFetches++
 		stats.VectorBytesRead += uint64(vectorView.dims) * 4
@@ -275,6 +276,7 @@ func (s *columnVectorGraphSearchSource) scorePreparedOrdinal(plan *columnVectorG
 			stats.BlockViewBuilds = plan.builds
 		}
 	}
+	scoreStart := columnVectorGraphNativeSearchStartDistanceKernel(stats)
 	dot := float64(vectorDotProductFloat32(query, vector))
 	if math.IsInf(dot, 0) || math.IsNaN(dot) {
 		if stats != nil {
@@ -282,6 +284,7 @@ func (s *columnVectorGraphSearchSource) scorePreparedOrdinal(plan *columnVectorG
 		}
 		dot = columnVectorGraphNativeDotProductFloat64(query, vector)
 	}
+	columnVectorGraphNativeSearchFinishDistanceKernel(stats, scoreStart)
 	score := dot * float64(queryInvNorm) * float64(invNorm)
 	if math.IsNaN(score) || math.IsInf(score, 0) {
 		return 0, true, fmt.Errorf("collections: column_graph %q candidate ordinal=%d cosine score is not finite", s.reader.def.Name, ordinal)

--- a/TreeDB/collections/column_vector_graph_prepared_search.go
+++ b/TreeDB/collections/column_vector_graph_prepared_search.go
@@ -600,7 +600,9 @@ func (v *columnVectorGraphPreparedSearchView) scoreOrdinalsIndexed(plan *columnV
 			rowIDs[i] = uint32(row)
 		}
 		dots := scratch.scoreTileDots[:runLen]
+		scoreStart := columnVectorGraphNativeSearchStartDistanceKernel(stats)
 		status := vectorops.DotFloat32Indexed(dots, part.values, query, rowIDs, v.dims)
+		columnVectorGraphNativeSearchFinishDistanceKernel(stats, scoreStart)
 		if status.Invalid || status.Rows != runLen {
 			return dst, false, nil
 		}
@@ -672,7 +674,10 @@ func (v *columnVectorGraphPreparedSearchView) scoreOrdinalsIndexedSinglePart(pla
 				}
 				start := ordinal * dims
 				vector := values[start : start+dims]
-				score, err := v.scorePreparedDot(query, queryInvNorm, ordinal, float64(vectorDotProductFloat32(query, vector)), vector, stats)
+				scoreStart := columnVectorGraphNativeSearchStartDistanceKernel(stats)
+				dot := float64(vectorDotProductFloat32(query, vector))
+				columnVectorGraphNativeSearchFinishDistanceKernel(stats, scoreStart)
+				score, err := v.scorePreparedDot(query, queryInvNorm, ordinal, dot, vector, stats)
 				if err != nil {
 					return dst, true, err
 				}
@@ -690,7 +695,10 @@ func (v *columnVectorGraphPreparedSearchView) scoreOrdinalsIndexedSinglePart(pla
 				row := int(rowID)
 				start := row * dims
 				vector := values[start : start+dims]
-				score, err := v.scorePreparedDot(query, queryInvNorm, ordinal, float64(vectorDotProductFloat32(query, vector)), vector, stats)
+				scoreStart := columnVectorGraphNativeSearchStartDistanceKernel(stats)
+				dot := float64(vectorDotProductFloat32(query, vector))
+				columnVectorGraphNativeSearchFinishDistanceKernel(stats, scoreStart)
+				score, err := v.scorePreparedDot(query, queryInvNorm, ordinal, dot, vector, stats)
 				if err != nil {
 					return dst, true, err
 				}
@@ -728,7 +736,9 @@ func (v *columnVectorGraphPreparedSearchView) scoreOrdinalsIndexedSinglePart(pla
 	}
 	scratch.scoreTileDots = ensureColumnVectorGraphNativeFloat32Scratch(scratch.scoreTileDots, len(ordinals))
 	dots := scratch.scoreTileDots[:len(ordinals)]
+	scoreStart := columnVectorGraphNativeSearchStartDistanceKernel(stats)
 	status := vectorops.DotFloat32Indexed(dots, values, query, rowIDs, dims)
+	columnVectorGraphNativeSearchFinishDistanceKernel(stats, scoreStart)
 	if status.Invalid || status.Rows != len(ordinals) {
 		return dst, false, nil
 	}
@@ -774,6 +784,7 @@ func (v *columnVectorGraphPreparedSearchView) recordScoreStats(stats *columnVect
 		return
 	}
 	stats.PreparedScoreCalls += uint64(count)
+	stats.FP32ScoreCalls += uint64(count)
 	stats.VisitedNodes += uint64(count)
 	stats.CandidateFetches += uint64(count)
 	stats.VectorBytesRead += uint64(count * v.dims * 4)

--- a/TreeDB/collections/column_vector_graph_prepared_search.go
+++ b/TreeDB/collections/column_vector_graph_prepared_search.go
@@ -404,6 +404,7 @@ func (v *columnVectorGraphPreparedSearchView) checkScalarScoreInputs(query []flo
 }
 
 func columnVectorGraphPreparedCosineScore(query []float32, queryInvNorm float32, ordinal int, vector []float32, invNorm float32, stats *columnVectorGraphNativeSearchStats) (float64, error) {
+	scoreStart := columnVectorGraphNativeSearchStartDistanceKernel(stats)
 	dot := float64(vectorDotProductFloat32(query, vector))
 	if math.IsInf(dot, 0) || math.IsNaN(dot) {
 		if stats != nil {
@@ -411,6 +412,7 @@ func columnVectorGraphPreparedCosineScore(query []float32, queryInvNorm float32,
 		}
 		dot = columnVectorGraphNativeDotProductFloat64(query, vector)
 	}
+	columnVectorGraphNativeSearchFinishDistanceKernel(stats, scoreStart)
 	score := dot * float64(queryInvNorm) * float64(invNorm)
 	if math.IsNaN(score) || math.IsInf(score, 0) {
 		return 0, fmt.Errorf("collections: column_graph candidate ordinal=%d cosine score is not finite", ordinal)

--- a/TreeDB/collections/column_vector_graph_quantized_scorer.go
+++ b/TreeDB/collections/column_vector_graph_quantized_scorer.go
@@ -319,7 +319,9 @@ func (s *columnVectorGraphScalarU8QuantizedScorer) scoreRawDotRowIDsPrepared(row
 	} else {
 		dst = dst[:len(rowIDs)]
 	}
+	scoreStart := columnVectorGraphNativeSearchStartDistanceKernel(stats)
 	status := vectorops.DotScalarU8CenteredIndexedPrevalidated(dst, s.codePayload, s.centeredQuery, rowIDs, s.dims)
+	columnVectorGraphNativeSearchFinishDistanceKernel(stats, scoreStart)
 	if status.Invalid || status.Rows != len(rowIDs) {
 		return dst[:0], fmt.Errorf("%w: column_graph quantized index %q scalar_u8 batch score invalid status=%+v rows=%d want %d", ErrVectorIndexSearchUnavailable, s.indexName, status, status.Rows, len(rowIDs))
 	}
@@ -373,7 +375,7 @@ func (s *columnVectorGraphScalarU8QuantizedScorer) scoreAndPushFrontierVisitedRo
 	for i, rowID := range rowIDs {
 		candidate := columnVectorGraphSearchCandidate{ordinal: int(rowID), score: scalarU8QuantizedCosineScoreFromDot(dots[i])}
 		if scratch.insertTop(topK, candidate) {
-			scratch.pushFrontier(candidate)
+			scratch.pushFrontierAccounting(candidate, stats)
 		}
 	}
 	return len(rowIDs), nil
@@ -394,7 +396,7 @@ func (s *columnVectorGraphScalarU8QuantizedScorer) scoreAndPushRawDotFrontierVis
 	for i, rowID := range rowIDs {
 		candidate := columnVectorGraphRawDotSearchCandidate{ordinal: int(rowID), dot: dots[i]}
 		if scratch.insertRawDotTop(topK, candidate) {
-			scratch.pushRawDotFrontier(candidate)
+			scratch.pushRawDotFrontierAccounting(candidate, stats)
 		}
 	}
 	return len(rowIDs), nil
@@ -509,7 +511,9 @@ func (s *columnVectorGraphRabitQQuantizedScorer) scoreOrdinal(ordinal int, scrat
 	if scratch == nil {
 		return 0, fmt.Errorf("collections: column_graph quantized rabitq_1bit scorer: %w", errColumnVectorGraphNativeSearchScratchRequired)
 	}
+	scoreStart := columnVectorGraphNativeSearchStartDistanceKernel(stats)
 	score, err := s.scoreOrdinalUnchecked(ordinal)
+	columnVectorGraphNativeSearchFinishDistanceKernel(stats, scoreStart)
 	if err != nil {
 		return 0, err
 	}
@@ -535,13 +539,16 @@ func (s *columnVectorGraphRabitQQuantizedScorer) scoreOrdinals(ordinals []int, d
 	if scratch == nil {
 		return dst[:0], fmt.Errorf("collections: column_graph quantized rabitq_1bit scorer: %w", errColumnVectorGraphNativeSearchScratchRequired)
 	}
+	scoreStart := columnVectorGraphNativeSearchStartDistanceKernel(stats)
 	for i, ordinal := range ordinals {
 		score, err := s.scoreOrdinalUnchecked(ordinal)
 		if err != nil {
+			columnVectorGraphNativeSearchFinishDistanceKernel(stats, scoreStart)
 			return dst[:i], err
 		}
 		dst[i] = score
 	}
+	columnVectorGraphNativeSearchFinishDistanceKernel(stats, scoreStart)
 	if stats != nil {
 		recordColumnVectorGraphScoreBatchStats(stats, len(ordinals), false, true)
 		s.recordScoreStats(stats, len(ordinals))
@@ -686,7 +693,9 @@ func (s *columnVectorGraphBRQQuantizedScorer) scoreOrdinal(ordinal int, scratch 
 	if scratch == nil {
 		return 0, fmt.Errorf("collections: column_graph quantized brq_1bit scorer: %w", errColumnVectorGraphNativeSearchScratchRequired)
 	}
+	scoreStart := columnVectorGraphNativeSearchStartDistanceKernel(stats)
 	score, err := s.scoreOrdinalUnchecked(ordinal)
+	columnVectorGraphNativeSearchFinishDistanceKernel(stats, scoreStart)
 	if err != nil {
 		return 0, err
 	}
@@ -712,13 +721,16 @@ func (s *columnVectorGraphBRQQuantizedScorer) scoreOrdinals(ordinals []int, dst 
 	if scratch == nil {
 		return dst[:0], fmt.Errorf("collections: column_graph quantized brq_1bit scorer: %w", errColumnVectorGraphNativeSearchScratchRequired)
 	}
+	scoreStart := columnVectorGraphNativeSearchStartDistanceKernel(stats)
 	for i, ordinal := range ordinals {
 		score, err := s.scoreOrdinalUnchecked(ordinal)
 		if err != nil {
+			columnVectorGraphNativeSearchFinishDistanceKernel(stats, scoreStart)
 			return dst[:i], err
 		}
 		dst[i] = score
 	}
+	columnVectorGraphNativeSearchFinishDistanceKernel(stats, scoreStart)
 	if stats != nil {
 		recordColumnVectorGraphScoreBatchStats(stats, len(ordinals), false, true)
 		s.recordScoreStats(stats, len(ordinals))

--- a/TreeDB/collections/column_vector_graph_raw_dot_search.go
+++ b/TreeDB/collections/column_vector_graph_raw_dot_search.go
@@ -45,6 +45,13 @@ func (s *columnVectorGraphNativeSearchScratch) pushRawDotFrontier(candidate colu
 	s.rawDotFrontierSiftUp(len(raw.frontier)-1, candidate)
 }
 
+func (s *columnVectorGraphNativeSearchScratch) pushRawDotFrontierAccounting(candidate columnVectorGraphRawDotSearchCandidate, stats *columnVectorGraphNativeSearchStats) {
+	if columnVectorGraphNativeSearchWorkAccountingEnabled(stats) {
+		stats.FrontierPushes++
+	}
+	s.pushRawDotFrontier(candidate)
+}
+
 func (s *columnVectorGraphNativeSearchScratch) popRawDotFrontier() (columnVectorGraphRawDotSearchCandidate, bool) {
 	raw := s.rawDot
 	if raw == nil || len(raw.frontier) == 0 {
@@ -58,6 +65,14 @@ func (s *columnVectorGraphNativeSearchScratch) popRawDotFrontier() (columnVector
 		s.rawDotFrontierSiftDown(0, last)
 	}
 	return best, true
+}
+
+func (s *columnVectorGraphNativeSearchScratch) popRawDotFrontierAccounting(stats *columnVectorGraphNativeSearchStats) (columnVectorGraphRawDotSearchCandidate, bool) {
+	candidate, ok := s.popRawDotFrontier()
+	if ok && columnVectorGraphNativeSearchWorkAccountingEnabled(stats) {
+		stats.FrontierPops++
+	}
+	return candidate, ok
 }
 
 func (s *columnVectorGraphNativeSearchScratch) rawDotFrontierSiftUp(idx int, candidate columnVectorGraphRawDotSearchCandidate) {

--- a/TreeDB/collections/column_vector_graph_search.go
+++ b/TreeDB/collections/column_vector_graph_search.go
@@ -371,6 +371,7 @@ type columnVectorGraphNativeSearchStats struct {
 	ScoreBatchOptimizedCalls             uint64
 	ScoreBatchScalarFallbackCalls        uint64
 	PreparedScoreCalls                   uint64
+	FP32ScoreCalls                       uint64
 	QuantizedScoreCalls                  uint64
 	QuantizedCodeBytesRead               uint64
 	QuantizedRerankCandidates            uint64
@@ -1003,6 +1004,7 @@ func (c *columnVectorGraphPreparedMinimalSearchCounters) publish(stats *columnVe
 	stats.ScoreBatchOptimizedCalls += c.ScoreBatchOptimizedCalls
 	stats.ScoreBatchScalarFallbackCalls += c.ScoreBatchScalarFallbackCalls
 	stats.PreparedScoreCalls += c.PreparedScoreCalls
+	stats.FP32ScoreCalls += c.PreparedScoreCalls
 	stats.VisitedNodes += c.PreparedScoreCalls
 	stats.VectorBytesRead += c.PreparedScoreCalls * uint64(c.dims) * 4
 	stats.NormBytesRead += c.PreparedScoreCalls * 4
@@ -2414,6 +2416,7 @@ func (r *columnVectorGraphPhysicalRowReader) scoreOrdinalLegacy(plan *columnVect
 	if stats != nil {
 		recordColumnVectorGraphScoreBatchStats(stats, 1, false, true)
 		stats.VisitedNodes++
+		stats.FP32ScoreCalls++
 		stats.BlockViewHits = plan.hits
 		stats.BlockViewMisses = plan.misses
 		stats.BlockViewBuilds = plan.builds
@@ -2456,7 +2459,9 @@ func (r *columnVectorGraphPhysicalRowReader) scoreOrdinalLegacy(plan *columnVect
 		stats.VectorBytesRead += uint64(len(vector)) * 4
 		stats.NormBytesRead += 4
 	}
+	scoreStart := columnVectorGraphNativeSearchStartDistanceKernel(stats)
 	score, err := columnVectorGraphNativeCosineScoreVector(query, queryInvNorm, ordinal, vector, invNorm)
+	columnVectorGraphNativeSearchFinishDistanceKernel(stats, scoreStart)
 	if err != nil {
 		return 0, err
 	}

--- a/TreeDB/collections/column_vector_graph_search.go
+++ b/TreeDB/collections/column_vector_graph_search.go
@@ -584,7 +584,7 @@ func columnVectorGraphNativeSearchFinishDistanceKernel(stats *columnVectorGraphN
 	if stats == nil || start.IsZero() {
 		return
 	}
-	stats.DistanceKernelNanos += uint64(time.Since(start))
+	stats.DistanceKernelNanos += columnVectorGraphNativeSearchElapsedNanos(start)
 }
 
 func columnVectorGraphNativeSearchStartGraphTraversal(stats *columnVectorGraphNativeSearchStats) (time.Time, uint64) {
@@ -598,14 +598,24 @@ func columnVectorGraphNativeSearchFinishGraphTraversal(stats *columnVectorGraphN
 	if stats == nil || start.IsZero() {
 		return
 	}
-	elapsed := uint64(time.Since(start))
+	elapsed := columnVectorGraphNativeSearchElapsedNanos(start)
 	distance := uint64(0)
 	if stats.DistanceKernelNanos > distanceBefore {
 		distance = stats.DistanceKernelNanos - distanceBefore
 	}
 	if elapsed > distance {
 		stats.GraphTraversalNanos += elapsed - distance
+		return
 	}
+	stats.GraphTraversalNanos++
+}
+
+func columnVectorGraphNativeSearchElapsedNanos(start time.Time) uint64 {
+	elapsed := uint64(time.Since(start))
+	if elapsed == 0 {
+		return 1
+	}
+	return elapsed
 }
 
 func (c *columnVectorGraphNativeSearchLoopCounters) publish(stats *columnVectorGraphNativeSearchStats, candidates uint64) {

--- a/TreeDB/collections/column_vector_graph_search.go
+++ b/TreeDB/collections/column_vector_graph_search.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math"
 	"sort"
+	"time"
 
 	"github.com/snissn/gomap/TreeDB/internal/brq"
 	"github.com/snissn/gomap/TreeDB/internal/rabitq"
@@ -73,6 +74,7 @@ const (
 	columnVectorGraphNativeSearchStatsModeDefault columnVectorGraphNativeSearchStatsMode = iota
 	columnVectorGraphNativeSearchStatsModeMinimal
 	columnVectorGraphNativeSearchStatsModeFullDiagnostics
+	columnVectorGraphNativeSearchStatsModeWorkAccounting
 	columnVectorGraphNativeSearchStatsModeBenchmarkDebug
 )
 
@@ -164,7 +166,7 @@ func (p *columnVectorGraphSearchPlan) preparedIndexedScoringDefaultEligible() bo
 
 func (m columnVectorGraphNativeSearchStatsMode) normalized() columnVectorGraphNativeSearchStatsMode {
 	switch m {
-	case columnVectorGraphNativeSearchStatsModeMinimal, columnVectorGraphNativeSearchStatsModeFullDiagnostics, columnVectorGraphNativeSearchStatsModeBenchmarkDebug:
+	case columnVectorGraphNativeSearchStatsModeMinimal, columnVectorGraphNativeSearchStatsModeFullDiagnostics, columnVectorGraphNativeSearchStatsModeWorkAccounting, columnVectorGraphNativeSearchStatsModeBenchmarkDebug:
 		return m
 	default:
 		return columnVectorGraphNativeSearchStatsModeFullDiagnostics
@@ -175,10 +177,16 @@ func (m columnVectorGraphNativeSearchStatsMode) minimal() bool {
 	return m.normalized() == columnVectorGraphNativeSearchStatsModeMinimal
 }
 
+func (m columnVectorGraphNativeSearchStatsMode) workAccounting() bool {
+	return m.normalized() == columnVectorGraphNativeSearchStatsModeWorkAccounting
+}
+
 func (m columnVectorGraphNativeSearchStatsMode) String() string {
 	switch m.normalized() {
 	case columnVectorGraphNativeSearchStatsModeMinimal:
 		return "minimal"
+	case columnVectorGraphNativeSearchStatsModeWorkAccounting:
+		return "work_accounting"
 	case columnVectorGraphNativeSearchStatsModeBenchmarkDebug:
 		return "benchmark_debug"
 	default:
@@ -543,11 +551,61 @@ type columnVectorGraphNativeSearchStats struct {
 	ExactCandidateOrderNonAdjacentForward uint64
 	ExactCandidateOrderBackwardJumps      uint64
 	ExactCandidateOrderMaxForwardRun      uint64
+
+	WorkAccountingSearches uint64
+	DistanceKernelNanos    uint64
+	GraphTraversalNanos    uint64
 }
 
 type columnVectorGraphNativeSearchLoopCounters struct {
 	Edges        uint64
 	VisitedEdges uint64
+}
+
+func columnVectorGraphNativeSearchStartWorkAccounting(stats *columnVectorGraphNativeSearchStats, mode columnVectorGraphNativeSearchStatsMode) {
+	if stats == nil || !mode.workAccounting() {
+		return
+	}
+	stats.WorkAccountingSearches = 1
+}
+
+func columnVectorGraphNativeSearchWorkAccountingEnabled(stats *columnVectorGraphNativeSearchStats) bool {
+	return stats != nil && stats.WorkAccountingSearches != 0
+}
+
+func columnVectorGraphNativeSearchStartDistanceKernel(stats *columnVectorGraphNativeSearchStats) time.Time {
+	if !columnVectorGraphNativeSearchWorkAccountingEnabled(stats) {
+		return time.Time{}
+	}
+	return time.Now()
+}
+
+func columnVectorGraphNativeSearchFinishDistanceKernel(stats *columnVectorGraphNativeSearchStats, start time.Time) {
+	if stats == nil || start.IsZero() {
+		return
+	}
+	stats.DistanceKernelNanos += uint64(time.Since(start))
+}
+
+func columnVectorGraphNativeSearchStartGraphTraversal(stats *columnVectorGraphNativeSearchStats) (time.Time, uint64) {
+	if !columnVectorGraphNativeSearchWorkAccountingEnabled(stats) {
+		return time.Time{}, 0
+	}
+	return time.Now(), stats.DistanceKernelNanos
+}
+
+func columnVectorGraphNativeSearchFinishGraphTraversal(stats *columnVectorGraphNativeSearchStats, start time.Time, distanceBefore uint64) {
+	if stats == nil || start.IsZero() {
+		return
+	}
+	elapsed := uint64(time.Since(start))
+	distance := uint64(0)
+	if stats.DistanceKernelNanos > distanceBefore {
+		distance = stats.DistanceKernelNanos - distanceBefore
+	}
+	if elapsed > distance {
+		stats.GraphTraversalNanos += elapsed - distance
+	}
 }
 
 func (c *columnVectorGraphNativeSearchLoopCounters) publish(stats *columnVectorGraphNativeSearchStats, candidates uint64) {
@@ -1413,6 +1471,7 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 		scoreTileCapacity = retainedCandidateLimit
 	}
 	statsMode := opts.StatsMode.normalized()
+	columnVectorGraphNativeSearchStartWorkAccounting(&stats, statsMode)
 	visitEpochBeforePrepare := uint64(0)
 	if statsMode == columnVectorGraphNativeSearchStatsModeBenchmarkDebug {
 		visitEpochBeforePrepare = scratch.visitEpoch
@@ -1515,6 +1574,7 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 	if err != nil {
 		return nil, stats, err
 	}
+	traversalStart, traversalDistanceBefore := columnVectorGraphNativeSearchStartGraphTraversal(&stats)
 	for layer := maxLayer; layer > 0; layer-- {
 		entryOrdinal, err = r.greedyNearestAtLayer(plan, singleBlockView, query, queryInvNorm, entryOrdinal, layer, candidateRows, hasCandidateRows, scratch, hotStats, countLoopEdges, &loopEdgeVisits, preparedMinimalCounters, debugCounters)
 		if err != nil {
@@ -1540,7 +1600,7 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 			if debugCounters != nil {
 				candidate, ok = scratch.popFrontierDebug(debugCounters)
 			} else {
-				candidate, ok = scratch.popFrontier()
+				candidate, ok = scratch.popFrontierAccounting(hotStats)
 			}
 			if !ok {
 				if len(scratch.top) >= retainedCandidateLimit {
@@ -1708,6 +1768,7 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 		}
 	}
 
+	columnVectorGraphNativeSearchFinishGraphTraversal(&stats, traversalStart, traversalDistanceBefore)
 	if len(scratch.top) == 0 {
 		return scratch.results, stats, nil
 	}
@@ -1800,7 +1861,7 @@ func (r *columnVectorGraphPhysicalRowReader) searchLayer0Wavefront(plan *columnV
 			if debugCounters != nil {
 				candidate, ok = scratch.popFrontierDebug(debugCounters)
 			} else {
-				candidate, ok = scratch.popFrontier()
+				candidate, ok = scratch.popFrontierAccounting(stats)
 			}
 			if !ok {
 				if len(wave) > 0 || len(scratch.top) >= retainedCandidateLimit {
@@ -2266,7 +2327,7 @@ func (r *columnVectorGraphPhysicalRowReader) scoreAndPushFrontierVisited(plan *c
 			scratch.pushFrontierDebug(candidate, debugCounters)
 		}
 	} else if scratch.insertTop(topK, candidate) {
-		scratch.pushFrontier(candidate)
+		scratch.pushFrontierAccounting(candidate, stats)
 	}
 	return nil
 }
@@ -2294,7 +2355,7 @@ func (r *columnVectorGraphPhysicalRowReader) scoreAndPushFrontierVisitedTile(pla
 				scratch.pushFrontierDebug(candidate, debugCounters)
 			}
 		} else if scratch.insertTop(topK, candidate) {
-			scratch.pushFrontier(candidate)
+			scratch.pushFrontierAccounting(candidate, stats)
 		}
 	}
 	return nil
@@ -2677,6 +2738,13 @@ func (s *columnVectorGraphNativeSearchScratch) pushFrontier(candidate columnVect
 	s.frontierSiftUp(len(s.frontier)-1, candidate)
 }
 
+func (s *columnVectorGraphNativeSearchScratch) pushFrontierAccounting(candidate columnVectorGraphSearchCandidate, stats *columnVectorGraphNativeSearchStats) {
+	if columnVectorGraphNativeSearchWorkAccountingEnabled(stats) {
+		stats.FrontierPushes++
+	}
+	s.pushFrontier(candidate)
+}
+
 func (s *columnVectorGraphNativeSearchScratch) pushFrontierDebug(candidate columnVectorGraphSearchCandidate, debugCounters *columnVectorGraphNativeSearchDebugCounters) {
 	debugCounters.stats.FrontierPushes++
 	s.frontier = append(s.frontier, columnVectorGraphSearchCandidate{})
@@ -2695,6 +2763,14 @@ func (s *columnVectorGraphNativeSearchScratch) popFrontier() (columnVectorGraphS
 		s.frontierSiftDown(0, last)
 	}
 	return best, true
+}
+
+func (s *columnVectorGraphNativeSearchScratch) popFrontierAccounting(stats *columnVectorGraphNativeSearchStats) (columnVectorGraphSearchCandidate, bool) {
+	candidate, ok := s.popFrontier()
+	if ok && columnVectorGraphNativeSearchWorkAccountingEnabled(stats) {
+		stats.FrontierPops++
+	}
+	return candidate, ok
 }
 
 func (s *columnVectorGraphNativeSearchScratch) popFrontierDebug(debugCounters *columnVectorGraphNativeSearchDebugCounters) (columnVectorGraphSearchCandidate, bool) {

--- a/TreeDB/collections/column_vector_graph_search_source.go
+++ b/TreeDB/collections/column_vector_graph_search_source.go
@@ -200,6 +200,7 @@ func (s *columnVectorGraphSearchSource) scoreOrdinal(plan *columnVectorGraphSear
 	if stats != nil {
 		recordColumnVectorGraphScoreBatchStats(stats, 1, false, true)
 		stats.VisitedNodes++
+		stats.FP32ScoreCalls++
 		stats.BlockViewHits = plan.hits
 		stats.BlockViewMisses = plan.misses
 		stats.BlockViewBuilds = plan.builds
@@ -218,7 +219,9 @@ func (s *columnVectorGraphSearchSource) scoreOrdinal(plan *columnVectorGraphSear
 		stats.VectorBytesRead += uint64(len(vector)) * 4
 		stats.NormBytesRead += 4
 	}
+	scoreStart := columnVectorGraphNativeSearchStartDistanceKernel(stats)
 	score, err := columnVectorGraphNativeCosineScoreVector(query, queryInvNorm, ordinal, vector, invNorm)
+	columnVectorGraphNativeSearchFinishDistanceKernel(stats, scoreStart)
 	if err != nil {
 		return 0, err
 	}
@@ -311,7 +314,9 @@ func (s *columnVectorGraphSearchSource) scoreOrdinalsIndexed(plan *columnVectorG
 			rowIDs[i] = uint32(loc.rowIndex)
 		}
 		dots := scratch.scoreTileDots[:runLen]
+		scoreStart := columnVectorGraphNativeSearchStartDistanceKernel(stats)
 		status := vectorops.DotFloat32Indexed(dots, part.values, query, rowIDs, s.dims)
+		columnVectorGraphNativeSearchFinishDistanceKernel(stats, scoreStart)
 		if status.Invalid || status.Rows != runLen {
 			return dst, false, nil
 		}
@@ -344,6 +349,7 @@ func (s *columnVectorGraphSearchSource) scoreOrdinalsIndexed(plan *columnVectorG
 		stats.ScoreBatchOptimizedCalls += optimizedCalls
 		stats.ScoreBatchScalarFallbackCalls += scalarFallbackCalls
 		stats.VisitedNodes += uint64(len(ordinals))
+		stats.FP32ScoreCalls += uint64(len(ordinals))
 		stats.CandidateFetches += uint64(len(ordinals))
 		stats.VectorBytesRead += uint64(len(ordinals) * s.dims * 4)
 		stats.NormBytesRead += uint64(len(ordinals) * 4)

--- a/TreeDB/collections/vector_index_search.go
+++ b/TreeDB/collections/vector_index_search.go
@@ -33,6 +33,8 @@ const (
 // Production/minimal mode is the steady-state low-overhead mode: it keeps
 // source-health, admission, result, and fallback counters while avoiding
 // per-edge/per-candidate diagnostic counters on the healthy prepared path.
+// Work-accounting mode is an explicit diagnostic mode for explaining per-query
+// search cost; do not mix it into low-overhead production throughput evidence.
 type VectorIndexSearchStatsMode string
 
 const (
@@ -40,6 +42,7 @@ const (
 	VectorIndexSearchStatsModeMinimal         VectorIndexSearchStatsMode = "minimal"
 	VectorIndexSearchStatsModeProduction      VectorIndexSearchStatsMode = "production"
 	VectorIndexSearchStatsModeFullDiagnostics VectorIndexSearchStatsMode = "full_diagnostics"
+	VectorIndexSearchStatsModeWorkAccounting  VectorIndexSearchStatsMode = "work_accounting"
 	VectorIndexSearchStatsModeBenchmarkDebug  VectorIndexSearchStatsMode = "benchmark_debug"
 )
 
@@ -49,6 +52,8 @@ func columnVectorGraphNativeSearchStatsModeFromPublic(mode VectorIndexSearchStat
 		return columnVectorGraphNativeSearchStatsModeFullDiagnostics, nil
 	case VectorIndexSearchStatsModeMinimal, VectorIndexSearchStatsModeProduction:
 		return columnVectorGraphNativeSearchStatsModeMinimal, nil
+	case VectorIndexSearchStatsModeWorkAccounting:
+		return columnVectorGraphNativeSearchStatsModeWorkAccounting, nil
 	case VectorIndexSearchStatsModeBenchmarkDebug:
 		return columnVectorGraphNativeSearchStatsModeBenchmarkDebug, nil
 	default:
@@ -156,6 +161,8 @@ type VectorIndexSearchStats struct {
 	ScoreBatchScalarFallbackCalls uint64 `json:"score_batch_fallback,omitempty"`
 	// PreparedScoreCalls counts candidate scores produced by the prepared vector/norm scoring view.
 	PreparedScoreCalls uint64 `json:"prepared_score_calls,omitempty"`
+	// FP32ScoreCalls aliases exact float32 candidate score calls for work-accounting consumers.
+	FP32ScoreCalls uint64 `json:"fp32_score_calls,omitempty"`
 	// QuantizedScoreCalls counts candidate scores produced by a quantized score-plane scorer.
 	QuantizedScoreCalls uint64 `json:"quantized_score_calls,omitempty"`
 	// QuantizedCodeBytesRead is the logical quantized code-row byte count read while scoring candidates.
@@ -164,6 +171,8 @@ type VectorIndexSearchStats struct {
 	QuantizedRerankCandidates uint64 `json:"quantized_rerank_candidates,omitempty"`
 	// QuantizedRerankExactScoreCalls counts exact FP32 score calls used by quantized_rerank.
 	QuantizedRerankExactScoreCalls uint64 `json:"quantized_rerank_exact_score_calls,omitempty"`
+	// ExactRerankScoreCalls aliases exact rerank score calls for work-accounting consumers.
+	ExactRerankScoreCalls uint64 `json:"exact_rerank_score_calls,omitempty"`
 	// QuantizedScorerActive reports that a validated quantized scorer served this search.
 	QuantizedScorerActive uint64 `json:"quantized_scorer_active,omitempty"`
 	// QuantizedAssetMissing reports that the selected quantized score-plane asset was absent.
@@ -537,6 +546,8 @@ type VectorIndexSearchStats struct {
 	TopKComparisons                       uint64 `json:"top_k_comparisons,omitempty"`
 	FrontierPushes                        uint64 `json:"frontier_pushes,omitempty"`
 	FrontierPops                          uint64 `json:"frontier_pops,omitempty"`
+	HeapPushes                            uint64 `json:"heap_pushes,omitempty"`
+	HeapPops                              uint64 `json:"heap_pops,omitempty"`
 	FrontierPopMisses                     uint64 `json:"frontier_pop_misses,omitempty"`
 	FrontierSiftUpCalls                   uint64 `json:"frontier_sift_up_calls,omitempty"`
 	FrontierSiftDownCalls                 uint64 `json:"frontier_sift_down_calls,omitempty"`
@@ -559,6 +570,14 @@ type VectorIndexSearchStats struct {
 	ExactCandidateOrderNonAdjacentForward uint64 `json:"exact_candidate_order_non_adjacent_forward,omitempty"`
 	ExactCandidateOrderBackwardJumps      uint64 `json:"exact_candidate_order_backward_jumps,omitempty"`
 	ExactCandidateOrderMaxForwardRun      uint64 `json:"exact_candidate_order_max_forward_run,omitempty"`
+	// WorkAccountingSearches reports that this search collected explicit work-accounting counters/timers.
+	WorkAccountingSearches uint64 `json:"work_accounting_searches,omitempty"`
+	// DistanceKernelNanos attributes query-local candidate scoring time to exact/quantized distance kernels.
+	DistanceKernelNanos uint64 `json:"distance_kernel_nanos,omitempty"`
+	// GraphTraversalNanos attributes HNSW traversal wall time excluding recorded distance-kernel time.
+	GraphTraversalNanos uint64 `json:"graph_traversal_nanos,omitempty"`
+	// ServiceResponseNanos attributes document-service response construction after collection search.
+	ServiceResponseNanos uint64 `json:"service_response_nanos,omitempty"`
 	// DocumentRowRefStateFetches counts post-top-k document fetches served with vector-index row-ref state.
 	DocumentRowRefStateFetches uint64 `json:"document_row_ref_state_fetches,omitempty"`
 	// DocumentRowRefLookupFallbacks counts post-top-k document fetches that fell back to ID-to-row-ref lookup.
@@ -2174,7 +2193,7 @@ func deltaInt64(before, after int64) int64 {
 }
 
 func vectorIndexSearchStatsFromInternal(searchStats columnVectorGraphNativeSearchStats, readerStats columnPhysicalRowReaderStats) VectorIndexSearchStats {
-	return VectorIndexSearchStats{
+	stats := VectorIndexSearchStats{
 		GraphRows:                             uint64(readerStats.Rows),
 		CandidateRows:                         searchStats.CandidateRows,
 		Candidates:                            searchStats.Candidates,
@@ -2363,5 +2382,15 @@ func vectorIndexSearchStatsFromInternal(searchStats columnVectorGraphNativeSearc
 		ExactCandidateOrderNonAdjacentForward: searchStats.ExactCandidateOrderNonAdjacentForward,
 		ExactCandidateOrderBackwardJumps:      searchStats.ExactCandidateOrderBackwardJumps,
 		ExactCandidateOrderMaxForwardRun:      searchStats.ExactCandidateOrderMaxForwardRun,
+		WorkAccountingSearches:                searchStats.WorkAccountingSearches,
+		DistanceKernelNanos:                   searchStats.DistanceKernelNanos,
+		GraphTraversalNanos:                   searchStats.GraphTraversalNanos,
 	}
+	if searchStats.WorkAccountingSearches != 0 {
+		stats.FP32ScoreCalls = searchStats.PreparedScoreCalls
+		stats.ExactRerankScoreCalls = searchStats.QuantizedRerankExactScoreCalls
+		stats.HeapPushes = searchStats.FrontierPushes
+		stats.HeapPops = searchStats.FrontierPops
+	}
+	return stats
 }

--- a/TreeDB/collections/vector_index_search.go
+++ b/TreeDB/collections/vector_index_search.go
@@ -2387,7 +2387,7 @@ func vectorIndexSearchStatsFromInternal(searchStats columnVectorGraphNativeSearc
 		GraphTraversalNanos:                   searchStats.GraphTraversalNanos,
 	}
 	if searchStats.WorkAccountingSearches != 0 {
-		stats.FP32ScoreCalls = searchStats.PreparedScoreCalls
+		stats.FP32ScoreCalls = searchStats.FP32ScoreCalls
 		stats.ExactRerankScoreCalls = searchStats.QuantizedRerankExactScoreCalls
 		stats.HeapPushes = searchStats.FrontierPushes
 		stats.HeapPops = searchStats.FrontierPops

--- a/TreeDB/docs/guides/vector-search-high-qps-collection-api.md
+++ b/TreeDB/docs/guides/vector-search-high-qps-collection-api.md
@@ -26,7 +26,8 @@ For the collection-level serving path:
    generation, and keep rebuild/setup outside the timed request loop.
 2. Use the exact/zero query mode with `IncludeDocuments=false`; leave document
    fetch options, filters, projections, legacy fallback controls, and
-   `benchmark_debug` stats out of the high-QPS request shape.
+   diagnostic stats modes (`benchmark_debug` and `work_accounting`) out of the
+   high-QPS request shape.
 3. Allocate one `VectorIndexSearchBuffer` per goroutine/worker. A buffer is not
    concurrency-safe, and returned `Results`/ID byte slices alias that buffer
    until it is reused or reset.
@@ -44,6 +45,10 @@ opts := collections.VectorIndexSearchOptions{
     EfSearch:  128,
     StatsMode: collections.VectorIndexSearchStatsModeProduction,
 }
+
+// Use VectorIndexSearchStatsModeWorkAccounting only for diagnostic attribution
+// runs. It adds explicit visited-node/edge, score-call, heap, and timer counters
+// and should not be mixed into production-QPS evidence rows.
 
 // Warm the collection-owned prepared search state outside the timed loop.
 if _, err := col.SearchVectorIndexWithBuffer(opts, &buffer); err != nil {

--- a/TreeDB/documentservice/service.go
+++ b/TreeDB/documentservice/service.go
@@ -598,6 +598,9 @@ func (s *Service) SearchBenchmarkVector(ctx context.Context, index string, req B
 	stats := search.Stats
 	if !responseStart.IsZero() {
 		stats.ServiceResponseNanos = uint64(time.Since(responseStart))
+		if stats.ServiceResponseNanos == 0 {
+			stats.ServiceResponseNanos = 1
+		}
 	}
 	return BenchmarkVectorSearchResponse{
 		Index:                     info,

--- a/TreeDB/documentservice/service.go
+++ b/TreeDB/documentservice/service.go
@@ -12,6 +12,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/snissn/gomap/TreeDB/collections"
 	backenddb "github.com/snissn/gomap/TreeDB/db"
@@ -586,9 +587,17 @@ func (s *Service) SearchBenchmarkVector(ctx context.Context, index string, req B
 	if err := validateBenchmarkVectorSearchRoute(queryMode, req, search); err != nil {
 		return BenchmarkVectorSearchResponse{}, err
 	}
+	responseStart := time.Time{}
+	if search.Stats.WorkAccountingSearches != 0 {
+		responseStart = time.Now()
+	}
 	results := benchmarkVectorSearchResults(search.Results)
 	if results == nil {
 		results = []BenchmarkVectorSearchResult{}
+	}
+	stats := search.Stats
+	if !responseStart.IsZero() {
+		stats.ServiceResponseNanos = uint64(time.Since(responseStart))
 	}
 	return BenchmarkVectorSearchResponse{
 		Index:                     info,
@@ -599,8 +608,8 @@ func (s *Service) SearchBenchmarkVector(ctx context.Context, index string, req B
 		QuantizedIndexName:        req.QuantizedIndexName,
 		QuantizedRerankCandidates: req.QuantizedRerankCandidates,
 		NoDocuments:               true,
-		Stats:                     search.Stats,
-		Diagnostics:               search.Diagnostics(),
+		Stats:                     stats,
+		Diagnostics:               stats.Diagnostics(),
 	}, nil
 }
 
@@ -1324,7 +1333,8 @@ func validateBenchmarkVectorStatsMode(mode collections.VectorIndexSearchStatsMod
 	case collections.VectorIndexSearchStatsModeDefault,
 		collections.VectorIndexSearchStatsModeMinimal,
 		collections.VectorIndexSearchStatsModeProduction,
-		collections.VectorIndexSearchStatsModeFullDiagnostics:
+		collections.VectorIndexSearchStatsModeFullDiagnostics,
+		collections.VectorIndexSearchStatsModeWorkAccounting:
 		return nil
 	case collections.VectorIndexSearchStatsModeBenchmarkDebug:
 		return serviceError(CodeInvalidRequest, "benchmark vector search does not support benchmark_debug stats_mode")

--- a/TreeDB/documentservice/service_test.go
+++ b/TreeDB/documentservice/service_test.go
@@ -752,6 +752,13 @@ func TestServiceBenchmarkVectorFailClosed(t *testing.T) {
 	if _, err := svc.OptimizeIndex(ctx, "bench", OptimizeIndexRequest{}); err != nil {
 		t.Fatalf("OptimizeIndex bench: %v", err)
 	}
+	work, err := svc.SearchBenchmarkVector(ctx, "bench", BenchmarkVectorSearchRequest{QueryEmbedding: []float32{1, 0}, TopK: 1, EfSearch: 4, StatsMode: collections.VectorIndexSearchStatsModeWorkAccounting})
+	if err != nil {
+		t.Fatalf("SearchBenchmarkVector work accounting: %v", err)
+	}
+	if !work.NoDocuments || work.Stats.WorkAccountingSearches != 1 || work.Stats.FP32ScoreCalls == 0 || work.Stats.DistanceKernelNanos == 0 || work.Stats.ServiceResponseNanos == 0 {
+		t.Fatalf("work-accounting benchmark response=%+v", work)
+	}
 	if _, err := svc.SearchBenchmarkVector(ctx, "bench", BenchmarkVectorSearchRequest{QueryEmbedding: []float32{1, 0}, TopK: 1, QueryMode: BenchmarkVectorQueryModeQuantizedRerank, QuantizedIndexName: "embedding.scalar_u8.missing", QuantizedRerankCandidates: 32}); ErrorCodeOf(err) != CodeIndexUnavailable {
 		t.Fatalf("unsupported/missing quantized err=%v code=%s", err, ErrorCodeOf(err))
 	}

--- a/docs/TREEDB_DOCUMENT_SERVICE_API.md
+++ b/docs/TREEDB_DOCUMENT_SERVICE_API.md
@@ -415,7 +415,12 @@ dense `/search/vector` route.
 
 Supported JSON `query_mode` values are `exact`, `quantized_only`, and
 `quantized_rerank`. Quantized modes require a declared quantized index name and
-fail closed when assets are missing, invalid, stale, or unavailable. Responses
+fail closed when assets are missing, invalid, stale, or unavailable. Supported
+`stats_mode` values are `minimal`/`production`, `full_diagnostics`, and
+`work_accounting`; `work_accounting` adds per-query work counters and timers such
+as visited nodes/edges, FP32/quantized/exact-rerank score calls, heap pushes/pops,
+`distance_kernel_nanos`, `graph_traversal_nanos`, and
+`service_response_nanos`, and should be kept out of headline QPS rows. Responses
 include result IDs/scores plus TreeDB stats/diagnostics so benchmark adapters can
 assert no-document guardrails: no documents fetched, no exact fallback for
 quantized modes, quantized scorer active, and rerank exact reads bounded by the


### PR DESCRIPTION
## Summary
- add `work_accounting` vector search stats mode for explicit per-query cost attribution
- count visited nodes/edges, FP32/quantized/exact-rerank score calls, heap pushes/pops, and distance-kernel vs graph-traversal timing on HNSW pack/prepared traversal paths
- expose document-service `service_response_nanos` for benchmark vector search responses and document the diagnostic boundary

## Validation
- `make test`

## Benchmark/evidence boundary
- `work_accounting` is diagnostic instrumentation and should not be mixed into production/high-QPS benchmark rows.
- Production/minimal stats remain the low-overhead serving mode.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `work_accounting` vector search stats mode providing detailed diagnostic metrics including FP32 scoring calls, heap operations, and timing breakdowns for distance kernel and graph traversal operations.

* **Documentation**
  * Updated API documentation and guides to clarify supported vector search stats modes; `work_accounting` is designated for diagnostic use only and should not be used in production high-QPS scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->