### PR TITLE
TreeDB parallel flush M14: final ceiling evidence

### DIFF
--- a/docs/TREEDB_RANDOM_WRITE_CEILING_BREAKER_M14_REPORT.md
+++ b/docs/TREEDB_RANDOM_WRITE_CEILING_BREAKER_M14_REPORT.md
@@ -1,35 +1,72 @@
 # TreeDB random-write ceiling breaker M14 final gate
 
-Issue: #2774 (M14). Parent tracker: #2743. Runtime base for the first
-remote matrix: `origin/main@e0a71320db7a727b451ebdd4b8254853cfc072a2` after
-M13 / PR #2780.
+Issue: #2774 (M14). Parent tracker: #2743. Runtime SHA:
+`e0a71320db7a727b451ebdd4b8254853cfc072a2` (M13 / PR #2780 merged).
 
-This report closes the post-M7 span-run/span-native ceiling-breaker stack by
-recording same-host evidence and a default-readiness decision. It is deliberately
-not an ops/sec-only report: the decision must account for old-leaf decode
-bytes/op, leaf merges/op, append frames/op, span shape, fallback reasons,
-checkpoint-inclusive wall time, stalls/backpressure, allocation/profile rows,
-and disk footprint.
+## Decision
 
-## Evidence collection plan
+**Result: the span-run/span-native stack materially reduced the measured
+random-write bottleneck when explicitly enabled, but it is not ready to become
+the default configuration.** Keep `FlushApplySpanNative` and
+`FlushBacklogCoalescing` opt-in/default-off for now.
+
+Why the ceiling-breaker is real:
+
+- On the same host/SHA, `span_native_c4` improved `random_write` by **+94.11%**
+  versus current unconfigured defaults (`145,427 -> 282,282 ops/s`) while also
+  reducing old-leaf decode bytes/op (`1603 -> 1395`), leaf merges/op
+  (`0.355 -> 0.318`), and append frames/op (`0.355 -> 0.318`).
+- Higher concurrency continued to move the write ceiling: `span_native_c16`
+  reached **312,391 random_write ops/s** and **766,645 batch_random ops/s**.
+- The intended path ran: c2/c4/c8/c16 rows used span-native for ~29.2M-29.7M
+  ops. Non-zero fallback reasons were only the expected M12
+  `close_or_checkpoint` drain fallbacks; root mismatch, output ownership, and
+  reducer validation fallbacks stayed zero.
+- Writer-side waiting improved on the useful rows: foreground-assist wait fell
+  from **77.7s** on defaults to **32.5s** at c4 and **26.9s** at c16; stall
+  waits were zero in all rows.
+
+Why default-on is still blocked:
+
+- `span_native_c1` is a clear unsafe default shape: `random_write` regressed
+  **-20.19%**, `batch_random` regressed versus defaults, and foreground-assist
+  wait increased to **106.0s**.
+- Checkpoint-inclusive latency is not uniformly better. Useful span-native rows
+  improved throughput, but post-run checkpoint time was generally higher than
+  the default row (`6.49s` default vs `8.17s-9.45s` for c4/c8/c16/cache-off;
+  `11.50s` for c4 without backlog). Random-write checkpoint time also rose
+  (`2.70s` default vs `7.01s-9.22s` useful span-native rows).
+- c8/c16 provide the highest throughput but increase CPU samples and
+  contention-profile totals compared with c4. They are throughput-ceiling rows,
+  not conservative production defaults.
+- The cache-disabled row was strong for this write-only matrix, but it is not a
+  default recommendation because read/scan guardrails were not part of M14.
+
+Recommended rollout posture:
+
+- **Default:** unchanged/off.
+- **Write-heavy experimental opt-in:** use span-native plus backlog coalescing
+  with `FlushApplyConcurrency >= 4` after workload-specific checkpoint and CPU
+  profiling. c4 is the conservative balanced row; c8/c16 are throughput-ceiling
+  rows with more contention/CPU evidence to watch.
+- **Rollback knobs:** omit/disable `-treedb-flush-apply-span-native`, omit/disable
+  `-treedb-flush-backlog-coalescing`, lower `-treedb-flush-apply-concurrency`,
+  or return to the unconfigured defaults. The outer-leaf read cache can be
+  disabled for write-only experiments (`-treedb-leaf-page-read-cache-entries=-1`)
+  but should not be changed as a read-path default from this matrix alone.
+
+## Evidence identity
 
 Remote host and artifact root:
 
 - host: `mikers@100.78.120.42` (`mikers-B560-DS3H-AC-Y1`)
-- artifact parent: `/mnt/fast4tb/gomap-profiles`
-- current matrix root: `/mnt/fast4tb/gomap-profiles/2774_m14_matrix_20260616_132256`
-
-Reproducibility helpers added by this PR:
-
-```sh
-ROOT=/mnt/fast4tb/gomap-profiles \
-  COMMIT=$(git rev-parse HEAD) \
-  scripts/treedb_m14_final_gate.sh
-
-python3 scripts/treedb_m14_matrix_summary.py \
-  /mnt/fast4tb/gomap-profiles/2774_m14_matrix_20260616_132256 \
-  --baseline-label default_unconfigured
-```
+- kernel: Linux 6.8.0-124-generic x86_64
+- Go: `go1.25.0 linux/amd64`
+- CPU workers visible: `nproc=12`
+- artifact root: `/mnt/fast4tb/gomap-profiles/2774_m14_matrix_20260616_132256`
+- generated summaries:
+  - `/mnt/fast4tb/gomap-profiles/2774_m14_matrix_20260616_132256/m14_matrix_summary.md`
+  - `/mnt/fast4tb/gomap-profiles/2774_m14_matrix_20260616_132256/m14_matrix_summary.json`
 
 Primary command shape for each 10M row:
 
@@ -48,31 +85,145 @@ Primary command shape for each 10M row:
 ./bin/benchprof -profiles-dir "$OUT"
 ```
 
-Rows under collection:
+`FlushApplyConcurrency=1,2,4,8,16` rows also used:
 
-| Row | Apply concurrency | Span-native | Backlog coalescing | Cache axis | Purpose |
-|---|---:|---:|---:|---|---|
-| `default_unconfigured` | default | false | false | default leaf read cache | Current default behavior / rollback floor. |
-| `legacy_parallel_c4` | 4 | false | false | default leaf read cache | Parallel recursive apply without span-native/backlog. |
-| `span_native_c1` | 1 | true | true | default leaf read cache | Span-native/backlog lower bound. |
-| `span_native_c2` | 2 | true | true | default leaf read cache | Span-native/backlog sweep. |
-| `span_native_c4` | 4 | true | true | default leaf read cache | M13 comparison/default candidate row. |
-| `span_native_c8` | 8 | true | true | default leaf read cache | Span-native/backlog sweep. |
-| `span_native_c16` | 16 | true | true | default leaf read cache | Span-native/backlog upper sweep. |
-| `span_native_c4_no_backlog` | 4 | true | false | default leaf read cache | Isolate M11 adaptive backlog coalescing. |
-| `span_native_c4_cache_disabled` | 4 | true | true | outer leaf read cache disabled | Cache-disabled guardrail row. |
+```sh
+-treedb-flush-apply-min-entries=1 \
+-treedb-flush-apply-min-spans=1 \
+-treedb-flush-apply-min-bytes=1 \
+-treedb-flush-apply-span-native \
+-treedb-flush-backlog-coalescing
+```
 
-`FlushApplyConcurrency=1,2,4,8,16` rows all use the primary min gates
-`-treedb-flush-apply-min-entries=1 -treedb-flush-apply-min-spans=1
--treedb-flush-apply-min-bytes=1`. The default row intentionally omits opt-in
-apply/span/backlog flags to measure the current shipped default.
+Cache-axis note: TreeDB currently has a fixed/default-env outer-leaf read cache
+(`outer_leaf_read_cache_entries=default/env`, effective 32768 in the run) and a
+cache-disabled mode. There is not a separate adaptive outer-leaf read-cache mode;
+the adaptive row in this gate is the M11 backlog-coalescing controller.
 
-## Final matrix summary
+## Throughput and checkpoint summary
 
-Pending remote matrix completion. The final PR update will paste the generated
-`m14_matrix_summary.md` tables and preserve artifact paths for every row.
+| Row | Concurrency | Span-native | Backlog | Cache | Seq ops/s | Batch ops/s | Random ops/s | Δ random vs default | Checkpoint batch | Checkpoint random | Post-run checkpoint |
+|---|---:|---:|---:|---|---:|---:|---:|---:|---:|---:|---:|
+| `default_unconfigured` | default | false | false | default | 2,560,082 | 322,644 | 145,427 | +0.00% | 1.16s | 2.70s | 6.49s |
+| `legacy_parallel_c4` | 4 | false | false | default | 2,732,468 | 613,337 | 226,416 | +55.69% | 814.25ms | 10.51s | 7.58s |
+| `span_native_c1` | 1 | true | true | default | 2,685,554 | 247,190 | 116,067 | -20.19% | 1.15s | 3.50s | 8.95s |
+| `span_native_c2` | 2 | true | true | default | 2,729,639 | 609,965 | 215,099 | +47.91% | 815.96ms | 12.56s | 5.78s |
+| `span_native_c4` | 4 | true | true | default | 2,710,831 | 696,101 | 282,282 | +94.11% | 824.29ms | 8.20s | 9.22s |
+| `span_native_c8` | 8 | true | true | default | 2,705,301 | 704,500 | 309,287 | +112.68% | 826.92ms | 7.21s | 9.10s |
+| `span_native_c16` | 16 | true | true | default | 2,725,757 | 766,645 | 312,391 | +114.81% | 833.62ms | 7.01s | 8.17s |
+| `span_native_c4_no_backlog` | 4 | true | false | default | 2,728,485 | 680,940 | 276,950 | +90.44% | 831.71ms | 8.11s | 11.50s |
+| `span_native_c4_cache_disabled` | 4 | true | true | disabled | 2,747,611 | 700,046 | 313,033 | +115.25% | 818.65ms | 7.38s | 9.45s |
 
-## Default-readiness decision
+## Bottleneck proof counters
 
-Pending remote matrix completion. The decision will include rollback knobs and
-any accepted regressions/caveats explicitly.
+| Row | old leaf B/op | leaf merges/op | append frames/op | apply ops/span | single-op span ratio | target split leaves | span-native used ops | fallbacks | close/chkp fallback ops | root reduce ns | publish ns |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| `default_unconfigured` | 1,603 | 0.355 | 0.355 |  |  | 0 | 0 | 0 | 0 | 356,981 | 18,513,955,885 |
+| `legacy_parallel_c4` | 1,453 | 0.330 | 0.330 | 3.033 | 0.633 | 0 | 0 | 734 | 0 | 346,427 | 15,514,455,153 |
+| `span_native_c1` | 1,602 | 0.355 | 0.355 | 2.821 | 0.682 | 0 | 29,708,113 | 12 | 218,612 | 6,372,102,050 | 21,811,431,150 |
+| `span_native_c2` | 1,378 | 0.316 | 0.316 | 3.167 | 0.610 | 0 | 29,688,490 | 10 | 218,611 | 4,081,879,756 | 11,235,511,751 |
+| `span_native_c4` | 1,395 | 0.318 | 0.318 | 3.146 | 0.619 | 0 | 29,688,511 | 10 | 218,612 | 4,363,775,346 | 14,362,201,706 |
+| `span_native_c8` | 1,406 | 0.320 | 0.321 | 3.123 | 0.619 | 0 | 29,196,607 | 19 | 710,980 | 4,319,757,006 | 15,358,903,079 |
+| `span_native_c16` | 1,407 | 0.320 | 0.321 | 3.121 | 0.619 | 0 | 29,196,574 | 20 | 711,046 | 4,320,975,055 | 14,126,573,975 |
+| `span_native_c4_no_backlog` | 1,472 | 0.332 | 0.332 | 3.014 | 0.644 | 0 | 29,698,193 | 10 | 218,612 | 5,093,285,131 | 15,133,140,814 |
+| `span_native_c4_cache_disabled` | 1,368 | 0.313 | 0.314 | 3.192 | 0.607 | 0 | 29,686,165 | 10 | 218,612 | 4,089,201,403 | 13,555,548,916 |
+
+Fallback reason detail:
+
+| Row | Non-zero fallback reasons |
+|---|---|
+| `default_unconfigured` | none |
+| `legacy_parallel_c4` | `span_native_not_implemented`: 29,914,354 ops / 9,863,096 spans |
+| `span_native_c1` | `close_or_checkpoint`: 218,612 ops / 198,405 spans |
+| `span_native_c2` | `close_or_checkpoint`: 218,611 ops / 198,080 spans |
+| `span_native_c4` | `close_or_checkpoint`: 218,612 ops / 198,048 spans |
+| `span_native_c8` | `close_or_checkpoint`: 710,980 ops / 576,298 spans |
+| `span_native_c16` | `close_or_checkpoint`: 711,046 ops / 584,373 spans |
+| `span_native_c4_no_backlog` | `close_or_checkpoint`: 218,612 ops / 198,061 spans |
+| `span_native_c4_cache_disabled` | `close_or_checkpoint`: 218,612 ops / 198,032 spans |
+
+## Writer stall / foreground assist / backlog counters
+
+| Row | fg assist calls | fg assist flushes | fg assist wait ns | active assist skips | progress wait ns | stall waits | coordinator blocking fallbacks | hard-overload fallbacks | queue backlog bytes |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| `default_unconfigured` | 13 | 3 | 77,693,578,529 | 0 | 0 | 0 | 13 | 0 | 0 |
+| `legacy_parallel_c4` | 6 | 0 | 44,435,758,710 | 2,467,377 | 0 | 0 | 6 | 6 | 0 |
+| `span_native_c1` | 14 | 4 | 105,993,401,056 | 0 | 0 | 0 | 14 | 0 | 0 |
+| `span_native_c2` | 6 | 0 | 48,451,003,280 | 2,467,375 | 0 | 0 | 6 | 6 | 0 |
+| `span_native_c4` | 5 | 0 | 32,467,058,418 | 2,104,618 | 0 | 0 | 5 | 5 | 0 |
+| `span_native_c8` | 5 | 0 | 27,885,986,352 | 1,917,688 | 0 | 0 | 5 | 4 | 0 |
+| `span_native_c16` | 5 | 0 | 26,864,508,284 | 1,886,376 | 0 | 0 | 5 | 4 | 0 |
+| `span_native_c4_no_backlog` | 5 | 0 | 34,727,494,749 | 2,104,728 | 0 | 0 | 5 | 5 | 0 |
+| `span_native_c4_cache_disabled` | 5 | 0 | 31,334,449,162 | 1,973,916 | 0 | 0 | 5 | 5 | 0 |
+
+Backlog coalescing counters:
+
+| Row | admitted runs | extra memtables | extra ops | selected memtables max | selected ops max | last single-op ratio | last ops/span |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| `default_unconfigured` | 0 | 0 | 0 | 0 | 0 | 0.000000 | 0.000000 |
+| `legacy_parallel_c4` | 0 | 0 | 0 | 0 | 0 | 0.000000 | 0.000000 |
+| `span_native_c1` | 0 | 0 | 0 | 0 | 0 | 0.502361 | 8.030750 |
+| `span_native_c2` | 1 | 16 | 493,448 | 48 | 1,480,344 | 0.569091 | 3.962833 |
+| `span_native_c4` | 2 | 32 | 986,896 | 48 | 1,480,344 | 0.595205 | 3.532906 |
+| `span_native_c8` | 2 | 32 | 986,896 | 48 | 1,480,344 | 0.603832 | 3.409103 |
+| `span_native_c16` | 2 | 32 | 986,896 | 48 | 1,480,344 | 0.603721 | 3.413830 |
+| `span_native_c4_no_backlog` | 0 | 0 | 0 | 0 | 0 | 0.000000 | 0.000000 |
+| `span_native_c4_cache_disabled` | 2 | 32 | 986,896 | 48 | 1,480,344 | 0.591578 | 3.482905 |
+
+## Disk usage at end of run
+
+| Row | index.db | WAL | value_vlog | leaf_vlog |
+|---|---:|---:|---:|---:|
+| `default_unconfigured` | 606 MiB | total=12 B files=1 other=12 B | total=0 B files=1 | total=3.7 GiB files=232 value=3.7 GiB other=24 KiB |
+| `legacy_parallel_c4` | 484 MiB | total=12 B files=1 other=12 B | total=0 B files=1 | total=3.4 GiB files=216 value=3.4 GiB other=22 KiB |
+| `span_native_c1` | 606 MiB | total=12 B files=1 other=12 B | total=0 B files=1 | total=3.7 GiB files=232 value=3.7 GiB other=24 KiB |
+| `span_native_c2` | 417 MiB | total=12 B files=1 other=12 B | total=0 B files=1 | total=3.3 GiB files=208 value=3.3 GiB other=21 KiB |
+| `span_native_c4` | 462 MiB | total=12 B files=1 other=12 B | total=0 B files=1 | total=3.3 GiB files=210 value=3.3 GiB other=21 KiB |
+| `span_native_c8` | 447 MiB | total=12 B files=1 other=12 B | total=0 B files=1 | total=3.3 GiB files=210 value=3.3 GiB other=21 KiB |
+| `span_native_c16` | 436 MiB | total=12 B files=1 other=12 B | total=0 B files=1 | total=3.4 GiB files=210 value=3.4 GiB other=21 KiB |
+| `span_native_c4_no_backlog` | 510 MiB | total=12 B files=1 other=12 B | total=0 B files=1 | total=3.5 GiB files=220 value=3.5 GiB other=22 KiB |
+| `span_native_c4_cache_disabled` | 443 MiB | total=12 B files=1 other=12 B | total=0 B files=1 | total=3.3 GiB files=208 value=3.3 GiB other=21 KiB |
+
+## Allocation and profile top rows
+
+Random-write allocation totals and top sampled allocation-object rows:
+
+| Row | alloc-space total | alloc-objects total | top alloc-object rows |
+|---|---:|---:|---|
+| `default_unconfigured` | 2.71GB | 9,232,395 | `Zipper.mergeLeaf` 1,974,391; `cachingLeafPageLog.AppendLeafPages` 1,835,089; `putValueLogPtrsNoClear` 1,835,047 |
+| `legacy_parallel_c4` | 3108.33MB | 24,681,672 | `DB.appendValueLogOneInternal` 10,043,614; `putVlogPreparedFrames` 7,121,739; `putValueLogPtrsNoClear` 1,835,047 |
+| `span_native_c1` | 2537.35MB | 9,534,278 | `putValueLogRecordsNoClear` 2,140,891; `Zipper.mergeLeaf` 1,998,970; `putValueLogPtrsNoClear` 1,900,587 |
+| `span_native_c2` | 3392MB | 22,969,237 | `DB.appendValueLogOneInternal` 9,437,399; `putVlogPreparedFrames` 6,400,829; `putValueLogPtrsNoClear` 1,747,667 |
+| `span_native_c4` | 3595.10MB | 20,285,794 | `DB.appendValueLogOneInternal` 8,306,878; `putVlogPreparedFrames` 5,614,379; `cachingLeafPageLog.AppendLeafPages` 1,507,397 |
+| `span_native_c8` | 3491.32MB | 21,927,356 | `DB.appendValueLogOneInternal` 8,863,944; `putVlogPreparedFrames` 5,963,910; `putValueLogRecordsNoClear` 1,638,437 |
+| `span_native_c16` | 3498.51MB | 20,117,156 | `DB.appendValueLogOneInternal` 8,274,114; `putVlogPreparedFrames` 5,417,767; `putValueLogPtrsNoClear` 1,376,286 |
+| `span_native_c4_no_backlog` | 3203.92MB | 21,591,960 | `DB.appendValueLogOneInternal` 8,749,251; `putVlogPreparedFrames` 5,483,304; `Zipper.mergeLeaf` 1,646,692 |
+| `span_native_c4_cache_disabled` | 3530.94MB | 20,863,793 | `DB.appendValueLogOneInternal` 8,962,254; `putVlogPreparedFrames` 5,483,304; `cachingLeafPageLog.AppendLeafPages` 1,474,628 |
+
+Random-write CPU/block/mutex/checkpoint top rows:
+
+| Row | CPU total/top | block total/top | mutex total/top | post-run checkpoint CPU total/top |
+|---|---|---|---|---|
+| `default_unconfigured` | 101.39s; `lz4block.decodeBlock` 9.04s; `CompressBlock` 7.71s; `runtime.memmove` 5.95s | 1702.58s; `runtime.selectgo` 740.11s; `sync.Mutex.Lock` 641.85s; `WaitGroup.Wait` 168.98s | 684.50s; `sync.Mutex.Unlock` 681.91s | 2.21s; `linux.Syscall6` 0.24s; `runtime.memmove` 0.20s; `lz4block.decodeBlock` 0.19s |
+| `legacy_parallel_c4` | 90.36s; `lz4block.decodeBlock` 8.22s; `CompressBlock` 6.77s; `runtime.memmove` 4.66s | 794.75s; `runtime.selectgo` 476.79s; `chanrecv2` 104.85s; `chanrecv1` 88.85s | 47.37s; `sync.Mutex.Unlock` 47.33s | 2.31s; `linux.Syscall6` 0.25s; `lz4block.decodeBlock` 0.20s; `runtime.memmove` 0.17s |
+| `span_native_c1` | 78.79s; `lz4block.decodeBlock` 8.89s; `CompressBlock` 6.07s; `cmpbody` 4.20s | 1292.96s; `runtime.selectgo` 941.31s; `chanrecv1` 171.86s; `sync.Mutex.Lock` 99.13s | 92.25s; `sync.Mutex.Unlock` 89.38s | 2.48s; `linux.Syscall6` 0.36s; `runtime.memmove` 0.17s; `lz4block.decodeBlock` 0.15s |
+| `span_native_c2` | 75.93s; `lz4block.decodeBlock` 7.76s; `CompressBlock` 5.69s; `cmpbody` 4.15s | 749.34s; `runtime.selectgo` 487.73s; `chanrecv1` 94.17s; `WaitGroup.Wait` 75.80s | 46.80s; `sync.Mutex.Unlock` 46.79s | 1.99s; `runtime.memmove` 0.20s; `lz4block.decodeBlock` 0.16s; `crc32IEEEVPCLMUL512` 0.12s |
+| `span_native_c4` | 77.01s; `lz4block.decodeBlock` 7.54s; `CompressBlock` 5.91s; `cmpbody` 3.96s | 637.53s; `runtime.selectgo` 383.58s; `chanrecv2` 83.49s; `chanrecv1` 71.05s | 36.89s; `sync.Mutex.Unlock` 36.86s | 10.84s; `lz4block.decodeBlock` 0.95s; `CompressBlock` 0.79s; `runtime.memmove` 0.66s |
+| `span_native_c8` | 89.56s; `lz4block.decodeBlock` 8.36s; `CompressBlock` 6.76s; `runtime.memmove` 4.35s | 676.23s; `runtime.selectgo` 332.99s; `chanrecv2` 166.11s; `chanrecv1` 64.96s | 57.16s; `sync.Mutex.Unlock` 57.02s | 7.79s; `lz4block.decodeBlock` 0.66s; `CompressBlock` 0.65s; `runtime.procyieldAsm` 0.43s |
+| `span_native_c16` | 94.87s; `lz4block.decodeBlock` 8.57s; `CompressBlock` 6.84s; `runtime.memmove` 5.07s | 814.65s; `runtime.selectgo` 352.69s; `chanrecv2` 250.78s; `sync.Mutex.Lock` 93.72s | 93.02s; `sync.Mutex.Unlock` 92.81s | 8.52s; `lz4block.decodeBlock` 0.67s; `CompressBlock` 0.54s; `runtime.memmove` 0.44s |
+| `span_native_c4_no_backlog` | 82.28s; `lz4block.decodeBlock` 8.08s; `CompressBlock` 6.55s; `runtime.memmove` 4.31s | 649.75s; `runtime.selectgo` 388.66s; `chanrecv2` 80.60s; `chanrecv1` 72.81s | 44.09s; `sync.Mutex.Unlock` 40.44s; `RWMutex.RUnlock` 3.63s | 11.42s; `lz4block.decodeBlock` 0.98s; `CompressBlock` 0.92s; `runtime.memmove` 0.68s |
+| `span_native_c4_cache_disabled` | 73.21s; `lz4block.decodeBlock` 7.92s; `CompressBlock` 6.42s; `cmpbody` 3.90s | 549.41s; `runtime.selectgo` 322.63s; `chanrecv2` 72.98s; `chanrecv1` 64.59s | 35.29s; `sync.Mutex.Unlock` 35.26s | 5.99s; `lz4block.decodeBlock` 0.61s; `CompressBlock` 0.49s; `runtime.memmove` 0.31s |
+
+## Notes and caveats
+
+- The `span_native_c4_cache_disabled` row is a useful write-ceiling guardrail,
+  not a default-read-cache decision. It should be followed by read/scan/reopen
+  guardrails before changing cache defaults.
+- `span_native_c1` proves span-native should not be default-enabled without a
+  concurrency/config gate; it used span-native but lost the apply parallelism
+  needed to offset reducer/prepare costs.
+- c8/c16 reduce foreground assist wait and improve throughput, but contention
+  and CPU profile totals rise. These rows should be treated as throughput knobs,
+  not universal defaults.
+- The matrix used 128-byte values, so ordinary `value_vlog` remained empty;
+  persistent outer leaves are in `leaf_vlog` and remained durable storage.

--- a/docs/TREEDB_RANDOM_WRITE_CEILING_BREAKER_M14_REPORT.md
+++ b/docs/TREEDB_RANDOM_WRITE_CEILING_BREAKER_M14_REPORT.md
@@ -1,0 +1,78 @@
+# TreeDB random-write ceiling breaker M14 final gate
+
+Issue: #2774 (M14). Parent tracker: #2743. Runtime base for the first
+remote matrix: `origin/main@e0a71320db7a727b451ebdd4b8254853cfc072a2` after
+M13 / PR #2780.
+
+This report closes the post-M7 span-run/span-native ceiling-breaker stack by
+recording same-host evidence and a default-readiness decision. It is deliberately
+not an ops/sec-only report: the decision must account for old-leaf decode
+bytes/op, leaf merges/op, append frames/op, span shape, fallback reasons,
+checkpoint-inclusive wall time, stalls/backpressure, allocation/profile rows,
+and disk footprint.
+
+## Evidence collection plan
+
+Remote host and artifact root:
+
+- host: `mikers@100.78.120.42` (`mikers-B560-DS3H-AC-Y1`)
+- artifact parent: `/mnt/fast4tb/gomap-profiles`
+- current matrix root: `/mnt/fast4tb/gomap-profiles/2774_m14_matrix_20260616_132256`
+
+Reproducibility helpers added by this PR:
+
+```sh
+ROOT=/mnt/fast4tb/gomap-profiles \
+  COMMIT=$(git rev-parse HEAD) \
+  scripts/treedb_m14_final_gate.sh
+
+python3 scripts/treedb_m14_matrix_summary.py \
+  /mnt/fast4tb/gomap-profiles/2774_m14_matrix_20260616_132256 \
+  --baseline-label default_unconfigured
+```
+
+Primary command shape for each 10M row:
+
+```sh
+./bin/unified-bench \
+  -dbs treedb \
+  -test sequential_write,batch_random,random_write \
+  -keys 10000000 \
+  -valsize 128 \
+  -batchsize 8000 \
+  -profile-dir "$OUT" \
+  -path-label m8-m14-10mm-gate \
+  -treedb-journal-lanes=1 \
+  -checkpoint-between-tests \
+  -progress=false
+./bin/benchprof -profiles-dir "$OUT"
+```
+
+Rows under collection:
+
+| Row | Apply concurrency | Span-native | Backlog coalescing | Cache axis | Purpose |
+|---|---:|---:|---:|---|---|
+| `default_unconfigured` | default | false | false | default leaf read cache | Current default behavior / rollback floor. |
+| `legacy_parallel_c4` | 4 | false | false | default leaf read cache | Parallel recursive apply without span-native/backlog. |
+| `span_native_c1` | 1 | true | true | default leaf read cache | Span-native/backlog lower bound. |
+| `span_native_c2` | 2 | true | true | default leaf read cache | Span-native/backlog sweep. |
+| `span_native_c4` | 4 | true | true | default leaf read cache | M13 comparison/default candidate row. |
+| `span_native_c8` | 8 | true | true | default leaf read cache | Span-native/backlog sweep. |
+| `span_native_c16` | 16 | true | true | default leaf read cache | Span-native/backlog upper sweep. |
+| `span_native_c4_no_backlog` | 4 | true | false | default leaf read cache | Isolate M11 adaptive backlog coalescing. |
+| `span_native_c4_cache_disabled` | 4 | true | true | outer leaf read cache disabled | Cache-disabled guardrail row. |
+
+`FlushApplyConcurrency=1,2,4,8,16` rows all use the primary min gates
+`-treedb-flush-apply-min-entries=1 -treedb-flush-apply-min-spans=1
+-treedb-flush-apply-min-bytes=1`. The default row intentionally omits opt-in
+apply/span/backlog flags to measure the current shipped default.
+
+## Final matrix summary
+
+Pending remote matrix completion. The final PR update will paste the generated
+`m14_matrix_summary.md` tables and preserve artifact paths for every row.
+
+## Default-readiness decision
+
+Pending remote matrix completion. The decision will include rollback knobs and
+any accepted regressions/caveats explicitly.

--- a/docs/TREEDB_RANDOM_WRITE_CEILING_BREAKER_M14_REPORT.md
+++ b/docs/TREEDB_RANDOM_WRITE_CEILING_BREAKER_M14_REPORT.md
@@ -59,7 +59,7 @@ Recommended rollout posture:
 
 Remote host and artifact root:
 
-- host: `mikers@100.78.120.42` (`mikers-B560-DS3H-AC-Y1`)
+- host: redacted remote 4TB benchmark host (`mikers-B560-DS3H-AC-Y1`)
 - kernel: Linux 6.8.0-124-generic x86_64
 - Go: `go1.25.0 linux/amd64`
 - CPU workers visible: `nproc=12`

--- a/docs/TREEDB_RANDOM_WRITE_CEILING_BREAKER_TODO.md
+++ b/docs/TREEDB_RANDOM_WRITE_CEILING_BREAKER_TODO.md
@@ -2,6 +2,8 @@
 
 Issue: #2768 (M8). Parent tracker: #2743.
 
+M14 final-gate report: `docs/TREEDB_RANDOM_WRITE_CEILING_BREAKER_M14_REPORT.md`.
+
 This document is the post-M7 contract for the M9-M14 span-run / span-native
 flush/apply stack. M8 is intentionally an architecture and observability PR:
 it does **not** implement span-native apply, adaptive backlog coalescing, a

--- a/scripts/treedb_m14_final_gate.sh
+++ b/scripts/treedb_m14_final_gate.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# Run the TreeDB M14 final-gate unified-bench matrix into a profile artifact root.
+#
+# Intended remote usage for #2774:
+#   ROOT=/mnt/fast4tb/gomap-profiles COMMIT=$(git rev-parse HEAD) \
+#     scripts/treedb_m14_final_gate.sh
+#
+# The script runs 10M-key TreeDB write profiles and then invokes
+# scripts/treedb_m14_matrix_summary.py to produce m14_matrix_summary.{md,json}.
+set -euo pipefail
+
+ROOT=${ROOT:-/mnt/fast4tb/gomap-profiles}
+REPO=${REPO:-$(pwd)}
+COMMIT=${COMMIT:-$(git -C "$REPO" rev-parse HEAD)}
+STAMP=${STAMP:-$(date -u +%Y%m%d_%H%M%S)}
+RUN_ROOT=${RUN_ROOT:-$ROOT/2774_m14_matrix_${STAMP}}
+LOG=$RUN_ROOT/gate.log
+
+mkdir -p "$RUN_ROOT"
+exec > >(tee -a "$LOG") 2>&1
+
+printf "run_root=%s\n" "$RUN_ROOT"
+printf "host=%s\n" "$(hostname)"
+printf "date_utc=%s\n" "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+printf "go=%s\n" "$(go version)"
+printf "git=%s\n" "$(git --version)"
+printf "nproc=%s\n" "$(nproc 2>/dev/null || sysctl -n hw.ncpu)"
+printf "kernel=%s\n" "$(uname -a)"
+printf "repo=%s\n" "$REPO"
+
+cd "$REPO"
+git checkout --force "$COMMIT"
+git clean -fdx
+printf "checked_out=%s\n" "$(git rev-parse HEAD)"
+git status --short --branch
+make unified-bench benchprof
+
+COMMON_ARGS=(
+  -dbs treedb
+  -test sequential_write,batch_random,random_write
+  -keys 10000000
+  -valsize 128
+  -batchsize 8000
+  -path-label m8-m14-10mm-gate
+  -treedb-journal-lanes=1
+  -checkpoint-between-tests
+  -progress=false
+)
+APPLY_ARGS_BASE=(
+  -treedb-flush-apply-min-entries=1
+  -treedb-flush-apply-min-spans=1
+  -treedb-flush-apply-min-bytes=1
+)
+
+write_meta() {
+  local out=$1 label=$2 concurrency=$3 span_native=$4 backlog=$5 cache_mode=$6 note=$7
+  cat > "$out/variant.env" <<EOF_META
+label=$label
+commit=$COMMIT
+concurrency=$concurrency
+span_native=$span_native
+backlog_coalescing=$backlog
+cache_mode=$cache_mode
+note=$note
+EOF_META
+}
+
+run_one() {
+  local label=$1; shift
+  local concurrency=$1; shift
+  local span_native=$1; shift
+  local backlog=$1; shift
+  local cache_mode=$1; shift
+  local note=$1; shift
+  local out="$RUN_ROOT/$label"
+  mkdir -p "$out"
+  printf "=== variant=%s concurrency=%s span_native=%s backlog=%s cache=%s out=%s ===\n" \
+    "$label" "$concurrency" "$span_native" "$backlog" "$cache_mode" "$out"
+  git rev-parse HEAD > "$out/COMMIT"
+  git status --short --branch > "$out/git_status.txt"
+  write_meta "$out" "$label" "$concurrency" "$span_native" "$backlog" "$cache_mode" "$note"
+
+  local args=("${COMMON_ARGS[@]}" -profile-dir "$out")
+  if [[ "$concurrency" != "default" ]]; then
+    args+=("${APPLY_ARGS_BASE[@]}" -treedb-flush-apply-concurrency="$concurrency")
+  fi
+  if [[ "$span_native" == "true" ]]; then
+    args+=(-treedb-flush-apply-span-native)
+  fi
+  if [[ "$backlog" == "true" ]]; then
+    args+=(-treedb-flush-backlog-coalescing)
+  fi
+  case "$cache_mode" in
+    default) ;;
+    disabled) args+=(-treedb-leaf-page-read-cache-entries=-1) ;;
+    large) args+=(-treedb-leaf-page-read-cache-entries=262144) ;;
+    *) echo "unknown cache_mode=$cache_mode" >&2; return 2 ;;
+  esac
+
+  printf "./bin/unified-bench" > "$out/command.sh"
+  printf " \\\n  %q" "${args[@]}" >> "$out/command.sh"
+  printf "\n" >> "$out/command.sh"
+  chmod +x "$out/command.sh"
+  /usr/bin/time -v ./bin/unified-bench "${args[@]}" > "$out/unified_bench.stdout.md" 2> "$out/unified_bench.stderr.log"
+  /usr/bin/time -v ./bin/benchprof -profiles-dir "$out" > "$out/benchprof_manual.log" 2>&1
+  printf "completed %s\n" "$label"
+}
+
+run_one default_unconfigured default false false default \
+  "current default knobs; primary command without opt-in apply/span/backlog flags"
+run_one legacy_parallel_c4 4 false false default \
+  "M2/M9 recursive worker apply path at c4; span-native/backlog disabled"
+run_one span_native_c1 1 true true default \
+  "span-native plus M11 backlog coalescing; default leaf cache"
+run_one span_native_c2 2 true true default \
+  "span-native plus M11 backlog coalescing; default leaf cache"
+run_one span_native_c4 4 true true default \
+  "span-native plus M11 backlog coalescing; default leaf cache"
+run_one span_native_c8 8 true true default \
+  "span-native plus M11 backlog coalescing; default leaf cache"
+run_one span_native_c16 16 true true default \
+  "span-native plus M11 backlog coalescing; default leaf cache"
+run_one span_native_c4_no_backlog 4 true false default \
+  "span-native enabled; M11 backlog coalescing disabled"
+run_one span_native_c4_cache_disabled 4 true true disabled \
+  "span-native plus backlog coalescing; outer leaf read cache disabled"
+
+if [[ -x scripts/treedb_m14_matrix_summary.py ]]; then
+  python3 scripts/treedb_m14_matrix_summary.py "$RUN_ROOT" --baseline-label default_unconfigured
+fi
+printf "M14 matrix done %s\nRUN_ROOT=%s\nLOG=%s\n" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$RUN_ROOT" "$LOG"

--- a/scripts/treedb_m14_final_gate.sh
+++ b/scripts/treedb_m14_final_gate.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Run the TreeDB M14 final-gate unified-bench matrix into a profile artifact root.
+# Run the TreeDB M14 final-gate unified-bench matrix into an out-of-repo profile artifact root.
 #
 # Intended remote usage for #2774:
 #   ROOT=/mnt/fast4tb/gomap-profiles COMMIT=$(git rev-parse HEAD) \
@@ -31,6 +31,14 @@ RUN_MANUAL_BENCHPROF=${RUN_MANUAL_BENCHPROF:-false}
 LOG=$RUN_ROOT/gate.log
 
 mkdir -p "$RUN_ROOT"
+REPO_ABS=$(cd "$REPO" && pwd -P)
+RUN_ROOT_ABS=$(cd "$RUN_ROOT" && pwd -P)
+case "$RUN_ROOT_ABS/" in
+  "$REPO_ABS"/*)
+    echo "RUN_ROOT must be outside the repository because the script runs git clean -fdx: $RUN_ROOT_ABS" >&2
+    exit 2
+    ;;
+esac
 exec > >(tee -a "$LOG") 2>&1
 
 printf "run_root=%s\n" "$RUN_ROOT"

--- a/scripts/treedb_m14_final_gate.sh
+++ b/scripts/treedb_m14_final_gate.sh
@@ -7,13 +7,27 @@
 #
 # The script runs 10M-key TreeDB write profiles and then invokes
 # scripts/treedb_m14_matrix_summary.py to produce m14_matrix_summary.{md,json}.
+# `unified-bench -profile-dir` auto-runs benchprof; set
+# RUN_MANUAL_BENCHPROF=true to also run the explicit second pass used by older
+# runbooks.
 set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)
+SUMMARY_SCRIPT_SRC=$SCRIPT_DIR/treedb_m14_matrix_summary.py
+if [[ ! -f "$SUMMARY_SCRIPT_SRC" ]]; then
+  echo "missing summary parser: $SUMMARY_SCRIPT_SRC" >&2
+  exit 2
+fi
+PRESERVED_SUMMARY_SCRIPT=$(mktemp)
+trap 'rm -f "$PRESERVED_SUMMARY_SCRIPT"' EXIT
+cp "$SUMMARY_SCRIPT_SRC" "$PRESERVED_SUMMARY_SCRIPT"
 
 ROOT=${ROOT:-/mnt/fast4tb/gomap-profiles}
 REPO=${REPO:-$(pwd)}
 COMMIT=${COMMIT:-$(git -C "$REPO" rev-parse HEAD)}
 STAMP=${STAMP:-$(date -u +%Y%m%d_%H%M%S)}
 RUN_ROOT=${RUN_ROOT:-$ROOT/2774_m14_matrix_${STAMP}}
+RUN_MANUAL_BENCHPROF=${RUN_MANUAL_BENCHPROF:-false}
 LOG=$RUN_ROOT/gate.log
 
 mkdir -p "$RUN_ROOT"
@@ -27,6 +41,8 @@ printf "git=%s\n" "$(git --version)"
 printf "nproc=%s\n" "$(nproc 2>/dev/null || sysctl -n hw.ncpu)"
 printf "kernel=%s\n" "$(uname -a)"
 printf "repo=%s\n" "$REPO"
+printf "run_manual_benchprof=%s\n" "$RUN_MANUAL_BENCHPROF"
+cp "$PRESERVED_SUMMARY_SCRIPT" "$RUN_ROOT/treedb_m14_matrix_summary.py"
 
 cd "$REPO"
 git checkout --force "$COMMIT"
@@ -102,7 +118,9 @@ run_one() {
   printf "\n" >> "$out/command.sh"
   chmod +x "$out/command.sh"
   /usr/bin/time -v ./bin/unified-bench "${args[@]}" > "$out/unified_bench.stdout.md" 2> "$out/unified_bench.stderr.log"
-  /usr/bin/time -v ./bin/benchprof -profiles-dir "$out" > "$out/benchprof_manual.log" 2>&1
+  if [[ "$RUN_MANUAL_BENCHPROF" == "true" ]]; then
+    /usr/bin/time -v ./bin/benchprof -profiles-dir "$out" > "$out/benchprof_manual.log" 2>&1
+  fi
   printf "completed %s\n" "$label"
 }
 
@@ -125,7 +143,5 @@ run_one span_native_c4_no_backlog 4 true false default \
 run_one span_native_c4_cache_disabled 4 true true disabled \
   "span-native plus backlog coalescing; outer leaf read cache disabled"
 
-if [[ -x scripts/treedb_m14_matrix_summary.py ]]; then
-  python3 scripts/treedb_m14_matrix_summary.py "$RUN_ROOT" --baseline-label default_unconfigured
-fi
+python3 "$RUN_ROOT/treedb_m14_matrix_summary.py" "$RUN_ROOT" --baseline-label default_unconfigured
 printf "M14 matrix done %s\nRUN_ROOT=%s\nLOG=%s\n" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$RUN_ROOT" "$LOG"

--- a/scripts/treedb_m14_matrix_summary.py
+++ b/scripts/treedb_m14_matrix_summary.py
@@ -253,6 +253,10 @@ def load_row(path: Path) -> MatrixRow:
         test_results = results.get(test, {}) or {}
         ops[test] = _to_float(test_results.get("TreeDB"))
     counters = {k: str(stats.get(k, "")) for k in COUNTER_KEYS if k in stats}
+    single_op_spans = _to_float(counters.get("treedb.flush_apply.span_run.single_op_spans_total"))
+    target_spans = _to_float(counters.get("treedb.flush_apply.span_run.target_leaf_spans_total"))
+    if single_op_spans is not None and target_spans not in (None, 0):
+        counters["derived.flush_apply.span_run.single_op_span_ratio"] = f"{single_op_spans / target_spans:.6f}"
     profiles = {
         "cpu_random_write": _profile_top(insights, "cpu_profiles", "random_write"),
         "cpu_batch_random": _profile_top(insights, "cpu_profiles", "batch_random"),
@@ -357,8 +361,8 @@ def render_markdown(root: Path, rows: List[MatrixRow], baseline_label: str = "")
         ("old leaf B/op", "treedb.flush_apply.old_leaf_read_decode.bytes_per_op"),
         ("leaf merges/op", "treedb.flush_apply.merge_build.leaf_merges_per_op"),
         ("append frames/op", "treedb.cache.flush_apply.leaf_log_append_frames_per_op"),
-        ("cache ops/span", "treedb.cache.flush_span_run.ops_per_span"),
-        ("cache single-op ratio", "treedb.cache.flush_span_run.single_op_span_ratio"),
+        ("apply ops/span", "treedb.flush_apply.span_run.ops_per_span"),
+        ("single-op span ratio", "derived.flush_apply.span_run.single_op_span_ratio"),
         ("target split leaves", "treedb.cache.flush_span_run.target_leaves_split_across_chunks_total"),
         ("span-native used ops", "treedb.flush_apply.span_native.used_ops_total"),
         ("fallbacks", "treedb.flush_apply.span_native.fallbacks_total"),

--- a/scripts/treedb_m14_matrix_summary.py
+++ b/scripts/treedb_m14_matrix_summary.py
@@ -1,0 +1,538 @@
+#!/usr/bin/env python3
+"""Summarize TreeDB M14 final-gate unified-bench artifact matrices.
+
+The script expects a matrix root with one subdirectory per row. Each row should
+contain the standard `unified-bench -profile-dir` files:
+
+  - benchprof_results.json
+  - benchprof_results.md
+  - insights.json
+
+Rows may also contain `variant.env` metadata written by the M14 runbook script.
+It writes `m14_matrix_summary.json` and `m14_matrix_summary.md` by default.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import re
+import sys
+import tempfile
+from dataclasses import dataclass, asdict
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Mapping, Optional
+
+TESTS = ("sequential_write", "batch_random", "random_write")
+CHECKPOINT_LABELS = ("Sequential Write", "Batch Random", "Random Write", "After Run")
+DISK_KEYS = ("maindb/index.db", "maindb/wal", "maindb/value_vlog", "maindb/leaf_vlog")
+COUNTER_KEYS = (
+    "treedb.flush_apply.old_leaf_read_decode.bytes_per_op",
+    "treedb.flush_apply.merge_build.leaf_merges_per_op",
+    "treedb.cache.flush_apply.leaf_log_append_frames_per_op",
+    "treedb.cache.flush_span_run.ops_per_span",
+    "treedb.cache.flush_span_run.single_op_span_ratio",
+    "treedb.cache.flush_span_run.target_leaves_split_across_chunks_total",
+    "treedb.flush_apply.span_run.ops_per_span",
+    "treedb.flush_apply.span_run.target_leaf_spans_total",
+    "treedb.flush_apply.span_run.single_op_spans_total",
+    "treedb.flush_apply.span_native.candidate_ops_total",
+    "treedb.flush_apply.span_native.eligible_ops_total",
+    "treedb.flush_apply.span_native.used_ops_total",
+    "treedb.flush_apply.span_native.fallbacks_total",
+    "treedb.flush_apply.span_native.fallback.reason.close_or_checkpoint.ops_total",
+    "treedb.flush_apply.span_native.fallback.reason.root_mismatch.ops_total",
+    "treedb.flush_apply.span_native.fallback.reason.output_ownership_failure.ops_total",
+    "treedb.flush_apply.span_native.fallback.reason.reducer_validation_failed.ops_total",
+    "treedb.flush_apply.root_reduce.ns_total",
+    "treedb.flush_apply.guarded_publish.ns_total",
+    "treedb.flush_apply.retry_total",
+    "treedb.flush_apply.mismatch_total",
+    "treedb.cache.flush_apply.foreground_assist_wait_ns_total",
+    "treedb.cache.flush_apply.coordinator.active_assist_skips_total",
+    "treedb.cache.flush_apply.coordinator.progress_wait_ns_total",
+    "treedb.cache.flush_apply.coordinator.stall_waits_total",
+    "treedb.cache.flush_apply.coordinator.blocking_fallbacks_total",
+    "treedb.cache.flush_apply.coordinator.hard_overload_fallbacks_total",
+    "treedb.cache.checkpoint.active_background_flush_wait_ns_total",
+    "treedb.cache.checkpoint.stage.value_log_flush.total_ns",
+    "treedb.cache.checkpoint.stage.leaf_value_log_sync.total_ns",
+    "treedb.cache.checkpoint.stage.reducer_publish.total_ns",
+    "treedb.cache.flush_backlog_coalescing.admitted_runs_total",
+    "treedb.cache.flush_backlog_coalescing.admitted_extra_memtables_total",
+    "treedb.cache.flush_backlog_coalescing.admitted_extra_ops_total",
+    "treedb.cache.flush_backlog_coalescing.selected_memtables_max",
+    "treedb.cache.flush_backlog_coalescing.selected_ops_max",
+)
+PROFILE_KINDS = (
+    "cpu_profiles",
+    "alloc_space_profiles",
+    "alloc_object_profiles",
+    "block_profiles",
+    "mutex_profiles",
+)
+
+
+def _read_text(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return ""
+
+
+def _parse_env(path: Path) -> Dict[str, str]:
+    out: Dict[str, str] = {}
+    for line in _read_text(path).splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        out[key.strip()] = value.strip()
+    return out
+
+
+def _extract_fenced_section(md: str, heading: str) -> str:
+    idx = md.find(heading)
+    if idx < 0:
+        return ""
+    first = md.find("```", idx)
+    if first < 0:
+        return ""
+    first_end = md.find("\n", first)
+    if first_end < 0:
+        return ""
+    second = md.find("```", first_end + 1)
+    if second < 0:
+        return ""
+    return md[first_end + 1 : second]
+
+
+def _parse_options(md: str) -> Dict[str, str]:
+    section = _extract_fenced_section(md, "## Resolved TreeDB Options")
+    opts: Dict[str, str] = {}
+    for raw in section.splitlines():
+        line = raw.strip()
+        if not line or line == "notes:" or line.startswith("-") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        opts[key.strip()] = value.strip()
+    return opts
+
+
+def _parse_checkpoint_table(md: str) -> Dict[str, str]:
+    section = _extract_fenced_section(md, "## Checkpoint Time")
+    checkpoints: Dict[str, str] = {}
+    for raw in section.splitlines():
+        line = raw.rstrip()
+        if not line.strip() or set(line.strip()) <= {"-"} or "Before Test" in line:
+            continue
+        m = re.match(r"^\s*(Sequential Write|Batch Random|Random Write|After Run)\s+(.+?)\s*$", line)
+        if m:
+            checkpoints[m.group(1)] = m.group(2).strip()
+    return checkpoints
+
+
+def _parse_disk_usage(md: str) -> Dict[str, str]:
+    section = _extract_fenced_section(md, "## Disk Usage")
+    disks: Dict[str, str] = {}
+    for raw in section.splitlines():
+        line = raw.strip()
+        if not line or line == "TreeDB:" or ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        key = key.strip()
+        if key in DISK_KEYS:
+            disks[key] = value.strip()
+    return disks
+
+
+def _to_float(value: Any) -> Optional[float]:
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        if isinstance(value, float) and math.isnan(value):
+            return None
+        return float(value)
+    text = str(value).strip().replace(",", "")
+    if not text:
+        return None
+    try:
+        return float(text)
+    except ValueError:
+        return None
+
+
+def _fmt_num(value: Any, digits: int = 3) -> str:
+    num = _to_float(value)
+    if num is None:
+        return ""
+    if abs(num) >= 1000 and num.is_integer():
+        return f"{int(num):,}"
+    if abs(num) >= 1000:
+        return f"{num:,.0f}"
+    if num.is_integer():
+        return str(int(num))
+    return f"{num:.{digits}f}"
+
+
+def _first_top(entries: Iterable[Mapping[str, Any]], n: int = 3) -> str:
+    parts: List[str] = []
+    for entry in list(entries)[:n]:
+        function = str(entry.get("function", "")).replace("|", "\\|")
+        flat = entry.get("flat", "")
+        flat_pct = entry.get("flat_pct", "")
+        if flat_pct != "":
+            parts.append(f"{function} ({flat}, {flat_pct}%)")
+        else:
+            parts.append(f"{function} ({flat})")
+    return "<br>".join(parts)
+
+
+def _profile_top(insights: Mapping[str, Any], kind_key: str, test: str, db_tag: Optional[str] = "treedb", n: int = 3) -> Dict[str, Any]:
+    for prof in insights.get(kind_key, []) or []:
+        if prof.get("test") != test:
+            continue
+        if db_tag is not None and prof.get("db_tag") != db_tag:
+            continue
+        return {
+            "total": prof.get("total", ""),
+            "top": list(prof.get("top_entries", []) or [])[:n],
+            "top_text": _first_top(prof.get("top_entries", []) or [], n=n),
+            "path": prof.get("path", ""),
+        }
+    return {"total": "", "top": [], "top_text": "", "path": ""}
+
+
+@dataclass
+class MatrixRow:
+    label: str
+    path: str
+    commit: str
+    concurrency: str
+    span_native: str
+    backlog_coalescing: str
+    cache_mode: str
+    note: str
+    options: Dict[str, str]
+    ops_per_sec: Dict[str, Optional[float]]
+    checkpoints: Dict[str, str]
+    disk_usage: Dict[str, str]
+    counters: Dict[str, str]
+    profiles: Dict[str, Dict[str, Any]]
+
+
+def load_row(path: Path) -> MatrixRow:
+    env = _parse_env(path / "variant.env")
+    commit = _read_text(path / "COMMIT").strip() or env.get("commit", "")
+    label = env.get("label") or path.name
+    md = _read_text(path / "benchprof_results.md")
+    with (path / "benchprof_results.json").open(encoding="utf-8") as f:
+        bench = json.load(f)
+    insights: Dict[str, Any] = {}
+    if (path / "insights.json").exists():
+        with (path / "insights.json").open(encoding="utf-8") as f:
+            insights = json.load(f)
+    run = bench.get("runs", [{}])[0]
+    results = run.get("results", {}) or {}
+    stats_by_db = run.get("treedb_stats", {}) or {}
+    stats = stats_by_db.get("TreeDB", {}) if isinstance(stats_by_db, Mapping) else {}
+    ops: Dict[str, Optional[float]] = {}
+    for test in TESTS:
+        test_results = results.get(test, {}) or {}
+        ops[test] = _to_float(test_results.get("TreeDB"))
+    counters = {k: str(stats.get(k, "")) for k in COUNTER_KEYS if k in stats}
+    profiles = {
+        "cpu_random_write": _profile_top(insights, "cpu_profiles", "random_write"),
+        "cpu_batch_random": _profile_top(insights, "cpu_profiles", "batch_random"),
+        "alloc_space_random_write": _profile_top(insights, "alloc_space_profiles", "random_write"),
+        "alloc_objects_random_write": _profile_top(insights, "alloc_object_profiles", "random_write"),
+        "block_random_write": _profile_top(insights, "block_profiles", "random_write"),
+        "mutex_random_write": _profile_top(insights, "mutex_profiles", "random_write"),
+        "checkpoint_post_run_cpu": _profile_top(insights, "cpu_profiles", "checkpoint/post", db_tag="run_treedb"),
+    }
+    return MatrixRow(
+        label=label,
+        path=str(path),
+        commit=commit,
+        concurrency=env.get("concurrency", ""),
+        span_native=env.get("span_native", ""),
+        backlog_coalescing=env.get("backlog_coalescing", ""),
+        cache_mode=env.get("cache_mode", ""),
+        note=env.get("note", ""),
+        options=_parse_options(md),
+        ops_per_sec=ops,
+        checkpoints=_parse_checkpoint_table(md),
+        disk_usage=_parse_disk_usage(md),
+        counters=counters,
+        profiles=profiles,
+    )
+
+
+def load_matrix(root: Path) -> List[MatrixRow]:
+    rows: List[MatrixRow] = []
+    for child in sorted(root.iterdir()):
+        if child.is_dir() and (child / "benchprof_results.json").exists():
+            rows.append(load_row(child))
+    return rows
+
+
+def _pct_delta(value: Optional[float], base: Optional[float]) -> str:
+    if value is None or base in (None, 0):
+        return ""
+    return f"{((value - base) / base) * 100:+.2f}%"
+
+
+def render_markdown(root: Path, rows: List[MatrixRow], baseline_label: str = "") -> str:
+    by_label = {row.label: row for row in rows}
+    baseline = by_label.get(baseline_label) if baseline_label else None
+    lines: List[str] = []
+    lines.append("# TreeDB M14 final-gate matrix summary")
+    lines.append("")
+    lines.append(f"- artifact root: `{root}`")
+    if rows:
+        commits = sorted({r.commit for r in rows if r.commit})
+        lines.append("- commits: " + ", ".join(f"`{c}`" for c in commits))
+    if baseline:
+        lines.append(f"- delta baseline: `{baseline.label}`")
+    lines.append("")
+    lines.append("## Throughput and checkpoint summary")
+    lines.append("")
+    header = [
+        "Row",
+        "Concurrency",
+        "Span-native",
+        "Backlog",
+        "Cache",
+        "Seq ops/s",
+        "Batch ops/s",
+        "Random ops/s",
+        "Δ random",
+        "Checkpoint batch",
+        "Checkpoint random",
+        "Post-run checkpoint",
+        "Artifact",
+    ]
+    lines.append("| " + " | ".join(header) + " |")
+    lines.append("|" + "|".join(["---"] + ["---:"] * 11 + ["---"]) + "|")
+    for row in rows:
+        lines.append(
+            "| "
+            + " | ".join(
+                [
+                    f"`{row.label}`",
+                    row.concurrency,
+                    row.span_native,
+                    row.backlog_coalescing,
+                    row.cache_mode,
+                    _fmt_num(row.ops_per_sec.get("sequential_write"), 0),
+                    _fmt_num(row.ops_per_sec.get("batch_random"), 0),
+                    _fmt_num(row.ops_per_sec.get("random_write"), 0),
+                    _pct_delta(row.ops_per_sec.get("random_write"), baseline.ops_per_sec.get("random_write") if baseline else None),
+                    row.checkpoints.get("Batch Random", ""),
+                    row.checkpoints.get("Random Write", ""),
+                    row.checkpoints.get("After Run", ""),
+                    f"`{row.path}`",
+                ]
+            )
+            + " |"
+        )
+    lines.append("")
+    lines.append("## Rewrite-amplification, span, reducer, and stall counters")
+    lines.append("")
+    counter_cols = [
+        ("old leaf B/op", "treedb.flush_apply.old_leaf_read_decode.bytes_per_op"),
+        ("leaf merges/op", "treedb.flush_apply.merge_build.leaf_merges_per_op"),
+        ("append frames/op", "treedb.cache.flush_apply.leaf_log_append_frames_per_op"),
+        ("cache ops/span", "treedb.cache.flush_span_run.ops_per_span"),
+        ("cache single-op ratio", "treedb.cache.flush_span_run.single_op_span_ratio"),
+        ("target split leaves", "treedb.cache.flush_span_run.target_leaves_split_across_chunks_total"),
+        ("span-native used ops", "treedb.flush_apply.span_native.used_ops_total"),
+        ("fallbacks", "treedb.flush_apply.span_native.fallbacks_total"),
+        ("close/chkp fallback ops", "treedb.flush_apply.span_native.fallback.reason.close_or_checkpoint.ops_total"),
+        ("root reduce ns", "treedb.flush_apply.root_reduce.ns_total"),
+        ("publish ns", "treedb.flush_apply.guarded_publish.ns_total"),
+        ("fg assist wait ns", "treedb.cache.flush_apply.foreground_assist_wait_ns_total"),
+        ("active assist skips", "treedb.cache.flush_apply.coordinator.active_assist_skips_total"),
+        ("stall waits", "treedb.cache.flush_apply.coordinator.stall_waits_total"),
+        ("checkpoint bg wait ns", "treedb.cache.checkpoint.active_background_flush_wait_ns_total"),
+        ("coalesced extra ops", "treedb.cache.flush_backlog_coalescing.admitted_extra_ops_total"),
+    ]
+    lines.append("| Row | " + " | ".join(c[0] for c in counter_cols) + " |")
+    lines.append("|---|" + "|".join("---:" for _ in counter_cols) + "|")
+    for row in rows:
+        vals = [_fmt_num(row.counters.get(k, ""), 3) for _, k in counter_cols]
+        lines.append("| `" + row.label + "` | " + " | ".join(vals) + " |")
+    lines.append("")
+    lines.append("## Disk usage")
+    lines.append("")
+    lines.append("| Row | index.db | WAL | value_vlog | leaf_vlog |")
+    lines.append("|---|---:|---:|---:|---:|")
+    for row in rows:
+        lines.append(
+            f"| `{row.label}` | {row.disk_usage.get('maindb/index.db', '')} | {row.disk_usage.get('maindb/wal', '')} | {row.disk_usage.get('maindb/value_vlog', '')} | {row.disk_usage.get('maindb/leaf_vlog', '')} |"
+        )
+    lines.append("")
+    lines.append("## Random-write top profile rows")
+    lines.append("")
+    lines.append("| Row | CPU total/top | alloc-space total/top | alloc-objects total/top | block total/top | mutex total/top | post-run checkpoint CPU total/top |")
+    lines.append("|---|---|---|---|---|---|---|")
+    for row in rows:
+        def cell(name: str) -> str:
+            p = row.profiles.get(name, {})
+            total = p.get("total", "")
+            top = p.get("top_text", "")
+            if total and top:
+                return f"{total}<br>{top}"
+            return str(total or top or "")
+
+        lines.append(
+            f"| `{row.label}` | {cell('cpu_random_write')} | {cell('alloc_space_random_write')} | {cell('alloc_objects_random_write')} | {cell('block_random_write')} | {cell('mutex_random_write')} | {cell('checkpoint_post_run_cpu')} |"
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def write_outputs(root: Path, rows: List[MatrixRow], baseline_label: str) -> None:
+    summary_json = {
+        "artifact_root": str(root),
+        "baseline_label": baseline_label,
+        "rows": [asdict(row) for row in rows],
+    }
+    (root / "m14_matrix_summary.json").write_text(json.dumps(summary_json, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    (root / "m14_matrix_summary.md").write_text(render_markdown(root, rows, baseline_label), encoding="utf-8")
+
+
+def _self_test() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        row = root / "span_native_c4"
+        row.mkdir()
+        (row / "variant.env").write_text(
+            "label=span_native_c4\ncommit=abc123\nconcurrency=4\nspan_native=true\nbacklog_coalescing=true\ncache_mode=default\nnote=test row\n",
+            encoding="utf-8",
+        )
+        (row / "COMMIT").write_text("abc123\n", encoding="utf-8")
+        (row / "benchprof_results.json").write_text(
+            json.dumps(
+                {
+                    "runs": [
+                        {
+                            "results": {
+                                "sequential_write": {"TreeDB": 10.0},
+                                "batch_random": {"TreeDB": 20.0},
+                                "random_write": {"TreeDB": 30.0},
+                            },
+                            "treedb_stats": {
+                                "TreeDB": {
+                                    "treedb.flush_apply.old_leaf_read_decode.bytes_per_op": "1.5",
+                                    "treedb.flush_apply.merge_build.leaf_merges_per_op": "0.25",
+                                    "treedb.cache.flush_apply.leaf_log_append_frames_per_op": "0.25",
+                                    "treedb.flush_apply.span_native.used_ops_total": "100",
+                                    "treedb.flush_apply.span_native.fallbacks_total": "0",
+                                }
+                            },
+                        }
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+        (row / "benchprof_results.md").write_text(
+            """
+## Resolved TreeDB Options
+
+```text
+flush_apply_concurrency=4
+flush_apply_span_native=true
+flush_backlog_coalescing=true
+```
+
+## Checkpoint Time (Between Tests + Post-run)
+
+```text
+     Before Test    TreeDB
+----------------  --------
+Sequential Write     100µs
+    Batch Random  200.00ms
+    Random Write     3.00s
+       After Run     4.00s
+```
+
+## Disk Usage (End of Run)
+
+```text
+TreeDB:
+  maindb/index.db: 1 MiB
+  maindb/wal: total=12 B files=1 other=12 B
+  maindb/value_vlog: total=0 B files=1
+  maindb/leaf_vlog: total=2 MiB files=1 value=2 MiB
+```
+""",
+            encoding="utf-8",
+        )
+        (row / "insights.json").write_text(
+            json.dumps(
+                {
+                    "cpu_profiles": [
+                        {
+                            "test": "random_write",
+                            "db_tag": "treedb",
+                            "total": "1s",
+                            "top_entries": [{"function": "f", "flat": "1s", "flat_pct": 100}],
+                        },
+                        {
+                            "test": "checkpoint/post",
+                            "db_tag": "run_treedb",
+                            "total": "2s",
+                            "top_entries": [{"function": "ckpt", "flat": "2s", "flat_pct": 100}],
+                        },
+                    ],
+                    "alloc_space_profiles": [],
+                    "alloc_object_profiles": [],
+                    "block_profiles": [],
+                    "mutex_profiles": [],
+                }
+            ),
+            encoding="utf-8",
+        )
+        rows = load_matrix(root)
+        assert len(rows) == 1, rows
+        got = rows[0]
+        assert got.label == "span_native_c4"
+        assert got.ops_per_sec["random_write"] == 30.0
+        assert got.checkpoints["After Run"] == "4.00s", got.checkpoints
+        assert got.disk_usage["maindb/leaf_vlog"].startswith("total=2 MiB")
+        md = render_markdown(root, rows, "span_native_c4")
+        assert "TreeDB M14 final-gate matrix summary" in md
+        assert "span_native_c4" in md
+        write_outputs(root, rows, "span_native_c4")
+        assert (root / "m14_matrix_summary.json").exists()
+        assert (root / "m14_matrix_summary.md").exists()
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("root", nargs="?", type=Path, help="matrix artifact root")
+    parser.add_argument("--baseline-label", default="", help="row label used for percent deltas")
+    parser.add_argument("--self-test", action="store_true", help="run built-in parser smoke test")
+    args = parser.parse_args(argv)
+    if args.self_test:
+        _self_test()
+        print("self-test passed")
+        return 0
+    if args.root is None:
+        parser.error("root is required unless --self-test is used")
+    root = args.root.resolve()
+    rows = load_matrix(root)
+    if not rows:
+        print(f"no benchmark rows found under {root}", file=sys.stderr)
+        return 1
+    write_outputs(root, rows, args.baseline_label)
+    print(root / "m14_matrix_summary.md")
+    print(root / "m14_matrix_summary.json")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/treedb_m14_matrix_summary.py
+++ b/scripts/treedb_m14_matrix_summary.py
@@ -166,7 +166,11 @@ def _parse_selected_stats(md: str) -> Dict[str, str]:
         if not line or line == "TreeDB:" or ":" not in line:
             continue
         key, value = line.split(":", 1)
-        stats[key.strip()] = value.strip()
+        key = key.strip()
+        value = value.strip()
+        stats[key] = value
+        if key.startswith("flush_backlog_coalescing."):
+            stats[f"treedb.cache.{key}"] = value
     return stats
 
 
@@ -386,7 +390,7 @@ def render_markdown(root: Path, rows: List[MatrixRow], baseline_label: str = "")
         ("active assist skips", "treedb.cache.flush_apply.coordinator.active_assist_skips_total"),
         ("stall waits", "treedb.cache.flush_apply.coordinator.stall_waits_total"),
         ("checkpoint bg wait ns", "treedb.cache.checkpoint.active_background_flush_wait_ns_total"),
-        ("coalesced extra ops", "flush_backlog_coalescing.admitted_extra_ops_total"),
+        ("coalesced extra ops", "treedb.cache.flush_backlog_coalescing.admitted_extra_ops_total"),
     ]
     lines.append("| Row | " + " | ".join(c[0] for c in counter_cols) + " |")
     lines.append("|---|" + "|".join("---:" for _ in counter_cols) + "|")
@@ -503,7 +507,7 @@ TreeDB:
 
 ```text
 TreeDB:
-  flush_backlog_coalescing.admitted_extra_ops_total: 42
+  treedb.cache.flush_backlog_coalescing.admitted_extra_ops_total: 42
 ```
 """,
             encoding="utf-8",
@@ -540,7 +544,7 @@ TreeDB:
         assert got.ops_per_sec["random_write"] == 30.0
         assert got.checkpoints["After Run"] == "4.00s", got.checkpoints
         assert got.disk_usage["maindb/leaf_vlog"].startswith("total=2 MiB")
-        assert got.counters["flush_backlog_coalescing.admitted_extra_ops_total"] == "42"
+        assert got.counters["treedb.cache.flush_backlog_coalescing.admitted_extra_ops_total"] == "42"
         md = render_markdown(root, rows, "span_native_c4")
         assert "TreeDB M14 final-gate matrix summary" in md
         assert "span_native_c4" in md

--- a/scripts/treedb_m14_matrix_summary.py
+++ b/scripts/treedb_m14_matrix_summary.py
@@ -25,6 +25,17 @@ from pathlib import Path
 from typing import Any, Dict, Iterable, List, Mapping, Optional
 
 TESTS = ("sequential_write", "batch_random", "random_write")
+ROW_ORDER = (
+    "default_unconfigured",
+    "legacy_parallel_c4",
+    "span_native_c1",
+    "span_native_c2",
+    "span_native_c4",
+    "span_native_c8",
+    "span_native_c16",
+    "span_native_c4_no_backlog",
+    "span_native_c4_cache_disabled",
+)
 CHECKPOINT_LABELS = ("Sequential Write", "Batch Random", "Random Write", "After Run")
 DISK_KEYS = ("maindb/index.db", "maindb/wal", "maindb/value_vlog", "maindb/leaf_vlog")
 COUNTER_KEYS = (
@@ -274,6 +285,8 @@ def load_matrix(root: Path) -> List[MatrixRow]:
     for child in sorted(root.iterdir()):
         if child.is_dir() and (child / "benchprof_results.json").exists():
             rows.append(load_row(child))
+    order = {label: i for i, label in enumerate(ROW_ORDER)}
+    rows.sort(key=lambda row: (order.get(row.label, len(order)), row.label))
     return rows
 
 

--- a/scripts/treedb_m14_matrix_summary.py
+++ b/scripts/treedb_m14_matrix_summary.py
@@ -158,6 +158,18 @@ def _parse_disk_usage(md: str) -> Dict[str, str]:
     return disks
 
 
+def _parse_selected_stats(md: str) -> Dict[str, str]:
+    section = _extract_fenced_section(md, "## TreeDB Selected Stats")
+    stats: Dict[str, str] = {}
+    for raw in section.splitlines():
+        line = raw.strip()
+        if not line or line == "TreeDB:" or ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        stats[key.strip()] = value.strip()
+    return stats
+
+
 def _to_float(value: Any) -> Optional[float]:
     if value is None:
         return None
@@ -253,6 +265,7 @@ def load_row(path: Path) -> MatrixRow:
         test_results = results.get(test, {}) or {}
         ops[test] = _to_float(test_results.get("TreeDB"))
     counters = {k: str(stats.get(k, "")) for k in COUNTER_KEYS if k in stats}
+    counters.update(_parse_selected_stats(md))
     single_op_spans = _to_float(counters.get("treedb.flush_apply.span_run.single_op_spans_total"))
     target_spans = _to_float(counters.get("treedb.flush_apply.span_run.target_leaf_spans_total"))
     if single_op_spans is not None and target_spans not in (None, 0):
@@ -373,7 +386,7 @@ def render_markdown(root: Path, rows: List[MatrixRow], baseline_label: str = "")
         ("active assist skips", "treedb.cache.flush_apply.coordinator.active_assist_skips_total"),
         ("stall waits", "treedb.cache.flush_apply.coordinator.stall_waits_total"),
         ("checkpoint bg wait ns", "treedb.cache.checkpoint.active_background_flush_wait_ns_total"),
-        ("coalesced extra ops", "treedb.cache.flush_backlog_coalescing.admitted_extra_ops_total"),
+        ("coalesced extra ops", "flush_backlog_coalescing.admitted_extra_ops_total"),
     ]
     lines.append("| Row | " + " | ".join(c[0] for c in counter_cols) + " |")
     lines.append("|---|" + "|".join("---:" for _ in counter_cols) + "|")
@@ -485,6 +498,13 @@ TreeDB:
   maindb/value_vlog: total=0 B files=1
   maindb/leaf_vlog: total=2 MiB files=1 value=2 MiB
 ```
+
+## TreeDB Selected Stats (End of Run)
+
+```text
+TreeDB:
+  flush_backlog_coalescing.admitted_extra_ops_total: 42
+```
 """,
             encoding="utf-8",
         )
@@ -520,6 +540,7 @@ TreeDB:
         assert got.ops_per_sec["random_write"] == 30.0
         assert got.checkpoints["After Run"] == "4.00s", got.checkpoints
         assert got.disk_usage["maindb/leaf_vlog"].startswith("total=2 MiB")
+        assert got.counters["flush_backlog_coalescing.admitted_extra_ops_total"] == "42"
         md = render_markdown(root, rows, "span_native_c4")
         assert "TreeDB M14 final-gate matrix summary" in md
         assert "span_native_c4" in md


### PR DESCRIPTION
## Objective

Close M14 for #2774 / parent #2743 with same-host final evidence and a production/default-readiness decision for the post-M7 TreeDB span-run/span-native random-write ceiling breaker.

## Scope / non-scope

Includes:
- Final report: `docs/TREEDB_RANDOM_WRITE_CEILING_BREAKER_M14_REPORT.md`.
- Repro harness: `scripts/treedb_m14_final_gate.sh`.
- Matrix parser: `scripts/treedb_m14_matrix_summary.py`.
- Link from `docs/TREEDB_RANDOM_WRITE_CEILING_BREAKER_TODO.md`.

Excludes runtime TreeDB architecture or default changes. This PR does not merge itself; coordinator owns final merge.

## Local validation

Latest local validation for head `3c942bbb5eeebf59c9516d3ece4febcabaa044bf`:

```sh
git diff --check
bash -n scripts/treedb_m14_final_gate.sh
python3 scripts/treedb_m14_matrix_summary.py --self-test
go test ./cmd/unified_bench ./cmd/benchprof ./internal/benchprof -count=1
```

## CI / AI review status

- Latest head: `3c942bbb5eeebf59c9516d3ece4febcabaa044bf`.
- CI: all latest-head GitHub checks are green.
- CodeRabbit: actionable findings addressed/resolved; latest re-request returned no new actionable comments.
- Codex: latest-head review for `3c942bbb5e` reported no major issues.
- Copilot: requested; no visible review response.
- Review threads: all resolved.

## Final evidence and decision

# TreeDB random-write ceiling breaker M14 final gate

Issue: #2774 (M14). Parent tracker: #2743. Runtime SHA:
`e0a71320db7a727b451ebdd4b8254853cfc072a2` (M13 / PR #2780 merged).

## Decision

**Result: the span-run/span-native stack materially reduced the measured
random-write bottleneck when explicitly enabled, but it is not ready to become
the default configuration.** Keep `FlushApplySpanNative` and
`FlushBacklogCoalescing` opt-in/default-off for now.

Why the ceiling-breaker is real:

- On the same host/SHA, `span_native_c4` improved `random_write` by **+94.11%**
  versus current unconfigured defaults (`145,427 -> 282,282 ops/s`) while also
  reducing old-leaf decode bytes/op (`1603 -> 1395`), leaf merges/op
  (`0.355 -> 0.318`), and append frames/op (`0.355 -> 0.318`).
- Higher concurrency continued to move the write ceiling: `span_native_c16`
  reached **312,391 random_write ops/s** and **766,645 batch_random ops/s**.
- The intended path ran: c2/c4/c8/c16 rows used span-native for ~29.2M-29.7M
  ops. Non-zero fallback reasons were only the expected M12
  `close_or_checkpoint` drain fallbacks; root mismatch, output ownership, and
  reducer validation fallbacks stayed zero.
- Writer-side waiting improved on the useful rows: foreground-assist wait fell
  from **77.7s** on defaults to **32.5s** at c4 and **26.9s** at c16; stall
  waits were zero in all rows.

Why default-on is still blocked:

- `span_native_c1` is a clear unsafe default shape: `random_write` regressed
  **-20.19%**, `batch_random` regressed versus defaults, and foreground-assist
  wait increased to **106.0s**.
- Checkpoint-inclusive latency is not uniformly better. Useful span-native rows
  improved throughput, but post-run checkpoint time was generally higher than
  the default row (`6.49s` default vs `8.17s-9.45s` for c4/c8/c16/cache-off;
  `11.50s` for c4 without backlog). Random-write checkpoint time also rose
  (`2.70s` default vs `7.01s-9.22s` useful span-native rows).
- c8/c16 provide the highest throughput but increase CPU samples and
  contention-profile totals compared with c4. They are throughput-ceiling rows,
  not conservative production defaults.
- The cache-disabled row was strong for this write-only matrix, but it is not a
  default recommendation because read/scan guardrails were not part of M14.

Recommended rollout posture:

- **Default:** unchanged/off.
- **Write-heavy experimental opt-in:** use span-native plus backlog coalescing
  with `FlushApplyConcurrency >= 4` after workload-specific checkpoint and CPU
  profiling. c4 is the conservative balanced row; c8/c16 are throughput-ceiling
  rows with more contention/CPU evidence to watch.
- **Rollback knobs:** omit/disable `-treedb-flush-apply-span-native`, omit/disable
  `-treedb-flush-backlog-coalescing`, lower `-treedb-flush-apply-concurrency`,
  or return to the unconfigured defaults. The outer-leaf read cache can be
  disabled for write-only experiments (`-treedb-leaf-page-read-cache-entries=-1`)
  but should not be changed as a read-path default from this matrix alone.

## Evidence identity

Remote host and artifact root:

- host: redacted remote 4TB benchmark host (`mikers-B560-DS3H-AC-Y1`)
- kernel: Linux 6.8.0-124-generic x86_64
- Go: `go1.25.0 linux/amd64`
- CPU workers visible: `nproc=12`
- artifact root: `/mnt/fast4tb/gomap-profiles/2774_m14_matrix_20260616_132256`
- generated summaries:
  - `/mnt/fast4tb/gomap-profiles/2774_m14_matrix_20260616_132256/m14_matrix_summary.md`
  - `/mnt/fast4tb/gomap-profiles/2774_m14_matrix_20260616_132256/m14_matrix_summary.json`

Primary command shape for each 10M row:

```sh
./bin/unified-bench \
  -dbs treedb \
  -test sequential_write,batch_random,random_write \
  -keys 10000000 \
  -valsize 128 \
  -batchsize 8000 \
  -profile-dir "$OUT" \
  -path-label m8-m14-10mm-gate \
  -treedb-journal-lanes=1 \
  -checkpoint-between-tests \
  -progress=false
./bin/benchprof -profiles-dir "$OUT"
```

`FlushApplyConcurrency=1,2,4,8,16` rows also used:

```sh
-treedb-flush-apply-min-entries=1 \
-treedb-flush-apply-min-spans=1 \
-treedb-flush-apply-min-bytes=1 \
-treedb-flush-apply-span-native \
-treedb-flush-backlog-coalescing
```

Cache-axis note: TreeDB currently has a fixed/default-env outer-leaf read cache
(`outer_leaf_read_cache_entries=default/env`, effective 32768 in the run) and a
cache-disabled mode. There is not a separate adaptive outer-leaf read-cache mode;
the adaptive row in this gate is the M11 backlog-coalescing controller.

## Throughput and checkpoint summary

| Row | Concurrency | Span-native | Backlog | Cache | Seq ops/s | Batch ops/s | Random ops/s | Δ random vs default | Checkpoint batch | Checkpoint random | Post-run checkpoint |
|---|---:|---:|---:|---|---:|---:|---:|---:|---:|---:|---:|
| `default_unconfigured` | default | false | false | default | 2,560,082 | 322,644 | 145,427 | +0.00% | 1.16s | 2.70s | 6.49s |
| `legacy_parallel_c4` | 4 | false | false | default | 2,732,468 | 613,337 | 226,416 | +55.69% | 814.25ms | 10.51s | 7.58s |
| `span_native_c1` | 1 | true | true | default | 2,685,554 | 247,190 | 116,067 | -20.19% | 1.15s | 3.50s | 8.95s |
| `span_native_c2` | 2 | true | true | default | 2,729,639 | 609,965 | 215,099 | +47.91% | 815.96ms | 12.56s | 5.78s |
| `span_native_c4` | 4 | true | true | default | 2,710,831 | 696,101 | 282,282 | +94.11% | 824.29ms | 8.20s | 9.22s |
| `span_native_c8` | 8 | true | true | default | 2,705,301 | 704,500 | 309,287 | +112.68% | 826.92ms | 7.21s | 9.10s |
| `span_native_c16` | 16 | true | true | default | 2,725,757 | 766,645 | 312,391 | +114.81% | 833.62ms | 7.01s | 8.17s |
| `span_native_c4_no_backlog` | 4 | true | false | default | 2,728,485 | 680,940 | 276,950 | +90.44% | 831.71ms | 8.11s | 11.50s |
| `span_native_c4_cache_disabled` | 4 | true | true | disabled | 2,747,611 | 700,046 | 313,033 | +115.25% | 818.65ms | 7.38s | 9.45s |

## Bottleneck proof counters

| Row | old leaf B/op | leaf merges/op | append frames/op | apply ops/span | single-op span ratio | target split leaves | span-native used ops | fallbacks | close/chkp fallback ops | root reduce ns | publish ns |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| `default_unconfigured` | 1,603 | 0.355 | 0.355 |  |  | 0 | 0 | 0 | 0 | 356,981 | 18,513,955,885 |
| `legacy_parallel_c4` | 1,453 | 0.330 | 0.330 | 3.033 | 0.633 | 0 | 0 | 734 | 0 | 346,427 | 15,514,455,153 |
| `span_native_c1` | 1,602 | 0.355 | 0.355 | 2.821 | 0.682 | 0 | 29,708,113 | 12 | 218,612 | 6,372,102,050 | 21,811,431,150 |
| `span_native_c2` | 1,378 | 0.316 | 0.316 | 3.167 | 0.610 | 0 | 29,688,490 | 10 | 218,611 | 4,081,879,756 | 11,235,511,751 |
| `span_native_c4` | 1,395 | 0.318 | 0.318 | 3.146 | 0.619 | 0 | 29,688,511 | 10 | 218,612 | 4,363,775,346 | 14,362,201,706 |
| `span_native_c8` | 1,406 | 0.320 | 0.321 | 3.123 | 0.619 | 0 | 29,196,607 | 19 | 710,980 | 4,319,757,006 | 15,358,903,079 |
| `span_native_c16` | 1,407 | 0.320 | 0.321 | 3.121 | 0.619 | 0 | 29,196,574 | 20 | 711,046 | 4,320,975,055 | 14,126,573,975 |
| `span_native_c4_no_backlog` | 1,472 | 0.332 | 0.332 | 3.014 | 0.644 | 0 | 29,698,193 | 10 | 218,612 | 5,093,285,131 | 15,133,140,814 |
| `span_native_c4_cache_disabled` | 1,368 | 0.313 | 0.314 | 3.192 | 0.607 | 0 | 29,686,165 | 10 | 218,612 | 4,089,201,403 | 13,555,548,916 |

Fallback reason detail:

| Row | Non-zero fallback reasons |
|---|---|
| `default_unconfigured` | none |
| `legacy_parallel_c4` | `span_native_not_implemented`: 29,914,354 ops / 9,863,096 spans |
| `span_native_c1` | `close_or_checkpoint`: 218,612 ops / 198,405 spans |
| `span_native_c2` | `close_or_checkpoint`: 218,611 ops / 198,080 spans |
| `span_native_c4` | `close_or_checkpoint`: 218,612 ops / 198,048 spans |
| `span_native_c8` | `close_or_checkpoint`: 710,980 ops / 576,298 spans |
| `span_native_c16` | `close_or_checkpoint`: 711,046 ops / 584,373 spans |
| `span_native_c4_no_backlog` | `close_or_checkpoint`: 218,612 ops / 198,061 spans |
| `span_native_c4_cache_disabled` | `close_or_checkpoint`: 218,612 ops / 198,032 spans |

## Writer stall / foreground assist / backlog counters

| Row | fg assist calls | fg assist flushes | fg assist wait ns | active assist skips | progress wait ns | stall waits | coordinator blocking fallbacks | hard-overload fallbacks | queue backlog bytes |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| `default_unconfigured` | 13 | 3 | 77,693,578,529 | 0 | 0 | 0 | 13 | 0 | 0 |
| `legacy_parallel_c4` | 6 | 0 | 44,435,758,710 | 2,467,377 | 0 | 0 | 6 | 6 | 0 |
| `span_native_c1` | 14 | 4 | 105,993,401,056 | 0 | 0 | 0 | 14 | 0 | 0 |
| `span_native_c2` | 6 | 0 | 48,451,003,280 | 2,467,375 | 0 | 0 | 6 | 6 | 0 |
| `span_native_c4` | 5 | 0 | 32,467,058,418 | 2,104,618 | 0 | 0 | 5 | 5 | 0 |
| `span_native_c8` | 5 | 0 | 27,885,986,352 | 1,917,688 | 0 | 0 | 5 | 4 | 0 |
| `span_native_c16` | 5 | 0 | 26,864,508,284 | 1,886,376 | 0 | 0 | 5 | 4 | 0 |
| `span_native_c4_no_backlog` | 5 | 0 | 34,727,494,749 | 2,104,728 | 0 | 0 | 5 | 5 | 0 |
| `span_native_c4_cache_disabled` | 5 | 0 | 31,334,449,162 | 1,973,916 | 0 | 0 | 5 | 5 | 0 |

Backlog coalescing counters:

| Row | admitted runs | extra memtables | extra ops | selected memtables max | selected ops max | last single-op ratio | last ops/span |
|---|---:|---:|---:|---:|---:|---:|---:|
| `default_unconfigured` | 0 | 0 | 0 | 0 | 0 | 0.000000 | 0.000000 |
| `legacy_parallel_c4` | 0 | 0 | 0 | 0 | 0 | 0.000000 | 0.000000 |
| `span_native_c1` | 0 | 0 | 0 | 0 | 0 | 0.502361 | 8.030750 |
| `span_native_c2` | 1 | 16 | 493,448 | 48 | 1,480,344 | 0.569091 | 3.962833 |
| `span_native_c4` | 2 | 32 | 986,896 | 48 | 1,480,344 | 0.595205 | 3.532906 |
| `span_native_c8` | 2 | 32 | 986,896 | 48 | 1,480,344 | 0.603832 | 3.409103 |
| `span_native_c16` | 2 | 32 | 986,896 | 48 | 1,480,344 | 0.603721 | 3.413830 |
| `span_native_c4_no_backlog` | 0 | 0 | 0 | 0 | 0 | 0.000000 | 0.000000 |
| `span_native_c4_cache_disabled` | 2 | 32 | 986,896 | 48 | 1,480,344 | 0.591578 | 3.482905 |

## Disk usage at end of run

| Row | index.db | WAL | value_vlog | leaf_vlog |
|---|---:|---:|---:|---:|
| `default_unconfigured` | 606 MiB | total=12 B files=1 other=12 B | total=0 B files=1 | total=3.7 GiB files=232 value=3.7 GiB other=24 KiB |
| `legacy_parallel_c4` | 484 MiB | total=12 B files=1 other=12 B | total=0 B files=1 | total=3.4 GiB files=216 value=3.4 GiB other=22 KiB |
| `span_native_c1` | 606 MiB | total=12 B files=1 other=12 B | total=0 B files=1 | total=3.7 GiB files=232 value=3.7 GiB other=24 KiB |
| `span_native_c2` | 417 MiB | total=12 B files=1 other=12 B | total=0 B files=1 | total=3.3 GiB files=208 value=3.3 GiB other=21 KiB |
| `span_native_c4` | 462 MiB | total=12 B files=1 other=12 B | total=0 B files=1 | total=3.3 GiB files=210 value=3.3 GiB other=21 KiB |
| `span_native_c8` | 447 MiB | total=12 B files=1 other=12 B | total=0 B files=1 | total=3.3 GiB files=210 value=3.3 GiB other=21 KiB |
| `span_native_c16` | 436 MiB | total=12 B files=1 other=12 B | total=0 B files=1 | total=3.4 GiB files=210 value=3.4 GiB other=21 KiB |
| `span_native_c4_no_backlog` | 510 MiB | total=12 B files=1 other=12 B | total=0 B files=1 | total=3.5 GiB files=220 value=3.5 GiB other=22 KiB |
| `span_native_c4_cache_disabled` | 443 MiB | total=12 B files=1 other=12 B | total=0 B files=1 | total=3.3 GiB files=208 value=3.3 GiB other=21 KiB |

## Allocation and profile top rows

Random-write allocation totals and top sampled allocation-object rows:

| Row | alloc-space total | alloc-objects total | top alloc-object rows |
|---|---:|---:|---|
| `default_unconfigured` | 2.71GB | 9,232,395 | `Zipper.mergeLeaf` 1,974,391; `cachingLeafPageLog.AppendLeafPages` 1,835,089; `putValueLogPtrsNoClear` 1,835,047 |
| `legacy_parallel_c4` | 3108.33MB | 24,681,672 | `DB.appendValueLogOneInternal` 10,043,614; `putVlogPreparedFrames` 7,121,739; `putValueLogPtrsNoClear` 1,835,047 |
| `span_native_c1` | 2537.35MB | 9,534,278 | `putValueLogRecordsNoClear` 2,140,891; `Zipper.mergeLeaf` 1,998,970; `putValueLogPtrsNoClear` 1,900,587 |
| `span_native_c2` | 3392MB | 22,969,237 | `DB.appendValueLogOneInternal` 9,437,399; `putVlogPreparedFrames` 6,400,829; `putValueLogPtrsNoClear` 1,747,667 |
| `span_native_c4` | 3595.10MB | 20,285,794 | `DB.appendValueLogOneInternal` 8,306,878; `putVlogPreparedFrames` 5,614,379; `cachingLeafPageLog.AppendLeafPages` 1,507,397 |
| `span_native_c8` | 3491.32MB | 21,927,356 | `DB.appendValueLogOneInternal` 8,863,944; `putVlogPreparedFrames` 5,963,910; `putValueLogRecordsNoClear` 1,638,437 |
| `span_native_c16` | 3498.51MB | 20,117,156 | `DB.appendValueLogOneInternal` 8,274,114; `putVlogPreparedFrames` 5,417,767; `putValueLogPtrsNoClear` 1,376,286 |
| `span_native_c4_no_backlog` | 3203.92MB | 21,591,960 | `DB.appendValueLogOneInternal` 8,749,251; `putVlogPreparedFrames` 5,483,304; `Zipper.mergeLeaf` 1,646,692 |
| `span_native_c4_cache_disabled` | 3530.94MB | 20,863,793 | `DB.appendValueLogOneInternal` 8,962,254; `putVlogPreparedFrames` 5,483,304; `cachingLeafPageLog.AppendLeafPages` 1,474,628 |

Random-write CPU/block/mutex/checkpoint top rows:

| Row | CPU total/top | block total/top | mutex total/top | post-run checkpoint CPU total/top |
|---|---|---|---|---|
| `default_unconfigured` | 101.39s; `lz4block.decodeBlock` 9.04s; `CompressBlock` 7.71s; `runtime.memmove` 5.95s | 1702.58s; `runtime.selectgo` 740.11s; `sync.Mutex.Lock` 641.85s; `WaitGroup.Wait` 168.98s | 684.50s; `sync.Mutex.Unlock` 681.91s | 2.21s; `linux.Syscall6` 0.24s; `runtime.memmove` 0.20s; `lz4block.decodeBlock` 0.19s |
| `legacy_parallel_c4` | 90.36s; `lz4block.decodeBlock` 8.22s; `CompressBlock` 6.77s; `runtime.memmove` 4.66s | 794.75s; `runtime.selectgo` 476.79s; `chanrecv2` 104.85s; `chanrecv1` 88.85s | 47.37s; `sync.Mutex.Unlock` 47.33s | 2.31s; `linux.Syscall6` 0.25s; `lz4block.decodeBlock` 0.20s; `runtime.memmove` 0.17s |
| `span_native_c1` | 78.79s; `lz4block.decodeBlock` 8.89s; `CompressBlock` 6.07s; `cmpbody` 4.20s | 1292.96s; `runtime.selectgo` 941.31s; `chanrecv1` 171.86s; `sync.Mutex.Lock` 99.13s | 92.25s; `sync.Mutex.Unlock` 89.38s | 2.48s; `linux.Syscall6` 0.36s; `runtime.memmove` 0.17s; `lz4block.decodeBlock` 0.15s |
| `span_native_c2` | 75.93s; `lz4block.decodeBlock` 7.76s; `CompressBlock` 5.69s; `cmpbody` 4.15s | 749.34s; `runtime.selectgo` 487.73s; `chanrecv1` 94.17s; `WaitGroup.Wait` 75.80s | 46.80s; `sync.Mutex.Unlock` 46.79s | 1.99s; `runtime.memmove` 0.20s; `lz4block.decodeBlock` 0.16s; `crc32IEEEVPCLMUL512` 0.12s |
| `span_native_c4` | 77.01s; `lz4block.decodeBlock` 7.54s; `CompressBlock` 5.91s; `cmpbody` 3.96s | 637.53s; `runtime.selectgo` 383.58s; `chanrecv2` 83.49s; `chanrecv1` 71.05s | 36.89s; `sync.Mutex.Unlock` 36.86s | 10.84s; `lz4block.decodeBlock` 0.95s; `CompressBlock` 0.79s; `runtime.memmove` 0.66s |
| `span_native_c8` | 89.56s; `lz4block.decodeBlock` 8.36s; `CompressBlock` 6.76s; `runtime.memmove` 4.35s | 676.23s; `runtime.selectgo` 332.99s; `chanrecv2` 166.11s; `chanrecv1` 64.96s | 57.16s; `sync.Mutex.Unlock` 57.02s | 7.79s; `lz4block.decodeBlock` 0.66s; `CompressBlock` 0.65s; `runtime.procyieldAsm` 0.43s |
| `span_native_c16` | 94.87s; `lz4block.decodeBlock` 8.57s; `CompressBlock` 6.84s; `runtime.memmove` 5.07s | 814.65s; `runtime.selectgo` 352.69s; `chanrecv2` 250.78s; `sync.Mutex.Lock` 93.72s | 93.02s; `sync.Mutex.Unlock` 92.81s | 8.52s; `lz4block.decodeBlock` 0.67s; `CompressBlock` 0.54s; `runtime.memmove` 0.44s |
| `span_native_c4_no_backlog` | 82.28s; `lz4block.decodeBlock` 8.08s; `CompressBlock` 6.55s; `runtime.memmove` 4.31s | 649.75s; `runtime.selectgo` 388.66s; `chanrecv2` 80.60s; `chanrecv1` 72.81s | 44.09s; `sync.Mutex.Unlock` 40.44s; `RWMutex.RUnlock` 3.63s | 11.42s; `lz4block.decodeBlock` 0.98s; `CompressBlock` 0.92s; `runtime.memmove` 0.68s |
| `span_native_c4_cache_disabled` | 73.21s; `lz4block.decodeBlock` 7.92s; `CompressBlock` 6.42s; `cmpbody` 3.90s | 549.41s; `runtime.selectgo` 322.63s; `chanrecv2` 72.98s; `chanrecv1` 64.59s | 35.29s; `sync.Mutex.Unlock` 35.26s | 5.99s; `lz4block.decodeBlock` 0.61s; `CompressBlock` 0.49s; `runtime.memmove` 0.31s |

## Notes and caveats

- The `span_native_c4_cache_disabled` row is a useful write-ceiling guardrail,
  not a default-read-cache decision. It should be followed by read/scan/reopen
  guardrails before changing cache defaults.
- `span_native_c1` proves span-native should not be default-enabled without a
  concurrency/config gate; it used span-native but lost the apply parallelism
  needed to offset reducer/prepare costs.
- c8/c16 reduce foreground assist wait and improve throughput, but contention
  and CPU profile totals rise. These rows should be treated as throughput knobs,
  not universal defaults.
- The matrix used 128-byte values, so ordinary `value_vlog` remained empty;
  persistent outer leaves are in `leaf_vlog` and remained durable storage.


Tracks #2774. Parent tracker #2743.
