### PR TITLE
TreeDB: avoid nonproductive single-lane checkpoint sharing

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -8015,6 +8015,7 @@ type DB struct {
 	checkpointSharedDrainBackgroundUnits                         atomic.Uint64
 	checkpointSharedDrainBackgroundOps                           atomic.Uint64
 	checkpointSharedDrainBackgroundBytes                         atomic.Uint64
+	checkpointPreflushKickSkips                                  atomic.Uint64
 	checkpointWALCleanupConsideredLast                           atomic.Uint64
 	checkpointWALCleanupRemovedLast                              atomic.Uint64
 	checkpointWALCleanupSkippedCurrentLast                       atomic.Uint64
@@ -21584,12 +21585,20 @@ func (db *DB) Checkpoint() error {
 	db.mu.RUnlock()
 	db.observeCheckpointDebt(checkpointDebtMemtables, checkpointDebtBytes)
 	if (checkpointDebtMemtables > 0 || checkpointDebtBytes > 0) && (!db.disableJournal || db.relaxedSync) {
-		// Kick the continuous drainer before the explicit checkpoint tries to take
-		// ownership. With WAL enabled, any pre-checkpoint async drain remains covered
-		// by WAL until this checkpoint rotates/trims it. In strict WAL-disabled mode,
-		// do not pre-drain asynchronously: Checkpoint must own the synced flush
-		// boundary so success implies a backend sync.
-		db.TriggerFlush()
+		if db.flushApplyConcurrency > 1 {
+			// Parallel checkpoint drains should capture the frontier first instead of
+			// racing their own background kick and then waiting on flushMu. The shared
+			// frontier path below publishes a bounded active frontier and triggers
+			// background help after checkpoint owns the pre-frontier durability boundary.
+			db.checkpointPreflushKickSkips.Add(1)
+		} else {
+			// Kick the continuous drainer before the explicit checkpoint tries to take
+			// ownership. With WAL enabled, any pre-checkpoint async drain remains covered
+			// by WAL until this checkpoint rotates/trims it. In strict WAL-disabled mode,
+			// do not pre-drain asynchronously: Checkpoint must own the synced flush
+			// boundary so success implies a backend sync.
+			db.TriggerFlush()
+		}
 	}
 	activeBackgroundFlushBeforeWait := db.flushCoordinatorActive.Load() > 0 && db.flushCoordinatorInFlightBytes.Load() > 0
 	barrierWaitStart := time.Now()
@@ -21795,7 +21804,15 @@ func (db *DB) Checkpoint() error {
 	leafLogAppendWaitBefore := db.flushApplyLeafLogAppendWaitNs.Load()
 	reducerPublishBefore := db.backendFlushApplyReducerPublishNs()
 	flushAllStart := time.Now()
-	if commandWALPublishPiggyback != nil || len(frontier.ids) < 8 || frontier.bytes < 8<<20 {
+	frontierLaneCount := len(db.lanes)
+	if frontierLaneCount == 0 {
+		frontierLaneCount = 1
+	}
+	_, frontierActiveLanes := db.checkpointFrontierActiveLanes(frontier, frontierLaneCount)
+	// Same-lane background claims serialize on flushLaneMu and only make the
+	// checkpoint wait for another owner. Share the active frontier only when the
+	// frontier spans multiple lanes that can make independent progress.
+	if commandWALPublishPiggyback != nil || len(frontier.ids) < 8 || frontier.bytes < 8<<20 || frontierActiveLanes <= 1 {
 		db.flushCheckpointFrontierLocked(true, commandWALPublishPiggyback, frontier)
 	} else {
 		db.setActiveCheckpointFrontier(frontier)
@@ -27415,6 +27432,7 @@ func (db *DB) Stats() map[string]string {
 	stats["treedb.cache.checkpoint.shared_drain.background_units_total"] = fmt.Sprintf("%d", db.checkpointSharedDrainBackgroundUnits.Load())
 	stats["treedb.cache.checkpoint.shared_drain.background_ops_total"] = fmt.Sprintf("%d", db.checkpointSharedDrainBackgroundOps.Load())
 	stats["treedb.cache.checkpoint.shared_drain.background_bytes_total"] = fmt.Sprintf("%d", db.checkpointSharedDrainBackgroundBytes.Load())
+	stats["treedb.cache.checkpoint.preflush_kick_skips_total"] = fmt.Sprintf("%d", db.checkpointPreflushKickSkips.Load())
 	stats["treedb.cache.checkpoint.wal_cleanup.considered_last"] = fmt.Sprintf("%d", db.checkpointWALCleanupConsideredLast.Load())
 	stats["treedb.cache.checkpoint.wal_cleanup.removed_last"] = fmt.Sprintf("%d", db.checkpointWALCleanupRemovedLast.Load())
 	stats["treedb.cache.checkpoint.wal_cleanup.skipped_current_last"] = fmt.Sprintf("%d", db.checkpointWALCleanupSkippedCurrentLast.Load())

--- a/TreeDB/caching/flush_backlog_coalescing_test.go
+++ b/TreeDB/caching/flush_backlog_coalescing_test.go
@@ -613,6 +613,21 @@ func TestCheckpointActiveFrontierFiltersBackgroundFlush(t *testing.T) {
 	}
 }
 
+func TestCheckpointParallelDrainSkipsPreflushKick(t *testing.T) {
+	db, _ := newCoalescingTestDB(t, Options{
+		FlushApplyConcurrency: 4,
+		FlushApplySpanNative:  true,
+	}, highSingleOpCoalescingSnapshot())
+	enqueuePointMemtables(t, db, 2, "preflushskip")
+
+	if err := db.Checkpoint(); err != nil {
+		t.Fatalf("Checkpoint: %v", err)
+	}
+	if got := coalescingStatUint64(t, db, "treedb.cache.checkpoint.preflush_kick_skips_total"); got == 0 {
+		t.Fatalf("preflush kick skips=%d want >0", got)
+	}
+}
+
 func TestCheckpointSharedFrontierRecordsBackgroundAndCheckpointWork(t *testing.T) {
 	db, backend := newCoalescingTestDB(t, Options{}, highSingleOpCoalescingSnapshot())
 	enqueuePointMemtables(t, db, 3, "sharedfrontier")

--- a/cmd/unified_bench/main.go
+++ b/cmd/unified_bench/main.go
@@ -6361,6 +6361,7 @@ func renderTreeDBSelectedStatsString(instances []*DBInstance, treeStats map[stri
 		{label: "flush_apply.cache.coordinator.hard_overload_fallbacks_total", alts: []string{"treedb.cache.flush_apply.coordinator.hard_overload_fallbacks_total"}},
 		{label: "checkpoint.flushmu_wait_total_ms", alts: []string{"treedb.cache.checkpoint.flushmu_wait_total_ms"}},
 		{label: "checkpoint.active_background_flush_wait_ns_total", alts: []string{"treedb.cache.checkpoint.active_background_flush_wait_ns_total"}},
+		{label: "checkpoint.preflush_kick_skips_total", alts: []string{"treedb.cache.checkpoint.preflush_kick_skips_total"}},
 		{label: "checkpoint.shared_drain.flushmu_releases_total", alts: []string{"treedb.cache.checkpoint.shared_drain.flushmu_releases_total"}},
 		{label: "checkpoint.shared_drain.checkpoint_units_total", alts: []string{"treedb.cache.checkpoint.shared_drain.checkpoint_units_total"}},
 		{label: "checkpoint.shared_drain.background_units_total", alts: []string{"treedb.cache.checkpoint.shared_drain.background_units_total"}},


### PR DESCRIPTION
## Summary

- skip the old checkpoint pre-flush background kick when parallel span-native checkpoint drains are enabled, so checkpoint captures/owns the frontier instead of racing its own `TriggerFlush` and then waiting on `flushMu`
- keep #2913 shared-frontier support, but only publish an active shared frontier when the checkpoint frontier spans multiple active lanes; single-lane background claims serialize on `flushLaneMu` and are now avoided as nonproductive
- add `treedb.cache.checkpoint.preflush_kick_skips_total` and surface it in unified-bench selected TreeDB stats
- add focused coverage that parallel checkpoint drains skip the pre-flush kick

Fixes #2905. Parent: #2899. Depends on #2913 / PR #2914.

## Gate status

M5 status: **pass with measured next limiter routed to M6/M7**.

#2913 proved the shared frontier coordinator, but the 10MM production shape has one active checkpoint lane. Letting background claim the same lane was genuine participation but nonproductive: it serialized on `flushLaneMu`, increased `flush_all`, and made checkpoint wait for another owner. M5 now uses the #2913 coordinator when multiple lanes can independently progress, and otherwise keeps the checkpoint-owned span-native drain for the single-lane production frontier.

Remaining limiter: active background flush wait / fan-in. This is already the stated M6/M7 territory; this PR does not claim to remove that limiter.

## Evidence

Artifacts:

- c4: `<remote-profile-root>/treedb_2905_single_lane_direct_noyield_c4_20260620_182515`
- c8: `<remote-profile-root>/treedb_2905_single_lane_direct_noyield_c8_20260620_182716`

Command shape: standard #2899 10MM explicit span-native/backlog-coalescing run with checkpoint-between-tests and `benchprof`.

| row | seq ops/s | batch ops/s | random ops/s | checkpoint after batch | checkpoint after random | post-run checkpoint | busy ratio | effective cores | flush_all total | active_bg_wait | close/checkpoint fallback | checkpoint units | background units |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| c4 | 2,448,568 | 560,773 | 260,199 | 1.24s | 6.86s | 11.03s | 96.9% | 3.69 | 12.78s | 27.13s | 0 | 64 | 0 |
| c8 | 2,382,208 | 577,415 | 282,637 | 1.42s | 6.54s | 11.23s | 96.6% | 7.22 | 17.70s | 16.71s | 0 | 80 | 0 |

Comparison to #2913 c4 review-fix profile:

- #2913 c4 random: 234,028/s; M5 c4 random: 260,199/s
- #2913 c4 after-random checkpoint: 8.04s; M5 c4: 6.86s
- #2913 c4 `flush_all`: 21.05s; M5 c4: 12.78s

## Tests

```sh
GOWORK=off go test ./TreeDB/caching -run 'TestCheckpointParallelDrainSkipsPreflushKick|TestCheckpointSharedFrontierRecordsBackgroundAndCheckpointWork|TestCachingDB_CheckpointWaiterReleasesFlushMu' -count=3
GOWORK=off go test ./TreeDB ./TreeDB/caching ./TreeDB/db -run 'SpanNative|Checkpoint|FlushBacklogCoalescing|FlushApply|CommandWAL|DomainIngress|Batch|RootPublish|DeleteRange|ReopenVerify_LeafPageLogGroupedFrameCRCIntegrityModes' -count=1
GOWORK=off go test -race ./TreeDB/caching -run 'TestCheckpointParallelDrainSkipsPreflushKick|TestCheckpointSharedFrontierRecordsBackgroundAndCheckpointWork|TestCheckpointActiveFrontierFiltersBackgroundFlush|TestCheckpointFrontierDrainLeavesPostFrontierQueued|TestCheckpointEmptyFrontierLeavesPostFrontierQueued|TestCachingDB_CheckpointWaiterReleasesFlushMu' -count=1
GOWORK=off go test ./TreeDB/...
GOWORK=off go test ./cmd/unified_bench -run 'TestTreeDBStats|TestBenchprof|Profile|Report' -count=1
```

All passed locally.

## Safety notes

- Command-WAL piggyback drains remain checkpoint-owned.
- Single-lane frontiers avoid background sharing because it is measured nonproductive serialization, not parallel progress.
- Multi-lane frontiers retain #2913 active-frontier sharing and tests.
- Final sync/WAL cleanup remains checkpoint-exclusive.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new observable metric for checkpoint parallel drain operations to enhance visibility into caching system performance metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->