### PR TITLE
TreeDB M5 reduce repeated leaf-log decode cost

### DIFF
--- a/TreeDB/db/leaf_page_read_cache.go
+++ b/TreeDB/db/leaf_page_read_cache.go
@@ -981,12 +981,21 @@ func (db *DB) disableLeafPageReadCacheForMaintenance() func() {
 }
 
 func (r *cachedLeafPageReader) ReadUnsafe(ptr page.ValuePtr) ([]byte, error) {
-	if key, err := page.LeafLogPtrFromValuePtr(ptr); err == nil {
+	var key page.LeafLogPtr
+	var keyOK bool
+	if k, err := page.LeafLogPtrFromValuePtr(ptr); err == nil {
+		key = k
+		keyOK = true
 		if data, ok := r.cache.get(key); ok {
 			return data, nil
 		}
 	}
-	return r.fallback.ReadUnsafe(ptr)
+	data, err := r.fallback.ReadUnsafe(ptr)
+	if err != nil {
+		return nil, err
+	}
+	r.storeReadMiss(key, keyOK, data)
+	return data, nil
 }
 
 func (r *cachedLeafPageReader) ReadUnsafeTo(ptr page.ValuePtr, dst []byte) ([]byte, bool, error) {
@@ -995,7 +1004,11 @@ func (r *cachedLeafPageReader) ReadUnsafeTo(ptr page.ValuePtr, dst []byte) ([]by
 }
 
 func (r *cachedLeafPageReader) ReadUnsafeToWithCacheHit(ptr page.ValuePtr, dst []byte) ([]byte, bool, bool, error) {
-	if key, err := page.LeafLogPtrFromValuePtr(ptr); err == nil {
+	var key page.LeafLogPtr
+	var keyOK bool
+	if k, err := page.LeafLogPtrFromValuePtr(ptr); err == nil {
+		key = k
+		keyOK = true
 		if data, usedDst, ok := r.cache.getTo(key, dst); ok {
 			return data, usedDst, true, nil
 		}
@@ -1007,13 +1020,26 @@ func (r *cachedLeafPageReader) ReadUnsafeToWithCacheHit(ptr page.ValuePtr, dst [
 		if err != nil {
 			return nil, false, false, err
 		}
+		r.storeReadMiss(key, keyOK, data)
 		return data, usedDst, false, nil
 	}
 	data, err := r.fallback.ReadUnsafe(ptr)
 	if err != nil {
 		return nil, false, false, err
 	}
+	r.storeReadMiss(key, keyOK, data)
 	return data, false, false, nil
+}
+
+func (r *cachedLeafPageReader) storeReadMiss(key page.LeafLogPtr, keyOK bool, leafPage []byte) {
+	if r == nil || r.cache == nil || !keyOK || len(leafPage) != page.PageSize {
+		return
+	}
+	recordChecksumVerified := false
+	if cap, ok := r.fallback.(readChecksumCapability); ok {
+		recordChecksumVerified = cap.ReadChecksumEnabled()
+	}
+	r.cache.storeReadMiss(key, leafPage, recordChecksumVerified)
 }
 
 func cloneLeafPageReadCacheData(data []byte) []byte {

--- a/TreeDB/db/leaf_page_read_cache_test.go
+++ b/TreeDB/db/leaf_page_read_cache_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pierrec/lz4/v4"
 	"github.com/snissn/gomap/TreeDB/page"
 )
 
@@ -338,6 +339,67 @@ func TestCachedLeafPageReaderReadMissAdmissionUnknownChecksumStaysUnverified(t *
 	}
 	if cache.markPageChecksumVerified(ptr) {
 		t.Fatal("unknown-checksum read-miss admission should not accept page checksum mark")
+	}
+}
+
+var cachedLeafPageReaderLZ4BenchSink byte
+
+type leafPageCacheLZ4BenchFallback struct {
+	encoded []byte
+	calls   int
+}
+
+func (f *leafPageCacheLZ4BenchFallback) ReadUnsafe(ptr page.ValuePtr) ([]byte, error) {
+	f.calls++
+	out := make([]byte, page.PageSize)
+	if _, err := lz4.UncompressBlock(f.encoded, out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (f *leafPageCacheLZ4BenchFallback) ReadUnsafeTo(ptr page.ValuePtr, dst []byte) ([]byte, bool, error) {
+	f.calls++
+	if cap(dst) < page.PageSize {
+		dst = make([]byte, page.PageSize)
+	} else {
+		dst = dst[:page.PageSize]
+	}
+	n, err := lz4.UncompressBlock(f.encoded, dst)
+	if err != nil {
+		return nil, false, err
+	}
+	return dst[:n], true, nil
+}
+
+func (f *leafPageCacheLZ4BenchFallback) ReadChecksumEnabled() bool { return true }
+
+func BenchmarkCachedLeafPageReaderRepeatedLZ4ReadMissAdmission(b *testing.B) {
+	leaf := bytes.Repeat([]byte("leaf-page|"), (page.PageSize/10)+1)
+	leaf = leaf[:page.PageSize]
+	encoded := make([]byte, lz4.CompressBlockBound(len(leaf)))
+	n, err := lz4.CompressBlock(leaf, encoded, nil)
+	if err != nil || n <= 0 {
+		b.Fatalf("compress: n=%d err=%v", n, err)
+	}
+	fallback := &leafPageCacheLZ4BenchFallback{encoded: encoded[:n]}
+	cache := newLeafPageReadCache(64)
+	reader := newCachedLeafPageReader(cache, fallback)
+	ptr := page.LeafLogPtr{FileID: 7, Offset: 128, RecordLengthHint: uint32(n)}
+	dst := make([]byte, 0, page.PageSize)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		got, _, _, err := reader.ReadUnsafeToWithCacheHit(ptr.ValuePtr(), dst[:0])
+		if err != nil {
+			b.Fatalf("read: %v", err)
+		}
+		cachedLeafPageReaderLZ4BenchSink ^= got[0]
+	}
+	b.StopTimer()
+	if b.N > 0 {
+		b.ReportMetric(float64(fallback.calls)/float64(b.N), "fallback_calls/op")
 	}
 }
 

--- a/TreeDB/db/leaf_page_read_cache_test.go
+++ b/TreeDB/db/leaf_page_read_cache_test.go
@@ -16,6 +16,7 @@ type leafPageCacheTestFallback struct {
 	readUnsafeToCalls int
 	err               error
 	data              []byte
+	checksumEnabled   bool
 }
 
 func (f *leafPageCacheTestFallback) Read(ptr page.ValuePtr) ([]byte, error) {
@@ -44,6 +45,10 @@ func (f *leafPageCacheTestFallback) ReadUnsafeTo(ptr page.ValuePtr, dst []byte) 
 		return dst, true, nil
 	}
 	return f.data, false, nil
+}
+
+func (f *leafPageCacheTestFallback) ReadChecksumEnabled() bool {
+	return f.checksumEnabled
 }
 
 type leafPageCacheUnsafeOnlyFallback struct {
@@ -265,6 +270,74 @@ func TestCachedLeafPageReaderMissReportsNoCacheHit(t *testing.T) {
 	}
 	if stats := cache.stats(); stats.Misses != 1 || stats.Stores != 0 || stats.Hits != 0 {
 		t.Fatalf("stats=%+v, want one miss and no store", stats)
+	}
+}
+
+func TestCachedLeafPageReaderReadMissAdmissionStoresRepeatedMiss(t *testing.T) {
+	cache := newLeafPageReadCache(8)
+	ptr := page.LeafLogPtr{FileID: 7, Offset: 128, RecordLengthHint: 4096}
+	leaf := bytes.Repeat([]byte{0x24}, page.PageSize)
+	fallback := &leafPageCacheTestFallback{data: leaf, checksumEnabled: true}
+	reader := newCachedLeafPageReader(cache, fallback)
+
+	dst := make([]byte, 0, page.PageSize)
+	for i := 0; i < 2; i++ {
+		got, usedDst, cacheHit, err := reader.ReadUnsafeToWithCacheHit(ptr.ValuePtr(), dst[:0])
+		if err != nil {
+			t.Fatalf("ReadUnsafeToWithCacheHit miss %d: %v", i, err)
+		}
+		if cacheHit {
+			t.Fatalf("miss %d cacheHit=true, want false before admission is served", i)
+		}
+		if !usedDst || !bytes.Equal(got, leaf) {
+			t.Fatalf("miss %d got usedDst=%v equal=%v", i, usedDst, bytes.Equal(got, leaf))
+		}
+	}
+	if fallback.readUnsafeToCalls != 2 {
+		t.Fatalf("fallback ReadUnsafeTo calls=%d, want 2", fallback.readUnsafeToCalls)
+	}
+	stats := cache.stats()
+	if stats.Misses != 2 || stats.ReadMissAdmissionSkips != 1 || stats.ReadMissAdmissionStores != 1 || stats.Stores != 1 {
+		t.Fatalf("stats after repeated miss=%+v, want one skipped candidate and one store", stats)
+	}
+
+	got, usedDst, cacheHit, err := reader.ReadUnsafeToWithCacheHit(ptr.ValuePtr(), dst[:0])
+	if err != nil {
+		t.Fatalf("ReadUnsafeToWithCacheHit hit: %v", err)
+	}
+	if !cacheHit || !usedDst || !bytes.Equal(got, leaf) {
+		t.Fatalf("cache hit got cacheHit=%v usedDst=%v equal=%v", cacheHit, usedDst, bytes.Equal(got, leaf))
+	}
+	if fallback.readUnsafeToCalls != 2 {
+		t.Fatalf("fallback calls after cache hit=%d, want 2", fallback.readUnsafeToCalls)
+	}
+
+	_, _, state, ok := cache.getToWithState(ptr, dst[:0])
+	if !ok || !state.RecordChecksumVerified || state.PageChecksumVerified {
+		t.Fatalf("checksum state=%+v ok=%v, want record verified only", state, ok)
+	}
+	if !cache.markPageChecksumVerified(ptr) {
+		t.Fatal("record-verified read-miss admission should accept page checksum mark")
+	}
+}
+
+func TestCachedLeafPageReaderReadMissAdmissionUnknownChecksumStaysUnverified(t *testing.T) {
+	cache := newLeafPageReadCache(8)
+	ptr := page.LeafLogPtr{FileID: 7, Offset: 128, RecordLengthHint: 4096}
+	leaf := bytes.Repeat([]byte{0x24}, page.PageSize)
+	fallback := &leafPageCacheUnsafeOnlyFallback{data: leaf}
+	reader := newCachedLeafPageReader(cache, fallback)
+
+	for i := 0; i < 2; i++ {
+		if _, _, err := reader.ReadUnsafeTo(ptr.ValuePtr(), make([]byte, 0, page.PageSize)); err != nil {
+			t.Fatalf("ReadUnsafeTo miss %d: %v", i, err)
+		}
+	}
+	if stats := cache.stats(); stats.ReadMissAdmissionStores != 1 {
+		t.Fatalf("stats=%+v, want one read-miss admission store", stats)
+	}
+	if cache.markPageChecksumVerified(ptr) {
+		t.Fatal("unknown-checksum read-miss admission should not accept page checksum mark")
 	}
 }
 

--- a/TreeDB/db/zipper_outerleaf_compressed_bench_test.go
+++ b/TreeDB/db/zipper_outerleaf_compressed_bench_test.go
@@ -105,6 +105,7 @@ func BenchmarkZipperApplyOuterLeafCompressedRandomOverwrite(b *testing.B) {
 	defer updateBatch.Close()
 
 	var leafMerges, leafLogLoads, leafLogWrites, leafBytesRead, leafBytesWritten int64
+	var leafRecordBytesRead, leafRecordBytesWritten, leafCacheHits, leafReaderCalls, leafScratchReads, leafViewReads int64
 	b.ReportAllocs()
 	b.SetBytes(int64(batchSize * (8 + valueSize)))
 	b.ResetTimer()
@@ -118,6 +119,12 @@ func BenchmarkZipperApplyOuterLeafCompressedRandomOverwrite(b *testing.B) {
 		leafLogWrites += int64(metrics.ZipperLeafLogPagesWritten)
 		leafBytesRead += int64(metrics.ZipperLeafLogNodeBytesRead)
 		leafBytesWritten += int64(metrics.ZipperLeafLogPageBytesWritten)
+		leafRecordBytesRead += int64(metrics.ZipperLeafLogRecordHintBytesRead)
+		leafRecordBytesWritten += int64(metrics.ZipperLeafLogRecordHintBytesWritten)
+		leafCacheHits += int64(metrics.ZipperLeafLogCacheHits)
+		leafReaderCalls += int64(metrics.ZipperLeafLogReaderCalls)
+		leafScratchReads += int64(metrics.ZipperLeafLogScratchReads)
+		leafViewReads += int64(metrics.ZipperLeafLogViewReads)
 	}
 	b.StopTimer()
 
@@ -129,5 +136,11 @@ func BenchmarkZipperApplyOuterLeafCompressedRandomOverwrite(b *testing.B) {
 		b.ReportMetric(float64(leafLogWrites)/n, "leaflog_writes/op")
 		b.ReportMetric(float64(leafBytesRead)/n, "leaflog_read_B/op")
 		b.ReportMetric(float64(leafBytesWritten)/n, "leaflog_write_B/op")
+		b.ReportMetric(float64(leafRecordBytesRead)/n, "leaflog_record_read_B/op")
+		b.ReportMetric(float64(leafRecordBytesWritten)/n, "leaflog_record_write_B/op")
+		b.ReportMetric(float64(leafCacheHits)/n, "leaflog_cache_hits/op")
+		b.ReportMetric(float64(leafReaderCalls)/n, "leaflog_reader_calls/op")
+		b.ReportMetric(float64(leafScratchReads)/n, "leaflog_scratch_reads/op")
+		b.ReportMetric(float64(leafViewReads)/n, "leaflog_view_reads/op")
 	}
 }

--- a/TreeDB/internal/valuelog/block_codec.go
+++ b/TreeDB/internal/valuelog/block_codec.go
@@ -60,7 +60,27 @@ func putBlockZstdEncoder(enc *zstd.Encoder) {
 	blockZstdEncoderPool.Put(enc)
 }
 
+// blockCodecScratch holds per-writer/preparer codec state. It is intentionally
+// caller-owned and not safe for concurrent use.
+type blockCodecScratch struct {
+	lz4Compressor *lz4.Compressor
+}
+
+func (s *blockCodecScratch) lz4() *lz4.Compressor {
+	if s == nil {
+		return nil
+	}
+	if s.lz4Compressor == nil {
+		s.lz4Compressor = &lz4.Compressor{}
+	}
+	return s.lz4Compressor
+}
+
 func encodeBlockPayload(codec BlockCodec, raw []byte, dst []byte) ([]byte, error) {
+	return encodeBlockPayloadWithScratch(codec, raw, dst, nil)
+}
+
+func encodeBlockPayloadWithScratch(codec BlockCodec, raw []byte, dst []byte, scratch *blockCodecScratch) ([]byte, error) {
 	if len(raw) == 0 {
 		if dst == nil {
 			return nil, nil
@@ -86,7 +106,15 @@ func encodeBlockPayload(codec BlockCodec, raw []byte, dst []byte) ([]byte, error
 			dst = make([]byte, bound)
 		}
 		dst = dst[:bound]
-		n, err := lz4.CompressBlock(raw, dst, nil)
+		var (
+			n   int
+			err error
+		)
+		if scratch != nil {
+			n, err = scratch.lz4().CompressBlock(raw, dst)
+		} else {
+			n, err = lz4.CompressBlock(raw, dst, nil)
+		}
 		if err != nil {
 			return nil, err
 		}

--- a/TreeDB/internal/valuelog/frame_preparer.go
+++ b/TreeDB/internal/valuelog/frame_preparer.go
@@ -14,10 +14,11 @@ import (
 //
 // It is not safe for concurrent use.
 type FramePreparer struct {
-	rawScratch   []byte
-	encScratch   []byte
-	blockScratch []byte
-	encLimiter   limitedSliceWriter
+	rawScratch        []byte
+	encScratch        []byte
+	blockScratch      []byte
+	blockCodecScratch blockCodecScratch
+	encLimiter        limitedSliceWriter
 
 	skipDictID uint64
 	codecs     *dictCodecEntry
@@ -388,7 +389,7 @@ func (p *FramePreparer) prepareBlockFrameBody(dst []byte, records []Record, offs
 		}
 	}
 	encodeStart := p.sampleEncodeStart()
-	encoded, encodeErr := encodeBlockPayload(p.blockCodec, payload, p.blockScratch[:0])
+	encoded, encodeErr := encodeBlockPayloadWithScratch(p.blockCodec, payload, p.blockScratch[:0], &p.blockCodecScratch)
 	encodeNs := p.sampleEncodeEnd(encodeStart, rawPayloadBytes, len(records))
 	if encoded != nil {
 		p.blockScratch = encoded[:0]

--- a/TreeDB/internal/valuelog/valuelog_test.go
+++ b/TreeDB/internal/valuelog/valuelog_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	"github.com/golang/snappy"
+	"github.com/pierrec/lz4/v4"
 	"github.com/snissn/compress/zstd"
 	"github.com/snissn/gomap/TreeDB/internal/crc"
 	"github.com/snissn/gomap/TreeDB/page"
@@ -2341,6 +2342,31 @@ func TestValueLogBlockCodecSnappy_ReusesProvidedBuffer(t *testing.T) {
 	}
 	if &out[0] != &dst[0] {
 		t.Fatalf("expected encode to reuse provided destination buffer")
+	}
+}
+
+func TestValueLogBlockCodecLZ4_ReusesWorkerLocalCompressorScratch(t *testing.T) {
+	var scratch blockCodecScratch
+	dst := make([]byte, lz4.CompressBlockBound(4096))
+	for i, fill := range []byte{'a', 'b'} {
+		raw := bytes.Repeat([]byte{fill}, 4096)
+		out, err := encodeBlockPayloadWithScratch(BlockCodecLZ4, raw, dst[:0], &scratch)
+		if err != nil {
+			t.Fatalf("encode %d: %v", i, err)
+		}
+		if len(out) == 0 {
+			t.Fatalf("encode %d returned empty output", i)
+		}
+		decoded, err := decodeBlockPayload(uint8(BlockCodecLZ4), out, uint32(len(raw)), nil)
+		if err != nil {
+			t.Fatalf("decode %d: %v", i, err)
+		}
+		if !bytes.Equal(decoded, raw) {
+			t.Fatalf("decode %d mismatch", i)
+		}
+	}
+	if scratch.lz4Compressor == nil {
+		t.Fatal("expected worker-local lz4 compressor scratch to be initialized")
 	}
 }
 

--- a/TreeDB/internal/valuelog/writer.go
+++ b/TreeDB/internal/valuelog/writer.go
@@ -74,6 +74,7 @@ type Writer struct {
 	encScratch             []byte
 	encLimiter             limitedSliceWriter
 	blockScratch           []byte
+	blockCodecScratch      blockCodecScratch
 	skipDictID             uint64
 	codecs                 *dictCodecEntry
 	dictFrameEncodeLevel   zstd.EncoderLevel
@@ -1929,7 +1930,7 @@ func (w *Writer) appendBlockFrameWithStats(records []Record, rawPayloadBytes int
 	}
 
 	encodeStart := w.sampleEncodeStart()
-	encoded, encodeErr := encodeBlockPayload(w.blockCodec, payload, w.blockScratch[:0])
+	encoded, encodeErr := encodeBlockPayloadWithScratch(w.blockCodec, payload, w.blockScratch[:0], &w.blockCodecScratch)
 	encodeNs := w.sampleEncodeEnd(encodeStart, rawPayloadBytes, k)
 	if encoded != nil {
 		w.blockScratch = encoded[:0]


### PR DESCRIPTION
## Objective

Reduce TreeDB M5 old-leaf decode/recompress overhead on the flush/apply path without changing the leaf-log/value-log on-disk format.

Closes #2830. Part of #2819.

## Context / base

- Depends on #2825 / #2846. That predecessor is now merged into `main`.
- This branch is rebased on `origin/main` after #2846 (`944b949f1`).

## What changed

- Reuses the existing two-miss `leafPageReadCache.storeReadMiss` admission policy from the zipper/apply cached leaf-page reader path.
  - First miss records a candidate.
  - Repeated miss for the same leaf-log pointer admits the decoded page.
  - Subsequent reads avoid the value-log fallback decode path.
  - Checksum state is preserved when the fallback implements `ReadChecksumEnabled`; unknown checksum state stays unverified and cannot be marked page-checksum-verified.
- Adds per-writer/per-frame-preparer LZ4 `Compressor` scratch for value-log block frame encode, avoiding global compressor-pool churn on LZ4 leaf-log/block writes.
- Extends the compressed outer-leaf apply benchmark with cache-path and record-length metrics:
  - `leaflog_record_read_B/op`
  - `leaflog_record_write_B/op`
  - `leaflog_cache_hits/op`
  - `leaflog_reader_calls/op`
  - `leaflog_scratch_reads/op`
  - `leaflog_view_reads/op`

## Explicit non-changes

- No on-disk format change.
- No leaf-log grouping K/default codec/capacity change.
- No checksum weakening; cache entries from unknown/unverified fallback state remain unverified.
- No delta/overlay leaf format was added. Broader full-leaf rewrite avoidance remains out of scope for this PR.

## Correctness / tests

Latest-head local validation:

```sh
GOWORK=off go test ./TreeDB/internal/valuelog ./TreeDB/db ./TreeDB/caching ./TreeDB/zipper -count=1
GOWORK=off go test -race ./TreeDB/db -run 'TestCachedLeafPageReaderReadMissAdmission|TestLeafPageReadCacheChecksum' -count=1
```

Broader validation also run after rebasing onto #2825/main:

```sh
GOWORK=off go test ./TreeDB/... -count=1
```

## Benchmarks / evidence

### Repeated read-miss LZ4 decode guardrail

Benchmark command:

```sh
GOWORK=off go test ./TreeDB/db -run '^$' -bench '^BenchmarkCachedLeafPageReaderRepeatedLZ4ReadMissAdmission$' -benchmem -count=10
```

Base was `44d4c7d5e` with the same benchmark harness temporarily applied; head is this PR.

| benchmark | base | head | result |
| --- | ---: | ---: | --- |
| repeated LZ4 read-miss ns/op | 1.630µs ±1% | 47.86ns ±14% | -97.06%, p=0.000 n=10 |
| fallback calls/op | 1.000 | ~0.0000001 | effectively eliminated after admission |
| B/op | 0 | 0 | unchanged |
| allocs/op | 0 | 0 | unchanged |

### Cache-disabled outer-leaf apply guardrail

Benchmark command:

```sh
GOWORK=off go test ./TreeDB/db -run '^$' -bench '^BenchmarkZipperApplyOuterLeafCompressedRandomOverwrite$' -benchmem -count=10
```

Fair rerun against base `44d4c7d5e` vs this patch showed no material cache-disabled regression:

| metric | base | head | result |
| --- | ---: | ---: | --- |
| ns/op | 8.014ms ±2% | 7.939ms ±4% | ~, p=0.971 n=10 |
| B/op | 177.1KiB ±2% | 174.1KiB ±2% | ~, p=0.063 n=10 |
| allocs/op | 104.5 | 104.0 | ~, p=0.141 n=10 |
| old leaf page bytes/op | 9.257MB | 9.257MB | unchanged |

Head-only added benchmark counters on that guardrail shape:

| counter | value |
| --- | ---: |
| `leaflog_record_read_B/op` | ~4.918MB/op |
| `leaflog_record_write_B/op` | ~959.5KB/op |
| `leaflog_cache_hits/op` | 0 |
| `leaflog_reader_calls/op` | 2,260 |
| `leaflog_scratch_reads/op` | 2,260 |
| `leaflog_view_reads/op` | 0 |

## Follow-ups / rejected alternatives

- Did not change live leaf-log grouped-frame K in this PR. Local K=4/K=1 trials reduced potential frame decode amplification but worsened or did not improve random-overwrite apply time, so this PR keeps K policy unchanged.
- Did not add a new delta/overlay leaf-log format; that would be a broader persistence/design change requiring separate reopen/corruption coverage.

## Status

- Not merged by this agent.
- CI and external/AI review status should be evaluated on this PR head before merge.
