### PR TITLE
TreeDB: multi-lane leaf-log writer substrate (stacked on #2935)

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -2819,7 +2819,13 @@ func (db *DB) valueLogLaneForFileID(fileID uint32) *lane {
 		return db.valueLogLaneByID(int(laneID))
 	}
 	for _, l := range db.leafLogAppendLanesSnapshot() {
-		if l != nil && db.currentValueLogSeq(l) == int(seq) {
+		if l == nil {
+			continue
+		}
+		l.vlogMu.Lock()
+		matches := l.vlogSeq == int(seq) && (l.vlogPath != "" || l.vlog != nil)
+		l.vlogMu.Unlock()
+		if matches {
 			return l
 		}
 	}

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -2811,7 +2811,7 @@ func (db *DB) valueLogLaneByID(laneID int) *lane {
 }
 
 func (db *DB) isLeafLogAppendLane(l *lane) bool {
-	if db == nil || !db.indexOuterLeavesInValueLog || l == nil {
+	if db == nil || !db.indexOuterLeavesInValueLog || l == nil || l.id != leafLogLaneID {
 		return false
 	}
 	if l == &db.leafLog {

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -7196,8 +7196,10 @@ func (db *DB) reconcileSplitValueLogWritersAfterBackendMaintenance() error {
 		}
 	}
 	if db.indexOuterLeavesInValueLog {
+		observedMaxSeq := maxSeqByLane[leafLogLaneID]
+		db.advanceLeafLogAppendSeqAtLeast(observedMaxSeq)
 		for _, l := range db.leafLogAppendLanesSnapshot() {
-			if err := db.advanceValueLogWriterPastObservedSeq(l, maxSeqByLane[leafLogLaneID]); err != nil {
+			if err := db.advanceLeafLogAppendWriterPastObservedSeq(l, observedMaxSeq); err != nil {
 				return err
 			}
 		}
@@ -7205,12 +7207,33 @@ func (db *DB) reconcileSplitValueLogWritersAfterBackendMaintenance() error {
 	return nil
 }
 
-func (db *DB) advanceValueLogWriterPastObservedSeq(l *lane, observedMaxSeq int) error {
+func (db *DB) advanceLeafLogAppendWriterPastObservedSeq(l *lane, observedMaxSeq int) error {
 	if db == nil || l == nil || observedMaxSeq <= 0 {
 		return nil
 	}
-	if db.isLeafLogAppendLane(l) {
-		db.advanceLeafLogAppendSeqAtLeast(observedMaxSeq)
+	l.vlogMu.Lock()
+	defer l.vlogMu.Unlock()
+	if observedMaxSeq <= l.vlogSeq {
+		return nil
+	}
+	if l.vlog == nil {
+		l.vlogSeq = observedMaxSeq
+		l.vlogPath = ""
+		l.vlogCaps = vlogWriterCaps{}
+		l.vlogModeSet = false
+		l.vlogModeWriter = nil
+		return nil
+	}
+	nextSeq, err := db.nextLeafLogAppendSeq()
+	if err != nil {
+		return err
+	}
+	return db.rotateValueLogMuHeldToSeq(l, nextSeq)
+}
+
+func (db *DB) advanceValueLogWriterPastObservedSeq(l *lane, observedMaxSeq int) error {
+	if db == nil || l == nil || observedMaxSeq <= 0 {
+		return nil
 	}
 	l.vlogMu.Lock()
 	defer l.vlogMu.Unlock()
@@ -24850,7 +24873,11 @@ func (db *DB) rotateValueLogMuHeldToSeq(l *lane, nextSeq int) error {
 		l.vlogSeq = nextSeq
 		l.vlogLiveBytes.Store(0)
 	}
-	if err := db.registerValueLogSegment(path, fileID); err != nil {
+	previousFileID := uint32(0)
+	if oldSeq > 0 && oldPath != "" {
+		previousFileID, _ = valuelog.EncodeFileID(uint32(l.id), uint32(oldSeq))
+	}
+	if err := db.registerValueLogSegmentReplacing(path, fileID, previousFileID); err != nil {
 		if oldPath != "" {
 			if hadClosedPrev {
 				l.vlogClosedSizes[oldPath] = closedPrev
@@ -24916,6 +24943,10 @@ func (db *DB) restoreValueLogWriterMuHeld(l *lane, path string, seq int) error {
 }
 
 func (db *DB) registerValueLogSegment(path string, fileID uint32) error {
+	return db.registerValueLogSegmentReplacing(path, fileID, 0)
+}
+
+func (db *DB) registerValueLogSegmentReplacing(path string, fileID, previousFileID uint32) error {
 	if db == nil {
 		return nil
 	}
@@ -24926,10 +24957,21 @@ func (db *DB) registerValueLogSegment(path string, fileID uint32) error {
 		if err := db.valueLogReader.RegisterSegment(path, fileID); err != nil {
 			return err
 		}
-		if err := db.valueLogReader.PromoteCurrentWritable(fileID); err != nil {
+		if err := db.valueLogReader.PromoteCurrentWritableReplacing(fileID, previousFileID); err != nil {
 			_ = db.valueLogReader.RemoveSegment(fileID)
 			return err
 		}
+	}
+	if registrar, ok := db.backend.(interface {
+		RegisterValueLogSegmentReplacing(path string, fileID, previousFileID uint32) error
+	}); ok {
+		if err := registrar.RegisterValueLogSegmentReplacing(path, fileID, previousFileID); err != nil {
+			if db.valueLogReader != nil {
+				_ = db.valueLogReader.RemoveSegment(fileID)
+			}
+			return err
+		}
+		return nil
 	}
 	if registrar, ok := db.backend.(interface {
 		RegisterValueLogSegment(path string, fileID uint32) error

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -2791,7 +2791,7 @@ func (db *DB) valueLogDirForLane(l *lane) string {
 	if db == nil {
 		return ""
 	}
-	if l != nil && db.indexOuterLeavesInValueLog && l == &db.leafLog && l.id == leafLogLaneID && db.leafLogDir != "" {
+	if db.isLeafLogAppendLane(l) && db.leafLogDir != "" {
 		return db.leafLogDir
 	}
 	return db.valueLogDir
@@ -2807,6 +2807,141 @@ func (db *DB) valueLogLaneByID(laneID int) *lane {
 	if laneID == leafLogLaneID && db.indexOuterLeavesInValueLog {
 		return &db.leafLog
 	}
+	return nil
+}
+
+func (db *DB) isLeafLogAppendLane(l *lane) bool {
+	if db == nil || !db.indexOuterLeavesInValueLog || l == nil {
+		return false
+	}
+	if l == &db.leafLog {
+		return true
+	}
+	db.leafLogAppendMu.RLock()
+	defer db.leafLogAppendMu.RUnlock()
+	for _, lane := range db.leafLogAppendLanes {
+		if lane == l {
+			return true
+		}
+	}
+	return false
+}
+
+func (db *DB) leafLogAppendCompressionSelector() *vlogCompressionSelector {
+	if db == nil || !db.indexOuterLeavesInValueLog {
+		return nil
+	}
+	seedCodec := db.valueLogBlockCodec
+	if normalizeVlogCompressionMode(db.valueLogCompressionMode) == vlogCompressionAuto && normalizeVlogAutoPolicy(db.valueLogAutoPolicy) != vlogAutoThroughput {
+		seedCodec = valuelog.BlockCodecLZ4
+	}
+	return newVlogCompressionSelectorWithSeed(
+		normalizeVlogAutoPolicy(db.valueLogAutoPolicy),
+		uint64(db.valueLogIncompressibleHold),
+		uint64(db.valueLogIncompressibleProbe),
+		seedCodec,
+	)
+}
+
+func (db *DB) initLeafLogAppendState(maxLeafVlogSeq int) {
+	if db == nil || !db.indexOuterLeavesInValueLog {
+		return
+	}
+	db.leafLogAppendMu.Lock()
+	defer db.leafLogAppendMu.Unlock()
+	db.leafLogAppendSeq.Store(uint32(maxLeafVlogSeq))
+	db.leafLogAppendLanes = []*lane{&db.leafLog}
+}
+
+func (db *DB) leafLogAppendLanesSnapshot() []*lane {
+	if db == nil || !db.indexOuterLeavesInValueLog {
+		return nil
+	}
+	db.leafLogAppendMu.RLock()
+	defer db.leafLogAppendMu.RUnlock()
+	if len(db.leafLogAppendLanes) == 0 {
+		return []*lane{&db.leafLog}
+	}
+	return append([]*lane(nil), db.leafLogAppendLanes...)
+}
+
+func (db *DB) leafLogAppendLaneForWorkerIndex(workerIndex int) *lane {
+	if db == nil || !db.indexOuterLeavesInValueLog {
+		return nil
+	}
+	if workerIndex <= 0 {
+		return &db.leafLog
+	}
+	db.leafLogAppendMu.Lock()
+	if len(db.leafLogAppendLanes) == 0 {
+		db.leafLogAppendLanes = []*lane{&db.leafLog}
+	}
+	for len(db.leafLogAppendLanes) <= workerIndex {
+		db.leafLogAppendLanes = append(db.leafLogAppendLanes, nil)
+	}
+	l := db.leafLogAppendLanes[workerIndex]
+	if l == nil {
+		l = &lane{
+			id:                      leafLogLaneID,
+			vlogGenerationClass:     db.leafLog.vlogGenerationClass,
+			vlogCompressionSelector: db.leafLogAppendCompressionSelector(),
+			vlogSeq:                 int(db.leafLogAppendSeq.Load()),
+		}
+		db.startVlogWriter(l)
+		db.leafLogAppendLanes[workerIndex] = l
+	}
+	db.leafLogAppendMu.Unlock()
+	return l
+}
+
+func (db *DB) advanceLeafLogAppendSeqAtLeast(seq int) {
+	if db == nil || !db.indexOuterLeavesInValueLog || seq <= 0 {
+		return
+	}
+	need := uint32(seq)
+	for {
+		cur := db.leafLogAppendSeq.Load()
+		if cur >= need {
+			return
+		}
+		if db.leafLogAppendSeq.CompareAndSwap(cur, need) {
+			return
+		}
+	}
+}
+
+func (db *DB) nextLeafLogAppendSeq() (int, error) {
+	if db == nil || !db.indexOuterLeavesInValueLog {
+		return 0, errWALUnavailable
+	}
+	for {
+		cur := db.leafLogAppendSeq.Load()
+		next := cur + 1
+		if next <= cur {
+			return 0, fmt.Errorf("cachingdb: leaf log sequence space exhausted")
+		}
+		if db.leafLogAppendSeq.CompareAndSwap(cur, next) {
+			return int(next), nil
+		}
+	}
+}
+
+func (db *DB) closeLeafValueLogLane(l *lane) error {
+	if db == nil || l == nil {
+		return nil
+	}
+	l.vlogMu.Lock()
+	defer l.vlogMu.Unlock()
+	if l.vlog != nil {
+		if err := l.vlog.Close(); err != nil {
+			return err
+		}
+		l.vlog = nil
+	}
+	l.vlogCaps = vlogWriterCaps{}
+	l.vlogLiveBytes.Store(0)
+	l.vlogModeSet = false
+	l.vlogModeWriter = nil
 	return nil
 }
 
@@ -2880,11 +3015,16 @@ func (db *DB) currentValueLogPaths() []string {
 		l.walMu.Unlock()
 	}
 	if db.indexOuterLeavesInValueLog && db.splitValueLogEnabled() {
-		db.leafLog.vlogMu.Lock()
-		if db.leafLog.vlogPath != "" {
-			paths = append(paths, db.leafLog.vlogPath)
+		for _, l := range db.leafLogAppendLanesSnapshot() {
+			if l == nil {
+				continue
+			}
+			l.vlogMu.Lock()
+			if l.vlogPath != "" {
+				paths = append(paths, l.vlogPath)
+			}
+			l.vlogMu.Unlock()
 		}
-		db.leafLog.vlogMu.Unlock()
 	}
 	return paths
 }
@@ -4474,16 +4614,21 @@ func (db *DB) valueLogRetainedStatsDetailed() valueLogRetainedGenerationStats {
 			l.vlogMu.Unlock()
 		}
 		if db.indexOuterLeavesInValueLog {
-			db.leafLog.vlogMu.Lock()
-			for path, size := range db.leafLog.vlogClosedSizes {
-				pathSizes[path] = size
-				pathClasses[path] = db.leafLog.vlogGenerationClass
+			for _, l := range db.leafLogAppendLanesSnapshot() {
+				if l == nil {
+					continue
+				}
+				l.vlogMu.Lock()
+				for path, size := range l.vlogClosedSizes {
+					pathSizes[path] = size
+					pathClasses[path] = l.vlogGenerationClass
+				}
+				if l.vlogPath != "" {
+					currentSizes[l.vlogPath] = l.vlogLiveBytes.Load()
+					pathClasses[l.vlogPath] = l.vlogGenerationClass
+				}
+				l.vlogMu.Unlock()
 			}
-			if db.leafLog.vlogPath != "" {
-				currentSizes[db.leafLog.vlogPath] = db.leafLog.vlogLiveBytes.Load()
-				pathClasses[db.leafLog.vlogPath] = db.leafLog.vlogGenerationClass
-			}
-			db.leafLog.vlogMu.Unlock()
 		}
 	} else {
 		for i := range db.lanes {
@@ -4825,17 +4970,21 @@ func (db *DB) BeginValueLogMaintenanceFence(ctx context.Context) (func(), error)
 		l.vlogMu.Unlock()
 	}
 	if db.indexOuterLeavesInValueLog {
-		l := &db.leafLog
-		l.vlogMu.Lock()
-		if l.vlogPath != "" {
-			db.markValueLogRetain(l.vlogPath)
-			err := db.rotateValueLogMuHeld(l)
-			l.vlogMu.Unlock()
-			if err != nil {
-				unlock()
-				return nil, err
+		for _, l := range db.leafLogAppendLanesSnapshot() {
+			if l == nil {
+				continue
 			}
-		} else {
+			l.vlogMu.Lock()
+			if l.vlogPath != "" {
+				db.markValueLogRetain(l.vlogPath)
+				err := db.rotateValueLogMuHeld(l)
+				l.vlogMu.Unlock()
+				if err != nil {
+					unlock()
+					return nil, err
+				}
+				continue
+			}
 			l.vlogMu.Unlock()
 		}
 	}
@@ -5631,8 +5780,12 @@ func (db *DB) allowValueLogPointers() bool {
 				bytes += l.vlogLiveBytes.Load()
 			}
 		}
-		if db.indexOuterLeavesInValueLog && db.leafLog.vlogPath != "" && db.leafLog.vlogPath == db.leafLog.vlogRetainedPath {
-			bytes += db.leafLog.vlogLiveBytes.Load()
+		if db.indexOuterLeavesInValueLog {
+			for _, l := range db.leafLogAppendLanesSnapshot() {
+				if l != nil && l.vlogPath != "" && l.vlogPath == l.vlogRetainedPath {
+					bytes += l.vlogLiveBytes.Load()
+				}
+			}
 		}
 	}
 	if bytes >= limit {
@@ -7031,8 +7184,10 @@ func (db *DB) reconcileSplitValueLogWritersAfterBackendMaintenance() error {
 		}
 	}
 	if db.indexOuterLeavesInValueLog {
-		if err := db.advanceValueLogWriterPastObservedSeq(&db.leafLog, maxSeqByLane[leafLogLaneID]); err != nil {
-			return err
+		for _, l := range db.leafLogAppendLanesSnapshot() {
+			if err := db.advanceValueLogWriterPastObservedSeq(l, maxSeqByLane[leafLogLaneID]); err != nil {
+				return err
+			}
 		}
 	}
 	return nil
@@ -7041,6 +7196,9 @@ func (db *DB) reconcileSplitValueLogWritersAfterBackendMaintenance() error {
 func (db *DB) advanceValueLogWriterPastObservedSeq(l *lane, observedMaxSeq int) error {
 	if db == nil || l == nil || observedMaxSeq <= 0 {
 		return nil
+	}
+	if db.isLeafLogAppendLane(l) {
+		db.advanceLeafLogAppendSeqAtLeast(observedMaxSeq)
 	}
 	l.vlogMu.Lock()
 	defer l.vlogMu.Unlock()
@@ -7118,7 +7276,7 @@ func (db *DB) valueLogMaxSegmentBytesForLane(l *lane) int64 {
 		return base
 	}
 	target := int64(0)
-	if db.indexOuterLeavesInValueLog && l == &db.leafLog && db.valueLogGenerationLeafTarget > 0 {
+	if db.isLeafLogAppendLane(l) && db.valueLogGenerationLeafTarget > 0 {
 		target = db.valueLogGenerationLeafTarget
 	} else {
 		switch l.vlogGenerationClass {
@@ -7721,16 +7879,19 @@ type DB struct {
 	backendRangeErr               error
 
 	// Durability
-	lanes         []lane
-	leafLog       lane
-	laneMu        sync.Mutex
-	laneCond      *sync.Cond
-	nextLane      int
-	flushLaneMu   []sync.Mutex
-	nextCommitSeq atomic.Uint64
-	walAckMu      sync.Mutex
-	walErr        error
-	nextRID       atomic.Uint64
+	lanes              []lane
+	leafLog            lane
+	leafLogAppendMu    sync.RWMutex
+	leafLogAppendLanes []*lane
+	leafLogAppendSeq   atomic.Uint32
+	laneMu             sync.Mutex
+	laneCond           *sync.Cond
+	nextLane           int
+	flushLaneMu        []sync.Mutex
+	nextCommitSeq      atomic.Uint64
+	walAckMu           sync.Mutex
+	walErr             error
+	nextRID            atomic.Uint64
 
 	// Legacy flags removed from public options; retained internally for code paths.
 	disableValueLog            bool
@@ -11018,12 +11179,8 @@ func Open(dir string, backend BackendDB, opts Options) (*DB, error) {
 		db.leafLog.id = leafLogLaneID
 		db.leafLog.vlogSeq = maxLeafVlogSeq
 		db.leafLog.vlogGenerationClass = vlogGenerationClassHot
-		db.leafLog.vlogCompressionSelector = newVlogCompressionSelectorWithSeed(
-			valueLogAutoPolicy,
-			uint64(valueLogIncompressibleHold),
-			uint64(valueLogIncompressibleProbe),
-			selectorSeedCodec,
-		)
+		db.leafLog.vlogCompressionSelector = db.leafLogAppendCompressionSelector()
+		db.initLeafLogAppendState(maxLeafVlogSeq)
 	}
 	if maxExistingRID > 0 {
 		db.nextRID.Store(maxExistingRID)
@@ -15010,7 +15167,7 @@ func (db *DB) appendValueLog(l *lane, dictID uint64, dict []byte, records []valu
 		wallStart = db.valueLogAutotuneMetrics.now()
 	}
 	selectorStart := time.Now()
-	leafLogAppend := db != nil && l == &db.leafLog
+	leafLogAppend := db != nil && db.isLeafLogAppendLane(l)
 	appendWallStart := time.Time{}
 	appendWait := time.Duration(0)
 	if leafLogAppend {
@@ -15806,7 +15963,7 @@ func (db *DB) appendValueLogOneInternal(l *lane, dictID uint64, dict []byte, rid
 		wallStart = db.valueLogAutotuneMetrics.now()
 	}
 	selectorStart := time.Now()
-	leafLogAppend := db != nil && l == &db.leafLog
+	leafLogAppend := db != nil && db.isLeafLogAppendLane(l)
 	appendWallStart := time.Time{}
 	appendWait := time.Duration(0)
 	if leafLogAppend {
@@ -22545,16 +22702,11 @@ func (db *DB) Close() error {
 		l.vlogMu.Unlock()
 	}
 	if db.indexOuterLeavesInValueLog {
-		db.leafLog.vlogMu.Lock()
-		if db.leafLog.vlog != nil {
-			_ = db.leafLog.vlog.Close()
-			db.leafLog.vlog = nil
-			db.leafLog.vlogCaps = vlogWriterCaps{}
-			db.leafLog.vlogLiveBytes.Store(0)
+		for _, l := range db.leafLogAppendLanesSnapshot() {
+			if err := db.closeLeafValueLogLane(l); err != nil {
+				errs = append(errs, err)
+			}
 		}
-		db.leafLog.vlogModeSet = false
-		db.leafLog.vlogModeWriter = nil
-		db.leafLog.vlogMu.Unlock()
 	}
 
 	if walBytes > 0 && !hadMemtables {
@@ -24580,6 +24732,13 @@ func (db *DB) rotateValueLogLocked(l *lane) error {
 }
 
 func (db *DB) rotateValueLogMuHeld(l *lane) error {
+	if db.isLeafLogAppendLane(l) {
+		nextSeq, err := db.nextLeafLogAppendSeq()
+		if err != nil {
+			return err
+		}
+		return db.rotateValueLogMuHeldToSeq(l, nextSeq)
+	}
 	return db.rotateValueLogMuHeldToSeq(l, l.vlogSeq+1)
 }
 
@@ -24599,6 +24758,9 @@ func (db *DB) ensureValueLogWriterMuHeld(l *lane) error {
 func (db *DB) rotateValueLogMuHeldToSeq(l *lane, nextSeq int) error {
 	if l == nil {
 		return errWALUnavailable
+	}
+	if db.isLeafLogAppendLane(l) {
+		db.advanceLeafLogAppendSeqAtLeast(nextSeq)
 	}
 	if nextSeq <= l.vlogSeq {
 		return nil
@@ -24699,7 +24861,7 @@ func (db *DB) rotateValueLogMuHeldToSeq(l *lane, nextSeq int) error {
 	}
 	l.vlogPath = path
 	l.vlogLiveBytes.Store(0)
-	if db.indexOuterLeavesInValueLog && l == &db.leafLog && l.id == leafLogLaneID {
+	if db.isLeafLogAppendLane(l) {
 		l.vlogCreatedSegments = append(l.vlogCreatedSegments, laneValueLogSegment{path: path, fileID: fileID})
 	}
 	return nil
@@ -24811,18 +24973,33 @@ func (db *DB) untrackValueLogSegmentLocked(path string) {
 	if !ok {
 		return
 	}
+	if laneID == leafLogLaneID && db.indexOuterLeavesInValueLog {
+		for _, l := range db.leafLogAppendLanesSnapshot() {
+			if db.untrackValueLogSegmentFromLane(l, path) {
+				return
+			}
+		}
+		return
+	}
 	l := db.valueLogLaneByID(laneID)
 	if l == nil {
 		return
 	}
+	db.untrackValueLogSegmentFromLane(l, path)
+}
+
+func (db *DB) untrackValueLogSegmentFromLane(l *lane, path string) bool {
+	if db == nil || l == nil {
+		return false
+	}
 	l.vlogMu.Lock()
 	defer l.vlogMu.Unlock()
 	if l.vlogClosedSizes == nil || path == "" {
-		return
+		return false
 	}
 	size, ok := l.vlogClosedSizes[path]
 	if !ok {
-		return
+		return false
 	}
 	delete(l.vlogClosedSizes, path)
 	db.valueLogRetainedClosedBytes.Add(-size)
@@ -24836,6 +25013,7 @@ func (db *DB) untrackValueLogSegmentLocked(path string) {
 			break
 		}
 	}
+	return true
 }
 
 func (db *DB) flushLoop() {

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -2810,6 +2810,22 @@ func (db *DB) valueLogLaneByID(laneID int) *lane {
 	return nil
 }
 
+func (db *DB) valueLogLaneForFileID(fileID uint32) *lane {
+	if db == nil || fileID == 0 {
+		return nil
+	}
+	laneID, seq := valuelog.DecodeFileID(fileID)
+	if laneID != leafLogLaneID || !db.indexOuterLeavesInValueLog {
+		return db.valueLogLaneByID(int(laneID))
+	}
+	for _, l := range db.leafLogAppendLanesSnapshot() {
+		if l != nil && db.currentValueLogSeq(l) == int(seq) {
+			return l
+		}
+	}
+	return nil
+}
+
 func (db *DB) isLeafLogAppendLane(l *lane) bool {
 	if db == nil || !db.indexOuterLeavesInValueLog || l == nil || l.id != leafLogLaneID {
 		return false
@@ -4026,19 +4042,24 @@ func (db *DB) readValueLogAppend(key []byte, ptr page.ValuePtr, dst []byte) ([]b
 }
 
 func (db *DB) flushValueLogForPtr(ptr page.ValuePtr) error {
+	_, err := db.flushValueLogForFileIDWithSize(ptr.FileID)
+	return err
+}
+
+func (db *DB) flushValueLogForFileIDWithSize(fileID uint32) (int64, error) {
 	if !db.valueLogEnabled() {
-		return nil
+		return -1, nil
 	}
-	laneID, seq := valuelog.DecodeFileID(ptr.FileID)
-	l := db.valueLogLaneByID(int(laneID))
+	_, seq := valuelog.DecodeFileID(fileID)
+	l := db.valueLogLaneForFileID(fileID)
 	if l == nil {
-		return nil
+		return -1, nil
 	}
 	currentSeq := db.currentValueLogSeq(l)
 	if currentSeq == int(seq) {
-		return db.flushValueLogLane(l)
+		return db.flushValueLogLaneWithSize(l)
 	}
-	return nil
+	return -1, nil
 }
 
 func (db *DB) flushValueLog(laneIDs ...int) error {
@@ -4186,7 +4207,7 @@ func dispatchBackendValueLogReadBarrierWithSize(key uintptr, fileID uint32) (int
 	if len(dbs) == 0 {
 		return -1, nil
 	}
-	laneID, seq := valuelog.DecodeFileID(fileID)
+	_, seq := valuelog.DecodeFileID(fileID)
 	var firstErr error
 	flushedAny := false
 	size := int64(-1)
@@ -4195,7 +4216,7 @@ func dispatchBackendValueLogReadBarrierWithSize(key uintptr, fileID uint32) (int
 		if db == nil || db.closing.Load() {
 			continue
 		}
-		l := db.valueLogLaneByID(int(laneID))
+		l := db.valueLogLaneForFileID(fileID)
 		if l == nil {
 			continue
 		}
@@ -4240,12 +4261,7 @@ func (db *DB) installBackendValueLogReadBarrier() {
 		key := backendValueLogReadBarrierKey(db.backend)
 		if key == 0 {
 			barrierSetter.SetCurrentValueLogReadBarrierWithSize(func(fileID uint32) (int64, error) {
-				laneID, _ := valuelog.DecodeFileID(fileID)
-				l := db.valueLogLaneByID(int(laneID))
-				if l == nil {
-					return -1, nil
-				}
-				return db.flushValueLogLaneWithSize(l)
+				return db.flushValueLogForFileIDWithSize(fileID)
 			})
 			return
 		}
@@ -4262,12 +4278,8 @@ func (db *DB) installBackendValueLogReadBarrier() {
 	key := backendValueLogReadBarrierKey(db.backend)
 	if key == 0 {
 		barrierSetter.SetCurrentValueLogReadBarrier(func(fileID uint32) error {
-			laneID, _ := valuelog.DecodeFileID(fileID)
-			l := db.valueLogLaneByID(int(laneID))
-			if l == nil {
-				return nil
-			}
-			return db.flushValueLogLane(l)
+			_, err := db.flushValueLogForFileIDWithSize(fileID)
+			return err
 		})
 		return
 	}
@@ -10864,6 +10876,7 @@ func Open(dir string, backend BackendDB, opts Options) (*DB, error) {
 	}
 	reader.SetDisableReadChecksum(opts.DisableReadChecksum)
 	reader.SetCurrentWritableMmapEnabled(opts.ValueLogCurrentWritableMmap)
+	reader.SetMultiCurrentWritableLane(valuelog.ReservedLeafLogLaneID, opts.IndexOuterLeavesInValueLog)
 	valueLogReader := reader
 	debugFlushPointers := envBool(envDebugFlushPointers)
 	debugFlushTiming := envBool(envDebugFlushTiming)
@@ -11319,6 +11332,11 @@ func Open(dir string, backend BackendDB, opts Options) (*DB, error) {
 				return currentZipperParallelMergePressure()
 			})
 		}
+	}
+	if db.valueLogReader != nil {
+		db.valueLogReader.SetCurrentWritableReadBarrierWithSize(func(fileID uint32) (int64, error) {
+			return db.flushValueLogForFileIDWithSize(fileID)
+		})
 	}
 	db.installBackendValueLogReadBarrier()
 

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -10703,10 +10703,10 @@ func Open(dir string, backend BackendDB, opts Options) (*DB, error) {
 	segments, _ := listNonEmptySplitLogSegments(walDir, valueLogDir, leafLogDir)
 	reserveLeafLogLane := opts.IndexOuterLeavesInValueLog
 	// Cached value-log RIDs remain globally unique across reopen/rewrite cycles.
-	// RID allocation is monotonic, so each lane's latest non-empty value-log
-	// segment contains that lane's high-watermark. Scanning only those tail
-	// segments avoids a full value-log pass during clean geth restarts while still
-	// seeding the allocator above every valid on-disk RID produced by this path.
+	// RID allocation is monotonic, so each non-leaf lane's latest non-empty
+	// value-log segment contains that lane's high-watermark. Leaf-log append lanes
+	// share one encoded lane across multiple physical writers, so their RID seed
+	// scans every non-empty reserved leaf-log segment.
 	maxExistingRID, err := maxValueLogRIDFromSegments(segments)
 	if err != nil {
 		return nil, err
@@ -32961,7 +32961,7 @@ func listNonEmptySplitLogSegments(walDir, valueLogDir, leafLogDir string) (segme
 
 func maxValueLogRIDFromSegments(segments []logSegmentInfo) (uint64, error) {
 	var maxRID uint64
-	for _, seg := range tailValueLogSegmentsByLane(segments) {
+	for _, seg := range ridSeedValueLogSegments(segments) {
 		if !seg.valueLog || seg.size <= 0 || seg.lane < 0 || seg.seq < 0 {
 			continue
 		}
@@ -32998,13 +32998,43 @@ func maxValueLogRIDFromSegments(segments []logSegmentInfo) (uint64, error) {
 	return maxRID, nil
 }
 
+func ridSeedValueLogSegments(segments []logSegmentInfo) []logSegmentInfo {
+	if len(segments) == 0 {
+		return nil
+	}
+	out := make([]logSegmentInfo, 0, len(segments))
+	for _, seg := range segments {
+		if !seg.valueLog || seg.size <= 0 || seg.lane < 0 || seg.seq < 0 {
+			continue
+		}
+		if seg.lane == leafLogLaneID {
+			out = append(out, seg)
+		}
+	}
+	out = append(out, tailValueLogSegmentsByLaneExcept(segments, leafLogLaneID)...)
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].lane != out[j].lane {
+			return out[i].lane < out[j].lane
+		}
+		if out[i].seq != out[j].seq {
+			return out[i].seq < out[j].seq
+		}
+		return out[i].path < out[j].path
+	})
+	return out
+}
+
 func tailValueLogSegmentsByLane(segments []logSegmentInfo) []logSegmentInfo {
+	return tailValueLogSegmentsByLaneExcept(segments, -1)
+}
+
+func tailValueLogSegmentsByLaneExcept(segments []logSegmentInfo, exceptLane int) []logSegmentInfo {
 	if len(segments) == 0 {
 		return nil
 	}
 	tailByLane := make(map[int]logSegmentInfo)
 	for _, seg := range segments {
-		if !seg.valueLog || seg.size <= 0 || seg.lane < 0 || seg.seq < 0 {
+		if !seg.valueLog || seg.size <= 0 || seg.lane < 0 || seg.seq < 0 || seg.lane == exceptLane {
 			continue
 		}
 		prev, ok := tailByLane[seg.lane]

--- a/TreeDB/caching/leaf_page_log.go
+++ b/TreeDB/caching/leaf_page_log.go
@@ -32,6 +32,9 @@ type compactLeafLogPayloadScratchPtrRef struct {
 }
 
 func newCachingLeafPageLog(db *DB, l *lane) backenddb.LeafPageLog {
+	if db != nil && db.indexOuterLeavesInValueLog && l == &db.leafLog {
+		return &cachingLeafPageLogGroup{db: db}
+	}
 	return &cachingLeafPageLog{db: db, lane: l}
 }
 
@@ -83,6 +86,23 @@ func (l *cachingLeafPageLog) CreatedLeafPageLogSegmentsSnapshot() ([]backenddb.L
 	return out, nil
 }
 
+func (l *cachingLeafPageLog) CurrentLeafPageLogSegmentsSnapshot() ([]backenddb.LeafPageLogSegment, error) {
+	if l == nil || l.lane == nil {
+		return nil, nil
+	}
+	lane := l.lane
+	lane.vlogMu.Lock()
+	defer lane.vlogMu.Unlock()
+	if lane.vlogPath == "" || lane.vlogSeq <= 0 {
+		return nil, nil
+	}
+	fileID, err := valuelog.EncodeFileID(uint32(lane.id), uint32(lane.vlogSeq))
+	if err != nil {
+		return nil, err
+	}
+	return []backenddb.LeafPageLogSegment{{Path: lane.vlogPath, FileID: fileID}}, nil
+}
+
 func (l *cachingLeafPageLog) MarkLeafPageLogSegmentsRegistered(segments []backenddb.LeafPageLogSegment) {
 	if l == nil || l.lane == nil || len(segments) == 0 {
 		return
@@ -123,6 +143,13 @@ func (db *DB) noteLeafGenerationRecordLength(ptr page.ValuePtr) {
 	if notifier, ok := db.backend.(interface{ NoteLeafGenerationRecordLength(page.ValuePtr) }); ok {
 		notifier.NoteLeafGenerationRecordLength(ptr)
 	}
+}
+
+func (l *cachingLeafPageLog) Close() error {
+	if l == nil || l.db == nil || l.lane == nil {
+		return nil
+	}
+	return l.db.closeLeafValueLogLane(l.lane)
 }
 
 func (l *cachingLeafPageLog) ConcurrentLeafPageAppends() bool { return true }

--- a/TreeDB/caching/leaf_page_log_lanes.go
+++ b/TreeDB/caching/leaf_page_log_lanes.go
@@ -2,7 +2,6 @@ package caching
 
 import (
 	"errors"
-	"sort"
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
 	"github.com/snissn/gomap/TreeDB/page"
@@ -217,24 +216,4 @@ func (g *cachingLeafPageLogGroup) forEachLane(fn func(*cachingLeafPageLog) error
 		}
 	}
 	return errors.Join(errs...)
-}
-
-func dedupeCachingLeafPageLogSegments(segments []backenddb.LeafPageLogSegment) []backenddb.LeafPageLogSegment {
-	if len(segments) == 0 {
-		return nil
-	}
-	sort.SliceStable(segments, func(i, j int) bool { return segments[i].FileID < segments[j].FileID })
-	out := segments[:0]
-	seen := make(map[uint32]struct{}, len(segments))
-	for _, seg := range segments {
-		if seg.Path == "" || seg.FileID == 0 {
-			continue
-		}
-		if _, ok := seen[seg.FileID]; ok {
-			continue
-		}
-		seen[seg.FileID] = struct{}{}
-		out = append(out, seg)
-	}
-	return out
 }

--- a/TreeDB/caching/leaf_page_log_lanes.go
+++ b/TreeDB/caching/leaf_page_log_lanes.go
@@ -1,0 +1,240 @@
+package caching
+
+import (
+	"errors"
+	"sort"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+	"github.com/snissn/gomap/TreeDB/page"
+)
+
+type cachingLeafPageLogGroup struct {
+	db *DB
+}
+
+var _ backenddb.LeafPageLog = (*cachingLeafPageLogGroup)(nil)
+var _ backenddb.LeafPageBatchLog = (*cachingLeafPageLogGroup)(nil)
+var _ backenddb.LeafPagePreparedLog = (*cachingLeafPageLogGroup)(nil)
+var _ backenddb.LeafPagePreparedBatchLog = (*cachingLeafPageLogGroup)(nil)
+var _ backenddb.LeafPageConcurrentAppendLog = (*cachingLeafPageLogGroup)(nil)
+var _ backenddb.LeafPageLogCreatedSegmentProvider = (*cachingLeafPageLogGroup)(nil)
+var _ backenddb.LeafPageLogCurrentSegmentProvider = (*cachingLeafPageLogGroup)(nil)
+var _ backenddb.LeafPageLogSegmentRegistrationObserver = (*cachingLeafPageLogGroup)(nil)
+var _ backenddb.LeafPageLogLaneProvider = (*cachingLeafPageLogGroup)(nil)
+
+func (g *cachingLeafPageLogGroup) laneForWorkerIndex(workerIndex int) (*lane, bool) {
+	if g == nil || g.db == nil || !g.db.indexOuterLeavesInValueLog {
+		return nil, false
+	}
+	l := g.db.leafLogAppendLaneForWorkerIndex(workerIndex)
+	if l == nil {
+		return nil, false
+	}
+	return l, true
+}
+
+func (g *cachingLeafPageLogGroup) laneLog(workerIndex int) (*cachingLeafPageLog, bool) {
+	l, ok := g.laneForWorkerIndex(workerIndex)
+	if !ok || l == nil {
+		return nil, false
+	}
+	return &cachingLeafPageLog{db: g.db, lane: l}, true
+}
+
+func (g *cachingLeafPageLogGroup) defaultLog() *cachingLeafPageLog {
+	if g == nil || g.db == nil {
+		return nil
+	}
+	return &cachingLeafPageLog{db: g.db, lane: g.db.leafLogAppendLaneForWorkerIndex(0)}
+}
+
+func (g *cachingLeafPageLogGroup) LeafPageLogLane(workerIndex int) (backenddb.LeafPageLog, bool) {
+	return g.laneLog(workerIndex)
+}
+
+func (g *cachingLeafPageLogGroup) AppendLeafPage(leafPage []byte) (page.LeafLogPtr, error) {
+	log := g.defaultLog()
+	if log == nil {
+		return page.LeafLogPtr{}, errors.New("cachingdb: leaf page log unavailable")
+	}
+	return log.AppendLeafPage(leafPage)
+}
+
+func (g *cachingLeafPageLogGroup) AppendLeafPages(leafPages [][]byte) ([]page.LeafLogPtr, error) {
+	log := g.defaultLog()
+	if log == nil {
+		return nil, errors.New("cachingdb: leaf page log unavailable")
+	}
+	return log.AppendLeafPages(leafPages)
+}
+
+func (g *cachingLeafPageLogGroup) AppendPreparedLeafPage(leafPage []byte, preparedPayload []byte) (page.LeafLogPtr, error) {
+	log := g.defaultLog()
+	if log == nil {
+		return page.LeafLogPtr{}, errors.New("cachingdb: leaf page log unavailable")
+	}
+	return log.AppendPreparedLeafPage(leafPage, preparedPayload)
+}
+
+func (g *cachingLeafPageLogGroup) AppendPreparedLeafPages(leafPages [][]byte, preparedPayloads [][]byte) ([]page.LeafLogPtr, error) {
+	log := g.defaultLog()
+	if log == nil {
+		return nil, errors.New("cachingdb: leaf page log unavailable")
+	}
+	return log.AppendPreparedLeafPages(leafPages, preparedPayloads)
+}
+
+func (g *cachingLeafPageLogGroup) ConcurrentLeafPageAppends() bool { return true }
+
+func (g *cachingLeafPageLogGroup) PreparedLeafPageAppends() bool { return true }
+
+func (g *cachingLeafPageLogGroup) PreparedLeafPageBatchAppends() bool { return true }
+
+func (g *cachingLeafPageLogGroup) CreatedLeafPageLogSegmentsSnapshot() ([]backenddb.LeafPageLogSegment, error) {
+	if g == nil || g.db == nil || !g.db.indexOuterLeavesInValueLog {
+		return nil, nil
+	}
+	segments := make([]backenddb.LeafPageLogSegment, 0, 4)
+	seen := make(map[uint32]struct{}, 4)
+	for _, l := range g.db.leafLogAppendLanesSnapshot() {
+		if l == nil {
+			continue
+		}
+		log := &cachingLeafPageLog{db: g.db, lane: l}
+		laneSegments, err := log.CreatedLeafPageLogSegmentsSnapshot()
+		if err != nil {
+			return nil, err
+		}
+		for _, seg := range laneSegments {
+			if seg.FileID == 0 || seg.Path == "" {
+				continue
+			}
+			if _, ok := seen[seg.FileID]; ok {
+				continue
+			}
+			seen[seg.FileID] = struct{}{}
+			segments = append(segments, seg)
+		}
+	}
+	return segments, nil
+}
+
+func (g *cachingLeafPageLogGroup) CurrentLeafPageLogSegmentsSnapshot() ([]backenddb.LeafPageLogSegment, error) {
+	if g == nil || g.db == nil || !g.db.indexOuterLeavesInValueLog {
+		return nil, nil
+	}
+	segments := make([]backenddb.LeafPageLogSegment, 0, 4)
+	seen := make(map[uint32]struct{}, 4)
+	for _, l := range g.db.leafLogAppendLanesSnapshot() {
+		if l == nil {
+			continue
+		}
+		log := &cachingLeafPageLog{db: g.db, lane: l}
+		laneSegments, err := log.CurrentLeafPageLogSegmentsSnapshot()
+		if err != nil {
+			return nil, err
+		}
+		for _, seg := range laneSegments {
+			if seg.FileID == 0 || seg.Path == "" {
+				continue
+			}
+			if _, ok := seen[seg.FileID]; ok {
+				continue
+			}
+			seen[seg.FileID] = struct{}{}
+			segments = append(segments, seg)
+		}
+	}
+	return segments, nil
+}
+
+func (g *cachingLeafPageLogGroup) CurrentValueLogSegment() (string, uint32, bool) {
+	segments, err := g.CurrentLeafPageLogSegmentsSnapshot()
+	if err != nil || len(segments) == 0 {
+		return "", 0, false
+	}
+	return segments[0].Path, segments[0].FileID, true
+}
+
+func (g *cachingLeafPageLogGroup) ProtectedLeafGenerationRootIDs() []uint64 {
+	if g == nil || g.db == nil {
+		return nil
+	}
+	protectedRootIDs, _ := g.db.publishedLeafGenerationProtectionIDs()
+	return protectedRootIDs
+}
+
+func (g *cachingLeafPageLogGroup) ProtectedLeafGenerationSystemRootIDs() []uint64 {
+	if g == nil || g.db == nil {
+		return nil
+	}
+	_, protectedSystemRootIDs := g.db.publishedLeafGenerationProtectionIDs()
+	return protectedSystemRootIDs
+}
+
+func (g *cachingLeafPageLogGroup) ProtectedLeafGenerationRootIDPair() ([]uint64, []uint64) {
+	if g == nil || g.db == nil {
+		return nil, nil
+	}
+	return g.db.publishedLeafGenerationProtectionIDs()
+}
+
+func (g *cachingLeafPageLogGroup) MarkLeafPageLogSegmentsRegistered(segments []backenddb.LeafPageLogSegment) {
+	if g == nil || g.db == nil || len(segments) == 0 || !g.db.indexOuterLeavesInValueLog {
+		return
+	}
+	for _, l := range g.db.leafLogAppendLanesSnapshot() {
+		if l == nil {
+			continue
+		}
+		(&cachingLeafPageLog{db: g.db, lane: l}).MarkLeafPageLogSegmentsRegistered(segments)
+	}
+}
+
+func (g *cachingLeafPageLogGroup) Flush() error {
+	return g.forEachLane(func(log *cachingLeafPageLog) error { return log.Flush() })
+}
+
+func (g *cachingLeafPageLogGroup) Sync() error {
+	return g.forEachLane(func(log *cachingLeafPageLog) error { return log.Sync() })
+}
+
+func (g *cachingLeafPageLogGroup) Close() error {
+	return g.forEachLane(func(log *cachingLeafPageLog) error { return log.Close() })
+}
+
+func (g *cachingLeafPageLogGroup) forEachLane(fn func(*cachingLeafPageLog) error) error {
+	if g == nil || g.db == nil || fn == nil || !g.db.indexOuterLeavesInValueLog {
+		return nil
+	}
+	var errs []error
+	for _, l := range g.db.leafLogAppendLanesSnapshot() {
+		if l == nil {
+			continue
+		}
+		if err := fn(&cachingLeafPageLog{db: g.db, lane: l}); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func dedupeCachingLeafPageLogSegments(segments []backenddb.LeafPageLogSegment) []backenddb.LeafPageLogSegment {
+	if len(segments) == 0 {
+		return nil
+	}
+	sort.SliceStable(segments, func(i, j int) bool { return segments[i].FileID < segments[j].FileID })
+	out := segments[:0]
+	seen := make(map[uint32]struct{}, len(segments))
+	for _, seg := range segments {
+		if seg.Path == "" || seg.FileID == 0 {
+			continue
+		}
+		if _, ok := seen[seg.FileID]; ok {
+			continue
+		}
+		seen[seg.FileID] = struct{}{}
+		out = append(out, seg)
+	}
+	return out
+}

--- a/TreeDB/caching/leaf_page_log_test.go
+++ b/TreeDB/caching/leaf_page_log_test.go
@@ -516,12 +516,21 @@ func TestCachingLeafPageLogLaneProviderFlushesSelectedLaneForLiveRead(t *testing
 			t.Fatalf("current writable ids %v missing %d", currentIDs, fileID)
 		}
 	}
+	var readBarrierFlushes atomic.Int32
+	db.testOnVlogFlush = func(laneID int) {
+		if laneID == leafLogLaneID {
+			readBarrierFlushes.Add(1)
+		}
+	}
 	got, err := db.valueLogReader.Read(lanePtr.ValuePtr())
 	if err != nil {
 		t.Fatalf("live read selected lane: %v", err)
 	}
 	if !bytes.Equal(got, lanePage) {
 		t.Fatalf("live read selected lane mismatch")
+	}
+	if readBarrierFlushes.Load() == 0 {
+		t.Fatalf("live read selected lane did not flush through current-writable barrier")
 	}
 }
 

--- a/TreeDB/caching/leaf_page_log_test.go
+++ b/TreeDB/caching/leaf_page_log_test.go
@@ -3,9 +3,11 @@ package caching
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -167,6 +169,52 @@ func TestDB_NoteLeafGenerationRecordLength_ForwardsToBackend(t *testing.T) {
 	if got := stub.notified[0]; got != ptr {
 		t.Fatalf("notified ptr=%+v want %+v", got, ptr)
 	}
+}
+
+type capturingLeafLogBackend struct {
+	BackendDB
+	leafLog backenddb.LeafPageLog
+}
+
+func (b *capturingLeafLogBackend) SetLeafPageLog(log backenddb.LeafPageLog) {
+	b.leafLog = log
+	if setter, ok := any(b.BackendDB).(interface{ SetLeafPageLog(backenddb.LeafPageLog) }); ok {
+		setter.SetLeafPageLog(log)
+	}
+}
+
+func openCachingLeafPageLogLaneTestDB(t *testing.T) (*DB, *capturingLeafLogBackend, string) {
+	t.Helper()
+	dir := t.TempDir()
+	backend, err := backenddb.Open(backenddb.Options{
+		Dir:                        dir,
+		IndexOuterLeavesInValueLog: true,
+	})
+	if err != nil {
+		t.Fatalf("backend open: %v", err)
+	}
+	captured := &capturingLeafLogBackend{BackendDB: backend}
+	db, err := Open(dir, captured, Options{
+		IndexOuterLeavesInValueLog: true,
+		FlushApplyConcurrency:      2,
+		RelaxedSync:                true,
+		AllowUnsafe:                true,
+	})
+	if err != nil {
+		_ = captured.Close()
+		t.Fatalf("cache open: %v", err)
+	}
+	if captured.leafLog == nil {
+		_ = db.Close()
+		t.Fatal("leaf log was not installed on backend")
+	}
+	return db, captured, dir
+}
+
+func testLeafPageBytes(label string) []byte {
+	buf := bytes.Repeat([]byte{0}, page.PageSize)
+	copy(buf, label)
+	return buf
 }
 
 func TestCompactLeafLogPayloadScratchPtrRefClearedForPooling(t *testing.T) {
@@ -331,5 +379,240 @@ func TestCachingLeafPageLog_AppendLeafPageCompactsSparseLeafPayload(t *testing.T
 	}
 	if info.Size() >= int64(valuelog.HeaderSize+page.PageSize) {
 		t.Fatalf("file size=%d want compact leaf payload smaller than raw %d", info.Size(), valuelog.HeaderSize+page.PageSize)
+	}
+}
+
+func TestCachingLeafPageLogLaneSelectionAppendsUniqueReadablePtrs(t *testing.T) {
+	db, captured, dir := openCachingLeafPageLogLaneTestDB(t)
+	provider, ok := captured.leafLog.(backenddb.LeafPageLogLaneProvider)
+	if !ok {
+		t.Fatal("captured leaf log missing lane provider")
+	}
+	defaultPage := testLeafPageBytes("lane-0-default")
+	defaultPtr, err := captured.leafLog.AppendLeafPage(defaultPage)
+	if err != nil {
+		t.Fatalf("default AppendLeafPage: %v", err)
+	}
+	if got := len(db.leafLogAppendLanesSnapshot()); got != 1 {
+		t.Fatalf("default append created %d leaf lanes, want 1", got)
+	}
+
+	const extraLanes = 3
+	type laneResult struct {
+		lane int
+		ptr  page.LeafLogPtr
+		want []byte
+	}
+	results := make(chan laneResult, extraLanes)
+	var wg sync.WaitGroup
+	for lane := 1; lane <= extraLanes; lane++ {
+		lane := lane
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			appender, ok := provider.LeafPageLogLane(lane)
+			if !ok || appender == nil {
+				t.Errorf("LeafPageLogLane(%d) unavailable", lane)
+				return
+			}
+			want := testLeafPageBytes(fmt.Sprintf("lane-%d", lane))
+			ptr, err := appender.AppendLeafPage(want)
+			if err != nil {
+				t.Errorf("lane %d AppendLeafPage: %v", lane, err)
+				return
+			}
+			results <- laneResult{lane: lane, ptr: ptr, want: want}
+		}()
+	}
+	wg.Wait()
+	close(results)
+
+	checks := []laneResult{{lane: 0, ptr: defaultPtr, want: defaultPage}}
+	for res := range results {
+		checks = append(checks, res)
+	}
+	if len(checks) != extraLanes+1 {
+		t.Fatalf("got %d appended pages, want %d", len(checks), extraLanes+1)
+	}
+	seen := map[uint32]struct{}{}
+	for _, res := range checks {
+		fileID := res.ptr.ValuePtr().FileID
+		laneID, seq := valuelog.DecodeFileID(fileID)
+		if laneID != leafLogLaneID {
+			t.Fatalf("lane %d fileID lane=%d want=%d (fileID=%d seq=%d)", res.lane, laneID, leafLogLaneID, fileID, seq)
+		}
+		if _, ok := seen[fileID]; ok {
+			t.Fatalf("duplicate leaf log fileID %d", fileID)
+		}
+		seen[fileID] = struct{}{}
+	}
+	if got := len(db.leafLogAppendLanesSnapshot()); got != extraLanes+1 {
+		t.Fatalf("lane snapshot len=%d want %d", got, extraLanes+1)
+	}
+
+	if err := db.Close(); err != nil {
+		t.Fatalf("Close cached db: %v", err)
+	}
+	backend2, err := backenddb.Open(backenddb.Options{
+		Dir:                        dir,
+		IndexOuterLeavesInValueLog: true,
+	})
+	if err != nil {
+		t.Fatalf("reopen backend: %v", err)
+	}
+	reopened, err := Open(dir, backend2, Options{
+		IndexOuterLeavesInValueLog: true,
+		FlushApplyConcurrency:      2,
+		RelaxedSync:                true,
+		AllowUnsafe:                true,
+	})
+	if err != nil {
+		_ = backend2.Close()
+		t.Fatalf("reopen cache: %v", err)
+	}
+	defer func() { _ = reopened.Close() }()
+
+	for _, res := range checks {
+		got, err := reopened.ReadValueLogRecord(res.ptr.ValuePtr())
+		if err != nil {
+			t.Fatalf("reopen read lane %d: %v", res.lane, err)
+		}
+		if !bytes.Equal(got, res.want) {
+			t.Fatalf("reopen read lane %d mismatch", res.lane)
+		}
+	}
+}
+
+func TestCachingLeafPageLogLaneSnapshotsAggregateAndMarkPerLane(t *testing.T) {
+	db, captured, _ := openCachingLeafPageLogLaneTestDB(t)
+	defer func() { _ = db.Close() }()
+	provider, ok := captured.leafLog.(backenddb.LeafPageLogLaneProvider)
+	if !ok {
+		t.Fatal("captured leaf log missing lane provider")
+	}
+	createdProvider, ok := captured.leafLog.(backenddb.LeafPageLogCreatedSegmentProvider)
+	if !ok {
+		t.Fatal("captured leaf log missing created snapshot provider")
+	}
+	currentProvider, ok := captured.leafLog.(backenddb.LeafPageLogCurrentSegmentProvider)
+	if !ok {
+		t.Fatal("captured leaf log missing current snapshot provider")
+	}
+	observer, ok := captured.leafLog.(backenddb.LeafPageLogSegmentRegistrationObserver)
+	if !ok {
+		t.Fatal("captured leaf log missing registration observer")
+	}
+
+	appenders := []backenddb.LeafPageLog{captured.leafLog}
+	for lane := 1; lane <= 2; lane++ {
+		appender, ok := provider.LeafPageLogLane(lane)
+		if !ok || appender == nil {
+			t.Fatalf("LeafPageLogLane(%d) unavailable", lane)
+		}
+		appenders = append(appenders, appender)
+	}
+	for i, appender := range appenders {
+		if _, err := appender.AppendLeafPage(testLeafPageBytes(fmt.Sprintf("snapshot-%d", i))); err != nil {
+			t.Fatalf("AppendLeafPage lane %d: %v", i, err)
+		}
+	}
+
+	created, err := createdProvider.CreatedLeafPageLogSegmentsSnapshot()
+	if err != nil {
+		t.Fatalf("CreatedLeafPageLogSegmentsSnapshot: %v", err)
+	}
+	if len(created) != len(appenders) {
+		t.Fatalf("created segments=%d want %d", len(created), len(appenders))
+	}
+	current, err := currentProvider.CurrentLeafPageLogSegmentsSnapshot()
+	if err != nil {
+		t.Fatalf("CurrentLeafPageLogSegmentsSnapshot: %v", err)
+	}
+	if len(current) != len(appenders) {
+		t.Fatalf("current segments=%d want %d", len(current), len(appenders))
+	}
+
+	observer.MarkLeafPageLogSegmentsRegistered(created[:1])
+	afterFirstMark, err := createdProvider.CreatedLeafPageLogSegmentsSnapshot()
+	if err != nil {
+		t.Fatalf("CreatedLeafPageLogSegmentsSnapshot after first mark: %v", err)
+	}
+	if len(afterFirstMark) != len(appenders)-1 {
+		t.Fatalf("created segments after first mark=%d want %d", len(afterFirstMark), len(appenders)-1)
+	}
+	currentAfterMark, err := currentProvider.CurrentLeafPageLogSegmentsSnapshot()
+	if err != nil {
+		t.Fatalf("CurrentLeafPageLogSegmentsSnapshot after first mark: %v", err)
+	}
+	if len(currentAfterMark) != len(appenders) {
+		t.Fatalf("current segments after mark=%d want %d", len(currentAfterMark), len(appenders))
+	}
+	observer.MarkLeafPageLogSegmentsRegistered(afterFirstMark)
+	finalCreated, err := createdProvider.CreatedLeafPageLogSegmentsSnapshot()
+	if err != nil {
+		t.Fatalf("CreatedLeafPageLogSegmentsSnapshot after final mark: %v", err)
+	}
+	if len(finalCreated) != 0 {
+		t.Fatalf("created segments after final mark=%d want 0", len(finalCreated))
+	}
+}
+
+func TestCachingLeafPageLogLanes_FlushSyncCloseTouchAllLanes(t *testing.T) {
+	db, captured, _ := openCachingLeafPageLogLaneTestDB(t)
+	provider, ok := captured.leafLog.(backenddb.LeafPageLogLaneProvider)
+	if !ok {
+		t.Fatal("captured leaf log missing lane provider")
+	}
+	closer, ok := captured.leafLog.(interface{ Close() error })
+	if !ok {
+		t.Fatal("captured leaf log missing close")
+	}
+	appenders := []backenddb.LeafPageLog{captured.leafLog}
+	for lane := 1; lane <= 2; lane++ {
+		appender, ok := provider.LeafPageLogLane(lane)
+		if !ok || appender == nil {
+			t.Fatalf("LeafPageLogLane(%d) unavailable", lane)
+		}
+		appenders = append(appenders, appender)
+	}
+	for i, appender := range appenders {
+		if _, err := appender.AppendLeafPage(testLeafPageBytes(fmt.Sprintf("touch-%d", i))); err != nil {
+			t.Fatalf("AppendLeafPage lane %d: %v", i, err)
+		}
+	}
+	var flushCalls atomic.Int32
+	var syncCalls atomic.Int32
+	db.testOnVlogFlush = func(laneID int) {
+		flushCalls.Add(1)
+	}
+	db.testOnVlogSync = func(laneID int) {
+		syncCalls.Add(1)
+	}
+	if err := captured.leafLog.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+	if got := flushCalls.Load(); got != int32(len(appenders)) {
+		t.Fatalf("flush count=%d want %d", got, len(appenders))
+	}
+	db.relaxedSync = false
+	if err := captured.leafLog.Sync(); err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+	if got := syncCalls.Load(); got != int32(len(appenders)) {
+		t.Fatalf("sync count=%d want %d", got, len(appenders))
+	}
+	if err := closer.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	for i, lane := range db.leafLogAppendLanesSnapshot() {
+		if lane == nil {
+			continue
+		}
+		if lane.vlog != nil {
+			t.Fatalf("lane %d still has an open writer", i)
+		}
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("db Close: %v", err)
 	}
 }

--- a/TreeDB/caching/leaf_page_log_test.go
+++ b/TreeDB/caching/leaf_page_log_test.go
@@ -534,6 +534,46 @@ func TestCachingLeafPageLogLaneProviderFlushesSelectedLaneForLiveRead(t *testing
 	}
 }
 
+func TestCachingLeafPageLogLaneLiveReadIgnoresInactiveSameSeqLane(t *testing.T) {
+	db, captured, _ := openCachingLeafPageLogLaneTestDB(t)
+	defer func() { _ = db.Close() }()
+	provider, ok := captured.leafLog.(backenddb.LeafPageLogLaneProvider)
+	if !ok {
+		t.Fatal("captured leaf log missing lane provider")
+	}
+	lane2, ok := provider.LeafPageLogLane(2)
+	if !ok || lane2 == nil {
+		t.Fatal("LeafPageLogLane(2) unavailable")
+	}
+	lanePage := testLeafPageBytes("live-lane-2")
+	lanePtr, err := lane2.AppendLeafPage(lanePage)
+	if err != nil {
+		t.Fatalf("lane 2 AppendLeafPage: %v", err)
+	}
+	lane1, ok := provider.LeafPageLogLane(1)
+	if !ok || lane1 == nil {
+		t.Fatal("LeafPageLogLane(1) unavailable")
+	}
+	_ = lane1
+
+	var readBarrierFlushes atomic.Int32
+	db.testOnVlogFlush = func(laneID int) {
+		if laneID == leafLogLaneID {
+			readBarrierFlushes.Add(1)
+		}
+	}
+	got, err := db.valueLogReader.Read(lanePtr.ValuePtr())
+	if err != nil {
+		t.Fatalf("live read selected lane with inactive same-seq lane: %v", err)
+	}
+	if !bytes.Equal(got, lanePage) {
+		t.Fatalf("live read selected lane with inactive same-seq lane mismatch")
+	}
+	if readBarrierFlushes.Load() == 0 {
+		t.Fatalf("live read selected lane did not flush active same-seq writer")
+	}
+}
+
 func TestCachingLeafPageLogLaneMaintenanceAdvanceUsesUniqueSequences(t *testing.T) {
 	db, captured, _ := openCachingLeafPageLogLaneTestDB(t)
 	defer func() { _ = db.Close() }()

--- a/TreeDB/caching/leaf_page_log_test.go
+++ b/TreeDB/caching/leaf_page_log_test.go
@@ -483,6 +483,47 @@ func TestCachingLeafPageLogLaneSelectionAppendsUniqueReadablePtrs(t *testing.T) 
 	}
 }
 
+func TestCachingLeafPageLogLaneProviderFlushesSelectedLaneForLiveRead(t *testing.T) {
+	db, captured, _ := openCachingLeafPageLogLaneTestDB(t)
+	defer func() { _ = db.Close() }()
+	provider, ok := captured.leafLog.(backenddb.LeafPageLogLaneProvider)
+	if !ok {
+		t.Fatal("captured leaf log missing lane provider")
+	}
+	defaultPage := testLeafPageBytes("live-default")
+	defaultPtr, err := captured.leafLog.AppendLeafPage(defaultPage)
+	if err != nil {
+		t.Fatalf("default AppendLeafPage: %v", err)
+	}
+	lane1, ok := provider.LeafPageLogLane(1)
+	if !ok || lane1 == nil {
+		t.Fatal("LeafPageLogLane(1) unavailable")
+	}
+	lanePage := testLeafPageBytes("live-lane-1")
+	lanePtr, err := lane1.AppendLeafPage(lanePage)
+	if err != nil {
+		t.Fatalf("lane 1 AppendLeafPage: %v", err)
+	}
+
+	currentIDs := db.valueLogReader.CurrentWritableFileIDs()
+	current := make(map[uint32]struct{}, len(currentIDs))
+	for _, id := range currentIDs {
+		current[id] = struct{}{}
+	}
+	for _, ptr := range []page.LeafLogPtr{defaultPtr, lanePtr} {
+		if _, ok := current[ptr.ValuePtr().FileID]; !ok {
+			t.Fatalf("current writable ids %v missing %d", currentIDs, ptr.ValuePtr().FileID)
+		}
+	}
+	got, err := db.valueLogReader.Read(lanePtr.ValuePtr())
+	if err != nil {
+		t.Fatalf("live read selected lane: %v", err)
+	}
+	if !bytes.Equal(got, lanePage) {
+		t.Fatalf("live read selected lane mismatch")
+	}
+}
+
 func TestCachingLeafPageLogLaneSnapshotsAggregateAndMarkPerLane(t *testing.T) {
 	db, captured, _ := openCachingLeafPageLogLaneTestDB(t)
 	defer func() { _ = db.Close() }()

--- a/TreeDB/caching/leaf_page_log_test.go
+++ b/TreeDB/caching/leaf_page_log_test.go
@@ -511,8 +511,9 @@ func TestCachingLeafPageLogLaneProviderFlushesSelectedLaneForLiveRead(t *testing
 		current[id] = struct{}{}
 	}
 	for _, ptr := range []page.LeafLogPtr{defaultPtr, lanePtr} {
-		if _, ok := current[ptr.ValuePtr().FileID]; !ok {
-			t.Fatalf("current writable ids %v missing %d", currentIDs, ptr.ValuePtr().FileID)
+		fileID := ptr.ValuePtr().FileID
+		if _, ok := current[fileID]; !ok {
+			t.Fatalf("current writable ids %v missing %d", currentIDs, fileID)
 		}
 	}
 	got, err := db.valueLogReader.Read(lanePtr.ValuePtr())
@@ -521,6 +522,83 @@ func TestCachingLeafPageLogLaneProviderFlushesSelectedLaneForLiveRead(t *testing
 	}
 	if !bytes.Equal(got, lanePage) {
 		t.Fatalf("live read selected lane mismatch")
+	}
+}
+
+func TestCachingLeafPageLogLaneMaintenanceAdvanceUsesUniqueSequences(t *testing.T) {
+	db, captured, _ := openCachingLeafPageLogLaneTestDB(t)
+	defer func() { _ = db.Close() }()
+	provider, ok := captured.leafLog.(backenddb.LeafPageLogLaneProvider)
+	if !ok {
+		t.Fatal("captured leaf log missing lane provider")
+	}
+	appenders := []backenddb.LeafPageLog{captured.leafLog}
+	for worker := 1; worker <= 2; worker++ {
+		appender, ok := provider.LeafPageLogLane(worker)
+		if !ok || appender == nil {
+			t.Fatalf("LeafPageLogLane(%d) unavailable", worker)
+		}
+		appenders = append(appenders, appender)
+	}
+	for i, appender := range appenders {
+		if _, err := appender.AppendLeafPage(testLeafPageBytes(fmt.Sprintf("advance-%d", i))); err != nil {
+			t.Fatalf("AppendLeafPage lane %d: %v", i, err)
+		}
+	}
+	lanes := db.leafLogAppendLanesSnapshot()
+	oldIDs := make(map[uint32]struct{}, len(lanes))
+	maxSeq := 0
+	for _, l := range lanes {
+		if l == nil || l.vlogSeq == 0 {
+			continue
+		}
+		fileID, err := valuelog.EncodeFileID(uint32(l.id), uint32(l.vlogSeq))
+		if err != nil {
+			t.Fatalf("EncodeFileID old seq %d: %v", l.vlogSeq, err)
+		}
+		oldIDs[fileID] = struct{}{}
+		if l.vlogSeq > maxSeq {
+			maxSeq = l.vlogSeq
+		}
+	}
+	observedMaxSeq := maxSeq + 10
+	db.advanceLeafLogAppendSeqAtLeast(observedMaxSeq)
+	for _, l := range lanes {
+		if err := db.advanceLeafLogAppendWriterPastObservedSeq(l, observedMaxSeq); err != nil {
+			t.Fatalf("advanceLeafLogAppendWriterPastObservedSeq: %v", err)
+		}
+	}
+	seenSeq := make(map[int]struct{}, len(lanes))
+	for _, l := range lanes {
+		if l == nil {
+			continue
+		}
+		if l.vlogSeq <= observedMaxSeq {
+			t.Fatalf("lane seq=%d want > observed %d", l.vlogSeq, observedMaxSeq)
+		}
+		if _, dup := seenSeq[l.vlogSeq]; dup {
+			t.Fatalf("duplicate advanced leaf seq %d", l.vlogSeq)
+		}
+		seenSeq[l.vlogSeq] = struct{}{}
+	}
+	currentIDs := db.valueLogReader.CurrentWritableFileIDs()
+	current := make(map[uint32]struct{}, len(currentIDs))
+	for _, id := range currentIDs {
+		current[id] = struct{}{}
+	}
+	for oldID := range oldIDs {
+		if _, stillCurrent := current[oldID]; stillCurrent {
+			t.Fatalf("old leaf segment %d still current after rotation; current=%v", oldID, currentIDs)
+		}
+	}
+	for _, l := range lanes {
+		fileID, err := valuelog.EncodeFileID(uint32(l.id), uint32(l.vlogSeq))
+		if err != nil {
+			t.Fatalf("EncodeFileID new seq %d: %v", l.vlogSeq, err)
+		}
+		if _, ok := current[fileID]; !ok {
+			t.Fatalf("current writable ids %v missing advanced file %d", currentIDs, fileID)
+		}
 	}
 }
 

--- a/TreeDB/caching/vlog_compression_selector.go
+++ b/TreeDB/caching/vlog_compression_selector.go
@@ -1614,7 +1614,7 @@ func (db *DB) preferLeafPageBlockCodec(l *lane, unitPayloadBytes int, configured
 	if db == nil || l == nil || !db.indexOuterLeavesInValueLog {
 		return configured, false
 	}
-	if l != &db.leafLog || l.id != leafLogLaneID {
+	if !db.isLeafLogAppendLane(l) {
 		return configured, false
 	}
 	switch normalizeVlogCompressionMode(db.valueLogCompressionMode) {
@@ -1898,7 +1898,7 @@ func (db *DB) observeVlogWriteMode(l *lane, mode vlogCompressionWriteMode, block
 }
 
 func (db *DB) isLiveLeafLogLane(l *lane) bool {
-	return db != nil && db.indexOuterLeavesInValueLog && l == &db.leafLog && l.id == leafLogLaneID
+	return db != nil && db.isLeafLogAppendLane(l)
 }
 
 func (db *DB) clampLiveLeafLogFrameK(l *lane, k int) int {

--- a/TreeDB/caching/vlog_generation_scheduler_test.go
+++ b/TreeDB/caching/vlog_generation_scheduler_test.go
@@ -6467,6 +6467,10 @@ func TestVlogGenerationRewritePlan_FiltersPenalizedSegments(t *testing.T) {
 		SelectedBytesStale: 75 << 20,
 	}
 	recorder.mu.Unlock()
+	// The first ineffective rewrite consumes the tiny test rewrite budget. Refill
+	// it explicitly so this test exercises penalty filtering instead of depending
+	// on wall-clock budget accrual, which is flaky on fast Windows runners.
+	db.vlogGenerationRewriteBudgetTokensBytes.Store(1024)
 	db.vlogGenerationLastRewriteUnixNano.Store(0)
 	db.vlogGenerationRewriteIneffectiveLastNS.Store(time.Now().Add(-2 * vlogGenerationRewriteIneffectiveBackoff).UnixNano())
 	db.vlogGenerationCheckpointKickPending.Store(false)
@@ -6558,6 +6562,10 @@ func TestVlogGenerationRewritePlan_ReadmitsPenalizedSegmentWhenStaleBytesImprove
 	}
 	recorder.mu.Unlock()
 	forceVlogMaintenanceIdle(db)
+	// The first ineffective rewrite consumes the tiny test rewrite budget. Refill
+	// it explicitly so this test exercises stale-byte readmission instead of
+	// depending on wall-clock budget accrual, which is flaky on fast runners.
+	db.vlogGenerationRewriteBudgetTokensBytes.Store(1024)
 	db.vlogGenerationLastRewriteUnixNano.Store(0)
 	db.vlogGenerationRewriteIneffectiveLastNS.Store(time.Now().Add(-2 * vlogGenerationRewriteIneffectiveBackoff).UnixNano())
 	db.maybeRunVlogGenerationMaintenance(false)

--- a/TreeDB/caching/vlog_segment_scan_test.go
+++ b/TreeDB/caching/vlog_segment_scan_test.go
@@ -35,6 +35,29 @@ func TestMaxValueLogRIDFromSegmentsScansLatestSegmentPerLane(t *testing.T) {
 	}
 }
 
+func TestMaxValueLogRIDFromSegmentsScansAllLeafLogSegments(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	leafSeq1 := writeRIDValueLogSegment(t, dir, leafLogLaneID, 1, 99)
+	leafSeq2 := writeRIDValueLogSegment(t, dir, leafLogLaneID, 2, 11)
+	lane0Tail := writeRIDValueLogSegment(t, dir, 0, 1, 22)
+
+	segments := []logSegmentInfo{
+		{path: leafSeq1, size: fileSize(t, leafSeq1), seq: 1, lane: leafLogLaneID, valueLog: true},
+		{path: leafSeq2, size: fileSize(t, leafSeq2), seq: 2, lane: leafLogLaneID, valueLog: true},
+		{path: lane0Tail, size: fileSize(t, lane0Tail), seq: 1, lane: 0, valueLog: true},
+	}
+
+	maxRID, err := maxValueLogRIDFromSegments(segments)
+	if err != nil {
+		t.Fatalf("maxValueLogRIDFromSegments: %v", err)
+	}
+	if maxRID != 99 {
+		t.Fatalf("maxRID=%d want 99 from older leaf-log physical writer", maxRID)
+	}
+}
+
 func TestMaxValueLogRIDFromSegments_IgnoresSegmentRemovedAfterScan(t *testing.T) {
 	t.Parallel()
 

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -1685,6 +1685,7 @@ func openWithLock(opts Options, lock *lockfile.Lock) (*DB, error) {
 	}
 	vm.SetDisableReadChecksum(opts.ValueLog.ReadIntegrity == IntegritySkipChecksums)
 	vm.SetCurrentWritableMmapEnabled(opts.ValueLog.CurrentWritableMmap)
+	vm.SetMultiCurrentWritableLane(valuelog.ReservedLeafLogLaneID, opts.IndexOuterLeavesInValueLog)
 	vm.SetDictLookup(opts.ValueLog.DictLookup)
 	vm.SetTemplateLookup(opts.ValueLog.TemplateLookup, opts.ValueLog.TemplateDecodeOptions)
 

--- a/TreeDB/db/leaf_page_log.go
+++ b/TreeDB/db/leaf_page_log.go
@@ -64,6 +64,16 @@ type LeafPageLogCreatedSegmentProvider interface {
 	CreatedLeafPageLogSegmentsSnapshot() ([]LeafPageLogSegment, error)
 }
 
+// LeafPageLogLaneProvider optionally exposes additional lane-specific leaf-page
+// log appenders for concurrent writers.
+type LeafPageLogLaneProvider interface {
+	LeafPageLogLane(workerIndex int) (LeafPageLog, bool)
+}
+
+// leafPageLogLaneProvider is retained for internal callers that still use the
+// unexported name.
+type leafPageLogLaneProvider = LeafPageLogLaneProvider
+
 // LeafPageLogCurrentSegmentProvider optionally reports every currently tracked
 // leaf-log segment. Implementations may return multiple current segments while
 // keeping the singular CurrentValueLogSegment compatibility path available.
@@ -269,6 +279,24 @@ func (l *leafPageLogWithRecordLengthHints) CurrentLeafPageLogSegmentsSnapshot() 
 		return nil, nil
 	}
 	return leafPageLogCurrentSegments(l.inner)
+}
+
+func (l *leafPageLogWithRecordLengthHints) LeafPageLogLane(workerIndex int) (LeafPageLog, bool) {
+	if l == nil || l.inner == nil {
+		return nil, false
+	}
+	provider, ok := l.inner.(LeafPageLogLaneProvider)
+	if !ok {
+		if workerIndex <= 0 {
+			return l, true
+		}
+		return nil, false
+	}
+	lane, ok := provider.LeafPageLogLane(workerIndex)
+	if !ok || lane == nil {
+		return nil, false
+	}
+	return wrapLeafPageLogWithRecordLengthHints(l.db, lane), true
 }
 
 func (l *leafPageLogWithRecordLengthHints) ProtectedLeafGenerationRootIDs() []uint64 {
@@ -485,8 +513,8 @@ func (db *DB) leafPageLogLaneForWorkerIndex(workerIndex int) (LeafPageLog, bool)
 	if db == nil || db.leafPageLog == nil {
 		return nil, false
 	}
-	if provider, ok := db.leafPageLog.(leafPageLogLaneProvider); ok {
-		return provider.leafPageLogLane(workerIndex)
+	if provider, ok := db.leafPageLog.(LeafPageLogLaneProvider); ok {
+		return provider.LeafPageLogLane(workerIndex)
 	}
 	if workerIndex <= 0 {
 		return db.leafPageLog, true

--- a/TreeDB/db/leaf_page_log.go
+++ b/TreeDB/db/leaf_page_log.go
@@ -462,13 +462,36 @@ func (db *DB) SetLeafPageLog(log LeafPageLog) {
 	if db == nil {
 		return
 	}
-	wrapped := wrapLeafPageLogWithRecordLengthHints(db, log)
+	wrapped := wrapLeafPageLogWithLaneSelection(wrapLeafPageLogWithRecordLengthHints(db, log))
 	db.writeMu.Lock()
 	db.leafPageLog = wrapped
 	if idx := db.idx.Load(); idx != nil && idx.zipper != nil {
 		idx.zipper.SetLeafPageLog(wrapped)
 	}
 	db.writeMu.Unlock()
+}
+
+func (db *DB) leafValueLogLanes() []LeafPageLog {
+	if db == nil || db.leafPageLog == nil {
+		return nil
+	}
+	if provider, ok := db.leafPageLog.(interface{ leafValueLogLanes() []LeafPageLog }); ok {
+		return provider.leafValueLogLanes()
+	}
+	return []LeafPageLog{db.leafPageLog}
+}
+
+func (db *DB) leafPageLogLaneForWorkerIndex(workerIndex int) (LeafPageLog, bool) {
+	if db == nil || db.leafPageLog == nil {
+		return nil, false
+	}
+	if provider, ok := db.leafPageLog.(leafPageLogLaneProvider); ok {
+		return provider.leafPageLogLane(workerIndex)
+	}
+	if workerIndex <= 0 {
+		return db.leafPageLog, true
+	}
+	return nil, false
 }
 
 // RegisterValueLogSegment registers a newly created value-log segment with the

--- a/TreeDB/db/leaf_page_log.go
+++ b/TreeDB/db/leaf_page_log.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/snissn/gomap/TreeDB/internal/valuelog"
 	"github.com/snissn/gomap/TreeDB/page"
 )
 
@@ -527,6 +528,14 @@ func (db *DB) leafPageLogLaneForWorkerIndex(workerIndex int) (LeafPageLog, bool)
 // when it rotates the shared value log so outer-leaf commits can publish a
 // current ValueLogSet via CurrentSetNoRefresh.
 func (db *DB) RegisterValueLogSegment(path string, fileID uint32) error {
+	return db.RegisterValueLogSegmentReplacing(path, fileID, 0)
+}
+
+// RegisterValueLogSegmentReplacing registers a newly created value-log segment
+// and marks it as current writable, sealing previousFileID when it is the prior
+// segment for the same physical writer. Cached leaf-log lanes use this because
+// multiple physical writers share the reserved encoded leaf-log lane id.
+func (db *DB) RegisterValueLogSegmentReplacing(path string, fileID, previousFileID uint32) error {
 	if db == nil {
 		return nil
 	}
@@ -539,7 +548,7 @@ func (db *DB) RegisterValueLogSegment(path string, fileID uint32) error {
 	if err := db.valueLogManager.RegisterSegment(path, fileID); err != nil {
 		return err
 	}
-	if err := db.valueLogManager.PromoteCurrentWritable(fileID); err != nil {
+	if err := db.valueLogManager.PromoteCurrentWritableReplacing(fileID, previousFileID); err != nil {
 		return err
 	}
 	if db.isLeafGenerationSegmentPath(path) {
@@ -592,6 +601,15 @@ func (db *DB) registerLeafPageLogSegmentsForPublish() (bool, error) {
 		registeredSegments = append(registeredSegments, seg)
 		if db.isLeafGenerationSegmentPath(seg.Path) {
 			db.queueLeafGenerationWritableFileID(seg.FileID)
+		}
+	}
+	for _, id := range db.valueLogManager.CurrentWritableFileIDs() {
+		lane, _ := valuelog.DecodeFileID(id)
+		if lane != valuelog.ReservedLeafLogLaneID {
+			continue
+		}
+		if _, current := currentByID[id]; !current {
+			db.valueLogManager.DemoteCurrentWritable(id)
 		}
 	}
 	if len(createdSegments) > 0 {

--- a/TreeDB/db/leaf_page_log_lanes.go
+++ b/TreeDB/db/leaf_page_log_lanes.go
@@ -465,6 +465,9 @@ func (g *leafPageLogLaneGroup) MarkLeafPageLogSegmentsRegistered(segments []Leaf
 	}
 	lanes, locks := g.snapshotLanesAndLocks()
 	for i, lane := range lanes {
+		if lane == nil {
+			continue
+		}
 		lock := leafPageLogLaneLockAt(locks, i)
 		lock.Lock()
 		markLeafPageLogSegmentsRegistered(lane, segments)

--- a/TreeDB/db/leaf_page_log_lanes.go
+++ b/TreeDB/db/leaf_page_log_lanes.go
@@ -11,11 +11,20 @@ import (
 )
 
 type leafPageLogLaneCloner interface {
-	cloneLeafPageLogLane(*leafLogSeqAllocator) (LeafPageLog, error)
+	cloneLeafPageLogLane(*leafLogSeqAllocator, *rewriteRIDAllocator) (LeafPageLog, error)
 }
 
 type leafPageLogSeqAllocatorSetter interface {
 	setLeafPageLogSeqAllocator(*leafLogSeqAllocator)
+}
+
+type leafPageLogSeqFloorProvider interface {
+	leafPageLogSeqFloor() uint32
+}
+
+type leafPageLogRIDAllocatorProvider interface {
+	leafPageLogRIDAllocator() *rewriteRIDAllocator
+	setLeafPageLogRIDAllocator(*rewriteRIDAllocator)
 }
 
 type leafLogSeqAllocator struct {
@@ -60,10 +69,12 @@ func (a *leafLogSeqAllocator) AdvanceAtLeast(seq uint32) {
 }
 
 type leafPageLogLaneGroup struct {
-	mu       sync.RWMutex
-	lanes    []LeafPageLog
-	cloner   leafPageLogLaneCloner
-	seqAlloc *leafLogSeqAllocator
+	mu        sync.RWMutex
+	lanes     []LeafPageLog
+	laneLocks []*sync.Mutex
+	cloner    leafPageLogLaneCloner
+	seqAlloc  *leafLogSeqAllocator
+	ridAlloc  *rewriteRIDAllocator
 }
 
 func wrapLeafPageLogWithLaneSelection(log LeafPageLog) LeafPageLog {
@@ -80,22 +91,31 @@ func wrapLeafPageLogWithLaneSelection(log LeafPageLog) LeafPageLog {
 	if group, ok := log.(*leafPageLogLaneGroup); ok {
 		return group
 	}
-	group := &leafPageLogLaneGroup{lanes: []LeafPageLog{log}}
+	group := &leafPageLogLaneGroup{lanes: []LeafPageLog{log}, laneLocks: []*sync.Mutex{newLeafPageLogLaneLock()}}
 	if cloner, ok := log.(leafPageLogLaneCloner); ok {
 		group.cloner = cloner
 		group.seqAlloc = newLeafLogSeqAllocator(leafPageLogMaxSeq(log))
 		if setter, ok := log.(leafPageLogSeqAllocatorSetter); ok {
 			setter.setLeafPageLogSeqAllocator(group.seqAlloc)
 		}
+		if ridProvider, ok := log.(leafPageLogRIDAllocatorProvider); ok {
+			group.ridAlloc = ridProvider.leafPageLogRIDAllocator()
+			ridProvider.setLeafPageLogRIDAllocator(group.ridAlloc)
+		}
 	}
 	return group
 }
+
+func newLeafPageLogLaneLock() *sync.Mutex { return &sync.Mutex{} }
 
 func leafPageLogMaxSeq(log LeafPageLog) uint32 {
 	if log == nil {
 		return 0
 	}
 	maxSeq := uint32(0)
+	if provider, ok := log.(leafPageLogSeqFloorProvider); ok {
+		maxSeq = provider.leafPageLogSeqFloor()
+	}
 	for _, segments := range [][]LeafPageLogSegment{mustLeafPageLogCreatedSegments(log), mustLeafPageLogCurrentSegments(log)} {
 		for _, seg := range segments {
 			if !isLeafLogWriterLane(seg.FileID) {
@@ -153,19 +173,11 @@ func maxSegmentTargetBytesForLane(dir string, fileID uint32, defaultTarget, leaf
 }
 
 func (g *leafPageLogLaneGroup) AppendLeafPage(leafPage []byte) (page.LeafLogPtr, error) {
-	lane := g.defaultLane()
-	if lane == nil {
-		return page.LeafLogPtr{}, errors.New("leaf page log unavailable")
-	}
-	ptr, err := lane.AppendLeafPage(leafPage)
-	if err != nil {
-		return page.LeafLogPtr{}, err
-	}
-	if g != nil && g.seqAlloc != nil {
-		_, seq := valuelog.DecodeFileID(ptr.ValuePtr().FileID)
-		g.seqAlloc.AdvanceAtLeast(seq)
-	}
-	return ptr, nil
+	return g.appendLeafPageAt(0, leafPage)
+}
+
+func (g *leafPageLogLaneGroup) AppendLeafPages(leafPages [][]byte) ([]page.LeafLogPtr, error) {
+	return g.appendLeafPagesAt(0, leafPages)
 }
 
 func (g *leafPageLogLaneGroup) Flush() error {
@@ -194,13 +206,12 @@ func (g *leafPageLogLaneGroup) LeafPageLogLane(workerIndex int) (LeafPageLog, bo
 		workerIndex = 0
 	}
 	if workerIndex == 0 {
-		return g, true
+		return &leafPageLogLaneHandle{group: g, index: 0}, true
 	}
 	g.mu.RLock()
 	if workerIndex < len(g.lanes) && g.lanes[workerIndex] != nil {
-		lane := g.lanes[workerIndex]
 		g.mu.RUnlock()
-		return lane, true
+		return &leafPageLogLaneHandle{group: g, index: workerIndex}, true
 	}
 	g.mu.RUnlock()
 	if g.cloner == nil {
@@ -209,17 +220,18 @@ func (g *leafPageLogLaneGroup) LeafPageLogLane(workerIndex int) (LeafPageLog, bo
 	g.mu.Lock()
 	defer g.mu.Unlock()
 	if workerIndex < len(g.lanes) && g.lanes[workerIndex] != nil {
-		return g.lanes[workerIndex], true
+		return &leafPageLogLaneHandle{group: g, index: workerIndex}, true
 	}
 	for len(g.lanes) <= workerIndex {
 		g.lanes = append(g.lanes, nil)
+		g.laneLocks = append(g.laneLocks, newLeafPageLogLaneLock())
 	}
-	lane, err := g.cloner.cloneLeafPageLogLane(g.seqAlloc)
+	lane, err := g.cloner.cloneLeafPageLogLane(g.seqAlloc, g.ridAlloc)
 	if err != nil {
 		return nil, false
 	}
 	g.lanes[workerIndex] = lane
-	return lane, true
+	return &leafPageLogLaneHandle{group: g, index: workerIndex}, true
 }
 
 func (g *leafPageLogLaneGroup) leafPageLogLane(workerIndex int) (LeafPageLog, bool) {
@@ -238,20 +250,158 @@ func (g *leafPageLogLaneGroup) defaultLane() LeafPageLog {
 	return g.lanes[0]
 }
 
+type leafPageLogLaneHandle struct {
+	group *leafPageLogLaneGroup
+	index int
+}
+
+func (h *leafPageLogLaneHandle) AppendLeafPage(leafPage []byte) (page.LeafLogPtr, error) {
+	if h == nil || h.group == nil {
+		return page.LeafLogPtr{}, errors.New("leaf page log unavailable")
+	}
+	return h.group.appendLeafPageAt(h.index, leafPage)
+}
+
+func (h *leafPageLogLaneHandle) AppendLeafPages(leafPages [][]byte) ([]page.LeafLogPtr, error) {
+	if h == nil || h.group == nil {
+		return nil, errors.New("leaf page log unavailable")
+	}
+	return h.group.appendLeafPagesAt(h.index, leafPages)
+}
+
+func (h *leafPageLogLaneHandle) Flush() error {
+	if h == nil || h.group == nil {
+		return nil
+	}
+	return h.group.withLane(h.index, func(lane LeafPageLog) error { return lane.Flush() })
+}
+
+func (h *leafPageLogLaneHandle) Sync() error {
+	if h == nil || h.group == nil {
+		return nil
+	}
+	return h.group.withLane(h.index, func(lane LeafPageLog) error { return lane.Sync() })
+}
+
+func (h *leafPageLogLaneHandle) LastLeafPageRecordLength() uint32 {
+	if h == nil || h.group == nil {
+		return 0
+	}
+	var recordLen uint32
+	_ = h.group.withLane(h.index, func(lane LeafPageLog) error {
+		if provider, ok := lane.(leafPageLogRecordLengthProvider); ok {
+			recordLen = provider.LastLeafPageRecordLength()
+		}
+		return nil
+	})
+	return recordLen
+}
+
+func (g *leafPageLogLaneGroup) appendLeafPageAt(index int, leafPage []byte) (page.LeafLogPtr, error) {
+	var ptr page.LeafLogPtr
+	err := g.withLane(index, func(lane LeafPageLog) error {
+		var err error
+		ptr, err = lane.AppendLeafPage(leafPage)
+		return err
+	})
+	if err != nil {
+		return page.LeafLogPtr{}, err
+	}
+	g.noteAppendedLeafPtr(ptr)
+	return ptr, nil
+}
+
+func (g *leafPageLogLaneGroup) appendLeafPagesAt(index int, leafPages [][]byte) ([]page.LeafLogPtr, error) {
+	if len(leafPages) == 0 {
+		return nil, nil
+	}
+	var ptrs []page.LeafLogPtr
+	err := g.withLane(index, func(lane LeafPageLog) error {
+		if batcher, ok := lane.(LeafPageBatchLog); ok {
+			var err error
+			ptrs, err = batcher.AppendLeafPages(leafPages)
+			return err
+		}
+		ptrs = make([]page.LeafLogPtr, len(leafPages))
+		for i, leafPage := range leafPages {
+			ptr, err := lane.AppendLeafPage(leafPage)
+			if err != nil {
+				return err
+			}
+			ptrs[i] = ptr
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(ptrs) != len(leafPages) {
+		return nil, fmt.Errorf("leaf page batch log returned %d ptrs for %d leaf pages", len(ptrs), len(leafPages))
+	}
+	for _, ptr := range ptrs {
+		g.noteAppendedLeafPtr(ptr)
+	}
+	return ptrs, nil
+}
+
+func (g *leafPageLogLaneGroup) withLane(index int, fn func(LeafPageLog) error) error {
+	if g == nil || fn == nil {
+		return errors.New("leaf page log unavailable")
+	}
+	lane, lock := g.laneAndLock(index)
+	if lane == nil {
+		return errors.New("leaf page log unavailable")
+	}
+	lock.Lock()
+	defer lock.Unlock()
+	return fn(lane)
+}
+
+func (g *leafPageLogLaneGroup) laneAndLock(index int) (LeafPageLog, *sync.Mutex) {
+	if g == nil {
+		return nil, newLeafPageLogLaneLock()
+	}
+	if index < 0 {
+		index = 0
+	}
+	g.mu.RLock()
+	defer g.mu.RUnlock()
+	if index >= len(g.lanes) || g.lanes[index] == nil {
+		return nil, newLeafPageLogLaneLock()
+	}
+	lock := leafPageLogLaneLockAt(g.laneLocks, index)
+	return g.lanes[index], lock
+}
+
+func leafPageLogLaneLockAt(locks []*sync.Mutex, index int) *sync.Mutex {
+	if index >= 0 && index < len(locks) && locks[index] != nil {
+		return locks[index]
+	}
+	return newLeafPageLogLaneLock()
+}
+
+func (g *leafPageLogLaneGroup) noteAppendedLeafPtr(ptr page.LeafLogPtr) {
+	if g == nil || g.seqAlloc == nil {
+		return
+	}
+	_, seq := valuelog.DecodeFileID(ptr.ValuePtr().FileID)
+	g.seqAlloc.AdvanceAtLeast(seq)
+}
+
 func (g *leafPageLogLaneGroup) CurrentValueLogSegment() (path string, fileID uint32, ok bool) {
 	if g == nil {
 		return "", 0, false
 	}
-	g.mu.RLock()
-	if len(g.lanes) > 0 && g.lanes[0] != nil {
-		lane := g.lanes[0]
-		g.mu.RUnlock()
-		provider, ok := lane.(leafPageLogCurrentSegmentProvider)
-		if ok {
-			return provider.CurrentValueLogSegment()
+	_ = g.withLane(0, func(lane LeafPageLog) error {
+		provider, hasProvider := lane.(leafPageLogCurrentSegmentProvider)
+		if hasProvider {
+			path, fileID, ok = provider.CurrentValueLogSegment()
 		}
+		return nil
+	})
+	if ok {
+		return path, fileID, true
 	}
-	g.mu.RUnlock()
 	segments, err := g.CurrentLeafPageLogSegmentsSnapshot()
 	if err != nil || len(segments) == 0 {
 		return "", 0, false
@@ -263,17 +413,19 @@ func (g *leafPageLogLaneGroup) CurrentLeafPageLogSegmentsSnapshot() ([]LeafPageL
 	if g == nil {
 		return nil, nil
 	}
-	g.mu.RLock()
-	defer g.mu.RUnlock()
-	if len(g.lanes) == 0 {
+	lanes, locks := g.snapshotLanesAndLocks()
+	if len(lanes) == 0 {
 		return nil, nil
 	}
-	out := make([]LeafPageLogSegment, 0, len(g.lanes))
-	for _, lane := range g.lanes {
+	out := make([]LeafPageLogSegment, 0, len(lanes))
+	for i, lane := range lanes {
 		if lane == nil {
 			continue
 		}
+		lock := leafPageLogLaneLockAt(locks, i)
+		lock.Lock()
 		segments, err := leafPageLogCurrentSegments(lane)
+		lock.Unlock()
 		if err != nil {
 			return nil, err
 		}
@@ -286,17 +438,19 @@ func (g *leafPageLogLaneGroup) CreatedLeafPageLogSegmentsSnapshot() ([]LeafPageL
 	if g == nil {
 		return nil, nil
 	}
-	g.mu.RLock()
-	defer g.mu.RUnlock()
-	if len(g.lanes) == 0 {
+	lanes, locks := g.snapshotLanesAndLocks()
+	if len(lanes) == 0 {
 		return nil, nil
 	}
-	out := make([]LeafPageLogSegment, 0, len(g.lanes))
-	for _, lane := range g.lanes {
+	out := make([]LeafPageLogSegment, 0, len(lanes))
+	for i, lane := range lanes {
 		if lane == nil {
 			continue
 		}
+		lock := leafPageLogLaneLockAt(locks, i)
+		lock.Lock()
 		segments, err := leafPageLogCreatedSegments(lane)
+		lock.Unlock()
 		if err != nil {
 			return nil, err
 		}
@@ -309,10 +463,12 @@ func (g *leafPageLogLaneGroup) MarkLeafPageLogSegmentsRegistered(segments []Leaf
 	if g == nil || len(segments) == 0 {
 		return
 	}
-	g.mu.RLock()
-	defer g.mu.RUnlock()
-	for _, lane := range g.lanes {
+	lanes, locks := g.snapshotLanesAndLocks()
+	for i, lane := range lanes {
+		lock := leafPageLogLaneLockAt(locks, i)
+		lock.Lock()
 		markLeafPageLogSegmentsRegistered(lane, segments)
+		lock.Unlock()
 	}
 }
 
@@ -320,23 +476,34 @@ func (g *leafPageLogLaneGroup) leafValueLogLanes() []LeafPageLog {
 	if g == nil {
 		return nil
 	}
+	lanes, _ := g.snapshotLanesAndLocks()
+	return lanes
+}
+
+func (g *leafPageLogLaneGroup) snapshotLanesAndLocks() ([]LeafPageLog, []*sync.Mutex) {
+	if g == nil {
+		return nil, nil
+	}
 	g.mu.RLock()
 	defer g.mu.RUnlock()
-	return g.lanes
+	return append([]LeafPageLog(nil), g.lanes...), append([]*sync.Mutex(nil), g.laneLocks...)
 }
 
 func (g *leafPageLogLaneGroup) forEachLane(fn func(LeafPageLog) error) error {
 	if g == nil || fn == nil {
 		return nil
 	}
-	g.mu.RLock()
-	defer g.mu.RUnlock()
+	lanes, locks := g.snapshotLanesAndLocks()
 	var firstErr error
-	for _, lane := range g.lanes {
+	for i, lane := range lanes {
 		if lane == nil {
 			continue
 		}
-		if err := fn(lane); err != nil && firstErr == nil {
+		lock := leafPageLogLaneLockAt(locks, i)
+		lock.Lock()
+		err := fn(lane)
+		lock.Unlock()
+		if err != nil && firstErr == nil {
 			firstErr = err
 		}
 	}
@@ -365,7 +532,40 @@ func (l *leafPageLogWithRecordLengthHints) setLeafPageLogSeqAllocator(seqAlloc *
 	setter.setLeafPageLogSeqAllocator(seqAlloc)
 }
 
-func (l *leafPageLogWithRecordLengthHints) cloneLeafPageLogLane(seqAlloc *leafLogSeqAllocator) (LeafPageLog, error) {
+func (l *leafPageLogWithRecordLengthHints) leafPageLogSeqFloor() uint32 {
+	if l == nil || l.inner == nil {
+		return 0
+	}
+	provider, ok := l.inner.(leafPageLogSeqFloorProvider)
+	if !ok {
+		return 0
+	}
+	return provider.leafPageLogSeqFloor()
+}
+
+func (l *leafPageLogWithRecordLengthHints) leafPageLogRIDAllocator() *rewriteRIDAllocator {
+	if l == nil || l.inner == nil {
+		return nil
+	}
+	provider, ok := l.inner.(leafPageLogRIDAllocatorProvider)
+	if !ok {
+		return nil
+	}
+	return provider.leafPageLogRIDAllocator()
+}
+
+func (l *leafPageLogWithRecordLengthHints) setLeafPageLogRIDAllocator(ridAlloc *rewriteRIDAllocator) {
+	if l == nil || l.inner == nil {
+		return
+	}
+	provider, ok := l.inner.(leafPageLogRIDAllocatorProvider)
+	if !ok {
+		return
+	}
+	provider.setLeafPageLogRIDAllocator(ridAlloc)
+}
+
+func (l *leafPageLogWithRecordLengthHints) cloneLeafPageLogLane(seqAlloc *leafLogSeqAllocator, ridAlloc *rewriteRIDAllocator) (LeafPageLog, error) {
 	if l == nil || l.inner == nil {
 		return nil, errors.New("leaf page log unavailable")
 	}
@@ -373,7 +573,7 @@ func (l *leafPageLogWithRecordLengthHints) cloneLeafPageLogLane(seqAlloc *leafLo
 	if !ok {
 		return nil, fmt.Errorf("leaf page log lane cloning unavailable")
 	}
-	clone, err := cloner.cloneLeafPageLogLane(seqAlloc)
+	clone, err := cloner.cloneLeafPageLogLane(seqAlloc, ridAlloc)
 	if err != nil {
 		return nil, err
 	}

--- a/TreeDB/db/leaf_page_log_lanes.go
+++ b/TreeDB/db/leaf_page_log_lanes.go
@@ -10,10 +10,6 @@ import (
 	"github.com/snissn/gomap/TreeDB/page"
 )
 
-type leafPageLogLaneProvider interface {
-	leafPageLogLane(workerIndex int) (LeafPageLog, bool)
-}
-
 type leafPageLogLaneCloner interface {
 	cloneLeafPageLogLane(*leafLogSeqAllocator) (LeafPageLog, error)
 }
@@ -73,6 +69,13 @@ type leafPageLogLaneGroup struct {
 func wrapLeafPageLogWithLaneSelection(log LeafPageLog) LeafPageLog {
 	if log == nil {
 		return nil
+	}
+	if wrapped, ok := log.(*leafPageLogWithRecordLengthHints); ok {
+		if _, ok := wrapped.inner.(LeafPageLogLaneProvider); ok {
+			return log
+		}
+	} else if _, ok := log.(LeafPageLogLaneProvider); ok {
+		return log
 	}
 	if group, ok := log.(*leafPageLogLaneGroup); ok {
 		return group
@@ -183,7 +186,7 @@ func (g *leafPageLogLaneGroup) Close() error {
 	})
 }
 
-func (g *leafPageLogLaneGroup) leafPageLogLane(workerIndex int) (LeafPageLog, bool) {
+func (g *leafPageLogLaneGroup) LeafPageLogLane(workerIndex int) (LeafPageLog, bool) {
 	if g == nil {
 		return nil, false
 	}
@@ -217,6 +220,10 @@ func (g *leafPageLogLaneGroup) leafPageLogLane(workerIndex int) (LeafPageLog, bo
 	}
 	g.lanes[workerIndex] = lane
 	return lane, true
+}
+
+func (g *leafPageLogLaneGroup) leafPageLogLane(workerIndex int) (LeafPageLog, bool) {
+	return g.LeafPageLogLane(workerIndex)
 }
 
 func (g *leafPageLogLaneGroup) defaultLane() LeafPageLog {

--- a/TreeDB/db/leaf_page_log_lanes.go
+++ b/TreeDB/db/leaf_page_log_lanes.go
@@ -1,0 +1,374 @@
+package db
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+
+	"github.com/snissn/gomap/TreeDB/internal/valuelog"
+	"github.com/snissn/gomap/TreeDB/page"
+)
+
+type leafPageLogLaneProvider interface {
+	leafPageLogLane(workerIndex int) (LeafPageLog, bool)
+}
+
+type leafPageLogLaneCloner interface {
+	cloneLeafPageLogLane(*leafLogSeqAllocator) (LeafPageLog, error)
+}
+
+type leafPageLogSeqAllocatorSetter interface {
+	setLeafPageLogSeqAllocator(*leafLogSeqAllocator)
+}
+
+type leafLogSeqAllocator struct {
+	next atomic.Uint32
+}
+
+func newLeafLogSeqAllocator(start uint32) *leafLogSeqAllocator {
+	a := &leafLogSeqAllocator{}
+	a.next.Store(start)
+	return a
+}
+
+func (a *leafLogSeqAllocator) Next() (uint32, error) {
+	if a == nil {
+		return 0, errors.New("leaf log sequence allocator unavailable")
+	}
+	for {
+		current := a.next.Load()
+		next := current + 1
+		if next <= current {
+			return 0, fmt.Errorf("leaf log sequence space exhausted")
+		}
+		if a.next.CompareAndSwap(current, next) {
+			return next, nil
+		}
+	}
+}
+
+func (a *leafLogSeqAllocator) AdvanceAtLeast(seq uint32) {
+	if a == nil {
+		return
+	}
+	for {
+		current := a.next.Load()
+		if current >= seq {
+			return
+		}
+		if a.next.CompareAndSwap(current, seq) {
+			return
+		}
+	}
+}
+
+type leafPageLogLaneGroup struct {
+	mu       sync.RWMutex
+	lanes    []LeafPageLog
+	cloner   leafPageLogLaneCloner
+	seqAlloc *leafLogSeqAllocator
+}
+
+func wrapLeafPageLogWithLaneSelection(log LeafPageLog) LeafPageLog {
+	if log == nil {
+		return nil
+	}
+	if group, ok := log.(*leafPageLogLaneGroup); ok {
+		return group
+	}
+	group := &leafPageLogLaneGroup{lanes: []LeafPageLog{log}}
+	if cloner, ok := log.(leafPageLogLaneCloner); ok {
+		group.cloner = cloner
+		group.seqAlloc = newLeafLogSeqAllocator(leafPageLogMaxSeq(log))
+		if setter, ok := log.(leafPageLogSeqAllocatorSetter); ok {
+			setter.setLeafPageLogSeqAllocator(group.seqAlloc)
+		}
+	}
+	return group
+}
+
+func leafPageLogMaxSeq(log LeafPageLog) uint32 {
+	if log == nil {
+		return 0
+	}
+	maxSeq := uint32(0)
+	for _, segments := range [][]LeafPageLogSegment{mustLeafPageLogCreatedSegments(log), mustLeafPageLogCurrentSegments(log)} {
+		for _, seg := range segments {
+			if !isLeafLogWriterLane(seg.FileID) {
+				continue
+			}
+			_, seq := valuelog.DecodeFileID(seg.FileID)
+			if seq > maxSeq {
+				maxSeq = seq
+			}
+		}
+	}
+	return maxSeq
+}
+
+func mustLeafPageLogCreatedSegments(log LeafPageLog) []LeafPageLogSegment {
+	segments, err := leafPageLogCreatedSegments(log)
+	if err != nil {
+		return nil
+	}
+	return segments
+}
+
+func mustLeafPageLogCurrentSegments(log LeafPageLog) []LeafPageLogSegment {
+	segments, err := leafPageLogCurrentSegments(log)
+	if err != nil {
+		return nil
+	}
+	return segments
+}
+
+func isLeafLogLane(fileID uint32) bool {
+	lane, _ := valuelog.DecodeFileID(fileID)
+	return lane == rewriteLeafLogLaneID
+}
+
+func isLeafLogWriterLane(fileID uint32) bool {
+	return isLeafLogLane(fileID)
+}
+
+func valueLogDirForLane(dir string, fileID uint32) string {
+	if isLeafLogLane(fileID) {
+		return LeafLogDirPath(dir)
+	}
+	return ValueLogDirPath(dir)
+}
+
+func maxSegmentTargetBytesForLane(dir string, fileID uint32, defaultTarget, leafTarget int64) int64 {
+	if isLeafLogLane(fileID) {
+		if leafTarget > 0 {
+			return leafTarget
+		}
+		return defaultTarget
+	}
+	return defaultTarget
+}
+
+func (g *leafPageLogLaneGroup) AppendLeafPage(leafPage []byte) (page.LeafLogPtr, error) {
+	lane := g.defaultLane()
+	if lane == nil {
+		return page.LeafLogPtr{}, errors.New("leaf page log unavailable")
+	}
+	ptr, err := lane.AppendLeafPage(leafPage)
+	if err != nil {
+		return page.LeafLogPtr{}, err
+	}
+	if g != nil && g.seqAlloc != nil {
+		_, seq := valuelog.DecodeFileID(ptr.ValuePtr().FileID)
+		g.seqAlloc.AdvanceAtLeast(seq)
+	}
+	return ptr, nil
+}
+
+func (g *leafPageLogLaneGroup) Flush() error {
+	return g.forEachLane(func(lane LeafPageLog) error { return lane.Flush() })
+}
+
+func (g *leafPageLogLaneGroup) Sync() error {
+	return g.forEachLane(func(lane LeafPageLog) error { return lane.Sync() })
+}
+
+func (g *leafPageLogLaneGroup) Close() error {
+	return g.forEachLane(func(lane LeafPageLog) error {
+		closer, ok := lane.(interface{ Close() error })
+		if !ok {
+			return nil
+		}
+		return closer.Close()
+	})
+}
+
+func (g *leafPageLogLaneGroup) leafPageLogLane(workerIndex int) (LeafPageLog, bool) {
+	if g == nil {
+		return nil, false
+	}
+	if workerIndex < 0 {
+		workerIndex = 0
+	}
+	if workerIndex == 0 {
+		return g, true
+	}
+	g.mu.RLock()
+	if workerIndex < len(g.lanes) && g.lanes[workerIndex] != nil {
+		lane := g.lanes[workerIndex]
+		g.mu.RUnlock()
+		return lane, true
+	}
+	g.mu.RUnlock()
+	if g.cloner == nil {
+		return nil, false
+	}
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if workerIndex < len(g.lanes) && g.lanes[workerIndex] != nil {
+		return g.lanes[workerIndex], true
+	}
+	for len(g.lanes) <= workerIndex {
+		g.lanes = append(g.lanes, nil)
+	}
+	lane, err := g.cloner.cloneLeafPageLogLane(g.seqAlloc)
+	if err != nil {
+		return nil, false
+	}
+	g.lanes[workerIndex] = lane
+	return lane, true
+}
+
+func (g *leafPageLogLaneGroup) defaultLane() LeafPageLog {
+	if g == nil {
+		return nil
+	}
+	g.mu.RLock()
+	defer g.mu.RUnlock()
+	if len(g.lanes) == 0 {
+		return nil
+	}
+	return g.lanes[0]
+}
+
+func (g *leafPageLogLaneGroup) CurrentValueLogSegment() (path string, fileID uint32, ok bool) {
+	if g == nil {
+		return "", 0, false
+	}
+	g.mu.RLock()
+	if len(g.lanes) > 0 && g.lanes[0] != nil {
+		lane := g.lanes[0]
+		g.mu.RUnlock()
+		provider, ok := lane.(leafPageLogCurrentSegmentProvider)
+		if ok {
+			return provider.CurrentValueLogSegment()
+		}
+	}
+	g.mu.RUnlock()
+	segments, err := g.CurrentLeafPageLogSegmentsSnapshot()
+	if err != nil || len(segments) == 0 {
+		return "", 0, false
+	}
+	return segments[0].Path, segments[0].FileID, true
+}
+
+func (g *leafPageLogLaneGroup) CurrentLeafPageLogSegmentsSnapshot() ([]LeafPageLogSegment, error) {
+	if g == nil {
+		return nil, nil
+	}
+	g.mu.RLock()
+	defer g.mu.RUnlock()
+	if len(g.lanes) == 0 {
+		return nil, nil
+	}
+	out := make([]LeafPageLogSegment, 0, len(g.lanes))
+	for _, lane := range g.lanes {
+		if lane == nil {
+			continue
+		}
+		segments, err := leafPageLogCurrentSegments(lane)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, segments...)
+	}
+	return sanitizeLeafPageLogCreatedSegments(out), nil
+}
+
+func (g *leafPageLogLaneGroup) CreatedLeafPageLogSegmentsSnapshot() ([]LeafPageLogSegment, error) {
+	if g == nil {
+		return nil, nil
+	}
+	g.mu.RLock()
+	defer g.mu.RUnlock()
+	if len(g.lanes) == 0 {
+		return nil, nil
+	}
+	out := make([]LeafPageLogSegment, 0, len(g.lanes))
+	for _, lane := range g.lanes {
+		if lane == nil {
+			continue
+		}
+		segments, err := leafPageLogCreatedSegments(lane)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, segments...)
+	}
+	return sanitizeLeafPageLogCreatedSegments(out), nil
+}
+
+func (g *leafPageLogLaneGroup) MarkLeafPageLogSegmentsRegistered(segments []LeafPageLogSegment) {
+	if g == nil || len(segments) == 0 {
+		return
+	}
+	g.mu.RLock()
+	defer g.mu.RUnlock()
+	for _, lane := range g.lanes {
+		markLeafPageLogSegmentsRegistered(lane, segments)
+	}
+}
+
+func (g *leafPageLogLaneGroup) leafValueLogLanes() []LeafPageLog {
+	if g == nil {
+		return nil
+	}
+	g.mu.RLock()
+	defer g.mu.RUnlock()
+	return g.lanes
+}
+
+func (g *leafPageLogLaneGroup) forEachLane(fn func(LeafPageLog) error) error {
+	if g == nil || fn == nil {
+		return nil
+	}
+	g.mu.RLock()
+	defer g.mu.RUnlock()
+	var firstErr error
+	for _, lane := range g.lanes {
+		if lane == nil {
+			continue
+		}
+		if err := fn(lane); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}
+
+func (l *leafPageLogWithRecordLengthHints) Close() error {
+	if l == nil || l.inner == nil {
+		return nil
+	}
+	closer, ok := l.inner.(interface{ Close() error })
+	if !ok {
+		return nil
+	}
+	return closer.Close()
+}
+
+func (l *leafPageLogWithRecordLengthHints) setLeafPageLogSeqAllocator(seqAlloc *leafLogSeqAllocator) {
+	if l == nil || l.inner == nil {
+		return
+	}
+	setter, ok := l.inner.(leafPageLogSeqAllocatorSetter)
+	if !ok {
+		return
+	}
+	setter.setLeafPageLogSeqAllocator(seqAlloc)
+}
+
+func (l *leafPageLogWithRecordLengthHints) cloneLeafPageLogLane(seqAlloc *leafLogSeqAllocator) (LeafPageLog, error) {
+	if l == nil || l.inner == nil {
+		return nil, errors.New("leaf page log unavailable")
+	}
+	cloner, ok := l.inner.(leafPageLogLaneCloner)
+	if !ok {
+		return nil, fmt.Errorf("leaf page log lane cloning unavailable")
+	}
+	clone, err := cloner.cloneLeafPageLogLane(seqAlloc)
+	if err != nil {
+		return nil, err
+	}
+	return &leafPageLogWithRecordLengthHints{db: l.db, inner: clone}, nil
+}

--- a/TreeDB/db/leaf_page_log_lanes_test.go
+++ b/TreeDB/db/leaf_page_log_lanes_test.go
@@ -272,7 +272,7 @@ func TestLeafPageLogLaneSelectionAppendsUniqueReadablePtrs(t *testing.T) {
 
 func TestLeafPageLogLaneSnapshotsAggregateAndMarkPerLane(t *testing.T) {
 	db, _ := openLeafPageLogLaneTestDB(t)
-	defer func() { _ = db.Close() }()
+	defer closeLeafPageLogLaneTestDB(t, db)
 
 	appenders := []LeafPageLog{db.leafPageLog}
 	for lane := 1; lane <= 2; lane++ {
@@ -318,6 +318,21 @@ func TestLeafPageLogLaneSnapshotsAggregateAndMarkPerLane(t *testing.T) {
 	}
 	if len(finalCreated) != 0 {
 		t.Fatalf("created segments after final mark=%d want 0", len(finalCreated))
+	}
+}
+
+func closeLeafPageLogLaneTestDB(t *testing.T, db *DB) {
+	t.Helper()
+	if db == nil {
+		return
+	}
+	if closer, ok := db.leafPageLog.(interface{ Close() error }); ok {
+		if err := closer.Close(); err != nil {
+			t.Fatalf("Close leaf log: %v", err)
+		}
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("Close DB: %v", err)
 	}
 }
 

--- a/TreeDB/db/leaf_page_log_lanes_test.go
+++ b/TreeDB/db/leaf_page_log_lanes_test.go
@@ -1,0 +1,327 @@
+package db
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/internal/valuelog"
+	"github.com/snissn/gomap/TreeDB/page"
+)
+
+type leafLaneCountingLog struct {
+	inner  LeafPageLog
+	counts *leafLaneCountingLogCounts
+}
+
+type leafLaneCountingLogCounts struct {
+	flush atomic.Uint32
+	sync  atomic.Uint32
+	close atomic.Uint32
+}
+
+func (l *leafLaneCountingLog) AppendLeafPage(leafPage []byte) (page.LeafLogPtr, error) {
+	if l == nil || l.inner == nil {
+		return page.LeafLogPtr{}, errors.New("leaf page log unavailable")
+	}
+	return l.inner.AppendLeafPage(leafPage)
+}
+
+func (l *leafLaneCountingLog) Flush() error {
+	if l == nil || l.inner == nil {
+		return nil
+	}
+	if l.counts != nil {
+		l.counts.flush.Add(1)
+	}
+	return l.inner.Flush()
+}
+
+func (l *leafLaneCountingLog) Sync() error {
+	if l == nil || l.inner == nil {
+		return nil
+	}
+	if l.counts != nil {
+		l.counts.sync.Add(1)
+	}
+	return l.inner.Sync()
+}
+
+func (l *leafLaneCountingLog) Close() error {
+	if l == nil || l.inner == nil {
+		return nil
+	}
+	if l.counts != nil {
+		l.counts.close.Add(1)
+	}
+	closer, ok := l.inner.(interface{ Close() error })
+	if !ok {
+		return nil
+	}
+	return closer.Close()
+}
+
+func (l *leafLaneCountingLog) CurrentValueLogSegment() (string, uint32, bool) {
+	if l == nil || l.inner == nil {
+		return "", 0, false
+	}
+	provider, ok := l.inner.(leafPageLogCurrentSegmentProvider)
+	if !ok {
+		return "", 0, false
+	}
+	return provider.CurrentValueLogSegment()
+}
+
+func (l *leafLaneCountingLog) CurrentLeafPageLogSegmentsSnapshot() ([]LeafPageLogSegment, error) {
+	if l == nil || l.inner == nil {
+		return nil, nil
+	}
+	return leafPageLogCurrentSegments(l.inner)
+}
+
+func (l *leafLaneCountingLog) CreatedLeafPageLogSegmentsSnapshot() ([]LeafPageLogSegment, error) {
+	if l == nil || l.inner == nil {
+		return nil, nil
+	}
+	return leafPageLogCreatedSegments(l.inner)
+}
+
+func (l *leafLaneCountingLog) MarkLeafPageLogSegmentsRegistered(segments []LeafPageLogSegment) {
+	if l == nil || l.inner == nil {
+		return
+	}
+	observer, ok := l.inner.(LeafPageLogSegmentRegistrationObserver)
+	if !ok {
+		return
+	}
+	observer.MarkLeafPageLogSegmentsRegistered(segments)
+}
+
+func (l *leafLaneCountingLog) cloneLeafPageLogLane(seqAlloc *leafLogSeqAllocator) (LeafPageLog, error) {
+	if l == nil || l.inner == nil {
+		return nil, errors.New("leaf page log unavailable")
+	}
+	cloner, ok := l.inner.(leafPageLogLaneCloner)
+	if !ok {
+		return nil, errors.New("leaf page log lane cloning unavailable")
+	}
+	clone, err := cloner.cloneLeafPageLogLane(seqAlloc)
+	if err != nil {
+		return nil, err
+	}
+	return &leafLaneCountingLog{inner: clone, counts: l.counts}, nil
+}
+
+func testLeafPageBytes(label string) []byte {
+	buf := bytes.Repeat([]byte{0}, page.PageSize)
+	copy(buf, label)
+	return buf
+}
+
+func openLeafPageLogLaneTestDB(t *testing.T) (*DB, LeafPageLogCloser) {
+	t.Helper()
+	dir := t.TempDir()
+	db, err := Open(Options{Dir: dir, IndexOuterLeavesInValueLog: true})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	leafLog, err := NewStandaloneLeafPageLog(dir, StandaloneLeafPageLogOptions{Compression: ValueLogCompressionOff})
+	if err != nil {
+		_ = db.Close()
+		t.Fatalf("NewStandaloneLeafPageLog: %v", err)
+	}
+	db.SetLeafPageLog(leafLog)
+	return db, leafLog
+}
+
+func TestLeafPageLogLaneSelectionAppendsUniqueReadablePtrs(t *testing.T) {
+	db, _ := openLeafPageLogLaneTestDB(t)
+
+	defaultPage := testLeafPageBytes("lane-0-default")
+	defaultPtr, err := db.leafPageLog.AppendLeafPage(defaultPage)
+	if err != nil {
+		t.Fatalf("default AppendLeafPage: %v", err)
+	}
+
+	const extraLanes = 3
+	type laneResult struct {
+		lane int
+		ptr  page.LeafLogPtr
+		want []byte
+	}
+	results := make(chan laneResult, extraLanes)
+	var wg sync.WaitGroup
+	for lane := 1; lane <= extraLanes; lane++ {
+		lane := lane
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			appender, ok := db.leafPageLogLaneForWorkerIndex(lane)
+			if !ok || appender == nil {
+				t.Errorf("leafPageLogLaneForWorkerIndex(%d) unavailable", lane)
+				return
+			}
+			want := testLeafPageBytes(fmt.Sprintf("lane-%d", lane))
+			ptr, err := appender.AppendLeafPage(want)
+			if err != nil {
+				t.Errorf("lane %d AppendLeafPage: %v", lane, err)
+				return
+			}
+			results <- laneResult{lane: lane, ptr: ptr, want: want}
+		}()
+	}
+	wg.Wait()
+	close(results)
+
+	seen := map[uint32]struct{}{}
+	checks := []laneResult{{lane: 0, ptr: defaultPtr, want: defaultPage}}
+	for res := range results {
+		checks = append(checks, res)
+	}
+	if len(checks) != extraLanes+1 {
+		t.Fatalf("got %d appended pages, want %d", len(checks), extraLanes+1)
+	}
+	for _, res := range checks {
+		fileID := res.ptr.ValuePtr().FileID
+		laneID, seq := valuelog.DecodeFileID(fileID)
+		if laneID != rewriteLeafLogLaneID {
+			t.Fatalf("lane %d fileID lane=%d want=%d (fileID=%d seq=%d)", res.lane, laneID, rewriteLeafLogLaneID, fileID, seq)
+		}
+		if _, ok := seen[fileID]; ok {
+			t.Fatalf("duplicate leaf log fileID %d", fileID)
+		}
+		seen[fileID] = struct{}{}
+	}
+
+	closer, ok := db.leafPageLog.(interface{ Close() error })
+	if !ok {
+		t.Fatal("leaf log missing Close")
+	}
+	if err := closer.Close(); err != nil {
+		t.Fatalf("Close leaf log: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	reopened, err := Open(Options{Dir: db.dir, IndexOuterLeavesInValueLog: true})
+	if err != nil {
+		t.Fatalf("reopen Open: %v", err)
+	}
+	defer func() { _ = reopened.Close() }()
+
+	for _, res := range checks {
+		got, err := reopened.valueLogManager.Read(res.ptr.ValuePtr())
+		if err != nil {
+			t.Fatalf("reopen read lane %d: %v", res.lane, err)
+		}
+		if !bytes.Equal(got, res.want) {
+			t.Fatalf("reopen read lane %d mismatch", res.lane)
+		}
+	}
+}
+
+func TestLeafPageLogLaneSnapshotsAggregateAndMarkPerLane(t *testing.T) {
+	db, _ := openLeafPageLogLaneTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	appenders := []LeafPageLog{db.leafPageLog}
+	for lane := 1; lane <= 2; lane++ {
+		appender, ok := db.leafPageLogLaneForWorkerIndex(lane)
+		if !ok || appender == nil {
+			t.Fatalf("leafPageLogLaneForWorkerIndex(%d) unavailable", lane)
+		}
+		appenders = append(appenders, appender)
+	}
+	for i, appender := range appenders {
+		if _, err := appender.AppendLeafPage(testLeafPageBytes(fmt.Sprintf("snapshot-%d", i))); err != nil {
+			t.Fatalf("AppendLeafPage lane %d: %v", i, err)
+		}
+	}
+
+	created, err := leafPageLogCreatedSegments(db.leafPageLog)
+	if err != nil {
+		t.Fatalf("CreatedLeafPageLogSegmentsSnapshot: %v", err)
+	}
+	if len(created) != len(appenders) {
+		t.Fatalf("created segments=%d want %d", len(created), len(appenders))
+	}
+	current, err := leafPageLogCurrentSegments(db.leafPageLog)
+	if err != nil {
+		t.Fatalf("CurrentLeafPageLogSegmentsSnapshot: %v", err)
+	}
+	if len(current) != len(appenders) {
+		t.Fatalf("current segments=%d want %d", len(current), len(appenders))
+	}
+
+	markLeafPageLogSegmentsRegistered(db.leafPageLog, created[:1])
+	afterFirstMark, err := leafPageLogCreatedSegments(db.leafPageLog)
+	if err != nil {
+		t.Fatalf("CreatedLeafPageLogSegmentsSnapshot after first mark: %v", err)
+	}
+	if len(afterFirstMark) != len(appenders)-1 {
+		t.Fatalf("created segments after first mark=%d want %d", len(afterFirstMark), len(appenders)-1)
+	}
+	markLeafPageLogSegmentsRegistered(db.leafPageLog, afterFirstMark)
+	finalCreated, err := leafPageLogCreatedSegments(db.leafPageLog)
+	if err != nil {
+		t.Fatalf("CreatedLeafPageLogSegmentsSnapshot after final mark: %v", err)
+	}
+	if len(finalCreated) != 0 {
+		t.Fatalf("created segments after final mark=%d want 0", len(finalCreated))
+	}
+}
+
+func TestLeafPageLogLanes_FlushSyncCloseTouchAllLanes(t *testing.T) {
+	dir := t.TempDir()
+	db, err := Open(Options{Dir: dir, IndexOuterLeavesInValueLog: true})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	baseLog, err := NewStandaloneLeafPageLog(dir, StandaloneLeafPageLogOptions{Compression: ValueLogCompressionOff})
+	if err != nil {
+		_ = db.Close()
+		t.Fatalf("NewStandaloneLeafPageLog: %v", err)
+	}
+	counts := &leafLaneCountingLogCounts{}
+	db.SetLeafPageLog(&leafLaneCountingLog{inner: baseLog, counts: counts})
+
+	for lane := 0; lane < 3; lane++ {
+		appender, ok := db.leafPageLogLaneForWorkerIndex(lane)
+		if !ok || appender == nil {
+			t.Fatalf("leafPageLogLaneForWorkerIndex(%d) unavailable", lane)
+		}
+		if _, err := appender.AppendLeafPage(testLeafPageBytes(fmt.Sprintf("touch-%d", lane))); err != nil {
+			t.Fatalf("AppendLeafPage lane %d: %v", lane, err)
+		}
+	}
+
+	if err := db.leafPageLog.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+	if got := counts.flush.Load(); got != 3 {
+		t.Fatalf("Flush count=%d want 3", got)
+	}
+	if err := db.leafPageLog.Sync(); err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+	if got := counts.sync.Load(); got != 3 {
+		t.Fatalf("Sync count=%d want 3", got)
+	}
+	closer, ok := db.leafPageLog.(interface{ Close() error })
+	if !ok {
+		t.Fatal("leaf log missing Close")
+	}
+	if err := closer.Close(); err != nil {
+		t.Fatalf("Close leaf log: %v", err)
+	}
+	if got := counts.close.Load(); got != 3 {
+		t.Fatalf("Close count=%d want 3", got)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("DB Close: %v", err)
+	}
+}

--- a/TreeDB/db/leaf_page_log_lanes_test.go
+++ b/TreeDB/db/leaf_page_log_lanes_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -100,7 +102,51 @@ func (l *leafLaneCountingLog) MarkLeafPageLogSegmentsRegistered(segments []LeafP
 	observer.MarkLeafPageLogSegmentsRegistered(segments)
 }
 
-func (l *leafLaneCountingLog) cloneLeafPageLogLane(seqAlloc *leafLogSeqAllocator) (LeafPageLog, error) {
+func (l *leafLaneCountingLog) setLeafPageLogSeqAllocator(seqAlloc *leafLogSeqAllocator) {
+	if l == nil || l.inner == nil {
+		return
+	}
+	setter, ok := l.inner.(leafPageLogSeqAllocatorSetter)
+	if !ok {
+		return
+	}
+	setter.setLeafPageLogSeqAllocator(seqAlloc)
+}
+
+func (l *leafLaneCountingLog) leafPageLogSeqFloor() uint32 {
+	if l == nil || l.inner == nil {
+		return 0
+	}
+	provider, ok := l.inner.(leafPageLogSeqFloorProvider)
+	if !ok {
+		return 0
+	}
+	return provider.leafPageLogSeqFloor()
+}
+
+func (l *leafLaneCountingLog) leafPageLogRIDAllocator() *rewriteRIDAllocator {
+	if l == nil || l.inner == nil {
+		return nil
+	}
+	provider, ok := l.inner.(leafPageLogRIDAllocatorProvider)
+	if !ok {
+		return nil
+	}
+	return provider.leafPageLogRIDAllocator()
+}
+
+func (l *leafLaneCountingLog) setLeafPageLogRIDAllocator(ridAlloc *rewriteRIDAllocator) {
+	if l == nil || l.inner == nil {
+		return
+	}
+	provider, ok := l.inner.(leafPageLogRIDAllocatorProvider)
+	if !ok {
+		return
+	}
+	provider.setLeafPageLogRIDAllocator(ridAlloc)
+}
+
+func (l *leafLaneCountingLog) cloneLeafPageLogLane(seqAlloc *leafLogSeqAllocator, ridAlloc *rewriteRIDAllocator) (LeafPageLog, error) {
 	if l == nil || l.inner == nil {
 		return nil, errors.New("leaf page log unavailable")
 	}
@@ -108,7 +154,7 @@ func (l *leafLaneCountingLog) cloneLeafPageLogLane(seqAlloc *leafLogSeqAllocator
 	if !ok {
 		return nil, errors.New("leaf page log lane cloning unavailable")
 	}
-	clone, err := cloner.cloneLeafPageLogLane(seqAlloc)
+	clone, err := cloner.cloneLeafPageLogLane(seqAlloc, ridAlloc)
 	if err != nil {
 		return nil, err
 	}
@@ -273,6 +319,119 @@ func TestLeafPageLogLaneSnapshotsAggregateAndMarkPerLane(t *testing.T) {
 	if len(finalCreated) != 0 {
 		t.Fatalf("created segments after final mark=%d want 0", len(finalCreated))
 	}
+}
+
+func TestLeafPageLogLaneGroupReopenSeedsSharedSeqAllocator(t *testing.T) {
+	dir := t.TempDir()
+	first, err := NewStandaloneLeafPageLog(dir, StandaloneLeafPageLogOptions{Compression: ValueLogCompressionOff})
+	if err != nil {
+		t.Fatalf("NewStandaloneLeafPageLog first: %v", err)
+	}
+	firstPtr, err := first.AppendLeafPage(testLeafPageBytes("first"))
+	if err != nil {
+		_ = first.Close()
+		t.Fatalf("first AppendLeafPage: %v", err)
+	}
+	if err := first.Close(); err != nil {
+		t.Fatalf("first Close: %v", err)
+	}
+	_, firstSeq := valuelog.DecodeFileID(firstPtr.ValuePtr().FileID)
+
+	second, err := NewStandaloneLeafPageLog(dir, StandaloneLeafPageLogOptions{Compression: ValueLogCompressionOff})
+	if err != nil {
+		t.Fatalf("NewStandaloneLeafPageLog second: %v", err)
+	}
+	group := wrapLeafPageLogWithLaneSelection(second)
+	provider, ok := group.(LeafPageLogLaneProvider)
+	if !ok {
+		_ = second.Close()
+		t.Fatal("wrapped leaf log missing lane provider")
+	}
+	lane, ok := provider.LeafPageLogLane(1)
+	if !ok || lane == nil {
+		_ = second.Close()
+		t.Fatal("lane 1 unavailable")
+	}
+	secondPtr, err := lane.AppendLeafPage(testLeafPageBytes("second"))
+	if err != nil {
+		_ = second.Close()
+		t.Fatalf("lane 1 AppendLeafPage: %v", err)
+	}
+	if closer, ok := group.(interface{ Close() error }); ok {
+		if err := closer.Close(); err != nil {
+			t.Fatalf("group Close: %v", err)
+		}
+	} else if err := second.Close(); err != nil {
+		t.Fatalf("second Close: %v", err)
+	}
+	_, secondSeq := valuelog.DecodeFileID(secondPtr.ValuePtr().FileID)
+	if secondSeq <= firstSeq {
+		t.Fatalf("reopened lane seq=%d, want > first seq=%d", secondSeq, firstSeq)
+	}
+}
+
+func TestLeafPageLogLaneGroupSharesRecordIDsAcrossLanes(t *testing.T) {
+	dir := t.TempDir()
+	baseLog, err := NewStandaloneLeafPageLog(dir, StandaloneLeafPageLogOptions{Compression: ValueLogCompressionOff})
+	if err != nil {
+		t.Fatalf("NewStandaloneLeafPageLog: %v", err)
+	}
+	group := wrapLeafPageLogWithLaneSelection(baseLog)
+	provider, ok := group.(LeafPageLogLaneProvider)
+	if !ok {
+		_ = baseLog.Close()
+		t.Fatal("wrapped leaf log missing lane provider")
+	}
+	lane0, ok := provider.LeafPageLogLane(0)
+	if !ok || lane0 == nil {
+		_ = baseLog.Close()
+		t.Fatal("lane 0 unavailable")
+	}
+	lane1, ok := provider.LeafPageLogLane(1)
+	if !ok || lane1 == nil {
+		_ = baseLog.Close()
+		t.Fatal("lane 1 unavailable")
+	}
+	ptr0, err := lane0.AppendLeafPage(testLeafPageBytes("rid-lane-0"))
+	if err != nil {
+		_ = baseLog.Close()
+		t.Fatalf("lane 0 AppendLeafPage: %v", err)
+	}
+	ptr1, err := lane1.AppendLeafPage(testLeafPageBytes("rid-lane-1"))
+	if err != nil {
+		_ = baseLog.Close()
+		t.Fatalf("lane 1 AppendLeafPage: %v", err)
+	}
+	if closer, ok := group.(interface{ Close() error }); ok {
+		if err := closer.Close(); err != nil {
+			t.Fatalf("group Close: %v", err)
+		}
+	} else if err := baseLog.Close(); err != nil {
+		t.Fatalf("base Close: %v", err)
+	}
+
+	rid0 := readLeafLogRIDForPtr(t, dir, ptr0)
+	rid1 := readLeafLogRIDForPtr(t, dir, ptr1)
+	if rid0 == rid1 {
+		t.Fatalf("duplicate RID across lanes: %d", rid0)
+	}
+}
+
+func readLeafLogRIDForPtr(t *testing.T, dir string, ptr page.LeafLogPtr) uint64 {
+	t.Helper()
+	valuePtr := ptr.ValuePtr()
+	lane, seq := valuelog.DecodeFileID(valuePtr.FileID)
+	path := filepath.Join(LeafLogDirPath(dir), fmt.Sprintf("value-l%d-%06d.log", lane, seq))
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open leaf log %s: %v", path, err)
+	}
+	defer func() { _ = f.Close() }()
+	rid, err := valuelog.ReadRIDAtUnverified(f, valuePtr.FileID, valuePtr)
+	if err != nil {
+		t.Fatalf("ReadRIDAtUnverified(%+v): %v", valuePtr, err)
+	}
+	return rid
 }
 
 func TestLeafPageLogLanes_FlushSyncCloseTouchAllLanes(t *testing.T) {

--- a/TreeDB/db/open_readonly.go
+++ b/TreeDB/db/open_readonly.go
@@ -64,6 +64,7 @@ func openReadOnly(opts Options) (*DB, error) {
 	}
 	vm.SetDisableReadChecksum(opts.ValueLog.ReadIntegrity == IntegritySkipChecksums)
 	vm.SetCurrentWritableMmapEnabled(opts.ValueLog.CurrentWritableMmap)
+	vm.SetMultiCurrentWritableLane(valuelog.ReservedLeafLogLaneID, opts.IndexOuterLeavesInValueLog)
 	vm.SetDictLookup(opts.ValueLog.DictLookup)
 	vm.SetTemplateLookup(opts.ValueLog.TemplateLookup, opts.ValueLog.TemplateDecodeOptions)
 
@@ -206,6 +207,7 @@ func openReadOnlyNoLock(opts Options) (*DB, error) {
 	}
 	vm.SetDisableReadChecksum(opts.ValueLog.ReadIntegrity == IntegritySkipChecksums)
 	vm.SetCurrentWritableMmapEnabled(opts.ValueLog.CurrentWritableMmap)
+	vm.SetMultiCurrentWritableLane(valuelog.ReservedLeafLogLaneID, opts.IndexOuterLeavesInValueLog)
 	vm.SetDictLookup(opts.ValueLog.DictLookup)
 	vm.SetTemplateLookup(opts.ValueLog.TemplateLookup, opts.ValueLog.TemplateDecodeOptions)
 

--- a/TreeDB/db/vlog_rewrite.go
+++ b/TreeDB/db/vlog_rewrite.go
@@ -1905,19 +1905,10 @@ func (db *DB) valueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 		}
 		// Register rewrite-created segments before publishing pointer swaps so
 		// finalizeCommit can stay on CurrentSetNoRefresh and avoid full scans.
-		for _, id := range batchCreatedIDs {
-			if hasLastRegisteredID && id == lastRegisteredCreatedID {
-				continue
-			}
-			path := db.valueLogManager.SegmentPath(id)
-			if err := db.valueLogManager.RegisterSegment(path, id); err != nil {
-				return err
-			}
-			if err := db.valueLogManager.PromoteCurrentWritable(id); err != nil {
-				return err
-			}
-			lastRegisteredCreatedID = id
-			hasLastRegisteredID = true
+		var registerErr error
+		lastRegisteredCreatedID, hasLastRegisteredID, registerErr = db.registerRewriteCreatedValueLogSegments(batchCreatedIDs, lastRegisteredCreatedID, hasLastRegisteredID)
+		if registerErr != nil {
+			return registerErr
 		}
 		if err := db.applyRewriteSwapBatchToMaintenanceRoot(root, collectionState, swaps, opts.SyncEachBatch); err != nil {
 			return err
@@ -2923,6 +2914,31 @@ func collectRewriteSwapPointerMatches(tr *tree.Tree, b *batch.Batch, swaps []rew
 		return nil, err
 	}
 	return delta, nil
+}
+
+func (db *DB) registerRewriteCreatedValueLogSegments(ids []uint32, previousFileID uint32, hasPrevious bool) (uint32, bool, error) {
+	if db == nil || db.valueLogManager == nil {
+		return previousFileID, hasPrevious, nil
+	}
+	for _, id := range ids {
+		if hasPrevious && id == previousFileID {
+			continue
+		}
+		path := db.valueLogManager.SegmentPath(id)
+		if err := db.valueLogManager.RegisterSegment(path, id); err != nil {
+			return previousFileID, hasPrevious, err
+		}
+		replacingID := uint32(0)
+		if hasPrevious {
+			replacingID = previousFileID
+		}
+		if err := db.valueLogManager.PromoteCurrentWritableReplacing(id, replacingID); err != nil {
+			return previousFileID, hasPrevious, err
+		}
+		previousFileID = id
+		hasPrevious = true
+	}
+	return previousFileID, hasPrevious, nil
 }
 
 func noteRewriteSwapTouchedSegments(b *batch.Batch, swaps []rewriteSwap) {

--- a/TreeDB/db/vlog_rewrite.go
+++ b/TreeDB/db/vlog_rewrite.go
@@ -3363,15 +3363,16 @@ type rewriteCreatedSegment struct {
 }
 
 type rewriteWriter struct {
-	walDir   string
-	lane     uint32
-	seq      uint32
-	maxSize  int64
-	leafDir  string
-	leafLane uint32
-	leafSeq  uint32
-	nextRID  uint64
-	ridAlloc *rewriteRIDAllocator
+	walDir           string
+	lane             uint32
+	seq              uint32
+	maxSize          int64
+	leafDir          string
+	leafLane         uint32
+	leafSeq          uint32
+	leafSeqAllocator *leafLogSeqAllocator
+	nextRID          uint64
+	ridAlloc         *rewriteRIDAllocator
 	// currentPath/currentFileID cache the active writer segment identity so
 	// CurrentValueLogSegment can avoid per-call path/fileID recomputation.
 	currentPath       string
@@ -3463,6 +3464,33 @@ func (w *rewriteWriter) ConfigureLeafLog(leafDir string, lane, startSeq uint32) 
 	w.leafSeq = startSeq
 }
 
+func (w *rewriteWriter) setLeafPageLogSeqAllocator(seqAlloc *leafLogSeqAllocator) {
+	if w == nil {
+		return
+	}
+	w.leafSeqAllocator = seqAlloc
+}
+
+func (w *rewriteWriter) cloneLeafPageLogLane(seqAlloc *leafLogSeqAllocator) (LeafPageLog, error) {
+	if w == nil {
+		return nil, errors.New("vlog-rewrite: nil writer")
+	}
+	if w.leafDir == "" {
+		return nil, errors.New("vlog-rewrite: leaf lane cloning requires a leaf writer")
+	}
+	clone := newRewriteWriter(w.walDir, w.lane, 0, w.maxSize)
+	clone.leafDir = w.leafDir
+	clone.leafLane = w.leafLane
+	clone.leafSeqAllocator = seqAlloc
+	clone.blockCompression = w.blockCompression
+	clone.blockCodec = w.blockCodec
+	clone.leafBlockCodec = w.leafBlockCodec
+	clone.SetKeepPolicy(w.keepIoNsPerByte, w.keepEncodeNsRaw, w.keepSafetyMargin)
+	clone.SetTemplateCompression(w.templateMode, w.templateCfg, w.templateStore)
+	clone.SetLeafDictMode(w.leafDictID, w.leafDict, w.leafDictUseRawPages)
+	return clone, nil
+}
+
 func (w *rewriteWriter) resetLeafLogSeqAtLeast(seq uint32) error {
 	if w == nil || w.leafDir == "" || seq <= w.leafSeq {
 		return nil
@@ -3472,6 +3500,9 @@ func (w *rewriteWriter) resetLeafLogSeqAtLeast(seq uint32) error {
 			return err
 		}
 		w.leafW = nil
+	}
+	if w.leafSeqAllocator != nil {
+		w.leafSeqAllocator.AdvanceAtLeast(seq)
 	}
 	w.leafSeq = seq
 	w.leafCurrentPath = ""
@@ -4050,8 +4081,31 @@ func (w *rewriteWriter) maybeRotateLeafForEstimate(estimate int64) error {
 	return w.rotateLeaf()
 }
 
-func (w *rewriteWriter) rotateLeaf() error {
+func (w *rewriteWriter) nextLeafSeq() (uint32, error) {
+	if w == nil {
+		return 0, errors.New("vlog-rewrite: nil writer")
+	}
+	if w.leafSeqAllocator != nil {
+		seq, err := w.leafSeqAllocator.Next()
+		if err != nil {
+			return 0, err
+		}
+		w.leafSeq = seq
+		return seq, nil
+	}
 	nextSeq := w.leafSeq + 1
+	if nextSeq <= w.leafSeq {
+		return 0, fmt.Errorf("vlog-rewrite: leaf log sequence space exhausted")
+	}
+	w.leafSeq = nextSeq
+	return nextSeq, nil
+}
+
+func (w *rewriteWriter) rotateLeaf() error {
+	nextSeq, err := w.nextLeafSeq()
+	if err != nil {
+		return err
+	}
 	fileID, err := valuelog.EncodeFileID(w.leafLane, nextSeq)
 	if err != nil {
 		return err

--- a/TreeDB/db/vlog_rewrite.go
+++ b/TreeDB/db/vlog_rewrite.go
@@ -260,6 +260,7 @@ type rewriteSourceSelectionStats struct {
 }
 
 type rewriteRIDAllocator struct {
+	mu      sync.Mutex
 	next    uint64
 	reserve func(count int) (uint64, error)
 }
@@ -301,6 +302,8 @@ func (a *rewriteRIDAllocator) Reserve(count int) (uint64, error) {
 	if err := validateRewriteRIDCount(count); err != nil {
 		return 0, err
 	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
 	if a.reserve != nil {
 		start, err := a.reserve(count)
 		if err != nil {
@@ -3471,7 +3474,32 @@ func (w *rewriteWriter) setLeafPageLogSeqAllocator(seqAlloc *leafLogSeqAllocator
 	w.leafSeqAllocator = seqAlloc
 }
 
-func (w *rewriteWriter) cloneLeafPageLogLane(seqAlloc *leafLogSeqAllocator) (LeafPageLog, error) {
+func (w *rewriteWriter) leafPageLogSeqFloor() uint32 {
+	if w == nil {
+		return 0
+	}
+	return w.leafSeq
+}
+
+func (w *rewriteWriter) leafPageLogRIDAllocator() *rewriteRIDAllocator {
+	if w == nil {
+		return nil
+	}
+	if w.ridAlloc != nil {
+		return w.ridAlloc
+	}
+	return newRewriteRIDAllocator(w.nextRID, nil)
+}
+
+func (w *rewriteWriter) setLeafPageLogRIDAllocator(ridAlloc *rewriteRIDAllocator) {
+	if w == nil || ridAlloc == nil {
+		return
+	}
+	w.ridAlloc = ridAlloc
+	w.nextRID = 0
+}
+
+func (w *rewriteWriter) cloneLeafPageLogLane(seqAlloc *leafLogSeqAllocator, ridAlloc *rewriteRIDAllocator) (LeafPageLog, error) {
 	if w == nil {
 		return nil, errors.New("vlog-rewrite: nil writer")
 	}
@@ -3482,6 +3510,7 @@ func (w *rewriteWriter) cloneLeafPageLogLane(seqAlloc *leafLogSeqAllocator) (Lea
 	clone.leafDir = w.leafDir
 	clone.leafLane = w.leafLane
 	clone.leafSeqAllocator = seqAlloc
+	clone.ridAlloc = ridAlloc
 	clone.blockCompression = w.blockCompression
 	clone.blockCodec = w.blockCodec
 	clone.leafBlockCodec = w.leafBlockCodec

--- a/TreeDB/db/vlog_rewrite_test.go
+++ b/TreeDB/db/vlog_rewrite_test.go
@@ -134,6 +134,56 @@ func TestNoteRewriteSwapTouchedSegments(t *testing.T) {
 	}
 }
 
+func TestRegisterRewriteCreatedValueLogSegmentsDemotesPriorMultiCurrentLeafSegment(t *testing.T) {
+	dir := t.TempDir()
+	ids := make([]uint32, 2)
+	for i := range ids {
+		id, err := valuelog.EncodeFileID(valuelog.ReservedLeafLogLaneID, uint32(i+1))
+		if err != nil {
+			t.Fatalf("EncodeFileID(%d): %v", i+1, err)
+		}
+		ids[i] = id
+		path := valuelog.SegmentPath(dir, id)
+		w, err := valuelog.NewWriter(path, id)
+		if err != nil {
+			t.Fatalf("NewWriter(%q): %v", path, err)
+		}
+		if _, err := w.Append(0, nil, uint64(i+1), []byte("leaf")); err != nil {
+			_ = w.Close()
+			t.Fatalf("Append(%q): %v", path, err)
+		}
+		if err := w.Close(); err != nil {
+			t.Fatalf("Close(%q): %v", path, err)
+		}
+	}
+
+	mgr, err := valuelog.NewManager(dir)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	t.Cleanup(func() { _ = mgr.Close() })
+	mgr.SetMultiCurrentWritableLane(valuelog.ReservedLeafLogLaneID, true)
+	d := &DB{valueLogManager: mgr}
+
+	last, hasLast, err := d.registerRewriteCreatedValueLogSegments([]uint32{ids[0]}, 0, false)
+	if err != nil {
+		t.Fatalf("register first segment: %v", err)
+	}
+	if got := mgr.CurrentWritableFileIDs(); !slices.Equal(got, []uint32{ids[0]}) {
+		t.Fatalf("current writable after first register=%v want [%d]", got, ids[0])
+	}
+	last, hasLast, err = d.registerRewriteCreatedValueLogSegments([]uint32{ids[1]}, last, hasLast)
+	if err != nil {
+		t.Fatalf("register second segment: %v", err)
+	}
+	if !hasLast || last != ids[1] {
+		t.Fatalf("last registered=(%d,%t) want (%d,true)", last, hasLast, ids[1])
+	}
+	if got := mgr.CurrentWritableFileIDs(); !slices.Equal(got, []uint32{ids[1]}) {
+		t.Fatalf("current writable after second register=%v want [%d]", got, ids[1])
+	}
+}
+
 func TestLeafRefRewriteCtx_LeafRemapInlinePromotion(t *testing.T) {
 	var ctx leafRefRewriteCtx
 

--- a/TreeDB/internal/valuelog/manager.go
+++ b/TreeDB/internal/valuelog/manager.go
@@ -1558,8 +1558,16 @@ func (m *Manager) registerSegmentLocked(path string, id uint32) error {
 
 // PromoteCurrentWritable marks fileID as current writable. By default this
 // seals the previous current segment in the same encoded lane. Lanes enabled via
-// SetMultiCurrentWritableLane instead use one current slot per file id.
+// SetMultiCurrentWritableLane instead use one current slot per file id unless a
+// caller provides a previous file id with PromoteCurrentWritableReplacing.
 func (m *Manager) PromoteCurrentWritable(fileID uint32) error {
+	return m.PromoteCurrentWritableReplacing(fileID, 0)
+}
+
+// PromoteCurrentWritableReplacing marks fileID current-writable and, when
+// previousFileID is non-zero, seals that writer's prior current segment even for
+// lanes that allow multiple current writers.
+func (m *Manager) PromoteCurrentWritableReplacing(fileID, previousFileID uint32) error {
 	if m == nil {
 		return nil
 	}
@@ -1574,25 +1582,52 @@ func (m *Manager) PromoteCurrentWritable(fileID uint32) error {
 		return &fileNotFoundError{id: fileID}
 	}
 	key := m.currentWritableKeyLocked(lane, fileID)
+	if previousFileID != 0 && previousFileID != fileID {
+		m.demoteCurrentWritableLocked(previousFileID, fileID)
+	}
 	if prevID, ok := m.currentWritableByLane[key]; ok && prevID != 0 && prevID != fileID {
-		if prev := m.files[prevID]; prev != nil {
-			prev.remapMu.Lock()
-			prev.currentWritable.Store(false)
-			if data, _ := prev.mmapData.Load().([]byte); len(data) > 0 {
-				if m.allowDemotedCurrentMmapLocked(prev, fileID) {
-					prev.sealedLazyMmapDenied.Store(false)
-					prev.sealedLazyMmapDeniedCountCap.Store(0)
-					prev.sealedLazyMmapDeniedBytesCap.Store(0)
-				} else {
-					prev.retirePersistentMmapToDeadLocked()
-				}
-			}
-			prev.remapMu.Unlock()
-		}
+		m.demoteCurrentWritableLocked(prevID, fileID)
 	}
 	f.currentWritable.Store(true)
 	m.currentWritableByLane[key] = fileID
 	return nil
+}
+
+// DemoteCurrentWritable seals fileID if it is currently tracked as writable.
+func (m *Manager) DemoteCurrentWritable(fileID uint32) {
+	if m == nil || fileID == 0 {
+		return
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.demoteCurrentWritableLocked(fileID, 0)
+}
+
+func (m *Manager) demoteCurrentWritableLocked(fileID, nextCurrentID uint32) {
+	if m == nil || fileID == 0 {
+		return
+	}
+	for key, id := range m.currentWritableByLane {
+		if id == fileID {
+			delete(m.currentWritableByLane, key)
+		}
+	}
+	prev := m.files[fileID]
+	if prev == nil {
+		return
+	}
+	prev.remapMu.Lock()
+	prev.currentWritable.Store(false)
+	if data, _ := prev.mmapData.Load().([]byte); len(data) > 0 {
+		if nextCurrentID != 0 && m.allowDemotedCurrentMmapLocked(prev, nextCurrentID) {
+			prev.sealedLazyMmapDenied.Store(false)
+			prev.sealedLazyMmapDeniedCountCap.Store(0)
+			prev.sealedLazyMmapDeniedBytesCap.Store(0)
+		} else {
+			prev.retirePersistentMmapToDeadLocked()
+		}
+	}
+	prev.remapMu.Unlock()
 }
 
 func (m *Manager) currentWritableKeyLocked(lane, fileID uint32) uint32 {

--- a/TreeDB/internal/valuelog/manager.go
+++ b/TreeDB/internal/valuelog/manager.go
@@ -1173,9 +1173,13 @@ type Manager struct {
 
 	mu    sync.RWMutex
 	files map[uint32]*File
-	// currentWritableByLane tracks the one segment per lane that may still grow
-	// and therefore is allowed to remap aggressively for zero-copy unsafe views.
-	currentWritableByLane map[uint32]uint32
+	// currentWritableByLane tracks segments that may still grow and therefore are
+	// allowed to remap aggressively for zero-copy unsafe views. Most lanes have a
+	// single current writer keyed by lane id; lanes listed in
+	// multiCurrentWritableLanes are keyed by file id so independent physical
+	// writers that share an encoded lane can remain current simultaneously.
+	currentWritableByLane     map[uint32]uint32
+	multiCurrentWritableLanes map[uint32]bool
 
 	refreshScans atomic.Uint64
 
@@ -1221,6 +1225,28 @@ func (m *Manager) SetCurrentWritableMmapEnabled(enabled bool) {
 		return
 	}
 	m.currentWritableMmap.Store(enabled)
+}
+
+// SetMultiCurrentWritableLane allows multiple physical files with the same
+// encoded lane id to remain current-writable at the same time. This is used for
+// TreeDB leaf-log append lanes, where the reserved lane id identifies the leaf
+// log class while file ids still identify independent writer streams.
+func (m *Manager) SetMultiCurrentWritableLane(lane uint32, enabled bool) {
+	if m == nil {
+		return
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if !enabled {
+		if m.multiCurrentWritableLanes != nil {
+			delete(m.multiCurrentWritableLanes, lane)
+		}
+		return
+	}
+	if m.multiCurrentWritableLanes == nil {
+		m.multiCurrentWritableLanes = make(map[uint32]bool)
+	}
+	m.multiCurrentWritableLanes[lane] = true
 }
 
 // SetCurrentWritableReadBarrier installs an optional callback that is invoked
@@ -1530,8 +1556,9 @@ func (m *Manager) registerSegmentLocked(path string, id uint32) error {
 	return nil
 }
 
-// PromoteCurrentWritable marks fileID as the current writable segment for its
-// lane and seals the previous current segment in that lane.
+// PromoteCurrentWritable marks fileID as current writable. By default this
+// seals the previous current segment in the same encoded lane. Lanes enabled via
+// SetMultiCurrentWritableLane instead use one current slot per file id.
 func (m *Manager) PromoteCurrentWritable(fileID uint32) error {
 	if m == nil {
 		return nil
@@ -1546,7 +1573,8 @@ func (m *Manager) PromoteCurrentWritable(fileID uint32) error {
 	if !ok {
 		return &fileNotFoundError{id: fileID}
 	}
-	if prevID, ok := m.currentWritableByLane[lane]; ok && prevID != 0 && prevID != fileID {
+	key := m.currentWritableKeyLocked(lane, fileID)
+	if prevID, ok := m.currentWritableByLane[key]; ok && prevID != 0 && prevID != fileID {
 		if prev := m.files[prevID]; prev != nil {
 			prev.remapMu.Lock()
 			prev.currentWritable.Store(false)
@@ -1563,8 +1591,15 @@ func (m *Manager) PromoteCurrentWritable(fileID uint32) error {
 		}
 	}
 	f.currentWritable.Store(true)
-	m.currentWritableByLane[lane] = fileID
+	m.currentWritableByLane[key] = fileID
 	return nil
+}
+
+func (m *Manager) currentWritableKeyLocked(lane, fileID uint32) uint32 {
+	if m != nil && m.multiCurrentWritableLanes != nil && m.multiCurrentWritableLanes[lane] {
+		return fileID
+	}
+	return lane
 }
 
 // CurrentWritableFileIDs returns the registered current writable value-log

--- a/TreeDB/internal/valuelog/manager_test.go
+++ b/TreeDB/internal/valuelog/manager_test.go
@@ -344,6 +344,41 @@ func TestManagerPromoteCurrentWritable_SwitchesPriorLaneSegmentToSealed(t *testi
 	}
 }
 
+func TestManagerPromoteCurrentWritable_AllowsMultiCurrentWritableLane(t *testing.T) {
+	mgr := &Manager{
+		files:                 make(map[uint32]*File),
+		currentWritableByLane: make(map[uint32]uint32),
+	}
+	mgr.SetMultiCurrentWritableLane(ReservedLeafLogLaneID, true)
+	f1 := &File{ID: mustEncodeFileID(t, ReservedLeafLogLaneID, 1)}
+	f2 := &File{ID: mustEncodeFileID(t, ReservedLeafLogLaneID, 2)}
+	mgr.files[f1.ID] = f1
+	mgr.files[f2.ID] = f2
+
+	if err := mgr.PromoteCurrentWritable(f1.ID); err != nil {
+		t.Fatalf("PromoteCurrentWritable(first): %v", err)
+	}
+	if err := mgr.PromoteCurrentWritable(f2.ID); err != nil {
+		t.Fatalf("PromoteCurrentWritable(second): %v", err)
+	}
+	if !f1.currentWritable.Load() {
+		t.Fatalf("first file was sealed despite multi-current lane")
+	}
+	if !f2.currentWritable.Load() {
+		t.Fatalf("second file not marked current writable")
+	}
+	gotIDs := mgr.CurrentWritableFileIDs()
+	got := make(map[uint32]struct{}, len(gotIDs))
+	for _, id := range gotIDs {
+		got[id] = struct{}{}
+	}
+	for _, id := range []uint32{f1.ID, f2.ID} {
+		if _, ok := got[id]; !ok {
+			t.Fatalf("CurrentWritableFileIDs missing %d; got %v", id, gotIDs)
+		}
+	}
+}
+
 func TestManagerSetCurrentWritableReadBarrier_NilClearsCallback(t *testing.T) {
 	mgr := &Manager{}
 	calls := 0

--- a/TreeDB/internal/valuelog/manager_test.go
+++ b/TreeDB/internal/valuelog/manager_test.go
@@ -379,6 +379,35 @@ func TestManagerPromoteCurrentWritable_AllowsMultiCurrentWritableLane(t *testing
 	}
 }
 
+func TestManagerPromoteCurrentWritableReplacing_DemotesPriorMultiCurrentWriter(t *testing.T) {
+	mgr := &Manager{
+		files:                 make(map[uint32]*File),
+		currentWritableByLane: make(map[uint32]uint32),
+	}
+	mgr.SetMultiCurrentWritableLane(ReservedLeafLogLaneID, true)
+	f1 := &File{ID: mustEncodeFileID(t, ReservedLeafLogLaneID, 1)}
+	f2 := &File{ID: mustEncodeFileID(t, ReservedLeafLogLaneID, 2)}
+	mgr.files[f1.ID] = f1
+	mgr.files[f2.ID] = f2
+
+	if err := mgr.PromoteCurrentWritable(f1.ID); err != nil {
+		t.Fatalf("PromoteCurrentWritable(first): %v", err)
+	}
+	if err := mgr.PromoteCurrentWritableReplacing(f2.ID, f1.ID); err != nil {
+		t.Fatalf("PromoteCurrentWritableReplacing(second): %v", err)
+	}
+	if f1.currentWritable.Load() {
+		t.Fatalf("first file still current writable after replacement")
+	}
+	if !f2.currentWritable.Load() {
+		t.Fatalf("second file not marked current writable")
+	}
+	gotIDs := mgr.CurrentWritableFileIDs()
+	if len(gotIDs) != 1 || gotIDs[0] != f2.ID {
+		t.Fatalf("CurrentWritableFileIDs=%v want [%d]", gotIDs, f2.ID)
+	}
+}
+
 func TestManagerSetCurrentWritableReadBarrier_NilClearsCallback(t *testing.T) {
 	mgr := &Manager{}
 	calls := 0


### PR DESCRIPTION
Dependency snapshot:
- Depends on #2926 / PR #2935, now merged at `1a8c3704188353da960ec9be8631430747837c3b`.
- PR is retargeted to `main` and includes additive commits only (no force-push).

Scope correction:
- The leaf-log lane substrate now lives in `TreeDB/caching`, the actual cached path wired by `newCachingLeafPageLog(db, &db.leafLog)`.
- Default `AppendLeafPage` still stays on lane 0.
- Selected-lane appends are opt-in through the exported lane-provider contract.
- Created/current segment snapshots, registration, flush/sync/close now fan out across leaf lanes.
- Shared leaf-log sequence allocation keeps selected lanes in the reserved leaf-log file-id family without duplicate segment IDs.
- Standalone/direct backend lane grouping now shares both sequence and RID allocators across lane clones and serializes each physical lane.
- Selected cached leaf lanes remain live-readable: current-writable tracking supports multiple current leaf-log files, replaces each writer's prior segment on rotation, and barriers flush by file ID/current seq.
- Online rewrite registration now demotes the previous segment for a single physical rewrite writer even when it writes in the reserved multi-current leaf-log lane.

Non-goals:
- No span-native production routing yet (#2928).
- No collector goroutine/queue.
- No default cached append behavior change.

Tests:
- `GOWORK=off go test ./TreeDB/caching -run 'TestCachingLeafPageLogLane' -count=1`
- `GOWORK=off go test ./TreeDB/internal/valuelog ./TreeDB/caching ./TreeDB/db -run 'TestManagerPromoteCurrentWritable|TestCachingLeafPageLogLane|TestLeafPageLogLane|TestFlushApplySpanNativeRootMismatchTracksAbandonedLeafLogOutput' -count=1`
- `GOWORK=off go test -race ./TreeDB/caching ./TreeDB/db ./TreeDB/internal/valuelog -run 'TestManagerPromoteCurrentWritable|TestCachingLeafPageLogLane|TestLeafPageLogLane|TestFlushApplySpanNativeRootMismatchTracksAbandonedLeafLogOutput' -count=1`
- `GOWORK=off go test -race ./TreeDB/caching -run 'TestCachingLeafPageLogLane|TestRaceFlushRotate' -count=1`
- `GOWORK=off go test ./TreeDB/caching -run 'TestVlogGenerationRewritePlan_(FiltersPenalizedSegments|ReadmitsPenalizedSegmentWhenStaleBytesImprove)$' -count=100`
- `GOWORK=off go test ./TreeDB/db -run 'TestRegisterRewriteCreatedValueLogSegmentsDemotesPriorMultiCurrentLeafSegment|TestValueLogRewriteOnline_RewritesCollectionLeafRefRootPointers|TestLeafRefRewriteCtx' -count=1`
- `GOWORK=off go test ./TreeDB/internal/valuelog ./TreeDB/db -run 'TestManagerPromoteCurrentWritable|TestRegisterRewriteCreatedValueLogSegmentsDemotesPriorMultiCurrentLeafSegment|TestLeafPageLogLane|TestValueLogRewriteOnline_RewritesCollectionLeafRefRootPointers' -count=1`
- `GOWORK=off go test -race ./TreeDB/caching ./TreeDB/db ./TreeDB/internal/valuelog -run 'TestManagerPromoteCurrentWritable|TestCachingLeafPageLogLane|TestLeafPageLogLane|TestRegisterRewriteCreatedValueLogSegmentsDemotesPriorMultiCurrentLeafSegment|TestFlushApplySpanNativeRootMismatchTracksAbandonedLeafLogOutput' -count=1`
- `GOWORK=off go test ./TreeDB/caching ./TreeDB/db ./TreeDB/internal/valuelog ./TreeDB/zipper -count=1`

Performance/allocation note:
- Production/default cached appends still use lane 0.
- Selected-lane access is opt-in and uses direct lane lookup; no collector queue is introduced.
- Segment aggregation happens in publish/flush/sync/close bookkeeping, not per leaf payload copy.
- Ordinary value-log appends return before the leaf-lane lock scan unless the lane id is the reserved leaf-log lane.

Risks / follow-ups:
- #2928 owns span-native worker routing onto this substrate.
- #2929/#2934 still own full checkpoint/reopen/GC/current-writable lifecycle hardening for multi-lane leaf-log output.

Latest local head:
- `2bcf92ef441687b8d580c51141a4e5c26c1f6633`
