### PR TITLE
Optimize span-native leaf-log payload batching

### DIFF
--- a/TreeDB/caching/leaf_page_log.go
+++ b/TreeDB/caching/leaf_page_log.go
@@ -359,6 +359,70 @@ func (l *cachingLeafPageLog) AppendPreparedLeafPages(leafPages [][]byte, prepare
 	return leafPtrs, nil
 }
 
+func (l *cachingLeafPageLog) AppendPreparedLeafPageChildRefs(leafPages [][]byte, preparedPayloads [][]byte, refs []page.ChildRef) ([]page.ChildRef, error) {
+	refs = refs[:0]
+	if l == nil || l.db == nil || l.lane == nil {
+		return nil, errWALUnavailable
+	}
+	if len(leafPages) == 0 {
+		return refs, nil
+	}
+	if len(preparedPayloads) != len(leafPages) {
+		return nil, fmt.Errorf("cachingdb: prepared leaf page child-ref batch has %d payloads for %d leaf pages", len(preparedPayloads), len(leafPages))
+	}
+	if len(leafPages) == 1 {
+		ptr, err := l.AppendPreparedLeafPage(leafPages[0], preparedPayloads[0])
+		if err != nil {
+			return nil, err
+		}
+		return append(refs, page.LeafLogChildRef(ptr)), nil
+	}
+	startRID, err := l.db.ReserveValueLogRIDs(len(leafPages))
+	if err != nil {
+		return nil, err
+	}
+	records := getValueLogRecordsCap(len(leafPages))
+	records = records[:len(leafPages)]
+	defer func() {
+		for i := range records {
+			records[i] = valuelog.Record{}
+		}
+		putValueLogRecordsNoClear(records)
+	}()
+	for i := range leafPages {
+		if len(leafPages[i]) != page.PageSize {
+			return nil, fmt.Errorf("cachingdb: prepared leaf page %d has invalid size: got=%dB want=%dB", i, len(leafPages[i]), page.PageSize)
+		}
+		records[i] = valuelog.Record{
+			RID:   startRID + uint64(i),
+			Value: preparedPayloads[i],
+		}
+	}
+	valuePtrs, err := l.db.appendValueLog(l.lane, 0, nil, records, journalDurabilityNone)
+	if err != nil {
+		l.db.observeLeafLogLaneAppend(l.lane, 0, 0, 0, 0, err)
+		return nil, err
+	}
+	defer putValueLogPtrs(valuePtrs)
+	if len(valuePtrs) != len(leafPages) {
+		return nil, fmt.Errorf("cachingdb: prepared leaf page child-ref batch returned %d ptrs for %d leaf pages", len(valuePtrs), len(leafPages))
+	}
+	if cap(refs) < len(valuePtrs) {
+		refs = make([]page.ChildRef, len(valuePtrs))
+	} else {
+		refs = refs[:len(valuePtrs)]
+	}
+	for i, ptr := range valuePtrs {
+		leafPtr, convErr := page.LeafLogPtrFromValuePtr(ptr)
+		if convErr != nil {
+			return nil, convErr
+		}
+		refs[i] = page.LeafLogChildRef(leafPtr)
+		l.db.noteLeafGenerationRecordLength(ptr)
+	}
+	return refs, nil
+}
+
 func getCompactLeafLogPayloadScratch() *compactLeafLogPayloadScratch {
 	if v := compactLeafLogPayloadScratchPool.Get(); v != nil {
 		if scratch, ok := v.(*compactLeafLogPayloadScratch); ok && scratch != nil && cap(scratch.buf) >= page.PageSize {

--- a/TreeDB/caching/leaf_page_log_lanes.go
+++ b/TreeDB/caching/leaf_page_log_lanes.go
@@ -15,6 +15,7 @@ var _ backenddb.LeafPageLog = (*cachingLeafPageLogGroup)(nil)
 var _ backenddb.LeafPageBatchLog = (*cachingLeafPageLogGroup)(nil)
 var _ backenddb.LeafPagePreparedLog = (*cachingLeafPageLogGroup)(nil)
 var _ backenddb.LeafPagePreparedBatchLog = (*cachingLeafPageLogGroup)(nil)
+var _ backenddb.LeafPagePreparedChildRefBatchLog = (*cachingLeafPageLogGroup)(nil)
 var _ backenddb.LeafPageConcurrentAppendLog = (*cachingLeafPageLogGroup)(nil)
 var _ backenddb.LeafPageLogCreatedSegmentProvider = (*cachingLeafPageLogGroup)(nil)
 var _ backenddb.LeafPageLogCurrentSegmentProvider = (*cachingLeafPageLogGroup)(nil)
@@ -81,6 +82,14 @@ func (g *cachingLeafPageLogGroup) AppendPreparedLeafPages(leafPages [][]byte, pr
 		return nil, errors.New("cachingdb: leaf page log unavailable")
 	}
 	return log.AppendPreparedLeafPages(leafPages, preparedPayloads)
+}
+
+func (g *cachingLeafPageLogGroup) AppendPreparedLeafPageChildRefs(leafPages [][]byte, preparedPayloads [][]byte, refs []page.ChildRef) ([]page.ChildRef, error) {
+	log := g.defaultLog()
+	if log == nil {
+		return nil, errors.New("cachingdb: leaf page log unavailable")
+	}
+	return log.AppendPreparedLeafPageChildRefs(leafPages, preparedPayloads, refs)
 }
 
 func (g *cachingLeafPageLogGroup) ConcurrentLeafPageAppends() bool { return true }

--- a/TreeDB/db/leaf_page_log.go
+++ b/TreeDB/db/leaf_page_log.go
@@ -56,6 +56,13 @@ type LeafPagePreparedBatchLog interface {
 	AppendPreparedLeafPages(leafPages [][]byte, preparedPayloads [][]byte) ([]page.LeafLogPtr, error)
 }
 
+type LeafPagePreparedChildRefBatchLog interface {
+	// AppendPreparedLeafPageChildRefs is the ChildRef-returning counterpart to
+	// AppendPreparedLeafPages. It lets hot paths avoid allocating an intermediate
+	// []LeafLogPtr when the caller ultimately needs ChildRefs.
+	AppendPreparedLeafPageChildRefs(leafPages [][]byte, preparedPayloads [][]byte, refs []page.ChildRef) ([]page.ChildRef, error)
+}
+
 type LeafPageLogSegment struct {
 	Path   string
 	FileID uint32
@@ -150,7 +157,10 @@ func (l *leafPageLogWithRecordLengthHints) PreparedLeafPageBatchAppends() bool {
 	if l == nil || l.inner == nil {
 		return false
 	}
-	_, ok := l.inner.(LeafPagePreparedBatchLog)
+	if _, ok := l.inner.(LeafPagePreparedBatchLog); ok {
+		return true
+	}
+	_, ok := l.inner.(LeafPagePreparedChildRefBatchLog)
 	return ok
 }
 
@@ -222,6 +232,48 @@ func (l *leafPageLogWithRecordLengthHints) AppendPreparedLeafPages(leafPages [][
 		return nil, err
 	}
 	return ptrs, nil
+}
+
+func (l *leafPageLogWithRecordLengthHints) AppendPreparedLeafPageChildRefs(leafPages [][]byte, preparedPayloads [][]byte, refs []page.ChildRef) ([]page.ChildRef, error) {
+	refs = refs[:0]
+	if l == nil || l.inner == nil {
+		return nil, errors.New("leaf page log unavailable")
+	}
+	if len(leafPages) == 0 {
+		return refs, nil
+	}
+	if len(preparedPayloads) != len(leafPages) {
+		return nil, fmt.Errorf("leaf page prepared child-ref batch has %d payloads for %d leaf pages", len(preparedPayloads), len(leafPages))
+	}
+	if prepared, ok := l.inner.(LeafPagePreparedChildRefBatchLog); ok {
+		out, err := prepared.AppendPreparedLeafPageChildRefs(leafPages, preparedPayloads, refs)
+		if err != nil {
+			return nil, err
+		}
+		if len(out) != len(leafPages) {
+			return nil, fmt.Errorf("leaf page prepared child-ref batch returned %d refs for %d leaf pages", len(out), len(leafPages))
+		}
+		for i, ref := range out {
+			if !ref.IsLeafLog() {
+				return nil, fmt.Errorf("leaf page prepared child-ref batch returned non-leaf-log ref at %d", i)
+			}
+			l.noteLeafPagePointer(leafPages[i], ref.Log)
+		}
+		return out, nil
+	}
+	ptrs, err := l.AppendPreparedLeafPages(leafPages, preparedPayloads)
+	if err != nil {
+		return nil, err
+	}
+	if cap(refs) < len(ptrs) {
+		refs = make([]page.ChildRef, len(ptrs))
+	} else {
+		refs = refs[:len(ptrs)]
+	}
+	for i, ptr := range ptrs {
+		refs[i] = page.LeafLogChildRef(ptr)
+	}
+	return refs, nil
 }
 
 func (l *leafPageLogWithRecordLengthHints) noteLeafPageBatchPointers(leafPages [][]byte, ptrs []page.LeafLogPtr) error {

--- a/TreeDB/internal/valuelog/leaf_page_payload.go
+++ b/TreeDB/internal/valuelog/leaf_page_payload.go
@@ -24,16 +24,35 @@ func MaybeCompactLeafLogPayload(leafPage []byte) ([]byte, bool, error) {
 	return MaybeCompactLeafLogPayloadTo(nil, leafPage)
 }
 
-func MaybeCompactLeafLogPayloadTo(dst, leafPage []byte) ([]byte, bool, error) {
+// MaybeCompactLeafLogPayloadLength returns the compact payload length that the
+// MaybeCompact* helpers would produce for leafPage, without materializing the
+// payload. A false compacted result means callers should use leafPage as-is.
+func MaybeCompactLeafLogPayloadLength(leafPage []byte) (compactLen int, compacted bool) {
+	_, _, compactLen, compacted = compactLeafLogPayloadShape(leafPage)
+	if !compacted {
+		return len(leafPage), false
+	}
+	return compactLen, true
+}
+
+func compactLeafLogPayloadShape(leafPage []byte) (prefixLen, suffixLen, compactLen int, compacted bool) {
 	if len(leafPage) != page.PageSize {
-		return leafPage, false, nil
+		return 0, 0, 0, false
 	}
 	prefixLen, suffixLen, err := node.LeafPageLiveBounds(leafPage)
 	if err != nil {
-		return leafPage, false, nil
+		return 0, 0, 0, false
 	}
-	compactLen := compactLeafPagePayloadHeaderSize + prefixLen + suffixLen
+	compactLen = compactLeafPagePayloadHeaderSize + prefixLen + suffixLen
 	if compactLen >= len(leafPage) {
+		return 0, 0, 0, false
+	}
+	return prefixLen, suffixLen, compactLen, true
+}
+
+func MaybeCompactLeafLogPayloadTo(dst, leafPage []byte) ([]byte, bool, error) {
+	prefixLen, suffixLen, compactLen, compacted := compactLeafLogPayloadShape(leafPage)
+	if !compacted {
 		return leafPage, false, nil
 	}
 
@@ -57,15 +76,8 @@ func MaybeCompactLeafLogPayloadTo(dst, leafPage []byte) ([]byte, bool, error) {
 }
 
 func MaybeAppendCompactLeafLogPayloadTo(dst, leafPage []byte) ([]byte, []byte, bool, error) {
-	if len(leafPage) != page.PageSize {
-		return dst, leafPage, false, nil
-	}
-	prefixLen, suffixLen, err := node.LeafPageLiveBounds(leafPage)
-	if err != nil {
-		return dst, leafPage, false, nil
-	}
-	compactLen := compactLeafPagePayloadHeaderSize + prefixLen + suffixLen
-	if compactLen >= len(leafPage) {
+	prefixLen, suffixLen, compactLen, compacted := compactLeafLogPayloadShape(leafPage)
+	if !compacted {
 		return dst, leafPage, false, nil
 	}
 

--- a/TreeDB/internal/valuelog/leaf_page_payload_test.go
+++ b/TreeDB/internal/valuelog/leaf_page_payload_test.go
@@ -117,12 +117,16 @@ func requireLeafPagesLogicallyEqual(t *testing.T, want, got []byte) {
 func TestMaybeCompactLeafLogPayload_SparseLeafRoundTrips(t *testing.T) {
 	leaf := buildSparseLeafPageForPayloadTest(t)
 
+	payloadLen, payloadLenCompacted := MaybeCompactLeafLogPayloadLength(leaf)
 	payload, compacted, err := MaybeCompactLeafLogPayload(leaf)
 	if err != nil {
 		t.Fatalf("MaybeCompactLeafLogPayload: %v", err)
 	}
 	if !compacted {
 		t.Fatalf("expected sparse leaf page to compact")
+	}
+	if !payloadLenCompacted || payloadLen != len(payload) {
+		t.Fatalf("payload length estimate=(%d,%v) want (%d,true)", payloadLen, payloadLenCompacted, len(payload))
 	}
 	if len(payload) >= len(leaf) {
 		t.Fatalf("payload len=%d want < %d", len(payload), len(leaf))

--- a/TreeDB/zipper/apply_worker_pool.go
+++ b/TreeDB/zipper/apply_worker_pool.go
@@ -17,7 +17,7 @@ type applyWorkerPoolRun struct {
 	count   int
 	workers int
 	fn      func(workerID, job int)
-	strided bool
+	seeded  bool
 	next    atomic.Int64
 	wg      sync.WaitGroup
 }
@@ -60,18 +60,15 @@ func (p *ApplyWorkerPool) worker() {
 			}
 			continue
 		}
-		if run.strided {
-			for job := task.workerID; job < run.count; job += run.workers {
-				run.fn(task.workerID, job)
+		if run.seeded && task.workerID < run.count {
+			run.fn(task.workerID, task.workerID)
+		}
+		for {
+			job := int(run.next.Add(1)) - 1
+			if job >= run.count {
+				break
 			}
-		} else {
-			for {
-				job := int(run.next.Add(1)) - 1
-				if job >= run.count {
-					break
-				}
-				run.fn(task.workerID, job)
-			}
+			run.fn(task.workerID, job)
 		}
 		run.wg.Done()
 	}
@@ -83,14 +80,14 @@ func (p *ApplyWorkerPool) Run(workers, count int, fn func(workerID, job int)) er
 	return p.run(workers, count, fn, false)
 }
 
-// RunStrided schedules jobs deterministically by workerID (job=workerID+n*workers).
+// RunSeeded schedules one initial job per workerID before dynamic work stealing.
 // This preserves worker-owned resources such as selected leaf-log lanes while
-// still using the reusable worker pool.
-func (p *ApplyWorkerPool) RunStrided(workers, count int, fn func(workerID, job int)) error {
+// retaining load balancing for the remaining jobs.
+func (p *ApplyWorkerPool) RunSeeded(workers, count int, fn func(workerID, job int)) error {
 	return p.run(workers, count, fn, true)
 }
 
-func (p *ApplyWorkerPool) run(workers, count int, fn func(workerID, job int), strided bool) error {
+func (p *ApplyWorkerPool) run(workers, count int, fn func(workerID, job int), seeded bool) error {
 	if count <= 0 || fn == nil {
 		return nil
 	}
@@ -107,7 +104,10 @@ func (p *ApplyWorkerPool) run(workers, count int, fn func(workerID, job int), st
 		workers = 1
 	}
 
-	run := &applyWorkerPoolRun{count: count, workers: workers, fn: fn, strided: strided}
+	run := &applyWorkerPoolRun{count: count, workers: workers, fn: fn, seeded: seeded}
+	if seeded {
+		run.next.Store(int64(workers))
+	}
 	run.wg.Add(workers)
 
 	p.mu.Lock()

--- a/TreeDB/zipper/apply_worker_pool.go
+++ b/TreeDB/zipper/apply_worker_pool.go
@@ -14,10 +14,12 @@ type applyWorkerPoolTask struct {
 }
 
 type applyWorkerPoolRun struct {
-	count int
-	fn    func(workerID, job int)
-	next  atomic.Int64
-	wg    sync.WaitGroup
+	count   int
+	workers int
+	fn      func(workerID, job int)
+	strided bool
+	next    atomic.Int64
+	wg      sync.WaitGroup
 }
 
 // ApplyWorkerPool is a small reusable worker pool for opt-in flush/apply COW
@@ -58,12 +60,18 @@ func (p *ApplyWorkerPool) worker() {
 			}
 			continue
 		}
-		for {
-			job := int(run.next.Add(1)) - 1
-			if job >= run.count {
-				break
+		if run.strided {
+			for job := task.workerID; job < run.count; job += run.workers {
+				run.fn(task.workerID, job)
 			}
-			run.fn(task.workerID, job)
+		} else {
+			for {
+				job := int(run.next.Add(1)) - 1
+				if job >= run.count {
+					break
+				}
+				run.fn(task.workerID, job)
+			}
 		}
 		run.wg.Done()
 	}
@@ -72,6 +80,17 @@ func (p *ApplyWorkerPool) worker() {
 // Run schedules up to workers reusable workers over count jobs. It blocks until
 // all scheduled workers finish. A closed pool returns errApplyWorkerPoolClosed.
 func (p *ApplyWorkerPool) Run(workers, count int, fn func(workerID, job int)) error {
+	return p.run(workers, count, fn, false)
+}
+
+// RunStrided schedules jobs deterministically by workerID (job=workerID+n*workers).
+// This preserves worker-owned resources such as selected leaf-log lanes while
+// still using the reusable worker pool.
+func (p *ApplyWorkerPool) RunStrided(workers, count int, fn func(workerID, job int)) error {
+	return p.run(workers, count, fn, true)
+}
+
+func (p *ApplyWorkerPool) run(workers, count int, fn func(workerID, job int), strided bool) error {
 	if count <= 0 || fn == nil {
 		return nil
 	}
@@ -88,7 +107,7 @@ func (p *ApplyWorkerPool) Run(workers, count int, fn func(workerID, job int)) er
 		workers = 1
 	}
 
-	run := &applyWorkerPoolRun{count: count, fn: fn}
+	run := &applyWorkerPoolRun{count: count, workers: workers, fn: fn, strided: strided}
 	run.wg.Add(workers)
 
 	p.mu.Lock()

--- a/TreeDB/zipper/span_native_apply.go
+++ b/TreeDB/zipper/span_native_apply.go
@@ -39,7 +39,25 @@ type spanNativeLeafLogOutputLane struct {
 	log  LeafPageLog
 }
 
-var spanNativeLeafLogPayloadScratchPool sync.Pool
+const spanNativeLeafLogPayloadArenaMaxCap = 16 << 20
+
+type spanNativeLeafLogPayloadScratch struct {
+	buf []byte
+}
+
+type spanNativeLeafLogPayloadArena struct {
+	buf []byte
+}
+
+type spanNativeLeafLogPayloadSlice struct {
+	items [][]byte
+}
+
+var (
+	spanNativeLeafLogPayloadScratchPool sync.Pool
+	spanNativeLeafLogPayloadArenaPool   sync.Pool
+	spanNativeLeafLogPayloadSlicePool   sync.Pool
+)
 
 func newSpanNativeLeafLogOutputGate(limit int) *spanNativeLeafLogOutputGate {
 	if limit <= 0 {
@@ -48,20 +66,100 @@ func newSpanNativeLeafLogOutputGate(limit int) *spanNativeLeafLogOutputGate {
 	return &spanNativeLeafLogOutputGate{sem: make(chan struct{}, limit)}
 }
 
-func acquireSpanNativeLeafLogPayloadScratch() []byte {
+func acquireSpanNativeLeafLogPayloadScratch() *spanNativeLeafLogPayloadScratch {
 	if v := spanNativeLeafLogPayloadScratchPool.Get(); v != nil {
-		if buf, ok := v.([]byte); ok && cap(buf) <= page.PageSize*2 {
-			return buf[:0]
+		if scratch, ok := v.(*spanNativeLeafLogPayloadScratch); ok && scratch != nil && cap(scratch.buf) <= page.PageSize*2 {
+			scratch.buf = scratch.buf[:0]
+			return scratch
 		}
 	}
-	return make([]byte, 0, page.PageSize)
+	return &spanNativeLeafLogPayloadScratch{buf: make([]byte, 0, page.PageSize)}
 }
 
-func releaseSpanNativeLeafLogPayloadScratch(buf []byte) {
-	if cap(buf) == 0 || cap(buf) > page.PageSize*2 {
+func releaseSpanNativeLeafLogPayloadScratch(scratch *spanNativeLeafLogPayloadScratch) {
+	if scratch == nil || cap(scratch.buf) == 0 || cap(scratch.buf) > page.PageSize*2 {
 		return
 	}
-	spanNativeLeafLogPayloadScratchPool.Put(buf[:0])
+	scratch.buf = scratch.buf[:0]
+	spanNativeLeafLogPayloadScratchPool.Put(scratch)
+}
+
+func acquireSpanNativeLeafLogPayloadArena(need int) *spanNativeLeafLogPayloadArena {
+	if need < 0 {
+		need = 0
+	}
+	if need <= spanNativeLeafLogPayloadArenaMaxCap {
+		if v := spanNativeLeafLogPayloadArenaPool.Get(); v != nil {
+			if arena, ok := v.(*spanNativeLeafLogPayloadArena); ok && arena != nil && cap(arena.buf) >= need && cap(arena.buf) <= spanNativeLeafLogPayloadArenaMaxCap {
+				arena.buf = arena.buf[:0]
+				return arena
+			}
+		}
+	}
+	arena := &spanNativeLeafLogPayloadArena{}
+	if need > 0 {
+		arena.buf = make([]byte, 0, need)
+	}
+	return arena
+}
+
+func releaseSpanNativeLeafLogPayloadArena(arena *spanNativeLeafLogPayloadArena) {
+	if arena == nil || cap(arena.buf) > spanNativeLeafLogPayloadArenaMaxCap {
+		return
+	}
+	arena.buf = arena.buf[:0]
+	spanNativeLeafLogPayloadArenaPool.Put(arena)
+}
+
+func acquireSpanNativeLeafLogPayloadSlice(n int) *spanNativeLeafLogPayloadSlice {
+	if n <= 0 {
+		return &spanNativeLeafLogPayloadSlice{}
+	}
+	if v := spanNativeLeafLogPayloadSlicePool.Get(); v != nil {
+		if lease, ok := v.(*spanNativeLeafLogPayloadSlice); ok && lease != nil && cap(lease.items) >= n && cap(lease.items) <= 1<<20 {
+			lease.items = lease.items[:n]
+			return lease
+		}
+	}
+	return &spanNativeLeafLogPayloadSlice{items: make([][]byte, n)}
+}
+
+func releaseSpanNativeLeafLogPayloadSlice(lease *spanNativeLeafLogPayloadSlice) {
+	if lease == nil || cap(lease.items) == 0 || cap(lease.items) > 1<<20 {
+		return
+	}
+	clear(lease.items[:cap(lease.items)])
+	lease.items = lease.items[:0]
+	spanNativeLeafLogPayloadSlicePool.Put(lease)
+}
+
+func estimateSpanNativeLeafLogPayloadArenaCap(leafPages [][]byte) int {
+	if len(leafPages) == 0 {
+		return 0
+	}
+	samples := len(leafPages)
+	if samples > 8 {
+		samples = 8
+	}
+	compactSamples := 0
+	totalCompactLen := 0
+	for i := 0; i < samples; i++ {
+		compactLen, compacted := valuelog.MaybeCompactLeafLogPayloadLength(leafPages[i])
+		if !compacted {
+			continue
+		}
+		compactSamples++
+		totalCompactLen += compactLen
+	}
+	if compactSamples == 0 {
+		return 0
+	}
+	avgCompactLen := (totalCompactLen + compactSamples - 1) / compactSamples
+	maxCap := page.PageSize * len(leafPages)
+	if avgCompactLen > maxCap/len(leafPages) {
+		return maxCap
+	}
+	return avgCompactLen * len(leafPages)
 }
 
 func (g *spanNativeLeafLogOutputGate) selectedLeafPageLogForWorker(z *Zipper, workerIndex int) (LeafPageLog, bool) {
@@ -111,11 +209,11 @@ func (g *spanNativeLeafLogOutputGate) persistLeafPageDataForWorker(z *Zipper, wo
 func (g *spanNativeLeafLogOutputGate) persistLeafPageDataToLog(z *Zipper, log LeafPageLog, leafPage []byte, metrics *adaptive.Metrics) (page.ChildRef, error) {
 	prepared := leafPageLogConsumesPreparedPayloads(log, false)
 	var payload []byte
-	var scratch []byte
+	var scratch *spanNativeLeafLogPayloadScratch
 	if prepared {
 		scratch = acquireSpanNativeLeafLogPayloadScratch()
 		var err error
-		payload, _, err = valuelog.MaybeCompactLeafLogPayloadTo(scratch[:0], leafPage)
+		payload, _, err = valuelog.MaybeCompactLeafLogPayloadTo(scratch.buf[:0], leafPage)
 		if err != nil {
 			releaseSpanNativeLeafLogPayloadScratch(scratch)
 			return page.ChildRef{}, err
@@ -167,35 +265,45 @@ func (g *spanNativeLeafLogOutputGate) persistLeafPageBatchDataToLog(z *Zipper, l
 	}
 	prepared := leafPageLogConsumesPreparedPayloads(log, true)
 	var payloads [][]byte
+	var payloadSlice *spanNativeLeafLogPayloadArena
+	var payloadLease *spanNativeLeafLogPayloadSlice
 	if prepared {
-		var payloadInline [8][]byte
-		if len(leafPages) <= len(payloadInline) {
-			payloads = payloadInline[:len(leafPages)]
-		} else {
-			payloads = make([][]byte, len(leafPages))
-		}
-		var arena []byte
+		payloadLease = acquireSpanNativeLeafLogPayloadSlice(len(leafPages))
+		payloads = payloadLease.items
+		payloadSlice = acquireSpanNativeLeafLogPayloadArena(estimateSpanNativeLeafLogPayloadArenaCap(leafPages))
 		for i, leafPage := range leafPages {
 			var err error
-			arena, payloads[i], _, err = valuelog.MaybeAppendCompactLeafLogPayloadTo(arena, leafPage)
+			payloadSlice.buf, payloads[i], _, err = valuelog.MaybeAppendCompactLeafLogPayloadTo(payloadSlice.buf, leafPage)
 			if err != nil {
+				releaseSpanNativeLeafLogPayloadSlice(payloadLease)
+				releaseSpanNativeLeafLogPayloadArena(payloadSlice)
 				return nil, err
 			}
 		}
 	}
 	waitStart := time.Now()
+	acquiredSemaphore := false
 	if g != nil && g.sem != nil {
 		g.sem <- struct{}{}
-		defer func() { <-g.sem }()
+		acquiredSemaphore = true
 	}
 	reservationWait := time.Since(waitStart)
 	if metrics != nil && reservationWait > 0 {
 		metrics.ZipperLeafLogOutputReservationWaitNs += reservationWait.Nanoseconds()
 	}
-	if !prepared {
-		return z.persistLeafPageBatchDataToLog(log, leafPages, refs, metrics)
+	var out []page.ChildRef
+	var err error
+	if prepared {
+		out, err = z.persistPreparedLeafPageBatchDataToLog(log, leafPages, payloads, refs, metrics)
+	} else {
+		out, err = z.persistLeafPageBatchDataToLog(log, leafPages, refs, metrics)
 	}
-	return z.persistPreparedLeafPageBatchDataToLog(log, leafPages, payloads, refs, metrics)
+	if acquiredSemaphore {
+		<-g.sem
+	}
+	releaseSpanNativeLeafLogPayloadSlice(payloadLease)
+	releaseSpanNativeLeafLogPayloadArena(payloadSlice)
+	return out, err
 }
 
 func (z *Zipper) applySpanNativeWithPrepared(rootID uint64, ops []batch.Entry, prepared ReadOnlyPrepareResult, workers int, workerPool *ApplyWorkerPool) (ApplyResult, bool, error) {

--- a/TreeDB/zipper/span_native_apply.go
+++ b/TreeDB/zipper/span_native_apply.go
@@ -476,7 +476,7 @@ func (z *Zipper) applySpanNativeWithPrepared(rootID uint64, ops []batch.Entry, p
 	if workerPool != nil {
 		var err error
 		if leafLogOutput != nil && scheduledWorkers > 1 {
-			err = workerPool.RunStrided(scheduledWorkers, len(workerRanges), runRange)
+			err = workerPool.RunSeeded(scheduledWorkers, len(workerRanges), runRange)
 		} else {
 			err = workerPool.Run(scheduledWorkers, len(workerRanges), runRange)
 		}
@@ -490,10 +490,18 @@ func (z *Zipper) applySpanNativeWithPrepared(rootID uint64, ops []batch.Entry, p
 			runRange(0, job)
 		}
 	} else if leafLogOutput != nil {
+		var nextJob int64 = int64(scheduledWorkers - 1)
 		var wg sync.WaitGroup
 		worker := func(workerID int) {
 			defer wg.Done()
-			for job := workerID; job < len(workerRanges); job += scheduledWorkers {
+			if workerID < len(workerRanges) {
+				runRange(workerID, workerID)
+			}
+			for {
+				job := int(atomic.AddInt64(&nextJob, 1))
+				if job >= len(workerRanges) {
+					return
+				}
 				runRange(workerID, job)
 			}
 		}

--- a/TreeDB/zipper/span_native_apply.go
+++ b/TreeDB/zipper/span_native_apply.go
@@ -151,19 +151,26 @@ func estimateSpanNativeLeafLogPayloadArenaCap(leafPages [][]byte) int {
 		compactSamples++
 		totalCompactLen += compactLen
 	}
-	if compactSamples == 0 {
-		return 0
+	if compactSamples != samples {
+		for i := samples; i < len(leafPages); i++ {
+			compactLen, compacted := valuelog.MaybeCompactLeafLogPayloadLength(leafPages[i])
+			if !compacted {
+				continue
+			}
+			totalCompactLen += compactLen
+		}
+		maxCap := page.PageSize * len(leafPages)
+		if totalCompactLen > maxCap {
+			return maxCap
+		}
+		return totalCompactLen
 	}
 	avgCompactLen := (totalCompactLen + compactSamples - 1) / compactSamples
-	estimatedCompactPages := (len(leafPages)*compactSamples + samples - 1) / samples
-	if estimatedCompactPages <= 0 {
-		return 0
-	}
-	maxCap := page.PageSize * estimatedCompactPages
-	if avgCompactLen > maxCap/estimatedCompactPages {
+	maxCap := page.PageSize * len(leafPages)
+	if avgCompactLen > maxCap/len(leafPages) {
 		return maxCap
 	}
-	return avgCompactLen * estimatedCompactPages
+	return avgCompactLen * len(leafPages)
 }
 
 func (g *spanNativeLeafLogOutputGate) selectedLeafPageLogForWorker(z *Zipper, workerIndex int) (LeafPageLog, bool) {

--- a/TreeDB/zipper/span_native_apply.go
+++ b/TreeDB/zipper/span_native_apply.go
@@ -155,11 +155,15 @@ func estimateSpanNativeLeafLogPayloadArenaCap(leafPages [][]byte) int {
 		return 0
 	}
 	avgCompactLen := (totalCompactLen + compactSamples - 1) / compactSamples
-	maxCap := page.PageSize * len(leafPages)
-	if avgCompactLen > maxCap/len(leafPages) {
+	estimatedCompactPages := (len(leafPages)*compactSamples + samples - 1) / samples
+	if estimatedCompactPages <= 0 {
+		return 0
+	}
+	maxCap := page.PageSize * estimatedCompactPages
+	if avgCompactLen > maxCap/estimatedCompactPages {
 		return maxCap
 	}
-	return avgCompactLen * len(leafPages)
+	return avgCompactLen * estimatedCompactPages
 }
 
 func (g *spanNativeLeafLogOutputGate) selectedLeafPageLogForWorker(z *Zipper, workerIndex int) (LeafPageLog, bool) {

--- a/TreeDB/zipper/span_native_apply.go
+++ b/TreeDB/zipper/span_native_apply.go
@@ -474,7 +474,13 @@ func (z *Zipper) applySpanNativeWithPrepared(rootID uint64, ops []batch.Entry, p
 		recordSpanNativeWorkUnitMetrics(&metrics, workerRanges)
 	}
 	if workerPool != nil {
-		if err := workerPool.Run(scheduledWorkers, len(workerRanges), runRange); err != nil {
+		var err error
+		if leafLogOutput != nil && scheduledWorkers > 1 {
+			err = workerPool.RunStrided(scheduledWorkers, len(workerRanges), runRange)
+		} else {
+			err = workerPool.Run(scheduledWorkers, len(workerRanges), runRange)
+		}
+		if err != nil {
 			finishScheduleStats()
 			metrics.ZipperApplyWallNs = time.Since(applyStart).Nanoseconds()
 			return ApplyResult{Metrics: metrics}, true, err
@@ -483,6 +489,19 @@ func (z *Zipper) applySpanNativeWithPrepared(rootID uint64, ops []batch.Entry, p
 		for job := range workerRanges {
 			runRange(0, job)
 		}
+	} else if leafLogOutput != nil {
+		var wg sync.WaitGroup
+		worker := func(workerID int) {
+			defer wg.Done()
+			for job := workerID; job < len(workerRanges); job += scheduledWorkers {
+				runRange(workerID, job)
+			}
+		}
+		for workerID := 0; workerID < scheduledWorkers; workerID++ {
+			wg.Add(1)
+			go worker(workerID)
+		}
+		wg.Wait()
 	} else {
 		var nextJob int64 = -1
 		var wg sync.WaitGroup

--- a/TreeDB/zipper/zipper.go
+++ b/TreeDB/zipper/zipper.go
@@ -59,6 +59,10 @@ type LeafPagePreparedBatchLog interface {
 	AppendPreparedLeafPages(leafPages [][]byte, preparedPayloads [][]byte) ([]page.LeafLogPtr, error)
 }
 
+type LeafPagePreparedChildRefBatchLog interface {
+	AppendPreparedLeafPageChildRefs(leafPages [][]byte, preparedPayloads [][]byte, refs []page.ChildRef) ([]page.ChildRef, error)
+}
+
 type LeafPageReader interface {
 	ReadUnsafe(ptr page.ValuePtr) ([]byte, error)
 }
@@ -1857,6 +1861,30 @@ func (z *Zipper) persistPreparedLeafPageBatchDataToLog(log LeafPageLog, leafPage
 	}
 	if len(preparedPayloads) != len(leafPages) {
 		return nil, fmt.Errorf("zipper: prepared leaf payload count %d for %d pages", len(preparedPayloads), len(leafPages))
+	}
+	if refBatcher, ok := log.(LeafPagePreparedChildRefBatchLog); ok {
+		appendStart := time.Now()
+		out, err := refBatcher.AppendPreparedLeafPageChildRefs(leafPages, preparedPayloads, refs)
+		appendWait := time.Since(appendStart)
+		if err != nil {
+			recordZipperLeafLogOutputAppend(metrics, appendWait, len(leafPages), false)
+			return nil, err
+		}
+		if len(out) != len(leafPages) {
+			recordZipperLeafLogOutputAppend(metrics, appendWait, len(leafPages), false)
+			return nil, fmt.Errorf("zipper: prepared leaf page child-ref batch returned %d refs for %d pages", len(out), len(leafPages))
+		}
+		for i, ref := range out {
+			if !ref.IsLeafLog() {
+				recordZipperLeafLogOutputAppend(metrics, appendWait, len(leafPages), false)
+				return nil, fmt.Errorf("zipper: prepared leaf page child-ref batch returned non-leaf-log ref at %d", i)
+			}
+		}
+		recordZipperLeafLogOutputAppend(metrics, appendWait, len(leafPages), true)
+		for i, ref := range out {
+			z.cachePersistedLeafPage(ref.Log, leafPages[i])
+		}
+		return out, nil
 	}
 	preparedBatcher, ok := log.(LeafPagePreparedBatchLog)
 	if !ok {

--- a/TreeDB/zipper/zipper.go
+++ b/TreeDB/zipper/zipper.go
@@ -1929,7 +1929,10 @@ func leafPageLogConsumesPreparedPayloads(log LeafPageLog, batch bool) bool {
 		if prepared, ok := log.(LeafPagePreparedBatchAppendLog); ok {
 			return prepared.PreparedLeafPageBatchAppends()
 		}
-		_, ok := log.(LeafPagePreparedBatchLog)
+		if _, ok := log.(LeafPagePreparedBatchLog); ok {
+			return true
+		}
+		_, ok := log.(LeafPagePreparedChildRefBatchLog)
 		return ok
 	}
 	if prepared, ok := log.(LeafPagePreparedAppendLog); ok {

--- a/TreeDB/zipper/zipper_test.go
+++ b/TreeDB/zipper/zipper_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/snissn/gomap/TreeDB/batch"
 	"github.com/snissn/gomap/TreeDB/internal/adaptive"
+	"github.com/snissn/gomap/TreeDB/internal/valuelog"
 	"github.com/snissn/gomap/TreeDB/node"
 	"github.com/snissn/gomap/TreeDB/page"
 	"github.com/snissn/gomap/TreeDB/pager"
@@ -1170,6 +1171,32 @@ func TestZipperMergeScratch_ConcurrentPendingLeafPageScratchReuse(t *testing.T) 
 		}(g)
 	}
 	wg.Wait()
+}
+
+func TestEstimateSpanNativeLeafLogPayloadArenaCapUsesCompactableRatio(t *testing.T) {
+	compactLeaf := make([]byte, page.PageSize)
+	builder := node.NewBuilderWithOptions(compactLeaf, page.PageTypeLeaf, node.BuilderOptions{
+		LeafPrefixCompression: true,
+		LeafColumnar:          true,
+		PackedValuePtr:        true,
+	})
+	for i := 0; i < 4; i++ {
+		if err := builder.AddLeafEntry([]byte{byte('k'), byte('0' + i)}, []byte("value"), node.FlagInline, page.ValuePtr{}); err != nil {
+			t.Fatalf("AddLeafEntry(%d): %v", i, err)
+		}
+	}
+	builder.FinishNoNode()
+	compactLen, compacted := valuelog.MaybeCompactLeafLogPayloadLength(compactLeaf)
+	if !compacted {
+		t.Fatalf("test leaf did not compact")
+	}
+	nonCompactLeaf := bytes.Repeat([]byte{'x'}, page.PageSize)
+	leafPages := [][]byte{compactLeaf, nonCompactLeaf, compactLeaf, nonCompactLeaf}
+	got := estimateSpanNativeLeafLogPayloadArenaCap(leafPages)
+	want := compactLen * 2
+	if got != want {
+		t.Fatalf("estimate=%d want %d", got, want)
+	}
 }
 
 type childRefPreparedBatchTestLog struct {

--- a/TreeDB/zipper/zipper_test.go
+++ b/TreeDB/zipper/zipper_test.go
@@ -1172,6 +1172,68 @@ func TestZipperMergeScratch_ConcurrentPendingLeafPageScratchReuse(t *testing.T) 
 	wg.Wait()
 }
 
+type childRefPreparedBatchTestLog struct {
+	called bool
+	next   uint64
+}
+
+func (l *childRefPreparedBatchTestLog) AppendLeafPage([]byte) (page.LeafLogPtr, error) {
+	return page.LeafLogPtr{}, fmt.Errorf("unexpected AppendLeafPage fallback")
+}
+
+func (l *childRefPreparedBatchTestLog) AppendPreparedLeafPageChildRefs(leafPages [][]byte, _ [][]byte, refs []page.ChildRef) ([]page.ChildRef, error) {
+	l.called = true
+	if cap(refs) < len(leafPages) {
+		refs = make([]page.ChildRef, len(leafPages))
+	} else {
+		refs = refs[:len(leafPages)]
+	}
+	if l.next == 0 {
+		l.next = 4
+	}
+	for i := range leafPages {
+		ptr := page.LeafLogPtr{FileID: 7, Offset: l.next, RecordLengthHint: page.PageSize, SubIndex: uint16(i)}
+		refs[i] = page.LeafLogChildRef(ptr)
+		l.next += page.PageSize + 32
+	}
+	return refs, nil
+}
+
+func TestPersistPreparedLeafPageBatchDataUsesChildRefBatcher(t *testing.T) {
+	z := New(nil, nil)
+	log := &childRefPreparedBatchTestLog{}
+	leafPages := [][]byte{
+		bytes.Repeat([]byte{'a'}, page.PageSize),
+		bytes.Repeat([]byte{'b'}, page.PageSize),
+		bytes.Repeat([]byte{'c'}, page.PageSize),
+	}
+	payloads := [][]byte{[]byte("payload-a"), []byte("payload-b"), []byte("payload-c")}
+	reusable := make([]page.ChildRef, 0, len(leafPages))
+	var metrics adaptive.Metrics
+
+	refs, err := z.persistPreparedLeafPageBatchDataToLog(log, leafPages, payloads, reusable, &metrics)
+	if err != nil {
+		t.Fatalf("persistPreparedLeafPageBatchDataToLog: %v", err)
+	}
+	if !log.called {
+		t.Fatalf("child-ref batch appender was not called")
+	}
+	if len(refs) != len(leafPages) {
+		t.Fatalf("refs len=%d want %d", len(refs), len(leafPages))
+	}
+	if cap(refs) != cap(reusable) {
+		t.Fatalf("refs cap=%d want reusable cap %d", cap(refs), cap(reusable))
+	}
+	for i, ref := range refs {
+		if !ref.IsLeafLog() || ref.Log.FileID != 7 || ref.Log.SubIndex != uint16(i) {
+			t.Fatalf("ref[%d]=%+v", i, ref)
+		}
+	}
+	if metrics.ZipperLeafLogOutputAppendCalls != 1 || metrics.ZipperLeafLogOutputAppendPages != len(leafPages) {
+		t.Fatalf("append metrics calls=%d pages=%d", metrics.ZipperLeafLogOutputAppendCalls, metrics.ZipperLeafLogOutputAppendPages)
+	}
+}
+
 type benchmarkLeafBatchLog struct {
 	next uint64
 	ptrs []page.LeafLogPtr

--- a/TreeDB/zipper/zipper_test.go
+++ b/TreeDB/zipper/zipper_test.go
@@ -1173,7 +1173,8 @@ func TestZipperMergeScratch_ConcurrentPendingLeafPageScratchReuse(t *testing.T) 
 	wg.Wait()
 }
 
-func TestEstimateSpanNativeLeafLogPayloadArenaCapUsesCompactableRatio(t *testing.T) {
+func buildCompactEstimateLeaf(t *testing.T) []byte {
+	t.Helper()
 	compactLeaf := make([]byte, page.PageSize)
 	builder := node.NewBuilderWithOptions(compactLeaf, page.PageTypeLeaf, node.BuilderOptions{
 		LeafPrefixCompression: true,
@@ -1186,12 +1187,36 @@ func TestEstimateSpanNativeLeafLogPayloadArenaCapUsesCompactableRatio(t *testing
 		}
 	}
 	builder.FinishNoNode()
+	return compactLeaf
+}
+
+func TestEstimateSpanNativeLeafLogPayloadArenaCapUsesCompactableRatio(t *testing.T) {
+	compactLeaf := buildCompactEstimateLeaf(t)
 	compactLen, compacted := valuelog.MaybeCompactLeafLogPayloadLength(compactLeaf)
 	if !compacted {
 		t.Fatalf("test leaf did not compact")
 	}
 	nonCompactLeaf := bytes.Repeat([]byte{'x'}, page.PageSize)
 	leafPages := [][]byte{compactLeaf, nonCompactLeaf, compactLeaf, nonCompactLeaf}
+	got := estimateSpanNativeLeafLogPayloadArenaCap(leafPages)
+	want := compactLen * 2
+	if got != want {
+		t.Fatalf("estimate=%d want %d", got, want)
+	}
+}
+
+func TestEstimateSpanNativeLeafLogPayloadArenaCapScansUnsampledMixedPages(t *testing.T) {
+	compactLeaf := buildCompactEstimateLeaf(t)
+	compactLen, compacted := valuelog.MaybeCompactLeafLogPayloadLength(compactLeaf)
+	if !compacted {
+		t.Fatalf("test leaf did not compact")
+	}
+	nonCompactLeaf := bytes.Repeat([]byte{'x'}, page.PageSize)
+	leafPages := make([][]byte, 0, 10)
+	for i := 0; i < 8; i++ {
+		leafPages = append(leafPages, nonCompactLeaf)
+	}
+	leafPages = append(leafPages, compactLeaf, compactLeaf)
 	got := estimateSpanNativeLeafLogPayloadArenaCap(leafPages)
 	want := compactLen * 2
 	if got != want {
@@ -1242,6 +1267,30 @@ func TestPersistPreparedLeafPageBatchDataUsesChildRefBatcher(t *testing.T) {
 	if err != nil {
 		t.Fatalf("persistPreparedLeafPageBatchDataToLog: %v", err)
 	}
+	requireChildRefPreparedBatchTestRefs(t, refs, leafPages, reusable, log, metrics)
+}
+
+func TestPersistLeafPageBatchDataDetectsChildRefPreparedBatcher(t *testing.T) {
+	z := New(nil, nil)
+	log := &childRefPreparedBatchTestLog{}
+	leafPages := [][]byte{
+		buildCompactEstimateLeaf(t),
+		buildCompactEstimateLeaf(t),
+		buildCompactEstimateLeaf(t),
+	}
+	reusable := make([]page.ChildRef, 0, len(leafPages))
+	var metrics adaptive.Metrics
+	gate := newSpanNativeLeafLogOutputGate(0)
+
+	refs, err := gate.persistLeafPageBatchDataToLog(z, log, leafPages, reusable, &metrics)
+	if err != nil {
+		t.Fatalf("persistLeafPageBatchDataToLog: %v", err)
+	}
+	requireChildRefPreparedBatchTestRefs(t, refs, leafPages, reusable, log, metrics)
+}
+
+func requireChildRefPreparedBatchTestRefs(t *testing.T, refs []page.ChildRef, leafPages [][]byte, reusable []page.ChildRef, log *childRefPreparedBatchTestLog, metrics adaptive.Metrics) {
+	t.Helper()
 	if !log.called {
 		t.Fatalf("child-ref batch appender was not called")
 	}

--- a/TreeDB/zipper/zipper_test.go
+++ b/TreeDB/zipper/zipper_test.go
@@ -1300,6 +1300,11 @@ func requireChildRefPreparedBatchTestRefs(t *testing.T, refs []page.ChildRef, le
 	if cap(refs) != cap(reusable) {
 		t.Fatalf("refs cap=%d want reusable cap %d", cap(refs), cap(reusable))
 	}
+	if len(refs) > 0 && cap(reusable) > 0 {
+		if &refs[:cap(refs)][0] != &reusable[:cap(reusable)][0] {
+			t.Fatalf("refs did not reuse reusable backing array")
+		}
+	}
 	for i, ref := range refs {
 		if !ref.IsLeafLog() || ref.Log.FileID != 7 || ref.Log.SubIndex != uint16(i) {
 			t.Fatalf("ref[%d]=%+v", i, ref)


### PR DESCRIPTION
## Summary

- Pool span-native prepared leaf-log payload arenas/slices and pre-size compact-payload arenas from sampled compact lengths, removing the per-batch `slices.Grow` allocation cliff seen in profiles.
- Add a prepared leaf-log ChildRef batch append interface so span-native output can avoid allocating an intermediate `[]LeafLogPtr` when it already needs `[]page.ChildRef`.
- Preserve selected-lane distribution by seeding one initial work unit per worker-owned lane before dynamic work stealing.

## Profile / benchmark evidence

Latest head: `154b662b5305710f5e172af8f8e87c7ea6aa4e0b`.

| concurrency | artifact | sequential_write | batch_random | random_write |
| --- | --- | ---: | ---: | ---: |
| c4 baseline | `<remote-profile-root>/treedb_2934_lifecycle_c4_20260621_215210` | 2,398,494/s | 581,973/s | 246,047/s |
| c4 candidate | `<remote-profile-root>/treedb_2930_seeded_lanes_c4_rerun_20260622_055426` | 2,568,556/s | 726,376/s | 252,059/s |
| c8 baseline | `<remote-profile-root>/treedb_2930_base_c8_20260622_040939` | 2,402,264/s | 607,295/s | 271,615/s |
| c8 candidate | `<remote-profile-root>/treedb_2930_seeded_lanes_c8_20260622_055052` | 2,551,052/s | 769,541/s | 316,039/s |
| c16 baseline | `<remote-profile-root>/treedb_2930_base_c16_20260622_041246` | 2,360,075/s | 625,223/s | 271,072/s |
| c16 candidate | `<remote-profile-root>/treedb_2930_seeded_lanes_c16_20260622_055645` | 2,545,003/s | 772,682/s | 329,746/s |

Selected counter movement:

| concurrency | leaf output append wait | reservation wait | lane lock wait | lane lock hold | scheduler busy | scheduler wait | checkpoint flush_all |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| c4 | -4.6% | -6.2% | -7.6% | -11.6% | -7.2% | -8.2% | +7.2% |
| c8 | -5.0% | -7.0% | -7.9% | +0.6% | -6.7% | -9.1% | -1.4% |
| c16 | -6.1% | -7.7% | -8.0% | -14.9% | -5.6% | -8.0% | -11.3% |

Allocation/profile notes:

- c4 random_write allocation profile total dropped from ~16.66 GiB to ~3.15 GiB.
- `spanNativeLeafLogOutputGate.persistLeafPageBatchDataToLog` random_write alloc-space dropped from ~13.42 GiB cumulative to ~166.7 MiB cumulative.
- All candidate c4/c8/c16 span-native fallback reason counters remained zero.
- Lane task distribution stayed active across selected lanes: c4 `4/4`, c8 `8/8`, c16 `12/12` selected worker lanes used.

Read/cache/scan smoke:

- `<remote-profile-root>/treedb_2930_read_scan_smoke_20260622_042614`
  - sequential_write 2,236,287/s
  - random_read 356,051/s
  - full_scan 8,866,443/s
  - prefix_scan 6,909,243/s

Commands used for c4/c8/c16 (with `-treedb-flush-apply-concurrency` set to `4`, `8`, or `16` respectively):

```sh
./bin/unified-bench -dbs treedb -test sequential_write,batch_random,random_write \
  -keys 10000000 -valsize 128 -batchsize 8000 -checkpoint-between-tests \
  -treedb-flush-admission-policy=explicit -treedb-flush-apply-span-native \
  -treedb-flush-backlog-coalescing -treedb-flush-apply-min-entries=1 \
  -treedb-flush-apply-min-spans=1 -treedb-flush-apply-min-bytes=1 \
  -treedb-flush-apply-concurrency=<4|8|16> \
  -profile-dir "$OUT" -progress=false
./bin/benchprof -profiles-dir "$OUT"
```

## Validation

- `GOWORK=off go test ./TreeDB/zipper -run 'Test(SpanNativeApplyLeafLogOutputRoutesWorkerRangesToSelectedLanes|EstimateSpanNativeLeafLogPayloadArenaCapUsesCompactableRatio|EstimateSpanNativeLeafLogPayloadArenaCapScansUnsampledMixedPages|PersistLeafPageBatchDataDetectsChildRefPreparedBatcher)' -count=20`
- `GOWORK=off go test ./TreeDB/zipper -run 'Test(PersistPreparedLeafPageBatchDataUsesChildRefBatcher|PersistLeafPageBatchDataDetectsChildRefPreparedBatcher)' -count=20`
- `GOWORK=off go test ./TreeDB/db ./TreeDB/caching ./TreeDB/zipper ./TreeDB/internal/valuelog -count=1`
- `GOWORK=off go test -race ./TreeDB/caching ./TreeDB/db ./TreeDB/zipper -run 'Test(CachingSpanNativeLeafLogOutputUsesSelectedLanes|CachingLeafPageLogLaneSnapshotsAggregateAndMarkPerLane|LeafPageLogLanes_FlushSyncCloseTouchAllLanes|LeafPageLogLanes_ReadSurfacesNoCacheAndReadOnlyOpen|LeafPageLogLanes_IteratorSnapshotSurvivesMultiLaneGC|PersistPreparedLeafPageBatchDataUsesChildRefBatcher|PersistLeafPageBatchDataDetectsChildRefPreparedBatcher|SpanNativeApplyLeafLogOutputRoutesWorkerRangesToSelectedLanes)' -count=1`
- `GOWORK=off go test ./TreeDB/... -count=1`

Closes #2930.
