### PR TITLE
collections: compress text-v2 position footprint

### DIFF
--- a/TreeDB/collections/text_backfill.go
+++ b/TreeDB/collections/text_backfill.go
@@ -37,6 +37,14 @@ type TextIndexBackfillStats struct {
 	V2StatusRecords   int
 	V2NextOrdinal     uint64
 	V2RootGeneration  uint64
+
+	V2DocIDBytes        uint64
+	V2DocMapBytes       uint64
+	V2PostingBlockBytes uint64
+	V2NormBlockBytes    uint64
+	V2PositionBytes     uint64
+	V2TermStatsBytes    uint64
+	V2StatusFormatBytes uint64
 }
 
 // TextIndexStorageStats reports durable text-root contents after validation.
@@ -65,6 +73,14 @@ type TextIndexStorageStats struct {
 	V2DeltaPostingBlocks  uint64
 	V2MicroPostingBlocks  uint64
 	V2RewriteMergeState   string
+
+	V2DocIDBytes        uint64
+	V2DocMapBytes       uint64
+	V2PostingBlockBytes uint64
+	V2NormBlockBytes    uint64
+	V2PositionBytes     uint64
+	V2TermStatsBytes    uint64
+	V2StatusFormatBytes uint64
 }
 
 type createTextIndexBackfillPlan struct {
@@ -323,8 +339,10 @@ func buildCreateTextV2IndexBackfillPlan(
 			Fields:          fieldNames,
 		})
 		tables[rootName].SetSteal(key, value)
+		bytesWritten := uint64(len(key) + len(value))
 		plan.stats.V2FormatRecords++
-		plan.stats.EncodedBytes += uint64(len(key) + len(value))
+		plan.stats.EncodedBytes += bytesWritten
+		plan.stats.V2StatusFormatBytes += bytesWritten
 	}
 
 	docIDRootName := collectionTextV2DocIDRootName(catalog.meta.Name, def.Name)
@@ -376,8 +394,10 @@ func buildCreateTextV2IndexBackfillPlan(
 				docIDKey := encodeTextV2DocIDKey(documentID)
 				docIDValue := encodeTextV2DocIDValue(textV2DocIDValue{Ordinal: ordinal, Generation: generation})
 				tables[docIDRootName].SetSteal(docIDKey, docIDValue)
+				docIDBytes := uint64(len(docIDKey) + len(docIDValue))
 				plan.stats.V2DocIDEntries++
-				plan.stats.EncodedBytes += uint64(len(docIDKey) + len(docIDValue))
+				plan.stats.EncodedBytes += docIDBytes
+				plan.stats.V2DocIDBytes += docIDBytes
 
 				docBlockStart := textV2OrdinalBlockStart(ordinal, textV2DefaultDocMapBlockSize)
 				docBlock := docMapBlocks[docBlockStart]
@@ -407,6 +427,7 @@ func buildCreateTextV2IndexBackfillPlan(
 				}
 				plan.stats.V2PositionEntries += positionEntries
 				plan.stats.EncodedBytes += positionBytes
+				plan.stats.V2PositionBytes += positionBytes
 				acc.addDocument(analysis)
 				plan.stats.DocumentsScanned++
 				it.Next()
@@ -422,15 +443,19 @@ func buildCreateTextV2IndexBackfillPlan(
 		key := encodeTextV2BlockKey(blockStart)
 		value := encodeTextV2DocMapBlockValue(*docMapBlocks[blockStart])
 		tables[docMapRootName].SetSteal(key, value)
+		docMapBytes := uint64(len(key) + len(value))
 		plan.stats.V2DocMapBlocks++
-		plan.stats.EncodedBytes += uint64(len(key) + len(value))
+		plan.stats.EncodedBytes += docMapBytes
+		plan.stats.V2DocMapBytes += docMapBytes
 	}
 	for _, blockStart := range sortedTextV2BlockStarts(normBlocks) {
 		key := encodeTextV2BlockKey(blockStart)
 		value := encodeTextV2NormBlockValue(*normBlocks[blockStart])
 		tables[normRootName].SetSteal(key, value)
+		normBytes := uint64(len(key) + len(value))
 		plan.stats.V2NormBlocks++
-		plan.stats.EncodedBytes += uint64(len(key) + len(value))
+		plan.stats.EncodedBytes += normBytes
+		plan.stats.V2NormBlockBytes += normBytes
 	}
 
 	postingBlocks, postingBytes, postingBlockCounts, err := buildTextV2PostingBatchTable(tables[postingBlocksRootName], &postingBuilder, textV2PostingBlockKindSealed, textV2PostingBlockTargetPostings, 1)
@@ -440,11 +465,13 @@ func buildCreateTextV2IndexBackfillPlan(
 	}
 	plan.stats.V2PostingBlocks = postingBlocks
 	plan.stats.EncodedBytes += postingBytes
+	plan.stats.V2PostingBlockBytes += postingBytes
 
 	statsEntries, statsBytes := addTextV2StatsEntries(tables[termsRootName], acc, def, 1, postingBlockCounts)
 	plan.stats.V2TermStats = statsEntries
 	plan.stats.StatsEntries = statsEntries
 	plan.stats.EncodedBytes += statsBytes
+	plan.stats.V2TermStatsBytes += statsBytes
 
 	statusKey := encodeTextV2StatusKey()
 	statusValue := encodeTextV2IndexStatusValue(textV2IndexStatusValue{
@@ -459,10 +486,12 @@ func buildCreateTextV2IndexBackfillPlan(
 		DeletedDocuments: 0,
 	})
 	tables[generationsRootName].SetSteal(statusKey, statusValue)
+	statusBytes := uint64(len(statusKey) + len(statusValue))
 	plan.stats.V2StatusRecords = 1
 	plan.stats.V2NextOrdinal = nextOrdinal
 	plan.stats.V2RootGeneration = 1
-	plan.stats.EncodedBytes += uint64(len(statusKey) + len(statusValue))
+	plan.stats.EncodedBytes += statusBytes
+	plan.stats.V2StatusFormatBytes += statusBytes
 
 	for _, rootName := range rootNames {
 		table := tables[rootName]
@@ -1096,6 +1125,36 @@ func inspectTextV2IndexStorageWithBudget(snap *backenddb.Snapshot, catalog *coll
 	return stats, nil
 }
 
+func addTextV2StorageLaneBytes(stats *TextIndexStorageStats, family textV2RootFamily, key, value []byte) {
+	if stats == nil {
+		return
+	}
+	bytesWritten := uint64(len(key) + len(value))
+	stats.EncodedBytes += bytesWritten
+	if textV2KeyIsKind(key, textV2KeyKindFormat) || textV2KeyIsKind(key, textV2KeyKindStatus) {
+		stats.V2StatusFormatBytes += bytesWritten
+		return
+	}
+	switch family {
+	case textV2RootFamilyDocID:
+		stats.V2DocIDBytes += bytesWritten
+	case textV2RootFamilyDocMap:
+		stats.V2DocMapBytes += bytesWritten
+	case textV2RootFamilyTerms:
+		stats.V2TermStatsBytes += bytesWritten
+	case textV2RootFamilyPostingBlocks:
+		stats.V2PostingBlockBytes += bytesWritten
+	case textV2RootFamilyNormBlocks:
+		stats.V2NormBlockBytes += bytesWritten
+	case textV2RootFamilyPositions:
+		stats.V2PositionBytes += bytesWritten
+	}
+}
+
+func textV2KeyIsKind(key []byte, kind byte) bool {
+	return len(key) == 2 && key[0] == textV2KeyVersion && key[1] == kind
+}
+
 func readTextV2StatusAtRoot(snap *backenddb.Snapshot, catalog *collectionCatalog, rootName string) (textV2IndexStatusValue, bool, error) {
 	raw, ok, err := collectionGetAppendAtCatalogRoot(snap, catalog, rootName, encodeTextV2StatusKey(), nil)
 	if err != nil || !ok {
@@ -1321,7 +1380,11 @@ func inspectTextV2Root(snap *backenddb.Snapshot, catalog *collectionCatalog, def
 			stats.V2TermStats++
 			stats.StatsEntries++
 		case family == textV2RootFamilyPositions:
-			position, err := decodeTextV2PositionValue(value)
+			_, term, err := decodeTextV2PositionKey(key)
+			if err != nil {
+				return err
+			}
+			position, err := decodeTextV2PositionValueForTerm(value, term)
 			if err != nil {
 				return err
 			}
@@ -1334,7 +1397,7 @@ func inspectTextV2Root(snap *backenddb.Snapshot, catalog *collectionCatalog, def
 		default:
 			return errMalformedTextStorage("unsupported text-v2 root %q family %s", rootName, family)
 		}
-		stats.EncodedBytes += uint64(len(key) + len(value))
+		addTextV2StorageLaneBytes(stats, family, key, value)
 		it.Next()
 	}
 	if err := it.Error(); err != nil {

--- a/TreeDB/collections/text_v2_contract_bench_test.go
+++ b/TreeDB/collections/text_v2_contract_bench_test.go
@@ -677,6 +677,7 @@ func BenchmarkTextV2PhraseProximity2733(b *testing.B) {
 			b.ReportMetric(float64(maxPostings), "max_postings/search")
 			b.ReportMetric(float64(stats.V2PositionEntries), "v2_position_entries")
 			b.ReportMetric(float64(stats.EncodedBytes)/float64(maxTextV2ContractInt2623(docs, 1)), "index_bytes/doc")
+			textV2ContractReportBackfillLaneBytes2623(b, docs, stats)
 			textV2ContractReportTextStats2623(b, sink)
 		})
 	}
@@ -1203,6 +1204,7 @@ func textV2ContractReportBackfillStats2623(b *testing.B, docs int, stats TextInd
 	b.ReportMetric(float64(entries)/docsDivisor, "index_entries/doc")
 	b.ReportMetric(float64(entries)/docsDivisor, "write_amp_entries/doc")
 	b.ReportMetric(float64(stats.EncodedBytes)/docsDivisor, "index_bytes/doc")
+	textV2ContractReportBackfillLaneBytes2623(b, docs, stats)
 }
 
 func textV2ContractReportWriteStats2623(b *testing.B, docs int, stats TextIndexStorageStats, writeAmpEntries uint64) {
@@ -1223,6 +1225,31 @@ func textV2ContractReportWriteStats2623(b *testing.B, docs int, stats TextIndexS
 	b.ReportMetric(float64(entries)/docsDivisor, "index_entries/doc")
 	b.ReportMetric(float64(writeAmpEntries)/docsDivisor, "write_amp_entries/doc")
 	b.ReportMetric(float64(stats.EncodedBytes)/docsDivisor, "index_bytes/doc")
+	textV2ContractReportStorageLaneBytes2623(b, docs, stats)
+}
+
+func textV2ContractReportBackfillLaneBytes2623(b *testing.B, docs int, stats TextIndexBackfillStats) {
+	b.Helper()
+	docsDivisor := float64(maxTextV2ContractInt2623(docs, 1))
+	b.ReportMetric(float64(stats.V2DocIDBytes)/docsDivisor, "v2_docid_bytes/doc")
+	b.ReportMetric(float64(stats.V2DocMapBytes)/docsDivisor, "v2_docmap_bytes/doc")
+	b.ReportMetric(float64(stats.V2PostingBlockBytes)/docsDivisor, "v2_posting_bytes/doc")
+	b.ReportMetric(float64(stats.V2NormBlockBytes)/docsDivisor, "v2_norm_bytes/doc")
+	b.ReportMetric(float64(stats.V2PositionBytes)/docsDivisor, "v2_position_bytes/doc")
+	b.ReportMetric(float64(stats.V2TermStatsBytes)/docsDivisor, "v2_term_bytes/doc")
+	b.ReportMetric(float64(stats.V2StatusFormatBytes)/docsDivisor, "v2_status_format_bytes/doc")
+}
+
+func textV2ContractReportStorageLaneBytes2623(b *testing.B, docs int, stats TextIndexStorageStats) {
+	b.Helper()
+	docsDivisor := float64(maxTextV2ContractInt2623(docs, 1))
+	b.ReportMetric(float64(stats.V2DocIDBytes)/docsDivisor, "v2_docid_bytes/doc")
+	b.ReportMetric(float64(stats.V2DocMapBytes)/docsDivisor, "v2_docmap_bytes/doc")
+	b.ReportMetric(float64(stats.V2PostingBlockBytes)/docsDivisor, "v2_posting_bytes/doc")
+	b.ReportMetric(float64(stats.V2NormBlockBytes)/docsDivisor, "v2_norm_bytes/doc")
+	b.ReportMetric(float64(stats.V2PositionBytes)/docsDivisor, "v2_position_bytes/doc")
+	b.ReportMetric(float64(stats.V2TermStatsBytes)/docsDivisor, "v2_term_bytes/doc")
+	b.ReportMetric(float64(stats.V2StatusFormatBytes)/docsDivisor, "v2_status_format_bytes/doc")
 }
 
 func textV2ContractReportHighDFBlocks2626(b *testing.B, docs int, blocks uint64) {

--- a/TreeDB/collections/text_v2_footprint_2835_test.go
+++ b/TreeDB/collections/text_v2_footprint_2835_test.go
@@ -45,6 +45,9 @@ func TestTextV2PositionValueV2RoundTripAndLegacyCompatibility2835(t *testing.T) 
 	if len(encoded) >= len(legacy) {
 		t.Fatalf("v2 encoded bytes=%d want smaller than legacy=%d", len(encoded), len(legacy))
 	}
+	if _, err := decodeTextV2PositionValueForTerm(encoded, "wrong-term"); err == nil {
+		t.Fatalf("decode v2 position with mismatched key term succeeded; want corruption")
+	}
 	if _, err := decodeTextV2PositionValueForTerm(legacy, "wrong-term"); err == nil {
 		t.Fatalf("decode legacy v1 with mismatched key term succeeded; want corruption")
 	}
@@ -56,6 +59,7 @@ func TestTextV2PositionValueV2RejectsCorruptDeltas2835(t *testing.T) {
 	raw = appendTextUvarint(raw, uint64(textV2FormatVersion))
 	raw = appendTextUvarint(raw, 1) // ordinal
 	raw = appendTextUvarint(raw, 1) // generation
+	raw = appendTextUvarint(raw, textV2PositionTermHash("refund"))
 	raw = appendTextUvarint(raw, 1) // field count
 	raw = appendTextUvarint(raw, 0) // field index
 	raw = appendTextUvarint(raw, 2) // frequency
@@ -72,8 +76,8 @@ func TestTextV2StorageStatsLaneBytesAndPositionSavings2835(t *testing.T) {
 	d := openTextV2TestDB(t, t.TempDir(), false)
 	defer func() { _ = d.Close() }()
 	col := createTextSearchCollection2627(t, d, "docs", TextIndexDefinition{Name: "lexical", Version: TextIndexVersionV2, StorePositions: true, StoreOffsets: true, Fields: []TextIndexField{{Field: "title"}, {Field: "body"}}}, [][]byte{[]byte("d1"), []byte("d2")}, [][]byte{
-		[]byte(`{"title":"refund policy","body":"refund policy support refund policy support refund policy support"}`),
-		[]byte(`{"title":"shipping policy","body":"shipping support policy refund support policy refund"}`),
+		[]byte(`{"title":"refundpolicytwenty835longtoken policy","body":"refundpolicytwenty835longtoken policy support refundpolicytwenty835longtoken policy support refundpolicytwenty835longtoken policy support"}`),
+		[]byte(`{"title":"shippingpolicytwenty835longtoken policy","body":"shippingpolicytwenty835longtoken support policy refundpolicytwenty835longtoken support policy refundpolicytwenty835longtoken"}`),
 	})
 
 	stats, err := col.TextIndexStorageStats("lexical")

--- a/TreeDB/collections/text_v2_footprint_2835_test.go
+++ b/TreeDB/collections/text_v2_footprint_2835_test.go
@@ -59,7 +59,7 @@ func TestTextV2PositionValueV2RejectsCorruptDeltas2835(t *testing.T) {
 	raw = appendTextUvarint(raw, uint64(textV2FormatVersion))
 	raw = appendTextUvarint(raw, 1) // ordinal
 	raw = appendTextUvarint(raw, 1) // generation
-	raw = appendTextUvarint(raw, textV2PositionTermHash("refund"))
+	raw = appendTextV2PositionTermBinding(raw, "refund")
 	raw = appendTextUvarint(raw, 1) // field count
 	raw = appendTextUvarint(raw, 0) // field index
 	raw = appendTextUvarint(raw, 2) // frequency

--- a/TreeDB/collections/text_v2_footprint_2835_test.go
+++ b/TreeDB/collections/text_v2_footprint_2835_test.go
@@ -1,0 +1,202 @@
+package collections
+
+import (
+	"bytes"
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func TestTextV2PositionValueV2RoundTripAndLegacyCompatibility2835(t *testing.T) {
+	value := textV2PositionValue{
+		FormatVersion: textV2FormatVersion,
+		Ordinal:       7,
+		Generation:    3,
+		Term:          "refund-policy-2835",
+		Fields: []textV2PositionFieldValue{
+			{FieldIndex: 1, Frequency: 4, Positions: []uint32{3, 130, 131, 4096}, Offsets: []textTokenOffset{{Start: 6, End: 12}, {Start: 260, End: 266}, {Start: 268, End: 274}, {Start: 8192, End: 8198}}},
+			{FieldIndex: 3, Frequency: 2, Positions: []uint32{0, 2048}, Offsets: []textTokenOffset{{Start: 0, End: 6}, {Start: 4096, End: 4102}}},
+		},
+	}
+
+	encoded := encodeTextV2PositionValue(value)
+	if encoded[0] != textV2PositionValueVersion {
+		t.Fatalf("position value version=%d want %d", encoded[0], textV2PositionValueVersion)
+	}
+	if _, err := decodeTextV2PositionValue(encoded); err == nil {
+		t.Fatalf("decode v2 position without key term succeeded; want fail-closed key-bound decode")
+	}
+	decoded, err := decodeTextV2PositionValueForTerm(encoded, value.Term)
+	if err != nil {
+		t.Fatalf("decode v2 position: %v", err)
+	}
+	if !reflect.DeepEqual(decoded, value) {
+		t.Fatalf("decoded v2 position=%+v want %+v", decoded, value)
+	}
+
+	legacy := encodeTextV2PositionValueV1ForTest(value)
+	legacyDecoded, err := decodeTextV2PositionValueForTerm(legacy, value.Term)
+	if err != nil {
+		t.Fatalf("decode legacy v1 position: %v", err)
+	}
+	if !reflect.DeepEqual(legacyDecoded, value) {
+		t.Fatalf("decoded legacy position=%+v want %+v", legacyDecoded, value)
+	}
+	if len(encoded) >= len(legacy) {
+		t.Fatalf("v2 encoded bytes=%d want smaller than legacy=%d", len(encoded), len(legacy))
+	}
+	if _, err := decodeTextV2PositionValueForTerm(legacy, "wrong-term"); err == nil {
+		t.Fatalf("decode legacy v1 with mismatched key term succeeded; want corruption")
+	}
+}
+
+func TestTextV2PositionValueV2RejectsCorruptDeltas2835(t *testing.T) {
+	var raw []byte
+	raw = append(raw, textV2PositionValueVersion)
+	raw = appendTextUvarint(raw, uint64(textV2FormatVersion))
+	raw = appendTextUvarint(raw, 1) // ordinal
+	raw = appendTextUvarint(raw, 1) // generation
+	raw = appendTextUvarint(raw, 1) // field count
+	raw = appendTextUvarint(raw, 0) // field index
+	raw = appendTextUvarint(raw, 2) // frequency
+	raw = appendTextUvarint(raw, 2) // position count
+	raw = appendTextUvarint(raw, 7) // first absolute position
+	raw = appendTextUvarint(raw, 0) // invalid second delta: non-increasing
+	raw = appendTextUvarint(raw, 0) // offsets count
+	if _, err := decodeTextV2PositionValueForTerm(raw, "refund"); err == nil {
+		t.Fatalf("decode corrupt v2 position deltas succeeded; want corruption")
+	}
+}
+
+func TestTextV2StorageStatsLaneBytesAndPositionSavings2835(t *testing.T) {
+	d := openTextV2TestDB(t, t.TempDir(), false)
+	defer func() { _ = d.Close() }()
+	col := createTextSearchCollection2627(t, d, "docs", TextIndexDefinition{Name: "lexical", Version: TextIndexVersionV2, StorePositions: true, StoreOffsets: true, Fields: []TextIndexField{{Field: "title"}, {Field: "body"}}}, [][]byte{[]byte("d1"), []byte("d2")}, [][]byte{
+		[]byte(`{"title":"refund policy","body":"refund policy support refund policy support refund policy support"}`),
+		[]byte(`{"title":"shipping policy","body":"shipping support policy refund support policy refund"}`),
+	})
+
+	stats, err := col.TextIndexStorageStats("lexical")
+	if err != nil {
+		t.Fatalf("TextIndexStorageStats: %v", err)
+	}
+	laneBytes := stats.V2DocIDBytes + stats.V2DocMapBytes + stats.V2PostingBlockBytes + stats.V2NormBlockBytes + stats.V2PositionBytes + stats.V2TermStatsBytes + stats.V2StatusFormatBytes
+	if laneBytes != stats.EncodedBytes {
+		t.Fatalf("lane bytes=%d encoded=%d stats=%+v", laneBytes, stats.EncodedBytes, stats)
+	}
+	if stats.V2PostingBlockBytes == 0 || stats.V2NormBlockBytes == 0 || stats.V2DocMapBytes == 0 || stats.V2PositionBytes == 0 || stats.V2TermStatsBytes == 0 || stats.V2StatusFormatBytes == 0 {
+		t.Fatalf("stats=%+v want non-zero v2 lane byte accounting", stats)
+	}
+	legacyPositionBytes := textV2LegacyPositionRootBytes2835(t, col)
+	if legacyPositionBytes <= stats.V2PositionBytes {
+		t.Fatalf("legacy position bytes=%d current=%d want current smaller", legacyPositionBytes, stats.V2PositionBytes)
+	}
+	legacyIndexBytes := stats.EncodedBytes - stats.V2PositionBytes + legacyPositionBytes
+	if legacyIndexBytes <= stats.EncodedBytes {
+		t.Fatalf("legacy index bytes=%d current=%d want current smaller", legacyIndexBytes, stats.EncodedBytes)
+	}
+}
+
+func BenchmarkTextV2PositionFootprint2835(b *testing.B) {
+	docs := textV2ContractEnvInt2623("TREEDB_TEXT_V2_FOOTPRINT_DOCS", 1024)
+	if docs < int(textV2PostingBlockTargetPostings)*3 {
+		docs = int(textV2PostingBlockTargetPostings) * 3
+	}
+	d, col, _ := openTextV2PhraseBenchFixture2733(b, docs, nil)
+	defer func() { _ = d.Close() }()
+	stats := textV2ContractStorageStats2623(b, col)
+	legacyPositionBytes := textV2LegacyPositionRootBytes2835(b, col)
+	legacyIndexBytes := stats.EncodedBytes - stats.V2PositionBytes + legacyPositionBytes
+	docsDivisor := float64(maxTextV2ContractInt2623(docs, 1))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := col.TextIndexStorageStats(textV2ContractIndexName2623); err != nil {
+			b.Fatalf("TextIndexStorageStats: %v", err)
+		}
+	}
+	b.StopTimer()
+	b.ReportMetric(float64(docs), "docs_fixture")
+	b.ReportMetric(float64(stats.EncodedBytes), "index_bytes")
+	b.ReportMetric(float64(legacyIndexBytes), "legacy_index_bytes")
+	b.ReportMetric(float64(stats.EncodedBytes)/docsDivisor, "index_bytes/doc")
+	b.ReportMetric(float64(legacyIndexBytes)/docsDivisor, "legacy_index_bytes/doc")
+	b.ReportMetric(float64(stats.V2PositionBytes), "v2_position_bytes")
+	b.ReportMetric(float64(legacyPositionBytes), "legacy_v2_position_bytes")
+	b.ReportMetric(float64(stats.V2PositionBytes)/docsDivisor, "v2_position_bytes/doc")
+	b.ReportMetric(float64(legacyPositionBytes)/docsDivisor, "legacy_v2_position_bytes/doc")
+	if legacyPositionBytes > 0 {
+		b.ReportMetric(100*(float64(legacyPositionBytes)-float64(stats.V2PositionBytes))/float64(legacyPositionBytes), "position_bytes_saved_pct")
+	}
+	textV2ContractReportStorageLaneBytes2623(b, docs, stats)
+}
+
+func textV2LegacyPositionRootBytes2835(tb testing.TB, col *Collection) uint64 {
+	tb.Helper()
+	if col == nil || col.db == nil {
+		return 0
+	}
+	snap := col.db.AcquireSnapshot()
+	if snap == nil {
+		tb.Fatalf("snapshot nil")
+	}
+	defer func() { _ = snap.Close() }()
+	catalog, err := col.catalogForSnapshot(snap)
+	if err != nil {
+		tb.Fatalf("catalog snapshot: %v", err)
+	}
+	rootName := collectionTextV2PositionsRootName(catalog.meta.Name, textV2ContractIndexName2623)
+	it, err := collectionIteratorAtCatalogRoot(snap, catalog, rootName, nil, nil, false)
+	if err != nil || it == nil {
+		tb.Fatalf("positions iterator: %v", err)
+	}
+	defer func() { _ = it.Close() }()
+	var total uint64
+	for it.Valid() {
+		if it.IsDeleted() {
+			it.Next()
+			continue
+		}
+		key := it.UnsafeKey()
+		if bytes.Equal(key, encodeTextV2FormatKey()) {
+			it.Next()
+			continue
+		}
+		_, term, err := decodeTextV2PositionKey(key)
+		if err != nil {
+			tb.Fatalf("decode position key: %v", err)
+		}
+		value, err := decodeTextV2PositionValueForTerm(it.ValueCopy(nil), term)
+		if err != nil {
+			tb.Fatalf("decode position value: %v", err)
+		}
+		legacy := encodeTextV2PositionValueV1ForTest(value)
+		total += uint64(len(key) + len(legacy))
+		it.Next()
+	}
+	if err := it.Error(); err != nil {
+		tb.Fatalf("positions iterator error: %v", err)
+	}
+	return total
+}
+
+func encodeTextV2PositionValueV1ForTest(value textV2PositionValue) []byte {
+	fields := cloneTextV2PositionFields(value.Fields)
+	sort.Slice(fields, func(i, j int) bool { return fields[i].FieldIndex < fields[j].FieldIndex })
+	out := make([]byte, 0, 1+binaryMaxVarintLen64ForTest2835*4+len(value.Term))
+	out = append(out, textV2PositionValueVersionV1)
+	out = appendTextUvarint(out, uint64(value.FormatVersion))
+	out = appendTextUvarint(out, value.Ordinal)
+	out = appendTextUvarint(out, value.Generation)
+	out = appendTextString(out, value.Term)
+	out = appendTextUvarint(out, uint64(len(fields)))
+	for _, field := range fields {
+		out = appendTextUvarint(out, uint64(field.FieldIndex))
+		out = appendTextUvarint(out, uint64(field.Frequency))
+		out = appendTextUint32Slice(out, field.Positions)
+		out = appendTextOffsetSlice(out, field.Offsets)
+	}
+	return out
+}
+
+const binaryMaxVarintLen64ForTest2835 = 10

--- a/TreeDB/collections/text_v2_phrase.go
+++ b/TreeDB/collections/text_v2_phrase.go
@@ -224,7 +224,7 @@ func readTextV2PhrasePositionValueAtSnapshot(
 	if !found {
 		return textV2PositionValue{}, errMalformedTextStorage("missing text-v2 position entry for phrase ordinal %d term %q", ordinal, term)
 	}
-	value, err := decodeTextV2PositionValue(raw)
+	value, err := decodeTextV2PositionValueForTerm(raw, term)
 	if err != nil {
 		return textV2PositionValue{}, err
 	}

--- a/TreeDB/collections/text_v2_positions.go
+++ b/TreeDB/collections/text_v2_positions.go
@@ -479,7 +479,9 @@ func estimateTextV2PositionValueLen(value textV2PositionValue, fields []textV2Po
 }
 
 func textV2PositionTermHash(term string) uint64 {
-	return columnPhysicalQueryHashString(term)
+	// A 32-bit fingerprint preserves an independent key/value term check for the
+	// compressed v2 payload without reintroducing the full duplicate term string.
+	return columnPhysicalQueryHashString(term) & 0xffffffff
 }
 
 func encodedTextV2PositionDeltasLen(values []uint32) int {

--- a/TreeDB/collections/text_v2_positions.go
+++ b/TreeDB/collections/text_v2_positions.go
@@ -3,6 +3,7 @@ package collections
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
 	"sort"
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
@@ -12,7 +13,8 @@ import (
 const (
 	textV2KeyKindPosition byte = 0x22
 
-	textV2PositionValueVersion byte = 1
+	textV2PositionValueVersionV1 byte = 1
+	textV2PositionValueVersion   byte = 2
 )
 
 type textV2PositionFieldValue struct {
@@ -76,23 +78,30 @@ func encodeTextV2PositionValue(value textV2PositionValue) []byte {
 	out = appendTextUvarint(out, uint64(value.FormatVersion))
 	out = appendTextUvarint(out, value.Ordinal)
 	out = appendTextUvarint(out, value.Generation)
-	out = appendTextString(out, value.Term)
 	out = appendTextUvarint(out, uint64(len(fields)))
 	for _, field := range fields {
 		out = appendTextUvarint(out, uint64(field.FieldIndex))
 		out = appendTextUvarint(out, uint64(field.Frequency))
-		out = appendTextUint32Slice(out, field.Positions)
+		out = appendTextV2PositionDeltas(out, field.Positions)
 		out = appendTextOffsetSlice(out, field.Offsets)
 	}
 	return out
 }
 
 func decodeTextV2PositionValue(raw []byte) (textV2PositionValue, error) {
+	return decodeTextV2PositionValueForTerm(raw, "")
+}
+
+func decodeTextV2PositionValueForTerm(raw []byte, keyTerm string) (textV2PositionValue, error) {
 	if len(raw) == 0 {
 		return textV2PositionValue{}, errMalformedTextStorage("empty text-v2 position value")
 	}
-	if raw[0] != textV2PositionValueVersion {
+	valueVersion := raw[0]
+	if valueVersion != textV2PositionValueVersion && valueVersion != textV2PositionValueVersionV1 {
 		return textV2PositionValue{}, errUnsupportedTextStorageVersion("text-v2 position value", raw[0])
+	}
+	if valueVersion == textV2PositionValueVersion && keyTerm == "" {
+		return textV2PositionValue{}, errMalformedTextStorage("text-v2 position value v2 requires key term")
 	}
 	cur := textCursor{buf: raw[1:]}
 	formatVersion, err := cur.readUvarint()
@@ -110,9 +119,15 @@ func decodeTextV2PositionValue(raw []byte) (textV2PositionValue, error) {
 	if err != nil {
 		return textV2PositionValue{}, errMalformedTextStorage("text-v2 position generation: %v", err)
 	}
-	term, err := cur.readString()
-	if err != nil {
-		return textV2PositionValue{}, errMalformedTextStorage("text-v2 position term: %v", err)
+	term := keyTerm
+	if valueVersion == textV2PositionValueVersionV1 {
+		term, err = cur.readString()
+		if err != nil {
+			return textV2PositionValue{}, errMalformedTextStorage("text-v2 position term: %v", err)
+		}
+		if keyTerm != "" && term != keyTerm {
+			return textV2PositionValue{}, errMalformedTextStorage("text-v2 position key/value term mismatch")
+		}
 	}
 	fieldCount, err := cur.readUvarint()
 	if err != nil {
@@ -135,7 +150,12 @@ func decodeTextV2PositionValue(raw []byte) (textV2PositionValue, error) {
 		if err != nil {
 			return textV2PositionValue{}, errMalformedTextStorage("text-v2 position field[%d] frequency: %v", i, err)
 		}
-		positions, err := cur.readUint32Slice()
+		var positions []uint32
+		if valueVersion == textV2PositionValueVersionV1 {
+			positions, err = cur.readUint32Slice()
+		} else {
+			positions, err = cur.readTextV2PositionDeltas()
+		}
 		if err != nil {
 			return textV2PositionValue{}, errMalformedTextStorage("text-v2 position field[%d] positions: %v", i, err)
 		}
@@ -439,11 +459,83 @@ func cloneTextV2PositionFields(fields []textV2PositionFieldValue) []textV2Positi
 }
 
 func estimateTextV2PositionValueLen(value textV2PositionValue, fields []textV2PositionFieldValue) int {
-	n := 1 + binary.MaxVarintLen64*4 + len(value.Term)
+	n := 1 + binary.MaxVarintLen64*4
 	for _, field := range fields {
 		n += binary.MaxVarintLen64 * 2
-		n += encodedTextUint32SliceLen(field.Positions)
+		n += encodedTextV2PositionDeltasLen(field.Positions)
 		n += encodedTextOffsetSliceLen(field.Offsets)
 	}
 	return n
+}
+
+func encodedTextV2PositionDeltasLen(values []uint32) int {
+	n := textUvarintLen(uint64(len(values)))
+	var prev uint32
+	for i, value := range values {
+		delta := value
+		if i > 0 {
+			if value <= prev {
+				delta = 0
+			} else {
+				delta = value - prev
+			}
+		}
+		n += textUvarintLen(uint64(delta))
+		prev = value
+	}
+	return n
+}
+
+func appendTextV2PositionDeltas(dst []byte, values []uint32) []byte {
+	dst = appendTextUvarint(dst, uint64(len(values)))
+	var prev uint32
+	for i, value := range values {
+		delta := value
+		if i > 0 {
+			if value <= prev {
+				delta = 0
+			} else {
+				delta = value - prev
+			}
+		}
+		dst = appendTextUvarint(dst, uint64(delta))
+		prev = value
+	}
+	return dst
+}
+
+func (c *textCursor) readTextV2PositionDeltas() ([]uint32, error) {
+	count, err := c.readUvarint()
+	if err != nil {
+		return nil, err
+	}
+	if count > uint64(c.remaining()+1) {
+		return nil, errors.New("count too large")
+	}
+	out := make([]uint32, 0, count)
+	var prev uint32
+	for i := uint64(0); i < count; i++ {
+		delta, err := c.readUvarint()
+		if err != nil {
+			return nil, err
+		}
+		if delta > uint64(^uint32(0)) {
+			return nil, errors.New("uint32 overflow")
+		}
+		var value uint32
+		if i == 0 {
+			value = uint32(delta)
+		} else {
+			if delta == 0 {
+				return nil, errors.New("non-increasing position delta")
+			}
+			if delta > uint64(^uint32(0)-prev) {
+				return nil, errors.New("uint32 overflow")
+			}
+			value = prev + uint32(delta)
+		}
+		out = append(out, value)
+		prev = value
+	}
+	return out, nil
 }

--- a/TreeDB/collections/text_v2_positions.go
+++ b/TreeDB/collections/text_v2_positions.go
@@ -78,6 +78,7 @@ func encodeTextV2PositionValue(value textV2PositionValue) []byte {
 	out = appendTextUvarint(out, uint64(value.FormatVersion))
 	out = appendTextUvarint(out, value.Ordinal)
 	out = appendTextUvarint(out, value.Generation)
+	out = appendTextUvarint(out, textV2PositionTermHash(value.Term))
 	out = appendTextUvarint(out, uint64(len(fields)))
 	for _, field := range fields {
 		out = appendTextUvarint(out, uint64(field.FieldIndex))
@@ -120,6 +121,15 @@ func decodeTextV2PositionValueForTerm(raw []byte, keyTerm string) (textV2Positio
 		return textV2PositionValue{}, errMalformedTextStorage("text-v2 position generation: %v", err)
 	}
 	term := keyTerm
+	if valueVersion == textV2PositionValueVersion {
+		termHash, err := cur.readUvarint()
+		if err != nil {
+			return textV2PositionValue{}, errMalformedTextStorage("text-v2 position term hash: %v", err)
+		}
+		if termHash != textV2PositionTermHash(keyTerm) {
+			return textV2PositionValue{}, errMalformedTextStorage("text-v2 position key/value term mismatch")
+		}
+	}
 	if valueVersion == textV2PositionValueVersionV1 {
 		term, err = cur.readString()
 		if err != nil {
@@ -459,13 +469,17 @@ func cloneTextV2PositionFields(fields []textV2PositionFieldValue) []textV2Positi
 }
 
 func estimateTextV2PositionValueLen(value textV2PositionValue, fields []textV2PositionFieldValue) int {
-	n := 1 + binary.MaxVarintLen64*4
+	n := 1 + binary.MaxVarintLen64*5
 	for _, field := range fields {
 		n += binary.MaxVarintLen64 * 2
 		n += encodedTextV2PositionDeltasLen(field.Positions)
 		n += encodedTextOffsetSliceLen(field.Offsets)
 	}
 	return n
+}
+
+func textV2PositionTermHash(term string) uint64 {
+	return columnPhysicalQueryHashString(term)
 }
 
 func encodedTextV2PositionDeltasLen(values []uint32) int {

--- a/TreeDB/collections/text_v2_positions.go
+++ b/TreeDB/collections/text_v2_positions.go
@@ -2,8 +2,10 @@ package collections
 
 import (
 	"bytes"
+	"crypto/sha256"
 	"encoding/binary"
 	"errors"
+	"io"
 	"sort"
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
@@ -78,7 +80,7 @@ func encodeTextV2PositionValue(value textV2PositionValue) []byte {
 	out = appendTextUvarint(out, uint64(value.FormatVersion))
 	out = appendTextUvarint(out, value.Ordinal)
 	out = appendTextUvarint(out, value.Generation)
-	out = appendTextUvarint(out, textV2PositionTermHash(value.Term))
+	out = appendTextV2PositionTermBinding(out, value.Term)
 	out = appendTextUvarint(out, uint64(len(fields)))
 	for _, field := range fields {
 		out = appendTextUvarint(out, uint64(field.FieldIndex))
@@ -122,12 +124,8 @@ func decodeTextV2PositionValueForTerm(raw []byte, keyTerm string) (textV2Positio
 	}
 	term := keyTerm
 	if valueVersion == textV2PositionValueVersion {
-		termHash, err := cur.readUvarint()
-		if err != nil {
-			return textV2PositionValue{}, errMalformedTextStorage("text-v2 position term hash: %v", err)
-		}
-		if termHash != textV2PositionTermHash(keyTerm) {
-			return textV2PositionValue{}, errMalformedTextStorage("text-v2 position key/value term mismatch")
+		if err := readTextV2PositionTermBinding(&cur, keyTerm); err != nil {
+			return textV2PositionValue{}, err
 		}
 	}
 	if valueVersion == textV2PositionValueVersionV1 {
@@ -469,7 +467,7 @@ func cloneTextV2PositionFields(fields []textV2PositionFieldValue) []textV2Positi
 }
 
 func estimateTextV2PositionValueLen(value textV2PositionValue, fields []textV2PositionFieldValue) int {
-	n := 1 + binary.MaxVarintLen64*5
+	n := 1 + binary.MaxVarintLen64*4 + encodedTextV2PositionTermBindingLen(value.Term)
 	for _, field := range fields {
 		n += binary.MaxVarintLen64 * 2
 		n += encodedTextV2PositionDeltasLen(field.Positions)
@@ -478,10 +476,46 @@ func estimateTextV2PositionValueLen(value textV2PositionValue, fields []textV2Po
 	return n
 }
 
-func textV2PositionTermHash(term string) uint64 {
-	// A 32-bit fingerprint preserves an independent key/value term check for the
-	// compressed v2 payload without reintroducing the full duplicate term string.
-	return columnPhysicalQueryHashString(term) & 0xffffffff
+const textV2PositionTermFingerprintSize = 5
+
+func appendTextV2PositionTermBinding(out []byte, term string) []byte {
+	out = appendTextUvarint(out, uint64(len(term)))
+	fingerprint := textV2PositionTermFingerprint(term)
+	return append(out, fingerprint[:]...)
+}
+
+func readTextV2PositionTermBinding(cur *textCursor, keyTerm string) error {
+	termLen, err := cur.readUvarint()
+	if err != nil {
+		return errMalformedTextStorage("text-v2 position term length: %v", err)
+	}
+	if termLen != uint64(len(keyTerm)) {
+		return errMalformedTextStorage("text-v2 position key/value term mismatch")
+	}
+	if cur.remaining() < textV2PositionTermFingerprintSize {
+		return errMalformedTextStorage("text-v2 position term fingerprint: %v", io.ErrUnexpectedEOF)
+	}
+	termFingerprint := cur.buf[cur.pos : cur.pos+textV2PositionTermFingerprintSize]
+	cur.pos += textV2PositionTermFingerprintSize
+	wantFingerprint := textV2PositionTermFingerprint(keyTerm)
+	if !bytes.Equal(termFingerprint, wantFingerprint[:]) {
+		return errMalformedTextStorage("text-v2 position key/value term mismatch")
+	}
+	return nil
+}
+
+func encodedTextV2PositionTermBindingLen(term string) int {
+	return textUvarintLen(uint64(len(term))) + textV2PositionTermFingerprintSize
+}
+
+func textV2PositionTermFingerprint(term string) [textV2PositionTermFingerprintSize]byte {
+	// Store the exact term length plus a SHA-256/40 fingerprint so the compressed
+	// v2 payload keeps an independent key/value term binding without
+	// reintroducing the full duplicate term string.
+	sum := sha256.Sum256([]byte(term))
+	var out [textV2PositionTermFingerprintSize]byte
+	copy(out[:], sum[:textV2PositionTermFingerprintSize])
+	return out
 }
 
 func encodedTextV2PositionDeltasLen(values []uint32) int {

--- a/TreeDB/collections/text_v2_search.go
+++ b/TreeDB/collections/text_v2_search.go
@@ -2171,7 +2171,7 @@ func validateTextV2PositionPostingAtSnapshot(snap *backenddb.Snapshot, catalog *
 	if !found {
 		return errMalformedTextStorage("missing text-v2 position entry for ordinal %d term %q", ordinal, term)
 	}
-	value, err := decodeTextV2PositionValue(raw)
+	value, err := decodeTextV2PositionValueForTerm(raw, term)
 	if err != nil {
 		return err
 	}

--- a/TreeDB/collections/text_v2_search_test.go
+++ b/TreeDB/collections/text_v2_search_test.go
@@ -220,7 +220,7 @@ func TestTextV2PositionsLaneCorruptionFailsClosedOnlyForDetailedMode2629(t *test
 		positionKey = encodeTextV2PositionKey(doc.Ordinal, "unique2629")
 	})
 	raw := textV2ReadRootBytes2624(t, d, "docs", collectionTextV2PositionsRootName("docs", "lexical"), positionKey)
-	position, err := decodeTextV2PositionValue(raw)
+	position, err := decodeTextV2PositionValueForTerm(raw, "unique2629")
 	if err != nil {
 		t.Fatalf("decode position value before corruption: %v", err)
 	}

--- a/TreeDB/docs/spec/collection-text-v2-contract.md
+++ b/TreeDB/docs/spec/collection-text-v2-contract.md
@@ -307,13 +307,17 @@ bounded top-K heap so final summaries do not require a full posting rescan. The
 `text-v2-posting-blocks` scoring format is unchanged.
 
 If a v2 index is created with `StorePositions`, M6 writes optional
-`text-v2-positions` entries keyed by `(ordinal, term)`. Values contain the
-current document generation, term, per-field term frequency, positions, and
-optional offsets. Detailed/compact materialization validates these entries for
-returned final results and fails closed on missing, corrupt, mismatched, or
-unsupported payloads; score-only mode does not read the lane. Update/delete
-maintenance removes old position entries through ordinary root deltas before
-writing any replacement entries, so physical reclamation remains normal TreeDB
+`text-v2-positions` entries keyed by `(ordinal, term)`. Current value format v2
+keeps the current document generation and per-field term frequency, delta-codes
+strictly increasing token positions, stores optional offsets, and intentionally
+omits the term already present in the key. Legacy value format v1 (with the term
+and absolute positions in the value) remains readable for pre-alpha test
+fixtures, but newly written position entries use the smaller key-bound v2
+payload. Detailed/compact materialization validates these entries for returned
+final results and fails closed on missing, corrupt, mismatched, or unsupported
+payloads; score-only mode does not read the lane. Update/delete maintenance
+removes old position entries through ordinary root deltas before writing any
+replacement entries, so physical reclamation remains normal TreeDB
 root/value-log maintenance. There is no standalone text-block GC.
 
 `SearchHybridTextCandidates` and the text leg of `SearchHybrid` use score-only
@@ -476,7 +480,7 @@ row applies. Explicit v1 rows report compatible zero/legacy values so v1/v2 comp
 | `scalar_filter_selectivity` | matched/(matched+rejected), reported as pct or ppm |
 | `fail_closed` | fail-closed count and reason |
 | `write_amplification` | text-root entries or bytes emitted per document |
-| `index_bytes_per_doc` | durable text-index bytes divided by indexed documents |
+| `index_bytes_per_doc` | durable text-index bytes divided by indexed documents; storage stats also expose v2 lane byte totals for docid, docmap, posting blocks, norm blocks, positions, term stats, and status/format records |
 | `rewrite_merge_state` | v2 generation/rewrite/merge lifecycle state |
 
 Candidate generation must keep `docs_fetched=0` and `full_doc_fallbacks=0`.

--- a/TreeDB/docs/spec/storage-format.md
+++ b/TreeDB/docs/spec/storage-format.md
@@ -339,7 +339,32 @@ uvarint TermLen
 bytes Term[TermLen]
 ```
 
-Position values are versioned and fail closed:
+Position values are versioned and fail closed. New writers use value version 2;
+readers still accept legacy value version 1 for pre-alpha fixtures.
+
+Version 2 omits the duplicate term string already present in the position key,
+retains a compact 32-bit FNV-1a term fingerprint for independent key/value
+mismatch detection, and delta-codes strictly increasing positions:
+
+```text
+u8      ValueVersion  = 2
+uvarint FormatVersion = 1
+uvarint Ordinal
+uvarint Generation
+uvarint TermFingerprint32  // low 32 bits of TreeDB FNV-1a string hash
+uvarint FieldEntryCount
+
+// repeated FieldEntryCount times, sorted by field index
+uvarint FieldIndex
+uvarint FieldTermFrequency
+uvarint PositionCount
+uvarint FirstPosition
+uvarint PositionDelta[PositionCount-1]
+uvarint OffsetCount
+repeated OffsetCount: uvarint Start, uvarint End
+```
+
+Legacy version 1 values include the full term string and absolute positions:
 
 ```text
 u8      ValueVersion  = 1

--- a/TreeDB/docs/spec/storage-format.md
+++ b/TreeDB/docs/spec/storage-format.md
@@ -343,15 +343,16 @@ Position values are versioned and fail closed. New writers use value version 2;
 readers still accept legacy value version 1 for pre-alpha fixtures.
 
 Version 2 omits the duplicate term string already present in the position key,
-retains a compact 32-bit FNV-1a term fingerprint for independent key/value
-mismatch detection, and delta-codes strictly increasing positions:
+retains an independent key/value term binding via the exact term length plus a
+40-bit SHA-256 fingerprint, and delta-codes strictly increasing positions:
 
 ```text
 u8      ValueVersion  = 2
 uvarint FormatVersion = 1
 uvarint Ordinal
 uvarint Generation
-uvarint TermFingerprint32  // low 32 bits of TreeDB FNV-1a string hash
+uvarint TermLen
+bytes[5] TermFingerprint40  // first 5 bytes of SHA-256(term)
 uvarint FieldEntryCount
 
 // repeated FieldEntryCount times, sorted by field index

--- a/cmd/treedb_text_hybrid_scale/main.go
+++ b/cmd/treedb_text_hybrid_scale/main.go
@@ -223,15 +223,22 @@ type maintenanceReport struct {
 }
 
 type storageSnapshot struct {
-	Label             string  `json:"label"`
-	Bytes             int64   `json:"bytes"`
-	BytesPerDoc       float64 `json:"bytes_per_doc,omitempty"`
-	TextEncodedBytes  uint64  `json:"text_encoded_bytes,omitempty"`
-	TextBytesPerDoc   float64 `json:"text_bytes_per_doc,omitempty"`
-	V2PostingBlocks   uint64  `json:"v2_posting_blocks,omitempty"`
-	V2LiveDocuments   uint64  `json:"v2_live_documents,omitempty"`
-	V2DeletedDocs     uint64  `json:"v2_deleted_docs,omitempty"`
-	VectorNativeBytes int64   `json:"vector_native_bytes,omitempty"`
+	Label                       string  `json:"label"`
+	Bytes                       int64   `json:"bytes"`
+	BytesPerDoc                 float64 `json:"bytes_per_doc,omitempty"`
+	TextEncodedBytes            uint64  `json:"text_encoded_bytes,omitempty"`
+	TextBytesPerDoc             float64 `json:"text_bytes_per_doc,omitempty"`
+	TextDocIDBytesPerDoc        float64 `json:"text_docid_bytes_per_doc,omitempty"`
+	TextDocMapBytesPerDoc       float64 `json:"text_docmap_bytes_per_doc,omitempty"`
+	TextPostingBlockBytesPerDoc float64 `json:"text_posting_block_bytes_per_doc,omitempty"`
+	TextNormBlockBytesPerDoc    float64 `json:"text_norm_block_bytes_per_doc,omitempty"`
+	TextPositionBytesPerDoc     float64 `json:"text_position_bytes_per_doc,omitempty"`
+	TextTermStatsBytesPerDoc    float64 `json:"text_term_stats_bytes_per_doc,omitempty"`
+	TextStatusFormatBytesPerDoc float64 `json:"text_status_format_bytes_per_doc,omitempty"`
+	V2PostingBlocks             uint64  `json:"v2_posting_blocks,omitempty"`
+	V2LiveDocuments             uint64  `json:"v2_live_documents,omitempty"`
+	V2DeletedDocs               uint64  `json:"v2_deleted_docs,omitempty"`
+	VectorNativeBytes           int64   `json:"vector_native_bytes,omitempty"`
 }
 
 type guardrailResult struct {
@@ -1425,8 +1432,16 @@ func rankBottlenecks(rep report) []bottleneckRow {
 func storageSnapshotFromText(label string, docs int, bytes int64, stats collections.TextIndexStorageStats, vectorStatus *collections.VectorIndexStatus) storageSnapshot {
 	snap := storageSnapshot{Label: label, Bytes: bytes, TextEncodedBytes: stats.EncodedBytes, V2PostingBlocks: stats.V2PostingBlocks, V2LiveDocuments: stats.V2LiveDocuments, V2DeletedDocs: stats.V2DeletedDocs}
 	if docs > 0 {
-		snap.BytesPerDoc = float64(bytes) / float64(docs)
-		snap.TextBytesPerDoc = float64(stats.EncodedBytes) / float64(docs)
+		docsDivisor := float64(docs)
+		snap.BytesPerDoc = float64(bytes) / docsDivisor
+		snap.TextBytesPerDoc = float64(stats.EncodedBytes) / docsDivisor
+		snap.TextDocIDBytesPerDoc = float64(stats.V2DocIDBytes) / docsDivisor
+		snap.TextDocMapBytesPerDoc = float64(stats.V2DocMapBytes) / docsDivisor
+		snap.TextPostingBlockBytesPerDoc = float64(stats.V2PostingBlockBytes) / docsDivisor
+		snap.TextNormBlockBytesPerDoc = float64(stats.V2NormBlockBytes) / docsDivisor
+		snap.TextPositionBytesPerDoc = float64(stats.V2PositionBytes) / docsDivisor
+		snap.TextTermStatsBytesPerDoc = float64(stats.V2TermStatsBytes) / docsDivisor
+		snap.TextStatusFormatBytesPerDoc = float64(stats.V2StatusFormatBytes) / docsDivisor
 	}
 	if vectorStatus != nil {
 		snap.VectorNativeBytes = vectorStatusBytes(vectorStatus)
@@ -1483,6 +1498,16 @@ func renderMarkdown(rep report) string {
 		fmt.Fprintf(&b, "| backfill fixture | %.3f | %.1f | %d | %.1f | %.1f | 0 |\n", rep.Backfill.TotalSeconds, rep.Backfill.RowsPerSecond, rep.Backfill.StorageBytes, rep.Backfill.StorageBytesPerDoc, float64(rep.Backfill.TextStorage.EncodedBytes)/float64(maxInt(rep.Backfill.Rows, 1)))
 	}
 	fmt.Fprintf(&b, "\nLoad breakdown: generation `%.3fs`, insert `%.3fs`, flush `%.3fs`, vector rebuild `%.3fs`, checkpoint `%.3fs`.\n\n", rep.Load.GenerationSeconds, rep.Load.InsertSeconds, rep.Load.FlushSeconds, rep.Load.VectorRebuildSeconds, rep.Load.CheckpointSeconds)
+
+	if len(rep.StorageSnapshots) != 0 {
+		fmt.Fprintf(&b, "### Text-v2 lane bytes/doc\n\n")
+		fmt.Fprintf(&b, "| snapshot | docid | docmap | postings | norms | positions | terms | status/format |\n")
+		fmt.Fprintf(&b, "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |\n")
+		for _, snap := range rep.StorageSnapshots {
+			fmt.Fprintf(&b, "| `%s` | %.1f | %.1f | %.1f | %.1f | %.1f | %.1f | %.1f |\n", snap.Label, snap.TextDocIDBytesPerDoc, snap.TextDocMapBytesPerDoc, snap.TextPostingBlockBytesPerDoc, snap.TextNormBlockBytesPerDoc, snap.TextPositionBytesPerDoc, snap.TextTermStatsBytesPerDoc, snap.TextStatusFormatBytesPerDoc)
+		}
+		fmt.Fprintf(&b, "\n")
+	}
 
 	if len(rep.Queries) != 0 {
 		fmt.Fprintf(&b, "## Retrieval latency\n\n")

--- a/docs/benchmarks/treedb_text_hybrid_industry_scoreboard.md
+++ b/docs/benchmarks/treedb_text_hybrid_industry_scoreboard.md
@@ -170,7 +170,8 @@ For Go benchmark rows, include:
   `fail_closed/search`, text posting/block/state/norm counters, scalar counters,
   vector candidate/edge counters;
 - build/storage context when available (`indexed_insert_batch_flush_vector_rebuild`,
-  `create_text_v2_index_backfill`, `index_bytes/doc`, external build/storage
+  `create_text_v2_index_backfill`, `index_bytes/doc`, v2 lane bytes/doc such as
+  `v2_posting_bytes/doc` and `v2_position_bytes/doc`, external build/storage
   fields).
 
 Candidate-generation rows must keep full document fetches at zero. Final-fetch

--- a/docs/benchmarks/treedb_text_hybrid_scale_runbook.md
+++ b/docs/benchmarks/treedb_text_hybrid_scale_runbook.md
@@ -138,7 +138,8 @@ Primary artifacts:
 The JSON/Markdown report includes:
 
 - load/build timings, rows/s, text storage, vector rebuild status, checkpoint
-  time, storage bytes, and bytes/doc;
+  time, storage bytes, bytes/doc, and text-v2 lane bytes/doc (docid, docmap,
+  postings, norms, positions, term stats, status/format);
 - text-only common, rare, multi-term AND, and multi-term OR score-only query rows;
 - hybrid text-only, text+scalar, and optional text+vector(+scalar) query rows;
 - p50/p95/p99/mean latency and derived ops/sec for each retrieval row;

--- a/docs/benchmarks/treedb_text_v2_contract_benchmarks.md
+++ b/docs/benchmarks/treedb_text_v2_contract_benchmarks.md
@@ -146,7 +146,10 @@ Report text write counters:
   operation. For maintained v2 insert/update/delete rows this is the emitted
   root-delta estimate (docID/docmap/norm/term-status/posting-block deltas plus
   the status generation), not the net post-mutation root size;
-- `index_bytes/doc`.
+- `index_bytes/doc`, plus v2 lane bytes/doc (`v2_docid_bytes/doc`,
+  `v2_docmap_bytes/doc`, `v2_posting_bytes/doc`, `v2_norm_bytes/doc`,
+  `v2_position_bytes/doc`, `v2_term_bytes/doc`, and
+  `v2_status_format_bytes/doc`).
 
 ## New text search scale rows
 
@@ -273,9 +276,10 @@ go test ./TreeDB/collections \
 
 Report `position_lookups/search`, `phrase_candidates_checked/search`,
 `phrase_candidates_matched/search`, `v2_position_entries`, `index_bytes/doc`,
-and the standard runtime/allocation counters. Stemming and synonym options are
-reserved extension seams and must fail closed until a future ticket defines their
-indexing/query expansion semantics and rebuild compatibility.
+`v2_position_bytes/doc`, and the standard runtime/allocation counters. Stemming
+and synonym options are reserved extension seams and must fail closed until a
+future ticket defines their indexing/query expansion semantics and rebuild
+compatibility.
 
 >=100k local artifact:
 


### PR DESCRIPTION
## Summary

Closes #2835. Parent: #2833. Follows #2834 / PR #2847 (`d1a7b4cea66bf14156bac321ace2601f04015c24`).

This is a deliberately small, reviewable footprint PR for TreeDB text-v2:

- writes a new position value format (`v2`) that omits the duplicate term already present in the `(ordinal, term)` key and delta-codes strictly increasing token positions;
- keeps legacy position value `v1` readable for pre-alpha fixtures/reopen tests;
- adds byte-lane accounting to `TextIndexBackfillStats` and `TextIndexStorageStats` for docid/docmap/posting/norm/position/term/status-format lanes;
- reports lane bytes/doc in text-v2 contract benchmarks and text-hybrid scale reports.

No scoring, query semantics, sidecar storage, standalone GC, or approximate behavior changes.

## Format / compatibility

TreeDB is pre-alpha, but this still reads legacy text-v2 position value `v1` payloads. New writes use position value `v2`. Decoding v2 is key-bound: callers must pass the term from the position key; the payload also carries the exact term length plus a compact SHA-256 fingerprint so key/value mismatches and raw value-only decode mistakes fail closed.

## Local validation

Tests:

```sh
GOWORK=off go test ./TreeDB/collections
GOWORK=off go test ./cmd/treedb_text_hybrid_scale ./TreeDB/docs
```

Focused format/search/rewrite smoke also ran:

```sh
GOWORK=off go test ./TreeDB/collections \
  -run 'TestTextV2PositionValueV2|TestTextV2StorageStatsLaneBytes|TestTextV2PositionsLaneCorruption|TestTextV2PhraseProximityCorrectness|TestTextV2PhrasePositionsReopen|TestTextV2RewriteMergePurges'
```

Race tests were not run: this PR does not introduce shared scratch or shared mutable serving state.

## Benchmark evidence

Context: Linux / Go `go1.26.0` / i5-11400F. Artifacts:

- baseline: `/tmp/gomap_issue_2835_baseline_more_20260618_172750`
- candidate: `/tmp/gomap_issue_2835_candidate_more_20260618_172840`
- key-bound fingerprint refresh: `/tmp/gomap_issue_2835_len_sha40_20260618_192025`
- earlier OR/WAND guardrail: `/tmp/gomap_issue_2835_baseline_20260618_171333`, `/tmp/gomap_issue_2835_candidate_20260618_172334`

### Footprint, 10k StorePositions fixture

Command:

```sh
GOWORK=off TREEDB_TEXT_V2_FOOTPRINT_DOCS=10000 go test ./TreeDB/collections \
  -run '^$' -bench '^BenchmarkTextV2PositionFootprint2835$' \
  -benchmem -benchtime=1x -count=1
```

| metric | legacy v1 estimate | current v2 | delta |
| --- | ---: | ---: | ---: |
| total text index bytes | 2,330,881 | 2,278,049 | -52,832 |
| total text index bytes/doc | 233.1 | 227.8 | -2.27% |
| position lane bytes | 1,532,180 | 1,479,348 | -3.45% |
| position lane bytes/doc | 153.2 | 147.9 | -3.45% |

Current lane bytes/doc on the same fixture after the key-bound fingerprint refresh: docid `24.99`, docmap `23.12`, postings `25.60`, norms `6.13`, positions `147.9`, terms `0.012`, status/format `0.016`.

### Phrase query latency/allocations, 10k StorePositions fixture

Command:

```sh
GOWORK=off go test ./TreeDB/collections -run '^$' \
  -bench '^BenchmarkTextV2PhraseProximity2733/(exact_refund_policy|proximity_refund_support_slop1)$' \
  -benchmem -benchtime=3x -count=5
benchstat baseline/phrase_count5.txt candidate/phrase_count5.txt
```

| row | sec/op | B/op | allocs/op | index bytes/doc |
| --- | ---: | ---: | ---: | ---: |
| exact_refund_policy | -14.84% | -3.78% | -14.16% | footprint row refreshed after strengthened binding: -2.27% total bytes/doc |
| proximity_refund_support_slop1 | -5.40% | -4.51% | -15.24% | footprint row refreshed after strengthened binding: -2.27% total bytes/doc |
| geomean | -10.24% | -4.14% | -14.70% | footprint row refreshed after strengthened binding: -2.27% total bytes/doc |

Counters stayed exact/zero-doc: `docs_fetched/search=0`, `full_doc_fallbacks/search=0`, `fail_closed/search=0`, candidate and phrase-match counts unchanged.

### Common/rare/AND query allocation guardrail, 256-doc fixture

Command:

```sh
GOWORK=off go test ./TreeDB/collections -run '^$' \
  -bench '^BenchmarkTextV2ContractSearchScale2623/docs_256/(score_only_common_no_docs|rare_no_docs|multi_term_and_no_docs)$' \
  -benchmem -benchtime=10x -count=10
benchstat baseline/search_256_count10.txt candidate/search_256_count10.txt
```

Result: `B/op` geomean `+0.00%`, `allocs/op` geomean `+0.00%`; `sec/op` geomean `-7.89%` (not claimed as an optimization, but no regression).

### OR/AND block-max guardrail, 10k fixture

Command:

```sh
GOWORK=off go test ./TreeDB/collections -run '^$' \
  -bench '^BenchmarkTextV2BlockMaxMultiTerm2730/(or_common_blockmax|and_common_blockmax|or_common_rare_blockmax)$' \
  -benchmem -benchtime=3x -count=3
```

Result: `B/op` geomean `-0.00%`, `allocs/op` geomean `+0.00%`; posting/block counters unchanged.

### Build/ingest guardrail, 256-doc fixture without StorePositions

Command:

```sh
GOWORK=off TREEDB_TEXT_V2_WRITE_DOCS=256 go test ./TreeDB/collections -run '^$' \
  -bench '^BenchmarkTextV2ContractWritePaths2623/(insert_batch_text_v2_indexed|create_text_v2_index_backfill)$' \
  -benchmem -benchtime=3x -count=10
benchstat baseline/write_build_256_count10.txt candidate/write_build_256_count10.txt
```

Result: `sec/op` geomean `+2.21%` with no statistically significant row regression, `B/op` geomean `+0.05%`, `allocs/op` geomean `-0.01%`, `index_bytes/doc` unchanged for non-position indexes.

## AI review status

After latest-head CI started, requested Codex and Copilot review via PR comments. CodeRabbit auto-review attempted but was rate-limited/skipped by the repo integration. Findings, if any, are not resolved yet at initial handoff.


