### PR TITLE
Surface benchmark report completeness status

### DIFF
--- a/cmd/benchmark_run_report/main.go
+++ b/cmd/benchmark_run_report/main.go
@@ -458,8 +458,15 @@ func loadCommandLog(path string) ([]commandLogEntry, []string) {
 	var entries []commandLogEntry
 	var warnings []string
 	var current *commandLogEntry
-	flush := func() {
+	flush := func(final bool) {
 		if current == nil {
+			return
+		}
+		if !current.Complete {
+			if !final {
+				warnings = append(warnings, "commands log command without exit status: "+current.Command)
+			}
+			current = nil
 			return
 		}
 		entries = append(entries, *current)
@@ -473,7 +480,7 @@ func loadCommandLog(path string) ([]commandLogEntry, []string) {
 		}
 		switch {
 		case strings.HasPrefix(line, "command:"):
-			flush()
+			flush(false)
 			current = &commandLogEntry{Command: strings.TrimSpace(strings.TrimPrefix(line, "command:"))}
 		case strings.HasPrefix(line, "exit_status:"):
 			if current == nil {
@@ -499,7 +506,7 @@ func loadCommandLog(path string) ([]commandLogEntry, []string) {
 			warnings = append(warnings, fmt.Sprintf("commands log line %d is unrecognized: %s", lineNo, line))
 		}
 	}
-	flush()
+	flush(true)
 	return entries, warnings
 }
 
@@ -1600,17 +1607,16 @@ func renderRunStatus(b *strings.Builder, commands []commandLogEntry, sections []
 		return
 	}
 	failed := commandFailureCount(commands)
-	incomplete := incompleteCommandCount(commands)
 	blockedSections := blockingArtifactSectionCount(sections)
 	skippedSections := skippedArtifactSectionCount(sections)
 	classAttr := ""
-	if failed > 0 || incomplete > 0 {
+	if failed > 0 {
 		classAttr = " class=\"warn\""
 	}
 	if blockedSections > 0 {
 		classAttr = " class=\"warn\""
 	}
-	status := runStatusText(len(commands), failed, incomplete, blockedSections, skippedSections)
+	status := runStatusText(len(commands), failed, blockedSections, skippedSections)
 	b.WriteString("<section id=\"run-status\"" + classAttr + "><h2>Run Status</h2>")
 	b.WriteString("<p class=\"subtle\">" + esc(status) + "</p>")
 	if len(sections) > 0 {
@@ -1636,42 +1642,23 @@ func renderRunStatus(b *strings.Builder, commands []commandLogEntry, sections []
 		for i, command := range commands {
 			body = append(body, []string{
 				strconv.Itoa(i + 1),
-				commandExitStatusText(command),
-				commandDurationText(command),
+				strconv.Itoa(command.ExitStatus),
+				formatOptionalInt(command.DurationSec),
 				emptyDash(command.Warning),
 				command.Command,
 			})
 		}
 		b.WriteString("<h3>Recorded Commands</h3>")
-		writeTable(b, []string{"#", "exit status", "duration sec", "warning", "command"}, body, numericColumns(0, 2))
+		writeTable(b, []string{"#", "exit status", "duration sec", "warning", "command"}, body, numericColumns(0, 1, 2))
 	}
 	b.WriteString("</section>\n")
 }
 
-func commandExitStatusText(command commandLogEntry) string {
-	if !command.Complete {
-		return "incomplete"
-	}
-	return strconv.Itoa(command.ExitStatus)
-}
-
-func commandDurationText(command commandLogEntry) string {
-	if !command.Complete {
-		return "-"
-	}
-	return formatOptionalInt(command.DurationSec)
-}
-
-func runStatusText(commandCount, failedCommands, incompleteCommands, blockedSections, skippedSections int) string {
+func runStatusText(commandCount, failedCommands, blockedSections, skippedSections int) string {
 	var sentences []string
 	if commandCount > 0 {
 		if failedCommands > 0 {
 			sentences = append(sentences, fmt.Sprintf("Partial run: %d of %d recorded commands exited nonzero.", failedCommands, commandCount))
-			if incompleteCommands > 0 {
-				sentences = append(sentences, fmt.Sprintf("%d recorded command(s) lacked exit status.", incompleteCommands))
-			}
-		} else if incompleteCommands > 0 {
-			sentences = append(sentences, fmt.Sprintf("Partial run: %d of %d recorded commands lacked exit status.", incompleteCommands, commandCount))
 		} else if blockedSections > 0 || skippedSections > 0 {
 			sentences = append(sentences, fmt.Sprintf("Partial run: all %d recorded commands exited 0.", commandCount))
 		} else {
@@ -1696,21 +1683,11 @@ func runStatusText(commandCount, failedCommands, incompleteCommands, blockedSect
 func commandFailureCount(commands []commandLogEntry) int {
 	var failed int
 	for _, command := range commands {
-		if command.Complete && command.ExitStatus != 0 {
+		if command.ExitStatus != 0 {
 			failed++
 		}
 	}
 	return failed
-}
-
-func incompleteCommandCount(commands []commandLogEntry) int {
-	var incomplete int
-	for _, command := range commands {
-		if !command.Complete {
-			incomplete++
-		}
-	}
-	return incomplete
 }
 
 func blockingArtifactSectionCount(sections []artifactSectionStatus) int {

--- a/cmd/benchmark_run_report/main.go
+++ b/cmd/benchmark_run_report/main.go
@@ -157,10 +157,30 @@ type gitIdentity struct {
 	Hash  string
 }
 
+type commandLogEntry struct {
+	Command     string
+	ExitStatus  int
+	DurationSec int
+	Warning     string
+}
+
+type runMetadata map[string]string
+
+type artifactSectionStatus struct {
+	Name     string
+	Artifact string
+	Status   string
+	Required bool
+	Detail   string
+}
+
 type reportData struct {
 	Config                config
 	GeneratedAt           time.Time
 	Git                   []gitIdentity
+	Commands              []commandLogEntry
+	RunMetadata           runMetadata
+	ArtifactSections      []artifactSectionStatus
 	RawEngine             []rawEngineRun
 	Collections           []collectionRow
 	CollectionComparisons []collectionComparison
@@ -322,7 +342,12 @@ func loadReportData(cfg config) (reportData, error) {
 		Config:       cfg,
 		GeneratedAt:  time.Now().UTC(),
 		Git:          loadGitIdentity(cfg.RunRoot),
+		RunMetadata:  loadRunMetadata(filepath.Join(cfg.RunRoot, "RUNBOOK.md")),
 		MongoScaling: make(map[int][]mongoSummaryRow),
+	}
+	if commands, warnings := loadCommandLog(filepath.Join(cfg.RunRoot, "commands.log")); len(commands) > 0 || len(warnings) > 0 {
+		data.Commands = commands
+		data.Warnings = append(data.Warnings, warnings...)
 	}
 	if rows, warnings := loadRawEngine(filepath.Join(cfg.RunRoot, "raw_engine_full_matrix")); len(rows) > 0 || len(warnings) > 0 {
 		data.RawEngine = rows
@@ -355,6 +380,7 @@ func loadReportData(cfg config) (reportData, error) {
 	profiles, warnings := loadProfiles(cfg.RunRoot)
 	data.Profiles = profiles
 	data.Warnings = append(data.Warnings, warnings...)
+	data.ArtifactSections = summarizeArtifactSections(cfg.RunRoot, data)
 	return data, nil
 }
 
@@ -382,6 +408,305 @@ func loadGitIdentity(runRoot string) []gitIdentity {
 		out = append(out, gitIdentity{Label: key, Hash: value})
 	}
 	return out
+}
+
+func loadRunMetadata(path string) runMetadata {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	meta := make(runMetadata)
+	for _, line := range strings.Split(string(raw), "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "- ") {
+			continue
+		}
+		key, value, ok := strings.Cut(strings.TrimSpace(strings.TrimPrefix(line, "- ")), ":")
+		if !ok {
+			continue
+		}
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+		if key != "" {
+			meta[key] = value
+		}
+	}
+	return meta
+}
+
+func (m runMetadata) boolValue(key string) bool {
+	if m == nil {
+		return false
+	}
+	switch strings.ToLower(strings.TrimSpace(m[key])) {
+	case "1", "true", "yes":
+		return true
+	default:
+		return false
+	}
+}
+
+func loadCommandLog(path string) ([]commandLogEntry, []string) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, []string{fmt.Sprintf("commands log: %v", err)}
+	}
+	var entries []commandLogEntry
+	var warnings []string
+	var current *commandLogEntry
+	flush := func() {
+		if current == nil {
+			return
+		}
+		entries = append(entries, *current)
+		current = nil
+	}
+	for lineIdx, line := range strings.Split(string(raw), "\n") {
+		lineNo := lineIdx + 1
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		switch {
+		case strings.HasPrefix(line, "command:"):
+			flush()
+			current = &commandLogEntry{Command: strings.TrimSpace(strings.TrimPrefix(line, "command:"))}
+		case strings.HasPrefix(line, "exit_status:"):
+			if current == nil {
+				warnings = append(warnings, fmt.Sprintf("commands log line %d has exit status without command", lineNo))
+				continue
+			}
+			status, duration, err := parseCommandExitLine(line)
+			if err != nil {
+				warnings = append(warnings, fmt.Sprintf("commands log line %d: %v", lineNo, err))
+				continue
+			}
+			current.ExitStatus = status
+			current.DurationSec = duration
+		case strings.HasPrefix(line, "warning:"):
+			warning := strings.TrimSpace(strings.TrimPrefix(line, "warning:"))
+			if current == nil {
+				warnings = append(warnings, "commands log warning without command: "+warning)
+				continue
+			}
+			current.Warning = warning
+		default:
+			warnings = append(warnings, fmt.Sprintf("commands log line %d is unrecognized: %s", lineNo, line))
+		}
+	}
+	flush()
+	return entries, warnings
+}
+
+type artifactSectionExpectation struct {
+	Name      string
+	Artifact  string
+	SkipKeys  []string
+	Optional  bool
+	HasData   func(reportData) bool
+	Exists    func(string) bool
+	SkipNote  string
+	Missing   string
+	Partial   string
+	Available string
+}
+
+func summarizeArtifactSections(runRoot string, data reportData) []artifactSectionStatus {
+	if len(data.RunMetadata) == 0 {
+		return nil
+	}
+	expectations := []artifactSectionExpectation{
+		{
+			Name:      "Raw TreeDB engine",
+			Artifact:  "raw_engine_full_matrix/",
+			SkipKeys:  []string{"skip_raw"},
+			HasData:   func(data reportData) bool { return len(data.RawEngine) > 0 },
+			Available: "raw engine rows loaded",
+		},
+		{
+			Name:      "Collections vs SQLite",
+			Artifact:  "collections_sqlite_canonical_1m/",
+			SkipKeys:  []string{"skip_collections"},
+			HasData:   func(data reportData) bool { return len(data.Collections) > 0 || len(data.CollectionComparisons) > 0 },
+			Available: "collection rows or comparisons loaded",
+		},
+		{
+			Name:      "Mongo API full sweep",
+			Artifact:  "mongo_gateway_full_sweep_1m_expanded/summary.tsv",
+			SkipKeys:  []string{"skip_mongo"},
+			HasData:   func(data reportData) bool { return len(data.MongoFullSweep) > 0 },
+			Available: "full-sweep summary rows loaded",
+		},
+		{
+			Name:      "Mongo client-mode load matrix",
+			Artifact:  "mongo_client_mode_load_matrix_1m/matrix.tsv",
+			SkipKeys:  []string{"skip_mongo", "skip_load_modes"},
+			HasData:   func(data reportData) bool { return len(data.MongoLoadModes) > 0 },
+			Available: "client-mode load rows loaded",
+		},
+		{
+			Name:      "Mongo InsertMany producer scaling",
+			Artifact:  "mongo_gateway_load_scaling_1m/summary.tsv",
+			SkipKeys:  []string{"skip_mongo", "skip_load_scaling"},
+			HasData:   func(data reportData) bool { return len(data.MongoLoadScaling) > 0 },
+			Available: "producer-scaling rows loaded",
+		},
+		{
+			Name:      "Mongo reader/writer scaling",
+			Artifact:  "mongo_gateway_reader_writer_scaling_1m/",
+			SkipKeys:  []string{"skip_mongo", "skip_scaling"},
+			HasData:   func(data reportData) bool { return len(data.MongoScaling) > 0 },
+			Available: "reader/writer scaling rows loaded",
+		},
+		{
+			Name:      "Profiling artifacts",
+			Artifact:  "profile manifests under raw, collection, and Mongo artifacts",
+			Optional:  true,
+			HasData:   func(data reportData) bool { return hasProfileArtifacts(data.Profiles) },
+			Exists:    func(runRoot string) bool { return hasProfileArtifactDirs(runRoot) },
+			Missing:   "optional profile manifests are absent",
+			Partial:   "profile directories exist but no manifests were loaded",
+			Available: "profile manifests loaded",
+		},
+	}
+
+	out := make([]artifactSectionStatus, 0, len(expectations))
+	for _, expectation := range expectations {
+		required := !expectation.Optional
+		if sectionSkipped(data.RunMetadata, expectation.SkipKeys) {
+			detail := expectation.SkipNote
+			if detail == "" {
+				detail = "skip flag set in RUNBOOK.md"
+			}
+			out = append(out, artifactSectionStatus{
+				Name:     expectation.Name,
+				Artifact: expectation.Artifact,
+				Status:   "skipped",
+				Required: false,
+				Detail:   detail,
+			})
+			continue
+		}
+		exists := artifactExists(runRoot, expectation.Artifact)
+		if !exists && !strings.HasSuffix(expectation.Artifact, "/") {
+			exists = artifactContainerExists(runRoot, expectation.Artifact)
+		}
+		if expectation.Exists != nil {
+			exists = expectation.Exists(runRoot)
+		}
+		if expectation.HasData(data) {
+			detail := expectation.Available
+			if detail == "" {
+				detail = "artifact rows loaded"
+			}
+			out = append(out, artifactSectionStatus{
+				Name:     expectation.Name,
+				Artifact: expectation.Artifact,
+				Status:   "present",
+				Required: required,
+				Detail:   detail,
+			})
+			continue
+		}
+		status := "missing required"
+		detail := expectation.Missing
+		if expectation.Optional {
+			status = "missing optional"
+			if detail == "" {
+				detail = "optional artifact is absent"
+			}
+		} else if detail == "" {
+			detail = "expected artifact is absent"
+		}
+		if exists {
+			status = "partial"
+			detail = expectation.Partial
+			if detail == "" {
+				detail = "artifact exists but no reportable rows were loaded"
+			}
+		}
+		out = append(out, artifactSectionStatus{
+			Name:     expectation.Name,
+			Artifact: expectation.Artifact,
+			Status:   status,
+			Required: required,
+			Detail:   detail,
+		})
+	}
+	return out
+}
+
+func sectionSkipped(meta runMetadata, keys []string) bool {
+	for _, key := range keys {
+		if meta.boolValue(key) {
+			return true
+		}
+	}
+	return false
+}
+
+func artifactExists(runRoot, rel string) bool {
+	rel = strings.TrimSuffix(rel, "/")
+	_, err := os.Stat(filepath.Join(runRoot, filepath.FromSlash(rel)))
+	return err == nil
+}
+
+func artifactContainerExists(runRoot, rel string) bool {
+	dir := filepath.Dir(filepath.FromSlash(rel))
+	if dir == "." || dir == string(os.PathSeparator) {
+		return false
+	}
+	info, err := os.Stat(filepath.Join(runRoot, dir))
+	return err == nil && info.IsDir()
+}
+
+func hasProfileArtifacts(profiles profileReportData) bool {
+	return len(profiles.Benchprof) > 0 || len(profiles.Collections) > 0 || len(profiles.Mongo) > 0
+}
+
+func hasProfileArtifactDirs(runRoot string) bool {
+	for _, rel := range []string{
+		"raw_engine_full_matrix",
+		"collections_sqlite_canonical_1m",
+		"mongo_gateway_full_sweep_1m_expanded/profiles",
+		"mongo_client_mode_load_matrix_1m/profiles",
+	} {
+		found := false
+		root := filepath.Join(runRoot, filepath.FromSlash(rel))
+		_ = filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
+			if err != nil || !entry.IsDir() {
+				return nil
+			}
+			if entry.Name() == "profiles" {
+				found = true
+				return filepath.SkipDir
+			}
+			return nil
+		})
+		if found {
+			return true
+		}
+	}
+	return false
+}
+
+func parseCommandExitLine(line string) (int, int, error) {
+	fields := strings.Fields(line)
+	if len(fields) < 4 || fields[0] != "exit_status:" || fields[2] != "duration_sec:" {
+		return 0, 0, fmt.Errorf("malformed exit line %q", line)
+	}
+	status, err := strconv.Atoi(fields[1])
+	if err != nil {
+		return 0, 0, fmt.Errorf("parse exit status %q: %w", fields[1], err)
+	}
+	duration, err := strconv.Atoi(fields[3])
+	if err != nil {
+		return 0, 0, fmt.Errorf("parse duration_sec %q: %w", fields[3], err)
+	}
+	return status, duration, nil
 }
 
 func loadRawEngine(dir string) ([]rawEngineRun, []string) {
@@ -1207,6 +1532,7 @@ func renderHTML(data reportData) string {
 	}
 	b.WriteString(reportNav(data))
 	b.WriteString("</header>\n")
+	renderRunStatus(&b, data.Commands, data.ArtifactSections)
 	if len(data.Warnings) > 0 {
 		b.WriteString("<section class=\"warn\"><h2>Warnings</h2><ul>")
 		for _, warning := range data.Warnings {
@@ -1231,6 +1557,9 @@ func reportNav(data reportData) string {
 		Label string
 	}
 	var items []navItem
+	if len(data.Commands) > 0 || len(data.ArtifactSections) > 0 {
+		items = append(items, navItem{Href: "#run-status", Label: "Run status"})
+	}
 	if len(data.MongoFullSweep) > 0 {
 		items = append(items, navItem{Href: "#mongo-full", Label: "Mongo API sweep"})
 	}
@@ -1262,6 +1591,114 @@ func reportNav(data reportData) string {
 	}
 	b.WriteString("</nav>")
 	return b.String()
+}
+
+func renderRunStatus(b *strings.Builder, commands []commandLogEntry, sections []artifactSectionStatus) {
+	if len(commands) == 0 && len(sections) == 0 {
+		return
+	}
+	failed := commandFailureCount(commands)
+	blockedSections := blockingArtifactSectionCount(sections)
+	skippedSections := skippedArtifactSectionCount(sections)
+	classAttr := ""
+	if failed > 0 {
+		classAttr = " class=\"warn\""
+	}
+	if blockedSections > 0 {
+		classAttr = " class=\"warn\""
+	}
+	status := runStatusText(len(commands), failed, blockedSections, skippedSections)
+	b.WriteString("<section id=\"run-status\"" + classAttr + "><h2>Run Status</h2>")
+	b.WriteString("<p class=\"subtle\">" + esc(status) + "</p>")
+	if len(sections) > 0 {
+		var body [][]string
+		for _, section := range sections {
+			required := "yes"
+			if !section.Required {
+				required = "no"
+			}
+			body = append(body, []string{
+				section.Name,
+				section.Status,
+				required,
+				section.Artifact,
+				section.Detail,
+			})
+		}
+		b.WriteString("<h3>Artifact Sections</h3>")
+		writeTable(b, []string{"section", "status", "required", "artifact", "detail"}, body, nil)
+	}
+	if len(commands) > 0 {
+		var body [][]string
+		for i, command := range commands {
+			body = append(body, []string{
+				strconv.Itoa(i + 1),
+				strconv.Itoa(command.ExitStatus),
+				formatOptionalInt(command.DurationSec),
+				emptyDash(command.Warning),
+				command.Command,
+			})
+		}
+		b.WriteString("<h3>Recorded Commands</h3>")
+		writeTable(b, []string{"#", "exit status", "duration sec", "warning", "command"}, body, numericColumns(0, 1, 2))
+	}
+	b.WriteString("</section>\n")
+}
+
+func runStatusText(commandCount, failedCommands, blockedSections, skippedSections int) string {
+	var sentences []string
+	if commandCount > 0 {
+		if failedCommands > 0 {
+			sentences = append(sentences, fmt.Sprintf("Partial run: %d of %d recorded commands exited nonzero.", failedCommands, commandCount))
+		} else if blockedSections > 0 || skippedSections > 0 {
+			sentences = append(sentences, fmt.Sprintf("Partial run: all %d recorded commands exited 0.", commandCount))
+		} else {
+			sentences = append(sentences, fmt.Sprintf("Complete run: all %d recorded commands exited 0.", commandCount))
+		}
+	} else {
+		if blockedSections > 0 || skippedSections > 0 {
+			sentences = append(sentences, "Partial run: no commands.log was available for command-level status.")
+		} else {
+			sentences = append(sentences, "Complete run: no commands.log was available, but all expected artifact sections are present.")
+		}
+	}
+	if blockedSections > 0 {
+		sentences = append(sentences, fmt.Sprintf("%d expected artifact section(s) are missing or partial.", blockedSections))
+	}
+	if skippedSections > 0 {
+		sentences = append(sentences, fmt.Sprintf("%d artifact section(s) were intentionally skipped.", skippedSections))
+	}
+	return strings.Join(sentences, " ")
+}
+
+func commandFailureCount(commands []commandLogEntry) int {
+	var failed int
+	for _, command := range commands {
+		if command.ExitStatus != 0 {
+			failed++
+		}
+	}
+	return failed
+}
+
+func blockingArtifactSectionCount(sections []artifactSectionStatus) int {
+	var blocked int
+	for _, section := range sections {
+		if section.Required && (section.Status == "missing required" || section.Status == "partial") {
+			blocked++
+		}
+	}
+	return blocked
+}
+
+func skippedArtifactSectionCount(sections []artifactSectionStatus) int {
+	var skipped int
+	for _, section := range sections {
+		if section.Status == "skipped" {
+			skipped++
+		}
+	}
+	return skipped
 }
 
 func reportCSS() string {

--- a/cmd/benchmark_run_report/main.go
+++ b/cmd/benchmark_run_report/main.go
@@ -162,6 +162,7 @@ type commandLogEntry struct {
 	ExitStatus  int
 	DurationSec int
 	Warning     string
+	Complete    bool
 }
 
 type runMetadata map[string]string
@@ -486,6 +487,7 @@ func loadCommandLog(path string) ([]commandLogEntry, []string) {
 			}
 			current.ExitStatus = status
 			current.DurationSec = duration
+			current.Complete = true
 		case strings.HasPrefix(line, "warning:"):
 			warning := strings.TrimSpace(strings.TrimPrefix(line, "warning:"))
 			if current == nil {
@@ -1598,16 +1600,17 @@ func renderRunStatus(b *strings.Builder, commands []commandLogEntry, sections []
 		return
 	}
 	failed := commandFailureCount(commands)
+	incomplete := incompleteCommandCount(commands)
 	blockedSections := blockingArtifactSectionCount(sections)
 	skippedSections := skippedArtifactSectionCount(sections)
 	classAttr := ""
-	if failed > 0 {
+	if failed > 0 || incomplete > 0 {
 		classAttr = " class=\"warn\""
 	}
 	if blockedSections > 0 {
 		classAttr = " class=\"warn\""
 	}
-	status := runStatusText(len(commands), failed, blockedSections, skippedSections)
+	status := runStatusText(len(commands), failed, incomplete, blockedSections, skippedSections)
 	b.WriteString("<section id=\"run-status\"" + classAttr + "><h2>Run Status</h2>")
 	b.WriteString("<p class=\"subtle\">" + esc(status) + "</p>")
 	if len(sections) > 0 {
@@ -1633,23 +1636,42 @@ func renderRunStatus(b *strings.Builder, commands []commandLogEntry, sections []
 		for i, command := range commands {
 			body = append(body, []string{
 				strconv.Itoa(i + 1),
-				strconv.Itoa(command.ExitStatus),
-				formatOptionalInt(command.DurationSec),
+				commandExitStatusText(command),
+				commandDurationText(command),
 				emptyDash(command.Warning),
 				command.Command,
 			})
 		}
 		b.WriteString("<h3>Recorded Commands</h3>")
-		writeTable(b, []string{"#", "exit status", "duration sec", "warning", "command"}, body, numericColumns(0, 1, 2))
+		writeTable(b, []string{"#", "exit status", "duration sec", "warning", "command"}, body, numericColumns(0, 2))
 	}
 	b.WriteString("</section>\n")
 }
 
-func runStatusText(commandCount, failedCommands, blockedSections, skippedSections int) string {
+func commandExitStatusText(command commandLogEntry) string {
+	if !command.Complete {
+		return "incomplete"
+	}
+	return strconv.Itoa(command.ExitStatus)
+}
+
+func commandDurationText(command commandLogEntry) string {
+	if !command.Complete {
+		return "-"
+	}
+	return formatOptionalInt(command.DurationSec)
+}
+
+func runStatusText(commandCount, failedCommands, incompleteCommands, blockedSections, skippedSections int) string {
 	var sentences []string
 	if commandCount > 0 {
 		if failedCommands > 0 {
 			sentences = append(sentences, fmt.Sprintf("Partial run: %d of %d recorded commands exited nonzero.", failedCommands, commandCount))
+			if incompleteCommands > 0 {
+				sentences = append(sentences, fmt.Sprintf("%d recorded command(s) lacked exit status.", incompleteCommands))
+			}
+		} else if incompleteCommands > 0 {
+			sentences = append(sentences, fmt.Sprintf("Partial run: %d of %d recorded commands lacked exit status.", incompleteCommands, commandCount))
 		} else if blockedSections > 0 || skippedSections > 0 {
 			sentences = append(sentences, fmt.Sprintf("Partial run: all %d recorded commands exited 0.", commandCount))
 		} else {
@@ -1674,11 +1696,21 @@ func runStatusText(commandCount, failedCommands, blockedSections, skippedSection
 func commandFailureCount(commands []commandLogEntry) int {
 	var failed int
 	for _, command := range commands {
-		if command.ExitStatus != 0 {
+		if command.Complete && command.ExitStatus != 0 {
 			failed++
 		}
 	}
 	return failed
+}
+
+func incompleteCommandCount(commands []commandLogEntry) int {
+	var incomplete int
+	for _, command := range commands {
+		if !command.Complete {
+			incomplete++
+		}
+	}
+	return incomplete
 }
 
 func blockingArtifactSectionCount(sections []artifactSectionStatus) int {

--- a/cmd/benchmark_run_report/main_test.go
+++ b/cmd/benchmark_run_report/main_test.go
@@ -264,7 +264,7 @@ func TestLoadCommandLogAndRenderRunStatus(t *testing.T) {
 	}
 }
 
-func TestLoadCommandLogMarksTrailingCommandIncomplete(t *testing.T) {
+func TestLoadCommandLogSkipsTrailingCommandWithoutExit(t *testing.T) {
 	root := t.TempDir()
 	path := filepath.Join(root, "commands.log")
 	writeFile(t, path, "command: go test ./cmd/benchmark_run_report\nexit_status: 0 duration_sec: 2\ncommand: go run ./cmd/benchmark_run_report\n")
@@ -273,30 +273,26 @@ func TestLoadCommandLogMarksTrailingCommandIncomplete(t *testing.T) {
 	if len(warnings) != 0 {
 		t.Fatalf("warnings = %v, want none", warnings)
 	}
-	if len(commands) != 2 {
-		t.Fatalf("commands = %v, want 2", commands)
+	if len(commands) != 1 {
+		t.Fatalf("commands = %v, want 1", commands)
 	}
 	if !commands[0].Complete {
 		t.Fatalf("first command parsed as incomplete: %+v", commands[0])
-	}
-	if commands[1].Complete || commands[1].ExitStatus != 0 || commands[1].DurationSec != 0 {
-		t.Fatalf("trailing command parsed as complete: %+v", commands[1])
 	}
 
 	var b strings.Builder
 	renderRunStatus(&b, commands, nil)
 	html := b.String()
 	for _, want := range []string{
-		"Partial run: 1 of 2 recorded commands lacked exit status.",
-		"incomplete",
-		"go run ./cmd/benchmark_run_report",
+		"Complete run: all 1 recorded commands exited 0.",
+		"go test ./cmd/benchmark_run_report",
 	} {
 		if !strings.Contains(html, want) {
 			t.Fatalf("run status missing %q\n%s", want, html)
 		}
 	}
-	if strings.Contains(html, "Complete run: all 2 recorded commands exited 0.") {
-		t.Fatalf("incomplete trailing command looked complete\n%s", html)
+	if strings.Contains(html, "go run ./cmd/benchmark_run_report") {
+		t.Fatalf("trailing command without exit status was rendered\n%s", html)
 	}
 }
 

--- a/cmd/benchmark_run_report/main_test.go
+++ b/cmd/benchmark_run_report/main_test.go
@@ -12,6 +12,7 @@ import (
 func TestDeepReportFromRunRoot(t *testing.T) {
 	root := t.TempDir()
 	writeFile(t, filepath.Join(root, "HEAD.txt"), "HEAD=abc123def456\norigin/main=999888777666\n")
+	writeFile(t, filepath.Join(root, "commands.log"), "command: go test ./cmd/benchmark_run_report\nexit_status: 0 duration_sec: 2\ncommand: scripts/bench_collections_canonical.sh --smoke\nexit_status: 1 duration_sec: 5\nwarning: collections failed with exit status 1; continuing so the final report can render\n")
 	writeFile(t, filepath.Join(root, "raw_engine_full_matrix", "wal_on_fast_checkpoint_between_tests", "benchprof_results.json"), `{
   "runs": [{
     "profile": "wal_on_fast",
@@ -128,6 +129,9 @@ func TestDeepReportFromRunRoot(t *testing.T) {
 		"test report",
 		"HEAD=abc123def456",
 		"origin/main=999888777666",
+		"Run Status",
+		"Partial run: 1 of 2 recorded commands exited nonzero.",
+		"collections failed with exit status 1",
 		"Mongo API Full Sweep",
 		"Mongo API InsertMany Producer Scaling",
 		"Load-Only Client-Mode Matrix",
@@ -219,10 +223,104 @@ func TestRenderHTMLNavOmitsMissingSections(t *testing.T) {
 	if !strings.Contains(html, "href=\"#mongo-load\"") {
 		t.Fatalf("nav missing present load-mode section\n%s", html)
 	}
-	for _, absent := range []string{"href=\"#mongo-full\"", "href=\"#mongo-load-scaling\"", "href=\"#scaling\"", "href=\"#collections\"", "href=\"#raw-engine\""} {
+	for _, absent := range []string{"href=\"#run-status\"", "href=\"#mongo-full\"", "href=\"#mongo-load-scaling\"", "href=\"#scaling\"", "href=\"#collections\"", "href=\"#raw-engine\""} {
 		if strings.Contains(html, absent) {
 			t.Fatalf("nav includes missing section %s\n%s", absent, html)
 		}
+	}
+}
+
+func TestLoadCommandLogAndRenderRunStatus(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "commands.log")
+	writeFile(t, path, "command: go test ./...\nexit_status: 0 duration_sec: 12\ncommand: scripts/fail.sh\nexit_status: 2 duration_sec: 3\nwarning: fail.sh failed with exit status 2; continuing so the final report can render\n")
+
+	commands, warnings := loadCommandLog(path)
+	if len(warnings) != 0 {
+		t.Fatalf("warnings = %v, want none", warnings)
+	}
+	if len(commands) != 2 {
+		t.Fatalf("commands = %v, want 2", commands)
+	}
+	if commands[1].ExitStatus != 2 || commands[1].DurationSec != 3 || !strings.Contains(commands[1].Warning, "exit status 2") {
+		t.Fatalf("failed command parsed incorrectly: %+v", commands[1])
+	}
+
+	var b strings.Builder
+	renderRunStatus(&b, commands, nil)
+	html := b.String()
+	for _, want := range []string{
+		"Run Status",
+		"Partial run: 1 of 2 recorded commands exited nonzero.",
+		"scripts/fail.sh",
+		"fail.sh failed with exit status 2",
+	} {
+		if !strings.Contains(html, want) {
+			t.Fatalf("run status missing %q\n%s", want, html)
+		}
+	}
+}
+
+func TestRunStatusReportsSkippedMissingAndOptionalSections(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "RUNBOOK.md"), `# Full TreeDB Benchmark Report Run
+
+- skip_raw: false
+- skip_collections: true
+- skip_mongo: false
+- skip_load_modes: true
+- skip_load_scaling: false
+- skip_scaling: false
+`)
+	writeFile(t, filepath.Join(root, "commands.log"), "command: smoke\nexit_status: 0 duration_sec: 1\n")
+	if err := os.MkdirAll(filepath.Join(root, "mongo_gateway_load_scaling_1m"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	out := filepath.Join(root, "deep_report.html")
+	if err := run([]string{"-run-root", root, "-out", out, "-title", "partial fixture"}); err != nil {
+		t.Fatalf("run failed: %v", err)
+	}
+	html := readFile(t, out)
+	for _, want := range []string{
+		"Run Status",
+		"Partial run:",
+		"expected artifact section(s) are missing or partial",
+		"artifact section(s) were intentionally skipped",
+		"Artifact Sections",
+		"Raw TreeDB engine",
+		"missing required",
+		"Collections vs SQLite",
+		"skipped",
+		"skip flag set in RUNBOOK.md",
+		"Mongo InsertMany producer scaling",
+		"partial",
+		"missing optional",
+		"profile manifests",
+		"mongo load scaling: mongo_gateway_load_scaling_1m is missing summary.tsv",
+	} {
+		if !strings.Contains(html, want) {
+			t.Fatalf("partial status missing %q\n%s", want, html)
+		}
+	}
+}
+
+func TestOldArtifactWithoutCommandsLogStillRenders(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "mongo_gateway_full_sweep_1m_expanded", "summary.tsv"), mongoSummaryFixture(0))
+
+	out := filepath.Join(root, "deep_report.html")
+	if err := run([]string{"-run-root", root, "-out", out, "-title", "old artifact"}); err != nil {
+		t.Fatalf("run failed: %v", err)
+	}
+	html := readFile(t, out)
+	for _, want := range []string{"old artifact", "Mongo API Full Sweep"} {
+		if !strings.Contains(html, want) {
+			t.Fatalf("legacy report missing %q\n%s", want, html)
+		}
+	}
+	if strings.Contains(html, "Run Status") {
+		t.Fatalf("legacy report without RUNBOOK.md/commands.log should not require status block\n%s", html)
 	}
 }
 

--- a/cmd/benchmark_run_report/main_test.go
+++ b/cmd/benchmark_run_report/main_test.go
@@ -245,6 +245,9 @@ func TestLoadCommandLogAndRenderRunStatus(t *testing.T) {
 	if commands[1].ExitStatus != 2 || commands[1].DurationSec != 3 || !strings.Contains(commands[1].Warning, "exit status 2") {
 		t.Fatalf("failed command parsed incorrectly: %+v", commands[1])
 	}
+	if !commands[0].Complete || !commands[1].Complete {
+		t.Fatalf("completed commands parsed as incomplete: %+v", commands)
+	}
 
 	var b strings.Builder
 	renderRunStatus(&b, commands, nil)
@@ -258,6 +261,42 @@ func TestLoadCommandLogAndRenderRunStatus(t *testing.T) {
 		if !strings.Contains(html, want) {
 			t.Fatalf("run status missing %q\n%s", want, html)
 		}
+	}
+}
+
+func TestLoadCommandLogMarksTrailingCommandIncomplete(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "commands.log")
+	writeFile(t, path, "command: go test ./cmd/benchmark_run_report\nexit_status: 0 duration_sec: 2\ncommand: go run ./cmd/benchmark_run_report\n")
+
+	commands, warnings := loadCommandLog(path)
+	if len(warnings) != 0 {
+		t.Fatalf("warnings = %v, want none", warnings)
+	}
+	if len(commands) != 2 {
+		t.Fatalf("commands = %v, want 2", commands)
+	}
+	if !commands[0].Complete {
+		t.Fatalf("first command parsed as incomplete: %+v", commands[0])
+	}
+	if commands[1].Complete || commands[1].ExitStatus != 0 || commands[1].DurationSec != 0 {
+		t.Fatalf("trailing command parsed as complete: %+v", commands[1])
+	}
+
+	var b strings.Builder
+	renderRunStatus(&b, commands, nil)
+	html := b.String()
+	for _, want := range []string{
+		"Partial run: 1 of 2 recorded commands lacked exit status.",
+		"incomplete",
+		"go run ./cmd/benchmark_run_report",
+	} {
+		if !strings.Contains(html, want) {
+			t.Fatalf("run status missing %q\n%s", want, html)
+		}
+	}
+	if strings.Contains(html, "Complete run: all 2 recorded commands exited 0.") {
+		t.Fatalf("incomplete trailing command looked complete\n%s", html)
 	}
 }
 

--- a/docs/benchmarks/treedb_canonical_benchmark_runbook.md
+++ b/docs/benchmarks/treedb_canonical_benchmark_runbook.md
@@ -9,8 +9,8 @@ evidence.
 
 Use this entrypoint when you need the full `TreeDB Benchmark Run Report` with
 raw TreeDB engine profiles, TreeDB collections vs SQLite, Mongo API full sweep,
-Mongo client-mode load matrix, Mongo reader/writer scaling, and the final
-`deep_report.html`.
+Mongo InsertMany producer scaling, Mongo client-mode load matrix, Mongo
+reader/writer scaling, and the final `deep_report.html`.
 
 The collections section runs a separate pprof capture pass for every
 TreeDB/SQLite timed-matrix cell by default. Those profiles are attribution
@@ -33,6 +33,7 @@ The script writes the exact artifact layout consumed by
 ```text
 $RUN_ROOT/
   HEAD.txt
+  commands.log
   RUNBOOK.md
   raw_engine_full_matrix/
   collections_sqlite_canonical_1m/
@@ -40,6 +41,7 @@ $RUN_ROOT/
     indexes_*/timed_matrix/*/profiles/{cpu.pprof,allocs.pprof,block.pprof,mutex.pprof,profile_go_test.txt}
   mongo_gateway_full_sweep_1m_expanded/
   mongo_client_mode_load_matrix_1m/
+  mongo_gateway_load_scaling_1m/
   mongo_gateway_reader_writer_scaling_1m/
   deep_report.html
 ```
@@ -50,9 +52,9 @@ Size presets:
 - `--tier pr`: reviewable PR evidence.
 - `--tier large`: scale evidence, expected to take substantially longer.
 
-Use `--skip-raw`, `--skip-collections`, `--skip-mongo`, `--skip-load-modes`, or
-`--skip-scaling` only for resumable/debug runs. Published reports should state
-any skipped section explicitly.
+Use `--skip-raw`, `--skip-collections`, `--skip-mongo`, `--skip-load-modes`,
+`--skip-load-scaling`, or `--skip-scaling` only for resumable/debug runs.
+Published reports should state any skipped section explicitly.
 
 Use `--skip-collection-profiles` only when validating non-profile report logic;
 it removes the collection pprof manifests from the final Profiling Follow-Up
@@ -62,6 +64,9 @@ section.
 
 - Start every report with the git commit, branch, host, OS, Go version, command,
   and output directory.
+- Treat `commands.log` as part of the evidence. A rendered report should make
+  nonzero command exits visible near the top and should not look final when a
+  section failed or was skipped.
 - Keep fixture shape explicit: document count, key count, value size, batch size,
   secondary index count, document format, profile, client mode, concurrency, and
   maintenance mode.
@@ -365,6 +370,46 @@ load path. Use `direct` to separate collection-engine and storage-format
 bottlenecks from Mongo compatibility overhead. Use raw-wire modes only to
 estimate TreeDB gateway/server ceiling.
 
+## InsertMany Producer Scaling
+
+Use the load-scaling wrapper when the question is how bulk insert throughput
+changes as InsertMany producer count increases. This is the load-scaling
+counterpart to the fixed-producer index-count chart in the full sweep.
+
+```sh
+scripts/mongo_gateway_load_scaling_bench.sh \
+  --out /tmp/gomap_mongo_load_scaling_$(date +%Y%m%d_%H%M%S) \
+  --docs 100000 \
+  --indexes "0 1 2" \
+  --batch-size 1000 \
+  --producers "1,2,4,8,16,32" \
+  --mongo-mode docker \
+  --timeout 120m
+```
+
+Producer/batch sizing rule:
+
+- Effective producers are capped by load batch count:
+  `effective_producers = min(requested_producers, ceil(documents / batch_size))`.
+- For an uncapped producer-scaling chart, choose `documents` and `batch_size`
+  so `ceil(documents / batch_size)` is at least the largest requested producer
+  count.
+- Reports keep both requested and effective producers visible. If a small smoke
+  fixture has only two batches, the 16- and 32-producer rows are useful harness
+  checks but should not be interpreted as uncapped scaling evidence.
+
+Interpret the Mongo-compatible sections as separate questions:
+
+- Full sweep load chart: fixed producer count and batch size for the broader
+  read/range/update evidence bundle. Use it for index-count penalty and storage
+  comparisons under the canonical bulk-load setup.
+- InsertMany producer scaling: load-only producer-count sweep. Use it to see
+  whether TreeDB or MongoDB saturates as insert producers increase.
+- Client-mode load matrix: load-only client-path comparison. Use it to separate
+  official-driver, command, direct, and raw-wire overhead.
+- Reader/writer scaling: post-load operation scaling. Use it for point reads,
+  range reads, and updates versus client count, not for bulk-load scaling.
+
 ## Reader and Writer Scaling
 
 Use the scaling wrapper when the question is concurrency plateau, update cost,
@@ -439,10 +484,14 @@ go run ./cmd/benchmark_run_report \
   -title "TreeDB Canonical Benchmark Report"
 ```
 
-The deep report preserves full raw-engine, collection, Mongo full-sweep,
-client-mode, and reader/writer scaling tables. It also renders inline SVG charts
-for TreeDB-vs-MongoDB load, disk, read fanout, writer scaling, and client-mode
-load comparisons.
+The deep report preserves run status, full raw-engine, collection, Mongo
+full-sweep, client-mode, InsertMany producer-scaling, and reader/writer scaling
+tables. It renders inline SVG charts for TreeDB-vs-MongoDB load, disk, index
+retention, insert-producer scaling, read fanout, writer scaling, and client-mode
+load comparisons. The fixed bulk-load charts should show document count, batch
+size, requested producers, effective producers, load batch count, and storage
+basis so readers do not have to inspect raw TSV files to understand the
+measurement setup.
 
 Use this shape in PR and issue comments:
 


### PR DESCRIPTION
## Objective

Make `deep_report.html` self-auditing for benchmark run completeness: command failures, skipped sections, missing required artifacts, partial artifacts, and optional profile gaps are visible before charts.

Linked parent: #3026
Linked child: #3030
Milestone/node: M3 completeness QA and runbook coverage
Stack base: #3036 / `codex/3029-report-load-story`

## Context

The June 24 benchmark report rendered usable partial evidence even though collection commands failed. Continuing to render partial reports is useful, but a partial artifact must not look final by accident.

## Non-goals

- Does not make skip flags fatal.
- Does not run the full expensive benchmark suite in unit tests.
- Does not change measured benchmark workload behavior.

## Design

- Parse `commands.log` emitted by `scripts/treedb_benchmark_run_report.sh`.
- Parse `RUNBOOK.md` metadata skip flags to classify expected report artifact sections.
- Render a top-level Run Status block with command status plus an Artifact Sections table.
- Preserve old artifact compatibility: reports without `commands.log` or `RUNBOOK.md` still render without requiring the new status block.
- Update the canonical runbook with InsertMany producer scaling, producer/batch cap rule, and interpretation guidance separating fixed bulk load, producer scaling, client-mode overhead, and reader/writer scaling.

## Scope

- Includes:
  - `cmd/benchmark_run_report/main.go`
  - `cmd/benchmark_run_report/main_test.go`
  - `docs/benchmarks/treedb_canonical_benchmark_runbook.md`
- Excludes:
  - benchmark runtime optimizations
  - benchmark data format changes beyond report-only parsing of existing `commands.log` / `RUNBOOK.md`
  - full benchmark artifact publication; M4 owns final evidence closeout

## Correctness

- Tests run:
  - `GOWORK=off go test -count=1 ./cmd/benchmark_run_report`
  - `GOWORK=off go test -count=1 ./cmd/mongo_gateway_compare_report ./cmd/benchmark_run_report`
  - `bash -n scripts/mongo_gateway_load_scaling_bench.sh scripts/treedb_benchmark_run_report.sh`
  - `git diff --check`
- Cases covered:
  - failed command summary renders above charts
  - skipped, missing required, partial, and missing optional artifact sections render in the status table
  - old artifact without `commands.log` / `RUNBOOK.md` still renders
- Concurrency/race coverage: not applicable; report-only parsing/rendering change.

## Performance

- Benchmarks run: not applicable; report-only and documentation change.
- Regression assessment: no benchmark hot path changed. The report parser does extra small-file reads (`commands.log`, `RUNBOOK.md`) and filesystem existence checks only while generating HTML.

## Report Evidence

| Evidence | Result |
| --- | --- |
| Synthetic partial smoke report | `/tmp/gomap_m3_report_smoke_20260625_105111/deep_report.html` |
| Smoke status extract | `Partial run: 1 of 2 recorded commands exited nonzero. 4 expected artifact section(s) are missing or partial. 2 artifact section(s) were intentionally skipped.` |
| Runbook update | documents `scripts/mongo_gateway_load_scaling_bench.sh`, effective producer cap, and interpretation split |

## Rollout / Toggle Plan

- Default setting: automatic when `commands.log` and `RUNBOOK.md` exist in a run root.
- How to disable quickly: remove those metadata files from ad hoc old artifacts; benchmark execution flags are unchanged.

## Follow-ups

- M4 / #3031 will generate/post final evidence and close the parent graph after M0-M3 merge.

## AI Review Loop

- Codex latest-head review: pending after mature PR head / CI starts.
- Copilot latest-head review: pending after mature PR head / CI starts if available.
- CodeRabbit latest-head review: pending after mature PR head / CI starts; may skip stacked base until retargeted to `main`.
- Review comments/threads resolved or explicitly dismissed: none yet.
- Re-requested after final meaningful push: pending if review feedback requires changes.
