### PR TITLE
TreeDB: add R3a command entry contracts

### DIFF
--- a/TreeDB/docs/command_wal_nativewire_alignment_test.go
+++ b/TreeDB/docs/command_wal_nativewire_alignment_test.go
@@ -185,11 +185,33 @@ func TestRaftApplyDoesNotReportRecoverableBeforeCommandWALAppliedLSN(t *testing.
 		"Native-wire and Raft alignment",
 		"must lower to a local command-WAL frame and satisfy the requested local ack boundary before reporting local recoverability",
 		"`raft_committed` is not local WAL append",
+		"For the R3a local apply harness tracked by #1654",
+		"lowers supported entries to local `CommandEnvelope` payloads",
+		"advances future `ApplyProgress` or applied-index metadata only after the selected local recoverability boundary is satisfied",
 	} {
 		if !strings.Contains(normalizedSpec, required) {
 			t.Fatalf("user-command WAL spec missing Raft/local recoverability rule: %q", required)
 		}
 	}
+}
+
+func TestRaftRoadmapUsesCommandWALRecoverabilityBoundary(t *testing.T) {
+	roadmap := readRepoText(t, "TreeDB/docs/spec/native-query-raft-roadmap.md")
+	normalizedRoadmap := collapseWhitespace(roadmap)
+	for _, forbidden := range []string{
+		"CollectionWALRecoverable",
+		"physical/root-delta WAL as the active plan",
+	} {
+		if strings.Contains(roadmap, forbidden) {
+			t.Fatalf("native-query Raft roadmap still uses stale recoverability language %q", forbidden)
+		}
+	}
+	assertContainsAll(t, normalizedRoadmap, "R3a command-WAL roadmap boundary",
+		"The current R3a planning slice (#1654, with executable children #3037-#3043)",
+		"user-command WAL `CommandEnvelope` payload",
+		"selected local command-WAL/`AppliedLSN` recoverability boundary",
+		"local command-WAL frame, normal executor effects, and selected root/`AppliedLSN` boundary",
+	)
 }
 
 func TestRaftCommandEntryAndLocalCommandPayloadUseSharedCanonicalSchema(t *testing.T) {

--- a/TreeDB/docs/spec/native-query-raft-roadmap.md
+++ b/TreeDB/docs/spec/native-query-raft-roadmap.md
@@ -201,6 +201,14 @@ Acceptance:
 
 Add Raft around the deterministic write set only.
 
+The current R3a planning slice (#1654, with executable children #3037-#3043)
+is the local state-machine boundary before networked Raft is selected:
+committed deterministic `CommandEntryV1` bytes are decoded directly, validated
+against command digest/target/idempotency rules, lowered to the local
+user-command WAL `CommandEnvelope` payload, applied through the normal executor,
+and only then allowed to advance future apply-progress metadata according to the
+selected local command-WAL/`AppliedLSN` recoverability boundary.
+
 Replicate:
 
 - collection create/drop metadata,
@@ -233,9 +241,10 @@ Acceptance:
   `locally_recoverable`; client `raft_committed` success is not returned until
   the responding node satisfies the selected local apply durability rule,
 - persistent applied-index, idempotency-result, and catalog-guard outcome
-  metadata cannot advance past a collection mutation unless that mutation is
-  `CollectionWALRecoverable` locally, or a later stable-Raft replay design proves
-  the entry is replayed before serving;
+  metadata cannot advance past a collection mutation unless the corresponding
+  local command-WAL frame, normal executor effects, and selected
+  root/`AppliedLSN` boundary are recoverable locally, or a later stable-Raft
+  replay design proves the entry is replayed before serving;
 - the same committed entry sequence applied to fresh DBs in separate processes
   produces the same logical state digest,
 - snapshot restore plus log-tail replay produces the same logical state digest

--- a/TreeDB/docs/spec/user-command-wal.md
+++ b/TreeDB/docs/spec/user-command-wal.md
@@ -607,6 +607,15 @@ single-node local API lands before the native-wire surface, the native-wire
 schema added later must either adopt the local canonical bytes or explicitly
 record why a wrapper is required.
 
+For the R3a local apply harness tracked by #1654, the deterministic entry is not
+the local WAL record itself. The harness decodes committed `CommandEntryV1`
+bytes, validates digest, target, idempotency, and allowlist metadata, lowers
+supported entries to local `CommandEnvelope` payloads, appends/applies through
+the user-command WAL and normal executor, and advances future `ApplyProgress` or
+applied-index metadata only after the selected local recoverability boundary is
+satisfied. If the selected boundary is root-recoverable, that means roots and
+`AppliedLSN` have been published atomically.
+
 ## 12. Future Command Admission Policy
 
 Every PR that adds or broadens a mutating user-facing command must update the

--- a/TreeDB/internal/raftentry/contract.go
+++ b/TreeDB/internal/raftentry/contract.go
@@ -1,0 +1,359 @@
+package raftentry
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"errors"
+	"fmt"
+
+	"github.com/snissn/gomap/TreeDB/internal/nativewire"
+)
+
+const (
+	EntryVersionV1 = uint64(1)
+
+	// ScopeRuleSingleGroupV1 is a schema-versioned single-group rule. It is
+	// covered by CommandDigestV1 even though it is not re-encoded inside the
+	// native-wire deterministic entry bytes.
+	ScopeRuleSingleGroupV1 ScopeRuleV1 = "single-group-v1"
+
+	DatabaseScopeDefaultV1 = "database/default"
+	CatalogScopeDefaultV1  = "catalog/default"
+
+	NoIdempotencyTokenV1 = "NoIdempotencyV1"
+
+	MaxIdempotencyKeyBytesV1 = 1024
+	MaxResultRecordBytesV1   = 64 << 10
+	MaxProgressRecordsV1     = 1 << 20
+)
+
+const digestDomainV1 = "TreeDB/R3a/CommandDigestV1\x00"
+
+type ScopeRuleV1 string
+
+type ApplyEntryID struct {
+	Term  uint64
+	Index uint64
+}
+
+type RequestMetadataV1 struct {
+	RequestID         uint64
+	AckPolicy         nativewire.AckPolicy
+	DeadlineUnixNanos int64
+	TraceContext      []byte
+	Compression       string
+	OmitResultIDs     bool
+	OmitResponseMeta  bool
+}
+
+type CommandDigestV1 [32]byte
+
+func (d CommandDigestV1) Hex() string {
+	return hex.EncodeToString(d[:])
+}
+
+type IdempotencyModeV1 string
+
+const (
+	IdempotencyRequiredV1 IdempotencyModeV1 = "required-idempotency-key-v1"
+	NoIdempotencyV1       IdempotencyModeV1 = "no-idempotency-v1"
+)
+
+type ApplyStatusV1 string
+
+const (
+	ApplyStatusApplied                   ApplyStatusV1 = "applied"
+	ApplyStatusAlreadyApplied            ApplyStatusV1 = "already-applied"
+	ApplyStatusDeterministicGuardFailure ApplyStatusV1 = "deterministic-guard-failure"
+	ApplyStatusRejectedUnsupported       ApplyStatusV1 = "rejected-unsupported"
+	ApplyStatusRejectedMalformed         ApplyStatusV1 = "rejected-malformed"
+	ApplyStatusRejectedConflict          ApplyStatusV1 = "rejected-conflict"
+	ApplyStatusRecoveryRequired          ApplyStatusV1 = "recovery-required"
+)
+
+type DeterministicErrorCodeV1 string
+
+const (
+	ErrorNoneV1                 DeterministicErrorCodeV1 = ""
+	ErrorUnsupportedCommandV1   DeterministicErrorCodeV1 = "unsupported-command"
+	ErrorMalformedEntryV1       DeterministicErrorCodeV1 = "malformed-entry"
+	ErrorUnsupportedVersionV1   DeterministicErrorCodeV1 = "unsupported-version"
+	ErrorUnsupportedFeatureV1   DeterministicErrorCodeV1 = "unsupported-feature"
+	ErrorMissingGuardV1         DeterministicErrorCodeV1 = "missing-guard"
+	ErrorTargetMismatchV1       DeterministicErrorCodeV1 = "target-mismatch"
+	ErrorRejectedConflictV1     DeterministicErrorCodeV1 = "rejected-conflict"
+	ErrorReadOnlyV1             DeterministicErrorCodeV1 = "read-only"
+	ErrorUnsafeDurabilityModeV1 DeterministicErrorCodeV1 = "unsafe-durability-mode"
+	ErrorResourceExhaustedV1    DeterministicErrorCodeV1 = "resource-exhausted"
+	ErrorNoIdempotencyV1        DeterministicErrorCodeV1 = "no-idempotency"
+	ErrorResultReplayRequiredV1 DeterministicErrorCodeV1 = "result-replay-required"
+	ErrorUnknownRequiredFieldV1 DeterministicErrorCodeV1 = "unknown-required-field"
+	ErrorUnsupportedScopeRuleV1 DeterministicErrorCodeV1 = "unsupported-scope-rule"
+)
+
+type ApplyResultV1 struct {
+	Status                 ApplyStatusV1
+	CommandDigest          CommandDigestV1
+	DeterministicErrorCode DeterministicErrorCodeV1
+	AffectedCount          int64
+	ResultDigest           CommandDigestV1
+}
+
+type TargetIdentityV1 struct {
+	ScopeRule              ScopeRuleV1
+	DatabaseScope          string
+	CatalogScope           string
+	CommandID              nativewire.CommandID
+	CommandVersion         uint64
+	CollectionRef          []byte
+	CollectionMeta         []byte
+	ExpectedCatalogVersion []byte
+}
+
+func (t TargetIdentityV1) Equal(u TargetIdentityV1) bool {
+	return t.ScopeRule == u.ScopeRule &&
+		t.DatabaseScope == u.DatabaseScope &&
+		t.CatalogScope == u.CatalogScope &&
+		t.CommandID == u.CommandID &&
+		t.CommandVersion == u.CommandVersion &&
+		bytes.Equal(t.CollectionRef, u.CollectionRef) &&
+		bytes.Equal(t.CollectionMeta, u.CollectionMeta) &&
+		bytes.Equal(t.ExpectedCatalogVersion, u.ExpectedCatalogVersion)
+}
+
+func (t TargetIdentityV1) Clone() TargetIdentityV1 {
+	t.CollectionRef = bytes.Clone(t.CollectionRef)
+	t.CollectionMeta = bytes.Clone(t.CollectionMeta)
+	t.ExpectedCatalogVersion = bytes.Clone(t.ExpectedCatalogVersion)
+	return t
+}
+
+type DecodeOptions struct {
+	Limits          nativewire.Limits
+	ScopeRule       ScopeRuleV1
+	DatabaseScope   string
+	CatalogScope    string
+	ApplyEntryID    ApplyEntryID
+	RequestMetadata RequestMetadataV1
+	ExpectedTarget  *TargetIdentityV1
+}
+
+type CommandEntryV1 struct {
+	Bytes          []byte
+	Decoded        nativewire.DeterministicEntry
+	Digest         CommandDigestV1
+	Target         TargetIdentityV1
+	IdempotencyKey []byte
+	Idempotency    IdempotencyModeV1
+	Row            CommandRowV1
+}
+
+type ValidationError struct {
+	Code DeterministicErrorCodeV1
+	Err  error
+}
+
+func (e *ValidationError) Error() string {
+	if e == nil {
+		return "raftentry: <nil>"
+	}
+	if e.Err == nil {
+		return fmt.Sprintf("raftentry: %s", e.Code)
+	}
+	return fmt.Sprintf("raftentry: %s: %v", e.Code, e.Err)
+}
+
+func (e *ValidationError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+func ErrorCodeOf(err error) (DeterministicErrorCodeV1, bool) {
+	var e *ValidationError
+	if errors.As(err, &e) {
+		return e.Code, true
+	}
+	return "", false
+}
+
+func DecodeCommandEntryV1(src []byte, opts DecodeOptions) (CommandEntryV1, error) {
+	scope, database, catalog, err := normalizeScope(opts)
+	if err != nil {
+		return CommandEntryV1{}, err
+	}
+	entryBytes := bytes.Clone(src)
+	decoded, err := nativewire.DecodeDeterministicEntry(entryBytes, opts.Limits)
+	if err != nil {
+		return CommandEntryV1{}, validationError(mapNativeWireError(err), err)
+	}
+	if decoded.Version != EntryVersionV1 {
+		return CommandEntryV1{}, validationError(ErrorUnsupportedVersionV1, fmt.Errorf("entry version %d", decoded.Version))
+	}
+	row := ClassifyNativeWireCommandV1(decoded.CommandID)
+	if !row.Known {
+		return CommandEntryV1{}, validationError(ErrorUnsupportedCommandV1, fmt.Errorf("native-wire command %d", decoded.CommandID))
+	}
+	if row.Decision != DecisionAccepted {
+		return CommandEntryV1{}, validationError(ErrorUnsupportedCommandV1, fmt.Errorf("%s is %s for R3a v1: %s", row.NativeWireCommand, row.Decision, row.Reason))
+	}
+	idempotencyKey, ok := sectionBytes(decoded.Sections, nativewire.SectionIdempotencyKey)
+	if !ok || len(idempotencyKey) == 0 {
+		return CommandEntryV1{}, validationError(ErrorNoIdempotencyV1, fmt.Errorf("%s missing idempotency key", row.NativeWireCommand))
+	}
+	if len(idempotencyKey) > MaxIdempotencyKeyBytesV1 {
+		return CommandEntryV1{}, validationError(ErrorResourceExhaustedV1, fmt.Errorf("idempotency key length %d exceeds %d", len(idempotencyKey), MaxIdempotencyKeyBytesV1))
+	}
+	if string(idempotencyKey) == NoIdempotencyTokenV1 {
+		return CommandEntryV1{}, validationError(ErrorNoIdempotencyV1, fmt.Errorf("%s is not accepted for replicated commands", NoIdempotencyTokenV1))
+	}
+	target := targetIdentity(decoded, scope, database, catalog)
+	if opts.ExpectedTarget != nil && !target.Equal(*opts.ExpectedTarget) {
+		return CommandEntryV1{}, validationError(ErrorTargetMismatchV1, fmt.Errorf("target identity mismatch"))
+	}
+	return CommandEntryV1{
+		Bytes:          entryBytes,
+		Decoded:        decoded,
+		Digest:         CommandDigestV1ForBytes(entryBytes, opts),
+		Target:         target,
+		IdempotencyKey: bytes.Clone(idempotencyKey),
+		Idempotency:    IdempotencyRequiredV1,
+		Row:            row,
+	}, nil
+}
+
+func CommandDigestV1ForBytes(src []byte, opts DecodeOptions) CommandDigestV1 {
+	scope := opts.ScopeRule
+	if scope == "" {
+		scope = ScopeRuleSingleGroupV1
+	}
+	database := opts.DatabaseScope
+	if database == "" {
+		database = DatabaseScopeDefaultV1
+	}
+	catalog := opts.CatalogScope
+	if catalog == "" {
+		catalog = CatalogScopeDefaultV1
+	}
+	h := sha256.New()
+	writeDigestField(h, "domain", []byte(digestDomainV1))
+	writeDigestU64(h, "entry-version", EntryVersionV1)
+	writeDigestField(h, "scope-rule", []byte(scope))
+	writeDigestField(h, "database-scope", []byte(database))
+	writeDigestField(h, "catalog-scope", []byte(catalog))
+	writeDigestField(h, "nativewire-deterministic-entry", src)
+	var out CommandDigestV1
+	copy(out[:], h.Sum(nil))
+	return out
+}
+
+func ValidateCommandDigestInputV1(src []byte, opts DecodeOptions) (CommandDigestV1, error) {
+	if _, _, _, err := normalizeScope(opts); err != nil {
+		return CommandDigestV1{}, err
+	}
+	if _, err := nativewire.DecodeDeterministicEntry(src, opts.Limits); err != nil {
+		return CommandDigestV1{}, validationError(mapNativeWireError(err), err)
+	}
+	return CommandDigestV1ForBytes(src, opts), nil
+}
+
+func normalizeScope(opts DecodeOptions) (ScopeRuleV1, string, string, error) {
+	scope := opts.ScopeRule
+	if scope == "" {
+		scope = ScopeRuleSingleGroupV1
+	}
+	if scope != ScopeRuleSingleGroupV1 {
+		return "", "", "", validationError(ErrorUnsupportedScopeRuleV1, fmt.Errorf("scope rule %q", scope))
+	}
+	database := opts.DatabaseScope
+	if database == "" {
+		database = DatabaseScopeDefaultV1
+	}
+	catalog := opts.CatalogScope
+	if catalog == "" {
+		catalog = CatalogScopeDefaultV1
+	}
+	return scope, database, catalog, nil
+}
+
+func targetIdentity(entry nativewire.DeterministicEntry, scope ScopeRuleV1, database, catalog string) TargetIdentityV1 {
+	return TargetIdentityV1{
+		ScopeRule:              scope,
+		DatabaseScope:          database,
+		CatalogScope:           catalog,
+		CommandID:              entry.CommandID,
+		CommandVersion:         entry.CommandVersion,
+		CollectionRef:          copySection(entry.Sections, nativewire.SectionCollectionRef),
+		CollectionMeta:         copySection(entry.Sections, nativewire.SectionCollectionMeta),
+		ExpectedCatalogVersion: copySection(entry.Sections, nativewire.SectionExpectedCatalogVersion),
+	}
+}
+
+func sectionBytes(sections []nativewire.Section, id nativewire.SectionID) ([]byte, bool) {
+	for _, section := range sections {
+		if section.ID == id {
+			return section.Bytes, true
+		}
+	}
+	return nil, false
+}
+
+func copySection(sections []nativewire.Section, id nativewire.SectionID) []byte {
+	raw, ok := sectionBytes(sections, id)
+	if !ok {
+		return nil
+	}
+	return bytes.Clone(raw)
+}
+
+func validationError(code DeterministicErrorCodeV1, err error) error {
+	return &ValidationError{Code: code, Err: err}
+}
+
+func mapNativeWireError(err error) DeterministicErrorCodeV1 {
+	code, ok := nativewire.ErrorCodeOf(err)
+	if !ok {
+		return ErrorMalformedEntryV1
+	}
+	switch code {
+	case nativewire.ErrMalformedFrame:
+		return ErrorMalformedEntryV1
+	case nativewire.ErrUnsupportedVersion:
+		return ErrorUnsupportedVersionV1
+	case nativewire.ErrUnsupportedFeature:
+		return ErrorUnsupportedFeatureV1
+	case nativewire.ErrInvalidCommand:
+		return ErrorMalformedEntryV1
+	case nativewire.ErrResourceExhausted:
+		return ErrorResourceExhaustedV1
+	case nativewire.ErrReadOnly:
+		return ErrorReadOnlyV1
+	case nativewire.ErrDurabilityUnavailable:
+		return ErrorUnsafeDurabilityModeV1
+	default:
+		return ErrorMalformedEntryV1
+	}
+}
+
+type digestWriter interface {
+	Write([]byte) (int, error)
+}
+
+func writeDigestField(w digestWriter, name string, value []byte) {
+	writeDigestU64(w, "field-name-len", uint64(len(name)))
+	_, _ = w.Write([]byte(name))
+	writeDigestU64(w, "field-value-len", uint64(len(value)))
+	_, _ = w.Write(value)
+}
+
+func writeDigestU64(w digestWriter, name string, value uint64) {
+	var buf [8]byte
+	binary.BigEndian.PutUint64(buf[:], value)
+	if name != "" {
+		_, _ = w.Write([]byte(name))
+	}
+	_, _ = w.Write(buf[:])
+}

--- a/TreeDB/internal/raftentry/contract_test.go
+++ b/TreeDB/internal/raftentry/contract_test.go
@@ -1,0 +1,484 @@
+package raftentry
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/internal/nativewire"
+)
+
+const (
+	createCollectionDigestV1Hex = "50d795a174052328acd5aa8c1378668a26384c32691d8eacd968b9ddbb2f070d"
+	insertBatchDigestV1Hex      = "7091242d8878fb3a1d1d2b6882ae19130d800dcffa853733433c6879a122952a"
+)
+
+func TestDecodeCommandEntryV1AcceptsCreateCollectionContract(t *testing.T) {
+	raw := readHexFixture(t, "../nativewire/testdata/v1/create_collection_entry.hex")
+	entry, err := DecodeCommandEntryV1(raw, DecodeOptions{})
+	if err != nil {
+		t.Fatalf("DecodeCommandEntryV1: %v", err)
+	}
+	if entry.Row.Decision != DecisionAccepted {
+		t.Fatalf("decision=%s, want accepted", entry.Row.Decision)
+	}
+	if entry.Row.DuplicateMode != DuplicateFailClosedAllowedV1 {
+		t.Fatalf("duplicate mode=%s, want fail closed", entry.Row.DuplicateMode)
+	}
+	if entry.Idempotency != IdempotencyRequiredV1 || len(entry.IdempotencyKey) == 0 {
+		t.Fatalf("idempotency=%s keyLen=%d", entry.Idempotency, len(entry.IdempotencyKey))
+	}
+	if entry.Target.ScopeRule != ScopeRuleSingleGroupV1 || entry.Target.DatabaseScope != DatabaseScopeDefaultV1 || entry.Target.CatalogScope != CatalogScopeDefaultV1 {
+		t.Fatalf("target scope=%+v", entry.Target)
+	}
+	if entry.Target.CommandID != nativewire.CommandCreateCollection || len(entry.Target.CollectionMeta) == 0 || len(entry.Target.ExpectedCatalogVersion) == 0 {
+		t.Fatalf("incomplete target identity: %+v", entry.Target)
+	}
+	if entry.Digest.Hex() != createCollectionDigestV1Hex {
+		t.Fatalf("create collection digest=%s want %s", entry.Digest.Hex(), createCollectionDigestV1Hex)
+	}
+}
+
+func TestDigestV1StabilityAcrossMetadataAndApplyEntryID(t *testing.T) {
+	base := deterministicInsertEntry(t, nil, 0)
+	variant := deterministicInsertEntry(t, []nativewire.Section{
+		{ID: nativewire.SectionAckPolicy, Bytes: uvarintPayload(uint64(nativewire.AckSynced))},
+		{ID: nativewire.SectionConsistencyPolicy, Bytes: uvarintPayload(3)},
+		{ID: nativewire.SectionCompression, Bytes: []byte{1}},
+		{ID: nativewire.SectionTraceContext, Bytes: []byte("trace")},
+		{ID: nativewire.SectionDeadline, Bytes: []byte("deadline")},
+		{ID: 9000, Bytes: []byte("ignored")},
+	}, nativewire.CommandFlagOmitResultIDs|nativewire.CommandFlagOmitResponseMeta)
+	if !bytes.Equal(base, variant) {
+		t.Fatalf("native-wire metadata changed deterministic entry\nbase=%x\nvariant=%x", base, variant)
+	}
+	d0, err := ValidateCommandDigestInputV1(base, DecodeOptions{
+		ApplyEntryID: ApplyEntryID{Term: 1, Index: 2},
+		RequestMetadata: RequestMetadataV1{
+			RequestID:         11,
+			AckPolicy:         nativewire.AckVisible,
+			DeadlineUnixNanos: 100,
+			TraceContext:      []byte("trace-a"),
+			Compression:       "none",
+			OmitResultIDs:     false,
+			OmitResponseMeta:  false,
+		},
+	})
+	if err != nil {
+		t.Fatalf("ValidateCommandDigestInputV1 base: %v", err)
+	}
+	d1, err := ValidateCommandDigestInputV1(variant, DecodeOptions{
+		ApplyEntryID: ApplyEntryID{Term: 9, Index: 10},
+		RequestMetadata: RequestMetadataV1{
+			RequestID:         99,
+			AckPolicy:         nativewire.AckSynced,
+			DeadlineUnixNanos: 900,
+			TraceContext:      []byte("trace-b"),
+			Compression:       "lz4",
+			OmitResultIDs:     true,
+			OmitResponseMeta:  true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("ValidateCommandDigestInputV1 variant: %v", err)
+	}
+	if d0 != d1 {
+		t.Fatalf("ApplyEntryID or metadata changed digest: %s != %s", d0.Hex(), d1.Hex())
+	}
+	if d0.Hex() != insertBatchDigestV1Hex {
+		t.Fatalf("insert digest=%s want %s", d0.Hex(), insertBatchDigestV1Hex)
+	}
+}
+
+func TestDigestV1CoversScopeAndCatalogIdentity(t *testing.T) {
+	raw := readHexFixture(t, "../nativewire/testdata/v1/create_collection_entry.hex")
+	base, err := ValidateCommandDigestInputV1(raw, DecodeOptions{})
+	if err != nil {
+		t.Fatalf("ValidateCommandDigestInputV1 base: %v", err)
+	}
+	differentDatabase, err := ValidateCommandDigestInputV1(raw, DecodeOptions{DatabaseScope: "database/tenant-b"})
+	if err != nil {
+		t.Fatalf("ValidateCommandDigestInputV1 database: %v", err)
+	}
+	differentCatalog, err := ValidateCommandDigestInputV1(raw, DecodeOptions{CatalogScope: "catalog/tenant-b"})
+	if err != nil {
+		t.Fatalf("ValidateCommandDigestInputV1 catalog: %v", err)
+	}
+	if base == differentDatabase {
+		t.Fatal("database scope did not affect CommandDigestV1")
+	}
+	if base == differentCatalog {
+		t.Fatal("catalog scope did not affect CommandDigestV1")
+	}
+}
+
+func TestDecodeCommandEntryV1RejectsClassifiedButNotAcceptedMutations(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		fixture string
+		command nativewire.CommandID
+	}{
+		{"insert", "../nativewire/testdata/v1/insert_batch_entry.hex", nativewire.CommandInsertBatch},
+		{"replace", "../nativewire/testdata/v1/replace_batch_entry.hex", nativewire.CommandReplaceBatch},
+		{"delete", "../nativewire/testdata/v1/delete_batch_entry.hex", nativewire.CommandDeleteBatch},
+		{"update_bson_set", "../nativewire/testdata/v1/update_bson_set_entry.hex", nativewire.CommandUpdateBSONSet},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			row := ClassifyNativeWireCommandV1(tc.command)
+			if !row.Known || row.Decision != DecisionRejected || row.CommandWALStatus != "WAL-supported" {
+				t.Fatalf("row=%+v, want classified WAL-supported rejection", row)
+			}
+			if _, err := DecodeCommandEntryV1(readHexFixture(t, tc.fixture), DecodeOptions{}); codeOf(err) != ErrorUnsupportedCommandV1 {
+				t.Fatalf("DecodeCommandEntryV1 err=%v code=%s, want unsupported command", err, codeOf(err))
+			}
+		})
+	}
+}
+
+func TestDecodeCommandEntryV1RejectsDDLBarriersReadsAndUnknowns(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		fixture string
+		command nativewire.CommandID
+	}{
+		{"create_index", "../nativewire/testdata/v1/create_index_entry.hex", nativewire.CommandCreateIndex},
+		{"drop_index", "../nativewire/testdata/v1/drop_index_entry.hex", nativewire.CommandDropIndex},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			row := ClassifyNativeWireCommandV1(tc.command)
+			if !row.Known || row.Decision != DecisionRejected || row.CommandWALStatus != "WAL-rejected" {
+				t.Fatalf("row=%+v, want WAL-rejected R3a rejection", row)
+			}
+			if _, err := DecodeCommandEntryV1(readHexFixture(t, tc.fixture), DecodeOptions{}); codeOf(err) != ErrorUnsupportedCommandV1 {
+				t.Fatalf("DecodeCommandEntryV1 err=%v code=%s, want unsupported command", err, codeOf(err))
+			}
+		})
+	}
+	for _, command := range []nativewire.CommandID{
+		nativewire.CommandDropCollection,
+		nativewire.CommandFlushCollection,
+		nativewire.CommandFlushAll,
+		nativewire.CommandCheckpoint,
+		nativewire.CommandGetMany,
+		nativewire.CommandOpenScan,
+		nativewire.CommandCursorNext,
+	} {
+		row := ClassifyNativeWireCommandV1(command)
+		if !row.Known || row.Decision != DecisionRejected {
+			t.Fatalf("command %d row=%+v, want known rejected row", command, row)
+		}
+	}
+	if row := ClassifyNativeWireCommandV1(nativewire.CommandID(9999)); row.Known {
+		t.Fatalf("unknown command classified as known: %+v", row)
+	}
+}
+
+func TestDecodeCommandEntryV1RejectsMalformedOversizedMissingGuardAndNoIdempotency(t *testing.T) {
+	if _, err := DecodeCommandEntryV1([]byte("bad"), DecodeOptions{}); codeOf(err) != ErrorMalformedEntryV1 {
+		t.Fatalf("malformed err=%v code=%s", err, codeOf(err))
+	}
+	raw := readHexFixture(t, "../nativewire/testdata/v1/create_collection_entry.hex")
+	if _, err := DecodeCommandEntryV1(raw, DecodeOptions{Limits: nativewire.Limits{MaxFrameSize: uint64(len(raw) - 1)}}); codeOf(err) != ErrorResourceExhaustedV1 {
+		t.Fatalf("oversized err=%v code=%s", err, codeOf(err))
+	}
+	missingGuard := deterministicCreateCollectionEntry(t, "client-a:create:users", false)
+	if _, err := DecodeCommandEntryV1(missingGuard, DecodeOptions{}); codeOf(err) != ErrorMalformedEntryV1 {
+		t.Fatalf("missing guard err=%v code=%s", err, codeOf(err))
+	}
+	noID := deterministicCreateCollectionEntry(t, NoIdempotencyTokenV1, true)
+	if _, err := DecodeCommandEntryV1(noID, DecodeOptions{}); codeOf(err) != ErrorNoIdempotencyV1 {
+		t.Fatalf("NoIdempotency err=%v code=%s", err, codeOf(err))
+	}
+	duplicateSingleton := appendDeterministicEntryRaw(nativewire.CommandCreateCollection, []nativewire.Section{
+		{ID: nativewire.SectionCollectionMeta, Bytes: createCollectionMetaPayload("users")},
+		{ID: nativewire.SectionCollectionMeta, Bytes: createCollectionMetaPayload("users")},
+		{ID: nativewire.SectionIdempotencyKey, Bytes: []byte("client-a:create:users")},
+		{ID: nativewire.SectionExpectedCatalogVersion, Bytes: uvarintPayload(7)},
+	})
+	if _, err := DecodeCommandEntryV1(duplicateSingleton, DecodeOptions{}); codeOf(err) != ErrorMalformedEntryV1 {
+		t.Fatalf("duplicate singleton err=%v code=%s", err, codeOf(err))
+	}
+	unknownVersion := appendDeterministicEntryRawWithHeader(nativewire.DeterministicEntryVersion+1, nativewire.CommandCreateCollection, 1, 0, []nativewire.Section{
+		{ID: nativewire.SectionCollectionMeta, Bytes: createCollectionMetaPayload("users")},
+		{ID: nativewire.SectionIdempotencyKey, Bytes: []byte("client-a:create:users")},
+		{ID: nativewire.SectionExpectedCatalogVersion, Bytes: uvarintPayload(7)},
+	})
+	if _, err := DecodeCommandEntryV1(unknownVersion, DecodeOptions{}); codeOf(err) != ErrorUnsupportedVersionV1 {
+		t.Fatalf("unknown version err=%v code=%s", err, codeOf(err))
+	}
+	unknownFeature := appendDeterministicEntryRawWithHeader(nativewire.DeterministicEntryVersion, nativewire.CommandCreateCollection, 1, 1, []nativewire.Section{
+		{ID: nativewire.SectionCollectionMeta, Bytes: createCollectionMetaPayload("users")},
+		{ID: nativewire.SectionIdempotencyKey, Bytes: []byte("client-a:create:users")},
+		{ID: nativewire.SectionExpectedCatalogVersion, Bytes: uvarintPayload(7)},
+	})
+	if _, err := DecodeCommandEntryV1(unknownFeature, DecodeOptions{}); codeOf(err) != ErrorUnsupportedFeatureV1 {
+		t.Fatalf("unknown feature err=%v code=%s", err, codeOf(err))
+	}
+	unknownCommand := appendDeterministicEntryRaw(nativewire.CommandID(9999), []nativewire.Section{
+		{ID: nativewire.SectionCollectionMeta, Bytes: createCollectionMetaPayload("users")},
+		{ID: nativewire.SectionIdempotencyKey, Bytes: []byte("client-a:create:users")},
+		{ID: nativewire.SectionExpectedCatalogVersion, Bytes: uvarintPayload(7)},
+	})
+	if _, err := DecodeCommandEntryV1(unknownCommand, DecodeOptions{}); codeOf(err) != ErrorUnsupportedVersionV1 {
+		t.Fatalf("unknown command err=%v code=%s", err, codeOf(err))
+	}
+}
+
+func TestDecodeCommandEntryV1RejectsTargetAndScopeMismatch(t *testing.T) {
+	raw := readHexFixture(t, "../nativewire/testdata/v1/create_collection_entry.hex")
+	entry, err := DecodeCommandEntryV1(raw, DecodeOptions{})
+	if err != nil {
+		t.Fatalf("DecodeCommandEntryV1: %v", err)
+	}
+	target := entry.Target.Clone()
+	target.ExpectedCatalogVersion = []byte{99}
+	if _, err := DecodeCommandEntryV1(raw, DecodeOptions{ExpectedTarget: &target}); codeOf(err) != ErrorTargetMismatchV1 {
+		t.Fatalf("target mismatch err=%v code=%s", err, codeOf(err))
+	}
+	if _, err := DecodeCommandEntryV1(raw, DecodeOptions{ScopeRule: ScopeRuleV1("multi-group-v1")}); codeOf(err) != ErrorUnsupportedScopeRuleV1 {
+		t.Fatalf("scope mismatch err=%v code=%s", err, codeOf(err))
+	}
+}
+
+func TestApplyResultV1VocabularyIsStable(t *testing.T) {
+	statuses := []ApplyStatusV1{
+		ApplyStatusApplied,
+		ApplyStatusAlreadyApplied,
+		ApplyStatusDeterministicGuardFailure,
+		ApplyStatusRejectedUnsupported,
+		ApplyStatusRejectedMalformed,
+		ApplyStatusRejectedConflict,
+		ApplyStatusRecoveryRequired,
+	}
+	for _, status := range statuses {
+		if status == "" {
+			t.Fatalf("empty ApplyResultV1 status in %v", statuses)
+		}
+	}
+	errors := []DeterministicErrorCodeV1{
+		ErrorUnsupportedCommandV1,
+		ErrorMalformedEntryV1,
+		ErrorUnsupportedVersionV1,
+		ErrorUnsupportedFeatureV1,
+		ErrorMissingGuardV1,
+		ErrorTargetMismatchV1,
+		ErrorRejectedConflictV1,
+		ErrorReadOnlyV1,
+		ErrorUnsafeDurabilityModeV1,
+		ErrorResourceExhaustedV1,
+		ErrorNoIdempotencyV1,
+		ErrorResultReplayRequiredV1,
+		ErrorUnknownRequiredFieldV1,
+		ErrorUnsupportedScopeRuleV1,
+	}
+	for _, code := range errors {
+		if code == "" {
+			t.Fatalf("empty deterministic error code in %v", errors)
+		}
+	}
+}
+
+func TestR3aAllowlistCoversNativeWireV1CommandsAndDocsMatrix(t *testing.T) {
+	rowsByNative := make(map[string]CommandRowV1)
+	for _, row := range AllCommandRowsV1() {
+		if !row.Known || row.NativeWireCommand == "" || row.CommandName == "" || row.CommandWALKind == "" || row.CommandWALStatus == "" || row.Reason == "" {
+			t.Fatalf("incomplete command row: %+v", row)
+		}
+		if _, exists := rowsByNative[row.NativeWireCommand]; exists {
+			t.Fatalf("duplicate row for %s", row.NativeWireCommand)
+		}
+		rowsByNative[row.NativeWireCommand] = row
+	}
+	for _, schema := range nativewire.MustV1Registry().Schemas() {
+		row := ClassifyNativeWireCommandV1(schema.ID)
+		if !row.Known {
+			t.Fatalf("missing row for schema %+v", schema)
+		}
+	}
+	alignment := loadAlignment(t)
+	for _, entry := range alignment.Entries {
+		row, ok := rowsByNative[entry.NativeWireCommand]
+		if !ok {
+			t.Fatalf("alignment entry %s has no R3a row", entry.NativeWireCommand)
+		}
+		if row.CommandWALStatus != entry.SupportMatrixStatus || row.CommandWALKind != entry.CommandWALKind {
+			t.Fatalf("%s row=%+v alignment=%+v", entry.NativeWireCommand, row, entry)
+		}
+		if row.Decision == DecisionAccepted && entry.SupportMatrixStatus != "WAL-supported" {
+			t.Fatalf("%s accepted without WAL-supported status", entry.NativeWireCommand)
+		}
+	}
+	if row := ClassifyNativeWireCommandV1(nativewire.CommandCreateCollection); row.Decision != DecisionAccepted || row.DuplicateMode != DuplicateFailClosedAllowedV1 || row.ResultReplayMode != ResultReplayFailClosedV1 {
+		t.Fatalf("create collection row=%+v", row)
+	}
+}
+
+func deterministicInsertEntry(t *testing.T, extra []nativewire.Section, commandFlags uint64) []byte {
+	t.Helper()
+	sections := []nativewire.Section{
+		{ID: nativewire.SectionCommandHeader, Bytes: nativewire.AppendCommandHeader(nil, nativewire.CommandHeader{ID: nativewire.CommandInsertBatch, Version: 1, Flags: commandFlags})},
+		{ID: nativewire.SectionIdempotencyKey, Bytes: []byte("id1")},
+		{ID: nativewire.SectionCollectionRef, Bytes: []byte{1, 'c'}},
+		{ID: nativewire.SectionDocumentFormat, Bytes: []byte{byte(nativewire.DocumentFormatBSON)}},
+		{ID: nativewire.SectionDocumentIDs, Bytes: nativewire.AppendByteVector(nil, []byte("a"))},
+		{ID: nativewire.SectionDocuments, Bytes: nativewire.AppendByteVector(nil, []byte{5, 0, 0, 0, 0})},
+		{ID: nativewire.SectionExpectedCatalogVersion, Bytes: uvarintPayload(7)},
+	}
+	sections = append(sections, extra...)
+	cmd, err := nativewire.MustV1Registry().ValidateRequestSections(sections)
+	if err != nil {
+		t.Fatalf("ValidateRequestSections: %v", err)
+	}
+	entry, err := nativewire.AppendDeterministicEntry(nil, cmd)
+	if err != nil {
+		t.Fatalf("AppendDeterministicEntry: %v", err)
+	}
+	return entry
+}
+
+func deterministicCreateCollectionEntry(t *testing.T, idempotency string, includeGuard bool) []byte {
+	t.Helper()
+	sections := []nativewire.Section{
+		{ID: nativewire.SectionCommandHeader, Bytes: nativewire.AppendCommandHeader(nil, nativewire.CommandHeader{ID: nativewire.CommandCreateCollection, Version: 1})},
+		{ID: nativewire.SectionIdempotencyKey, Bytes: []byte(idempotency)},
+		{ID: nativewire.SectionCollectionMeta, Bytes: createCollectionMetaPayload("users")},
+	}
+	if includeGuard {
+		sections = append(sections, nativewire.Section{ID: nativewire.SectionExpectedCatalogVersion, Bytes: uvarintPayload(7)})
+	}
+	cmd, err := nativewire.MustV1Registry().ValidateRequestSections(sections)
+	if err != nil && includeGuard {
+		t.Fatalf("ValidateRequestSections: %v", err)
+	}
+	if err != nil {
+		return appendDeterministicEntryRaw(nativewire.CommandCreateCollection, sections)
+	}
+	entry, err := nativewire.AppendDeterministicEntry(nil, cmd)
+	if err != nil {
+		t.Fatalf("AppendDeterministicEntry: %v", err)
+	}
+	return entry
+}
+
+func createCollectionMetaPayload(name string) []byte {
+	dst := uvarintPayload(1)
+	dst = appendString(dst, name)
+	dst = binary.AppendUvarint(dst, uint64(nativewire.DocumentFormatDefault))
+	dst = binary.AppendUvarint(dst, 0)
+	dst = binary.AppendUvarint(dst, 0)
+	dst = binary.AppendUvarint(dst, 0)
+	dst = binary.AppendUvarint(dst, 0)
+	dst = binary.AppendUvarint(dst, 0)
+	dst = binary.AppendVarint(dst, 0)
+	dst = binary.AppendVarint(dst, 0)
+	dst = binary.AppendVarint(dst, 0)
+	dst = binary.AppendUvarint(dst, 0)
+	dst = binary.AppendUvarint(dst, 0)
+	dst = binary.AppendVarint(dst, 0)
+	dst = binary.AppendUvarint(dst, 0)
+	return dst
+}
+
+func appendString(dst []byte, value string) []byte {
+	dst = binary.AppendUvarint(dst, uint64(len(value)))
+	return append(dst, value...)
+}
+
+func appendDeterministicEntryRaw(commandID nativewire.CommandID, sections []nativewire.Section) []byte {
+	return appendDeterministicEntryRawWithHeader(nativewire.DeterministicEntryVersion, commandID, 1, 0, sections)
+}
+
+func appendDeterministicEntryRawWithHeader(entryVersion uint64, commandID nativewire.CommandID, commandVersion uint64, commandFlags uint64, sections []nativewire.Section) []byte {
+	deterministic := make([]nativewire.Section, 0, len(sections))
+	for _, section := range sections {
+		switch section.ID {
+		case nativewire.SectionCommandHeader:
+			continue
+		case nativewire.SectionDeadline, nativewire.SectionTraceContext, nativewire.SectionAckPolicy, nativewire.SectionConsistencyPolicy, nativewire.SectionChecksum, nativewire.SectionCompression, nativewire.SectionResponseMeta, nativewire.SectionCursorMeta:
+			continue
+		default:
+			deterministic = append(deterministic, section)
+		}
+	}
+	sortSections(deterministic)
+	dst := []byte(nativewire.DeterministicEntryMagic)
+	dst = binary.AppendUvarint(dst, entryVersion)
+	dst = binary.AppendUvarint(dst, uint64(commandID))
+	dst = binary.AppendUvarint(dst, commandVersion)
+	dst = binary.AppendUvarint(dst, commandFlags)
+	dst = binary.AppendUvarint(dst, uint64(len(deterministic)))
+	for _, section := range deterministic {
+		dst = binary.AppendUvarint(dst, uint64(section.ID))
+		dst = binary.AppendUvarint(dst, uint64(len(section.Bytes)))
+		dst = append(dst, section.Bytes...)
+	}
+	return dst
+}
+
+func sortSections(sections []nativewire.Section) {
+	for i := 1; i < len(sections); i++ {
+		for j := i; j > 0 && sections[j].ID < sections[j-1].ID; j-- {
+			sections[j], sections[j-1] = sections[j-1], sections[j]
+		}
+	}
+}
+
+func uvarintPayload(value uint64) []byte {
+	return binary.AppendUvarint(nil, value)
+}
+
+func codeOf(err error) DeterministicErrorCodeV1 {
+	code, _ := ErrorCodeOf(err)
+	return code
+}
+
+type alignmentManifest struct {
+	Entries []alignmentEntry `json:"entries"`
+}
+
+type alignmentEntry struct {
+	NativeWireCommand   string `json:"nativewire_command"`
+	CommandWALKind      string `json:"command_wal_kind"`
+	SupportMatrixStatus string `json:"support_matrix_status"`
+}
+
+func loadAlignment(t *testing.T) alignmentManifest {
+	t.Helper()
+	raw, err := os.ReadFile(repoPath(t, "../../docs/spec/command-wal-nativewire-alignment.json"))
+	if err != nil {
+		t.Fatalf("read alignment: %v", err)
+	}
+	var manifest alignmentManifest
+	if err := json.Unmarshal(raw, &manifest); err != nil {
+		t.Fatalf("decode alignment: %v", err)
+	}
+	return manifest
+}
+
+func readHexFixture(t *testing.T, rel string) []byte {
+	t.Helper()
+	raw, err := os.ReadFile(repoPath(t, rel))
+	if err != nil {
+		t.Fatalf("read fixture %s: %v", rel, err)
+	}
+	compact := bytes.Join(bytes.Fields(raw), nil)
+	out, err := hex.DecodeString(string(compact))
+	if err != nil {
+		t.Fatalf("decode fixture %s: %v", rel, err)
+	}
+	return out
+}
+
+func repoPath(t *testing.T, rel string) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(file), rel))
+}

--- a/TreeDB/internal/raftentry/doc.go
+++ b/TreeDB/internal/raftentry/doc.go
@@ -1,0 +1,12 @@
+// Package raftentry defines the R3a v1 deterministic command-entry contract.
+//
+// R3a v1 does not introduce a second semantic command encoding. CommandEntryV1
+// bytes are the existing native-wire deterministic entry bytes. This package
+// adds the Raft-apply contract around those bytes: digest domain separation,
+// target/scope identity, command classification, idempotency requirements, and
+// deterministic result vocabulary.
+//
+// Fixture stability is checked with:
+//
+//	GOWORK=off go test ./TreeDB/internal/raftentry ./TreeDB/internal/nativewire ./TreeDB/docs
+package raftentry

--- a/TreeDB/internal/raftentry/matrix.go
+++ b/TreeDB/internal/raftentry/matrix.go
@@ -1,0 +1,150 @@
+package raftentry
+
+import "github.com/snissn/gomap/TreeDB/internal/nativewire"
+
+type DecisionV1 string
+
+const (
+	DecisionAccepted DecisionV1 = "accepted"
+	DecisionRejected DecisionV1 = "rejected"
+)
+
+type DuplicateModeV1 string
+
+const (
+	DuplicateReplayRequiredV1      DuplicateModeV1 = "replay-required"
+	DuplicateFailClosedAllowedV1   DuplicateModeV1 = "duplicate-fail-closed-allowed"
+	DuplicateRejectedUnsupportedV1 DuplicateModeV1 = "rejected"
+)
+
+type ResultReplayModeV1 string
+
+const (
+	ResultReplayPersistedPayloadOrDigestV1 ResultReplayModeV1 = "persisted-result-payload-or-digest"
+	ResultReplayFailClosedV1               ResultReplayModeV1 = "fail-closed-until-result-store"
+	ResultReplayNoneRejectedV1             ResultReplayModeV1 = "none-rejected"
+)
+
+type CommandRowV1 struct {
+	Known                   bool
+	CommandID               nativewire.CommandID
+	NativeWireCommand       string
+	CommandName             string
+	Decision                DecisionV1
+	DuplicateMode           DuplicateModeV1
+	ResultReplayMode        ResultReplayModeV1
+	CommandWALStatus        string
+	CommandWALKind          string
+	DeterministicEntryBytes string
+	Reason                  string
+}
+
+func ClassifyNativeWireCommandV1(id nativewire.CommandID) CommandRowV1 {
+	row, ok := commandRowsV1[id]
+	if !ok {
+		return CommandRowV1{CommandID: id}
+	}
+	return row
+}
+
+func AllCommandRowsV1() []CommandRowV1 {
+	ids := []nativewire.CommandID{
+		nativewire.CommandCreateCollection,
+		nativewire.CommandListCollections,
+		nativewire.CommandCreateIndex,
+		nativewire.CommandListIndexes,
+		nativewire.CommandDropIndex,
+		nativewire.CommandOpenCollection,
+		nativewire.CommandCloseCollection,
+		nativewire.CommandDropCollection,
+		nativewire.CommandInsertBatch,
+		nativewire.CommandReplaceBatch,
+		nativewire.CommandDeleteBatch,
+		nativewire.CommandFlushCollection,
+		nativewire.CommandFlushAll,
+		nativewire.CommandCheckpoint,
+		nativewire.CommandUpdateBSONSet,
+		nativewire.CommandGetMany,
+		nativewire.CommandIndexLookup,
+		nativewire.CommandIndexRange,
+		nativewire.CommandOpenScan,
+		nativewire.CommandCursorNext,
+		nativewire.CommandCursorClose,
+		nativewire.CommandExplain,
+		nativewire.CommandStats,
+	}
+	rows := make([]CommandRowV1, 0, len(ids))
+	for _, id := range ids {
+		rows = append(rows, ClassifyNativeWireCommandV1(id))
+	}
+	return rows
+}
+
+var commandRowsV1 = map[nativewire.CommandID]CommandRowV1{
+	nativewire.CommandCreateCollection: acceptedRow(
+		nativewire.CommandCreateCollection,
+		"CommandCreateCollection",
+		"create_collection",
+		"CatalogCreateCollection",
+		"native-wire deterministic entry fixture",
+		"first vertical-slice contract; duplicates fail closed until durable result replay lands",
+	),
+
+	nativewire.CommandCreateIndex:    rejectedRow(nativewire.CommandCreateIndex, "CommandCreateIndex", "create_index", "WAL-rejected", "future catalog index create", "future_rejected_v1", "index DDL is deterministic at native-wire level but has no accepted R3a command-WAL payload/recovery contract"),
+	nativewire.CommandDropIndex:      rejectedRow(nativewire.CommandDropIndex, "CommandDropIndex", "drop_index", "WAL-rejected", "future catalog index drop", "future_rejected_v1", "index DDL is deterministic at native-wire level but has no accepted R3a command-WAL payload/recovery contract"),
+	nativewire.CommandDropCollection: rejectedRow(nativewire.CommandDropCollection, "CommandDropCollection", "drop_collection", "WAL-rejected", "future catalog collection drop", "local_only_rejected_v1", "collection drop is local-only/rejected until catalog payloads and recovery tests exist"),
+
+	nativewire.CommandInsertBatch:   rejectedRow(nativewire.CommandInsertBatch, "CommandInsertBatch", "insert_batch", "WAL-supported", "CollectionInsertBatchByID", "native-wire deterministic entry fixture", "classified for future widening but not accepted before create identity/generation and result replay contracts land"),
+	nativewire.CommandReplaceBatch:  rejectedRow(nativewire.CommandReplaceBatch, "CommandReplaceBatch", "replace_batch", "WAL-supported", "CollectionUpdateBatchByID", "native-wire deterministic entry fixture", "classified for future widening but not accepted before create identity/generation and result replay contracts land"),
+	nativewire.CommandDeleteBatch:   rejectedRow(nativewire.CommandDeleteBatch, "CommandDeleteBatch", "delete_batch", "WAL-supported", "CollectionDeleteBatchByID", "native-wire deterministic entry fixture", "classified for future widening but not accepted before create identity/generation and result replay contracts land"),
+	nativewire.CommandUpdateBSONSet: rejectedRow(nativewire.CommandUpdateBSONSet, "CommandUpdateBSONSet", "update_bson_set", "WAL-supported", "CollectionUpdateBatchByID", "native-wire deterministic entry fixture", "classified for future widening but not accepted before create identity/generation and result replay contracts land"),
+
+	nativewire.CommandFlushCollection: rejectedRow(nativewire.CommandFlushCollection, "CommandFlushCollection", "flush_collection", "WAL-supported", "local durability barrier", "local_only_barrier_v1", "local durability barriers are not replicated command identity"),
+	nativewire.CommandFlushAll:        rejectedRow(nativewire.CommandFlushAll, "CommandFlushAll", "flush_all", "WAL-supported", "local durability barrier", "local_only_barrier_v1", "local durability barriers are not replicated command identity"),
+	nativewire.CommandCheckpoint:      rejectedRow(nativewire.CommandCheckpoint, "CommandCheckpoint", "checkpoint", "WAL-supported", "local durability barrier", "local_only_barrier_v1", "local durability barriers are not replicated command identity"),
+
+	nativewire.CommandListCollections: rejectedRow(nativewire.CommandListCollections, "CommandListCollections", "list_collections", "read-only", "none", "read_rejected_v1", "reads and metadata listing are not replicated mutations"),
+	nativewire.CommandListIndexes:     rejectedRow(nativewire.CommandListIndexes, "CommandListIndexes", "list_indexes", "read-only", "none", "read_rejected_v1", "reads and metadata listing are not replicated mutations"),
+	nativewire.CommandOpenCollection:  rejectedRow(nativewire.CommandOpenCollection, "CommandOpenCollection", "open_collection", "read-only", "none", "read_rejected_v1", "connection-local collection handles are not deterministic command identity"),
+	nativewire.CommandCloseCollection: rejectedRow(nativewire.CommandCloseCollection, "CommandCloseCollection", "close_collection", "read-only", "none", "read_rejected_v1", "connection-local collection handles are not deterministic command identity"),
+	nativewire.CommandGetMany:         rejectedRow(nativewire.CommandGetMany, "CommandGetMany", "get_many", "read-only", "none", "read_rejected_v1", "reads are not replicated mutations"),
+	nativewire.CommandIndexLookup:     rejectedRow(nativewire.CommandIndexLookup, "CommandIndexLookup", "index_lookup", "read-only", "none", "read_rejected_v1", "reads are not replicated mutations"),
+	nativewire.CommandIndexRange:      rejectedRow(nativewire.CommandIndexRange, "CommandIndexRange", "index_range", "read-only", "none", "read_rejected_v1", "reads are not replicated mutations"),
+	nativewire.CommandOpenScan:        rejectedRow(nativewire.CommandOpenScan, "CommandOpenScan", "open_scan", "read-only", "none", "read_rejected_v1", "cursor state is not replicated command identity"),
+	nativewire.CommandCursorNext:      rejectedRow(nativewire.CommandCursorNext, "CommandCursorNext", "cursor_next", "read-only", "none", "read_rejected_v1", "cursor state is not replicated command identity"),
+	nativewire.CommandCursorClose:     rejectedRow(nativewire.CommandCursorClose, "CommandCursorClose", "cursor_close", "read-only", "none", "read_rejected_v1", "cursor state is not replicated command identity"),
+	nativewire.CommandExplain:         rejectedRow(nativewire.CommandExplain, "CommandExplain", "explain", "read-only", "none", "read_rejected_v1", "reads are not replicated mutations"),
+	nativewire.CommandStats:           rejectedRow(nativewire.CommandStats, "CommandStats", "stats", "read-only", "none", "read_rejected_v1", "reads are not replicated mutations"),
+}
+
+func acceptedRow(id nativewire.CommandID, nativeWireCommand, commandName, walKind, bytes, reason string) CommandRowV1 {
+	return CommandRowV1{
+		Known:                   true,
+		CommandID:               id,
+		NativeWireCommand:       nativeWireCommand,
+		CommandName:             commandName,
+		Decision:                DecisionAccepted,
+		DuplicateMode:           DuplicateFailClosedAllowedV1,
+		ResultReplayMode:        ResultReplayFailClosedV1,
+		CommandWALStatus:        "WAL-supported",
+		CommandWALKind:          walKind,
+		DeterministicEntryBytes: bytes,
+		Reason:                  reason,
+	}
+}
+
+func rejectedRow(id nativewire.CommandID, nativeWireCommand, commandName, walStatus, walKind, bytes, reason string) CommandRowV1 {
+	return CommandRowV1{
+		Known:                   true,
+		CommandID:               id,
+		NativeWireCommand:       nativeWireCommand,
+		CommandName:             commandName,
+		Decision:                DecisionRejected,
+		DuplicateMode:           DuplicateRejectedUnsupportedV1,
+		ResultReplayMode:        ResultReplayNoneRejectedV1,
+		CommandWALStatus:        walStatus,
+		CommandWALKind:          walKind,
+		DeterministicEntryBytes: bytes,
+		Reason:                  reason,
+	}
+}


### PR DESCRIPTION
## Summary

- Add `TreeDB/internal/raftentry` as the R3a v1 contract layer over existing native-wire deterministic entry bytes; no second semantic command encoding is introduced.
- Define `CommandEntryV1`, `CommandDigestV1`, `ApplyResultV1`, `ApplyEntryID`, request metadata exclusion, target identity, single-group-v1/database/catalog scope, idempotency mode, result replay modes, and stable rejection/error vocabulary.
- Add an executable allowlist/rejection matrix: create collection is accepted as duplicate-fail-closed for the first vertical slice; insert/replace/delete/update_bson_set are classified but rejected; index DDL, drop collection, barriers, reads/cursors, malformed/oversized/unknown/missing-guard entries fail closed.
- Add fixture/digest stability tests pinned to native-wire deterministic fixtures and command-WAL/native-wire alignment docs.

Closes #3038.
Refs #1654.

## Tests

- `GOWORK=off go test ./TreeDB/internal/nativewire ./TreeDB/docs ./TreeDB/internal/raftentry`

## Benchmarks

Not run. This PR adds a narrow internal contract/validation package and tests only; it does not wire the contract into a hot storage, read/write, command-WAL executor, or apply path.

## Scope Notes

- No command-WAL apply API extraction or apply harness acceptance is implemented here.
- Create collection is contract-accepted only with duplicate-fail-closed result semantics until durable result replay/progress storage lands downstream.
- Mutation widening remains rejected for R3a v1 until #3040/#3041/#3042 wire and prove the apply/lower/convergence path.

## Review Status

Internal diff review completed. AI reviews were not requested because the coordinator owns review timing for this graph.