### PR TITLE
TreeDB: reduce span-native apply allocation churn

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -74,9 +74,7 @@ var errWALUnavailable = errors.New("cachingdb: wal unavailable")
 var iteratorDebugEnabled atomic.Bool
 
 var valueLogEligiblePool sync.Pool                  // stores []int
-var valueLogRecordPool sync.Pool                    // stores []valuelog.Record
 var valueLogKeyPool sync.Pool                       // stores [][]byte
-var valueLogPtrPool sync.Pool                       // stores []page.ValuePtr
 var batchArenaPools [batchArenaClassCount]sync.Pool // stores []byte
 var batchArenaLeasePool sync.Pool                   // stores *batchArenaLease
 var appendOnlyDirectValueArenaPools [appendOnlyDirectValueArenaClassCount]sync.Pool
@@ -89,9 +87,17 @@ var outerLeafArenaLeases [outerLeafArenaClassCount][][]byte
 var outerLeafBlobRefScratchPool sync.Pool
 var outerLeafEncoderPool sync.Pool // stores *outerleaf.Encoder
 var valueLogPreparedBodyPool sync.Pool
-var valueLogPreparedFramesPool sync.Pool     // stores []preparedDictFrame
 var valueLogDictPrepareResultsPool sync.Pool // stores chan vlogDictPrepareResult
 var valueLogFramePreparerPool sync.Pool      // stores *valuelog.FramePreparer
+var valueLogRecordLeaseMu sync.Mutex
+var valueLogRecordLeases [][]valuelog.Record
+var valueLogRecordLeaseCapTotal int
+var valueLogPtrLeaseMu sync.Mutex
+var valueLogPtrLeases [][]page.ValuePtr
+var valueLogPtrLeaseCapTotal int
+var valueLogPreparedFramesLeaseMu sync.Mutex
+var valueLogPreparedFrameLeases [][]preparedDictFrame
+var valueLogPreparedFrameLeaseCapTotal int
 var valueLogKeyLeaseMu sync.Mutex
 var valueLogKeyLeases [][][]byte
 var backendValueLogReadBarrierRegistryMu sync.Mutex
@@ -1113,9 +1119,16 @@ func noteBatchArenaPoolGC(numGC uint64) {
 }
 
 const (
-	maxValueLogKeyLeaseCount = 64
-	maxValueLogKeyLeaseCap   = 1 << 20
-	batchArenaMinShift       = 12
+	maxValueLogSliceLeaseCount            = 256
+	maxValueLogRecordLeaseCap             = 1 << 20
+	maxValueLogRecordLeaseTotalCap        = 1 << 20
+	maxValueLogPtrLeaseCap                = 1 << 20
+	maxValueLogPtrLeaseTotalCap           = 1 << 20
+	maxValueLogPreparedFrameLeaseCap      = 1 << 14
+	maxValueLogPreparedFrameLeaseTotalCap = 1 << 14
+	maxValueLogKeyLeaseCount              = 64
+	maxValueLogKeyLeaseCap                = 1 << 20
+	batchArenaMinShift                    = 12
 	// batch arenas are chunked key/value copy buffers that may be leased to
 	// memtables. Keep the max pooled chunk size modest to avoid retaining large
 	// mostly-empty tail chunks during big restore batches.
@@ -1207,6 +1220,108 @@ func putBatchInt64SliceRef(ref *batchInt64SliceRef) {
 	batchInt64SliceRefPool.Put(ref)
 }
 
+func takeValueLogRecordLease(capacity int) []valuelog.Record {
+	valueLogRecordLeaseMu.Lock()
+	for i := len(valueLogRecordLeases) - 1; i >= 0; i-- {
+		s := valueLogRecordLeases[i]
+		if cap(s) < capacity {
+			continue
+		}
+		last := len(valueLogRecordLeases) - 1
+		valueLogRecordLeases[i] = valueLogRecordLeases[last]
+		valueLogRecordLeases[last] = nil
+		valueLogRecordLeases = valueLogRecordLeases[:last]
+		valueLogRecordLeaseCapTotal -= cap(s)
+		valueLogRecordLeaseMu.Unlock()
+		return s
+	}
+	valueLogRecordLeaseMu.Unlock()
+	return nil
+}
+
+func storeValueLogRecordLease(s []valuelog.Record) bool {
+	if s == nil || cap(s) == 0 || cap(s) > maxValueLogRecordLeaseCap {
+		return false
+	}
+	valueLogRecordLeaseMu.Lock()
+	if len(valueLogRecordLeases) >= maxValueLogSliceLeaseCount || valueLogRecordLeaseCapTotal+cap(s) > maxValueLogRecordLeaseTotalCap {
+		valueLogRecordLeaseMu.Unlock()
+		return false
+	}
+	valueLogRecordLeases = append(valueLogRecordLeases, s[:0])
+	valueLogRecordLeaseCapTotal += cap(s)
+	valueLogRecordLeaseMu.Unlock()
+	return true
+}
+
+func takeValueLogPtrLease(capacity int) []page.ValuePtr {
+	valueLogPtrLeaseMu.Lock()
+	for i := len(valueLogPtrLeases) - 1; i >= 0; i-- {
+		s := valueLogPtrLeases[i]
+		if cap(s) < capacity {
+			continue
+		}
+		last := len(valueLogPtrLeases) - 1
+		valueLogPtrLeases[i] = valueLogPtrLeases[last]
+		valueLogPtrLeases[last] = nil
+		valueLogPtrLeases = valueLogPtrLeases[:last]
+		valueLogPtrLeaseCapTotal -= cap(s)
+		valueLogPtrLeaseMu.Unlock()
+		return s
+	}
+	valueLogPtrLeaseMu.Unlock()
+	return nil
+}
+
+func storeValueLogPtrLease(s []page.ValuePtr) bool {
+	if s == nil || cap(s) == 0 || cap(s) > maxValueLogPtrLeaseCap {
+		return false
+	}
+	valueLogPtrLeaseMu.Lock()
+	if len(valueLogPtrLeases) >= maxValueLogSliceLeaseCount || valueLogPtrLeaseCapTotal+cap(s) > maxValueLogPtrLeaseTotalCap {
+		valueLogPtrLeaseMu.Unlock()
+		return false
+	}
+	valueLogPtrLeases = append(valueLogPtrLeases, s[:0])
+	valueLogPtrLeaseCapTotal += cap(s)
+	valueLogPtrLeaseMu.Unlock()
+	return true
+}
+
+func takeVlogPreparedFrameLease(capacity int) []preparedDictFrame {
+	valueLogPreparedFramesLeaseMu.Lock()
+	for i := len(valueLogPreparedFrameLeases) - 1; i >= 0; i-- {
+		s := valueLogPreparedFrameLeases[i]
+		if cap(s) < capacity {
+			continue
+		}
+		last := len(valueLogPreparedFrameLeases) - 1
+		valueLogPreparedFrameLeases[i] = valueLogPreparedFrameLeases[last]
+		valueLogPreparedFrameLeases[last] = nil
+		valueLogPreparedFrameLeases = valueLogPreparedFrameLeases[:last]
+		valueLogPreparedFrameLeaseCapTotal -= cap(s)
+		valueLogPreparedFramesLeaseMu.Unlock()
+		return s
+	}
+	valueLogPreparedFramesLeaseMu.Unlock()
+	return nil
+}
+
+func storeVlogPreparedFrameLease(s []preparedDictFrame) bool {
+	if s == nil || cap(s) == 0 || cap(s) > maxValueLogPreparedFrameLeaseCap {
+		return false
+	}
+	valueLogPreparedFramesLeaseMu.Lock()
+	if len(valueLogPreparedFrameLeases) >= maxValueLogSliceLeaseCount || valueLogPreparedFrameLeaseCapTotal+cap(s) > maxValueLogPreparedFrameLeaseTotalCap {
+		valueLogPreparedFramesLeaseMu.Unlock()
+		return false
+	}
+	valueLogPreparedFrameLeases = append(valueLogPreparedFrameLeases, s[:0])
+	valueLogPreparedFrameLeaseCapTotal += cap(s)
+	valueLogPreparedFramesLeaseMu.Unlock()
+	return true
+}
+
 func getValueLogEligible(capacity int) []int {
 	if capacity < 0 {
 		capacity = 0
@@ -1236,12 +1351,8 @@ func getValueLogRecords(n int) []valuelog.Record {
 	if n < 0 {
 		n = 0
 	}
-	if v := valueLogRecordPool.Get(); v != nil {
-		if s, ok := v.([]valuelog.Record); ok {
-			if cap(s) >= n {
-				return s[:n]
-			}
-		}
+	if s := takeValueLogRecordLease(n); s != nil {
+		return s[:n]
 	}
 	return make([]valuelog.Record, n)
 }
@@ -1250,12 +1361,8 @@ func getValueLogRecordsCap(capacity int) []valuelog.Record {
 	if capacity < 0 {
 		capacity = 0
 	}
-	if v := valueLogRecordPool.Get(); v != nil {
-		if s, ok := v.([]valuelog.Record); ok {
-			if cap(s) >= capacity {
-				return s[:0]
-			}
-		}
+	if s := takeValueLogRecordLease(capacity); s != nil {
+		return s[:0]
 	}
 	return make([]valuelog.Record, 0, capacity)
 }
@@ -1268,10 +1375,10 @@ func putValueLogRecords(s []valuelog.Record) {
 		s[i] = valuelog.Record{}
 	}
 	// Avoid retaining huge slices in the pool.
-	if cap(s) > 1<<20 {
+	if cap(s) > maxValueLogRecordLeaseCap {
 		return
 	}
-	valueLogRecordPool.Put(s[:0])
+	_ = storeValueLogRecordLease(s)
 }
 
 func clearValueLogRecordValues(s []valuelog.Record) {
@@ -1288,7 +1395,7 @@ func putValueLogRecordsNoClear(s []valuelog.Record) {
 	}
 	// Avoid O(cap) clearing work for oversized slices that we intentionally
 	// drop instead of returning to the pool.
-	if cap(s) > 1<<20 {
+	if cap(s) > maxValueLogRecordLeaseCap {
 		return
 	}
 	records := s
@@ -1296,7 +1403,7 @@ func putValueLogRecordsNoClear(s []valuelog.Record) {
 		records = records[:cap(records)]
 	}
 	clearValueLogRecordValues(records)
-	valueLogRecordPool.Put(s[:0])
+	_ = storeValueLogRecordLease(s)
 }
 
 func outerLeafArenaClassForLen(capacity int) (idx int, classCap int, ok bool) {
@@ -1888,12 +1995,8 @@ func getValueLogPtrs(n int) []page.ValuePtr {
 	if n < 0 {
 		n = 0
 	}
-	if v := valueLogPtrPool.Get(); v != nil {
-		if s, ok := v.([]page.ValuePtr); ok {
-			if cap(s) >= n {
-				return s[:n]
-			}
-		}
+	if s := takeValueLogPtrLease(n); s != nil {
+		return s[:n]
 	}
 	return make([]page.ValuePtr, n)
 }
@@ -1902,15 +2005,13 @@ func getValueLogPtrsCap(capacity int) []page.ValuePtr {
 	if capacity < 0 {
 		capacity = 0
 	}
-	if v := valueLogPtrPool.Get(); v != nil {
-		if s, ok := v.([]page.ValuePtr); ok {
-			maxCap := capacity * 2
-			if maxCap < 256 {
-				maxCap = 256
-			}
-			if cap(s) >= capacity && cap(s) <= maxCap {
-				return s[:0]
-			}
+	if s := takeValueLogPtrLease(capacity); s != nil {
+		maxCap := capacity * 2
+		if maxCap < 256 {
+			maxCap = 256
+		}
+		if cap(s) <= maxCap {
+			return s[:0]
 		}
 	}
 	return make([]page.ValuePtr, 0, capacity)
@@ -1926,10 +2027,10 @@ func putValueLogPtrsNoClear(s []page.ValuePtr) {
 	}
 	// page.ValuePtr contains no pointer fields, so we can safely skip element
 	// clearing in hot paths to reduce memclr overhead.
-	if cap(s) > 1<<20 {
+	if cap(s) > maxValueLogPtrLeaseCap {
 		return
 	}
-	valueLogPtrPool.Put(s[:0])
+	_ = storeValueLogPtrLease(s)
 }
 
 func getValueLogKeys(capacity int) [][]byte {
@@ -2004,12 +2105,8 @@ func getVlogPreparedFrames(n int) []preparedDictFrame {
 	if n < 0 {
 		n = 0
 	}
-	if v := valueLogPreparedFramesPool.Get(); v != nil {
-		if s, ok := v.([]preparedDictFrame); ok {
-			if cap(s) >= n {
-				return s[:n]
-			}
-		}
+	if s := takeVlogPreparedFrameLease(n); s != nil {
+		return s[:n]
 	}
 	return make([]preparedDictFrame, n)
 }
@@ -2022,7 +2119,7 @@ func putVlogPreparedFrames(frames []preparedDictFrame) {
 	if cap(frames) > maxVlogPreparedFramesPoolCap {
 		return
 	}
-	valueLogPreparedFramesPool.Put(frames[:0])
+	_ = storeVlogPreparedFrameLease(frames)
 }
 
 func getVlogFramePreparer() *valuelog.FramePreparer {
@@ -15019,6 +15116,44 @@ func releasePreparedDictFrames(frames []preparedDictFrame) {
 	}
 }
 
+func (db *DB) prepareAppendFrameOne(
+	rid uint64,
+	value []byte,
+	writeMode vlogCompressionWriteMode,
+	blockCodec valuelog.BlockCodec,
+	ioNsPerStoredByte float64,
+	encodeNsPerRawByte float64,
+	safetyMargin float64,
+) (preparedDictFrame, int64, error) {
+	blockCompression := writeMode == vlogWriteBlock
+	if !blockCompression {
+		return preparedDictFrame{}, 0, nil
+	}
+	prepStart := time.Now()
+	preparer := getVlogFramePreparer()
+	preparer.SetDictFrameEncoderOptions(db.valueLogDictFrameEncodeLevel, db.valueLogDictFrameEnableEntropy)
+	preparer.SetBlockCompression(blockCodec, true)
+	preparer.SetKeepPolicy(ioNsPerStoredByte, encodeNsPerRawByte, safetyMargin)
+	preparer.SetEncodeSampleStride(0)
+	bodyBuf := getVlogPreparedFrameBody()
+	var rec [1]valuelog.Record
+	rec[0] = valuelog.Record{RID: rid, Value: value}
+	body, stats, err := preparer.PrepareFrameInto(bodyBuf.buf[:0], 0, nil, rec[:])
+	putVlogFramePreparer(preparer)
+	if err != nil {
+		putVlogPreparedFrameBody(bodyBuf)
+		return preparedDictFrame{}, time.Since(prepStart).Nanoseconds(), err
+	}
+	bodyBuf.buf = body
+	return preparedDictFrame{
+		start:   0,
+		end:     1,
+		body:    body,
+		bodyBuf: bodyBuf,
+		stats:   stats,
+	}, time.Since(prepStart).Nanoseconds(), nil
+}
+
 func (db *DB) valueLogKeepPolicy() (ioNsPerStoredByte, encodeNsPerRawByte, safetyMargin float64) {
 	safetyMargin = db.valueLogAutotuneSafetyMargin()
 	if db.valueLogAutotuneOptions.Mode == valuelog.AutotuneOff {
@@ -16222,29 +16357,22 @@ func (db *DB) appendValueLogOneInternal(l *lane, dictID uint64, dict []byte, rid
 		}
 	}
 
-	var preparedOneFrames []preparedDictFrame
+	var preparedOneFrame preparedDictFrame
 	var preparedOnePrepNs int64
 	if leafLogAppend && finalWriteMode == vlogWriteBlock && db.flushApplyConcurrency > 1 {
-		var rec [1]valuelog.Record
-		rec[0] = valuelog.Record{RID: rid, Value: value}
 		keepIoNs, keepEncodeNs, keepSafety := db.valueLogKeepPolicy()
 		if forceBlockCompressionAttempt {
 			keepIoNs = 0
 			keepEncodeNs = 0
 		}
-		prepared, prepNs, prepErr := db.prepareAppendFrames(
-			l,
-			0,
-			nil,
-			rec[:],
-			1,
-			len(value),
+		prepared, prepNs, prepErr := db.prepareAppendFrameOne(
+			rid,
+			value,
 			finalWriteMode,
 			finalBlockCodec,
 			keepIoNs,
 			keepEncodeNs,
 			keepSafety,
-			wallStart,
 		)
 		if prepErr != nil {
 			return page.ValuePtr{}, "", prepErr
@@ -16253,16 +16381,13 @@ func (db *DB) appendValueLogOneInternal(l *lane, dictID uint64, dict []byte, rid
 		if prepNs > 0 {
 			db.observeFlushApplyLeafLogEncodeCompress(time.Duration(prepNs))
 		}
-		if len(prepared) > 0 {
-			preparedOneFrames = prepared
-			defer func() {
-				releasePreparedDictFrames(preparedOneFrames)
-				putVlogPreparedFrames(preparedOneFrames)
-			}()
-		}
+		preparedOneFrame = prepared
 	}
 
 	if allowQueue && db.shouldQueueValueLogOne(l, dictID, len(value), durability, finalWriteMode, wallStart) {
+		if preparedOneFrame.bodyBuf != nil {
+			releasePreparedDictFrame(&preparedOneFrame)
+		}
 		if dictID == 0 && !l.vlogQueueing.Load() && l.vlogMu.TryLock() {
 			if err := db.ensureValueLogWriterMuHeld(l); err != nil {
 				l.vlogMu.Unlock()
@@ -16444,21 +16569,33 @@ func (db *DB) appendValueLogOneInternal(l *lane, dictID uint64, dict []byte, rid
 	}
 	if err := db.ensureValueLogWriterMuHeld(l); err != nil {
 		l.vlogMu.Unlock()
+		if preparedOneFrame.bodyBuf != nil {
+			releasePreparedDictFrame(&preparedOneFrame)
+		}
 		return page.ValuePtr{}, "", err
 	}
 	w := l.vlog
 	if w == nil {
 		l.vlogMu.Unlock()
+		if preparedOneFrame.bodyBuf != nil {
+			releasePreparedDictFrame(&preparedOneFrame)
+		}
 		return page.ValuePtr{}, "", errWALUnavailable
 	}
 	if rotateErr := db.rotateValueLogForMaxSegmentMuHeld(l, w); rotateErr != nil {
 		l.vlogMu.Unlock()
+		if preparedOneFrame.bodyBuf != nil {
+			releasePreparedDictFrame(&preparedOneFrame)
+		}
 		return page.ValuePtr{}, "", rotateErr
 	}
 	// Reload writer in case rotation replaced l.vlog.
 	w = l.vlog
 	if w == nil {
 		l.vlogMu.Unlock()
+		if preparedOneFrame.bodyBuf != nil {
+			releasePreparedDictFrame(&preparedOneFrame)
+		}
 		return page.ValuePtr{}, "", errWALUnavailable
 	}
 	if l.vlogCaps.writer != w {
@@ -16473,7 +16610,10 @@ func (db *DB) appendValueLogOneInternal(l *lane, dictID uint64, dict []byte, rid
 	startSize := w.Size()
 	flushedBoundary := false
 	syncedBoundary := false
-	usePreparedOneFrame := len(preparedOneFrames) == 1 && caps.prepared != nil
+	usePreparedOneFrame := preparedOneFrame.bodyBuf != nil && caps.prepared != nil
+	if preparedOneFrame.bodyBuf != nil && caps.prepared == nil {
+		releasePreparedDictFrame(&preparedOneFrame)
+	}
 
 	if !usePreparedOneFrame {
 		applyValueLogOneKeepPolicy(policySetter)
@@ -16484,16 +16624,22 @@ func (db *DB) appendValueLogOneInternal(l *lane, dictID uint64, dict []byte, rid
 
 	stats := valuelog.FrameStats{Records: 1, RawPayloadBytes: len(value), StoredPayloadBytes: len(value)}
 	if usePreparedOneFrame {
-		pf := &preparedOneFrames[0]
+		pf := &preparedOneFrame
 		stats = pf.stats
-		var ptrScratch [1]page.ValuePtr
-		ptrs, frameErr := caps.prepared.AppendEncodedFrameInto(pf.body, pf.stats.Records, ptrScratch[:])
-		if frameErr != nil {
-			err = frameErr
-		} else if len(ptrs) != 1 {
-			err = fmt.Errorf("cachingdb: value-log wrote %d ptrs for 1 prepared record", len(ptrs))
+		if oneAppender, ok := w.(interface {
+			AppendEncodedFrameOne([]byte) (page.ValuePtr, error)
+		}); ok && pf.stats.Records == 1 {
+			ptr, err = oneAppender.AppendEncodedFrameOne(pf.body)
 		} else {
-			ptr = ptrs[0]
+			var ptrScratch [1]page.ValuePtr
+			ptrs, frameErr := caps.prepared.AppendEncodedFrameInto(pf.body, pf.stats.Records, ptrScratch[:])
+			if frameErr != nil {
+				err = frameErr
+			} else if len(ptrs) != 1 {
+				err = fmt.Errorf("cachingdb: value-log wrote %d ptrs for 1 prepared record", len(ptrs))
+			} else {
+				ptr = ptrs[0]
+			}
 		}
 		releasePreparedDictFrame(pf)
 	} else if finalWriteMode == vlogWriteBlock {

--- a/TreeDB/caching/vlog_prepared_allocs_test.go
+++ b/TreeDB/caching/vlog_prepared_allocs_test.go
@@ -1,0 +1,140 @@
+package caching
+
+import (
+	"testing"
+	"time"
+
+	"github.com/snissn/gomap/TreeDB/internal/valuelog"
+	"github.com/snissn/gomap/TreeDB/page"
+)
+
+func newPreparedAppendAllocTestLog(tb testing.TB) (*DB, *cachingLeafPageLog) {
+	tb.Helper()
+	clock := valuelog.NewVirtualClock(time.Unix(0, 0))
+	sink := &valuelog.VirtualSink{Clock: clock}
+	fileID, err := valuelog.EncodeFileID(uint32(leafLogLaneID), 1)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	writer := valuelog.NewWriterWithSink(sink, fileID)
+	writer.SetEncodeSampleStride(0)
+	db := &DB{
+		closeCh:                    make(chan struct{}),
+		indexOuterLeavesInValueLog: true,
+		valueLogCompressionMode:    uint8(vlogCompressionBlock),
+		valueLogBlockCodec:         valuelog.BlockCodecLZ4,
+		flushApplyConcurrency:      2,
+		valueLogAutotuneOptions:    valuelog.AutotuneOptions{Mode: valuelog.AutotuneOff},
+	}
+	db.leafLog = lane{id: leafLogLaneID, vlog: writer, vlogSeq: 1}
+	return db, &cachingLeafPageLog{db: db, lane: &db.leafLog}
+}
+
+func BenchmarkAppendPreparedLeafPageAllocs(b *testing.B) {
+	_, log := newPreparedAppendAllocTestLog(b)
+	leafPage := make([]byte, page.PageSize)
+	payload := make([]byte, 256)
+	for i := range payload {
+		payload[i] = byte(i)
+	}
+	if _, err := log.AppendPreparedLeafPage(leafPage, payload); err != nil {
+		b.Fatal(err)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := log.AppendPreparedLeafPage(leafPage, payload); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func preparedLeafBatchFixture(n int) ([][]byte, [][]byte) {
+	leafPages := make([][]byte, n)
+	payloads := make([][]byte, n)
+	for i := 0; i < n; i++ {
+		leafPages[i] = make([]byte, page.PageSize)
+		payloads[i] = make([]byte, 256)
+		payloads[i][0] = byte(i)
+	}
+	return leafPages, payloads
+}
+
+func TestAppendPreparedLeafPageAllocsBudget(t *testing.T) {
+	if testRaceEnabled {
+		t.Skip("AllocsPerRun is not stable under -race")
+	}
+	_, log := newPreparedAppendAllocTestLog(t)
+	leafPage := make([]byte, page.PageSize)
+	payload := make([]byte, 256)
+	if _, err := log.AppendPreparedLeafPage(leafPage, payload); err != nil {
+		t.Fatal(err)
+	}
+	allocs := testing.AllocsPerRun(1000, func() {
+		if _, err := log.AppendPreparedLeafPage(leafPage, payload); err != nil {
+			t.Fatal(err)
+		}
+	})
+	if allocs > 0 {
+		t.Fatalf("AppendPreparedLeafPage steady-state allocs = %.2f, want 0", allocs)
+	}
+}
+
+func TestAppendPreparedLeafPageChildRefsAllocsBudget(t *testing.T) {
+	if testRaceEnabled {
+		t.Skip("AllocsPerRun is not stable under -race")
+	}
+	_, log := newPreparedAppendAllocTestLog(t)
+	leafPages, payloads := preparedLeafBatchFixture(128)
+	refs := make([]page.ChildRef, 0, len(leafPages))
+	if _, err := log.AppendPreparedLeafPageChildRefs(leafPages, payloads, refs); err != nil {
+		t.Fatal(err)
+	}
+	allocs := testing.AllocsPerRun(1000, func() {
+		out, err := log.AppendPreparedLeafPageChildRefs(leafPages, payloads, refs)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(out) != len(leafPages) {
+			t.Fatalf("refs len=%d want %d", len(out), len(leafPages))
+		}
+	})
+	if allocs > 0 {
+		t.Fatalf("AppendPreparedLeafPageChildRefs steady-state allocs = %.2f, want 0", allocs)
+	}
+}
+
+func BenchmarkAppendPreparedLeafPagesAllocs(b *testing.B) {
+	_, log := newPreparedAppendAllocTestLog(b)
+	leafPages, payloads := preparedLeafBatchFixture(128)
+	if _, err := log.AppendPreparedLeafPages(leafPages, payloads); err != nil {
+		b.Fatal(err)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		ptrs, err := log.AppendPreparedLeafPages(leafPages, payloads)
+		if err != nil {
+			b.Fatal(err)
+		}
+		_ = ptrs
+	}
+}
+
+func BenchmarkAppendPreparedLeafPageChildRefsAllocs(b *testing.B) {
+	_, log := newPreparedAppendAllocTestLog(b)
+	leafPages, payloads := preparedLeafBatchFixture(128)
+	refs := make([]page.ChildRef, 0, len(leafPages))
+	if _, err := log.AppendPreparedLeafPageChildRefs(leafPages, payloads, refs); err != nil {
+		b.Fatal(err)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		out, err := log.AppendPreparedLeafPageChildRefs(leafPages, payloads, refs)
+		if err != nil {
+			b.Fatal(err)
+		}
+		_ = out
+	}
+}

--- a/TreeDB/docs/spec/apply-allocation-churn-2960.md
+++ b/TreeDB/docs/spec/apply-allocation-churn-2960.md
@@ -1,0 +1,53 @@
+# TreeDB #2960 apply allocation churn census
+
+Parent tracker: #2960. Child issues covered: #2964-#2972.
+
+This note records the source-level ownership map used for the allocation cleanup in the span-native prepared apply / leaf-log append path.
+
+## Hot allocation ownership map
+
+| Area | Pre-cleanup owner | Allocation class | Resolution |
+| --- | --- | --- | --- |
+| `caching.(*DB).appendValueLogOneInternal` | single prepared block leaf-log append | `[1]valuelog.Record` and `[1]page.ValuePtr` scratch escaped through generic prepared-frame and interface append helpers | Added `prepareAppendFrameOne` and `valuelog.Writer.AppendEncodedFrameOne`; the single prepared append benchmark is now `0 allocs/op` after warmup. |
+| `caching.putVlogPreparedFrames` | prepared frame metadata pool | `sync.Pool.Put([]preparedDictFrame)` boxed slice headers, one object per prepared append/batch return | Replaced the hot slice return path with bounded typed lease stacks for prepared-frame slices. |
+| `caching.putValueLogRecordsNoClear` | prepared leaf batch record scratch | `sync.Pool.Put([]valuelog.Record)` boxed slice headers, one object per prepared batch | Replaced the hot slice return path with bounded typed lease stacks for value-log record slices. |
+| `caching.putValueLogPtrsNoClear` | value pointer scratch | `sync.Pool.Put([]page.ValuePtr)` boxed slice headers, one object per append/batch return | Replaced the hot slice return path with bounded typed lease stacks for value-log pointer slices. |
+| `valuelog.FramePreparer.PrepareFrameInto` | frame body construction | Body allocation only when caller destination capacity is insufficient | Added allocation-budget tests proving reused destinations stay at `0 allocs/op`. |
+| `valuelog.Writer.AppendEncodedFrameInto` | prepared frame append | Pointer-slice allocation avoided only when caller supplies `dst`; single-frame callers still needed slice scratch | Added `AppendEncodedFrameOne` for one-frame prepared appends without caller slice scratch. |
+| `zipper` prepared payload staging | span-native worker payload production | Payload arena/slice ownership is already wrapper-based and reused; no per-page slice boxing found in the selected path | No change needed. |
+
+## Remaining allocations and scope boundaries
+
+- `AppendPreparedLeafPages` still allocates one returned `[]page.LeafLogPtr` per call. This is API-owned output, not per-frame metadata churn. The span-native path uses `AppendPreparedLeafPageChildRefs` with caller-owned refs and is now `0 allocs/op` after warmup.
+- Encoded frame body storage is still required until the writer has copied/appended it. Reuse is through `vlogPreparedFrameBody` leases; allocation-budget tests warm this path before measuring steady state.
+- Error formatting, segment-rotation retain path slices, and dictionary codec initialization are outside the steady-state prepared apply hot path measured here.
+
+## Focused evidence
+
+Local focused before/after on the same host (`11th Gen Intel(R) Core(TM) i5-11400F`, Go 1.25.7 toolchain):
+
+| Benchmark | Before | After |
+| --- | ---: | ---: |
+| `BenchmarkAppendValueLogAllocs` | ~25-26 B/op, `1 allocs/op` | ~0-1 B/op, `0 allocs/op` |
+| `BenchmarkAppendPreparedLeafPageAllocs` | ~73 B/op, `3 allocs/op` | `0 B/op`, `0 allocs/op` |
+| `BenchmarkAppendPreparedLeafPagesAllocs` | ~3195-3205 B/op, `4 allocs/op` | ~3110 B/op, `1 allocs/op` (returned `[]LeafLogPtr`) |
+| `BenchmarkAppendPreparedLeafPageChildRefsAllocs` | not present | `0-2 B/op`, `0 allocs/op` |
+
+10M random-write profile runs on the same host/base (`origin/main`/`dfe3f6d83` versus this branch) with `-treedb-flush-apply-span-native`, backlog coalescing, `-batchsize 8000`, `-valsize 128`, and `-profile-dir`:
+
+| Apply concurrency | Baseline ops/s | After ops/s | Baseline alloc objects | After alloc objects |
+| ---: | ---: | ---: | ---: | ---: |
+| 4 | 617,723 | 627,029 | 7,704,858 | 1,175,184 |
+| 8 | 805,575 | 843,368 | 5,767,481 | 1,090,480 |
+| 16 | 829,229 | 830,128 | 6,893,958 | 1,116,675 |
+
+After the cleanup, the former top allocation sites (`appendValueLogOneInternal`, `putVlogPreparedFrames`, `putValueLogRecordsNoClear`, `putValueLogPtrsNoClear`) are no longer material in the 10M c8/c16 allocation profiles. The c16 run reported only ~0.10s total leaf-log append-lock wait (`leaf_log_lanes.append_lock_wait_ns_total=100,596,414` baseline, `104,354,400` after), so no follow-on lane-contention implementation was required for #2972.
+
+Representative validation commands:
+
+```sh
+GOWORK=off go test ./TreeDB/caching -run 'TestAppendPreparedLeafPage(AllocsBudget|ChildRefsAllocsBudget)$' -count=1
+GOWORK=off go test ./TreeDB/internal/valuelog -run 'TestAppendEncodedFrameOne_RoundTripAndAllocsBudget|TestFramePreparerAndAppendEncodedFrameIntoAllocsBudget' -count=1
+GOWORK=off go test ./TreeDB/caching -run '^$' -bench 'BenchmarkAppendValueLogAllocs|BenchmarkAppendPreparedLeaf(Page|PageChildRefs|Pages)Allocs' -benchmem -count=3
+GOWORK=off go test ./TreeDB/...
+```

--- a/TreeDB/internal/valuelog/valuelog_test.go
+++ b/TreeDB/internal/valuelog/valuelog_test.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"testing"
+	"time"
 
 	"github.com/golang/snappy"
 	"github.com/pierrec/lz4/v4"
@@ -1428,6 +1429,90 @@ func TestAppendEncodedFrameInto_RoundTripWithDict(t *testing.T) {
 		if !bytes.Equal(got, expect[i]) {
 			t.Fatalf("ptr%d mismatch", i+1)
 		}
+	}
+}
+
+func TestAppendEncodedFrameOne_RoundTripAndAllocsBudget(t *testing.T) {
+	records := []Record{{RID: 1, Value: []byte("single prepared frame payload")}}
+	prep := NewFramePreparer()
+	body, _, err := prep.PrepareFrameInto(nil, 0, nil, records)
+	if err != nil {
+		t.Fatalf("PrepareFrameInto: %v", err)
+	}
+
+	clock := NewVirtualClock(time.Unix(0, 0))
+	writer := NewWriterWithSink(&VirtualSink{Clock: clock}, page.ValueLogFileID(1))
+	if _, err := writer.AppendEncodedFrameOne(body); err != nil {
+		t.Fatalf("warm AppendEncodedFrameOne: %v", err)
+	}
+	allocs := testing.AllocsPerRun(1000, func() {
+		if _, err := writer.AppendEncodedFrameOne(body); err != nil {
+			t.Fatalf("AppendEncodedFrameOne: %v", err)
+		}
+	})
+	if allocs > 0 {
+		t.Fatalf("AppendEncodedFrameOne steady-state allocs = %.2f, want 0", allocs)
+	}
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "value-000001.log")
+	fileWriter, err := NewWriter(path, page.ValueLogFileID(2))
+	if err != nil {
+		t.Fatalf("new writer: %v", err)
+	}
+	ptr, err := fileWriter.AppendEncodedFrameOne(body)
+	if err != nil {
+		_ = fileWriter.Close()
+		t.Fatalf("AppendEncodedFrameOne file: %v", err)
+	}
+	if err := fileWriter.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open file: %v", err)
+	}
+	defer f.Close()
+	got, err := ReadAtWithDict(f, ptr, true, nil, nil, nil, templ.DecodeOptions{})
+	if err != nil {
+		t.Fatalf("ReadAtWithDict: %v", err)
+	}
+	if !bytes.Equal(got, records[0].Value) {
+		t.Fatalf("round trip mismatch: got %q want %q", got, records[0].Value)
+	}
+}
+
+func TestFramePreparerAndAppendEncodedFrameIntoAllocsBudget(t *testing.T) {
+	records := []Record{{RID: 1, Value: bytes.Repeat([]byte("x"), 256)}}
+	prep := NewFramePreparer()
+	body, _, err := prep.PrepareFrameInto(nil, 0, nil, records)
+	if err != nil {
+		t.Fatalf("warm PrepareFrameInto: %v", err)
+	}
+	allocs := testing.AllocsPerRun(1000, func() {
+		var prepErr error
+		body, _, prepErr = prep.PrepareFrameInto(body[:0], 0, nil, records)
+		if prepErr != nil {
+			t.Fatalf("PrepareFrameInto: %v", prepErr)
+		}
+	})
+	if allocs > 0 {
+		t.Fatalf("PrepareFrameInto steady-state allocs = %.2f, want 0", allocs)
+	}
+
+	clock := NewVirtualClock(time.Unix(0, 0))
+	writer := NewWriterWithSink(&VirtualSink{Clock: clock}, page.ValueLogFileID(1))
+	ptrScratch := make([]page.ValuePtr, len(records))
+	if _, err := writer.AppendEncodedFrameInto(body, len(records), ptrScratch); err != nil {
+		t.Fatalf("warm AppendEncodedFrameInto: %v", err)
+	}
+	allocs = testing.AllocsPerRun(1000, func() {
+		if _, err := writer.AppendEncodedFrameInto(body, len(records), ptrScratch); err != nil {
+			t.Fatalf("AppendEncodedFrameInto: %v", err)
+		}
+	})
+	if allocs > 0 {
+		t.Fatalf("AppendEncodedFrameInto steady-state allocs = %.2f, want 0", allocs)
 	}
 }
 

--- a/TreeDB/internal/valuelog/writer.go
+++ b/TreeDB/internal/valuelog/writer.go
@@ -1045,6 +1045,64 @@ func (w *Writer) AppendFrameWithStats(dictID uint64, dict []byte, records []Reco
 	return ptrs, stats, nil
 }
 
+// AppendEncodedFrameOne appends a pre-encoded single-record grouped frame body
+// and returns its value pointer without requiring caller-owned pointer-slice
+// scratch.
+func (w *Writer) AppendEncodedFrameOne(body []byte) (page.ValuePtr, error) {
+	if w == nil {
+		return page.ValuePtr{}, errors.New("valuelog: nil writer")
+	}
+	if len(body) < FrameHeaderSize {
+		return page.ValuePtr{}, ErrCorrupt
+	}
+	if body[0] != FrameVersion {
+		return page.ValuePtr{}, ErrCorrupt
+	}
+	if int(body[2]) != 1 {
+		return page.ValuePtr{}, ErrCorrupt
+	}
+	if len(body) > int(^uint32(0)) {
+		return page.ValuePtr{}, ErrRecordTooLarge
+	}
+	bodyLen := uint32(len(body))
+	if recordSizeExceedsMax(bodyLen) {
+		return page.ValuePtr{}, ErrRecordTooLarge
+	}
+
+	recordLen := HeaderSize + len(body)
+	start := w.size
+	if cap(w.scratch) < recordLen {
+		w.scratch = make([]byte, recordLen)
+	}
+	buf := w.scratch[:recordLen]
+
+	buf[4] = Version
+	buf[5] = recordFlagGrouped
+	buf[6] = 0
+	buf[7] = 0
+	binary.LittleEndian.PutUint64(buf[8:16], 0)
+	binary.LittleEndian.PutUint32(buf[16:20], bodyLen)
+	copy(buf[HeaderSize:], body)
+
+	sum := crc.ChecksumParts(buf[4:HeaderSize], body)
+	binary.LittleEndian.PutUint32(buf[0:4], sum)
+
+	if err := w.writeBytes(buf); err != nil {
+		return page.ValuePtr{}, err
+	}
+	w.size += int64(recordLen)
+
+	recordLenHint := uint32(headerWithoutCRC) + bodyLen
+	if recordLenHint > page.ValuePtrGroupedMaxRecordLen {
+		recordLenHint = 0
+	}
+	return page.ValuePtr{
+		Offset: uint64(start + 4),
+		Length: page.ValuePtrMarkGrouped(recordLenHint, 0),
+		FileID: w.fileID,
+	}, nil
+}
+
 // AppendEncodedFrameInto appends a pre-encoded grouped frame body and fills dst
 // with grouped value pointers (dst must be at least k long).
 //


### PR DESCRIPTION
## Summary

Closes #2960.
Closes #2964.
Closes #2965.
Closes #2966.
Closes #2967.
Closes #2968.
Closes #2969.
Closes #2970.
Closes #2971.
Closes #2972.

Implements the TreeDB span-native apply allocation-churn cleanup graph:

- replaces hot `sync.Pool` slice-header boxing for value-log records, value pointers, and prepared-frame metadata with bounded typed lease stacks;
- adds a single-frame prepared leaf-log append path (`DB.prepareAppendFrameOne`) and `valuelog.Writer.AppendEncodedFrameOne` so one-page prepared appends avoid temporary `[]Record` / `[]ValuePtr` slices;
- adds allocation-budget tests/benchmarks for prepared leaf-log append and valuelog prepared-frame APIs;
- documents the allocation ownership census and 10M-profile before/after evidence in `TreeDB/docs/spec/apply-allocation-churn-2960.md`.

M7 append-contention work was not needed after M6: the former append allocation sites disappeared from the target c8/c16 allocation profiles, and c16 leaf-log append-lock wait remained ~0.10s total in the 10M run.

## Local validation

Correctness:

```sh
GOWORK=off go test -count=1 ./TreeDB/caching ./TreeDB/internal/valuelog ./TreeDB/zipper
GOWORK=off go test -race -count=1 ./TreeDB/caching ./TreeDB/internal/valuelog ./TreeDB/zipper
GOWORK=off go test -count=1 ./TreeDB/...
```

Focused allocation benches after the change:

```text
BenchmarkAppendValueLogAllocs-12                      0 allocs/op (~1 B/op)
BenchmarkAppendPreparedLeafPageAllocs-12              0 B/op, 0 allocs/op
BenchmarkAppendPreparedLeafPagesAllocs-12             ~3104-3126 B/op, 1 allocs/op (returned []LeafLogPtr)
BenchmarkAppendPreparedLeafPageChildRefsAllocs-12     0 B/op, 0 allocs/op
```

10M random-write profile runs on the same host/base (`origin/main`/`dfe3f6d83` vs this branch), `-treedb-flush-apply-span-native`, backlog coalescing, `-batchsize 8000`, `-valsize 128`, and `-profile-dir`:

| Apply concurrency | Baseline ops/s | After ops/s | Baseline alloc objects | After alloc objects |
| ---: | ---: | ---: | ---: | ---: |
| 4 | 617,723 | 627,029 | 7,704,858 | 1,175,184 |
| 8 | 805,575 | 843,368 | 5,767,481 | 1,090,480 |
| 16 | 829,229 | 830,128 | 6,893,958 | 1,116,675 |

The former hot allocation sources (`appendValueLogOneInternal`, `putVlogPreparedFrames`, `putValueLogRecordsNoClear`, `putValueLogPtrsNoClear`) are no longer material in the c8/c16 10M allocation profiles.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized memory buffer pooling strategy for value-log operations with capacity bounds
  * Streamlined single-frame encode-and-append operations

* **Tests**
  * Added allocation behavior benchmarks and budget tests for value-log append paths

* **Documentation**
  * Added allocation cleanup specification documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->