### PR TITLE
TreeDB: add checkpoint wait productivity counters

### DIFF
--- a/TreeDB/caching/checkpoint_productivity_stats_test.go
+++ b/TreeDB/caching/checkpoint_productivity_stats_test.go
@@ -36,6 +36,16 @@ func TestCheckpointWaitProductivityStatsNoopCheckpoint(t *testing.T) {
 	}
 	defer func() { _ = db.Close() }()
 
+	db.checkpointFlushAllWorkersLast.Store(2)
+	db.checkpointFlushAllFrontierLanesLast.Store(2)
+	db.checkpointOwnedDrainUnitsLast.Store(3)
+	db.checkpointOwnedDrainOpsLast.Store(4)
+	db.checkpointOwnedDrainBytesLast.Store(5)
+	db.checkpointOwnedDrainNsLast.Store(6)
+	db.checkpointBackgroundDrainUnitsLast.Store(7)
+	db.checkpointBackgroundDrainOpsLast.Store(8)
+	db.checkpointBackgroundDrainBytesLast.Store(9)
+
 	if err := db.Checkpoint(); err != nil {
 		t.Fatalf("Checkpoint: %v", err)
 	}
@@ -50,8 +60,15 @@ func TestCheckpointWaitProductivityStatsNoopCheckpoint(t *testing.T) {
 		"treedb.cache.checkpoint.wait.frontier_units_at_request_last",
 		"treedb.cache.checkpoint.wait.remaining_frontier_units_last",
 		"treedb.cache.checkpoint.wait.drained_frontier_units_last",
+		"treedb.cache.checkpoint.flush_all.workers_last",
+		"treedb.cache.checkpoint.flush_all.frontier_lanes_last",
 		"treedb.cache.checkpoint.flush_all.owned_drain_units_last",
+		"treedb.cache.checkpoint.flush_all.owned_drain_ops_last",
+		"treedb.cache.checkpoint.flush_all.owned_drain_bytes_last",
+		"treedb.cache.checkpoint.flush_all.owned_drain_ns_last",
 		"treedb.cache.checkpoint.flush_all.background_drain_units_last",
+		"treedb.cache.checkpoint.flush_all.background_drain_ops_last",
+		"treedb.cache.checkpoint.flush_all.background_drain_bytes_last",
 	} {
 		if got := requireStatUint64(t, stats, key); got != 0 {
 			t.Fatalf("%s=%d want 0", key, got)

--- a/TreeDB/caching/checkpoint_productivity_stats_test.go
+++ b/TreeDB/caching/checkpoint_productivity_stats_test.go
@@ -65,6 +65,64 @@ func TestCheckpointWaitProductivityStatsNoopCheckpoint(t *testing.T) {
 	}
 }
 
+func TestCheckpointWaitProductivityStatsLateDrainUsesCurrentWaitDuration(t *testing.T) {
+	frontier := checkpointFrontier{
+		ids: map[uint64]checkpointFrontierUnit{
+			1: {bytes: 4096, laneID: 0},
+		},
+		laneUnits: map[uint16]uint64{0: 1},
+		units:     1,
+		bytes:     4096,
+		captured:  true,
+	}
+
+	t.Run("late-drained frontier records current wait", func(t *testing.T) {
+		db := &DB{}
+		staleWaitNs := uint64(time.Hour.Nanoseconds())
+		db.checkpointActiveBackgroundFlushWaitLastNs.Store(staleWaitNs)
+
+		wait := 25 * time.Millisecond
+		residual := db.observeCheckpointFlushMuWaitAfterLock(frontier, wait, false)
+		if residual.drainedUnits != 1 || residual.drainedBytes != 4096 {
+			t.Fatalf("drained frontier = (%d units, %d bytes), want (1, 4096)", residual.drainedUnits, residual.drainedBytes)
+		}
+		waitNs := uint64(wait.Nanoseconds())
+		if got := db.checkpointActiveBackgroundFlushWaitLastNs.Load(); got != waitNs {
+			t.Fatalf("active wait last ns=%d want current wait %d, stale was %d", got, waitNs, staleWaitNs)
+		}
+		if got := db.checkpointActiveBackgroundFlushWaitSamples.Load(); got != 1 {
+			t.Fatalf("active wait samples=%d want 1", got)
+		}
+		currentRate := checkpointRatePerSecond(db.checkpointWaitFrontierDrainedBytesLast.Load(), db.checkpointActiveBackgroundFlushWaitLastNs.Load())
+		staleRate := checkpointRatePerSecond(db.checkpointWaitFrontierDrainedBytesLast.Load(), staleWaitNs)
+		if currentRate <= staleRate {
+			t.Fatalf("wait drain rate=%f should use current wait and exceed stale-rate %f", currentRate, staleRate)
+		}
+	})
+
+	t.Run("no active or drained frontier clears stale wait", func(t *testing.T) {
+		db := &DB{}
+		db.queue = append(db.queue, nil)
+		db.queueIDs = []uint64{1}
+		db.queueLaneIDs = []uint16{0}
+		db.checkpointActiveBackgroundFlushWaitLastNs.Store(uint64(time.Hour.Nanoseconds()))
+
+		residual := db.observeCheckpointFlushMuWaitAfterLock(frontier, 25*time.Millisecond, false)
+		if residual.drainedUnits != 0 || residual.frontierUnits != 1 {
+			t.Fatalf("residual frontier = drained %d remaining %d, want drained 0 remaining 1", residual.drainedUnits, residual.frontierUnits)
+		}
+		if got := db.checkpointActiveBackgroundFlushWaitLastNs.Load(); got != 0 {
+			t.Fatalf("active wait last ns=%d want 0", got)
+		}
+		if got := db.checkpointActiveBackgroundFlushWaitSamples.Load(); got != 0 {
+			t.Fatalf("active wait samples=%d want 0", got)
+		}
+		if got := checkpointRatePerSecond(db.checkpointWaitFrontierDrainedBytesLast.Load(), db.checkpointActiveBackgroundFlushWaitLastNs.Load()); got != 0 {
+			t.Fatalf("wait drain rate=%f want 0", got)
+		}
+	})
+}
+
 func TestCheckpointWaitProductivityStatsQueuedFrontierNoActiveBackground(t *testing.T) {
 	db, _ := newCoalescingTestDB(t, Options{
 		DisableWAL:  true,

--- a/TreeDB/caching/checkpoint_productivity_stats_test.go
+++ b/TreeDB/caching/checkpoint_productivity_stats_test.go
@@ -1,0 +1,266 @@
+package caching
+
+import (
+	"runtime"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/snissn/gomap/TreeDB/batch"
+)
+
+func requireStatFloat64(t *testing.T, stats map[string]string, key string) float64 {
+	t.Helper()
+	raw, ok := stats[key]
+	if !ok {
+		t.Fatalf("missing stat %s", key)
+	}
+	v, err := strconv.ParseFloat(raw, 64)
+	if err != nil {
+		t.Fatalf("parse stat %s=%q: %v", key, raw, err)
+	}
+	return v
+}
+
+func TestCheckpointWaitProductivityStatsNoopCheckpoint(t *testing.T) {
+	db, err := Open(t.TempDir(), NewMockBackend(), Options{
+		FlushThreshold: 1 << 60,
+		MemtableShards: 1,
+		JournalLanes:   1,
+		DisableWAL:     true,
+		AllowUnsafe:    true,
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	if err := db.Checkpoint(); err != nil {
+		t.Fatalf("Checkpoint: %v", err)
+	}
+
+	stats := db.Stats()
+	for _, key := range []string{
+		"treedb.cache.checkpoint.debt.queue_units_last",
+		"treedb.cache.checkpoint.debt.queue_bytes_last",
+		"treedb.cache.checkpoint.debt.mutable_bytes_last",
+		"treedb.cache.checkpoint.debt.active_in_flight_bytes_last",
+		"treedb.cache.checkpoint.debt.active_workers_last",
+		"treedb.cache.checkpoint.wait.frontier_units_at_request_last",
+		"treedb.cache.checkpoint.wait.remaining_frontier_units_last",
+		"treedb.cache.checkpoint.wait.drained_frontier_units_last",
+		"treedb.cache.checkpoint.flush_all.owned_drain_units_last",
+		"treedb.cache.checkpoint.flush_all.background_drain_units_last",
+	} {
+		if got := requireStatUint64(t, stats, key); got != 0 {
+			t.Fatalf("%s=%d want 0", key, got)
+		}
+	}
+	if got := requireStatUint64(t, stats, "treedb.cache.checkpoint.noop_skips"); got != 1 {
+		t.Fatalf("noop skips=%d want 1", got)
+	}
+	if got := requireStatFloat64(t, stats, "treedb.cache.checkpoint.productive_wait_ratio_last"); got != 0 {
+		t.Fatalf("productive wait ratio=%f want 0", got)
+	}
+}
+
+func TestCheckpointWaitProductivityStatsQueuedFrontierNoActiveBackground(t *testing.T) {
+	db, _ := newCoalescingTestDB(t, Options{
+		DisableWAL:  true,
+		AllowUnsafe: true,
+	}, highSingleOpCoalescingSnapshot())
+	enqueuePointMemtables(t, db, 2, "queuedfrontier")
+	if err := db.Set([]byte("queuedfrontier-mutable"), []byte("value")); err != nil {
+		t.Fatalf("Set mutable: %v", err)
+	}
+
+	if err := db.Checkpoint(); err != nil {
+		t.Fatalf("Checkpoint: %v", err)
+	}
+
+	stats := db.Stats()
+	if got := requireStatUint64(t, stats, "treedb.cache.checkpoint.debt.queue_units_last"); got != 2 {
+		t.Fatalf("debt queue units=%d want 2", got)
+	}
+	if got := requireStatUint64(t, stats, "treedb.cache.checkpoint.debt.queue_bytes_last"); got == 0 {
+		t.Fatalf("debt queue bytes=%d want >0", got)
+	}
+	if got := requireStatUint64(t, stats, "treedb.cache.checkpoint.debt.mutable_bytes_last"); got == 0 {
+		t.Fatalf("mutable bytes=%d want >0", got)
+	}
+	if got := requireStatUint64(t, stats, "treedb.cache.checkpoint.debt.active_in_flight_bytes_last"); got != 0 {
+		t.Fatalf("active in-flight bytes=%d want 0", got)
+	}
+	if got := requireStatUint64(t, stats, "treedb.cache.checkpoint.wait.active_in_flight_bytes_at_request_last"); got != 0 {
+		t.Fatalf("wait active in-flight bytes=%d want 0", got)
+	}
+	if got := requireStatUint64(t, stats, "treedb.cache.checkpoint.wait.frontier_units_at_request_last"); got != 2 {
+		t.Fatalf("wait frontier at request=%d want 2", got)
+	}
+	if got := requireStatUint64(t, stats, "treedb.cache.checkpoint.wait.remaining_frontier_units_last"); got != 2 {
+		t.Fatalf("wait remaining frontier=%d want 2", got)
+	}
+	if got := requireStatUint64(t, stats, "treedb.cache.checkpoint.wait.drained_frontier_units_last"); got != 0 {
+		t.Fatalf("wait drained frontier=%d want 0", got)
+	}
+	if got := requireStatUint64(t, stats, "treedb.cache.checkpoint.frontier.drained_units_last"); got != 3 {
+		t.Fatalf("checkpoint frontier drained=%d want 3", got)
+	}
+	if got := requireStatUint64(t, stats, "treedb.cache.checkpoint.flush_all.owned_drain_units_last"); got != 3 {
+		t.Fatalf("owned drain units=%d want 3", got)
+	}
+	if got := requireStatUint64(t, stats, "treedb.cache.checkpoint.flush_all.owned_drain_bytes_last"); got == 0 {
+		t.Fatalf("owned drain bytes=%d want >0", got)
+	}
+	if got := requireStatUint64(t, stats, "treedb.cache.checkpoint.active_background_flush_wait_samples"); got != 0 {
+		t.Fatalf("active background wait samples=%d want 0", got)
+	}
+}
+
+type checkpointWaitBlockingBackend struct {
+	*MockBackend
+	once        sync.Once
+	releaseOnce sync.Once
+	started     chan struct{}
+	release     chan struct{}
+}
+
+func newCheckpointWaitBlockingBackend() *checkpointWaitBlockingBackend {
+	return &checkpointWaitBlockingBackend{
+		MockBackend: NewMockBackend(),
+		started:     make(chan struct{}),
+		release:     make(chan struct{}),
+	}
+}
+
+func (b *checkpointWaitBlockingBackend) NewBatch() batch.Interface {
+	return &checkpointWaitBlockingBatch{Interface: b.MockBackend.NewBatch(), backend: b}
+}
+
+func (b *checkpointWaitBlockingBackend) blockOnce() {
+	b.once.Do(func() {
+		close(b.started)
+		<-b.release
+	})
+}
+
+func (b *checkpointWaitBlockingBackend) releaseBlock() {
+	b.releaseOnce.Do(func() { close(b.release) })
+}
+
+type checkpointWaitBlockingBatch struct {
+	batch.Interface
+	backend *checkpointWaitBlockingBackend
+}
+
+func (b *checkpointWaitBlockingBatch) Write() error {
+	b.backend.blockOnce()
+	return b.Interface.Write()
+}
+
+func (b *checkpointWaitBlockingBatch) WriteSync() error {
+	b.backend.blockOnce()
+	return b.Interface.WriteSync()
+}
+
+func TestCheckpointWaitProductivityStatsActiveBackgroundDrainsFrontier(t *testing.T) {
+	backend := newCheckpointWaitBlockingBackend()
+	defer backend.releaseBlock()
+	db, err := Open(t.TempDir(), backend, Options{
+		FlushThreshold:        1 << 60,
+		FlushBuildConcurrency: 1,
+		MemtableShards:        1,
+		JournalLanes:          1,
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	enqueuePointMemtables(t, db, 2, "activewait")
+
+	bgDone := make(chan struct{})
+	go func() {
+		db.flushAll(false)
+		close(bgDone)
+	}()
+
+	select {
+	case <-backend.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("background flush did not reach blocking backend write")
+	}
+	if got := db.flushCoordinatorInFlightBytes.Load(); got <= 0 {
+		t.Fatalf("in-flight bytes before checkpoint=%d want >0", got)
+	}
+
+	checkpointDone := make(chan error, 1)
+	go func() { checkpointDone <- db.Checkpoint() }()
+	deadline := time.After(5 * time.Second)
+	for db.checkpointFlushPreemptRequests.Load() == 0 {
+		select {
+		case <-deadline:
+			t.Fatal("checkpoint did not reach flush wait")
+		default:
+			runtimeGosched()
+		}
+	}
+
+	backend.releaseBlock()
+	select {
+	case <-bgDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("background flush did not finish")
+	}
+	select {
+	case err := <-checkpointDone:
+		if err != nil {
+			t.Fatalf("Checkpoint: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("checkpoint did not finish")
+	}
+
+	stats := db.Stats()
+	if got := requireStatUint64(t, stats, "treedb.cache.checkpoint.debt.queue_units_last"); got != 2 {
+		t.Fatalf("debt queue units=%d want 2", got)
+	}
+	if got := requireStatUint64(t, stats, "treedb.cache.checkpoint.debt.active_in_flight_bytes_last"); got == 0 {
+		t.Fatalf("active in-flight bytes=%d want >0", got)
+	}
+	if got := requireStatUint64(t, stats, "treedb.cache.checkpoint.debt.active_workers_last"); got == 0 {
+		t.Fatalf("active workers=%d want >0", got)
+	}
+	if got := requireStatUint64(t, stats, "treedb.cache.checkpoint.wait.active_workers_at_request_last"); got == 0 {
+		t.Fatalf("wait active workers=%d want >0", got)
+	}
+	if got := requireStatUint64(t, stats, "treedb.cache.checkpoint.active_background_flush_wait_samples"); got == 0 {
+		t.Fatalf("active background wait samples=%d want >0", got)
+	}
+	if got := requireStatUint64(t, stats, "treedb.cache.checkpoint.active_background_flush_wait_ns_last"); got == 0 {
+		t.Fatalf("active background wait last ns=%d want >0", got)
+	}
+	if got := requireStatUint64(t, stats, "treedb.cache.checkpoint.wait.frontier_units_at_request_last"); got != 2 {
+		t.Fatalf("wait frontier at request=%d want 2", got)
+	}
+	if got := requireStatUint64(t, stats, "treedb.cache.checkpoint.wait.remaining_frontier_units_last"); got != 1 {
+		t.Fatalf("wait remaining frontier=%d want 1", got)
+	}
+	if got := requireStatUint64(t, stats, "treedb.cache.checkpoint.wait.drained_frontier_units_last"); got != 1 {
+		t.Fatalf("wait drained frontier=%d want 1", got)
+	}
+	if got := requireStatUint64(t, stats, "treedb.cache.checkpoint.frontier.units_last"); got != 1 {
+		t.Fatalf("checkpoint-owned frontier units=%d want 1", got)
+	}
+	if got := requireStatUint64(t, stats, "treedb.cache.checkpoint.flush_all.owned_drain_units_last"); got != 1 {
+		t.Fatalf("owned drain units=%d want 1", got)
+	}
+	if got := requireStatFloat64(t, stats, "treedb.cache.checkpoint.wait.frontier_drain_bytes_per_sec_last"); got == 0 {
+		t.Fatalf("wait drain bytes/sec=%f want >0", got)
+	}
+	_ = requireStatFloat64(t, stats, "treedb.cache.checkpoint.productive_wait_ratio_last")
+}
+
+func runtimeGosched() {
+	runtime.Gosched()
+}

--- a/TreeDB/caching/checkpoint_productivity_stats_test.go
+++ b/TreeDB/caching/checkpoint_productivity_stats_test.go
@@ -141,9 +141,12 @@ func TestCheckpointWaitProductivityStatsLateDrainUsesCurrentWaitDuration(t *test
 }
 
 func TestCheckpointWaitProductivityStatsQueuedFrontierNoActiveBackground(t *testing.T) {
+	// Keep the queued frontier stable until Checkpoint owns flushMu; legacy queue
+	// backpressure can otherwise race this no-active-background assertion.
 	db, _ := newCoalescingTestDB(t, Options{
-		DisableWAL:  true,
-		AllowUnsafe: true,
+		DisableWAL:         true,
+		AllowUnsafe:        true,
+		MaxQueuedMemtables: -1,
 	}, highSingleOpCoalescingSnapshot())
 	enqueuePointMemtables(t, db, 2, "queuedfrontier")
 	if err := db.Set([]byte("queuedfrontier-mutable"), []byte("value")); err != nil {

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -21662,9 +21662,9 @@ func (db *DB) observeCheckpointFrontierCapture(f checkpointFrontier) {
 	updateAtomicMaxUint64(&db.checkpointFrontierBytesMax, f.bytes)
 }
 
-func (db *DB) observeCheckpointWaitFrontierAfterLock(f checkpointFrontier) {
+func (db *DB) observeCheckpointWaitFrontierAfterLock(f checkpointFrontier) checkpointFrontierResidualStats {
 	if db == nil {
-		return
+		return checkpointFrontierResidualStats{}
 	}
 	db.mu.RLock()
 	residual := db.checkpointFrontierResidualStatsLocked(f)
@@ -21681,6 +21681,20 @@ func (db *DB) observeCheckpointWaitFrontierAfterLock(f checkpointFrontier) {
 	db.checkpointWaitPostFrontierUnitsLast.Store(residual.postUnits)
 	db.checkpointWaitPostFrontierBytesLast.Store(residual.postBytes)
 	db.checkpointWaitPostFrontierLanesLast.Store(residual.postLanes)
+	return residual
+}
+
+func (db *DB) observeCheckpointFlushMuWaitAfterLock(f checkpointFrontier, wait time.Duration, activeBackgroundFlushBeforeWait bool) checkpointFrontierResidualStats {
+	residual := db.observeCheckpointWaitFrontierAfterLock(f)
+	if db == nil {
+		return residual
+	}
+	if activeBackgroundFlushBeforeWait || residual.drainedUnits > 0 || residual.drainedBytes > 0 {
+		db.observeCheckpointActiveBackgroundFlushWait(wait)
+	} else {
+		db.checkpointActiveBackgroundFlushWaitLastNs.Store(0)
+	}
+	return residual
 }
 
 func (db *DB) observeCheckpointFrontierDrain(f checkpointFrontier) {
@@ -22051,16 +22065,13 @@ func (db *DB) Checkpoint() error {
 	barrierWaitStart := time.Now()
 	flushMuWaitStart := barrierWaitStart
 	db.flushMu.Lock()
+	flushMuWaitDur := time.Since(flushMuWaitStart)
 	barrierWaitDur := time.Since(barrierWaitStart)
 	db.observeCheckpointBarrierWait(barrierWaitDur)
-	db.observeCheckpointWaitFrontierAfterLock(requestFrontier)
-	flushMuWaitDur := time.Since(flushMuWaitStart)
+	db.observeCheckpointFlushMuWaitAfterLock(requestFrontier, flushMuWaitDur, activeBackgroundFlushBeforeWait)
 	flushMuWait := uint64(flushMuWaitDur)
 	db.checkpointFlushMuWaitNs.Add(flushMuWait)
 	updateAtomicMaxUint64(&db.checkpointFlushMuWaitMaxNs, flushMuWait)
-	if activeBackgroundFlushBeforeWait {
-		db.observeCheckpointActiveBackgroundFlushWait(flushMuWaitDur)
-	}
 	flushMuHeld := true
 	unlockFlushMu := func() {
 		if flushMuHeld {

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -21745,6 +21745,21 @@ func (db *DB) observeCheckpointSharedDrainWork(background bool, units int, ops i
 	db.checkpointSharedDrainCheckpointBytes.Add(byu)
 }
 
+func (db *DB) resetCheckpointFlushAllLastStats() {
+	if db == nil {
+		return
+	}
+	db.checkpointFlushAllWorkersLast.Store(0)
+	db.checkpointFlushAllFrontierLanesLast.Store(0)
+	db.checkpointOwnedDrainUnitsLast.Store(0)
+	db.checkpointOwnedDrainOpsLast.Store(0)
+	db.checkpointOwnedDrainBytesLast.Store(0)
+	db.checkpointOwnedDrainNsLast.Store(0)
+	db.checkpointBackgroundDrainUnitsLast.Store(0)
+	db.checkpointBackgroundDrainOpsLast.Store(0)
+	db.checkpointBackgroundDrainBytesLast.Store(0)
+}
+
 func (db *DB) observeCheckpointOwnedDrain(checkpointUnitsBefore, checkpointOpsBefore, checkpointBytesBefore uint64, backgroundUnitsBefore, backgroundOpsBefore, backgroundBytesBefore uint64, d time.Duration) {
 	if db == nil {
 		return
@@ -22103,6 +22118,8 @@ func (db *DB) Checkpoint() error {
 		db.checkpointMu.Unlock()
 		lockFlushMu()
 	}
+
+	db.resetCheckpointFlushAllLastStats()
 
 	defer func() { // This defer runs when db.Checkpoint() returns
 		db.checkpointMu.Lock()

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -8190,17 +8190,45 @@ type DB struct {
 	checkpointStagePostMaintenance                               checkpointStageStats
 	checkpointActiveBackgroundFlushWaitNs                        atomic.Uint64
 	checkpointActiveBackgroundFlushWaitMaxNs                     atomic.Uint64
+	checkpointActiveBackgroundFlushWaitLastNs                    atomic.Uint64
 	checkpointActiveBackgroundFlushWaitSamples                   atomic.Uint64
 	checkpointDebtMemtablesLast                                  atomic.Uint64
 	checkpointDebtMemtablesMax                                   atomic.Uint64
 	checkpointDebtBytesLast                                      atomic.Uint64
 	checkpointDebtBytesMax                                       atomic.Uint64
+	checkpointDebtQueueUnitsLast                                 atomic.Uint64
+	checkpointDebtQueueUnitsMax                                  atomic.Uint64
+	checkpointDebtQueueBytesLast                                 atomic.Uint64
+	checkpointDebtQueueBytesMax                                  atomic.Uint64
+	checkpointDebtMutableBytesLast                               atomic.Uint64
+	checkpointDebtMutableBytesMax                                atomic.Uint64
+	checkpointDebtActiveInFlightBytesLast                        atomic.Uint64
+	checkpointDebtActiveInFlightBytesMax                         atomic.Uint64
+	checkpointDebtActiveWorkersLast                              atomic.Uint64
+	checkpointDebtActiveWorkersMax                               atomic.Uint64
+	checkpointDebtFrontierLanesLast                              atomic.Uint64
+	checkpointDebtFrontierLanesMax                               atomic.Uint64
+	checkpointWaitFrontierUnitsAtRequestLast                     atomic.Uint64
+	checkpointWaitFrontierBytesAtRequestLast                     atomic.Uint64
+	checkpointWaitFrontierLanesAtRequestLast                     atomic.Uint64
+	checkpointWaitFrontierRemainingUnitsLast                     atomic.Uint64
+	checkpointWaitFrontierRemainingBytesLast                     atomic.Uint64
+	checkpointWaitFrontierRemainingLanesLast                     atomic.Uint64
+	checkpointWaitFrontierDrainedUnitsLast                       atomic.Uint64
+	checkpointWaitFrontierDrainedBytesLast                       atomic.Uint64
+	checkpointWaitFrontierDrainedLanesLast                       atomic.Uint64
+	checkpointWaitPostFrontierUnitsLast                          atomic.Uint64
+	checkpointWaitPostFrontierBytesLast                          atomic.Uint64
+	checkpointWaitPostFrontierLanesLast                          atomic.Uint64
 	checkpointBarrierWaitNs                                      atomic.Uint64
 	checkpointBarrierWaitMaxNs                                   atomic.Uint64
 	checkpointBarrierWaitSamples                                 atomic.Uint64
 	checkpointFlushAllWorkerPasses                               atomic.Uint64
 	checkpointFlushAllWorkersTotal                               atomic.Uint64
 	checkpointFlushAllWorkersMax                                 atomic.Uint64
+	checkpointFlushAllWorkersLast                                atomic.Uint64
+	checkpointFlushAllFrontierLanesLast                          atomic.Uint64
+	checkpointFlushAllFrontierLanesMax                           atomic.Uint64
 	checkpointFrontierSamples                                    atomic.Uint64
 	checkpointFrontierUnitsLast                                  atomic.Uint64
 	checkpointFrontierUnitsMax                                   atomic.Uint64
@@ -8225,6 +8253,13 @@ type DB struct {
 	checkpointSharedDrainBackgroundUnits                         atomic.Uint64
 	checkpointSharedDrainBackgroundOps                           atomic.Uint64
 	checkpointSharedDrainBackgroundBytes                         atomic.Uint64
+	checkpointOwnedDrainUnitsLast                                atomic.Uint64
+	checkpointOwnedDrainOpsLast                                  atomic.Uint64
+	checkpointOwnedDrainBytesLast                                atomic.Uint64
+	checkpointOwnedDrainNsLast                                   atomic.Uint64
+	checkpointBackgroundDrainUnitsLast                           atomic.Uint64
+	checkpointBackgroundDrainOpsLast                             atomic.Uint64
+	checkpointBackgroundDrainBytesLast                           atomic.Uint64
 	checkpointPreflushKickSkips                                  atomic.Uint64
 	checkpointWALCleanupConsideredLast                           atomic.Uint64
 	checkpointWALCleanupRemovedLast                              atomic.Uint64
@@ -21372,39 +21407,104 @@ func (db *DB) recordCheckpointCutover(d time.Duration) {
 	}
 }
 
-func (db *DB) checkpointDebtSnapshotLocked() (memtables uint64, bytes uint64) {
-	if db == nil {
-		return 0, 0
+func nonNegativeInt64ToUint64(v int64) uint64 {
+	if v <= 0 {
+		return 0
 	}
-	if queued := len(db.queue); queued > 0 {
-		memtables += uint64(queued)
-	}
-	if mutableBytes := db.mutableBytes.Load(); mutableBytes > 0 {
-		// Count the mutable shard set as one pending checkpoint cutover unit. The
-		// exact shard count is intentionally avoided here because writers mutate
-		// shard-local tables under shard locks, while this checkpoint-debt snapshot
-		// only needs a cheap lock-free indication of foreground dirtiness.
-		memtables++
-		bytes += uint64(mutableBytes)
-	}
-	if backlog := db.queueBacklogBytes.Load(); backlog > 0 {
-		bytes += uint64(backlog)
-	}
-	return memtables, bytes
+	return uint64(v)
 }
 
-func (db *DB) observeCheckpointDebt(memtables, bytes uint64) {
+type checkpointDebtSnapshot struct {
+	queueUnits          uint64
+	queueBytes          uint64
+	mutableBytes        uint64
+	activeInFlightBytes uint64
+	activeWorkers       uint64
+	frontierLanes       uint64
+}
+
+func (s checkpointDebtSnapshot) memtables() uint64 {
+	units := s.queueUnits
+	if s.mutableBytes > 0 {
+		// Count the mutable shard set as one pending checkpoint cutover unit. The
+		// exact shard count is intentionally avoided because writers mutate
+		// shard-local tables under shard locks, while checkpoint debt only needs a
+		// cheap indication of foreground dirtiness.
+		units++
+	}
+	return units
+}
+
+func (s checkpointDebtSnapshot) bytes() uint64 {
+	return s.queueBytes + s.mutableBytes
+}
+
+func (db *DB) checkpointDebtSnapshotLocked() checkpointDebtSnapshot {
+	if db == nil {
+		return checkpointDebtSnapshot{}
+	}
+	snap := checkpointDebtSnapshot{
+		queueUnits:          uint64(len(db.queue)),
+		mutableBytes:        nonNegativeInt64ToUint64(db.mutableBytes.Load()),
+		activeInFlightBytes: nonNegativeInt64ToUint64(db.flushCoordinatorInFlightBytes.Load()),
+		activeWorkers:       nonNegativeInt64ToUint64(db.flushCoordinatorActive.Load()),
+	}
+	if len(db.queue) > 0 {
+		lanes := make(map[uint16]struct{})
+		for i, mem := range db.queue {
+			if mem != nil {
+				if size := mem.Size(); size > 0 {
+					snap.queueBytes += uint64(size)
+				}
+			}
+			laneID := uint16(0)
+			if i < len(db.queueLaneIDs) {
+				laneID = db.queueLaneIDs[i]
+			}
+			lanes[laneID] = struct{}{}
+		}
+		snap.frontierLanes = uint64(len(lanes))
+	}
+	if snap.queueBytes == 0 {
+		// Preserve the historical debt byte basis if a caller injected backlog bytes
+		// without materialized test memtables.
+		snap.queueBytes = nonNegativeInt64ToUint64(db.queueBacklogBytes.Load())
+	}
+	return snap
+}
+
+func (db *DB) observeCheckpointDebt(s checkpointDebtSnapshot) {
 	if db == nil {
 		return
 	}
+	memtables := s.memtables()
+	bytes := s.bytes()
 	db.checkpointDebtMemtablesLast.Store(memtables)
 	db.checkpointDebtBytesLast.Store(bytes)
 	updateAtomicMaxUint64(&db.checkpointDebtMemtablesMax, memtables)
 	updateAtomicMaxUint64(&db.checkpointDebtBytesMax, bytes)
+	db.checkpointDebtQueueUnitsLast.Store(s.queueUnits)
+	db.checkpointDebtQueueBytesLast.Store(s.queueBytes)
+	db.checkpointDebtMutableBytesLast.Store(s.mutableBytes)
+	db.checkpointDebtActiveInFlightBytesLast.Store(s.activeInFlightBytes)
+	db.checkpointDebtActiveWorkersLast.Store(s.activeWorkers)
+	db.checkpointDebtFrontierLanesLast.Store(s.frontierLanes)
+	updateAtomicMaxUint64(&db.checkpointDebtQueueUnitsMax, s.queueUnits)
+	updateAtomicMaxUint64(&db.checkpointDebtQueueBytesMax, s.queueBytes)
+	updateAtomicMaxUint64(&db.checkpointDebtMutableBytesMax, s.mutableBytes)
+	updateAtomicMaxUint64(&db.checkpointDebtActiveInFlightBytesMax, s.activeInFlightBytes)
+	updateAtomicMaxUint64(&db.checkpointDebtActiveWorkersMax, s.activeWorkers)
+	updateAtomicMaxUint64(&db.checkpointDebtFrontierLanesMax, s.frontierLanes)
+}
+
+type checkpointFrontierUnit struct {
+	bytes  uint64
+	laneID uint16
 }
 
 type checkpointFrontier struct {
-	ids            map[uint64]struct{}
+	ids            map[uint64]checkpointFrontierUnit
+	laneUnits      map[uint16]uint64
 	units          uint64
 	bytes          uint64
 	captured       bool
@@ -21417,6 +21517,10 @@ func (f checkpointFrontier) contains(id uint64) bool {
 	}
 	_, ok := f.ids[id]
 	return ok
+}
+
+func (f checkpointFrontier) laneCount() uint64 {
+	return uint64(len(f.laneUnits))
 }
 
 func (db *DB) setActiveCheckpointFrontier(f checkpointFrontier) {
@@ -21442,8 +21546,8 @@ func (db *DB) activeCheckpointFrontier() (checkpointFrontier, bool) {
 		return checkpointFrontier{}, false
 	}
 	db.checkpointActiveFrontierMu.RLock()
-	// checkpointFrontier.ids is immutable after capture; sharing the map backing
-	// store across copies is safe as long as frontier membership remains read-only.
+	// checkpointFrontier maps are immutable after capture; sharing their backing
+	// stores across copies is safe as long as frontier membership remains read-only.
 	f := db.checkpointActiveFrontier
 	db.checkpointActiveFrontierMu.RUnlock()
 	return f, f.captured
@@ -21454,7 +21558,8 @@ func (db *DB) captureCheckpointFrontierLocked() checkpointFrontier {
 	if db == nil || len(db.queue) == 0 {
 		return f
 	}
-	f.ids = make(map[uint64]struct{}, len(db.queue))
+	f.ids = make(map[uint64]checkpointFrontierUnit, len(db.queue))
+	f.laneUnits = make(map[uint16]uint64)
 	for i, mem := range db.queue {
 		var id uint64
 		if i < len(db.queueIDs) {
@@ -21464,41 +21569,85 @@ func (db *DB) captureCheckpointFrontierLocked() checkpointFrontier {
 			f.missingQueueID = true
 			continue
 		}
-		f.ids[id] = struct{}{}
-		f.units++
-		if mem != nil {
-			if size := mem.Size(); size > 0 {
-				f.bytes += uint64(size)
-			}
-		}
-	}
-	return f
-}
-
-func (db *DB) checkpointFrontierResidualLocked(f checkpointFrontier) (frontierUnits, frontierBytes, postUnits, postBytes uint64) {
-	if db == nil || len(db.queue) == 0 {
-		return 0, 0, 0, 0
-	}
-	for i, mem := range db.queue {
-		var id uint64
-		if i < len(db.queueIDs) {
-			id = db.queueIDs[i]
-		}
 		var size uint64
 		if mem != nil {
 			if s := mem.Size(); s > 0 {
 				size = uint64(s)
 			}
 		}
-		if f.contains(id) {
-			frontierUnits++
-			frontierBytes += size
-		} else {
-			postUnits++
-			postBytes += size
+		laneID := uint16(0)
+		if i < len(db.queueLaneIDs) {
+			laneID = db.queueLaneIDs[i]
+		}
+		f.ids[id] = checkpointFrontierUnit{bytes: size, laneID: laneID}
+		f.laneUnits[laneID]++
+		f.units++
+		f.bytes += size
+	}
+	return f
+}
+
+type checkpointFrontierResidualStats struct {
+	frontierUnits uint64
+	frontierBytes uint64
+	frontierLanes uint64
+	drainedUnits  uint64
+	drainedBytes  uint64
+	drainedLanes  uint64
+	postUnits     uint64
+	postBytes     uint64
+	postLanes     uint64
+}
+
+func (db *DB) checkpointFrontierResidualStatsLocked(f checkpointFrontier) checkpointFrontierResidualStats {
+	var stats checkpointFrontierResidualStats
+	remainingByLane := make(map[uint16]uint64)
+	postLanes := make(map[uint16]struct{})
+	if db != nil {
+		for i, mem := range db.queue {
+			var id uint64
+			if i < len(db.queueIDs) {
+				id = db.queueIDs[i]
+			}
+			var size uint64
+			if mem != nil {
+				if s := mem.Size(); s > 0 {
+					size = uint64(s)
+				}
+			}
+			laneID := uint16(0)
+			if i < len(db.queueLaneIDs) {
+				laneID = db.queueLaneIDs[i]
+			}
+			if unit, ok := f.ids[id]; ok {
+				if size == 0 {
+					size = unit.bytes
+				}
+				stats.frontierUnits++
+				stats.frontierBytes += size
+				remainingByLane[unit.laneID]++
+			} else {
+				stats.postUnits++
+				stats.postBytes += size
+				postLanes[laneID] = struct{}{}
+			}
 		}
 	}
-	return frontierUnits, frontierBytes, postUnits, postBytes
+	stats.frontierLanes = uint64(len(remainingByLane))
+	stats.postLanes = uint64(len(postLanes))
+	stats.drainedUnits = saturatingSubUint64(f.units, stats.frontierUnits)
+	stats.drainedBytes = saturatingSubUint64(f.bytes, stats.frontierBytes)
+	for laneID, units := range f.laneUnits {
+		if remainingByLane[laneID] < units {
+			stats.drainedLanes++
+		}
+	}
+	return stats
+}
+
+func (db *DB) checkpointFrontierResidualLocked(f checkpointFrontier) (frontierUnits, frontierBytes, postUnits, postBytes uint64) {
+	stats := db.checkpointFrontierResidualStatsLocked(f)
+	return stats.frontierUnits, stats.frontierBytes, stats.postUnits, stats.postBytes
 }
 
 func (db *DB) observeCheckpointFrontierCapture(f checkpointFrontier) {
@@ -21512,21 +21661,40 @@ func (db *DB) observeCheckpointFrontierCapture(f checkpointFrontier) {
 	updateAtomicMaxUint64(&db.checkpointFrontierBytesMax, f.bytes)
 }
 
+func (db *DB) observeCheckpointWaitFrontierAfterLock(f checkpointFrontier) {
+	if db == nil {
+		return
+	}
+	db.mu.RLock()
+	residual := db.checkpointFrontierResidualStatsLocked(f)
+	db.mu.RUnlock()
+	db.checkpointWaitFrontierUnitsAtRequestLast.Store(f.units)
+	db.checkpointWaitFrontierBytesAtRequestLast.Store(f.bytes)
+	db.checkpointWaitFrontierLanesAtRequestLast.Store(f.laneCount())
+	db.checkpointWaitFrontierRemainingUnitsLast.Store(residual.frontierUnits)
+	db.checkpointWaitFrontierRemainingBytesLast.Store(residual.frontierBytes)
+	db.checkpointWaitFrontierRemainingLanesLast.Store(residual.frontierLanes)
+	db.checkpointWaitFrontierDrainedUnitsLast.Store(residual.drainedUnits)
+	db.checkpointWaitFrontierDrainedBytesLast.Store(residual.drainedBytes)
+	db.checkpointWaitFrontierDrainedLanesLast.Store(residual.drainedLanes)
+	db.checkpointWaitPostFrontierUnitsLast.Store(residual.postUnits)
+	db.checkpointWaitPostFrontierBytesLast.Store(residual.postBytes)
+	db.checkpointWaitPostFrontierLanesLast.Store(residual.postLanes)
+}
+
 func (db *DB) observeCheckpointFrontierDrain(f checkpointFrontier) {
 	if db == nil {
 		return
 	}
 	db.mu.RLock()
-	frontierUnits, frontierBytes, postUnits, postBytes := db.checkpointFrontierResidualLocked(f)
+	residual := db.checkpointFrontierResidualStatsLocked(f)
 	db.mu.RUnlock()
-	drainedUnits := saturatingSubUint64(f.units, frontierUnits)
-	drainedBytes := saturatingSubUint64(f.bytes, frontierBytes)
-	db.checkpointFrontierDrainedUnitsLast.Store(drainedUnits)
-	db.checkpointFrontierDrainedBytesLast.Store(drainedBytes)
-	db.checkpointFrontierPostUnitsLast.Store(postUnits)
-	db.checkpointFrontierPostBytesLast.Store(postBytes)
-	updateAtomicMaxUint64(&db.checkpointFrontierPostUnitsMax, postUnits)
-	updateAtomicMaxUint64(&db.checkpointFrontierPostBytesMax, postBytes)
+	db.checkpointFrontierDrainedUnitsLast.Store(residual.drainedUnits)
+	db.checkpointFrontierDrainedBytesLast.Store(residual.drainedBytes)
+	db.checkpointFrontierPostUnitsLast.Store(residual.postUnits)
+	db.checkpointFrontierPostBytesLast.Store(residual.postBytes)
+	updateAtomicMaxUint64(&db.checkpointFrontierPostUnitsMax, residual.postUnits)
+	updateAtomicMaxUint64(&db.checkpointFrontierPostBytesMax, residual.postBytes)
 }
 
 func (db *DB) observeCheckpointSharedDrainWait(d time.Duration) {
@@ -21562,6 +21730,22 @@ func (db *DB) observeCheckpointSharedDrainWork(background bool, units int, ops i
 	db.checkpointSharedDrainCheckpointBytes.Add(byu)
 }
 
+func (db *DB) observeCheckpointOwnedDrain(checkpointUnitsBefore, checkpointOpsBefore, checkpointBytesBefore uint64, backgroundUnitsBefore, backgroundOpsBefore, backgroundBytesBefore uint64, d time.Duration) {
+	if db == nil {
+		return
+	}
+	if d < 0 {
+		d = 0
+	}
+	db.checkpointOwnedDrainUnitsLast.Store(saturatingSubUint64(db.checkpointSharedDrainCheckpointUnits.Load(), checkpointUnitsBefore))
+	db.checkpointOwnedDrainOpsLast.Store(saturatingSubUint64(db.checkpointSharedDrainCheckpointOps.Load(), checkpointOpsBefore))
+	db.checkpointOwnedDrainBytesLast.Store(saturatingSubUint64(db.checkpointSharedDrainCheckpointBytes.Load(), checkpointBytesBefore))
+	db.checkpointOwnedDrainNsLast.Store(uint64(d.Nanoseconds()))
+	db.checkpointBackgroundDrainUnitsLast.Store(saturatingSubUint64(db.checkpointSharedDrainBackgroundUnits.Load(), backgroundUnitsBefore))
+	db.checkpointBackgroundDrainOpsLast.Store(saturatingSubUint64(db.checkpointSharedDrainBackgroundOps.Load(), backgroundOpsBefore))
+	db.checkpointBackgroundDrainBytesLast.Store(saturatingSubUint64(db.checkpointSharedDrainBackgroundBytes.Load(), backgroundBytesBefore))
+}
+
 func (db *DB) observeCheckpointWALCleanupCoverage(considered, removed, skippedCurrent, skippedPreRotate, skippedRetained uint64) {
 	if db == nil {
 		return
@@ -21593,7 +21777,17 @@ func (db *DB) observeCheckpointFlushAllWorkers(workers int) {
 	u := uint64(workers)
 	db.checkpointFlushAllWorkerPasses.Add(1)
 	db.checkpointFlushAllWorkersTotal.Add(u)
+	db.checkpointFlushAllWorkersLast.Store(u)
 	updateAtomicMaxUint64(&db.checkpointFlushAllWorkersMax, u)
+}
+
+func (db *DB) observeCheckpointFlushAllFrontierLanes(lanes int) {
+	if db == nil || lanes <= 0 {
+		return
+	}
+	u := uint64(lanes)
+	db.checkpointFlushAllFrontierLanesLast.Store(u)
+	updateAtomicMaxUint64(&db.checkpointFlushAllFrontierLanesMax, u)
 }
 
 type checkpointStageStats struct {
@@ -21633,6 +21827,22 @@ func appendCheckpointStageStats(stats map[string]string, name string, s *checkpo
 	stats[prefix+".last_ns"] = fmt.Sprintf("%d", s.lastNs.Load())
 	stats[prefix+".total_ns"] = fmt.Sprintf("%d", s.totalNs.Load())
 	stats[prefix+".max_ns"] = fmt.Sprintf("%d", s.maxNs.Load())
+}
+
+func checkpointRatePerSecond(amount, ns uint64) float64 {
+	if amount == 0 || ns == 0 {
+		return 0
+	}
+	return float64(amount) * float64(time.Second) / float64(ns)
+}
+
+func checkpointRateRatio(numeratorAmount, numeratorNs, denominatorAmount, denominatorNs uint64) float64 {
+	numerator := checkpointRatePerSecond(numeratorAmount, numeratorNs)
+	denominator := checkpointRatePerSecond(denominatorAmount, denominatorNs)
+	if numerator == 0 || denominator == 0 {
+		return 0
+	}
+	return numerator / denominator
 }
 
 const (
@@ -21812,9 +22022,11 @@ func (db *DB) Checkpoint() error {
 	// flushMu first to avoid deadlocks.
 	checkpointBgErrBefore := db.backgroundError()
 	db.mu.RLock()
-	checkpointDebtMemtables, checkpointDebtBytes := db.checkpointDebtSnapshotLocked()
+	requestFrontier := db.captureCheckpointFrontierLocked()
+	checkpointDebt := db.checkpointDebtSnapshotLocked()
 	db.mu.RUnlock()
-	db.observeCheckpointDebt(checkpointDebtMemtables, checkpointDebtBytes)
+	db.observeCheckpointDebt(checkpointDebt)
+	checkpointDebtMemtables, checkpointDebtBytes := checkpointDebt.memtables(), checkpointDebt.bytes()
 	if (checkpointDebtMemtables > 0 || checkpointDebtBytes > 0) && (!db.disableJournal || db.relaxedSync) {
 		if db.flushApplyConcurrency > 1 {
 			// Parallel checkpoint drains should capture the frontier first instead of
@@ -21840,6 +22052,7 @@ func (db *DB) Checkpoint() error {
 	db.flushMu.Lock()
 	barrierWaitDur := time.Since(barrierWaitStart)
 	db.observeCheckpointBarrierWait(barrierWaitDur)
+	db.observeCheckpointWaitFrontierAfterLock(requestFrontier)
 	flushMuWaitDur := time.Since(flushMuWaitStart)
 	flushMuWait := uint64(flushMuWaitDur)
 	db.checkpointFlushMuWaitNs.Add(flushMuWait)
@@ -22043,11 +22256,21 @@ func (db *DB) Checkpoint() error {
 		frontierLaneCount = 1
 	}
 	_, frontierActiveLanes := db.checkpointFrontierActiveLanes(frontier, frontierLaneCount)
+	db.observeCheckpointFlushAllFrontierLanes(frontierActiveLanes)
+	checkpointDrainUnitsBefore := db.checkpointSharedDrainCheckpointUnits.Load()
+	checkpointDrainOpsBefore := db.checkpointSharedDrainCheckpointOps.Load()
+	checkpointDrainBytesBefore := db.checkpointSharedDrainCheckpointBytes.Load()
+	backgroundDrainUnitsBefore := db.checkpointSharedDrainBackgroundUnits.Load()
+	backgroundDrainOpsBefore := db.checkpointSharedDrainBackgroundOps.Load()
+	backgroundDrainBytesBefore := db.checkpointSharedDrainBackgroundBytes.Load()
+	var ownedDrainDur time.Duration
 	// Same-lane background claims serialize on flushLaneMu and only make the
 	// checkpoint wait for another owner. Share the active frontier only when the
 	// frontier spans multiple lanes that can make independent progress.
 	if commandWALPublishPiggyback != nil || len(frontier.ids) < 8 || frontier.bytes < 8<<20 || frontierActiveLanes <= 1 {
+		ownedDrainStart := time.Now()
 		db.flushCheckpointFrontierLocked(true, commandWALPublishPiggyback, frontier)
+		ownedDrainDur = time.Since(ownedDrainStart)
 	} else {
 		db.setActiveCheckpointFrontier(frontier)
 		if len(frontier.ids) > 0 {
@@ -22060,11 +22283,18 @@ func (db *DB) Checkpoint() error {
 		// frontier bounds the queue IDs it may claim, per-lane flushLaneMu serializes
 		// apply work, and final sync/WAL cleanup remains checkpoint-exclusive after
 		// reacquiring flushMu below.
+		ownedDrainStart := time.Now()
 		db.flushCheckpointFrontierLocked(true, nil, frontier)
+		ownedDrainDur = time.Since(ownedDrainStart)
 		lockFlushMu()
 		db.clearActiveCheckpointFrontier()
 		db.observeCheckpointSharedDrainWait(time.Since(flushAllStart))
 	}
+	db.observeCheckpointOwnedDrain(
+		checkpointDrainUnitsBefore, checkpointDrainOpsBefore, checkpointDrainBytesBefore,
+		backgroundDrainUnitsBefore, backgroundDrainOpsBefore, backgroundDrainBytesBefore,
+		ownedDrainDur,
+	)
 	db.observeCheckpointFrontierDrain(frontier)
 	postFrontierWALDebt := false
 	if frontier.captured {
@@ -27722,17 +27952,33 @@ func (db *DB) Stats() map[string]string {
 	stats["treedb.cache.checkpoint.flushmu_wait_max_ms"] = fmt.Sprintf("%.3f", float64(db.checkpointFlushMuWaitMaxNs.Load())/float64(time.Millisecond))
 	stats["treedb.cache.checkpoint.active_background_flush_wait_ns_total"] = fmt.Sprintf("%d", db.checkpointActiveBackgroundFlushWaitNs.Load())
 	stats["treedb.cache.checkpoint.active_background_flush_wait_ns_max"] = fmt.Sprintf("%d", db.checkpointActiveBackgroundFlushWaitMaxNs.Load())
+	stats["treedb.cache.checkpoint.active_background_flush_wait_ns_last"] = fmt.Sprintf("%d", db.checkpointActiveBackgroundFlushWaitLastNs.Load())
 	stats["treedb.cache.checkpoint.active_background_flush_wait_samples"] = fmt.Sprintf("%d", db.checkpointActiveBackgroundFlushWaitSamples.Load())
 	stats["treedb.cache.checkpoint.debt_memtables_last"] = fmt.Sprintf("%d", db.checkpointDebtMemtablesLast.Load())
 	stats["treedb.cache.checkpoint.debt_memtables_max"] = fmt.Sprintf("%d", db.checkpointDebtMemtablesMax.Load())
 	stats["treedb.cache.checkpoint.debt_bytes_last"] = fmt.Sprintf("%d", db.checkpointDebtBytesLast.Load())
 	stats["treedb.cache.checkpoint.debt_bytes_max"] = fmt.Sprintf("%d", db.checkpointDebtBytesMax.Load())
+	stats["treedb.cache.checkpoint.debt.queue_units_last"] = fmt.Sprintf("%d", db.checkpointDebtQueueUnitsLast.Load())
+	stats["treedb.cache.checkpoint.debt.queue_units_max"] = fmt.Sprintf("%d", db.checkpointDebtQueueUnitsMax.Load())
+	stats["treedb.cache.checkpoint.debt.queue_bytes_last"] = fmt.Sprintf("%d", db.checkpointDebtQueueBytesLast.Load())
+	stats["treedb.cache.checkpoint.debt.queue_bytes_max"] = fmt.Sprintf("%d", db.checkpointDebtQueueBytesMax.Load())
+	stats["treedb.cache.checkpoint.debt.mutable_bytes_last"] = fmt.Sprintf("%d", db.checkpointDebtMutableBytesLast.Load())
+	stats["treedb.cache.checkpoint.debt.mutable_bytes_max"] = fmt.Sprintf("%d", db.checkpointDebtMutableBytesMax.Load())
+	stats["treedb.cache.checkpoint.debt.active_in_flight_bytes_last"] = fmt.Sprintf("%d", db.checkpointDebtActiveInFlightBytesLast.Load())
+	stats["treedb.cache.checkpoint.debt.active_in_flight_bytes_max"] = fmt.Sprintf("%d", db.checkpointDebtActiveInFlightBytesMax.Load())
+	stats["treedb.cache.checkpoint.debt.active_workers_last"] = fmt.Sprintf("%d", db.checkpointDebtActiveWorkersLast.Load())
+	stats["treedb.cache.checkpoint.debt.active_workers_max"] = fmt.Sprintf("%d", db.checkpointDebtActiveWorkersMax.Load())
+	stats["treedb.cache.checkpoint.debt.frontier_lanes_last"] = fmt.Sprintf("%d", db.checkpointDebtFrontierLanesLast.Load())
+	stats["treedb.cache.checkpoint.debt.frontier_lanes_max"] = fmt.Sprintf("%d", db.checkpointDebtFrontierLanesMax.Load())
 	stats["treedb.cache.checkpoint.barrier_wait_ns_total"] = fmt.Sprintf("%d", db.checkpointBarrierWaitNs.Load())
 	stats["treedb.cache.checkpoint.barrier_wait_ns_max"] = fmt.Sprintf("%d", db.checkpointBarrierWaitMaxNs.Load())
 	stats["treedb.cache.checkpoint.barrier_wait_samples"] = fmt.Sprintf("%d", db.checkpointBarrierWaitSamples.Load())
 	stats["treedb.cache.checkpoint.flush_all.worker_passes_total"] = fmt.Sprintf("%d", db.checkpointFlushAllWorkerPasses.Load())
 	stats["treedb.cache.checkpoint.flush_all.workers_total"] = fmt.Sprintf("%d", db.checkpointFlushAllWorkersTotal.Load())
 	stats["treedb.cache.checkpoint.flush_all.workers_max"] = fmt.Sprintf("%d", db.checkpointFlushAllWorkersMax.Load())
+	stats["treedb.cache.checkpoint.flush_all.workers_last"] = fmt.Sprintf("%d", db.checkpointFlushAllWorkersLast.Load())
+	stats["treedb.cache.checkpoint.flush_all.frontier_lanes_last"] = fmt.Sprintf("%d", db.checkpointFlushAllFrontierLanesLast.Load())
+	stats["treedb.cache.checkpoint.flush_all.frontier_lanes_max"] = fmt.Sprintf("%d", db.checkpointFlushAllFrontierLanesMax.Load())
 	stats["treedb.cache.checkpoint.frontier.samples"] = fmt.Sprintf("%d", db.checkpointFrontierSamples.Load())
 	stats["treedb.cache.checkpoint.frontier.units_last"] = fmt.Sprintf("%d", db.checkpointFrontierUnitsLast.Load())
 	stats["treedb.cache.checkpoint.frontier.units_max"] = fmt.Sprintf("%d", db.checkpointFrontierUnitsMax.Load())
@@ -27744,6 +27990,20 @@ func (db *DB) Stats() map[string]string {
 	stats["treedb.cache.checkpoint.frontier.post_units_max"] = fmt.Sprintf("%d", db.checkpointFrontierPostUnitsMax.Load())
 	stats["treedb.cache.checkpoint.frontier.post_bytes_last"] = fmt.Sprintf("%d", db.checkpointFrontierPostBytesLast.Load())
 	stats["treedb.cache.checkpoint.frontier.post_bytes_max"] = fmt.Sprintf("%d", db.checkpointFrontierPostBytesMax.Load())
+	stats["treedb.cache.checkpoint.wait.active_workers_at_request_last"] = fmt.Sprintf("%d", db.checkpointDebtActiveWorkersLast.Load())
+	stats["treedb.cache.checkpoint.wait.active_in_flight_bytes_at_request_last"] = fmt.Sprintf("%d", db.checkpointDebtActiveInFlightBytesLast.Load())
+	stats["treedb.cache.checkpoint.wait.frontier_units_at_request_last"] = fmt.Sprintf("%d", db.checkpointWaitFrontierUnitsAtRequestLast.Load())
+	stats["treedb.cache.checkpoint.wait.frontier_bytes_at_request_last"] = fmt.Sprintf("%d", db.checkpointWaitFrontierBytesAtRequestLast.Load())
+	stats["treedb.cache.checkpoint.wait.frontier_lanes_at_request_last"] = fmt.Sprintf("%d", db.checkpointWaitFrontierLanesAtRequestLast.Load())
+	stats["treedb.cache.checkpoint.wait.remaining_frontier_units_last"] = fmt.Sprintf("%d", db.checkpointWaitFrontierRemainingUnitsLast.Load())
+	stats["treedb.cache.checkpoint.wait.remaining_frontier_bytes_last"] = fmt.Sprintf("%d", db.checkpointWaitFrontierRemainingBytesLast.Load())
+	stats["treedb.cache.checkpoint.wait.remaining_frontier_lanes_last"] = fmt.Sprintf("%d", db.checkpointWaitFrontierRemainingLanesLast.Load())
+	stats["treedb.cache.checkpoint.wait.drained_frontier_units_last"] = fmt.Sprintf("%d", db.checkpointWaitFrontierDrainedUnitsLast.Load())
+	stats["treedb.cache.checkpoint.wait.drained_frontier_bytes_last"] = fmt.Sprintf("%d", db.checkpointWaitFrontierDrainedBytesLast.Load())
+	stats["treedb.cache.checkpoint.wait.drained_frontier_lanes_last"] = fmt.Sprintf("%d", db.checkpointWaitFrontierDrainedLanesLast.Load())
+	stats["treedb.cache.checkpoint.wait.post_frontier_units_last"] = fmt.Sprintf("%d", db.checkpointWaitPostFrontierUnitsLast.Load())
+	stats["treedb.cache.checkpoint.wait.post_frontier_bytes_last"] = fmt.Sprintf("%d", db.checkpointWaitPostFrontierBytesLast.Load())
+	stats["treedb.cache.checkpoint.wait.post_frontier_lanes_last"] = fmt.Sprintf("%d", db.checkpointWaitPostFrontierLanesLast.Load())
 	stats["treedb.cache.checkpoint.shared_drain.flushmu_releases_total"] = fmt.Sprintf("%d", db.checkpointSharedDrainFlushMuReleases.Load())
 	stats["treedb.cache.checkpoint.shared_drain.wait_ns_total"] = fmt.Sprintf("%d", db.checkpointSharedDrainWaitNs.Load())
 	stats["treedb.cache.checkpoint.shared_drain.wait_ns_max"] = fmt.Sprintf("%d", db.checkpointSharedDrainWaitMaxNs.Load())
@@ -27753,6 +28013,28 @@ func (db *DB) Stats() map[string]string {
 	stats["treedb.cache.checkpoint.shared_drain.background_units_total"] = fmt.Sprintf("%d", db.checkpointSharedDrainBackgroundUnits.Load())
 	stats["treedb.cache.checkpoint.shared_drain.background_ops_total"] = fmt.Sprintf("%d", db.checkpointSharedDrainBackgroundOps.Load())
 	stats["treedb.cache.checkpoint.shared_drain.background_bytes_total"] = fmt.Sprintf("%d", db.checkpointSharedDrainBackgroundBytes.Load())
+	waitDrainUnits := db.checkpointWaitFrontierDrainedUnitsLast.Load()
+	waitDrainBytes := db.checkpointWaitFrontierDrainedBytesLast.Load()
+	waitDrainNs := db.checkpointActiveBackgroundFlushWaitLastNs.Load()
+	ownedDrainUnits := db.checkpointOwnedDrainUnitsLast.Load()
+	ownedDrainBytes := db.checkpointOwnedDrainBytesLast.Load()
+	ownedDrainNs := db.checkpointOwnedDrainNsLast.Load()
+	stats["treedb.cache.checkpoint.flush_all.owned_drain_units_last"] = fmt.Sprintf("%d", ownedDrainUnits)
+	stats["treedb.cache.checkpoint.flush_all.owned_drain_ops_last"] = fmt.Sprintf("%d", db.checkpointOwnedDrainOpsLast.Load())
+	stats["treedb.cache.checkpoint.flush_all.owned_drain_bytes_last"] = fmt.Sprintf("%d", ownedDrainBytes)
+	stats["treedb.cache.checkpoint.flush_all.owned_drain_ns_last"] = fmt.Sprintf("%d", ownedDrainNs)
+	stats["treedb.cache.checkpoint.flush_all.background_drain_units_last"] = fmt.Sprintf("%d", db.checkpointBackgroundDrainUnitsLast.Load())
+	stats["treedb.cache.checkpoint.flush_all.background_drain_ops_last"] = fmt.Sprintf("%d", db.checkpointBackgroundDrainOpsLast.Load())
+	stats["treedb.cache.checkpoint.flush_all.background_drain_bytes_last"] = fmt.Sprintf("%d", db.checkpointBackgroundDrainBytesLast.Load())
+	stats["treedb.cache.checkpoint.wait.frontier_drain_units_per_sec_last"] = fmt.Sprintf("%.6f", checkpointRatePerSecond(waitDrainUnits, waitDrainNs))
+	stats["treedb.cache.checkpoint.wait.frontier_drain_bytes_per_sec_last"] = fmt.Sprintf("%.6f", checkpointRatePerSecond(waitDrainBytes, waitDrainNs))
+	stats["treedb.cache.checkpoint.flush_all.owned_drain_units_per_sec_last"] = fmt.Sprintf("%.6f", checkpointRatePerSecond(ownedDrainUnits, ownedDrainNs))
+	stats["treedb.cache.checkpoint.flush_all.owned_drain_bytes_per_sec_last"] = fmt.Sprintf("%.6f", checkpointRatePerSecond(ownedDrainBytes, ownedDrainNs))
+	productiveWaitRatio := checkpointRateRatio(waitDrainBytes, waitDrainNs, ownedDrainBytes, ownedDrainNs)
+	if productiveWaitRatio == 0 {
+		productiveWaitRatio = checkpointRateRatio(waitDrainUnits, waitDrainNs, ownedDrainUnits, ownedDrainNs)
+	}
+	stats["treedb.cache.checkpoint.productive_wait_ratio_last"] = fmt.Sprintf("%.6f", productiveWaitRatio)
 	stats["treedb.cache.checkpoint.flush_preempt_requests_total"] = fmt.Sprintf("%d", db.checkpointFlushPreemptRequests.Load())
 	stats["treedb.cache.checkpoint.preflush_kick_skips_total"] = fmt.Sprintf("%d", db.checkpointPreflushKickSkips.Load())
 	stats["treedb.cache.checkpoint.wal_cleanup.considered_last"] = fmt.Sprintf("%d", db.checkpointWALCleanupConsideredLast.Load())

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -8334,6 +8334,7 @@ type DB struct {
 	flushBacklogCoalescingLastOldLeafBytesPerOpPPM               atomic.Uint64
 	flushBacklogCoalescingSkipReasons                            [flushBacklogCoalescingSkipReasonCount]atomic.Uint64
 	flushCoordinatorActive                                       atomic.Int64
+	flushCoordinatorActiveWorkers                                atomic.Int64
 	flushCoordinatorInFlightBytes                                atomic.Int64
 	flushCoordinatorProgress                                     atomic.Uint64
 	flushCoordinatorErrors                                       atomic.Uint64
@@ -21447,7 +21448,7 @@ func (db *DB) checkpointDebtSnapshotLocked() checkpointDebtSnapshot {
 		queueUnits:          uint64(len(db.queue)),
 		mutableBytes:        nonNegativeInt64ToUint64(db.mutableBytes.Load()),
 		activeInFlightBytes: nonNegativeInt64ToUint64(db.flushCoordinatorInFlightBytes.Load()),
-		activeWorkers:       nonNegativeInt64ToUint64(db.flushCoordinatorActive.Load()),
+		activeWorkers:       nonNegativeInt64ToUint64(db.flushCoordinatorActiveWorkers.Load()),
 	}
 	if len(db.queue) > 0 {
 		lanes := make(map[uint16]struct{})

--- a/TreeDB/caching/flush_apply_stats.go
+++ b/TreeDB/caching/flush_apply_stats.go
@@ -258,6 +258,7 @@ func (db *DB) beginFlushCoordinatorWork(bytes int64) {
 	if db == nil {
 		return
 	}
+	db.flushCoordinatorActiveWorkers.Add(1)
 	if bytes > 0 {
 		db.flushCoordinatorInFlightBytes.Add(bytes)
 	}
@@ -268,6 +269,7 @@ func (db *DB) finishFlushCoordinatorWork(bytes int64, success bool) {
 	if db == nil {
 		return
 	}
+	addAtomicInt64FloorZero(&db.flushCoordinatorActiveWorkers, -1)
 	if bytes > 0 {
 		addAtomicInt64FloorZero(&db.flushCoordinatorInFlightBytes, -bytes)
 	}
@@ -529,6 +531,7 @@ func (db *DB) appendCacheFlushApplyStats(stats map[string]string) {
 		stats["treedb.cache.flush_backlog_coalescing.skip.reason."+reason.String()+"_total"] = fmt.Sprintf("%d", db.flushBacklogCoalescingSkipReasons[reason].Load())
 	}
 	stats["treedb.cache.flush_apply.coordinator.active"] = fmt.Sprintf("%d", db.flushCoordinatorActive.Load())
+	stats["treedb.cache.flush_apply.coordinator.active_workers"] = fmt.Sprintf("%d", db.flushCoordinatorActiveWorkers.Load())
 	stats["treedb.cache.flush_apply.coordinator.in_flight_bytes"] = fmt.Sprintf("%d", db.flushCoordinatorInFlightBytes.Load())
 	stats["treedb.cache.flush_apply.coordinator.progress_total"] = fmt.Sprintf("%d", db.flushCoordinatorProgress.Load())
 	stats["treedb.cache.flush_apply.coordinator.errors_total"] = fmt.Sprintf("%d", db.flushCoordinatorErrors.Load())

--- a/TreeDB/caching/flush_apply_stats.go
+++ b/TreeDB/caching/flush_apply_stats.go
@@ -231,6 +231,7 @@ func (db *DB) observeCheckpointActiveBackgroundFlushWait(wait time.Duration) {
 	}
 	ns := uint64(wait.Nanoseconds())
 	db.checkpointActiveBackgroundFlushWaitNs.Add(ns)
+	db.checkpointActiveBackgroundFlushWaitLastNs.Store(ns)
 	db.checkpointActiveBackgroundFlushWaitSamples.Add(1)
 	updateAtomicMaxUint64(&db.checkpointActiveBackgroundFlushWaitMaxNs, ns)
 }

--- a/TreeDB/caching/flush_apply_stats.go
+++ b/TreeDB/caching/flush_apply_stats.go
@@ -226,7 +226,11 @@ func (db *DB) observeFlushSpanRunTargetLeafSpanSummary(targetLeafSpans, singleOp
 }
 
 func (db *DB) observeCheckpointActiveBackgroundFlushWait(wait time.Duration) {
-	if db == nil || wait <= 0 {
+	if db == nil {
+		return
+	}
+	if wait <= 0 {
+		db.checkpointActiveBackgroundFlushWaitLastNs.Store(0)
 		return
 	}
 	ns := uint64(wait.Nanoseconds())


### PR DESCRIPTION
## Objective

Close #2945 by adding stable TreeDB checkpoint/flush stats that classify whether `checkpoint.active_background_flush_wait` drained checkpoint-relevant debt or was coordination loss.

## Latest update (aee75c187)

Fixed the latest `race-check (linux)-2` failure by making `TestCheckpointWaitProductivityStatsQueuedFrontierNoActiveBackground` deterministic: the test disables legacy queue backpressure so no background flush can race and drain the queued frontier before the checkpoint wait-frontier sample. This is test-only; production checkpoint/flush behavior and counters are unchanged.

## Latest update (ae6e01228)

Fixed the latest Codex P2 review finding from `7dee66cda`: no-op checkpoints now clear the new per-checkpoint flush-all/drain `_last` fields (`workers_last`, `frontier_lanes_last`, checkpoint-owned drain, and background drain) after the checkpoint becomes active and before early no-op returns. Totals/max counters and checkpoint coordination behavior are unchanged.

## Latest update (7dee66cda)

Fixed the Codex P2 review finding from `f79657b2d4`: the checkpoint wait-frontier snapshot now records `active_background_flush_wait_ns_last` from the same `flushMu` wait when an active background flush was observed before waiting **or** the request frontier drained while waiting, and clears that per-checkpoint duration when neither happened. This keeps `frontier_drain_*_per_sec_last` and `productive_wait_ratio_last` from using a stale denominator. Scope remains instrumentation/statistics only.

## Context

#2943 needs M0 instrumentation before M1/M2 can classify checkpoint wait and apply ceilings. This PR is instrumentation/classification substrate only.

## Non-goals

- No checkpoint coordinator rewrite.
- No handoff/preemption behavior change.
- No default policy change.
- No claim that active-background wait is a bug.

## Exact counter list

Added flush/checkpoint request/debt counters:

- `treedb.cache.flush_apply.coordinator.active_workers`
- `treedb.cache.checkpoint.active_background_flush_wait_ns_last`
- `treedb.cache.checkpoint.debt.queue_units_last`, `.queue_units_max`
- `treedb.cache.checkpoint.debt.queue_bytes_last`, `.queue_bytes_max`
- `treedb.cache.checkpoint.debt.mutable_bytes_last`, `.mutable_bytes_max`
- `treedb.cache.checkpoint.debt.active_in_flight_bytes_last`, `.active_in_flight_bytes_max`
- `treedb.cache.checkpoint.debt.active_workers_last`, `.active_workers_max`
- `treedb.cache.checkpoint.debt.frontier_lanes_last`, `.frontier_lanes_max`

Added wait/frontier counters:

- `treedb.cache.checkpoint.wait.active_workers_at_request_last`
- `treedb.cache.checkpoint.wait.active_in_flight_bytes_at_request_last`
- `treedb.cache.checkpoint.wait.frontier_units_at_request_last`
- `treedb.cache.checkpoint.wait.frontier_bytes_at_request_last`
- `treedb.cache.checkpoint.wait.frontier_lanes_at_request_last`
- `treedb.cache.checkpoint.wait.remaining_frontier_units_last`
- `treedb.cache.checkpoint.wait.remaining_frontier_bytes_last`
- `treedb.cache.checkpoint.wait.remaining_frontier_lanes_last`
- `treedb.cache.checkpoint.wait.drained_frontier_units_last`
- `treedb.cache.checkpoint.wait.drained_frontier_bytes_last`
- `treedb.cache.checkpoint.wait.drained_frontier_lanes_last`
- `treedb.cache.checkpoint.wait.post_frontier_units_last`
- `treedb.cache.checkpoint.wait.post_frontier_bytes_last`
- `treedb.cache.checkpoint.wait.post_frontier_lanes_last`
- `treedb.cache.checkpoint.wait.frontier_drain_units_per_sec_last`
- `treedb.cache.checkpoint.wait.frontier_drain_bytes_per_sec_last`

Added checkpoint-owned/background drain counters:

- `treedb.cache.checkpoint.flush_all.workers_last`
- `treedb.cache.checkpoint.flush_all.frontier_lanes_last`, `.frontier_lanes_max`
- `treedb.cache.checkpoint.flush_all.owned_drain_units_last`
- `treedb.cache.checkpoint.flush_all.owned_drain_ops_last`
- `treedb.cache.checkpoint.flush_all.owned_drain_bytes_last`
- `treedb.cache.checkpoint.flush_all.owned_drain_ns_last`
- `treedb.cache.checkpoint.flush_all.background_drain_units_last`
- `treedb.cache.checkpoint.flush_all.background_drain_ops_last`
- `treedb.cache.checkpoint.flush_all.background_drain_bytes_last`
- `treedb.cache.checkpoint.flush_all.owned_drain_units_per_sec_last`
- `treedb.cache.checkpoint.flush_all.owned_drain_bytes_per_sec_last`
- `treedb.cache.checkpoint.productive_wait_ratio_last`

Validated existing stage/classification counters remain available, including `treedb.cache.checkpoint.frontier.*`, `treedb.cache.checkpoint.shared_drain.*`, and `treedb.cache.checkpoint.stage.backend_boundary.*`.

## Formulas enabled

- `debt_at_request_units = debt.queue_units_last + (debt.mutable_bytes_last > 0 ? 1 : 0)`
- `debt_at_request_bytes = debt.queue_bytes_last + debt.mutable_bytes_last`
- `remaining_debt_after_wait_units = wait.remaining_frontier_units_last + (debt.mutable_bytes_last > 0 ? 1 : 0)`
- `remaining_debt_after_wait_bytes = wait.remaining_frontier_bytes_last + debt.mutable_bytes_last`
- `debt_drained_during_wait = wait.drained_frontier_{units,bytes}_last`
- `wait_drain_rate = wait.frontier_drain_{units,bytes}_per_sec_last` (`drained / active_background_flush_wait_ns_last`)
- `checkpoint_owned_drain_rate = flush_all.owned_drain_{units,bytes}_per_sec_last` (`owned_drain / owned_drain_ns_last`)
- `productive_wait_ratio = treedb.cache.checkpoint.productive_wait_ratio_last` (wait bytes/sec divided by checkpoint-owned bytes/sec, falling back to units/sec when bytes are zero)

`active_in_flight_bytes_*` is reported separately because current flush work still has queue identity while in flight; it is an activity classifier, not blindly additive with queue bytes.

## Design / no-runtime-behavior-change rationale

The PR snapshots checkpoint request queue IDs/lanes/bytes under existing `db.mu`, compares that immutable frontier after `flushMu` acquisition, and records atomic counters. The active checkpoint frontier map remains immutable and protected by the existing `checkpointActiveFrontierMu` publication path. A new `flush_apply.coordinator.active_workers` atomic mirrors existing in-flight byte accounting around flush work begin/finish. Flush behavior, handoff/preemption, sync policy, and defaults are unchanged.

## Tests

Latest head: `aee75c1875aecf14e26f91d74322c0bd1b6bc879`.

- `gofmt -w TreeDB/caching/db.go TreeDB/caching/flush_apply_stats.go TreeDB/caching/checkpoint_productivity_stats_test.go` ✅
- `git diff --check origin/main...HEAD` ✅
- `GOWORK=off go test ./TreeDB/caching -run 'TestCheckpointWaitProductivityStats' -count=1` ✅
- `GOWORK=off go test -race ./TreeDB/caching -run 'TestCheckpointWaitProductivityStats' -count=1` ✅
- `GOWORK=off go test -race ./TreeDB/caching -run '^TestCheckpointWaitProductivityStatsQueuedFrontierNoActiveBackground$' -count=20 -failfast` ✅
- `GOWORK=off go test ./TreeDB/caching ./TreeDB/db ./cmd/unified_bench -count=1` ✅

Focused coverage added for:

- empty/no-op checkpoint;
- queued frontier + mutable debt with no active background;
- checkpoint beginning while background actively drains one frontier unit;
- stale prior `active_background_flush_wait_ns_last` cannot leak into a later no-active/no-drain snapshot or a late-drained frontier rate denominator;
- stale prior per-checkpoint flush-all/drain `_last` stats cannot leak through a later no-op checkpoint.

## AI review disposition

- Codex P2 on `f79657b2d4` (“Keep wait-rate numerator and denominator from the same checkpoint”) fixed in `7dee66cda`.
- Codex P2 on `7dee66cda` (“Reset per-checkpoint drain stats on no-op checkpoints”) fixed in `ae6e01228`.
- Codex/Copilot re-review requested after pushing `aee75c187`.
- CodeRabbit passed on `7dee66cda`; latest-head CodeRabbit/CI will rerun after `ae6e01228`.

## Performance

No benchmark run: instrumentation-only checkpoint-path counters/tests. The changed code adds request/frontier map snapshots only on checkpoint/flush accounting paths, not per foreground write.

## Follow-ups

- #2946/#2947 can consume these counters to classify active-background wait and apply ceiling.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for checkpoint wait and productivity statistics across various checkpoint scenarios.

* **Refactor**
  * Enhanced instrumentation with new metrics for checkpoint debt, frontier wait/drain behavior, and flush timing.
  * Improved monitoring of flush coordinator activity and drain rate performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


