### PR TITLE
[codex] add R3a deterministic apply harness

### DIFF
--- a/TreeDB/db/command_wal_raw.go
+++ b/TreeDB/db/command_wal_raw.go
@@ -252,6 +252,9 @@ func (db *DB) NewCommandWALIntent(kind commitlog.CommandKind, scope commitlog.Co
 	if db == nil || !db.commandWAL {
 		return nil, nil
 	}
+	if db.readOnly {
+		return nil, ErrReadOnly
+	}
 	if db.durability == DurabilityWALOffRelaxed {
 		return nil, fmt.Errorf("%w: WAL-off durability is incompatible with command WAL", ErrCommandWALUnsupported)
 	}
@@ -563,6 +566,9 @@ func (db *DB) appendPublicCommandWALIntent(intent *CommandWALIntent, sync bool) 
 // publishing roots. It is used by cached public command-WAL writers that must
 // make a typed frame replay-visible before inserting the mutation into memory.
 func (db *DB) AppendCommandWALIntent(intent *CommandWALIntent, sync bool) (uint64, error) {
+	if db != nil && db.readOnly {
+		return 0, ErrReadOnly
+	}
 	return db.appendPublicCommandWALIntent(intent, sync)
 }
 
@@ -572,6 +578,9 @@ func (db *DB) AppendCommandWALIntent(intent *CommandWALIntent, sync bool) (uint6
 func (db *DB) AppendCommandWALPayload(kind commitlog.CommandKind, scope commitlog.CommandScope, payloadFormat commitlog.PayloadFormat, payload []byte, sync bool) (uint64, error) {
 	if db == nil || !db.commandWAL {
 		return 0, nil
+	}
+	if db.readOnly {
+		return 0, ErrReadOnly
 	}
 	if db.durability == DurabilityWALOffRelaxed {
 		return 0, fmt.Errorf("%w: WAL-off durability is incompatible with command WAL", ErrCommandWALUnsupported)
@@ -750,6 +759,9 @@ func (db *DB) PublishCommandWALNoop(intent *CommandWALIntent, sync bool) error {
 	}
 	if db == nil {
 		return ErrClosed
+	}
+	if db.readOnly {
+		return ErrReadOnly
 	}
 	if !db.CommandWALEnabled() {
 		return ErrCommandWALUnsupported

--- a/TreeDB/internal/commandwalapply/apply.go
+++ b/TreeDB/internal/commandwalapply/apply.go
@@ -1,0 +1,181 @@
+// Package commandwalapply exposes the narrow internal boundary between future
+// R3a deterministic-entry lowering and TreeDB's local command WAL.
+package commandwalapply
+
+import (
+	"fmt"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+	"github.com/snissn/gomap/TreeDB/internal/commitlog"
+)
+
+// RecoverabilityStatus names the local recovery boundary reached by an apply
+// step. These are local TreeDB states, not Raft consensus states.
+type RecoverabilityStatus string
+
+const (
+	StatusLocallyApplied         RecoverabilityStatus = "locally_applied"
+	StatusLocallyWALRecoverable  RecoverabilityStatus = "locally_wal_recoverable"
+	StatusLocallyRootRecoverable RecoverabilityStatus = "locally_root_recoverable"
+)
+
+// LoweredFrameClass identifies which already-classified lowering path produced
+// a frame. This spike accepts only the scoped no-op class so it cannot widen the
+// replicated command set ahead of the R3a contract and harness PRs.
+type LoweredFrameClass uint8
+
+const (
+	LoweredFrameClassTestNoop LoweredFrameClass = iota + 1
+)
+
+// ApplyMetadata is the explicit metadata slot future R3a apply code will carry
+// beside a lowered frame. It is intentionally empty here; this package must not
+// define #3038's entry/result/idempotency contract or #3040's apply metadata.
+type ApplyMetadata struct{}
+
+// LoweredFrame is the command-WAL payload produced after deterministic-entry
+// classification and lowering. It is not a native-wire request and does not
+// encode a Raft log entry.
+type LoweredFrame struct {
+	Class         LoweredFrameClass
+	Kind          commitlog.CommandKind
+	Scope         commitlog.CommandScope
+	PayloadFormat commitlog.PayloadFormat
+	Payload       []byte
+}
+
+// Options controls local command-WAL durability for this apply boundary.
+type Options struct {
+	Sync bool
+}
+
+// Handle is the append token required to publish the same local command-WAL
+// frame after the normal executor has made the command locally visible.
+type Handle struct {
+	intent *backenddb.CommandWALIntent
+	lsn    uint64
+}
+
+// LSN returns the local command-WAL sequence number assigned at append time.
+func (h Handle) LSN() uint64 {
+	return h.lsn
+}
+
+// Result describes the local apply/recoverability boundary reached.
+type Result struct {
+	LSN               uint64
+	Status            RecoverabilityStatus
+	AppliedCommandLSN uint64
+}
+
+// TestNoopFrame returns the only frame class accepted by this issue's spike: a
+// canonical empty RawKVBatch command. It exercises append/finalize without
+// accepting user mutations or bypassing collection/catalog executors.
+func TestNoopFrame() (LoweredFrame, error) {
+	payload, err := commitlog.EncodeRawKVBatchPayload(nil)
+	if err != nil {
+		return LoweredFrame{}, err
+	}
+	return LoweredFrame{
+		Class:         LoweredFrameClassTestNoop,
+		Kind:          commitlog.CommandKindRawKVBatch,
+		Scope:         commitlog.CommandScopeRawKV,
+		PayloadFormat: commitlog.PayloadFormatRawKVBatchV1,
+		Payload:       payload,
+	}, nil
+}
+
+// Append validates and appends a lowered local command-WAL frame. It does not
+// publish roots or AppliedCommandLSN; callers must run the normal executor and
+// then call Finalize with the returned handle.
+func Append(db *backenddb.DB, frame LoweredFrame, _ ApplyMetadata, opts Options) (Handle, Result, error) {
+	if db == nil {
+		return Handle{}, Result{}, backenddb.ErrClosed
+	}
+	if !db.CommandWALEnabled() {
+		return Handle{}, Result{}, fmt.Errorf("%w: command wal apply requires command_wal_v1", backenddb.ErrCommandWALUnsupported)
+	}
+	if err := validateLoweredFrame(frame); err != nil {
+		return Handle{}, Result{}, err
+	}
+	intent, err := db.NewCommandWALIntent(frame.Kind, frame.Scope, frame.PayloadFormat, frame.Payload)
+	if err != nil {
+		return Handle{}, Result{}, err
+	}
+	if intent == nil {
+		return Handle{}, Result{}, fmt.Errorf("%w: command wal apply intent unavailable", backenddb.ErrCommandWALUnsupported)
+	}
+	lsn, err := db.AppendCommandWALIntent(intent, opts.Sync)
+	if err != nil {
+		return Handle{}, Result{}, err
+	}
+	applied := uint64(0)
+	if state := db.State(); state != nil {
+		applied = state.AppliedCommandLSN
+	}
+	return Handle{intent: intent, lsn: lsn}, Result{
+		LSN:               lsn,
+		Status:            StatusLocallyWALRecoverable,
+		AppliedCommandLSN: applied,
+	}, nil
+}
+
+// Finalize publishes the current roots with AppliedCommandLSN covering the
+// command frame represented by handle. The no-op frame used by this spike has no
+// mutation effects, but the publish path is the same root/AppliedLSN boundary
+// future executor-backed commands must use.
+func Finalize(db *backenddb.DB, handle Handle, _ ApplyMetadata, opts Options) (Result, error) {
+	if db == nil {
+		return Result{}, backenddb.ErrClosed
+	}
+	if handle.intent == nil || handle.lsn == 0 {
+		return Result{}, fmt.Errorf("%w: command wal apply finalize missing appended frame", backenddb.ErrCommandWALRejected)
+	}
+	if err := db.PublishCommandWALNoop(handle.intent, opts.Sync); err != nil {
+		return Result{}, err
+	}
+	applied := uint64(0)
+	if state := db.State(); state != nil {
+		applied = state.AppliedCommandLSN
+	}
+	return Result{
+		LSN:               handle.lsn,
+		Status:            StatusLocallyRootRecoverable,
+		AppliedCommandLSN: applied,
+	}, nil
+}
+
+// ApplyNoop appends and finalizes the scoped no-op frame. It exists only to
+// test the boundary end-to-end without adding accepted replicated commands.
+func ApplyNoop(db *backenddb.DB, frame LoweredFrame, meta ApplyMetadata, opts Options) (Result, error) {
+	handle, _, err := Append(db, frame, meta, opts)
+	if err != nil {
+		return Result{}, err
+	}
+	return Finalize(db, handle, meta, opts)
+}
+
+func validateLoweredFrame(frame LoweredFrame) error {
+	switch frame.Class {
+	case LoweredFrameClassTestNoop:
+		return validateTestNoopFrame(frame)
+	default:
+		return fmt.Errorf("%w: command wal apply frame class %d is not accepted", backenddb.ErrCommandWALUnsupported, frame.Class)
+	}
+}
+
+func validateTestNoopFrame(frame LoweredFrame) error {
+	if frame.Kind != commitlog.CommandKindRawKVBatch ||
+		frame.Scope != commitlog.CommandScopeRawKV ||
+		frame.PayloadFormat != commitlog.PayloadFormatRawKVBatchV1 {
+		return fmt.Errorf("%w: command wal apply test frame has unsupported identity kind=%d scope=%d format=%d", backenddb.ErrCommandWALUnsupported, frame.Kind, frame.Scope, frame.PayloadFormat)
+	}
+	ops, err := commitlog.DecodeRawKVBatchPayload(frame.Payload)
+	if err != nil {
+		return fmt.Errorf("%w: malformed command wal apply test frame: %v", backenddb.ErrCommandWALRejected, err)
+	}
+	if len(ops) != 0 {
+		return fmt.Errorf("%w: command wal apply test frame must be an empty RawKVBatch", backenddb.ErrCommandWALUnsupported)
+	}
+	return nil
+}

--- a/TreeDB/internal/commandwalapply/apply_test.go
+++ b/TreeDB/internal/commandwalapply/apply_test.go
@@ -1,0 +1,304 @@
+package commandwalapply
+
+import (
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+	"github.com/snissn/gomap/TreeDB/internal/commitlog"
+)
+
+func TestRecoverabilityStatusNames(t *testing.T) {
+	if StatusLocallyApplied != "locally_applied" {
+		t.Fatalf("StatusLocallyApplied=%q", StatusLocallyApplied)
+	}
+	if StatusLocallyWALRecoverable != "locally_wal_recoverable" {
+		t.Fatalf("StatusLocallyWALRecoverable=%q", StatusLocallyWALRecoverable)
+	}
+	if StatusLocallyRootRecoverable != "locally_root_recoverable" {
+		t.Fatalf("StatusLocallyRootRecoverable=%q", StatusLocallyRootRecoverable)
+	}
+}
+
+func TestAppendAndFinalizeNoopFrame(t *testing.T) {
+	dir := t.TempDir()
+	db, err := backenddb.Open(backenddb.Options{
+		Dir:                          dir,
+		CommandWAL:                   true,
+		DisableBackgroundPrune:       true,
+		CommandWALStatsScan:          true,
+		CommandWALSegmentTargetBytes: 1 << 20,
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+
+	frame, err := TestNoopFrame()
+	if err != nil {
+		_ = db.Close()
+		t.Fatalf("TestNoopFrame: %v", err)
+	}
+	handle, appendResult, err := Append(db, frame, ApplyMetadata{}, Options{})
+	if err != nil {
+		_ = db.Close()
+		t.Fatalf("Append: %v", err)
+	}
+	if appendResult.Status != StatusLocallyWALRecoverable {
+		_ = db.Close()
+		t.Fatalf("append status=%q, want %q", appendResult.Status, StatusLocallyWALRecoverable)
+	}
+	if appendResult.LSN == 0 || handle.LSN() != appendResult.LSN {
+		_ = db.Close()
+		t.Fatalf("append lsn=%d handle=%d, want non-zero match", appendResult.LSN, handle.LSN())
+	}
+	if appendResult.AppliedCommandLSN != 0 || db.State().AppliedCommandLSN != 0 {
+		_ = db.Close()
+		t.Fatalf("AppliedCommandLSN after append result=%d state=%d, want 0", appendResult.AppliedCommandLSN, db.State().AppliedCommandLSN)
+	}
+	frames := readCommandWALFrames(t, dir)
+	if len(frames) != 1 {
+		_ = db.Close()
+		t.Fatalf("command WAL frames after append=%d, want 1", len(frames))
+	}
+	assertNoopFrame(t, frames[0], appendResult.LSN)
+
+	finalResult, err := Finalize(db, handle, ApplyMetadata{}, Options{})
+	if err != nil {
+		_ = db.Close()
+		t.Fatalf("Finalize: %v", err)
+	}
+	if finalResult.Status != StatusLocallyRootRecoverable {
+		_ = db.Close()
+		t.Fatalf("final status=%q, want %q", finalResult.Status, StatusLocallyRootRecoverable)
+	}
+	if finalResult.LSN != appendResult.LSN || finalResult.AppliedCommandLSN != appendResult.LSN {
+		_ = db.Close()
+		t.Fatalf("final result=%+v, want lsn and applied %d", finalResult, appendResult.LSN)
+	}
+	if got := len(readCommandWALFrames(t, dir)); got != 1 {
+		_ = db.Close()
+		t.Fatalf("command WAL frames after finalize=%d, want no duplicate append", got)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	ro, err := backenddb.Open(backenddb.Options{Dir: dir, ReadOnly: true, CommandWAL: true})
+	if err != nil {
+		t.Fatalf("read-only reopen after finalize: %v", err)
+	}
+	if got := ro.State().AppliedCommandLSN; got != appendResult.LSN {
+		_ = ro.Close()
+		t.Fatalf("reopen AppliedCommandLSN=%d, want %d", got, appendResult.LSN)
+	}
+	if err := ro.Close(); err != nil {
+		t.Fatalf("Close read-only: %v", err)
+	}
+}
+
+func TestRejectedInputFailsBeforeAppend(t *testing.T) {
+	dir := t.TempDir()
+	db, err := backenddb.Open(backenddb.Options{Dir: dir, CommandWAL: true, DisableBackgroundPrune: true})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	frame, err := TestNoopFrame()
+	if err != nil {
+		t.Fatalf("TestNoopFrame: %v", err)
+	}
+	nonEmptyPayload, err := commitlog.EncodeRawKVBatchPayload([]commitlog.RawKVOperation{{
+		Op:    commitlog.RawKVOpSet,
+		Key:   []byte("k"),
+		Value: []byte("v"),
+	}})
+	if err != nil {
+		t.Fatalf("EncodeRawKVBatchPayload: %v", err)
+	}
+	tests := []struct {
+		name    string
+		frame   LoweredFrame
+		wantErr error
+		wantMsg string
+	}{
+		{
+			name: "unsupported class",
+			frame: LoweredFrame{
+				Class:         0,
+				Kind:          commitlog.CommandKindRawKVBatch,
+				Scope:         commitlog.CommandScopeRawKV,
+				PayloadFormat: commitlog.PayloadFormatRawKVBatchV1,
+				Payload:       frame.Payload,
+			},
+			wantErr: backenddb.ErrCommandWALUnsupported,
+			wantMsg: "not accepted",
+		},
+		{
+			name: "unsupported identity",
+			frame: LoweredFrame{
+				Class:         LoweredFrameClassTestNoop,
+				Kind:          commitlog.CommandKindCollectionInsertBatchByID,
+				Scope:         commitlog.CommandScopeCollection,
+				PayloadFormat: commitlog.PayloadFormatCollectionInsertBatchByIDV1,
+				Payload:       frame.Payload,
+			},
+			wantErr: backenddb.ErrCommandWALUnsupported,
+			wantMsg: "unsupported identity",
+		},
+		{
+			name: "malformed payload",
+			frame: LoweredFrame{
+				Class:         LoweredFrameClassTestNoop,
+				Kind:          commitlog.CommandKindRawKVBatch,
+				Scope:         commitlog.CommandScopeRawKV,
+				PayloadFormat: commitlog.PayloadFormatRawKVBatchV1,
+				Payload:       []byte{0x01},
+			},
+			wantErr: backenddb.ErrCommandWALRejected,
+			wantMsg: "malformed",
+		},
+		{
+			name: "non empty raw kv payload",
+			frame: LoweredFrame{
+				Class:         LoweredFrameClassTestNoop,
+				Kind:          commitlog.CommandKindRawKVBatch,
+				Scope:         commitlog.CommandScopeRawKV,
+				PayloadFormat: commitlog.PayloadFormatRawKVBatchV1,
+				Payload:       nonEmptyPayload,
+			},
+			wantErr: backenddb.ErrCommandWALUnsupported,
+			wantMsg: "empty RawKVBatch",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			before := len(readCommandWALFrames(t, dir))
+			_, _, err := Append(db, tt.frame, ApplyMetadata{}, Options{})
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("Append error=%v, want %v", err, tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantMsg) {
+				t.Fatalf("Append error=%v, want message containing %q", err, tt.wantMsg)
+			}
+			after := len(readCommandWALFrames(t, dir))
+			if after != before {
+				t.Fatalf("command WAL frames after rejected input=%d, want %d", after, before)
+			}
+		})
+	}
+}
+
+func TestApplyRejectsReadOnlyDB(t *testing.T) {
+	dir := t.TempDir()
+	db, err := backenddb.Open(backenddb.Options{Dir: dir, CommandWAL: true, DisableBackgroundPrune: true})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	ro, err := backenddb.Open(backenddb.Options{Dir: dir, ReadOnly: true, CommandWAL: true})
+	if err != nil {
+		t.Fatalf("Open read-only: %v", err)
+	}
+	defer func() { _ = ro.Close() }()
+	frame, err := TestNoopFrame()
+	if err != nil {
+		t.Fatalf("TestNoopFrame: %v", err)
+	}
+	if _, _, err := Append(ro, frame, ApplyMetadata{}, Options{}); !errors.Is(err, backenddb.ErrReadOnly) {
+		t.Fatalf("Append read-only error=%v, want ErrReadOnly", err)
+	}
+	if got := len(readCommandWALFrames(t, dir)); got != 0 {
+		t.Fatalf("command WAL frames after read-only apply=%d, want 0", got)
+	}
+}
+
+func TestApplyRejectsCommandWALDisabledDB(t *testing.T) {
+	dir := t.TempDir()
+	db, err := backenddb.Open(backenddb.Options{
+		Dir:                    dir,
+		Durability:             backenddb.DurabilityWALOffRelaxed,
+		DisableBackgroundPrune: true,
+	})
+	if err != nil {
+		t.Fatalf("Open WAL-off DB: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	frame, err := TestNoopFrame()
+	if err != nil {
+		t.Fatalf("TestNoopFrame: %v", err)
+	}
+	if _, _, err := Append(db, frame, ApplyMetadata{}, Options{}); !errors.Is(err, backenddb.ErrCommandWALUnsupported) {
+		t.Fatalf("Append command-WAL-disabled error=%v, want ErrCommandWALUnsupported", err)
+	}
+	if got := len(readCommandWALFrames(t, dir)); got != 0 {
+		t.Fatalf("command WAL frames after disabled apply=%d, want 0", got)
+	}
+}
+
+func readCommandWALFrames(t *testing.T, dir string) []commitlog.CommandEnvelope {
+	t.Helper()
+	walDir := backenddb.WALDirPath(dir)
+	entries, err := os.ReadDir(walDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		t.Fatalf("ReadDir %s: %v", walDir, err)
+	}
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if !entry.IsDir() && commitlog.IsCommandSegmentName(entry.Name()) {
+			names = append(names, entry.Name())
+		}
+	}
+	sort.Strings(names)
+	var frames []commitlog.CommandEnvelope
+	for _, name := range names {
+		path := filepath.Join(walDir, name)
+		r, err := commitlog.NewReader(path)
+		if err != nil {
+			t.Fatalf("NewReader %s: %v", name, err)
+		}
+		for {
+			env, err := r.ReadCommandFrame()
+			if err != nil {
+				if errors.Is(err, io.EOF) {
+					break
+				}
+				_ = r.Close()
+				t.Fatalf("ReadCommandFrame %s: %v", name, err)
+			}
+			frames = append(frames, env)
+		}
+		if err := r.Close(); err != nil {
+			t.Fatalf("Close reader %s: %v", name, err)
+		}
+	}
+	return frames
+}
+
+func assertNoopFrame(t *testing.T, env commitlog.CommandEnvelope, wantLSN uint64) {
+	t.Helper()
+	if env.LSN != wantLSN ||
+		env.Kind != commitlog.CommandKindRawKVBatch ||
+		env.Scope != commitlog.CommandScopeRawKV ||
+		env.PayloadFormat != commitlog.PayloadFormatRawKVBatchV1 {
+		t.Fatalf("noop frame identity=%+v, want lsn=%d RawKVBatch/RawKV/V1", env, wantLSN)
+	}
+	ops, err := commitlog.DecodeRawKVBatchPayload(env.Payload)
+	if err != nil {
+		t.Fatalf("DecodeRawKVBatchPayload: %v", err)
+	}
+	if len(ops) != 0 {
+		t.Fatalf("noop frame ops=%+v, want empty", ops)
+	}
+}

--- a/TreeDB/internal/raftapply/apply.go
+++ b/TreeDB/internal/raftapply/apply.go
@@ -1,0 +1,209 @@
+package raftapply
+
+import (
+	"errors"
+	"fmt"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+	"github.com/snissn/gomap/TreeDB/internal/commandwalapply"
+	"github.com/snissn/gomap/TreeDB/internal/nativewire"
+	"github.com/snissn/gomap/TreeDB/internal/raftentry"
+)
+
+// LocalDurabilityBoundaryV1 names the local durability boundary a committed
+// deterministic entry is allowed to use before it becomes locally visible.
+type LocalDurabilityBoundaryV1 string
+
+const (
+	// LocalDurabilityCommandWALV1 requires a local command-WAL frame before any
+	// visible mutation, result/idempotency record, or apply-progress advance.
+	LocalDurabilityCommandWALV1 LocalDurabilityBoundaryV1 = "local-command-wal-v1"
+)
+
+// ApplyMetadataV1 is explicit per-entry metadata carried beside committed
+// deterministic entry bytes. None of these fields are native-wire request
+// structs or handler inputs.
+type ApplyMetadataV1 struct {
+	EntryID                 raftentry.ApplyEntryID
+	LocalDurabilityBoundary LocalDurabilityBoundaryV1
+	SyncLocalCommandWAL     bool
+
+	ScopeRule       raftentry.ScopeRuleV1
+	DatabaseScope   string
+	CatalogScope    string
+	RequestMetadata raftentry.RequestMetadataV1
+	ExpectedTarget  *raftentry.TargetIdentityV1
+}
+
+// CommandWALApplySeam is the local command-WAL append/finalize boundary added
+// by commandwalapply. Rejection tests inject a counting seam to prove this
+// boundary is not called before fail-closed validation completes.
+type CommandWALApplySeam interface {
+	Append(*backenddb.DB, commandwalapply.LoweredFrame, commandwalapply.ApplyMetadata, commandwalapply.Options) (commandwalapply.Handle, commandwalapply.Result, error)
+	Finalize(*backenddb.DB, commandwalapply.Handle, commandwalapply.ApplyMetadata, commandwalapply.Options) (commandwalapply.Result, error)
+}
+
+type defaultCommandWALApplySeam struct{}
+
+func (defaultCommandWALApplySeam) Append(db *backenddb.DB, frame commandwalapply.LoweredFrame, meta commandwalapply.ApplyMetadata, opts commandwalapply.Options) (commandwalapply.Handle, commandwalapply.Result, error) {
+	return commandwalapply.Append(db, frame, meta, opts)
+}
+
+func (defaultCommandWALApplySeam) Finalize(db *backenddb.DB, handle commandwalapply.Handle, meta commandwalapply.ApplyMetadata, opts commandwalapply.Options) (commandwalapply.Result, error) {
+	return commandwalapply.Finalize(db, handle, meta, opts)
+}
+
+// Options wires the harness to deterministic decode limits, fake or durable
+// stores, and the command-WAL seam. Nil stores are allowed for early tests but
+// mean duplicates/progress cannot be durably recorded.
+type Options struct {
+	DecodeLimits        nativewire.Limits
+	ProgressStore       ApplyProgressStore
+	ResultStore         ApplyResultStore
+	CommandWALApplySeam CommandWALApplySeam
+}
+
+// Harness applies committed deterministic entry bytes to one local DB handle.
+type Harness struct {
+	db       *backenddb.DB
+	opts     Options
+	walApply CommandWALApplySeam
+}
+
+// NewHarness constructs an R3a apply harness for committed deterministic bytes.
+func NewHarness(db *backenddb.DB, opts Options) *Harness {
+	walApply := opts.CommandWALApplySeam
+	if walApply == nil {
+		walApply = defaultCommandWALApplySeam{}
+	}
+	return &Harness{db: db, opts: opts, walApply: walApply}
+}
+
+// ApplyCommittedEntryV1 applies committed deterministic entry bytes through a
+// short-lived harness.
+func ApplyCommittedEntryV1(db *backenddb.DB, entryBytes []byte, meta ApplyMetadataV1, opts Options) (raftentry.ApplyResultV1, error) {
+	return NewHarness(db, opts).ApplyCommittedEntryV1(entryBytes, meta)
+}
+
+// ApplyCommittedEntryV1 decodes, validates, classifies, and fail-closed rejects
+// committed deterministic entry bytes. This slice deliberately does not lower
+// any command to a local command-WAL frame yet.
+func (h *Harness) ApplyCommittedEntryV1(entryBytes []byte, meta ApplyMetadataV1) (raftentry.ApplyResultV1, error) {
+	if h == nil {
+		return reject(raftentry.CommandDigestV1{}, raftentry.ErrorUnsafeDurabilityModeV1, fmt.Errorf("raftapply: nil harness"))
+	}
+	if err := h.preflightLocalBoundary(meta); err != nil {
+		code, _ := ErrorCodeOf(err)
+		return reject(raftentry.CommandDigestV1{}, code, err)
+	}
+	if err := validateApplyEntryID(meta.EntryID); err != nil {
+		code, _ := ErrorCodeOf(err)
+		return reject(raftentry.CommandDigestV1{}, code, err)
+	}
+	if h.opts.ProgressStore != nil {
+		if err := h.opts.ProgressStore.CheckCanApply(meta.EntryID); err != nil {
+			code, _ := ErrorCodeOf(err)
+			return reject(raftentry.CommandDigestV1{}, code, err)
+		}
+	}
+
+	decodeOpts := raftentry.DecodeOptions{
+		Limits:          h.opts.DecodeLimits,
+		ScopeRule:       meta.ScopeRule,
+		DatabaseScope:   meta.DatabaseScope,
+		CatalogScope:    meta.CatalogScope,
+		ApplyEntryID:    meta.EntryID,
+		RequestMetadata: meta.RequestMetadata,
+		ExpectedTarget:  meta.ExpectedTarget,
+	}
+	entry, err := raftentry.DecodeCommandEntryV1(entryBytes, decodeOpts)
+	if err != nil {
+		code := codeFromDecodeError(err)
+		digest, _ := raftentry.ValidateCommandDigestInputV1(entryBytes, decodeOpts)
+		return reject(digest, code, err)
+	}
+
+	if h.opts.ResultStore != nil {
+		record, ok, err := h.opts.ResultStore.LookupApplyResult(meta.EntryID)
+		if err != nil {
+			code, _ := ErrorCodeOf(err)
+			return reject(entry.Digest, code, err)
+		}
+		if ok {
+			if record.CommandDigest != entry.Digest {
+				return reject(entry.Digest, raftentry.ErrorRejectedConflictV1, fmt.Errorf("raftapply: apply entry %d/%d digest conflicts with existing result", meta.EntryID.Term, meta.EntryID.Index))
+			}
+			return reject(entry.Digest, raftentry.ErrorResultReplayRequiredV1, fmt.Errorf("raftapply: apply entry %d/%d result replay is not implemented", meta.EntryID.Term, meta.EntryID.Index))
+		}
+	}
+
+	return reject(entry.Digest, raftentry.ErrorUnsupportedCommandV1, fmt.Errorf("raftapply: %s decoded but command lowering is deferred", entry.Row.NativeWireCommand))
+}
+
+func (h *Harness) preflightLocalBoundary(meta ApplyMetadataV1) error {
+	if meta.LocalDurabilityBoundary != LocalDurabilityCommandWALV1 {
+		if meta.LocalDurabilityBoundary == "" {
+			return codedError(raftentry.ErrorUnsafeDurabilityModeV1, "missing local durability boundary")
+		}
+		return codedError(raftentry.ErrorUnsafeDurabilityModeV1, "unsupported local durability boundary %q", meta.LocalDurabilityBoundary)
+	}
+	if h.db == nil {
+		return codedError(raftentry.ErrorUnsafeDurabilityModeV1, "nil DB cannot provide local command WAL durability")
+	}
+	if !h.db.CommandWALEnabled() {
+		return codedError(raftentry.ErrorUnsafeDurabilityModeV1, "local command WAL is disabled")
+	}
+	if err := h.db.CheckStorageMaintenanceReady(); err != nil {
+		if errors.Is(err, backenddb.ErrReadOnly) {
+			return codedError(raftentry.ErrorReadOnlyV1, "read-only DB rejects deterministic apply")
+		}
+		if errors.Is(err, backenddb.ErrClosed) {
+			return codedError(raftentry.ErrorUnsafeDurabilityModeV1, "closed DB rejects deterministic apply")
+		}
+		return codedError(raftentry.ErrorUnsafeDurabilityModeV1, "local command WAL boundary is not writable: %v", err)
+	}
+	return nil
+}
+
+func validateApplyEntryID(id raftentry.ApplyEntryID) error {
+	if id.Term == 0 || id.Index == 0 {
+		return codedError(raftentry.ErrorMalformedEntryV1, "apply entry id must have non-zero term and index")
+	}
+	return nil
+}
+
+func codeFromDecodeError(err error) raftentry.DeterministicErrorCodeV1 {
+	if code, ok := raftentry.ErrorCodeOf(err); ok {
+		return code
+	}
+	return raftentry.ErrorMalformedEntryV1
+}
+
+func reject(digest raftentry.CommandDigestV1, code raftentry.DeterministicErrorCodeV1, err error) (raftentry.ApplyResultV1, error) {
+	if code == "" {
+		code = raftentry.ErrorMalformedEntryV1
+	}
+	result := raftentry.ApplyResultV1{
+		Status:                 statusForCode(code),
+		CommandDigest:          digest,
+		DeterministicErrorCode: code,
+	}
+	return result, &Error{Code: code, Err: err}
+}
+
+func statusForCode(code raftentry.DeterministicErrorCodeV1) raftentry.ApplyStatusV1 {
+	switch code {
+	case raftentry.ErrorMalformedEntryV1:
+		return raftentry.ApplyStatusRejectedMalformed
+	case raftentry.ErrorUnsupportedCommandV1,
+		raftentry.ErrorUnsupportedVersionV1,
+		raftentry.ErrorUnsupportedFeatureV1,
+		raftentry.ErrorUnknownRequiredFieldV1,
+		raftentry.ErrorUnsupportedScopeRuleV1:
+		return raftentry.ApplyStatusRejectedUnsupported
+	case raftentry.ErrorRejectedConflictV1:
+		return raftentry.ApplyStatusRejectedConflict
+	default:
+		return raftentry.ApplyStatusDeterministicGuardFailure
+	}
+}

--- a/TreeDB/internal/raftapply/apply_test.go
+++ b/TreeDB/internal/raftapply/apply_test.go
@@ -1,0 +1,379 @@
+package raftapply
+
+import (
+	"encoding/hex"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/collections"
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+	"github.com/snissn/gomap/TreeDB/internal/commandwalapply"
+	"github.com/snissn/gomap/TreeDB/internal/commitlog"
+	"github.com/snissn/gomap/TreeDB/internal/raftentry"
+)
+
+func TestUnsupportedDeterministicEntryRejectsBeforeAppendAndStores(t *testing.T) {
+	dir := t.TempDir()
+	db := openApplyHarnessDB(t, dir)
+	defer func() { _ = db.Close() }()
+
+	progress := NewMemoryApplyProgressStore(8, 8)
+	results := NewMemoryApplyResultStore(8)
+	seam := &countingCommandWALApplySeam{}
+	raw := readHexFixture(t, "../nativewire/testdata/v1/insert_batch_entry.hex")
+
+	beforeLSN := db.State().AppliedCommandLSN
+	result, err := ApplyCommittedEntryV1(db, raw, applyMeta(1, 1), Options{
+		ProgressStore:       progress,
+		ResultStore:         results,
+		CommandWALApplySeam: seam,
+	})
+	assertRejected(t, result, err, raftentry.ApplyStatusRejectedUnsupported, raftentry.ErrorUnsupportedCommandV1)
+	if result.CommandDigest == (raftentry.CommandDigestV1{}) {
+		t.Fatal("unsupported deterministic entry should still report a digest")
+	}
+	if seam.appendCalls != 0 || seam.finalizeCalls != 0 {
+		t.Fatalf("command-WAL seam calls append=%d finalize=%d, want 0", seam.appendCalls, seam.finalizeCalls)
+	}
+	if got := len(readCommandWALFrames(t, dir)); got != 0 {
+		t.Fatalf("command WAL frames=%d, want 0", got)
+	}
+	if got := db.State().AppliedCommandLSN; got != beforeLSN {
+		t.Fatalf("AppliedCommandLSN=%d, want %d", got, beforeLSN)
+	}
+	if progress.Len() != 0 {
+		t.Fatalf("progress records=%d, want 0", progress.Len())
+	}
+	if results.Len() != 0 {
+		t.Fatalf("result records=%d, want 0", results.Len())
+	}
+}
+
+func TestCreateCollectionDecodedButNotLoweredDoesNotMutateCatalog(t *testing.T) {
+	dir := t.TempDir()
+	db := openApplyHarnessDB(t, dir)
+	defer func() { _ = db.Close() }()
+
+	seam := &countingCommandWALApplySeam{}
+	raw := readHexFixture(t, "../nativewire/testdata/v1/create_collection_entry.hex")
+	result, err := ApplyCommittedEntryV1(db, raw, applyMeta(1, 1), Options{
+		ProgressStore:       NewMemoryApplyProgressStore(8, 8),
+		ResultStore:         NewMemoryApplyResultStore(8),
+		CommandWALApplySeam: seam,
+	})
+	assertRejected(t, result, err, raftentry.ApplyStatusRejectedUnsupported, raftentry.ErrorUnsupportedCommandV1)
+	if seam.appendCalls != 0 || len(readCommandWALFrames(t, dir)) != 0 {
+		t.Fatalf("create_collection rejection reached command WAL seam/files append=%d frames=%d", seam.appendCalls, len(readCommandWALFrames(t, dir)))
+	}
+	_, openErr := collections.NewCollectionManager(db).OpenCollection("users")
+	if !errors.Is(openErr, collections.ErrCollectionNotFound) {
+		t.Fatalf("OpenCollection users error=%v, want ErrCollectionNotFound", openErr)
+	}
+	if got := db.State().AppliedCommandLSN; got != 0 {
+		t.Fatalf("AppliedCommandLSN=%d, want 0", got)
+	}
+}
+
+func TestMalformedBytesReturnDeterministicErrorWithoutAppend(t *testing.T) {
+	dir := t.TempDir()
+	db := openApplyHarnessDB(t, dir)
+	defer func() { _ = db.Close() }()
+
+	seam := &countingCommandWALApplySeam{}
+	result, err := ApplyCommittedEntryV1(db, []byte("bad"), applyMeta(1, 1), Options{CommandWALApplySeam: seam})
+	assertRejected(t, result, err, raftentry.ApplyStatusRejectedMalformed, raftentry.ErrorMalformedEntryV1)
+	if result.CommandDigest != (raftentry.CommandDigestV1{}) {
+		t.Fatalf("malformed digest=%s, want zero digest", result.CommandDigest.Hex())
+	}
+	if seam.appendCalls != 0 || len(readCommandWALFrames(t, dir)) != 0 {
+		t.Fatalf("malformed input reached append path append=%d frames=%d", seam.appendCalls, len(readCommandWALFrames(t, dir)))
+	}
+}
+
+func TestHarnessApplyAPIAcceptsDeterministicBytesOnly(t *testing.T) {
+	method := reflect.TypeOf((*Harness).ApplyCommittedEntryV1)
+	if method.NumIn() != 3 {
+		t.Fatalf("Harness.ApplyCommittedEntryV1 inputs=%d, want receiver+bytes+metadata", method.NumIn())
+	}
+	bytesType := method.In(1)
+	if bytesType.Kind() != reflect.Slice || bytesType.Elem().Kind() != reflect.Uint8 {
+		t.Fatalf("ApplyCommittedEntryV1 input=%s, want []byte deterministic entry", bytesType)
+	}
+	if got := method.In(2); got != reflect.TypeOf(ApplyMetadataV1{}) {
+		t.Fatalf("ApplyCommittedEntryV1 metadata input=%s, want ApplyMetadataV1", got)
+	}
+}
+
+func TestProgressBoundOverflowFailsBeforeAppendOrMutation(t *testing.T) {
+	dir := t.TempDir()
+	db := openApplyHarnessDB(t, dir)
+	defer func() { _ = db.Close() }()
+
+	seam := &countingCommandWALApplySeam{}
+	raw := readHexFixture(t, "../nativewire/testdata/v1/create_collection_entry.hex")
+	result, err := ApplyCommittedEntryV1(db, raw, applyMeta(1, 2), Options{
+		ProgressStore:       NewMemoryApplyProgressStore(8, 1),
+		CommandWALApplySeam: seam,
+	})
+	assertRejected(t, result, err, raftentry.ApplyStatusDeterministicGuardFailure, raftentry.ErrorResourceExhaustedV1)
+	if seam.appendCalls != 0 || len(readCommandWALFrames(t, dir)) != 0 {
+		t.Fatalf("overflow reached append path append=%d frames=%d", seam.appendCalls, len(readCommandWALFrames(t, dir)))
+	}
+	_, openErr := collections.NewCollectionManager(db).OpenCollection("users")
+	if !errors.Is(openErr, collections.ErrCollectionNotFound) {
+		t.Fatalf("OpenCollection users after overflow error=%v, want ErrCollectionNotFound", openErr)
+	}
+}
+
+func TestProgressGapFailsBeforeAppendOrMutation(t *testing.T) {
+	dir := t.TempDir()
+	db := openApplyHarnessDB(t, dir)
+	defer func() { _ = db.Close() }()
+
+	seam := &countingCommandWALApplySeam{}
+	raw := readHexFixture(t, "../nativewire/testdata/v1/create_collection_entry.hex")
+	result, err := ApplyCommittedEntryV1(db, raw, applyMeta(1, 2), Options{
+		ProgressStore:       NewMemoryApplyProgressStore(8, 8),
+		CommandWALApplySeam: seam,
+	})
+	assertRejected(t, result, err, raftentry.ApplyStatusRejectedConflict, raftentry.ErrorRejectedConflictV1)
+	if seam.appendCalls != 0 || len(readCommandWALFrames(t, dir)) != 0 {
+		t.Fatalf("gap reached append path append=%d frames=%d", seam.appendCalls, len(readCommandWALFrames(t, dir)))
+	}
+	if got := db.State().AppliedCommandLSN; got != 0 {
+		t.Fatalf("AppliedCommandLSN after gap=%d, want 0", got)
+	}
+	_, openErr := collections.NewCollectionManager(db).OpenCollection("users")
+	if !errors.Is(openErr, collections.ErrCollectionNotFound) {
+		t.Fatalf("OpenCollection users after gap error=%v, want ErrCollectionNotFound", openErr)
+	}
+}
+
+func TestReadOnlyDBApplyFailsBeforeAppendOrMutation(t *testing.T) {
+	dir := t.TempDir()
+	db := openApplyHarnessDB(t, dir)
+	if err := db.Close(); err != nil {
+		t.Fatalf("Close writable DB: %v", err)
+	}
+	ro, err := backenddb.Open(backenddb.Options{Dir: dir, ReadOnly: true, CommandWAL: true, DisableBackgroundPrune: true})
+	if err != nil {
+		t.Fatalf("Open read-only DB: %v", err)
+	}
+	defer func() { _ = ro.Close() }()
+
+	seam := &countingCommandWALApplySeam{}
+	raw := readHexFixture(t, "../nativewire/testdata/v1/create_collection_entry.hex")
+	result, applyErr := ApplyCommittedEntryV1(ro, raw, applyMeta(1, 1), Options{CommandWALApplySeam: seam})
+	assertRejected(t, result, applyErr, raftentry.ApplyStatusDeterministicGuardFailure, raftentry.ErrorReadOnlyV1)
+	if seam.appendCalls != 0 || len(readCommandWALFrames(t, dir)) != 0 {
+		t.Fatalf("read-only apply reached append path append=%d frames=%d", seam.appendCalls, len(readCommandWALFrames(t, dir)))
+	}
+	_, openErr := collections.NewCollectionManager(ro).OpenCollection("users")
+	if !errors.Is(openErr, collections.ErrCollectionNotFound) {
+		t.Fatalf("OpenCollection users after read-only apply error=%v, want ErrCollectionNotFound", openErr)
+	}
+}
+
+func TestUnsafeDurabilityFailsBeforeAppend(t *testing.T) {
+	dir := t.TempDir()
+	db := openApplyHarnessDB(t, dir)
+	defer func() { _ = db.Close() }()
+
+	meta := applyMeta(1, 1)
+	meta.LocalDurabilityBoundary = LocalDurabilityBoundaryV1("local-visible-only-v1")
+	seam := &countingCommandWALApplySeam{}
+	raw := readHexFixture(t, "../nativewire/testdata/v1/create_collection_entry.hex")
+	result, err := ApplyCommittedEntryV1(db, raw, meta, Options{CommandWALApplySeam: seam})
+	assertRejected(t, result, err, raftentry.ApplyStatusDeterministicGuardFailure, raftentry.ErrorUnsafeDurabilityModeV1)
+	if seam.appendCalls != 0 || len(readCommandWALFrames(t, dir)) != 0 {
+		t.Fatalf("unsafe durability reached append path append=%d frames=%d", seam.appendCalls, len(readCommandWALFrames(t, dir)))
+	}
+}
+
+func TestSameApplyEntryIDDifferentDigestConflictsBeforeAppend(t *testing.T) {
+	dir := t.TempDir()
+	db := openApplyHarnessDB(t, dir)
+	defer func() { _ = db.Close() }()
+
+	id := raftentry.ApplyEntryID{Term: 1, Index: 1}
+	results := NewMemoryApplyResultStore(8)
+	var otherDigest raftentry.CommandDigestV1
+	otherDigest[0] = 1
+	if err := results.RecordApplyResult(ApplyResultRecordV1{
+		EntryID:       id,
+		CommandDigest: otherDigest,
+		Result: raftentry.ApplyResultV1{
+			Status:                 raftentry.ApplyStatusApplied,
+			CommandDigest:          otherDigest,
+			DeterministicErrorCode: raftentry.ErrorNoneV1,
+		},
+	}); err != nil {
+		t.Fatalf("seed result record: %v", err)
+	}
+
+	seam := &countingCommandWALApplySeam{}
+	raw := readHexFixture(t, "../nativewire/testdata/v1/create_collection_entry.hex")
+	result, err := ApplyCommittedEntryV1(db, raw, applyMeta(id.Term, id.Index), Options{
+		ResultStore:         results,
+		CommandWALApplySeam: seam,
+	})
+	assertRejected(t, result, err, raftentry.ApplyStatusRejectedConflict, raftentry.ErrorRejectedConflictV1)
+	if seam.appendCalls != 0 || len(readCommandWALFrames(t, dir)) != 0 {
+		t.Fatalf("conflict reached append path append=%d frames=%d", seam.appendCalls, len(readCommandWALFrames(t, dir)))
+	}
+	if results.Len() != 1 {
+		t.Fatalf("result records after conflict=%d, want seeded record only", results.Len())
+	}
+}
+
+func TestMemoryStoresAreBounded(t *testing.T) {
+	id1 := raftentry.ApplyEntryID{Term: 1, Index: 1}
+	id2 := raftentry.ApplyEntryID{Term: 1, Index: 2}
+	var digest raftentry.CommandDigestV1
+	digest[0] = 7
+
+	results := NewMemoryApplyResultStore(1)
+	if err := results.RecordApplyResult(ApplyResultRecordV1{EntryID: id1, CommandDigest: digest}); err != nil {
+		t.Fatalf("RecordApplyResult id1: %v", err)
+	}
+	if err := results.RecordApplyResult(ApplyResultRecordV1{EntryID: id2, CommandDigest: digest}); codeOf(err) != raftentry.ErrorResourceExhaustedV1 {
+		t.Fatalf("RecordApplyResult id2 error=%v code=%s, want resource exhausted", err, codeOf(err))
+	}
+
+	progress := NewMemoryApplyProgressStore(1, 8)
+	if err := progress.RecordApplied(ApplyProgressRecordV1{EntryID: id1, CommandDigest: digest}); err != nil {
+		t.Fatalf("RecordApplied id1: %v", err)
+	}
+	if err := progress.RecordApplied(ApplyProgressRecordV1{EntryID: id2, CommandDigest: digest}); codeOf(err) != raftentry.ErrorResourceExhaustedV1 {
+		t.Fatalf("RecordApplied id2 error=%v code=%s, want resource exhausted", err, codeOf(err))
+	}
+
+	progress = NewMemoryApplyProgressStore(8, 8)
+	if err := progress.RecordApplied(ApplyProgressRecordV1{EntryID: id1, CommandDigest: digest}); err != nil {
+		t.Fatalf("RecordApplied lower-index setup: %v", err)
+	}
+	if err := progress.CheckCanApply(id1); codeOf(err) != raftentry.ErrorRejectedConflictV1 {
+		t.Fatalf("CheckCanApply duplicate/lower error=%v code=%s, want conflict", err, codeOf(err))
+	}
+	id3 := raftentry.ApplyEntryID{Term: 1, Index: 3}
+	if err := progress.CheckCanApply(id3); codeOf(err) != raftentry.ErrorRejectedConflictV1 {
+		t.Fatalf("CheckCanApply gap error=%v code=%s, want conflict", err, codeOf(err))
+	}
+}
+
+func openApplyHarnessDB(t *testing.T, dir string) *backenddb.DB {
+	t.Helper()
+	db, err := backenddb.Open(backenddb.Options{
+		Dir:                          dir,
+		CommandWAL:                   true,
+		DisableBackgroundPrune:       true,
+		CommandWALStatsScan:          true,
+		CommandWALSegmentTargetBytes: 1 << 20,
+	})
+	if err != nil {
+		t.Fatalf("Open DB: %v", err)
+	}
+	return db
+}
+
+func applyMeta(term, index uint64) ApplyMetadataV1 {
+	return ApplyMetadataV1{
+		EntryID:                 raftentry.ApplyEntryID{Term: term, Index: index},
+		LocalDurabilityBoundary: LocalDurabilityCommandWALV1,
+	}
+}
+
+func assertRejected(t *testing.T, result raftentry.ApplyResultV1, err error, wantStatus raftentry.ApplyStatusV1, wantCode raftentry.DeterministicErrorCodeV1) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("ApplyCommittedEntryV1 returned nil error for rejected result %+v", result)
+	}
+	if result.Status != wantStatus || result.DeterministicErrorCode != wantCode {
+		t.Fatalf("result status/code=%s/%s, want %s/%s (err=%v)", result.Status, result.DeterministicErrorCode, wantStatus, wantCode, err)
+	}
+	if got := codeOf(err); got != wantCode {
+		t.Fatalf("error code=%s, want %s (err=%v)", got, wantCode, err)
+	}
+}
+
+func codeOf(err error) raftentry.DeterministicErrorCodeV1 {
+	code, _ := ErrorCodeOf(err)
+	return code
+}
+
+func readHexFixture(t *testing.T, rel string) []byte {
+	t.Helper()
+	raw, err := os.ReadFile(rel)
+	if err != nil {
+		t.Fatalf("read fixture %s: %v", rel, err)
+	}
+	hexText := strings.Join(strings.Fields(string(raw)), "")
+	out, err := hex.DecodeString(hexText)
+	if err != nil {
+		t.Fatalf("decode fixture %s: %v", rel, err)
+	}
+	return out
+}
+
+func readCommandWALFrames(t *testing.T, dir string) []commitlog.CommandEnvelope {
+	t.Helper()
+	walDir := backenddb.WALDirPath(dir)
+	entries, err := os.ReadDir(walDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		t.Fatalf("ReadDir %s: %v", walDir, err)
+	}
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if !entry.IsDir() && commitlog.IsCommandSegmentName(entry.Name()) {
+			names = append(names, entry.Name())
+		}
+	}
+	sort.Strings(names)
+	var frames []commitlog.CommandEnvelope
+	for _, name := range names {
+		path := filepath.Join(walDir, name)
+		r, err := commitlog.NewReader(path)
+		if err != nil {
+			t.Fatalf("NewReader %s: %v", name, err)
+		}
+		for {
+			env, err := r.ReadCommandFrame()
+			if err != nil {
+				if errors.Is(err, io.EOF) {
+					break
+				}
+				_ = r.Close()
+				t.Fatalf("ReadCommandFrame %s: %v", name, err)
+			}
+			frames = append(frames, env)
+		}
+		if err := r.Close(); err != nil {
+			t.Fatalf("Close reader %s: %v", name, err)
+		}
+	}
+	return frames
+}
+
+type countingCommandWALApplySeam struct {
+	appendCalls   int
+	finalizeCalls int
+}
+
+func (s *countingCommandWALApplySeam) Append(db *backenddb.DB, frame commandwalapply.LoweredFrame, meta commandwalapply.ApplyMetadata, opts commandwalapply.Options) (commandwalapply.Handle, commandwalapply.Result, error) {
+	s.appendCalls++
+	return commandwalapply.Handle{}, commandwalapply.Result{}, errors.New("unexpected append")
+}
+
+func (s *countingCommandWALApplySeam) Finalize(db *backenddb.DB, handle commandwalapply.Handle, meta commandwalapply.ApplyMetadata, opts commandwalapply.Options) (commandwalapply.Result, error) {
+	s.finalizeCalls++
+	return commandwalapply.Result{}, errors.New("unexpected finalize")
+}

--- a/TreeDB/internal/raftapply/doc.go
+++ b/TreeDB/internal/raftapply/doc.go
@@ -1,0 +1,8 @@
+// Package raftapply applies committed R3a deterministic entry bytes to a local
+// TreeDB replica.
+//
+// This package is intentionally a skeleton. It owns the committed-bytes apply
+// boundary, deterministic rejection results, and fake bounded stores used by
+// tests while real durable apply progress/result storage and command lowering
+// are implemented in later slices.
+package raftapply

--- a/TreeDB/internal/raftapply/stores.go
+++ b/TreeDB/internal/raftapply/stores.go
@@ -1,0 +1,229 @@
+package raftapply
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/snissn/gomap/TreeDB/internal/raftentry"
+)
+
+// Error carries stable deterministic apply error names through fake stores and
+// the harness boundary.
+type Error struct {
+	Code raftentry.DeterministicErrorCodeV1
+	Err  error
+}
+
+func (e *Error) Error() string {
+	if e == nil {
+		return "raftapply: <nil>"
+	}
+	if e.Err == nil {
+		return fmt.Sprintf("raftapply: %s", e.Code)
+	}
+	return fmt.Sprintf("raftapply: %s: %v", e.Code, e.Err)
+}
+
+func (e *Error) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+// ErrorCodeOf extracts stable deterministic error names returned by this
+// package or by the predecessor raftentry decoder.
+func ErrorCodeOf(err error) (raftentry.DeterministicErrorCodeV1, bool) {
+	var e *Error
+	if errors.As(err, &e) {
+		return e.Code, true
+	}
+	return raftentry.ErrorCodeOf(err)
+}
+
+func codedError(code raftentry.DeterministicErrorCodeV1, format string, args ...any) error {
+	return &Error{Code: code, Err: fmt.Errorf(format, args...)}
+}
+
+// ApplyResultRecordV1 is the fake/durable result-store unit keyed by
+// ApplyEntryID. The result payload is intentionally bounded separately from the
+// deterministic entry bytes.
+type ApplyResultRecordV1 struct {
+	EntryID       raftentry.ApplyEntryID
+	CommandDigest raftentry.CommandDigestV1
+	Result        raftentry.ApplyResultV1
+}
+
+// ApplyResultStore records deterministic apply results for idempotency/replay.
+type ApplyResultStore interface {
+	LookupApplyResult(raftentry.ApplyEntryID) (ApplyResultRecordV1, bool, error)
+	RecordApplyResult(ApplyResultRecordV1) error
+}
+
+// ApplyProgressRecordV1 records the apply-progress transition made after an
+// entry has reached the selected local durability and visibility boundary.
+type ApplyProgressRecordV1 struct {
+	EntryID       raftentry.ApplyEntryID
+	CommandDigest raftentry.CommandDigestV1
+}
+
+// ApplyProgressStore checks monotonic apply order and records durable progress.
+type ApplyProgressStore interface {
+	CheckCanApply(raftentry.ApplyEntryID) error
+	RecordApplied(ApplyProgressRecordV1) error
+	LastApplied() (raftentry.ApplyEntryID, bool)
+}
+
+// MemoryApplyResultStore is a bounded fake result/idempotency store for tests
+// and early harness wiring. It is not durable.
+type MemoryApplyResultStore struct {
+	mu      sync.Mutex
+	max     int
+	records map[raftentry.ApplyEntryID]ApplyResultRecordV1
+}
+
+func NewMemoryApplyResultStore(maxRecords int) *MemoryApplyResultStore {
+	if maxRecords < 0 {
+		maxRecords = 0
+	}
+	return &MemoryApplyResultStore{max: maxRecords, records: make(map[raftentry.ApplyEntryID]ApplyResultRecordV1)}
+}
+
+func (s *MemoryApplyResultStore) LookupApplyResult(id raftentry.ApplyEntryID) (ApplyResultRecordV1, bool, error) {
+	if s == nil {
+		return ApplyResultRecordV1{}, false, nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	record, ok := s.records[id]
+	return record, ok, nil
+}
+
+func (s *MemoryApplyResultStore) RecordApplyResult(record ApplyResultRecordV1) error {
+	if s == nil {
+		return nil
+	}
+	if err := validateApplyEntryID(record.EntryID); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if existing, ok := s.records[record.EntryID]; ok {
+		if existing.CommandDigest != record.CommandDigest {
+			return codedError(raftentry.ErrorRejectedConflictV1, "apply result digest conflict for %d/%d", record.EntryID.Term, record.EntryID.Index)
+		}
+		s.records[record.EntryID] = record
+		return nil
+	}
+	if len(s.records) >= s.max {
+		return codedError(raftentry.ErrorResourceExhaustedV1, "apply result store capacity %d reached", s.max)
+	}
+	s.records[record.EntryID] = record
+	return nil
+}
+
+func (s *MemoryApplyResultStore) Len() int {
+	if s == nil {
+		return 0
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.records)
+}
+
+// MemoryApplyProgressStore is a bounded fake apply-progress store for tests and
+// early harness wiring. It enforces contiguous indexes and non-decreasing terms.
+type MemoryApplyProgressStore struct {
+	mu       sync.Mutex
+	max      int
+	maxIndex uint64
+	last     raftentry.ApplyEntryID
+	records  map[raftentry.ApplyEntryID]ApplyProgressRecordV1
+}
+
+func NewMemoryApplyProgressStore(maxRecords int, maxIndex uint64) *MemoryApplyProgressStore {
+	if maxRecords < 0 {
+		maxRecords = 0
+	}
+	return &MemoryApplyProgressStore{max: maxRecords, maxIndex: maxIndex, records: make(map[raftentry.ApplyEntryID]ApplyProgressRecordV1)}
+}
+
+func (s *MemoryApplyProgressStore) CheckCanApply(id raftentry.ApplyEntryID) error {
+	if s == nil {
+		return nil
+	}
+	if err := validateApplyEntryID(id); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.checkCanApplyLocked(id)
+}
+
+func (s *MemoryApplyProgressStore) RecordApplied(record ApplyProgressRecordV1) error {
+	if s == nil {
+		return nil
+	}
+	if err := validateApplyEntryID(record.EntryID); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if existing, ok := s.records[record.EntryID]; ok {
+		if existing.CommandDigest != record.CommandDigest {
+			return codedError(raftentry.ErrorRejectedConflictV1, "apply progress digest conflict for %d/%d", record.EntryID.Term, record.EntryID.Index)
+		}
+		s.records[record.EntryID] = record
+		return nil
+	}
+	if err := s.checkCanApplyLocked(record.EntryID); err != nil {
+		return err
+	}
+	if len(s.records) >= s.max {
+		return codedError(raftentry.ErrorResourceExhaustedV1, "apply progress store capacity %d reached", s.max)
+	}
+	s.records[record.EntryID] = record
+	s.last = record.EntryID
+	return nil
+}
+
+func (s *MemoryApplyProgressStore) LastApplied() (raftentry.ApplyEntryID, bool) {
+	if s == nil {
+		return raftentry.ApplyEntryID{}, false
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.last, s.last.Index != 0
+}
+
+func (s *MemoryApplyProgressStore) Len() int {
+	if s == nil {
+		return 0
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.records)
+}
+
+func (s *MemoryApplyProgressStore) checkCanApplyLocked(id raftentry.ApplyEntryID) error {
+	if s.maxIndex != 0 && id.Index > s.maxIndex {
+		return codedError(raftentry.ErrorResourceExhaustedV1, "apply entry index %d exceeds bound %d", id.Index, s.maxIndex)
+	}
+	if s.last.Index == 0 {
+		if id.Index != 1 {
+			return codedError(raftentry.ErrorRejectedConflictV1, "apply entry starts at index %d; want 1", id.Index)
+		}
+		return nil
+	}
+	if id.Index <= s.last.Index {
+		return codedError(raftentry.ErrorRejectedConflictV1, "apply entry index %d is not after last applied %d", id.Index, s.last.Index)
+	}
+	if id.Index != s.last.Index+1 {
+		return codedError(raftentry.ErrorRejectedConflictV1, "apply entry index gap: got %d after %d", id.Index, s.last.Index)
+	}
+	if id.Term < s.last.Term {
+		return codedError(raftentry.ErrorRejectedConflictV1, "apply entry term %d is below last applied term %d", id.Term, s.last.Term)
+	}
+	return nil
+}

--- a/TreeDB/internal/raftentry/contract.go
+++ b/TreeDB/internal/raftentry/contract.go
@@ -1,0 +1,359 @@
+package raftentry
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"errors"
+	"fmt"
+
+	"github.com/snissn/gomap/TreeDB/internal/nativewire"
+)
+
+const (
+	EntryVersionV1 = uint64(1)
+
+	// ScopeRuleSingleGroupV1 is a schema-versioned single-group rule. It is
+	// covered by CommandDigestV1 even though it is not re-encoded inside the
+	// native-wire deterministic entry bytes.
+	ScopeRuleSingleGroupV1 ScopeRuleV1 = "single-group-v1"
+
+	DatabaseScopeDefaultV1 = "database/default"
+	CatalogScopeDefaultV1  = "catalog/default"
+
+	NoIdempotencyTokenV1 = "NoIdempotencyV1"
+
+	MaxIdempotencyKeyBytesV1 = 1024
+	MaxResultRecordBytesV1   = 64 << 10
+	MaxProgressRecordsV1     = 1 << 20
+)
+
+const digestDomainV1 = "TreeDB/R3a/CommandDigestV1\x00"
+
+type ScopeRuleV1 string
+
+type ApplyEntryID struct {
+	Term  uint64
+	Index uint64
+}
+
+type RequestMetadataV1 struct {
+	RequestID         uint64
+	AckPolicy         nativewire.AckPolicy
+	DeadlineUnixNanos int64
+	TraceContext      []byte
+	Compression       string
+	OmitResultIDs     bool
+	OmitResponseMeta  bool
+}
+
+type CommandDigestV1 [32]byte
+
+func (d CommandDigestV1) Hex() string {
+	return hex.EncodeToString(d[:])
+}
+
+type IdempotencyModeV1 string
+
+const (
+	IdempotencyRequiredV1 IdempotencyModeV1 = "required-idempotency-key-v1"
+	NoIdempotencyV1       IdempotencyModeV1 = "no-idempotency-v1"
+)
+
+type ApplyStatusV1 string
+
+const (
+	ApplyStatusApplied                   ApplyStatusV1 = "applied"
+	ApplyStatusAlreadyApplied            ApplyStatusV1 = "already-applied"
+	ApplyStatusDeterministicGuardFailure ApplyStatusV1 = "deterministic-guard-failure"
+	ApplyStatusRejectedUnsupported       ApplyStatusV1 = "rejected-unsupported"
+	ApplyStatusRejectedMalformed         ApplyStatusV1 = "rejected-malformed"
+	ApplyStatusRejectedConflict          ApplyStatusV1 = "rejected-conflict"
+	ApplyStatusRecoveryRequired          ApplyStatusV1 = "recovery-required"
+)
+
+type DeterministicErrorCodeV1 string
+
+const (
+	ErrorNoneV1                 DeterministicErrorCodeV1 = ""
+	ErrorUnsupportedCommandV1   DeterministicErrorCodeV1 = "unsupported-command"
+	ErrorMalformedEntryV1       DeterministicErrorCodeV1 = "malformed-entry"
+	ErrorUnsupportedVersionV1   DeterministicErrorCodeV1 = "unsupported-version"
+	ErrorUnsupportedFeatureV1   DeterministicErrorCodeV1 = "unsupported-feature"
+	ErrorMissingGuardV1         DeterministicErrorCodeV1 = "missing-guard"
+	ErrorTargetMismatchV1       DeterministicErrorCodeV1 = "target-mismatch"
+	ErrorRejectedConflictV1     DeterministicErrorCodeV1 = "rejected-conflict"
+	ErrorReadOnlyV1             DeterministicErrorCodeV1 = "read-only"
+	ErrorUnsafeDurabilityModeV1 DeterministicErrorCodeV1 = "unsafe-durability-mode"
+	ErrorResourceExhaustedV1    DeterministicErrorCodeV1 = "resource-exhausted"
+	ErrorNoIdempotencyV1        DeterministicErrorCodeV1 = "no-idempotency"
+	ErrorResultReplayRequiredV1 DeterministicErrorCodeV1 = "result-replay-required"
+	ErrorUnknownRequiredFieldV1 DeterministicErrorCodeV1 = "unknown-required-field"
+	ErrorUnsupportedScopeRuleV1 DeterministicErrorCodeV1 = "unsupported-scope-rule"
+)
+
+type ApplyResultV1 struct {
+	Status                 ApplyStatusV1
+	CommandDigest          CommandDigestV1
+	DeterministicErrorCode DeterministicErrorCodeV1
+	AffectedCount          int64
+	ResultDigest           CommandDigestV1
+}
+
+type TargetIdentityV1 struct {
+	ScopeRule              ScopeRuleV1
+	DatabaseScope          string
+	CatalogScope           string
+	CommandID              nativewire.CommandID
+	CommandVersion         uint64
+	CollectionRef          []byte
+	CollectionMeta         []byte
+	ExpectedCatalogVersion []byte
+}
+
+func (t TargetIdentityV1) Equal(u TargetIdentityV1) bool {
+	return t.ScopeRule == u.ScopeRule &&
+		t.DatabaseScope == u.DatabaseScope &&
+		t.CatalogScope == u.CatalogScope &&
+		t.CommandID == u.CommandID &&
+		t.CommandVersion == u.CommandVersion &&
+		bytes.Equal(t.CollectionRef, u.CollectionRef) &&
+		bytes.Equal(t.CollectionMeta, u.CollectionMeta) &&
+		bytes.Equal(t.ExpectedCatalogVersion, u.ExpectedCatalogVersion)
+}
+
+func (t TargetIdentityV1) Clone() TargetIdentityV1 {
+	t.CollectionRef = bytes.Clone(t.CollectionRef)
+	t.CollectionMeta = bytes.Clone(t.CollectionMeta)
+	t.ExpectedCatalogVersion = bytes.Clone(t.ExpectedCatalogVersion)
+	return t
+}
+
+type DecodeOptions struct {
+	Limits          nativewire.Limits
+	ScopeRule       ScopeRuleV1
+	DatabaseScope   string
+	CatalogScope    string
+	ApplyEntryID    ApplyEntryID
+	RequestMetadata RequestMetadataV1
+	ExpectedTarget  *TargetIdentityV1
+}
+
+type CommandEntryV1 struct {
+	Bytes          []byte
+	Decoded        nativewire.DeterministicEntry
+	Digest         CommandDigestV1
+	Target         TargetIdentityV1
+	IdempotencyKey []byte
+	Idempotency    IdempotencyModeV1
+	Row            CommandRowV1
+}
+
+type ValidationError struct {
+	Code DeterministicErrorCodeV1
+	Err  error
+}
+
+func (e *ValidationError) Error() string {
+	if e == nil {
+		return "raftentry: <nil>"
+	}
+	if e.Err == nil {
+		return fmt.Sprintf("raftentry: %s", e.Code)
+	}
+	return fmt.Sprintf("raftentry: %s: %v", e.Code, e.Err)
+}
+
+func (e *ValidationError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+func ErrorCodeOf(err error) (DeterministicErrorCodeV1, bool) {
+	var e *ValidationError
+	if errors.As(err, &e) {
+		return e.Code, true
+	}
+	return "", false
+}
+
+func DecodeCommandEntryV1(src []byte, opts DecodeOptions) (CommandEntryV1, error) {
+	scope, database, catalog, err := normalizeScope(opts)
+	if err != nil {
+		return CommandEntryV1{}, err
+	}
+	entryBytes := bytes.Clone(src)
+	decoded, err := nativewire.DecodeDeterministicEntry(entryBytes, opts.Limits)
+	if err != nil {
+		return CommandEntryV1{}, validationError(mapNativeWireError(err), err)
+	}
+	if decoded.Version != EntryVersionV1 {
+		return CommandEntryV1{}, validationError(ErrorUnsupportedVersionV1, fmt.Errorf("entry version %d", decoded.Version))
+	}
+	row := ClassifyNativeWireCommandV1(decoded.CommandID)
+	if !row.Known {
+		return CommandEntryV1{}, validationError(ErrorUnsupportedCommandV1, fmt.Errorf("native-wire command %d", decoded.CommandID))
+	}
+	if row.Decision != DecisionAccepted {
+		return CommandEntryV1{}, validationError(ErrorUnsupportedCommandV1, fmt.Errorf("%s is %s for R3a v1: %s", row.NativeWireCommand, row.Decision, row.Reason))
+	}
+	idempotencyKey, ok := sectionBytes(decoded.Sections, nativewire.SectionIdempotencyKey)
+	if !ok || len(idempotencyKey) == 0 {
+		return CommandEntryV1{}, validationError(ErrorNoIdempotencyV1, fmt.Errorf("%s missing idempotency key", row.NativeWireCommand))
+	}
+	if len(idempotencyKey) > MaxIdempotencyKeyBytesV1 {
+		return CommandEntryV1{}, validationError(ErrorResourceExhaustedV1, fmt.Errorf("idempotency key length %d exceeds %d", len(idempotencyKey), MaxIdempotencyKeyBytesV1))
+	}
+	if string(idempotencyKey) == NoIdempotencyTokenV1 {
+		return CommandEntryV1{}, validationError(ErrorNoIdempotencyV1, fmt.Errorf("%s is not accepted for replicated commands", NoIdempotencyTokenV1))
+	}
+	target := targetIdentity(decoded, scope, database, catalog)
+	if opts.ExpectedTarget != nil && !target.Equal(*opts.ExpectedTarget) {
+		return CommandEntryV1{}, validationError(ErrorTargetMismatchV1, fmt.Errorf("target identity mismatch"))
+	}
+	return CommandEntryV1{
+		Bytes:          entryBytes,
+		Decoded:        decoded,
+		Digest:         CommandDigestV1ForBytes(entryBytes, opts),
+		Target:         target,
+		IdempotencyKey: bytes.Clone(idempotencyKey),
+		Idempotency:    IdempotencyRequiredV1,
+		Row:            row,
+	}, nil
+}
+
+func CommandDigestV1ForBytes(src []byte, opts DecodeOptions) CommandDigestV1 {
+	scope := opts.ScopeRule
+	if scope == "" {
+		scope = ScopeRuleSingleGroupV1
+	}
+	database := opts.DatabaseScope
+	if database == "" {
+		database = DatabaseScopeDefaultV1
+	}
+	catalog := opts.CatalogScope
+	if catalog == "" {
+		catalog = CatalogScopeDefaultV1
+	}
+	h := sha256.New()
+	writeDigestField(h, "domain", []byte(digestDomainV1))
+	writeDigestU64(h, "entry-version", EntryVersionV1)
+	writeDigestField(h, "scope-rule", []byte(scope))
+	writeDigestField(h, "database-scope", []byte(database))
+	writeDigestField(h, "catalog-scope", []byte(catalog))
+	writeDigestField(h, "nativewire-deterministic-entry", src)
+	var out CommandDigestV1
+	copy(out[:], h.Sum(nil))
+	return out
+}
+
+func ValidateCommandDigestInputV1(src []byte, opts DecodeOptions) (CommandDigestV1, error) {
+	if _, _, _, err := normalizeScope(opts); err != nil {
+		return CommandDigestV1{}, err
+	}
+	if _, err := nativewire.DecodeDeterministicEntry(src, opts.Limits); err != nil {
+		return CommandDigestV1{}, validationError(mapNativeWireError(err), err)
+	}
+	return CommandDigestV1ForBytes(src, opts), nil
+}
+
+func normalizeScope(opts DecodeOptions) (ScopeRuleV1, string, string, error) {
+	scope := opts.ScopeRule
+	if scope == "" {
+		scope = ScopeRuleSingleGroupV1
+	}
+	if scope != ScopeRuleSingleGroupV1 {
+		return "", "", "", validationError(ErrorUnsupportedScopeRuleV1, fmt.Errorf("scope rule %q", scope))
+	}
+	database := opts.DatabaseScope
+	if database == "" {
+		database = DatabaseScopeDefaultV1
+	}
+	catalog := opts.CatalogScope
+	if catalog == "" {
+		catalog = CatalogScopeDefaultV1
+	}
+	return scope, database, catalog, nil
+}
+
+func targetIdentity(entry nativewire.DeterministicEntry, scope ScopeRuleV1, database, catalog string) TargetIdentityV1 {
+	return TargetIdentityV1{
+		ScopeRule:              scope,
+		DatabaseScope:          database,
+		CatalogScope:           catalog,
+		CommandID:              entry.CommandID,
+		CommandVersion:         entry.CommandVersion,
+		CollectionRef:          copySection(entry.Sections, nativewire.SectionCollectionRef),
+		CollectionMeta:         copySection(entry.Sections, nativewire.SectionCollectionMeta),
+		ExpectedCatalogVersion: copySection(entry.Sections, nativewire.SectionExpectedCatalogVersion),
+	}
+}
+
+func sectionBytes(sections []nativewire.Section, id nativewire.SectionID) ([]byte, bool) {
+	for _, section := range sections {
+		if section.ID == id {
+			return section.Bytes, true
+		}
+	}
+	return nil, false
+}
+
+func copySection(sections []nativewire.Section, id nativewire.SectionID) []byte {
+	raw, ok := sectionBytes(sections, id)
+	if !ok {
+		return nil
+	}
+	return bytes.Clone(raw)
+}
+
+func validationError(code DeterministicErrorCodeV1, err error) error {
+	return &ValidationError{Code: code, Err: err}
+}
+
+func mapNativeWireError(err error) DeterministicErrorCodeV1 {
+	code, ok := nativewire.ErrorCodeOf(err)
+	if !ok {
+		return ErrorMalformedEntryV1
+	}
+	switch code {
+	case nativewire.ErrMalformedFrame:
+		return ErrorMalformedEntryV1
+	case nativewire.ErrUnsupportedVersion:
+		return ErrorUnsupportedVersionV1
+	case nativewire.ErrUnsupportedFeature:
+		return ErrorUnsupportedFeatureV1
+	case nativewire.ErrInvalidCommand:
+		return ErrorMalformedEntryV1
+	case nativewire.ErrResourceExhausted:
+		return ErrorResourceExhaustedV1
+	case nativewire.ErrReadOnly:
+		return ErrorReadOnlyV1
+	case nativewire.ErrDurabilityUnavailable:
+		return ErrorUnsafeDurabilityModeV1
+	default:
+		return ErrorMalformedEntryV1
+	}
+}
+
+type digestWriter interface {
+	Write([]byte) (int, error)
+}
+
+func writeDigestField(w digestWriter, name string, value []byte) {
+	writeDigestU64(w, "field-name-len", uint64(len(name)))
+	_, _ = w.Write([]byte(name))
+	writeDigestU64(w, "field-value-len", uint64(len(value)))
+	_, _ = w.Write(value)
+}
+
+func writeDigestU64(w digestWriter, name string, value uint64) {
+	var buf [8]byte
+	binary.BigEndian.PutUint64(buf[:], value)
+	if name != "" {
+		_, _ = w.Write([]byte(name))
+	}
+	_, _ = w.Write(buf[:])
+}

--- a/TreeDB/internal/raftentry/contract_test.go
+++ b/TreeDB/internal/raftentry/contract_test.go
@@ -1,0 +1,484 @@
+package raftentry
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/internal/nativewire"
+)
+
+const (
+	createCollectionDigestV1Hex = "50d795a174052328acd5aa8c1378668a26384c32691d8eacd968b9ddbb2f070d"
+	insertBatchDigestV1Hex      = "7091242d8878fb3a1d1d2b6882ae19130d800dcffa853733433c6879a122952a"
+)
+
+func TestDecodeCommandEntryV1AcceptsCreateCollectionContract(t *testing.T) {
+	raw := readHexFixture(t, "../nativewire/testdata/v1/create_collection_entry.hex")
+	entry, err := DecodeCommandEntryV1(raw, DecodeOptions{})
+	if err != nil {
+		t.Fatalf("DecodeCommandEntryV1: %v", err)
+	}
+	if entry.Row.Decision != DecisionAccepted {
+		t.Fatalf("decision=%s, want accepted", entry.Row.Decision)
+	}
+	if entry.Row.DuplicateMode != DuplicateFailClosedAllowedV1 {
+		t.Fatalf("duplicate mode=%s, want fail closed", entry.Row.DuplicateMode)
+	}
+	if entry.Idempotency != IdempotencyRequiredV1 || len(entry.IdempotencyKey) == 0 {
+		t.Fatalf("idempotency=%s keyLen=%d", entry.Idempotency, len(entry.IdempotencyKey))
+	}
+	if entry.Target.ScopeRule != ScopeRuleSingleGroupV1 || entry.Target.DatabaseScope != DatabaseScopeDefaultV1 || entry.Target.CatalogScope != CatalogScopeDefaultV1 {
+		t.Fatalf("target scope=%+v", entry.Target)
+	}
+	if entry.Target.CommandID != nativewire.CommandCreateCollection || len(entry.Target.CollectionMeta) == 0 || len(entry.Target.ExpectedCatalogVersion) == 0 {
+		t.Fatalf("incomplete target identity: %+v", entry.Target)
+	}
+	if entry.Digest.Hex() != createCollectionDigestV1Hex {
+		t.Fatalf("create collection digest=%s want %s", entry.Digest.Hex(), createCollectionDigestV1Hex)
+	}
+}
+
+func TestDigestV1StabilityAcrossMetadataAndApplyEntryID(t *testing.T) {
+	base := deterministicInsertEntry(t, nil, 0)
+	variant := deterministicInsertEntry(t, []nativewire.Section{
+		{ID: nativewire.SectionAckPolicy, Bytes: uvarintPayload(uint64(nativewire.AckSynced))},
+		{ID: nativewire.SectionConsistencyPolicy, Bytes: uvarintPayload(3)},
+		{ID: nativewire.SectionCompression, Bytes: []byte{1}},
+		{ID: nativewire.SectionTraceContext, Bytes: []byte("trace")},
+		{ID: nativewire.SectionDeadline, Bytes: []byte("deadline")},
+		{ID: 9000, Bytes: []byte("ignored")},
+	}, nativewire.CommandFlagOmitResultIDs|nativewire.CommandFlagOmitResponseMeta)
+	if !bytes.Equal(base, variant) {
+		t.Fatalf("native-wire metadata changed deterministic entry\nbase=%x\nvariant=%x", base, variant)
+	}
+	d0, err := ValidateCommandDigestInputV1(base, DecodeOptions{
+		ApplyEntryID: ApplyEntryID{Term: 1, Index: 2},
+		RequestMetadata: RequestMetadataV1{
+			RequestID:         11,
+			AckPolicy:         nativewire.AckVisible,
+			DeadlineUnixNanos: 100,
+			TraceContext:      []byte("trace-a"),
+			Compression:       "none",
+			OmitResultIDs:     false,
+			OmitResponseMeta:  false,
+		},
+	})
+	if err != nil {
+		t.Fatalf("ValidateCommandDigestInputV1 base: %v", err)
+	}
+	d1, err := ValidateCommandDigestInputV1(variant, DecodeOptions{
+		ApplyEntryID: ApplyEntryID{Term: 9, Index: 10},
+		RequestMetadata: RequestMetadataV1{
+			RequestID:         99,
+			AckPolicy:         nativewire.AckSynced,
+			DeadlineUnixNanos: 900,
+			TraceContext:      []byte("trace-b"),
+			Compression:       "lz4",
+			OmitResultIDs:     true,
+			OmitResponseMeta:  true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("ValidateCommandDigestInputV1 variant: %v", err)
+	}
+	if d0 != d1 {
+		t.Fatalf("ApplyEntryID or metadata changed digest: %s != %s", d0.Hex(), d1.Hex())
+	}
+	if d0.Hex() != insertBatchDigestV1Hex {
+		t.Fatalf("insert digest=%s want %s", d0.Hex(), insertBatchDigestV1Hex)
+	}
+}
+
+func TestDigestV1CoversScopeAndCatalogIdentity(t *testing.T) {
+	raw := readHexFixture(t, "../nativewire/testdata/v1/create_collection_entry.hex")
+	base, err := ValidateCommandDigestInputV1(raw, DecodeOptions{})
+	if err != nil {
+		t.Fatalf("ValidateCommandDigestInputV1 base: %v", err)
+	}
+	differentDatabase, err := ValidateCommandDigestInputV1(raw, DecodeOptions{DatabaseScope: "database/tenant-b"})
+	if err != nil {
+		t.Fatalf("ValidateCommandDigestInputV1 database: %v", err)
+	}
+	differentCatalog, err := ValidateCommandDigestInputV1(raw, DecodeOptions{CatalogScope: "catalog/tenant-b"})
+	if err != nil {
+		t.Fatalf("ValidateCommandDigestInputV1 catalog: %v", err)
+	}
+	if base == differentDatabase {
+		t.Fatal("database scope did not affect CommandDigestV1")
+	}
+	if base == differentCatalog {
+		t.Fatal("catalog scope did not affect CommandDigestV1")
+	}
+}
+
+func TestDecodeCommandEntryV1RejectsClassifiedButNotAcceptedMutations(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		fixture string
+		command nativewire.CommandID
+	}{
+		{"insert", "../nativewire/testdata/v1/insert_batch_entry.hex", nativewire.CommandInsertBatch},
+		{"replace", "../nativewire/testdata/v1/replace_batch_entry.hex", nativewire.CommandReplaceBatch},
+		{"delete", "../nativewire/testdata/v1/delete_batch_entry.hex", nativewire.CommandDeleteBatch},
+		{"update_bson_set", "../nativewire/testdata/v1/update_bson_set_entry.hex", nativewire.CommandUpdateBSONSet},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			row := ClassifyNativeWireCommandV1(tc.command)
+			if !row.Known || row.Decision != DecisionRejected || row.CommandWALStatus != "WAL-supported" {
+				t.Fatalf("row=%+v, want classified WAL-supported rejection", row)
+			}
+			if _, err := DecodeCommandEntryV1(readHexFixture(t, tc.fixture), DecodeOptions{}); codeOf(err) != ErrorUnsupportedCommandV1 {
+				t.Fatalf("DecodeCommandEntryV1 err=%v code=%s, want unsupported command", err, codeOf(err))
+			}
+		})
+	}
+}
+
+func TestDecodeCommandEntryV1RejectsDDLBarriersReadsAndUnknowns(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		fixture string
+		command nativewire.CommandID
+	}{
+		{"create_index", "../nativewire/testdata/v1/create_index_entry.hex", nativewire.CommandCreateIndex},
+		{"drop_index", "../nativewire/testdata/v1/drop_index_entry.hex", nativewire.CommandDropIndex},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			row := ClassifyNativeWireCommandV1(tc.command)
+			if !row.Known || row.Decision != DecisionRejected || row.CommandWALStatus != "WAL-rejected" {
+				t.Fatalf("row=%+v, want WAL-rejected R3a rejection", row)
+			}
+			if _, err := DecodeCommandEntryV1(readHexFixture(t, tc.fixture), DecodeOptions{}); codeOf(err) != ErrorUnsupportedCommandV1 {
+				t.Fatalf("DecodeCommandEntryV1 err=%v code=%s, want unsupported command", err, codeOf(err))
+			}
+		})
+	}
+	for _, command := range []nativewire.CommandID{
+		nativewire.CommandDropCollection,
+		nativewire.CommandFlushCollection,
+		nativewire.CommandFlushAll,
+		nativewire.CommandCheckpoint,
+		nativewire.CommandGetMany,
+		nativewire.CommandOpenScan,
+		nativewire.CommandCursorNext,
+	} {
+		row := ClassifyNativeWireCommandV1(command)
+		if !row.Known || row.Decision != DecisionRejected {
+			t.Fatalf("command %d row=%+v, want known rejected row", command, row)
+		}
+	}
+	if row := ClassifyNativeWireCommandV1(nativewire.CommandID(9999)); row.Known {
+		t.Fatalf("unknown command classified as known: %+v", row)
+	}
+}
+
+func TestDecodeCommandEntryV1RejectsMalformedOversizedMissingGuardAndNoIdempotency(t *testing.T) {
+	if _, err := DecodeCommandEntryV1([]byte("bad"), DecodeOptions{}); codeOf(err) != ErrorMalformedEntryV1 {
+		t.Fatalf("malformed err=%v code=%s", err, codeOf(err))
+	}
+	raw := readHexFixture(t, "../nativewire/testdata/v1/create_collection_entry.hex")
+	if _, err := DecodeCommandEntryV1(raw, DecodeOptions{Limits: nativewire.Limits{MaxFrameSize: uint64(len(raw) - 1)}}); codeOf(err) != ErrorResourceExhaustedV1 {
+		t.Fatalf("oversized err=%v code=%s", err, codeOf(err))
+	}
+	missingGuard := deterministicCreateCollectionEntry(t, "client-a:create:users", false)
+	if _, err := DecodeCommandEntryV1(missingGuard, DecodeOptions{}); codeOf(err) != ErrorMalformedEntryV1 {
+		t.Fatalf("missing guard err=%v code=%s", err, codeOf(err))
+	}
+	noID := deterministicCreateCollectionEntry(t, NoIdempotencyTokenV1, true)
+	if _, err := DecodeCommandEntryV1(noID, DecodeOptions{}); codeOf(err) != ErrorNoIdempotencyV1 {
+		t.Fatalf("NoIdempotency err=%v code=%s", err, codeOf(err))
+	}
+	duplicateSingleton := appendDeterministicEntryRaw(nativewire.CommandCreateCollection, []nativewire.Section{
+		{ID: nativewire.SectionCollectionMeta, Bytes: createCollectionMetaPayload("users")},
+		{ID: nativewire.SectionCollectionMeta, Bytes: createCollectionMetaPayload("users")},
+		{ID: nativewire.SectionIdempotencyKey, Bytes: []byte("client-a:create:users")},
+		{ID: nativewire.SectionExpectedCatalogVersion, Bytes: uvarintPayload(7)},
+	})
+	if _, err := DecodeCommandEntryV1(duplicateSingleton, DecodeOptions{}); codeOf(err) != ErrorMalformedEntryV1 {
+		t.Fatalf("duplicate singleton err=%v code=%s", err, codeOf(err))
+	}
+	unknownVersion := appendDeterministicEntryRawWithHeader(nativewire.DeterministicEntryVersion+1, nativewire.CommandCreateCollection, 1, 0, []nativewire.Section{
+		{ID: nativewire.SectionCollectionMeta, Bytes: createCollectionMetaPayload("users")},
+		{ID: nativewire.SectionIdempotencyKey, Bytes: []byte("client-a:create:users")},
+		{ID: nativewire.SectionExpectedCatalogVersion, Bytes: uvarintPayload(7)},
+	})
+	if _, err := DecodeCommandEntryV1(unknownVersion, DecodeOptions{}); codeOf(err) != ErrorUnsupportedVersionV1 {
+		t.Fatalf("unknown version err=%v code=%s", err, codeOf(err))
+	}
+	unknownFeature := appendDeterministicEntryRawWithHeader(nativewire.DeterministicEntryVersion, nativewire.CommandCreateCollection, 1, 1, []nativewire.Section{
+		{ID: nativewire.SectionCollectionMeta, Bytes: createCollectionMetaPayload("users")},
+		{ID: nativewire.SectionIdempotencyKey, Bytes: []byte("client-a:create:users")},
+		{ID: nativewire.SectionExpectedCatalogVersion, Bytes: uvarintPayload(7)},
+	})
+	if _, err := DecodeCommandEntryV1(unknownFeature, DecodeOptions{}); codeOf(err) != ErrorUnsupportedFeatureV1 {
+		t.Fatalf("unknown feature err=%v code=%s", err, codeOf(err))
+	}
+	unknownCommand := appendDeterministicEntryRaw(nativewire.CommandID(9999), []nativewire.Section{
+		{ID: nativewire.SectionCollectionMeta, Bytes: createCollectionMetaPayload("users")},
+		{ID: nativewire.SectionIdempotencyKey, Bytes: []byte("client-a:create:users")},
+		{ID: nativewire.SectionExpectedCatalogVersion, Bytes: uvarintPayload(7)},
+	})
+	if _, err := DecodeCommandEntryV1(unknownCommand, DecodeOptions{}); codeOf(err) != ErrorUnsupportedVersionV1 {
+		t.Fatalf("unknown command err=%v code=%s", err, codeOf(err))
+	}
+}
+
+func TestDecodeCommandEntryV1RejectsTargetAndScopeMismatch(t *testing.T) {
+	raw := readHexFixture(t, "../nativewire/testdata/v1/create_collection_entry.hex")
+	entry, err := DecodeCommandEntryV1(raw, DecodeOptions{})
+	if err != nil {
+		t.Fatalf("DecodeCommandEntryV1: %v", err)
+	}
+	target := entry.Target.Clone()
+	target.ExpectedCatalogVersion = []byte{99}
+	if _, err := DecodeCommandEntryV1(raw, DecodeOptions{ExpectedTarget: &target}); codeOf(err) != ErrorTargetMismatchV1 {
+		t.Fatalf("target mismatch err=%v code=%s", err, codeOf(err))
+	}
+	if _, err := DecodeCommandEntryV1(raw, DecodeOptions{ScopeRule: ScopeRuleV1("multi-group-v1")}); codeOf(err) != ErrorUnsupportedScopeRuleV1 {
+		t.Fatalf("scope mismatch err=%v code=%s", err, codeOf(err))
+	}
+}
+
+func TestApplyResultV1VocabularyIsStable(t *testing.T) {
+	statuses := []ApplyStatusV1{
+		ApplyStatusApplied,
+		ApplyStatusAlreadyApplied,
+		ApplyStatusDeterministicGuardFailure,
+		ApplyStatusRejectedUnsupported,
+		ApplyStatusRejectedMalformed,
+		ApplyStatusRejectedConflict,
+		ApplyStatusRecoveryRequired,
+	}
+	for _, status := range statuses {
+		if status == "" {
+			t.Fatalf("empty ApplyResultV1 status in %v", statuses)
+		}
+	}
+	errors := []DeterministicErrorCodeV1{
+		ErrorUnsupportedCommandV1,
+		ErrorMalformedEntryV1,
+		ErrorUnsupportedVersionV1,
+		ErrorUnsupportedFeatureV1,
+		ErrorMissingGuardV1,
+		ErrorTargetMismatchV1,
+		ErrorRejectedConflictV1,
+		ErrorReadOnlyV1,
+		ErrorUnsafeDurabilityModeV1,
+		ErrorResourceExhaustedV1,
+		ErrorNoIdempotencyV1,
+		ErrorResultReplayRequiredV1,
+		ErrorUnknownRequiredFieldV1,
+		ErrorUnsupportedScopeRuleV1,
+	}
+	for _, code := range errors {
+		if code == "" {
+			t.Fatalf("empty deterministic error code in %v", errors)
+		}
+	}
+}
+
+func TestR3aAllowlistCoversNativeWireV1CommandsAndDocsMatrix(t *testing.T) {
+	rowsByNative := make(map[string]CommandRowV1)
+	for _, row := range AllCommandRowsV1() {
+		if !row.Known || row.NativeWireCommand == "" || row.CommandName == "" || row.CommandWALKind == "" || row.CommandWALStatus == "" || row.Reason == "" {
+			t.Fatalf("incomplete command row: %+v", row)
+		}
+		if _, exists := rowsByNative[row.NativeWireCommand]; exists {
+			t.Fatalf("duplicate row for %s", row.NativeWireCommand)
+		}
+		rowsByNative[row.NativeWireCommand] = row
+	}
+	for _, schema := range nativewire.MustV1Registry().Schemas() {
+		row := ClassifyNativeWireCommandV1(schema.ID)
+		if !row.Known {
+			t.Fatalf("missing row for schema %+v", schema)
+		}
+	}
+	alignment := loadAlignment(t)
+	for _, entry := range alignment.Entries {
+		row, ok := rowsByNative[entry.NativeWireCommand]
+		if !ok {
+			t.Fatalf("alignment entry %s has no R3a row", entry.NativeWireCommand)
+		}
+		if row.CommandWALStatus != entry.SupportMatrixStatus || row.CommandWALKind != entry.CommandWALKind {
+			t.Fatalf("%s row=%+v alignment=%+v", entry.NativeWireCommand, row, entry)
+		}
+		if row.Decision == DecisionAccepted && entry.SupportMatrixStatus != "WAL-supported" {
+			t.Fatalf("%s accepted without WAL-supported status", entry.NativeWireCommand)
+		}
+	}
+	if row := ClassifyNativeWireCommandV1(nativewire.CommandCreateCollection); row.Decision != DecisionAccepted || row.DuplicateMode != DuplicateFailClosedAllowedV1 || row.ResultReplayMode != ResultReplayFailClosedV1 {
+		t.Fatalf("create collection row=%+v", row)
+	}
+}
+
+func deterministicInsertEntry(t *testing.T, extra []nativewire.Section, commandFlags uint64) []byte {
+	t.Helper()
+	sections := []nativewire.Section{
+		{ID: nativewire.SectionCommandHeader, Bytes: nativewire.AppendCommandHeader(nil, nativewire.CommandHeader{ID: nativewire.CommandInsertBatch, Version: 1, Flags: commandFlags})},
+		{ID: nativewire.SectionIdempotencyKey, Bytes: []byte("id1")},
+		{ID: nativewire.SectionCollectionRef, Bytes: []byte{1, 'c'}},
+		{ID: nativewire.SectionDocumentFormat, Bytes: []byte{byte(nativewire.DocumentFormatBSON)}},
+		{ID: nativewire.SectionDocumentIDs, Bytes: nativewire.AppendByteVector(nil, []byte("a"))},
+		{ID: nativewire.SectionDocuments, Bytes: nativewire.AppendByteVector(nil, []byte{5, 0, 0, 0, 0})},
+		{ID: nativewire.SectionExpectedCatalogVersion, Bytes: uvarintPayload(7)},
+	}
+	sections = append(sections, extra...)
+	cmd, err := nativewire.MustV1Registry().ValidateRequestSections(sections)
+	if err != nil {
+		t.Fatalf("ValidateRequestSections: %v", err)
+	}
+	entry, err := nativewire.AppendDeterministicEntry(nil, cmd)
+	if err != nil {
+		t.Fatalf("AppendDeterministicEntry: %v", err)
+	}
+	return entry
+}
+
+func deterministicCreateCollectionEntry(t *testing.T, idempotency string, includeGuard bool) []byte {
+	t.Helper()
+	sections := []nativewire.Section{
+		{ID: nativewire.SectionCommandHeader, Bytes: nativewire.AppendCommandHeader(nil, nativewire.CommandHeader{ID: nativewire.CommandCreateCollection, Version: 1})},
+		{ID: nativewire.SectionIdempotencyKey, Bytes: []byte(idempotency)},
+		{ID: nativewire.SectionCollectionMeta, Bytes: createCollectionMetaPayload("users")},
+	}
+	if includeGuard {
+		sections = append(sections, nativewire.Section{ID: nativewire.SectionExpectedCatalogVersion, Bytes: uvarintPayload(7)})
+	}
+	cmd, err := nativewire.MustV1Registry().ValidateRequestSections(sections)
+	if err != nil && includeGuard {
+		t.Fatalf("ValidateRequestSections: %v", err)
+	}
+	if err != nil {
+		return appendDeterministicEntryRaw(nativewire.CommandCreateCollection, sections)
+	}
+	entry, err := nativewire.AppendDeterministicEntry(nil, cmd)
+	if err != nil {
+		t.Fatalf("AppendDeterministicEntry: %v", err)
+	}
+	return entry
+}
+
+func createCollectionMetaPayload(name string) []byte {
+	dst := uvarintPayload(1)
+	dst = appendString(dst, name)
+	dst = binary.AppendUvarint(dst, uint64(nativewire.DocumentFormatDefault))
+	dst = binary.AppendUvarint(dst, 0)
+	dst = binary.AppendUvarint(dst, 0)
+	dst = binary.AppendUvarint(dst, 0)
+	dst = binary.AppendUvarint(dst, 0)
+	dst = binary.AppendUvarint(dst, 0)
+	dst = binary.AppendVarint(dst, 0)
+	dst = binary.AppendVarint(dst, 0)
+	dst = binary.AppendVarint(dst, 0)
+	dst = binary.AppendUvarint(dst, 0)
+	dst = binary.AppendUvarint(dst, 0)
+	dst = binary.AppendVarint(dst, 0)
+	dst = binary.AppendUvarint(dst, 0)
+	return dst
+}
+
+func appendString(dst []byte, value string) []byte {
+	dst = binary.AppendUvarint(dst, uint64(len(value)))
+	return append(dst, value...)
+}
+
+func appendDeterministicEntryRaw(commandID nativewire.CommandID, sections []nativewire.Section) []byte {
+	return appendDeterministicEntryRawWithHeader(nativewire.DeterministicEntryVersion, commandID, 1, 0, sections)
+}
+
+func appendDeterministicEntryRawWithHeader(entryVersion uint64, commandID nativewire.CommandID, commandVersion uint64, commandFlags uint64, sections []nativewire.Section) []byte {
+	deterministic := make([]nativewire.Section, 0, len(sections))
+	for _, section := range sections {
+		switch section.ID {
+		case nativewire.SectionCommandHeader:
+			continue
+		case nativewire.SectionDeadline, nativewire.SectionTraceContext, nativewire.SectionAckPolicy, nativewire.SectionConsistencyPolicy, nativewire.SectionChecksum, nativewire.SectionCompression, nativewire.SectionResponseMeta, nativewire.SectionCursorMeta:
+			continue
+		default:
+			deterministic = append(deterministic, section)
+		}
+	}
+	sortSections(deterministic)
+	dst := []byte(nativewire.DeterministicEntryMagic)
+	dst = binary.AppendUvarint(dst, entryVersion)
+	dst = binary.AppendUvarint(dst, uint64(commandID))
+	dst = binary.AppendUvarint(dst, commandVersion)
+	dst = binary.AppendUvarint(dst, commandFlags)
+	dst = binary.AppendUvarint(dst, uint64(len(deterministic)))
+	for _, section := range deterministic {
+		dst = binary.AppendUvarint(dst, uint64(section.ID))
+		dst = binary.AppendUvarint(dst, uint64(len(section.Bytes)))
+		dst = append(dst, section.Bytes...)
+	}
+	return dst
+}
+
+func sortSections(sections []nativewire.Section) {
+	for i := 1; i < len(sections); i++ {
+		for j := i; j > 0 && sections[j].ID < sections[j-1].ID; j-- {
+			sections[j], sections[j-1] = sections[j-1], sections[j]
+		}
+	}
+}
+
+func uvarintPayload(value uint64) []byte {
+	return binary.AppendUvarint(nil, value)
+}
+
+func codeOf(err error) DeterministicErrorCodeV1 {
+	code, _ := ErrorCodeOf(err)
+	return code
+}
+
+type alignmentManifest struct {
+	Entries []alignmentEntry `json:"entries"`
+}
+
+type alignmentEntry struct {
+	NativeWireCommand   string `json:"nativewire_command"`
+	CommandWALKind      string `json:"command_wal_kind"`
+	SupportMatrixStatus string `json:"support_matrix_status"`
+}
+
+func loadAlignment(t *testing.T) alignmentManifest {
+	t.Helper()
+	raw, err := os.ReadFile(repoPath(t, "../../docs/spec/command-wal-nativewire-alignment.json"))
+	if err != nil {
+		t.Fatalf("read alignment: %v", err)
+	}
+	var manifest alignmentManifest
+	if err := json.Unmarshal(raw, &manifest); err != nil {
+		t.Fatalf("decode alignment: %v", err)
+	}
+	return manifest
+}
+
+func readHexFixture(t *testing.T, rel string) []byte {
+	t.Helper()
+	raw, err := os.ReadFile(repoPath(t, rel))
+	if err != nil {
+		t.Fatalf("read fixture %s: %v", rel, err)
+	}
+	compact := bytes.Join(bytes.Fields(raw), nil)
+	out, err := hex.DecodeString(string(compact))
+	if err != nil {
+		t.Fatalf("decode fixture %s: %v", rel, err)
+	}
+	return out
+}
+
+func repoPath(t *testing.T, rel string) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(file), rel))
+}

--- a/TreeDB/internal/raftentry/doc.go
+++ b/TreeDB/internal/raftentry/doc.go
@@ -1,0 +1,12 @@
+// Package raftentry defines the R3a v1 deterministic command-entry contract.
+//
+// R3a v1 does not introduce a second semantic command encoding. CommandEntryV1
+// bytes are the existing native-wire deterministic entry bytes. This package
+// adds the Raft-apply contract around those bytes: digest domain separation,
+// target/scope identity, command classification, idempotency requirements, and
+// deterministic result vocabulary.
+//
+// Fixture stability is checked with:
+//
+//	GOWORK=off go test ./TreeDB/internal/raftentry ./TreeDB/internal/nativewire ./TreeDB/docs
+package raftentry

--- a/TreeDB/internal/raftentry/matrix.go
+++ b/TreeDB/internal/raftentry/matrix.go
@@ -1,0 +1,150 @@
+package raftentry
+
+import "github.com/snissn/gomap/TreeDB/internal/nativewire"
+
+type DecisionV1 string
+
+const (
+	DecisionAccepted DecisionV1 = "accepted"
+	DecisionRejected DecisionV1 = "rejected"
+)
+
+type DuplicateModeV1 string
+
+const (
+	DuplicateReplayRequiredV1      DuplicateModeV1 = "replay-required"
+	DuplicateFailClosedAllowedV1   DuplicateModeV1 = "duplicate-fail-closed-allowed"
+	DuplicateRejectedUnsupportedV1 DuplicateModeV1 = "rejected"
+)
+
+type ResultReplayModeV1 string
+
+const (
+	ResultReplayPersistedPayloadOrDigestV1 ResultReplayModeV1 = "persisted-result-payload-or-digest"
+	ResultReplayFailClosedV1               ResultReplayModeV1 = "fail-closed-until-result-store"
+	ResultReplayNoneRejectedV1             ResultReplayModeV1 = "none-rejected"
+)
+
+type CommandRowV1 struct {
+	Known                   bool
+	CommandID               nativewire.CommandID
+	NativeWireCommand       string
+	CommandName             string
+	Decision                DecisionV1
+	DuplicateMode           DuplicateModeV1
+	ResultReplayMode        ResultReplayModeV1
+	CommandWALStatus        string
+	CommandWALKind          string
+	DeterministicEntryBytes string
+	Reason                  string
+}
+
+func ClassifyNativeWireCommandV1(id nativewire.CommandID) CommandRowV1 {
+	row, ok := commandRowsV1[id]
+	if !ok {
+		return CommandRowV1{CommandID: id}
+	}
+	return row
+}
+
+func AllCommandRowsV1() []CommandRowV1 {
+	ids := []nativewire.CommandID{
+		nativewire.CommandCreateCollection,
+		nativewire.CommandListCollections,
+		nativewire.CommandCreateIndex,
+		nativewire.CommandListIndexes,
+		nativewire.CommandDropIndex,
+		nativewire.CommandOpenCollection,
+		nativewire.CommandCloseCollection,
+		nativewire.CommandDropCollection,
+		nativewire.CommandInsertBatch,
+		nativewire.CommandReplaceBatch,
+		nativewire.CommandDeleteBatch,
+		nativewire.CommandFlushCollection,
+		nativewire.CommandFlushAll,
+		nativewire.CommandCheckpoint,
+		nativewire.CommandUpdateBSONSet,
+		nativewire.CommandGetMany,
+		nativewire.CommandIndexLookup,
+		nativewire.CommandIndexRange,
+		nativewire.CommandOpenScan,
+		nativewire.CommandCursorNext,
+		nativewire.CommandCursorClose,
+		nativewire.CommandExplain,
+		nativewire.CommandStats,
+	}
+	rows := make([]CommandRowV1, 0, len(ids))
+	for _, id := range ids {
+		rows = append(rows, ClassifyNativeWireCommandV1(id))
+	}
+	return rows
+}
+
+var commandRowsV1 = map[nativewire.CommandID]CommandRowV1{
+	nativewire.CommandCreateCollection: acceptedRow(
+		nativewire.CommandCreateCollection,
+		"CommandCreateCollection",
+		"create_collection",
+		"CatalogCreateCollection",
+		"native-wire deterministic entry fixture",
+		"first vertical-slice contract; duplicates fail closed until durable result replay lands",
+	),
+
+	nativewire.CommandCreateIndex:    rejectedRow(nativewire.CommandCreateIndex, "CommandCreateIndex", "create_index", "WAL-rejected", "future catalog index create", "future_rejected_v1", "index DDL is deterministic at native-wire level but has no accepted R3a command-WAL payload/recovery contract"),
+	nativewire.CommandDropIndex:      rejectedRow(nativewire.CommandDropIndex, "CommandDropIndex", "drop_index", "WAL-rejected", "future catalog index drop", "future_rejected_v1", "index DDL is deterministic at native-wire level but has no accepted R3a command-WAL payload/recovery contract"),
+	nativewire.CommandDropCollection: rejectedRow(nativewire.CommandDropCollection, "CommandDropCollection", "drop_collection", "WAL-rejected", "future catalog collection drop", "local_only_rejected_v1", "collection drop is local-only/rejected until catalog payloads and recovery tests exist"),
+
+	nativewire.CommandInsertBatch:   rejectedRow(nativewire.CommandInsertBatch, "CommandInsertBatch", "insert_batch", "WAL-supported", "CollectionInsertBatchByID", "native-wire deterministic entry fixture", "classified for future widening but not accepted before create identity/generation and result replay contracts land"),
+	nativewire.CommandReplaceBatch:  rejectedRow(nativewire.CommandReplaceBatch, "CommandReplaceBatch", "replace_batch", "WAL-supported", "CollectionUpdateBatchByID", "native-wire deterministic entry fixture", "classified for future widening but not accepted before create identity/generation and result replay contracts land"),
+	nativewire.CommandDeleteBatch:   rejectedRow(nativewire.CommandDeleteBatch, "CommandDeleteBatch", "delete_batch", "WAL-supported", "CollectionDeleteBatchByID", "native-wire deterministic entry fixture", "classified for future widening but not accepted before create identity/generation and result replay contracts land"),
+	nativewire.CommandUpdateBSONSet: rejectedRow(nativewire.CommandUpdateBSONSet, "CommandUpdateBSONSet", "update_bson_set", "WAL-supported", "CollectionUpdateBatchByID", "native-wire deterministic entry fixture", "classified for future widening but not accepted before create identity/generation and result replay contracts land"),
+
+	nativewire.CommandFlushCollection: rejectedRow(nativewire.CommandFlushCollection, "CommandFlushCollection", "flush_collection", "WAL-supported", "local durability barrier", "local_only_barrier_v1", "local durability barriers are not replicated command identity"),
+	nativewire.CommandFlushAll:        rejectedRow(nativewire.CommandFlushAll, "CommandFlushAll", "flush_all", "WAL-supported", "local durability barrier", "local_only_barrier_v1", "local durability barriers are not replicated command identity"),
+	nativewire.CommandCheckpoint:      rejectedRow(nativewire.CommandCheckpoint, "CommandCheckpoint", "checkpoint", "WAL-supported", "local durability barrier", "local_only_barrier_v1", "local durability barriers are not replicated command identity"),
+
+	nativewire.CommandListCollections: rejectedRow(nativewire.CommandListCollections, "CommandListCollections", "list_collections", "read-only", "none", "read_rejected_v1", "reads and metadata listing are not replicated mutations"),
+	nativewire.CommandListIndexes:     rejectedRow(nativewire.CommandListIndexes, "CommandListIndexes", "list_indexes", "read-only", "none", "read_rejected_v1", "reads and metadata listing are not replicated mutations"),
+	nativewire.CommandOpenCollection:  rejectedRow(nativewire.CommandOpenCollection, "CommandOpenCollection", "open_collection", "read-only", "none", "read_rejected_v1", "connection-local collection handles are not deterministic command identity"),
+	nativewire.CommandCloseCollection: rejectedRow(nativewire.CommandCloseCollection, "CommandCloseCollection", "close_collection", "read-only", "none", "read_rejected_v1", "connection-local collection handles are not deterministic command identity"),
+	nativewire.CommandGetMany:         rejectedRow(nativewire.CommandGetMany, "CommandGetMany", "get_many", "read-only", "none", "read_rejected_v1", "reads are not replicated mutations"),
+	nativewire.CommandIndexLookup:     rejectedRow(nativewire.CommandIndexLookup, "CommandIndexLookup", "index_lookup", "read-only", "none", "read_rejected_v1", "reads are not replicated mutations"),
+	nativewire.CommandIndexRange:      rejectedRow(nativewire.CommandIndexRange, "CommandIndexRange", "index_range", "read-only", "none", "read_rejected_v1", "reads are not replicated mutations"),
+	nativewire.CommandOpenScan:        rejectedRow(nativewire.CommandOpenScan, "CommandOpenScan", "open_scan", "read-only", "none", "read_rejected_v1", "cursor state is not replicated command identity"),
+	nativewire.CommandCursorNext:      rejectedRow(nativewire.CommandCursorNext, "CommandCursorNext", "cursor_next", "read-only", "none", "read_rejected_v1", "cursor state is not replicated command identity"),
+	nativewire.CommandCursorClose:     rejectedRow(nativewire.CommandCursorClose, "CommandCursorClose", "cursor_close", "read-only", "none", "read_rejected_v1", "cursor state is not replicated command identity"),
+	nativewire.CommandExplain:         rejectedRow(nativewire.CommandExplain, "CommandExplain", "explain", "read-only", "none", "read_rejected_v1", "reads are not replicated mutations"),
+	nativewire.CommandStats:           rejectedRow(nativewire.CommandStats, "CommandStats", "stats", "read-only", "none", "read_rejected_v1", "reads are not replicated mutations"),
+}
+
+func acceptedRow(id nativewire.CommandID, nativeWireCommand, commandName, walKind, bytes, reason string) CommandRowV1 {
+	return CommandRowV1{
+		Known:                   true,
+		CommandID:               id,
+		NativeWireCommand:       nativeWireCommand,
+		CommandName:             commandName,
+		Decision:                DecisionAccepted,
+		DuplicateMode:           DuplicateFailClosedAllowedV1,
+		ResultReplayMode:        ResultReplayFailClosedV1,
+		CommandWALStatus:        "WAL-supported",
+		CommandWALKind:          walKind,
+		DeterministicEntryBytes: bytes,
+		Reason:                  reason,
+	}
+}
+
+func rejectedRow(id nativewire.CommandID, nativeWireCommand, commandName, walStatus, walKind, bytes, reason string) CommandRowV1 {
+	return CommandRowV1{
+		Known:                   true,
+		CommandID:               id,
+		NativeWireCommand:       nativeWireCommand,
+		CommandName:             commandName,
+		Decision:                DecisionRejected,
+		DuplicateMode:           DuplicateRejectedUnsupportedV1,
+		ResultReplayMode:        ResultReplayNoneRejectedV1,
+		CommandWALStatus:        walStatus,
+		CommandWALKind:          walKind,
+		DeterministicEntryBytes: bytes,
+		Reason:                  reason,
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `TreeDB/internal/raftapply` as the R3a internal apply harness for committed deterministic entry bytes.
- Carries explicit `ApplyEntryID` and local durability metadata, decodes through `raftentry.DecodeCommandEntryV1`, and fail-closed rejects before the command-WAL apply seam.
- Adds bounded in-memory apply progress/result stores for the deferred durable-store phase.
- Keeps accepted command lowering deferred: `create_collection` is decoded/classified but still rejected as not lowered in this slice.

Closes #3040
Refs #1654

## Stack / Merge Notes

This PR is intentionally stacked on the reviewed #3038 R3a contract branch and #3039 command-WAL seam branch through merge commits on `codex/3040-r3a-apply-harness`. Do not merge this PR until those predecessor branches have merged and this branch is revalidated on latest `main`.

## Start-Phase Test Plan

- Add a committed-bytes-only harness API rather than native-wire request or handler replay entry points.
- Prove unsupported and malformed deterministic bytes return stable `ApplyResultV1` status/error names before command-WAL append.
- Prove rejected entries do not advance `AppliedCommandLSN`, fake apply progress, result/idempotency stores, or catalog state.
- Cover read-only, unsafe local durability boundary, progress bound/gap rejection, and same `ApplyEntryID` digest conflict paths.
- Re-run predecessor packages that own deterministic entry contracts and the command-WAL append seam.

## Close-Phase Test Evidence

- `GOWORK=off go test ./TreeDB/internal/raftapply ./TreeDB/internal/raftentry ./TreeDB/internal/commandwalapply`
- `GOWORK=off go test ./TreeDB/internal/nativewire ./TreeDB/internal/raftentry ./TreeDB/internal/commandwalapply ./TreeDB/internal/raftapply`
- `git diff --check HEAD~1 HEAD`

## Benchmark Evidence / Rationale

No benchmark was run. This slice adds a new internal harness and rejection tests only; it is not wired into hot write/read paths, and tests assert rejected paths keep command-WAL append count at zero. The decode/classification rejection path can be benchmarked when a later slice wires accepted lowering or a caller-facing apply loop.
