### PR TITLE
TreeDB q2 active-group distinct bitset

### DIFF
--- a/TreeDB/collections/column_physical_q2_1950_test.go
+++ b/TreeDB/collections/column_physical_q2_1950_test.go
@@ -3,6 +3,7 @@ package collections
 import (
 	"errors"
 	"fmt"
+	"reflect"
 	"sort"
 	"strings"
 	"testing"
@@ -170,6 +171,177 @@ func TestTypedColumnQ2DenseGroupCountDistinctBitsetLayout1950(t *testing.T) {
 	_, _, ok = columnTypedColumnDenseGroupCountDistinctBitsetLayout(1, columnTypedColumnDenseGroupCountDistinctMaxBitsetWords*64+1)
 	if ok {
 		t.Fatalf("oversized layout ok=true want false")
+	}
+}
+
+func TestTypedColumnQ2DenseGroupCountDistinctActiveGroupBitset1950(t *testing.T) {
+	const (
+		groupCardinality    = 4096
+		distinctCardinality = 65536
+		groupA              = 100
+		groupB              = 200
+		groupRejected       = 300
+	)
+	groupDictionary := make([]string, groupCardinality)
+	groupDictionary[groupA] = "app.active.a"
+	groupDictionary[groupB] = "app.active.b"
+	groupDictionary[groupRejected] = "app.rejected"
+	distinctDictionary := make([]string, distinctCardinality)
+	groupCodes := []uint32{groupA, groupA, groupA, groupB, groupB, groupB, groupRejected}
+	distinctCodes := []uint32{10, 10, 11, 20, 21, 20, 30}
+	predicateCodes := []uint32{1, 1, 1, 1, 1, 1, 0}
+	allowed := []uint64{2}
+	req := ColumnPhysicalQueryRequest{
+		Kind:           ColumnPhysicalQueryGroupCountAndDistinct,
+		GroupColumn:    "collection",
+		DistinctColumn: "did",
+		Predicates: []ColumnPhysicalQueryPredicate{
+			{Column: "kind", Value: "commit"},
+			{Column: "operation", Value: "create"},
+		},
+	}
+	runner := &columnTypedColumnPhysicalQueryRunner{
+		plan: columnTypedColumnPhysicalQueryPlan{
+			ProjectedColumns:        []string{"collection", "did", "kind", "operation"},
+			PredicateDiagnostics:    newColumnPhysicalQueryPredicateDiagnosticPlan(req),
+			DenseGroupCountDistinct: true,
+		},
+		parts: []columnTypedColumnPhysicalQueryPart{
+			{
+				Rows: len(groupCodes),
+				DenseGroupCountDistinct: &columnTypedColumnDenseGroupCountDistinctPart{
+					Rows: len(groupCodes),
+					Group: columnTypedColumnDenseStringCodeColumn{
+						Codes:            groupCodes,
+						GlobalCodes:      groupCodes,
+						GlobalDictionary: groupDictionary,
+					},
+					Distinct: columnTypedColumnDenseStringCodeColumn{
+						Codes:            distinctCodes,
+						GlobalCodes:      distinctCodes,
+						GlobalDictionary: distinctDictionary,
+					},
+					Predicates: []columnTypedColumnDensePredicatePart{
+						{Codes: predicateCodes, Allowed: allowed},
+						{Codes: predicateCodes, Allowed: allowed},
+					},
+				},
+			},
+		},
+	}
+
+	result, err := runner.runDenseGroupCountDistinct(columnPhysicalScanSnapshotView{}, req)
+	if err != nil {
+		t.Fatalf("runDenseGroupCountDistinct: %v", err)
+	}
+	if result.Diagnostics.DenseGroupCountDistinctReducer != columnTypedColumnDenseGroupCountDistinctReducerActiveBitset {
+		t.Fatalf("reducer=%q want %q diagnostics=%+v", result.Diagnostics.DenseGroupCountDistinctReducer, columnTypedColumnDenseGroupCountDistinctReducerActiveBitset, result.Diagnostics)
+	}
+	if result.Diagnostics.DenseGroupCountDistinctGroups != groupCardinality || result.Diagnostics.DenseGroupCountDistinctValues != distinctCardinality {
+		t.Fatalf("cardinality diagnostics=%+v want groups=%d values=%d", result.Diagnostics, groupCardinality, distinctCardinality)
+	}
+	if got, want := result.Diagnostics.DenseGroupCountDistinctPairBitWords, 2*((distinctCardinality+63)/64); got != want {
+		t.Fatalf("pair bit words=%d want active group words=%d diagnostics=%+v", got, want, result.Diagnostics)
+	}
+	if result.Diagnostics.RowsScanned != len(groupCodes) || result.Diagnostics.RowsMatched != 6 || result.Diagnostics.ReduceRows != 6 {
+		t.Fatalf("row diagnostics=%+v want scanned=%d matched/reduced=6", result.Diagnostics, len(groupCodes))
+	}
+	got := columnPhysicalJSONBenchQ2CountsP0(result.Groups)
+	want := map[string]columnPhysicalJSONBenchQ2CountP0{
+		"app.active.a": {Count: 3, Distinct: 2},
+		"app.active.b": {Count: 3, Distinct: 2},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("groups=%v want %v raw=%+v", got, want, result.Groups)
+	}
+}
+
+func BenchmarkTypedColumnQ2DenseGroupCountDistinctActiveGroups1950(b *testing.B) {
+	const (
+		rows                = 262144
+		activeGroups        = 13
+		groupCardinality    = 4096
+		distinctCardinality = 65536
+	)
+	groupDictionary := make([]string, groupCardinality)
+	activeGroupCodes := make([]uint32, activeGroups)
+	for groupIdx := 0; groupIdx < activeGroups; groupIdx++ {
+		code := uint32(100 + groupIdx)
+		activeGroupCodes[groupIdx] = code
+		groupDictionary[code] = fmt.Sprintf("app.active.%02d", groupIdx)
+	}
+	distinctDictionary := make([]string, distinctCardinality)
+	groupCodes := make([]uint32, rows)
+	distinctCodes := make([]uint32, rows)
+	predicateCodes := make([]uint32, rows)
+	for row := 0; row < rows; row++ {
+		groupCodes[row] = activeGroupCodes[row%activeGroups]
+		distinctCodes[row] = uint32(row % distinctCardinality)
+		predicateCodes[row] = 1
+	}
+	allowed := []uint64{2}
+	req := ColumnPhysicalQueryRequest{
+		Kind:           ColumnPhysicalQueryGroupCountAndDistinct,
+		GroupColumn:    "collection",
+		DistinctColumn: "did",
+		Predicates: []ColumnPhysicalQueryPredicate{
+			{Column: "kind", Value: "commit"},
+			{Column: "operation", Value: "create"},
+		},
+	}
+	runner := &columnTypedColumnPhysicalQueryRunner{
+		plan: columnTypedColumnPhysicalQueryPlan{
+			ProjectedColumns:        []string{"collection", "did", "kind", "operation"},
+			PredicateDiagnostics:    newColumnPhysicalQueryPredicateDiagnosticPlan(req),
+			DenseGroupCountDistinct: true,
+		},
+		parts: []columnTypedColumnPhysicalQueryPart{
+			{
+				Rows: rows,
+				DenseGroupCountDistinct: &columnTypedColumnDenseGroupCountDistinctPart{
+					Rows: rows,
+					Group: columnTypedColumnDenseStringCodeColumn{
+						Codes:            groupCodes,
+						GlobalCodes:      groupCodes,
+						GlobalDictionary: groupDictionary,
+					},
+					Distinct: columnTypedColumnDenseStringCodeColumn{
+						Codes:            distinctCodes,
+						GlobalCodes:      distinctCodes,
+						GlobalDictionary: distinctDictionary,
+					},
+					Predicates: []columnTypedColumnDensePredicatePart{
+						{Codes: predicateCodes, Allowed: allowed},
+						{Codes: predicateCodes, Allowed: allowed},
+					},
+				},
+			},
+		},
+	}
+	preview, err := runner.runDenseGroupCountDistinct(columnPhysicalScanSnapshotView{}, req)
+	if err != nil {
+		b.Fatalf("preview runDenseGroupCountDistinct: %v", err)
+	}
+	if len(preview.Groups) != activeGroups || preview.Diagnostics.ReduceRows != rows {
+		b.Fatalf("preview groups=%d reduce=%d diagnostics=%+v", len(preview.Groups), preview.Diagnostics.ReduceRows, preview.Diagnostics)
+	}
+	b.SetBytes(rows)
+	b.ReportAllocs()
+	b.ResetTimer()
+	var last ColumnPhysicalQueryDiagnostics
+	for i := 0; i < b.N; i++ {
+		result, err := runner.runDenseGroupCountDistinct(columnPhysicalScanSnapshotView{}, req)
+		if err != nil {
+			b.Fatalf("runDenseGroupCountDistinct: %v", err)
+		}
+		last = result.Diagnostics
+	}
+	b.StopTimer()
+	b.ReportMetric(float64(last.RowsScanned), "rows_scanned/op")
+	b.ReportMetric(float64(last.ReduceRows), "reduce_rows/op")
+	b.ReportMetric(float64(last.DenseGroupCountDistinctPairBitWords), "pair_bit_words/op")
+	if last.ScanNanos > 0 {
+		b.ReportMetric(float64(last.RowsScanned)*1e9/float64(last.ScanNanos), "diag_rows_per_sec")
 	}
 }
 

--- a/TreeDB/collections/column_physical_typed_column_query.go
+++ b/TreeDB/collections/column_physical_typed_column_query.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math/bits"
+	"slices"
 	"sort"
 	"time"
 )
@@ -12,8 +14,9 @@ import (
 const columnTypedColumnDenseGroupCountDistinctMaxBitsetWords = 2 << 20
 
 const (
-	columnTypedColumnDenseGroupCountDistinctReducerPairBitset    = "pair_bitset"
-	columnTypedColumnDenseGroupCountDistinctReducerPackedPairMap = "packed_pair_map"
+	columnTypedColumnDenseGroupCountDistinctReducerPairBitset   = "pair_bitset"
+	columnTypedColumnDenseGroupCountDistinctReducerActiveBitset = "active_group_bitset"
+	columnTypedColumnDenseGroupCountDistinctReducerSortedPairs  = "sorted_packed_pairs"
 )
 
 type columnTypedColumnPhysicalQueryPlan struct {
@@ -153,7 +156,10 @@ type columnTypedColumnPhysicalQueryRunner struct {
 	denseGroupCountDistinctCounts         []int
 	denseGroupCountDistinctDistinctCounts []int
 	denseGroupCountDistinctPairBits       []uint64
-	denseGroupCountDistinctPairs          map[uint64]struct{}
+	denseGroupCountDistinctGroupActive    []bool
+	denseGroupCountDistinctGroupOffsets   []int
+	denseGroupCountDistinctActiveGroups   []int
+	denseGroupCountDistinctPairList       []uint64
 	denseGroupHourCounts                  map[string][24]int
 	denseLocalHourCounts                  []int
 	denseSpanValues                       map[string]columnPhysicalQuerySpan
@@ -2203,15 +2209,29 @@ func columnTypedColumnDenseGroupCountDistinctBitsetLayout(groupCardinality, dist
 	if wordsPerGroup <= 0 {
 		return 0, 0, false
 	}
-	maxInt := int(^uint(0) >> 1)
-	if groupCardinality > maxInt/wordsPerGroup {
-		return 0, 0, false
-	}
-	totalWords := groupCardinality * wordsPerGroup
-	if totalWords > columnTypedColumnDenseGroupCountDistinctMaxBitsetWords {
-		return 0, 0, false
+	totalWords, ok := columnTypedColumnDenseGroupCountDistinctBitsetWords(groupCardinality, wordsPerGroup)
+	if !ok {
+		return wordsPerGroup, 0, false
 	}
 	return wordsPerGroup, totalWords, true
+}
+
+func columnTypedColumnDenseGroupCountDistinctBitsetWords(groups, wordsPerGroup int) (int, bool) {
+	if groups < 0 || wordsPerGroup < 0 {
+		return 0, false
+	}
+	if groups == 0 || wordsPerGroup == 0 {
+		return 0, true
+	}
+	maxInt := int(^uint(0) >> 1)
+	if groups > maxInt/wordsPerGroup {
+		return 0, false
+	}
+	totalWords := groups * wordsPerGroup
+	if totalWords > columnTypedColumnDenseGroupCountDistinctMaxBitsetWords {
+		return 0, false
+	}
+	return totalWords, true
 }
 
 func (r *columnTypedColumnPhysicalQueryRunner) runDenseGroupCountDistinct(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest) (ColumnPhysicalQueryResult, error) {
@@ -2253,6 +2273,9 @@ func (r *columnTypedColumnPhysicalQueryRunner) runDenseGroupCountDistinct(view c
 		clear(r.denseGroupCountDistinctDistinctCounts)
 	}
 	wordsPerGroup, pairBitWords, usePairBitset := columnTypedColumnDenseGroupCountDistinctBitsetLayout(groupCardinality, distinctCardinality)
+	reducer := columnTypedColumnDenseGroupCountDistinctReducerPairBitset
+	useActivePairBitset := false
+	useSortedPairs := false
 	if usePairBitset {
 		if cap(r.denseGroupCountDistinctPairBits) < pairBitWords {
 			r.denseGroupCountDistinctPairBits = make([]uint64, pairBitWords)
@@ -2260,12 +2283,28 @@ func (r *columnTypedColumnPhysicalQueryRunner) runDenseGroupCountDistinct(view c
 			r.denseGroupCountDistinctPairBits = r.denseGroupCountDistinctPairBits[:pairBitWords]
 			clear(r.denseGroupCountDistinctPairBits)
 		}
-	} else {
-		if r.denseGroupCountDistinctPairs == nil {
-			r.denseGroupCountDistinctPairs = make(map[uint64]struct{}, groupCardinality)
+	} else if wordsPerGroup > 0 && wordsPerGroup <= columnTypedColumnDenseGroupCountDistinctMaxBitsetWords {
+		reducer = columnTypedColumnDenseGroupCountDistinctReducerActiveBitset
+		useActivePairBitset = true
+		pairBitWords = 0
+		r.denseGroupCountDistinctPairBits = r.denseGroupCountDistinctPairBits[:0]
+		if cap(r.denseGroupCountDistinctGroupActive) < groupCardinality {
+			r.denseGroupCountDistinctGroupActive = make([]bool, groupCardinality)
 		} else {
-			clear(r.denseGroupCountDistinctPairs)
+			r.denseGroupCountDistinctGroupActive = r.denseGroupCountDistinctGroupActive[:groupCardinality]
+			clear(r.denseGroupCountDistinctGroupActive)
 		}
+		if cap(r.denseGroupCountDistinctGroupOffsets) < groupCardinality {
+			r.denseGroupCountDistinctGroupOffsets = make([]int, groupCardinality)
+		} else {
+			r.denseGroupCountDistinctGroupOffsets = r.denseGroupCountDistinctGroupOffsets[:groupCardinality]
+		}
+		r.denseGroupCountDistinctActiveGroups = r.denseGroupCountDistinctActiveGroups[:0]
+	} else {
+		reducer = columnTypedColumnDenseGroupCountDistinctReducerSortedPairs
+		useSortedPairs = true
+		pairBitWords = 0
+		r.denseGroupCountDistinctPairList = r.denseGroupCountDistinctPairList[:0]
 	}
 
 	rowsScanned := 0
@@ -2319,35 +2358,72 @@ func (r *columnTypedColumnPhysicalQueryRunner) runDenseGroupCountDistinct(view c
 				return ColumnPhysicalQueryResult{Diagnostics: diag}, fmt.Errorf("collections: dense typed-column grouped count-distinct part %d group code[%d]=%d outside cardinality=%d", partIdx, rowIdx, groupCode, len(r.denseGroupCountDistinctCounts))
 			}
 			r.denseGroupCountDistinctCounts[groupIdx]++
+			distinctIdx, ok := columnDictionaryCodeIndex(distinctCode, distinctCardinality)
+			if !ok {
+				diag := r.diagnostics(view, req, rowsScanned, matchedRows, reduceRows, time.Since(start).Nanoseconds())
+				diag.DenseGroupCountDistinctUsed = true
+				return ColumnPhysicalQueryResult{Diagnostics: diag}, fmt.Errorf("collections: dense typed-column grouped count-distinct part %d distinct code[%d]=%d outside cardinality=%d", partIdx, rowIdx, distinctCode, distinctCardinality)
+			}
 			if usePairBitset {
-				distinctIdx, ok := columnDictionaryCodeIndex(distinctCode, distinctCardinality)
-				if !ok {
-					diag := r.diagnostics(view, req, rowsScanned, matchedRows, reduceRows, time.Since(start).Nanoseconds())
-					diag.DenseGroupCountDistinctUsed = true
-					return ColumnPhysicalQueryResult{Diagnostics: diag}, fmt.Errorf("collections: dense typed-column grouped count-distinct part %d distinct code[%d]=%d outside cardinality=%d", partIdx, rowIdx, distinctCode, distinctCardinality)
-				}
 				wordIdx := groupIdx*wordsPerGroup + distinctIdx/64
 				mask := uint64(1) << uint(distinctIdx&63)
 				if r.denseGroupCountDistinctPairBits[wordIdx]&mask == 0 {
 					r.denseGroupCountDistinctPairBits[wordIdx] |= mask
 					r.denseGroupCountDistinctDistinctCounts[groupIdx]++
 				}
+			} else if useActivePairBitset {
+				if !r.denseGroupCountDistinctGroupActive[groupIdx] {
+					nextPairBitWords, ok := columnTypedColumnDenseGroupCountDistinctBitsetWords(len(r.denseGroupCountDistinctActiveGroups)+1, wordsPerGroup)
+					if !ok {
+						r.convertDenseGroupCountDistinctActiveBitsToPairs(wordsPerGroup, distinctCardinality)
+						clear(r.denseGroupCountDistinctDistinctCounts)
+						reducer = columnTypedColumnDenseGroupCountDistinctReducerSortedPairs
+						useActivePairBitset = false
+						useSortedPairs = true
+						pairBitWords = 0
+					} else {
+						offset := len(r.denseGroupCountDistinctPairBits)
+						if cap(r.denseGroupCountDistinctPairBits) < nextPairBitWords {
+							nextBits := make([]uint64, nextPairBitWords)
+							copy(nextBits, r.denseGroupCountDistinctPairBits)
+							r.denseGroupCountDistinctPairBits = nextBits
+						} else {
+							r.denseGroupCountDistinctPairBits = r.denseGroupCountDistinctPairBits[:nextPairBitWords]
+							clear(r.denseGroupCountDistinctPairBits[offset:nextPairBitWords])
+						}
+						r.denseGroupCountDistinctGroupActive[groupIdx] = true
+						r.denseGroupCountDistinctGroupOffsets[groupIdx] = offset
+						r.denseGroupCountDistinctActiveGroups = append(r.denseGroupCountDistinctActiveGroups, groupIdx)
+						pairBitWords = nextPairBitWords
+					}
+				}
+				if useActivePairBitset {
+					wordIdx := r.denseGroupCountDistinctGroupOffsets[groupIdx] + distinctIdx/64
+					mask := uint64(1) << uint(distinctIdx&63)
+					if r.denseGroupCountDistinctPairBits[wordIdx]&mask == 0 {
+						r.denseGroupCountDistinctPairBits[wordIdx] |= mask
+						r.denseGroupCountDistinctDistinctCounts[groupIdx]++
+					}
+				} else {
+					r.denseGroupCountDistinctPairList = append(r.denseGroupCountDistinctPairList, uint64(groupIdx)<<32|uint64(distinctIdx))
+				}
 			} else {
-				pair := uint64(groupCode)<<32 | uint64(distinctCode)
-				r.denseGroupCountDistinctPairs[pair] = struct{}{}
+				r.denseGroupCountDistinctPairList = append(r.denseGroupCountDistinctPairList, uint64(groupIdx)<<32|uint64(distinctIdx))
 			}
 		}
 	}
-	if !usePairBitset {
-		for pair := range r.denseGroupCountDistinctPairs {
-			groupCode := uint32(pair >> 32)
-			groupIdx, ok := columnDictionaryCodeIndex(groupCode, len(r.denseGroupCountDistinctDistinctCounts))
-			if !ok {
-				diag := r.diagnostics(view, req, rowsScanned, matchedRows, reduceRows, time.Since(start).Nanoseconds())
-				diag.DenseGroupCountDistinctUsed = true
-				return ColumnPhysicalQueryResult{Diagnostics: diag}, fmt.Errorf("collections: dense typed-column grouped count-distinct pair group code=%d outside cardinality=%d", groupCode, len(r.denseGroupCountDistinctDistinctCounts))
+	if useSortedPairs {
+		slices.Sort(r.denseGroupCountDistinctPairList)
+		var previous uint64
+		havePrevious := false
+		for _, pair := range r.denseGroupCountDistinctPairList {
+			if havePrevious && pair == previous {
+				continue
 			}
+			groupIdx := int(pair >> 32)
 			r.denseGroupCountDistinctDistinctCounts[groupIdx]++
+			previous = pair
+			havePrevious = true
 		}
 	}
 	r.resultGroups = r.resultGroups[:0]
@@ -2366,7 +2442,7 @@ func (r *columnTypedColumnPhysicalQueryRunner) runDenseGroupCountDistinct(view c
 	sortColumnPhysicalQueryGroupsByKey(r.resultGroups)
 	diag := r.diagnostics(view, req, rowsScanned, matchedRows, reduceRows, time.Since(start).Nanoseconds())
 	diag.DenseGroupCountDistinctUsed = true
-	annotateColumnTypedColumnDenseGroupCountDistinctDiagnostics(&diag, groupCardinality, distinctCardinality, pairBitWords, usePairBitset)
+	annotateColumnTypedColumnDenseGroupCountDistinctDiagnostics(&diag, groupCardinality, distinctCardinality, pairBitWords, reducer)
 	diag.ResultGroups = len(r.resultGroups)
 	result := ColumnPhysicalQueryResult{Groups: r.resultGroups, Diagnostics: diag}
 	finalizeColumnPhysicalQueryResultGroups(req, &result)
@@ -2374,18 +2450,32 @@ func (r *columnTypedColumnPhysicalQueryRunner) runDenseGroupCountDistinct(view c
 	return result, nil
 }
 
-func annotateColumnTypedColumnDenseGroupCountDistinctDiagnostics(diag *ColumnPhysicalQueryDiagnostics, groupCardinality, distinctCardinality, pairBitWords int, usePairBitset bool) {
+func (r *columnTypedColumnPhysicalQueryRunner) convertDenseGroupCountDistinctActiveBitsToPairs(wordsPerGroup, distinctCardinality int) {
+	r.denseGroupCountDistinctPairList = r.denseGroupCountDistinctPairList[:0]
+	for _, groupIdx := range r.denseGroupCountDistinctActiveGroups {
+		offset := r.denseGroupCountDistinctGroupOffsets[groupIdx]
+		groupBits := r.denseGroupCountDistinctPairBits[offset : offset+wordsPerGroup]
+		for wordOffset, word := range groupBits {
+			for word != 0 {
+				bit := bits.TrailingZeros64(word)
+				distinctIdx := wordOffset*64 + bit
+				if distinctIdx < distinctCardinality {
+					r.denseGroupCountDistinctPairList = append(r.denseGroupCountDistinctPairList, uint64(groupIdx)<<32|uint64(distinctIdx))
+				}
+				word &= word - 1
+			}
+		}
+	}
+}
+
+func annotateColumnTypedColumnDenseGroupCountDistinctDiagnostics(diag *ColumnPhysicalQueryDiagnostics, groupCardinality, distinctCardinality, pairBitWords int, reducer string) {
 	if diag == nil {
 		return
 	}
 	diag.DenseGroupCountDistinctGroups = groupCardinality
 	diag.DenseGroupCountDistinctValues = distinctCardinality
 	diag.DenseGroupCountDistinctPairBitWords = pairBitWords
-	if usePairBitset {
-		diag.DenseGroupCountDistinctReducer = columnTypedColumnDenseGroupCountDistinctReducerPairBitset
-		return
-	}
-	diag.DenseGroupCountDistinctReducer = columnTypedColumnDenseGroupCountDistinctReducerPackedPairMap
+	diag.DenseGroupCountDistinctReducer = reducer
 }
 
 func (r *columnTypedColumnPhysicalQueryRunner) runDenseGroupHourCount(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest) (ColumnPhysicalQueryResult, error) {


### PR DESCRIPTION
Refs #3002
Parent tracker: #3000

## Summary

- Replaces the dense q2 grouped count-distinct packed-pair hash-map fallback with an exact active-group bitset reducer when global group x distinct cardinality is too large for the existing full bitset but the filtered active group set is small.
- Keeps the existing full pair bitset path for compact dictionaries.
- Adds a bounded exact fallback to sorted packed pairs if the active group set grows past the configured bitset word budget.
- Adds diagnostics labels for `active_group_bitset` and `sorted_packed_pairs`, plus a regression test and focused benchmark for the large-global-cardinality/small-active-group q2 shape.

## Verification

- `go test ./TreeDB/collections -run 'TestTypedColumnQ2DenseGroupCountDistinct(BitsetLayout|ActiveGroupBitset|NoSortLocalDictionaries)1950$' -count=1`
- `go test ./TreeDB/collections -run 'TestTypedColumnQ2|TestColumnPhysicalQueryRunnerDistinctSidecarParityAndAllocationM1634|TestColumnPhysicalQueryJSONBenchParityP0/q2|TestColumnStoreCompaction.*q2|TestColumnPhysicalSortKey.*q2' -count=1`
- `go test ./TreeDB/collections -count=1`
- `go run ./cmd/unified_bench -suite column_store -dbs treedb -profile durable -keys 100000 -batchsize 1000 -profile-dir "$OUT" -path-label native-fastpath -column-store-path serial_column_scan -column-store-query q2 -progress=false`
  - artifact dir: `/tmp/q2_active_unified_hzynVu`
  - q2 synthetic serial column scan: `30.83251 ns/row`, fallback `none`, parity `pass`, bytes read `2335200`

## Focused Reducer Benchmark

Same benchmark was applied to an `origin/main` temp worktree at `2934d0828` for the baseline.

- baseline log: `/tmp/q2_active_baseline_bench_n10.txt`
- branch log: `/tmp/q2_active_branch_bench_n10.txt`
- benchstat: `/tmp/q2_active_benchstat_n10.txt`

```text
TypedColumnQ2DenseGroupCountDistinctActiveGroups1950-8  6.249m ± 9%  ->  1.488m ± 1%  -76.19% (p=0.000 n=10)
B/s                                                        40.00Mi ± 8% -> 168.04Mi ± 1% +320.07%
diag_rows_per_sec                                         41.48M ± 5%  -> 175.23M ± 2%  +322.44%
rows_scanned/op                                           262.1k       -> 262.1k
reduce_rows/op                                            262.1k       -> 262.1k
B/op                                                       0            -> 0
allocs/op                                                  0            -> 0
```

## Caveat

I could not run the external full JSONBench q2 vs ClickHouse gate locally because this checkout does not have the full external `$HOME/data/bluesky` dataset or local ClickHouse environment. This PR provides the reducer implementation, package benchmark evidence, and gomap synthetic q2 smoke evidence; #3002 should still carry the full external current-head gate.
