### PR TITLE
Render Mongo load-scaling and index retention report sections

### DIFF
--- a/cmd/benchmark_run_report/main.go
+++ b/cmd/benchmark_run_report/main.go
@@ -166,6 +166,7 @@ type reportData struct {
 	CollectionComparisons []collectionComparison
 	MongoFullSweep        []mongoSummaryRow
 	MongoLoadModes        []loadModeRow
+	MongoLoadScaling      []mongoSummaryRow
 	MongoScaling          map[int][]mongoSummaryRow
 	Profiles              profileReportData
 	Warnings              []string
@@ -342,6 +343,10 @@ func loadReportData(cfg config) (reportData, error) {
 		data.Warnings = append(data.Warnings, warnings...)
 	} else if !errors.Is(err, os.ErrNotExist) {
 		data.Warnings = append(data.Warnings, err.Error())
+	}
+	if rows, warnings := loadMongoLoadScaling(filepath.Join(cfg.RunRoot, "mongo_gateway_load_scaling_1m")); len(rows) > 0 || len(warnings) > 0 {
+		data.MongoLoadScaling = rows
+		data.Warnings = append(data.Warnings, warnings...)
 	}
 	if scaling, warnings := loadMongoScaling(filepath.Join(cfg.RunRoot, "mongo_gateway_reader_writer_scaling_1m")); len(scaling) > 0 || len(warnings) > 0 {
 		data.MongoScaling = scaling
@@ -794,6 +799,21 @@ func loadMongoLoadModes(dir string) ([]loadModeRow, []string, error) {
 	return out, warnings, nil
 }
 
+func loadMongoLoadScaling(dir string) ([]mongoSummaryRow, []string) {
+	path := filepath.Join(dir, "summary.tsv")
+	rows, err := readMongoSummary(path)
+	if err == nil {
+		return rows, nil
+	}
+	if errors.Is(err, os.ErrNotExist) {
+		if _, statErr := os.Stat(dir); statErr == nil {
+			return nil, []string{fmt.Sprintf("mongo load scaling: %s is missing summary.tsv", filepath.Base(dir))}
+		}
+		return nil, nil
+	}
+	return nil, []string{err.Error()}
+}
+
 func resolveRunArtifactPath(baseDir, relPath string) (string, error) {
 	if strings.TrimSpace(relPath) == "" {
 		return "", fmt.Errorf("empty artifact path under %s", baseDir)
@@ -1195,6 +1215,7 @@ func renderHTML(data reportData) string {
 		b.WriteString("</ul></section>\n")
 	}
 	renderMongoFullSweep(&b, data.MongoFullSweep)
+	renderMongoLoadScaling(&b, data.MongoLoadScaling)
 	renderMongoLoadModes(&b, data.MongoLoadModes)
 	renderMongoScaling(&b, data.MongoScaling)
 	renderCollections(&b, data.Collections, data.CollectionComparisons)
@@ -1212,6 +1233,9 @@ func reportNav(data reportData) string {
 	var items []navItem
 	if len(data.MongoFullSweep) > 0 {
 		items = append(items, navItem{Href: "#mongo-full", Label: "Mongo API sweep"})
+	}
+	if len(data.MongoLoadScaling) > 0 {
+		items = append(items, navItem{Href: "#mongo-load-scaling", Label: "Load scaling"})
 	}
 	if len(data.MongoLoadModes) > 0 {
 		items = append(items, navItem{Href: "#mongo-load", Label: "Load modes"})
@@ -2336,6 +2360,7 @@ func renderMongoFullSweep(b *strings.Builder, rows []mongoSummaryRow) {
 			{Name: "MongoDB", Values: mongoRowDisk(loadRows, "mongo"), Color: "#1f8a5b"},
 		}, "bytes"))
 		b.WriteString("<p class=\"subtle\"><strong>Storage basis:</strong> " + esc(mongoStorageBasisText(loadRows)) + "</p>")
+		writeMongoIndexRetentionTable(b, loadRows)
 	}
 	b.WriteString("</div></div>")
 	for _, idx := range indexes {
@@ -2412,6 +2437,149 @@ func renderMongoLoadModes(b *strings.Builder, rows []loadModeRow) {
 	writeTable(b, []string{"indexes", "target", "config", "load docs/sec", "physical bytes", "raw JSON"}, body, numericColumns(0, 3, 4))
 	b.WriteString("</details>")
 	b.WriteString("</section>\n")
+}
+
+func renderMongoLoadScaling(b *strings.Builder, rows []mongoSummaryRow) {
+	loadRows := mongoLoadScalingRows(rows)
+	if len(loadRows) == 0 {
+		return
+	}
+	b.WriteString("<section id=\"mongo-load-scaling\"><h2>Mongo API InsertMany Producer Scaling</h2>")
+	b.WriteString("<p class=\"subtle\">Load-only BSON `driver-command-raw` TreeDB-vs-MongoDB sweep. This section varies InsertMany producer count and is separate from reader/writer operation scaling.</p>")
+	if metadata := mongoLoadScalingScopeText(loadRows); metadata != "" {
+		b.WriteString("<p class=\"subtle\"><strong>Scope:</strong> " + esc(metadata) + "</p>")
+	}
+	b.WriteString("<div class=\"chart-grid\">")
+	for _, idx := range sortedMongoIndexes(loadRows) {
+		counts := mongoLoadProducerCounts(loadRows, idx)
+		if len(counts) == 0 {
+			continue
+		}
+		b.WriteString(lineChart("Insert throughput vs insert producers, "+indexCountLabel(idx), countLabels(counts), "insert producers", "docs/sec", []chartSeries{
+			{Name: "TreeDB", Values: mongoLoadProducerOps(loadRows, idx, counts, "tree"), Color: "#2867c7"},
+			{Name: "MongoDB", Values: mongoLoadProducerOps(loadRows, idx, counts, "mongo"), Color: "#1f8a5b"},
+		}, "docs/sec"))
+	}
+	b.WriteString("</div>")
+	writeMongoLoadScalingSummaryTable(b, loadRows)
+	b.WriteString("<details><summary>Raw load-scaling TSV rows</summary>")
+	writeMongoSummaryTable(b, loadRows)
+	b.WriteString("</details></section>\n")
+}
+
+func mongoLoadScalingRows(rows []mongoSummaryRow) []mongoSummaryRow {
+	var out []mongoSummaryRow
+	for _, row := range rows {
+		if row.Phase == "load_insert_many" {
+			out = append(out, row)
+		}
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].SecondaryIndexes != out[j].SecondaryIndexes {
+			return out[i].SecondaryIndexes < out[j].SecondaryIndexes
+		}
+		if mongoLoadProducerCount(out[i]) != mongoLoadProducerCount(out[j]) {
+			return mongoLoadProducerCount(out[i]) < mongoLoadProducerCount(out[j])
+		}
+		return out[i].TreeDBConfig < out[j].TreeDBConfig
+	})
+	return out
+}
+
+func mongoLoadScalingScopeText(rows []mongoSummaryRow) string {
+	if len(rows) == 0 {
+		return ""
+	}
+	first := rows[0]
+	for _, row := range rows[1:] {
+		if row.Documents != first.Documents || row.BatchSize != first.BatchSize || row.TreeDBConfig != first.TreeDBConfig || row.MongoConfig != first.MongoConfig {
+			return "mixed document, batch, or client-mode metadata; see raw load-scaling rows"
+		}
+	}
+	parts := []string{fmt.Sprintf("%s docs", commaInt(int64(first.Documents)))}
+	if first.BatchSize > 0 {
+		parts = append(parts, fmt.Sprintf("batch size %s", commaInt(int64(first.BatchSize))))
+	}
+	if batches := mongoLoadBatchCount(first); batches > 0 {
+		parts = append(parts, fmt.Sprintf("%s load batches", commaInt(int64(batches))))
+	}
+	if first.TreeDBConfig != "" {
+		parts = append(parts, "TreeDB "+first.TreeDBConfig)
+	}
+	if first.MongoConfig != "" {
+		parts = append(parts, "MongoDB "+first.MongoConfig)
+	}
+	return strings.Join(parts, ", ")
+}
+
+func mongoLoadProducerCounts(rows []mongoSummaryRow, idx int) []int {
+	seen := make(map[int]bool)
+	for _, row := range rows {
+		if row.SecondaryIndexes != idx {
+			continue
+		}
+		count := mongoLoadProducerCount(row)
+		if count > 0 {
+			seen[count] = true
+		}
+	}
+	var out []int
+	for count := range seen {
+		out = append(out, count)
+	}
+	sort.Ints(out)
+	return out
+}
+
+func mongoLoadProducerOps(rows []mongoSummaryRow, idx int, counts []int, side string) []float64 {
+	out := make([]float64, 0, len(counts))
+	for _, count := range counts {
+		row, ok := mongoLoadProducerRow(rows, idx, count)
+		if !ok {
+			out = append(out, 0)
+			continue
+		}
+		if side == "mongo" {
+			out = append(out, row.MongoOpsSec)
+		} else {
+			out = append(out, row.TreeDBOpsSec)
+		}
+	}
+	return out
+}
+
+func mongoLoadProducerRow(rows []mongoSummaryRow, idx, count int) (mongoSummaryRow, bool) {
+	for _, row := range rows {
+		if row.SecondaryIndexes == idx && mongoLoadProducerCount(row) == count {
+			return row, true
+		}
+	}
+	return mongoSummaryRow{}, false
+}
+
+func mongoLoadProducerCount(row mongoSummaryRow) int {
+	if row.InsertProducers > 0 {
+		return row.InsertProducers
+	}
+	return mongoEffectiveLoadProducers(row)
+}
+
+func writeMongoLoadScalingSummaryTable(b *strings.Builder, rows []mongoSummaryRow) {
+	var body [][]string
+	for _, row := range rows {
+		body = append(body, []string{
+			strconv.Itoa(row.SecondaryIndexes),
+			formatOptionalInt(mongoLoadProducerCount(row)),
+			formatOptionalInt(mongoEffectiveLoadProducers(row)),
+			formatOptionalInt(mongoLoadBatchCount(row)),
+			fmtOps(row.TreeDBOpsSec),
+			fmtOps(row.MongoOpsSec),
+			fmtRatio(row.TreeDBToMongoRatio),
+		})
+	}
+	b.WriteString("<h3>Producer scaling summary</h3>")
+	b.WriteString("<p class=\"subtle\">Requested producers are used on the chart axis. Effective producers show capped runs when requested producers exceed the number of load batches.</p>")
+	writeTable(b, []string{"indexes", "requested producers", "effective producers", "load batches", "TreeDB docs/sec", "MongoDB docs/sec", "TreeDB/MongoDB"}, body, numericColumns(0, 1, 2, 3, 4, 5, 6))
 }
 
 func fullSweepLoadNote(rows []mongoSummaryRow) string {
@@ -2885,6 +3053,39 @@ func mongoRowDisk(rows []mongoSummaryRow, side string) []float64 {
 		}
 	}
 	return out
+}
+
+func writeMongoIndexRetentionTable(b *strings.Builder, rows []mongoSummaryRow) {
+	if len(rows) == 0 {
+		return
+	}
+	var baseline mongoSummaryRow
+	var hasBaseline bool
+	for _, row := range rows {
+		if row.SecondaryIndexes == 0 {
+			baseline = row
+			hasBaseline = true
+			break
+		}
+	}
+	if !hasBaseline {
+		return
+	}
+	var body [][]string
+	for _, row := range rows {
+		body = append(body, []string{
+			strconv.Itoa(row.SecondaryIndexes),
+			fmtOps(row.TreeDBOpsSec),
+			fmtOps(row.MongoOpsSec),
+			fmtPercentRatio(ratioOrZero(row.TreeDBOpsSec, baseline.TreeDBOpsSec)),
+			fmtPercentRatio(ratioOrZero(row.MongoOpsSec, baseline.MongoOpsSec)),
+			fmtRatio(row.TreeDBToMongoRatio),
+			fmtRatio(row.TreeDBToMongoPhysRatio),
+		})
+	}
+	b.WriteString("<h3>Index throughput retention</h3>")
+	b.WriteString("<p class=\"subtle\">Retention is each load throughput divided by the 0-secondary-index load throughput for the same database.</p>")
+	writeTable(b, []string{"secondary indexes", "TreeDB docs/sec", "MongoDB docs/sec", "TreeDB retained", "MongoDB retained", "TreeDB/MongoDB throughput", "TreeDB/MongoDB physical bytes"}, body, numericColumns(0, 1, 2, 3, 4, 5, 6))
 }
 
 func mongoStorageBasisText(rows []mongoSummaryRow) string {
@@ -3759,6 +3960,20 @@ func fmtRatio(v float64) string {
 		return "-"
 	}
 	return fmt.Sprintf("%.2fx", v)
+}
+
+func fmtPercentRatio(v float64) string {
+	if v == 0 {
+		return "-"
+	}
+	return fmt.Sprintf("%.1f%%", v*100)
+}
+
+func ratioOrZero(numerator, denominator float64) float64 {
+	if denominator == 0 {
+		return 0
+	}
+	return numerator / denominator
 }
 
 func fmtBytes(v float64) string {

--- a/cmd/benchmark_run_report/main.go
+++ b/cmd/benchmark_run_report/main.go
@@ -1234,7 +1234,7 @@ func reportNav(data reportData) string {
 	if len(data.MongoFullSweep) > 0 {
 		items = append(items, navItem{Href: "#mongo-full", Label: "Mongo API sweep"})
 	}
-	if len(data.MongoLoadScaling) > 0 {
+	if hasMongoLoadScalingRows(data.MongoLoadScaling) {
 		items = append(items, navItem{Href: "#mongo-load-scaling", Label: "Load scaling"})
 	}
 	if len(data.MongoLoadModes) > 0 {
@@ -2484,6 +2484,15 @@ func mongoLoadScalingRows(rows []mongoSummaryRow) []mongoSummaryRow {
 		return out[i].TreeDBConfig < out[j].TreeDBConfig
 	})
 	return out
+}
+
+func hasMongoLoadScalingRows(rows []mongoSummaryRow) bool {
+	for _, row := range rows {
+		if row.Phase == "load_insert_many" {
+			return true
+		}
+	}
+	return false
 }
 
 func mongoLoadScalingScopeText(rows []mongoSummaryRow) string {
@@ -3963,18 +3972,18 @@ func fmtRatio(v float64) string {
 	return fmt.Sprintf("%.2fx", v)
 }
 
-func fmtPercentRatio(v float64) string {
-	if v == 0 {
+func fmtPercentRatio(v float64, ok bool) string {
+	if !ok {
 		return "-"
 	}
 	return fmt.Sprintf("%.1f%%", v*100)
 }
 
-func ratioOrZero(numerator, denominator float64) float64 {
+func ratioOrZero(numerator, denominator float64) (float64, bool) {
 	if denominator == 0 {
-		return 0
+		return 0, false
 	}
-	return numerator / denominator
+	return numerator / denominator, true
 }
 
 func fmtBytes(v float64) string {

--- a/cmd/benchmark_run_report/main_test.go
+++ b/cmd/benchmark_run_report/main_test.go
@@ -102,6 +102,7 @@ func TestDeepReportFromRunRoot(t *testing.T) {
 	summary0 := mongoSummaryFixture(0)
 	summary4 := mongoSummaryFixture(4)
 	writeFile(t, filepath.Join(root, "mongo_gateway_full_sweep_1m_expanded", "summary.tsv"), summary0+strings.TrimPrefix(summary4, mongoSummaryHeader))
+	writeFile(t, filepath.Join(root, "mongo_gateway_load_scaling_1m", "summary.tsv"), mongoLoadScalingSummaryFixture())
 	writeFile(t, filepath.Join(root, "mongo_gateway_reader_writer_scaling_1m", "indexes_0", "summary.tsv"), summary0)
 	writeFile(t, filepath.Join(root, "mongo_gateway_reader_writer_scaling_1m", "indexes_4", "summary.tsv"), summary4)
 	writeFile(t, filepath.Join(root, "mongo_client_mode_load_matrix_1m", "matrix.tsv"), "target\tconfig\tdocuments\tsecondary_indexes\traw_json\tphysical_bytes\n"+
@@ -128,6 +129,7 @@ func TestDeepReportFromRunRoot(t *testing.T) {
 		"HEAD=abc123def456",
 		"origin/main=999888777666",
 		"Mongo API Full Sweep",
+		"Mongo API InsertMany Producer Scaling",
 		"Load-Only Client-Mode Matrix",
 		"Mongo API Reader/Writer Scaling",
 		"Collections vs SQLite",
@@ -144,6 +146,11 @@ func TestDeepReportFromRunRoot(t *testing.T) {
 		"Client Count",
 		"Load interpretation:",
 		"pure ingest client-mode matrix",
+		"Index throughput retention",
+		"Producer scaling summary",
+		"Insert Throughput Vs Insert Producers, 0 Indexes",
+		"requested producers",
+		"effective producers",
 		"4 Indexes: Mongo API Scaling",
 		"Single threaded client",
 		"ID Find One: Throughput Vs Reader Clients",
@@ -212,7 +219,7 @@ func TestRenderHTMLNavOmitsMissingSections(t *testing.T) {
 	if !strings.Contains(html, "href=\"#mongo-load\"") {
 		t.Fatalf("nav missing present load-mode section\n%s", html)
 	}
-	for _, absent := range []string{"href=\"#mongo-full\"", "href=\"#scaling\"", "href=\"#collections\"", "href=\"#raw-engine\""} {
+	for _, absent := range []string{"href=\"#mongo-full\"", "href=\"#mongo-load-scaling\"", "href=\"#scaling\"", "href=\"#collections\"", "href=\"#raw-engine\""} {
 		if strings.Contains(html, absent) {
 			t.Fatalf("nav includes missing section %s\n%s", absent, html)
 		}
@@ -734,6 +741,55 @@ func TestFullSweepLoadNoteReportsProducerMetadata(t *testing.T) {
 	}
 }
 
+func TestRenderMongoLoadScalingSection(t *testing.T) {
+	rows := []mongoSummaryRow{
+		{Documents: 100, BatchSize: 25, LoadBatchCount: 4, SecondaryIndexes: 0, TreeDBConfig: "treedb_bson", MongoConfig: "mongo", Phase: "load_insert_many", InsertProducers: 1, EffectiveProducers: 1, TreeDBOpsSec: 1000, MongoOpsSec: 500, TreeDBToMongoRatio: 2},
+		{Documents: 100, BatchSize: 25, LoadBatchCount: 4, SecondaryIndexes: 0, TreeDBConfig: "treedb_bson", MongoConfig: "mongo", Phase: "load_insert_many", InsertProducers: 2, EffectiveProducers: 2, TreeDBOpsSec: 1600, MongoOpsSec: 700, TreeDBToMongoRatio: 2.29},
+		{Documents: 100, BatchSize: 25, LoadBatchCount: 4, SecondaryIndexes: 1, TreeDBConfig: "treedb_bson", MongoConfig: "mongo", Phase: "load_insert_many", InsertProducers: 1, EffectiveProducers: 1, TreeDBOpsSec: 800, MongoOpsSec: 300, TreeDBToMongoRatio: 2.67},
+	}
+	var b strings.Builder
+	renderMongoLoadScaling(&b, rows)
+	html := b.String()
+	for _, want := range []string{
+		"Mongo API InsertMany Producer Scaling",
+		"Insert Throughput Vs Insert Producers, 0 Indexes",
+		"Insert Throughput Vs Insert Producers, 1 Index",
+		"Producer scaling summary",
+		"requested producers",
+		"effective producers",
+		"Raw load-scaling TSV rows",
+		"1,600",
+		"2.29x",
+	} {
+		if !strings.Contains(html, want) {
+			t.Fatalf("load-scaling section missing %q\n%s", want, html)
+		}
+	}
+}
+
+func TestMongoIndexRetentionTable(t *testing.T) {
+	rows := []mongoSummaryRow{
+		{SecondaryIndexes: 0, TreeDBOpsSec: 100, MongoOpsSec: 80, TreeDBToMongoRatio: 1.25, TreeDBToMongoPhysRatio: 0.4},
+		{SecondaryIndexes: 1, TreeDBOpsSec: 80, MongoOpsSec: 40, TreeDBToMongoRatio: 2, TreeDBToMongoPhysRatio: 0.3},
+	}
+	var b strings.Builder
+	writeMongoIndexRetentionTable(&b, rows)
+	html := b.String()
+	for _, want := range []string{
+		"Index throughput retention",
+		"TreeDB retained",
+		"MongoDB retained",
+		"80.0%",
+		"50.0%",
+		"2.00x",
+		"0.30x",
+	} {
+		if !strings.Contains(html, want) {
+			t.Fatalf("retention table missing %q\n%s", want, html)
+		}
+	}
+}
+
 func TestFormatChartTooltipValueDoesNotDoubleBytes(t *testing.T) {
 	if got := formatChartTooltipValue(1024*1024, "bytes"); got != "1.00 MiB" {
 		t.Fatalf("bytes tooltip = %q, want 1.00 MiB", got)
@@ -754,6 +810,23 @@ func TestLoadMongoScalingWarnsMissingSummary(t *testing.T) {
 	}
 	if len(warnings) != 1 || !strings.Contains(warnings[0], "indexes_0") || !strings.Contains(warnings[0], "summary.tsv") {
 		t.Fatalf("warnings = %v, want missing summary warning", warnings)
+	}
+}
+
+func TestLoadMongoLoadScalingWarnsMissingSummary(t *testing.T) {
+	root := t.TempDir()
+	rows, warnings := loadMongoLoadScaling(root)
+	if len(rows) != 0 {
+		t.Fatalf("rows = %v, want none", rows)
+	}
+	if len(warnings) != 1 || !strings.Contains(warnings[0], "mongo load scaling") || !strings.Contains(warnings[0], "summary.tsv") {
+		t.Fatalf("warnings = %v, want missing load-scaling summary warning", warnings)
+	}
+
+	missingRoot := filepath.Join(t.TempDir(), "absent")
+	rows, warnings = loadMongoLoadScaling(missingRoot)
+	if len(rows) != 0 || len(warnings) != 0 {
+		t.Fatalf("absent root rows=%v warnings=%v, want none", rows, warnings)
 	}
 }
 
@@ -824,6 +897,22 @@ func mongoSummaryFixtureWithLoadMetadata(indexes, batchSize, requestedProducers,
 	return mongoSummaryHeaderWithLoadMetadata +
 		fmt.Sprintf("100\t%d\tfalse\t\ttreedb_bson\tmongo\tload_insert_many\t1000\t1000\t1000\t500\t500\t2000\t2\t2\t1\t2\t3\t4\t5\t6\tmaintenance\t1000\t2000\t3000\t4000\t5000\t0.25\t0.4\t%d\t%d\t%d\t%d\t%d\n",
 			indexes, batchSize, requestedProducers, effectiveProducers, loadBatchCount, loadBatchCount)
+}
+
+func mongoLoadScalingSummaryFixture() string {
+	return mongoSummaryHeaderWithLoadMetadata +
+		mongoLoadScalingSummaryRow(0, 1, 1, 1000, 500) +
+		mongoLoadScalingSummaryRow(0, 2, 2, 1600, 700) +
+		mongoLoadScalingSummaryRow(1, 1, 1, 800, 300) +
+		mongoLoadScalingSummaryRow(1, 2, 2, 1200, 450)
+}
+
+func mongoLoadScalingSummaryRow(indexes, requestedProducers, effectiveProducers int, treeOps, mongoOps float64) string {
+	batchSize := 25
+	loadBatchCount := 4
+	ratio := treeOps / mongoOps
+	return fmt.Sprintf("100\t%d\tfalse\t\ttreedb_bson\tmongo\tload_insert_many\t%.0f\t%.0f\t1000\t%.0f\t%.0f\t2000\t%.2f\t%.2f\t1\t2\t3\t4\t5\t6\tmaintenance\t1000\t2000\t3000\t4000\t5000\t0.25\t0.4\t%d\t%d\t%d\t%d\t%d\n",
+		indexes, treeOps, treeOps, mongoOps, mongoOps, ratio, ratio, batchSize, requestedProducers, effectiveProducers, loadBatchCount, loadBatchCount)
 }
 
 func writeFile(t *testing.T, path, content string) {

--- a/scripts/treedb_benchmark_run_report.sh
+++ b/scripts/treedb_benchmark_run_report.sh
@@ -35,7 +35,7 @@ SKIP_RAW="${SKIP_RAW:-false}"
 SKIP_COLLECTIONS="${SKIP_COLLECTIONS:-false}"
 SKIP_MONGO="${SKIP_MONGO:-false}"
 SKIP_LOAD_MODES="${SKIP_LOAD_MODES:-false}"
-SKIP_LOAD_SCALING="${SKIP_LOAD_SCALING:-true}"
+SKIP_LOAD_SCALING="${SKIP_LOAD_SCALING:-false}"
 SKIP_SCALING="${SKIP_SCALING:-false}"
 ORIGINAL_ARGS=("$@")
 FAILURES=0
@@ -83,7 +83,7 @@ Options:
   --skip-mongo           Skip all Mongo-compatible sections.
   --skip-load-modes      Skip Mongo client-mode load matrix.
   --include-load-scaling Include Mongo InsertMany producer-scaling sweep.
-                         Default: skipped until the renderer support lands.
+                         Default: included once rendered report support is present.
   --skip-load-scaling    Skip Mongo InsertMany producer-scaling sweep.
   --skip-scaling         Skip Mongo reader/writer scaling.
   --help                 Show this help.

--- a/scripts/treedb_benchmark_run_report.sh
+++ b/scripts/treedb_benchmark_run_report.sh
@@ -83,7 +83,7 @@ Options:
   --skip-mongo           Skip all Mongo-compatible sections.
   --skip-load-modes      Skip Mongo client-mode load matrix.
   --include-load-scaling Include Mongo InsertMany producer-scaling sweep.
-                         Default: included once rendered report support is present.
+                         Default: included.
   --skip-load-scaling    Skip Mongo InsertMany producer-scaling sweep.
   --skip-scaling         Skip Mongo reader/writer scaling.
   --help                 Show this help.


### PR DESCRIPTION
## Objective

Close #3029 under parent #3026 by rendering the fixed-load index story and the new InsertMany producer-scaling story directly in `deep_report.html`.

Depends on #3034 / #3027 for load metadata and #3035 / #3028 for the `mongo_gateway_load_scaling_1m/` artifact.

## Context

The report previously showed full-sweep insert throughput vs secondary indexes, reader/writer operation scaling, and client-mode load comparisons, but it did not clearly separate fixed bulk-load producer count from InsertMany producer scaling.

## Non-Goals

- No benchmark workload changes.
- No broad visual redesign.
- No claim that producer scaling exists when the load-scaling artifact is absent.

## Design

- Load `mongo_gateway_load_scaling_1m/summary.tsv` when present.
- Add a `Mongo API InsertMany Producer Scaling` section with requested producer count on the x-axis.
- Keep effective producers and load batch count visible in a producer-scaling summary table to catch capped runs.
- Add an `Index throughput retention` table in the full-sweep index overview, comparing each index count against the 0-index load baseline.
- Keep old artifacts compatible; missing load-scaling directories are omitted, and present-but-missing summaries become warnings.

## Scope

- Runtime benchmark code changed: no.
- Benchmark orchestration changed: no.
- Report parser/rendering changed: yes.

## Correctness

The new section uses the same `mongoSummaryRow` parser as the full sweep. Tests cover old-artifact omission, load-scaling section rendering, nav presence/absence, and retention math.

## Performance

Report-only change. No benchmark runtime path is touched.

## Evidence

| Check | Result |
| --- | --- |
| `GOWORK=off go test -count=1 ./cmd/benchmark_run_report` | pass |
| `git diff --check` | pass |
| smoke report | `/tmp/gomap_m2_report_smoke_20260625_104151/deep_report.html` |

Smoke render command:

```sh
SMOKE_RUN=/tmp/gomap_m2_report_smoke_20260625_104151
GOWORK=off go run ./cmd/benchmark_run_report -run-root "$SMOKE_RUN" -out "$SMOKE_RUN/deep_report.html" -title "Mongo load scaling smoke report"
```

HTML excerpt checks found:

- `Mongo API InsertMany Producer Scaling`
- `Insert Throughput Vs Insert Producers, 0 Indexes`
- `Producer scaling summary`

## AI Review Status

Not yet resolved. This stacked PR is ready for CI/review against the M1 branch; final merge remains blocked on #3034 and #3035 landing first.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Mongo insert-many producer-scaling section to benchmark HTML reports when data is available.
  * Added an index throughput retention view to help compare throughput and storage efficiency across index-count configurations.

* **Bug Fixes**
  * Reports now handle missing load-scaling data more gracefully, showing warnings only when appropriate.
  * Benchmark report runs now include load-scaling output by default unless explicitly skipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->