### PR TITLE
TreeDB M5: record parallel flush production gate

### DIFF
--- a/TreeDB/docs/spec/concurrency-paradigms.md
+++ b/TreeDB/docs/spec/concurrency-paradigms.md
@@ -389,6 +389,8 @@ Notes:
 - `FlushBuildMinEntries <= 0` defaults to `16k`.
 - `FlushBuildMinUnits <= 0` defaults to `2`.
 - `FlushApplyConcurrency` is not enabled by default; when set, workers are still capped by `GOMAXPROCS` and read-only leaf-span planning.
+- M5 keeps this path opt-in/default-off. Default-on production readiness is
+  blocked on the M6 checkpoint allocation/memcopy work tracked in #2757.
 - With value-log-backed outer leaves, workers may prepare block/dict
   grouped-frame bodies outside the leaf-log append mutex, but the durable append
   stream remains serialized per leaf-log lane. Published roots install leaf-log

--- a/docs/SPRINT_TREEDB_FLUSH_THROUGHPUT.md
+++ b/docs/SPRINT_TREEDB_FLUSH_THROUGHPUT.md
@@ -64,6 +64,57 @@ This file is the sprint source of truth:
 
 ## Results / follow-ups
 
+### M5 production gate and default decision (2026-06-14)
+
+M5 consumes the merged M0-M4 parallel flush/apply stack and records the rollout decision. It does **not** ship the broad checkpoint allocation/memcopy optimization work; that work is split to M6 (#2757). The M5 decision is therefore conservative: `Options.FlushApplyConcurrency` remains opt-in/default-off and is not production-default-ready until the checkpoint gate is resolved.
+
+Predecessor state consumed by M5:
+
+| milestone | issue / PR | merge SHA | production-gate relevance |
+| --- | --- | --- | --- |
+| M0 observability | #2744 / #2750 | `1d80580679c50f7f4f60141804a39f7ce74ee2a1` | Flush/apply counters and benchprof metadata. |
+| M1 span planning | #2745 / #2751 | `7e4e5eac8df60980bf64c42808ac85a3815d5a46` | Side-effect-free read-only leaf span planning. |
+| M2 worker pool | #2746 / #2753 | `a699ada6b360358139f7a00d2a09eb52932cf07c` | Bounded opt-in COW apply worker pool; default remains off. |
+| M3 leaf-log ownership | #2747 / #2754 | `41052a22ca50a2a3597f8903a0935df41e11968a` | Prepared leaf-log output outside append lock with persistent-pointer accounting. |
+| M4 coordinator/backpressure | #2748 / #2755 | `f6a5292bacd6191a848374a38ad141fce06d9f24` | Foreground assist/yield coordination for the opt-in path. |
+
+M4 closeout evidence showed the opt-in path can remove the active-flush wait bottleneck under the parent 10M command, but this is not enough for a default-on decision:
+
+| Metric | M3 baseline | M4 opt-in | Notes |
+| --- | ---: | ---: | --- |
+| `sequential_write` | 2,724,512 ops/s | 2,594,436 ops/s | isolated M4 rerun was 2,683,525 ops/s; treat full-run cell as noisy guardrail. |
+| `batch_random` | 299,948 ops/s | 2,350,647 ops/s | active parallel flush/backpressure improvement. |
+| `random_write` | 177,997 ops/s | 1,685,212 ops/s | active parallel flush/backpressure improvement. |
+| `batch_random` block samples | 667.49s | 89.43s | bottleneck moved substantially. |
+| `batch_random` mutex samples | 49.93s | 0.68s | foreground lock contention removed on the opt-in path. |
+
+Serial/default guardrail from the same M4 evidence stayed stable because the new path is disabled unless `FlushApplyConcurrency > 1`:
+
+| Metric | M3 serial | M4 serial |
+| --- | ---: | ---: |
+| `sequential_write` | 2,620,851 ops/s | 2,728,865 ops/s |
+| `batch_random` | 390,129 ops/s | 390,717 ops/s |
+| `random_write` | 145,739 ops/s | 158,573 ops/s |
+
+Checkpoint gate status: unresolved and assigned to M6 (#2757). User checkpoint-between-tests evidence on a parallel candidate (`FlushApplyConcurrency=16`, 10M keys, `sequential_write,batch_random`, min gates all `1`, `journal-lanes=1`) reported:
+
+| Metric | Result |
+| --- | ---: |
+| `sequential_write` | 1,715,358 ops/s |
+| `batch_random` | 196,609 ops/s |
+| checkpoint before `sequential_write` | 201.53ms |
+| checkpoint before `batch_random` | 707.53ms |
+| post-run checkpoint | 48.91s |
+| final `leaf_vlog` | 1.3GiB across 80 files |
+
+M5 interpretation:
+
+- Default decision: keep `FlushApplyConcurrency <= 1` as the default serial path.
+- Production status: the parallel path is experimental/workload-specific opt-in, not a production default.
+- Rollout: before enabling, run a workload-specific matrix such as `FlushApplyConcurrency=1,2,4,8` (or hardware-appropriate values) with `-checkpoint-between-tests`, CPU/alloc/block/mutex profiles, stage counters, and final `index.db`/`leaf_vlog` footprint.
+- Rollback: set `FlushApplyConcurrency <= 1`; no data migration is required because the knob changes only in-memory apply strategy and durable leaf/value-log output remains persistent storage.
+- Blocking follow-up: M6 (#2757) owns aggressive checkpoint allocation, memcopy, memclr, and drain/merge optimization. Parent production-default readiness should not be claimed until M6 reduces or explains the post-run checkpoint cost.
+
 ### Perf server results (B560 / i5-11400F, 2026-01-27)
 
 Hardware:

--- a/docs/TREEDB_TUNING.md
+++ b/docs/TREEDB_TUNING.md
@@ -92,7 +92,16 @@ optionally build the `SetOps` batch in parallel:
 
 ### `Options.FlushApplyConcurrency` (opt-in/default-off)
 
-`FlushApplyConcurrency > 1` enables the experimental M2 bounded worker-pool path for B-tree COW apply. It is separate from `FlushBuildConcurrency` and remains default-off. The effective worker count is capped by `GOMAXPROCS`, planned leaf-span count, and the `FlushApplyMinEntries`, `FlushApplyMinSpans`, and `FlushApplyMinBytes` gates. Leaf/value-log output remains persistent storage; failed or abandoned apply attempts do not publish roots.
+`FlushApplyConcurrency > 1` enables the experimental bounded worker-pool path for B-tree COW apply. It is separate from `FlushBuildConcurrency` and remains default-off. The effective worker count is capped by `GOMAXPROCS`, planned leaf-span count, and the `FlushApplyMinEntries`, `FlushApplyMinSpans`, and `FlushApplyMinBytes` gates. Leaf/value-log output remains persistent storage; failed or abandoned apply attempts do not publish roots, and unreachable prepared output is reclaimed only by reachability-based maintenance.
+
+Rollout guidance:
+
+- Leave the default serial path in place unless checkpoint/drain evidence for the workload justifies an opt-in value.
+- Benchmark `1,2,4,8` (or a smaller hardware-appropriate matrix) with `-checkpoint-between-tests`, allocation profiles, and storage footprint before enabling in production.
+- Roll back by setting `FlushApplyConcurrency <= 1`; no data migration is required because the option changes only the in-memory apply strategy.
+- Watch `treedb.flush_apply.*`, `treedb.cache.flush_apply.*`, `prepared_output.*`, checkpoint wall times, allocation profiles, and final `index.db`/`leaf_vlog` footprint. Regressions in write throughput, checkpoint time, allocation volume, or footprint should keep the option disabled.
+
+Known blocker: default-on production readiness is deferred to #2757, which owns checkpoint allocation, memcopy, and memclr optimization. Until that gate is resolved, treat `FlushApplyConcurrency > 1` as workload-specific and experimental.
 
 ### Read latency under flush debt (cached mode)
 


### PR DESCRIPTION
## Objective

Close M5 (#2749) by recording the production-gate/default decision for the merged M0-M4 parallel TreeDB flush/apply stack. Closes #2749.

## Context

M0-M4 are merged into `origin/main` at `f6a5292bacd6191a848374a38ad141fce06d9f24`. The user-provided checkpoint evidence shows a large unresolved post-run checkpoint cost, so broad checkpoint allocation/memcopy/memclr optimization is now M6: #2757.

Predecessor merge SHAs consumed by this M5 gate:

| milestone | issue / PR | merge SHA |
| --- | --- | --- |
| M0 observability | #2744 / #2750 | `1d80580679c50f7f4f60141804a39f7ce74ee2a1` |
| M1 span planning | #2745 / #2751 | `7e4e5eac8df60980bf64c42808ac85a3815d5a46` |
| M2 worker pool | #2746 / #2753 | `a699ada6b360358139f7a00d2a09eb52932cf07c` |
| M3 leaf-log ownership | #2747 / #2754 | `41052a22ca50a2a3597f8903a0935df41e11968a` |
| M4 coordinator/backpressure | #2748 / #2755 | `f6a5292bacd6191a848374a38ad141fce06d9f24` |

## Non-goals

- No broad checkpoint optimization campaign in M5.
- No new hot-path code in this PR.
- No default-on production rollout for `FlushApplyConcurrency > 1`.
- No durability shortcut for WAL/value-log/leaf-log persistent pointer targets.

## Design

- Update the sprint/source-of-truth doc with M5 status, default decision, predecessor evidence, checkpoint blocker, rollout/rollback guidance, and M6 handoff.
- Update tuning/concurrency docs to keep `FlushApplyConcurrency` opt-in/default-off and explicitly link the default-on blocker to #2757.
- Recovery note: the interrupted manager had uncommitted checkpoint allocation-pooling code. I preserved the initial diff locally under `/tmp/2749-initial-full.diff` and did not ship those code changes here because they are M6-owned optimization work.

## Scope

- Includes: `docs/SPRINT_TREEDB_FLUSH_THROUGHPUT.md`, `docs/TREEDB_TUNING.md`, `TreeDB/docs/spec/concurrency-paradigms.md`.
- Excludes: TreeDB runtime code, benchmark harness code, on-disk formats, default option values.

## Correctness

Tests run on latest head `d3b6bf74f`:

- `go test ./TreeDB/db ./TreeDB/caching ./TreeDB/zipper -count=1`
- `go test ./TreeDB -run 'Test(ReopenVerify|LeafGenerationGC_CachedModeCheckpointsBeforeDryRun|StatsReportsValueLogReadIntegrityAndReadCounters)' -count=1`
- `go test ./cmd/unified_bench ./cmd/benchprof ./cmd/internal/treedbstats ./internal/benchprof -count=1`
- `go test -race ./TreeDB/db -run 'TestFlushApply(CloseAndCheckpointDrainInProgressApply|ConcurrencyUsesBoundedWorkerPoolForPointSpans)' -count=1`
- `go test -race ./TreeDB/caching -run 'Test(FlushCoordinator|WaitForStopWithConcurrentFlushTrigger|StopBackpressureFlushesAndReturns)' -count=1`

Logs: `/tmp/2749-post-cleanup-tests.log`, `/tmp/2749-race-tests.log`.

## Performance

No new benchmark was run for this docs-only M5 gate. The decision consumes merged M2-M4 benchmark evidence plus the user checkpoint evidence:

- M4 opt-in parent 10M: `batch_random` 299,948 -> 2,350,647 ops/s; `random_write` 177,997 -> 1,685,212 ops/s; mutex/block contention moved down substantially.
- M4 serial/default guardrail stayed stable because the opt-in path is disabled unless `FlushApplyConcurrency > 1`.
- Checkpoint blocker for M6 (#2757): user 10M checkpoint-between-tests run at `FlushApplyConcurrency=16` reported `sequential_write=1,715,358 ops/s`, `batch_random=196,609 ops/s`, pre-test checkpoints `201.53ms` and `707.53ms`, post-run checkpoint `48.91s`, and `leaf_vlog=1.3GiB` across 80 files.

## Rollout / Toggle Plan

- Default setting: keep `FlushApplyConcurrency <= 1` / serial path default.
- Opt-in guidance: enable `FlushApplyConcurrency > 1` only after workload-specific checkpoint-inclusive evidence with CPU/alloc/block/mutex profiles and storage footprint checks.
- Rollback: set `FlushApplyConcurrency <= 1`; no data migration is needed because the knob changes only in-memory apply strategy.

## Risks / Caveats

- Parallel flush/apply is not production-default-ready while #2757 is unresolved.
- Existing M4 evidence shows strong opt-in write-path improvements but does not clear the checkpoint gate.
- The final default-on decision should wait for M6 evidence that materially reduces or explains the post-run checkpoint cost.

## Follow-ups

- #2757: checkpoint allocation, memcopy, memclr, and drain/merge optimization.
- Parent #2743 should continue tracking production-default readiness as blocked on M6.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated concurrency configuration documentation with M5 production status, rollout guidance, and known blockers for opt-in deployments
  * Added production gate decision details including benchmark evidence comparing performance against baseline configurations
  * Clarified worker-pool strategy implementation parameters, capacity thresholds, and resource reclamation behavior
  * Documented deferral of default-enabled production readiness to M6 pending infrastructure optimization work

<!-- end of auto-generated comment: release notes by coderabbit.ai -->