### PR TITLE
Optimize TreeDB ordered-root batch publish

### DIFF
--- a/TreeDB/db/ordered_root_publish.go
+++ b/TreeDB/db/ordered_root_publish.go
@@ -903,6 +903,17 @@ func (db *DB) publishOrderedRootDeltaBatch(baseRoot uint64, delta *batch.Batch, 
 	return db.publishOrderedRootDeltaBatchWithAllocator(idx, baseRoot, delta, opts, idx.allocator, &pagerAllocator{p: idx.pager}, false)
 }
 
+func (db *DB) orderedRootDeltaBatchApplyOptions() zipper.ApplyOptions {
+	applyOpts := db.flushApplyOptions()
+	applyOpts.SpanNativeApply = false
+	applyOpts.SpanNativeForceFallbackReason = ""
+	if applyOpts.ParallelApplyConcurrency <= 1 {
+		applyOpts.PrepareReadOnly = false
+		applyOpts.ReadOnlyPrepareWorkers = 0
+	}
+	return applyOpts
+}
+
 func (db *DB) publishOrderedRootDeltaBatchWithAllocator(idx *indexGen, baseRoot uint64, delta *batch.Batch, opts orderedRootPublishOptions, alloc zipper.PageAllocator, coldBuildAlloc bulk.Allocator, includeDeletedOnColdBuild bool) (newRoot uint64, retired []uint64, metrics adaptive.Metrics, err error) {
 	if db == nil {
 		err = ErrClosed
@@ -950,6 +961,21 @@ func (db *DB) publishOrderedRootDeltaBatchWithAllocator(idx *indexGen, baseRoot 
 	rootZipper, err := db.orderedRootZipperForOptionsWithAllocator(idx, opts, alloc)
 	if err != nil {
 		return 0, nil, metrics, err
+	}
+	applyOpts := db.orderedRootDeltaBatchApplyOptions()
+	prepareBuf := db.acquireFlushApplyReadOnlyPrepareBuffer(applyOpts)
+	if prepareBuf != nil {
+		applyOpts.ReadOnlyPrepare = prepareBuf.opts
+	}
+	if flushApplyUseOptions(applyOpts) {
+		result, applyErr := rootZipper.ApplyWithOptions(baseRoot, delta, applyOpts)
+		db.observeFlushApplyPrepareResult(result, applyErr)
+		db.releaseFlushApplyReadOnlyPrepareBuffer(prepareBuf, &result)
+		newRoot = result.RootID
+		retired = result.PendingRetiredPages
+		metrics = result.Metrics
+		err = applyErr
+		return
 	}
 	newRoot, retired, metrics, err = rootZipper.Apply(baseRoot, delta)
 	return
@@ -2586,39 +2612,35 @@ func (db *DB) publishOrderedRootDeltaBatchGroupWithSystemDeltaBuilderSerialized(
 			db.releasePendingValueLogAppendPtrCollector(collector)
 		}
 	}()
-	for idx := range ordered {
-		opts, err := db.orderedRootPublishOptionsForPolicy(ordered[idx].StoragePolicy)
-		if err != nil {
-			return 0, nil, err
-		}
-		if ordered[idx].PrepareReadOnly {
-			rootZipper, prepErr := db.orderedRootZipperForOptionsWithAllocator(idxGen, opts, idxGen.allocator)
-			if prepErr != nil {
-				return 0, nil, prepErr
-			}
-			summary, workerSummary, prepareNs, validationFailed, prepErr := db.runOrderedRootDeltaBatchReadOnlyPrepare(rootZipper, ordered[idx].BaseRoot, ordered[idx].Delta, ordered[idx].ReadOnlyPrepareWorkers)
-			addOrderedRootReadOnlyPreparePhaseStats(&phaseStats, summary, workerSummary, prepareNs, prepErr, validationFailed)
-			db.observeFlushApplyReadOnlyPrepare(summary, workerSummary, prepareNs, prepErr, validationFailed)
-			if prepErr != nil {
-				return 0, nil, prepErr
+	if err = db.prepareOrderedRootDeltaBatchGroupReadOnly(idxGen, ordered, idxGen.allocator, &phaseStats); err != nil {
+		return 0, nil, err
+	}
+	phaseStart := time.Now()
+	rootApplyResults, parallelRootApply := db.applyOrderedRootDeltaBatchGroupRoots(idxGen, ordered, idxGen.allocator, &pagerAllocator{p: idxGen.pager})
+	phaseStats.rootApplyNs += orderedRootDeltaGroupPhaseDurationNs(phaseStart)
+	if parallelRootApply {
+		phaseStats.rootApplyParallelGroups++
+		for idx := range ordered {
+			if ordered[idx].ParallelApply && ordered[idx].Delta != nil && !ordered[idx].Delta.IsEmpty() {
+				phaseStats.rootApplyParallelRoots++
 			}
 		}
-		phaseStart := time.Now()
-		rootID, rootRetired, metrics, err := db.publishOrderedRootDeltaBatchWithAllocator(idxGen, ordered[idx].BaseRoot, ordered[idx].Delta, opts, idxGen.allocator, &pagerAllocator{p: idxGen.pager}, ordered[idx].IncludeDeletedOnColdBuild)
-		phaseStats.rootApplyNs += orderedRootDeltaGroupPhaseDurationNs(phaseStart)
-		phaseStats.rootApplyCalls++
-		if err != nil {
-			return 0, nil, err
+	}
+	for idx := range rootApplyResults {
+		result := rootApplyResults[idx]
+		if result.err != nil {
+			return 0, nil, result.err
 		}
 		touchedValueLogSegments = appendOrderedRootDeltaBatchFinalTouchedValueLogSegments(ordered[idx].Delta, touchedValueLogSegments)
-		rootIDs[idx] = rootID
+		rootIDs[idx] = result.rootID
 		rootsObserved++
-		retired = append(retired, rootRetired...)
-		mergeOrderedRootPublishMetrics(&merged, metrics)
-		phaseStats.rootApplyMetrics.add(metrics)
+		retired = append(retired, result.retired...)
+		mergeOrderedRootPublishMetrics(&merged, result.metrics)
+		phaseStats.rootApplyMetrics.add(result.metrics)
+		phaseStats.rootApplyCalls++
 	}
 
-	phaseStart := time.Now()
+	phaseStart = time.Now()
 	iter, err := buildSystemDeltaIter(append([]uint64(nil), rootIDs...))
 	phaseStats.systemBuildNs += orderedRootDeltaGroupPhaseDurationNs(phaseStart)
 	if err != nil {
@@ -2787,39 +2809,35 @@ func (db *DB) publishOrderedRootDeltaBatchGroupWithCommandWALContextAndSystemDel
 			db.releasePendingValueLogAppendPtrCollector(collector)
 		}
 	}()
-	for idx := range allOrdered {
-		opts, err := db.orderedRootPublishOptionsForPolicy(allOrdered[idx].StoragePolicy)
-		if err != nil {
-			return 0, nil, err
-		}
-		if allOrdered[idx].PrepareReadOnly {
-			rootZipper, prepErr := db.orderedRootZipperForOptionsWithAllocator(idxGen, opts, idxGen.allocator)
-			if prepErr != nil {
-				return 0, nil, prepErr
-			}
-			summary, workerSummary, prepareNs, validationFailed, prepErr := db.runOrderedRootDeltaBatchReadOnlyPrepare(rootZipper, allOrdered[idx].BaseRoot, allOrdered[idx].Delta, allOrdered[idx].ReadOnlyPrepareWorkers)
-			addOrderedRootReadOnlyPreparePhaseStats(&phaseStats, summary, workerSummary, prepareNs, prepErr, validationFailed)
-			db.observeFlushApplyReadOnlyPrepare(summary, workerSummary, prepareNs, prepErr, validationFailed)
-			if prepErr != nil {
-				return 0, nil, prepErr
+	if err = db.prepareOrderedRootDeltaBatchGroupReadOnly(idxGen, allOrdered, idxGen.allocator, &phaseStats); err != nil {
+		return 0, nil, err
+	}
+	phaseStart := time.Now()
+	rootApplyResults, parallelRootApply := db.applyOrderedRootDeltaBatchGroupRoots(idxGen, allOrdered, idxGen.allocator, &pagerAllocator{p: idxGen.pager})
+	phaseStats.rootApplyNs += orderedRootDeltaGroupPhaseDurationNs(phaseStart)
+	if parallelRootApply {
+		phaseStats.rootApplyParallelGroups++
+		for idx := range allOrdered {
+			if allOrdered[idx].ParallelApply && allOrdered[idx].Delta != nil && !allOrdered[idx].Delta.IsEmpty() {
+				phaseStats.rootApplyParallelRoots++
 			}
 		}
-		phaseStart := time.Now()
-		rootID, rootRetired, metrics, err := db.publishOrderedRootDeltaBatchWithAllocator(idxGen, allOrdered[idx].BaseRoot, allOrdered[idx].Delta, opts, idxGen.allocator, &pagerAllocator{p: idxGen.pager}, allOrdered[idx].IncludeDeletedOnColdBuild)
-		phaseStats.rootApplyNs += orderedRootDeltaGroupPhaseDurationNs(phaseStart)
-		phaseStats.rootApplyCalls++
-		if err != nil {
-			return 0, nil, err
+	}
+	for idx := range rootApplyResults {
+		result := rootApplyResults[idx]
+		if result.err != nil {
+			return 0, nil, result.err
 		}
 		touchedValueLogSegments = appendOrderedRootDeltaBatchFinalTouchedValueLogSegments(allOrdered[idx].Delta, touchedValueLogSegments)
-		rootIDs[idx] = rootID
+		rootIDs[idx] = result.rootID
 		rootsObserved++
-		retired = append(retired, rootRetired...)
-		mergeOrderedRootPublishMetrics(&merged, metrics)
-		phaseStats.rootApplyMetrics.add(metrics)
+		retired = append(retired, result.retired...)
+		mergeOrderedRootPublishMetrics(&merged, result.metrics)
+		phaseStats.rootApplyMetrics.add(result.metrics)
+		phaseStats.rootApplyCalls++
 	}
 
-	phaseStart := time.Now()
+	phaseStart = time.Now()
 	iter, err := buildSystemDeltaIter(ctx, rootIDs)
 	phaseStats.systemBuildNs += orderedRootDeltaGroupPhaseDurationNs(phaseStart)
 	if err != nil {

--- a/TreeDB/db/ordered_root_publish_test.go
+++ b/TreeDB/db/ordered_root_publish_test.go
@@ -2337,6 +2337,186 @@ func TestPublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder_OptimisticAppli
 	}
 }
 
+func TestPublishOrderedRootDeltaBatchGroupWithCommandWALAndSystemDeltaBuilder_AppliesRootsInParallel(t *testing.T) {
+	dir := t.TempDir()
+	enableCommandWALFormat(t, dir)
+	db := openCommandWALDB(t, dir)
+	defer db.Close()
+
+	deltaAIter := mustFrozenSystemMemtable(t, "a/1", "delta-a").NewIterator(nil, nil)
+	deltaA, err := OrderedRootDeltaBatchFromIterator(deltaAIter)
+	_ = deltaAIter.Close()
+	if err != nil {
+		t.Fatalf("delta a batch: %v", err)
+	}
+	defer func() { _ = deltaA.Close() }()
+
+	deltaBIter := mustFrozenSystemMemtable(t, "b/1", "delta-b").NewIterator(nil, nil)
+	deltaB, err := OrderedRootDeltaBatchFromIterator(deltaBIter)
+	_ = deltaBIter.Close()
+	if err != nil {
+		t.Fatalf("delta b batch: %v", err)
+	}
+	defer func() { _ = deltaB.Close() }()
+
+	systemRoot, rootIDs, err := db.PublishOrderedRootDeltaBatchGroupWithCommandWALAndSystemDeltaBuilder([]OrderedRootDeltaBatchPublishInput{
+		{BaseRoot: 0, Delta: deltaA, ParallelApply: true},
+		{BaseRoot: 0, Delta: deltaB, ParallelApply: true},
+	}, mustRawKVCommandWALIntent(t, db, "cmd/parallel-roots", "1"), func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+		if len(rootIDs) != 2 || rootIDs[0] == 0 || rootIDs[1] == 0 {
+			return nil, errors.New("unexpected command WAL root IDs")
+		}
+		return mustFrozenSystemMemtable(t,
+			"sys/collections/users/a", strconv.FormatUint(rootIDs[0], 10),
+			"sys/collections/users/b", strconv.FormatUint(rootIDs[1], 10),
+		).NewIterator(nil, nil), nil
+	})
+	if err != nil {
+		t.Fatalf("publish command WAL delta batch group: %v", err)
+	}
+	if systemRoot == 0 || len(rootIDs) != 2 || rootIDs[0] == 0 || rootIDs[1] == 0 {
+		t.Fatalf("systemRoot=%d rootIDs=%v, want non-zero system root and two non-zero roots", systemRoot, rootIDs)
+	}
+	if got := db.State().AppliedCommandLSN; got == 0 {
+		t.Fatalf("AppliedCommandLSN=%d, want command WAL frame applied", got)
+	}
+	requireCommandWALPublishReady(t, db, "parallel command WAL root publish")
+
+	snap := db.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("expected snapshot")
+	}
+	defer func() { _ = snap.Close() }()
+	for rootIdx, kv := range []map[string]string{
+		{"a/1": "delta-a"},
+		{"b/1": "delta-b"},
+	} {
+		for key, want := range kv {
+			entry, err := snap.GetEntryAtRoot(rootIDs[rootIdx], []byte(key))
+			if err != nil {
+				t.Fatalf("GetEntryAtRoot(root=%d key=%s): %v", rootIdx, key, err)
+			}
+			if got := string(entry.Value); got != want {
+				t.Fatalf("root=%d key=%s got=%q want %q", rootIdx, key, got, want)
+			}
+		}
+	}
+
+	stats := db.Stats()
+	if got := stats["treedb.publish.ordered_root_delta_group.root_apply_parallel_groups_total"]; got != "1" {
+		t.Fatalf("parallel groups stat=%q want 1", got)
+	}
+	if got := stats["treedb.publish.ordered_root_delta_group.root_apply_parallel_roots_total"]; got != "2" {
+		t.Fatalf("parallel roots stat=%q want 2", got)
+	}
+	if got := stats["treedb.publish.ordered_root_delta_group.root_apply_calls_total"]; got != "2" {
+		t.Fatalf("root apply calls stat=%q want 2", got)
+	}
+}
+
+func TestPublishOrderedRootDeltaBatchGroupWithCommandWALAndSystemDeltaBuilder_WarmRootsUseFlushApplyOptions(t *testing.T) {
+	dir := t.TempDir()
+	enableCommandWALFormat(t, dir)
+	db, err := Open(Options{
+		Dir:                        dir,
+		FlushAdmissionPolicy:       FlushAdmissionPolicyExplicit,
+		FlushApplyConcurrency:      2,
+		FlushApplyMinEntries:       1,
+		FlushApplyMinSpans:         1,
+		FlushApplyMinBytes:         1,
+		DisableBackgroundPrune:     true,
+		IndexOuterLeavesInValueLog: true,
+	})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	makeDelta := func(kv ...string) *batch.Batch {
+		t.Helper()
+		table := mustFrozenSystemMemtable(t, kv...)
+		iter := table.NewIterator(nil, nil)
+		delta, err := OrderedRootDeltaBatchFromIterator(iter)
+		_ = iter.Close()
+		if err != nil {
+			t.Fatalf("delta batch: %v", err)
+		}
+		return delta
+	}
+
+	baseA := makeDelta("a/1", "base-a")
+	defer func() { _ = baseA.Close() }()
+	baseB := makeDelta("b/1", "base-b")
+	defer func() { _ = baseB.Close() }()
+	_, baseRootIDs, err := db.PublishOrderedRootDeltaBatchGroupWithCommandWALAndSystemDeltaBuilder([]OrderedRootDeltaBatchPublishInput{
+		{BaseRoot: 0, Delta: baseA},
+		{BaseRoot: 0, Delta: baseB},
+	}, mustRawKVCommandWALIntent(t, db, "cmd/base-roots", "1"), func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+		if len(rootIDs) != 2 || rootIDs[0] == 0 || rootIDs[1] == 0 {
+			return nil, errors.New("unexpected base root IDs")
+		}
+		return mustFrozenSystemMemtable(t,
+			"sys/collections/users/a", strconv.FormatUint(rootIDs[0], 10),
+			"sys/collections/users/b", strconv.FormatUint(rootIDs[1], 10),
+		).NewIterator(nil, nil), nil
+	})
+	if err != nil {
+		t.Fatalf("publish base roots: %v", err)
+	}
+
+	updateA := makeDelta("a/2", "delta-a")
+	defer func() { _ = updateA.Close() }()
+	updateB := makeDelta("b/2", "delta-b")
+	defer func() { _ = updateB.Close() }()
+	_, updatedRootIDs, err := db.PublishOrderedRootDeltaBatchGroupWithCommandWALAndSystemDeltaBuilder([]OrderedRootDeltaBatchPublishInput{
+		{BaseRoot: baseRootIDs[0], Delta: updateA, ParallelApply: true},
+		{BaseRoot: baseRootIDs[1], Delta: updateB, ParallelApply: true},
+	}, mustRawKVCommandWALIntent(t, db, "cmd/warm-roots", "1"), func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+		if len(rootIDs) != 2 || rootIDs[0] == 0 || rootIDs[1] == 0 {
+			return nil, errors.New("unexpected updated root IDs")
+		}
+		return mustFrozenSystemMemtable(t,
+			"sys/collections/users/a", strconv.FormatUint(rootIDs[0], 10),
+			"sys/collections/users/b", strconv.FormatUint(rootIDs[1], 10),
+		).NewIterator(nil, nil), nil
+	})
+	if err != nil {
+		t.Fatalf("publish warm roots: %v", err)
+	}
+	requireCommandWALPublishReady(t, db, "warm command WAL root publish")
+
+	snap := db.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("expected snapshot")
+	}
+	defer func() { _ = snap.Close() }()
+	for rootIdx, kv := range []map[string]string{
+		{"a/1": "base-a", "a/2": "delta-a"},
+		{"b/1": "base-b", "b/2": "delta-b"},
+	} {
+		for key, want := range kv {
+			entry, err := snap.GetEntryAtRoot(updatedRootIDs[rootIdx], []byte(key))
+			if err != nil {
+				t.Fatalf("GetEntryAtRoot(root=%d key=%s): %v", rootIdx, key, err)
+			}
+			if got := string(entry.Value); got != want {
+				t.Fatalf("root=%d key=%s got=%q want %q", rootIdx, key, got, want)
+			}
+		}
+	}
+
+	stats := db.Stats()
+	if got := stats["treedb.flush_apply.read_only_prepare.calls_total"]; got != "2" {
+		t.Fatalf("read-only prepare calls stat=%q want 2", got)
+	}
+	if got := stats["treedb.publish.ordered_root_delta_group.root_apply_parallel_groups_total"]; got != "1" {
+		t.Fatalf("parallel groups stat=%q want 1", got)
+	}
+	if got := stats["treedb.publish.ordered_root_delta_group.root_apply_parallel_roots_total"]; got != "2" {
+		t.Fatalf("parallel roots stat=%q want 2", got)
+	}
+}
+
 func TestPublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder_OptimisticColdBuildsRootsInParallel(t *testing.T) {
 	dir := t.TempDir()
 	db, err := Open(Options{Dir: dir})


### PR DESCRIPTION
## Summary

- Reuse the ordered-root batch apply helper in serialized grouped publish paths so collection roots that opt in to `ParallelApply` can apply concurrently before the final system-root commit.
- Route warm ordered-root delta batches through `ApplyWithOptions` to reuse read-only prepare and parallel COW apply when flush-apply concurrency is enabled.
- Keep span-native output disabled for ordered-root delta batches until root-local storage-policy/tombstone cases have explicit span-native execution coverage.

Fixes #2320.
Part of #2999.

## Evidence

Baseline is the repaired canonical collection run at `/mnt/fast4tb/tmp/gomap_full_benchmark_report_20260624_190225`, commit `37fd3866948dbef775a8efabfd578e208b19de63`:

| Secondary indexes | Baseline ns/doc | Candidate avg ns/doc | Docs/sec delta |
| ---: | ---: | ---: | ---: |
| 0 | 562.6 | 540.5 | +4.1% |
| 1 | 995.8 | 946.7 | +5.2% |
| 2 | 1440.0 | 1344.7 | +7.1% |

Candidate commit: `65220c3ca`.

Benchmark command:

```sh
TREEDB_COLLECTION_BENCH_ENGINE=command_wal_relaxed \
TREEDB_COLLECTION_DOCUMENT_FORMAT=template-v1 \
TREEDB_COLLECTION_BENCH_BATCH_SIZE=16000 \
TREEDB_COLLECTION_DATA_OUTER_LEAVES_IN_VLOG=true \
TREEDB_COLLECTION_INDEX_OUTER_LEAVES_IN_VLOG=true \
TREEDB_COLLECTION_PATH_LABEL=native-fastpath \
GOWORK=off go test ./TreeDB/collections -run '^$' \
  -bench '^BenchmarkCollectionShapeInsertBatch$/^indexes_(0|1|2)$' \
  -benchmem -benchtime=100000x -count=3
```

Candidate samples:

- indexes 0: `575.3`, `523.9`, `522.2` ns/op
- indexes 1: `956.9`, `920.9`, `962.3` ns/op
- indexes 2: `1341`, `1340`, `1353` ns/op

## Validation

- `GOWORK=off go test ./TreeDB/db -run 'TestPublishOrderedRootDeltaBatchGroup|TestApplyOrderedRootDeltaBatchGroupRoots|TestOrderedRootDeltaBatchPrepareReadOnlyStats'`
- `GOWORK=off go test ./TreeDB/collections`
- Focused insert benchmark command above

Full `./TreeDB/db` package validation is currently blocked by `TestLeafGenerationGC_RemovesUnreachableMultiLaneSegmentsAfterReopen`, which also reproduces on the non-optimization checkout at `origin/main`.
