### PR TITLE
docs: align R3a apply docs with command WAL

### DIFF
--- a/TreeDB/docs/command_wal_nativewire_alignment_test.go
+++ b/TreeDB/docs/command_wal_nativewire_alignment_test.go
@@ -185,11 +185,33 @@ func TestRaftApplyDoesNotReportRecoverableBeforeCommandWALAppliedLSN(t *testing.
 		"Native-wire and Raft alignment",
 		"must lower to a local command-WAL frame and satisfy the requested local ack boundary before reporting local recoverability",
 		"`raft_committed` is not local WAL append",
+		"For the R3a local apply harness tracked by #1654",
+		"lowers supported entries to local `CommandEnvelope` payloads",
+		"advances future `ApplyProgress` or applied-index metadata only after the selected local recoverability boundary is satisfied",
 	} {
 		if !strings.Contains(normalizedSpec, required) {
 			t.Fatalf("user-command WAL spec missing Raft/local recoverability rule: %q", required)
 		}
 	}
+}
+
+func TestRaftRoadmapUsesCommandWALRecoverabilityBoundary(t *testing.T) {
+	roadmap := readRepoText(t, "TreeDB/docs/spec/native-query-raft-roadmap.md")
+	normalizedRoadmap := collapseWhitespace(roadmap)
+	for _, forbidden := range []string{
+		"CollectionWALRecoverable",
+		"physical/root-delta WAL as the active plan",
+	} {
+		if strings.Contains(roadmap, forbidden) {
+			t.Fatalf("native-query Raft roadmap still uses stale recoverability language %q", forbidden)
+		}
+	}
+	assertContainsAll(t, normalizedRoadmap, "R3a command-WAL roadmap boundary",
+		"The current R3a planning slice (#1654, with executable children #3037-#3043)",
+		"user-command WAL `CommandEnvelope` payload",
+		"selected local command-WAL/`AppliedLSN` recoverability boundary",
+		"local command-WAL frame, normal executor effects, and selected root/`AppliedLSN` boundary",
+	)
 }
 
 func TestRaftCommandEntryAndLocalCommandPayloadUseSharedCanonicalSchema(t *testing.T) {

--- a/TreeDB/docs/spec/native-query-raft-roadmap.md
+++ b/TreeDB/docs/spec/native-query-raft-roadmap.md
@@ -201,6 +201,14 @@ Acceptance:
 
 Add Raft around the deterministic write set only.
 
+The current R3a planning slice (#1654, with executable children #3037-#3043)
+is the local state-machine boundary before networked Raft is selected:
+committed deterministic `CommandEntryV1` bytes are decoded directly, validated
+against command digest/target/idempotency rules, lowered to the local
+user-command WAL `CommandEnvelope` payload, applied through the normal executor,
+and only then allowed to advance future apply-progress metadata according to the
+selected local command-WAL/`AppliedLSN` recoverability boundary.
+
 Replicate:
 
 - collection create/drop metadata,
@@ -233,9 +241,10 @@ Acceptance:
   `locally_recoverable`; client `raft_committed` success is not returned until
   the responding node satisfies the selected local apply durability rule,
 - persistent applied-index, idempotency-result, and catalog-guard outcome
-  metadata cannot advance past a collection mutation unless that mutation is
-  `CollectionWALRecoverable` locally, or a later stable-Raft replay design proves
-  the entry is replayed before serving;
+  metadata cannot advance past a collection mutation unless the corresponding
+  local command-WAL frame, normal executor effects, and selected
+  root/`AppliedLSN` boundary are recoverable locally, or a later stable-Raft
+  replay design proves the entry is replayed before serving;
 - the same committed entry sequence applied to fresh DBs in separate processes
   produces the same logical state digest,
 - snapshot restore plus log-tail replay produces the same logical state digest

--- a/TreeDB/docs/spec/user-command-wal.md
+++ b/TreeDB/docs/spec/user-command-wal.md
@@ -607,6 +607,15 @@ single-node local API lands before the native-wire surface, the native-wire
 schema added later must either adopt the local canonical bytes or explicitly
 record why a wrapper is required.
 
+For the R3a local apply harness tracked by #1654, the deterministic entry is not
+the local WAL record itself. The harness decodes committed `CommandEntryV1`
+bytes, validates digest, target, idempotency, and allowlist metadata, lowers
+supported entries to local `CommandEnvelope` payloads, appends/applies through
+the user-command WAL and normal executor, and advances future `ApplyProgress` or
+applied-index metadata only after the selected local recoverability boundary is
+satisfied. If the selected boundary is root-recoverable, that means roots and
+`AppliedLSN` have been published atomically.
+
 ## 12. Future Command Admission Policy
 
 Every PR that adds or broadens a mutating user-facing command must update the


### PR DESCRIPTION
## Objective

Align R3a-0 docs with the current user-command WAL / `AppliedLSN` model so future R3a implementation PRs do not inherit old collection-WAL recoverability language.

Closes #3037.
Part of #1654.

## Context

#1654 now links the executable R3a child issues #3037-#3043 and follow-on Raft planning trackers #3044-#3046. This PR keeps #1654 as the umbrella contract and updates the local docs surface for #3037 without touching runtime implementation code.

## Scope

Includes:
- `TreeDB/docs/spec/native-query-raft-roadmap.md`
- `TreeDB/docs/spec/user-command-wal.md`
- `TreeDB/docs/command_wal_nativewire_alignment_test.go`

Excludes:
- runtime code changes
- apply harness implementation
- deterministic entry/result/allowlist runtime contracts owned by #3038
- command-WAL apply API extraction owned by #3039
- JSON manifest changes

Runtime code changed: no.

## Design

- Names R3a as the local deterministic apply boundary before networked Raft selection.
- Replaces stale `CollectionWALRecoverable` wording with local command-WAL frame, normal executor effects, and selected root/`AppliedLSN` recoverability wording.
- Adds docs-test coverage requiring the R3a command-WAL/`CommandEnvelope`/`ApplyProgress` alignment text and rejecting the stale recoverability term in the Raft roadmap.

## Correctness

Tests run:
- `GOWORK=off go test ./TreeDB/docs -count=1`
- `git diff --check`

JSON manifests changed: no.

## Performance

Benchmarks run: not run.

Benchmark rationale: docs/test-only alignment. No runtime code, hot path, storage format, benchmark harness, or command-WAL execution code changed.

## Risks

- This PR intentionally does not update runtime contracts or implementation surfaces owned by #3038/#3039.
- Latest-head CI still needs to run on GitHub.

## Review Status

AI reviews were not requested. Per the graph instructions, review requests are left to the coordinator after the PR is mature enough for the full stack review loop.
