### PR TITLE
TreeDB parallel flush M10: span-native apply engine and reducer

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -7290,6 +7290,10 @@ type Options struct {
 	FlushApplyMinSpans int
 	// FlushApplyMinBytes gates backend opt-in parallel apply by planned bytes.
 	FlushApplyMinBytes int
+	// FlushApplySpanNative enables backend M10 opt-in span-native apply. The
+	// backend owns execution; cached mode carries this knob for config/reporting
+	// symmetry and keeps the path default-off.
+	FlushApplySpanNative bool
 
 	// FlushBackendMaxEntries caps how many operations are buffered into a single
 	// backend batch before committing it and continuing with a fresh batch.
@@ -7869,6 +7873,7 @@ type DB struct {
 	flushApplyMinEntries                              int
 	flushApplyMinSpans                                int
 	flushApplyMinBytes                                int
+	flushApplySpanNative                              bool
 	flushBackendMaxEntries                            int
 	flushBackendInitEntries                           int
 	flushBackendMaxBatches                            int
@@ -10781,6 +10786,7 @@ func Open(dir string, backend BackendDB, opts Options) (*DB, error) {
 		flushApplyMinEntries:                 opts.FlushApplyMinEntries,
 		flushApplyMinSpans:                   opts.FlushApplyMinSpans,
 		flushApplyMinBytes:                   opts.FlushApplyMinBytes,
+		flushApplySpanNative:                 opts.FlushApplySpanNative,
 		flushBackendMaxEntries:               opts.FlushBackendMaxEntries,
 		flushBackendInitEntries:              flushBackendInitEntries,
 		flushBackendMaxBatches:               opts.FlushBackendMaxBatches,

--- a/TreeDB/db/batch.go
+++ b/TreeDB/db/batch.go
@@ -294,7 +294,7 @@ func (b *Batch) writeOptimistic(sync bool, intent *commandWALBatchIntent) (bool,
 	var retired []uint64
 	var metrics adaptive.Metrics
 	var err error
-	if applyOpts.ParallelApplyConcurrency > 1 {
+	if flushApplyUseOptions(applyOpts) {
 		result, applyErr := z.ApplyWithOptions(rootID, b.batch, applyOpts)
 		b.db.observeFlushApplyPrepareResult(result, applyErr)
 		b.db.releaseFlushApplyReadOnlyPrepareBuffer(prepareBuf, &result)
@@ -430,7 +430,7 @@ func (b *Batch) writeSerialized(sync bool, intent *commandWALBatchIntent) error 
 	var retired []uint64
 	var metrics adaptive.Metrics
 	var err error
-	if applyOpts.ParallelApplyConcurrency > 1 {
+	if flushApplyUseOptions(applyOpts) {
 		result, applyErr := idx.zipper.ApplyWithOptions(rootID, b.batch, applyOpts)
 		b.db.observeFlushApplyPrepareResult(result, applyErr)
 		b.db.releaseFlushApplyReadOnlyPrepareBuffer(prepareBuf, &result)

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -334,6 +334,8 @@ type DB struct {
 	flushApplySpanNativeCandidateSpans            atomic.Uint64
 	flushApplySpanNativeEligibleOps               atomic.Uint64
 	flushApplySpanNativeEligibleSpans             atomic.Uint64
+	flushApplySpanNativeUsedOps                   atomic.Uint64
+	flushApplySpanNativeUsedSpans                 atomic.Uint64
 	flushApplySpanNativeIneligibleOps             atomic.Uint64
 	flushApplySpanNativeIneligibleSpans           atomic.Uint64
 	flushApplySpanNativeFallbacks                 atomic.Uint64

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -349,6 +349,7 @@ type DB struct {
 	flushApplyMinEntries  int
 	flushApplyMinSpans    int
 	flushApplyMinBytes    int
+	flushApplySpanNative  bool
 	flushApplyWorkerPool  *zipper.ApplyWorkerPool
 
 	flushApplyReadOnlyPrepareMu   sync.Mutex
@@ -991,6 +992,10 @@ type Options struct {
 	// FlushApplyMinBytes gates opt-in parallel apply by planned span bytes.
 	// Values <=0 use the internal default.
 	FlushApplyMinBytes int
+	// FlushApplySpanNative enables the M10 opt-in span-native apply candidate
+	// path. It is default-off and initially restricted to exact point spans; all
+	// unsupported runs fall back to recursive apply.
+	FlushApplySpanNative bool
 
 	// FlushBackendMaxEntries caps how many operations are buffered into a single
 	// backend batch before committing it and continuing with a fresh batch.
@@ -1611,6 +1616,7 @@ func openWithLock(opts Options, lock *lockfile.Lock) (*DB, error) {
 		flushApplyMinEntries:           opts.FlushApplyMinEntries,
 		flushApplyMinSpans:             opts.FlushApplyMinSpans,
 		flushApplyMinBytes:             opts.FlushApplyMinBytes,
+		flushApplySpanNative:           opts.FlushApplySpanNative,
 		flushApplyWorkerPool:           flushApplyWorkerPool,
 		dir:                            opts.Dir,
 		columnAssetRootDir:             layout.columnAssetDir,

--- a/TreeDB/db/flush_apply_options.go
+++ b/TreeDB/db/flush_apply_options.go
@@ -23,6 +23,10 @@ func (db *DB) flushApplyOptions() zipper.ApplyOptions {
 	}
 }
 
+func flushApplyUseOptions(opts zipper.ApplyOptions) bool {
+	return opts.ParallelApplyConcurrency > 1 || opts.SpanNativeApply || opts.PrepareReadOnly
+}
+
 func (db *DB) observeFlushApplyPrepareResult(result zipper.ApplyResult, err error) {
 	if db == nil || !result.ReadOnlyPrepareRequested {
 		return

--- a/TreeDB/db/flush_apply_options.go
+++ b/TreeDB/db/flush_apply_options.go
@@ -35,7 +35,9 @@ func (db *DB) observeFlushApplyPrepareResult(result zipper.ApplyResult, err erro
 	db.observeFlushApplyReadOnlyPrepare(summary, workerSummary, result.ReadOnlyPrepareNs, err, result.ReadOnlyPrepareValidationFailed)
 	if result.SpanNativeEligible {
 		db.observeFlushApplySpanNativeEligible(summary)
-		if !result.SpanNativeUsed {
+		if result.SpanNativeUsed {
+			db.observeFlushApplySpanNativeUsed(summary)
+		} else {
 			db.observeFlushApplySpanNativeFallbackAfterCandidate(summary, FlushSpanRunFallbackSpanNativeNotImplemented, false)
 		}
 		return

--- a/TreeDB/db/flush_apply_options.go
+++ b/TreeDB/db/flush_apply_options.go
@@ -5,17 +5,21 @@ import (
 )
 
 func (db *DB) flushApplyOptions() zipper.ApplyOptions {
-	if db == nil || db.flushApplyConcurrency <= 1 {
+	if db == nil {
+		return zipper.ApplyOptions{}
+	}
+	if db.flushApplyConcurrency <= 1 && !db.flushApplySpanNative {
 		return zipper.ApplyOptions{}
 	}
 	return zipper.ApplyOptions{
-		PrepareReadOnly:           true,
+		PrepareReadOnly:           db.flushApplyConcurrency > 1 || db.flushApplySpanNative,
 		ReadOnlyPrepareWorkers:    db.flushApplyConcurrency,
 		ParallelApplyConcurrency:  db.flushApplyConcurrency,
 		ParallelApplyWorkerPool:   db.flushApplyWorkerPool,
 		ParallelApplyMinSpans:     db.flushApplyMinSpans,
 		ParallelApplyMinSpanOps:   db.flushApplyMinEntries,
 		ParallelApplyMinSpanBytes: db.flushApplyMinBytes,
+		SpanNativeApply:           db.flushApplySpanNative,
 	}
 }
 
@@ -29,5 +33,12 @@ func (db *DB) observeFlushApplyPrepareResult(result zipper.ApplyResult, err erro
 		workerSummary = result.ReadOnlyPrepare.LeafSpanWorkerRangeSummary(db.flushApplyConcurrency)
 	}
 	db.observeFlushApplyReadOnlyPrepare(summary, workerSummary, result.ReadOnlyPrepareNs, err, result.ReadOnlyPrepareValidationFailed)
+	if result.SpanNativeEligible {
+		db.observeFlushApplySpanNativeEligible(summary)
+		if !result.SpanNativeUsed {
+			db.observeFlushApplySpanNativeFallbackAfterCandidate(summary, FlushSpanRunFallbackSpanNativeNotImplemented, false)
+		}
+		return
+	}
 	db.observeFlushApplySpanNativeFallback(summary, classifyFlushApplySpanNativeFallback(summary, err, result.ReadOnlyPrepareValidationFailed))
 }

--- a/TreeDB/db/flush_apply_parallel_test.go
+++ b/TreeDB/db/flush_apply_parallel_test.go
@@ -406,6 +406,41 @@ func TestFlushApplySpanNativePartialMultiLeafParentStitchWithStats(t *testing.T)
 	}
 }
 
+func TestFlushApplySpanNativeSparsePointSpansWithStats(t *testing.T) {
+	d := openFlushApplyTestDBWithSpanNative(t, 4, true)
+	putBatch(t, d, 0, 12000, "base")
+	usedBefore := requireDBStatUint64(t, d, "treedb.flush_apply.span_native.used_ops_total")
+	fallbackBefore := requireDBStatUint64(t, d, "treedb.flush_apply.span_native.fallback.reason.span_native_not_implemented.ops_total")
+
+	b := d.NewBatch()
+	updated := []int{17, 997, 2049, 4097, 6143, 8191, 11003}
+	for _, i := range updated {
+		key := []byte(fmt.Sprintf("key-%06d", i))
+		if err := b.Set(key, []byte(fmt.Sprintf("sparse-%06d", i))); err != nil {
+			t.Fatalf("Set sparse %d: %v", i, err)
+		}
+	}
+	if err := b.Write(); err != nil {
+		t.Fatalf("sparse Write: %v", err)
+	}
+	for _, i := range updated {
+		key := []byte(fmt.Sprintf("key-%06d", i))
+		want := fmt.Sprintf("sparse-%06d", i)
+		if got, err := d.Get(key); err != nil || string(got) != want {
+			t.Fatalf("updated key %q got=%q err=%v want %q", key, got, err, want)
+		}
+	}
+	if got, err := d.Get([]byte("key-000123")); err != nil || string(got) != "base-000123" {
+		t.Fatalf("untouched key got=%q err=%v", got, err)
+	}
+	if got := requireDBStatUint64(t, d, "treedb.flush_apply.span_native.used_ops_total"); got <= usedBefore {
+		t.Fatalf("span-native used ops delta=%d want >0 for sparse point spans", got-usedBefore)
+	}
+	if got := requireDBStatUint64(t, d, "treedb.flush_apply.span_native.fallback.reason.span_native_not_implemented.ops_total"); got != fallbackBefore {
+		t.Fatalf("span-native not-implemented fallback ops delta=%d want 0 for sparse point spans", got-fallbackBefore)
+	}
+}
+
 func TestFlushApplySpanNativeRootMismatchTracksAbandonedLeafLogOutput(t *testing.T) {
 	d := openFlushApplyLeafLogTestDBWithSpanNative(t, 4, true)
 	putBatch(t, d, 0, 9000, "base")

--- a/TreeDB/db/flush_apply_parallel_test.go
+++ b/TreeDB/db/flush_apply_parallel_test.go
@@ -73,6 +73,10 @@ func (l *lockedRewriteLeafPageLog) CurrentValueLogSegment() (string, uint32, boo
 }
 
 func openFlushApplyTestDB(t *testing.T, concurrency int) *DB {
+	return openFlushApplyTestDBWithSpanNative(t, concurrency, false)
+}
+
+func openFlushApplyTestDBWithSpanNative(t *testing.T, concurrency int, spanNative bool) *DB {
 	t.Helper()
 	d, err := Open(Options{
 		Dir:                   t.TempDir(),
@@ -81,9 +85,10 @@ func openFlushApplyTestDB(t *testing.T, concurrency int) *DB {
 		FlushApplyMinEntries:  1,
 		FlushApplyMinSpans:    1,
 		FlushApplyMinBytes:    1,
+		FlushApplySpanNative:  spanNative,
 	})
 	if err != nil {
-		t.Fatalf("Open(concurrency=%d): %v", concurrency, err)
+		t.Fatalf("Open(concurrency=%d spanNative=%v): %v", concurrency, spanNative, err)
 	}
 	t.Cleanup(func() { _ = d.Close() })
 	return d
@@ -362,6 +367,42 @@ func TestFlushApplyRootMismatchTracksAbandonedLeafLogOutput(t *testing.T) {
 	}
 	if prepared < installed+abandoned {
 		t.Fatalf("prepared leaf-log output=%d < installed+abandoned=%d+%d", prepared, installed, abandoned)
+	}
+}
+
+func TestFlushApplySpanNativePartialMultiLeafFallsBackWithStats(t *testing.T) {
+	d := openFlushApplyTestDBWithSpanNative(t, 4, true)
+	putBatch(t, d, 0, 9000, "base")
+	usedBefore := requireDBStatUint64(t, d, "treedb.flush_apply.span_native.used_ops_total")
+	fallbackBefore := requireDBStatUint64(t, d, "treedb.flush_apply.span_native.fallback.reason.span_native_not_implemented.ops_total")
+
+	b := d.NewBatch()
+	for i := 2000; i < 7000; i++ {
+		key := []byte(fmt.Sprintf("key-%06d", i))
+		if err := b.Set(key, []byte(fmt.Sprintf("partial-%06d", i))); err != nil {
+			t.Fatalf("Set %d: %v", i, err)
+		}
+	}
+	if err := b.Write(); err != nil {
+		t.Fatalf("partial Write: %v", err)
+	}
+	if got, err := d.Get([]byte("key-000123")); err != nil || string(got) != "base-000123" {
+		t.Fatalf("untouched left key got=%q err=%v", got, err)
+	}
+	if got, err := d.Get([]byte("key-003456")); err != nil || string(got) != "partial-003456" {
+		t.Fatalf("updated key got=%q err=%v", got, err)
+	}
+	if got, err := d.Get([]byte("key-008000")); err != nil || string(got) != "base-008000" {
+		t.Fatalf("untouched right key got=%q err=%v", got, err)
+	}
+	if got := requireDBStatUint64(t, d, "treedb.flush_apply.span_native.eligible_ops_total"); got == 0 {
+		t.Fatalf("span-native eligible ops = 0, want partial run classified before fallback")
+	}
+	if got := requireDBStatUint64(t, d, "treedb.flush_apply.span_native.used_ops_total"); got != usedBefore {
+		t.Fatalf("span-native used ops delta=%d want 0 for partial parent-stitch fallback", got-usedBefore)
+	}
+	if got := requireDBStatUint64(t, d, "treedb.flush_apply.span_native.fallback.reason.span_native_not_implemented.ops_total"); got <= fallbackBefore {
+		t.Fatalf("span-native not-implemented fallback ops delta=%d want >0", got-fallbackBefore)
 	}
 }
 

--- a/TreeDB/db/flush_apply_parallel_test.go
+++ b/TreeDB/db/flush_apply_parallel_test.go
@@ -370,7 +370,7 @@ func TestFlushApplyRootMismatchTracksAbandonedLeafLogOutput(t *testing.T) {
 	}
 }
 
-func TestFlushApplySpanNativePartialMultiLeafFallsBackWithStats(t *testing.T) {
+func TestFlushApplySpanNativePartialMultiLeafParentStitchWithStats(t *testing.T) {
 	d := openFlushApplyTestDBWithSpanNative(t, 4, true)
 	putBatch(t, d, 0, 9000, "base")
 	usedBefore := requireDBStatUint64(t, d, "treedb.flush_apply.span_native.used_ops_total")
@@ -398,11 +398,11 @@ func TestFlushApplySpanNativePartialMultiLeafFallsBackWithStats(t *testing.T) {
 	if got := requireDBStatUint64(t, d, "treedb.flush_apply.span_native.eligible_ops_total"); got == 0 {
 		t.Fatalf("span-native eligible ops = 0, want partial run classified before fallback")
 	}
-	if got := requireDBStatUint64(t, d, "treedb.flush_apply.span_native.used_ops_total"); got != usedBefore {
-		t.Fatalf("span-native used ops delta=%d want 0 for partial parent-stitch fallback", got-usedBefore)
+	if got := requireDBStatUint64(t, d, "treedb.flush_apply.span_native.used_ops_total"); got <= usedBefore {
+		t.Fatalf("span-native used ops delta=%d want >0 for partial parent-stitch path", got-usedBefore)
 	}
-	if got := requireDBStatUint64(t, d, "treedb.flush_apply.span_native.fallback.reason.span_native_not_implemented.ops_total"); got <= fallbackBefore {
-		t.Fatalf("span-native not-implemented fallback ops delta=%d want >0", got-fallbackBefore)
+	if got := requireDBStatUint64(t, d, "treedb.flush_apply.span_native.fallback.reason.span_native_not_implemented.ops_total"); got != fallbackBefore {
+		t.Fatalf("span-native not-implemented fallback ops delta=%d want 0 for partial parent-stitch path", got-fallbackBefore)
 	}
 }
 

--- a/TreeDB/db/flush_apply_parallel_test.go
+++ b/TreeDB/db/flush_apply_parallel_test.go
@@ -441,6 +441,37 @@ func TestFlushApplySpanNativeSparsePointSpansWithStats(t *testing.T) {
 	}
 }
 
+func TestFlushApplySpanNativeSingleWorkerUsesApplyWithOptionsStats(t *testing.T) {
+	d := openFlushApplyTestDBWithSpanNative(t, 1, true)
+	putBatch(t, d, 0, 4096, "base")
+	prepareBefore := requireDBStatUint64(t, d, "treedb.flush_apply.read_only_prepare.calls_total")
+	usedBefore := requireDBStatUint64(t, d, "treedb.flush_apply.span_native.used_ops_total")
+	fallbackBefore := requireDBStatUint64(t, d, "treedb.flush_apply.span_native.fallback.reason.span_native_not_implemented.ops_total")
+
+	b := d.NewBatch()
+	for i := 0; i < 4096; i++ {
+		key := []byte(fmt.Sprintf("key-%06d", i))
+		if err := b.Set(key, []byte(fmt.Sprintf("single-%06d", i))); err != nil {
+			t.Fatalf("Set %d: %v", i, err)
+		}
+	}
+	if err := b.Write(); err != nil {
+		t.Fatalf("single-worker span-native Write: %v", err)
+	}
+	if got, err := d.Get([]byte("key-000123")); err != nil || string(got) != "single-000123" {
+		t.Fatalf("updated key got=%q err=%v", got, err)
+	}
+	if got := requireDBStatUint64(t, d, "treedb.flush_apply.read_only_prepare.calls_total"); got <= prepareBefore {
+		t.Fatalf("read-only prepare calls delta=%d want >0 for span-native single-worker path", got-prepareBefore)
+	}
+	if got := requireDBStatUint64(t, d, "treedb.flush_apply.span_native.used_ops_total"); got <= usedBefore {
+		t.Fatalf("span-native used ops delta=%d want >0 with FlushApplySpanNative and concurrency=1", got-usedBefore)
+	}
+	if got := requireDBStatUint64(t, d, "treedb.flush_apply.span_native.fallback.reason.span_native_not_implemented.ops_total"); got != fallbackBefore {
+		t.Fatalf("span-native not-implemented fallback ops delta=%d want 0 for single-worker path", got-fallbackBefore)
+	}
+}
+
 func TestFlushApplySpanNativeRootMismatchTracksAbandonedLeafLogOutput(t *testing.T) {
 	d := openFlushApplyLeafLogTestDBWithSpanNative(t, 4, true)
 	putBatch(t, d, 0, 9000, "base")

--- a/TreeDB/db/flush_apply_parallel_test.go
+++ b/TreeDB/db/flush_apply_parallel_test.go
@@ -90,6 +90,10 @@ func openFlushApplyTestDB(t *testing.T, concurrency int) *DB {
 }
 
 func openFlushApplyLeafLogTestDB(t *testing.T, concurrency int) *DB {
+	return openFlushApplyLeafLogTestDBWithSpanNative(t, concurrency, false)
+}
+
+func openFlushApplyLeafLogTestDBWithSpanNative(t *testing.T, concurrency int, spanNative bool) *DB {
 	t.Helper()
 	d, err := Open(Options{
 		Dir:                        t.TempDir(),
@@ -99,6 +103,7 @@ func openFlushApplyLeafLogTestDB(t *testing.T, concurrency int) *DB {
 		FlushApplyMinEntries:       1,
 		FlushApplyMinSpans:         1,
 		FlushApplyMinBytes:         1,
+		FlushApplySpanNative:       spanNative,
 		ValueLog: ValueLogOptions{
 			Compression: ValueLogCompressionBlock,
 			BlockCodec:  ValueLogBlockLZ4,
@@ -357,6 +362,58 @@ func TestFlushApplyRootMismatchTracksAbandonedLeafLogOutput(t *testing.T) {
 	}
 	if prepared < installed+abandoned {
 		t.Fatalf("prepared leaf-log output=%d < installed+abandoned=%d+%d", prepared, installed, abandoned)
+	}
+}
+
+func TestFlushApplySpanNativeRootMismatchTracksAbandonedLeafLogOutput(t *testing.T) {
+	d := openFlushApplyLeafLogTestDBWithSpanNative(t, 4, true)
+	putBatch(t, d, 0, 9000, "base")
+
+	var fired atomic.Bool
+	d.testAfterOptimisticApplyHook = func() {
+		if !fired.CompareAndSwap(false, true) {
+			return
+		}
+		other := d.NewBatch()
+		if err := other.Set([]byte("key-concurrent"), []byte("concurrent")); err != nil {
+			t.Fatalf("concurrent Set: %v", err)
+		}
+		if err := other.Write(); err != nil {
+			t.Fatalf("concurrent Write: %v", err)
+		}
+	}
+	defer func() { d.testAfterOptimisticApplyHook = nil }()
+
+	b := d.NewBatch()
+	for i := 0; i < 9000; i++ {
+		key := []byte(fmt.Sprintf("key-%06d", i))
+		if err := b.Set(key, []byte(fmt.Sprintf("span-retry-%06d", i))); err != nil {
+			t.Fatalf("Set %d: %v", i, err)
+		}
+	}
+	if err := b.Write(); err != nil {
+		t.Fatalf("Write with retry: %v", err)
+	}
+	if got, err := d.Get([]byte("key-concurrent")); err != nil || string(got) != "concurrent" {
+		t.Fatalf("concurrent value got=%q err=%v", got, err)
+	}
+	if got, err := d.Get([]byte("key-000123")); err != nil || string(got) != "span-retry-000123" {
+		t.Fatalf("retried value got=%q err=%v", got, err)
+	}
+	if got := requireDBStatUint64(t, d, "treedb.flush_apply.span_native.used_ops_total"); got == 0 {
+		t.Fatalf("span-native used ops = 0, want first optimistic attempt to run span-native")
+	}
+	if got := requireDBStatUint64(t, d, "treedb.flush_apply.mismatch_total"); got == 0 {
+		t.Fatalf("mismatch stat=0 want >0")
+	}
+	if got := requireDBStatUint64(t, d, "treedb.flush_apply.retry_total"); got == 0 {
+		t.Fatalf("retry stat=0 want >0")
+	}
+	if got := requireDBStatUint64(t, d, "treedb.flush_apply.prepared_output.leaf_log_pages_abandoned_total"); got == 0 {
+		t.Fatalf("abandoned leaf-log output = 0, want span-native retry output counted")
+	}
+	if got := requireDBStatUint64(t, d, "treedb.flush_apply.prepared_output.leaf_log_pages_installed_total"); got == 0 {
+		t.Fatalf("installed leaf-log output = 0, want final retry output counted")
 	}
 }
 

--- a/TreeDB/db/flush_apply_stats.go
+++ b/TreeDB/db/flush_apply_stats.go
@@ -108,13 +108,24 @@ func (db *DB) observeFlushApplySpanNativeCandidate(summary zipper.ReadOnlyLeafSp
 	return ops, spans
 }
 
-func (db *DB) observeFlushApplySpanNativeEligible(summary zipper.ReadOnlyLeafSpanSummary) {
+func (db *DB) observeFlushApplySpanNativeEligible(summary zipper.ReadOnlyLeafSpanSummary) (int, int) {
 	ops, spans := db.observeFlushApplySpanNativeCandidate(summary)
 	if ops > 0 {
 		db.flushApplySpanNativeEligibleOps.Add(uint64(ops))
 	}
 	if spans > 0 {
 		db.flushApplySpanNativeEligibleSpans.Add(uint64(spans))
+	}
+	return ops, spans
+}
+
+func (db *DB) observeFlushApplySpanNativeUsed(summary zipper.ReadOnlyLeafSpanSummary) {
+	ops, spans := flushApplySpanNativeOpsAndSpans(summary)
+	if ops > 0 {
+		db.flushApplySpanNativeUsedOps.Add(uint64(ops))
+	}
+	if spans > 0 {
+		db.flushApplySpanNativeUsedSpans.Add(uint64(spans))
 	}
 }
 
@@ -374,6 +385,8 @@ func (db *DB) appendFlushApplyStats(stats map[string]string) {
 	stats["treedb.flush_apply.span_native.candidate_spans_total"] = fmt.Sprintf("%d", db.flushApplySpanNativeCandidateSpans.Load())
 	stats["treedb.flush_apply.span_native.eligible_ops_total"] = fmt.Sprintf("%d", db.flushApplySpanNativeEligibleOps.Load())
 	stats["treedb.flush_apply.span_native.eligible_spans_total"] = fmt.Sprintf("%d", db.flushApplySpanNativeEligibleSpans.Load())
+	stats["treedb.flush_apply.span_native.used_ops_total"] = fmt.Sprintf("%d", db.flushApplySpanNativeUsedOps.Load())
+	stats["treedb.flush_apply.span_native.used_spans_total"] = fmt.Sprintf("%d", db.flushApplySpanNativeUsedSpans.Load())
 	stats["treedb.flush_apply.span_native.ineligible_ops_total"] = fmt.Sprintf("%d", db.flushApplySpanNativeIneligibleOps.Load())
 	stats["treedb.flush_apply.span_native.ineligible_spans_total"] = fmt.Sprintf("%d", db.flushApplySpanNativeIneligibleSpans.Load())
 	stats["treedb.flush_apply.span_native.fallbacks_total"] = fmt.Sprintf("%d", db.flushApplySpanNativeFallbacks.Load())

--- a/TreeDB/db/flush_apply_stats.go
+++ b/TreeDB/db/flush_apply_stats.go
@@ -86,29 +86,64 @@ func (db *DB) observeFlushApplyReadOnlyPrepare(summary zipper.ReadOnlyLeafSpanSu
 	}
 }
 
-func (db *DB) observeFlushApplySpanNativeFallback(summary zipper.ReadOnlyLeafSpanSummary, reason FlushSpanRunFallbackReason) {
+func flushApplySpanNativeOpsAndSpans(summary zipper.ReadOnlyLeafSpanSummary) (int, int) {
+	ops := summary.Ops
+	if ops <= 0 {
+		ops = summary.SpanOps
+	}
+	return ops, summary.Spans
+}
+
+func (db *DB) observeFlushApplySpanNativeCandidate(summary zipper.ReadOnlyLeafSpanSummary) (int, int) {
+	if db == nil {
+		return 0, 0
+	}
+	ops, spans := flushApplySpanNativeOpsAndSpans(summary)
+	if ops > 0 {
+		db.flushApplySpanNativeCandidateOps.Add(uint64(ops))
+	}
+	if spans > 0 {
+		db.flushApplySpanNativeCandidateSpans.Add(uint64(spans))
+	}
+	return ops, spans
+}
+
+func (db *DB) observeFlushApplySpanNativeEligible(summary zipper.ReadOnlyLeafSpanSummary) {
+	ops, spans := db.observeFlushApplySpanNativeCandidate(summary)
+	if ops > 0 {
+		db.flushApplySpanNativeEligibleOps.Add(uint64(ops))
+	}
+	if spans > 0 {
+		db.flushApplySpanNativeEligibleSpans.Add(uint64(spans))
+	}
+}
+
+func (db *DB) observeFlushApplySpanNativeFallbackAfterCandidate(summary zipper.ReadOnlyLeafSpanSummary, reason FlushSpanRunFallbackReason, countIneligible bool) {
 	if db == nil {
 		return
 	}
 	if !reason.Valid() {
 		reason = FlushSpanRunFallbackUnknown
 	}
-	ops := summary.Ops
-	if ops <= 0 {
-		ops = summary.SpanOps
-	}
-	spans := summary.Spans
+	ops, spans := flushApplySpanNativeOpsAndSpans(summary)
 	if ops > 0 {
-		db.flushApplySpanNativeCandidateOps.Add(uint64(ops))
-		db.flushApplySpanNativeIneligibleOps.Add(uint64(ops))
+		if countIneligible {
+			db.flushApplySpanNativeIneligibleOps.Add(uint64(ops))
+		}
 		db.flushApplySpanNativeFallbackOps[reason].Add(uint64(ops))
 	}
 	if spans > 0 {
-		db.flushApplySpanNativeCandidateSpans.Add(uint64(spans))
-		db.flushApplySpanNativeIneligibleSpans.Add(uint64(spans))
+		if countIneligible {
+			db.flushApplySpanNativeIneligibleSpans.Add(uint64(spans))
+		}
 		db.flushApplySpanNativeFallbackSpans[reason].Add(uint64(spans))
 	}
 	db.flushApplySpanNativeFallbacks.Add(1)
+}
+
+func (db *DB) observeFlushApplySpanNativeFallback(summary zipper.ReadOnlyLeafSpanSummary, reason FlushSpanRunFallbackReason) {
+	db.observeFlushApplySpanNativeCandidate(summary)
+	db.observeFlushApplySpanNativeFallbackAfterCandidate(summary, reason, true)
 }
 
 func classifyFlushApplySpanNativeFallback(summary zipper.ReadOnlyLeafSpanSummary, err error, validationFailure bool) FlushSpanRunFallbackReason {

--- a/TreeDB/db/span_native_apply_stats_test.go
+++ b/TreeDB/db/span_native_apply_stats_test.go
@@ -37,8 +37,37 @@ func TestFlushApplySpanNativeEligibleCountersDoNotMarkIneligible(t *testing.T) {
 	if got := db.flushApplySpanNativeIneligibleOps.Load(); got != 0 {
 		t.Fatalf("ineligible ops=%d want 0", got)
 	}
+	if got := db.flushApplySpanNativeUsedOps.Load(); got != 0 {
+		t.Fatalf("used ops=%d want 0 for eligible fallback scaffold", got)
+	}
 	if got := db.flushApplySpanNativeFallbackOps[FlushSpanRunFallbackSpanNativeNotImplemented].Load(); got != 4 {
 		t.Fatalf("not-implemented fallback ops=%d want 4", got)
+	}
+}
+
+func TestFlushApplySpanNativeUsedCounters(t *testing.T) {
+	db := &DB{flushApplyConcurrency: 4, flushApplySpanNative: true}
+	result := zipper.ApplyResult{
+		ReadOnlyPrepareRequested: true,
+		ReadOnlyPrepare: zipper.ReadOnlyPrepareResult{
+			Ops:            4,
+			PointOps:       4,
+			ExactLeafSpans: true,
+			LeafSpans:      make([]zipper.ReadOnlyLeafSpan, 2),
+		},
+		SpanNativeEligible: true,
+		SpanNativeWorkers:  2,
+		SpanNativeUsed:     true,
+	}
+	db.observeFlushApplyPrepareResult(result, nil)
+	if got := db.flushApplySpanNativeUsedOps.Load(); got != 4 {
+		t.Fatalf("used ops=%d want 4", got)
+	}
+	if got := db.flushApplySpanNativeUsedSpans.Load(); got != 2 {
+		t.Fatalf("used spans=%d want 2", got)
+	}
+	if got := db.flushApplySpanNativeFallbacks.Load(); got != 0 {
+		t.Fatalf("fallbacks=%d want 0", got)
 	}
 }
 

--- a/TreeDB/db/span_native_apply_stats_test.go
+++ b/TreeDB/db/span_native_apply_stats_test.go
@@ -1,0 +1,57 @@
+package db
+
+import (
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/zipper"
+)
+
+func TestFlushApplySpanNativeEligibleCountersDoNotMarkIneligible(t *testing.T) {
+	db := &DB{flushApplyConcurrency: 4, flushApplySpanNative: true}
+	result := zipper.ApplyResult{
+		ReadOnlyPrepareRequested: true,
+		ReadOnlyPrepare: zipper.ReadOnlyPrepareResult{
+			Ops:            4,
+			PointOps:       4,
+			ExactLeafSpans: true,
+			LeafSpans:      make([]zipper.ReadOnlyLeafSpan, 2),
+		},
+		SpanNativeEligible: true,
+		SpanNativeWorkers:  2,
+	}
+	// LeafSpanSummary derives span count from LeafSpans and op count from Ops.
+	db.observeFlushApplyPrepareResult(result, nil)
+
+	if got := db.flushApplySpanNativeCandidateOps.Load(); got != 4 {
+		t.Fatalf("candidate ops=%d want 4", got)
+	}
+	if got := db.flushApplySpanNativeCandidateSpans.Load(); got != 2 {
+		t.Fatalf("candidate spans=%d want 2", got)
+	}
+	if got := db.flushApplySpanNativeEligibleOps.Load(); got != 4 {
+		t.Fatalf("eligible ops=%d want 4", got)
+	}
+	if got := db.flushApplySpanNativeEligibleSpans.Load(); got != 2 {
+		t.Fatalf("eligible spans=%d want 2", got)
+	}
+	if got := db.flushApplySpanNativeIneligibleOps.Load(); got != 0 {
+		t.Fatalf("ineligible ops=%d want 0", got)
+	}
+	if got := db.flushApplySpanNativeFallbackOps[FlushSpanRunFallbackSpanNativeNotImplemented].Load(); got != 4 {
+		t.Fatalf("not-implemented fallback ops=%d want 4", got)
+	}
+}
+
+func TestFlushApplyOptionsEnableSpanNativePrepareWithoutParallelWorkers(t *testing.T) {
+	db := &DB{flushApplySpanNative: true}
+	opts := db.flushApplyOptions()
+	if !opts.SpanNativeApply {
+		t.Fatalf("SpanNativeApply=false want true")
+	}
+	if !opts.PrepareReadOnly {
+		t.Fatalf("PrepareReadOnly=false want true")
+	}
+	if opts.ParallelApplyConcurrency != 0 {
+		t.Fatalf("ParallelApplyConcurrency=%d want 0", opts.ParallelApplyConcurrency)
+	}
+}

--- a/TreeDB/public.go
+++ b/TreeDB/public.go
@@ -693,6 +693,7 @@ func Open(opts Options) (*DB, error) {
 		FlushApplyMinEntries:                     opts.FlushApplyMinEntries,
 		FlushApplyMinSpans:                       opts.FlushApplyMinSpans,
 		FlushApplyMinBytes:                       opts.FlushApplyMinBytes,
+		FlushApplySpanNative:                     opts.FlushApplySpanNative,
 		FlushBackendMaxEntries:                   opts.FlushBackendMaxEntries,
 		FlushBackendMaxBatches:                   opts.FlushBackendMaxBatches,
 		FlushSpanRunTargetPlanning:               opts.FlushSpanRunTargetPlanning,

--- a/TreeDB/zipper/parallel_apply_test.go
+++ b/TreeDB/zipper/parallel_apply_test.go
@@ -83,6 +83,22 @@ func (l *failingBatchLeafPageLog) AppendLeafPages([][]byte) ([]page.LeafLogPtr, 
 	return nil, l.err
 }
 
+func TestApplyWorkerPoolNilRunFallsBackSerial(t *testing.T) {
+	var p *ApplyWorkerPool
+	var jobs []int
+	if err := p.Run(4, 3, func(workerID, job int) {
+		if workerID != 0 {
+			t.Fatalf("workerID=%d want serial fallback worker 0", workerID)
+		}
+		jobs = append(jobs, job)
+	}); err != nil {
+		t.Fatalf("nil Run: %v", err)
+	}
+	if got, want := fmt.Sprint(jobs), "[0 1 2]"; got != want {
+		t.Fatalf("jobs=%s want %s", got, want)
+	}
+}
+
 func newParallelApplyTestZipper(t *testing.T) (*pager.Pager, *Zipper) {
 	t.Helper()
 	p, err := pager.Open(filepath.Join(t.TempDir(), "index.db"), 64*1024)

--- a/TreeDB/zipper/read_only_prepare.go
+++ b/TreeDB/zipper/read_only_prepare.go
@@ -48,6 +48,12 @@ type ApplyOptions struct {
 	// ParallelApplyMinSpanBytes gates opt-in worker-pool apply by estimated bytes.
 	// Values <=0 disable the byte-count gate.
 	ParallelApplyMinSpanBytes int
+
+	// SpanNativeApply enables the M10 opt-in span-native apply candidate path.
+	// The initial gate is deliberately narrower than M2 parallel COW apply: exact
+	// point-only leaf spans, no cold build, no maintenance rewrite, and bounded
+	// workers. Unsupported runs fail closed to the recursive apply fallback.
+	SpanNativeApply bool
 }
 
 // ApplyResult is the complete in-memory result of a root apply attempt. The
@@ -78,6 +84,14 @@ type ApplyResult struct {
 	// applying all gates. ParallelApplyUsed is true when that count was >1.
 	ParallelApplyWorkers int
 	ParallelApplyUsed    bool
+
+	// SpanNativeEligible reports that the M10 opt-in span-native gate accepted the
+	// read-only plan. SpanNativeWorkers is the bounded worker count selected for
+	// future span jobs. SpanNativeUsed remains false until the real span-native
+	// execution engine replaces recursive fallback for eligible runs.
+	SpanNativeEligible bool
+	SpanNativeWorkers  int
+	SpanNativeUsed     bool
 }
 
 // ReadOnlyPrepareOptions configures a read-only root preparation pass. The zero
@@ -706,12 +720,67 @@ func resolveParallelApplyWorkers(opts ApplyOptions, summary ReadOnlyLeafSpanSumm
 	return workers
 }
 
+func resolveSpanNativeApplyWorkers(opts ApplyOptions, summary ReadOnlyLeafSpanSummary) int {
+	if !opts.SpanNativeApply {
+		return 0
+	}
+	workers := opts.ParallelApplyConcurrency
+	if workers <= 0 {
+		workers = 1
+	}
+	if gomax := runtime.GOMAXPROCS(0); gomax > 0 && workers > gomax {
+		workers = gomax
+	}
+	if summary.Spans > 0 && workers > summary.Spans {
+		workers = summary.Spans
+	}
+	if workers <= 0 {
+		workers = 1
+	}
+	return workers
+}
+
+func spanNativeApplyFallbackReason(opts ApplyOptions, summary ReadOnlyLeafSpanSummary, err error, validationFailure bool) (int, string) {
+	if !opts.SpanNativeApply {
+		return 0, "disabled"
+	}
+	if validationFailure {
+		return 0, "validation_failed"
+	}
+	if err != nil {
+		return 0, "prepare_error"
+	}
+	if summary.ColdBuild {
+		return 0, "cold_build"
+	}
+	if summary.Maintenance {
+		return 0, "maintenance"
+	}
+	if summary.DeleteRanges > 0 {
+		return 0, "range_delete_barrier"
+	}
+	if !summary.ExactLeafSpans {
+		return 0, "inexact_leaf_spans"
+	}
+	if summary.PointOps <= 0 || summary.Spans <= 0 {
+		return 0, "below_threshold"
+	}
+	workers := resolveSpanNativeApplyWorkers(opts, summary)
+	if workers <= 0 {
+		return 0, "below_threshold"
+	}
+	return workers, ""
+}
+
 func readOnlyWorkerTarget(opts ApplyOptions) int {
 	if opts.ReadOnlyPrepareWorkers > 0 {
 		return opts.ReadOnlyPrepareWorkers
 	}
 	if opts.ParallelApplyConcurrency > 0 {
 		return opts.ParallelApplyConcurrency
+	}
+	if opts.SpanNativeApply {
+		return 1
 	}
 	return 0
 }
@@ -726,7 +795,7 @@ func (z *Zipper) ApplyWithOptions(rootID uint64, b *batch.Batch, opts ApplyOptio
 	var prepared ReadOnlyPrepareResult
 	var preparedNs uint64
 	result := ApplyResult{}
-	prepareRequested := opts.PrepareReadOnly || opts.ParallelApplyConcurrency > 1
+	prepareRequested := opts.PrepareReadOnly || opts.ParallelApplyConcurrency > 1 || opts.SpanNativeApply
 	if prepareRequested {
 		result.ReadOnlyPrepareRequested = true
 		var err error
@@ -743,6 +812,27 @@ func (z *Zipper) ApplyWithOptions(rootID uint64, b *batch.Batch, opts ApplyOptio
 		if err := prepared.ValidateLeafSpans(); err != nil {
 			result.ReadOnlyPrepareValidationFailed = true
 			return result, fmt.Errorf("zipper: invalid read-only prepare plan: %w", err)
+		}
+	}
+
+	if workers, reason := spanNativeApplyFallbackReason(opts, prepared.LeafSpanSummary(), nil, false); reason == "" {
+		result.SpanNativeEligible = true
+		result.SpanNativeWorkers = workers
+		var spanOps []batch.Entry
+		if b != nil && b.HasDeleteRanges() {
+			spanOps, _ = b.ApplyPlan()
+		} else if b != nil {
+			spanOps = b.SortedEntries()
+		}
+		spanResult, used, spanErr := z.applySpanNativeWithPrepared(rootID, spanOps, prepared)
+		if used {
+			spanResult.ReadOnlyPrepare = prepared
+			spanResult.ReadOnlyPrepareNs = preparedNs
+			spanResult.ReadOnlyPrepareRequested = result.ReadOnlyPrepareRequested
+			spanResult.ReadOnlyPrepareWorkerSummary = result.ReadOnlyPrepareWorkerSummary
+			spanResult.SpanNativeEligible = true
+			spanResult.SpanNativeWorkers = workers
+			return spanResult, spanErr
 		}
 	}
 

--- a/TreeDB/zipper/read_only_prepare.go
+++ b/TreeDB/zipper/read_only_prepare.go
@@ -799,6 +799,12 @@ func (z *Zipper) ApplyWithOptions(rootID uint64, b *batch.Batch, opts ApplyOptio
 	if prepareRequested {
 		result.ReadOnlyPrepareRequested = true
 		var err error
+		if opts.SpanNativeApply {
+			// Span-native apply consumes exact leaf span boundaries to distinguish
+			// whole-root from sparse/partial replacement sets. OmitKeys plans use nil
+			// bounds for point-only spans and are planning-only, not execution-safe.
+			opts.ReadOnlyPrepare.OmitKeys = false
+		}
 		prepareStart := time.Now()
 		prepared, err = z.PrepareReadOnly(rootID, b, opts.ReadOnlyPrepare)
 		preparedNs = elapsedNsSince(prepareStart)

--- a/TreeDB/zipper/read_only_prepare.go
+++ b/TreeDB/zipper/read_only_prepare.go
@@ -824,7 +824,7 @@ func (z *Zipper) ApplyWithOptions(rootID uint64, b *batch.Batch, opts ApplyOptio
 		} else if b != nil {
 			spanOps = b.SortedEntries()
 		}
-		spanResult, used, spanErr := z.applySpanNativeWithPrepared(rootID, spanOps, prepared)
+		spanResult, used, spanErr := z.applySpanNativeWithPrepared(rootID, spanOps, prepared, workers, opts.ParallelApplyWorkerPool)
 		if used {
 			spanResult.ReadOnlyPrepare = prepared
 			spanResult.ReadOnlyPrepareNs = preparedNs

--- a/TreeDB/zipper/span_native_apply.go
+++ b/TreeDB/zipper/span_native_apply.go
@@ -2,7 +2,6 @@ package zipper
 
 import (
 	"bytes"
-	"sort"
 	"sync"
 	"time"
 
@@ -39,7 +38,7 @@ func (z *Zipper) applySpanNativeWithPrepared(rootID uint64, ops []batch.Entry, p
 	outputs := scratch.acquireSpanNativeLeafOutputs(spanCount, z.outerLeavesInValueLog)
 	rangeMetrics := make([]adaptive.Metrics, len(workerRanges))
 	rangeRetired := make([][]uint64, len(workerRanges))
-	rangeSplits := make([][]spanNativeLeafSplitOutput, len(workerRanges))
+	rangeSplits := make([]spanNativeLeafSplitRange, len(workerRanges))
 	var firstErr error
 	var errOnce sync.Once
 	runRange := func(_ int, job int) {
@@ -47,7 +46,7 @@ func (z *Zipper) applySpanNativeWithPrepared(rootID uint64, ops []batch.Entry, p
 		end := workerRange.FirstSpan + workerRange.SpanCount
 		var localMetrics adaptive.Metrics
 		var localRetired []uint64
-		var localSplits []spanNativeLeafSplitOutput
+		var localSplits [][]Split
 		for i := workerRange.FirstSpan; i < end; i++ {
 			span := prepared.LeafSpans[i]
 			newRef, splits, err := z.writeRecursive(span.Ref, ops[span.PointOpStart:span.PointOpEnd], nil, false, nil, &localMetrics, span.LowKey, span.HighKey, &localRetired, scratch, false, applyRunConfig{maxParallelWorkers: 1})
@@ -60,12 +59,17 @@ func (z *Zipper) applySpanNativeWithPrepared(rootID uint64, ops []batch.Entry, p
 				return
 			}
 			if len(splits) > 0 {
-				localSplits = append(localSplits, spanNativeLeafSplitOutput{index: i, splits: splits})
+				if localSplits == nil {
+					localSplits = make([][]Split, workerRange.SpanCount)
+				}
+				localSplits[i-workerRange.FirstSpan] = splits
 			}
 		}
 		rangeMetrics[job] = localMetrics
 		rangeRetired[job] = localRetired
-		rangeSplits[job] = localSplits
+		if localSplits != nil {
+			rangeSplits[job] = spanNativeLeafSplitRange{start: workerRange.FirstSpan, splits: localSplits}
+		}
 	}
 	if err := workerPool.Run(workers, len(workerRanges), runRange); err != nil {
 		metrics.ZipperApplyWallNs = time.Since(applyStart).Nanoseconds()
@@ -78,8 +82,8 @@ func (z *Zipper) applySpanNativeWithPrepared(rootID uint64, ops []batch.Entry, p
 		if len(rangeRetired[i]) > 0 {
 			retired = append(retired, rangeRetired[i]...)
 		}
-		if len(rangeSplits[i]) > 0 {
-			outputs.splitOutputs = append(outputs.splitOutputs, rangeSplits[i]...)
+		if len(rangeSplits[i].splits) > 0 {
+			outputs.splitRanges = append(outputs.splitRanges, rangeSplits[i])
 		}
 	}
 	if firstErr != nil {
@@ -148,16 +152,16 @@ const (
 	spanNativeLeafOutputLeafLogs
 )
 
-type spanNativeLeafSplitOutput struct {
-	index  int
-	splits []Split
+type spanNativeLeafSplitRange struct {
+	start  int
+	splits [][]Split
 }
 
 type spanNativeLeafOutputs struct {
-	mode         spanNativeLeafOutputMode
-	pageIDs      []uint64
-	leafLogRefs  []byte
-	splitOutputs []spanNativeLeafSplitOutput
+	mode        spanNativeLeafOutputMode
+	pageIDs     []uint64
+	leafLogRefs []byte
+	splitRanges []spanNativeLeafSplitRange
 }
 
 func (s *mergeScratch) acquireSpanNativeLeafOutputs(count int, leafLogs bool) spanNativeLeafOutputs {
@@ -176,7 +180,7 @@ func (s *mergeScratch) acquireSpanNativeLeafOutputs(count int, leafLogs bool) sp
 			s.spanNativeOutputLogScratch = s.spanNativeOutputLogScratch[:bytesNeeded]
 			refs = s.spanNativeOutputLogScratch
 		}
-		return spanNativeLeafOutputs{mode: spanNativeLeafOutputLeafLogs, leafLogRefs: refs, splitOutputs: s.acquireSpanNativeLeafSplitOutputs()}
+		return spanNativeLeafOutputs{mode: spanNativeLeafOutputLeafLogs, leafLogRefs: refs}
 	}
 	var pageIDs []uint64
 	if s == nil || cap(s.spanNativeOutputPageScratch) < count {
@@ -188,15 +192,7 @@ func (s *mergeScratch) acquireSpanNativeLeafOutputs(count int, leafLogs bool) sp
 		s.spanNativeOutputPageScratch = s.spanNativeOutputPageScratch[:count]
 		pageIDs = s.spanNativeOutputPageScratch
 	}
-	return spanNativeLeafOutputs{mode: spanNativeLeafOutputPages, pageIDs: pageIDs, splitOutputs: s.acquireSpanNativeLeafSplitOutputs()}
-}
-
-func (s *mergeScratch) acquireSpanNativeLeafSplitOutputs() []spanNativeLeafSplitOutput {
-	if s == nil || cap(s.spanNativeOutputSplitScratch) == 0 {
-		return nil
-	}
-	s.spanNativeOutputSplitScratch = s.spanNativeOutputSplitScratch[:0]
-	return s.spanNativeOutputSplitScratch
+	return spanNativeLeafOutputs{mode: spanNativeLeafOutputPages, pageIDs: pageIDs}
 }
 
 func (o *spanNativeLeafOutputs) setRef(index int, ref page.ChildRef) error {
@@ -245,12 +241,18 @@ func (o *spanNativeLeafOutputs) output(index int) spanNativeLeafOutput {
 }
 
 func (o *spanNativeLeafOutputs) splits(index int) []Split {
-	if o == nil || len(o.splitOutputs) == 0 {
+	if o == nil || len(o.splitRanges) == 0 {
 		return nil
 	}
-	i := sort.Search(len(o.splitOutputs), func(i int) bool { return o.splitOutputs[i].index >= index })
-	if i < len(o.splitOutputs) && o.splitOutputs[i].index == index {
-		return o.splitOutputs[i].splits
+	for i := range o.splitRanges {
+		r := &o.splitRanges[i]
+		if index < r.start {
+			return nil
+		}
+		local := index - r.start
+		if local >= 0 && local < len(r.splits) {
+			return r.splits[local]
+		}
 	}
 	return nil
 }

--- a/TreeDB/zipper/span_native_apply.go
+++ b/TreeDB/zipper/span_native_apply.go
@@ -2,6 +2,7 @@ package zipper
 
 import (
 	"bytes"
+	"sort"
 	"sync"
 	"time"
 
@@ -35,9 +36,10 @@ func (z *Zipper) applySpanNativeWithPrepared(rootID uint64, ops []batch.Entry, p
 		workerRanges = append(workerRanges, ReadOnlyLeafSpanWorkerRange{FirstSpan: 0, SpanCount: spanCount, Ops: len(ops)})
 	}
 	workers = len(workerRanges)
-	outputs := scratch.acquireSpanNativeLeafOutputs(spanCount)
+	outputs := scratch.acquireSpanNativeLeafOutputs(spanCount, z.outerLeavesInValueLog)
 	rangeMetrics := make([]adaptive.Metrics, len(workerRanges))
 	rangeRetired := make([][]uint64, len(workerRanges))
+	rangeSplits := make([][]spanNativeLeafSplitOutput, len(workerRanges))
 	var firstErr error
 	var errOnce sync.Once
 	runRange := func(_ int, job int) {
@@ -45,6 +47,7 @@ func (z *Zipper) applySpanNativeWithPrepared(rootID uint64, ops []batch.Entry, p
 		end := workerRange.FirstSpan + workerRange.SpanCount
 		var localMetrics adaptive.Metrics
 		var localRetired []uint64
+		var localSplits []spanNativeLeafSplitOutput
 		for i := workerRange.FirstSpan; i < end; i++ {
 			span := prepared.LeafSpans[i]
 			newRef, splits, err := z.writeRecursive(span.Ref, ops[span.PointOpStart:span.PointOpEnd], nil, false, nil, &localMetrics, span.LowKey, span.HighKey, &localRetired, scratch, false, applyRunConfig{maxParallelWorkers: 1})
@@ -52,10 +55,17 @@ func (z *Zipper) applySpanNativeWithPrepared(rootID uint64, ops []batch.Entry, p
 				errOnce.Do(func() { firstErr = err })
 				return
 			}
-			outputs[i] = spanNativeLeafOutput{ref: newRef, splits: splits}
+			if err := outputs.setRef(i, newRef); err != nil {
+				errOnce.Do(func() { firstErr = err })
+				return
+			}
+			if len(splits) > 0 {
+				localSplits = append(localSplits, spanNativeLeafSplitOutput{index: i, splits: splits})
+			}
 		}
 		rangeMetrics[job] = localMetrics
 		rangeRetired[job] = localRetired
+		rangeSplits[job] = localSplits
 	}
 	if err := workerPool.Run(workers, len(workerRanges), runRange); err != nil {
 		metrics.ZipperApplyWallNs = time.Since(applyStart).Nanoseconds()
@@ -68,6 +78,9 @@ func (z *Zipper) applySpanNativeWithPrepared(rootID uint64, ops []batch.Entry, p
 		if len(rangeRetired[i]) > 0 {
 			retired = append(retired, rangeRetired[i]...)
 		}
+		if len(rangeSplits[i]) > 0 {
+			outputs.splitOutputs = append(outputs.splitOutputs, rangeSplits[i]...)
+		}
 	}
 	if firstErr != nil {
 		metrics.ZipperApplyWallNs = time.Since(applyStart).Nanoseconds()
@@ -75,7 +88,7 @@ func (z *Zipper) applySpanNativeWithPrepared(rootID uint64, ops []batch.Entry, p
 	}
 
 	rootReduceStart := time.Now()
-	newRootID, err := z.reduceSpanNativeRootWithContext(rootID, spanNativeLeafReplacements{spans: prepared.LeafSpans, outputs: outputs}, &metrics, &retired, scratch)
+	newRootID, err := z.reduceSpanNativeRootWithContext(rootID, spanNativeLeafReplacements{spans: prepared.LeafSpans, outputs: &outputs}, &metrics, &retired, scratch)
 	metrics.ZipperRootReduceNs += time.Since(rootReduceStart).Nanoseconds()
 	metrics.ZipperApplyWallNs = time.Since(applyStart).Nanoseconds()
 	if err != nil {
@@ -128,36 +141,139 @@ type spanNativeLeafOutput struct {
 	splits []Split
 }
 
-func (s *mergeScratch) acquireSpanNativeLeafOutputs(count int) []spanNativeLeafOutput {
+type spanNativeLeafOutputMode uint8
+
+const (
+	spanNativeLeafOutputPages spanNativeLeafOutputMode = iota
+	spanNativeLeafOutputLeafLogs
+)
+
+type spanNativeLeafSplitOutput struct {
+	index  int
+	splits []Split
+}
+
+type spanNativeLeafOutputs struct {
+	mode         spanNativeLeafOutputMode
+	pageIDs      []uint64
+	leafLogRefs  []byte
+	splitOutputs []spanNativeLeafSplitOutput
+}
+
+func (s *mergeScratch) acquireSpanNativeLeafOutputs(count int, leafLogs bool) spanNativeLeafOutputs {
 	if count <= 0 {
+		return spanNativeLeafOutputs{}
+	}
+	if leafLogs {
+		bytesNeeded := count * page.LogRecordRefSize
+		var refs []byte
+		if s == nil || cap(s.spanNativeOutputLogScratch) < bytesNeeded {
+			refs = make([]byte, bytesNeeded)
+			if s != nil {
+				s.spanNativeOutputLogScratch = refs
+			}
+		} else {
+			s.spanNativeOutputLogScratch = s.spanNativeOutputLogScratch[:bytesNeeded]
+			refs = s.spanNativeOutputLogScratch
+		}
+		return spanNativeLeafOutputs{mode: spanNativeLeafOutputLeafLogs, leafLogRefs: refs, splitOutputs: s.acquireSpanNativeLeafSplitOutputs()}
+	}
+	var pageIDs []uint64
+	if s == nil || cap(s.spanNativeOutputPageScratch) < count {
+		pageIDs = make([]uint64, count)
+		if s != nil {
+			s.spanNativeOutputPageScratch = pageIDs
+		}
+	} else {
+		s.spanNativeOutputPageScratch = s.spanNativeOutputPageScratch[:count]
+		pageIDs = s.spanNativeOutputPageScratch
+	}
+	return spanNativeLeafOutputs{mode: spanNativeLeafOutputPages, pageIDs: pageIDs, splitOutputs: s.acquireSpanNativeLeafSplitOutputs()}
+}
+
+func (s *mergeScratch) acquireSpanNativeLeafSplitOutputs() []spanNativeLeafSplitOutput {
+	if s == nil || cap(s.spanNativeOutputSplitScratch) == 0 {
 		return nil
 	}
-	if s == nil {
-		return make([]spanNativeLeafOutput, count)
+	s.spanNativeOutputSplitScratch = s.spanNativeOutputSplitScratch[:0]
+	return s.spanNativeOutputSplitScratch
+}
+
+func (o *spanNativeLeafOutputs) setRef(index int, ref page.ChildRef) error {
+	if o == nil || index < 0 {
+		return page.ErrInvalidPageType
 	}
-	if cap(s.spanNativeOutputScratch) < count {
-		s.spanNativeOutputScratch = make([]spanNativeLeafOutput, count)
-		return s.spanNativeOutputScratch
+	switch o.mode {
+	case spanNativeLeafOutputLeafLogs:
+		if ref.Kind != page.ChildRefLeafLog {
+			return page.ErrInvalidPageType
+		}
+		offset := index * page.LogRecordRefSize
+		if offset < 0 || offset+page.LogRecordRefSize > len(o.leafLogRefs) {
+			return page.ErrInvalidPageType
+		}
+		page.EncodeLogRecordRef(o.leafLogRefs[offset:offset+page.LogRecordRefSize], ref.Log)
+		return nil
+	case spanNativeLeafOutputPages:
+		if ref.Kind != page.ChildRefPage || index >= len(o.pageIDs) {
+			return page.ErrInvalidPageType
+		}
+		o.pageIDs[index] = ref.Page
+		return nil
+	default:
+		return page.ErrInvalidPageType
 	}
-	s.spanNativeOutputScratch = s.spanNativeOutputScratch[:count]
-	clear(s.spanNativeOutputScratch)
-	return s.spanNativeOutputScratch
+}
+
+func (o *spanNativeLeafOutputs) output(index int) spanNativeLeafOutput {
+	if o == nil || index < 0 {
+		return spanNativeLeafOutput{}
+	}
+	out := spanNativeLeafOutput{splits: o.splits(index)}
+	switch o.mode {
+	case spanNativeLeafOutputLeafLogs:
+		offset := index * page.LogRecordRefSize
+		if offset >= 0 && offset+page.LogRecordRefSize <= len(o.leafLogRefs) {
+			out.ref = page.LeafLogChildRef(page.DecodeLogRecordRef(o.leafLogRefs[offset : offset+page.LogRecordRefSize]))
+		}
+	case spanNativeLeafOutputPages:
+		if index < len(o.pageIDs) {
+			out.ref = page.PageChildRef(o.pageIDs[index])
+		}
+	}
+	return out
+}
+
+func (o *spanNativeLeafOutputs) splits(index int) []Split {
+	if o == nil || len(o.splitOutputs) == 0 {
+		return nil
+	}
+	i := sort.Search(len(o.splitOutputs), func(i int) bool { return o.splitOutputs[i].index >= index })
+	if i < len(o.splitOutputs) && o.splitOutputs[i].index == index {
+		return o.splitOutputs[i].splits
+	}
+	return nil
 }
 
 type spanNativeLeafReplacements struct {
 	spans   []ReadOnlyLeafSpan
-	outputs []spanNativeLeafOutput
+	outputs *spanNativeLeafOutputs
+	start   int
 }
 
 func (r spanNativeLeafReplacements) len() int {
-	if len(r.spans) < len(r.outputs) {
-		return len(r.spans)
+	return len(r.spans)
+}
+
+func (r spanNativeLeafReplacements) output(index int) spanNativeLeafOutput {
+	if r.outputs == nil || index < 0 || index >= len(r.spans) {
+		return spanNativeLeafOutput{}
 	}
-	return len(r.outputs)
+	return r.outputs.output(r.start + index)
 }
 
 func (r spanNativeLeafReplacements) slice(start, end int) spanNativeLeafReplacements {
-	return spanNativeLeafReplacements{spans: r.spans[start:end], outputs: r.outputs[start:end]}
+	return spanNativeLeafReplacements{spans: r.spans[start:end], outputs: r.outputs, start: r.start + start}
 }
 
 func (z *Zipper) reduceSpanNativeRootWithContext(rootID uint64, replacements spanNativeLeafReplacements, metrics *adaptive.Metrics, retired *[]uint64, scratch *mergeScratch) (uint64, error) {
@@ -167,8 +283,9 @@ func (z *Zipper) reduceSpanNativeRootWithContext(rootID uint64, replacements spa
 	if spanNativeReplacementsCoverWholeRoot(replacements) {
 		var refs []Split
 		for i := 0; i < replacements.len(); i++ {
-			refs = append(refs, spanNativeReplacementHeadSplit(replacements.spans[i], replacements.outputs[i]))
-			refs = append(refs, replacements.outputs[i].splits...)
+			out := replacements.output(i)
+			refs = append(refs, spanNativeReplacementHeadSplit(replacements.spans[i], out))
+			refs = append(refs, out.splits...)
 		}
 		return z.reduceSpanNativeRoot(refs, metrics)
 	}
@@ -221,7 +338,8 @@ func (z *Zipper) stitchSpanNativeRecursive(ref page.ChildRef, low, high []byte, 
 	case page.PageTypeLeaf, 0:
 		for i := 0; i < replacements.len(); i++ {
 			if replacements.spans[i].Ref == ref {
-				return replacements.outputs[i].ref, replacements.outputs[i].splits, true, nil
+				out := replacements.output(i)
+				return out.ref, out.splits, true, nil
 			}
 		}
 		return ref, nil, false, nil
@@ -279,10 +397,11 @@ func (z *Zipper) stitchSpanNativeRecursive(ref page.ChildRef, low, high []byte, 
 			}
 			if childReplacements.len() == 1 && childReplacements.spans[0].Ref == childRef {
 				changed = true
-				if err := writer.append(Split{Key: key, Ref: childReplacements.outputs[0].ref}); err != nil {
+				out := childReplacements.output(0)
+				if err := writer.append(Split{Key: key, Ref: out.ref}); err != nil {
 					return page.ChildRef{}, nil, false, err
 				}
-				for _, s := range childReplacements.outputs[0].splits {
+				for _, s := range out.splits {
 					if err := writer.append(s); err != nil {
 						return page.ChildRef{}, nil, false, err
 					}

--- a/TreeDB/zipper/span_native_apply.go
+++ b/TreeDB/zipper/span_native_apply.go
@@ -14,9 +14,9 @@ func (z *Zipper) applySpanNativeWithPrepared(rootID uint64, ops []batch.Entry, p
 	if prepared.DeleteRanges != 0 || prepared.ColdBuild || prepared.Maintenance || !prepared.ExactLeafSpans || len(prepared.LeafSpans) == 0 {
 		return ApplyResult{}, false, nil
 	}
-	if len(prepared.LeafSpans) > 1 && !spanNativeCoversWholeRoot(prepared.LeafSpans) {
-		// Partial multi-leaf replacement needs parent-context stitching. Keep that
-		// out of the first opt-in reducer and fall back before preparing output.
+	if !spanNativeCoversWholeRoot(prepared.LeafSpans) {
+		// Partial leaf replacement needs parent-context stitching. Keep that out of
+		// the first opt-in reducer and fall back before preparing output.
 		return ApplyResult{}, false, nil
 	}
 

--- a/TreeDB/zipper/span_native_apply.go
+++ b/TreeDB/zipper/span_native_apply.go
@@ -30,45 +30,32 @@ func (z *Zipper) applySpanNativeWithPrepared(rootID uint64, ops []batch.Entry, p
 		workers = spanCount
 	}
 
-	replacements := make([]spanNativeLeafReplacement, spanCount)
-	spanMetrics := make([]adaptive.Metrics, spanCount)
-	spanRetired := make([][]uint64, spanCount)
 	workerRanges := prepared.AppendLeafSpanWorkerRanges(nil, workers)
 	if len(workerRanges) == 0 {
 		workerRanges = append(workerRanges, ReadOnlyLeafSpanWorkerRange{FirstSpan: 0, SpanCount: spanCount, Ops: len(ops)})
 	}
 	workers = len(workerRanges)
+	outputs := make([]spanNativeLeafOutput, spanCount)
+	rangeMetrics := make([]adaptive.Metrics, len(workerRanges))
+	rangeRetired := make([][]uint64, len(workerRanges))
 	var firstErr error
 	var errOnce sync.Once
-	runSpan := func(i int) bool {
-		span := prepared.LeafSpans[i]
-		var childMetrics adaptive.Metrics
-		var childRetired []uint64
-		newRef, splits, err := z.writeRecursive(span.Ref, ops[span.PointOpStart:span.PointOpEnd], nil, false, nil, &childMetrics, span.LowKey, span.HighKey, &childRetired, scratch, false, applyRunConfig{maxParallelWorkers: 1})
-		if err != nil {
-			errOnce.Do(func() { firstErr = err })
-			return false
-		}
-		spanKey := span.LowKey
-		if spanKey == nil {
-			spanKey = []byte{}
-		}
-		refs := make([]Split, 0, len(splits)+1)
-		refs = append(refs, Split{Key: spanKey, Ref: newRef})
-		refs = append(refs, splits...)
-		replacements[i] = spanNativeLeafReplacement{span: span, refs: refs}
-		spanMetrics[i] = childMetrics
-		spanRetired[i] = childRetired
-		return true
-	}
 	runRange := func(_ int, job int) {
 		workerRange := workerRanges[job]
 		end := workerRange.FirstSpan + workerRange.SpanCount
+		var localMetrics adaptive.Metrics
+		var localRetired []uint64
 		for i := workerRange.FirstSpan; i < end; i++ {
-			if !runSpan(i) {
+			span := prepared.LeafSpans[i]
+			newRef, splits, err := z.writeRecursive(span.Ref, ops[span.PointOpStart:span.PointOpEnd], nil, false, nil, &localMetrics, span.LowKey, span.HighKey, &localRetired, scratch, false, applyRunConfig{maxParallelWorkers: 1})
+			if err != nil {
+				errOnce.Do(func() { firstErr = err })
 				return
 			}
+			outputs[i] = spanNativeLeafOutput{ref: newRef, splits: splits}
 		}
+		rangeMetrics[job] = localMetrics
+		rangeRetired[job] = localRetired
 	}
 	if err := workerPool.Run(workers, len(workerRanges), runRange); err != nil {
 		metrics.ZipperApplyWallNs = time.Since(applyStart).Nanoseconds()
@@ -76,10 +63,10 @@ func (z *Zipper) applySpanNativeWithPrepared(rootID uint64, ops []batch.Entry, p
 	}
 
 	var retired []uint64
-	for i := range spanMetrics {
-		mergeMetrics(&metrics, &spanMetrics[i])
-		if len(spanRetired[i]) > 0 {
-			retired = append(retired, spanRetired[i]...)
+	for i := range rangeMetrics {
+		mergeMetrics(&metrics, &rangeMetrics[i])
+		if len(rangeRetired[i]) > 0 {
+			retired = append(retired, rangeRetired[i]...)
 		}
 	}
 	if firstErr != nil {
@@ -88,7 +75,7 @@ func (z *Zipper) applySpanNativeWithPrepared(rootID uint64, ops []batch.Entry, p
 	}
 
 	rootReduceStart := time.Now()
-	newRootID, err := z.reduceSpanNativeRootWithContext(rootID, replacements, &metrics, &retired, scratch)
+	newRootID, err := z.reduceSpanNativeRootWithContext(rootID, spanNativeLeafReplacements{spans: prepared.LeafSpans, outputs: outputs}, &metrics, &retired, scratch)
 	metrics.ZipperRootReduceNs += time.Since(rootReduceStart).Nanoseconds()
 	metrics.ZipperApplyWallNs = time.Since(applyStart).Nanoseconds()
 	if err != nil {
@@ -136,19 +123,36 @@ func validateSpanNativePreparedPlan(ops []batch.Entry, prepared ReadOnlyPrepareR
 	return expectedPointStart == len(ops)
 }
 
-type spanNativeLeafReplacement struct {
-	span ReadOnlyLeafSpan
-	refs []Split
+type spanNativeLeafOutput struct {
+	ref    page.ChildRef
+	splits []Split
 }
 
-func (z *Zipper) reduceSpanNativeRootWithContext(rootID uint64, replacements []spanNativeLeafReplacement, metrics *adaptive.Metrics, retired *[]uint64, scratch *mergeScratch) (uint64, error) {
-	if len(replacements) == 0 {
+type spanNativeLeafReplacements struct {
+	spans   []ReadOnlyLeafSpan
+	outputs []spanNativeLeafOutput
+}
+
+func (r spanNativeLeafReplacements) len() int {
+	if len(r.spans) < len(r.outputs) {
+		return len(r.spans)
+	}
+	return len(r.outputs)
+}
+
+func (r spanNativeLeafReplacements) slice(start, end int) spanNativeLeafReplacements {
+	return spanNativeLeafReplacements{spans: r.spans[start:end], outputs: r.outputs[start:end]}
+}
+
+func (z *Zipper) reduceSpanNativeRootWithContext(rootID uint64, replacements spanNativeLeafReplacements, metrics *adaptive.Metrics, retired *[]uint64, scratch *mergeScratch) (uint64, error) {
+	if replacements.len() == 0 {
 		return 0, page.ErrInvalidPageType
 	}
 	if spanNativeReplacementsCoverWholeRoot(replacements) {
 		var refs []Split
-		for i := range replacements {
-			refs = append(refs, replacements[i].refs...)
+		for i := 0; i < replacements.len(); i++ {
+			refs = append(refs, spanNativeReplacementHeadSplit(replacements.spans[i], replacements.outputs[i]))
+			refs = append(refs, replacements.outputs[i].splits...)
 		}
 		return z.reduceSpanNativeRoot(refs, metrics)
 	}
@@ -165,21 +169,29 @@ func (z *Zipper) reduceSpanNativeRootWithContext(rootID uint64, replacements []s
 	return z.reduceSpanNativeRoot(refs, metrics)
 }
 
-func spanNativeReplacementsCoverWholeRoot(replacements []spanNativeLeafReplacement) bool {
-	if len(replacements) == 0 || replacements[0].span.LowKey != nil || replacements[len(replacements)-1].span.HighKey != nil {
+func spanNativeReplacementHeadSplit(span ReadOnlyLeafSpan, output spanNativeLeafOutput) Split {
+	spanKey := span.LowKey
+	if spanKey == nil {
+		spanKey = []byte{}
+	}
+	return Split{Key: spanKey, Ref: output.ref}
+}
+
+func spanNativeReplacementsCoverWholeRoot(replacements spanNativeLeafReplacements) bool {
+	if replacements.len() == 0 || replacements.spans[0].LowKey != nil || replacements.spans[replacements.len()-1].HighKey != nil {
 		return false
 	}
-	prevHigh := replacements[0].span.HighKey
-	for i := 1; i < len(replacements); i++ {
-		if !bytes.Equal(replacements[i].span.LowKey, prevHigh) {
+	prevHigh := replacements.spans[0].HighKey
+	for i := 1; i < replacements.len(); i++ {
+		if !bytes.Equal(replacements.spans[i].LowKey, prevHigh) {
 			return false
 		}
-		prevHigh = replacements[i].span.HighKey
+		prevHigh = replacements.spans[i].HighKey
 	}
 	return true
 }
 
-func (z *Zipper) stitchSpanNativeRecursive(ref page.ChildRef, low, high []byte, replacements []spanNativeLeafReplacement, metrics *adaptive.Metrics, retired *[]uint64, scratch *mergeScratch) (page.ChildRef, []Split, bool, error) {
+func (z *Zipper) stitchSpanNativeRecursive(ref page.ChildRef, low, high []byte, replacements spanNativeLeafReplacements, metrics *adaptive.Metrics, retired *[]uint64, scratch *mergeScratch) (page.ChildRef, []Split, bool, error) {
 	oldNode, oldFromPager, leafScratch, leafScratchRef, loadSource, err := z.loadNodeRef(ref, scratch)
 	if err != nil {
 		return page.ChildRef{}, nil, false, err
@@ -191,24 +203,16 @@ func (z *Zipper) stitchSpanNativeRecursive(ref page.ChildRef, low, high []byte, 
 
 	switch oldNode.Type() {
 	case page.PageTypeLeaf, 0:
-		for i := range replacements {
-			if replacements[i].span.Ref == ref {
-				refs := append([]Split(nil), replacements[i].refs...)
-				if len(refs) == 0 {
-					return page.ChildRef{}, nil, false, page.ErrInvalidPageType
-				}
-				if low == nil {
-					refs[0].Key = []byte{}
-				} else {
-					refs[0].Key = low
-				}
-				return refs[0].Ref, refs[1:], true, nil
+		for i := 0; i < replacements.len(); i++ {
+			if replacements.spans[i].Ref == ref {
+				return replacements.outputs[i].ref, replacements.outputs[i].splits, true, nil
 			}
 		}
 		return ref, nil, false, nil
 	case page.PageTypeInternal:
 		count := oldNode.Count()
-		children := make([]Split, 0, count)
+		copyKeys := oldNode.InternalBaseDeltaEnabled()
+		writer := spanNativeSplitLevelWriter{z: z, metrics: metrics}
 		changed := false
 		replacementIdx := 0
 		for i := uint16(0); i < count; i++ {
@@ -221,7 +225,10 @@ func (z *Zipper) stitchSpanNativeRecursive(ref page.ChildRef, low, high []byte, 
 			}
 			childLow := low
 			if len(key) != 0 {
-				childLow = append([]byte(nil), key...)
+				childLow = key
+				if copyKeys {
+					childLow = append([]byte(nil), key...)
+				}
 			}
 			childHigh := high
 			if i+1 < count {
@@ -232,31 +239,38 @@ func (z *Zipper) stitchSpanNativeRecursive(ref page.ChildRef, low, high []byte, 
 				if nextKey == nil {
 					nextKey = []byte{}
 				}
-				childHigh = append([]byte(nil), nextKey...)
+				childHigh = nextKey
+				if copyKeys {
+					childHigh = append([]byte(nil), nextKey...)
+				}
 			}
 
-			for replacementIdx < len(replacements) && spanNativeReplacementBeforeRange(replacements[replacementIdx], childLow) {
+			for replacementIdx < replacements.len() && spanNativeReplacementBeforeRange(replacements.spans[replacementIdx], childLow) {
 				replacementIdx++
 			}
 			childReplacementStart := replacementIdx
 			childReplacementEnd := childReplacementStart
-			for childReplacementEnd < len(replacements) && spanNativeReplacementOverlapsRange(replacements[childReplacementEnd], childLow, childHigh) {
+			for childReplacementEnd < replacements.len() && spanNativeReplacementOverlapsRange(replacements.spans[childReplacementEnd], childLow, childHigh) {
 				childReplacementEnd++
 			}
-			childReplacements := replacements[childReplacementStart:childReplacementEnd]
+			childReplacements := replacements.slice(childReplacementStart, childReplacementEnd)
 			replacementIdx = childReplacementEnd
-			if len(childReplacements) == 0 {
-				children = append(children, Split{Key: key, Ref: childRef})
+			if childReplacements.len() == 0 {
+				if err := writer.append(Split{Key: key, Ref: childRef}); err != nil {
+					return page.ChildRef{}, nil, false, err
+				}
 				continue
 			}
-			if len(childReplacements) == 1 && childReplacements[0].span.Ref == childRef {
-				replacement := childReplacements[0]
-				if len(replacement.refs) == 0 {
-					return page.ChildRef{}, nil, false, page.ErrInvalidPageType
-				}
+			if childReplacements.len() == 1 && childReplacements.spans[0].Ref == childRef {
 				changed = true
-				children = append(children, Split{Key: key, Ref: replacement.refs[0].Ref})
-				children = append(children, replacement.refs[1:]...)
+				if err := writer.append(Split{Key: key, Ref: childReplacements.outputs[0].ref}); err != nil {
+					return page.ChildRef{}, nil, false, err
+				}
+				for _, s := range childReplacements.outputs[0].splits {
+					if err := writer.append(s); err != nil {
+						return page.ChildRef{}, nil, false, err
+					}
+				}
 				continue
 			}
 
@@ -264,12 +278,17 @@ func (z *Zipper) stitchSpanNativeRecursive(ref page.ChildRef, low, high []byte, 
 			if err != nil {
 				return page.ChildRef{}, nil, false, err
 			}
-			if childChanged {
-				changed = true
-				children = append(children, Split{Key: key, Ref: newRef})
-				children = append(children, childSplits...)
-			} else {
-				children = append(children, Split{Key: key, Ref: childRef})
+			if !childChanged {
+				return page.ChildRef{}, nil, false, page.ErrInvalidPageType
+			}
+			changed = true
+			if err := writer.append(Split{Key: key, Ref: newRef}); err != nil {
+				return page.ChildRef{}, nil, false, err
+			}
+			for _, s := range childSplits {
+				if err := writer.append(s); err != nil {
+					return page.ChildRef{}, nil, false, err
+				}
 			}
 		}
 		if !changed {
@@ -278,7 +297,7 @@ func (z *Zipper) stitchSpanNativeRecursive(ref page.ChildRef, low, high []byte, 
 		if oldFromPager && retired != nil && ref.Kind == page.ChildRefPage && ref.Page != 0 {
 			*retired = append(*retired, ref.Page)
 		}
-		refs, err := z.reduceSpanNativeSplitLevel(children, metrics)
+		refs, err := writer.finish()
 		if err != nil {
 			return page.ChildRef{}, nil, false, err
 		}
@@ -291,13 +310,98 @@ func (z *Zipper) stitchSpanNativeRecursive(ref page.ChildRef, low, high []byte, 
 	}
 }
 
-func spanNativeReplacementBeforeRange(replacement spanNativeLeafReplacement, low []byte) bool {
-	span := replacement.span
+type spanNativeSplitLevelWriter struct {
+	z               *Zipper
+	metrics         *adaptive.Metrics
+	nextLevelNodes  []Split
+	currentBuilder  *node.Builder
+	currentStartKey []byte
+}
+
+func (w *spanNativeSplitLevelWriter) append(child Split) error {
+	if w.currentBuilder == nil {
+		allocHint := uint64(0)
+		if child.Ref.Kind == page.ChildRefPage {
+			allocHint = child.Ref.Page
+		}
+		pid, err := w.z.allocator.Alloc(allocHint)
+		if err != nil {
+			return err
+		}
+		data, err := w.z.pager.GetForWrite(pid)
+		if err != nil {
+			return err
+		}
+		w.currentBuilder = w.z.newBuilderForType(data, page.PageTypeInternal, nil)
+		w.currentBuilder.SetPageID(pid)
+		w.currentStartKey = child.Key
+		w.currentBuilder.SetInternalFenceBounds(w.currentStartKey, nil)
+	}
+
+	childKey := child.Key
+	if childKey == nil {
+		childKey = []byte{}
+	}
+	childSize := 2 + 8 + len(childKey)
+	if child.Ref.Kind == page.ChildRefLeafLog {
+		childSize = 2 + page.LogRecordRefSize + len(childKey)
+	} else if w.z.indexInternalBaseDelta {
+		childSize = 2 + 4 + len(childKey)
+	}
+	var err error
+	if w.z.internalSoftFull(w.currentBuilder, childSize) {
+		err = node.ErrNodeFull
+	} else {
+		err = w.currentBuilder.AddInternalChildRef(childKey, child.Ref)
+		if err == nil {
+			recordZipperInternalChildRef(w.metrics, child.Ref)
+		}
+	}
+	if err == node.ErrNodeFull {
+		w.finishCurrent()
+
+		pid, allocErr := w.z.allocator.Alloc(w.currentBuilder.PageID())
+		if allocErr != nil {
+			return allocErr
+		}
+		data, getErr := w.z.pager.GetForWrite(pid)
+		if getErr != nil {
+			return getErr
+		}
+		w.currentBuilder = w.z.newBuilderForType(data, page.PageTypeInternal, nil)
+		w.currentBuilder.SetPageID(pid)
+		w.currentStartKey = child.Key
+		w.currentBuilder.SetInternalFenceBounds(w.currentStartKey, nil)
+
+		if addErr := w.currentBuilder.AddInternalChildRef(childKey, child.Ref); addErr != nil {
+			return addErr
+		}
+		recordZipperInternalChildRef(w.metrics, child.Ref)
+	} else if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (w *spanNativeSplitLevelWriter) finishCurrent() {
+	w.currentBuilder.FinishNoNode()
+	recordZipperInternalPageWrite(w.metrics)
+	w.nextLevelNodes = append(w.nextLevelNodes, Split{Key: w.currentStartKey, Ref: page.PageChildRef(w.currentBuilder.PageID())})
+}
+
+func (w *spanNativeSplitLevelWriter) finish() ([]Split, error) {
+	if w.currentBuilder != nil {
+		w.finishCurrent()
+		w.currentBuilder = nil
+	}
+	return w.nextLevelNodes, nil
+}
+
+func spanNativeReplacementBeforeRange(span ReadOnlyLeafSpan, low []byte) bool {
 	return span.HighKey != nil && low != nil && bytes.Compare(span.HighKey, low) <= 0
 }
 
-func spanNativeReplacementOverlapsRange(replacement spanNativeLeafReplacement, low, high []byte) bool {
-	span := replacement.span
+func spanNativeReplacementOverlapsRange(span ReadOnlyLeafSpan, low, high []byte) bool {
 	if span.HighKey != nil && low != nil && bytes.Compare(span.HighKey, low) <= 0 {
 		return false
 	}

--- a/TreeDB/zipper/span_native_apply.go
+++ b/TreeDB/zipper/span_native_apply.go
@@ -22,7 +22,7 @@ func (z *Zipper) applySpanNativeWithPrepared(rootID uint64, ops []batch.Entry, p
 	defer z.releaseApplyScratch(scratch)
 
 	var retired []uint64
-	spanOutputs := make([]Split, 0, len(prepared.LeafSpans))
+	replacements := make([]spanNativeLeafReplacement, 0, len(prepared.LeafSpans))
 	for i := range prepared.LeafSpans {
 		span := prepared.LeafSpans[i]
 		newRef, splits, err := z.writeRecursive(span.Ref, ops[span.PointOpStart:span.PointOpEnd], nil, false, nil, &metrics, span.LowKey, span.HighKey, &retired, scratch, false, applyRunConfig{})
@@ -34,15 +34,14 @@ func (z *Zipper) applySpanNativeWithPrepared(rootID uint64, ops []batch.Entry, p
 		if spanKey == nil {
 			spanKey = []byte{}
 		}
-		spanOutputs = append(spanOutputs, Split{Key: spanKey, Ref: newRef})
-		spanOutputs = append(spanOutputs, splits...)
-	}
-	if rootID != 0 && (len(prepared.LeafSpans) > 1 || !(prepared.LeafSpans[0].Ref.Kind == page.ChildRefPage && prepared.LeafSpans[0].Ref.Page == rootID)) {
-		retired = append(retired, rootID)
+		refs := make([]Split, 0, len(splits)+1)
+		refs = append(refs, Split{Key: spanKey, Ref: newRef})
+		refs = append(refs, splits...)
+		replacements = append(replacements, spanNativeLeafReplacement{span: span, refs: refs})
 	}
 
 	rootReduceStart := time.Now()
-	newRootID, err := z.reduceSpanNativeRoot(spanOutputs, &metrics)
+	newRootID, err := z.reduceSpanNativeRootWithContext(rootID, replacements, &metrics, &retired, scratch)
 	metrics.ZipperRootReduceNs += time.Since(rootReduceStart).Nanoseconds()
 	metrics.ZipperApplyWallNs = time.Since(applyStart).Nanoseconds()
 	if err != nil {
@@ -63,11 +62,6 @@ func validateSpanNativePreparedPlan(ops []batch.Entry, prepared ReadOnlyPrepareR
 		return false
 	}
 	spans := prepared.LeafSpans
-	if !spanNativeCoversWholeRoot(spans) {
-		// Partial leaf replacement needs parent-context stitching. Keep that out of
-		// the first opt-in reducer and fall back before preparing output.
-		return false
-	}
 	expectedPointStart := 0
 	var prevHigh []byte
 	for i := range spans {
@@ -75,11 +69,7 @@ func validateSpanNativePreparedPlan(ops []batch.Entry, prepared ReadOnlyPrepareR
 		if span.DeleteRangeStart != span.DeleteRangeEnd || span.PointOpStart != expectedPointStart || span.PointOpEnd > len(ops) || span.PointOpEnd <= span.PointOpStart {
 			return false
 		}
-		if i == 0 {
-			if span.LowKey != nil {
-				return false
-			}
-		} else if !bytes.Equal(span.LowKey, prevHigh) {
+		if i > 0 && !bytes.Equal(span.LowKey, prevHigh) {
 			return false
 		}
 		if span.LowKey != nil && span.HighKey != nil && bytes.Compare(span.LowKey, span.HighKey) >= 0 {
@@ -88,11 +78,151 @@ func validateSpanNativePreparedPlan(ops []batch.Entry, prepared ReadOnlyPrepareR
 		prevHigh = span.HighKey
 		expectedPointStart = span.PointOpEnd
 	}
-	return expectedPointStart == len(ops) && spans[len(spans)-1].HighKey == nil
+	return expectedPointStart == len(ops)
+}
+
+type spanNativeLeafReplacement struct {
+	span ReadOnlyLeafSpan
+	refs []Split
 }
 
 func spanNativeCoversWholeRoot(spans []ReadOnlyLeafSpan) bool {
 	return len(spans) > 0 && spans[0].LowKey == nil && spans[len(spans)-1].HighKey == nil
+}
+
+func (z *Zipper) reduceSpanNativeRootWithContext(rootID uint64, replacements []spanNativeLeafReplacement, metrics *adaptive.Metrics, retired *[]uint64, scratch *mergeScratch) (uint64, error) {
+	if len(replacements) == 0 {
+		return 0, page.ErrInvalidPageType
+	}
+	if spanNativeCoversWholeRoot(replacementSpans(replacements)) {
+		var refs []Split
+		for i := range replacements {
+			refs = append(refs, replacements[i].refs...)
+		}
+		return z.reduceSpanNativeRoot(refs, metrics)
+	}
+	ref, splits, changed, err := z.stitchSpanNativeRecursive(page.PageChildRef(rootID), nil, nil, replacements, metrics, retired, scratch)
+	if err != nil {
+		return 0, err
+	}
+	if !changed {
+		return 0, page.ErrInvalidPageType
+	}
+	refs := make([]Split, 0, len(splits)+1)
+	refs = append(refs, Split{Key: []byte{}, Ref: ref})
+	refs = append(refs, splits...)
+	return z.reduceSpanNativeRoot(refs, metrics)
+}
+
+func replacementSpans(replacements []spanNativeLeafReplacement) []ReadOnlyLeafSpan {
+	spans := make([]ReadOnlyLeafSpan, len(replacements))
+	for i := range replacements {
+		spans[i] = replacements[i].span
+	}
+	return spans
+}
+
+func (z *Zipper) stitchSpanNativeRecursive(ref page.ChildRef, low, high []byte, replacements []spanNativeLeafReplacement, metrics *adaptive.Metrics, retired *[]uint64, scratch *mergeScratch) (page.ChildRef, []Split, bool, error) {
+	oldNode, oldFromPager, leafScratch, leafScratchRef, loadSource, err := z.loadNodeRef(ref, scratch)
+	if err != nil {
+		return page.ChildRef{}, nil, false, err
+	}
+	recordZipperNodeLoad(metrics, ref, oldNode, loadSource)
+	if leafScratchRef {
+		defer releaseLeafPageScratch(scratch, leafScratch)
+	}
+
+	switch oldNode.Type() {
+	case page.PageTypeLeaf, 0:
+		for i := range replacements {
+			if replacements[i].span.Ref == ref {
+				refs := append([]Split(nil), replacements[i].refs...)
+				if len(refs) == 0 {
+					return page.ChildRef{}, nil, false, page.ErrInvalidPageType
+				}
+				if low == nil {
+					refs[0].Key = []byte{}
+				} else {
+					refs[0].Key = low
+				}
+				return refs[0].Ref, refs[1:], true, nil
+			}
+		}
+		return ref, nil, false, nil
+	case page.PageTypeInternal:
+		count := oldNode.Count()
+		children := make([]Split, 0, count)
+		changed := false
+		for i := uint16(0); i < count; i++ {
+			key, childRef, err := oldNode.GetInternalEntryRefView(i)
+			if err != nil {
+				return page.ChildRef{}, nil, false, err
+			}
+			if key == nil {
+				key = []byte{}
+			}
+			childLow := low
+			if len(key) != 0 {
+				childLow = append([]byte(nil), key...)
+			}
+			childHigh := high
+			if i+1 < count {
+				nextKey, _, err := oldNode.GetInternalEntryRefView(i + 1)
+				if err != nil {
+					return page.ChildRef{}, nil, false, err
+				}
+				if nextKey == nil {
+					nextKey = []byte{}
+				}
+				childHigh = append([]byte(nil), nextKey...)
+			}
+			if !spanNativeReplacementsOverlap(replacements, childLow, childHigh) {
+				children = append(children, Split{Key: key, Ref: childRef})
+				continue
+			}
+			newRef, childSplits, childChanged, err := z.stitchSpanNativeRecursive(childRef, childLow, childHigh, replacements, metrics, retired, scratch)
+			if err != nil {
+				return page.ChildRef{}, nil, false, err
+			}
+			if childChanged {
+				changed = true
+				children = append(children, Split{Key: key, Ref: newRef})
+				children = append(children, childSplits...)
+			} else {
+				children = append(children, Split{Key: key, Ref: childRef})
+			}
+		}
+		if !changed {
+			return ref, nil, false, nil
+		}
+		if oldFromPager && retired != nil && ref.Kind == page.ChildRefPage && ref.Page != 0 {
+			*retired = append(*retired, ref.Page)
+		}
+		refs, err := z.reduceSpanNativeSplitLevel(children, metrics)
+		if err != nil {
+			return page.ChildRef{}, nil, false, err
+		}
+		if len(refs) == 0 {
+			return page.ChildRef{}, nil, false, page.ErrInvalidPageType
+		}
+		return refs[0].Ref, refs[1:], true, nil
+	default:
+		return page.ChildRef{}, nil, false, page.ErrInvalidPageType
+	}
+}
+
+func spanNativeReplacementsOverlap(replacements []spanNativeLeafReplacement, low, high []byte) bool {
+	for i := range replacements {
+		span := replacements[i].span
+		if span.HighKey != nil && low != nil && bytes.Compare(span.HighKey, low) <= 0 {
+			continue
+		}
+		if high != nil && span.LowKey != nil && bytes.Compare(span.LowKey, high) >= 0 {
+			continue
+		}
+		return true
+	}
+	return false
 }
 
 func (z *Zipper) reduceSpanNativeRoot(currentLevelNodes []Split, metrics *adaptive.Metrics) (uint64, error) {

--- a/TreeDB/zipper/span_native_apply.go
+++ b/TreeDB/zipper/span_native_apply.go
@@ -36,6 +36,7 @@ func (z *Zipper) applySpanNativeWithPrepared(rootID uint64, ops []batch.Entry, p
 	}
 	workers = len(workerRanges)
 	outputs := scratch.acquireSpanNativeLeafOutputs(spanCount, z.outerLeavesInValueLog)
+	defer outputs.release()
 	rangeMetrics := make([]adaptive.Metrics, len(workerRanges))
 	rangeRetired := make([][]uint64, len(workerRanges))
 	rangeSplits := make([]spanNativeLeafSplitRange, len(workerRanges))
@@ -47,20 +48,28 @@ func (z *Zipper) applySpanNativeWithPrepared(rootID uint64, ops []batch.Entry, p
 		var localMetrics adaptive.Metrics
 		var localRetired []uint64
 		var localSplits [][]Split
+		releaseLocalSplits := func() {
+			if localSplits != nil {
+				releaseSpanNativeSplitSlices(localSplits)
+				localSplits = nil
+			}
+		}
 		for i := workerRange.FirstSpan; i < end; i++ {
 			span := prepared.LeafSpans[i]
 			newRef, splits, err := z.writeRecursive(span.Ref, ops[span.PointOpStart:span.PointOpEnd], nil, false, nil, &localMetrics, span.LowKey, span.HighKey, &localRetired, scratch, false, applyRunConfig{maxParallelWorkers: 1})
 			if err != nil {
+				releaseLocalSplits()
 				errOnce.Do(func() { firstErr = err })
 				return
 			}
 			if err := outputs.setRef(i, newRef); err != nil {
+				releaseLocalSplits()
 				errOnce.Do(func() { firstErr = err })
 				return
 			}
 			if len(splits) > 0 {
 				if localSplits == nil {
-					localSplits = make([][]Split, workerRange.SpanCount)
+					localSplits = acquireSpanNativeSplitSlices(workerRange.SpanCount)
 				}
 				localSplits[i-workerRange.FirstSpan] = splits
 			}
@@ -164,35 +173,149 @@ type spanNativeLeafOutputs struct {
 	splitRanges []spanNativeLeafSplitRange
 }
 
+const spanNativeOutputPoolKeep = 8
+
+var (
+	spanNativeLogRefPool     spanNativeByteSlicePool
+	spanNativePageIDPool     spanNativeUint64SlicePool
+	spanNativeSplitSlicePool spanNativeSplitSlicePoolType
+)
+
+type spanNativeByteSlicePool struct {
+	mu   sync.Mutex
+	bufs [][]byte
+}
+
+func (p *spanNativeByteSlicePool) get(size int) []byte {
+	if size <= 0 {
+		return nil
+	}
+	p.mu.Lock()
+	for i := len(p.bufs) - 1; i >= 0; i-- {
+		buf := p.bufs[i]
+		if cap(buf) >= size {
+			last := len(p.bufs) - 1
+			p.bufs[i] = p.bufs[last]
+			p.bufs[last] = nil
+			p.bufs = p.bufs[:last]
+			p.mu.Unlock()
+			return buf[:size]
+		}
+	}
+	p.mu.Unlock()
+	return make([]byte, size)
+}
+
+func (p *spanNativeByteSlicePool) put(buf []byte, maxCap int) {
+	if cap(buf) == 0 || cap(buf) > maxCap {
+		return
+	}
+	p.mu.Lock()
+	if len(p.bufs) < spanNativeOutputPoolKeep {
+		p.bufs = append(p.bufs, buf[:0])
+	}
+	p.mu.Unlock()
+}
+
+type spanNativeUint64SlicePool struct {
+	mu   sync.Mutex
+	bufs [][]uint64
+}
+
+func (p *spanNativeUint64SlicePool) get(size int) []uint64 {
+	if size <= 0 {
+		return nil
+	}
+	p.mu.Lock()
+	for i := len(p.bufs) - 1; i >= 0; i-- {
+		buf := p.bufs[i]
+		if cap(buf) >= size {
+			last := len(p.bufs) - 1
+			p.bufs[i] = p.bufs[last]
+			p.bufs[last] = nil
+			p.bufs = p.bufs[:last]
+			p.mu.Unlock()
+			return buf[:size]
+		}
+	}
+	p.mu.Unlock()
+	return make([]uint64, size)
+}
+
+func (p *spanNativeUint64SlicePool) put(buf []uint64, maxCap int) {
+	if cap(buf) == 0 || cap(buf) > maxCap {
+		return
+	}
+	p.mu.Lock()
+	if len(p.bufs) < spanNativeOutputPoolKeep {
+		p.bufs = append(p.bufs, buf[:0])
+	}
+	p.mu.Unlock()
+}
+
+type spanNativeSplitSlicePoolType struct {
+	mu   sync.Mutex
+	bufs [][][]Split
+}
+
+func acquireSpanNativeSplitSlices(size int) [][]Split {
+	if size <= 0 {
+		return nil
+	}
+	spanNativeSplitSlicePool.mu.Lock()
+	for i := len(spanNativeSplitSlicePool.bufs) - 1; i >= 0; i-- {
+		buf := spanNativeSplitSlicePool.bufs[i]
+		if cap(buf) >= size {
+			last := len(spanNativeSplitSlicePool.bufs) - 1
+			spanNativeSplitSlicePool.bufs[i] = spanNativeSplitSlicePool.bufs[last]
+			spanNativeSplitSlicePool.bufs[last] = nil
+			spanNativeSplitSlicePool.bufs = spanNativeSplitSlicePool.bufs[:last]
+			spanNativeSplitSlicePool.mu.Unlock()
+			return buf[:size]
+		}
+	}
+	spanNativeSplitSlicePool.mu.Unlock()
+	return make([][]Split, size)
+}
+
+func releaseSpanNativeSplitSlices(buf [][]Split) {
+	if cap(buf) == 0 || cap(buf) > mergeSpanNativeOutputKeepCap {
+		return
+	}
+	clear(buf)
+	spanNativeSplitSlicePool.mu.Lock()
+	if len(spanNativeSplitSlicePool.bufs) < spanNativeOutputPoolKeep {
+		spanNativeSplitSlicePool.bufs = append(spanNativeSplitSlicePool.bufs, buf[:0])
+	}
+	spanNativeSplitSlicePool.mu.Unlock()
+}
+
 func (s *mergeScratch) acquireSpanNativeLeafOutputs(count int, leafLogs bool) spanNativeLeafOutputs {
 	if count <= 0 {
 		return spanNativeLeafOutputs{}
 	}
 	if leafLogs {
 		bytesNeeded := count * page.LogRecordRefSize
-		var refs []byte
-		if s == nil || cap(s.spanNativeOutputLogScratch) < bytesNeeded {
-			refs = make([]byte, bytesNeeded)
-			if s != nil {
-				s.spanNativeOutputLogScratch = refs
-			}
-		} else {
-			s.spanNativeOutputLogScratch = s.spanNativeOutputLogScratch[:bytesNeeded]
-			refs = s.spanNativeOutputLogScratch
-		}
-		return spanNativeLeafOutputs{mode: spanNativeLeafOutputLeafLogs, leafLogRefs: refs}
+		return spanNativeLeafOutputs{mode: spanNativeLeafOutputLeafLogs, leafLogRefs: spanNativeLogRefPool.get(bytesNeeded)}
 	}
-	var pageIDs []uint64
-	if s == nil || cap(s.spanNativeOutputPageScratch) < count {
-		pageIDs = make([]uint64, count)
-		if s != nil {
-			s.spanNativeOutputPageScratch = pageIDs
-		}
-	} else {
-		s.spanNativeOutputPageScratch = s.spanNativeOutputPageScratch[:count]
-		pageIDs = s.spanNativeOutputPageScratch
+	return spanNativeLeafOutputs{mode: spanNativeLeafOutputPages, pageIDs: spanNativePageIDPool.get(count)}
+}
+
+func (o *spanNativeLeafOutputs) release() {
+	if o == nil {
+		return
 	}
-	return spanNativeLeafOutputs{mode: spanNativeLeafOutputPages, pageIDs: pageIDs}
+	switch o.mode {
+	case spanNativeLeafOutputLeafLogs:
+		spanNativeLogRefPool.put(o.leafLogRefs, mergeSpanNativeOutputLogKeepBytes)
+	case spanNativeLeafOutputPages:
+		spanNativePageIDPool.put(o.pageIDs, mergeSpanNativeOutputPageKeepCap)
+	}
+	for i := range o.splitRanges {
+		releaseSpanNativeSplitSlices(o.splitRanges[i].splits)
+		o.splitRanges[i] = spanNativeLeafSplitRange{}
+	}
+	*o = spanNativeLeafOutputs{}
 }
 
 func (o *spanNativeLeafOutputs) setRef(index int, ref page.ChildRef) error {
@@ -349,6 +472,7 @@ func (z *Zipper) stitchSpanNativeRecursive(ref page.ChildRef, low, high []byte, 
 		count := oldNode.Count()
 		copyKeys := oldNode.InternalBaseDeltaEnabled()
 		writer := spanNativeSplitLevelWriter{z: z, metrics: metrics}
+		defer writer.abort()
 		changed := false
 		replacementIdx := 0
 		for i := uint16(0); i < count; i++ {
@@ -469,7 +593,7 @@ func (w *spanNativeSplitLevelWriter) append(child Split) error {
 		if err != nil {
 			return err
 		}
-		w.currentBuilder = w.z.newBuilderForType(data, page.PageTypeInternal, nil)
+		w.currentBuilder = w.z.newPooledBuilderForType(data, page.PageTypeInternal, nil)
 		w.currentBuilder.SetPageID(pid)
 		w.currentStartKey = child.Key
 		w.currentBuilder.SetInternalFenceBounds(w.currentStartKey, nil)
@@ -495,9 +619,9 @@ func (w *spanNativeSplitLevelWriter) append(child Split) error {
 		}
 	}
 	if err == node.ErrNodeFull {
-		w.finishCurrent()
+		finishedPageID := w.finishCurrent()
 
-		pid, allocErr := w.z.allocator.Alloc(w.currentBuilder.PageID())
+		pid, allocErr := w.z.allocator.Alloc(finishedPageID)
 		if allocErr != nil {
 			return allocErr
 		}
@@ -505,7 +629,7 @@ func (w *spanNativeSplitLevelWriter) append(child Split) error {
 		if getErr != nil {
 			return getErr
 		}
-		w.currentBuilder = w.z.newBuilderForType(data, page.PageTypeInternal, nil)
+		w.currentBuilder = w.z.newPooledBuilderForType(data, page.PageTypeInternal, nil)
 		w.currentBuilder.SetPageID(pid)
 		w.currentStartKey = child.Key
 		w.currentBuilder.SetInternalFenceBounds(w.currentStartKey, nil)
@@ -520,18 +644,28 @@ func (w *spanNativeSplitLevelWriter) append(child Split) error {
 	return nil
 }
 
-func (w *spanNativeSplitLevelWriter) finishCurrent() {
+func (w *spanNativeSplitLevelWriter) finishCurrent() uint64 {
+	pageID := w.currentBuilder.PageID()
 	w.currentBuilder.FinishNoNode()
 	recordZipperInternalPageWrite(w.metrics)
-	w.nextLevelNodes = append(w.nextLevelNodes, Split{Key: w.currentStartKey, Ref: page.PageChildRef(w.currentBuilder.PageID())})
+	w.nextLevelNodes = append(w.nextLevelNodes, Split{Key: w.currentStartKey, Ref: page.PageChildRef(pageID)})
+	releasePooledBuilder(w.currentBuilder)
+	w.currentBuilder = nil
+	return pageID
 }
 
 func (w *spanNativeSplitLevelWriter) finish() ([]Split, error) {
 	if w.currentBuilder != nil {
 		w.finishCurrent()
-		w.currentBuilder = nil
 	}
 	return w.nextLevelNodes, nil
+}
+
+func (w *spanNativeSplitLevelWriter) abort() {
+	if w.currentBuilder != nil {
+		releasePooledBuilder(w.currentBuilder)
+		w.currentBuilder = nil
+	}
 }
 
 func spanNativeReplacementBeforeRange(span ReadOnlyLeafSpan, low []byte) bool {

--- a/TreeDB/zipper/span_native_apply.go
+++ b/TreeDB/zipper/span_native_apply.go
@@ -11,12 +11,7 @@ import (
 )
 
 func (z *Zipper) applySpanNativeWithPrepared(rootID uint64, ops []batch.Entry, prepared ReadOnlyPrepareResult) (ApplyResult, bool, error) {
-	if prepared.DeleteRanges != 0 || prepared.ColdBuild || prepared.Maintenance || !prepared.ExactLeafSpans || len(prepared.LeafSpans) == 0 {
-		return ApplyResult{}, false, nil
-	}
-	if !spanNativeCoversWholeRoot(prepared.LeafSpans) {
-		// Partial leaf replacement needs parent-context stitching. Keep that out of
-		// the first opt-in reducer and fall back before preparing output.
+	if !validateSpanNativePreparedPlan(ops, prepared) {
 		return ApplyResult{}, false, nil
 	}
 
@@ -30,12 +25,6 @@ func (z *Zipper) applySpanNativeWithPrepared(rootID uint64, ops []batch.Entry, p
 	spanOutputs := make([]Split, 0, len(prepared.LeafSpans))
 	for i := range prepared.LeafSpans {
 		span := prepared.LeafSpans[i]
-		if span.DeleteRangeStart != span.DeleteRangeEnd || span.PointOpStart < 0 || span.PointOpEnd > len(ops) || span.PointOpEnd <= span.PointOpStart {
-			return ApplyResult{}, false, nil
-		}
-		if i > 0 && span.PointOpStart != prepared.LeafSpans[i-1].PointOpEnd {
-			return ApplyResult{}, false, nil
-		}
 		newRef, splits, err := z.writeRecursive(span.Ref, ops[span.PointOpStart:span.PointOpEnd], nil, false, nil, &metrics, span.LowKey, span.HighKey, &retired, scratch, false, applyRunConfig{})
 		if err != nil {
 			metrics.ZipperApplyWallNs = time.Since(applyStart).Nanoseconds()
@@ -47,12 +36,6 @@ func (z *Zipper) applySpanNativeWithPrepared(rootID uint64, ops []batch.Entry, p
 		}
 		spanOutputs = append(spanOutputs, Split{Key: spanKey, Ref: newRef})
 		spanOutputs = append(spanOutputs, splits...)
-	}
-	if len(prepared.LeafSpans) > 0 && prepared.LeafSpans[0].PointOpStart != 0 {
-		return ApplyResult{}, false, nil
-	}
-	if len(prepared.LeafSpans) > 0 && prepared.LeafSpans[len(prepared.LeafSpans)-1].PointOpEnd != len(ops) {
-		return ApplyResult{}, false, nil
 	}
 	if rootID != 0 && (len(prepared.LeafSpans) > 1 || !(prepared.LeafSpans[0].Ref.Kind == page.ChildRefPage && prepared.LeafSpans[0].Ref.Page == rootID)) {
 		retired = append(retired, rootID)
@@ -73,6 +56,39 @@ func (z *Zipper) applySpanNativeWithPrepared(rootID uint64, ops []batch.Entry, p
 		SpanNativeWorkers:   1,
 		SpanNativeUsed:      true,
 	}, true, nil
+}
+
+func validateSpanNativePreparedPlan(ops []batch.Entry, prepared ReadOnlyPrepareResult) bool {
+	if prepared.DeleteRanges != 0 || prepared.ColdBuild || prepared.Maintenance || !prepared.ExactLeafSpans || len(prepared.LeafSpans) == 0 {
+		return false
+	}
+	spans := prepared.LeafSpans
+	if !spanNativeCoversWholeRoot(spans) {
+		// Partial leaf replacement needs parent-context stitching. Keep that out of
+		// the first opt-in reducer and fall back before preparing output.
+		return false
+	}
+	expectedPointStart := 0
+	var prevHigh []byte
+	for i := range spans {
+		span := spans[i]
+		if span.DeleteRangeStart != span.DeleteRangeEnd || span.PointOpStart != expectedPointStart || span.PointOpEnd > len(ops) || span.PointOpEnd <= span.PointOpStart {
+			return false
+		}
+		if i == 0 {
+			if span.LowKey != nil {
+				return false
+			}
+		} else if !bytes.Equal(span.LowKey, prevHigh) {
+			return false
+		}
+		if span.LowKey != nil && span.HighKey != nil && bytes.Compare(span.LowKey, span.HighKey) >= 0 {
+			return false
+		}
+		prevHigh = span.HighKey
+		expectedPointStart = span.PointOpEnd
+	}
+	return expectedPointStart == len(ops) && spans[len(spans)-1].HighKey == nil
 }
 
 func spanNativeCoversWholeRoot(spans []ReadOnlyLeafSpan) bool {

--- a/TreeDB/zipper/span_native_apply.go
+++ b/TreeDB/zipper/span_native_apply.go
@@ -19,8 +19,8 @@ func (z *Zipper) applySpanNativeWithPrepared(rootID uint64, ops []batch.Entry, p
 	applyStart := time.Now()
 	var metrics adaptive.Metrics
 	metrics.ZipperApplyOps = len(ops)
-	scratch := z.acquireApplyScratch()
-	defer z.releaseApplyScratch(scratch)
+	coordinatorScratch := z.acquireApplyScratch()
+	defer z.releaseApplyScratch(coordinatorScratch)
 
 	spanCount := len(prepared.LeafSpans)
 	if workers <= 0 {
@@ -35,14 +35,23 @@ func (z *Zipper) applySpanNativeWithPrepared(rootID uint64, ops []batch.Entry, p
 		workerRanges = append(workerRanges, ReadOnlyLeafSpanWorkerRange{FirstSpan: 0, SpanCount: spanCount, Ops: len(ops)})
 	}
 	workers = len(workerRanges)
-	outputs := scratch.acquireSpanNativeLeafOutputs(spanCount, z.outerLeavesInValueLog)
+	outputs := coordinatorScratch.acquireSpanNativeLeafOutputs(spanCount, z.outerLeavesInValueLog)
 	defer outputs.release()
+	workerScratches := make([]*mergeScratch, len(workerRanges))
+	defer func() {
+		for i := range workerScratches {
+			z.releaseApplyScratch(workerScratches[i])
+			workerScratches[i] = nil
+		}
+	}()
 	rangeMetrics := make([]adaptive.Metrics, len(workerRanges))
 	rangeRetired := make([][]uint64, len(workerRanges))
 	rangeSplits := make([]spanNativeLeafSplitRange, len(workerRanges))
 	var firstErr error
 	var errOnce sync.Once
 	runRange := func(_ int, job int) {
+		workerScratch := z.acquireApplyScratch()
+		workerScratches[job] = workerScratch
 		workerRange := workerRanges[job]
 		end := workerRange.FirstSpan + workerRange.SpanCount
 		var localMetrics adaptive.Metrics
@@ -56,7 +65,7 @@ func (z *Zipper) applySpanNativeWithPrepared(rootID uint64, ops []batch.Entry, p
 		}
 		for i := workerRange.FirstSpan; i < end; i++ {
 			span := prepared.LeafSpans[i]
-			newRef, splits, err := z.writeRecursive(span.Ref, ops[span.PointOpStart:span.PointOpEnd], nil, false, nil, &localMetrics, span.LowKey, span.HighKey, &localRetired, scratch, false, applyRunConfig{maxParallelWorkers: 1})
+			newRef, splits, err := z.writeRecursive(span.Ref, ops[span.PointOpStart:span.PointOpEnd], nil, false, nil, &localMetrics, span.LowKey, span.HighKey, &localRetired, workerScratch, false, applyRunConfig{maxParallelWorkers: 1})
 			if err != nil {
 				releaseLocalSplits()
 				errOnce.Do(func() { firstErr = err })
@@ -101,7 +110,7 @@ func (z *Zipper) applySpanNativeWithPrepared(rootID uint64, ops []batch.Entry, p
 	}
 
 	rootReduceStart := time.Now()
-	newRootID, err := z.reduceSpanNativeRootWithContext(rootID, spanNativeLeafReplacements{spans: prepared.LeafSpans, outputs: &outputs}, &metrics, &retired, scratch)
+	newRootID, err := z.reduceSpanNativeRootWithContext(rootID, spanNativeLeafReplacements{spans: prepared.LeafSpans, outputs: &outputs}, &metrics, &retired, coordinatorScratch)
 	metrics.ZipperRootReduceNs += time.Since(rootReduceStart).Nanoseconds()
 	metrics.ZipperApplyWallNs = time.Since(applyStart).Nanoseconds()
 	if err != nil {

--- a/TreeDB/zipper/span_native_apply.go
+++ b/TreeDB/zipper/span_native_apply.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/snissn/gomap/TreeDB/batch"
 	"github.com/snissn/gomap/TreeDB/internal/adaptive"
+	"github.com/snissn/gomap/TreeDB/node"
 	"github.com/snissn/gomap/TreeDB/page"
 )
 
@@ -51,11 +52,101 @@ func (z *Zipper) applySpanNativeWithPrepared(rootID uint64, ops []batch.Entry, p
 }
 
 func (z *Zipper) reduceSpanNativeSingleLeafRoot(newRef page.ChildRef, splits []Split, metrics *adaptive.Metrics) (uint64, error) {
-	if len(splits) != 0 {
-		// Multi-split deterministic reducer support is added after the single-leaf
-		// job path is proven. Fail closed rather than silently re-entering the
-		// recursive reducer for already-prepared span output.
-		return 0, page.ErrInvalidPageType
+	if len(splits) == 0 {
+		return z.ensureRootPage([]byte{}, newRef, metrics)
 	}
-	return z.ensureRootPage([]byte{}, newRef, metrics)
+	currentLevelNodes := make([]Split, 0, len(splits)+1)
+	currentLevelNodes = append(currentLevelNodes, Split{Key: []byte{}, Ref: newRef})
+	currentLevelNodes = append(currentLevelNodes, splits...)
+	for {
+		if len(currentLevelNodes) == 1 {
+			return z.ensureRootPage(currentLevelNodes[0].Key, currentLevelNodes[0].Ref, metrics)
+		}
+		metrics.ZipperRootSplitLevels++
+		nextLevelNodes, err := z.reduceSpanNativeSplitLevel(currentLevelNodes, metrics)
+		if err != nil {
+			return 0, err
+		}
+		currentLevelNodes = nextLevelNodes
+	}
+}
+
+func (z *Zipper) reduceSpanNativeSplitLevel(currentLevelNodes []Split, metrics *adaptive.Metrics) ([]Split, error) {
+	var nextLevelNodes []Split
+	var currentBuilder *node.Builder
+	var currentStartKey []byte
+
+	for i, child := range currentLevelNodes {
+		if currentBuilder == nil {
+			allocHint := uint64(0)
+			if child.Ref.Kind == page.ChildRefPage {
+				allocHint = child.Ref.Page
+			}
+			pid, err := z.allocator.Alloc(allocHint)
+			if err != nil {
+				return nil, err
+			}
+			data, err := z.pager.GetForWrite(pid)
+			if err != nil {
+				return nil, err
+			}
+			currentBuilder = z.newBuilderForType(data, page.PageTypeInternal, nil)
+			currentBuilder.SetPageID(pid)
+			currentStartKey = child.Key
+			currentBuilder.SetInternalFenceBounds(currentStartKey, nil)
+		}
+
+		childKey := child.Key
+		if childKey == nil {
+			childKey = []byte{}
+		}
+		childSize := 2 + 8 + len(childKey)
+		if child.Ref.Kind == page.ChildRefLeafLog {
+			childSize = 2 + page.LogRecordRefSize + len(childKey)
+		} else if z.indexInternalBaseDelta {
+			childSize = 2 + 4 + len(childKey)
+		}
+		var err error
+		if z.internalSoftFull(currentBuilder, childSize) {
+			err = node.ErrNodeFull
+		} else {
+			err = currentBuilder.AddInternalChildRef(childKey, child.Ref)
+			if err == nil {
+				recordZipperInternalChildRef(metrics, child.Ref)
+			}
+		}
+		if err == node.ErrNodeFull {
+			currentBuilder.FinishNoNode()
+			recordZipperInternalPageWrite(metrics)
+			nextLevelNodes = append(nextLevelNodes, Split{Key: currentStartKey, Ref: page.PageChildRef(currentBuilder.PageID())})
+
+			pid, allocErr := z.allocator.Alloc(currentBuilder.PageID())
+			if allocErr != nil {
+				return nil, allocErr
+			}
+			data, getErr := z.pager.GetForWrite(pid)
+			if getErr != nil {
+				return nil, getErr
+			}
+			currentBuilder = z.newBuilderForType(data, page.PageTypeInternal, nil)
+			currentBuilder.SetPageID(pid)
+			currentStartKey = child.Key
+			currentBuilder.SetInternalFenceBounds(currentStartKey, nil)
+
+			if addErr := currentBuilder.AddInternalChildRef(childKey, child.Ref); addErr != nil {
+				return nil, addErr
+			}
+			recordZipperInternalChildRef(metrics, child.Ref)
+		} else if err != nil {
+			return nil, err
+		}
+
+		if i == len(currentLevelNodes)-1 {
+			currentBuilder.FinishNoNode()
+			recordZipperInternalPageWrite(metrics)
+			nextLevelNodes = append(nextLevelNodes, Split{Key: currentStartKey, Ref: page.PageChildRef(currentBuilder.PageID())})
+			currentBuilder = nil
+		}
+	}
+	return nextLevelNodes, nil
 }

--- a/TreeDB/zipper/span_native_apply.go
+++ b/TreeDB/zipper/span_native_apply.go
@@ -3,6 +3,7 @@ package zipper
 import (
 	"bytes"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/snissn/gomap/TreeDB/batch"
@@ -89,9 +90,33 @@ func (z *Zipper) applySpanNativeWithPrepared(rootID uint64, ops []batch.Entry, p
 			rangeSplits[job] = spanNativeLeafSplitRange{start: workerRange.FirstSpan, splits: localSplits}
 		}
 	}
-	if err := workerPool.Run(workers, len(workerRanges), runRange); err != nil {
-		metrics.ZipperApplyWallNs = time.Since(applyStart).Nanoseconds()
-		return ApplyResult{Metrics: metrics}, true, err
+	if workerPool != nil {
+		if err := workerPool.Run(workers, len(workerRanges), runRange); err != nil {
+			metrics.ZipperApplyWallNs = time.Since(applyStart).Nanoseconds()
+			return ApplyResult{Metrics: metrics}, true, err
+		}
+	} else if workers <= 1 {
+		for job := range workerRanges {
+			runRange(0, job)
+		}
+	} else {
+		var nextJob int64 = -1
+		var wg sync.WaitGroup
+		worker := func(workerID int) {
+			defer wg.Done()
+			for {
+				job := int(atomic.AddInt64(&nextJob, 1))
+				if job >= len(workerRanges) {
+					return
+				}
+				runRange(workerID, job)
+			}
+		}
+		for workerID := 0; workerID < workers; workerID++ {
+			wg.Add(1)
+			go worker(workerID)
+		}
+		wg.Wait()
 	}
 
 	var retired []uint64

--- a/TreeDB/zipper/span_native_apply.go
+++ b/TreeDB/zipper/span_native_apply.go
@@ -127,7 +127,7 @@ func (z *Zipper) applySpanNativeWithPrepared(rootID uint64, ops []batch.Entry, p
 }
 
 func validateSpanNativePreparedPlan(ops []batch.Entry, prepared ReadOnlyPrepareResult) bool {
-	if prepared.DeleteRanges != 0 || prepared.ColdBuild || prepared.Maintenance || !prepared.ExactLeafSpans || len(prepared.LeafSpans) == 0 {
+	if prepared.OmitKeys || prepared.DeleteRanges != 0 || prepared.ColdBuild || prepared.Maintenance || !prepared.ExactLeafSpans || len(prepared.LeafSpans) == 0 {
 		return false
 	}
 	spans := prepared.LeafSpans

--- a/TreeDB/zipper/span_native_apply.go
+++ b/TreeDB/zipper/span_native_apply.go
@@ -415,6 +415,9 @@ func (z *Zipper) reduceSpanNativeRootWithContext(rootID uint64, replacements spa
 		return 0, page.ErrInvalidPageType
 	}
 	if spanNativeReplacementsCoverWholeRoot(replacements) {
+		if err := z.retireSpanNativeWholeRootInternalPages(rootID, replacements, retired, scratch); err != nil {
+			return 0, err
+		}
 		var refs []Split
 		for i := 0; i < replacements.len(); i++ {
 			out := replacements.output(i)
@@ -442,6 +445,57 @@ func spanNativeReplacementHeadSplit(span ReadOnlyLeafSpan, output spanNativeLeaf
 		spanKey = []byte{}
 	}
 	return Split{Key: spanKey, Ref: output.ref}
+}
+
+func (z *Zipper) retireSpanNativeWholeRootInternalPages(rootID uint64, replacements spanNativeLeafReplacements, retired *[]uint64, scratch *mergeScratch) error {
+	if retired == nil || replacements.len() == 0 {
+		return nil
+	}
+	spanIdx := 0
+	var walk func(page.ChildRef) error
+	walk = func(ref page.ChildRef) error {
+		if spanIdx < replacements.len() && replacements.spans[spanIdx].Ref == ref {
+			spanIdx++
+			return nil
+		}
+		if ref.Kind != page.ChildRefPage {
+			return nil
+		}
+		oldNode, oldFromPager, leafScratch, leafScratchRef, _, err := z.loadNodeRef(ref, scratch)
+		if err != nil {
+			return err
+		}
+		if leafScratchRef {
+			defer releaseLeafPageScratch(scratch, leafScratch)
+		}
+		switch oldNode.Type() {
+		case page.PageTypeLeaf, 0:
+			return nil
+		case page.PageTypeInternal:
+			if oldFromPager && ref.Page != 0 {
+				*retired = append(*retired, ref.Page)
+			}
+			for i := uint16(0); i < oldNode.Count(); i++ {
+				childRef, err := oldNode.GetInternalChildRef(i)
+				if err != nil {
+					return err
+				}
+				if err := walk(childRef); err != nil {
+					return err
+				}
+			}
+			return nil
+		default:
+			return page.ErrInvalidPageType
+		}
+	}
+	if err := walk(page.PageChildRef(rootID)); err != nil {
+		return err
+	}
+	if spanIdx != replacements.len() {
+		return page.ErrInvalidPageType
+	}
+	return nil
 }
 
 func spanNativeReplacementsCoverWholeRoot(replacements spanNativeLeafReplacements) bool {

--- a/TreeDB/zipper/span_native_apply.go
+++ b/TreeDB/zipper/span_native_apply.go
@@ -10,11 +10,12 @@ import (
 )
 
 func (z *Zipper) applySpanNativeWithPrepared(rootID uint64, ops []batch.Entry, prepared ReadOnlyPrepareResult) (ApplyResult, bool, error) {
-	if prepared.DeleteRanges != 0 || prepared.ColdBuild || prepared.Maintenance || !prepared.ExactLeafSpans || len(prepared.LeafSpans) != 1 {
+	if prepared.DeleteRanges != 0 || prepared.ColdBuild || prepared.Maintenance || !prepared.ExactLeafSpans || len(prepared.LeafSpans) == 0 {
 		return ApplyResult{}, false, nil
 	}
-	span := prepared.LeafSpans[0]
-	if span.DeleteRangeStart != span.DeleteRangeEnd || span.PointOpStart < 0 || span.PointOpEnd > len(ops) || span.PointOpEnd <= span.PointOpStart {
+	if len(prepared.LeafSpans) > 1 && !spanNativeCoversWholeRoot(prepared.LeafSpans) {
+		// Partial multi-leaf replacement needs parent-context stitching. Keep that
+		// out of the first opt-in reducer and fall back before preparing output.
 		return ApplyResult{}, false, nil
 	}
 
@@ -25,17 +26,39 @@ func (z *Zipper) applySpanNativeWithPrepared(rootID uint64, ops []batch.Entry, p
 	defer z.releaseApplyScratch(scratch)
 
 	var retired []uint64
-	newRef, splits, err := z.writeRecursive(span.Ref, ops[span.PointOpStart:span.PointOpEnd], nil, false, nil, &metrics, span.LowKey, span.HighKey, &retired, scratch, false, applyRunConfig{})
-	if err != nil {
-		metrics.ZipperApplyWallNs = time.Since(applyStart).Nanoseconds()
-		return ApplyResult{Metrics: metrics}, true, err
+	spanOutputs := make([]Split, 0, len(prepared.LeafSpans))
+	for i := range prepared.LeafSpans {
+		span := prepared.LeafSpans[i]
+		if span.DeleteRangeStart != span.DeleteRangeEnd || span.PointOpStart < 0 || span.PointOpEnd > len(ops) || span.PointOpEnd <= span.PointOpStart {
+			return ApplyResult{}, false, nil
+		}
+		if i > 0 && span.PointOpStart != prepared.LeafSpans[i-1].PointOpEnd {
+			return ApplyResult{}, false, nil
+		}
+		newRef, splits, err := z.writeRecursive(span.Ref, ops[span.PointOpStart:span.PointOpEnd], nil, false, nil, &metrics, span.LowKey, span.HighKey, &retired, scratch, false, applyRunConfig{})
+		if err != nil {
+			metrics.ZipperApplyWallNs = time.Since(applyStart).Nanoseconds()
+			return ApplyResult{Metrics: metrics}, true, err
+		}
+		spanKey := span.LowKey
+		if spanKey == nil {
+			spanKey = []byte{}
+		}
+		spanOutputs = append(spanOutputs, Split{Key: spanKey, Ref: newRef})
+		spanOutputs = append(spanOutputs, splits...)
 	}
-	if rootID != 0 && !(span.Ref.Kind == page.ChildRefPage && span.Ref.Page == rootID) {
+	if len(prepared.LeafSpans) > 0 && prepared.LeafSpans[0].PointOpStart != 0 {
+		return ApplyResult{}, false, nil
+	}
+	if len(prepared.LeafSpans) > 0 && prepared.LeafSpans[len(prepared.LeafSpans)-1].PointOpEnd != len(ops) {
+		return ApplyResult{}, false, nil
+	}
+	if rootID != 0 && (len(prepared.LeafSpans) > 1 || !(prepared.LeafSpans[0].Ref.Kind == page.ChildRefPage && prepared.LeafSpans[0].Ref.Page == rootID)) {
 		retired = append(retired, rootID)
 	}
 
 	rootReduceStart := time.Now()
-	newRootID, err := z.reduceSpanNativeSingleLeafRoot(newRef, splits, &metrics)
+	newRootID, err := z.reduceSpanNativeRoot(spanOutputs, &metrics)
 	metrics.ZipperRootReduceNs += time.Since(rootReduceStart).Nanoseconds()
 	metrics.ZipperApplyWallNs = time.Since(applyStart).Nanoseconds()
 	if err != nil {
@@ -51,13 +74,14 @@ func (z *Zipper) applySpanNativeWithPrepared(rootID uint64, ops []batch.Entry, p
 	}, true, nil
 }
 
-func (z *Zipper) reduceSpanNativeSingleLeafRoot(newRef page.ChildRef, splits []Split, metrics *adaptive.Metrics) (uint64, error) {
-	if len(splits) == 0 {
-		return z.ensureRootPage([]byte{}, newRef, metrics)
+func spanNativeCoversWholeRoot(spans []ReadOnlyLeafSpan) bool {
+	return len(spans) > 0 && spans[0].LowKey == nil && spans[len(spans)-1].HighKey == nil
+}
+
+func (z *Zipper) reduceSpanNativeRoot(currentLevelNodes []Split, metrics *adaptive.Metrics) (uint64, error) {
+	if len(currentLevelNodes) == 0 {
+		return 0, page.ErrInvalidPageType
 	}
-	currentLevelNodes := make([]Split, 0, len(splits)+1)
-	currentLevelNodes = append(currentLevelNodes, Split{Key: []byte{}, Ref: newRef})
-	currentLevelNodes = append(currentLevelNodes, splits...)
 	for {
 		if len(currentLevelNodes) == 1 {
 			return z.ensureRootPage(currentLevelNodes[0].Key, currentLevelNodes[0].Ref, metrics)

--- a/TreeDB/zipper/span_native_apply.go
+++ b/TreeDB/zipper/span_native_apply.go
@@ -1,6 +1,7 @@
 package zipper
 
 import (
+	"bytes"
 	"time"
 
 	"github.com/snissn/gomap/TreeDB/batch"
@@ -79,8 +80,8 @@ func spanNativeCoversWholeRoot(spans []ReadOnlyLeafSpan) bool {
 }
 
 func (z *Zipper) reduceSpanNativeRoot(currentLevelNodes []Split, metrics *adaptive.Metrics) (uint64, error) {
-	if len(currentLevelNodes) == 0 {
-		return 0, page.ErrInvalidPageType
+	if err := validateSpanNativeReducerRefs(currentLevelNodes); err != nil {
+		return 0, err
 	}
 	for {
 		if len(currentLevelNodes) == 1 {
@@ -93,6 +94,23 @@ func (z *Zipper) reduceSpanNativeRoot(currentLevelNodes []Split, metrics *adapti
 		}
 		currentLevelNodes = nextLevelNodes
 	}
+}
+
+func validateSpanNativeReducerRefs(refs []Split) error {
+	if len(refs) == 0 {
+		return page.ErrInvalidPageType
+	}
+	if len(refs[0].Key) != 0 {
+		return page.ErrInvalidPageType
+	}
+	prev := refs[0].Key
+	for i := 1; i < len(refs); i++ {
+		if len(refs[i].Key) == 0 || bytes.Compare(refs[i].Key, prev) <= 0 {
+			return page.ErrInvalidPageType
+		}
+		prev = refs[i].Key
+	}
+	return nil
 }
 
 func (z *Zipper) reduceSpanNativeSplitLevel(currentLevelNodes []Split, metrics *adaptive.Metrics) ([]Split, error) {

--- a/TreeDB/zipper/span_native_apply.go
+++ b/TreeDB/zipper/span_native_apply.go
@@ -135,7 +135,7 @@ func validateSpanNativePreparedPlan(ops []batch.Entry, prepared ReadOnlyPrepareR
 	var prevHigh []byte
 	for i := range spans {
 		span := spans[i]
-		if span.DeleteRangeStart != span.DeleteRangeEnd || span.PointOpStart != expectedPointStart || span.PointOpEnd > len(ops) || span.PointOpEnd <= span.PointOpStart {
+		if span.DeleteRangeStart != span.DeleteRangeEnd || span.PointOpStart < 0 || span.PointOpEnd < 0 || span.PointOpStart != expectedPointStart || span.PointOpEnd > len(ops) || span.PointOpEnd <= span.PointOpStart {
 			return false
 		}
 		if span.LowKey != nil && span.HighKey != nil && bytes.Compare(span.LowKey, span.HighKey) >= 0 {
@@ -545,13 +545,12 @@ func (z *Zipper) stitchSpanNativeRecursive(ref page.ChildRef, low, high []byte, 
 			}
 			if key == nil {
 				key = []byte{}
+			} else if copyKeys {
+				key = append([]byte(nil), key...)
 			}
 			childLow := low
 			if len(key) != 0 {
 				childLow = key
-				if copyKeys {
-					childLow = append([]byte(nil), key...)
-				}
 			}
 			childHigh := high
 			if i+1 < count {
@@ -561,11 +560,10 @@ func (z *Zipper) stitchSpanNativeRecursive(ref page.ChildRef, low, high []byte, 
 				}
 				if nextKey == nil {
 					nextKey = []byte{}
+				} else if copyKeys {
+					nextKey = append([]byte(nil), nextKey...)
 				}
 				childHigh = nextKey
-				if copyKeys {
-					childHigh = append([]byte(nil), nextKey...)
-				}
 			}
 
 			for replacementIdx < replacements.len() && spanNativeReplacementBeforeRange(replacements.spans[replacementIdx], childLow) {

--- a/TreeDB/zipper/span_native_apply.go
+++ b/TreeDB/zipper/span_native_apply.go
@@ -2,6 +2,7 @@ package zipper
 
 import (
 	"bytes"
+	"sync"
 	"time"
 
 	"github.com/snissn/gomap/TreeDB/batch"
@@ -10,7 +11,7 @@ import (
 	"github.com/snissn/gomap/TreeDB/page"
 )
 
-func (z *Zipper) applySpanNativeWithPrepared(rootID uint64, ops []batch.Entry, prepared ReadOnlyPrepareResult) (ApplyResult, bool, error) {
+func (z *Zipper) applySpanNativeWithPrepared(rootID uint64, ops []batch.Entry, prepared ReadOnlyPrepareResult, workers int, workerPool *ApplyWorkerPool) (ApplyResult, bool, error) {
 	if !validateSpanNativePreparedPlan(ops, prepared) {
 		return ApplyResult{}, false, nil
 	}
@@ -21,14 +22,32 @@ func (z *Zipper) applySpanNativeWithPrepared(rootID uint64, ops []batch.Entry, p
 	scratch := z.acquireApplyScratch()
 	defer z.releaseApplyScratch(scratch)
 
-	var retired []uint64
-	replacements := make([]spanNativeLeafReplacement, 0, len(prepared.LeafSpans))
-	for i := range prepared.LeafSpans {
+	spanCount := len(prepared.LeafSpans)
+	if workers <= 0 {
+		workers = 1
+	}
+	if workers > spanCount {
+		workers = spanCount
+	}
+
+	replacements := make([]spanNativeLeafReplacement, spanCount)
+	spanMetrics := make([]adaptive.Metrics, spanCount)
+	spanRetired := make([][]uint64, spanCount)
+	workerRanges := prepared.AppendLeafSpanWorkerRanges(nil, workers)
+	if len(workerRanges) == 0 {
+		workerRanges = append(workerRanges, ReadOnlyLeafSpanWorkerRange{FirstSpan: 0, SpanCount: spanCount, Ops: len(ops)})
+	}
+	workers = len(workerRanges)
+	var firstErr error
+	var errOnce sync.Once
+	runSpan := func(i int) bool {
 		span := prepared.LeafSpans[i]
-		newRef, splits, err := z.writeRecursive(span.Ref, ops[span.PointOpStart:span.PointOpEnd], nil, false, nil, &metrics, span.LowKey, span.HighKey, &retired, scratch, false, applyRunConfig{})
+		var childMetrics adaptive.Metrics
+		var childRetired []uint64
+		newRef, splits, err := z.writeRecursive(span.Ref, ops[span.PointOpStart:span.PointOpEnd], nil, false, nil, &childMetrics, span.LowKey, span.HighKey, &childRetired, scratch, false, applyRunConfig{maxParallelWorkers: 1})
 		if err != nil {
-			metrics.ZipperApplyWallNs = time.Since(applyStart).Nanoseconds()
-			return ApplyResult{Metrics: metrics}, true, err
+			errOnce.Do(func() { firstErr = err })
+			return false
 		}
 		spanKey := span.LowKey
 		if spanKey == nil {
@@ -37,7 +56,35 @@ func (z *Zipper) applySpanNativeWithPrepared(rootID uint64, ops []batch.Entry, p
 		refs := make([]Split, 0, len(splits)+1)
 		refs = append(refs, Split{Key: spanKey, Ref: newRef})
 		refs = append(refs, splits...)
-		replacements = append(replacements, spanNativeLeafReplacement{span: span, refs: refs})
+		replacements[i] = spanNativeLeafReplacement{span: span, refs: refs}
+		spanMetrics[i] = childMetrics
+		spanRetired[i] = childRetired
+		return true
+	}
+	runRange := func(_ int, job int) {
+		workerRange := workerRanges[job]
+		end := workerRange.FirstSpan + workerRange.SpanCount
+		for i := workerRange.FirstSpan; i < end; i++ {
+			if !runSpan(i) {
+				return
+			}
+		}
+	}
+	if err := workerPool.Run(workers, len(workerRanges), runRange); err != nil {
+		metrics.ZipperApplyWallNs = time.Since(applyStart).Nanoseconds()
+		return ApplyResult{Metrics: metrics}, true, err
+	}
+
+	var retired []uint64
+	for i := range spanMetrics {
+		mergeMetrics(&metrics, &spanMetrics[i])
+		if len(spanRetired[i]) > 0 {
+			retired = append(retired, spanRetired[i]...)
+		}
+	}
+	if firstErr != nil {
+		metrics.ZipperApplyWallNs = time.Since(applyStart).Nanoseconds()
+		return ApplyResult{Metrics: metrics, PendingRetiredPages: retired}, true, firstErr
 	}
 
 	rootReduceStart := time.Now()
@@ -52,7 +99,7 @@ func (z *Zipper) applySpanNativeWithPrepared(rootID uint64, ops []batch.Entry, p
 		PendingRetiredPages: retired,
 		Metrics:             metrics,
 		SpanNativeEligible:  true,
-		SpanNativeWorkers:   1,
+		SpanNativeWorkers:   workers,
 		SpanNativeUsed:      true,
 	}, true, nil
 }
@@ -69,10 +116,18 @@ func validateSpanNativePreparedPlan(ops []batch.Entry, prepared ReadOnlyPrepareR
 		if span.DeleteRangeStart != span.DeleteRangeEnd || span.PointOpStart != expectedPointStart || span.PointOpEnd > len(ops) || span.PointOpEnd <= span.PointOpStart {
 			return false
 		}
-		if i > 0 && !bytes.Equal(span.LowKey, prevHigh) {
+		if span.LowKey != nil && span.HighKey != nil && bytes.Compare(span.LowKey, span.HighKey) >= 0 {
 			return false
 		}
-		if span.LowKey != nil && span.HighKey != nil && bytes.Compare(span.LowKey, span.HighKey) >= 0 {
+		if i > 0 {
+			if prevHigh == nil || span.LowKey == nil || bytes.Compare(span.LowKey, prevHigh) < 0 {
+				return false
+			}
+		}
+		if span.LowKey != nil && bytes.Compare(ops[span.PointOpStart].Key, span.LowKey) < 0 {
+			return false
+		}
+		if span.HighKey != nil && bytes.Compare(ops[span.PointOpEnd-1].Key, span.HighKey) >= 0 {
 			return false
 		}
 		prevHigh = span.HighKey
@@ -86,15 +141,11 @@ type spanNativeLeafReplacement struct {
 	refs []Split
 }
 
-func spanNativeCoversWholeRoot(spans []ReadOnlyLeafSpan) bool {
-	return len(spans) > 0 && spans[0].LowKey == nil && spans[len(spans)-1].HighKey == nil
-}
-
 func (z *Zipper) reduceSpanNativeRootWithContext(rootID uint64, replacements []spanNativeLeafReplacement, metrics *adaptive.Metrics, retired *[]uint64, scratch *mergeScratch) (uint64, error) {
 	if len(replacements) == 0 {
 		return 0, page.ErrInvalidPageType
 	}
-	if spanNativeCoversWholeRoot(replacementSpans(replacements)) {
+	if spanNativeReplacementsCoverWholeRoot(replacements) {
 		var refs []Split
 		for i := range replacements {
 			refs = append(refs, replacements[i].refs...)
@@ -114,12 +165,18 @@ func (z *Zipper) reduceSpanNativeRootWithContext(rootID uint64, replacements []s
 	return z.reduceSpanNativeRoot(refs, metrics)
 }
 
-func replacementSpans(replacements []spanNativeLeafReplacement) []ReadOnlyLeafSpan {
-	spans := make([]ReadOnlyLeafSpan, len(replacements))
-	for i := range replacements {
-		spans[i] = replacements[i].span
+func spanNativeReplacementsCoverWholeRoot(replacements []spanNativeLeafReplacement) bool {
+	if len(replacements) == 0 || replacements[0].span.LowKey != nil || replacements[len(replacements)-1].span.HighKey != nil {
+		return false
 	}
-	return spans
+	prevHigh := replacements[0].span.HighKey
+	for i := 1; i < len(replacements); i++ {
+		if !bytes.Equal(replacements[i].span.LowKey, prevHigh) {
+			return false
+		}
+		prevHigh = replacements[i].span.HighKey
+	}
+	return true
 }
 
 func (z *Zipper) stitchSpanNativeRecursive(ref page.ChildRef, low, high []byte, replacements []spanNativeLeafReplacement, metrics *adaptive.Metrics, retired *[]uint64, scratch *mergeScratch) (page.ChildRef, []Split, bool, error) {
@@ -153,6 +210,7 @@ func (z *Zipper) stitchSpanNativeRecursive(ref page.ChildRef, low, high []byte, 
 		count := oldNode.Count()
 		children := make([]Split, 0, count)
 		changed := false
+		replacementIdx := 0
 		for i := uint16(0); i < count; i++ {
 			key, childRef, err := oldNode.GetInternalEntryRefView(i)
 			if err != nil {
@@ -176,11 +234,33 @@ func (z *Zipper) stitchSpanNativeRecursive(ref page.ChildRef, low, high []byte, 
 				}
 				childHigh = append([]byte(nil), nextKey...)
 			}
-			if !spanNativeReplacementsOverlap(replacements, childLow, childHigh) {
+
+			for replacementIdx < len(replacements) && spanNativeReplacementBeforeRange(replacements[replacementIdx], childLow) {
+				replacementIdx++
+			}
+			childReplacementStart := replacementIdx
+			childReplacementEnd := childReplacementStart
+			for childReplacementEnd < len(replacements) && spanNativeReplacementOverlapsRange(replacements[childReplacementEnd], childLow, childHigh) {
+				childReplacementEnd++
+			}
+			childReplacements := replacements[childReplacementStart:childReplacementEnd]
+			replacementIdx = childReplacementEnd
+			if len(childReplacements) == 0 {
 				children = append(children, Split{Key: key, Ref: childRef})
 				continue
 			}
-			newRef, childSplits, childChanged, err := z.stitchSpanNativeRecursive(childRef, childLow, childHigh, replacements, metrics, retired, scratch)
+			if len(childReplacements) == 1 && childReplacements[0].span.Ref == childRef {
+				replacement := childReplacements[0]
+				if len(replacement.refs) == 0 {
+					return page.ChildRef{}, nil, false, page.ErrInvalidPageType
+				}
+				changed = true
+				children = append(children, Split{Key: key, Ref: replacement.refs[0].Ref})
+				children = append(children, replacement.refs[1:]...)
+				continue
+			}
+
+			newRef, childSplits, childChanged, err := z.stitchSpanNativeRecursive(childRef, childLow, childHigh, childReplacements, metrics, retired, scratch)
 			if err != nil {
 				return page.ChildRef{}, nil, false, err
 			}
@@ -211,18 +291,20 @@ func (z *Zipper) stitchSpanNativeRecursive(ref page.ChildRef, low, high []byte, 
 	}
 }
 
-func spanNativeReplacementsOverlap(replacements []spanNativeLeafReplacement, low, high []byte) bool {
-	for i := range replacements {
-		span := replacements[i].span
-		if span.HighKey != nil && low != nil && bytes.Compare(span.HighKey, low) <= 0 {
-			continue
-		}
-		if high != nil && span.LowKey != nil && bytes.Compare(span.LowKey, high) >= 0 {
-			continue
-		}
-		return true
+func spanNativeReplacementBeforeRange(replacement spanNativeLeafReplacement, low []byte) bool {
+	span := replacement.span
+	return span.HighKey != nil && low != nil && bytes.Compare(span.HighKey, low) <= 0
+}
+
+func spanNativeReplacementOverlapsRange(replacement spanNativeLeafReplacement, low, high []byte) bool {
+	span := replacement.span
+	if span.HighKey != nil && low != nil && bytes.Compare(span.HighKey, low) <= 0 {
+		return false
 	}
-	return false
+	if high != nil && span.LowKey != nil && bytes.Compare(span.LowKey, high) >= 0 {
+		return false
+	}
+	return true
 }
 
 func (z *Zipper) reduceSpanNativeRoot(currentLevelNodes []Split, metrics *adaptive.Metrics) (uint64, error) {

--- a/TreeDB/zipper/span_native_apply.go
+++ b/TreeDB/zipper/span_native_apply.go
@@ -35,7 +35,7 @@ func (z *Zipper) applySpanNativeWithPrepared(rootID uint64, ops []batch.Entry, p
 		workerRanges = append(workerRanges, ReadOnlyLeafSpanWorkerRange{FirstSpan: 0, SpanCount: spanCount, Ops: len(ops)})
 	}
 	workers = len(workerRanges)
-	outputs := make([]spanNativeLeafOutput, spanCount)
+	outputs := scratch.acquireSpanNativeLeafOutputs(spanCount)
 	rangeMetrics := make([]adaptive.Metrics, len(workerRanges))
 	rangeRetired := make([][]uint64, len(workerRanges))
 	var firstErr error
@@ -126,6 +126,22 @@ func validateSpanNativePreparedPlan(ops []batch.Entry, prepared ReadOnlyPrepareR
 type spanNativeLeafOutput struct {
 	ref    page.ChildRef
 	splits []Split
+}
+
+func (s *mergeScratch) acquireSpanNativeLeafOutputs(count int) []spanNativeLeafOutput {
+	if count <= 0 {
+		return nil
+	}
+	if s == nil {
+		return make([]spanNativeLeafOutput, count)
+	}
+	if cap(s.spanNativeOutputScratch) < count {
+		s.spanNativeOutputScratch = make([]spanNativeLeafOutput, count)
+		return s.spanNativeOutputScratch
+	}
+	s.spanNativeOutputScratch = s.spanNativeOutputScratch[:count]
+	clear(s.spanNativeOutputScratch)
+	return s.spanNativeOutputScratch
 }
 
 type spanNativeLeafReplacements struct {

--- a/TreeDB/zipper/span_native_apply.go
+++ b/TreeDB/zipper/span_native_apply.go
@@ -1,0 +1,61 @@
+package zipper
+
+import (
+	"time"
+
+	"github.com/snissn/gomap/TreeDB/batch"
+	"github.com/snissn/gomap/TreeDB/internal/adaptive"
+	"github.com/snissn/gomap/TreeDB/page"
+)
+
+func (z *Zipper) applySpanNativeWithPrepared(rootID uint64, ops []batch.Entry, prepared ReadOnlyPrepareResult) (ApplyResult, bool, error) {
+	if prepared.DeleteRanges != 0 || prepared.ColdBuild || prepared.Maintenance || !prepared.ExactLeafSpans || len(prepared.LeafSpans) != 1 {
+		return ApplyResult{}, false, nil
+	}
+	span := prepared.LeafSpans[0]
+	if span.DeleteRangeStart != span.DeleteRangeEnd || span.PointOpStart < 0 || span.PointOpEnd > len(ops) || span.PointOpEnd <= span.PointOpStart {
+		return ApplyResult{}, false, nil
+	}
+
+	applyStart := time.Now()
+	var metrics adaptive.Metrics
+	metrics.ZipperApplyOps = len(ops)
+	scratch := z.acquireApplyScratch()
+	defer z.releaseApplyScratch(scratch)
+
+	var retired []uint64
+	newRef, splits, err := z.writeRecursive(span.Ref, ops[span.PointOpStart:span.PointOpEnd], nil, false, nil, &metrics, span.LowKey, span.HighKey, &retired, scratch, false, applyRunConfig{})
+	if err != nil {
+		metrics.ZipperApplyWallNs = time.Since(applyStart).Nanoseconds()
+		return ApplyResult{Metrics: metrics}, true, err
+	}
+	if rootID != 0 && !(span.Ref.Kind == page.ChildRefPage && span.Ref.Page == rootID) {
+		retired = append(retired, rootID)
+	}
+
+	rootReduceStart := time.Now()
+	newRootID, err := z.reduceSpanNativeSingleLeafRoot(newRef, splits, &metrics)
+	metrics.ZipperRootReduceNs += time.Since(rootReduceStart).Nanoseconds()
+	metrics.ZipperApplyWallNs = time.Since(applyStart).Nanoseconds()
+	if err != nil {
+		return ApplyResult{Metrics: metrics, PendingRetiredPages: retired}, true, err
+	}
+	return ApplyResult{
+		RootID:              newRootID,
+		PendingRetiredPages: retired,
+		Metrics:             metrics,
+		SpanNativeEligible:  true,
+		SpanNativeWorkers:   1,
+		SpanNativeUsed:      true,
+	}, true, nil
+}
+
+func (z *Zipper) reduceSpanNativeSingleLeafRoot(newRef page.ChildRef, splits []Split, metrics *adaptive.Metrics) (uint64, error) {
+	if len(splits) != 0 {
+		// Multi-split deterministic reducer support is added after the single-leaf
+		// job path is proven. Fail closed rather than silently re-entering the
+		// recursive reducer for already-prepared span output.
+		return 0, page.ErrInvalidPageType
+	}
+	return z.ensureRootPage([]byte{}, newRef, metrics)
+}

--- a/TreeDB/zipper/span_native_apply_engine_test.go
+++ b/TreeDB/zipper/span_native_apply_engine_test.go
@@ -24,6 +24,35 @@ func TestSpanNativeApplySingleLeafParity(t *testing.T) {
 		}
 	}
 
+	assertSpanNativeParity(t, serial, native, serialRoot, nativeRoot, delta)
+}
+
+func TestSpanNativeApplySingleLeafSplitReducerParity(t *testing.T) {
+	_, serial := newReadOnlyPrepareZipper(t)
+	_, native := newReadOnlyPrepareZipper(t)
+	serialRoot := buildReadOnlyPrepareRootWithKeys(t, serial, 1)
+	nativeRoot := buildReadOnlyPrepareRootWithKeys(t, native, 1)
+
+	delta := batch.New(panicValueReader{}, page.DefaultInlineThreshold)
+	defer func() { _ = delta.Close() }()
+	value := bytes.Repeat([]byte("v"), 200)
+	for i := 1; i < 140; i++ {
+		if err := delta.Set([]byte(fmt.Sprintf("key-%06d", i)), value); err != nil {
+			t.Fatalf("Set update: %v", err)
+		}
+	}
+
+	result := assertSpanNativeParity(t, serial, native, serialRoot, nativeRoot, delta)
+	if result.Metrics.Splits == 0 {
+		t.Fatalf("span-native split reducer test did not produce splits; metrics=%+v", result.Metrics)
+	}
+	if result.Metrics.ZipperRootSplitLevels == 0 {
+		t.Fatalf("root split levels=%d want >0", result.Metrics.ZipperRootSplitLevels)
+	}
+}
+
+func assertSpanNativeParity(t *testing.T, serial, native *Zipper, serialRoot, nativeRoot uint64, delta *batch.Batch) ApplyResult {
+	t.Helper()
 	serialNewRoot, _, _, err := serial.Apply(serialRoot, delta)
 	if err != nil {
 		t.Fatalf("serial Apply: %v", err)
@@ -43,45 +72,50 @@ func TestSpanNativeApplySingleLeafParity(t *testing.T) {
 	if !bytes.Equal(serialPairs, nativePairs) {
 		t.Fatalf("span-native output mismatch\nserial=%q\nnative=%q", serialPairs, nativePairs)
 	}
+	return result
 }
 
 func collectRootLeafPairs(t *testing.T, z *Zipper, rootID uint64) []byte {
 	t.Helper()
-	data, err := z.pager.Get(rootID)
+	return collectChildRefLeafPairs(t, z, page.PageChildRef(rootID))
+}
+
+func collectChildRefLeafPairs(t *testing.T, z *Zipper, ref page.ChildRef) []byte {
+	t.Helper()
+	if ref.Kind != page.ChildRefPage {
+		t.Fatalf("child kind=%d want page", ref.Kind)
+	}
+	data, err := z.pager.Get(ref.Page)
 	if err != nil {
-		t.Fatalf("get root %d: %v", rootID, err)
+		t.Fatalf("get page %d: %v", ref.Page, err)
 	}
 	n := node.NewNode(data)
-	if n.Type() == page.PageTypeInternal {
-		if n.Count() != 1 {
-			t.Fatalf("internal root count=%d want 1 for test helper", n.Count())
+	switch n.Type() {
+	case page.PageTypeLeaf, 0:
+		var out []byte
+		for i := uint16(0); i < n.Count(); i++ {
+			entry, err := n.GetLeafEntry(i)
+			if err != nil {
+				t.Fatalf("leaf entry %d: %v", i, err)
+			}
+			out = append(out, entry.Key...)
+			out = append(out, '=')
+			out = append(out, entry.Value...)
+			out = append(out, '\n')
 		}
-		ref, err := n.GetInternalChildRef(0)
-		if err != nil {
-			t.Fatalf("get root child: %v", err)
+		return out
+	case page.PageTypeInternal:
+		var out []byte
+		for i := uint16(0); i < n.Count(); i++ {
+			child, err := n.GetInternalChildRef(i)
+			if err != nil {
+				t.Fatalf("internal child %d: %v", i, err)
+			}
+			out = append(out, collectChildRefLeafPairs(t, z, child)...)
 		}
-		if ref.Kind != page.ChildRefPage {
-			t.Fatalf("root child kind=%d want page", ref.Kind)
-		}
-		data, err = z.pager.Get(ref.Page)
-		if err != nil {
-			t.Fatalf("get child %d: %v", ref.Page, err)
-		}
-		n = node.NewNode(data)
+		return out
+	default:
+		t.Fatalf("node type=%d want leaf/internal", n.Type())
+		return nil
 	}
-	if n.Type() != page.PageTypeLeaf {
-		t.Fatalf("node type=%d want leaf", n.Type())
-	}
-	var out []byte
-	for i := uint16(0); i < n.Count(); i++ {
-		entry, err := n.GetLeafEntry(i)
-		if err != nil {
-			t.Fatalf("leaf entry %d: %v", i, err)
-		}
-		out = append(out, entry.Key...)
-		out = append(out, '=')
-		out = append(out, entry.Value...)
-		out = append(out, '\n')
-	}
-	return out
 }

--- a/TreeDB/zipper/span_native_apply_engine_test.go
+++ b/TreeDB/zipper/span_native_apply_engine_test.go
@@ -122,6 +122,57 @@ func TestSpanNativeApplySparseMultiLeafParentStitchParity(t *testing.T) {
 	}
 }
 
+func TestSpanNativeApplyConcurrentWorkerLocalScratchSplitParity(t *testing.T) {
+	_, serial := newReadOnlyPrepareZipper(t)
+	_, native := newReadOnlyPrepareZipper(t)
+	serialRoot := buildReadOnlyPrepareRootWithKeys(t, serial, 4096)
+	nativeRoot := buildReadOnlyPrepareRootWithKeys(t, native, 4096)
+
+	delta := batch.New(panicValueReader{}, page.DefaultInlineThreshold)
+	defer func() { _ = delta.Close() }()
+	value := bytes.Repeat([]byte("v"), 180)
+	for _, anchor := range []int{17, 1029, 2053, 3079} {
+		for j := 0; j < 48; j++ {
+			key := []byte(fmt.Sprintf("key-%06d-%03d", anchor, j))
+			if err := delta.Set(key, value); err != nil {
+				t.Fatalf("Set anchor=%d j=%d: %v", anchor, j, err)
+			}
+		}
+	}
+
+	prepared, err := native.PrepareReadOnly(nativeRoot, delta, ReadOnlyPrepareOptions{})
+	if err != nil {
+		t.Fatalf("PrepareReadOnly: %v", err)
+	}
+	if len(prepared.LeafSpans) < 4 {
+		t.Fatalf("prepared spans=%d want at least 4 worker ranges", len(prepared.LeafSpans))
+	}
+	pool := NewApplyWorkerPool(4)
+	defer pool.Close()
+
+	serialNewRoot, _, _, err := serial.Apply(serialRoot, delta)
+	if err != nil {
+		t.Fatalf("serial Apply: %v", err)
+	}
+	result, err := native.ApplyWithOptions(nativeRoot, delta, ApplyOptions{
+		SpanNativeApply:          true,
+		ParallelApplyConcurrency: 4,
+		ParallelApplyWorkerPool:  pool,
+	})
+	if err != nil {
+		t.Fatalf("span-native ApplyWithOptions: %v", err)
+	}
+	if !result.SpanNativeEligible || !result.SpanNativeUsed || result.SpanNativeWorkers < 2 {
+		t.Fatalf("span-native flags eligible/used/workers=%v/%v/%d", result.SpanNativeEligible, result.SpanNativeUsed, result.SpanNativeWorkers)
+	}
+	if result.Metrics.Splits == 0 {
+		t.Fatalf("splits=%d want split outputs from worker-local scratch", result.Metrics.Splits)
+	}
+	if !bytes.Equal(collectRootLeafPairs(t, serial, serialNewRoot), collectRootLeafPairs(t, native, result.RootID)) {
+		t.Fatalf("concurrent span-native output mismatch")
+	}
+}
+
 func TestSpanNativeApplyRejectsInvalidPreparedPlanBeforeOutput(t *testing.T) {
 	p, z := newReadOnlyPrepareZipper(t)
 	rootID := buildReadOnlyPrepareRootWithKeys(t, z, 40)

--- a/TreeDB/zipper/span_native_apply_engine_test.go
+++ b/TreeDB/zipper/span_native_apply_engine_test.go
@@ -51,6 +51,29 @@ func TestSpanNativeApplySingleLeafSplitReducerParity(t *testing.T) {
 	}
 }
 
+func TestSpanNativeApplyWholeRootMultiLeafReducerParity(t *testing.T) {
+	_, serial := newReadOnlyPrepareZipper(t)
+	_, native := newReadOnlyPrepareZipper(t)
+	serialRoot := buildReadOnlyPrepareRootWithKeys(t, serial, 200)
+	nativeRoot := buildReadOnlyPrepareRootWithKeys(t, native, 200)
+
+	delta := batch.New(panicValueReader{}, page.DefaultInlineThreshold)
+	defer func() { _ = delta.Close() }()
+	for i := 0; i < 200; i++ {
+		if err := delta.Set([]byte(fmt.Sprintf("key-%06d", i)), []byte(fmt.Sprintf("multi-%06d", i))); err != nil {
+			t.Fatalf("Set update: %v", err)
+		}
+	}
+
+	result := assertSpanNativeParity(t, serial, native, serialRoot, nativeRoot, delta)
+	if result.Metrics.ZipperLeafMerges < 2 {
+		t.Fatalf("leaf merges=%d want multi-leaf", result.Metrics.ZipperLeafMerges)
+	}
+	if result.Metrics.ZipperRootSplitLevels == 0 {
+		t.Fatalf("root split levels=%d want reducer to build internal root", result.Metrics.ZipperRootSplitLevels)
+	}
+}
+
 func assertSpanNativeParity(t *testing.T, serial, native *Zipper, serialRoot, nativeRoot uint64, delta *batch.Batch) ApplyResult {
 	t.Helper()
 	serialNewRoot, _, _, err := serial.Apply(serialRoot, delta)
@@ -64,8 +87,8 @@ func assertSpanNativeParity(t *testing.T, serial, native *Zipper, serialRoot, na
 	if !result.SpanNativeEligible || !result.SpanNativeUsed {
 		t.Fatalf("span-native flags eligible/used=%v/%v", result.SpanNativeEligible, result.SpanNativeUsed)
 	}
-	if result.Metrics.ZipperLeafMerges != 1 {
-		t.Fatalf("leaf merges=%d want 1", result.Metrics.ZipperLeafMerges)
+	if result.Metrics.ZipperLeafMerges < 1 {
+		t.Fatalf("leaf merges=%d want at least 1", result.Metrics.ZipperLeafMerges)
 	}
 	serialPairs := collectRootLeafPairs(t, serial, serialNewRoot)
 	nativePairs := collectRootLeafPairs(t, native, result.RootID)

--- a/TreeDB/zipper/span_native_apply_engine_test.go
+++ b/TreeDB/zipper/span_native_apply_engine_test.go
@@ -84,6 +84,51 @@ func TestSpanNativeApplyPartialMultiLeafFallsBackBeforeSpanOutput(t *testing.T) 
 	}
 }
 
+func TestSpanNativeApplyRejectsInvalidPreparedPlanBeforeOutput(t *testing.T) {
+	p, z := newReadOnlyPrepareZipper(t)
+	rootID := buildReadOnlyPrepareRootWithKeys(t, z, 40)
+	delta := batch.New(panicValueReader{}, page.DefaultInlineThreshold)
+	defer func() { _ = delta.Close() }()
+	for i := 0; i < 40; i++ {
+		if err := delta.Set([]byte(fmt.Sprintf("key-%06d", i)), []byte(fmt.Sprintf("guard-%06d", i))); err != nil {
+			t.Fatalf("Set update: %v", err)
+		}
+	}
+	prepared, err := z.PrepareReadOnly(rootID, delta, ReadOnlyPrepareOptions{})
+	if err != nil {
+		t.Fatalf("PrepareReadOnly: %v", err)
+	}
+	if len(prepared.LeafSpans) == 0 {
+		t.Fatalf("expected prepared spans")
+	}
+	ops := delta.SortedEntries()
+	if !validateSpanNativePreparedPlan(ops, prepared) {
+		t.Fatalf("fresh whole-root plan unexpectedly ineligible")
+	}
+
+	bad := prepared
+	bad.LeafSpans = append([]ReadOnlyLeafSpan(nil), prepared.LeafSpans...)
+	bad.LeafSpans[0].PointOpStart = 1
+	beforePages := p.PageCount()
+	_, used, err := z.applySpanNativeWithPrepared(rootID, ops, bad)
+	if err != nil {
+		t.Fatalf("applySpanNativeWithPrepared invalid plan err=%v", err)
+	}
+	if used {
+		t.Fatalf("invalid prepared plan used span-native output path")
+	}
+	if got := p.PageCount(); got != beforePages {
+		t.Fatalf("invalid prepared plan allocated pages: got %d want %d", got, beforePages)
+	}
+
+	bad = prepared
+	bad.LeafSpans = append([]ReadOnlyLeafSpan(nil), prepared.LeafSpans...)
+	bad.LeafSpans[0].LowKey = []byte("not-root-min")
+	if validateSpanNativePreparedPlan(ops, bad) {
+		t.Fatalf("validateSpanNativePreparedPlan accepted non-root-min first span")
+	}
+}
+
 func TestSpanNativeReducerRejectsNondeterministicRefOrder(t *testing.T) {
 	_, z := newReadOnlyPrepareZipper(t)
 	_, err := z.reduceSpanNativeRoot([]Split{

--- a/TreeDB/zipper/span_native_apply_engine_test.go
+++ b/TreeDB/zipper/span_native_apply_engine_test.go
@@ -81,6 +81,47 @@ func TestSpanNativeApplyPartialMultiLeafParentStitchParity(t *testing.T) {
 	}
 }
 
+func TestSpanNativeApplySparseMultiLeafParentStitchParity(t *testing.T) {
+	_, serial := newReadOnlyPrepareZipper(t)
+	_, native := newReadOnlyPrepareZipper(t)
+	serialRoot := buildReadOnlyPrepareRootWithKeys(t, serial, 4096)
+	nativeRoot := buildReadOnlyPrepareRootWithKeys(t, native, 4096)
+
+	delta := batch.New(panicValueReader{}, page.DefaultInlineThreshold)
+	defer func() { _ = delta.Close() }()
+	for _, i := range []int{17, 511, 1029, 2053, 3079, 4095} {
+		if err := delta.Set([]byte(fmt.Sprintf("key-%06d", i)), []byte(fmt.Sprintf("sparse-%06d", i))); err != nil {
+			t.Fatalf("Set sparse %d: %v", i, err)
+		}
+	}
+
+	prepared, err := native.PrepareReadOnly(nativeRoot, delta, ReadOnlyPrepareOptions{})
+	if err != nil {
+		t.Fatalf("PrepareReadOnly: %v", err)
+	}
+	if len(prepared.LeafSpans) < 2 {
+		t.Fatalf("prepared spans=%d want sparse multi-leaf", len(prepared.LeafSpans))
+	}
+	sawGap := false
+	for i := 1; i < len(prepared.LeafSpans); i++ {
+		if !bytes.Equal(prepared.LeafSpans[i].LowKey, prepared.LeafSpans[i-1].HighKey) {
+			sawGap = true
+			break
+		}
+	}
+	if !sawGap {
+		t.Fatalf("prepared spans were contiguous; want sparse parent-stitch coverage")
+	}
+	if !validateSpanNativePreparedPlan(delta.SortedEntries(), prepared) {
+		t.Fatalf("sparse prepared plan rejected by span-native validator")
+	}
+
+	result := assertSpanNativeParity(t, serial, native, serialRoot, nativeRoot, delta)
+	if result.Metrics.ZipperInternalPagesWritten == 0 {
+		t.Fatalf("internal pages written=%d want sparse parent stitch", result.Metrics.ZipperInternalPagesWritten)
+	}
+}
+
 func TestSpanNativeApplyRejectsInvalidPreparedPlanBeforeOutput(t *testing.T) {
 	p, z := newReadOnlyPrepareZipper(t)
 	rootID := buildReadOnlyPrepareRootWithKeys(t, z, 40)
@@ -107,7 +148,7 @@ func TestSpanNativeApplyRejectsInvalidPreparedPlanBeforeOutput(t *testing.T) {
 	bad.LeafSpans = append([]ReadOnlyLeafSpan(nil), prepared.LeafSpans...)
 	bad.LeafSpans[0].PointOpStart = 1
 	beforePages := p.PageCount()
-	_, used, err := z.applySpanNativeWithPrepared(rootID, ops, bad)
+	_, used, err := z.applySpanNativeWithPrepared(rootID, ops, bad, 1, nil)
 	if err != nil {
 		t.Fatalf("applySpanNativeWithPrepared invalid plan err=%v", err)
 	}
@@ -157,8 +198,8 @@ func TestSpanNativeApplyWholeRootMultiLeafReducerParity(t *testing.T) {
 	if result.Metrics.ZipperLeafMerges < 2 {
 		t.Fatalf("leaf merges=%d want multi-leaf", result.Metrics.ZipperLeafMerges)
 	}
-	if result.Metrics.ZipperRootSplitLevels == 0 {
-		t.Fatalf("root split levels=%d want reducer to build internal root", result.Metrics.ZipperRootSplitLevels)
+	if result.Metrics.ZipperInternalPagesWritten == 0 {
+		t.Fatalf("internal pages written=%d want context reducer to rebuild parent/root pages", result.Metrics.ZipperInternalPagesWritten)
 	}
 }
 

--- a/TreeDB/zipper/span_native_apply_engine_test.go
+++ b/TreeDB/zipper/span_native_apply_engine_test.go
@@ -81,6 +81,41 @@ func TestSpanNativeApplyPartialMultiLeafParentStitchParity(t *testing.T) {
 	}
 }
 
+func TestSpanNativeApplyInternalBaseDeltaPartialStitchCopiesSeparatorKeys(t *testing.T) {
+	_, serial := newReadOnlyPrepareZipper(t)
+	_, native := newReadOnlyPrepareZipper(t)
+	serial.SetIndexInternalBaseDelta(true)
+	native.SetIndexInternalBaseDelta(true)
+	serialRoot := buildReadOnlyPrepareRootWithKeys(t, serial, 4096)
+	nativeRoot := buildReadOnlyPrepareRootWithKeys(t, native, 4096)
+	if got := collectSpanNativeTestInternalPageIDs(t, native, nativeRoot); len(got) == 0 {
+		t.Fatalf("native root has no base-delta internal pages; test requires partial internal stitching")
+	}
+
+	delta := batch.New(panicValueReader{}, page.DefaultInlineThreshold)
+	defer func() { _ = delta.Close() }()
+	for i := 900; i < 3200; i++ {
+		if err := delta.Set([]byte(fmt.Sprintf("key-%06d", i)), []byte(fmt.Sprintf("bd-%06d", i))); err != nil {
+			t.Fatalf("Set base-delta update %d: %v", i, err)
+		}
+	}
+
+	serialNewRoot, _, _, err := serial.Apply(serialRoot, delta)
+	if err != nil {
+		t.Fatalf("serial Apply: %v", err)
+	}
+	result, err := native.ApplyWithOptions(nativeRoot, delta, ApplyOptions{SpanNativeApply: true, ParallelApplyConcurrency: 2})
+	if err != nil {
+		t.Fatalf("span-native ApplyWithOptions: %v", err)
+	}
+	if !result.SpanNativeEligible || !result.SpanNativeUsed {
+		t.Fatalf("span-native flags eligible/used=%v/%v", result.SpanNativeEligible, result.SpanNativeUsed)
+	}
+	if !bytes.Equal(collectRootLeafPairs(t, serial, serialNewRoot), collectRootLeafPairs(t, native, result.RootID)) {
+		t.Fatalf("base-delta partial stitch output mismatch")
+	}
+}
+
 func TestSpanNativeApplySparseMultiLeafParentStitchParity(t *testing.T) {
 	_, serial := newReadOnlyPrepareZipper(t)
 	_, native := newReadOnlyPrepareZipper(t)
@@ -208,6 +243,30 @@ func TestSpanNativeApplyRejectsInvalidPreparedPlanBeforeOutput(t *testing.T) {
 	}
 	if got := p.PageCount(); got != beforePages {
 		t.Fatalf("invalid prepared plan allocated pages: got %d want %d", got, beforePages)
+	}
+
+	bad = prepared
+	bad.LeafSpans = append([]ReadOnlyLeafSpan(nil), prepared.LeafSpans...)
+	bad.LeafSpans[0].PointOpStart = -1
+	if validateSpanNativePreparedPlan(ops, bad) {
+		t.Fatalf("validateSpanNativePreparedPlan accepted negative PointOpStart")
+	}
+	_, used, err = z.applySpanNativeWithPrepared(rootID, ops, bad, 1, nil)
+	if err != nil {
+		t.Fatalf("applySpanNativeWithPrepared negative PointOpStart err=%v", err)
+	}
+	if used {
+		t.Fatalf("negative PointOpStart used span-native output path")
+	}
+	if got := p.PageCount(); got != beforePages {
+		t.Fatalf("negative PointOpStart allocated pages: got %d want %d", got, beforePages)
+	}
+
+	bad = prepared
+	bad.LeafSpans = append([]ReadOnlyLeafSpan(nil), prepared.LeafSpans...)
+	bad.LeafSpans[0].PointOpEnd = -1
+	if validateSpanNativePreparedPlan(ops, bad) {
+		t.Fatalf("validateSpanNativePreparedPlan accepted negative PointOpEnd")
 	}
 
 	bad = prepared

--- a/TreeDB/zipper/span_native_apply_engine_test.go
+++ b/TreeDB/zipper/span_native_apply_engine_test.go
@@ -254,6 +254,40 @@ func TestSpanNativeApplyWholeRootMultiLeafReducerParity(t *testing.T) {
 	}
 }
 
+func TestSpanNativeApplyWholeRootMultiLeafRetiresInternalPages(t *testing.T) {
+	_, z := newReadOnlyPrepareZipper(t)
+	rootID := buildReadOnlyPrepareRootWithKeys(t, z, 1024)
+	oldInternalPages := collectSpanNativeTestInternalPageIDs(t, z, rootID)
+	if len(oldInternalPages) == 0 {
+		t.Fatalf("old root has no internal pages; test requires whole-root multi-leaf rewrite")
+	}
+
+	delta := batch.New(panicValueReader{}, page.DefaultInlineThreshold)
+	defer func() { _ = delta.Close() }()
+	for i := 0; i < 1024; i++ {
+		if err := delta.Set([]byte(fmt.Sprintf("key-%06d", i)), []byte(fmt.Sprintf("retire-%06d", i))); err != nil {
+			t.Fatalf("Set update: %v", err)
+		}
+	}
+
+	result, err := z.ApplyWithOptions(rootID, delta, ApplyOptions{SpanNativeApply: true})
+	if err != nil {
+		t.Fatalf("span-native ApplyWithOptions: %v", err)
+	}
+	if !result.SpanNativeEligible || !result.SpanNativeUsed {
+		t.Fatalf("span-native flags eligible/used=%v/%v", result.SpanNativeEligible, result.SpanNativeUsed)
+	}
+	retired := make(map[uint64]struct{}, len(result.PendingRetiredPages))
+	for _, pageID := range result.PendingRetiredPages {
+		retired[pageID] = struct{}{}
+	}
+	for _, pageID := range oldInternalPages {
+		if _, ok := retired[pageID]; !ok {
+			t.Fatalf("old internal page %d missing from pending retired pages %v", pageID, result.PendingRetiredPages)
+		}
+	}
+}
+
 func assertSpanNativeParity(t *testing.T, serial, native *Zipper, serialRoot, nativeRoot uint64, delta *batch.Batch) ApplyResult {
 	t.Helper()
 	serialNewRoot, _, _, err := serial.Apply(serialRoot, delta)
@@ -281,6 +315,35 @@ func assertSpanNativeParity(t *testing.T, serial, native *Zipper, serialRoot, na
 func collectRootLeafPairs(t *testing.T, z *Zipper, rootID uint64) []byte {
 	t.Helper()
 	return collectChildRefLeafPairs(t, z, page.PageChildRef(rootID))
+}
+
+func collectSpanNativeTestInternalPageIDs(t *testing.T, z *Zipper, rootID uint64) []uint64 {
+	t.Helper()
+	return collectSpanNativeTestInternalPageIDsRef(t, z, page.PageChildRef(rootID))
+}
+
+func collectSpanNativeTestInternalPageIDsRef(t *testing.T, z *Zipper, ref page.ChildRef) []uint64 {
+	t.Helper()
+	if ref.Kind != page.ChildRefPage {
+		return nil
+	}
+	data, err := z.pager.Get(ref.Page)
+	if err != nil {
+		t.Fatalf("get page %d: %v", ref.Page, err)
+	}
+	n := node.NewNode(data)
+	if n.Type() != page.PageTypeInternal {
+		return nil
+	}
+	out := []uint64{ref.Page}
+	for i := uint16(0); i < n.Count(); i++ {
+		child, err := n.GetInternalChildRef(i)
+		if err != nil {
+			t.Fatalf("internal child %d: %v", i, err)
+		}
+		out = append(out, collectSpanNativeTestInternalPageIDsRef(t, z, child)...)
+	}
+	return out
 }
 
 func collectChildRefLeafPairs(t *testing.T, z *Zipper, ref page.ChildRef) []byte {

--- a/TreeDB/zipper/span_native_apply_engine_test.go
+++ b/TreeDB/zipper/span_native_apply_engine_test.go
@@ -51,7 +51,7 @@ func TestSpanNativeApplySingleLeafSplitReducerParity(t *testing.T) {
 	}
 }
 
-func TestSpanNativeApplyPartialMultiLeafFallsBackBeforeSpanOutput(t *testing.T) {
+func TestSpanNativeApplyPartialMultiLeafParentStitchParity(t *testing.T) {
 	_, serial := newReadOnlyPrepareZipper(t)
 	_, native := newReadOnlyPrepareZipper(t)
 	serialRoot := buildReadOnlyPrepareRootWithKeys(t, serial, 1000)
@@ -73,11 +73,8 @@ func TestSpanNativeApplyPartialMultiLeafFallsBackBeforeSpanOutput(t *testing.T) 
 	if err != nil {
 		t.Fatalf("span-native ApplyWithOptions: %v", err)
 	}
-	if !result.SpanNativeEligible {
-		t.Fatalf("SpanNativeEligible=false want candidate eligible before parent-stitch fallback")
-	}
-	if result.SpanNativeUsed {
-		t.Fatalf("SpanNativeUsed=true want fallback before partial multi-leaf prepared output")
+	if !result.SpanNativeEligible || !result.SpanNativeUsed {
+		t.Fatalf("span-native flags eligible/used=%v/%v want parent-stitch path", result.SpanNativeEligible, result.SpanNativeUsed)
 	}
 	if !bytes.Equal(collectRootLeafPairs(t, serial, serialNewRoot), collectRootLeafPairs(t, native, result.RootID)) {
 		t.Fatalf("partial fallback output mismatch")
@@ -123,9 +120,10 @@ func TestSpanNativeApplyRejectsInvalidPreparedPlanBeforeOutput(t *testing.T) {
 
 	bad = prepared
 	bad.LeafSpans = append([]ReadOnlyLeafSpan(nil), prepared.LeafSpans...)
-	bad.LeafSpans[0].LowKey = []byte("not-root-min")
+	bad.LeafSpans[0].LowKey = []byte("z")
+	bad.LeafSpans[0].HighKey = []byte("a")
 	if validateSpanNativePreparedPlan(ops, bad) {
-		t.Fatalf("validateSpanNativePreparedPlan accepted non-root-min first span")
+		t.Fatalf("validateSpanNativePreparedPlan accepted non-monotonic span bounds")
 	}
 }
 

--- a/TreeDB/zipper/span_native_apply_engine_test.go
+++ b/TreeDB/zipper/span_native_apply_engine_test.go
@@ -81,6 +81,42 @@ func TestSpanNativeApplyPartialMultiLeafParentStitchParity(t *testing.T) {
 	}
 }
 
+func TestSpanNativeApplyOmitKeysOptionKeepsBoundariesForPartialSpan(t *testing.T) {
+	_, serial := newReadOnlyPrepareZipper(t)
+	_, native := newReadOnlyPrepareZipper(t)
+	serialRoot := buildReadOnlyPrepareRootWithKeys(t, serial, 4096)
+	nativeRoot := buildReadOnlyPrepareRootWithKeys(t, native, 4096)
+
+	delta := batch.New(panicValueReader{}, page.DefaultInlineThreshold)
+	defer func() { _ = delta.Close() }()
+	for i := 1800; i < 1820; i++ {
+		if err := delta.Set([]byte(fmt.Sprintf("key-%06d", i)), []byte(fmt.Sprintf("omit-%06d", i))); err != nil {
+			t.Fatalf("Set omit-keys update %d: %v", i, err)
+		}
+	}
+
+	serialNewRoot, _, _, err := serial.Apply(serialRoot, delta)
+	if err != nil {
+		t.Fatalf("serial Apply: %v", err)
+	}
+	result, err := native.ApplyWithOptions(nativeRoot, delta, ApplyOptions{
+		SpanNativeApply: true,
+		ReadOnlyPrepare: ReadOnlyPrepareOptions{OmitKeys: true},
+	})
+	if err != nil {
+		t.Fatalf("span-native ApplyWithOptions: %v", err)
+	}
+	if result.ReadOnlyPrepare.OmitKeys {
+		t.Fatalf("span-native prepare kept OmitKeys=true; execution needs exact boundaries")
+	}
+	if !result.SpanNativeEligible || !result.SpanNativeUsed {
+		t.Fatalf("span-native flags eligible/used=%v/%v", result.SpanNativeEligible, result.SpanNativeUsed)
+	}
+	if !bytes.Equal(collectRootLeafPairs(t, serial, serialNewRoot), collectRootLeafPairs(t, native, result.RootID)) {
+		t.Fatalf("span-native omit-keys partial output mismatch")
+	}
+}
+
 func TestSpanNativeApplyInternalBaseDeltaPartialStitchCopiesSeparatorKeys(t *testing.T) {
 	_, serial := newReadOnlyPrepareZipper(t)
 	_, native := newReadOnlyPrepareZipper(t)
@@ -243,6 +279,23 @@ func TestSpanNativeApplyRejectsInvalidPreparedPlanBeforeOutput(t *testing.T) {
 	}
 	if got := p.PageCount(); got != beforePages {
 		t.Fatalf("invalid prepared plan allocated pages: got %d want %d", got, beforePages)
+	}
+
+	bad = prepared
+	bad.OmitKeys = true
+	bad.LeafSpans = append([]ReadOnlyLeafSpan(nil), prepared.LeafSpans...)
+	if validateSpanNativePreparedPlan(ops, bad) {
+		t.Fatalf("validateSpanNativePreparedPlan accepted OmitKeys plan")
+	}
+	_, used, err = z.applySpanNativeWithPrepared(rootID, ops, bad, 1, nil)
+	if err != nil {
+		t.Fatalf("applySpanNativeWithPrepared OmitKeys err=%v", err)
+	}
+	if used {
+		t.Fatalf("OmitKeys plan used span-native output path")
+	}
+	if got := p.PageCount(); got != beforePages {
+		t.Fatalf("OmitKeys plan allocated pages: got %d want %d", got, beforePages)
 	}
 
 	bad = prepared

--- a/TreeDB/zipper/span_native_apply_engine_test.go
+++ b/TreeDB/zipper/span_native_apply_engine_test.go
@@ -1,0 +1,87 @@
+package zipper
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/batch"
+	"github.com/snissn/gomap/TreeDB/node"
+	"github.com/snissn/gomap/TreeDB/page"
+)
+
+func TestSpanNativeApplySingleLeafParity(t *testing.T) {
+	_, serial := newReadOnlyPrepareZipper(t)
+	_, native := newReadOnlyPrepareZipper(t)
+	serialRoot := buildReadOnlyPrepareRootWithKeys(t, serial, 40)
+	nativeRoot := buildReadOnlyPrepareRootWithKeys(t, native, 40)
+
+	delta := batch.New(panicValueReader{}, page.DefaultInlineThreshold)
+	defer func() { _ = delta.Close() }()
+	for i := 10; i < 20; i++ {
+		if err := delta.Set([]byte(fmt.Sprintf("key-%06d", i)), []byte(fmt.Sprintf("native-%06d", i))); err != nil {
+			t.Fatalf("Set update: %v", err)
+		}
+	}
+
+	serialNewRoot, _, _, err := serial.Apply(serialRoot, delta)
+	if err != nil {
+		t.Fatalf("serial Apply: %v", err)
+	}
+	result, err := native.ApplyWithOptions(nativeRoot, delta, ApplyOptions{SpanNativeApply: true, ParallelApplyConcurrency: 2})
+	if err != nil {
+		t.Fatalf("span-native ApplyWithOptions: %v", err)
+	}
+	if !result.SpanNativeEligible || !result.SpanNativeUsed {
+		t.Fatalf("span-native flags eligible/used=%v/%v", result.SpanNativeEligible, result.SpanNativeUsed)
+	}
+	if result.Metrics.ZipperLeafMerges != 1 {
+		t.Fatalf("leaf merges=%d want 1", result.Metrics.ZipperLeafMerges)
+	}
+	serialPairs := collectRootLeafPairs(t, serial, serialNewRoot)
+	nativePairs := collectRootLeafPairs(t, native, result.RootID)
+	if !bytes.Equal(serialPairs, nativePairs) {
+		t.Fatalf("span-native output mismatch\nserial=%q\nnative=%q", serialPairs, nativePairs)
+	}
+}
+
+func collectRootLeafPairs(t *testing.T, z *Zipper, rootID uint64) []byte {
+	t.Helper()
+	data, err := z.pager.Get(rootID)
+	if err != nil {
+		t.Fatalf("get root %d: %v", rootID, err)
+	}
+	n := node.NewNode(data)
+	if n.Type() == page.PageTypeInternal {
+		if n.Count() != 1 {
+			t.Fatalf("internal root count=%d want 1 for test helper", n.Count())
+		}
+		ref, err := n.GetInternalChildRef(0)
+		if err != nil {
+			t.Fatalf("get root child: %v", err)
+		}
+		if ref.Kind != page.ChildRefPage {
+			t.Fatalf("root child kind=%d want page", ref.Kind)
+		}
+		data, err = z.pager.Get(ref.Page)
+		if err != nil {
+			t.Fatalf("get child %d: %v", ref.Page, err)
+		}
+		n = node.NewNode(data)
+	}
+	if n.Type() != page.PageTypeLeaf {
+		t.Fatalf("node type=%d want leaf", n.Type())
+	}
+	var out []byte
+	for i := uint16(0); i < n.Count(); i++ {
+		entry, err := n.GetLeafEntry(i)
+		if err != nil {
+			t.Fatalf("leaf entry %d: %v", i, err)
+		}
+		out = append(out, entry.Key...)
+		out = append(out, '=')
+		out = append(out, entry.Value...)
+		out = append(out, '\n')
+	}
+	return out
+}

--- a/TreeDB/zipper/span_native_apply_engine_test.go
+++ b/TreeDB/zipper/span_native_apply_engine_test.go
@@ -51,6 +51,51 @@ func TestSpanNativeApplySingleLeafSplitReducerParity(t *testing.T) {
 	}
 }
 
+func TestSpanNativeApplyPartialMultiLeafFallsBackBeforeSpanOutput(t *testing.T) {
+	_, serial := newReadOnlyPrepareZipper(t)
+	_, native := newReadOnlyPrepareZipper(t)
+	serialRoot := buildReadOnlyPrepareRootWithKeys(t, serial, 1000)
+	nativeRoot := buildReadOnlyPrepareRootWithKeys(t, native, 1000)
+
+	delta := batch.New(panicValueReader{}, page.DefaultInlineThreshold)
+	defer func() { _ = delta.Close() }()
+	for i := 200; i < 700; i++ {
+		if err := delta.Set([]byte(fmt.Sprintf("key-%06d", i)), []byte(fmt.Sprintf("partial-%06d", i))); err != nil {
+			t.Fatalf("Set update: %v", err)
+		}
+	}
+
+	serialNewRoot, _, _, err := serial.Apply(serialRoot, delta)
+	if err != nil {
+		t.Fatalf("serial Apply: %v", err)
+	}
+	result, err := native.ApplyWithOptions(nativeRoot, delta, ApplyOptions{SpanNativeApply: true, ParallelApplyConcurrency: 2})
+	if err != nil {
+		t.Fatalf("span-native ApplyWithOptions: %v", err)
+	}
+	if !result.SpanNativeEligible {
+		t.Fatalf("SpanNativeEligible=false want candidate eligible before parent-stitch fallback")
+	}
+	if result.SpanNativeUsed {
+		t.Fatalf("SpanNativeUsed=true want fallback before partial multi-leaf prepared output")
+	}
+	if !bytes.Equal(collectRootLeafPairs(t, serial, serialNewRoot), collectRootLeafPairs(t, native, result.RootID)) {
+		t.Fatalf("partial fallback output mismatch")
+	}
+}
+
+func TestSpanNativeReducerRejectsNondeterministicRefOrder(t *testing.T) {
+	_, z := newReadOnlyPrepareZipper(t)
+	_, err := z.reduceSpanNativeRoot([]Split{
+		{Key: []byte{}, Ref: page.PageChildRef(1)},
+		{Key: []byte("b"), Ref: page.PageChildRef(2)},
+		{Key: []byte("a"), Ref: page.PageChildRef(3)},
+	}, nil)
+	if err == nil {
+		t.Fatalf("reduceSpanNativeRoot accepted out-of-order refs")
+	}
+}
+
 func TestSpanNativeApplyWholeRootMultiLeafReducerParity(t *testing.T) {
 	_, serial := newReadOnlyPrepareZipper(t)
 	_, native := newReadOnlyPrepareZipper(t)

--- a/TreeDB/zipper/span_native_apply_test.go
+++ b/TreeDB/zipper/span_native_apply_test.go
@@ -1,0 +1,52 @@
+package zipper
+
+import "testing"
+
+func TestSpanNativeApplyEligibilityStrictPointSpans(t *testing.T) {
+	summary := ReadOnlyLeafSpanSummary{
+		Ops:            4,
+		PointOps:       4,
+		Spans:          2,
+		SpanOps:        4,
+		ExactLeafSpans: true,
+	}
+	workers, reason := spanNativeApplyFallbackReason(ApplyOptions{SpanNativeApply: true, ParallelApplyConcurrency: 8}, summary, nil, false)
+	if reason != "" {
+		t.Fatalf("reason=%q want eligible", reason)
+	}
+	if workers != 2 {
+		t.Fatalf("workers=%d want bounded by spans=2", workers)
+	}
+}
+
+func TestSpanNativeApplyEligibilityFallbackReasons(t *testing.T) {
+	base := ReadOnlyLeafSpanSummary{Ops: 1, PointOps: 1, Spans: 1, SpanOps: 1, ExactLeafSpans: true}
+	cases := []struct {
+		name              string
+		opts              ApplyOptions
+		summary           ReadOnlyLeafSpanSummary
+		validationFailure bool
+		want              string
+	}{
+		{name: "disabled", opts: ApplyOptions{}, summary: base, want: "disabled"},
+		{name: "validation", opts: ApplyOptions{SpanNativeApply: true}, summary: base, validationFailure: true, want: "validation_failed"},
+		{name: "cold", opts: ApplyOptions{SpanNativeApply: true}, summary: withSpanNativeSummary(base, func(s *ReadOnlyLeafSpanSummary) { s.ColdBuild = true }), want: "cold_build"},
+		{name: "maintenance", opts: ApplyOptions{SpanNativeApply: true}, summary: withSpanNativeSummary(base, func(s *ReadOnlyLeafSpanSummary) { s.Maintenance = true }), want: "maintenance"},
+		{name: "range", opts: ApplyOptions{SpanNativeApply: true}, summary: withSpanNativeSummary(base, func(s *ReadOnlyLeafSpanSummary) { s.DeleteRanges = 1 }), want: "range_delete_barrier"},
+		{name: "inexact", opts: ApplyOptions{SpanNativeApply: true}, summary: withSpanNativeSummary(base, func(s *ReadOnlyLeafSpanSummary) { s.ExactLeafSpans = false }), want: "inexact_leaf_spans"},
+		{name: "empty", opts: ApplyOptions{SpanNativeApply: true}, summary: withSpanNativeSummary(base, func(s *ReadOnlyLeafSpanSummary) { s.PointOps = 0 }), want: "below_threshold"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, reason := spanNativeApplyFallbackReason(tc.opts, tc.summary, nil, tc.validationFailure)
+			if reason != tc.want {
+				t.Fatalf("reason=%q want %q", reason, tc.want)
+			}
+		})
+	}
+}
+
+func withSpanNativeSummary(in ReadOnlyLeafSpanSummary, mutate func(*ReadOnlyLeafSpanSummary)) ReadOnlyLeafSpanSummary {
+	mutate(&in)
+	return in
+}

--- a/TreeDB/zipper/zipper.go
+++ b/TreeDB/zipper/zipper.go
@@ -113,8 +113,9 @@ type Zipper struct {
 	maintenanceOpsPerCoalesce int
 	parallelMergePressure     ParallelMergePressureSource
 
-	scratchMu    sync.Mutex
-	applyScratch *mergeScratch
+	scratchMu        sync.Mutex
+	applyScratch     *mergeScratch
+	applyScratchFree []*mergeScratch
 }
 
 type ParallelMergePressureLevel uint8
@@ -161,6 +162,7 @@ const (
 	mergeSpanNativeOutputKeepCap      = 1 << 20
 	mergeSpanNativeOutputLogKeepBytes = mergeSpanNativeOutputKeepCap * page.LogRecordRefSize
 	mergeSpanNativeOutputPageKeepCap  = mergeSpanNativeOutputKeepCap
+	applyScratchKeep                  = 8
 
 	mergeInternalMinParallelChildren         = 8
 	mergeInternalMinParallelOps              = 4096
@@ -781,8 +783,15 @@ func (z *Zipper) acquireApplyScratch() *mergeScratch {
 		return newMergeScratch()
 	}
 	z.scratchMu.Lock()
-	s := z.applyScratch
-	z.applyScratch = nil
+	var s *mergeScratch
+	if n := len(z.applyScratchFree); n > 0 {
+		s = z.applyScratchFree[n-1]
+		z.applyScratchFree[n-1] = nil
+		z.applyScratchFree = z.applyScratchFree[:n-1]
+	} else {
+		s = z.applyScratch
+		z.applyScratch = nil
+	}
 	z.scratchMu.Unlock()
 	if s == nil {
 		s = newMergeScratch()
@@ -797,6 +806,11 @@ func (z *Zipper) releaseApplyScratch(s *mergeScratch) {
 	}
 	s.reset()
 	z.scratchMu.Lock()
+	if len(z.applyScratchFree) < applyScratchKeep {
+		z.applyScratchFree = append(z.applyScratchFree, s)
+		z.scratchMu.Unlock()
+		return
+	}
 	if z.applyScratch == nil {
 		z.applyScratch = s
 		z.scratchMu.Unlock()

--- a/TreeDB/zipper/zipper.go
+++ b/TreeDB/zipper/zipper.go
@@ -140,25 +140,28 @@ type pendingLeafPagePersist struct {
 }
 
 const (
-	mergeSplitKeyArenaInitCap     = page.PageSize
-	mergeSplitKeyArenaKeepCap     = 1 << 20
-	mergeOuterLeafPageInitCap     = 16
-	mergeOuterLeafPageKeepCap     = 128
-	mergeLeafPageScratchInit      = 16
-	mergeLeafPageScratchKeep      = 128
-	mergeNodeKeyScratchInit       = 16
-	mergeNodeKeyScratchKeep       = 128
-	mergeNodeKeyScratchMaxCap     = 1 << 20
-	mergePendingLeafPersistInit   = 8
-	mergePendingLeafPersistKeep   = 64
-	mergePendingLeafPersistMaxCap = 512
-	mergeLeafPageBatchInit        = 8
-	mergeLeafPageBatchKeep        = 64
-	mergeLeafPageBatchMaxCap      = 512
-	mergeChildRefBatchInit        = 8
-	mergeChildRefBatchKeep        = 64
-	mergeChildRefBatchMaxCap      = 512
-	mergeSpanNativeOutputKeepCap  = 1 << 20
+	mergeSplitKeyArenaInitCap         = page.PageSize
+	mergeSplitKeyArenaKeepCap         = 1 << 20
+	mergeOuterLeafPageInitCap         = 16
+	mergeOuterLeafPageKeepCap         = 128
+	mergeLeafPageScratchInit          = 16
+	mergeLeafPageScratchKeep          = 128
+	mergeNodeKeyScratchInit           = 16
+	mergeNodeKeyScratchKeep           = 128
+	mergeNodeKeyScratchMaxCap         = 1 << 20
+	mergePendingLeafPersistInit       = 8
+	mergePendingLeafPersistKeep       = 64
+	mergePendingLeafPersistMaxCap     = 512
+	mergeLeafPageBatchInit            = 8
+	mergeLeafPageBatchKeep            = 64
+	mergeLeafPageBatchMaxCap          = 512
+	mergeChildRefBatchInit            = 8
+	mergeChildRefBatchKeep            = 64
+	mergeChildRefBatchMaxCap          = 512
+	mergeSpanNativeOutputKeepCap      = 1 << 20
+	mergeSpanNativeOutputSplitKeepCap = 1024
+	mergeSpanNativeOutputLogKeepBytes = mergeSpanNativeOutputKeepCap * page.LogRecordRefSize
+	mergeSpanNativeOutputPageKeepCap  = mergeSpanNativeOutputKeepCap
 
 	mergeInternalMinParallelChildren         = 8
 	mergeInternalMinParallelOps              = 4096
@@ -169,15 +172,17 @@ const (
 )
 
 type mergeScratch struct {
-	mu                        sync.Mutex
-	splitKeyArena             []byte
-	outerLeafBuildPages       []*outerLeafBuildPage
-	leafPageScratch           [][]byte
-	nodeKeyScratch            [][]byte
-	pendingLeafPersistScratch [][]pendingLeafPagePersist
-	leafPageBatchScratch      [][][]byte
-	childRefBatchScratch      [][]page.ChildRef
-	spanNativeOutputScratch   []spanNativeLeafOutput
+	mu                           sync.Mutex
+	splitKeyArena                []byte
+	outerLeafBuildPages          []*outerLeafBuildPage
+	leafPageScratch              [][]byte
+	nodeKeyScratch               [][]byte
+	pendingLeafPersistScratch    [][]pendingLeafPagePersist
+	leafPageBatchScratch         [][][]byte
+	childRefBatchScratch         [][]page.ChildRef
+	spanNativeOutputLogScratch   []byte
+	spanNativeOutputPageScratch  []uint64
+	spanNativeOutputSplitScratch []spanNativeLeafSplitOutput
 }
 
 func newMergeScratch() *mergeScratch {
@@ -257,11 +262,23 @@ func (s *mergeScratch) reset() {
 		}
 		s.childRefBatchScratch = s.childRefBatchScratch[:mergeChildRefBatchKeep]
 	}
-	clear(s.spanNativeOutputScratch)
-	if cap(s.spanNativeOutputScratch) > mergeSpanNativeOutputKeepCap {
-		s.spanNativeOutputScratch = nil
+	if cap(s.spanNativeOutputLogScratch) > mergeSpanNativeOutputLogKeepBytes {
+		s.spanNativeOutputLogScratch = nil
 	} else {
-		s.spanNativeOutputScratch = s.spanNativeOutputScratch[:0]
+		s.spanNativeOutputLogScratch = s.spanNativeOutputLogScratch[:0]
+	}
+	if cap(s.spanNativeOutputPageScratch) > mergeSpanNativeOutputPageKeepCap {
+		s.spanNativeOutputPageScratch = nil
+	} else {
+		s.spanNativeOutputPageScratch = s.spanNativeOutputPageScratch[:0]
+	}
+	if cap(s.spanNativeOutputSplitScratch) > 0 {
+		clear(s.spanNativeOutputSplitScratch[:cap(s.spanNativeOutputSplitScratch)])
+	}
+	if cap(s.spanNativeOutputSplitScratch) > mergeSpanNativeOutputSplitKeepCap {
+		s.spanNativeOutputSplitScratch = nil
+	} else {
+		s.spanNativeOutputSplitScratch = s.spanNativeOutputSplitScratch[:0]
 	}
 }
 

--- a/TreeDB/zipper/zipper.go
+++ b/TreeDB/zipper/zipper.go
@@ -159,7 +159,6 @@ const (
 	mergeChildRefBatchKeep            = 64
 	mergeChildRefBatchMaxCap          = 512
 	mergeSpanNativeOutputKeepCap      = 1 << 20
-	mergeSpanNativeOutputSplitKeepCap = 1024
 	mergeSpanNativeOutputLogKeepBytes = mergeSpanNativeOutputKeepCap * page.LogRecordRefSize
 	mergeSpanNativeOutputPageKeepCap  = mergeSpanNativeOutputKeepCap
 
@@ -172,17 +171,16 @@ const (
 )
 
 type mergeScratch struct {
-	mu                           sync.Mutex
-	splitKeyArena                []byte
-	outerLeafBuildPages          []*outerLeafBuildPage
-	leafPageScratch              [][]byte
-	nodeKeyScratch               [][]byte
-	pendingLeafPersistScratch    [][]pendingLeafPagePersist
-	leafPageBatchScratch         [][][]byte
-	childRefBatchScratch         [][]page.ChildRef
-	spanNativeOutputLogScratch   []byte
-	spanNativeOutputPageScratch  []uint64
-	spanNativeOutputSplitScratch []spanNativeLeafSplitOutput
+	mu                          sync.Mutex
+	splitKeyArena               []byte
+	outerLeafBuildPages         []*outerLeafBuildPage
+	leafPageScratch             [][]byte
+	nodeKeyScratch              [][]byte
+	pendingLeafPersistScratch   [][]pendingLeafPagePersist
+	leafPageBatchScratch        [][][]byte
+	childRefBatchScratch        [][]page.ChildRef
+	spanNativeOutputLogScratch  []byte
+	spanNativeOutputPageScratch []uint64
 }
 
 func newMergeScratch() *mergeScratch {
@@ -271,14 +269,6 @@ func (s *mergeScratch) reset() {
 		s.spanNativeOutputPageScratch = nil
 	} else {
 		s.spanNativeOutputPageScratch = s.spanNativeOutputPageScratch[:0]
-	}
-	if cap(s.spanNativeOutputSplitScratch) > 0 {
-		clear(s.spanNativeOutputSplitScratch[:cap(s.spanNativeOutputSplitScratch)])
-	}
-	if cap(s.spanNativeOutputSplitScratch) > mergeSpanNativeOutputSplitKeepCap {
-		s.spanNativeOutputSplitScratch = nil
-	} else {
-		s.spanNativeOutputSplitScratch = s.spanNativeOutputSplitScratch[:0]
 	}
 }
 

--- a/TreeDB/zipper/zipper.go
+++ b/TreeDB/zipper/zipper.go
@@ -171,16 +171,14 @@ const (
 )
 
 type mergeScratch struct {
-	mu                          sync.Mutex
-	splitKeyArena               []byte
-	outerLeafBuildPages         []*outerLeafBuildPage
-	leafPageScratch             [][]byte
-	nodeKeyScratch              [][]byte
-	pendingLeafPersistScratch   [][]pendingLeafPagePersist
-	leafPageBatchScratch        [][][]byte
-	childRefBatchScratch        [][]page.ChildRef
-	spanNativeOutputLogScratch  []byte
-	spanNativeOutputPageScratch []uint64
+	mu                        sync.Mutex
+	splitKeyArena             []byte
+	outerLeafBuildPages       []*outerLeafBuildPage
+	leafPageScratch           [][]byte
+	nodeKeyScratch            [][]byte
+	pendingLeafPersistScratch [][]pendingLeafPagePersist
+	leafPageBatchScratch      [][][]byte
+	childRefBatchScratch      [][]page.ChildRef
 }
 
 func newMergeScratch() *mergeScratch {
@@ -259,16 +257,6 @@ func (s *mergeScratch) reset() {
 			extra[i] = nil
 		}
 		s.childRefBatchScratch = s.childRefBatchScratch[:mergeChildRefBatchKeep]
-	}
-	if cap(s.spanNativeOutputLogScratch) > mergeSpanNativeOutputLogKeepBytes {
-		s.spanNativeOutputLogScratch = nil
-	} else {
-		s.spanNativeOutputLogScratch = s.spanNativeOutputLogScratch[:0]
-	}
-	if cap(s.spanNativeOutputPageScratch) > mergeSpanNativeOutputPageKeepCap {
-		s.spanNativeOutputPageScratch = nil
-	} else {
-		s.spanNativeOutputPageScratch = s.spanNativeOutputPageScratch[:0]
 	}
 }
 

--- a/TreeDB/zipper/zipper.go
+++ b/TreeDB/zipper/zipper.go
@@ -158,6 +158,7 @@ const (
 	mergeChildRefBatchInit        = 8
 	mergeChildRefBatchKeep        = 64
 	mergeChildRefBatchMaxCap      = 512
+	mergeSpanNativeOutputKeepCap  = 1 << 20
 
 	mergeInternalMinParallelChildren         = 8
 	mergeInternalMinParallelOps              = 4096
@@ -176,6 +177,7 @@ type mergeScratch struct {
 	pendingLeafPersistScratch [][]pendingLeafPagePersist
 	leafPageBatchScratch      [][][]byte
 	childRefBatchScratch      [][]page.ChildRef
+	spanNativeOutputScratch   []spanNativeLeafOutput
 }
 
 func newMergeScratch() *mergeScratch {
@@ -254,6 +256,12 @@ func (s *mergeScratch) reset() {
 			extra[i] = nil
 		}
 		s.childRefBatchScratch = s.childRefBatchScratch[:mergeChildRefBatchKeep]
+	}
+	clear(s.spanNativeOutputScratch)
+	if cap(s.spanNativeOutputScratch) > mergeSpanNativeOutputKeepCap {
+		s.spanNativeOutputScratch = nil
+	} else {
+		s.spanNativeOutputScratch = s.spanNativeOutputScratch[:0]
 	}
 }
 

--- a/cmd/unified_bench/README.md
+++ b/cmd/unified_bench/README.md
@@ -125,6 +125,7 @@ These are mainly for experiments and should usually be left at engine defaults:
 - `-treedb-vlog-rewrite-*`
 - `-treedb-flush-build-*`
 - `-treedb-flush-apply-concurrency` and `-treedb-flush-apply-min-*` (opt-in/default-off TreeDB COW apply workers)
+- `-treedb-flush-apply-span-native` (M10 opt-in/default-off span-native apply/reducer for eligible exact point spans)
 - `-treedb-flush-span-run-target-planning` (diagnostic/default-off read-only target-leaf planning for canonical flush runs)
 - `-treedb-max-queued-memtables`, `-treedb-slowdown-backlog-seconds`, `-treedb-stop-backlog-seconds`
 

--- a/cmd/unified_bench/adapter_treedb.go
+++ b/cmd/unified_bench/adapter_treedb.go
@@ -36,6 +36,7 @@ var (
 	treedbFlushApplyMinEntries            = flag.Int("treedb-flush-apply-min-entries", 0, "TreeDB: minimum planned span ops to enable opt-in parallel apply (0=default)")
 	treedbFlushApplyMinSpans              = flag.Int("treedb-flush-apply-min-spans", 0, "TreeDB: minimum planned leaf spans to enable opt-in parallel apply (0=default)")
 	treedbFlushApplyMinBytes              = flag.Int("treedb-flush-apply-min-bytes", 0, "TreeDB: minimum planned span bytes to enable opt-in parallel apply (0=default)")
+	treedbFlushApplySpanNative            = flag.Bool("treedb-flush-apply-span-native", false, "TreeDB: opt-in M10 span-native apply/reducer for eligible exact point spans (default off)")
 	treedbFlushBackendMaxEntries          = flag.Int("treedb-flush-backend-max-entries", 0, "TreeDB (cached): max entries per backend flush batch before intermediate commit (0=default, <0=disable chunking)")
 	treedbFlushBackendMaxBatches          = flag.Int("treedb-flush-backend-max-batches", 0, "TreeDB (cached): max intermediate backend commits per flush (0=default, <0=disable cap)")
 	treedbFlushSpanRunTargetPlanning      = flag.Bool("treedb-flush-span-run-target-planning", false, "TreeDB (cached): diagnostic opt-in read-only target-leaf planning for canonical flush runs")
@@ -360,6 +361,7 @@ func (r treeDBOptionsReport) formatText(indent string) string {
 	lines = append(lines, fmt.Sprintf("flush_apply_min_entries_configured=%d", r.opts.FlushApplyMinEntries))
 	lines = append(lines, fmt.Sprintf("flush_apply_min_spans_configured=%d", r.opts.FlushApplyMinSpans))
 	lines = append(lines, fmt.Sprintf("flush_apply_min_bytes_configured=%d", r.opts.FlushApplyMinBytes))
+	lines = append(lines, fmt.Sprintf("flush_apply_span_native=%t", r.opts.FlushApplySpanNative))
 	lines = append(lines, fmt.Sprintf("flush_span_run_target_planning=%t", r.opts.FlushSpanRunTargetPlanning))
 	lines = append(lines, fmt.Sprintf("vlog.force_pointers=%t", r.opts.ValueLog.ForcePointers))
 
@@ -681,6 +683,7 @@ func buildTreeDBOptionsWithConfig(dir string, cfg treeDBOptionsBuildConfig) (tre
 		FlushApplyMinEntries:       *treedbFlushApplyMinEntries,
 		FlushApplyMinSpans:         *treedbFlushApplyMinSpans,
 		FlushApplyMinBytes:         *treedbFlushApplyMinBytes,
+		FlushApplySpanNative:       *treedbFlushApplySpanNative,
 		FlushBackendMaxEntries:     *treedbFlushBackendMaxEntries,
 		FlushBackendMaxBatches:     *treedbFlushBackendMaxBatches,
 		FlushSpanRunTargetPlanning: *treedbFlushSpanRunTargetPlanning,


### PR DESCRIPTION
## Scope

M10 draft for #2770 / parent #2743. This remains an opt-in span-native apply/reducer slice, not default-on rollout.

Implemented:
- Adds default-off `Options.FlushApplySpanNative` plumbing through TreeDB/caching/backend apply options.
- Adds unified-bench `-treedb-flush-apply-span-native` flag for opt-in perf evidence.
- Adds span-native eligibility/result plumbing and counters: candidate/eligible/used totals plus fallback reason accounting.
- Executes real span-native apply for supported exact point-span shapes instead of recursively applying the original batch for that work:
  - whole-root single-leaf point span;
  - single-leaf split output with deterministic root reducer;
  - whole-root multi-leaf exact point spans with deterministic root/internal reconstruction;
  - partial/sparse leaf span parent-context stitching into existing internal/root context.
- Validates prepared span ownership before output allocation and reducer ref order before root reconstruction.
- Optimizes the span-native allocation path after remote profiling:
  - sparse parent stitching avoids rebuilding full child/split slices;
  - leaf output refs are compact/pool-backed instead of one large `[]spanNativeLeafOutput` allocation;
  - sparse split-output scratch and internal stitch builders are pooled/reused;
  - parallel span-native workers now use worker-local `mergeScratch` instances, with split-output scratch retained until deterministic root reduction completes.
- Fixes coordinator-review blockers found after rerun9:
  - `FlushApplySpanNative=true` now uses `ApplyWithOptions`/read-only prepare even when `FlushApplyConcurrency` is default/single-worker;
  - whole-root multi-leaf span-native rewrites now include old root/internal pages in pending retirement before deterministic reducer output is published.

## Non-scope / guardrails

- Default remains off.
- No range-delete span-native apply.
- No M11 adaptive/backpressure tuning.
- No durable read-visible overlay or keyspace sharding.
- No permanent keyspace partitioning.
- No unsafe truncation/rollback of persistent value-log or leaf-log output.

## Tests / CI

Latest local validation for `a11a7100cec915de001fc756723d3ae2a1fa6f45`:

```sh
go test ./TreeDB/zipper ./TreeDB/db ./TreeDB/caching -count=1
go test -race ./TreeDB/zipper -run 'TestSpanNativeApplyOmitKeysOptionKeepsBoundariesForPartialSpan|TestSpanNativeApplyConcurrentWorkerLocalScratchSplitParity|TestSpanNativeApplyWholeRootMultiLeafRetiresInternalPages|TestSpanNativeApplyInternalBaseDeltaPartialStitchCopiesSeparatorKeys|TestApplyWorkerPoolNilRunFallsBackSerial' -count=1
go test -race ./TreeDB/db -run 'TestFlushApplySpanNativeSingleWorkerUsesApplyWithOptionsStats|TestFlushApplySpanNativeSparsePointSpansWithStats' -count=1
```

Latest-head CI for `a11a7100cec915de001fc756723d3ae2a1fa6f45`: green. PR remains ready; do not merge until coordinator approval.

## Remote evidence summary

Host for remote gates: `mikers@100.78.120.42` (`mikers-B560-DS3H-AC-Y1`)
Repo: `/mnt/fast4tb/gomap-profiles/2770_m10_bench_repo`
Execution path label: `m8-m14-10mm-gate`

Common command shape: `-dbs treedb -test sequential_write,batch_random,random_write -keys 10000000 -valsize 128 -batchsize 8000 -treedb-journal-lanes=1 -checkpoint-between-tests -progress=false -treedb-flush-apply-concurrency=4 -treedb-flush-apply-min-entries=1 -treedb-flush-apply-min-spans=1 -treedb-flush-apply-min-bytes=1`; M10 runs additionally use `-treedb-flush-apply-span-native`.

### Rerun9: latest remote perf confirmation after worker-local scratch (`43599cd54`)

Artifacts:
- log: `/mnt/fast4tb/gomap-profiles/2770_rerun9_gate_20260615_201142.log`
- base: `/mnt/fast4tb/gomap-profiles/2770_rerun9_m9_base_20260615_201142`
- M10: `/mnt/fast4tb/gomap-profiles/2770_rerun9_m10_43599cd54_20260615_201142`

| metric | M9 base | M10 latest | delta |
| --- | ---: | ---: | ---: |
| sequential_write | 2,783,471 ops/s | 2,770,628 ops/s | -0.46% |
| batch_random | 582,028 ops/s | 688,511 ops/s | +18.30% |
| random_write | 252,868 ops/s | 265,265 ops/s | +4.90% |
| alloc sequential_write | 955.37MB | 916.69MB | -4.05% |
| alloc batch_random | 4.58GB | 4.40GB | -3.93% |
| alloc random_write | 3088.94MB | 3211.58MB | +3.97% |
| random CPU profile samples | 83.84s | 83.89s | +0.06% |
| index.db | 484 MiB | 510 MiB | higher reducer/stitch output |
| leaf_vlog | 3.4 GiB / 216 files | 3.5 GiB / 220 files | slightly higher |

Key rerun9 counters:

| counter | M9 base | M10 latest | movement |
| --- | ---: | ---: | ---: |
| span_native.candidate_ops_total | 29,914,486 | 29,916,806 | flat |
| span_native.eligible_ops_total | 0 | 29,916,806 | now eligible |
| span_native.used_ops_total | 0 | 29,916,806 | all candidates used |
| span_native.used_spans_total | 0 | 9,926,403 | sparse span path active |
| span_native.fallbacks_total | 734 | 0 | no span-native fallback at latest head |
| merge_build.internal_merges_total | 752,669 | 0 | eliminated from apply path |
| merge_build.internal_pages_written_total | 844,426 | 918,728 | +8.80% reducer/stitch pages |
| merge_build.leaf_merges_total | 9,783,497 | 9,926,403 | +1.46% |
| apply_ns_total | 48.558s | 42.595s | -12.28% |
| root_reduce.ns_total | 0.0004s | 5.962s | expected deterministic reducer/stitch work |

Rerun9 profile readout: the worker-local scratch correctness fix preserves the intended throughput shape. Batch/random throughput remain positive while sequential is essentially flat. Allocation profile is acceptable for this opt-in path: sequential and batch allocation improve; random alloc-space is +3.97% with the remaining span-native-specific sampled allocation in bounded/pool-backed split scratch (`acquireSpanNativeSplitSlices`, 126MB sampled flat). The original multi-GB output-allocation regressions and shared-scratch concurrency risk are resolved.

### Earlier evidence notes

- Rerun8 (`387e43465`) was the pre-worker-local-scratch readiness run: batch_random +17.61%, random_write +7.58%, random alloc-space -0.49%. Superseded by rerun9 because `applySpanNativeWithPrepared` now uses worker-local scratch.
- Rerun7 (`a9f4653f0`) was not acceptable alone: random_write -2.98% and random alloc-space +21.4%. Later compact/pool-backed output and scratch changes fixed this.
- Rerun6 (`ef9080b0f`) was a noisy/outlier run with a severe base random allocation outlier (13.85GB); not used as readiness evidence.

## Current status

Latest head `a11a7100cec915de001fc756723d3ae2a1fa6f45` fixes the coordinator-review blockers after rerun9: single-worker span-native DB flushes enter `ApplyWithOptions`, whole-root multi-leaf rewrites retire old internal pages, invalid negative point bounds and omit-key prepared plans fail closed, base-delta separator keys are copied before scratch reuse, and nil-pool span-native concurrency now uses a per-call worker fallback. Latest-head CI is green, and rerun9 remains the latest remote performance evidence for the target write-heavy opt-in path (`batch_random +18.30%`, `random_write +4.90%`, `sequential_write -0.46%`).

No known M10 blockers remain. PR is ready for coordinator review. Do not merge until coordinator approval.

Tracks #2770.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added opt-in span-native apply optimization for database flush operations, providing an alternative execution path for eligible workloads.
  * New metrics now track span-native operation usage and performance (`treedb.flush_apply.span_native.used_ops_total` and `treedb.flush_apply.span_native.used_spans_total`).

* **Documentation**
  * Added configuration documentation for the new span-native apply option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

