### PR TITLE
TreeDB: route span-native leaf output to leaf-log lanes

### DIFF
--- a/TreeDB/caching/leaf_page_log_test.go
+++ b/TreeDB/caching/leaf_page_log_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -479,6 +480,117 @@ func TestCachingLeafPageLogLaneSelectionAppendsUniqueReadablePtrs(t *testing.T) 
 		}
 		if !bytes.Equal(got, res.want) {
 			t.Fatalf("reopen read lane %d mismatch", res.lane)
+		}
+	}
+}
+
+func TestCachingSpanNativeLeafLogOutputUsesSelectedLanes(t *testing.T) {
+	dir := t.TempDir()
+	backend, err := backenddb.Open(backenddb.Options{
+		Dir:                        dir,
+		ChunkSize:                  64 * 1024,
+		IndexOuterLeavesInValueLog: true,
+		FlushAdmissionPolicy:       backenddb.FlushAdmissionPolicyExplicit,
+		FlushApplyConcurrency:      4,
+		FlushApplyMinEntries:       1,
+		FlushApplyMinSpans:         1,
+		FlushApplyMinBytes:         1,
+		FlushApplySpanNative:       true,
+		ValueLog: backenddb.ValueLogOptions{
+			Compression: backenddb.ValueLogCompressionBlock,
+			BlockCodec:  backenddb.ValueLogBlockLZ4,
+		},
+	})
+	if err != nil {
+		t.Fatalf("backend open: %v", err)
+	}
+	captured := &capturingLeafLogBackend{BackendDB: backend}
+	db, err := Open(dir, captured, Options{
+		IndexOuterLeavesInValueLog: true,
+		FlushApplyConcurrency:      4,
+		FlushApplyMinEntries:       1,
+		FlushApplyMinSpans:         1,
+		FlushApplyMinBytes:         1,
+		FlushApplySpanNative:       true,
+		RelaxedSync:                true,
+		AllowUnsafe:                true,
+	})
+	if err != nil {
+		_ = captured.Close()
+		t.Fatalf("cache open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	writeBatch := func(label string, fn func(*Batch) error) {
+		t.Helper()
+		b := db.NewBatch()
+		if err := fn(b); err != nil {
+			_ = b.Close()
+			t.Fatalf("%s build: %v", label, err)
+		}
+		if err := b.Write(); err != nil {
+			_ = b.Close()
+			t.Fatalf("%s write: %v", label, err)
+		}
+		if err := b.Close(); err != nil {
+			t.Fatalf("%s close: %v", label, err)
+		}
+	}
+	writeBatch("base", func(b *Batch) error {
+		for i := 0; i < 8192; i++ {
+			key := []byte(fmt.Sprintf("key-%06d", i))
+			val := bytes.Repeat([]byte{byte(1 + i%251)}, 180)
+			if err := b.Set(key, val); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if err := db.Checkpoint(); err != nil {
+		t.Fatalf("base Checkpoint: %v", err)
+	}
+
+	writeBatch("updates", func(b *Batch) error {
+		for i := 0; i < 512; i++ {
+			idx := (i * 97) % 8192
+			key := []byte(fmt.Sprintf("key-%06d", idx))
+			val := []byte(fmt.Sprintf("updated-%06d", idx))
+			if err := b.Set(key, val); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if err := db.Checkpoint(); err != nil {
+		t.Fatalf("updates Checkpoint: %v", err)
+	}
+
+	stats := captured.Stats()
+	raw := stats["treedb.flush_apply.span_native.used_ops_total"]
+	usedOps, err := strconv.ParseUint(raw, 10, 64)
+	if err != nil || usedOps == 0 {
+		t.Fatalf("span-native used ops stat=%q err=%v want >0", raw, err)
+	}
+	lanes := db.leafLogAppendLanesSnapshot()
+	nonDefault := 0
+	for i, l := range lanes {
+		if i > 0 && l != nil && l.vlogSeq > 0 {
+			nonDefault++
+		}
+	}
+	if nonDefault == 0 {
+		t.Fatalf("selected leaf-log lanes=%d want >0 (snapshot len=%d, leafLog=%T, outer=%t, append_calls=%q)", nonDefault, len(lanes), captured.leafLog, db.indexOuterLeavesInValueLog, stats["treedb.flush_apply.leaf_log_output.append_calls_total"])
+	}
+
+	for _, idx := range []int{0, 97, 97 * 7 % 8192} {
+		key := []byte(fmt.Sprintf("key-%06d", idx))
+		got, err := db.Get(key)
+		if err != nil {
+			t.Fatalf("Get(%q): %v", key, err)
+		}
+		want := []byte(fmt.Sprintf("updated-%06d", idx))
+		if !bytes.Equal(got, want) {
+			t.Fatalf("Get(%q)=%q want %q", key, got, want)
 		}
 	}
 }

--- a/TreeDB/caching/leaf_page_log_test.go
+++ b/TreeDB/caching/leaf_page_log_test.go
@@ -174,7 +174,16 @@ func TestDB_NoteLeafGenerationRecordLength_ForwardsToBackend(t *testing.T) {
 
 type capturingLeafLogBackend struct {
 	BackendDB
-	leafLog backenddb.LeafPageLog
+	leafLog   backenddb.LeafPageLog
+	closeOnce sync.Once
+	closeErr  error
+}
+
+func (b *capturingLeafLogBackend) Close() error {
+	b.closeOnce.Do(func() {
+		b.closeErr = b.BackendDB.Close()
+	})
+	return b.closeErr
 }
 
 func (b *capturingLeafLogBackend) SetLeafPageLog(log backenddb.LeafPageLog) {
@@ -519,7 +528,10 @@ func TestCachingSpanNativeLeafLogOutputUsesSelectedLanes(t *testing.T) {
 		_ = captured.Close()
 		t.Fatalf("cache open: %v", err)
 	}
-	defer func() { _ = db.Close() }()
+	defer func() {
+		_ = db.Close()
+		_ = captured.Close()
+	}()
 
 	writeBatch := func(label string, fn func(*Batch) error) {
 		t.Helper()
@@ -574,7 +586,13 @@ func TestCachingSpanNativeLeafLogOutputUsesSelectedLanes(t *testing.T) {
 	lanes := db.leafLogAppendLanesSnapshot()
 	nonDefault := 0
 	for i, l := range lanes {
-		if i > 0 && l != nil && l.vlogSeq > 0 {
+		if i == 0 || l == nil {
+			continue
+		}
+		l.vlogMu.Lock()
+		used := l.vlogSeq > 0
+		l.vlogMu.Unlock()
+		if used {
 			nonDefault++
 		}
 	}

--- a/TreeDB/caching/vlog_generation_protected_paths_test.go
+++ b/TreeDB/caching/vlog_generation_protected_paths_test.go
@@ -360,9 +360,18 @@ func mustCurrentValueLogPathsForOwnershipTest(t *testing.T, db *DB) (valuePath s
 	db.lanes[0].vlogMu.Lock()
 	valuePath = db.lanes[0].vlogPath
 	db.lanes[0].vlogMu.Unlock()
-	db.leafLog.vlogMu.Lock()
-	leafPath = db.leafLog.vlogPath
-	db.leafLog.vlogMu.Unlock()
+	for _, leafLane := range db.leafLogAppendLanesSnapshot() {
+		if leafLane == nil {
+			continue
+		}
+		leafLane.vlogMu.Lock()
+		path := leafLane.vlogPath
+		leafLane.vlogMu.Unlock()
+		if path != "" {
+			leafPath = path
+			break
+		}
+	}
 	if valuePath == "" {
 		t.Fatal("missing current value_vlog path")
 	}

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -2094,6 +2094,7 @@ func (db *DB) Close() error {
 	// Wait for active apply attempts before closing the reusable flush/apply
 	// worker pool and tearing down index resources.
 	db.writeMu.Lock()
+	leafPageLog := db.leafPageLog
 	if db.flushApplyWorkerPool != nil {
 		db.flushApplyWorkerPool.Close()
 		db.flushApplyWorkerPool = nil
@@ -2133,6 +2134,11 @@ func (db *DB) Close() error {
 	}
 	if err := db.closeAllIndexes(); err != nil {
 		errs = append(errs, err)
+	}
+	if group, ok := leafPageLog.(*leafPageLogLaneGroup); ok {
+		if err := group.CloseSelectedLanes(); err != nil {
+			errs = append(errs, err)
+		}
 	}
 	if vm != nil {
 		if err := vm.Close(); err != nil {

--- a/TreeDB/db/leaf_page_log.go
+++ b/TreeDB/db/leaf_page_log.go
@@ -300,6 +300,10 @@ func (l *leafPageLogWithRecordLengthHints) LeafPageLogLane(workerIndex int) (Lea
 	return wrapLeafPageLogWithRecordLengthHints(l.db, lane), true
 }
 
+func (l *leafPageLogWithRecordLengthHints) LeafPageLogLaneAny(workerIndex int) (any, bool) {
+	return l.LeafPageLogLane(workerIndex)
+}
+
 func (l *leafPageLogWithRecordLengthHints) ProtectedLeafGenerationRootIDs() []uint64 {
 	if l == nil || l.inner == nil {
 		return nil

--- a/TreeDB/db/leaf_page_log_lanes.go
+++ b/TreeDB/db/leaf_page_log_lanes.go
@@ -277,6 +277,8 @@ func (g *leafPageLogLaneGroup) LeafPageLogLaneAny(workerIndex int) (any, bool) {
 	return g.LeafPageLogLane(workerIndex)
 }
 
+func (g *leafPageLogLaneGroup) ConcurrentLeafPageAppends() bool { return g != nil }
+
 func (g *leafPageLogLaneGroup) leafPageLogLane(workerIndex int) (LeafPageLog, bool) {
 	return g.LeafPageLogLane(workerIndex)
 }

--- a/TreeDB/db/leaf_page_log_lanes.go
+++ b/TreeDB/db/leaf_page_log_lanes.go
@@ -234,6 +234,10 @@ func (g *leafPageLogLaneGroup) LeafPageLogLane(workerIndex int) (LeafPageLog, bo
 	return &leafPageLogLaneHandle{group: g, index: workerIndex}, true
 }
 
+func (g *leafPageLogLaneGroup) LeafPageLogLaneAny(workerIndex int) (any, bool) {
+	return g.LeafPageLogLane(workerIndex)
+}
+
 func (g *leafPageLogLaneGroup) leafPageLogLane(workerIndex int) (LeafPageLog, bool) {
 	return g.LeafPageLogLane(workerIndex)
 }

--- a/TreeDB/db/leaf_page_log_lanes.go
+++ b/TreeDB/db/leaf_page_log_lanes.go
@@ -189,13 +189,52 @@ func (g *leafPageLogLaneGroup) Sync() error {
 }
 
 func (g *leafPageLogLaneGroup) Close() error {
-	return g.forEachLane(func(lane LeafPageLog) error {
+	if g == nil {
+		return nil
+	}
+	g.mu.Lock()
+	lanes := append([]LeafPageLog(nil), g.lanes...)
+	for i := range g.lanes {
+		g.lanes[i] = nil
+	}
+	g.mu.Unlock()
+	var err error
+	for _, lane := range lanes {
+		if lane == nil {
+			continue
+		}
 		closer, ok := lane.(interface{ Close() error })
 		if !ok {
-			return nil
+			continue
 		}
-		return closer.Close()
-	})
+		err = errors.Join(err, closer.Close())
+	}
+	return err
+}
+
+func (g *leafPageLogLaneGroup) CloseSelectedLanes() error {
+	if g == nil {
+		return nil
+	}
+	g.mu.Lock()
+	lanes := append([]LeafPageLog(nil), g.lanes...)
+	for i := 1; i < len(g.lanes); i++ {
+		g.lanes[i] = nil
+	}
+	g.mu.Unlock()
+	var err error
+	for i := 1; i < len(lanes); i++ {
+		lane := lanes[i]
+		if lane == nil {
+			continue
+		}
+		closer, ok := lane.(interface{ Close() error })
+		if !ok {
+			continue
+		}
+		err = errors.Join(err, closer.Close())
+	}
+	return err
 }
 
 func (g *leafPageLogLaneGroup) LeafPageLogLane(workerIndex int) (LeafPageLog, bool) {

--- a/TreeDB/db/leaf_page_log_lanes_test.go
+++ b/TreeDB/db/leaf_page_log_lanes_test.go
@@ -183,6 +183,20 @@ func openLeafPageLogLaneTestDB(t *testing.T) (*DB, LeafPageLogCloser) {
 	return db, leafLog
 }
 
+func TestLeafPageLogLaneGroupAdvertisesConcurrentAppends(t *testing.T) {
+	db, leafLog := openLeafPageLogLaneTestDB(t)
+	defer func() { _ = leafLog.Close() }()
+	defer func() { _ = db.Close() }()
+
+	concurrent, ok := db.leafPageLog.(LeafPageConcurrentAppendLog)
+	if !ok {
+		t.Fatalf("leaf log %T missing concurrent append marker", db.leafPageLog)
+	}
+	if !concurrent.ConcurrentLeafPageAppends() {
+		t.Fatalf("ConcurrentLeafPageAppends=false for %T", db.leafPageLog)
+	}
+}
+
 func TestLeafPageLogLaneSelectionAppendsUniqueReadablePtrs(t *testing.T) {
 	db, _ := openLeafPageLogLaneTestDB(t)
 

--- a/TreeDB/zipper/span_native_apply.go
+++ b/TreeDB/zipper/span_native_apply.go
@@ -255,7 +255,7 @@ func (z *Zipper) applySpanNativeWithPrepared(rootID uint64, ops []batch.Entry, p
 	var workerBusyNs atomic.Int64
 	var dispatchedTasks atomic.Uint64
 	var completedTasks atomic.Uint64
-	runRange := func(_ int, job int) {
+	runRange := func(workerID int, job int) {
 		dispatchedTasks.Add(1)
 		busyStart := time.Now()
 		defer func() {
@@ -281,7 +281,7 @@ func (z *Zipper) applySpanNativeWithPrepared(rootID uint64, ops []batch.Entry, p
 		}
 		var leafPagePersister leafPagePersistSink = leafLogOutput
 		if leafLogOutput != nil && scheduledWorkers > 1 {
-			laneIndex := (job % scheduledWorkers) + 1
+			laneIndex := workerID + 1
 			leafPagePersister = &spanNativeLeafLogOutputLane{gate: leafLogOutput, log: leafLogOutput.leafPageLogForWorker(z, laneIndex)}
 		}
 		workerApplyCfg := applyRunConfig{maxParallelWorkers: 1, leafPagePersister: leafPagePersister}

--- a/TreeDB/zipper/span_native_apply.go
+++ b/TreeDB/zipper/span_native_apply.go
@@ -34,6 +34,11 @@ type spanNativeLeafLogOutputGate struct {
 	sem chan struct{}
 }
 
+type spanNativeLeafLogOutputLane struct {
+	gate *spanNativeLeafLogOutputGate
+	log  LeafPageLog
+}
+
 var spanNativeLeafLogPayloadScratchPool sync.Pool
 
 func newSpanNativeLeafLogOutputGate(limit int) *spanNativeLeafLogOutputGate {
@@ -59,8 +64,44 @@ func releaseSpanNativeLeafLogPayloadScratch(buf []byte) {
 	spanNativeLeafLogPayloadScratchPool.Put(buf[:0])
 }
 
+func (g *spanNativeLeafLogOutputGate) leafPageLogForWorker(z *Zipper, workerIndex int) LeafPageLog {
+	if z == nil || z.leafPageLog == nil {
+		return nil
+	}
+	if workerIndex > 0 {
+		if provider, ok := z.leafPageLog.(LeafPageLogLaneProvider); ok {
+			if laneLog, ok := provider.LeafPageLogLane(workerIndex); ok && laneLog != nil {
+				return laneLog
+			}
+		}
+		if provider, ok := z.leafPageLog.(leafPageLogLaneAnyProvider); ok {
+			if lane, ok := provider.LeafPageLogLaneAny(workerIndex); ok && lane != nil {
+				if laneLog, ok := lane.(LeafPageLog); ok && laneLog != nil {
+					return laneLog
+				}
+			}
+		}
+	}
+	return z.leafPageLog
+}
+
 func (g *spanNativeLeafLogOutputGate) persistLeafPageData(z *Zipper, leafPage []byte, metrics *adaptive.Metrics) (page.ChildRef, error) {
-	prepared := z.leafPageLogConsumesPreparedPayloads(false)
+	return g.persistLeafPageDataForWorker(z, 0, leafPage, metrics)
+}
+
+func (g *spanNativeLeafLogOutputLane) persistLeafPageData(z *Zipper, leafPage []byte, metrics *adaptive.Metrics) (page.ChildRef, error) {
+	if g == nil || g.gate == nil {
+		return z.persistLeafPageData(leafPage, metrics)
+	}
+	return g.gate.persistLeafPageDataToLog(z, g.log, leafPage, metrics)
+}
+
+func (g *spanNativeLeafLogOutputGate) persistLeafPageDataForWorker(z *Zipper, workerIndex int, leafPage []byte, metrics *adaptive.Metrics) (page.ChildRef, error) {
+	return g.persistLeafPageDataToLog(z, g.leafPageLogForWorker(z, workerIndex), leafPage, metrics)
+}
+
+func (g *spanNativeLeafLogOutputGate) persistLeafPageDataToLog(z *Zipper, log LeafPageLog, leafPage []byte, metrics *adaptive.Metrics) (page.ChildRef, error) {
+	prepared := leafPageLogConsumesPreparedPayloads(log, false)
 	var payload []byte
 	var scratch []byte
 	if prepared {
@@ -82,26 +123,41 @@ func (g *spanNativeLeafLogOutputGate) persistLeafPageData(z *Zipper, leafPage []
 		metrics.ZipperLeafLogOutputReservationWaitNs += reservationWait.Nanoseconds()
 	}
 	if !prepared {
-		return z.persistLeafPageData(leafPage, metrics)
+		return z.persistLeafPageDataToLog(log, leafPage, metrics)
 	}
-	ref, err := z.persistPreparedLeafPageDataTo(leafPage, payload, metrics)
+	ref, err := z.persistPreparedLeafPageDataToLog(log, leafPage, payload, metrics)
 	releaseSpanNativeLeafLogPayloadScratch(scratch)
 	return ref, err
 }
 
 func (g *spanNativeLeafLogOutputGate) persistLeafPageBatchDataTo(z *Zipper, leafPages [][]byte, refs []page.ChildRef, metrics *adaptive.Metrics) ([]page.ChildRef, error) {
+	return g.persistLeafPageBatchDataToForWorker(z, 0, leafPages, refs, metrics)
+}
+
+func (g *spanNativeLeafLogOutputLane) persistLeafPageBatchDataTo(z *Zipper, leafPages [][]byte, refs []page.ChildRef, metrics *adaptive.Metrics) ([]page.ChildRef, error) {
+	if g == nil || g.gate == nil {
+		return z.persistLeafPageBatchDataTo(leafPages, refs, metrics)
+	}
+	return g.gate.persistLeafPageBatchDataToLog(z, g.log, leafPages, refs, metrics)
+}
+
+func (g *spanNativeLeafLogOutputGate) persistLeafPageBatchDataToForWorker(z *Zipper, workerIndex int, leafPages [][]byte, refs []page.ChildRef, metrics *adaptive.Metrics) ([]page.ChildRef, error) {
+	return g.persistLeafPageBatchDataToLog(z, g.leafPageLogForWorker(z, workerIndex), leafPages, refs, metrics)
+}
+
+func (g *spanNativeLeafLogOutputGate) persistLeafPageBatchDataToLog(z *Zipper, log LeafPageLog, leafPages [][]byte, refs []page.ChildRef, metrics *adaptive.Metrics) ([]page.ChildRef, error) {
 	refs = refs[:0]
 	if len(leafPages) == 0 {
 		return refs, nil
 	}
 	if len(leafPages) == 1 {
-		ref, err := g.persistLeafPageData(z, leafPages[0], metrics)
+		ref, err := g.persistLeafPageDataToLog(z, log, leafPages[0], metrics)
 		if err != nil {
 			return nil, err
 		}
 		return append(refs, ref), nil
 	}
-	prepared := z.leafPageLogConsumesPreparedPayloads(true)
+	prepared := leafPageLogConsumesPreparedPayloads(log, true)
 	var payloads [][]byte
 	if prepared {
 		var payloadInline [8][]byte
@@ -129,9 +185,9 @@ func (g *spanNativeLeafLogOutputGate) persistLeafPageBatchDataTo(z *Zipper, leaf
 		metrics.ZipperLeafLogOutputReservationWaitNs += reservationWait.Nanoseconds()
 	}
 	if !prepared {
-		return z.persistLeafPageBatchDataTo(leafPages, refs, metrics)
+		return z.persistLeafPageBatchDataToLog(log, leafPages, refs, metrics)
 	}
-	return z.persistPreparedLeafPageBatchDataTo(leafPages, payloads, refs, metrics)
+	return z.persistPreparedLeafPageBatchDataToLog(log, leafPages, payloads, refs, metrics)
 }
 
 func (z *Zipper) applySpanNativeWithPrepared(rootID uint64, ops []batch.Entry, prepared ReadOnlyPrepareResult, workers int, workerPool *ApplyWorkerPool) (ApplyResult, bool, error) {
@@ -223,7 +279,12 @@ func (z *Zipper) applySpanNativeWithPrepared(rootID uint64, ops []batch.Entry, p
 			rangeMetrics[job] = localMetrics
 			rangeRetired[job] = localRetired
 		}
-		workerApplyCfg := applyRunConfig{maxParallelWorkers: 1, leafPagePersister: leafLogOutput}
+		var leafPagePersister leafPagePersistSink = leafLogOutput
+		if leafLogOutput != nil && scheduledWorkers > 1 {
+			laneIndex := (job % scheduledWorkers) + 1
+			leafPagePersister = &spanNativeLeafLogOutputLane{gate: leafLogOutput, log: leafLogOutput.leafPageLogForWorker(z, laneIndex)}
+		}
+		workerApplyCfg := applyRunConfig{maxParallelWorkers: 1, leafPagePersister: leafPagePersister}
 		for i := workerRange.FirstSpan; i < end; i++ {
 			span := prepared.LeafSpans[i]
 			newRef, splits, err := z.writeRecursive(span.Ref, ops[span.PointOpStart:span.PointOpEnd], nil, false, nil, &localMetrics, span.LowKey, span.HighKey, &localRetired, workerScratch, false, workerApplyCfg)

--- a/TreeDB/zipper/span_native_apply_engine_test.go
+++ b/TreeDB/zipper/span_native_apply_engine_test.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/snissn/gomap/TreeDB/batch"
 	"github.com/snissn/gomap/TreeDB/node"
@@ -255,16 +256,25 @@ func TestSpanNativeApplyConcurrentWorkerLocalScratchSplitParity(t *testing.T) {
 }
 
 type laneRecordingLeafPageLog struct {
-	mu                    sync.Mutex
-	next                  uint64
-	pages                 map[page.LeafLogPtr][]byte
-	appendCounts          map[int]int
-	batchCalls            map[int]int
-	preparedSingleCalls   map[int]int
-	preparedBatchCalls    map[int]int
-	preparedBatchPageLens []int
-	failLane              int
-	failErr               error
+	mu                     sync.Mutex
+	next                   uint64
+	pages                  map[page.LeafLogPtr][]byte
+	appendCounts           map[int]int
+	batchCalls             map[int]int
+	preparedSingleCalls    map[int]int
+	preparedBatchCalls     map[int]int
+	preparedBatchPageLens  []int
+	activeMu               sync.Mutex
+	activeLanes            map[int]int
+	sameLaneConcurrent     bool
+	sameLaneConcurrentCh   chan struct{}
+	sameLaneConcurrentOnce sync.Once
+	blockLane              int
+	blockEntered           chan struct{}
+	blockRelease           chan struct{}
+	blockOnce              sync.Once
+	failLane               int
+	failErr                error
 }
 
 type laneRecordingLeafPageLogView struct {
@@ -290,6 +300,72 @@ func (l *laneRecordingLeafPageLog) resetObservations() {
 	l.preparedSingleCalls = make(map[int]int)
 	l.preparedBatchCalls = make(map[int]int)
 	l.preparedBatchPageLens = nil
+}
+
+func (l *laneRecordingLeafPageLog) blockFirstAppendOnLane(lane int) (entered <-chan struct{}, release func()) {
+	enteredCh := make(chan struct{})
+	releaseCh := make(chan struct{})
+	l.activeMu.Lock()
+	l.activeLanes = make(map[int]int)
+	l.sameLaneConcurrent = false
+	l.sameLaneConcurrentCh = make(chan struct{})
+	l.sameLaneConcurrentOnce = sync.Once{}
+	l.blockLane = lane
+	l.blockEntered = enteredCh
+	l.blockRelease = releaseCh
+	l.blockOnce = sync.Once{}
+	l.activeMu.Unlock()
+	return enteredCh, func() { close(releaseCh) }
+}
+
+func (l *laneRecordingLeafPageLog) observedSameLaneConcurrentAppend() bool {
+	l.activeMu.Lock()
+	defer l.activeMu.Unlock()
+	return l.sameLaneConcurrent
+}
+
+func (l *laneRecordingLeafPageLog) sameLaneConcurrentSignal() <-chan struct{} {
+	l.activeMu.Lock()
+	defer l.activeMu.Unlock()
+	return l.sameLaneConcurrentCh
+}
+
+func (l *laneRecordingLeafPageLog) enterAppendLane(lane int) func() {
+	l.activeMu.Lock()
+	if l.activeLanes == nil && l.blockEntered == nil && l.sameLaneConcurrentCh == nil {
+		l.activeMu.Unlock()
+		return func() {}
+	}
+	if l.activeLanes == nil {
+		l.activeLanes = make(map[int]int)
+	}
+	if l.activeLanes[lane] > 0 {
+		l.sameLaneConcurrent = true
+		if l.sameLaneConcurrentCh != nil {
+			l.sameLaneConcurrentOnce.Do(func() { close(l.sameLaneConcurrentCh) })
+		}
+	}
+	l.activeLanes[lane]++
+	var wait <-chan struct{}
+	if lane == l.blockLane && l.blockEntered != nil && l.blockRelease != nil {
+		l.blockOnce.Do(func() {
+			close(l.blockEntered)
+			wait = l.blockRelease
+		})
+	}
+	l.activeMu.Unlock()
+	if wait != nil {
+		<-wait
+	}
+	return func() {
+		l.activeMu.Lock()
+		if l.activeLanes[lane] <= 1 {
+			delete(l.activeLanes, lane)
+		} else {
+			l.activeLanes[lane]--
+		}
+		l.activeMu.Unlock()
+	}
 }
 
 func (l *laneRecordingLeafPageLog) LeafPageLogLane(workerIndex int) (LeafPageLog, bool) {
@@ -358,9 +434,12 @@ func (v *laneRecordingLeafPageLogView) PreparedLeafPageAppends() bool { return t
 func (v *laneRecordingLeafPageLogView) PreparedLeafPageBatchAppends() bool { return true }
 
 func (l *laneRecordingLeafPageLog) appendLeafPagesForLane(lane int, leafPages [][]byte, batchCall bool, prepared bool) ([]page.LeafLogPtr, error) {
+	leave := l.enterAppendLane(lane)
+	defer leave()
+
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	if l.failErr != nil && lane == l.failLane {
+	if l.failErr != nil && (lane == l.failLane || (l.failLane < 0 && lane > 0)) {
 		return nil, l.failErr
 	}
 	if l.next == 0 {
@@ -553,11 +632,70 @@ func TestSpanNativeApplyLeafLogOutputRoutesWorkerRangesToSelectedLanes(t *testin
 	}
 }
 
+func TestSpanNativeApplyLeafLogOutputLanesFollowWorkerID(t *testing.T) {
+	_, native := newReadOnlyPrepareZipper(t)
+	native.SetOuterLeavesInValueLog(true)
+	store := newLaneRecordingLeafPageLog()
+	native.SetLeafPageLog(store)
+	native.SetLeafPageReader(store)
+
+	nativeRoot := buildReadOnlyPrepareRootWithKeys(t, native, 8192)
+	store.resetObservations()
+	entered, release := store.blockFirstAppendOnLane(1)
+
+	delta := batch.New(panicValueReader{}, page.DefaultInlineThreshold)
+	defer func() { _ = delta.Close() }()
+	value := bytes.Repeat([]byte("v"), 180)
+	for anchor := 0; anchor < 8192; anchor += 257 {
+		for j := 0; j < 16; j++ {
+			key := []byte(fmt.Sprintf("key-%06d-%03d", anchor, j))
+			if err := delta.Set(key, value); err != nil {
+				t.Fatalf("Set anchor=%d j=%d: %v", anchor, j, err)
+			}
+		}
+	}
+
+	type applyResult struct {
+		result ApplyResult
+		err    error
+	}
+	done := make(chan applyResult, 1)
+	go func() {
+		result, err := native.ApplyWithOptions(nativeRoot, delta, ApplyOptions{SpanNativeApply: true, ParallelApplyConcurrency: 2})
+		done <- applyResult{result: result, err: err}
+	}()
+
+	select {
+	case <-entered:
+	case res := <-done:
+		t.Fatalf("ApplyWithOptions completed before lane 1 append blocked: result=%+v err=%v", res.result, res.err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for lane 1 append to block")
+	}
+
+	select {
+	case <-store.sameLaneConcurrentSignal():
+	case <-time.After(100 * time.Millisecond):
+	}
+	release()
+
+	res := <-done
+	if res.err != nil {
+		t.Fatalf("ApplyWithOptions: %v", res.err)
+	}
+	if !res.result.SpanNativeUsed || res.result.SpanNativeWorkers != 2 {
+		t.Fatalf("span-native used/workers=%v/%d", res.result.SpanNativeUsed, res.result.SpanNativeWorkers)
+	}
+	if store.observedSameLaneConcurrentAppend() {
+		t.Fatalf("observed concurrent appends to the same selected lane; lane selection must follow worker ID")
+	}
+}
+
 func TestSpanNativeApplyLeafLogOutputSelectedLaneFailureReturnsBeforeReduce(t *testing.T) {
 	_, native := newReadOnlyPrepareZipper(t)
 	native.SetOuterLeavesInValueLog(true)
 	store := newLaneRecordingLeafPageLog()
-	store.failLane = 1
+	store.failLane = -1
 	store.failErr = errors.New("test selected leaf-log lane append failure")
 	native.SetLeafPageLog(store)
 	native.SetLeafPageReader(store)

--- a/TreeDB/zipper/span_native_apply_engine_test.go
+++ b/TreeDB/zipper/span_native_apply_engine_test.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"runtime"
+	"sync"
 	"testing"
 
 	"github.com/snissn/gomap/TreeDB/batch"
@@ -252,6 +254,180 @@ func TestSpanNativeApplyConcurrentWorkerLocalScratchSplitParity(t *testing.T) {
 	}
 }
 
+type laneRecordingLeafPageLog struct {
+	mu                    sync.Mutex
+	next                  uint64
+	pages                 map[page.LeafLogPtr][]byte
+	appendCounts          map[int]int
+	batchCalls            map[int]int
+	preparedSingleCalls   map[int]int
+	preparedBatchCalls    map[int]int
+	preparedBatchPageLens []int
+	failLane              int
+	failErr               error
+}
+
+type laneRecordingLeafPageLogView struct {
+	parent *laneRecordingLeafPageLog
+	lane   int
+}
+
+func newLaneRecordingLeafPageLog() *laneRecordingLeafPageLog {
+	return &laneRecordingLeafPageLog{
+		pages:               make(map[page.LeafLogPtr][]byte),
+		appendCounts:        make(map[int]int),
+		batchCalls:          make(map[int]int),
+		preparedSingleCalls: make(map[int]int),
+		preparedBatchCalls:  make(map[int]int),
+	}
+}
+
+func (l *laneRecordingLeafPageLog) resetObservations() {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.appendCounts = make(map[int]int)
+	l.batchCalls = make(map[int]int)
+	l.preparedSingleCalls = make(map[int]int)
+	l.preparedBatchCalls = make(map[int]int)
+	l.preparedBatchPageLens = nil
+}
+
+func (l *laneRecordingLeafPageLog) LeafPageLogLane(workerIndex int) (LeafPageLog, bool) {
+	if workerIndex <= 0 {
+		return l, true
+	}
+	return &laneRecordingLeafPageLogView{parent: l, lane: workerIndex}, true
+}
+
+func (l *laneRecordingLeafPageLog) ConcurrentLeafPageAppends() bool { return true }
+
+func (l *laneRecordingLeafPageLog) PreparedLeafPageAppends() bool { return true }
+
+func (l *laneRecordingLeafPageLog) PreparedLeafPageBatchAppends() bool { return true }
+
+func (l *laneRecordingLeafPageLog) AppendLeafPage(leafPage []byte) (page.LeafLogPtr, error) {
+	ptrs, err := l.appendLeafPagesForLane(0, [][]byte{leafPage}, false, false)
+	if err != nil {
+		return page.LeafLogPtr{}, err
+	}
+	return ptrs[0], nil
+}
+
+func (l *laneRecordingLeafPageLog) AppendLeafPages(leafPages [][]byte) ([]page.LeafLogPtr, error) {
+	return l.appendLeafPagesForLane(0, leafPages, true, false)
+}
+
+func (l *laneRecordingLeafPageLog) AppendPreparedLeafPage(leafPage []byte, _ []byte) (page.LeafLogPtr, error) {
+	ptrs, err := l.appendLeafPagesForLane(0, [][]byte{leafPage}, false, true)
+	if err != nil {
+		return page.LeafLogPtr{}, err
+	}
+	return ptrs[0], nil
+}
+
+func (l *laneRecordingLeafPageLog) AppendPreparedLeafPages(leafPages [][]byte, _ [][]byte) ([]page.LeafLogPtr, error) {
+	return l.appendLeafPagesForLane(0, leafPages, true, true)
+}
+
+func (v *laneRecordingLeafPageLogView) AppendLeafPage(leafPage []byte) (page.LeafLogPtr, error) {
+	ptrs, err := v.parent.appendLeafPagesForLane(v.lane, [][]byte{leafPage}, false, false)
+	if err != nil {
+		return page.LeafLogPtr{}, err
+	}
+	return ptrs[0], nil
+}
+
+func (v *laneRecordingLeafPageLogView) AppendLeafPages(leafPages [][]byte) ([]page.LeafLogPtr, error) {
+	return v.parent.appendLeafPagesForLane(v.lane, leafPages, true, false)
+}
+
+func (v *laneRecordingLeafPageLogView) AppendPreparedLeafPage(leafPage []byte, _ []byte) (page.LeafLogPtr, error) {
+	ptrs, err := v.parent.appendLeafPagesForLane(v.lane, [][]byte{leafPage}, false, true)
+	if err != nil {
+		return page.LeafLogPtr{}, err
+	}
+	return ptrs[0], nil
+}
+
+func (v *laneRecordingLeafPageLogView) AppendPreparedLeafPages(leafPages [][]byte, _ [][]byte) ([]page.LeafLogPtr, error) {
+	return v.parent.appendLeafPagesForLane(v.lane, leafPages, true, true)
+}
+
+func (v *laneRecordingLeafPageLogView) PreparedLeafPageAppends() bool { return true }
+
+func (v *laneRecordingLeafPageLogView) PreparedLeafPageBatchAppends() bool { return true }
+
+func (l *laneRecordingLeafPageLog) appendLeafPagesForLane(lane int, leafPages [][]byte, batchCall bool, prepared bool) ([]page.LeafLogPtr, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.failErr != nil && lane == l.failLane {
+		return nil, l.failErr
+	}
+	if l.next == 0 {
+		l.next = 4
+	}
+	baseOffset := l.next
+	l.next += page.PageSize + 32
+	fileID := uint32(10_000 + lane)
+	ptrs := make([]page.LeafLogPtr, len(leafPages))
+	for i, leafPage := range leafPages {
+		recordLen := uint32(page.PageSize)
+		if len(leafPages) > 1 {
+			recordLen = page.ValuePtrMarkGrouped(page.PageSize, uint8(i))
+		}
+		ptr := page.LeafLogPtr{FileID: fileID, Offset: baseOffset, RecordLengthHint: recordLen, SubIndex: uint16(i)}
+		ptrs[i] = ptr
+		l.pages[ptr] = append([]byte(nil), leafPage...)
+	}
+	l.appendCounts[lane] += len(leafPages)
+	if batchCall {
+		l.batchCalls[lane]++
+	}
+	if prepared {
+		if batchCall {
+			l.preparedBatchCalls[lane]++
+			l.preparedBatchPageLens = append(l.preparedBatchPageLens, len(leafPages))
+		} else {
+			l.preparedSingleCalls[lane]++
+		}
+	}
+	return ptrs, nil
+}
+
+func (l *laneRecordingLeafPageLog) ReadUnsafe(ptr page.ValuePtr) ([]byte, error) {
+	leafPtr, err := page.LeafLogPtrFromValuePtr(ptr)
+	if err != nil {
+		return nil, err
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	data, ok := l.pages[leafPtr]
+	if !ok {
+		return nil, io.EOF
+	}
+	return append([]byte(nil), data...), nil
+}
+
+func (l *laneRecordingLeafPageLog) observedAppendCounts() map[int]int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	out := make(map[int]int, len(l.appendCounts))
+	for lane, count := range l.appendCounts {
+		out[lane] = count
+	}
+	return out
+}
+
+func (l *laneRecordingLeafPageLog) observedPreparedBatchCalls() int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	total := 0
+	for _, count := range l.preparedBatchCalls {
+		total += count
+	}
+	return total
+}
+
 func TestSpanNativeApplyLeafLogOutputPreparedWorkerAppends(t *testing.T) {
 	_, serial := newReadOnlyPrepareZipper(t)
 	serial.SetOuterLeavesInValueLog(true)
@@ -312,6 +488,101 @@ func TestSpanNativeApplyLeafLogOutputPreparedWorkerAppends(t *testing.T) {
 	}
 	if !bytes.Equal(collectRootLeafPairs(t, serial, serialNewRoot), collectRootLeafPairs(t, native, result.RootID)) {
 		t.Fatalf("span-native prepared leaf-log output mismatch")
+	}
+}
+
+func TestSpanNativeApplyLeafLogOutputRoutesWorkerRangesToSelectedLanes(t *testing.T) {
+	_, serial := newReadOnlyPrepareZipper(t)
+	serial.SetOuterLeavesInValueLog(true)
+	serialStore := newBatchMemoryLeafPageStore()
+	serial.SetLeafPageLog(serialStore)
+	serial.SetLeafPageReader(serialStore)
+
+	_, native := newReadOnlyPrepareZipper(t)
+	native.SetOuterLeavesInValueLog(true)
+	nativeStore := newLaneRecordingLeafPageLog()
+	native.SetLeafPageLog(nativeStore)
+	native.SetLeafPageReader(nativeStore)
+
+	serialRoot := buildReadOnlyPrepareRootWithKeys(t, serial, 4096)
+	nativeRoot := buildReadOnlyPrepareRootWithKeys(t, native, 4096)
+	nativeStore.resetObservations()
+
+	delta := batch.New(panicValueReader{}, page.DefaultInlineThreshold)
+	defer func() { _ = delta.Close() }()
+	value := bytes.Repeat([]byte("v"), 180)
+	for _, anchor := range []int{17, 1029, 2053, 3079} {
+		for j := 0; j < 48; j++ {
+			key := []byte(fmt.Sprintf("key-%06d-%03d", anchor, j))
+			if err := delta.Set(key, value); err != nil {
+				t.Fatalf("Set anchor=%d j=%d: %v", anchor, j, err)
+			}
+		}
+	}
+
+	serialNewRoot, _, _, err := serial.Apply(serialRoot, delta)
+	if err != nil {
+		t.Fatalf("serial Apply: %v", err)
+	}
+	result, err := native.ApplyWithOptions(nativeRoot, delta, ApplyOptions{SpanNativeApply: true, ParallelApplyConcurrency: 4})
+	if err != nil {
+		t.Fatalf("span-native ApplyWithOptions: %v", err)
+	}
+	if !result.SpanNativeUsed || result.SpanNativeWorkers < 2 {
+		t.Fatalf("span-native used/workers=%v/%d", result.SpanNativeUsed, result.SpanNativeWorkers)
+	}
+	counts := nativeStore.observedAppendCounts()
+	if counts[0] != 0 {
+		t.Fatalf("default lane appends after reset=%d want 0; counts=%v", counts[0], counts)
+	}
+	selectedLanes := 0
+	for lane, count := range counts {
+		if lane <= 0 || count <= 0 {
+			continue
+		}
+		selectedLanes++
+	}
+	if selectedLanes < 2 {
+		t.Fatalf("selected lanes with appends=%d counts=%v want >=2", selectedLanes, counts)
+	}
+	if preparedBatches := nativeStore.observedPreparedBatchCalls(); preparedBatches == 0 {
+		t.Fatalf("prepared batch calls=0 counts=%v", counts)
+	}
+	if !bytes.Equal(collectRootLeafPairs(t, serial, serialNewRoot), collectRootLeafPairs(t, native, result.RootID)) {
+		t.Fatalf("span-native lane-routed leaf-log output mismatch")
+	}
+}
+
+func TestSpanNativeApplyLeafLogOutputSelectedLaneFailureReturnsBeforeReduce(t *testing.T) {
+	_, native := newReadOnlyPrepareZipper(t)
+	native.SetOuterLeavesInValueLog(true)
+	store := newLaneRecordingLeafPageLog()
+	store.failLane = 1
+	store.failErr = errors.New("test selected leaf-log lane append failure")
+	native.SetLeafPageLog(store)
+	native.SetLeafPageReader(store)
+
+	nativeRoot := buildReadOnlyPrepareRootWithKeys(t, native, 4096)
+	store.resetObservations()
+
+	delta := batch.New(panicValueReader{}, page.DefaultInlineThreshold)
+	defer func() { _ = delta.Close() }()
+	value := bytes.Repeat([]byte("v"), 180)
+	for _, anchor := range []int{17, 1029, 2053, 3079} {
+		for j := 0; j < 48; j++ {
+			key := []byte(fmt.Sprintf("key-%06d-%03d", anchor, j))
+			if err := delta.Set(key, value); err != nil {
+				t.Fatalf("Set anchor=%d j=%d: %v", anchor, j, err)
+			}
+		}
+	}
+
+	result, err := native.ApplyWithOptions(nativeRoot, delta, ApplyOptions{SpanNativeApply: true, ParallelApplyConcurrency: 4})
+	if !errors.Is(err, store.failErr) {
+		t.Fatalf("ApplyWithOptions err=%v want %v", err, store.failErr)
+	}
+	if result.RootID != 0 {
+		t.Fatalf("RootID=%d want zero because selected-lane output failed before reducer publication", result.RootID)
 	}
 }
 

--- a/TreeDB/zipper/zipper.go
+++ b/TreeDB/zipper/zipper.go
@@ -47,6 +47,14 @@ type LeafPageConcurrentAppendLog interface {
 	ConcurrentLeafPageAppends() bool
 }
 
+type LeafPageLogLaneProvider interface {
+	LeafPageLogLane(workerIndex int) (LeafPageLog, bool)
+}
+
+type leafPageLogLaneAnyProvider interface {
+	LeafPageLogLaneAny(workerIndex int) (any, bool)
+}
+
 type LeafPagePreparedBatchLog interface {
 	AppendPreparedLeafPages(leafPages [][]byte, preparedPayloads [][]byte) ([]page.LeafLogPtr, error)
 }
@@ -1782,11 +1790,15 @@ func (z *Zipper) persistLeafPageDataWithConfig(leafPage []byte, metrics *adaptiv
 }
 
 func (z *Zipper) persistLeafPageData(leafPage []byte, metrics *adaptive.Metrics) (page.ChildRef, error) {
-	if z.leafPageLog == nil {
+	return z.persistLeafPageDataToLog(z.leafPageLog, leafPage, metrics)
+}
+
+func (z *Zipper) persistLeafPageDataToLog(log LeafPageLog, leafPage []byte, metrics *adaptive.Metrics) (page.ChildRef, error) {
+	if log == nil {
 		return page.ChildRef{}, errors.New("zipper: missing leaf page log")
 	}
 	appendStart := time.Now()
-	ptr, err := z.leafPageLog.AppendLeafPage(leafPage)
+	ptr, err := log.AppendLeafPage(leafPage)
 	recordZipperLeafLogOutputAppend(metrics, time.Since(appendStart), 1, err == nil)
 	if err != nil {
 		return page.ChildRef{}, err
@@ -1804,7 +1816,11 @@ func (z *Zipper) persistLeafPageBatchDataTo(leafPages [][]byte, refs []page.Chil
 }
 
 func (z *Zipper) persistPreparedLeafPageDataTo(leafPage []byte, preparedPayload []byte, metrics *adaptive.Metrics) (page.ChildRef, error) {
-	if prepared, ok := z.leafPageLog.(LeafPagePreparedLog); ok {
+	return z.persistPreparedLeafPageDataToLog(z.leafPageLog, leafPage, preparedPayload, metrics)
+}
+
+func (z *Zipper) persistPreparedLeafPageDataToLog(log LeafPageLog, leafPage []byte, preparedPayload []byte, metrics *adaptive.Metrics) (page.ChildRef, error) {
+	if prepared, ok := log.(LeafPagePreparedLog); ok {
 		appendStart := time.Now()
 		ptr, err := prepared.AppendPreparedLeafPage(leafPage, preparedPayload)
 		appendWait := time.Since(appendStart)
@@ -1820,7 +1836,7 @@ func (z *Zipper) persistPreparedLeafPageDataTo(leafPage []byte, preparedPayload 
 	var onePayload [1][]byte
 	onePage[0] = leafPage
 	onePayload[0] = preparedPayload
-	refs, err := z.persistPreparedLeafPageBatchDataTo(onePage[:], onePayload[:], nil, metrics)
+	refs, err := z.persistPreparedLeafPageBatchDataToLog(log, onePage[:], onePayload[:], nil, metrics)
 	if err != nil {
 		return page.ChildRef{}, err
 	}
@@ -1831,6 +1847,10 @@ func (z *Zipper) persistPreparedLeafPageDataTo(leafPage []byte, preparedPayload 
 }
 
 func (z *Zipper) persistPreparedLeafPageBatchDataTo(leafPages [][]byte, preparedPayloads [][]byte, refs []page.ChildRef, metrics *adaptive.Metrics) ([]page.ChildRef, error) {
+	return z.persistPreparedLeafPageBatchDataToLog(z.leafPageLog, leafPages, preparedPayloads, refs, metrics)
+}
+
+func (z *Zipper) persistPreparedLeafPageBatchDataToLog(log LeafPageLog, leafPages [][]byte, preparedPayloads [][]byte, refs []page.ChildRef, metrics *adaptive.Metrics) ([]page.ChildRef, error) {
 	refs = refs[:0]
 	if len(leafPages) == 0 {
 		return refs, nil
@@ -1838,9 +1858,9 @@ func (z *Zipper) persistPreparedLeafPageBatchDataTo(leafPages [][]byte, prepared
 	if len(preparedPayloads) != len(leafPages) {
 		return nil, fmt.Errorf("zipper: prepared leaf payload count %d for %d pages", len(preparedPayloads), len(leafPages))
 	}
-	preparedBatcher, ok := z.leafPageLog.(LeafPagePreparedBatchLog)
+	preparedBatcher, ok := log.(LeafPagePreparedBatchLog)
 	if !ok {
-		return z.persistLeafPageBatchDataTo(leafPages, refs, metrics)
+		return z.persistLeafPageBatchDataToLog(log, leafPages, refs, metrics)
 	}
 	appendStart := time.Now()
 	ptrs, err := preparedBatcher.AppendPreparedLeafPages(leafPages, preparedPayloads)
@@ -1867,42 +1887,53 @@ func (z *Zipper) persistPreparedLeafPageBatchDataTo(leafPages [][]byte, prepared
 }
 
 func (z *Zipper) leafPageLogConsumesPreparedPayloads(batch bool) bool {
-	if z == nil || z.leafPageLog == nil {
+	if z == nil {
+		return false
+	}
+	return leafPageLogConsumesPreparedPayloads(z.leafPageLog, batch)
+}
+
+func leafPageLogConsumesPreparedPayloads(log LeafPageLog, batch bool) bool {
+	if log == nil {
 		return false
 	}
 	if batch {
-		if prepared, ok := z.leafPageLog.(LeafPagePreparedBatchAppendLog); ok {
+		if prepared, ok := log.(LeafPagePreparedBatchAppendLog); ok {
 			return prepared.PreparedLeafPageBatchAppends()
 		}
-		_, ok := z.leafPageLog.(LeafPagePreparedBatchLog)
+		_, ok := log.(LeafPagePreparedBatchLog)
 		return ok
 	}
-	if prepared, ok := z.leafPageLog.(LeafPagePreparedAppendLog); ok {
+	if prepared, ok := log.(LeafPagePreparedAppendLog); ok {
 		return prepared.PreparedLeafPageAppends()
 	}
-	_, ok := z.leafPageLog.(LeafPagePreparedLog)
+	_, ok := log.(LeafPagePreparedLog)
 	return ok
 }
 
 func (z *Zipper) persistLeafPageBatchDataToWithConfig(leafPages [][]byte, refs []page.ChildRef, metrics *adaptive.Metrics, cfg applyRunConfig) ([]page.ChildRef, error) {
+	if cfg.leafPagePersister != nil {
+		return cfg.leafPagePersister.persistLeafPageBatchDataTo(z, leafPages, refs, metrics)
+	}
+	return z.persistLeafPageBatchDataToLog(z.leafPageLog, leafPages, refs, metrics)
+}
+
+func (z *Zipper) persistLeafPageBatchDataToLog(log LeafPageLog, leafPages [][]byte, refs []page.ChildRef, metrics *adaptive.Metrics) ([]page.ChildRef, error) {
 	refs = refs[:0]
 	if len(leafPages) == 0 {
 		return refs, nil
 	}
-	if cfg.leafPagePersister != nil {
-		return cfg.leafPagePersister.persistLeafPageBatchDataTo(z, leafPages, refs, metrics)
-	}
 	if len(leafPages) == 1 {
-		ref, err := z.persistLeafPageData(leafPages[0], metrics)
+		ref, err := z.persistLeafPageDataToLog(log, leafPages[0], metrics)
 		if err != nil {
 			return nil, err
 		}
 		return append(refs, ref), nil
 	}
-	if z.leafPageLog == nil {
+	if log == nil {
 		return nil, errors.New("zipper: missing leaf page log")
 	}
-	batcher, ok := z.leafPageLog.(LeafPageBatchLog)
+	batcher, ok := log.(LeafPageBatchLog)
 	if !ok {
 		if cap(refs) < len(leafPages) {
 			refs = make([]page.ChildRef, len(leafPages))
@@ -1910,7 +1941,7 @@ func (z *Zipper) persistLeafPageBatchDataToWithConfig(leafPages [][]byte, refs [
 			refs = refs[:len(leafPages)]
 		}
 		for i, leafPage := range leafPages {
-			ref, err := z.persistLeafPageData(leafPage, metrics)
+			ref, err := z.persistLeafPageDataToLog(log, leafPage, metrics)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
## Summary

- Route span-native worker leaf output through selected leaf-log lanes when a lane provider is installed, while preserving lane 0 for default/reducer appends and single-worker runs.
- Add log-specific persist helpers so `AppendLeafPage`, `AppendLeafPages`, `AppendPreparedLeafPage`, and `AppendPreparedLeafPages` stay intact on the selected lane.
- Add a structural `LeafPageLogLaneAny` bridge for DB/caching wrappers whose lane provider returns `db.LeafPageLog`, and cache the selected lane appender per worker task to avoid per-page wrapper allocations.
- Select lanes by worker ID (not job index) and advertise DB lane groups as concurrent appenders so the span-native gate does not re-serialize selected-lane output.
- Close standalone selected lane clones from `DB.Close()` so direct backend tests/users do not leave lane files open on Windows while keeping caller-owned lane 0 lifecycle intact.
- Add zipper and cached integration coverage for lane routing, prepared batch appends, selected-lane failure fail-closed behavior, and multi-current leaf path test assumptions.

Closes #2928.

## Validation

Latest-head local validation after the close fix and AI review commits:

- `GOWORK=off go test ./TreeDB/zipper -run 'TestSpanNativeApplyLeafLogOutput(RoutesWorkerRangesToSelectedLanes|LanesFollowWorkerID|SelectedLaneFailureReturnsBeforeReduce|PreparedWorkerAppends|CommitFailureReturnsBeforeReduce)|TestSpanNativeApplyConcurrentWorkerLocalScratchSplitParity' -count=1`
- `GOWORK=off go test ./TreeDB/db -run 'TestLeafPageLogLaneGroupAdvertisesConcurrentAppends|TestLeafPageLogLaneSelectionAppendsUniqueReadablePtrs|TestLeafPageLogLaneSnapshotsAggregateAndMarkPerLane|TestLeafPageLogLanes_FlushSyncCloseTouchAllLanes|TestFlushApplySpanNativePreparedLeafLogOutputReopens' -count=10`
- `GOWORK=off go test ./TreeDB/db ./TreeDB/caching ./TreeDB/zipper -count=1`
- `GOWORK=off go test -race ./TreeDB/zipper -run 'TestSpanNativeApplyLeafLogOutput(RoutesWorkerRangesToSelectedLanes|LanesFollowWorkerID|SelectedLaneFailureReturnsBeforeReduce|PreparedWorkerAppends|CommitFailureReturnsBeforeReduce)|TestSpanNativeApplyConcurrentWorkerLocalScratchSplitParity' -count=1`
- `GOWORK=off go test -race ./TreeDB/caching ./TreeDB/db ./TreeDB/internal/valuelog -run 'TestCachingSpanNativeLeafLogOutputUsesSelectedLanes|TestCachingLeafPageLogLane|TestLeafPageLogLaneGroupAdvertisesConcurrentAppends|TestFlushApplySpanNativePreparedLeafLogOutputReopens|TestManagerPromoteCurrentWritable|TestRegisterRewriteCreatedValueLogSegmentsDemotesPriorMultiCurrentLeafSegment' -count=1`
- `GOWORK=off go test ./TreeDB/... -count=1`

Also run before the close-fix / AI-review commits:

- `GOWORK=off go test ./TreeDB/zipper -run 'TestSpanNativeApplyLeafLogOutput(RoutesWorkerRangesToSelectedLanes|SelectedLaneFailureReturnsBeforeReduce|PreparedWorkerAppends|CommitFailureReturnsBeforeReduce)|TestSpanNativeApplyConcurrentWorkerLocalScratchSplitParity' -count=10`
- `GOWORK=off go test ./TreeDB/caching -run 'TestCachingSpanNativeLeafLogOutputUsesSelectedLanes|TestValueLogProtectedPaths_ExcludeLeafPathsInSplitMode|TestCollectValueLogLiveIDs_ExcludesLeafLogIDsInSplitMode|TestPruneRetainedValueLogs_IgnoresLeafPathsInSplitMode' -count=10`

## c4 profile gate

Command: #2928 issue c4 standard row (`sequential_write,batch_random,random_write`, 10MM keys, explicit c4 span-native/backlog, profile-dir).

Artifacts:
- latest candidate: `<remote-profile-root>/treedb_2928_lanes_c4_exact_codexfix_20260621_170116`
- latest-head baseline (#2927 / `origin/main`): `<remote-profile-root>/treedb_2928_baseline_c4_exact_20260621_152141`
- historical #2918 baseline: `<remote-profile-root>/treedb_2916_preempt2_c4_20260620_200303`

| row | sequential_write/s | batch_random/s | random_write/s | leaf append wait | active bg checkpoint wait | close/checkpoint fallback ops |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| #2927 baseline | 2,418,011 | 528,228 | 248,641 | 67.65s | 20.31s | 0 |
| #2928 candidate | 2,467,851 | 555,479 | 252,573 | 52.76s | 18.17s | 0 |
| #2918 historical | 2,585,332 | 561,153 | 256,034 | 65.81s | 18.04s | 0 |

Candidate improves append wait vs both baselines and keeps span-native close/checkpoint fallback at zero. Against latest-head #2927, sequential is +2.1%, batch-random is +5.2%, and random-write is +1.6%.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multi-worker leaf-log lane selection to improve throughput and resource utilization in parallel operations.
  * Implemented lane-aware persistence routing for span-native leaf-log output.

* **Bug Fixes**
  * Improved resource cleanup with explicit error handling during database shutdown.

* **Tests**
  * Added comprehensive test coverage for worker lane routing, failure handling, and concurrent append capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->