### PR TITLE
TreeDB: skip nil leaf-ref cache locks

### DIFF
--- a/TreeDB/zipper/zipper.go
+++ b/TreeDB/zipper/zipper.go
@@ -132,6 +132,7 @@ type Zipper struct {
 	leafPageLog           LeafPageLog
 	leafPageReader        LeafPageReader
 	leafRefCacheMu        sync.RWMutex
+	leafRefCacheActive    atomic.Bool
 	leafRefCache          map[page.LeafLogPtr][]byte
 
 	leafReserveBytes          int
@@ -1530,14 +1531,8 @@ func (z *Zipper) applyWithConfig(rootID uint64, b *batch.Batch, cfg applyRunConf
 		// maintenance may reload newly written leaf refs before the value log is
 		// flushed. Pure put/restore applies do not revisit those fresh leaves, so
 		// avoid retaining their page buffers for the whole commit.
-		z.leafRefCacheMu.Lock()
-		z.leafRefCache = make(map[page.LeafLogPtr][]byte)
-		z.leafRefCacheMu.Unlock()
-		defer func() {
-			z.leafRefCacheMu.Lock()
-			z.leafRefCache = nil
-			z.leafRefCacheMu.Unlock()
-		}()
+		z.beginLeafRefCache()
+		defer z.endLeafRefCache()
 	}
 
 	var retired []uint64
@@ -1680,7 +1675,7 @@ func (z *Zipper) loadNodeRef(ref page.ChildRef, scratchCtx *mergeScratch) (node.
 	}
 	if ref.Kind == page.ChildRefLeafLog {
 		ptr := ref.Log
-		if z.outerLeavesInValueLog {
+		if z.outerLeavesInValueLog && z.leafRefCacheActive.Load() {
 			z.leafRefCacheMu.RLock()
 			data, cached := z.leafRefCache[ptr]
 			z.leafRefCacheMu.RUnlock()
@@ -2004,7 +1999,30 @@ func (z *Zipper) persistLeafPageBatchDataToLog(log LeafPageLog, leafPages [][]by
 	return refs, nil
 }
 
+func (z *Zipper) beginLeafRefCache() {
+	if z == nil {
+		return
+	}
+	z.leafRefCacheMu.Lock()
+	z.leafRefCache = make(map[page.LeafLogPtr][]byte)
+	z.leafRefCacheActive.Store(true)
+	z.leafRefCacheMu.Unlock()
+}
+
+func (z *Zipper) endLeafRefCache() {
+	if z == nil {
+		return
+	}
+	z.leafRefCacheMu.Lock()
+	z.leafRefCache = nil
+	z.leafRefCacheActive.Store(false)
+	z.leafRefCacheMu.Unlock()
+}
+
 func (z *Zipper) cachePersistedLeafPage(ptr page.LeafLogPtr, leafPage []byte) {
+	if z == nil || !z.leafRefCacheActive.Load() {
+		return
+	}
 	z.leafRefCacheMu.Lock()
 	if z.leafRefCache != nil {
 		// Persist paths often hand us builder/scratch buffers that are reused later

--- a/TreeDB/zipper/zipper_test.go
+++ b/TreeDB/zipper/zipper_test.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/snissn/gomap/TreeDB/batch"
 	"github.com/snissn/gomap/TreeDB/internal/adaptive"
@@ -304,7 +305,8 @@ func TestZipperLeafRefCacheAvoidsUnflushedReads(t *testing.T) {
 
 	// Simulate Apply() scope: enable the in-flight leaf-ref cache so loadNode can
 	// resolve freshly appended leaf pages before the leafPageLog is flushed.
-	z.leafRefCache = make(map[page.LeafLogPtr][]byte)
+	z.beginLeafRefCache()
+	defer z.endLeafRefCache()
 
 	data := make([]byte, page.PageSize)
 	b := node.NewBuilder(data, page.PageTypeLeaf)
@@ -353,7 +355,8 @@ func TestZipperLeafRefCacheOwnsPersistedLeafBytes(t *testing.T) {
 	z.SetOuterLeavesInValueLog(true)
 	z.SetLeafPageLog(&stubLeafPageLog{})
 	z.SetLeafPageReader(&countingLeafPageReader{})
-	z.leafRefCache = make(map[page.LeafLogPtr][]byte)
+	z.beginLeafRefCache()
+	defer z.endLeafRefCache()
 
 	data := make([]byte, page.PageSize)
 	b := node.NewBuilder(data, page.PageTypeLeaf)
@@ -390,6 +393,24 @@ func TestZipperLeafRefCacheOwnsPersistedLeafBytes(t *testing.T) {
 	}
 	if got := loaded.Type(); got != page.PageTypeLeaf {
 		t.Fatalf("loaded.Type()=%d want %d", got, page.PageTypeLeaf)
+	}
+}
+
+func TestZipperCachePersistedLeafPageNoopAvoidsLockWhenCacheInactive(t *testing.T) {
+	z := &Zipper{}
+	z.leafRefCacheMu.Lock()
+	defer z.leafRefCacheMu.Unlock()
+
+	done := make(chan struct{})
+	go func() {
+		z.cachePersistedLeafPage(page.LeafLogPtr{FileID: 1, Offset: 128}, []byte("leaf"))
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("cachePersistedLeafPage blocked on leafRefCacheMu with inactive cache")
 	}
 }
 


### PR DESCRIPTION
## Objective

Implement #2988 M2 by making persisted-leaf cache updates a true no-op when no in-flight leaf-ref cache is active, avoiding the nil-cache mutex/copy path on pure put/span-native writes.

Closes #2991.

## Context

#2990 removed the old span-native task over-fragmentation. This follow-up removes the secondary cache coordination overhead called out in #2988: `cachePersistedLeafPage` previously acquired `leafRefCacheMu` even when `leafRefCache` was nil.

## Non-goals

- No changes to value-log or leaf-log durability/registration semantics.
- No batching/worker-local output cache redesign.
- No unsafe unlocked read of `leafRefCache`; the active state is explicit and atomically published.
- M3 owns final c8/c16 benchmark/profile validation.

## Design

- Add an explicit `leafRefCacheActive` atomic flag to select the no-op path before taking `leafRefCacheMu`.
- Wrap maintenance cache lifetime in `beginLeafRefCache` / `endLeafRefCache` helpers.
- `cachePersistedLeafPage` returns immediately when no in-flight cache is active; when active, it keeps the existing locked owning-copy behavior.
- `loadNodeRef` also skips the leaf-ref cache lock when the cache is inactive and falls through to the leaf-page reader.

Invariants:

- Maintenance/rewrite paths with an active cache still own copied leaf bytes.
- Pure non-maintenance writes do not retain fresh leaf page buffers.
- The active flag and map are updated under `leafRefCacheMu`; cache readers/writers still double-check under the lock when active.

## Scope

- Includes: `TreeDB/zipper/zipper.go`, focused leaf-ref cache tests.
- Excludes: scheduler changes (#2990, already merged), final c16 validation (#2992).

## Correctness

- Tests run (exact commands):
  - `GOWORK=off go test ./TreeDB/zipper -run 'TestZipperLeafRefCacheAvoidsUnflushedReads|TestZipperLeafRefCacheOwnsPersistedLeafBytes|TestZipperCachePersistedLeafPageNoopAvoidsLockWhenCacheInactive|TestZipperApply_NonMaintenanceRestorePathDoesNotInstallLeafRefCache|TestZipperApply_MaintenanceRestorePathInstallsLeafRefCache' -count=1` ✅
  - `GOWORK=off go test ./TreeDB/zipper -count=1` ✅
  - `GOWORK=off go test ./TreeDB/db -run 'Test.*LeafRef|Test.*Maintenance|TestReopen|TestValueLogGC' -count=1` ✅
  - `GOWORK=off go test -race ./TreeDB/zipper -run 'TestZipperCachePersistedLeafPageNoopAvoidsLockWhenCacheInactive|TestZipperLeafRefCacheAvoidsUnflushedReads|TestZipperLeafRefCacheOwnsPersistedLeafBytes' -count=1` ✅
- New coverage:
  - inactive cache path returns while `leafRefCacheMu` is held, proving it does not take the lock;
  - active cache path still avoids unflushed reads and owns persisted leaf bytes;
  - non-maintenance apply does not install cache, maintenance apply does.

## Performance

- Benchmarks run: not run in this M2 PR; #2992 owns the final c8/c16 matrix and mutex/block profile.
- Expected movement: pure random writes with no in-flight cache no longer pay `cachePersistedLeafPage` mutex acquisition/copy checks; maintenance path remains unchanged except for an atomic active check before locked cache use.
- Regressions: none identified in focused/race tests.

## Rollout / Toggle Plan

- Default setting: applies automatically to existing outer-leaf-in-value-log paths.
- Disable quickly: revert this PR; no config/on-disk format change.

## Follow-ups

- #2992: combined c16 locality validation and parent closeout.

### AI Review Loop

- Codex latest-head review: pending request after PR creation.
- Copilot latest-head review: pending request after PR creation.
- CodeRabbit latest-head review: pending request after PR creation.
- Review comments/threads resolved or explicitly dismissed: pending.
- Re-requested after final meaningful push: n/a.
