### PR TITLE
treedb: enable guarded span-native default admission

### DIFF
--- a/.github/workflows/treedb-tests.yml
+++ b/.github/workflows/treedb-tests.yml
@@ -466,6 +466,11 @@ jobs:
             auto_log="vlog_auto_incompressible_auto_attempt${attempt}.txt"
             echo "incompressible gate attempt ${attempt}/${max_attempts}"
 
+            # Keep this value-log compression gate independent of the
+            # unconfigured flush-admission default under test in #2788. Force
+            # admission off for both rows so the strict auto/off comparison stays
+            # on the old serial/default-off flush boundary and measures value-log
+            # auto behavior rather than span-native admission changes.
             if ! go run ./cmd/unified_bench \
               -keys 1000000 \
               -valsize 512 \
@@ -480,6 +485,7 @@ jobs:
               -treedb-force-value-pointers=true \
               -treedb-value-log-threshold=1 \
               -treedb-vlog-dict-train-bytes=-1 \
+              -treedb-flush-admission-policy=off \
               > "${off_log}" 2>&1; then
               echo "treedb_vlog_off benchmark failed on attempt ${attempt}"
               tail -n 80 "${off_log}" || true
@@ -500,6 +506,7 @@ jobs:
               -treedb-force-value-pointers=true \
               -treedb-value-log-threshold=1 \
               -treedb-vlog-dict-train-bytes=-1 \
+              -treedb-flush-admission-policy=off \
               > "${auto_log}" 2>&1; then
               echo "treedb_vlog_auto benchmark failed on attempt ${attempt}"
               tail -n 80 "${auto_log}" || true

--- a/TreeDB/caching/flush_apply_stats_test.go
+++ b/TreeDB/caching/flush_apply_stats_test.go
@@ -361,7 +361,7 @@ func TestFlushSpanRunLeafAwareChunksExposeEmergencySplit(t *testing.T) {
 }
 
 func TestFlushSpanRunRuntimeTargetLeafPlanningDefaultOff(t *testing.T) {
-	backend, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	backend, err := backenddb.Open(backenddb.Options{Dir: t.TempDir(), FlushAdmissionPolicy: backenddb.FlushAdmissionPolicyExplicit})
 	if err != nil {
 		t.Fatalf("open backend: %v", err)
 	}

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -993,8 +993,9 @@ type Options struct {
 	// FlushAdmissionPolicy selects how TreeDB admits the span-native/backlog
 	// flush/apply candidate path. The zero value (auto) admits the measured
 	// conservative c4/adaptive candidate on sufficiently parallel hosts and fails
-	// closed on low-concurrency hosts. Explicit preserves caller-supplied knobs;
-	// Off force-disables span-native/backlog/concurrency as a rollback policy.
+	// closed on low-concurrency hosts or DurabilityWALOffRelaxed unsafe-durability
+	// opens. Explicit preserves caller-supplied knobs; Off force-disables
+	// span-native/backlog/concurrency as a rollback policy.
 	FlushAdmissionPolicy FlushAdmissionPolicy
 
 	// FlushApplyConcurrency enables M2 parallel COW apply for backend flush/write

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -857,10 +857,11 @@ type Options struct {
 	//   - >0 sets the exact number of set-associative cache entries.
 	LeafPageReadCacheEntries int
 	// LeafPageReadCacheWriteAdmission controls write-side cache population for
-	// outer-leaf pages stored in the value log. The zero value preserves the
-	// historical immediate admission behavior. Adaptive admission is opt-in and
-	// only changes in-memory cache population, not persistent leaf-log/value-log
-	// writes or pointer validity.
+	// outer-leaf pages stored in the value log. The field's zero value is the
+	// historical immediate admission behavior for explicit/off policies; the
+	// default auto flush-admission policy upgrades it to the measured adaptive
+	// write-admission candidate. Adaptive admission only changes in-memory cache
+	// population, not persistent leaf-log/value-log writes or pointer validity.
 	LeafPageReadCacheWriteAdmission LeafPageReadCacheWriteAdmissionPolicy
 
 	// Durability configures cached-mode durability semantics.
@@ -990,16 +991,17 @@ type Options struct {
 	FlushBuildPrefetchUnits int
 
 	// FlushAdmissionPolicy selects how TreeDB admits the span-native/backlog
-	// flush/apply candidate path. The zero value (explicit) preserves current
-	// defaults: span-native/backlog/concurrency stay off unless existing explicit
-	// knobs request them. Off force-disables the candidate path. Auto is the
-	// future-default selector and currently fails closed for low concurrency and
-	// unresolved checkpoint debt.
+	// flush/apply candidate path. The zero value (auto) admits the measured
+	// conservative c4/adaptive candidate on sufficiently parallel hosts and fails
+	// closed on low-concurrency hosts. Explicit preserves caller-supplied knobs;
+	// Off force-disables span-native/backlog/concurrency as a rollback policy.
 	FlushAdmissionPolicy FlushAdmissionPolicy
 
-	// FlushApplyConcurrency enables opt-in M2 parallel COW apply for backend
-	// flush/write batches using a bounded reusable worker pool. It is separate
-	// from FlushBuildConcurrency; values <=1 keep the M2 worker-pool path off.
+	// FlushApplyConcurrency enables M2 parallel COW apply for backend flush/write
+	// batches using a bounded reusable worker pool. It is separate from
+	// FlushBuildConcurrency. Values <=1 keep the worker-pool path off for
+	// explicit policy; the default auto admission policy chooses a conservative
+	// c4 candidate when the low-concurrency guardrail passes.
 	FlushApplyConcurrency int
 	// FlushApplyMinEntries gates opt-in parallel apply by planned span-local ops.
 	// Values <=0 use the internal default.
@@ -1010,9 +1012,10 @@ type Options struct {
 	// FlushApplyMinBytes gates opt-in parallel apply by planned span bytes.
 	// Values <=0 use the internal default.
 	FlushApplyMinBytes int
-	// FlushApplySpanNative enables the M10 opt-in span-native apply candidate
-	// path. It is default-off and initially restricted to exact point spans; all
-	// unsupported runs fall back to recursive apply.
+	// FlushApplySpanNative enables the M10 span-native apply candidate path. The
+	// default auto admission policy enables it only for the measured conservative
+	// c4 candidate; explicit policy preserves caller-provided values. Unsupported
+	// runs fall back to recursive apply.
 	FlushApplySpanNative bool
 
 	// FlushBackendMaxEntries caps how many operations are buffered into a single
@@ -1036,7 +1039,8 @@ type Options struct {
 	FlushSpanRunTargetPlanning bool
 
 	// FlushBacklogCoalescing enables the M11 bounded adaptive cached-flush
-	// coalescing controller. It is default-off; when enabled the cache layer may
+	// coalescing controller. The default auto admission policy enables it for the
+	// measured conservative c4 candidate; when enabled the cache layer may
 	// include additional already-sealed eligible memtables in one canonical flush
 	// run under observed cumulative single-op-span pressure and explicit budgets.
 	FlushBacklogCoalescing bool

--- a/TreeDB/db/flush_admission_policy.go
+++ b/TreeDB/db/flush_admission_policy.go
@@ -2,53 +2,64 @@ package db
 
 import (
 	"fmt"
+	"runtime"
 	"strings"
 )
 
+const (
+	defaultFlushAdmissionAutoConcurrency = 4
+	defaultFlushAdmissionAutoMinEntries  = 1
+	defaultFlushAdmissionAutoMinSpans    = 1
+	defaultFlushAdmissionAutoMinBytes    = 1
+)
+
 // FlushAdmissionPolicy controls how TreeDB admits the span-native/backlog
-// flush/apply candidate path. The zero value preserves the pre-existing
-// explicit-opt-in behavior: defaults remain off, and callers that set the
-// existing FlushApply*/FlushBacklog* knobs keep their requested behavior.
+// flush/apply candidate path. The zero value is the default auto selector: it
+// admits the measured conservative c4/adaptive candidate on sufficiently
+// parallel hosts, declines low-concurrency shapes, and leaves rollback and
+// explicit opt-in policies available.
 type FlushAdmissionPolicy uint8
 
 const (
-	// FlushAdmissionPolicyExplicit preserves existing explicit knobs. This is the
-	// default policy and does not infer or enable span-native/backlog behavior.
-	FlushAdmissionPolicyExplicit FlushAdmissionPolicy = iota
+	// FlushAdmissionPolicyAuto is the default selector. It admits the measured
+	// c4 span-native/backlog/adaptive-cache candidate only when the low-concurrency
+	// guardrail passes; otherwise it fails closed to the serial path.
+	FlushAdmissionPolicyAuto FlushAdmissionPolicy = iota
+	// FlushAdmissionPolicyExplicit preserves existing explicit knobs. Use this to
+	// opt in to a non-default span-native/backlog/concurrency/cache shape.
+	FlushAdmissionPolicyExplicit
 	// FlushAdmissionPolicyOff force-disables span-native, backlog coalescing, and
 	// flush-apply worker-pool concurrency as a rollback/fail-closed policy.
 	FlushAdmissionPolicyOff
-	// FlushAdmissionPolicyAuto is the future-default selector path. It currently
-	// fails closed while checkpoint debt remains unresolved and when configured
-	// concurrency is too low to avoid the known c1 regression shape.
-	FlushAdmissionPolicyAuto
 )
 
 const (
-	FlushAdmissionReasonNoExplicitOptIn = "no_explicit_opt_in"
-	FlushAdmissionReasonExplicitOptIn   = "explicit_opt_in"
-	FlushAdmissionReasonPolicyOff       = "policy_off"
-	FlushAdmissionReasonAutoAdmitted    = "auto_admitted"
-	FlushAdmissionReasonLowConcurrency  = "low_concurrency"
-	FlushAdmissionReasonCheckpointDebt  = "checkpoint_debt_unresolved"
-	FlushAdmissionReasonInvalidPolicy   = "invalid_policy"
+	FlushAdmissionReasonNoExplicitOptIn     = "no_explicit_opt_in"
+	FlushAdmissionReasonExplicitOptIn       = "explicit_opt_in"
+	FlushAdmissionReasonPolicyOff           = "policy_off"
+	FlushAdmissionReasonAutoAdmitted        = "auto_admitted"
+	FlushAdmissionReasonAutoAdmittedC4Adapt = "auto_admitted_c4_adaptive"
+	FlushAdmissionReasonLowConcurrency      = "low_concurrency"
+	FlushAdmissionReasonUnsafeDurability    = "unsafe_durability"
+	FlushAdmissionReasonCheckpointDebt      = "checkpoint_debt_unresolved"
+	FlushAdmissionReasonInvalidPolicy       = "invalid_policy"
 )
 
-// Keep the unresolved #2794/B1 checkpoint debt represented in code, not only in
-// benchmark notes. A future checkpoint-debt mitigation can flip this seam (or
-// replace it with a measured runtime signal) and the auto path will still keep
-// the low-concurrency guardrail below.
-const flushAdmissionCheckpointDebtResolved = false
+// #2794/B1 checkpoint debt is accepted for this cycle as a bounded analytics
+// model tradeoff, not as a mandatory runtime-mitigation blocker. Keep this seam
+// explicit so a future gate can fail closed again without changing callers.
+const flushAdmissionCheckpointDebtAccepted = true
 
 // FlushAdmissionDecision is the normalized admission result reported through
 // DB.Stats and benchmark option reports.
 type FlushAdmissionDecision struct {
-	Policy                 FlushAdmissionPolicy
-	Admitted               bool
-	Reason                 string
-	FlushApplyConcurrency  int
-	FlushApplySpanNative   bool
-	FlushBacklogCoalescing bool
+	Policy                          FlushAdmissionPolicy
+	Admitted                        bool
+	Reason                          string
+	FlushApplyConcurrency           int
+	FlushApplySpanNative            bool
+	FlushBacklogCoalescing          bool
+	LeafPageReadCacheWriteAdmission LeafPageReadCacheWriteAdmissionPolicy
 }
 
 func (p FlushAdmissionPolicy) String() string {
@@ -74,17 +85,17 @@ func (p FlushAdmissionPolicy) Valid() bool {
 }
 
 // ParseFlushAdmissionPolicy parses off|explicit|auto policy values. Empty and
-// "default" preserve the current explicit-opt-in default.
+// "default" use the current default auto selector.
 func ParseFlushAdmissionPolicy(raw string) (FlushAdmissionPolicy, error) {
 	switch strings.ToLower(strings.TrimSpace(raw)) {
-	case "", "default", "unset", "explicit":
+	case "", "default", "unset", "auto", "adaptive":
+		return FlushAdmissionPolicyAuto, nil
+	case "explicit", "manual":
 		return FlushAdmissionPolicyExplicit, nil
 	case "off", "false", "0", "disabled", "disable":
 		return FlushAdmissionPolicyOff, nil
-	case "auto", "adaptive":
-		return FlushAdmissionPolicyAuto, nil
 	default:
-		return FlushAdmissionPolicyExplicit, fmt.Errorf("unsupported flush admission policy %q (expected off|explicit|auto)", raw)
+		return FlushAdmissionPolicyAuto, fmt.Errorf("unsupported flush admission policy %q (expected off|explicit|auto)", raw)
 	}
 }
 
@@ -94,7 +105,7 @@ func ParseFlushAdmissionPolicy(raw string) (FlushAdmissionPolicy, error) {
 // losing the original decline reason.
 func NormalizeFlushAdmissionOptions(opts *Options) FlushAdmissionDecision {
 	if opts == nil {
-		return FlushAdmissionDecision{Policy: FlushAdmissionPolicyExplicit, Reason: FlushAdmissionReasonNoExplicitOptIn}
+		return FlushAdmissionDecision{Policy: FlushAdmissionPolicyAuto, Reason: FlushAdmissionReasonLowConcurrency}
 	}
 	if opts.flushAdmissionNormalized {
 		return opts.flushAdmissionDecision.withStatsDefaults()
@@ -119,10 +130,11 @@ func computeFlushAdmissionDecision(opts *Options) FlushAdmissionDecision {
 	policy := opts.FlushAdmissionPolicy
 	effectiveConcurrency := normalizeFlushApplyConcurrency(opts.FlushApplyConcurrency)
 	decision := FlushAdmissionDecision{
-		Policy:                 policy,
-		FlushApplyConcurrency:  effectiveConcurrency,
-		FlushApplySpanNative:   opts.FlushApplySpanNative,
-		FlushBacklogCoalescing: opts.FlushBacklogCoalescing,
+		Policy:                          policy,
+		FlushApplyConcurrency:           effectiveConcurrency,
+		FlushApplySpanNative:            opts.FlushApplySpanNative,
+		FlushBacklogCoalescing:          opts.FlushBacklogCoalescing,
+		LeafPageReadCacheWriteAdmission: opts.LeafPageReadCacheWriteAdmission,
 	}
 
 	if !policy.Valid() {
@@ -145,10 +157,14 @@ func computeFlushAdmissionDecision(opts *Options) FlushAdmissionDecision {
 		return decision
 	case FlushAdmissionPolicyAuto:
 		reasons := make([]string, 0, 2)
-		if effectiveConcurrency <= 1 {
+		candidateConcurrency := autoFlushApplyConcurrency(opts.FlushApplyConcurrency)
+		if candidateConcurrency < defaultFlushAdmissionAutoConcurrency {
 			reasons = append(reasons, FlushAdmissionReasonLowConcurrency)
 		}
-		if !flushAdmissionCheckpointDebtResolved {
+		if opts.Durability == DurabilityWALOffRelaxed {
+			reasons = append(reasons, FlushAdmissionReasonUnsafeDurability)
+		}
+		if !flushAdmissionCheckpointDebtAccepted {
 			reasons = append(reasons, FlushAdmissionReasonCheckpointDebt)
 		}
 		if len(reasons) > 0 {
@@ -156,24 +172,40 @@ func computeFlushAdmissionDecision(opts *Options) FlushAdmissionDecision {
 			return decision
 		}
 
-		// Unreachable while checkpoint debt remains unresolved. Keep the admission
-		// side explicit for #2794/#2788: if the debt gate is resolved later, auto
-		// chooses the measured span-native/backlog candidate only with safe
-		// configured concurrency.
-		opts.FlushApplyConcurrency = effectiveConcurrency
+		opts.FlushApplyConcurrency = defaultFlushAdmissionAutoConcurrency
+		opts.FlushApplyMinEntries = defaultFlushAdmissionAutoMinEntries
+		opts.FlushApplyMinSpans = defaultFlushAdmissionAutoMinSpans
+		opts.FlushApplyMinBytes = defaultFlushAdmissionAutoMinBytes
 		opts.FlushApplySpanNative = true
 		opts.FlushBacklogCoalescing = true
+		if opts.LeafPageReadCacheWriteAdmission == LeafPageReadCacheWriteAdmissionImmediate || opts.LeafPageReadCacheWriteAdmission == LeafPageReadCacheWriteAdmissionAdaptive {
+			opts.LeafPageReadCacheWriteAdmission = LeafPageReadCacheWriteAdmissionAdaptive
+		}
+
 		decision.Admitted = true
-		decision.Reason = FlushAdmissionReasonAutoAdmitted
-		decision.FlushApplyConcurrency = effectiveConcurrency
+		decision.Reason = FlushAdmissionReasonAutoAdmittedC4Adapt
+		decision.FlushApplyConcurrency = defaultFlushAdmissionAutoConcurrency
 		decision.FlushApplySpanNative = true
 		decision.FlushBacklogCoalescing = true
+		decision.LeafPageReadCacheWriteAdmission = opts.LeafPageReadCacheWriteAdmission
 		return decision
 	default:
 		// Defensive fallback; policy.Valid handled this above.
 		decision.disableAll(opts, FlushAdmissionReasonInvalidPolicy)
 		return decision
 	}
+}
+
+func autoFlushApplyConcurrency(configured int) int {
+	if configured > 0 {
+		return normalizeFlushApplyConcurrency(configured)
+	}
+	workers := defaultFlushAdmissionAutoConcurrency
+	gomax := runtime.GOMAXPROCS(0)
+	if gomax < workers {
+		workers = gomax
+	}
+	return normalizeFlushApplyConcurrency(workers)
 }
 
 func (d *FlushAdmissionDecision) disableAll(opts *Options, reason string) {
@@ -187,6 +219,9 @@ func (d *FlushAdmissionDecision) disableAll(opts *Options, reason string) {
 	d.FlushApplyConcurrency = 0
 	d.FlushApplySpanNative = false
 	d.FlushBacklogCoalescing = false
+	if opts != nil {
+		d.LeafPageReadCacheWriteAdmission = opts.LeafPageReadCacheWriteAdmission
+	}
 }
 
 func (d FlushAdmissionDecision) withStatsDefaults() FlushAdmissionDecision {
@@ -198,9 +233,16 @@ func (d FlushAdmissionDecision) withStatsDefaults() FlushAdmissionDecision {
 	}
 	if d.Reason == "" {
 		if d.Admitted {
-			d.Reason = FlushAdmissionReasonExplicitOptIn
-		} else {
+			switch d.Policy {
+			case FlushAdmissionPolicyAuto:
+				d.Reason = FlushAdmissionReasonAutoAdmitted
+			default:
+				d.Reason = FlushAdmissionReasonExplicitOptIn
+			}
+		} else if d.Policy == FlushAdmissionPolicyExplicit {
 			d.Reason = FlushAdmissionReasonNoExplicitOptIn
+		} else {
+			d.Reason = FlushAdmissionReasonLowConcurrency
 		}
 	}
 	return d

--- a/TreeDB/db/flush_admission_policy_test.go
+++ b/TreeDB/db/flush_admission_policy_test.go
@@ -180,6 +180,24 @@ func TestNormalizeFlushAdmission_AutoCapsConfiguredConcurrencyToC4Candidate(t *t
 	}
 }
 
+func TestNormalizeFlushAdmission_AutoDeclinesWALOffUnsafeDurability(t *testing.T) {
+	oldGOMAXPROCS := runtime.GOMAXPROCS(4)
+	defer runtime.GOMAXPROCS(oldGOMAXPROCS)
+
+	opts := Options{Durability: DurabilityWALOffRelaxed}
+	decision := NormalizeFlushAdmissionOptions(&opts)
+
+	if decision.Admitted {
+		t.Fatalf("admitted=true want false")
+	}
+	if decision.Reason != FlushAdmissionReasonUnsafeDurability {
+		t.Fatalf("reason=%q want %q", decision.Reason, FlushAdmissionReasonUnsafeDurability)
+	}
+	if opts.FlushApplyConcurrency != 0 || opts.FlushApplySpanNative || opts.FlushBacklogCoalescing {
+		t.Fatalf("auto unsafe-durability decline did not force off: concurrency=%d span=%t backlog=%t", opts.FlushApplyConcurrency, opts.FlushApplySpanNative, opts.FlushBacklogCoalescing)
+	}
+}
+
 func TestFlushAdmissionStatsExposePolicyReasonAndCandidate(t *testing.T) {
 	oldGOMAXPROCS := runtime.GOMAXPROCS(4)
 	defer runtime.GOMAXPROCS(oldGOMAXPROCS)

--- a/TreeDB/db/flush_admission_policy_test.go
+++ b/TreeDB/db/flush_admission_policy_test.go
@@ -6,33 +6,70 @@ import (
 	"testing"
 )
 
-func TestNormalizeFlushAdmission_DefaultExplicitUnconfiguredStaysOff(t *testing.T) {
+func TestNormalizeFlushAdmission_DefaultAutoAdmitsC4Adaptive(t *testing.T) {
+	oldGOMAXPROCS := runtime.GOMAXPROCS(4)
+	defer runtime.GOMAXPROCS(oldGOMAXPROCS)
+
 	opts := Options{}
 	decision := NormalizeFlushAdmissionOptions(&opts)
 
-	if decision.Policy != FlushAdmissionPolicyExplicit {
-		t.Fatalf("policy=%s want explicit", decision.Policy)
+	if decision.Policy != FlushAdmissionPolicyAuto {
+		t.Fatalf("policy=%s want auto", decision.Policy)
+	}
+	if !decision.Admitted {
+		t.Fatalf("admitted=false want true; reason=%q", decision.Reason)
+	}
+	if decision.Reason != FlushAdmissionReasonAutoAdmittedC4Adapt {
+		t.Fatalf("reason=%q want %q", decision.Reason, FlushAdmissionReasonAutoAdmittedC4Adapt)
+	}
+	if opts.FlushApplyConcurrency != 4 || !opts.FlushApplySpanNative || !opts.FlushBacklogCoalescing {
+		t.Fatalf("default auto did not select c4 span/backlog: concurrency=%d span=%t backlog=%t", opts.FlushApplyConcurrency, opts.FlushApplySpanNative, opts.FlushBacklogCoalescing)
+	}
+	if opts.FlushApplyMinEntries != 1 || opts.FlushApplyMinSpans != 1 || opts.FlushApplyMinBytes != 1 {
+		t.Fatalf("default auto did not select measured min gates: entries=%d spans=%d bytes=%d", opts.FlushApplyMinEntries, opts.FlushApplyMinSpans, opts.FlushApplyMinBytes)
+	}
+	if opts.LeafPageReadCacheWriteAdmission != LeafPageReadCacheWriteAdmissionAdaptive {
+		t.Fatalf("default auto cache admission=%s want adaptive", opts.LeafPageReadCacheWriteAdmission)
+	}
+	if decision.FlushApplyConcurrency != 4 || !decision.FlushApplySpanNative || !decision.FlushBacklogCoalescing || decision.LeafPageReadCacheWriteAdmission != LeafPageReadCacheWriteAdmissionAdaptive {
+		t.Fatalf("decision did not report c4 adaptive candidate: %+v", decision)
+	}
+}
+
+func TestNormalizeFlushAdmission_DefaultAutoDeclinesLowConcurrency(t *testing.T) {
+	oldGOMAXPROCS := runtime.GOMAXPROCS(1)
+	defer runtime.GOMAXPROCS(oldGOMAXPROCS)
+
+	opts := Options{}
+	decision := NormalizeFlushAdmissionOptions(&opts)
+
+	if decision.Policy != FlushAdmissionPolicyAuto {
+		t.Fatalf("policy=%s want auto", decision.Policy)
 	}
 	if decision.Admitted {
 		t.Fatalf("admitted=true want false")
 	}
-	if decision.Reason != FlushAdmissionReasonNoExplicitOptIn {
-		t.Fatalf("reason=%q want %q", decision.Reason, FlushAdmissionReasonNoExplicitOptIn)
+	if decision.Reason != FlushAdmissionReasonLowConcurrency {
+		t.Fatalf("reason=%q want %q", decision.Reason, FlushAdmissionReasonLowConcurrency)
 	}
-	if opts.FlushApplySpanNative || opts.FlushBacklogCoalescing || opts.FlushApplyConcurrency != 0 {
-		t.Fatalf("default explicit mutated opts: span=%t backlog=%t concurrency=%d", opts.FlushApplySpanNative, opts.FlushBacklogCoalescing, opts.FlushApplyConcurrency)
+	if opts.FlushApplyConcurrency != 0 || opts.FlushApplySpanNative || opts.FlushBacklogCoalescing {
+		t.Fatalf("auto low-concurrency decline did not force off: concurrency=%d span=%t backlog=%t", opts.FlushApplyConcurrency, opts.FlushApplySpanNative, opts.FlushBacklogCoalescing)
+	}
+	if opts.LeafPageReadCacheWriteAdmission != LeafPageReadCacheWriteAdmissionImmediate {
+		t.Fatalf("auto low-concurrency decline changed cache admission to %s", opts.LeafPageReadCacheWriteAdmission)
 	}
 }
 
 func TestNormalizeFlushAdmission_OffForcesCandidateOff(t *testing.T) {
 	opts := Options{
-		FlushAdmissionPolicy:   FlushAdmissionPolicyOff,
-		FlushApplyConcurrency:  4,
-		FlushApplySpanNative:   true,
-		FlushBacklogCoalescing: true,
-		FlushApplyMinEntries:   1,
-		FlushApplyMinSpans:     1,
-		FlushApplyMinBytes:     1,
+		FlushAdmissionPolicy:            FlushAdmissionPolicyOff,
+		FlushApplyConcurrency:           4,
+		FlushApplySpanNative:            true,
+		FlushBacklogCoalescing:          true,
+		FlushApplyMinEntries:            1,
+		FlushApplyMinSpans:              1,
+		FlushApplyMinBytes:              1,
+		LeafPageReadCacheWriteAdmission: LeafPageReadCacheWriteAdmissionAdaptive,
 	}
 	decision := NormalizeFlushAdmissionOptions(&opts)
 
@@ -44,6 +81,9 @@ func TestNormalizeFlushAdmission_OffForcesCandidateOff(t *testing.T) {
 	}
 	if opts.FlushApplyConcurrency != 0 || opts.FlushApplySpanNative || opts.FlushBacklogCoalescing {
 		t.Fatalf("off policy did not force off: concurrency=%d span=%t backlog=%t", opts.FlushApplyConcurrency, opts.FlushApplySpanNative, opts.FlushBacklogCoalescing)
+	}
+	if opts.LeafPageReadCacheWriteAdmission != LeafPageReadCacheWriteAdmissionAdaptive {
+		t.Fatalf("off policy should not rewrite explicit cache admission: %s", opts.LeafPageReadCacheWriteAdmission)
 	}
 }
 
@@ -96,7 +136,10 @@ func TestNormalizeFlushAdmission_ExplicitOptInKeepsC4Compatibility(t *testing.T)
 	}
 }
 
-func TestNormalizeFlushAdmission_AutoDeclinesLowConcurrencyAndCheckpointDebt(t *testing.T) {
+func TestNormalizeFlushAdmission_AutoDeclinesConfiguredC1RegressionShape(t *testing.T) {
+	oldGOMAXPROCS := runtime.GOMAXPROCS(4)
+	defer runtime.GOMAXPROCS(oldGOMAXPROCS)
+
 	opts := Options{
 		FlushAdmissionPolicy:   FlushAdmissionPolicyAuto,
 		FlushApplyConcurrency:  1,
@@ -108,39 +151,40 @@ func TestNormalizeFlushAdmission_AutoDeclinesLowConcurrencyAndCheckpointDebt(t *
 	if decision.Admitted {
 		t.Fatalf("admitted=true want false")
 	}
-	for _, want := range []string{FlushAdmissionReasonLowConcurrency, FlushAdmissionReasonCheckpointDebt} {
-		if !strings.Contains(decision.Reason, want) {
-			t.Fatalf("reason=%q missing %q", decision.Reason, want)
-		}
+	if decision.Reason != FlushAdmissionReasonLowConcurrency {
+		t.Fatalf("reason=%q want %q", decision.Reason, FlushAdmissionReasonLowConcurrency)
 	}
 	if opts.FlushApplyConcurrency != 0 || opts.FlushApplySpanNative || opts.FlushBacklogCoalescing {
-		t.Fatalf("auto decline did not force off: concurrency=%d span=%t backlog=%t", opts.FlushApplyConcurrency, opts.FlushApplySpanNative, opts.FlushBacklogCoalescing)
+		t.Fatalf("auto c1 decline did not force off: concurrency=%d span=%t backlog=%t", opts.FlushApplyConcurrency, opts.FlushApplySpanNative, opts.FlushBacklogCoalescing)
 	}
 }
 
-func TestNormalizeFlushAdmission_AutoDeclinesUnresolvedCheckpointDebtAtC4(t *testing.T) {
-	oldGOMAXPROCS := runtime.GOMAXPROCS(4)
+func TestNormalizeFlushAdmission_AutoCapsConfiguredConcurrencyToC4Candidate(t *testing.T) {
+	oldGOMAXPROCS := runtime.GOMAXPROCS(16)
 	defer runtime.GOMAXPROCS(oldGOMAXPROCS)
 
 	opts := Options{
 		FlushAdmissionPolicy:  FlushAdmissionPolicyAuto,
-		FlushApplyConcurrency: 4,
+		FlushApplyConcurrency: 16,
 	}
 	decision := NormalizeFlushAdmissionOptions(&opts)
 
-	if decision.Admitted {
-		t.Fatalf("admitted=true want false")
+	if !decision.Admitted {
+		t.Fatalf("admitted=false want true; reason=%q", decision.Reason)
 	}
-	if decision.Reason != FlushAdmissionReasonCheckpointDebt {
-		t.Fatalf("reason=%q want %q", decision.Reason, FlushAdmissionReasonCheckpointDebt)
+	if opts.FlushApplyConcurrency != 4 || decision.FlushApplyConcurrency != 4 {
+		t.Fatalf("auto should cap to c4 candidate: opts=%d decision=%d", opts.FlushApplyConcurrency, decision.FlushApplyConcurrency)
 	}
-	if opts.FlushApplyConcurrency != 0 || opts.FlushApplySpanNative || opts.FlushBacklogCoalescing {
-		t.Fatalf("auto checkpoint decline did not force off: concurrency=%d span=%t backlog=%t", opts.FlushApplyConcurrency, opts.FlushApplySpanNative, opts.FlushBacklogCoalescing)
+	if decision.Reason != FlushAdmissionReasonAutoAdmittedC4Adapt {
+		t.Fatalf("reason=%q want %q", decision.Reason, FlushAdmissionReasonAutoAdmittedC4Adapt)
 	}
 }
 
-func TestFlushAdmissionStatsExposePolicyAndReason(t *testing.T) {
-	opts := Options{FlushAdmissionPolicy: FlushAdmissionPolicyAuto, FlushApplyConcurrency: 1, FlushApplySpanNative: true}
+func TestFlushAdmissionStatsExposePolicyReasonAndCandidate(t *testing.T) {
+	oldGOMAXPROCS := runtime.GOMAXPROCS(4)
+	defer runtime.GOMAXPROCS(oldGOMAXPROCS)
+
+	opts := Options{}
 	decision := NormalizeFlushAdmissionOptions(&opts)
 	db := &DB{flushAdmission: decision}
 	stats := map[string]string{}
@@ -149,14 +193,20 @@ func TestFlushAdmissionStatsExposePolicyAndReason(t *testing.T) {
 	if got := stats["treedb.flush_admission.policy"]; got != "auto" {
 		t.Fatalf("stats policy=%q want auto", got)
 	}
-	if got := stats["treedb.flush_admission.admitted"]; got != "false" {
-		t.Fatalf("stats admitted=%q want false", got)
+	if got := stats["treedb.flush_admission.admitted"]; got != "true" {
+		t.Fatalf("stats admitted=%q want true", got)
 	}
-	if got := stats["treedb.flush_admission.reason"]; !strings.Contains(got, FlushAdmissionReasonLowConcurrency) || !strings.Contains(got, FlushAdmissionReasonCheckpointDebt) {
-		t.Fatalf("stats reason=%q missing low concurrency/checkpoint debt", got)
+	if got := stats["treedb.flush_admission.reason"]; got != FlushAdmissionReasonAutoAdmittedC4Adapt {
+		t.Fatalf("stats reason=%q want %q", got, FlushAdmissionReasonAutoAdmittedC4Adapt)
 	}
-	if got := stats["treedb.flush_admission.flush_apply_span_native"]; got != "false" {
-		t.Fatalf("stats span native=%q want false", got)
+	if got := stats["treedb.flush_admission.flush_apply_concurrency"]; got != "4" {
+		t.Fatalf("stats concurrency=%q want 4", got)
+	}
+	if got := stats["treedb.flush_admission.flush_apply_span_native"]; got != "true" {
+		t.Fatalf("stats span native=%q want true", got)
+	}
+	if got := stats["treedb.flush_admission.leaf_page_read_cache_write_admission"]; got != "adaptive" {
+		t.Fatalf("stats cache admission=%q want adaptive", got)
 	}
 }
 
@@ -165,11 +215,11 @@ func TestParseFlushAdmissionPolicy(t *testing.T) {
 		raw  string
 		want FlushAdmissionPolicy
 	}{
-		{raw: "", want: FlushAdmissionPolicyExplicit},
-		{raw: "default", want: FlushAdmissionPolicyExplicit},
+		{raw: "", want: FlushAdmissionPolicyAuto},
+		{raw: "default", want: FlushAdmissionPolicyAuto},
+		{raw: "auto", want: FlushAdmissionPolicyAuto},
 		{raw: "explicit", want: FlushAdmissionPolicyExplicit},
 		{raw: "off", want: FlushAdmissionPolicyOff},
-		{raw: "auto", want: FlushAdmissionPolicyAuto},
 	} {
 		got, err := ParseFlushAdmissionPolicy(tc.raw)
 		if err != nil {
@@ -181,5 +231,15 @@ func TestParseFlushAdmissionPolicy(t *testing.T) {
 	}
 	if _, err := ParseFlushAdmissionPolicy("bad"); err == nil {
 		t.Fatal("ParseFlushAdmissionPolicy accepted bad policy")
+	}
+}
+
+func TestNormalizeFlushAdmission_StatsDefaultsKeepExplicitNoOptIn(t *testing.T) {
+	d := FlushAdmissionDecision{Policy: FlushAdmissionPolicyExplicit}.withStatsDefaults()
+	if d.Admitted {
+		t.Fatalf("admitted=true want false")
+	}
+	if !strings.Contains(d.Reason, FlushAdmissionReasonNoExplicitOptIn) {
+		t.Fatalf("reason=%q missing %q", d.Reason, FlushAdmissionReasonNoExplicitOptIn)
 	}
 }

--- a/TreeDB/db/flush_apply_parallel_test.go
+++ b/TreeDB/db/flush_apply_parallel_test.go
@@ -81,6 +81,7 @@ func openFlushApplyTestDBWithSpanNative(t *testing.T, concurrency int, spanNativ
 	d, err := Open(Options{
 		Dir:                   t.TempDir(),
 		ChunkSize:             64 * 1024,
+		FlushAdmissionPolicy:  FlushAdmissionPolicyExplicit,
 		FlushApplyConcurrency: concurrency,
 		FlushApplyMinEntries:  1,
 		FlushApplyMinSpans:    1,

--- a/TreeDB/db/flush_apply_parallel_test.go
+++ b/TreeDB/db/flush_apply_parallel_test.go
@@ -105,6 +105,7 @@ func openFlushApplyLeafLogTestDBWithSpanNative(t *testing.T, concurrency int, sp
 		Dir:                        t.TempDir(),
 		ChunkSize:                  64 * 1024,
 		IndexOuterLeavesInValueLog: true,
+		FlushAdmissionPolicy:       FlushAdmissionPolicyExplicit,
 		FlushApplyConcurrency:      concurrency,
 		FlushApplyMinEntries:       1,
 		FlushApplyMinSpans:         1,

--- a/TreeDB/db/flush_apply_stats.go
+++ b/TreeDB/db/flush_apply_stats.go
@@ -323,6 +323,7 @@ func (db *DB) appendFlushApplyStats(stats map[string]string) {
 	stats["treedb.flush_admission.flush_apply_concurrency"] = fmt.Sprintf("%d", admission.FlushApplyConcurrency)
 	stats["treedb.flush_admission.flush_apply_span_native"] = fmt.Sprintf("%t", admission.FlushApplySpanNative)
 	stats["treedb.flush_admission.flush_backlog_coalescing"] = fmt.Sprintf("%t", admission.FlushBacklogCoalescing)
+	stats["treedb.flush_admission.leaf_page_read_cache_write_admission"] = admission.LeafPageReadCacheWriteAdmission.String()
 
 	applyOps := db.flushApplyOps.Load()
 	stats["treedb.flush_apply.apply_calls_total"] = fmt.Sprintf("%d", db.flushApplyCalls.Load())

--- a/TreeDB/db/read_only_prepare_test.go
+++ b/TreeDB/db/read_only_prepare_test.go
@@ -51,7 +51,7 @@ func readOnlyPrepareRootSeq(d *DB) (root, seq uint64) {
 
 func TestDBPrepareReadOnlyApplyPlanSideEffectFreeAndStats(t *testing.T) {
 	dir := t.TempDir()
-	d, err := Open(Options{Dir: dir})
+	d, err := Open(Options{Dir: dir, FlushAdmissionPolicy: FlushAdmissionPolicyExplicit})
 	if err != nil {
 		t.Fatalf("open db: %v", err)
 	}
@@ -136,7 +136,7 @@ func TestDBPrepareReadOnlyApplyPlanSideEffectFreeAndStats(t *testing.T) {
 
 func TestOrderedRootDeltaBatchPrepareReadOnlyStats(t *testing.T) {
 	dir := t.TempDir()
-	d, err := Open(Options{Dir: dir})
+	d, err := Open(Options{Dir: dir, FlushAdmissionPolicy: FlushAdmissionPolicyExplicit})
 	if err != nil {
 		t.Fatalf("open db: %v", err)
 	}

--- a/TreeDB/reopen_verify_test.go
+++ b/TreeDB/reopen_verify_test.go
@@ -331,6 +331,7 @@ func TestReopenVerify_ParallelFlushLeafLogOutput(t *testing.T) {
 		Dir:                        dir,
 		IndexOuterLeavesInValueLog: true,
 		FlushThreshold:             64 * 1024,
+		FlushAdmissionPolicy:       treedb.FlushAdmissionPolicyExplicit,
 		FlushApplyConcurrency:      4,
 		FlushApplyMinEntries:       1,
 		FlushApplyMinSpans:         1,

--- a/TreeDB/span_native_hardening_test.go
+++ b/TreeDB/span_native_hardening_test.go
@@ -29,6 +29,7 @@ func TestSpanNativeCheckpointDrainFallbackReopenRewriteAndGC(t *testing.T) {
 	opts := treedb.Options{
 		Dir:                   dir,
 		FlushThreshold:        64 << 20,
+		FlushAdmissionPolicy:  treedb.FlushAdmissionPolicyExplicit,
 		FlushApplyConcurrency: 4,
 		FlushApplyMinEntries:  1,
 		FlushApplyMinSpans:    1,

--- a/cmd/unified_bench/adapter_treedb.go
+++ b/cmd/unified_bench/adapter_treedb.go
@@ -39,16 +39,16 @@ var (
 	treedbFlushBuildChunkMinBytes         = flag.Int("treedb-flush-build-chunk-min-bytes", 0, "TreeDB (cached): adaptive chunk min bytes (0=default)")
 	treedbFlushBuildChunkMaxBytes         = flag.Int("treedb-flush-build-chunk-max-bytes", 0, "TreeDB (cached): adaptive chunk max bytes (0=default)")
 	treedbFlushBuildPrefetchUnits         = flag.Int("treedb-flush-build-prefetch-units", 0, "TreeDB (cached): prefetch units for parallel flush build (0=default)")
-	treedbFlushAdmissionPolicy            = flag.String("treedb-flush-admission-policy", "explicit", "TreeDB: span-native/backlog/concurrency admission policy (explicit|off|auto; default explicit preserves existing opt-in flags)")
-	treedbFlushApplyConcurrency           = flag.Int("treedb-flush-apply-concurrency", 0, "TreeDB: opt-in flush/apply COW worker-pool concurrency (0/1=disabled)")
-	treedbFlushApplyMinEntries            = flag.Int("treedb-flush-apply-min-entries", 0, "TreeDB: minimum planned span ops to enable opt-in parallel apply (0=default)")
-	treedbFlushApplyMinSpans              = flag.Int("treedb-flush-apply-min-spans", 0, "TreeDB: minimum planned leaf spans to enable opt-in parallel apply (0=default)")
-	treedbFlushApplyMinBytes              = flag.Int("treedb-flush-apply-min-bytes", 0, "TreeDB: minimum planned span bytes to enable opt-in parallel apply (0=default)")
-	treedbFlushApplySpanNative            = flag.Bool("treedb-flush-apply-span-native", false, "TreeDB: opt-in M10 span-native apply/reducer for eligible exact point spans (default off)")
+	treedbFlushAdmissionPolicy            = flag.String("treedb-flush-admission-policy", "auto", "TreeDB: span-native/backlog/concurrency admission policy (auto|explicit|off; default auto selects conservative c4/adaptive when admitted)")
+	treedbFlushApplyConcurrency           = flag.Int("treedb-flush-apply-concurrency", 0, "TreeDB: flush/apply COW worker-pool concurrency override (auto default chooses c4 when admitted; 0/1 disables under explicit)")
+	treedbFlushApplyMinEntries            = flag.Int("treedb-flush-apply-min-entries", 0, "TreeDB: minimum planned span ops to enable parallel apply (0=policy default)")
+	treedbFlushApplyMinSpans              = flag.Int("treedb-flush-apply-min-spans", 0, "TreeDB: minimum planned leaf spans to enable parallel apply (0=policy default)")
+	treedbFlushApplyMinBytes              = flag.Int("treedb-flush-apply-min-bytes", 0, "TreeDB: minimum planned span bytes to enable parallel apply (0=policy default)")
+	treedbFlushApplySpanNative            = flag.Bool("treedb-flush-apply-span-native", false, "TreeDB: M10 span-native apply/reducer override for eligible exact point spans (auto enables when admitted)")
 	treedbFlushBackendMaxEntries          = flag.Int("treedb-flush-backend-max-entries", 0, "TreeDB (cached): max entries per backend flush batch before intermediate commit (0=default, <0=disable chunking)")
 	treedbFlushBackendMaxBatches          = flag.Int("treedb-flush-backend-max-batches", 0, "TreeDB (cached): max intermediate backend commits per flush (0=default, <0=disable cap)")
 	treedbFlushSpanRunTargetPlanning      = flag.Bool("treedb-flush-span-run-target-planning", false, "TreeDB (cached): diagnostic opt-in read-only target-leaf planning for canonical flush runs")
-	treedbFlushBacklogCoalescing          = flag.Bool("treedb-flush-backlog-coalescing", false, "TreeDB (cached): opt-in M11 bounded adaptive backlog coalescing controller")
+	treedbFlushBacklogCoalescing          = flag.Bool("treedb-flush-backlog-coalescing", false, "TreeDB (cached): M11 bounded adaptive backlog coalescing override (auto enables when admitted)")
 	treedbFlushBacklogCoalescingMaxMems   = flag.Int("treedb-flush-backlog-coalescing-max-memtables", 0, "TreeDB (cached): M11 coalescing max memtables per run (0=default)")
 	treedbFlushBacklogCoalescingMaxBytes  = flag.Int64("treedb-flush-backlog-coalescing-max-bytes", 0, "TreeDB (cached): M11 coalescing soft max queued bytes per run; first included memtable may exceed (0=default)")
 	treedbFlushBacklogCoalescingMaxOps    = flag.Int("treedb-flush-backlog-coalescing-max-ops", 0, "TreeDB (cached): M11 coalescing soft max point ops per run; first included memtable may exceed (0=default)")
@@ -969,6 +969,8 @@ func buildTreeDBOptionsWithConfig(dir string, cfg treeDBOptionsBuildConfig) (tre
 	admission := treedbdb.NormalizeFlushAdmissionOptions(&opts)
 	if admission.Policy == treedb.FlushAdmissionPolicyOff {
 		notes = append(notes, "flush_admission_policy=off force-disables span-native, backlog coalescing, and flush-apply concurrency")
+	} else if admission.Policy == treedb.FlushAdmissionPolicyAuto && admission.Admitted {
+		notes = append(notes, "flush_admission_policy=auto admitted: "+admission.Reason)
 	} else if admission.Policy == treedb.FlushAdmissionPolicyAuto && !admission.Admitted {
 		notes = append(notes, "flush_admission_policy=auto declined: "+admission.Reason)
 	}

--- a/cmd/unified_bench/main.go
+++ b/cmd/unified_bench/main.go
@@ -6285,6 +6285,13 @@ func renderTreeDBSelectedStatsString(instances []*DBInstance, treeStats map[stri
 	}{
 		{label: "write_path.mode", alts: []string{"treedb.write_path.mode"}},
 		{label: "write_path.redo_log", alts: []string{"treedb.write_path.redo_log"}},
+		{label: "flush_admission.policy", alts: []string{"treedb.flush_admission.policy"}},
+		{label: "flush_admission.admitted", alts: []string{"treedb.flush_admission.admitted"}},
+		{label: "flush_admission.reason", alts: []string{"treedb.flush_admission.reason"}},
+		{label: "flush_admission.flush_apply_concurrency", alts: []string{"treedb.flush_admission.flush_apply_concurrency"}},
+		{label: "flush_admission.flush_apply_span_native", alts: []string{"treedb.flush_admission.flush_apply_span_native"}},
+		{label: "flush_admission.flush_backlog_coalescing", alts: []string{"treedb.flush_admission.flush_backlog_coalescing"}},
+		{label: "flush_admission.leaf_page_read_cache_write_admission", alts: []string{"treedb.flush_admission.leaf_page_read_cache_write_admission"}},
 		{label: "vlog_mmap.current_writable_map_target_bytes", alts: []string{"treedb.vlog.mmap_current_writable_map_target_bytes", "treedb.cache.vlog_mmap.current_writable_map_target_bytes"}},
 		{label: "vlog_mmap.max_mapped_sealed_segments", alts: []string{"treedb.vlog.mmap_max_mapped_sealed_segments", "treedb.cache.vlog_mmap.max_mapped_sealed_segments"}},
 		{label: "vlog_mmap.max_mapped_sealed_bytes", alts: []string{"treedb.vlog.mmap_max_mapped_sealed_bytes", "treedb.cache.vlog_mmap.max_mapped_sealed_bytes"}},

--- a/cmd/unified_bench/main_test.go
+++ b/cmd/unified_bench/main_test.go
@@ -2963,6 +2963,11 @@ func TestRenderTreeDBSelectedStatsString_IncludesSpanRunProofCounters(t *testing
 	instances := []*DBInstance{{Name: "tree", Wrapper: &fixedNameDB{name: "TreeDB"}}}
 	stats := map[string]map[string]string{
 		"TreeDB": {
+			"treedb.flush_admission.policy":                                                        "auto",
+			"treedb.flush_admission.admitted":                                                      "true",
+			"treedb.flush_admission.reason":                                                        "auto_admitted_c4_adaptive",
+			"treedb.flush_admission.flush_apply_concurrency":                                       "4",
+			"treedb.flush_admission.leaf_page_read_cache_write_admission":                          "adaptive",
 			"treedb.cache.flush_span_run.source_point_ops_total":                                   "11",
 			"treedb.cache.flush_span_run.planned_point_ops_total":                                  "10",
 			"treedb.cache.flush_span_run.backend_chunks_total":                                     "3",
@@ -2987,6 +2992,11 @@ func TestRenderTreeDBSelectedStatsString_IncludesSpanRunProofCounters(t *testing
 
 	got := renderTreeDBSelectedStatsString(instances, stats)
 	for _, want := range []string{
+		"flush_admission.policy: auto",
+		"flush_admission.admitted: true",
+		"flush_admission.reason: auto_admitted_c4_adaptive",
+		"flush_admission.flush_apply_concurrency: 4",
+		"flush_admission.leaf_page_read_cache_write_admission: adaptive",
 		"flush_span_run.source_point_ops_total: 11",
 		"flush_span_run.planned_point_ops_total: 10",
 		"flush_span_run.backend_chunks_total: 3",

--- a/cmd/unified_bench/profiles_treedb_index_test.go
+++ b/cmd/unified_bench/profiles_treedb_index_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"runtime"
 	"strconv"
 	"strings"
 	"testing"
@@ -110,6 +111,48 @@ func TestBuildTreeDBOptions_LeafPageReadCacheWriteAdmissionRejectsInvalid(t *tes
 	}
 }
 
+func TestBuildTreeDBOptions_FlushAdmissionDefaultAutoReportsC4Adaptive(t *testing.T) {
+	oldGOMAXPROCS := runtime.GOMAXPROCS(4)
+	defer runtime.GOMAXPROCS(oldGOMAXPROCS)
+	saved := saveTreeDBFlagState()
+	defer restoreTreeDBFlagState(saved)
+
+	resetTreeDBIndexFlagsForTest()
+
+	opts, rep, err := buildTreeDBOptions("")
+	if err != nil {
+		t.Fatalf("buildTreeDBOptions default auto: %v", err)
+	}
+	if opts.FlushAdmissionPolicy != treedb.FlushAdmissionPolicyAuto || opts.FlushApplyConcurrency != 4 || !opts.FlushApplySpanNative || !opts.FlushBacklogCoalescing {
+		t.Fatalf("default auto candidate not selected: policy=%s concurrency=%d span=%t backlog=%t", opts.FlushAdmissionPolicy, opts.FlushApplyConcurrency, opts.FlushApplySpanNative, opts.FlushBacklogCoalescing)
+	}
+	if opts.FlushApplyMinEntries != 1 || opts.FlushApplyMinSpans != 1 || opts.FlushApplyMinBytes != 1 {
+		t.Fatalf("default auto min gates not selected: entries=%d spans=%d bytes=%d", opts.FlushApplyMinEntries, opts.FlushApplyMinSpans, opts.FlushApplyMinBytes)
+	}
+	if opts.LeafPageReadCacheWriteAdmission != treedb.LeafPageReadCacheWriteAdmissionAdaptive {
+		t.Fatalf("default auto cache admission=%s want adaptive", opts.LeafPageReadCacheWriteAdmission)
+	}
+	text := rep.formatText("")
+	for _, want := range []string{
+		"flush_admission_policy=auto",
+		"flush_admission_admitted=true",
+		"flush_admission_reason=auto_admitted_c4_adaptive",
+		"flush_admission_effective_concurrency=4",
+		"flush_apply_concurrency=4",
+		"flush_apply_min_entries_configured=1",
+		"flush_apply_min_spans_configured=1",
+		"flush_apply_min_bytes_configured=1",
+		"flush_apply_span_native=true",
+		"flush_backlog_coalescing=true",
+		"outer_leaf_read_cache_write_admission=adaptive",
+		"  - flush_admission_policy=auto admitted: auto_admitted_c4_adaptive",
+	} {
+		if !treeDBReportHasLine(text, want) {
+			t.Fatalf("resolved options missing line %q: %q", want, text)
+		}
+	}
+}
+
 func TestBuildTreeDBOptions_FlushAdmissionExplicitPreservesOptInFlags(t *testing.T) {
 	saved := saveTreeDBFlagState()
 	defer restoreTreeDBFlagState(saved)
@@ -173,7 +216,7 @@ func TestBuildTreeDBOptions_FlushAdmissionOffForcesOff(t *testing.T) {
 	}
 }
 
-func TestBuildTreeDBOptions_FlushAdmissionAutoDeclinesLowConcurrencyAndCheckpointDebt(t *testing.T) {
+func TestBuildTreeDBOptions_FlushAdmissionAutoDeclinesLowConcurrency(t *testing.T) {
 	saved := saveTreeDBFlagState()
 	defer restoreTreeDBFlagState(saved)
 
@@ -194,8 +237,8 @@ func TestBuildTreeDBOptions_FlushAdmissionAutoDeclinesLowConcurrencyAndCheckpoin
 	for _, want := range []string{
 		"flush_admission_policy=auto",
 		"flush_admission_admitted=false",
-		"flush_admission_reason=low_concurrency,checkpoint_debt_unresolved",
-		"  - flush_admission_policy=auto declined: low_concurrency,checkpoint_debt_unresolved",
+		"flush_admission_reason=low_concurrency",
+		"  - flush_admission_policy=auto declined: low_concurrency",
 	} {
 		if !treeDBReportHasLine(text, want) {
 			t.Fatalf("resolved options missing line %q: %q", want, text)
@@ -529,7 +572,7 @@ func resetTreeDBIndexFlagsForTest() {
 	*treedbAllowUnsafe = false
 	*treedbMaintenanceMode = "bench"
 	*treedbFlushThreshold = 64 * 1024 * 1024
-	*treedbFlushAdmissionPolicy = "explicit"
+	*treedbFlushAdmissionPolicy = "auto"
 	*treedbFlushApplyConcurrency = 0
 	*treedbFlushApplySpanNative = false
 	*treedbFlushBacklogCoalescing = false

--- a/docs/TREEDB_SPAN_NATIVE_DEFAULT_GATE_M5_REPORT.md
+++ b/docs/TREEDB_SPAN_NATIVE_DEFAULT_GATE_M5_REPORT.md
@@ -1,0 +1,226 @@
+# TreeDB span-native default gate M5 report
+
+Issue: #2788. Parent tracker: #2782.
+
+## Decision
+
+M5 enables a conservative TreeDB default admission policy for the span-native
+flush/apply + backlog coalescing stack:
+
+- default/unconfigured `FlushAdmissionPolicy` is `auto`;
+- `auto` admits the measured `c4` span-native + backlog candidate with adaptive
+  write-side outer-leaf cache admission when the low-concurrency and durability
+  guardrails pass;
+- `auto` declines low-concurrency/c1-shaped configurations and WAL-off unsafe
+  durability;
+- `FlushAdmissionPolicyOff` remains the immediate rollback knob;
+- `FlushAdmissionPolicyExplicit` preserves explicit opt-in/override behavior for
+  c4/c16/immediate/cache-disabled comparison rows and experiments.
+
+The chosen default is **not** the write-only ceiling row. `c16` and
+cache-disabled rows remain explicit comparison/diagnostic rows because they carry
+higher allocation/contention or remove the read-cache axis.
+
+## Artifact roots
+
+Public paths intentionally redact the benchmark host, user, address, and raw
+mount path.
+
+- Final gate root:
+  `<remote-profile-root>/2788_final_gate_20260617_034229/final_10mm`
+- Final parsed summary:
+  `<remote-profile-root>/2788_final_gate_20260617_034229/final_10mm/2788_final_gate_summary.md`
+  and
+  `<remote-profile-root>/2788_final_gate_20260617_034229/final_10mm/2788_final_gate_summary.json`
+- Write/checkpoint parser summary:
+  `<remote-profile-root>/2788_final_gate_20260617_034229/final_10mm/write_checkpoint/m14_matrix_summary.md`
+  and
+  `<remote-profile-root>/2788_final_gate_20260617_034229/final_10mm/write_checkpoint/m14_matrix_summary.json`
+- Settled-scan rechecks:
+  - `<remote-profile-root>/2788_final_gate_20260617_034229/scan_recheck_10mm`
+  - `<remote-profile-root>/2788_final_gate_20260617_034229/scan_recheck2_10mm`
+  - `<remote-profile-root>/2788_final_gate_20260617_034229/scan_recheck3_reversed_10mm`
+
+## Matrix command policy
+
+Because the branch changes unified-bench's default
+`-treedb-flush-admission-policy` to `auto`, explicit comparison rows must pass an
+explicit policy flag:
+
+- unconfigured candidate row: no admission-policy flag, relying on default auto;
+- rollback rows: `-treedb-flush-admission-policy=off`;
+- explicit c4/c16/cache-disabled rows:
+  `-treedb-flush-admission-policy=explicit` plus the row-specific knobs.
+
+Common final 10MM shape:
+
+```text
+-dbs treedb
+-keys 10000000
+-valsize 128
+-batchsize 8000
+-path-label m8-m14-10mm-gate
+-treedb-journal-lanes=1
+-progress=false
+```
+
+Write/checkpoint rows used:
+
+```text
+-test sequential_write,batch_random,random_write
+-checkpoint-between-tests
+```
+
+Settled point-read rows used:
+
+```text
+-test sequential_write,random_write,random_read
+-checkpoint-between-tests
+-settle-before-scans
+-treedb-cache-stats-before-reads
+-read-require-hit
+```
+
+Settled scan rows used:
+
+```text
+-test sequential_write,random_write,full_scan,prefix_scan
+-checkpoint-between-tests
+-settle-before-scans
+-treedb-cache-stats-before-reads
+-range-queries 200
+-range-span 100
+```
+
+Mixed/debt read+scan rows used the same read/scan tests without a settle
+boundary before reads/scans.
+
+## Write/checkpoint gate
+
+| Row | Policy | Admitted | Reason | Cache admission | random_write | Δ random | RW checkpoint | checkpoint efficiency | write+checkpoint | Δ write+checkpoint | post-run checkpoint |
+| --- | --- | ---: | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| `main_default_unconfigured` | explicit | false | `no_explicit_opt_in` | immediate | 159,527 | +0.0% | 11.20s | 0.893 Mops/s | 135.3 kops/s | +0.0% | 9.29s |
+| `branch_default_auto` | auto | true | `auto_admitted_c4_adaptive` | adaptive | 272,400 | +70.8% | 7.89s | 1.267 Mops/s | 224.2 kops/s | +65.7% | 6.44s |
+| `branch_forced_off` | off | false | `policy_off` | immediate | 152,289 | -4.5% | 11.06s | 0.904 Mops/s | 130.3 kops/s | -3.7% | 7.43s |
+| `branch_auto_c1_decline` | auto | false | `low_concurrency` | immediate | 149,759 | -6.1% | 9.03s | 1.107 Mops/s | 131.9 kops/s | -2.5% | 8.82s |
+| `branch_explicit_c4_adaptive` | explicit | true | `explicit_opt_in` | adaptive | 271,405 | +70.1% | 7.85s | 1.274 Mops/s | 223.7 kops/s | +65.3% | 8.35s |
+| `branch_explicit_c4_immediate` | explicit | true | `explicit_opt_in` | immediate | 288,985 | +81.2% | 9.96s | 1.004 Mops/s | 224.4 kops/s | +65.8% | 10.65s |
+| `branch_explicit_c16_immediate` | explicit | true | `explicit_opt_in` | immediate | 295,189 | +85.0% | 7.24s | 1.381 Mops/s | 243.2 kops/s | +79.7% | 5.04s |
+| `branch_explicit_c4_cache_disabled` | explicit | true | `explicit_opt_in` | diagnostic disabled cache | 303,888 | +90.5% | 7.84s | 1.276 Mops/s | 245.4 kops/s | +81.3% | 9.04s |
+
+Interpretation:
+
+- The default-auto row materially improves random-write throughput and
+  write+checkpoint throughput versus current main default.
+- Checkpoint boundaries remain multi-second. Per #2794, this is accepted as a
+  bounded pause-profile model tradeoff when normalized checkpoint efficiency and
+  write+checkpoint throughput remain strong.
+- `branch_forced_off` and `branch_auto_c1_decline` preserve fail-closed behavior
+  and do not admit the known M14 c1 regression shape.
+- `c16` remains an explicit ceiling/alternative, not the default, because it has
+  higher allocation/contention tradeoffs even when its write+checkpoint row is
+  strong.
+
+## Read/scan guardrails and scan recheck
+
+Original final rows:
+
+| Workload | Row | random_write | random_read | Δ read | full_scan | Δ full | prefix_scan | Δ prefix | RW checkpoint |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| settled point-read | `main_default_unconfigured` | 407,138 | 254,220 | +0.0% | | | | | 1.06s |
+| settled point-read | `branch_default_auto` | 587,433 | 259,675 | +2.1% | | | | | 856.79ms |
+| settled scan | `main_default_unconfigured` | 406,160 | | | 4,477,346 | +0.0% | 4,647,435 | +0.0% | 1.04s |
+| settled scan | `branch_default_auto` | 599,736 | | | 4,267,533 | -4.7% | 4,292,895 | -7.6% | 817.72ms |
+| mixed/debt read+scan | `main_default_unconfigured` | 345,161 | 233,041 | +0.0% | 4,360,130 | +0.0% | 4,696,435 | +0.0% | |
+| mixed/debt read+scan | `branch_default_auto` | 560,678 | 241,249 | +3.5% | 4,756,140 | +9.1% | 4,602,588 | -2.0% | |
+
+The original settled-scan row showed a material-looking scan regression and was
+not accepted as-is. Three focused same-host 10MM settled-scan rechecks were run:
+
+| Recheck root | Order | main full | branch full | Δ full | main prefix | branch prefix | Δ prefix |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| `<remote-profile-root>/2788_final_gate_20260617_034229/scan_recheck_10mm` | main first | 4,512,678 | 4,443,442 | -1.5% | 4,674,164 | 4,588,975 | -1.8% |
+| `<remote-profile-root>/2788_final_gate_20260617_034229/scan_recheck2_10mm` | main first | 4,539,130 | 4,408,511 | -2.9% | 4,690,126 | 4,635,810 | -1.2% |
+| `<remote-profile-root>/2788_final_gate_20260617_034229/scan_recheck3_reversed_10mm` | branch first | 4,485,289 | 4,649,065 | +3.7% | 4,464,942 | 4,529,067 | +1.4% |
+
+Recheck median branch-default delta: full-scan -1.5%, prefix-scan -1.2%. The
+reversed-order recheck was positive for both scan metrics, so the original
+`-7.6%` prefix-scan row is treated as a noisy outlier rather than a reproducible
+material regression. The report intentionally keeps both the original row and
+rechecks visible.
+
+Point-read and mixed/debt read+scan guardrails are flat to faster for the
+default-auto row in the final gate.
+
+## Required counters
+
+Write/checkpoint counters from row-local JSON stats:
+
+| Row | old-leaf B/op | leaf merges/op | append frames/op | span used ops | close/checkpoint fallback ops | backlog runs | backlog extra ops | cache stores | write stores/skips | index.db | leaf_vlog |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| `main_default_unconfigured` | 1609.048482 | 0.356899 | 0.357579 | 0 | 0 | 0 | 0 | 13,843,600 | 0/0 | 605 MiB | 3.7 GiB |
+| `branch_default_auto` | 1367.772644 | 0.313250 | 0.313807 | 29,686,164 | 218,612 | 2 | 986,896 | 1,445,504 | 1,445,504/10,698,674 | 443 MiB | 3.3 GiB |
+| `branch_forced_off` | 1609.050863 | 0.356898 | 0.357579 | 0 | 0 | 0 | 0 | 13,843,599 | 0/0 | 605 MiB | 3.7 GiB |
+| `branch_auto_c1_decline` | 1609.047905 | 0.356899 | 0.357579 | 0 | 0 | 0 | 0 | 13,843,617 | 0/0 | 605 MiB | 3.7 GiB |
+| `branch_explicit_c4_adaptive` | 1367.801864 | 0.313251 | 0.313808 | 29,686,163 | 218,612 | 2 | 986,896 | 1,448,365 | 1,448,365/10,695,840 | 433 MiB | 3.3 GiB |
+| `branch_explicit_c4_immediate` | 1403.267800 | 0.320052 | 0.320612 | 29,688,493 | 218,612 | 2 | 986,896 | 12,410,958 | 0/0 | 442 MiB | 3.3 GiB |
+| `branch_explicit_c16_immediate` | 1403.690578 | 0.319872 | 0.320435 | 29,196,523 | 710,839 | 2 | 986,896 | 12,415,627 | 0/0 | 459 MiB | 3.3 GiB |
+| `branch_explicit_c4_cache_disabled` | 1367.752190 | 0.313250 | 0.313807 | 29,686,165 | 218,612 | 2 | 986,896 | 0 | 0/0 | 427 MiB | 3.3 GiB |
+
+Default auto uses adaptive write admission: about 1.45M write-side cache stores
+and 10.70M write skips in the write/checkpoint row, versus 12.41M stores for the
+explicit c4 immediate row. This preserves the M4 cache-churn rationale while
+keeping read-miss admission intact in read guardrails.
+
+## Focused validation
+
+Final-root focused test logs are under
+`<remote-profile-root>/2788_final_gate_20260617_034229/final_10mm/focused_tests/`.
+
+Commands:
+
+```text
+git diff --check
+go test ./TreeDB/db ./TreeDB/caching ./TreeDB/zipper ./cmd/unified_bench -count=1
+go test ./TreeDB -run 'TestReopenVerify_(WALOn_Checkpoint|WALOn_WriteSync|WALOn_Checkpoint_LeafPagesInValueLog|LeafPageLogGroupedFrameCRCIntegrityModes)$' -count=1
+go test ./TreeDB/db -run 'Test(NormalizeFlushAdmission|FlushAdmissionStats|ParseFlushAdmission|LeafPageReadCache(AdaptiveWriteAdmission|ConcurrentSetAssociativeAccess|WriteAdmissionImmediate))' -count=1
+go test -race ./TreeDB/db -run 'Test(NormalizeFlushAdmission|LeafPageReadCache(AdaptiveWriteAdmissionSkipsWhenSlotLockContended|ConcurrentSetAssociativeAccess))' -count=1
+```
+
+All focused commands passed.
+
+Local validation before this report:
+
+```text
+git diff --check
+go test ./TreeDB/db ./TreeDB/caching ./TreeDB/zipper ./cmd/unified_bench -count=1
+```
+
+## Rollback and caveats
+
+Rollback:
+
+- API: set `Options.FlushAdmissionPolicy = FlushAdmissionPolicyOff`.
+- unified-bench/CLI: pass `-treedb-flush-admission-policy=off`.
+- The rollback row force-disables span-native apply, backlog coalescing, and
+  flush-apply concurrency.
+
+Caveats:
+
+- The default auto policy requires the low-concurrency guardrail to pass and
+  declines c1-shaped configurations.
+- WAL-off unsafe durability is declined by default auto. Explicit policy remains
+  available for experiments that intentionally choose unsafe durability.
+- Checkpoint pauses remain visible multi-second events. They are accepted here
+  because normalized checkpoint efficiency and write+checkpoint throughput pass
+  the #2794 model gate; this is a pause-profile tradeoff, not a claim that
+  checkpoint debt disappeared.
+- The original final settled-scan row is retained because it looked material.
+  Focused rechecks did not reproduce a material scan regression.
+- Cache-disabled remains diagnostic only and is not a default candidate.
+
+## Handoff
+
+M5 gives the parent tracker a default-on decision with rollback. Future work can
+still revisit the policy if production workloads show scan-tail sensitivity,
+checkpoint pause sensitivity, or allocation/contention issues outside this gate.

--- a/docs/TREEDB_TUNING.md
+++ b/docs/TREEDB_TUNING.md
@@ -90,18 +90,49 @@ optionally build the `SetOps` batch in parallel:
 - `>1` uses up to that many goroutines to build per-memtable ops, then concatenates in queue order
   (oldest → newest) to preserve “newest wins” semantics.
 
-### `Options.FlushApplyConcurrency` (opt-in/default-off)
+### Span-native flush admission (default auto)
 
-`FlushApplyConcurrency > 1` enables the experimental bounded worker-pool path for B-tree COW apply. It is separate from `FlushBuildConcurrency` and remains default-off. The effective worker count is capped by `GOMAXPROCS`, planned leaf-span count, and the `FlushApplyMinEntries`, `FlushApplyMinSpans`, and `FlushApplyMinBytes` gates. Leaf/value-log output remains persistent storage; failed or abandoned apply attempts do not publish roots, and unreachable prepared output is reclaimed only by reachability-based maintenance.
+`Options.FlushAdmissionPolicy` selects how TreeDB admits the span-native
+flush/apply + backlog coalescing path:
+
+- `FlushAdmissionPolicyAuto` is the default/unconfigured policy. It admits the
+  measured conservative c4 span-native + backlog candidate with adaptive
+  write-side outer-leaf cache admission when the low-concurrency and durability
+  guardrails pass.
+- `FlushAdmissionPolicyOff` is the immediate rollback policy. It force-disables
+  span-native apply, backlog coalescing, and flush-apply concurrency.
+- `FlushAdmissionPolicyExplicit` preserves caller-supplied knobs for experiments
+  and explicit c4/c16/cache-disabled comparisons.
+
+`FlushApplyConcurrency`, `FlushApplySpanNative`, and `FlushBacklogCoalescing`
+remain available as explicit knobs. Under the default `auto` policy, TreeDB
+normalizes the admitted candidate to c4 with `FlushApplyMinEntries=1`,
+`FlushApplyMinSpans=1`, `FlushApplyMinBytes=1`, span-native enabled, backlog
+coalescing enabled, and adaptive write-side cache admission. The policy declines
+low-concurrency/c1-shaped configurations and WAL-off unsafe durability. Leaf and
+value-log output remain persistent storage; failed or abandoned apply attempts do
+not publish roots, and unreachable prepared output is reclaimed only by
+reachability-based maintenance.
 
 Rollout guidance:
 
-- Leave the default serial path in place unless checkpoint/drain evidence for the workload justifies an opt-in value.
-- Benchmark `1,2,4,8` (or a smaller hardware-appropriate matrix) with `-checkpoint-between-tests`, allocation profiles, and storage footprint before enabling in production.
-- Roll back by setting `FlushApplyConcurrency <= 1`; no data migration is required because the option changes only the in-memory apply strategy.
-- Watch `treedb.flush_apply.*`, `treedb.cache.flush_apply.*`, `prepared_output.*`, checkpoint wall times, allocation profiles, and final `index.db`/`leaf_vlog` footprint. Regressions in write throughput, checkpoint time, allocation volume, or footprint should keep the option disabled.
+- Use the default auto policy for normal durable cached-mode workloads.
+- Roll back immediately with `FlushAdmissionPolicyOff` or
+  `-treedb-flush-admission-policy=off`; no data migration is required because
+  the option changes only in-memory apply/cache policy.
+- Use `FlushAdmissionPolicyExplicit` for non-default experiments such as c16,
+  immediate cache admission, or cache-disabled diagnostic rows.
+- Watch `treedb.flush_admission.*`, `treedb.flush_apply.*`,
+  `treedb.cache.flush_apply.*`, `prepared_output.*`, checkpoint wall times,
+  allocation profiles, cache hit/store/eviction counters, and final
+  `index.db`/`leaf_vlog` footprint. Reproducible regressions in read/scan
+  throughput, checkpoint time, allocation volume, or footprint should trigger
+  rollback or a narrower explicit policy.
 
-Known blockers: #2786/M3 records a default-off decision for span-native/backlog admission because #2785/M2 left checkpoint-inclusive latency debt unresolved. #2794 must resolve that checkpoint debt, #2795 must resolve fail-closed default admission for the M14 c1 regression, #2787 must run the read/cache guardrail matrix, and #2788 must run the final gate before any default-on claim. Until those pass, treat `FlushApplyConcurrency > 1`, `FlushApplySpanNative`, and `FlushBacklogCoalescing` as workload-specific experimental opt-ins.
+M5/#2788 evidence is recorded in
+`docs/TREEDB_SPAN_NATIVE_DEFAULT_GATE_M5_REPORT.md`. Checkpoint pauses remain
+multi-second and are an accepted bounded model tradeoff, not a claim that
+checkpoint debt disappeared.
 
 ### Read latency under flush debt (cached mode)
 

--- a/scripts/treedb_m14_final_gate.sh
+++ b/scripts/treedb_m14_final_gate.sh
@@ -7,6 +7,10 @@
 #
 # The script runs 10M-key TreeDB write profiles and then invokes
 # scripts/treedb_m14_matrix_summary.py to produce m14_matrix_summary.{md,json}.
+# Since #2788 changed unified-bench's default flush-admission policy to auto,
+# all non-default explicit comparison rows below pass
+# -treedb-flush-admission-policy=explicit so they are not normalized to the
+# current default candidate shape.
 # `unified-bench -profile-dir` auto-runs benchprof; set
 # RUN_MANUAL_BENCHPROF=true to also run the explicit second pass used by older
 # runbooks.
@@ -77,7 +81,7 @@ APPLY_ARGS_BASE=(
 )
 
 write_meta() {
-  local out=$1 label=$2 concurrency=$3 span_native=$4 backlog=$5 cache_mode=$6 note=$7
+  local out=$1 label=$2 concurrency=$3 span_native=$4 backlog=$5 cache_mode=$6 admission_policy=$7 note=$8
   cat > "$out/variant.env" <<EOF_META
 label=$label
 commit=$COMMIT
@@ -85,6 +89,7 @@ concurrency=$concurrency
 span_native=$span_native
 backlog_coalescing=$backlog
 cache_mode=$cache_mode
+flush_admission_policy=$admission_policy
 note=$note
 EOF_META
 }
@@ -102,9 +107,16 @@ run_one() {
     "$label" "$concurrency" "$span_native" "$backlog" "$cache_mode" "$out"
   git rev-parse HEAD > "$out/COMMIT"
   git status --short --branch > "$out/git_status.txt"
-  write_meta "$out" "$label" "$concurrency" "$span_native" "$backlog" "$cache_mode" "$note"
+  local admission_policy=auto_default
+  if [[ "$label" != "default_unconfigured" ]]; then
+    admission_policy=explicit
+  fi
+  write_meta "$out" "$label" "$concurrency" "$span_native" "$backlog" "$cache_mode" "$admission_policy" "$note"
 
   local args=("${COMMON_ARGS[@]}" -profile-dir "$out")
+  if [[ "$admission_policy" == "explicit" ]]; then
+    args+=(-treedb-flush-admission-policy=explicit)
+  fi
   if [[ "$concurrency" != "default" ]]; then
     args+=("${APPLY_ARGS_BASE[@]}" -treedb-flush-apply-concurrency="$concurrency")
   fi

--- a/scripts/treedb_m14_matrix_summary.py
+++ b/scripts/treedb_m14_matrix_summary.py
@@ -132,6 +132,14 @@ def _parse_options(md: str) -> Dict[str, str]:
     return opts
 
 
+def _effective_option(env: Mapping[str, str], opts: Mapping[str, str], env_key: str, option_key: str) -> str:
+    """Return resolved option metadata when present, otherwise variant.env."""
+    value = opts.get(option_key, "")
+    if value != "":
+        return value
+    return env.get(env_key, "")
+
+
 def _parse_checkpoint_table(md: str) -> Dict[str, str]:
     section = _extract_fenced_section(md, "## Checkpoint Time")
     checkpoints: Dict[str, str] = {}
@@ -269,6 +277,7 @@ def load_row(path: Path) -> MatrixRow:
     for test in TESTS:
         test_results = results.get(test, {}) or {}
         ops[test] = _to_float(test_results.get("TreeDB"))
+    options = _parse_options(md)
     counters = {k: str(stats.get(k, "")) for k in COUNTER_KEYS if k in stats}
     counters.update(_parse_selected_stats(md))
     single_op_spans = _to_float(counters.get("treedb.flush_apply.span_run.single_op_spans_total"))
@@ -288,12 +297,12 @@ def load_row(path: Path) -> MatrixRow:
         label=label,
         path=str(path),
         commit=commit,
-        concurrency=env.get("concurrency", ""),
-        span_native=env.get("span_native", ""),
-        backlog_coalescing=env.get("backlog_coalescing", ""),
+        concurrency=_effective_option(env, options, "concurrency", "flush_apply_concurrency"),
+        span_native=_effective_option(env, options, "span_native", "flush_apply_span_native"),
+        backlog_coalescing=_effective_option(env, options, "backlog_coalescing", "flush_backlog_coalescing"),
         cache_mode=env.get("cache_mode", ""),
         note=env.get("note", ""),
-        options=_parse_options(md),
+        options=options,
         ops_per_sec=ops,
         checkpoints=_parse_checkpoint_table(md),
         disk_usage=_parse_disk_usage(md),
@@ -444,10 +453,10 @@ def write_outputs(root: Path, rows: List[MatrixRow], baseline_label: str) -> Non
 def _self_test() -> None:
     with tempfile.TemporaryDirectory() as td:
         root = Path(td)
-        row = root / "span_native_c4"
+        row = root / "default_unconfigured"
         row.mkdir()
         (row / "variant.env").write_text(
-            "label=span_native_c4\ncommit=abc123\nconcurrency=4\nspan_native=true\nbacklog_coalescing=true\ncache_mode=default\nnote=test row\n",
+            "label=default_unconfigured\ncommit=abc123\nconcurrency=default\nspan_native=false\nbacklog_coalescing=false\ncache_mode=default\nnote=test row\n",
             encoding="utf-8",
         )
         (row / "COMMIT").write_text("abc123\n", encoding="utf-8")
@@ -545,17 +554,21 @@ TreeDB:
         rows = load_matrix(root)
         assert len(rows) == 1, rows
         got = rows[0]
-        assert got.label == "span_native_c4"
+        assert got.label == "default_unconfigured"
+        assert got.concurrency == "4", got
+        assert got.span_native == "true", got
+        assert got.backlog_coalescing == "true", got
         assert got.ops_per_sec["random_write"] == 30.0
         assert got.checkpoints["After Run"] == "4.00s", got.checkpoints
         assert got.disk_usage["maindb/leaf_vlog"].startswith("total=2 MiB")
         assert got.counters["treedb.cache.flush_backlog_coalescing.admitted_extra_ops_total"] == "42"
         assert got.counters["treedb.cache.checkpoint.stage.flush_all.total_ns"] == "303"
-        md = render_markdown(root, rows, "span_native_c4")
+        md = render_markdown(root, rows, "default_unconfigured")
         assert "TreeDB M14 final-gate matrix summary" in md
-        assert "span_native_c4" in md
+        assert "default_unconfigured" in md
+        assert "| `default_unconfigured` | 4 | true | true |" in md
         assert "checkpoint flush_all ns" in md
-        write_outputs(root, rows, "span_native_c4")
+        write_outputs(root, rows, "default_unconfigured")
         assert (root / "m14_matrix_summary.json").exists()
         assert (root / "m14_matrix_summary.md").exists()
 


### PR DESCRIPTION
Closes #2788

## Summary

- Enables TreeDB's guarded default flush admission policy: unconfigured/default TreeDB now uses `FlushAdmissionPolicyAuto`.
- Default auto admits the conservative c4 span-native + backlog coalescing candidate with adaptive write-side outer-leaf cache admission when guardrails pass.
- Preserves rollback and overrides:
  - `FlushAdmissionPolicyOff` / `-treedb-flush-admission-policy=off` force-disables span-native/backlog/concurrency.
  - `FlushAdmissionPolicyExplicit` / `-treedb-flush-admission-policy=explicit` preserves explicit c4/c16/immediate/cache-disabled experiments.
- Adds/updates focused admission tests, unified-bench reporting, tuning docs, and the M5 final gate report.

## Final decision

Default-on with rollback.

The selected default is **c4 adaptive**, not the c16 or cache-disabled ceiling row. Checkpoint pauses remain multi-second and are documented as the accepted bounded #2794 model tradeoff; this PR does not claim checkpoint debt disappeared.

## Public artifact roots

Public paths are redacted by policy.

- Final gate: `<remote-profile-root>/2788_final_gate_20260617_034229/final_10mm`
- Final parsed summary: `<remote-profile-root>/2788_final_gate_20260617_034229/final_10mm/2788_final_gate_summary.{md,json}`
- Write/checkpoint parser summary: `<remote-profile-root>/2788_final_gate_20260617_034229/final_10mm/write_checkpoint/m14_matrix_summary.{md,json}`
- Settled-scan rechecks:
  - `<remote-profile-root>/2788_final_gate_20260617_034229/scan_recheck_10mm`
  - `<remote-profile-root>/2788_final_gate_20260617_034229/scan_recheck2_10mm`
  - `<remote-profile-root>/2788_final_gate_20260617_034229/scan_recheck3_reversed_10mm`

## Final 10MM write/checkpoint gate

| Row | policy | admitted | reason | cache | random_write | Δ random | RW checkpoint | ckpt eff | write+ckpt | Δ write+ckpt | post-run |
| --- | --- | ---: | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| main default | explicit | false | `no_explicit_opt_in` | immediate | 159,527 | +0.0% | 11.20s | 0.893 Mops/s | 135.3 kops/s | +0.0% | 9.29s |
| branch default auto | auto | true | `auto_admitted_c4_adaptive` | adaptive | 272,400 | +70.8% | 7.89s | 1.267 Mops/s | 224.2 kops/s | +65.7% | 6.44s |
| branch forced off | off | false | `policy_off` | immediate | 152,289 | -4.5% | 11.06s | 0.904 Mops/s | 130.3 kops/s | -3.7% | 7.43s |
| branch auto c1 decline | auto | false | `low_concurrency` | immediate | 149,759 | -6.1% | 9.03s | 1.107 Mops/s | 131.9 kops/s | -2.5% | 8.82s |
| explicit c4 adaptive | explicit | true | `explicit_opt_in` | adaptive | 271,405 | +70.1% | 7.85s | 1.274 Mops/s | 223.7 kops/s | +65.3% | 8.35s |
| explicit c4 immediate | explicit | true | `explicit_opt_in` | immediate | 288,985 | +81.2% | 9.96s | 1.004 Mops/s | 224.4 kops/s | +65.8% | 10.65s |
| explicit c16 immediate | explicit | true | `explicit_opt_in` | immediate | 295,189 | +85.0% | 7.24s | 1.381 Mops/s | 243.2 kops/s | +79.7% | 5.04s |
| explicit c4 cache-disabled | explicit | true | `explicit_opt_in` | diagnostic | 303,888 | +90.5% | 7.84s | 1.276 Mops/s | 245.4 kops/s | +81.3% | 9.04s |

## Read/scan guardrail note

The original final settled-scan row showed a material-looking regression for branch default auto:

- full_scan: -4.7%
- prefix_scan: -7.6%

This was treated as blocking and rechecked before this PR body was written. Focused same-host 10MM settled-scan rechecks:

| Recheck | Order | full_scan delta | prefix_scan delta |
| --- | --- | ---: | ---: |
| scan_recheck_10mm | main first | -1.5% | -1.8% |
| scan_recheck2_10mm | main first | -2.9% | -1.2% |
| scan_recheck3_reversed_10mm | branch first | +3.7% | +1.4% |

Median recheck delta: full_scan -1.5%, prefix_scan -1.2%. The reversed-order run was positive for both scan metrics, so the original -7.6% prefix row is treated as a noisy outlier, not a reproducible material scan regression.

Other guardrails in the final gate:

- settled point read: branch default auto random_read +2.1% vs main default;
- mixed/debt read+scan: branch default auto random_read +3.5%, full_scan +9.1%, prefix_scan -2.0%;
- focused reopen/read-integrity/cache tests passed.

## Required counters

From row-local JSON stats in the final write/checkpoint gate:

| Row | old-leaf B/op | leaf merges/op | append frames/op | span used ops | close/ckpt fallback ops | backlog extra ops | cache stores | write stores/skips | index.db | leaf_vlog |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| main default | 1609.048482 | 0.356899 | 0.357579 | 0 | 0 | 0 | 13,843,600 | 0/0 | 605 MiB | 3.7 GiB |
| branch default auto | 1367.772644 | 0.313250 | 0.313807 | 29,686,164 | 218,612 | 986,896 | 1,445,504 | 1,445,504/10,698,674 | 443 MiB | 3.3 GiB |
| branch forced off | 1609.050863 | 0.356898 | 0.357579 | 0 | 0 | 0 | 13,843,599 | 0/0 | 605 MiB | 3.7 GiB |
| branch auto c1 decline | 1609.047905 | 0.356899 | 0.357579 | 0 | 0 | 0 | 13,843,617 | 0/0 | 605 MiB | 3.7 GiB |
| explicit c4 adaptive | 1367.801864 | 0.313251 | 0.313808 | 29,686,163 | 218,612 | 986,896 | 1,448,365 | 1,448,365/10,695,840 | 433 MiB | 3.3 GiB |
| explicit c4 immediate | 1403.267800 | 0.320052 | 0.320612 | 29,688,493 | 218,612 | 986,896 | 12,410,958 | 0/0 | 442 MiB | 3.3 GiB |
| explicit c16 immediate | 1403.690578 | 0.319872 | 0.320435 | 29,196,523 | 710,839 | 986,896 | 12,415,627 | 0/0 | 459 MiB | 3.3 GiB |
| explicit c4 cache-disabled | 1367.752190 | 0.313250 | 0.313807 | 29,686,165 | 218,612 | 986,896 | 0 | 0/0 | 427 MiB | 3.3 GiB |

## Tests

Latest head: `5abb3d9201ff6e90669c7c49ddaad3f31e56a964`.

Local/coordinator gates:

```text
git diff --check origin/main...HEAD
go vet ./TreeDB/...
go test ./TreeDB/db ./TreeDB/caching ./TreeDB/zipper ./cmd/unified_bench -count=1
python3 scripts/treedb_m14_matrix_summary.py --self-test
GOMAXPROCS=2 go test ./TreeDB/db -run 'TestFlushApplySpanNative(RootMismatchTracksAbandonedLeafLogOutput|FinalizeFailureTracksOutputOwnershipFallback)' -count=20 -failfast -v
GOMAXPROCS=2 go test ./TreeDB -run 'TestReopenVerify_ParallelFlushLeafLogOutput|TestSpanNativeCheckpointDrainFallbackReopenRewriteAndGC' -count=5 -failfast -v
GOMAXPROCS=2 go test ./TreeDB/... -p 1 -count=1
```

Additional local focused gates run during PR preparation:

```text
git diff --check
go test ./TreeDB/db ./TreeDB/caching ./TreeDB/zipper ./cmd/unified_bench -count=1
go test ./TreeDB -run 'TestReopenVerify_(WALOn_Checkpoint|WALOn_WriteSync|WALOn_Checkpoint_LeafPagesInValueLog|LeafPageLogGroupedFrameCRCIntegrityModes)$' -count=1
go test ./TreeDB/db -run 'Test(NormalizeFlushAdmission|FlushAdmissionStats|ParseFlushAdmission|LeafPageReadCache(AdaptiveWriteAdmission|ConcurrentSetAssociativeAccess|WriteAdmissionImmediate))' -count=1
go test -race ./TreeDB/db -run 'Test(NormalizeFlushAdmission|LeafPageReadCache(AdaptiveWriteAdmissionSkipsWhenSlotLockContended|ConcurrentSetAssociativeAccess))' -count=1
```

Latest-head CI is green at `5abb3d9201ff6e90669c7c49ddaad3f31e56a964` with `mergeStateStatus=CLEAN`. This includes TreeDB Linux/macOS/Windows shards, TreeDB race checks, TreeDB `perf-smoke (linux)`, root vet+test, unified_bench vet+test and suites, HashDB Windows, redisserver protocol bench, format, and read-snapshot guardrails. The value-log incompressible auto/off gate remains a value-log gate: both value-log rows now force `-treedb-flush-admission-policy=off` so the comparison stays on the old serial/default-off flush boundary.

Remote final root ran the same focused test set before 10MM rows; logs are under `<remote-profile-root>/2788_final_gate_20260617_034229/final_10mm/focused_tests/`.

## Caveats / rollback

- Roll back with `FlushAdmissionPolicyOff` or `-treedb-flush-admission-policy=off`.
- Checkpoint pauses remain visible multi-second events; this is the accepted #2794 bounded model tradeoff.
- Cache-disabled is diagnostic only.
- c16 is an explicit ceiling/alternative, not the default.
- No on-disk format change.

## Review status

Ready for review at `5abb3d9201ff6e90669c7c49ddaad3f31e56a964`. Latest-head CI is green and `mergeStateStatus=CLEAN`. AI review triggers were requested via `@codex review`, `@copilot review`, and `@coderabbitai review`; CodeRabbit's doc finding was fixed in `0fa16c117`, the Codex M14 metadata/summary finding was fixed in `5abb3d920`, and both review threads are resolved. Coordinator owns final review/merge; this PR is not merged by this agent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Flush admission now defaults to auto mode with adaptive cache write-side admission, improving concurrent flushing on multi-core systems.
  * New observability metrics expose admission policy, decision status, reason, concurrency, and cache behavior.

* **Documentation**
  * Updated guidance on flush admission policies and their impact on span-native operations.
  * New reference documentation on default auto-admission behavior and requirements.

* **Tests & Tooling**
  * Updated test configurations to reflect new default admission policy.
  * Enhanced benchmark reporting to include admission metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

