### PR TITLE
treedb: reduce geth batch replay copies

### DIFF
--- a/TreeDB/command_wal_public_cached.go
+++ b/TreeDB/command_wal_public_cached.go
@@ -318,6 +318,13 @@ func (b *commandWALPublicBatch) setView(key, value []byte, retainReplayViews boo
 	b.preparePayloadForAppend()
 	key = normalizeRawKVPointKey(key)
 	value = normalizeRawKVValue(value)
+	if retainReplayViews && commandWALPublicAllZeroBytes(value) {
+		// The raw-KV payload builder tracks the first zero value by backing-array
+		// identity so repeated immutable zero buffers can avoid rescanning. Adapter
+		// replay-byte callers may reuse and mutate their value buffer between Put
+		// calls, so keep that compact-zero identity tied to an immutable copy.
+		value = append([]byte(nil), value...)
+	}
 	oldLen, oldCount := b.payload.Len(), b.payload.Count()
 	keyView, valueView, err = b.payload.AppendSet(key, value)
 	if err != nil {
@@ -502,6 +509,15 @@ func (b *commandWALPublicBatch) Reset() {
 	b.dirty = false
 	b.retainPayloadAfterWrite = false
 	b.closed = false
+}
+
+func commandWALPublicAllZeroBytes(p []byte) bool {
+	for _, b := range p {
+		if b != 0 {
+			return false
+		}
+	}
+	return len(p) > 0
 }
 
 func (b *commandWALPublicBatch) commandWALPayload() ([]byte, error) {

--- a/TreeDB/command_wal_public_cached.go
+++ b/TreeDB/command_wal_public_cached.go
@@ -202,7 +202,12 @@ type commandWALPublicBatch struct {
 	payloadByteHint   int
 	opCount           int
 	dirty             bool
-	closed            bool
+	// retainPayloadAfterWrite is set by adapter-only replay-view helpers. It
+	// keeps payload-owned key/value views valid after a successful Write until
+	// Reset/Close or the next mutation. Ordinary public Batch callers do not use
+	// those helpers and keep the previous reset-after-write behavior.
+	retainPayloadAfterWrite bool
+	closed                  bool
 }
 
 // Seed command payload capacity for moderately sized values. The op hint is
@@ -229,6 +234,20 @@ func (b *commandWALPublicBatch) resetPayloadWithHint() {
 		return
 	}
 	_ = b.payload.ResetWithHint(b.payloadOpHint, b.payloadByteHint)
+}
+
+func (b *commandWALPublicBatch) preparePayloadForAppend() {
+	if b == nil || !b.retainPayloadAfterWrite || b.dirty {
+		return
+	}
+	// A previous adapter replay-view Write kept payload bytes alive for external
+	// Replay/rebuild semantics. If the inner batch is reused directly without an
+	// explicit Reset, drop those retained bytes before appending a fresh command
+	// payload. The geth adapter detaches borrowed replay views before taking this
+	// path after Write.
+	b.resetPayloadWithHint()
+	b.opCount = 0
+	b.retainPayloadAfterWrite = false
 }
 
 func (b *commandWALPublicBatch) rebindInnerViewers() {
@@ -270,81 +289,91 @@ func (b *commandWALPublicBatch) disableInnerStreamingBypass() {
 }
 
 func (b *commandWALPublicBatch) Set(key, value []byte) error {
-	if b == nil || b.inner == nil {
-		return ErrClosed
-	}
-	key = normalizeRawKVPointKey(key)
-	value = normalizeRawKVValue(value)
-	oldLen, oldCount := b.payload.Len(), b.payload.Count()
-	keyView, valueView, err := b.payload.AppendSet(key, value)
-	if err != nil {
-		return err
-	}
-	if err := b.innerSetView(keyView, valueView); err != nil {
-		b.payload.Truncate(oldLen, oldCount)
-		return err
-	}
-	b.opCount++
-	b.dirty = true
-	return nil
+	_, _, err := b.setView(key, value, false)
+	return err
 }
 
 func (b *commandWALPublicBatch) SetView(key, value []byte) error {
+	_, _, err := b.setView(key, value, false)
+	return err
+}
+
+// SetViewWithReplayBytes records a Put and returns payload-owned immutable
+// key/value views for higher-level adapters that must preserve replay order
+// without making their own hot-path byte clone. The returned views remain valid
+// until this batch is Reset or Closed, or until a subsequent mutation after
+// Write reuses the payload. If the adapter needs to rebuild/reuse the batch
+// after Write, it must copy the views before causing Reset or append reuse on
+// the inner batch.
+//
+// This method is intentionally not part of the public Batch interface.
+func (b *commandWALPublicBatch) SetViewWithReplayBytes(key, value []byte) (keyView, valueView []byte, err error) {
+	return b.setView(key, value, true)
+}
+
+func (b *commandWALPublicBatch) setView(key, value []byte, retainReplayViews bool) (keyView, valueView []byte, err error) {
 	if b == nil || b.inner == nil {
-		return ErrClosed
+		return nil, nil, ErrClosed
 	}
+	b.preparePayloadForAppend()
 	key = normalizeRawKVPointKey(key)
 	value = normalizeRawKVValue(value)
 	oldLen, oldCount := b.payload.Len(), b.payload.Count()
-	keyView, valueView, err := b.payload.AppendSet(key, value)
+	keyView, valueView, err = b.payload.AppendSet(key, value)
 	if err != nil {
-		return err
+		return nil, nil, err
 	}
 	if err := b.innerSetView(keyView, valueView); err != nil {
 		b.payload.Truncate(oldLen, oldCount)
-		return err
+		return nil, nil, err
 	}
 	b.opCount++
 	b.dirty = true
-	return nil
+	if retainReplayViews {
+		b.retainPayloadAfterWrite = true
+	}
+	return keyView, valueView, nil
 }
 
 func (b *commandWALPublicBatch) Delete(key []byte) error {
-	if b == nil || b.inner == nil {
-		return ErrClosed
-	}
-	key = normalizeRawKVPointKey(key)
-	oldLen, oldCount := b.payload.Len(), b.payload.Count()
-	keyView, err := b.payload.AppendDelete(key)
-	if err != nil {
-		return err
-	}
-	if err := b.innerDeleteView(keyView); err != nil {
-		b.payload.Truncate(oldLen, oldCount)
-		return err
-	}
-	b.opCount++
-	b.dirty = true
-	return nil
+	_, err := b.deleteView(key, false)
+	return err
 }
 
 func (b *commandWALPublicBatch) DeleteView(key []byte) error {
+	_, err := b.deleteView(key, false)
+	return err
+}
+
+// DeleteViewWithReplayBytes records a Delete and returns a payload-owned key
+// view for adapter replay logs. See SetViewWithReplayBytes for lifetime rules.
+//
+// This method is intentionally not part of the public Batch interface.
+func (b *commandWALPublicBatch) DeleteViewWithReplayBytes(key []byte) (keyView []byte, err error) {
+	return b.deleteView(key, true)
+}
+
+func (b *commandWALPublicBatch) deleteView(key []byte, retainReplayViews bool) (keyView []byte, err error) {
 	if b == nil || b.inner == nil {
-		return ErrClosed
+		return nil, ErrClosed
 	}
+	b.preparePayloadForAppend()
 	key = normalizeRawKVPointKey(key)
 	oldLen, oldCount := b.payload.Len(), b.payload.Count()
-	keyView, err := b.payload.AppendDelete(key)
+	keyView, err = b.payload.AppendDelete(key)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if err := b.innerDeleteView(keyView); err != nil {
 		b.payload.Truncate(oldLen, oldCount)
-		return err
+		return nil, err
 	}
 	b.opCount++
 	b.dirty = true
-	return nil
+	if retainReplayViews {
+		b.retainPayloadAfterWrite = true
+	}
+	return keyView, nil
 }
 
 func (b *commandWALPublicBatch) DeleteRange(start, end []byte) error {
@@ -354,6 +383,7 @@ func (b *commandWALPublicBatch) DeleteRange(start, end []byte) error {
 	if batch.IsDeleteRangeNoop(start, end) {
 		return nil
 	}
+	b.preparePayloadForAppend()
 	oldLen, oldCount := b.payload.Len(), b.payload.Count()
 	if _, err := b.payload.AppendDeleteRange(start, end); err != nil {
 		return err
@@ -406,7 +436,9 @@ func (b *commandWALPublicBatch) write(sync bool) error {
 			return err
 		}
 		b.disableInnerStreamingBypass()
-		b.resetPayloadWithHint()
+		if !b.retainPayloadAfterWrite {
+			b.resetPayloadWithHint()
+		}
 		b.opCount = 0
 		b.dirty = false
 		return nil
@@ -421,7 +453,9 @@ func (b *commandWALPublicBatch) write(sync bool) error {
 		}
 	}
 	b.disableInnerStreamingBypass()
-	b.resetPayloadWithHint()
+	if !b.retainPayloadAfterWrite {
+		b.resetPayloadWithHint()
+	}
 	b.opCount = 0
 	b.dirty = false
 	return nil
@@ -439,7 +473,9 @@ func (b *commandWALPublicBatch) Close() error {
 	b.innerSetViewFn = nil
 	b.innerDeleteViewFn = nil
 	b.resetPayloadWithHint()
+	b.opCount = 0
 	b.dirty = false
+	b.retainPayloadAfterWrite = false
 	b.closed = true
 	return err
 }
@@ -454,6 +490,7 @@ func (b *commandWALPublicBatch) Reset() {
 		b.resetPayloadWithHint()
 		b.opCount = 0
 		b.dirty = false
+		b.retainPayloadAfterWrite = false
 		b.closed = false
 		return
 	}
@@ -463,6 +500,7 @@ func (b *commandWALPublicBatch) Reset() {
 	b.resetPayloadWithHint()
 	b.opCount = 0
 	b.dirty = false
+	b.retainPayloadAfterWrite = false
 	b.closed = false
 }
 

--- a/TreeDB/command_wal_public_test.go
+++ b/TreeDB/command_wal_public_test.go
@@ -897,6 +897,41 @@ func TestPublicCommandWALBatchResetFallbackKeepsWrapperUsable(t *testing.T) {
 	}
 }
 
+func TestPublicCommandWALBatchReplayBytesSurviveWriteUntilReset(t *testing.T) {
+	inner := &commandWALHookBatch{}
+	wrapped := newCommandWALPublicBatch(nil, inner, 2)
+	key := []byte("alpha")
+	value := []byte("value")
+	keyView, valueView, err := wrapped.SetViewWithReplayBytes(key, value)
+	if err != nil {
+		t.Fatalf("SetViewWithReplayBytes: %v", err)
+	}
+	copy(key, "omega")
+	copy(value, "xxxxx")
+	if string(keyView) != "alpha" || string(valueView) != "value" {
+		t.Fatalf("replay views changed before Write: key=%q value=%q", keyView, valueView)
+	}
+	if err := wrapped.Write(); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if inner.writeAfterCalls != 1 {
+		t.Fatalf("WriteAfterCommandWALAppend calls=%d want 1", inner.writeAfterCalls)
+	}
+	if !wrapped.retainPayloadAfterWrite {
+		t.Fatal("Write did not retain replay-view payload")
+	}
+	if wrapped.dirty || wrapped.opCount != 0 {
+		t.Fatalf("post-Write dirty=%t opCount=%d, want clean", wrapped.dirty, wrapped.opCount)
+	}
+	if string(keyView) != "alpha" || string(valueView) != "value" {
+		t.Fatalf("replay views changed after Write: key=%q value=%q", keyView, valueView)
+	}
+	wrapped.Reset()
+	if wrapped.retainPayloadAfterWrite {
+		t.Fatal("Reset left replay-view payload retained")
+	}
+}
+
 func TestPublicCommandWALBatchResetPreservesCompactZeroScanFallback(t *testing.T) {
 	wrapped := newCommandWALPublicBatch(nil, &commandWALResetBatch{}, 8000)
 	zeroValue := make([]byte, 128)
@@ -958,6 +993,20 @@ type commandWALNoResetBatch struct {
 
 type commandWALResetBatch struct {
 	commandWALNoResetBatch
+}
+
+type commandWALHookBatch struct {
+	commandWALResetBatch
+	writeAfterCalls int
+}
+
+func (b *commandWALHookBatch) WriteAfterCommandWALAppend(_ bool, appendCommand func() error) error {
+	if err := appendCommand(); err != nil {
+		return err
+	}
+	b.writeAfterCalls++
+	b.Reset()
+	return nil
 }
 
 func (b *commandWALResetBatch) Reset() {

--- a/TreeDB/integration/gethethdb/adapter.go
+++ b/TreeDB/integration/gethethdb/adapter.go
@@ -446,12 +446,13 @@ func prefixUpperBound(prefix []byte) []byte {
 
 // Batch implements ethdb.Batch.
 type Batch struct {
-	db           *Database
-	inner        treedb.Batch
-	size         int
-	closed       error
-	ops          []batchOp
-	needsRebuild bool
+	db             *Database
+	inner          treedb.Batch
+	size           int
+	closed         error
+	ops            []batchOp
+	hasBorrowedOps bool
+	needsRebuild   bool
 }
 
 var _ ethdb.Batch = (*Batch)(nil)
@@ -465,9 +466,10 @@ const (
 )
 
 type batchOp struct {
-	kind  batchOpKind
-	key   []byte
-	value []byte
+	kind     batchOpKind
+	key      []byte
+	value    []byte
+	borrowed bool
 }
 
 // Keep adapter op-log reserves bounded because geth-style NewBatchWithSize
@@ -506,16 +508,46 @@ type batchDeleteViewer interface {
 	DeleteView(key []byte) error
 }
 
+type batchReplayBytesSetter interface {
+	SetViewWithReplayBytes(key, value []byte) (keyView, valueView []byte, err error)
+}
+
+type batchReplayBytesDeleter interface {
+	DeleteViewWithReplayBytes(key []byte) (keyView []byte, err error)
+}
+
 func (b *Batch) recordOp(op batchOp) {
 	b.ops = append(b.ops, op)
+	if op.borrowed {
+		b.hasBorrowedOps = true
+	}
 }
 
 func (b *Batch) clearOps() {
+	b.hasBorrowedOps = false
 	if len(b.ops) == 0 {
 		return
 	}
 	clear(b.ops)
 	b.ops = b.ops[:0]
+}
+
+func (b *Batch) detachBorrowedOps() {
+	if b == nil || !b.hasBorrowedOps {
+		return
+	}
+	for i := range b.ops {
+		op := &b.ops[i]
+		if !op.borrowed {
+			continue
+		}
+		op.key = cloneBytes(op.key)
+		if op.kind == batchOpPut || op.kind == batchOpDeleteRange {
+			op.value = cloneBytes(op.value)
+		}
+		op.borrowed = false
+	}
+	b.hasBorrowedOps = false
 }
 
 func (b *Batch) ensureInnerReady() error {
@@ -570,6 +602,15 @@ func (b *Batch) Put(key []byte, value []byte) error {
 	if err := b.ensureInnerReady(); err != nil {
 		return err
 	}
+	if setter, ok := b.inner.(batchReplayBytesSetter); ok {
+		keyView, valueView, err := setter.SetViewWithReplayBytes(key, value)
+		if err != nil {
+			return err
+		}
+		b.recordOp(batchOp{kind: batchOpPut, key: keyView, value: valueView, borrowed: true})
+		b.size += len(key) + len(value)
+		return nil
+	}
 	op := batchOp{kind: batchOpPut, key: cloneBytes(key), value: cloneBytes(value)}
 	if err := b.applyOpToInner(op); err != nil {
 		return err
@@ -591,6 +632,15 @@ func (b *Batch) Delete(key []byte) error {
 	}
 	if err := b.ensureInnerReady(); err != nil {
 		return err
+	}
+	if deleter, ok := b.inner.(batchReplayBytesDeleter); ok {
+		keyView, err := deleter.DeleteViewWithReplayBytes(key)
+		if err != nil {
+			return err
+		}
+		b.recordOp(batchOp{kind: batchOpDelete, key: keyView, borrowed: true})
+		b.size += len(key)
+		return nil
 	}
 	op := batchOp{kind: batchOpDelete, key: cloneBytes(key)}
 	if err := b.applyOpToInner(op); err != nil {
@@ -666,6 +716,9 @@ func (b *Batch) rebuildInnerFromOps() error {
 		b.closed = ErrClosed
 		return ErrClosed
 	}
+	// Borrowed operation-log slices point into the current inner command-WAL
+	// payload. Rebuilding resets that inner payload, so detach before Reset.
+	b.detachBorrowedOps()
 	if b.inner != nil {
 		if resetter, ok := b.inner.(interface{ Reset() }); ok {
 			resetter.Reset()
@@ -759,6 +812,10 @@ func (b *Batch) Close() {
 	if b == nil || b.inner == nil {
 		return
 	}
+	// Keep ethdb Replay semantics for already queued operations even after Close:
+	// borrowed replay views must outlive the inner command-WAL payload being
+	// closed/reset here.
+	b.detachBorrowedOps()
 	_ = b.inner.Close()
 	b.inner = nil
 	b.needsRebuild = false

--- a/TreeDB/integration/gethethdb/adapter_test.go
+++ b/TreeDB/integration/gethethdb/adapter_test.go
@@ -505,6 +505,94 @@ func TestBatchClonesCallerBuffersForWriteReplayAndReuse(t *testing.T) {
 	assertValue(t, db, []byte("key-a"), []byte("value-a"))
 }
 
+func TestBatchReplayBeforeWriteUsesCommandWALOwnedBytes(t *testing.T) {
+	db := openTestDB(t)
+	batch, ok := db.NewBatch().(*Batch)
+	if !ok {
+		t.Fatalf("NewBatch type=%T want *Batch", db.NewBatch())
+	}
+	key := []byte("key-a")
+	value := []byte("value-a")
+	if err := batch.Put(key, value); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	if !batch.hasBorrowedOps {
+		t.Skip("local TreeDB command-WAL replay-byte optimization unavailable without a gomap module replace")
+	}
+	copy(key, "key-b")
+	copy(value, "value-b")
+	var rec replayRecorder
+	if err := batch.Replay(&rec); err != nil {
+		t.Fatalf("Replay before Write: %v", err)
+	}
+	if want := []string{"put:key-a=value-a"}; !slices.Equal(rec.ops, want) {
+		t.Fatalf("replay before Write ops=%v want %v", rec.ops, want)
+	}
+	if err := batch.Write(); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if !batch.hasBorrowedOps {
+		t.Fatal("Write+pending replay should retain borrowed op-log bytes until Reset/rebuild")
+	}
+	batch.Reset()
+	if batch.hasBorrowedOps || len(batch.ops) != 0 {
+		t.Fatalf("Reset left borrowed=%t ops=%d", batch.hasBorrowedOps, len(batch.ops))
+	}
+}
+
+func TestBatchRepeatedWriteDetachesCommandWALBorrowedReplayBytes(t *testing.T) {
+	db := openTestDB(t)
+	batch := db.NewBatch().(*Batch)
+	if err := batch.Put([]byte("key-a"), []byte("value-a")); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	if err := batch.Write(); err != nil {
+		t.Fatalf("first Write: %v", err)
+	}
+	if !batch.hasBorrowedOps {
+		t.Skip("local TreeDB command-WAL replay-byte optimization unavailable without a gomap module replace")
+	}
+	if err := db.Delete([]byte("key-a")); err != nil {
+		t.Fatalf("external Delete: %v", err)
+	}
+	if err := batch.Write(); err != nil {
+		t.Fatalf("second Write: %v", err)
+	}
+	if batch.hasBorrowedOps {
+		t.Fatal("repeated Write should detach borrowed replay bytes before rebuilding")
+	}
+	assertValue(t, db, []byte("key-a"), []byte("value-a"))
+}
+
+func TestBatchReplayAfterCloseDetachesCommandWALBorrowedReplayBytes(t *testing.T) {
+	db := openTestDB(t)
+	batch := db.NewBatch().(*Batch)
+	if err := batch.Put([]byte("key-a"), []byte("value-a")); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	if err := batch.Write(); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if !batch.hasBorrowedOps {
+		t.Skip("local TreeDB command-WAL replay-byte optimization unavailable without a gomap module replace")
+	}
+	closer, ok := any(batch).(interface{ Close() })
+	if !ok {
+		t.Fatal("batch does not expose Close")
+	}
+	closer.Close()
+	if batch.hasBorrowedOps {
+		t.Fatal("Close should detach borrowed replay bytes")
+	}
+	var rec replayRecorder
+	if err := batch.Replay(&rec); err != nil {
+		t.Fatalf("Replay after Close: %v", err)
+	}
+	if want := []string{"put:key-a=value-a"}; !slices.Equal(rec.ops, want) {
+		t.Fatalf("replay after Close ops=%v want %v", rec.ops, want)
+	}
+}
+
 func TestBatchDeleteAndDeleteRangeCloneCallerBuffersForReplayAndReuse(t *testing.T) {
 	db := openTestDB(t)
 	for _, key := range []string{"aa", "bb", "bc", "za", "zb"} {

--- a/TreeDB/integration/gethethdb/adapter_test.go
+++ b/TreeDB/integration/gethethdb/adapter_test.go
@@ -540,6 +540,34 @@ func TestBatchReplayBeforeWriteUsesCommandWALOwnedBytes(t *testing.T) {
 	}
 }
 
+func TestBatchBorrowedReplayBytesHandleReusedZeroValueBuffer(t *testing.T) {
+	db := openTestDB(t)
+	batch := db.NewBatch().(*Batch)
+	value := make([]byte, len("value-b"))
+	if err := batch.Put([]byte("key-a"), value); err != nil {
+		t.Fatalf("Put zero value: %v", err)
+	}
+	if !batch.hasBorrowedOps {
+		t.Skip("local TreeDB command-WAL replay-byte optimization unavailable without a gomap module replace")
+	}
+	copy(value, "value-b")
+	if err := batch.Put([]byte("key-b"), value); err != nil {
+		t.Fatalf("Put reused nonzero value: %v", err)
+	}
+	var rec replayRecorder
+	if err := batch.Replay(&rec); err != nil {
+		t.Fatalf("Replay before Write: %v", err)
+	}
+	if want := []string{"put:key-a=\x00\x00\x00\x00\x00\x00\x00", "put:key-b=value-b"}; !slices.Equal(rec.ops, want) {
+		t.Fatalf("replay ops=%q want %q", rec.ops, want)
+	}
+	if err := batch.Write(); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	assertValue(t, db, []byte("key-a"), make([]byte, len("value-b")))
+	assertValue(t, db, []byte("key-b"), []byte("value-b"))
+}
+
 func TestBatchRepeatedWriteDetachesCommandWALBorrowedReplayBytes(t *testing.T) {
 	db := openTestDB(t)
 	batch := db.NewBatch().(*Batch)

--- a/TreeDB/integration/gethethdb/go.mod
+++ b/TreeDB/integration/gethethdb/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/ethereum/go-ethereum v1.16.9
-	github.com/snissn/gomap v0.0.0-20260605130228-58f3398da631
+	github.com/snissn/gomap v0.0.0-20260613184912-397cae481914
 )
 
 require (

--- a/TreeDB/integration/gethethdb/go.mod
+++ b/TreeDB/integration/gethethdb/go.mod
@@ -1,6 +1,6 @@
 module github.com/snissn/gomap/TreeDB/integration/gethethdb
 
-go 1.25.0
+go 1.26
 
 require (
 	github.com/ethereum/go-ethereum v1.16.9
@@ -16,5 +16,5 @@ require (
 	github.com/snissn/go-crc32-asm v0.0.0-20260522204125-08945951423a // indirect
 	github.com/tidwall/btree v1.8.1 // indirect
 	github.com/zeebo/xxh3 v1.1.0 // indirect
-	golang.org/x/sys v0.40.0 // indirect
+	golang.org/x/sys v0.41.0 // indirect
 )

--- a/TreeDB/integration/gethethdb/go.mod
+++ b/TreeDB/integration/gethethdb/go.mod
@@ -4,7 +4,7 @@ go 1.26
 
 require (
 	github.com/ethereum/go-ethereum v1.16.9
-	github.com/snissn/gomap v0.0.0-20260613184912-397cae481914
+	github.com/snissn/gomap v0.0.0-20260613195517-98e19772e489
 )
 
 require (

--- a/TreeDB/integration/gethethdb/go.sum
+++ b/TreeDB/integration/gethethdb/go.sum
@@ -18,6 +18,8 @@ github.com/snissn/go-crc32-asm v0.0.0-20260522204125-08945951423a h1:uqSq50AAT36
 github.com/snissn/go-crc32-asm v0.0.0-20260522204125-08945951423a/go.mod h1:PDwKLbWpRDAN2IPbK9PxIgSx0YdwQaSOLWObRawQJ58=
 github.com/snissn/gomap v0.0.0-20260605130228-58f3398da631 h1:O7x3b+ndZz/saU7VWloGvdVCol1SwmVWLUs9GtdYmTU=
 github.com/snissn/gomap v0.0.0-20260605130228-58f3398da631/go.mod h1:QSwxtipoA9YdqEDYTU2UE6ZU4R2odrOdeLdtz6jzqtI=
+github.com/snissn/gomap v0.0.0-20260613184912-397cae481914 h1:LwTsNJWCQyi1MAMOjp2ATwxXxE2lT2atfSEGsDjHuaU=
+github.com/snissn/gomap v0.0.0-20260613184912-397cae481914/go.mod h1:WSaOg+m8hiLvRpKSqn3ylr0H4ZMKOHghhJqIg1/RO/4=
 github.com/tidwall/btree v1.8.1 h1:27ehoXvm5AG/g+1VxLS1SD3vRhp/H7LuEfwNvddEdmA=
 github.com/tidwall/btree v1.8.1/go.mod h1:jBbTdUWhSZClZWoDg54VnvV7/54modSOzDN7VXftj1A=
 github.com/zeebo/assert v1.3.0 h1:g7C04CbJuIDKNPFHmsk4hwZDO5O+kntRxzaUoNXj+IQ=

--- a/TreeDB/integration/gethethdb/go.sum
+++ b/TreeDB/integration/gethethdb/go.sum
@@ -16,8 +16,6 @@ github.com/snissn/compress v1.18.2-snissn.0.0.20260506201017-87fb149e4721 h1:2XY
 github.com/snissn/compress v1.18.2-snissn.0.0.20260506201017-87fb149e4721/go.mod h1:p4xiZN07JMUF5xuybNGkG+pozT12MAblxCx36z+PIYM=
 github.com/snissn/go-crc32-asm v0.0.0-20260522204125-08945951423a h1:uqSq50AAT36ZzDiRApq8GNsbeJASPaneZ6aKfw3KShc=
 github.com/snissn/go-crc32-asm v0.0.0-20260522204125-08945951423a/go.mod h1:PDwKLbWpRDAN2IPbK9PxIgSx0YdwQaSOLWObRawQJ58=
-github.com/snissn/gomap v0.0.0-20260605130228-58f3398da631 h1:O7x3b+ndZz/saU7VWloGvdVCol1SwmVWLUs9GtdYmTU=
-github.com/snissn/gomap v0.0.0-20260605130228-58f3398da631/go.mod h1:QSwxtipoA9YdqEDYTU2UE6ZU4R2odrOdeLdtz6jzqtI=
 github.com/snissn/gomap v0.0.0-20260613184912-397cae481914 h1:LwTsNJWCQyi1MAMOjp2ATwxXxE2lT2atfSEGsDjHuaU=
 github.com/snissn/gomap v0.0.0-20260613184912-397cae481914/go.mod h1:WSaOg+m8hiLvRpKSqn3ylr0H4ZMKOHghhJqIg1/RO/4=
 github.com/tidwall/btree v1.8.1 h1:27ehoXvm5AG/g+1VxLS1SD3vRhp/H7LuEfwNvddEdmA=
@@ -26,5 +24,5 @@ github.com/zeebo/assert v1.3.0 h1:g7C04CbJuIDKNPFHmsk4hwZDO5O+kntRxzaUoNXj+IQ=
 github.com/zeebo/assert v1.3.0/go.mod h1:Pq9JiuJQpG8JLJdtkwrJESF0Foym2/D9XMU5ciN/wJ0=
 github.com/zeebo/xxh3 v1.1.0 h1:s7DLGDK45Dyfg7++yxI0khrfwq9661w9EN78eP/UZVs=
 github.com/zeebo/xxh3 v1.1.0/go.mod h1:IisAie1LELR4xhVinxWS5+zf1lA4p0MW4T+w+W07F5s=
-golang.org/x/sys v0.40.0 h1:DBZZqJ2Rkml6QMQsZywtnjnnGvHza6BTfYFWY9kjEWQ=
-golang.org/x/sys v0.40.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
+golang.org/x/sys v0.41.0 h1:Ivj+2Cp/ylzLiEU89QhWblYnOE9zerudt9Ftecq2C6k=
+golang.org/x/sys v0.41.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=

--- a/TreeDB/integration/gethethdb/go.sum
+++ b/TreeDB/integration/gethethdb/go.sum
@@ -16,8 +16,8 @@ github.com/snissn/compress v1.18.2-snissn.0.0.20260506201017-87fb149e4721 h1:2XY
 github.com/snissn/compress v1.18.2-snissn.0.0.20260506201017-87fb149e4721/go.mod h1:p4xiZN07JMUF5xuybNGkG+pozT12MAblxCx36z+PIYM=
 github.com/snissn/go-crc32-asm v0.0.0-20260522204125-08945951423a h1:uqSq50AAT36ZzDiRApq8GNsbeJASPaneZ6aKfw3KShc=
 github.com/snissn/go-crc32-asm v0.0.0-20260522204125-08945951423a/go.mod h1:PDwKLbWpRDAN2IPbK9PxIgSx0YdwQaSOLWObRawQJ58=
-github.com/snissn/gomap v0.0.0-20260613184912-397cae481914 h1:LwTsNJWCQyi1MAMOjp2ATwxXxE2lT2atfSEGsDjHuaU=
-github.com/snissn/gomap v0.0.0-20260613184912-397cae481914/go.mod h1:WSaOg+m8hiLvRpKSqn3ylr0H4ZMKOHghhJqIg1/RO/4=
+github.com/snissn/gomap v0.0.0-20260613195517-98e19772e489 h1:Mh7rm7Pgt+D4QlmmEBSuqpxiIRUs7BbTAr1ZRMaZLsw=
+github.com/snissn/gomap v0.0.0-20260613195517-98e19772e489/go.mod h1:WSaOg+m8hiLvRpKSqn3ylr0H4ZMKOHghhJqIg1/RO/4=
 github.com/tidwall/btree v1.8.1 h1:27ehoXvm5AG/g+1VxLS1SD3vRhp/H7LuEfwNvddEdmA=
 github.com/tidwall/btree v1.8.1/go.mod h1:jBbTdUWhSZClZWoDg54VnvV7/54modSOzDN7VXftj1A=
 github.com/zeebo/assert v1.3.0 h1:g7C04CbJuIDKNPFHmsk4hwZDO5O+kntRxzaUoNXj+IQ=

--- a/TreeDB/integration/gethethdb/reopen_test.go
+++ b/TreeDB/integration/gethethdb/reopen_test.go
@@ -21,6 +21,40 @@ func openAtPath(t testing.TB, dir string) *Database {
 	return db
 }
 
+func TestCommandWALReopenPersistsBorrowedBatchPut(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "treedb")
+	db := openAtPath(t, dir)
+
+	batch, ok := db.NewBatch().(*Batch)
+	if !ok {
+		t.Fatalf("NewBatch type=%T want *Batch", db.NewBatch())
+	}
+	key := []byte("borrowed-key")
+	value := []byte("borrowed-value")
+	if err := batch.Put(key, value); err != nil {
+		t.Fatalf("batch Put: %v", err)
+	}
+	if !batch.hasBorrowedOps {
+		t.Skip("local TreeDB command-WAL replay-byte optimization unavailable without a gomap module replace")
+	}
+	copy(key, "mutated-key-")
+	copy(value, "mutated-value-")
+	if err := batch.Write(); err != nil {
+		t.Fatalf("batch Write: %v", err)
+	}
+	if err := db.SyncKeyValue(); err != nil {
+		t.Fatalf("SyncKeyValue: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	reopened := openAtPath(t, dir)
+	defer reopened.Close()
+	assertValue(t, reopened, []byte("borrowed-key"), []byte("borrowed-value"))
+	assertMissing(t, reopened, []byte("mutated-key-"))
+}
+
 func TestCommandWALReopenPersistsAdapterOperations(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), "treedb")
 	db := openAtPath(t, dir)


### PR DESCRIPTION
## Summary

Fixes #2709. Parent tracker: #2676.

Reduces TreeDB geth `ethdb.Batch` write allocation/copy pressure on the durable command-WAL path by letting the geth adapter record replay-log entries as command-WAL payload-owned byte views for the common Put/Delete path. The adapter detaches those borrowed views only when an uncommon repeated `Write`/rebuild or `Close` needs the operation log to outlive the inner command-WAL payload.

Scope boundaries preserved:

- no command-WAL durability/flush/sync semantic changes;
- no read-integrity/default checksum changes;
- no DeleteRange range tombstone work;
- TreeDB remains explicit/experimental; Pebble remains default.

## Tests

Latest head after Codex review fixes (`cfc3c21f5b9ef89b81a2a12ad6ab1cb39f31b06c`):

```sh
go test ./TreeDB -run 'TestPublicCommandWALBatchReplayBytesSurviveWriteUntilReset|TestPublicCommandWALBatchResetPreservesCompactZeroScanFallback|TestPublicCommandWALBatchResetFallbackKeepsWrapperUsable' -count=1

go test ./TreeDB/caching -run 'Test(BatchSetView|AppendOnlyBatchSetView|BatchWriteSortedSetView|CanPiggybackCommandWAL|CachingBatch|CachingDB_DeleteRange)' -count=1

go test ./TreeDB/db -run 'Test.*CommandWAL|TestNewBatchWithSize|TestRawKV' -count=1

(cd TreeDB/integration/gethethdb && GOTOOLCHAIN=go1.26.0 go test ./... -run 'TestBatch(BorrowedReplayBytesHandleReusedZeroValueBuffer|ReplayBeforeWriteUsesCommandWALOwnedBytes|RepeatedWriteDetachesCommandWALBorrowedReplayBytes|ReplayAfterCloseDetachesCommandWALBorrowedReplayBytes)' -count=1)

(cd TreeDB/integration/gethethdb && GOTOOLCHAIN=go1.26.0 go test ./... -count=1)

cd TreeDB/integration/gethethdb && \
OUT=/tmp/gethethdb_2709_final_local_20260613T192217Z && \
MOD="$OUT/local.mod" && cp go.mod "$MOD" && cp go.sum "${MOD%.mod}.sum" && \
printf '\nreplace github.com/snissn/gomap => %s\n' "$(cd ../../.. && pwd)" >> "$MOD" && \
GOTOOLCHAIN=go1.26.0 GOFLAGS="-modfile=$MOD -mod=mod" go test ./... -count=1
```

## Review-fix notes

Codex latest-head review found and this PR fixed:

- nested `gethethdb` module versioning: the submodule now requires a root `github.com/snissn/gomap` pseudo-version that exposes the replay-byte TreeDB batch methods, and is tidied for Go 1.26 to match the root module;
- reused zero-value buffer safety: replay-byte `Put` now copies all-zero values before handing them to the raw-KV compact-zero payload builder, so a caller that reuses and mutates the same value backing array cannot cause later non-zero puts to replay/write as compact zeros.

New regression coverage: `TestBatchBorrowedReplayBytesHandleReusedZeroValueBuffer`.

## Performance evidence

### Latest-head 1M timing reruns

Latest-head candidate/base timing artifacts after branch update:

- candidate: `/tmp/geth_hotkv_2709_latesthead_candidate_1m_timing_20260613T190942Z_r1`
- baseline: `/tmp/geth_hotkv_2709_latesthead_baseline_1m_timing_20260613T190942Z_r1`
- earlier latest-head pair: `/tmp/geth_hotkv_2709_latesthead_candidate_1m_timing_20260613T190839Z_r1` vs `/tmp/geth_hotkv_2709_latesthead_baseline_1m_timing_20260613T190839Z_r1`

Primary latest-head timing pair:

| metric | baseline | candidate | candidate/base |
|---|---:|---:|---:|
| write ops/sec | 378,881 | 585,356 | 1.54x |
| read ops/sec | 159,251 | 136,131 | 0.85x noisy/non-targeted |
| iterate keys/sec | 7,889,736 | 6,911,704 | 0.88x noisy/non-targeted |
| DeleteRange keys/sec | 948,048 | 438,508 | 0.46x noisy/non-targeted |
| size bytes | 771,304,381 | 771,304,381 | unchanged |
| post-delete bytes | 393,933,629 | 393,938,751 | effectively unchanged |

An earlier latest-head timing pair showed the same write-direction improvement but different non-target phase noise:

| metric | baseline | candidate | candidate/base |
|---|---:|---:|---:|
| write ops/sec | 272,329 | 339,690 | 1.25x |
| read ops/sec | 112,896 | 96,799 | 0.86x noisy/non-targeted |
| iterate keys/sec | 6,379,199 | 5,352,765 | 0.84x noisy/non-targeted |
| DeleteRange keys/sec | 394,105 | 505,407 | 1.28x noisy/non-targeted |

The code path changed here is geth-adapter command-WAL batch write/replay ownership. It does not change read, iteration, DeleteRange, storage format, value-log read integrity, or command-WAL frame semantics. Non-target phase timing was noisy across runs; storage and write-path counters remained effectively unchanged.

### Latest-head profile/memstats evidence

Profile/memstats artifacts after updating onto current main:

- baseline profile: `/tmp/geth_hotkv_2709_latest_base_1m_profile_20260613T184054Z`
- baseline profiles: `/tmp/geth_hotkv_2709_latest_base_1m_profiles_20260613T184054Z/01_geth-mixed_geth-mixed_v128_b102400_verify_value`
- candidate profile: `/tmp/geth_hotkv_2709_latest_candidate_1m_profile_20260613T184951Z`
- candidate profiles: `/tmp/geth_hotkv_2709_latest_candidate_1m_profiles_20260613T184951Z/01_geth-mixed_geth-mixed_v128_b102400_verify_value`

Write phase memstats:

| metric | baseline | candidate | delta |
|---|---:|---:|---:|
| `total_alloc_bytes` | 1,372,239,808 | 989,101,408 | -27.9% |
| `mallocs` | 3,176,372 | 1,176,931 | -63.0% |
| `num_gc_delta` | 2 | 1 | -1 GC |

Write counters remained shape-equivalent in the profiled 1M runs: command-WAL frames and value-log write-mode/frame counters did not change materially. Storage bytes were unchanged.

### Adapter microbenchmark

Pre-update microbench artifact `/tmp/gethethdb_2709_bench_20260613T181342Z/benchstat.txt` for the same diff:

- `BatchWrite/adapter`: allocs/op `82 -> 49` (-40.2%), B/op -4.6%, sec/op -6.8%.
- `BatchWriteReset/adapter`: allocs/op `59 -> 26` (-55.9%), B/op -10.6%, sec/op -2.4%.

A latest-head candidate-only sanity rerun is at `/tmp/gethethdb_2709_bench_rebased_20260613T182243Z/candidate.bench`.

## Regression assessment

- Target write allocation/copy pressure improved materially: ~28% fewer write-phase allocated bytes and ~63% fewer write-phase mallocs in the 1M profile evidence.
- Write throughput improved in both latest-head timing pairs, though absolute throughput remains noisy.
- No storage-size, post-delete-size, command-WAL frame-count, read-integrity, or durability semantic change is intended.
- Read/iterate/DeleteRange timings in the latest-head pairs were noisy and non-targeted; the changed code is not on those read/iteration/DeleteRange paths.

## AI review / CI status

- CI: latest-head CI is running for `cfc3c21f5b9ef89b81a2a12ad6ab1cb39f31b06c` after Codex P1/P2 fixes. Previous heads were green.
- AI reviews: Codex P1 zero-buffer and P2 module requirement findings fixed; latest-head re-review requested.
- Merge status: not merged by manager; coordinator owns final review/merge.


