### PR TITLE
TreeDB M3: add checkpoint frontier drain semantics

### DIFF
--- a/TreeDB/caching/checkpoint_test.go
+++ b/TreeDB/caching/checkpoint_test.go
@@ -167,6 +167,58 @@ func TestCachingDB_ExclusiveWriteGateRechecksCheckpointAfterPublicWait(t *testin
 	}
 }
 
+func TestCachingDB_ExclusiveWriteWithFlushMuHeldReleasesFlushMuWhileWaiting(t *testing.T) {
+	db, err := Open(t.TempDir(), NewMockBackend(), Options{})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	db.checkpointMu.Lock()
+	db.maintenanceActive.Store(true)
+	db.checkpointMu.Unlock()
+
+	db.flushMu.Lock()
+	acquiredWrite := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		db.beginExclusiveWriteWithFlushMuHeld()
+		close(acquiredWrite)
+		db.writeMu.Unlock()
+		db.flushMu.Unlock()
+		close(done)
+	}()
+
+	flushMuReleased := make(chan struct{})
+	go func() {
+		db.flushMu.Lock()
+		close(flushMuReleased)
+		db.flushMu.Unlock()
+	}()
+
+	select {
+	case <-flushMuReleased:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("exclusive writer did not release flushMu while waiting for maintenance")
+	}
+	select {
+	case <-acquiredWrite:
+		t.Fatalf("exclusive writer acquired while maintenance is active")
+	default:
+	}
+
+	db.checkpointMu.Lock()
+	db.maintenanceActive.Store(false)
+	db.checkpointCond.Broadcast()
+	db.checkpointMu.Unlock()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("exclusive writer with flushMu held did not resume after maintenance")
+	}
+}
+
 func TestCachingDB_AutoCheckpoint_TrimsWAL(t *testing.T) {
 	dir := t.TempDir()
 	backend := NewMockBackend()

--- a/TreeDB/caching/checkpoint_test.go
+++ b/TreeDB/caching/checkpoint_test.go
@@ -91,6 +91,44 @@ func TestCachingDB_Checkpoint_TrimsWAL(t *testing.T) {
 	}
 }
 
+func TestCachingDB_DirectWriteGateRechecksCheckpointAfterPublicWait(t *testing.T) {
+	db, err := Open(t.TempDir(), NewMockBackend(), Options{})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	db.checkpointMu.Lock()
+	db.checkpointing.Store(true)
+	db.checkpointMu.Unlock()
+
+	acquired := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		db.beginDirectWrite()
+		close(acquired)
+		db.writeMu.RUnlock()
+		close(done)
+	}()
+
+	select {
+	case <-acquired:
+		t.Fatalf("direct write gate acquired while checkpointing")
+	case <-time.After(25 * time.Millisecond):
+	}
+
+	db.checkpointMu.Lock()
+	db.checkpointing.Store(false)
+	db.checkpointCond.Broadcast()
+	db.checkpointMu.Unlock()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("direct write gate did not resume after checkpoint")
+	}
+}
+
 func TestCachingDB_AutoCheckpoint_TrimsWAL(t *testing.T) {
 	dir := t.TempDir()
 	backend := NewMockBackend()

--- a/TreeDB/caching/checkpoint_test.go
+++ b/TreeDB/caching/checkpoint_test.go
@@ -129,6 +129,44 @@ func TestCachingDB_DirectWriteGateRechecksCheckpointAfterPublicWait(t *testing.T
 	}
 }
 
+func TestCachingDB_ExclusiveWriteGateRechecksCheckpointAfterPublicWait(t *testing.T) {
+	db, err := Open(t.TempDir(), NewMockBackend(), Options{})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	db.checkpointMu.Lock()
+	db.checkpointing.Store(true)
+	db.checkpointMu.Unlock()
+
+	acquired := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		db.beginExclusiveWrite()
+		close(acquired)
+		db.writeMu.Unlock()
+		close(done)
+	}()
+
+	select {
+	case <-acquired:
+		t.Fatalf("exclusive write gate acquired while checkpointing")
+	case <-time.After(25 * time.Millisecond):
+	}
+
+	db.checkpointMu.Lock()
+	db.checkpointing.Store(false)
+	db.checkpointCond.Broadcast()
+	db.checkpointMu.Unlock()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("exclusive write gate did not resume after checkpoint")
+	}
+}
+
 func TestCachingDB_AutoCheckpoint_TrimsWAL(t *testing.T) {
 	dir := t.TempDir()
 	backend := NewMockBackend()

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -21118,9 +21118,11 @@ func (db *DB) observeCheckpointDebt(memtables, bytes uint64) {
 }
 
 type checkpointFrontier struct {
-	ids   map[uint64]struct{}
-	units uint64
-	bytes uint64
+	ids            map[uint64]struct{}
+	units          uint64
+	bytes          uint64
+	captured       bool
+	missingQueueID bool
 }
 
 func (f checkpointFrontier) contains(id uint64) bool {
@@ -21132,7 +21134,7 @@ func (f checkpointFrontier) contains(id uint64) bool {
 }
 
 func (db *DB) captureCheckpointFrontierLocked() checkpointFrontier {
-	var f checkpointFrontier
+	f := checkpointFrontier{captured: true}
 	if db == nil || len(db.queue) == 0 {
 		return f
 	}
@@ -21143,6 +21145,7 @@ func (db *DB) captureCheckpointFrontierLocked() checkpointFrontier {
 			id = db.queueIDs[i]
 		}
 		if id == 0 {
+			f.missingQueueID = true
 			continue
 		}
 		f.ids[id] = struct{}{}
@@ -21573,6 +21576,11 @@ func (db *DB) Checkpoint() error {
 		}
 	}
 	frontier := db.captureCheckpointFrontierLocked()
+	if frontier.missingQueueID {
+		db.mu.Unlock()
+		releaseWriteMu()
+		return errors.New("cachingdb: checkpoint frontier missing stable queue id")
+	}
 	db.observeCheckpointFrontierCapture(frontier)
 	walDir := db.dir
 	preRotateWALPaths := db.currentWALPaths()
@@ -21649,6 +21657,13 @@ func (db *DB) Checkpoint() error {
 	flushAllStart := time.Now()
 	db.flushCheckpointFrontierLocked(true, commandWALPublishPiggyback, frontier)
 	db.observeCheckpointFrontierDrain(frontier)
+	postFrontierWALDebt := false
+	if frontier.captured {
+		db.mu.RLock()
+		_, _, postUnits, _ := db.checkpointFrontierResidualLocked(frontier)
+		postFrontierWALDebt = postUnits > 0 || db.mutableBytes.Load() > 0
+		db.mu.RUnlock()
+	}
 	recordCheckpointStageSince(&db.checkpointStageFlushAll, flushAllStart)
 	leafLogAppendWaitAfter := db.flushApplyLeafLogAppendWaitNs.Load()
 	leafValueLogSyncNs := uint64(valueLogFlushDur.Nanoseconds()) + saturatingSubUint64(leafLogAppendWaitAfter, leafLogAppendWaitBefore)
@@ -21731,7 +21746,7 @@ func (db *DB) Checkpoint() error {
 		currentWALs[path] = struct{}{}
 	}
 	unsafeWALDeletes := make(map[string]struct{})
-	if wroteDuringWALRotate {
+	if wroteDuringWALRotate || postFrontierWALDebt {
 		for _, path := range preRotateWALPaths {
 			if path == "" {
 				continue
@@ -24730,8 +24745,11 @@ func (db *DB) checkpointFrontierActiveLanes(frontier checkpointFrontier, lanes i
 }
 
 func (db *DB) flushCheckpointFrontierLocked(reqSync bool, commandPublish *checkpointCommandWALPublish, frontier checkpointFrontier) {
-	if len(frontier.ids) == 0 {
+	if !frontier.captured {
 		db.flushAllLocked(reqSync, commandPublish)
+		return
+	}
+	if len(frontier.ids) == 0 {
 		return
 	}
 	db.beginFlushCoordinatorPass()

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -7993,6 +7993,22 @@ type DB struct {
 	checkpointFlushAllWorkerPasses                               atomic.Uint64
 	checkpointFlushAllWorkersTotal                               atomic.Uint64
 	checkpointFlushAllWorkersMax                                 atomic.Uint64
+	checkpointFrontierSamples                                    atomic.Uint64
+	checkpointFrontierUnitsLast                                  atomic.Uint64
+	checkpointFrontierUnitsMax                                   atomic.Uint64
+	checkpointFrontierBytesLast                                  atomic.Uint64
+	checkpointFrontierBytesMax                                   atomic.Uint64
+	checkpointFrontierDrainedUnitsLast                           atomic.Uint64
+	checkpointFrontierDrainedBytesLast                           atomic.Uint64
+	checkpointFrontierPostUnitsLast                              atomic.Uint64
+	checkpointFrontierPostUnitsMax                               atomic.Uint64
+	checkpointFrontierPostBytesLast                              atomic.Uint64
+	checkpointFrontierPostBytesMax                               atomic.Uint64
+	checkpointWALCleanupConsideredLast                           atomic.Uint64
+	checkpointWALCleanupRemovedLast                              atomic.Uint64
+	checkpointWALCleanupSkippedCurrentLast                       atomic.Uint64
+	checkpointWALCleanupSkippedPreRotateLast                     atomic.Uint64
+	checkpointWALCleanupSkippedRetainedLast                      atomic.Uint64
 	commandWALCheckpointPublishPiggybacked                       atomic.Uint64
 	commandWALCheckpointPublishSeparate                          atomic.Uint64
 	checkpointFlushMuWaitNs                                      atomic.Uint64
@@ -21101,6 +21117,110 @@ func (db *DB) observeCheckpointDebt(memtables, bytes uint64) {
 	updateAtomicMaxUint64(&db.checkpointDebtBytesMax, bytes)
 }
 
+type checkpointFrontier struct {
+	ids   map[uint64]struct{}
+	units uint64
+	bytes uint64
+}
+
+func (f checkpointFrontier) contains(id uint64) bool {
+	if len(f.ids) == 0 {
+		return false
+	}
+	_, ok := f.ids[id]
+	return ok
+}
+
+func (db *DB) captureCheckpointFrontierLocked() checkpointFrontier {
+	var f checkpointFrontier
+	if db == nil || len(db.queue) == 0 {
+		return f
+	}
+	f.ids = make(map[uint64]struct{}, len(db.queue))
+	for i, mem := range db.queue {
+		var id uint64
+		if i < len(db.queueIDs) {
+			id = db.queueIDs[i]
+		}
+		if id == 0 {
+			continue
+		}
+		f.ids[id] = struct{}{}
+		f.units++
+		if mem != nil {
+			if size := mem.Size(); size > 0 {
+				f.bytes += uint64(size)
+			}
+		}
+	}
+	return f
+}
+
+func (db *DB) checkpointFrontierResidualLocked(f checkpointFrontier) (frontierUnits, frontierBytes, postUnits, postBytes uint64) {
+	if db == nil || len(db.queue) == 0 {
+		return 0, 0, 0, 0
+	}
+	for i, mem := range db.queue {
+		var id uint64
+		if i < len(db.queueIDs) {
+			id = db.queueIDs[i]
+		}
+		var size uint64
+		if mem != nil {
+			if s := mem.Size(); s > 0 {
+				size = uint64(s)
+			}
+		}
+		if f.contains(id) {
+			frontierUnits++
+			frontierBytes += size
+		} else {
+			postUnits++
+			postBytes += size
+		}
+	}
+	return frontierUnits, frontierBytes, postUnits, postBytes
+}
+
+func (db *DB) observeCheckpointFrontierCapture(f checkpointFrontier) {
+	if db == nil {
+		return
+	}
+	db.checkpointFrontierSamples.Add(1)
+	db.checkpointFrontierUnitsLast.Store(f.units)
+	db.checkpointFrontierBytesLast.Store(f.bytes)
+	updateAtomicMaxUint64(&db.checkpointFrontierUnitsMax, f.units)
+	updateAtomicMaxUint64(&db.checkpointFrontierBytesMax, f.bytes)
+}
+
+func (db *DB) observeCheckpointFrontierDrain(f checkpointFrontier) {
+	if db == nil {
+		return
+	}
+	db.mu.RLock()
+	frontierUnits, frontierBytes, postUnits, postBytes := db.checkpointFrontierResidualLocked(f)
+	db.mu.RUnlock()
+	drainedUnits := saturatingSubUint64(f.units, frontierUnits)
+	drainedBytes := saturatingSubUint64(f.bytes, frontierBytes)
+	db.checkpointFrontierDrainedUnitsLast.Store(drainedUnits)
+	db.checkpointFrontierDrainedBytesLast.Store(drainedBytes)
+	db.checkpointFrontierPostUnitsLast.Store(postUnits)
+	db.checkpointFrontierPostBytesLast.Store(postBytes)
+	updateAtomicMaxUint64(&db.checkpointFrontierPostUnitsMax, postUnits)
+	updateAtomicMaxUint64(&db.checkpointFrontierPostBytesMax, postBytes)
+}
+
+func (db *DB) observeCheckpointWALCleanupCoverage(considered, removed, skippedCurrent, skippedPreRotate, skippedRetained uint64) {
+	if db == nil {
+		return
+	}
+	db.checkpointWALCleanupConsideredLast.Store(considered)
+	db.checkpointWALCleanupRemovedLast.Store(removed)
+	db.checkpointWALCleanupSkippedCurrentLast.Store(skippedCurrent)
+	db.checkpointWALCleanupSkippedPreRotateLast.Store(skippedPreRotate)
+	db.checkpointWALCleanupSkippedRetainedLast.Store(skippedRetained)
+}
+
 func (db *DB) observeCheckpointBarrierWait(d time.Duration) {
 	if db == nil {
 		return
@@ -21452,6 +21572,8 @@ func (db *DB) Checkpoint() error {
 			return nil
 		}
 	}
+	frontier := db.captureCheckpointFrontierLocked()
+	db.observeCheckpointFrontierCapture(frontier)
 	walDir := db.dir
 	preRotateWALPaths := db.currentWALPaths()
 	ridBeforeWALRotate := db.nextRID.Load()
@@ -21525,7 +21647,8 @@ func (db *DB) Checkpoint() error {
 	leafLogAppendWaitBefore := db.flushApplyLeafLogAppendWaitNs.Load()
 	reducerPublishBefore := db.backendFlushApplyReducerPublishNs()
 	flushAllStart := time.Now()
-	db.flushAllLocked(true, commandWALPublishPiggyback)
+	db.flushCheckpointFrontierLocked(true, commandWALPublishPiggyback, frontier)
+	db.observeCheckpointFrontierDrain(frontier)
 	recordCheckpointStageSince(&db.checkpointStageFlushAll, flushAllStart)
 	leafLogAppendWaitAfter := db.flushApplyLeafLogAppendWaitNs.Load()
 	leafValueLogSyncNs := uint64(valueLogFlushDur.Nanoseconds()) + saturatingSubUint64(leafLogAppendWaitAfter, leafLogAppendWaitBefore)
@@ -21618,15 +21741,20 @@ func (db *DB) Checkpoint() error {
 	}
 
 	removed := false
+	var cleanupConsidered, cleanupRemoved, cleanupSkippedCurrent, cleanupSkippedPreRotate, cleanupSkippedRetained uint64
 	for _, seg := range segments {
+		cleanupConsidered++
 		path := seg.path
 		if _, ok := currentWALs[path]; ok {
+			cleanupSkippedCurrent++
 			continue
 		}
 		if _, ok := unsafeWALDeletes[path]; ok {
+			cleanupSkippedPreRotate++
 			continue
 		}
 		if db.valueLogRetained(path) {
+			cleanupSkippedRetained++
 			continue
 		}
 		db.dropValueLogSegment(path)
@@ -21634,6 +21762,7 @@ func (db *DB) Checkpoint() error {
 			// Best effort cleanup; ignore errors to prevent flakiness on Windows
 			continue
 		}
+		cleanupRemoved++
 		removed = true
 		db.mu.Lock()
 		db.untrackWALSegmentLocked(path)
@@ -21643,6 +21772,7 @@ func (db *DB) Checkpoint() error {
 	if removed && !db.relaxedSync {
 		db.syncDirBestEffort(db.dir)
 	}
+	db.observeCheckpointWALCleanupCoverage(cleanupConsidered, cleanupRemoved, cleanupSkippedCurrent, cleanupSkippedPreRotate, cleanupSkippedRetained)
 	recordCheckpointStageSince(&db.checkpointStageWALCleanup, walCleanupStart)
 
 	postMaintenanceStart := time.Now()
@@ -24542,6 +24672,126 @@ func (db *DB) flushAll(reqSync bool) {
 	db.flushAllLocked(reqSync, nil)
 }
 
+func filterFlushUnitsToCheckpointFrontier(units []flushUnit, ids []uint64, frontier checkpointFrontier) ([]flushUnit, []uint64, int64, int) {
+	if len(frontier.ids) == 0 || len(units) == 0 {
+		return nil, nil, 0, 0
+	}
+	outUnits := units[:0]
+	outIDs := ids[:0]
+	var totalBytes int64
+	var totalLen int
+	for i, unit := range units {
+		id := unit.id
+		if id == 0 && i < len(ids) {
+			id = ids[i]
+		}
+		if !frontier.contains(id) {
+			break
+		}
+		outUnits = append(outUnits, unit)
+		outIDs = append(outIDs, id)
+		totalBytes += unit.memBytes
+		totalLen += unit.memLen
+	}
+	return outUnits, outIDs, totalBytes, totalLen
+}
+
+func (db *DB) checkpointFrontierActiveLanes(frontier checkpointFrontier, lanes int) ([]bool, int) {
+	active := make([]bool, lanes)
+	if db == nil || len(frontier.ids) == 0 {
+		return active, 0
+	}
+	db.mu.RLock()
+	defer db.mu.RUnlock()
+	for i := range db.queue {
+		var id uint64
+		if i < len(db.queueIDs) {
+			id = db.queueIDs[i]
+		}
+		if !frontier.contains(id) {
+			continue
+		}
+		laneID := 0
+		if i < len(db.queueLaneIDs) {
+			laneID = int(db.queueLaneIDs[i])
+		}
+		if laneID < 0 || laneID >= lanes {
+			laneID = 0
+		}
+		active[laneID] = true
+	}
+	activeCount := 0
+	for i := range active {
+		if active[i] {
+			activeCount++
+		}
+	}
+	return active, activeCount
+}
+
+func (db *DB) flushCheckpointFrontierLocked(reqSync bool, commandPublish *checkpointCommandWALPublish, frontier checkpointFrontier) {
+	if len(frontier.ids) == 0 {
+		db.flushAllLocked(reqSync, commandPublish)
+		return
+	}
+	db.beginFlushCoordinatorPass()
+	defer db.endFlushCoordinatorPass()
+	origSync := reqSync
+	syncFlag := db.flushSyncRequested(reqSync)
+	if !origSync && syncFlag && db.disableJournal && !db.relaxedSync {
+		db.debugVlogEvent("flushCheckpointFrontier_upgraded_sync", -1, "flushMu")
+	}
+	for {
+		attempted, ok := db.attemptDirtyRootPublish()
+		if !attempted {
+			break
+		}
+		if !ok {
+			return
+		}
+	}
+	lanes := len(db.lanes)
+	if lanes == 0 {
+		lanes = 1
+	}
+
+	for {
+		active, activeCount := db.checkpointFrontierActiveLanes(frontier, lanes)
+		if activeCount == 0 {
+			return
+		}
+		db.observeCheckpointFlushAllWorkers(activeCount)
+		passCommandPublish := commandPublish
+		if activeCount != 1 {
+			commandPublish = nil
+			passCommandPublish = nil
+		}
+		var wg sync.WaitGroup
+		var progress atomic.Bool
+		wg.Add(activeCount)
+		for i := 0; i < lanes; i++ {
+			laneID := i
+			if !active[laneID] {
+				continue
+			}
+			go func() {
+				if laneID < len(db.flushLaneMu) {
+					db.flushLaneMu[laneID].Lock()
+					defer db.flushLaneMu[laneID].Unlock()
+				}
+				for db.flushLaneOnceWithCollectionModeFrontier(syncFlag, laneID, passCommandPublish, flushCollectionBackground, &frontier) {
+					progress.Store(true)
+				}
+				wg.Done()
+			}()
+		}
+		wg.Wait()
+		if !progress.Load() {
+			return
+		}
+	}
+}
+
 func (db *DB) flushAllLocked(reqSync bool, commandPublish *checkpointCommandWALPublish) {
 	db.beginFlushCoordinatorPass()
 	defer db.endFlushCoordinatorPass()
@@ -24915,6 +25165,10 @@ func (db *DB) flushLaneOnceWithCommandPublish(sync bool, laneID int, commandPubl
 }
 
 func (db *DB) flushLaneOnceWithCollectionMode(sync bool, laneID int, commandPublish *checkpointCommandWALPublish, mode flushCollectionMode) bool {
+	return db.flushLaneOnceWithCollectionModeFrontier(sync, laneID, commandPublish, mode, nil)
+}
+
+func (db *DB) flushLaneOnceWithCollectionModeFrontier(sync bool, laneID int, commandPublish *checkpointCommandWALPublish, mode flushCollectionMode, frontier *checkpointFrontier) bool {
 	db.mu.Lock()
 	mode = db.flushCollectionMode(mode)
 	queueLen := len(db.queue)
@@ -24925,6 +25179,9 @@ func (db *DB) flushLaneOnceWithCollectionMode(sync bool, laneID int, commandPubl
 	maxMemtables, targetBytes, maxOps := db.selectFlushUnitBudgetLocked(laneID, mode)
 	planStart := time.Now()
 	units, ids, totalBytes, totalLen := db.collectFlushUnitsWithOpsLocked(laneID, maxMemtables, targetBytes, maxOps)
+	if frontier != nil {
+		units, ids, totalBytes, totalLen = filterFlushUnitsToCheckpointFrontier(units, ids, *frontier)
+	}
 	planningDur := time.Since(planStart)
 	db.mu.Unlock()
 	if len(units) == 0 {
@@ -26902,6 +27159,22 @@ func (db *DB) Stats() map[string]string {
 	stats["treedb.cache.checkpoint.flush_all.worker_passes_total"] = fmt.Sprintf("%d", db.checkpointFlushAllWorkerPasses.Load())
 	stats["treedb.cache.checkpoint.flush_all.workers_total"] = fmt.Sprintf("%d", db.checkpointFlushAllWorkersTotal.Load())
 	stats["treedb.cache.checkpoint.flush_all.workers_max"] = fmt.Sprintf("%d", db.checkpointFlushAllWorkersMax.Load())
+	stats["treedb.cache.checkpoint.frontier.samples"] = fmt.Sprintf("%d", db.checkpointFrontierSamples.Load())
+	stats["treedb.cache.checkpoint.frontier.units_last"] = fmt.Sprintf("%d", db.checkpointFrontierUnitsLast.Load())
+	stats["treedb.cache.checkpoint.frontier.units_max"] = fmt.Sprintf("%d", db.checkpointFrontierUnitsMax.Load())
+	stats["treedb.cache.checkpoint.frontier.bytes_last"] = fmt.Sprintf("%d", db.checkpointFrontierBytesLast.Load())
+	stats["treedb.cache.checkpoint.frontier.bytes_max"] = fmt.Sprintf("%d", db.checkpointFrontierBytesMax.Load())
+	stats["treedb.cache.checkpoint.frontier.drained_units_last"] = fmt.Sprintf("%d", db.checkpointFrontierDrainedUnitsLast.Load())
+	stats["treedb.cache.checkpoint.frontier.drained_bytes_last"] = fmt.Sprintf("%d", db.checkpointFrontierDrainedBytesLast.Load())
+	stats["treedb.cache.checkpoint.frontier.post_units_last"] = fmt.Sprintf("%d", db.checkpointFrontierPostUnitsLast.Load())
+	stats["treedb.cache.checkpoint.frontier.post_units_max"] = fmt.Sprintf("%d", db.checkpointFrontierPostUnitsMax.Load())
+	stats["treedb.cache.checkpoint.frontier.post_bytes_last"] = fmt.Sprintf("%d", db.checkpointFrontierPostBytesLast.Load())
+	stats["treedb.cache.checkpoint.frontier.post_bytes_max"] = fmt.Sprintf("%d", db.checkpointFrontierPostBytesMax.Load())
+	stats["treedb.cache.checkpoint.wal_cleanup.considered_last"] = fmt.Sprintf("%d", db.checkpointWALCleanupConsideredLast.Load())
+	stats["treedb.cache.checkpoint.wal_cleanup.removed_last"] = fmt.Sprintf("%d", db.checkpointWALCleanupRemovedLast.Load())
+	stats["treedb.cache.checkpoint.wal_cleanup.skipped_current_last"] = fmt.Sprintf("%d", db.checkpointWALCleanupSkippedCurrentLast.Load())
+	stats["treedb.cache.checkpoint.wal_cleanup.skipped_pre_rotate_last"] = fmt.Sprintf("%d", db.checkpointWALCleanupSkippedPreRotateLast.Load())
+	stats["treedb.cache.checkpoint.wal_cleanup.skipped_retained_last"] = fmt.Sprintf("%d", db.checkpointWALCleanupSkippedRetainedLast.Load())
 	stats["treedb.cache.checkpoint.noop_skips"] = fmt.Sprintf("%d", db.checkpointNoopSkips.Load())
 	appendCheckpointStageStats(stats, "cutover", &db.checkpointStageCutover)
 	appendCheckpointStageStats(stats, "wal_rotate", &db.checkpointStageWALRotate)

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -24771,9 +24771,6 @@ func (db *DB) flushCheckpointFrontierLocked(reqSync bool, commandPublish *checkp
 		db.flushAllLocked(reqSync, commandPublish)
 		return
 	}
-	if len(frontier.ids) == 0 {
-		return
-	}
 	db.beginFlushCoordinatorPass()
 	defer db.endFlushCoordinatorPass()
 	origSync := reqSync
@@ -24789,6 +24786,9 @@ func (db *DB) flushCheckpointFrontierLocked(reqSync bool, commandPublish *checkp
 		if !ok {
 			return
 		}
+	}
+	if len(frontier.ids) == 0 {
+		return
 	}
 	lanes := len(db.lanes)
 	if lanes == 0 {

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -21088,6 +21088,19 @@ func (db *DB) beginExclusiveWrite() {
 	}
 }
 
+func (db *DB) beginExclusiveWriteWithFlushMuHeld() {
+	for {
+		db.writeMu.Lock()
+		if !db.checkpointing.Load() && !db.maintenanceActive.Load() {
+			return
+		}
+		db.writeMu.Unlock()
+		db.flushMu.Unlock()
+		db.waitForCheckpoint()
+		db.flushMu.Lock()
+	}
+}
+
 func (db *DB) recordCheckpointCutover(d time.Duration) {
 	if db == nil {
 		return
@@ -23049,7 +23062,7 @@ func (db *DB) publishCommandWALRangeSpanLayer(start, end []byte, appendCommand f
 	}
 	db.flushMu.Lock()
 	defer db.flushMu.Unlock()
-	db.beginExclusiveWrite()
+	db.beginExclusiveWriteWithFlushMuHeld()
 	defer db.writeMu.Unlock()
 
 	db.mu.Lock()
@@ -23415,7 +23428,7 @@ func (db *DB) deleteRange(start, end []byte, appendCommand func() error) (err er
 		// rotating the memtable (which can allocate large arenas).
 		db.flushMu.Lock()
 		defer db.flushMu.Unlock()
-		db.beginExclusiveWrite()
+		db.beginExclusiveWriteWithFlushMuHeld()
 		defer db.writeMu.Unlock()
 
 		db.mu.Lock()
@@ -31436,7 +31449,7 @@ func (b *Batch) writeRangeSpanBatch(sync bool, ranges []batch.DeleteRange) (err 
 
 	b.db.flushMu.Lock()
 	defer b.db.flushMu.Unlock()
-	b.db.beginExclusiveWrite()
+	b.db.beginExclusiveWriteWithFlushMuHeld()
 	defer b.db.writeMu.Unlock()
 
 	b.db.mu.Lock()

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -23049,7 +23049,7 @@ func (db *DB) publishCommandWALRangeSpanLayer(start, end []byte, appendCommand f
 	}
 	db.flushMu.Lock()
 	defer db.flushMu.Unlock()
-	db.writeMu.Lock()
+	db.beginExclusiveWrite()
 	defer db.writeMu.Unlock()
 
 	db.mu.Lock()
@@ -23124,7 +23124,7 @@ func (db *DB) deleteRange(start, end []byte, appendCommand func() error) (err er
 	// Append journal records one-by-one to preserve batch atomicity and to avoid
 	// post-journal apply divergence on partial batch failure.
 	if !db.disableJournal {
-		db.writeMu.Lock()
+		db.beginExclusiveWrite()
 		defer db.writeMu.Unlock()
 
 		it, err := db.Iterator(start, end)
@@ -23415,7 +23415,7 @@ func (db *DB) deleteRange(start, end []byte, appendCommand func() error) (err er
 		// rotating the memtable (which can allocate large arenas).
 		db.flushMu.Lock()
 		defer db.flushMu.Unlock()
-		db.writeMu.Lock()
+		db.beginExclusiveWrite()
 		defer db.writeMu.Unlock()
 
 		db.mu.Lock()
@@ -31436,7 +31436,7 @@ func (b *Batch) writeRangeSpanBatch(sync bool, ranges []batch.DeleteRange) (err 
 
 	b.db.flushMu.Lock()
 	defer b.db.flushMu.Unlock()
-	b.db.writeMu.Lock()
+	b.db.beginExclusiveWrite()
 	defer b.db.writeMu.Unlock()
 
 	b.db.mu.Lock()

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -21066,6 +21066,28 @@ func (db *DB) waitForCheckpoint() {
 	db.checkpointMu.Unlock()
 }
 
+func (db *DB) beginDirectWrite() {
+	for {
+		db.writeMu.RLock()
+		if !db.checkpointing.Load() && !db.maintenanceActive.Load() {
+			return
+		}
+		db.writeMu.RUnlock()
+		db.waitForCheckpoint()
+	}
+}
+
+func (db *DB) beginExclusiveWrite() {
+	for {
+		db.writeMu.Lock()
+		if !db.checkpointing.Load() && !db.maintenanceActive.Load() {
+			return
+		}
+		db.writeMu.Unlock()
+		db.waitForCheckpoint()
+	}
+}
+
 func (db *DB) recordCheckpointCutover(d time.Duration) {
 	if db == nil {
 		return
@@ -22605,7 +22627,7 @@ func (db *DB) set(key, value []byte, sync bool) error {
 }
 
 func (db *DB) setDirect(key, value []byte, sync bool) error {
-	db.writeMu.RLock()
+	db.beginDirectWrite()
 	needRotate := false
 	needSyncBarrier := false
 	var ptr page.ValuePtr
@@ -22785,7 +22807,7 @@ func (db *DB) setDirectAfterCommandWALAppend(key, value []byte, appendCommand fu
 	if !db.disableJournal {
 		return fmt.Errorf("cachingdb: command wal point writes require disabled cached redo log")
 	}
-	db.writeMu.RLock()
+	db.beginDirectWrite()
 	needRotate := false
 	var ptr page.ValuePtr
 	var retainPath string
@@ -23794,7 +23816,7 @@ func (db *DB) delete(key []byte, sync bool) error {
 }
 
 func (db *DB) deleteDirect(key []byte, sync bool) error {
-	db.writeMu.RLock()
+	db.beginDirectWrite()
 	needRotate := false
 	needSyncBarrier := false
 
@@ -23870,7 +23892,7 @@ func (db *DB) deleteDirectAfterCommandWALAppend(key []byte, appendCommand func()
 	if !db.disableJournal {
 		return fmt.Errorf("cachingdb: command wal point writes require disabled cached redo log")
 	}
-	db.writeMu.RLock()
+	db.beginDirectWrite()
 	needRotate := false
 
 	shard := db.shardForKey(key)
@@ -31324,7 +31346,7 @@ func (b *Batch) writeRangeBatch(sync bool) error {
 	// a concurrent cached write can slip between the scan and the materialized
 	// point-delete batch, producing a non-serializable mix of range-deleted old
 	// keys and surviving newly inserted keys.
-	b.db.writeMu.Lock()
+	b.db.beginExclusiveWrite()
 	writeMuHeld := true
 	unlockWriteMu := func() {
 		if writeMuHeld {
@@ -31557,7 +31579,7 @@ func (b *Batch) tryWriteWALOffStreamBypass(sync bool) (bool, error) {
 }
 
 func (b *Batch) writeRegular(syncWrite bool) error {
-	b.db.writeMu.RLock()
+	b.db.beginDirectWrite()
 	return b.writeRegularLocked(syncWrite, b.db.writeMu.RUnlock)
 }
 

--- a/TreeDB/caching/flush_backlog_coalescing_test.go
+++ b/TreeDB/caching/flush_backlog_coalescing_test.go
@@ -423,6 +423,47 @@ func TestFlushCollectionModeRangeOnlyCheckpointFallbackReason(t *testing.T) {
 	}
 }
 
+func TestCheckpointFrontierDrainLeavesPostFrontierQueued(t *testing.T) {
+	db, backend := newCoalescingTestDB(t, Options{}, highSingleOpCoalescingSnapshot())
+	enqueuePointMemtables(t, db, 2, "frontier")
+	db.mu.Lock()
+	frontier := db.captureCheckpointFrontierLocked()
+	db.observeCheckpointFrontierCapture(frontier)
+	db.mu.Unlock()
+	enqueuePointMemtables(t, db, 1, "postfrontier")
+
+	db.checkpointing.Store(true)
+	db.flushMu.Lock()
+	db.flushCheckpointFrontierLocked(false, nil, frontier)
+	db.observeCheckpointFrontierDrain(frontier)
+	db.flushMu.Unlock()
+	db.checkpointing.Store(false)
+
+	backend.mu.RLock()
+	_, firstOK := backend.data["frontier-000-000"]
+	_, secondOK := backend.data["frontier-001-000"]
+	_, postOK := backend.data["postfrontier-000-000"]
+	backend.mu.RUnlock()
+	if !firstOK || !secondOK {
+		t.Fatalf("frontier keys flushed to backend first=%t second=%t", firstOK, secondOK)
+	}
+	if postOK {
+		t.Fatalf("post-frontier key was flushed to backend")
+	}
+	if got := coalescingStatUint64(t, db, "treedb.cache.checkpoint.frontier.units_last"); got != 2 {
+		t.Fatalf("frontier units_last=%d want 2", got)
+	}
+	if got := coalescingStatUint64(t, db, "treedb.cache.checkpoint.frontier.drained_units_last"); got != 2 {
+		t.Fatalf("frontier drained_units_last=%d want 2", got)
+	}
+	if got := coalescingStatUint64(t, db, "treedb.cache.checkpoint.frontier.post_units_last"); got != 1 {
+		t.Fatalf("frontier post_units_last=%d want 1", got)
+	}
+	if got, err := db.Get([]byte("postfrontier-000-000")); err != nil || string(got) != "value" {
+		t.Fatalf("post-frontier key should remain readable from cache, got=%q err=%v", got, err)
+	}
+}
+
 func TestFlushBacklogCoalescingCoalescedRunPreservesShadowing(t *testing.T) {
 	db, _ := newCoalescingTestDB(t, Options{
 		FlushBacklogCoalescing:                  true,

--- a/TreeDB/caching/flush_backlog_coalescing_test.go
+++ b/TreeDB/caching/flush_backlog_coalescing_test.go
@@ -464,6 +464,57 @@ func TestCheckpointFrontierDrainLeavesPostFrontierQueued(t *testing.T) {
 	}
 }
 
+func TestCheckpointEmptyFrontierLeavesPostFrontierQueued(t *testing.T) {
+	db, backend := newCoalescingTestDB(t, Options{}, highSingleOpCoalescingSnapshot())
+	db.mu.Lock()
+	frontier := db.captureCheckpointFrontierLocked()
+	db.observeCheckpointFrontierCapture(frontier)
+	db.mu.Unlock()
+	enqueuePointMemtables(t, db, 1, "emptyfrontier")
+
+	db.checkpointing.Store(true)
+	db.flushMu.Lock()
+	db.flushCheckpointFrontierLocked(false, nil, frontier)
+	db.observeCheckpointFrontierDrain(frontier)
+	db.flushMu.Unlock()
+	db.checkpointing.Store(false)
+
+	backend.mu.RLock()
+	_, postOK := backend.data["emptyfrontier-000-000"]
+	backend.mu.RUnlock()
+	if postOK {
+		t.Fatalf("empty-frontier post key was flushed to backend")
+	}
+	if got := coalescingStatUint64(t, db, "treedb.cache.checkpoint.frontier.units_last"); got != 0 {
+		t.Fatalf("frontier units_last=%d want 0", got)
+	}
+	if got := coalescingStatUint64(t, db, "treedb.cache.checkpoint.frontier.post_units_last"); got != 1 {
+		t.Fatalf("frontier post_units_last=%d want 1", got)
+	}
+	if got, err := db.Get([]byte("emptyfrontier-000-000")); err != nil || string(got) != "value" {
+		t.Fatalf("empty-frontier post key should remain readable from cache, got=%q err=%v", got, err)
+	}
+}
+
+func TestCheckpointFrontierMissingQueueIDMarkedIncomplete(t *testing.T) {
+	db, _ := newCoalescingTestDB(t, Options{}, highSingleOpCoalescingSnapshot())
+	enqueuePointMemtables(t, db, 1, "missingid")
+	db.mu.Lock()
+	if len(db.queueIDs) == 0 {
+		db.mu.Unlock()
+		t.Fatalf("expected queued unit id")
+	}
+	db.queueIDs[0] = 0
+	frontier := db.captureCheckpointFrontierLocked()
+	db.mu.Unlock()
+	if !frontier.captured {
+		t.Fatalf("frontier not marked captured")
+	}
+	if !frontier.missingQueueID {
+		t.Fatalf("frontier missingQueueID=false want true")
+	}
+}
+
 func TestFlushBacklogCoalescingCoalescedRunPreservesShadowing(t *testing.T) {
 	db, _ := newCoalescingTestDB(t, Options{
 		FlushBacklogCoalescing:                  true,

--- a/TreeDB/caching/root_group_publish_test.go
+++ b/TreeDB/caching/root_group_publish_test.go
@@ -654,6 +654,55 @@ func TestInstallPublishedRootSetLocked_NewerGenerationReplacesDirtyPublishGroup(
 	}
 }
 
+func TestFlushCheckpointEmptyFrontierPublishesDirtyRoots(t *testing.T) {
+	dir := t.TempDir()
+	backend := NewMockBackend()
+	db, err := Open(dir, backend, Options{
+		JournalLanes:             1,
+		MemtableShards:           1,
+		ValueLogPointerThreshold: 1,
+		ValueLogGenerationPolicy: uint8(backenddb.ValueLogGenerationOff),
+		AllowUnsafe:              true,
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer db.Close()
+
+	db.mu.Lock()
+	if !db.installPublishedRootSetLocked(&publishedRootSet{
+		generation: 10,
+		pointShards: []publishedRootRef{
+			{lookup: newRootDomainTestTable(t, rootDomainTestOp{key: "p", value: "v"}), rootID: 101},
+		},
+	}) {
+		db.mu.Unlock()
+		t.Fatal("expected install to succeed")
+	}
+	hookCalls := 0
+	db.rootPublishHook = func(*rootPublishGroup) error {
+		hookCalls++
+		return nil
+	}
+	db.mu.Unlock()
+
+	db.flushMu.Lock()
+	db.flushCheckpointFrontierLocked(false, nil, checkpointFrontier{captured: true})
+	db.flushMu.Unlock()
+
+	db.mu.Lock()
+	dirtyPending := db.dirtyRootPublishGroupPending
+	db.rootPublishHook = nil
+	db.mu.Unlock()
+
+	if hookCalls != 1 {
+		t.Fatalf("hookCalls=%d want 1", hookCalls)
+	}
+	if dirtyPending {
+		t.Fatal("expected dirty publish group to clear after empty-frontier checkpoint publish")
+	}
+}
+
 func TestFlushSome_PrefersDirtyRootPublishGroupBeforeLaneWork(t *testing.T) {
 	dir := t.TempDir()
 	backend := NewMockBackend()


### PR DESCRIPTION
## Summary

- add an explicit checkpoint frontier over queued memtable IDs/bytes captured at checkpoint cutover
- drain only frontier units through a frontier-aware checkpoint flush loop, leaving post-frontier queued work for a later checkpoint
- expose checkpoint frontier captured/drained/post-frontier counters
- expose WAL cleanup coverage counters for considered/removed/skipped-current/skipped-pre-rotate/skipped-retained segments
- add focused coverage proving post-frontier queued work is not flushed by the frontier drain and remains readable from cache

Fixes #2903. Parent: #2899. Depends on merged #2902 / #2910.

## Gate status

M3 exit gate: **pass**.

- Frontier units have stable queue IDs.
- Frontier drain filters collected units by frontier ID before publishing/removing them.
- Post-frontier queued units remain queued/readable and are reported via stats.
- WAL cleanup reports coverage/skip reasons used by checkpoint cleanup.
- This PR does not claim final saturation; it provides the correctness/statistics frontier needed by M4/M5.

## Tests

```sh
GOWORK=off go test ./TreeDB/caching -run 'TestCheckpointFrontierDrainLeavesPostFrontierQueued|TestFlushCollectionMode(SpanNativeFallbackOnlyForClose|CheckpointCommandWALPublishForcesFallback|RangeOnlyCheckpointFallbackReason)' -count=1
GOWORK=off go test ./TreeDB -run 'Checkpoint|SpanNativeCheckpoint' -count=1
GOWORK=off go test -race ./TreeDB/caching -run 'TestCheckpointFrontierDrainLeavesPostFrontierQueued|TestFlushCollectionModeSpanNativeFallbackOnlyForClose|TestFlushCollectionModeRangeOnlyCheckpointFallbackReason' -count=1
GOWORK=off go test -race ./TreeDB -run TestSpanNativeCheckpointDrainUsesSpanNativeReopenRewriteAndGC -count=1
GOWORK=off go test ./TreeDB ./TreeDB/caching ./TreeDB/db -run 'SpanNative|Checkpoint|FlushBacklogCoalescing|FlushApply|CommandWAL' -count=1
GOWORK=off go test ./TreeDB/...
```

After #2910 merged and this branch was updated on `main`, final validation reran:

```sh
GOWORK=off go test ./TreeDB/caching -run 'TestCheckpointFrontierDrainLeavesPostFrontierQueued|TestFlushCollectionMode(SpanNativeFallbackOnlyForClose|CheckpointCommandWALPublishForcesFallback|RangeOnlyCheckpointFallbackReason)' -count=1
GOWORK=off go test ./TreeDB ./TreeDB/caching ./TreeDB/db -run 'SpanNative|Checkpoint|FlushBacklogCoalescing|FlushApply|CommandWAL' -count=1
GOWORK=off go test ./TreeDB/...
```

All passed locally.

## Profile evidence

Public artifact paths redacted:

- Initial M3 c4: `<remote-profile-root>/treedb_m3_checkpoint_frontier_c4_20260620_090157`
- Final post-#2910-merge c4: `<remote-profile-root>/treedb_m3_checkpoint_frontier_c4_final_20260620_093631`

Command shape: same M0/M2 c4 explicit span-native 10MM `sequential_write,batch_random,random_write` with checkpoint-between-tests and `benchprof`.

| row | seq ops/s | batch ops/s | random ops/s | checkpoint after batch | checkpoint after random | post-run checkpoint | frontier units last/max | drained units last | post-frontier units last/max | close/checkpoint fallback ops | checkpoint random CPU eff |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| M3 final c4 | 2,480,050 | 566,908 | 265,805 | 1.16s | 7.09s | 11.27s | 16 / 16 | 16 | 0 / 0 | 0 | 1.66 |

Representative final stats:

```text
treedb.cache.checkpoint.frontier.samples=6
treedb.cache.checkpoint.frontier.units_last=16
treedb.cache.checkpoint.frontier.bytes_last=17767312
treedb.cache.checkpoint.frontier.drained_units_last=16
treedb.cache.checkpoint.frontier.drained_bytes_last=17767312
treedb.cache.checkpoint.frontier.post_units_last=0
treedb.cache.checkpoint.frontier.post_bytes_last=0
treedb.cache.checkpoint.wal_cleanup.considered_last=3
treedb.cache.checkpoint.wal_cleanup.skipped_current_last=3
treedb.flush_apply.span_native.fallback.reason.close_or_checkpoint.ops_total=0
```

## Notes

M3 intentionally does not change default concurrency policy and does not claim checkpoint saturation. M4 should use these frontier counters/semantics to coalesce checkpoint frontier work into larger span-native jobs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Checkpointing now respects a captured “frontier” to better bound what gets flushed, while keeping post-frontier data available.

* **Bug Fixes**
  * Improved checkpoint/writer synchronization so direct and exclusive writes properly re-check and resume after checkpointing pauses end.

* **Chores**
  * Expanded checkpoint and WAL cleanup instrumentation, including richer skip-reason coverage and frontier/post-flush unit/byte metrics.

* **Tests**
  * Added coverage for frontier drain behavior (normal, empty frontier, and missing queue ID) plus write-gate and dirty-root publish scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->