### PR TITLE
TreeDB M6 reduce append-only latest-index allocation growth

### DIFF
--- a/TreeDB/internal/memtable/append_only.go
+++ b/TreeDB/internal/memtable/append_only.go
@@ -24,24 +24,29 @@ const (
 	appendOnlyInlineKeyLen                  = 8
 	// Pool size-class boundaries. Min/Max initial entries are derived from
 	// these shifts so the three constants can't drift out of sync.
-	appendOnlyEntryPoolMinShift         = 7
-	appendOnlyEntryPoolMaxShift         = 20
-	appendOnlyEntryPoolClassCount       = appendOnlyEntryPoolMaxShift - appendOnlyEntryPoolMinShift + 1
-	appendOnlyEntryPoolMaxCap           = 1 << appendOnlyEntryPoolMaxShift // 1 << 20
-	appendOnlyMinInitialEntries         = 1 << appendOnlyEntryPoolMinShift // 128
-	appendOnlyMaxInitialEntries         = 1 << appendOnlyEntryPoolMaxShift // 1 << 20
-	appendOnlyIteratorPoolMaxCap        = 1 << 20
-	appendOnlyIteratorPtrPoolMaxCap     = 1 << 20
-	appendOnlyReusableKeyMaxCap         = 1 << 10
-	appendOnlyKeyArenaDefaultChunk      = 2 << 10
-	appendOnlyValueArenaMinShift        = 12
-	appendOnlyValueArenaMaxShift        = 20
-	appendOnlyValueArenaClassCount      = appendOnlyValueArenaMaxShift - appendOnlyValueArenaMinShift + 1
-	appendOnlyValueArenaDefaultChunk    = 32 << 10
-	appendOnlyValueArenaPoolMaxCap      = 1 << appendOnlyValueArenaMaxShift
-	appendOnlyValueArenaRetainMaxCap    = 4 << 20
-	appendOnlyValueArenaRetainChunks    = 128
-	appendOnlySortedRunMaxCount         = 256
+	appendOnlyEntryPoolMinShift      = 7
+	appendOnlyEntryPoolMaxShift      = 20
+	appendOnlyEntryPoolClassCount    = appendOnlyEntryPoolMaxShift - appendOnlyEntryPoolMinShift + 1
+	appendOnlyEntryPoolMaxCap        = 1 << appendOnlyEntryPoolMaxShift // 1 << 20
+	appendOnlyMinInitialEntries      = 1 << appendOnlyEntryPoolMinShift // 128
+	appendOnlyMaxInitialEntries      = 1 << appendOnlyEntryPoolMaxShift // 1 << 20
+	appendOnlyIteratorPoolMaxCap     = 1 << 20
+	appendOnlyIteratorPtrPoolMaxCap  = 1 << 20
+	appendOnlyReusableKeyMaxCap      = 1 << 10
+	appendOnlyKeyArenaDefaultChunk   = 2 << 10
+	appendOnlyValueArenaMinShift     = 12
+	appendOnlyValueArenaMaxShift     = 20
+	appendOnlyValueArenaClassCount   = appendOnlyValueArenaMaxShift - appendOnlyValueArenaMinShift + 1
+	appendOnlyValueArenaDefaultChunk = 32 << 10
+	appendOnlyValueArenaPoolMaxCap   = 1 << appendOnlyValueArenaMaxShift
+	appendOnlyValueArenaRetainMaxCap = 4 << 20
+	appendOnlyValueArenaRetainChunks = 128
+	appendOnlySortedRunMaxCount      = 256
+	// When random writes break append-only ordering, the table falls back to a
+	// latest-key map. Pre-size that map from the table's steady-state entry hint
+	// (bounded above) so hot random-write ingestion does not repeatedly grow maps
+	// from tiny capacity after the sorted-run fast path is exhausted.
+	appendOnlyLatestIndexMaxReserve     = 8 << 10
 	appendOnlyReuseOversizeFactor       = 4
 	appendOnlyResetDropThresholdEntries = 1 << 15
 	appendOnlyAggressiveGrowCutoff      = appendOnlyResetDropThresholdEntries * 2
@@ -875,6 +880,23 @@ func (m *AppendOnly) buildSortedLatestIndicesLocked() []int {
 	return indices
 }
 
+func (m *AppendOnly) latestIndexReserveHintLocked(need int) int {
+	if need < 0 {
+		need = 0
+	}
+	reserve := need
+	if need > appendOnlySortedRunMaxCount && m.baseEntriesLen > reserve {
+		reserve = m.baseEntriesLen
+	}
+	if reserve > appendOnlyLatestIndexMaxReserve {
+		reserve = appendOnlyLatestIndexMaxReserve
+	}
+	if reserve < need {
+		reserve = need
+	}
+	return reserve
+}
+
 func (m *AppendOnly) rebuildLatestIndexLocked() {
 	m.clearSortedRunsLocked()
 	if m.count == 0 {
@@ -894,7 +916,7 @@ func (m *AppendOnly) rebuildLatestIndexLocked() {
 	if m.latest64 != nil {
 		clear(m.latest64)
 	}
-	reserve := m.count
+	reserve := m.latestIndexReserveHintLocked(m.count)
 	active := m.entries[:m.count]
 	for i := range active {
 		k := appendOnlyEntryKey(&active[i])
@@ -920,13 +942,13 @@ func (m *AppendOnly) updateLatestIndexLocked(key []byte, idx int) {
 	}
 	if k64, ok := appendOnlyKeyU64(key); ok {
 		if m.latest64 == nil {
-			m.latest64 = make(map[uint64]int, 1)
+			m.latest64 = make(map[uint64]int, m.latestIndexReserveHintLocked(idx+1))
 		}
 		m.latest64[k64] = idx
 		return
 	}
 	if m.latest == nil {
-		m.latest = make(map[string]int, 1)
+		m.latest = make(map[string]int, m.latestIndexReserveHintLocked(idx+1))
 	}
 	m.latest[appendOnlyKeyString(key)] = idx
 }

--- a/TreeDB/internal/memtable/append_only.go
+++ b/TreeDB/internal/memtable/append_only.go
@@ -889,10 +889,7 @@ func (m *AppendOnly) latestIndexReserveHintLocked(need int) int {
 		reserve = m.baseEntriesLen
 	}
 	if reserve > appendOnlyLatestIndexMaxReserve {
-		reserve = appendOnlyLatestIndexMaxReserve
-	}
-	if reserve < need {
-		reserve = need
+		return appendOnlyLatestIndexMaxReserve
 	}
 	return reserve
 }

--- a/TreeDB/internal/memtable/append_only_pool_test.go
+++ b/TreeDB/internal/memtable/append_only_pool_test.go
@@ -658,6 +658,13 @@ func TestAppendOnlyLatestIndexFallbackLatestWinsAndOwnsBytes(t *testing.T) {
 	}
 
 	m.Reset()
+	m.mu.RLock()
+	latestLen := len(m.latest)
+	latest64Len := len(m.latest64)
+	m.mu.RUnlock()
+	if latestLen != 0 || latest64Len != 0 {
+		t.Fatalf("reset leaked latest-index entries: latest=%d latest64=%d", latestLen, latest64Len)
+	}
 	if got, _, ok := m.Get(target[:]); ok {
 		t.Fatalf("reset leaked old latest-index entry with value %q", got)
 	}

--- a/TreeDB/internal/memtable/append_only_pool_test.go
+++ b/TreeDB/internal/memtable/append_only_pool_test.go
@@ -624,11 +624,31 @@ func TestAppendOnlyLatestIndexReserveHintBounds(t *testing.T) {
 		large.mu.Unlock()
 		t.Fatalf("large reserve hint=%d want capped %d", got, appendOnlyLatestIndexMaxReserve)
 	}
-	if got, need := large.latestIndexReserveHintLocked(appendOnlyLatestIndexMaxReserve+123), appendOnlyLatestIndexMaxReserve+123; got != need {
+	if got := large.latestIndexReserveHintLocked(appendOnlyLatestIndexMaxReserve + 123); got != appendOnlyLatestIndexMaxReserve {
 		large.mu.Unlock()
-		t.Fatalf("reserve hint below need: got=%d need=%d", got, need)
+		t.Fatalf("reserve hint above cap: got=%d want %d", got, appendOnlyLatestIndexMaxReserve)
 	}
 	large.mu.Unlock()
+}
+
+func TestAppendOnlyLateMixedKeyLatestIndexReserveStaysCapped(t *testing.T) {
+	m := NewAppendOnlyWithEntryCapacity(appendOnlyLatestIndexMaxReserve * 4)
+	var key [appendOnlyInlineKeyLen]byte
+	for i := 0; i < appendOnlyLatestIndexMaxReserve+appendOnlySortedRunMaxCount; i++ {
+		binary.BigEndian.PutUint64(key[:], uint64(1_000_000+i))
+		m.Set(key[:], []byte{1})
+	}
+	m.mu.Lock()
+	if got := m.latestIndexReserveHintLocked(m.count + 1); got != appendOnlyLatestIndexMaxReserve {
+		m.mu.Unlock()
+		t.Fatalf("late mixed-key reserve hint=%d want capped %d", got, appendOnlyLatestIndexMaxReserve)
+	}
+	m.mu.Unlock()
+
+	m.Set([]byte("variable-width-key"), []byte("value"))
+	if got, _, ok := m.Get([]byte("variable-width-key")); !ok || string(got) != "value" {
+		t.Fatalf("late mixed-key lookup=(%q, ok=%t), want value", got, ok)
+	}
 }
 
 func TestAppendOnlyLatestIndexFallbackLatestWinsAndOwnsBytes(t *testing.T) {

--- a/TreeDB/internal/memtable/append_only_pool_test.go
+++ b/TreeDB/internal/memtable/append_only_pool_test.go
@@ -1,6 +1,7 @@
 package memtable
 
 import (
+	"encoding/binary"
 	"sync"
 	"testing"
 	"time"
@@ -605,5 +606,59 @@ func TestBuildSortedLatestIndicesLockedRetainsGrownIndexBuf(t *testing.T) {
 	retained := m.indexBuf[:len(indices)]
 	if &retained[0] != &indices[0] {
 		t.Fatal("indexBuf does not retain grown indices backing array")
+	}
+}
+
+func TestAppendOnlyLatestIndexReserveHintBounds(t *testing.T) {
+	small := NewAppendOnlyWithEntryCapacity(16)
+	small.mu.Lock()
+	if got := small.latestIndexReserveHintLocked(2); got != 2 {
+		small.mu.Unlock()
+		t.Fatalf("small reserve hint=%d want exact need 2", got)
+	}
+	small.mu.Unlock()
+
+	large := NewAppendOnlyWithEntryCapacity(appendOnlyLatestIndexMaxReserve * 4)
+	large.mu.Lock()
+	if got := large.latestIndexReserveHintLocked(appendOnlySortedRunMaxCount + 1); got != appendOnlyLatestIndexMaxReserve {
+		large.mu.Unlock()
+		t.Fatalf("large reserve hint=%d want capped %d", got, appendOnlyLatestIndexMaxReserve)
+	}
+	if got, need := large.latestIndexReserveHintLocked(appendOnlyLatestIndexMaxReserve+123), appendOnlyLatestIndexMaxReserve+123; got != need {
+		large.mu.Unlock()
+		t.Fatalf("reserve hint below need: got=%d need=%d", got, need)
+	}
+	large.mu.Unlock()
+}
+
+func TestAppendOnlyLatestIndexFallbackLatestWinsAndOwnsBytes(t *testing.T) {
+	m := NewAppendOnlyWithEntryCapacity(appendOnlyLatestIndexMaxReserve * 2)
+	var key [appendOnlyInlineKeyLen]byte
+	for i := 0; i < appendOnlySortedRunMaxCount+8; i++ {
+		binary.BigEndian.PutUint64(key[:], uint64(10_000-i))
+		value := []byte{byte(i)}
+		m.Set(key[:], value)
+		key[0] = 0xff
+		value[0] = 0xee
+	}
+
+	var target [appendOnlyInlineKeyLen]byte
+	binary.BigEndian.PutUint64(target[:], 42)
+	first := []byte("first-value")
+	m.Set(target[:], first)
+	first[0] = 'X'
+	second := []byte("second-value")
+	m.Set(target[:], second)
+	second[0] = 'Y'
+
+	m.Freeze()
+	got, deleted, ok := m.Get(target[:])
+	if !ok || deleted || string(got) != "second-value" {
+		t.Fatalf("Get target=(%q, deleted=%t, ok=%t), want second-value", got, deleted, ok)
+	}
+
+	m.Reset()
+	if got, _, ok := m.Get(target[:]); ok {
+		t.Fatalf("reset leaked old latest-index entry with value %q", got)
 	}
 }


### PR DESCRIPTION
## Objective

Reduce TreeDB random-write allocation pressure in the append-only memtable ingestion path by avoiding repeated latest-index map growth after random writes exhaust the sorted-run fast path.

Closes #2831. Part of #2819.

## Context

The #2825/#2819 allocation profiles showed random_write spending sampled allocation space in `memtable.(*AppendOnly).updateLatestIndexLocked` / `rebuildLatestIndexLocked`. This PR keeps the change local to M6 write ingestion and does not alter flush worker coarsening, decode/recompress, leaf-log output, publish/checkpoint architecture, or storage formats.

## Non-goals

- No worker coarsening or task-shape changes (#2826).
- No old-leaf decode/recompress changes (#2830).
- No leaf-log output sharding (#2827), publish/checkpoint work (#2828/#2829), or adaptive policy changes (#2832).
- No on-disk format, value-log/leaf-log, WAL, reopen, GC, or durability semantic changes.

## Design

- Add a bounded `AppendOnly.latestIndexReserveHintLocked` helper.
- When unordered append-only writes fall back from sorted runs to latest-key maps, initialize `latest` / `latest64` with the table's entry-capacity hint, capped at 8K entries.
- Small tables keep exact/small map hints; the larger reserve is only used once the unordered path has exceeded `appendOnlySortedRunMaxCount`.
- Existing reset/release paths still clear or drop latest-index maps; no published immutable state is made mutable.

## Scope

- Includes:
  - `TreeDB/internal/memtable/append_only.go`
  - `TreeDB/internal/memtable/append_only_pool_test.go`
- Excludes:
  - backend flush/apply scheduling and span coarsening
  - value-log / leaf-log formats and lifecycle
  - checkpoint publish/drain behavior

## Correctness

Tests run (exact commands):

```sh
GOWORK=off go test ./TreeDB/internal/memtable -run 'TestAppendOnlyLatestIndex|TestBuildSortedLatestIndicesLockedRetainsGrownIndexBuf' -count=1
GOWORK=off go test ./TreeDB/internal/memtable -count=1
GOWORK=off go test -race ./TreeDB/internal/memtable -run 'TestAppendOnlyLatestIndex|TestBuildSortedLatestIndicesLockedRetainsGrownIndexBuf|TestAppendOnlyReset' -count=1
GOWORK=off go test ./TreeDB/internal/memtable ./TreeDB/caching ./TreeDB/db ./TreeDB/zipper -count=1
```

Added coverage:

- latest-index reserve bounds for small and large append-only tables;
- latest-wins correctness after sorted-run fallback;
- key/value ownership after caller buffer mutation;
- reset does not leak old latest-index entries.

Persistence/reopen tests are not specifically required because this PR changes only in-memory memtable map sizing and no leaf-generation bookkeeping or on-disk state.

## Performance

### Allocation profile

Commands:

```sh
# base: origin/main at 944b949f1f350b8c933277471a7f81c58adf8fd5
OUT=<local-profile-root>/2831_baseline_profile_20260618_164517
./bin/unified-bench -dbs treedb -test sequential_write,batch_random,random_write \
  -keys 200000 -valsize 128 -batchsize 8000 -checkpoint-between-tests \
  -progress=false -profile-dir "$OUT" -format markdown

go tool pprof -top -nodecount=20 "$OUT/allocs_random_write_treedb.pprof"

# head: pi/2831-m6
OUT=<local-profile-root>/2831_final_profile_20260618_165917
./bin/unified-bench -dbs treedb -test sequential_write,batch_random,random_write \
  -keys 200000 -valsize 128 -batchsize 8000 -checkpoint-between-tests \
  -progress=false -profile-dir "$OUT" -format markdown

go tool pprof -top -nodecount=20 "$OUT/allocs_random_write_treedb.pprof"
```

Sampled `random_write` allocation profile:

| Metric | Base | Head | Result |
| --- | ---: | ---: | ---: |
| total sampled alloc_space | 20,593.59 KiB | 10,160.30 KiB | -50.7% |
| append-only latest-index alloc_space | 11,463.15 KiB | 3,647.37 KiB | -68.2% |
| append-only latest-index alloc_objects | 635 | 202 | -68.2% |

Profile-enabled throughput is intentionally not used as the throughput gate because writing pprof artifacts perturbs these short local runs.

### Throughput/checkpoint smoke

No-profile paired local smoke, same host/shape, 2 runs each:

```sh
./bin/unified-bench -dbs treedb -test sequential_write,batch_random,random_write \
  -keys 1000000 -valsize 128 -batchsize 8000 -checkpoint-between-tests \
  -progress=false -format markdown
```

Mean results:

| Metric | Base | Head | Result |
| --- | ---: | ---: | ---: |
| sequential_write ops/s | 2,248,512 | 2,219,731 | -1.3% |
| batch_random ops/s | 2,477,002 | 2,369,105 | -4.4% |
| random_write ops/s | 1,902,301 | 1,862,620 | -2.1% |
| checkpoint before batch_random | 309.6 ms | 306.9 ms | -0.9% |
| checkpoint before random_write | 941.3 ms | 925.6 ms | -1.7% |
| post-run checkpoint | 1.39 s | 1.355 s | -2.5% |

Focused append-only memtable microbench:

```sh
# base worktree and head worktree
GOWORK=off go test ./TreeDB/internal/memtable -run '^$' \
  -bench 'BenchmarkMemtableSetParallel_ModeCompare/append_only' -benchmem -count=5
benchstat /tmp/2831_base_memtable_bench.txt /tmp/2831_head_memtable_bench.txt
```

`benchstat` showed no significant `ns/op` change; geomean `sec/op` +1.76%, `B/op` -1.48%, `allocs/op` unchanged at zero.

## Rollout / Toggle Plan

- Default setting: always active for append-only memtables, capped at 8K entries.
- Fast rollback: revert this commit; no data migration or on-disk cleanup required.

## Follow-ups

- Remaining M6/M7 allocation sources include value-log compression/profile overhead and flush/apply scratch paths; those are left to their scoped issues/follow-ups.

### AI Review Loop

- Codex latest-head review: not requested yet; wait for PR CI to start/settle per tracker guidance.
- Copilot latest-head review: not requested yet.
- CodeRabbit latest-head review: auto-started by repository integration on PR creation; not manually requested.
- Review comments/threads resolved or explicitly dismissed: none yet.
- Re-requested after final meaningful push: not applicable.
