### PR TITLE
Wire q1 aggregate metadata into column-store suite

### DIFF
--- a/cmd/unified_bench/README.md
+++ b/cmd/unified_bench/README.md
@@ -351,6 +351,9 @@ physical-column labels with a deterministic JSONBench-shaped fixture.
 so the unified-bench default still exercises the durable gate. The runnable
 execution labels are `row_store_baseline`, `b_tree_index_baseline`,
 `serial_column_scan`, `aggregate_metadata`, and `parallel_column_scan`.
+The `aggregate_metadata` path uses typed aggregate metadata for q1, q4b, and
+q5_metadata where those assets are available; the other synthetic query shapes
+reroute to serial physical scans.
 
 ```bash
 OUT=$(mktemp -d /tmp/gomap_column_store_profiles_XXXXXX)

--- a/cmd/unified_bench/suite_column_store.go
+++ b/cmd/unified_bench/suite_column_store.go
@@ -42,6 +42,7 @@ const (
 	columnStoreSuiteBenchMetricPrefix  = "column_store_"
 	columnStoreSuiteAliasFullScanQ1    = "alias_full_scan_from_" + columnStoreQueryQ1
 	columnStoreSuiteAliasPrefixQ4A     = "alias_prefix_scan_from_" + columnStoreQueryQ4A
+	columnStoreSuiteQ1AggregateCount   = "q1_kind_count"
 	columnStoreSuiteQ5AggregateMin     = "q5_did_time_span_min"
 	columnStoreSuiteQ5AggregateMax     = "q5_did_time_span_max"
 	columnStoreSuiteMaxInt64DecimalLen = 20 // len("-9223372036854775808")
@@ -96,7 +97,7 @@ var (
 		{alias: "parallel", canonical: columnStorePathParallelColumnScan},
 	}
 	columnStoreSuitePathUsage = fmt.Sprintf(
-		"Forced column-store execution label for -suite column_store (canonical: %s; aliases: %s; executable: %s; accepted labels: %s; aggregate_metadata executes q4b and q5_metadata through typed aggregate metadata assets when available; other queries reroute to serial physical scan)",
+		"Forced column-store execution label for -suite column_store (canonical: %s; aliases: %s; executable: %s; accepted labels: %s; aggregate_metadata executes q1, q4b, and q5_metadata through typed aggregate metadata assets when available; other queries reroute to serial physical scan)",
 		columnStoreSuitePathCanonicalHelp,
 		columnStoreSuitePathAliasHelp(columnStoreSuitePathAliases),
 		columnStoreSuitePathList(columnStoreSuiteExecutableForcedPaths),
@@ -756,7 +757,7 @@ func runColumnStoreSuite(baseCfg BenchConfig, opts columnStoreSuiteOptions) (str
 			SchemaHash:                      manifestIdentity.SchemaHash,
 		},
 		ProductionScope:          "production column-enabled TreeDB collection manifest/control-plane path plus isolated physical column assets and M14B planner-routed physical query execution",
-		PhysicalColumnQuery:      "M14B routes forced serial and insert-only parallel_column_scan labels through the TreeDB physical query adapter; forced aggregate_metadata is executable for q4b and q5_metadata through typed aggregate metadata assets and other queries reroute to serial physical scan; unsupported prerequisites fail closed before row fallback",
+		PhysicalColumnQuery:      "M14B routes forced serial and insert-only parallel_column_scan labels through the TreeDB physical query adapter; forced aggregate_metadata is executable for q1, q4b, and q5_metadata through typed aggregate metadata assets and other queries reroute to serial physical scan; unsupported prerequisites fail closed before row fallback",
 		ExternalJSONBenchStatus:  "gomap-only synthetic report cells are implemented here; external snissn/JSONBench full-data and comparison cells are implemented separately and require a fresh run against the selected gomap dependency",
 		ReportCaveats:            columnStoreReportCaveats(),
 		ColgranuleReuseMap:       columnStoreColgranuleReuseMap(),
@@ -1006,6 +1007,7 @@ func columnStoreSuiteConfig() *collections.ColumnStoreConfig {
 		},
 		SortKey: []collections.ColumnSortKey{{Column: "time_us"}},
 		AggregateMetadata: []collections.ColumnAggregateMetadata{
+			{Name: columnStoreSuiteQ1AggregateCount, GroupColumn: "kind", Kind: collections.ColumnAggregateCount},
 			{Name: columnStoreSuiteQ5AggregateMin, Column: "time_us", GroupColumn: "did", Kind: collections.ColumnAggregateMin},
 			{Name: columnStoreSuiteQ5AggregateMax, Column: "time_us", GroupColumn: "did", Kind: collections.ColumnAggregateMax},
 		},
@@ -1658,6 +1660,8 @@ func columnStoreSuiteQueryIndexCandidates(name string) []string {
 
 func columnStoreSuiteAggregateMetadataName(name string) string {
 	switch name {
+	case columnStoreQueryQ1:
+		return columnStoreSuiteQ1AggregateCount
 	case columnStoreQueryQ4B:
 		return columnStoreSuiteQ5AggregateMax
 	case columnStoreQueryQ5Metadata:
@@ -2714,6 +2718,9 @@ func columnStoreQueryAliasOf(name, path string) string {
 func columnStoreQueryImplementationNote(name, requestedPath, planPath string) string {
 	if requestedPath == columnStorePathAggregateMetadata && planPath == columnStorePathSerialColumnScan && columnStoreSuiteAggregateMetadataName(name) == "" {
 		return "aggregate_metadata_forced_path_rerouted_to_serial_column_scan_no_metadata_asset_for_query_m14b"
+	}
+	if name == columnStoreQueryQ1 && planPath == columnStorePathAggregateMetadata {
+		return "q1_physical_aggregate_metadata_asset_fast_path"
 	}
 	if name == columnStoreQueryQ4B && planPath == columnStorePathAggregateMetadata {
 		return "q4b_physical_aggregate_metadata_asset_fast_path"

--- a/cmd/unified_bench/suite_column_store_test.go
+++ b/cmd/unified_bench/suite_column_store_test.go
@@ -1956,6 +1956,13 @@ func TestColumnStoreSuiteExecutesForcedAggregateAndParallelPhysicalPathsM14B(t *
 			}
 			cellMetrics := assertColumnStoreJSONBenchCellShapeM1955(t, report, tc.forcedPath == columnStorePathAggregateMetadata)
 			if tc.forcedPath == columnStorePathAggregateMetadata {
+				q1Cells := cellMetrics[columnStoreQueryQ1]
+				if q1Cells[columnStoreJSONBenchCellColumnDirectMetadata+"/"+columnStoreJSONBenchModeDirect].MetadataDataScanPath != columnStoreJSONBenchScanPathMetadata {
+					t.Fatalf("q1 missing direct metadata cell: %+v", q1Cells)
+				}
+				if q1Cells[columnStoreJSONBenchCellColumnPreparedMetadata+"/"+columnStoreJSONBenchModePrepared].MetadataDataScanPath != columnStoreJSONBenchScanPathMetadata {
+					t.Fatalf("q1 missing prepared metadata cell: %+v", q1Cells)
+				}
 				q4bCells := cellMetrics[columnStoreQueryQ4B]
 				if q4bCells[columnStoreJSONBenchCellColumnDirectMetadata+"/"+columnStoreJSONBenchModeDirect].MetadataDataScanPath != columnStoreJSONBenchScanPathMetadata {
 					t.Fatalf("q4b missing direct metadata cell: %+v", q4bCells)
@@ -1966,7 +1973,7 @@ func TestColumnStoreSuiteExecutesForcedAggregateAndParallelPhysicalPathsM14B(t *
 			}
 			queryMetrics := assertColumnStoreQueryMetricCoverageM11A(t, report.Queries)
 			for _, q := range report.Queries {
-				metadataFastPath := q.Name == columnStoreQueryQ4B || q.Name == columnStoreQueryQ5Metadata
+				metadataFastPath := q.Name == columnStoreQueryQ1 || q.Name == columnStoreQueryQ4B || q.Name == columnStoreQueryQ5Metadata
 				if tc.forcedPath == columnStorePathAggregateMetadata && !metadataFastPath {
 					if q.PlanLabel != columnStorePathSerialColumnScan {
 						t.Fatalf("query %s plan_label=%q want %q under aggregate_metadata forced path", q.Name, q.PlanLabel, columnStorePathSerialColumnScan)
@@ -2013,6 +2020,16 @@ func TestColumnStoreSuiteExecutesForcedAggregateAndParallelPhysicalPathsM14B(t *
 				}
 			}
 			if tc.forcedPath == columnStorePathAggregateMetadata {
+				q1 := queryMetrics[columnStoreQueryQ1]
+				if q1.PlanLabel != columnStorePathAggregateMetadata {
+					t.Fatalf("q1 plan_label=%q want %q", q1.PlanLabel, columnStorePathAggregateMetadata)
+				}
+				if q1.MetadataHits == 0 {
+					t.Fatalf("q1 metadata_hits=0 want aggregate metadata fast path: %+v", q1)
+				}
+				if !strings.Contains(q1.ThroughputInterpretation, "metadata-bound") {
+					t.Fatalf("q1 throughput_interpretation=%q want metadata-bound aggregate classification", q1.ThroughputInterpretation)
+				}
 				q4b := queryMetrics[columnStoreQueryQ4B]
 				if q4b.PlanLabel != columnStorePathAggregateMetadata {
 					t.Fatalf("q4b plan_label=%q want %q", q4b.PlanLabel, columnStorePathAggregateMetadata)
@@ -2772,7 +2789,7 @@ func TestColumnStoreSuiteConfigUsesExplicitAggregateMetadataNamesM11A(t *testing
 		names = append(names, agg.Name)
 	}
 	got := strings.Join(names, ",")
-	if !strings.Contains(got, columnStoreSuiteQ5AggregateMin) || !strings.Contains(got, columnStoreSuiteQ5AggregateMax) {
+	if !strings.Contains(got, columnStoreSuiteQ1AggregateCount) || !strings.Contains(got, columnStoreSuiteQ5AggregateMin) || !strings.Contains(got, columnStoreSuiteQ5AggregateMax) {
 		t.Fatalf("aggregate metadata names=%q", got)
 	}
 	if strings.Contains(got, "q5_did_time_span,") || strings.HasSuffix(got, "q5_did_time_span") {
@@ -2927,19 +2944,14 @@ func TestColumnStoreSuiteAggregateMetadataRequestUsesRegisteredNameM11B(t *testi
 	for _, agg := range cfg.AggregateMetadata {
 		registered[agg.Name] = true
 	}
-	name := columnStoreSuiteAggregateMetadataName(columnStoreQueryQ5Metadata)
-	if name == "" {
-		t.Fatal("q5_metadata did not request aggregate metadata")
-	}
-	if !registered[name] {
-		t.Fatalf("q5_metadata requested aggregate metadata %q outside registered names", name)
-	}
-	name = columnStoreSuiteAggregateMetadataName(columnStoreQueryQ4B)
-	if name == "" {
-		t.Fatal("q4b did not request aggregate metadata")
-	}
-	if !registered[name] {
-		t.Fatalf("q4b requested aggregate metadata %q outside registered names", name)
+	for _, query := range []string{columnStoreQueryQ1, columnStoreQueryQ4B, columnStoreQueryQ5Metadata} {
+		name := columnStoreSuiteAggregateMetadataName(query)
+		if name == "" {
+			t.Fatalf("%s did not request aggregate metadata", query)
+		}
+		if !registered[name] {
+			t.Fatalf("%s requested aggregate metadata %q outside registered names", query, name)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- register the q1 grouped-count aggregate metadata asset in the column_store suite config
- route forced `aggregate_metadata` q1 requests to the q1 metadata asset instead of rerouting to serial scan
- update report/help text and tests so q1 joins q4b/q5_metadata as an executable metadata path

Part of #2892 and #3000. This does not close #2892 because q3 external JSONBench routing/evidence and final q1/q3 ClickHouse gate remain outstanding.

## Evidence
- `go test ./cmd/unified_bench -run 'TestColumnStoreSuite(ConfigUsesExplicitAggregateMetadataNamesM11A|AggregateMetadataRequestUsesRegisteredNameM11B|ExecutesForcedAggregateAndParallelPhysicalPathsM14B)$' -count=1`\n- `go test ./cmd/unified_bench -count=1`\n- `go test ./cmd/unified_bench -run '^$' -bench 'BenchmarkColumnStoreSuite(SerialPhysical|AggregateMetadata)QueriesM14C$' -benchmem -benchtime=200ms -count=3`\n- q1-only synthetic smoke, 10K rows, serial: `/tmp/gomap_q1_serial_0LMWyN/column_store_results.json` -> `storage_source=compatibility_dictionary_code_int64_asset`, `bytes_read=42360`, `metadata_hits=0`, `dictionary_code_hits=10`, `ns_per_row=31.2333`\n- q1-only synthetic smoke, 10K rows, aggregate_metadata: `/tmp/gomap_q1_metadata_7KA6WC/column_store_results.json` -> `storage_source=aggregate_metadata`, `bytes_read=5210`, `metadata_hits=10`, `dictionary_code_hits=0`, `ns_per_row=36.4917`\n\n## Notes\n- The local synthetic q3 query is still a plain hour-count shape. It is intentionally not wired to the grouped-hour q3 metadata primitive here; that should be exercised by the full JSONBench shape that has the real predicate/group columns.\n- The q1 metadata path reduces bytes read in this small smoke but is not yet faster than the serial dictionary sidecar at 10K rows, so follow-up optimization/evidence is still required before making headline performance claims.\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `aggregate_metadata` now recognizes `q1` in the column-store benchmark path, alongside the existing supported query assets.
  * Updated benchmark reporting so `q1` is clearly labeled as using the metadata fast path.
  * Improved validation so aggregate-metadata queries are consistently routed and reported, including `q1`, `q4b`, and `q5_metadata`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->