### PR TITLE
bench: add text v2 phase 2 gap synthesis

### DIFF
--- a/cmd/treedb_text_hybrid_scoreboard/main.go
+++ b/cmd/treedb_text_hybrid_scoreboard/main.go
@@ -20,7 +20,10 @@ import (
 	"time"
 )
 
-const schemaVersion = "treedb_text_hybrid_scoreboard/v1"
+const (
+	schemaVersion          = "treedb_text_hybrid_scoreboard/v1"
+	phase2SynthesisVersion = "treedb_text_v2_phase2_gap_synthesis/v1"
+)
 
 type config struct {
 	outDir               string
@@ -106,6 +109,7 @@ type report struct {
 	Rows               []scoreboardRow     `json:"rows"`
 	CounterValidations []counterValidation `json:"counter_validations,omitempty"`
 	Unavailable        []unavailableRow    `json:"unavailable,omitempty"`
+	Phase2Synthesis    phase2Synthesis     `json:"phase2_synthesis"`
 	Caveats            []string            `json:"caveats,omitempty"`
 }
 
@@ -169,6 +173,53 @@ type unavailableRow struct {
 	System string `json:"system"`
 	Reason string `json:"reason"`
 	Source string `json:"source,omitempty"`
+}
+
+type phase2Synthesis struct {
+	SchemaVersion          string                    `json:"schema_version"`
+	ClassificationBasis    string                    `json:"classification_basis"`
+	ExternalBaselines      []phase2ExternalBaseline  `json:"external_baselines"`
+	BenchmarkTargets       []phase2BenchmarkTarget   `json:"benchmark_targets"`
+	GapClassifications     []phase2GapClassification `json:"gap_classifications"`
+	PriorityOrder          []phase2Priority          `json:"priority_order"`
+	AnalyzerSemanticsNotes []string                  `json:"analyzer_semantics_notes"`
+}
+
+type phase2ExternalBaseline struct {
+	System   string `json:"system"`
+	Status   string `json:"status"`
+	Evidence string `json:"evidence"`
+	Caveat   string `json:"caveat,omitempty"`
+}
+
+type phase2BenchmarkTarget struct {
+	ShapeID          string   `json:"shape_id"`
+	Shape            string   `json:"shape"`
+	Description      string   `json:"description"`
+	PrimaryIssue     string   `json:"primary_issue"`
+	RequiredRows     []string `json:"required_rows"`
+	RequiredCounters []string `json:"required_counters"`
+}
+
+type phase2GapClassification struct {
+	ShapeID                string   `json:"shape_id"`
+	Shape                  string   `json:"shape"`
+	Classification         string   `json:"classification"`
+	Priority               int      `json:"priority"`
+	PrimaryIssue           string   `json:"primary_issue"`
+	TreeDBEvidence         string   `json:"treedb_evidence"`
+	ExternalEvidence       string   `json:"external_evidence"`
+	Rationale              string   `json:"rationale"`
+	RequiredFollowUpRows   []string `json:"required_follow_up_rows"`
+	NonEquivalentSemantics []string `json:"non_equivalent_semantics,omitempty"`
+}
+
+type phase2Priority struct {
+	Priority             int      `json:"priority"`
+	ShapeID              string   `json:"shape_id"`
+	PrimaryIssue         string   `json:"primary_issue"`
+	Rationale            string   `json:"rationale"`
+	RequiredFollowUpRows []string `json:"required_follow_up_rows"`
 }
 
 type goBenchSample struct {
@@ -309,6 +360,7 @@ func buildReport(cfg config) (report, error) {
 	}
 
 	sortRows(rep.Rows)
+	rep.Phase2Synthesis = buildPhase2Synthesis(rep.Rows, rep.Unavailable)
 	rep.CounterValidations = validateCounterRows(rep.Rows)
 	var failures []string
 	for _, check := range rep.CounterValidations {
@@ -967,6 +1019,457 @@ func validateCounterRows(rows []scoreboardRow) []counterValidation {
 	return checks
 }
 
+func buildPhase2Synthesis(rows []scoreboardRow, unavailable []unavailableRow) phase2Synthesis {
+	targets := phase2BenchmarkTargets()
+	classifications := make([]phase2GapClassification, 0, len(targets))
+	for _, target := range targets {
+		classifications = append(classifications, classifyPhase2Gap(target, rows, unavailable))
+	}
+	sort.Slice(classifications, func(i, j int) bool {
+		if classifications[i].Priority == classifications[j].Priority {
+			return classifications[i].ShapeID < classifications[j].ShapeID
+		}
+		return classifications[i].Priority < classifications[j].Priority
+	})
+	priorities := make([]phase2Priority, 0, len(classifications))
+	for _, row := range classifications {
+		priorities = append(priorities, phase2Priority{
+			Priority:             row.Priority,
+			ShapeID:              row.ShapeID,
+			PrimaryIssue:         row.PrimaryIssue,
+			Rationale:            row.Rationale,
+			RequiredFollowUpRows: append([]string(nil), row.RequiredFollowUpRows...),
+		})
+	}
+	sort.Slice(priorities, func(i, j int) bool {
+		if priorities[i].Priority == priorities[j].Priority {
+			return priorities[i].ShapeID < priorities[j].ShapeID
+		}
+		return priorities[i].Priority < priorities[j].Priority
+	})
+	return phase2Synthesis{
+		SchemaVersion:          phase2SynthesisVersion,
+		ClassificationBasis:    "phase-2 target taxonomy plus captured scoreboard rows; ahead/near require comparable external rows, while missing or non-equivalent external rows stay behind/far by evidence gap rather than parity claim",
+		ExternalBaselines:      phase2ExternalBaselines(rows, unavailable),
+		BenchmarkTargets:       targets,
+		GapClassifications:     classifications,
+		PriorityOrder:          priorities,
+		AnalyzerSemanticsNotes: phase2AnalyzerSemanticsNotes(),
+	}
+}
+
+func phase2ExternalBaselines(rows []scoreboardRow, unavailable []unavailableRow) []phase2ExternalBaseline {
+	systems := []string{"SQLite FTS5", "Bleve", "Tantivy", "Lucene"}
+	out := make([]phase2ExternalBaseline, 0, len(systems))
+	for _, system := range systems {
+		var rowLabels []string
+		for _, row := range rows {
+			if strings.EqualFold(row.System, system) {
+				rowLabels = append(rowLabels, row.SourceLabel)
+			}
+		}
+		if len(rowLabels) > 0 {
+			sort.Strings(rowLabels)
+			out = append(out, phase2ExternalBaseline{System: system, Status: "available", Evidence: fmt.Sprintf("captured scoreboard row(s): %s", strings.Join(rowLabels, ", ")), Caveat: externalBaselineCaveat(system)})
+			continue
+		}
+		if reason, source, ok := unavailableReason(system, unavailable); ok {
+			evidence := reason
+			if source != "" {
+				evidence = evidence + " (source: " + source + ")"
+			}
+			out = append(out, phase2ExternalBaseline{System: system, Status: "unavailable", Evidence: evidence, Caveat: externalBaselineCaveat(system)})
+			continue
+		}
+		out = append(out, phase2ExternalBaseline{System: system, Status: "not_captured", Evidence: "no artifact or explicit unavailable marker in this scoreboard run", Caveat: externalBaselineCaveat(system)})
+	}
+	return out
+}
+
+func unavailableReason(system string, unavailable []unavailableRow) (reason, source string, ok bool) {
+	for _, row := range unavailable {
+		if strings.EqualFold(row.System, system) {
+			return row.Reason, row.Source, true
+		}
+	}
+	return "", "", false
+}
+
+func externalBaselineCaveat(system string) string {
+	switch system {
+	case "SQLite FTS5":
+		return "embedded FTS baseline; rowid+bm25 retrieval is not Lucene/Tantivy/Bleve analyzer or query-parser parity"
+	case "Bleve":
+		return "requires a pinned Go harness with the same corpus, analyzer, query semantics, and result-order checks"
+	case "Tantivy":
+		return "requires a pinned Rust/Tantivy harness with the same corpus, analyzer, query semantics, and result-order checks"
+	case "Lucene":
+		return "requires a pinned Lucene/JMH or OpenSearch run with the same corpus, analyzer, query semantics, and result-order checks"
+	default:
+		return ""
+	}
+}
+
+func phase2BenchmarkTargets() []phase2BenchmarkTarget {
+	commonCounters := []string{"docs_fetched/search=0", "full_doc_fallbacks/search=0", "fail_closed/search=0", "text_state_lookups/search=0", "text_match_details/search=0"}
+	blockCounters := append(append([]string(nil), commonCounters...), "posting_blocks_visited/search", "posting_blocks_skipped/search", "threshold_updates/search")
+	return []phase2BenchmarkTarget{
+		{
+			ShapeID:          "single_term_common",
+			Shape:            "single-term common",
+			Description:      "High-document-frequency BM25F top-k term with exact block-max skipping.",
+			PrimaryIssue:     "#2835",
+			RequiredRows:     []string{"TreeDB 10k and 100k blockmax_common_topk", "SQLite FTS5/Lucene/Tantivy/Bleve common-term top-k rows"},
+			RequiredCounters: blockCounters,
+		},
+		{
+			ShapeID:          "single_term_rare",
+			Shape:            "single-term rare",
+			Description:      "Low-document-frequency BM25F top-k term where decode/setup overhead dominates.",
+			PrimaryIssue:     "#2835",
+			RequiredRows:     []string{"TreeDB rare term score-only 10k/100k/1M", "SQLite FTS5/Lucene/Tantivy/Bleve rare-term top-k rows"},
+			RequiredCounters: commonCounters,
+		},
+		{
+			ShapeID:          "multi_term_and",
+			Shape:            "multi-term AND",
+			Description:      "Exact BM25F conjunction over multiple query terms with deterministic ranking.",
+			PrimaryIssue:     "#2837",
+			RequiredRows:     []string{"TreeDB multi_term_and score-only 10k/100k/1M", "SQLite FTS5/Lucene/Tantivy/Bleve explicit AND rows"},
+			RequiredCounters: append(append([]string(nil), commonCounters...), "posting_blocks_visited/search", "candidates_scored/search"),
+		},
+		{
+			ShapeID:          "multi_term_or_wand",
+			Shape:            "multi-term OR/WAND",
+			Description:      "Exact BM25F disjunction with block-max/WAND pruning and deterministic ranking.",
+			PrimaryIssue:     "#2836",
+			RequiredRows:     []string{"TreeDB or_common/or_common_rare/or_high_frequency blockmax and exhaustive rows", "Lucene/Tantivy/Bleve OR/WAND rows", "SQLite FTS5 OR row if semantics are made explicit"},
+			RequiredCounters: append(append([]string(nil), blockCounters...), "blockmax_fallbacks/search", "candidates_scored/search"),
+		},
+		{
+			ShapeID:          "phrase",
+			Shape:            "phrase/proximity",
+			Description:      "Bounded position-lane phrase/proximity query over StorePositions text-v2 indexes.",
+			PrimaryIssue:     "#2839",
+			RequiredRows:     []string{"TreeDB phrase exact/slop 10k/100k", "Lucene/Tantivy/Bleve phrase/proximity rows with analyzer notes"},
+			RequiredCounters: append(append([]string(nil), commonCounters...), "position_lookups/search", "phrase_candidates_checked/search", "phrase_candidates_matched/search"),
+		},
+		{
+			ShapeID:          "hybrid_text_scalar",
+			Shape:            "hybrid text+scalar",
+			Description:      "BM25F candidate generation composed with indexed scalar filtering without full-document fetch.",
+			PrimaryIssue:     "#2836",
+			RequiredRows:     []string{"TreeDB text_scalar and hybrid_scalar no-doc rows at rare/broad selectivity", "Lucene/Tantivy/Bleve equivalent filter rows or documented non-equivalence"},
+			RequiredCounters: append(append([]string(nil), blockCounters...), "scalar_prefilter_ids/search", "text_candidates/search"),
+		},
+		{
+			ShapeID:          "index_build_ingest",
+			Shape:            "index build/ingest",
+			Description:      "Text-v2 CreateTextIndex backfill and maintained insert/update/delete throughput.",
+			PrimaryIssue:     "#2835",
+			RequiredRows:     []string{"TreeDB CreateTextIndex/backfill and InsertBatch text-v2 rows", "SQLite FTS5/Lucene/Tantivy/Bleve build rows with WAL/checkpoint boundary"},
+			RequiredCounters: []string{"rows/s", "B/op", "allocs/op", "index_bytes/doc", "posting_blocks/doc", "write_amp_entries/doc"},
+		},
+		{
+			ShapeID:          "index_size",
+			Shape:            "index size",
+			Description:      "Durable text index bytes/doc, separating primary payload, WAL, value-log, and text-v2 roots.",
+			PrimaryIssue:     "#2835",
+			RequiredRows:     []string{"TreeDB durable text-v2 bytes/doc after checkpoint and rewrite", "SQLite FTS5/Lucene/Tantivy/Bleve index bytes/doc after equivalent optimize/vacuum"},
+			RequiredCounters: []string{"storage_bytes", "storage_bytes_per_doc", "index_bytes/doc", "value-log bytes", "WAL excluded"},
+		},
+		{
+			ShapeID:          "reopen",
+			Shape:            "reopen/recovery",
+			Description:      "Close/open and post-reopen text/hybrid probe latency with snapshot-bound roots.",
+			PrimaryIssue:     "#2837",
+			RequiredRows:     []string{"TreeDB scale harness reopen probe at 10k/1M/10M", "External engine reopen/open-reader rows where embedded equivalents exist"},
+			RequiredCounters: []string{"close_seconds", "open_seconds", "probe_seconds", "docs_fetched/search=0", "fail_closed/search=0"},
+		},
+		{
+			ShapeID:          "maintenance_rewrite",
+			Shape:            "maintenance/rewrite",
+			Description:      "Bounded logical text-v2 rewrite plus normal TreeDB physical reclamation and post-rewrite search probes.",
+			PrimaryIssue:     "#2840",
+			RequiredRows:     []string{"TreeDB RewriteTextIndex/MaintainTextIndexes rows with stale-posting debt", "External optimize/merge rows if used as a comparator"},
+			RequiredCounters: []string{"stale_postings_purged/op", "tombstones_purged/op", "posting_blocks_read/op", "posting_blocks_written/op", "rewrite seconds", "post-rewrite search ns/op"},
+		},
+	}
+}
+
+func classifyPhase2Gap(target phase2BenchmarkTarget, rows []scoreboardRow, unavailable []unavailableRow) phase2GapClassification {
+	treeRows := matchingRowsForPhase2Target(rows, target.ShapeID, true)
+	externalRows := matchingRowsForPhase2Target(rows, target.ShapeID, false)
+	classification, rationale := defaultPhase2Classification(target.ShapeID)
+	if measuredClass, measuredRationale, ok := measuredPhase2Classification(target.ShapeID, treeRows, externalRows); ok {
+		classification, rationale = measuredClass, measuredRationale
+	}
+	return phase2GapClassification{
+		ShapeID:                target.ShapeID,
+		Shape:                  target.Shape,
+		Classification:         classification,
+		Priority:               phase2PriorityForTarget(target.ShapeID),
+		PrimaryIssue:           target.PrimaryIssue,
+		TreeDBEvidence:         phase2EvidenceSummary("TreeDB", target.ShapeID, treeRows),
+		ExternalEvidence:       phase2ExternalEvidenceSummary(target.ShapeID, externalRows, unavailable),
+		Rationale:              rationale,
+		RequiredFollowUpRows:   append([]string(nil), target.RequiredRows...),
+		NonEquivalentSemantics: phase2SemanticsForTarget(target.ShapeID),
+	}
+}
+
+func measuredPhase2Classification(shapeID string, treeRows, externalRows []scoreboardRow) (string, string, bool) {
+	if len(treeRows) == 0 || len(externalRows) == 0 {
+		return "", "", false
+	}
+	if shapeID == "index_size" {
+		treeStorage, okTree := bestStorageBytesPerDoc(treeRows)
+		extStorage, okExt := bestStorageBytesPerDoc(externalRows)
+		if okTree && okExt && extStorage > 0 {
+			ratio := treeStorage / extStorage
+			return classFromLowerIsBetterRatio(ratio), fmt.Sprintf("captured comparable storage rows: TreeDB %.3g B/doc vs external %.3g B/doc (ratio %.3gx)", treeStorage, extStorage, ratio), true
+		}
+		return "", "", false
+	}
+	treeNS, okTree := bestNsPerOp(treeRows)
+	extNS, okExt := bestNsPerOp(externalRows)
+	if !okTree || !okExt || extNS <= 0 {
+		return "", "", false
+	}
+	ratio := treeNS / extNS
+	return classFromLowerIsBetterRatio(ratio), fmt.Sprintf("captured comparable latency rows: TreeDB %.3g ns/op vs external %.3g ns/op (ratio %.3gx)", treeNS, extNS, ratio), true
+}
+
+func classFromLowerIsBetterRatio(ratio float64) string {
+	switch {
+	case ratio <= 0.8:
+		return "ahead"
+	case ratio <= 1.5:
+		return "near_parity"
+	case ratio <= 8:
+		return "behind_but_tractable"
+	default:
+		return "far_behind"
+	}
+}
+
+func bestNsPerOp(rows []scoreboardRow) (float64, bool) {
+	best := math.Inf(1)
+	for _, row := range rows {
+		if row.NsPerOp != nil && *row.NsPerOp > 0 && *row.NsPerOp < best {
+			best = *row.NsPerOp
+		}
+	}
+	if math.IsInf(best, 1) {
+		return 0, false
+	}
+	return best, true
+}
+
+func bestStorageBytesPerDoc(rows []scoreboardRow) (float64, bool) {
+	best := math.Inf(1)
+	for _, row := range rows {
+		if row.StorageBytesPerDoc != nil && *row.StorageBytesPerDoc > 0 && *row.StorageBytesPerDoc < best {
+			best = *row.StorageBytesPerDoc
+		}
+	}
+	if math.IsInf(best, 1) {
+		return 0, false
+	}
+	return best, true
+}
+
+func defaultPhase2Classification(shapeID string) (string, string) {
+	switch shapeID {
+	case "index_size":
+		return "far_behind", "phase-1 scoreboard has external storage rows but lacks a durable TreeDB text-v2 bytes/doc row, so footprint parity is the first evidence and optimization gap"
+	case "single_term_common":
+		return "behind_but_tractable", "TreeDB has exact block-max common-term evidence, but comparable Lucene/Tantivy/Bleve/SQLite rows and bytes/doc context are missing"
+	case "multi_term_or_wand":
+		return "behind_but_tractable", "exact OR/WAND block-max landed in phase 1, but scalar-aware pruning and external OR/WAND rows are still required before parity claims"
+	case "hybrid_text_scalar":
+		return "behind_but_tractable", "TreeDB has zero-document hybrid/scalar rows, but industry baselines are non-equivalent or unavailable and scalar-aware WAND counters need expansion"
+	case "index_build_ingest":
+		return "behind_but_tractable", "build and ingest rows exist but are not yet separated into text-only durable bytes/doc and external-equivalent build boundaries"
+	case "phrase":
+		return "behind_but_tractable", "bounded phrase/proximity exists, but Lucene/Tantivy/Bleve phrase semantics and analyzer behavior are broader and unmeasured"
+	case "reopen":
+		return "behind_but_tractable", "scale harness covers reopen, but phase-2 needs refreshed 1M/10M rows and external open-reader comparators where feasible"
+	case "maintenance_rewrite":
+		return "behind_but_tractable", "bounded rewrite/maintenance exists, but phase-2 needs debt, duration, and post-maintenance search rows at larger scale"
+	case "multi_term_and":
+		return "behind_but_tractable", "exact AND serving exists, but current scoreboard lacks external conjunction rows and scale refreshes"
+	case "single_term_rare":
+		return "behind_but_tractable", "rare-term serving should be tractable, but phase-2 needs explicit rows because setup/decode overhead can dominate"
+	default:
+		return "behind_but_tractable", "target requires phase-2 evidence before parity claims"
+	}
+}
+
+func phase2PriorityForTarget(shapeID string) int {
+	switch shapeID {
+	case "index_size":
+		return 1
+	case "single_term_common":
+		return 2
+	case "multi_term_or_wand":
+		return 3
+	case "hybrid_text_scalar":
+		return 4
+	case "index_build_ingest":
+		return 5
+	case "phrase":
+		return 6
+	case "reopen":
+		return 7
+	case "maintenance_rewrite":
+		return 8
+	case "multi_term_and":
+		return 9
+	case "single_term_rare":
+		return 10
+	default:
+		return 99
+	}
+}
+
+func matchingRowsForPhase2Target(rows []scoreboardRow, shapeID string, treeDB bool) []scoreboardRow {
+	var matches []scoreboardRow
+	for _, row := range rows {
+		isTreeDB := strings.EqualFold(row.System, "TreeDB")
+		if treeDB != isTreeDB {
+			continue
+		}
+		if phase2RowMatchesTarget(row, shapeID) {
+			matches = append(matches, row)
+		}
+	}
+	sortRows(matches)
+	return matches
+}
+
+func phase2RowMatchesTarget(row scoreboardRow, shapeID string) bool {
+	text := strings.ToLower(strings.Join([]string{row.Modality, row.Engine, row.QueryShape, row.Boundary, row.Benchmark}, " "))
+	switch shapeID {
+	case "single_term_common":
+		return strings.Contains(text, "common term") || strings.Contains(text, "blockmax_common_topk") || strings.Contains(text, "exhaustive_common_topk")
+	case "single_term_rare":
+		return strings.Contains(text, "rare term") || strings.Contains(text, "rare_no_docs") || strings.Contains(text, "rare_score")
+	case "multi_term_and":
+		return strings.Contains(text, "multi-term and") || strings.Contains(text, "multi_term_and") || strings.Contains(text, "and_common")
+	case "multi_term_or_wand":
+		return strings.Contains(text, "multi-term or") || strings.Contains(text, "or/wand") || strings.Contains(text, "wand") || strings.Contains(text, "or_common") || strings.Contains(text, "or_high_frequency")
+	case "phrase":
+		return strings.Contains(text, "phrase") || strings.Contains(text, "proximity")
+	case "hybrid_text_scalar":
+		return row.Modality == "text_scalar" || row.Modality == "hybrid_scalar" || (strings.Contains(text, "scalar") && strings.Contains(text, "text"))
+	case "index_build_ingest":
+		return row.Modality == "build_storage" || strings.Contains(text, "index build") || strings.Contains(text, "ingest") || strings.Contains(text, "insertbatch") || strings.Contains(text, "backfill")
+	case "index_size":
+		return row.StorageBytes != nil || row.StorageBytesPerDoc != nil || strings.Contains(text, "storage") || strings.Contains(text, "index size")
+	case "reopen":
+		return strings.Contains(text, "reopen") || strings.Contains(text, "recovery")
+	case "maintenance_rewrite":
+		return strings.Contains(text, "maintenance") || strings.Contains(text, "rewrite") || strings.Contains(text, "compact")
+	default:
+		return false
+	}
+}
+
+func phase2EvidenceSummary(system, shapeID string, rows []scoreboardRow) string {
+	if len(rows) == 0 {
+		if system == "TreeDB" {
+			return phase2TreeDBFallbackEvidence(shapeID)
+		}
+		return "no comparable row captured"
+	}
+	parts := make([]string, 0, len(rows))
+	for _, row := range rows {
+		var metricParts []string
+		if row.NsPerOp != nil {
+			metricParts = append(metricParts, "ns/op="+formatNumber(*row.NsPerOp))
+		}
+		if row.StorageBytesPerDoc != nil {
+			metricParts = append(metricParts, "storage="+formatNumber(*row.StorageBytesPerDoc)+" B/doc")
+		}
+		if row.BuildSeconds != nil {
+			metricParts = append(metricParts, "build="+formatSecondsPtr(row.BuildSeconds))
+		}
+		metric := ""
+		if len(metricParts) > 0 {
+			metric = " " + strings.Join(metricParts, ", ")
+		}
+		parts = append(parts, fmt.Sprintf("%s/%s%s", row.SourceLabel, row.Benchmark, metric))
+	}
+	return fmt.Sprintf("captured %d row(s): %s", len(rows), strings.Join(parts, "; "))
+}
+
+func phase2TreeDBFallbackEvidence(shapeID string) string {
+	switch shapeID {
+	case "single_term_common":
+		return "phase-1 #2810/#2809 evidence includes TreeDB block-max common-term rows; rerun scoreboard for current numbers"
+	case "single_term_rare":
+		return "scale harness defines rare-term score-only rows; current scoreboard run did not capture them"
+	case "multi_term_and":
+		return "phase-1 text-v2 contract and scale harness define exact multi-term AND rows; current scoreboard run did not capture them"
+	case "multi_term_or_wand":
+		return "#2812 landed exact multi-term OR/WAND block-max rows; current scoreboard run did not capture them"
+	case "phrase":
+		return "#2815 landed bounded phrase/proximity rows; current scoreboard run did not capture them"
+	case "hybrid_text_scalar":
+		return "#2810 scoreboard includes zero-doc hybrid/scalar row support; rerun with scalar selectivity rows if absent"
+	case "index_build_ingest":
+		return "#2810/#2813 harnesses include build/backfill/ingest rows; current scoreboard run did not capture a text-only equivalent"
+	case "index_size":
+		return "TreeDB durable text-v2 bytes/doc is not captured in the current scoreboard run"
+	case "reopen":
+		return "#2813 scale harness includes reopen probes; current scoreboard run did not capture reopen rows"
+	case "maintenance_rewrite":
+		return "#2814 maintenance policy and #2813 scale harness include rewrite/maintenance rows; current scoreboard run did not capture them"
+	default:
+		return "no TreeDB row captured"
+	}
+}
+
+func phase2ExternalEvidenceSummary(shapeID string, externalRows []scoreboardRow, unavailable []unavailableRow) string {
+	if len(externalRows) > 0 {
+		return phase2EvidenceSummary("external", shapeID, externalRows)
+	}
+	var statuses []string
+	for _, system := range []string{"SQLite FTS5", "Bleve", "Tantivy", "Lucene"} {
+		if reason, _, ok := unavailableReason(system, unavailable); ok {
+			statuses = append(statuses, fmt.Sprintf("%s=unavailable (%s)", system, reason))
+		} else {
+			statuses = append(statuses, fmt.Sprintf("%s=not_captured", system))
+		}
+	}
+	return "no comparable external row captured; " + strings.Join(statuses, "; ")
+}
+
+func phase2SemanticsForTarget(shapeID string) []string {
+	switch shapeID {
+	case "single_term_common", "single_term_rare", "multi_term_and", "multi_term_or_wand":
+		return []string{"TreeDB simple analyzer/BM25F weighting is not automatically equivalent to SQLite unicode61/porter, Bleve analyzers, Tantivy tokenizers, or Lucene analyzers", "explicit AND/OR query semantics must be pinned before latency ratios are parity evidence"}
+	case "phrase":
+		return []string{"TreeDB phrase/proximity is structured and bounded over StorePositions indexes; it is not a Lucene-compatible query DSL", "slop, stopword position gaps, and unsupported stemming/synonym expansion must be recorded per row"}
+	case "hybrid_text_scalar":
+		return []string{"SQLite FTS5 is not a hybrid text+scalar engine by itself", "Lucene/Tantivy/Bleve filter semantics and whether filters are pre- or post-score must be documented"}
+	case "index_build_ingest", "index_size", "reopen", "maintenance_rewrite":
+		return []string{"storage/build boundaries must state WAL inclusion, checkpoint/optimize/vacuum state, and retained primary-payload treatment"}
+	default:
+		return nil
+	}
+}
+
+func phase2AnalyzerSemanticsNotes() []string {
+	return []string{
+		"Do not compare TreeDB BM25F rows with external BM25/BM25F rows unless analyzer, field weights, top-k, query operator, and final-document fetch boundaries are pinned.",
+		"SQLite FTS5 default rows are useful embedded baselines, but they are not Lucene/Tantivy/Bleve analyzer or query-parser parity.",
+		"Phrase/proximity rows must record StorePositions, slop, stopword behavior, and unsupported stemming/synonym states; unsupported states must fail closed.",
+		"Candidate-generation rows must keep full-document fetch counters at zero; final-fetch rows belong in separate tables.",
+	}
+}
+
 func requiresZeroDocValidation(row scoreboardRow) bool {
 	lowerBoundary := strings.ToLower(row.Boundary)
 	lowerName := strings.ToLower(row.Benchmark)
@@ -1031,6 +1534,8 @@ func renderMarkdown(rep report) string {
 		fmt.Fprintf(&b, "| _none_ | | | | | | | | | | | |\n")
 	}
 
+	renderPhase2SynthesisMarkdown(&b, rep.Phase2Synthesis)
+
 	fmt.Fprintf(&b, "\n## Zero-doc counter validation\n\n")
 	fmt.Fprintf(&b, "| Source | Benchmark | OK | Checks / failures |\n")
 	fmt.Fprintf(&b, "| --- | --- | --- | --- |\n")
@@ -1068,6 +1573,44 @@ func renderMarkdown(rep report) string {
 		fmt.Fprintf(&b, "\n## Captured host/context\n\n```text\n%s\n```\n", rep.Context.ContextText)
 	}
 	return b.String()
+}
+
+func renderPhase2SynthesisMarkdown(b *strings.Builder, syn phase2Synthesis) {
+	if syn.SchemaVersion == "" {
+		return
+	}
+	fmt.Fprintf(b, "\n## Phase-2 gap classification\n\n")
+	fmt.Fprintf(b, "Schema: `%s`  \n", syn.SchemaVersion)
+	fmt.Fprintf(b, "Basis: %s\n\n", syn.ClassificationBasis)
+	fmt.Fprintf(b, "Classification vocabulary: `ahead` and `near_parity` require comparable external evidence; `behind_but_tractable` means the feature/evidence exists but phase-2 work is still needed; `far_behind` marks a blocking parity/evidence gap and must not be read as an unmeasured performance ratio.\n\n")
+
+	fmt.Fprintf(b, "### External baseline coverage\n\n")
+	fmt.Fprintf(b, "| System | Status | Evidence | Caveat |\n")
+	fmt.Fprintf(b, "| --- | --- | --- | --- |\n")
+	for _, row := range syn.ExternalBaselines {
+		fmt.Fprintf(b, "| %s | `%s` | %s | %s |\n", escape(row.System), escape(row.Status), escape(row.Evidence), escape(row.Caveat))
+	}
+
+	fmt.Fprintf(b, "\n### Benchmark target taxonomy\n\n")
+	fmt.Fprintf(b, "| Target | Shape | Primary issue | Required rows | Required counters |\n")
+	fmt.Fprintf(b, "| --- | --- | --- | --- | --- |\n")
+	for _, row := range syn.BenchmarkTargets {
+		fmt.Fprintf(b, "| `%s` | %s | %s | %s | %s |\n", escape(row.ShapeID), escape(row.Shape), escape(row.PrimaryIssue), escape(strings.Join(row.RequiredRows, "; ")), escape(strings.Join(row.RequiredCounters, "; ")))
+	}
+
+	fmt.Fprintf(b, "\n### Gap classification and priority order\n\n")
+	fmt.Fprintf(b, "| Priority | Target | Classification | TreeDB evidence | External evidence | Required follow-up rows | Rationale |\n")
+	fmt.Fprintf(b, "| ---: | --- | --- | --- | --- | --- | --- |\n")
+	for _, row := range syn.GapClassifications {
+		fmt.Fprintf(b, "| %d | `%s` | `%s` | %s | %s | %s | %s |\n", row.Priority, escape(row.ShapeID), escape(row.Classification), escape(row.TreeDBEvidence), escape(row.ExternalEvidence), escape(strings.Join(row.RequiredFollowUpRows, "; ")), escape(row.Rationale))
+	}
+
+	if len(syn.AnalyzerSemanticsNotes) > 0 {
+		fmt.Fprintf(b, "\n### Non-equivalent analyzer/query semantics\n\n")
+		for _, note := range syn.AnalyzerSemanticsNotes {
+			fmt.Fprintf(b, "- %s\n", note)
+		}
+	}
 }
 
 func compactQueryBoundary(row scoreboardRow) string {

--- a/cmd/treedb_text_hybrid_scoreboard/main.go
+++ b/cmd/treedb_text_hybrid_scoreboard/main.go
@@ -1219,42 +1219,113 @@ func classifyPhase2Gap(target phase2BenchmarkTarget, rows []scoreboardRow, unava
 }
 
 func measuredPhase2Classification(shapeID string, treeRows, externalRows []scoreboardRow) (string, string, bool) {
-	comparableExternalRows := phase2ComparableExternalRows(externalRows)
-	if len(treeRows) == 0 || len(comparableExternalRows) == 0 {
+	pairs := phase2ComparablePairs(treeRows, externalRows)
+	if len(pairs) == 0 {
 		return "", "", false
 	}
-	// Why: SQLite FTS5 is a useful embedded baseline, but the #2834 readout
-	// explicitly treats SQLite-only evidence as non-equivalent for industry
-	// parity. Ratio-based ahead/near claims require a non-SQLite baseline row
-	// from a pinned comparable search engine harness.
-	externalRows = comparableExternalRows
-	if shapeID == "index_size" {
-		treeStorage, okTree := bestStorageBytesPerDoc(treeRows)
-		extStorage, okExt := bestStorageBytesPerDoc(externalRows)
-		if okTree && okExt && extStorage > 0 {
-			ratio := treeStorage / extStorage
-			return classFromLowerIsBetterRatio(ratio), fmt.Sprintf("captured comparable storage rows: TreeDB %.3g B/doc vs external %.3g B/doc (ratio %.3gx)", treeStorage, extStorage, ratio), true
+	bestRatio := math.Inf(1)
+	var best phase2ComparablePair
+	for _, pair := range pairs {
+		var treeMetric, externalMetric float64
+		var ok bool
+		if shapeID == "index_size" {
+			treeMetric, externalMetric, ok = comparableStoragePair(pair.TreeDB, pair.External)
+		} else {
+			treeMetric, externalMetric, ok = comparableLatencyPair(pair.TreeDB, pair.External)
 		}
-		return "", "", false
-	}
-	treeNS, okTree := bestNsPerOp(treeRows)
-	extNS, okExt := bestNsPerOp(externalRows)
-	if !okTree || !okExt || extNS <= 0 {
-		return "", "", false
-	}
-	ratio := treeNS / extNS
-	return classFromLowerIsBetterRatio(ratio), fmt.Sprintf("captured comparable latency rows: TreeDB %.3g ns/op vs external %.3g ns/op (ratio %.3gx)", treeNS, extNS, ratio), true
-}
-
-func phase2ComparableExternalRows(rows []scoreboardRow) []scoreboardRow {
-	out := make([]scoreboardRow, 0, len(rows))
-	for _, row := range rows {
-		if strings.EqualFold(row.System, "SQLite FTS5") || strings.EqualFold(row.Engine, "sqlite_fts5") {
+		if !ok || externalMetric <= 0 {
 			continue
 		}
-		out = append(out, row)
+		ratio := treeMetric / externalMetric
+		if ratio < bestRatio {
+			bestRatio = ratio
+			best = pair
+		}
 	}
-	return out
+	if math.IsInf(bestRatio, 1) {
+		return "", "", false
+	}
+	if shapeID == "index_size" {
+		return classFromLowerIsBetterRatio(bestRatio), fmt.Sprintf("captured explicit comparable storage pair: TreeDB %s vs %s (ratio %.3gx)", phase2RowMetricSummary(best.TreeDB, true), phase2RowMetricSummary(best.External, true), bestRatio), true
+	}
+	return classFromLowerIsBetterRatio(bestRatio), fmt.Sprintf("captured explicit comparable latency pair: TreeDB %s vs %s (ratio %.3gx)", phase2RowMetricSummary(best.TreeDB, false), phase2RowMetricSummary(best.External, false), bestRatio), true
+}
+
+type phase2ComparablePair struct {
+	TreeDB   scoreboardRow
+	External scoreboardRow
+}
+
+func phase2ComparablePairs(treeRows, externalRows []scoreboardRow) []phase2ComparablePair {
+	var pairs []phase2ComparablePair
+	for _, treeRow := range treeRows {
+		if !phase2ExplicitComparableRow(treeRow) {
+			continue
+		}
+		for _, externalRow := range externalRows {
+			if !phase2ExplicitComparableRow(externalRow) || !phase2NonSQLiteExternalRow(externalRow) {
+				continue
+			}
+			if !phase2ComparableRowMetadata(treeRow, externalRow) {
+				continue
+			}
+			pairs = append(pairs, phase2ComparablePair{TreeDB: treeRow, External: externalRow})
+		}
+	}
+	return pairs
+}
+
+func phase2ExplicitComparableRow(row scoreboardRow) bool {
+	if row.Metrics != nil && row.Metrics["phase2_comparable"] == 1 {
+		return true
+	}
+	for _, caveat := range row.Caveats {
+		if strings.Contains(strings.ToLower(caveat), "phase2_comparable") {
+			return true
+		}
+	}
+	return false
+}
+
+func phase2NonSQLiteExternalRow(row scoreboardRow) bool {
+	return !strings.EqualFold(row.System, "SQLite FTS5") && !strings.EqualFold(row.Engine, "sqlite_fts5")
+}
+
+func phase2ComparableRowMetadata(a, b scoreboardRow) bool {
+	if a.Dataset == "" || b.Dataset == "" || a.Dataset != b.Dataset {
+		return false
+	}
+	if a.TopK != b.TopK {
+		return false
+	}
+	if a.QuerySet != "" && b.QuerySet != "" && a.QuerySet != b.QuerySet {
+		return false
+	}
+	return true
+}
+
+func comparableLatencyPair(treeRow, externalRow scoreboardRow) (float64, float64, bool) {
+	if treeRow.NsPerOp == nil || externalRow.NsPerOp == nil || *treeRow.NsPerOp <= 0 || *externalRow.NsPerOp <= 0 {
+		return 0, 0, false
+	}
+	return *treeRow.NsPerOp, *externalRow.NsPerOp, true
+}
+
+func comparableStoragePair(treeRow, externalRow scoreboardRow) (float64, float64, bool) {
+	if treeRow.StorageBytesPerDoc == nil || externalRow.StorageBytesPerDoc == nil || *treeRow.StorageBytesPerDoc <= 0 || *externalRow.StorageBytesPerDoc <= 0 {
+		return 0, 0, false
+	}
+	return *treeRow.StorageBytesPerDoc, *externalRow.StorageBytesPerDoc, true
+}
+
+func phase2RowMetricSummary(row scoreboardRow, storage bool) string {
+	metric := ""
+	if storage && row.StorageBytesPerDoc != nil {
+		metric = " storage=" + formatNumber(*row.StorageBytesPerDoc) + " B/doc"
+	} else if !storage && row.NsPerOp != nil {
+		metric = " ns/op=" + formatNumber(*row.NsPerOp)
+	}
+	return fmt.Sprintf("%s/%s%s", row.SourceLabel, row.Benchmark, metric)
 }
 
 func classFromLowerIsBetterRatio(ratio float64) string {

--- a/cmd/treedb_text_hybrid_scoreboard/main.go
+++ b/cmd/treedb_text_hybrid_scoreboard/main.go
@@ -1041,12 +1041,6 @@ func buildPhase2Synthesis(rows []scoreboardRow, unavailable []unavailableRow) ph
 			RequiredFollowUpRows: append([]string(nil), row.RequiredFollowUpRows...),
 		})
 	}
-	sort.Slice(priorities, func(i, j int) bool {
-		if priorities[i].Priority == priorities[j].Priority {
-			return priorities[i].ShapeID < priorities[j].ShapeID
-		}
-		return priorities[i].Priority < priorities[j].Priority
-	})
 	return phase2Synthesis{
 		SchemaVersion:          phase2SynthesisVersion,
 		ClassificationBasis:    "phase-2 target taxonomy plus captured scoreboard rows; ahead/near require comparable external rows, while missing or non-equivalent external rows stay behind/far by evidence gap rather than parity claim",
@@ -1297,7 +1291,11 @@ func phase2NonSQLiteExternalRow(row scoreboardRow) bool {
 }
 
 func phase2ComparableRowMetadata(a, b scoreboardRow) bool {
-	if a.Dataset == "" || b.Dataset == "" || a.Dataset != b.Dataset {
+	if aDocs, okA := phase2DatasetDocs(a.Dataset); okA {
+		if bDocs, okB := phase2DatasetDocs(b.Dataset); okB && aDocs != bDocs {
+			return false
+		}
+	} else if bDocs, okB := phase2DatasetDocs(b.Dataset); okB && bDocs != "" {
 		return false
 	}
 	if a.TopK != b.TopK {
@@ -1307,6 +1305,16 @@ func phase2ComparableRowMetadata(a, b scoreboardRow) bool {
 		return false
 	}
 	return true
+}
+
+func phase2DatasetDocs(dataset string) (string, bool) {
+	for _, field := range strings.Fields(dataset) {
+		if strings.HasPrefix(field, "docs=") {
+			value := strings.TrimPrefix(field, "docs=")
+			return value, value != ""
+		}
+	}
+	return "", false
 }
 
 func comparableLatencyPair(treeRow, externalRow scoreboardRow) (float64, float64, bool) {
@@ -1324,10 +1332,22 @@ func comparableStoragePair(treeRow, externalRow scoreboardRow) (float64, float64
 }
 
 func comparableBuildPair(treeRow, externalRow scoreboardRow) (float64, float64, bool) {
-	if treeRow.BuildSeconds == nil || externalRow.BuildSeconds == nil || *treeRow.BuildSeconds <= 0 || *externalRow.BuildSeconds <= 0 {
+	treeSeconds, okTree := rowBuildSecondsMetric(treeRow)
+	externalSeconds, okExternal := rowBuildSecondsMetric(externalRow)
+	if !okTree || !okExternal || treeSeconds <= 0 || externalSeconds <= 0 {
 		return 0, 0, false
 	}
-	return *treeRow.BuildSeconds, *externalRow.BuildSeconds, true
+	return treeSeconds, externalSeconds, true
+}
+
+func rowBuildSecondsMetric(row scoreboardRow) (float64, bool) {
+	if row.BuildSeconds != nil && *row.BuildSeconds > 0 {
+		return *row.BuildSeconds, true
+	}
+	if row.NsPerOp != nil && *row.NsPerOp > 0 {
+		return *row.NsPerOp / 1e9, true
+	}
+	return 0, false
 }
 
 func phase2RowMetricSummary(row scoreboardRow, metricKind string) string {
@@ -1338,8 +1358,8 @@ func phase2RowMetricSummary(row scoreboardRow, metricKind string) string {
 			metric = " storage=" + formatNumber(*row.StorageBytesPerDoc) + " B/doc"
 		}
 	case "build":
-		if row.BuildSeconds != nil {
-			metric = " build=" + formatSecondsPtr(row.BuildSeconds)
+		if seconds, ok := rowBuildSecondsMetric(row); ok {
+			metric = " build=" + formatSecondsPtr(&seconds)
 		}
 	default:
 		if row.NsPerOp != nil {
@@ -1360,32 +1380,6 @@ func classFromLowerIsBetterRatio(ratio float64) string {
 	default:
 		return "far_behind"
 	}
-}
-
-func bestNsPerOp(rows []scoreboardRow) (float64, bool) {
-	best := math.Inf(1)
-	for _, row := range rows {
-		if row.NsPerOp != nil && *row.NsPerOp > 0 && *row.NsPerOp < best {
-			best = *row.NsPerOp
-		}
-	}
-	if math.IsInf(best, 1) {
-		return 0, false
-	}
-	return best, true
-}
-
-func bestStorageBytesPerDoc(rows []scoreboardRow) (float64, bool) {
-	best := math.Inf(1)
-	for _, row := range rows {
-		if row.StorageBytesPerDoc != nil && *row.StorageBytesPerDoc > 0 && *row.StorageBytesPerDoc < best {
-			best = *row.StorageBytesPerDoc
-		}
-	}
-	if math.IsInf(best, 1) {
-		return 0, false
-	}
-	return best, true
 }
 
 func defaultPhase2Classification(shapeID string) (string, string) {

--- a/cmd/treedb_text_hybrid_scoreboard/main.go
+++ b/cmd/treedb_text_hybrid_scoreboard/main.go
@@ -1366,7 +1366,11 @@ func phase2RowMatchesTarget(row scoreboardRow, shapeID string) bool {
 	case "index_build_ingest":
 		return row.Modality == "build_storage" || strings.Contains(text, "index build") || strings.Contains(text, "ingest") || strings.Contains(text, "insertbatch") || strings.Contains(text, "backfill")
 	case "index_size":
-		return row.StorageBytes != nil || row.StorageBytesPerDoc != nil || strings.Contains(text, "storage") || strings.Contains(text, "index size")
+		// Why: many retrieval and vector rows carry storage_bytes_per_doc for
+		// context. Treat index-size parity as measured only when the row's own
+		// benchmark/query/boundary explicitly represents a text index footprint
+		// boundary, not merely because a storage metric is attached.
+		return strings.Contains(text, "index size") || strings.Contains(text, "bytes/doc") || strings.Contains(text, "index_bytes") || (strings.Contains(text, "storage") && strings.Contains(text, "text"))
 	case "reopen":
 		return strings.Contains(text, "reopen") || strings.Contains(text, "recovery")
 	case "maintenance_rewrite":

--- a/cmd/treedb_text_hybrid_scoreboard/main.go
+++ b/cmd/treedb_text_hybrid_scoreboard/main.go
@@ -1230,6 +1230,8 @@ func measuredPhase2Classification(shapeID string, treeRows, externalRows []score
 		var ok bool
 		if shapeID == "index_size" {
 			treeMetric, externalMetric, ok = comparableStoragePair(pair.TreeDB, pair.External)
+		} else if shapeID == "index_build_ingest" {
+			treeMetric, externalMetric, ok = comparableBuildPair(pair.TreeDB, pair.External)
 		} else {
 			treeMetric, externalMetric, ok = comparableLatencyPair(pair.TreeDB, pair.External)
 		}
@@ -1246,9 +1248,12 @@ func measuredPhase2Classification(shapeID string, treeRows, externalRows []score
 		return "", "", false
 	}
 	if shapeID == "index_size" {
-		return classFromLowerIsBetterRatio(bestRatio), fmt.Sprintf("captured explicit comparable storage pair: TreeDB %s vs %s (ratio %.3gx)", phase2RowMetricSummary(best.TreeDB, true), phase2RowMetricSummary(best.External, true), bestRatio), true
+		return classFromLowerIsBetterRatio(bestRatio), fmt.Sprintf("captured explicit comparable storage pair: TreeDB %s vs %s (ratio %.3gx)", phase2RowMetricSummary(best.TreeDB, "storage"), phase2RowMetricSummary(best.External, "storage"), bestRatio), true
 	}
-	return classFromLowerIsBetterRatio(bestRatio), fmt.Sprintf("captured explicit comparable latency pair: TreeDB %s vs %s (ratio %.3gx)", phase2RowMetricSummary(best.TreeDB, false), phase2RowMetricSummary(best.External, false), bestRatio), true
+	if shapeID == "index_build_ingest" {
+		return classFromLowerIsBetterRatio(bestRatio), fmt.Sprintf("captured explicit comparable build pair: TreeDB %s vs %s (ratio %.3gx)", phase2RowMetricSummary(best.TreeDB, "build"), phase2RowMetricSummary(best.External, "build"), bestRatio), true
+	}
+	return classFromLowerIsBetterRatio(bestRatio), fmt.Sprintf("captured explicit comparable latency pair: TreeDB %s vs %s (ratio %.3gx)", phase2RowMetricSummary(best.TreeDB, "latency"), phase2RowMetricSummary(best.External, "latency"), bestRatio), true
 }
 
 type phase2ComparablePair struct {
@@ -1318,12 +1323,28 @@ func comparableStoragePair(treeRow, externalRow scoreboardRow) (float64, float64
 	return *treeRow.StorageBytesPerDoc, *externalRow.StorageBytesPerDoc, true
 }
 
-func phase2RowMetricSummary(row scoreboardRow, storage bool) string {
+func comparableBuildPair(treeRow, externalRow scoreboardRow) (float64, float64, bool) {
+	if treeRow.BuildSeconds == nil || externalRow.BuildSeconds == nil || *treeRow.BuildSeconds <= 0 || *externalRow.BuildSeconds <= 0 {
+		return 0, 0, false
+	}
+	return *treeRow.BuildSeconds, *externalRow.BuildSeconds, true
+}
+
+func phase2RowMetricSummary(row scoreboardRow, metricKind string) string {
 	metric := ""
-	if storage && row.StorageBytesPerDoc != nil {
-		metric = " storage=" + formatNumber(*row.StorageBytesPerDoc) + " B/doc"
-	} else if !storage && row.NsPerOp != nil {
-		metric = " ns/op=" + formatNumber(*row.NsPerOp)
+	switch metricKind {
+	case "storage":
+		if row.StorageBytesPerDoc != nil {
+			metric = " storage=" + formatNumber(*row.StorageBytesPerDoc) + " B/doc"
+		}
+	case "build":
+		if row.BuildSeconds != nil {
+			metric = " build=" + formatSecondsPtr(row.BuildSeconds)
+		}
+	default:
+		if row.NsPerOp != nil {
+			metric = " ns/op=" + formatNumber(*row.NsPerOp)
+		}
 	}
 	return fmt.Sprintf("%s/%s%s", row.SourceLabel, row.Benchmark, metric)
 }

--- a/cmd/treedb_text_hybrid_scoreboard/main.go
+++ b/cmd/treedb_text_hybrid_scoreboard/main.go
@@ -1219,9 +1219,15 @@ func classifyPhase2Gap(target phase2BenchmarkTarget, rows []scoreboardRow, unava
 }
 
 func measuredPhase2Classification(shapeID string, treeRows, externalRows []scoreboardRow) (string, string, bool) {
-	if len(treeRows) == 0 || len(externalRows) == 0 {
+	comparableExternalRows := phase2ComparableExternalRows(externalRows)
+	if len(treeRows) == 0 || len(comparableExternalRows) == 0 {
 		return "", "", false
 	}
+	// Why: SQLite FTS5 is a useful embedded baseline, but the #2834 readout
+	// explicitly treats SQLite-only evidence as non-equivalent for industry
+	// parity. Ratio-based ahead/near claims require a non-SQLite baseline row
+	// from a pinned comparable search engine harness.
+	externalRows = comparableExternalRows
 	if shapeID == "index_size" {
 		treeStorage, okTree := bestStorageBytesPerDoc(treeRows)
 		extStorage, okExt := bestStorageBytesPerDoc(externalRows)
@@ -1238,6 +1244,17 @@ func measuredPhase2Classification(shapeID string, treeRows, externalRows []score
 	}
 	ratio := treeNS / extNS
 	return classFromLowerIsBetterRatio(ratio), fmt.Sprintf("captured comparable latency rows: TreeDB %.3g ns/op vs external %.3g ns/op (ratio %.3gx)", treeNS, extNS, ratio), true
+}
+
+func phase2ComparableExternalRows(rows []scoreboardRow) []scoreboardRow {
+	out := make([]scoreboardRow, 0, len(rows))
+	for _, row := range rows {
+		if strings.EqualFold(row.System, "SQLite FTS5") || strings.EqualFold(row.Engine, "sqlite_fts5") {
+			continue
+		}
+		out = append(out, row)
+	}
+	return out
 }
 
 func classFromLowerIsBetterRatio(ratio float64) string {

--- a/cmd/treedb_text_hybrid_scoreboard/main_test.go
+++ b/cmd/treedb_text_hybrid_scoreboard/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -233,5 +234,135 @@ func TestRunWritesReportBeforeReturningCounterFailure(t *testing.T) {
 	}
 	if _, statErr := os.Stat(filepath.Join(out, "scoreboard.json")); statErr != nil {
 		t.Fatalf("scoreboard.json not written before failure: %v", statErr)
+	}
+}
+
+func TestPhase2SynthesisGolden(t *testing.T) {
+	treedbNS := 1_100_000.0
+	sqliteNS := 1_000_000.0
+	treedbStorage := 144.0
+	sqliteStorage := 128.0
+	syn := buildPhase2Synthesis([]scoreboardRow{
+		{
+			SourceLabel:        "treedb_common_10k",
+			System:             "TreeDB",
+			Engine:             "treedb_text_v2",
+			Modality:           "text_only",
+			QueryShape:         "common term BM25F top-k with block-max pruning",
+			Boundary:           "No-document text-v2 score-only BM25F search",
+			Benchmark:          "BenchmarkTextV2BlockMaxCommonTerm2628/blockmax_common_topk",
+			NsPerOp:            &treedbNS,
+			StorageBytesPerDoc: &treedbStorage,
+		},
+		{
+			SourceLabel:        "sqlite_common_10k",
+			System:             "SQLite FTS5",
+			Engine:             "sqlite_fts5",
+			Modality:           "text_only",
+			QueryShape:         "common term FTS5 MATCH top-k",
+			Boundary:           "no-document rowid+bm25 retrieval only",
+			Benchmark:          "sqlite_fts5/common_term_no_docs",
+			NsPerOp:            &sqliteNS,
+			StorageBytesPerDoc: &sqliteStorage,
+		},
+	}, []unavailableRow{
+		{System: "Bleve", Reason: "not run in unit test"},
+		{System: "Tantivy", Reason: "not run in unit test"},
+		{System: "Lucene", Reason: "not run in unit test"},
+	})
+	payload, err := json.MarshalIndent(syn, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal synthesis: %v", err)
+	}
+	payload = append(payload, '\n')
+	goldenPath := filepath.Join("testdata", "phase2_synthesis_golden.json")
+	if os.Getenv("UPDATE_GOLDEN") == "1" {
+		if err := os.WriteFile(goldenPath, payload, 0o644); err != nil {
+			t.Fatalf("update golden %s: %v", goldenPath, err)
+		}
+		return
+	}
+	want, err := os.ReadFile(goldenPath)
+	if err != nil {
+		t.Fatalf("read golden %s: %v", goldenPath, err)
+	}
+	if string(payload) != string(want) {
+		t.Fatalf("phase2 synthesis golden mismatch\n--- got ---\n%s\n--- want ---\n%s", payload, want)
+	}
+}
+
+func TestRunWritesPhase2SynthesisArtifacts(t *testing.T) {
+	dir := t.TempDir()
+	goBench := filepath.Join(dir, "go.txt")
+	if err := os.WriteFile(goBench, []byte(`BenchmarkTextV2BlockMaxCommonTerm2628/blockmax_common_topk-8 1 1000 ns/op 16 B/op 1 allocs/op 0 docs_fetched/search 0 full_doc_fallbacks/search 0 fail_closed/search 0 state_lookups/search 0 match_details/search 4 posting_blocks_visited/search 2 posting_blocks_skipped/search
+`), 0o644); err != nil {
+		t.Fatalf("write go bench: %v", err)
+	}
+	out := filepath.Join(dir, "out")
+	if err := run(config{
+		outDir:      out,
+		goBenches:   namedPaths{{Name: "treedb_text_blockmax_10k", Path: goBench}},
+		unavailable: namedValues{{Name: "Lucene", Value: "not run in artifact smoke"}, {Name: "Tantivy", Value: "not run in artifact smoke"}, {Name: "Bleve", Value: "not run in artifact smoke"}},
+	}); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	jsonPayload, err := os.ReadFile(filepath.Join(out, "scoreboard.json"))
+	if err != nil {
+		t.Fatalf("read scoreboard.json: %v", err)
+	}
+	var rep report
+	if err := json.Unmarshal(jsonPayload, &rep); err != nil {
+		t.Fatalf("parse scoreboard.json: %v", err)
+	}
+	if rep.Phase2Synthesis.SchemaVersion != phase2SynthesisVersion {
+		t.Fatalf("phase2 synthesis schema=%q", rep.Phase2Synthesis.SchemaVersion)
+	}
+	mdPayload, err := os.ReadFile(filepath.Join(out, "scoreboard.md"))
+	if err != nil {
+		t.Fatalf("read scoreboard.md: %v", err)
+	}
+	md := string(mdPayload)
+	for _, want := range []string{"## Phase-2 gap classification", "single_term_common", "External baseline coverage", "Non-equivalent analyzer/query semantics"} {
+		if !strings.Contains(md, want) {
+			t.Fatalf("scoreboard.md missing %q:\n%s", want, md)
+		}
+	}
+}
+
+func TestPhase2GapReadoutDocContainsRequiredTaxonomy(t *testing.T) {
+	path := filepath.Join("..", "..", "docs", "benchmarks", "treedb_text_v2_phase2_gap_classification.md")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	doc := string(data)
+	for _, want := range []string{
+		"/tmp/gomap_2727_scoreboard_candidate_20260613_090425",
+		"scripts/bench_text_hybrid_scoreboard.sh",
+		"single_term_common",
+		"single_term_rare",
+		"multi_term_and",
+		"multi_term_or_wand",
+		"phrase",
+		"hybrid_text_scalar",
+		"index_build_ingest",
+		"index_size",
+		"reopen",
+		"maintenance_rewrite",
+		"ahead",
+		"near_parity",
+		"behind_but_tractable",
+		"far_behind",
+		"SQLite FTS5",
+		"Bleve",
+		"Tantivy",
+		"Lucene",
+	} {
+		if !strings.Contains(doc, want) {
+			t.Fatalf("phase2 readout missing %q", want)
+		}
+	}
+	if strings.Contains(strings.ToLower(doc), "slab") {
+		t.Fatalf("phase2 readout should use value-log/storage-native wording, not slab")
 	}
 }

--- a/cmd/treedb_text_hybrid_scoreboard/main_test.go
+++ b/cmd/treedb_text_hybrid_scoreboard/main_test.go
@@ -368,7 +368,7 @@ func TestPhase2SynthesisRequiresExplicitComparablePair(t *testing.T) {
 
 	rows[0].Metrics = map[string]float64{"phase2_comparable": 1}
 	rows[1].Metrics = map[string]float64{"phase2_comparable": 1}
-	rows[1].Dataset = rows[0].Dataset
+	rows[1].Dataset = rows[0].Dataset + " queries=1000"
 	syn = buildPhase2Synthesis(rows, nil)
 	common = phase2ClassificationByID(t, syn, "single_term_common")
 	if common.Classification != "ahead" {
@@ -377,21 +377,21 @@ func TestPhase2SynthesisRequiresExplicitComparablePair(t *testing.T) {
 }
 
 func TestPhase2SynthesisComparesExplicitBuildPairs(t *testing.T) {
-	treeBuild := 0.8
+	treeBuildNS := 800_000_000.0
 	luceneBuild := 1.0
 	syn := buildPhase2Synthesis([]scoreboardRow{
 		{
-			SourceLabel:  "treedb_build_10k",
-			System:       "TreeDB",
-			Engine:       "treedb_text_v2",
-			Modality:     "build_storage",
-			Dataset:      "docs=10000",
-			TopK:         0,
-			QueryShape:   "text-v2 index build",
-			Boundary:     "checkpointed text index build",
-			Benchmark:    "BenchmarkCreateTextIndex/build",
-			BuildSeconds: &treeBuild,
-			Metrics:      map[string]float64{"phase2_comparable": 1},
+			SourceLabel: "treedb_build_10k",
+			System:      "TreeDB",
+			Engine:      "treedb_text_v2",
+			Modality:    "build_storage",
+			Dataset:     "docs=10000",
+			TopK:        0,
+			QueryShape:  "text-v2 index build",
+			Boundary:    "checkpointed text index build",
+			Benchmark:   "BenchmarkCreateTextIndex/build",
+			NsPerOp:     &treeBuildNS,
+			Metrics:     map[string]float64{"phase2_comparable": 1},
 		},
 		{
 			SourceLabel:  "lucene_build_10k",

--- a/cmd/treedb_text_hybrid_scoreboard/main_test.go
+++ b/cmd/treedb_text_hybrid_scoreboard/main_test.go
@@ -291,6 +291,46 @@ func TestPhase2SynthesisGolden(t *testing.T) {
 	}
 }
 
+func TestPhase2SynthesisDoesNotClaimParityFromSQLiteOnly(t *testing.T) {
+	treedbNS := 700_000.0
+	sqliteNS := 1_000_000.0
+	syn := buildPhase2Synthesis([]scoreboardRow{
+		{
+			SourceLabel: "treedb_common_10k",
+			System:      "TreeDB",
+			Engine:      "treedb_text_v2",
+			Modality:    "text_only",
+			QueryShape:  "common term BM25F top-k with block-max pruning",
+			Boundary:    "No-document text-v2 score-only BM25F search",
+			Benchmark:   "BenchmarkTextV2BlockMaxCommonTerm2628/blockmax_common_topk",
+			NsPerOp:     &treedbNS,
+		},
+		{
+			SourceLabel: "sqlite_common_10k",
+			System:      "SQLite FTS5",
+			Engine:      "sqlite_fts5",
+			Modality:    "text_only",
+			QueryShape:  "common term FTS5 MATCH top-k",
+			Boundary:    "no-document rowid+bm25 retrieval only",
+			Benchmark:   "sqlite_fts5/common_term_no_docs",
+			NsPerOp:     &sqliteNS,
+		},
+	}, []unavailableRow{{System: "Lucene", Reason: "not run"}, {System: "Tantivy", Reason: "not run"}, {System: "Bleve", Reason: "not run"}})
+	var common phase2GapClassification
+	for _, got := range syn.GapClassifications {
+		if got.ShapeID == "single_term_common" {
+			common = got
+			break
+		}
+	}
+	if common.Classification == "ahead" || common.Classification == "near_parity" {
+		t.Fatalf("single_term_common classification=%q from SQLite-only evidence; want evidence gap", common.Classification)
+	}
+	if !strings.Contains(common.ExternalEvidence, "sqlite_common_10k") {
+		t.Fatalf("single_term_common external evidence=%q should still document SQLite row availability", common.ExternalEvidence)
+	}
+}
+
 func TestPhase2IndexSizeIgnoresIncidentalRetrievalStorage(t *testing.T) {
 	treedbNS := 1_100_000.0
 	sqliteNS := 1_000_000.0

--- a/cmd/treedb_text_hybrid_scoreboard/main_test.go
+++ b/cmd/treedb_text_hybrid_scoreboard/main_test.go
@@ -331,6 +331,62 @@ func TestPhase2SynthesisDoesNotClaimParityFromSQLiteOnly(t *testing.T) {
 	}
 }
 
+func TestPhase2SynthesisRequiresExplicitComparablePair(t *testing.T) {
+	treedbNS := 700_000.0
+	luceneNS := 1_000_000.0
+	rows := []scoreboardRow{
+		{
+			SourceLabel: "treedb_common_10k",
+			System:      "TreeDB",
+			Engine:      "treedb_text_v2",
+			Modality:    "text_only",
+			Dataset:     "docs=10000",
+			TopK:        10,
+			QueryShape:  "common term BM25F top-k with block-max pruning",
+			Boundary:    "No-document text-v2 score-only BM25F search",
+			Benchmark:   "BenchmarkTextV2BlockMaxCommonTerm2628/blockmax_common_topk",
+			NsPerOp:     &treedbNS,
+		},
+		{
+			SourceLabel: "lucene_common_1m",
+			System:      "Lucene",
+			Engine:      "lucene",
+			Modality:    "text_only",
+			Dataset:     "docs=1000000",
+			TopK:        10,
+			QueryShape:  "common term BM25 top-k",
+			Boundary:    "no-document scorer top-k",
+			Benchmark:   "lucene/common_term_no_docs",
+			NsPerOp:     &luceneNS,
+		},
+	}
+	syn := buildPhase2Synthesis(rows, nil)
+	common := phase2ClassificationByID(t, syn, "single_term_common")
+	if common.Classification == "ahead" || common.Classification == "near_parity" {
+		t.Fatalf("single_term_common classification=%q from unpaired rows; want default evidence gap", common.Classification)
+	}
+
+	rows[0].Metrics = map[string]float64{"phase2_comparable": 1}
+	rows[1].Metrics = map[string]float64{"phase2_comparable": 1}
+	rows[1].Dataset = rows[0].Dataset
+	syn = buildPhase2Synthesis(rows, nil)
+	common = phase2ClassificationByID(t, syn, "single_term_common")
+	if common.Classification != "ahead" {
+		t.Fatalf("single_term_common classification=%q with explicit comparable pair; want ahead", common.Classification)
+	}
+}
+
+func phase2ClassificationByID(t *testing.T, syn phase2Synthesis, shapeID string) phase2GapClassification {
+	t.Helper()
+	for _, got := range syn.GapClassifications {
+		if got.ShapeID == shapeID {
+			return got
+		}
+	}
+	t.Fatalf("missing phase2 classification %q", shapeID)
+	return phase2GapClassification{}
+}
+
 func TestPhase2IndexSizeIgnoresIncidentalRetrievalStorage(t *testing.T) {
 	treedbNS := 1_100_000.0
 	sqliteNS := 1_000_000.0

--- a/cmd/treedb_text_hybrid_scoreboard/main_test.go
+++ b/cmd/treedb_text_hybrid_scoreboard/main_test.go
@@ -376,6 +376,46 @@ func TestPhase2SynthesisRequiresExplicitComparablePair(t *testing.T) {
 	}
 }
 
+func TestPhase2SynthesisComparesExplicitBuildPairs(t *testing.T) {
+	treeBuild := 0.8
+	luceneBuild := 1.0
+	syn := buildPhase2Synthesis([]scoreboardRow{
+		{
+			SourceLabel:  "treedb_build_10k",
+			System:       "TreeDB",
+			Engine:       "treedb_text_v2",
+			Modality:     "build_storage",
+			Dataset:      "docs=10000",
+			TopK:         0,
+			QueryShape:   "text-v2 index build",
+			Boundary:     "checkpointed text index build",
+			Benchmark:    "BenchmarkCreateTextIndex/build",
+			BuildSeconds: &treeBuild,
+			Metrics:      map[string]float64{"phase2_comparable": 1},
+		},
+		{
+			SourceLabel:  "lucene_build_10k",
+			System:       "Lucene",
+			Engine:       "lucene",
+			Modality:     "build_storage",
+			Dataset:      "docs=10000",
+			TopK:         0,
+			QueryShape:   "Lucene index build",
+			Boundary:     "optimized index build",
+			Benchmark:    "lucene/build",
+			BuildSeconds: &luceneBuild,
+			Metrics:      map[string]float64{"phase2_comparable": 1},
+		},
+	}, nil)
+	build := phase2ClassificationByID(t, syn, "index_build_ingest")
+	if build.Classification != "ahead" {
+		t.Fatalf("index_build_ingest classification=%q rationale=%q; want build metric comparison", build.Classification, build.Rationale)
+	}
+	if !strings.Contains(build.Rationale, "build pair") {
+		t.Fatalf("index_build_ingest rationale=%q missing build pair evidence", build.Rationale)
+	}
+}
+
 func phase2ClassificationByID(t *testing.T, syn phase2Synthesis, shapeID string) phase2GapClassification {
 	t.Helper()
 	for _, got := range syn.GapClassifications {

--- a/cmd/treedb_text_hybrid_scoreboard/main_test.go
+++ b/cmd/treedb_text_hybrid_scoreboard/main_test.go
@@ -291,6 +291,50 @@ func TestPhase2SynthesisGolden(t *testing.T) {
 	}
 }
 
+func TestPhase2IndexSizeIgnoresIncidentalRetrievalStorage(t *testing.T) {
+	treedbNS := 1_100_000.0
+	sqliteNS := 1_000_000.0
+	treedbStorage := 144.0
+	sqliteStorage := 128.0
+	syn := buildPhase2Synthesis([]scoreboardRow{
+		{
+			SourceLabel:        "treedb_common_10k",
+			System:             "TreeDB",
+			Engine:             "treedb_text_v2",
+			Modality:           "text_only",
+			QueryShape:         "common term BM25F top-k with block-max pruning",
+			Boundary:           "No-document text-v2 score-only BM25F search",
+			Benchmark:          "BenchmarkTextV2BlockMaxCommonTerm2628/blockmax_common_topk",
+			NsPerOp:            &treedbNS,
+			StorageBytesPerDoc: &treedbStorage,
+		},
+		{
+			SourceLabel:        "sqlite_common_10k",
+			System:             "SQLite FTS5",
+			Engine:             "sqlite_fts5",
+			Modality:           "text_only",
+			QueryShape:         "common term FTS5 MATCH top-k",
+			Boundary:           "no-document rowid+bm25 retrieval only",
+			Benchmark:          "sqlite_fts5/common_term_no_docs",
+			NsPerOp:            &sqliteNS,
+			StorageBytesPerDoc: &sqliteStorage,
+		},
+	}, nil)
+	var indexSize phase2GapClassification
+	for _, got := range syn.GapClassifications {
+		if got.ShapeID == "index_size" {
+			indexSize = got
+			break
+		}
+	}
+	if indexSize.Classification != "far_behind" {
+		t.Fatalf("index_size classification=%q evidence=%q; incidental retrieval storage must not become index-size parity evidence", indexSize.Classification, indexSize.TreeDBEvidence)
+	}
+	if !strings.Contains(indexSize.TreeDBEvidence, "not captured") {
+		t.Fatalf("index_size TreeDB evidence=%q want explicit missing footprint evidence", indexSize.TreeDBEvidence)
+	}
+}
+
 func TestRunWritesPhase2SynthesisArtifacts(t *testing.T) {
 	dir := t.TempDir()
 	goBench := filepath.Join(dir, "go.txt")

--- a/cmd/treedb_text_hybrid_scoreboard/testdata/phase2_synthesis_golden.json
+++ b/cmd/treedb_text_hybrid_scoreboard/testdata/phase2_synthesis_golden.json
@@ -224,12 +224,12 @@
     {
       "shape_id": "index_size",
       "shape": "index size",
-      "classification": "near_parity",
+      "classification": "far_behind",
       "priority": 1,
       "primary_issue": "#2835",
-      "treedb_evidence": "captured 1 row(s): treedb_common_10k/BenchmarkTextV2BlockMaxCommonTerm2628/blockmax_common_topk ns/op=1100000, storage=144 B/doc",
-      "external_evidence": "captured 1 row(s): sqlite_common_10k/sqlite_fts5/common_term_no_docs ns/op=1000000, storage=128 B/doc",
-      "rationale": "captured comparable storage rows: TreeDB 144 B/doc vs external 128 B/doc (ratio 1.12x)",
+      "treedb_evidence": "TreeDB durable text-v2 bytes/doc is not captured in the current scoreboard run",
+      "external_evidence": "no comparable external row captured; SQLite FTS5=not_captured; Bleve=unavailable (not run in unit test); Tantivy=unavailable (not run in unit test); Lucene=unavailable (not run in unit test)",
+      "rationale": "phase-1 scoreboard has external storage rows but lacks a durable TreeDB text-v2 bytes/doc row, so footprint parity is the first evidence and optimization gap",
       "required_follow_up_rows": [
         "TreeDB durable text-v2 bytes/doc after checkpoint and rewrite",
         "SQLite FTS5/Lucene/Tantivy/Bleve index bytes/doc after equivalent optimize/vacuum"
@@ -404,7 +404,7 @@
       "priority": 1,
       "shape_id": "index_size",
       "primary_issue": "#2835",
-      "rationale": "captured comparable storage rows: TreeDB 144 B/doc vs external 128 B/doc (ratio 1.12x)",
+      "rationale": "phase-1 scoreboard has external storage rows but lacks a durable TreeDB text-v2 bytes/doc row, so footprint parity is the first evidence and optimization gap",
       "required_follow_up_rows": [
         "TreeDB durable text-v2 bytes/doc after checkpoint and rewrite",
         "SQLite FTS5/Lucene/Tantivy/Bleve index bytes/doc after equivalent optimize/vacuum"

--- a/cmd/treedb_text_hybrid_scoreboard/testdata/phase2_synthesis_golden.json
+++ b/cmd/treedb_text_hybrid_scoreboard/testdata/phase2_synthesis_golden.json
@@ -241,12 +241,12 @@
     {
       "shape_id": "single_term_common",
       "shape": "single-term common",
-      "classification": "near_parity",
+      "classification": "behind_but_tractable",
       "priority": 2,
       "primary_issue": "#2835",
       "treedb_evidence": "captured 1 row(s): treedb_common_10k/BenchmarkTextV2BlockMaxCommonTerm2628/blockmax_common_topk ns/op=1100000, storage=144 B/doc",
       "external_evidence": "captured 1 row(s): sqlite_common_10k/sqlite_fts5/common_term_no_docs ns/op=1000000, storage=128 B/doc",
-      "rationale": "captured comparable latency rows: TreeDB 1.1e+06 ns/op vs external 1e+06 ns/op (ratio 1.1x)",
+      "rationale": "TreeDB has exact block-max common-term evidence, but comparable Lucene/Tantivy/Bleve/SQLite rows and bytes/doc context are missing",
       "required_follow_up_rows": [
         "TreeDB 10k and 100k blockmax_common_topk",
         "SQLite FTS5/Lucene/Tantivy/Bleve common-term top-k rows"
@@ -414,7 +414,7 @@
       "priority": 2,
       "shape_id": "single_term_common",
       "primary_issue": "#2835",
-      "rationale": "captured comparable latency rows: TreeDB 1.1e+06 ns/op vs external 1e+06 ns/op (ratio 1.1x)",
+      "rationale": "TreeDB has exact block-max common-term evidence, but comparable Lucene/Tantivy/Bleve/SQLite rows and bytes/doc context are missing",
       "required_follow_up_rows": [
         "TreeDB 10k and 100k blockmax_common_topk",
         "SQLite FTS5/Lucene/Tantivy/Bleve common-term top-k rows"

--- a/cmd/treedb_text_hybrid_scoreboard/testdata/phase2_synthesis_golden.json
+++ b/cmd/treedb_text_hybrid_scoreboard/testdata/phase2_synthesis_golden.json
@@ -1,0 +1,511 @@
+{
+  "schema_version": "treedb_text_v2_phase2_gap_synthesis/v1",
+  "classification_basis": "phase-2 target taxonomy plus captured scoreboard rows; ahead/near require comparable external rows, while missing or non-equivalent external rows stay behind/far by evidence gap rather than parity claim",
+  "external_baselines": [
+    {
+      "system": "SQLite FTS5",
+      "status": "available",
+      "evidence": "captured scoreboard row(s): sqlite_common_10k",
+      "caveat": "embedded FTS baseline; rowid+bm25 retrieval is not Lucene/Tantivy/Bleve analyzer or query-parser parity"
+    },
+    {
+      "system": "Bleve",
+      "status": "unavailable",
+      "evidence": "not run in unit test",
+      "caveat": "requires a pinned Go harness with the same corpus, analyzer, query semantics, and result-order checks"
+    },
+    {
+      "system": "Tantivy",
+      "status": "unavailable",
+      "evidence": "not run in unit test",
+      "caveat": "requires a pinned Rust/Tantivy harness with the same corpus, analyzer, query semantics, and result-order checks"
+    },
+    {
+      "system": "Lucene",
+      "status": "unavailable",
+      "evidence": "not run in unit test",
+      "caveat": "requires a pinned Lucene/JMH or OpenSearch run with the same corpus, analyzer, query semantics, and result-order checks"
+    }
+  ],
+  "benchmark_targets": [
+    {
+      "shape_id": "single_term_common",
+      "shape": "single-term common",
+      "description": "High-document-frequency BM25F top-k term with exact block-max skipping.",
+      "primary_issue": "#2835",
+      "required_rows": [
+        "TreeDB 10k and 100k blockmax_common_topk",
+        "SQLite FTS5/Lucene/Tantivy/Bleve common-term top-k rows"
+      ],
+      "required_counters": [
+        "docs_fetched/search=0",
+        "full_doc_fallbacks/search=0",
+        "fail_closed/search=0",
+        "text_state_lookups/search=0",
+        "text_match_details/search=0",
+        "posting_blocks_visited/search",
+        "posting_blocks_skipped/search",
+        "threshold_updates/search"
+      ]
+    },
+    {
+      "shape_id": "single_term_rare",
+      "shape": "single-term rare",
+      "description": "Low-document-frequency BM25F top-k term where decode/setup overhead dominates.",
+      "primary_issue": "#2835",
+      "required_rows": [
+        "TreeDB rare term score-only 10k/100k/1M",
+        "SQLite FTS5/Lucene/Tantivy/Bleve rare-term top-k rows"
+      ],
+      "required_counters": [
+        "docs_fetched/search=0",
+        "full_doc_fallbacks/search=0",
+        "fail_closed/search=0",
+        "text_state_lookups/search=0",
+        "text_match_details/search=0"
+      ]
+    },
+    {
+      "shape_id": "multi_term_and",
+      "shape": "multi-term AND",
+      "description": "Exact BM25F conjunction over multiple query terms with deterministic ranking.",
+      "primary_issue": "#2837",
+      "required_rows": [
+        "TreeDB multi_term_and score-only 10k/100k/1M",
+        "SQLite FTS5/Lucene/Tantivy/Bleve explicit AND rows"
+      ],
+      "required_counters": [
+        "docs_fetched/search=0",
+        "full_doc_fallbacks/search=0",
+        "fail_closed/search=0",
+        "text_state_lookups/search=0",
+        "text_match_details/search=0",
+        "posting_blocks_visited/search",
+        "candidates_scored/search"
+      ]
+    },
+    {
+      "shape_id": "multi_term_or_wand",
+      "shape": "multi-term OR/WAND",
+      "description": "Exact BM25F disjunction with block-max/WAND pruning and deterministic ranking.",
+      "primary_issue": "#2836",
+      "required_rows": [
+        "TreeDB or_common/or_common_rare/or_high_frequency blockmax and exhaustive rows",
+        "Lucene/Tantivy/Bleve OR/WAND rows",
+        "SQLite FTS5 OR row if semantics are made explicit"
+      ],
+      "required_counters": [
+        "docs_fetched/search=0",
+        "full_doc_fallbacks/search=0",
+        "fail_closed/search=0",
+        "text_state_lookups/search=0",
+        "text_match_details/search=0",
+        "posting_blocks_visited/search",
+        "posting_blocks_skipped/search",
+        "threshold_updates/search",
+        "blockmax_fallbacks/search",
+        "candidates_scored/search"
+      ]
+    },
+    {
+      "shape_id": "phrase",
+      "shape": "phrase/proximity",
+      "description": "Bounded position-lane phrase/proximity query over StorePositions text-v2 indexes.",
+      "primary_issue": "#2839",
+      "required_rows": [
+        "TreeDB phrase exact/slop 10k/100k",
+        "Lucene/Tantivy/Bleve phrase/proximity rows with analyzer notes"
+      ],
+      "required_counters": [
+        "docs_fetched/search=0",
+        "full_doc_fallbacks/search=0",
+        "fail_closed/search=0",
+        "text_state_lookups/search=0",
+        "text_match_details/search=0",
+        "position_lookups/search",
+        "phrase_candidates_checked/search",
+        "phrase_candidates_matched/search"
+      ]
+    },
+    {
+      "shape_id": "hybrid_text_scalar",
+      "shape": "hybrid text+scalar",
+      "description": "BM25F candidate generation composed with indexed scalar filtering without full-document fetch.",
+      "primary_issue": "#2836",
+      "required_rows": [
+        "TreeDB text_scalar and hybrid_scalar no-doc rows at rare/broad selectivity",
+        "Lucene/Tantivy/Bleve equivalent filter rows or documented non-equivalence"
+      ],
+      "required_counters": [
+        "docs_fetched/search=0",
+        "full_doc_fallbacks/search=0",
+        "fail_closed/search=0",
+        "text_state_lookups/search=0",
+        "text_match_details/search=0",
+        "posting_blocks_visited/search",
+        "posting_blocks_skipped/search",
+        "threshold_updates/search",
+        "scalar_prefilter_ids/search",
+        "text_candidates/search"
+      ]
+    },
+    {
+      "shape_id": "index_build_ingest",
+      "shape": "index build/ingest",
+      "description": "Text-v2 CreateTextIndex backfill and maintained insert/update/delete throughput.",
+      "primary_issue": "#2835",
+      "required_rows": [
+        "TreeDB CreateTextIndex/backfill and InsertBatch text-v2 rows",
+        "SQLite FTS5/Lucene/Tantivy/Bleve build rows with WAL/checkpoint boundary"
+      ],
+      "required_counters": [
+        "rows/s",
+        "B/op",
+        "allocs/op",
+        "index_bytes/doc",
+        "posting_blocks/doc",
+        "write_amp_entries/doc"
+      ]
+    },
+    {
+      "shape_id": "index_size",
+      "shape": "index size",
+      "description": "Durable text index bytes/doc, separating primary payload, WAL, value-log, and text-v2 roots.",
+      "primary_issue": "#2835",
+      "required_rows": [
+        "TreeDB durable text-v2 bytes/doc after checkpoint and rewrite",
+        "SQLite FTS5/Lucene/Tantivy/Bleve index bytes/doc after equivalent optimize/vacuum"
+      ],
+      "required_counters": [
+        "storage_bytes",
+        "storage_bytes_per_doc",
+        "index_bytes/doc",
+        "value-log bytes",
+        "WAL excluded"
+      ]
+    },
+    {
+      "shape_id": "reopen",
+      "shape": "reopen/recovery",
+      "description": "Close/open and post-reopen text/hybrid probe latency with snapshot-bound roots.",
+      "primary_issue": "#2837",
+      "required_rows": [
+        "TreeDB scale harness reopen probe at 10k/1M/10M",
+        "External engine reopen/open-reader rows where embedded equivalents exist"
+      ],
+      "required_counters": [
+        "close_seconds",
+        "open_seconds",
+        "probe_seconds",
+        "docs_fetched/search=0",
+        "fail_closed/search=0"
+      ]
+    },
+    {
+      "shape_id": "maintenance_rewrite",
+      "shape": "maintenance/rewrite",
+      "description": "Bounded logical text-v2 rewrite plus normal TreeDB physical reclamation and post-rewrite search probes.",
+      "primary_issue": "#2840",
+      "required_rows": [
+        "TreeDB RewriteTextIndex/MaintainTextIndexes rows with stale-posting debt",
+        "External optimize/merge rows if used as a comparator"
+      ],
+      "required_counters": [
+        "stale_postings_purged/op",
+        "tombstones_purged/op",
+        "posting_blocks_read/op",
+        "posting_blocks_written/op",
+        "rewrite seconds",
+        "post-rewrite search ns/op"
+      ]
+    }
+  ],
+  "gap_classifications": [
+    {
+      "shape_id": "index_size",
+      "shape": "index size",
+      "classification": "near_parity",
+      "priority": 1,
+      "primary_issue": "#2835",
+      "treedb_evidence": "captured 1 row(s): treedb_common_10k/BenchmarkTextV2BlockMaxCommonTerm2628/blockmax_common_topk ns/op=1100000, storage=144 B/doc",
+      "external_evidence": "captured 1 row(s): sqlite_common_10k/sqlite_fts5/common_term_no_docs ns/op=1000000, storage=128 B/doc",
+      "rationale": "captured comparable storage rows: TreeDB 144 B/doc vs external 128 B/doc (ratio 1.12x)",
+      "required_follow_up_rows": [
+        "TreeDB durable text-v2 bytes/doc after checkpoint and rewrite",
+        "SQLite FTS5/Lucene/Tantivy/Bleve index bytes/doc after equivalent optimize/vacuum"
+      ],
+      "non_equivalent_semantics": [
+        "storage/build boundaries must state WAL inclusion, checkpoint/optimize/vacuum state, and retained primary-payload treatment"
+      ]
+    },
+    {
+      "shape_id": "single_term_common",
+      "shape": "single-term common",
+      "classification": "near_parity",
+      "priority": 2,
+      "primary_issue": "#2835",
+      "treedb_evidence": "captured 1 row(s): treedb_common_10k/BenchmarkTextV2BlockMaxCommonTerm2628/blockmax_common_topk ns/op=1100000, storage=144 B/doc",
+      "external_evidence": "captured 1 row(s): sqlite_common_10k/sqlite_fts5/common_term_no_docs ns/op=1000000, storage=128 B/doc",
+      "rationale": "captured comparable latency rows: TreeDB 1.1e+06 ns/op vs external 1e+06 ns/op (ratio 1.1x)",
+      "required_follow_up_rows": [
+        "TreeDB 10k and 100k blockmax_common_topk",
+        "SQLite FTS5/Lucene/Tantivy/Bleve common-term top-k rows"
+      ],
+      "non_equivalent_semantics": [
+        "TreeDB simple analyzer/BM25F weighting is not automatically equivalent to SQLite unicode61/porter, Bleve analyzers, Tantivy tokenizers, or Lucene analyzers",
+        "explicit AND/OR query semantics must be pinned before latency ratios are parity evidence"
+      ]
+    },
+    {
+      "shape_id": "multi_term_or_wand",
+      "shape": "multi-term OR/WAND",
+      "classification": "behind_but_tractable",
+      "priority": 3,
+      "primary_issue": "#2836",
+      "treedb_evidence": "#2812 landed exact multi-term OR/WAND block-max rows; current scoreboard run did not capture them",
+      "external_evidence": "no comparable external row captured; SQLite FTS5=not_captured; Bleve=unavailable (not run in unit test); Tantivy=unavailable (not run in unit test); Lucene=unavailable (not run in unit test)",
+      "rationale": "exact OR/WAND block-max landed in phase 1, but scalar-aware pruning and external OR/WAND rows are still required before parity claims",
+      "required_follow_up_rows": [
+        "TreeDB or_common/or_common_rare/or_high_frequency blockmax and exhaustive rows",
+        "Lucene/Tantivy/Bleve OR/WAND rows",
+        "SQLite FTS5 OR row if semantics are made explicit"
+      ],
+      "non_equivalent_semantics": [
+        "TreeDB simple analyzer/BM25F weighting is not automatically equivalent to SQLite unicode61/porter, Bleve analyzers, Tantivy tokenizers, or Lucene analyzers",
+        "explicit AND/OR query semantics must be pinned before latency ratios are parity evidence"
+      ]
+    },
+    {
+      "shape_id": "hybrid_text_scalar",
+      "shape": "hybrid text+scalar",
+      "classification": "behind_but_tractable",
+      "priority": 4,
+      "primary_issue": "#2836",
+      "treedb_evidence": "#2810 scoreboard includes zero-doc hybrid/scalar row support; rerun with scalar selectivity rows if absent",
+      "external_evidence": "no comparable external row captured; SQLite FTS5=not_captured; Bleve=unavailable (not run in unit test); Tantivy=unavailable (not run in unit test); Lucene=unavailable (not run in unit test)",
+      "rationale": "TreeDB has zero-document hybrid/scalar rows, but industry baselines are non-equivalent or unavailable and scalar-aware WAND counters need expansion",
+      "required_follow_up_rows": [
+        "TreeDB text_scalar and hybrid_scalar no-doc rows at rare/broad selectivity",
+        "Lucene/Tantivy/Bleve equivalent filter rows or documented non-equivalence"
+      ],
+      "non_equivalent_semantics": [
+        "SQLite FTS5 is not a hybrid text+scalar engine by itself",
+        "Lucene/Tantivy/Bleve filter semantics and whether filters are pre- or post-score must be documented"
+      ]
+    },
+    {
+      "shape_id": "index_build_ingest",
+      "shape": "index build/ingest",
+      "classification": "behind_but_tractable",
+      "priority": 5,
+      "primary_issue": "#2835",
+      "treedb_evidence": "#2810/#2813 harnesses include build/backfill/ingest rows; current scoreboard run did not capture a text-only equivalent",
+      "external_evidence": "no comparable external row captured; SQLite FTS5=not_captured; Bleve=unavailable (not run in unit test); Tantivy=unavailable (not run in unit test); Lucene=unavailable (not run in unit test)",
+      "rationale": "build and ingest rows exist but are not yet separated into text-only durable bytes/doc and external-equivalent build boundaries",
+      "required_follow_up_rows": [
+        "TreeDB CreateTextIndex/backfill and InsertBatch text-v2 rows",
+        "SQLite FTS5/Lucene/Tantivy/Bleve build rows with WAL/checkpoint boundary"
+      ],
+      "non_equivalent_semantics": [
+        "storage/build boundaries must state WAL inclusion, checkpoint/optimize/vacuum state, and retained primary-payload treatment"
+      ]
+    },
+    {
+      "shape_id": "phrase",
+      "shape": "phrase/proximity",
+      "classification": "behind_but_tractable",
+      "priority": 6,
+      "primary_issue": "#2839",
+      "treedb_evidence": "#2815 landed bounded phrase/proximity rows; current scoreboard run did not capture them",
+      "external_evidence": "no comparable external row captured; SQLite FTS5=not_captured; Bleve=unavailable (not run in unit test); Tantivy=unavailable (not run in unit test); Lucene=unavailable (not run in unit test)",
+      "rationale": "bounded phrase/proximity exists, but Lucene/Tantivy/Bleve phrase semantics and analyzer behavior are broader and unmeasured",
+      "required_follow_up_rows": [
+        "TreeDB phrase exact/slop 10k/100k",
+        "Lucene/Tantivy/Bleve phrase/proximity rows with analyzer notes"
+      ],
+      "non_equivalent_semantics": [
+        "TreeDB phrase/proximity is structured and bounded over StorePositions indexes; it is not a Lucene-compatible query DSL",
+        "slop, stopword position gaps, and unsupported stemming/synonym expansion must be recorded per row"
+      ]
+    },
+    {
+      "shape_id": "reopen",
+      "shape": "reopen/recovery",
+      "classification": "behind_but_tractable",
+      "priority": 7,
+      "primary_issue": "#2837",
+      "treedb_evidence": "#2813 scale harness includes reopen probes; current scoreboard run did not capture reopen rows",
+      "external_evidence": "no comparable external row captured; SQLite FTS5=not_captured; Bleve=unavailable (not run in unit test); Tantivy=unavailable (not run in unit test); Lucene=unavailable (not run in unit test)",
+      "rationale": "scale harness covers reopen, but phase-2 needs refreshed 1M/10M rows and external open-reader comparators where feasible",
+      "required_follow_up_rows": [
+        "TreeDB scale harness reopen probe at 10k/1M/10M",
+        "External engine reopen/open-reader rows where embedded equivalents exist"
+      ],
+      "non_equivalent_semantics": [
+        "storage/build boundaries must state WAL inclusion, checkpoint/optimize/vacuum state, and retained primary-payload treatment"
+      ]
+    },
+    {
+      "shape_id": "maintenance_rewrite",
+      "shape": "maintenance/rewrite",
+      "classification": "behind_but_tractable",
+      "priority": 8,
+      "primary_issue": "#2840",
+      "treedb_evidence": "#2814 maintenance policy and #2813 scale harness include rewrite/maintenance rows; current scoreboard run did not capture them",
+      "external_evidence": "no comparable external row captured; SQLite FTS5=not_captured; Bleve=unavailable (not run in unit test); Tantivy=unavailable (not run in unit test); Lucene=unavailable (not run in unit test)",
+      "rationale": "bounded rewrite/maintenance exists, but phase-2 needs debt, duration, and post-maintenance search rows at larger scale",
+      "required_follow_up_rows": [
+        "TreeDB RewriteTextIndex/MaintainTextIndexes rows with stale-posting debt",
+        "External optimize/merge rows if used as a comparator"
+      ],
+      "non_equivalent_semantics": [
+        "storage/build boundaries must state WAL inclusion, checkpoint/optimize/vacuum state, and retained primary-payload treatment"
+      ]
+    },
+    {
+      "shape_id": "multi_term_and",
+      "shape": "multi-term AND",
+      "classification": "behind_but_tractable",
+      "priority": 9,
+      "primary_issue": "#2837",
+      "treedb_evidence": "phase-1 text-v2 contract and scale harness define exact multi-term AND rows; current scoreboard run did not capture them",
+      "external_evidence": "no comparable external row captured; SQLite FTS5=not_captured; Bleve=unavailable (not run in unit test); Tantivy=unavailable (not run in unit test); Lucene=unavailable (not run in unit test)",
+      "rationale": "exact AND serving exists, but current scoreboard lacks external conjunction rows and scale refreshes",
+      "required_follow_up_rows": [
+        "TreeDB multi_term_and score-only 10k/100k/1M",
+        "SQLite FTS5/Lucene/Tantivy/Bleve explicit AND rows"
+      ],
+      "non_equivalent_semantics": [
+        "TreeDB simple analyzer/BM25F weighting is not automatically equivalent to SQLite unicode61/porter, Bleve analyzers, Tantivy tokenizers, or Lucene analyzers",
+        "explicit AND/OR query semantics must be pinned before latency ratios are parity evidence"
+      ]
+    },
+    {
+      "shape_id": "single_term_rare",
+      "shape": "single-term rare",
+      "classification": "behind_but_tractable",
+      "priority": 10,
+      "primary_issue": "#2835",
+      "treedb_evidence": "scale harness defines rare-term score-only rows; current scoreboard run did not capture them",
+      "external_evidence": "no comparable external row captured; SQLite FTS5=not_captured; Bleve=unavailable (not run in unit test); Tantivy=unavailable (not run in unit test); Lucene=unavailable (not run in unit test)",
+      "rationale": "rare-term serving should be tractable, but phase-2 needs explicit rows because setup/decode overhead can dominate",
+      "required_follow_up_rows": [
+        "TreeDB rare term score-only 10k/100k/1M",
+        "SQLite FTS5/Lucene/Tantivy/Bleve rare-term top-k rows"
+      ],
+      "non_equivalent_semantics": [
+        "TreeDB simple analyzer/BM25F weighting is not automatically equivalent to SQLite unicode61/porter, Bleve analyzers, Tantivy tokenizers, or Lucene analyzers",
+        "explicit AND/OR query semantics must be pinned before latency ratios are parity evidence"
+      ]
+    }
+  ],
+  "priority_order": [
+    {
+      "priority": 1,
+      "shape_id": "index_size",
+      "primary_issue": "#2835",
+      "rationale": "captured comparable storage rows: TreeDB 144 B/doc vs external 128 B/doc (ratio 1.12x)",
+      "required_follow_up_rows": [
+        "TreeDB durable text-v2 bytes/doc after checkpoint and rewrite",
+        "SQLite FTS5/Lucene/Tantivy/Bleve index bytes/doc after equivalent optimize/vacuum"
+      ]
+    },
+    {
+      "priority": 2,
+      "shape_id": "single_term_common",
+      "primary_issue": "#2835",
+      "rationale": "captured comparable latency rows: TreeDB 1.1e+06 ns/op vs external 1e+06 ns/op (ratio 1.1x)",
+      "required_follow_up_rows": [
+        "TreeDB 10k and 100k blockmax_common_topk",
+        "SQLite FTS5/Lucene/Tantivy/Bleve common-term top-k rows"
+      ]
+    },
+    {
+      "priority": 3,
+      "shape_id": "multi_term_or_wand",
+      "primary_issue": "#2836",
+      "rationale": "exact OR/WAND block-max landed in phase 1, but scalar-aware pruning and external OR/WAND rows are still required before parity claims",
+      "required_follow_up_rows": [
+        "TreeDB or_common/or_common_rare/or_high_frequency blockmax and exhaustive rows",
+        "Lucene/Tantivy/Bleve OR/WAND rows",
+        "SQLite FTS5 OR row if semantics are made explicit"
+      ]
+    },
+    {
+      "priority": 4,
+      "shape_id": "hybrid_text_scalar",
+      "primary_issue": "#2836",
+      "rationale": "TreeDB has zero-document hybrid/scalar rows, but industry baselines are non-equivalent or unavailable and scalar-aware WAND counters need expansion",
+      "required_follow_up_rows": [
+        "TreeDB text_scalar and hybrid_scalar no-doc rows at rare/broad selectivity",
+        "Lucene/Tantivy/Bleve equivalent filter rows or documented non-equivalence"
+      ]
+    },
+    {
+      "priority": 5,
+      "shape_id": "index_build_ingest",
+      "primary_issue": "#2835",
+      "rationale": "build and ingest rows exist but are not yet separated into text-only durable bytes/doc and external-equivalent build boundaries",
+      "required_follow_up_rows": [
+        "TreeDB CreateTextIndex/backfill and InsertBatch text-v2 rows",
+        "SQLite FTS5/Lucene/Tantivy/Bleve build rows with WAL/checkpoint boundary"
+      ]
+    },
+    {
+      "priority": 6,
+      "shape_id": "phrase",
+      "primary_issue": "#2839",
+      "rationale": "bounded phrase/proximity exists, but Lucene/Tantivy/Bleve phrase semantics and analyzer behavior are broader and unmeasured",
+      "required_follow_up_rows": [
+        "TreeDB phrase exact/slop 10k/100k",
+        "Lucene/Tantivy/Bleve phrase/proximity rows with analyzer notes"
+      ]
+    },
+    {
+      "priority": 7,
+      "shape_id": "reopen",
+      "primary_issue": "#2837",
+      "rationale": "scale harness covers reopen, but phase-2 needs refreshed 1M/10M rows and external open-reader comparators where feasible",
+      "required_follow_up_rows": [
+        "TreeDB scale harness reopen probe at 10k/1M/10M",
+        "External engine reopen/open-reader rows where embedded equivalents exist"
+      ]
+    },
+    {
+      "priority": 8,
+      "shape_id": "maintenance_rewrite",
+      "primary_issue": "#2840",
+      "rationale": "bounded rewrite/maintenance exists, but phase-2 needs debt, duration, and post-maintenance search rows at larger scale",
+      "required_follow_up_rows": [
+        "TreeDB RewriteTextIndex/MaintainTextIndexes rows with stale-posting debt",
+        "External optimize/merge rows if used as a comparator"
+      ]
+    },
+    {
+      "priority": 9,
+      "shape_id": "multi_term_and",
+      "primary_issue": "#2837",
+      "rationale": "exact AND serving exists, but current scoreboard lacks external conjunction rows and scale refreshes",
+      "required_follow_up_rows": [
+        "TreeDB multi_term_and score-only 10k/100k/1M",
+        "SQLite FTS5/Lucene/Tantivy/Bleve explicit AND rows"
+      ]
+    },
+    {
+      "priority": 10,
+      "shape_id": "single_term_rare",
+      "primary_issue": "#2835",
+      "rationale": "rare-term serving should be tractable, but phase-2 needs explicit rows because setup/decode overhead can dominate",
+      "required_follow_up_rows": [
+        "TreeDB rare term score-only 10k/100k/1M",
+        "SQLite FTS5/Lucene/Tantivy/Bleve rare-term top-k rows"
+      ]
+    }
+  ],
+  "analyzer_semantics_notes": [
+    "Do not compare TreeDB BM25F rows with external BM25/BM25F rows unless analyzer, field weights, top-k, query operator, and final-document fetch boundaries are pinned.",
+    "SQLite FTS5 default rows are useful embedded baselines, but they are not Lucene/Tantivy/Bleve analyzer or query-parser parity.",
+    "Phrase/proximity rows must record StorePositions, slop, stopword behavior, and unsupported stemming/synonym states; unsupported states must fail closed.",
+    "Candidate-generation rows must keep full-document fetch counters at zero; final-fetch rows belong in separate tables."
+  ]
+}

--- a/docs/benchmarks/treedb_text_hybrid_industry_scoreboard.md
+++ b/docs/benchmarks/treedb_text_hybrid_industry_scoreboard.md
@@ -1,10 +1,11 @@
-# TreeDB text-v2/hybrid industry comparison scoreboard (#2727)
+# TreeDB text-v2/hybrid industry comparison scoreboard (#2727/#2834)
 
 This runbook is the stable #2727 scoreboard contract for downstream text-v2 and
-hybrid optimization issues. It measures TreeDB text-only, vector-only,
-text+vector, and text+vector+scalar retrieval rows against local external
-baselines where practical. It is a benchmark/report harness, not an optimization
-or industry-parity claim.
+hybrid optimization issues. #2834 layers the phase-2 gap-classification
+synthesis on the same artifacts. The harness measures TreeDB text-only,
+vector-only, text+vector, and text+vector+scalar retrieval rows against local
+external baselines where practical. It is a benchmark/report harness, not an
+optimization or industry-parity claim.
 
 ## Stable commands and artifacts
 
@@ -17,8 +18,10 @@ RUN_DIR=/tmp/gomap_text_hybrid_scoreboard_$(date +%Y%m%d_%H%M%S) \
 
 Primary outputs:
 
-- `$RUN_DIR/scoreboard.md`
-- `$RUN_DIR/scoreboard.json`
+- `$RUN_DIR/scoreboard.md` with retrieval rows, zero-doc validation, and the
+  phase-2 gap classification table
+- `$RUN_DIR/scoreboard.json` with schema `treedb_text_hybrid_scoreboard/v1` and
+  nested `phase2_synthesis` schema `treedb_text_v2_phase2_gap_synthesis/v1`
 - `$RUN_DIR/context.txt`
 - raw TreeDB Go benchmark logs under `$RUN_DIR/treedb_*.txt`
 - optional external JSON artifacts such as `$RUN_DIR/sqlite_fts5_10k.json`
@@ -174,14 +177,27 @@ Candidate-generation rows must keep full document fetches at zero. Final-fetch
 rows must keep document fetches bounded by top-K and should stay separate from
 candidate rows.
 
+## Phase-2 synthesis readout
+
+The durable #2834 baseline readout is published at
+`docs/benchmarks/treedb_text_v2_phase2_gap_classification.md`. It classifies the
+current evidence by target shape (`single_term_common`, `single_term_rare`,
+`multi_term_and`, `multi_term_or_wand`, `phrase`, `hybrid_text_scalar`,
+`index_build_ingest`, `index_size`, `reopen`, and `maintenance_rewrite`) using
+`ahead`, `near_parity`, `behind_but_tractable`, and `far_behind` vocabulary.
+`ahead` and `near_parity` require comparable external evidence; unavailable or
+non-equivalent external rows remain explicit gaps rather than parity claims.
+
 ## Downstream contract surface
 
-Downstream issues #2728, #2729, #2731, and #2734 can cite:
+Downstream issues #2728, #2729, #2731, #2734, and phase-2 issues #2835-#2840 can cite:
 
 - `scripts/bench_text_hybrid_scoreboard.sh` as the stable capture entry point;
 - `cmd/treedb_text_hybrid_scoreboard` as the parser/report generator;
-- `scoreboard.json` schema `treedb_text_hybrid_scoreboard/v1`;
-- `scoreboard.md` retrieval and zero-doc counter validation tables.
+- `scoreboard.json` schema `treedb_text_hybrid_scoreboard/v1` and nested
+  `phase2_synthesis` schema `treedb_text_v2_phase2_gap_synthesis/v1`;
+- `scoreboard.md` retrieval, phase-2 gap classification, and zero-doc counter
+  validation tables.
 
 Avoid changing these names or table meanings without updating this runbook and
 the parser/report tests.

--- a/docs/benchmarks/treedb_text_v2_phase2_gap_classification.md
+++ b/docs/benchmarks/treedb_text_v2_phase2_gap_classification.md
@@ -1,0 +1,122 @@
+# TreeDB text-v2 phase-2 scoreboard synthesis (#2834)
+
+This is the phase-2 baseline readout for parent #2833. It synthesizes the
+completed #2810/#2809 scoreboard and hardening evidence into a durable target
+taxonomy for TreeDB collection text-v2 work. It does **not** claim industry
+parity unless a comparable external row is present with pinned corpus, analyzer,
+query semantics, storage boundary, and zero-document candidate counters.
+
+## Source artifacts and commands
+
+Primary #2810 scoreboard source:
+
+- artifact root: `/tmp/gomap_2727_scoreboard_candidate_20260613_090425`
+- report: `/tmp/gomap_2727_scoreboard_candidate_20260613_090425/scoreboard.md`
+- JSON: `/tmp/gomap_2727_scoreboard_candidate_20260613_090425/scoreboard.json`
+- command:
+
+```sh
+RUN_DIR=/tmp/gomap_2727_scoreboard_candidate_20260613_090425 \
+BENCHTIME=1x COUNT=1 RUN_100K=true TEXT_100K_BENCHTIME=1x TEXT_100K_COUNT=1 \
+SQLITE_FTS5_QUERIES=1000 \
+scripts/bench_text_hybrid_scoreboard.sh
+```
+
+Phase-1 follow-up evidence roots from #2809/#2808 closeout:
+
+| Area | Issue / PR | Source artifact root |
+| --- | --- | --- |
+| scoreboard foundation | #2810 / PR #2735 | `/tmp/gomap_2727_scoreboard_candidate_20260613_090425` |
+| posting allocation and rewrite follow-up | #2811 / PR #2738 | `/tmp/gomap_2728_finalizer_bench_20260613_125335`, `/tmp/gomap_2728_rewrite_rerun_20260613_125509` |
+| exact multi-term OR/WAND | #2812 / PR #2739 | `/tmp/gomap_2730_candidate_bench_10k_latest_20260613_145109.log`, `/tmp/gomap_2730_candidate_bench_100k_latest_20260613_145115.log` |
+| 1M scale harness | #2813 / PR #2740 | `/tmp/gomap_2731_final_20260613_160144`, `/tmp/gomap_2731_scale_1m_candidate65536_20260613_160325/scale_report.md` |
+| bounded phrase/analyzer rows | #2815 / PR #2741 | `/tmp/gomap_2733_validation_20260613_154526`, `/tmp/gomap_2733_bench_final_20260613_154513` |
+| maintenance policy | #2814 / PR #2742 | `/tmp/gomap_2732_validation_20260613_164404/benchmark_summary.md` |
+| hardening | #2808 | merged hardening tests; no benchmark run required because the PR was test-only |
+
+Current capture entry points remain:
+
+```sh
+RUN_DIR=/tmp/gomap_text_hybrid_scoreboard_$(date +%Y%m%d_%H%M%S) \
+  scripts/bench_text_hybrid_scoreboard.sh
+
+RUN_DIR=/tmp/gomap_text_hybrid_scale_smoke_$(date +%Y%m%d_%H%M%S) \
+SMOKE_ROWS=128 SMOKE_QUERIES=3 SMOKE_BATCH_SIZE=64 \
+DIMS=4 M=4 EF_CONSTRUCTION=32 EF_SEARCH=32 READERS=2 \
+  scripts/bench_text_hybrid_scale.sh
+```
+
+The scoreboard parser now emits `phase2_synthesis` in `scoreboard.json` with
+schema `treedb_text_v2_phase2_gap_synthesis/v1`, plus a matching Markdown
+section in `scoreboard.md`.
+
+## Classification vocabulary
+
+| Class | Meaning |
+| --- | --- |
+| `ahead` | TreeDB has comparable external evidence and is materially better on the stated boundary. |
+| `near_parity` | TreeDB has comparable external evidence and is in the same practical band. |
+| `behind_but_tractable` | TreeDB has a feature or harness path, but still lacks comparable rows, scale refresh, counters, or a bounded optimization. |
+| `far_behind` | A parity claim is blocked by a major evidence/coverage gap or missing durable metric. This is not an unmeasured latency ratio. |
+
+As of this baseline, no shape is classified `ahead` or `near_parity` for
+industry parity because Lucene, Tantivy, and Bleve rows are unavailable and the
+SQLite FTS5 row is only an embedded text baseline with non-equivalent analyzer
+and query semantics.
+
+## External baseline coverage
+
+| Baseline | Current status | Notes |
+| --- | --- | --- |
+| SQLite FTS5 | available in #2810 smoke | Useful embedded rowid + `bm25()` baseline. Not a Lucene/Tantivy/Bleve semantics match and not a hybrid engine by itself. |
+| Bleve | unavailable / not captured | Requires a pinned Go harness with the same synthetic corpus, analyzer, explicit query operators, top-k, and result-order checks. |
+| Tantivy | unavailable / not captured | Requires a pinned Rust harness with the same corpus, analyzer/tokenizer, query operators, top-k, build/storage boundary, and result-order checks. |
+| Lucene | unavailable / not captured | Requires pinned Lucene/JMH or OpenSearch evidence with identical corpus/query contract before any Lucene parity claim. |
+
+## Phase-2 gap classification table
+
+| Priority | Target ID | Shape | Classification | Current TreeDB evidence | External evidence | Required follow-up rows |
+| ---: | --- | --- | --- | --- | --- | --- |
+| 1 | `index_size` | index size | `far_behind` | Text-v2 storage exists in B-tree-native roots and persistent value-log values, but #2810 does not publish durable text-v2 bytes/doc with WAL excluded. | SQLite FTS5 storage exists; Lucene/Tantivy/Bleve unavailable. | TreeDB durable text-v2 bytes/doc after checkpoint and rewrite; external index bytes/doc after equivalent optimize/vacuum; separate primary payload, WAL, value-log, and text roots. |
+| 2 | `single_term_common` | single-term common | `behind_but_tractable` | #2810/#2809 include exact block-max common-term rows with zero document fetch. | No comparable Lucene/Tantivy/Bleve common-term row; SQLite row is not enough for parity. | 10k/100k/1M TreeDB `blockmax_common_topk`; matching SQLite/Lucene/Tantivy/Bleve common-term top-k with analyzer notes. |
+| 3 | `multi_term_or_wand` | multi-term OR/WAND | `behind_but_tractable` | #2812 landed exact OR/WAND block-max evidence. | External OR/WAND rows unavailable. | TreeDB `or_common`, `or_common_rare`, and `or_high_frequency` blockmax/exhaustive rows; Lucene/Tantivy/Bleve explicit OR rows; scalar-aware pruning counters for #2836. |
+| 4 | `hybrid_text_scalar` | hybrid text+scalar | `behind_but_tractable` | #2810 has zero-document hybrid/scalar rows and scalar-prefilter counters. | SQLite FTS5 is not a hybrid text+scalar comparator; Lucene/Tantivy/Bleve filter semantics not captured. | Rare and broad scalar selectivity rows with `scalar_prefilter_ids/search`, `text_candidates/search`, block skip counters, and explain output once #2838 lands. |
+| 5 | `index_build_ingest` | index build/ingest | `behind_but_tractable` | Build/backfill/write rows exist across #2810/#2813, but text-only ingest and bytes/doc are not yet the scoreboard headline. | SQLite FTS5 build seconds exist; Lucene/Tantivy/Bleve build rows unavailable. | Text-v2 CreateTextIndex/backfill, InsertBatch, update/delete, write amp, and external build rows with checkpoint/optimize boundary. |
+| 6 | `phrase` | phrase/proximity | `behind_but_tractable` | #2815 landed bounded structured phrase/proximity over `StorePositions=true`. | Lucene/Tantivy/Bleve phrase/proximity rows unavailable and have broader query/analyzer semantics. | Exact phrase and slop rows at 10k/100k with position counters; Lucene/Tantivy/Bleve phrase rows with stopword/slop notes. |
+| 7 | `reopen` | reopen/recovery | `behind_but_tractable` | #2813 scale harness includes close/open/probe rows. | External open-reader/reopen rows unavailable. | 10k/1M/10M close/open/probe rows, post-reopen zero-doc search, and external open-reader rows where feasible. |
+| 8 | `maintenance_rewrite` | maintenance/rewrite | `behind_but_tractable` | #2814 landed bounded logical rewrite/maintenance through normal TreeDB maintenance. | External optimize/merge comparators unavailable. | Rewrite debt, duration, stale posting purge, post-rewrite search, and physical reclamation rows at scale. |
+| 9 | `multi_term_and` | multi-term AND | `behind_but_tractable` | Exact AND serving exists and is in the scale harness target set. | No external explicit AND rows captured. | TreeDB AND score-only rows at 10k/100k/1M plus matching SQLite/Lucene/Tantivy/Bleve explicit AND rows. |
+| 10 | `single_term_rare` | single-term rare | `behind_but_tractable` | Rare-term rows are defined by the scale harness, but not represented in the #2810 headline table. | No external rare-term rows captured. | Rare-term 10k/100k/1M rows with allocation/decode counters and matching external rare-term rows. |
+
+## Recommended phase-2 order
+
+1. **#2835 footprint first**: publish `index_size` and build/ingest bytes/doc
+   rows, then compress posting/index footprint without weakening exact BM25F.
+2. **#2835 common-term hot path**: use the same rows to reduce allocations,
+   cache churn, and high-document-frequency block overhead.
+3. **#2836 OR/WAND + scalar pruning**: extend exact block-max evidence with
+   scalar-aware pruning counters and broad/rare scalar selectivity rows.
+4. **#2838 explain/observability**: make every gap row explainable, including
+   terms, blocks visited/skipped, scalar pruning, fail-closed reasons, and score
+   components.
+5. **#2837 scale refresh**: refresh 1M/10M, reopen, maintenance, and tail rows
+   after footprint/scalar-pruning changes land.
+6. **#2839 analyzer/relevance expansion**: keep phrase/analyzer features
+   bounded and fail-closed; add quality labels only after the benchmark semantics
+   are pinned.
+7. **#2840 hardening**: close with fuzz/crash/race coverage over the expanded
+   phase-2 feature set.
+
+## Non-equivalent analyzer/query semantics notes
+
+- TreeDB text-v2 uses persisted collection analyzer options and BM25F field
+  weights; external rows must document analyzer/tokenizer, field weights, query
+  operator, top-k, and tie ordering.
+- SQLite FTS5 `MATCH 'refund policy'` plus `bm25()` is not automatically the
+  same as TreeDB default BM25F OR, explicit AND, or phrase semantics.
+- Lucene/Tantivy/Bleve phrase, slop, stemming, synonyms, stopwords, and query DSL
+  support are broader than TreeDB's bounded structured phrase/proximity API.
+- Candidate-generation rows must keep full-document fetch counters at zero.
+  Rows that fetch final documents are valid only as separate final-fetch rows.
+- Storage rows must say whether WAL is excluded and whether optimize/vacuum,
+  checkpoint, TreeDB value-log rewrite, and normal storage compaction have run.


### PR DESCRIPTION
## Summary

Closes #2834.

Adds the phase-2 TreeDB text-v2 gap synthesis on top of the existing #2727/#2810 text/hybrid scoreboard harness:

- emits a nested `phase2_synthesis` JSON object with schema `treedb_text_v2_phase2_gap_synthesis/v1`;
- renders a matching `## Phase-2 gap classification` section in `scoreboard.md`;
- publishes `docs/benchmarks/treedb_text_v2_phase2_gap_classification.md` as the durable #2833 baseline readout;
- documents external baseline availability/non-equivalence for SQLite FTS5, Bleve, Tantivy, and Lucene;
- classifies phase-2 target shapes (`single_term_common`, `single_term_rare`, `multi_term_and`, `multi_term_or_wand`, `phrase`, `hybrid_text_scalar`, `index_build_ingest`, `index_size`, `reopen`, `maintenance_rewrite`) with priority and follow-up benchmark rows.

## Scope / non-goals

- No TreeDB query/storage hot-path changes.
- No parity claim without comparable external rows; missing/non-equivalent baselines remain explicit evidence gaps.
- No on-disk format changes.

## Tests

- `GOWORK=off go test ./cmd/treedb_text_hybrid_scoreboard`

## Benchmarks / performance

Not applicable: this PR changes the scoreboard parser/report synthesis and docs only. It does not touch TreeDB runtime hot paths.

## AI review status

Not requested yet. This PR has coherent code/docs and focused tests; coordinator may request Codex/Copilot/CodeRabbit review after latest-head CI starts/runs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Phase-2 gap classification synthesis to the text/hybrid industry scoreboard reports, providing structured analysis of benchmark performance gaps across external baselines.
  * New "Phase-2 gap classification" section now appears in scoreboard outputs (both JSON and Markdown formats).

* **Documentation**
  * Added documentation on Phase-2 gap classification vocabulary and methodology.
  * Updated scoreboard runbook with Phase-2 synthesis layer details.

* **Tests**
  * Added comprehensive test coverage for Phase-2 synthesis generation and artifact validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->