### PR TITLE
Add Mongo InsertMany producer-scaling bundle

### DIFF
--- a/scripts/mongo_gateway_load_scaling_bench.sh
+++ b/scripts/mongo_gateway_load_scaling_bench.sh
@@ -1,0 +1,292 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+cd "$ROOT"
+
+TMP_BASE="${TMPDIR:-/tmp}"
+TMP_BASE="${TMP_BASE%/}"
+OUT_DIR="${OUT_DIR:-$(mktemp -d "$TMP_BASE/gomap_mongo_gateway_load_scaling_XXXXXX")}"
+DOCS="${DOCS:-100000}"
+INDEXES_LIST="${INDEXES_LIST:-0 1 2}"
+BATCH_SIZE="${BATCH_SIZE:-1000}"
+PRODUCERS_LIST="${PRODUCERS_LIST:-1 2 4 8 16 32}"
+MONGO_MODE="${MONGO_MODE:-docker}"
+MONGO_URI="${MONGO_URI:-mongodb://127.0.0.1:27017}"
+MONGO_IMAGE="${MONGO_IMAGE:-mongo:8}"
+MONGO_COMPACT="${MONGO_COMPACT:-}"
+MONGO_MAX_POOL_SIZE="${MONGO_MAX_POOL_SIZE:-128}"
+MONGO_MAX_CONNECTING="${MONGO_MAX_CONNECTING:-32}"
+TIMEOUT="${TIMEOUT:-120m}"
+TITLE="${TITLE:-Mongo API InsertMany Producer Scaling}"
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/mongo_gateway_load_scaling_bench.sh [options]
+
+Runs load-only TreeDB-vs-MongoDB InsertMany comparisons across insert producer
+counts. Each producer count gets a normal mongo_gateway_compare.sh bundle under:
+
+  <out>/producers_<N>/
+
+The wrapper also writes an aggregate summary TSV at:
+
+  <out>/summary.tsv
+
+Options:
+  --out DIR              Output directory. Default: mktemp under $TMPDIR or /tmp.
+  --docs N               Documents per producer-count run. Default: 100000.
+  --indexes LIST         Space- or comma-separated secondary index counts. Default: "0 1 2".
+  --batch-size N         InsertMany batch size. Default: 1000.
+  --producers LIST       Space- or comma-separated producer counts. Default: "1 2 4 8 16 32".
+  --mongo-mode MODE      docker or external. Default: docker.
+  --mongo-uri URI        MongoDB URI for external runs. Default: mongodb://127.0.0.1:27017.
+  --mongo-image IMAGE    Docker image for docker mode. Default: mongo:8.
+  --mongo-compact BOOL   Compact MongoDB before final stats collection.
+  --timeout DURATION     Per-cell timeout. Default: 120m.
+  --title TITLE          Bundle title.
+  --help                 Show this help.
+
+Environment overrides use the uppercase variable names in the script.
+EOF
+}
+
+require_value() {
+  local opt=$1
+  local value=${2-}
+  if [[ -z "$value" || "$value" == --* ]]; then
+    echo "missing value for $opt" >&2
+    usage >&2
+    exit 2
+  fi
+}
+
+normalize_list() {
+  printf '%s' "$1" | tr ',' ' '
+}
+
+is_positive_int() {
+  [[ "$1" =~ ^[0-9]+$ ]] && [[ "$1" -gt 0 ]]
+}
+
+is_nonnegative_int() {
+  [[ "$1" =~ ^[0-9]+$ ]]
+}
+
+max_int_in_list() {
+  local max=0
+  local value
+  for value in $1; do
+    if [[ "$value" -gt "$max" ]]; then
+      max=$value
+    fi
+  done
+  printf '%s' "$max"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --out)
+      require_value "$1" "${2-}"
+      OUT_DIR="$2"
+      shift 2
+      ;;
+    --docs)
+      require_value "$1" "${2-}"
+      DOCS="$2"
+      shift 2
+      ;;
+    --indexes)
+      require_value "$1" "${2-}"
+      INDEXES_LIST="$2"
+      shift 2
+      ;;
+    --batch-size)
+      require_value "$1" "${2-}"
+      BATCH_SIZE="$2"
+      shift 2
+      ;;
+    --producers)
+      require_value "$1" "${2-}"
+      PRODUCERS_LIST="$2"
+      shift 2
+      ;;
+    --mongo-mode)
+      require_value "$1" "${2-}"
+      MONGO_MODE="$2"
+      shift 2
+      ;;
+    --mongo-uri)
+      require_value "$1" "${2-}"
+      MONGO_URI="$2"
+      shift 2
+      ;;
+    --mongo-image)
+      require_value "$1" "${2-}"
+      MONGO_IMAGE="$2"
+      shift 2
+      ;;
+    --mongo-compact=*)
+      MONGO_COMPACT="${1#*=}"
+      shift
+      ;;
+    --mongo-compact)
+      require_value "$1" "${2-}"
+      MONGO_COMPACT="$2"
+      shift 2
+      ;;
+    --timeout)
+      require_value "$1" "${2-}"
+      TIMEOUT="$2"
+      shift 2
+      ;;
+    --title)
+      require_value "$1" "${2-}"
+      TITLE="$2"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+INDEXES_LIST=$(normalize_list "$INDEXES_LIST")
+PRODUCERS_LIST=$(normalize_list "$PRODUCERS_LIST")
+
+if ! is_positive_int "$DOCS"; then
+  echo "invalid --docs $DOCS (want positive integer)" >&2
+  exit 2
+fi
+if ! is_positive_int "$BATCH_SIZE"; then
+  echo "invalid --batch-size $BATCH_SIZE (want positive integer)" >&2
+  exit 2
+fi
+for indexes in $INDEXES_LIST; do
+  if ! is_nonnegative_int "$indexes"; then
+    echo "invalid --indexes value $indexes (want non-negative integers)" >&2
+    exit 2
+  fi
+done
+for producers in $PRODUCERS_LIST; do
+  if ! is_positive_int "$producers"; then
+    echo "invalid --producers value $producers (want positive integers)" >&2
+    exit 2
+  fi
+done
+case "$MONGO_MODE" in
+  docker|external) ;;
+  *)
+    echo "invalid --mongo-mode $MONGO_MODE (want docker or external)" >&2
+    exit 2
+    ;;
+esac
+
+OUT_DIR=$(mkdir -p "$(dirname "$OUT_DIR")" && cd "$(dirname "$OUT_DIR")" && pwd -P)/$(basename "$OUT_DIR")
+mkdir -p "$OUT_DIR"
+
+load_batches=$(((DOCS + BATCH_SIZE - 1) / BATCH_SIZE))
+max_producers=$(max_int_in_list "$PRODUCERS_LIST")
+if [[ "$load_batches" -lt "$max_producers" ]]; then
+  echo "warning: docs=$DOCS batch_size=$BATCH_SIZE yields only $load_batches load batches; requested producers up to $max_producers will be capped" >&2
+fi
+
+RUN_INDEX="$OUT_DIR/producer_runs.tsv"
+printf 'producer\trun_dir\tsummary_tsv\tmatrix_tsv\treport_md\n' > "$RUN_INDEX"
+
+for producers in $PRODUCERS_LIST; do
+  run_dir="$OUT_DIR/producers_${producers}"
+  mongo_compact_args=()
+  if [[ -n "$MONGO_COMPACT" ]]; then
+    mongo_compact_args=(--mongo-compact "$MONGO_COMPACT")
+  fi
+  env \
+    TREEDB_DOCUMENT_FORMATS=bson \
+    TREEDB_CLIENT_MODES=driver-command-raw \
+    MONGO_CLIENT_MODES=driver-command-raw \
+    BATCH_SIZE="$BATCH_SIZE" \
+    INSERT_PRODUCERS="$producers" \
+    MONGO_MAX_POOL_SIZE="$MONGO_MAX_POOL_SIZE" \
+    MONGO_MAX_CONNECTING="$MONGO_MAX_CONNECTING" \
+    PREBUILD_DOCUMENTS=true \
+    READS=0 \
+    RANGE_READS=0 \
+    UPDATES=0 \
+    DELETES=0 \
+    CONCURRENT_READ_KINDS=id \
+    CONCURRENT_READERS=0 \
+    CONCURRENT_READER_SWEEP= \
+    CONCURRENT_READS=0 \
+    CONCURRENT_RANGE_READERS=0 \
+    CONCURRENT_RANGE_READER_SWEEP= \
+    CONCURRENT_RANGE_READS=0 \
+    CONCURRENT_WRITERS=0 \
+    CONCURRENT_WRITER_SWEEP= \
+    CONCURRENT_WRITES=0 \
+    PROFILE_TREEDB=false \
+    ./scripts/mongo_gateway_compare.sh \
+      --out "$run_dir" \
+      --docs "$DOCS" \
+      --indexes "$INDEXES_LIST" \
+      --mongo-mode "$MONGO_MODE" \
+      --mongo-image "$MONGO_IMAGE" \
+      "${mongo_compact_args[@]}" \
+      --mongo-uri "$MONGO_URI" \
+      --timeout "$TIMEOUT" \
+      --title "$TITLE, producers=${producers}"
+  printf '%s\t%s\t%s\t%s\t%s\n' "$producers" "producers_${producers}" "producers_${producers}/summary.tsv" "producers_${producers}/matrix.tsv" "producers_${producers}/report.md" >> "$RUN_INDEX"
+done
+
+AGG_SUMMARY="$OUT_DIR/summary.tsv"
+tmp_summary="$OUT_DIR/.summary.tsv.tmp"
+rm -f "$tmp_summary"
+wrote_header=false
+for producers in $PRODUCERS_LIST; do
+  summary="$OUT_DIR/producers_${producers}/summary.tsv"
+  if [[ ! -s "$summary" ]]; then
+    echo "missing summary for producers=$producers: $summary" >&2
+    exit 1
+  fi
+  if [[ "$wrote_header" == false ]]; then
+    cat "$summary" > "$tmp_summary"
+    wrote_header=true
+  else
+    tail -n +2 "$summary" >> "$tmp_summary"
+  fi
+done
+mv "$tmp_summary" "$AGG_SUMMARY"
+
+cat > "$OUT_DIR/README.md" <<EOF
+# Mongo Gateway InsertMany Producer Scaling Bundle
+
+- output directory: \`$OUT_DIR\`
+- aggregate summary TSV: \`$AGG_SUMMARY\`
+- producer run index: \`$RUN_INDEX\`
+- docs: \`$DOCS\`
+- secondary indexes: \`$INDEXES_LIST\`
+- batch size: \`$BATCH_SIZE\`
+- load batches: \`$load_batches\`
+- producer counts: \`$PRODUCERS_LIST\`
+- MongoDB mode: \`$MONGO_MODE\`
+- MongoDB image: \`$MONGO_IMAGE\`
+- MongoDB URI: \`$MONGO_URI\`
+- MongoDB compact: \`${MONGO_COMPACT:-mode default}\`
+- MongoDB Go driver pool options: \`maxPoolSize=$MONGO_MAX_POOL_SIZE maxConnecting=$MONGO_MAX_CONNECTING\`
+- timeout: \`$TIMEOUT\`
+
+Each \`producers_<N>/\` directory is a normal load-only \`mongo_gateway_compare.sh\`
+bundle with raw JSON, \`matrix.tsv\`, \`summary.tsv\`, and \`report.md\`.
+
+The aggregate \`summary.tsv\` is a concatenation of the producer run summaries.
+Use the \`insert_producers\`, \`effective_producers\`, and \`load_batch_count\`
+columns to distinguish requested producer counts from capped effective counts.
+EOF
+
+echo "Mongo gateway load-scaling bundle: $OUT_DIR"
+echo "Aggregate summary: $AGG_SUMMARY"

--- a/scripts/mongo_gateway_load_scaling_bench.sh
+++ b/scripts/mongo_gateway_load_scaling_bench.sh
@@ -253,11 +253,41 @@ for producers in $PRODUCERS_LIST; do
     echo "missing summary for producers=$producers: $summary" >&2
     exit 1
   fi
+  include_header=false
   if [[ "$wrote_header" == false ]]; then
-    cat "$summary" > "$tmp_summary"
+    include_header=true
     wrote_header=true
-  else
-    tail -n +2 "$summary" >> "$tmp_summary"
+  fi
+  if ! awk -v include_header="$include_header" -F '\t' '
+    BEGIN {
+      OFS = FS
+    }
+    NR == 1 {
+      for (i = 1; i <= NF; i++) {
+        if ($i == "phase") {
+          phase_col = i
+        }
+      }
+      if (include_header == "true") {
+        print
+      }
+      next
+    }
+    phase_col > 0 && $phase_col == "load_insert_many" {
+      rows++
+      print
+    }
+    END {
+      if (phase_col == 0) {
+        exit 2
+      }
+      if (rows == 0) {
+        exit 3
+      }
+    }
+  ' "$summary" >> "$tmp_summary"; then
+    echo "failed to append load_insert_many rows for producers=$producers from $summary" >&2
+    exit 1
   fi
 done
 mv "$tmp_summary" "$AGG_SUMMARY"
@@ -283,7 +313,8 @@ cat > "$OUT_DIR/README.md" <<EOF
 Each \`producers_<N>/\` directory is a normal load-only \`mongo_gateway_compare.sh\`
 bundle with raw JSON, \`matrix.tsv\`, \`summary.tsv\`, and \`report.md\`.
 
-The aggregate \`summary.tsv\` is a concatenation of the producer run summaries.
+The aggregate \`summary.tsv\` keeps one header and only the \`load_insert_many\`
+rows from each producer run summary.
 Use the \`insert_producers\`, \`effective_producers\`, and \`load_batch_count\`
 columns to distinguish requested producer counts from capped effective counts.
 EOF

--- a/scripts/treedb_benchmark_run_report.sh
+++ b/scripts/treedb_benchmark_run_report.sh
@@ -18,6 +18,9 @@ COLLECTION_PROFILE_BENCHTIME="${COLLECTION_PROFILE_BENCHTIME:-}"
 COLLECTION_PROFILE_COUNT="${COLLECTION_PROFILE_COUNT:-1}"
 MONGO_BATCH_SIZE="${MONGO_BATCH_SIZE:-10000}"
 INSERT_PRODUCERS="${INSERT_PRODUCERS:-8}"
+MONGO_LOAD_SCALING_DOCS="${MONGO_LOAD_SCALING_DOCS:-}"
+MONGO_LOAD_SCALING_BATCH_SIZE="${MONGO_LOAD_SCALING_BATCH_SIZE:-1000}"
+MONGO_LOAD_PRODUCERS="${MONGO_LOAD_PRODUCERS:-1,2,4,8,16,32}"
 MONGO_MODE="${MONGO_MODE:-docker}"
 MONGO_URI="${MONGO_URI:-mongodb://127.0.0.1:27017}"
 MONGO_IMAGE="${MONGO_IMAGE:-mongo:8}"
@@ -32,6 +35,7 @@ SKIP_RAW="${SKIP_RAW:-false}"
 SKIP_COLLECTIONS="${SKIP_COLLECTIONS:-false}"
 SKIP_MONGO="${SKIP_MONGO:-false}"
 SKIP_LOAD_MODES="${SKIP_LOAD_MODES:-false}"
+SKIP_LOAD_SCALING="${SKIP_LOAD_SCALING:-false}"
 SKIP_SCALING="${SKIP_SCALING:-false}"
 ORIGINAL_ARGS=("$@")
 FAILURES=0
@@ -47,6 +51,7 @@ The output layout intentionally matches cmd/benchmark_run_report:
   <run-root>/collections_sqlite_canonical_1m/
   <run-root>/mongo_gateway_full_sweep_1m_expanded/
   <run-root>/mongo_client_mode_load_matrix_1m/
+  <run-root>/mongo_gateway_load_scaling_1m/
   <run-root>/mongo_gateway_reader_writer_scaling_1m/
   <run-root>/deep_report.html
 
@@ -58,6 +63,11 @@ Options:
   --raw-keys N           Override raw engine key count.
   --collection-docs N    Override collection/SQLite document count.
   --mongo-docs N         Override Mongo-compatible document count.
+  --mongo-load-docs N    Override Mongo load-scaling document count. Default: --mongo-docs.
+  --mongo-load-batch-size N
+                         Override Mongo load-scaling InsertMany batch size. Default: 1000.
+  --mongo-load-producers LIST
+                         Producer counts for Mongo load scaling. Default: "1,2,4,8,16,32".
   --mongo-mode MODE      Mongo mode for full/load comparison: docker or external. Default: docker.
   --mongo-uri URI        MongoDB URI for external/scaling runs. Default: mongodb://127.0.0.1:27017.
   --mongo-image IMAGE    Docker image for --mongo-mode docker. Default: mongo:8.
@@ -72,12 +82,14 @@ Options:
                           Skip pprof capture for TreeDB collections vs SQLite.
   --skip-mongo           Skip all Mongo-compatible sections.
   --skip-load-modes      Skip Mongo client-mode load matrix.
+  --skip-load-scaling    Skip Mongo InsertMany producer-scaling sweep.
   --skip-scaling         Skip Mongo reader/writer scaling.
   --help                 Show this help.
 
 Environment overrides use the uppercase variable names in the script, including
 RUN_ROOT, TIER, INDEXES_LIST, RAW_KEYS, COLLECTION_DOCS,
 COLLECTION_PROFILES, COLLECTION_PROFILE_BENCHTIME, COLLECTION_PROFILE_COUNT, MONGO_DOCS,
+MONGO_LOAD_SCALING_DOCS, MONGO_LOAD_SCALING_BATCH_SIZE, MONGO_LOAD_PRODUCERS,
 MONGO_MODE, MONGO_URI, MONGO_IMAGE (default: mongo:8), MONGO_COMPACT, MONGO_READERS, MONGO_WRITERS, TIMEOUT, and TITLE.
 EOF
 }
@@ -148,6 +160,21 @@ while [[ $# -gt 0 ]]; do
       MONGO_DOCS="$2"
       shift 2
       ;;
+    --mongo-load-docs)
+      require_value "$1" "${2-}"
+      MONGO_LOAD_SCALING_DOCS="$2"
+      shift 2
+      ;;
+    --mongo-load-batch-size)
+      require_value "$1" "${2-}"
+      MONGO_LOAD_SCALING_BATCH_SIZE="$2"
+      shift 2
+      ;;
+    --mongo-load-producers)
+      require_value "$1" "${2-}"
+      MONGO_LOAD_PRODUCERS="$2"
+      shift 2
+      ;;
     --mongo-mode)
       require_value "$1" "${2-}"
       MONGO_MODE="$2"
@@ -202,6 +229,10 @@ while [[ $# -gt 0 ]]; do
       SKIP_LOAD_MODES=true
       shift
       ;;
+    --skip-load-scaling)
+      SKIP_LOAD_SCALING=true
+      shift
+      ;;
     --skip-scaling)
       SKIP_SCALING=true
       shift
@@ -254,6 +285,7 @@ case "$TIER" in
     exit 2
     ;;
 esac
+MONGO_LOAD_SCALING_DOCS="${MONGO_LOAD_SCALING_DOCS:-$MONGO_DOCS}"
 raw_skip_mongo=$SKIP_MONGO
 SKIP_MONGO=$(normalize_bool_text "$SKIP_MONGO") || {
   echo "invalid SKIP_MONGO=$raw_skip_mongo (want true/false, 1/0, or yes/no)" >&2
@@ -287,6 +319,7 @@ if ! bool_true "$SKIP_MONGO"; then
 fi
 
 INDEXES_LIST=$(normalize_list "$INDEXES_LIST")
+MONGO_LOAD_PRODUCERS=$(normalize_list "$MONGO_LOAD_PRODUCERS")
 MONGO_READERS=$(normalize_list "$MONGO_READERS")
 MONGO_WRITERS=$(normalize_list "$MONGO_WRITERS")
 
@@ -343,6 +376,9 @@ write_metadata() {
     echo "- collection_profile_benchtime: ${COLLECTION_PROFILE_BENCHTIME:-${COLLECTION_BENCHTIME:-${COLLECTION_DOCS}x}}"
     echo "- collection_profile_count: $COLLECTION_PROFILE_COUNT"
     echo "- mongo_docs: $MONGO_DOCS"
+    echo "- mongo_load_scaling_docs: $MONGO_LOAD_SCALING_DOCS"
+    echo "- mongo_load_scaling_batch_size: $MONGO_LOAD_SCALING_BATCH_SIZE"
+    echo "- mongo_load_producers: $MONGO_LOAD_PRODUCERS"
     echo "- mongo_mode: $MONGO_MODE"
     echo "- mongo_image: $MONGO_IMAGE"
     echo "- mongo_compact: $MONGO_COMPACT"
@@ -356,6 +392,7 @@ write_metadata() {
     echo "- skip_collections: $SKIP_COLLECTIONS"
     echo "- skip_mongo: $SKIP_MONGO"
     echo "- skip_load_modes: $SKIP_LOAD_MODES"
+    echo "- skip_load_scaling: $SKIP_LOAD_SCALING"
     echo "- skip_scaling: $SKIP_SCALING"
     echo "- go: $(go version)"
     echo "- uname: $(uname -a)"
@@ -515,6 +552,27 @@ run_mongo_load_modes() {
       --title "Mongo API Client-Mode Load Matrix"
 }
 
+run_mongo_load_scaling() {
+  bool_true "$SKIP_MONGO" && return 0
+  bool_true "$SKIP_LOAD_SCALING" && return 0
+  local root="$RUN_ROOT/mongo_gateway_load_scaling_1m"
+  run_logged mongo_load_scaling env \
+    MONGO_MAX_POOL_SIZE="$MONGO_MAX_POOL_SIZE" \
+    MONGO_MAX_CONNECTING="$MONGO_MAX_CONNECTING" \
+    ./scripts/mongo_gateway_load_scaling_bench.sh \
+      --out "$root" \
+      --docs "$MONGO_LOAD_SCALING_DOCS" \
+      --indexes "$INDEXES_LIST" \
+      --batch-size "$MONGO_LOAD_SCALING_BATCH_SIZE" \
+      --producers "$MONGO_LOAD_PRODUCERS" \
+      --mongo-mode "$MONGO_MODE" \
+      --mongo-image "$MONGO_IMAGE" \
+      --mongo-compact "$MONGO_COMPACT" \
+      --mongo-uri "$MONGO_URI" \
+      --timeout "$TIMEOUT" \
+      --title "Mongo API InsertMany Producer Scaling"
+}
+
 run_mongo_scaling() {
   bool_true "$SKIP_MONGO" && return 0
   bool_true "$SKIP_SCALING" && return 0
@@ -557,6 +615,7 @@ run_raw_engine
 run_collections
 run_mongo_full_sweep
 run_mongo_load_modes
+run_mongo_load_scaling
 run_mongo_scaling
 render_report
 

--- a/scripts/treedb_benchmark_run_report.sh
+++ b/scripts/treedb_benchmark_run_report.sh
@@ -35,7 +35,7 @@ SKIP_RAW="${SKIP_RAW:-false}"
 SKIP_COLLECTIONS="${SKIP_COLLECTIONS:-false}"
 SKIP_MONGO="${SKIP_MONGO:-false}"
 SKIP_LOAD_MODES="${SKIP_LOAD_MODES:-false}"
-SKIP_LOAD_SCALING="${SKIP_LOAD_SCALING:-false}"
+SKIP_LOAD_SCALING="${SKIP_LOAD_SCALING:-true}"
 SKIP_SCALING="${SKIP_SCALING:-false}"
 ORIGINAL_ARGS=("$@")
 FAILURES=0
@@ -82,6 +82,8 @@ Options:
                           Skip pprof capture for TreeDB collections vs SQLite.
   --skip-mongo           Skip all Mongo-compatible sections.
   --skip-load-modes      Skip Mongo client-mode load matrix.
+  --include-load-scaling Include Mongo InsertMany producer-scaling sweep.
+                         Default: skipped until the renderer support lands.
   --skip-load-scaling    Skip Mongo InsertMany producer-scaling sweep.
   --skip-scaling         Skip Mongo reader/writer scaling.
   --help                 Show this help.
@@ -227,6 +229,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --skip-load-modes)
       SKIP_LOAD_MODES=true
+      shift
+      ;;
+    --include-load-scaling)
+      SKIP_LOAD_SCALING=false
       shift
       ;;
     --skip-load-scaling)


### PR DESCRIPTION
## Objective

Close #3028 under parent #3026 by adding a dedicated Mongo-compatible InsertMany producer-scaling sweep to the canonical benchmark bundle.

Depends on #3034 / #3027 for the additive summary metadata consumed by this producer-scaling artifact.

## Context

The existing deep report has a fixed-producer full sweep and a separate reader/writer client-count sweep. It did not have a load-only producer-count sweep, so the report could not answer how bulk `InsertMany` throughput changes as producer count changes.

## Non-Goals

- Do not replace reader/writer scaling.
- Do not tune TreeDB or MongoDB performance.
- Do not change measured workload behavior outside the new optional benchmark section.

## Design

- Add `scripts/mongo_gateway_load_scaling_bench.sh`, a wrapper that runs load-only `mongo_gateway_compare.sh` bundles for each requested producer count.
- Use the comparable BSON `driver-command-raw` TreeDB-vs-MongoDB path with prebuilt documents and no read/update phases.
- Write normal per-producer bundles under `producers_<N>/` and aggregate their `summary.tsv` rows at the load-scaling root.
- Wire the wrapper into `scripts/treedb_benchmark_run_report.sh` as `mongo_gateway_load_scaling_1m/`, enabled by default unless `--skip-load-scaling` is set.
- Default load-scaling batch size is `1000`, so the PR-tier default of 100,000 docs has 100 load batches and avoids capping the default 1,2,4,8,16,32 producer chart.

## Scope

- Runtime benchmark code changed: no.
- Benchmark orchestration changed: yes.
- Report rendering changed: no, owned by #3029.

## Correctness

The wrapper delegates raw benchmark execution and per-cell report generation to the existing `mongo_gateway_compare.sh` path. The aggregate summary is a header-preserving concatenation of the per-producer summaries, relying on the M0 metadata columns to distinguish requested/effective producers.

## Performance

This adds a new default section to full deep-benchmark runs. It performs one load-only TreeDB/MongoDB comparison bundle per requested producer count. It intentionally disables TreeDB profiling and read/update phases to keep runtime bounded.

## Evidence

| Check | Result |
| --- | --- |
| `bash -n scripts/mongo_gateway_load_scaling_bench.sh scripts/treedb_benchmark_run_report.sh` | pass |
| `git diff --check` | pass |
| tiny smoke | `/tmp/gomap_mongo_load_scaling_smoke_20260625_103605` |

Smoke command:

```sh
scripts/mongo_gateway_load_scaling_bench.sh --out /tmp/gomap_mongo_load_scaling_smoke_20260625_103605 --docs 20 --indexes 0 --batch-size 10 --producers 1,2 --mongo-mode docker --mongo-image mongo:8 --timeout 2m
```

Smoke load rows:

| producer | index | effective | load batches |
| ---: | ---: | ---: | ---: |
| 1 | 0 | 1 | 2 |
| 2 | 0 | 2 | 2 |

## AI Review Status

Not yet resolved. This stacked PR is ready for automated review and CI against the M0 branch; final merge remains blocked on #3034 landing first.
