### PR TITLE
TreeDB text v2: reduce posting scan allocations

### DIFF
--- a/TreeDB/collections/text_v2_blockmax_test.go
+++ b/TreeDB/collections/text_v2_blockmax_test.go
@@ -84,6 +84,33 @@ func TestTextV2BlockMaxMultiTermANDExactParitySkipsAndLazyDetails2688(t *testing
 	}
 }
 
+func TestTextV2BlockMaxSingleTermOverlappingMutationFallsBackExact2728(t *testing.T) {
+	d := openTextV2TestDB(t, t.TempDir(), false)
+	defer func() { _ = d.Close() }()
+	ids, docs := textV2BlockMaxFixtureDocs2628(256, 8)
+	col := createTextSearchCollection2627(t, d, "docs", TextIndexDefinition{Name: "lexical", Version: TextIndexVersionV2, Fields: []TextIndexField{{Field: "title", Weight: 5}, {Field: "body"}}}, ids, docs)
+	if _, _, err := col.Update([]byte("doc-000042"), func([]byte) ([]byte, bool, error) {
+		return []byte(`{"title":"refund refund refund","body":"refund refund"}`), true, nil
+	}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	opts := TextSearchOptions{IndexName: "lexical", Query: "refund", TopK: 5, CandidateLimit: len(ids), MaxPostingsScanned: len(ids) * 4}
+	exhaustiveOpts := opts
+	exhaustiveOpts.textV2DisableBlockMax = true
+	exhaustive, err := col.searchText(exhaustiveOpts, textSearchResultScoreOnly)
+	if err != nil {
+		t.Fatalf("exhaustive update search: %v", err)
+	}
+	got, err := col.searchText(opts, textSearchResultScoreOnly)
+	if err != nil {
+		t.Fatalf("block-max update search: %v", err)
+	}
+	assertTextSearchParity2627(t, got, exhaustive)
+	if got.Stats.TextBlockMaxFallbacks == 0 || got.Stats.DocumentsFetched != 0 || got.Stats.TextStateLookups != 0 || got.Stats.FailClosed != 0 {
+		t.Fatalf("stats=%+v want exact fallback for overlapping single-term mutation blocks without docs/state/fail", got.Stats)
+	}
+}
+
 func TestTextV2BlockMaxMultiTermANDOverlappingMutationFallsBackExact2688(t *testing.T) {
 	d := openTextV2TestDB(t, t.TempDir(), false)
 	defer func() { _ = d.Close() }()

--- a/TreeDB/collections/text_v2_posting_blocks.go
+++ b/TreeDB/collections/text_v2_posting_blocks.go
@@ -206,13 +206,17 @@ func decodeTextV2PostingBlockValue(raw []byte) (textV2PostingBlockValue, error) 
 	}
 	value := scanner.block
 	value.Entries = make([]textV2PostingBlockEntry, 0, scanner.block.Summary.DocCount)
+	fieldCount := len(scanner.block.Summary.MaxFieldTermFrequencies)
+	fieldArena := make([]uint32, 0, int(scanner.block.Summary.DocCount)*fieldCount)
 	var entry textV2PostingBlockEntry
 	for scanner.Next(&entry) {
+		fieldOffset := len(fieldArena)
+		fieldArena = append(fieldArena, entry.FieldFrequencies...)
 		value.Entries = append(value.Entries, textV2PostingBlockEntry{
 			Ordinal:          entry.Ordinal,
 			Generation:       entry.Generation,
 			TermFrequency:    entry.TermFrequency,
-			FieldFrequencies: append([]uint32(nil), entry.FieldFrequencies...),
+			FieldFrequencies: fieldArena[fieldOffset:len(fieldArena):len(fieldArena)],
 			Flags:            entry.Flags,
 		})
 	}
@@ -401,7 +405,10 @@ func newTextV2PostingBlockEntryScanner(raw []byte, scratch []uint32) (*textV2Pos
 	if uint64(fieldCount) != fieldCountRaw || fieldCount == 0 || fieldCount > textV2PostingBlockMaxFieldCount {
 		return nil, errMalformedTextStorage("text-v2 posting block field count invalid")
 	}
-	maxFieldTF := make([]uint32, 0, fieldCount)
+	fieldCountInt := int(fieldCount)
+	fieldMetadata := make([]uint32, fieldCountInt*2)
+	maxFieldTF := fieldMetadata[:fieldCountInt:fieldCountInt]
+	computedFieldTF := fieldMetadata[fieldCountInt : fieldCountInt*2 : fieldCountInt*2]
 	for i := uint32(0); i < fieldCount; i++ {
 		fieldTF, err := cur.readUvarint()
 		if err != nil {
@@ -410,7 +417,7 @@ func newTextV2PostingBlockEntryScanner(raw []byte, scratch []uint32) (*textV2Pos
 		if uint64(checkedTextUint32(fieldTF)) != fieldTF {
 			return nil, errMalformedTextStorage("text-v2 posting block max field frequency[%d] overflows uint32", i)
 		}
-		maxFieldTF = append(maxFieldTF, uint32(fieldTF))
+		maxFieldTF[i] = uint32(fieldTF)
 	}
 	if cur.remaining() == 0 {
 		return nil, errMalformedTextStorage("text-v2 posting block missing upper-bound kind")
@@ -430,8 +437,12 @@ func newTextV2PostingBlockEntryScanner(raw []byte, scratch []uint32) (*textV2Pos
 	if entryCount > uint64(cur.remaining()+1) {
 		return nil, errMalformedTextStorage("text-v2 posting block entry count too large")
 	}
-	if cap(scratch) < int(fieldCount) {
-		scratch = make([]uint32, fieldCount)
+	minEntryBytes := uint64(fieldCount) + 4 // ordinal delta, generation, flags, term frequency, and one byte per field lane.
+	if entryCount > uint64(cur.remaining())/minEntryBytes {
+		return nil, errMalformedTextStorage("text-v2 posting block entry payload too short")
+	}
+	if cap(scratch) < fieldCountInt {
+		scratch = make([]uint32, fieldCountInt)
 	}
 	return &textV2PostingBlockEntryScanner{
 		block: textV2PostingBlockValue{
@@ -452,8 +463,8 @@ func newTextV2PostingBlockEntryScanner(raw []byte, scratch []uint32) (*textV2Pos
 		cur:              cur,
 		remaining:        docCount,
 		prevOrdinal:      blockStart - 1,
-		fieldScratch:     scratch[:fieldCount],
-		computedFieldTF:  make([]uint32, fieldCount),
+		fieldScratch:     scratch[:fieldCountInt],
+		computedFieldTF:  computedFieldTF,
 		checksumVerified: checksumVerified,
 	}, nil
 }
@@ -592,7 +603,7 @@ func (s *textV2PostingBlockEntryScanner) finish() {
 		return
 	}
 	s.computed.UpperBoundKind = s.block.Summary.UpperBoundKind
-	s.computed.MaxFieldTermFrequencies = append([]uint32(nil), s.computedFieldTF...)
+	s.computed.MaxFieldTermFrequencies = s.computedFieldTF
 	if !textV2PostingBlockSummaryEqual(s.computed, s.block.Summary) {
 		s.err = errMalformedTextStorage("text-v2 posting block summary/upper-bound metadata mismatch")
 	}

--- a/TreeDB/collections/text_v2_posting_blocks_test.go
+++ b/TreeDB/collections/text_v2_posting_blocks_test.go
@@ -3,8 +3,10 @@ package collections
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
 	"errors"
 	"fmt"
+	"hash/crc32"
 	"math"
 	"slices"
 	"strings"
@@ -88,6 +90,7 @@ func TestTextV2PostingBlockCodecRoundTripAndFailClosed2625(t *testing.T) {
 			return b
 		}())},
 		{name: "unsupported upper bound", raw: encodeTextV2PostingBlockValue(func() textV2PostingBlockValue { b := block; b.Summary.UpperBoundKind = 99; return b }())},
+		{name: "entry payload too short", raw: encodeTextV2PostingBlockHeaderWithoutEntries2728()},
 		{name: "entry flags", raw: encodeTextV2PostingBlockValue(func() textV2PostingBlockValue {
 			b := block
 			b.Entries = cloneTextV2PostingBlockEntries(block.Entries)
@@ -999,6 +1002,26 @@ func BenchmarkTextV2PostingBlockEncodeUpdate2625(b *testing.B) {
 			textV2PostingBlockBenchSink2625 += uint64(len(blocks[0].Value))
 		}
 	})
+}
+
+func encodeTextV2PostingBlockHeaderWithoutEntries2728() []byte {
+	out := []byte{textV2PostingBlockValueVersion}
+	out = appendTextUvarint(out, uint64(textV2FormatVersion))
+	out = append(out, byte(textV2PostingBlockKindSealed), 0)
+	out = appendTextUvarint(out, 1) // block start
+	out = appendTextUvarint(out, 1) // block id
+	out = appendTextUvarint(out, 1) // first ordinal
+	out = appendTextUvarint(out, 1) // last ordinal
+	out = appendTextUvarint(out, 1) // doc count
+	out = appendTextUvarint(out, 1) // max term frequency
+	out = appendTextUvarint(out, 2) // field count
+	out = appendTextUvarint(out, 1) // max field frequency[0]
+	out = appendTextUvarint(out, 0) // max field frequency[1]
+	out = append(out, textV2PostingUpperBoundKindBM25FLaneMax)
+	out = appendTextUvarint(out, 1) // entry count, intentionally no entry payload follows.
+	var checksum [textV2PostingBlockChecksumBytes]byte
+	binary.BigEndian.PutUint32(checksum[:], crc32.ChecksumIEEE(out))
+	return append(out, checksum[:]...)
 }
 
 func mutatePostingBlockRaw2625(raw []byte, offset int, value byte) []byte {

--- a/TreeDB/collections/text_v2_search.go
+++ b/TreeDB/collections/text_v2_search.go
@@ -559,12 +559,21 @@ func executeTextV2BlockMaxSearchAtSnapshot(
 	defer func() { _ = it.Close() }()
 
 	baseStats := response.Stats
+	fallbackToExactScan := func() (TextSearchResponse, error) {
+		fallback := response
+		fallback.Stats = baseStats
+		fallback.Stats.TextBlockMaxFallbacks++
+		fallbackOpts := opts
+		fallbackOpts.textV2DisableBlockMax = true
+		return executeTextV2SearchAtSnapshot(c, snap, catalog, idx, fallbackOpts, []string{term}, TextSearchOperatorOR, candidateLimit, maxPostingsScanned, resultMode, fallback)
+	}
 	cache := textV2SearchBlockCache{}
 	top := textV2SearchTopK{limit: opts.TopK, candidates: make([]textV2SearchTopCandidate, 0, opts.TopK)}
-	seenCurrent := make(map[uint64]uint64)
 	fieldCount := len(ctx.fieldNames)
 	var scratch []uint32
 	var blocksSeen uint64
+	var lastBlockLast uint64
+	var hasLastBlock bool
 	scanStart := time.Now()
 	for it.Valid() {
 		keyBytes := it.UnsafeKey()
@@ -589,14 +598,11 @@ func executeTextV2BlockMaxSearchAtSnapshot(
 		if len(scanner.block.Summary.MaxFieldTermFrequencies) != fieldCount {
 			return textSearchFailClosed(response, textSearchFailClosedStorageCorrupt, errMalformedTextStorage("text-v2 posting block field count %d want %d", len(scanner.block.Summary.MaxFieldTermFrequencies), fieldCount))
 		}
-		if !scanner.ChecksumVerified() {
-			fallback := response
-			fallback.Stats = baseStats
-			fallback.Stats.TextBlockMaxFallbacks++
-			fallbackOpts := opts
-			fallbackOpts.textV2DisableBlockMax = true
-			return executeTextV2SearchAtSnapshot(c, snap, catalog, idx, fallbackOpts, []string{term}, TextSearchOperatorOR, candidateLimit, maxPostingsScanned, resultMode, fallback)
+		if !scanner.ChecksumVerified() || scanner.block.Kind != textV2PostingBlockKindSealed || (hasLastBlock && scanner.block.Summary.FirstOrdinal <= lastBlockLast) {
+			return fallbackToExactScan()
 		}
+		hasLastBlock = true
+		lastBlockLast = scanner.block.Summary.LastOrdinal
 		blocksSeen++
 		if allowSet != nil && !allowSet.intersects(scanner.block.Summary.FirstOrdinal, scanner.block.Summary.LastOrdinal) {
 			response.Stats.TextPostingBlocksSkipped++
@@ -651,10 +657,6 @@ func executeTextV2BlockMaxSearchAtSnapshot(
 			if docMap.tombstoned() {
 				continue
 			}
-			if prevGeneration, seen := seenCurrent[entry.Ordinal]; seen && prevGeneration == entry.Generation {
-				return textSearchFailClosed(response, textSearchFailClosedStorageCorrupt, errMalformedTextStorage("duplicate text-v2 posting for term %q ordinal %d generation %d", term, entry.Ordinal, entry.Generation))
-			}
-			seenCurrent[entry.Ordinal] = entry.Generation
 			if candidateLimit > 0 && response.Stats.TextCandidatesScored >= uint64(candidateLimit) {
 				response.Stats.Truncated = true
 				response.Stats.FailClosedReason = textSearchFailClosedCandidateLimit


### PR DESCRIPTION
## Objective

Reduce allocation overhead in TreeDB text-v2 posting-block decode/scan and single-term block-max search paths while preserving exact BM25F semantics and zero-document-fetch candidate generation.

Closes #2728. Part of #2726.

## Context

#2728 is the posting-block allocation/encoding/search slice after the text-v2 default and #2727 scoreboard work. The observed hot spots were per-entry field-frequency clones during posting-block decode and a per-query `seenCurrent` map in single-term block-max search.

## Non-goals

- No approximate scoring or BM25F semantic changes.
- No external sidecar/segment store and no storage-format rewrite.
- No hybrid fusion/candidate-budgeting changes (#2729 scope).
- No rewrite-path runtime claim; rewrite evidence below is allocation/counter evidence only because local runtime variance is high.

## Design

- `decodeTextV2PostingBlockValue` now stores decoded field-frequency lanes in one arena and gives each decoded entry a bounded slice into that arena.
- `newTextV2PostingBlockEntryScanner` coalesces header/computed field metadata allocations and rejects impossible entry payloads before decode allocation.
- Single-term block-max search no longer allocates a `seenCurrent` map in the common sealed/non-overlapping path. It falls back to exact scan for legacy/no-checksum, non-sealed, or overlapping blocks. Exact scan still fails closed on duplicate current postings, so mutation semantics and corruption detection are preserved.
- Added focused fail-closed and mutation fallback tests.

## Scope

Includes:

- `TreeDB/collections/text_v2_posting_blocks.go`
- `TreeDB/collections/text_v2_search.go`
- `TreeDB/collections/text_v2_posting_blocks_test.go`
- `TreeDB/collections/text_v2_blockmax_test.go`

Excludes: hybrid fusion/ranking, vector paths, public API, on-disk format changes, and value-log/GC behavior.

## Correctness

Tests run on candidate `58d06b97645ccdada363ce41c130aba1f0789ef8`:

```sh
go test ./TreeDB/collections -count=1 -run 'TestTextV2(PostingBlockCodecRoundTripAndFailClosed2625|PostingBlockStorageFailsClosedOnCorruption2625|PostingBlockStorageFailsClosedOnFieldLaneMismatch2625|BlockMax(SingleTermExactParityAndSkips2628|SingleTermOverlappingMutationFallsBackExact2728|MultiTermANDExactParitySkipsAndLazyDetails2688|MultiTermANDOverlappingMutationFallsBackExact2688|RandomizedExactnessAndFallbacks2628|CorruptMetadataFailsClosed2628)|Search(ScoreParity2627|SkipsStaleGenerationsAndTombstones2627|SnapshotBindingAndReopen2627|StalePostingsDoNotConsumeCandidateBudget2627|FailClosedOnMissingAndCorruptRoots2627|IncludeDocumentsFetchesOnlyTopKAndDetailsLazy2627))$'
go test ./TreeDB/collections -count=1
go test ./TreeDB/... -count=1
go test ./TreeDB/mongo_gateway -count=1
```

Results/artifacts:

- Focused text-v2 tests: pass, `/tmp/gomap_2728_tests_head_20260613_125128.log`
- `go test ./TreeDB/collections -count=1`: pass, `/tmp/gomap_2728_collections_all_20260613_125634.log`
- `go test ./TreeDB/... -count=1`: one `TreeDB/mongo_gateway` timeout in standalone server update visibility; all other packages passed, `/tmp/gomap_2728_treedb_all_20260613_125805.log`
- `go test ./TreeDB/mongo_gateway -count=1`: rerun pass, `/tmp/gomap_2728_mongo_gateway_rerun_20260613_130200.log`

Corruption/edge coverage added:

- Posting-block header with declared entries but no entry payload fails closed before allocation.
- Single-term block-max overlapping mutation blocks fall back to exact scan with BM25F parity and `docs_fetched=0`, `text_state_lookups=0`, `fail_closed=0`.

## Performance

Environment: Apple M3, Darwin arm64, Go `1.26.0`. Baseline is `88b15a93a429bce58f9314938283f01a8a5670ec`; candidate is `58d06b97645ccdada363ce41c130aba1f0789ef8`.

Artifact roots:

- Main before/after matrix: `/tmp/gomap_2728_finalizer_bench_20260613_125335`
- Rewrite variance rerun: `/tmp/gomap_2728_rewrite_rerun_20260613_125509`

Commands:

```sh
go test ./TreeDB/collections -run '^$' -bench '^BenchmarkTextV2PostingBlock(Codec2625|EncodeUpdate2625)$' -benchtime=50x -count=6 -cpu=8 -benchmem
TREEDB_TEXT_V2_RUN_100K=1 go test ./TreeDB/collections -run '^$' -bench '^BenchmarkTextV2ScoreSearchScale2627/(docs_10000|docs_100000)/(score_only_common_no_docs|multi_term_and_no_docs)$' -benchtime=3x -count=6 -cpu=8 -benchmem
TREEDB_TEXT_V2_BLOCKMAX_DOCS=10000 go test ./TreeDB/collections -run '^$' -bench '^BenchmarkTextV2BlockMaxCommonTerm2628/blockmax_common_topk$' -benchtime=5x -count=6 -cpu=8 -benchmem
TREEDB_TEXT_V2_BLOCKMAX_DOCS=100000 go test ./TreeDB/collections -run '^$' -bench '^BenchmarkTextV2BlockMaxCommonTerm2628/blockmax_common_topk$' -benchtime=3x -count=6 -cpu=8 -benchmem
go test ./TreeDB/collections -run '^$' -bench '^BenchmarkTextV2ContractWritePaths2623/(insert_batch_text_v2_indexed|create_text_v2_index_backfill)$' -benchtime=3x -count=6 -cpu=8 -benchmem
TREEDB_TEXT_V2_REWRITE_DOCS=512 go test ./TreeDB/collections -run '^$' -bench '^BenchmarkTextV2RewriteMerge2630$' -benchtime=10x -count=10 -cpu=8 -benchmem
```

Benchstat summary (center values; ops/sec computed from ns/op):

| Benchmark | Base ns/op | Base ops/sec | Candidate ns/op | Candidate ops/sec | B/op base -> candidate | allocs/op base -> candidate | Counters / notes |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |
| Posting decode_128 | 4,695 | 213k | 3,167 | 316k | 9.312Ki -> 9.305Ki | 134 -> 5 | bytes/posting 6.172 unchanged |
| Posting scan_128_reused_entry | 2,452 | 408k | 2,560 | 391k | 320 -> 312 | 5 -> 3 | bytes/posting 6.172 unchanged; runtime ~ |
| Posting build_sealed_100k | 5,578,000 | 179 | 4,787,000 | 209 | 16.60Mi -> 16.60Mi | 103.1k -> 103.1k | blocks 782, postings 100k unchanged |
| Search 10k common score-only | 2,944,000 | 340 | 2,310,000 | 433 | 1.972Mi -> 1.407Mi | 1,142 -> 905 | candidates/postings 10k, docs/state/fail/fallback 0 unchanged |
| Search 10k multi-term AND | 3,645,000 | 274 | 3,249,000 | 308 | 2.038Mi -> 2.036Mi | 1.569k -> 1.253k | candidates 10k, postings 20k, docs/state/fail/fallback 0 unchanged |
| Search 100k common score-only | 35,520,000 | 28.2 | 22,050,000 | 45.4 | 18.57Mi -> 14.04Mi | 10.044k -> 7.948k | candidates/postings 100k, docs/state/fail/fallback 0 unchanged |
| Search 100k multi-term AND | 37,100,000 | 27.0 | 39,420,000 | 25.4 | 18.85Mi -> 18.82Mi | 13.99k -> 10.86k | runtime ~; candidates 100k/postings 200k, docs/state/fail/fallback 0 unchanged |
| Blockmax 10k common top-k | 326,300 | 3,065 | 254,100 | 3,936 | 273.0Ki -> 200.4Ki | 518 -> 409 | scored/postings 1.280k, skipped/visited 69/10, docs/state/fail/fallback 0 unchanged |
| Blockmax 100k common top-k | 3,523,000 | 284 | 2,771,000 | 361 | 2.440Mi -> 1.874Mi | 4.106k -> 3.147k | scored/postings 12.54k, skipped/visited 684/98, docs/state/fail/fallback 0 unchanged |
| Write insert_batch_text_v2_indexed | 2,463,000 | 406 | 2,653,000 | 377 | 3.030Mi -> 2.947Mi | 23.21k -> 23.21k | runtime ~; write/storage counters unchanged |
| Write create_text_v2_index_backfill | 2,052,000 | 487 | 2,277,000 | 439 | 2.711Mi -> 2.659Mi | 21.50k -> 21.49k | runtime ~; write/storage counters unchanged |
| Rewrite merge 512 docs | 2,615,000 | 382 | 2,796,000 | 358 | 1.481Mi -> 1.478Mi | 8.850k -> 8.380k | runtime ~ with high variance; posting blocks read/written/deleted and purges unchanged |

Regression assessment:

- Primary claim is allocation reduction with unchanged text counters; runtime varies locally and is not overclaimed.
- Search allocation geomean: B/op `-14.35%`, allocs/op `-21.04%` across selected 10k/100k common + AND rows.
- Blockmax allocation: 10k B/op `-26.62%`, allocs/op `-21.04%`; 100k B/op `-23.18%`, allocs/op `-23.36%`.
- Posting codec allocation: decode allocs `134 -> 5`, scan allocs `5 -> 3`; encoded bytes/posting unchanged.
- Write path counters unchanged; no material allocation regression. Rewrite rerun shows allocs `8.850k -> 8.380k` with counters unchanged, but no rewrite runtime claim due high variance.
- No docs-fetched, state-lookup, fail-closed, fallback, candidate, posting, or block-skip counter regressions in the reported text-v2 rows.

## Rollout / Toggle Plan

No user-visible toggle or format migration. This keeps the existing text-v2 storage format; disabling blockmax via existing internal test option still uses exact scan.

## CI Status

- Latest PR head: `58d06b97645ccdada363ce41c130aba1f0789ef8`.
- Latest-head CI: 26/26 checks passing; `mergeStateStatus=CLEAN`.

## AI Review Loop

- Internal finalizer review: completed against current diff and current-head tests/benchmarks.
- Codex latest-head review: requested with `@codex review`; result: no major issues on `58d06b9764`.
- Copilot latest-head review: requested with `@copilot review`; no Copilot response observed in this repo.
- CodeRabbit latest-head review: auto-started/requested; rate-limited/review skipped, no actionable findings available.
- Review comments/threads: 0 review threads / 0 unresolved.
