### PR TITLE
Harden leaf-log lane lifecycle limits

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -2942,6 +2942,12 @@ func (db *DB) nextLeafLogAppendSeq() (int, error) {
 		if next <= cur {
 			return 0, fmt.Errorf("cachingdb: leaf log sequence space exhausted")
 		}
+		if _, err := valuelog.EncodeFileID(uint32(leafLogLaneID), next); err != nil {
+			if errors.Is(err, valuelog.ErrSegmentIDRange) {
+				return 0, fmt.Errorf("cachingdb: leaf log sequence space exhausted")
+			}
+			return 0, err
+		}
 		if db.leafLogAppendSeq.CompareAndSwap(cur, next) {
 			return int(next), nil
 		}

--- a/TreeDB/caching/leaf_page_log_lanes_lifecycle_test.go
+++ b/TreeDB/caching/leaf_page_log_lanes_lifecycle_test.go
@@ -1,0 +1,28 @@
+package caching
+
+import (
+	"strings"
+	"testing"
+)
+
+const leafLogMaxSegmentSeqForTest = 1<<23 - 1
+
+func TestNextLeafLogAppendSeqRejectsSegmentIDExhaustion(t *testing.T) {
+	db := &DB{indexOuterLeavesInValueLog: true}
+	db.leafLogAppendSeq.Store(leafLogMaxSegmentSeqForTest)
+	if _, err := db.nextLeafLogAppendSeq(); err == nil || !strings.Contains(err.Error(), "sequence space exhausted") {
+		t.Fatalf("nextLeafLogAppendSeq exhaustion error=%v, want sequence space exhausted", err)
+	}
+	if got := db.leafLogAppendSeq.Load(); got != leafLogMaxSegmentSeqForTest {
+		t.Fatalf("leafLogAppendSeq advanced after exhaustion: got %d want %d", got, uint32(leafLogMaxSegmentSeqForTest))
+	}
+
+	db.leafLogAppendSeq.Store(leafLogMaxSegmentSeqForTest - 1)
+	seq, err := db.nextLeafLogAppendSeq()
+	if err != nil {
+		t.Fatalf("nextLeafLogAppendSeq at max valid seq: %v", err)
+	}
+	if seq != leafLogMaxSegmentSeqForTest {
+		t.Fatalf("seq=%d want max %d", seq, uint32(leafLogMaxSegmentSeqForTest))
+	}
+}

--- a/TreeDB/db/leaf_page_log_lanes.go
+++ b/TreeDB/db/leaf_page_log_lanes.go
@@ -47,6 +47,12 @@ func (a *leafLogSeqAllocator) Next() (uint32, error) {
 		if next <= current {
 			return 0, fmt.Errorf("leaf log sequence space exhausted")
 		}
+		if _, err := valuelog.EncodeFileID(rewriteLeafLogLaneID, next); err != nil {
+			if errors.Is(err, valuelog.ErrSegmentIDRange) {
+				return 0, fmt.Errorf("leaf log sequence space exhausted")
+			}
+			return 0, err
+		}
 		if a.next.CompareAndSwap(current, next) {
 			return next, nil
 		}

--- a/TreeDB/db/leaf_page_log_lanes_lifecycle_test.go
+++ b/TreeDB/db/leaf_page_log_lanes_lifecycle_test.go
@@ -1,0 +1,104 @@
+package db
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/internal/valuelog"
+	"github.com/snissn/gomap/TreeDB/page"
+)
+
+const leafLogMaxSegmentSeqForTest = 1<<23 - 1
+
+func TestLeafLogSeqAllocatorRejectsSegmentIDExhaustion(t *testing.T) {
+	alloc := newLeafLogSeqAllocator(leafLogMaxSegmentSeqForTest)
+	if _, err := alloc.Next(); err == nil || !strings.Contains(err.Error(), "sequence space exhausted") {
+		t.Fatalf("Next exhaustion error=%v, want sequence space exhausted", err)
+	}
+	if got := alloc.next.Load(); got != leafLogMaxSegmentSeqForTest {
+		t.Fatalf("allocator advanced after exhaustion: got %d want %d", got, uint32(leafLogMaxSegmentSeqForTest))
+	}
+
+	alloc = newLeafLogSeqAllocator(leafLogMaxSegmentSeqForTest - 1)
+	seq, err := alloc.Next()
+	if err != nil {
+		t.Fatalf("Next at max valid seq: %v", err)
+	}
+	if seq != leafLogMaxSegmentSeqForTest {
+		t.Fatalf("seq=%d want max %d", seq, uint32(leafLogMaxSegmentSeqForTest))
+	}
+}
+
+func TestLeafPageLogLanes_SmallSegmentCurrentSetAndRefreshBounded(t *testing.T) {
+	db, leafLog, opts := openLeafLogLaneGCTestDB(t, 32<<10)
+	defer closeLeafLogLaneGCTestDB(t, db, leafLog)
+
+	refreshBefore := db.valueLogManager.RefreshScanCount()
+	putBatch(t, db, 0, 4096, "base")
+	putBatch(t, db, 0, 4096, "final")
+	if got, want := db.valueLogManager.RefreshScanCount(), refreshBefore; got != want {
+		t.Fatalf("multi-lane writes triggered value-log refresh scans: before=%d after=%d", want, got)
+	}
+	if got := requireDBStatUint64(t, db, "treedb.flush_apply.span_native.used_ops_total"); got == 0 {
+		t.Fatalf("span-native used ops = 0, want lane-routed leaf output")
+	}
+
+	currentSegments := requireLeafLogCurrentSegments(t, db, 2)
+	wantCurrentIDs := make([]uint32, 0, len(currentSegments))
+	for _, seg := range currentSegments {
+		wantCurrentIDs = append(wantCurrentIDs, seg.FileID)
+	}
+	sort.Slice(wantCurrentIDs, func(i, j int) bool { return wantCurrentIDs[i] < wantCurrentIDs[j] })
+	gotCurrentIDs := db.valueLogManager.CurrentWritableFileIDs()
+	if !reflect.DeepEqual(gotCurrentIDs, wantCurrentIDs) {
+		t.Fatalf("current writable file IDs=%v want %v", gotCurrentIDs, wantCurrentIDs)
+	}
+	state := db.State()
+	if state == nil || state.ValueLogSet == nil || state.LeafGenerations == nil {
+		t.Fatalf("state missing value-log set/leaf generations: %+v", state)
+	}
+	for _, seg := range currentSegments {
+		if _, ok := state.ValueLogSet.Files[seg.FileID]; !ok {
+			t.Fatalf("current segment %d missing from ValueLogSet", seg.FileID)
+		}
+		rawFileID := page.ValueLogSegmentID(seg.FileID)
+		if _, ok := state.LeafGenerations.FileToGeneration[rawFileID]; !ok {
+			t.Fatalf("current segment raw file %d missing from leaf-generation view", rawFileID)
+		}
+	}
+
+	files, err := filepath.Glob(filepath.Join(LeafLogDirPath(opts.Dir), "value-l*-*.log"))
+	if err != nil {
+		t.Fatalf("Glob leaf_vlog: %v", err)
+	}
+	if len(files) <= len(currentSegments) {
+		t.Fatalf("small segment fixture did not rotate: files=%d current=%d", len(files), len(currentSegments))
+	}
+	if len(files) > 128 {
+		t.Fatalf("small segment fixture created unbounded leaf_vlog files=%d", len(files))
+	}
+	seen := make(map[uint32]string, len(files))
+	for _, path := range files {
+		base := filepath.Base(path)
+		var lane, seq uint32
+		if _, err := fmt.Sscanf(base, "value-l%d-%06d.log", &lane, &seq); err != nil {
+			t.Fatalf("parse leaf log name %q: %v", base, err)
+		}
+		fileID, err := valuelog.EncodeFileID(lane, seq)
+		if err != nil {
+			t.Fatalf("EncodeFileID(%d,%d): %v", lane, seq, err)
+		}
+		if prev, ok := seen[fileID]; ok {
+			t.Fatalf("duplicate leaf log fileID %d for %s and %s", fileID, prev, path)
+		}
+		seen[fileID] = path
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("stat leaf log %s: %v", path, err)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Fail closed before leaf-log lane sequence allocation crosses the encoded value-log file-id range, for both direct DB standalone lanes and cached leaf-log append lanes.
- Add lifecycle guardrails for sequence exhaustion, small-segment rotation/current-set registration, bounded refresh scans, current-writable IDs, manifest coverage, and duplicate file IDs.

## Benchmark / footprint evidence

Latest head `1d0973d69`.

### Standard c4 lifecycle row

Artifact: `<remote-profile-root>/treedb_2934_lifecycle_c4_20260621_215210`

| test | ops/s |
| --- | ---: |
| sequential_write | 2,398,494 |
| batch_random | 581,973 |
| random_write | 246,047 |

Selected lifecycle stats:
- leaf-log lanes configured/active/used: `5/5/5`
- append calls/pages: `9,821,083 / 12,666,005`
- segment rotations total: `108`
- current active segments: 5 (one per lane, via per-lane `segments_active=1`)
- selected worker lane tasks lanes/total/max: `4 / 6128 / 1535`
- checkpoint `leaf_value_log_sync`: total `17.57ms`, max `11.30ms`, samples `6`

### Small leaf segment stress

Artifact: `<remote-profile-root>/treedb_2934_small_leaf_segments_20260621_215402`

| test | ops/s |
| --- | ---: |
| sequential_write | 2,258,635 |
| batch_random | 2,604,917 |
| random_write | 1,704,830 |

Selected lifecycle stats:
- leaf-log lanes configured/active/used: `5/5/5`
- append calls/pages: `242,810 / 384,588`
- segment rotations total: `128`
- selected worker lane tasks lanes/total/max: `4 / 784 / 200`

Commands:

```sh
./bin/unified-bench -dbs treedb -test sequential_write,batch_random,random_write \
  -keys 10000000 -valsize 128 -batchsize 8000 -checkpoint-between-tests \
  -treedb-flush-admission-policy=explicit -treedb-flush-apply-span-native \
  -treedb-flush-backlog-coalescing -treedb-flush-apply-min-entries=1 \
  -treedb-flush-apply-min-spans=1 -treedb-flush-apply-min-bytes=1 \
  -treedb-flush-apply-concurrency=4 \
  -profile-dir "$OUT" -progress=false
./bin/benchprof -profiles-dir "$OUT"
```

Small-segment stress used the issue-prescribed env override with 1M keys:

```sh
TREEDB_VLOG_GENERATION_LEAF_SEGMENT_TARGET_BYTES=$((1<<20)) \
./bin/unified-bench -dbs treedb -test sequential_write,batch_random,random_write \
  -keys 1000000 -valsize 128 -batchsize 8000 -checkpoint-between-tests \
  -treedb-flush-admission-policy=explicit -treedb-flush-apply-span-native \
  -treedb-flush-backlog-coalescing -treedb-flush-apply-min-entries=1 \
  -treedb-flush-apply-min-spans=1 -treedb-flush-apply-min-bytes=1 \
  -treedb-flush-apply-concurrency=4 \
  -profile-dir "$OUT" -progress=false
./bin/benchprof -profiles-dir "$OUT"
```

## Validation

- `GOWORK=off go test ./TreeDB/db ./TreeDB/caching -run 'Test(LeafLogSeqAllocatorRejectsSegmentIDExhaustion|LeafPageLogLanes_SmallSegmentCurrentSetAndRefreshBounded|NextLeafLogAppendSeqRejectsSegmentIDExhaustion)' -count=1 -v`
- `GOWORK=off go test ./TreeDB/db ./TreeDB/caching ./TreeDB/internal/valuelog -count=1`
- `GOWORK=off go test -race ./TreeDB/db ./TreeDB/caching -run 'Test(LeafLogSeqAllocatorRejectsSegmentIDExhaustion|LeafPageLogLanes_SmallSegmentCurrentSetAndRefreshBounded|NextLeafLogAppendSeqRejectsSegmentIDExhaustion|LeafPageLogLanes_FlushSyncCloseTouchAllLanes|CachingLeafPageLogLanes_FlushSyncCloseTouchAllLanes)' -count=1`

Closes #2934.
