### PR TITLE
TreeDB text v2/hybrid: build comparison scoreboard

### DIFF
--- a/benchmarks/text_hybrid_scoreboard/sqlite_fts5_bench.py
+++ b/benchmarks/text_hybrid_scoreboard/sqlite_fts5_bench.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""SQLite FTS5 text baseline for the TreeDB text/hybrid scoreboard.
+
+The script intentionally uses only Python's stdlib sqlite3 module. It writes a
+small JSON artifact that cmd/treedb_text_hybrid_scoreboard can ingest. If the
+local sqlite3 build lacks FTS5 support, it writes an explicit unavailable JSON
+instead of fabricating a row.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import platform
+import sqlite3
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run a deterministic SQLite FTS5 text baseline")
+    parser.add_argument("--docs", type=int, default=10_000)
+    parser.add_argument("--queries", type=int, default=1_000)
+    parser.add_argument("--top-k", type=int, default=10)
+    parser.add_argument("--query", default="refund policy")
+    parser.add_argument("--out", required=True, help="JSON output path")
+    parser.add_argument("--db", default="", help="SQLite DB path; defaults to a file beside --out")
+    parser.add_argument("--keep-db", action="store_true")
+    parser.add_argument("--tokenize", default="unicode61")
+    return parser.parse_args()
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def unavailable(args: argparse.Namespace, reason: str) -> dict[str, Any]:
+    return {
+        "schema_version": "treedb_text_hybrid_external/v1",
+        "status": "unavailable",
+        "system": "SQLite FTS5",
+        "engine": "sqlite_fts5",
+        "unavailable_reason": reason,
+        "command": " ".join(sys.argv),
+        "versions": versions(),
+    }
+
+
+def versions() -> dict[str, str]:
+    return {
+        "python": sys.version.replace("\n", " "),
+        "sqlite": sqlite3.sqlite_version,
+        "platform": platform.platform(),
+    }
+
+
+def configure(conn: sqlite3.Connection) -> None:
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA synchronous=NORMAL")
+    conn.execute("PRAGMA temp_store=MEMORY")
+    conn.execute("PRAGMA cache_size=-200000")
+
+
+def fixture_row(i: int) -> tuple[str, str]:
+    if i % 2 == 0:
+        title = "refund policy"
+        body = f"refund policy customer credit shard {i % 17} incident {i % 31}"
+    else:
+        title = "shipping status"
+        body = f"shipping status update parcel route shard {i % 17} customer {i % 31}"
+    return title, body
+
+
+def storage_bytes(db_path: Path) -> int:
+    total = 0
+    for suffix in ("", "-wal", "-shm"):
+        path = Path(str(db_path) + suffix)
+        if path.exists():
+            total += path.stat().st_size
+    return total
+
+
+def percentile(sorted_values: list[int], pct: float) -> int:
+    if not sorted_values:
+        return 0
+    if len(sorted_values) == 1:
+        return sorted_values[0]
+    rank = (len(sorted_values) - 1) * pct / 100.0
+    lo = int(rank)
+    hi = min(lo + 1, len(sorted_values) - 1)
+    frac = rank - lo
+    return int(sorted_values[lo] * (1 - frac) + sorted_values[hi] * frac)
+
+
+def main() -> int:
+    args = parse_args()
+    out = Path(args.out)
+    if args.docs <= 0 or args.queries <= 0 or args.top_k <= 0:
+        raise SystemExit("--docs, --queries, and --top-k must be positive")
+
+    db_path = Path(args.db) if args.db else out.with_suffix(".sqlite3")
+    if db_path.exists():
+        db_path.unlink()
+    for suffix in ("-wal", "-shm"):
+        p = Path(str(db_path) + suffix)
+        if p.exists():
+            p.unlink()
+
+    try:
+        conn = sqlite3.connect(str(db_path))
+        configure(conn)
+        conn.execute(f"CREATE VIRTUAL TABLE docs_fts USING fts5(title, body, tokenize='{args.tokenize}')")
+    except sqlite3.Error as exc:
+        write_json(out, unavailable(args, f"Python sqlite3/SQLite does not provide usable FTS5: {exc}"))
+        return 0
+
+    build_start = time.perf_counter()
+    with conn:
+        conn.executemany("INSERT INTO docs_fts(rowid, title, body) VALUES (?, ?, ?)", ((i + 1, *fixture_row(i)) for i in range(args.docs)))
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+    build_seconds = time.perf_counter() - build_start
+
+    sql = "SELECT rowid, bm25(docs_fts, 3.0, 1.0) AS score FROM docs_fts WHERE docs_fts MATCH ? ORDER BY score LIMIT ?"
+    # Warm outside the timed loop and assert that the query shape has hits.
+    warm = list(conn.execute(sql, (args.query, args.top_k)))
+    if not warm:
+        raise SystemExit(f"query {args.query!r} returned no rows")
+
+    durations: list[int] = []
+    total_results = 0
+    search_start = time.perf_counter_ns()
+    for i in range(args.queries):
+        start = time.perf_counter_ns()
+        rows = list(conn.execute(sql, (args.query, args.top_k)))
+        durations.append(time.perf_counter_ns() - start)
+        total_results += len(rows)
+    total_nanos = time.perf_counter_ns() - search_start
+    sorted_durations = sorted(durations)
+    avg_nanos = total_nanos / args.queries
+    ops_per_second = 1_000_000_000 / avg_nanos if avg_nanos > 0 else 0
+
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+    conn.close()
+    total_storage = storage_bytes(db_path)
+    if not args.keep_db:
+        for suffix in ("", "-wal", "-shm"):
+            p = Path(str(db_path) + suffix)
+            try:
+                p.unlink()
+            except FileNotFoundError:
+                pass
+
+    payload = {
+        "schema_version": "treedb_text_hybrid_external/v1",
+        "status": "ok",
+        "system": "SQLite FTS5",
+        "engine": "sqlite_fts5",
+        "modality": "text_only",
+        "dataset": {
+            "docs": args.docs,
+            "queries": args.queries,
+            "top_k": args.top_k,
+            "fields": 2,
+        },
+        "query_set": "synthetic refund/shipping corpus",
+        "query_shape": f"FTS5 MATCH {args.query!r} + bm25 top-{args.top_k}",
+        "boundary": "no-document rowid+bm25 retrieval only; no primary JSON document fetch",
+        "benchmark": "sqlite_fts5/search_rowid_bm25_no_docs",
+        "command": " ".join(sys.argv),
+        "versions": versions(),
+        "build": {"seconds": build_seconds},
+        "storage": {"total_bytes": total_storage, "bytes_per_doc": total_storage / args.docs},
+        "search": {
+            "queries": args.queries,
+            "avg_nanos": avg_nanos,
+            "ops_per_second": ops_per_second,
+            "p50_nanos": percentile(sorted_durations, 50),
+            "p95_nanos": percentile(sorted_durations, 95),
+            "p99_nanos": percentile(sorted_durations, 99),
+        },
+        "metrics": {
+            "docs_fetched/search": 0,
+            "full_doc_fallbacks/search": 0,
+            "fail_closed/search": 0,
+            "results/search": total_results / args.queries,
+        },
+        "caveats": [
+            "SQLite FTS5 is an embedded text baseline only; it is not a vector or hybrid-search engine.",
+            "Storage includes the SQLite FTS table file after WAL checkpoint/truncate.",
+        ],
+    }
+    write_json(out, payload)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/text_hybrid_scoreboard/sqlite_fts5_bench.py
+++ b/benchmarks/text_hybrid_scoreboard/sqlite_fts5_bench.py
@@ -102,6 +102,8 @@ def main() -> int:
         raise SystemExit("--docs, --queries, and --top-k must be positive")
 
     db_path = Path(args.db) if args.db else out.with_suffix(".sqlite3")
+    out.parent.mkdir(parents=True, exist_ok=True)
+    db_path.parent.mkdir(parents=True, exist_ok=True)
     if db_path.exists():
         db_path.unlink()
     for suffix in ("-wal", "-shm"):

--- a/benchmarks/text_hybrid_scoreboard/sqlite_fts5_bench.py
+++ b/benchmarks/text_hybrid_scoreboard/sqlite_fts5_bench.py
@@ -19,6 +19,15 @@ from pathlib import Path
 from typing import Any
 
 
+ALLOWED_TOKENIZER_DDL = {
+    "ascii": "CREATE VIRTUAL TABLE docs_fts USING fts5(title, body, tokenize='ascii')",
+    "porter": "CREATE VIRTUAL TABLE docs_fts USING fts5(title, body, tokenize='porter')",
+    "unicode61": (
+        "CREATE VIRTUAL TABLE docs_fts USING fts5(title, body, tokenize='unicode61')"
+    ),
+}
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Run a deterministic SQLite FTS5 text baseline")
     parser.add_argument("--docs", type=int, default=10_000)
@@ -37,7 +46,7 @@ def write_json(path: Path, payload: dict[str, Any]) -> None:
     path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
 
-def unavailable(args: argparse.Namespace, reason: str) -> dict[str, Any]:
+def unavailable(reason: str) -> dict[str, Any]:
     return {
         "schema_version": "treedb_text_hybrid_external/v1",
         "status": "unavailable",
@@ -100,6 +109,11 @@ def main() -> int:
     out = Path(args.out)
     if args.docs <= 0 or args.queries <= 0 or args.top_k <= 0:
         raise SystemExit("--docs, --queries, and --top-k must be positive")
+    try:
+        tokenizer_ddl = ALLOWED_TOKENIZER_DDL[args.tokenize]
+    except KeyError as exc:
+        allowed = ", ".join(sorted(ALLOWED_TOKENIZER_DDL))
+        raise SystemExit(f"--tokenize must be one of: {allowed}") from exc
 
     db_path = Path(args.db) if args.db else out.with_suffix(".sqlite3")
     out.parent.mkdir(parents=True, exist_ok=True)
@@ -114,9 +128,9 @@ def main() -> int:
     try:
         conn = sqlite3.connect(str(db_path))
         configure(conn)
-        conn.execute(f"CREATE VIRTUAL TABLE docs_fts USING fts5(title, body, tokenize='{args.tokenize}')")
+        conn.execute(tokenizer_ddl)
     except sqlite3.Error as exc:
-        write_json(out, unavailable(args, f"Python sqlite3/SQLite does not provide usable FTS5: {exc}"))
+        write_json(out, unavailable(f"Python sqlite3/SQLite does not provide usable FTS5: {exc}"))
         return 0
 
     build_start = time.perf_counter()
@@ -134,7 +148,7 @@ def main() -> int:
     durations: list[int] = []
     total_results = 0
     search_start = time.perf_counter_ns()
-    for i in range(args.queries):
+    for _ in range(args.queries):
         start = time.perf_counter_ns()
         rows = list(conn.execute(sql, (args.query, args.top_k)))
         durations.append(time.perf_counter_ns() - start)

--- a/benchmarks/text_hybrid_scoreboard/test_sqlite_fts5_bench.py
+++ b/benchmarks/text_hybrid_scoreboard/test_sqlite_fts5_bench.py
@@ -30,8 +30,7 @@ class SQLiteFTS5BenchTest(unittest.TestCase):
                     str(out),
                 ],
                 check=False,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
+                capture_output=True,
                 text=True,
             )
             self.assertEqual(result.returncode, 0, result.stderr)
@@ -43,6 +42,36 @@ class SQLiteFTS5BenchTest(unittest.TestCase):
                 self.skipTest(f"local Python sqlite3 lacks usable FTS5: {reason}")
             self.assertEqual(payload.get("status"), "ok")
             self.assertEqual(payload.get("metrics", {}).get("docs_fetched/search"), 0)
+
+    def test_rejects_unsupported_tokenizer_before_sql_ddl(self) -> None:
+        script = Path(__file__).with_name("sqlite_fts5_bench.py")
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp) / "sqlite_fts5.json"
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(script),
+                    "--docs",
+                    "32",
+                    "--queries",
+                    "2",
+                    "--top-k",
+                    "5",
+                    "--tokenize",
+                    "unicode61'); DROP TABLE docs_fts; --",
+                    "--out",
+                    str(out),
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("--tokenize must be one of", result.stderr)
+            self.assertFalse(
+                out.exists(),
+                "invalid tokenizer should fail before writing a baseline artifact",
+            )
 
 
 if __name__ == "__main__":

--- a/benchmarks/text_hybrid_scoreboard/test_sqlite_fts5_bench.py
+++ b/benchmarks/text_hybrid_scoreboard/test_sqlite_fts5_bench.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Focused tests for the SQLite FTS5 scoreboard baseline runner."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+class SQLiteFTS5BenchTest(unittest.TestCase):
+    def test_fresh_out_directory_creates_sidecar_db_parent(self) -> None:
+        script = Path(__file__).with_name("sqlite_fts5_bench.py")
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp) / "fresh" / "nested" / "sqlite_fts5.json"
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(script),
+                    "--docs",
+                    "32",
+                    "--queries",
+                    "2",
+                    "--top-k",
+                    "5",
+                    "--out",
+                    str(out),
+                ],
+                check=False,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertTrue(out.exists(), "runner should create the fresh output directory")
+            payload = json.loads(out.read_text(encoding="utf-8"))
+            reason = payload.get("unavailable_reason", "")
+            self.assertNotIn("unable to open database file", reason)
+            if payload.get("status") == "unavailable":
+                self.skipTest(f"local Python sqlite3 lacks usable FTS5: {reason}")
+            self.assertEqual(payload.get("status"), "ok")
+            self.assertEqual(payload.get("metrics", {}).get("docs_fetched/search"), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cmd/treedb_text_hybrid_scoreboard/main.go
+++ b/cmd/treedb_text_hybrid_scoreboard/main.go
@@ -406,7 +406,13 @@ func rowsFromGoBench(input namedPath) ([]scoreboardRow, error) {
 	if err != nil {
 		return nil, fmt.Errorf("parse go bench %s: %w", input.Path, err)
 	}
+	if len(samples) == 0 {
+		return nil, fmt.Errorf("parse go bench %s: no benchmark rows found", input.Path)
+	}
 	aggs := aggregateGoBenchSamples(samples)
+	if len(aggs) == 0 {
+		return nil, fmt.Errorf("parse go bench %s: no benchmark aggregates found", input.Path)
+	}
 	rows := make([]scoreboardRow, 0, len(aggs))
 	for _, agg := range aggs {
 		row := classifyGoBenchmark(input, agg)

--- a/cmd/treedb_text_hybrid_scoreboard/main.go
+++ b/cmd/treedb_text_hybrid_scoreboard/main.go
@@ -349,7 +349,10 @@ func buildContext(cfg config) reportContext {
 			contextText = strings.TrimSpace(string(raw))
 		}
 	}
-	goVersion := strings.TrimSpace(runCmd("go", "version"))
+	goVersion := goVersionFromContextText(contextText)
+	if goVersion == "" {
+		goVersion = runtimeGoVersion()
+	}
 	host, _ := os.Hostname()
 	return reportContext{
 		RepoRoot:    repoRoot,
@@ -378,12 +381,19 @@ func runGit(repoRoot string, args ...string) string {
 	return string(out)
 }
 
-func runCmd(name string, args ...string) string {
-	out, err := exec.Command(name, args...).Output()
-	if err != nil {
-		return ""
+func goVersionFromContextText(contextText string) string {
+	for _, line := range strings.Split(contextText, "\n") {
+		line = strings.TrimSpace(line)
+		value, ok := strings.CutPrefix(line, "go=")
+		if ok && strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
 	}
-	return string(out)
+	return ""
+}
+
+func runtimeGoVersion() string {
+	return fmt.Sprintf("go version %s %s/%s", runtime.Version(), runtime.GOOS, runtime.GOARCH)
 }
 
 func runtimeGOOS() string   { return runtime.GOOS }

--- a/cmd/treedb_text_hybrid_scoreboard/main.go
+++ b/cmd/treedb_text_hybrid_scoreboard/main.go
@@ -1,0 +1,1272 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const schemaVersion = "treedb_text_hybrid_scoreboard/v1"
+
+type config struct {
+	outDir               string
+	repoRoot             string
+	contextPath          string
+	branch               string
+	commit               string
+	baseRef              string
+	baseSHA              string
+	issue                string
+	parentIssue          string
+	allowCounterFailures bool
+	goBenches            namedPaths
+	externals            namedPaths
+	unavailable          namedValues
+	commands             namedValues
+	caveats              multiValues
+}
+
+type namedPath struct {
+	Name string `json:"name"`
+	Path string `json:"path"`
+}
+
+type namedPaths []namedPath
+
+func (n *namedPaths) String() string { return fmt.Sprintf("%v", []namedPath(*n)) }
+func (n *namedPaths) Set(raw string) error {
+	name, value, err := splitNameValue(raw)
+	if err != nil {
+		return err
+	}
+	*n = append(*n, namedPath{Name: name, Path: value})
+	return nil
+}
+
+type namedValue struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+type namedValues []namedValue
+
+func (n *namedValues) String() string { return fmt.Sprintf("%v", []namedValue(*n)) }
+func (n *namedValues) Set(raw string) error {
+	name, value, err := splitNameValue(raw)
+	if err != nil {
+		return err
+	}
+	*n = append(*n, namedValue{Name: name, Value: value})
+	return nil
+}
+
+type multiValues []string
+
+func (m *multiValues) String() string { return strings.Join(*m, ",") }
+func (m *multiValues) Set(raw string) error {
+	*m = append(*m, raw)
+	return nil
+}
+
+func splitNameValue(raw string) (string, string, error) {
+	idx := strings.Index(raw, "=")
+	if idx <= 0 || idx == len(raw)-1 {
+		return "", "", fmt.Errorf("expected name=value, got %q", raw)
+	}
+	name := strings.TrimSpace(raw[:idx])
+	value := strings.TrimSpace(raw[idx+1:])
+	if name == "" || value == "" {
+		return "", "", fmt.Errorf("expected non-empty name=value, got %q", raw)
+	}
+	return name, value, nil
+}
+
+type report struct {
+	SchemaVersion      string              `json:"schema_version"`
+	GeneratedAt        string              `json:"generated_at"`
+	Issue              string              `json:"issue,omitempty"`
+	ParentIssue        string              `json:"parent_issue,omitempty"`
+	Context            reportContext       `json:"context"`
+	Commands           []namedValue        `json:"commands,omitempty"`
+	Inputs             reportInputs        `json:"inputs"`
+	Rows               []scoreboardRow     `json:"rows"`
+	CounterValidations []counterValidation `json:"counter_validations,omitempty"`
+	Unavailable        []unavailableRow    `json:"unavailable,omitempty"`
+	Caveats            []string            `json:"caveats,omitempty"`
+}
+
+type reportContext struct {
+	RepoRoot    string `json:"repo_root,omitempty"`
+	Branch      string `json:"branch,omitempty"`
+	Commit      string `json:"commit,omitempty"`
+	BaseRef     string `json:"base_ref,omitempty"`
+	BaseSHA     string `json:"base_sha,omitempty"`
+	GoVersion   string `json:"go_version,omitempty"`
+	OS          string `json:"os,omitempty"`
+	Arch        string `json:"arch,omitempty"`
+	Host        string `json:"host,omitempty"`
+	ContextPath string `json:"context_path,omitempty"`
+	ContextText string `json:"context_text,omitempty"`
+}
+
+type reportInputs struct {
+	GoBenchmarks []namedPath `json:"go_benchmarks,omitempty"`
+	ExternalJSON []namedPath `json:"external_json,omitempty"`
+}
+
+type scoreboardRow struct {
+	SourceLabel        string             `json:"source_label"`
+	SourcePath         string             `json:"source_path,omitempty"`
+	System             string             `json:"system"`
+	Engine             string             `json:"engine,omitempty"`
+	Modality           string             `json:"modality"`
+	Dataset            string             `json:"dataset,omitempty"`
+	QuerySet           string             `json:"query_set,omitempty"`
+	QueryShape         string             `json:"query_shape,omitempty"`
+	TopK               int                `json:"top_k,omitempty"`
+	Boundary           string             `json:"boundary,omitempty"`
+	Benchmark          string             `json:"benchmark,omitempty"`
+	Samples            int                `json:"samples,omitempty"`
+	Iterations         int64              `json:"iterations,omitempty"`
+	NsPerOp            *float64           `json:"ns_per_op,omitempty"`
+	MinNsPerOp         *float64           `json:"min_ns_per_op,omitempty"`
+	MaxNsPerOp         *float64           `json:"max_ns_per_op,omitempty"`
+	OpsPerSec          *float64           `json:"ops_per_sec,omitempty"`
+	BytesPerOp         *float64           `json:"bytes_per_op,omitempty"`
+	AllocsPerOp        *float64           `json:"allocs_per_op,omitempty"`
+	BuildSeconds       *float64           `json:"build_seconds,omitempty"`
+	StorageBytes       *int64             `json:"storage_bytes,omitempty"`
+	StorageBytesPerDoc *float64           `json:"storage_bytes_per_doc,omitempty"`
+	Metrics            map[string]float64 `json:"metrics,omitempty"`
+	Caveats            []string           `json:"caveats,omitempty"`
+}
+
+type counterValidation struct {
+	SourceLabel string   `json:"source_label"`
+	Benchmark   string   `json:"benchmark"`
+	Modality    string   `json:"modality"`
+	Boundary    string   `json:"boundary"`
+	OK          bool     `json:"ok"`
+	Checks      []string `json:"checks"`
+	Failures    []string `json:"failures,omitempty"`
+}
+
+type unavailableRow struct {
+	System string `json:"system"`
+	Reason string `json:"reason"`
+	Source string `json:"source,omitempty"`
+}
+
+type goBenchSample struct {
+	Name        string
+	Iterations  int64
+	NsPerOp     float64
+	BytesPerOp  *float64
+	AllocsPerOp *float64
+	Metrics     map[string]float64
+}
+
+type goBenchAggregate struct {
+	Name          string
+	Samples       int
+	Iterations    int64
+	MeanNsPerOp   float64
+	MinNsPerOp    float64
+	MaxNsPerOp    float64
+	BytesPerOp    *float64
+	AllocsPerOp   *float64
+	MeanMetrics   map[string]float64
+	MetricSamples map[string]int
+}
+
+var benchmarkNameRE = regexp.MustCompile(`^(Benchmark\S+)-\d+$`)
+
+func main() {
+	cfg, err := parseFlags(os.Args[1:])
+	if err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			os.Exit(0)
+		}
+		fmt.Fprintf(os.Stderr, "treedb_text_hybrid_scoreboard: %v\n", err)
+		os.Exit(2)
+	}
+	if err := run(cfg); err != nil {
+		fmt.Fprintf(os.Stderr, "treedb_text_hybrid_scoreboard: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func parseFlags(args []string) (config, error) {
+	var cfg config
+	fs := flag.NewFlagSet("treedb_text_hybrid_scoreboard", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	fs.StringVar(&cfg.outDir, "out-dir", "", "Output directory for scoreboard.json and scoreboard.md")
+	fs.StringVar(&cfg.repoRoot, "repo-root", "", "Repository root; defaults to git rev-parse --show-toplevel when available")
+	fs.StringVar(&cfg.contextPath, "context", "", "Optional context text file captured beside benchmark artifacts")
+	fs.StringVar(&cfg.branch, "branch", "", "Git branch label; defaults to current branch when available")
+	fs.StringVar(&cfg.commit, "commit", "", "Git commit label; defaults to current HEAD when available")
+	fs.StringVar(&cfg.baseRef, "base-ref", "", "Baseline/base ref label")
+	fs.StringVar(&cfg.baseSHA, "base-sha", "", "Baseline/base commit SHA")
+	fs.StringVar(&cfg.issue, "issue", "2727", "Issue number or URL")
+	fs.StringVar(&cfg.parentIssue, "parent-issue", "2726", "Parent issue number or URL")
+	fs.BoolVar(&cfg.allowCounterFailures, "allow-counter-failures", false, "Write reports even when zero-doc counter validation fails")
+	fs.Var(&cfg.goBenches, "go-bench", "Go benchmark artifact as name=path; may be repeated")
+	fs.Var(&cfg.externals, "external", "External baseline JSON artifact as name=path; may be repeated")
+	fs.Var(&cfg.unavailable, "unavailable", "Unavailable external baseline as system=reason; may be repeated")
+	fs.Var(&cfg.commands, "command", "Reproduction command as name=command text; may be repeated")
+	fs.Var(&cfg.caveats, "caveat", "Caveat text to include in the report; may be repeated")
+	if err := fs.Parse(args); err != nil {
+		return config{}, err
+	}
+	if cfg.outDir == "" {
+		return config{}, fmt.Errorf("-out-dir is required")
+	}
+	if len(cfg.goBenches) == 0 && len(cfg.externals) == 0 && len(cfg.unavailable) == 0 {
+		return config{}, fmt.Errorf("at least one -go-bench, -external, or -unavailable input is required")
+	}
+	return cfg, nil
+}
+
+func run(cfg config) error {
+	rep, reportErr := buildReport(cfg)
+	var validationErr counterValidationFailureError
+	if reportErr != nil && !errors.As(reportErr, &validationErr) {
+		return reportErr
+	}
+	if err := os.MkdirAll(cfg.outDir, 0o755); err != nil {
+		return fmt.Errorf("create out dir: %w", err)
+	}
+	jsonPath := filepath.Join(cfg.outDir, "scoreboard.json")
+	mdPath := filepath.Join(cfg.outDir, "scoreboard.md")
+	payload, err := json.MarshalIndent(rep, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal report: %w", err)
+	}
+	if err := os.WriteFile(jsonPath, payload, 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", jsonPath, err)
+	}
+	if err := os.WriteFile(mdPath, []byte(renderMarkdown(rep)), 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", mdPath, err)
+	}
+	fmt.Printf("wrote scoreboard json: %s\n", jsonPath)
+	fmt.Printf("wrote scoreboard md:   %s\n", mdPath)
+	if reportErr != nil && !cfg.allowCounterFailures {
+		return reportErr
+	}
+	return nil
+}
+
+func buildReport(cfg config) (report, error) {
+	ctx := buildContext(cfg)
+	rep := report{
+		SchemaVersion: schemaVersion,
+		GeneratedAt:   time.Now().UTC().Format(time.RFC3339),
+		Issue:         cfg.issue,
+		ParentIssue:   cfg.parentIssue,
+		Context:       ctx,
+		Commands:      []namedValue(cfg.commands),
+		Inputs: reportInputs{
+			GoBenchmarks: []namedPath(cfg.goBenches),
+			ExternalJSON: []namedPath(cfg.externals),
+		},
+		Caveats: append([]string(nil), cfg.caveats...),
+	}
+	if len(rep.Caveats) == 0 {
+		rep.Caveats = defaultCaveats()
+	}
+
+	for _, input := range cfg.goBenches {
+		rows, err := rowsFromGoBench(input)
+		if err != nil {
+			return rep, err
+		}
+		rep.Rows = append(rep.Rows, rows...)
+	}
+	for _, input := range cfg.externals {
+		rows, unavailable, err := rowsFromExternal(input)
+		if err != nil {
+			return rep, err
+		}
+		rep.Rows = append(rep.Rows, rows...)
+		rep.Unavailable = append(rep.Unavailable, unavailable...)
+	}
+	for _, item := range cfg.unavailable {
+		rep.Unavailable = append(rep.Unavailable, unavailableRow{System: item.Name, Reason: item.Value})
+	}
+
+	sortRows(rep.Rows)
+	rep.CounterValidations = validateCounterRows(rep.Rows)
+	var failures []string
+	for _, check := range rep.CounterValidations {
+		if !check.OK {
+			failures = append(failures, fmt.Sprintf("%s %s: %s", check.SourceLabel, check.Benchmark, strings.Join(check.Failures, "; ")))
+		}
+	}
+	if len(failures) > 0 {
+		return rep, counterValidationFailureError{Failures: failures}
+	}
+	return rep, nil
+}
+
+type counterValidationFailureError struct {
+	Failures []string
+}
+
+func (e counterValidationFailureError) Error() string {
+	return "zero-doc counter validation failed: " + strings.Join(e.Failures, " | ")
+}
+
+func buildContext(cfg config) reportContext {
+	repoRoot := cfg.repoRoot
+	if repoRoot == "" {
+		repoRoot = strings.TrimSpace(runGit(repoRoot, "rev-parse", "--show-toplevel"))
+	}
+	branch := cfg.branch
+	if branch == "" {
+		branch = strings.TrimSpace(runGit(repoRoot, "branch", "--show-current"))
+	}
+	commit := cfg.commit
+	if commit == "" {
+		commit = strings.TrimSpace(runGit(repoRoot, "rev-parse", "HEAD"))
+	}
+	contextText := ""
+	if cfg.contextPath != "" {
+		if raw, err := os.ReadFile(cfg.contextPath); err == nil {
+			contextText = strings.TrimSpace(string(raw))
+		}
+	}
+	goVersion := strings.TrimSpace(runCmd("go", "version"))
+	host, _ := os.Hostname()
+	return reportContext{
+		RepoRoot:    repoRoot,
+		Branch:      branch,
+		Commit:      commit,
+		BaseRef:     cfg.baseRef,
+		BaseSHA:     cfg.baseSHA,
+		GoVersion:   goVersion,
+		OS:          runtimeGOOS(),
+		Arch:        runtimeGOARCH(),
+		Host:        host,
+		ContextPath: cfg.contextPath,
+		ContextText: contextText,
+	}
+}
+
+func runGit(repoRoot string, args ...string) string {
+	cmd := exec.Command("git", args...)
+	if repoRoot != "" {
+		cmd.Dir = repoRoot
+	}
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	return string(out)
+}
+
+func runCmd(name string, args ...string) string {
+	out, err := exec.Command(name, args...).Output()
+	if err != nil {
+		return ""
+	}
+	return string(out)
+}
+
+func runtimeGOOS() string   { return runtime.GOOS }
+func runtimeGOARCH() string { return runtime.GOARCH }
+
+func defaultCaveats() []string {
+	return []string{
+		"TreeDB rows are same-host local benchmark rows, not standalone industry-parity claims.",
+		"No-document candidate rows must keep docs_fetched/search=0, full_doc_fallbacks/search=0, and fail_closed/search=0.",
+		"External systems expose different counters; unavailable counters are left blank instead of inferred.",
+	}
+}
+
+func rowsFromGoBench(input namedPath) ([]scoreboardRow, error) {
+	raw, err := os.ReadFile(input.Path)
+	if err != nil {
+		return nil, fmt.Errorf("read go bench %s: %w", input.Path, err)
+	}
+	samples, err := parseGoBench(bytes.NewReader(raw))
+	if err != nil {
+		return nil, fmt.Errorf("parse go bench %s: %w", input.Path, err)
+	}
+	aggs := aggregateGoBenchSamples(samples)
+	rows := make([]scoreboardRow, 0, len(aggs))
+	for _, agg := range aggs {
+		row := classifyGoBenchmark(input, agg)
+		rows = append(rows, row)
+	}
+	return rows, nil
+}
+
+func parseGoBench(r io.Reader) ([]goBenchSample, error) {
+	var samples []goBenchSample
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		if strings.HasPrefix(line, "{") {
+			var event struct {
+				Output string `json:"Output"`
+			}
+			if err := json.Unmarshal([]byte(line), &event); err == nil && event.Output != "" {
+				line = strings.TrimSpace(event.Output)
+			}
+		}
+		if !strings.HasPrefix(line, "Benchmark") {
+			continue
+		}
+		sample, ok, err := parseGoBenchLine(line)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
+			samples = append(samples, sample)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return samples, nil
+}
+
+func parseGoBenchLine(line string) (goBenchSample, bool, error) {
+	fields := strings.Fields(line)
+	if len(fields) < 4 {
+		return goBenchSample{}, false, nil
+	}
+	name := normalizeBenchmarkName(fields[0])
+	iterations, err := strconv.ParseInt(fields[1], 10, 64)
+	if err != nil {
+		return goBenchSample{}, false, nil
+	}
+	sample := goBenchSample{Name: name, Iterations: iterations, Metrics: make(map[string]float64)}
+	for i := 2; i+1 < len(fields); i += 2 {
+		value, err := strconv.ParseFloat(fields[i], 64)
+		if err != nil {
+			return goBenchSample{}, false, fmt.Errorf("parse metric value %q in %q: %w", fields[i], line, err)
+		}
+		unit := fields[i+1]
+		switch unit {
+		case "ns/op":
+			sample.NsPerOp = value
+		case "B/op":
+			sample.BytesPerOp = floatPtr(value)
+		case "allocs/op":
+			sample.AllocsPerOp = floatPtr(value)
+		default:
+			sample.Metrics[unit] = value
+		}
+	}
+	if sample.NsPerOp <= 0 {
+		return goBenchSample{}, false, nil
+	}
+	return sample, true, nil
+}
+
+func normalizeBenchmarkName(name string) string {
+	if match := benchmarkNameRE.FindStringSubmatch(name); match != nil {
+		return match[1]
+	}
+	return name
+}
+
+func aggregateGoBenchSamples(samples []goBenchSample) []goBenchAggregate {
+	byName := make(map[string][]goBenchSample)
+	for _, sample := range samples {
+		byName[sample.Name] = append(byName[sample.Name], sample)
+	}
+	out := make([]goBenchAggregate, 0, len(byName))
+	for name, group := range byName {
+		agg := goBenchAggregate{Name: name, Samples: len(group), MinNsPerOp: math.Inf(1), MaxNsPerOp: 0, MeanMetrics: make(map[string]float64), MetricSamples: make(map[string]int)}
+		var nsTotal float64
+		var bytesTotal float64
+		var bytesN int
+		var allocsTotal float64
+		var allocsN int
+		for _, sample := range group {
+			agg.Iterations += sample.Iterations
+			nsTotal += sample.NsPerOp
+			if sample.NsPerOp < agg.MinNsPerOp {
+				agg.MinNsPerOp = sample.NsPerOp
+			}
+			if sample.NsPerOp > agg.MaxNsPerOp {
+				agg.MaxNsPerOp = sample.NsPerOp
+			}
+			if sample.BytesPerOp != nil {
+				bytesTotal += *sample.BytesPerOp
+				bytesN++
+			}
+			if sample.AllocsPerOp != nil {
+				allocsTotal += *sample.AllocsPerOp
+				allocsN++
+			}
+			for k, v := range sample.Metrics {
+				agg.MeanMetrics[k] += v
+				agg.MetricSamples[k]++
+			}
+		}
+		agg.MeanNsPerOp = nsTotal / float64(len(group))
+		if bytesN > 0 {
+			agg.BytesPerOp = floatPtr(bytesTotal / float64(bytesN))
+		}
+		if allocsN > 0 {
+			agg.AllocsPerOp = floatPtr(allocsTotal / float64(allocsN))
+		}
+		for k, total := range agg.MeanMetrics {
+			agg.MeanMetrics[k] = total / float64(agg.MetricSamples[k])
+		}
+		out = append(out, agg)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}
+
+func classifyGoBenchmark(input namedPath, agg goBenchAggregate) scoreboardRow {
+	name := agg.Name
+	metrics := cloneMetrics(agg.MeanMetrics)
+	modality := "other"
+	engine := "treedb"
+	boundary := "Go benchmark timed operation"
+	queryShape := ""
+	querySet := "synthetic"
+
+	lower := strings.ToLower(name)
+	switch {
+	case strings.Contains(lower, "indexed_insert_batch_flush_vector_rebuild"):
+		modality = "build_storage"
+		engine = "treedb_collection_text_vector"
+		boundary = "InsertBatch + Flush + vector RebuildVectorIndex timed by benchmark; setup excluded per Go benchmark"
+		queryShape = "index build / ingest"
+	case strings.Contains(lower, "create_text_v2_index_backfill"):
+		modality = "build_storage"
+		engine = "treedb_text_v2"
+		boundary = "CreateTextIndex v2 backfill timed by benchmark; primary insert setup excluded"
+		queryShape = "text-v2 index build"
+	case strings.Contains(lower, "mode_vector_only_no_docs") && !strings.Contains(lower, "filter_none_100pct"):
+		modality = "vector_scalar"
+		engine = "treedb_hybrid_executor"
+		boundary = "No-document vector+scalar candidate generation and filtering"
+		queryShape = "vector top-k candidates + indexed scalar filter"
+	case strings.Contains(lower, "mode_text_only_no_docs") && !strings.Contains(lower, "filter_none_100pct"):
+		modality = "text_scalar"
+		engine = "treedb_hybrid_executor"
+		boundary = "No-document text+scalar candidate generation and filtering"
+		queryShape = "refund policy BM25F candidates + indexed scalar filter"
+	case strings.Contains(lower, "search_vector_candidates") || strings.Contains(lower, "mode_vector_only_no_docs"):
+		modality = "vector_only"
+		engine = "treedb_column_graph"
+		boundary = "No-document vector candidate generation"
+		queryShape = "vector top-k candidates"
+	case strings.Contains(lower, "search_hybrid_v2_no_docs_scalar_filter"):
+		modality = "text_scalar"
+		engine = "treedb_hybrid_executor"
+		boundary = "No-document text+scalar candidate generation through the hybrid executor"
+		queryShape = "refund policy BM25F candidates + indexed scalar filter"
+	case strings.Contains(lower, "mode_hybrid_no_docs") && !strings.Contains(lower, "filter_none_100pct"):
+		modality = "hybrid_scalar"
+		engine = "treedb_hybrid_executor"
+		boundary = "No-document text+vector/scalar candidate generation and fusion"
+		queryShape = "refund policy + vector + indexed scalar filter"
+	case strings.Contains(lower, "search_hybrid_no_docs_scalar_filter"):
+		modality = "hybrid_scalar"
+		engine = "treedb_hybrid_executor"
+		boundary = "No-document hybrid+scalar candidate generation and fusion"
+		queryShape = "refund policy + vector + indexed scalar filter"
+	case strings.Contains(lower, "mode_hybrid_no_docs"):
+		modality = "hybrid"
+		engine = "treedb_hybrid_executor"
+		boundary = "No-document text+vector candidate generation and fusion"
+		queryShape = "refund policy + vector"
+	case strings.Contains(lower, "search_text_v2_candidates"):
+		modality = "text_only"
+		engine = "treedb_text_v2"
+		boundary = "No-document text-v2 candidate generation"
+		queryShape = "refund policy BM25F candidates"
+	case strings.Contains(lower, "mode_text_only_no_docs"):
+		modality = "text_only"
+		engine = "treedb_text_v2"
+		boundary = "No-document text-only SearchHybrid executor row"
+		queryShape = "refund policy BM25F candidates"
+	case strings.Contains(lower, "benchmarktextv2") || strings.Contains(lower, "blockmax_common_topk") || strings.Contains(lower, "score_only"):
+		modality = "text_only"
+		engine = "treedb_text_v2"
+		boundary = "No-document text-v2 score-only BM25F search"
+		queryShape = textQueryShapeFromBenchmark(name)
+	}
+	if strings.Contains(lower, "fetch_topk") || strings.Contains(lower, "include") {
+		boundary = "Final top-k document fetch/materialization"
+	}
+
+	row := scoreboardRow{
+		SourceLabel: input.Name,
+		SourcePath:  input.Path,
+		System:      "TreeDB",
+		Engine:      engine,
+		Modality:    modality,
+		Dataset:     datasetFromMetricsAndName(metrics, name, input.Name),
+		QuerySet:    querySet,
+		QueryShape:  queryShape,
+		TopK:        topKFromMetricsAndName(metrics, name),
+		Boundary:    boundary,
+		Benchmark:   name,
+		Samples:     agg.Samples,
+		Iterations:  agg.Iterations,
+		NsPerOp:     floatPtr(agg.MeanNsPerOp),
+		MinNsPerOp:  floatPtr(agg.MinNsPerOp),
+		MaxNsPerOp:  floatPtr(agg.MaxNsPerOp),
+		OpsPerSec:   floatPtr(opsPerSecond(agg.MeanNsPerOp)),
+		BytesPerOp:  agg.BytesPerOp,
+		AllocsPerOp: agg.AllocsPerOp,
+		Metrics:     metrics,
+	}
+	if v, ok := metrics["index_bytes/doc"]; ok {
+		row.StorageBytesPerDoc = floatPtr(v)
+	}
+	return row
+}
+
+func textQueryShapeFromBenchmark(name string) string {
+	lower := strings.ToLower(name)
+	switch {
+	case strings.Contains(lower, "blockmax_common_topk"):
+		return "common term BM25F top-k with block-max pruning"
+	case strings.Contains(lower, "exhaustive_common_topk"):
+		return "common term BM25F exhaustive reference"
+	case strings.Contains(lower, "multi_term_and"):
+		return "multi-term AND BM25F"
+	case strings.Contains(lower, "rare"):
+		return "rare term BM25F"
+	case strings.Contains(lower, "common"):
+		return "common term BM25F"
+	default:
+		return "BM25F text search"
+	}
+}
+
+func datasetFromMetricsAndName(metrics map[string]float64, name, sourceLabel string) string {
+	var parts []string
+	if docs, ok := metricAny(metrics, "docs_fixture", "docs/op"); ok && docs > 0 {
+		parts = append(parts, fmt.Sprintf("docs=%s", formatNumber(docs)))
+	} else if docs := docsFromBenchmarkName(name); docs > 0 {
+		parts = append(parts, fmt.Sprintf("docs=%d", docs))
+	} else if docs := docsFromSourceLabel(sourceLabel); docs > 0 {
+		parts = append(parts, fmt.Sprintf("docs=%d", docs))
+	}
+	if dims, ok := metrics["vector_dims"]; ok && dims > 0 {
+		parts = append(parts, fmt.Sprintf("dims=%s", formatNumber(dims)))
+	}
+	if budget, ok := metricAny(metrics, "candidate_budget/source", "candidate_budget/search"); ok && budget > 0 {
+		parts = append(parts, fmt.Sprintf("candidate_budget=%s", formatNumber(budget)))
+	} else if budget := candidateBudgetFromBenchmarkName(name); budget > 0 {
+		parts = append(parts, fmt.Sprintf("candidate_budget=%d", budget))
+	}
+	if topk, ok := metrics["topk/search"]; ok && topk > 0 {
+		parts = append(parts, fmt.Sprintf("topK=%s", formatNumber(topk)))
+	} else if topk := topKFromBenchmarkName(name); topk > 0 {
+		parts = append(parts, fmt.Sprintf("topK=%d", topk))
+	}
+	return strings.Join(parts, ", ")
+}
+
+func topKFromMetricsAndName(metrics map[string]float64, name string) int {
+	if v := intMetric(metrics, "topk/search"); v > 0 {
+		return v
+	}
+	return topKFromBenchmarkName(name)
+}
+
+func topKFromBenchmarkName(name string) int {
+	return intAfterToken(name, "topK_")
+}
+
+func candidateBudgetFromBenchmarkName(name string) int {
+	return intAfterToken(name, "candidates_")
+}
+
+func docsFromBenchmarkName(name string) int {
+	return intAfterToken(name, "docs_")
+}
+
+func docsFromSourceLabel(label string) int {
+	lower := strings.ToLower(label)
+	if strings.Contains(lower, "100k") {
+		return 100_000
+	}
+	if strings.Contains(lower, "10k") {
+		return 10_000
+	}
+	if strings.Contains(lower, "1m") {
+		return 1_000_000
+	}
+	return 0
+}
+
+func intAfterToken(s, token string) int {
+	idx := strings.Index(s, token)
+	if idx < 0 {
+		return 0
+	}
+	start := idx + len(token)
+	end := start
+	for end < len(s) && s[end] >= '0' && s[end] <= '9' {
+		end++
+	}
+	if end == start {
+		return 0
+	}
+	value, _ := strconv.Atoi(s[start:end])
+	return value
+}
+
+func rowsFromExternal(input namedPath) ([]scoreboardRow, []unavailableRow, error) {
+	raw, err := os.ReadFile(input.Path)
+	if err != nil {
+		return nil, nil, fmt.Errorf("read external %s: %w", input.Path, err)
+	}
+	var obj map[string]any
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		return nil, nil, fmt.Errorf("parse external %s: %w", input.Path, err)
+	}
+	if status, _ := obj["status"].(string); strings.EqualFold(status, "unavailable") {
+		system := stringField(obj, "system", input.Name)
+		reason := stringField(obj, "unavailable_reason", stringField(obj, "reason", "external baseline unavailable"))
+		return nil, []unavailableRow{{System: system, Reason: reason, Source: input.Path}}, nil
+	}
+	if _, ok := obj["search_benchmarks"]; ok {
+		return rowsFromVectorExternal(input, obj), nil, nil
+	}
+	row := rowFromGenericExternal(input, obj)
+	return []scoreboardRow{row}, nil, nil
+}
+
+func rowFromGenericExternal(input namedPath, obj map[string]any) scoreboardRow {
+	metrics := numberMap(obj["metrics"])
+	search := mapValue(obj["search"])
+	build := mapValue(obj["build"])
+	storage := mapValue(obj["storage"])
+	if len(storage) == 0 {
+		storage = mapValue(obj["storage_after_build"])
+	}
+	ns := numberPtrAny(search, "avg_nanos", "ns_per_op")
+	ops := numberPtrAny(search, "ops_per_second", "ops_per_sec")
+	if ops == nil && ns != nil {
+		ops = floatPtr(opsPerSecond(*ns))
+	}
+	bytesPerOp := numberPtrAny(search, "bytes_per_op")
+	allocsPerOp := numberPtrAny(search, "allocs_per_op")
+	buildSeconds := numberPtrAny(build, "seconds", "build_seconds")
+	storageBytes := int64PtrAny(storage, "total_bytes", "storage_bytes")
+	storagePerDoc := numberPtrAny(storage, "bytes_per_doc", "storage_bytes_per_doc")
+	return scoreboardRow{
+		SourceLabel:        input.Name,
+		SourcePath:         input.Path,
+		System:             stringField(obj, "system", input.Name),
+		Engine:             stringField(obj, "engine", "external"),
+		Modality:           stringField(obj, "modality", "text_only"),
+		Dataset:            datasetFromExternal(obj),
+		QuerySet:           stringField(obj, "query_set", "synthetic"),
+		QueryShape:         stringField(obj, "query_shape", "external top-k query"),
+		TopK:               externalTopK(obj),
+		Boundary:           stringField(obj, "boundary", "external benchmark boundary"),
+		Benchmark:          stringField(obj, "benchmark", input.Name),
+		Samples:            1,
+		NsPerOp:            ns,
+		OpsPerSec:          ops,
+		BytesPerOp:         bytesPerOp,
+		AllocsPerOp:        allocsPerOp,
+		BuildSeconds:       buildSeconds,
+		StorageBytes:       storageBytes,
+		StorageBytesPerDoc: storagePerDoc,
+		Metrics:            metrics,
+		Caveats:            stringSlice(obj["caveats"]),
+	}
+}
+
+func rowsFromVectorExternal(input namedPath, obj map[string]any) []scoreboardRow {
+	benchmarks, _ := obj["search_benchmarks"].([]any)
+	rows := make([]scoreboardRow, 0, len(benchmarks))
+	buildSeconds := phaseSeconds(obj)
+	storage := preferredStorage(obj)
+	storageBytes := int64PtrAny(storage, "total_bytes")
+	storagePerDoc := numberPtrAny(storage, "bytes_per_doc")
+	for _, item := range benchmarks {
+		rowMap := mapValue(item)
+		if len(rowMap) == 0 {
+			continue
+		}
+		metrics := map[string]float64{}
+		for _, key := range []string{"avg_documents_fetched", "avg_response_owned_result_allocs", "avg_search_route_hnsw_search_pack", "avg_search_route_quantized_only", "avg_search_route_quantized_rerank", "avg_search_route_column_graph_prepared", "avg_search_route_column_graph_fallback", "avg_graph_row_fallbacks", "avg_typed_column_fallbacks", "avg_vector_scratch_decodes", "avg_candidates", "avg_vector_bytes", "avg_norm_bytes"} {
+			if v, ok := number(rowMap[key]); ok {
+				metrics[key] = v
+			}
+		}
+		if v, ok := metrics["avg_documents_fetched"]; ok {
+			metrics["docs_fetched/search"] = v
+		}
+		ns := numberPtrAny(rowMap, "avg_nanos")
+		ops := numberPtrAny(rowMap, "ops_per_second")
+		if ops == nil && ns != nil {
+			ops = floatPtr(opsPerSecond(*ns))
+		}
+		concurrency := int(numberAny(rowMap, "concurrency"))
+		dataset := fmt.Sprintf("docs=%s, dims=%s, topK=%s, concurrency=%d", formatNumber(numberAny(obj, "docs")), formatNumber(numberAny(obj, "dimensions")), formatNumber(numberAny(obj, "top_k")), concurrency)
+		rows = append(rows, scoreboardRow{
+			SourceLabel:        input.Name,
+			SourcePath:         input.Path,
+			System:             vectorSystemName(obj),
+			Engine:             stringField(obj, "engine", stringField(obj, "backend", input.Name)),
+			Modality:           "vector_only",
+			Dataset:            dataset,
+			QuerySet:           "TreeDB-exported synthetic vector set",
+			QueryShape:         "vector ANN top-k",
+			TopK:               externalTopK(obj),
+			Boundary:           "Vector search; external harness semantics documented by source artifact",
+			Benchmark:          fmt.Sprintf("%s/search_c%d", stringField(obj, "backend", input.Name), concurrency),
+			Samples:            1,
+			NsPerOp:            ns,
+			OpsPerSec:          ops,
+			BuildSeconds:       buildSeconds,
+			StorageBytes:       storageBytes,
+			StorageBytesPerDoc: storagePerDoc,
+			Metrics:            metrics,
+		})
+	}
+	return rows
+}
+
+func phaseSeconds(obj map[string]any) *float64 {
+	for _, key := range []string{"build", "rebuild"} {
+		m := mapValue(obj[key])
+		if v := numberPtrAny(m, "seconds"); v != nil {
+			return v
+		}
+	}
+	return nil
+}
+
+func preferredStorage(obj map[string]any) map[string]any {
+	for _, key := range []string{"storage_after_index_vacuum", "storage_after_build", "storage_after_close", "storage_after_compact", "storage"} {
+		m := mapValue(obj[key])
+		if len(m) > 0 {
+			return m
+		}
+	}
+	return nil
+}
+
+func vectorSystemName(obj map[string]any) string {
+	backend := stringField(obj, "backend", "external_vector")
+	switch backend {
+	case "sqlite_vectorlite":
+		return "SQLite+Vectorlite"
+	case "pgvector":
+		return "PostgreSQL+pgvector"
+	case "mongodb_vector_search":
+		return "MongoDB Vector Search"
+	case "treedb", "treedb_column_graph":
+		return "TreeDB"
+	default:
+		if strings.HasPrefix(backend, "treedb_") {
+			return "TreeDB"
+		}
+		return backend
+	}
+}
+
+func externalTopK(obj map[string]any) int {
+	if topK := int(numberAny(obj, "top_k", "topK")); topK > 0 {
+		return topK
+	}
+	dataset := mapValue(obj["dataset"])
+	return int(numberAny(dataset, "top_k", "topK"))
+}
+
+func datasetFromExternal(obj map[string]any) string {
+	if raw, ok := obj["dataset"].(string); ok {
+		return raw
+	}
+	m := mapValue(obj["dataset"])
+	var parts []string
+	for _, key := range []string{"docs", "documents", "dims", "dimensions", "queries", "top_k", "topK", "candidate_budget"} {
+		if v, ok := number(m[key]); ok {
+			label := key
+			if key == "documents" {
+				label = "docs"
+			}
+			if key == "dimensions" {
+				label = "dims"
+			}
+			if key == "top_k" || key == "topK" {
+				label = "topK"
+			}
+			parts = append(parts, fmt.Sprintf("%s=%s", label, formatNumber(v)))
+		}
+	}
+	if len(parts) > 0 {
+		return strings.Join(parts, ", ")
+	}
+	return ""
+}
+
+func validateCounterRows(rows []scoreboardRow) []counterValidation {
+	var checks []counterValidation
+	for _, row := range rows {
+		if !requiresZeroDocValidation(row) {
+			continue
+		}
+		check := counterValidation{SourceLabel: row.SourceLabel, Benchmark: row.Benchmark, Modality: row.Modality, Boundary: row.Boundary, OK: true}
+		for _, metric := range []string{"docs_fetched/search", "full_doc_fallbacks/search", "fail_closed/search"} {
+			checkMetricZero(row, metric, &check)
+		}
+		if row.System == "TreeDB" && (row.Modality == "text_only" || row.Modality == "text_scalar" || row.Modality == "hybrid" || row.Modality == "hybrid_scalar") {
+			checkEitherMetricZero(row, []string{"text_state_lookups/search", "state_lookups/search"}, &check)
+			checkEitherMetricZero(row, []string{"text_match_details/search", "match_details/search"}, &check)
+		}
+		checks = append(checks, check)
+	}
+	return checks
+}
+
+func requiresZeroDocValidation(row scoreboardRow) bool {
+	lowerBoundary := strings.ToLower(row.Boundary)
+	lowerName := strings.ToLower(row.Benchmark)
+	candidate := strings.Contains(lowerBoundary, "no-document") || strings.Contains(lowerBoundary, "no-doc") || strings.Contains(lowerName, "no_docs") || strings.Contains(lowerName, "candidates_no_docs") || strings.Contains(lowerName, "score_only") || strings.Contains(lowerName, "blockmax_common_topk")
+	if !candidate {
+		return false
+	}
+	if row.System == "TreeDB" {
+		return true
+	}
+	_, hasDocs := row.Metrics["docs_fetched/search"]
+	_, hasFallback := row.Metrics["full_doc_fallbacks/search"]
+	_, hasFailClosed := row.Metrics["fail_closed/search"]
+	return hasDocs && hasFallback && hasFailClosed
+}
+
+func checkMetricZero(row scoreboardRow, metric string, check *counterValidation) {
+	value, ok := row.Metrics[metric]
+	if !ok {
+		check.Failures = append(check.Failures, fmt.Sprintf("missing %s", metric))
+		check.OK = false
+		return
+	}
+	check.Checks = append(check.Checks, fmt.Sprintf("%s=%s", metric, formatNumber(value)))
+	if value != 0 {
+		check.Failures = append(check.Failures, fmt.Sprintf("%s=%s want 0", metric, formatNumber(value)))
+		check.OK = false
+	}
+}
+
+func checkEitherMetricZero(row scoreboardRow, names []string, check *counterValidation) {
+	for _, name := range names {
+		if _, ok := row.Metrics[name]; ok {
+			checkMetricZero(row, name, check)
+			return
+		}
+	}
+	check.Failures = append(check.Failures, fmt.Sprintf("missing one of %s", strings.Join(names, ", ")))
+	check.OK = false
+}
+
+func renderMarkdown(rep report) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "# TreeDB text-v2/hybrid industry comparison scoreboard\n\n")
+	fmt.Fprintf(&b, "Generated: `%s`  \n", rep.GeneratedAt)
+	if rep.Issue != "" {
+		fmt.Fprintf(&b, "Issue: `%s`  \n", rep.Issue)
+	}
+	if rep.ParentIssue != "" {
+		fmt.Fprintf(&b, "Parent: `%s`  \n", rep.ParentIssue)
+	}
+	fmt.Fprintf(&b, "Branch: `%s`  \nCommit: `%s`  \nBase: `%s` `%s`  \nGo: `%s`  \nHost: `%s`\n\n", rep.Context.Branch, rep.Context.Commit, rep.Context.BaseRef, rep.Context.BaseSHA, rep.Context.GoVersion, rep.Context.Host)
+
+	fmt.Fprintf(&b, "## Retrieval scoreboard\n\n")
+	fmt.Fprintf(&b, "| System | Modality | Dataset | Query / boundary | ns/op | ops/sec | B/op | allocs/op | Build | Storage | Counters | Source |\n")
+	fmt.Fprintf(&b, "| --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | --- | --- |\n")
+	for _, row := range rep.Rows {
+		fmt.Fprintf(&b, "| %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | `%s` |\n",
+			escape(row.System), escape(row.Modality), escape(row.Dataset), escape(compactQueryBoundary(row)), formatFloatPtr(row.NsPerOp), formatFloatPtr(row.OpsPerSec), formatFloatPtr(row.BytesPerOp), formatFloatPtr(row.AllocsPerOp), formatSecondsPtr(row.BuildSeconds), formatStorage(row), escape(counterSummary(row)), escape(row.SourceLabel))
+	}
+	if len(rep.Rows) == 0 {
+		fmt.Fprintf(&b, "| _none_ | | | | | | | | | | | |\n")
+	}
+
+	fmt.Fprintf(&b, "\n## Zero-doc counter validation\n\n")
+	fmt.Fprintf(&b, "| Source | Benchmark | OK | Checks / failures |\n")
+	fmt.Fprintf(&b, "| --- | --- | --- | --- |\n")
+	for _, check := range rep.CounterValidations {
+		details := strings.Join(check.Checks, "; ")
+		if !check.OK {
+			details = details + " FAIL: " + strings.Join(check.Failures, "; ")
+		}
+		fmt.Fprintf(&b, "| `%s` | `%s` | %t | %s |\n", escape(check.SourceLabel), escape(check.Benchmark), check.OK, escape(details))
+	}
+	if len(rep.CounterValidations) == 0 {
+		fmt.Fprintf(&b, "| _none_ | | true | no zero-doc rows detected |\n")
+	}
+
+	if len(rep.Commands) > 0 {
+		fmt.Fprintf(&b, "\n## Reproduction commands\n\n")
+		for _, command := range rep.Commands {
+			fmt.Fprintf(&b, "### %s\n\n```sh\n%s\n```\n\n", command.Name, command.Value)
+		}
+	}
+
+	if len(rep.Unavailable) > 0 {
+		fmt.Fprintf(&b, "\n## External baselines not captured in this run\n\n")
+		fmt.Fprintf(&b, "| System | Reason | Source |\n| --- | --- | --- |\n")
+		for _, row := range rep.Unavailable {
+			fmt.Fprintf(&b, "| %s | %s | `%s` |\n", escape(row.System), escape(row.Reason), escape(row.Source))
+		}
+	}
+
+	fmt.Fprintf(&b, "\n## Caveats\n\n")
+	for _, caveat := range rep.Caveats {
+		fmt.Fprintf(&b, "- %s\n", caveat)
+	}
+	if rep.Context.ContextText != "" {
+		fmt.Fprintf(&b, "\n## Captured host/context\n\n```text\n%s\n```\n", rep.Context.ContextText)
+	}
+	return b.String()
+}
+
+func compactQueryBoundary(row scoreboardRow) string {
+	parts := []string{}
+	if row.QueryShape != "" {
+		parts = append(parts, row.QueryShape)
+	}
+	if row.Boundary != "" {
+		parts = append(parts, row.Boundary)
+	}
+	if row.Benchmark != "" {
+		parts = append(parts, row.Benchmark)
+	}
+	return strings.Join(parts, " — ")
+}
+
+func counterSummary(row scoreboardRow) string {
+	keys := []string{"docs_fetched/search", "full_doc_fallbacks/search", "fail_closed/search", "text_state_lookups/search", "state_lookups/search", "text_postings/search", "postings_scanned/search", "posting_blocks_visited/search", "posting_blocks_skipped/search", "vector_candidates/search", "vector_examined/search", "scalar_prefilter_ids/search"}
+	var parts []string
+	for _, key := range keys {
+		if v, ok := row.Metrics[key]; ok {
+			label := strings.TrimSuffix(key, "/search")
+			parts = append(parts, fmt.Sprintf("%s=%s", label, formatNumber(v)))
+		}
+	}
+	return strings.Join(parts, ", ")
+}
+
+func formatStorage(row scoreboardRow) string {
+	if row.StorageBytes == nil && row.StorageBytesPerDoc == nil {
+		return ""
+	}
+	var parts []string
+	if row.StorageBytes != nil {
+		parts = append(parts, bytesHuman(*row.StorageBytes))
+	}
+	if row.StorageBytesPerDoc != nil {
+		parts = append(parts, fmt.Sprintf("%s B/doc", formatNumber(*row.StorageBytesPerDoc)))
+	}
+	return strings.Join(parts, ", ")
+}
+
+func sortRows(rows []scoreboardRow) {
+	sort.Slice(rows, func(i, j int) bool {
+		a, b := rows[i], rows[j]
+		for _, cmp := range []int{strings.Compare(a.Modality, b.Modality), strings.Compare(a.System, b.System), strings.Compare(a.Dataset, b.Dataset), strings.Compare(a.Benchmark, b.Benchmark)} {
+			if cmp < 0 {
+				return true
+			}
+			if cmp > 0 {
+				return false
+			}
+		}
+		return false
+	})
+}
+
+func cloneMetrics(in map[string]float64) map[string]float64 {
+	out := make(map[string]float64, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}
+
+func metricAny(metrics map[string]float64, names ...string) (float64, bool) {
+	for _, name := range names {
+		if v, ok := metrics[name]; ok {
+			return v, true
+		}
+	}
+	return 0, false
+}
+
+func intMetric(metrics map[string]float64, name string) int {
+	if v, ok := metrics[name]; ok {
+		return int(v)
+	}
+	return 0
+}
+
+func opsPerSecond(ns float64) float64 {
+	if ns <= 0 {
+		return 0
+	}
+	return 1e9 / ns
+}
+
+func floatPtr(v float64) *float64 { return &v }
+func int64Ptr(v int64) *int64     { return &v }
+
+func number(v any) (float64, bool) {
+	switch x := v.(type) {
+	case float64:
+		return x, true
+	case int:
+		return float64(x), true
+	case int64:
+		return float64(x), true
+	case json.Number:
+		f, err := x.Float64()
+		return f, err == nil
+	case string:
+		f, err := strconv.ParseFloat(x, 64)
+		return f, err == nil
+	default:
+		return 0, false
+	}
+}
+
+func numberAny(m map[string]any, names ...string) float64 {
+	if v := numberPtrAny(m, names...); v != nil {
+		return *v
+	}
+	return 0
+}
+
+func numberPtrAny(m map[string]any, names ...string) *float64 {
+	for _, name := range names {
+		if v, ok := number(m[name]); ok {
+			return floatPtr(v)
+		}
+	}
+	return nil
+}
+
+func int64PtrAny(m map[string]any, names ...string) *int64 {
+	for _, name := range names {
+		if v, ok := number(m[name]); ok {
+			return int64Ptr(int64(v))
+		}
+	}
+	return nil
+}
+
+func numberMap(v any) map[string]float64 {
+	m := mapValue(v)
+	out := make(map[string]float64, len(m))
+	for k, raw := range m {
+		if f, ok := number(raw); ok {
+			out[k] = f
+		}
+	}
+	return out
+}
+
+func mapValue(v any) map[string]any {
+	if v == nil {
+		return nil
+	}
+	if m, ok := v.(map[string]any); ok {
+		return m
+	}
+	return nil
+}
+
+func stringField(m map[string]any, name, fallback string) string {
+	if v, ok := m[name].(string); ok && v != "" {
+		return v
+	}
+	return fallback
+}
+
+func stringSlice(v any) []string {
+	items, ok := v.([]any)
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, len(items))
+	for _, item := range items {
+		if s, ok := item.(string); ok {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+func formatNumber(v float64) string {
+	if math.IsNaN(v) || math.IsInf(v, 0) {
+		return ""
+	}
+	if math.Abs(v-math.Round(v)) < 0.000001 {
+		return strconv.FormatInt(int64(math.Round(v)), 10)
+	}
+	if math.Abs(v) >= 1000 {
+		return strconv.FormatFloat(v, 'f', 1, 64)
+	}
+	return strconv.FormatFloat(v, 'f', 3, 64)
+}
+
+func formatFloatPtr(v *float64) string {
+	if v == nil {
+		return ""
+	}
+	return formatNumber(*v)
+}
+
+func formatSecondsPtr(v *float64) string {
+	if v == nil {
+		return ""
+	}
+	return fmt.Sprintf("%ss", formatNumber(*v))
+}
+
+func bytesHuman(v int64) string {
+	units := []string{"B", "KiB", "MiB", "GiB", "TiB"}
+	f := float64(v)
+	unit := 0
+	for f >= 1024 && unit < len(units)-1 {
+		f /= 1024
+		unit++
+	}
+	if unit == 0 {
+		return fmt.Sprintf("%dB", v)
+	}
+	return fmt.Sprintf("%.2f%s", f, units[unit])
+}
+
+func escape(s string) string {
+	s = strings.ReplaceAll(s, "|", "\\|")
+	s = strings.ReplaceAll(s, "\n", " ")
+	return s
+}

--- a/cmd/treedb_text_hybrid_scoreboard/main.go
+++ b/cmd/treedb_text_hybrid_scoreboard/main.go
@@ -193,7 +193,10 @@ type goBenchAggregate struct {
 	MetricSamples map[string]int
 }
 
-var benchmarkNameRE = regexp.MustCompile(`^(Benchmark\S+)-\d+$`)
+var (
+	benchmarkNameRE   = regexp.MustCompile(`^(Benchmark\S+)-\d+$`)
+	docsSourceLabelRE = regexp.MustCompile(`(?:^|[_-])docs[_-]([0-9]+)(?:$|[_-])`)
+)
 
 func main() {
 	cfg, err := parseFlags(os.Args[1:])
@@ -714,6 +717,11 @@ func docsFromBenchmarkName(name string) int {
 
 func docsFromSourceLabel(label string) int {
 	lower := strings.ToLower(label)
+	if match := docsSourceLabelRE.FindStringSubmatch(lower); match != nil {
+		if docs, err := strconv.Atoi(match[1]); err == nil {
+			return docs
+		}
+	}
 	if strings.Contains(lower, "100k") {
 		return 100_000
 	}

--- a/cmd/treedb_text_hybrid_scoreboard/main.go
+++ b/cmd/treedb_text_hybrid_scoreboard/main.go
@@ -286,10 +286,7 @@ func buildReport(cfg config) (report, error) {
 			GoBenchmarks: []namedPath(cfg.goBenches),
 			ExternalJSON: []namedPath(cfg.externals),
 		},
-		Caveats: append([]string(nil), cfg.caveats...),
-	}
-	if len(rep.Caveats) == 0 {
-		rep.Caveats = defaultCaveats()
+		Caveats: append(defaultCaveats(), cfg.caveats...),
 	}
 
 	for _, input := range cfg.goBenches {

--- a/cmd/treedb_text_hybrid_scoreboard/main_test.go
+++ b/cmd/treedb_text_hybrid_scoreboard/main_test.go
@@ -76,6 +76,27 @@ func TestRowsFromGoBenchRejectsEmptyArtifacts(t *testing.T) {
 	}
 }
 
+func TestBuildReportAppendsCustomCaveatsToDefaults(t *testing.T) {
+	rep, err := buildReport(config{
+		outDir:      t.TempDir(),
+		unavailable: namedValues{{Name: "Lucene", Value: "not run in unit test"}},
+		caveats:     multiValues{"custom 100k smoke caveat"},
+	})
+	if err != nil {
+		t.Fatalf("buildReport: %v", err)
+	}
+	md := renderMarkdown(rep)
+	for _, want := range []string{
+		"TreeDB rows are same-host local benchmark rows",
+		"No-document candidate rows must keep docs_fetched/search=0",
+		"custom 100k smoke caveat",
+	} {
+		if !strings.Contains(md, want) {
+			t.Fatalf("caveats missing %q: %#v\n%s", want, rep.Caveats, md)
+		}
+	}
+}
+
 func TestHybridCloseoutOverrideLabelDrivesDatasetDocs(t *testing.T) {
 	dir := t.TempDir()
 	goBench := filepath.Join(dir, "hybrid.txt")

--- a/cmd/treedb_text_hybrid_scoreboard/main_test.go
+++ b/cmd/treedb_text_hybrid_scoreboard/main_test.go
@@ -64,6 +64,18 @@ func TestCounterValidationFailsClosedForZeroDocRows(t *testing.T) {
 	}
 }
 
+func TestRowsFromGoBenchRejectsEmptyArtifacts(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "empty_bench.txt")
+	if err := os.WriteFile(path, []byte("PASS\nok\tgithub.com/snissn/gomap/TreeDB/collections\t0.01s\n"), 0o644); err != nil {
+		t.Fatalf("write empty bench: %v", err)
+	}
+	_, err := rowsFromGoBench(namedPath{Name: "empty", Path: path})
+	if err == nil || !strings.Contains(err.Error(), "no benchmark rows found") {
+		t.Fatalf("rowsFromGoBench err=%v want no benchmark rows found", err)
+	}
+}
+
 func TestBuildReportParsesExternalAndRendersUnavailable(t *testing.T) {
 	dir := t.TempDir()
 	goBench := filepath.Join(dir, "go.txt")

--- a/cmd/treedb_text_hybrid_scoreboard/main_test.go
+++ b/cmd/treedb_text_hybrid_scoreboard/main_test.go
@@ -76,6 +76,26 @@ func TestRowsFromGoBenchRejectsEmptyArtifacts(t *testing.T) {
 	}
 }
 
+func TestBuildReportUsesCapturedGoVersionFromContext(t *testing.T) {
+	dir := t.TempDir()
+	contextPath := filepath.Join(dir, "context.txt")
+	wantGo := "go version go9.99.0 custom/arch"
+	if err := os.WriteFile(contextPath, []byte("timestamp=unit-test\ngo="+wantGo+"\npython=Python 3.x\n"), 0o644); err != nil {
+		t.Fatalf("write context: %v", err)
+	}
+	rep, err := buildReport(config{
+		outDir:      dir,
+		repoRoot:    dir,
+		contextPath: contextPath,
+	})
+	if err != nil {
+		t.Fatalf("buildReport: %v", err)
+	}
+	if got := rep.Context.GoVersion; got != wantGo {
+		t.Fatalf("go version=%q want captured context version %q", got, wantGo)
+	}
+}
+
 func TestBuildReportAppendsCustomCaveatsToDefaults(t *testing.T) {
 	rep, err := buildReport(config{
 		outDir:      t.TempDir(),

--- a/cmd/treedb_text_hybrid_scoreboard/main_test.go
+++ b/cmd/treedb_text_hybrid_scoreboard/main_test.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestParseGoBenchAggregatesMetricsAndDerivesOps(t *testing.T) {
+	raw := `goos: darwin
+BenchmarkIndexInsertSearch2564/search_text_v2_candidates_no_docs-8          3   4000000 ns/op   1200 B/op   12 allocs/op   10000 docs_fixture   64 candidate_budget/source   10 topk/search   0 docs_fetched/search   0 full_doc_fallbacks/search   0 fail_closed/search   0 text_state_lookups/search   0 text_match_details/search   812 posting_blocks_visited/search
+BenchmarkIndexInsertSearch2564/search_text_v2_candidates_no_docs-8          3   5000000 ns/op   1400 B/op   14 allocs/op   10000 docs_fixture   64 candidate_budget/source   10 topk/search   0 docs_fetched/search   0 full_doc_fallbacks/search   0 fail_closed/search   0 text_state_lookups/search   0 text_match_details/search   820 posting_blocks_visited/search
+`
+	samples, err := parseGoBench(bytes.NewBufferString(raw))
+	if err != nil {
+		t.Fatalf("parseGoBench: %v", err)
+	}
+	if got, want := len(samples), 2; got != want {
+		t.Fatalf("samples=%d want %d", got, want)
+	}
+	aggs := aggregateGoBenchSamples(samples)
+	if got, want := len(aggs), 1; got != want {
+		t.Fatalf("aggregates=%d want %d", got, want)
+	}
+	agg := aggs[0]
+	if agg.MeanNsPerOp != 4500000 || *agg.BytesPerOp != 1300 || *agg.AllocsPerOp != 13 {
+		t.Fatalf("aggregate=%+v want averaged ns/bytes/allocs", agg)
+	}
+	row := classifyGoBenchmark(namedPath{Name: "treedb_10k", Path: "bench.txt"}, agg)
+	if row.Modality != "text_only" || row.Engine != "treedb_text_v2" {
+		t.Fatalf("row modality/engine=%s/%s", row.Modality, row.Engine)
+	}
+	if row.OpsPerSec == nil || *row.OpsPerSec < 222 || *row.OpsPerSec > 223 {
+		t.Fatalf("ops/sec=%v want about 222", row.OpsPerSec)
+	}
+	if !strings.Contains(row.Dataset, "docs=10000") || !strings.Contains(row.Dataset, "candidate_budget=64") {
+		t.Fatalf("dataset=%q", row.Dataset)
+	}
+}
+
+func TestCounterValidationFailsClosedForZeroDocRows(t *testing.T) {
+	row := scoreboardRow{
+		SourceLabel: "treedb_bad",
+		System:      "TreeDB",
+		Modality:    "text_only",
+		Boundary:    "No-document text-v2 candidate generation",
+		Benchmark:   "BenchmarkIndexInsertSearch2564/search_text_v2_candidates_no_docs",
+		Metrics: map[string]float64{
+			"docs_fetched/search":       1,
+			"full_doc_fallbacks/search": 0,
+			"fail_closed/search":        0,
+			"text_state_lookups/search": 0,
+			"text_match_details/search": 0,
+		},
+	}
+	checks := validateCounterRows([]scoreboardRow{row})
+	if got, want := len(checks), 1; got != want {
+		t.Fatalf("checks=%d want %d", got, want)
+	}
+	if checks[0].OK || !strings.Contains(strings.Join(checks[0].Failures, " "), "docs_fetched/search=1 want 0") {
+		t.Fatalf("check=%+v want docs_fetched failure", checks[0])
+	}
+}
+
+func TestBuildReportParsesExternalAndRendersUnavailable(t *testing.T) {
+	dir := t.TempDir()
+	goBench := filepath.Join(dir, "go.txt")
+	if err := os.WriteFile(goBench, []byte(`BenchmarkIndexInsertSearch2564/search_hybrid_v2_no_docs_scalar_filter-8 1 1200000 ns/op 2048 B/op 20 allocs/op 10000 docs_fixture 16 vector_dims 64 candidate_budget/source 10 topk/search 0 docs_fetched/search 0 full_doc_fallbacks/search 0 fail_closed/search 0 text_state_lookups/search 0 text_match_details/search 625 scalar_prefilter_ids/search 64 text_candidates/search
+`), 0o644); err != nil {
+		t.Fatalf("write go bench: %v", err)
+	}
+	external := filepath.Join(dir, "sqlite_fts5.json")
+	if err := os.WriteFile(external, []byte(`{
+  "schema_version":"treedb_text_hybrid_external/v1",
+  "status":"ok",
+  "system":"SQLite FTS5",
+  "engine":"sqlite_fts5",
+  "modality":"text_only",
+  "dataset":{"docs":10000,"queries":1000,"top_k":10},
+  "query_shape":"MATCH refund policy bm25 top-k",
+  "boundary":"no-document rowid+bm25 only; no full document fetch",
+  "benchmark":"sqlite_fts5/search",
+  "search":{"avg_nanos":250000,"ops_per_second":4000},
+  "build":{"seconds":0.75},
+  "storage":{"total_bytes":1048576,"bytes_per_doc":104.8},
+  "metrics":{"docs_fetched/search":0,"full_doc_fallbacks/search":0,"fail_closed/search":0}
+}`), 0o644); err != nil {
+		t.Fatalf("write external: %v", err)
+	}
+	rep, err := buildReport(config{
+		outDir:      dir,
+		goBenches:   namedPaths{{Name: "treedb_10k", Path: goBench}},
+		externals:   namedPaths{{Name: "sqlite_fts5_10k", Path: external}},
+		unavailable: namedValues{{Name: "Lucene", Value: "not run in unit test"}},
+	})
+	if err != nil {
+		t.Fatalf("buildReport: %v", err)
+	}
+	if got, want := len(rep.Rows), 2; got != want {
+		t.Fatalf("rows=%d want %d", got, want)
+	}
+	var sawSQLiteTopK bool
+	for _, row := range rep.Rows {
+		if row.System == "SQLite FTS5" && row.TopK == 10 {
+			sawSQLiteTopK = true
+		}
+	}
+	if !sawSQLiteTopK {
+		t.Fatalf("SQLite FTS5 topK not propagated from dataset: %#v", rep.Rows)
+	}
+	if got, want := len(rep.CounterValidations), 2; got != want {
+		t.Fatalf("counter validations=%d want %d", got, want)
+	}
+	md := renderMarkdown(rep)
+	for _, want := range []string{"SQLite FTS5", "text_scalar", "Lucene", "not run in unit test", "scoreboard"} {
+		if !strings.Contains(md, want) {
+			t.Fatalf("markdown missing %q:\n%s", want, md)
+		}
+	}
+}
+
+func TestRunRejectsMissingInputsEvenWhenCounterFailuresAllowed(t *testing.T) {
+	dir := t.TempDir()
+	err := run(config{outDir: filepath.Join(dir, "out"), allowCounterFailures: true, goBenches: namedPaths{{Name: "missing", Path: filepath.Join(dir, "missing.txt")}}})
+	if err == nil || !strings.Contains(err.Error(), "read go bench") {
+		t.Fatalf("run err=%v want missing input error", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, "out", "scoreboard.json")); !os.IsNotExist(statErr) {
+		t.Fatalf("scoreboard.json exists for missing input: %v", statErr)
+	}
+}
+
+func TestRunWritesReportBeforeReturningCounterFailure(t *testing.T) {
+	dir := t.TempDir()
+	goBench := filepath.Join(dir, "bad.txt")
+	if err := os.WriteFile(goBench, []byte(`BenchmarkIndexInsertSearch2564/search_text_v2_candidates_no_docs-8 1 1000 ns/op 1 B/op 1 allocs/op 1 docs_fetched/search 0 full_doc_fallbacks/search 0 fail_closed/search 0 text_state_lookups/search 0 text_match_details/search
+`), 0o644); err != nil {
+		t.Fatalf("write bad bench: %v", err)
+	}
+	out := filepath.Join(dir, "out")
+	err := run(config{outDir: out, goBenches: namedPaths{{Name: "bad", Path: goBench}}})
+	if err == nil {
+		t.Fatal("run err=nil want counter validation failure")
+	}
+	if _, statErr := os.Stat(filepath.Join(out, "scoreboard.json")); statErr != nil {
+		t.Fatalf("scoreboard.json not written before failure: %v", statErr)
+	}
+}

--- a/cmd/treedb_text_hybrid_scoreboard/main_test.go
+++ b/cmd/treedb_text_hybrid_scoreboard/main_test.go
@@ -162,7 +162,14 @@ func TestBuildReportParsesExternalAndRendersUnavailable(t *testing.T) {
 
 func TestRunRejectsMissingInputsEvenWhenCounterFailuresAllowed(t *testing.T) {
 	dir := t.TempDir()
-	err := run(config{outDir: filepath.Join(dir, "out"), allowCounterFailures: true, goBenches: namedPaths{{Name: "missing", Path: filepath.Join(dir, "missing.txt")}}})
+	err := run(config{
+		outDir:               filepath.Join(dir, "out"),
+		allowCounterFailures: true,
+		goBenches: namedPaths{{
+			Name: "missing",
+			Path: filepath.Join(dir, "missing.txt"),
+		}},
+	})
 	if err == nil || !strings.Contains(err.Error(), "read go bench") {
 		t.Fatalf("run err=%v want missing input error", err)
 	}

--- a/cmd/treedb_text_hybrid_scoreboard/main_test.go
+++ b/cmd/treedb_text_hybrid_scoreboard/main_test.go
@@ -76,6 +76,33 @@ func TestRowsFromGoBenchRejectsEmptyArtifacts(t *testing.T) {
 	}
 }
 
+func TestHybridCloseoutOverrideLabelDrivesDatasetDocs(t *testing.T) {
+	dir := t.TempDir()
+	goBench := filepath.Join(dir, "hybrid.txt")
+	if err := os.WriteFile(goBench, []byte(`BenchmarkSearchHybridCloseout2506/mode_hybrid_no_docs/topK_10/candidates_64/filter_none_100pct-8 1 1000 ns/op 10 B/op 1 allocs/op 0 docs_fetched/search 0 full_doc_fallbacks/search 0 fail_closed/search 0 text_state_lookups/search 0 text_match_details/search
+`), 0o644); err != nil {
+		t.Fatalf("write go bench: %v", err)
+	}
+	rep, err := buildReport(config{
+		outDir:    dir,
+		goBenches: namedPaths{{Name: "treedb_hybrid_closeout_docs_64", Path: goBench}},
+	})
+	if err != nil {
+		t.Fatalf("buildReport: %v", err)
+	}
+	if got, want := len(rep.Rows), 1; got != want {
+		t.Fatalf("rows=%d want %d", got, want)
+	}
+	row := rep.Rows[0]
+	if !strings.Contains(row.Dataset, "docs=64") || strings.Contains(row.Dataset, "docs=10000") {
+		t.Fatalf("dataset=%q want docs=64 from source label override", row.Dataset)
+	}
+	md := renderMarkdown(rep)
+	if !strings.Contains(md, "docs=64") || strings.Contains(md, "docs=10000") {
+		t.Fatalf("markdown dataset did not use override docs:\n%s", md)
+	}
+}
+
 func TestBuildReportParsesExternalAndRendersUnavailable(t *testing.T) {
 	dir := t.TempDir()
 	goBench := filepath.Join(dir, "go.txt")

--- a/docs/benchmarks/treedb_text_hybrid_industry_scoreboard.md
+++ b/docs/benchmarks/treedb_text_hybrid_industry_scoreboard.md
@@ -35,6 +35,11 @@ go run ./cmd/treedb_text_hybrid_scoreboard \
   -external "sqlite_fts5_10k=$RUN_DIR/sqlite_fts5_10k.json"
 ```
 
+When `DOCS_10K` is overridden for smoke or scaled-down runs, the script uses an
+exact-doc hybrid source label such as `treedb_hybrid_closeout_docs_64` so the
+report dataset metadata reflects the actual fixture size rather than the default
+10k label.
+
 The generator fails closed by default when a TreeDB no-document candidate row has
 non-zero `docs_fetched/search`, `full_doc_fallbacks/search`, `fail_closed/search`,
 or text-v2 state/match-detail counters where score-only rows require zero. Use

--- a/docs/benchmarks/treedb_text_hybrid_industry_scoreboard.md
+++ b/docs/benchmarks/treedb_text_hybrid_industry_scoreboard.md
@@ -1,0 +1,164 @@
+# TreeDB text-v2/hybrid industry comparison scoreboard (#2727)
+
+This runbook is the stable #2727 scoreboard contract for downstream text-v2 and
+hybrid optimization issues. It measures TreeDB text-only, vector-only,
+text+vector, and text+vector+scalar retrieval rows against local external
+baselines where practical. It is a benchmark/report harness, not an optimization
+or industry-parity claim.
+
+## Stable commands and artifacts
+
+Default local smoke/current matrix:
+
+```sh
+RUN_DIR=/tmp/gomap_text_hybrid_scoreboard_$(date +%Y%m%d_%H%M%S) \
+  scripts/bench_text_hybrid_scoreboard.sh
+```
+
+Primary outputs:
+
+- `$RUN_DIR/scoreboard.md`
+- `$RUN_DIR/scoreboard.json`
+- `$RUN_DIR/context.txt`
+- raw TreeDB Go benchmark logs under `$RUN_DIR/treedb_*.txt`
+- optional external JSON artifacts such as `$RUN_DIR/sqlite_fts5_10k.json`
+
+The report generator can also be used directly with raw artifacts:
+
+```sh
+go run ./cmd/treedb_text_hybrid_scoreboard \
+  -out-dir "$RUN_DIR" \
+  -context "$RUN_DIR/context.txt" \
+  -go-bench "treedb_index_insert_search_10k=$RUN_DIR/treedb_index_insert_search_10k.txt" \
+  -go-bench "treedb_hybrid_closeout_10k=$RUN_DIR/treedb_hybrid_closeout_10k.txt" \
+  -go-bench "treedb_text_blockmax_10k=$RUN_DIR/treedb_text_blockmax_10k.txt" \
+  -external "sqlite_fts5_10k=$RUN_DIR/sqlite_fts5_10k.json"
+```
+
+The generator fails closed by default when a TreeDB no-document candidate row has
+non-zero `docs_fetched/search`, `full_doc_fallbacks/search`, `fail_closed/search`,
+or text-v2 state/match-detail counters where score-only rows require zero. Use
+`-allow-counter-failures` only to inspect a broken run; do not cite that report as
+passing evidence.
+
+## Corpus and query contract
+
+### TreeDB 10k current matrix
+
+The default script runs these TreeDB rows with `DOCS_10K=10000`, `DIMS=16`,
+`M=8`, `topK=10`, and candidate budgets of `64` unless a benchmark row specifies
+otherwise:
+
+```sh
+GOWORK=off TREEDB_INDEX_BENCH_DOCS=10000 TREEDB_INDEX_BENCH_DIMS=16 TREEDB_INDEX_BENCH_M=8 \
+  go test ./TreeDB/collections -run '^$' \
+  -bench '^BenchmarkIndexInsertSearch2564/(search_text_v2_candidates_no_docs|search_vector_candidates_no_docs|search_hybrid_v2_no_docs_scalar_filter|indexed_insert_batch_flush_vector_rebuild)$' \
+  -benchmem -benchtime=3x -count=1
+
+GOWORK=off TREEDB_HYBRID_BENCH_DOCS=10000 TREEDB_HYBRID_BENCH_DIMS=16 TREEDB_HYBRID_BENCH_M=8 \
+  go test ./TreeDB/collections -run '^$' \
+  -bench '^BenchmarkSearchHybridCloseout2506/mode_(text_only_no_docs|vector_only_no_docs|hybrid_no_docs)/topK_10/candidates_64/filter_(none_100pct|rare_06pct)$' \
+  -benchmem -benchtime=3x -count=1
+
+GOWORK=off TREEDB_TEXT_V2_BLOCKMAX_DOCS=10000 \
+  go test ./TreeDB/collections -run '^$' \
+  -bench '^BenchmarkTextV2BlockMaxCommonTerm2628/(blockmax_common_topk|exhaustive_common_topk)$' \
+  -benchmem -benchtime=3x -count=1
+```
+
+The corpus is deterministic synthetic customer-support text plus vectors:
+
+- text fields: `title` weight `3`, `body` weight `1`;
+- analyzer: TreeDB simple analyzer/default text-v2 analyzer assumptions used by
+  collection text indexes;
+- text query: `refund policy` for hybrid closeout rows; common single term
+  `refund` for block-max rows;
+- vector query: deterministic vector near the refund-topic documents;
+- scalar filter: indexed tenant value `tenant-rare-06pct` where used;
+- relevance labels: synthetic/topic-derived only. Use recall/quality labels from
+  a real corpus before making relevance-quality claims.
+
+### 100k rows
+
+The default smoke run does not start heavier 100k jobs automatically. Run:
+
+```sh
+RUN_100K=true TEXT_100K_BENCHTIME=1x TEXT_100K_COUNT=1 \
+  RUN_DIR=/tmp/gomap_text_hybrid_scoreboard_100k_$(date +%Y%m%d_%H%M%S) \
+  scripts/bench_text_hybrid_scoreboard.sh
+```
+
+This adds the 100k text-v2 blockmax/common-term rows. 100k hybrid/vector rows
+remain opt-in and should be planned explicitly before long local or service
+runs.
+
+## External baselines
+
+### SQLite FTS5 embedded text baseline
+
+The default script runs the stdlib Python SQLite FTS5 runner when FTS5 is
+available:
+
+```sh
+python3 benchmarks/text_hybrid_scoreboard/sqlite_fts5_bench.py \
+  --docs 10000 --queries 1000 --top-k 10 \
+  --out "$RUN_DIR/sqlite_fts5_10k.json"
+```
+
+Boundary: `rowid` + `bm25()` retrieval only from an FTS5 virtual table; no primary
+JSON document fetch is timed. Storage is the SQLite DB file after WAL checkpoint
+and truncate. If the local SQLite build lacks FTS5, the script emits an explicit
+`status=unavailable` JSON artifact that the scoreboard records without inventing
+numbers.
+
+### Vector and hybrid service baselines
+
+Use the existing vector external comparison harness for durable vector-only
+comparators when a run is needed:
+
+```sh
+RUN_DIR=/tmp/gomap_vector_db_compare_$(date +%Y%m%d_%H%M%S) \
+BACKENDS=treedb_column_graph,vectorlite,pgvector \
+DOCS=10000 DIMS=1536 QUERIES=10000 VALIDATE_QUERIES=64 TOP_K=10 \
+SEARCH_CONCURRENCY=1,8 M=16 EF_CONSTRUCTION=128 EF_SEARCH=128 \
+scripts/bench_vector_db_compare.sh
+```
+
+The scoreboard generator accepts the resulting JSON files with repeated
+`-external name=path` flags and maps `search_benchmarks` rows into vector-only
+scoreboard rows.
+
+Lucene, Tantivy, Bleve, Qdrant, Weaviate, Milvus, and OpenSearch hybrid rows are
+not run by the default smoke harness. Add pinned service/library commands and
+artifacts before citing them; otherwise record an explicit unavailable reason.
+
+## Metrics every scoreboard row must report
+
+For Go benchmark rows, include:
+
+- exact command and artifact root;
+- branch/commit, base ref/SHA, Go version, host/OS/load context;
+- dataset shape, query shape, topK, candidate budget, and measured boundary;
+- `ns/op`, derived `ops/sec`, `B/op`, and `allocs/op`;
+- relevant counters: `docs_fetched/search`, `full_doc_fallbacks/search`,
+  `fail_closed/search`, text posting/block/state/norm counters, scalar counters,
+  vector candidate/edge counters;
+- build/storage context when available (`indexed_insert_batch_flush_vector_rebuild`,
+  `create_text_v2_index_backfill`, `index_bytes/doc`, external build/storage
+  fields).
+
+Candidate-generation rows must keep full document fetches at zero. Final-fetch
+rows must keep document fetches bounded by top-K and should stay separate from
+candidate rows.
+
+## Downstream contract surface
+
+Downstream issues #2728, #2729, #2731, and #2734 can cite:
+
+- `scripts/bench_text_hybrid_scoreboard.sh` as the stable capture entry point;
+- `cmd/treedb_text_hybrid_scoreboard` as the parser/report generator;
+- `scoreboard.json` schema `treedb_text_hybrid_scoreboard/v1`;
+- `scoreboard.md` retrieval and zero-doc counter validation tables.
+
+Avoid changing these names or table meanings without updating this runbook and
+the parser/report tests.

--- a/scripts/bench_text_hybrid_scoreboard.sh
+++ b/scripts/bench_text_hybrid_scoreboard.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+cd "$ROOT"
+
+RUN_DIR="${RUN_DIR:-/tmp/gomap_text_hybrid_scoreboard_$(date +%Y%m%d_%H%M%S)}"
+GO_BIN="${GO_BIN:-go}"
+PYTHON="${PYTHON:-python3}"
+BENCHTIME="${BENCHTIME:-3x}"
+COUNT="${COUNT:-1}"
+DOCS_10K="${DOCS_10K:-10000}"
+DIMS="${DIMS:-16}"
+M="${M:-8}"
+RUN_100K="${RUN_100K:-false}"
+RUN_SQLITE_FTS5="${RUN_SQLITE_FTS5:-true}"
+SQLITE_FTS5_QUERIES="${SQLITE_FTS5_QUERIES:-1000}"
+SQLITE_FTS5_DOCS="${SQLITE_FTS5_DOCS:-$DOCS_10K}"
+TEXT_100K_BENCHTIME="${TEXT_100K_BENCHTIME:-1x}"
+TEXT_100K_COUNT="${TEXT_100K_COUNT:-1}"
+
+mkdir -p "$RUN_DIR"
+
+{
+  echo "timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  echo "repo=$ROOT"
+  echo "branch=$(git branch --show-current 2>/dev/null || true)"
+  echo "commit=$(git rev-parse HEAD 2>/dev/null || true)"
+  echo "go=$($GO_BIN version 2>/dev/null || true)"
+  echo "python=$($PYTHON --version 2>&1 || true)"
+  echo "uname=$(uname -a 2>/dev/null || true)"
+  echo "cpu=$(sysctl -n machdep.cpu.brand_string 2>/dev/null || true)"
+  echo "ncpu=$(sysctl -n hw.ncpu 2>/dev/null || nproc 2>/dev/null || true)"
+  echo "uptime=$(uptime 2>/dev/null || true)"
+} | tee "$RUN_DIR/context.txt"
+
+run_go_bench() {
+  local label="$1"
+  local outfile="$2"
+  shift 2
+  echo "==> $label"
+  set -o pipefail
+  "$@" | tee "$outfile"
+}
+
+INDEX_10K="$RUN_DIR/treedb_index_insert_search_10k.txt"
+run_go_bench "TreeDB 10k text-v2/vector/hybrid+scalar candidates" "$INDEX_10K" \
+  env GOWORK=off \
+    TREEDB_INDEX_BENCH_DOCS="$DOCS_10K" \
+    TREEDB_INDEX_BENCH_DIMS="$DIMS" \
+    TREEDB_INDEX_BENCH_M="$M" \
+    "$GO_BIN" test ./TreeDB/collections \
+      -run '^$' \
+      -bench '^BenchmarkIndexInsertSearch2564/(search_text_v2_candidates_no_docs|search_vector_candidates_no_docs|search_hybrid_v2_no_docs_scalar_filter|indexed_insert_batch_flush_vector_rebuild)$' \
+      -benchmem \
+      -benchtime="$BENCHTIME" \
+      -count="$COUNT"
+
+HYBRID_10K="$RUN_DIR/treedb_hybrid_closeout_10k.txt"
+run_go_bench "TreeDB 10k text-only/vector-only/hybrid/hybrid+scalar executor rows" "$HYBRID_10K" \
+  env GOWORK=off \
+    TREEDB_HYBRID_BENCH_DOCS="$DOCS_10K" \
+    TREEDB_HYBRID_BENCH_DIMS="$DIMS" \
+    TREEDB_HYBRID_BENCH_M="$M" \
+    "$GO_BIN" test ./TreeDB/collections \
+      -run '^$' \
+      -bench '^BenchmarkSearchHybridCloseout2506/mode_(text_only_no_docs|vector_only_no_docs|hybrid_no_docs)/topK_10/candidates_64/filter_(none_100pct|rare_06pct)$' \
+      -benchmem \
+      -benchtime="$BENCHTIME" \
+      -count="$COUNT"
+
+TEXT_BLOCKMAX_10K="$RUN_DIR/treedb_text_blockmax_10k.txt"
+run_go_bench "TreeDB 10k text-v2 blockmax/exhaustive common-term rows" "$TEXT_BLOCKMAX_10K" \
+  env GOWORK=off \
+    TREEDB_TEXT_V2_BLOCKMAX_DOCS="$DOCS_10K" \
+    "$GO_BIN" test ./TreeDB/collections \
+      -run '^$' \
+      -bench '^BenchmarkTextV2BlockMaxCommonTerm2628/(blockmax_common_topk|exhaustive_common_topk)$' \
+      -benchmem \
+      -benchtime="$BENCHTIME" \
+      -count="$COUNT"
+
+SCOREBOARD_ARGS=(
+  -out-dir "$RUN_DIR"
+  -context "$RUN_DIR/context.txt"
+  -base-ref "origin/main"
+  -base-sha "$(git merge-base HEAD origin/main 2>/dev/null || true)"
+  -go-bench "treedb_index_insert_search_10k=$INDEX_10K"
+  -go-bench "treedb_hybrid_closeout_10k=$HYBRID_10K"
+  -go-bench "treedb_text_blockmax_10k=$TEXT_BLOCKMAX_10K"
+  -command "treedb_index_insert_search_10k=GOWORK=off TREEDB_INDEX_BENCH_DOCS=$DOCS_10K TREEDB_INDEX_BENCH_DIMS=$DIMS TREEDB_INDEX_BENCH_M=$M $GO_BIN test ./TreeDB/collections -run '^$' -bench '^BenchmarkIndexInsertSearch2564/(search_text_v2_candidates_no_docs|search_vector_candidates_no_docs|search_hybrid_v2_no_docs_scalar_filter|indexed_insert_batch_flush_vector_rebuild)$' -benchmem -benchtime=$BENCHTIME -count=$COUNT"
+  -command "treedb_hybrid_closeout_10k=GOWORK=off TREEDB_HYBRID_BENCH_DOCS=$DOCS_10K TREEDB_HYBRID_BENCH_DIMS=$DIMS TREEDB_HYBRID_BENCH_M=$M $GO_BIN test ./TreeDB/collections -run '^$' -bench '^BenchmarkSearchHybridCloseout2506/mode_(text_only_no_docs|vector_only_no_docs|hybrid_no_docs)/topK_10/candidates_64/filter_(none_100pct|rare_06pct)$' -benchmem -benchtime=$BENCHTIME -count=$COUNT"
+  -command "treedb_text_blockmax_10k=GOWORK=off TREEDB_TEXT_V2_BLOCKMAX_DOCS=$DOCS_10K $GO_BIN test ./TreeDB/collections -run '^$' -bench '^BenchmarkTextV2BlockMaxCommonTerm2628/(blockmax_common_topk|exhaustive_common_topk)$' -benchmem -benchtime=$BENCHTIME -count=$COUNT"
+)
+
+if [[ "$RUN_SQLITE_FTS5" == "true" || "$RUN_SQLITE_FTS5" == "1" || "$RUN_SQLITE_FTS5" == "yes" ]]; then
+  SQLITE_JSON="$RUN_DIR/sqlite_fts5_10k.json"
+  echo "==> SQLite FTS5 text baseline"
+  "$PYTHON" benchmarks/text_hybrid_scoreboard/sqlite_fts5_bench.py \
+    --docs "$SQLITE_FTS5_DOCS" \
+    --queries "$SQLITE_FTS5_QUERIES" \
+    --top-k 10 \
+    --out "$SQLITE_JSON"
+  SCOREBOARD_ARGS+=(
+    -external "sqlite_fts5_10k=$SQLITE_JSON"
+    -command "sqlite_fts5_10k=$PYTHON benchmarks/text_hybrid_scoreboard/sqlite_fts5_bench.py --docs $SQLITE_FTS5_DOCS --queries $SQLITE_FTS5_QUERIES --top-k 10 --out $SQLITE_JSON"
+  )
+fi
+
+if [[ "$RUN_100K" == "true" || "$RUN_100K" == "1" || "$RUN_100K" == "yes" ]]; then
+  TEXT_BLOCKMAX_100K="$RUN_DIR/treedb_text_blockmax_100k.txt"
+  run_go_bench "TreeDB 100k text-v2 blockmax/exhaustive common-term rows" "$TEXT_BLOCKMAX_100K" \
+    env GOWORK=off \
+      TREEDB_TEXT_V2_BLOCKMAX_DOCS=100000 \
+      "$GO_BIN" test ./TreeDB/collections \
+        -run '^$' \
+        -bench '^BenchmarkTextV2BlockMaxCommonTerm2628/(blockmax_common_topk|exhaustive_common_topk)$' \
+        -benchmem \
+        -benchtime="$TEXT_100K_BENCHTIME" \
+        -count="$TEXT_100K_COUNT"
+  SCOREBOARD_ARGS+=(
+    -go-bench "treedb_text_blockmax_100k=$TEXT_BLOCKMAX_100K"
+    -command "treedb_text_blockmax_100k=GOWORK=off TREEDB_TEXT_V2_BLOCKMAX_DOCS=100000 $GO_BIN test ./TreeDB/collections -run '^$' -bench '^BenchmarkTextV2BlockMaxCommonTerm2628/(blockmax_common_topk|exhaustive_common_topk)$' -benchmem -benchtime=$TEXT_100K_BENCHTIME -count=$TEXT_100K_COUNT"
+  )
+else
+  SCOREBOARD_ARGS+=(
+    -caveat "100k text-v2 blockmax rows are available with RUN_100K=true; the default smoke matrix keeps them off to avoid surprise long local runs."
+  )
+fi
+
+SCOREBOARD_ARGS+=(
+  -unavailable "Lucene=not run by the default local harness; use a pinned Lucene/JMH or OpenSearch run with the same corpus/query contract before making Lucene parity claims"
+  -unavailable "Tantivy=not run by the default local harness; requires a Rust/Tantivy harness pinned to this corpus and query set"
+  -unavailable "Bleve=not run by the default local harness; requires adding or invoking a Bleve-specific runner outside TreeDB production code"
+  -unavailable "Qdrant/Weaviate/Milvus/OpenSearch hybrid=not run by the default smoke harness; use service-specific durable deployments or documented local proxies before citing industry hybrid parity"
+)
+
+"$GO_BIN" run ./cmd/treedb_text_hybrid_scoreboard "${SCOREBOARD_ARGS[@]}"
+
+cat > "$RUN_DIR/README.md" <<EOF_README
+# TreeDB text/hybrid scoreboard run
+
+Primary artifacts:
+
+- scoreboard: \`$RUN_DIR/scoreboard.md\`
+- scoreboard JSON: \`$RUN_DIR/scoreboard.json\`
+- context: \`$RUN_DIR/context.txt\`
+- TreeDB 10k index/search raw: \`$INDEX_10K\`
+- TreeDB 10k hybrid executor raw: \`$HYBRID_10K\`
+- TreeDB 10k text blockmax raw: \`$TEXT_BLOCKMAX_10K\`
+
+Set \`RUN_100K=true\` for the heavier 100k text blockmax rows. Set
+\`RUN_SQLITE_FTS5=false\` to skip the local SQLite FTS5 embedded text baseline.
+EOF_README
+
+echo "scoreboard: $RUN_DIR/scoreboard.md"

--- a/scripts/bench_text_hybrid_scoreboard.sh
+++ b/scripts/bench_text_hybrid_scoreboard.sh
@@ -43,8 +43,18 @@ run_go_bench() {
   "$@" | tee "$outfile"
 }
 
+scoreboard_doc_label() {
+  local docs="$1"
+  case "$docs" in
+    10000) printf '10k' ;;
+    100000) printf '100k' ;;
+    1000000) printf '1m' ;;
+    *) printf 'docs_%s' "$docs" ;;
+  esac
+}
+
 INDEX_10K="$RUN_DIR/treedb_index_insert_search_10k.txt"
-run_go_bench "TreeDB 10k text-v2/vector/hybrid+scalar candidates" "$INDEX_10K" \
+run_go_bench "TreeDB $DOCS_10K-doc text-v2/vector/hybrid+scalar candidates" "$INDEX_10K" \
   env GOWORK=off \
     TREEDB_INDEX_BENCH_DOCS="$DOCS_10K" \
     TREEDB_INDEX_BENCH_DIMS="$DIMS" \
@@ -56,8 +66,9 @@ run_go_bench "TreeDB 10k text-v2/vector/hybrid+scalar candidates" "$INDEX_10K" \
       -benchtime="$BENCHTIME" \
       -count="$COUNT"
 
-HYBRID_10K="$RUN_DIR/treedb_hybrid_closeout_10k.txt"
-run_go_bench "TreeDB 10k text-only/vector-only/hybrid/hybrid+scalar executor rows" "$HYBRID_10K" \
+HYBRID_10K_LABEL="treedb_hybrid_closeout_$(scoreboard_doc_label "$DOCS_10K")"
+HYBRID_10K="$RUN_DIR/$HYBRID_10K_LABEL.txt"
+run_go_bench "TreeDB $DOCS_10K-doc text-only/vector-only/hybrid/hybrid+scalar executor rows" "$HYBRID_10K" \
   env GOWORK=off \
     TREEDB_HYBRID_BENCH_DOCS="$DOCS_10K" \
     TREEDB_HYBRID_BENCH_DIMS="$DIMS" \
@@ -70,7 +81,7 @@ run_go_bench "TreeDB 10k text-only/vector-only/hybrid/hybrid+scalar executor row
       -count="$COUNT"
 
 TEXT_BLOCKMAX_10K="$RUN_DIR/treedb_text_blockmax_10k.txt"
-run_go_bench "TreeDB 10k text-v2 blockmax/exhaustive common-term rows" "$TEXT_BLOCKMAX_10K" \
+run_go_bench "TreeDB $DOCS_10K-doc text-v2 blockmax/exhaustive common-term rows" "$TEXT_BLOCKMAX_10K" \
   env GOWORK=off \
     TREEDB_TEXT_V2_BLOCKMAX_DOCS="$DOCS_10K" \
     "$GO_BIN" test ./TreeDB/collections \
@@ -86,10 +97,10 @@ SCOREBOARD_ARGS=(
   -base-ref "origin/main"
   -base-sha "$(git merge-base HEAD origin/main 2>/dev/null || true)"
   -go-bench "treedb_index_insert_search_10k=$INDEX_10K"
-  -go-bench "treedb_hybrid_closeout_10k=$HYBRID_10K"
+  -go-bench "$HYBRID_10K_LABEL=$HYBRID_10K"
   -go-bench "treedb_text_blockmax_10k=$TEXT_BLOCKMAX_10K"
   -command "treedb_index_insert_search_10k=GOWORK=off TREEDB_INDEX_BENCH_DOCS=$DOCS_10K TREEDB_INDEX_BENCH_DIMS=$DIMS TREEDB_INDEX_BENCH_M=$M $GO_BIN test ./TreeDB/collections -run '^$' -bench '^BenchmarkIndexInsertSearch2564/(search_text_v2_candidates_no_docs|search_vector_candidates_no_docs|search_hybrid_v2_no_docs_scalar_filter|indexed_insert_batch_flush_vector_rebuild)$' -benchmem -benchtime=$BENCHTIME -count=$COUNT"
-  -command "treedb_hybrid_closeout_10k=GOWORK=off TREEDB_HYBRID_BENCH_DOCS=$DOCS_10K TREEDB_HYBRID_BENCH_DIMS=$DIMS TREEDB_HYBRID_BENCH_M=$M $GO_BIN test ./TreeDB/collections -run '^$' -bench '^BenchmarkSearchHybridCloseout2506/mode_(text_only_no_docs|vector_only_no_docs|hybrid_no_docs)/topK_10/candidates_64/filter_(none_100pct|rare_06pct)$' -benchmem -benchtime=$BENCHTIME -count=$COUNT"
+  -command "$HYBRID_10K_LABEL=GOWORK=off TREEDB_HYBRID_BENCH_DOCS=$DOCS_10K TREEDB_HYBRID_BENCH_DIMS=$DIMS TREEDB_HYBRID_BENCH_M=$M $GO_BIN test ./TreeDB/collections -run '^$' -bench '^BenchmarkSearchHybridCloseout2506/mode_(text_only_no_docs|vector_only_no_docs|hybrid_no_docs)/topK_10/candidates_64/filter_(none_100pct|rare_06pct)$' -benchmem -benchtime=$BENCHTIME -count=$COUNT"
   -command "treedb_text_blockmax_10k=GOWORK=off TREEDB_TEXT_V2_BLOCKMAX_DOCS=$DOCS_10K $GO_BIN test ./TreeDB/collections -run '^$' -bench '^BenchmarkTextV2BlockMaxCommonTerm2628/(blockmax_common_topk|exhaustive_common_topk)$' -benchmem -benchtime=$BENCHTIME -count=$COUNT"
 )
 
@@ -145,9 +156,9 @@ Primary artifacts:
 - scoreboard: \`$RUN_DIR/scoreboard.md\`
 - scoreboard JSON: \`$RUN_DIR/scoreboard.json\`
 - context: \`$RUN_DIR/context.txt\`
-- TreeDB 10k index/search raw: \`$INDEX_10K\`
-- TreeDB 10k hybrid executor raw: \`$HYBRID_10K\`
-- TreeDB 10k text blockmax raw: \`$TEXT_BLOCKMAX_10K\`
+- TreeDB $DOCS_10K-doc index/search raw: \`$INDEX_10K\`
+- TreeDB $DOCS_10K-doc hybrid executor raw: \`$HYBRID_10K\`
+- TreeDB $DOCS_10K-doc text blockmax raw: \`$TEXT_BLOCKMAX_10K\`
 
 Set \`RUN_100K=true\` for the heavier 100k text blockmax rows. Set
 \`RUN_SQLITE_FTS5=false\` to skip the local SQLite FTS5 embedded text baseline.


### PR DESCRIPTION
## Linked issues

- Closes #2727
- Part of #2726 (M0 scoreboard foundation)

## Scope

Adds a repeatable TreeDB text-v2/hybrid industry comparison scoreboard contract:

- `scripts/bench_text_hybrid_scoreboard.sh` capture entry point.
- `cmd/treedb_text_hybrid_scoreboard` parser/report generator producing `scoreboard.json` (`treedb_text_hybrid_scoreboard/v1`) and `scoreboard.md`.
- `benchmarks/text_hybrid_scoreboard/sqlite_fts5_bench.py` local embedded SQLite FTS5 text baseline JSON artifact.
- `docs/benchmarks/treedb_text_hybrid_industry_scoreboard.md` runbook defining corpus/query/analyzer/top-k assumptions, external baseline caveats, required counters, and downstream contract surface.

Non-goals honored: no TreeDB production text/vector scoring changes, no optimizer changes, no external IR sidecar, and no industry-parity claims without artifacts/caveats.

## Start-phase plan

- Inventory existing text-v2, hybrid, vector, and external vector benchmark harnesses.
- Reuse current TreeDB benchmark rows where possible rather than adding production-path code.
- Add parser/report-generation tests and zero-doc counter validation tests.
- Capture 10k TreeDB text-only/vector-only/hybrid/hybrid+scalar rows and 100k text-v2 blockmax rows where practical.
- Capture a practical local external text baseline (SQLite FTS5) and document unavailable external systems.

## Close-phase tests

- `go test ./cmd/treedb_text_hybrid_scoreboard`
- `go test ./TreeDB/collections -run '^(TestTextV2HybridTextCandidatesNoDocCounters2627|TestTextV2DefaultSafe10KCandidateAndScalarBudgets2687|TestHybridCloseoutFixtureCandidateGenerationFetchesNoDocuments2506)$'`
- `go test ./cmd/treedb_text_hybrid_scoreboard ./TreeDB/collections`
- Smoke script check:
  - `RUN_DIR=/tmp/gomap_scoreboard_script_smoke DOCS_10K=64 BENCHTIME=1x COUNT=1 SQLITE_FTS5_DOCS=100 SQLITE_FTS5_QUERIES=5 RUN_100K=false scripts/bench_text_hybrid_scoreboard.sh`

## Benchmark evidence

Artifact root: `/tmp/gomap_2727_scoreboard_candidate_20260613_090425`

Command:

```sh
RUN_DIR=/tmp/gomap_2727_scoreboard_candidate_20260613_090425 \
BENCHTIME=1x COUNT=1 RUN_100K=true TEXT_100K_BENCHTIME=1x TEXT_100K_COUNT=1 \
SQLITE_FTS5_QUERIES=1000 \
scripts/bench_text_hybrid_scoreboard.sh
```

Hardware/context: Apple M3, 8 CPUs, macOS/Darwin arm64, Go `go1.26.0 darwin/arm64`; context file notes high background load (`load averages: 14.84 13.53 11.10`). Treat as same-host current/reference evidence, not isolated parity numbers.

Primary report: `/tmp/gomap_2727_scoreboard_candidate_20260613_090425/scoreboard.md`
JSON: `/tmp/gomap_2727_scoreboard_candidate_20260613_090425/scoreboard.json`

Representative rows from the report (all `-benchtime=1x`, `-count=1`):

| Row | Dataset/boundary | ns/op | ops/sec | B/op | allocs/op | Key counters |
| --- | --- | ---: | ---: | ---: | ---: | --- |
| TreeDB text-v2 candidates | 10k docs, no-doc `refund policy` | 5,016,250 | 199.353 | 2,969,248 | 11,181 | `docs_fetched=0`, `full_doc_fallbacks=0`, `fail_closed=0`, `text_state_lookups=0` |
| TreeDB vector candidates | 10k docs, no-doc vector | 63,125 | 15,841.6 | 149,816 | 83 | `docs_fetched=0`, `vector_candidates=64`, `vector_examined=269` |
| TreeDB hybrid | 10k docs, no-doc text+vector | 13,240,958 | 75.523 | 3,261,592 | 12,592 | `docs_fetched=0`, `text_state_lookups=0`, `vector_candidates=64` |
| TreeDB hybrid+scalar | 10k docs, no-doc text+vector+tenant filter | 2,116,333 | 472.515 | 1,999,976 | 6,291 | `docs_fetched=0`, `scalar_prefilter_ids=625`, `vector_candidates=64` |
| TreeDB text-v2 blockmax | 100k docs, no-doc common term | 3,842,292 | 260.261 | 2,557,792 | 4,105 | `docs_fetched=0`, `posting_blocks_skipped=684` |
| SQLite FTS5 | 10k docs, rowid+bm25 no-doc text baseline | 2,744,012.4 | 364.430 | n/a | n/a | `docs_fetched=0`, storage `1.28MiB`, build `0.050s` |

External baselines not run by the smoke harness are explicitly marked unavailable in the report: Lucene, Tantivy, Bleve, and Qdrant/Weaviate/Milvus/OpenSearch hybrid.

## Measurement boundary

TreeDB retrieval rows time no-document candidate generation/fusion unless explicitly labeled build/storage. Candidate-generation rows must keep `docs_fetched/search=0`, `full_doc_fallbacks/search=0`, `fail_closed/search=0`, and text-v2 state/match detail counters at zero where applicable. SQLite FTS5 times rowid + `bm25()` retrieval without primary JSON fetch.

## Performance regression assessment

This PR adds benchmark/report tooling and docs only; it does not change TreeDB production text/vector/hybrid scoring or storage paths. No material production performance regression is expected. The scoreboard artifact is current-reference evidence for downstream comparison, not an optimization claim.

## Review and CI status

- Internal high-thinking reviewer: PASS after fixes; no blocking findings/no nits.
- AI reviews: not requested yet. Per policy, they will only be requested after this mature PR is pushed with current tests/benchmark evidence and CI is running/green.
- CI: pending after PR creation.

## Unresolved threads / caveats

- 1M/10M scale runs are intentionally left to #2731; this PR provides 10k plus 100k text blockmax evidence and stable commands.
- Service-backed industry hybrid baselines require pinned external deployments before citing parity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added benchmarking infrastructure for SQLite FTS5 text search with detailed performance metrics (latency percentiles, throughput, result counts).
  * Added scoreboard report generator that aggregates and compares benchmark results from multiple search engines, producing formatted reports and JSON artifacts.
  * Added automated benchmark orchestration script for streamlined performance testing.

* **Documentation**
  * Added comprehensive guide for text/hybrid industry benchmarking procedures and expected metrics.

* **Tests**
  * Added test coverage for benchmarking tools and report generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->