### PR TITLE
TreeDB text-v2 scalar-aware pruning

### DIFF
--- a/TreeDB/collections/text_explain.go
+++ b/TreeDB/collections/text_explain.go
@@ -318,7 +318,7 @@ func textSearchExplainBindV2Context(explain *TextSearchExplain, ctx *textV2Searc
 	explain.Serving.BM25B = textSearchBM25B
 	if allowSet != nil {
 		explain.Serving.ScalarPruning.Enabled = true
-		explain.Serving.ScalarPruning.AllowSetSize = uint64(len(allowSet.sorted))
+		explain.Serving.ScalarPruning.AllowSetSize = uint64(allowSet.size())
 	}
 }
 

--- a/TreeDB/collections/text_v2_phrase.go
+++ b/TreeDB/collections/text_v2_phrase.go
@@ -46,7 +46,7 @@ func executeTextV2PhraseSearchAtSnapshot(
 	}
 	textSearchExplainBindV2Context(response.Explain, ctx, uniqueTerms, allowSet)
 	if allowSet != nil {
-		response.Stats.TextScalarPrefilterIDs = uint64(len(allowSet.sorted))
+		response.Stats.TextScalarPrefilterIDs = uint64(allowSet.size())
 	}
 	if allowSet.empty() {
 		response.Results = []TextSearchResult{}

--- a/TreeDB/collections/text_v2_scalar_pruning_2874_test.go
+++ b/TreeDB/collections/text_v2_scalar_pruning_2874_test.go
@@ -1,0 +1,305 @@
+package collections
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"math"
+	"testing"
+)
+
+func TestTextV2ScalarPruningPostFilterParity2874(t *testing.T) {
+	d := openTextV2TestDB(t, t.TempDir(), false)
+	defer func() { _ = d.Close() }()
+
+	const docsN = 512
+	ids, docs := textV2ScalarPruningDocs2874(docsN)
+	col := createTextSearchCollection2627(t, d, "docs", TextIndexDefinition{
+		Name:    "lexical",
+		Version: TextIndexVersionV2,
+		Fields:  []TextIndexField{{Field: "title", Weight: 3}, {Field: "body"}},
+	}, ids, docs)
+
+	cases := []struct {
+		name         string
+		query        string
+		operator     TextSearchOperator
+		topK         int
+		allow        hybridScalarAllowSet
+		wantBlocks   bool
+		wantPostings bool
+	}{
+		{name: "selective_block_skip_single", query: "refund", topK: 5, allow: textV2ScalarAllowFirst2874(8), wantBlocks: true},
+		{name: "interleaved_posting_reject_or", query: "refund OR policy", operator: TextSearchOperatorOR, topK: 8, allow: textV2ScalarAllowEvery2874(docsN, 17), wantPostings: true},
+		{name: "interleaved_posting_reject_and", query: "refund AND policy", operator: TextSearchOperatorAND, topK: 8, allow: textV2ScalarAllowEvery2874(docsN, 19), wantPostings: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := TextSearchOptions{IndexName: "lexical", Query: tc.query, Operator: tc.operator, TopK: tc.topK, CandidateLimit: docsN, MaxPostingsScanned: docsN * 8, textV2AllowedDocumentIDs: tc.allow}
+			got, err := col.searchText(opts, textSearchResultScoreOnly)
+			if err != nil {
+				t.Fatalf("scalar-pruned search: %v", err)
+			}
+			refOpts := opts
+			refOpts.TopK = docsN
+			refOpts.CandidateLimit = docsN
+			refOpts.textV2AllowedDocumentIDs = nil
+			refOpts.textV2DisableBlockMax = true
+			all, err := col.searchText(refOpts, textSearchResultScoreOnly)
+			if err != nil {
+				t.Fatalf("exhaustive unfiltered reference: %v", err)
+			}
+			want := textV2ScalarPostFilterReference2874(all, tc.allow, tc.topK)
+			assertTextV2ScalarResults2874(t, got.Results, want)
+			if got.Stats.FailClosed != 0 || got.Stats.DocumentsFetched != 0 || got.Stats.FullDocumentScanFallbacks != 0 || got.Stats.TextStateLookups != 0 {
+				t.Fatalf("stats=%+v want exact no-doc scalar pruning", got.Stats)
+			}
+			if got.Stats.TextScalarPrefilterIDs != uint64(len(tc.allow)) {
+				t.Fatalf("stats=%+v want scalar prefilter ids=%d", got.Stats, len(tc.allow))
+			}
+			if tc.wantBlocks && got.Stats.TextScalarPostingBlocksSkipped == 0 {
+				t.Fatalf("stats=%+v want scalar posting-block skips", got.Stats)
+			}
+			if tc.wantPostings && got.Stats.TextScalarPostingsRejected == 0 {
+				t.Fatalf("stats=%+v want scalar posting rejections", got.Stats)
+			}
+			if got.Stats.TextCandidatesScored > uint64(len(tc.allow)) {
+				t.Fatalf("stats=%+v want scored candidates bounded by allow-set size %d", got.Stats, len(tc.allow))
+			}
+		})
+	}
+}
+
+func TestTextV2ScalarPruningMissingAllowedDocIDFailsClosed2874(t *testing.T) {
+	d := openTextV2TestDB(t, t.TempDir(), false)
+	defer func() { _ = d.Close() }()
+
+	ids, docs := textV2ScalarPruningDocs2874(32)
+	col := createTextSearchCollection2627(t, d, "docs", TextIndexDefinition{Name: "lexical", Version: TextIndexVersionV2, Fields: []TextIndexField{{Field: "title"}, {Field: "body"}}}, ids, docs)
+	got, err := col.searchText(TextSearchOptions{
+		IndexName:                "lexical",
+		Query:                    "refund",
+		TopK:                     5,
+		CandidateLimit:           32,
+		MaxPostingsScanned:       128,
+		textV2AllowedDocumentIDs: hybridScalarAllowSet{"doc-000000": {}, "doc-missing": {}},
+	}, textSearchResultScoreOnly)
+	if !errors.Is(err, ErrTextIndexUnavailable) || !errors.Is(err, ErrTextIndexStorageCorrupt) {
+		t.Fatalf("err=%v want text index unavailable/storage corrupt", err)
+	}
+	if got.Stats.FailClosed != 1 || got.Stats.FailClosedReason != textSearchFailClosedStorageCorrupt || got.Stats.DocumentsFetched != 0 || got.Stats.FullDocumentScanFallbacks != 0 || got.Stats.TextPostingsScanned != 0 {
+		t.Fatalf("response=%+v want fail-closed before posting traversal and no docs", got)
+	}
+}
+
+func TestTextV2ScalarPruningHybridReopenNoDocGuardrail2874(t *testing.T) {
+	dir := t.TempDir()
+	d := openTextV2TestDB(t, dir, false)
+	closed := false
+	defer func() {
+		if !closed {
+			_ = d.Close()
+		}
+	}()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "docs", Indexes: []IndexDefinition{{Name: "tenant", Field: "tenant", ValueType: IndexValueString}}}); err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	col, err := mgr.OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("OpenCollection: %v", err)
+	}
+	ids, docs := textV2ScalarPruningTenantDocs2874(160, 6)
+	if _, err := col.InsertBatch(ids, docs); err != nil {
+		t.Fatalf("InsertBatch: %v", err)
+	}
+	if _, _, err := col.CreateTextIndex(TextIndexDefinition{Name: "lexical", Version: TextIndexVersionV2, Fields: []TextIndexField{{Field: "title", Weight: 2}, {Field: "body"}}}); err != nil {
+		t.Fatalf("CreateTextIndex: %v", err)
+	}
+
+	before := textV2SearchHybridRareTenant2874(t, col, 4)
+	if before.Stats.DocumentsFetched != 0 || before.Stats.FullDocumentScanFallbacks != 0 || before.Stats.FailClosed != 0 || before.Stats.TextScalarPrefilterIDs != 6 {
+		t.Fatalf("before=%+v want no-doc scalar-pruned hybrid search", before)
+	}
+	if err := d.Checkpoint(); err != nil {
+		t.Fatalf("Checkpoint: %v", err)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	closed = true
+
+	reopened := openTextV2TestDB(t, dir, false)
+	defer func() { _ = reopened.Close() }()
+	reopenedCol, err := NewCollectionManager(reopened).OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("OpenCollection reopened: %v", err)
+	}
+	after := textV2SearchHybridRareTenant2874(t, reopenedCol, 4)
+	assertHybridSearchResultIDs2874(t, after.Results, hybridSearchResultIDs2874(before.Results))
+	if after.Stats.DocumentsFetched != 0 || after.Stats.FullDocumentScanFallbacks != 0 || after.Stats.FailClosed != 0 || after.Stats.TextScalarPrefilterIDs != before.Stats.TextScalarPrefilterIDs {
+		t.Fatalf("after=%+v before=%+v want snapshot-stable no-doc scalar pruning after reopen", after, before)
+	}
+}
+
+func BenchmarkTextV2ScalarPruningSelectivity2874(b *testing.B) {
+	d := openTextV2TestDB(b, b.TempDir(), false)
+	defer func() { _ = d.Close() }()
+
+	const docsN = 4096
+	ids, docs := textV2ScalarPruningDocs2874(docsN)
+	col := createTextSearchCollection2627(b, d, "docs", TextIndexDefinition{Name: "lexical", Version: TextIndexVersionV2, Fields: []TextIndexField{{Field: "title", Weight: 3}, {Field: "body"}}}, ids, docs)
+	cases := []struct {
+		name  string
+		allow hybridScalarAllowSet
+	}{
+		{name: "no_filter", allow: nil},
+		{name: "selectivity_0_1pct", allow: textV2ScalarAllowCount2874(docsN, maxTextV2ScalarInt2874(1, docsN/1000))},
+		{name: "selectivity_1pct", allow: textV2ScalarAllowCount2874(docsN, docsN/100)},
+		{name: "selectivity_5pct", allow: textV2ScalarAllowCount2874(docsN, docsN*5/100)},
+		{name: "selectivity_10pct", allow: textV2ScalarAllowCount2874(docsN, docsN/10)},
+		{name: "selectivity_25pct", allow: textV2ScalarAllowCount2874(docsN, docsN/4)},
+		{name: "selectivity_50pct", allow: textV2ScalarAllowCount2874(docsN, docsN/2)},
+		{name: "selectivity_100pct", allow: textV2ScalarAllowCount2874(docsN, docsN)},
+	}
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			opts := TextSearchOptions{IndexName: "lexical", Query: "refund OR policy", Operator: TextSearchOperatorOR, TopK: 10, CandidateLimit: docsN, MaxPostingsScanned: docsN * 8, textV2AllowedDocumentIDs: tc.allow}
+			var last TextSearchResponse
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				got, err := col.searchText(opts, textSearchResultScoreOnly)
+				if err != nil {
+					b.Fatalf("searchText: %v", err)
+				}
+				last = got
+			}
+			b.StopTimer()
+			b.ReportMetric(float64(last.Stats.TextScalarPrefilterIDs), "scalar_prefilter_ids/search")
+			b.ReportMetric(float64(last.Stats.TextScalarPostingBlocksSkipped), "scalar_posting_blocks_skipped/search")
+			b.ReportMetric(float64(last.Stats.TextScalarPostingsRejected), "scalar_postings_rejected/search")
+			b.ReportMetric(float64(last.Stats.TextCandidatesScored), "candidates_scored/search")
+			b.ReportMetric(float64(last.Stats.TextCandidatesReturned), "text_candidates/search")
+			b.ReportMetric(float64(last.Stats.TextPostingBlocksVisited), "blocks_visited/search")
+			b.ReportMetric(float64(last.Stats.TextPostingBlocksSkipped), "blocks_skipped/search")
+			b.ReportMetric(float64(last.Stats.DocumentsFetched), "docs_fetched/search")
+			b.ReportMetric(float64(last.Stats.TextPostingsScanned), "postings_scanned/search")
+		})
+	}
+}
+
+func textV2ScalarPruningDocs2874(count int) ([][]byte, [][]byte) {
+	ids := make([][]byte, count)
+	docs := make([][]byte, count)
+	for i := range ids {
+		ids[i] = []byte(fmt.Sprintf("doc-%06d", i))
+		title := "refund policy"
+		if i%7 == 0 {
+			title = "refund refund policy"
+		}
+		body := fmt.Sprintf("refund policy support common shard-%02d bucket-%02d", i%13, i%29)
+		docs[i] = []byte(fmt.Sprintf(`{"title":%q,"body":%q}`, title, body))
+	}
+	return ids, docs
+}
+
+func textV2ScalarPruningTenantDocs2874(count, rare int) ([][]byte, [][]byte) {
+	ids := make([][]byte, count)
+	docs := make([][]byte, count)
+	for i := range ids {
+		ids[i] = []byte(fmt.Sprintf("doc-%06d", i))
+		tenant := "tenant-broad"
+		if i < rare {
+			tenant = "tenant-rare"
+		}
+		docs[i] = []byte(fmt.Sprintf(`{"title":"refund policy","body":"refund policy support %03d","tenant":%q}`, i, tenant))
+	}
+	return ids, docs
+}
+
+func textV2ScalarAllowFirst2874(count int) hybridScalarAllowSet {
+	return textV2ScalarAllowCount2874(count, count)
+}
+
+func textV2ScalarAllowEvery2874(total, step int) hybridScalarAllowSet {
+	allow := make(hybridScalarAllowSet)
+	if step <= 0 {
+		step = 1
+	}
+	for i := 0; i < total; i += step {
+		allow[fmt.Sprintf("doc-%06d", i)] = struct{}{}
+	}
+	return allow
+}
+
+func textV2ScalarAllowCount2874(total, count int) hybridScalarAllowSet {
+	allow := make(hybridScalarAllowSet, count)
+	if count > total {
+		count = total
+	}
+	for i := 0; i < count; i++ {
+		allow[fmt.Sprintf("doc-%06d", i)] = struct{}{}
+	}
+	return allow
+}
+
+func textV2ScalarPostFilterReference2874(all TextSearchResponse, allow hybridScalarAllowSet, topK int) []TextSearchResult {
+	filtered := make([]TextSearchResult, 0, len(all.Results))
+	for _, result := range all.Results {
+		if _, ok := allow[string(result.DocumentID)]; !ok {
+			continue
+		}
+		result.Rank = len(filtered) + 1
+		filtered = append(filtered, result)
+		if len(filtered) == topK {
+			break
+		}
+	}
+	return filtered
+}
+
+func assertTextV2ScalarResults2874(t *testing.T, got, want []TextSearchResult) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("result length got=%d want=%d got=%+v want=%+v", len(got), len(want), got, want)
+	}
+	for i := range want {
+		if !bytes.Equal(got[i].DocumentID, want[i].DocumentID) || got[i].Rank != want[i].Rank || math.Abs(got[i].Score-want[i].Score) > 1e-12 {
+			t.Fatalf("result[%d] got=%+v want=%+v", i, got[i], want[i])
+		}
+	}
+}
+
+func textV2SearchHybridRareTenant2874(t testing.TB, col *Collection, topK int) HybridSearchResponse {
+	t.Helper()
+	got, err := col.SearchHybrid(HybridSearchOptions{TopK: topK, Text: &HybridTextQuery{IndexName: "lexical", Query: "refund OR policy", CandidateLimit: 64}, ScalarFilter: &HybridScalarFilter{IndexName: "tenant", Value: "tenant-rare"}, ResultMode: HybridResultModeScoreOnly})
+	if err != nil {
+		t.Fatalf("SearchHybrid rare tenant: %v", err)
+	}
+	return got
+}
+
+func hybridSearchResultIDs2874(results []HybridSearchResult) []string {
+	ids := make([]string, len(results))
+	for i := range results {
+		ids[i] = string(results[i].ID)
+	}
+	return ids
+}
+
+func assertHybridSearchResultIDs2874(t testing.TB, results []HybridSearchResult, want []string) {
+	t.Helper()
+	got := hybridSearchResultIDs2874(results)
+	if !slicesEqualStrings(got, want) {
+		t.Fatalf("ids=%v want %v results=%+v", got, want, results)
+	}
+}
+
+func maxTextV2ScalarInt2874(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/TreeDB/collections/text_v2_search.go
+++ b/TreeDB/collections/text_v2_search.go
@@ -169,14 +169,23 @@ func (e textV2SearchDocMapEntry) tombstoned() bool { return e.Flags&textV2DocFla
 type textV2SearchOrdinalAllowSet struct {
 	ordinals map[uint64]struct{}
 	sorted   []uint64
+	count    int
+	all      bool
 }
 
 func (s *textV2SearchOrdinalAllowSet) empty() bool {
-	return s != nil && len(s.sorted) == 0
+	return s != nil && s.count == 0
+}
+
+func (s *textV2SearchOrdinalAllowSet) size() int {
+	if s == nil {
+		return 0
+	}
+	return s.count
 }
 
 func (s *textV2SearchOrdinalAllowSet) contains(ordinal uint64) bool {
-	if s == nil {
+	if s == nil || s.all {
 		return true
 	}
 	_, ok := s.ordinals[ordinal]
@@ -184,14 +193,26 @@ func (s *textV2SearchOrdinalAllowSet) contains(ordinal uint64) bool {
 }
 
 func (s *textV2SearchOrdinalAllowSet) intersects(first, last uint64) bool {
-	if s == nil {
-		return true
+	_, _, ok := s.rangeBounds(first, last)
+	return ok
+}
+
+func (s *textV2SearchOrdinalAllowSet) rangeBounds(first, last uint64) (int, int, bool) {
+	if first > last {
+		return 0, 0, false
 	}
-	if first > last || len(s.sorted) == 0 {
-		return false
+	if s == nil || s.all {
+		return 0, 0, true
 	}
-	i := sort.Search(len(s.sorted), func(i int) bool { return s.sorted[i] >= first })
-	return i < len(s.sorted) && s.sorted[i] <= last
+	if len(s.sorted) == 0 {
+		return 0, 0, false
+	}
+	start := sort.Search(len(s.sorted), func(i int) bool { return s.sorted[i] >= first })
+	if start >= len(s.sorted) || s.sorted[start] > last {
+		return 0, 0, false
+	}
+	end := sort.Search(len(s.sorted), func(i int) bool { return s.sorted[i] > last })
+	return start, end, true
 }
 
 type textV2SearchTopCandidate struct {
@@ -298,7 +319,7 @@ func executeTextV2SearchAtSnapshot(
 	}
 	textSearchExplainBindV2Context(response.Explain, ctx, terms, allowSet)
 	if allowSet != nil {
-		response.Stats.TextScalarPrefilterIDs = uint64(len(allowSet.sorted))
+		response.Stats.TextScalarPrefilterIDs = uint64(allowSet.size())
 	}
 	if allowSet.empty() {
 		response.Results = []TextSearchResult{}
@@ -557,7 +578,8 @@ func newTextV2SearchOrdinalAllowSet(snap *backenddb.Snapshot, catalog *collectio
 	sort.Strings(ids)
 	set := &textV2SearchOrdinalAllowSet{ordinals: make(map[uint64]struct{}, len(ids)), sorted: make([]uint64, 0, len(ids))}
 	for _, id := range ids {
-		doc, ok, err := readTextV2DocIDAtRoot(snap, catalog, ctx.docIDRootName, []byte(id))
+		documentID := []byte(id)
+		doc, ok, err := readTextV2DocIDAtRoot(snap, catalog, ctx.docIDRootName, documentID)
 		if err != nil {
 			return nil, err
 		}
@@ -573,6 +595,8 @@ func newTextV2SearchOrdinalAllowSet(snap *backenddb.Snapshot, catalog *collectio
 		}
 	}
 	slices.Sort(set.sorted)
+	set.count = len(set.sorted)
+	set.all = uint64(set.count) == ctx.status.LiveDocuments
 	return set, nil
 }
 
@@ -672,11 +696,11 @@ func executeTextV2BlockMaxSearchAtSnapshot(
 				it.Next()
 				continue
 			}
-			tightUpperBound, err := textV2SearchTightBlockUpperBound(snap, catalog, ctx, &cache, term, scanner.block.Summary, &response.Stats)
+			tightUpperBound, err := textV2SearchTightBlockUpperBound(snap, catalog, ctx, &cache, allowSet, term, scanner.block.Summary, &response.Stats)
 			if err != nil {
 				return textSearchFailClosed(response, textSearchFailClosedStorageCorrupt, err)
 			}
-			canSkip, err := textV2SearchTightUpperBoundSkipsRange(snap, catalog, ctx, &cache, tightUpperBound, scanner.block.Summary.FirstOrdinal, scanner.block.Summary.LastOrdinal, &top)
+			canSkip, err := textV2SearchTightUpperBoundSkipsRange(snap, catalog, ctx, &cache, allowSet, tightUpperBound, scanner.block.Summary.FirstOrdinal, scanner.block.Summary.LastOrdinal, &top)
 			if err != nil {
 				return textSearchFailClosed(response, textSearchFailClosedStorageCorrupt, err)
 			}
@@ -935,13 +959,13 @@ func executeTextV2ANDBlockMaxSearchAtSnapshot(
 			if !canSkip {
 				tightCombinedUpperBound := 0.0
 				for _, state := range states {
-					if err := tightenTextV2BlockMaxStateUpperBound(snap, catalog, ctx, &cache, state, &response.Stats); err != nil {
+					if err := tightenTextV2BlockMaxStateUpperBound(snap, catalog, ctx, &cache, allowSet, state, &response.Stats); err != nil {
 						return textSearchFailClosed(response, textSearchFailClosedStorageCorrupt, err)
 					}
 					tightCombinedUpperBound += state.upperBound
 				}
 				var err error
-				canSkip, err = textV2SearchTightUpperBoundSkipsRange(snap, catalog, ctx, &cache, tightCombinedUpperBound, first, last, &top)
+				canSkip, err = textV2SearchTightUpperBoundSkipsRange(snap, catalog, ctx, &cache, allowSet, tightCombinedUpperBound, first, last, &top)
 				if err != nil {
 					return textSearchFailClosed(response, textSearchFailClosedStorageCorrupt, err)
 				}
@@ -1137,12 +1161,25 @@ func (s *textV2ANDBlockMaxTermState) currentLast() uint64 {
 	return s.block.Summary.LastOrdinal
 }
 
-func (s *textV2ANDBlockMaxTermState) ensureDecoded(ctx *textV2SearchContext, fieldCount, maxPostingsScanned int, stats *TextSearchStats) (bool, error) {
+func (s *textV2ANDBlockMaxTermState) ensureDecoded(ctx *textV2SearchContext, fieldCount, maxPostingsScanned int, allowSet *textV2SearchOrdinalAllowSet, stats *TextSearchStats) (bool, error) {
 	if s == nil || s.exhausted || s.scanner == nil {
 		return false, errMalformedTextStorage("text-v2 AND block-max missing current block")
 	}
 	if s.decoded {
 		return false, nil
+	}
+	allowIdx, allowEnd, filterAllowed := 0, 0, false
+	if allowSet != nil && !allowSet.all {
+		allowIdx, allowEnd, filterAllowed = allowSet.rangeBounds(s.block.Summary.FirstOrdinal, s.block.Summary.LastOrdinal)
+		if !filterAllowed {
+			if stats != nil {
+				stats.TextPostingBlocksSkipped++
+				stats.TextScalarPostingBlocksSkipped++
+			}
+			s.scratch = s.scanner.fieldScratch
+			s.decoded = true
+			return false, nil
+		}
 	}
 	if stats != nil {
 		stats.TextPostingBlocksVisited++
@@ -1162,6 +1199,17 @@ func (s *textV2ANDBlockMaxTermState) ensureDecoded(ctx *textV2SearchContext, fie
 		}
 		if entry.Ordinal >= ctx.status.NextOrdinal || entry.Generation > ctx.status.RootGeneration {
 			return false, errMalformedTextStorage("text-v2 posting entry outside status snapshot")
+		}
+		if filterAllowed {
+			for allowIdx < allowEnd && allowSet.sorted[allowIdx] < entry.Ordinal {
+				allowIdx++
+			}
+			if allowIdx >= allowEnd || allowSet.sorted[allowIdx] != entry.Ordinal {
+				if stats != nil {
+					stats.TextScalarPostingsRejected++
+				}
+				continue
+			}
 		}
 		posting, err := textV2SearchPostingValueFromEntry(entry, fieldCount)
 		if err != nil {
@@ -1307,7 +1355,7 @@ func visitTextV2ANDBlockMaxOverlap(
 ) (bool, bool, error) {
 	fieldCount := len(ctx.fieldNames)
 	for _, state := range states {
-		truncated, err := state.ensureDecoded(ctx, fieldCount, maxPostingsScanned, stats)
+		truncated, err := state.ensureDecoded(ctx, fieldCount, maxPostingsScanned, allowSet, stats)
 		if truncated || err != nil {
 			return truncated, false, err
 		}
@@ -1494,7 +1542,7 @@ func executeTextV2ORBlockMaxSearchAtSnapshot(
 		textV2ORBlockMaxSortStates(active)
 
 		if threshold, ok := top.threshold(); ok {
-			truncated, progressed, err := skipTextV2ORBlockMaxLowUpperWindow(snap, catalog, ctx, &cache, active, fieldCount, maxPostingsScanned, threshold, &top, &response.Stats)
+			truncated, progressed, err := skipTextV2ORBlockMaxLowUpperWindow(snap, catalog, ctx, &cache, allowSet, active, fieldCount, maxPostingsScanned, threshold, &top, &response.Stats)
 			if err != nil {
 				return textSearchFailClosed(response, textSearchFailClosedStorageCorrupt, err)
 			}
@@ -1520,7 +1568,7 @@ func executeTextV2ORBlockMaxSearchAtSnapshot(
 				}
 			}
 			if pivot < 0 {
-				truncated, err := advanceTextV2BlockMaxStatePastCurrent(ctx, active[0], fieldCount, maxPostingsScanned, &response.Stats)
+				truncated, err := advanceTextV2BlockMaxStatePastCurrent(ctx, active[0], fieldCount, maxPostingsScanned, allowSet, &response.Stats)
 				if err != nil {
 					return textSearchFailClosed(response, textSearchFailClosedStorageCorrupt, err)
 				}
@@ -1540,7 +1588,7 @@ func executeTextV2ORBlockMaxSearchAtSnapshot(
 			return textSearchFailClosed(response, textSearchFailClosedStorageCorrupt, errMalformedTextStorage("text-v2 OR block-max invalid target ordinal"))
 		}
 		if active[0].currentFirst() < target {
-			truncated, err := advanceTextV2BlockMaxStateTo(ctx, active[0], fieldCount, maxPostingsScanned, target, &response.Stats)
+			truncated, err := advanceTextV2BlockMaxStateTo(ctx, active[0], fieldCount, maxPostingsScanned, allowSet, target, &response.Stats)
 			if err != nil {
 				return textSearchFailClosed(response, textSearchFailClosedStorageCorrupt, err)
 			}
@@ -1668,11 +1716,11 @@ func textV2ORBlockMaxSortStates(states []*textV2ANDBlockMaxTermState) {
 	})
 }
 
-func tightenTextV2BlockMaxStateUpperBound(snap *backenddb.Snapshot, catalog *collectionCatalog, ctx *textV2SearchContext, cache *textV2SearchBlockCache, state *textV2ANDBlockMaxTermState, stats *TextSearchStats) error {
+func tightenTextV2BlockMaxStateUpperBound(snap *backenddb.Snapshot, catalog *collectionCatalog, ctx *textV2SearchContext, cache *textV2SearchBlockCache, allowSet *textV2SearchOrdinalAllowSet, state *textV2ANDBlockMaxTermState, stats *TextSearchStats) error {
 	if state == nil || state.exhausted || state.upperBoundTight {
 		return nil
 	}
-	upperBound, err := textV2SearchTightBlockUpperBound(snap, catalog, ctx, cache, state.term, state.block.Summary, stats)
+	upperBound, err := textV2SearchTightBlockUpperBound(snap, catalog, ctx, cache, allowSet, state.term, state.block.Summary, stats)
 	if err != nil {
 		return err
 	}
@@ -1699,7 +1747,7 @@ func skipTextV2ORBlockMaxDisallowedBlocks(ctx *textV2SearchContext, states []*te
 	return nil
 }
 
-func skipTextV2ORBlockMaxLowUpperWindow(snap *backenddb.Snapshot, catalog *collectionCatalog, ctx *textV2SearchContext, cache *textV2SearchBlockCache, states []*textV2ANDBlockMaxTermState, fieldCount, maxPostingsScanned int, threshold float64, top *textV2SearchTopK, stats *TextSearchStats) (bool, bool, error) {
+func skipTextV2ORBlockMaxLowUpperWindow(snap *backenddb.Snapshot, catalog *collectionCatalog, ctx *textV2SearchContext, cache *textV2SearchBlockCache, allowSet *textV2SearchOrdinalAllowSet, states []*textV2ANDBlockMaxTermState, fieldCount, maxPostingsScanned int, threshold float64, top *textV2SearchTopK, stats *TextSearchStats) (bool, bool, error) {
 	if len(states) == 0 {
 		return false, false, nil
 	}
@@ -1736,13 +1784,13 @@ func skipTextV2ORBlockMaxLowUpperWindow(snap *backenddb.Snapshot, catalog *colle
 	if !canSkip {
 		tightUpperSum := 0.0
 		for _, state := range overlapping {
-			if err := tightenTextV2BlockMaxStateUpperBound(snap, catalog, ctx, cache, state, stats); err != nil {
+			if err := tightenTextV2BlockMaxStateUpperBound(snap, catalog, ctx, cache, allowSet, state, stats); err != nil {
 				return false, false, err
 			}
 			tightUpperSum += state.upperBound
 		}
 		var err error
-		canSkip, err = textV2SearchTightUpperBoundSkipsRange(snap, catalog, ctx, cache, tightUpperSum, windowFirst, windowLast, top)
+		canSkip, err = textV2SearchTightUpperBoundSkipsRange(snap, catalog, ctx, cache, allowSet, tightUpperSum, windowFirst, windowLast, top)
 		if err != nil {
 			return false, false, err
 		}
@@ -1769,7 +1817,7 @@ func skipTextV2ORBlockMaxLowUpperWindow(snap *backenddb.Snapshot, catalog *colle
 			progressed = true
 			continue
 		}
-		truncated, err := advanceTextV2BlockMaxStateTo(ctx, state, fieldCount, maxPostingsScanned, target, stats)
+		truncated, err := advanceTextV2BlockMaxStateTo(ctx, state, fieldCount, maxPostingsScanned, allowSet, target, stats)
 		if truncated || err != nil {
 			return truncated, progressed, err
 		}
@@ -1778,7 +1826,7 @@ func skipTextV2ORBlockMaxLowUpperWindow(snap *backenddb.Snapshot, catalog *colle
 	return false, progressed, nil
 }
 
-func advanceTextV2BlockMaxStateTo(ctx *textV2SearchContext, state *textV2ANDBlockMaxTermState, fieldCount, maxPostingsScanned int, target uint64, stats *TextSearchStats) (bool, error) {
+func advanceTextV2BlockMaxStateTo(ctx *textV2SearchContext, state *textV2ANDBlockMaxTermState, fieldCount, maxPostingsScanned int, allowSet *textV2SearchOrdinalAllowSet, target uint64, stats *TextSearchStats) (bool, error) {
 	if state == nil || state.exhausted {
 		return false, nil
 	}
@@ -1794,7 +1842,7 @@ func advanceTextV2BlockMaxStateTo(ctx *textV2SearchContext, state *textV2ANDBloc
 		}
 		return false, nil
 	}
-	truncated, err := state.ensureDecoded(ctx, fieldCount, maxPostingsScanned, stats)
+	truncated, err := state.ensureDecoded(ctx, fieldCount, maxPostingsScanned, allowSet, stats)
 	if truncated || err != nil {
 		return truncated, err
 	}
@@ -1809,11 +1857,11 @@ func advanceTextV2BlockMaxStateTo(ctx *textV2SearchContext, state *textV2ANDBloc
 	return false, nil
 }
 
-func advanceTextV2BlockMaxStatePastCurrent(ctx *textV2SearchContext, state *textV2ANDBlockMaxTermState, fieldCount, maxPostingsScanned int, stats *TextSearchStats) (bool, error) {
+func advanceTextV2BlockMaxStatePastCurrent(ctx *textV2SearchContext, state *textV2ANDBlockMaxTermState, fieldCount, maxPostingsScanned int, allowSet *textV2SearchOrdinalAllowSet, stats *TextSearchStats) (bool, error) {
 	if state == nil || state.exhausted {
 		return false, nil
 	}
-	truncated, err := state.ensureDecoded(ctx, fieldCount, maxPostingsScanned, stats)
+	truncated, err := state.ensureDecoded(ctx, fieldCount, maxPostingsScanned, allowSet, stats)
 	if truncated || err != nil {
 		return truncated, err
 	}
@@ -1844,10 +1892,7 @@ func visitTextV2ORBlockMaxCandidate(
 ) (bool, error) {
 	fieldCount := len(ctx.fieldNames)
 	if allowSet != nil && !allowSet.contains(target) {
-		if stats != nil {
-			stats.TextScalarPostingsRejected++
-		}
-		return advanceTextV2ORBlockMaxStatesPastTarget(ctx, advanceStates, fieldCount, maxPostingsScanned, target, stats)
+		return decodeTextV2ORBlockMaxStatesAtTarget(ctx, advanceStates, fieldCount, maxPostingsScanned, allowSet, target, stats)
 	}
 	norm, ok, err := cache.normEntry(snap, catalog, ctx, target, stats)
 	if err != nil {
@@ -1865,7 +1910,7 @@ func visitTextV2ORBlockMaxCandidate(
 			if state == nil || state.exhausted || state.currentFirst() != target {
 				continue
 			}
-			truncated, err := state.ensureDecoded(ctx, fieldCount, maxPostingsScanned, stats)
+			truncated, err := state.ensureDecoded(ctx, fieldCount, maxPostingsScanned, allowSet, stats)
 			if truncated || err != nil {
 				return truncated, err
 			}
@@ -1930,15 +1975,39 @@ func visitTextV2ORBlockMaxCandidate(
 			}
 		}
 	}
-	return advanceTextV2ORBlockMaxStatesPastTarget(ctx, advanceStates, fieldCount, maxPostingsScanned, target, stats)
+	return advanceTextV2ORBlockMaxStatesPastTarget(ctx, advanceStates, fieldCount, maxPostingsScanned, allowSet, target, stats)
 }
 
-func advanceTextV2ORBlockMaxStatesPastTarget(ctx *textV2SearchContext, states []*textV2ANDBlockMaxTermState, fieldCount, maxPostingsScanned int, target uint64, stats *TextSearchStats) (bool, error) {
+func decodeTextV2ORBlockMaxStatesAtTarget(ctx *textV2SearchContext, states []*textV2ANDBlockMaxTermState, fieldCount, maxPostingsScanned int, allowSet *textV2SearchOrdinalAllowSet, target uint64, stats *TextSearchStats) (bool, error) {
 	for _, state := range states {
 		if state == nil || state.exhausted || state.currentFirst() != target {
 			continue
 		}
-		truncated, err := advanceTextV2BlockMaxStatePastCurrent(ctx, state, fieldCount, maxPostingsScanned, stats)
+		truncated, err := state.ensureDecoded(ctx, fieldCount, maxPostingsScanned, allowSet, stats)
+		if truncated || err != nil {
+			return truncated, err
+		}
+		for state.entryIdx < len(state.entries) && state.entries[state.entryIdx].ordinal < target {
+			state.entryIdx++
+		}
+		if state.entryIdx < len(state.entries) && state.entries[state.entryIdx].ordinal == target && allowSet != nil && !allowSet.contains(target) {
+			state.entryIdx++
+		}
+		for state != nil && !state.exhausted && state.decoded && state.entryIdx >= len(state.entries) {
+			if err := state.advanceBlock(ctx, fieldCount); err != nil {
+				return false, err
+			}
+		}
+	}
+	return false, nil
+}
+
+func advanceTextV2ORBlockMaxStatesPastTarget(ctx *textV2SearchContext, states []*textV2ANDBlockMaxTermState, fieldCount, maxPostingsScanned int, allowSet *textV2SearchOrdinalAllowSet, target uint64, stats *TextSearchStats) (bool, error) {
+	for _, state := range states {
+		if state == nil || state.exhausted || state.currentFirst() != target {
+			continue
+		}
+		truncated, err := advanceTextV2BlockMaxStatePastCurrent(ctx, state, fieldCount, maxPostingsScanned, allowSet, stats)
 		if truncated || err != nil {
 			return truncated, err
 		}
@@ -2213,7 +2282,7 @@ func textV2SearchBlockUpperBound(term string, summary textV2PostingBlockSummary,
 	return textV2SearchBlockUpperBoundWithFieldLengthMinimums(term, summary, ctx, nil)
 }
 
-func textV2SearchTightBlockUpperBound(snap *backenddb.Snapshot, catalog *collectionCatalog, ctx *textV2SearchContext, cache *textV2SearchBlockCache, term string, summary textV2PostingBlockSummary, stats *TextSearchStats) (float64, error) {
+func textV2SearchTightBlockUpperBound(snap *backenddb.Snapshot, catalog *collectionCatalog, ctx *textV2SearchContext, cache *textV2SearchBlockCache, allowSet *textV2SearchOrdinalAllowSet, term string, summary textV2PostingBlockSummary, stats *TextSearchStats) (float64, error) {
 	if cache == nil {
 		return 0, errMalformedTextStorage("text-v2 search cache is nil")
 	}
@@ -2225,7 +2294,7 @@ func textV2SearchTightBlockUpperBound(snap *backenddb.Snapshot, catalog *collect
 	} else {
 		mins = mins[:fieldCount]
 	}
-	hasLive, complete, err := cache.minFieldLengthsInRange(snap, catalog, ctx, summary.FirstOrdinal, summary.LastOrdinal, mins, stats)
+	hasLive, complete, err := cache.minFieldLengthsInAllowedRange(snap, catalog, ctx, allowSet, summary.FirstOrdinal, summary.LastOrdinal, mins, stats)
 	if err != nil {
 		return 0, err
 	}
@@ -2283,7 +2352,7 @@ func textV2SearchBlockUpperBoundWithFieldLengthMinimums(term string, summary tex
 	return idf * ((combinedTFUpper * (textSearchBM25K1 + 1)) / (combinedTFUpper + textSearchBM25K1)), nil
 }
 
-func textV2SearchTightUpperBoundSkipsRange(snap *backenddb.Snapshot, catalog *collectionCatalog, ctx *textV2SearchContext, cache *textV2SearchBlockCache, upperBound float64, first, last uint64, top *textV2SearchTopK) (bool, error) {
+func textV2SearchTightUpperBoundSkipsRange(snap *backenddb.Snapshot, catalog *collectionCatalog, ctx *textV2SearchContext, cache *textV2SearchBlockCache, allowSet *textV2SearchOrdinalAllowSet, upperBound float64, first, last uint64, top *textV2SearchTopK) (bool, error) {
 	worst, ok := top.worst()
 	if !ok {
 		return false, nil
@@ -2294,7 +2363,7 @@ func textV2SearchTightUpperBoundSkipsRange(snap *backenddb.Snapshot, catalog *co
 	if upperBound > worst.score {
 		return false, nil
 	}
-	minDocID, hasLive, complete, err := cache.minDocumentIDInRange(snap, catalog, ctx, first, last)
+	minDocID, hasLive, complete, err := cache.minDocumentIDInAllowedRange(snap, catalog, ctx, allowSet, first, last)
 	if err != nil {
 		return false, err
 	}
@@ -2776,6 +2845,59 @@ func (cache *textV2SearchBlockCache) minFieldLengthsInRange(snap *backenddb.Snap
 	return hasLive, true, nil
 }
 
+func (cache *textV2SearchBlockCache) minFieldLengthsInAllowedRange(snap *backenddb.Snapshot, catalog *collectionCatalog, ctx *textV2SearchContext, allowSet *textV2SearchOrdinalAllowSet, first, last uint64, mins []uint32, stats *TextSearchStats) (hasLive bool, complete bool, err error) {
+	if allowSet == nil || allowSet.all {
+		return cache.minFieldLengthsInRange(snap, catalog, ctx, first, last, mins, stats)
+	}
+	if first == 0 || last < first {
+		return false, false, errMalformedTextStorage("text-v2 invalid scalar norm range [%d,%d]", first, last)
+	}
+	if len(mins) != len(ctx.fieldNames) {
+		return false, false, errMalformedTextStorage("text-v2 scalar norm min field count %d want %d", len(mins), len(ctx.fieldNames))
+	}
+	for i := range mins {
+		mins[i] = math.MaxUint32
+	}
+	start, end, ok := allowSet.rangeBounds(first, last)
+	if !ok {
+		return false, true, nil
+	}
+	for i := start; i < end; i++ {
+		ordinal := allowSet.sorted[i]
+		blockStart := textV2OrdinalBlockStart(ordinal, textV2DefaultNormBlockSize)
+		if blockStart == 0 {
+			return false, false, errMalformedTextStorage("text-v2 invalid scalar norm ordinal %d", ordinal)
+		}
+		block, found, err := cache.normBlockAtOptional(snap, catalog, ctx, blockStart, stats)
+		if err != nil {
+			return false, false, err
+		}
+		if !found {
+			return hasLive, false, nil
+		}
+		entry, found := block.find(ordinal)
+		if !found {
+			return hasLive, false, nil
+		}
+		if len(entry.FieldLengths) != len(ctx.fieldNames) {
+			return false, false, errMalformedTextStorage("text-v2 scalar norm entry field count %d want %d", len(entry.FieldLengths), len(ctx.fieldNames))
+		}
+		if entry.Ordinal >= ctx.status.NextOrdinal || entry.Generation > ctx.status.NormGeneration {
+			return false, false, errMalformedTextStorage("text-v2 scalar norm entry outside status snapshot")
+		}
+		if entry.tombstoned() {
+			continue
+		}
+		for fieldIdx, length := range entry.FieldLengths {
+			if length < mins[fieldIdx] {
+				mins[fieldIdx] = length
+			}
+		}
+		hasLive = true
+	}
+	return hasLive, true, nil
+}
+
 func (cache *textV2SearchBlockCache) docMapBlockAtOptional(snap *backenddb.Snapshot, catalog *collectionCatalog, ctx *textV2SearchContext, blockStart uint64) (textV2SearchDocMapBlock, bool, error) {
 	if blockStart == 0 {
 		return textV2SearchDocMapBlock{}, false, errMalformedTextStorage("text-v2 invalid docmap block start")
@@ -2876,6 +2998,47 @@ func (cache *textV2SearchBlockCache) minDocumentIDInRange(snap *backenddb.Snapsh
 			break
 		}
 		blockStart += uint64(textV2DefaultDocMapBlockSize)
+	}
+	return minID, minID != nil, true, nil
+}
+
+func (cache *textV2SearchBlockCache) minDocumentIDInAllowedRange(snap *backenddb.Snapshot, catalog *collectionCatalog, ctx *textV2SearchContext, allowSet *textV2SearchOrdinalAllowSet, first, last uint64) (minID []byte, hasLive bool, complete bool, err error) {
+	if allowSet == nil || allowSet.all {
+		return cache.minDocumentIDInRange(snap, catalog, ctx, first, last)
+	}
+	if first == 0 || last < first {
+		return nil, false, false, errMalformedTextStorage("text-v2 invalid scalar docmap range [%d,%d]", first, last)
+	}
+	start, end, ok := allowSet.rangeBounds(first, last)
+	if !ok {
+		return nil, false, true, nil
+	}
+	for i := start; i < end; i++ {
+		ordinal := allowSet.sorted[i]
+		blockStart := textV2OrdinalBlockStart(ordinal, textV2DefaultDocMapBlockSize)
+		if blockStart == 0 {
+			return nil, false, false, errMalformedTextStorage("text-v2 invalid scalar docmap ordinal %d", ordinal)
+		}
+		block, found, err := cache.docMapBlockAtOptional(snap, catalog, ctx, blockStart)
+		if err != nil {
+			return nil, false, false, err
+		}
+		if !found {
+			return minID, minID != nil, false, nil
+		}
+		entry, found := block.find(ordinal)
+		if !found {
+			return minID, minID != nil, false, nil
+		}
+		if entry.Ordinal >= ctx.status.NextOrdinal || entry.Generation > ctx.status.DocMapGeneration {
+			return nil, false, false, errMalformedTextStorage("text-v2 scalar docmap entry outside status snapshot")
+		}
+		if entry.tombstoned() {
+			continue
+		}
+		if minID == nil || bytes.Compare(entry.DocumentID, minID) < 0 {
+			minID = entry.DocumentID
+		}
 	}
 	return minID, minID != nil, true, nil
 }


### PR DESCRIPTION
## Objective

Implement #2874 scalar-aware text-v2 posting/block pruning on top of #2885 / #2873.

Links: parent #2872, child #2874. Stacked on #2885 (`snissn/2873-high-df-pruning`) and **blocked until #2885 merges**, then this branch must be rebased/revalidated on `main` before any final mergeability claim.

## Scope

- Thread snapshot-bound scalar allow-sets through text-v2 single-term, AND, OR/WAND, phrase/explain paths without document fetches.
- Use scalar ordinals to tighten block upper-bound norm minima and deterministic tie proofs where exact evidence is complete.
- Filter decoded WAND/AND posting entries against sorted scalar ordinals before norm/docmap scoring, while skipping scalar-disjoint posting blocks.
- Preserve exact BM25F scoring, deterministic document-ID tie ordering, no-doc guardrails, and fail-closed behavior on missing/mismatched scalar/text state.
- Add focused #2874 parity/fail-closed/reopen tests and a selectivity sweep benchmark.

Non-goals: vector rebuild, approximate ranking, new scalar index format/sidecar, or changing #2873 public contracts.

## Dependency status

- Base branch: `snissn/2873-high-df-pruning`
- Current base head used locally: `1d4074cd10ccf9ff86712ff82fb687a88debd0f6`
- This PR remains blocked on #2885 merge and main rebase/revalidation.

## Tests

```sh
GOWORK=off go test ./TreeDB/collections -run 'TestTextV2ScalarPruning.*2874|TestTextV2ScalarAwareWANDPruningContract2836|TestTextV2BlockMaxMultiTerm(AND|OR)ScalarPrefilter|TestTextV2ScalarFilterPruningEmptyRareBroad|TestTextV2BlockMaxMissing(Norm|DocMap)BlockFailsClosed2873' -count=1
GOWORK=off go test ./TreeDB/collections -count=1
```

Both passed locally at head `68cd8fe29`.

Added coverage:

- filtered ranking parity versus exhaustive unfiltered search plus exact scalar post-filter reference;
- scalar missing-docID fail-closed before posting traversal with zero document fetches;
- hybrid scalar reopen/snapshot no-doc guardrail;
- scalar posting block skipped / scalar postings rejected counters;
- selectivity sweep benchmark counters.

## Benchmark evidence

Host/context: local Linux amd64, Intel i5-11400F, Go 1.26.0. Baseline is current #2873 stack head `1d4074cd1`; after is this PR head `68cd8fe29`.

Before/after command:

```sh
GOWORK=off go test ./TreeDB/collections -run '^$' -bench '^BenchmarkTextV2ScalarAwareWANDPruning2836/(high_selectivity_or|moderate_selectivity_and)$' -benchmem -benchtime=10x -count=3
```

Representative median-ish local rows:

| row | #2873 ns/op | #2874 ns/op | scalar blocks skipped | scalar postings rejected #2873→#2874 | B/op #2873→#2874 | allocs/op #2873→#2874 |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| high_selectivity_or | 69.6µs | 66.4µs | 62 | 0 → 224 | ~70.9KB → ~32.0KB | 171 → 164 |
| moderate_selectivity_and | 545.6µs | 500.5µs | 0 | 372 → 744 | ~626.0KB → ~582.5KB | 633 → 622 |

Focused selectivity sweep command:

```sh
GOWORK=off go test ./TreeDB/collections -run '^$' -bench '^BenchmarkTextV2ScalarPruningSelectivity2874$' -benchmem -benchtime=1x -count=1
```

| selectivity | ns/op | prefilter IDs | blocks visited/skipped | scalar blocks skipped | scalar postings rejected | candidates scored | text candidates | docs fetched | B/op | allocs/op |
| --- | ---: | ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| no_filter | 1.816ms | 0 | 64 / 0 | 0 | 0 | 4096 | 10 | 0 | 631KB | 372 |
| 0.1% | 175µs | 4 | 2 / 62 | 62 | 248 | 4 | 4 | 0 | 39.7KB | 140 |
| 1% | 129µs | 40 | 2 / 62 | 62 | 176 | 40 | 10 | 0 | 63.7KB | 228 |
| 5% | 286µs | 204 | 4 / 60 | 60 | 104 | 204 | 10 | 0 | 114KB | 565 |
| 10% | 462µs | 409 | 8 / 56 | 56 | 206 | 409 | 10 | 0 | 153KB | 983 |
| 25% | 1.002ms | 1024 | 16 / 48 | 48 | 0 | 1024 | 10 | 0 | 290KB | 2249 |
| 50% | 1.959ms | 2048 | 32 / 32 | 32 | 0 | 2048 | 10 | 0 | 517KB | 4367 |
| 100% | 3.487ms | 4096 | 64 / 0 | 0 | 0 | 4096 | 10 | 0 | 960KB | 8581 |

The 100% scalar row includes exact scalar ID→text ordinal validation cost; traversal counters match the no-filter path. Broad public hybrid filters that exceed the bounded scalar lookup budget still fail closed rather than scanning documents.

## Guardrails / risks

- `docs_fetched/search=0` in focused benchmark rows.
- No full-document fallback added.
- Missing scalar/text docID state fails closed with `text_index_storage_corrupt` before posting traversal.
- PR is dependency-ready only relative to #2885; not final-mergeable until #2885 merges and this branch is rebased/revalidated on main.
