### PR TITLE
Codify ordered-root span-native publish classification

### DIFF
--- a/TreeDB/collections/ordered_root_span_native_classification_test.go
+++ b/TreeDB/collections/ordered_root_span_native_classification_test.go
@@ -1,0 +1,471 @@
+package collections
+
+import (
+	"strings"
+	"testing"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+)
+
+type collectionOrderedRootRouteAnchor string
+
+const (
+	collectionRouteCollectionManagerCreateCollection                 collectionOrderedRootRouteAnchor = "TreeDB/collections.(*CollectionManager).CreateCollection"
+	collectionRouteCollectionInsertBatch                             collectionOrderedRootRouteAnchor = "TreeDB/collections.(*Collection).InsertBatch"
+	collectionRouteCollectionFlush                                   collectionOrderedRootRouteAnchor = "TreeDB/collections.(*Collection).Flush"
+	collectionRouteCollectionCompactRootOverlays                     collectionOrderedRootRouteAnchor = "TreeDB/collections.(*Collection).CompactRootOverlays"
+	collectionRouteCollectionDeleteDocument                          collectionOrderedRootRouteAnchor = "TreeDB/collections.(*Collection).DeleteDocument"
+	collectionRouteCollectionDeleteBatch                             collectionOrderedRootRouteAnchor = "TreeDB/collections.(*Collection).DeleteBatch"
+	collectionRouteCollectionUpdate                                  collectionOrderedRootRouteAnchor = "TreeDB/collections.(*Collection).Update"
+	collectionRouteCollectionUpdateBatch                             collectionOrderedRootRouteAnchor = "TreeDB/collections.(*Collection).UpdateBatch"
+	collectionRouteCommandWALActive                                  collectionOrderedRootRouteAnchor = "TreeDB/collections.(*Collection).commandWALActive"
+	collectionRouteWithCommandWALPublishCoordinator                  collectionOrderedRootRouteAnchor = "TreeDB/collections.(*Collection).withCommandWALPublishCoordinator"
+	collectionRouteNewInsertCommandWALIntent                         collectionOrderedRootRouteAnchor = "TreeDB/collections.(*Collection).newCollectionInsertCommandWALIntent"
+	collectionRouteNewDeleteCommandWALIntent                         collectionOrderedRootRouteAnchor = "TreeDB/collections.(*Collection).newCollectionDeleteCommandWALIntent"
+	collectionRouteNewUpdateCommandWALIntent                         collectionOrderedRootRouteAnchor = "TreeDB/collections.(*Collection).newCollectionUpdateCommandWALIntent"
+	collectionRouteFlushBufferedNoIndexLocked                        collectionOrderedRootRouteAnchor = "TreeDB/collections.(*Collection).flushBufferedNoIndexLocked"
+	collectionRouteBufferIndexedInsertPlanLocked                     collectionOrderedRootRouteAnchor = "TreeDB/collections.(*Collection).bufferIndexedInsertPlanLocked"
+	collectionRoutePublishPreparedIndexedFlush                       collectionOrderedRootRouteAnchor = "TreeDB/collections.(*Collection).publishPreparedIndexedFlush"
+	collectionRouteCompactRootOverlaysLocked                         collectionOrderedRootRouteAnchor = "TreeDB/collections.(*Collection).compactRootOverlaysLocked"
+	collectionRoutePublishUpdateBatchPlanLocked                      collectionOrderedRootRouteAnchor = "TreeDB/collections.(*Collection).publishUpdateBatchPlanLocked"
+	collectionRouteBuildRootDescriptorSystemDeltaIterator            collectionOrderedRootRouteAnchor = "TreeDB/collections.(*Collection).buildRootDescriptorSystemDeltaIterator"
+	collectionRouteBuildOverlayDescriptorSystemDelta                 collectionOrderedRootRouteAnchor = "TreeDB/collections.(*Collection).buildRootOverlayDescriptorSystemDeltaIteratorForMeta"
+	collectionRouteInsertBatchPlanPublishRootRuns                    collectionOrderedRootRouteAnchor = "TreeDB/collections.(*insertBatchPlan).publishRootRuns"
+	collectionRouteInsertBatchPlanRootNamesAndBaseIDs                collectionOrderedRootRouteAnchor = "TreeDB/collections.insertBatchPlanRootNamesAndBaseIDs"
+	collectionRouteBuildBufferedOverlayDeltaBatchInputs              collectionOrderedRootRouteAnchor = "TreeDB/collections.buildBufferedRootOverlayDeltaBatchPublishInputs"
+	collectionRouteBuildBufferedDeltaBatchInputs                     collectionOrderedRootRouteAnchor = "TreeDB/collections.buildBufferedRootDeltaBatchPublishInputs"
+	collectionRouteBuildRootDeltaBatchInputsFromTables               collectionOrderedRootRouteAnchor = "TreeDB/collections.buildRootDeltaBatchPublishInputsFromTables"
+	collectionRouteCoalesceCollectionRootDeltaTables                 collectionOrderedRootRouteAnchor = "TreeDB/collections.coalesceCollectionRootDeltaTables"
+	collectionRouteBuildCollectionRootOverlayFilters                 collectionOrderedRootRouteAnchor = "TreeDB/collections.buildCollectionRootOverlayFilters"
+	collectionRouteOverlayDeltaBaseRoot                              collectionOrderedRootRouteAnchor = "TreeDB/collections.overlayDeltaBaseRoot"
+	collectionRouteDBPublishOrderedRootGroup                         collectionOrderedRootRouteAnchor = "TreeDB/db.(*DB).PublishOrderedRootGroup"
+	collectionRouteDBPublishOrderedRootDeltaGroup                    collectionOrderedRootRouteAnchor = "TreeDB/db.(*DB).PublishOrderedRootDeltaGroupWithSystemDeltaBuilder"
+	collectionRouteDBPublishOrderedRootDeltaGroupCommandWAL          collectionOrderedRootRouteAnchor = "TreeDB/db.(*DB).PublishOrderedRootDeltaGroupWithCommandWALAndSystemDeltaBuilder"
+	collectionRouteDBPublishOrderedRootDeltaBatch                    collectionOrderedRootRouteAnchor = "TreeDB/db.(*DB).PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder"
+	collectionRouteDBPublishOrderedRootDeltaBatchPreflight           collectionOrderedRootRouteAnchor = "TreeDB/db.(*DB).PublishOrderedRootDeltaBatchGroupWithPreflightAndSystemDeltaBuilder"
+	collectionRouteDBPublishOrderedRootDeltaBatchCommandWAL          collectionOrderedRootRouteAnchor = "TreeDB/db.(*DB).PublishOrderedRootDeltaBatchGroupWithCommandWALAndSystemDeltaBuilder"
+	collectionRouteDBPublishOrderedRootDeltaBatchPreflightCommandWAL collectionOrderedRootRouteAnchor = "TreeDB/db.(*DB).PublishOrderedRootDeltaBatchGroupWithPreflightCommandWALAndSystemDeltaBuilder"
+)
+
+var collectionOrderedRootRouteAnchorEvidence = map[collectionOrderedRootRouteAnchor]any{
+	collectionRouteCollectionManagerCreateCollection:                 (*CollectionManager).CreateCollection,
+	collectionRouteCollectionInsertBatch:                             (*Collection).InsertBatch,
+	collectionRouteCollectionFlush:                                   (*Collection).Flush,
+	collectionRouteCollectionCompactRootOverlays:                     (*Collection).CompactRootOverlays,
+	collectionRouteCollectionDeleteDocument:                          (*Collection).DeleteDocument,
+	collectionRouteCollectionDeleteBatch:                             (*Collection).DeleteBatch,
+	collectionRouteCollectionUpdate:                                  (*Collection).Update,
+	collectionRouteCollectionUpdateBatch:                             (*Collection).UpdateBatch,
+	collectionRouteCommandWALActive:                                  (*Collection).commandWALActive,
+	collectionRouteWithCommandWALPublishCoordinator:                  (*Collection).withCommandWALPublishCoordinator,
+	collectionRouteNewInsertCommandWALIntent:                         (*Collection).newCollectionInsertCommandWALIntent,
+	collectionRouteNewDeleteCommandWALIntent:                         (*Collection).newCollectionDeleteCommandWALIntent,
+	collectionRouteNewUpdateCommandWALIntent:                         (*Collection).newCollectionUpdateCommandWALIntent,
+	collectionRouteFlushBufferedNoIndexLocked:                        (*Collection).flushBufferedNoIndexLocked,
+	collectionRouteBufferIndexedInsertPlanLocked:                     (*Collection).bufferIndexedInsertPlanLocked,
+	collectionRoutePublishPreparedIndexedFlush:                       (*Collection).publishPreparedIndexedFlush,
+	collectionRouteCompactRootOverlaysLocked:                         (*Collection).compactRootOverlaysLocked,
+	collectionRoutePublishUpdateBatchPlanLocked:                      (*Collection).publishUpdateBatchPlanLocked,
+	collectionRouteBuildRootDescriptorSystemDeltaIterator:            (*Collection).buildRootDescriptorSystemDeltaIterator,
+	collectionRouteBuildOverlayDescriptorSystemDelta:                 (*Collection).buildRootOverlayDescriptorSystemDeltaIteratorForMeta,
+	collectionRouteInsertBatchPlanPublishRootRuns:                    (*insertBatchPlan).publishRootRuns,
+	collectionRouteInsertBatchPlanRootNamesAndBaseIDs:                insertBatchPlanRootNamesAndBaseIDs,
+	collectionRouteBuildBufferedOverlayDeltaBatchInputs:              buildBufferedRootOverlayDeltaBatchPublishInputs,
+	collectionRouteBuildBufferedDeltaBatchInputs:                     buildBufferedRootDeltaBatchPublishInputs,
+	collectionRouteBuildRootDeltaBatchInputsFromTables:               buildRootDeltaBatchPublishInputsFromTables,
+	collectionRouteCoalesceCollectionRootDeltaTables:                 coalesceCollectionRootDeltaTables,
+	collectionRouteBuildCollectionRootOverlayFilters:                 buildCollectionRootOverlayFilters,
+	collectionRouteOverlayDeltaBaseRoot:                              overlayDeltaBaseRoot,
+	collectionRouteDBPublishOrderedRootGroup:                         (*backenddb.DB).PublishOrderedRootGroup,
+	collectionRouteDBPublishOrderedRootDeltaGroup:                    (*backenddb.DB).PublishOrderedRootDeltaGroupWithSystemDeltaBuilder,
+	collectionRouteDBPublishOrderedRootDeltaGroupCommandWAL:          (*backenddb.DB).PublishOrderedRootDeltaGroupWithCommandWALAndSystemDeltaBuilder,
+	collectionRouteDBPublishOrderedRootDeltaBatch:                    (*backenddb.DB).PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder,
+	collectionRouteDBPublishOrderedRootDeltaBatchPreflight:           (*backenddb.DB).PublishOrderedRootDeltaBatchGroupWithPreflightAndSystemDeltaBuilder,
+	collectionRouteDBPublishOrderedRootDeltaBatchCommandWAL:          (*backenddb.DB).PublishOrderedRootDeltaBatchGroupWithCommandWALAndSystemDeltaBuilder,
+	collectionRouteDBPublishOrderedRootDeltaBatchPreflightCommandWAL: (*backenddb.DB).PublishOrderedRootDeltaBatchGroupWithPreflightCommandWALAndSystemDeltaBuilder,
+}
+
+type collectionOrderedRootExpectedOutcome string
+
+const (
+	collectionOrderedRootOutcomeBufferedNoIndexFlush     collectionOrderedRootExpectedOutcome = "buffered-no-index-flush-delta-group"
+	collectionOrderedRootOutcomeBufferedIndexedFlush     collectionOrderedRootExpectedOutcome = "buffered-indexed-flush-delta-batch"
+	collectionOrderedRootOutcomeOverlayWarmSingleBase    collectionOrderedRootExpectedOutcome = "overlay-single-base-warm-delta-batch"
+	collectionOrderedRootOutcomeOverlayColdBuildZeroBase collectionOrderedRootExpectedOutcome = "overlay-zero-base-cold-build-delta-batch"
+	collectionOrderedRootOutcomeOverlayCompaction        collectionOrderedRootExpectedOutcome = "overlay-compaction-delta-group"
+	collectionOrderedRootOutcomeNonCommandWALDeltaGroup  collectionOrderedRootExpectedOutcome = "non-command-wal-delta-group"
+	collectionOrderedRootOutcomeCommandWALDeltaGroup     collectionOrderedRootExpectedOutcome = "command-wal-delta-group"
+	collectionOrderedRootOutcomeNonCommandWALDeltaBatch  collectionOrderedRootExpectedOutcome = "non-command-wal-delta-batch"
+	collectionOrderedRootOutcomeCommandWALDeltaBatch     collectionOrderedRootExpectedOutcome = "command-wal-delta-batch"
+	collectionOrderedRootOutcomeMultiIndexRootGroups     collectionOrderedRootExpectedOutcome = "multi-index-root-groups"
+)
+
+type collectionOrderedRootDownstreamAction string
+
+const (
+	collectionOrderedRootActionEligibleFor3022Observability collectionOrderedRootDownstreamAction = "eligible-for-#3022-observability"
+	collectionOrderedRootActionRequires3023Correctness      collectionOrderedRootDownstreamAction = "requires-#3023-correctness"
+	collectionOrderedRootActionRequires3024OutputOwnership  collectionOrderedRootDownstreamAction = "requires-#3024-output-ownership"
+	collectionOrderedRootActionImplementedCurrentSerialOnly collectionOrderedRootDownstreamAction = "implemented-current-serial-only"
+)
+
+var collectionOrderedRootExpectedOutcomes = map[collectionOrderedRootExpectedOutcome]struct{}{
+	collectionOrderedRootOutcomeBufferedNoIndexFlush:     {},
+	collectionOrderedRootOutcomeBufferedIndexedFlush:     {},
+	collectionOrderedRootOutcomeOverlayWarmSingleBase:    {},
+	collectionOrderedRootOutcomeOverlayColdBuildZeroBase: {},
+	collectionOrderedRootOutcomeOverlayCompaction:        {},
+	collectionOrderedRootOutcomeNonCommandWALDeltaGroup:  {},
+	collectionOrderedRootOutcomeCommandWALDeltaGroup:     {},
+	collectionOrderedRootOutcomeNonCommandWALDeltaBatch:  {},
+	collectionOrderedRootOutcomeCommandWALDeltaBatch:     {},
+	collectionOrderedRootOutcomeMultiIndexRootGroups:     {},
+}
+
+var collectionOrderedRootDownstreamActions = map[collectionOrderedRootDownstreamAction]struct{}{
+	collectionOrderedRootActionEligibleFor3022Observability: {},
+	collectionOrderedRootActionRequires3023Correctness:      {},
+	collectionOrderedRootActionRequires3024OutputOwnership:  {},
+	collectionOrderedRootActionImplementedCurrentSerialOnly: {},
+}
+
+type collectionOrderedRootRouteClassificationRow struct {
+	ID                string
+	PublicAnchors     []collectionOrderedRootRouteAnchor
+	InternalAnchors   []collectionOrderedRootRouteAnchor
+	DBPublishAnchors  []collectionOrderedRootRouteAnchor
+	ExpectedOutcome   collectionOrderedRootExpectedOutcome
+	DownstreamActions []collectionOrderedRootDownstreamAction
+	RootGroups        string
+	ProductionSupport string
+	Covers            []string
+}
+
+func collectionOrderedRootRouteClassificationRows() []collectionOrderedRootRouteClassificationRow {
+	return []collectionOrderedRootRouteClassificationRow{
+		{
+			ID:               "buffered-no-index-flush-primary-root",
+			PublicAnchors:    []collectionOrderedRootRouteAnchor{collectionRouteCollectionFlush},
+			InternalAnchors:  []collectionOrderedRootRouteAnchor{collectionRouteFlushBufferedNoIndexLocked, collectionRouteBuildRootDescriptorSystemDeltaIterator},
+			DBPublishAnchors: []collectionOrderedRootRouteAnchor{collectionRouteDBPublishOrderedRootDeltaGroup},
+			ExpectedOutcome:  collectionOrderedRootOutcomeBufferedNoIndexFlush,
+			DownstreamActions: []collectionOrderedRootDownstreamAction{
+				collectionOrderedRootActionEligibleFor3022Observability,
+				collectionOrderedRootActionRequires3023Correctness,
+			},
+			RootGroups:        "primary root only; BaseRoot is the catalog primary root",
+			ProductionSupport: "current buffered no-index flush is supported through serial ordered-root delta group publish; #3022/#3023 must classify span-native enablement",
+			Covers:            []string{"buffered_flush", "non_command_wal_publish", "primary_root"},
+		},
+		{
+			ID:              "buffered-indexed-flush-root-groups",
+			PublicAnchors:   []collectionOrderedRootRouteAnchor{collectionRouteCollectionInsertBatch, collectionRouteCollectionFlush},
+			InternalAnchors: []collectionOrderedRootRouteAnchor{collectionRouteBufferIndexedInsertPlanLocked, collectionRoutePublishPreparedIndexedFlush, collectionRouteBuildBufferedDeltaBatchInputs},
+			DBPublishAnchors: []collectionOrderedRootRouteAnchor{
+				collectionRouteDBPublishOrderedRootDeltaBatch,
+			},
+			ExpectedOutcome: collectionOrderedRootOutcomeBufferedIndexedFlush,
+			DownstreamActions: []collectionOrderedRootDownstreamAction{
+				collectionOrderedRootActionEligibleFor3022Observability,
+				collectionOrderedRootActionRequires3023Correctness,
+				collectionOrderedRootActionRequires3024OutputOwnership,
+			},
+			RootGroups:        "primary, secondary, index-state, text, and unique-value roots materialized from indexed flush units",
+			ProductionSupport: "current indexed flush is supported through ordered-root delta batch publish; #3022 observes route choice and #3023/#3024 gate span-native output",
+			Covers:            []string{"buffered_flush", "multi_index_roots", "secondary_index_roots", "non_command_wal_publish"},
+		},
+		{
+			ID:              "indexed-overlay-single-base-warm-flush",
+			PublicAnchors:   []collectionOrderedRootRouteAnchor{collectionRouteCollectionInsertBatch, collectionRouteCollectionFlush},
+			InternalAnchors: []collectionOrderedRootRouteAnchor{collectionRoutePublishPreparedIndexedFlush, collectionRouteBuildBufferedOverlayDeltaBatchInputs, collectionRouteOverlayDeltaBaseRoot},
+			DBPublishAnchors: []collectionOrderedRootRouteAnchor{
+				collectionRouteDBPublishOrderedRootDeltaBatch,
+			},
+			ExpectedOutcome: collectionOrderedRootOutcomeOverlayWarmSingleBase,
+			DownstreamActions: []collectionOrderedRootDownstreamAction{
+				collectionOrderedRootActionRequires3023Correctness,
+				collectionOrderedRootActionRequires3024OutputOwnership,
+			},
+			RootGroups:        "one existing overlay becomes the nonzero BaseRoot; new overlay delta includes deleted markers",
+			ProductionSupport: "single-overlay flush is current warm behavior, distinct from cold-build zero-base overlay publish",
+			Covers:            []string{"overlay_flush", "overlay_warm_single_base", "buffered_flush"},
+		},
+		{
+			ID:              "indexed-overlay-zero-base-cold-build-flush",
+			PublicAnchors:   []collectionOrderedRootRouteAnchor{collectionRouteCollectionInsertBatch, collectionRouteCollectionFlush},
+			InternalAnchors: []collectionOrderedRootRouteAnchor{collectionRoutePublishPreparedIndexedFlush, collectionRouteBuildBufferedOverlayDeltaBatchInputs, collectionRouteOverlayDeltaBaseRoot},
+			DBPublishAnchors: []collectionOrderedRootRouteAnchor{
+				collectionRouteDBPublishOrderedRootDeltaBatch,
+			},
+			ExpectedOutcome: collectionOrderedRootOutcomeOverlayColdBuildZeroBase,
+			DownstreamActions: []collectionOrderedRootDownstreamAction{
+				collectionOrderedRootActionRequires3023Correctness,
+				collectionOrderedRootActionRequires3024OutputOwnership,
+			},
+			RootGroups:        "zero or multiple existing overlays force BaseRoot=0 and include deleted markers",
+			ProductionSupport: "zero-base overlay publish remains a deterministic cold-build classification until #3023/#3024 reclassify it",
+			Covers:            []string{"overlay_flush", "overlay_cold_build_zero_base", "buffered_flush"},
+		},
+		{
+			ID:               "overlay-compaction-maintenance",
+			PublicAnchors:    []collectionOrderedRootRouteAnchor{collectionRouteCollectionCompactRootOverlays},
+			InternalAnchors:  []collectionOrderedRootRouteAnchor{collectionRouteCompactRootOverlaysLocked, collectionRouteBuildOverlayDescriptorSystemDelta},
+			DBPublishAnchors: []collectionOrderedRootRouteAnchor{collectionRouteDBPublishOrderedRootDeltaGroup},
+			ExpectedOutcome:  collectionOrderedRootOutcomeOverlayCompaction,
+			DownstreamActions: []collectionOrderedRootDownstreamAction{
+				collectionOrderedRootActionImplementedCurrentSerialOnly,
+				collectionOrderedRootActionEligibleFor3022Observability,
+			},
+			RootGroups:        "overlay root names are folded into base roots and overlay descriptors are cleared in one system commit",
+			ProductionSupport: "current maintenance compaction is serial ordered-root delta group publish, not span-native output",
+			Covers:            []string{"overlay_compaction", "overlay_flush", "non_command_wal_publish"},
+		},
+		{
+			ID:              "insert-non-command-wal-root-groups",
+			PublicAnchors:   []collectionOrderedRootRouteAnchor{collectionRouteCollectionInsertBatch},
+			InternalAnchors: []collectionOrderedRootRouteAnchor{collectionRouteInsertBatchPlanRootNamesAndBaseIDs, collectionRouteBuildRootDescriptorSystemDeltaIterator},
+			DBPublishAnchors: []collectionOrderedRootRouteAnchor{
+				collectionRouteDBPublishOrderedRootDeltaGroup,
+			},
+			ExpectedOutcome: collectionOrderedRootOutcomeNonCommandWALDeltaGroup,
+			DownstreamActions: []collectionOrderedRootDownstreamAction{
+				collectionOrderedRootActionEligibleFor3022Observability,
+				collectionOrderedRootActionRequires3023Correctness,
+			},
+			RootGroups:        "primary plus any secondary, text, vector, or index-state roots in the insert plan",
+			ProductionSupport: "foreground non-command-WAL insert publish is current serial behavior; #3022/#3023 must classify span-native route changes",
+			Covers:            []string{"non_command_wal_publish", "insert_root_groups", "multi_index_roots"},
+		},
+		{
+			ID:              "insert-command-wal-root-groups",
+			PublicAnchors:   []collectionOrderedRootRouteAnchor{collectionRouteCollectionInsertBatch},
+			InternalAnchors: []collectionOrderedRootRouteAnchor{collectionRouteCommandWALActive, collectionRouteWithCommandWALPublishCoordinator, collectionRouteNewInsertCommandWALIntent},
+			DBPublishAnchors: []collectionOrderedRootRouteAnchor{
+				collectionRouteDBPublishOrderedRootDeltaGroupCommandWAL,
+			},
+			ExpectedOutcome: collectionOrderedRootOutcomeCommandWALDeltaGroup,
+			DownstreamActions: []collectionOrderedRootDownstreamAction{
+				collectionOrderedRootActionEligibleFor3022Observability,
+				collectionOrderedRootActionRequires3023Correctness,
+			},
+			RootGroups:        "same insert root group as non-command-WAL, with command intent appended before ordered-root publish",
+			ProductionSupport: "command-WAL insert publish is supported; span-native eligibility must preserve command-WAL ordering",
+			Covers:            []string{"command_wal_publish", "insert_root_groups", "multi_index_roots"},
+		},
+		{
+			ID:              "delete-non-command-wal-root-groups",
+			PublicAnchors:   []collectionOrderedRootRouteAnchor{collectionRouteCollectionDeleteDocument, collectionRouteCollectionDeleteBatch},
+			InternalAnchors: []collectionOrderedRootRouteAnchor{collectionRouteBuildRootDeltaBatchInputsFromTables, collectionRouteBuildRootDescriptorSystemDeltaIterator},
+			DBPublishAnchors: []collectionOrderedRootRouteAnchor{
+				collectionRouteDBPublishOrderedRootDeltaBatch,
+			},
+			ExpectedOutcome: collectionOrderedRootOutcomeNonCommandWALDeltaBatch,
+			DownstreamActions: []collectionOrderedRootDownstreamAction{
+				collectionOrderedRootActionRequires3023Correctness,
+				collectionOrderedRootActionRequires3024OutputOwnership,
+			},
+			RootGroups:        "primary tombstones plus secondary, text, index-state, and retained-column reclaim roots when present",
+			ProductionSupport: "delete root groups are supported through ordered-root delta batch publish; #3023/#3024 gate span-native enablement",
+			Covers:            []string{"delete_root_groups", "non_command_wal_publish", "multi_index_roots"},
+		},
+		{
+			ID:              "delete-command-wal-root-groups",
+			PublicAnchors:   []collectionOrderedRootRouteAnchor{collectionRouteCollectionDeleteDocument, collectionRouteCollectionDeleteBatch},
+			InternalAnchors: []collectionOrderedRootRouteAnchor{collectionRouteCommandWALActive, collectionRouteWithCommandWALPublishCoordinator, collectionRouteNewDeleteCommandWALIntent},
+			DBPublishAnchors: []collectionOrderedRootRouteAnchor{
+				collectionRouteDBPublishOrderedRootDeltaBatchCommandWAL,
+			},
+			ExpectedOutcome: collectionOrderedRootOutcomeCommandWALDeltaBatch,
+			DownstreamActions: []collectionOrderedRootDownstreamAction{
+				collectionOrderedRootActionRequires3023Correctness,
+				collectionOrderedRootActionRequires3024OutputOwnership,
+			},
+			RootGroups:        "same delete root group as non-command-WAL, covered by a command-WAL delete intent",
+			ProductionSupport: "command-WAL delete publish is supported; span-native eligibility must preserve command-WAL ordering and batch atomicity",
+			Covers:            []string{"delete_root_groups", "command_wal_publish", "multi_index_roots"},
+		},
+		{
+			ID:              "update-non-command-wal-root-groups",
+			PublicAnchors:   []collectionOrderedRootRouteAnchor{collectionRouteCollectionUpdate, collectionRouteCollectionUpdateBatch},
+			InternalAnchors: []collectionOrderedRootRouteAnchor{collectionRoutePublishUpdateBatchPlanLocked, collectionRouteCoalesceCollectionRootDeltaTables, collectionRouteBuildRootDeltaBatchInputsFromTables},
+			DBPublishAnchors: []collectionOrderedRootRouteAnchor{
+				collectionRouteDBPublishOrderedRootDeltaBatchPreflight,
+			},
+			ExpectedOutcome: collectionOrderedRootOutcomeNonCommandWALDeltaBatch,
+			DownstreamActions: []collectionOrderedRootDownstreamAction{
+				collectionOrderedRootActionRequires3023Correctness,
+				collectionOrderedRootActionRequires3024OutputOwnership,
+			},
+			RootGroups:        "coalesced primary, secondary, unique, text, vector, and index-state update deltas",
+			ProductionSupport: "non-command-WAL update publish is supported with preflight validation; #3023/#3024 gate span-native enablement",
+			Covers:            []string{"update_root_groups", "non_command_wal_publish", "multi_index_roots"},
+		},
+		{
+			ID:              "update-command-wal-root-groups",
+			PublicAnchors:   []collectionOrderedRootRouteAnchor{collectionRouteCollectionUpdate, collectionRouteCollectionUpdateBatch},
+			InternalAnchors: []collectionOrderedRootRouteAnchor{collectionRouteCommandWALActive, collectionRouteWithCommandWALPublishCoordinator, collectionRouteNewUpdateCommandWALIntent},
+			DBPublishAnchors: []collectionOrderedRootRouteAnchor{
+				collectionRouteDBPublishOrderedRootDeltaBatchPreflightCommandWAL,
+			},
+			ExpectedOutcome: collectionOrderedRootOutcomeCommandWALDeltaBatch,
+			DownstreamActions: []collectionOrderedRootDownstreamAction{
+				collectionOrderedRootActionRequires3023Correctness,
+				collectionOrderedRootActionRequires3024OutputOwnership,
+			},
+			RootGroups:        "same update root group as non-command-WAL, covered by a command-WAL update intent",
+			ProductionSupport: "command-WAL update publish is supported; span-native eligibility must preserve command-WAL ordering and preflight semantics",
+			Covers:            []string{"update_root_groups", "command_wal_publish", "multi_index_roots"},
+		},
+		{
+			ID:              "multi-index-root-group-inventory",
+			PublicAnchors:   []collectionOrderedRootRouteAnchor{collectionRouteCollectionManagerCreateCollection, collectionRouteCollectionInsertBatch, collectionRouteCollectionUpdateBatch, collectionRouteCollectionDeleteBatch},
+			InternalAnchors: []collectionOrderedRootRouteAnchor{collectionRouteInsertBatchPlanPublishRootRuns, collectionRouteInsertBatchPlanRootNamesAndBaseIDs, collectionRouteBuildCollectionRootOverlayFilters},
+			DBPublishAnchors: []collectionOrderedRootRouteAnchor{
+				collectionRouteDBPublishOrderedRootGroup,
+				collectionRouteDBPublishOrderedRootDeltaGroup,
+				collectionRouteDBPublishOrderedRootDeltaBatch,
+			},
+			ExpectedOutcome: collectionOrderedRootOutcomeMultiIndexRootGroups,
+			DownstreamActions: []collectionOrderedRootDownstreamAction{
+				collectionOrderedRootActionEligibleFor3022Observability,
+				collectionOrderedRootActionRequires3023Correctness,
+			},
+			RootGroups:        "collection primary, secondary, index-state, text, vector, unique-value, and overlay root descriptors",
+			ProductionSupport: "multi-index root group inventory is supported by current serial/group publish and must remain explicit for #3022/#3023",
+			Covers:            []string{"multi_index_roots", "secondary_index_roots", "insert_root_groups", "update_root_groups", "delete_root_groups"},
+		},
+	}
+}
+
+func TestCollectionOrderedRootRouteClassificationCoversPublicSurfaces(t *testing.T) {
+	required := map[string]bool{
+		"buffered_flush":               false,
+		"overlay_flush":                false,
+		"overlay_compaction":           false,
+		"command_wal_publish":          false,
+		"non_command_wal_publish":      false,
+		"insert_root_groups":           false,
+		"delete_root_groups":           false,
+		"update_root_groups":           false,
+		"multi_index_roots":            false,
+		"secondary_index_roots":        false,
+		"primary_root":                 false,
+		"overlay_warm_single_base":     false,
+		"overlay_cold_build_zero_base": false,
+	}
+
+	rows := collectionOrderedRootRouteClassificationRows()
+	if len(rows) == 0 {
+		t.Fatal("collection ordered-root route classification matrix is empty")
+	}
+	seenIDs := make(map[string]struct{}, len(rows))
+	for _, row := range rows {
+		validateCollectionOrderedRootRouteClassificationRow(t, row, seenIDs)
+		for _, token := range row.Covers {
+			if _, ok := required[token]; !ok {
+				t.Fatalf("collection ordered-root row %q has unregistered coverage token %q", row.ID, token)
+			}
+			required[token] = true
+		}
+	}
+	for token, seen := range required {
+		if !seen {
+			t.Fatalf("collection ordered-root route classification missing coverage token %q", token)
+		}
+	}
+}
+
+func TestCollectionOrderedRootOverlayDeltaBaseClassification(t *testing.T) {
+	warm := collectionOrderedRootRouteClassificationRowByID(t, "indexed-overlay-single-base-warm-flush")
+	if warm.ExpectedOutcome != collectionOrderedRootOutcomeOverlayWarmSingleBase {
+		t.Fatalf("warm overlay row outcome=%q want %q", warm.ExpectedOutcome, collectionOrderedRootOutcomeOverlayWarmSingleBase)
+	}
+	cold := collectionOrderedRootRouteClassificationRowByID(t, "indexed-overlay-zero-base-cold-build-flush")
+	if cold.ExpectedOutcome != collectionOrderedRootOutcomeOverlayColdBuildZeroBase {
+		t.Fatalf("cold overlay row outcome=%q want %q", cold.ExpectedOutcome, collectionOrderedRootOutcomeOverlayColdBuildZeroBase)
+	}
+
+	if got := overlayDeltaBaseRoot(nil); got != 0 {
+		t.Fatalf("overlayDeltaBaseRoot(nil)=%d want 0 cold-build base", got)
+	}
+	if got := overlayDeltaBaseRoot([]uint64{17}); got != 17 {
+		t.Fatalf("overlayDeltaBaseRoot(single)=%d want warm base 17", got)
+	}
+	if got := overlayDeltaBaseRoot([]uint64{17, 23}); got != 0 {
+		t.Fatalf("overlayDeltaBaseRoot(multiple)=%d want 0 cold-build base", got)
+	}
+}
+
+func validateCollectionOrderedRootRouteClassificationRow(t *testing.T, row collectionOrderedRootRouteClassificationRow, seenIDs map[string]struct{}) {
+	t.Helper()
+	if row.ID == "" {
+		t.Fatalf("collection ordered-root row has empty ID: %+v", row)
+	}
+	if _, exists := seenIDs[row.ID]; exists {
+		t.Fatalf("duplicate collection ordered-root row ID %q", row.ID)
+	}
+	seenIDs[row.ID] = struct{}{}
+	for field, value := range map[string]string{
+		"expected_outcome":   string(row.ExpectedOutcome),
+		"root_groups":        row.RootGroups,
+		"production_support": row.ProductionSupport,
+	} {
+		if strings.TrimSpace(value) == "" {
+			t.Fatalf("collection ordered-root row %q missing %s", row.ID, field)
+		}
+		lower := strings.ToLower(value)
+		if strings.Contains(lower, "unknown") || strings.Contains(lower, "implicit disabled") {
+			t.Fatalf("collection ordered-root row %q has unclassified %s=%q", row.ID, field, value)
+		}
+	}
+	if _, ok := collectionOrderedRootExpectedOutcomes[row.ExpectedOutcome]; !ok {
+		t.Fatalf("collection ordered-root row %q has unsupported expected outcome %q", row.ID, row.ExpectedOutcome)
+	}
+	validateCollectionOrderedRootAnchors(t, row.ID, "public", row.PublicAnchors)
+	validateCollectionOrderedRootAnchors(t, row.ID, "internal", row.InternalAnchors)
+	validateCollectionOrderedRootAnchors(t, row.ID, "db_publish", row.DBPublishAnchors)
+	if len(row.DownstreamActions) == 0 {
+		t.Fatalf("collection ordered-root row %q has no downstream action", row.ID)
+	}
+	seenActions := make(map[collectionOrderedRootDownstreamAction]struct{}, len(row.DownstreamActions))
+	for _, action := range row.DownstreamActions {
+		if _, ok := collectionOrderedRootDownstreamActions[action]; !ok {
+			t.Fatalf("collection ordered-root row %q has unsupported downstream action %q", row.ID, action)
+		}
+		if _, exists := seenActions[action]; exists {
+			t.Fatalf("collection ordered-root row %q repeats downstream action %q", row.ID, action)
+		}
+		seenActions[action] = struct{}{}
+	}
+	if len(row.Covers) == 0 {
+		t.Fatalf("collection ordered-root row %q has no coverage tokens", row.ID)
+	}
+}
+
+func validateCollectionOrderedRootAnchors(t *testing.T, rowID, field string, anchors []collectionOrderedRootRouteAnchor) {
+	t.Helper()
+	if len(anchors) == 0 {
+		t.Fatalf("collection ordered-root row %q has no %s anchors", rowID, field)
+	}
+	seen := make(map[collectionOrderedRootRouteAnchor]struct{}, len(anchors))
+	for _, anchor := range anchors {
+		if _, ok := collectionOrderedRootRouteAnchorEvidence[anchor]; !ok {
+			t.Fatalf("collection ordered-root row %q has unsupported %s anchor %q", rowID, field, anchor)
+		}
+		if _, exists := seen[anchor]; exists {
+			t.Fatalf("collection ordered-root row %q repeats %s anchor %q", rowID, field, anchor)
+		}
+		seen[anchor] = struct{}{}
+	}
+}
+
+func collectionOrderedRootRouteClassificationRowByID(t *testing.T, id string) collectionOrderedRootRouteClassificationRow {
+	t.Helper()
+	for _, row := range collectionOrderedRootRouteClassificationRows() {
+		if row.ID == id {
+			return row
+		}
+	}
+	t.Fatalf("missing collection ordered-root route classification row %q", id)
+	return collectionOrderedRootRouteClassificationRow{}
+}

--- a/TreeDB/db/ordered_root_span_native_classification_test.go
+++ b/TreeDB/db/ordered_root_span_native_classification_test.go
@@ -14,10 +14,121 @@ const (
 	orderedRootPublishStatusBlockedByPrefix             = "blocked_by:"
 )
 
+type orderedRootPublishRouteAnchor string
+
+const (
+	orderedRootRouteDBPublishOrderedRootIterator                                               orderedRootPublishRouteAnchor = "TreeDB/db.(*DB).PublishOrderedRootIterator"
+	orderedRootRouteDBPublishOrderedRootGroup                                                  orderedRootPublishRouteAnchor = "TreeDB/db.(*DB).PublishOrderedRootGroup"
+	orderedRootRouteDBPublishOrderedRootGroupWithSystemBuilder                                 orderedRootPublishRouteAnchor = "TreeDB/db.(*DB).PublishOrderedRootGroupWithSystemBuilder"
+	orderedRootRouteDBPublishOrderedRootDeltaGroupWithSystemBuilder                            orderedRootPublishRouteAnchor = "TreeDB/db.(*DB).PublishOrderedRootDeltaGroupWithSystemBuilder"
+	orderedRootRouteDBPublishOrderedRootDeltaGroupWithSystemDeltaBuilder                       orderedRootPublishRouteAnchor = "TreeDB/db.(*DB).PublishOrderedRootDeltaGroupWithSystemDeltaBuilder"
+	orderedRootRouteDBPublishOrderedRootDeltaGroupWithCommandWALContextAndSystemDeltaBuilder   orderedRootPublishRouteAnchor = "TreeDB/db.(*DB).PublishOrderedRootDeltaGroupWithCommandWALContextAndSystemDeltaBuilder"
+	orderedRootRouteDBPublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder                  orderedRootPublishRouteAnchor = "TreeDB/db.(*DB).PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder"
+	orderedRootRouteDBPublishOrderedRootDeltaBatchGroupWithCommandWALAndSystemDeltaBuilder     orderedRootPublishRouteAnchor = "TreeDB/db.(*DB).PublishOrderedRootDeltaBatchGroupWithCommandWALAndSystemDeltaBuilder"
+	orderedRootRouteDBPublishOrderedRootDeltaBatchGroupWithPreflightAndSystemDeltaBuilder      orderedRootPublishRouteAnchor = "TreeDB/db.(*DB).PublishOrderedRootDeltaBatchGroupWithPreflightAndSystemDeltaBuilder"
+	orderedRootRouteDBPublishOrderedRootDeltaBatchGroupWithPreflightCommandWALAndSystemBuilder orderedRootPublishRouteAnchor = "TreeDB/db.(*DB).PublishOrderedRootDeltaBatchGroupWithPreflightCommandWALAndSystemDeltaBuilder"
+	orderedRootRouteDBOrderedRootDeltaBatchApplyOptions                                        orderedRootPublishRouteAnchor = "TreeDB/db.(*DB).orderedRootDeltaBatchApplyOptions"
+	orderedRootRouteDBPublishOrderedRootDeltaBatchWithAllocator                                orderedRootPublishRouteAnchor = "TreeDB/db.(*DB).publishOrderedRootDeltaBatchWithAllocator"
+	orderedRootRouteDBRunOrderedRootDeltaBatchReadOnlyPrepare                                  orderedRootPublishRouteAnchor = "TreeDB/db.(*DB).runOrderedRootDeltaBatchReadOnlyPrepare"
+	orderedRootRouteDBTryPublishOrderedRootDeltaBatchGroupOptimistic                           orderedRootPublishRouteAnchor = "TreeDB/db.(*DB).tryPublishOrderedRootDeltaBatchGroupOptimistic"
+	orderedRootRouteDBRejectUnloggedCommandWALRootPublish                                      orderedRootPublishRouteAnchor = "TreeDB/db.(*DB).rejectUnloggedCommandWALRootPublish"
+	orderedRootRouteOrderedRootDeltaBatchPublishInput                                          orderedRootPublishRouteAnchor = "TreeDB/db.OrderedRootDeltaBatchPublishInput"
+	orderedRootRouteOrderedRootStoragePagerLeaves                                              orderedRootPublishRouteAnchor = "TreeDB/db.OrderedRootStoragePagerLeaves"
+	orderedRootRouteOrderedRootStorageValueLogLeaves                                           orderedRootPublishRouteAnchor = "TreeDB/db.OrderedRootStorageValueLogLeaves"
+	orderedRootRouteFlushAdmissionPolicyAuto                                                   orderedRootPublishRouteAnchor = "TreeDB/db.FlushAdmissionPolicyAuto"
+)
+
+var orderedRootPublishRouteAnchorEvidence = map[orderedRootPublishRouteAnchor]any{
+	orderedRootRouteDBPublishOrderedRootIterator:                                               (*DB).PublishOrderedRootIterator,
+	orderedRootRouteDBPublishOrderedRootGroup:                                                  (*DB).PublishOrderedRootGroup,
+	orderedRootRouteDBPublishOrderedRootGroupWithSystemBuilder:                                 (*DB).PublishOrderedRootGroupWithSystemBuilder,
+	orderedRootRouteDBPublishOrderedRootDeltaGroupWithSystemBuilder:                            (*DB).PublishOrderedRootDeltaGroupWithSystemBuilder,
+	orderedRootRouteDBPublishOrderedRootDeltaGroupWithSystemDeltaBuilder:                       (*DB).PublishOrderedRootDeltaGroupWithSystemDeltaBuilder,
+	orderedRootRouteDBPublishOrderedRootDeltaGroupWithCommandWALContextAndSystemDeltaBuilder:   (*DB).PublishOrderedRootDeltaGroupWithCommandWALContextAndSystemDeltaBuilder,
+	orderedRootRouteDBPublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder:                  (*DB).PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder,
+	orderedRootRouteDBPublishOrderedRootDeltaBatchGroupWithCommandWALAndSystemDeltaBuilder:     (*DB).PublishOrderedRootDeltaBatchGroupWithCommandWALAndSystemDeltaBuilder,
+	orderedRootRouteDBPublishOrderedRootDeltaBatchGroupWithPreflightAndSystemDeltaBuilder:      (*DB).PublishOrderedRootDeltaBatchGroupWithPreflightAndSystemDeltaBuilder,
+	orderedRootRouteDBPublishOrderedRootDeltaBatchGroupWithPreflightCommandWALAndSystemBuilder: (*DB).PublishOrderedRootDeltaBatchGroupWithPreflightCommandWALAndSystemDeltaBuilder,
+	orderedRootRouteDBOrderedRootDeltaBatchApplyOptions:                                        (*DB).orderedRootDeltaBatchApplyOptions,
+	orderedRootRouteDBPublishOrderedRootDeltaBatchWithAllocator:                                (*DB).publishOrderedRootDeltaBatchWithAllocator,
+	orderedRootRouteDBRunOrderedRootDeltaBatchReadOnlyPrepare:                                  (*DB).runOrderedRootDeltaBatchReadOnlyPrepare,
+	orderedRootRouteDBTryPublishOrderedRootDeltaBatchGroupOptimistic:                           (*DB).tryPublishOrderedRootDeltaBatchGroupOptimistic,
+	orderedRootRouteDBRejectUnloggedCommandWALRootPublish:                                      (*DB).rejectUnloggedCommandWALRootPublish,
+	orderedRootRouteOrderedRootDeltaBatchPublishInput:                                          OrderedRootDeltaBatchPublishInput{},
+	orderedRootRouteOrderedRootStoragePagerLeaves:                                              OrderedRootStoragePagerLeaves,
+	orderedRootRouteOrderedRootStorageValueLogLeaves:                                           OrderedRootStorageValueLogLeaves,
+	orderedRootRouteFlushAdmissionPolicyAuto:                                                   FlushAdmissionPolicyAuto,
+}
+
+type orderedRootPublishExpectedOutcome string
+
+const (
+	orderedRootOutcomeCurrentSerialPublish            orderedRootPublishExpectedOutcome = "current-serial-publish"
+	orderedRootOutcomeCurrentSerializedGroupPublish   orderedRootPublishExpectedOutcome = "current-serialized-group-publish"
+	orderedRootOutcomeCurrentOptimisticGroupPublish   orderedRootPublishExpectedOutcome = "current-optimistic-group-publish"
+	orderedRootOutcomeCurrentCommandWALCoveredPublish orderedRootPublishExpectedOutcome = "current-command-wal-covered-publish"
+	orderedRootOutcomeCurrentFailClosed               orderedRootPublishExpectedOutcome = "current-fail-closed"
+	orderedRootOutcomePolicyBlocked                   orderedRootPublishExpectedOutcome = "policy-blocked"
+	orderedRootOutcomeCurrentReadOnlyPrepareOnly      orderedRootPublishExpectedOutcome = "current-read-only-prepare-only"
+	orderedRootOutcomeBlanketNonSpanNativeFallback    orderedRootPublishExpectedOutcome = "current-blanket-non-span-native-fallback"
+	orderedRootOutcomeCurrentEmptyNoop                orderedRootPublishExpectedOutcome = "current-empty-noop"
+	orderedRootOutcomeCurrentStoragePolicy            orderedRootPublishExpectedOutcome = "current-storage-policy"
+	orderedRootOutcomeCurrentCollectionRoute          orderedRootPublishExpectedOutcome = "current-collection-route"
+	orderedRootOutcomeCurrentWarmOverlaySingleBase    orderedRootPublishExpectedOutcome = "current-warm-overlay-single-base"
+	orderedRootOutcomeCurrentColdBuildZeroBase        orderedRootPublishExpectedOutcome = "current-cold-build-zero-base"
+	orderedRootOutcomeCurrentSnapshotVisibility       orderedRootPublishExpectedOutcome = "current-snapshot-visibility"
+	orderedRootOutcomeRawRouteBlocked                 orderedRootPublishExpectedOutcome = "raw-route-blocked"
+)
+
+type orderedRootPublishDownstreamAction string
+
+const (
+	orderedRootActionImplementedCurrentSerialOnly   orderedRootPublishDownstreamAction = "implemented-current-serial-only"
+	orderedRootActionEligibleFor3022Observability   orderedRootPublishDownstreamAction = "eligible-for-#3022-observability"
+	orderedRootActionRequires3023Correctness        orderedRootPublishDownstreamAction = "requires-#3023-correctness"
+	orderedRootActionRequires3024OutputOwnership    orderedRootPublishDownstreamAction = "requires-#3024-output-ownership"
+	orderedRootActionBlockedBy3032                  orderedRootPublishDownstreamAction = "blocked-by-#3032"
+	orderedRootActionBlockedBy3033                  orderedRootPublishDownstreamAction = "blocked-by-#3033"
+	orderedRootActionImplementedCurrentFailClosed   orderedRootPublishDownstreamAction = "implemented-current-fail-closed"
+	orderedRootActionImplementedCurrentReadOnlyOnly orderedRootPublishDownstreamAction = "implemented-current-read-only-only"
+)
+
+var orderedRootExpectedOutcomes = map[orderedRootPublishExpectedOutcome]struct{}{
+	orderedRootOutcomeCurrentSerialPublish:            {},
+	orderedRootOutcomeCurrentSerializedGroupPublish:   {},
+	orderedRootOutcomeCurrentOptimisticGroupPublish:   {},
+	orderedRootOutcomeCurrentCommandWALCoveredPublish: {},
+	orderedRootOutcomeCurrentFailClosed:               {},
+	orderedRootOutcomePolicyBlocked:                   {},
+	orderedRootOutcomeCurrentReadOnlyPrepareOnly:      {},
+	orderedRootOutcomeBlanketNonSpanNativeFallback:    {},
+	orderedRootOutcomeCurrentEmptyNoop:                {},
+	orderedRootOutcomeCurrentStoragePolicy:            {},
+	orderedRootOutcomeCurrentCollectionRoute:          {},
+	orderedRootOutcomeCurrentWarmOverlaySingleBase:    {},
+	orderedRootOutcomeCurrentColdBuildZeroBase:        {},
+	orderedRootOutcomeCurrentSnapshotVisibility:       {},
+	orderedRootOutcomeRawRouteBlocked:                 {},
+}
+
+var orderedRootDownstreamActions = map[orderedRootPublishDownstreamAction]struct{}{
+	orderedRootActionImplementedCurrentSerialOnly:   {},
+	orderedRootActionEligibleFor3022Observability:   {},
+	orderedRootActionRequires3023Correctness:        {},
+	orderedRootActionRequires3024OutputOwnership:    {},
+	orderedRootActionBlockedBy3032:                  {},
+	orderedRootActionBlockedBy3033:                  {},
+	orderedRootActionImplementedCurrentFailClosed:   {},
+	orderedRootActionImplementedCurrentReadOnlyOnly: {},
+}
+
 type orderedRootSpanNativeClassificationRow struct {
 	ID                string
 	Category          string
 	Route             string
+	RouteAnchors      []orderedRootPublishRouteAnchor
+	ExpectedOutcome   orderedRootPublishExpectedOutcome
+	DownstreamActions []orderedRootPublishDownstreamAction
 	Mode              string
 	Semantics         string
 	Storage           string
@@ -33,27 +144,36 @@ func orderedRootSpanNativeClassificationRows() []orderedRootSpanNativeClassifica
 			ID:                "direct-iterator-publish-cold-warm",
 			Category:          "direct publisher routes",
 			Route:             "PublishOrderedRootIterator",
+			RouteAnchors:      []orderedRootPublishRouteAnchor{orderedRootRouteDBPublishOrderedRootIterator},
+			ExpectedOutcome:   orderedRootOutcomeCurrentSerialPublish,
+			DownstreamActions: []orderedRootPublishDownstreamAction{orderedRootActionImplementedCurrentSerialOnly, orderedRootActionEligibleFor3022Observability},
 			Mode:              "serial apply",
 			Semantics:         "point inserts and overwrites through ordered iterators",
 			Storage:           "root-local inline or DB default leaf policy",
 			Durability:        "checkpoint, reopen, snapshot read visibility",
 			Status:            orderedRootPublishStatusImplemented,
-			ProductionSupport: "current serial publisher is supported; it does not claim ordered-root span-native apply",
+			ProductionSupport: "current serial publisher is supported; it remains serial-only unless #3022 observability identifies a later span-native candidate",
 			Covers: []string{
 				"direct_batch_publish", "serial_apply", "point_insert", "overwrite",
 				"inline_leaf_output", "root_local_policy", "checkpoint", "reopen", "snapshot_read_visibility",
 			},
 		},
 		{
-			ID:                "grouped-full-root-publish",
-			Category:          "direct publisher routes",
-			Route:             "PublishOrderedRootGroup and PublishOrderedRootGroupWithSystemBuilder",
+			ID:       "grouped-full-root-publish",
+			Category: "direct publisher routes",
+			Route:    "PublishOrderedRootGroup and PublishOrderedRootGroupWithSystemBuilder",
+			RouteAnchors: []orderedRootPublishRouteAnchor{
+				orderedRootRouteDBPublishOrderedRootGroup,
+				orderedRootRouteDBPublishOrderedRootGroupWithSystemBuilder,
+			},
+			ExpectedOutcome:   orderedRootOutcomeCurrentSerializedGroupPublish,
+			DownstreamActions: []orderedRootPublishDownstreamAction{orderedRootActionImplementedCurrentSerialOnly, orderedRootActionEligibleFor3022Observability},
 			Mode:              "serialized group publish",
 			Semantics:         "full-root grouped publication with system descriptor publish",
 			Storage:           "per-root storage policy",
 			Durability:        "one backend commit preserves system-root identity",
 			Status:            orderedRootPublishStatusImplemented,
-			ProductionSupport: "current grouped full-root publish is supported for ordered roots and descriptors",
+			ProductionSupport: "current grouped full-root publish is supported for ordered roots and descriptors; span-native enablement is not implied by this serial route",
 			Covers: []string{
 				"grouped_publish", "serialized_group_publish", "system_delta_builder_publish",
 				"non_command_wal_system_publish", "multi_index_root_groups", "system_root_identity",
@@ -63,27 +183,36 @@ func orderedRootSpanNativeClassificationRows() []orderedRootSpanNativeClassifica
 			ID:                "serialized-delta-group-publish",
 			Category:          "direct publisher routes",
 			Route:             "PublishOrderedRootDeltaGroupWithSystemDeltaBuilder",
+			RouteAnchors:      []orderedRootPublishRouteAnchor{orderedRootRouteDBPublishOrderedRootDeltaGroupWithSystemDeltaBuilder},
+			ExpectedOutcome:   orderedRootOutcomeCurrentSerialPublish,
+			DownstreamActions: []orderedRootPublishDownstreamAction{orderedRootActionRequires3023Correctness},
 			Mode:              "serial apply",
 			Semantics:         "warm root-local iterator deltas preserve omitted base entries",
 			Storage:           "per-root storage policy",
 			Durability:        "system root and ordered roots commit together",
 			Status:            orderedRootPublishStatusImplemented,
-			ProductionSupport: "current iterator-delta publish is supported as serial ordered-root behavior",
+			ProductionSupport: "current iterator-delta publish is supported as serial ordered-root behavior; span-native enablement requires #3023 correctness coverage",
 			Covers: []string{
 				"serialized_group_publish", "point_insert", "overwrite", "delete_tombstone",
 				"mixed_update_delete_batch", "system_root_identity",
 			},
 		},
 		{
-			ID:                "optimistic-delta-batch-group-publish",
-			Category:          "direct publisher routes",
-			Route:             "PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder",
+			ID:       "optimistic-delta-batch-group-publish",
+			Category: "direct publisher routes",
+			Route:    "PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder",
+			RouteAnchors: []orderedRootPublishRouteAnchor{
+				orderedRootRouteDBPublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder,
+				orderedRootRouteDBTryPublishOrderedRootDeltaBatchGroupOptimistic,
+			},
+			ExpectedOutcome:   orderedRootOutcomeCurrentOptimisticGroupPublish,
+			DownstreamActions: []orderedRootPublishDownstreamAction{orderedRootActionRequires3023Correctness, orderedRootActionRequires3024OutputOwnership},
 			Mode:              "optimistic group publish with optional root-level parallel apply",
 			Semantics:         "materialized batch deltas publish roots before guarded final commit",
 			Storage:           "per-root storage policy",
 			Durability:        "root mismatch retries through serialized fallback",
 			Status:            orderedRootPublishStatusImplemented,
-			ProductionSupport: "current optimistic root-group publish is supported; root-level parallelism is not span-native leaf apply",
+			ProductionSupport: "current optimistic root-group publish is supported; span-native leaf apply requires #3023 correctness and #3024 output ownership",
 			Covers: []string{
 				"optimistic_group_publish", "parallel_root_apply", "duplicate_same_key_overwrite",
 				"output_ownership", "snapshot_read_visibility",
@@ -93,12 +222,15 @@ func orderedRootSpanNativeClassificationRows() []orderedRootSpanNativeClassifica
 			ID:                "command-wal-context-publish",
 			Category:          "system-root routes",
 			Route:             "PublishOrderedRootDeltaGroupWithCommandWALContextAndSystemDeltaBuilder",
+			RouteAnchors:      []orderedRootPublishRouteAnchor{orderedRootRouteDBPublishOrderedRootDeltaGroupWithCommandWALContextAndSystemDeltaBuilder},
+			ExpectedOutcome:   orderedRootOutcomeCurrentCommandWALCoveredPublish,
+			DownstreamActions: []orderedRootPublishDownstreamAction{orderedRootActionRequires3023Correctness, orderedRootActionEligibleFor3022Observability},
 			Mode:              "WAL-enabled command publish",
 			Semantics:         "command-WAL LSN is assigned before system delta builder",
 			Storage:           "per-root storage policy",
 			Durability:        "command-WAL ordering and system-root identity",
 			Status:            orderedRootPublishStatusImplemented,
-			ProductionSupport: "current command-WAL covered ordered-root publish is supported with fail-closed poisoning on post-append errors",
+			ProductionSupport: "current command-WAL covered ordered-root publish is supported with fail-closed poisoning; span-native enablement requires #3023 and #3022 observability",
 			Covers: []string{
 				"command_wal_system_publish", "wal_enabled", "command_wal_ordering", "system_root_identity",
 			},
@@ -107,6 +239,9 @@ func orderedRootSpanNativeClassificationRows() []orderedRootSpanNativeClassifica
 			ID:                "unlogged-publish-in-command-wal-mode",
 			Category:          "system-root routes",
 			Route:             "ordinary non-command-WAL ordered-root publish on command-WAL DB",
+			RouteAnchors:      []orderedRootPublishRouteAnchor{orderedRootRouteDBRejectUnloggedCommandWALRootPublish},
+			ExpectedOutcome:   orderedRootOutcomeCurrentFailClosed,
+			DownstreamActions: []orderedRootPublishDownstreamAction{orderedRootActionImplementedCurrentFailClosed},
 			Mode:              "WAL-enabled rejection",
 			Semantics:         "uncovered logical system changes cannot bypass command-WAL",
 			Storage:           "per-root storage policy",
@@ -121,6 +256,9 @@ func orderedRootSpanNativeClassificationRows() []orderedRootSpanNativeClassifica
 			ID:                "wal-disabled-cached-mode-admission",
 			Category:          "execution modes",
 			Route:             "cached ordered-root collection publish with WAL disabled",
+			RouteAnchors:      []orderedRootPublishRouteAnchor{orderedRootRouteFlushAdmissionPolicyAuto},
+			ExpectedOutcome:   orderedRootOutcomePolicyBlocked,
+			DownstreamActions: []orderedRootPublishDownstreamAction{orderedRootActionBlockedBy3032},
 			Mode:              "WAL-disabled cached mode",
 			Semantics:         "ordered-root behavior depends on resolved default admission decision",
 			Storage:           "persistent value-log remains durable storage",
@@ -132,9 +270,15 @@ func orderedRootSpanNativeClassificationRows() []orderedRootSpanNativeClassifica
 			},
 		},
 		{
-			ID:                "read-only-prepare-only",
-			Category:          "execution modes",
-			Route:             "OrderedRootDeltaBatchPublishInput.PrepareReadOnly",
+			ID:       "read-only-prepare-only",
+			Category: "execution modes",
+			Route:    "OrderedRootDeltaBatchPublishInput.PrepareReadOnly",
+			RouteAnchors: []orderedRootPublishRouteAnchor{
+				orderedRootRouteOrderedRootDeltaBatchPublishInput,
+				orderedRootRouteDBRunOrderedRootDeltaBatchReadOnlyPrepare,
+			},
+			ExpectedOutcome:   orderedRootOutcomeCurrentReadOnlyPrepareOnly,
+			DownstreamActions: []orderedRootPublishDownstreamAction{orderedRootActionImplementedCurrentReadOnlyOnly, orderedRootActionEligibleFor3022Observability},
 			Mode:              "read-only prepare",
 			Semantics:         "side-effect-free leaf-span planning before warm apply",
 			Storage:           "no durable output owned by prepare",
@@ -146,43 +290,58 @@ func orderedRootSpanNativeClassificationRows() []orderedRootSpanNativeClassifica
 			},
 		},
 		{
-			ID:                "span-native-prior-no-replacement-changed-root",
-			Category:          "execution modes",
-			Route:             "orderedRootDeltaBatchApplyOptions",
+			ID:       "ordered-root-blanket-non-span-native-fallback",
+			Category: "execution modes",
+			Route:    "orderedRootDeltaBatchApplyOptions",
+			RouteAnchors: []orderedRootPublishRouteAnchor{
+				orderedRootRouteDBOrderedRootDeltaBatchApplyOptions,
+				orderedRootRouteDBPublishOrderedRootDeltaBatchWithAllocator,
+			},
+			ExpectedOutcome:   orderedRootOutcomeBlanketNonSpanNativeFallback,
+			DownstreamActions: []orderedRootPublishDownstreamAction{orderedRootActionRequires3023Correctness, orderedRootActionRequires3024OutputOwnership},
 			Mode:              "span-native prepare/apply",
-			Semantics:         "prior reducer failure class: no replacement changed root",
+			Semantics:         "ordered-root delta batches currently force non-span-native apply before reducer execution",
 			Storage:           "prepared span-native output is not produced for ordered-root delta batches",
-			Durability:        "no span-native reducer publish occurs",
+			Durability:        "no span-native reducer publish occurs; prior no-replacement-changed-root reducer failure is classified but not reproduced here",
 			Status:            orderedRootPublishStatusDeterministicFallbackPrefix + FlushSpanRunFallbackSpanNativeNotImplemented.String(),
-			ProductionSupport: "current support is explicit fallback before reducer execution; #3023/#3024 must update this row before enablement",
+			ProductionSupport: "current support is blanket non-span-native fallback before reducer execution; #3023/#3024 must update this row before enablement",
 			Covers: []string{
-				"span_native_prepare", "prior_no_replacement_changed_root_failure", "output_ownership",
+				"span_native_prepare", "prior_no_replacement_changed_root_guardrail", "output_ownership",
 			},
 		},
 		{
 			ID:                "empty-and-noop-deltas",
 			Category:          "delta semantics",
 			Route:             "publishOrderedRootDeltaBatchWithAllocator",
+			RouteAnchors:      []orderedRootPublishRouteAnchor{orderedRootRouteDBPublishOrderedRootDeltaBatchWithAllocator},
+			ExpectedOutcome:   orderedRootOutcomeCurrentEmptyNoop,
+			DownstreamActions: []orderedRootPublishDownstreamAction{orderedRootActionRequires3023Correctness},
 			Mode:              "serial apply",
 			Semantics:         "empty deltas and unchanged roots preserve base root identity",
 			Storage:           "no new leaf output",
 			Durability:        "checkpoint/reopen observe existing root",
 			Status:            orderedRootPublishStatusImplemented,
-			ProductionSupport: "supported current behavior; no-op rows must remain explicit in later span-native enablement",
+			ProductionSupport: "supported current behavior; no-op rows must remain explicit in #3023 span-native correctness enablement",
 			Covers: []string{
 				"empty_delta", "unchanged_noop_root", "checkpoint", "reopen",
 			},
 		},
 		{
-			ID:                "delete-tombstone-and-mixed-deltas",
-			Category:          "delta semantics",
-			Route:             "PublishOrderedRootDeltaGroupWithSystemBuilder and batch variant",
+			ID:       "delete-tombstone-and-mixed-deltas",
+			Category: "delta semantics",
+			Route:    "PublishOrderedRootDeltaGroupWithSystemBuilder and batch variant",
+			RouteAnchors: []orderedRootPublishRouteAnchor{
+				orderedRootRouteDBPublishOrderedRootDeltaGroupWithSystemBuilder,
+				orderedRootRouteDBPublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder,
+			},
+			ExpectedOutcome:   orderedRootOutcomeCurrentSerialPublish,
+			DownstreamActions: []orderedRootPublishDownstreamAction{orderedRootActionRequires3023Correctness, orderedRootActionRequires3024OutputOwnership},
 			Mode:              "serial apply",
 			Semantics:         "deletes, tombstones, and mixed update/delete batches",
 			Storage:           "per-root storage policy",
 			Durability:        "value-log refs removed from replaced/deleted entries become GC candidates only after commit reachability changes",
 			Status:            orderedRootPublishStatusImplemented,
-			ProductionSupport: "supported serial behavior; span-native correctness remains gated by #3023",
+			ProductionSupport: "supported serial behavior; span-native correctness remains gated by #3023 and output ownership by #3024",
 			Covers: []string{
 				"delete_tombstone", "mixed_update_delete_batch", "value_log_gc_safety",
 			},
@@ -191,12 +350,15 @@ func orderedRootSpanNativeClassificationRows() []orderedRootSpanNativeClassifica
 			ID:                "pager-inline-leaf-output",
 			Category:          "storage/output policy",
 			Route:             "OrderedRootStoragePagerLeaves",
+			RouteAnchors:      []orderedRootPublishRouteAnchor{orderedRootRouteOrderedRootStoragePagerLeaves},
+			ExpectedOutcome:   orderedRootOutcomeCurrentStoragePolicy,
+			DownstreamActions: []orderedRootPublishDownstreamAction{orderedRootActionRequires3024OutputOwnership},
 			Mode:              "serial apply",
 			Semantics:         "inline/pager leaf output for ordered roots",
 			Storage:           "pager leaves with root-local policy",
 			Durability:        "checkpoint/reopen through index pages",
 			Status:            orderedRootPublishStatusImplemented,
-			ProductionSupport: "supported current output policy",
+			ProductionSupport: "supported current output policy; span-native output ownership proof is #3024 work",
 			Covers: []string{
 				"inline_leaf_output", "root_local_policy", "checkpoint", "reopen",
 			},
@@ -205,68 +367,116 @@ func orderedRootSpanNativeClassificationRows() []orderedRootSpanNativeClassifica
 			ID:                "value-log-leaf-output",
 			Category:          "storage/output policy",
 			Route:             "OrderedRootStorageValueLogLeaves",
+			RouteAnchors:      []orderedRootPublishRouteAnchor{orderedRootRouteOrderedRootStorageValueLogLeaves},
+			ExpectedOutcome:   orderedRootOutcomeCurrentStoragePolicy,
+			DownstreamActions: []orderedRootPublishDownstreamAction{orderedRootActionRequires3024OutputOwnership},
 			Mode:              "serial apply",
 			Semantics:         "ordered-root leaves stored as persistent leaf-log records",
 			Storage:           "value-log leaf output",
 			Durability:        "persistent pointer reachability and value-log GC safety",
 			Status:            orderedRootPublishStatusImplemented,
-			ProductionSupport: "supported as persistent value-log storage; later span-native output ownership must preserve the same reachability rules",
+			ProductionSupport: "supported as persistent value-log storage; #3024 span-native output ownership must preserve the same reachability rules",
 			Covers: []string{
 				"value_log_leaf_output", "persistent_vlog_pointer_reachability", "value_log_gc_safety", "checkpoint", "reopen",
 			},
 		},
 		{
-			ID:                "collection-buffered-roots",
-			Category:          "collection routes",
-			Route:             "Collection buffered root publish",
+			ID:       "collection-buffered-roots",
+			Category: "collection routes",
+			Route:    "Collection buffered root publish",
+			RouteAnchors: []orderedRootPublishRouteAnchor{
+				orderedRootRouteDBPublishOrderedRootDeltaGroupWithSystemDeltaBuilder,
+				orderedRootRouteDBPublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder,
+			},
+			ExpectedOutcome:   orderedRootOutcomeCurrentCollectionRoute,
+			DownstreamActions: []orderedRootPublishDownstreamAction{orderedRootActionEligibleFor3022Observability, orderedRootActionRequires3023Correctness},
 			Mode:              "ordered-root delta batch group",
 			Semantics:         "primary buffered roots publish through ordered-root batch APIs",
 			Storage:           "collection-selected root policy",
 			Durability:        "collection metadata and roots commit together",
 			Status:            orderedRootPublishStatusImplemented,
-			ProductionSupport: "current buffered collection publish is supported; ordered-root span-native enablement remains gated",
+			ProductionSupport: "current buffered collection publish is supported; #3022 must observe route selection and #3023 gates span-native enablement",
 			Covers: []string{
 				"buffered_collection_roots", "collection_routes",
 			},
 		},
 		{
-			ID:                "collection-secondary-index-roots",
-			Category:          "collection routes",
-			Route:             "secondary index root groups",
+			ID:       "collection-secondary-index-roots",
+			Category: "collection routes",
+			Route:    "secondary index root groups",
+			RouteAnchors: []orderedRootPublishRouteAnchor{
+				orderedRootRouteDBPublishOrderedRootGroup,
+				orderedRootRouteDBPublishOrderedRootDeltaGroupWithSystemDeltaBuilder,
+				orderedRootRouteDBPublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder,
+			},
+			ExpectedOutcome:   orderedRootOutcomeCurrentCollectionRoute,
+			DownstreamActions: []orderedRootPublishDownstreamAction{orderedRootActionEligibleFor3022Observability, orderedRootActionRequires3023Correctness},
 			Mode:              "multi-index ordered-root group",
 			Semantics:         "secondary indexes publish alongside collection roots",
 			Storage:           "collection-selected root policy",
 			Durability:        "multi-index root group identity is persisted through system descriptors",
 			Status:            orderedRootPublishStatusImplemented,
-			ProductionSupport: "current secondary-index root publishing is supported via ordered-root groups",
+			ProductionSupport: "current secondary-index root publishing is supported via ordered-root groups; #3022 observes route choice and #3023 gates span-native enablement",
 			Covers: []string{
 				"secondary_index_roots", "multi_index_root_groups", "system_root_identity", "collection_routes",
 			},
 		},
 		{
-			ID:                "collection-overlay-cold-build-routes",
-			Category:          "collection routes",
-			Route:             "overlay and cold-build ordered-root routes",
-			Mode:              "cold build or overlay publish",
-			Semantics:         "cold build, overlay roots, and tombstones that mask older entries",
+			ID:       "collection-overlay-single-base-warm-route",
+			Category: "collection routes",
+			Route:    "single-overlay ordered-root delta batch publish",
+			RouteAnchors: []orderedRootPublishRouteAnchor{
+				orderedRootRouteDBPublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder,
+				orderedRootRouteDBPublishOrderedRootDeltaBatchWithAllocator,
+			},
+			ExpectedOutcome:   orderedRootOutcomeCurrentWarmOverlaySingleBase,
+			DownstreamActions: []orderedRootPublishDownstreamAction{orderedRootActionRequires3023Correctness, orderedRootActionRequires3024OutputOwnership},
+			Mode:              "warm overlay publish",
+			Semantics:         "exactly one overlay can be used as the nonzero base root before publishing a newer overlay delta",
+			Storage:           "collection-selected root policy",
+			Durability:        "checkpoint/reopen preserve overlay identity",
+			Status:            orderedRootPublishStatusImplemented,
+			ProductionSupport: "supported current warm overlay behavior; #3023/#3024 must classify correctness and output ownership before span-native enablement",
+			Covers: []string{
+				"overlay_warm_single_base_route", "tombstone_semantics", "checkpoint", "reopen",
+			},
+		},
+		{
+			ID:       "collection-overlay-cold-build-zero-base-route",
+			Category: "collection routes",
+			Route:    "zero-base overlay/cold-build ordered-root routes",
+			RouteAnchors: []orderedRootPublishRouteAnchor{
+				orderedRootRouteDBPublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder,
+				orderedRootRouteDBPublishOrderedRootDeltaBatchWithAllocator,
+			},
+			ExpectedOutcome:   orderedRootOutcomeCurrentColdBuildZeroBase,
+			DownstreamActions: []orderedRootPublishDownstreamAction{orderedRootActionRequires3023Correctness, orderedRootActionRequires3024OutputOwnership},
+			Mode:              "cold build publish",
+			Semantics:         "zero overlays or multiple existing overlays use BaseRoot=0 and include deleted entries as cold-build input",
 			Storage:           "collection-selected root policy",
 			Durability:        "checkpoint/reopen preserve overlay identity",
 			Status:            orderedRootPublishStatusDeterministicFallbackPrefix + FlushSpanRunFallbackColdBuild.String(),
-			ProductionSupport: "supported current cold-build route; it is a deterministic non-span-native path until enablement work classifies it differently",
+			ProductionSupport: "supported current cold-build route; #3023/#3024 must update this row before span-native output is enabled",
 			Covers: []string{
 				"overlay_cold_build_routes", "tombstone_semantics", "checkpoint", "reopen",
 			},
 		},
 		{
-			ID:                "snapshot-and-system-root-visibility",
-			Category:          "durability/read correctness",
-			Route:             "group final commit",
+			ID:       "snapshot-and-system-root-visibility",
+			Category: "durability/read correctness",
+			Route:    "group final commit",
+			RouteAnchors: []orderedRootPublishRouteAnchor{
+				orderedRootRouteDBPublishOrderedRootGroupWithSystemBuilder,
+				orderedRootRouteDBPublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder,
+			},
+			ExpectedOutcome:   orderedRootOutcomeCurrentSnapshotVisibility,
+			DownstreamActions: []orderedRootPublishDownstreamAction{orderedRootActionRequires3023Correctness},
 			Mode:              "serial or optimistic publish",
 			Semantics:         "read visibility and system-root identity after publish",
 			Storage:           "per-root storage policy",
 			Durability:        "snapshot/read visibility and system-root identity",
 			Status:            orderedRootPublishStatusImplemented,
-			ProductionSupport: "supported current invariant; span-native publish must keep the same root visibility boundary",
+			ProductionSupport: "supported current invariant; #3023 span-native publish must keep the same root visibility boundary",
 			Covers: []string{
 				"snapshot_read_visibility", "system_root_identity",
 			},
@@ -275,6 +485,9 @@ func orderedRootSpanNativeClassificationRows() []orderedRootSpanNativeClassifica
 			ID:                "default-admission-concurrency-dependency",
 			Category:          "execution modes",
 			Route:             "resolved admission decision from #3032",
+			RouteAnchors:      []orderedRootPublishRouteAnchor{orderedRootRouteFlushAdmissionPolicyAuto},
+			ExpectedOutcome:   orderedRootOutcomePolicyBlocked,
+			DownstreamActions: []orderedRootPublishDownstreamAction{orderedRootActionBlockedBy3032},
 			Mode:              "auto/explicit/off admission",
 			Semantics:         "ordered-root default eligibility must consume one policy contract",
 			Storage:           "no storage change in this issue",
@@ -289,6 +502,9 @@ func orderedRootSpanNativeClassificationRows() []orderedRootSpanNativeClassifica
 			ID:                "raw-route-shared-contract-dependency",
 			Category:          "route ownership",
 			Route:             "raw TreeDB span-native route inventory",
+			RouteAnchors:      []orderedRootPublishRouteAnchor{orderedRootRouteDBPublishOrderedRootDeltaBatchWithAllocator},
+			ExpectedOutcome:   orderedRootOutcomeRawRouteBlocked,
+			DownstreamActions: []orderedRootPublishDownstreamAction{orderedRootActionBlockedBy3033},
 			Mode:              "raw/default route parity",
 			Semantics:         "ordered-root coverage must not substitute for raw route support",
 			Storage:           "no storage change in this issue",
@@ -304,46 +520,48 @@ func orderedRootSpanNativeClassificationRows() []orderedRootSpanNativeClassifica
 
 func TestOrderedRootSpanNativeClassificationMatrixCoversIssue3021(t *testing.T) {
 	required := map[string]bool{
-		"direct_batch_publish":                      false,
-		"grouped_publish":                           false,
-		"serialized_group_publish":                  false,
-		"optimistic_group_publish":                  false,
-		"system_delta_builder_publish":              false,
-		"command_wal_system_publish":                false,
-		"non_command_wal_system_publish":            false,
-		"buffered_collection_roots":                 false,
-		"secondary_index_roots":                     false,
-		"multi_index_root_groups":                   false,
-		"overlay_cold_build_routes":                 false,
-		"serial_apply":                              false,
-		"parallel_root_apply":                       false,
-		"read_only_prepare":                         false,
-		"span_native_prepare":                       false,
-		"wal_enabled":                               false,
-		"wal_disabled_cached_mode":                  false,
-		"admission_policy_dependency_3032":          false,
-		"point_insert":                              false,
-		"overwrite":                                 false,
-		"unchanged_noop_root":                       false,
-		"delete_tombstone":                          false,
-		"tombstone_semantics":                       false,
-		"mixed_update_delete_batch":                 false,
-		"empty_delta":                               false,
-		"duplicate_same_key_overwrite":              false,
-		"inline_leaf_output":                        false,
-		"root_local_policy":                         false,
-		"value_log_leaf_output":                     false,
-		"output_ownership":                          false,
-		"persistent_vlog_pointer_reachability":      false,
-		"checkpoint":                                false,
-		"reopen":                                    false,
-		"snapshot_read_visibility":                  false,
-		"system_root_identity":                      false,
-		"command_wal_ordering":                      false,
-		"value_log_gc_safety":                       false,
-		"depends_3032":                              false,
-		"depends_3033":                              false,
-		"prior_no_replacement_changed_root_failure": false,
+		"direct_batch_publish":                        false,
+		"grouped_publish":                             false,
+		"serialized_group_publish":                    false,
+		"optimistic_group_publish":                    false,
+		"system_delta_builder_publish":                false,
+		"command_wal_system_publish":                  false,
+		"non_command_wal_system_publish":              false,
+		"collection_routes":                           false,
+		"buffered_collection_roots":                   false,
+		"secondary_index_roots":                       false,
+		"multi_index_root_groups":                     false,
+		"overlay_warm_single_base_route":              false,
+		"overlay_cold_build_routes":                   false,
+		"serial_apply":                                false,
+		"parallel_root_apply":                         false,
+		"read_only_prepare":                           false,
+		"span_native_prepare":                         false,
+		"wal_enabled":                                 false,
+		"wal_disabled_cached_mode":                    false,
+		"admission_policy_dependency_3032":            false,
+		"point_insert":                                false,
+		"overwrite":                                   false,
+		"unchanged_noop_root":                         false,
+		"delete_tombstone":                            false,
+		"tombstone_semantics":                         false,
+		"mixed_update_delete_batch":                   false,
+		"empty_delta":                                 false,
+		"duplicate_same_key_overwrite":                false,
+		"inline_leaf_output":                          false,
+		"root_local_policy":                           false,
+		"value_log_leaf_output":                       false,
+		"output_ownership":                            false,
+		"persistent_vlog_pointer_reachability":        false,
+		"checkpoint":                                  false,
+		"reopen":                                      false,
+		"snapshot_read_visibility":                    false,
+		"system_root_identity":                        false,
+		"command_wal_ordering":                        false,
+		"value_log_gc_safety":                         false,
+		"depends_3032":                                false,
+		"depends_3033":                                false,
+		"prior_no_replacement_changed_root_guardrail": false,
 	}
 
 	rows := orderedRootSpanNativeClassificationRows()
@@ -354,9 +572,10 @@ func TestOrderedRootSpanNativeClassificationMatrixCoversIssue3021(t *testing.T) 
 	for _, row := range rows {
 		validateOrderedRootSpanNativeClassificationRow(t, row, seenIDs)
 		for _, token := range row.Covers {
-			if _, ok := required[token]; ok {
-				required[token] = true
+			if _, ok := required[token]; !ok {
+				t.Fatalf("ordered-root classification row %q has unregistered coverage token %q", row.ID, token)
 			}
+			required[token] = true
 		}
 	}
 	for token, seen := range required {
@@ -378,6 +597,7 @@ func validateOrderedRootSpanNativeClassificationRow(t *testing.T, row orderedRoo
 	for field, value := range map[string]string{
 		"category":           row.Category,
 		"route":              row.Route,
+		"expected_outcome":   string(row.ExpectedOutcome),
 		"mode":               row.Mode,
 		"semantics":          row.Semantics,
 		"storage":            row.Storage,
@@ -407,16 +627,57 @@ func validateOrderedRootSpanNativeClassificationRow(t *testing.T, row orderedRoo
 	default:
 		t.Fatalf("classification row %q has unsupported status %q", row.ID, row.Status)
 	}
+	if len(row.RouteAnchors) == 0 {
+		t.Fatalf("classification row %q has no concrete route anchors", row.ID)
+	}
+	for _, anchor := range row.RouteAnchors {
+		if _, ok := orderedRootPublishRouteAnchorEvidence[anchor]; !ok {
+			t.Fatalf("classification row %q has unsupported route anchor %q", row.ID, anchor)
+		}
+	}
+	if _, ok := orderedRootExpectedOutcomes[row.ExpectedOutcome]; !ok {
+		t.Fatalf("classification row %q has unsupported expected outcome %q", row.ID, row.ExpectedOutcome)
+	}
+	if len(row.DownstreamActions) == 0 {
+		t.Fatalf("classification row %q has no downstream action", row.ID)
+	}
+	seenActions := make(map[orderedRootPublishDownstreamAction]struct{}, len(row.DownstreamActions))
+	for _, action := range row.DownstreamActions {
+		if _, ok := orderedRootDownstreamActions[action]; !ok {
+			t.Fatalf("classification row %q has unsupported downstream action %q", row.ID, action)
+		}
+		if _, exists := seenActions[action]; exists {
+			t.Fatalf("classification row %q repeats downstream action %q", row.ID, action)
+		}
+		seenActions[action] = struct{}{}
+	}
+	switch {
+	case strings.HasPrefix(row.Status, orderedRootPublishStatusBlockedByPrefix+"#3032"):
+		if _, ok := seenActions[orderedRootActionBlockedBy3032]; !ok {
+			t.Fatalf("classification row %q blocked by #3032 without matching downstream action", row.ID)
+		}
+	case strings.HasPrefix(row.Status, orderedRootPublishStatusBlockedByPrefix+"#3033"):
+		if _, ok := seenActions[orderedRootActionBlockedBy3033]; !ok {
+			t.Fatalf("classification row %q blocked by #3033 without matching downstream action", row.ID)
+		}
+	default:
+		if _, ok := seenActions[orderedRootActionBlockedBy3032]; ok {
+			t.Fatalf("classification row %q has #3032 action without blocked status", row.ID)
+		}
+		if _, ok := seenActions[orderedRootActionBlockedBy3033]; ok {
+			t.Fatalf("classification row %q has #3033 action without blocked status", row.ID)
+		}
+	}
 	if len(row.Covers) == 0 {
 		t.Fatalf("classification row %q has no coverage tokens", row.ID)
 	}
 }
 
-func TestOrderedRootSpanNativePublishLocksReducerNoReplacementFallback(t *testing.T) {
-	row := orderedRootSpanNativeClassificationRowByID(t, "span-native-prior-no-replacement-changed-root")
+func TestOrderedRootSpanNativePublishLocksBlanketNonSpanNativeFallback(t *testing.T) {
+	row := orderedRootSpanNativeClassificationRowByID(t, "ordered-root-blanket-non-span-native-fallback")
 	wantStatus := orderedRootPublishStatusDeterministicFallbackPrefix + FlushSpanRunFallbackSpanNativeNotImplemented.String()
 	if row.Status != wantStatus {
-		t.Fatalf("prior reducer failure row status=%q want %q", row.Status, wantStatus)
+		t.Fatalf("blanket non-span-native fallback row status=%q want %q", row.Status, wantStatus)
 	}
 
 	db, err := Open(Options{
@@ -480,18 +741,10 @@ func TestOrderedRootSpanNativePublishLocksReducerNoReplacementFallback(t *testin
 	}
 
 	stats := db.Stats()
-	if got := stats["treedb.flush_apply.read_only_prepare.calls_total"]; got == "0" {
-		t.Fatalf("read-only prepare calls=%q, want ordered-root prepare-only path to run", got)
-	}
-	if got := stats["treedb.flush_apply.span_native.used_ops_total"]; got != "0" {
-		t.Fatalf("span-native used ops=%q, want deterministic non-span-native fallback for ordered-root publish", got)
-	}
-	if got := stats["treedb.flush_apply.span_native.fallback.reason."+FlushSpanRunFallbackSpanNativeNotImplemented.String()+".ops_total"]; got == "0" {
-		t.Fatalf("span-native-not-implemented fallback ops=%q, want deterministic fallback classification", got)
-	}
-	if got := stats["treedb.flush_apply.span_native.fallback.reason."+FlushSpanRunFallbackUnknown.String()+".ops_total"]; got != "0" {
-		t.Fatalf("unknown fallback ops=%q, want zero", got)
-	}
+	requireOrderedRootStatCounterPositive(t, stats, "treedb.flush_apply.read_only_prepare.calls_total")
+	requireOrderedRootStatCounterZero(t, stats, "treedb.flush_apply.span_native.used_ops_total")
+	requireOrderedRootStatCounterPositive(t, stats, "treedb.flush_apply.span_native.fallback.reason."+FlushSpanRunFallbackSpanNativeNotImplemented.String()+".ops_total")
+	requireOrderedRootStatCounterZero(t, stats, "treedb.flush_apply.span_native.fallback.reason."+FlushSpanRunFallbackUnknown.String()+".ops_total")
 }
 
 func orderedRootSpanNativeClassificationRowByID(t *testing.T, id string) orderedRootSpanNativeClassificationRow {
@@ -503,4 +756,31 @@ func orderedRootSpanNativeClassificationRowByID(t *testing.T, id string) ordered
 	}
 	t.Fatalf("missing ordered-root classification row %q", id)
 	return orderedRootSpanNativeClassificationRow{}
+}
+
+func requireOrderedRootStatCounterPositive(t *testing.T, stats map[string]string, key string) {
+	t.Helper()
+	if got := orderedRootStatCounterValue(t, stats, key); got == 0 {
+		t.Fatalf("stat %q=0, want positive counter", key)
+	}
+}
+
+func requireOrderedRootStatCounterZero(t *testing.T, stats map[string]string, key string) {
+	t.Helper()
+	if got := orderedRootStatCounterValue(t, stats, key); got != 0 {
+		t.Fatalf("stat %q=%d, want zero counter", key, got)
+	}
+}
+
+func orderedRootStatCounterValue(t *testing.T, stats map[string]string, key string) uint64 {
+	t.Helper()
+	raw, ok := stats[key]
+	if !ok {
+		t.Fatalf("missing stat %q", key)
+	}
+	got, err := strconv.ParseUint(raw, 10, 64)
+	if err != nil {
+		t.Fatalf("stat %q=%q is not an unsigned counter: %v", key, raw, err)
+	}
+	return got
 }

--- a/TreeDB/db/ordered_root_span_native_classification_test.go
+++ b/TreeDB/db/ordered_root_span_native_classification_test.go
@@ -1,0 +1,506 @@
+package db
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/internal/iterator"
+)
+
+const (
+	orderedRootPublishStatusImplemented                 = "implemented"
+	orderedRootPublishStatusDeterministicFallbackPrefix = "deterministic_fallback:"
+	orderedRootPublishStatusBlockedByPrefix             = "blocked_by:"
+)
+
+type orderedRootSpanNativeClassificationRow struct {
+	ID                string
+	Category          string
+	Route             string
+	Mode              string
+	Semantics         string
+	Storage           string
+	Durability        string
+	Status            string
+	ProductionSupport string
+	Covers            []string
+}
+
+func orderedRootSpanNativeClassificationRows() []orderedRootSpanNativeClassificationRow {
+	return []orderedRootSpanNativeClassificationRow{
+		{
+			ID:                "direct-iterator-publish-cold-warm",
+			Category:          "direct publisher routes",
+			Route:             "PublishOrderedRootIterator",
+			Mode:              "serial apply",
+			Semantics:         "point inserts and overwrites through ordered iterators",
+			Storage:           "root-local inline or DB default leaf policy",
+			Durability:        "checkpoint, reopen, snapshot read visibility",
+			Status:            orderedRootPublishStatusImplemented,
+			ProductionSupport: "current serial publisher is supported; it does not claim ordered-root span-native apply",
+			Covers: []string{
+				"direct_batch_publish", "serial_apply", "point_insert", "overwrite",
+				"inline_leaf_output", "root_local_policy", "checkpoint", "reopen", "snapshot_read_visibility",
+			},
+		},
+		{
+			ID:                "grouped-full-root-publish",
+			Category:          "direct publisher routes",
+			Route:             "PublishOrderedRootGroup and PublishOrderedRootGroupWithSystemBuilder",
+			Mode:              "serialized group publish",
+			Semantics:         "full-root grouped publication with system descriptor publish",
+			Storage:           "per-root storage policy",
+			Durability:        "one backend commit preserves system-root identity",
+			Status:            orderedRootPublishStatusImplemented,
+			ProductionSupport: "current grouped full-root publish is supported for ordered roots and descriptors",
+			Covers: []string{
+				"grouped_publish", "serialized_group_publish", "system_delta_builder_publish",
+				"non_command_wal_system_publish", "multi_index_root_groups", "system_root_identity",
+			},
+		},
+		{
+			ID:                "serialized-delta-group-publish",
+			Category:          "direct publisher routes",
+			Route:             "PublishOrderedRootDeltaGroupWithSystemDeltaBuilder",
+			Mode:              "serial apply",
+			Semantics:         "warm root-local iterator deltas preserve omitted base entries",
+			Storage:           "per-root storage policy",
+			Durability:        "system root and ordered roots commit together",
+			Status:            orderedRootPublishStatusImplemented,
+			ProductionSupport: "current iterator-delta publish is supported as serial ordered-root behavior",
+			Covers: []string{
+				"serialized_group_publish", "point_insert", "overwrite", "delete_tombstone",
+				"mixed_update_delete_batch", "system_root_identity",
+			},
+		},
+		{
+			ID:                "optimistic-delta-batch-group-publish",
+			Category:          "direct publisher routes",
+			Route:             "PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder",
+			Mode:              "optimistic group publish with optional root-level parallel apply",
+			Semantics:         "materialized batch deltas publish roots before guarded final commit",
+			Storage:           "per-root storage policy",
+			Durability:        "root mismatch retries through serialized fallback",
+			Status:            orderedRootPublishStatusImplemented,
+			ProductionSupport: "current optimistic root-group publish is supported; root-level parallelism is not span-native leaf apply",
+			Covers: []string{
+				"optimistic_group_publish", "parallel_root_apply", "duplicate_same_key_overwrite",
+				"output_ownership", "snapshot_read_visibility",
+			},
+		},
+		{
+			ID:                "command-wal-context-publish",
+			Category:          "system-root routes",
+			Route:             "PublishOrderedRootDeltaGroupWithCommandWALContextAndSystemDeltaBuilder",
+			Mode:              "WAL-enabled command publish",
+			Semantics:         "command-WAL LSN is assigned before system delta builder",
+			Storage:           "per-root storage policy",
+			Durability:        "command-WAL ordering and system-root identity",
+			Status:            orderedRootPublishStatusImplemented,
+			ProductionSupport: "current command-WAL covered ordered-root publish is supported with fail-closed poisoning on post-append errors",
+			Covers: []string{
+				"command_wal_system_publish", "wal_enabled", "command_wal_ordering", "system_root_identity",
+			},
+		},
+		{
+			ID:                "unlogged-publish-in-command-wal-mode",
+			Category:          "system-root routes",
+			Route:             "ordinary non-command-WAL ordered-root publish on command-WAL DB",
+			Mode:              "WAL-enabled rejection",
+			Semantics:         "uncovered logical system changes cannot bypass command-WAL",
+			Storage:           "per-root storage policy",
+			Durability:        "command-WAL ordering barrier",
+			Status:            orderedRootPublishStatusDeterministicFallbackPrefix + "command_wal_barrier",
+			ProductionSupport: "supported fail-closed rejection; caller must use command-WAL covered publish APIs",
+			Covers: []string{
+				"non_command_wal_system_publish", "wal_enabled", "command_wal_ordering",
+			},
+		},
+		{
+			ID:                "wal-disabled-cached-mode-admission",
+			Category:          "execution modes",
+			Route:             "cached ordered-root collection publish with WAL disabled",
+			Mode:              "WAL-disabled cached mode",
+			Semantics:         "ordered-root behavior depends on resolved default admission decision",
+			Storage:           "persistent value-log remains durable storage",
+			Durability:        "WAL-off durability posture is owned by admission policy",
+			Status:            orderedRootPublishStatusBlockedByPrefix + "#3032",
+			ProductionSupport: "production support waits for #3032 resolved admission and rollback contract",
+			Covers: []string{
+				"wal_disabled_cached_mode", "admission_policy_dependency_3032", "depends_3032",
+			},
+		},
+		{
+			ID:                "read-only-prepare-only",
+			Category:          "execution modes",
+			Route:             "OrderedRootDeltaBatchPublishInput.PrepareReadOnly",
+			Mode:              "read-only prepare",
+			Semantics:         "side-effect-free leaf-span planning before warm apply",
+			Storage:           "no durable output owned by prepare",
+			Durability:        "planning must not publish roots or value-log pointers",
+			Status:            orderedRootPublishStatusImplemented,
+			ProductionSupport: "supported as diagnostics and planning only; it does not enable ordered-root span-native output",
+			Covers: []string{
+				"read_only_prepare", "output_ownership",
+			},
+		},
+		{
+			ID:                "span-native-prior-no-replacement-changed-root",
+			Category:          "execution modes",
+			Route:             "orderedRootDeltaBatchApplyOptions",
+			Mode:              "span-native prepare/apply",
+			Semantics:         "prior reducer failure class: no replacement changed root",
+			Storage:           "prepared span-native output is not produced for ordered-root delta batches",
+			Durability:        "no span-native reducer publish occurs",
+			Status:            orderedRootPublishStatusDeterministicFallbackPrefix + FlushSpanRunFallbackSpanNativeNotImplemented.String(),
+			ProductionSupport: "current support is explicit fallback before reducer execution; #3023/#3024 must update this row before enablement",
+			Covers: []string{
+				"span_native_prepare", "prior_no_replacement_changed_root_failure", "output_ownership",
+			},
+		},
+		{
+			ID:                "empty-and-noop-deltas",
+			Category:          "delta semantics",
+			Route:             "publishOrderedRootDeltaBatchWithAllocator",
+			Mode:              "serial apply",
+			Semantics:         "empty deltas and unchanged roots preserve base root identity",
+			Storage:           "no new leaf output",
+			Durability:        "checkpoint/reopen observe existing root",
+			Status:            orderedRootPublishStatusImplemented,
+			ProductionSupport: "supported current behavior; no-op rows must remain explicit in later span-native enablement",
+			Covers: []string{
+				"empty_delta", "unchanged_noop_root", "checkpoint", "reopen",
+			},
+		},
+		{
+			ID:                "delete-tombstone-and-mixed-deltas",
+			Category:          "delta semantics",
+			Route:             "PublishOrderedRootDeltaGroupWithSystemBuilder and batch variant",
+			Mode:              "serial apply",
+			Semantics:         "deletes, tombstones, and mixed update/delete batches",
+			Storage:           "per-root storage policy",
+			Durability:        "value-log refs removed from replaced/deleted entries become GC candidates only after commit reachability changes",
+			Status:            orderedRootPublishStatusImplemented,
+			ProductionSupport: "supported serial behavior; span-native correctness remains gated by #3023",
+			Covers: []string{
+				"delete_tombstone", "mixed_update_delete_batch", "value_log_gc_safety",
+			},
+		},
+		{
+			ID:                "pager-inline-leaf-output",
+			Category:          "storage/output policy",
+			Route:             "OrderedRootStoragePagerLeaves",
+			Mode:              "serial apply",
+			Semantics:         "inline/pager leaf output for ordered roots",
+			Storage:           "pager leaves with root-local policy",
+			Durability:        "checkpoint/reopen through index pages",
+			Status:            orderedRootPublishStatusImplemented,
+			ProductionSupport: "supported current output policy",
+			Covers: []string{
+				"inline_leaf_output", "root_local_policy", "checkpoint", "reopen",
+			},
+		},
+		{
+			ID:                "value-log-leaf-output",
+			Category:          "storage/output policy",
+			Route:             "OrderedRootStorageValueLogLeaves",
+			Mode:              "serial apply",
+			Semantics:         "ordered-root leaves stored as persistent leaf-log records",
+			Storage:           "value-log leaf output",
+			Durability:        "persistent pointer reachability and value-log GC safety",
+			Status:            orderedRootPublishStatusImplemented,
+			ProductionSupport: "supported as persistent value-log storage; later span-native output ownership must preserve the same reachability rules",
+			Covers: []string{
+				"value_log_leaf_output", "persistent_vlog_pointer_reachability", "value_log_gc_safety", "checkpoint", "reopen",
+			},
+		},
+		{
+			ID:                "collection-buffered-roots",
+			Category:          "collection routes",
+			Route:             "Collection buffered root publish",
+			Mode:              "ordered-root delta batch group",
+			Semantics:         "primary buffered roots publish through ordered-root batch APIs",
+			Storage:           "collection-selected root policy",
+			Durability:        "collection metadata and roots commit together",
+			Status:            orderedRootPublishStatusImplemented,
+			ProductionSupport: "current buffered collection publish is supported; ordered-root span-native enablement remains gated",
+			Covers: []string{
+				"buffered_collection_roots", "collection_routes",
+			},
+		},
+		{
+			ID:                "collection-secondary-index-roots",
+			Category:          "collection routes",
+			Route:             "secondary index root groups",
+			Mode:              "multi-index ordered-root group",
+			Semantics:         "secondary indexes publish alongside collection roots",
+			Storage:           "collection-selected root policy",
+			Durability:        "multi-index root group identity is persisted through system descriptors",
+			Status:            orderedRootPublishStatusImplemented,
+			ProductionSupport: "current secondary-index root publishing is supported via ordered-root groups",
+			Covers: []string{
+				"secondary_index_roots", "multi_index_root_groups", "system_root_identity", "collection_routes",
+			},
+		},
+		{
+			ID:                "collection-overlay-cold-build-routes",
+			Category:          "collection routes",
+			Route:             "overlay and cold-build ordered-root routes",
+			Mode:              "cold build or overlay publish",
+			Semantics:         "cold build, overlay roots, and tombstones that mask older entries",
+			Storage:           "collection-selected root policy",
+			Durability:        "checkpoint/reopen preserve overlay identity",
+			Status:            orderedRootPublishStatusDeterministicFallbackPrefix + FlushSpanRunFallbackColdBuild.String(),
+			ProductionSupport: "supported current cold-build route; it is a deterministic non-span-native path until enablement work classifies it differently",
+			Covers: []string{
+				"overlay_cold_build_routes", "tombstone_semantics", "checkpoint", "reopen",
+			},
+		},
+		{
+			ID:                "snapshot-and-system-root-visibility",
+			Category:          "durability/read correctness",
+			Route:             "group final commit",
+			Mode:              "serial or optimistic publish",
+			Semantics:         "read visibility and system-root identity after publish",
+			Storage:           "per-root storage policy",
+			Durability:        "snapshot/read visibility and system-root identity",
+			Status:            orderedRootPublishStatusImplemented,
+			ProductionSupport: "supported current invariant; span-native publish must keep the same root visibility boundary",
+			Covers: []string{
+				"snapshot_read_visibility", "system_root_identity",
+			},
+		},
+		{
+			ID:                "default-admission-concurrency-dependency",
+			Category:          "execution modes",
+			Route:             "resolved admission decision from #3032",
+			Mode:              "auto/explicit/off admission",
+			Semantics:         "ordered-root default eligibility must consume one policy contract",
+			Storage:           "no storage change in this issue",
+			Durability:        "unsafe WAL-off/default rows must fail closed by policy",
+			Status:            orderedRootPublishStatusBlockedByPrefix + "#3032",
+			ProductionSupport: "blocked until #3032 defines deterministic auto/explicit/off admission and rollback",
+			Covers: []string{
+				"admission_policy_dependency_3032", "depends_3032",
+			},
+		},
+		{
+			ID:                "raw-route-shared-contract-dependency",
+			Category:          "route ownership",
+			Route:             "raw TreeDB span-native route inventory",
+			Mode:              "raw/default route parity",
+			Semantics:         "ordered-root coverage must not substitute for raw route support",
+			Storage:           "no storage change in this issue",
+			Durability:        "raw route checkpoint/reopen/GC proof remains separate",
+			Status:            orderedRootPublishStatusBlockedByPrefix + "#3033",
+			ProductionSupport: "blocked until #3033 classifies raw public/cached/command-WAL routes",
+			Covers: []string{
+				"depends_3033",
+			},
+		},
+	}
+}
+
+func TestOrderedRootSpanNativeClassificationMatrixCoversIssue3021(t *testing.T) {
+	required := map[string]bool{
+		"direct_batch_publish":                      false,
+		"grouped_publish":                           false,
+		"serialized_group_publish":                  false,
+		"optimistic_group_publish":                  false,
+		"system_delta_builder_publish":              false,
+		"command_wal_system_publish":                false,
+		"non_command_wal_system_publish":            false,
+		"buffered_collection_roots":                 false,
+		"secondary_index_roots":                     false,
+		"multi_index_root_groups":                   false,
+		"overlay_cold_build_routes":                 false,
+		"serial_apply":                              false,
+		"parallel_root_apply":                       false,
+		"read_only_prepare":                         false,
+		"span_native_prepare":                       false,
+		"wal_enabled":                               false,
+		"wal_disabled_cached_mode":                  false,
+		"admission_policy_dependency_3032":          false,
+		"point_insert":                              false,
+		"overwrite":                                 false,
+		"unchanged_noop_root":                       false,
+		"delete_tombstone":                          false,
+		"tombstone_semantics":                       false,
+		"mixed_update_delete_batch":                 false,
+		"empty_delta":                               false,
+		"duplicate_same_key_overwrite":              false,
+		"inline_leaf_output":                        false,
+		"root_local_policy":                         false,
+		"value_log_leaf_output":                     false,
+		"output_ownership":                          false,
+		"persistent_vlog_pointer_reachability":      false,
+		"checkpoint":                                false,
+		"reopen":                                    false,
+		"snapshot_read_visibility":                  false,
+		"system_root_identity":                      false,
+		"command_wal_ordering":                      false,
+		"value_log_gc_safety":                       false,
+		"depends_3032":                              false,
+		"depends_3033":                              false,
+		"prior_no_replacement_changed_root_failure": false,
+	}
+
+	rows := orderedRootSpanNativeClassificationRows()
+	if len(rows) == 0 {
+		t.Fatal("ordered-root classification matrix is empty")
+	}
+	seenIDs := make(map[string]struct{}, len(rows))
+	for _, row := range rows {
+		validateOrderedRootSpanNativeClassificationRow(t, row, seenIDs)
+		for _, token := range row.Covers {
+			if _, ok := required[token]; ok {
+				required[token] = true
+			}
+		}
+	}
+	for token, seen := range required {
+		if !seen {
+			t.Fatalf("ordered-root classification matrix missing issue #3021 coverage token %q", token)
+		}
+	}
+}
+
+func validateOrderedRootSpanNativeClassificationRow(t *testing.T, row orderedRootSpanNativeClassificationRow, seenIDs map[string]struct{}) {
+	t.Helper()
+	if row.ID == "" {
+		t.Fatalf("classification row has empty ID: %+v", row)
+	}
+	if _, exists := seenIDs[row.ID]; exists {
+		t.Fatalf("duplicate classification row ID %q", row.ID)
+	}
+	seenIDs[row.ID] = struct{}{}
+	for field, value := range map[string]string{
+		"category":           row.Category,
+		"route":              row.Route,
+		"mode":               row.Mode,
+		"semantics":          row.Semantics,
+		"storage":            row.Storage,
+		"durability":         row.Durability,
+		"status":             row.Status,
+		"production_support": row.ProductionSupport,
+	} {
+		if strings.TrimSpace(value) == "" {
+			t.Fatalf("classification row %q missing %s", row.ID, field)
+		}
+		lower := strings.ToLower(value)
+		if strings.Contains(lower, "unknown") || strings.Contains(lower, "implicit disabled") {
+			t.Fatalf("classification row %q has unclassified %s=%q", row.ID, field, value)
+		}
+	}
+	switch {
+	case row.Status == orderedRootPublishStatusImplemented:
+	case strings.HasPrefix(row.Status, orderedRootPublishStatusDeterministicFallbackPrefix):
+		if strings.TrimPrefix(row.Status, orderedRootPublishStatusDeterministicFallbackPrefix) == "" {
+			t.Fatalf("classification row %q has empty deterministic fallback reason", row.ID)
+		}
+	case strings.HasPrefix(row.Status, orderedRootPublishStatusBlockedByPrefix):
+		issue := strings.TrimPrefix(row.Status, orderedRootPublishStatusBlockedByPrefix)
+		if !strings.HasPrefix(issue, "#") || len(issue) == 1 {
+			t.Fatalf("classification row %q has invalid blocker status %q", row.ID, row.Status)
+		}
+	default:
+		t.Fatalf("classification row %q has unsupported status %q", row.ID, row.Status)
+	}
+	if len(row.Covers) == 0 {
+		t.Fatalf("classification row %q has no coverage tokens", row.ID)
+	}
+}
+
+func TestOrderedRootSpanNativePublishLocksReducerNoReplacementFallback(t *testing.T) {
+	row := orderedRootSpanNativeClassificationRowByID(t, "span-native-prior-no-replacement-changed-root")
+	wantStatus := orderedRootPublishStatusDeterministicFallbackPrefix + FlushSpanRunFallbackSpanNativeNotImplemented.String()
+	if row.Status != wantStatus {
+		t.Fatalf("prior reducer failure row status=%q want %q", row.Status, wantStatus)
+	}
+
+	db, err := Open(Options{
+		Dir:                    t.TempDir(),
+		FlushAdmissionPolicy:   FlushAdmissionPolicyExplicit,
+		FlushApplyConcurrency:  2,
+		FlushApplyMinEntries:   1,
+		FlushApplyMinSpans:     1,
+		FlushApplyMinBytes:     1,
+		FlushApplySpanNative:   true,
+		DisableBackgroundPrune: true,
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	rawApplyOpts := db.flushApplyOptions()
+	if !rawApplyOpts.SpanNativeApply {
+		t.Fatal("fixture did not request raw span-native apply")
+	}
+	orderedApplyOpts := db.orderedRootDeltaBatchApplyOptions()
+	if orderedApplyOpts.SpanNativeApply {
+		t.Fatalf("ordered-root delta batch span-native apply enabled; matrix row %q must be updated before behavior changes", row.ID)
+	}
+	if orderedApplyOpts.SpanNativeForceFallbackReason != "" {
+		t.Fatalf("ordered-root fallback reason hook=%q, want empty because behavior is current forced non-span-native apply", orderedApplyOpts.SpanNativeForceFallbackReason)
+	}
+	if !orderedApplyOpts.PrepareReadOnly || orderedApplyOpts.ReadOnlyPrepareWorkers != 2 {
+		t.Fatalf("ordered-root read-only prepare options=%+v, want prepare-only planning with two workers", orderedApplyOpts)
+	}
+
+	baseRoot, err := db.PublishOrderedRootIterator(0, mustFrozenSystemMemtable(t, "doc/1", "base").NewIterator(nil, nil))
+	if err != nil {
+		t.Fatalf("PublishOrderedRootIterator: %v", err)
+	}
+	updateIter := mustFrozenSystemMemtable(t, "doc/2", "update").NewIterator(nil, nil)
+	update, err := OrderedRootDeltaBatchFromIterator(updateIter)
+	_ = updateIter.Close()
+	if err != nil {
+		t.Fatalf("OrderedRootDeltaBatchFromIterator: %v", err)
+	}
+	defer func() { _ = update.Close() }()
+
+	_, rootIDs, err := db.PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder(
+		[]OrderedRootDeltaBatchPublishInput{{
+			BaseRoot:               baseRoot,
+			Delta:                  update,
+			PrepareReadOnly:        true,
+			ReadOnlyPrepareWorkers: 2,
+		}},
+		func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+			return mustFrozenSystemMemtable(t, "sys/collections/users/root", strconv.FormatUint(rootIDs[0], 10)).NewIterator(nil, nil), nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("PublishOrderedRootDeltaBatchGroupWithSystemDeltaBuilder: %v", err)
+	}
+	if len(rootIDs) != 1 || rootIDs[0] == 0 {
+		t.Fatalf("rootIDs=%v, want one non-zero root", rootIDs)
+	}
+
+	stats := db.Stats()
+	if got := stats["treedb.flush_apply.read_only_prepare.calls_total"]; got == "0" {
+		t.Fatalf("read-only prepare calls=%q, want ordered-root prepare-only path to run", got)
+	}
+	if got := stats["treedb.flush_apply.span_native.used_ops_total"]; got != "0" {
+		t.Fatalf("span-native used ops=%q, want deterministic non-span-native fallback for ordered-root publish", got)
+	}
+	if got := stats["treedb.flush_apply.span_native.fallback.reason."+FlushSpanRunFallbackSpanNativeNotImplemented.String()+".ops_total"]; got == "0" {
+		t.Fatalf("span-native-not-implemented fallback ops=%q, want deterministic fallback classification", got)
+	}
+	if got := stats["treedb.flush_apply.span_native.fallback.reason."+FlushSpanRunFallbackUnknown.String()+".ops_total"]; got != "0" {
+		t.Fatalf("unknown fallback ops=%q, want zero", got)
+	}
+}
+
+func orderedRootSpanNativeClassificationRowByID(t *testing.T, id string) orderedRootSpanNativeClassificationRow {
+	t.Helper()
+	for _, row := range orderedRootSpanNativeClassificationRows() {
+		if row.ID == id {
+			return row
+		}
+	}
+	t.Fatalf("missing ordered-root classification row %q", id)
+	return orderedRootSpanNativeClassificationRow{}
+}

--- a/TreeDB/db/ordered_root_span_native_classification_test.go
+++ b/TreeDB/db/ordered_root_span_native_classification_test.go
@@ -122,6 +122,11 @@ var orderedRootDownstreamActions = map[orderedRootPublishDownstreamAction]struct
 	orderedRootActionImplementedCurrentReadOnlyOnly: {},
 }
 
+var orderedRootSupportedBlockerActions = map[string]orderedRootPublishDownstreamAction{
+	"#3032": orderedRootActionBlockedBy3032,
+	"#3033": orderedRootActionBlockedBy3033,
+}
+
 type orderedRootSpanNativeClassificationRow struct {
 	ID                string
 	Category          string
@@ -585,6 +590,19 @@ func TestOrderedRootSpanNativeClassificationMatrixCoversIssue3021(t *testing.T) 
 	}
 }
 
+func TestOrderedRootSpanNativeClassificationRejectsUnsupportedBlockerIDs(t *testing.T) {
+	for _, issue := range []string{"#3032", "#3033"} {
+		if _, ok := orderedRootSupportedBlockerActions[issue]; !ok {
+			t.Fatalf("supported blocker %s missing from classification blocker set", issue)
+		}
+	}
+	for _, issue := range []string{"#3034", "#3022", "3032", ""} {
+		if action, ok := orderedRootSupportedBlockerActions[issue]; ok {
+			t.Fatalf("unsupported blocker %q mapped to downstream action %q", issue, action)
+		}
+	}
+}
+
 func validateOrderedRootSpanNativeClassificationRow(t *testing.T, row orderedRootSpanNativeClassificationRow, seenIDs map[string]struct{}) {
 	t.Helper()
 	if row.ID == "" {
@@ -621,8 +639,8 @@ func validateOrderedRootSpanNativeClassificationRow(t *testing.T, row orderedRoo
 		}
 	case strings.HasPrefix(row.Status, orderedRootPublishStatusBlockedByPrefix):
 		issue := strings.TrimPrefix(row.Status, orderedRootPublishStatusBlockedByPrefix)
-		if !strings.HasPrefix(issue, "#") || len(issue) == 1 {
-			t.Fatalf("classification row %q has invalid blocker status %q", row.ID, row.Status)
+		if _, ok := orderedRootSupportedBlockerActions[issue]; !ok {
+			t.Fatalf("classification row %q has unsupported blocker status %q", row.ID, row.Status)
 		}
 	default:
 		t.Fatalf("classification row %q has unsupported status %q", row.ID, row.Status)
@@ -651,21 +669,17 @@ func validateOrderedRootSpanNativeClassificationRow(t *testing.T, row orderedRoo
 		}
 		seenActions[action] = struct{}{}
 	}
-	switch {
-	case strings.HasPrefix(row.Status, orderedRootPublishStatusBlockedByPrefix+"#3032"):
-		if _, ok := seenActions[orderedRootActionBlockedBy3032]; !ok {
-			t.Fatalf("classification row %q blocked by #3032 without matching downstream action", row.ID)
+	if strings.HasPrefix(row.Status, orderedRootPublishStatusBlockedByPrefix) {
+		issue := strings.TrimPrefix(row.Status, orderedRootPublishStatusBlockedByPrefix)
+		action := orderedRootSupportedBlockerActions[issue]
+		if _, ok := seenActions[action]; !ok {
+			t.Fatalf("classification row %q blocked by %s without matching downstream action", row.ID, issue)
 		}
-	case strings.HasPrefix(row.Status, orderedRootPublishStatusBlockedByPrefix+"#3033"):
-		if _, ok := seenActions[orderedRootActionBlockedBy3033]; !ok {
-			t.Fatalf("classification row %q blocked by #3033 without matching downstream action", row.ID)
-		}
-	default:
-		if _, ok := seenActions[orderedRootActionBlockedBy3032]; ok {
-			t.Fatalf("classification row %q has #3032 action without blocked status", row.ID)
-		}
-		if _, ok := seenActions[orderedRootActionBlockedBy3033]; ok {
-			t.Fatalf("classification row %q has #3033 action without blocked status", row.ID)
+	} else {
+		for issue, action := range orderedRootSupportedBlockerActions {
+			if _, ok := seenActions[action]; ok {
+				t.Fatalf("classification row %q has %s action without blocked status", row.ID, issue)
+			}
 		}
 	}
 	if len(row.Covers) == 0 {


### PR DESCRIPTION
Closes #3021
Part of #3020

## Scope

This adds test-only ordered-root publish route classification scaffolding before any ordered-root behavior changes. It does not change production behavior.

## Classification Matrix

The checked db-package matrix now binds each row to concrete route/function/API anchors, an expected outcome, production-support posture, and downstream action. A row cannot satisfy the matrix by adding a free-form token only.

The matrix covers:

- Direct, group, system, and collection ordered-root publish routes.
- Serial, parallel, read-only, and span-native prepare modes.
- No-op, overwrite, delete, tombstone, empty, and duplicate semantics.
- Inline leaf and value-log leaf output, including checkpoint/reopen and GC implications.
- Explicit downstream posture for current serial behavior: implemented-current-serial-only, eligible-for-#3022-observability, requires-#3023-correctness, requires-#3024-output-ownership, or blocked-by-#3032/#3033.

Rows must carry a supported production-support status and one of:

- `implemented`
- `deterministic_fallback:<reason>`
- `blocked_by:<issue>`

The prior `no replacement changed root` failure class is not claimed as reproduced here. The revised row/test lock down the behavior that is actually present today: blanket non-span-native fallback/read-only planning before reducer execution.

## Collection Routes

A new collection-package checked helper binds collection route coverage to public and internal collection surfaces, including:

- Buffered flush and overlay flush routes.
- Command-WAL and non-command-WAL publish paths.
- Insert, delete, and update root groups.
- Multi-index and secondary-index root publish inventory.
- Overlay compaction maintenance routes.

The prior broad overlay row is split into warm single-base overlay behavior and cold-build zero-base behavior so #3022/#3023 can consume the contract without ambiguity.

## Guardrails

The tests fail on unknown rows, implicit-disabled wording, duplicate IDs, missing production-support notes, missing required route anchors, missing expected outcomes, missing downstream actions, unsupported blocked dependency links, or unexpected span-native fallback routing.

The stats assertions in the span-native fallback test now fail on missing stat keys and parse counters explicitly before checking zero or positive expectations.

## Validation

- `GOWORK=off go test ./TreeDB/db -count=1 -run 'OrderedRoot|SpanNative|Publish'` — passed, `ok ... 2.977s`
- `GOWORK=off go test ./TreeDB/collections -count=1 -run 'Insert|Index|Delete|OrderedRoot|SpanNative'` — passed, `ok ... 27.154s`
- `git diff --check` — passed

Go version: `go1.26.0 linux/amd64`.

## Benchmarks

Not run. This is classification/test scaffolding only and does not alter write-path behavior, admission policy, compact ownership, storage format, or benchmark-relevant runtime behavior.

## Notes

- AI review was not requested per worker instructions.
- This PR remains draft.
