### PR TITLE
treedb: specialize scalar_u8 scorer score loops

### DIFF
--- a/TreeDB/collections/column_vector_graph_quantized_asset_test.go
+++ b/TreeDB/collections/column_vector_graph_quantized_asset_test.go
@@ -592,6 +592,17 @@ func TestColumnGraphScalarU8AlphaScorerAdjustsRankingAndTies2844(t *testing.T) {
 	if stats.QuantizedScoreCalls != uint64(len(ordinals)) || stats.QuantizedScoreCodecScalarU8Alpha != 1 || stats.VectorBytesRead != 0 || stats.NormBytesRead != 0 {
 		t.Fatalf("alpha scorer stats=%+v", stats)
 	}
+	legacyScorer := scorer
+	legacyScorer.alphaLookup = nil
+	legacyScorer.alphaScoreScales = nil
+	var legacyScratch columnVectorGraphNativeSearchScratch
+	var legacyStats columnVectorGraphNativeSearchStats
+	if _, err := legacyScorer.scoreOrdinals(ordinals, scores[:0], &legacyScratch, &legacyStats); err != nil {
+		t.Fatalf("legacy scoreOrdinals: %v", err)
+	}
+	if legacyStats.QuantizedScoreCalls != uint64(len(ordinals)) || legacyStats.QuantizedScoreCodecScalarU8Alpha != 0 {
+		t.Fatalf("legacy scorer stats=%+v want no scalar_u8 alpha counter", legacyStats)
+	}
 }
 
 func TestColumnGraphScalarU8AlphaLookupUniformGranuleEdges2866(t *testing.T) {

--- a/TreeDB/collections/column_vector_graph_quantized_scorer.go
+++ b/TreeDB/collections/column_vector_graph_quantized_scorer.go
@@ -302,8 +302,14 @@ func (s *columnVectorGraphScalarU8QuantizedScorer) scoreRowIDsPrepared(rowIDs []
 	if err != nil {
 		return dst[:0], err
 	}
+	if s.alphaLookup == nil {
+		for i, dot := range dots {
+			dst[i] = scalarU8QuantizedCosineScoreFromDot(dot)
+		}
+		return dst, nil
+	}
 	for i, dot := range dots {
-		score, ok := s.scoreFromDotRowID(dot, rowIDs[i])
+		score, ok := s.scoreAlphaFromDotRowID(dot, rowIDs[i])
 		if !ok {
 			return dst[:0], fmt.Errorf("%w: column_graph quantized index %q scalar_u8 alpha row_id=%d unavailable", ErrVectorIndexSearchUnavailable, s.indexName, rowIDs[i])
 		}
@@ -315,6 +321,13 @@ func (s *columnVectorGraphScalarU8QuantizedScorer) scoreRowIDsPrepared(rowIDs []
 func (s *columnVectorGraphScalarU8QuantizedScorer) scoreFromDotRowID(dot int64, rowID uint32) (float64, bool) {
 	if s == nil || s.alphaLookup == nil {
 		return scalarU8QuantizedCosineScoreFromDot(dot), true
+	}
+	return s.scoreAlphaFromDotRowID(dot, rowID)
+}
+
+func (s *columnVectorGraphScalarU8QuantizedScorer) scoreAlphaFromDotRowID(dot int64, rowID uint32) (float64, bool) {
+	if s == nil || s.alphaLookup == nil {
+		return 0, false
 	}
 	row := int(rowID)
 	if len(s.alphaScoreScales) == s.alphaLookup.granules {
@@ -573,15 +586,27 @@ func (s *columnVectorGraphScalarU8QuantizedScorer) scoreGreedyBestRowIDsPrevalid
 		return best, bestScore, false, err
 	}
 	changed := false
+	if s.alphaLookup == nil {
+		for i, rowID := range rowIDs {
+			neighborOrdinal := int(rowID)
+			score := scalarU8QuantizedCosineScoreFromDot(dots[i])
+			// Preserve the prepared traversal's public float64 score formula and
+			// exact lower-ordinal tie behavior while avoiding the intermediate
+			// float64 score tile used by the generic row-ID score seam.
+			if score > bestScore || (score == bestScore && neighborOrdinal < best) {
+				best = neighborOrdinal
+				bestScore = score
+				changed = true
+			}
+		}
+		return best, bestScore, changed, nil
+	}
 	for i, rowID := range rowIDs {
 		neighborOrdinal := int(rowID)
-		score, ok := s.scoreFromDotRowID(dots[i], rowID)
+		score, ok := s.scoreAlphaFromDotRowID(dots[i], rowID)
 		if !ok {
 			return best, bestScore, false, fmt.Errorf("%w: column_graph quantized index %q scalar_u8 alpha row_id=%d unavailable", ErrVectorIndexSearchUnavailable, s.indexName, rowID)
 		}
-		// Preserve the prepared traversal's public float64 score formula and
-		// exact lower-ordinal tie behavior while avoiding the intermediate
-		// float64 score tile used by the generic row-ID score seam.
 		if score > bestScore || (score == bestScore && neighborOrdinal < best) {
 			best = neighborOrdinal
 			bestScore = score
@@ -603,8 +628,17 @@ func (s *columnVectorGraphScalarU8QuantizedScorer) scoreAndPushFrontierVisitedRo
 	if err != nil {
 		return 0, err
 	}
+	if s.alphaLookup == nil {
+		for i, rowID := range rowIDs {
+			candidate := columnVectorGraphSearchCandidate{ordinal: int(rowID), score: scalarU8QuantizedCosineScoreFromDot(dots[i])}
+			if scratch.insertTop(topK, candidate) {
+				scratch.pushFrontierAccounting(candidate, stats)
+			}
+		}
+		return len(rowIDs), nil
+	}
 	for i, rowID := range rowIDs {
-		score, ok := s.scoreFromDotRowID(dots[i], rowID)
+		score, ok := s.scoreAlphaFromDotRowID(dots[i], rowID)
 		if !ok {
 			return 0, fmt.Errorf("%w: column_graph quantized index %q scalar_u8 alpha row_id=%d unavailable", ErrVectorIndexSearchUnavailable, s.indexName, rowID)
 		}


### PR DESCRIPTION
Closes #2868.

Parent: #2864. Follows #2865, #2866, and #2867.

## Summary

* Split `scalar_u8` row-score conversion loops into separate legacy and alpha paths after raw-dot scoring.
* Keep the legacy path free of per-row alpha dispatch.
* Keep alpha adjustment isolated in a dedicated helper using precomputed per-granule scales.
* Add a regression assertion that legacy `scalar_u8` scoring does not report the alpha stats counter, while alpha scoring does.

## Tests

* `GOMAXPROCS=8 GOWORK=off go test ./TreeDB/collections -run 'TestColumnGraphScalarU8AlphaScorer|TestColumnGraphScalarU8AlphaPreparedTraversal|TestColumnGraphScalarU8AlphaLookup' -count=1`
* `GOMAXPROCS=8 GOWORK=off go test ./TreeDB/collections -count=1`

## Benchmarks / Profiles

* Baseline from #2865:

  * Alpha focused qonly `c=1`: 26,211 ns/op, 0 B/op, 0 allocs/op
  * Legacy: 24,355 ns/op
* After #2867:

  * Alpha focused qonly `c=1`: 23,620 ns/op
  * Legacy: 21,774 ns/op
* This PR:

  * Alpha focused qonly `c=1`: 23,341 ns/op, 0 B/op, 0 allocs/op
  * Legacy qonly `c=1`: 22,093 ns/op, 0 B/op, 0 allocs/op
  * Artifact: `/tmp/alpha_2868_20260619_094748/`
* Profile confirms that legacy avoids the alpha helper, while alpha uses the dedicated `scoreAlphaFromDotRowID` helper, which accounts for ~3.44% flat in the focused alpha profile.

## Regression Gate

* No default behavior change; omitted `scalar_u8_calibration` remains legacy.
* Stats, API, and fail-closed behavior are preserved.

## AI Review

* Not requested yet; local test and benchmark evidence are included for coordinator review.
