### PR TITLE
TreeDB: allow nullable aggregate metadata predicates

### DIFF
--- a/TreeDB/collections/column_aggregate_metadata_asset.go
+++ b/TreeDB/collections/column_aggregate_metadata_asset.go
@@ -298,7 +298,7 @@ func buildColumnAggregateMetadataAsset(cfg ColumnStoreConfig, rows []columnDecla
 			}
 			groupValue := row.Values[groupIdx]
 			if groupValue.Null || !groupValue.Present {
-				return columnAggregateMetadataAsset{}, false, fmt.Errorf("%w: aggregate metadata %q does not support null or missing values", ErrColumnQueryPlanUnsupported, aggregate.Name)
+				groupValue = columnDeclaredValue{Type: ColumnStoreValueString, Present: true, String: ""}
 			}
 			if groupValue.Type != ColumnStoreValueString {
 				return columnAggregateMetadataAsset{}, false, fmt.Errorf("%w: aggregate metadata %q encountered incompatible row value types", ErrColumnQueryPlanUnsupported, aggregate.Name)

--- a/TreeDB/collections/column_aggregate_metadata_predicate.go
+++ b/TreeDB/collections/column_aggregate_metadata_predicate.go
@@ -36,9 +36,6 @@ func columnAggregateMetadataPredicateSpecs(cfg ColumnStoreConfig, predicates []C
 		if !col.Dictionary {
 			return nil, fmt.Errorf("%w: aggregate metadata predicate column %q requires dictionary string storage", ErrColumnQueryPlanUnsupported, predicate.Column)
 		}
-		if col.Nullable {
-			return nil, fmt.Errorf("%w: aggregate metadata predicate column %q does not support nullable values", ErrColumnQueryPlanUnsupported, predicate.Column)
-		}
 		kind := columnPhysicalQueryPredicateKindOrDefault(predicate.Kind)
 		var values []string
 		switch kind {
@@ -162,7 +159,7 @@ func columnAggregateMetadataPredicatesMatchRow(specs []columnAggregateMetadataPr
 		}
 		value := values[spec.columnIdx]
 		if value.Null || !value.Present {
-			return false, fmt.Errorf("%w: aggregate metadata predicate column %q does not support null or missing values", ErrColumnQueryPlanUnsupported, spec.column)
+			return false, nil
 		}
 		if value.Type != ColumnStoreValueString {
 			return false, fmt.Errorf("%w: aggregate metadata predicate column %q encountered incompatible row value type %q", ErrColumnQueryPlanUnsupported, spec.column, value.Type)

--- a/TreeDB/collections/column_aggregate_metadata_predicate.go
+++ b/TreeDB/collections/column_aggregate_metadata_predicate.go
@@ -6,10 +6,11 @@ import (
 )
 
 type columnAggregateMetadataPredicateSpec struct {
-	column    string
-	kind      ColumnPhysicalQueryPredicateKind
-	values    []string
-	columnIdx int
+	column              string
+	kind                ColumnPhysicalQueryPredicateKind
+	values              []string
+	columnIdx           int
+	missingMatchesEmpty bool
 }
 
 func columnAggregateMetadataPredicateSpecs(cfg ColumnStoreConfig, predicates []ColumnPhysicalQueryPredicate) ([]columnAggregateMetadataPredicateSpec, error) {
@@ -66,10 +67,25 @@ func columnAggregateMetadataPredicateSpecs(cfg ColumnStoreConfig, predicates []C
 				}
 			}
 		}
-		specs = append(specs, columnAggregateMetadataPredicateSpec{column: predicate.Column, kind: kind, values: values, columnIdx: columnIdx})
+		specs = append(specs, columnAggregateMetadataPredicateSpec{
+			column:              predicate.Column,
+			kind:                kind,
+			values:              values,
+			columnIdx:           columnIdx,
+			missingMatchesEmpty: col.Nullable && columnAggregateMetadataPredicateValuesContainEmpty(values),
+		})
 	}
 	sort.Slice(specs, func(i, j int) bool { return specs[i].column < specs[j].column })
 	return specs, nil
+}
+
+func columnAggregateMetadataPredicateValuesContainEmpty(values []string) bool {
+	for _, value := range values {
+		if value == "" {
+			return true
+		}
+	}
+	return false
 }
 
 func columnAggregateMetadataCanonicalPredicates(cfg ColumnStoreConfig, predicates []ColumnPhysicalQueryPredicate) ([]ColumnPhysicalQueryPredicate, error) {
@@ -159,6 +175,9 @@ func columnAggregateMetadataPredicatesMatchRow(specs []columnAggregateMetadataPr
 		}
 		value := values[spec.columnIdx]
 		if value.Null || !value.Present {
+			if spec.missingMatchesEmpty {
+				continue
+			}
 			return false, nil
 		}
 		if value.Type != ColumnStoreValueString {

--- a/TreeDB/collections/column_aggregate_metadata_predicate_1951_test.go
+++ b/TreeDB/collections/column_aggregate_metadata_predicate_1951_test.go
@@ -153,6 +153,117 @@ func TestPredicateQualifiedAggregateMetadataQ3GroupHourDirectPrepared2892(t *tes
 	}
 }
 
+func TestPredicateQualifiedAggregateMetadataNullablePredicatesSkipNullRows3001(t *testing.T) {
+	cfg := *predicateAggregateMetadataConfig1951()
+	for idx := range cfg.Columns {
+		switch cfg.Columns[idx].Name {
+		case "kind", "operation", "collection", "did":
+			cfg.Columns[idx].Nullable = true
+		}
+	}
+	cfg.AggregateMetadata = []ColumnAggregateMetadata{{
+		Name:        "matching_dids",
+		GroupColumn: "did",
+		Kind:        ColumnAggregateCount,
+		Predicates:  columnPredicateAggregateMetadataPostPredicates1951(),
+	}}
+	rows := []columnDeclaredRow{
+		{ID: []byte("match"), Values: []columnDeclaredValue{
+			{Type: ColumnStoreValueInt64, Present: true, Int64: 1},
+			{Type: ColumnStoreValueString, Present: true, String: "commit"},
+			{Type: ColumnStoreValueString, Present: true, String: "create"},
+			{Type: ColumnStoreValueString, Present: true, String: "app.bsky.feed.post"},
+			{Type: ColumnStoreValueString, Present: true, String: "did:match"},
+		}},
+		{ID: []byte("null-kind"), Values: []columnDeclaredValue{
+			{Type: ColumnStoreValueInt64, Present: true, Int64: 2},
+			{Type: ColumnStoreValueString, Present: true, Null: true},
+			{Type: ColumnStoreValueString, Present: true, String: "create"},
+			{Type: ColumnStoreValueString, Present: true, String: "app.bsky.feed.post"},
+			{Type: ColumnStoreValueString, Present: true, String: "did:null-kind"},
+		}},
+		{ID: []byte("missing-operation"), Values: []columnDeclaredValue{
+			{Type: ColumnStoreValueInt64, Present: true, Int64: 3},
+			{Type: ColumnStoreValueString, Present: true, String: "commit"},
+			{Type: ColumnStoreValueString},
+			{Type: ColumnStoreValueString, Present: true, String: "app.bsky.feed.post"},
+			{Type: ColumnStoreValueString, Present: true, String: "did:missing-operation"},
+		}},
+		{ID: []byte("wrong-collection"), Values: []columnDeclaredValue{
+			{Type: ColumnStoreValueInt64, Present: true, Int64: 4},
+			{Type: ColumnStoreValueString, Present: true, String: "commit"},
+			{Type: ColumnStoreValueString, Present: true, String: "create"},
+			{Type: ColumnStoreValueString, Present: true, String: "app.bsky.feed.like"},
+			{Type: ColumnStoreValueString, Present: true, String: "did:wrong-collection"},
+		}},
+	}
+
+	asset, ok, err := buildColumnAggregateMetadataAsset(cfg, rows, cfg.AggregateMetadata[0], "events", "events/column-assets", 1, typedColumnPartAssetPartID, 1)
+	if err != nil || !ok {
+		t.Fatalf("buildColumnAggregateMetadataAsset ok=%v err=%v", ok, err)
+	}
+	want := []columnAggregateMetadataEntry{{Group: "did:match", Count: 1}}
+	if !equalColumnAggregateMetadataEntries3001(asset.Entries, want) {
+		t.Fatalf("asset entries=%+v want %+v", asset.Entries, want)
+	}
+}
+
+func TestAggregateMetadataNullableGroupBucketsAsEmptyString3001(t *testing.T) {
+	cfg := *typedColumnSortKeyConfig1948(nil)
+	for idx := range cfg.Columns {
+		if cfg.Columns[idx].Name == "collection" {
+			cfg.Columns[idx].Nullable = true
+		}
+	}
+	aggregate := ColumnAggregateMetadata{
+		Name:        "collection_count",
+		GroupColumn: "collection",
+		Kind:        ColumnAggregateCount,
+	}
+	rows := []columnDeclaredRow{
+		{ID: []byte("alpha"), Values: []columnDeclaredValue{
+			{Type: ColumnStoreValueInt64, Present: true, Int64: 1},
+			{Type: ColumnStoreValueString, Present: true, String: "commit"},
+			{Type: ColumnStoreValueString, Present: true, String: "create"},
+			{Type: ColumnStoreValueString, Present: true, String: "alpha"},
+			{Type: ColumnStoreValueString, Present: true, String: "did:alpha"},
+		}},
+		{ID: []byte("null-group"), Values: []columnDeclaredValue{
+			{Type: ColumnStoreValueInt64, Present: true, Int64: 2},
+			{Type: ColumnStoreValueString, Present: true, String: "commit"},
+			{Type: ColumnStoreValueString, Present: true, String: "create"},
+			{Type: ColumnStoreValueString, Present: true, Null: true},
+			{Type: ColumnStoreValueString, Present: true, String: "did:null"},
+		}},
+		{ID: []byte("missing-group"), Values: []columnDeclaredValue{
+			{Type: ColumnStoreValueInt64, Present: true, Int64: 3},
+			{Type: ColumnStoreValueString, Present: true, String: "commit"},
+			{Type: ColumnStoreValueString, Present: true, String: "create"},
+			{Type: ColumnStoreValueString},
+			{Type: ColumnStoreValueString, Present: true, String: "did:missing"},
+		}},
+		{ID: []byte("deleted-null-group"), Deleted: true, Values: []columnDeclaredValue{
+			{Type: ColumnStoreValueInt64, Present: true, Int64: 4},
+			{Type: ColumnStoreValueString, Present: true, String: "commit"},
+			{Type: ColumnStoreValueString, Present: true, String: "create"},
+			{Type: ColumnStoreValueString, Present: true, Null: true},
+			{Type: ColumnStoreValueString, Present: true, String: "did:deleted"},
+		}},
+	}
+
+	asset, ok, err := buildColumnAggregateMetadataAsset(cfg, rows, aggregate, "events", "events/column-assets", 1, typedColumnPartAssetPartID, 1)
+	if err != nil || !ok {
+		t.Fatalf("buildColumnAggregateMetadataAsset ok=%v err=%v", ok, err)
+	}
+	want := []columnAggregateMetadataEntry{
+		{Group: "", Count: 2},
+		{Group: "alpha", Count: 1},
+	}
+	if !equalColumnAggregateMetadataEntries3001(asset.Entries, want) {
+		t.Fatalf("asset entries=%+v want %+v", asset.Entries, want)
+	}
+}
+
 func TestPredicateQualifiedAggregateMetadataExactPredicateCoverage1951(t *testing.T) {
 	_, col, closeFn := openPredicateAggregateMetadataFixture1951(t, [][]columnPhysicalJSONBenchParityEventP0{columnPhysicalQ5DenseBatchA1950()})
 	defer closeFn()
@@ -619,4 +730,16 @@ func reportPredicateAggregateMetadataBenchMetrics1951(b *testing.B, diag ColumnP
 	b.ReportMetric(float64(diag.ReduceRows), "reduce_rows/op")
 	b.ReportMetric(float64(diag.DecodedMetadataBytes), "metadata_decoded_bytes/op")
 	b.ReportMetric(float64(diag.ResultShapeNanos), "result_shape_ns/op")
+}
+
+func equalColumnAggregateMetadataEntries3001(left, right []columnAggregateMetadataEntry) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for idx := range left {
+		if left[idx] != right[idx] {
+			return false
+		}
+	}
+	return true
 }

--- a/TreeDB/collections/column_aggregate_metadata_predicate_1951_test.go
+++ b/TreeDB/collections/column_aggregate_metadata_predicate_1951_test.go
@@ -208,6 +208,64 @@ func TestPredicateQualifiedAggregateMetadataNullablePredicatesSkipNullRows3001(t
 	}
 }
 
+func TestPredicateQualifiedAggregateMetadataNullableEmptyPredicateMatchesMissingRows3001(t *testing.T) {
+	cfg := *predicateAggregateMetadataConfig1951()
+	for idx := range cfg.Columns {
+		if cfg.Columns[idx].Name == "operation" {
+			cfg.Columns[idx].Nullable = true
+		}
+	}
+	cfg.AggregateMetadata = []ColumnAggregateMetadata{{
+		Name:        "empty_operation_dids",
+		GroupColumn: "did",
+		Kind:        ColumnAggregateCount,
+		Predicates:  []ColumnPhysicalQueryPredicate{{Column: "operation", Value: ""}},
+	}}
+	rows := []columnDeclaredRow{
+		{ID: []byte("explicit-empty"), Values: []columnDeclaredValue{
+			{Type: ColumnStoreValueInt64, Present: true, Int64: 1},
+			{Type: ColumnStoreValueString, Present: true, String: "commit"},
+			{Type: ColumnStoreValueString, Present: true, String: ""},
+			{Type: ColumnStoreValueString, Present: true, String: "app.bsky.feed.post"},
+			{Type: ColumnStoreValueString, Present: true, String: "did:empty"},
+		}},
+		{ID: []byte("null-operation"), Values: []columnDeclaredValue{
+			{Type: ColumnStoreValueInt64, Present: true, Int64: 2},
+			{Type: ColumnStoreValueString, Present: true, String: "commit"},
+			{Type: ColumnStoreValueString, Present: true, Null: true},
+			{Type: ColumnStoreValueString, Present: true, String: "app.bsky.feed.post"},
+			{Type: ColumnStoreValueString, Present: true, String: "did:null"},
+		}},
+		{ID: []byte("missing-operation"), Values: []columnDeclaredValue{
+			{Type: ColumnStoreValueInt64, Present: true, Int64: 3},
+			{Type: ColumnStoreValueString, Present: true, String: "commit"},
+			{Type: ColumnStoreValueString},
+			{Type: ColumnStoreValueString, Present: true, String: "app.bsky.feed.post"},
+			{Type: ColumnStoreValueString, Present: true, String: "did:missing"},
+		}},
+		{ID: []byte("create-operation"), Values: []columnDeclaredValue{
+			{Type: ColumnStoreValueInt64, Present: true, Int64: 4},
+			{Type: ColumnStoreValueString, Present: true, String: "commit"},
+			{Type: ColumnStoreValueString, Present: true, String: "create"},
+			{Type: ColumnStoreValueString, Present: true, String: "app.bsky.feed.post"},
+			{Type: ColumnStoreValueString, Present: true, String: "did:create"},
+		}},
+	}
+
+	asset, ok, err := buildColumnAggregateMetadataAsset(cfg, rows, cfg.AggregateMetadata[0], "events", "events/column-assets", 1, typedColumnPartAssetPartID, 1)
+	if err != nil || !ok {
+		t.Fatalf("buildColumnAggregateMetadataAsset ok=%v err=%v", ok, err)
+	}
+	want := []columnAggregateMetadataEntry{
+		{Group: "did:empty", Count: 1},
+		{Group: "did:missing", Count: 1},
+		{Group: "did:null", Count: 1},
+	}
+	if !equalColumnAggregateMetadataEntries3001(asset.Entries, want) {
+		t.Fatalf("asset entries=%+v want %+v", asset.Entries, want)
+	}
+}
+
 func TestAggregateMetadataNullableGroupBucketsAsEmptyString3001(t *testing.T) {
 	cfg := *typedColumnSortKeyConfig1948(nil)
 	for idx := range cfg.Columns {

--- a/TreeDB/collections/typed_storage_naming_test.go
+++ b/TreeDB/collections/typed_storage_naming_test.go
@@ -332,9 +332,9 @@ type typedStorageLegacyNameAllowlistEntry struct {
 
 var typedStorageLegacyNameAllowlist = []typedStorageLegacyNameAllowlistEntry{
 	{path: "TreeDB/collections/api.go", classification: typedStorageLegacyCompatibility, matchingLines: 56, occurrences: 62},
-	{path: "TreeDB/collections/column_aggregate_metadata_asset.go", classification: typedStorageLegacyDerived, matchingLines: 17, occurrences: 19},
+	{path: "TreeDB/collections/column_aggregate_metadata_asset.go", classification: typedStorageLegacyDerived, matchingLines: 18, occurrences: 20},
 	{path: "TreeDB/collections/column_aggregate_metadata_predicate.go", classification: typedStorageLegacyDerived, matchingLines: 6, occurrences: 6},
-	{path: "TreeDB/collections/column_aggregate_metadata_predicate_1951_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 17, occurrences: 18},
+	{path: "TreeDB/collections/column_aggregate_metadata_predicate_1951_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 57, occurrences: 58},
 	{path: "TreeDB/collections/column_aggregate_metadata_typed_column_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 19, occurrences: 21},
 	{path: "TreeDB/collections/column_asset_gc_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 35, occurrences: 37},
 	{path: "TreeDB/collections/column_asset_lifecycle.go", classification: typedStorageLegacyCompatibility, matchingLines: 1, occurrences: 1},

--- a/TreeDB/collections/typed_storage_naming_test.go
+++ b/TreeDB/collections/typed_storage_naming_test.go
@@ -334,7 +334,7 @@ var typedStorageLegacyNameAllowlist = []typedStorageLegacyNameAllowlistEntry{
 	{path: "TreeDB/collections/api.go", classification: typedStorageLegacyCompatibility, matchingLines: 56, occurrences: 62},
 	{path: "TreeDB/collections/column_aggregate_metadata_asset.go", classification: typedStorageLegacyDerived, matchingLines: 18, occurrences: 20},
 	{path: "TreeDB/collections/column_aggregate_metadata_predicate.go", classification: typedStorageLegacyDerived, matchingLines: 6, occurrences: 6},
-	{path: "TreeDB/collections/column_aggregate_metadata_predicate_1951_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 57, occurrences: 58},
+	{path: "TreeDB/collections/column_aggregate_metadata_predicate_1951_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 77, occurrences: 78},
 	{path: "TreeDB/collections/column_aggregate_metadata_typed_column_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 19, occurrences: 21},
 	{path: "TreeDB/collections/column_asset_gc_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 35, occurrences: 37},
 	{path: "TreeDB/collections/column_asset_lifecycle.go", classification: typedStorageLegacyCompatibility, matchingLines: 1, occurrences: 1},


### PR DESCRIPTION
## Summary

- allow aggregate metadata predicates on nullable dictionary string columns to treat null/missing cells as non-matches instead of rejecting the metadata build
- allow nullable/missing string group cells to materialize into the empty-string group, matching physical query semantics and letting full-retained JSONBench metadata build on nullable full-data columns
- add focused regression tests for nullable predicate skip behavior and nullable group bucketing, and update the typed-storage naming inventory counts for the new compatibility references

## Linked tracker

- Parent: #3000
- Final evidence gate: #3001
- Historical q1/q3 metadata child: #2892

## Start-phase test plan

- Focused aggregate metadata tests for nullable predicates/group keys.
- Full `TreeDB/collections` package after naming allowlist update.
- External JSONBench harness smoke using local gomap replace to prove the production full-retained q1/q3/q5 metadata path can build and run.

## Close-phase test evidence

```sh
go test ./TreeDB/collections -run 'TestPredicateQualifiedAggregateMetadataNullablePredicatesSkipNullRows3001|TestAggregateMetadataNullableGroupBucketsAsEmptyString3001|TestPredicateQualifiedAggregateMetadataQ3GroupHourDirectPrepared2892|TestPredicateQualifiedAggregateMetadataQ4Q5DirectPrepared1951' -count=1
```

Result: passed.

```sh
go test ./TreeDB/collections -run 'TestTypedStorageLegacyNameAllowlistIsComplete|TestPredicateQualifiedAggregateMetadataNullablePredicatesSkipNullRows3001|TestAggregateMetadataNullableGroupBucketsAsEmptyString3001' -count=1
```

Result: passed.

```sh
go test ./TreeDB/collections -count=1
```

Result: passed.

## Benchmark evidence

External JSONBench rerun using this branch via `GOMAP_REPLACE` and local JSONBench harness changes:

```sh
OUT_DIR=/tmp/jsonbench_preferred_columnstore_clickhouse_1m_fullmeta_20260625_110844 \
DATA_DIR=/Users/michaelseiler/data/bluesky \
ROWS=1000000 TRIES=3 \
GOMAP_REPLACE=/Users/michaelseiler/dev/snissn/gomap-clean \
CLICKHOUSE_BIN=/Users/michaelseiler/dev/snissn/JSONBench/clickhouse/clickhouse \
RUN_CLICKHOUSE=0 \
CLICKHOUSE_RESULT=/tmp/jsonbench_preferred_columnstore_clickhouse_1m_20260625_205241/clickhouse/result.json \
./run_preferred_columnstore_clickhouse_compare.sh
```

Artifacts:

- `/tmp/jsonbench_preferred_columnstore_clickhouse_1m_fullmeta_20260625_110844/preferred_summary.md`
- `/tmp/jsonbench_preferred_columnstore_clickhouse_1m_fullmeta_20260625_110844/treedb/report.json`
- reused ClickHouse reference: `/tmp/jsonbench_preferred_columnstore_clickhouse_1m_20260625_205241/clickhouse/result.json`

| query | TreeDB best | ClickHouse best | TreeDB status | storage source | fallback |
| --- | ---: | ---: | --- | --- | --- |
| q1 | `5.0us` | `0.0030s` | `595.0x faster` | `aggregate_metadata` | `none` |
| q2 | `0.0074s` | `0.0200s` | `2.7x faster` | `typed_column_part_section` | `none` |
| q3 | `1.7us` | `0.0110s` | `6598.7x faster` | `aggregate_metadata` | `none` |
| q4 | `242.8us` | `0.0120s` | `49.4x faster` | `typed_column_part_section` | `none` |
| q5 | `667.9us` | `0.0130s` | `19.5x faster` | `aggregate_metadata` | `none` |

Diagnostic highlights from TreeDB full-retained rows:

- q1/q3/q5: `document_scan_fallback=false`, `query_path=column_physical`, `storage_source=aggregate_metadata`.
- q1: `decoded_metadata_bytes=105102`, `physical_bytes_scanned=105102`, `result_groups=15`.
- q3: `decoded_metadata_bytes=45814`, `physical_bytes_scanned=45814`, `result_groups=3`.
- q5: `decoded_metadata_bytes=5709366`, `physical_bytes_scanned=5709366`, `result_groups=3`.
- full-retained durable storage: `131.12 MiB`, typed part `20.63 MiB`, WAL `0 B`; load `26.236s`.

## 10M gate status

The 10M command failed before query measurement on a malformed input row, not a TreeDB query-performance path:

```sh
OUT_DIR=/tmp/jsonbench_preferred_columnstore_clickhouse_10m_fullmeta_20260625_111402 \
DATA_DIR=/Users/michaelseiler/data/bluesky \
ROWS=10000000 TRIES=3 \
GOMAP_REPLACE=/Users/michaelseiler/dev/snissn/gomap-clean \
CLICKHOUSE_BIN=/Users/michaelseiler/dev/snissn/JSONBench/clickhouse/clickhouse \
./run_preferred_columnstore_clickhouse_compare.sh
```

Failure:

```text
jsonbench_treedb: read /Users/michaelseiler/data/bluesky/file_0005.json.gz: collections: invalid JSON document for column retained payload: unexpected EOF
```

Follow-up validation:

```sh
gzip -t /Users/michaelseiler/data/bluesky/file_*.json.gz
```

Result: passed, so the gzip shards are complete.

```sh
gzip -cd /Users/michaelseiler/data/bluesky/file_0005.json.gz | jq -c . >/dev/null
```

Result: `jq: parse error: Invalid string: control characters from U+0000 through U+001F must be escaped at line 91841, column 80`.

This leaves the 10M gate blocked on data/harness invalid-row policy. ClickHouse is currently run with `CLICKHOUSE_ALLOW_ERRORS=1`; TreeDB full-retained retained-payload loading still fails closed on malformed JSON.

## Performance regression assessment

The changed code affects aggregate metadata build semantics only. It removes nullable-column build rejections for dictionary string predicates and group keys, enabling the existing exact metadata path over full-retained nullable columns. The 1M evidence shows q1/q3/q5 route to aggregate metadata and no q2/q4 regression in the preferred comparison.

## AI review status

Not requested yet. This PR is now mature enough for normal CI/review: coherent patch, focused tests, full affected package test, benchmark evidence, and tracker-linked 10M blocker are documented.
