### PR TITLE
Record benchmark report M4 evidence

### DIFF
--- a/docs/benchmarks/full_benchmark_report_20260625.md
+++ b/docs/benchmarks/full_benchmark_report_20260625.md
@@ -8,8 +8,10 @@ June 24 artifact.
 ## Artifact
 
 - Report: `/tmp/gomap_m4_final_smoke_goworkoff_20260625_105430/deep_report.html`
+- Current-head rerender: `/tmp/gomap_m4_final_smoke_goworkoff_20260625_105430/deep_report_current_head.html`
 - Run root: `/tmp/gomap_m4_final_smoke_goworkoff_20260625_105430`
 - Commit: `0927decca6c846e1c9a42686cd2363f37b7fbeaf`
+- Current render commit: `fe7fa40b784941db94bc655474bb07366c093f51`
 - Branch: `codex/3031-final-report-evidence`
 - Go: `go version go1.25.7 linux/amd64`
 - Host: `Linux mikers-B560-DS3H-AC-Y1 6.8.0-124-generic x86_64`
@@ -20,6 +22,10 @@ Run status from the rendered report:
 ```text
 Complete run: all 20 recorded commands exited 0.
 ```
+
+The current-head rerender used the completed run root above and validated the
+same complete run status after the command-log parser stopped counting
+in-progress commands as successful.
 
 All required report sections were present: raw TreeDB engine, collections vs
 SQLite, Mongo API full sweep, Mongo client-mode load matrix, Mongo InsertMany

--- a/docs/benchmarks/full_benchmark_report_20260625.md
+++ b/docs/benchmarks/full_benchmark_report_20260625.md
@@ -11,7 +11,7 @@ June 24 artifact.
 - Current-head rerender: `/tmp/gomap_m4_final_smoke_goworkoff_20260625_105430/deep_report_current_head.html`
 - Run root: `/tmp/gomap_m4_final_smoke_goworkoff_20260625_105430`
 - Commit: `0927decca6c846e1c9a42686cd2363f37b7fbeaf`
-- Current render commit: `fe7fa40b784941db94bc655474bb07366c093f51`
+- Current render commit: `2fbd3987c459fd5b23ad3f7f3fd11717d9feb471`
 - Branch: `codex/3031-final-report-evidence`
 - Go: `go version go1.25.7 linux/amd64`
 - Host: `Linux mikers-B560-DS3H-AC-Y1 6.8.0-124-generic x86_64`
@@ -23,9 +23,9 @@ Run status from the rendered report:
 Complete run: all 20 recorded commands exited 0.
 ```
 
-The current-head rerender used the completed run root above and validated the
-same complete run status after the command-log parser stopped counting
-in-progress commands as successful.
+The current-head rerender used the completed run root above after this branch
+was retargeted through M3 and validated the same complete run status after the
+command-log parser stopped counting in-progress commands as successful.
 
 All required report sections were present: raw TreeDB engine, collections vs
 SQLite, Mongo API full sweep, Mongo client-mode load matrix, Mongo InsertMany

--- a/docs/benchmarks/full_benchmark_report_20260625.md
+++ b/docs/benchmarks/full_benchmark_report_20260625.md
@@ -1,0 +1,94 @@
+# TreeDB Benchmark Report Evidence, 2026-06-25
+
+This is the M4 closeout artifact for the benchmark-report graph in
+`snissn/gomap#3026`. It is a complete smoke-scale validation run for the report
+and harness changes, not a throughput-regression comparison against the larger
+June 24 artifact.
+
+## Artifact
+
+- Report: `/tmp/gomap_m4_final_smoke_goworkoff_20260625_105430/deep_report.html`
+- Run root: `/tmp/gomap_m4_final_smoke_goworkoff_20260625_105430`
+- Commit: `0927decca6c846e1c9a42686cd2363f37b7fbeaf`
+- Branch: `codex/3031-final-report-evidence`
+- Go: `go version go1.25.7 linux/amd64`
+- Host: `Linux mikers-B560-DS3H-AC-Y1 6.8.0-124-generic x86_64`
+- Mongo mode: Docker, image `mongo:8`
+
+Run status from the rendered report:
+
+```text
+Complete run: all 20 recorded commands exited 0.
+```
+
+All required report sections were present: raw TreeDB engine, collections vs
+SQLite, Mongo API full sweep, Mongo client-mode load matrix, Mongo InsertMany
+producer scaling, Mongo reader/writer scaling, and optional profile manifests.
+
+## Command
+
+```sh
+RUN_ROOT=/tmp/gomap_m4_final_smoke_goworkoff_20260625_105430
+GOWORK=off \
+MONGO_BATCH_SIZE=1000 \
+INSERT_PRODUCERS=8 \
+MONGO_READS=200 \
+MONGO_RANGE_READS=50 \
+MONGO_UPDATES=50 \
+MONGO_CONCURRENT_READS=200 \
+MONGO_CONCURRENT_WRITES=100 \
+MONGO_READERS=1,2 \
+MONGO_WRITERS=1,2 \
+scripts/treedb_benchmark_run_report.sh \
+  --out "$RUN_ROOT" \
+  --tier smoke \
+  --raw-keys 10000 \
+  --collection-docs 1000 \
+  --mongo-docs 32000 \
+  --mongo-load-docs 32000 \
+  --mongo-load-batch-size 1000 \
+  --mongo-load-producers "1,2,4,8,16,32" \
+  --indexes "0 1 2" \
+  --mongo-mode docker \
+  --mongo-image mongo:8 \
+  --timeout 10m \
+  --title "TreeDB Benchmark Report M4 Complete Smoke"
+```
+
+`GOWORK=off` is included because this local checkout's ambient `go.work`
+references a sibling module that requires a newer Go version than the workspace
+declares.
+
+## Fixed-Producer Index Count
+
+The full-sweep load chart used 32,000 documents, batch size 1,000, requested
+insert producers 8, effective producers 8, and 32 load batches. The run used
+`range_index=true`, so the 0-secondary-index row still maintained the additional
+range index during insert.
+
+| secondary indexes | TreeDB docs/sec | MongoDB docs/sec | TreeDB/MongoDB |
+| ---: | ---: | ---: | ---: |
+| 0 | 439,212 | 487,549 | 0.90x |
+| 1 | 323,459 | 294,195 | 1.10x |
+| 2 | 303,069 | 241,194 | 1.26x |
+
+## InsertMany Producer Scaling Peaks
+
+The producer-scaling sweep used 32,000 documents and batch size 1,000, so the
+1/2/4/8/16/32 producer rows all had enough load batches to avoid producer-count
+cap artifacts.
+
+| secondary indexes | TreeDB peak docs/sec | TreeDB producers | MongoDB peak docs/sec | MongoDB producers |
+| ---: | ---: | ---: | ---: | ---: |
+| 0 | 537,154 | 4 effective | 248,362 | 2 effective |
+| 1 | 438,909 | 4 effective | 350,992 | 8 effective |
+| 2 | 365,509 | 32 effective | 290,705 | 8 effective |
+
+## Notes
+
+- This artifact validates final report storytelling, metadata propagation,
+  load-scaling charts, index-retention tables, run-status visibility, and
+  profile-manifest rendering.
+- Treat throughput numbers as smoke-scale evidence only. The June 24 larger
+  artifact remains the scale comparison until a deliberate PR or large-tier run
+  is selected.


### PR DESCRIPTION
## Objective

Close M4 by recording a complete smoke-scale benchmark report artifact that validates the final report experience from #3026 after M0-M3 changes.

Linked parent: #3026
Linked child: #3031
Milestone/node: M4 final evidence closeout
Stack base: #3053 / `codex/3030-report-completeness`

## Context

The graph needs one current artifact showing the final report can render all sections together with run completeness status, load metadata, index-retention tables, producer-scaling charts, reader/writer scaling, and profile manifests.

## Non-goals

- Does not publish a large-tier throughput comparison.
- Does not claim a TreeDB throughput improvement versus the June 24 artifact, since workload size and commands differ.
- Does not change benchmark runtime code.

## Design

- Adds `docs/benchmarks/full_benchmark_report_20260625.md` with exact command, artifact path, commit, environment, run status, and headline smoke tables.
- The document explicitly frames the artifact as smoke-scale validation evidence.
- The successful command uses `GOWORK=off` because this local checkout's ambient `go.work` points at a sibling module requiring a newer Go version than the workspace declares.

## Scope

- Includes:
  - `docs/benchmarks/full_benchmark_report_20260625.md`
- Excludes:
  - code changes
  - benchmark harness changes
  - full/large benchmark publication

## Correctness

- Tests / commands run:
  - Complete smoke report command from the added doc.
  - `git diff --check`
- Smoke artifact:
  - `/tmp/gomap_m4_final_smoke_goworkoff_20260625_105430/deep_report.html`
- Rendered run status:
  - `Complete run: all 20 recorded commands exited 0.`
- Artifact sections present:
  - raw TreeDB engine
  - collections vs SQLite
  - Mongo API full sweep
  - Mongo client-mode load matrix
  - Mongo InsertMany producer scaling
  - Mongo reader/writer scaling
  - optional profile manifests

## Performance

- Benchmark evidence: smoke-scale validation only.
- Full-sweep shape: 32,000 docs, batch size 1,000, requested/effective insert producers 8, load batches 32, indexes 0/1/2.
- Producer-scaling shape: 32,000 docs, batch size 1,000, producers 1/2/4/8/16/32; all rows had enough batches to avoid producer caps.
- Regression assessment: documentation-only PR; no runtime code changed.

## Report Evidence

| Evidence | Result |
| --- | --- |
| Final smoke report | `/tmp/gomap_m4_final_smoke_goworkoff_20260625_105430/deep_report.html` |
| Run status | all 20 recorded commands exited 0 |
| Fixed-producer full sweep | TreeDB/MongoDB load ratio: 0.90x at 0 indexes, 1.10x at 1, 1.26x at 2 |
| Producer-scaling peaks | TreeDB peaks: 537k docs/s at 0 indexes, 439k at 1, 366k at 2 |
| Producer cap check | 32 load batches, requested producers through 32, effective producers through 32 |

## Rollout / Toggle Plan

- Default setting: docs-only evidence record.
- How to disable quickly: revert this docs commit if the artifact should not be published in repo docs.

## Follow-ups

- After M0-M4 merge, post the final evidence to #3026 and close the child issues.
- A deliberate PR/large-tier benchmark can replace this smoke artifact when the coordinator wants new publishable performance numbers.

## AI Review Loop

- Codex latest-head review: pending after mature PR head / CI starts.
- Copilot latest-head review: pending after mature PR head / CI starts if available.
- CodeRabbit latest-head review: pending after mature PR head / CI starts; may skip stacked base until retargeted to `main`.
- Review comments/threads resolved or explicitly dismissed: none yet.
- Re-requested after final meaningful push: pending if review feedback requires changes.
