### PR TITLE
treedb: reduce parallel flush prepare allocations

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -75,6 +75,7 @@ var outerLeafEncoderPool sync.Pool // stores *outerleaf.Encoder
 var valueLogPreparedBodyPool sync.Pool
 var valueLogPreparedFramesPool sync.Pool     // stores []preparedDictFrame
 var valueLogDictPrepareResultsPool sync.Pool // stores chan vlogDictPrepareResult
+var valueLogFramePreparerPool sync.Pool      // stores *valuelog.FramePreparer
 var valueLogKeyLeaseMu sync.Mutex
 var valueLogKeyLeases [][][]byte
 var backendValueLogReadBarrierRegistryMu sync.Mutex
@@ -2014,6 +2015,23 @@ func putVlogPreparedFrames(frames []preparedDictFrame) {
 		return
 	}
 	valueLogPreparedFramesPool.Put(frames[:0])
+}
+
+func getVlogFramePreparer() *valuelog.FramePreparer {
+	if v := valueLogFramePreparerPool.Get(); v != nil {
+		if preparer, ok := v.(*valuelog.FramePreparer); ok && preparer != nil {
+			return preparer
+		}
+	}
+	return valuelog.NewFramePreparer()
+}
+
+func putVlogFramePreparer(preparer *valuelog.FramePreparer) {
+	if preparer == nil {
+		return
+	}
+	preparer.ResetForReuse()
+	valueLogFramePreparerPool.Put(preparer)
 }
 
 func getVlogDictPrepareResults(capacity int) chan vlogDictPrepareResult {
@@ -14633,7 +14651,8 @@ func (db *DB) prepareAppendFrames(
 		// Keep frame encode/compress work out of vlogMu even when worker threads are
 		// unavailable. This reduces leaf-log/value-log lock hold time on small and
 		// medium batches while preserving one serialized persistent append stream.
-		preparer := valuelog.NewFramePreparer()
+		preparer := getVlogFramePreparer()
+		defer putVlogFramePreparer(preparer)
 		preparer.SetDictFrameEncoderOptions(db.valueLogDictFrameEncodeLevel, db.valueLogDictFrameEnableEntropy)
 		preparer.SetBlockCompression(blockCodec, blockCompression)
 		preparer.SetKeepPolicy(ioNsPerStoredByte, encodeNsPerRawByte, safetyMargin)

--- a/TreeDB/caching/value_log_record_pool_test.go
+++ b/TreeDB/caching/value_log_record_pool_test.go
@@ -1,6 +1,7 @@
 package caching
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/snissn/gomap/TreeDB/internal/valuelog"
@@ -19,4 +20,27 @@ func TestPutValueLogRecordsNoClear_Smoke(t *testing.T) {
 	putValueLogRecordsNoClear(recs)
 	// Do not assert on recs after putValueLogRecordsNoClear; ownership has been
 	// returned to the global pool and another goroutine may reuse it.
+}
+
+func TestVlogFramePreparerPoolResetsCompressionState(t *testing.T) {
+	records := []valuelog.Record{
+		{RID: 1, Value: bytes.Repeat([]byte("leaf-page|"), 512)},
+		{RID: 2, Value: bytes.Repeat([]byte("leaf-page|"), 512)},
+	}
+	prep := getVlogFramePreparer()
+	prep.SetBlockCompression(valuelog.BlockCodecLZ4, true)
+	if _, stats, err := prep.PrepareFrameInto(nil, 0, nil, records); err != nil {
+		t.Fatalf("PrepareFrameInto compressed: %v", err)
+	} else if !stats.Attempted {
+		t.Fatalf("expected compression attempt before returning to pool")
+	}
+	putVlogFramePreparer(prep)
+
+	reused := getVlogFramePreparer()
+	defer putVlogFramePreparer(reused)
+	if _, stats, err := reused.PrepareFrameInto(nil, 0, nil, records); err != nil {
+		t.Fatalf("PrepareFrameInto after pool reset: %v", err)
+	} else if stats.Attempted {
+		t.Fatalf("pooled preparer kept compression enabled after reset")
+	}
 }

--- a/TreeDB/db/batch.go
+++ b/TreeDB/db/batch.go
@@ -286,6 +286,10 @@ func (b *Batch) writeOptimistic(sync bool, intent *commandWALBatchIntent) (bool,
 	tracker := newAllocTracker(idx.allocator)
 	z := idx.zipper.CloneWithAllocator(tracker)
 	applyOpts := b.db.flushApplyOptions()
+	prepareBuf := b.db.acquireFlushApplyReadOnlyPrepareBuffer(applyOpts)
+	if prepareBuf != nil {
+		applyOpts.ReadOnlyPrepare = prepareBuf.opts
+	}
 	var newRoot uint64
 	var retired []uint64
 	var metrics adaptive.Metrics
@@ -293,6 +297,7 @@ func (b *Batch) writeOptimistic(sync bool, intent *commandWALBatchIntent) (bool,
 	if applyOpts.ParallelApplyConcurrency > 1 {
 		result, applyErr := z.ApplyWithOptions(rootID, b.batch, applyOpts)
 		b.db.observeFlushApplyPrepareResult(result, applyErr)
+		b.db.releaseFlushApplyReadOnlyPrepareBuffer(prepareBuf, &result)
 		newRoot = result.RootID
 		retired = result.PendingRetiredPages
 		metrics = result.Metrics
@@ -417,6 +422,10 @@ func (b *Batch) writeSerialized(sync bool, intent *commandWALBatchIntent) error 
 	defer idx.registry.Unregister(regID)
 
 	applyOpts := b.db.flushApplyOptions()
+	prepareBuf := b.db.acquireFlushApplyReadOnlyPrepareBuffer(applyOpts)
+	if prepareBuf != nil {
+		applyOpts.ReadOnlyPrepare = prepareBuf.opts
+	}
 	var newRoot uint64
 	var retired []uint64
 	var metrics adaptive.Metrics
@@ -424,6 +433,7 @@ func (b *Batch) writeSerialized(sync bool, intent *commandWALBatchIntent) error 
 	if applyOpts.ParallelApplyConcurrency > 1 {
 		result, applyErr := idx.zipper.ApplyWithOptions(rootID, b.batch, applyOpts)
 		b.db.observeFlushApplyPrepareResult(result, applyErr)
+		b.db.releaseFlushApplyReadOnlyPrepareBuffer(prepareBuf, &result)
 		newRoot = result.RootID
 		retired = result.PendingRetiredPages
 		metrics = result.Metrics

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -340,6 +340,9 @@ type DB struct {
 	flushApplyMinBytes    int
 	flushApplyWorkerPool  *zipper.ApplyWorkerPool
 
+	flushApplyReadOnlyPrepareMu   sync.Mutex
+	flushApplyReadOnlyPrepareFree []*flushApplyReadOnlyPrepareBuffer
+
 	// R4 warm-publish counters. Warm native apply is used for bounded deltas;
 	// larger or ineligible deltas record an explicit rebuild fallback selection.
 	systemRootWarmPublishAttempts         atomic.Uint64

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -1952,6 +1952,7 @@ func (db *DB) Close() error {
 		db.flushApplyWorkerPool.Close()
 		db.flushApplyWorkerPool = nil
 	}
+	db.clearFlushApplyReadOnlyPrepareBuffers()
 	db.writeMu.Unlock()
 	db.stopCommitCombiner()
 	db.pruner.Stop()

--- a/TreeDB/db/flush_apply_prepare_pool.go
+++ b/TreeDB/db/flush_apply_prepare_pool.go
@@ -28,6 +28,16 @@ func (db *DB) acquireFlushApplyReadOnlyPrepareBuffer(opts zipper.ApplyOptions) *
 	return &flushApplyReadOnlyPrepareBuffer{}
 }
 
+func (db *DB) clearFlushApplyReadOnlyPrepareBuffers() {
+	if db == nil {
+		return
+	}
+	db.flushApplyReadOnlyPrepareMu.Lock()
+	clear(db.flushApplyReadOnlyPrepareFree)
+	db.flushApplyReadOnlyPrepareFree = nil
+	db.flushApplyReadOnlyPrepareMu.Unlock()
+}
+
 func (db *DB) releaseFlushApplyReadOnlyPrepareBuffer(buf *flushApplyReadOnlyPrepareBuffer, result *zipper.ApplyResult) {
 	if db == nil || buf == nil {
 		return

--- a/TreeDB/db/flush_apply_prepare_pool.go
+++ b/TreeDB/db/flush_apply_prepare_pool.go
@@ -1,0 +1,53 @@
+package db
+
+import "github.com/snissn/gomap/TreeDB/zipper"
+
+const flushApplyReadOnlyPrepareBufferKeep = 4
+
+type flushApplyReadOnlyPrepareBuffer struct {
+	opts zipper.ReadOnlyPrepareOptions
+}
+
+func (db *DB) acquireFlushApplyReadOnlyPrepareBuffer(opts zipper.ApplyOptions) *flushApplyReadOnlyPrepareBuffer {
+	if db == nil || (!opts.PrepareReadOnly && opts.ParallelApplyConcurrency <= 1) {
+		return nil
+	}
+	db.flushApplyReadOnlyPrepareMu.Lock()
+	n := len(db.flushApplyReadOnlyPrepareFree)
+	if n > 0 {
+		buf := db.flushApplyReadOnlyPrepareFree[n-1]
+		db.flushApplyReadOnlyPrepareFree[n-1] = nil
+		db.flushApplyReadOnlyPrepareFree = db.flushApplyReadOnlyPrepareFree[:n-1]
+		db.flushApplyReadOnlyPrepareMu.Unlock()
+		if buf != nil {
+			return buf
+		}
+		return &flushApplyReadOnlyPrepareBuffer{}
+	}
+	db.flushApplyReadOnlyPrepareMu.Unlock()
+	return &flushApplyReadOnlyPrepareBuffer{}
+}
+
+func (db *DB) releaseFlushApplyReadOnlyPrepareBuffer(buf *flushApplyReadOnlyPrepareBuffer, result *zipper.ApplyResult) {
+	if db == nil || buf == nil {
+		return
+	}
+	if result == nil {
+		buf.opts = zipper.ReadOnlyPrepareOptions{}
+	} else {
+		prepared := result.ReadOnlyPrepare
+		prepared.ResetForReuse()
+		buf.opts = prepared.ReuseOptions()
+		// Drop the caller's reference to buffers that may now be reused by a later
+		// apply attempt. Callers must observe any read-only prepare stats before
+		// returning the buffer.
+		result.ReadOnlyPrepare = zipper.ReadOnlyPrepareResult{}
+	}
+	db.flushApplyReadOnlyPrepareMu.Lock()
+	if len(db.flushApplyReadOnlyPrepareFree) < flushApplyReadOnlyPrepareBufferKeep {
+		db.flushApplyReadOnlyPrepareFree = append(db.flushApplyReadOnlyPrepareFree, buf)
+		db.flushApplyReadOnlyPrepareMu.Unlock()
+		return
+	}
+	db.flushApplyReadOnlyPrepareMu.Unlock()
+}

--- a/TreeDB/db/flush_apply_prepare_pool_test.go
+++ b/TreeDB/db/flush_apply_prepare_pool_test.go
@@ -1,0 +1,12 @@
+package db
+
+import "testing"
+
+func TestClearFlushApplyReadOnlyPrepareBuffersDropsFreeList(t *testing.T) {
+	db := &DB{}
+	db.flushApplyReadOnlyPrepareFree = []*flushApplyReadOnlyPrepareBuffer{{}, {}}
+	db.clearFlushApplyReadOnlyPrepareBuffers()
+	if db.flushApplyReadOnlyPrepareFree != nil {
+		t.Fatalf("prepare buffer free-list retained after clear: len=%d cap=%d", len(db.flushApplyReadOnlyPrepareFree), cap(db.flushApplyReadOnlyPrepareFree))
+	}
+}

--- a/TreeDB/db/ordered_root_publish.go
+++ b/TreeDB/db/ordered_root_publish.go
@@ -2087,7 +2087,7 @@ func orderedRootDeltaBatchGroupParallelApplyEligible(ordered []OrderedRootDeltaB
 	return parallelActive >= orderedRootDeltaBatchGroupParallelApplyMinRoots
 }
 
-func runOrderedRootDeltaBatchReadOnlyPrepare(rootZipper *zipper.Zipper, baseRoot uint64, delta *batch.Batch, workers int) (zipper.ReadOnlyPrepareResult, zipper.ReadOnlyLeafSpanSummary, zipper.ReadOnlyLeafSpanWorkerRangeSummary, uint64, bool, error) {
+func runOrderedRootDeltaBatchReadOnlyPrepare(rootZipper *zipper.Zipper, baseRoot uint64, delta *batch.Batch, workers int, prepareOpts zipper.ReadOnlyPrepareOptions) (zipper.ReadOnlyPrepareResult, zipper.ReadOnlyLeafSpanSummary, zipper.ReadOnlyLeafSpanWorkerRangeSummary, uint64, bool, error) {
 	var prepared zipper.ReadOnlyPrepareResult
 	var summary zipper.ReadOnlyLeafSpanSummary
 	var workerSummary zipper.ReadOnlyLeafSpanWorkerRangeSummary
@@ -2095,7 +2095,7 @@ func runOrderedRootDeltaBatchReadOnlyPrepare(rootZipper *zipper.Zipper, baseRoot
 		return prepared, summary, workerSummary, 0, false, errors.New("missing ordered root zipper")
 	}
 	prepareStart := time.Now()
-	prepared, err := rootZipper.PrepareReadOnly(baseRoot, delta, zipper.ReadOnlyPrepareOptions{})
+	prepared, err := rootZipper.PrepareReadOnly(baseRoot, delta, prepareOpts)
 	prepareNs := orderedRootDeltaGroupPhaseDurationNs(prepareStart)
 	summary = prepared.LeafSpanSummary()
 	workerSummary = prepared.LeafSpanWorkerRangeSummary(workers)
@@ -2106,6 +2106,20 @@ func runOrderedRootDeltaBatchReadOnlyPrepare(rootZipper *zipper.Zipper, baseRoot
 		return prepared, summary, workerSummary, prepareNs, true, fmt.Errorf("treedb: invalid ordered-root read-only apply plan: %w", validationErr)
 	}
 	return prepared, summary, workerSummary, prepareNs, false, nil
+}
+
+func (db *DB) runOrderedRootDeltaBatchReadOnlyPrepare(rootZipper *zipper.Zipper, baseRoot uint64, delta *batch.Batch, workers int) (zipper.ReadOnlyLeafSpanSummary, zipper.ReadOnlyLeafSpanWorkerRangeSummary, uint64, bool, error) {
+	applyOpts := zipper.ApplyOptions{PrepareReadOnly: true, ReadOnlyPrepareWorkers: workers}
+	prepareBuf := db.acquireFlushApplyReadOnlyPrepareBuffer(applyOpts)
+	if prepareBuf != nil {
+		applyOpts.ReadOnlyPrepare = prepareBuf.opts
+	}
+	prepared, summary, workerSummary, prepareNs, validationFailed, err := runOrderedRootDeltaBatchReadOnlyPrepare(rootZipper, baseRoot, delta, workers, applyOpts.ReadOnlyPrepare)
+	if prepareBuf != nil {
+		result := zipper.ApplyResult{ReadOnlyPrepare: prepared}
+		db.releaseFlushApplyReadOnlyPrepareBuffer(prepareBuf, &result)
+	}
+	return summary, workerSummary, prepareNs, validationFailed, err
 }
 
 func addOrderedRootReadOnlyPreparePhaseStats(phases *orderedRootDeltaGroupPublishPhaseStats, summary zipper.ReadOnlyLeafSpanSummary, workerSummary zipper.ReadOnlyLeafSpanWorkerRangeSummary, prepareNs uint64, err error, validationFailed bool) {
@@ -2154,7 +2168,7 @@ func (db *DB) prepareOrderedRootDeltaBatchGroupReadOnly(idx *indexGen, ordered [
 		if err != nil {
 			return err
 		}
-		_, summary, workerSummary, prepareNs, validationFailed, err := runOrderedRootDeltaBatchReadOnlyPrepare(rootZipper, ordered[orderedIdx].BaseRoot, ordered[orderedIdx].Delta, ordered[orderedIdx].ReadOnlyPrepareWorkers)
+		summary, workerSummary, prepareNs, validationFailed, err := db.runOrderedRootDeltaBatchReadOnlyPrepare(rootZipper, ordered[orderedIdx].BaseRoot, ordered[orderedIdx].Delta, ordered[orderedIdx].ReadOnlyPrepareWorkers)
 		addOrderedRootReadOnlyPreparePhaseStats(phaseStats, summary, workerSummary, prepareNs, err, validationFailed)
 		db.observeFlushApplyReadOnlyPrepare(summary, workerSummary, prepareNs, err, validationFailed)
 		if err != nil {
@@ -2493,7 +2507,7 @@ func (db *DB) publishOrderedRootDeltaBatchGroupWithSystemDeltaBuilderSerialized(
 			if prepErr != nil {
 				return 0, nil, prepErr
 			}
-			_, summary, workerSummary, prepareNs, validationFailed, prepErr := runOrderedRootDeltaBatchReadOnlyPrepare(rootZipper, ordered[idx].BaseRoot, ordered[idx].Delta, ordered[idx].ReadOnlyPrepareWorkers)
+			summary, workerSummary, prepareNs, validationFailed, prepErr := db.runOrderedRootDeltaBatchReadOnlyPrepare(rootZipper, ordered[idx].BaseRoot, ordered[idx].Delta, ordered[idx].ReadOnlyPrepareWorkers)
 			addOrderedRootReadOnlyPreparePhaseStats(&phaseStats, summary, workerSummary, prepareNs, prepErr, validationFailed)
 			db.observeFlushApplyReadOnlyPrepare(summary, workerSummary, prepareNs, prepErr, validationFailed)
 			if prepErr != nil {
@@ -2683,7 +2697,7 @@ func (db *DB) publishOrderedRootDeltaBatchGroupWithCommandWALContextAndSystemDel
 			if prepErr != nil {
 				return 0, nil, prepErr
 			}
-			_, summary, workerSummary, prepareNs, validationFailed, prepErr := runOrderedRootDeltaBatchReadOnlyPrepare(rootZipper, allOrdered[idx].BaseRoot, allOrdered[idx].Delta, allOrdered[idx].ReadOnlyPrepareWorkers)
+			summary, workerSummary, prepareNs, validationFailed, prepErr := db.runOrderedRootDeltaBatchReadOnlyPrepare(rootZipper, allOrdered[idx].BaseRoot, allOrdered[idx].Delta, allOrdered[idx].ReadOnlyPrepareWorkers)
 			addOrderedRootReadOnlyPreparePhaseStats(&phaseStats, summary, workerSummary, prepareNs, prepErr, validationFailed)
 			db.observeFlushApplyReadOnlyPrepare(summary, workerSummary, prepareNs, prepErr, validationFailed)
 			if prepErr != nil {

--- a/TreeDB/internal/valuelog/decode_scratch_pool_test.go
+++ b/TreeDB/internal/valuelog/decode_scratch_pool_test.go
@@ -48,6 +48,25 @@ func TestDecodeScratchPool_ReusesLargeBuffer(t *testing.T) {
 	}
 }
 
+func TestFileDecodeScratch_RetainsParallelSmallBuffers(t *testing.T) {
+	f := &File{}
+	first := make([]byte, 0, 32<<10)
+	second := make([]byte, 0, 64<<10)
+	f.releaseDecodeScratch(first)
+	f.releaseDecodeScratch(second)
+
+	gotA := f.takeDecodeScratch(64 << 10)
+	if cap(gotA) < 64<<10 {
+		t.Fatalf("first take cap=%d want >=64KiB", cap(gotA))
+	}
+	gotB := f.takeDecodeScratch(32 << 10)
+	if cap(gotB) < 32<<10 {
+		t.Fatalf("second take cap=%d want >=32KiB", cap(gotB))
+	}
+	f.releaseDecodeScratch(gotA)
+	f.releaseDecodeScratch(gotB)
+}
+
 func TestFileDecodeScratch_ReusesLargeBuffer(t *testing.T) {
 	minCap := maxDecodeScratchKeep + (64 << 10) // 320KiB
 	if minCap > maxLargeDecodeScratchKeep {

--- a/TreeDB/internal/valuelog/frame_preparer.go
+++ b/TreeDB/internal/valuelog/frame_preparer.go
@@ -40,12 +40,52 @@ type FramePreparer struct {
 }
 
 func NewFramePreparer() *FramePreparer {
-	return &FramePreparer{
-		dictFrameEncodeLevel: zstd.SpeedFastest,
-		blockCodec:           BlockCodecSnappy,
-		clock:                RealClock{},
-		keepSafetyMargin:     DefaultKeepSafetyMargin,
+	p := &FramePreparer{}
+	p.ResetForReuse()
+	return p
+}
+
+const framePreparerScratchKeepCap = 8 << 20
+
+// ResetForReuse restores the default policy/hint state while retaining bounded
+// scratch buffers. It is intended for callers that pool FramePreparers between
+// independent append batches without changing compression semantics from a
+// freshly-created preparer.
+func (p *FramePreparer) ResetForReuse() {
+	if p == nil {
+		return
 	}
+	if cap(p.rawScratch) > framePreparerScratchKeepCap {
+		p.rawScratch = nil
+	} else {
+		p.rawScratch = p.rawScratch[:0]
+	}
+	if cap(p.encScratch) > framePreparerScratchKeepCap {
+		p.encScratch = nil
+	} else {
+		p.encScratch = p.encScratch[:0]
+	}
+	if cap(p.blockScratch) > framePreparerScratchKeepCap {
+		p.blockScratch = nil
+	} else {
+		p.blockScratch = p.blockScratch[:0]
+	}
+	p.encLimiter = limitedSliceWriter{}
+	p.skipDictID = 0
+	p.codecs = nil
+	p.noBenefit = 0
+	p.skipRemain = 0
+	p.dictFrameEncodeLevel = zstd.SpeedFastest
+	p.dictFrameEnableEntropy = false
+	p.blockCodec = BlockCodecSnappy
+	p.blockCompression = false
+	p.clock = RealClock{}
+	p.encodeCostModel = nil
+	p.encodeSampleStride = 0
+	p.encodeSampleCount = 0
+	p.keepIoNsPerStoredByte = 0
+	p.keepEncodeNsPerRawByte = 0
+	p.keepSafetyMargin = DefaultKeepSafetyMargin
 }
 
 func (p *FramePreparer) SetDictFrameEncoderOptions(level zstd.EncoderLevel, enableEntropy bool) {

--- a/TreeDB/internal/valuelog/manager.go
+++ b/TreeDB/internal/valuelog/manager.go
@@ -69,9 +69,10 @@ type File struct {
 	cacheLen   int
 	cacheOffs  [MaxFrameK + 1]uint32
 	cacheRaw   []byte
-	// decodeScratch retains one reusable decode buffer for compressed grouped
-	// reads, reducing sync.Pool churn across adjacent frame misses.
-	decodeScratch []byte
+	// decodeScratch retains reusable decode buffers for compressed grouped reads,
+	// reducing sync.Pool churn across adjacent and parallel frame misses.
+	decodeScratch      []byte
+	decodeScratchSpare [][]byte
 	// cacheRawPooled tracks whether cacheRaw currently owns a pooled decode
 	// scratch buffer that must be returned on eviction.
 	cacheRawPooled bool
@@ -213,6 +214,8 @@ func (f *File) setCacheRawLocked(raw []byte, pooled bool) {
 	f.cacheRawPooled = pooled
 }
 
+const fileDecodeScratchSpareKeep = 8
+
 func (f *File) stashDecodeScratch(buf []byte) {
 	if cap(buf) == 0 {
 		return
@@ -223,7 +226,13 @@ func (f *File) stashDecodeScratch(buf []byte) {
 	}
 	f.scratchMu.Lock()
 	defer f.scratchMu.Unlock()
-	buf = buf[:0]
+	f.stashDecodeScratchLocked(buf[:0])
+}
+
+func (f *File) stashDecodeScratchLocked(buf []byte) {
+	if cap(buf) == 0 {
+		return
+	}
 	if cap(f.decodeScratch) == 0 {
 		f.decodeScratch = buf
 		return
@@ -231,7 +240,10 @@ func (f *File) stashDecodeScratch(buf []byte) {
 	if cap(buf) > cap(f.decodeScratch) {
 		old := f.decodeScratch
 		f.decodeScratch = buf
-		putDecodeScratch(old)
+		buf = old
+	}
+	if len(f.decodeScratchSpare) < fileDecodeScratchSpareKeep {
+		f.decodeScratchSpare = append(f.decodeScratchSpare, buf[:0])
 		return
 	}
 	putDecodeScratch(buf)
@@ -242,15 +254,25 @@ func (f *File) takeDecodeScratch(minCap int) []byte {
 		return nil
 	}
 	f.scratchMu.Lock()
-	scratch := f.decodeScratch
-	f.decodeScratch = nil
-	f.scratchMu.Unlock()
-	if cap(scratch) >= minCap {
+	if cap(f.decodeScratch) >= minCap {
+		scratch := f.decodeScratch
+		f.decodeScratch = nil
+		f.scratchMu.Unlock()
 		return scratch[:0]
 	}
-	if scratch != nil {
-		putDecodeScratch(scratch)
+	for i := len(f.decodeScratchSpare) - 1; i >= 0; i-- {
+		if cap(f.decodeScratchSpare[i]) < minCap {
+			continue
+		}
+		scratch := f.decodeScratchSpare[i]
+		last := len(f.decodeScratchSpare) - 1
+		f.decodeScratchSpare[i] = f.decodeScratchSpare[last]
+		f.decodeScratchSpare[last] = nil
+		f.decodeScratchSpare = f.decodeScratchSpare[:last]
+		f.scratchMu.Unlock()
+		return scratch[:0]
 	}
+	f.scratchMu.Unlock()
 	return getDecodeScratch(minCap)
 }
 
@@ -264,20 +286,8 @@ func (f *File) releaseDecodeScratch(buf []byte) {
 	}
 	buf = buf[:0]
 	f.scratchMu.Lock()
-	if cap(f.decodeScratch) == 0 {
-		f.decodeScratch = buf
-		f.scratchMu.Unlock()
-		return
-	}
-	if cap(buf) > cap(f.decodeScratch) {
-		old := f.decodeScratch
-		f.decodeScratch = buf
-		f.scratchMu.Unlock()
-		putDecodeScratch(old)
-		return
-	}
+	f.stashDecodeScratchLocked(buf)
 	f.scratchMu.Unlock()
-	putDecodeScratch(buf)
 }
 
 func (f *File) resetGroupedFrameCacheLocked() {
@@ -449,6 +459,8 @@ func (f *File) Close() error {
 	f.scratchMu.Lock()
 	scratch = f.decodeScratch
 	f.decodeScratch = nil
+	scratchSpare := f.decodeScratchSpare
+	f.decodeScratchSpare = nil
 	f.scratchMu.Unlock()
 	f.groupedMu.Lock()
 	cache := f.groupedFrameCache.Load()
@@ -459,6 +471,9 @@ func (f *File) Close() error {
 	}
 	if scratch != nil {
 		putDecodeScratch(scratch)
+	}
+	for _, buf := range scratchSpare {
+		putDecodeScratch(buf)
 	}
 
 	f.remapMu.Lock()

--- a/TreeDB/internal/valuelog/valuelog_test.go
+++ b/TreeDB/internal/valuelog/valuelog_test.go
@@ -1562,6 +1562,42 @@ func TestFramePreparer_PrepareFrameInto_ReusesBuffer(t *testing.T) {
 	}
 }
 
+func TestFramePreparer_ResetForReuseRestoresDefaultsAndKeepsBoundedScratch(t *testing.T) {
+	records := []Record{
+		{RID: 1, Value: bytes.Repeat([]byte("alpha-001|"), 256)},
+		{RID: 2, Value: bytes.Repeat([]byte("bravo-002|"), 256)},
+	}
+	prep := NewFramePreparer()
+	prep.SetBlockCompression(BlockCodecLZ4, true)
+	prep.SetKeepPolicy(1e9, 0, 1)
+	if _, stats, err := prep.PrepareFrameInto(nil, 0, nil, records); err != nil {
+		t.Fatalf("PrepareFrameInto block: %v", err)
+	} else if !stats.Attempted {
+		t.Fatalf("expected block compression attempt")
+	}
+	rawCap := cap(prep.rawScratch)
+	blockCap := cap(prep.blockScratch)
+	if blockCap == 0 {
+		t.Fatalf("expected block scratch allocation, rawCap=%d blockCap=%d", rawCap, blockCap)
+	}
+	prep.skipDictID = 99
+	prep.noBenefit = 7
+	prep.skipRemain = 13
+	prep.encodeSampleStride = 5
+	prep.encodeSampleCount = 11
+
+	prep.ResetForReuse()
+	if cap(prep.rawScratch) != rawCap || cap(prep.blockScratch) != blockCap {
+		t.Fatalf("scratch caps after reset raw=%d/%d block=%d/%d", cap(prep.rawScratch), rawCap, cap(prep.blockScratch), blockCap)
+	}
+	if prep.blockCodec != BlockCodecSnappy || prep.blockCompression || prep.dictFrameEncodeLevel != zstd.SpeedFastest || prep.keepSafetyMargin != DefaultKeepSafetyMargin {
+		t.Fatalf("defaults not restored: codec=%v block=%v level=%v margin=%v", prep.blockCodec, prep.blockCompression, prep.dictFrameEncodeLevel, prep.keepSafetyMargin)
+	}
+	if prep.skipDictID != 0 || prep.noBenefit != 0 || prep.skipRemain != 0 || prep.encodeSampleStride != 0 || prep.encodeSampleCount != 0 {
+		t.Fatalf("hints/sampling not reset: skipDictID=%d noBenefit=%d skipRemain=%d stride=%d count=%d", prep.skipDictID, prep.noBenefit, prep.skipRemain, prep.encodeSampleStride, prep.encodeSampleCount)
+	}
+}
+
 func TestFramePreparer_KeepPolicySkipsCompression(t *testing.T) {
 	records := []Record{
 		{RID: 1, Value: bytes.Repeat([]byte("alpha-001|"), 32)},

--- a/TreeDB/zipper/read_only_prepare.go
+++ b/TreeDB/zipper/read_only_prepare.go
@@ -347,9 +347,20 @@ func readOnlyPrepareCeilDiv64(n, d int64) int64 {
 // The returned options must not be used while r's LeafSpans are still needed.
 func (r ReadOnlyPrepareResult) ReuseOptions() ReadOnlyPrepareOptions {
 	return ReadOnlyPrepareOptions{
-		leafSpans: r.LeafSpans[:0],
+		leafSpans: clearReadOnlyLeafSpanBuffer(r.LeafSpans),
 		keyArena:  r.keyArena[:0],
 	}
+}
+
+func clearReadOnlyLeafSpanBuffer(spans []ReadOnlyLeafSpan) []ReadOnlyLeafSpan {
+	if cap(spans) == 0 {
+		return nil
+	}
+	// ReadOnlyLeafSpan contains key slices into keyArena. Clear the full backing
+	// array before pooling so stale slice headers beyond len(spans) cannot keep an
+	// oversized/dropped key arena live across later flushes.
+	clear(spans[:cap(spans)])
+	return spans[:0]
 }
 
 // ResetForReuse clears result metadata while retaining bounded reusable
@@ -364,7 +375,7 @@ func (r *ReadOnlyPrepareResult) ResetForReuse() {
 	keyArena := r.keyArena
 	*r = ReadOnlyPrepareResult{}
 	if cap(leafSpans) <= readOnlyPrepareResultReuseLeafSpanKeepCap {
-		r.LeafSpans = leafSpans[:0]
+		r.LeafSpans = clearReadOnlyLeafSpanBuffer(leafSpans)
 	}
 	if cap(keyArena) <= readOnlyPrepareResultReuseKeyArenaKeepCap {
 		r.keyArena = keyArena[:0]

--- a/TreeDB/zipper/read_only_prepare.go
+++ b/TreeDB/zipper/read_only_prepare.go
@@ -210,8 +210,8 @@ type ReadOnlyPrepareResult struct {
 }
 
 const (
-	readOnlyPrepareResultReuseLeafSpanKeepCap = 4096
-	readOnlyPrepareResultReuseKeyArenaKeepCap = 1 << 20
+	readOnlyPrepareResultReuseLeafSpanKeepCap = 65536
+	readOnlyPrepareResultReuseKeyArenaKeepCap = 16 << 20
 )
 
 // LeafSpanSummary returns an allocation-free aggregate view of r's leaf spans.
@@ -530,6 +530,31 @@ func readOnlyPrepareRangeBytes(r batch.DeleteRange) int {
 	return len(r.Start) + len(r.End)
 }
 
+func (r *ReadOnlyPrepareResult) ensureInitialCapacity(ops []batch.Entry, ranges []batch.DeleteRange) {
+	if r == nil {
+		return
+	}
+	spanHint := len(ops) + len(ranges)
+	if spanHint > readOnlyPrepareResultReuseLeafSpanKeepCap {
+		spanHint = readOnlyPrepareResultReuseLeafSpanKeepCap
+	}
+	if spanHint > 0 && cap(r.LeafSpans) < spanHint {
+		r.LeafSpans = make([]ReadOnlyLeafSpan, 0, spanHint)
+	}
+	keyHintUnits := len(ops) + len(ranges)
+	keyHint := 0
+	if keyHintUnits > 0 {
+		if keyHintUnits > readOnlyPrepareResultReuseKeyArenaKeepCap/32 {
+			keyHint = readOnlyPrepareResultReuseKeyArenaKeepCap
+		} else {
+			keyHint = keyHintUnits * 32
+		}
+	}
+	if keyHint > 0 && cap(r.keyArena) < keyHint {
+		r.keyArena = make([]byte, 0, keyHint)
+	}
+}
+
 func (r *ReadOnlyPrepareResult) addLeafSpan(ref page.ChildRef, low, high []byte, ops []batch.Entry, opBase int, ranges []batch.DeleteRange, rangeBase int) {
 	if len(ops) == 0 && len(ranges) == 0 {
 		return
@@ -684,6 +709,7 @@ func (z *Zipper) PrepareReadOnly(rootID uint64, b *batch.Batch, opts ReadOnlyPre
 		result.ExactLeafSpans = true
 		return result, nil
 	}
+	result.ensureInitialCapacity(ops, ranges)
 	maintenance, _ := z.shouldRunMaintenance(ops)
 	if len(ranges) > 0 {
 		maintenance = false

--- a/TreeDB/zipper/read_only_prepare_test.go
+++ b/TreeDB/zipper/read_only_prepare_test.go
@@ -124,6 +124,53 @@ func TestReadOnlyPrepareResultResetForReuseKeepsBoundedBuffers(t *testing.T) {
 	}
 }
 
+func TestReadOnlyPrepareResultResetForReuseClearsLeafSpanReferences(t *testing.T) {
+	arena := []byte("oversized-key-arena")
+	spans := make([]ReadOnlyLeafSpan, 1, 4)
+	spans[0].LowKey = arena[:4]
+	spans = spans[:cap(spans)]
+	spans[3].HighKey = arena[4:]
+	spans = spans[:1]
+
+	r := ReadOnlyPrepareResult{
+		LeafSpans: spans,
+		keyArena:  make([]byte, 1, readOnlyPrepareResultReuseKeyArenaKeepCap+1),
+	}
+	r.ResetForReuse()
+	if len(r.LeafSpans) != 0 || cap(r.LeafSpans) != cap(spans) {
+		t.Fatalf("leaf spans len/cap after reset=%d/%d", len(r.LeafSpans), cap(r.LeafSpans))
+	}
+	cleared := r.LeafSpans[:cap(r.LeafSpans)]
+	for i, span := range cleared {
+		if span.LowKey != nil || span.HighKey != nil || span.FirstOpKey != nil || span.LastOpKey != nil {
+			t.Fatalf("span %d retained key refs after reset: %+v", i, span)
+		}
+	}
+	if r.keyArena != nil {
+		t.Fatalf("oversized key arena retained after reset: cap=%d", cap(r.keyArena))
+	}
+}
+
+func TestReadOnlyPrepareResultReuseOptionsClearsFullLeafSpanCapacity(t *testing.T) {
+	arena := []byte("previous-key-arena")
+	spans := make([]ReadOnlyLeafSpan, 1, 3)
+	spans[0].FirstOpKey = arena[:4]
+	spans = spans[:cap(spans)]
+	spans[2].LastOpKey = arena[4:]
+	spans = spans[:1]
+
+	opts := (ReadOnlyPrepareResult{LeafSpans: spans}).ReuseOptions()
+	if len(opts.leafSpans) != 0 || cap(opts.leafSpans) != cap(spans) {
+		t.Fatalf("reuse leaf spans len/cap=%d/%d", len(opts.leafSpans), cap(opts.leafSpans))
+	}
+	cleared := opts.leafSpans[:cap(opts.leafSpans)]
+	for i, span := range cleared {
+		if span.LowKey != nil || span.HighKey != nil || span.FirstOpKey != nil || span.LastOpKey != nil {
+			t.Fatalf("span %d retained key refs after reuse options: %+v", i, span)
+		}
+	}
+}
+
 func TestReadOnlyPrepareResultEnsureInitialCapacityPresizesBoundedBuffers(t *testing.T) {
 	ops := make([]batch.Entry, 128)
 	var r ReadOnlyPrepareResult

--- a/TreeDB/zipper/read_only_prepare_test.go
+++ b/TreeDB/zipper/read_only_prepare_test.go
@@ -101,6 +101,48 @@ func TestZipperPrepareReadOnlyEmptyBatchDoesNotTraverse(t *testing.T) {
 	}
 }
 
+func TestReadOnlyPrepareResultResetForReuseKeepsBoundedBuffers(t *testing.T) {
+	bounded := ReadOnlyPrepareResult{
+		LeafSpans: make([]ReadOnlyLeafSpan, 3, readOnlyPrepareResultReuseLeafSpanKeepCap),
+		keyArena:  make([]byte, 7, readOnlyPrepareResultReuseKeyArenaKeepCap),
+	}
+	bounded.ResetForReuse()
+	if len(bounded.LeafSpans) != 0 || cap(bounded.LeafSpans) != readOnlyPrepareResultReuseLeafSpanKeepCap {
+		t.Fatalf("bounded leaf spans len/cap=%d/%d", len(bounded.LeafSpans), cap(bounded.LeafSpans))
+	}
+	if len(bounded.keyArena) != 0 || cap(bounded.keyArena) != readOnlyPrepareResultReuseKeyArenaKeepCap {
+		t.Fatalf("bounded key arena len/cap=%d/%d", len(bounded.keyArena), cap(bounded.keyArena))
+	}
+
+	oversized := ReadOnlyPrepareResult{
+		LeafSpans: make([]ReadOnlyLeafSpan, 1, readOnlyPrepareResultReuseLeafSpanKeepCap+1),
+		keyArena:  make([]byte, 1, readOnlyPrepareResultReuseKeyArenaKeepCap+1),
+	}
+	oversized.ResetForReuse()
+	if oversized.LeafSpans != nil || oversized.keyArena != nil {
+		t.Fatalf("oversized buffers retained: leaf cap=%d key cap=%d", cap(oversized.LeafSpans), cap(oversized.keyArena))
+	}
+}
+
+func TestReadOnlyPrepareResultEnsureInitialCapacityPresizesBoundedBuffers(t *testing.T) {
+	ops := make([]batch.Entry, 128)
+	var r ReadOnlyPrepareResult
+	r.ensureInitialCapacity(ops, nil)
+	if cap(r.LeafSpans) != len(ops) {
+		t.Fatalf("leaf span cap=%d want %d", cap(r.LeafSpans), len(ops))
+	}
+	if cap(r.keyArena) != len(ops)*32 {
+		t.Fatalf("key arena cap=%d want %d", cap(r.keyArena), len(ops)*32)
+	}
+
+	ops = make([]batch.Entry, readOnlyPrepareResultReuseLeafSpanKeepCap+100)
+	r = ReadOnlyPrepareResult{}
+	r.ensureInitialCapacity(ops, nil)
+	if cap(r.LeafSpans) != readOnlyPrepareResultReuseLeafSpanKeepCap {
+		t.Fatalf("capped leaf span cap=%d want %d", cap(r.LeafSpans), readOnlyPrepareResultReuseLeafSpanKeepCap)
+	}
+}
+
 func TestZipperPrepareReadOnlyColdAndSingleLeafPlans(t *testing.T) {
 	cold := batch.New(panicValueReader{}, page.DefaultInlineThreshold)
 	defer func() { _ = cold.Close() }()


### PR DESCRIPTION
## Summary

Implements TreeDB parallel-flush M6 allocation/lock-pressure cleanup for checkpoint-inclusive write workloads.

- Pools/reuses value-log `FramePreparer` instances on the serial prepare path and adds `ResetForReuse` so pooled preparers do not retain compression policy/hint state.
- Adds bounded DB-level reuse for `ReadOnlyPrepareResult` span/key buffers across flush apply and ordered-root read-only prepare paths.
- Raises the bounded read-only prepare reuse caps to cover the observed 10M checkpoint workload (`spans_max=54555`) and pre-sizes buffers before leaf-span discovery.
- Retains a bounded per-file set of value-log decode scratch buffers to reduce sync.Pool churn under parallel grouped-frame reads.
- Adds unit/race coverage for reset/reuse behavior.

Fixes #2757.

## Benchmark evidence

Command shape used for before/after 10M runs:

```sh
./bin/unified-bench \
  -dbs treedb \
  -test sequential_write,batch_random \
  -keys 10000000 \
  -profile-dir "$OUT" \
  -path-label=native-fastpath \
  -treedb-journal-lanes=1 \
  -treedb-flush-apply-concurrency=16 \
  -treedb-flush-apply-min-entries=1 \
  -treedb-flush-apply-min-spans=1 \
  -treedb-flush-apply-min-bytes=1 \
  -checkpoint-between-tests \
  -progress=false
```

Baseline (`0c7cd7040`, `/tmp/2757_before_10m_20260614_162427`):

- Sequential Write: `2,705,491` ops/s
- Batch Random: `425,285` ops/s
- Checkpoint before Batch Random: `744.06ms`
- Post-run checkpoint: `13.49s`
- `allocs_batch_random_treedb.pprof`: `16.98GB total`
  - `valuelog.encodeBlockPayload`: `6.82GB`
  - `ReadOnlyPrepareResult.addLeafSpan`: `1.61GB` flat / `1.89GB` cum
  - `ReadOnlyPrepareResult.cloneKey`: `0.66GB`
  - `valuelog.NewFramePreparer`: `0.35GB`
- Stats:
  - `treedb.cache.flush_apply.leaf_log_encode_compress_ns_total=15302512786`
  - `treedb.flush_apply.read_only_prepare.ns_total=13014186452`
  - `treedb.flush_apply.apply_ns_total=18903054882`

After (`/tmp/2757_after6_10m_20260614_163035`):

- Sequential Write: `2,694,931` ops/s
- Batch Random: `457,107` ops/s (~+7.5%)
- Checkpoint before Batch Random: `882.47ms`
- Post-run checkpoint: `12.63s` (~-6.4%)
- `allocs_batch_random_treedb.pprof`: `4.91GB total` (~-71%)
  - `valuelog.encodeBlockPayload` no longer appears in top allocation rows
  - `valuelog.NewFramePreparer` no longer appears in top allocation rows
  - `ReadOnlyPrepareResult.addLeafSpan` no longer appears in top allocation rows
  - Remaining top allocation classes are mostly batch/memtable arenas and `valuelog.getDecodeScratch` (`74.20MB`)
- Stats:
  - `treedb.cache.flush_apply.leaf_log_encode_compress_ns_total=11187398786` (~-27%)
  - `treedb.flush_apply.read_only_prepare.ns_total=11980640690` (~-8%)
  - `treedb.flush_apply.apply_ns_total=17325486757` (~-8%)

CPU after 10M still shows the next bottleneck as actual LZ4 decode/compress and merge work (`mergeLeaf` / `readViaMmapViewTo`), not the eliminated prepare allocations.

## Tests

```sh
go test ./TreeDB/internal/valuelog ./TreeDB/zipper ./TreeDB/db ./TreeDB/caching ./TreeDB -count=1
go test ./cmd/unified_bench ./cmd/benchprof ./cmd/internal/treedbstats ./internal/benchprof -count=1
go test -race ./TreeDB/db -run 'TestFlushApply(CloseAndCheckpointDrainInProgressApply|ConcurrencyUsesBoundedWorkerPoolForPointSpans|RootMismatchRetriesWithoutPublishingAbandonedWork|RootMismatchTracksAbandonedLeafLogOutput)' -count=1
go test -race ./TreeDB/caching -run 'Test(FlushCoordinator|WaitForStopWithConcurrentFlushTrigger|StopBackpressureFlushesAndReturns|VlogFramePreparerPoolResetsCompressionState)' -count=1
go test -race ./TreeDB/internal/valuelog -run 'Test(FileDecodeScratch|ValueLogManager_ReadUnsafeTo_CompressedGrouped|ManagerReadUnsafeAppendBatch_Grouped)' -count=1
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage to ensure pooled internal buffers are correctly reset between uses, including compression state and read-only preparation buffer lifecycle/capacity behavior.
* **Bug Fixes**
  * Prevented stale state from being retained across reuse in read-only prepare and value-log frame preparation, improving correctness under pooled reuse.
* **Chores**
  * Improved internal memory efficiency with pooling and more controlled buffer reuse, including safer reuse thresholds and buffer pre-sizing to reduce unnecessary allocations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->