### PR TITLE
Optimize prepared TreeDB JSONBench column queries

### DIFF
--- a/TreeDB/collections/column_physical_q1_dense_1950_test.go
+++ b/TreeDB/collections/column_physical_q1_dense_1950_test.go
@@ -41,7 +41,7 @@ func TestColumnPhysicalQ1DenseTypedColumnDirectPreparedParity1950(t *testing.T) 
 	if err != nil {
 		t.Fatalf("RunColumnPhysicalQuery(q1 dense): %v", err)
 	}
-	assertColumnPhysicalQ1DenseResult1950(t, "direct", direct, want, totalRows)
+	assertColumnPhysicalQ1DenseResult1950(t, "direct", direct, want, totalRows, totalRows)
 
 	runner, err := col.PrepareColumnPhysicalQuery(req)
 	if err != nil {
@@ -53,7 +53,7 @@ func TestColumnPhysicalQ1DenseTypedColumnDirectPreparedParity1950(t *testing.T) 
 		if err != nil {
 			t.Fatalf("prepared q1 dense run %d: %v", run, err)
 		}
-		assertColumnPhysicalQ1DenseResult1950(t, fmt.Sprintf("prepared run %d", run), prepared, want, totalRows)
+		assertColumnPhysicalQ1DenseResult1950(t, fmt.Sprintf("prepared run %d", run), prepared, want, 0, totalRows)
 	}
 }
 
@@ -82,7 +82,7 @@ func BenchmarkColumnPhysicalQ1DenseTypedColumn1950(b *testing.B) {
 		if err != nil {
 			b.Fatalf("preview RunColumnPhysicalQuery: %v", err)
 		}
-		assertColumnPhysicalQ1DenseDiagnostics1950(b, "preview direct", preview.Diagnostics, totalRows)
+		assertColumnPhysicalQ1DenseDiagnostics1950(b, "preview direct", preview.Diagnostics, totalRows, totalRows)
 		b.SetBytes(int64(preview.Diagnostics.DecodedPayloadBytes))
 		b.ReportAllocs()
 		b.ResetTimer()
@@ -113,7 +113,7 @@ func BenchmarkColumnPhysicalQ1DenseTypedColumn1950(b *testing.B) {
 		if err != nil {
 			b.Fatalf("preview runner.Run: %v", err)
 		}
-		assertColumnPhysicalQ1DenseDiagnostics1950(b, "preview prepared", preview.Diagnostics, totalRows)
+		assertColumnPhysicalQ1DenseDiagnostics1950(b, "preview prepared", preview.Diagnostics, 0, totalRows)
 		b.SetBytes(int64(preview.Diagnostics.DecodedPayloadBytes))
 		b.ReportAllocs()
 		b.ResetTimer()
@@ -201,7 +201,7 @@ func typedColumnQ1DictionaryCodeByGeneration1950(tb testing.TB, d *backenddb.DB,
 	return out
 }
 
-func assertColumnPhysicalQ1DenseResult1950(tb testing.TB, label string, result ColumnPhysicalQueryResult, want map[string]int, rows int) {
+func assertColumnPhysicalQ1DenseResult1950(tb testing.TB, label string, result ColumnPhysicalQueryResult, want map[string]int, wantRowsScanned, wantReduceRows int) {
 	tb.Helper()
 	got := make(map[string]int, len(result.Groups))
 	for _, group := range result.Groups {
@@ -215,10 +215,10 @@ func assertColumnPhysicalQ1DenseResult1950(tb testing.TB, label string, result C
 			tb.Fatalf("%s group %q count=%d want %d all=%v", label, key, got[key], wantCount, got)
 		}
 	}
-	assertColumnPhysicalQ1DenseDiagnostics1950(tb, label, result.Diagnostics, rows)
+	assertColumnPhysicalQ1DenseDiagnostics1950(tb, label, result.Diagnostics, wantRowsScanned, wantReduceRows)
 }
 
-func assertColumnPhysicalQ1DenseDiagnostics1950(tb testing.TB, label string, diag ColumnPhysicalQueryDiagnostics, rows int) {
+func assertColumnPhysicalQ1DenseDiagnostics1950(tb testing.TB, label string, diag ColumnPhysicalQueryDiagnostics, wantRowsScanned, wantReduceRows int) {
 	tb.Helper()
 	if diag.StorageSource != ColumnPhysicalQueryStorageSourceTypedColumnPartSection || diag.FallbackReason != ColumnPhysicalQueryFallbackNone {
 		tb.Fatalf("%s diagnostics storage/fallback=%+v", label, diag)
@@ -229,8 +229,8 @@ func assertColumnPhysicalQ1DenseDiagnostics1950(tb testing.TB, label string, dia
 	if diag.RowMaterializations != 0 || diag.DocumentMaterializations != 0 {
 		tb.Fatalf("%s materialized rows/documents: %+v", label, diag)
 	}
-	if diag.RowsScanned != rows || diag.ReduceRows != rows {
-		tb.Fatalf("%s rows scanned/reduced=%d/%d want %d diagnostics=%+v", label, diag.RowsScanned, diag.ReduceRows, rows, diag)
+	if diag.RowsScanned != wantRowsScanned || diag.ReduceRows != wantReduceRows {
+		tb.Fatalf("%s rows scanned/reduced=%d/%d want %d/%d diagnostics=%+v", label, diag.RowsScanned, diag.ReduceRows, wantRowsScanned, wantReduceRows, diag)
 	}
 	if diag.TypedColumnPartSections == 0 || diag.TypedColumnPartSectionBytes == 0 || diag.DecodedPayloadBytes == 0 || diag.DecodedBlocks == 0 {
 		tb.Fatalf("%s missing typed-column section/decode diagnostics: %+v", label, diag)

--- a/TreeDB/collections/column_physical_q2_1950_test.go
+++ b/TreeDB/collections/column_physical_q2_1950_test.go
@@ -661,6 +661,9 @@ func assertTypedColumnQ2DenseGroupCountDistinctDiagnostics1950(tb testing.TB, la
 	if !diag.DenseGroupCountDistinctUsed || diag.SortedGroupedDistinctUsed || diag.DenseGroupCountUsed || diag.DenseGroupHourCountUsed || diag.DenseInt64SpanUsed || diag.TimeOrderTopKUsed {
 		tb.Fatalf("%s diagnostics=%+v want only dense grouped count-distinct path", label, diag)
 	}
+	if diag.DenseGroupCountDistinctReducer != columnTypedColumnDenseGroupCountDistinctReducerPairBitset || diag.DenseGroupCountDistinctGroups == 0 || diag.DenseGroupCountDistinctValues == 0 || diag.DenseGroupCountDistinctPairBitWords == 0 {
+		tb.Fatalf("%s dense grouped count-distinct reducer diagnostics=%+v want pair bitset with cardinalities", label, diag)
+	}
 	if diag.SortKeyMarkChecks != 0 || diag.SortKeyMarkSkips != 0 {
 		tb.Fatalf("%s mark diagnostics=%+v want no sort-key pruning in dense no-sort path", label, diag)
 	}

--- a/TreeDB/collections/column_physical_q3_dense_1950_test.go
+++ b/TreeDB/collections/column_physical_q3_dense_1950_test.go
@@ -33,7 +33,7 @@ func TestColumnPhysicalQ3DenseTypedColumnDirectPreparedParity1950(t *testing.T) 
 	if err != nil {
 		t.Fatalf("RunColumnPhysicalQuery(q3 dense): %v", err)
 	}
-	assertColumnPhysicalQ3DenseResult1950(t, "direct", direct, want, len(events), matchedRows)
+	assertColumnPhysicalQ3DenseResult1950(t, "direct", direct, want, len(events), matchedRows, matchedRows)
 
 	runner, err := col.PrepareColumnPhysicalQuery(req)
 	if err != nil {
@@ -45,7 +45,7 @@ func TestColumnPhysicalQ3DenseTypedColumnDirectPreparedParity1950(t *testing.T) 
 		if err != nil {
 			t.Fatalf("prepared q3 dense run %d: %v", run, err)
 		}
-		assertColumnPhysicalQ3DenseResult1950(t, fmt.Sprintf("prepared run %d", run), prepared, want, len(events), matchedRows)
+		assertColumnPhysicalQ3DenseResult1950(t, fmt.Sprintf("prepared run %d", run), prepared, want, 0, matchedRows, matchedRows)
 	}
 
 	noPredicateReq := req
@@ -71,7 +71,7 @@ func BenchmarkColumnPhysicalQ3DenseTypedColumn1950(b *testing.B) {
 		if err != nil {
 			b.Fatalf("preview RunColumnPhysicalQuery: %v", err)
 		}
-		assertColumnPhysicalQ3DenseDiagnostics1950(b, "preview direct", preview.Diagnostics, len(events), matchedRows, len(preview.Groups))
+		assertColumnPhysicalQ3DenseDiagnostics1950(b, "preview direct", preview.Diagnostics, len(events), matchedRows, matchedRows, len(preview.Groups))
 		b.SetBytes(int64(preview.Diagnostics.DecodedPayloadBytes))
 		b.ReportAllocs()
 		b.ResetTimer()
@@ -102,7 +102,7 @@ func BenchmarkColumnPhysicalQ3DenseTypedColumn1950(b *testing.B) {
 		if err != nil {
 			b.Fatalf("preview runner.Run: %v", err)
 		}
-		assertColumnPhysicalQ3DenseDiagnostics1950(b, "preview prepared", preview.Diagnostics, len(events), matchedRows, len(preview.Groups))
+		assertColumnPhysicalQ3DenseDiagnostics1950(b, "preview prepared", preview.Diagnostics, 0, matchedRows, matchedRows, len(preview.Groups))
 		b.SetBytes(int64(preview.Diagnostics.DecodedPayloadBytes))
 		b.ReportAllocs()
 		b.ResetTimer()
@@ -203,7 +203,7 @@ func columnPhysicalQ3DenseReferenceGroups1950(events []columnPhysicalJSONBenchPa
 	return groups
 }
 
-func assertColumnPhysicalQ3DenseResult1950(tb testing.TB, label string, result ColumnPhysicalQueryResult, want []ColumnPhysicalQueryGroup, rows, matchedRows int) {
+func assertColumnPhysicalQ3DenseResult1950(tb testing.TB, label string, result ColumnPhysicalQueryResult, want []ColumnPhysicalQueryGroup, wantRowsScanned, wantRowsMatched, wantReduceRows int) {
 	tb.Helper()
 	if len(result.Groups) != len(want) {
 		tb.Fatalf("%s groups=%+v want %+v", label, result.Groups, want)
@@ -213,10 +213,10 @@ func assertColumnPhysicalQ3DenseResult1950(tb testing.TB, label string, result C
 			tb.Fatalf("%s groups=%+v want %+v", label, result.Groups, want)
 		}
 	}
-	assertColumnPhysicalQ3DenseDiagnostics1950(tb, label, result.Diagnostics, rows, matchedRows, len(want))
+	assertColumnPhysicalQ3DenseDiagnostics1950(tb, label, result.Diagnostics, wantRowsScanned, wantRowsMatched, wantReduceRows, len(want))
 }
 
-func assertColumnPhysicalQ3DenseDiagnostics1950(tb testing.TB, label string, diag ColumnPhysicalQueryDiagnostics, rows, matchedRows, resultGroups int) {
+func assertColumnPhysicalQ3DenseDiagnostics1950(tb testing.TB, label string, diag ColumnPhysicalQueryDiagnostics, wantRowsScanned, wantRowsMatched, wantReduceRows, resultGroups int) {
 	tb.Helper()
 	if diag.StorageSource != ColumnPhysicalQueryStorageSourceTypedColumnPartSection || diag.FallbackReason != ColumnPhysicalQueryFallbackNone {
 		tb.Fatalf("%s diagnostics storage/fallback=%+v", label, diag)
@@ -227,8 +227,8 @@ func assertColumnPhysicalQ3DenseDiagnostics1950(tb testing.TB, label string, dia
 	if diag.RowMaterializations != 0 || diag.DocumentMaterializations != 0 {
 		tb.Fatalf("%s materialized rows/documents: %+v", label, diag)
 	}
-	if diag.RowsScanned != rows || diag.RowsMatched != matchedRows || diag.ReduceRows != matchedRows {
-		tb.Fatalf("%s rows scanned/matched/reduced=%d/%d/%d want %d/%d diagnostics=%+v", label, diag.RowsScanned, diag.RowsMatched, diag.ReduceRows, rows, matchedRows, diag)
+	if diag.RowsScanned != wantRowsScanned || diag.RowsMatched != wantRowsMatched || diag.ReduceRows != wantReduceRows {
+		tb.Fatalf("%s rows scanned/matched/reduced=%d/%d/%d want %d/%d/%d diagnostics=%+v", label, diag.RowsScanned, diag.RowsMatched, diag.ReduceRows, wantRowsScanned, wantRowsMatched, wantReduceRows, diag)
 	}
 	if diag.PredicateCount != 3 || diag.PredicateLiterals != 5 {
 		tb.Fatalf("%s predicate diagnostics=%+v want two equal predicates plus three-value IN", label, diag)

--- a/TreeDB/collections/column_physical_query.go
+++ b/TreeDB/collections/column_physical_query.go
@@ -152,6 +152,10 @@ type ColumnPhysicalQueryDiagnostics struct {
 	SortedGroupedDistinctFallbackReason string
 	DenseGroupCountUsed                 bool
 	DenseGroupCountDistinctUsed         bool
+	DenseGroupCountDistinctReducer      string
+	DenseGroupCountDistinctGroups       int
+	DenseGroupCountDistinctValues       int
+	DenseGroupCountDistinctPairBitWords int
 	DenseGroupHourCountUsed             bool
 	DenseInt64SpanUsed                  bool
 	TimeOrderTopKUsed                   bool
@@ -379,7 +383,7 @@ func (c *Collection) PrepareColumnPhysicalQuery(req ColumnPhysicalQueryRequest) 
 	readCache.returnViews = true
 	var metadata *columnAggregateMetadataRunner
 	var exec *columnPhysicalQueryExecutor
-	typedColumn, typedColumnCandidate, err := prepareColumnTypedColumnPhysicalQueryRunner(view, req, &readCache)
+	typedColumn, typedColumnCandidate, err := prepareColumnTypedColumnPhysicalQueryRunner(view, req, &readCache, true)
 	if err != nil {
 		_ = readCache.close()
 		return nil, err
@@ -1371,6 +1375,16 @@ func mergeColumnPhysicalQueryDiagnostics(left, right ColumnPhysicalQueryDiagnost
 	left.SortedGroupedDistinctFallbackReason = mergeColumnPhysicalSortKeyFallbackReason(left.SortedGroupedDistinctFallbackReason, right.SortedGroupedDistinctFallbackReason)
 	left.DenseGroupCountUsed = left.DenseGroupCountUsed || right.DenseGroupCountUsed
 	left.DenseGroupCountDistinctUsed = left.DenseGroupCountDistinctUsed || right.DenseGroupCountDistinctUsed
+	left.DenseGroupCountDistinctReducer = mergeColumnPhysicalQueryReducerLabel(left.DenseGroupCountDistinctReducer, right.DenseGroupCountDistinctReducer)
+	if right.DenseGroupCountDistinctGroups > left.DenseGroupCountDistinctGroups {
+		left.DenseGroupCountDistinctGroups = right.DenseGroupCountDistinctGroups
+	}
+	if right.DenseGroupCountDistinctValues > left.DenseGroupCountDistinctValues {
+		left.DenseGroupCountDistinctValues = right.DenseGroupCountDistinctValues
+	}
+	if right.DenseGroupCountDistinctPairBitWords > left.DenseGroupCountDistinctPairBitWords {
+		left.DenseGroupCountDistinctPairBitWords = right.DenseGroupCountDistinctPairBitWords
+	}
 	left.DenseGroupHourCountUsed = left.DenseGroupHourCountUsed || right.DenseGroupHourCountUsed
 	left.DenseInt64SpanUsed = left.DenseInt64SpanUsed || right.DenseInt64SpanUsed
 	left.TimeOrderTopKUsed = left.TimeOrderTopKUsed || right.TimeOrderTopKUsed
@@ -1403,6 +1417,16 @@ func mergeColumnPhysicalQueryStorageSource(left, right ColumnPhysicalQueryStorag
 		return left
 	}
 	return ColumnPhysicalQueryStorageSourceMixed
+}
+
+func mergeColumnPhysicalQueryReducerLabel(left, right string) string {
+	if left == "" {
+		return right
+	}
+	if right == "" || right == left {
+		return left
+	}
+	return "mixed"
 }
 
 func mergeColumnPhysicalQueryFallbackReason(left, right ColumnPhysicalQueryFallbackReason) ColumnPhysicalQueryFallbackReason {

--- a/TreeDB/collections/column_physical_typed_column_1947_test.go
+++ b/TreeDB/collections/column_physical_typed_column_1947_test.go
@@ -127,12 +127,16 @@ func TestColumnPhysicalJSONBenchTypedColumnPartDirectPreparedReopen1947(t *testi
 				t.Fatalf("PrepareColumnPhysicalQuery(%s): %v", tc.name, err)
 			}
 			defer func() { _ = runner.Close() }()
+			wantPreparedRowsScanned := len(scanned)
+			if tc.name == "q1" || tc.name == "q3" {
+				wantPreparedRowsScanned = 0
+			}
 			for run := 0; run < 2; run++ {
 				prepared, err := runner.Run()
 				if err != nil {
 					t.Fatalf("prepared %s run %d: %v", tc.name, run, err)
 				}
-				assertColumnPhysicalJSONBenchTypedColumnDiagnostics1947(t, tc.name, prepared.Diagnostics, len(scanned), tc.wantPredicates, tc.wantMatchedRows, tc.wantReduceRows)
+				assertColumnPhysicalJSONBenchTypedColumnDiagnostics1947(t, tc.name, prepared.Diagnostics, wantPreparedRowsScanned, tc.wantPredicates, tc.wantMatchedRows, tc.wantReduceRows)
 				preparedHash := columnPhysicalJSONBenchHashLinesP0(columnPhysicalJSONBenchPhysicalLinesP0(tc.name, prepared.Groups))
 				if preparedHash != rowHash {
 					t.Fatalf("%s prepared run %d hash=%016x want row scan %016x groups=%+v", tc.name, run, preparedHash, rowHash, prepared.Groups)
@@ -505,8 +509,8 @@ func TestColumnPhysicalJSONBenchTypedColumnPartPreparedRunnerPinsSnapshot1947(t 
 		t.Fatalf("prepared initial Run: %v", err)
 	}
 	firstHash := columnPhysicalJSONBenchHashLinesP0(columnPhysicalJSONBenchPhysicalLinesP0("q1", first.Groups))
-	if first.Diagnostics.RowsScanned != len(events) || first.Diagnostics.StorageSource != ColumnPhysicalQueryStorageSourceTypedColumnPartSection {
-		t.Fatalf("initial prepared diagnostics=%+v want typed-column snapshot rows=%d", first.Diagnostics, len(events))
+	if first.Diagnostics.RowsScanned != 0 || first.Diagnostics.ReduceRows != len(events) || first.Diagnostics.StorageSource != ColumnPhysicalQueryStorageSourceTypedColumnPartSection {
+		t.Fatalf("initial prepared diagnostics=%+v want typed-column summary over snapshot rows=%d", first.Diagnostics, len(events))
 	}
 
 	newEvent := columnPhysicalJSONBenchParityEventP0{ID: "e99", TimeUS: events[0].TimeUS + 99*columnPhysicalQueryHourUS, Kind: "commit", Operation: "create", Collection: "app.bsky.feed.reply", Did: "did_new"}
@@ -527,8 +531,8 @@ func TestColumnPhysicalJSONBenchTypedColumnPartPreparedRunnerPinsSnapshot1947(t 
 		t.Fatalf("prepared pinned Run after insert: %v", err)
 	}
 	pinnedHash := columnPhysicalJSONBenchHashLinesP0(columnPhysicalJSONBenchPhysicalLinesP0("q1", pinned.Groups))
-	if pinned.Diagnostics.RowsScanned != len(events) || pinnedHash != firstHash {
-		t.Fatalf("prepared pinned diagnostics=%+v hash=%016x want original rows=%d hash=%016x", pinned.Diagnostics, pinnedHash, len(events), firstHash)
+	if pinned.Diagnostics.RowsScanned != 0 || pinned.Diagnostics.ReduceRows != len(events) || pinnedHash != firstHash {
+		t.Fatalf("prepared pinned diagnostics=%+v hash=%016x want original summary rows=%d hash=%016x", pinned.Diagnostics, pinnedHash, len(events), firstHash)
 	}
 	if err := runner.Close(); err != nil {
 		t.Fatalf("runner Close: %v", err)

--- a/TreeDB/collections/column_physical_typed_column_query.go
+++ b/TreeDB/collections/column_physical_typed_column_query.go
@@ -11,6 +11,11 @@ import (
 
 const columnTypedColumnDenseGroupCountDistinctMaxBitsetWords = 2 << 20
 
+const (
+	columnTypedColumnDenseGroupCountDistinctReducerPairBitset    = "pair_bitset"
+	columnTypedColumnDenseGroupCountDistinctReducerPackedPairMap = "packed_pair_map"
+)
+
 type columnTypedColumnPhysicalQueryPlan struct {
 	Fields                  []TypedStorageField
 	Selected                []bool
@@ -128,6 +133,7 @@ type columnTypedColumnPhysicalQueryPart struct {
 type columnTypedColumnPhysicalQueryRunner struct {
 	plan                                  columnTypedColumnPhysicalQueryPlan
 	parts                                 []columnTypedColumnPhysicalQueryPart
+	aggregateSummary                      *columnTypedColumnPhysicalAggregateSummary
 	assetBytes                            int64
 	sections                              int
 	sectionBytes                          uint64
@@ -157,6 +163,14 @@ type columnTypedColumnPhysicalQueryRunner struct {
 	timeOrderHeap                         columnTypedColumnTimeOrderTopKHeap
 	timeOrderTopKScratch                  []ColumnPhysicalQueryGroup
 	resultGroups                          []ColumnPhysicalQueryGroup
+}
+
+type columnTypedColumnPhysicalAggregateSummary struct {
+	groups              []ColumnPhysicalQueryGroup
+	matchedRows         int
+	reduceRows          int
+	denseGroupCount     bool
+	denseGroupHourCount bool
 }
 
 func (c *Collection) runColumnPhysicalQueryTypedColumnPartInSnapshotView(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest) (ColumnPhysicalQueryResult, bool, error) {
@@ -189,7 +203,7 @@ func (c *Collection) runColumnPhysicalQueryTypedColumnPartInSnapshotView(view co
 	}
 	readCache.returnViews = true
 	defer func() { _ = readCache.close() }()
-	runner, candidate, err := prepareColumnTypedColumnPhysicalQueryRunner(view, req, &readCache)
+	runner, candidate, err := prepareColumnTypedColumnPhysicalQueryRunner(view, req, &readCache, false)
 	if err != nil || !candidate {
 		result := ColumnPhysicalQueryResult{}
 		result.Diagnostics.ScanNanos = time.Since(start).Nanoseconds()
@@ -362,7 +376,7 @@ func applyTypedColumnLatestVisibilityDiagnostics(diag *ColumnPhysicalQueryDiagno
 	diag.VisibilityNanos = visibilityNanos
 }
 
-func prepareColumnTypedColumnPhysicalQueryRunner(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest, readCache *columnPhysicalAssetReadCache) (*columnTypedColumnPhysicalQueryRunner, bool, error) {
+func prepareColumnTypedColumnPhysicalQueryRunner(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest, readCache *columnPhysicalAssetReadCache, prepareSummaries bool) (*columnTypedColumnPhysicalQueryRunner, bool, error) {
 	if !columnTypedColumnPhysicalQueryTouchesTypedColumnPart(view.FullConfig, req) {
 		return nil, false, nil
 	}
@@ -393,6 +407,11 @@ func prepareColumnTypedColumnPhysicalQueryRunner(view columnPhysicalScanSnapshot
 	runner, err := decodeColumnTypedColumnPhysicalQueryRunnerParts(view, req, plan, refsByGeneration, readCache, false)
 	if err != nil {
 		return nil, true, err
+	}
+	if prepareSummaries {
+		if err := prepareColumnTypedColumnPhysicalAggregateSummary(runner, req); err != nil {
+			return nil, true, err
+		}
 	}
 	return runner, true, nil
 }
@@ -482,6 +501,164 @@ func decodeColumnTypedColumnPhysicalQueryRunnerParts(view columnPhysicalScanSnap
 		}
 	}
 	return runner, nil
+}
+
+func prepareColumnTypedColumnPhysicalAggregateSummary(runner *columnTypedColumnPhysicalQueryRunner, req ColumnPhysicalQueryRequest) error {
+	if runner == nil {
+		return nil
+	}
+	var (
+		summary *columnTypedColumnPhysicalAggregateSummary
+		err     error
+	)
+	switch {
+	case columnTypedColumnPhysicalQueryUseDenseGroupCount(runner.plan, req):
+		summary, err = buildColumnTypedColumnDenseGroupCountSummary(runner.parts)
+	case columnTypedColumnPhysicalQueryUseDenseGroupHourCount(runner.plan, req):
+		summary, err = buildColumnTypedColumnDenseGroupHourCountSummary(runner.parts)
+	}
+	if err != nil {
+		return err
+	}
+	runner.aggregateSummary = summary
+	return nil
+}
+
+func buildColumnTypedColumnDenseGroupCountSummary(parts []columnTypedColumnPhysicalQueryPart) (*columnTypedColumnPhysicalAggregateSummary, error) {
+	counts := make(map[string]int, 16)
+	reduceRows := 0
+	var localCounts []int
+	for partIdx := range parts {
+		dense := parts[partIdx].DenseGroupCount
+		if dense == nil {
+			return nil, fmt.Errorf("collections: dense typed-column group-count missing prepared part %d", partIdx)
+		}
+		if dense.Cardinality == 0 && len(dense.Codes) != 0 {
+			return nil, fmt.Errorf("collections: dense typed-column group-count part %d has empty dictionary", partIdx)
+		}
+		if cap(localCounts) < dense.Cardinality {
+			localCounts = make([]int, dense.Cardinality)
+		} else {
+			localCounts = localCounts[:dense.Cardinality]
+			clear(localCounts)
+		}
+		for rowIdx, code := range dense.Codes {
+			localIdx, ok := columnDictionaryCodeIndex(code, len(localCounts))
+			if !ok {
+				return nil, fmt.Errorf("collections: dense typed-column group-count part %d code[%d]=%d outside cardinality=%d", partIdx, rowIdx, code, len(localCounts))
+			}
+			localCounts[localIdx]++
+		}
+		reduceRows += len(dense.Codes)
+		for localCode, count := range localCounts {
+			if count == 0 {
+				continue
+			}
+			key, ok := dense.DictionaryByCode[int64(localCode)]
+			if !ok {
+				return nil, fmt.Errorf("collections: dense typed-column group-count part %d dictionary missing local code %d", partIdx, localCode)
+			}
+			counts[key] += count
+		}
+	}
+	groups := make([]ColumnPhysicalQueryGroup, 0, len(counts))
+	for key, count := range counts {
+		if count == 0 {
+			continue
+		}
+		groups = append(groups, ColumnPhysicalQueryGroup{Key: key, Count: count})
+	}
+	sortColumnPhysicalQueryGroupsByKey(groups)
+	return &columnTypedColumnPhysicalAggregateSummary{
+		groups:          groups,
+		reduceRows:      reduceRows,
+		denseGroupCount: true,
+	}, nil
+}
+
+func buildColumnTypedColumnDenseGroupHourCountSummary(parts []columnTypedColumnPhysicalQueryPart) (*columnTypedColumnPhysicalAggregateSummary, error) {
+	counts := make(map[string][24]int, 16)
+	matchedRows := 0
+	reduceRows := 0
+	var localHourCounts []int
+	for partIdx := range parts {
+		dense := parts[partIdx].DenseGroupHourCount
+		if dense == nil {
+			return nil, fmt.Errorf("collections: dense typed-column group-hour missing prepared part %d", partIdx)
+		}
+		if dense.Cardinality == 0 && len(dense.GroupCodes) != 0 {
+			return nil, fmt.Errorf("collections: dense typed-column group-hour part %d has empty dictionary", partIdx)
+		}
+		if len(dense.GroupCodes) != len(dense.Values) {
+			return nil, fmt.Errorf("collections: dense typed-column group-hour part %d group/value rows=%d/%d", partIdx, len(dense.GroupCodes), len(dense.Values))
+		}
+		needLocal := dense.Cardinality * 24
+		if cap(localHourCounts) < needLocal {
+			localHourCounts = make([]int, needLocal)
+		} else {
+			localHourCounts = localHourCounts[:needLocal]
+			clear(localHourCounts)
+		}
+		if columnTypedColumnDensePredicatesRejectAll(dense.Predicates) {
+			continue
+		}
+		for rowIdx, code := range dense.GroupCodes {
+			if !columnTypedColumnDensePredicatesMatch(dense.Predicates, rowIdx) {
+				continue
+			}
+			if len(dense.Predicates) != 0 {
+				matchedRows++
+			}
+			reduceRows++
+			localIdx, ok := columnDictionaryCodeIndex(code, dense.Cardinality)
+			if !ok {
+				return nil, fmt.Errorf("collections: dense typed-column group-hour part %d code[%d]=%d outside cardinality=%d", partIdx, rowIdx, code, dense.Cardinality)
+			}
+			hour := columnPhysicalQueryUTCHour(dense.Values[rowIdx])
+			localHourCounts[localIdx*24+hour]++
+		}
+		for localCode := 0; localCode < dense.Cardinality; localCode++ {
+			key := ""
+			var byHour [24]int
+			seen := false
+			base := localCode * 24
+			for hour := 0; hour < 24; hour++ {
+				count := localHourCounts[base+hour]
+				if count == 0 {
+					continue
+				}
+				if !seen {
+					var ok bool
+					key, ok = dense.DictionaryByCode[int64(localCode)]
+					if !ok {
+						return nil, fmt.Errorf("collections: dense typed-column group-hour part %d dictionary missing local code %d", partIdx, localCode)
+					}
+					byHour = counts[key]
+					seen = true
+				}
+				byHour[hour] += count
+			}
+			if seen {
+				counts[key] = byHour
+			}
+		}
+	}
+	groups := make([]ColumnPhysicalQueryGroup, 0, len(counts))
+	for key, byHour := range counts {
+		for hour, count := range byHour {
+			if count == 0 {
+				continue
+			}
+			groups = append(groups, ColumnPhysicalQueryGroup{Key: key, Hour: hour, Count: count})
+		}
+	}
+	sortColumnPhysicalQueryGroupsByKeyHour(groups)
+	return &columnTypedColumnPhysicalAggregateSummary{
+		groups:              groups,
+		matchedRows:         matchedRows,
+		reduceRows:          reduceRows,
+		denseGroupHourCount: true,
+	}, nil
 }
 
 func prepareColumnTypedColumnSortedGroupedDistinctGlobalCodes(parts []columnTypedColumnPhysicalQueryPart) error {
@@ -1014,7 +1191,22 @@ func decodeTypedColumnPhysicalQueryPart(plan columnTypedColumnPhysicalQueryPlan,
 	}, nil
 }
 
+func (s *columnTypedColumnPhysicalAggregateSummary) run(r *columnTypedColumnPhysicalQueryRunner, view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest) (ColumnPhysicalQueryResult, error) {
+	start := time.Now()
+	r.resultGroups = append(r.resultGroups[:0], s.groups...)
+	diag := r.diagnostics(view, req, 0, s.matchedRows, s.reduceRows, time.Since(start).Nanoseconds())
+	diag.DenseGroupCountUsed = s.denseGroupCount
+	diag.DenseGroupHourCountUsed = s.denseGroupHourCount
+	result := ColumnPhysicalQueryResult{Groups: r.resultGroups, Diagnostics: diag}
+	finalizeColumnPhysicalQueryResultGroups(req, &result)
+	r.resultGroups = result.Groups
+	return result, nil
+}
+
 func (r *columnTypedColumnPhysicalQueryRunner) run(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest) (ColumnPhysicalQueryResult, error) {
+	if r.aggregateSummary != nil {
+		return r.aggregateSummary.run(r, view, req)
+	}
 	if columnTypedColumnPhysicalQueryUseTimeOrderTopK(r.plan, req) {
 		return r.runTimeOrderTopK(view, req)
 	}
@@ -2174,11 +2366,26 @@ func (r *columnTypedColumnPhysicalQueryRunner) runDenseGroupCountDistinct(view c
 	sortColumnPhysicalQueryGroupsByKey(r.resultGroups)
 	diag := r.diagnostics(view, req, rowsScanned, matchedRows, reduceRows, time.Since(start).Nanoseconds())
 	diag.DenseGroupCountDistinctUsed = true
+	annotateColumnTypedColumnDenseGroupCountDistinctDiagnostics(&diag, groupCardinality, distinctCardinality, pairBitWords, usePairBitset)
 	diag.ResultGroups = len(r.resultGroups)
 	result := ColumnPhysicalQueryResult{Groups: r.resultGroups, Diagnostics: diag}
 	finalizeColumnPhysicalQueryResultGroups(req, &result)
 	r.resultGroups = result.Groups
 	return result, nil
+}
+
+func annotateColumnTypedColumnDenseGroupCountDistinctDiagnostics(diag *ColumnPhysicalQueryDiagnostics, groupCardinality, distinctCardinality, pairBitWords int, usePairBitset bool) {
+	if diag == nil {
+		return
+	}
+	diag.DenseGroupCountDistinctGroups = groupCardinality
+	diag.DenseGroupCountDistinctValues = distinctCardinality
+	diag.DenseGroupCountDistinctPairBitWords = pairBitWords
+	if usePairBitset {
+		diag.DenseGroupCountDistinctReducer = columnTypedColumnDenseGroupCountDistinctReducerPairBitset
+		return
+	}
+	diag.DenseGroupCountDistinctReducer = columnTypedColumnDenseGroupCountDistinctReducerPackedPairMap
 }
 
 func (r *columnTypedColumnPhysicalQueryRunner) runDenseGroupHourCount(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest) (ColumnPhysicalQueryResult, error) {
@@ -2381,19 +2588,33 @@ func (r *columnTypedColumnPhysicalQueryRunner) runDenseInt64Span(view columnPhys
 			r.denseSpanValues[key] = cur
 		}
 	}
+	scanNanos := time.Since(start).Nanoseconds()
 	r.resultGroups = r.resultGroups[:0]
+	diag := r.diagnostics(view, req, rowsScanned, matchedRows, reduceRows, scanNanos)
+	diag.DenseInt64SpanUsed = true
+	if req.TopK > 0 {
+		shapeStart := time.Now()
+		candidates := 0
+		for key, span := range r.denseSpanValues {
+			if req.SkipEmptyGroupKey && key == "" {
+				continue
+			}
+			candidates++
+			insertColumnPhysicalTopKGroup(&r.resultGroups, ColumnPhysicalQueryGroup{Key: key, Int64: span.max - span.min}, req.TopK, req.TopKOrder)
+		}
+		diag.ResultShapeNanos += time.Since(shapeStart).Nanoseconds()
+		diag.TopKLimit = req.TopK
+		diag.TopKOrder = string(req.TopKOrder)
+		diag.TopKCandidates = candidates
+		diag.ResultGroups = len(r.resultGroups)
+		return ColumnPhysicalQueryResult{Groups: r.resultGroups, Diagnostics: diag}, nil
+	}
 	for key, span := range r.denseSpanValues {
 		r.resultGroups = append(r.resultGroups, ColumnPhysicalQueryGroup{Key: key, Int64: span.max - span.min})
 	}
-	if req.TopK == 0 {
-		sortColumnPhysicalQueryGroupsByKey(r.resultGroups)
-	}
-	diag := r.diagnostics(view, req, rowsScanned, matchedRows, reduceRows, time.Since(start).Nanoseconds())
-	diag.DenseInt64SpanUsed = true
-	result := ColumnPhysicalQueryResult{Groups: r.resultGroups, Diagnostics: diag}
-	finalizeColumnPhysicalQueryResultGroups(req, &result)
-	r.resultGroups = result.Groups
-	return result, nil
+	sortColumnPhysicalQueryGroupsByKey(r.resultGroups)
+	diag.ResultGroups = len(r.resultGroups)
+	return ColumnPhysicalQueryResult{Groups: r.resultGroups, Diagnostics: diag}, nil
 }
 
 func columnTypedColumnDensePredicatesRejectAll(predicates []columnTypedColumnDensePredicatePart) bool {

--- a/TreeDB/docs/spec/typed-column-production-jsonbench-plan.md
+++ b/TreeDB/docs/spec/typed-column-production-jsonbench-plan.md
@@ -1105,6 +1105,13 @@ Reports must never merge direct and prepared rows. Prepared rows can show the
 steady-state service ceiling; direct rows show ad-hoc query performance and are
 the primary optimization target in this plan.
 
+Current production prepared runners may build exact reusable summaries during
+setup for predicate-compatible q1 and q3 typed-column scans. Hot prepared `Run`
+calls can then answer those queries without scanning data rows while preserving
+the same result hash and reducer cardinality diagnostics as the direct path.
+This is a prepared-service ceiling, not a substitute for direct or persisted
+summary work; benchmark reports must still keep direct q1/q3 rows visible.
+
 ## Direct vs Prepared Contract
 
 Direct and prepared share logical query semantics, result shape, diagnostics, and
@@ -1129,6 +1136,11 @@ Prepared query requirements:
   state no longer matches.
 - Prepared rows are allowed to outperform direct rows, but they must not be used
   to hide poor direct performance.
+
+Top-K result shaping should avoid materializing the full candidate result set
+when the query only needs a bounded Top-K. For q5 dense-span scans, keep the
+candidate counter diagnostic, but feed candidates directly into the bounded
+Top-K reducer instead of appending every user span before trimming.
 
 Shared implementation preference:
 


### PR DESCRIPTION
## Summary

Refs #3000, #3001, #2892, #3002, #3003.

This is the first implementation slice for the TreeDB JSONBench q1-q5 production-default performance graph. It keeps the production typed-column path as the target and avoids benchmark-only shortcuts.

- Add prepared typed-column exact summaries for q1 dense group-count and q3 dense group-hour-count. Prepared hot `Run` now returns exact results with `RowsScanned=0`, while direct one-shot q1/q3 remains visible as the direct-performance target.
- Add q2 dense grouped count-distinct reducer diagnostics for reducer representation, group cardinality, distinct cardinality, and pair-bitset size. This makes future q2 profile decisions explicit instead of inferring from map/bitset costs.
- Shape q5 dense-span TopK directly into a bounded TopK result slice instead of materializing every candidate group before trimming.
- Document the prepared q1/q3 ceiling and q5 bounded TopK expectation in the typed-column production JSONBench plan.

## Evidence

Focused changed-path tests:

```sh
go test ./TreeDB/collections -run 'TestColumnPhysicalQ1DenseTypedColumnDirectPreparedParity1950|TestColumnPhysicalQ3DenseTypedColumnDirectPreparedParity1950|TestColumnPhysicalJSONBenchTypedColumnPartDirectPreparedReopen1947|TestColumnPhysicalJSONBenchTypedColumnPartPreparedRunnerPinsSnapshot1947|TestTypedColumnQ2DenseGroupCountDistinctNoSortLocalDictionaries1950|TestTypedColumnQ2DenseGroupCountDistinctBitsetLayout1950|TestColumnPhysicalQ5DenseTypedColumnDirectPreparedParity1950' -count=1
```

Result: `ok github.com/snissn/gomap/TreeDB/collections 1.024s`

q4a/q4b neighboring production guards:

```sh
go test ./TreeDB/collections -run 'TestColumnPhysicalQ4ATimeOrderTopKDirectPreparedParity1950|TestTypedColumnQ4BTopKMarkPrunedParity1950|TestTypedColumnSortKeyQ4BMarkPrunedParity1949|TestColumnPhysicalQ4ATimeOrderLatestVisibleMutationReopen1953|TestColumnPhysicalQ4BTopKSortedLatestVisibleMutation1953' -count=1
```

Result: `ok github.com/snissn/gomap/TreeDB/collections 2.020s`

Docs package:

```sh
go test ./TreeDB/docs -count=1
```

Result: `ok github.com/snissn/gomap/TreeDB/docs 1.195s`

Collection package during full run:

```sh
go test ./...
```

Result: failed only in `github.com/snissn/gomap/TreeDB/db` on `TestLeafGenerationGC_RemovesUnreachableMultiLaneSegmentsAfterReopen`; `TreeDB/collections` passed in `110.697s`. I verified the exact failing DB test also fails on current `origin/main` at `86afe5fc8`, so this is tracked as baseline breakage rather than introduced by this PR.

Baseline failure verification:

```sh
go test ./TreeDB/db -run '^TestLeafGenerationGC_RemovesUnreachableMultiLaneSegmentsAfterReopen$' -count=1
```

On `origin/main` `86afe5fc8`: fails with `sealed mid-generation lane segments=1 want >=2`.

Microbenchmarks on Apple M3:

```sh
go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnPhysicalQ1DenseTypedColumn1950|BenchmarkColumnPhysicalQ3DenseTypedColumn1950|BenchmarkColumnPhysicalQ5DenseTypedColumn1950|BenchmarkTypedColumnQ2SortedGroupedDistinct1950' -benchtime=100x -count=3
```

Notable current-head results:

- q1 prepared: `367-370 ns/op`, `0 rows_scanned/op`, `0 B/op`, `0 allocs/op`.
- q3 prepared: `417-442 ns/op`, `0 rows_scanned/op`, `0 B/op`, `0 allocs/op`.
- q5 prepared: `207-209 us/op`, `0 B/op`, `0 allocs/op`, `2046 topk_candidates/op`.
- q2 prepared sorted-prefix: `659-666 us/op`, `267 B/op`, `2 allocs/op`.
- q2 prepared primary-id fallback: `348-354 us/op`, `44 B/op`, `0 allocs/op`.

JSONBench 6-row smoke:

```sh
OUT_DIR=/tmp/jsonbench_treedb_smoke_3000_20260625_075225 \
DATA_DIR=./testdata/bluesky \
ROWS=6 \
TRIES=1 \
GOMAP_REPLACE=/Users/michaelseiler/dev/snissn/gomap-clean \
STORAGE_LAYOUTS=column-store-full-prepared \
SUITE=full \
VALIDATE_RECONSTRUCTION=1 \
./run_columnstore_benchmark.sh
```

Result: passed for q1-q5. Artifacts: `/tmp/jsonbench_treedb_smoke_3000_20260625_075225/report.md` and `/tmp/jsonbench_treedb_smoke_3000_20260625_075225/columnstore_summary.md`.

Caveat: the external JSONBench summary still reports loaded-row fallback counts for q1/q3 prepared physical scan rows because that harness treats zero non-metadata diagnostics as unknown scanned rows. The gomap tests and benchmarks above validate the new prepared q1/q3 `RowsScanned=0` behavior.

## Follow-up Gates

The 1M/10M TreeDB-vs-ClickHouse comparison remains blocked locally by missing full Bluesky data under `$HOME/data/bluesky` and no `clickhouse` binary in `PATH`. The command to run after those are available is:

```sh
cd /Users/michaelseiler/dev/snissn/JSONBench/treedb
OUT_DIR=/tmp/jsonbench_preferred_columnstore_clickhouse_$(date -u +%Y%m%d_%H%M%S) \
DATA_DIR="$HOME/data/bluesky" \
ROWS=10000000 \
TRIES=3 \
GOMAP_REPLACE=/Users/michaelseiler/dev/snissn/gomap-clean \
./run_preferred_columnstore_clickhouse_compare.sh
```
