### PR TITLE
Draft: treedb command-WAL DeleteRange spans

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -28974,6 +28974,17 @@ func (db *DB) Iterator(start, end []byte) (merging.Iterator, error) {
 			}
 			return db.wrapForegroundIterator(it)
 		}
+		if rootDomainSnapshotHasPublishedState(iteratorSnap) {
+			diskIter, ok, err := db.livePublishedRootIterator(iteratorSnap, start, end, false)
+			if err != nil {
+				return nil, err
+			}
+			if !ok || diskIter == nil {
+				out := merging.Iterator(&emptyIterator{start: start, end: end})
+				return decorate(out, 0), nil
+			}
+			return decorate(diskIter, 1), nil
+		}
 		if backendRangeKnown && !overlapsQuery(start, end, backendRange) {
 			out := merging.Iterator(&emptyIterator{start: start, end: end})
 			return decorate(out, 0), nil
@@ -29095,7 +29106,7 @@ func (db *DB) Iterator(start, end []byte) (merging.Iterator, error) {
 			ok       bool
 		)
 		if usePublishedRoot {
-			diskIter, ok, err = rootDomainPublishedIterator(iteratorSnap, start, end)
+			diskIter, ok, err = db.livePublishedRootIterator(iteratorSnap, start, end, false)
 		} else {
 			diskIter, err = db.backend.Iterator(start, end)
 			ok = true
@@ -29336,7 +29347,9 @@ func (db *DB) ReverseIterator(start, end []byte) (merging.Iterator, error) {
 
 	view = db.retainMemtableView()
 	queueLenLocked := 0
+	var iteratorSnap rootDomainSnapshot
 	if snap, ok := liveIteratorRootDomainSnapshot(view); ok {
+		iteratorSnap = snap
 		queueLenLocked = len(snap.immutables)
 	} else if view == nil {
 		queueLenLocked = len(db.queue)
@@ -29363,6 +29376,17 @@ func (db *DB) ReverseIterator(start, end []byte) (merging.Iterator, error) {
 				it = &debugIterator{Iterator: it, queueLen: 0, sourcesUsed: sourcesUsed}
 			}
 			return db.wrapForegroundIterator(it)
+		}
+		if rootDomainSnapshotHasPublishedState(iteratorSnap) {
+			diskIter, ok, err := db.livePublishedRootIterator(iteratorSnap, start, end, true)
+			if err != nil {
+				return nil, err
+			}
+			if !ok || diskIter == nil {
+				out := merging.Iterator(&emptyIterator{start: start, end: end})
+				return decorate(out, 0), nil
+			}
+			return decorate(diskIter, 1), nil
 		}
 		if backendRangeKnown && !overlapsQuery(start, end, backendRange) {
 			out := merging.Iterator(&emptyIterator{start: start, end: end})
@@ -29393,6 +29417,7 @@ func (db *DB) ReverseIterator(start, end []byte) (merging.Iterator, error) {
 	var queueRangeSpans [][]batch.DeleteRange
 	if view != nil {
 		if snap, ok := liveIteratorRootDomainSnapshot(view); ok {
+			iteratorSnap = snap
 			queue = snap.immutables
 			if len(view.rootIteratorRanges) == len(queue) {
 				queueRanges = view.rootIteratorRanges
@@ -29403,6 +29428,7 @@ func (db *DB) ReverseIterator(start, end []byte) (merging.Iterator, error) {
 		}
 	} else {
 		rawSnap, rawRanges := db.rawIteratorRootDomainSnapshot()
+		iteratorSnap = rawSnap
 		queue = rawSnap.immutables
 		queueRanges = rawRanges
 	}
@@ -29456,9 +29482,21 @@ func (db *DB) ReverseIterator(start, end []byte) (merging.Iterator, error) {
 		prio++
 	}
 
-	// Disk Iterator
-	if !backendRangeKnown || overlapsQuery(start, end, backendRange) {
-		diskIter, err := db.backend.ReverseIterator(start, end)
+	// Disk/published-root iterator. If the view pins an iterator root, iterate
+	// from that published root instead of crossing to the backend default root.
+	usePublishedRoot := rootDomainSnapshotHasPublishedState(iteratorSnap)
+	if usePublishedRoot || !backendRangeKnown || overlapsQuery(start, end, backendRange) {
+		var (
+			diskIter iterator.UnsafeIterator
+			err      error
+			ok       bool
+		)
+		if usePublishedRoot {
+			diskIter, ok, err = db.livePublishedRootIterator(iteratorSnap, start, end, true)
+		} else {
+			diskIter, err = db.backend.ReverseIterator(start, end)
+			ok = true
+		}
 		if err != nil {
 			for i := range sources {
 				if sources[i].Iter != nil {
@@ -29468,11 +29506,13 @@ func (db *DB) ReverseIterator(start, end []byte) (merging.Iterator, error) {
 			return nil, err
 		}
 
-		diskIter = newRangeSpanFilteringIterator(diskIter, appendNewerRangeSpansForSource(nil, queueRangeSpans, -1), db)
-		sources = append(sources, merging.IteratorSource{
-			Iter:     diskIter,
-			Priority: prio,
-		})
+		if ok && diskIter != nil {
+			diskIter = newRangeSpanFilteringIterator(diskIter, appendNewerRangeSpansForSource(nil, queueRangeSpans, -1), db)
+			sources = append(sources, merging.IteratorSource{
+				Iter:     diskIter,
+				Priority: prio,
+			})
+		}
 	}
 
 	if len(sources) == 0 {

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -7606,6 +7606,7 @@ type DB struct {
 	memtableViewTelemetry         memtableViewLifecycleTelemetry
 	retainedArenaTrimLastUnixNano atomic.Int64
 	queueRanges                   []keyRange
+	queueRangeSpans               [][]batch.DeleteRange
 	queueWALPaths                 [][]string
 	queueValueLogPaths            [][]string
 	backendRange                  keyRange
@@ -7778,6 +7779,18 @@ type DB struct {
 	deleteRangeFastPathClears                         atomic.Uint64
 	deleteRangeBackendDirectBatches                   atomic.Uint64
 	deleteRangeBackendDirectKeys                      atomic.Uint64
+	rangeSpanLayersTotal                              atomic.Uint64
+	rangeSpanInputTotal                               atomic.Uint64
+	rangeSpanEffectiveTotal                           atomic.Uint64
+	rangeSpanKeysMaterializedTotal                    atomic.Uint64
+	rangeSpanPointOverridesTotal                      atomic.Uint64
+	rangeSpanPointProbes                              atomic.Uint64
+	rangeSpanPointHits                                atomic.Uint64
+	rangeSpanIteratorProbes                           atomic.Uint64
+	rangeSpanIteratorSkips                            atomic.Uint64
+	rangeSpanRangeOnlyQueuedUnits                     atomic.Uint64
+	rangeSpanRangeOnlyFlushed                         atomic.Uint64
+	rangeSpanSpansFlushed                             atomic.Uint64
 	memtableAdaptive                                  bool
 	memtableAdaptiveObserve                           atomic.Bool
 	memtableAdaptiveBTreeMinIters                     uint64
@@ -8551,6 +8564,7 @@ type memtableView struct {
 	queue                    []memtable.Table
 	queueShardIDs            []uint16
 	queueRanges              []keyRange
+	queueRangeSpans          [][]batch.DeleteRange
 	rootVersion              uint64
 	rootPointShards          []rootDomainSnapshot
 	rootSnapshotShards       []rootDomainSnapshot
@@ -9513,6 +9527,9 @@ func (db *DB) publishMemtablesLocked() {
 		qr := make([]keyRange, len(db.queueRanges))
 		copy(qr, db.queueRanges)
 		view.queueRanges = qr
+	}
+	if len(db.queueRangeSpans) > 0 {
+		view.queueRangeSpans = cloneRangeSpanLayers(db.queueRangeSpans)
 	}
 	view.rootVersion = db.rootDomainVersion.Add(1)
 	db.publishRootDomainSnapshotsLocked(view)
@@ -22174,6 +22191,83 @@ func (db *DB) recordDeleteRangeKeys(visitedKeys, tombstoneKeys, materializedKeys
 	}
 }
 
+func (db *DB) enqueueRangeSpanLayerLocked(spans []batch.DeleteRange) error {
+	if db == nil || len(spans) == 0 {
+		return nil
+	}
+	cloned := cloneRangeSpans(spans)
+	if len(cloned) == 0 {
+		return nil
+	}
+	mt, err := db.newMutableMemtableWithCapacityMode(0, db.currentMemtableMode())
+	if err != nil {
+		return err
+	}
+	mt.Freeze()
+	queueLaneID := 0
+	db.queue = append(db.queue, mt)
+	db.queueShardIDs = append(db.queueShardIDs, 0)
+	db.queueLaneIDs = append(db.queueLaneIDs, uint16(queueLaneID))
+	db.queueIDs = append(db.queueIDs, db.nextQueueID.Add(1))
+	db.queueEnqueueNS = append(db.queueEnqueueNS, time.Now().UnixNano())
+	db.queueRanges = append(db.queueRanges, keyRange{})
+	db.queueRangeSpans = append(db.queueRangeSpans, cloned)
+	db.queueWALPaths = append(db.queueWALPaths, nil)
+	db.queueValueLogPaths = append(db.queueValueLogPaths, nil)
+	db.resyncRootDomainQueuedRunsLocked()
+	db.rangeSpanLayersTotal.Add(1)
+	db.rangeSpanInputTotal.Add(uint64(len(spans)))
+	db.rangeSpanEffectiveTotal.Add(uint64(len(cloned)))
+	db.rangeSpanRangeOnlyQueuedUnits.Add(1)
+	return nil
+}
+
+func (db *DB) publishCommandWALRangeSpanLayer(start, end []byte, appendCommand func() error) error {
+	if db == nil {
+		return nil
+	}
+	if appendCommand == nil {
+		return fmt.Errorf("cachingdb: missing command wal append callback")
+	}
+	db.flushMu.Lock()
+	defer db.flushMu.Unlock()
+	db.writeMu.Lock()
+	defer db.writeMu.Unlock()
+
+	db.mu.Lock()
+	rotate := db.mutableBytes.Load() > 0
+	if !rotate {
+		for i := range db.mutableShards {
+			mt := db.mutableShards[i].mem
+			if mt != nil && mt.Len() != 0 {
+				rotate = true
+				break
+			}
+		}
+	}
+	if rotate {
+		if err := db.rotateMutableShardsLocked(minMemtablePrealloc, false); err != nil {
+			db.mu.Unlock()
+			return err
+		}
+	}
+	if err := appendCommand(); err != nil {
+		db.mu.Unlock()
+		return err
+	}
+	spans := []batch.DeleteRange{{Start: start, End: end}}
+	if err := db.enqueueRangeSpanLayerLocked(spans); err != nil {
+		db.mu.Unlock()
+		return err
+	}
+	db.publishMemtablesLocked()
+	db.mu.Unlock()
+
+	db.noteWrite()
+	db.maybeAssistFlush()
+	return nil
+}
+
 func (db *DB) deleteRange(start, end []byte, appendCommand func() error) (err error) {
 	if db == nil {
 		return nil
@@ -22203,6 +22297,10 @@ func (db *DB) deleteRange(start, end []byte, appendCommand func() error) (err er
 			db.reportError(fmt.Errorf("cachingdb: post-command-wal delete range failed: %w", err))
 		}
 	}()
+
+	if appendCommand != nil && db.disableJournal {
+		return db.publishCommandWALRangeSpanLayer(start, end, appendCommandBeforeVisibility)
+	}
 
 	// Journal-enabled mode: do a snapshot scan and apply per-key deletes directly.
 	// Append journal records one-by-one to preserve batch atomicity and to avoid
@@ -22465,6 +22563,7 @@ func (db *DB) deleteRange(start, end []byte, appendCommand func() error) (err er
 			db.queueIDs = nil
 			db.queueEnqueueNS = nil
 			db.queueRanges = nil
+			db.queueRangeSpans = nil
 			db.queueWALPaths = nil
 			db.queueValueLogPaths = nil
 			db.queueBacklogBytes.Store(0)
@@ -22535,6 +22634,7 @@ func (db *DB) deleteRange(start, end []byte, appendCommand func() error) (err er
 			db.queueIDs = nil
 			db.queueEnqueueNS = nil
 			db.queueRanges = nil
+			db.queueRangeSpans = nil
 			db.queueWALPaths = nil
 			db.queueValueLogPaths = nil
 			db.queueBacklogBytes.Store(0)
@@ -22614,6 +22714,7 @@ func (db *DB) deleteRange(start, end []byte, appendCommand func() error) (err er
 			dstIDs := db.queueIDs[:0]
 			dstEnqueueNS := db.queueEnqueueNS[:0]
 			dstRanges := db.queueRanges[:0]
+			dstRangeSpans := db.queueRangeSpans[:0]
 			dstWALPaths := db.queueWALPaths[:0]
 			dstValueLogPaths := db.queueValueLogPaths[:0]
 			for i, mem := range db.queue {
@@ -22648,6 +22749,11 @@ func (db *DB) deleteRange(start, end []byte, appendCommand func() error) (err er
 					dstEnqueueNS = append(dstEnqueueNS, 0)
 				}
 				dstRanges = append(dstRanges, r)
+				if i < len(db.queueRangeSpans) {
+					dstRangeSpans = append(dstRangeSpans, db.queueRangeSpans[i])
+				} else {
+					dstRangeSpans = append(dstRangeSpans, nil)
+				}
 				if i < len(db.queueWALPaths) {
 					dstWALPaths = append(dstWALPaths, db.queueWALPaths[i])
 				} else {
@@ -22665,6 +22771,7 @@ func (db *DB) deleteRange(start, end []byte, appendCommand func() error) (err er
 			db.queueIDs = dstIDs
 			db.queueEnqueueNS = dstEnqueueNS
 			db.queueRanges = dstRanges
+			db.queueRangeSpans = dstRangeSpans
 			db.queueWALPaths = dstWALPaths
 			db.queueValueLogPaths = dstValueLogPaths
 			db.resyncRootDomainQueuedRunsLocked()
@@ -23071,6 +23178,7 @@ func (db *DB) rotateMemtableLockedWithCapacity(triggerFlush bool, newCapacity in
 			db.queueEnqueueNS = append(db.queueEnqueueNS, enqueueNS)
 			db.queueBacklogBytes.Add(memBytes)
 			db.queueRanges = append(db.queueRanges, shard.rng)
+			db.queueRangeSpans = append(db.queueRangeSpans, nil)
 			db.queueWALPaths = append(db.queueWALPaths, walPaths)
 			db.queueValueLogPaths = append(db.queueValueLogPaths, valueLogPaths)
 		} else {
@@ -23276,6 +23384,7 @@ func (db *DB) rotateMutableShardsLocked(newCapacity int, triggerFlush bool) erro
 			db.queueEnqueueNS = append(db.queueEnqueueNS, enqueueNS)
 			db.queueBacklogBytes.Add(memBytes)
 			db.queueRanges = append(db.queueRanges, shard.rng)
+			db.queueRangeSpans = append(db.queueRangeSpans, nil)
 			db.queueWALPaths = append(db.queueWALPaths, walPaths)
 			db.queueValueLogPaths = append(db.queueValueLogPaths, valueLogPaths)
 		} else {
@@ -23910,6 +24019,7 @@ type flushUnit struct {
 	memBytes int64
 	memLen   int
 	memRange keyRange
+	spans    []batch.DeleteRange
 	walPaths []string
 	id       uint64
 	laneID   int
@@ -23953,6 +24063,13 @@ func (db *DB) collectFlushUnitsLocked(laneID int, maxMemtables int, targetBytes 
 		if i < len(db.queueRanges) {
 			rng = db.queueRanges[i]
 		}
+		var spans []batch.DeleteRange
+		if i < len(db.queueRangeSpans) {
+			spans = db.queueRangeSpans[i]
+		}
+		if len(spans) > 0 && len(units) > 0 {
+			break
+		}
 		var id uint64
 		if i < len(db.queueIDs) {
 			id = db.queueIDs[i]
@@ -23966,6 +24083,7 @@ func (db *DB) collectFlushUnitsLocked(laneID int, maxMemtables int, targetBytes 
 			memBytes: memBytes,
 			memLen:   memLen,
 			memRange: rng,
+			spans:    spans,
 			walPaths: walPaths,
 			id:       id,
 			laneID:   unitLaneID,
@@ -23973,13 +24091,29 @@ func (db *DB) collectFlushUnitsLocked(laneID int, maxMemtables int, targetBytes 
 		ids = append(ids, id)
 		totalBytes += memBytes
 		totalLen += memLen
+		if len(spans) > 0 {
+			break
+		}
 	}
 	return units, ids, totalBytes, totalLen
 }
 
+func flushUnitSpanCount(units []flushUnit) int {
+	total := 0
+	for _, unit := range units {
+		total += len(unit.spans)
+	}
+	return total
+}
+
 func (db *DB) removeQueuedUnitsLocked(removeIDs map[uint64]struct{}, units []flushUnit, totalBytes int64) {
 	for _, unit := range units {
-		if unit.memRange.valid {
+		if len(unit.spans) > 0 {
+			// Range deletes can shrink or clear the backend key range; force a later
+			// recompute instead of widening with stale min/max hints.
+			db.backendRangeKnown = false
+			db.backendRange = keyRange{}
+		} else if unit.memRange.valid {
 			db.backendRange.add(unit.memRange.min)
 			db.backendRange.add(unit.memRange.max)
 		}
@@ -23992,6 +24126,7 @@ func (db *DB) removeQueuedUnitsLocked(removeIDs map[uint64]struct{}, units []flu
 	dstIDs := db.queueIDs[:0]
 	dstEnqueueNS := db.queueEnqueueNS[:0]
 	dstRanges := db.queueRanges[:0]
+	dstRangeSpans := db.queueRangeSpans[:0]
 	dstWALPaths := db.queueWALPaths[:0]
 	dstValueLogPaths := db.queueValueLogPaths[:0]
 
@@ -24024,6 +24159,9 @@ func (db *DB) removeQueuedUnitsLocked(removeIDs map[uint64]struct{}, units []flu
 		if i < len(db.queueRanges) {
 			dstRanges = append(dstRanges, db.queueRanges[i])
 		}
+		if i < len(db.queueRangeSpans) {
+			dstRangeSpans = append(dstRangeSpans, db.queueRangeSpans[i])
+		}
 		if i < len(db.queueWALPaths) {
 			dstWALPaths = append(dstWALPaths, db.queueWALPaths[i])
 		}
@@ -24038,6 +24176,7 @@ func (db *DB) removeQueuedUnitsLocked(removeIDs map[uint64]struct{}, units []flu
 	db.queueIDs = dstIDs
 	db.queueEnqueueNS = dstEnqueueNS
 	db.queueRanges = dstRanges
+	db.queueRangeSpans = dstRangeSpans
 	db.queueWALPaths = dstWALPaths
 	db.queueValueLogPaths = dstValueLogPaths
 	db.resyncRootDomainQueuedRunsLocked()
@@ -24081,8 +24220,67 @@ func (db *DB) flushLaneOnceWithCommandPublish(sync bool, laneID int, commandPubl
 	if len(units) == 0 {
 		return false
 	}
+	totalSpans := flushUnitSpanCount(units)
 
-	if totalLen == 0 {
+	if totalLen == 0 && totalSpans == 0 {
+		db.mu.Lock()
+		removeIDs := make(map[uint64]struct{}, len(ids))
+		for _, id := range ids {
+			removeIDs[id] = struct{}{}
+		}
+		db.removeQueuedUnitsLocked(removeIDs, units, totalBytes)
+		db.mu.Unlock()
+		return true
+	}
+	if totalLen == 0 && totalSpans > 0 {
+		backendBatch := db.newBackendBatchWithSize(totalSpans)
+		reserveBackendBatchOps(backendBatch, totalSpans)
+		pending := 0
+		for _, unit := range units {
+			for _, span := range unit.spans {
+				if err := backendBatch.DeleteRange(span.Start, span.End); err != nil {
+					db.reportError(fmt.Errorf("cachingdb: flush failed (range span): %w", err))
+					_ = backendBatch.Close()
+					return false
+				}
+				pending++
+			}
+		}
+		commandPublishAttached := false
+		if pending > 0 {
+			var attachErr error
+			commandPublishAttached, attachErr = commandPublish.attach(backendBatch)
+			if attachErr != nil {
+				db.reportError(attachErr)
+				_ = backendBatch.Close()
+				return false
+			}
+			db.backendWriteBatchesTotal.Add(1)
+			var err error
+			if sync {
+				err = backendBatch.WriteSync()
+			} else {
+				err = backendBatch.Write()
+			}
+			cerr := backendBatch.Close()
+			if err == nil {
+				err = cerr
+			}
+			if err != nil {
+				db.reportError(err)
+				return false
+			}
+			if commandPublishAttached {
+				commandPublish.consumed = true
+				db.commandWALCheckpointPublishPiggybacked.Add(1)
+			}
+		} else if err := backendBatch.Close(); err != nil {
+			db.reportError(err)
+			return false
+		}
+
+		db.rangeSpanRangeOnlyFlushed.Add(uint64(len(units)))
+		db.rangeSpanSpansFlushed.Add(uint64(pending))
 		db.mu.Lock()
 		removeIDs := make(map[uint64]struct{}, len(ids))
 		for _, id := range ids {
@@ -24093,9 +24291,10 @@ func (db *DB) flushLaneOnceWithCommandPublish(sync bool, laneID int, commandPubl
 		return true
 	}
 
-	backendEntriesCap := db.flushBackendEntriesCap(totalLen, sync)
+	backendEntriesCap := db.flushBackendEntriesCap(totalLen+totalSpans, sync)
 
-	useParallel := db.flushBuildConcurrency > 1 &&
+	useParallel := totalSpans == 0 &&
+		db.flushBuildConcurrency > 1 &&
 		totalLen >= db.flushBuildMinEntries &&
 		len(units) >= db.flushBuildMinUnits &&
 		runtime.GOMAXPROCS(0) > 1
@@ -25263,7 +25462,7 @@ func (db *DB) canBypassMemtableRead(view *memtableView, key []byte) bool {
 }
 
 func (db *DB) canBypassMemtableReadWithSnapshot(view *memtableView, key []byte, snap rootDomainSnapshot, haveSnapshot bool) bool {
-	if view == nil || db.mutableBytes.Load() != 0 {
+	if view == nil || db.mutableBytes.Load() != 0 || memtableViewHasRangeSpans(view) {
 		return false
 	}
 	if haveSnapshot {
@@ -25293,7 +25492,7 @@ func (db *DB) canBypassMemtableReadMany(view *memtableView, keys [][]byte) bool 
 	if len(keys) == 0 {
 		return true
 	}
-	if view == nil || db.mutableBytes.Load() != 0 {
+	if view == nil || db.mutableBytes.Load() != 0 || memtableViewHasRangeSpans(view) {
 		return false
 	}
 	if len(view.rootPointShards) > 0 {
@@ -25638,6 +25837,29 @@ func (db *DB) getMemtable(key []byte) ([]byte, bool, error) {
 	view := db.retainMemtableView()
 	if view != nil {
 		defer db.releaseMemtableView(view)
+		if memtableViewHasRangeSpans(view) {
+			val, ptr, flags, found := db.lookupViewEntryWithRangeSpans(view, key, true)
+			if found {
+				if flags&node.FlagTombstone != 0 {
+					return nil, true, nil
+				}
+				if flags&node.FlagPointer != 0 {
+					if val == nil {
+						readVal, err := db.readValueLog(key, ptr)
+						if err != nil {
+							return nil, true, err
+						}
+						return readVal, true, nil
+					}
+					return val, true, nil
+				}
+				if val == nil {
+					return []byte{}, true, nil
+				}
+				return val, true, nil
+			}
+			return nil, false, nil
+		}
 		snap, haveSnapshot := livePointRootDomainSnapshot(view, db, key)
 		if db.canBypassMemtableReadWithSnapshot(view, key, snap, haveSnapshot) {
 			return nil, false, nil
@@ -25693,6 +25915,29 @@ func (db *DB) getMemtableAppend(key, dst []byte) ([]byte, bool, error) {
 	view := db.retainMemtableView()
 	if view != nil {
 		defer db.releaseMemtableView(view)
+		if memtableViewHasRangeSpans(view) {
+			val, ptr, flags, found := db.lookupViewEntryWithRangeSpans(view, key, true)
+			if found {
+				if flags&node.FlagTombstone != 0 {
+					return dst, true, tree.ErrKeyNotFound
+				}
+				if flags&node.FlagPointer != 0 {
+					if val == nil {
+						out, err := db.readValueLogAppend(key, ptr, dst)
+						if err != nil {
+							return dst, true, err
+						}
+						return out, true, nil
+					}
+					return append(dst, val...), true, nil
+				}
+				if val == nil {
+					return dst, true, nil
+				}
+				return append(dst, val...), true, nil
+			}
+			return dst, false, nil
+		}
 		snap, haveSnapshot := livePointRootDomainSnapshot(view, db, key)
 		if db.canBypassMemtableReadWithSnapshot(view, key, snap, haveSnapshot) {
 			return dst, false, nil
@@ -25905,7 +26150,7 @@ func (db *DB) GetMany(keys [][]byte) ([][]byte, error) {
 	if view != nil {
 		defer db.releaseMemtableView(view)
 	}
-	if view != nil && len(view.rootPointShards) > 0 {
+	if view != nil && len(view.rootPointShards) > 0 && !memtableViewHasRangeSpans(view) {
 		return db.getManyFromPublishedRootPointShards(view, keys)
 	}
 	db.noteRootDomainGetManyFallback(len(keys))
@@ -26008,7 +26253,7 @@ func (db *DB) GetManyView(keys [][]byte, fn tree.GetManyViewFunc) error {
 	if view != nil {
 		defer db.releaseMemtableView(view)
 	}
-	if view != nil && len(view.rootPointShards) > 0 {
+	if view != nil && len(view.rootPointShards) > 0 && !memtableViewHasRangeSpans(view) {
 		return db.getManyViewFromPublishedRootPointShards(view, keys, fn)
 	}
 	db.noteRootDomainGetManyFallback(len(keys))
@@ -26079,6 +26324,13 @@ func (db *DB) Has(key []byte) (bool, error) {
 	view := db.retainMemtableView()
 	if view != nil {
 		defer db.releaseMemtableView(view)
+		if memtableViewHasRangeSpans(view) {
+			_, _, flags, found := db.lookupViewEntryWithRangeSpans(view, key, true)
+			if found {
+				return flags&node.FlagTombstone == 0, nil
+			}
+			return db.backend.Has(key)
+		}
 		snap, haveSnapshot := livePointRootDomainSnapshot(view, db, key)
 		if haveSnapshot {
 			_, _, flags, found := snap.getEntry(key)
@@ -26115,6 +26367,16 @@ func (db *DB) HasMany(keys [][]byte) ([]bool, error) {
 	view := db.retainMemtableView()
 	if view != nil {
 		defer db.releaseMemtableView(view)
+		if memtableViewHasRangeSpans(view) {
+			for i, key := range keys {
+				exists, err := db.Has(key)
+				if err != nil {
+					return nil, err
+				}
+				out[i] = exists
+			}
+			return out, nil
+		}
 	}
 	backendSnap := provider.AcquireSnapshot()
 	if backendSnap == nil {
@@ -26418,9 +26680,12 @@ func (db *DB) Stats() map[string]string {
 	db.mu.RUnlock()
 	var mutableTables []memtable.Table
 	var queueTables []memtable.Table
+	rangeSpanActiveLayers := 0
+	rangeSpanActiveSpans := 0
 	if view := db.retainMemtableViewUntracked(); view != nil {
 		mutableTables = append(mutableTables, view.mutables...)
 		queueTables = append(queueTables, view.queue...)
+		rangeSpanActiveLayers, rangeSpanActiveSpans = rangeSpanLayerCounts(view.queueRangeSpans)
 		db.releaseUntrackedMemtableView(view)
 	} else {
 		db.mu.RLock()
@@ -26431,6 +26696,7 @@ func (db *DB) Stats() map[string]string {
 			}
 		}
 		queueTables = append(queueTables, db.queue...)
+		rangeSpanActiveLayers, rangeSpanActiveSpans = rangeSpanLayerCounts(db.queueRangeSpans)
 		db.mu.RUnlock()
 	}
 	mutableResidency := summarizeMemtableResidency(mutableTables)
@@ -26603,6 +26869,20 @@ func (db *DB) Stats() map[string]string {
 	stats["treedb.cache.delete_range.fast_path_clears_total"] = fmt.Sprintf("%d", db.deleteRangeFastPathClears.Load())
 	stats["treedb.cache.delete_range.backend_direct_batches_total"] = fmt.Sprintf("%d", db.deleteRangeBackendDirectBatches.Load())
 	stats["treedb.cache.delete_range.backend_direct_keys_total"] = fmt.Sprintf("%d", db.deleteRangeBackendDirectKeys.Load())
+	stats["treedb.cache.range_span.layers_total"] = fmt.Sprintf("%d", db.rangeSpanLayersTotal.Load())
+	stats["treedb.cache.range_span.active_layers"] = fmt.Sprintf("%d", rangeSpanActiveLayers)
+	stats["treedb.cache.range_span.active_spans"] = fmt.Sprintf("%d", rangeSpanActiveSpans)
+	stats["treedb.cache.range_span.input_total"] = fmt.Sprintf("%d", db.rangeSpanInputTotal.Load())
+	stats["treedb.cache.range_span.effective_total"] = fmt.Sprintf("%d", db.rangeSpanEffectiveTotal.Load())
+	stats["treedb.cache.range_span.keys_materialized_total"] = fmt.Sprintf("%d", db.rangeSpanKeysMaterializedTotal.Load())
+	stats["treedb.cache.range_span.point_overrides_total"] = fmt.Sprintf("%d", db.rangeSpanPointOverridesTotal.Load())
+	stats["treedb.cache.range_span.point_probes_total"] = fmt.Sprintf("%d", db.rangeSpanPointProbes.Load())
+	stats["treedb.cache.range_span.point_hits_total"] = fmt.Sprintf("%d", db.rangeSpanPointHits.Load())
+	stats["treedb.cache.range_span.iterator_probes_total"] = fmt.Sprintf("%d", db.rangeSpanIteratorProbes.Load())
+	stats["treedb.cache.range_span.iterator_skips_total"] = fmt.Sprintf("%d", db.rangeSpanIteratorSkips.Load())
+	stats["treedb.cache.range_span.range_only_queued_units_total"] = fmt.Sprintf("%d", db.rangeSpanRangeOnlyQueuedUnits.Load())
+	stats["treedb.cache.range_span.range_only_flushed_total"] = fmt.Sprintf("%d", db.rangeSpanRangeOnlyFlushed.Load())
+	stats["treedb.cache.range_span.spans_flushed_total"] = fmt.Sprintf("%d", db.rangeSpanSpansFlushed.Load())
 	stats["treedb.cache.mutable_bytes"] = fmt.Sprintf("%d", db.mutableBytes.Load())
 	stats["treedb.cache.flush_threshold_bytes"] = fmt.Sprintf("%d", flushThreshold)
 	stats["treedb.cache.mutable_flush_threshold_base_bytes"] = fmt.Sprintf("%d", mutableThresholdBase)
@@ -28674,11 +28954,15 @@ func (db *DB) Iterator(start, end []byte) (merging.Iterator, error) {
 	}()
 	var queue []memtable.Table
 	var queueRanges []keyRange
+	var queueRangeSpans [][]batch.DeleteRange
 	if view != nil {
 		if snap, ok := liveIteratorRootDomainSnapshot(view); ok {
 			queue = snap.immutables
 			if len(view.rootIteratorRanges) == len(queue) {
 				queueRanges = view.rootIteratorRanges
+			}
+			if len(view.queueRangeSpans) == len(queue) {
+				queueRangeSpans = view.queueRangeSpans
 			}
 		}
 	} else {
@@ -28731,7 +29015,8 @@ func (db *DB) Iterator(start, end []byte) (merging.Iterator, error) {
 	// Note: We skip mutable shards because we just rotated them (so they're empty) or they were already empty.
 	prio := 0
 	for i := len(queue) - 1; i >= 0; i-- {
-		if i < len(queueRanges) && !overlapsQuery(start, end, queueRanges[i]) {
+		spanOverlap := i < len(queueRangeSpans) && rangeSpansOverlapQuery(queueRangeSpans[i], start, end)
+		if i < len(queueRanges) && !overlapsQuery(start, end, queueRanges[i]) && !spanOverlap {
 			prio++
 			continue
 		}
@@ -28741,6 +29026,7 @@ func (db *DB) Iterator(start, end []byte) (merging.Iterator, error) {
 				return db.readValueLog(key, ptr)
 			})
 		}
+		qIter = newRangeSpanFilteringIterator(qIter, appendNewerRangeSpansForSource(nil, queueRangeSpans, i), db)
 		sources = append(sources, merging.IteratorSource{
 			Iter:     qIter,
 			Priority: prio,
@@ -28762,6 +29048,7 @@ func (db *DB) Iterator(start, end []byte) (merging.Iterator, error) {
 			return nil, err
 		}
 
+		diskIter = newRangeSpanFilteringIterator(diskIter, appendNewerRangeSpansForSource(nil, queueRangeSpans, -1), db)
 		sources = append(sources, merging.IteratorSource{
 			Iter:     diskIter,
 			Priority: prio,
@@ -29041,11 +29328,15 @@ func (db *DB) ReverseIterator(start, end []byte) (merging.Iterator, error) {
 	}()
 	var queue []memtable.Table
 	var queueRanges []keyRange
+	var queueRangeSpans [][]batch.DeleteRange
 	if view != nil {
 		if snap, ok := liveIteratorRootDomainSnapshot(view); ok {
 			queue = snap.immutables
 			if len(view.rootIteratorRanges) == len(queue) {
 				queueRanges = view.rootIteratorRanges
+			}
+			if len(view.queueRangeSpans) == len(queue) {
+				queueRangeSpans = view.queueRangeSpans
 			}
 		}
 	} else {
@@ -29083,7 +29374,8 @@ func (db *DB) ReverseIterator(start, end []byte) (merging.Iterator, error) {
 	// Priority 0..N: Queue (Newest first)
 	prio := 0
 	for i := len(queue) - 1; i >= 0; i-- {
-		if i < len(queueRanges) && !overlapsQuery(start, end, queueRanges[i]) {
+		spanOverlap := i < len(queueRangeSpans) && rangeSpansOverlapQuery(queueRangeSpans[i], start, end)
+		if i < len(queueRanges) && !overlapsQuery(start, end, queueRanges[i]) && !spanOverlap {
 			prio++
 			continue
 		}
@@ -29093,6 +29385,7 @@ func (db *DB) ReverseIterator(start, end []byte) (merging.Iterator, error) {
 				return db.readValueLog(key, ptr)
 			})
 		}
+		qIter = newRangeSpanFilteringIterator(qIter, appendNewerRangeSpansForSource(nil, queueRangeSpans, i), db)
 		sources = append(sources, merging.IteratorSource{
 			Iter:     qIter,
 			Priority: prio,
@@ -29113,6 +29406,7 @@ func (db *DB) ReverseIterator(start, end []byte) (merging.Iterator, error) {
 			return nil, err
 		}
 
+		diskIter = newRangeSpanFilteringIterator(diskIter, appendNewerRangeSpansForSource(nil, queueRangeSpans, -1), db)
 		sources = append(sources, merging.IteratorSource{
 			Iter:     diskIter,
 			Priority: prio,
@@ -30631,6 +30925,9 @@ func (b *Batch) writeRangeBatch(sync bool) error {
 		b.Reset()
 		return nil
 	}
+	if b.commandWALAppend != nil && b.db.disableJournal && len(points) == 0 && len(ranges) > 0 {
+		return b.writeRangeSpanBatch(sync, ranges)
+	}
 
 	// Hold the writer gate across snapshot enumeration and publish. Without this,
 	// a concurrent cached write can slip between the scan and the materialized
@@ -30704,6 +31001,68 @@ func (b *Batch) writeRangeBatch(sync bool) error {
 		b.hasViewOps = origHasViewOps
 	}
 	return err
+}
+
+func (b *Batch) writeRangeSpanBatch(sync bool, ranges []batch.DeleteRange) (err error) {
+	_ = sync
+	if b == nil || b.db == nil {
+		return backenddb.ErrClosed
+	}
+	if len(ranges) == 0 {
+		b.updateBatchEntryHint()
+		b.updateBatchCopyHint()
+		b.Reset()
+		return nil
+	}
+	commandWALAppended := false
+	defer func() {
+		if err != nil && commandWALAppended {
+			b.db.reportError(fmt.Errorf("cachingdb: post-command-wal range batch failed: %w", err))
+		}
+	}()
+
+	b.db.flushMu.Lock()
+	defer b.db.flushMu.Unlock()
+	b.db.writeMu.Lock()
+	defer b.db.writeMu.Unlock()
+
+	b.db.mu.Lock()
+	rotate := b.db.mutableBytes.Load() > 0
+	if !rotate {
+		for i := range b.db.mutableShards {
+			mt := b.db.mutableShards[i].mem
+			if mt != nil && mt.Len() != 0 {
+				rotate = true
+				break
+			}
+		}
+	}
+	if rotate {
+		if err := b.db.rotateMutableShardsLocked(minMemtablePrealloc, false); err != nil {
+			b.db.mu.Unlock()
+			return err
+		}
+	}
+	if b.commandWALAppend != nil {
+		if err := b.commandWALAppend(); err != nil {
+			b.db.mu.Unlock()
+			return err
+		}
+		commandWALAppended = true
+	}
+	if err := b.db.enqueueRangeSpanLayerLocked(ranges); err != nil {
+		b.db.mu.Unlock()
+		return err
+	}
+	b.db.publishMemtablesLocked()
+	b.db.mu.Unlock()
+
+	b.db.noteWrite()
+	b.db.maybeAssistFlush()
+	b.updateBatchEntryHint()
+	b.updateBatchCopyHint()
+	b.Reset()
+	return nil
 }
 
 func (b *Batch) tryWriteWALOffStreamBypass(sync bool) (bool, error) {

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -7791,6 +7791,7 @@ type DB struct {
 	rangeSpanRangeOnlyQueuedUnits                     atomic.Uint64
 	rangeSpanRangeOnlyFlushed                         atomic.Uint64
 	rangeSpanSpansFlushed                             atomic.Uint64
+	rangeSpanFlushBatches                             atomic.Uint64
 	memtableAdaptive                                  bool
 	memtableAdaptiveObserve                           atomic.Bool
 	memtableAdaptiveBTreeMinIters                     uint64
@@ -24000,6 +24001,12 @@ const (
 	flushCombineTargetBytes    int64 = 64 * 1024 * 1024  // 64MiB
 	flushCombineTargetBytesMax       = 256 * 1024 * 1024 // 256MiB
 	flushCombineMaxMemtables         = 32
+	// Range-only command-WAL span layers are tiny, commute with each other, and
+	// otherwise force one backend sync per DeleteRange during checkpoint. Combine
+	// consecutive span-only units aggressively while still not crossing point-write
+	// units, which preserves the existing ordering boundary between points and
+	// ranges.
+	flushRangeSpanCombineMaxUnits = 1024
 	// flushBackendBatchMaxEntries caps how many operations we buffer into a single
 	// backend batch before committing it and continuing with a fresh batch.
 	//
@@ -24037,22 +24044,35 @@ func (db *DB) collectFlushUnitsLocked(laneID int, maxMemtables int, targetBytes 
 	ids := make([]uint64, 0, maxMemtables)
 	var totalBytes int64
 	var totalLen int
-	for i := 0; i < queueLen && len(units) < maxMemtables; i++ {
+	spanOnly := false
+	for i := 0; i < queueLen; i++ {
+		unitLimit := maxMemtables
+		if spanOnly {
+			unitLimit = flushRangeSpanCombineMaxUnits
+		}
+		if len(units) >= unitLimit {
+			break
+		}
 		if laneID >= 0 {
 			unitLaneID := 0
 			if i < len(db.queueLaneIDs) {
 				unitLaneID = int(db.queueLaneIDs[i])
 			}
 			if unitLaneID != laneID {
+				if spanOnly {
+					break
+				}
 				continue
 			}
-		} else if i >= maxMemtables {
+		} else if !spanOnly && i >= maxMemtables {
+			break
+		} else if spanOnly && i >= flushRangeSpanCombineMaxUnits {
 			break
 		}
 		mem := db.queue[i]
 		memBytes := mem.Size()
 		memLen := mem.Len()
-		if len(units) > 0 && targetBytes > 0 && totalBytes >= targetBytes {
+		if !spanOnly && len(units) > 0 && targetBytes > 0 && totalBytes >= targetBytes {
 			break
 		}
 		var walPaths []string
@@ -24067,7 +24087,12 @@ func (db *DB) collectFlushUnitsLocked(laneID int, maxMemtables int, targetBytes 
 		if i < len(db.queueRangeSpans) {
 			spans = db.queueRangeSpans[i]
 		}
-		if len(spans) > 0 && len(units) > 0 {
+		hasSpans := len(spans) > 0
+		if hasSpans {
+			if len(units) > 0 && !spanOnly {
+				break
+			}
+		} else if spanOnly {
 			break
 		}
 		var id uint64
@@ -24091,8 +24116,8 @@ func (db *DB) collectFlushUnitsLocked(laneID int, maxMemtables int, targetBytes 
 		ids = append(ids, id)
 		totalBytes += memBytes
 		totalLen += memLen
-		if len(spans) > 0 {
-			break
+		if hasSpans {
+			spanOnly = true
 		}
 	}
 	return units, ids, totalBytes, totalLen
@@ -24255,6 +24280,7 @@ func (db *DB) flushLaneOnceWithCommandPublish(sync bool, laneID int, commandPubl
 				_ = backendBatch.Close()
 				return false
 			}
+			db.rangeSpanFlushBatches.Add(1)
 			db.backendWriteBatchesTotal.Add(1)
 			var err error
 			if sync {
@@ -26883,6 +26909,7 @@ func (db *DB) Stats() map[string]string {
 	stats["treedb.cache.range_span.range_only_queued_units_total"] = fmt.Sprintf("%d", db.rangeSpanRangeOnlyQueuedUnits.Load())
 	stats["treedb.cache.range_span.range_only_flushed_total"] = fmt.Sprintf("%d", db.rangeSpanRangeOnlyFlushed.Load())
 	stats["treedb.cache.range_span.spans_flushed_total"] = fmt.Sprintf("%d", db.rangeSpanSpansFlushed.Load())
+	stats["treedb.cache.range_span.flush_batches_total"] = fmt.Sprintf("%d", db.rangeSpanFlushBatches.Load())
 	stats["treedb.cache.mutable_bytes"] = fmt.Sprintf("%d", db.mutableBytes.Load())
 	stats["treedb.cache.flush_threshold_bytes"] = fmt.Sprintf("%d", flushThreshold)
 	stats["treedb.cache.mutable_flush_threshold_base_bytes"] = fmt.Sprintf("%d", mutableThresholdBase)

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -22544,6 +22544,9 @@ func (db *DB) deleteRange(start, end []byte, appendCommand func() error) (err er
 			// end is exclusive; to cover maxKey it must be strictly greater.
 			coversAll = false
 		}
+		if coversAll && !queryCoversRangeSpanLayers(start, end, db.queueRangeSpans) {
+			coversAll = false
+		}
 
 		// Fast path: if the backend is empty and the delete range covers all keys we
 		// currently have buffered in memory, just drop the in-memory state. This
@@ -22608,8 +22611,17 @@ func (db *DB) deleteRange(start, end []byte, appendCommand func() error) (err er
 		}
 		mutableRange := db.snapshotMutableRange()
 		coversInMemory := queryCoversRange(start, end, mutableRange)
-		for _, r := range db.queueRanges {
-			if !queryCoversRange(start, end, r) {
+		for i, mem := range db.queue {
+			r := keyRange{}
+			rangeKnown := i < len(db.queueRanges)
+			if rangeKnown {
+				r = db.queueRanges[i]
+			}
+			var spans []batch.DeleteRange
+			if i < len(db.queueRangeSpans) {
+				spans = db.queueRangeSpans[i]
+			}
+			if (!rangeKnown && mem != nil && mem.Len() != 0) || !queryCoversRange(start, end, r) || !queryCoversRangeSpans(start, end, spans) {
 				coversInMemory = false
 				break
 			}
@@ -22720,10 +22732,15 @@ func (db *DB) deleteRange(start, end []byte, appendCommand func() error) (err er
 			dstValueLogPaths := db.queueValueLogPaths[:0]
 			for i, mem := range db.queue {
 				r := keyRange{}
-				if i < len(db.queueRanges) {
+				rangeKnown := i < len(db.queueRanges)
+				if rangeKnown {
 					r = db.queueRanges[i]
 				}
-				if queryCoversRange(start, end, r) {
+				var spans []batch.DeleteRange
+				if i < len(db.queueRangeSpans) {
+					spans = db.queueRangeSpans[i]
+				}
+				if (rangeKnown || mem == nil || mem.Len() == 0) && queryCoversRange(start, end, r) && queryCoversRangeSpans(start, end, spans) {
 					db.queueRetiredMemtableLocked(mem)
 					db.queueBacklogBytes.Add(-mem.Size())
 					continue
@@ -22750,11 +22767,7 @@ func (db *DB) deleteRange(start, end []byte, appendCommand func() error) (err er
 					dstEnqueueNS = append(dstEnqueueNS, 0)
 				}
 				dstRanges = append(dstRanges, r)
-				if i < len(db.queueRangeSpans) {
-					dstRangeSpans = append(dstRangeSpans, db.queueRangeSpans[i])
-				} else {
-					dstRangeSpans = append(dstRangeSpans, nil)
-				}
+				dstRangeSpans = append(dstRangeSpans, spans)
 				if i < len(db.queueWALPaths) {
 					dstWALPaths = append(dstWALPaths, db.queueWALPaths[i])
 				} else {

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -23911,61 +23911,74 @@ func (db *DB) flushAllLocked(reqSync bool, commandPublish *checkpointCommandWALP
 		lanes = 1
 	}
 
-	// Only spawn flush workers for lanes that actually have queued memtables.
-	// Otherwise each lane does an O(queueLen) scan in collectFlushUnitsLocked to
-	// discover there's nothing to do, which can be extremely expensive when the
-	// queue is large and lanes > 1.
-	active := make([]bool, lanes)
-	db.mu.RLock()
-	queueLen := len(db.queue)
-	for i := 0; i < queueLen; i++ {
-		laneID := 0
-		if i < len(db.queueLaneIDs) {
-			laneID = int(db.queueLaneIDs[i])
+	for {
+		// Only spawn flush workers for lanes that actually have queued memtables.
+		// Otherwise each lane does an O(queueLen) scan in collectFlushUnitsLocked to
+		// discover there's nothing to do, which can be extremely expensive when the
+		// queue is large and lanes > 1.
+		active := make([]bool, lanes)
+		db.mu.RLock()
+		queueLen := len(db.queue)
+		for i := 0; i < queueLen; i++ {
+			laneID := 0
+			if i < len(db.queueLaneIDs) {
+				laneID = int(db.queueLaneIDs[i])
+			}
+			if laneID < 0 || laneID >= lanes {
+				laneID = 0
+			}
+			active[laneID] = true
 		}
-		if laneID < 0 || laneID >= lanes {
-			laneID = 0
-		}
-		active[laneID] = true
-	}
-	db.mu.RUnlock()
+		db.mu.RUnlock()
 
-	activeCount := 0
-	for i := range active {
-		if active[i] {
-			activeCount++
-		}
-	}
-	if activeCount == 0 {
-		return
-	}
-	if activeCount != 1 {
-		commandPublish = nil
-	}
-	var wg sync.WaitGroup
-	wg.Add(activeCount)
-	for i := 0; i < lanes; i++ {
-		laneID := i
-		if !active[laneID] {
-			continue
-		}
-		go func() {
-			if laneID < len(db.flushLaneMu) {
-				db.flushLaneMu[laneID].Lock()
-				defer db.flushLaneMu[laneID].Unlock()
+		activeCount := 0
+		for i := range active {
+			if active[i] {
+				activeCount++
 			}
-			for db.flushLaneOnceWithCommandPublish(syncFlag, laneID, commandPublish) {
+		}
+		if activeCount == 0 {
+			return
+		}
+		passCommandPublish := commandPublish
+		if activeCount != 1 {
+			// Preserve the previous behavior: command-WAL checkpoint publication is
+			// only piggybacked when a single lane owns the whole flush pass.
+			commandPublish = nil
+			passCommandPublish = nil
+		}
+		var wg sync.WaitGroup
+		var progress atomic.Bool
+		wg.Add(activeCount)
+		for i := 0; i < lanes; i++ {
+			laneID := i
+			if !active[laneID] {
+				continue
 			}
-			wg.Done()
-		}()
-	}
-	wg.Wait()
-	if !db.checkpointing.Load() {
+			go func() {
+				if laneID < len(db.flushLaneMu) {
+					db.flushLaneMu[laneID].Lock()
+					defer db.flushLaneMu[laneID].Unlock()
+				}
+				for db.flushLaneOnceWithCommandPublish(syncFlag, laneID, passCommandPublish) {
+					progress.Store(true)
+				}
+				wg.Done()
+			}()
+		}
+		wg.Wait()
+
 		db.mu.RLock()
 		queueEmpty := len(db.queue) == 0
 		db.mu.RUnlock()
 		if queueEmpty {
-			db.trimRetainedArenasAfterFlush(false)
+			if !db.checkpointing.Load() {
+				db.trimRetainedArenasAfterFlush(false)
+			}
+			return
+		}
+		if !progress.Load() {
+			return
 		}
 	}
 }
@@ -24053,13 +24066,33 @@ func (db *DB) collectFlushUnitsLocked(laneID int, maxMemtables int, targetBytes 
 		if len(units) >= unitLimit {
 			break
 		}
-		if laneID >= 0 {
-			unitLaneID := 0
-			if i < len(db.queueLaneIDs) {
-				unitLaneID = int(db.queueLaneIDs[i])
+		var spans []batch.DeleteRange
+		if i < len(db.queueRangeSpans) {
+			spans = db.queueRangeSpans[i]
+		}
+		hasSpans := len(spans) > 0
+		if hasSpans {
+			// Range-span units are global ordering barriers: older point units from
+			// any lane must be flushed before the span, and newer point units from
+			// any lane must not pass it. Therefore a span can only be collected when
+			// it is at the global queue head (or immediately after another collected
+			// span-only barrier unit).
+			if !spanOnly && i != 0 {
+				break
 			}
+			if len(units) > 0 && !spanOnly {
+				break
+			}
+		} else if spanOnly {
+			break
+		}
+		unitLaneID := 0
+		if i < len(db.queueLaneIDs) {
+			unitLaneID = int(db.queueLaneIDs[i])
+		}
+		if laneID >= 0 {
 			if unitLaneID != laneID {
-				if spanOnly {
+				if hasSpans || spanOnly {
 					break
 				}
 				continue
@@ -24083,25 +24116,9 @@ func (db *DB) collectFlushUnitsLocked(laneID int, maxMemtables int, targetBytes 
 		if i < len(db.queueRanges) {
 			rng = db.queueRanges[i]
 		}
-		var spans []batch.DeleteRange
-		if i < len(db.queueRangeSpans) {
-			spans = db.queueRangeSpans[i]
-		}
-		hasSpans := len(spans) > 0
-		if hasSpans {
-			if len(units) > 0 && !spanOnly {
-				break
-			}
-		} else if spanOnly {
-			break
-		}
 		var id uint64
 		if i < len(db.queueIDs) {
 			id = db.queueIDs[i]
-		}
-		unitLaneID := 0
-		if i < len(db.queueLaneIDs) {
-			unitLaneID = int(db.queueLaneIDs[i])
 		}
 		units = append(units, flushUnit{
 			mem:      mem,

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -28950,7 +28950,9 @@ func (db *DB) Iterator(start, end []byte) (merging.Iterator, error) {
 	backendRange := db.backendRange
 	view = db.retainMemtableView()
 	queueLenLocked := 0
+	var iteratorSnap rootDomainSnapshot
 	if snap, ok := liveIteratorRootDomainSnapshot(view); ok {
+		iteratorSnap = snap
 		queueLenLocked = len(snap.immutables)
 	} else if view == nil {
 		queueLenLocked = len(db.queue)
@@ -29001,6 +29003,7 @@ func (db *DB) Iterator(start, end []byte) (merging.Iterator, error) {
 	var queueRangeSpans [][]batch.DeleteRange
 	if view != nil {
 		if snap, ok := liveIteratorRootDomainSnapshot(view); ok {
+			iteratorSnap = snap
 			queue = snap.immutables
 			if len(view.rootIteratorRanges) == len(queue) {
 				queueRanges = view.rootIteratorRanges
@@ -29011,6 +29014,7 @@ func (db *DB) Iterator(start, end []byte) (merging.Iterator, error) {
 		}
 	} else {
 		rawSnap, rawRanges := db.rawIteratorRootDomainSnapshot()
+		iteratorSnap = rawSnap
 		queue = rawSnap.immutables
 		queueRanges = rawRanges
 	}
@@ -29079,10 +29083,23 @@ func (db *DB) Iterator(start, end []byte) (merging.Iterator, error) {
 		prio++
 	}
 
-	// Disk Iterator
-	// Only skip if we definitively know the range and it doesn't overlap.
-	if !backendRangeKnown || overlapsQuery(start, end, backendRange) {
-		diskIter, err := db.backend.Iterator(start, end)
+	// Disk/published-root iterator. If the view pins an iterator root, iterate
+	// from that published root instead of crossing to the backend default root.
+	// Only skip default-backend probes when we definitively know the range and it
+	// doesn't overlap; a pinned published root is already range-scoped by the root.
+	usePublishedRoot := rootDomainSnapshotHasPublishedState(iteratorSnap)
+	if usePublishedRoot || !backendRangeKnown || overlapsQuery(start, end, backendRange) {
+		var (
+			diskIter iterator.UnsafeIterator
+			err      error
+			ok       bool
+		)
+		if usePublishedRoot {
+			diskIter, ok, err = rootDomainPublishedIterator(iteratorSnap, start, end)
+		} else {
+			diskIter, err = db.backend.Iterator(start, end)
+			ok = true
+		}
 		if err != nil {
 			for i := range sources {
 				if sources[i].Iter != nil {
@@ -29091,12 +29108,13 @@ func (db *DB) Iterator(start, end []byte) (merging.Iterator, error) {
 			}
 			return nil, err
 		}
-
-		diskIter = newRangeSpanFilteringIterator(diskIter, appendNewerRangeSpansForSource(nil, queueRangeSpans, -1), db)
-		sources = append(sources, merging.IteratorSource{
-			Iter:     diskIter,
-			Priority: prio,
-		})
+		if ok && diskIter != nil {
+			diskIter = newRangeSpanFilteringIterator(diskIter, appendNewerRangeSpansForSource(nil, queueRangeSpans, -1), db)
+			sources = append(sources, merging.IteratorSource{
+				Iter:     diskIter,
+				Priority: prio,
+			})
+		}
 	}
 
 	if len(sources) == 0 {

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -30860,8 +30860,14 @@ func (b *Batch) maybeSwitchToStreaming() {
 	}
 
 	// Only attempt streaming if the batch is strictly increasing and starts beyond
-	// the maximum key present in the in-memory layers.
+	// the maximum key present in the in-memory layers. Active range spans are
+	// barriers for later point writes, so direct-to-backend streaming must stay off
+	// while any span-only queued unit is visible.
 	b.db.mu.RLock()
+	if rangeSpanLayerHasSpans(b.db.queueRangeSpans) {
+		b.db.mu.RUnlock()
+		return
+	}
 	queueRanges := append([]keyRange(nil), b.db.queueRanges...)
 	b.db.mu.RUnlock()
 
@@ -31186,11 +31192,17 @@ func (b *Batch) tryWriteWALOffStreamBypass(sync bool) (bool, error) {
 	}
 
 	// Only attempt streaming if the batch is strictly increasing and starts beyond
-	// the maximum key present in the in-memory layers.
+	// the maximum key present in the in-memory layers. Active range spans are
+	// barriers for later point writes, so direct-to-backend streaming must stay off
+	// while any span-only queued unit is visible.
 	b.db.mu.RLock()
+	hasRangeSpans := rangeSpanLayerHasSpans(b.db.queueRangeSpans)
 	queueRanges := append([]keyRange(nil), b.db.queueRanges...)
 	queueLen := len(b.db.queue)
 	b.db.mu.RUnlock()
+	if hasRangeSpans {
+		return false, nil
+	}
 	if queueLen > 0 && len(queueRanges) == 0 {
 		// Cannot reason about overlap without queue range tracking.
 		return false, nil
@@ -32304,10 +32316,15 @@ func (b *Batch) writeBypass(sync bool) (err error) {
 	)
 	view := b.db.retainMemtableView()
 	if view != nil {
+		if memtableViewHasRangeSpans(view) {
+			b.db.releaseMemtableView(view)
+			return b.writeRegular(sync)
+		}
 		defer b.db.releaseMemtableView(view)
 	}
 
 	b.db.mu.RLock()
+	hasRangeSpans := view == nil && rangeSpanLayerHasSpans(b.db.queueRangeSpans)
 	overlaps = rangesOverlap(batchRange, mutableRange)
 	if view != nil {
 		mutables = view.mutables
@@ -32334,6 +32351,9 @@ func (b *Batch) writeBypass(sync bool) (err error) {
 		}
 	}
 	b.db.mu.RUnlock()
+	if hasRangeSpans {
+		return b.writeRegular(sync)
+	}
 
 	if !overlaps {
 		if len(queueRanges) == 0 && len(queue) > 0 {

--- a/TreeDB/caching/delete_range_test.go
+++ b/TreeDB/caching/delete_range_test.go
@@ -449,6 +449,45 @@ func TestCachingDB_CommandWALRangeSpanIteratorPreservesPublishedRoot(t *testing.
 	}
 }
 
+func TestCachingDB_CommandWALRangeSpanSurvivesDisjointOrdinaryDeleteRange(t *testing.T) {
+	backend := NewMockBackend()
+	backend.Set([]byte("b"), []byte("old"))
+	db, err := Open(t.TempDir(), backend, Options{
+		DisableWAL:     true,
+		AllowUnsafe:    true,
+		FlushThreshold: 1 << 20,
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	if err := db.DeleteRangeAfterCommandWALAppend([]byte("a"), []byte("c"), func() error { return nil }); err != nil {
+		t.Fatalf("DeleteRangeAfterCommandWALAppend: %v", err)
+	}
+	if val, err := db.Get([]byte("b")); err != nil || val != nil {
+		t.Fatalf("b after active span=(%q,%v), want missing", val, err)
+	}
+
+	if err := db.DeleteRange([]byte("x"), []byte("z")); err != nil {
+		t.Fatalf("ordinary DeleteRange: %v", err)
+	}
+	if val, err := db.Get([]byte("b")); err != nil || val != nil {
+		t.Fatalf("b after disjoint ordinary DeleteRange=(%q,%v), want missing", val, err)
+	}
+	stats := db.Stats()
+	if got := deleteRangeStatUint64(t, stats, "treedb.cache.range_span.active_spans"); got != 1 {
+		t.Fatalf("active range spans after ordinary DeleteRange=%d want 1", got)
+	}
+
+	if err := db.Checkpoint(); err != nil {
+		t.Fatalf("Checkpoint: %v", err)
+	}
+	if val, err := db.Get([]byte("b")); err != nil || val != nil {
+		t.Fatalf("b after checkpoint=(%q,%v), want missing", val, err)
+	}
+}
+
 func TestCachingDB_CommandWALRangeSpanBlocksLaterWriteSyncBypass(t *testing.T) {
 	db, err := Open(t.TempDir(), NewMockBackend(), Options{
 		DisableWAL:     true,

--- a/TreeDB/caching/delete_range_test.go
+++ b/TreeDB/caching/delete_range_test.go
@@ -260,6 +260,110 @@ func TestCachingBatch_CommandWALRangeOnlyUsesSpanLayer(t *testing.T) {
 	}
 }
 
+func rangeSpanTestKeyForLane(t *testing.T, db *DB, wantLane int) []byte {
+	t.Helper()
+	for i := byte(1); i < 250; i++ {
+		key := []byte{i}
+		if gotLane := db.laneForShardIndex(db.shardIndex(key)); gotLane == wantLane {
+			return key
+		}
+	}
+	t.Fatalf("no test key found for lane %d", wantLane)
+	return nil
+}
+
+func rangeSpanTestEnd(key []byte) []byte {
+	if len(key) == 0 || key[0] == 0xff {
+		return nil
+	}
+	return []byte{key[0] + 1}
+}
+
+func TestCachingDB_CommandWALRangeSpanFlushCollectionRespectsLaneBarriers(t *testing.T) {
+	newDB := func(t *testing.T) *DB {
+		t.Helper()
+		db, err := Open(t.TempDir(), NewMockBackend(), Options{
+			DisableWAL:     true,
+			AllowUnsafe:    true,
+			JournalLanes:   2,
+			MemtableShards: 2,
+			FlushThreshold: 1 << 20,
+		})
+		if err != nil {
+			t.Fatalf("Open: %v", err)
+		}
+		return db
+	}
+
+	t.Run("span waits for older point from another lane", func(t *testing.T) {
+		db := newDB(t)
+		defer func() { _ = db.Close() }()
+		key := rangeSpanTestKeyForLane(t, db, 1)
+		if err := db.Set(key, []byte("old")); err != nil {
+			t.Fatalf("Set: %v", err)
+		}
+		if err := db.DeleteRangeAfterCommandWALAppend(key, rangeSpanTestEnd(key), func() error { return nil }); err != nil {
+			t.Fatalf("DeleteRangeAfterCommandWALAppend: %v", err)
+		}
+
+		db.mu.Lock()
+		if len(db.queue) < 2 {
+			db.mu.Unlock()
+			t.Fatalf("queue len=%d want point+span", len(db.queue))
+		}
+		spanUnits, _, _, _ := db.collectFlushUnitsLocked(0, flushCombineMaxMemtables, flushCombineTargetBytes)
+		if len(spanUnits) != 0 {
+			db.mu.Unlock()
+			t.Fatalf("lane 0 collected %d units before older lane-1 point flushed; want barrier", len(spanUnits))
+		}
+		pointUnits, _, _, _ := db.collectFlushUnitsLocked(1, flushCombineMaxMemtables, flushCombineTargetBytes)
+		if len(pointUnits) == 0 || len(pointUnits[0].spans) != 0 {
+			db.mu.Unlock()
+			t.Fatalf("lane 1 units=%+v, want older point unit before span", pointUnits)
+		}
+		db.mu.Unlock()
+
+		if err := db.Checkpoint(); err != nil {
+			t.Fatalf("Checkpoint: %v", err)
+		}
+		if got := deleteRangeStatUint64(t, db.Stats(), "treedb.cache.range_span.active_layers"); got != 0 {
+			t.Fatalf("active range layers after checkpoint=%d want 0", got)
+		}
+		if val, err := db.Get(key); err != nil || val != nil {
+			t.Fatalf("Get after checkpoint=(%q,%v), want missing", val, err)
+		}
+	})
+
+	t.Run("newer point waits behind older span from another lane", func(t *testing.T) {
+		db := newDB(t)
+		defer func() { _ = db.Close() }()
+		key := rangeSpanTestKeyForLane(t, db, 1)
+		if err := db.DeleteRangeAfterCommandWALAppend(key, rangeSpanTestEnd(key), func() error { return nil }); err != nil {
+			t.Fatalf("DeleteRangeAfterCommandWALAppend: %v", err)
+		}
+		if err := db.Set(key, []byte("new")); err != nil {
+			t.Fatalf("Set: %v", err)
+		}
+		db.mu.Lock()
+		if err := db.rotateMutableShardsLocked(minMemtablePrealloc, false); err != nil {
+			db.mu.Unlock()
+			t.Fatalf("rotateMutableShardsLocked: %v", err)
+		}
+		defer db.mu.Unlock()
+		if len(db.queue) < 2 {
+			t.Fatalf("queue len=%d want span+point", len(db.queue))
+		}
+		pointUnits, _, _, _ := db.collectFlushUnitsLocked(1, flushCombineMaxMemtables, flushCombineTargetBytes)
+		if len(pointUnits) != 0 {
+			t.Fatalf("lane 1 collected %d point units before older span flushed; want barrier", len(pointUnits))
+		}
+		spanUnits, _, _, _ := db.collectFlushUnitsLocked(0, flushCombineMaxMemtables, flushCombineTargetBytes)
+		if len(spanUnits) == 0 || len(spanUnits[0].spans) == 0 {
+			t.Fatalf("lane 0 units=%+v, want span barrier at queue head", spanUnits)
+		}
+	})
+}
+
 func TestCachingDB_CommandWALRangeSpanCheckpointCombinesFlushUnits(t *testing.T) {
 	db, err := Open(t.TempDir(), NewMockBackend(), Options{
 		DisableWAL:     true,

--- a/TreeDB/caching/delete_range_test.go
+++ b/TreeDB/caching/delete_range_test.go
@@ -260,6 +260,51 @@ func TestCachingBatch_CommandWALRangeOnlyUsesSpanLayer(t *testing.T) {
 	}
 }
 
+func TestCachingDB_CommandWALRangeSpanCheckpointCombinesFlushUnits(t *testing.T) {
+	db, err := Open(t.TempDir(), NewMockBackend(), Options{
+		DisableWAL:     true,
+		AllowUnsafe:    true,
+		FlushThreshold: 1 << 20,
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	const ranges = 40
+	for i := 0; i < ranges; i++ {
+		start := []byte{byte(i + 1)}
+		end := []byte{byte(i + 2)}
+		if err := db.DeleteRangeAfterCommandWALAppend(start, end, func() error { return nil }); err != nil {
+			t.Fatalf("DeleteRangeAfterCommandWALAppend(%d): %v", i, err)
+		}
+	}
+	before := db.Stats()
+	if got := deleteRangeStatUint64(t, before, "treedb.cache.range_span.active_layers"); got != ranges {
+		t.Fatalf("active_layers before checkpoint=%d want %d", got, ranges)
+	}
+	beforeBatches := deleteRangeStatUint64(t, before, "treedb.cache.stats.backend_write_batches_total")
+	if err := db.Checkpoint(); err != nil {
+		t.Fatalf("Checkpoint: %v", err)
+	}
+	after := db.Stats()
+	if got := deleteRangeStatUint64(t, after, "treedb.cache.range_span.active_layers"); got != 0 {
+		t.Fatalf("active_layers after checkpoint=%d want 0", got)
+	}
+	if got := deleteRangeStatUint64(t, after, "treedb.cache.range_span.spans_flushed_total"); got != ranges {
+		t.Fatalf("spans_flushed_total=%d want %d", got, ranges)
+	}
+	if got := deleteRangeStatUint64(t, after, "treedb.cache.range_span.range_only_flushed_total"); got != ranges {
+		t.Fatalf("range_only_flushed_total=%d want %d", got, ranges)
+	}
+	if got := deleteRangeStatUint64(t, after, "treedb.cache.range_span.flush_batches_total"); got != 1 {
+		t.Fatalf("range_span flush_batches_total=%d want 1", got)
+	}
+	if got := deleteRangeStatUint64(t, after, "treedb.cache.stats.backend_write_batches_total") - beforeBatches; got != 1 {
+		t.Fatalf("backend write batches for range spans=%d want 1", got)
+	}
+}
+
 func TestCachingDB_CommandWALRangeSpanBounds(t *testing.T) {
 	db, err := Open(t.TempDir(), NewMockBackend(), Options{
 		DisableWAL:     true,

--- a/TreeDB/caching/delete_range_test.go
+++ b/TreeDB/caching/delete_range_test.go
@@ -337,6 +337,79 @@ func TestCachingDB_CommandWALRangeSpanPreservesPublishedRootMiss(t *testing.T) {
 	}
 }
 
+func TestCachingDB_CommandWALRangeSpanIteratorPreservesPublishedRoot(t *testing.T) {
+	backend, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("backend Open: %v", err)
+	}
+	defer func() { _ = backend.Close() }()
+	if err := backend.SetSync([]byte("root-a-only"), []byte("root-a")); err != nil {
+		t.Fatalf("seed root A: %v", err)
+	}
+	rootA := uint64(0)
+	if state := backend.State(); state != nil {
+		rootA = state.RootPageID
+	}
+	if rootA == 0 {
+		t.Fatalf("root A id is zero")
+	}
+	if err := backend.SetSync([]byte("m"), []byte("default-m")); err != nil {
+		t.Fatalf("seed default root: %v", err)
+	}
+
+	db, err := Open(t.TempDir(), backend, Options{
+		DisableWAL:     true,
+		AllowUnsafe:    true,
+		FlushThreshold: 1 << 20,
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	db.mu.Lock()
+	if ok := db.installPublishedRootSetLocked(&publishedRootSet{
+		generation: 1,
+		iterator: publishedRootRef{
+			rootID: rootA,
+		},
+	}); !ok {
+		db.mu.Unlock()
+		t.Fatalf("installPublishedRootSetLocked returned false")
+	}
+	db.mu.Unlock()
+	if err := db.DeleteRangeAfterCommandWALAppend([]byte("x"), []byte("z"), func() error { return nil }); err != nil {
+		t.Fatalf("DeleteRangeAfterCommandWALAppend: %v", err)
+	}
+
+	liveIt, err := db.Iterator([]byte("m"), []byte("n"))
+	if err != nil {
+		t.Fatalf("live Iterator: %v", err)
+	}
+	if got := collectIteratorKeysForDeleteRangeTest(t, liveIt); len(got) != 0 {
+		t.Fatalf("live root-bound iterator keys=%v want empty", got)
+	}
+	if got, err := db.HasPrefixes([][]byte{[]byte("m")}); err != nil || len(got) != 1 || got[0] {
+		t.Fatalf("live HasPrefixes(m)=(%v,%v), want [false],nil", got, err)
+	}
+
+	snap := db.AcquireSnapshot()
+	if snap == nil {
+		t.Fatalf("AcquireSnapshot returned nil")
+	}
+	defer func() { _ = snap.Close() }()
+	snapIt, err := snap.Iterator([]byte("m"), []byte("n"))
+	if err != nil {
+		t.Fatalf("snapshot Iterator: %v", err)
+	}
+	if got := collectIteratorKeysForDeleteRangeTest(t, snapIt); len(got) != 0 {
+		t.Fatalf("snapshot root-bound iterator keys=%v want empty", got)
+	}
+	if got, err := snap.HasPrefixes([][]byte{[]byte("m")}); err != nil || len(got) != 1 || got[0] {
+		t.Fatalf("snapshot HasPrefixes(m)=(%v,%v), want [false],nil", got, err)
+	}
+}
+
 func TestCachingBatch_CommandWALRangeOnlyUsesSpanLayer(t *testing.T) {
 	db, err := Open(t.TempDir(), NewMockBackend(), Options{
 		DisableWAL:     true,

--- a/TreeDB/caching/delete_range_test.go
+++ b/TreeDB/caching/delete_range_test.go
@@ -173,6 +173,12 @@ func TestCachingDB_CommandWALRangeSpanVisibilitySnapshotsAndCheckpoint(t *testin
 	if val, err := snapAfter.Get([]byte("b")); err != nil || string(val) != "new" {
 		t.Fatalf("snapshot after range b=(%q,%v), want new,nil", val, err)
 	}
+	if out, err := snapAfter.GetAppend([]byte("b"), nil); err != nil || string(out) != "new" {
+		t.Fatalf("snapshot after range GetAppend(b)=(%q,%v), want new,nil", out, err)
+	}
+	if _, err := snapAfter.GetAppend([]byte("a"), nil); !errors.Is(err, tree.ErrKeyNotFound) {
+		t.Fatalf("snapshot after range GetAppend(a) err=%v, want ErrKeyNotFound", err)
+	}
 
 	stats := db.Stats()
 	if got := deleteRangeStatUint64(t, stats, "treedb.cache.delete_range.materialized_keys_total"); got != 0 {
@@ -324,6 +330,25 @@ func TestCachingDB_CommandWALRangeSpanPreservesPublishedRootMiss(t *testing.T) {
 		t.Fatalf("DeleteRangeAfterCommandWALAppend: %v", err)
 	}
 
+	if val, err := db.Get([]byte("root-a-only")); err != nil || string(val) != "root-a" {
+		t.Fatalf("live root-id active span Get(root-a-only)=(%q,%v), want root-a,nil", val, err)
+	}
+	if out, err := db.GetAppend([]byte("root-a-only"), []byte("prefix:")); err != nil || string(out) != "prefix:root-a" {
+		t.Fatalf("live root-id active span GetAppend(root-a-only)=(%q,%v), want prefix:root-a,nil", out, err)
+	}
+	if ok, err := db.Has([]byte("root-a-only")); err != nil || !ok {
+		t.Fatalf("live root-id active span Has(root-a-only)=(%t,%v), want true,nil", ok, err)
+	}
+	if val, err := db.Get([]byte("m")); err != nil || val != nil {
+		t.Fatalf("live root-bound miss Get(m)=(%q,%v), want missing", val, err)
+	}
+	if out, err := db.GetAppend([]byte("m"), []byte("prefix:")); !errors.Is(err, tree.ErrKeyNotFound) || string(out) != "prefix:" {
+		t.Fatalf("live root-bound miss GetAppend(m)=(%q,%v), want prefix:,ErrKeyNotFound", out, err)
+	}
+	if ok, err := db.Has([]byte("m")); err != nil || ok {
+		t.Fatalf("live root-bound miss Has(m)=(%t,%v), want false,nil", ok, err)
+	}
+
 	snap := db.AcquireSnapshot()
 	if snap == nil {
 		t.Fatalf("AcquireSnapshot returned nil")
@@ -389,6 +414,13 @@ func TestCachingDB_CommandWALRangeSpanIteratorPreservesPublishedRoot(t *testing.
 	if got := collectIteratorKeysForDeleteRangeTest(t, liveIt); len(got) != 0 {
 		t.Fatalf("live root-bound iterator keys=%v want empty", got)
 	}
+	liveRIt, err := db.ReverseIterator([]byte("m"), []byte("n"))
+	if err != nil {
+		t.Fatalf("live ReverseIterator: %v", err)
+	}
+	if got := collectIteratorKeysForDeleteRangeTest(t, liveRIt); len(got) != 0 {
+		t.Fatalf("live root-bound reverse iterator keys=%v want empty", got)
+	}
 	if got, err := db.HasPrefixes([][]byte{[]byte("m")}); err != nil || len(got) != 1 || got[0] {
 		t.Fatalf("live HasPrefixes(m)=(%v,%v), want [false],nil", got, err)
 	}
@@ -404,6 +436,13 @@ func TestCachingDB_CommandWALRangeSpanIteratorPreservesPublishedRoot(t *testing.
 	}
 	if got := collectIteratorKeysForDeleteRangeTest(t, snapIt); len(got) != 0 {
 		t.Fatalf("snapshot root-bound iterator keys=%v want empty", got)
+	}
+	snapRIt, err := snap.ReverseIterator([]byte("m"), []byte("n"))
+	if err != nil {
+		t.Fatalf("snapshot ReverseIterator: %v", err)
+	}
+	if got := collectIteratorKeysForDeleteRangeTest(t, snapRIt); len(got) != 0 {
+		t.Fatalf("snapshot root-bound reverse iterator keys=%v want empty", got)
 	}
 	if got, err := snap.HasPrefixes([][]byte{[]byte("m")}); err != nil || len(got) != 1 || got[0] {
 		t.Fatalf("snapshot HasPrefixes(m)=(%v,%v), want [false],nil", got, err)

--- a/TreeDB/caching/delete_range_test.go
+++ b/TreeDB/caching/delete_range_test.go
@@ -6,8 +6,10 @@ import (
 	"time"
 
 	"github.com/snissn/gomap/TreeDB/batch"
+	backenddb "github.com/snissn/gomap/TreeDB/db"
 	"github.com/snissn/gomap/TreeDB/internal/commitlog"
 	"github.com/snissn/gomap/TreeDB/internal/memtable"
+	"github.com/snissn/gomap/TreeDB/tree"
 )
 
 type countingLogWriter struct {
@@ -49,6 +51,279 @@ type errMemtable struct {
 
 func (m *errMemtable) DeleteWithCallback(_ []byte, _ func(k, v []byte) error) error {
 	return m.deleteErr
+}
+
+func collectIteratorKeysForDeleteRangeTest(t *testing.T, it interface {
+	Valid() bool
+	Next()
+	Key() []byte
+	Error() error
+	Close() error
+}) []string {
+	t.Helper()
+	var keys []string
+	for it.Valid() {
+		keys = append(keys, string(it.Key()))
+		it.Next()
+	}
+	if err := it.Error(); err != nil {
+		_ = it.Close()
+		t.Fatalf("iterator error: %v", err)
+	}
+	if err := it.Close(); err != nil {
+		t.Fatalf("iterator close: %v", err)
+	}
+	return keys
+}
+
+func TestCachingDB_CommandWALRangeSpanVisibilitySnapshotsAndCheckpoint(t *testing.T) {
+	backend, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("backend Open: %v", err)
+	}
+	defer func() { _ = backend.Close() }()
+	db, err := Open(t.TempDir(), backend, Options{
+		DisableWAL:     true,
+		AllowUnsafe:    true,
+		FlushThreshold: 1 << 20,
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	for _, kv := range []struct{ k, v string }{{"a", "va"}, {"b", "vb"}, {"c", "vc"}, {"z", "vz"}} {
+		if err := db.Set([]byte(kv.k), []byte(kv.v)); err != nil {
+			t.Fatalf("Set(%s): %v", kv.k, err)
+		}
+	}
+	snapBefore := db.AcquireSnapshot()
+	if snapBefore == nil {
+		t.Fatalf("AcquireSnapshot before range returned nil")
+	}
+	defer func() { _ = snapBefore.Close() }()
+
+	appendCalls := 0
+	if err := db.DeleteRangeAfterCommandWALAppend([]byte("a"), []byte("d"), func() error {
+		appendCalls++
+		return nil
+	}); err != nil {
+		t.Fatalf("DeleteRangeAfterCommandWALAppend: %v", err)
+	}
+	if appendCalls != 1 {
+		t.Fatalf("append calls=%d want 1", appendCalls)
+	}
+
+	if val, err := snapBefore.Get([]byte("b")); err != nil || string(val) != "vb" {
+		t.Fatalf("snapshot before range b=(%q,%v), want vb,nil", val, err)
+	}
+	if val, err := db.Get([]byte("b")); err != nil || val != nil {
+		t.Fatalf("live b after range=(%q,%v), want missing", val, err)
+	}
+	if ok, err := db.Has([]byte("b")); err != nil || ok {
+		t.Fatalf("live Has(b)=(%t,%v), want false,nil", ok, err)
+	}
+	if val, err := db.Get([]byte("z")); err != nil || string(val) != "vz" {
+		t.Fatalf("live z after range=(%q,%v), want vz,nil", val, err)
+	}
+	if got, err := db.HasMany([][]byte{[]byte("a"), []byte("b"), []byte("z")}); err != nil || len(got) != 3 || got[0] || got[1] || !got[2] {
+		t.Fatalf("HasMany after range=(%v,%v), want [false false true],nil", got, err)
+	}
+	if got, err := db.HasPrefixes([][]byte{[]byte("a"), []byte("z")}); err != nil || len(got) != 2 || got[0] || !got[1] {
+		t.Fatalf("HasPrefixes after range=(%v,%v), want [false true],nil", got, err)
+	}
+	statsAfterRange := db.Stats()
+	if got := deleteRangeStatUint64(t, statsAfterRange, "treedb.cache.range_span.active_layers"); got != 1 {
+		t.Fatalf("active range layers=%d want 1", got)
+	}
+	if got := deleteRangeStatUint64(t, statsAfterRange, "treedb.cache.range_span.active_spans"); got != 1 {
+		t.Fatalf("active range spans=%d want 1", got)
+	}
+
+	if err := db.Set([]byte("b"), []byte("new")); err != nil {
+		t.Fatalf("Set(b after range): %v", err)
+	}
+	if val, err := db.Get([]byte("b")); err != nil || string(val) != "new" {
+		t.Fatalf("live b after override=(%q,%v), want new,nil", val, err)
+	}
+
+	it, err := db.Iterator(nil, nil)
+	if err != nil {
+		t.Fatalf("Iterator: %v", err)
+	}
+	if got, want := collectIteratorKeysForDeleteRangeTest(t, it), []string{"b", "z"}; len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("forward keys=%v want %v", got, want)
+	}
+	rit, err := db.ReverseIterator(nil, nil)
+	if err != nil {
+		t.Fatalf("ReverseIterator: %v", err)
+	}
+	if got, want := collectIteratorKeysForDeleteRangeTest(t, rit), []string{"z", "b"}; len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("reverse keys=%v want %v", got, want)
+	}
+
+	snapAfter := db.AcquireSnapshot()
+	if snapAfter == nil {
+		t.Fatalf("AcquireSnapshot after range returned nil")
+	}
+	defer func() { _ = snapAfter.Close() }()
+	if _, err := snapAfter.Get([]byte("a")); !errors.Is(err, tree.ErrKeyNotFound) {
+		t.Fatalf("snapshot after range Get(a) err=%v want ErrKeyNotFound", err)
+	}
+	if val, err := snapAfter.Get([]byte("b")); err != nil || string(val) != "new" {
+		t.Fatalf("snapshot after range b=(%q,%v), want new,nil", val, err)
+	}
+
+	stats := db.Stats()
+	if got := deleteRangeStatUint64(t, stats, "treedb.cache.delete_range.materialized_keys_total"); got != 0 {
+		t.Fatalf("materialized_keys_total=%d want 0", got)
+	}
+	if got := deleteRangeStatUint64(t, stats, "treedb.cache.delete_range.iterators_total"); got != 0 {
+		t.Fatalf("delete_range iterators_total=%d want 0", got)
+	}
+
+	if err := db.Checkpoint(); err != nil {
+		t.Fatalf("Checkpoint: %v", err)
+	}
+	stats = db.Stats()
+	if got := deleteRangeStatUint64(t, stats, "treedb.cache.range_span.active_layers"); got != 0 {
+		t.Fatalf("active range layers after checkpoint=%d want 0", got)
+	}
+	if got := deleteRangeStatUint64(t, stats, "treedb.cache.range_span.spans_flushed_total"); got != 1 {
+		t.Fatalf("spans_flushed_total=%d want 1", got)
+	}
+	if val, err := db.Get([]byte("a")); err != nil || val != nil {
+		t.Fatalf("a after checkpoint=(%q,%v), want missing", val, err)
+	}
+	if val, err := db.Get([]byte("b")); err != nil || string(val) != "new" {
+		t.Fatalf("b after checkpoint=(%q,%v), want new,nil", val, err)
+	}
+}
+
+func TestCachingBatch_CommandWALRangeOnlyUsesSpanLayer(t *testing.T) {
+	db, err := Open(t.TempDir(), NewMockBackend(), Options{
+		DisableWAL:     true,
+		AllowUnsafe:    true,
+		FlushThreshold: 1 << 20,
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	for _, key := range []string{"a", "b", "c", "z"} {
+		if err := db.Set([]byte(key), []byte("v")); err != nil {
+			t.Fatalf("Set(%s): %v", key, err)
+		}
+	}
+
+	b := db.NewBatch()
+	for _, bounds := range []struct{ start, end string }{{"a", "c"}, {"c", "d"}, {"b", "d"}} {
+		if err := b.DeleteRange([]byte(bounds.start), []byte(bounds.end)); err != nil {
+			t.Fatalf("DeleteRange(%s,%s): %v", bounds.start, bounds.end, err)
+		}
+	}
+	appendCalls := 0
+	if err := b.WriteAfterCommandWALAppend(false, func() error {
+		appendCalls++
+		return nil
+	}); err != nil {
+		t.Fatalf("WriteAfterCommandWALAppend: %v", err)
+	}
+	_ = b.Close()
+	if appendCalls != 1 {
+		t.Fatalf("append calls=%d want 1", appendCalls)
+	}
+	if val, err := db.Get([]byte("b")); err != nil || val != nil {
+		t.Fatalf("b after batch range=(%q,%v), want missing", val, err)
+	}
+	stats := db.Stats()
+	if got := deleteRangeStatUint64(t, stats, "treedb.cache.delete_range.batch_calls_total"); got != 3 {
+		t.Fatalf("batch_calls_total=%d want 3", got)
+	}
+	if got := deleteRangeStatUint64(t, stats, "treedb.cache.delete_range.batch_writes_total"); got != 1 {
+		t.Fatalf("batch_writes_total=%d want 1", got)
+	}
+	if got := deleteRangeStatUint64(t, stats, "treedb.cache.delete_range.input_ranges_total"); got != 3 {
+		t.Fatalf("input_ranges_total=%d want 3", got)
+	}
+	if got := deleteRangeStatUint64(t, stats, "treedb.cache.delete_range.effective_ranges_total"); got != 1 {
+		t.Fatalf("effective_ranges_total=%d want 1", got)
+	}
+	if got := deleteRangeStatUint64(t, stats, "treedb.cache.delete_range.coalesced_ranges_total"); got != 2 {
+		t.Fatalf("coalesced_ranges_total=%d want 2", got)
+	}
+	if got := deleteRangeStatUint64(t, stats, "treedb.cache.delete_range.materialized_keys_total"); got != 0 {
+		t.Fatalf("materialized_keys_total=%d want 0", got)
+	}
+	if got := deleteRangeStatUint64(t, stats, "treedb.cache.range_span.layers_total"); got != 1 {
+		t.Fatalf("range span layers_total=%d want 1", got)
+	}
+}
+
+func TestCachingDB_CommandWALRangeSpanBounds(t *testing.T) {
+	db, err := Open(t.TempDir(), NewMockBackend(), Options{
+		DisableWAL:     true,
+		AllowUnsafe:    true,
+		FlushThreshold: 1 << 20,
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	for _, kv := range []struct{ k, v []byte }{
+		{[]byte{}, []byte("empty")},
+		{[]byte("a"), []byte("va")},
+		{[]byte("b"), []byte("vb")},
+	} {
+		if err := db.Set(kv.k, kv.v); err != nil {
+			t.Fatalf("Set(%q): %v", kv.k, err)
+		}
+	}
+	appendCalls := 0
+	if err := db.DeleteRangeAfterCommandWALAppend([]byte("z"), []byte("a"), func() error {
+		appendCalls++
+		return nil
+	}); err != nil {
+		t.Fatalf("reversed DeleteRange: %v", err)
+	}
+	if err := db.DeleteRangeAfterCommandWALAppend(nil, []byte{}, func() error {
+		appendCalls++
+		return nil
+	}); err != nil {
+		t.Fatalf("nil-to-empty DeleteRange: %v", err)
+	}
+	if appendCalls != 0 {
+		t.Fatalf("noop append calls=%d want 0", appendCalls)
+	}
+	if val, err := db.Get([]byte{}); err != nil || string(val) != "empty" {
+		t.Fatalf("empty key after no-ops=(%q,%v), want empty,nil", val, err)
+	}
+	if err := db.DeleteRangeAfterCommandWALAppend([]byte{}, []byte("a"), func() error {
+		appendCalls++
+		return nil
+	}); err != nil {
+		t.Fatalf("empty-to-a DeleteRange: %v", err)
+	}
+	if val, err := db.Get([]byte{}); err != nil || val != nil {
+		t.Fatalf("empty key after [empty,a)=(%q,%v), want missing", val, err)
+	}
+	if val, err := db.Get([]byte("a")); err != nil || string(val) != "va" {
+		t.Fatalf("a after [empty,a)=(%q,%v), want va,nil", val, err)
+	}
+	if err := db.DeleteRangeAfterCommandWALAppend(nil, nil, func() error {
+		appendCalls++
+		return nil
+	}); err != nil {
+		t.Fatalf("full DeleteRange: %v", err)
+	}
+	for _, key := range [][]byte{[]byte("a"), []byte("b")} {
+		if val, err := db.Get(key); err != nil || val != nil {
+			t.Fatalf("%q after full range=(%q,%v), want missing", key, val, err)
+		}
+	}
+	if appendCalls != 2 {
+		t.Fatalf("append calls=%d want 2 for effective ranges", appendCalls)
+	}
 }
 
 func TestCachingDB_DeleteRange_WALApplyFailurePoisonsWrites(t *testing.T) {

--- a/TreeDB/caching/delete_range_test.go
+++ b/TreeDB/caching/delete_range_test.go
@@ -449,6 +449,50 @@ func TestCachingDB_CommandWALRangeSpanIteratorPreservesPublishedRoot(t *testing.
 	}
 }
 
+func TestCachingDB_CommandWALRangeSpanBlocksLaterWriteSyncBypass(t *testing.T) {
+	db, err := Open(t.TempDir(), NewMockBackend(), Options{
+		DisableWAL:     true,
+		AllowUnsafe:    true,
+		FlushThreshold: 1 << 20,
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	appendCalls := 0
+	if err := db.DeleteRangeAfterCommandWALAppend([]byte("a"), []byte("c"), func() error {
+		appendCalls++
+		return nil
+	}); err != nil {
+		t.Fatalf("DeleteRangeAfterCommandWALAppend: %v", err)
+	}
+	if appendCalls != 1 {
+		t.Fatalf("append calls=%d want 1", appendCalls)
+	}
+
+	b := db.NewBatch()
+	if err := b.Set([]byte("b"), []byte("new")); err != nil {
+		t.Fatalf("batch Set: %v", err)
+	}
+	if err := b.WriteSync(); err != nil {
+		t.Fatalf("batch WriteSync: %v", err)
+	}
+	if err := b.Close(); err != nil {
+		t.Fatalf("batch Close: %v", err)
+	}
+
+	if val, err := db.Get([]byte("b")); err != nil || string(val) != "new" {
+		t.Fatalf("newer point after active span b=(%q,%v), want new,nil", val, err)
+	}
+	if err := db.Checkpoint(); err != nil {
+		t.Fatalf("Checkpoint: %v", err)
+	}
+	if val, err := db.Get([]byte("b")); err != nil || string(val) != "new" {
+		t.Fatalf("newer point after span checkpoint b=(%q,%v), want new,nil", val, err)
+	}
+}
+
 func TestCachingBatch_CommandWALRangeOnlyUsesSpanLayer(t *testing.T) {
 	db, err := Open(t.TempDir(), NewMockBackend(), Options{
 		DisableWAL:     true,

--- a/TreeDB/caching/delete_range_test.go
+++ b/TreeDB/caching/delete_range_test.go
@@ -200,6 +200,85 @@ func TestCachingDB_CommandWALRangeSpanVisibilitySnapshotsAndCheckpoint(t *testin
 	}
 }
 
+func TestCachingDB_CommandWALRangeSpanFiltersPublishedRoot(t *testing.T) {
+	backend, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("backend Open: %v", err)
+	}
+	defer func() { _ = backend.Close() }()
+	db, err := Open(t.TempDir(), backend, Options{
+		DisableWAL:     true,
+		AllowUnsafe:    true,
+		FlushThreshold: 1 << 20,
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	published := newRootDomainTestTable(t,
+		rootDomainTestOp{key: "b", value: "root-b"},
+		rootDomainTestOp{key: "c", value: "root-c"},
+		rootDomainTestOp{key: "z", value: "root-z"},
+	)
+	db.mu.Lock()
+	if ok := db.installPublishedRootSetLocked(&publishedRootSet{
+		generation: 1,
+		pointShards: []publishedRootRef{{
+			lookup: published,
+			rootID: 1,
+		}},
+	}); !ok {
+		db.mu.Unlock()
+		t.Fatalf("installPublishedRootSetLocked returned false")
+	}
+	db.mu.Unlock()
+
+	if err := db.DeleteRangeAfterCommandWALAppend([]byte("b"), []byte("d"), func() error { return nil }); err != nil {
+		t.Fatalf("DeleteRangeAfterCommandWALAppend: %v", err)
+	}
+
+	if val, err := db.Get([]byte("z")); err != nil || string(val) != "root-z" {
+		t.Fatalf("active span outside-root z=(%q,%v), want root-z,nil", val, err)
+	}
+	if out, err := db.GetAppend([]byte("z"), []byte("prefix:")); err != nil || string(out) != "prefix:root-z" {
+		t.Fatalf("active span outside-root GetAppend(z)=(%q,%v), want prefix:root-z,nil", out, err)
+	}
+	if val, err := db.Get([]byte("c")); err != nil || val != nil {
+		t.Fatalf("active span inside-root c=(%q,%v), want missing", val, err)
+	}
+	if _, err := db.GetAppend([]byte("c"), nil); !errors.Is(err, tree.ErrKeyNotFound) {
+		t.Fatalf("active span inside-root GetAppend(c) err=%v want ErrKeyNotFound", err)
+	}
+	if ok, err := db.Has([]byte("c")); err != nil || ok {
+		t.Fatalf("active span Has(c)=(%t,%v), want false,nil", ok, err)
+	}
+	if err := db.Set([]byte("b"), []byte("new-b")); err != nil {
+		t.Fatalf("Set override: %v", err)
+	}
+	if val, err := db.Get([]byte("b")); err != nil || string(val) != "new-b" {
+		t.Fatalf("active span newer override b=(%q,%v), want new-b,nil", val, err)
+	}
+
+	snap := db.AcquireSnapshot()
+	if snap == nil {
+		t.Fatalf("AcquireSnapshot returned nil")
+	}
+	defer func() { _ = snap.Close() }()
+	if val, err := snap.Get([]byte("z")); err != nil || string(val) != "root-z" {
+		t.Fatalf("snapshot active span outside-root z=(%q,%v), want root-z,nil", val, err)
+	}
+	if out, err := snap.GetAppend([]byte("z"), []byte("prefix:")); err != nil || string(out) != "prefix:root-z" {
+		t.Fatalf("snapshot active span outside-root GetAppend(z)=(%q,%v), want prefix:root-z,nil", out, err)
+	}
+	if _, err := snap.Get([]byte("c")); !errors.Is(err, tree.ErrKeyNotFound) {
+		t.Fatalf("snapshot active span inside-root c err=%v want ErrKeyNotFound", err)
+	}
+	if val, err := snap.Get([]byte("b")); err != nil || string(val) != "new-b" {
+		t.Fatalf("snapshot active span newer override b=(%q,%v), want new-b,nil", val, err)
+	}
+}
+
 func TestCachingBatch_CommandWALRangeOnlyUsesSpanLayer(t *testing.T) {
 	db, err := Open(t.TempDir(), NewMockBackend(), Options{
 		DisableWAL:     true,

--- a/TreeDB/caching/delete_range_test.go
+++ b/TreeDB/caching/delete_range_test.go
@@ -279,6 +279,64 @@ func TestCachingDB_CommandWALRangeSpanFiltersPublishedRoot(t *testing.T) {
 	}
 }
 
+func TestCachingDB_CommandWALRangeSpanPreservesPublishedRootMiss(t *testing.T) {
+	backend, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("backend Open: %v", err)
+	}
+	defer func() { _ = backend.Close() }()
+	if err := backend.SetSync([]byte("root-a-only"), []byte("root-a")); err != nil {
+		t.Fatalf("seed root A: %v", err)
+	}
+	rootA := uint64(0)
+	if state := backend.State(); state != nil {
+		rootA = state.RootPageID
+	}
+	if rootA == 0 {
+		t.Fatalf("root A id is zero")
+	}
+	if err := backend.SetSync([]byte("m"), []byte("default-m")); err != nil {
+		t.Fatalf("seed default root: %v", err)
+	}
+
+	db, err := Open(t.TempDir(), backend, Options{
+		DisableWAL:     true,
+		AllowUnsafe:    true,
+		FlushThreshold: 1 << 20,
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	db.mu.Lock()
+	if ok := db.installPublishedRootSetLocked(&publishedRootSet{
+		generation: 1,
+		pointShards: []publishedRootRef{{
+			rootID: rootA,
+		}},
+	}); !ok {
+		db.mu.Unlock()
+		t.Fatalf("installPublishedRootSetLocked returned false")
+	}
+	db.mu.Unlock()
+	if err := db.DeleteRangeAfterCommandWALAppend([]byte("x"), []byte("z"), func() error { return nil }); err != nil {
+		t.Fatalf("DeleteRangeAfterCommandWALAppend: %v", err)
+	}
+
+	snap := db.AcquireSnapshot()
+	if snap == nil {
+		t.Fatalf("AcquireSnapshot returned nil")
+	}
+	defer func() { _ = snap.Close() }()
+	if _, err := snap.Get([]byte("m")); !errors.Is(err, tree.ErrKeyNotFound) {
+		t.Fatalf("snapshot root-bound miss Get(m) err=%v want ErrKeyNotFound", err)
+	}
+	if out, err := snap.GetAppend([]byte("m"), []byte("prefix:")); !errors.Is(err, tree.ErrKeyNotFound) || string(out) != "prefix:" {
+		t.Fatalf("snapshot root-bound miss GetAppend(m)=(%q,%v), want prefix:,ErrKeyNotFound", out, err)
+	}
+}
+
 func TestCachingBatch_CommandWALRangeOnlyUsesSpanLayer(t *testing.T) {
 	db, err := Open(t.TempDir(), NewMockBackend(), Options{
 		DisableWAL:     true,

--- a/TreeDB/caching/range_spans.go
+++ b/TreeDB/caching/range_spans.go
@@ -163,8 +163,19 @@ func memtableViewHasRangeSpans(view *memtableView) bool {
 }
 
 func (db *DB) lookupViewEntryWithRangeSpans(view *memtableView, key []byte, includeMutable bool) (val []byte, ptr page.ValuePtr, flags byte, found bool) {
+	rootSnap, haveRootSnap := livePointRootDomainSnapshot(view, db, key)
+	val, ptr, flags, found, _ = db.lookupViewEntryWithRangeSpansAndRootSource(view, key, includeMutable, rootSnap, haveRootSnap)
+	return val, ptr, flags, found
+}
+
+func (db *DB) lookupViewEntryWithRangeSpansAndRoot(view *memtableView, key []byte, includeMutable bool, rootSnap rootDomainSnapshot, haveRootSnap bool) (val []byte, ptr page.ValuePtr, flags byte, found bool) {
+	val, ptr, flags, found, _ = db.lookupViewEntryWithRangeSpansAndRootSource(view, key, includeMutable, rootSnap, haveRootSnap)
+	return val, ptr, flags, found
+}
+
+func (db *DB) lookupViewEntryWithRangeSpansAndRootSource(view *memtableView, key []byte, includeMutable bool, rootSnap rootDomainSnapshot, haveRootSnap bool) (val []byte, ptr page.ValuePtr, flags byte, found bool, source rootDomainEntrySource) {
 	if db == nil || view == nil {
-		return nil, page.ValuePtr{}, 0, false
+		return nil, page.ValuePtr{}, 0, false, rootDomainEntrySourceNone
 	}
 	shardIdx := 0
 	if len(db.mutableShards) > 1 {
@@ -177,7 +188,7 @@ func (db *DB) lookupViewEntryWithRangeSpans(view *memtableView, key []byte, incl
 					db.rangeSpanPointProbes.Add(1)
 					db.rangeSpanPointHits.Add(1)
 				}
-				return val, ptr, flags, true
+				return val, ptr, flags, true, rootDomainEntrySourceCached
 			}
 		}
 	}
@@ -192,22 +203,39 @@ func (db *DB) lookupViewEntryWithRangeSpans(view *memtableView, key []byte, incl
 					if db != nil {
 						db.rangeSpanPointHits.Add(1)
 					}
-					return val, ptr, flags, true
+					return val, ptr, flags, true, rootDomainEntrySourceCached
 				}
 			}
 		}
 		if idx < len(view.queueRangeSpans) && rangeSpansContainKey(view.queueRangeSpans[idx], key) {
-			return nil, page.ValuePtr{}, node.FlagTombstone, true
+			return nil, page.ValuePtr{}, node.FlagTombstone, true, rootDomainEntrySourceCached
 		}
 	}
-	return nil, page.ValuePtr{}, 0, false
+	if haveRootSnap && rootSnap.published != nil {
+		if db != nil {
+			db.rangeSpanPointProbes.Add(1)
+		}
+		if val, ptr, flags, found = rootSnap.published.GetEntry(key); found {
+			if db != nil {
+				db.rangeSpanPointHits.Add(1)
+			}
+			return val, ptr, flags, true, rootDomainEntrySourcePublished
+		}
+	}
+	return nil, page.ValuePtr{}, 0, false, rootDomainEntrySourceNone
 }
 
 func (s *Snapshot) lookupEntryWithRangeSpans(key []byte) (val []byte, ptr page.ValuePtr, flags byte, found bool) {
+	val, ptr, flags, found, _ = s.lookupEntryWithRangeSpansSource(key)
+	return val, ptr, flags, found
+}
+
+func (s *Snapshot) lookupEntryWithRangeSpansSource(key []byte) (val []byte, ptr page.ValuePtr, flags byte, found bool, source rootDomainEntrySource) {
 	if s == nil || s.view == nil || s.db == nil {
-		return nil, page.ValuePtr{}, 0, false
+		return nil, page.ValuePtr{}, 0, false, rootDomainEntrySourceNone
 	}
-	return s.db.lookupViewEntryWithRangeSpans(s.view, key, false)
+	rootSnap := rootDomainSnapshotFromCachedSnapshot(s, key)
+	return s.db.lookupViewEntryWithRangeSpansAndRootSource(s.view, key, false, rootSnap, true)
 }
 
 func rangeSpanPrefixEnd(prefix []byte) []byte {

--- a/TreeDB/caching/range_spans.go
+++ b/TreeDB/caching/range_spans.go
@@ -221,6 +221,10 @@ func (db *DB) lookupViewEntryWithRangeSpansAndRootSource(view *memtableView, key
 			}
 			return val, ptr, flags, true, rootDomainEntrySourcePublished
 		}
+		// The applicable published root is authoritative for this view/snapshot.
+		// Treat its miss as a terminal not-found marker so active-span paths do not
+		// fall through to the default backend root and cross root domains.
+		return nil, page.ValuePtr{}, node.FlagTombstone, true, rootDomainEntrySourcePublished
 	}
 	return nil, page.ValuePtr{}, 0, false, rootDomainEntrySourceNone
 }

--- a/TreeDB/caching/range_spans.go
+++ b/TreeDB/caching/range_spans.go
@@ -70,6 +70,41 @@ func rangeSpansOverlapQuery(spans []batch.DeleteRange, start, end []byte) bool {
 	return false
 }
 
+func queryCoversRangeSpan(start, end []byte, span batch.DeleteRange) bool {
+	if batch.IsDeleteRangeNoop(span.Start, span.End) {
+		return true
+	}
+	if start != nil {
+		if span.Start == nil || bytes.Compare(start, span.Start) > 0 {
+			return false
+		}
+	}
+	if end != nil {
+		if span.End == nil || bytes.Compare(end, span.End) < 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func queryCoversRangeSpans(start, end []byte, spans []batch.DeleteRange) bool {
+	for _, span := range spans {
+		if !queryCoversRangeSpan(start, end, span) {
+			return false
+		}
+	}
+	return true
+}
+
+func queryCoversRangeSpanLayers(start, end []byte, layers [][]batch.DeleteRange) bool {
+	for _, spans := range layers {
+		if !queryCoversRangeSpans(start, end, spans) {
+			return false
+		}
+	}
+	return true
+}
+
 func rangeSpanLayerHasSpans(layers [][]batch.DeleteRange) bool {
 	for _, spans := range layers {
 		if len(spans) > 0 {

--- a/TreeDB/caching/range_spans.go
+++ b/TreeDB/caching/range_spans.go
@@ -1,0 +1,225 @@
+package caching
+
+import (
+	"bytes"
+
+	"github.com/snissn/gomap/TreeDB/batch"
+	"github.com/snissn/gomap/TreeDB/internal/iterator"
+	"github.com/snissn/gomap/TreeDB/node"
+	"github.com/snissn/gomap/TreeDB/page"
+)
+
+func cloneRangeSpanBound(bound []byte) []byte {
+	if bound == nil {
+		return nil
+	}
+	if len(bound) == 0 {
+		return rawKVEmptyPointKey
+	}
+	return append([]byte(nil), bound...)
+}
+
+func cloneRangeSpans(spans []batch.DeleteRange) []batch.DeleteRange {
+	if len(spans) == 0 {
+		return nil
+	}
+	out := make([]batch.DeleteRange, 0, len(spans))
+	for _, span := range spans {
+		if batch.IsDeleteRangeNoop(span.Start, span.End) {
+			continue
+		}
+		out = append(out, batch.DeleteRange{
+			Start: cloneRangeSpanBound(span.Start),
+			End:   cloneRangeSpanBound(span.End),
+		})
+	}
+	return out
+}
+
+func rangeSpansContainKey(spans []batch.DeleteRange, key []byte) bool {
+	if key == nil || len(spans) == 0 {
+		return false
+	}
+	for _, span := range spans {
+		if batch.DeleteRangeContainsKey(span, key) {
+			return true
+		}
+	}
+	return false
+}
+
+func rangeSpanOverlapsQuery(span batch.DeleteRange, start, end []byte) bool {
+	if batch.IsDeleteRangeNoop(span.Start, span.End) || batch.IsDeleteRangeNoop(start, end) {
+		return false
+	}
+	if end != nil && span.Start != nil && bytes.Compare(end, span.Start) <= 0 {
+		return false
+	}
+	if start != nil && span.End != nil && bytes.Compare(span.End, start) <= 0 {
+		return false
+	}
+	return true
+}
+
+func rangeSpansOverlapQuery(spans []batch.DeleteRange, start, end []byte) bool {
+	for _, span := range spans {
+		if rangeSpanOverlapsQuery(span, start, end) {
+			return true
+		}
+	}
+	return false
+}
+
+func rangeSpanLayerHasSpans(layers [][]batch.DeleteRange) bool {
+	for _, spans := range layers {
+		if len(spans) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func rangeSpanLayerCounts(layers [][]batch.DeleteRange) (layerCount, spanCount int) {
+	for _, spans := range layers {
+		if len(spans) == 0 {
+			continue
+		}
+		layerCount++
+		spanCount += len(spans)
+	}
+	return layerCount, spanCount
+}
+
+func cloneRangeSpanLayers(layers [][]batch.DeleteRange) [][]batch.DeleteRange {
+	if len(layers) == 0 {
+		return nil
+	}
+	out := make([][]batch.DeleteRange, len(layers))
+	for i := range layers {
+		out[i] = cloneRangeSpans(layers[i])
+	}
+	return out
+}
+
+func appendNewerRangeSpansForSource(dst []batch.DeleteRange, layers [][]batch.DeleteRange, sourceIdx int) []batch.DeleteRange {
+	if len(layers) == 0 {
+		return dst
+	}
+	if sourceIdx < -1 {
+		sourceIdx = -1
+	}
+	for idx := sourceIdx + 1; idx < len(layers); idx++ {
+		if len(layers[idx]) == 0 {
+			continue
+		}
+		dst = append(dst, layers[idx]...)
+	}
+	return dst
+}
+
+type rangeSpanFilteringIterator struct {
+	iterator.UnsafeIterator
+	db    *DB
+	spans []batch.DeleteRange
+}
+
+func newRangeSpanFilteringIterator(inner iterator.UnsafeIterator, spans []batch.DeleteRange, db *DB) iterator.UnsafeIterator {
+	if inner == nil || len(spans) == 0 {
+		return inner
+	}
+	it := &rangeSpanFilteringIterator{UnsafeIterator: inner, spans: spans, db: db}
+	it.advance()
+	return it
+}
+
+func (it *rangeSpanFilteringIterator) advance() {
+	for it.UnsafeIterator != nil && it.UnsafeIterator.Valid() {
+		key := it.UnsafeIterator.UnsafeKey()
+		if it.db != nil {
+			it.db.rangeSpanIteratorProbes.Add(1)
+		}
+		if !rangeSpansContainKey(it.spans, key) {
+			return
+		}
+		if it.db != nil {
+			it.db.rangeSpanIteratorSkips.Add(1)
+		}
+		it.UnsafeIterator.Next()
+	}
+}
+
+func (it *rangeSpanFilteringIterator) Next() {
+	it.UnsafeIterator.Next()
+	it.advance()
+}
+
+func (it *rangeSpanFilteringIterator) Seek(key []byte) {
+	it.UnsafeIterator.Seek(key)
+	it.advance()
+}
+
+func memtableViewHasRangeSpans(view *memtableView) bool {
+	return view != nil && rangeSpanLayerHasSpans(view.queueRangeSpans)
+}
+
+func (db *DB) lookupViewEntryWithRangeSpans(view *memtableView, key []byte, includeMutable bool) (val []byte, ptr page.ValuePtr, flags byte, found bool) {
+	if db == nil || view == nil {
+		return nil, page.ValuePtr{}, 0, false
+	}
+	shardIdx := 0
+	if len(db.mutableShards) > 1 {
+		shardIdx = db.shardIndex(key)
+	}
+	if includeMutable && shardIdx >= 0 && shardIdx < len(view.mutables) {
+		if mt := view.mutables[shardIdx]; mt != nil {
+			if val, ptr, flags, found = mt.GetEntry(key); found {
+				if db != nil {
+					db.rangeSpanPointProbes.Add(1)
+					db.rangeSpanPointHits.Add(1)
+				}
+				return val, ptr, flags, true
+			}
+		}
+	}
+	for idx := len(view.queue) - 1; idx >= 0; idx-- {
+		mt := view.queue[idx]
+		if mt != nil {
+			if len(view.queueShardIDs) <= idx || int(view.queueShardIDs[idx]) == shardIdx {
+				if db != nil {
+					db.rangeSpanPointProbes.Add(1)
+				}
+				if val, ptr, flags, found = mt.GetEntry(key); found {
+					if db != nil {
+						db.rangeSpanPointHits.Add(1)
+					}
+					return val, ptr, flags, true
+				}
+			}
+		}
+		if idx < len(view.queueRangeSpans) && rangeSpansContainKey(view.queueRangeSpans[idx], key) {
+			return nil, page.ValuePtr{}, node.FlagTombstone, true
+		}
+	}
+	return nil, page.ValuePtr{}, 0, false
+}
+
+func (s *Snapshot) lookupEntryWithRangeSpans(key []byte) (val []byte, ptr page.ValuePtr, flags byte, found bool) {
+	if s == nil || s.view == nil || s.db == nil {
+		return nil, page.ValuePtr{}, 0, false
+	}
+	return s.db.lookupViewEntryWithRangeSpans(s.view, key, false)
+}
+
+func rangeSpanPrefixEnd(prefix []byte) []byte {
+	if len(prefix) == 0 {
+		return nil
+	}
+	end := append([]byte(nil), prefix...)
+	for i := len(end) - 1; i >= 0; i-- {
+		if end[i] != 0xff {
+			end[i]++
+			return end[:i+1]
+		}
+	}
+	return nil
+}

--- a/TreeDB/caching/range_spans.go
+++ b/TreeDB/caching/range_spans.go
@@ -211,19 +211,26 @@ func (db *DB) lookupViewEntryWithRangeSpansAndRootSource(view *memtableView, key
 			return nil, page.ValuePtr{}, node.FlagTombstone, true, rootDomainEntrySourceCached
 		}
 	}
-	if haveRootSnap && rootSnap.published != nil {
-		if db != nil {
-			db.rangeSpanPointProbes.Add(1)
+	if haveRootSnap && rootDomainSnapshotHasPublishedState(rootSnap) {
+		resolvedSnap, release := db.resolveLivePublishedRootSnapshot(rootSnap)
+		if release != nil {
+			defer release()
 		}
-		if val, ptr, flags, found = rootSnap.published.GetEntry(key); found {
+		if resolvedSnap.published != nil {
 			if db != nil {
-				db.rangeSpanPointHits.Add(1)
+				db.rangeSpanPointProbes.Add(1)
 			}
-			return val, ptr, flags, true, rootDomainEntrySourcePublished
+			if val, ptr, flags, found = resolvedSnap.published.GetEntry(key); found {
+				if db != nil {
+					db.rangeSpanPointHits.Add(1)
+				}
+				return val, ptr, flags, true, rootDomainEntrySourcePublished
+			}
 		}
 		// The applicable published root is authoritative for this view/snapshot.
-		// Treat its miss as a terminal not-found marker so active-span paths do not
-		// fall through to the default backend root and cross root domains.
+		// Treat its miss (or an unresolvable root ID) as a terminal not-found marker
+		// so active-span paths do not fall through to the default backend root and
+		// cross root domains.
 		return nil, page.ValuePtr{}, node.FlagTombstone, true, rootDomainEntrySourcePublished
 	}
 	return nil, page.ValuePtr{}, 0, false, rootDomainEntrySourceNone

--- a/TreeDB/caching/root_domain.go
+++ b/TreeDB/caching/root_domain.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"sync"
 	"sync/atomic"
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
@@ -23,8 +24,16 @@ type rootDomainIteratorFactory interface {
 	Iterator(start, end []byte) (iterator.UnsafeIterator, error)
 }
 
+type rootDomainReverseIteratorFactory interface {
+	ReverseIterator(start, end []byte) (iterator.UnsafeIterator, error)
+}
+
 type rootDomainUnsafeIteratorFactory interface {
 	NewIterator(start, end []byte) iterator.UnsafeIterator
+}
+
+type rootDomainUnsafeReverseIteratorFactory interface {
+	NewReverseIterator(start, end []byte) iterator.UnsafeIterator
 }
 
 // rootDomainState is the native cached state shape for one logical root-domain.
@@ -766,6 +775,21 @@ func (l backendSnapshotLookup) Iterator(start, end []byte) (iterator.UnsafeItera
 	return l.snapshot.Iterator(start, end)
 }
 
+func (l backendSnapshotLookup) ReverseIterator(start, end []byte) (iterator.UnsafeIterator, error) {
+	if l.snapshot == nil {
+		return nil, backenddb.ErrClosed
+	}
+	if l.db != nil {
+		if err := l.db.flushValueLogForBackendRead(); err != nil {
+			return nil, err
+		}
+	}
+	if l.rootID != 0 {
+		return l.snapshot.ReverseIteratorAtRoot(l.rootID, start, end)
+	}
+	return l.snapshot.ReverseIterator(start, end)
+}
+
 func rootDomainSnapshotFromMemtableView(view *memtableView, shardIdx int, includeMutable bool) rootDomainSnapshot {
 	if view == nil {
 		return rootDomainSnapshot{}
@@ -1017,7 +1041,7 @@ func liveIteratorRootDomainSnapshot(view *memtableView) (rootDomainSnapshot, boo
 	if view == nil {
 		return rootDomainSnapshot{}, false
 	}
-	if rootDomainSnapshotHasInMemoryState(view.rootIterator) {
+	if rootDomainSnapshotHasInMemoryState(view.rootIterator) || rootDomainSnapshotHasPublishedState(view.rootIterator) {
 		return view.rootIterator, true
 	}
 	return rootDomainSnapshot{}, false
@@ -1245,7 +1269,7 @@ func rootDomainSnapshotNeedsPublish(s rootDomainSnapshot) bool {
 
 func rootDomainPublishedIterator(s rootDomainSnapshot, start, end []byte) (iterator.UnsafeIterator, bool, error) {
 	if s.published == nil {
-		return nil, false, nil
+		return nil, s.publishedRootID != 0, nil
 	}
 	switch published := s.published.(type) {
 	case rootDomainUnsafeIteratorFactory:
@@ -1256,6 +1280,83 @@ func rootDomainPublishedIterator(s rootDomainSnapshot, start, end []byte) (itera
 	default:
 		return nil, true, nil
 	}
+}
+
+func rootDomainPublishedReverseIterator(s rootDomainSnapshot, start, end []byte) (iterator.UnsafeIterator, bool, error) {
+	if s.published == nil {
+		return nil, s.publishedRootID != 0, nil
+	}
+	switch published := s.published.(type) {
+	case rootDomainUnsafeReverseIteratorFactory:
+		return published.NewReverseIterator(start, end), true, nil
+	case rootDomainReverseIteratorFactory:
+		iter, err := published.ReverseIterator(start, end)
+		return iter, true, err
+	default:
+		return nil, true, nil
+	}
+}
+
+type leasedUnsafeIterator struct {
+	iterator.UnsafeIterator
+	closeOnce sync.Once
+	closeErr  error
+	release   func()
+}
+
+func (it *leasedUnsafeIterator) Close() error {
+	if it == nil {
+		return nil
+	}
+	it.closeOnce.Do(func() {
+		if it.UnsafeIterator != nil {
+			it.closeErr = it.UnsafeIterator.Close()
+		}
+		if it.release != nil {
+			it.release()
+		}
+	})
+	return it.closeErr
+}
+
+func (db *DB) resolveLivePublishedRootSnapshot(s rootDomainSnapshot) (rootDomainSnapshot, func()) {
+	if db == nil || s.published != nil || s.publishedRootID == 0 {
+		return s, nil
+	}
+	provider, ok := db.backend.(backendSnapshotProvider)
+	if !ok {
+		return s, nil
+	}
+	snap := provider.AcquireSnapshot()
+	if snap == nil {
+		return s, nil
+	}
+	s.published = backendSnapshotLookup{db: db, snapshot: snap, rootID: s.publishedRootID}
+	return s, func() { _ = snap.Close() }
+}
+
+func (db *DB) livePublishedRootIterator(s rootDomainSnapshot, start, end []byte, reverse bool) (iterator.UnsafeIterator, bool, error) {
+	s, release := db.resolveLivePublishedRootSnapshot(s)
+	var (
+		it  iterator.UnsafeIterator
+		ok  bool
+		err error
+	)
+	if reverse {
+		it, ok, err = rootDomainPublishedReverseIterator(s, start, end)
+	} else {
+		it, ok, err = rootDomainPublishedIterator(s, start, end)
+	}
+	if err != nil || !ok || it == nil {
+		if release != nil {
+			release()
+		}
+		return it, ok, err
+	}
+	if release != nil {
+		it = &leasedUnsafeIterator{UnsafeIterator: it, release: release}
+	}
+	return it, ok, nil
 }
 
 func (s rootDomainSnapshot) iteratorSources(start, end []byte) ([]merging.IteratorSource, error) {

--- a/TreeDB/caching/root_domain.go
+++ b/TreeDB/caching/root_domain.go
@@ -1243,6 +1243,21 @@ func rootDomainSnapshotNeedsPublish(s rootDomainSnapshot) bool {
 	return s.mutable != nil || len(s.immutables) > 0
 }
 
+func rootDomainPublishedIterator(s rootDomainSnapshot, start, end []byte) (iterator.UnsafeIterator, bool, error) {
+	if s.published == nil {
+		return nil, false, nil
+	}
+	switch published := s.published.(type) {
+	case rootDomainUnsafeIteratorFactory:
+		return published.NewIterator(start, end), true, nil
+	case rootDomainIteratorFactory:
+		iter, err := published.Iterator(start, end)
+		return iter, true, err
+	default:
+		return nil, true, nil
+	}
+}
+
 func (s rootDomainSnapshot) iteratorSources(start, end []byte) ([]merging.IteratorSource, error) {
 	sources := make([]merging.IteratorSource, 0, 1+len(s.immutables)+1)
 	prio := 0

--- a/TreeDB/caching/snapshot.go
+++ b/TreeDB/caching/snapshot.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"github.com/snissn/gomap/TreeDB/batch"
 	backenddb "github.com/snissn/gomap/TreeDB/db"
 	"github.com/snissn/gomap/TreeDB/internal/iterator"
 	"github.com/snissn/gomap/TreeDB/internal/merging"
@@ -348,6 +349,13 @@ func (s *Snapshot) lookupRootDomainSnapshotEntry(key []byte) (snap rootDomainSna
 	if s == nil {
 		return rootDomainSnapshot{}, nil, page.ValuePtr{}, 0, false, rootDomainEntrySourceNone
 	}
+	if memtableViewHasRangeSpans(s.view) {
+		val, ptr, flags, found = s.lookupEntryWithRangeSpans(key)
+		if found {
+			return rootDomainSnapshot{}, val, ptr, flags, true, rootDomainEntrySourceCached
+		}
+		return rootDomainSnapshot{}, nil, page.ValuePtr{}, 0, false, rootDomainEntrySourceNone
+	}
 	snap = rootDomainSnapshotFromCachedSnapshot(s, key)
 	val, ptr, flags, found, source = snap.getEntryWithSource(key)
 	return snap, val, ptr, flags, found, source
@@ -359,7 +367,13 @@ func (s *Snapshot) lookupRootDomainEntry(key []byte) (val []byte, ptr page.Value
 }
 
 func (s *Snapshot) lookupCachedRootDomainEntry(key []byte) (val []byte, ptr page.ValuePtr, flags byte, found bool) {
-	if s == nil || len(s.rootPointShards) == 0 {
+	if s == nil {
+		return nil, page.ValuePtr{}, 0, false
+	}
+	if memtableViewHasRangeSpans(s.view) {
+		return s.lookupEntryWithRangeSpans(key)
+	}
+	if len(s.rootPointShards) == 0 {
 		return nil, page.ValuePtr{}, 0, false
 	}
 	shardIdx := 0
@@ -491,6 +505,10 @@ func (s *Snapshot) iteratorSources(start, end []byte, reverse bool) ([]merging.I
 		return nil, backenddb.ErrClosed
 	}
 	queue := s.rootIterator.immutables
+	var queueRangeSpans [][]batch.DeleteRange
+	if s.view != nil && len(s.view.queueRangeSpans) == len(queue) {
+		queueRangeSpans = s.view.queueRangeSpans
+	}
 	sources := make([]merging.IteratorSource, 0, len(queue)+1)
 	prio := 0
 	for idx := len(queue) - 1; idx >= 0; idx-- {
@@ -505,6 +523,7 @@ func (s *Snapshot) iteratorSources(start, end []byte, reverse bool) ([]merging.I
 				return s.db.readValueLog(key, ptr)
 			})
 		}
+		qIter = newRangeSpanFilteringIterator(qIter, appendNewerRangeSpansForSource(nil, queueRangeSpans, idx), s.db)
 		sources = append(sources, merging.IteratorSource{Iter: qIter, Priority: prio})
 		prio++
 	}
@@ -525,6 +544,7 @@ func (s *Snapshot) iteratorSources(start, end []byte, reverse bool) ([]merging.I
 		}
 		return nil, err
 	}
+	diskIter = newRangeSpanFilteringIterator(diskIter, appendNewerRangeSpansForSource(nil, queueRangeSpans, -1), s.db)
 	sources = append(sources, merging.IteratorSource{Iter: diskIter, Priority: prio})
 	return sources, nil
 }
@@ -593,6 +613,15 @@ func (s *Snapshot) GetAppend(key, dst []byte) ([]byte, error) {
 		}
 		recordSnapshotRootDomainRead(rootDomainEntrySourceCached, false, len(val))
 		return append(dst, val...), nil
+	}
+	if memtableViewHasRangeSpans(s.view) {
+		if s.backend == nil || s.db == nil {
+			return dst, tree.ErrKeyNotFound
+		}
+		if err := s.db.flushValueLogForBackendRead(); err != nil {
+			return dst, err
+		}
+		return s.backend.GetAppend(key, dst)
 	}
 	snap := rootDomainSnapshotFromCachedSnapshot(s, key)
 	// backendSnapshotLookup (used when a published ref falls back to backend
@@ -840,6 +869,16 @@ func (s *Snapshot) HasMany(keys [][]byte) ([]bool, error) {
 	if s == nil || s.backend == nil {
 		return nil, backenddb.ErrClosed
 	}
+	if memtableViewHasRangeSpans(s.view) {
+		for i, key := range keys {
+			ok, err := s.Has(key)
+			if err != nil {
+				return nil, err
+			}
+			out[i] = ok
+		}
+		return out, nil
+	}
 
 	refs := make([]getManyProbeRef, len(keys))
 	shardCount := len(s.rootPointShards)
@@ -938,6 +977,23 @@ func (s *Snapshot) HasPrefixes(prefixes [][]byte) ([]bool, error) {
 	}
 	if s == nil || s.backend == nil {
 		return nil, backenddb.ErrClosed
+	}
+	if memtableViewHasRangeSpans(s.view) {
+		for i, prefix := range prefixes {
+			it, err := s.Iterator(prefix, rangeSpanPrefixEnd(prefix))
+			if err != nil {
+				return nil, err
+			}
+			out[i] = it.Valid()
+			if err := it.Error(); err != nil {
+				_ = it.Close()
+				return nil, err
+			}
+			if err := it.Close(); err != nil {
+				return nil, err
+			}
+		}
+		return out, nil
 	}
 
 	refs := make([]prefixProbeRef, len(prefixes))

--- a/TreeDB/caching/snapshot.go
+++ b/TreeDB/caching/snapshot.go
@@ -350,11 +350,12 @@ func (s *Snapshot) lookupRootDomainSnapshotEntry(key []byte) (snap rootDomainSna
 		return rootDomainSnapshot{}, nil, page.ValuePtr{}, 0, false, rootDomainEntrySourceNone
 	}
 	if memtableViewHasRangeSpans(s.view) {
-		val, ptr, flags, found = s.lookupEntryWithRangeSpans(key)
+		snap = rootDomainSnapshotFromCachedSnapshot(s, key)
+		val, ptr, flags, found, source = s.db.lookupViewEntryWithRangeSpansAndRootSource(s.view, key, false, snap, true)
 		if found {
-			return rootDomainSnapshot{}, val, ptr, flags, true, rootDomainEntrySourceCached
+			return snap, val, ptr, flags, true, source
 		}
-		return rootDomainSnapshot{}, nil, page.ValuePtr{}, 0, false, rootDomainEntrySourceNone
+		return snap, nil, page.ValuePtr{}, 0, false, rootDomainEntrySourceNone
 	}
 	snap = rootDomainSnapshotFromCachedSnapshot(s, key)
 	val, ptr, flags, found, source = snap.getEntryWithSource(key)

--- a/TreeDB/caching/snapshot.go
+++ b/TreeDB/caching/snapshot.go
@@ -505,7 +505,8 @@ func (s *Snapshot) iteratorSources(start, end []byte, reverse bool) ([]merging.I
 	if s == nil || s.backend == nil {
 		return nil, backenddb.ErrClosed
 	}
-	queue := s.rootIterator.immutables
+	rootSnap := rootDomainIteratorSnapshotFromCachedSnapshot(s)
+	queue := rootSnap.immutables
 	var queueRangeSpans [][]batch.DeleteRange
 	if s.view != nil && len(s.view.queueRangeSpans) == len(queue) {
 		queueRangeSpans = s.view.queueRangeSpans
@@ -531,11 +532,17 @@ func (s *Snapshot) iteratorSources(start, end []byte, reverse bool) ([]merging.I
 	var (
 		diskIter iterator.UnsafeIterator
 		err      error
+		ok       bool
 	)
 	if reverse {
 		diskIter, err = s.backend.ReverseIterator(start, end)
+		ok = true
 	} else {
-		diskIter, err = s.backend.Iterator(start, end)
+		diskIter, ok, err = rootDomainPublishedIterator(rootSnap, start, end)
+		if !ok {
+			diskIter, err = s.backend.Iterator(start, end)
+			ok = true
+		}
 	}
 	if err != nil {
 		for i := range sources {
@@ -545,8 +552,10 @@ func (s *Snapshot) iteratorSources(start, end []byte, reverse bool) ([]merging.I
 		}
 		return nil, err
 	}
-	diskIter = newRangeSpanFilteringIterator(diskIter, appendNewerRangeSpansForSource(nil, queueRangeSpans, -1), s.db)
-	sources = append(sources, merging.IteratorSource{Iter: diskIter, Priority: prio})
+	if ok && diskIter != nil {
+		diskIter = newRangeSpanFilteringIterator(diskIter, appendNewerRangeSpansForSource(nil, queueRangeSpans, -1), s.db)
+		sources = append(sources, merging.IteratorSource{Iter: diskIter, Priority: prio})
+	}
 	return sources, nil
 }
 

--- a/TreeDB/caching/snapshot.go
+++ b/TreeDB/caching/snapshot.go
@@ -535,8 +535,11 @@ func (s *Snapshot) iteratorSources(start, end []byte, reverse bool) ([]merging.I
 		ok       bool
 	)
 	if reverse {
-		diskIter, err = s.backend.ReverseIterator(start, end)
-		ok = true
+		diskIter, ok, err = rootDomainPublishedReverseIterator(rootSnap, start, end)
+		if !ok {
+			diskIter, err = s.backend.ReverseIterator(start, end)
+			ok = true
+		}
 	} else {
 		diskIter, ok, err = rootDomainPublishedIterator(rootSnap, start, end)
 		if !ok {

--- a/TreeDB/command_wal_public_test.go
+++ b/TreeDB/command_wal_public_test.go
@@ -1,6 +1,7 @@
 package treedb
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -1454,6 +1455,15 @@ func TestPublicCommandWALDeleteRangeValueLogPointersReopen(t *testing.T) {
 		_ = db.Close()
 		t.Fatalf("Checkpoint: %v", err)
 	}
+	stats := db.Stats()
+	if got := stats["treedb.cache.range_span.spans_flushed_total"]; got != "1" {
+		_ = db.Close()
+		t.Fatalf("range spans flushed=%s want 1", got)
+	}
+	if got, want := stats["treedb.command_wal.live_covered_max_lsn"], stats["treedb.command_wal.live_accepted_max_lsn"]; got != want {
+		_ = db.Close()
+		t.Fatalf("covered command WAL LSN=%s want accepted max %s", got, want)
+	}
 	if err := db.Close(); err != nil {
 		t.Fatalf("Close: %v", err)
 	}
@@ -1463,6 +1473,11 @@ func TestPublicCommandWALDeleteRangeValueLogPointersReopen(t *testing.T) {
 		t.Fatalf("Reopen: %v", err)
 	}
 	defer reopen.Close()
+	requireRawKVValue(t, reopen, []byte("a"), []byte("left-pointer-value"))
+	requireRawKVValue(t, reopen, []byte("c"), []byte("right-pointer-value"))
+	if _, err := reopen.ValueLogGC(context.Background(), ValueLogGCOptions{}); err != nil {
+		t.Fatalf("ValueLogGC after range checkpoint: %v", err)
+	}
 	requireRawKVValue(t, reopen, []byte("a"), []byte("left-pointer-value"))
 	requireRawKVValue(t, reopen, []byte("c"), []byte("right-pointer-value"))
 	has, err := reopen.Has([]byte("b"))

--- a/TreeDB/db/root_snapshot.go
+++ b/TreeDB/db/root_snapshot.go
@@ -112,6 +112,18 @@ func (s *Snapshot) IteratorAtRootWithOptions(rootID uint64, start, end []byte, o
 	return tr.IteratorWithOptions(start, end, opts), nil
 }
 
+func (s *Snapshot) ReverseIteratorAtRoot(rootID uint64, start, end []byte) (iterator.UnsafeIterator, error) {
+	return s.ReverseIteratorAtRootWithOptions(rootID, start, end, IteratorOptions{})
+}
+
+func (s *Snapshot) ReverseIteratorAtRootWithOptions(rootID uint64, start, end []byte, opts IteratorOptions) (iterator.UnsafeIterator, error) {
+	tr, err := s.treeAtRoot(rootID)
+	if err != nil {
+		return nil, err
+	}
+	return tr.ReverseIteratorWithOptions(start, end, opts), nil
+}
+
 func (s *Snapshot) HasManyAtRoot(rootID uint64, keys [][]byte) ([]bool, error) {
 	out := make([]bool, len(keys))
 	if len(keys) == 0 {

--- a/TreeDB/raw_kv_parity_test.go
+++ b/TreeDB/raw_kv_parity_test.go
@@ -7,6 +7,24 @@ import (
 	"github.com/snissn/gomap/TreeDB/internal/commitlog"
 )
 
+func requireRawKVMissing(t *testing.T, db *DB, key []byte) {
+	t.Helper()
+	got, err := db.Get(key)
+	if err != nil {
+		t.Fatalf("Get(%q): %v", key, err)
+	}
+	if got != nil {
+		t.Fatalf("Get(%q)=%q want missing", key, got)
+	}
+	has, err := db.Has(key)
+	if err != nil {
+		t.Fatalf("Has(%q): %v", key, err)
+	}
+	if has {
+		t.Fatalf("Has(%q)=true, want false", key)
+	}
+}
+
 func requireRawKVValue(t *testing.T, db *DB, key []byte, want []byte) {
 	t.Helper()
 	got, err := db.Get(key)
@@ -267,6 +285,53 @@ func TestReopenEmptyKeyNilValueValueLogPointer(t *testing.T) {
 	requireRawKVValue(t, reopen, []byte{}, []byte("pointer-value"))
 	requireRawKVValue(t, reopen, nil, []byte("pointer-value"))
 	requireRawKVValue(t, reopen, []byte("zero"), []byte{})
+}
+
+func TestCommandWALRawKVDeleteRangeSpanReopen(t *testing.T) {
+	dir := t.TempDir()
+	db, err := Open(Options{
+		Dir:                 dir,
+		Durability:          DurabilityWALOnRelaxed,
+		CommandWAL:          true,
+		CommandWALStatsScan: true,
+	})
+	if err != nil {
+		t.Fatalf("Open command WAL: %v", err)
+	}
+	for _, kv := range []struct{ k, v string }{{"a", "va"}, {"b", "vb"}, {"z", "vz"}} {
+		if err := db.Set([]byte(kv.k), []byte(kv.v)); err != nil {
+			_ = db.Close()
+			t.Fatalf("Set(%s): %v", kv.k, err)
+		}
+	}
+	if err := db.DeleteRange([]byte("a"), []byte("c")); err != nil {
+		_ = db.Close()
+		t.Fatalf("DeleteRange: %v", err)
+	}
+	requireRawKVMissing(t, db, []byte("a"))
+	requireRawKVMissing(t, db, []byte("b"))
+	requireRawKVValue(t, db, []byte("z"), []byte("vz"))
+	stats := db.Stats()
+	if got := stats["treedb.cache.delete_range.materialized_keys_total"]; got != "0" {
+		_ = db.Close()
+		t.Fatalf("materialized_keys_total=%s want 0", got)
+	}
+	if got := stats["treedb.cache.range_span.active_spans"]; got != "1" {
+		_ = db.Close()
+		t.Fatalf("active_spans=%s want 1", got)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	reopen, err := Open(Options{Dir: dir, CommandWALStatsScan: true})
+	if err != nil {
+		t.Fatalf("Reopen command WAL: %v", err)
+	}
+	defer func() { _ = reopen.Close() }()
+	requireRawKVMissing(t, reopen, []byte("a"))
+	requireRawKVMissing(t, reopen, []byte("b"))
+	requireRawKVValue(t, reopen, []byte("z"), []byte("vz"))
 }
 
 func TestCommandWALRawKVParityEmptyKeyNilValueReopen(t *testing.T) {

--- a/benchmarks/geth_hot_kv/harness_test.go
+++ b/benchmarks/geth_hot_kv/harness_test.go
@@ -62,6 +62,7 @@ func TestHarnessExposesReadIntegrityIterationAndCounterLabels(t *testing.T) {
 		"treedb.cache.delete_range.backend_direct_batches_total",
 		"treedb.cache.range_span.layers_total",
 		"treedb.cache.range_span.iterator_skips_total",
+		"treedb.cache.range_span.flush_batches_total",
 		"if hasReadCounterDeltas(runs) {",
 		"if !hasDeleteRangeCounterDeltas(runs) {",
 	} {

--- a/benchmarks/geth_hot_kv/harness_test.go
+++ b/benchmarks/geth_hot_kv/harness_test.go
@@ -60,6 +60,8 @@ func TestHarnessExposesReadIntegrityIterationAndCounterLabels(t *testing.T) {
 		"treedb.cache.delete_range.snapshot_iterators_total",
 		"treedb.cache.delete_range.materialized_keys_total",
 		"treedb.cache.delete_range.backend_direct_batches_total",
+		"treedb.cache.range_span.layers_total",
+		"treedb.cache.range_span.iterator_skips_total",
 		"if hasReadCounterDeltas(runs) {",
 		"if !hasDeleteRangeCounterDeltas(runs) {",
 	} {

--- a/benchmarks/geth_hot_kv/testdata/treedb_nitro_soak.go
+++ b/benchmarks/geth_hot_kv/testdata/treedb_nitro_soak.go
@@ -813,6 +813,20 @@ var interestingStatKeys = []string{
 	"treedb.cache.delete_range.fast_path_clears_total",
 	"treedb.cache.delete_range.backend_direct_batches_total",
 	"treedb.cache.delete_range.backend_direct_keys_total",
+	"treedb.cache.range_span.layers_total",
+	"treedb.cache.range_span.active_layers",
+	"treedb.cache.range_span.active_spans",
+	"treedb.cache.range_span.input_total",
+	"treedb.cache.range_span.effective_total",
+	"treedb.cache.range_span.keys_materialized_total",
+	"treedb.cache.range_span.point_overrides_total",
+	"treedb.cache.range_span.point_probes_total",
+	"treedb.cache.range_span.point_hits_total",
+	"treedb.cache.range_span.iterator_probes_total",
+	"treedb.cache.range_span.iterator_skips_total",
+	"treedb.cache.range_span.range_only_queued_units_total",
+	"treedb.cache.range_span.range_only_flushed_total",
+	"treedb.cache.range_span.spans_flushed_total",
 }
 
 var interestingStatPrefixes = []string{
@@ -831,6 +845,7 @@ var interestingStatPrefixes = []string{
 	"treedb.cache.memtable_adaptive.",
 	"treedb.cache.memtable_stats.",
 	"treedb.cache.memtable_view.",
+	"treedb.cache.range_span.",
 	"treedb.freelist.",
 	"treedb.graveyard.",
 	"treedb.pages.",
@@ -1070,9 +1085,9 @@ func writeStatDeltaSummary(sb *strings.Builder, runs []runResult) {
 		return
 	}
 	sb.WriteString("\n## TreeDB DeleteRange counters\n\n")
-	sb.WriteString("Per-phase DeleteRange deltas from TreeDB `Stat()` output. `input ranges` counts submitted non-empty ranges; `effective ranges` counts ranges after exact adjacent/overlap coalescing in the write plan; materialized keys are copied into point tombstones by the cached fallback.\n\n")
-	sb.WriteString("| engine | read integrity | iteration mode | phase | db calls | batch calls | batch writes | input ranges | effective ranges | coalesced ranges | visited keys | materialized keys | materialized key bytes | tombstone keys | iterators | snapshot iters | backend iters | memtable iters | queue iters | fast clears | backend direct batches | backend direct keys |\n")
-	sb.WriteString("|---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|\n")
+	sb.WriteString("Per-phase DeleteRange deltas from TreeDB `Stat()` output. `input ranges` counts submitted non-empty ranges; `effective ranges` counts ranges after exact adjacent/overlap coalescing in the write plan; materialized keys are copied into point tombstones by the cached fallback. Span columns report command-WAL range-span overlay activity.\n\n")
+	sb.WriteString("| engine | read integrity | iteration mode | phase | db calls | batch calls | batch writes | input ranges | effective ranges | coalesced ranges | visited keys | materialized keys | materialized key bytes | tombstone keys | iterators | snapshot iters | backend iters | memtable iters | queue iters | fast clears | backend direct batches | backend direct keys | span layers | span active | span input | span effective | span materialized keys | span iter probes | span iter skips | span queued units | span flushed | spans flushed |\n")
+	sb.WriteString("|---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|\n")
 	for _, run := range runs {
 		for _, phase := range []string{phaseWrite, phaseRead, phaseIterate, phaseDeleteRange, phaseReopen} {
 			result, ok := run.Phases[phase]
@@ -1082,7 +1097,7 @@ func writeStatDeltaSummary(sb *strings.Builder, runs []runResult) {
 			if !hasAnyStatDeltaValue(result.StatDelta, deleteRangeCounterKeys...) {
 				continue
 			}
-			fmt.Fprintf(sb, "| %s | %s | %s | %s | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d |\n",
+			fmt.Fprintf(sb, "| %s | %s | %s | %s | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d |\n",
 				run.Engine,
 				run.ReadIntegrity,
 				run.IterationMode,
@@ -1105,6 +1120,16 @@ func writeStatDeltaSummary(sb *strings.Builder, runs []runResult) {
 				statDeltaValue(result.StatDelta, "treedb.cache.delete_range.fast_path_clears_total"),
 				statDeltaValue(result.StatDelta, "treedb.cache.delete_range.backend_direct_batches_total"),
 				statDeltaValue(result.StatDelta, "treedb.cache.delete_range.backend_direct_keys_total"),
+				statDeltaValue(result.StatDelta, "treedb.cache.range_span.layers_total"),
+				statDeltaValue(result.StatDelta, "treedb.cache.range_span.active_spans"),
+				statDeltaValue(result.StatDelta, "treedb.cache.range_span.input_total"),
+				statDeltaValue(result.StatDelta, "treedb.cache.range_span.effective_total"),
+				statDeltaValue(result.StatDelta, "treedb.cache.range_span.keys_materialized_total"),
+				statDeltaValue(result.StatDelta, "treedb.cache.range_span.iterator_probes_total"),
+				statDeltaValue(result.StatDelta, "treedb.cache.range_span.iterator_skips_total"),
+				statDeltaValue(result.StatDelta, "treedb.cache.range_span.range_only_queued_units_total"),
+				statDeltaValue(result.StatDelta, "treedb.cache.range_span.range_only_flushed_total"),
+				statDeltaValue(result.StatDelta, "treedb.cache.range_span.spans_flushed_total"),
 			)
 		}
 	}
@@ -1157,6 +1182,17 @@ var deleteRangeCounterKeys = []string{
 	"treedb.cache.delete_range.fast_path_clears_total",
 	"treedb.cache.delete_range.backend_direct_batches_total",
 	"treedb.cache.delete_range.backend_direct_keys_total",
+	"treedb.cache.range_span.layers_total",
+	"treedb.cache.range_span.active_layers",
+	"treedb.cache.range_span.active_spans",
+	"treedb.cache.range_span.input_total",
+	"treedb.cache.range_span.effective_total",
+	"treedb.cache.range_span.keys_materialized_total",
+	"treedb.cache.range_span.iterator_probes_total",
+	"treedb.cache.range_span.iterator_skips_total",
+	"treedb.cache.range_span.range_only_queued_units_total",
+	"treedb.cache.range_span.range_only_flushed_total",
+	"treedb.cache.range_span.spans_flushed_total",
 }
 
 func hasDeleteRangeCounterDeltas(runs []runResult) bool {

--- a/benchmarks/geth_hot_kv/testdata/treedb_nitro_soak.go
+++ b/benchmarks/geth_hot_kv/testdata/treedb_nitro_soak.go
@@ -827,6 +827,7 @@ var interestingStatKeys = []string{
 	"treedb.cache.range_span.range_only_queued_units_total",
 	"treedb.cache.range_span.range_only_flushed_total",
 	"treedb.cache.range_span.spans_flushed_total",
+	"treedb.cache.range_span.flush_batches_total",
 }
 
 var interestingStatPrefixes = []string{
@@ -1086,8 +1087,8 @@ func writeStatDeltaSummary(sb *strings.Builder, runs []runResult) {
 	}
 	sb.WriteString("\n## TreeDB DeleteRange counters\n\n")
 	sb.WriteString("Per-phase DeleteRange deltas from TreeDB `Stat()` output. `input ranges` counts submitted non-empty ranges; `effective ranges` counts ranges after exact adjacent/overlap coalescing in the write plan; materialized keys are copied into point tombstones by the cached fallback. Span columns report command-WAL range-span overlay activity.\n\n")
-	sb.WriteString("| engine | read integrity | iteration mode | phase | db calls | batch calls | batch writes | input ranges | effective ranges | coalesced ranges | visited keys | materialized keys | materialized key bytes | tombstone keys | iterators | snapshot iters | backend iters | memtable iters | queue iters | fast clears | backend direct batches | backend direct keys | span layers | span active | span input | span effective | span materialized keys | span iter probes | span iter skips | span queued units | span flushed | spans flushed |\n")
-	sb.WriteString("|---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|\n")
+	sb.WriteString("| engine | read integrity | iteration mode | phase | db calls | batch calls | batch writes | input ranges | effective ranges | coalesced ranges | visited keys | materialized keys | materialized key bytes | tombstone keys | iterators | snapshot iters | backend iters | memtable iters | queue iters | fast clears | backend direct batches | backend direct keys | span layers | span active | span input | span effective | span materialized keys | span iter probes | span iter skips | span queued units | span flushed | spans flushed | span flush batches |\n")
+	sb.WriteString("|---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|\n")
 	for _, run := range runs {
 		for _, phase := range []string{phaseWrite, phaseRead, phaseIterate, phaseDeleteRange, phaseReopen} {
 			result, ok := run.Phases[phase]
@@ -1097,7 +1098,7 @@ func writeStatDeltaSummary(sb *strings.Builder, runs []runResult) {
 			if !hasAnyStatDeltaValue(result.StatDelta, deleteRangeCounterKeys...) {
 				continue
 			}
-			fmt.Fprintf(sb, "| %s | %s | %s | %s | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d |\n",
+			fmt.Fprintf(sb, "| %s | %s | %s | %s | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d |\n",
 				run.Engine,
 				run.ReadIntegrity,
 				run.IterationMode,
@@ -1130,6 +1131,7 @@ func writeStatDeltaSummary(sb *strings.Builder, runs []runResult) {
 				statDeltaValue(result.StatDelta, "treedb.cache.range_span.range_only_queued_units_total"),
 				statDeltaValue(result.StatDelta, "treedb.cache.range_span.range_only_flushed_total"),
 				statDeltaValue(result.StatDelta, "treedb.cache.range_span.spans_flushed_total"),
+				statDeltaValue(result.StatDelta, "treedb.cache.range_span.flush_batches_total"),
 			)
 		}
 	}
@@ -1193,6 +1195,7 @@ var deleteRangeCounterKeys = []string{
 	"treedb.cache.range_span.range_only_queued_units_total",
 	"treedb.cache.range_span.range_only_flushed_total",
 	"treedb.cache.range_span.spans_flushed_total",
+	"treedb.cache.range_span.flush_batches_total",
 }
 
 func hasDeleteRangeCounterDeltas(runs []runResult) bool {

--- a/scripts/treedb_geth_hot_kv_matrix.sh
+++ b/scripts/treedb_geth_hot_kv_matrix.sh
@@ -271,6 +271,20 @@ stat_key_groups = {
     'delete_range_fast_path_clears': ['treedb.cache.delete_range.fast_path_clears_total'],
     'delete_range_backend_direct_batches': ['treedb.cache.delete_range.backend_direct_batches_total'],
     'delete_range_backend_direct_keys': ['treedb.cache.delete_range.backend_direct_keys_total'],
+    'range_span_layers': ['treedb.cache.range_span.layers_total'],
+    'range_span_active_layers': ['treedb.cache.range_span.active_layers'],
+    'range_span_active_spans': ['treedb.cache.range_span.active_spans'],
+    'range_span_input': ['treedb.cache.range_span.input_total'],
+    'range_span_effective': ['treedb.cache.range_span.effective_total'],
+    'range_span_keys_materialized': ['treedb.cache.range_span.keys_materialized_total'],
+    'range_span_point_overrides': ['treedb.cache.range_span.point_overrides_total'],
+    'range_span_point_probes': ['treedb.cache.range_span.point_probes_total'],
+    'range_span_point_hits': ['treedb.cache.range_span.point_hits_total'],
+    'range_span_iterator_probes': ['treedb.cache.range_span.iterator_probes_total'],
+    'range_span_iterator_skips': ['treedb.cache.range_span.iterator_skips_total'],
+    'range_span_range_only_queued_units': ['treedb.cache.range_span.range_only_queued_units_total'],
+    'range_span_range_only_flushed': ['treedb.cache.range_span.range_only_flushed_total'],
+    'range_span_spans_flushed': ['treedb.cache.range_span.spans_flushed_total'],
 }
 
 vlog_stat_names = [
@@ -287,6 +301,10 @@ delete_range_stat_names = [
     'delete_range_memtable_iterators', 'delete_range_queue_iterators', 'delete_range_visited_keys', 'delete_range_tombstone_keys',
     'delete_range_materialized_keys', 'delete_range_materialized_key_bytes',
     'delete_range_fast_path_clears', 'delete_range_backend_direct_batches', 'delete_range_backend_direct_keys',
+    'range_span_layers', 'range_span_active_layers', 'range_span_active_spans',
+    'range_span_input', 'range_span_effective', 'range_span_keys_materialized',
+    'range_span_iterator_probes', 'range_span_iterator_skips',
+    'range_span_range_only_queued_units', 'range_span_range_only_flushed', 'range_span_spans_flushed',
 ]
 
 def fmt(n):
@@ -443,11 +461,11 @@ with open(md, 'w') as out:
     delete_phase_rows = [(r, phase, vals) for r, phase, vals in phase_rows if any(vals[name] for name in delete_range_stat_names)]
     if delete_phase_rows:
         out.write('\n## TreeDB DeleteRange counters\n\n')
-        out.write('Per-phase DeleteRange counters from TreeDB `Stat()`. Input ranges are submitted non-empty ranges; effective ranges are exact adjacent/overlap-coalesced write-plan ranges; materialized keys are copied into point tombstones by the cached fallback. Full machine-readable counters are in `phase_counters.tsv`; all nonzero parseable TreeDB stat deltas are in `phase_stat_deltas.tsv`.\n\n')
-        out.write('| key shape | value size | batch target bytes | read-integrity | iteration mode | engine | phase | db calls | batch calls | batch writes | input ranges | effective ranges | coalesced ranges | visited keys | materialized keys | materialized key bytes | tombstone keys | iterators | snapshot iters | backend iters | memtable iters | queue iters | fast clears | backend direct batches | backend direct keys |\n')
-        out.write('|---|---:|---:|---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|\n')
+        out.write('Per-phase DeleteRange counters from TreeDB `Stat()`. Input ranges are submitted non-empty ranges; effective ranges are exact adjacent/overlap-coalesced write-plan ranges; materialized keys are copied into point tombstones by the cached fallback. Span columns report command-WAL range-span overlay activity. Full machine-readable counters are in `phase_counters.tsv`; all nonzero parseable TreeDB stat deltas are in `phase_stat_deltas.tsv`.\n\n')
+        out.write('| key shape | value size | batch target bytes | read-integrity | iteration mode | engine | phase | db calls | batch calls | batch writes | input ranges | effective ranges | coalesced ranges | visited keys | materialized keys | materialized key bytes | tombstone keys | iterators | snapshot iters | backend iters | memtable iters | queue iters | fast clears | backend direct batches | backend direct keys | span layers | span active | span input | span effective | span materialized keys | span iter probes | span iter skips | span queued units | span flushed | spans flushed |\n')
+        out.write('|---|---:|---:|---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|\n')
         for r, phase, vals in delete_phase_rows:
-            out.write('| {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} |\n'.format(
+            cells = [
                 r['key_shape'], fmt(r['value_size']), fmt(r['batch_target_bytes']), r['read_integrity'],
                 r['iteration_mode'], r['engine'], phase,
                 fmt(vals['delete_range_calls']), fmt(vals['delete_range_batch_calls']), fmt(vals['delete_range_batch_writes']),
@@ -458,7 +476,14 @@ with open(md, 'w') as out:
                 fmt(vals['delete_range_backend_iterators']), fmt(vals['delete_range_memtable_iterators']),
                 fmt(vals['delete_range_queue_iterators']),
                 fmt(vals['delete_range_fast_path_clears']), fmt(vals['delete_range_backend_direct_batches']),
-                fmt(vals['delete_range_backend_direct_keys'])))
+                fmt(vals['delete_range_backend_direct_keys']),
+                fmt(vals['range_span_layers']), fmt(vals['range_span_active_spans']),
+                fmt(vals['range_span_input']), fmt(vals['range_span_effective']),
+                fmt(vals['range_span_keys_materialized']), fmt(vals['range_span_iterator_probes']),
+                fmt(vals['range_span_iterator_skips']), fmt(vals['range_span_range_only_queued_units']),
+                fmt(vals['range_span_range_only_flushed']), fmt(vals['range_span_spans_flushed']),
+            ]
+            out.write('| ' + ' | '.join(cells) + ' |\n')
 
 PY
 

--- a/scripts/treedb_geth_hot_kv_matrix.sh
+++ b/scripts/treedb_geth_hot_kv_matrix.sh
@@ -285,6 +285,7 @@ stat_key_groups = {
     'range_span_range_only_queued_units': ['treedb.cache.range_span.range_only_queued_units_total'],
     'range_span_range_only_flushed': ['treedb.cache.range_span.range_only_flushed_total'],
     'range_span_spans_flushed': ['treedb.cache.range_span.spans_flushed_total'],
+    'range_span_flush_batches': ['treedb.cache.range_span.flush_batches_total'],
 }
 
 vlog_stat_names = [
@@ -305,6 +306,7 @@ delete_range_stat_names = [
     'range_span_input', 'range_span_effective', 'range_span_keys_materialized',
     'range_span_iterator_probes', 'range_span_iterator_skips',
     'range_span_range_only_queued_units', 'range_span_range_only_flushed', 'range_span_spans_flushed',
+    'range_span_flush_batches',
 ]
 
 def fmt(n):
@@ -462,8 +464,8 @@ with open(md, 'w') as out:
     if delete_phase_rows:
         out.write('\n## TreeDB DeleteRange counters\n\n')
         out.write('Per-phase DeleteRange counters from TreeDB `Stat()`. Input ranges are submitted non-empty ranges; effective ranges are exact adjacent/overlap-coalesced write-plan ranges; materialized keys are copied into point tombstones by the cached fallback. Span columns report command-WAL range-span overlay activity. Full machine-readable counters are in `phase_counters.tsv`; all nonzero parseable TreeDB stat deltas are in `phase_stat_deltas.tsv`.\n\n')
-        out.write('| key shape | value size | batch target bytes | read-integrity | iteration mode | engine | phase | db calls | batch calls | batch writes | input ranges | effective ranges | coalesced ranges | visited keys | materialized keys | materialized key bytes | tombstone keys | iterators | snapshot iters | backend iters | memtable iters | queue iters | fast clears | backend direct batches | backend direct keys | span layers | span active | span input | span effective | span materialized keys | span iter probes | span iter skips | span queued units | span flushed | spans flushed |\n')
-        out.write('|---|---:|---:|---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|\n')
+        out.write('| key shape | value size | batch target bytes | read-integrity | iteration mode | engine | phase | db calls | batch calls | batch writes | input ranges | effective ranges | coalesced ranges | visited keys | materialized keys | materialized key bytes | tombstone keys | iterators | snapshot iters | backend iters | memtable iters | queue iters | fast clears | backend direct batches | backend direct keys | span layers | span active | span input | span effective | span materialized keys | span iter probes | span iter skips | span queued units | span flushed | spans flushed | span flush batches |\n')
+        out.write('|---|---:|---:|---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|\n')
         for r, phase, vals in delete_phase_rows:
             cells = [
                 r['key_shape'], fmt(r['value_size']), fmt(r['batch_target_bytes']), r['read_integrity'],
@@ -482,6 +484,7 @@ with open(md, 'w') as out:
                 fmt(vals['range_span_keys_materialized']), fmt(vals['range_span_iterator_probes']),
                 fmt(vals['range_span_iterator_skips']), fmt(vals['range_span_range_only_queued_units']),
                 fmt(vals['range_span_range_only_flushed']), fmt(vals['range_span_spans_flushed']),
+                fmt(vals['range_span_flush_batches']),
             ]
             out.write('| ' + ' | '.join(cells) + ' |\n')
 


### PR DESCRIPTION
## Latest review blocker: ordinary DeleteRange preserving active spans

Addressed in `a92fd2462`: ordinary WAL-off `DeleteRange` now treats queued command-WAL range-span layers as visibility state with their own bounds. The in-memory clear/drop fast paths only discard span-only queued units when the new delete range actually covers the span bounds; disjoint ordinary deletes preserve the older active span.

Regression coverage added:

- `TestCachingDB_CommandWALRangeSpanSurvivesDisjointOrdinaryDeleteRange` seeds backend key `b`, queues active span `[a,c)`, runs ordinary `DeleteRange([x,z))`, and verifies `b` stays hidden both before and after checkpoint with `active_spans=1` before checkpoint.

Focused validation on `a92fd2462`:

- `go test ./TreeDB/caching -run 'TestCachingDB_CommandWALRangeSpan' -count=1`
- `go test ./TreeDB/caching ./TreeDB ./benchmarks/geth_hot_kv -count=1`

30k TreeDB geth-hot-KV smoke on `a92fd2462`:

- run dir: `/tmp/geth_hotkv_2736_remote_30k_20260614T105743Z`
- geth worktree: `/tmp/go-ethereum_treedb_refresh_2736` at `b8082ae45`, run with `GOWORK=off`, `GOTOOLCHAIN=go1.26.0`, and a temporary `-modfile` replacing `github.com/snissn/gomap` with this PR worktree
- matrix row: write **235,629 ops/sec**, read **343,263 ops/sec**, iterate **6,814,440 keys/sec**, DeleteRange **526,011 keys/sec**, size **27,125,444 bytes**, post-delete **15,791,842 bytes**
- DeleteRange counters: `materialized_keys=0`, `range_span_layers=152`, `range_span_input=300`, `range_span_effective=300`, `range_only_queued_units=152`, `range_only_flushed=152`, `spans_flushed=300`, `span_flush_batches=1`

1M TreeDB geth-hot-KV evidence on `a92fd2462`:

- run dir: `/tmp/geth_hotkv_2736_remote_1m_20260614T105818Z`
- same geth worktree/toolchain setup; `KEYS=1000000 READS=400000`
- matrix row: write **643,228 ops/sec**, read **256,724 ops/sec**, iterate **6,192,367 keys/sec**, DeleteRange **246,911 keys/sec**, size **771,304,384 bytes**, post-delete **393,821,731 bytes**
- DeleteRange counters: `materialized_keys=0`, `range_span_layers=5050`, `range_span_input=10000`, `range_span_effective=10000`, `range_only_queued_units=5050`, `range_only_flushed=5050`, `spans_flushed=10000`, `span_flush_batches=5`

CI for head `a92fd2462` is green; Codex reviewed `a92fd2462a` with no major issues; all review threads are resolved. This remains local/benchmark evidence only and does not claim public-testnet readiness.

## Latest review blocker: backend bypass across active range spans

Addressed in `e75026fa`: active range spans now block direct-to-backend point write bypass/streaming paths. While a span-only command-WAL `DeleteRange` unit is queued, later point batches stay on the cached memtable path so their newer writes remain above the older span and survive checkpoint.

Regression coverage added:

- `TestCachingDB_CommandWALRangeSpanBlocksLaterWriteSyncBypass` queues `DeleteRangeAfterCommandWALAppend("a", "c")`, then writes `b=new` through a regular `NewBatch().WriteSync()` while the span is active, and verifies `b` is visible before and after checkpoint.

Focused validation on `e75026fa0976f2f1a8f72ec09626d16da86339fd`:

- `go test ./TreeDB/caching -run 'TestCachingDB_CommandWALRangeSpan' -count=1`
- `go test ./TreeDB/caching ./TreeDB ./benchmarks/geth_hot_kv -count=1`

30k TreeDB geth-hot-KV smoke on `e75026fa`:

- run dir: `/tmp/geth_hotkv_2736_remote_30k_20260614T004419Z`
- geth worktree: `/tmp/go-ethereum_treedb_refresh_2736` at `b8082ae45`, run with `GOWORK=off`, `GOTOOLCHAIN=go1.26.0`, and a temporary `-modfile` replacing `github.com/snissn/gomap` with this PR worktree
- matrix row: write **229,318 ops/sec**, read **370,433 ops/sec**, iterate **7,079,040 keys/sec**, DeleteRange **568,255 keys/sec**, size **27,125,444 bytes**, post-delete **15,791,842 bytes**
- DeleteRange counters (`phase_counters.tsv`): `materialized_keys=0`, `range_span_layers=152`, `range_span_input=300`, `range_span_effective=300`, `range_only_queued_units=152`, `range_only_flushed=152`, `spans_flushed=300`, `span_flush_batches=1`

CI for head `e75026fa` is green; PR remains draft/WIP until AI review gates are clean. This remains local/benchmark evidence only and does not claim public-testnet readiness.

## Latest review blockers: root-ID active-span reads and reverse iterators

Addressed in `4df9f738`: active-span point lookup now treats `publishedRootID` as authoritative, resolving it through a backend snapshot when the published lookup object is absent and otherwise returning a terminal root-bound miss instead of falling through to the backend default root. Live and snapshot reverse iterators now open from the pinned published iterator root (including root-ID-backed roots) before applying range-span filtering.

Regression coverage added/extended:

- `TestCachingDB_CommandWALRangeSpanPreservesPublishedRootMiss` now covers live `Get`, `GetAppend`, and `Has` for a root-ID-only published root A where A lacks `m`, the backend default root later contains `m`, and the active span is outside `m`; live reads keep `m` missing and still resolve a root-A hit.
- `TestCachingDB_CommandWALRangeSpanIteratorPreservesPublishedRoot` now covers live and snapshot `ReverseIterator("m", "n")` in the same root-domain scenario, in addition to forward iterators and prefix probes.
- `TestCachingDB_CommandWALRangeSpanVisibilitySnapshotsAndCheckpoint` now includes explicit snapshot `GetAppend` assertions through active spans.

Focused validation on `4df9f738172f9717949bdfe67d64cf1f74d09004`:

- `go test ./TreeDB/caching -run 'TestCachingDB_CommandWALRangeSpan' -count=1`
- `go test ./TreeDB/caching ./TreeDB ./benchmarks/geth_hot_kv -count=1`
- `go test ./TreeDB/db -run 'Test.*Root|Test.*Reverse|TestSnapshot' -count=1`

30k TreeDB geth-hot-KV smoke on the latest head:

- run dir: `/tmp/geth_hotkv_2736_remote_30k_20260614T002520Z`
- geth worktree: `/tmp/go-ethereum_treedb_refresh_2736` at `b8082ae45`, run with `GOWORK=off`, `GOTOOLCHAIN=go1.26.0`, and a temporary `-modfile` replacing `github.com/snissn/gomap` with this PR worktree
- matrix row: write **232,266 ops/sec**, read **386,784 ops/sec**, iterate **7,137,691 keys/sec**, DeleteRange **559,272 keys/sec**, size **27,125,444 bytes**, post-delete **15,791,842 bytes**
- DeleteRange counters (`phase_counters.tsv`): `materialized_keys=0`, `range_span_layers=152`, `range_span_input=300`, `range_span_effective=300`, `range_only_queued_units=152`, `range_only_flushed=152`, `spans_flushed=300`, `span_flush_batches=1`

CI for head `4df9f738` is running; PR remains draft/WIP until CI and AI review gates are clean. This evidence is benchmark/local correctness evidence only and does not claim public-testnet readiness.

## Latest review blocker: iterators/prefix probes through active spans

Codex P1 on active-span iterators crossing from a pinned published root to the backend default root is addressed in `805f8d7c`: live and snapshot forward iterator construction now uses the applicable published iterator root when one is pinned, then applies newer range-span filtering on top. This keeps iterator and active-span prefix-probe behavior root-bound instead of falling through to the default backend root.

Regression coverage added: `TestCachingDB_CommandWALRangeSpanIteratorPreservesPublishedRoot` creates root A without key `m`, advances the backend default root to contain `m`, queues an active range span outside `m`, and verifies both live and snapshot `Iterator("m", "n")` are empty; it also verifies live and snapshot `HasPrefixes("m")` stay false.

Focused validation after this fix:

- `go test ./TreeDB/caching -run 'TestCachingDB_CommandWALRangeSpanIteratorPreservesPublishedRoot' -count=1`
- `go test ./TreeDB/caching -run 'TestCachingDB_CommandWALRangeSpanIteratorPreservesPublishedRoot|TestCachingDB_CommandWALRangeSpanPreservesPublishedRootMiss|TestCachingDB_CommandWALRangeSpanFiltersPublishedRoot|TestCachingDB_CommandWALRangeSpanVisibilitySnapshotsAndCheckpoint|TestCachingDB_CommandWALRangeSpanFlushCollectionRespectsLaneBarriers|TestCachingDB_CommandWALRangeSpanCheckpointCombinesFlushUnits|TestCachingBatch_CommandWALRangeOnlyUsesSpanLayer' -count=1`
- `go test ./TreeDB/caching ./TreeDB ./benchmarks/geth_hot_kv`

## Latest review blocker: root-bound misses through active spans

Codex P1 on active-span published-root misses is addressed in `c903f1be`: when the applicable published root is probed and misses, span-aware lookup now returns a terminal not-found marker instead of `found=false`, preventing `Snapshot.Get`/`GetAppend` (and live view paths) from falling through to the default backend root and crossing root domains.

Regression coverage added: `TestCachingDB_CommandWALRangeSpanPreservesPublishedRootMiss` creates published root A without key `m`, advances the backend default root to contain `m`, queues an active range span outside `m`, then verifies a snapshot pinned to root A still reports `m` missing for both `Get` and `GetAppend`.

Focused validation after this fix:

- `go test ./TreeDB/caching -run 'TestCachingDB_CommandWALRangeSpanPreservesPublishedRootMiss' -count=1`
- `go test ./TreeDB/caching -run 'TestCachingDB_CommandWALRangeSpanPreservesPublishedRootMiss|TestCachingDB_CommandWALRangeSpanFiltersPublishedRoot|TestCachingDB_CommandWALRangeSpanVisibilitySnapshotsAndCheckpoint|TestCachingDB_CommandWALRangeSpanFlushCollectionRespectsLaneBarriers|TestCachingDB_CommandWALRangeSpanCheckpointCombinesFlushUnits|TestCachingBatch_CommandWALRangeOnlyUsesSpanLayer' -count=1`
- `go test ./TreeDB/caching ./TreeDB ./benchmarks/geth_hot_kv`

## Latest review blocker: published-root lookups with active spans

Codex P1 on active range spans bypassing published-root lookups is addressed in `60b411fb`: after scanning mutable/queued tables and range-span layers, span-aware point lookup now probes the applicable published root snapshot instead of falling through to the backend default lookup. Snapshot lookup uses the same helper with source attribution preserved, so published-root hits remain visible outside active spans while covered root keys stay hidden and newer queued/mutable overrides still win.

Regression coverage added: `TestCachingDB_CommandWALRangeSpanFiltersPublishedRoot` installs a root-only published point set, queues an active command-WAL `DeleteRange` span, and verifies live + snapshot `Get`/`GetAppend` behavior for:

- key outside span from published root remains visible
- key inside span from published root is hidden
- newer override inside the span is visible

Focused validation after this fix:

- `go test ./TreeDB/caching -run 'TestCachingDB_CommandWALRangeSpanFiltersPublishedRoot' -count=1`
- `go test ./TreeDB/caching -run 'TestCachingDB_CommandWALRangeSpanFiltersPublishedRoot|TestCachingDB_CommandWALRangeSpanVisibilitySnapshotsAndCheckpoint|TestCachingDB_CommandWALRangeSpanFlushCollectionRespectsLaneBarriers|TestCachingDB_CommandWALRangeSpanCheckpointCombinesFlushUnits|TestCachingBatch_CommandWALRangeOnlyUsesSpanLayer' -count=1`
- `go test ./TreeDB/caching -count=1`
- `go test ./TreeDB/caching ./TreeDB ./benchmarks/geth_hot_kv`

## Latest review blocker: range-span barriers across lanes

Codex P1 on multi-lane ordering is addressed in `43270df3`: range-span flush collection now treats span units as global barriers across lanes. A span can only be collected at the global queue head (or after already-collected consecutive span-only units), so older point units from any lane must flush before it and newer point units from any lane cannot pass it. `flushAllLocked` now re-runs lane passes while progress is made so a lane that was initially blocked by another lane's older point unit can flush the span after that point unit drains.

Regression coverage added: `TestCachingDB_CommandWALRangeSpanFlushCollectionRespectsLaneBarriers` builds multi-lane point/span queues and asserts both older-point-before-span and span-before-newer-point barriers, plus checkpoint drains active spans and leaves the deleted key missing.

Focused validation after this fix:

- `go test ./TreeDB/caching -run 'TestCachingDB_CommandWALRangeSpanFlushCollectionRespectsLaneBarriers|TestCachingDB_CommandWALRangeSpanCheckpointCombinesFlushUnits' -count=1`
- `go test ./TreeDB/caching ./TreeDB ./benchmarks/geth_hot_kv`
- 30k geth-hot-KV smoke after barrier fix: `/tmp/geth_hotkv_2736_barrier_30k_20260613T124032Z/matrix_results.md`; DeleteRange **558,670 keys/sec**, materialized keys = 0, span flush batches = 1.

## Draft / WIP status — keep draft

This PR remains **draft/WIP**. The prior 30k geth-hot-KV `DeleteRange` blocker has been profiled and a targeted fix has been pushed, but this should not be marked ready/mergeable until review and any requested broader benchmark confirmation complete.

## Blocker attribution and targeted fix

Focused 30k split run before the fix showed the range-span overlay itself was not the cost:

- DB-level `DeleteRange` loop: **4.84 ms** for 150 range calls / 150 queued span layers.
- Batched `DeleteRange` loop: **1.22 ms** for 2 batch writes / 2 queued span layers.
- `SyncKeyValue()` / checkpoint: **1.119 s**.
- Checkpoint counters: `range_only_flushed=152`, `spans_flushed=300`, `checkpoint.runs=1`, `command_wal.checkpoint_publish.separate=1`, `freelist.alloc_pages_total=325`, `freelist.free_pages_total=327`.

CPU profile attribution for the slow run:

- `caching.(*DB).flushLaneOnceWithCommandPublish` / `flushAllLocked`: 80% cumulative sampled CPU.
- `db.(*Batch).WriteSync` / backend commit: 70% cumulative sampled CPU.
- Most flat samples were syscall I/O; wall time was checkpoint/backend apply, not span visibility or key materialization.

Exact hotspot: `collectFlushUnitsLocked` forced **one range-only queued unit per backend `WriteSync`**, so 152 small command-WAL range-span units became 152 backend sync/apply commits during checkpoint.

Targeted fix in `3297fdf5`: combine consecutive span-only flush units into one backend batch (bounded by `flushRangeSpanCombineMaxUnits`) without crossing point-write units. Added `treedb.cache.range_span.flush_batches_total` to prove the split.

## Current 30k evidence after fix

Focused split run after fix:

- DB-level `DeleteRange` loop: **3.24 ms**.
- Batched `DeleteRange` loop: **1.12 ms**.
- `SyncKeyValue()` / checkpoint: **24.42 ms**.
- Total delete phase: **30.96 ms**, **~968,798 keys/sec** in the split harness.
- Checkpoint counters: `range_only_flushed=152`, `spans_flushed=300`, but now only **1** range-span flush batch.

Profile/matrix capture after fix:

```sh
GETH_REPO=/Users/michaelseiler/dev/snissn/go-ethereum \
GOFLAGS='-modfile=go.gomap2736.mod' \
PROFILE_DIR=/tmp/geth_hotkv_2736_final_profiles_30k_20260613T115701Z \
PROFILE_ENGINES=treedb ENGINES=treedb KEYS=30000 READS=12000 \
KEY_SHAPES=geth-mixed VALUE_SHAPES=geth-mixed VALUE_SIZES=128 \
BATCH_TARGET_BYTES=102400 TREEDB_READ_INTEGRITIES=verify \
ITERATION_MODES=value \
RUN_DIR=/tmp/geth_hotkv_2736_final_profile_30k_20260613T115701Z \
scripts/treedb_geth_hot_kv_matrix.sh
```

Artifacts:

- `/tmp/geth_hotkv_2736_final_profile_30k_20260613T115701Z/matrix_results.md`
- `/tmp/geth_hotkv_2736_final_profiles_30k_20260613T115701Z/.../cpu_delete_range_treedb.pprof`

After-fix matrix row:

- write: 174,848 ops/sec
- read: 424,196 ops/sec
- iterate: 8,607,395 keys/sec
- DeleteRange: **904,392 keys/sec**
- DeleteRange duration: **33 ms**
- size: 27,125,441 bytes; post-delete: 15,791,839 bytes
- DeleteRange counters: materialized keys = 0; range-span layers = 152; input/effective spans = 300/300; range-only queued/flushed units = 152/152; spans flushed = 300; **span flush batches = 1**

The post-fix CPU profile is too short to accumulate meaningful samples (10 ms total samples, runtime allocation only), consistent with the phase no longer being checkpoint/backend-sync bound.

## Summary

Implements #2711 R1 candidate: a cached command-WAL `DeleteRange` range-span overlay with no persistent B-tree/page format changes.

- Adds immutable queued range-span layers for command-WAL cached mode instead of materializing per-key tombstones for range-only deletes.
- Makes live reads, snapshots, `HasMany`/prefix probes, and forward/reverse iterators span-aware, including newer point writes overriding older spans.
- Flushes span-only queued units through existing backend `Batch.DeleteRange`, with range-only span units combined at checkpoint to avoid one backend sync per range call.
- Keeps mixed point+range command-WAL batches on the conservative materialized path.
- Adds `treedb.cache.range_span.*` counters and teaches geth-hot-KV reports to surface them.

## Correctness / invariants

- Command WAL remains the durable source before checkpoint; range spans are only cached visibility overlays.
- Checkpoint drains spans through the existing backend delete-range API.
- Active spans leave backend pointers in place until checkpoint, conservatively protecting snapshots and value-log references.
- Value-log pointer reopen + GC coverage is extended for the checkpointed range-delete case.
- Consecutive range-only span layers are safe to combine because range deletes commute; the combiner does not cross point-write units.

## Tests run locally

- `go test ./TreeDB/caching -run 'TestCachingDB_CommandWALRangeSpanCheckpointCombinesFlushUnits' -count=1`
- `go test ./TreeDB/caching`
- `go test ./TreeDB ./TreeDB/caching ./benchmarks/geth_hot_kv`
- `go test ./...`

Note: one earlier full-suite attempt hit a transient `TreeDB/mongo_gateway` timeout; rerunning that package-specific test passed, and the final `go test ./...` passed.











<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reverse iterator APIs for root-scoped operations.
  * Introduced atomic metrics counters for tracking range-span lifecycle and behavior.

* **Tests**
  * Expanded test coverage with comprehensive command-WAL range-span validation and boundary condition testing.
  * Added helper functions for range-span and raw key-value assertion checks.

* **Chores**
  * Updated benchmark harness and reporting scripts to track new range-span instrumentation metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->