### PR TITLE
treedb: add q5 prepared global span reducer

### DIFF
--- a/TreeDB/collections/column_physical_q5_dense_1950_test.go
+++ b/TreeDB/collections/column_physical_q5_dense_1950_test.go
@@ -34,7 +34,7 @@ func TestColumnPhysicalQ5DenseTypedColumnDirectPreparedParity1950(t *testing.T) 
 	if err != nil {
 		t.Fatalf("RunColumnPhysicalQuery(q5 dense): %v", err)
 	}
-	assertColumnPhysicalQ5DenseResult1950(t, "direct", direct, want, len(events), matchedRows)
+	assertColumnPhysicalQ5DenseResult1950(t, "direct", direct, want, len(events), matchedRows, columnTypedColumnDenseInt64SpanReducerLocalMap)
 
 	runner, err := col.PrepareColumnPhysicalQuery(req)
 	if err != nil {
@@ -46,7 +46,7 @@ func TestColumnPhysicalQ5DenseTypedColumnDirectPreparedParity1950(t *testing.T) 
 		if err != nil {
 			t.Fatalf("prepared q5 dense run %d: %v", run, err)
 		}
-		assertColumnPhysicalQ5DenseResult1950(t, fmt.Sprintf("prepared run %d", run), prepared, want, len(events), matchedRows)
+		assertColumnPhysicalQ5DenseResult1950(t, fmt.Sprintf("prepared run %d", run), prepared, want, len(events), matchedRows, columnTypedColumnDenseInt64SpanReducerGlobalCodes)
 	}
 
 	noPredicateReq := req
@@ -57,7 +57,7 @@ func TestColumnPhysicalQ5DenseTypedColumnDirectPreparedParity1950(t *testing.T) 
 	if err != nil {
 		t.Fatalf("RunColumnPhysicalQuery(q5 dense no predicates): %v", err)
 	}
-	if !noPredicate.Diagnostics.DenseInt64SpanUsed || noPredicate.Diagnostics.RowsScanned != len(events) || noPredicate.Diagnostics.RowsMatched != 0 || noPredicate.Diagnostics.ReduceRows != len(events) {
+	if !noPredicate.Diagnostics.DenseInt64SpanUsed || noPredicate.Diagnostics.DenseInt64SpanReducer != columnTypedColumnDenseInt64SpanReducerLocalMap || noPredicate.Diagnostics.RowsScanned != len(events) || noPredicate.Diagnostics.RowsMatched != 0 || noPredicate.Diagnostics.ReduceRows != len(events) {
 		t.Fatalf("no-predicate diagnostics=%+v want dense span with RowsMatched=0 and ReduceRows=%d", noPredicate.Diagnostics, len(events))
 	}
 }
@@ -74,7 +74,7 @@ func BenchmarkColumnPhysicalQ5DenseTypedColumn1950(b *testing.B) {
 		if err != nil {
 			b.Fatalf("preview RunColumnPhysicalQuery: %v", err)
 		}
-		assertColumnPhysicalQ5DenseDiagnostics1950(b, "preview direct", preview.Diagnostics, len(events), matchedRows, req.TopK, len(preview.Groups))
+		assertColumnPhysicalQ5DenseDiagnostics1950(b, "preview direct", preview.Diagnostics, len(events), matchedRows, req.TopK, len(preview.Groups), columnTypedColumnDenseInt64SpanReducerLocalMap)
 		b.SetBytes(int64(preview.Diagnostics.DecodedPayloadBytes))
 		b.ReportAllocs()
 		b.ResetTimer()
@@ -105,7 +105,7 @@ func BenchmarkColumnPhysicalQ5DenseTypedColumn1950(b *testing.B) {
 		if err != nil {
 			b.Fatalf("preview runner.Run: %v", err)
 		}
-		assertColumnPhysicalQ5DenseDiagnostics1950(b, "preview prepared", preview.Diagnostics, len(events), matchedRows, req.TopK, len(preview.Groups))
+		assertColumnPhysicalQ5DenseDiagnostics1950(b, "preview prepared", preview.Diagnostics, len(events), matchedRows, req.TopK, len(preview.Groups), columnTypedColumnDenseInt64SpanReducerGlobalCodes)
 		b.SetBytes(int64(preview.Diagnostics.DecodedPayloadBytes))
 		b.ReportAllocs()
 		b.ResetTimer()
@@ -227,7 +227,7 @@ func columnPhysicalQ5DenseReferenceGroups1950(events []columnPhysicalJSONBenchPa
 	return groups
 }
 
-func assertColumnPhysicalQ5DenseResult1950(tb testing.TB, label string, result ColumnPhysicalQueryResult, want []ColumnPhysicalQueryGroup, rows, matchedRows int) {
+func assertColumnPhysicalQ5DenseResult1950(tb testing.TB, label string, result ColumnPhysicalQueryResult, want []ColumnPhysicalQueryGroup, rows, matchedRows int, wantReducer string) {
 	tb.Helper()
 	if len(result.Groups) != len(want) {
 		tb.Fatalf("%s groups=%+v want %+v", label, result.Groups, want)
@@ -237,16 +237,19 @@ func assertColumnPhysicalQ5DenseResult1950(tb testing.TB, label string, result C
 			tb.Fatalf("%s groups=%+v want %+v", label, result.Groups, want)
 		}
 	}
-	assertColumnPhysicalQ5DenseDiagnostics1950(tb, label, result.Diagnostics, rows, matchedRows, 3, len(want))
+	assertColumnPhysicalQ5DenseDiagnostics1950(tb, label, result.Diagnostics, rows, matchedRows, 3, len(want), wantReducer)
 }
 
-func assertColumnPhysicalQ5DenseDiagnostics1950(tb testing.TB, label string, diag ColumnPhysicalQueryDiagnostics, rows, matchedRows, topK, resultGroups int) {
+func assertColumnPhysicalQ5DenseDiagnostics1950(tb testing.TB, label string, diag ColumnPhysicalQueryDiagnostics, rows, matchedRows, topK, resultGroups int, wantReducer string) {
 	tb.Helper()
 	if diag.StorageSource != ColumnPhysicalQueryStorageSourceTypedColumnPartSection || diag.FallbackReason != ColumnPhysicalQueryFallbackNone {
 		tb.Fatalf("%s diagnostics storage/fallback=%+v", label, diag)
 	}
 	if !diag.DenseInt64SpanUsed {
 		tb.Fatalf("%s diagnostics did not mark dense int64-span use: %+v", label, diag)
+	}
+	if diag.DenseInt64SpanReducer != wantReducer {
+		tb.Fatalf("%s dense int64-span reducer=%q want %q diagnostics=%+v", label, diag.DenseInt64SpanReducer, wantReducer, diag)
 	}
 	if diag.RowMaterializations != 0 || diag.DocumentMaterializations != 0 {
 		tb.Fatalf("%s materialized rows/documents: %+v", label, diag)

--- a/TreeDB/collections/column_physical_query.go
+++ b/TreeDB/collections/column_physical_query.go
@@ -158,6 +158,7 @@ type ColumnPhysicalQueryDiagnostics struct {
 	DenseGroupCountDistinctPairBitWords int
 	DenseGroupHourCountUsed             bool
 	DenseInt64SpanUsed                  bool
+	DenseInt64SpanReducer               string
 	TimeOrderTopKUsed                   bool
 	DecodedPayloadBytes                 uint64
 	FallbackReads                       int
@@ -1391,6 +1392,7 @@ func mergeColumnPhysicalQueryDiagnostics(left, right ColumnPhysicalQueryDiagnost
 	}
 	left.DenseGroupHourCountUsed = left.DenseGroupHourCountUsed || right.DenseGroupHourCountUsed
 	left.DenseInt64SpanUsed = left.DenseInt64SpanUsed || right.DenseInt64SpanUsed
+	left.DenseInt64SpanReducer = mergeColumnPhysicalQueryReducerLabel(left.DenseInt64SpanReducer, right.DenseInt64SpanReducer)
 	left.TimeOrderTopKUsed = left.TimeOrderTopKUsed || right.TimeOrderTopKUsed
 	left.DecodedPayloadBytes += right.DecodedPayloadBytes
 	left.PhysicalBytesScanned += right.PhysicalBytesScanned

--- a/TreeDB/collections/column_physical_typed_column_query.go
+++ b/TreeDB/collections/column_physical_typed_column_query.go
@@ -17,6 +17,8 @@ const (
 	columnTypedColumnDenseGroupCountDistinctReducerPairBitset   = "pair_bitset"
 	columnTypedColumnDenseGroupCountDistinctReducerActiveBitset = "active_group_bitset"
 	columnTypedColumnDenseGroupCountDistinctReducerSortedPairs  = "sorted_packed_pairs"
+	columnTypedColumnDenseInt64SpanReducerGlobalCodes           = "global_codes"
+	columnTypedColumnDenseInt64SpanReducerLocalMap              = "local_map"
 )
 
 type columnTypedColumnPhysicalQueryPlan struct {
@@ -80,6 +82,8 @@ type columnTypedColumnDenseInt64SpanPart struct {
 	DictionaryByCode map[int64]string
 	GroupCodes       []uint32
 	GroupValid       []bool
+	GlobalRanks      []uint32
+	GlobalDictionary []string
 	Values           []int64
 	Predicates       []columnTypedColumnDensePredicatePart
 }
@@ -329,7 +333,7 @@ func runColumnPhysicalQueryTypedColumnPartLatestVisibleInSnapshotView(view colum
 		return result, true, fmt.Errorf("%w: typed-column sorted latest-visible physical query requires sorted typed_column_part assets", ErrColumnQueryPlanUnsupported)
 	}
 
-	runner, err := decodeColumnTypedColumnPhysicalQueryRunnerParts(view, req, plan, refsByGeneration, &readCache, columnTypedColumnPhysicalQueryUseSortedLatestVisible(plan, req))
+	runner, err := decodeColumnTypedColumnPhysicalQueryRunnerParts(view, req, plan, refsByGeneration, &readCache, columnTypedColumnPhysicalQueryUseSortedLatestVisible(plan, req), false)
 	if err != nil {
 		result := ColumnPhysicalQueryResult{Diagnostics: columnTypedColumnPhysicalMutationDiagnostics(view, req)}
 		annotateColumnPhysicalQueryResult(&result, ColumnPhysicalQueryStorageSourceTypedColumnPartSection, ColumnPhysicalQueryFallbackMutationVisibilityUnsupported)
@@ -410,7 +414,7 @@ func prepareColumnTypedColumnPhysicalQueryRunner(view columnPhysicalScanSnapshot
 	if _, err := validateTypedColumnPhysicalAssetPairing(refsByGeneration, view.AssetRefs); err != nil {
 		return nil, true, typedColumnPhysicalQueryPairingError(err)
 	}
-	runner, err := decodeColumnTypedColumnPhysicalQueryRunnerParts(view, req, plan, refsByGeneration, readCache, false)
+	runner, err := decodeColumnTypedColumnPhysicalQueryRunnerParts(view, req, plan, refsByGeneration, readCache, false, prepareSummaries)
 	if err != nil {
 		return nil, true, err
 	}
@@ -422,7 +426,7 @@ func prepareColumnTypedColumnPhysicalQueryRunner(view columnPhysicalScanSnapshot
 	return runner, true, nil
 }
 
-func decodeColumnTypedColumnPhysicalQueryRunnerParts(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest, plan columnTypedColumnPhysicalQueryPlan, refsByGeneration map[uint64]columnManifestAssetRefForScan, readCache *columnPhysicalAssetReadCache, includePhysicalRows bool) (*columnTypedColumnPhysicalQueryRunner, error) {
+func decodeColumnTypedColumnPhysicalQueryRunnerParts(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest, plan columnTypedColumnPhysicalQueryPlan, refsByGeneration map[uint64]columnManifestAssetRefForScan, readCache *columnPhysicalAssetReadCache, includePhysicalRows bool, prepareDenseInt64SpanGlobalCodes bool) (*columnTypedColumnPhysicalQueryRunner, error) {
 	if readCache == nil {
 		return nil, errors.New("collections: typed-column part physical query missing read cache")
 	}
@@ -503,6 +507,10 @@ func decodeColumnTypedColumnPhysicalQueryRunnerParts(view columnPhysicalScanSnap
 		}
 	} else if allowDenseGroupCountDistinct && columnTypedColumnPhysicalQueryUseDenseGroupCountDistinct(plan, req) {
 		if err := prepareColumnTypedColumnDenseGroupCountDistinctGlobalCodes(runner.parts); err != nil {
+			return nil, err
+		}
+	} else if prepareDenseInt64SpanGlobalCodes && columnTypedColumnPhysicalQueryUseDenseInt64Span(plan, req) {
+		if err := prepareColumnTypedColumnDenseInt64SpanGlobalCodes(runner.parts); err != nil {
 			return nil, err
 		}
 	}
@@ -831,6 +839,64 @@ func prepareColumnTypedColumnDenseGroupCountDistinctGlobalColumnCodes(column *co
 	column.GlobalCodes = globalCodes
 	column.GlobalDictionary = globalDictionary
 	return nil
+}
+
+func prepareColumnTypedColumnDenseInt64SpanGlobalCodes(parts []columnTypedColumnPhysicalQueryPart) error {
+	dictionary, ranks, err := columnTypedColumnDenseInt64SpanGlobalDictionary(parts)
+	if err != nil {
+		return err
+	}
+	for partIdx := range parts {
+		dense := parts[partIdx].DenseInt64Span
+		if dense == nil {
+			return fmt.Errorf("collections: dense typed-column int64-span missing prepared part %d", partIdx)
+		}
+		globalRanks := make([]uint32, dense.Cardinality)
+		for localCode := 0; localCode < dense.Cardinality; localCode++ {
+			value, ok := dense.DictionaryByCode[int64(localCode)]
+			if !ok {
+				return fmt.Errorf("collections: dense typed-column int64-span part %d dictionary missing local code %d", partIdx, localCode)
+			}
+			rank, ok := ranks[value]
+			if !ok {
+				return fmt.Errorf("collections: dense typed-column int64-span part %d local value %q missing from global dictionary", partIdx, value)
+			}
+			globalRanks[localCode] = rank
+		}
+		dense.GlobalRanks = globalRanks
+		dense.GlobalDictionary = dictionary
+	}
+	return nil
+}
+
+func columnTypedColumnDenseInt64SpanGlobalDictionary(parts []columnTypedColumnPhysicalQueryPart) ([]string, map[string]uint32, error) {
+	values := make(map[string]struct{})
+	for partIdx := range parts {
+		dense := parts[partIdx].DenseInt64Span
+		if dense == nil {
+			return nil, nil, fmt.Errorf("collections: dense typed-column int64-span missing prepared part %d", partIdx)
+		}
+		for localCode := 0; localCode < dense.Cardinality; localCode++ {
+			value, ok := dense.DictionaryByCode[int64(localCode)]
+			if !ok {
+				return nil, nil, fmt.Errorf("collections: dense typed-column int64-span part %d dictionary missing local code %d", partIdx, localCode)
+			}
+			values[value] = struct{}{}
+		}
+	}
+	dictionary := make([]string, 0, len(values))
+	for value := range values {
+		dictionary = append(dictionary, value)
+	}
+	sort.Strings(dictionary)
+	ranks := make(map[string]uint32, len(dictionary))
+	for rank, value := range dictionary {
+		if uint64(rank) > uint64(^uint32(0)) {
+			return nil, nil, fmt.Errorf("collections: dense typed-column int64-span global dictionary cardinality=%d exceeds uint32", len(dictionary))
+		}
+		ranks[value] = uint32(rank)
+	}
+	return dictionary, ranks, nil
 }
 
 func columnTypedColumnPhysicalQueryTouchesTypedColumnPart(cfg ColumnStoreConfig, req ColumnPhysicalQueryRequest) bool {
@@ -1572,20 +1638,23 @@ func (r *columnTypedColumnPhysicalQueryRunner) runLatestVisibleDenseInt64Span(vi
 		if err != nil {
 			diag := r.latestVisibleDiagnostics(view, req, state, visibilityBytes, visibilityNanos, rowsScanned, matchedRows, reduceRows, time.Since(start).Nanoseconds())
 			diag.DenseInt64SpanUsed = true
+			diag.DenseInt64SpanReducer = columnTypedColumnDenseInt64SpanReducerLocalMap
 			return ColumnPhysicalQueryResult{Diagnostics: diag}, err
 		}
 		dense := part.DenseInt64Span
 		if dense == nil {
 			diag := r.latestVisibleDiagnostics(view, req, state, visibilityBytes, visibilityNanos, rowsScanned, matchedRows, reduceRows, time.Since(start).Nanoseconds())
 			diag.DenseInt64SpanUsed = true
+			diag.DenseInt64SpanReducer = columnTypedColumnDenseInt64SpanReducerLocalMap
 			return ColumnPhysicalQueryResult{Diagnostics: diag}, fmt.Errorf("collections: dense typed-column int64-span missing prepared part %d", partIdx)
 		}
 		if len(dense.GroupCodes) != len(dense.Values) {
 			diag := r.latestVisibleDiagnostics(view, req, state, visibilityBytes, visibilityNanos, rowsScanned, matchedRows, reduceRows, time.Since(start).Nanoseconds())
 			diag.DenseInt64SpanUsed = true
+			diag.DenseInt64SpanReducer = columnTypedColumnDenseInt64SpanReducerLocalMap
 			return ColumnPhysicalQueryResult{Diagnostics: diag}, fmt.Errorf("collections: dense typed-column int64-span part %d group/value rows=%d/%d", partIdx, len(dense.GroupCodes), len(dense.Values))
 		}
-		if cap(r.denseLocalSpans) < dense.Cardinality {
+		if cap(r.denseLocalSpans) < dense.Cardinality || cap(r.denseLocalSpanSeen) < dense.Cardinality {
 			r.denseLocalSpans = make([]columnPhysicalQuerySpan, dense.Cardinality)
 			r.denseLocalSpanSeen = make([]bool, dense.Cardinality)
 		} else {
@@ -1616,12 +1685,14 @@ func (r *columnTypedColumnPhysicalQueryRunner) runLatestVisibleDenseInt64Span(vi
 				}
 				diag := r.latestVisibleDiagnostics(view, req, state, visibilityBytes, visibilityNanos, rowsScanned, matchedRows, reduceRows, time.Since(start).Nanoseconds())
 				diag.DenseInt64SpanUsed = true
+				diag.DenseInt64SpanReducer = columnTypedColumnDenseInt64SpanReducerLocalMap
 				return ColumnPhysicalQueryResult{Diagnostics: diag}, fmt.Errorf("%w: dense typed-column int64-span nullable group column requires skip-empty group key", ErrColumnQueryPlanUnsupported)
 			}
 			localIdx, ok := columnDictionaryCodeIndex(code, len(r.denseLocalSpans))
 			if !ok {
 				diag := r.latestVisibleDiagnostics(view, req, state, visibilityBytes, visibilityNanos, rowsScanned, matchedRows, reduceRows, time.Since(start).Nanoseconds())
 				diag.DenseInt64SpanUsed = true
+				diag.DenseInt64SpanReducer = columnTypedColumnDenseInt64SpanReducerLocalMap
 				return ColumnPhysicalQueryResult{Diagnostics: diag}, fmt.Errorf("collections: dense typed-column int64-span part %d code[%d]=%d outside cardinality=%d", partIdx, rowIdx, code, len(r.denseLocalSpans))
 			}
 			value := dense.Values[rowIdx]
@@ -1647,6 +1718,7 @@ func (r *columnTypedColumnPhysicalQueryRunner) runLatestVisibleDenseInt64Span(vi
 			if !ok {
 				diag := r.latestVisibleDiagnostics(view, req, state, visibilityBytes, visibilityNanos, rowsScanned, matchedRows, reduceRows, time.Since(start).Nanoseconds())
 				diag.DenseInt64SpanUsed = true
+				diag.DenseInt64SpanReducer = columnTypedColumnDenseInt64SpanReducerLocalMap
 				return ColumnPhysicalQueryResult{Diagnostics: diag}, fmt.Errorf("collections: dense typed-column int64-span part %d dictionary missing local code %d", partIdx, localCode)
 			}
 			partSpan := r.denseLocalSpans[localCode]
@@ -1673,6 +1745,7 @@ func (r *columnTypedColumnPhysicalQueryRunner) runLatestVisibleDenseInt64Span(vi
 	}
 	diag := r.latestVisibleDiagnostics(view, req, state, visibilityBytes, visibilityNanos, rowsScanned, matchedRows, reduceRows, time.Since(start).Nanoseconds())
 	diag.DenseInt64SpanUsed = true
+	diag.DenseInt64SpanReducer = columnTypedColumnDenseInt64SpanReducerLocalMap
 	result := ColumnPhysicalQueryResult{Groups: r.resultGroups, Diagnostics: diag}
 	finalizeColumnPhysicalQueryResultGroups(req, &result)
 	r.resultGroups = result.Groups
@@ -2581,6 +2654,173 @@ func (r *columnTypedColumnPhysicalQueryRunner) runDenseGroupHourCount(view colum
 }
 
 func (r *columnTypedColumnPhysicalQueryRunner) runDenseInt64Span(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest) (ColumnPhysicalQueryResult, error) {
+	if columnTypedColumnDenseInt64SpanPartsHaveGlobalCodes(r.parts) {
+		return r.runDenseInt64SpanGlobalCodes(view, req)
+	}
+	return r.runDenseInt64SpanLocalMap(view, req)
+}
+
+func columnTypedColumnDenseInt64SpanPartsHaveGlobalCodes(parts []columnTypedColumnPhysicalQueryPart) bool {
+	if len(parts) == 0 {
+		return false
+	}
+	cardinality := -1
+	for partIdx := range parts {
+		dense := parts[partIdx].DenseInt64Span
+		if dense == nil || dense.GlobalDictionary == nil || len(dense.GlobalRanks) != dense.Cardinality {
+			return false
+		}
+		if cardinality < 0 {
+			cardinality = len(dense.GlobalDictionary)
+			continue
+		}
+		if len(dense.GlobalDictionary) != cardinality {
+			return false
+		}
+	}
+	return true
+}
+
+func (r *columnTypedColumnPhysicalQueryRunner) runDenseInt64SpanGlobalCodes(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest) (ColumnPhysicalQueryResult, error) {
+	start := time.Now()
+	var groupDictionary []string
+	for partIdx := range r.parts {
+		dense := r.parts[partIdx].DenseInt64Span
+		if dense == nil {
+			diag := r.diagnostics(view, req, 0, 0, 0, time.Since(start).Nanoseconds())
+			diag.DenseInt64SpanUsed = true
+			diag.DenseInt64SpanReducer = columnTypedColumnDenseInt64SpanReducerGlobalCodes
+			return ColumnPhysicalQueryResult{Diagnostics: diag}, fmt.Errorf("collections: dense typed-column int64-span missing prepared part %d", partIdx)
+		}
+		if len(dense.GroupCodes) != len(dense.Values) || len(dense.GlobalRanks) != dense.Cardinality {
+			diag := r.diagnostics(view, req, 0, 0, 0, time.Since(start).Nanoseconds())
+			diag.DenseInt64SpanUsed = true
+			diag.DenseInt64SpanReducer = columnTypedColumnDenseInt64SpanReducerGlobalCodes
+			return ColumnPhysicalQueryResult{Diagnostics: diag}, fmt.Errorf("collections: dense typed-column int64-span part %d group/value/global-rank rows=%d/%d cardinality=%d/%d", partIdx, len(dense.GroupCodes), len(dense.Values), len(dense.GlobalRanks), dense.Cardinality)
+		}
+		if groupDictionary == nil {
+			groupDictionary = dense.GlobalDictionary
+			continue
+		}
+		if len(dense.GlobalDictionary) != len(groupDictionary) {
+			diag := r.diagnostics(view, req, 0, 0, 0, time.Since(start).Nanoseconds())
+			diag.DenseInt64SpanUsed = true
+			diag.DenseInt64SpanReducer = columnTypedColumnDenseInt64SpanReducerGlobalCodes
+			return ColumnPhysicalQueryResult{Diagnostics: diag}, fmt.Errorf("collections: dense typed-column int64-span part %d global cardinality=%d want %d", partIdx, len(dense.GlobalDictionary), len(groupDictionary))
+		}
+	}
+	groupCardinality := len(groupDictionary)
+	if cap(r.denseLocalSpans) < groupCardinality || cap(r.denseLocalSpanSeen) < groupCardinality {
+		r.denseLocalSpans = make([]columnPhysicalQuerySpan, groupCardinality)
+		r.denseLocalSpanSeen = make([]bool, groupCardinality)
+	} else {
+		r.denseLocalSpans = r.denseLocalSpans[:groupCardinality]
+		clear(r.denseLocalSpans)
+		r.denseLocalSpanSeen = r.denseLocalSpanSeen[:groupCardinality]
+		clear(r.denseLocalSpanSeen)
+	}
+	rowsScanned := 0
+	matchedRows := 0
+	reduceRows := 0
+	for partIdx := range r.parts {
+		dense := r.parts[partIdx].DenseInt64Span
+		if columnTypedColumnDensePredicatesRejectAll(dense.Predicates) {
+			rowsScanned += len(dense.GroupCodes)
+			continue
+		}
+		for rowIdx := range dense.GroupCodes {
+			rowsScanned++
+			if !columnTypedColumnDensePredicatesMatch(dense.Predicates, rowIdx) {
+				continue
+			}
+			if len(dense.Predicates) != 0 {
+				matchedRows++
+			}
+			reduceRows++
+			if !columnTypedColumnDenseCodeValid(dense.GroupValid, rowIdx) {
+				if req.SkipEmptyGroupKey {
+					continue
+				}
+				diag := r.diagnostics(view, req, rowsScanned, matchedRows, reduceRows, time.Since(start).Nanoseconds())
+				diag.DenseInt64SpanUsed = true
+				diag.DenseInt64SpanReducer = columnTypedColumnDenseInt64SpanReducerGlobalCodes
+				return ColumnPhysicalQueryResult{Diagnostics: diag}, fmt.Errorf("%w: dense typed-column int64-span nullable group column requires skip-empty group key", ErrColumnQueryPlanUnsupported)
+			}
+			localIdx, ok := columnDictionaryCodeIndex(dense.GroupCodes[rowIdx], len(dense.GlobalRanks))
+			if !ok {
+				diag := r.diagnostics(view, req, rowsScanned, matchedRows, reduceRows, time.Since(start).Nanoseconds())
+				diag.DenseInt64SpanUsed = true
+				diag.DenseInt64SpanReducer = columnTypedColumnDenseInt64SpanReducerGlobalCodes
+				return ColumnPhysicalQueryResult{Diagnostics: diag}, fmt.Errorf("collections: dense typed-column int64-span part %d code[%d]=%d outside cardinality=%d", partIdx, rowIdx, dense.GroupCodes[rowIdx], len(dense.GlobalRanks))
+			}
+			globalCode := dense.GlobalRanks[localIdx]
+			globalIdx, ok := columnDictionaryCodeIndex(globalCode, len(r.denseLocalSpans))
+			if !ok {
+				diag := r.diagnostics(view, req, rowsScanned, matchedRows, reduceRows, time.Since(start).Nanoseconds())
+				diag.DenseInt64SpanUsed = true
+				diag.DenseInt64SpanReducer = columnTypedColumnDenseInt64SpanReducerGlobalCodes
+				return ColumnPhysicalQueryResult{Diagnostics: diag}, fmt.Errorf("collections: dense typed-column int64-span part %d global code[%d]=%d outside cardinality=%d", partIdx, rowIdx, globalCode, len(r.denseLocalSpans))
+			}
+			value := dense.Values[rowIdx]
+			if !r.denseLocalSpanSeen[globalIdx] {
+				r.denseLocalSpans[globalIdx] = columnPhysicalQuerySpan{min: value, max: value}
+				r.denseLocalSpanSeen[globalIdx] = true
+				continue
+			}
+			span := r.denseLocalSpans[globalIdx]
+			if value < span.min {
+				span.min = value
+			}
+			if value > span.max {
+				span.max = value
+			}
+			r.denseLocalSpans[globalIdx] = span
+		}
+	}
+	scanNanos := time.Since(start).Nanoseconds()
+	r.resultGroups = r.resultGroups[:0]
+	diag := r.diagnostics(view, req, rowsScanned, matchedRows, reduceRows, scanNanos)
+	diag.DenseInt64SpanUsed = true
+	diag.DenseInt64SpanReducer = columnTypedColumnDenseInt64SpanReducerGlobalCodes
+	if req.TopK > 0 {
+		shapeStart := time.Now()
+		candidates := 0
+		for globalIdx, seen := range r.denseLocalSpanSeen {
+			if !seen {
+				continue
+			}
+			key := groupDictionary[globalIdx]
+			if req.SkipEmptyGroupKey && key == "" {
+				continue
+			}
+			span := r.denseLocalSpans[globalIdx]
+			candidates++
+			insertColumnPhysicalTopKGroup(&r.resultGroups, ColumnPhysicalQueryGroup{Key: key, Int64: span.max - span.min}, req.TopK, req.TopKOrder)
+		}
+		diag.ResultShapeNanos += time.Since(shapeStart).Nanoseconds()
+		diag.TopKLimit = req.TopK
+		diag.TopKOrder = string(req.TopKOrder)
+		diag.TopKCandidates = candidates
+		diag.ResultGroups = len(r.resultGroups)
+		return ColumnPhysicalQueryResult{Groups: r.resultGroups, Diagnostics: diag}, nil
+	}
+	for globalIdx, seen := range r.denseLocalSpanSeen {
+		if !seen {
+			continue
+		}
+		key := groupDictionary[globalIdx]
+		if req.SkipEmptyGroupKey && key == "" {
+			continue
+		}
+		span := r.denseLocalSpans[globalIdx]
+		r.resultGroups = append(r.resultGroups, ColumnPhysicalQueryGroup{Key: key, Int64: span.max - span.min})
+	}
+	sortColumnPhysicalQueryGroupsByKey(r.resultGroups)
+	diag.ResultGroups = len(r.resultGroups)
+	return ColumnPhysicalQueryResult{Groups: r.resultGroups, Diagnostics: diag}, nil
+}
+
+func (r *columnTypedColumnPhysicalQueryRunner) runDenseInt64SpanLocalMap(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest) (ColumnPhysicalQueryResult, error) {
 	start := time.Now()
 	if r.denseSpanValues == nil {
 		r.denseSpanValues = make(map[string]columnPhysicalQuerySpan, 16)
@@ -2595,14 +2835,16 @@ func (r *columnTypedColumnPhysicalQueryRunner) runDenseInt64Span(view columnPhys
 		if dense == nil {
 			diag := r.diagnostics(view, req, rowsScanned, matchedRows, reduceRows, time.Since(start).Nanoseconds())
 			diag.DenseInt64SpanUsed = true
+			diag.DenseInt64SpanReducer = columnTypedColumnDenseInt64SpanReducerLocalMap
 			return ColumnPhysicalQueryResult{Diagnostics: diag}, fmt.Errorf("collections: dense typed-column int64-span missing prepared part %d", partIdx)
 		}
 		if len(dense.GroupCodes) != len(dense.Values) {
 			diag := r.diagnostics(view, req, rowsScanned, matchedRows, reduceRows, time.Since(start).Nanoseconds())
 			diag.DenseInt64SpanUsed = true
+			diag.DenseInt64SpanReducer = columnTypedColumnDenseInt64SpanReducerLocalMap
 			return ColumnPhysicalQueryResult{Diagnostics: diag}, fmt.Errorf("collections: dense typed-column int64-span part %d group/value rows=%d/%d", partIdx, len(dense.GroupCodes), len(dense.Values))
 		}
-		if cap(r.denseLocalSpans) < dense.Cardinality {
+		if cap(r.denseLocalSpans) < dense.Cardinality || cap(r.denseLocalSpanSeen) < dense.Cardinality {
 			r.denseLocalSpans = make([]columnPhysicalQuerySpan, dense.Cardinality)
 			r.denseLocalSpanSeen = make([]bool, dense.Cardinality)
 		} else {
@@ -2630,12 +2872,14 @@ func (r *columnTypedColumnPhysicalQueryRunner) runDenseInt64Span(view columnPhys
 				}
 				diag := r.diagnostics(view, req, rowsScanned, matchedRows, reduceRows, time.Since(start).Nanoseconds())
 				diag.DenseInt64SpanUsed = true
+				diag.DenseInt64SpanReducer = columnTypedColumnDenseInt64SpanReducerLocalMap
 				return ColumnPhysicalQueryResult{Diagnostics: diag}, fmt.Errorf("%w: dense typed-column int64-span nullable group column requires skip-empty group key", ErrColumnQueryPlanUnsupported)
 			}
 			localIdx, ok := columnDictionaryCodeIndex(code, len(r.denseLocalSpans))
 			if !ok {
 				diag := r.diagnostics(view, req, rowsScanned, matchedRows, reduceRows, time.Since(start).Nanoseconds())
 				diag.DenseInt64SpanUsed = true
+				diag.DenseInt64SpanReducer = columnTypedColumnDenseInt64SpanReducerLocalMap
 				return ColumnPhysicalQueryResult{Diagnostics: diag}, fmt.Errorf("collections: dense typed-column int64-span part %d code[%d]=%d outside cardinality=%d", partIdx, rowIdx, code, len(r.denseLocalSpans))
 			}
 			value := dense.Values[rowIdx]
@@ -2661,6 +2905,7 @@ func (r *columnTypedColumnPhysicalQueryRunner) runDenseInt64Span(view columnPhys
 			if !ok {
 				diag := r.diagnostics(view, req, rowsScanned, matchedRows, reduceRows, time.Since(start).Nanoseconds())
 				diag.DenseInt64SpanUsed = true
+				diag.DenseInt64SpanReducer = columnTypedColumnDenseInt64SpanReducerLocalMap
 				return ColumnPhysicalQueryResult{Diagnostics: diag}, fmt.Errorf("collections: dense typed-column int64-span part %d dictionary missing local code %d", partIdx, localCode)
 			}
 			partSpan := r.denseLocalSpans[localCode]
@@ -2682,6 +2927,7 @@ func (r *columnTypedColumnPhysicalQueryRunner) runDenseInt64Span(view columnPhys
 	r.resultGroups = r.resultGroups[:0]
 	diag := r.diagnostics(view, req, rowsScanned, matchedRows, reduceRows, scanNanos)
 	diag.DenseInt64SpanUsed = true
+	diag.DenseInt64SpanReducer = columnTypedColumnDenseInt64SpanReducerLocalMap
 	if req.TopK > 0 {
 		shapeStart := time.Now()
 		candidates := 0

--- a/cmd/unified_bench/suite_column_store.go
+++ b/cmd/unified_bench/suite_column_store.go
@@ -232,6 +232,8 @@ type columnStoreQueryMetric struct {
 	RowsScanned              int                               `json:"rows_scanned"`
 	RowsMatched              int                               `json:"rows_matched"`
 	ReduceRows               int                               `json:"reduce_rows"`
+	TopKCandidates           int                               `json:"topk_candidates,omitempty"`
+	DenseInt64SpanReducer    string                            `json:"dense_int64_span_reducer,omitempty"`
 	DecodedGranules          int                               `json:"decoded_granules"`
 	PlannerCandidates        int                               `json:"planner_candidates"`
 	PlannerReason            string                            `json:"planner_reason,omitempty"`
@@ -291,6 +293,8 @@ type columnStoreJSONBenchCell struct {
 	RowsScanned                      int                               `json:"rows_scanned"`
 	RowsMatched                      int                               `json:"rows_matched"`
 	ReduceRows                       int                               `json:"reduce_rows"`
+	TopKCandidates                   int                               `json:"topk_candidates,omitempty"`
+	DenseInt64SpanReducer            string                            `json:"dense_int64_span_reducer,omitempty"`
 	DecodedGranules                  int                               `json:"decoded_granules"`
 	SkippedGranules                  int                               `json:"skipped_granules"`
 	ScheduledGranules                int                               `json:"scheduled_granules"`
@@ -370,6 +374,8 @@ type columnStoreQueryExecution struct {
 	RowsScanned            int
 	RowsMatched            int
 	ReduceRows             int
+	TopKCandidates         int
+	DenseInt64SpanReducer  string
 	DecodedGranules        int
 	DecodedBlocks          int
 	DecodedPayloadBytes    uint64
@@ -1592,6 +1598,8 @@ func runColumnStoreSuiteQueries(collection *collections.Collection, rows int, ra
 			RowsScanned:            exec.RowsScanned,
 			RowsMatched:            exec.RowsMatched,
 			ReduceRows:             exec.ReduceRows,
+			TopKCandidates:         exec.TopKCandidates,
+			DenseInt64SpanReducer:  exec.DenseInt64SpanReducer,
 			DecodedGranules:        exec.DecodedGranules,
 			PlannerCandidates:      plan.Diagnostics.CandidatePlans,
 			PlannerReason:          plan.Diagnostics.Reason,
@@ -1798,6 +1806,8 @@ func executeColumnStoreSuitePhysicalQuery(collection *collections.Collection, qu
 		RowsScanned:            diag.RowsScanned,
 		RowsMatched:            diag.RowsMatched,
 		ReduceRows:             diag.ReduceRows,
+		TopKCandidates:         diag.TopKCandidates,
+		DenseInt64SpanReducer:  diag.DenseInt64SpanReducer,
 		DecodedGranules:        diag.DecodedGranules,
 		DecodedBlocks:          diag.DecodedBlocks,
 		DecodedPayloadBytes:    diag.DecodedPayloadBytes,
@@ -1890,6 +1900,8 @@ func executeColumnStoreSuitePreparedPhysicalQuery(collection *collections.Collec
 		RowsScanned:            diag.RowsScanned,
 		RowsMatched:            diag.RowsMatched,
 		ReduceRows:             diag.ReduceRows,
+		TopKCandidates:         diag.TopKCandidates,
+		DenseInt64SpanReducer:  diag.DenseInt64SpanReducer,
 		DecodedGranules:        diag.DecodedGranules,
 		DecodedBlocks:          diag.DecodedBlocks,
 		DecodedPayloadBytes:    diag.DecodedPayloadBytes,
@@ -2301,6 +2313,8 @@ func columnStoreJSONBenchCellFromQueryMetric(q columnStoreQueryMetric, cfg *coll
 	cell.RowsScanned = q.RowsScanned
 	cell.RowsMatched = q.RowsMatched
 	cell.ReduceRows = q.ReduceRows
+	cell.TopKCandidates = q.TopKCandidates
+	cell.DenseInt64SpanReducer = q.DenseInt64SpanReducer
 	cell.DecodedGranules = q.DecodedGranules
 	cell.SkippedGranules = q.SkippedGranules
 	cell.ScheduledGranules = q.ScheduledGranules
@@ -2362,6 +2376,8 @@ func columnStoreJSONBenchCellFromPreparedExecution(name string, rawHash uint64, 
 	cell.RowsScanned = exec.RowsScanned
 	cell.RowsMatched = exec.RowsMatched
 	cell.ReduceRows = exec.ReduceRows
+	cell.TopKCandidates = exec.TopKCandidates
+	cell.DenseInt64SpanReducer = exec.DenseInt64SpanReducer
 	cell.DecodedGranules = exec.DecodedGranules
 	cell.SkippedGranules = exec.SkippedGranules
 	cell.ScheduledGranules = exec.ScheduledGranules


### PR DESCRIPTION
## Summary

- add a prepared-run q5 dense int64-span reducer that maps per-part local string codes to one global dictionary and reduces spans by global rank
- keep direct and latest-visible q5 dense-span execution on the existing local-map reducer so one-shot direct latency stays neutral
- expose dense int64-span reducer and top-k candidate diagnostics through column-store JSONBench output structs

## Tracker

Refs #3003
Refs #3000

## Validation

- `go test ./TreeDB/collections -run 'TestColumnPhysicalQ5DenseTypedColumnDirectPreparedParity1950|TestColumnPhysicalLatestVisibleQ5DenseTypedColumn1953'`
- `go test ./cmd/unified_bench`
- `go test ./cmd/unified_bench -run 'TestColumnStore'`
- `go test ./TreeDB/collections -run 'TestColumnPhysicalQ(1|2|3|4|5)|TestColumnAggregateMetadata|TestColumnPhysicalLatestVisibleQ(4|5)'`
- `go test ./TreeDB/collections`
- `go run ./cmd/unified_bench -suite column_store -dbs treedb -keys 16384 -batchsize 4096 -column-store-path serial_column_scan -column-store-query q5 -profile-dir /tmp/q5_global_span_report_vHsLMa`
- `go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnPhysicalQ5DenseTypedColumn1950/(direct_RunColumnPhysicalQuery|prepared_runner_Run)$' -benchmem -count=10`

## Benchmark Notes

Final q5 dense typed-column microbench on Apple M3:

- direct `RunColumnPhysicalQuery`: mostly ~0.692-0.724 ms/op, one 0.856 ms outlier, ~1.73 MB/op, 2427 allocs/op
- prepared `runner.Run`: ~0.123-0.126 ms/op, 0 B/op, 0 allocs/op
- both paths report 16,384 rows scanned, 5,044 reduce rows, and 2,046 top-k candidates

This keeps direct q5 behavior around the baseline range while moving the reusable prepared hot path from the previous ~0.207-0.209 ms/op range to ~0.124-0.126 ms/op.

The small unified-bench q5 smoke completed and wrote `/tmp/q5_global_span_report_vHsLMa`. That smoke uses the current synthetic compatibility route for q5, so the new reducer diagnostic fields are validated through the typed-column q5 unit benchmark rather than that smoke artifact. The full external JSONBench/ClickHouse gate remains follow-up tracker work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visibility into which dense int64 span reducer was used during column queries.
  * Extended benchmark and query metrics to report additional execution diagnostics.

* **Bug Fixes**
  * Improved diagnostics for dense int64 span queries so merged results preserve reducer information.
  * Tightened validation in tests to confirm the expected reducer path is selected in direct and prepared executions.

* **Tests**
  * Updated query tests and benchmarks to assert reducer selection and related diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->