### PR TITLE
Expose Mongo load metadata in benchmark reports

### DIFF
--- a/cmd/benchmark_run_report/main.go
+++ b/cmd/benchmark_run_report/main.go
@@ -98,6 +98,11 @@ type mongoSummaryRow struct {
 	MongoPhysicalBytes      float64
 	TreeDBToMongoTotalRatio float64
 	TreeDBToMongoPhysRatio  float64
+	BatchSize               int
+	InsertProducers         int
+	EffectiveProducers      int
+	DriverCalls             int
+	LoadBatchCount          int
 	Source                  string
 }
 
@@ -682,6 +687,19 @@ func readMongoSummary(path string) ([]mongoSummaryRow, error) {
 			setErr(err)
 			return v
 		}
+		optionalIntField := func(name string) int {
+			if _, ok := header[normalizeTSVHeader(name)]; !ok {
+				return 0
+			}
+			v, err := tsvField(path, header, rec, line, name)
+			setErr(err)
+			if v == "" {
+				return 0
+			}
+			parsed, err := parseIntColumn(path, line, name, v)
+			setErr(err)
+			return parsed
+		}
 		boolField := func(name string) bool {
 			v, err := parseBoolColumn(path, line, name, get(name))
 			setErr(err)
@@ -717,6 +735,11 @@ func readMongoSummary(path string) ([]mongoSummaryRow, error) {
 			MongoPhysicalBytes:      floatField("mongo_physical_bytes"),
 			TreeDBToMongoTotalRatio: floatField("treedb_to_mongo_dbstats_total_ratio"),
 			TreeDBToMongoPhysRatio:  floatField("treedb_to_mongo_physical_ratio"),
+			BatchSize:               optionalIntField("batch_size"),
+			InsertProducers:         optionalIntField("insert_producers"),
+			EffectiveProducers:      optionalIntField("effective_producers"),
+			DriverCalls:             optionalIntField("driver_calls"),
+			LoadBatchCount:          optionalIntField("load_batch_count"),
 			Source:                  filepath.Base(filepath.Dir(path)),
 		}
 		if parseErr != nil {
@@ -2393,6 +2416,9 @@ func renderMongoLoadModes(b *strings.Builder, rows []loadModeRow) {
 
 func fullSweepLoadNote(rows []mongoSummaryRow) string {
 	note := "The load chart in this section is the load phase of the broader full sweep, not the pure ingest client-mode matrix. Use it when interpreting the read/range/update sweep as a whole; use the load-only matrix below when comparing client paths."
+	if metadata := mongoLoadMetadataText(rows); metadata != "" {
+		note += " " + metadata
+	}
 	for _, row := range rows {
 		if row.Phase == "load_insert_many" && row.SecondaryIndexes == 0 && row.RangeIndex {
 			note += " This run has range_index=true, so even the displayed 0-secondary-index load cell maintains the additional age_1 range index during insert."
@@ -2400,6 +2426,90 @@ func fullSweepLoadNote(rows []mongoSummaryRow) string {
 		}
 	}
 	return "<p class=\"subtle\"><strong>Load interpretation:</strong> " + esc(note) + "</p>"
+}
+
+func mongoLoadMetadataText(rows []mongoSummaryRow) string {
+	loadRows := mongoRowsForPhase(rows, "load_insert_many")
+	if len(loadRows) == 0 {
+		return ""
+	}
+	first, ok := firstMongoLoadRowWithMetadata(loadRows)
+	if !ok {
+		return "Load metadata is unavailable in this summary; regenerate with a newer compare report to show batch size and producer counts."
+	}
+	for _, row := range loadRows {
+		if !mongoLoadHasMetadata(row) || !sameMongoLoadMetadata(first, row) {
+			return "Load rows use mixed or incomplete document, batch, or producer metadata; see the raw full-sweep TSV rows."
+		}
+	}
+	parts := []string{fmt.Sprintf("%s docs", commaInt(int64(first.Documents)))}
+	if first.BatchSize > 0 {
+		parts = append(parts, fmt.Sprintf("batch size %s", commaInt(int64(first.BatchSize))))
+	}
+	requested := first.InsertProducers
+	effective := mongoEffectiveLoadProducers(first)
+	batches := mongoLoadBatchCount(first)
+	switch {
+	case requested > 0 && effective > 0 && requested != effective:
+		if batches > 0 {
+			parts = append(parts, fmt.Sprintf("requested insert producers %d, effective %d (capped by %d load batches)", requested, effective, batches))
+		} else {
+			parts = append(parts, fmt.Sprintf("requested insert producers %d, effective %d", requested, effective))
+		}
+	case requested > 0:
+		parts = append(parts, fmt.Sprintf("insert producers %d", requested))
+	case effective > 0:
+		parts = append(parts, fmt.Sprintf("effective insert producers %d", effective))
+	}
+	if first.DriverCalls > 0 {
+		parts = append(parts, fmt.Sprintf("driver calls %s", commaInt(int64(first.DriverCalls))))
+	}
+	return "Measured load metadata: " + strings.Join(parts, ", ") + "."
+}
+
+func firstMongoLoadRowWithMetadata(rows []mongoSummaryRow) (mongoSummaryRow, bool) {
+	for _, row := range rows {
+		if mongoLoadHasMetadata(row) {
+			return row, true
+		}
+	}
+	return mongoSummaryRow{}, false
+}
+
+func mongoLoadHasMetadata(row mongoSummaryRow) bool {
+	return row.BatchSize > 0 || row.InsertProducers > 0 || row.EffectiveProducers > 0 || row.DriverCalls > 0 || row.LoadBatchCount > 0
+}
+
+func sameMongoLoadMetadata(a, b mongoSummaryRow) bool {
+	return a.Documents == b.Documents &&
+		a.BatchSize == b.BatchSize &&
+		a.InsertProducers == b.InsertProducers &&
+		mongoEffectiveLoadProducers(a) == mongoEffectiveLoadProducers(b) &&
+		mongoLoadBatchCount(a) == mongoLoadBatchCount(b)
+}
+
+func mongoEffectiveLoadProducers(row mongoSummaryRow) int {
+	if row.EffectiveProducers > 0 {
+		return row.EffectiveProducers
+	}
+	if row.InsertProducers <= 0 {
+		return 0
+	}
+	batches := mongoLoadBatchCount(row)
+	if batches > 0 && row.InsertProducers > batches {
+		return batches
+	}
+	return row.InsertProducers
+}
+
+func mongoLoadBatchCount(row mongoSummaryRow) int {
+	if row.LoadBatchCount > 0 {
+		return row.LoadBatchCount
+	}
+	if row.Documents <= 0 || row.BatchSize <= 0 {
+		return 0
+	}
+	return (row.Documents + row.BatchSize - 1) / row.BatchSize
 }
 
 func renderMongoScaling(b *strings.Builder, byIndex map[int][]mongoSummaryRow) {
@@ -2471,6 +2581,11 @@ func writeMongoSummaryTable(b *strings.Builder, rows []mongoSummaryRow) {
 			row.TreeDBConfig,
 			emptyDash(row.MongoConfig),
 			row.Phase,
+			formatOptionalInt(row.BatchSize),
+			formatOptionalInt(row.InsertProducers),
+			formatOptionalInt(mongoEffectiveLoadProducers(row)),
+			formatOptionalInt(row.DriverCalls),
+			formatOptionalInt(mongoLoadBatchCount(row)),
 			fmtOps(row.TreeDBOpsSec),
 			fmtOps(row.MongoOpsSec),
 			fmtRatio(row.TreeDBToMongoRatio),
@@ -2484,7 +2599,14 @@ func writeMongoSummaryTable(b *strings.Builder, rows []mongoSummaryRow) {
 			row.Source,
 		})
 	}
-	writeTable(b, []string{"docs", "indexes", "range index", "range mode", "TreeDB config", "Mongo config", "phase", "TreeDB ops/s", "Mongo ops/s", "ratio", "TreeDB p95 us", "Mongo p95 us", "TreeDB disk snapshot", "TreeDB logical bytes", "TreeDB physical", "Mongo dbStats total", "Mongo physical", "source"}, body, numericColumns(0, 1, 7, 8, 9, 10, 11, 13, 14, 15, 16))
+	writeTable(b, []string{"docs", "indexes", "range index", "range mode", "TreeDB config", "Mongo config", "phase", "batch size", "insert producers", "effective producers", "driver calls", "load batches", "TreeDB ops/s", "Mongo ops/s", "ratio", "TreeDB p95 us", "Mongo p95 us", "TreeDB disk snapshot", "TreeDB logical bytes", "TreeDB physical", "Mongo dbStats total", "Mongo physical", "source"}, body, numericColumns(0, 1, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 18, 19, 20, 21))
+}
+
+func formatOptionalInt(value int) string {
+	if value <= 0 {
+		return "n/a"
+	}
+	return commaInt(int64(value))
 }
 
 func sortedMongoIndexes(rows []mongoSummaryRow) []int {

--- a/cmd/benchmark_run_report/main.go
+++ b/cmd/benchmark_run_report/main.go
@@ -2489,17 +2489,18 @@ func sameMongoLoadMetadata(a, b mongoSummaryRow) bool {
 }
 
 func mongoEffectiveLoadProducers(row mongoSummaryRow) int {
-	if row.EffectiveProducers > 0 {
-		return row.EffectiveProducers
+	effective := row.EffectiveProducers
+	if effective <= 0 {
+		effective = row.InsertProducers
 	}
-	if row.InsertProducers <= 0 {
+	if effective <= 0 {
 		return 0
 	}
 	batches := mongoLoadBatchCount(row)
-	if batches > 0 && row.InsertProducers > batches {
+	if batches > 0 && effective > batches {
 		return batches
 	}
-	return row.InsertProducers
+	return effective
 }
 
 func mongoLoadBatchCount(row mongoSummaryRow) int {

--- a/cmd/benchmark_run_report/main_test.go
+++ b/cmd/benchmark_run_report/main_test.go
@@ -715,7 +715,7 @@ func TestFullSweepLoadNoteReportsProducerMetadata(t *testing.T) {
 		Phase:              "load_insert_many",
 		BatchSize:          25,
 		InsertProducers:    8,
-		EffectiveProducers: 4,
+		EffectiveProducers: 8,
 		DriverCalls:        4,
 		LoadBatchCount:     4,
 	}})

--- a/cmd/benchmark_run_report/main_test.go
+++ b/cmd/benchmark_run_report/main_test.go
@@ -505,6 +505,31 @@ func TestReadMongoSummaryStrictParsing(t *testing.T) {
 	}
 }
 
+func TestReadMongoSummaryOptionalLoadMetadata(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "summary.tsv")
+
+	writeFile(t, path, mongoSummaryFixture(0))
+	rows, err := readMongoSummary(path)
+	if err != nil {
+		t.Fatalf("read old summary: %v", err)
+	}
+	if rows[0].BatchSize != 0 || rows[0].InsertProducers != 0 || rows[0].EffectiveProducers != 0 || rows[0].DriverCalls != 0 || rows[0].LoadBatchCount != 0 {
+		t.Fatalf("old summary parsed metadata: %+v", rows[0])
+	}
+
+	writeFile(t, path, mongoSummaryFixtureWithLoadMetadata(0, 25, 8, 4))
+	rows, err = readMongoSummary(path)
+	if err != nil {
+		t.Fatalf("read summary with load metadata: %v", err)
+	}
+	got := rows[0]
+	if got.BatchSize != 25 || got.InsertProducers != 8 || got.EffectiveProducers != 4 || got.DriverCalls != 4 || got.LoadBatchCount != 4 {
+		t.Fatalf("load metadata = batch=%d requested=%d effective=%d calls=%d batches=%d",
+			got.BatchSize, got.InsertProducers, got.EffectiveProducers, got.DriverCalls, got.LoadBatchCount)
+	}
+}
+
 func TestMongoSweepCountsObservedOnly(t *testing.T) {
 	rows := []mongoSummaryRow{
 		{SecondaryIndexes: 0, Phase: "concurrent_id_find_one_r16", TreeDBOpsSec: 160, MongoOpsSec: 80},
@@ -683,6 +708,32 @@ func TestFullSweepLoadNoteRangeIndexMentionsDisplayedZeroOnly(t *testing.T) {
 	}
 }
 
+func TestFullSweepLoadNoteReportsProducerMetadata(t *testing.T) {
+	note := fullSweepLoadNote([]mongoSummaryRow{{
+		Documents:          100,
+		SecondaryIndexes:   0,
+		Phase:              "load_insert_many",
+		BatchSize:          25,
+		InsertProducers:    8,
+		EffectiveProducers: 4,
+		DriverCalls:        4,
+		LoadBatchCount:     4,
+	}})
+	for _, want := range []string{
+		"Measured load metadata",
+		"100 docs",
+		"batch size 25",
+		"requested insert producers 8",
+		"effective 4",
+		"capped by 4 load batches",
+		"driver calls 4",
+	} {
+		if !strings.Contains(note, want) {
+			t.Fatalf("note missing %q\n%s", want, note)
+		}
+	}
+}
+
 func TestFormatChartTooltipValueDoesNotDoubleBytes(t *testing.T) {
 	if got := formatChartTooltipValue(1024*1024, "bytes"); got != "1.00 MiB" {
 		t.Fatalf("bytes tooltip = %q, want 1.00 MiB", got)
@@ -760,10 +811,19 @@ func TestParseConfigRejectsInvalidRunRoot(t *testing.T) {
 
 const mongoSummaryHeader = "documents\tsecondary_indexes\trange_index\trange_mode\ttreedb_config\tmongo_config\tphase\ttreedb_ops_sec\ttreedb_sampled_ops_sec\ttreedb_sampled_ns_per_op\tmongo_ops_sec\tmongo_sampled_ops_sec\tmongo_sampled_ns_per_op\ttreedb_to_mongo_ops_ratio\ttreedb_to_mongo_sampled_ops_ratio\ttreedb_p50_us\tmongo_p50_us\ttreedb_p95_us\tmongo_p95_us\ttreedb_p99_us\tmongo_p99_us\ttreedb_disk_snapshot\ttreedb_disk_bytes\ttreedb_physical_bytes\tmongo_dbstats_data_size_bytes\tmongo_dbstats_total_size_bytes\tmongo_physical_bytes\ttreedb_to_mongo_dbstats_total_ratio\ttreedb_to_mongo_physical_ratio\n"
 
+const mongoSummaryHeaderWithLoadMetadata = "documents\tsecondary_indexes\trange_index\trange_mode\ttreedb_config\tmongo_config\tphase\ttreedb_ops_sec\ttreedb_sampled_ops_sec\ttreedb_sampled_ns_per_op\tmongo_ops_sec\tmongo_sampled_ops_sec\tmongo_sampled_ns_per_op\ttreedb_to_mongo_ops_ratio\ttreedb_to_mongo_sampled_ops_ratio\ttreedb_p50_us\tmongo_p50_us\ttreedb_p95_us\tmongo_p95_us\ttreedb_p99_us\tmongo_p99_us\ttreedb_disk_snapshot\ttreedb_disk_bytes\ttreedb_physical_bytes\tmongo_dbstats_data_size_bytes\tmongo_dbstats_total_size_bytes\tmongo_physical_bytes\ttreedb_to_mongo_dbstats_total_ratio\ttreedb_to_mongo_physical_ratio\tbatch_size\tinsert_producers\teffective_producers\tdriver_calls\tload_batch_count\n"
+
 func mongoSummaryFixture(indexes int) string {
 	return mongoSummaryHeader +
 		fmt.Sprintf("100\t%d\tfalse\t\ttreedb_bson\tmongo\tload_insert_many\t1000\t1000\t1000\t500\t500\t2000\t2\t2\t1\t2\t3\t4\t5\t6\tmaintenance\t1000\t2000\t3000\t4000\t5000\t0.25\t0.4\n", indexes) +
 		fmt.Sprintf("100\t%d\tfalse\t\ttreedb_bson\tmongo\tconcurrent_id_find_one_r1\t2000\t2000\t500\t1000\t1000\t1000\t2\t2\t1\t2\t3\t4\t5\t6\tmaintenance\t1000\t2000\t3000\t4000\t5000\t0.25\t0.4\n", indexes)
+}
+
+func mongoSummaryFixtureWithLoadMetadata(indexes, batchSize, requestedProducers, effectiveProducers int) string {
+	loadBatchCount := (100 + batchSize - 1) / batchSize
+	return mongoSummaryHeaderWithLoadMetadata +
+		fmt.Sprintf("100\t%d\tfalse\t\ttreedb_bson\tmongo\tload_insert_many\t1000\t1000\t1000\t500\t500\t2000\t2\t2\t1\t2\t3\t4\t5\t6\tmaintenance\t1000\t2000\t3000\t4000\t5000\t0.25\t0.4\t%d\t%d\t%d\t%d\t%d\n",
+			indexes, batchSize, requestedProducers, effectiveProducers, loadBatchCount, loadBatchCount)
 }
 
 func writeFile(t *testing.T, path, content string) {

--- a/cmd/mongo_gateway_compare_report/main.go
+++ b/cmd/mongo_gateway_compare_report/main.go
@@ -1593,14 +1593,8 @@ func summaryLoadMetadataFields(cmp phaseComparison, cell cellComparison) []strin
 	if !ok {
 		return []string{"", "", "", "", ""}
 	}
-	loadBatches := derivedLoadBatchCount(result, phase)
-	effectiveProducers := phase.EffectiveProducers
-	if effectiveProducers <= 0 && result.InsertProducers > 0 {
-		effectiveProducers = result.InsertProducers
-		if loadBatches > 0 && effectiveProducers > loadBatches {
-			effectiveProducers = loadBatches
-		}
-	}
+	loadBatches := summaryLoadBatchCount(result, phase)
+	effectiveProducers := summaryEffectiveLoadProducers(result, phase)
 	return []string{
 		formatRawInt(result.BatchSize > 0, int64(result.BatchSize)),
 		formatRawInt(result.InsertProducers > 0, int64(result.InsertProducers)),
@@ -1620,7 +1614,22 @@ func summaryLoadMetadataSource(cmp phaseComparison, cell cellComparison) (benchm
 	return benchmarkResult{}, phaseResult{}, false
 }
 
-func derivedLoadBatchCount(result benchmarkResult, phase phaseResult) int {
+func summaryEffectiveLoadProducers(result benchmarkResult, phase phaseResult) int {
+	effective := phase.EffectiveProducers
+	batches := summaryLoadBatchCount(result, phase)
+	if effective <= 0 {
+		effective = result.InsertProducers
+	}
+	if effective <= 0 {
+		return 0
+	}
+	if batches > 0 && effective > batches {
+		return batches
+	}
+	return effective
+}
+
+func summaryLoadBatchCount(result benchmarkResult, phase phaseResult) int {
 	if result.Documents > 0 && result.BatchSize > 0 {
 		return (result.Documents + result.BatchSize - 1) / result.BatchSize
 	}

--- a/cmd/mongo_gateway_compare_report/main.go
+++ b/cmd/mongo_gateway_compare_report/main.go
@@ -40,6 +40,8 @@ type benchmarkResult struct {
 	Database                   string            `json:"database"`
 	Collection                 string            `json:"collection"`
 	Documents                  int               `json:"documents"`
+	BatchSize                  int               `json:"batch_size"`
+	InsertProducers            int               `json:"insert_producers"`
 	SecondaryIndexes           int               `json:"secondary_indexes"`
 	RangeIndex                 bool              `json:"range_index"`
 	ClientMode                 string            `json:"client_mode,omitempty"`
@@ -67,6 +69,7 @@ type phaseResult struct {
 	Name                    string             `json:"name"`
 	Operations              int                `json:"operations"`
 	DriverCalls             int                `json:"driver_calls"`
+	EffectiveProducers      int                `json:"effective_producers,omitempty"`
 	DurationMillis          float64            `json:"duration_ms"`
 	OpsPerSecond            float64            `json:"ops_per_sec"`
 	SampledOpsPerSecond     float64            `json:"sampled_ops_per_sec,omitempty"`
@@ -1520,6 +1523,11 @@ func writeSummaryTSV(path string, cells []cellComparison) error {
 		"mongo_physical_bytes",
 		"treedb_to_mongo_dbstats_total_ratio",
 		"treedb_to_mongo_physical_ratio",
+		"batch_size",
+		"insert_producers",
+		"effective_producers",
+		"driver_calls",
+		"load_batch_count",
 	}
 	if err := writer.Write(header); err != nil {
 		return err
@@ -1568,12 +1576,55 @@ func writeSummaryTSV(path string, cells []cellComparison) error {
 			formatRawMeasuredRatio(treeOK && mongoTotalOK, treeBytes, mongoTotal),
 			formatRawRatio(safeRatio(float64(treePhysical), float64(mongoPhysical))),
 		}
+		row = append(row, summaryLoadMetadataFields(cmp, cell)...)
 		if err := writer.Write(row); err != nil {
 			return err
 		}
 	}
 	writer.Flush()
 	return writer.Error()
+}
+
+func summaryLoadMetadataFields(cmp phaseComparison, cell cellComparison) []string {
+	if cmp.Name != "load_insert_many" {
+		return []string{"", "", "", "", ""}
+	}
+	result, phase, ok := summaryLoadMetadataSource(cmp, cell)
+	if !ok {
+		return []string{"", "", "", "", ""}
+	}
+	loadBatches := derivedLoadBatchCount(result, phase)
+	effectiveProducers := phase.EffectiveProducers
+	if effectiveProducers <= 0 && result.InsertProducers > 0 {
+		effectiveProducers = result.InsertProducers
+		if loadBatches > 0 && effectiveProducers > loadBatches {
+			effectiveProducers = loadBatches
+		}
+	}
+	return []string{
+		formatRawInt(result.BatchSize > 0, int64(result.BatchSize)),
+		formatRawInt(result.InsertProducers > 0, int64(result.InsertProducers)),
+		formatRawInt(effectiveProducers > 0, int64(effectiveProducers)),
+		formatRawInt(phase.DriverCalls > 0, int64(phase.DriverCalls)),
+		formatRawInt(loadBatches > 0, int64(loadBatches)),
+	}
+}
+
+func summaryLoadMetadataSource(cmp phaseComparison, cell cellComparison) (benchmarkResult, phaseResult, bool) {
+	if cmp.HasTreeDB {
+		return cell.TreeDB.Result, cmp.TreeDBPhase, true
+	}
+	if cmp.HasMongo && cell.Mongo != nil {
+		return cell.Mongo.Result, cmp.MongoPhase, true
+	}
+	return benchmarkResult{}, phaseResult{}, false
+}
+
+func derivedLoadBatchCount(result benchmarkResult, phase phaseResult) int {
+	if result.Documents > 0 && result.BatchSize > 0 {
+		return (result.Documents + result.BatchSize - 1) / result.BatchSize
+	}
+	return phase.DriverCalls
 }
 
 func findCell(cells []cellComparison, key cellKey) cellComparison {

--- a/cmd/mongo_gateway_compare_report/main_test.go
+++ b/cmd/mongo_gateway_compare_report/main_test.go
@@ -89,7 +89,7 @@ func TestSummaryTSVEmitsLoadMetadataColumns(t *testing.T) {
   "insert_producers": 4,
   "secondary_indexes": 0,
   "phases": [
-    {"name": "load_insert_many", "operations": 10, "driver_calls": 3, "effective_producers": 3, "ops_per_sec": 1000, "latency_micros": {}},
+    {"name": "load_insert_many", "operations": 10, "driver_calls": 3, "effective_producers": 9, "ops_per_sec": 1000, "latency_micros": {}},
     {"name": "id_find_one", "operations": 10, "driver_calls": 10, "ops_per_sec": 2000, "latency_micros": {}}
   ],
   "treedb_disk_after_checkpoint": {"total_bytes": 1000}
@@ -103,7 +103,7 @@ func TestSummaryTSVEmitsLoadMetadataColumns(t *testing.T) {
   "insert_producers": 4,
   "secondary_indexes": 0,
   "phases": [
-    {"name": "load_insert_many", "operations": 10, "driver_calls": 3, "effective_producers": 3, "ops_per_sec": 500, "latency_micros": {}},
+    {"name": "load_insert_many", "operations": 10, "driver_calls": 3, "effective_producers": 9, "ops_per_sec": 500, "latency_micros": {}},
     {"name": "id_find_one", "operations": 10, "driver_calls": 10, "ops_per_sec": 2500, "latency_micros": {}}
   ],
   "mongodb_stats_final": {"dataSize": 1300, "totalSize": 1500}

--- a/cmd/mongo_gateway_compare_report/main_test.go
+++ b/cmd/mongo_gateway_compare_report/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/csv"
 	"os"
 	"path/filepath"
 	"strings"
@@ -68,6 +69,81 @@ func TestReportFromMatrix(t *testing.T) {
 	summary := readFile(t, summaryPath)
 	if !strings.Contains(summary, "load_insert_many\t10000.000000\t12500.000000\t80.000000\t5000.000000\t6250.000000\t160.000000\t2.000000\t2.000000") {
 		t.Fatalf("summary missing load ratio:\n%s", summary)
+	}
+}
+
+func TestSummaryTSVEmitsLoadMetadataColumns(t *testing.T) {
+	dir := t.TempDir()
+	treedbPath := filepath.Join(dir, "treedb.json")
+	mongoPath := filepath.Join(dir, "mongo.json")
+	matrixPath := filepath.Join(dir, "matrix.tsv")
+	reportPath := filepath.Join(dir, "report.md")
+	summaryPath := filepath.Join(dir, "summary.tsv")
+
+	writeFile(t, treedbPath, `{
+  "target": "treedb",
+  "database": "bench",
+  "collection": "docs",
+  "documents": 10,
+  "batch_size": 4,
+  "insert_producers": 4,
+  "secondary_indexes": 0,
+  "phases": [
+    {"name": "load_insert_many", "operations": 10, "driver_calls": 3, "effective_producers": 3, "ops_per_sec": 1000, "latency_micros": {}},
+    {"name": "id_find_one", "operations": 10, "driver_calls": 10, "ops_per_sec": 2000, "latency_micros": {}}
+  ],
+  "treedb_disk_after_checkpoint": {"total_bytes": 1000}
+}`)
+	writeFile(t, mongoPath, `{
+  "target": "mongo",
+  "database": "bench",
+  "collection": "docs",
+  "documents": 10,
+  "batch_size": 4,
+  "insert_producers": 4,
+  "secondary_indexes": 0,
+  "phases": [
+    {"name": "load_insert_many", "operations": 10, "driver_calls": 3, "effective_producers": 3, "ops_per_sec": 500, "latency_micros": {}},
+    {"name": "id_find_one", "operations": 10, "driver_calls": 10, "ops_per_sec": 2500, "latency_micros": {}}
+  ],
+  "mongodb_stats_final": {"dataSize": 1300, "totalSize": 1500}
+}`)
+	writeFile(t, matrixPath, "target\tdocuments\tsecondary_indexes\traw_json\tphysical_bytes\n"+
+		"treedb\t10\t0\ttreedb.json\t2048\n"+
+		"mongo\t10\t0\tmongo.json\t4096\n")
+
+	if err := run([]string{
+		"-matrix", matrixPath,
+		"-report", reportPath,
+		"-summary", summaryPath,
+	}); err != nil {
+		t.Fatalf("run failed: %v", err)
+	}
+
+	records := readTSV(t, summaryPath)
+	header := tsvHeaderMap(t, records[0])
+	for _, name := range []string{"batch_size", "insert_producers", "effective_producers", "driver_calls", "load_batch_count"} {
+		if _, ok := header[name]; !ok {
+			t.Fatalf("summary header missing %q: %v", name, records[0])
+		}
+	}
+	load := tsvRowByPhase(t, records, header, "load_insert_many")
+	for name, want := range map[string]string{
+		"batch_size":          "4",
+		"insert_producers":    "4",
+		"effective_producers": "3",
+		"driver_calls":        "3",
+		"load_batch_count":    "3",
+	} {
+		if got := load[header[name]]; got != want {
+			t.Fatalf("load row %s=%q want %q\nrow=%v", name, got, want, load)
+		}
+	}
+	read := tsvRowByPhase(t, records, header, "id_find_one")
+	for _, name := range []string{"batch_size", "insert_producers", "effective_producers", "driver_calls", "load_batch_count"} {
+		if got := read[header[name]]; got != "" {
+			t.Fatalf("non-load row %s=%q want blank\nrow=%v", name, got, read)
+		}
 	}
 }
 
@@ -1398,4 +1474,43 @@ func readFile(t *testing.T, path string) string {
 		t.Fatal(err)
 	}
 	return string(data)
+}
+
+func readTSV(t *testing.T, path string) [][]string {
+	t.Helper()
+	reader := csv.NewReader(strings.NewReader(readFile(t, path)))
+	reader.Comma = '\t'
+	reader.FieldsPerRecord = -1
+	records, err := reader.ReadAll()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(records) == 0 {
+		t.Fatalf("%s: empty TSV", path)
+	}
+	return records
+}
+
+func tsvHeaderMap(t *testing.T, header []string) map[string]int {
+	t.Helper()
+	out := make(map[string]int, len(header))
+	for i, name := range header {
+		out[name] = i
+	}
+	return out
+}
+
+func tsvRowByPhase(t *testing.T, records [][]string, header map[string]int, phase string) []string {
+	t.Helper()
+	phaseCol, ok := header["phase"]
+	if !ok {
+		t.Fatalf("header missing phase column: %v", header)
+	}
+	for _, row := range records[1:] {
+		if phaseCol < len(row) && row[phaseCol] == phase {
+			return row
+		}
+	}
+	t.Fatalf("missing phase %q in records: %v", phase, records)
+	return nil
 }


### PR DESCRIPTION
## Objective

Close #3027 under parent #3026 by making Mongo-compatible load metadata first-class in the benchmark report pipeline.

## Context

The full-sweep load chart already comes from a bulk `load_insert_many` phase, but previous `summary.tsv` rows dropped the exact load shape. That made generated `deep_report.html` files unable to state batch size, requested producers, effective producers, driver calls, or producer capping without raw JSON inspection.

## Non-Goals

- No benchmark workload behavior changes.
- No new benchmark dimensions.
- No broad report redesign beyond exposing the metadata needed by later milestones.

## Design

- Additive `summary.tsv` columns at the end of `cmd/mongo_gateway_compare_report` output: `batch_size`, `insert_producers`, `effective_producers`, `driver_calls`, and `load_batch_count`.
- Keep non-load phase rows blank for these fields.
- Parse the new columns in `cmd/benchmark_run_report` only when present, so old artifacts continue to render.
- Update the full-sweep load interpretation note and raw TSV table to show requested/effective producer metadata and capped producer cases.

## Scope

- Runtime benchmark code changed: no.
- Report-only / artifact-contract code changed: yes.
- Workload behavior changed: no.

## Correctness

The parser remains header-based and treats the new fields as optional. Old `summary.tsv` files parse with zero metadata values; new files surface producer/batch metadata in notes and raw tables.

## Performance

No benchmark execution path changes. The report generator adds only TSV field parsing and string formatting.

## Evidence

| Check | Result |
| --- | --- |
| `GOWORK=off go test -count=1 ./cmd/mongo_gateway_compare_report ./cmd/benchmark_run_report` | pass |
| `git diff --check` | pass |
| Before | summary rows stopped at storage ratios and did not carry load producer metadata |
| After | load rows include batch size, requested/effective producers, driver calls, and derived load batch count |

## AI Review Status

Not yet requested. This PR is ready for review after GitHub checks start on the pushed branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added load-metadata details to Mongo benchmark reports, including batch size, producer counts, driver calls, and load batch counts.
  * Expanded the full-sweep Mongo report to show a clearer load interpretation note when metadata is available.

* **Bug Fixes**
  * Report generation now handles missing metadata columns gracefully instead of failing.
  * Load-related values are shown only for relevant phases, keeping other rows clean and readable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->