### PR TITLE
TreeDB text-v2 high-DF block-max pruning

### DIFF
--- a/TreeDB/collections/text_v2_blockmax_test.go
+++ b/TreeDB/collections/text_v2_blockmax_test.go
@@ -299,6 +299,43 @@ func TestTextV2BlockMaxMissingNormBlockFailsClosed2873(t *testing.T) {
 	}
 }
 
+func TestTextV2BlockMaxMissingDocMapBlockFailsClosed2873(t *testing.T) {
+	d := openTextV2TestDB(t, t.TempDir(), false)
+	defer func() { _ = d.Close() }()
+	ids, docs := textV2BlockMaxUniformHighDFDocs2873(1024, false)
+	col := createTextSearchCollection2627(t, d, "docs", TextIndexDefinition{
+		Name:    "lexical",
+		Version: TextIndexVersionV2,
+		Fields:  []TextIndexField{{Field: "title", Weight: 5}, {Field: "body"}},
+	}, ids, docs)
+
+	missingBlockStart := uint64(textV2DefaultDocMapBlockSize) + 1
+	docMapRoot := collectionTextV2DocMapRootName("docs", "lexical")
+	if raw := textV2ReadRootBytes2624(t, d, "docs", docMapRoot, encodeTextV2BlockKey(missingBlockStart)); len(raw) == 0 {
+		t.Fatalf("missing fixture docmap block %d before corruption", missingBlockStart)
+	}
+	deleteTextRootValue2624(t, d, "docs", docMapRoot, encodeTextV2BlockKey(missingBlockStart))
+
+	opts := TextSearchOptions{IndexName: "lexical", Query: "refund", TopK: 10, CandidateLimit: len(ids), MaxPostingsScanned: len(ids) * 2}
+	exhaustiveOpts := opts
+	exhaustiveOpts.textV2DisableBlockMax = true
+	exhaustive, err := col.searchText(exhaustiveOpts, textSearchResultScoreOnly)
+	if !errors.Is(err, ErrTextIndexUnavailable) || !errors.Is(err, ErrTextIndexStorageCorrupt) {
+		t.Fatalf("exhaustive err=%v response=%+v want unavailable/storage corrupt", err, exhaustive)
+	}
+	if exhaustive.Stats.FailClosed != 1 || exhaustive.Stats.FailClosedReason != textSearchFailClosedStorageCorrupt || exhaustive.Stats.DocumentsFetched != 0 {
+		t.Fatalf("exhaustive stats=%+v want storage-corrupt fail-closed without docs", exhaustive.Stats)
+	}
+
+	got, err := col.searchText(opts, textSearchResultScoreOnly)
+	if !errors.Is(err, ErrTextIndexUnavailable) || !errors.Is(err, ErrTextIndexStorageCorrupt) {
+		t.Fatalf("block-max err=%v response=%+v want unavailable/storage corrupt", err, got)
+	}
+	if got.Stats.FailClosed != 1 || got.Stats.FailClosedReason != textSearchFailClosedStorageCorrupt || got.Stats.DocumentsFetched != 0 {
+		t.Fatalf("block-max stats=%+v want storage-corrupt fail-closed without docs", got.Stats)
+	}
+}
+
 func TestTextV2BlockMaxHighDFMicroBlocksExactPruning2873(t *testing.T) {
 	d := openTextV2TestDB(t, t.TempDir(), false)
 	defer func() { _ = d.Close() }()

--- a/TreeDB/collections/text_v2_blockmax_test.go
+++ b/TreeDB/collections/text_v2_blockmax_test.go
@@ -336,6 +336,74 @@ func TestTextV2BlockMaxMissingDocMapBlockFailsClosed2873(t *testing.T) {
 	}
 }
 
+func TestTextV2BlockMaxEmptyNormBlockRangeFailsClosed2873(t *testing.T) {
+	d := openTextV2TestDB(t, t.TempDir(), false)
+	defer func() { _ = d.Close() }()
+	ids, docs := textV2BlockMaxUniformHighDFDocs2873(1024, false)
+	col := createTextSearchCollection2627(t, d, "docs", TextIndexDefinition{
+		Name:    "lexical",
+		Version: TextIndexVersionV2,
+		Fields:  []TextIndexField{{Field: "title", Weight: 5}, {Field: "body"}},
+	}, ids, docs)
+
+	blockStart := uint64(textV2DefaultNormBlockSize) + 1
+	normRoot := collectionTextV2NormBlocksRootName("docs", "lexical")
+	key := encodeTextV2BlockKey(blockStart)
+	raw := textV2ReadRootBytes2624(t, d, "docs", normRoot, key)
+	block, err := decodeTextV2NormBlockValue(raw)
+	if err != nil {
+		t.Fatalf("decode norm block: %v", err)
+	}
+	if len(block.Entries) == 0 {
+		t.Fatalf("fixture norm block %d has no entries before corruption", blockStart)
+	}
+	block.Entries = nil
+	corruptTextRootValue(t, d, "docs", normRoot, key, encodeTextV2NormBlockValue(block))
+
+	opts := TextSearchOptions{IndexName: "lexical", Query: "refund", TopK: 10, CandidateLimit: len(ids), MaxPostingsScanned: len(ids) * 2}
+	got, err := col.searchText(opts, textSearchResultScoreOnly)
+	if !errors.Is(err, ErrTextIndexUnavailable) || !errors.Is(err, ErrTextIndexStorageCorrupt) {
+		t.Fatalf("block-max err=%v response=%+v want unavailable/storage corrupt", err, got)
+	}
+	if got.Stats.FailClosed != 1 || got.Stats.FailClosedReason != textSearchFailClosedStorageCorrupt || got.Stats.DocumentsFetched != 0 {
+		t.Fatalf("block-max stats=%+v want storage-corrupt fail-closed without docs", got.Stats)
+	}
+}
+
+func TestTextV2BlockMaxEmptyDocMapBlockRangeFailsClosed2873(t *testing.T) {
+	d := openTextV2TestDB(t, t.TempDir(), false)
+	defer func() { _ = d.Close() }()
+	ids, docs := textV2BlockMaxUniformHighDFDocs2873(1024, false)
+	col := createTextSearchCollection2627(t, d, "docs", TextIndexDefinition{
+		Name:    "lexical",
+		Version: TextIndexVersionV2,
+		Fields:  []TextIndexField{{Field: "title", Weight: 5}, {Field: "body"}},
+	}, ids, docs)
+
+	blockStart := uint64(textV2DefaultDocMapBlockSize) + 1
+	docMapRoot := collectionTextV2DocMapRootName("docs", "lexical")
+	key := encodeTextV2BlockKey(blockStart)
+	raw := textV2ReadRootBytes2624(t, d, "docs", docMapRoot, key)
+	block, err := decodeTextV2DocMapBlockValue(raw)
+	if err != nil {
+		t.Fatalf("decode docmap block: %v", err)
+	}
+	if len(block.Entries) == 0 {
+		t.Fatalf("fixture docmap block %d has no entries before corruption", blockStart)
+	}
+	block.Entries = nil
+	corruptTextRootValue(t, d, "docs", docMapRoot, key, encodeTextV2DocMapBlockValue(block))
+
+	opts := TextSearchOptions{IndexName: "lexical", Query: "refund", TopK: 10, CandidateLimit: len(ids), MaxPostingsScanned: len(ids) * 2}
+	got, err := col.searchText(opts, textSearchResultScoreOnly)
+	if !errors.Is(err, ErrTextIndexUnavailable) || !errors.Is(err, ErrTextIndexStorageCorrupt) {
+		t.Fatalf("block-max err=%v response=%+v want unavailable/storage corrupt", err, got)
+	}
+	if got.Stats.FailClosed != 1 || got.Stats.FailClosedReason != textSearchFailClosedStorageCorrupt || got.Stats.DocumentsFetched != 0 {
+		t.Fatalf("block-max stats=%+v want storage-corrupt fail-closed without docs", got.Stats)
+	}
+}
+
 func TestTextV2BlockMaxHighDFMicroBlocksExactPruning2873(t *testing.T) {
 	d := openTextV2TestDB(t, t.TempDir(), false)
 	defer func() { _ = d.Close() }()

--- a/TreeDB/collections/text_v2_blockmax_test.go
+++ b/TreeDB/collections/text_v2_blockmax_test.go
@@ -212,6 +212,145 @@ func TestTextV2BlockMaxMultiTermORTieBreak2730(t *testing.T) {
 	}
 }
 
+func TestTextV2BlockMaxHighDFTieExactPruning2873(t *testing.T) {
+	d := openTextV2TestDB(t, t.TempDir(), false)
+	defer func() { _ = d.Close() }()
+	ids, docs := textV2BlockMaxUniformHighDFDocs2873(1024, false)
+	col := createTextSearchCollection2627(t, d, "docs", TextIndexDefinition{
+		Name:    "lexical",
+		Version: TextIndexVersionV2,
+		Fields:  []TextIndexField{{Field: "title", Weight: 5}, {Field: "body"}},
+	}, ids, docs)
+
+	cases := []struct {
+		name     string
+		query    string
+		operator TextSearchOperator
+	}{
+		{name: "common", query: "refund"},
+		{name: "and", query: "refund AND policy", operator: TextSearchOperatorAND},
+		{name: "or", query: "refund OR policy", operator: TextSearchOperatorOR},
+		{name: "or_high_frequency", query: "refund OR policy OR support OR common", operator: TextSearchOperatorOR},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := TextSearchOptions{IndexName: "lexical", Query: tc.query, Operator: tc.operator, TopK: 10, CandidateLimit: len(ids), MaxPostingsScanned: len(ids) * 8}
+			exhaustiveOpts := opts
+			exhaustiveOpts.textV2DisableBlockMax = true
+			exhaustive, err := col.searchText(exhaustiveOpts, textSearchResultScoreOnly)
+			if err != nil {
+				t.Fatalf("exhaustive %s: %v", tc.name, err)
+			}
+			got, err := col.searchText(opts, textSearchResultScoreOnly)
+			if err != nil {
+				t.Fatalf("block-max %s: %v", tc.name, err)
+			}
+			assertTextSearchParity2627(t, got, exhaustive)
+			if got.Stats.TextBlockMaxFallbacks != 0 || got.Stats.FailClosed != 0 || got.Stats.DocumentsFetched != 0 || got.Stats.FullDocumentScanFallbacks != 0 {
+				t.Fatalf("stats=%+v want native exact no-doc high-DF path", got.Stats)
+			}
+			if got.Stats.TextStateLookups != 0 || got.Stats.TextMatchDetailsBuilt != 0 {
+				t.Fatalf("stats=%+v want score-only no-state/no-match-detail high-DF path", got.Stats)
+			}
+			if got.Stats.TextPostingBlocksSkipped == 0 || got.Stats.TextBlockMaxThresholds == 0 {
+				t.Fatalf("stats=%+v want high-DF block skips and threshold updates", got.Stats)
+			}
+			if got.Stats.TextPostingsScanned >= exhaustive.Stats.TextPostingsScanned || got.Stats.TextCandidatesScored >= exhaustive.Stats.TextCandidatesScored {
+				t.Fatalf("block-max stats=%+v exhaustive=%+v want fewer high-DF decoded/scored postings", got.Stats, exhaustive.Stats)
+			}
+		})
+	}
+}
+
+func TestTextV2BlockMaxHighDFMicroBlocksExactPruning2873(t *testing.T) {
+	d := openTextV2TestDB(t, t.TempDir(), false)
+	defer func() { _ = d.Close() }()
+	ids, docs := textV2BlockMaxUniformHighDFDocs2873(1024, false)
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "docs",
+		TextIndexes: []TextIndexDefinition{{
+			Name:    "lexical",
+			Version: TextIndexVersionV2,
+			Fields:  []TextIndexField{{Field: "title", Weight: 3}, {Field: "body"}},
+		}},
+	}); err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	col, err := mgr.OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("OpenCollection: %v", err)
+	}
+	if _, err := col.InsertBatch(ids, docs); err != nil {
+		t.Fatalf("InsertBatch: %v", err)
+	}
+
+	cases := []struct {
+		name     string
+		query    string
+		operator TextSearchOperator
+	}{
+		{name: "common", query: "refund"},
+		{name: "and", query: "refund AND policy", operator: TextSearchOperatorAND},
+		{name: "or", query: "refund OR policy", operator: TextSearchOperatorOR},
+		{name: "or_high_frequency", query: "refund OR policy OR support OR common", operator: TextSearchOperatorOR},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := TextSearchOptions{IndexName: "lexical", Query: tc.query, Operator: tc.operator, TopK: 10, CandidateLimit: len(ids), MaxPostingsScanned: len(ids) * 8}
+			exhaustiveOpts := opts
+			exhaustiveOpts.textV2DisableBlockMax = true
+			exhaustive, err := col.searchText(exhaustiveOpts, textSearchResultScoreOnly)
+			if err != nil {
+				t.Fatalf("exhaustive micro %s: %v", tc.name, err)
+			}
+			got, err := col.searchText(opts, textSearchResultScoreOnly)
+			if err != nil {
+				t.Fatalf("block-max micro %s: %v", tc.name, err)
+			}
+			assertTextSearchParity2627(t, got, exhaustive)
+			if got.Stats.TextBlockMaxFallbacks != 0 || got.Stats.FailClosed != 0 || got.Stats.DocumentsFetched != 0 || got.Stats.FullDocumentScanFallbacks != 0 {
+				t.Fatalf("stats=%+v want native exact no-doc micro-block path", got.Stats)
+			}
+			if got.Stats.TextPostingBlocksSkipped == 0 || got.Stats.TextBlockMaxThresholds == 0 {
+				t.Fatalf("stats=%+v want micro-block high-DF skips and threshold updates", got.Stats)
+			}
+			if got.Stats.TextPostingsScanned >= exhaustive.Stats.TextPostingsScanned || got.Stats.TextCandidatesScored >= exhaustive.Stats.TextCandidatesScored {
+				t.Fatalf("micro block-max stats=%+v exhaustive=%+v want fewer decoded/scored postings", got.Stats, exhaustive.Stats)
+			}
+		})
+	}
+}
+
+func TestTextV2BlockMaxHighDFTiePruningRespectsDocIDOrder2873(t *testing.T) {
+	d := openTextV2TestDB(t, t.TempDir(), false)
+	defer func() { _ = d.Close() }()
+	ids, docs := textV2BlockMaxUniformHighDFDocs2873(384, true)
+	col := createTextSearchCollection2627(t, d, "docs", TextIndexDefinition{Name: "lexical", Version: TextIndexVersionV2, Fields: []TextIndexField{{Field: "title", Weight: 5}, {Field: "body"}}}, ids, docs)
+
+	opts := TextSearchOptions{IndexName: "lexical", Query: "refund OR policy", Operator: TextSearchOperatorOR, TopK: 10, CandidateLimit: len(ids), MaxPostingsScanned: len(ids) * 4}
+	exhaustiveOpts := opts
+	exhaustiveOpts.textV2DisableBlockMax = true
+	exhaustive, err := col.searchText(exhaustiveOpts, textSearchResultScoreOnly)
+	if err != nil {
+		t.Fatalf("exhaustive reversed-id OR: %v", err)
+	}
+	got, err := col.searchText(opts, textSearchResultScoreOnly)
+	if err != nil {
+		t.Fatalf("block-max reversed-id OR: %v", err)
+	}
+	assertTextSearchParity2627(t, got, exhaustive)
+	for i := 0; i < opts.TopK; i++ {
+		wantID := fmt.Sprintf("doc-%06d", i)
+		if string(got.Results[i].DocumentID) != wantID {
+			t.Fatalf("results=%+v want lexical tie winner %q at rank %d", got.Results, wantID, i+1)
+		}
+	}
+	if got.Stats.TextBlockMaxFallbacks != 0 || got.Stats.FailClosed != 0 || got.Stats.DocumentsFetched != 0 {
+		t.Fatalf("stats=%+v want exact native reversed-id tie path", got.Stats)
+	}
+}
+
 func TestTextV2BlockMaxMultiTermORReopen2730(t *testing.T) {
 	dir := t.TempDir()
 	d := openTextV2TestDB(t, dir, false)
@@ -694,6 +833,20 @@ func TestTextV2BlockMaxCorruptMetadataFailsClosed2628(t *testing.T) {
 			t.Fatalf("query %q stats=%+v want metadata fail-closed without docs", query, got.Stats)
 		}
 	}
+}
+
+func textV2BlockMaxUniformHighDFDocs2873(count int, reverseIDs bool) ([][]byte, [][]byte) {
+	ids := make([][]byte, count)
+	docs := make([][]byte, count)
+	for i := 0; i < count; i++ {
+		idOrdinal := i
+		if reverseIDs {
+			idOrdinal = count - 1 - i
+		}
+		ids[i] = []byte(fmt.Sprintf("doc-%06d", idOrdinal))
+		docs[i] = []byte(`{"title":"refund policy","body":"refund policy support common","tenant":"tenant-broad"}`)
+	}
+	return ids, docs
 }
 
 func textV2BlockMaxFixtureDocs2628(count, highDocs int) ([][]byte, [][]byte) {

--- a/TreeDB/collections/text_v2_blockmax_test.go
+++ b/TreeDB/collections/text_v2_blockmax_test.go
@@ -262,6 +262,43 @@ func TestTextV2BlockMaxHighDFTieExactPruning2873(t *testing.T) {
 	}
 }
 
+func TestTextV2BlockMaxMissingNormBlockFailsClosed2873(t *testing.T) {
+	d := openTextV2TestDB(t, t.TempDir(), false)
+	defer func() { _ = d.Close() }()
+	ids, docs := textV2BlockMaxUniformHighDFDocs2873(1024, false)
+	col := createTextSearchCollection2627(t, d, "docs", TextIndexDefinition{
+		Name:    "lexical",
+		Version: TextIndexVersionV2,
+		Fields:  []TextIndexField{{Field: "title", Weight: 5}, {Field: "body"}},
+	}, ids, docs)
+
+	missingBlockStart := uint64(textV2DefaultNormBlockSize) + 1
+	normRoot := collectionTextV2NormBlocksRootName("docs", "lexical")
+	if raw := textV2ReadRootBytes2624(t, d, "docs", normRoot, encodeTextV2BlockKey(missingBlockStart)); len(raw) == 0 {
+		t.Fatalf("missing fixture norm block %d before corruption", missingBlockStart)
+	}
+	deleteTextRootValue2624(t, d, "docs", normRoot, encodeTextV2BlockKey(missingBlockStart))
+
+	opts := TextSearchOptions{IndexName: "lexical", Query: "refund", TopK: 10, CandidateLimit: len(ids), MaxPostingsScanned: len(ids) * 2}
+	exhaustiveOpts := opts
+	exhaustiveOpts.textV2DisableBlockMax = true
+	exhaustive, err := col.searchText(exhaustiveOpts, textSearchResultScoreOnly)
+	if !errors.Is(err, ErrTextIndexUnavailable) || !errors.Is(err, ErrTextIndexStorageCorrupt) {
+		t.Fatalf("exhaustive err=%v response=%+v want unavailable/storage corrupt", err, exhaustive)
+	}
+	if exhaustive.Stats.FailClosed != 1 || exhaustive.Stats.FailClosedReason != textSearchFailClosedStorageCorrupt || exhaustive.Stats.DocumentsFetched != 0 {
+		t.Fatalf("exhaustive stats=%+v want storage-corrupt fail-closed without docs", exhaustive.Stats)
+	}
+
+	got, err := col.searchText(opts, textSearchResultScoreOnly)
+	if !errors.Is(err, ErrTextIndexUnavailable) || !errors.Is(err, ErrTextIndexStorageCorrupt) {
+		t.Fatalf("block-max err=%v response=%+v want unavailable/storage corrupt", err, got)
+	}
+	if got.Stats.FailClosed != 1 || got.Stats.FailClosedReason != textSearchFailClosedStorageCorrupt || got.Stats.DocumentsFetched != 0 {
+		t.Fatalf("block-max stats=%+v want storage-corrupt fail-closed without docs", got.Stats)
+	}
+}
+
 func TestTextV2BlockMaxHighDFMicroBlocksExactPruning2873(t *testing.T) {
 	d := openTextV2TestDB(t, t.TempDir(), false)
 	defer func() { _ = d.Close() }()

--- a/TreeDB/collections/text_v2_search.go
+++ b/TreeDB/collections/text_v2_search.go
@@ -2207,9 +2207,12 @@ func textV2SearchTightBlockUpperBound(snap *backenddb.Snapshot, catalog *collect
 	} else {
 		mins = mins[:fieldCount]
 	}
-	hasLive, err := cache.minFieldLengthsInRange(snap, catalog, ctx, summary.FirstOrdinal, summary.LastOrdinal, mins, stats)
+	hasLive, complete, err := cache.minFieldLengthsInRange(snap, catalog, ctx, summary.FirstOrdinal, summary.LastOrdinal, mins, stats)
 	if err != nil {
 		return 0, err
+	}
+	if !complete {
+		return textV2SearchBlockUpperBound(term, summary, ctx)
 	}
 	if !hasLive {
 		return 0, nil
@@ -2692,41 +2695,40 @@ func (cache *textV2SearchBlockCache) normEntry(snap *backenddb.Snapshot, catalog
 	return entry, true, nil
 }
 
-func (cache *textV2SearchBlockCache) minFieldLengthsInRange(snap *backenddb.Snapshot, catalog *collectionCatalog, ctx *textV2SearchContext, first, last uint64, mins []uint32, stats *TextSearchStats) (bool, error) {
+func (cache *textV2SearchBlockCache) minFieldLengthsInRange(snap *backenddb.Snapshot, catalog *collectionCatalog, ctx *textV2SearchContext, first, last uint64, mins []uint32, stats *TextSearchStats) (hasLive bool, complete bool, err error) {
 	if first == 0 || last < first {
-		return false, errMalformedTextStorage("text-v2 invalid norm range [%d,%d]", first, last)
+		return false, false, errMalformedTextStorage("text-v2 invalid norm range [%d,%d]", first, last)
 	}
 	if len(mins) != len(ctx.fieldNames) {
-		return false, errMalformedTextStorage("text-v2 norm min field count %d want %d", len(mins), len(ctx.fieldNames))
+		return false, false, errMalformedTextStorage("text-v2 norm min field count %d want %d", len(mins), len(ctx.fieldNames))
 	}
 	for i := range mins {
 		mins[i] = math.MaxUint32
 	}
 	blockStart := textV2OrdinalBlockStart(first, textV2DefaultNormBlockSize)
 	if blockStart == 0 {
-		return false, errMalformedTextStorage("text-v2 invalid norm range start %d", first)
+		return false, false, errMalformedTextStorage("text-v2 invalid norm range start %d", first)
 	}
-	hasLive := false
 	for blockStart <= last {
 		block, found, err := cache.normBlockAtOptional(snap, catalog, ctx, blockStart, stats)
 		if err != nil {
-			return false, err
+			return false, false, err
 		}
 		if !found {
-			if blockStart > math.MaxUint64-uint64(textV2DefaultNormBlockSize) {
-				break
-			}
-			blockStart += uint64(textV2DefaultNormBlockSize)
-			continue
+			// Missing norm blocks can be legitimate sparse/tombstone-purged ordinal gaps,
+			// but they make the field-length minimum incomplete for this posting range.
+			// The caller must fail closed to the loose summary-only bound instead of
+			// treating the gap as proof that no live posting ordinal can score.
+			return hasLive, false, nil
 		}
 		idx := sort.Search(len(block.Entries), func(i int) bool { return block.Entries[i].Ordinal >= first })
 		for idx < len(block.Entries) && block.Entries[idx].Ordinal <= last {
 			entry := block.Entries[idx]
 			if len(entry.FieldLengths) != len(ctx.fieldNames) {
-				return false, errMalformedTextStorage("text-v2 norm entry field count %d want %d", len(entry.FieldLengths), len(ctx.fieldNames))
+				return false, false, errMalformedTextStorage("text-v2 norm entry field count %d want %d", len(entry.FieldLengths), len(ctx.fieldNames))
 			}
 			if entry.Ordinal >= ctx.status.NextOrdinal || entry.Generation > ctx.status.NormGeneration {
-				return false, errMalformedTextStorage("text-v2 norm entry outside status snapshot")
+				return false, false, errMalformedTextStorage("text-v2 norm entry outside status snapshot")
 			}
 			if !entry.tombstoned() {
 				for fieldIdx, length := range entry.FieldLengths {
@@ -2743,7 +2745,7 @@ func (cache *textV2SearchBlockCache) minFieldLengthsInRange(snap *backenddb.Snap
 		}
 		blockStart += uint64(textV2DefaultNormBlockSize)
 	}
-	return hasLive, nil
+	return hasLive, true, nil
 }
 
 func (cache *textV2SearchBlockCache) docMapBlockAtOptional(snap *backenddb.Snapshot, catalog *collectionCatalog, ctx *textV2SearchContext, blockStart uint64) (textV2SearchDocMapBlock, bool, error) {

--- a/TreeDB/collections/text_v2_search.go
+++ b/TreeDB/collections/text_v2_search.go
@@ -2891,7 +2891,13 @@ func (cache *textV2SearchBlockCache) minDocumentIDInRange(snap *backenddb.Snapsh
 		}
 		blockStart += uint64(textV2DefaultDocMapBlockSize)
 	}
-	return minID, minID != nil, true, nil
+	if minID == nil {
+		// A range with only tombstoned doc-map entries is not a safe tie-prune
+		// proof: corrupt tombstone flags can otherwise hide the required
+		// norm/docmap consistency check for referenced postings.
+		return nil, false, false, nil
+	}
+	return minID, true, true, nil
 }
 
 func orderTextV2SearchScanTerms(terms []string, operator TextSearchOperator, stats map[string]textV2TermStatsValue) []string {

--- a/TreeDB/collections/text_v2_search.go
+++ b/TreeDB/collections/text_v2_search.go
@@ -2742,16 +2742,19 @@ func (cache *textV2SearchBlockCache) minFieldLengthsInRange(snap *backenddb.Snap
 			// treating the gap as proof that no live posting ordinal can score.
 			return hasLive, false, nil
 		}
-		idx := sort.Search(len(block.Entries), func(i int) bool { return block.Entries[i].Ordinal >= first })
-		blockHadEntry := idx < len(block.Entries) && block.Entries[idx].Ordinal <= last
-		if !blockHadEntry {
-			// A present sidecar block with no entries in the posting range does not
-			// prove the range is empty: the posting block may still reference a
-			// corrupt/missing norm entry that the exact scorer must fail closed on.
-			return hasLive, false, nil
-		}
-		for idx < len(block.Entries) && block.Entries[idx].Ordinal <= last {
+		overlapFirst := max(first, blockStart)
+		overlapLast := min(last, blockStart+uint64(textV2DefaultNormBlockSize)-1)
+		idx := sort.Search(len(block.Entries), func(i int) bool { return block.Entries[i].Ordinal >= overlapFirst })
+		expectedOrdinal := overlapFirst
+		for idx < len(block.Entries) && block.Entries[idx].Ordinal <= overlapLast {
 			entry := block.Entries[idx]
+			if entry.Ordinal != expectedOrdinal {
+				// A present sidecar block with a missing entry in the posting range
+				// does not prove the range is empty or fully bounded: the posting block
+				// may still reference a corrupt/missing norm entry that the exact scorer
+				// must fail closed on.
+				return hasLive, false, nil
+			}
 			if len(entry.FieldLengths) != len(ctx.fieldNames) {
 				return false, false, errMalformedTextStorage("text-v2 norm entry field count %d want %d", len(entry.FieldLengths), len(ctx.fieldNames))
 			}
@@ -2766,7 +2769,11 @@ func (cache *textV2SearchBlockCache) minFieldLengthsInRange(snap *backenddb.Snap
 				}
 				hasLive = true
 			}
+			expectedOrdinal++
 			idx++
+		}
+		if expectedOrdinal <= overlapLast {
+			return hasLive, false, nil
 		}
 		if blockStart > math.MaxUint64-uint64(textV2DefaultNormBlockSize) {
 			break
@@ -2854,23 +2861,30 @@ func (cache *textV2SearchBlockCache) minDocumentIDInRange(snap *backenddb.Snapsh
 			// referenced posting can fail closed through the required docmap lookup.
 			return minID, minID != nil, false, nil
 		}
-		idx := sort.Search(len(block.Entries), func(i int) bool { return block.Entries[i].Ordinal >= first })
-		blockHadEntry := idx < len(block.Entries) && block.Entries[idx].Ordinal <= last
-		if !blockHadEntry {
-			// A present sidecar block with no entries in the posting range does not
-			// prove the range is empty: the posting block may still reference a
-			// corrupt/missing docmap entry that the exact scorer must fail closed on.
-			return minID, minID != nil, false, nil
-		}
-		for idx < len(block.Entries) && block.Entries[idx].Ordinal <= last {
+		overlapFirst := max(first, blockStart)
+		overlapLast := min(last, blockStart+uint64(textV2DefaultDocMapBlockSize)-1)
+		idx := sort.Search(len(block.Entries), func(i int) bool { return block.Entries[i].Ordinal >= overlapFirst })
+		expectedOrdinal := overlapFirst
+		for idx < len(block.Entries) && block.Entries[idx].Ordinal <= overlapLast {
 			entry := block.Entries[idx]
+			if entry.Ordinal != expectedOrdinal {
+				// A present sidecar block with a missing entry in the posting range
+				// does not prove the range is empty or fully bounded: the posting block
+				// may still reference a corrupt/missing docmap entry that the exact
+				// scorer must fail closed on.
+				return minID, minID != nil, false, nil
+			}
 			if entry.Ordinal >= ctx.status.NextOrdinal || entry.Generation > ctx.status.DocMapGeneration {
 				return nil, false, false, errMalformedTextStorage("text-v2 docmap entry outside status snapshot")
 			}
 			if !entry.tombstoned() && (minID == nil || bytes.Compare(entry.DocumentID, minID) < 0) {
 				minID = entry.DocumentID
 			}
+			expectedOrdinal++
 			idx++
+		}
+		if expectedOrdinal <= overlapLast {
+			return minID, minID != nil, false, nil
 		}
 		if blockStart > math.MaxUint64-uint64(textV2DefaultDocMapBlockSize) {
 			break

--- a/TreeDB/collections/text_v2_search.go
+++ b/TreeDB/collections/text_v2_search.go
@@ -217,6 +217,13 @@ func (t *textV2SearchTopK) threshold() (float64, bool) {
 	return t.candidates[len(t.candidates)-1].score, true
 }
 
+func (t *textV2SearchTopK) worst() (textV2SearchTopCandidate, bool) {
+	if t == nil || t.limit <= 0 || len(t.candidates) < t.limit {
+		return textV2SearchTopCandidate{}, false
+	}
+	return t.candidates[len(t.candidates)-1], true
+}
+
 func (t *textV2SearchTopK) add(candidate textV2SearchTopCandidate) bool {
 	_, _, thresholdChanged := t.addCandidate(candidate)
 	return thresholdChanged
@@ -631,7 +638,7 @@ func executeTextV2BlockMaxSearchAtSnapshot(
 		if len(scanner.block.Summary.MaxFieldTermFrequencies) != fieldCount {
 			return textSearchFailClosed(response, textSearchFailClosedStorageCorrupt, errMalformedTextStorage("text-v2 posting block field count %d want %d", len(scanner.block.Summary.MaxFieldTermFrequencies), fieldCount))
 		}
-		if !scanner.ChecksumVerified() || scanner.block.Kind != textV2PostingBlockKindSealed || (hasLastBlock && scanner.block.Summary.FirstOrdinal <= lastBlockLast) {
+		if !scanner.ChecksumVerified() || !textV2PostingBlockKindSupportsBlockMax(scanner.block.Kind) || (hasLastBlock && scanner.block.Summary.FirstOrdinal <= lastBlockLast) {
 			return fallbackToExactScan()
 		}
 		hasLastBlock = true
@@ -647,10 +654,25 @@ func executeTextV2BlockMaxSearchAtSnapshot(
 		if err != nil {
 			return textSearchFailClosed(response, textSearchFailClosedStorageCorrupt, err)
 		}
-		if threshold, ok := top.threshold(); ok && blockUpperBound < threshold {
-			response.Stats.TextPostingBlocksSkipped++
-			it.Next()
-			continue
+		if threshold, ok := top.threshold(); ok {
+			if blockUpperBound < threshold {
+				response.Stats.TextPostingBlocksSkipped++
+				it.Next()
+				continue
+			}
+			tightUpperBound, err := textV2SearchTightBlockUpperBound(snap, catalog, ctx, &cache, term, scanner.block.Summary, &response.Stats)
+			if err != nil {
+				return textSearchFailClosed(response, textSearchFailClosedStorageCorrupt, err)
+			}
+			canSkip, err := textV2SearchTightUpperBoundSkipsRange(snap, catalog, ctx, &cache, tightUpperBound, scanner.block.Summary.FirstOrdinal, scanner.block.Summary.LastOrdinal, &top)
+			if err != nil {
+				return textSearchFailClosed(response, textSearchFailClosedStorageCorrupt, err)
+			}
+			if canSkip {
+				response.Stats.TextPostingBlocksSkipped++
+				it.Next()
+				continue
+			}
 		}
 		response.Stats.TextPostingBlocksVisited++
 		var entry textV2PostingBlockEntry
@@ -780,6 +802,7 @@ type textV2ANDBlockMaxTermState struct {
 	block            textV2PostingBlockValue
 	scanner          *textV2PostingBlockEntryScanner
 	upperBound       float64
+	upperBoundTight  bool
 	entries          []textV2ANDBlockMaxPostingEntry
 	entryIdx         int
 	decoded          bool
@@ -891,11 +914,28 @@ func executeTextV2ANDBlockMaxSearchAtSnapshot(
 		for _, state := range states {
 			combinedUpperBound += state.upperBound
 		}
-		if threshold, ok := top.threshold(); ok && combinedUpperBound < threshold {
-			if err := skipTextV2ANDBlockMaxOverlapThrough(ctx, states, fieldCount, last, &response.Stats, false); err != nil {
-				return textSearchFailClosed(response, textSearchFailClosedStorageCorrupt, err)
+		if threshold, ok := top.threshold(); ok {
+			canSkip := combinedUpperBound < threshold
+			if !canSkip {
+				tightCombinedUpperBound := 0.0
+				for _, state := range states {
+					if err := tightenTextV2BlockMaxStateUpperBound(snap, catalog, ctx, &cache, state, &response.Stats); err != nil {
+						return textSearchFailClosed(response, textSearchFailClosedStorageCorrupt, err)
+					}
+					tightCombinedUpperBound += state.upperBound
+				}
+				var err error
+				canSkip, err = textV2SearchTightUpperBoundSkipsRange(snap, catalog, ctx, &cache, tightCombinedUpperBound, first, last, &top)
+				if err != nil {
+					return textSearchFailClosed(response, textSearchFailClosedStorageCorrupt, err)
+				}
 			}
-			continue
+			if canSkip {
+				if err := skipTextV2ANDBlockMaxOverlapThrough(ctx, states, fieldCount, last, &response.Stats, false); err != nil {
+					return textSearchFailClosed(response, textSearchFailClosedStorageCorrupt, err)
+				}
+				continue
+			}
 		}
 
 		retainDetail := (resultMode != textSearchResultScoreOnly || response.Explain != nil) && len(terms) > 1
@@ -1007,6 +1047,7 @@ func (s *textV2ANDBlockMaxTermState) loadNextBlock(ctx *textV2SearchContext, fie
 	s.block = textV2PostingBlockValue{}
 	s.scanner = nil
 	s.upperBound = 0
+	s.upperBoundTight = false
 	s.entries = s.entries[:0]
 	s.entryIdx = 0
 	s.decoded = false
@@ -1037,7 +1078,7 @@ func (s *textV2ANDBlockMaxTermState) loadNextBlock(ctx *textV2SearchContext, fie
 		if err != nil {
 			return err
 		}
-		if scanner.block.Kind != textV2PostingBlockKindSealed || !scanner.ChecksumVerified() || (s.hasLastBlock && scanner.block.Summary.FirstOrdinal <= s.lastBlockLast) {
+		if !textV2PostingBlockKindSupportsBlockMax(scanner.block.Kind) || !scanner.ChecksumVerified() || (s.hasLastBlock && scanner.block.Summary.FirstOrdinal <= s.lastBlockLast) {
 			s.requiresFallback = true
 		}
 		s.block = scanner.block
@@ -1142,7 +1183,7 @@ func textV2ANDBlockMaxAnyExhausted(states []*textV2ANDBlockMaxTermState) bool {
 
 func textV2ANDBlockMaxNeedsFallback(states []*textV2ANDBlockMaxTermState) bool {
 	for _, state := range states {
-		if state == nil || state.requiresFallback || (!state.exhausted && (state.scanner == nil || !state.scanner.ChecksumVerified() || state.scanner.block.Kind != textV2PostingBlockKindSealed)) {
+		if state == nil || state.requiresFallback || (!state.exhausted && (state.scanner == nil || !state.scanner.ChecksumVerified() || !textV2PostingBlockKindSupportsBlockMax(state.scanner.block.Kind))) {
 			return true
 		}
 	}
@@ -1435,7 +1476,7 @@ func executeTextV2ORBlockMaxSearchAtSnapshot(
 		textV2ORBlockMaxSortStates(active)
 
 		if threshold, ok := top.threshold(); ok {
-			truncated, progressed, err := skipTextV2ORBlockMaxLowUpperWindow(ctx, active, fieldCount, maxPostingsScanned, threshold, &response.Stats)
+			truncated, progressed, err := skipTextV2ORBlockMaxLowUpperWindow(snap, catalog, ctx, &cache, active, fieldCount, maxPostingsScanned, threshold, &top, &response.Stats)
 			if err != nil {
 				return textSearchFailClosed(response, textSearchFailClosedStorageCorrupt, err)
 			}
@@ -1569,6 +1610,15 @@ func executeTextV2ORBlockMaxSearchAtSnapshot(
 	return response, nil
 }
 
+func textV2PostingBlockKindSupportsBlockMax(kind textV2PostingBlockKind) bool {
+	switch kind {
+	case textV2PostingBlockKindSealed, textV2PostingBlockKindMicro:
+		return true
+	default:
+		return false
+	}
+}
+
 func textV2ORBlockMaxActiveStates(states, scratch []*textV2ANDBlockMaxTermState) []*textV2ANDBlockMaxTermState {
 	active := scratch[:0]
 	for _, state := range states {
@@ -1600,6 +1650,19 @@ func textV2ORBlockMaxSortStates(states []*textV2ANDBlockMaxTermState) {
 	})
 }
 
+func tightenTextV2BlockMaxStateUpperBound(snap *backenddb.Snapshot, catalog *collectionCatalog, ctx *textV2SearchContext, cache *textV2SearchBlockCache, state *textV2ANDBlockMaxTermState, stats *TextSearchStats) error {
+	if state == nil || state.exhausted || state.upperBoundTight {
+		return nil
+	}
+	upperBound, err := textV2SearchTightBlockUpperBound(snap, catalog, ctx, cache, state.term, state.block.Summary, stats)
+	if err != nil {
+		return err
+	}
+	state.upperBound = upperBound
+	state.upperBoundTight = true
+	return nil
+}
+
 func skipTextV2ORBlockMaxDisallowedBlocks(ctx *textV2SearchContext, states []*textV2ANDBlockMaxTermState, fieldCount int, allowSet *textV2SearchOrdinalAllowSet, stats *TextSearchStats) error {
 	if allowSet == nil {
 		return nil
@@ -1618,7 +1681,7 @@ func skipTextV2ORBlockMaxDisallowedBlocks(ctx *textV2SearchContext, states []*te
 	return nil
 }
 
-func skipTextV2ORBlockMaxLowUpperWindow(ctx *textV2SearchContext, states []*textV2ANDBlockMaxTermState, fieldCount, maxPostingsScanned int, threshold float64, stats *TextSearchStats) (bool, bool, error) {
+func skipTextV2ORBlockMaxLowUpperWindow(snap *backenddb.Snapshot, catalog *collectionCatalog, ctx *textV2SearchContext, cache *textV2SearchBlockCache, states []*textV2ANDBlockMaxTermState, fieldCount, maxPostingsScanned int, threshold float64, top *textV2SearchTopK, stats *TextSearchStats) (bool, bool, error) {
 	if len(states) == 0 {
 		return false, false, nil
 	}
@@ -1628,11 +1691,17 @@ func skipTextV2ORBlockMaxLowUpperWindow(ctx *textV2SearchContext, states []*text
 	}
 	windowLast := uint64(math.MaxUint64)
 	upperSum := 0.0
+	var overlappingInline [8]*textV2ANDBlockMaxTermState
+	overlapping := overlappingInline[:0]
+	if len(states) > len(overlappingInline) {
+		overlapping = make([]*textV2ANDBlockMaxTermState, 0, len(states))
+	}
 	for _, state := range states {
 		currentFirst := state.currentFirst()
 		currentLast := state.currentLast()
 		if currentFirst <= windowFirst && currentLast >= windowFirst {
 			upperSum += state.upperBound
+			overlapping = append(overlapping, state)
 			if currentLast < windowLast {
 				windowLast = currentLast
 			}
@@ -1642,7 +1711,25 @@ func skipTextV2ORBlockMaxLowUpperWindow(ctx *textV2SearchContext, states []*text
 			windowLast = currentFirst - 1
 		}
 	}
-	if windowLast < windowFirst || upperSum >= threshold {
+	if windowLast < windowFirst {
+		return false, false, nil
+	}
+	canSkip := upperSum < threshold
+	if !canSkip {
+		tightUpperSum := 0.0
+		for _, state := range overlapping {
+			if err := tightenTextV2BlockMaxStateUpperBound(snap, catalog, ctx, cache, state, stats); err != nil {
+				return false, false, err
+			}
+			tightUpperSum += state.upperBound
+		}
+		var err error
+		canSkip, err = textV2SearchTightUpperBoundSkipsRange(snap, catalog, ctx, cache, tightUpperSum, windowFirst, windowLast, top)
+		if err != nil {
+			return false, false, err
+		}
+	}
+	if !canSkip {
 		return false, false, nil
 	}
 	target := windowLast + 1
@@ -2105,19 +2192,44 @@ func textV2SearchPostingValueFromEntry(entry textV2PostingBlockEntry, fieldCount
 }
 
 func textV2SearchBlockUpperBound(term string, summary textV2PostingBlockSummary, ctx *textV2SearchContext) (float64, error) {
+	return textV2SearchBlockUpperBoundWithFieldLengthMinimums(term, summary, ctx, nil)
+}
+
+func textV2SearchTightBlockUpperBound(snap *backenddb.Snapshot, catalog *collectionCatalog, ctx *textV2SearchContext, cache *textV2SearchBlockCache, term string, summary textV2PostingBlockSummary, stats *TextSearchStats) (float64, error) {
+	if cache == nil {
+		return 0, errMalformedTextStorage("text-v2 search cache is nil")
+	}
+	fieldCount := len(ctx.fieldNames)
+	var inline [8]uint32
+	mins := inline[:]
+	if fieldCount > len(inline) {
+		mins = make([]uint32, fieldCount)
+	} else {
+		mins = mins[:fieldCount]
+	}
+	hasLive, err := cache.minFieldLengthsInRange(snap, catalog, ctx, summary.FirstOrdinal, summary.LastOrdinal, mins, stats)
+	if err != nil {
+		return 0, err
+	}
+	if !hasLive {
+		return 0, nil
+	}
+	return textV2SearchBlockUpperBoundWithFieldLengthMinimums(term, summary, ctx, mins)
+}
+
+func textV2SearchBlockUpperBoundWithFieldLengthMinimums(term string, summary textV2PostingBlockSummary, ctx *textV2SearchContext, minFieldLengths []uint32) (float64, error) {
 	if summary.UpperBoundKind != textV2PostingUpperBoundKindBM25FLaneMax {
 		return 0, errMalformedTextStorage("text-v2 posting block unsupported upper-bound kind %d", summary.UpperBoundKind)
 	}
 	if len(summary.MaxFieldTermFrequencies) != len(ctx.fieldNames) {
 		return 0, errMalformedTextStorage("text-v2 posting block upper-bound field count %d want %d", len(summary.MaxFieldTermFrequencies), len(ctx.fieldNames))
 	}
+	if minFieldLengths != nil && len(minFieldLengths) != len(ctx.fieldNames) {
+		return 0, errMalformedTextStorage("text-v2 posting block upper-bound min field count %d want %d", len(minFieldLengths), len(ctx.fieldNames))
+	}
 	stats := ctx.termStats[term]
 	if stats.DocumentFrequency == 0 || stats.DocumentFrequency > ctx.corpus.DocumentCount {
 		return 0, errMalformedTextStorage("text-v2 term %q document frequency %d outside corpus %d", term, stats.DocumentFrequency, ctx.corpus.DocumentCount)
-	}
-	minDenominator := 1 - textSearchBM25B
-	if minDenominator <= 0 {
-		return 0, errMalformedTextStorage("invalid BM25F normalization denominator")
 	}
 	var combinedTFUpper float64
 	for fieldIdx, maxTF := range summary.MaxFieldTermFrequencies {
@@ -2128,7 +2240,18 @@ func textV2SearchBlockUpperBound(term string, summary textV2PostingBlockSummary,
 		if statsValue.DocumentCount == 0 || statsValue.TotalTokenCount == 0 {
 			return 0, errMalformedTextStorage("missing text-v2 field accounting for %q", ctx.fieldNames[fieldIdx])
 		}
-		combinedTFUpper += ctx.fieldWeights[fieldIdx] * (float64(maxTF) / minDenominator)
+		avgLength := float64(statsValue.TotalTokenCount) / float64(statsValue.DocumentCount)
+		if avgLength <= 0 {
+			return 0, errMalformedTextStorage("invalid average text-v2 field length for %q", ctx.fieldNames[fieldIdx])
+		}
+		denominator := 1 - textSearchBM25B
+		if minFieldLengths != nil {
+			denominator += textSearchBM25B * (float64(minFieldLengths[fieldIdx]) / avgLength)
+		}
+		if denominator <= 0 {
+			return 0, errMalformedTextStorage("invalid BM25F normalization denominator")
+		}
+		combinedTFUpper += ctx.fieldWeights[fieldIdx] * (float64(maxTF) / denominator)
 	}
 	if combinedTFUpper <= 0 {
 		return 0, nil
@@ -2137,6 +2260,27 @@ func textV2SearchBlockUpperBound(term string, summary textV2PostingBlockSummary,
 	df := float64(stats.DocumentFrequency)
 	idf := math.Log(1 + (corpusDocuments-df+0.5)/(df+0.5))
 	return idf * ((combinedTFUpper * (textSearchBM25K1 + 1)) / (combinedTFUpper + textSearchBM25K1)), nil
+}
+
+func textV2SearchTightUpperBoundSkipsRange(snap *backenddb.Snapshot, catalog *collectionCatalog, ctx *textV2SearchContext, cache *textV2SearchBlockCache, upperBound float64, first, last uint64, top *textV2SearchTopK) (bool, error) {
+	worst, ok := top.worst()
+	if !ok {
+		return false, nil
+	}
+	if upperBound < worst.score {
+		return true, nil
+	}
+	if upperBound > worst.score {
+		return false, nil
+	}
+	minDocID, hasLive, err := cache.minDocumentIDInRange(snap, catalog, ctx, first, last)
+	if err != nil {
+		return false, err
+	}
+	if !hasLive {
+		return true, nil
+	}
+	return bytes.Compare(minDocID, worst.documentID) >= 0, nil
 }
 
 func scoreTextV2SearchPostingValue(term string, posting textV2SearchPostingValue, ctx *textV2SearchContext, norm textV2SearchNormEntry) (float64, error) {
@@ -2486,33 +2630,57 @@ func (b textV2SearchDocMapBlock) find(ordinal uint64) (textV2SearchDocMapEntry, 
 	return textV2SearchDocMapEntry{}, false
 }
 
-func (cache *textV2SearchBlockCache) normEntry(snap *backenddb.Snapshot, catalog *collectionCatalog, ctx *textV2SearchContext, ordinal uint64, stats *TextSearchStats) (textV2SearchNormEntry, bool, error) {
-	blockStart := textV2OrdinalBlockStart(ordinal, textV2DefaultNormBlockSize)
+func (cache *textV2SearchBlockCache) normBlockAtOptional(snap *backenddb.Snapshot, catalog *collectionCatalog, ctx *textV2SearchContext, blockStart uint64, stats *TextSearchStats) (textV2SearchNormBlock, bool, error) {
 	if blockStart == 0 {
-		return textV2SearchNormEntry{}, false, errMalformedTextStorage("text-v2 invalid norm ordinal %d", ordinal)
+		return textV2SearchNormBlock{}, false, errMalformedTextStorage("text-v2 invalid norm block start")
 	}
 	if cache.normBlocks == nil {
 		cache.normBlocks = make(map[uint64]textV2SearchNormBlock)
 	}
 	block, ok := cache.normBlocks[blockStart]
-	if !ok {
-		raw, found, err := collectionGetAppendAtCatalogRoot(snap, catalog, ctx.normBlocksRootName, encodeTextV2BlockKey(blockStart), nil)
-		if err != nil {
-			return textV2SearchNormEntry{}, false, err
-		}
+	if ok {
+		return block, true, nil
+	}
+	raw, found, err := collectionGetAppendAtCatalogRoot(snap, catalog, ctx.normBlocksRootName, encodeTextV2BlockKey(blockStart), nil)
+	if err != nil {
+		return textV2SearchNormBlock{}, false, err
+	}
+	if stats != nil {
 		stats.TextNormLookups++
-		if !found {
-			return textV2SearchNormEntry{}, false, errMalformedTextStorage("missing text-v2 norm block %d", blockStart)
-		}
-		decoded, err := decodeTextV2SearchNormBlock(raw)
-		if err != nil {
-			return textV2SearchNormEntry{}, false, err
-		}
-		if decoded.BlockStart != blockStart || decoded.BlockSize != textV2DefaultNormBlockSize || decoded.FieldCount != uint32(len(ctx.fieldNames)) {
-			return textV2SearchNormEntry{}, false, errMalformedTextStorage("text-v2 norm block key/value mismatch")
-		}
-		cache.normBlocks[blockStart] = decoded
-		block = decoded
+	}
+	if !found {
+		return textV2SearchNormBlock{}, false, nil
+	}
+	decoded, err := decodeTextV2SearchNormBlock(raw)
+	if err != nil {
+		return textV2SearchNormBlock{}, false, err
+	}
+	if decoded.BlockStart != blockStart || decoded.BlockSize != textV2DefaultNormBlockSize || decoded.FieldCount != uint32(len(ctx.fieldNames)) {
+		return textV2SearchNormBlock{}, false, errMalformedTextStorage("text-v2 norm block key/value mismatch")
+	}
+	cache.normBlocks[blockStart] = decoded
+	return decoded, true, nil
+}
+
+func (cache *textV2SearchBlockCache) normBlockAt(snap *backenddb.Snapshot, catalog *collectionCatalog, ctx *textV2SearchContext, blockStart uint64, stats *TextSearchStats) (textV2SearchNormBlock, error) {
+	block, found, err := cache.normBlockAtOptional(snap, catalog, ctx, blockStart, stats)
+	if err != nil {
+		return textV2SearchNormBlock{}, err
+	}
+	if !found {
+		return textV2SearchNormBlock{}, errMalformedTextStorage("missing text-v2 norm block %d", blockStart)
+	}
+	return block, nil
+}
+
+func (cache *textV2SearchBlockCache) normEntry(snap *backenddb.Snapshot, catalog *collectionCatalog, ctx *textV2SearchContext, ordinal uint64, stats *TextSearchStats) (textV2SearchNormEntry, bool, error) {
+	blockStart := textV2OrdinalBlockStart(ordinal, textV2DefaultNormBlockSize)
+	if blockStart == 0 {
+		return textV2SearchNormEntry{}, false, errMalformedTextStorage("text-v2 invalid norm ordinal %d", ordinal)
+	}
+	block, err := cache.normBlockAt(snap, catalog, ctx, blockStart, stats)
+	if err != nil {
+		return textV2SearchNormEntry{}, false, err
 	}
 	entry, found := block.find(ordinal)
 	if !found {
@@ -2524,32 +2692,108 @@ func (cache *textV2SearchBlockCache) normEntry(snap *backenddb.Snapshot, catalog
 	return entry, true, nil
 }
 
-func (cache *textV2SearchBlockCache) docMapEntry(snap *backenddb.Snapshot, catalog *collectionCatalog, ctx *textV2SearchContext, ordinal uint64) (textV2SearchDocMapEntry, bool, error) {
-	blockStart := textV2OrdinalBlockStart(ordinal, textV2DefaultDocMapBlockSize)
+func (cache *textV2SearchBlockCache) minFieldLengthsInRange(snap *backenddb.Snapshot, catalog *collectionCatalog, ctx *textV2SearchContext, first, last uint64, mins []uint32, stats *TextSearchStats) (bool, error) {
+	if first == 0 || last < first {
+		return false, errMalformedTextStorage("text-v2 invalid norm range [%d,%d]", first, last)
+	}
+	if len(mins) != len(ctx.fieldNames) {
+		return false, errMalformedTextStorage("text-v2 norm min field count %d want %d", len(mins), len(ctx.fieldNames))
+	}
+	for i := range mins {
+		mins[i] = math.MaxUint32
+	}
+	blockStart := textV2OrdinalBlockStart(first, textV2DefaultNormBlockSize)
 	if blockStart == 0 {
-		return textV2SearchDocMapEntry{}, false, errMalformedTextStorage("text-v2 invalid docmap ordinal %d", ordinal)
+		return false, errMalformedTextStorage("text-v2 invalid norm range start %d", first)
+	}
+	hasLive := false
+	for blockStart <= last {
+		block, found, err := cache.normBlockAtOptional(snap, catalog, ctx, blockStart, stats)
+		if err != nil {
+			return false, err
+		}
+		if !found {
+			if blockStart > math.MaxUint64-uint64(textV2DefaultNormBlockSize) {
+				break
+			}
+			blockStart += uint64(textV2DefaultNormBlockSize)
+			continue
+		}
+		idx := sort.Search(len(block.Entries), func(i int) bool { return block.Entries[i].Ordinal >= first })
+		for idx < len(block.Entries) && block.Entries[idx].Ordinal <= last {
+			entry := block.Entries[idx]
+			if len(entry.FieldLengths) != len(ctx.fieldNames) {
+				return false, errMalformedTextStorage("text-v2 norm entry field count %d want %d", len(entry.FieldLengths), len(ctx.fieldNames))
+			}
+			if entry.Ordinal >= ctx.status.NextOrdinal || entry.Generation > ctx.status.NormGeneration {
+				return false, errMalformedTextStorage("text-v2 norm entry outside status snapshot")
+			}
+			if !entry.tombstoned() {
+				for fieldIdx, length := range entry.FieldLengths {
+					if length < mins[fieldIdx] {
+						mins[fieldIdx] = length
+					}
+				}
+				hasLive = true
+			}
+			idx++
+		}
+		if blockStart > math.MaxUint64-uint64(textV2DefaultNormBlockSize) {
+			break
+		}
+		blockStart += uint64(textV2DefaultNormBlockSize)
+	}
+	return hasLive, nil
+}
+
+func (cache *textV2SearchBlockCache) docMapBlockAtOptional(snap *backenddb.Snapshot, catalog *collectionCatalog, ctx *textV2SearchContext, blockStart uint64) (textV2SearchDocMapBlock, bool, error) {
+	if blockStart == 0 {
+		return textV2SearchDocMapBlock{}, false, errMalformedTextStorage("text-v2 invalid docmap block start")
 	}
 	if cache.docMapBlocks == nil {
 		cache.docMapBlocks = make(map[uint64]textV2SearchDocMapBlock)
 	}
 	block, ok := cache.docMapBlocks[blockStart]
-	if !ok {
-		raw, found, err := collectionGetAppendAtCatalogRoot(snap, catalog, ctx.docMapRootName, encodeTextV2BlockKey(blockStart), nil)
-		if err != nil {
-			return textV2SearchDocMapEntry{}, false, err
-		}
-		if !found {
-			return textV2SearchDocMapEntry{}, false, errMalformedTextStorage("missing text-v2 docmap block %d", blockStart)
-		}
-		decoded, err := decodeTextV2SearchDocMapBlock(raw)
-		if err != nil {
-			return textV2SearchDocMapEntry{}, false, err
-		}
-		if decoded.BlockStart != blockStart || decoded.BlockSize != textV2DefaultDocMapBlockSize {
-			return textV2SearchDocMapEntry{}, false, errMalformedTextStorage("text-v2 docmap block key/value mismatch")
-		}
-		cache.docMapBlocks[blockStart] = decoded
-		block = decoded
+	if ok {
+		return block, true, nil
+	}
+	raw, found, err := collectionGetAppendAtCatalogRoot(snap, catalog, ctx.docMapRootName, encodeTextV2BlockKey(blockStart), nil)
+	if err != nil {
+		return textV2SearchDocMapBlock{}, false, err
+	}
+	if !found {
+		return textV2SearchDocMapBlock{}, false, nil
+	}
+	decoded, err := decodeTextV2SearchDocMapBlock(raw)
+	if err != nil {
+		return textV2SearchDocMapBlock{}, false, err
+	}
+	if decoded.BlockStart != blockStart || decoded.BlockSize != textV2DefaultDocMapBlockSize {
+		return textV2SearchDocMapBlock{}, false, errMalformedTextStorage("text-v2 docmap block key/value mismatch")
+	}
+	cache.docMapBlocks[blockStart] = decoded
+	return decoded, true, nil
+}
+
+func (cache *textV2SearchBlockCache) docMapBlockAt(snap *backenddb.Snapshot, catalog *collectionCatalog, ctx *textV2SearchContext, blockStart uint64) (textV2SearchDocMapBlock, error) {
+	block, found, err := cache.docMapBlockAtOptional(snap, catalog, ctx, blockStart)
+	if err != nil {
+		return textV2SearchDocMapBlock{}, err
+	}
+	if !found {
+		return textV2SearchDocMapBlock{}, errMalformedTextStorage("missing text-v2 docmap block %d", blockStart)
+	}
+	return block, nil
+}
+
+func (cache *textV2SearchBlockCache) docMapEntry(snap *backenddb.Snapshot, catalog *collectionCatalog, ctx *textV2SearchContext, ordinal uint64) (textV2SearchDocMapEntry, bool, error) {
+	blockStart := textV2OrdinalBlockStart(ordinal, textV2DefaultDocMapBlockSize)
+	if blockStart == 0 {
+		return textV2SearchDocMapEntry{}, false, errMalformedTextStorage("text-v2 invalid docmap ordinal %d", ordinal)
+	}
+	block, err := cache.docMapBlockAt(snap, catalog, ctx, blockStart)
+	if err != nil {
+		return textV2SearchDocMapEntry{}, false, err
 	}
 	entry, found := block.find(ordinal)
 	if !found {
@@ -2559,6 +2803,46 @@ func (cache *textV2SearchBlockCache) docMapEntry(snap *backenddb.Snapshot, catal
 		return textV2SearchDocMapEntry{}, false, errMalformedTextStorage("text-v2 docmap entry outside status snapshot")
 	}
 	return entry, true, nil
+}
+
+func (cache *textV2SearchBlockCache) minDocumentIDInRange(snap *backenddb.Snapshot, catalog *collectionCatalog, ctx *textV2SearchContext, first, last uint64) ([]byte, bool, error) {
+	if first == 0 || last < first {
+		return nil, false, errMalformedTextStorage("text-v2 invalid docmap range [%d,%d]", first, last)
+	}
+	blockStart := textV2OrdinalBlockStart(first, textV2DefaultDocMapBlockSize)
+	if blockStart == 0 {
+		return nil, false, errMalformedTextStorage("text-v2 invalid docmap range start %d", first)
+	}
+	var minID []byte
+	for blockStart <= last {
+		block, found, err := cache.docMapBlockAtOptional(snap, catalog, ctx, blockStart)
+		if err != nil {
+			return nil, false, err
+		}
+		if !found {
+			if blockStart > math.MaxUint64-uint64(textV2DefaultDocMapBlockSize) {
+				break
+			}
+			blockStart += uint64(textV2DefaultDocMapBlockSize)
+			continue
+		}
+		idx := sort.Search(len(block.Entries), func(i int) bool { return block.Entries[i].Ordinal >= first })
+		for idx < len(block.Entries) && block.Entries[idx].Ordinal <= last {
+			entry := block.Entries[idx]
+			if entry.Ordinal >= ctx.status.NextOrdinal || entry.Generation > ctx.status.DocMapGeneration {
+				return nil, false, errMalformedTextStorage("text-v2 docmap entry outside status snapshot")
+			}
+			if !entry.tombstoned() && (minID == nil || bytes.Compare(entry.DocumentID, minID) < 0) {
+				minID = entry.DocumentID
+			}
+			idx++
+		}
+		if blockStart > math.MaxUint64-uint64(textV2DefaultDocMapBlockSize) {
+			break
+		}
+		blockStart += uint64(textV2DefaultDocMapBlockSize)
+	}
+	return minID, minID != nil, nil
 }
 
 func orderTextV2SearchScanTerms(terms []string, operator TextSearchOperator, stats map[string]textV2TermStatsValue) []string {

--- a/TreeDB/collections/text_v2_search.go
+++ b/TreeDB/collections/text_v2_search.go
@@ -2276,9 +2276,12 @@ func textV2SearchTightUpperBoundSkipsRange(snap *backenddb.Snapshot, catalog *co
 	if upperBound > worst.score {
 		return false, nil
 	}
-	minDocID, hasLive, err := cache.minDocumentIDInRange(snap, catalog, ctx, first, last)
+	minDocID, hasLive, complete, err := cache.minDocumentIDInRange(snap, catalog, ctx, first, last)
 	if err != nil {
 		return false, err
+	}
+	if !complete {
+		return false, nil
 	}
 	if !hasLive {
 		return true, nil
@@ -2807,32 +2810,30 @@ func (cache *textV2SearchBlockCache) docMapEntry(snap *backenddb.Snapshot, catal
 	return entry, true, nil
 }
 
-func (cache *textV2SearchBlockCache) minDocumentIDInRange(snap *backenddb.Snapshot, catalog *collectionCatalog, ctx *textV2SearchContext, first, last uint64) ([]byte, bool, error) {
+func (cache *textV2SearchBlockCache) minDocumentIDInRange(snap *backenddb.Snapshot, catalog *collectionCatalog, ctx *textV2SearchContext, first, last uint64) (minID []byte, hasLive bool, complete bool, err error) {
 	if first == 0 || last < first {
-		return nil, false, errMalformedTextStorage("text-v2 invalid docmap range [%d,%d]", first, last)
+		return nil, false, false, errMalformedTextStorage("text-v2 invalid docmap range [%d,%d]", first, last)
 	}
 	blockStart := textV2OrdinalBlockStart(first, textV2DefaultDocMapBlockSize)
 	if blockStart == 0 {
-		return nil, false, errMalformedTextStorage("text-v2 invalid docmap range start %d", first)
+		return nil, false, false, errMalformedTextStorage("text-v2 invalid docmap range start %d", first)
 	}
-	var minID []byte
 	for blockStart <= last {
 		block, found, err := cache.docMapBlockAtOptional(snap, catalog, ctx, blockStart)
 		if err != nil {
-			return nil, false, err
+			return nil, false, false, err
 		}
 		if !found {
-			if blockStart > math.MaxUint64-uint64(textV2DefaultDocMapBlockSize) {
-				break
-			}
-			blockStart += uint64(textV2DefaultDocMapBlockSize)
-			continue
+			// Missing docmap blocks make the document-ID tie proof incomplete.
+			// Do not treat the gap as empty; let the caller visit the range so a
+			// referenced posting can fail closed through the required docmap lookup.
+			return minID, minID != nil, false, nil
 		}
 		idx := sort.Search(len(block.Entries), func(i int) bool { return block.Entries[i].Ordinal >= first })
 		for idx < len(block.Entries) && block.Entries[idx].Ordinal <= last {
 			entry := block.Entries[idx]
 			if entry.Ordinal >= ctx.status.NextOrdinal || entry.Generation > ctx.status.DocMapGeneration {
-				return nil, false, errMalformedTextStorage("text-v2 docmap entry outside status snapshot")
+				return nil, false, false, errMalformedTextStorage("text-v2 docmap entry outside status snapshot")
 			}
 			if !entry.tombstoned() && (minID == nil || bytes.Compare(entry.DocumentID, minID) < 0) {
 				minID = entry.DocumentID
@@ -2844,7 +2845,7 @@ func (cache *textV2SearchBlockCache) minDocumentIDInRange(snap *backenddb.Snapsh
 		}
 		blockStart += uint64(textV2DefaultDocMapBlockSize)
 	}
-	return minID, minID != nil, nil
+	return minID, minID != nil, true, nil
 }
 
 func orderTextV2SearchScanTerms(terms []string, operator TextSearchOperator, stats map[string]textV2TermStatsValue) []string {

--- a/TreeDB/collections/text_v2_search.go
+++ b/TreeDB/collections/text_v2_search.go
@@ -2743,6 +2743,13 @@ func (cache *textV2SearchBlockCache) minFieldLengthsInRange(snap *backenddb.Snap
 			return hasLive, false, nil
 		}
 		idx := sort.Search(len(block.Entries), func(i int) bool { return block.Entries[i].Ordinal >= first })
+		blockHadEntry := idx < len(block.Entries) && block.Entries[idx].Ordinal <= last
+		if !blockHadEntry {
+			// A present sidecar block with no entries in the posting range does not
+			// prove the range is empty: the posting block may still reference a
+			// corrupt/missing norm entry that the exact scorer must fail closed on.
+			return hasLive, false, nil
+		}
 		for idx < len(block.Entries) && block.Entries[idx].Ordinal <= last {
 			entry := block.Entries[idx]
 			if len(entry.FieldLengths) != len(ctx.fieldNames) {
@@ -2848,6 +2855,13 @@ func (cache *textV2SearchBlockCache) minDocumentIDInRange(snap *backenddb.Snapsh
 			return minID, minID != nil, false, nil
 		}
 		idx := sort.Search(len(block.Entries), func(i int) bool { return block.Entries[i].Ordinal >= first })
+		blockHadEntry := idx < len(block.Entries) && block.Entries[idx].Ordinal <= last
+		if !blockHadEntry {
+			// A present sidecar block with no entries in the posting range does not
+			// prove the range is empty: the posting block may still reference a
+			// corrupt/missing docmap entry that the exact scorer must fail closed on.
+			return minID, minID != nil, false, nil
+		}
 		for idx < len(block.Entries) && block.Entries[idx].Ordinal <= last {
 			entry := block.Entries[idx]
 			if entry.Ordinal >= ctx.status.NextOrdinal || entry.Generation > ctx.status.DocMapGeneration {


### PR DESCRIPTION
## Objective

Implement #2873 high-document-frequency exact BM25F block-max/WAND pruning for text-v2 common, AND, and OR score-only rows.

Links: parent #2872, child #2873.

## Context

The 1M text-v2 scale rows were falling back to broad scoring on online micro posting blocks (`500k` scored candidates for common/AND/OR). This PR keeps exact scoring and deterministic tie-breaking while allowing top-k thresholds and block/window upper bounds to prune those rows.

## Non-goals

- No approximate ranking, lossy early termination, or tie-break changes.
- No vector rebuild, hybrid budget policy, or scalar-specific pruning changes.
- No on-disk format or public API changes.

## Design

- Treat checksum-verified, non-overlapping text-v2 `micro` posting blocks as block-max eligible, matching sealed blocks. Overlapping/malformed/unsupported blocks still fall back exactly and increment `blockmax_fallbacks`.
- Tighten BM25F block upper bounds using snapshot-bound norm field-length minima after the existing summary-only upper-bound fast check.
- Prune equal-score blocks/windows only when docmap range minimum document ID proves no tied candidate can beat the current top-k worst document ID.
- For tight norm-min probes, absent norm blocks make the tight bound incomplete, so the search falls back to the safe loose summary-only upper bound; norm absence is no longer used as proof that no live ordinal can score. For equal-score tie pruning, absent docmap blocks make the document-ID proof incomplete, so the range is visited instead of skipped. If a referenced posting then lacks required norm/docmap state, candidate scoring fails closed as storage corrupt.

## Scope

- Includes: `TreeDB/collections/text_v2_search.go`, `TreeDB/collections/text_v2_blockmax_test.go`.
- Excludes: vector rebuild, scalar-aware follow-up #2874, posting decode/allocation follow-up #2876 beyond shared existing counters.

## Correctness

Tests run:

```sh
GOWORK=off go test ./TreeDB/collections -run 'TestTextV2BlockMax|TestTextV2QueryExplain|TestTextV2Scalar' -count=1
GOWORK=off go test ./TreeDB/collections -count=1

# latest post-review fixes at 440daef
GOWORK=off go test ./TreeDB/collections -run 'TestTextV2BlockMaxMissing(Norm|DocMap)BlockFailsClosed2873' -count=1
GOWORK=off go test ./TreeDB/collections -run 'TextV2.*BlockMax|BlockMax.*TextV2' -count=1
```

Added/tightened tests:

- high-DF common/AND/OR/high-frequency exact parity vs exhaustive on sealed blocks;
- same parity/pruning on online `micro` blocks (the scale-harness write path);
- reversed docID tie fixture to guard deterministic tie-breaking;
- missing norm-block and docmap-block corruption fixtures now require block-max to fail closed like exhaustive instead of skipping on incomplete upper-bound/tie proofs;
- existing overlapping mutation fallback tests continue to require exact fallback.

## Performance

Host/context: local Linux amd64, Intel i5-11400F, Go 1.26.0. Baseline at `590888a82e1f752cfd8401d97b50bf5fd82c1196`; after at `20045ef425f2e80d218fa4821e8414c2a8fcd69c`. Commands:

```sh
GOWORK=off TREEDB_TEXT_V2_BLOCKMAX_DOCS=100000 go test ./TreeDB/collections -run '^$' -bench '^BenchmarkTextV2BlockMaxCommonTerm2628/(blockmax_common_topk|exhaustive_common_topk)$' -benchmem -benchtime=1x -count=1
GOWORK=off TREEDB_TEXT_V2_OR_WAND_DOCS=100000 go test ./TreeDB/collections -run '^$' -bench '^BenchmarkTextV2BlockMaxMultiTerm2730/(or_common|and_common|or_common_rare|or_high_frequency)_(blockmax|exhaustive)$' -benchmem -benchtime=1x -count=1
RUN_DIR=/tmp/gomap_text_hybrid_scale_1m_high_df_2873_20260619_100329 RUN_1M=true RUN_SMOKE=false ONE_M_ROWS=1000000 ONE_M_QUERIES=25 ONE_M_BATCH_SIZE=16384 ONE_M_BACKFILL_ROWS=100000 ONE_M_MAINTENANCE_UPDATES=10000 ONE_M_MAINTENANCE_DELETES=5000 ONE_M_CANDIDATE_LIMIT=65536 DIMS=16 M=8 EF_CONSTRUCTION=128 EF_SEARCH=128 TOP_K=10 READERS=4 scripts/bench_text_hybrid_scale.sh
```

100k focused rows:

| row | before ns/op | after ns/op | before scored/postings/visited/skipped | after scored/postings/visited/skipped | B/op before→after | allocs before→after |
| --- | ---: | ---: | --- | --- | ---: | ---: |
| common blockmax | 3.315ms | 1.511ms | 12,544 / 12,544 / 98 / 684 | 256 / 256 / 2 / 780 | 1,964,888 → 1,964,888 | 3,146 → 3,146 |
| OR common blockmax | 43.291ms | 5.066ms | 100,000 / 200,000 / 1,564 / 0 | 128 / 256 / 2 / 1,562 | 15,093,768 → 7,398,504 | 10,328 → 7,962 |
| AND common blockmax | 43.456ms | 5.586ms | 100,000 / 200,000 / 1,564 / 0 | 128 / 256 / 2 / 1,562 | 19,823,160 → 7,411,776 | 10,859 → 7,983 |
| OR common+rare blockmax | 13.205ms | 14.279ms | 1,895 / 100,999 / 790 / 1 | 1,157 / 100,999 / 790 / 1 | 14,850,200 → 14,853,856 | 7,998 → 8,002 |
| OR high-frequency blockmax | 70.385ms | 29.286ms | 100,000 / 399,968 / 3,128 / 0 | 128 / 399,936 / 3,126 / 2 | 15,625,528 → 15,621,680 | 15,055 → 15,049 |

1M scale artifact: `/tmp/gomap_text_hybrid_scale_1m_high_df_2873_20260619_100329/scale_1m/scale_report.md`.

| 1M row | baseline p50 / p95 | after p50 / p95 | baseline counters | after counters |
| --- | ---: | ---: | --- | --- |
| `text_common_score_only` | 579.960ms / 665.410ms | 85.244ms / 106.498ms | postings=500,000 blocks=15,625 scored=500,000 | postings=32 visited=1 skipped=15,624 scored=32 |
| `text_multi_term_and_score_only` | 817.554ms / 1.155s | 97.237ms / 112.949ms | postings=1,000,000 blocks=31,250 scored=500,000 | postings=64 visited=2 skipped=31,248 scored=32 |
| `text_multi_term_or_score_only` | 742.687ms / 954.785ms | 98.711ms / 110.983ms | postings=1,000,000 blocks=31,250 scored=500,000 | postings=64 visited=2 skipped=31,248 scored=11 |

Guardrails stayed PASS in the 1M run: `docs_fetched=0`, `fail_closed=0`; maintenance rewrite postcondition PASS. The OR common+rare 100k wall-time row is within noisy 1x evidence and not a target regression; candidate count drops and allocations are effectively flat.

Latest-head smoke after the norm/docmap review fixes (`440daef`):

```sh
GOWORK=off TREEDB_TEXT_V2_BLOCKMAX_DOCS=100000 go test ./TreeDB/collections -run '^$' -bench '^BenchmarkTextV2BlockMaxCommonTerm2628/blockmax_common_topk$' -benchmem -benchtime=1x -count=1
```

`blockmax_common_topk`: `1.406ms/op`, `256` postings/scored, `2` blocks visited, `780` skipped, `docs_fetched=0`, `fail_closed=0`, `blockmax_fallbacks=0`, `1,964,888 B/op`, `3,146 allocs/op`.

## Rollout / Toggle Plan

Default behavior remains exact block-max/WAND for supported text-v2 shapes. Unsupported/overlapping/corrupt blocks fall back exactly or fail closed as before. Internal tests can still disable block-max via `textV2DisableBlockMax`.

## Follow-ups

- #2876 can continue posting decode/allocation work; no public iterator/counter contract change here.
- #2874 can build scalar-aware pruning on the existing counters/contracts.

## CI / AI Review Loop

- CI: latest head `440daef` running after the post-review fixes; previous mature head `20045ef4` was green.
- Codex: P2 missing-norm-block and missing-docmap-block threads fixed/replied/resolved in `76625e8` and `440daef`; Codex re-review requested after latest fix.
- Copilot/CodeRabbit: Copilot re-review requested after latest fix; CodeRabbit latest-head status is non-blocking success/skipped after an initial rate-limit notice.


