### PR TITLE
TreeDB M2: allow checkpoint span-native point drains

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -24954,7 +24954,7 @@ func (db *DB) flushLaneOnceWithCollectionMode(sync bool, laneID int, commandPubl
 	if totalLen == 0 && totalSpans > 0 {
 		buildStart := time.Now()
 		backendBatch := db.newBackendBatchWithSize(totalSpans)
-		setBackendBatchSpanNativeFallback(backendBatch, flushSpanNativeFallbackReasonForCollectionMode(mode))
+		setBackendBatchSpanNativeFallback(backendBatch, flushRangeOnlySpanNativeFallbackReasonForCollectionMode(mode))
 		reserveBackendBatchOps(backendBatch, totalSpans)
 		pending := 0
 		for _, unit := range units {

--- a/TreeDB/caching/db_test.go
+++ b/TreeDB/caching/db_test.go
@@ -28,26 +28,27 @@ const retainedPruneNegativeAssertWait = 150 * time.Millisecond
 
 // MockBackend implements BackendDB
 type MockBackend struct {
-	mu                     sync.RWMutex
-	data                   map[string][]byte
-	lastOps                []batch.Entry
-	writeCalls             int
-	writeSyncs             int
-	iteratorCalls          int
-	iteratorStartedCh      chan struct{}
-	iteratorBlockCh        chan struct{}
-	writeErr               error
-	setOpsErr              error
-	setErr                 error
-	deleteErr              error
-	registerValueLogErr    error
-	markValueLogZombieErr  error
-	markValueLogZombieID   uint32
-	pointerEntries         map[string]page.ValuePtr
-	setOpsInlineValueLimit int
-	fragReport             map[string]string
-	fragErr                error
-	vacuumErr              error
+	mu                           sync.RWMutex
+	data                         map[string][]byte
+	lastOps                      []batch.Entry
+	writeCalls                   int
+	writeSyncs                   int
+	iteratorCalls                int
+	iteratorStartedCh            chan struct{}
+	iteratorBlockCh              chan struct{}
+	writeErr                     error
+	setOpsErr                    error
+	setErr                       error
+	deleteErr                    error
+	registerValueLogErr          error
+	markValueLogZombieErr        error
+	markValueLogZombieID         uint32
+	pointerEntries               map[string]page.ValuePtr
+	setOpsInlineValueLimit       int
+	lastSpanNativeFallbackReason db.FlushSpanRunFallbackReason
+	fragReport                   map[string]string
+	fragErr                      error
+	vacuumErr                    error
 }
 
 func NewMockBackend() *MockBackend {
@@ -764,6 +765,12 @@ func (b *MockBatch) WriteSync() error {
 	b.mb.writeSyncs++
 	b.mb.mu.Unlock()
 	return nil
+}
+
+func (b *MockBatch) SetFlushApplySpanNativeFallback(reason db.FlushSpanRunFallbackReason) {
+	b.mb.mu.Lock()
+	b.mb.lastSpanNativeFallbackReason = reason
+	b.mb.mu.Unlock()
 }
 
 func (b *MockBatch) Close() error              { return nil }

--- a/TreeDB/caching/db_test.go
+++ b/TreeDB/caching/db_test.go
@@ -773,6 +773,8 @@ func (b *MockBatch) SetFlushApplySpanNativeFallback(reason db.FlushSpanRunFallba
 	b.mb.mu.Unlock()
 }
 
+func (b *MockBatch) SetCommandWALPublish(uint64, []db.CommandWALLSNRange) error { return nil }
+
 func (b *MockBatch) Close() error              { return nil }
 func (b *MockBatch) GetByteSize() (int, error) { return 0, nil }
 

--- a/TreeDB/caching/flush_backlog_coalescing.go
+++ b/TreeDB/caching/flush_backlog_coalescing.go
@@ -90,11 +90,24 @@ type backendBatchSpanNativeFallbackSetter interface {
 
 func flushSpanNativeFallbackReasonForCollectionMode(mode flushCollectionMode) backenddb.FlushSpanRunFallbackReason {
 	switch mode {
-	case flushCollectionCheckpoint, flushCollectionClose:
+	case flushCollectionClose:
+		// Keep close conservative: Close may be running after background workers are
+		// quiescing and must not start new optimistic span-native durable output
+		// unless that path is separately scoped and proven. Checkpoint point drains
+		// are allowed to use span-native apply so long as the ordinary eligibility
+		// checks below still pass; unsafe range/command/lane/root/output cases keep
+		// their fail-closed fallback reasons.
 		return backenddb.FlushSpanRunFallbackCloseOrCheckpoint
 	default:
 		return backenddb.FlushSpanRunFallbackUnknown
 	}
+}
+
+func flushRangeOnlySpanNativeFallbackReasonForCollectionMode(mode flushCollectionMode) backenddb.FlushSpanRunFallbackReason {
+	if mode == flushCollectionClose {
+		return backenddb.FlushSpanRunFallbackCloseOrCheckpoint
+	}
+	return backenddb.FlushSpanRunFallbackRangeDeleteBarrier
 }
 
 func setBackendBatchSpanNativeFallback(backendBatch batch.Interface, reason backenddb.FlushSpanRunFallbackReason) {

--- a/TreeDB/caching/flush_backlog_coalescing.go
+++ b/TreeDB/caching/flush_backlog_coalescing.go
@@ -110,6 +110,13 @@ func flushRangeOnlySpanNativeFallbackReasonForCollectionMode(mode flushCollectio
 	return backenddb.FlushSpanRunFallbackRangeDeleteBarrier
 }
 
+func flushPointRunSpanNativeFallbackReasonForCollectionMode(mode flushCollectionMode, commandPublish *checkpointCommandWALPublish) backenddb.FlushSpanRunFallbackReason {
+	if commandPublish != nil && commandPublish.appliedLSN != 0 && !commandPublish.consumed {
+		return backenddb.FlushSpanRunFallbackCommandWALBarrier
+	}
+	return flushSpanNativeFallbackReasonForCollectionMode(mode)
+}
+
 func setBackendBatchSpanNativeFallback(backendBatch batch.Interface, reason backenddb.FlushSpanRunFallbackReason) {
 	if backendBatch == nil || !reason.Valid() || reason == backenddb.FlushSpanRunFallbackUnknown {
 		return

--- a/TreeDB/caching/flush_backlog_coalescing_test.go
+++ b/TreeDB/caching/flush_backlog_coalescing_test.go
@@ -365,6 +365,32 @@ func TestFlushCollectionModeSpanNativeFallbackOnlyForClose(t *testing.T) {
 	}
 }
 
+func TestFlushCollectionModeCheckpointCommandWALPublishForcesFallback(t *testing.T) {
+	db, backend := newCoalescingTestDB(t, Options{
+		FlushApplySpanNative:  true,
+		FlushApplyConcurrency: 4,
+		FlushApplyMinEntries:  1,
+		FlushApplyMinSpans:    1,
+		FlushApplyMinBytes:    1,
+	}, highSingleOpCoalescingSnapshot())
+	enqueuePointMemtables(t, db, 1, "commandwal")
+	db.checkpointing.Store(true)
+	publish := &checkpointCommandWALPublish{appliedLSN: 7, ranges: []backenddb.CommandWALLSNRange{{First: 1, Last: 7}}}
+	if !db.flushLaneOnceWithCollectionMode(false, 0, publish, flushCollectionBackground) {
+		t.Fatalf("flushLaneOnceWithCollectionMode returned false")
+	}
+	db.checkpointing.Store(false)
+	if !publish.consumed {
+		t.Fatalf("command WAL publish was not consumed")
+	}
+	backend.mu.RLock()
+	got := backend.lastSpanNativeFallbackReason
+	backend.mu.RUnlock()
+	if got != backenddb.FlushSpanRunFallbackCommandWALBarrier {
+		t.Fatalf("command WAL checkpoint fallback reason=%s want %s", got, backenddb.FlushSpanRunFallbackCommandWALBarrier)
+	}
+}
+
 func TestFlushCollectionModeRangeOnlyCheckpointFallbackReason(t *testing.T) {
 	db, backend := newCoalescingTestDB(t, Options{
 		DisableWAL:                 true,

--- a/TreeDB/caching/flush_backlog_coalescing_test.go
+++ b/TreeDB/caching/flush_backlog_coalescing_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/snissn/gomap/TreeDB/batch"
 	backenddb "github.com/snissn/gomap/TreeDB/db"
 )
 
@@ -327,6 +328,72 @@ func TestFlushBacklogCoalescingDrainModesBypassAdaptiveAdmission(t *testing.T) {
 				t.Fatalf("source_memtables_max=%d want base flush of 1", got)
 			}
 		})
+	}
+}
+
+func TestFlushCollectionModeSpanNativeFallbackOnlyForClose(t *testing.T) {
+	cases := []struct {
+		name string
+		mode flushCollectionMode
+		mark func(*DB)
+		want backenddb.FlushSpanRunFallbackReason
+	}{
+		{name: "checkpoint", mode: flushCollectionBackground, mark: func(db *DB) { db.checkpointing.Store(true) }, want: backenddb.FlushSpanRunFallbackUnknown},
+		{name: "close", mode: flushCollectionBackground, mark: func(db *DB) { db.closing.Store(true) }, want: backenddb.FlushSpanRunFallbackCloseOrCheckpoint},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			db, backend := newCoalescingTestDB(t, Options{
+				FlushBacklogCoalescing: true,
+			}, highSingleOpCoalescingSnapshot())
+			enqueuePointMemtables(t, db, 1, "fallback"+tc.name)
+			if tc.mark != nil {
+				tc.mark(db)
+			}
+			if !db.flushLaneOnceWithCollectionMode(false, 0, nil, tc.mode) {
+				t.Fatalf("flushLaneOnceWithCollectionMode returned false")
+			}
+			db.checkpointing.Store(false)
+			db.closing.Store(false)
+			backend.mu.RLock()
+			got := backend.lastSpanNativeFallbackReason
+			backend.mu.RUnlock()
+			if got != tc.want {
+				t.Fatalf("fallback reason=%s want %s", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFlushCollectionModeRangeOnlyCheckpointFallbackReason(t *testing.T) {
+	db, backend := newCoalescingTestDB(t, Options{
+		DisableWAL:                 true,
+		AllowUnsafe:                true,
+		FlushBacklogCoalescing:     true,
+		FlushApplySpanNative:       true,
+		FlushApplyConcurrency:      4,
+		FlushApplyMinEntries:       1,
+		FlushApplyMinSpans:         1,
+		FlushApplyMinBytes:         1,
+		FlushSpanRunTargetPlanning: true,
+	}, highSingleOpCoalescingSnapshot())
+	db.mu.Lock()
+	if err := db.enqueueRangeSpanLayerLocked([]batch.DeleteRange{{Start: []byte("point-a"), End: []byte("point-z")}}); err != nil {
+		db.mu.Unlock()
+		t.Fatalf("enqueueRangeSpanLayerLocked: %v", err)
+	}
+	db.publishMemtablesLocked()
+	db.mu.Unlock()
+	db.checkpointing.Store(true)
+	if !db.flushLaneOnceWithCollectionMode(false, 0, nil, flushCollectionBackground) {
+		t.Fatalf("flushLaneOnceWithCollectionMode returned false")
+	}
+	db.checkpointing.Store(false)
+	backend.mu.RLock()
+	got := backend.lastSpanNativeFallbackReason
+	backend.mu.RUnlock()
+	if got != backenddb.FlushSpanRunFallbackRangeDeleteBarrier {
+		t.Fatalf("range-only checkpoint fallback reason=%s want %s", got, backenddb.FlushSpanRunFallbackRangeDeleteBarrier)
 	}
 }
 

--- a/TreeDB/caching/flush_run_planner.go
+++ b/TreeDB/caching/flush_run_planner.go
@@ -794,7 +794,7 @@ func (db *DB) writeCanonicalFlushRunChunks(run *canonicalFlushRun, chunks []back
 
 func (db *DB) flushCanonicalPointUnitsStreamed(syncFlush bool, laneID int, commandPublish *checkpointCommandWALPublish, units []flushUnit, ids []uint64, totalBytes int64, totalLen int, totalSpans int, mode flushCollectionMode) bool {
 	flushStart := time.Now()
-	spanNativeFallbackReason := flushSpanNativeFallbackReasonForCollectionMode(mode)
+	spanNativeFallbackReason := flushPointRunSpanNativeFallbackReasonForCollectionMode(mode, commandPublish)
 	buildStart := flushStart
 	build, err := db.buildCanonicalUnitRuns(units, totalLen, totalSpans)
 	if err != nil {
@@ -990,7 +990,7 @@ func (db *DB) flushCanonicalPointUnits(syncFlush bool, laneID int, commandPublis
 		return db.flushCanonicalPointUnitsStreamed(syncFlush, laneID, commandPublish, units, ids, totalBytes, totalLen, totalSpans, mode)
 	}
 	flushStart := time.Now()
-	spanNativeFallbackReason := flushSpanNativeFallbackReasonForCollectionMode(mode)
+	spanNativeFallbackReason := flushPointRunSpanNativeFallbackReasonForCollectionMode(mode, commandPublish)
 	buildStart := flushStart
 	run, err := db.buildCanonicalFlushRun(units, totalLen, totalSpans)
 	if err != nil {

--- a/TreeDB/span_native_hardening_test.go
+++ b/TreeDB/span_native_hardening_test.go
@@ -24,7 +24,7 @@ func requirePublicStatUint64(t *testing.T, db *treedb.DB, key string) uint64 {
 	return v
 }
 
-func TestSpanNativeCheckpointDrainFallbackReopenRewriteAndGC(t *testing.T) {
+func TestSpanNativeCheckpointDrainUsesSpanNativeReopenRewriteAndGC(t *testing.T) {
 	dir := t.TempDir()
 	opts := treedb.Options{
 		Dir:                   dir,
@@ -55,11 +55,31 @@ func TestSpanNativeCheckpointDrainFallbackReopenRewriteAndGC(t *testing.T) {
 	}
 	if err := db.Checkpoint(); err != nil {
 		_ = db.Close()
-		t.Fatalf("checkpoint: %v", err)
+		t.Fatalf("checkpoint base: %v", err)
 	}
-	if got := requirePublicStatUint64(t, db, "treedb.flush_apply.span_native.fallback.reason.close_or_checkpoint.ops_total"); got == 0 {
+	usedBefore := requirePublicStatUint64(t, db, "treedb.flush_apply.span_native.used_ops_total")
+	closeFallbackBefore := requirePublicStatUint64(t, db, "treedb.flush_apply.span_native.fallback.reason.close_or_checkpoint.ops_total")
+	for i := 0; i < 96; i++ {
+		key := fmt.Sprintf("key-%04d", i)
+		value := bytes.Repeat([]byte{byte(251 - i%251)}, 2048)
+		values[key] = value
+		if err := db.Set([]byte(key), value); err != nil {
+			_ = db.Close()
+			t.Fatalf("update %s: %v", key, err)
+		}
+	}
+	if err := db.Checkpoint(); err != nil {
 		_ = db.Close()
-		t.Fatalf("close_or_checkpoint fallback ops=0 want checkpoint drain to force serial-safe fallback")
+		t.Fatalf("checkpoint update: %v", err)
+	}
+	usedAfter := requirePublicStatUint64(t, db, "treedb.flush_apply.span_native.used_ops_total")
+	if usedAfter <= usedBefore {
+		_ = db.Close()
+		t.Fatalf("span-native used ops did not increase across checkpoint point drain: before=%d after=%d", usedBefore, usedAfter)
+	}
+	if got := requirePublicStatUint64(t, db, "treedb.flush_apply.span_native.fallback.reason.close_or_checkpoint.ops_total"); got != closeFallbackBefore {
+		_ = db.Close()
+		t.Fatalf("close_or_checkpoint fallback ops changed during checkpoint point drain: before=%d after=%d", closeFallbackBefore, got)
 	}
 	if err := db.Close(); err != nil {
 		t.Fatalf("close: %v", err)


### PR DESCRIPTION
## Summary

- allow checkpoint-owned point-write drains to use span-native apply by no longer forcing `close_or_checkpoint` fallback for checkpoint collection mode
- keep close drains conservative with the existing `close_or_checkpoint` forced fallback
- keep unsafe range-only drains explicitly serialized/accounted as `range_delete_barrier`
- update checkpoint/reopen/rewrite/GC hardening coverage to prove checkpoint point drains increase span-native used ops without increasing close/checkpoint fallback

Fixes #2902. Parent: #2899.

## Gate status

M2 exit gate: **pass for intended path unlock**.

- Eligible checkpoint point drains no longer force `close_or_checkpoint`.
- Close remains conservative.
- Range-only checkpoint drains remain fail-closed/accounted as `range_delete_barrier`.
- Checkpoint still does not prove final saturation; remaining limiter is routed to M3/M4/M5 as planned.

## Tests

```sh
GOWORK=off go test ./TreeDB/caching -run 'TestFlushCollectionModeSpanNativeFallbackOnlyForClose|TestFlushCollectionModeRangeOnlyCheckpointFallbackReason|TestFlushBacklogCoalescingDrainModesBypassAdaptiveAdmission' -count=1
GOWORK=off go test ./TreeDB -run TestSpanNativeCheckpointDrainUsesSpanNativeReopenRewriteAndGC -count=1
GOWORK=off go test ./TreeDB ./TreeDB/caching ./TreeDB/db -run 'SpanNative|Checkpoint|FlushBacklogCoalescing|FlushApply|DeleteRange' -count=1
GOWORK=off go test -race ./TreeDB/caching -run 'TestFlushCollectionModeSpanNativeFallbackOnlyForClose|TestFlushCollectionModeRangeOnlyCheckpointFallbackReason' -count=1
GOWORK=off go test -race ./TreeDB -run TestSpanNativeCheckpointDrainUsesSpanNativeReopenRewriteAndGC -count=1
GOWORK=off go test ./TreeDB/...
```

All passed locally.

## Benchmark / profile evidence

Public artifact paths redacted as `<remote-profile-root>/...`.

Baseline current-main M0 c4: `<remote-profile-root>/parallel_saturation_m0_20260620_082057/c4`  
Candidate c4 run A: `<remote-profile-root>/treedb_m2_checkpoint_span_native_c4_20260620_083808`  
Candidate c4 run B/latest: `<remote-profile-root>/treedb_m2_checkpoint_span_native_c4_final_20260620_084524`

Command shape:

```sh
./bin/unified-bench -dbs treedb -test sequential_write,batch_random,random_write \
  -keys 10000000 -valsize 128 -batchsize 8000 \
  -checkpoint-between-tests \
  -treedb-flush-admission-policy=explicit \
  -treedb-flush-apply-span-native \
  -treedb-flush-backlog-coalescing \
  -treedb-flush-apply-min-entries=1 \
  -treedb-flush-apply-min-spans=1 \
  -treedb-flush-apply-min-bytes=1 \
  -treedb-flush-apply-concurrency=4 \
  -profile-dir "$OUT" -progress=false
./bin/benchprof -profiles-dir "$OUT"
```

| row | seq ops/s | batch ops/s | random ops/s | checkpoint after batch | checkpoint after random | post-run checkpoint | span-native used ops | `close_or_checkpoint` fallback ops | fallbacks total | worker busy | busy/apply CPU |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| current-main M0 c4 | 2,471,900 | 508,054 | 257,889 | 1.17s | 6.96s | 10.98s | 29,698,254 | 218,612 | 10 | 97.1% | 3.16 |
| candidate c4 A | 2,551,092 | 548,024 | 252,509 | 1.23s | 6.62s | 10.02s | 29,912,309 | 0 | 0 | ~97% | ~3.2 |
| candidate c4 B/latest | 2,524,448 | 511,229 | 253,358 | 1.15s | 7.12s | 11.90s | 29,916,871 | 0 | 0 | 97.1% | 3.22 |

Interpretation:

- Intended path proof is strong: `close_or_checkpoint` fallback drops from 218,612 ops to zero and all span-native fallback counters are zero in the c4 candidate runs.
- Checkpoint wall/throughput does not materially improve yet; the latest run is within the observed A/B noise envelope. This is expected for M2 and is routed to M3 frontier semantics, M4 coalescing, and M5 shared drain.
- No read/reopen/GC/value-log regression was observed in focused hardening tests or `go test ./TreeDB/...`.

## AI review readiness

Internal review and evidence are complete. CI is expected on this pushed head. AI review should be requested after CI starts/settles per tracker policy.


## Review fix

Codex identified that checkpoint command-WAL piggyback publication must remain a span-native barrier. Latest head `69b161ac` adds `flushPointRunSpanNativeFallbackReasonForCollectionMode` so non-consumed checkpoint command-WAL publish intents force `command_wal_barrier`, plus `TestFlushCollectionModeCheckpointCommandWALPublishForcesFallback`.

Additional latest-head validation after this fix:

```sh
GOWORK=off go test ./TreeDB/caching -run 'TestFlushCollectionMode(SpanNativeFallbackOnlyForClose|CheckpointCommandWALPublishForcesFallback|RangeOnlyCheckpointFallbackReason)' -count=1
GOWORK=off go test ./TreeDB ./TreeDB/caching ./TreeDB/db -run 'SpanNative|Checkpoint|FlushBacklogCoalescing|FlushApply|CommandWAL' -count=1
GOWORK=off go test -race ./TreeDB/caching -run 'TestFlushCollectionMode(SpanNativeFallbackOnlyForClose|CheckpointCommandWALPublishForcesFallback|RangeOnlyCheckpointFallbackReason)' -count=1
GOWORK=off go test -race ./TreeDB -run TestSpanNativeCheckpointDrainUsesSpanNativeReopenRewriteAndGC -count=1
```
