### PR TITLE
TreeDB: use one span-native range per worker

### DIFF
--- a/TreeDB/zipper/read_only_prepare.go
+++ b/TreeDB/zipper/read_only_prepare.go
@@ -307,16 +307,13 @@ func (r ReadOnlyPrepareResult) AppendLeafSpanWorkerRanges(dst []ReadOnlyLeafSpan
 	return dst
 }
 
-const readOnlyLeafSpanWorkUnitQueueFactor = 4
-
-// AppendLeafSpanWorkUnitRanges appends bounded, contiguous span-native work
-// units to dst. It targets a small ready-work queue ahead of the admitted
-// workers, with range size derived from total estimated span ops and bytes
-// rather than one task per leaf span. No task crosses publication order: ranges
-// preserve span order and outputs still publish by original span index.
+// AppendLeafSpanWorkUnitRanges appends one contiguous span-native work unit per
+// active worker to dst. The active worker count is clamped by the non-empty
+// prepared leaf spans, ranges preserve span order, and no empty range is
+// emitted. Outputs still publish by original span index.
 func (r ReadOnlyPrepareResult) AppendLeafSpanWorkUnitRanges(dst []ReadOnlyLeafSpanWorkerRange, workers int) []ReadOnlyLeafSpanWorkerRange {
 	leafSummary := r.LeafSpanSummary()
-	r.forEachLeafSpanWorkUnitRange(workers, leafSummary, func(workerRange ReadOnlyLeafSpanWorkerRange) {
+	r.forEachLeafSpanWorkerRange(workers, leafSummary, func(workerRange ReadOnlyLeafSpanWorkerRange) {
 		dst = append(dst, workerRange)
 	})
 	return dst
@@ -379,66 +376,6 @@ func (r ReadOnlyPrepareResult) forEachLeafSpanWorkerRange(workers int, leafSumma
 			cumulativeOps += int64(spanOps)
 			spanIdx++
 			if remainingRanges > 0 && cumulativeOps >= targetCumulativeOps {
-				break
-			}
-		}
-		fn(ReadOnlyLeafSpanWorkerRange{
-			FirstSpan: firstSpan,
-			SpanCount: spanIdx - firstSpan,
-			Ops:       rangeOps,
-			Bytes:     rangeBytes,
-		})
-	}
-}
-
-func readOnlyLeafSpanWorkUnitTargetRanges(workers, spans int) int {
-	if workers <= 0 || spans <= 0 {
-		return 0
-	}
-	if workers <= 1 {
-		return 1
-	}
-	target := workers * readOnlyLeafSpanWorkUnitQueueFactor
-	if target < workers {
-		target = workers
-	}
-	if target > spans {
-		target = spans
-	}
-	return target
-}
-
-func (r ReadOnlyPrepareResult) forEachLeafSpanWorkUnitRange(workers int, leafSummary ReadOnlyLeafSpanSummary, fn func(ReadOnlyLeafSpanWorkerRange)) {
-	if fn == nil || workers <= 0 || len(r.LeafSpans) == 0 {
-		return
-	}
-	targetRanges := readOnlyLeafSpanWorkUnitTargetRanges(workers, len(r.LeafSpans))
-	if targetRanges <= 0 {
-		return
-	}
-	totalOps := int64(leafSummary.SpanOps)
-	if totalOps <= 0 {
-		totalOps = int64(r.Ops)
-	}
-	targetOps := readOnlyPrepareCeilDiv64(totalOps, int64(targetRanges))
-	if targetOps <= 0 {
-		targetOps = 1
-	}
-	targetBytes := readOnlyPrepareCeilDiv64(int64(leafSummary.SpanBytes), int64(targetRanges))
-
-	spanIdx := 0
-	for rangeIdx := 0; rangeIdx < targetRanges && spanIdx < len(r.LeafSpans); rangeIdx++ {
-		firstSpan := spanIdx
-		rangeOps := 0
-		rangeBytes := 0
-		remainingRanges := targetRanges - rangeIdx - 1
-		lastAllowedSpan := len(r.LeafSpans) - remainingRanges
-		for spanIdx < lastAllowedSpan {
-			span := r.LeafSpans[spanIdx]
-			rangeOps += span.OpCount
-			rangeBytes += span.ByteCount
-			spanIdx++
-			if remainingRanges > 0 && (int64(rangeOps) >= targetOps || (targetBytes > 0 && int64(rangeBytes) >= targetBytes)) {
 				break
 			}
 		}

--- a/TreeDB/zipper/read_only_prepare_test.go
+++ b/TreeDB/zipper/read_only_prepare_test.go
@@ -650,7 +650,7 @@ func TestReadOnlyPrepareResultWorkerRanges(t *testing.T) {
 	}
 }
 
-func TestReadOnlyPrepareResultWorkUnitRangesBoundReadyQueue(t *testing.T) {
+func TestReadOnlyPrepareResultWorkUnitRangesOneRangePerWorker(t *testing.T) {
 	const spans = 64
 	prepared := ReadOnlyPrepareResult{Ops: spans, PointOps: spans, ExactLeafSpans: true}
 	for i := 0; i < spans; i++ {
@@ -675,8 +675,8 @@ func TestReadOnlyPrepareResultWorkUnitRangesBoundReadyQueue(t *testing.T) {
 	requireValidReadOnlyPrepare(t, prepared)
 
 	ranges := prepared.AppendLeafSpanWorkUnitRanges(nil, 4)
-	if len(ranges) <= 4 || len(ranges) > 4*readOnlyLeafSpanWorkUnitQueueFactor {
-		t.Fatalf("work-unit ranges=%d want bounded queue > workers and <= factor cap: %+v", len(ranges), ranges)
+	if len(ranges) != 4 {
+		t.Fatalf("work-unit ranges=%d want one range per active worker: %+v", len(ranges), ranges)
 	}
 	if ranges[0].SpanCount <= 1 {
 		t.Fatalf("first work unit spans=%d want grouped adjacent spans", ranges[0].SpanCount)
@@ -697,9 +697,26 @@ func TestReadOnlyPrepareResultWorkUnitRangesBoundReadyQueue(t *testing.T) {
 		t.Fatalf("work units cover spans/ops/bytes=%d/%d/%d want %d/%d/%d", totalSpans, totalOps, totalBytes, spans, spans, spans*100)
 	}
 
+	for _, workers := range []int{8, 16} {
+		workerRanges := prepared.AppendLeafSpanWorkUnitRanges(nil, workers)
+		if len(workerRanges) != workers {
+			t.Fatalf("workers=%d emitted %d ranges, want one range per active worker", workers, len(workerRanges))
+		}
+	}
+
 	serialRanges := prepared.AppendLeafSpanWorkUnitRanges(nil, 1)
 	if len(serialRanges) != 1 || serialRanges[0].SpanCount != spans {
 		t.Fatalf("single-worker work units=%+v want one range covering all spans", serialRanges)
+	}
+
+	tooManyWorkerRanges := prepared.AppendLeafSpanWorkUnitRanges(nil, spans+10)
+	if len(tooManyWorkerRanges) != spans {
+		t.Fatalf("over-subscribed workers emitted %d ranges, want clamp to %d non-empty spans", len(tooManyWorkerRanges), spans)
+	}
+
+	emptyRanges := (ReadOnlyPrepareResult{}).AppendLeafSpanWorkUnitRanges(nil, 8)
+	if len(emptyRanges) != 0 {
+		t.Fatalf("empty prepare emitted ranges: %+v", emptyRanges)
 	}
 }
 

--- a/TreeDB/zipper/span_native_apply.go
+++ b/TreeDB/zipper/span_native_apply.go
@@ -336,7 +336,10 @@ func (z *Zipper) applySpanNativeWithPrepared(rootID uint64, ops []batch.Entry, p
 		workers = spanCount
 	}
 
-	rangeCapacity := readOnlyLeafSpanWorkUnitTargetRanges(workers, spanCount)
+	rangeCapacity := workers
+	if rangeCapacity > spanCount {
+		rangeCapacity = spanCount
+	}
 	workerRanges := coordinatorScratch.acquireSpanWorkerRanges(rangeCapacity)
 	workerRanges = prepared.AppendLeafSpanWorkUnitRanges(workerRanges, workers)
 	if len(workerRanges) == 0 {

--- a/TreeDB/zipper/span_native_apply_engine_test.go
+++ b/TreeDB/zipper/span_native_apply_engine_test.go
@@ -765,7 +765,7 @@ func TestSpanNativeApplyLeafLogOutputCommitFailureReturnsBeforeReduce(t *testing
 	}
 }
 
-func TestSpanNativeApplyGroupsTinyLeafSpansIntoBoundedWorkUnits(t *testing.T) {
+func TestSpanNativeApplyGroupsTinyLeafSpansIntoWorkerRanges(t *testing.T) {
 	prevProcs := runtime.GOMAXPROCS(4)
 	t.Cleanup(func() { runtime.GOMAXPROCS(prevProcs) })
 
@@ -786,7 +786,7 @@ func TestSpanNativeApplyGroupsTinyLeafSpansIntoBoundedWorkUnits(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PrepareReadOnly: %v", err)
 	}
-	if len(prepared.LeafSpans) <= 4*readOnlyLeafSpanWorkUnitQueueFactor {
+	if len(prepared.LeafSpans) <= 4 {
 		t.Fatalf("prepared spans=%d want enough tiny spans to prove grouping", len(prepared.LeafSpans))
 	}
 	serialNewRoot, _, _, err := serial.Apply(serialRoot, delta)
@@ -807,8 +807,8 @@ func TestSpanNativeApplyGroupsTinyLeafSpansIntoBoundedWorkUnits(t *testing.T) {
 		t.Fatalf("span-native flags eligible/used/workers=%v/%v/%d", result.SpanNativeEligible, result.SpanNativeUsed, result.SpanNativeWorkers)
 	}
 	ready := result.Metrics.ZipperSpanNativeReadyTasks
-	if ready <= result.SpanNativeWorkers || ready > result.SpanNativeWorkers*readOnlyLeafSpanWorkUnitQueueFactor {
-		t.Fatalf("ready work units=%d want bounded queue > workers and <= factor cap", ready)
+	if ready != result.SpanNativeWorkers {
+		t.Fatalf("ready work units=%d want one range per active worker %d", ready, result.SpanNativeWorkers)
 	}
 	if ready >= len(prepared.LeafSpans) {
 		t.Fatalf("ready work units=%d should group %d leaf spans", ready, len(prepared.LeafSpans))


### PR DESCRIPTION
## Objective

Implement #2988 M1 by deleting the internal `workers * queueFactor` span-native task fanout and emitting one contiguous prepared leaf-span range per active apply worker.

Closes #2990.

## Context

#2988/#2989 selected the simple model:

```text
total prepared span/apply work -> split into W contiguous chunks -> W = active apply workers clamped by non-empty work
```

This PR applies that contract to the span-native prepared apply path.

## Non-goals

- No work stealing.
- No central output collector or global append queue.
- No c16/default promotion.
- No compression, leaf-log lane default, reducer/publish, or durability changes.
- M3 owns final throughput validation.

## Design

- `AppendLeafSpanWorkUnitRanges` now reuses the deterministic worker-range partitioner.
- The removed internal queue factor no longer multiplies ready tasks.
- Apply scratch capacity is sized from the active worker count, clamped by prepared spans.
- Output append fanout remains based on scheduled workers.

Invariants:

- Emitted ranges are contiguous, non-overlapping, deterministic, and non-empty.
- Range count is at most active workers and at most prepared span count.
- Outputs continue to publish by original prepared span index.
- Span-native fallback/validation behavior is unchanged.

## Scope

- Includes: `TreeDB/zipper/read_only_prepare.go`, `span_native_apply.go`, focused zipper tests.
- Excludes: nil leaf-ref cache no-op path (#2991), final c8/c16 gate (#2992).

## Correctness

- Tests run (exact commands):
  - `GOWORK=off go test ./TreeDB/zipper -run 'TestReadOnlyPrepareResultWorkUnitRangesOneRangePerWorker|TestSpanNativeApplyGroupsTinyLeafSpansIntoWorkerRanges|TestSpanNativeApplyRejectsInvalidPreparedPlanBeforeOutput' -count=1` ✅
  - `GOWORK=off go test ./TreeDB/zipper -count=1` ✅
  - `GOWORK=off go test ./TreeDB/db -run 'TestSpanNative|TestFlushApply|TestReopen|TestValueLogGC' -count=1` ✅
  - `GOWORK=off go test ./TreeDB/zipper ./TreeDB/db -count=1` ❌ existing unrelated local failure in `TestLeafGenerationGC_RemovesUnreachableMultiLaneSegmentsAfterReopen`: `sealed mid-generation lane segments=1 want >=2`; rerun of that single test fails the same way on this branch and is outside the touched span-native scheduler files.
- New/updated coverage:
  - c8/c16 worker counts emit exactly one range per active worker with enough spans.
  - over-subscribed worker counts clamp to non-empty spans.
  - empty work emits no tasks.
  - span-native apply metrics report `ready == SpanNativeWorkers` for the grouped tiny-span case.

## Performance

- Benchmarks run: not run for this M1 PR; #2992 owns final c8/c16 throughput matrix.
- Expected counter movement: ready/dispatched/completed tasks and queue depth collapse from factor-shaped fanout to active-worker shape; ops/spans/bytes per task increase accordingly.
- Regressions: none identified in focused tests.

## Rollout / Toggle Plan

- Default setting: applies only when span-native apply is enabled/eligible.
- Disable quickly: disable `-treedb-flush-apply-span-native` / span-native apply options.

## Follow-ups

- #2991: remove nil leaf-ref cache lock/copy overhead.
- #2992: final combined c16 locality validation and closeout.

### AI Review Loop

- Codex latest-head review: pending request after PR creation.
- Copilot latest-head review: pending request after PR creation.
- CodeRabbit latest-head review: pending request after PR creation.
- Review comments/threads resolved or explicitly dismissed: pending.
- Re-requested after final meaningful push: n/a.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how leaf-span work is partitioned, so work ranges now align more directly with available workers and avoid oversized queue-based batching.
  * Updated span-native apply behavior to cap work ranges cleanly when worker count exceeds available spans.

* **Tests**
  * Expanded coverage for worker-range behavior across multiple worker counts, including single-worker, over-provisioned, and empty-result cases.
  * Adjusted span-native apply tests to reflect the new one-range-per-worker behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->