### PR TITLE
Reduce text-v2 posting decode allocations

### DIFF
--- a/TreeDB/collections/hybrid_executor.go
+++ b/TreeDB/collections/hybrid_executor.go
@@ -10,6 +10,11 @@ import (
 
 const (
 	hybridDefaultCandidateLimitMultiplier = 4
+	// hybridCandidatePreallocLimit caps speculative combined text+vector
+	// candidate preallocation. Candidate limits are caller-controlled; keep the
+	// optimization bounded and let appends grow proportionally to actual source
+	// results for unusually large requests.
+	hybridCandidatePreallocLimit = 4 * 1024
 	// hybridScalarDefaultLookupLimit is the finite indexed allow-set guardrail
 	// for default scalar prefilters. Broader filters still fail closed as
 	// scalar_filter_unbounded instead of falling back to document scans.
@@ -357,11 +362,8 @@ func (c *Collection) hybridScalarIndexExists(indexName string) (bool, error) {
 
 func (c *Collection) hybridSearchCandidates(plan hybridSearchExecutionPlan, allowSet hybridScalarAllowSet) ([]HybridSearchCandidate, HybridSearchStats, error) {
 	var out []HybridSearchCandidate
-	if plan.text != nil && plan.vector != nil {
-		capHint := plan.text.CandidateLimit + plan.vector.CandidateLimit
-		if capHint > 0 {
-			out = make([]HybridSearchCandidate, 0, capHint)
-		}
+	if capHint := hybridSearchCandidatePreallocHint(plan); capHint > 0 {
+		out = make([]HybridSearchCandidate, 0, capHint)
 	}
 	var stats HybridSearchStats
 	runText := func() error {
@@ -406,6 +408,26 @@ func (c *Collection) hybridSearchCandidates(plan hybridSearchExecutionPlan, allo
 		}
 	}
 	return out, stats, nil
+}
+
+func hybridSearchCandidatePreallocHint(plan hybridSearchExecutionPlan) int {
+	if plan.text == nil || plan.vector == nil {
+		return 0
+	}
+	hint := 0
+	if plan.text.CandidateLimit > 0 {
+		hint = plan.text.CandidateLimit
+		if hint >= hybridCandidatePreallocLimit {
+			return hybridCandidatePreallocLimit
+		}
+	}
+	if plan.vector.CandidateLimit > 0 {
+		if plan.vector.CandidateLimit >= hybridCandidatePreallocLimit-hint {
+			return hybridCandidatePreallocLimit
+		}
+		hint += plan.vector.CandidateLimit
+	}
+	return hint
 }
 
 func appendHybridSearchCandidates(dst, src []HybridSearchCandidate) []HybridSearchCandidate {

--- a/TreeDB/collections/hybrid_executor.go
+++ b/TreeDB/collections/hybrid_executor.go
@@ -357,6 +357,12 @@ func (c *Collection) hybridScalarIndexExists(indexName string) (bool, error) {
 
 func (c *Collection) hybridSearchCandidates(plan hybridSearchExecutionPlan, allowSet hybridScalarAllowSet) ([]HybridSearchCandidate, HybridSearchStats, error) {
 	var out []HybridSearchCandidate
+	if plan.text != nil && plan.vector != nil {
+		capHint := plan.text.CandidateLimit + plan.vector.CandidateLimit
+		if capHint > 0 {
+			out = make([]HybridSearchCandidate, 0, capHint)
+		}
+	}
 	var stats HybridSearchStats
 	runText := func() error {
 		if plan.text == nil {
@@ -367,7 +373,7 @@ func (c *Collection) hybridSearchCandidates(plan hybridSearchExecutionPlan, allo
 		if err != nil {
 			return hybridCandidateSourceError{source: HybridCandidateSourceText, err: err}
 		}
-		out = append(out, response.Candidates...)
+		out = appendHybridSearchCandidates(out, response.Candidates)
 		return nil
 	}
 	runVector := func() error {
@@ -379,7 +385,7 @@ func (c *Collection) hybridSearchCandidates(plan hybridSearchExecutionPlan, allo
 		if err != nil {
 			return hybridCandidateSourceError{source: HybridCandidateSourceVector, err: err}
 		}
-		out = append(out, response.Candidates...)
+		out = appendHybridSearchCandidates(out, response.Candidates)
 		return nil
 	}
 
@@ -402,11 +408,21 @@ func (c *Collection) hybridSearchCandidates(plan hybridSearchExecutionPlan, allo
 	return out, stats, nil
 }
 
+func appendHybridSearchCandidates(dst, src []HybridSearchCandidate) []HybridSearchCandidate {
+	if len(src) == 0 {
+		return dst
+	}
+	if dst == nil {
+		return src
+	}
+	return append(dst, src...)
+}
+
 func hybridFilterCandidatesByScalarAllowSet(candidates []HybridSearchCandidate, allowSet hybridScalarAllowSet, stats *HybridSearchStats) []HybridSearchCandidate {
 	if allowSet == nil {
 		return candidates
 	}
-	out := make([]HybridSearchCandidate, 0, len(candidates))
+	out := candidates[:0]
 	for _, candidate := range candidates {
 		if stats != nil {
 			stats.ScalarPostfilterChecks++
@@ -435,7 +451,7 @@ func hybridFilterResultsByScalarAllowSet(results []HybridSearchResult, allowSet 
 	if allowSet == nil {
 		return results
 	}
-	filtered := make([]HybridSearchResult, 0, len(results))
+	filtered := results[:0]
 	for _, result := range results {
 		if stats != nil {
 			stats.ScalarPostfilterChecks++

--- a/TreeDB/collections/hybrid_search_executor_test.go
+++ b/TreeDB/collections/hybrid_search_executor_test.go
@@ -103,6 +103,27 @@ func TestSearchHybridExecutorTextVectorOverlapAndBoundedFetch2505(t *testing.T) 
 	}
 }
 
+func TestHybridSearchCandidatePreallocHintBoundsLimits2876(t *testing.T) {
+	plan := hybridSearchExecutionPlan{
+		text:   &HybridTextQuery{CandidateLimit: 64},
+		vector: &HybridVectorQuery{CandidateLimit: 64},
+	}
+	if got := hybridSearchCandidatePreallocHint(plan); got != 128 {
+		t.Fatalf("cap hint=%d want exact small combined limit", got)
+	}
+
+	plan.text.CandidateLimit = maxCollectionInt
+	plan.vector.CandidateLimit = maxCollectionInt
+	if got := hybridSearchCandidatePreallocHint(plan); got != hybridCandidatePreallocLimit {
+		t.Fatalf("cap hint=%d want bounded limit %d", got, hybridCandidatePreallocLimit)
+	}
+
+	plan.vector = nil
+	if got := hybridSearchCandidatePreallocHint(plan); got != 0 {
+		t.Fatalf("single-source cap hint=%d want 0", got)
+	}
+}
+
 func TestSearchHybridExecutorTextOnlyAndVectorOnly2505(t *testing.T) {
 	_, d, col, def := openHybridSearchExecutorFixture2505(t, []hybridSearchExecutorFixtureRow2505{
 		{id: "doc-a", title: "refund", body: "refund refund", city: "sea", score: 10, vector: []float32{1, 0, 0}},

--- a/TreeDB/collections/text_v2_positions.go
+++ b/TreeDB/collections/text_v2_positions.go
@@ -375,7 +375,7 @@ func readTextV2PositionPostingAtRootCounted(snap *backenddb.Snapshot, catalog *c
 			if err := scanner.Err(); err != nil {
 				return textV2SearchPostingValue{}, false, scanned, err
 			}
-			scratch = scanner.fieldScratch
+			scratch = scanner.scratch
 			it.Next()
 			continue
 		}
@@ -398,7 +398,7 @@ func readTextV2PositionPostingAtRootCounted(snap *backenddb.Snapshot, catalog *c
 		if err := scanner.Err(); err != nil {
 			return textV2SearchPostingValue{}, false, scanned, err
 		}
-		scratch = scanner.fieldScratch
+		scratch = scanner.scratch
 		it.Next()
 	}
 	if err := it.Error(); err != nil {

--- a/TreeDB/collections/text_v2_posting_blocks.go
+++ b/TreeDB/collections/text_v2_posting_blocks.go
@@ -155,6 +155,22 @@ func decodeTextV2PostingBlockKeyForPrefix(raw, prefix []byte) (textV2PostingBloc
 	return decodeTextV2PostingBlockKey(raw)
 }
 
+func decodeTextV2PostingBlockKeySuffixForPrefix(raw, prefix []byte) (uint64, uint64, error) {
+	if !bytes.HasPrefix(raw, prefix) {
+		return 0, 0, errMalformedTextStorage("text-v2 posting block key outside requested term prefix")
+	}
+	suffix := raw[len(prefix):]
+	if len(suffix) != 16 {
+		return 0, 0, errMalformedTextStorage("text-v2 posting block key suffix length %d", len(suffix))
+	}
+	blockStart := binary.BigEndian.Uint64(suffix[:8])
+	blockID := binary.BigEndian.Uint64(suffix[8:])
+	if blockStart == 0 || blockID == 0 {
+		return 0, 0, errMalformedTextStorage("text-v2 posting block key blockStart/blockID cannot be zero")
+	}
+	return blockStart, blockID, nil
+}
+
 func encodeTextV2PostingBlockValue(value textV2PostingBlockValue) []byte {
 	entries := cloneTextV2PostingBlockEntries(value.Entries)
 	slices.SortFunc(entries, func(a, b textV2PostingBlockEntry) int {
@@ -300,12 +316,14 @@ func buildTextV2PostingBlockKVs(term string, entries []textV2PostingBlockEntry, 
 }
 
 type textV2PostingBlockEntryScanner struct {
-	block            textV2PostingBlockValue
-	cur              textCursor
-	remaining        uint32
-	seen             uint32
-	prevOrdinal      uint64
-	fieldScratch     []uint32
+	block        textV2PostingBlockValue
+	cur          textCursor
+	remaining    uint32
+	seen         uint32
+	prevOrdinal  uint64
+	fieldScratch []uint32
+	// scratch is caller-owned decode storage reused only within one iterator/query.
+	scratch          []uint32
 	computed         textV2PostingBlockSummary
 	computedFieldTF  []uint32
 	checksumVerified bool
@@ -314,6 +332,10 @@ type textV2PostingBlockEntryScanner struct {
 }
 
 func newTextV2PostingBlockEntryScanner(raw []byte, scratch []uint32) (*textV2PostingBlockEntryScanner, error) {
+	return initTextV2PostingBlockEntryScanner(nil, raw, scratch)
+}
+
+func initTextV2PostingBlockEntryScanner(dst *textV2PostingBlockEntryScanner, raw []byte, scratch []uint32) (*textV2PostingBlockEntryScanner, error) {
 	if len(raw) == 0 {
 		return nil, errMalformedTextStorage("empty text-v2 posting block value")
 	}
@@ -406,9 +428,15 @@ func newTextV2PostingBlockEntryScanner(raw []byte, scratch []uint32) (*textV2Pos
 		return nil, errMalformedTextStorage("text-v2 posting block field count invalid")
 	}
 	fieldCountInt := int(fieldCount)
-	fieldMetadata := make([]uint32, fieldCountInt*2)
-	maxFieldTF := fieldMetadata[:fieldCountInt:fieldCountInt]
-	computedFieldTF := fieldMetadata[fieldCountInt : fieldCountInt*2 : fieldCountInt*2]
+	scratchNeeded := fieldCountInt * 3
+	if cap(scratch) < scratchNeeded {
+		scratch = make([]uint32, scratchNeeded)
+	}
+	scratch = scratch[:scratchNeeded]
+	fieldScratch := scratch[:fieldCountInt:fieldCountInt]
+	maxFieldTF := scratch[fieldCountInt : fieldCountInt*2 : fieldCountInt*2]
+	computedFieldTF := scratch[fieldCountInt*2 : scratchNeeded : scratchNeeded]
+	clear(computedFieldTF)
 	for i := uint32(0); i < fieldCount; i++ {
 		fieldTF, err := cur.readUvarint()
 		if err != nil {
@@ -441,10 +469,10 @@ func newTextV2PostingBlockEntryScanner(raw []byte, scratch []uint32) (*textV2Pos
 	if entryCount > uint64(cur.remaining())/minEntryBytes {
 		return nil, errMalformedTextStorage("text-v2 posting block entry payload too short")
 	}
-	if cap(scratch) < fieldCountInt {
-		scratch = make([]uint32, fieldCountInt)
+	if dst == nil {
+		dst = &textV2PostingBlockEntryScanner{}
 	}
-	return &textV2PostingBlockEntryScanner{
+	*dst = textV2PostingBlockEntryScanner{
 		block: textV2PostingBlockValue{
 			FormatVersion: uint32(formatVersion),
 			Kind:          kind,
@@ -463,10 +491,12 @@ func newTextV2PostingBlockEntryScanner(raw []byte, scratch []uint32) (*textV2Pos
 		cur:              cur,
 		remaining:        docCount,
 		prevOrdinal:      blockStart - 1,
-		fieldScratch:     scratch[:fieldCountInt],
+		fieldScratch:     fieldScratch,
+		scratch:          scratch,
 		computedFieldTF:  computedFieldTF,
 		checksumVerified: checksumVerified,
-	}, nil
+	}
+	return dst, nil
 }
 
 func (s *textV2PostingBlockEntryScanner) Summary() textV2PostingBlockSummary {
@@ -652,7 +682,7 @@ func scanTextV2PostingBlocksForTerm(
 		if err := scanner.Err(); err != nil {
 			return err
 		}
-		scratch = scanner.fieldScratch
+		scratch = scanner.scratch
 		it.Next()
 	}
 	return it.Error()

--- a/TreeDB/collections/text_v2_posting_blocks_test.go
+++ b/TreeDB/collections/text_v2_posting_blocks_test.go
@@ -38,6 +38,10 @@ func TestTextV2PostingBlockCodecRoundTripAndFailClosed2625(t *testing.T) {
 		if err != nil || decoded.Term != term {
 			t.Fatalf("decode key for prefix=%+v err=%v", decoded, err)
 		}
+		blockStart, blockID, err := decodeTextV2PostingBlockKeySuffixForPrefix(key, prefix)
+		if err != nil || blockStart != 1 || blockID != 7 {
+			t.Fatalf("decode key suffix start=%d id=%d err=%v", blockStart, blockID, err)
+		}
 	}
 	if _, err := decodeTextV2PostingBlockKey([]byte{textV2KeyVersion, textV2KeyKindPostingBlock, 0}); !errors.Is(err, ErrTextIndexStorageCorrupt) {
 		t.Fatalf("short key err=%v want ErrTextIndexStorageCorrupt", err)
@@ -111,6 +115,47 @@ func TestTextV2PostingBlockCodecRoundTripAndFailClosed2625(t *testing.T) {
 				t.Fatalf("err=%v want ErrTextIndexStorageCorrupt", err)
 			}
 		})
+	}
+}
+
+func TestTextV2PostingBlockScannerScratchReuseAllocGuard2876(t *testing.T) {
+	blocks, err := buildTextV2PostingBlockKVs("refund", syntheticTextV2PostingEntries2625(int(textV2PostingBlockTargetPostings), 2), 2, textV2PostingBlockBuildOptions{})
+	if err != nil {
+		t.Fatalf("build blocks: %v", err)
+	}
+	if len(blocks) != 1 {
+		t.Fatalf("blocks=%d want 1", len(blocks))
+	}
+	var scratch []uint32
+	var scanner textV2PostingBlockEntryScanner
+	scan := func() uint64 {
+		s, err := initTextV2PostingBlockEntryScanner(&scanner, blocks[0].Value, scratch)
+		if err != nil {
+			panic(err)
+		}
+		var sum uint64
+		var entry textV2PostingBlockEntry
+		for s.Next(&entry) {
+			sum += uint64(entry.TermFrequency)
+		}
+		if err := s.Err(); err != nil {
+			panic(err)
+		}
+		scratch = s.scratch
+		return sum
+	}
+	if sum := scan(); sum == 0 {
+		t.Fatal("warm scan produced zero term frequency")
+	}
+	var sink uint64
+	allocs := testing.AllocsPerRun(100, func() {
+		sink += scan()
+	})
+	if sink == 0 {
+		t.Fatal("scan sink stayed zero")
+	}
+	if allocs != 0 {
+		t.Fatalf("scanner warm scratch allocs/run=%v want 0", allocs)
 	}
 }
 
@@ -957,7 +1002,7 @@ func BenchmarkTextV2PostingBlockRangeScanVsV1Synthetic2625(b *testing.B) {
 					if err := scanner.Err(); err != nil {
 						b.Fatal(err)
 					}
-					scratch = scanner.fieldScratch
+					scratch = scanner.scratch
 				}
 				textV2PostingBlockBenchSink2625 += sum
 			}

--- a/TreeDB/collections/text_v2_rewrite.go
+++ b/TreeDB/collections/text_v2_rewrite.go
@@ -883,7 +883,7 @@ func scanTextV2PostingRewriteTerms(snap *backenddb.Snapshot, catalog *collection
 		if err := scanner.Err(); err != nil {
 			return err
 		}
-		scratch = scanner.fieldScratch
+		scratch = scanner.scratch
 		it.Next()
 	}
 	if err := it.Error(); err != nil {

--- a/TreeDB/collections/text_v2_search.go
+++ b/TreeDB/collections/text_v2_search.go
@@ -217,6 +217,17 @@ func (t *textV2SearchTopK) threshold() (float64, bool) {
 	return t.candidates[len(t.candidates)-1].score, true
 }
 
+func (t *textV2SearchTopK) needsDocumentIDForScore(score float64) bool {
+	if t == nil || t.limit <= 0 {
+		return false
+	}
+	if len(t.candidates) < t.limit {
+		return true
+	}
+	worst := t.candidates[len(t.candidates)-1].score
+	return score >= worst
+}
+
 func (t *textV2SearchTopK) add(candidate textV2SearchTopCandidate) bool {
 	_, _, thresholdChanged := t.addCandidate(candidate)
 	return thresholdChanged
@@ -604,6 +615,7 @@ func executeTextV2BlockMaxSearchAtSnapshot(
 	top := textV2SearchTopK{limit: opts.TopK, candidates: make([]textV2SearchTopCandidate, 0, opts.TopK)}
 	fieldCount := len(ctx.fieldNames)
 	var scratch []uint32
+	var scannerStorage textV2PostingBlockEntryScanner
 	var blocksSeen uint64
 	var lastBlockLast uint64
 	var hasLastBlock bool
@@ -617,15 +629,15 @@ func executeTextV2BlockMaxSearchAtSnapshot(
 			it.Next()
 			continue
 		}
-		key, err := decodeTextV2PostingBlockKeyForPrefix(keyBytes, prefix)
+		keyBlockStart, keyBlockID, err := decodeTextV2PostingBlockKeySuffixForPrefix(keyBytes, prefix)
 		if err != nil {
 			return textSearchFailClosed(response, textSearchFailClosedStorageCorrupt, err)
 		}
-		scanner, err := newTextV2PostingBlockEntryScanner(it.UnsafeValue(), scratch)
+		scanner, err := initTextV2PostingBlockEntryScanner(&scannerStorage, it.UnsafeValue(), scratch)
 		if err != nil {
 			return textSearchFailClosed(response, textSearchFailClosedStorageCorrupt, err)
 		}
-		if scanner.block.BlockStart != key.BlockStart || scanner.block.BlockID != key.BlockID {
+		if scanner.block.BlockStart != keyBlockStart || scanner.block.BlockID != keyBlockID {
 			return textSearchFailClosed(response, textSearchFailClosedStorageCorrupt, errMalformedTextStorage("text-v2 posting block key/value identity mismatch"))
 		}
 		if len(scanner.block.Summary.MaxFieldTermFrequencies) != fieldCount {
@@ -679,19 +691,6 @@ func executeTextV2BlockMaxSearchAtSnapshot(
 			if !ok || norm.tombstoned() || norm.Generation != entry.Generation {
 				continue
 			}
-			docMap, ok, err := cache.docMapEntry(snap, catalog, ctx, entry.Ordinal)
-			if err != nil {
-				return textSearchFailClosed(response, textSearchFailClosedStorageCorrupt, err)
-			}
-			if !ok {
-				continue
-			}
-			if norm.Generation != docMap.Generation || norm.Flags != docMap.Flags {
-				return textSearchFailClosed(response, textSearchFailClosedStorageCorrupt, errMalformedTextStorage("text-v2 norm/docmap generation mismatch for ordinal %d", entry.Ordinal))
-			}
-			if docMap.tombstoned() {
-				continue
-			}
 			if candidateLimit > 0 && response.Stats.TextCandidatesScored >= uint64(candidateLimit) {
 				response.Stats.Truncated = true
 				response.Stats.FailClosedReason = textSearchFailClosedCandidateLimit
@@ -706,6 +705,23 @@ func executeTextV2BlockMaxSearchAtSnapshot(
 			if err != nil {
 				return textSearchFailClosed(response, textSearchFailClosedStorageCorrupt, err)
 			}
+			response.Stats.TextCandidatesScored++
+			if !top.needsDocumentIDForScore(score) {
+				continue
+			}
+			docMap, ok, err := cache.docMapEntry(snap, catalog, ctx, entry.Ordinal)
+			if err != nil {
+				return textSearchFailClosed(response, textSearchFailClosedStorageCorrupt, err)
+			}
+			if !ok {
+				continue
+			}
+			if norm.Generation != docMap.Generation || norm.Flags != docMap.Flags {
+				return textSearchFailClosed(response, textSearchFailClosedStorageCorrupt, errMalformedTextStorage("text-v2 norm/docmap generation mismatch for ordinal %d", entry.Ordinal))
+			}
+			if docMap.tombstoned() {
+				continue
+			}
 			beforeThreshold, beforeReady := top.threshold()
 			topCandidate := textV2SearchTopCandidate{ordinal: entry.Ordinal, generation: entry.Generation, documentID: docMap.DocumentID, score: score}
 			if resultMode != textSearchResultScoreOnly || response.Explain != nil {
@@ -714,7 +730,6 @@ func executeTextV2BlockMaxSearchAtSnapshot(
 				topCandidate.hasPosting = true
 			}
 			top.add(topCandidate)
-			response.Stats.TextCandidatesScored++
 			afterThreshold, afterReady := top.threshold()
 			if afterReady && (!beforeReady || afterThreshold > beforeThreshold) {
 				response.Stats.TextBlockMaxThresholds++
@@ -723,7 +738,7 @@ func executeTextV2BlockMaxSearchAtSnapshot(
 		if err := scanner.Err(); err != nil {
 			return textSearchFailClosed(response, textSearchFailClosedStorageCorrupt, err)
 		}
-		scratch = scanner.fieldScratch
+		scratch = scanner.scratch
 		it.Next()
 	}
 	if err := it.Error(); err != nil {
@@ -779,6 +794,7 @@ type textV2ANDBlockMaxTermState struct {
 	scratch          []uint32
 	block            textV2PostingBlockValue
 	scanner          *textV2PostingBlockEntryScanner
+	scannerStorage   textV2PostingBlockEntryScanner
 	upperBound       float64
 	entries          []textV2ANDBlockMaxPostingEntry
 	entryIdx         int
@@ -1019,15 +1035,15 @@ func (s *textV2ANDBlockMaxTermState) loadNextBlock(ctx *textV2SearchContext, fie
 			s.it.Next()
 			continue
 		}
-		key, err := decodeTextV2PostingBlockKeyForPrefix(keyBytes, s.prefix)
+		keyBlockStart, keyBlockID, err := decodeTextV2PostingBlockKeySuffixForPrefix(keyBytes, s.prefix)
 		if err != nil {
 			return err
 		}
-		scanner, err := newTextV2PostingBlockEntryScanner(s.it.UnsafeValue(), s.scratch)
+		scanner, err := initTextV2PostingBlockEntryScanner(&s.scannerStorage, s.it.UnsafeValue(), s.scratch)
 		if err != nil {
 			return err
 		}
-		if scanner.block.BlockStart != key.BlockStart || scanner.block.BlockID != key.BlockID {
+		if scanner.block.BlockStart != keyBlockStart || scanner.block.BlockID != keyBlockID {
 			return errMalformedTextStorage("text-v2 posting block key/value identity mismatch")
 		}
 		if len(scanner.block.Summary.MaxFieldTermFrequencies) != fieldCount {
@@ -1115,7 +1131,7 @@ func (s *textV2ANDBlockMaxTermState) ensureDecoded(ctx *textV2SearchContext, fie
 	if err := s.scanner.Err(); err != nil {
 		return false, err
 	}
-	s.scratch = s.scanner.fieldScratch
+	s.scratch = s.scanner.scratch
 	s.decoded = true
 	return false, nil
 }
@@ -1301,42 +1317,44 @@ func visitTextV2ANDBlockMaxOverlap(
 				if !current {
 					return false, true, nil
 				}
-				docMap, ok, err := cache.docMapEntry(snap, catalog, ctx, target)
+				if previousGeneration, seen := seenCurrent[target]; seen && previousGeneration == norm.Generation {
+					return false, false, errMalformedTextStorage("duplicate current text-v2 AND candidate ordinal %d generation %d", target, norm.Generation)
+				}
+				if candidateLimit > 0 && stats != nil && stats.TextCandidatesScored >= uint64(candidateLimit) {
+					stats.Truncated = true
+					stats.FailClosedReason = textSearchFailClosedCandidateLimit
+					return true, false, nil
+				}
+				score, err := scoreTextV2ANDBlockMaxCandidate(states, ctx, norm)
 				if err != nil {
 					return false, false, err
 				}
-				if ok {
-					if norm.Generation != docMap.Generation || norm.Flags != docMap.Flags {
-						return false, false, errMalformedTextStorage("text-v2 norm/docmap generation mismatch for ordinal %d", target)
+				seenCurrent[target] = norm.Generation
+				if stats != nil {
+					stats.TextCandidatesScored++
+				}
+				if top.needsDocumentIDForScore(score) {
+					docMap, ok, err := cache.docMapEntry(snap, catalog, ctx, target)
+					if err != nil {
+						return false, false, err
 					}
-					if !docMap.tombstoned() {
-						if previousGeneration, seen := seenCurrent[target]; seen && previousGeneration == norm.Generation {
-							return false, false, errMalformedTextStorage("duplicate current text-v2 AND candidate ordinal %d generation %d", target, norm.Generation)
+					if ok {
+						if norm.Generation != docMap.Generation || norm.Flags != docMap.Flags {
+							return false, false, errMalformedTextStorage("text-v2 norm/docmap generation mismatch for ordinal %d", target)
 						}
-						if candidateLimit > 0 && stats != nil && stats.TextCandidatesScored >= uint64(candidateLimit) {
-							stats.Truncated = true
-							stats.FailClosedReason = textSearchFailClosedCandidateLimit
-							return true, false, nil
-						}
-						score, err := scoreTextV2ANDBlockMaxCandidate(states, ctx, norm)
-						if err != nil {
-							return false, false, err
-						}
-						topCandidate := textV2SearchTopCandidate{ordinal: target, generation: norm.Generation, documentID: docMap.DocumentID, score: score}
-						pos, admitted, thresholdChanged := top.addCandidate(topCandidate)
-						if admitted && retainDetail {
-							detail := &textV2SearchCandidate{ordinal: target, generation: norm.Generation, documentID: append([]byte(nil), docMap.DocumentID...), score: score}
-							for _, state := range states {
-								if err := detail.addPostingValue(state.term, state.entries[state.entryIdx].value); err != nil {
-									return false, false, err
+						if !docMap.tombstoned() {
+							topCandidate := textV2SearchTopCandidate{ordinal: target, generation: norm.Generation, documentID: docMap.DocumentID, score: score}
+							pos, admitted, thresholdChanged := top.addCandidate(topCandidate)
+							if admitted && retainDetail {
+								detail := &textV2SearchCandidate{ordinal: target, generation: norm.Generation, documentID: append([]byte(nil), docMap.DocumentID...), score: score}
+								for _, state := range states {
+									if err := detail.addPostingValue(state.term, state.entries[state.entryIdx].value); err != nil {
+										return false, false, err
+									}
 								}
+								top.candidates[pos].detail = detail
 							}
-							top.candidates[pos].detail = detail
-						}
-						seenCurrent[target] = norm.Generation
-						if stats != nil {
-							stats.TextCandidatesScored++
-							if thresholdChanged {
+							if stats != nil && thresholdChanged {
 								stats.TextBlockMaxThresholds++
 							}
 						}
@@ -1748,25 +1766,11 @@ func visitTextV2ORBlockMaxCandidate(
 	if err != nil {
 		return false, err
 	}
-	var docMap textV2SearchDocMapEntry
-	if ok && !norm.tombstoned() {
-		docMap, ok, err = cache.docMapEntry(snap, catalog, ctx, target)
-		if err != nil {
-			return false, err
-		}
-		if ok {
-			if norm.Generation != docMap.Generation || norm.Flags != docMap.Flags {
-				return false, errMalformedTextStorage("text-v2 norm/docmap generation mismatch for ordinal %d", target)
-			}
-			if docMap.tombstoned() {
-				ok = false
-			}
-		}
-	}
+	currentOK := ok && !norm.tombstoned()
 
 	score := 0.0
 	matched := false
-	if ok {
+	if currentOK {
 		// Accumulate in canonical query-term order (scoreStates), not the
 		// WAND-active order (advanceStates), so floating-point ties match the
 		// exhaustive scorer's deterministic ordering exactly.
@@ -1801,28 +1805,41 @@ func visitTextV2ORBlockMaxCandidate(
 		}
 	}
 	if matched {
-		topCandidate := textV2SearchTopCandidate{ordinal: target, generation: norm.Generation, documentID: docMap.DocumentID, score: score}
-		pos, admitted, thresholdChanged := top.addCandidate(topCandidate)
-		if admitted && retainDetail {
-			detail := &textV2SearchCandidate{ordinal: target, generation: norm.Generation, documentID: append([]byte(nil), docMap.DocumentID...), score: score}
-			for _, state := range scoreStates {
-				if state == nil || state.exhausted || state.currentFirst() != target || state.entryIdx >= len(state.entries) || state.entries[state.entryIdx].ordinal != target {
-					continue
-				}
-				posting := state.entries[state.entryIdx].value
-				if posting.generation != norm.Generation {
-					continue
-				}
-				if err := detail.addPostingValue(state.term, posting); err != nil {
-					return false, err
-				}
-			}
-			top.candidates[pos].detail = detail
-		}
 		if stats != nil {
 			stats.TextCandidatesScored++
-			if thresholdChanged {
-				stats.TextBlockMaxThresholds++
+		}
+		if top.needsDocumentIDForScore(score) {
+			docMap, ok, err := cache.docMapEntry(snap, catalog, ctx, target)
+			if err != nil {
+				return false, err
+			}
+			if ok {
+				if norm.Generation != docMap.Generation || norm.Flags != docMap.Flags {
+					return false, errMalformedTextStorage("text-v2 norm/docmap generation mismatch for ordinal %d", target)
+				}
+				if !docMap.tombstoned() {
+					topCandidate := textV2SearchTopCandidate{ordinal: target, generation: norm.Generation, documentID: docMap.DocumentID, score: score}
+					pos, admitted, thresholdChanged := top.addCandidate(topCandidate)
+					if admitted && retainDetail {
+						detail := &textV2SearchCandidate{ordinal: target, generation: norm.Generation, documentID: append([]byte(nil), docMap.DocumentID...), score: score}
+						for _, state := range scoreStates {
+							if state == nil || state.exhausted || state.currentFirst() != target || state.entryIdx >= len(state.entries) || state.entries[state.entryIdx].ordinal != target {
+								continue
+							}
+							posting := state.entries[state.entryIdx].value
+							if posting.generation != norm.Generation {
+								continue
+							}
+							if err := detail.addPostingValue(state.term, posting); err != nil {
+								return false, err
+							}
+						}
+						top.candidates[pos].detail = detail
+					}
+					if stats != nil && thresholdChanged {
+						stats.TextBlockMaxThresholds++
+					}
+				}
 			}
 		}
 	}
@@ -1968,6 +1985,7 @@ func scanTextV2SearchPostingBlocksTerm(
 	}
 	defer func() { _ = it.Close() }()
 	var scratch []uint32
+	var scannerStorage textV2PostingBlockEntryScanner
 	var blocksSeen uint64
 	fieldCount := len(ctx.fieldNames)
 	for it.Valid() {
@@ -1979,15 +1997,15 @@ func scanTextV2SearchPostingBlocksTerm(
 			it.Next()
 			continue
 		}
-		key, err := decodeTextV2PostingBlockKeyForPrefix(keyBytes, prefix)
+		keyBlockStart, keyBlockID, err := decodeTextV2PostingBlockKeySuffixForPrefix(keyBytes, prefix)
 		if err != nil {
 			return false, err
 		}
-		scanner, err := newTextV2PostingBlockEntryScanner(it.UnsafeValue(), scratch)
+		scanner, err := initTextV2PostingBlockEntryScanner(&scannerStorage, it.UnsafeValue(), scratch)
 		if err != nil {
 			return false, err
 		}
-		if scanner.block.BlockStart != key.BlockStart || scanner.block.BlockID != key.BlockID {
+		if scanner.block.BlockStart != keyBlockStart || scanner.block.BlockID != keyBlockID {
 			return false, errMalformedTextStorage("text-v2 posting block key/value identity mismatch")
 		}
 		if len(scanner.block.Summary.MaxFieldTermFrequencies) != fieldCount {
@@ -2046,7 +2064,7 @@ func scanTextV2SearchPostingBlocksTerm(
 		if err := scanner.Err(); err != nil {
 			return false, err
 		}
-		scratch = scanner.fieldScratch
+		scratch = scanner.scratch
 		it.Next()
 	}
 	if err := it.Error(); err != nil {


### PR DESCRIPTION
## Linked issues

- Parent tracker: #2872
- Child issue: #2876

## Summary

- Reuses text-v2 posting-block scanner scratch explicitly within a single iterator/query and adds a stack-initialized scanner path for search traversal.
- Adds a prefix-suffix posting-block key decoder for hot traversal paths so known-term scans do not allocate/decode the term string per block.
- Delays doc-map lookup in score-only block-max/WAND traversal until a scored candidate can affect top-K ordering, preserving exact document-ID tie-breaking for admitted/tie candidates.
- Avoids extra hybrid candidate/filter slice allocations by reusing source candidate slices where safe and filtering in place on local response-owned slices.
- Bounds combined hybrid text+vector candidate preallocation so large caller-provided candidate limits cannot trigger speculative large allocations before source execution.
- Adds scanner scratch and prealloc bound guardrail tests.

No on-disk format changes. No vector rebuild changes.

## Tests

Artifacts: `/tmp/gomap_2876_tests_20260619_094033`; additional post-review-fix local tests run on latest head.

- `GOWORK=off go test ./TreeDB/collections -run 'TestTextV2PostingBlockScannerScratchReuseAllocGuard2876|TestTextV2BlockMax|TestTextV2Search|TestTextV2WritePathSnapshotVisibility2626|TestTextV2WritePathDeleteSnapshotVisibility2626|TestHybridCloseoutFixtureCandidateGenerationFetchesNoDocuments2506|TestHybridSearch'`
- `GOWORK=off go test -race ./TreeDB/collections -run 'TestTextV2MaintenancePolicyConcurrentSearch2732|TestHybridCloseoutFixtureCandidateGenerationFetchesNoDocuments2506'`
- `GOWORK=off go test ./TreeDB/collections`
- Post-review-fix latest-head: `GOWORK=off go test ./TreeDB/collections -run 'TestHybridSearchCandidatePreallocHintBoundsLimits2876|TestSearchHybridExecutorTextVectorOverlapAndBoundedFetch2505|TestTextV2PostingBlockScannerScratchReuseAllocGuard2876'`
- Post-review-fix latest-head: `GOWORK=off go test ./TreeDB/collections`
- Replacement-manager verification on latest head `934e1420e64095e97ed39b71e94d83ebd1558fe0`: `GOWORK=off go test ./TreeDB/collections -run '^TestHybridSearchCandidatePreallocHintBoundsLimits2876$' -count=1`

## Benchmarks and profiles

Host/context: Linux amd64, Intel i5-11400F, Go `go1.25.0`; synthetic TreeDB benchmark fixtures. Baseline was `590888a82e1f752cfd8401d97b50bf5fd82c1196`; latest head is `934e1420e64095e97ed39b71e94d83ebd1558fe0`.

Primary artifacts:

- Baseline required/profile run: `/tmp/gomap_2876_baseline_20260619_092754`
- Baseline repeated rows: `/tmp/gomap_2876_baseline_count_20260619_093814`
- Latest-head after required/profile + repeated rows: `/tmp/gomap_2876_after_head_20260619_101729`

Commands run included the issue-required matrix:

```sh
GOWORK=off TREEDB_TEXT_V2_BLOCKMAX_DOCS=100000 go test ./TreeDB/collections -run '^$' -bench '^BenchmarkTextV2BlockMaxCommonTerm2628/(blockmax_common_topk|exhaustive_common_topk)$' -benchmem -memprofile /tmp/.../text_v2_blockmax_100k_mem.pprof -cpuprofile /tmp/.../text_v2_blockmax_100k_cpu.pprof -benchtime=1x -count=1
GOWORK=off TREEDB_TEXT_V2_OR_WAND_DOCS=100000 go test ./TreeDB/collections -run '^$' -bench '^BenchmarkTextV2BlockMaxMultiTerm2730/(or_common|and_common|or_common_rare|or_high_frequency)_(blockmax|exhaustive)$' -benchmem -benchtime=1x -count=1
GOWORK=off TREEDB_HYBRID_BENCH_DOCS=10000 TREEDB_HYBRID_BENCH_DIMS=16 TREEDB_HYBRID_BENCH_M=8 go test ./TreeDB/collections -run '^$' -bench '^BenchmarkSearchHybridCloseout2506/mode_(text_only_no_docs|hybrid_no_docs)/topK_10/candidates_64/filter_(none_100pct|rare_06pct)$' -benchmem -benchtime=3x -count=1
```

Repeated-row median table, latest head vs baseline:

| Row | ns/op before -> after | ops/sec before -> after | B/op before -> after | allocs/op before -> after | Δ B/op | Δ allocs |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| blockmax common | 3.666 ms -> 3.427 ms | 272.8 -> 291.8 | 1.87 MiB -> 1.64 MiB | 3,146 -> 800 | -12.4% | -74.6% |
| OR common blockmax | 45.216 ms -> 32.266 ms | 22.1 -> 31.0 | 14.39 MiB -> 6.60 MiB | 10,320 -> 3,276 | -54.1% | -68.3% |
| AND common blockmax | 42.516 ms -> 30.532 ms | 23.5 -> 32.8 | 18.90 MiB -> 11.11 MiB | 10,860 -> 3,809 | -41.2% | -64.9% |
| OR common+rare blockmax | 13.954 ms -> 13.772 ms | 71.7 -> 72.6 | 14.17 MiB -> 13.94 MiB | 8,002 -> 5,628 | -1.7% | -29.7% |
| OR high-frequency blockmax | 70.582 ms -> 67.281 ms | 14.2 -> 14.9 | 14.90 MiB -> 13.98 MiB | 15,049 -> 5,671 | -6.1% | -62.3% |
| hybrid text only none | 4.796 ms -> 4.429 ms | 208.5 -> 225.8 | 2.94 MiB -> 2.84 MiB | 11,908 -> 10,959 | -3.4% | -8.0% |
| hybrid text only rare | 2.168 ms -> 2.070 ms | 461.3 -> 483.1 | 1.80 MiB -> 1.69 MiB | 6,917 -> 5,967 | -6.0% | -13.7% |
| hybrid no docs none | 4.700 ms -> 4.618 ms | 212.8 -> 216.6 | 3.12 MiB -> 3.02 MiB | 12,055 -> 11,106 | -3.2% | -7.9% |
| hybrid no docs rare | 2.180 ms -> 2.158 ms | 458.7 -> 463.4 | 1.96 MiB -> 1.85 MiB | 7,011 -> 6,061 | -5.9% | -13.6% |

Benchstat notes:

- Blockmax common B/op `-12.38%`, allocs/op `-74.57%`; median sec/op improved.
- OR/AND/common-rare/high-frequency blockmax allocation reductions range from `-1.7%` to `-54.1%` B/op and `-29.7%` to `-68.3%` allocs/op; median sec/op did not regress in these latest repeated runs.
- Hybrid closeout targeted rows reduced B/op and allocs/op for all targeted rows and median sec/op improved in these latest repeated runs.
- Exhaustive multi-term rows from the pre-review after probe were effectively unchanged in sec/op geomean (`+0.23%`, `~`) while B/op and allocs/op decreased slightly; latest-head required run kept exhaustive rows healthy.

Counter guardrails remained stable in targeted rows: `docs_fetched/search=0`, `full_doc_fallbacks/search=0`, `fail_closed/search=0`, `state_lookups/search=0`, no-doc hybrid rows stayed no-doc.

## Profile summary

- Baseline heap profiles showed search allocations concentrated in `scanTextV2SearchPostingBlocksTerm`, `executeTextV2SearchAtSnapshot`, posting-block scanner setup, norm/docmap block decode, and hybrid candidate/fusion copies (setup still dominates full `go test` memprofiles).
- After profiles show the scanner allocation guard is no longer a leading hot allocation in targeted block-max traversal; remaining search allocations are primarily norm/docmap block materialization and exhaustive candidate map/detail construction.
- Hybrid profiles still include fixture/vector/text-index setup cost; measured per-op reductions come from avoiding duplicate candidate/filter slice backing arrays and lower text candidate traversal allocation.

## AI review follow-up

- Codex review noted speculative hybrid preallocation from unbounded candidate limits. Addressed in `934e1420e64095e97ed39b71e94d83ebd1558fe0` with `hybridCandidatePreallocLimit` plus `TestHybridSearchCandidatePreallocHintBoundsLimits2876`. Replacement-manager follow-up verified the bounded helper, replied on the outdated review thread, and resolved it. Latest Codex review on `934e1420e6` reported no major issues.
- CodeRabbit was requested after CI queue visibility; repo/account rate-limit messages appeared, then CodeRabbit status reported completed/skipped. Copilot was requested; no blocking Copilot output is visible.

## Risks and non-goals

- Score-only block-max/WAND now defers doc-map lookup for candidates that cannot enter top-K by score threshold. Exact ranking is preserved because document IDs are still loaded for admitted or tie-threshold candidates.
- Scratch buffers are query/iterator-local only; no shared mutable scratch state or cross-snapshot cache was added.
- No on-disk format changes; no vector rebuild optimization; no ranking/analyzer semantics changes.

## CI / reviews

- CI: latest head `934e1420e64095e97ed39b71e94d83ebd1558fe0` is green. `mergeStateStatus=CLEAN`; all latest-head checks pass, including Format, Root/TreeDB/HashDB/unified_bench vet+test, read-snapshot guardrails, redisserver bench, TreeDB race/perf-smoke, and unified_bench suites/profile gates.
- AI reviews requested after PR creation and CI queue visibility: `@codex review`, `@copilot review`, `@coderabbitai review`; Codex feedback was addressed and the only review thread is resolved.

Coordinator owns merge; this PR must not be self-merged.

