### PR TITLE
treedb: precompute scalar_u8 alpha score scales

### DIFF
--- a/TreeDB/collections/column_vector_graph_quantized_asset_test.go
+++ b/TreeDB/collections/column_vector_graph_quantized_asset_test.go
@@ -594,6 +594,72 @@ func TestColumnGraphScalarU8AlphaScorerAdjustsRankingAndTies2844(t *testing.T) {
 	}
 }
 
+func TestColumnGraphScalarU8AlphaLookupUniformGranuleEdges2866(t *testing.T) {
+	rowsPerGranule := typedColumnDefaultRowsPerGranule()
+	if rowsPerGranule < 2 {
+		t.Fatalf("rows_per_granule=%d want >=2", rowsPerGranule)
+	}
+	const dims = 1
+	codes := bytes.Repeat([]byte{128}, rowsPerGranule*2*dims)
+	_, q, _, lookup, _ := prepareScalarU8AlphaPreparedForTest2844(t, dims, codes, []float32{0.5, 0.25}, []uint32{uint32(rowsPerGranule), uint32(rowsPerGranule)})
+	if lookup.uniformGranuleRows != rowsPerGranule {
+		t.Fatalf("uniformGranuleRows=%d want %d", lookup.uniformGranuleRows, rowsPerGranule)
+	}
+	for _, tc := range []struct {
+		row       int
+		want      int
+		wantOK    bool
+		wantAlpha float32
+	}{
+		{row: -1, wantOK: false},
+		{row: 0, want: 0, wantOK: true, wantAlpha: 0.5},
+		{row: rowsPerGranule - 1, want: 0, wantOK: true, wantAlpha: 0.5},
+		{row: rowsPerGranule, want: 1, wantOK: true, wantAlpha: 0.25},
+		{row: rowsPerGranule*2 - 1, want: 1, wantOK: true, wantAlpha: 0.25},
+		{row: rowsPerGranule * 2, wantOK: false},
+	} {
+		alpha, granule, ok := lookup.AlphaForRow(tc.row)
+		if ok != tc.wantOK || granule != tc.want || (ok && alpha != tc.wantAlpha) {
+			t.Fatalf("AlphaForRow(%d)=(alpha=%v granule=%d ok=%v) want (alpha=%v granule=%d ok=%v)", tc.row, alpha, granule, ok, tc.wantAlpha, tc.want, tc.wantOK)
+		}
+	}
+	var scales [2]float64
+	if !prepareColumnVectorGraphScalarU8AlphaScoreScales(scales[:], lookup, 0.75) {
+		t.Fatal("prepare alpha score scales failed")
+	}
+	if got, want := scales[0], float64(0.75*0.5)/columnVectorGraphScalarU8CodeScale; got != want {
+		t.Fatalf("scale[0]=%v want %v", got, want)
+	}
+	if got, want := scales[1], float64(0.75*0.25)/columnVectorGraphScalarU8CodeScale; got != want {
+		t.Fatalf("scale[1]=%v want %v", got, want)
+	}
+	_ = q
+}
+
+func TestColumnGraphScalarU8AlphaLookupTailGranuleEdges2866(t *testing.T) {
+	rowsPerGranule := typedColumnDefaultRowsPerGranule()
+	if rowsPerGranule < 2 {
+		t.Fatalf("rows_per_granule=%d want >=2", rowsPerGranule)
+	}
+	const dims = 1
+	tailRows := 1
+	rowCount := rowsPerGranule + tailRows
+	codes := bytes.Repeat([]byte{128}, rowCount*dims)
+	_, _, _, lookup, _ := prepareScalarU8AlphaPreparedForTest2844(t, dims, codes, []float32{0.5, 1}, []uint32{uint32(rowsPerGranule), uint32(tailRows)})
+	if lookup.uniformGranuleRows != rowsPerGranule {
+		t.Fatalf("uniformGranuleRows=%d want first full granule size %d", lookup.uniformGranuleRows, rowsPerGranule)
+	}
+	if granule, ok := lookup.granuleForRow(rowsPerGranule - 1); !ok || granule != 0 {
+		t.Fatalf("last full row granule=%d ok=%v want granule 0", granule, ok)
+	}
+	if granule, ok := lookup.granuleForRow(rowsPerGranule); !ok || granule != 1 {
+		t.Fatalf("tail row granule=%d ok=%v want granule 1", granule, ok)
+	}
+	if _, ok := lookup.granuleForRow(rowCount); ok {
+		t.Fatalf("row %d unexpectedly resolved", rowCount)
+	}
+}
+
 func TestColumnGraphScalarU8AlphaPreparedTraversalQuantizedOnlyAndRerankUseAlpha2844(t *testing.T) {
 	rows := []columnGraphRebuildInputRowV2A{
 		{id: "doc-exact", vector: []float32{1, 0, 0}},

--- a/TreeDB/collections/column_vector_graph_quantized_scorer.go
+++ b/TreeDB/collections/column_vector_graph_quantized_scorer.go
@@ -105,6 +105,10 @@ type columnVectorGraphScalarU8QuantizedScorer struct {
 	// alphaLookup is non-nil only for scalar_u8 per_granule_alpha scoring.
 	alphaLookup *columnVectorGraphScalarU8AlphaLookup
 	queryAlpha  float32
+	// alphaScoreScales stores queryAlpha*granuleAlpha/(255*255), indexed by
+	// alpha granule. It aliases caller-owned scratch and is valid for the
+	// lifetime of the prepared search using that scratch.
+	alphaScoreScales []float64
 }
 
 func (r *columnVectorGraphPhysicalRowReader) prepareScalarU8QuantizedScorer(mode columnVectorGraphNativeSearchQueryMode, indexName string, query []float32, queryInvNorm float32, scratch *columnVectorGraphNativeSearchScratch) (columnVectorGraphScalarU8QuantizedScorer, error) {
@@ -173,6 +177,10 @@ func (r *columnVectorGraphPhysicalRowReader) prepareScalarU8QuantizedScorer(mode
 		if alphaErr != nil {
 			return columnVectorGraphScalarU8QuantizedScorer{}, fmt.Errorf("%w: %w: column_graph %q query_mode=%s quantized index %q scalar_u8 query alpha: %v", ErrVectorIndexSearchUnavailable, errColumnVectorGraphQuantizedAssetInvalid, r.def.Name, mode.String(), indexName, alphaErr)
 		}
+		scratch.quantizedScalarU8AlphaScales = ensureColumnVectorGraphNativeFloat64Scratch(scratch.quantizedScalarU8AlphaScales, alphaLookup.granules)
+		if !prepareColumnVectorGraphScalarU8AlphaScoreScales(scratch.quantizedScalarU8AlphaScales[:alphaLookup.granules], alphaLookup, queryAlpha) {
+			return columnVectorGraphScalarU8QuantizedScorer{}, fmt.Errorf("%w: %w: column_graph %q query_mode=%s quantized index %q scalar_u8 alpha score scales unavailable", ErrVectorIndexSearchUnavailable, errColumnVectorGraphQuantizedAssetInvalid, r.def.Name, mode.String(), indexName)
+		}
 	}
 	centeredScratch := resizeColumnVectorGraphNativeScalarU8CenteredScratch(scratch.quantizedQueryCentered, r.def.Dimensions)[:r.def.Dimensions]
 	var centeredSum int64
@@ -191,7 +199,11 @@ func (r *columnVectorGraphPhysicalRowReader) prepareScalarU8QuantizedScorer(mode
 		return columnVectorGraphScalarU8QuantizedScorer{}, fmt.Errorf("%w: %w: column_graph %q query_mode=%s quantized index %q centered scalar_u8 query unavailable", ErrVectorIndexSearchUnavailable, errColumnVectorGraphQuantizedAssetInvalid, r.def.Name, mode.String(), indexName)
 	}
 	scratch.quantizedQueryCentered = centeredScratch
-	return columnVectorGraphScalarU8QuantizedScorer{indexName: indexName, dims: r.def.Dimensions, codeRows: codeRows, codePayload: codePayload, centeredQuery: centeredQuery, alphaLookup: alphaLookup, queryAlpha: queryAlpha}, nil
+	var alphaScoreScales []float64
+	if alphaLookup != nil {
+		alphaScoreScales = scratch.quantizedScalarU8AlphaScales[:alphaLookup.granules]
+	}
+	return columnVectorGraphScalarU8QuantizedScorer{indexName: indexName, dims: r.def.Dimensions, codeRows: codeRows, codePayload: codePayload, centeredQuery: centeredQuery, alphaLookup: alphaLookup, queryAlpha: queryAlpha, alphaScoreScales: alphaScoreScales}, nil
 }
 
 func (s *columnVectorGraphScalarU8QuantizedScorer) scoreOrdinal(ordinal int, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) (float64, error) {
@@ -238,6 +250,9 @@ func (s *columnVectorGraphScalarU8QuantizedScorer) validatePrepared() error {
 	}
 	if s.alphaLookup != nil {
 		if !validColumnVectorGraphScalarU8Alpha(s.queryAlpha) || !s.alphaLookup.validShapeForRows(s.codeRows.Rows()) {
+			return fmt.Errorf("%w: column_graph quantized scalar_u8 alpha scorer is unavailable", ErrVectorIndexSearchUnavailable)
+		}
+		if len(s.alphaScoreScales) > 0 && len(s.alphaScoreScales) != s.alphaLookup.granules {
 			return fmt.Errorf("%w: column_graph quantized scalar_u8 alpha scorer is unavailable", ErrVectorIndexSearchUnavailable)
 		}
 	}
@@ -298,15 +313,47 @@ func (s *columnVectorGraphScalarU8QuantizedScorer) scoreRowIDsPrepared(rowIDs []
 }
 
 func (s *columnVectorGraphScalarU8QuantizedScorer) scoreFromDotRowID(dot int64, rowID uint32) (float64, bool) {
-	score := scalarU8QuantizedCosineScoreFromDot(dot)
 	if s == nil || s.alphaLookup == nil {
-		return score, true
+		return scalarU8QuantizedCosineScoreFromDot(dot), true
 	}
-	alpha, _, ok := s.alphaLookup.AlphaForRow(int(rowID))
+	row := int(rowID)
+	if len(s.alphaScoreScales) == s.alphaLookup.granules {
+		if row < 0 || row >= s.alphaLookup.rows {
+			return 0, false
+		}
+		if uniform := s.alphaLookup.uniformGranuleRows; uniform > 0 {
+			granule := row / uniform
+			if granule >= len(s.alphaScoreScales) {
+				granule = len(s.alphaScoreScales) - 1
+			}
+			return float64(dot) * s.alphaScoreScales[granule], true
+		}
+		granule, ok := s.alphaLookup.granuleForRow(row)
+		if !ok {
+			return 0, false
+		}
+		return float64(dot) * s.alphaScoreScales[granule], true
+	}
+	alpha, _, ok := s.alphaLookup.AlphaForRow(row)
 	if !ok {
 		return 0, false
 	}
-	return score * float64(s.queryAlpha) * float64(alpha), true
+	return scalarU8QuantizedCosineScoreFromDot(dot) * float64(s.queryAlpha) * float64(alpha), true
+}
+
+func prepareColumnVectorGraphScalarU8AlphaScoreScales(dst []float64, lookup *columnVectorGraphScalarU8AlphaLookup, queryAlpha float32) bool {
+	if lookup == nil || len(dst) != lookup.granules || len(lookup.alphaPayload) != lookup.granules*4 || !validColumnVectorGraphScalarU8Alpha(queryAlpha) {
+		return false
+	}
+	queryScale := float64(queryAlpha) / columnVectorGraphScalarU8CodeScale
+	for granule := 0; granule < lookup.granules; granule++ {
+		alpha := math.Float32frombits(binary.LittleEndian.Uint32(lookup.alphaPayload[granule*4 : granule*4+4]))
+		if !validColumnVectorGraphScalarU8Alpha(alpha) {
+			return false
+		}
+		dst[granule] = queryScale * float64(alpha)
+	}
+	return true
 }
 
 func columnVectorGraphScalarU8QueryAlpha(q QuantizedVectorIndexDefinition, query []float32, queryInvNorm float32, scratch *columnVectorGraphNativeSearchScratch) (float32, error) {

--- a/TreeDB/collections/column_vector_graph_search.go
+++ b/TreeDB/collections/column_vector_graph_search.go
@@ -1050,34 +1050,35 @@ type columnVectorGraphSearchCandidate struct {
 // It is not concurrency-safe. Parallel searches over immutable graph assets are
 // valid with one reader and one scratch per worker.
 type columnVectorGraphNativeSearchScratch struct {
-	scoreScratch             columnPhysicalRowReaderScratch
-	expandScratch            columnPhysicalRowReaderScratch
-	resultScratch            columnPhysicalRowReaderScratch
-	visitMarks               []uint64
-	visitEpoch               uint64
-	frontier                 []columnVectorGraphSearchCandidate
-	top                      []columnVectorGraphSearchCandidate
-	rawDot                   *columnVectorGraphRawDotSearchScratch
-	results                  []columnVectorGraphNativeSearchResult
-	idBuffers                [][]byte
-	resultIDViews            [][]byte
-	resultOrder              []int
-	resultOrdinals           []int
-	resultRowRefs            []DocumentRowRef
-	resultHasRefs            []bool
-	scoreTileOrdinals        []int
-	scoreTileScores          []float64
-	scoreTileRowIDs          []uint32
-	scoreTileDots            []float32
-	scoreTileQuantizedDots   []int64
-	quantizedQueryCentered   []vectorops.ScalarU8CenteredCode
-	quantizedRabitQWorkspace rabitq.Workspace
-	quantizedBRQWorkspace    brq.Workspace
-	preparedQuantizedPlane   columnHNSWPreparedQuantizedScorePlane
-	preparedScalarU8Plane    columnHNSWPreparedScalarU8ScorePlane
-	preparedTraversalStats   columnVectorGraphNativeSearchStats
-	wavefrontCandidates      []columnVectorGraphSearchCandidate
-	searchPlan               columnVectorGraphSearchPlan
+	scoreScratch                 columnPhysicalRowReaderScratch
+	expandScratch                columnPhysicalRowReaderScratch
+	resultScratch                columnPhysicalRowReaderScratch
+	visitMarks                   []uint64
+	visitEpoch                   uint64
+	frontier                     []columnVectorGraphSearchCandidate
+	top                          []columnVectorGraphSearchCandidate
+	rawDot                       *columnVectorGraphRawDotSearchScratch
+	results                      []columnVectorGraphNativeSearchResult
+	idBuffers                    [][]byte
+	resultIDViews                [][]byte
+	resultOrder                  []int
+	resultOrdinals               []int
+	resultRowRefs                []DocumentRowRef
+	resultHasRefs                []bool
+	scoreTileOrdinals            []int
+	scoreTileScores              []float64
+	scoreTileRowIDs              []uint32
+	scoreTileDots                []float32
+	scoreTileQuantizedDots       []int64
+	quantizedQueryCentered       []vectorops.ScalarU8CenteredCode
+	quantizedScalarU8AlphaScales []float64
+	quantizedRabitQWorkspace     rabitq.Workspace
+	quantizedBRQWorkspace        brq.Workspace
+	preparedQuantizedPlane       columnHNSWPreparedQuantizedScorePlane
+	preparedScalarU8Plane        columnHNSWPreparedScalarU8ScorePlane
+	preparedTraversalStats       columnVectorGraphNativeSearchStats
+	wavefrontCandidates          []columnVectorGraphSearchCandidate
+	searchPlan                   columnVectorGraphSearchPlan
 }
 
 func (s *columnVectorGraphNativeSearchScratch) prepare(rowCount, dimensions, degree, topK, efSearch, scoreTileCapacity, wavefrontWidth int) error {


### PR DESCRIPTION
Closes #2866.\n\nParent: #2864. Depends on baseline #2865/#2870.\n\n## Summary\n- precompute query-local per-granule alpha score scales in search scratch\n- use the precomputed scale from the score loop, avoiding repeated alpha decode and query-alpha multiply/divide\n- add focused uniform/tail granule lookup edge tests\n\n## Tests\n- `GOMAXPROCS=8 GOWORK=off go test ./TreeDB/collections -run 'TestColumnGraphScalarU8Alpha' -count=1`\n- `GOMAXPROCS=8 GOWORK=off go test ./TreeDB/internal/quantizedasset ./TreeDB/collections -count=1`\n\n## Benchmarks / profiles\n- Baseline from #2865: alpha focused qonly c=1 26,211 ns/op, 0 B/op, 0 allocs/op; legacy 24,355 ns/op.\n- This PR focused alpha qonly c=1: 25,211 ns/op, 0 B/op, 0 allocs/op; artifact `/tmp/alpha_2866b_20260619_090841/`.\n- Focused legacy qonly c=1 on this branch: 23,917 ns/op, 0 B/op, 0 allocs/op; artifact `/tmp/alpha_2866_20260619_090702/`.\n- Production scalar rows smoke: `/tmp/alpha_2866_prod2_20260619_090916/collection_scalar_rows.txt` (alpha rows retain 100% recall and 0 B/op / 0 allocs/op).\n\n## Regression gate\n- No default change; omitted `scalar_u8_calibration` remains legacy.\n- Alpha fail-closed validation remains before scorer construction.\n\n## AI review\n- Not requested yet; local tests and benchmark evidence are included for coordinator review.