### PR TITLE
collections: enable nullable typed-column q4/q5 TopK fast paths

### DIFF
--- a/TreeDB/collections/column_physical_typed_column_1947_test.go
+++ b/TreeDB/collections/column_physical_typed_column_1947_test.go
@@ -239,6 +239,74 @@ func TestColumnPhysicalJSONBenchTypedColumnPartNullableFullDataMissingStrings216
 	}
 }
 
+func TestColumnPhysicalJSONBenchTypedColumnPartNullableFullDataTopKFastPaths2878(t *testing.T) {
+	docs := []string{
+		`{"time_us":1000,"kind":"commit","did":"did_a","commit":{"operation":"create","collection":"app.bsky.feed.post"}}`,
+		`{"time_us":1050,"kind":"commit","did":"did_x","commit":{"collection":"app.bsky.feed.post"}}`,
+		`{"time_us":1100,"kind":"commit","commit":{"operation":"create","collection":"app.bsky.feed.post"}}`,
+		`{"time_us":1200,"kind":"commit","did":"did_b","commit":{"operation":"create","collection":"app.bsky.feed.post"}}`,
+		`{"time_us":2000,"kind":"commit","did":"did_a","commit":{"operation":"create","collection":"app.bsky.feed.post"}}`,
+		`{"time_us":2200,"kind":"commit","did":"did_delete","commit":{"operation":"delete","collection":"app.bsky.feed.post"}}`,
+		`{"time_us":2500,"kind":"commit","did":"did_c","commit":{"operation":"create","collection":"app.bsky.feed.post"}}`,
+		`{"time_us":3000,"kind":"commit","did":"did_c","commit":{"operation":"create","collection":"app.bsky.feed.post"}}`,
+	}
+	_, collection, closeFn := openColumnPhysicalJSONBenchNullableFullDataFixture2165(t, docs)
+	defer closeFn()
+
+	postCreate := []ColumnPhysicalQueryPredicate{
+		{Column: "kind", Value: "commit"},
+		{Column: "operation", Value: "create"},
+		{Column: "event", Value: "app.bsky.feed.post"},
+	}
+	q4 := ColumnPhysicalQueryRequest{
+		Kind:              ColumnPhysicalQueryGroupMinInt64,
+		GroupColumn:       "did",
+		ValueColumn:       "time_us",
+		Predicates:        postCreate,
+		TopK:              2,
+		TopKOrder:         ColumnPhysicalQueryTopKInt64Asc,
+		SkipEmptyGroupKey: true,
+	}
+	q4Want := []ColumnPhysicalQueryGroup{{Key: "did_a", Int64: 1000}, {Key: "did_b", Int64: 1200}}
+	runNullableFullDataTopKFastPath2878(t, collection, "q4", q4, q4Want, func(tb testing.TB, label string, diag ColumnPhysicalQueryDiagnostics) {
+		tb.Helper()
+		assertNullableFullDataTopKBaseDiagnostics2878(tb, label, diag, len(postCreate), q4.TopK, string(q4.TopKOrder), len(q4Want))
+		if !diag.TimeOrderTopKUsed || diag.DenseInt64SpanUsed {
+			tb.Fatalf("%s diagnostics=%+v want time-order topK only", label, diag)
+		}
+		if diag.RowsScanned != 4 || diag.RowsMatched != 3 || diag.ReduceRows != 3 {
+			tb.Fatalf("%s diagnostics=%+v want early q4 scan/match/reduce 4/3/3", label, diag)
+		}
+		if diag.TopKCandidates != len(q4Want) {
+			tb.Fatalf("%s diagnostics=%+v want topK candidates=%d", label, diag, len(q4Want))
+		}
+	})
+
+	q5 := ColumnPhysicalQueryRequest{
+		Kind:              ColumnPhysicalQueryGroupInt64Span,
+		GroupColumn:       "did",
+		ValueColumn:       "time_us",
+		Predicates:        postCreate,
+		TopK:              2,
+		TopKOrder:         ColumnPhysicalQueryTopKInt64Desc,
+		SkipEmptyGroupKey: true,
+	}
+	q5Want := []ColumnPhysicalQueryGroup{{Key: "did_a", Int64: 1000}, {Key: "did_c", Int64: 500}}
+	runNullableFullDataTopKFastPath2878(t, collection, "q5", q5, q5Want, func(tb testing.TB, label string, diag ColumnPhysicalQueryDiagnostics) {
+		tb.Helper()
+		assertNullableFullDataTopKBaseDiagnostics2878(tb, label, diag, len(postCreate), q5.TopK, string(q5.TopKOrder), len(q5Want))
+		if !diag.DenseInt64SpanUsed || diag.TimeOrderTopKUsed {
+			tb.Fatalf("%s diagnostics=%+v want dense int64-span only", label, diag)
+		}
+		if diag.RowsScanned != len(docs) || diag.RowsMatched != 6 || diag.ReduceRows != 6 {
+			tb.Fatalf("%s diagnostics=%+v want q5 scan/match/reduce %d/6/6", label, diag, len(docs))
+		}
+		if diag.TopKCandidates != 3 {
+			tb.Fatalf("%s diagnostics=%+v want three non-empty topK candidates", label, diag)
+		}
+	})
+}
+
 func TestColumnPhysicalJSONBenchTypedColumnPartEdgeShapes1947(t *testing.T) {
 	events := columnPhysicalJSONBenchParityEventsP0()
 	_, collection, closeFn, _ := openColumnPhysicalJSONBenchTypedColumnPartFixture1947(t, events)
@@ -651,6 +719,53 @@ func runNullableFullDataQuery2165(tb testing.TB, collection *Collection, name st
 		}
 	}
 	return direct
+}
+
+func runNullableFullDataTopKFastPath2878(tb testing.TB, collection *Collection, name string, req ColumnPhysicalQueryRequest, want []ColumnPhysicalQueryGroup, assertDiag func(testing.TB, string, ColumnPhysicalQueryDiagnostics)) {
+	tb.Helper()
+	direct, err := collection.RunColumnPhysicalQuery(req)
+	if err != nil {
+		tb.Fatalf("RunColumnPhysicalQuery(%s): %v", name, err)
+	}
+	if !reflect.DeepEqual(direct.Groups, want) {
+		tb.Fatalf("%s direct groups=%+v want %+v", name, direct.Groups, want)
+	}
+	assertDiag(tb, name+" direct", direct.Diagnostics)
+
+	runner, err := collection.PrepareColumnPhysicalQuery(req)
+	if err != nil {
+		tb.Fatalf("PrepareColumnPhysicalQuery(%s): %v", name, err)
+	}
+	defer func() { _ = runner.Close() }()
+	for run := 0; run < 2; run++ {
+		prepared, err := runner.Run()
+		if err != nil {
+			tb.Fatalf("prepared %s run %d: %v", name, run, err)
+		}
+		if !reflect.DeepEqual(prepared.Groups, want) {
+			tb.Fatalf("%s prepared run %d groups=%+v want %+v", name, run, prepared.Groups, want)
+		}
+		assertDiag(tb, fmt.Sprintf("%s prepared %d", name, run), prepared.Diagnostics)
+	}
+}
+
+func assertNullableFullDataTopKBaseDiagnostics2878(tb testing.TB, label string, diag ColumnPhysicalQueryDiagnostics, predicates, topK int, order string, resultGroups int) {
+	tb.Helper()
+	if diag.StorageSource != ColumnPhysicalQueryStorageSourceTypedColumnPartSection || diag.FallbackReason != ColumnPhysicalQueryFallbackNone {
+		tb.Fatalf("%s diagnostics storage/fallback=%+v want typed-column source without fallback", label, diag)
+	}
+	if diag.RowMaterializations != 0 || diag.DocumentMaterializations != 0 {
+		tb.Fatalf("%s materialized row/document on typed-column physical path: %+v", label, diag)
+	}
+	if diag.PredicateCount != predicates || diag.PredicateLiterals != predicates {
+		tb.Fatalf("%s predicate diagnostics=%+v want %d equality predicates", label, diag, predicates)
+	}
+	if diag.DecodedBlocks == 0 || diag.DecodedPayloadBytes == 0 || diag.TypedColumnPartSections == 0 || diag.TypedColumnPartSectionBytes == 0 {
+		tb.Fatalf("%s typed-column decode diagnostics missing: %+v", label, diag)
+	}
+	if diag.TopKLimit != topK || diag.TopKOrder != order || diag.ResultGroups != resultGroups {
+		tb.Fatalf("%s topK diagnostics=%+v want limit=%d order=%q groups=%d", label, diag, topK, order, resultGroups)
+	}
 }
 
 func assertNullableFullDataGenericDiagnostics2165(tb testing.TB, label string, diag ColumnPhysicalQueryDiagnostics) {

--- a/TreeDB/collections/column_physical_typed_column_1947_test.go
+++ b/TreeDB/collections/column_physical_typed_column_1947_test.go
@@ -305,6 +305,53 @@ func TestColumnPhysicalJSONBenchTypedColumnPartNullableFullDataTopKFastPaths2878
 			tb.Fatalf("%s diagnostics=%+v want three non-empty topK candidates", label, diag)
 		}
 	})
+
+	missingOperation := []ColumnPhysicalQueryPredicate{
+		{Column: "kind", Value: "commit"},
+		{Column: "operation", Value: ""},
+		{Column: "event", Value: "app.bsky.feed.post"},
+	}
+	q4MissingOperation := ColumnPhysicalQueryRequest{
+		Kind:              ColumnPhysicalQueryGroupMinInt64,
+		GroupColumn:       "did",
+		ValueColumn:       "time_us",
+		Predicates:        missingOperation,
+		TopK:              1,
+		TopKOrder:         ColumnPhysicalQueryTopKInt64Asc,
+		SkipEmptyGroupKey: true,
+	}
+	q4MissingOperationWant := []ColumnPhysicalQueryGroup{{Key: "did_x", Int64: 1050}}
+	runNullableFullDataTopKFastPath2878(t, collection, "q4 missing operation", q4MissingOperation, q4MissingOperationWant, func(tb testing.TB, label string, diag ColumnPhysicalQueryDiagnostics) {
+		tb.Helper()
+		assertNullableFullDataTopKBaseDiagnostics2878(tb, label, diag, len(missingOperation), q4MissingOperation.TopK, string(q4MissingOperation.TopKOrder), len(q4MissingOperationWant))
+		if !diag.TimeOrderTopKUsed || diag.DenseInt64SpanUsed {
+			tb.Fatalf("%s diagnostics=%+v want time-order topK only", label, diag)
+		}
+		if diag.RowsMatched != 1 || diag.ReduceRows != 1 {
+			tb.Fatalf("%s diagnostics=%+v want nullable missing operation to match exactly one row", label, diag)
+		}
+	})
+
+	q5MissingOperation := ColumnPhysicalQueryRequest{
+		Kind:              ColumnPhysicalQueryGroupInt64Span,
+		GroupColumn:       "did",
+		ValueColumn:       "time_us",
+		Predicates:        missingOperation,
+		TopK:              1,
+		TopKOrder:         ColumnPhysicalQueryTopKInt64Desc,
+		SkipEmptyGroupKey: true,
+	}
+	q5MissingOperationWant := []ColumnPhysicalQueryGroup{{Key: "did_x", Int64: 0}}
+	runNullableFullDataTopKFastPath2878(t, collection, "q5 missing operation", q5MissingOperation, q5MissingOperationWant, func(tb testing.TB, label string, diag ColumnPhysicalQueryDiagnostics) {
+		tb.Helper()
+		assertNullableFullDataTopKBaseDiagnostics2878(tb, label, diag, len(missingOperation), q5MissingOperation.TopK, string(q5MissingOperation.TopKOrder), len(q5MissingOperationWant))
+		if !diag.DenseInt64SpanUsed || diag.TimeOrderTopKUsed {
+			tb.Fatalf("%s diagnostics=%+v want dense int64-span only", label, diag)
+		}
+		if diag.RowsMatched != 1 || diag.ReduceRows != 1 {
+			tb.Fatalf("%s diagnostics=%+v want nullable missing operation to match exactly one row", label, diag)
+		}
+	})
 }
 
 func TestColumnPhysicalJSONBenchTypedColumnPartEdgeShapes1947(t *testing.T) {

--- a/TreeDB/collections/column_physical_typed_column_query.go
+++ b/TreeDB/collections/column_physical_typed_column_query.go
@@ -34,10 +34,11 @@ type columnTypedColumnDenseGroupCountPart struct {
 }
 
 type columnTypedColumnDensePredicatePart struct {
-	Codes      []uint32
-	Valid      []bool
-	Allowed    []uint64
-	RejectsAll bool
+	Codes               []uint32
+	Valid               []bool
+	Allowed             []uint64
+	MissingMatchesEmpty bool
+	RejectsAll          bool
 }
 
 type columnTypedColumnDenseGroupHourCountPart struct {
@@ -2017,12 +2018,12 @@ func columnTypedColumnDensePredicatesMatch(predicates []columnTypedColumnDensePr
 			return false
 		}
 		if !columnTypedColumnDenseCodeValid(predicate.Valid, rowIdx) {
-			return false
+			if !predicate.MissingMatchesEmpty {
+				return false
+			}
+			continue
 		}
-		code := predicate.Codes[rowIdx]
-		word := int(code / 64)
-		bit := uint(code % 64)
-		if word >= len(predicate.Allowed) || (predicate.Allowed[word]&(uint64(1)<<bit)) == 0 {
+		if !columnTypedColumnCodeAllowed(predicate.Allowed, predicate.Codes[rowIdx]) {
 			return false
 		}
 	}
@@ -2031,6 +2032,12 @@ func columnTypedColumnDensePredicatesMatch(predicates []columnTypedColumnDensePr
 
 func columnTypedColumnDenseCodeValid(valid []bool, rowIdx int) bool {
 	return valid == nil || (rowIdx >= 0 && rowIdx < len(valid) && valid[rowIdx])
+}
+
+func columnTypedColumnCodeAllowed(allowed []uint64, code uint32) bool {
+	word := int(code / 64)
+	bit := uint(code % 64)
+	return word < len(allowed) && (allowed[word]&(uint64(1)<<bit)) != 0
 }
 
 func columnTypedColumnPhysicalQueryUseSortedGroupedDistinct(plan columnTypedColumnPhysicalQueryPlan, req ColumnPhysicalQueryRequest) bool {

--- a/TreeDB/collections/column_physical_typed_column_query.go
+++ b/TreeDB/collections/column_physical_typed_column_query.go
@@ -35,6 +35,7 @@ type columnTypedColumnDenseGroupCountPart struct {
 
 type columnTypedColumnDensePredicatePart struct {
 	Codes      []uint32
+	Valid      []bool
 	Allowed    []uint64
 	RejectsAll bool
 }
@@ -51,6 +52,7 @@ type columnTypedColumnDenseInt64SpanPart struct {
 	Cardinality      int
 	DictionaryByCode map[int64]string
 	GroupCodes       []uint32
+	GroupValid       []bool
 	Values           []int64
 	Predicates       []columnTypedColumnDensePredicatePart
 }
@@ -1202,6 +1204,14 @@ func (r *columnTypedColumnPhysicalQueryRunner) runLatestVisibleDenseInt64Span(vi
 				matchedRows++
 			}
 			reduceRows++
+			if !columnTypedColumnDenseCodeValid(dense.GroupValid, rowIdx) {
+				if req.SkipEmptyGroupKey {
+					continue
+				}
+				diag := r.latestVisibleDiagnostics(view, req, state, visibilityBytes, visibilityNanos, rowsScanned, matchedRows, reduceRows, time.Since(start).Nanoseconds())
+				diag.DenseInt64SpanUsed = true
+				return ColumnPhysicalQueryResult{Diagnostics: diag}, fmt.Errorf("%w: dense typed-column int64-span nullable group column requires skip-empty group key", ErrColumnQueryPlanUnsupported)
+			}
 			localIdx, ok := columnDictionaryCodeIndex(code, len(r.denseLocalSpans))
 			if !ok {
 				diag := r.latestVisibleDiagnostics(view, req, state, visibilityBytes, visibilityNanos, rowsScanned, matchedRows, reduceRows, time.Since(start).Nanoseconds())
@@ -1284,7 +1294,7 @@ func columnTypedColumnPhysicalQueryShapeCanUseDenseInt64Span(req ColumnPhysicalQ
 }
 
 func columnTypedColumnPhysicalQueryUseDenseInt64Span(plan columnTypedColumnPhysicalQueryPlan, req ColumnPhysicalQueryRequest) bool {
-	return !plan.NullableStringValues && plan.DenseInt64Span && columnTypedColumnPhysicalQueryShapeCanUseDenseInt64Span(req)
+	return plan.DenseInt64Span && columnTypedColumnPhysicalQueryShapeCanUseDenseInt64Span(req) && columnTypedColumnPhysicalQueryNullableStringsAllowedForTopK(plan, req)
 }
 
 func columnTypedColumnPhysicalQueryShapeCanUseTimeOrderTopK(req ColumnPhysicalQueryRequest) bool {
@@ -1300,7 +1310,14 @@ func columnTypedColumnPhysicalQuerySortKeyCanUseTimeOrderTopK(sortKey []ColumnSo
 }
 
 func columnTypedColumnPhysicalQueryUseTimeOrderTopK(plan columnTypedColumnPhysicalQueryPlan, req ColumnPhysicalQueryRequest) bool {
-	return !plan.NullableStringValues && plan.TimeOrderTopK && columnTypedColumnPhysicalQueryShapeCanUseTimeOrderTopK(req)
+	return plan.TimeOrderTopK && columnTypedColumnPhysicalQueryShapeCanUseTimeOrderTopK(req) && columnTypedColumnPhysicalQueryNullableStringsAllowedForTopK(plan, req)
+}
+
+func columnTypedColumnPhysicalQueryNullableStringsAllowedForTopK(plan columnTypedColumnPhysicalQueryPlan, req ColumnPhysicalQueryRequest) bool {
+	if !plan.NullableStringValues {
+		return true
+	}
+	return req.SkipEmptyGroupKey
 }
 
 func (r *columnTypedColumnPhysicalQueryRunner) runTimeOrderTopK(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest) (ColumnPhysicalQueryResult, error) {
@@ -1913,6 +1930,14 @@ func (r *columnTypedColumnPhysicalQueryRunner) runDenseInt64Span(view columnPhys
 				matchedRows++
 			}
 			reduceRows++
+			if !columnTypedColumnDenseCodeValid(dense.GroupValid, rowIdx) {
+				if req.SkipEmptyGroupKey {
+					continue
+				}
+				diag := r.diagnostics(view, req, rowsScanned, matchedRows, reduceRows, time.Since(start).Nanoseconds())
+				diag.DenseInt64SpanUsed = true
+				return ColumnPhysicalQueryResult{Diagnostics: diag}, fmt.Errorf("%w: dense typed-column int64-span nullable group column requires skip-empty group key", ErrColumnQueryPlanUnsupported)
+			}
 			localIdx, ok := columnDictionaryCodeIndex(code, len(r.denseLocalSpans))
 			if !ok {
 				diag := r.diagnostics(view, req, rowsScanned, matchedRows, reduceRows, time.Since(start).Nanoseconds())
@@ -1991,6 +2016,9 @@ func columnTypedColumnDensePredicatesMatch(predicates []columnTypedColumnDensePr
 		if rowIdx < 0 || rowIdx >= len(predicate.Codes) {
 			return false
 		}
+		if !columnTypedColumnDenseCodeValid(predicate.Valid, rowIdx) {
+			return false
+		}
 		code := predicate.Codes[rowIdx]
 		word := int(code / 64)
 		bit := uint(code % 64)
@@ -1999,6 +2027,10 @@ func columnTypedColumnDensePredicatesMatch(predicates []columnTypedColumnDensePr
 		}
 	}
 	return true
+}
+
+func columnTypedColumnDenseCodeValid(valid []bool, rowIdx int) bool {
+	return valid == nil || (rowIdx >= 0 && rowIdx < len(valid) && valid[rowIdx])
 }
 
 func columnTypedColumnPhysicalQueryUseSortedGroupedDistinct(plan columnTypedColumnPhysicalQueryPlan, req ColumnPhysicalQueryRequest) bool {

--- a/TreeDB/collections/typed_column_adapter.go
+++ b/TreeDB/collections/typed_column_adapter.go
@@ -1467,10 +1467,11 @@ type columnTypedColumnTimeOrderCodeColumn struct {
 }
 
 type columnTypedColumnTimeOrderPredicateColumn struct {
-	CodeColumn    columnTypedColumnTimeOrderCodeColumn
-	Allowed       []uint64
-	RejectsAll    bool
-	UsesGroupCode bool
+	CodeColumn          columnTypedColumnTimeOrderCodeColumn
+	Allowed             []uint64
+	MissingMatchesEmpty bool
+	RejectsAll          bool
+	UsesGroupCode       bool
 }
 
 type columnTypedColumnTimeOrderTopKPart struct {
@@ -1553,25 +1554,26 @@ func decodeTypedColumnPhysicalQueryTimeOrderTopKPart(plan columnTypedColumnPhysi
 	predicates := make([]columnTypedColumnTimeOrderPredicateColumn, 0, len(plan.PredicateSpecs))
 	for _, spec := range plan.PredicateSpecs {
 		if spec.column == plan.GroupColumn {
-			allowed, rejectsAll, err := timeOrderTopKAllowedCodes(groupColumn, cardinality, spec)
+			allowed, missingMatchesEmpty, rejectsAll, err := timeOrderTopKAllowedCodes(groupColumn, cardinality, spec)
 			if err != nil {
 				return columnTypedColumnPhysicalQueryPart{}, err
 			}
-			predicates = append(predicates, columnTypedColumnTimeOrderPredicateColumn{CodeColumn: group, Allowed: allowed, RejectsAll: rejectsAll, UsesGroupCode: true})
+			predicates = append(predicates, columnTypedColumnTimeOrderPredicateColumn{CodeColumn: group, Allowed: allowed, MissingMatchesEmpty: missingMatchesEmpty, RejectsAll: rejectsAll, UsesGroupCode: true})
 			continue
 		}
 		predicateColumn, predicatePartColumn, predicateCardinality, err := typedColumnDenseStringCodeColumn(adapterPart, plan.Fields, spec.column, "time-order topK predicate")
 		if err != nil {
 			return columnTypedColumnPhysicalQueryPart{}, err
 		}
-		allowed, rejectsAll, err := timeOrderTopKAllowedCodes(predicateColumn, predicateCardinality, spec)
+		allowed, missingMatchesEmpty, rejectsAll, err := timeOrderTopKAllowedCodes(predicateColumn, predicateCardinality, spec)
 		if err != nil {
 			return columnTypedColumnPhysicalQueryPart{}, err
 		}
 		predicates = append(predicates, columnTypedColumnTimeOrderPredicateColumn{
-			CodeColumn: columnTypedColumnTimeOrderCodeColumn{PartColumn: predicatePartColumn, Cardinality: predicateCardinality, DictionaryByCode: predicateColumn.ReverseDictionary, Nullable: predicateColumn.Field.Nullable},
-			Allowed:    allowed,
-			RejectsAll: rejectsAll,
+			CodeColumn:          columnTypedColumnTimeOrderCodeColumn{PartColumn: predicatePartColumn, Cardinality: predicateCardinality, DictionaryByCode: predicateColumn.ReverseDictionary, Nullable: predicateColumn.Field.Nullable},
+			Allowed:             allowed,
+			MissingMatchesEmpty: missingMatchesEmpty,
+			RejectsAll:          rejectsAll,
 		})
 	}
 
@@ -1656,22 +1658,26 @@ func validateTypedColumnTimeOrderTopKMarks(part *typedcolumn.ColumnPart, valueCo
 	return nil
 }
 
-func timeOrderTopKAllowedCodes(column typedColumnAdapterColumn, cardinality int, spec columnPhysicalQueryPredicateSpec) ([]uint64, bool, error) {
+func timeOrderTopKAllowedCodes(column typedColumnAdapterColumn, cardinality int, spec columnPhysicalQueryPredicateSpec) ([]uint64, bool, bool, error) {
 	allowed := make([]uint64, (cardinality+63)/64)
 	matchedLiterals := 0
+	missingMatchesEmpty := false
 	for _, value := range spec.values {
+		if column.Field.Nullable && value == "" {
+			missingMatchesEmpty = true
+		}
 		code, ok := column.Dictionary[value]
 		if !ok {
 			continue
 		}
 		if code < 0 || uint64(code) >= uint64(cardinality) {
-			return nil, false, fmt.Errorf("collections: time-order topK predicate dictionary code %d outside cardinality %d for column %q", code, cardinality, column.Definition.Name)
+			return nil, false, false, fmt.Errorf("collections: time-order topK predicate dictionary code %d outside cardinality %d for column %q", code, cardinality, column.Definition.Name)
 		}
 		idx := int(code)
 		allowed[idx/64] |= uint64(1) << uint(idx%64)
 		matchedLiterals++
 	}
-	return allowed, matchedLiterals == 0, nil
+	return allowed, missingMatchesEmpty, matchedLiterals == 0 && !missingMatchesEmpty, nil
 }
 
 func (p *columnTypedColumnTimeOrderTopKPart) resetTimeOrderTopKScan() {
@@ -1758,12 +1764,12 @@ func (p *columnTypedColumnTimeOrderTopKPart) evaluateTimeOrderTopKRow(granuleIdx
 			return "", false, decoded, blocks, decodedBytes, fmt.Errorf("collections: time-order topK predicate row=%d outside decoded rows=%d", rowInGranule, len(codes))
 		}
 		if valid := p.predicateValid[predIdx]; valid != nil && !columnTypedColumnDenseCodeValid(valid, rowInGranule) {
-			return "", false, decoded, blocks, decodedBytes, nil
+			if !predicate.MissingMatchesEmpty {
+				return "", false, decoded, blocks, decodedBytes, nil
+			}
+			continue
 		}
-		code := codes[rowInGranule]
-		word := int(code / 64)
-		bit := uint(code % 64)
-		if word >= len(predicate.Allowed) || (predicate.Allowed[word]&(uint64(1)<<bit)) == 0 {
+		if !columnTypedColumnCodeAllowed(predicate.Allowed, codes[rowInGranule]) {
 			return "", false, decoded, blocks, decodedBytes, nil
 		}
 	}
@@ -2183,7 +2189,11 @@ func decodeTypedColumnDensePredicatePart(adapterPart *typedColumnAdapterPart, fi
 	}
 	allowed := make([]uint64, (cardinality+63)/64)
 	matchedLiterals := 0
+	missingMatchesEmpty := false
 	for _, value := range spec.values {
+		if adapterColumn.Field.Nullable && value == "" {
+			missingMatchesEmpty = true
+		}
 		code, ok := adapterColumn.Dictionary[value]
 		if !ok {
 			continue
@@ -2195,7 +2205,7 @@ func decodeTypedColumnDensePredicatePart(adapterPart *typedColumnAdapterPart, fi
 		allowed[idx/64] |= uint64(1) << uint(idx%64)
 		matchedLiterals++
 	}
-	if matchedLiterals == 0 {
+	if matchedLiterals == 0 && !missingMatchesEmpty {
 		return columnTypedColumnDensePredicatePart{RejectsAll: true}, 0, 0, nil
 	}
 	if adapterColumn.Field.Nullable {
@@ -2203,7 +2213,7 @@ func decodeTypedColumnDensePredicatePart(adapterPart *typedColumnAdapterPart, fi
 		if err != nil {
 			return columnTypedColumnDensePredicatePart{}, 0, 0, err
 		}
-		return columnTypedColumnDensePredicatePart{Codes: codes, Valid: valid, Allowed: allowed}, decodedBytes, blocks, nil
+		return columnTypedColumnDensePredicatePart{Codes: codes, Valid: valid, Allowed: allowed, MissingMatchesEmpty: missingMatchesEmpty}, decodedBytes, blocks, nil
 	}
 	codes, decodedBytes, blocks, err := decodeTypedColumnDenseUint32Codes(partColumn, cardinality, rows, "predicate")
 	if err != nil {

--- a/TreeDB/collections/typed_column_adapter.go
+++ b/TreeDB/collections/typed_column_adapter.go
@@ -1463,6 +1463,7 @@ type columnTypedColumnTimeOrderCodeColumn struct {
 	PartColumn       typedcolumn.ColumnPartColumn
 	Cardinality      int
 	DictionaryByCode map[int64]string
+	Nullable         bool
 }
 
 type columnTypedColumnTimeOrderPredicateColumn struct {
@@ -1483,7 +1484,9 @@ type columnTypedColumnTimeOrderTopKPart struct {
 	decodedGranule int
 	timeValues     []int64
 	groupCodes     []uint32
+	groupValid     []bool
 	predicateCodes [][]uint32
+	predicateValid [][]bool
 }
 
 // decodeTypedColumnPhysicalQueryTimeOrderTopKPart prepares the q4a
@@ -1546,7 +1549,7 @@ func decodeTypedColumnPhysicalQueryTimeOrderTopKPart(plan columnTypedColumnPhysi
 		return columnTypedColumnPhysicalQueryPart{}, err
 	}
 
-	group := columnTypedColumnTimeOrderCodeColumn{PartColumn: groupPartColumn, Cardinality: cardinality, DictionaryByCode: groupColumn.ReverseDictionary}
+	group := columnTypedColumnTimeOrderCodeColumn{PartColumn: groupPartColumn, Cardinality: cardinality, DictionaryByCode: groupColumn.ReverseDictionary, Nullable: groupColumn.Field.Nullable}
 	predicates := make([]columnTypedColumnTimeOrderPredicateColumn, 0, len(plan.PredicateSpecs))
 	for _, spec := range plan.PredicateSpecs {
 		if spec.column == plan.GroupColumn {
@@ -1566,7 +1569,7 @@ func decodeTypedColumnPhysicalQueryTimeOrderTopKPart(plan columnTypedColumnPhysi
 			return columnTypedColumnPhysicalQueryPart{}, err
 		}
 		predicates = append(predicates, columnTypedColumnTimeOrderPredicateColumn{
-			CodeColumn: columnTypedColumnTimeOrderCodeColumn{PartColumn: predicatePartColumn, Cardinality: predicateCardinality, DictionaryByCode: predicateColumn.ReverseDictionary},
+			CodeColumn: columnTypedColumnTimeOrderCodeColumn{PartColumn: predicatePartColumn, Cardinality: predicateCardinality, DictionaryByCode: predicateColumn.ReverseDictionary, Nullable: predicateColumn.Field.Nullable},
 			Allowed:    allowed,
 			RejectsAll: rejectsAll,
 		})
@@ -1675,12 +1678,21 @@ func (p *columnTypedColumnTimeOrderTopKPart) resetTimeOrderTopKScan() {
 	p.decodedGranule = -1
 	p.timeValues = p.timeValues[:0]
 	p.groupCodes = p.groupCodes[:0]
+	p.groupValid = p.groupValid[:0]
 	if cap(p.predicateCodes) < len(p.Predicates) {
 		p.predicateCodes = make([][]uint32, len(p.Predicates))
 	} else {
 		p.predicateCodes = p.predicateCodes[:len(p.Predicates)]
 		for idx := range p.predicateCodes {
 			p.predicateCodes[idx] = p.predicateCodes[idx][:0]
+		}
+	}
+	if cap(p.predicateValid) < len(p.Predicates) {
+		p.predicateValid = make([][]bool, len(p.Predicates))
+	} else {
+		p.predicateValid = p.predicateValid[:len(p.Predicates)]
+		for idx := range p.predicateValid {
+			p.predicateValid[idx] = p.predicateValid[idx][:0]
 		}
 	}
 }
@@ -1745,6 +1757,9 @@ func (p *columnTypedColumnTimeOrderTopKPart) evaluateTimeOrderTopKRow(granuleIdx
 		if rowInGranule < 0 || rowInGranule >= len(codes) {
 			return "", false, decoded, blocks, decodedBytes, fmt.Errorf("collections: time-order topK predicate row=%d outside decoded rows=%d", rowInGranule, len(codes))
 		}
+		if valid := p.predicateValid[predIdx]; valid != nil && !columnTypedColumnDenseCodeValid(valid, rowInGranule) {
+			return "", false, decoded, blocks, decodedBytes, nil
+		}
 		code := codes[rowInGranule]
 		word := int(code / 64)
 		bit := uint(code % 64)
@@ -1754,6 +1769,9 @@ func (p *columnTypedColumnTimeOrderTopKPart) evaluateTimeOrderTopKRow(granuleIdx
 	}
 	if rowInGranule < 0 || rowInGranule >= len(p.groupCodes) {
 		return "", false, decoded, blocks, decodedBytes, fmt.Errorf("collections: time-order topK group row=%d outside decoded rows=%d", rowInGranule, len(p.groupCodes))
+	}
+	if !columnTypedColumnDenseCodeValid(p.groupValid, rowInGranule) {
+		return "", true, decoded, blocks, decodedBytes, nil
 	}
 	groupCode := p.groupCodes[rowInGranule]
 	if uint64(groupCode) >= uint64(p.Group.Cardinality) {
@@ -1797,7 +1815,12 @@ func (p *columnTypedColumnTimeOrderTopKPart) ensureTimeOrderTopKGranuleDecoded(g
 	}
 	var groupBytes uint64
 	var groupBlocks int
-	p.groupCodes, groupBytes, groupBlocks, err = decodeTypedColumnUint32CodesForRowRange(p.Group.PartColumn, p.Group.Cardinality, granule.FirstRow, granule.RowCount, "time-order topK group", p.groupCodes)
+	if p.Group.Nullable {
+		p.groupCodes, p.groupValid, groupBytes, groupBlocks, err = decodeTypedColumnNullableUint32CodesForRowRange(p.Group.PartColumn, p.Group.Cardinality, granule.FirstRow, granule.RowCount, "time-order topK group", p.groupCodes, p.groupValid)
+	} else {
+		p.groupCodes, groupBytes, groupBlocks, err = decodeTypedColumnUint32CodesForRowRange(p.Group.PartColumn, p.Group.Cardinality, granule.FirstRow, granule.RowCount, "time-order topK group", p.groupCodes)
+		p.groupValid = nil
+	}
 	decodedBytes += groupBytes
 	blocks += groupBlocks
 	if err != nil {
@@ -1806,11 +1829,17 @@ func (p *columnTypedColumnTimeOrderTopKPart) ensureTimeOrderTopKGranuleDecoded(g
 	for idx, predicate := range p.Predicates {
 		if predicate.UsesGroupCode {
 			p.predicateCodes[idx] = p.groupCodes
+			p.predicateValid[idx] = p.groupValid
 			continue
 		}
 		var predicateBytes uint64
 		var predicateBlocks int
-		p.predicateCodes[idx], predicateBytes, predicateBlocks, err = decodeTypedColumnUint32CodesForRowRange(predicate.CodeColumn.PartColumn, predicate.CodeColumn.Cardinality, granule.FirstRow, granule.RowCount, "time-order topK predicate", p.predicateCodes[idx])
+		if predicate.CodeColumn.Nullable {
+			p.predicateCodes[idx], p.predicateValid[idx], predicateBytes, predicateBlocks, err = decodeTypedColumnNullableUint32CodesForRowRange(predicate.CodeColumn.PartColumn, predicate.CodeColumn.Cardinality, granule.FirstRow, granule.RowCount, "time-order topK predicate", p.predicateCodes[idx], p.predicateValid[idx])
+		} else {
+			p.predicateCodes[idx], predicateBytes, predicateBlocks, err = decodeTypedColumnUint32CodesForRowRange(predicate.CodeColumn.PartColumn, predicate.CodeColumn.Cardinality, granule.FirstRow, granule.RowCount, "time-order topK predicate", p.predicateCodes[idx])
+			p.predicateValid[idx] = nil
+		}
 		decodedBytes += predicateBytes
 		blocks += predicateBlocks
 		if err != nil {
@@ -1923,6 +1952,77 @@ func decodeTypedColumnUint32CodesForRowRange(partColumn typedcolumn.ColumnPartCo
 	return out, decodedBytes, blocks, nil
 }
 
+func decodeTypedColumnNullableUint32CodesForRowRange(partColumn typedcolumn.ColumnPartColumn, cardinality, firstRow, rowCount int, role string, dst []uint32, validDst []bool) ([]uint32, []bool, uint64, int, error) {
+	if rowCount < 0 || firstRow < 0 {
+		return nil, nil, 0, 0, fmt.Errorf("collections: dense typed-column %s invalid row range first=%d rows=%d", role, firstRow, rowCount)
+	}
+	if rowCount == 0 {
+		return dst[:0], validDst[:0], 0, 0, nil
+	}
+	limit := firstRow + rowCount
+	out := dst[:0]
+	if cap(out) < rowCount {
+		out = make([]uint32, 0, rowCount)
+	}
+	valid := validDst[:0]
+	if cap(valid) < rowCount {
+		valid = make([]bool, 0, rowCount)
+	}
+	var valueScratch []int64
+	var nullScratch []bool
+	var defaultScratch []bool
+	var reader typedcolumn.GranuleReader
+	decodedBytes := uint64(0)
+	blocks := 0
+	for blockIdx, block := range partColumn.Blocks {
+		blockFirst := block.Descriptor.FirstRow
+		blockLimit := blockFirst + block.Descriptor.RowCount
+		if blockLimit <= firstRow {
+			continue
+		}
+		if blockFirst >= limit {
+			break
+		}
+		g := block.Granule
+		if g.HasMinMax {
+			if g.Min < 0 || g.Max < 0 || g.Min > g.Max || uint64(g.Max) >= uint64(cardinality) {
+				return nil, nil, decodedBytes, blocks, fmt.Errorf("collections: dense typed-column %s block %d min/max [%d,%d] outside cardinality %d", role, blockIdx, g.Min, g.Max, cardinality)
+			}
+		}
+		values, nulls, defaults, err := reader.DecodeNullableInt64Into(valueScratch[:0], nullScratch[:0], defaultScratch[:0], g)
+		if err != nil {
+			return nil, nil, decodedBytes, blocks, fmt.Errorf("collections: dense typed-column %s block %d: %w", role, blockIdx, err)
+		}
+		if len(values) != block.Descriptor.RowCount || len(nulls) != block.Descriptor.RowCount || len(defaults) != block.Descriptor.RowCount {
+			return nil, nil, decodedBytes, blocks, fmt.Errorf("collections: dense typed-column %s block %d decoded rows values/nulls/defaults=%d/%d/%d want %d", role, blockIdx, len(values), len(nulls), len(defaults), block.Descriptor.RowCount)
+		}
+		start := max(firstRow, blockFirst)
+		end := min(limit, blockLimit)
+		for row := start - blockFirst; row < end-blockFirst; row++ {
+			if nulls[row] || defaults[row] {
+				out = append(out, 0)
+				valid = append(valid, false)
+				continue
+			}
+			code := values[row]
+			if code < 0 || uint64(code) >= uint64(cardinality) || code > int64(^uint32(0)) {
+				return nil, nil, decodedBytes, blocks, fmt.Errorf("collections: dense typed-column %s code=%d outside cardinality=%d", role, code, cardinality)
+			}
+			out = append(out, uint32(code))
+			valid = append(valid, true)
+		}
+		valueScratch = values
+		nullScratch = nulls
+		defaultScratch = defaults
+		decodedBytes += uint64(g.RawBytes)
+		blocks++
+	}
+	if len(out) != rowCount || len(valid) != rowCount {
+		return nil, nil, decodedBytes, blocks, fmt.Errorf("collections: dense typed-column %s decoded rows codes/valid=%d/%d want range rows=%d", role, len(out), len(valid), rowCount)
+	}
+	return out, valid, decodedBytes, blocks, nil
+}
+
 // decodeTypedColumnPhysicalQueryDenseInt64SpanPart prepares the q5 typed-column
 // section fast path from the adapter seam so production query routing does not
 // import the typedcolumn data plane directly.
@@ -1974,9 +2074,20 @@ func decodeTypedColumnPhysicalQueryDenseInt64SpanPart(plan columnTypedColumnPhys
 		return columnTypedColumnPhysicalQueryPart{}, fmt.Errorf("%w: dense typed-column int64-span value column %q type=%s", ErrColumnQueryPlanUnsupported, plan.ValueColumn, valuePartColumn.Definition.Type)
 	}
 
-	groupCodes, groupDecodedBytes, groupBlocks, err := decodeTypedColumnDenseUint32Codes(groupPartColumn, cardinality, summary.Rows, "int64-span group")
-	if err != nil {
-		return columnTypedColumnPhysicalQueryPart{}, err
+	var groupCodes []uint32
+	var groupValid []bool
+	var groupDecodedBytes uint64
+	var groupBlocks int
+	if groupColumn.Field.Nullable {
+		groupCodes, groupValid, groupDecodedBytes, groupBlocks, err = decodeTypedColumnDenseNullableUint32Codes(groupPartColumn, cardinality, summary.Rows, "int64-span group")
+		if err != nil {
+			return columnTypedColumnPhysicalQueryPart{}, err
+		}
+	} else {
+		groupCodes, groupDecodedBytes, groupBlocks, err = decodeTypedColumnDenseUint32Codes(groupPartColumn, cardinality, summary.Rows, "int64-span group")
+		if err != nil {
+			return columnTypedColumnPhysicalQueryPart{}, err
+		}
 	}
 	values, valueDecodedBytes, valueBlocks, err := decodeTypedColumnDenseInt64Values(valuePartColumn, summary.Rows, "int64-span value")
 	if err != nil {
@@ -2015,6 +2126,7 @@ func decodeTypedColumnPhysicalQueryDenseInt64SpanPart(plan columnTypedColumnPhys
 			Cardinality:      cardinality,
 			DictionaryByCode: groupColumn.ReverseDictionary,
 			GroupCodes:       groupCodes,
+			GroupValid:       groupValid,
 			Values:           values,
 			Predicates:       predicates,
 		},
@@ -2035,14 +2147,18 @@ func typedColumnDenseStringCodeColumn(adapterPart *typedColumnAdapterPart, field
 			break
 		}
 	}
-	if adapterColumn.Field.Nullable || adapterColumn.Definition.Type != typedcolumn.ColumnTypeLowCardinalityCode || adapterColumn.Definition.Encoding != typedcolumn.EncodingLowCardinalityUint32 {
-		return typedColumnAdapterColumn{}, typedcolumn.ColumnPartColumn{}, 0, fmt.Errorf("%w: dense typed-column %s column %q is not a non-null low-cardinality string", ErrColumnQueryPlanUnsupported, role, column)
+	wantEncoding := typedcolumn.EncodingLowCardinalityUint32
+	if adapterColumn.Field.Nullable {
+		wantEncoding = typedcolumn.EncodingNullableInt64
+	}
+	if adapterColumn.Definition.Type != typedcolumn.ColumnTypeLowCardinalityCode || adapterColumn.Definition.Encoding != wantEncoding {
+		return typedColumnAdapterColumn{}, typedcolumn.ColumnPartColumn{}, 0, fmt.Errorf("%w: dense typed-column %s column %q is not a compatible low-cardinality string", ErrColumnQueryPlanUnsupported, role, column)
 	}
 	partColumn, ok := adapterPart.Part.Columns[adapterColumn.Definition.Name]
 	if !ok {
 		return typedColumnAdapterColumn{}, typedcolumn.ColumnPartColumn{}, 0, fmt.Errorf("collections: dense typed-column %s missing column %q", role, adapterColumn.Definition.Name)
 	}
-	if partColumn.Definition.Type != typedcolumn.ColumnTypeLowCardinalityCode || partColumn.Definition.Encoding != typedcolumn.EncodingLowCardinalityUint32 || partColumn.Definition.Cardinality == 0 {
+	if partColumn.Definition.Type != typedcolumn.ColumnTypeLowCardinalityCode || partColumn.Definition.Encoding != wantEncoding || (!adapterColumn.Field.Nullable && partColumn.Definition.Cardinality == 0) {
 		return typedColumnAdapterColumn{}, typedcolumn.ColumnPartColumn{}, 0, fmt.Errorf("%w: dense typed-column %s column %q type=%s encoding=%s cardinality=%d", ErrColumnQueryPlanUnsupported, role, column, partColumn.Definition.Type, partColumn.Definition.Encoding, partColumn.Definition.Cardinality)
 	}
 	if uint64(int(partColumn.Definition.Cardinality)) != uint64(partColumn.Definition.Cardinality) {
@@ -2081,6 +2197,13 @@ func decodeTypedColumnDensePredicatePart(adapterPart *typedColumnAdapterPart, fi
 	}
 	if matchedLiterals == 0 {
 		return columnTypedColumnDensePredicatePart{RejectsAll: true}, 0, 0, nil
+	}
+	if adapterColumn.Field.Nullable {
+		codes, valid, decodedBytes, blocks, err := decodeTypedColumnDenseNullableUint32Codes(partColumn, cardinality, rows, "predicate")
+		if err != nil {
+			return columnTypedColumnDensePredicatePart{}, 0, 0, err
+		}
+		return columnTypedColumnDensePredicatePart{Codes: codes, Valid: valid, Allowed: allowed}, decodedBytes, blocks, nil
 	}
 	codes, decodedBytes, blocks, err := decodeTypedColumnDenseUint32Codes(partColumn, cardinality, rows, "predicate")
 	if err != nil {
@@ -2121,6 +2244,10 @@ func decodeTypedColumnDenseUint32Codes(partColumn typedcolumn.ColumnPartColumn, 
 		return nil, 0, 0, fmt.Errorf("collections: dense typed-column %s decoded rows=%d want part rows=%d", role, len(codes), rows)
 	}
 	return codes, decodedBytes, len(partColumn.Blocks), nil
+}
+
+func decodeTypedColumnDenseNullableUint32Codes(partColumn typedcolumn.ColumnPartColumn, cardinality int, rows int, role string) ([]uint32, []bool, uint64, int, error) {
+	return decodeTypedColumnNullableUint32CodesForRowRange(partColumn, cardinality, 0, rows, role, make([]uint32, 0, rows), make([]bool, 0, rows))
 }
 
 func decodeTypedColumnDenseInt64Values(partColumn typedcolumn.ColumnPartColumn, rows int, role string) ([]int64, uint64, int, error) {


### PR DESCRIPTION
## Summary
- allow typed-column q4/q5 TopK fast paths for nullable full-data string columns when the request skips empty group keys
- decode nullable dictionary-code columns with validity masks for time-order TopK predicates/groups and dense int64-span predicates/groups
- add nullable full-data q4/q5 coverage for direct and prepared runners, including fast-path diagnostics

Part of #2878. This is the gomap engine-side fast-path fix; JSONBench request wiring and current-main evidence will follow in the paired JSONBench PR after this dependency lands.

## Validation
- `go test ./TreeDB/collections -run 'NullableFullData|Q4A|Q5Dense' -count=1`\n- `go test ./TreeDB/collections -count=1`