### PR TITLE
collections: reuse global codes for q2 grouped distinct

### DIFF
--- a/TreeDB/collections/column_physical_q2_1950_test.go
+++ b/TreeDB/collections/column_physical_q2_1950_test.go
@@ -3,6 +3,7 @@ package collections
 import (
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 	"testing"
 
@@ -133,6 +134,19 @@ func TestTypedColumnQ2SortedGroupedDistinctLocalDictionariesAndEmptyValues1950(t
 	if got["app.emptydid"].Count != 2 || got["app.emptydid"].Distinct != 1 {
 		t.Fatalf("empty did counts=%+v want empty distinct value counted once", got["app.emptydid"])
 	}
+
+	runner, err := col.PrepareColumnPhysicalQuery(typedColumnQ2Request1950())
+	if err != nil {
+		t.Fatalf("PrepareColumnPhysicalQuery(q2 local dictionaries): %v", err)
+	}
+	defer func() { _ = runner.Close() }()
+	assertTypedColumnQ2PreparedGlobalCodes1950(t, runner)
+	prepared, err := runner.Run()
+	if err != nil {
+		t.Fatalf("prepared q2 local dictionaries: %v", err)
+	}
+	assertTypedColumnQ2SortedGroupedDistinctResult1950(t, "prepared local dictionaries", prepared, rowHash, want)
+	assertTypedColumnQ2SortedGroupedDistinctDiagnostics1950(t, "prepared local dictionaries", prepared.Diagnostics, len(events), columnPhysicalJSONBenchReferenceMatchedRowsP0("q2", events), true)
 }
 
 func TestTypedColumnQ2SortedGroupedDistinctPrefixMismatchFallback1950(t *testing.T) {
@@ -320,6 +334,81 @@ func flattenColumnPhysicalEvents1950(batches [][]columnPhysicalJSONBenchParityEv
 		events = append(events, batch...)
 	}
 	return events
+}
+
+func assertTypedColumnQ2PreparedGlobalCodes1950(tb testing.TB, runner *ColumnPhysicalQueryRunner) {
+	tb.Helper()
+	if runner == nil || runner.typedColumn == nil {
+		tb.Fatalf("prepared q2 runner missing typed-column state")
+	}
+	if len(runner.typedColumn.parts) < 2 {
+		tb.Fatalf("prepared q2 parts=%d want multiple local dictionaries", len(runner.typedColumn.parts))
+	}
+	didMRank := -1
+	didMParts := 0
+	for partIdx := range runner.typedColumn.parts {
+		part := runner.typedColumn.parts[partIdx].SortedGroupedDistinct
+		if part == nil {
+			tb.Fatalf("part %d missing sorted grouped-distinct state", partIdx)
+		}
+		if len(part.Group.GlobalCodes) != part.Rows || len(part.Distinct.GlobalCodes) != part.Rows {
+			tb.Fatalf("part %d global code rows group=%d distinct=%d want %d", partIdx, len(part.Group.GlobalCodes), len(part.Distinct.GlobalCodes), part.Rows)
+		}
+		if !sort.StringsAreSorted(part.Group.GlobalDictionary) || !sort.StringsAreSorted(part.Distinct.GlobalDictionary) {
+			tb.Fatalf("part %d global dictionaries not lexicographically sorted group=%v distinct=%v", partIdx, part.Group.GlobalDictionary, part.Distinct.GlobalDictionary)
+		}
+		for row, code := range part.Group.GlobalCodes {
+			if int(code) >= len(part.Group.GlobalDictionary) {
+				tb.Fatalf("part %d group global code row=%d code=%d outside cardinality=%d", partIdx, row, code, len(part.Group.GlobalDictionary))
+			}
+		}
+		for row, code := range part.Distinct.GlobalCodes {
+			if int(code) >= len(part.Distinct.GlobalDictionary) {
+				tb.Fatalf("part %d distinct global code row=%d code=%d outside cardinality=%d", partIdx, row, code, len(part.Distinct.GlobalDictionary))
+			}
+		}
+		localDidM := -1
+		for code, value := range part.Distinct.Dictionary {
+			if value == "did:m" {
+				localDidM = code
+				break
+			}
+		}
+		if localDidM < 0 {
+			continue
+		}
+		partDidMRank := -1
+		for rank, value := range part.Distinct.GlobalDictionary {
+			if value == "did:m" {
+				partDidMRank = rank
+				break
+			}
+		}
+		if partDidMRank < 0 {
+			tb.Fatalf("part %d distinct global dictionary missing did:m", partIdx)
+		}
+		if didMRank < 0 {
+			didMRank = partDidMRank
+		} else if didMRank != partDidMRank {
+			tb.Fatalf("did:m global rank part %d=%d want %d", partIdx, partDidMRank, didMRank)
+		}
+		seenDidMRow := false
+		for row, localCode := range part.Distinct.Codes {
+			if localCode == int64(localDidM) {
+				seenDidMRow = true
+				if part.Distinct.GlobalCodes[row] != uint32(partDidMRank) {
+					tb.Fatalf("part %d did:m row=%d global code=%d want %d", partIdx, row, part.Distinct.GlobalCodes[row], partDidMRank)
+				}
+			}
+		}
+		if !seenDidMRow {
+			tb.Fatalf("part %d local did:m code=%d not referenced by any row", partIdx, localDidM)
+		}
+		didMParts++
+	}
+	if didMParts < 2 {
+		tb.Fatalf("did:m appeared in %d parts want at least two to prove cross-part global rank reuse", didMParts)
+	}
 }
 
 func openTypedColumnSortKeyFixtureBatches1950(tb testing.TB, sortKey []ColumnSortKey, batches [][]columnPhysicalJSONBenchParityEventP0) (*backenddb.DB, *Collection, func()) {

--- a/TreeDB/collections/column_physical_typed_column_query.go
+++ b/TreeDB/collections/column_physical_typed_column_query.go
@@ -59,8 +59,10 @@ type columnTypedColumnDenseInt64SpanPart struct {
 }
 
 type columnTypedColumnSortedGroupedDistinctCodeColumn struct {
-	Codes      []int64
-	Dictionary []string
+	Codes            []int64
+	Dictionary       []string
+	GlobalCodes      []uint32
+	GlobalDictionary []string
 }
 
 type columnTypedColumnSortedGroupedDistinctPredicate struct {
@@ -444,7 +446,88 @@ func decodeColumnTypedColumnPhysicalQueryRunnerParts(view columnPhysicalScanSnap
 	if len(runner.parts) == 0 && len(view.AssetRefs) != 0 {
 		return nil, errors.New("collections: typed-column part physical query has no live typed_column_part assets")
 	}
+	if columnTypedColumnPhysicalQueryUseSortedGroupedDistinct(plan, req) {
+		if err := prepareColumnTypedColumnSortedGroupedDistinctGlobalCodes(runner.parts); err != nil {
+			return nil, err
+		}
+	}
 	return runner, nil
+}
+
+func prepareColumnTypedColumnSortedGroupedDistinctGlobalCodes(parts []columnTypedColumnPhysicalQueryPart) error {
+	groupDict, groupRanks, err := columnTypedColumnSortedGroupedDistinctGlobalDictionary(parts, func(part *columnTypedColumnSortedGroupedDistinctPart) *columnTypedColumnSortedGroupedDistinctCodeColumn {
+		return &part.Group
+	})
+	if err != nil {
+		return err
+	}
+	distinctDict, distinctRanks, err := columnTypedColumnSortedGroupedDistinctGlobalDictionary(parts, func(part *columnTypedColumnSortedGroupedDistinctPart) *columnTypedColumnSortedGroupedDistinctCodeColumn {
+		return &part.Distinct
+	})
+	if err != nil {
+		return err
+	}
+	for partIdx := range parts {
+		part := parts[partIdx].SortedGroupedDistinct
+		if part == nil {
+			return fmt.Errorf("collections: sorted grouped-distinct missing prepared part %d", partIdx)
+		}
+		if err := prepareColumnTypedColumnSortedGroupedDistinctGlobalColumnCodes(&part.Group, groupDict, groupRanks); err != nil {
+			return fmt.Errorf("collections: sorted grouped-distinct group part %d: %w", partIdx, err)
+		}
+		if err := prepareColumnTypedColumnSortedGroupedDistinctGlobalColumnCodes(&part.Distinct, distinctDict, distinctRanks); err != nil {
+			return fmt.Errorf("collections: sorted grouped-distinct distinct part %d: %w", partIdx, err)
+		}
+	}
+	return nil
+}
+
+func columnTypedColumnSortedGroupedDistinctGlobalDictionary(parts []columnTypedColumnPhysicalQueryPart, selectColumn func(*columnTypedColumnSortedGroupedDistinctPart) *columnTypedColumnSortedGroupedDistinctCodeColumn) ([]string, map[string]uint32, error) {
+	values := make(map[string]struct{})
+	for partIdx := range parts {
+		part := parts[partIdx].SortedGroupedDistinct
+		if part == nil {
+			return nil, nil, fmt.Errorf("collections: sorted grouped-distinct missing prepared part %d", partIdx)
+		}
+		column := selectColumn(part)
+		for _, value := range column.Dictionary {
+			values[value] = struct{}{}
+		}
+	}
+	dictionary := make([]string, 0, len(values))
+	for value := range values {
+		dictionary = append(dictionary, value)
+	}
+	sort.Strings(dictionary)
+	ranks := make(map[string]uint32, len(dictionary))
+	for rank, value := range dictionary {
+		if uint64(rank) > uint64(^uint32(0)) {
+			return nil, nil, fmt.Errorf("collections: sorted grouped-distinct global dictionary cardinality=%d exceeds uint32", len(dictionary))
+		}
+		ranks[value] = uint32(rank)
+	}
+	return dictionary, ranks, nil
+}
+
+func prepareColumnTypedColumnSortedGroupedDistinctGlobalColumnCodes(column *columnTypedColumnSortedGroupedDistinctCodeColumn, globalDictionary []string, ranks map[string]uint32) error {
+	localRanks := make([]uint32, len(column.Dictionary))
+	for localCode, value := range column.Dictionary {
+		rank, ok := ranks[value]
+		if !ok {
+			return fmt.Errorf("local dictionary value %q missing from global dictionary", value)
+		}
+		localRanks[localCode] = rank
+	}
+	globalCodes := make([]uint32, len(column.Codes))
+	for row, localCode := range column.Codes {
+		if localCode < 0 || localCode >= int64(len(localRanks)) {
+			return fmt.Errorf("row=%d code=%d outside cardinality=%d", row, localCode, len(localRanks))
+		}
+		globalCodes[row] = localRanks[localCode]
+	}
+	column.GlobalCodes = globalCodes
+	column.GlobalDictionary = globalDictionary
+	return nil
 }
 
 func columnTypedColumnPhysicalQueryTouchesTypedColumnPart(cfg ColumnStoreConfig, req ColumnPhysicalQueryRequest) bool {
@@ -2069,55 +2152,13 @@ func (r *columnTypedColumnPhysicalQueryRunner) runSortedGroupedDistinct(view col
 		}
 	}
 
-	groups := r.resultGroups[:0]
-	firstGroup := true
-	currentGroup := ""
-	currentDistinct := ""
-	groupRows := 0
-	distinctRows := 0
-	reduceRows := 0
-	emitGroup := func() {
-		if firstGroup {
-			return
-		}
-		groups = append(groups, ColumnPhysicalQueryGroup{Key: currentGroup, Count: groupRows, DistinctCount: distinctRows})
+	groups, reduceRows, err := r.reduceSortedGroupedDistinct(iterators, &heap)
+	if err != nil {
+		rowsScanned, matchedRows := columnTypedColumnSortedGroupedDistinctIteratorTotals(iterators)
+		diag := r.diagnostics(view, req, rowsScanned, matchedRows, reduceRows, time.Since(start).Nanoseconds())
+		diag.SortedGroupedDistinctUsed = true
+		return ColumnPhysicalQueryResult{Diagnostics: diag}, err
 	}
-	for heap.len() != 0 {
-		iteratorIdx := heap.pop(iterators)
-		iterator := iterators[iteratorIdx]
-		group := iterator.currentGroup
-		distinct := iterator.currentDistinct
-		if firstGroup {
-			firstGroup = false
-			currentGroup = group
-			currentDistinct = distinct
-			groupRows = 1
-			distinctRows = 1
-		} else if group != currentGroup {
-			emitGroup()
-			currentGroup = group
-			currentDistinct = distinct
-			groupRows = 1
-			distinctRows = 1
-		} else {
-			groupRows++
-			if distinct != currentDistinct {
-				currentDistinct = distinct
-				distinctRows++
-			}
-		}
-		reduceRows++
-		if err := iterator.advance(); err != nil {
-			rowsScanned, matchedRows := columnTypedColumnSortedGroupedDistinctIteratorTotals(iterators)
-			diag := r.diagnostics(view, req, rowsScanned, matchedRows, reduceRows, time.Since(start).Nanoseconds())
-			diag.SortedGroupedDistinctUsed = true
-			return ColumnPhysicalQueryResult{Diagnostics: diag}, err
-		}
-		if !iterator.done {
-			heap.push(iteratorIdx, iterators)
-		}
-	}
-	emitGroup()
 	r.resultGroups = groups
 	rowsScanned, matchedRows := columnTypedColumnSortedGroupedDistinctIteratorTotals(iterators)
 	diag := r.diagnostics(view, req, rowsScanned, matchedRows, reduceRows, time.Since(start).Nanoseconds())
@@ -2159,55 +2200,13 @@ func (r *columnTypedColumnPhysicalQueryRunner) runLatestVisibleSortedGroupedDist
 		}
 	}
 
-	groups := r.resultGroups[:0]
-	firstGroup := true
-	currentGroup := ""
-	currentDistinct := ""
-	groupRows := 0
-	distinctRows := 0
-	reduceRows := 0
-	emitGroup := func() {
-		if firstGroup {
-			return
-		}
-		groups = append(groups, ColumnPhysicalQueryGroup{Key: currentGroup, Count: groupRows, DistinctCount: distinctRows})
+	groups, reduceRows, err := r.reduceSortedGroupedDistinct(iterators, &heap)
+	if err != nil {
+		rowsScanned, matchedRows := columnTypedColumnSortedGroupedDistinctIteratorTotals(iterators)
+		diag := r.latestVisibleDiagnostics(view, req, state, visibilityBytes, visibilityNanos, rowsScanned, matchedRows, reduceRows, time.Since(start).Nanoseconds())
+		diag.SortedGroupedDistinctUsed = true
+		return ColumnPhysicalQueryResult{Diagnostics: diag}, err
 	}
-	for heap.len() != 0 {
-		iteratorIdx := heap.pop(iterators)
-		iterator := iterators[iteratorIdx]
-		group := iterator.currentGroup
-		distinct := iterator.currentDistinct
-		if firstGroup {
-			firstGroup = false
-			currentGroup = group
-			currentDistinct = distinct
-			groupRows = 1
-			distinctRows = 1
-		} else if group != currentGroup {
-			emitGroup()
-			currentGroup = group
-			currentDistinct = distinct
-			groupRows = 1
-			distinctRows = 1
-		} else {
-			groupRows++
-			if distinct != currentDistinct {
-				currentDistinct = distinct
-				distinctRows++
-			}
-		}
-		reduceRows++
-		if err := iterator.advance(); err != nil {
-			rowsScanned, matchedRows := columnTypedColumnSortedGroupedDistinctIteratorTotals(iterators)
-			diag := r.latestVisibleDiagnostics(view, req, state, visibilityBytes, visibilityNanos, rowsScanned, matchedRows, reduceRows, time.Since(start).Nanoseconds())
-			diag.SortedGroupedDistinctUsed = true
-			return ColumnPhysicalQueryResult{Diagnostics: diag}, err
-		}
-		if !iterator.done {
-			heap.push(iteratorIdx, iterators)
-		}
-	}
-	emitGroup()
 	r.resultGroups = groups
 	rowsScanned, matchedRows := columnTypedColumnSortedGroupedDistinctIteratorTotals(iterators)
 	diag := r.latestVisibleDiagnostics(view, req, state, visibilityBytes, visibilityNanos, rowsScanned, matchedRows, reduceRows, time.Since(start).Nanoseconds())
@@ -2219,22 +2218,25 @@ func (r *columnTypedColumnPhysicalQueryRunner) runLatestVisibleSortedGroupedDist
 }
 
 type columnTypedColumnSortedGroupedDistinctIterator struct {
-	partIndex        int
-	row              int
-	rows             int
-	rowIndexes       []int
-	physicalRows     []int
-	visibility       *typedColumnLatestPhysicalPart
-	codePart         *columnTypedColumnSortedGroupedDistinctPart
-	groupValues      []columnDeclaredValue
-	distinctValues   []columnDeclaredValue
-	predicateSpecs   []columnPhysicalQueryPredicateSpec
-	predicateColumns [][]columnDeclaredValue
-	currentGroup     string
-	currentDistinct  string
-	done             bool
-	rowsScanned      int
-	matchedRows      int
+	partIndex           int
+	row                 int
+	rows                int
+	rowIndexes          []int
+	physicalRows        []int
+	visibility          *typedColumnLatestPhysicalPart
+	codePart            *columnTypedColumnSortedGroupedDistinctPart
+	groupValues         []columnDeclaredValue
+	distinctValues      []columnDeclaredValue
+	predicateSpecs      []columnPhysicalQueryPredicateSpec
+	predicateColumns    [][]columnDeclaredValue
+	currentGroup        string
+	currentDistinct     string
+	currentGroupCode    uint32
+	currentDistinctCode uint32
+	globalCodes         bool
+	done                bool
+	rowsScanned         int
+	matchedRows         int
 }
 
 func newColumnTypedColumnSortedGroupedDistinctIterator(part *columnTypedColumnPhysicalQueryPart, plan columnTypedColumnPhysicalQueryPlan, req ColumnPhysicalQueryRequest, partIndex int, visibility *typedColumnLatestPhysicalPart) (*columnTypedColumnSortedGroupedDistinctIterator, error) {
@@ -2246,6 +2248,7 @@ func newColumnTypedColumnSortedGroupedDistinctIterator(part *columnTypedColumnPh
 			physicalRows: part.SortedGroupedDistinct.PhysicalRows,
 			visibility:   visibility,
 			codePart:     part.SortedGroupedDistinct,
+			globalCodes:  columnTypedColumnSortedGroupedDistinctPartHasGlobalCodes(part.SortedGroupedDistinct),
 		}, nil
 	}
 	partRows := len(part.RowIndexes)
@@ -2364,6 +2367,20 @@ func (it *columnTypedColumnSortedGroupedDistinctIterator) advanceCodes() error {
 		if len(it.codePart.Predicates) != 0 {
 			it.matchedRows++
 		}
+		if it.globalCodes {
+			if rowIdx >= len(it.codePart.Group.GlobalCodes) || rowIdx >= len(it.codePart.Distinct.GlobalCodes) {
+				return fmt.Errorf("collections: sorted grouped-distinct row=%d outside global code rows group=%d distinct=%d", rowIdx, len(it.codePart.Group.GlobalCodes), len(it.codePart.Distinct.GlobalCodes))
+			}
+			it.currentGroupCode = it.codePart.Group.GlobalCodes[rowIdx]
+			it.currentDistinctCode = it.codePart.Distinct.GlobalCodes[rowIdx]
+			if int(it.currentGroupCode) >= len(it.codePart.Group.GlobalDictionary) {
+				return fmt.Errorf("collections: sorted grouped-distinct global group code=%d outside cardinality=%d", it.currentGroupCode, len(it.codePart.Group.GlobalDictionary))
+			}
+			if int(it.currentDistinctCode) >= len(it.codePart.Distinct.GlobalDictionary) {
+				return fmt.Errorf("collections: sorted grouped-distinct global distinct code=%d outside cardinality=%d", it.currentDistinctCode, len(it.codePart.Distinct.GlobalDictionary))
+			}
+			return nil
+		}
 		groupCode := it.codePart.Group.Codes[rowIdx]
 		distinctCode := it.codePart.Distinct.Codes[rowIdx]
 		if groupCode < 0 || groupCode >= int64(len(it.codePart.Group.Dictionary)) {
@@ -2379,7 +2396,139 @@ func (it *columnTypedColumnSortedGroupedDistinctIterator) advanceCodes() error {
 	it.done = true
 	it.currentGroup = ""
 	it.currentDistinct = ""
+	it.currentGroupCode = 0
+	it.currentDistinctCode = 0
 	return nil
+}
+
+func columnTypedColumnSortedGroupedDistinctPartHasGlobalCodes(part *columnTypedColumnSortedGroupedDistinctPart) bool {
+	return part != nil &&
+		len(part.Group.GlobalCodes) == part.Rows &&
+		len(part.Distinct.GlobalCodes) == part.Rows &&
+		part.Group.GlobalDictionary != nil &&
+		part.Distinct.GlobalDictionary != nil
+}
+
+func (r *columnTypedColumnPhysicalQueryRunner) reduceSortedGroupedDistinct(iterators []*columnTypedColumnSortedGroupedDistinctIterator, heap *columnTypedColumnSortedGroupedDistinctHeap) ([]ColumnPhysicalQueryGroup, int, error) {
+	if columnTypedColumnSortedGroupedDistinctHeapUsesGlobalCodes(iterators, heap) {
+		return r.reduceSortedGroupedDistinctGlobalCodes(iterators, heap)
+	}
+	return r.reduceSortedGroupedDistinctStrings(iterators, heap)
+}
+
+func (r *columnTypedColumnPhysicalQueryRunner) reduceSortedGroupedDistinctGlobalCodes(iterators []*columnTypedColumnSortedGroupedDistinctIterator, heap *columnTypedColumnSortedGroupedDistinctHeap) ([]ColumnPhysicalQueryGroup, int, error) {
+	groups := r.resultGroups[:0]
+	firstGroup := true
+	var currentGroupCode uint32
+	var currentDistinctCode uint32
+	var groupDictionary []string
+	groupRows := 0
+	distinctRows := 0
+	reduceRows := 0
+	emitGroup := func() {
+		if firstGroup {
+			return
+		}
+		groups = append(groups, ColumnPhysicalQueryGroup{Key: groupDictionary[currentGroupCode], Count: groupRows, DistinctCount: distinctRows})
+	}
+	for heap.len() != 0 {
+		iteratorIdx := heap.pop(iterators)
+		iterator := iterators[iteratorIdx]
+		groupCode := iterator.currentGroupCode
+		distinctCode := iterator.currentDistinctCode
+		if firstGroup {
+			firstGroup = false
+			currentGroupCode = groupCode
+			currentDistinctCode = distinctCode
+			groupDictionary = iterator.codePart.Group.GlobalDictionary
+			groupRows = 1
+			distinctRows = 1
+		} else if groupCode != currentGroupCode {
+			emitGroup()
+			currentGroupCode = groupCode
+			currentDistinctCode = distinctCode
+			groupDictionary = iterator.codePart.Group.GlobalDictionary
+			groupRows = 1
+			distinctRows = 1
+		} else {
+			groupRows++
+			if distinctCode != currentDistinctCode {
+				currentDistinctCode = distinctCode
+				distinctRows++
+			}
+		}
+		reduceRows++
+		if err := iterator.advance(); err != nil {
+			return groups, reduceRows, err
+		}
+		if !iterator.done {
+			heap.push(iteratorIdx, iterators)
+		}
+	}
+	emitGroup()
+	return groups, reduceRows, nil
+}
+
+func (r *columnTypedColumnPhysicalQueryRunner) reduceSortedGroupedDistinctStrings(iterators []*columnTypedColumnSortedGroupedDistinctIterator, heap *columnTypedColumnSortedGroupedDistinctHeap) ([]ColumnPhysicalQueryGroup, int, error) {
+	groups := r.resultGroups[:0]
+	firstGroup := true
+	currentGroup := ""
+	currentDistinct := ""
+	groupRows := 0
+	distinctRows := 0
+	reduceRows := 0
+	emitGroup := func() {
+		if firstGroup {
+			return
+		}
+		groups = append(groups, ColumnPhysicalQueryGroup{Key: currentGroup, Count: groupRows, DistinctCount: distinctRows})
+	}
+	for heap.len() != 0 {
+		iteratorIdx := heap.pop(iterators)
+		iterator := iterators[iteratorIdx]
+		group := iterator.currentGroup
+		distinct := iterator.currentDistinct
+		if firstGroup {
+			firstGroup = false
+			currentGroup = group
+			currentDistinct = distinct
+			groupRows = 1
+			distinctRows = 1
+		} else if group != currentGroup {
+			emitGroup()
+			currentGroup = group
+			currentDistinct = distinct
+			groupRows = 1
+			distinctRows = 1
+		} else {
+			groupRows++
+			if distinct != currentDistinct {
+				currentDistinct = distinct
+				distinctRows++
+			}
+		}
+		reduceRows++
+		if err := iterator.advance(); err != nil {
+			return groups, reduceRows, err
+		}
+		if !iterator.done {
+			heap.push(iteratorIdx, iterators)
+		}
+	}
+	emitGroup()
+	return groups, reduceRows, nil
+}
+
+func columnTypedColumnSortedGroupedDistinctHeapUsesGlobalCodes(iterators []*columnTypedColumnSortedGroupedDistinctIterator, heap *columnTypedColumnSortedGroupedDistinctHeap) bool {
+	if heap.len() == 0 {
+		return false
+	}
+	for _, iteratorIdx := range heap.items {
+		if iteratorIdx < 0 || iteratorIdx >= len(iterators) || !iterators[iteratorIdx].globalCodes {
+			return false
+		}
+	}
+	return true
 }
 
 type columnTypedColumnSortedGroupedDistinctHeap struct {
@@ -2428,6 +2577,15 @@ func (h *columnTypedColumnSortedGroupedDistinctHeap) pop(iterators []*columnType
 }
 
 func columnTypedColumnSortedGroupedDistinctIteratorLess(left, right *columnTypedColumnSortedGroupedDistinctIterator) bool {
+	if left.globalCodes && right.globalCodes {
+		if left.currentGroupCode != right.currentGroupCode {
+			return left.currentGroupCode < right.currentGroupCode
+		}
+		if left.currentDistinctCode != right.currentDistinctCode {
+			return left.currentDistinctCode < right.currentDistinctCode
+		}
+		return left.partIndex < right.partIndex
+	}
 	if left.currentGroup != right.currentGroup {
 		return left.currentGroup < right.currentGroup
 	}


### PR DESCRIPTION
Closes #2880.
Parent: #2854.
Depends on: #2877, #2878.

## Summary
- prepares shared lexicographic global dictionary ranks for sorted grouped-distinct typed-column parts after decode
- uses the prepared global group/distinct codes in the q2 heap/reducer loop, materializing strings only when emitting result groups
- keeps the existing string reducer as fallback and adds a multi-part local-dictionary regression assertion for prepared q2 runners

## Evidence
Baseline artifacts: `/tmp/gomap_2880_q2_baseline_20260619_213732`
Candidate artifacts: `/tmp/gomap_2880_q2_candidate_20260619_114901`

Focused prepared q2 benchmark, count=8:

| metric | baseline | candidate | delta |
| --- | ---: | ---: | ---: |
| best ns/op | 940,447 | 897,544 | -4.6% |
| median ns/op | 1,173,016 | 1,017,413 | -13.3% |
| rows scanned/op | 65,536 | 65,536 | same |
| rows matched/reduced/op | 59,553 | 59,553 | same |
| allocs/op | 2 | 2 | same |

Profile comparison from single timed profile capture:
- baseline: `BenchmarkTypedColumnQ2SortedGroupedDistinct1950/prepared/sorted_prefix` = 1,106,263 ns/op, 248 B/op, 2 allocs/op
- candidate: same benchmark = 1,026,385 ns/op, 264 B/op, 2 allocs/op
- baseline CPU top had `runSortedGroupedDistinct` at 0.41s flat / 1.31s cumulative and `runtime.memequal` at 0.13s flat
- candidate CPU top has `reduceSortedGroupedDistinctGlobalCodes` at 0.28s flat / 1.27s cumulative and `runtime.memequal` down to 0.03s flat
- remaining q2 hot path is predicate-code checks plus heap pop/push in `advanceCodes` and the numeric reducer loop

Direct q2 sweep remains setup/decode dominated at about 8.1-8.8 ms/op, while prepared stays about 1.0-1.2 ms/op in these local samples. I am not claiming full q1-q5 parity from this PR; #2881 owns the final current-head evidence gate.

## Validation
- `go test ./TreeDB/collections -run 'TestTypedColumnQ2SortedGroupedDistinct|TestTypedColumnQ2MutationVisibilityLatestVisibleC3|TestColumnPhysicalJSONBenchQ2|TestColumnPhysicalJSONBenchTypedColumnPartStoresFullQ2Columns1947' -count=1`
- `go test ./TreeDB/collections -count=1`
- `go test ./TreeDB/collections -run 'TestColumnPhysicalJSONBenchParityQ1Q5P0|TestColumnPhysicalQ1DenseTypedColumnDirectPreparedParity1950|TestColumnPhysicalQ3DenseTypedColumnDirectPreparedParity1950' -count=1`
- `go test ./TreeDB/collections -run '^$' -bench 'BenchmarkTypedColumnQ2SortedGroupedDistinct1950/prepared/sorted_prefix$' -benchmem -count=8`
- `go test ./TreeDB/collections -run '^$' -bench 'BenchmarkTypedColumnQ2SortedGroupedDistinct1950/prepared/sorted_prefix$' -benchmem -count=1 -cpuprofile ... -memprofile ...`