### PR TITLE
TreeDB #2946: classify checkpoint active-background wait

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -27933,6 +27933,9 @@ func (db *DB) Stats() map[string]string {
 	}
 
 	stats["treedb.cache.queue_len"] = fmt.Sprintf("%d", queueLen)
+	stats["treedb.cache.flush_apply.coordinator.active"] = fmt.Sprintf("%d", db.flushCoordinatorActive.Load())
+	stats["treedb.cache.flush_apply.coordinator.active_workers"] = fmt.Sprintf("%d", db.flushCoordinatorActiveWorkers.Load())
+	stats["treedb.cache.flush_apply.coordinator.in_flight_bytes"] = fmt.Sprintf("%d", db.flushCoordinatorInFlightBytes.Load())
 	deleteRangeSnapshotIterators := db.deleteRangeIterators.Load()
 	deleteRangeBackendIterators := db.deleteRangeBackendIterators.Load()
 	deleteRangeMemtableIterators := db.deleteRangeMemtableIterators.Load()

--- a/cmd/benchprof/README.md
+++ b/cmd/benchprof/README.md
@@ -68,7 +68,10 @@ splits, and per-workload counters) into a "Collection Workload Metadata" table.
   - `block.pprof` / `mutex.pprof` (global run-level fallback/supplement)
   - `trace.out` (detected, but not deeply analyzed yet)
 - `benchprof_results.json` preserves selected TreeDB stats under
-  `runs[].treedb_stats` when the benchmark exposes them. This is the raw
+  `runs[].treedb_stats` when the benchmark exposes them. Checkpoint-enabled
+  runs also expose `runs[].checkpoint_durations_seconds`, optional
+  `runs[].checkpoint_settle_seconds`, and checkpoint-local selected stats under
+  `runs[].checkpoint_treedb_stats`. This is the raw
   counter metadata used for TreeDB root-apply/cache review artifacts. For
   value-log mmap reads, unified-bench selected displays prefer backend
   `treedb.vlog.mmap_read.*` counters over cache-prefixed aliases, and the

--- a/cmd/unified_bench/README.md
+++ b/cmd/unified_bench/README.md
@@ -191,6 +191,8 @@ explicitly deferred.
 - `-max-wall` abort the run if wall time exceeds this duration (guardrail; `0` = disabled)
 - `-max-rss-mb` abort the run if RSS exceeds this many MiB (guardrail; `0` = disabled; Linux-only)
 - `-checkpoint-between-tests` force a best-effort durability checkpoint between tests (DBs that support `Checkpoint()`), and also once after the final test so end-of-run disk usage reflects a settled state
+- `-checkpoint-settle-before-tests` comma-separated checkpoint labels that should first wait for TreeDB queue/background debt to drain before checkpointing (for example `random_read`, `post-run`, or `all`); useful for immediate-vs-settled checkpoint comparisons without changing production behavior
+- `-checkpoint-settle-timeout` maximum wait for `-checkpoint-settle-before-tests` (default `10m`)
 - `-vacuum-between-tests` vacuum supported DBs between tests (implies `-checkpoint-between-tests`; TreeDB uses `VacuumIndexOnline`)
 - `-treedb-vlog-rewrite-after-run` run the full TreeDB `CompactStorage` path after the run and report before/after disk usage + the data directory path; the flag name is kept for compatibility
 - `-treedb-vacuum-after-vlog-rewrite-run` run offline TreeDB index vacuum after `-treedb-vlog-rewrite-after-run` before final reporting (disable explicitly with `-treedb-vacuum-after-vlog-rewrite-run=false`)
@@ -246,7 +248,12 @@ This writes:
 For TreeDB runs, `benchprof_results.json` also preserves selected TreeDB stats
 under `runs[].treedb_stats`, including ordered-root/root-apply, value-log mmap
 read counters, and generic plus leaf-specific mmap sealed-budget caps used by
-raw-engine review gates. Selected mmap read display fields prefer the backend
+raw-engine review gates. Checkpoint-enabled runs also export
+`runs[].checkpoint_durations_seconds`; selected settled runs export
+`runs[].checkpoint_settle_seconds`; and TreeDB checkpoint snapshots are preserved
+under `runs[].checkpoint_treedb_stats` so immediate-vs-settled checkpoint rows can
+use the checkpoint-local `*_last` counters even if a final no-op checkpoint runs
+before end-of-run stats are captured. Selected mmap read display fields prefer the backend
 `treedb.vlog.mmap_read.*` family over cache aliases so counts and ratios come
 from one source family. The `collection_storage` suite also
 adds `runs[].collection_workloads` entries with stable mode/workload names,

--- a/cmd/unified_bench/README.md
+++ b/cmd/unified_bench/README.md
@@ -191,7 +191,7 @@ explicitly deferred.
 - `-max-wall` abort the run if wall time exceeds this duration (guardrail; `0` = disabled)
 - `-max-rss-mb` abort the run if RSS exceeds this many MiB (guardrail; `0` = disabled; Linux-only)
 - `-checkpoint-between-tests` force a best-effort durability checkpoint between tests (DBs that support `Checkpoint()`), and also once after the final test so end-of-run disk usage reflects a settled state
-- `-checkpoint-settle-before-tests` comma-separated checkpoint labels that should first wait for TreeDB queue/background debt to drain before checkpointing (for example `random_read`, `post-run`, or `all`); useful for immediate-vs-settled checkpoint comparisons without changing production behavior
+- `-checkpoint-settle-before-tests` comma-separated checkpoint labels that should first wait for TreeDB queue/background debt to drain before checkpointing (for example `random_read`, `post-run`, or `all`; explicit labels must match the selected test order or the run fails); useful for immediate-vs-settled checkpoint comparisons without changing production behavior
 - `-checkpoint-settle-timeout` maximum wait for `-checkpoint-settle-before-tests` (default `10m`)
 - `-vacuum-between-tests` vacuum supported DBs between tests (implies `-checkpoint-between-tests`; TreeDB uses `VacuumIndexOnline`)
 - `-treedb-vlog-rewrite-after-run` run the full TreeDB `CompactStorage` path after the run and report before/after disk usage + the data directory path; the flag name is kept for compatibility

--- a/cmd/unified_bench/main.go
+++ b/cmd/unified_bench/main.go
@@ -89,6 +89,8 @@ var (
 	maxRSSMB = flag.Int("max-rss-mb", 0, "Abort the benchmark run if RSS exceeds this many MiB (0=disabled; Linux-only)")
 
 	checkpointBetweenTests          = flag.Bool("checkpoint-between-tests", false, "Force a best-effort durability checkpoint between each benchmark test (DBs that support Checkpoint())")
+	checkpointSettleBeforeTestsArg  = flag.String("checkpoint-settle-before-tests", "", "Comma-separated checkpoint-before-test labels that should wait for TreeDB queue/background debt to drain before checkpointing (use all for every checkpoint; supports post-run)")
+	checkpointSettleTimeout         = flag.Duration("checkpoint-settle-timeout", defaultCheckpointSettleTimeout, "Maximum time to wait for TreeDB queue/background debt to drain before a selected checkpoint")
 	vacuumBetweenTests              = flag.Bool("vacuum-between-tests", false, "Vacuum supported DBs between each benchmark test (implies -checkpoint-between-tests; TreeDB: VacuumIndexOnline)")
 	checkpointEveryOps              = flag.Int("checkpoint-every-ops", 0, "Force a best-effort durability checkpoint every N ops during write-heavy tests (0=disabled; DBs that support Checkpoint())")
 	checkpointEveryBytes            = flag.Int64("checkpoint-every-bytes", 0, "Force a best-effort durability checkpoint every N approx bytes during write-heavy tests (0=disabled; DBs that support Checkpoint())")
@@ -111,6 +113,8 @@ func flagExplicit(name string) bool {
 }
 
 const checkpointPostRunLabel = "post-run"
+
+const defaultCheckpointSettleTimeout = 10 * time.Minute
 
 const (
 	defaultBatchDeleteRangeWidth     = 100
@@ -190,6 +194,9 @@ type BenchConfig struct {
 	MaxRSSMB int
 
 	CheckpointBetweenTests          bool
+	CheckpointSettleBeforeTests     map[string]struct{}
+	CheckpointSettleBeforeAll       bool
+	CheckpointSettleTimeout         time.Duration
 	VacuumBetweenTests              bool
 	CheckpointEveryOps              int
 	CheckpointEveryBytes            int64
@@ -220,21 +227,23 @@ type dirDiskUsage struct {
 }
 
 type BenchRun struct {
-	Config              BenchConfig
-	Instances           []*DBInstance
-	TestOrder           []string
-	DisplayNames        map[string]string
-	Results             map[string]map[string]float64
-	CheckpointDurations map[string]map[string]time.Duration
-	VacuumDurations     map[string]map[string]time.Duration
-	VacuumIndexBytes    map[string]map[string][2]uint64 // [0]=before, [1]=after (best-effort; treedb only)
-	TreeDBDiskUsage     map[string]treeDBDiskUsage
-	TreeDBVlogRewrite   map[string]treeDBVlogRewriteReport
-	TreeDBPerf          map[string]map[string]treeDBPerfMetrics
-	TreeDBStats         map[string]map[string]string
-	DiskUsage           map[string]dirDiskUsage
-	BatchDeleteRange    map[string]map[string]batchDeleteRangeReport
-	CollectionWorkloads []benchprofCollectionWorkload
+	Config                    BenchConfig
+	Instances                 []*DBInstance
+	TestOrder                 []string
+	DisplayNames              map[string]string
+	Results                   map[string]map[string]float64
+	CheckpointDurations       map[string]map[string]time.Duration
+	CheckpointSettleDurations map[string]map[string]time.Duration
+	CheckpointTreeDBStats     map[string]map[string]map[string]string
+	VacuumDurations           map[string]map[string]time.Duration
+	VacuumIndexBytes          map[string]map[string][2]uint64 // [0]=before, [1]=after (best-effort; treedb only)
+	TreeDBDiskUsage           map[string]treeDBDiskUsage
+	TreeDBVlogRewrite         map[string]treeDBVlogRewriteReport
+	TreeDBPerf                map[string]map[string]treeDBPerfMetrics
+	TreeDBStats               map[string]map[string]string
+	DiskUsage                 map[string]dirDiskUsage
+	BatchDeleteRange          map[string]map[string]batchDeleteRangeReport
+	CollectionWorkloads       []benchprofCollectionWorkload
 }
 
 type treeDBPerfMetrics struct {
@@ -297,14 +306,17 @@ type benchprofExport struct {
 }
 
 type benchprofExportRun struct {
-	Keys                int                                          `json:"keys"`
-	Profile             string                                       `json:"profile,omitempty"`
-	ExecutionPath       string                                       `json:"execution_path,omitempty"`
-	Results             map[string]map[string]float64                `json:"results,omitempty"`
-	TreeDBPerf          map[string]map[string]treeDBPerfMetrics      `json:"treedb_perf,omitempty"`
-	TreeDBStats         map[string]map[string]string                 `json:"treedb_stats,omitempty"`
-	BatchDeleteRange    map[string]map[string]batchDeleteRangeReport `json:"batch_delete_range,omitempty"`
-	CollectionWorkloads []benchprofCollectionWorkload                `json:"collection_workloads,omitempty"`
+	Keys                       int                                          `json:"keys"`
+	Profile                    string                                       `json:"profile,omitempty"`
+	ExecutionPath              string                                       `json:"execution_path,omitempty"`
+	Results                    map[string]map[string]float64                `json:"results,omitempty"`
+	CheckpointDurationsSeconds map[string]map[string]float64                `json:"checkpoint_durations_seconds,omitempty"`
+	CheckpointSettleSeconds    map[string]map[string]float64                `json:"checkpoint_settle_seconds,omitempty"`
+	CheckpointTreeDBStats      map[string]map[string]map[string]string      `json:"checkpoint_treedb_stats,omitempty"`
+	TreeDBPerf                 map[string]map[string]treeDBPerfMetrics      `json:"treedb_perf,omitempty"`
+	TreeDBStats                map[string]map[string]string                 `json:"treedb_stats,omitempty"`
+	BatchDeleteRange           map[string]map[string]batchDeleteRangeReport `json:"batch_delete_range,omitempty"`
+	CollectionWorkloads        []benchprofCollectionWorkload                `json:"collection_workloads,omitempty"`
 }
 
 type scanDiag struct {
@@ -527,6 +539,7 @@ func main() {
 
 	// Populate TreeDB specific config into BenchConfig by reading the flags defined in adapter_treedb.go
 	effectiveReadWorkers := resolveReadWorkers(*readWorkers)
+	checkpointSettleBeforeTests, checkpointSettleBeforeAll := parseCheckpointSettleBeforeTests(*checkpointSettleBeforeTestsArg)
 	baseCfg := BenchConfig{
 		Keys:                             *numKeys,
 		KeyShape:                         *keyShapeArg,
@@ -562,6 +575,9 @@ func main() {
 		MaxWall:                          *maxWall,
 		MaxRSSMB:                         *maxRSSMB,
 		CheckpointBetweenTests:           *checkpointBetweenTests || *vacuumBetweenTests,
+		CheckpointSettleBeforeTests:      checkpointSettleBeforeTests,
+		CheckpointSettleBeforeAll:        checkpointSettleBeforeAll,
+		CheckpointSettleTimeout:          *checkpointSettleTimeout,
 		VacuumBetweenTests:               *vacuumBetweenTests,
 		CheckpointEveryOps:               *checkpointEveryOps,
 		CheckpointEveryBytes:             *checkpointEveryBytes,
@@ -1363,6 +1379,32 @@ func benchprofJSONResults(results map[string]map[string]float64) map[string]map[
 	return out
 }
 
+func benchprofJSONDurationSeconds(durations map[string]map[string]time.Duration) map[string]map[string]float64 {
+	if len(durations) == 0 {
+		return nil
+	}
+	out := make(map[string]map[string]float64, len(durations))
+	for label, perDB := range durations {
+		if len(perDB) == 0 {
+			continue
+		}
+		clean := make(map[string]float64, len(perDB))
+		for dbName, d := range perDB {
+			if d < 0 {
+				continue
+			}
+			clean[dbName] = d.Seconds()
+		}
+		if len(clean) > 0 {
+			out[label] = clean
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
 func writeBenchprofArtifactsToPaths(jsonPath, markdownPath, executionPath string, runs []BenchRun) error {
 	jsonPath = strings.TrimSpace(jsonPath)
 	markdownPath = strings.TrimSpace(markdownPath)
@@ -1387,14 +1429,17 @@ func writeBenchprofArtifactsToPaths(jsonPath, markdownPath, executionPath string
 	}
 	for _, run := range runs {
 		out.Runs = append(out.Runs, benchprofExportRun{
-			Keys:                run.Config.Keys,
-			Profile:             strings.TrimSpace(run.Config.Profile),
-			ExecutionPath:       executionPath,
-			Results:             benchprofJSONResults(run.Results),
-			TreeDBPerf:          run.TreeDBPerf,
-			TreeDBStats:         selectedBenchprofTreeDBStats(run.TreeDBStats),
-			BatchDeleteRange:    run.BatchDeleteRange,
-			CollectionWorkloads: run.CollectionWorkloads,
+			Keys:                       run.Config.Keys,
+			Profile:                    strings.TrimSpace(run.Config.Profile),
+			ExecutionPath:              executionPath,
+			Results:                    benchprofJSONResults(run.Results),
+			CheckpointDurationsSeconds: benchprofJSONDurationSeconds(run.CheckpointDurations),
+			CheckpointSettleSeconds:    benchprofJSONDurationSeconds(run.CheckpointSettleDurations),
+			CheckpointTreeDBStats:      selectedBenchprofCheckpointTreeDBStats(run.CheckpointTreeDBStats),
+			TreeDBPerf:                 run.TreeDBPerf,
+			TreeDBStats:                selectedBenchprofTreeDBStats(run.TreeDBStats),
+			BatchDeleteRange:           run.BatchDeleteRange,
+			CollectionWorkloads:        run.CollectionWorkloads,
 		})
 	}
 
@@ -1437,6 +1482,60 @@ func selectedBenchprofTreeDBStats(stats map[string]map[string]string) map[string
 		return nil
 	}
 	return out
+}
+
+func selectedBenchprofCheckpointTreeDBStats(stats map[string]map[string]map[string]string) map[string]map[string]map[string]string {
+	if len(stats) == 0 {
+		return nil
+	}
+	out := make(map[string]map[string]map[string]string)
+	for label, perDB := range stats {
+		selectedPerDB := selectedBenchprofTreeDBStats(perDB)
+		if len(selectedPerDB) == 0 {
+			continue
+		}
+		out[label] = selectedPerDB
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func recordDuration(dst map[string]map[string]time.Duration, label, dbName string, d time.Duration) {
+	if dst == nil || label == "" || dbName == "" {
+		return
+	}
+	perDB := dst[label]
+	if perDB == nil {
+		perDB = make(map[string]time.Duration)
+		dst[label] = perDB
+	}
+	perDB[dbName] = d
+}
+
+func recordCheckpointTreeDBStats(dst map[string]map[string]map[string]string, label string, db kvstore.DB) {
+	if dst == nil || label == "" || db == nil {
+		return
+	}
+	sp, ok := db.(kvstore.StatsProvider)
+	if !ok {
+		return
+	}
+	selected := treedbstats.Selected(sp.Stats())
+	if len(selected) == 0 {
+		return
+	}
+	copySnap := make(map[string]string, len(selected))
+	for k, v := range selected {
+		copySnap[k] = v
+	}
+	perDB := dst[label]
+	if perDB == nil {
+		perDB = make(map[string]map[string]string)
+		dst[label] = perDB
+	}
+	perDB[db.Name()] = copySnap
 }
 
 func validateBenchprofExecutionPath(executionPath string) error {
@@ -2351,6 +2450,8 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 
 	guard := newBenchGuard(cfg)
 	checkpointDurations := make(map[string]map[string]time.Duration)
+	checkpointSettleDurations := make(map[string]map[string]time.Duration)
+	checkpointTreeDBStats := make(map[string]map[string]map[string]string)
 	vacuumDurations := make(map[string]map[string]time.Duration)
 	vacuumIndexBytes := make(map[string]map[string][2]uint64)
 	treeDBPerf := make(map[string]map[string]treeDBPerfMetrics)
@@ -4541,6 +4642,16 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 					}
 				}
 
+				if shouldSettleBeforeCheckpoint(cfg, testName) {
+					settleDur, settled, settleErr := waitForTreeDBQueueDrainInstance(inst, cfg.CheckpointSettleTimeout)
+					if settleErr != nil {
+						return BenchRun{}, fmt.Errorf("settle %s before checkpoint %s: %w", inst.Name, testName, settleErr)
+					}
+					if settled {
+						recordDuration(checkpointSettleDurations, testName, inst.Wrapper.Name(), settleDur)
+					}
+				}
+
 				start := time.Now()
 				checkpointErr := cp.Checkpoint()
 
@@ -4552,6 +4663,7 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 				if checkpointErr != nil {
 					return BenchRun{}, fmt.Errorf("checkpoint %s before %s: %w", inst.Name, testName, checkpointErr)
 				}
+				recordCheckpointTreeDBStats(checkpointTreeDBStats, testName, inst.Wrapper)
 				chkMap[inst.Wrapper.Name()] = time.Since(start)
 			}
 			checkpointDurations[testName] = chkMap
@@ -4830,6 +4942,16 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 				}
 			}
 
+			if shouldSettleBeforeCheckpoint(cfg, checkpointPostRunLabel) {
+				settleDur, settled, settleErr := waitForTreeDBQueueDrainInstance(inst, cfg.CheckpointSettleTimeout)
+				if settleErr != nil {
+					return BenchRun{}, fmt.Errorf("settle %s before checkpoint %s: %w", inst.Name, checkpointPostRunLabel, settleErr)
+				}
+				if settled {
+					recordDuration(checkpointSettleDurations, checkpointPostRunLabel, inst.Wrapper.Name(), settleDur)
+				}
+			}
+
 			start := time.Now()
 			checkpointErr := cp.Checkpoint()
 
@@ -4841,6 +4963,7 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 			if checkpointErr != nil {
 				return BenchRun{}, fmt.Errorf("checkpoint %s after run: %w", inst.Name, checkpointErr)
 			}
+			recordCheckpointTreeDBStats(checkpointTreeDBStats, checkpointPostRunLabel, inst.Wrapper)
 			chkMap[inst.Wrapper.Name()] = time.Since(start)
 		}
 		if len(chkMap) > 0 {
@@ -4964,20 +5087,22 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 	}
 
 	return BenchRun{
-		Config:              cfg,
-		Instances:           instances,
-		TestOrder:           finalTestOrder,
-		DisplayNames:        displayNames,
-		Results:             results,
-		CheckpointDurations: checkpointDurations,
-		VacuumDurations:     vacuumDurations,
-		VacuumIndexBytes:    vacuumIndexBytes,
-		TreeDBDiskUsage:     treedbDisk,
-		TreeDBVlogRewrite:   treedbRewrite,
-		TreeDBPerf:          treeDBPerf,
-		TreeDBStats:         treedbStats,
-		DiskUsage:           diskUsage,
-		BatchDeleteRange:    batchDeleteRangeReports,
+		Config:                    cfg,
+		Instances:                 instances,
+		TestOrder:                 finalTestOrder,
+		DisplayNames:              displayNames,
+		Results:                   results,
+		CheckpointDurations:       checkpointDurations,
+		CheckpointSettleDurations: checkpointSettleDurations,
+		CheckpointTreeDBStats:     checkpointTreeDBStats,
+		VacuumDurations:           vacuumDurations,
+		VacuumIndexBytes:          vacuumIndexBytes,
+		TreeDBDiskUsage:           treedbDisk,
+		TreeDBVlogRewrite:         treedbRewrite,
+		TreeDBPerf:                treeDBPerf,
+		TreeDBStats:               treedbStats,
+		DiskUsage:                 diskUsage,
+		BatchDeleteRange:          batchDeleteRangeReports,
 	}, nil
 }
 
@@ -5869,6 +5994,20 @@ func renderMarkdownSingle(run BenchRun) string {
 		sb.WriteString(renderCheckpointDurationsTableString(run.Instances, run.TestOrder, run.DisplayNames, run.CheckpointDurations))
 		sb.WriteString("```\n")
 	}
+	if len(run.CheckpointSettleDurations) > 0 {
+		sb.WriteString("\n")
+		sb.WriteString("## Checkpoint Settle Time (Before Selected Checkpoints)\n\n")
+		sb.WriteString("```text\n")
+		sb.WriteString(renderCheckpointDurationsTableString(run.Instances, run.TestOrder, run.DisplayNames, run.CheckpointSettleDurations))
+		sb.WriteString("```\n")
+	}
+	if checkpointStats := strings.TrimSpace(renderCheckpointTreeDBStatsString(run.Instances, run.TestOrder, run.DisplayNames, run.CheckpointTreeDBStats)); checkpointStats != "" {
+		sb.WriteString("\n")
+		sb.WriteString("## TreeDB Selected Stats (Checkpoint Snapshots)\n\n")
+		sb.WriteString("```text\n")
+		sb.WriteString(checkpointStats)
+		sb.WriteString("\n```\n")
+	}
 	if len(run.VacuumDurations) > 0 {
 		sb.WriteString("\n")
 		sb.WriteString("## Vacuum Time (Between Tests)\n\n")
@@ -5944,6 +6083,61 @@ func renderMarkdownSingle(run BenchRun) string {
 		}
 	}
 	return sb.String()
+}
+
+func renderCheckpointTreeDBStatsString(instances []*DBInstance, finalTestOrder []string, displayNames map[string]string, checkpointStats map[string]map[string]map[string]string) string {
+	if len(checkpointStats) == 0 {
+		return ""
+	}
+	order := make([]string, 0, len(finalTestOrder)+1)
+	seen := make(map[string]struct{}, len(checkpointStats))
+	for _, testName := range finalTestOrder {
+		if _, ok := checkpointStats[testName]; !ok {
+			continue
+		}
+		order = append(order, testName)
+		seen[testName] = struct{}{}
+	}
+	if _, ok := checkpointStats[checkpointPostRunLabel]; ok {
+		if _, already := seen[checkpointPostRunLabel]; !already {
+			order = append(order, checkpointPostRunLabel)
+			seen[checkpointPostRunLabel] = struct{}{}
+		}
+	}
+	var extras []string
+	for label := range checkpointStats {
+		if _, ok := seen[label]; ok {
+			continue
+		}
+		extras = append(extras, label)
+	}
+	sort.Strings(extras)
+	order = append(order, extras...)
+
+	var sb strings.Builder
+	for _, label := range order {
+		statsText := strings.TrimSpace(renderTreeDBSelectedStatsString(instances, checkpointStats[label]))
+		if statsText == "" {
+			continue
+		}
+		if sb.Len() > 0 {
+			sb.WriteByte('\n')
+		}
+		display := displayNames[label]
+		if strings.TrimSpace(display) == "" {
+			display = label
+		}
+		if label == checkpointPostRunLabel {
+			sb.WriteString("after run")
+		} else {
+			sb.WriteString("before ")
+			sb.WriteString(display)
+		}
+		sb.WriteByte('\n')
+		sb.WriteString(statsText)
+		sb.WriteByte('\n')
+	}
+	return strings.TrimSpace(sb.String())
 }
 
 func renderTreeDBPerfString(instances []*DBInstance, finalTestOrder []string, displayNames map[string]string, perf map[string]map[string]treeDBPerfMetrics) string {
@@ -6364,6 +6558,9 @@ func renderTreeDBSelectedStatsString(instances []*DBInstance, treeStats map[stri
 		{label: "flush_apply.prepared_output.leaf_log_pages_installed_total", alts: []string{"treedb.flush_apply.prepared_output.leaf_log_pages_installed_total"}},
 		{label: "flush_apply.prepared_output.leaf_log_pages_abandoned_total", alts: []string{"treedb.flush_apply.prepared_output.leaf_log_pages_abandoned_total"}},
 		{label: "flush_apply.cache.foreground_assist_wait_ns_total", alts: []string{"treedb.cache.flush_apply.foreground_assist_wait_ns_total"}},
+		{label: "flush_apply.cache.coordinator.active", alts: []string{"treedb.cache.flush_apply.coordinator.active"}},
+		{label: "flush_apply.cache.coordinator.active_workers", alts: []string{"treedb.cache.flush_apply.coordinator.active_workers"}},
+		{label: "flush_apply.cache.coordinator.in_flight_bytes", alts: []string{"treedb.cache.flush_apply.coordinator.in_flight_bytes"}},
 		{label: "flush_apply.cache.coordinator.active_assist_skips_total", alts: []string{"treedb.cache.flush_apply.coordinator.active_assist_skips_total"}},
 		{label: "flush_apply.cache.coordinator.progress_wait_ns_total", alts: []string{"treedb.cache.flush_apply.coordinator.progress_wait_ns_total"}},
 		{label: "flush_apply.cache.coordinator.stall_waits_total", alts: []string{"treedb.cache.flush_apply.coordinator.stall_waits_total"}},
@@ -7590,6 +7787,39 @@ func formatDuration(d time.Duration) string {
 	return fmt.Sprintf("%dµs", d.Microseconds())
 }
 
+func parseCheckpointSettleBeforeTests(arg string) (map[string]struct{}, bool) {
+	parts := parseList(arg)
+	if len(parts) == 0 {
+		return nil, false
+	}
+	out := make(map[string]struct{}, len(parts))
+	all := false
+	for _, raw := range parts {
+		if raw == "" {
+			continue
+		}
+		switch raw {
+		case "all", "*":
+			all = true
+			continue
+		case "after_run", "after-run", "postrun", "post_run":
+			raw = checkpointPostRunLabel
+		}
+		if raw != checkpointPostRunLabel {
+			normalized := normalizeTests([]string{raw})
+			if len(normalized) == 0 {
+				continue
+			}
+			raw = normalized[0]
+		}
+		out[raw] = struct{}{}
+	}
+	if len(out) == 0 {
+		out = nil
+	}
+	return out, all
+}
+
 func parseList(s string) []string {
 	parts := strings.Split(s, ",")
 	for i := range parts {
@@ -7691,6 +7921,63 @@ func settleBenchInstances(instances []*DBInstance) error {
 	return nil
 }
 
+func shouldSettleBeforeCheckpoint(cfg BenchConfig, label string) bool {
+	if label == "" {
+		return false
+	}
+	if cfg.CheckpointSettleBeforeAll {
+		return true
+	}
+	if len(cfg.CheckpointSettleBeforeTests) == 0 {
+		return false
+	}
+	_, ok := cfg.CheckpointSettleBeforeTests[label]
+	return ok
+}
+
+func checkpointSettleTimeoutOrDefault(timeout time.Duration) time.Duration {
+	if timeout <= 0 {
+		return defaultCheckpointSettleTimeout
+	}
+	return timeout
+}
+
+func waitForTreeDBQueueDrainInstance(inst *DBInstance, timeout time.Duration) (time.Duration, bool, error) {
+	if inst == nil || inst.Wrapper == nil || !isTreeDBInstance(inst) {
+		return 0, false, nil
+	}
+	sp, ok := inst.Wrapper.(kvstore.StatsProvider)
+	if !ok {
+		return 0, false, nil
+	}
+	timeout = checkpointSettleTimeoutOrDefault(timeout)
+	start := time.Now()
+	deadline := start.Add(timeout)
+	for {
+		stats := sp.Stats()
+		pending := false
+		if queueLen, ok := parseStatInt64(stats, "treedb.cache.queue_len"); ok && queueLen > 0 {
+			pending = true
+		}
+		if backlogBytes, ok := parseStatInt64(stats, "treedb.cache.queue_backlog_bytes"); ok && backlogBytes > 0 {
+			pending = true
+		}
+		if activeWorkers, ok := parseStatInt64(stats, "treedb.cache.flush_apply.coordinator.active_workers"); ok && activeWorkers > 0 {
+			pending = true
+		}
+		if inFlightBytes, ok := parseStatInt64(stats, "treedb.cache.flush_apply.coordinator.in_flight_bytes"); ok && inFlightBytes > 0 {
+			pending = true
+		}
+		if !pending {
+			return time.Since(start), true, nil
+		}
+		if time.Now().After(deadline) {
+			return time.Since(start), true, fmt.Errorf("checkpoint settle timeout: treedb cache queue did not drain within %s", timeout)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
 func waitForTreeDBQueueDrain(instances []*DBInstance, timeout time.Duration) error {
 	deadline := time.Now().Add(timeout)
 	for {
@@ -7712,6 +7999,14 @@ func waitForTreeDBQueueDrain(instances []*DBInstance, timeout time.Duration) err
 				break
 			}
 			if backlogBytes, ok := parseStatInt64(stats, "treedb.cache.queue_backlog_bytes"); ok && backlogBytes > 0 {
+				pending = true
+				break
+			}
+			if activeWorkers, ok := parseStatInt64(stats, "treedb.cache.flush_apply.coordinator.active_workers"); ok && activeWorkers > 0 {
+				pending = true
+				break
+			}
+			if inFlightBytes, ok := parseStatInt64(stats, "treedb.cache.flush_apply.coordinator.in_flight_bytes"); ok && inFlightBytes > 0 {
 				pending = true
 				break
 			}

--- a/cmd/unified_bench/main.go
+++ b/cmd/unified_bench/main.go
@@ -4448,6 +4448,9 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 	if len(finalTestOrder) == 0 {
 		return BenchRun{}, fmt.Errorf("no tests selected")
 	}
+	if err := validateCheckpointSettleBeforeTests(cfg, finalTestOrder); err != nil {
+		return BenchRun{}, err
+	}
 
 	maxEncodedKey := uint64(cfg.Keys)
 	setMaxEncoded := func(v uint64) {
@@ -4632,12 +4635,19 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 				}
 
 				if shouldSettleBeforeCheckpoint(cfg, testName) {
-					settleDur, settled, settleErr := waitForTreeDBQueueDrainInstance(inst, cfg.CheckpointSettleTimeout)
+					if err := guard.Checkpoint(); err != nil {
+						return BenchRun{}, err
+					}
+					settleTimeout := checkpointSettleTimeoutWithGuard(cfg.CheckpointSettleTimeout, guard)
+					settleDur, settled, settleErr := waitForTreeDBQueueDrainInstance(inst, settleTimeout)
 					if settleErr != nil {
 						return BenchRun{}, fmt.Errorf("settle %s before checkpoint %s: %w", inst.Name, testName, settleErr)
 					}
 					if settled {
 						recordDuration(checkpointSettleDurations, testName, inst.Wrapper.Name(), settleDur)
+					}
+					if err := guard.Checkpoint(); err != nil {
+						return BenchRun{}, err
 					}
 				}
 
@@ -4932,12 +4942,19 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 			}
 
 			if shouldSettleBeforeCheckpoint(cfg, checkpointPostRunLabel) {
-				settleDur, settled, settleErr := waitForTreeDBQueueDrainInstance(inst, cfg.CheckpointSettleTimeout)
+				if err := guard.Checkpoint(); err != nil {
+					return BenchRun{}, err
+				}
+				settleTimeout := checkpointSettleTimeoutWithGuard(cfg.CheckpointSettleTimeout, guard)
+				settleDur, settled, settleErr := waitForTreeDBQueueDrainInstance(inst, settleTimeout)
 				if settleErr != nil {
 					return BenchRun{}, fmt.Errorf("settle %s before checkpoint %s: %w", inst.Name, checkpointPostRunLabel, settleErr)
 				}
 				if settled {
 					recordDuration(checkpointSettleDurations, checkpointPostRunLabel, inst.Wrapper.Name(), settleDur)
+				}
+				if err := guard.Checkpoint(); err != nil {
+					return BenchRun{}, err
 				}
 			}
 
@@ -7935,9 +7952,46 @@ func shouldSettleBeforeCheckpoint(cfg BenchConfig, label string) bool {
 	return ok
 }
 
+func validateCheckpointSettleBeforeTests(cfg BenchConfig, finalTestOrder []string) error {
+	if len(cfg.CheckpointSettleBeforeTests) == 0 {
+		return nil
+	}
+	valid := make(map[string]struct{}, len(finalTestOrder)+1)
+	for _, label := range finalTestOrder {
+		valid[label] = struct{}{}
+	}
+	valid[checkpointPostRunLabel] = struct{}{}
+	var unknown []string
+	for label := range cfg.CheckpointSettleBeforeTests {
+		if _, ok := valid[label]; !ok {
+			unknown = append(unknown, label)
+		}
+	}
+	if len(unknown) == 0 {
+		return nil
+	}
+	sort.Strings(unknown)
+	return fmt.Errorf("unknown checkpoint settle label(s): %s", strings.Join(unknown, ","))
+}
+
 func checkpointSettleTimeoutOrDefault(timeout time.Duration) time.Duration {
 	if timeout <= 0 {
 		return defaultCheckpointSettleTimeout
+	}
+	return timeout
+}
+
+func checkpointSettleTimeoutWithGuard(timeout time.Duration, guard *benchGuard) time.Duration {
+	timeout = checkpointSettleTimeoutOrDefault(timeout)
+	if guard == nil || guard.deadline.IsZero() {
+		return timeout
+	}
+	remaining := time.Until(guard.deadline)
+	if remaining <= 0 {
+		return time.Nanosecond
+	}
+	if remaining < timeout {
+		return remaining
 	}
 	return timeout
 }
@@ -7960,6 +8014,9 @@ func waitForTreeDBQueueDrainInstance(inst *DBInstance, timeout time.Duration) (t
 			pending = true
 		}
 		if backlogBytes, ok := parseStatInt64(stats, "treedb.cache.queue_backlog_bytes"); ok && backlogBytes > 0 {
+			pending = true
+		}
+		if active, ok := parseStatInt64(stats, "treedb.cache.flush_apply.coordinator.active"); ok && active > 0 {
 			pending = true
 		}
 		if activeWorkers, ok := parseStatInt64(stats, "treedb.cache.flush_apply.coordinator.active_workers"); ok && activeWorkers > 0 {
@@ -7999,6 +8056,10 @@ func waitForTreeDBQueueDrain(instances []*DBInstance, timeout time.Duration) err
 				break
 			}
 			if backlogBytes, ok := parseStatInt64(stats, "treedb.cache.queue_backlog_bytes"); ok && backlogBytes > 0 {
+				pending = true
+				break
+			}
+			if active, ok := parseStatInt64(stats, "treedb.cache.flush_apply.coordinator.active"); ok && active > 0 {
 				pending = true
 				break
 			}

--- a/cmd/unified_bench/main.go
+++ b/cmd/unified_bench/main.go
@@ -4631,6 +4631,16 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 					continue
 				}
 
+				if shouldSettleBeforeCheckpoint(cfg, testName) {
+					settleDur, settled, settleErr := waitForTreeDBQueueDrainInstance(inst, cfg.CheckpointSettleTimeout)
+					if settleErr != nil {
+						return BenchRun{}, fmt.Errorf("settle %s before checkpoint %s: %w", inst.Name, testName, settleErr)
+					}
+					if settled {
+						recordDuration(checkpointSettleDurations, testName, inst.Wrapper.Name(), settleDur)
+					}
+				}
+
 				var (
 					checkpointCPUFile *os.File
 					err               error
@@ -4639,16 +4649,6 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 					checkpointCPUFile, err = startCheckpointCPUProfile(cfg, profileHooks, testName, inst.Wrapper.Name())
 					if err != nil {
 						return BenchRun{}, fmt.Errorf("checkpoint %s before %s profiling: %w", inst.Name, testName, err)
-					}
-				}
-
-				if shouldSettleBeforeCheckpoint(cfg, testName) {
-					settleDur, settled, settleErr := waitForTreeDBQueueDrainInstance(inst, cfg.CheckpointSettleTimeout)
-					if settleErr != nil {
-						return BenchRun{}, fmt.Errorf("settle %s before checkpoint %s: %w", inst.Name, testName, settleErr)
-					}
-					if settled {
-						recordDuration(checkpointSettleDurations, testName, inst.Wrapper.Name(), settleDur)
 					}
 				}
 
@@ -4931,6 +4931,16 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 				continue
 			}
 
+			if shouldSettleBeforeCheckpoint(cfg, checkpointPostRunLabel) {
+				settleDur, settled, settleErr := waitForTreeDBQueueDrainInstance(inst, cfg.CheckpointSettleTimeout)
+				if settleErr != nil {
+					return BenchRun{}, fmt.Errorf("settle %s before checkpoint %s: %w", inst.Name, checkpointPostRunLabel, settleErr)
+				}
+				if settled {
+					recordDuration(checkpointSettleDurations, checkpointPostRunLabel, inst.Wrapper.Name(), settleDur)
+				}
+			}
+
 			var (
 				checkpointCPUFile *os.File
 				err               error
@@ -4939,16 +4949,6 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 				checkpointCPUFile, err = startCheckpointCPUProfile(cfg, profileHooks, checkpointPostRunLabel, inst.Wrapper.Name())
 				if err != nil {
 					return BenchRun{}, fmt.Errorf("checkpoint %s after run profiling: %w", inst.Name, err)
-				}
-			}
-
-			if shouldSettleBeforeCheckpoint(cfg, checkpointPostRunLabel) {
-				settleDur, settled, settleErr := waitForTreeDBQueueDrainInstance(inst, cfg.CheckpointSettleTimeout)
-				if settleErr != nil {
-					return BenchRun{}, fmt.Errorf("settle %s before checkpoint %s: %w", inst.Name, checkpointPostRunLabel, settleErr)
-				}
-				if settled {
-					recordDuration(checkpointSettleDurations, checkpointPostRunLabel, inst.Wrapper.Name(), settleDur)
 				}
 			}
 

--- a/cmd/unified_bench/main.go
+++ b/cmd/unified_bench/main.go
@@ -4673,8 +4673,8 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 				if checkpointErr != nil {
 					return BenchRun{}, fmt.Errorf("checkpoint %s before %s: %w", inst.Name, testName, checkpointErr)
 				}
-				recordCheckpointTreeDBStats(checkpointTreeDBStats, testName, inst.Wrapper)
 				chkMap[inst.Wrapper.Name()] = time.Since(start)
+				recordCheckpointTreeDBStats(checkpointTreeDBStats, testName, inst.Wrapper)
 			}
 			checkpointDurations[testName] = chkMap
 
@@ -4980,8 +4980,8 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 			if checkpointErr != nil {
 				return BenchRun{}, fmt.Errorf("checkpoint %s after run: %w", inst.Name, checkpointErr)
 			}
-			recordCheckpointTreeDBStats(checkpointTreeDBStats, checkpointPostRunLabel, inst.Wrapper)
 			chkMap[inst.Wrapper.Name()] = time.Since(start)
+			recordCheckpointTreeDBStats(checkpointTreeDBStats, checkpointPostRunLabel, inst.Wrapper)
 		}
 		if len(chkMap) > 0 {
 			checkpointDurations[checkpointPostRunLabel] = chkMap

--- a/cmd/unified_bench/main_test.go
+++ b/cmd/unified_bench/main_test.go
@@ -265,6 +265,7 @@ func (d *checkpointStatsDB) Stats() map[string]string {
 	return map[string]string{
 		"treedb.cache.queue_len":                                                       "0",
 		"treedb.cache.queue_backlog_bytes":                                             "0",
+		"treedb.cache.flush_apply.coordinator.active":                                  "0",
 		"treedb.cache.flush_apply.coordinator.active_workers":                          "0",
 		"treedb.cache.flush_apply.coordinator.in_flight_bytes":                         "0",
 		"treedb.cache.checkpoint.active_background_flush_wait_ns_last":                 fmt.Sprintf("%d", calls*10),
@@ -276,15 +277,18 @@ func (d *checkpointStatsDB) Stats() map[string]string {
 
 func (d *activeFlushStatsDB) Stats() map[string]string {
 	calls := d.statsCalls.Add(1)
+	active := "0"
 	activeWorkers := "0"
 	inFlightBytes := "0"
 	if calls == 1 {
+		active = "1"
 		activeWorkers = "1"
 		inFlightBytes = "1024"
 	}
 	return map[string]string{
 		"treedb.cache.queue_len":                               "0",
 		"treedb.cache.queue_backlog_bytes":                     "0",
+		"treedb.cache.flush_apply.coordinator.active":          active,
 		"treedb.cache.flush_apply.coordinator.active_workers":  activeWorkers,
 		"treedb.cache.flush_apply.coordinator.in_flight_bytes": inFlightBytes,
 	}
@@ -1986,6 +1990,31 @@ func TestWaitForTreeDBQueueDrainInstanceWaitsForActiveFlush(t *testing.T) {
 	}
 	if got := db.statsCalls.Load(); got < 2 {
 		t.Fatalf("stats calls=%d want at least 2", got)
+	}
+}
+
+func TestRunBenchmark_CheckpointSettleRejectsUnknownLabel(t *testing.T) {
+	const dbName = "treedb_checkpoint_bad_settle_label_mock"
+	RegisterHiddenDB(dbName, func(dir string) (kvstore.DB, error) {
+		return &checkpointStatsDB{fixedNameDB: fixedNameDB{name: "TreeDB"}}, nil
+	})
+
+	_, err := runBenchmark(BenchConfig{
+		Keys:           1,
+		ValueSize:      1,
+		BatchSize:      1,
+		DBsArg:         dbName,
+		TestsArg:       "sequential_write",
+		KeepDir:        false,
+		Progress:       false,
+		SeedUsed:       1,
+		ReadRequireHit: false,
+
+		CheckpointBetweenTests:      true,
+		CheckpointSettleBeforeTests: map[string]struct{}{"typo_label": {}},
+	})
+	if err == nil || !strings.Contains(err.Error(), "unknown checkpoint settle label") {
+		t.Fatalf("runBenchmark error=%v, want unknown checkpoint settle label", err)
 	}
 }
 

--- a/cmd/unified_bench/main_test.go
+++ b/cmd/unified_bench/main_test.go
@@ -209,6 +209,16 @@ type closeStatsDB struct {
 	closed        atomic.Bool
 }
 
+type checkpointStatsDB struct {
+	fixedNameDB
+	checkpointCalls atomic.Int64
+}
+
+type activeFlushStatsDB struct {
+	fixedNameDB
+	statsCalls atomic.Int64
+}
+
 func (d *closeStatsDB) Name() string { return d.name }
 
 func (d *closeStatsDB) Close() error {
@@ -243,6 +253,41 @@ func (d *closeStatsDB) Stats() map[string]string {
 	}
 	stats["treedb.publish.ordered_root_delta_group.root_apply_calls_total"] = "0"
 	return stats
+}
+
+func (d *checkpointStatsDB) Checkpoint() error {
+	d.checkpointCalls.Add(1)
+	return nil
+}
+
+func (d *checkpointStatsDB) Stats() map[string]string {
+	calls := d.checkpointCalls.Load()
+	return map[string]string{
+		"treedb.cache.queue_len":                                                       "0",
+		"treedb.cache.queue_backlog_bytes":                                             "0",
+		"treedb.cache.flush_apply.coordinator.active_workers":                          "0",
+		"treedb.cache.flush_apply.coordinator.in_flight_bytes":                         "0",
+		"treedb.cache.checkpoint.active_background_flush_wait_ns_last":                 fmt.Sprintf("%d", calls*10),
+		"treedb.cache.checkpoint.wait.frontier_units_at_request_last":                  fmt.Sprintf("%d", calls),
+		"treedb.cache.checkpoint.stage.flush_all.total_ns":                             fmt.Sprintf("%d", calls*100),
+		"treedb.flush_apply.span_native.fallback.reason.close_or_checkpoint.ops_total": fmt.Sprintf("%d", calls),
+	}
+}
+
+func (d *activeFlushStatsDB) Stats() map[string]string {
+	calls := d.statsCalls.Add(1)
+	activeWorkers := "0"
+	inFlightBytes := "0"
+	if calls == 1 {
+		activeWorkers = "1"
+		inFlightBytes = "1024"
+	}
+	return map[string]string{
+		"treedb.cache.queue_len":                               "0",
+		"treedb.cache.queue_backlog_bytes":                     "0",
+		"treedb.cache.flush_apply.coordinator.active_workers":  activeWorkers,
+		"treedb.cache.flush_apply.coordinator.in_flight_bytes": inFlightBytes,
+	}
 }
 
 type settleProbeDB struct {
@@ -1861,6 +1906,86 @@ func TestRunBenchmark_CheckpointBetweenTests_RunsFinalCheckpoint(t *testing.T) {
 	}
 	if _, ok := run.CheckpointDurations[checkpointPostRunLabel]; !ok {
 		t.Fatalf("expected post-run checkpoint durations under %q", checkpointPostRunLabel)
+	}
+}
+
+func TestRunBenchmark_CheckpointSettleAndStatsSnapshots(t *testing.T) {
+	const dbName = "treedb_checkpoint_stats_mock"
+	RegisterHiddenDB(dbName, func(dir string) (kvstore.DB, error) {
+		return &checkpointStatsDB{fixedNameDB: fixedNameDB{name: "TreeDB"}}, nil
+	})
+
+	run, err := runBenchmark(BenchConfig{
+		Keys:           1,
+		ValueSize:      1,
+		BatchSize:      1,
+		DBsArg:         dbName,
+		TestsArg:       "sequential_write,random_read",
+		KeepDir:        false,
+		Progress:       false,
+		SeedUsed:       1,
+		ReadRequireHit: false,
+
+		CheckpointBetweenTests:      true,
+		CheckpointSettleBeforeTests: map[string]struct{}{"random_read": {}},
+		CheckpointSettleTimeout:     100 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("runBenchmark: %v", err)
+	}
+	if _, ok := run.CheckpointSettleDurations["random_read"]["TreeDB"]; !ok {
+		t.Fatalf("missing checkpoint settle duration: %#v", run.CheckpointSettleDurations)
+	}
+	randomReadStats := run.CheckpointTreeDBStats["random_read"]["TreeDB"]
+	if got := randomReadStats["treedb.cache.checkpoint.wait.frontier_units_at_request_last"]; got == "" || got == "0" {
+		t.Fatalf("missing checkpoint snapshot stats: %#v", randomReadStats)
+	}
+	if got := randomReadStats["treedb.cache.checkpoint.active_background_flush_wait_ns_last"]; got == "" || got == "0" {
+		t.Fatalf("missing checkpoint wait last stat: %#v", randomReadStats)
+	}
+
+	md := renderMarkdownSingle(run)
+	if !strings.Contains(md, "## Checkpoint Settle Time (Before Selected Checkpoints)") {
+		t.Fatalf("missing checkpoint settle markdown section:\n%s", md)
+	}
+	if !strings.Contains(md, "## TreeDB Selected Stats (Checkpoint Snapshots)") {
+		t.Fatalf("missing checkpoint stats markdown section:\n%s", md)
+	}
+
+	dir := t.TempDir()
+	if err := writeBenchprofArtifacts(dir, "native-fastpath", []BenchRun{run}); err != nil {
+		t.Fatalf("writeBenchprofArtifacts: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "benchprof_results.json"))
+	if err != nil {
+		t.Fatalf("read benchprof_results.json: %v", err)
+	}
+	var parsed benchprofExport
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("parse benchprof_results.json: %v", err)
+	}
+	if len(parsed.Runs) != 1 {
+		t.Fatalf("runs=%d want 1", len(parsed.Runs))
+	}
+	if _, ok := parsed.Runs[0].CheckpointSettleSeconds["random_read"]["TreeDB"]; !ok {
+		t.Fatalf("missing exported settle seconds: %#v", parsed.Runs[0].CheckpointSettleSeconds)
+	}
+	if got := parsed.Runs[0].CheckpointTreeDBStats["random_read"]["TreeDB"]["treedb.cache.checkpoint.wait.frontier_units_at_request_last"]; got == "" || got == "0" {
+		t.Fatalf("missing exported checkpoint stats: %#v", parsed.Runs[0].CheckpointTreeDBStats)
+	}
+}
+
+func TestWaitForTreeDBQueueDrainInstanceWaitsForActiveFlush(t *testing.T) {
+	db := &activeFlushStatsDB{fixedNameDB: fixedNameDB{name: "TreeDB"}}
+	_, settled, err := waitForTreeDBQueueDrainInstance(&DBInstance{Name: "treedb", Wrapper: db}, 200*time.Millisecond)
+	if err != nil {
+		t.Fatalf("waitForTreeDBQueueDrainInstance: %v", err)
+	}
+	if !settled {
+		t.Fatalf("settled=false want true")
+	}
+	if got := db.statsCalls.Load(); got < 2 {
+		t.Fatalf("stats calls=%d want at least 2", got)
 	}
 }
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -66,6 +66,7 @@ Behavioral guarantees for downstream systems (e.g., replication layers).
 - **[TreeDB Vector Search Closeout](../TreeDB/docs/spec/vector-search-closeout-2483.md)**: Exact FP32, scalar_u8, RaBitQ, and BRQ route-boundary/evidence index with #2487 snapshot caveats and #2494 crossover-pending status.
 - **[Unified Bench](../cmd/unified_bench/README.md)**: Usage guide for benchmark execution and artifact capture.
 - **[BenchProf](../cmd/benchprof/README.md)**: Analysis tool for CPU/alloc/block/mutex profiles and ops/sec outputs.
+- **[TreeDB Checkpoint Wait Classification M1](TREEDB_CHECKPOINT_WAIT_CLASSIFICATION_M1_REPORT.md)**: #2946 immediate/settled checkpoint wait classification and artifact table.
 - **[Redis Protocol Benchmarking](REDIS_PROTOCOL_BENCHMARKING.md)**: Preferred way to measure Redis wrapper throughput.
 - **[Dev Notes](DEV_NOTES.md)**: Performance investigations and future optimization ideas.
 

--- a/docs/TREEDB_CHECKPOINT_WAIT_CLASSIFICATION_M1_REPORT.md
+++ b/docs/TREEDB_CHECKPOINT_WAIT_CLASSIFICATION_M1_REPORT.md
@@ -1,7 +1,7 @@
 # TreeDB Checkpoint Wait Classification M1 Report
 
-Issue: [#2946](https://github.com/snissn/gomap/issues/2946)  
-Parent tracker: [#2943](https://github.com/snissn/gomap/issues/2943)  
+Issue: [#2946](https://github.com/snissn/gomap/issues/2946)
+Parent tracker: [#2943](https://github.com/snissn/gomap/issues/2943)
 Root parents: [#2916](https://github.com/snissn/gomap/issues/2916) / [#2899](https://github.com/snissn/gomap/issues/2899)
 
 ## Verdict
@@ -42,8 +42,11 @@ report does not claim parent closure.
 
 - Evidence root: `/tmp/gomap_2946_checkpoint_wait_20260623_122739`
 - Evidence head SHA: `a7f1f9cb11cd939bec6a28d6c2caa6d76e9acd65`
-- Base SHA: `4613e89013a7708413185dedbf0bbb89025577a1` (`origin/main`, includes
+- Evidence base SHA: `4613e89013a7708413185dedbf0bbb89025577a1` (`origin/main`, includes
   #2945/#2949 and #2950)
+- Branch was later rebased onto `8d430e1b4e6e837f10c09db7bbb2b6a341768e64`
+  (PR #2962 / #2947) without rerunning the full matrix, per coordinator
+  direction.
 - Host: `mikers-B560-DS3H-AC-Y1`
 - CPU: Intel i5-11400F, 6 cores / 12 threads (`nproc=12`)
 - OS: Linux `6.8.0-124-generic` x86_64

--- a/docs/TREEDB_CHECKPOINT_WAIT_CLASSIFICATION_M1_REPORT.md
+++ b/docs/TREEDB_CHECKPOINT_WAIT_CLASSIFICATION_M1_REPORT.md
@@ -1,0 +1,186 @@
+# TreeDB Checkpoint Wait Classification M1 Report
+
+Issue: [#2946](https://github.com/snissn/gomap/issues/2946)  
+Parent tracker: [#2943](https://github.com/snissn/gomap/issues/2943)  
+Root parents: [#2916](https://github.com/snissn/gomap/issues/2916) / [#2899](https://github.com/snissn/gomap/issues/2899)
+
+## Verdict
+
+Classification: **productive checkpoint debt drain**.
+
+The immediate c4/c8/c16 checkpoint rows all show `active_background_flush_wait`
+draining the full pre-checkpoint frontier visible at request time. Total wall for
+`random_write + checkpoint` is not worse than `random_write + settle + checkpoint`
+for the same c4/c8/c16 shape. There is no close/checkpoint span-native fallback
+and no post-frontier queue debt in these checkpoint snapshots.
+
+Action: **do not open a checkpoint handoff/ownership implementation issue from
+this milestone**. The wait is real wall time, but the counters classify it as
+background workers already draining checkpoint-relevant debt, not idle
+coordination loss. Keep #2916/#2899 open for the broader parent gates; this
+report does not claim parent closure.
+
+## Scope And Harness Notes
+
+- Production checkpoint ownership/coordinator behavior was not changed.
+- This PR adds benchmark-only/reporting support to preserve checkpoint-local
+  TreeDB stats under `benchprof_results.json` and to optionally wait before a
+  selected checkpoint row. That was needed because end-of-run stats can be
+  overwritten by later no-op checkpoints.
+- The `settled` rows used `-checkpoint-settle-before-tests=random_read`, which
+  waits for TreeDB queue/backlog and active in-flight counters to become idle
+  before the `random_read` checkpoint. On this host, c8/c16 still sometimes had
+  a new active worker by the time checkpoint requested `flushMu`; those rows are
+  therefore treated as partially settled harness rows, not proof that active wait
+  can be eliminated. They still support the classification because the active
+  wait drains all visible frontier debt and total wall is not worse.
+- A redundant later run root, `/tmp/gomap_2946_checkpoint_wait_20260623_124218`,
+  was stopped and is intentionally ignored. The complete evidence root is the
+  one listed below.
+
+## Evidence Identity
+
+- Evidence root: `/tmp/gomap_2946_checkpoint_wait_20260623_122739`
+- Evidence head SHA: `a7f1f9cb11cd939bec6a28d6c2caa6d76e9acd65`
+- Base SHA: `4613e89013a7708413185dedbf0bbb89025577a1` (`origin/main`, includes
+  #2945/#2949 and #2950)
+- Host: `mikers-B560-DS3H-AC-Y1`
+- CPU: Intel i5-11400F, 6 cores / 12 threads (`nproc=12`)
+- OS: Linux `6.8.0-124-generic` x86_64
+- Host notes/artifacts: `manifest.txt`, `lscpu.txt`, `uname.txt` in the evidence
+  root.
+
+All substantial benchmark commands were run under:
+
+```sh
+flock /tmp/gomap_diag_bench.lock -c '<benchmark command>'
+```
+
+Command template:
+
+```sh
+./bin/unified-bench \
+  -dbs treedb \
+  -test sequential_write,batch_random,random_write,random_read \
+  -keys 10000000 -valsize 128 -batchsize 8000 \
+  -checkpoint-between-tests \
+  -treedb-flush-admission-policy=explicit \
+  -treedb-flush-apply-span-native \
+  -treedb-flush-backlog-coalescing \
+  -treedb-flush-apply-min-entries=1 \
+  -treedb-flush-apply-min-spans=1 \
+  -treedb-flush-apply-min-bytes=1 \
+  -treedb-flush-apply-concurrency=<4|8|16> \
+  -profile-dir <row-dir> \
+  -path-label m8-m14-10mm-gate \
+  -read-require-hit \
+  -progress=false
+```
+
+Settled rows additionally used:
+
+```sh
+-checkpoint-settle-before-tests=random_read -checkpoint-settle-timeout=10m
+```
+
+Each row directory contains `command.txt`, `run.log`, `benchprof_results.json`,
+`benchprof_results.md`, `insights.{md,json,html}`, CPU/alloc profiles,
+checkpoint CPU profiles, block/mutex profiles, and `trace.out`.
+
+## Total-Wall Rows
+
+`write wall` is computed as `10,000,000 / random_write_ops_per_sec`. `checkpoint
+wall` is the checkpoint before `random_read`, i.e. the checkpoint after the
+`random_write` phase.
+
+| c | row | random_write ops/s | write wall s | settle wall s | checkpoint wall s | total wall s | artifact |
+|---:|---|---:|---:|---:|---:|---:|---|
+| c4 | immediate | 274,088 | 36.48 | 0.00 | 9.21 | 45.69 | `/tmp/gomap_2946_checkpoint_wait_20260623_122739/immediate_c4` |
+| c4 | settled | 250,018 | 40.00 | 1.91 | 6.37 | 48.28 | `/tmp/gomap_2946_checkpoint_wait_20260623_122739/settled_c4` |
+| c8 | immediate | 335,408 | 29.81 | 0.00 | 10.16 | 39.97 | `/tmp/gomap_2946_checkpoint_wait_20260623_122739/immediate_c8` |
+| c8 | settled | 348,151 | 28.72 | 3.95 | 6.91 | 39.59 | `/tmp/gomap_2946_checkpoint_wait_20260623_122739/settled_c8` |
+| c16 | immediate | 355,888 | 28.10 | 0.00 | 10.68 | 38.78 | `/tmp/gomap_2946_checkpoint_wait_20260623_122739/immediate_c16` |
+| c16 | settled | 314,057 | 31.84 | 0.005 | 7.17 | 39.02 | `/tmp/gomap_2946_checkpoint_wait_20260623_122739/settled_c16` |
+
+Immediate-vs-settled total comparison:
+
+| c | immediate total s | settled total s | immediate - settled s | interpretation |
+|---:|---:|---:|---:|---|
+| c4 | 45.69 | 48.28 | -2.58 | immediate is faster/equal |
+| c8 | 39.97 | 39.59 | +0.39 | similar within run noise |
+| c16 | 38.78 | 39.02 | -0.23 | immediate is faster/equal |
+
+## Checkpoint Productivity Counters
+
+The key signal is whether active wait drains checkpoint-relevant frontier debt.
+All immediate rows drained the full frontier captured at request. c8/c16 have no
+checkpoint-owned drain because the frontier was already gone by the time
+checkpoint owned the drain path.
+
+| c | row | debt at request units / MiB | active workers / frontier lanes at request | drained during active wait units / MiB / lanes | wait drain MiB/s | checkpoint-owned drain units / MiB | checkpoint-owned MiB/s | productive wait ratio |
+|---:|---|---:|---:|---:|---:|---:|---:|---:|
+| c4 | immediate | 32 / 128.00 | 1 / 1 | 32 / 128.00 / 1 | 34.81 | 16 / 16.91 | 3.10 | 11.24 |
+| c4 | settled | 0 / 0.00 | 0 / 0 | 0 / 0.00 / 0 | 0.00 | 16 / 16.97 | 2.69 | 0.00 |
+| c8 | immediate | 16 / 16.96 | 1 / 1 | 16 / 16.96 / 1 | 3.52 | 0 / 0.00 | 0.00 | 0.00 |
+| c8 | settled | 16 / 16.95 | 1 / 1 | 16 / 16.95 / 1 | 3.96 | 0 / 0.00 | 0.00 | 0.00 |
+| c16 | immediate | 16 / 16.96 | 1 / 1 | 16 / 16.96 / 1 | 5.60 | 0 / 0.00 | 0.00 | 0.00 |
+| c16 | settled | 16 / 16.95 | 1 / 1 | 16 / 16.95 / 1 | 2.78 | 0 / 0.00 | 0.00 | 0.00 |
+
+Notes:
+
+- `productive_wait_ratio=0` in c8/c16 is a denominator artifact: the checkpoint
+  owned no frontier bytes after active wait, so no owned-drain rate exists for a
+  ratio comparison.
+- c4 is the clean side-by-side comparison: immediate active wait drains 128 MiB
+  at 34.81 MiB/s while the later checkpoint-owned drain rate is 3.10 MiB/s.
+  That is productive, not underproductive.
+
+## Checkpoint Stage Counters
+
+`active-bg wait` is row-local (`*_last`). The public stats currently expose
+`barrier_wait`/`flushmu_wait` totals and max, not a row-local last value; for
+rows with active background wait, the row-local active wait is the relevant
+flushMu/barrier wait component.
+
+| c | row | active-bg wait s | barrier/flushMu note | flush_all s | backend_boundary s | reducer_publish s | leaf_value_log_sync s | WAL rotate s | WAL cleanup s |
+|---:|---|---:|---|---:|---:|---:|---:|---:|---:|
+| c4 | immediate | 3.68 | active wait last | 5.46 | 0.00 | 0.31 | 0.006 | 0.065 | 0.000002 |
+| c4 | settled | 0.00 | no active wait last; only max counter is run-scoped | 6.32 | 3.74 | 0.33 | 0.005 | 0.046 | 0.000002 |
+| c8 | immediate | 4.83 | active wait last | 6.13 | 0.99 | 0.33 | 0.006 | 0.087 | 0.000003 |
+| c8 | settled | 4.28 | active wait last | 6.80 | 0.36 | 0.33 | 0.006 | 0.091 | 0.000002 |
+| c16 | immediate | 3.03 | active wait last | 6.74 | 0.41 | 0.33 | 0.006 | 0.090 | 0.000002 |
+| c16 | settled | 6.09 | active wait last | 7.07 | 1.22 | 0.34 | 0.006 | 0.091 | 0.000002 |
+
+## Fallback And Post-Frontier Counters
+
+| c | row | close/checkpoint fallback ops / spans | any fallback ops | checkpoint-owned workers / lanes | background drain units / MiB | wait post units / MiB | frontier post units / MiB |
+|---:|---|---:|---:|---:|---:|---:|---:|
+| c4 | immediate | 0 / 0 | 0 | 1 / 1 | 0 / 0.00 | 0 / 0.00 | 0 / 0.00 |
+| c4 | settled | 0 / 0 | 0 | 1 / 1 | 0 / 0.00 | 0 / 0.00 | 0 / 0.00 |
+| c8 | immediate | 0 / 0 | 0 | 0 / 0 | 0 / 0.00 | 0 / 0.00 | 0 / 0.00 |
+| c8 | settled | 0 / 0 | 0 | 0 / 0 | 0 / 0.00 | 0 / 0.00 | 0 / 0.00 |
+| c16 | immediate | 0 / 0 | 0 | 0 / 0 | 0 / 0.00 | 0 / 0.00 | 0 / 0.00 |
+| c16 | settled | 0 / 0 | 0 | 0 / 0 | 0 / 0.00 | 0 / 0.00 | 0 / 0.00 |
+
+All span-native fallback reason `ops_total` counters were zero in these
+checkpoint snapshots, including `close_or_checkpoint`.
+
+## Classification Against #2946 Rules
+
+| Rule | Evidence | Result |
+|---|---|---|
+| Productive debt drain | Active wait drains all request frontier in immediate c4/c8/c16. Total wall immediate is equal/faster than settled for c4/c16 and within 0.39s for c8. | **Pass** |
+| Underproductive wait | Would require wait to drain much slower or with fewer lanes/workers than checkpoint-owned drain. c4 shows wait rate above owned drain; c8/c16 leave no owned drain to compare. | Not supported |
+| Wasteful wait | Would require large active wait with little checkpoint-relevant drain. All immediate waits drain the full visible frontier. | Not supported |
+| Harness/noise | c8/c16 settled rows are only partially settled, but the immediate rows and total-wall comparison are consistent enough for this classification. | Caveat, not blocker |
+
+## Follow-Up Guidance
+
+- Do not pursue a checkpoint ownership/coordinator PR just to move
+  `active_background_flush_wait` into `flush_all`; #2946 evidence says that would
+  mostly relabel productive debt drain.
+- If a future decision needs a strictly quiescent settled row, make the harness
+  require a stable idle window for queue/backlog/active in-flight counters before
+  the settled checkpoint. That is not needed to classify #2946.
+- Continue #2943 through apply/hardware-ceiling and branch-selection gates. Do
+  not close #2916/#2899 based on this report alone.


### PR DESCRIPTION
## Objective

Close #2946 with a measurement/report-only classification of TreeDB checkpoint `active_background_flush_wait` after the #2945 productivity counters.

Closes #2946. Updates parent tracker context for #2943 / #2916; does **not** close #2916 or #2899.

## Verdict

Classification: **productive checkpoint debt drain**.

Immediate c4/c8/c16 checkpoint rows all show active wait draining the full pre-checkpoint frontier visible at request time. Total wall for `random_write + checkpoint` is equal/faster than or within noise of `random_write + settle + checkpoint`. Close/checkpoint span-native fallback remains zero.

## Scope

Includes:
- benchmark-only support for `-checkpoint-settle-before-tests` and checkpoint-local TreeDB stat snapshots in `benchprof_results.json`;
- docs for the new benchmark/reporting fields;
- `docs/TREEDB_CHECKPOINT_WAIT_CLASSIFICATION_M1_REPORT.md` with the evidence table and classification.

Excludes:
- no production checkpoint ownership/coordinator changes;
- no TreeDB on-disk format change;
- no claim that #2916/#2899 are closed.

## Evidence

Evidence root: `/tmp/gomap_2946_checkpoint_wait_20260623_122739`

Evidence identity:
- evidence head: `a7f1f9cb11cd939bec6a28d6c2caa6d76e9acd65`
- evidence base: `4613e89013a7708413185dedbf0bbb89025577a1`
- current PR head rebased onto latest `origin/main` after #2947/#2962 merge
- host: `mikers-B560-DS3H-AC-Y1`, Intel i5-11400F, 6c/12t, Linux 6.8

Rows/artifacts:
- c4 immediate: `/tmp/gomap_2946_checkpoint_wait_20260623_122739/immediate_c4`
- c4 settled: `/tmp/gomap_2946_checkpoint_wait_20260623_122739/settled_c4`
- c8 immediate: `/tmp/gomap_2946_checkpoint_wait_20260623_122739/immediate_c8`
- c8 settled: `/tmp/gomap_2946_checkpoint_wait_20260623_122739/settled_c8`
- c16 immediate: `/tmp/gomap_2946_checkpoint_wait_20260623_122739/immediate_c16`
- c16 settled: `/tmp/gomap_2946_checkpoint_wait_20260623_122739/settled_c16`

Each row has `command.txt`, `run.log`, `benchprof_results.json/md`, `insights.{md,json,html}`, CPU/alloc/checkpoint CPU/block/mutex profiles, and `trace.out`.

## Tests / validation

Latest-head local validation:

```sh
git diff --check origin/main...HEAD
GOWORK=off go test ./cmd/unified_bench ./cmd/benchprof ./TreeDB/caching -run 'TestRunBenchmark_CheckpointSettleAndStatsSnapshots|TestWaitForTreeDBQueueDrainInstanceWaitsForActiveFlush|TestCheckpointWaitProductivityStats' -count=1
```

Additional validation run earlier on the same branch shape:

```sh
go test ./cmd/unified_bench -count=1
go test ./cmd/benchprof ./cmd/internal/treedbstats -count=1
go test ./TreeDB/caching -run 'TestFlushApplyStats|TestCheckpointWaitProductivityStats' -count=1
```

## AI review status

Not requested yet at PR creation time; PR is ready for latest-head AI review after CI starts.

## Caveats

The c8/c16 settled rows are documented as partially settled harness rows because a new active worker could appear by checkpoint request time. This does not change the classification: the active wait drains all visible frontier debt and total wall does not prove wasteful coordination loss.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added checkpoint settle functionality to benchmark runner with new `-checkpoint-settle-before-tests` and `-checkpoint-settle-timeout` flags to wait for background queue draining before durability checkpoints.
  * Benchmark results now capture and export checkpoint settle durations and TreeDB checkpoint snapshot statistics.

* **Documentation**
  * Updated benchmark documentation with new checkpoint settle flags and checkpoint timing/statistics fields.
  * Added TreeDB Checkpoint Wait Classification M1 Report detailing checkpoint behavior analysis and benchmark evidence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Latest-head update after #2951 merge and review fixes

After #2951 PR #2961 merged, coordinator merged latest `origin/main` (`f5eadadeaa3e06a1eadb4722714c7ead58a066e2`) into this branch and pushed head `078653c27c61af4b5f7bc2377c3100ed3dceea1c`.

Review fixes included after initial PR creation:

- moved checkpoint CPU profiling to start after optional settle waits, so `checkpoint_cpu_checkpoint_*` artifacts cover `Checkpoint()` rather than pre-checkpoint settle polling;
- rejected unknown `-checkpoint-settle-before-tests` labels instead of silently accepting typos;
- included `treedb.cache.flush_apply.coordinator.active` in settle-drain predicates;
- capped settle waits by remaining `-max-wall` budget and checked the guard before/after waits.

Latest-head validation:

```sh
git diff --check origin/main...HEAD
GOWORK=off go test ./cmd/unified_bench ./cmd/benchprof ./cmd/internal/treedbstats ./TreeDB/caching -count=1
```


## Latest review fix: checkpoint timing excludes stat snapshot overhead

After latest Codex review, head `8b5555568d749f2c9c4383b04b1227cd1ca671eda` records checkpoint duration immediately after `Checkpoint()` returns and before collecting checkpoint-local stats snapshots, for both between-test and post-run checkpoint paths.

Validation repeated:

```sh
git diff --check origin/main...HEAD
GOWORK=off go test ./cmd/unified_bench ./cmd/benchprof ./cmd/internal/treedbstats ./TreeDB/caching -count=1
```
