### PR TITLE
Harden leaf-log lane generation GC

### DIFF
--- a/TreeDB/db/leaf_generation_gc.go
+++ b/TreeDB/db/leaf_generation_gc.go
@@ -157,6 +157,10 @@ func (db *DB) leafGenerationGC(ctx context.Context, opts LeafGenerationGCOptions
 		// appends may still land in that file until the lane rotates or closes.
 		if leafGenerationRecordIntersectsFileIDSet(*gen, currentLeafLogRawFileIDs) {
 			stats.GenerationsLive++
+			if gen.State != leafGenerationStateSealed {
+				gen.State = leafGenerationStateSealed
+				intermediateChanged = true
+			}
 			continue
 		}
 		if _, ok := liveGenerations[gen.GenerationID]; ok {

--- a/TreeDB/db/leaf_generation_gc.go
+++ b/TreeDB/db/leaf_generation_gc.go
@@ -80,6 +80,10 @@ func (db *DB) leafGenerationGC(ctx context.Context, opts LeafGenerationGCOptions
 		return stats, nil
 	}
 	filePaths := db.leafGenerationFilePaths(manifest)
+	currentLeafLogRawFileIDs, err := db.currentLeafPageLogRawFileIDSet()
+	if err != nil {
+		return stats, err
+	}
 
 	snap := db.AcquireSnapshot()
 	if snap == nil {
@@ -135,12 +139,24 @@ func (db *DB) leafGenerationGC(ctx context.Context, opts LeafGenerationGCOptions
 				if activeFileRefs[fileID] > 0 {
 					continue
 				}
+				if _, current := currentLeafLogRawFileIDs[fileID]; current {
+					continue
+				}
 				zombieFileIDs[page.ValueLogFileID(fileID)] = struct{}{}
 			}
 			continue
 		}
 		if gen.State == leafGenerationStateWritable {
 			stats.GenerationsWritable++
+			continue
+		}
+		// Multiple physical leaf-log append writers can be current at once while
+		// the generation manifest still records one file per generation. A sealed
+		// generation that owns an active current writer must not be zombied just
+		// because the current root no longer references its older pages; future
+		// appends may still land in that file until the lane rotates or closes.
+		if leafGenerationRecordIntersectsFileIDSet(*gen, currentLeafLogRawFileIDs) {
+			stats.GenerationsLive++
 			continue
 		}
 		if _, ok := liveGenerations[gen.GenerationID]; ok {
@@ -242,6 +258,43 @@ func (db *DB) leafGenerationGC(ctx context.Context, opts LeafGenerationGCOptions
 	}
 	db.leafGenerationManifest = manifest
 	return stats, nil
+}
+
+func (db *DB) currentLeafPageLogRawFileIDSet() (map[uint32]struct{}, error) {
+	if db == nil || db.leafPageLog == nil {
+		return nil, nil
+	}
+	segments, err := leafPageLogCurrentSegments(db.leafPageLog)
+	if err != nil {
+		return nil, err
+	}
+	if len(segments) == 0 {
+		return nil, nil
+	}
+	out := make(map[uint32]struct{}, len(segments))
+	for _, seg := range segments {
+		rawFileID, ok := rawLeafGenerationFileID(seg.FileID)
+		if !ok {
+			continue
+		}
+		out[rawFileID] = struct{}{}
+	}
+	if len(out) == 0 {
+		return nil, nil
+	}
+	return out, nil
+}
+
+func leafGenerationRecordIntersectsFileIDSet(gen leafGenerationRecord, fileIDs map[uint32]struct{}) bool {
+	if len(fileIDs) == 0 || len(gen.FileIDs) == 0 {
+		return false
+	}
+	for _, fileID := range gen.FileIDs {
+		if _, ok := fileIDs[fileID]; ok {
+			return true
+		}
+	}
+	return false
 }
 
 func leafGenerationActiveFileRefCounts(manifest *leafGenerationManifest) map[uint32]int {

--- a/TreeDB/db/leaf_generation_gc_test.go
+++ b/TreeDB/db/leaf_generation_gc_test.go
@@ -71,6 +71,105 @@ func currentLeafSegmentOrFatal(t *testing.T, leafLog *rewriteWriter) (string, ui
 	return path, fileID
 }
 
+func openLeafLogLaneGCTestDB(t *testing.T, maxSegmentBytes int64) (*DB, LeafPageLogCloser, Options) {
+	t.Helper()
+	dir := t.TempDir()
+	opts := Options{
+		Dir:                        dir,
+		ChunkSize:                  64 * 1024,
+		Durability:                 DurabilityWALOffRelaxed,
+		DisableBackgroundPrune:     true,
+		IndexOuterLeavesInValueLog: true,
+		FlushAdmissionPolicy:       FlushAdmissionPolicyExplicit,
+		FlushApplyConcurrency:      4,
+		FlushApplyMinEntries:       1,
+		FlushApplyMinSpans:         1,
+		FlushApplyMinBytes:         1,
+		FlushApplySpanNative:       true,
+		ValueLog: ValueLogOptions{
+			Compression: ValueLogCompressionOff,
+		},
+	}
+	db, err := Open(opts)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	leafLog, err := NewStandaloneLeafPageLog(dir, StandaloneLeafPageLogOptions{
+		MaxSegmentBytes: maxSegmentBytes,
+		Compression:     ValueLogCompressionOff,
+	})
+	if err != nil {
+		_ = db.Close()
+		t.Fatalf("NewStandaloneLeafPageLog: %v", err)
+	}
+	db.SetLeafPageLog(leafLog)
+	return db, leafLog, opts
+}
+
+func closeLeafLogLaneGCTestDB(t *testing.T, db *DB, leafLog LeafPageLogCloser) {
+	t.Helper()
+	if db != nil {
+		if err := db.Close(); err != nil {
+			t.Fatalf("Close DB: %v", err)
+		}
+	}
+	if leafLog != nil {
+		if err := leafLog.Close(); err != nil {
+			t.Fatalf("Close leaf log: %v", err)
+		}
+	}
+}
+
+func requireLeafLogCurrentSegments(t *testing.T, db *DB, min int) []LeafPageLogSegment {
+	t.Helper()
+	segments, err := leafPageLogCurrentSegments(db.leafPageLog)
+	if err != nil {
+		t.Fatalf("leafPageLogCurrentSegments: %v", err)
+	}
+	if len(segments) < min {
+		t.Fatalf("current leaf-log segments=%d want >=%d: %+v", len(segments), min, segments)
+	}
+	return segments
+}
+
+func leafGenerationManifestRawFileIDSet(manifest *leafGenerationManifest) map[uint32]struct{} {
+	out := make(map[uint32]struct{})
+	if manifest == nil {
+		return out
+	}
+	for _, gen := range manifest.Generations {
+		for _, rawFileID := range gen.FileIDs {
+			if rawFileID != 0 {
+				out[rawFileID] = struct{}{}
+			}
+		}
+	}
+	return out
+}
+
+func currentLeafLogRawFileIDSetForTest(t *testing.T, db *DB) map[uint32]struct{} {
+	t.Helper()
+	currentRaw, err := db.currentLeafPageLogRawFileIDSet()
+	if err != nil {
+		t.Fatalf("currentLeafPageLogRawFileIDSet: %v", err)
+	}
+	if currentRaw == nil {
+		return map[uint32]struct{}{}
+	}
+	return currentRaw
+}
+
+func leafGenerationRawFileIDsWithout(base, exclude map[uint32]struct{}) []uint32 {
+	out := make([]uint32, 0, len(base))
+	for rawFileID := range base {
+		if _, skip := exclude[rawFileID]; skip {
+			continue
+		}
+		out = append(out, rawFileID)
+	}
+	return out
+}
+
 func findLeafGenerationByFileID(t *testing.T, manifest *leafGenerationManifest, fileID uint32) leafGenerationRecord {
 	t.Helper()
 	if manifest == nil {
@@ -207,6 +306,197 @@ func TestLeafGenerationGC_DeletesFullyDeadGeneration(t *testing.T) {
 	remaining := manifestAfter.Generations[0]
 	if got, want := remaining.FileIDs[0], rawFileID2; got != want {
 		t.Fatalf("remaining generation fileID=%d, want %d", got, want)
+	}
+}
+
+func TestLeafPageLogLanes_CheckpointReopenPublishesEveryCurrentLane(t *testing.T) {
+	db, leafLog, opts := openLeafLogLaneGCTestDB(t, 0)
+	closed := false
+	defer func() {
+		if !closed {
+			closeLeafLogLaneGCTestDB(t, db, leafLog)
+		}
+	}()
+
+	putBatch(t, db, 0, 4096, "base")
+	updates := db.NewBatch()
+	expected := map[string][]byte{
+		"key-000000": []byte("base-000000"),
+	}
+	for _, anchor := range []int{17, 1029, 2053, 3079} {
+		for j := 0; j < 48; j++ {
+			key := []byte(fmt.Sprintf("key-%06d-%03d", anchor, j))
+			val := bytes.Repeat([]byte{byte(1 + (anchor+j)%251)}, 180)
+			if err := updates.Set(key, val); err != nil {
+				_ = updates.Close()
+				t.Fatalf("Set update anchor=%d j=%d: %v", anchor, j, err)
+			}
+			if j == 7 || j == 47 {
+				expected[string(key)] = append([]byte(nil), val...)
+			}
+		}
+	}
+	if err := updates.Write(); err != nil {
+		_ = updates.Close()
+		t.Fatalf("Write updates: %v", err)
+	}
+	if err := updates.Close(); err != nil {
+		t.Fatalf("Close updates: %v", err)
+	}
+	if got := requireDBStatUint64(t, db, "treedb.flush_apply.span_native.used_ops_total"); got == 0 {
+		t.Fatalf("span-native used ops = 0, want lane-routed leaf output")
+	}
+	currentSegments := requireLeafLogCurrentSegments(t, db, 2)
+
+	manifest := loadLeafGenerationManifestOrFatal(t, opts.Dir)
+	view := newLeafGenerationView(manifest)
+	if view == nil {
+		t.Fatal("leaf generation view missing")
+	}
+	for _, seg := range currentSegments {
+		rawFileID := page.ValueLogSegmentID(seg.FileID)
+		if _, ok := view.FileToGeneration[rawFileID]; !ok {
+			t.Fatalf("current lane segment %d (%s) missing from leaf-generation manifest", seg.FileID, seg.Path)
+		}
+	}
+	set := db.valueLogManager.CurrentSetNoRefresh()
+	if set == nil {
+		t.Fatal("missing value-log set")
+	}
+	for _, seg := range currentSegments {
+		if _, ok := set.Files[seg.FileID]; !ok {
+			_ = db.valueLogManager.Release(set)
+			t.Fatalf("current lane segment %d (%s) missing from value-log set", seg.FileID, seg.Path)
+		}
+	}
+	if err := db.valueLogManager.Release(set); err != nil {
+		t.Fatalf("Release value-log set: %v", err)
+	}
+
+	if err := db.Checkpoint(); err != nil {
+		t.Fatalf("Checkpoint: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("Close DB: %v", err)
+	}
+	if err := leafLog.Close(); err != nil {
+		t.Fatalf("Close leaf log: %v", err)
+	}
+	closed = true
+
+	reopened, err := Open(opts)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer func() { _ = reopened.Close() }()
+	for key, want := range expected {
+		got, err := reopened.Get([]byte(key))
+		if err != nil {
+			t.Fatalf("reopen Get(%q): %v", key, err)
+		}
+		if !bytes.Equal(got, want) {
+			t.Fatalf("reopen Get(%q)=%q want %q", key, got, want)
+		}
+	}
+}
+
+func TestLeafGenerationGC_RetainsCurrentUnreachableLeafLogLaneSegment(t *testing.T) {
+	db, leafLog, _ := openLeafLogLaneGCTestDB(t, 0)
+	defer closeLeafLogLaneGCTestDB(t, db, leafLog)
+
+	putBatch(t, db, 0, 4096, "old")
+	baseSegments := requireLeafLogCurrentSegments(t, db, 1)
+	base := baseSegments[0]
+	baseRawFileID := page.ValueLogSegmentID(base.FileID)
+
+	putBatch(t, db, 0, 4096, "new")
+	currentRaw := currentLeafLogRawFileIDSetForTest(t, db)
+	if _, ok := currentRaw[baseRawFileID]; !ok {
+		t.Fatalf("base segment %d is no longer a current leaf-log lane; current=%v", base.FileID, currentRaw)
+	}
+	if _, err := db.LeafGenerationGC(context.Background(), LeafGenerationGCOptions{}); err != nil {
+		t.Fatalf("LeafGenerationGC: %v", err)
+	}
+	if _, err := os.Stat(base.Path); err != nil {
+		t.Fatalf("current but unreachable leaf-log segment was removed: %s err=%v", base.Path, err)
+	}
+	for _, seg := range requireLeafLogCurrentSegments(t, db, 2) {
+		if _, err := os.Stat(seg.Path); err != nil {
+			t.Fatalf("current leaf-log segment missing after GC: %s err=%v", seg.Path, err)
+		}
+	}
+}
+
+func TestLeafGenerationGC_RemovesUnreachableMultiLaneSegmentsAfterReopen(t *testing.T) {
+	db, leafLog, opts := openLeafLogLaneGCTestDB(t, 32<<10)
+	closed := false
+	defer func() {
+		if !closed {
+			closeLeafLogLaneGCTestDB(t, db, leafLog)
+		}
+	}()
+
+	putBatch(t, db, 0, 4096, "old")
+	baseIDs := leafGenerationManifestRawFileIDSet(loadLeafGenerationManifestOrFatal(t, opts.Dir))
+	putBatch(t, db, 0, 4096, "mid")
+	midIDs := leafGenerationManifestRawFileIDSet(loadLeafGenerationManifestOrFatal(t, opts.Dir))
+	midOnly := leafGenerationRawFileIDsWithout(midIDs, baseIDs)
+	midOnlySet := make(map[uint32]struct{}, len(midOnly))
+	for _, rawFileID := range midOnly {
+		midOnlySet[rawFileID] = struct{}{}
+	}
+	sealedMid := leafGenerationRawFileIDsWithout(midOnlySet, currentLeafLogRawFileIDSetForTest(t, db))
+	if len(sealedMid) < 2 {
+		t.Fatalf("sealed mid-generation lane segments=%d want >=2 (midOnly=%v)", len(sealedMid), midOnly)
+	}
+	sealedMidPaths := make([]string, 0, len(sealedMid))
+	for _, rawFileID := range sealedMid {
+		path := leafGenerationFallbackPath(opts.Dir, rawFileID)
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("stat sealed mid segment %d: %v", rawFileID, err)
+		}
+		sealedMidPaths = append(sealedMidPaths, path)
+	}
+
+	putBatch(t, db, 0, 4096, "final")
+	if err := db.Checkpoint(); err != nil {
+		t.Fatalf("Checkpoint: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("Close DB: %v", err)
+	}
+	if err := leafLog.Close(); err != nil {
+		t.Fatalf("Close leaf log: %v", err)
+	}
+	closed = true
+
+	reopened, err := Open(opts)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer func() { _ = reopened.Close() }()
+	stats, err := reopened.LeafGenerationGC(context.Background(), LeafGenerationGCOptions{})
+	if err != nil {
+		t.Fatalf("LeafGenerationGC: %v", err)
+	}
+	if stats.FilesDeleted == 0 {
+		t.Fatalf("FilesDeleted=0 want reclaimed sealed mid-generation lane segments (stats=%+v)", stats)
+	}
+	for _, path := range sealedMidPaths {
+		if err := waitForPathRemoval(path, 5*time.Second); err != nil {
+			t.Fatalf("waitForPathRemoval(%s): %v (stats=%+v)", path, err, stats)
+		}
+	}
+	for _, idx := range []int{0, 1029, 3079} {
+		key := []byte(fmt.Sprintf("key-%06d", idx))
+		got, err := reopened.Get(key)
+		if err != nil {
+			t.Fatalf("reopened Get(%q): %v", key, err)
+		}
+		want := []byte(fmt.Sprintf("final-%06d", idx))
+		if !bytes.Equal(got, want) {
+			t.Fatalf("reopened Get(%q)=%q want %q", key, got, want)
+		}
 	}
 }
 

--- a/TreeDB/db/leaf_generation_gc_test.go
+++ b/TreeDB/db/leaf_generation_gc_test.go
@@ -347,6 +347,12 @@ func TestLeafPageLogLanes_CheckpointReopenPublishesEveryCurrentLane(t *testing.T
 		t.Fatalf("span-native used ops = 0, want lane-routed leaf output")
 	}
 	currentSegments := requireLeafLogCurrentSegments(t, db, 2)
+	currentLaneFileIDs := make(map[uint32]string, len(currentSegments))
+	currentLaneRawFileIDs := make(map[uint32]string, len(currentSegments))
+	for _, seg := range currentSegments {
+		currentLaneFileIDs[seg.FileID] = seg.Path
+		currentLaneRawFileIDs[page.ValueLogSegmentID(seg.FileID)] = seg.Path
+	}
 
 	manifest := loadLeafGenerationManifestOrFatal(t, opts.Dir)
 	view := newLeafGenerationView(manifest)
@@ -389,6 +395,31 @@ func TestLeafPageLogLanes_CheckpointReopenPublishesEveryCurrentLane(t *testing.T
 		t.Fatalf("reopen: %v", err)
 	}
 	defer func() { _ = reopened.Close() }()
+
+	reopenedManifest := loadLeafGenerationManifestOrFatal(t, opts.Dir)
+	reopenedView := newLeafGenerationView(reopenedManifest)
+	if reopenedView == nil {
+		t.Fatal("reopened leaf generation view missing")
+	}
+	for rawFileID, path := range currentLaneRawFileIDs {
+		if _, ok := reopenedView.FileToGeneration[rawFileID]; !ok {
+			t.Fatalf("reopened manifest missing current lane raw file %d (%s)", rawFileID, path)
+		}
+	}
+	reopenedSet := reopened.valueLogManager.CurrentSetNoRefresh()
+	if reopenedSet == nil {
+		t.Fatal("missing reopened value-log set")
+	}
+	for fileID, path := range currentLaneFileIDs {
+		if _, ok := reopenedSet.Files[fileID]; !ok {
+			_ = reopened.valueLogManager.Release(reopenedSet)
+			t.Fatalf("reopened value-log set missing current lane segment %d (%s)", fileID, path)
+		}
+	}
+	if err := reopened.valueLogManager.Release(reopenedSet); err != nil {
+		t.Fatalf("Release reopened value-log set: %v", err)
+	}
+
 	for key, want := range expected {
 		got, err := reopened.Get([]byte(key))
 		if err != nil {
@@ -414,8 +445,41 @@ func TestLeafGenerationGC_RetainsCurrentUnreachableLeafLogLaneSegment(t *testing
 	if _, ok := currentRaw[baseRawFileID]; !ok {
 		t.Fatalf("base segment %d is no longer a current leaf-log lane; current=%v", base.FileID, currentRaw)
 	}
+	manifest := loadLeafGenerationManifestOrFatal(t, db.dir)
+	markedRetiring := false
+	for i := range manifest.Generations {
+		for _, rawFileID := range manifest.Generations[i].FileIDs {
+			if rawFileID != baseRawFileID {
+				continue
+			}
+			manifest.Generations[i].State = leafGenerationStateRetiring
+			manifest.Generations[i].RetiredCommitSeq = 123
+			markedRetiring = true
+			break
+		}
+		if markedRetiring {
+			break
+		}
+	}
+	if !markedRetiring {
+		t.Fatalf("base raw file id %d missing from manifest", baseRawFileID)
+	}
+	if err := saveLeafGenerationManifest(LeafLogDirPath(db.dir), manifest); err != nil {
+		t.Fatalf("save retiring manifest: %v", err)
+	}
+	db.mu.Lock()
+	db.leafGenerationManifest = manifest
+	db.mu.Unlock()
+	if err := db.publishLeafGenerationState(false); err != nil {
+		t.Fatalf("publish retiring manifest: %v", err)
+	}
+
 	if _, err := db.LeafGenerationGC(context.Background(), LeafGenerationGCOptions{}); err != nil {
 		t.Fatalf("LeafGenerationGC: %v", err)
+	}
+	afterManifest := loadLeafGenerationManifestOrFatal(t, db.dir)
+	if gen := findLeafGenerationByFileID(t, afterManifest, baseRawFileID); gen.State != leafGenerationStateSealed {
+		t.Fatalf("current leaf-log generation state=%q want %q", gen.State, leafGenerationStateSealed)
 	}
 	if _, err := os.Stat(base.Path); err != nil {
 		t.Fatalf("current but unreachable leaf-log segment was removed: %s err=%v", base.Path, err)


### PR DESCRIPTION
## Summary

- Protect every current leaf-log append-lane segment during leaf-generation GC, even when the manifest has already sealed that segment because another lane published later output.
- Add multi-lane durability/manifest/GC tests covering checkpoint + reopen, active current-lane retention, and unreachable multi-lane reclamation after reopen.

## Validation

- `GOWORK=off go test ./TreeDB/db -run 'TestLeafPageLogLanes_CheckpointReopenPublishesEveryCurrentLane|TestLeafGenerationGC_RetainsCurrentUnreachableLeafLogLaneSegment|TestLeafGenerationGC_RemovesUnreachableMultiLaneSegmentsAfterReopen|TestLeafGenerationGC_DeletesFullyDeadGeneration|TestLeafPageLogLane' -count=1`
- `GOWORK=off go test ./TreeDB/caching ./TreeDB/db ./TreeDB/zipper -count=1`
- `GOWORK=off go test -race ./TreeDB/db -run 'TestLeafGenerationGC_RetainsCurrentUnreachableLeafLogLaneSegment|TestLeafPageLogLanes_CheckpointReopenPublishesEveryCurrentLane|TestLeafPageLogLanes_FlushSyncCloseTouchAllLanes' -count=1`

Closes #2929.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed garbage collection to prevent accidental deletion of leaf-log files that are actively being written.

* **Tests**
  * Added comprehensive test coverage for leaf-log garbage collection across database checkpoints, reopens, and multi-lane concurrent write scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->