### PR TITLE
TreeDB: add R3a command-WAL apply seam

### DIFF
--- a/TreeDB/db/command_wal_raw.go
+++ b/TreeDB/db/command_wal_raw.go
@@ -252,6 +252,9 @@ func (db *DB) NewCommandWALIntent(kind commitlog.CommandKind, scope commitlog.Co
 	if db == nil || !db.commandWAL {
 		return nil, nil
 	}
+	if db.readOnly {
+		return nil, ErrReadOnly
+	}
 	if db.durability == DurabilityWALOffRelaxed {
 		return nil, fmt.Errorf("%w: WAL-off durability is incompatible with command WAL", ErrCommandWALUnsupported)
 	}
@@ -563,6 +566,9 @@ func (db *DB) appendPublicCommandWALIntent(intent *CommandWALIntent, sync bool) 
 // publishing roots. It is used by cached public command-WAL writers that must
 // make a typed frame replay-visible before inserting the mutation into memory.
 func (db *DB) AppendCommandWALIntent(intent *CommandWALIntent, sync bool) (uint64, error) {
+	if db != nil && db.readOnly {
+		return 0, ErrReadOnly
+	}
 	return db.appendPublicCommandWALIntent(intent, sync)
 }
 
@@ -572,6 +578,9 @@ func (db *DB) AppendCommandWALIntent(intent *CommandWALIntent, sync bool) (uint6
 func (db *DB) AppendCommandWALPayload(kind commitlog.CommandKind, scope commitlog.CommandScope, payloadFormat commitlog.PayloadFormat, payload []byte, sync bool) (uint64, error) {
 	if db == nil || !db.commandWAL {
 		return 0, nil
+	}
+	if db.readOnly {
+		return 0, ErrReadOnly
 	}
 	if db.durability == DurabilityWALOffRelaxed {
 		return 0, fmt.Errorf("%w: WAL-off durability is incompatible with command WAL", ErrCommandWALUnsupported)
@@ -750,6 +759,9 @@ func (db *DB) PublishCommandWALNoop(intent *CommandWALIntent, sync bool) error {
 	}
 	if db == nil {
 		return ErrClosed
+	}
+	if db.readOnly {
+		return ErrReadOnly
 	}
 	if !db.CommandWALEnabled() {
 		return ErrCommandWALUnsupported

--- a/TreeDB/docs/command_wal_nativewire_alignment_test.go
+++ b/TreeDB/docs/command_wal_nativewire_alignment_test.go
@@ -185,11 +185,33 @@ func TestRaftApplyDoesNotReportRecoverableBeforeCommandWALAppliedLSN(t *testing.
 		"Native-wire and Raft alignment",
 		"must lower to a local command-WAL frame and satisfy the requested local ack boundary before reporting local recoverability",
 		"`raft_committed` is not local WAL append",
+		"For the R3a local apply harness tracked by #1654",
+		"lowers supported entries to local `CommandEnvelope` payloads",
+		"advances future `ApplyProgress` or applied-index metadata only after the selected local recoverability boundary is satisfied",
 	} {
 		if !strings.Contains(normalizedSpec, required) {
 			t.Fatalf("user-command WAL spec missing Raft/local recoverability rule: %q", required)
 		}
 	}
+}
+
+func TestRaftRoadmapUsesCommandWALRecoverabilityBoundary(t *testing.T) {
+	roadmap := readRepoText(t, "TreeDB/docs/spec/native-query-raft-roadmap.md")
+	normalizedRoadmap := collapseWhitespace(roadmap)
+	for _, forbidden := range []string{
+		"CollectionWALRecoverable",
+		"physical/root-delta WAL as the active plan",
+	} {
+		if strings.Contains(roadmap, forbidden) {
+			t.Fatalf("native-query Raft roadmap still uses stale recoverability language %q", forbidden)
+		}
+	}
+	assertContainsAll(t, normalizedRoadmap, "R3a command-WAL roadmap boundary",
+		"The current R3a planning slice (#1654, with executable children #3037-#3043)",
+		"user-command WAL `CommandEnvelope` payload",
+		"selected local command-WAL/`AppliedLSN` recoverability boundary",
+		"local command-WAL frame, normal executor effects, and selected root/`AppliedLSN` boundary",
+	)
 }
 
 func TestRaftCommandEntryAndLocalCommandPayloadUseSharedCanonicalSchema(t *testing.T) {

--- a/TreeDB/docs/spec/native-query-raft-roadmap.md
+++ b/TreeDB/docs/spec/native-query-raft-roadmap.md
@@ -201,6 +201,14 @@ Acceptance:
 
 Add Raft around the deterministic write set only.
 
+The current R3a planning slice (#1654, with executable children #3037-#3043)
+is the local state-machine boundary before networked Raft is selected:
+committed deterministic `CommandEntryV1` bytes are decoded directly, validated
+against command digest/target/idempotency rules, lowered to the local
+user-command WAL `CommandEnvelope` payload, applied through the normal executor,
+and only then allowed to advance future apply-progress metadata according to the
+selected local command-WAL/`AppliedLSN` recoverability boundary.
+
 Replicate:
 
 - collection create/drop metadata,
@@ -233,9 +241,10 @@ Acceptance:
   `locally_recoverable`; client `raft_committed` success is not returned until
   the responding node satisfies the selected local apply durability rule,
 - persistent applied-index, idempotency-result, and catalog-guard outcome
-  metadata cannot advance past a collection mutation unless that mutation is
-  `CollectionWALRecoverable` locally, or a later stable-Raft replay design proves
-  the entry is replayed before serving;
+  metadata cannot advance past a collection mutation unless the corresponding
+  local command-WAL frame, normal executor effects, and selected
+  root/`AppliedLSN` boundary are recoverable locally, or a later stable-Raft
+  replay design proves the entry is replayed before serving;
 - the same committed entry sequence applied to fresh DBs in separate processes
   produces the same logical state digest,
 - snapshot restore plus log-tail replay produces the same logical state digest

--- a/TreeDB/docs/spec/user-command-wal.md
+++ b/TreeDB/docs/spec/user-command-wal.md
@@ -607,6 +607,15 @@ single-node local API lands before the native-wire surface, the native-wire
 schema added later must either adopt the local canonical bytes or explicitly
 record why a wrapper is required.
 
+For the R3a local apply harness tracked by #1654, the deterministic entry is not
+the local WAL record itself. The harness decodes committed `CommandEntryV1`
+bytes, validates digest, target, idempotency, and allowlist metadata, lowers
+supported entries to local `CommandEnvelope` payloads, appends/applies through
+the user-command WAL and normal executor, and advances future `ApplyProgress` or
+applied-index metadata only after the selected local recoverability boundary is
+satisfied. If the selected boundary is root-recoverable, that means roots and
+`AppliedLSN` have been published atomically.
+
 ## 12. Future Command Admission Policy
 
 Every PR that adds or broadens a mutating user-facing command must update the

--- a/TreeDB/internal/commandwalapply/apply.go
+++ b/TreeDB/internal/commandwalapply/apply.go
@@ -1,0 +1,181 @@
+// Package commandwalapply exposes the narrow internal boundary between future
+// R3a deterministic-entry lowering and TreeDB's local command WAL.
+package commandwalapply
+
+import (
+	"fmt"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+	"github.com/snissn/gomap/TreeDB/internal/commitlog"
+)
+
+// RecoverabilityStatus names the local recovery boundary reached by an apply
+// step. These are local TreeDB states, not Raft consensus states.
+type RecoverabilityStatus string
+
+const (
+	StatusLocallyApplied         RecoverabilityStatus = "locally_applied"
+	StatusLocallyWALRecoverable  RecoverabilityStatus = "locally_wal_recoverable"
+	StatusLocallyRootRecoverable RecoverabilityStatus = "locally_root_recoverable"
+)
+
+// LoweredFrameClass identifies which already-classified lowering path produced
+// a frame. This spike accepts only the scoped no-op class so it cannot widen the
+// replicated command set ahead of the R3a contract and harness PRs.
+type LoweredFrameClass uint8
+
+const (
+	LoweredFrameClassTestNoop LoweredFrameClass = iota + 1
+)
+
+// ApplyMetadata is the explicit metadata slot future R3a apply code will carry
+// beside a lowered frame. It is intentionally empty here; this package must not
+// define #3038's entry/result/idempotency contract or #3040's apply metadata.
+type ApplyMetadata struct{}
+
+// LoweredFrame is the command-WAL payload produced after deterministic-entry
+// classification and lowering. It is not a native-wire request and does not
+// encode a Raft log entry.
+type LoweredFrame struct {
+	Class         LoweredFrameClass
+	Kind          commitlog.CommandKind
+	Scope         commitlog.CommandScope
+	PayloadFormat commitlog.PayloadFormat
+	Payload       []byte
+}
+
+// Options controls local command-WAL durability for this apply boundary.
+type Options struct {
+	Sync bool
+}
+
+// Handle is the append token required to publish the same local command-WAL
+// frame after the normal executor has made the command locally visible.
+type Handle struct {
+	intent *backenddb.CommandWALIntent
+	lsn    uint64
+}
+
+// LSN returns the local command-WAL sequence number assigned at append time.
+func (h Handle) LSN() uint64 {
+	return h.lsn
+}
+
+// Result describes the local apply/recoverability boundary reached.
+type Result struct {
+	LSN               uint64
+	Status            RecoverabilityStatus
+	AppliedCommandLSN uint64
+}
+
+// TestNoopFrame returns the only frame class accepted by this issue's spike: a
+// canonical empty RawKVBatch command. It exercises append/finalize without
+// accepting user mutations or bypassing collection/catalog executors.
+func TestNoopFrame() (LoweredFrame, error) {
+	payload, err := commitlog.EncodeRawKVBatchPayload(nil)
+	if err != nil {
+		return LoweredFrame{}, err
+	}
+	return LoweredFrame{
+		Class:         LoweredFrameClassTestNoop,
+		Kind:          commitlog.CommandKindRawKVBatch,
+		Scope:         commitlog.CommandScopeRawKV,
+		PayloadFormat: commitlog.PayloadFormatRawKVBatchV1,
+		Payload:       payload,
+	}, nil
+}
+
+// Append validates and appends a lowered local command-WAL frame. It does not
+// publish roots or AppliedCommandLSN; callers must run the normal executor and
+// then call Finalize with the returned handle.
+func Append(db *backenddb.DB, frame LoweredFrame, _ ApplyMetadata, opts Options) (Handle, Result, error) {
+	if db == nil {
+		return Handle{}, Result{}, backenddb.ErrClosed
+	}
+	if !db.CommandWALEnabled() {
+		return Handle{}, Result{}, fmt.Errorf("%w: command wal apply requires command_wal_v1", backenddb.ErrCommandWALUnsupported)
+	}
+	if err := validateLoweredFrame(frame); err != nil {
+		return Handle{}, Result{}, err
+	}
+	intent, err := db.NewCommandWALIntent(frame.Kind, frame.Scope, frame.PayloadFormat, frame.Payload)
+	if err != nil {
+		return Handle{}, Result{}, err
+	}
+	if intent == nil {
+		return Handle{}, Result{}, fmt.Errorf("%w: command wal apply intent unavailable", backenddb.ErrCommandWALUnsupported)
+	}
+	lsn, err := db.AppendCommandWALIntent(intent, opts.Sync)
+	if err != nil {
+		return Handle{}, Result{}, err
+	}
+	applied := uint64(0)
+	if state := db.State(); state != nil {
+		applied = state.AppliedCommandLSN
+	}
+	return Handle{intent: intent, lsn: lsn}, Result{
+		LSN:               lsn,
+		Status:            StatusLocallyWALRecoverable,
+		AppliedCommandLSN: applied,
+	}, nil
+}
+
+// Finalize publishes the current roots with AppliedCommandLSN covering the
+// command frame represented by handle. The no-op frame used by this spike has no
+// mutation effects, but the publish path is the same root/AppliedLSN boundary
+// future executor-backed commands must use.
+func Finalize(db *backenddb.DB, handle Handle, _ ApplyMetadata, opts Options) (Result, error) {
+	if db == nil {
+		return Result{}, backenddb.ErrClosed
+	}
+	if handle.intent == nil || handle.lsn == 0 {
+		return Result{}, fmt.Errorf("%w: command wal apply finalize missing appended frame", backenddb.ErrCommandWALRejected)
+	}
+	if err := db.PublishCommandWALNoop(handle.intent, opts.Sync); err != nil {
+		return Result{}, err
+	}
+	applied := uint64(0)
+	if state := db.State(); state != nil {
+		applied = state.AppliedCommandLSN
+	}
+	return Result{
+		LSN:               handle.lsn,
+		Status:            StatusLocallyRootRecoverable,
+		AppliedCommandLSN: applied,
+	}, nil
+}
+
+// ApplyNoop appends and finalizes the scoped no-op frame. It exists only to
+// test the boundary end-to-end without adding accepted replicated commands.
+func ApplyNoop(db *backenddb.DB, frame LoweredFrame, meta ApplyMetadata, opts Options) (Result, error) {
+	handle, _, err := Append(db, frame, meta, opts)
+	if err != nil {
+		return Result{}, err
+	}
+	return Finalize(db, handle, meta, opts)
+}
+
+func validateLoweredFrame(frame LoweredFrame) error {
+	switch frame.Class {
+	case LoweredFrameClassTestNoop:
+		return validateTestNoopFrame(frame)
+	default:
+		return fmt.Errorf("%w: command wal apply frame class %d is not accepted", backenddb.ErrCommandWALUnsupported, frame.Class)
+	}
+}
+
+func validateTestNoopFrame(frame LoweredFrame) error {
+	if frame.Kind != commitlog.CommandKindRawKVBatch ||
+		frame.Scope != commitlog.CommandScopeRawKV ||
+		frame.PayloadFormat != commitlog.PayloadFormatRawKVBatchV1 {
+		return fmt.Errorf("%w: command wal apply test frame has unsupported identity kind=%d scope=%d format=%d", backenddb.ErrCommandWALUnsupported, frame.Kind, frame.Scope, frame.PayloadFormat)
+	}
+	ops, err := commitlog.DecodeRawKVBatchPayload(frame.Payload)
+	if err != nil {
+		return fmt.Errorf("%w: malformed command wal apply test frame: %v", backenddb.ErrCommandWALRejected, err)
+	}
+	if len(ops) != 0 {
+		return fmt.Errorf("%w: command wal apply test frame must be an empty RawKVBatch", backenddb.ErrCommandWALUnsupported)
+	}
+	return nil
+}

--- a/TreeDB/internal/commandwalapply/apply_test.go
+++ b/TreeDB/internal/commandwalapply/apply_test.go
@@ -1,0 +1,304 @@
+package commandwalapply
+
+import (
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+	"github.com/snissn/gomap/TreeDB/internal/commitlog"
+)
+
+func TestRecoverabilityStatusNames(t *testing.T) {
+	if StatusLocallyApplied != "locally_applied" {
+		t.Fatalf("StatusLocallyApplied=%q", StatusLocallyApplied)
+	}
+	if StatusLocallyWALRecoverable != "locally_wal_recoverable" {
+		t.Fatalf("StatusLocallyWALRecoverable=%q", StatusLocallyWALRecoverable)
+	}
+	if StatusLocallyRootRecoverable != "locally_root_recoverable" {
+		t.Fatalf("StatusLocallyRootRecoverable=%q", StatusLocallyRootRecoverable)
+	}
+}
+
+func TestAppendAndFinalizeNoopFrame(t *testing.T) {
+	dir := t.TempDir()
+	db, err := backenddb.Open(backenddb.Options{
+		Dir:                          dir,
+		CommandWAL:                   true,
+		DisableBackgroundPrune:       true,
+		CommandWALStatsScan:          true,
+		CommandWALSegmentTargetBytes: 1 << 20,
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+
+	frame, err := TestNoopFrame()
+	if err != nil {
+		_ = db.Close()
+		t.Fatalf("TestNoopFrame: %v", err)
+	}
+	handle, appendResult, err := Append(db, frame, ApplyMetadata{}, Options{})
+	if err != nil {
+		_ = db.Close()
+		t.Fatalf("Append: %v", err)
+	}
+	if appendResult.Status != StatusLocallyWALRecoverable {
+		_ = db.Close()
+		t.Fatalf("append status=%q, want %q", appendResult.Status, StatusLocallyWALRecoverable)
+	}
+	if appendResult.LSN == 0 || handle.LSN() != appendResult.LSN {
+		_ = db.Close()
+		t.Fatalf("append lsn=%d handle=%d, want non-zero match", appendResult.LSN, handle.LSN())
+	}
+	if appendResult.AppliedCommandLSN != 0 || db.State().AppliedCommandLSN != 0 {
+		_ = db.Close()
+		t.Fatalf("AppliedCommandLSN after append result=%d state=%d, want 0", appendResult.AppliedCommandLSN, db.State().AppliedCommandLSN)
+	}
+	frames := readCommandWALFrames(t, dir)
+	if len(frames) != 1 {
+		_ = db.Close()
+		t.Fatalf("command WAL frames after append=%d, want 1", len(frames))
+	}
+	assertNoopFrame(t, frames[0], appendResult.LSN)
+
+	finalResult, err := Finalize(db, handle, ApplyMetadata{}, Options{})
+	if err != nil {
+		_ = db.Close()
+		t.Fatalf("Finalize: %v", err)
+	}
+	if finalResult.Status != StatusLocallyRootRecoverable {
+		_ = db.Close()
+		t.Fatalf("final status=%q, want %q", finalResult.Status, StatusLocallyRootRecoverable)
+	}
+	if finalResult.LSN != appendResult.LSN || finalResult.AppliedCommandLSN != appendResult.LSN {
+		_ = db.Close()
+		t.Fatalf("final result=%+v, want lsn and applied %d", finalResult, appendResult.LSN)
+	}
+	if got := len(readCommandWALFrames(t, dir)); got != 1 {
+		_ = db.Close()
+		t.Fatalf("command WAL frames after finalize=%d, want no duplicate append", got)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	ro, err := backenddb.Open(backenddb.Options{Dir: dir, ReadOnly: true, CommandWAL: true})
+	if err != nil {
+		t.Fatalf("read-only reopen after finalize: %v", err)
+	}
+	if got := ro.State().AppliedCommandLSN; got != appendResult.LSN {
+		_ = ro.Close()
+		t.Fatalf("reopen AppliedCommandLSN=%d, want %d", got, appendResult.LSN)
+	}
+	if err := ro.Close(); err != nil {
+		t.Fatalf("Close read-only: %v", err)
+	}
+}
+
+func TestRejectedInputFailsBeforeAppend(t *testing.T) {
+	dir := t.TempDir()
+	db, err := backenddb.Open(backenddb.Options{Dir: dir, CommandWAL: true, DisableBackgroundPrune: true})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	frame, err := TestNoopFrame()
+	if err != nil {
+		t.Fatalf("TestNoopFrame: %v", err)
+	}
+	nonEmptyPayload, err := commitlog.EncodeRawKVBatchPayload([]commitlog.RawKVOperation{{
+		Op:    commitlog.RawKVOpSet,
+		Key:   []byte("k"),
+		Value: []byte("v"),
+	}})
+	if err != nil {
+		t.Fatalf("EncodeRawKVBatchPayload: %v", err)
+	}
+	tests := []struct {
+		name    string
+		frame   LoweredFrame
+		wantErr error
+		wantMsg string
+	}{
+		{
+			name: "unsupported class",
+			frame: LoweredFrame{
+				Class:         0,
+				Kind:          commitlog.CommandKindRawKVBatch,
+				Scope:         commitlog.CommandScopeRawKV,
+				PayloadFormat: commitlog.PayloadFormatRawKVBatchV1,
+				Payload:       frame.Payload,
+			},
+			wantErr: backenddb.ErrCommandWALUnsupported,
+			wantMsg: "not accepted",
+		},
+		{
+			name: "unsupported identity",
+			frame: LoweredFrame{
+				Class:         LoweredFrameClassTestNoop,
+				Kind:          commitlog.CommandKindCollectionInsertBatchByID,
+				Scope:         commitlog.CommandScopeCollection,
+				PayloadFormat: commitlog.PayloadFormatCollectionInsertBatchByIDV1,
+				Payload:       frame.Payload,
+			},
+			wantErr: backenddb.ErrCommandWALUnsupported,
+			wantMsg: "unsupported identity",
+		},
+		{
+			name: "malformed payload",
+			frame: LoweredFrame{
+				Class:         LoweredFrameClassTestNoop,
+				Kind:          commitlog.CommandKindRawKVBatch,
+				Scope:         commitlog.CommandScopeRawKV,
+				PayloadFormat: commitlog.PayloadFormatRawKVBatchV1,
+				Payload:       []byte{0x01},
+			},
+			wantErr: backenddb.ErrCommandWALRejected,
+			wantMsg: "malformed",
+		},
+		{
+			name: "non empty raw kv payload",
+			frame: LoweredFrame{
+				Class:         LoweredFrameClassTestNoop,
+				Kind:          commitlog.CommandKindRawKVBatch,
+				Scope:         commitlog.CommandScopeRawKV,
+				PayloadFormat: commitlog.PayloadFormatRawKVBatchV1,
+				Payload:       nonEmptyPayload,
+			},
+			wantErr: backenddb.ErrCommandWALUnsupported,
+			wantMsg: "empty RawKVBatch",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			before := len(readCommandWALFrames(t, dir))
+			_, _, err := Append(db, tt.frame, ApplyMetadata{}, Options{})
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("Append error=%v, want %v", err, tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantMsg) {
+				t.Fatalf("Append error=%v, want message containing %q", err, tt.wantMsg)
+			}
+			after := len(readCommandWALFrames(t, dir))
+			if after != before {
+				t.Fatalf("command WAL frames after rejected input=%d, want %d", after, before)
+			}
+		})
+	}
+}
+
+func TestApplyRejectsReadOnlyDB(t *testing.T) {
+	dir := t.TempDir()
+	db, err := backenddb.Open(backenddb.Options{Dir: dir, CommandWAL: true, DisableBackgroundPrune: true})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	ro, err := backenddb.Open(backenddb.Options{Dir: dir, ReadOnly: true, CommandWAL: true})
+	if err != nil {
+		t.Fatalf("Open read-only: %v", err)
+	}
+	defer func() { _ = ro.Close() }()
+	frame, err := TestNoopFrame()
+	if err != nil {
+		t.Fatalf("TestNoopFrame: %v", err)
+	}
+	if _, _, err := Append(ro, frame, ApplyMetadata{}, Options{}); !errors.Is(err, backenddb.ErrReadOnly) {
+		t.Fatalf("Append read-only error=%v, want ErrReadOnly", err)
+	}
+	if got := len(readCommandWALFrames(t, dir)); got != 0 {
+		t.Fatalf("command WAL frames after read-only apply=%d, want 0", got)
+	}
+}
+
+func TestApplyRejectsCommandWALDisabledDB(t *testing.T) {
+	dir := t.TempDir()
+	db, err := backenddb.Open(backenddb.Options{
+		Dir:                    dir,
+		Durability:             backenddb.DurabilityWALOffRelaxed,
+		DisableBackgroundPrune: true,
+	})
+	if err != nil {
+		t.Fatalf("Open WAL-off DB: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	frame, err := TestNoopFrame()
+	if err != nil {
+		t.Fatalf("TestNoopFrame: %v", err)
+	}
+	if _, _, err := Append(db, frame, ApplyMetadata{}, Options{}); !errors.Is(err, backenddb.ErrCommandWALUnsupported) {
+		t.Fatalf("Append command-WAL-disabled error=%v, want ErrCommandWALUnsupported", err)
+	}
+	if got := len(readCommandWALFrames(t, dir)); got != 0 {
+		t.Fatalf("command WAL frames after disabled apply=%d, want 0", got)
+	}
+}
+
+func readCommandWALFrames(t *testing.T, dir string) []commitlog.CommandEnvelope {
+	t.Helper()
+	walDir := backenddb.WALDirPath(dir)
+	entries, err := os.ReadDir(walDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		t.Fatalf("ReadDir %s: %v", walDir, err)
+	}
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if !entry.IsDir() && commitlog.IsCommandSegmentName(entry.Name()) {
+			names = append(names, entry.Name())
+		}
+	}
+	sort.Strings(names)
+	var frames []commitlog.CommandEnvelope
+	for _, name := range names {
+		path := filepath.Join(walDir, name)
+		r, err := commitlog.NewReader(path)
+		if err != nil {
+			t.Fatalf("NewReader %s: %v", name, err)
+		}
+		for {
+			env, err := r.ReadCommandFrame()
+			if err != nil {
+				if errors.Is(err, io.EOF) {
+					break
+				}
+				_ = r.Close()
+				t.Fatalf("ReadCommandFrame %s: %v", name, err)
+			}
+			frames = append(frames, env)
+		}
+		if err := r.Close(); err != nil {
+			t.Fatalf("Close reader %s: %v", name, err)
+		}
+	}
+	return frames
+}
+
+func assertNoopFrame(t *testing.T, env commitlog.CommandEnvelope, wantLSN uint64) {
+	t.Helper()
+	if env.LSN != wantLSN ||
+		env.Kind != commitlog.CommandKindRawKVBatch ||
+		env.Scope != commitlog.CommandScopeRawKV ||
+		env.PayloadFormat != commitlog.PayloadFormatRawKVBatchV1 {
+		t.Fatalf("noop frame identity=%+v, want lsn=%d RawKVBatch/RawKV/V1", env, wantLSN)
+	}
+	ops, err := commitlog.DecodeRawKVBatchPayload(env.Payload)
+	if err != nil {
+		t.Fatalf("DecodeRawKVBatchPayload: %v", err)
+	}
+	if len(ops) != 0 {
+		t.Fatalf("noop frame ops=%+v, want empty", ops)
+	}
+}


### PR DESCRIPTION
## Summary
- add internal `TreeDB/internal/commandwalapply` seam for already-lowered command-WAL frames with explicit local recoverability statuses: `locally_applied`, `locally_wal_recoverable`, and `locally_root_recoverable`
- accept only a scoped empty RawKV no-op test frame in this PR, so the seam can prove append/finalize behavior without widening replicated command support
- reject unsupported/malformed input before command-WAL append and return explicit read-only errors from low-level command-WAL intent/publish helpers

## Scope / Links
Fixes #3039
Part of #1654

This PR owns only the local command-WAL apply seam. It does not define #3038's deterministic entry/result/allowlist contract, does not build #3040's apply harness, and does not accept create/insert/update/delete replicated entries.

## Tests
- `GOWORK=off go test ./TreeDB/internal/commandwalapply`
- `GOWORK=off go test ./TreeDB/db -run 'CommandWAL|ReadOnly'`
- `GOWORK=off go test ./TreeDB/collections -run 'CommandWAL|ColumnStore.*CommandWAL'`
- `GOWORK=off go test ./TreeDB/nativewire -run 'CommandWAL|Mutation|Metadata'`
- `GOWORK=off go test ./TreeDB/mongo_gateway/... -run 'CommandWAL|Mutation|Insert|Update|Delete'`
- `git diff --check`

## Benchmarks
No benchmark run. This is an internal API extraction/spike: no production write path calls the new package, and the only accepted frame is an empty scoped test no-op. Focused tests prove no accepted mutation widening and no frame append on malformed/unsupported/read-only inputs.

## Risks / Non-goals
- Future accepted mutation classes still need executor-specific integration so create/insert/update/delete entries go through normal TreeDB catalog/collection executors before finalize.
- The explicit metadata slot is intentionally empty here; #3038/#3040 must define and consume the actual deterministic entry/result/apply metadata.
- This does not implement networked Raft or replay native-wire request handlers.
