### PR TITLE
Document TreeDB text-v2 100k and 1M evidence

### DIFF
--- a/docs/benchmarks/treedb_text_hybrid_industry_scoreboard.md
+++ b/docs/benchmarks/treedb_text_hybrid_industry_scoreboard.md
@@ -100,6 +100,38 @@ This adds the 100k text-v2 blockmax/common-term rows. 100k hybrid/vector rows
 remain opt-in and should be planned explicitly before long local or service
 runs.
 
+### Latest local 100k scoreboard capture (2026-06-19)
+
+Artifact root: `/tmp/gomap_text_hybrid_scoreboard_100k_20260619_085040`
+
+Command:
+
+```sh
+RUN_100K=true TEXT_100K_BENCHTIME=1x TEXT_100K_COUNT=1 \
+RUN_DIR=/tmp/gomap_text_hybrid_scoreboard_100k_20260619_085040 \
+scripts/bench_text_hybrid_scoreboard.sh
+```
+
+Host/context: Apple M3, 8 CPUs, `go1.26.0 darwin/arm64`, branch `main`, commit
+`7f0e68d9c46afb9d54152d8bc558ebcdc89fd468`. The run was on an interactive
+laptop with load averages around `3.66 4.40 4.25`; treat it as local evidence,
+not an industry-parity claim.
+
+Key rows from `scoreboard.md`:
+
+| row | docs | ns/op | ops/sec | B/op | allocs/op | guardrail counters |
+| --- | ---: | ---: | ---: | ---: | ---: | --- |
+| TreeDB blockmax common top-k | 10k | 259,986 | 3,846.4 | 205,304 | 409 | docs_fetched=0, fail_closed=0, postings_scanned=1,280, blocks_visited=10, blocks_skipped=69 |
+| TreeDB exhaustive common top-k | 10k | 6,435,319 | 155.4 | 4,630,901 | 20,988 | docs_fetched=0, fail_closed=0, postings_scanned=10,000 |
+| TreeDB blockmax common top-k | 100k | 2,535,375 | 394.4 | 1,964,888 | 3,146 | docs_fetched=0, fail_closed=0, postings_scanned=12,544, blocks_visited=98, blocks_skipped=684 |
+| TreeDB exhaustive common top-k | 100k | 75,703,333 | 13.2 | 45,237,440 | 208,483 | docs_fetched=0, fail_closed=0, postings_scanned=100,000 |
+| SQLite FTS5 rowid+bm25 baseline | 10k | 2,031,922 | 492.1 | — | — | docs_fetched=0, fail_closed=0 |
+
+This local capture shows TreeDB's v2 block-max common-term row at 100k is about
+`29.9x` faster than its exact exhaustive reference. The SQLite FTS5 row remains
+a useful embedded baseline but is not equivalent to TreeDB BM25F/Lucene-style
+semantics; Lucene, Tantivy, and Bleve rows were still unavailable in this run.
+
 ### Focused multi-term OR/WAND rows (#2730)
 
 For exact multi-term text-v2 serving evidence outside the default scoreboard

--- a/docs/benchmarks/treedb_text_v2_scale_soak_2837.md
+++ b/docs/benchmarks/treedb_text_v2_scale_soak_2837.md
@@ -6,12 +6,17 @@ the stacked branch.
 
 ## Status
 
-A full 10M+ corpus soak was not run in this coordinator session because the
-GitHub queue was saturated with latest-head CI for the phase-2 stack and a 10M
-local run would exceed the interactive merge window. The checked-in scale
-harness remains the intended path for the full artifact; this PR adds the
-current reproduction commands, a 10k smoke artifact, and explicit risk notes so
-#2837 does not silently imply production-scale parity.
+The checked-in scale harness is now validated beyond the original #2837 10k
+smoke: a 1M local scale run completed on `main` at
+`7f0e68d9c46afb9d54152d8bc558ebcdc89fd468` and is summarized below. A 10M
+selected run was started with the documented approval-gated command at
+`/tmp/gomap_text_hybrid_scale_10m_20260619_085923`; do not cite the 10M run as
+passing evidence until its `scale_report.md` exists and the guardrails are
+checked.
+
+The 1M run is scale evidence, not an industry-parity claim: the corpus is
+synthetic, the host was an interactive laptop, and external Lucene/Tantivy/Bleve
+comparison rows are still unavailable.
 
 ## 10k smoke artifact
 
@@ -31,6 +36,75 @@ GOWORK=off TREEDB_TEXT_V2_SCALE_DOCS=10000 TREEDB_TEXT_V2_SCALE_QUERIES=64 \
 | score_only_common_no_docs | 15,085,012 | 5,686,114 | 30,120 | 0 | 0 | 10,000 | 10,000 |
 | multi_term_or_no_docs | 19,410,268 | 5,926,320 | 40,128 | 0 | 0 | 10,000 | 20,000 |
 | multi_term_and_no_docs | 18,427,475 | 5,926,338 | 40,129 | 0 | 0 | 10,000 | 20,000 |
+
+## 1M local scale artifact
+
+Artifact root: `/tmp/gomap_text_hybrid_scale_1m_20260619_085339`
+
+Command:
+
+```sh
+RUN_DIR=/tmp/gomap_text_hybrid_scale_1m_20260619_085339 \
+RUN_1M=true RUN_SMOKE=false \
+ONE_M_ROWS=1000000 ONE_M_QUERIES=25 ONE_M_BATCH_SIZE=16384 \
+ONE_M_BACKFILL_ROWS=100000 \
+ONE_M_MAINTENANCE_UPDATES=10000 ONE_M_MAINTENANCE_DELETES=5000 \
+ONE_M_CANDIDATE_LIMIT=65536 \
+DIMS=16 M=8 EF_CONSTRUCTION=128 EF_SEARCH=128 \
+TOP_K=10 READERS=4 \
+scripts/bench_text_hybrid_scale.sh
+```
+
+Host/context: Apple M3, 8 CPUs, `go1.26.0 darwin/arm64`, branch `main`, commit
+`7f0e68d9c46afb9d54152d8bc558ebcdc89fd468`.
+
+### 1M load/storage
+
+| phase | seconds | rows/s | storage bytes | bytes/doc | text bytes/doc | vector native bytes |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| load | 73.187 | 13,663.6 | 1,087,374,509 | 1,087.4 | 109.5 | 594,042,904 |
+| backfill fixture | 0.793 | 126,128.7 | 64,225,653 | 642.3 | 96.3 | 0 |
+
+Load breakdown: generation `1.121s`, insert `10.474s`, vector rebuild
+`60.077s`, checkpoint `0.294s`. Vector rebuild dominated this mixed
+text/vector scale row, so text-only ingest conclusions should use a text-only
+companion benchmark.
+
+Text-v2 lane bytes/doc after load: docid `21.0`, docmap `19.1`, postings
+`62.2`, norms `7.1`, positions `0.0`, terms `0.0`, status/format `0.0`.
+
+### 1M retrieval latency
+
+| row | p50 | p95 | p99 | mean | ops/sec | guardrail | key counters |
+| --- | ---: | ---: | ---: | ---: | ---: | --- | --- |
+| text_common_score_only | 579.960ms | 665.410ms | 672.957ms | 591.458ms | 1.7 | PASS | docs_fetched=0, fail_closed=0, postings=500,000, blocks_visited=15,625, scored=500,000 |
+| text_rare_score_only | 6.639ms | 7.960ms | 7.965ms | 6.954ms | 143.8 | PASS | docs_fetched=0, fail_closed=0, postings=1,004, blocks_visited=62, scored=1,004 |
+| text_multi_term_and_score_only | 817.554ms | 1.155s | 1.453s | 870.334ms | 1.1 | PASS | docs_fetched=0, fail_closed=0, postings=1,000,000, blocks_visited=31,250, scored=500,000 |
+| text_multi_term_or_score_only | 742.687ms | 954.785ms | 1.129s | 758.433ms | 1.3 | PASS | docs_fetched=0, fail_closed=0, postings=1,000,000, blocks_visited=31,250, scored=500,000 |
+| hybrid_text_only_no_docs | 757.478ms | 901.653ms | 914.127ms | 773.759ms | 1.3 | PASS | docs_fetched=0, fail_closed=0, text_candidates=65,536 |
+| hybrid_text_scalar_no_docs | 217.200ms | 236.491ms | 242.767ms | 218.762ms | 4.6 | PASS | docs_fetched=0, fail_closed=0, text_candidates=62,500, scalar_prefilter=62,500 |
+| hybrid_text_vector_no_docs | 1.561s | 1.831s | 1.849s | 1.595s | 0.6 | PASS | docs_fetched=0, fail_closed=0, text_candidates=65,536, vector_candidates=65,536 |
+| hybrid_text_vector_scalar_no_docs | 1.077s | 1.796s | 2.034s | 1.199s | 0.8 | PASS | docs_fetched=0, fail_closed=0, text_candidates=62,500, vector_candidates=65,536 |
+
+Reopen: close `0.005s`, open `1.577s`, open collection `0.001s`, probe
+`3.377s`, total `4.962s`.
+
+Concurrent serving/write sanity: readers `4`, queries `25`, writes `1024`,
+throughput `2.7 ops/s`, p50 `1.336s`, p95 `1.840s`, p99 `1.843s`, writer
+`0.129s`, guardrail PASS.
+
+Maintenance/rewrite: updates `10,000` in `2.164s`, deletes `5,000` in `0.061s`,
+rewrite `4.996s`, checkpoint `0.121s`; read `350,369` blocks, wrote `58,724`,
+deleted `350,369`, purged `112,516` stale postings; postcondition PASS.
+
+### 1M interpretation
+
+The guardrails passed across all reported rows, so the run is valid
+zero-document candidate-generation evidence. The main performance warning is
+that high-document-frequency text rows still score very large candidate sets at
+1M (`500k` scored for common and OR/AND rows). Rare-term latency is much better,
+and scalar filtering materially reduces the text-only hybrid row, but high-DF
+common/multi-term serving remains the primary scale optimization target.
 
 ## Full-scale reproduction plan
 
@@ -57,10 +131,10 @@ Recommended companion captures:
 
 ## Risk notes
 
-- This PR does not claim 10M+ parity; it documents that the full soak remains a
-  required production-readiness artifact.
-- The 10k smoke confirms the no-document-fetch and fail-closed counters for the
-  current harness shapes only.
+- This note does not claim 10M+ parity until a completed 10M `scale_report.md`
+  is linked and reviewed.
+- The 1M run confirms no-document-fetch and fail-closed guardrails for the
+  reported synthetic scale shapes.
 - Any future claim about 10M/50M behavior should link the full artifact root and
   update this note with p50/p95/p99, storage growth, rewrite debt, and memory
   high-water data.


### PR DESCRIPTION
## Scope

Closes #2879.

- Update `docs/benchmarks/treedb_text_hybrid_industry_scoreboard.md` with the 2026-06-19 local 100k scoreboard summary.
- Update `docs/benchmarks/treedb_text_v2_scale_soak_2837.md` with the completed 1M local scale summary.
- Record the selected 10M run root only as in-progress/not yet citeable.

## Docs-only status

Documentation-only PR under `docs/benchmarks/`. No implementation changes, no benchmark harness changes, and no vector rebuild optimization. Wording is intentionally scoped to local synthetic evidence and does not claim industry parity.

## Benchmark artifacts referenced (not rerun in this PR)

| Artifact | Status | Notes |
| --- | --- | --- |
| `/tmp/gomap_text_hybrid_scoreboard_100k_20260619_085040/scoreboard.md` | referenced | 100k block-max/exhaustive scoreboard rows from commit `7f0e68d9c46afb9d54152d8bc558ebcdc89fd468` |
| `/tmp/gomap_text_hybrid_scale_1m_20260619_085339/scale_1m/scale_report.md` | referenced | completed 1M scale artifact with reported guardrails passing |
| `/tmp/gomap_text_hybrid_scale_10m_20260619_085923` | in progress / not citeable | checked before PR; no completed `scale_report.md` found |

No benchmark rerun was performed for this docs-only change; the PR summarizes existing local artifacts.

## Validation

- `git diff --check` ✅
- Markdown diff reviewed for table column formatting, command fences, caveats, and no overclaim ✅
- Lightweight local Markdown sanity script checked balanced fences/table column counts for the two edited files ✅
- Optional docs lint: not run because no local `markdownlint`, `markdownlint-cli2`, or `mdl` binary was available; change is docs-only benchmark notes.

## CI status

Latest head: `632c06b6f3e50dedbb369083e3c2f2d9f1c26868`. GitHub Actions/checks are passing on this head.

## 10M caveat

The 10M selected run root is mentioned only as started/in progress. It must not be cited as passing evidence until a completed `scale_report.md` exists and guardrails are reviewed.

## AI review status

- Codex: requested via `@codex review` after validation at latest head; no findings posted yet.
- Copilot: requested via `@copilot review` after validation at latest head; no findings posted yet.
- CodeRabbit: requested via `@coderabbitai review`; bot reported review finished/skipped after a rate-limit notice, with no findings blocking this docs-only PR.
