### PR TITLE
TreeDB: classify compact leaf-page-log owners

### DIFF
--- a/TreeDB/compact_storage.go
+++ b/TreeDB/compact_storage.go
@@ -17,6 +17,39 @@ const (
 	CompactStorageExhaustive = treedbdb.CompactStorageExhaustive
 )
 
+type CompactStorageOwnerStatus = treedbdb.CompactStorageOwnerStatus
+
+const (
+	CompactStorageOwnerStatusSupportedTarget      = treedbdb.CompactStorageOwnerStatusSupportedTarget
+	CompactStorageOwnerStatusLiveWriterFailClosed = treedbdb.CompactStorageOwnerStatusLiveWriterFailClosed
+	CompactStorageOwnerStatusExternalUnsupported  = treedbdb.CompactStorageOwnerStatusExternalUnsupported
+	CompactStorageOwnerStatusBlockingBug          = treedbdb.CompactStorageOwnerStatusBlockingBug
+)
+
+type CompactStorageLeafPageLogOwnerClass = treedbdb.CompactStorageLeafPageLogOwnerClass
+
+const (
+	CompactStorageLeafPageLogOwnerNone                     = treedbdb.CompactStorageLeafPageLogOwnerNone
+	CompactStorageLeafPageLogOwnerCommandWALReplayInline   = treedbdb.CompactStorageLeafPageLogOwnerCommandWALReplayInline
+	CompactStorageLeafPageLogOwnerInternalHiddenByWrapper  = treedbdb.CompactStorageLeafPageLogOwnerInternalHiddenByWrapper
+	CompactStorageLeafPageLogOwnerCachedWrapper            = treedbdb.CompactStorageLeafPageLogOwnerCachedWrapper
+	CompactStorageLeafPageLogOwnerStandaloneCallerExternal = treedbdb.CompactStorageLeafPageLogOwnerStandaloneCallerExternal
+)
+
+type CompactStorageLifecycleState = treedbdb.CompactStorageLifecycleState
+
+const (
+	CompactStorageLifecycleExclusiveMaintenance = treedbdb.CompactStorageLifecycleExclusiveMaintenance
+	CompactStorageLifecycleQuiescedMaintenance  = treedbdb.CompactStorageLifecycleQuiescedMaintenance
+	CompactStorageLifecycleActiveWriter         = treedbdb.CompactStorageLifecycleActiveWriter
+)
+
+var ErrCompactStorageLeafPageLogOwnerUnsupported = treedbdb.ErrCompactStorageLeafPageLogOwnerUnsupported
+
+type CompactStorageLeafPageLogOwnerClassification = treedbdb.CompactStorageLeafPageLogOwnerClassification
+
+type CompactStorageLeafPageLogOwnerError = treedbdb.CompactStorageLeafPageLogOwnerError
+
 // CompactStorageOptions controls full storage compaction across TreeDB storage
 // domains. Prefer this high-level API over manually sequencing value-log
 // rewrite, value-log GC, leaf-generation pack/GC, and index vacuum.
@@ -105,6 +138,16 @@ func (db *DB) CompactStorage(ctx context.Context, opts CompactStorageOptions) (C
 	}
 	success = true
 	return CompactStorageStats(stats), nil
+}
+
+// CompactStorageLeafPageLogOwnerClassification reports the backend leaf-log
+// owner classification currently visible to CompactStorage. The lifecycle
+// argument is a modeled contract category, not runtime proof of quiescence.
+func (db *DB) CompactStorageLeafPageLogOwnerClassification(lifecycle CompactStorageLifecycleState) CompactStorageLeafPageLogOwnerClassification {
+	if db == nil || db.backend == nil {
+		return treedbdb.CompactStorageLeafPageLogOwnerClassification{}
+	}
+	return db.backend.CompactStorageLeafPageLogOwnerClassification(lifecycle)
 }
 
 func (db *DB) applyCachedCompactStorageOptions(opts *CompactStorageOptions, checkpoint bool) error {

--- a/TreeDB/compact_storage_test.go
+++ b/TreeDB/compact_storage_test.go
@@ -3,6 +3,7 @@ package treedb_test
 import (
 	"bytes"
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -10,6 +11,44 @@ import (
 	treedb "github.com/snissn/gomap/TreeDB"
 	backenddb "github.com/snissn/gomap/TreeDB/db"
 )
+
+func TestCompactStoragePublicCommandWALRelaxedDefaultOwnerClassification(t *testing.T) {
+	dir := t.TempDir()
+	opts := treedb.OptionsFor(treedb.ProfileCommandWALRelaxed, dir)
+	opts.DisableSideStores = true
+	db, err := treedb.Open(opts)
+	if err != nil {
+		t.Fatalf("Open command_wal_relaxed public cached DB: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	if err := db.SetSync([]byte("canonical"), bytes.Repeat([]byte("v"), 512)); err != nil {
+		t.Fatalf("SetSync canonical public cached write: %v", err)
+	}
+
+	classification := db.CompactStorageLeafPageLogOwnerClassification(treedb.CompactStorageLifecycleQuiescedMaintenance)
+	if classification.OwnerClass != treedb.CompactStorageLeafPageLogOwnerCachedWrapper {
+		t.Fatalf("owner=%q want %q (classification=%+v)", classification.OwnerClass, treedb.CompactStorageLeafPageLogOwnerCachedWrapper, classification)
+	}
+	if classification.Status != treedb.CompactStorageOwnerStatusBlockingBug {
+		t.Fatalf("status=%q want %q (classification=%+v)", classification.Status, treedb.CompactStorageOwnerStatusBlockingBug, classification)
+	}
+	if !classification.RequiresQuiescence {
+		t.Fatalf("RequiresQuiescence=false, want true (classification=%+v)", classification)
+	}
+
+	_, err = db.CompactStorage(context.Background(), treedb.CompactStorageOptions{Mode: treedb.CompactStorageExhaustive})
+	if !errors.Is(err, treedb.ErrCompactStorageLeafPageLogOwnerUnsupported) {
+		t.Fatalf("CompactStorage exhaustive error=%v, want owner unsupported", err)
+	}
+	var ownerErr *treedb.CompactStorageLeafPageLogOwnerError
+	if !errors.As(err, &ownerErr) {
+		t.Fatalf("CompactStorage exhaustive error=%T, want CompactStorageLeafPageLogOwnerError", err)
+	}
+	if ownerErr.Classification.OwnerClass != treedb.CompactStorageLeafPageLogOwnerCachedWrapper {
+		t.Fatalf("error owner=%q want %q", ownerErr.Classification.OwnerClass, treedb.CompactStorageLeafPageLogOwnerCachedWrapper)
+	}
+}
 
 func TestCompactStorageFullPacksLeafGenerationDebtOffline(t *testing.T) {
 	dir := t.TempDir()

--- a/TreeDB/db/compact_storage.go
+++ b/TreeDB/db/compact_storage.go
@@ -25,6 +25,81 @@ const (
 	CompactStorageExhaustive CompactStorageMode = "exhaustive"
 )
 
+// CompactStorageOwnerStatus is the production support category for an
+// exhaustive compact leaf-page-log owner.
+type CompactStorageOwnerStatus string
+
+const (
+	CompactStorageOwnerStatusSupportedTarget      CompactStorageOwnerStatus = "supported-target"
+	CompactStorageOwnerStatusLiveWriterFailClosed CompactStorageOwnerStatus = "live-writer fail-closed"
+	CompactStorageOwnerStatusExternalUnsupported  CompactStorageOwnerStatus = "external-owner unsupported"
+	CompactStorageOwnerStatusBlockingBug          CompactStorageOwnerStatus = "blocking-bug"
+)
+
+// CompactStorageLeafPageLogOwnerClass identifies who owns the currently
+// installed leaf-page-log writer from CompactStorage's point of view.
+type CompactStorageLeafPageLogOwnerClass string
+
+const (
+	CompactStorageLeafPageLogOwnerNone                     CompactStorageLeafPageLogOwnerClass = "no installed leaf log"
+	CompactStorageLeafPageLogOwnerCommandWALReplayInline   CompactStorageLeafPageLogOwnerClass = "command-WAL/replay-inline internal owner"
+	CompactStorageLeafPageLogOwnerInternalHiddenByWrapper  CompactStorageLeafPageLogOwnerClass = "internal owner hidden by wrapper"
+	CompactStorageLeafPageLogOwnerCachedWrapper            CompactStorageLeafPageLogOwnerClass = "cached/wrapper owner"
+	CompactStorageLeafPageLogOwnerStandaloneCallerExternal CompactStorageLeafPageLogOwnerClass = "standalone/caller external owner"
+)
+
+// CompactStorageLifecycleState records the writer lifecycle assumption used by
+// the owner classifier.
+type CompactStorageLifecycleState string
+
+const (
+	CompactStorageLifecycleExclusiveMaintenance CompactStorageLifecycleState = "exclusive maintenance"
+	CompactStorageLifecycleQuiescedMaintenance  CompactStorageLifecycleState = "quiesced maintenance"
+	CompactStorageLifecycleActiveWriter         CompactStorageLifecycleState = "active writer"
+)
+
+// ErrCompactStorageLeafPageLogOwnerUnsupported is returned when exhaustive
+// compact reaches an installed leaf-page-log owner it cannot safely replace.
+var ErrCompactStorageLeafPageLogOwnerUnsupported = errors.New("treedb: compact storage leaf page log owner unsupported")
+
+// CompactStorageLeafPageLogOwnerClassification is the compact-owner production
+// support contract attached to fail-closed exhaustive compact errors.
+type CompactStorageLeafPageLogOwnerClassification struct {
+	OwnerClass         CompactStorageLeafPageLogOwnerClass
+	Status             CompactStorageOwnerStatus
+	Lifecycle          CompactStorageLifecycleState
+	Replaceable        bool
+	RequiresQuiescence bool
+	Detail             string
+}
+
+// CompactStorageLeafPageLogOwnerError carries the owner classification that
+// caused exhaustive compact to fail closed.
+type CompactStorageLeafPageLogOwnerError struct {
+	Classification CompactStorageLeafPageLogOwnerClassification
+}
+
+func (e *CompactStorageLeafPageLogOwnerError) Error() string {
+	classification := CompactStorageLeafPageLogOwnerClassification{}
+	if e != nil {
+		classification = e.Classification
+	}
+	status := classification.Status
+	if status == "" {
+		status = CompactStorageOwnerStatusExternalUnsupported
+	}
+	return fmt.Sprintf(
+		"treedb: exhaustive compact requires an internally-owned leaf page log; close or clear the installed leaf page log before compacting (owner=%s status=%s lifecycle=%s)",
+		classification.OwnerClass,
+		status,
+		classification.Lifecycle,
+	)
+}
+
+func (e *CompactStorageLeafPageLogOwnerError) Unwrap() error {
+	return ErrCompactStorageLeafPageLogOwnerUnsupported
+}
+
 // CompactStorageOptions controls full storage compaction across TreeDB storage
 // domains. Prefer this high-level API over manually sequencing value-log
 // rewrite, value-log GC, leaf-generation pack/GC, and index vacuum.
@@ -260,7 +335,9 @@ func (db *DB) compactStorage(ctx context.Context, opts CompactStorageOptions) (C
 	}
 	defer cleanupLeafLog()
 	if opts.Mode == CompactStorageExhaustive && db.indexOuterLeavesInValueLog && compactLeafLog == nil && db.leafPageLog != nil {
-		return stats, fmt.Errorf("treedb: exhaustive compact requires an internally-owned leaf page log; close or clear the installed leaf page log before compacting")
+		return stats, &CompactStorageLeafPageLogOwnerError{
+			Classification: compactStorageClassifyLeafPageLogOwner(db.leafPageLog, CompactStorageLifecycleExclusiveMaintenance),
+		}
 	}
 
 	// Leaf-pack/GC can make pre-compact leaf generations unreachable before
@@ -1351,11 +1428,128 @@ func (db *DB) installCompactStorageLeafPageLog(opts CompactStorageOptions) (*rew
 }
 
 func compactStorageReplaceableLeafPageLog(log LeafPageLog) bool {
-	if wrapped, ok := log.(*leafPageLogWithRecordLengthHints); ok {
-		log = wrapped.inner
+	classification := compactStorageClassifyLeafPageLogOwner(log, CompactStorageLifecycleExclusiveMaintenance)
+	return classification.Replaceable && classification.Status == CompactStorageOwnerStatusSupportedTarget
+}
+
+func compactStorageClassifyLeafPageLogOwner(log LeafPageLog, lifecycle CompactStorageLifecycleState) CompactStorageLeafPageLogOwnerClassification {
+	if lifecycle == "" {
+		lifecycle = CompactStorageLifecycleExclusiveMaintenance
 	}
-	_, ok := log.(replayInlineLeafPageLog)
-	return ok
+	ownerClass := compactStorageLeafPageLogOwnerClass(log)
+	classification := CompactStorageLeafPageLogOwnerClassification{
+		OwnerClass: ownerClass,
+		Lifecycle:  lifecycle,
+	}
+	switch ownerClass {
+	case CompactStorageLeafPageLogOwnerNone:
+		classification.Status = CompactStorageOwnerStatusSupportedTarget
+		classification.Replaceable = true
+	case CompactStorageLeafPageLogOwnerCommandWALReplayInline:
+		if lifecycle == CompactStorageLifecycleActiveWriter {
+			classification.Status = CompactStorageOwnerStatusLiveWriterFailClosed
+			classification.RequiresQuiescence = true
+			classification.Detail = "command-WAL cleanup and checkpoint/close drains must quiesce before exhaustive compact can replace the replay-inline owner"
+		} else {
+			classification.Status = CompactStorageOwnerStatusSupportedTarget
+			classification.Replaceable = true
+		}
+	case CompactStorageLeafPageLogOwnerInternalHiddenByWrapper:
+		if lifecycle == CompactStorageLifecycleActiveWriter {
+			classification.Status = CompactStorageOwnerStatusLiveWriterFailClosed
+			classification.RequiresQuiescence = true
+			classification.Detail = "lane/wrapper replay-inline owner must be quiesced before exhaustive compact can reason about replacement"
+		} else {
+			classification.Status = CompactStorageOwnerStatusBlockingBug
+			classification.Detail = "replay-inline owner is internally owned but hidden behind leaf-log wrappers that compact replacement does not unwrap yet"
+		}
+	case CompactStorageLeafPageLogOwnerCachedWrapper:
+		if lifecycle == CompactStorageLifecycleActiveWriter {
+			classification.Status = CompactStorageOwnerStatusLiveWriterFailClosed
+			classification.RequiresQuiescence = true
+			classification.Detail = "background flush/apply workers and cached backlog must be fenced before exhaustive compact can take over the owner"
+		} else {
+			classification.Status = CompactStorageOwnerStatusBlockingBug
+			classification.RequiresQuiescence = true
+			classification.Detail = "cached/wrapper owners need an explicit quiesced handoff or unwrap capability before exhaustive compact can replace them"
+		}
+	default:
+		classification.Status = CompactStorageOwnerStatusExternalUnsupported
+		classification.Detail = "standalone caller-owned leaf logs remain outside exhaustive compact ownership"
+	}
+	return classification
+}
+
+func compactStorageLeafPageLogOwnerClass(log LeafPageLog) CompactStorageLeafPageLogOwnerClass {
+	if log == nil {
+		return CompactStorageLeafPageLogOwnerNone
+	}
+	if wrapped, ok := log.(*leafPageLogWithRecordLengthHints); ok {
+		return compactStorageLeafPageLogOwnerClass(wrapped.inner)
+	}
+	if _, ok := log.(replayInlineLeafPageLog); ok {
+		return CompactStorageLeafPageLogOwnerCommandWALReplayInline
+	}
+	if group, ok := log.(*leafPageLogLaneGroup); ok {
+		return compactStorageLeafPageLogLaneGroupOwnerClass(group)
+	}
+	if compactStorageLooksLikeCachedLeafPageLog(log) {
+		return CompactStorageLeafPageLogOwnerCachedWrapper
+	}
+	return CompactStorageLeafPageLogOwnerStandaloneCallerExternal
+}
+
+func compactStorageLeafPageLogLaneGroupOwnerClass(group *leafPageLogLaneGroup) CompactStorageLeafPageLogOwnerClass {
+	if group == nil {
+		return CompactStorageLeafPageLogOwnerNone
+	}
+	lanes, _ := group.snapshotLanesAndLocks()
+	if len(lanes) == 0 {
+		return CompactStorageLeafPageLogOwnerStandaloneCallerExternal
+	}
+	allCommandWALReplayInline := true
+	allExternal := true
+	for _, lane := range lanes {
+		switch compactStorageLeafPageLogOwnerClass(lane) {
+		case CompactStorageLeafPageLogOwnerCommandWALReplayInline:
+			allExternal = false
+		case CompactStorageLeafPageLogOwnerCachedWrapper:
+			return CompactStorageLeafPageLogOwnerCachedWrapper
+		case CompactStorageLeafPageLogOwnerInternalHiddenByWrapper:
+			allExternal = false
+		case CompactStorageLeafPageLogOwnerStandaloneCallerExternal:
+			allCommandWALReplayInline = false
+		default:
+			allCommandWALReplayInline = false
+			allExternal = false
+		}
+	}
+	if allCommandWALReplayInline {
+		return CompactStorageLeafPageLogOwnerInternalHiddenByWrapper
+	}
+	if allExternal {
+		return CompactStorageLeafPageLogOwnerStandaloneCallerExternal
+	}
+	return CompactStorageLeafPageLogOwnerInternalHiddenByWrapper
+}
+
+func compactStorageLooksLikeCachedLeafPageLog(log LeafPageLog) bool {
+	if log == nil {
+		return false
+	}
+	if _, ok := log.(LeafPageConcurrentAppendLog); !ok {
+		return false
+	}
+	if _, ok := log.(LeafPageLogLaneProvider); ok {
+		return true
+	}
+	if _, ok := log.(LeafPageLogCreatedSegmentProvider); ok {
+		return true
+	}
+	if _, ok := log.(LeafPageLogCurrentSegmentProvider); ok {
+		return true
+	}
+	return false
 }
 
 func (db *DB) refreshCompactStorageLeafPageLog(writer *rewriteWriter) error {

--- a/TreeDB/db/compact_storage.go
+++ b/TreeDB/db/compact_storage.go
@@ -65,8 +65,11 @@ var ErrCompactStorageLeafPageLogOwnerUnsupported = errors.New("treedb: compact s
 // CompactStorageLeafPageLogOwnerClassification is the compact-owner production
 // support contract attached to fail-closed exhaustive compact errors.
 type CompactStorageLeafPageLogOwnerClassification struct {
-	OwnerClass         CompactStorageLeafPageLogOwnerClass
-	Status             CompactStorageOwnerStatus
+	OwnerClass CompactStorageLeafPageLogOwnerClass
+	Status     CompactStorageOwnerStatus
+	// Lifecycle is a caller-supplied modeled state, not runtime proof. The
+	// current CompactStorage refusal path classifies after taking the exclusive
+	// maintenance lock and therefore passes CompactStorageLifecycleExclusiveMaintenance.
 	Lifecycle          CompactStorageLifecycleState
 	Replaceable        bool
 	RequiresQuiescence bool
@@ -1432,6 +1435,20 @@ func compactStorageReplaceableLeafPageLog(log LeafPageLog) bool {
 	return classification.Replaceable && classification.Status == CompactStorageOwnerStatusSupportedTarget
 }
 
+// CompactStorageLeafPageLogOwnerClassification reports the compact-owner
+// support category for the currently installed leaf-page log. The lifecycle
+// argument is a modeled assumption used by the contract matrix; it does not
+// prove the database is actually in that lifecycle state.
+func (db *DB) CompactStorageLeafPageLogOwnerClassification(lifecycle CompactStorageLifecycleState) CompactStorageLeafPageLogOwnerClassification {
+	if db == nil {
+		return compactStorageClassifyLeafPageLogOwner(nil, lifecycle)
+	}
+	db.writeMu.Lock()
+	log := db.leafPageLog
+	db.writeMu.Unlock()
+	return compactStorageClassifyLeafPageLogOwner(log, lifecycle)
+}
+
 func compactStorageClassifyLeafPageLogOwner(log LeafPageLog, lifecycle CompactStorageLifecycleState) CompactStorageLeafPageLogOwnerClassification {
 	if lifecycle == "" {
 		lifecycle = CompactStorageLifecycleExclusiveMaintenance
@@ -1449,7 +1466,7 @@ func compactStorageClassifyLeafPageLogOwner(log LeafPageLog, lifecycle CompactSt
 		if lifecycle == CompactStorageLifecycleActiveWriter {
 			classification.Status = CompactStorageOwnerStatusLiveWriterFailClosed
 			classification.RequiresQuiescence = true
-			classification.Detail = "command-WAL cleanup and checkpoint/close drains must quiesce before exhaustive compact can replace the replay-inline owner"
+			classification.Detail = "modeled active-writer status: command-WAL cleanup and checkpoint/close drains must quiesce before exhaustive compact can replace the replay-inline owner"
 		} else {
 			classification.Status = CompactStorageOwnerStatusSupportedTarget
 			classification.Replaceable = true
@@ -1458,7 +1475,7 @@ func compactStorageClassifyLeafPageLogOwner(log LeafPageLog, lifecycle CompactSt
 		if lifecycle == CompactStorageLifecycleActiveWriter {
 			classification.Status = CompactStorageOwnerStatusLiveWriterFailClosed
 			classification.RequiresQuiescence = true
-			classification.Detail = "lane/wrapper replay-inline owner must be quiesced before exhaustive compact can reason about replacement"
+			classification.Detail = "modeled active-writer status: lane/wrapper replay-inline owner must be quiesced before exhaustive compact can reason about replacement"
 		} else {
 			classification.Status = CompactStorageOwnerStatusBlockingBug
 			classification.Detail = "replay-inline owner is internally owned but hidden behind leaf-log wrappers that compact replacement does not unwrap yet"
@@ -1467,7 +1484,7 @@ func compactStorageClassifyLeafPageLogOwner(log LeafPageLog, lifecycle CompactSt
 		if lifecycle == CompactStorageLifecycleActiveWriter {
 			classification.Status = CompactStorageOwnerStatusLiveWriterFailClosed
 			classification.RequiresQuiescence = true
-			classification.Detail = "background flush/apply workers and cached backlog must be fenced before exhaustive compact can take over the owner"
+			classification.Detail = "modeled active-writer status: background flush/apply workers and cached backlog must be fenced before exhaustive compact can take over the owner"
 		} else {
 			classification.Status = CompactStorageOwnerStatusBlockingBug
 			classification.RequiresQuiescence = true

--- a/TreeDB/db/compact_storage_owner_matrix_test.go
+++ b/TreeDB/db/compact_storage_owner_matrix_test.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/snissn/gomap/TreeDB/page"
@@ -142,7 +143,7 @@ func TestCompactStorageLeafPageLogOwnerMatrix(t *testing.T) {
 	}
 }
 
-func TestCompactStorageCommandWALValueLogLeafPageLogCurrentBlockingBug(t *testing.T) {
+func TestCompactStorageRawBackendCommandWALValueLogLeafPageLogCurrentBlockingBug(t *testing.T) {
 	d, err := Open(Options{
 		Dir:                        t.TempDir(),
 		CommandWAL:                 true,
@@ -179,6 +180,24 @@ func TestCompactStorageCommandWALValueLogLeafPageLogCurrentBlockingBug(t *testin
 	}
 }
 
+func TestCompactStorageActiveWriterLifecycleIsModeledStatus(t *testing.T) {
+	log := compactStorageMatrixCachedLeafPageLog{}
+	active := compactStorageClassifyLeafPageLogOwner(log, CompactStorageLifecycleActiveWriter)
+	if active.Status != CompactStorageOwnerStatusLiveWriterFailClosed {
+		t.Fatalf("active status=%q want %q", active.Status, CompactStorageOwnerStatusLiveWriterFailClosed)
+	}
+	if !strings.Contains(active.Detail, "modeled active-writer status") {
+		t.Fatalf("active detail=%q, want modeled-status wording", active.Detail)
+	}
+	exclusive := compactStorageClassifyLeafPageLogOwner(log, CompactStorageLifecycleExclusiveMaintenance)
+	if exclusive.Status != CompactStorageOwnerStatusBlockingBug {
+		t.Fatalf("exclusive status=%q want %q", exclusive.Status, CompactStorageOwnerStatusBlockingBug)
+	}
+	if strings.Contains(exclusive.Detail, "active-writer") {
+		t.Fatalf("exclusive detail=%q should not imply active-writer runtime proof", exclusive.Detail)
+	}
+}
+
 func TestCompactStorageDefaultProducedOwnerContractMatrix(t *testing.T) {
 	tests := []struct {
 		name               string
@@ -198,12 +217,13 @@ func TestCompactStorageDefaultProducedOwnerContractMatrix(t *testing.T) {
 			quiescence:   []string{"checkpoint-close-drain"},
 		},
 		{
-			name:         "command_wal_relaxed default profile value-log backed outer leaves",
-			producerPath: "treedb.OptionsFor(ProfileCommandWALRelaxed)",
-			owner:        CompactStorageLeafPageLogOwnerInternalHiddenByWrapper,
-			lifecycle:    CompactStorageLifecycleQuiescedMaintenance,
-			status:       CompactStorageOwnerStatusBlockingBug,
-			quiescence:   []string{"checkpoint-close-drain", "command-wal-cleanup"},
+			name:               "public command_wal_relaxed default profile value-log backed outer leaves",
+			producerPath:       "treedb.Open(treedb.OptionsFor(ProfileCommandWALRelaxed)) cached wrapper; fixture-proved in TreeDB/compact_storage_test.go",
+			owner:              CompactStorageLeafPageLogOwnerCachedWrapper,
+			lifecycle:          CompactStorageLifecycleQuiescedMaintenance,
+			status:             CompactStorageOwnerStatusBlockingBug,
+			quiescence:         []string{"background-flush-apply-workers", "checkpoint-close-drain", "command-wal-cleanup", "cached-backlog"},
+			missingFixtureWork: "supported-target requires #3049 to implement explicit cached owner handoff/unwrap; #3048 proves the canonical owner class only",
 		},
 		{
 			name:               "public cached wrapper value-log backed outer leaves",
@@ -215,8 +235,8 @@ func TestCompactStorageDefaultProducedOwnerContractMatrix(t *testing.T) {
 			missingFixtureWork: "cached exhaustive compact needs explicit quiesced owner handoff or unwrap fixture before it can be marked supported-target",
 		},
 		{
-			name:         "treedb raw command WAL maintenance path",
-			producerPath: "TreeDB/cmd/treemap compact -rw -mode exhaustive over command-WAL raw dir",
+			name:         "raw backend command WAL maintenance path",
+			producerPath: "TreeDB/db.Open or TreeDB/cmd/treemap compact -rw -mode exhaustive over a raw command-WAL backend dir; not the public cached canonical collection path",
 			owner:        CompactStorageLeafPageLogOwnerInternalHiddenByWrapper,
 			lifecycle:    CompactStorageLifecycleExclusiveMaintenance,
 			status:       CompactStorageOwnerStatusBlockingBug,

--- a/TreeDB/db/compact_storage_owner_matrix_test.go
+++ b/TreeDB/db/compact_storage_owner_matrix_test.go
@@ -1,0 +1,265 @@
+package db
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/page"
+)
+
+type compactStorageMatrixLeafPageLog struct{}
+
+func (compactStorageMatrixLeafPageLog) AppendLeafPage([]byte) (page.LeafLogPtr, error) {
+	return page.LeafLogPtr{}, nil
+}
+
+func (compactStorageMatrixLeafPageLog) Flush() error { return nil }
+
+func (compactStorageMatrixLeafPageLog) Sync() error { return nil }
+
+type compactStorageMatrixCachedLeafPageLog struct {
+	compactStorageMatrixLeafPageLog
+}
+
+func (compactStorageMatrixCachedLeafPageLog) ConcurrentLeafPageAppends() bool { return true }
+
+func (compactStorageMatrixCachedLeafPageLog) LeafPageLogLane(int) (LeafPageLog, bool) {
+	return compactStorageMatrixLeafPageLog{}, true
+}
+
+func (compactStorageMatrixCachedLeafPageLog) CreatedLeafPageLogSegmentsSnapshot() ([]LeafPageLogSegment, error) {
+	return nil, nil
+}
+
+func (compactStorageMatrixCachedLeafPageLog) CurrentLeafPageLogSegmentsSnapshot() ([]LeafPageLogSegment, error) {
+	return nil, nil
+}
+
+func TestCompactStorageLeafPageLogOwnerMatrix(t *testing.T) {
+	externalLeafLog := newRewriteWriter(ValueLogDirPath(t.TempDir()), 0, 0, 0)
+	externalLeafLog.ConfigureLeafLog(LeafLogDirPath(t.TempDir()), rewriteLeafLogLaneID, 0)
+	externalLeafLog.blockCompression = true
+	externalLeafLog.ridAlloc = newRewriteRIDAllocator(1, nil)
+	defer func() { _ = externalLeafLog.Close() }()
+
+	tests := []struct {
+		name            string
+		log             LeafPageLog
+		lifecycle       CompactStorageLifecycleState
+		wantOwner       CompactStorageLeafPageLogOwnerClass
+		wantStatus      CompactStorageOwnerStatus
+		wantReplaceable bool
+		wantQuiescence  bool
+	}{
+		{
+			name:            "no installed leaf log",
+			lifecycle:       CompactStorageLifecycleExclusiveMaintenance,
+			wantOwner:       CompactStorageLeafPageLogOwnerNone,
+			wantStatus:      CompactStorageOwnerStatusSupportedTarget,
+			wantReplaceable: true,
+		},
+		{
+			name:            "command WAL replay inline internal owner",
+			log:             replayInlineLeafPageLog{},
+			lifecycle:       CompactStorageLifecycleExclusiveMaintenance,
+			wantOwner:       CompactStorageLeafPageLogOwnerCommandWALReplayInline,
+			wantStatus:      CompactStorageOwnerStatusSupportedTarget,
+			wantReplaceable: true,
+		},
+		{
+			name:            "command WAL replay inline with record length wrapper",
+			log:             &leafPageLogWithRecordLengthHints{inner: replayInlineLeafPageLog{}},
+			lifecycle:       CompactStorageLifecycleQuiescedMaintenance,
+			wantOwner:       CompactStorageLeafPageLogOwnerCommandWALReplayInline,
+			wantStatus:      CompactStorageOwnerStatusSupportedTarget,
+			wantReplaceable: true,
+		},
+		{
+			name:           "command WAL replay inline hidden by lane wrapper",
+			log:            wrapLeafPageLogWithLaneSelection(&leafPageLogWithRecordLengthHints{inner: replayInlineLeafPageLog{}}),
+			lifecycle:      CompactStorageLifecycleExclusiveMaintenance,
+			wantOwner:      CompactStorageLeafPageLogOwnerInternalHiddenByWrapper,
+			wantStatus:     CompactStorageOwnerStatusBlockingBug,
+			wantQuiescence: false,
+		},
+		{
+			name:           "command WAL replay inline hidden by lane wrapper active writer",
+			log:            wrapLeafPageLogWithLaneSelection(&leafPageLogWithRecordLengthHints{inner: replayInlineLeafPageLog{}}),
+			lifecycle:      CompactStorageLifecycleActiveWriter,
+			wantOwner:      CompactStorageLeafPageLogOwnerInternalHiddenByWrapper,
+			wantStatus:     CompactStorageOwnerStatusLiveWriterFailClosed,
+			wantQuiescence: true,
+		},
+		{
+			name:       "standalone caller external owner with lane RID compression variants",
+			log:        wrapLeafPageLogWithLaneSelection(&leafPageLogWithRecordLengthHints{inner: externalLeafLog}),
+			lifecycle:  CompactStorageLifecycleExclusiveMaintenance,
+			wantOwner:  CompactStorageLeafPageLogOwnerStandaloneCallerExternal,
+			wantStatus: CompactStorageOwnerStatusExternalUnsupported,
+		},
+		{
+			name:       "plain caller external owner",
+			log:        compactStorageMatrixLeafPageLog{},
+			lifecycle:  CompactStorageLifecycleQuiescedMaintenance,
+			wantOwner:  CompactStorageLeafPageLogOwnerStandaloneCallerExternal,
+			wantStatus: CompactStorageOwnerStatusExternalUnsupported,
+		},
+		{
+			name:           "cached wrapper owner active writer",
+			log:            compactStorageMatrixCachedLeafPageLog{},
+			lifecycle:      CompactStorageLifecycleActiveWriter,
+			wantOwner:      CompactStorageLeafPageLogOwnerCachedWrapper,
+			wantStatus:     CompactStorageOwnerStatusLiveWriterFailClosed,
+			wantQuiescence: true,
+		},
+		{
+			name:           "cached wrapper owner quiesced maintenance",
+			log:            compactStorageMatrixCachedLeafPageLog{},
+			lifecycle:      CompactStorageLifecycleQuiescedMaintenance,
+			wantOwner:      CompactStorageLeafPageLogOwnerCachedWrapper,
+			wantStatus:     CompactStorageOwnerStatusBlockingBug,
+			wantQuiescence: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := compactStorageClassifyLeafPageLogOwner(tt.log, tt.lifecycle)
+			if got.OwnerClass != tt.wantOwner {
+				t.Fatalf("owner=%q want %q (classification=%+v)", got.OwnerClass, tt.wantOwner, got)
+			}
+			if got.Status != tt.wantStatus {
+				t.Fatalf("status=%q want %q (classification=%+v)", got.Status, tt.wantStatus, got)
+			}
+			if got.Replaceable != tt.wantReplaceable {
+				t.Fatalf("replaceable=%t want %t (classification=%+v)", got.Replaceable, tt.wantReplaceable, got)
+			}
+			if got.RequiresQuiescence != tt.wantQuiescence {
+				t.Fatalf("requires quiescence=%t want %t (classification=%+v)", got.RequiresQuiescence, tt.wantQuiescence, got)
+			}
+		})
+	}
+}
+
+func TestCompactStorageCommandWALValueLogLeafPageLogCurrentBlockingBug(t *testing.T) {
+	d, err := Open(Options{
+		Dir:                        t.TempDir(),
+		CommandWAL:                 true,
+		Durability:                 DurabilityWALOnRelaxed,
+		DisableSideStores:          true,
+		IndexOuterLeavesInValueLog: true,
+	})
+	if err != nil {
+		t.Fatalf("Open command WAL value-log outer leaves: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+	if d.leafPageLog == nil {
+		t.Fatal("expected command WAL open to install replay-inline leaf page log")
+	}
+
+	classification := compactStorageClassifyLeafPageLogOwner(d.leafPageLog, CompactStorageLifecycleExclusiveMaintenance)
+	if classification.OwnerClass != CompactStorageLeafPageLogOwnerInternalHiddenByWrapper {
+		t.Fatalf("owner=%q want %q (classification=%+v)", classification.OwnerClass, CompactStorageLeafPageLogOwnerInternalHiddenByWrapper, classification)
+	}
+	if classification.Status != CompactStorageOwnerStatusBlockingBug {
+		t.Fatalf("status=%q want %q (classification=%+v)", classification.Status, CompactStorageOwnerStatusBlockingBug, classification)
+	}
+
+	_, err = d.CompactStorage(context.Background(), CompactStorageOptions{Mode: CompactStorageExhaustive})
+	if !errors.Is(err, ErrCompactStorageLeafPageLogOwnerUnsupported) {
+		t.Fatalf("CompactStorage exhaustive error=%v, want owner unsupported", err)
+	}
+	var ownerErr *CompactStorageLeafPageLogOwnerError
+	if !errors.As(err, &ownerErr) {
+		t.Fatalf("CompactStorage exhaustive error=%T, want CompactStorageLeafPageLogOwnerError", err)
+	}
+	if ownerErr.Classification.Status != CompactStorageOwnerStatusBlockingBug {
+		t.Fatalf("error status=%q want %q", ownerErr.Classification.Status, CompactStorageOwnerStatusBlockingBug)
+	}
+}
+
+func TestCompactStorageDefaultProducedOwnerContractMatrix(t *testing.T) {
+	tests := []struct {
+		name               string
+		producerPath       string
+		owner              CompactStorageLeafPageLogOwnerClass
+		lifecycle          CompactStorageLifecycleState
+		status             CompactStorageOwnerStatus
+		quiescence         []string
+		missingFixtureWork string
+	}{
+		{
+			name:         "backend raw no installed leaf log value-log backed outer leaves",
+			producerPath: "TreeDB/db.Open with IndexOuterLeavesInValueLog and no installed leaf log",
+			owner:        CompactStorageLeafPageLogOwnerNone,
+			lifecycle:    CompactStorageLifecycleExclusiveMaintenance,
+			status:       CompactStorageOwnerStatusSupportedTarget,
+			quiescence:   []string{"checkpoint-close-drain"},
+		},
+		{
+			name:         "command_wal_relaxed default profile value-log backed outer leaves",
+			producerPath: "treedb.OptionsFor(ProfileCommandWALRelaxed)",
+			owner:        CompactStorageLeafPageLogOwnerInternalHiddenByWrapper,
+			lifecycle:    CompactStorageLifecycleQuiescedMaintenance,
+			status:       CompactStorageOwnerStatusBlockingBug,
+			quiescence:   []string{"checkpoint-close-drain", "command-wal-cleanup"},
+		},
+		{
+			name:               "public cached wrapper value-log backed outer leaves",
+			producerPath:       "treedb.Open cached wrapper",
+			owner:              CompactStorageLeafPageLogOwnerCachedWrapper,
+			lifecycle:          CompactStorageLifecycleQuiescedMaintenance,
+			status:             CompactStorageOwnerStatusBlockingBug,
+			quiescence:         []string{"background-flush-apply-workers", "checkpoint-close-drain", "cached-backlog"},
+			missingFixtureWork: "cached exhaustive compact needs explicit quiesced owner handoff or unwrap fixture before it can be marked supported-target",
+		},
+		{
+			name:         "treedb raw command WAL maintenance path",
+			producerPath: "TreeDB/cmd/treemap compact -rw -mode exhaustive over command-WAL raw dir",
+			owner:        CompactStorageLeafPageLogOwnerInternalHiddenByWrapper,
+			lifecycle:    CompactStorageLifecycleExclusiveMaintenance,
+			status:       CompactStorageOwnerStatusBlockingBug,
+			quiescence:   []string{"checkpoint-close-drain", "command-wal-cleanup"},
+		},
+		{
+			name:               "ordered-root value-log backed outer leaves",
+			producerPath:       "ordered-root route matrix",
+			owner:              CompactStorageLeafPageLogOwnerCachedWrapper,
+			lifecycle:          CompactStorageLifecycleQuiescedMaintenance,
+			status:             CompactStorageOwnerStatusBlockingBug,
+			quiescence:         []string{"background-flush-apply-workers", "checkpoint-close-drain", "ordered-root-publishers", "cached-backlog"},
+			missingFixtureWork: "ordered-root route fixtures are owned by sibling #3021/#3032; #3048 records expected compact owner classification only",
+		},
+	}
+
+	coveredQuiescence := make(map[string]bool)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.producerPath == "" {
+				t.Fatal("producer path must be recorded")
+			}
+			if tt.owner == "" || tt.lifecycle == "" || tt.status == "" {
+				t.Fatalf("incomplete contract row: %+v", tt)
+			}
+			if tt.status == CompactStorageOwnerStatusBlockingBug && tt.missingFixtureWork == "" &&
+				tt.owner != CompactStorageLeafPageLogOwnerInternalHiddenByWrapper {
+				t.Fatalf("blocking bug row without fixture/design work: %+v", tt)
+			}
+			for _, dimension := range tt.quiescence {
+				coveredQuiescence[dimension] = true
+			}
+		})
+	}
+	for _, required := range []string{
+		"background-flush-apply-workers",
+		"checkpoint-close-drain",
+		"ordered-root-publishers",
+		"cached-backlog",
+		"command-wal-cleanup",
+	} {
+		if !coveredQuiescence[required] {
+			t.Fatalf("missing quiescence dimension %q", required)
+		}
+	}
+}

--- a/TreeDB/db/compact_storage_test.go
+++ b/TreeDB/db/compact_storage_test.go
@@ -3,11 +3,11 @@ package db
 import (
 	"bytes"
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"reflect"
 	"runtime"
-	"strings"
 	"testing"
 	"time"
 
@@ -1452,8 +1452,15 @@ func TestCompactStorageExhaustiveRefusesExternalLeafPageLog(t *testing.T) {
 	writeLeafGenerationKeys(t, d, "current", 8, 'x')
 
 	_, err := d.CompactStorage(context.Background(), CompactStorageOptions{Mode: CompactStorageExhaustive})
-	if err == nil || !strings.Contains(err.Error(), "internally-owned leaf page log") {
-		t.Fatalf("CompactStorage exhaustive with external leaf log error=%v, want ownership error", err)
+	if !errors.Is(err, ErrCompactStorageLeafPageLogOwnerUnsupported) {
+		t.Fatalf("CompactStorage exhaustive with external leaf log error=%v, want owner unsupported", err)
+	}
+	var ownerErr *CompactStorageLeafPageLogOwnerError
+	if !errors.As(err, &ownerErr) {
+		t.Fatalf("CompactStorage exhaustive error=%T, want CompactStorageLeafPageLogOwnerError", err)
+	}
+	if ownerErr.Classification.Status != CompactStorageOwnerStatusExternalUnsupported {
+		t.Fatalf("owner status=%q want %q", ownerErr.Classification.Status, CompactStorageOwnerStatusExternalUnsupported)
 	}
 }
 


### PR DESCRIPTION
Refs #3048.

## Summary

- adds typed exhaustive compact leaf-page-log owner status categories: supported-target, live-writer fail-closed, external-owner unsupported, and blocking-bug
- replaces the string-only exhaustive compact leaf-log ownership failure with a typed error carrying the owner classification while preserving the existing error text
- exposes a narrow read-only owner-classification helper for backend/public test scaffolding; lifecycle inputs are modeled contract categories, not runtime proof of active writer or quiescence
- adds a DB-package owner/lifecycle matrix covering no installed leaf log, direct command-WAL replay-inline, record-length/lane wrappers, standalone caller-owned leaf logs with lane/RID/compression variants, cached-like wrappers, active writer, and quiesced/exclusive maintenance states
- fixture-proves the canonical public/default `treedb.Open(treedb.OptionsFor(ProfileCommandWALRelaxed))` write-produced shape as `cached/wrapper owner`, currently `blocking-bug` until #3049 implements explicit cached owner handoff/unwrap
- keeps the raw backend command-WAL + index-vlog reproduction as a separate raw-backend scope, classified as wrapper-hidden replay-inline/internal owner `blocking-bug`
- records default-produced DB directory contract rows for backend raw, public command_wal_relaxed, cached wrapper, treedb raw, and ordered-root paths, with exact missing fixture/design work for cached and ordered-root ownership handoff

## Design notes

This is classification/test scaffolding only. It does not make exhaustive compact broadly replace cached/wrapper owners or lane-wrapped command-WAL owners. The public/default command_wal_relaxed path is now fixture-proven as cached/wrapper, not the raw backend replay-inline wrapper shape. The raw backend command-WAL limitation remains fail-closed and is explicitly labeled `blocking-bug` for raw maintenance paths.

The #3047 parent body did not need a design-lane update; this PR body carries the contract delta.

## Validation

- `GOWORK=off go test ./TreeDB/db -run 'Compact|LeafPageLog|ValueLog'`
- `GOWORK=off go test ./TreeDB/caching -run 'LeafPageLog|Compact|Checkpoint|Close|ValueLog|Flush'`
- `GOWORK=off go test ./TreeDB -run 'Compact|LeafPageLog|ValueLog'`
- `make fmt`
- `git diff --check`

## Benchmarks

Not run. This PR only adds owner classification/error scaffolding and tests; no benchmark/report guardrail code or broad compact behavior was touched.