### PR TITLE
TreeDB parallel flush M13: span-native hot-path scratch polish

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -1901,15 +1901,7 @@ func getValueLogPtrsCap(capacity int) []page.ValuePtr {
 }
 
 func putValueLogPtrs(s []page.ValuePtr) {
-	if s == nil {
-		return
-	}
-	clear(s)
-	// Avoid retaining huge slices in the pool.
-	if cap(s) > 1<<20 {
-		return
-	}
-	valueLogPtrPool.Put(s[:0])
+	putValueLogPtrsNoClear(s)
 }
 
 func putValueLogPtrsNoClear(s []page.ValuePtr) {
@@ -13237,6 +13229,7 @@ func (db *DB) vlogDictPrepareLoop(l *lane) {
 		}
 		bodyBuf := getVlogPreparedFrameBody()
 		body, stats, err := preparer.PrepareFrameInto(bodyBuf.buf[:0], task.dictID, task.dict, task.records)
+		preparer.TrimScratchForReuse()
 		if err != nil {
 			putVlogPreparedFrameBody(bodyBuf)
 			db.publishVlogDictPrepareResult(task, vlogDictPrepareResult{
@@ -14761,7 +14754,6 @@ func (db *DB) prepareAppendFrames(
 	useWorkers := db.shouldUseVlogDictPrepWorkers(l, frameCount, rawPayloadBytes)
 	prepStart := time.Now()
 	prepared := getVlogPreparedFrames(frameCount)
-	clear(prepared)
 	if !useWorkers {
 		// Keep frame encode/compress work out of vlogMu even when worker threads are
 		// unavailable. This reduces leaf-log/value-log lock hold time on small and

--- a/TreeDB/internal/valuelog/frame_preparer.go
+++ b/TreeDB/internal/valuelog/frame_preparer.go
@@ -55,6 +55,31 @@ func (p *FramePreparer) ResetForReuse() {
 	if p == nil {
 		return
 	}
+	p.TrimScratchForReuse()
+	p.skipDictID = 0
+	p.codecs = nil
+	p.noBenefit = 0
+	p.skipRemain = 0
+	p.dictFrameEncodeLevel = zstd.SpeedFastest
+	p.dictFrameEnableEntropy = false
+	p.blockCodec = BlockCodecSnappy
+	p.blockCompression = false
+	p.clock = RealClock{}
+	p.encodeCostModel = nil
+	p.encodeSampleStride = 0
+	p.encodeSampleCount = 0
+	p.keepIoNsPerStoredByte = 0
+	p.keepEncodeNsPerRawByte = 0
+	p.keepSafetyMargin = DefaultKeepSafetyMargin
+}
+
+// TrimScratchForReuse drops oversized temporary buffers while preserving codec
+// and compression-hint state. Long-lived prepare workers call this between
+// tasks so an occasional large frame does not pin unbounded scratch memory.
+func (p *FramePreparer) TrimScratchForReuse() {
+	if p == nil {
+		return
+	}
 	if cap(p.rawScratch) > framePreparerScratchKeepCap {
 		p.rawScratch = nil
 	} else {
@@ -71,21 +96,6 @@ func (p *FramePreparer) ResetForReuse() {
 		p.blockScratch = p.blockScratch[:0]
 	}
 	p.encLimiter = limitedSliceWriter{}
-	p.skipDictID = 0
-	p.codecs = nil
-	p.noBenefit = 0
-	p.skipRemain = 0
-	p.dictFrameEncodeLevel = zstd.SpeedFastest
-	p.dictFrameEnableEntropy = false
-	p.blockCodec = BlockCodecSnappy
-	p.blockCompression = false
-	p.clock = RealClock{}
-	p.encodeCostModel = nil
-	p.encodeSampleStride = 0
-	p.encodeSampleCount = 0
-	p.keepIoNsPerStoredByte = 0
-	p.keepEncodeNsPerRawByte = 0
-	p.keepSafetyMargin = DefaultKeepSafetyMargin
 }
 
 func (p *FramePreparer) SetDictFrameEncoderOptions(level zstd.EncoderLevel, enableEntropy bool) {

--- a/TreeDB/internal/valuelog/valuelog_test.go
+++ b/TreeDB/internal/valuelog/valuelog_test.go
@@ -1598,6 +1598,32 @@ func TestFramePreparer_ResetForReuseRestoresDefaultsAndKeepsBoundedScratch(t *te
 	}
 }
 
+func TestFramePreparer_TrimScratchForReuseKeepsPolicyAndBoundsBuffers(t *testing.T) {
+	prep := NewFramePreparer()
+	prep.SetKeepPolicy(11, 13, 0.25)
+	prep.SetBlockCompression(BlockCodecLZ4, true)
+	prep.rawScratch = make([]byte, framePreparerScratchKeepCap+1)
+	prep.encScratch = make([]byte, 0, framePreparerScratchKeepCap+1)
+	prep.blockScratch = make([]byte, 0, framePreparerScratchKeepCap)
+	prep.encLimiter.buf = []byte("retained")
+	prep.TrimScratchForReuse()
+	if prep.rawScratch != nil || prep.encScratch != nil {
+		t.Fatalf("oversized scratch retained: raw=%d enc=%d", cap(prep.rawScratch), cap(prep.encScratch))
+	}
+	if cap(prep.blockScratch) != framePreparerScratchKeepCap || len(prep.blockScratch) != 0 {
+		t.Fatalf("bounded block scratch not retained/reset: len=%d cap=%d", len(prep.blockScratch), cap(prep.blockScratch))
+	}
+	if prep.encLimiter.buf != nil || prep.encLimiter.limit != 0 {
+		t.Fatalf("enc limiter retained state: %+v", prep.encLimiter)
+	}
+	if prep.keepIoNsPerStoredByte != 11 || prep.keepEncodeNsPerRawByte != 13 || prep.keepSafetyMargin != 0.25 {
+		t.Fatalf("trim reset keep policy: got io=%v encode=%v safety=%v", prep.keepIoNsPerStoredByte, prep.keepEncodeNsPerRawByte, prep.keepSafetyMargin)
+	}
+	if prep.blockCodec != BlockCodecLZ4 || !prep.blockCompression {
+		t.Fatalf("trim reset block compression state")
+	}
+}
+
 func TestFramePreparer_KeepPolicySkipsCompression(t *testing.T) {
 	records := []Record{
 		{RID: 1, Value: bytes.Repeat([]byte("alpha-001|"), 32)},

--- a/TreeDB/zipper/span_native_apply.go
+++ b/TreeDB/zipper/span_native_apply.go
@@ -43,23 +43,29 @@ func (z *Zipper) applySpanNativeWithPrepared(rootID uint64, ops []batch.Entry, p
 		workers = spanCount
 	}
 
-	workerRanges := prepared.AppendLeafSpanWorkerRanges(nil, workers)
+	workerRanges := coordinatorScratch.acquireSpanWorkerRanges(workers)
+	workerRanges = prepared.AppendLeafSpanWorkerRanges(workerRanges, workers)
 	if len(workerRanges) == 0 {
 		workerRanges = append(workerRanges, ReadOnlyLeafSpanWorkerRange{FirstSpan: 0, SpanCount: spanCount, Ops: len(ops)})
 	}
+	defer coordinatorScratch.releaseSpanWorkerRanges(workerRanges)
 	workers = len(workerRanges)
 	outputs := coordinatorScratch.acquireSpanNativeLeafOutputs(spanCount, z.outerLeavesInValueLog)
 	defer outputs.release()
-	workerScratches := make([]*mergeScratch, len(workerRanges))
+	workerScratches := coordinatorScratch.acquireSpanWorkerScratchSlots(len(workerRanges))
 	defer func() {
 		for i := range workerScratches {
 			z.releaseApplyScratch(workerScratches[i])
 			workerScratches[i] = nil
 		}
+		coordinatorScratch.releaseSpanWorkerScratchSlots(workerScratches)
 	}()
-	rangeMetrics := make([]adaptive.Metrics, len(workerRanges))
-	rangeRetired := make([][]uint64, len(workerRanges))
-	rangeSplits := make([]spanNativeLeafSplitRange, len(workerRanges))
+	rangeMetrics := coordinatorScratch.acquireSpanRangeMetrics(len(workerRanges))
+	defer coordinatorScratch.releaseSpanRangeMetrics(rangeMetrics)
+	rangeRetired := coordinatorScratch.acquireSpanRangeRetired(len(workerRanges))
+	defer coordinatorScratch.releaseSpanRangeRetired(rangeRetired)
+	rangeSplits := coordinatorScratch.acquireSpanRangeSplits(len(workerRanges))
+	defer coordinatorScratch.releaseSpanRangeSplits(rangeSplits)
 	var firstErr error
 	var errOnce sync.Once
 	runRange := func(_ int, job int) {
@@ -457,7 +463,20 @@ func (z *Zipper) reduceSpanNativeRootWithContext(rootID uint64, replacements spa
 		if err := z.retireSpanNativeWholeRootInternalPages(rootID, replacements, retired, scratch); err != nil {
 			return 0, err
 		}
-		var refs []Split
+		if replacements.len() == 1 {
+			out := replacements.output(0)
+			if len(out.splits) == 0 {
+				var one [1]Split
+				one[0] = spanNativeReplacementHeadSplit(replacements.spans[0], out)
+				return z.reduceSpanNativeRoot(one[:], metrics)
+			}
+		}
+		refCap := replacements.len()
+		for i := 0; i < replacements.len(); i++ {
+			refCap += len(replacements.output(i).splits)
+		}
+		refs := scratch.acquireSpanRootRefs(refCap)
+		defer scratch.releaseSpanRootRefs(refs)
 		for i := 0; i < replacements.len(); i++ {
 			out := replacements.output(i)
 			refs = append(refs, spanNativeReplacementHeadSplit(replacements.spans[i], out))
@@ -472,7 +491,13 @@ func (z *Zipper) reduceSpanNativeRootWithContext(rootID uint64, replacements spa
 	if !changed {
 		return 0, fmt.Errorf("%w: no replacement changed root", ErrSpanNativeReducerValidation)
 	}
-	refs := make([]Split, 0, len(splits)+1)
+	if len(splits) == 0 {
+		var one [1]Split
+		one[0] = Split{Key: []byte{}, Ref: ref}
+		return z.reduceSpanNativeRoot(one[:], metrics)
+	}
+	refs := scratch.acquireSpanRootRefs(len(splits) + 1)
+	defer scratch.releaseSpanRootRefs(refs)
 	refs = append(refs, Split{Key: []byte{}, Ref: ref})
 	refs = append(refs, splits...)
 	return z.reduceSpanNativeRoot(refs, metrics)

--- a/TreeDB/zipper/zipper.go
+++ b/TreeDB/zipper/zipper.go
@@ -159,6 +159,8 @@ const (
 	mergeChildRefBatchInit            = 8
 	mergeChildRefBatchKeep            = 64
 	mergeChildRefBatchMaxCap          = 512
+	mergeSpanNativeRangeScratchMaxCap = 4096
+	mergeSpanNativeRootRefMaxCap      = 4096
 	mergeSpanNativeOutputKeepCap      = 1 << 20
 	mergeSpanNativeOutputLogKeepBytes = mergeSpanNativeOutputKeepCap * page.LogRecordRefSize
 	mergeSpanNativeOutputPageKeepCap  = mergeSpanNativeOutputKeepCap
@@ -181,6 +183,12 @@ type mergeScratch struct {
 	pendingLeafPersistScratch [][]pendingLeafPagePersist
 	leafPageBatchScratch      [][][]byte
 	childRefBatchScratch      [][]page.ChildRef
+	spanWorkerRangeScratch    []ReadOnlyLeafSpanWorkerRange
+	spanWorkerScratchScratch  []*mergeScratch
+	spanRangeMetricsScratch   []adaptive.Metrics
+	spanRangeRetiredScratch   [][]uint64
+	spanRangeSplitsScratch    []spanNativeLeafSplitRange
+	spanRootRefsScratch       []Split
 }
 
 func newMergeScratch() *mergeScratch {
@@ -259,6 +267,41 @@ func (s *mergeScratch) reset() {
 			extra[i] = nil
 		}
 		s.childRefBatchScratch = s.childRefBatchScratch[:mergeChildRefBatchKeep]
+	}
+	if cap(s.spanWorkerRangeScratch) > mergeSpanNativeRangeScratchMaxCap {
+		s.spanWorkerRangeScratch = nil
+	} else {
+		s.spanWorkerRangeScratch = s.spanWorkerRangeScratch[:0]
+	}
+	if cap(s.spanWorkerScratchScratch) > mergeSpanNativeRangeScratchMaxCap {
+		s.spanWorkerScratchScratch = nil
+	} else {
+		clear(s.spanWorkerScratchScratch)
+		s.spanWorkerScratchScratch = s.spanWorkerScratchScratch[:0]
+	}
+	if cap(s.spanRangeMetricsScratch) > mergeSpanNativeRangeScratchMaxCap {
+		s.spanRangeMetricsScratch = nil
+	} else {
+		clear(s.spanRangeMetricsScratch)
+		s.spanRangeMetricsScratch = s.spanRangeMetricsScratch[:0]
+	}
+	if cap(s.spanRangeRetiredScratch) > mergeSpanNativeRangeScratchMaxCap {
+		s.spanRangeRetiredScratch = nil
+	} else {
+		clear(s.spanRangeRetiredScratch)
+		s.spanRangeRetiredScratch = s.spanRangeRetiredScratch[:0]
+	}
+	if cap(s.spanRangeSplitsScratch) > mergeSpanNativeRangeScratchMaxCap {
+		s.spanRangeSplitsScratch = nil
+	} else {
+		clear(s.spanRangeSplitsScratch)
+		s.spanRangeSplitsScratch = s.spanRangeSplitsScratch[:0]
+	}
+	if cap(s.spanRootRefsScratch) > mergeSpanNativeRootRefMaxCap {
+		s.spanRootRefsScratch = nil
+	} else {
+		clear(s.spanRootRefsScratch)
+		s.spanRootRefsScratch = s.spanRootRefsScratch[:0]
 	}
 }
 
@@ -478,17 +521,189 @@ func (s *mergeScratch) releaseChildRefBatch(buf []page.ChildRef) {
 	if buf == nil {
 		return
 	}
-	full := buf[:cap(buf)]
-	clear(full)
 	if s == nil || cap(buf) > mergeChildRefBatchMaxCap {
 		return
 	}
 	s.mu.Lock()
 	if len(s.childRefBatchScratch) < mergeChildRefBatchKeep {
-		s.childRefBatchScratch = append(s.childRefBatchScratch, full[:0])
+		s.childRefBatchScratch = append(s.childRefBatchScratch, buf[:0])
 		s.mu.Unlock()
 		return
 	}
+	s.mu.Unlock()
+}
+
+func (s *mergeScratch) acquireSpanWorkerRanges(capacity int) []ReadOnlyLeafSpanWorkerRange {
+	if capacity < 0 {
+		capacity = 0
+	}
+	if s == nil {
+		return make([]ReadOnlyLeafSpanWorkerRange, 0, capacity)
+	}
+	s.mu.Lock()
+	buf := s.spanWorkerRangeScratch
+	s.spanWorkerRangeScratch = nil
+	s.mu.Unlock()
+	if cap(buf) >= capacity {
+		return buf[:0]
+	}
+	return make([]ReadOnlyLeafSpanWorkerRange, 0, capacity)
+}
+
+func (s *mergeScratch) releaseSpanWorkerRanges(buf []ReadOnlyLeafSpanWorkerRange) {
+	if s == nil || cap(buf) == 0 || cap(buf) > mergeSpanNativeRangeScratchMaxCap {
+		return
+	}
+	s.mu.Lock()
+	s.spanWorkerRangeScratch = buf[:0]
+	s.mu.Unlock()
+}
+
+func (s *mergeScratch) acquireSpanWorkerScratchSlots(capacity int) []*mergeScratch {
+	if capacity < 0 {
+		capacity = 0
+	}
+	if s == nil {
+		return make([]*mergeScratch, capacity)
+	}
+	s.mu.Lock()
+	buf := s.spanWorkerScratchScratch
+	s.spanWorkerScratchScratch = nil
+	s.mu.Unlock()
+	if cap(buf) >= capacity {
+		buf = buf[:capacity]
+		clear(buf)
+		return buf
+	}
+	return make([]*mergeScratch, capacity)
+}
+
+func (s *mergeScratch) releaseSpanWorkerScratchSlots(buf []*mergeScratch) {
+	if s == nil || cap(buf) == 0 || cap(buf) > mergeSpanNativeRangeScratchMaxCap {
+		return
+	}
+	full := buf[:cap(buf)]
+	clear(full)
+	s.mu.Lock()
+	s.spanWorkerScratchScratch = full[:0]
+	s.mu.Unlock()
+}
+
+func (s *mergeScratch) acquireSpanRangeMetrics(capacity int) []adaptive.Metrics {
+	if capacity < 0 {
+		capacity = 0
+	}
+	if s == nil {
+		return make([]adaptive.Metrics, capacity)
+	}
+	s.mu.Lock()
+	buf := s.spanRangeMetricsScratch
+	s.spanRangeMetricsScratch = nil
+	s.mu.Unlock()
+	if cap(buf) >= capacity {
+		buf = buf[:capacity]
+		clear(buf)
+		return buf
+	}
+	return make([]adaptive.Metrics, capacity)
+}
+
+func (s *mergeScratch) releaseSpanRangeMetrics(buf []adaptive.Metrics) {
+	if s == nil || cap(buf) == 0 || cap(buf) > mergeSpanNativeRangeScratchMaxCap {
+		return
+	}
+	full := buf[:cap(buf)]
+	clear(full)
+	s.mu.Lock()
+	s.spanRangeMetricsScratch = full[:0]
+	s.mu.Unlock()
+}
+
+func (s *mergeScratch) acquireSpanRangeRetired(capacity int) [][]uint64 {
+	if capacity < 0 {
+		capacity = 0
+	}
+	if s == nil {
+		return make([][]uint64, capacity)
+	}
+	s.mu.Lock()
+	buf := s.spanRangeRetiredScratch
+	s.spanRangeRetiredScratch = nil
+	s.mu.Unlock()
+	if cap(buf) >= capacity {
+		buf = buf[:capacity]
+		clear(buf)
+		return buf
+	}
+	return make([][]uint64, capacity)
+}
+
+func (s *mergeScratch) releaseSpanRangeRetired(buf [][]uint64) {
+	if s == nil || cap(buf) == 0 || cap(buf) > mergeSpanNativeRangeScratchMaxCap {
+		return
+	}
+	full := buf[:cap(buf)]
+	clear(full)
+	s.mu.Lock()
+	s.spanRangeRetiredScratch = full[:0]
+	s.mu.Unlock()
+}
+
+func (s *mergeScratch) acquireSpanRangeSplits(capacity int) []spanNativeLeafSplitRange {
+	if capacity < 0 {
+		capacity = 0
+	}
+	if s == nil {
+		return make([]spanNativeLeafSplitRange, capacity)
+	}
+	s.mu.Lock()
+	buf := s.spanRangeSplitsScratch
+	s.spanRangeSplitsScratch = nil
+	s.mu.Unlock()
+	if cap(buf) >= capacity {
+		buf = buf[:capacity]
+		clear(buf)
+		return buf
+	}
+	return make([]spanNativeLeafSplitRange, capacity)
+}
+
+func (s *mergeScratch) releaseSpanRangeSplits(buf []spanNativeLeafSplitRange) {
+	if s == nil || cap(buf) == 0 || cap(buf) > mergeSpanNativeRangeScratchMaxCap {
+		return
+	}
+	full := buf[:cap(buf)]
+	clear(full)
+	s.mu.Lock()
+	s.spanRangeSplitsScratch = full[:0]
+	s.mu.Unlock()
+}
+
+func (s *mergeScratch) acquireSpanRootRefs(capacity int) []Split {
+	if capacity < 0 {
+		capacity = 0
+	}
+	if s == nil {
+		return make([]Split, 0, capacity)
+	}
+	s.mu.Lock()
+	buf := s.spanRootRefsScratch
+	s.spanRootRefsScratch = nil
+	s.mu.Unlock()
+	if cap(buf) >= capacity {
+		return buf[:0]
+	}
+	return make([]Split, 0, capacity)
+}
+
+func (s *mergeScratch) releaseSpanRootRefs(buf []Split) {
+	if s == nil || cap(buf) == 0 || cap(buf) > mergeSpanNativeRootRefMaxCap {
+		return
+	}
+	full := buf[:cap(buf)]
+	clear(full)
+	s.mu.Lock()
+	s.spanRootRefsScratch = full[:0]
 	s.mu.Unlock()
 }
 

--- a/TreeDB/zipper/zipper_test.go
+++ b/TreeDB/zipper/zipper_test.go
@@ -1099,12 +1099,12 @@ func TestZipperMergeScratch_TrimsPendingLeafPageScratchCaches(t *testing.T) {
 	for i := 0; i < mergeChildRefBatchKeep+16; i++ {
 		s.releaseChildRefBatch(make([]page.ChildRef, 0, 1))
 	}
-	s.releaseSpanWorkerRanges(make([]ReadOnlyLeafSpanWorkerRange, 0, mergeSpanNativeRangeScratchMaxCap+1))
-	s.releaseSpanWorkerScratchSlots(make([]*mergeScratch, 0, mergeSpanNativeRangeScratchMaxCap+1))
-	s.releaseSpanRangeMetrics(make([]adaptive.Metrics, 0, mergeSpanNativeRangeScratchMaxCap+1))
-	s.releaseSpanRangeRetired(make([][]uint64, 0, mergeSpanNativeRangeScratchMaxCap+1))
-	s.releaseSpanRangeSplits(make([]spanNativeLeafSplitRange, 0, mergeSpanNativeRangeScratchMaxCap+1))
-	s.releaseSpanRootRefs(make([]Split, 0, mergeSpanNativeRootRefMaxCap+1))
+	s.spanWorkerRangeScratch = make([]ReadOnlyLeafSpanWorkerRange, 0, mergeSpanNativeRangeScratchMaxCap+1)
+	s.spanWorkerScratchScratch = make([]*mergeScratch, 0, mergeSpanNativeRangeScratchMaxCap+1)
+	s.spanRangeMetricsScratch = make([]adaptive.Metrics, 0, mergeSpanNativeRangeScratchMaxCap+1)
+	s.spanRangeRetiredScratch = make([][]uint64, 0, mergeSpanNativeRangeScratchMaxCap+1)
+	s.spanRangeSplitsScratch = make([]spanNativeLeafSplitRange, 0, mergeSpanNativeRangeScratchMaxCap+1)
+	s.spanRootRefsScratch = make([]Split, 0, mergeSpanNativeRootRefMaxCap+1)
 	z.releaseApplyScratch(s)
 
 	reused := z.acquireApplyScratch()

--- a/TreeDB/zipper/zipper_test.go
+++ b/TreeDB/zipper/zipper_test.go
@@ -1068,21 +1068,22 @@ func TestZipperMergeScratch_ReusesAndClearsLeafPageBatchScratch(t *testing.T) {
 	s.releaseLeafPageBatch(reused)
 }
 
-func TestZipperMergeScratch_ReusesAndClearsChildRefBatchScratch(t *testing.T) {
+func TestZipperMergeScratch_ReusesChildRefBatchScratchWithoutClearing(t *testing.T) {
 	s := newMergeScratch()
 	buf := s.acquireChildRefBatch(2)
 	buf = append(buf, page.PageChildRef(1), page.PageChildRef(2))
 	s.releaseChildRefBatch(buf)
 
 	reused := s.acquireChildRefBatch(2)
+	if len(reused) != 0 {
+		t.Fatalf("reused len=%d want 0", len(reused))
+	}
 	if cap(reused) < 2 {
 		t.Fatalf("reused cap=%d want >=2", cap(reused))
 	}
-	for i, ref := range reused[:cap(reused)] {
-		if ref != (page.ChildRef{}) {
-			t.Fatalf("child ref batch scratch retained ref %d: %+v", i, ref)
-		}
-	}
+	// page.ChildRef contains no heap pointers; release intentionally avoids a
+	// full-cap clear so hot batch persistence does not pay avoidable memclr cost.
+	reused = append(reused, page.PageChildRef(3), page.PageChildRef(4))
 	s.releaseChildRefBatch(reused)
 }
 
@@ -1098,6 +1099,12 @@ func TestZipperMergeScratch_TrimsPendingLeafPageScratchCaches(t *testing.T) {
 	for i := 0; i < mergeChildRefBatchKeep+16; i++ {
 		s.releaseChildRefBatch(make([]page.ChildRef, 0, 1))
 	}
+	s.releaseSpanWorkerRanges(make([]ReadOnlyLeafSpanWorkerRange, 0, mergeSpanNativeRangeScratchMaxCap+1))
+	s.releaseSpanWorkerScratchSlots(make([]*mergeScratch, 0, mergeSpanNativeRangeScratchMaxCap+1))
+	s.releaseSpanRangeMetrics(make([]adaptive.Metrics, 0, mergeSpanNativeRangeScratchMaxCap+1))
+	s.releaseSpanRangeRetired(make([][]uint64, 0, mergeSpanNativeRangeScratchMaxCap+1))
+	s.releaseSpanRangeSplits(make([]spanNativeLeafSplitRange, 0, mergeSpanNativeRangeScratchMaxCap+1))
+	s.releaseSpanRootRefs(make([]Split, 0, mergeSpanNativeRootRefMaxCap+1))
 	z.releaseApplyScratch(s)
 
 	reused := z.acquireApplyScratch()
@@ -1109,6 +1116,24 @@ func TestZipperMergeScratch_TrimsPendingLeafPageScratchCaches(t *testing.T) {
 	}
 	if len(reused.childRefBatchScratch) > mergeChildRefBatchKeep {
 		t.Fatalf("child ref batch scratch len=%d exceeds keep %d", len(reused.childRefBatchScratch), mergeChildRefBatchKeep)
+	}
+	if cap(reused.spanWorkerRangeScratch) > mergeSpanNativeRangeScratchMaxCap {
+		t.Fatalf("span worker range scratch cap=%d exceeds max %d", cap(reused.spanWorkerRangeScratch), mergeSpanNativeRangeScratchMaxCap)
+	}
+	if cap(reused.spanWorkerScratchScratch) > mergeSpanNativeRangeScratchMaxCap {
+		t.Fatalf("span worker scratch slots cap=%d exceeds max %d", cap(reused.spanWorkerScratchScratch), mergeSpanNativeRangeScratchMaxCap)
+	}
+	if cap(reused.spanRangeMetricsScratch) > mergeSpanNativeRangeScratchMaxCap {
+		t.Fatalf("span range metrics cap=%d exceeds max %d", cap(reused.spanRangeMetricsScratch), mergeSpanNativeRangeScratchMaxCap)
+	}
+	if cap(reused.spanRangeRetiredScratch) > mergeSpanNativeRangeScratchMaxCap {
+		t.Fatalf("span range retired cap=%d exceeds max %d", cap(reused.spanRangeRetiredScratch), mergeSpanNativeRangeScratchMaxCap)
+	}
+	if cap(reused.spanRangeSplitsScratch) > mergeSpanNativeRangeScratchMaxCap {
+		t.Fatalf("span range splits cap=%d exceeds max %d", cap(reused.spanRangeSplitsScratch), mergeSpanNativeRangeScratchMaxCap)
+	}
+	if cap(reused.spanRootRefsScratch) > mergeSpanNativeRootRefMaxCap {
+		t.Fatalf("span root refs cap=%d exceeds max %d", cap(reused.spanRootRefsScratch), mergeSpanNativeRootRefMaxCap)
 	}
 	z.releaseApplyScratch(reused)
 }


### PR DESCRIPTION
## Objective

Implement M13 hot-path polish for #2773 by reducing bounded per-span/per-replacement scratch churn in the opt-in span-native TreeDB flush/apply path without changing architecture or default rollout state.

## Context

M10-M12 made span-native apply correct and observable. This PR starts the M13 polish pass with small, fail-closed hot-path fixes: reuse span-native worker/reducer scratch, trim prepared-frame worker scratch, and remove avoidable memclr on pointer-only pools.

## Non-goals

- No span-native default-on decision (M14 owns that).
- No correctness-semantic changes to improve benchmark numbers.
- No unbounded buffer retention.
- No checksum/read-integrity weakening.
- No value-log/leaf-log rollback/truncation semantics.
- No broad architecture rewrite or durable overlay.

## Design

- Reuses span-native coordinator scratch for worker ranges, worker scratch slots, per-range metrics/retired/split arrays, and small reducer ref buffers with explicit caps.
- Keeps the single-ref reducer path on stack storage for common one-replacement/no-split jobs.
- Adds `FramePreparer.TrimScratchForReuse` so long-lived value-log prepare workers shed oversized scratch between tasks while preserving codec/hint state.
- Removes redundant clears for `page.ValuePtr` / `page.ChildRef` pools that contain no heap pointers and are returned with length zero.
- Existing fallback/output ownership accounting is preserved; prepared durable output remains installed or abandoned by existing M12 paths.

## Scope

Includes:
- `TreeDB/zipper/{zipper.go,span_native_apply.go,zipper_test.go}`
- `TreeDB/internal/valuelog/{frame_preparer.go,valuelog_test.go}`
- `TreeDB/caching/db.go`

Excludes:
- Global deterministic leaf-log append reordering beyond existing per-merge batching (still under evaluation/profile evidence).
- Leaf-page read-cache write-admission policy changes unless profiling shows a safe win.
- Public/on-disk format changes.

## Correctness

Current recovery validation for head `fa0f71f07`:

```sh
git diff --check origin/main...HEAD
git diff --check
go test ./TreeDB/internal/valuelog -run 'TestFramePreparer' -count=1
go test ./TreeDB/zipper -run 'TestZipperMergeScratch|TestSpanNative' -count=1
go test ./TreeDB/caching ./TreeDB/db ./TreeDB/zipper ./TreeDB/internal/valuelog -count=1
```

The recovery commit is a test-only fix to make the span scratch trim test inject
oversized retained buffers directly instead of using release helpers that
correctly drop oversized buffers.

Earlier manager validation on `97c786360` also included focused caching tests,
`./cmd/unified_bench`, and targeted zipper/db race checks; not rerun after the
test-only recovery commit.

## Performance

Remote 10MM before/after gate completed on `mikers@100.78.120.42`:

- run root: `/mnt/fast4tb/gomap-profiles/2773_m13_gate_20260616_124937`
- base: `6155deba719203fe50edbc34cee917313332d90e`
- head: `fa0f71f0738ee37af5898488134f5fae2e4846fa`
- command shape: `m8-m14-10mm-gate`, `-keys 10000000`, tests `sequential_write,batch_random,random_write`, `-treedb-flush-apply-span-native`, `-treedb-flush-backlog-coalescing`, apply concurrency/min gates `4/1/1/1`, checkpoint between tests.
- artifacts under each variant: `benchprof_results.{json,md}`, per-test CPU/allocs/block/mutex profiles, checkpoint CPU profiles, `trace.out`, `insights.{json,md,html}`. Summary: `comparison.{md,json}` at run root.

| Test | Base ops/s | Head ops/s | Δ |
| --- | ---: | ---: | ---: |
| `sequential_write` | 2,704,468 | 2,735,209 | +1.14% |
| `batch_random` | 688,947 | 720,081 | +4.52% |
| `random_write` | 292,481 | 285,934 | -2.24% |

Checkpoint table:

| Boundary | Base | Head |
| --- | ---: | ---: |
| Sequential Write | 521µs | 342µs |
| Batch Random | 824.90ms | 604.14ms |
| Random Write | 8.24s | 9.94s |
| After Run | 11.41s | 8.65s |

Selected counters:

| Counter | Base | Head |
| --- | ---: | ---: |
| `treedb.flush_apply.span_native.eligible_ops_total` | 29688509 | 29688494 |
| `treedb.flush_apply.span_native.eligible_spans_total` | 9308073 | 9373696 |
| `treedb.flush_apply.span_native.fallbacks_total` | 10 | 10 |
| `treedb.flush_apply.root_reduce.ns_per_op` | 151.389668 | 148.342535 |
| `treedb.flush_apply.old_leaf_read_decode.bytes_per_op` | 1395.227242 | 1403.316510 |
| `treedb.flush_apply.merge_build.leaf_merges_per_op` | 0.317855 | 0.320054 |
| `treedb.cache.flush_apply.leaf_log_append_frames_per_op` | 0.318421 | 0.320614 |
| `treedb.cache.checkpoint.active_background_flush_wait_ns_total` | 26524984711 | 26340903266 |
| `treedb.cache.checkpoint.stage.reducer_publish.total_ns` | 14643944213 | 12984518708 |

Storage at end of run: `maindb/index.db` base 469 MiB, head 440 MiB; `leaf_vlog` 3.3 GiB for both.

Microbench before/after on local Apple M3:

| Benchmark | Before | After |
| --- | ---: | ---: |
| `BenchmarkMergeLeafOuterLeafBatchScratch` | ~14.35-14.45 us/op, 6915 B/op, 3 allocs/op | ~14.50-14.64 us/op, 6915-6916 B/op, 3 allocs/op |
| `BenchmarkZipperApplyOuterLeafRandomOverwrite` | ~5.67-5.97 ms/op, ~786-821 KiB/op, 4325-4326 allocs/op | ~5.31-5.37 ms/op, ~771-799 KiB/op, 4325 allocs/op |

## Rollout / Toggle Plan

- Defaults unchanged: span-native and backlog coalescing remain opt-in/default-off.
- Revert path: disable `FlushApplySpanNative` / omit `-treedb-flush-apply-span-native`; scratch changes are internal and bounded.

## Follow-ups

- Continue M13 profiling for deterministic cross-worker leaf append batching and cache admission only if profiles show a safe throughput win.
- M14 #2774 owns final ceiling evidence and default-readiness decision after M13 merges.

Tracks #2773. Parent tracker #2743.

## AI Review Loop

- Latest-head CI is green.
- Coordinator review in progress; AI reviews not requested yet.





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized internal memory management through enhanced object pooling for scratch buffers used in value log processing, improving resource reuse efficiency.
  * Refactored state initialization and cleanup logic to better bound retained scratch buffers and prevent memory overhead during reuse.

* **Tests**
  * Added comprehensive tests to verify scratch buffer trimming behavior and memory pooling correctness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->