### PR TITLE
treedb: streamline scalar_u8 query code preparation

### DIFF
--- a/TreeDB/collections/column_vector_graph_quantized_asset.go
+++ b/TreeDB/collections/column_vector_graph_quantized_asset.go
@@ -1225,14 +1225,17 @@ func columnVectorGraphScalarU8Code(value float32) byte {
 	if math.IsNaN(float64(value)) {
 		return 0
 	}
-	scaled := math.Round((float64(value) + 1.0) * 127.5)
-	if scaled < 0 {
+	scaled := (float64(value) + 1.0) * 127.5
+	if scaled <= 0 {
 		return 0
 	}
-	if scaled > 255 {
+	if scaled >= 255 {
 		return 255
 	}
-	return byte(scaled)
+	// For the non-negative unclamped range, math.Round(scaled) is exactly
+	// floor(scaled+0.5). Avoid the generic math.Round call in query-prep hot
+	// loops while preserving the scalar_u8 v1 byte mapping.
+	return byte(scaled + 0.5)
 }
 
 func columnVectorGraphQuantizedAssetStateType(q QuantizedVectorIndexDefinition) (logicalType, physicalEncoding string) {

--- a/TreeDB/collections/column_vector_graph_quantized_scorer.go
+++ b/TreeDB/collections/column_vector_graph_quantized_scorer.go
@@ -183,13 +183,13 @@ func (r *columnVectorGraphPhysicalRowReader) prepareScalarU8QuantizedScorer(mode
 		}
 	}
 	centeredScratch := resizeColumnVectorGraphNativeScalarU8CenteredScratch(scratch.quantizedQueryCentered, r.def.Dimensions)[:r.def.Dimensions]
+	queryCodeScale := queryInvNorm
+	if alphaLookup != nil {
+		queryCodeScale *= 1 / queryAlpha
+	}
 	var centeredSum int64
 	for i, value := range query {
-		codeValue := value * queryInvNorm
-		if alphaLookup != nil {
-			codeValue /= queryAlpha
-		}
-		code := columnVectorGraphScalarU8Code(codeValue)
+		code := columnVectorGraphScalarU8Code(value * queryCodeScale)
 		centered := vectorops.ScalarU8CenteredValue(code)
 		centeredScratch[i] = centered
 		centeredSum += int64(centered)


### PR DESCRIPTION
Closes #2867.\n\nParent: #2864. Follows baseline #2865 and lookup-scale optimization #2866.\n\n## Summary\n- precompute the scalar_u8 query code scale once per prepared scorer\n- remove the per-dimension alpha branch/divide from query code generation\n- replace generic `math.Round` in `columnVectorGraphScalarU8Code` with the equivalent non-negative floor(x+0.5) mapping, preserving the existing scalar_u8 v1 rounding tests\n\n## Tests\n- `GOMAXPROCS=8 GOWORK=off go test ./TreeDB/internal/vectorops ./TreeDB/collections -run 'TestColumnGraphScalarU8CodeMatchesRoundReference|TestColumnGraphScalarU8AlphaQuantileSparseQuery|TestColumnGraphScalarU8Alpha' -count=1`\n- `GOMAXPROCS=8 GOWORK=off go test ./TreeDB/internal/vectorops ./TreeDB/collections -count=1`\n\n## Benchmarks / profiles\n- Baseline from #2865: alpha focused qonly c=1 26,211 ns/op, 0 B/op, 0 allocs/op; legacy 24,355 ns/op.\n- After #2866: alpha focused qonly c=1 25,211 ns/op.\n- This PR focused alpha qonly c=1: 23,620 ns/op, 0 B/op, 0 allocs/op; legacy qonly c=1: 21,774 ns/op, 0 B/op, 0 allocs/op. Artifact: `/tmp/alpha_2867_20260619_092229/`.\n- Profile attribution: `columnVectorGraphScalarU8Code` down to ~2.26% cumulative in the alpha hot profile; `prepareScalarU8QuantizedScorer` ~10.17% cumulative.\n\n## Regression gate\n- No default change; omitted `scalar_u8_calibration` remains legacy.\n- Existing NaN/clamp/rounding reference test passes.\n\n## AI review\n- Not requested yet; local tests and benchmark evidence are included for coordinator review.