### PR TITLE
Fix canonical collection benchmark partial outputs

### DIFF
--- a/cmd/collection_canonical_bench/main.go
+++ b/cmd/collection_canonical_bench/main.go
@@ -343,22 +343,22 @@ func run(argv []string) error {
 		}
 	}
 	if !cfg.SkipOfflineRewrite {
-		if err := runOfflineRewriteMatrix(cfg, canon, "offline_compact", phaseOfflineCompact, "full"); err != nil {
-			return err
-		}
-		if err := runOfflineRewriteMatrix(cfg, canon, "exhaustive_compact", phaseExhaustiveCompact, "exhaustive"); err != nil {
-			return err
-		}
+		runReportPhase(canon, "error", "phase.offline_compact.failed", "offline compact matrix", func() error {
+			return runOfflineRewriteMatrix(cfg, canon, "offline_compact", phaseOfflineCompact, "full")
+		})
+		runReportPhase(canon, "warning", "phase.exhaustive_compact.failed", "exhaustive compact matrix", func() error {
+			return runOfflineRewriteMatrix(cfg, canon, "exhaustive_compact", phaseExhaustiveCompact, "exhaustive")
+		})
 	}
 	if !cfg.SkipFullLeafgen {
-		if err := runFullLeafgenFixture(cfg, canon, formats); err != nil {
-			return err
-		}
+		runReportPhase(canon, "warning", "phase.full_leafgen_pack_gc.failed", "full leafgen pack/GC fixture", func() error {
+			return runFullLeafgenFixture(cfg, canon, formats)
+		})
 	}
 
 	canon.Comparisons = buildCompactedComparisons(canon)
 	finalizeRunMetadata(canon)
-	canon.Checks = validateCanonicalRun(canon)
+	canon.Checks = append(canon.Checks, validateCanonicalRun(canon)...)
 	if err := writeOutputs(canon); err != nil {
 		return err
 	}
@@ -369,6 +369,16 @@ func run(argv []string) error {
 		return errors.New("guardrail validation failed; rerun with -allow-incomplete to keep partial results")
 	}
 	return nil
+}
+
+func runReportPhase(canon *canonicalRun, severity, code, label string, fn func() error) {
+	if err := fn(); err != nil {
+		canon.Checks = append(canon.Checks, guardrailCheck{
+			Severity: severity,
+			Code:     code,
+			Message:  fmt.Sprintf("%s failed; writing completed canonical phases anyway: %v", label, err),
+		})
+	}
 }
 
 func normalizeRunPaths(cfg *config) error {
@@ -578,12 +588,13 @@ func runOfflineRewriteMatrix(cfg config, canon *canonicalRun, dirName, compactPh
 }
 
 func runFullLeafgenFixture(cfg config, canon *canonicalRun, formats []string) error {
+	var errs []error
 	for _, format := range formats {
 		if err := runFullLeafgenFixtureForFormat(cfg, canon, format); err != nil {
-			return err
+			errs = append(errs, err)
 		}
 	}
-	return nil
+	return errors.Join(errs...)
 }
 
 func runFullLeafgenFixtureForFormat(cfg config, canon *canonicalRun, format string) error {

--- a/cmd/collection_canonical_bench/main_test.go
+++ b/cmd/collection_canonical_bench/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -75,6 +76,66 @@ func TestPrepareRunDirRemovesPriorCanonicalArtifacts(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(dir, runDirSentinel)); err != nil {
 		t.Fatalf("run-dir sentinel should be present: %v", err)
+	}
+}
+
+func TestRunReportPhaseRecordsWarningAndContinues(t *testing.T) {
+	canon := &canonicalRun{}
+	called := false
+
+	runReportPhase(canon, "warning", "phase.test.failed", "test phase", func() error {
+		called = true
+		return errors.New("boom")
+	})
+
+	if !called {
+		t.Fatal("optional phase was not called")
+	}
+	if len(canon.Checks) != 1 {
+		t.Fatalf("checks = %#v, want one warning", canon.Checks)
+	}
+	check := canon.Checks[0]
+	if check.Severity != "warning" || check.Code != "phase.test.failed" || !strings.Contains(check.Message, "boom") {
+		t.Fatalf("unexpected optional phase warning: %#v", check)
+	}
+}
+
+func TestRunReportPhaseRecordsErrorAndContinues(t *testing.T) {
+	canon := &canonicalRun{}
+
+	runReportPhase(canon, "error", "phase.required.failed", "required phase", func() error {
+		return errors.New("boom")
+	})
+
+	if len(canon.Checks) != 1 {
+		t.Fatalf("checks = %#v, want one error", canon.Checks)
+	}
+	check := canon.Checks[0]
+	if check.Severity != "error" || check.Code != "phase.required.failed" || !strings.Contains(check.Message, "boom") {
+		t.Fatalf("unexpected required phase error: %#v", check)
+	}
+}
+
+func TestCanonicalValidationPreservesExistingWarnings(t *testing.T) {
+	canon := knownExampleRun()
+	canon.Checks = append(canon.Checks, guardrailCheck{
+		Severity: "warning",
+		Code:     "phase.exhaustive_compact.failed",
+		Message:  "exhaustive compact matrix failed",
+	})
+	canon.Checks = append(canon.Checks, validateCanonicalRun(canon)...)
+
+	var sawOptionalWarning bool
+	for _, check := range canon.Checks {
+		if check.Code == "phase.exhaustive_compact.failed" {
+			sawOptionalWarning = true
+		}
+		if check.Severity == "error" {
+			t.Fatalf("unexpected guardrail error: %#v", check)
+		}
+	}
+	if !sawOptionalWarning {
+		t.Fatalf("optional phase warning was not preserved: %#v", canon.Checks)
 	}
 }
 


### PR DESCRIPTION
Closes #2998.
Part of #2999.

## Summary

- Keeps canonical collection benchmark output generation alive after post-timed maintenance/report phases fail.
- Preserves failed maintenance commands in `commands[]` and emits guardrail checks before validation.
- Treats production offline compact failures as guardrail errors, while the currently unsupported exhaustive compact diagnostic is a warning so completed timed/offline rows are still serialized.
- Lets full-leafgen fixture attempts continue across formats and reports any failures as warnings.

## Evidence

Latest affected run root:

`/mnt/fast4tb/tmp/gomap_full_benchmark_report_20260624_190225`

Root cause observed in the failed canonical jobs:

```text
CompactStorage error: treedb: exhaustive compact requires an internally-owned leaf page log; close or clear the installed leaf page log before compacting
```

After this fix, focused reruns wrote canonical outputs for:

- `collections_sqlite_canonical_1m/indexes_0/benchmark_results.json`
- `collections_sqlite_canonical_1m/indexes_1/benchmark_results.json`
- `collections_sqlite_canonical_1m/indexes_2/benchmark_results.json`

The rerendered `deep_report.html` no longer contains the previous missing `benchmark_results.json` warnings.

Canonical template-v1 post-insert rows from the repaired run:

| Secondary indexes | Docs/sec | ns/doc |
| ---: | ---: | ---: |
| 0 | 1,777,462 | 562.6 |
| 1 | 1,004,218 | 995.8 |
| 2 | 694,444 | 1440.0 |

Expected guardrail warning is preserved in each run:

`phase.exhaustive_compact.failed`

## Validation

- `GOWORK=off go test ./cmd/collection_canonical_bench ./cmd/benchmark_run_report`
- Final smoke: `USE_BUILT_BIN=1 GOWORK=off ./scripts/bench_collections_canonical.sh -out-dir /tmp/treedb_canonical_smoke_final_rNVJui -docs 100 -batch-size 50 -indexes 0 -formats template-v1 -benchtime 100x -count 1 -skip-full-leafgen`
- Focused canonical rerun for indexes `0`, `1`, and `2` under `/mnt/fast4tb/tmp/gomap_full_benchmark_report_20260624_190225/collections_sqlite_canonical_1m`
- Deep report rerender: `GOWORK=off go run ./cmd/benchmark_run_report -run-root /mnt/fast4tb/tmp/gomap_full_benchmark_report_20260624_190225 -out /mnt/fast4tb/tmp/gomap_full_benchmark_report_20260624_190225/deep_report.html -title 'TreeDB Benchmark Run Report'`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Benchmark runs now continue through later phases even if one phase fails, instead of stopping immediately.
  * Failures are now reported more consistently, with warnings and errors preserved in the final results.
  * Full fixture processing now collects all format-specific failures rather than failing on the first one.
  * Overall run status now reflects whether any critical issues were found, while still allowing incomplete runs when enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->