### PR TITLE
TreeDB: add dense q2 count-distinct reducer

### DIFF
--- a/TreeDB/collections/column_physical_latest_visible_1953_test.go
+++ b/TreeDB/collections/column_physical_latest_visible_1953_test.go
@@ -179,6 +179,62 @@ func TestColumnPhysicalNonDenseNoPredicateMutationUsesTypedLatestVisible1953(t *
 	assertPreparedMutationFailsClosed1953(t, col, req)
 }
 
+func TestColumnPhysicalQ2NoSortLatestVisibleNoPredicateUsesGeneric1953(t *testing.T) {
+	batches := [][]columnPhysicalJSONBenchParityEventP0{{
+		{ID: "a1", TimeUS: 100, Kind: "commit", Operation: "create", Collection: "app.alpha", Did: "did:one"},
+		{ID: "a2", TimeUS: 110, Kind: "commit", Operation: "create", Collection: "app.alpha", Did: "did:two"},
+		{ID: "b1", TimeUS: 120, Kind: "commit", Operation: "create", Collection: "app.beta", Did: "did:one"},
+	}, {
+		{ID: "c1", TimeUS: 130, Kind: "identity", Operation: "update", Collection: "app.gamma", Did: "did:three"},
+		{ID: "a3", TimeUS: 140, Kind: "commit", Operation: "delete", Collection: "app.alpha", Did: "did:one"},
+	}}
+	_, _, col, closeFn := openTypedColumnLatestVisibleFixture1953(t, nil, batches)
+	defer closeFn()
+	events := flattenColumnPhysicalEvents1950(batches)
+	latest := latestEventMap1953(events)
+
+	updated := latest["a1"]
+	updated.Collection = "app.beta"
+	updated.Did = "did:two"
+	updated.TimeUS += 77
+	updateTypedColumnEvent1953(t, col, updated)
+	latest[updated.ID] = updated
+	deleteTypedColumnEvent1953(t, col, "c1")
+	delete(latest, "c1")
+
+	req := ColumnPhysicalQueryRequest{
+		Kind:           ColumnPhysicalQueryGroupCountAndDistinct,
+		GroupColumn:    "collection",
+		DistinctColumn: "did",
+	}
+	result, err := col.RunColumnPhysicalQuery(req)
+	if err != nil {
+		t.Fatalf("RunColumnPhysicalQuery(q2 no-sort no-predicate latest-visible): %v diagnostics=%+v", err, result.Diagnostics)
+	}
+	live := latestEvents1953(latest)
+	got := columnPhysicalJSONBenchQ2CountsP0(result.Groups)
+	want := collectionDidCountDistinct1953(live)
+	if !columnPhysicalJSONBenchQ2CountsEqualP0(got, want) {
+		t.Fatalf("q2 no-sort latest-visible counts=%v want %v groups=%+v", got, want, result.Groups)
+	}
+	if result.Diagnostics.StorageSource != ColumnPhysicalQueryStorageSourceTypedColumnPartSection || result.Diagnostics.FallbackReason != ColumnPhysicalQueryFallbackNone {
+		t.Fatalf("q2 no-sort diagnostics=%+v want typed-column latest-visible path", result.Diagnostics)
+	}
+	if result.Diagnostics.DenseGroupCountDistinctUsed || result.Diagnostics.SortedGroupedDistinctUsed {
+		t.Fatalf("q2 no-sort diagnostics=%+v want generic latest-visible count-distinct path", result.Diagnostics)
+	}
+	if result.Diagnostics.MutationParts == 0 || result.Diagnostics.VisibilityRows != len(live) || result.Diagnostics.DeletedRows == 0 {
+		t.Fatalf("q2 no-sort visibility diagnostics=%+v want mutation parts, visible=%d, deleted rows", result.Diagnostics, len(live))
+	}
+	if result.Diagnostics.PredicateCount != 0 || result.Diagnostics.RowsMatched != 0 || result.Diagnostics.ReduceRows != len(live) {
+		t.Fatalf("q2 no-sort reduce diagnostics=%+v want no predicates and reduce rows=%d", result.Diagnostics, len(live))
+	}
+	if result.Diagnostics.RowMaterializations != 0 || result.Diagnostics.DocumentMaterializations != 0 {
+		t.Fatalf("q2 no-sort materialization diagnostics=%+v want no row/document materialization", result.Diagnostics)
+	}
+	assertPreparedMutationFailsClosed1953(t, col, req)
+}
+
 func TestColumnPhysicalQ2SortedLatestVisibleMutationReopen1953(t *testing.T) {
 	batches := [][]columnPhysicalJSONBenchParityEventP0{typedColumnQ2SortedBatchA1950(), typedColumnQ2SortedBatchB1950()}
 	dir, d, col, closeFn := openTypedColumnLatestVisibleFixture1953(t, typedColumnQ2ClickHouseSortKey1950(), batches)
@@ -710,6 +766,23 @@ func latestEvents1953(latest map[string]columnPhysicalJSONBenchParityEventP0) []
 		out = append(out, event)
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
+	return out
+}
+
+func collectionDidCountDistinct1953(events []columnPhysicalJSONBenchParityEventP0) map[string]columnPhysicalJSONBenchQ2CountP0 {
+	counts := make(map[string]int64)
+	distinct := make(map[string]map[string]struct{})
+	for _, event := range events {
+		counts[event.Collection]++
+		if distinct[event.Collection] == nil {
+			distinct[event.Collection] = make(map[string]struct{})
+		}
+		distinct[event.Collection][event.Did] = struct{}{}
+	}
+	out := make(map[string]columnPhysicalJSONBenchQ2CountP0, len(counts))
+	for collection, count := range counts {
+		out[collection] = columnPhysicalJSONBenchQ2CountP0{Count: count, Distinct: int64(len(distinct[collection]))}
+	}
 	return out
 }
 

--- a/TreeDB/collections/column_physical_q2_1950_test.go
+++ b/TreeDB/collections/column_physical_q2_1950_test.go
@@ -98,6 +98,61 @@ func TestTypedColumnQ2SortedGroupedDistinctFallback1950(t *testing.T) {
 	}
 }
 
+func TestTypedColumnQ2DenseGroupCountDistinctNoSortLocalDictionaries1950(t *testing.T) {
+	batches := [][]columnPhysicalJSONBenchParityEventP0{typedColumnQ2LocalDictBatchA1950(), typedColumnQ2LocalDictBatchB1950()}
+	events := flattenColumnPhysicalEvents1950(batches)
+	d, col, closeFn := openTypedColumnSortKeyFixtureBatches1950(t, nil, batches)
+	defer closeFn()
+
+	codesByGeneration := typedColumnQ1DictionaryCodeByGeneration1950(t, d, col, "did", "did:m")
+	if len(codesByGeneration) < 2 {
+		t.Fatalf("did:m dictionary codes by generation=%v want at least two", codesByGeneration)
+	}
+	seenCodes := make(map[int64]struct{}, len(codesByGeneration))
+	for _, code := range codesByGeneration {
+		seenCodes[code] = struct{}{}
+	}
+	if len(seenCodes) < 2 {
+		t.Fatalf("did:m local dictionary codes=%v want differing local dictionary orders", codesByGeneration)
+	}
+
+	req := typedColumnQ2Request1950()
+	rowHash := columnPhysicalJSONBenchHashLinesP0(columnPhysicalJSONBenchReferenceLinesP0("q2", events))
+	want := columnPhysicalJSONBenchQ2ReferenceCountsP0(events)
+	matchedRows := columnPhysicalJSONBenchReferenceMatchedRowsP0("q2", events)
+
+	direct, err := col.RunColumnPhysicalQuery(req)
+	if err != nil {
+		t.Fatalf("RunColumnPhysicalQuery(q2 dense no-sort): %v", err)
+	}
+	assertTypedColumnQ2SortedGroupedDistinctResult1950(t, "dense no-sort", direct, rowHash, want)
+	assertTypedColumnQ2DenseGroupCountDistinctDiagnostics1950(t, "dense no-sort", direct.Diagnostics, len(events), matchedRows)
+
+	runner, err := col.PrepareColumnPhysicalQuery(req)
+	if err != nil {
+		t.Fatalf("PrepareColumnPhysicalQuery(q2 dense no-sort): %v", err)
+	}
+	defer func() { _ = runner.Close() }()
+	prepared, err := runner.Run()
+	if err != nil {
+		t.Fatalf("prepared q2 dense no-sort: %v", err)
+	}
+	assertTypedColumnQ2DensePreparedGlobalCodes1950(t, runner)
+	assertTypedColumnQ2SortedGroupedDistinctResult1950(t, "prepared dense no-sort", prepared, rowHash, want)
+	assertTypedColumnQ2DenseGroupCountDistinctDiagnostics1950(t, "prepared dense no-sort", prepared.Diagnostics, len(events), matchedRows)
+
+	got := columnPhysicalJSONBenchQ2CountsP0(prepared.Groups)
+	if got["app.z"].Count != 4 || got["app.z"].Distinct != 2 {
+		t.Fatalf("app.z counts=%+v want duplicate did:m counted once across different local dictionaries", got["app.z"])
+	}
+	if got[""].Count != 1 || got[""].Distinct != 1 {
+		t.Fatalf("empty event counts=%+v want real empty group value", got[""])
+	}
+	if got["app.emptydid"].Count != 2 || got["app.emptydid"].Distinct != 1 {
+		t.Fatalf("empty did counts=%+v want empty distinct value counted once", got["app.emptydid"])
+	}
+}
+
 func TestTypedColumnQ2SortedGroupedDistinctLocalDictionariesAndEmptyValues1950(t *testing.T) {
 	batches := [][]columnPhysicalJSONBenchParityEventP0{typedColumnQ2LocalDictBatchA1950(), typedColumnQ2LocalDictBatchB1950()}
 	events := flattenColumnPhysicalEvents1950(batches)
@@ -411,6 +466,71 @@ func assertTypedColumnQ2PreparedGlobalCodes1950(tb testing.TB, runner *ColumnPhy
 	}
 }
 
+func assertTypedColumnQ2DensePreparedGlobalCodes1950(tb testing.TB, runner *ColumnPhysicalQueryRunner) {
+	tb.Helper()
+	if runner == nil || runner.typedColumn == nil {
+		tb.Fatalf("prepared q2 runner missing typed-column state")
+	}
+	if len(runner.typedColumn.parts) < 2 {
+		tb.Fatalf("prepared q2 parts=%d want multiple local dictionaries", len(runner.typedColumn.parts))
+	}
+	didMRank := -1
+	didMParts := 0
+	for partIdx := range runner.typedColumn.parts {
+		part := runner.typedColumn.parts[partIdx].DenseGroupCountDistinct
+		if part == nil {
+			tb.Fatalf("part %d missing dense grouped count-distinct state", partIdx)
+		}
+		if len(part.Group.GlobalCodes) != part.Rows || len(part.Distinct.GlobalCodes) != part.Rows {
+			tb.Fatalf("part %d global code rows group=%d distinct=%d want %d", partIdx, len(part.Group.GlobalCodes), len(part.Distinct.GlobalCodes), part.Rows)
+		}
+		if !sort.StringsAreSorted(part.Group.GlobalDictionary) || !sort.StringsAreSorted(part.Distinct.GlobalDictionary) {
+			tb.Fatalf("part %d global dictionaries not lexicographically sorted group=%v distinct=%v", partIdx, part.Group.GlobalDictionary, part.Distinct.GlobalDictionary)
+		}
+		localDidM := -1
+		for code, value := range part.Distinct.Dictionary {
+			if value == "did:m" {
+				localDidM = code
+				break
+			}
+		}
+		if localDidM < 0 {
+			continue
+		}
+		partDidMRank := -1
+		for rank, value := range part.Distinct.GlobalDictionary {
+			if value == "did:m" {
+				partDidMRank = rank
+				break
+			}
+		}
+		if partDidMRank < 0 {
+			tb.Fatalf("part %d distinct global dictionary missing did:m", partIdx)
+		}
+		if didMRank < 0 {
+			didMRank = partDidMRank
+		} else if didMRank != partDidMRank {
+			tb.Fatalf("did:m global rank part %d=%d want %d", partIdx, partDidMRank, didMRank)
+		}
+		seenDidMRow := false
+		for row, localCode := range part.Distinct.Codes {
+			if localCode == uint32(localDidM) && columnTypedColumnDenseCodeValid(part.Distinct.Valid, row) {
+				seenDidMRow = true
+				if part.Distinct.GlobalCodes[row] != uint32(partDidMRank) {
+					tb.Fatalf("part %d did:m row=%d global code=%d want %d", partIdx, row, part.Distinct.GlobalCodes[row], partDidMRank)
+				}
+			}
+		}
+		if !seenDidMRow {
+			tb.Fatalf("part %d local did:m code=%d not referenced by any row", partIdx, localDidM)
+		}
+		didMParts++
+	}
+	if didMParts < 2 {
+		tb.Fatalf("did:m appeared in %d parts want at least two to prove cross-part global rank reuse", didMParts)
+	}
+}
+
 func openTypedColumnSortKeyFixtureBatches1950(tb testing.TB, sortKey []ColumnSortKey, batches [][]columnPhysicalJSONBenchParityEventP0) (*backenddb.DB, *Collection, func()) {
 	tb.Helper()
 	dir := tb.TempDir()
@@ -501,5 +621,27 @@ func assertTypedColumnQ2SortedGroupedDistinctDiagnostics1950(tb testing.TB, labe
 		if diag.SortKeyMarkChecks == 0 {
 			tb.Fatalf("%s mark diagnostics=%+v want sorted-prefix mark checks", label, diag)
 		}
+	}
+}
+
+func assertTypedColumnQ2DenseGroupCountDistinctDiagnostics1950(tb testing.TB, label string, diag ColumnPhysicalQueryDiagnostics, totalRows, matchedRows int) {
+	tb.Helper()
+	if diag.StorageSource != ColumnPhysicalQueryStorageSourceTypedColumnPartSection || diag.FallbackReason != ColumnPhysicalQueryFallbackNone {
+		tb.Fatalf("%s diagnostics=%+v want typed-column source without storage fallback", label, diag)
+	}
+	if diag.PredicateCount != 2 || diag.RowsMatched != matchedRows || diag.ReduceRows != matchedRows {
+		tb.Fatalf("%s predicate diagnostics=%+v want predicates=2 matched/reduced=%d", label, diag, matchedRows)
+	}
+	if diag.RowsScanned != totalRows {
+		tb.Fatalf("%s rows scanned diagnostics=%+v want full no-sort scan %d", label, diag, totalRows)
+	}
+	if diag.RowMaterializations != 0 || diag.DocumentMaterializations != 0 {
+		tb.Fatalf("%s materialization diagnostics=%+v want no row/document materialization", label, diag)
+	}
+	if !diag.DenseGroupCountDistinctUsed || diag.SortedGroupedDistinctUsed || diag.DenseGroupCountUsed || diag.DenseGroupHourCountUsed || diag.DenseInt64SpanUsed || diag.TimeOrderTopKUsed {
+		tb.Fatalf("%s diagnostics=%+v want only dense grouped count-distinct path", label, diag)
+	}
+	if diag.SortKeyMarkChecks != 0 || diag.SortKeyMarkSkips != 0 {
+		tb.Fatalf("%s mark diagnostics=%+v want no sort-key pruning in dense no-sort path", label, diag)
 	}
 }

--- a/TreeDB/collections/column_physical_query.go
+++ b/TreeDB/collections/column_physical_query.go
@@ -151,6 +151,7 @@ type ColumnPhysicalQueryDiagnostics struct {
 	SortedGroupedDistinctUsed           bool
 	SortedGroupedDistinctFallbackReason string
 	DenseGroupCountUsed                 bool
+	DenseGroupCountDistinctUsed         bool
 	DenseGroupHourCountUsed             bool
 	DenseInt64SpanUsed                  bool
 	TimeOrderTopKUsed                   bool
@@ -1369,6 +1370,7 @@ func mergeColumnPhysicalQueryDiagnostics(left, right ColumnPhysicalQueryDiagnost
 	}
 	left.SortedGroupedDistinctFallbackReason = mergeColumnPhysicalSortKeyFallbackReason(left.SortedGroupedDistinctFallbackReason, right.SortedGroupedDistinctFallbackReason)
 	left.DenseGroupCountUsed = left.DenseGroupCountUsed || right.DenseGroupCountUsed
+	left.DenseGroupCountDistinctUsed = left.DenseGroupCountDistinctUsed || right.DenseGroupCountDistinctUsed
 	left.DenseGroupHourCountUsed = left.DenseGroupHourCountUsed || right.DenseGroupHourCountUsed
 	left.DenseInt64SpanUsed = left.DenseInt64SpanUsed || right.DenseInt64SpanUsed
 	left.TimeOrderTopKUsed = left.TimeOrderTopKUsed || right.TimeOrderTopKUsed

--- a/TreeDB/collections/column_physical_typed_column_1947_test.go
+++ b/TreeDB/collections/column_physical_typed_column_1947_test.go
@@ -212,7 +212,7 @@ func TestColumnPhysicalJSONBenchTypedColumnPartNullableFullDataMissingStrings216
 		DistinctColumn: "did",
 		Predicates:     commitCreate,
 	}
-	q2Result := runNullableFullDataQuery2165(t, collection, "q2", q2, len(docs), len(commitCreate), 4, 4)
+	q2Result := runNullableFullDataDenseQ2Query2165(t, collection, "q2", q2, len(docs), len(commitCreate), 4, 4)
 	wantQ2 := map[string]columnPhysicalCountDistinct2165{
 		"":                   {Count: 1, Distinct: 1},
 		"app.bsky.feed.post": {Count: 3, Distinct: 2},
@@ -768,6 +768,35 @@ func runNullableFullDataQuery2165(tb testing.TB, collection *Collection, name st
 	return direct
 }
 
+func runNullableFullDataDenseQ2Query2165(tb testing.TB, collection *Collection, name string, req ColumnPhysicalQueryRequest, wantRows, wantPredicates, wantMatched, wantReduce int) ColumnPhysicalQueryResult {
+	tb.Helper()
+	direct, err := collection.RunColumnPhysicalQuery(req)
+	if err != nil {
+		tb.Fatalf("RunColumnPhysicalQuery(%s): %v", name, err)
+	}
+	assertColumnPhysicalJSONBenchTypedColumnDiagnostics1947(tb, name+" direct", direct.Diagnostics, wantRows, wantPredicates, wantMatched, wantReduce)
+	assertNullableFullDataDenseQ2Diagnostics2165(tb, name+" direct", direct.Diagnostics)
+
+	runner, err := collection.PrepareColumnPhysicalQuery(req)
+	if err != nil {
+		tb.Fatalf("PrepareColumnPhysicalQuery(%s): %v", name, err)
+	}
+	defer func() { _ = runner.Close() }()
+	var prepared ColumnPhysicalQueryResult
+	for run := 0; run < 2; run++ {
+		prepared, err = runner.Run()
+		if err != nil {
+			tb.Fatalf("prepared %s run %d: %v", name, run, err)
+		}
+		assertColumnPhysicalJSONBenchTypedColumnDiagnostics1947(tb, fmt.Sprintf("%s prepared %d", name, run), prepared.Diagnostics, wantRows, wantPredicates, wantMatched, wantReduce)
+		assertNullableFullDataDenseQ2Diagnostics2165(tb, fmt.Sprintf("%s prepared %d", name, run), prepared.Diagnostics)
+		if !reflect.DeepEqual(prepared.Groups, direct.Groups) {
+			tb.Fatalf("%s prepared run %d groups=%+v want direct %+v", name, run, prepared.Groups, direct.Groups)
+		}
+	}
+	return direct
+}
+
 func runNullableFullDataTopKFastPath2878(tb testing.TB, collection *Collection, name string, req ColumnPhysicalQueryRequest, want []ColumnPhysicalQueryGroup, assertDiag func(testing.TB, string, ColumnPhysicalQueryDiagnostics)) {
 	tb.Helper()
 	direct, err := collection.RunColumnPhysicalQuery(req)
@@ -817,7 +846,7 @@ func assertNullableFullDataTopKBaseDiagnostics2878(tb testing.TB, label string, 
 
 func assertNullableFullDataGenericDiagnostics2165(tb testing.TB, label string, diag ColumnPhysicalQueryDiagnostics) {
 	tb.Helper()
-	if diag.DenseGroupCountUsed || diag.DenseGroupHourCountUsed || diag.DenseInt64SpanUsed || diag.SortedGroupedDistinctUsed || diag.TimeOrderTopKUsed {
+	if diag.DenseGroupCountUsed || diag.DenseGroupCountDistinctUsed || diag.DenseGroupHourCountUsed || diag.DenseInt64SpanUsed || diag.SortedGroupedDistinctUsed || diag.TimeOrderTopKUsed {
 		tb.Fatalf("%s nullable full-data query used nullable-unsafe fast path: %+v", label, diag)
 	}
 	if diag.SortKeyPrefixPlanned || diag.SortKeyMarkChecks != 0 || diag.SortKeyMarkSkips != 0 {
@@ -825,6 +854,19 @@ func assertNullableFullDataGenericDiagnostics2165(tb testing.TB, label string, d
 	}
 	if diag.DecodedBlocks == 0 || diag.DecodedPayloadBytes == 0 {
 		tb.Fatalf("%s nullable full-data query did not report typed-column decode work: %+v", label, diag)
+	}
+}
+
+func assertNullableFullDataDenseQ2Diagnostics2165(tb testing.TB, label string, diag ColumnPhysicalQueryDiagnostics) {
+	tb.Helper()
+	if !diag.DenseGroupCountDistinctUsed || diag.DenseGroupCountUsed || diag.DenseGroupHourCountUsed || diag.DenseInt64SpanUsed || diag.SortedGroupedDistinctUsed || diag.TimeOrderTopKUsed {
+		tb.Fatalf("%s diagnostics=%+v want only dense q2 count-distinct fast path", label, diag)
+	}
+	if diag.SortKeyPrefixPlanned || diag.SortKeyMarkChecks != 0 || diag.SortKeyMarkSkips != 0 {
+		tb.Fatalf("%s dense q2 diagnostics used sort-key pruning: %+v", label, diag)
+	}
+	if diag.DecodedBlocks == 0 || diag.DecodedPayloadBytes == 0 {
+		tb.Fatalf("%s dense q2 diagnostics did not report typed-column decode work: %+v", label, diag)
 	}
 }
 

--- a/TreeDB/collections/column_physical_typed_column_query.go
+++ b/TreeDB/collections/column_physical_typed_column_query.go
@@ -413,6 +413,7 @@ func decodeColumnTypedColumnPhysicalQueryRunnerParts(view columnPhysicalScanSnap
 	defer func() { readCache.returnViews = savedReturnViews }()
 
 	var rawScratch []byte
+	allowDenseGroupCountDistinct := view.MutationParts == 0
 	for _, physical := range view.AssetRefs {
 		if physical.Role == ColumnManifestPartRoleTombstone || physical.Reason == ColumnPublishOperationDelete {
 			continue
@@ -443,7 +444,7 @@ func decodeColumnTypedColumnPhysicalQueryRunnerParts(view columnPhysicalScanSnap
 			part, err = decodeTypedColumnPhysicalQueryTimeOrderTopKPart(plan, view.FullConfig.SchemaHash, typedRef, physical, raw, includePhysicalRows)
 		case columnTypedColumnPhysicalQueryUseSortedGroupedDistinct(plan, req):
 			part, err = decodeTypedColumnPhysicalQuerySortedGroupedDistinctPart(plan, view.FullConfig.SchemaHash, typedRef, physical, raw, includePhysicalRows)
-		case columnTypedColumnPhysicalQueryUseDenseGroupCountDistinct(plan, req):
+		case allowDenseGroupCountDistinct && columnTypedColumnPhysicalQueryUseDenseGroupCountDistinct(plan, req):
 			part, err = decodeTypedColumnPhysicalQueryDenseGroupCountDistinctPart(plan, view.FullConfig.SchemaHash, typedRef, physical, raw)
 		default:
 			part, err = decodeTypedColumnPhysicalQueryPart(plan, view.FullConfig.SchemaHash, typedRef, physical, raw, includePhysicalRows)
@@ -472,7 +473,7 @@ func decodeColumnTypedColumnPhysicalQueryRunnerParts(view columnPhysicalScanSnap
 		if err := prepareColumnTypedColumnSortedGroupedDistinctGlobalCodes(runner.parts); err != nil {
 			return nil, err
 		}
-	} else if columnTypedColumnPhysicalQueryUseDenseGroupCountDistinct(plan, req) {
+	} else if allowDenseGroupCountDistinct && columnTypedColumnPhysicalQueryUseDenseGroupCountDistinct(plan, req) {
 		if err := prepareColumnTypedColumnDenseGroupCountDistinctGlobalCodes(runner.parts); err != nil {
 			return nil, err
 		}

--- a/TreeDB/collections/column_physical_typed_column_query.go
+++ b/TreeDB/collections/column_physical_typed_column_query.go
@@ -10,21 +10,22 @@ import (
 )
 
 type columnTypedColumnPhysicalQueryPlan struct {
-	Fields               []TypedStorageField
-	Selected             []bool
-	ProjectedColumns     []string
-	PredicateDiagnostics columnPhysicalQueryPredicateDiagnosticPlan
-	GroupColumn          string
-	ValueColumn          string
-	DistinctColumn       string
-	PredicateSpecs       []columnPhysicalQueryPredicateSpec
-	SortKey              []ColumnSortKey
-	SortKeyPrefix        columnTypedColumnSortKeyPrefixPlan
-	DenseGroupCount      bool
-	DenseGroupHourCount  bool
-	DenseInt64Span       bool
-	TimeOrderTopK        bool
-	NullableStringValues bool
+	Fields                  []TypedStorageField
+	Selected                []bool
+	ProjectedColumns        []string
+	PredicateDiagnostics    columnPhysicalQueryPredicateDiagnosticPlan
+	GroupColumn             string
+	ValueColumn             string
+	DistinctColumn          string
+	PredicateSpecs          []columnPhysicalQueryPredicateSpec
+	SortKey                 []ColumnSortKey
+	SortKeyPrefix           columnTypedColumnSortKeyPrefixPlan
+	DenseGroupCount         bool
+	DenseGroupCountDistinct bool
+	DenseGroupHourCount     bool
+	DenseInt64Span          bool
+	TimeOrderTopK           bool
+	NullableStringValues    bool
 }
 
 type columnTypedColumnDenseGroupCountPart struct {
@@ -39,6 +40,21 @@ type columnTypedColumnDensePredicatePart struct {
 	Allowed             []uint64
 	MissingMatchesEmpty bool
 	RejectsAll          bool
+}
+
+type columnTypedColumnDenseStringCodeColumn struct {
+	Codes            []uint32
+	Valid            []bool
+	Dictionary       []string
+	GlobalCodes      []uint32
+	GlobalDictionary []string
+}
+
+type columnTypedColumnDenseGroupCountDistinctPart struct {
+	Rows       int
+	Group      columnTypedColumnDenseStringCodeColumn
+	Distinct   columnTypedColumnDenseStringCodeColumn
+	Predicates []columnTypedColumnDensePredicatePart
 }
 
 type columnTypedColumnDenseGroupHourCountPart struct {
@@ -100,6 +116,7 @@ type columnTypedColumnPhysicalQueryPart struct {
 	SortKeyMarkSkips          int
 	SortKeyMarkFallbackReason string
 	DenseGroupCount           *columnTypedColumnDenseGroupCountPart
+	DenseGroupCountDistinct   *columnTypedColumnDenseGroupCountDistinctPart
 	DenseGroupHourCount       *columnTypedColumnDenseGroupHourCountPart
 	DenseInt64Span            *columnTypedColumnDenseInt64SpanPart
 	SortedGroupedDistinct     *columnTypedColumnSortedGroupedDistinctPart
@@ -107,33 +124,36 @@ type columnTypedColumnPhysicalQueryPart struct {
 }
 
 type columnTypedColumnPhysicalQueryRunner struct {
-	plan                      columnTypedColumnPhysicalQueryPlan
-	parts                     []columnTypedColumnPhysicalQueryPart
-	assetBytes                int64
-	sections                  int
-	sectionBytes              uint64
-	granulesConsidered        int
-	granulesDecoded           int
-	granulesSkipped           int
-	decodedBlocks             int
-	decodedPayloadBytes       uint64
-	sortKeyMarkChecks         int
-	sortKeyMarkMatches        int
-	sortKeyMarkSkips          int
-	sortKeyMarkFallbackReason string
-	segmentFileCacheHits      uint64
-	segmentFileCacheMisses    uint64
-	denseGroupCounts          map[string]int
-	denseLocalCounts          []int
-	denseGroupHourCounts      map[string][24]int
-	denseLocalHourCounts      []int
-	denseSpanValues           map[string]columnPhysicalQuerySpan
-	denseLocalSpans           []columnPhysicalQuerySpan
-	denseLocalSpanSeen        []bool
-	timeOrderMinValues        map[string]int64
-	timeOrderHeap             columnTypedColumnTimeOrderTopKHeap
-	timeOrderTopKScratch      []ColumnPhysicalQueryGroup
-	resultGroups              []ColumnPhysicalQueryGroup
+	plan                                  columnTypedColumnPhysicalQueryPlan
+	parts                                 []columnTypedColumnPhysicalQueryPart
+	assetBytes                            int64
+	sections                              int
+	sectionBytes                          uint64
+	granulesConsidered                    int
+	granulesDecoded                       int
+	granulesSkipped                       int
+	decodedBlocks                         int
+	decodedPayloadBytes                   uint64
+	sortKeyMarkChecks                     int
+	sortKeyMarkMatches                    int
+	sortKeyMarkSkips                      int
+	sortKeyMarkFallbackReason             string
+	segmentFileCacheHits                  uint64
+	segmentFileCacheMisses                uint64
+	denseGroupCounts                      map[string]int
+	denseLocalCounts                      []int
+	denseGroupCountDistinctCounts         []int
+	denseGroupCountDistinctDistinctCounts []int
+	denseGroupCountDistinctPairs          map[uint64]struct{}
+	denseGroupHourCounts                  map[string][24]int
+	denseLocalHourCounts                  []int
+	denseSpanValues                       map[string]columnPhysicalQuerySpan
+	denseLocalSpans                       []columnPhysicalQuerySpan
+	denseLocalSpanSeen                    []bool
+	timeOrderMinValues                    map[string]int64
+	timeOrderHeap                         columnTypedColumnTimeOrderTopKHeap
+	timeOrderTopKScratch                  []ColumnPhysicalQueryGroup
+	resultGroups                          []ColumnPhysicalQueryGroup
 }
 
 func (c *Collection) runColumnPhysicalQueryTypedColumnPartInSnapshotView(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest) (ColumnPhysicalQueryResult, bool, error) {
@@ -423,6 +443,8 @@ func decodeColumnTypedColumnPhysicalQueryRunnerParts(view columnPhysicalScanSnap
 			part, err = decodeTypedColumnPhysicalQueryTimeOrderTopKPart(plan, view.FullConfig.SchemaHash, typedRef, physical, raw, includePhysicalRows)
 		case columnTypedColumnPhysicalQueryUseSortedGroupedDistinct(plan, req):
 			part, err = decodeTypedColumnPhysicalQuerySortedGroupedDistinctPart(plan, view.FullConfig.SchemaHash, typedRef, physical, raw, includePhysicalRows)
+		case columnTypedColumnPhysicalQueryUseDenseGroupCountDistinct(plan, req):
+			part, err = decodeTypedColumnPhysicalQueryDenseGroupCountDistinctPart(plan, view.FullConfig.SchemaHash, typedRef, physical, raw)
 		default:
 			part, err = decodeTypedColumnPhysicalQueryPart(plan, view.FullConfig.SchemaHash, typedRef, physical, raw, includePhysicalRows)
 		}
@@ -448,6 +470,10 @@ func decodeColumnTypedColumnPhysicalQueryRunnerParts(view columnPhysicalScanSnap
 	}
 	if columnTypedColumnPhysicalQueryUseSortedGroupedDistinct(plan, req) {
 		if err := prepareColumnTypedColumnSortedGroupedDistinctGlobalCodes(runner.parts); err != nil {
+			return nil, err
+		}
+	} else if columnTypedColumnPhysicalQueryUseDenseGroupCountDistinct(plan, req) {
+		if err := prepareColumnTypedColumnDenseGroupCountDistinctGlobalCodes(runner.parts); err != nil {
 			return nil, err
 		}
 	}
@@ -521,6 +547,96 @@ func prepareColumnTypedColumnSortedGroupedDistinctGlobalColumnCodes(column *colu
 	globalCodes := make([]uint32, len(column.Codes))
 	for row, localCode := range column.Codes {
 		if localCode < 0 || localCode >= int64(len(localRanks)) {
+			return fmt.Errorf("row=%d code=%d outside cardinality=%d", row, localCode, len(localRanks))
+		}
+		globalCodes[row] = localRanks[localCode]
+	}
+	column.GlobalCodes = globalCodes
+	column.GlobalDictionary = globalDictionary
+	return nil
+}
+
+func prepareColumnTypedColumnDenseGroupCountDistinctGlobalCodes(parts []columnTypedColumnPhysicalQueryPart) error {
+	groupDict, groupRanks, err := columnTypedColumnDenseGroupCountDistinctGlobalDictionary(parts, func(part *columnTypedColumnDenseGroupCountDistinctPart) *columnTypedColumnDenseStringCodeColumn {
+		return &part.Group
+	})
+	if err != nil {
+		return err
+	}
+	distinctDict, distinctRanks, err := columnTypedColumnDenseGroupCountDistinctGlobalDictionary(parts, func(part *columnTypedColumnDenseGroupCountDistinctPart) *columnTypedColumnDenseStringCodeColumn {
+		return &part.Distinct
+	})
+	if err != nil {
+		return err
+	}
+	for partIdx := range parts {
+		part := parts[partIdx].DenseGroupCountDistinct
+		if part == nil {
+			return fmt.Errorf("collections: dense grouped count-distinct missing prepared part %d", partIdx)
+		}
+		if err := prepareColumnTypedColumnDenseGroupCountDistinctGlobalColumnCodes(&part.Group, groupDict, groupRanks); err != nil {
+			return fmt.Errorf("collections: dense grouped count-distinct group part %d: %w", partIdx, err)
+		}
+		if err := prepareColumnTypedColumnDenseGroupCountDistinctGlobalColumnCodes(&part.Distinct, distinctDict, distinctRanks); err != nil {
+			return fmt.Errorf("collections: dense grouped count-distinct distinct part %d: %w", partIdx, err)
+		}
+	}
+	return nil
+}
+
+func columnTypedColumnDenseGroupCountDistinctGlobalDictionary(parts []columnTypedColumnPhysicalQueryPart, selectColumn func(*columnTypedColumnDenseGroupCountDistinctPart) *columnTypedColumnDenseStringCodeColumn) ([]string, map[string]uint32, error) {
+	values := make(map[string]struct{})
+	for partIdx := range parts {
+		part := parts[partIdx].DenseGroupCountDistinct
+		if part == nil {
+			return nil, nil, fmt.Errorf("collections: dense grouped count-distinct missing prepared part %d", partIdx)
+		}
+		column := selectColumn(part)
+		for _, value := range column.Dictionary {
+			values[value] = struct{}{}
+		}
+		for _, valid := range column.Valid {
+			if !valid {
+				values[""] = struct{}{}
+				break
+			}
+		}
+	}
+	dictionary := make([]string, 0, len(values))
+	for value := range values {
+		dictionary = append(dictionary, value)
+	}
+	sort.Strings(dictionary)
+	ranks := make(map[string]uint32, len(dictionary))
+	for rank, value := range dictionary {
+		if uint64(rank) > uint64(^uint32(0)) {
+			return nil, nil, fmt.Errorf("collections: dense grouped count-distinct global dictionary cardinality=%d exceeds uint32", len(dictionary))
+		}
+		ranks[value] = uint32(rank)
+	}
+	return dictionary, ranks, nil
+}
+
+func prepareColumnTypedColumnDenseGroupCountDistinctGlobalColumnCodes(column *columnTypedColumnDenseStringCodeColumn, globalDictionary []string, ranks map[string]uint32) error {
+	localRanks := make([]uint32, len(column.Dictionary))
+	for localCode, value := range column.Dictionary {
+		rank, ok := ranks[value]
+		if !ok {
+			return fmt.Errorf("local dictionary value %q missing from global dictionary", value)
+		}
+		localRanks[localCode] = rank
+	}
+	emptyRank, emptyOK := ranks[""]
+	globalCodes := make([]uint32, len(column.Codes))
+	for row, localCode := range column.Codes {
+		if !columnTypedColumnDenseCodeValid(column.Valid, row) {
+			if !emptyOK {
+				return fmt.Errorf("row=%d nullable missing value has no empty-string global rank", row)
+			}
+			globalCodes[row] = emptyRank
+			continue
+		}
+		if uint64(localCode) >= uint64(len(localRanks)) {
 			return fmt.Errorf("row=%d code=%d outside cardinality=%d", row, localCode, len(localRanks))
 		}
 		globalCodes[row] = localRanks[localCode]
@@ -625,6 +741,7 @@ func planColumnTypedColumnPhysicalQuery(cfg ColumnStoreConfig, req ColumnPhysica
 		plan.SortKeyPrefix = columnTypedColumnSortKeyPrefixPlan{}
 	}
 	plan.DenseGroupCount = columnTypedColumnPhysicalQueryShapeCanUseDenseGroupCount(req)
+	plan.DenseGroupCountDistinct = columnTypedColumnPhysicalQueryShapeCanUseDenseGroupCountDistinct(req)
 	plan.DenseGroupHourCount = columnTypedColumnPhysicalQueryShapeCanUseDenseGroupHourCount(req)
 	plan.DenseInt64Span = columnTypedColumnPhysicalQueryShapeCanUseDenseInt64Span(req)
 	plan.TimeOrderTopK = columnTypedColumnPhysicalQueryShapeCanUseTimeOrderTopK(req) && columnTypedColumnPhysicalQuerySortKeyCanUseTimeOrderTopK(sortKey, req)
@@ -913,6 +1030,9 @@ func (r *columnTypedColumnPhysicalQueryRunner) run(view columnPhysicalScanSnapsh
 			r.resultGroups = result.Groups
 		}
 		return result, err
+	}
+	if columnTypedColumnPhysicalQueryUseDenseGroupCountDistinct(r.plan, req) {
+		return r.runDenseGroupCountDistinct(view, req)
 	}
 
 	start := time.Now()
@@ -1363,6 +1483,14 @@ func columnTypedColumnPhysicalQueryShapeCanUseDenseGroupCount(req ColumnPhysical
 
 func columnTypedColumnPhysicalQueryUseDenseGroupCount(plan columnTypedColumnPhysicalQueryPlan, req ColumnPhysicalQueryRequest) bool {
 	return !plan.NullableStringValues && plan.DenseGroupCount && columnTypedColumnPhysicalQueryShapeCanUseDenseGroupCount(req)
+}
+
+func columnTypedColumnPhysicalQueryShapeCanUseDenseGroupCountDistinct(req ColumnPhysicalQueryRequest) bool {
+	return req.Kind == ColumnPhysicalQueryGroupCountAndDistinct && req.GroupColumn != "" && req.DistinctColumn != "" && req.GroupColumn != req.DistinctColumn && req.AggregateMetadataName == "" && req.ValueColumn == "" && req.TopK == 0 && req.TopKOrder == ""
+}
+
+func columnTypedColumnPhysicalQueryUseDenseGroupCountDistinct(plan columnTypedColumnPhysicalQueryPlan, req ColumnPhysicalQueryRequest) bool {
+	return plan.DenseGroupCountDistinct && columnTypedColumnPhysicalQueryShapeCanUseDenseGroupCountDistinct(req)
 }
 
 func columnTypedColumnPhysicalQueryShapeCanUseDenseGroupHourCount(req ColumnPhysicalQueryRequest) bool {
@@ -1861,6 +1989,127 @@ func (r *columnTypedColumnPhysicalQueryRunner) runDenseGroupCount(view columnPhy
 	sortColumnPhysicalQueryGroupsByKey(r.resultGroups)
 	diag := r.diagnostics(view, req, rowsScanned, 0, rowsScanned, time.Since(start).Nanoseconds())
 	diag.DenseGroupCountUsed = true
+	diag.ResultGroups = len(r.resultGroups)
+	result := ColumnPhysicalQueryResult{Groups: r.resultGroups, Diagnostics: diag}
+	finalizeColumnPhysicalQueryResultGroups(req, &result)
+	r.resultGroups = result.Groups
+	return result, nil
+}
+
+func (r *columnTypedColumnPhysicalQueryRunner) runDenseGroupCountDistinct(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest) (ColumnPhysicalQueryResult, error) {
+	start := time.Now()
+	groupCardinality := 0
+	haveGroupCardinality := false
+	for partIdx := range r.parts {
+		dense := r.parts[partIdx].DenseGroupCountDistinct
+		if dense == nil {
+			diag := r.diagnostics(view, req, 0, 0, 0, time.Since(start).Nanoseconds())
+			diag.DenseGroupCountDistinctUsed = true
+			return ColumnPhysicalQueryResult{Diagnostics: diag}, fmt.Errorf("collections: dense typed-column grouped count-distinct missing prepared part %d", partIdx)
+		}
+		if !haveGroupCardinality {
+			groupCardinality = len(dense.Group.GlobalDictionary)
+			haveGroupCardinality = true
+		} else if len(dense.Group.GlobalDictionary) != groupCardinality {
+			diag := r.diagnostics(view, req, 0, 0, 0, time.Since(start).Nanoseconds())
+			diag.DenseGroupCountDistinctUsed = true
+			return ColumnPhysicalQueryResult{Diagnostics: diag}, fmt.Errorf("collections: dense typed-column grouped count-distinct part %d group global cardinality=%d want %d", partIdx, len(dense.Group.GlobalDictionary), groupCardinality)
+		}
+	}
+	if cap(r.denseGroupCountDistinctCounts) < groupCardinality {
+		r.denseGroupCountDistinctCounts = make([]int, groupCardinality)
+	} else {
+		r.denseGroupCountDistinctCounts = r.denseGroupCountDistinctCounts[:groupCardinality]
+		clear(r.denseGroupCountDistinctCounts)
+	}
+	if cap(r.denseGroupCountDistinctDistinctCounts) < groupCardinality {
+		r.denseGroupCountDistinctDistinctCounts = make([]int, groupCardinality)
+	} else {
+		r.denseGroupCountDistinctDistinctCounts = r.denseGroupCountDistinctDistinctCounts[:groupCardinality]
+		clear(r.denseGroupCountDistinctDistinctCounts)
+	}
+	if r.denseGroupCountDistinctPairs == nil {
+		r.denseGroupCountDistinctPairs = make(map[uint64]struct{}, groupCardinality)
+	} else {
+		clear(r.denseGroupCountDistinctPairs)
+	}
+
+	rowsScanned := 0
+	matchedRows := 0
+	reduceRows := 0
+	var groupDictionary []string
+	for partIdx := range r.parts {
+		dense := r.parts[partIdx].DenseGroupCountDistinct
+		if dense == nil {
+			diag := r.diagnostics(view, req, rowsScanned, matchedRows, reduceRows, time.Since(start).Nanoseconds())
+			diag.DenseGroupCountDistinctUsed = true
+			return ColumnPhysicalQueryResult{Diagnostics: diag}, fmt.Errorf("collections: dense typed-column grouped count-distinct missing prepared part %d", partIdx)
+		}
+		if groupDictionary == nil {
+			groupDictionary = dense.Group.GlobalDictionary
+		}
+		if dense.Rows != len(dense.Group.GlobalCodes) || dense.Rows != len(dense.Distinct.GlobalCodes) || dense.Rows != len(dense.Group.Codes) || dense.Rows != len(dense.Distinct.Codes) {
+			diag := r.diagnostics(view, req, rowsScanned, matchedRows, reduceRows, time.Since(start).Nanoseconds())
+			diag.DenseGroupCountDistinctUsed = true
+			return ColumnPhysicalQueryResult{Diagnostics: diag}, fmt.Errorf("collections: dense typed-column grouped count-distinct part %d rows=%d group_codes=%d distinct_codes=%d group_local=%d distinct_local=%d", partIdx, dense.Rows, len(dense.Group.GlobalCodes), len(dense.Distinct.GlobalCodes), len(dense.Group.Codes), len(dense.Distinct.Codes))
+		}
+		if len(dense.Group.GlobalDictionary) != groupCardinality {
+			diag := r.diagnostics(view, req, rowsScanned, matchedRows, reduceRows, time.Since(start).Nanoseconds())
+			diag.DenseGroupCountDistinctUsed = true
+			return ColumnPhysicalQueryResult{Diagnostics: diag}, fmt.Errorf("collections: dense typed-column grouped count-distinct part %d group global cardinality=%d want %d", partIdx, len(dense.Group.GlobalDictionary), groupCardinality)
+		}
+		if columnTypedColumnDensePredicatesRejectAll(dense.Predicates) {
+			rowsScanned += dense.Rows
+			continue
+		}
+		for rowIdx := 0; rowIdx < dense.Rows; rowIdx++ {
+			rowsScanned++
+			if !columnTypedColumnDensePredicatesMatch(dense.Predicates, rowIdx) {
+				continue
+			}
+			if len(dense.Predicates) != 0 {
+				matchedRows++
+			}
+			reduceRows++
+			groupCode := dense.Group.GlobalCodes[rowIdx]
+			distinctCode := dense.Distinct.GlobalCodes[rowIdx]
+			groupIdx, ok := columnDictionaryCodeIndex(groupCode, len(r.denseGroupCountDistinctCounts))
+			if !ok {
+				diag := r.diagnostics(view, req, rowsScanned, matchedRows, reduceRows, time.Since(start).Nanoseconds())
+				diag.DenseGroupCountDistinctUsed = true
+				return ColumnPhysicalQueryResult{Diagnostics: diag}, fmt.Errorf("collections: dense typed-column grouped count-distinct part %d group code[%d]=%d outside cardinality=%d", partIdx, rowIdx, groupCode, len(r.denseGroupCountDistinctCounts))
+			}
+			r.denseGroupCountDistinctCounts[groupIdx]++
+			pair := uint64(groupCode)<<32 | uint64(distinctCode)
+			r.denseGroupCountDistinctPairs[pair] = struct{}{}
+		}
+	}
+	for pair := range r.denseGroupCountDistinctPairs {
+		groupCode := uint32(pair >> 32)
+		groupIdx, ok := columnDictionaryCodeIndex(groupCode, len(r.denseGroupCountDistinctDistinctCounts))
+		if !ok {
+			diag := r.diagnostics(view, req, rowsScanned, matchedRows, reduceRows, time.Since(start).Nanoseconds())
+			diag.DenseGroupCountDistinctUsed = true
+			return ColumnPhysicalQueryResult{Diagnostics: diag}, fmt.Errorf("collections: dense typed-column grouped count-distinct pair group code=%d outside cardinality=%d", groupCode, len(r.denseGroupCountDistinctDistinctCounts))
+		}
+		r.denseGroupCountDistinctDistinctCounts[groupIdx]++
+	}
+	r.resultGroups = r.resultGroups[:0]
+	for groupIdx, count := range r.denseGroupCountDistinctCounts {
+		distinct := r.denseGroupCountDistinctDistinctCounts[groupIdx]
+		if count == 0 && distinct == 0 {
+			continue
+		}
+		if groupIdx >= len(groupDictionary) {
+			diag := r.diagnostics(view, req, rowsScanned, matchedRows, reduceRows, time.Since(start).Nanoseconds())
+			diag.DenseGroupCountDistinctUsed = true
+			return ColumnPhysicalQueryResult{Diagnostics: diag}, fmt.Errorf("collections: dense typed-column grouped count-distinct group index=%d outside dictionary=%d", groupIdx, len(groupDictionary))
+		}
+		r.resultGroups = append(r.resultGroups, ColumnPhysicalQueryGroup{Key: groupDictionary[groupIdx], Count: count, DistinctCount: distinct})
+	}
+	sortColumnPhysicalQueryGroupsByKey(r.resultGroups)
+	diag := r.diagnostics(view, req, rowsScanned, matchedRows, reduceRows, time.Since(start).Nanoseconds())
+	diag.DenseGroupCountDistinctUsed = true
 	diag.ResultGroups = len(r.resultGroups)
 	result := ColumnPhysicalQueryResult{Groups: r.resultGroups, Diagnostics: diag}
 	finalizeColumnPhysicalQueryResultGroups(req, &result)

--- a/TreeDB/collections/typed_column_adapter.go
+++ b/TreeDB/collections/typed_column_adapter.go
@@ -2139,6 +2139,102 @@ func decodeTypedColumnPhysicalQueryDenseInt64SpanPart(plan columnTypedColumnPhys
 	}, nil
 }
 
+// decodeTypedColumnPhysicalQueryDenseGroupCountDistinctPart prepares the q2
+// typed-column section fast path. It decodes dictionary codes for the group,
+// distinct, and predicate columns once, then the runner reduces by integer code.
+func decodeTypedColumnPhysicalQueryDenseGroupCountDistinctPart(plan columnTypedColumnPhysicalQueryPlan, schemaHash uint64, typedRef, physical columnManifestAssetRefForScan, raw []byte) (columnTypedColumnPhysicalQueryPart, error) {
+	image, err := typedcolumn.ParseColumnPartImage(raw)
+	if err != nil {
+		return columnTypedColumnPhysicalQueryPart{}, err
+	}
+	adapterPart, err := typedColumnAdapterPartFromImageWithoutRowLocators(typedColumnAdapterOptions{Fields: plan.Fields, SchemaVersion: uint32(schemaHash)}, image)
+	if err != nil {
+		return columnTypedColumnPhysicalQueryPart{}, err
+	}
+	summary := typedColumnAdapterImageSummary{PartID: image.PartID, Rows: image.Rows, Sections: len(image.Sections), SectionBytes: typedColumnPhysicalQueryImageSectionBytes(image), SortKey: columnSortKeysFromTypedColumnSortKeys(adapterPart.Part.Descriptor.SortKey)}
+	if summary.PartID != typedRef.Ref.PartID || summary.Rows != typedRef.Rows {
+		return columnTypedColumnPhysicalQueryPart{}, fmt.Errorf("typed_column_part image/ref mismatch image_part=%d ref_part=%d image_rows=%d manifest_rows=%d", summary.PartID, typedRef.Ref.PartID, summary.Rows, typedRef.Rows)
+	}
+	if physical.Rows != 0 && summary.Rows != physical.Rows {
+		return columnTypedColumnPhysicalQueryPart{}, fmt.Errorf("typed_column_part rows=%d do not match physical rows=%d", summary.Rows, physical.Rows)
+	}
+	if err := validateTypedColumnPhysicalQuerySortMetadata(plan.SortKey, typedRef.SortKey, summary.SortKey); err != nil {
+		return columnTypedColumnPhysicalQueryPart{}, err
+	}
+
+	group, groupDecodedBytes, groupBlocks, err := typedColumnDenseGroupCountDistinctCodeColumn(adapterPart, plan.Fields, plan.GroupColumn, summary.Rows, "grouped count-distinct group")
+	if err != nil {
+		return columnTypedColumnPhysicalQueryPart{}, err
+	}
+	distinct, distinctDecodedBytes, distinctBlocks, err := typedColumnDenseGroupCountDistinctCodeColumn(adapterPart, plan.Fields, plan.DistinctColumn, summary.Rows, "grouped count-distinct distinct")
+	if err != nil {
+		return columnTypedColumnPhysicalQueryPart{}, err
+	}
+	if len(group.Codes) != len(distinct.Codes) {
+		return columnTypedColumnPhysicalQueryPart{}, fmt.Errorf("collections: dense typed-column grouped count-distinct group/distinct rows=%d/%d", len(group.Codes), len(distinct.Codes))
+	}
+
+	predicates := make([]columnTypedColumnDensePredicatePart, 0, len(plan.PredicateSpecs))
+	predicateDecodedBytes := uint64(0)
+	predicateBlocks := 0
+	for _, spec := range plan.PredicateSpecs {
+		predicate, decodedBytes, blocks, err := decodeTypedColumnDensePredicatePart(adapterPart, plan.Fields, spec, summary.Rows)
+		if err != nil {
+			return columnTypedColumnPhysicalQueryPart{}, err
+		}
+		predicates = append(predicates, predicate)
+		predicateDecodedBytes += decodedBytes
+		predicateBlocks += blocks
+	}
+
+	decodedBlocks := groupBlocks + distinctBlocks + predicateBlocks
+	return columnTypedColumnPhysicalQueryPart{
+		Ref:                 typedRef,
+		PhysicalRef:         physical,
+		Rows:                summary.Rows,
+		Bytes:               int64(len(raw)),
+		Sections:            summary.Sections,
+		SectionBytes:        summary.SectionBytes,
+		GranulesConsidered:  decodedBlocks,
+		GranulesDecoded:     decodedBlocks,
+		DecodedBlocks:       decodedBlocks,
+		DecodedPayloadBytes: groupDecodedBytes + distinctDecodedBytes + predicateDecodedBytes,
+		DenseGroupCountDistinct: &columnTypedColumnDenseGroupCountDistinctPart{
+			Rows:       summary.Rows,
+			Group:      group,
+			Distinct:   distinct,
+			Predicates: predicates,
+		},
+	}, nil
+}
+
+func typedColumnDenseGroupCountDistinctCodeColumn(adapterPart *typedColumnAdapterPart, fields []TypedStorageField, column string, rows int, role string) (columnTypedColumnDenseStringCodeColumn, uint64, int, error) {
+	adapterColumn, partColumn, cardinality, err := typedColumnDenseStringCodeColumn(adapterPart, fields, column, role)
+	if err != nil {
+		return columnTypedColumnDenseStringCodeColumn{}, 0, 0, err
+	}
+	dictionary := make([]string, cardinality)
+	for code := 0; code < cardinality; code++ {
+		value, ok := adapterColumn.ReverseDictionary[int64(code)]
+		if !ok {
+			return columnTypedColumnDenseStringCodeColumn{}, 0, 0, fmt.Errorf("collections: dense typed-column %s dictionary missing local code %d for column %q", role, code, adapterColumn.Definition.Name)
+		}
+		dictionary[code] = value
+	}
+	if adapterColumn.Field.Nullable {
+		codes, valid, decodedBytes, blocks, err := decodeTypedColumnDenseNullableUint32Codes(partColumn, cardinality, rows, role)
+		if err != nil {
+			return columnTypedColumnDenseStringCodeColumn{}, 0, 0, err
+		}
+		return columnTypedColumnDenseStringCodeColumn{Codes: codes, Valid: valid, Dictionary: dictionary}, decodedBytes, blocks, nil
+	}
+	codes, decodedBytes, blocks, err := decodeTypedColumnDenseUint32Codes(partColumn, cardinality, rows, role)
+	if err != nil {
+		return columnTypedColumnDenseStringCodeColumn{}, 0, 0, err
+	}
+	return columnTypedColumnDenseStringCodeColumn{Codes: codes, Dictionary: dictionary}, decodedBytes, blocks, nil
+}
+
 func typedColumnDenseStringCodeColumn(adapterPart *typedColumnAdapterPart, fields []TypedStorageField, column, role string) (typedColumnAdapterColumn, typedcolumn.ColumnPartColumn, int, error) {
 	adapterColumn, ok, err := typedColumnStringPredicateAdapterColumn(fields, column)
 	if err != nil {


### PR DESCRIPTION
## Objective

Add a dense typed-column reducer for JSONBench q2's fused `ColumnPhysicalQueryGroupCountAndDistinct` shape so the production full-data layout can avoid per-row string extraction and string-map aggregation.

Fixes #2895.

## Context

#2894 reduced JSONBench q2 from two physical queries to one fused query, but the 1M `column-store-full-prepared` run still spent most time in typed-column string value extraction, predicate matching, string hashing, and `mapassign_faststr`. The full-data layout is sorted by `time_us` and uses nullable string columns, so the existing sorted grouped-distinct q2 path is not valid there.

## Non-goals

- No full-data sort-key change.
- No storage-format change.
- No approximate distinct.
- No q1/q3/q4/q5 behavior change beyond shared diagnostic merge support.
- No JSONBench harness change in this PR.

## Design

- Adds `DenseGroupCountDistinctUsed` diagnostics.
- Adds a typed-column q2 decode path that reads dictionary codes for group, distinct, and predicate columns, including nullable string columns.
- Normalizes local dictionaries to shared per-run global ranks, preserving empty-string semantics for null/missing values.
- Reduces q2 by integer group code and packed `(groupCode, distinctCode)` pairs, materializing strings only for final result groups.
- Keeps sorted grouped-distinct ahead of the dense q2 path so the existing sorted-prefix optimization still wins when valid.

## Scope

Includes:
- `ColumnPhysicalQueryDiagnostics`
- typed-column physical query plan/decode/run paths
- dense q2 adapter decode helpers
- q2 dense no-sort/local-dictionary tests
- nullable full-data q2 tests

Excludes:
- JSONBench command changes; those stay in #2894.
- mutation latest-visible q2 dense serving.
- any sort-key or on-disk format changes.

## Correctness

Tests run:
- `go test ./TreeDB/collections -run 'TestTypedColumnQ2|TestColumnPhysicalJSONBenchTypedColumnPartNullableFullData|TestColumnPhysicalJSONBenchTypedColumnPartDirectPreparedReopen1947' -count=1`
- `go test ./TreeDB/collections -count=1`

Covered edge cases:
- nullable full-data q2 where null/missing strings map to empty-string semantics.
- no-sort q2 over multiple typed-column parts with differing local dictionary codes.
- prepared runner reuse with global code ranks.
- empty group and empty distinct values.
- sorted q2 path remains selected before dense q2 when the q2 sort prefix is valid.

## Performance

Local benchmark command:
- `go test ./TreeDB/collections -run '^$' -bench 'BenchmarkTypedColumnQ2SortedGroupedDistinct1950/(direct|prepared)/(primary_id_fallback|sorted_prefix)$' -benchtime=3x -count=1`

Apple M3 results:

| case | ns/op | allocs/op | notes |
| --- | ---: | ---: | --- |
| direct/sorted_prefix | 14,588,403 | 9,079 | existing sorted q2 path still selected |
| prepared/sorted_prefix | 873,361 | 3 | existing sorted q2 path still selected |
| direct/primary_id_fallback | 18,738,917 | 8,875 | now dense q2, includes decode |
| prepared/primary_id_fallback | 1,821,625 | 28 | now dense q2, avoids row string maps |

Remote JSONBench q2 evidence will be added after the #2894 harness is rerun against this gomap head.

## Rollout / Toggle Plan

Default setting: automatic for typed-column `GroupCountAndDistinct` q2 shapes when sorted grouped-distinct is not selected.

Disable quickly: revert this PR; no format or config migration is involved.

## Follow-ups

- #2894: consume this gomap head in JSONBench, expose the q2 dense diagnostic, and rerun q2/q1/q3 guard evidence.
- #2891: record q2 current-head evidence and decide whether additional q2 work is warranted after remote timing.

## Optimization PR Checklist (TreeDB)

### Scope
- [x] Single, clear objective for this PR.
- [x] Explicit include list above.
- [x] Explicit exclude list above.
- [x] No unwanted feature reintroduction.

### Safety / Correctness
- [x] No written-vs-durable semantics changed.
- [x] No new mmap usage.
- [x] No new on-disk length fields.
- [x] Decode validation remains fail-closed with explicit errors.
- [x] No concurrency change.

### Tests
- [x] Added deterministic regression tests for q2 dense no-sort and nullable full-data semantics.
- [x] Tests avoid sleeps.
- [x] Format/parsing corruption cases not applicable; no format change.
- [ ] `go test ./... -count=1`
- [x] Targeted package tests and benchmark listed above.

### Benchmarks / Measurements
- [x] Ran relevant q2 benchmark.
- [x] Reported current results.
- [x] Compression worst-case not applicable.

### Docs
- [x] No docs required; no config or format change.

### Rollout / Toggle Plan
- [x] Conservative automatic path selection; sorted q2 remains preferred.
- [x] Revert-only rollback, no migration.
- [x] Diagnostic flag added for observability.
