### PR TITLE
Optimize semantic-stream retained payload inserts

### DIFF
--- a/TreeDB/collections/column_reconstruction.go
+++ b/TreeDB/collections/column_reconstruction.go
@@ -47,12 +47,9 @@ func columnRetainedPayloadJSONFromJSONDocument(cfg ColumnStoreConfig, document [
 	case ColumnRetainedPayloadNone:
 		return []byte("{}"), nil
 	case ColumnRetainedPayloadNonColumn:
-		obj, err := decodeColumnJSONObject(document)
+		obj, err := columnRetainedPayloadJSONObjectFromJSONDocument(cfg, document)
 		if err != nil {
 			return nil, err
-		}
-		for _, col := range cfg.Columns {
-			deleteColumnJSONPath(obj, col.Path)
 		}
 		out, err := json.Marshal(obj)
 		if err != nil {
@@ -61,6 +58,24 @@ func columnRetainedPayloadJSONFromJSONDocument(cfg ColumnStoreConfig, document [
 		return out, nil
 	default:
 		return nil, fmt.Errorf("collections: unsupported retained payload policy %q", cfg.RetainedPayload)
+	}
+}
+
+func columnRetainedPayloadJSONObjectFromJSONDocument(cfg ColumnStoreConfig, document []byte) (map[string]any, error) {
+	switch cfg.RetainedPayload {
+	case ColumnRetainedPayloadNone:
+		return map[string]any{}, nil
+	case ColumnRetainedPayloadNonColumn:
+		obj, err := decodeColumnJSONObject(document)
+		if err != nil {
+			return nil, err
+		}
+		for _, col := range cfg.Columns {
+			deleteColumnJSONPath(obj, col.Path)
+		}
+		return obj, nil
+	default:
+		return nil, fmt.Errorf("collections: retained payload policy %q cannot produce object payload", cfg.RetainedPayload)
 	}
 }
 

--- a/TreeDB/collections/column_retained_payload_audit_test.go
+++ b/TreeDB/collections/column_retained_payload_audit_test.go
@@ -630,6 +630,54 @@ func TestColumnRetainedSemanticStreamV1StoredBlockZSTDWrapper2662(t *testing.T) 
 	}
 }
 
+func TestColumnRetainedSemanticStreamV1InsertFastPathMatchesRetainedJSONPipeline3067(t *testing.T) {
+	cfg := jsonbenchRetainedPayloadAuditConfig2382(true)
+	cfg.RetainedPayloadEncoding = ColumnRetainedPayloadEncodingSemanticStreamV1
+	documents := [][]byte{
+		[]byte(`{"time_us":1,"kind":"commit","did":"did:plc:one","commit":{"operation":"create","collection":"app.bsky.feed.post","rkey":"r-0001","record":{"$type":"app.bsky.feed.post","text":"hello","tags":["one",{"nested":true}],"empty":{}}},"payload":{"body":"kept","count":17}}`),
+		[]byte(`{"time_us":2,"kind":"commit","did":"did:plc:two","commit":{"operation":"update","collection":"app.bsky.feed.post","rkey":"r-0002","record":{"$type":"app.bsky.feed.post","text":"world","facets":[{"index":{"byteStart":0,"byteEnd":5}}]}},"identity":{"seq":12,"handle":"example.test"}}`),
+	}
+
+	prepared, err := prepareColumnRetainedPayloadInsertBatchStorageDocuments(*cfg, documents, nil)
+	if err != nil {
+		t.Fatalf("prepare semantic-stream-v1 documents: %v", err)
+	}
+	if prepared.semanticStreamBlocks == nil {
+		t.Fatal("prepare semantic-stream-v1 documents did not return block table")
+	}
+	defer resetCollectionRunTable(prepared.semanticStreamBlocks)
+
+	iter := prepared.semanticStreamBlocks.NewIterator(nil, nil)
+	defer func() { _ = iter.Close() }()
+	if !iter.Valid() {
+		t.Fatal("semantic-stream-v1 block table is empty")
+	}
+	gotBlock := append([]byte(nil), iter.UnsafeValue()...)
+	iter.Next()
+	if iter.Valid() {
+		t.Fatal("semantic-stream-v1 block table has more than one block")
+	}
+	if err := iter.Error(); err != nil {
+		t.Fatalf("iterate semantic-stream-v1 block table: %v", err)
+	}
+
+	retainedJSON := make([][]byte, len(documents))
+	for i, document := range documents {
+		retained, err := columnRetainedPayloadJSONFromJSONDocument(*cfg, document)
+		if err != nil {
+			t.Fatalf("legacy retained JSON row %d: %v", i, err)
+		}
+		retainedJSON[i] = retained
+	}
+	wantBlock, err := encodeColumnRetainedSemanticStreamV1Block(retainedJSON)
+	if err != nil {
+		t.Fatalf("legacy semantic-stream-v1 block: %v", err)
+	}
+	if !bytes.Equal(gotBlock, wantBlock) {
+		t.Fatalf("semantic-stream-v1 fast path block mismatch: got %d bytes want %d", len(gotBlock), len(wantBlock))
+	}
+}
+
 func TestColumnRetainedSemanticStreamV1StoredBlockZSTDRawLimitFallback2662(t *testing.T) {
 	raw, err := encodeColumnRetainedSemanticStreamV1RawBlock([][]byte{
 		[]byte(`{"payload":"same","commit":{"record":{"text":"same retained body"}}}`),

--- a/TreeDB/collections/column_retained_semantic_stream.go
+++ b/TreeDB/collections/column_retained_semantic_stream.go
@@ -289,23 +289,27 @@ func prepareColumnRetainedSemanticStreamV1StorageDocuments(cfg ColumnStoreConfig
 		if end > len(documents) {
 			end = len(documents)
 		}
-		retainedJSON := make([][]byte, end-start)
-		for i := start; i < end; i++ {
-			retained, err := columnRetainedPayloadJSONFromJSONDocument(cfg, documents[i])
+		rows := end - start
+		streams := make(map[string]*columnRetainedSemanticStreamPath)
+		for row, i := 0, start; i < end; row, i = row+1, i+1 {
+			retained, err := columnRetainedPayloadJSONObjectFromJSONDocument(cfg, documents[i])
 			if err != nil {
 				resetCollectionRunTable(blockTable)
 				return columnRetainedPayloadStorageDocuments{}, err
 			}
-			retainedJSON[i-start] = retained
+			if err := collectColumnRetainedSemanticStreamObjectPaths(retained, nil, uint64(row), streams); err != nil {
+				resetCollectionRunTable(blockTable)
+				return columnRetainedPayloadStorageDocuments{}, fmt.Errorf("collections: semantic-stream-v1 retained row %d: %w", row, err)
+			}
 		}
-		block, err := encodeColumnRetainedSemanticStreamV1Block(retainedJSON)
+		block, err := encodeColumnRetainedSemanticStreamV1BlockFromStreams(rows, streams)
 		if err != nil {
 			resetCollectionRunTable(blockTable)
 			return columnRetainedPayloadStorageDocuments{}, err
 		}
 		sum := sha256.Sum256(block)
 		blockKey := append([]byte(nil), sum[:]...)
-		for i := range retainedJSON {
+		for i := 0; i < rows; i++ {
 			out.documents[start+i] = encodeColumnRetainedSemanticStreamV1Locator(blockKey, uint64(i))
 		}
 		setCollectionRunValue(blockTable, blockKey, block)
@@ -776,14 +780,32 @@ func encodeColumnRetainedSemanticStreamV1RawBlock(documents [][]byte) ([]byte, e
 			return nil, fmt.Errorf("collections: semantic-stream-v1 retained row %d: %w", row, err)
 		}
 	}
+	return encodeColumnRetainedSemanticStreamV1RawBlockFromStreams(len(documents), streams)
+}
+
+func encodeColumnRetainedSemanticStreamV1BlockFromStreams(rows int, streams map[string]*columnRetainedSemanticStreamPath) ([]byte, error) {
+	raw, err := encodeColumnRetainedSemanticStreamV1RawBlockFromStreams(rows, streams)
+	if err != nil {
+		return nil, err
+	}
+	return encodeColumnRetainedSemanticStreamV1StoredBlock(raw)
+}
+
+func encodeColumnRetainedSemanticStreamV1RawBlockFromStreams(rows int, streams map[string]*columnRetainedSemanticStreamPath) ([]byte, error) {
+	if rows <= 0 {
+		return nil, errors.New("collections: semantic-stream-v1 retained block requires at least one row")
+	}
+	if err := validateColumnRetainedSemanticStreamV1BlockRows(uint64(rows)); err != nil {
+		return nil, err
+	}
 	keys := make([]string, 0, len(streams))
 	for key := range streams {
 		keys = append(keys, key)
 	}
 	sort.Strings(keys)
-	out := make([]byte, 0, len(columnRetainedSemanticStreamV1BlockMagic)+len(documents)*16)
+	out := make([]byte, 0, len(columnRetainedSemanticStreamV1BlockMagic)+rows*16)
 	out = append(out, columnRetainedSemanticStreamV1BlockMagic...)
-	out = binary.AppendUvarint(out, uint64(len(documents)))
+	out = binary.AppendUvarint(out, uint64(rows))
 	out = binary.AppendUvarint(out, uint64(len(keys)))
 	for _, key := range keys {
 		stream := streams[key]
@@ -924,6 +946,45 @@ func collectColumnRetainedSemanticStreamPaths(raw json.RawMessage, path []string
 		}
 		appendColumnRetainedSemanticStreamValue(path, row, trimmed, streams)
 	}
+	return nil
+}
+
+func collectColumnRetainedSemanticStreamObjectPaths(obj map[string]any, path []string, row uint64, streams map[string]*columnRetainedSemanticStreamPath) error {
+	if len(obj) == 0 {
+		if len(path) > 0 {
+			return appendColumnRetainedSemanticStreamJSONValue(path, row, obj, streams)
+		}
+		return nil
+	}
+	keys := make([]string, 0, len(obj))
+	for key := range obj {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		nextPath := append(append([]string(nil), path...), key)
+		if err := collectColumnRetainedSemanticStreamAnyPaths(obj[key], nextPath, row, streams); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func collectColumnRetainedSemanticStreamAnyPaths(value any, path []string, row uint64, streams map[string]*columnRetainedSemanticStreamPath) error {
+	switch typed := value.(type) {
+	case map[string]any:
+		return collectColumnRetainedSemanticStreamObjectPaths(typed, path, row, streams)
+	default:
+		return appendColumnRetainedSemanticStreamJSONValue(path, row, typed, streams)
+	}
+}
+
+func appendColumnRetainedSemanticStreamJSONValue(path []string, row uint64, value any, streams map[string]*columnRetainedSemanticStreamPath) error {
+	raw, err := json.Marshal(value)
+	if err != nil {
+		return fmt.Errorf("collections: encode semantic-stream-v1 retained value: %w", err)
+	}
+	appendColumnRetainedSemanticStreamValue(path, row, raw, streams)
 	return nil
 }
 

--- a/TreeDB/collections/typed_storage_naming_test.go
+++ b/TreeDB/collections/typed_storage_naming_test.go
@@ -379,7 +379,7 @@ var typedStorageLegacyNameAllowlist = []typedStorageLegacyNameAllowlistEntry{
 	{path: "TreeDB/collections/column_publish_write_path_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 163, occurrences: 183},
 	{path: "TreeDB/collections/column_query_plan.go", classification: typedStorageLegacyCompatibility, matchingLines: 43, occurrences: 43},
 	{path: "TreeDB/collections/column_query_plan_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 56, occurrences: 68},
-	{path: "TreeDB/collections/column_reconstruction.go", classification: typedStorageLegacyCompatibility, matchingLines: 56, occurrences: 71},
+	{path: "TreeDB/collections/column_reconstruction.go", classification: typedStorageLegacyCompatibility, matchingLines: 57, occurrences: 72},
 	{path: "TreeDB/collections/column_reconstruction_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 27, occurrences: 31},
 	{path: "TreeDB/collections/column_retained_payload_audit.go", classification: typedStorageLegacyCompatibility, matchingLines: 8, occurrences: 8},
 	{path: "TreeDB/collections/column_retained_payload_audit_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 29, occurrences: 30},


### PR DESCRIPTION
Refs #3067
Related #3070

## Summary

This is a first load-path slice for the JSONBench full-retained column-store insert/load gap. It keeps the existing `semantic-stream-v1` on-disk block format and persistent value-log semantics unchanged, but avoids the extra retained JSON marshal/unmarshal pass during `InsertBatch` preparation.

Previously the full-retained semantic-stream path did:

1. decode JSON document into object
2. delete declared column paths
3. marshal retained object to JSON
4. unmarshal that retained JSON again into raw semantic-stream paths

This PR collects semantic-stream paths directly from the retained object produced in step 2, then encodes the same stored block bytes.

## Scope Classification

Realigned tracker scope: this PR improves insert/load preparation only.

- Improves: semantic-stream retained payload `InsertBatch` preparation time.
- Does not measure or claim: broad TreeDB SQL superiority, `one_shot_end_to_end`, `first_touch_after_open`, `no_aggregate_metadata` scans, arbitrary-expression scans, or ClickHouse raw-scan parity.
- Hot prepared q1-q5 metadata-backed timings remain secondary evidence under #3000/#3001/#3070.
- Storage effect: intentionally unchanged in the measured 100k before/after.
- Closure effect: this does not close #3067, #3001, #3000, or #3070.

## Evidence

Tests:

- `go test ./TreeDB/collections -run 'Test.*(RetainedPayload|SemanticStream|Reconstruction).*' -count=1`
- `go test ./TreeDB/collections ./cmd/treedb_retained_payload_audit -count=1`
- `git diff --check`

Regression coverage:

- Adds `TestColumnRetainedSemanticStreamV1InsertFastPathMatchesRetainedJSONPipeline3067`, which verifies the new insert fast path produces byte-identical semantic-stream stored blocks compared with the prior retained-JSON pipeline.

100k full-retained JSONBench before/after on this machine:

| run | insert | load wall | durable storage | value_vlog |
|---|---:|---:|---:|---:|
| baseline `/tmp/jsonbench_treedb_full_100k_baseline_20260625_135809` | `3.114781914s` | `3.470748708s` | `17,565,485` | `9,751,620` |
| this PR `/tmp/jsonbench_treedb_full_100k_fastpath_20260625_140210` | `2.528072251s` | `2.863400292s` | `17,565,485` | `9,751,620` |

Delta: insert `18.8%` faster, load wall `17.5%` faster. Storage is intentionally unchanged.

1M full-retained post-patch smoke:

- Artifact: `/tmp/jsonbench_treedb_full_1m_fastpath_20260625_140620/report.md`
- Result: `/tmp/jsonbench_treedb_full_1m_fastpath_20260625_140620/rows1000000_column-store-full-prepared_json_full_all/result.json`
- Insert: `25.041744544s`
- Load wall: `28.188710208s`
- Durable storage: `137,488,386` bytes (`131.12 MiB`)
- `value_vlog`: `97,309,293` bytes
- q1/q2/q3/q4/q4a/q4b/q5 all remain on `column_physical` with no fallback in the report.

Reconstruction smoke:

- Artifact: `/tmp/jsonbench_treedb_reconstruction_smoke_fastpath_20260625_140312/report.md`
- Source/stored canonical JSON hashes match for 6-row `column-store-full-prepared` with `VALIDATE_RECONSTRUCTION=1`.

## Review And CI State

- Internal read-only review found no material issues in the four-file diff.
- CodeRabbit posted only a rate-limit notice; it did not provide substantive findings.
- Latest-head CI must be rerun after the branch is realigned with current `origin/main` because `main` advanced after the first green run.

## Remaining Work

The next #3067 slice should target retained block density/layout, codec strategy, or the next measured insert/load bottleneck. The separate #3070 child owns one-shot/no-metadata benchmark support before #3000/#3001 can make a primary SQL-style performance claim.
