### PR TITLE
TreeDB B2: add fail-closed flush admission policy

### DIFF
--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -347,6 +347,8 @@ type DB struct {
 	flushApplyRetries                             atomic.Uint64
 	flushApplyMismatches                          atomic.Uint64
 
+	flushAdmission FlushAdmissionDecision
+
 	flushApplyConcurrency int
 	flushApplyMinEntries  int
 	flushApplyMinSpans    int
@@ -987,6 +989,14 @@ type Options struct {
 	// of the consumer. Values <= 0 use FlushBuildConcurrency.
 	FlushBuildPrefetchUnits int
 
+	// FlushAdmissionPolicy selects how TreeDB admits the span-native/backlog
+	// flush/apply candidate path. The zero value (explicit) preserves current
+	// defaults: span-native/backlog/concurrency stay off unless existing explicit
+	// knobs request them. Off force-disables the candidate path. Auto is the
+	// future-default selector and currently fails closed for low concurrency and
+	// unresolved checkpoint debt.
+	FlushAdmissionPolicy FlushAdmissionPolicy
+
 	// FlushApplyConcurrency enables opt-in M2 parallel COW apply for backend
 	// flush/write batches using a bounded reusable worker pool. It is separate
 	// from FlushBuildConcurrency; values <=1 keep the M2 worker-pool path off.
@@ -1059,6 +1069,9 @@ type Options struct {
 	// FlushBacklogCoalescingMinOldLeafBytesPerOp optionally requires observed
 	// old-leaf decode bytes/op before coalescing (0=disabled).
 	FlushBacklogCoalescingMinOldLeafBytesPerOp float64
+
+	flushAdmissionDecision   FlushAdmissionDecision
+	flushAdmissionNormalized bool
 
 	// JournalLanes controls the number of active commit/value log lanes (0=default).
 	// Max supported lanes is 255; value-log segment sequence per lane is capped at 8,388,607.
@@ -1394,6 +1407,7 @@ func Open(opts Options) (*DB, error) {
 	if opts.PruneMaxDuration == 0 {
 		opts.PruneMaxDuration = 25 * time.Millisecond
 	}
+	NormalizeFlushAdmissionOptions(&opts)
 	if opts.FlushApplyMinEntries <= 0 {
 		opts.FlushApplyMinEntries = defaultFlushApplyMinEntries
 	}
@@ -1464,6 +1478,9 @@ func validateOptions(opts Options) error {
 	case LeafPageReadCacheWriteAdmissionImmediate, LeafPageReadCacheWriteAdmissionAdaptive:
 	default:
 		return fmt.Errorf("treedb: invalid leaf page read cache write admission policy %d", opts.LeafPageReadCacheWriteAdmission)
+	}
+	if !opts.FlushAdmissionPolicy.Valid() {
+		return fmt.Errorf("treedb: invalid flush admission policy %d", opts.FlushAdmissionPolicy)
 	}
 	if opts.ReadOnly {
 		// Read-only opens never mutate on-disk state, so "unsafe" write options do
@@ -1660,6 +1677,7 @@ func openWithLock(opts Options, lock *lockfile.Lock) (*DB, error) {
 		indexAdaptiveLeafEncoding:      opts.IndexAdaptiveLeafEncoding,
 		piggybackCompaction:            !opts.DisablePiggybackCompaction,
 		maintenanceOpsPerCoalesce:      opts.MaintenanceOpsPerCoalesce,
+		flushAdmission:                 FlushAdmissionDecisionForOptions(opts),
 		flushApplyConcurrency:          flushApplyConcurrency,
 		flushApplyMinEntries:           opts.FlushApplyMinEntries,
 		flushApplyMinSpans:             opts.FlushApplyMinSpans,

--- a/TreeDB/db/flush_admission_policy.go
+++ b/TreeDB/db/flush_admission_policy.go
@@ -126,27 +126,13 @@ func computeFlushAdmissionDecision(opts *Options) FlushAdmissionDecision {
 	}
 
 	if !policy.Valid() {
-		opts.FlushApplyConcurrency = 0
-		opts.FlushApplySpanNative = false
-		opts.FlushBacklogCoalescing = false
-		decision.Admitted = false
-		decision.Reason = FlushAdmissionReasonInvalidPolicy
-		decision.FlushApplyConcurrency = 0
-		decision.FlushApplySpanNative = false
-		decision.FlushBacklogCoalescing = false
+		decision.disableAll(opts, FlushAdmissionReasonInvalidPolicy)
 		return decision
 	}
 
 	switch policy {
 	case FlushAdmissionPolicyOff:
-		opts.FlushApplyConcurrency = 0
-		opts.FlushApplySpanNative = false
-		opts.FlushBacklogCoalescing = false
-		decision.Admitted = false
-		decision.Reason = FlushAdmissionReasonPolicyOff
-		decision.FlushApplyConcurrency = 0
-		decision.FlushApplySpanNative = false
-		decision.FlushBacklogCoalescing = false
+		decision.disableAll(opts, FlushAdmissionReasonPolicyOff)
 		return decision
 	case FlushAdmissionPolicyExplicit:
 		if opts.FlushApplySpanNative || opts.FlushBacklogCoalescing || effectiveConcurrency > 1 {
@@ -166,14 +152,7 @@ func computeFlushAdmissionDecision(opts *Options) FlushAdmissionDecision {
 			reasons = append(reasons, FlushAdmissionReasonCheckpointDebt)
 		}
 		if len(reasons) > 0 {
-			opts.FlushApplyConcurrency = 0
-			opts.FlushApplySpanNative = false
-			opts.FlushBacklogCoalescing = false
-			decision.Admitted = false
-			decision.Reason = strings.Join(reasons, ",")
-			decision.FlushApplyConcurrency = 0
-			decision.FlushApplySpanNative = false
-			decision.FlushBacklogCoalescing = false
+			decision.disableAll(opts, strings.Join(reasons, ","))
 			return decision
 		}
 
@@ -192,16 +171,22 @@ func computeFlushAdmissionDecision(opts *Options) FlushAdmissionDecision {
 		return decision
 	default:
 		// Defensive fallback; policy.Valid handled this above.
+		decision.disableAll(opts, FlushAdmissionReasonInvalidPolicy)
+		return decision
+	}
+}
+
+func (d *FlushAdmissionDecision) disableAll(opts *Options, reason string) {
+	if opts != nil {
 		opts.FlushApplyConcurrency = 0
 		opts.FlushApplySpanNative = false
 		opts.FlushBacklogCoalescing = false
-		decision.Admitted = false
-		decision.Reason = FlushAdmissionReasonInvalidPolicy
-		decision.FlushApplyConcurrency = 0
-		decision.FlushApplySpanNative = false
-		decision.FlushBacklogCoalescing = false
-		return decision
 	}
+	d.Admitted = false
+	d.Reason = reason
+	d.FlushApplyConcurrency = 0
+	d.FlushApplySpanNative = false
+	d.FlushBacklogCoalescing = false
 }
 
 func (d FlushAdmissionDecision) withStatsDefaults() FlushAdmissionDecision {

--- a/TreeDB/db/flush_admission_policy.go
+++ b/TreeDB/db/flush_admission_policy.go
@@ -1,0 +1,222 @@
+package db
+
+import (
+	"fmt"
+	"strings"
+)
+
+// FlushAdmissionPolicy controls how TreeDB admits the span-native/backlog
+// flush/apply candidate path. The zero value preserves the pre-existing
+// explicit-opt-in behavior: defaults remain off, and callers that set the
+// existing FlushApply*/FlushBacklog* knobs keep their requested behavior.
+type FlushAdmissionPolicy uint8
+
+const (
+	// FlushAdmissionPolicyExplicit preserves existing explicit knobs. This is the
+	// default policy and does not infer or enable span-native/backlog behavior.
+	FlushAdmissionPolicyExplicit FlushAdmissionPolicy = iota
+	// FlushAdmissionPolicyOff force-disables span-native, backlog coalescing, and
+	// flush-apply worker-pool concurrency as a rollback/fail-closed policy.
+	FlushAdmissionPolicyOff
+	// FlushAdmissionPolicyAuto is the future-default selector path. It currently
+	// fails closed while checkpoint debt remains unresolved and when configured
+	// concurrency is too low to avoid the known c1 regression shape.
+	FlushAdmissionPolicyAuto
+)
+
+const (
+	FlushAdmissionReasonNoExplicitOptIn = "no_explicit_opt_in"
+	FlushAdmissionReasonExplicitOptIn   = "explicit_opt_in"
+	FlushAdmissionReasonPolicyOff       = "policy_off"
+	FlushAdmissionReasonAutoAdmitted    = "auto_admitted"
+	FlushAdmissionReasonLowConcurrency  = "low_concurrency"
+	FlushAdmissionReasonCheckpointDebt  = "checkpoint_debt_unresolved"
+	FlushAdmissionReasonInvalidPolicy   = "invalid_policy"
+)
+
+// Keep the unresolved #2794/B1 checkpoint debt represented in code, not only in
+// benchmark notes. A future checkpoint-debt mitigation can flip this seam (or
+// replace it with a measured runtime signal) and the auto path will still keep
+// the low-concurrency guardrail below.
+const flushAdmissionCheckpointDebtResolved = false
+
+// FlushAdmissionDecision is the normalized admission result reported through
+// DB.Stats and benchmark option reports.
+type FlushAdmissionDecision struct {
+	Policy                 FlushAdmissionPolicy
+	Admitted               bool
+	Reason                 string
+	FlushApplyConcurrency  int
+	FlushApplySpanNative   bool
+	FlushBacklogCoalescing bool
+}
+
+func (p FlushAdmissionPolicy) String() string {
+	switch p {
+	case FlushAdmissionPolicyExplicit:
+		return "explicit"
+	case FlushAdmissionPolicyOff:
+		return "off"
+	case FlushAdmissionPolicyAuto:
+		return "auto"
+	default:
+		return fmt.Sprintf("unknown(%d)", p)
+	}
+}
+
+func (p FlushAdmissionPolicy) Valid() bool {
+	switch p {
+	case FlushAdmissionPolicyExplicit, FlushAdmissionPolicyOff, FlushAdmissionPolicyAuto:
+		return true
+	default:
+		return false
+	}
+}
+
+// ParseFlushAdmissionPolicy parses off|explicit|auto policy values. Empty and
+// "default" preserve the current explicit-opt-in default.
+func ParseFlushAdmissionPolicy(raw string) (FlushAdmissionPolicy, error) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "", "default", "unset", "explicit":
+		return FlushAdmissionPolicyExplicit, nil
+	case "off", "false", "0", "disabled", "disable":
+		return FlushAdmissionPolicyOff, nil
+	case "auto", "adaptive":
+		return FlushAdmissionPolicyAuto, nil
+	default:
+		return FlushAdmissionPolicyExplicit, fmt.Errorf("unsupported flush admission policy %q (expected off|explicit|auto)", raw)
+	}
+}
+
+// NormalizeFlushAdmissionOptions applies the fail-closed admission seam to opts
+// and stores the decision in the options for Open/Stats. It is idempotent so
+// public wrappers can normalize before passing options to the backend without
+// losing the original decline reason.
+func NormalizeFlushAdmissionOptions(opts *Options) FlushAdmissionDecision {
+	if opts == nil {
+		return FlushAdmissionDecision{Policy: FlushAdmissionPolicyExplicit, Reason: FlushAdmissionReasonNoExplicitOptIn}
+	}
+	if opts.flushAdmissionNormalized {
+		return opts.flushAdmissionDecision.withStatsDefaults()
+	}
+
+	decision := computeFlushAdmissionDecision(opts)
+	opts.flushAdmissionDecision = decision
+	opts.flushAdmissionNormalized = true
+	return decision.withStatsDefaults()
+}
+
+// FlushAdmissionDecisionForOptions returns the decision already stored in opts,
+// or computes the decision for a copy without mutating the caller's options.
+func FlushAdmissionDecisionForOptions(opts Options) FlushAdmissionDecision {
+	if opts.flushAdmissionNormalized {
+		return opts.flushAdmissionDecision.withStatsDefaults()
+	}
+	return NormalizeFlushAdmissionOptions(&opts)
+}
+
+func computeFlushAdmissionDecision(opts *Options) FlushAdmissionDecision {
+	policy := opts.FlushAdmissionPolicy
+	effectiveConcurrency := normalizeFlushApplyConcurrency(opts.FlushApplyConcurrency)
+	decision := FlushAdmissionDecision{
+		Policy:                 policy,
+		FlushApplyConcurrency:  effectiveConcurrency,
+		FlushApplySpanNative:   opts.FlushApplySpanNative,
+		FlushBacklogCoalescing: opts.FlushBacklogCoalescing,
+	}
+
+	if !policy.Valid() {
+		opts.FlushApplyConcurrency = 0
+		opts.FlushApplySpanNative = false
+		opts.FlushBacklogCoalescing = false
+		decision.Admitted = false
+		decision.Reason = FlushAdmissionReasonInvalidPolicy
+		decision.FlushApplyConcurrency = 0
+		decision.FlushApplySpanNative = false
+		decision.FlushBacklogCoalescing = false
+		return decision
+	}
+
+	switch policy {
+	case FlushAdmissionPolicyOff:
+		opts.FlushApplyConcurrency = 0
+		opts.FlushApplySpanNative = false
+		opts.FlushBacklogCoalescing = false
+		decision.Admitted = false
+		decision.Reason = FlushAdmissionReasonPolicyOff
+		decision.FlushApplyConcurrency = 0
+		decision.FlushApplySpanNative = false
+		decision.FlushBacklogCoalescing = false
+		return decision
+	case FlushAdmissionPolicyExplicit:
+		if opts.FlushApplySpanNative || opts.FlushBacklogCoalescing || effectiveConcurrency > 1 {
+			decision.Admitted = true
+			decision.Reason = FlushAdmissionReasonExplicitOptIn
+		} else {
+			decision.Admitted = false
+			decision.Reason = FlushAdmissionReasonNoExplicitOptIn
+		}
+		return decision
+	case FlushAdmissionPolicyAuto:
+		reasons := make([]string, 0, 2)
+		if effectiveConcurrency <= 1 {
+			reasons = append(reasons, FlushAdmissionReasonLowConcurrency)
+		}
+		if !flushAdmissionCheckpointDebtResolved {
+			reasons = append(reasons, FlushAdmissionReasonCheckpointDebt)
+		}
+		if len(reasons) > 0 {
+			opts.FlushApplyConcurrency = 0
+			opts.FlushApplySpanNative = false
+			opts.FlushBacklogCoalescing = false
+			decision.Admitted = false
+			decision.Reason = strings.Join(reasons, ",")
+			decision.FlushApplyConcurrency = 0
+			decision.FlushApplySpanNative = false
+			decision.FlushBacklogCoalescing = false
+			return decision
+		}
+
+		// Unreachable while checkpoint debt remains unresolved. Keep the admission
+		// side explicit for #2794/#2788: if the debt gate is resolved later, auto
+		// chooses the measured span-native/backlog candidate only with safe
+		// configured concurrency.
+		opts.FlushApplyConcurrency = effectiveConcurrency
+		opts.FlushApplySpanNative = true
+		opts.FlushBacklogCoalescing = true
+		decision.Admitted = true
+		decision.Reason = FlushAdmissionReasonAutoAdmitted
+		decision.FlushApplyConcurrency = effectiveConcurrency
+		decision.FlushApplySpanNative = true
+		decision.FlushBacklogCoalescing = true
+		return decision
+	default:
+		// Defensive fallback; policy.Valid handled this above.
+		opts.FlushApplyConcurrency = 0
+		opts.FlushApplySpanNative = false
+		opts.FlushBacklogCoalescing = false
+		decision.Admitted = false
+		decision.Reason = FlushAdmissionReasonInvalidPolicy
+		decision.FlushApplyConcurrency = 0
+		decision.FlushApplySpanNative = false
+		decision.FlushBacklogCoalescing = false
+		return decision
+	}
+}
+
+func (d FlushAdmissionDecision) withStatsDefaults() FlushAdmissionDecision {
+	if !d.Policy.Valid() {
+		if d.Reason == "" {
+			d.Reason = FlushAdmissionReasonInvalidPolicy
+		}
+		return d
+	}
+	if d.Reason == "" {
+		if d.Admitted {
+			d.Reason = FlushAdmissionReasonExplicitOptIn
+		} else {
+			d.Reason = FlushAdmissionReasonNoExplicitOptIn
+		}
+	}
+	return d
+}

--- a/TreeDB/db/flush_admission_policy_test.go
+++ b/TreeDB/db/flush_admission_policy_test.go
@@ -1,0 +1,185 @@
+package db
+
+import (
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestNormalizeFlushAdmission_DefaultExplicitUnconfiguredStaysOff(t *testing.T) {
+	opts := Options{}
+	decision := NormalizeFlushAdmissionOptions(&opts)
+
+	if decision.Policy != FlushAdmissionPolicyExplicit {
+		t.Fatalf("policy=%s want explicit", decision.Policy)
+	}
+	if decision.Admitted {
+		t.Fatalf("admitted=true want false")
+	}
+	if decision.Reason != FlushAdmissionReasonNoExplicitOptIn {
+		t.Fatalf("reason=%q want %q", decision.Reason, FlushAdmissionReasonNoExplicitOptIn)
+	}
+	if opts.FlushApplySpanNative || opts.FlushBacklogCoalescing || opts.FlushApplyConcurrency != 0 {
+		t.Fatalf("default explicit mutated opts: span=%t backlog=%t concurrency=%d", opts.FlushApplySpanNative, opts.FlushBacklogCoalescing, opts.FlushApplyConcurrency)
+	}
+}
+
+func TestNormalizeFlushAdmission_OffForcesCandidateOff(t *testing.T) {
+	opts := Options{
+		FlushAdmissionPolicy:   FlushAdmissionPolicyOff,
+		FlushApplyConcurrency:  4,
+		FlushApplySpanNative:   true,
+		FlushBacklogCoalescing: true,
+		FlushApplyMinEntries:   1,
+		FlushApplyMinSpans:     1,
+		FlushApplyMinBytes:     1,
+	}
+	decision := NormalizeFlushAdmissionOptions(&opts)
+
+	if decision.Admitted {
+		t.Fatalf("admitted=true want false")
+	}
+	if decision.Reason != FlushAdmissionReasonPolicyOff {
+		t.Fatalf("reason=%q want %q", decision.Reason, FlushAdmissionReasonPolicyOff)
+	}
+	if opts.FlushApplyConcurrency != 0 || opts.FlushApplySpanNative || opts.FlushBacklogCoalescing {
+		t.Fatalf("off policy did not force off: concurrency=%d span=%t backlog=%t", opts.FlushApplyConcurrency, opts.FlushApplySpanNative, opts.FlushBacklogCoalescing)
+	}
+}
+
+func TestNormalizeFlushAdmission_ExplicitOptInKeepsC1Compatibility(t *testing.T) {
+	opts := Options{
+		FlushAdmissionPolicy:   FlushAdmissionPolicyExplicit,
+		FlushApplyConcurrency:  1,
+		FlushApplySpanNative:   true,
+		FlushBacklogCoalescing: true,
+	}
+	decision := NormalizeFlushAdmissionOptions(&opts)
+
+	if !decision.Admitted {
+		t.Fatalf("admitted=false want true")
+	}
+	if decision.Reason != FlushAdmissionReasonExplicitOptIn {
+		t.Fatalf("reason=%q want %q", decision.Reason, FlushAdmissionReasonExplicitOptIn)
+	}
+	if opts.FlushApplyConcurrency != 1 || !opts.FlushApplySpanNative || !opts.FlushBacklogCoalescing {
+		t.Fatalf("explicit policy mutated opt-in opts: concurrency=%d span=%t backlog=%t", opts.FlushApplyConcurrency, opts.FlushApplySpanNative, opts.FlushBacklogCoalescing)
+	}
+	if decision.FlushApplyConcurrency != 0 {
+		t.Fatalf("effective concurrency=%d want 0 for c1", decision.FlushApplyConcurrency)
+	}
+}
+
+func TestNormalizeFlushAdmission_ExplicitOptInKeepsC4Compatibility(t *testing.T) {
+	oldGOMAXPROCS := runtime.GOMAXPROCS(4)
+	defer runtime.GOMAXPROCS(oldGOMAXPROCS)
+
+	opts := Options{
+		FlushAdmissionPolicy:   FlushAdmissionPolicyExplicit,
+		FlushApplyConcurrency:  4,
+		FlushApplySpanNative:   true,
+		FlushBacklogCoalescing: true,
+	}
+	decision := NormalizeFlushAdmissionOptions(&opts)
+
+	if !decision.Admitted {
+		t.Fatalf("admitted=false want true")
+	}
+	if decision.Reason != FlushAdmissionReasonExplicitOptIn {
+		t.Fatalf("reason=%q want %q", decision.Reason, FlushAdmissionReasonExplicitOptIn)
+	}
+	if opts.FlushApplyConcurrency != 4 || !opts.FlushApplySpanNative || !opts.FlushBacklogCoalescing {
+		t.Fatalf("explicit c4 mutated opts: concurrency=%d span=%t backlog=%t", opts.FlushApplyConcurrency, opts.FlushApplySpanNative, opts.FlushBacklogCoalescing)
+	}
+	if decision.FlushApplyConcurrency <= 1 {
+		t.Fatalf("effective concurrency=%d want >1 for c4", decision.FlushApplyConcurrency)
+	}
+}
+
+func TestNormalizeFlushAdmission_AutoDeclinesLowConcurrencyAndCheckpointDebt(t *testing.T) {
+	opts := Options{
+		FlushAdmissionPolicy:   FlushAdmissionPolicyAuto,
+		FlushApplyConcurrency:  1,
+		FlushApplySpanNative:   true,
+		FlushBacklogCoalescing: true,
+	}
+	decision := NormalizeFlushAdmissionOptions(&opts)
+
+	if decision.Admitted {
+		t.Fatalf("admitted=true want false")
+	}
+	for _, want := range []string{FlushAdmissionReasonLowConcurrency, FlushAdmissionReasonCheckpointDebt} {
+		if !strings.Contains(decision.Reason, want) {
+			t.Fatalf("reason=%q missing %q", decision.Reason, want)
+		}
+	}
+	if opts.FlushApplyConcurrency != 0 || opts.FlushApplySpanNative || opts.FlushBacklogCoalescing {
+		t.Fatalf("auto decline did not force off: concurrency=%d span=%t backlog=%t", opts.FlushApplyConcurrency, opts.FlushApplySpanNative, opts.FlushBacklogCoalescing)
+	}
+}
+
+func TestNormalizeFlushAdmission_AutoDeclinesUnresolvedCheckpointDebtAtC4(t *testing.T) {
+	oldGOMAXPROCS := runtime.GOMAXPROCS(4)
+	defer runtime.GOMAXPROCS(oldGOMAXPROCS)
+
+	opts := Options{
+		FlushAdmissionPolicy:  FlushAdmissionPolicyAuto,
+		FlushApplyConcurrency: 4,
+	}
+	decision := NormalizeFlushAdmissionOptions(&opts)
+
+	if decision.Admitted {
+		t.Fatalf("admitted=true want false")
+	}
+	if decision.Reason != FlushAdmissionReasonCheckpointDebt {
+		t.Fatalf("reason=%q want %q", decision.Reason, FlushAdmissionReasonCheckpointDebt)
+	}
+	if opts.FlushApplyConcurrency != 0 || opts.FlushApplySpanNative || opts.FlushBacklogCoalescing {
+		t.Fatalf("auto checkpoint decline did not force off: concurrency=%d span=%t backlog=%t", opts.FlushApplyConcurrency, opts.FlushApplySpanNative, opts.FlushBacklogCoalescing)
+	}
+}
+
+func TestFlushAdmissionStatsExposePolicyAndReason(t *testing.T) {
+	opts := Options{FlushAdmissionPolicy: FlushAdmissionPolicyAuto, FlushApplyConcurrency: 1, FlushApplySpanNative: true}
+	decision := NormalizeFlushAdmissionOptions(&opts)
+	db := &DB{flushAdmission: decision}
+	stats := map[string]string{}
+	db.appendFlushApplyStats(stats)
+
+	if got := stats["treedb.flush_admission.policy"]; got != "auto" {
+		t.Fatalf("stats policy=%q want auto", got)
+	}
+	if got := stats["treedb.flush_admission.admitted"]; got != "false" {
+		t.Fatalf("stats admitted=%q want false", got)
+	}
+	if got := stats["treedb.flush_admission.reason"]; !strings.Contains(got, FlushAdmissionReasonLowConcurrency) || !strings.Contains(got, FlushAdmissionReasonCheckpointDebt) {
+		t.Fatalf("stats reason=%q missing low concurrency/checkpoint debt", got)
+	}
+	if got := stats["treedb.flush_admission.flush_apply_span_native"]; got != "false" {
+		t.Fatalf("stats span native=%q want false", got)
+	}
+}
+
+func TestParseFlushAdmissionPolicy(t *testing.T) {
+	for _, tc := range []struct {
+		raw  string
+		want FlushAdmissionPolicy
+	}{
+		{raw: "", want: FlushAdmissionPolicyExplicit},
+		{raw: "default", want: FlushAdmissionPolicyExplicit},
+		{raw: "explicit", want: FlushAdmissionPolicyExplicit},
+		{raw: "off", want: FlushAdmissionPolicyOff},
+		{raw: "auto", want: FlushAdmissionPolicyAuto},
+	} {
+		got, err := ParseFlushAdmissionPolicy(tc.raw)
+		if err != nil {
+			t.Fatalf("ParseFlushAdmissionPolicy(%q): %v", tc.raw, err)
+		}
+		if got != tc.want {
+			t.Fatalf("ParseFlushAdmissionPolicy(%q)=%s want %s", tc.raw, got, tc.want)
+		}
+	}
+	if _, err := ParseFlushAdmissionPolicy("bad"); err == nil {
+		t.Fatal("ParseFlushAdmissionPolicy accepted bad policy")
+	}
+}

--- a/TreeDB/db/flush_apply_stats.go
+++ b/TreeDB/db/flush_apply_stats.go
@@ -316,6 +316,14 @@ func (db *DB) appendFlushApplyStats(stats map[string]string) {
 	if db == nil || stats == nil {
 		return
 	}
+	admission := db.flushAdmission.withStatsDefaults()
+	stats["treedb.flush_admission.policy"] = admission.Policy.String()
+	stats["treedb.flush_admission.admitted"] = fmt.Sprintf("%t", admission.Admitted)
+	stats["treedb.flush_admission.reason"] = admission.Reason
+	stats["treedb.flush_admission.flush_apply_concurrency"] = fmt.Sprintf("%d", admission.FlushApplyConcurrency)
+	stats["treedb.flush_admission.flush_apply_span_native"] = fmt.Sprintf("%t", admission.FlushApplySpanNative)
+	stats["treedb.flush_admission.flush_backlog_coalescing"] = fmt.Sprintf("%t", admission.FlushBacklogCoalescing)
+
 	applyOps := db.flushApplyOps.Load()
 	stats["treedb.flush_apply.apply_calls_total"] = fmt.Sprintf("%d", db.flushApplyCalls.Load())
 	stats["treedb.flush_apply.apply_errors_total"] = fmt.Sprintf("%d", db.flushApplyErrors.Load())

--- a/TreeDB/db/open_readonly.go
+++ b/TreeDB/db/open_readonly.go
@@ -17,6 +17,7 @@ func openReadOnly(opts Options) (*DB, error) {
 	if err := applyReadOnlyDefaults(&opts); err != nil {
 		return nil, err
 	}
+	NormalizeFlushAdmissionOptions(&opts)
 	if err := ensureNoLegacyMixedWALValueSegments(opts.Dir); err != nil {
 		return nil, err
 	}
@@ -80,6 +81,7 @@ func openReadOnly(opts Options) (*DB, error) {
 		valueLogManager:                vm,
 		lock:                           lock,
 		adaptive:                       adaptiveCtrl,
+		flushAdmission:                 FlushAdmissionDecisionForOptions(opts),
 		keepRecent:                     opts.KeepRecent,
 		valueLogCompression:            opts.ValueLog.Compression,
 		valueLogAutoPolicy:             opts.ValueLog.AutoPolicy,
@@ -169,6 +171,7 @@ func openReadOnlyNoLock(opts Options) (*DB, error) {
 	if err := applyReadOnlyDefaults(&opts); err != nil {
 		return nil, err
 	}
+	NormalizeFlushAdmissionOptions(&opts)
 	if err := ensureNoLegacyMixedWALValueSegments(opts.Dir); err != nil {
 		return nil, err
 	}
@@ -218,6 +221,7 @@ func openReadOnlyNoLock(opts Options) (*DB, error) {
 		durability:                     opts.Durability,
 		valueLogManager:                vm,
 		adaptive:                       adaptiveCtrl,
+		flushAdmission:                 FlushAdmissionDecisionForOptions(opts),
 		keepRecent:                     opts.KeepRecent,
 		valueLogCompression:            opts.ValueLog.Compression,
 		valueLogAutoPolicy:             opts.ValueLog.AutoPolicy,

--- a/TreeDB/public.go
+++ b/TreeDB/public.go
@@ -32,6 +32,10 @@ type MaintenancePhase = caching.MaintenancePhase
 
 type LeafPageReadCacheWriteAdmissionPolicy = db.LeafPageReadCacheWriteAdmissionPolicy
 
+type FlushAdmissionPolicy = db.FlushAdmissionPolicy
+
+type FlushAdmissionDecision = db.FlushAdmissionDecision
+
 const (
 	MaintenancePhaseSteady  = caching.MaintenancePhaseSteady
 	MaintenancePhaseRestore = caching.MaintenancePhaseRestore
@@ -39,6 +43,10 @@ const (
 
 	LeafPageReadCacheWriteAdmissionImmediate = db.LeafPageReadCacheWriteAdmissionImmediate
 	LeafPageReadCacheWriteAdmissionAdaptive  = db.LeafPageReadCacheWriteAdmissionAdaptive
+
+	FlushAdmissionPolicyExplicit = db.FlushAdmissionPolicyExplicit
+	FlushAdmissionPolicyOff      = db.FlushAdmissionPolicyOff
+	FlushAdmissionPolicyAuto     = db.FlushAdmissionPolicyAuto
 )
 
 var errVacuumUnsupported = db.ErrVacuumUnsupported
@@ -465,6 +473,7 @@ func Open(opts Options) (*DB, error) {
 
 	// Keep opts.DisableSideStores consistent with the resolved layout.
 	opts.DisableSideStores = layout.disableSideStores
+	db.NormalizeFlushAdmissionOptions(&opts)
 
 	writePath := writePathFromOptions(opts)
 	if envBool(envWritePathLog) {

--- a/cmd/unified_bench/adapter_treedb.go
+++ b/cmd/unified_bench/adapter_treedb.go
@@ -39,6 +39,7 @@ var (
 	treedbFlushBuildChunkMinBytes         = flag.Int("treedb-flush-build-chunk-min-bytes", 0, "TreeDB (cached): adaptive chunk min bytes (0=default)")
 	treedbFlushBuildChunkMaxBytes         = flag.Int("treedb-flush-build-chunk-max-bytes", 0, "TreeDB (cached): adaptive chunk max bytes (0=default)")
 	treedbFlushBuildPrefetchUnits         = flag.Int("treedb-flush-build-prefetch-units", 0, "TreeDB (cached): prefetch units for parallel flush build (0=default)")
+	treedbFlushAdmissionPolicy            = flag.String("treedb-flush-admission-policy", "explicit", "TreeDB: span-native/backlog/concurrency admission policy (explicit|off|auto; default explicit preserves existing opt-in flags)")
 	treedbFlushApplyConcurrency           = flag.Int("treedb-flush-apply-concurrency", 0, "TreeDB: opt-in flush/apply COW worker-pool concurrency (0/1=disabled)")
 	treedbFlushApplyMinEntries            = flag.Int("treedb-flush-apply-min-entries", 0, "TreeDB: minimum planned span ops to enable opt-in parallel apply (0=default)")
 	treedbFlushApplyMinSpans              = flag.Int("treedb-flush-apply-min-spans", 0, "TreeDB: minimum planned leaf spans to enable opt-in parallel apply (0=default)")
@@ -380,6 +381,14 @@ func formatTreeDBFlushBacklogCoalescingSingleOpRatio(v float64) string {
 	return fmt.Sprintf("%.6f", v)
 }
 
+func parseTreeDBFlushAdmissionPolicy(raw string) (treedb.FlushAdmissionPolicy, error) {
+	policy, err := treedbdb.ParseFlushAdmissionPolicy(raw)
+	if err != nil {
+		return policy, fmt.Errorf("TreeDB: %w", err)
+	}
+	return policy, nil
+}
+
 type treeDBOptionsReport struct {
 	opts            treedb.Options
 	maintenanceMode string
@@ -415,6 +424,11 @@ func (r treeDBOptionsReport) formatText(indent string) string {
 	lines = append(lines, fmt.Sprintf("outer_leaf_read_cache_write_admission=%s", r.opts.LeafPageReadCacheWriteAdmission.String()))
 	lines = append(lines, fmt.Sprintf("cached.domain_ingress_workers=%d", r.opts.DomainIngressWorkers))
 	lines = append(lines, fmt.Sprintf("cached.domain_ingress_queue_size=%d", r.opts.DomainIngressQueueSize))
+	admission := treedbdb.FlushAdmissionDecisionForOptions(r.opts)
+	lines = append(lines, fmt.Sprintf("flush_admission_policy=%s", admission.Policy.String()))
+	lines = append(lines, fmt.Sprintf("flush_admission_admitted=%t", admission.Admitted))
+	lines = append(lines, fmt.Sprintf("flush_admission_reason=%s", admission.Reason))
+	lines = append(lines, fmt.Sprintf("flush_admission_effective_concurrency=%d", admission.FlushApplyConcurrency))
 	lines = append(lines, fmt.Sprintf("flush_apply_concurrency=%d", r.opts.FlushApplyConcurrency))
 	lines = append(lines, fmt.Sprintf("flush_apply_min_entries_configured=%d", r.opts.FlushApplyMinEntries))
 	lines = append(lines, fmt.Sprintf("flush_apply_min_spans_configured=%d", r.opts.FlushApplyMinSpans))
@@ -717,6 +731,10 @@ func buildTreeDBOptionsWithConfig(dir string, cfg treeDBOptionsBuildConfig) (tre
 	if err != nil {
 		return treedb.Options{}, treeDBOptionsReport{}, err
 	}
+	flushAdmissionPolicy, err := parseTreeDBFlushAdmissionPolicy(*treedbFlushAdmissionPolicy)
+	if err != nil {
+		return treedb.Options{}, treeDBOptionsReport{}, err
+	}
 	if writeAdmissionPolicy == treedb.LeafPageReadCacheWriteAdmissionAdaptive {
 		notes = append(notes, "outer_leaf_read_cache_write_admission=adaptive is opt-in; skipped writes remain durable and read misses can still admit")
 	}
@@ -761,6 +779,7 @@ func buildTreeDBOptionsWithConfig(dir string, cfg treeDBOptionsBuildConfig) (tre
 		FlushBuildChunkMinBytes:                    *treedbFlushBuildChunkMinBytes,
 		FlushBuildChunkMaxBytes:                    *treedbFlushBuildChunkMaxBytes,
 		FlushBuildPrefetchUnits:                    *treedbFlushBuildPrefetchUnits,
+		FlushAdmissionPolicy:                       flushAdmissionPolicy,
 		FlushApplyConcurrency:                      *treedbFlushApplyConcurrency,
 		FlushApplyMinEntries:                       *treedbFlushApplyMinEntries,
 		FlushApplyMinSpans:                         *treedbFlushApplyMinSpans,
@@ -946,6 +965,12 @@ func buildTreeDBOptionsWithConfig(dir string, cfg treeDBOptionsBuildConfig) (tre
 	}
 	if _, err := treedbdb.ResolveLeafPageReadCacheEntries(opts.LeafPageReadCacheEntries); err != nil {
 		return treedb.Options{}, treeDBOptionsReport{}, err
+	}
+	admission := treedbdb.NormalizeFlushAdmissionOptions(&opts)
+	if admission.Policy == treedb.FlushAdmissionPolicyOff {
+		notes = append(notes, "flush_admission_policy=off force-disables span-native, backlog coalescing, and flush-apply concurrency")
+	} else if admission.Policy == treedb.FlushAdmissionPolicyAuto && !admission.Admitted {
+		notes = append(notes, "flush_admission_policy=auto declined: "+admission.Reason)
 	}
 
 	rep := treeDBOptionsReport{opts: opts, maintenanceMode: maintenanceMode, notes: notes, warnings: warnings}

--- a/cmd/unified_bench/profiles_treedb_index_test.go
+++ b/cmd/unified_bench/profiles_treedb_index_test.go
@@ -195,12 +195,21 @@ func TestBuildTreeDBOptions_FlushAdmissionAutoDeclinesLowConcurrencyAndCheckpoin
 		"flush_admission_policy=auto",
 		"flush_admission_admitted=false",
 		"flush_admission_reason=low_concurrency,checkpoint_debt_unresolved",
-		"flush_admission_policy=auto declined: low_concurrency,checkpoint_debt_unresolved",
+		"  - flush_admission_policy=auto declined: low_concurrency,checkpoint_debt_unresolved",
 	} {
-		if !strings.Contains(text, want) {
-			t.Fatalf("resolved options missing %q: %q", want, text)
+		if !treeDBReportHasLine(text, want) {
+			t.Fatalf("resolved options missing line %q: %q", want, text)
 		}
 	}
+}
+
+func treeDBReportHasLine(text, want string) bool {
+	for _, line := range strings.Split(text, "\n") {
+		if line == want {
+			return true
+		}
+	}
+	return false
 }
 
 func TestBuildTreeDBOptions_FlushAdmissionRejectsInvalidPolicy(t *testing.T) {

--- a/cmd/unified_bench/profiles_treedb_index_test.go
+++ b/cmd/unified_bench/profiles_treedb_index_test.go
@@ -110,6 +110,115 @@ func TestBuildTreeDBOptions_LeafPageReadCacheWriteAdmissionRejectsInvalid(t *tes
 	}
 }
 
+func TestBuildTreeDBOptions_FlushAdmissionExplicitPreservesOptInFlags(t *testing.T) {
+	saved := saveTreeDBFlagState()
+	defer restoreTreeDBFlagState(saved)
+
+	resetTreeDBIndexFlagsForTest()
+	*treedbFlushAdmissionPolicy = "explicit"
+	*treedbFlushApplyConcurrency = 4
+	*treedbFlushApplySpanNative = true
+	*treedbFlushBacklogCoalescing = true
+
+	opts, rep, err := buildTreeDBOptions("")
+	if err != nil {
+		t.Fatalf("buildTreeDBOptions flush admission explicit: %v", err)
+	}
+	if opts.FlushAdmissionPolicy != treedb.FlushAdmissionPolicyExplicit || opts.FlushApplyConcurrency != 4 || !opts.FlushApplySpanNative || !opts.FlushBacklogCoalescing {
+		t.Fatalf("explicit opt-in not preserved: policy=%s concurrency=%d span=%t backlog=%t", opts.FlushAdmissionPolicy, opts.FlushApplyConcurrency, opts.FlushApplySpanNative, opts.FlushBacklogCoalescing)
+	}
+	text := rep.formatText("")
+	for _, want := range []string{
+		"flush_admission_policy=explicit",
+		"flush_admission_admitted=true",
+		"flush_admission_reason=explicit_opt_in",
+		"flush_apply_span_native=true",
+		"flush_backlog_coalescing=true",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("resolved options missing %q: %q", want, text)
+		}
+	}
+}
+
+func TestBuildTreeDBOptions_FlushAdmissionOffForcesOff(t *testing.T) {
+	saved := saveTreeDBFlagState()
+	defer restoreTreeDBFlagState(saved)
+
+	resetTreeDBIndexFlagsForTest()
+	*treedbFlushAdmissionPolicy = "off"
+	*treedbFlushApplyConcurrency = 4
+	*treedbFlushApplySpanNative = true
+	*treedbFlushBacklogCoalescing = true
+
+	opts, rep, err := buildTreeDBOptions("")
+	if err != nil {
+		t.Fatalf("buildTreeDBOptions flush admission off: %v", err)
+	}
+	if opts.FlushAdmissionPolicy != treedb.FlushAdmissionPolicyOff || opts.FlushApplyConcurrency != 0 || opts.FlushApplySpanNative || opts.FlushBacklogCoalescing {
+		t.Fatalf("off policy not forced off: policy=%s concurrency=%d span=%t backlog=%t", opts.FlushAdmissionPolicy, opts.FlushApplyConcurrency, opts.FlushApplySpanNative, opts.FlushBacklogCoalescing)
+	}
+	text := rep.formatText("")
+	for _, want := range []string{
+		"flush_admission_policy=off",
+		"flush_admission_admitted=false",
+		"flush_admission_reason=policy_off",
+		"flush_apply_concurrency=0",
+		"flush_apply_span_native=false",
+		"flush_backlog_coalescing=false",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("resolved options missing %q: %q", want, text)
+		}
+	}
+}
+
+func TestBuildTreeDBOptions_FlushAdmissionAutoDeclinesLowConcurrencyAndCheckpointDebt(t *testing.T) {
+	saved := saveTreeDBFlagState()
+	defer restoreTreeDBFlagState(saved)
+
+	resetTreeDBIndexFlagsForTest()
+	*treedbFlushAdmissionPolicy = "auto"
+	*treedbFlushApplyConcurrency = 1
+	*treedbFlushApplySpanNative = true
+	*treedbFlushBacklogCoalescing = true
+
+	opts, rep, err := buildTreeDBOptions("")
+	if err != nil {
+		t.Fatalf("buildTreeDBOptions flush admission auto: %v", err)
+	}
+	if opts.FlushAdmissionPolicy != treedb.FlushAdmissionPolicyAuto || opts.FlushApplyConcurrency != 0 || opts.FlushApplySpanNative || opts.FlushBacklogCoalescing {
+		t.Fatalf("auto decline not forced off: policy=%s concurrency=%d span=%t backlog=%t", opts.FlushAdmissionPolicy, opts.FlushApplyConcurrency, opts.FlushApplySpanNative, opts.FlushBacklogCoalescing)
+	}
+	text := rep.formatText("")
+	for _, want := range []string{
+		"flush_admission_policy=auto",
+		"flush_admission_admitted=false",
+		"flush_admission_reason=low_concurrency,checkpoint_debt_unresolved",
+		"flush_admission_policy=auto declined: low_concurrency,checkpoint_debt_unresolved",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("resolved options missing %q: %q", want, text)
+		}
+	}
+}
+
+func TestBuildTreeDBOptions_FlushAdmissionRejectsInvalidPolicy(t *testing.T) {
+	saved := saveTreeDBFlagState()
+	defer restoreTreeDBFlagState(saved)
+
+	resetTreeDBIndexFlagsForTest()
+	*treedbFlushAdmissionPolicy = "bad-policy"
+
+	_, _, err := buildTreeDBOptions("")
+	if err == nil {
+		t.Fatal("buildTreeDBOptions unexpectedly accepted invalid flush admission policy")
+	}
+	if !strings.Contains(err.Error(), "flush admission policy") {
+		t.Fatalf("buildTreeDBOptions error=%q, want flush admission context", err)
+	}
+}
+
 func TestBuildTreeDBOptions_LeafPageReadCacheEntriesDefaultRejectsOutOfRangeEnv(t *testing.T) {
 	saved := saveTreeDBFlagState()
 	defer restoreTreeDBFlagState(saved)
@@ -282,6 +391,10 @@ type savedTreeDBFlagState struct {
 	allowUnsafe             bool
 	maintenanceMode         string
 	flushThreshold          int64
+	flushAdmissionPolicy    string
+	flushApplyConcurrency   int
+	flushApplySpanNative    bool
+	flushBacklogCoalescing  bool
 	explicitFlags           map[string]bool
 }
 
@@ -324,6 +437,10 @@ func saveTreeDBFlagState() savedTreeDBFlagState {
 		allowUnsafe:             *treedbAllowUnsafe,
 		maintenanceMode:         *treedbMaintenanceMode,
 		flushThreshold:          *treedbFlushThreshold,
+		flushAdmissionPolicy:    *treedbFlushAdmissionPolicy,
+		flushApplyConcurrency:   *treedbFlushApplyConcurrency,
+		flushApplySpanNative:    *treedbFlushApplySpanNative,
+		flushBacklogCoalescing:  *treedbFlushBacklogCoalescing,
 		explicitFlags:           copyMap,
 	}
 }
@@ -362,6 +479,10 @@ func restoreTreeDBFlagState(s savedTreeDBFlagState) {
 	*treedbAllowUnsafe = s.allowUnsafe
 	*treedbMaintenanceMode = s.maintenanceMode
 	*treedbFlushThreshold = s.flushThreshold
+	*treedbFlushAdmissionPolicy = s.flushAdmissionPolicy
+	*treedbFlushApplyConcurrency = s.flushApplyConcurrency
+	*treedbFlushApplySpanNative = s.flushApplySpanNative
+	*treedbFlushBacklogCoalescing = s.flushBacklogCoalescing
 	explicitFlags = s.explicitFlags
 }
 
@@ -399,6 +520,10 @@ func resetTreeDBIndexFlagsForTest() {
 	*treedbAllowUnsafe = false
 	*treedbMaintenanceMode = "bench"
 	*treedbFlushThreshold = 64 * 1024 * 1024
+	*treedbFlushAdmissionPolicy = "explicit"
+	*treedbFlushApplyConcurrency = 0
+	*treedbFlushApplySpanNative = false
+	*treedbFlushBacklogCoalescing = false
 	explicitFlags = map[string]bool{}
 }
 


### PR DESCRIPTION
## Summary

Closes #2795 (B2 under #2782).

This PR adds a small runtime admission seam for TreeDB span-native/backlog/concurrency configuration:

- new `Options.FlushAdmissionPolicy` with `explicit` (zero/default), `off`, and `auto`;
- default `explicit` preserves the current default-off behavior and existing opt-in knobs;
- `off` force-disables span-native, backlog coalescing, and flush-apply worker concurrency as a rollback path;
- `auto` fails closed for the known low-concurrency/c1 regression shape and while #2794 checkpoint debt remains unresolved;
- admission/decline policy and reason are exposed in `DB.Stats()` and the unified-bench TreeDB option report.

## Scope / non-scope

In scope:
- option normalization/reporting only;
- focused policy, explicit override, stats, and unified-bench report tests.

Out of scope:
- no default enablement of span-native/backlog;
- no checkpoint-debt mitigation (#2794 remains the runtime mitigation track);
- no persistent format changes;
- no hot-path apply/backlog algorithm changes.

## Performance gate waiver

The #2782 10MM runtime gate is waived for this PR because default/unconfigured behavior remains `explicit` and default-off, and the diff changes init/config normalization plus stats/reporting only. There is no measured hot-path/default behavior change unless a caller explicitly selects `off` or `auto`.

## Validation

Original local validation:

```sh
go test ./TreeDB/db ./cmd/unified_bench -run 'Test(NormalizeFlushAdmission|FlushAdmissionStats|ParseFlushAdmission|BuildTreeDBOptions_FlushAdmission|TreeDBOptionsReportFlushBacklog)' -count=1
go test ./TreeDB/db ./TreeDB/caching ./cmd/unified_bench -count=1
go test ./TreeDB -run TestDoesNotExist -count=1
git diff --check
```

Review-fix local validation on `36dff84e9a629d409c05ce98c5195880cc3bde86`:

```sh
go test ./TreeDB/db ./cmd/unified_bench -run 'Test(NormalizeFlushAdmission|FlushAdmissionStats|ParseFlushAdmission|BuildTreeDBOptions_FlushAdmission)' -count=1
git diff --check
```

Latest-head CI for `36dff84e9a629d409c05ce98c5195880cc3bde86`: running after review-fix push.

## Downstream handoff

- #2787/#2788 can treat the stable contract as default-off / opt-in-only unless #2794 lands a measured checkpoint-debt mitigation.
- Auto/future-default admission currently declines with `checkpoint_debt_unresolved`; c1/low-concurrency also declines with `low_concurrency`.
- Existing rollback knobs remain available: span-native off, backlog off, concurrency override, adaptive cache off.

## Review status

- Ready for review.
- CodeRabbit threads from the first review were fixed and resolved:
  - unified-bench auto-policy report assertion now checks exact lines;
  - optional disable-path helper de-dup was applied.
- Re-requested: Codex, Copilot, and CodeRabbit after `36dff84e9a629d409c05ce98c5195880cc3bde86`.
