### PR TITLE
TreeDB: enable nullable dense q1 group counts

### DIFF
--- a/TreeDB/collections/column_physical_typed_column_1947_test.go
+++ b/TreeDB/collections/column_physical_typed_column_1947_test.go
@@ -201,7 +201,7 @@ func TestColumnPhysicalJSONBenchTypedColumnPartNullableFullDataMissingStrings216
 	defer closeFn()
 
 	q1 := ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCount, GroupColumn: "event"}
-	q1Result := runNullableFullDataQuery2165(t, collection, "q1", q1, len(docs), 0, 0, len(docs))
+	q1Result := runNullableFullDataDenseQ1Query3075(t, collection, "q1", q1, len(docs), 0, 0, len(docs))
 	if got, want := columnPhysicalGroupCountMap2165(q1Result.Groups), map[string]int{"": 2, "app.bsky.feed.post": 4}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("q1 groups=%v want %v raw=%+v", got, want, q1Result.Groups)
 	}
@@ -772,6 +772,35 @@ func runNullableFullDataQuery2165(tb testing.TB, collection *Collection, name st
 	return direct
 }
 
+func runNullableFullDataDenseQ1Query3075(tb testing.TB, collection *Collection, name string, req ColumnPhysicalQueryRequest, wantRows, wantPredicates, wantMatched, wantReduce int) ColumnPhysicalQueryResult {
+	tb.Helper()
+	direct, err := collection.RunColumnPhysicalQuery(req)
+	if err != nil {
+		tb.Fatalf("RunColumnPhysicalQuery(%s): %v", name, err)
+	}
+	assertColumnPhysicalJSONBenchTypedColumnDiagnostics1947(tb, name+" direct", direct.Diagnostics, wantRows, wantPredicates, wantMatched, wantReduce)
+	assertNullableFullDataDenseQ1Diagnostics3075(tb, name+" direct", direct.Diagnostics)
+
+	runner, err := collection.PrepareColumnPhysicalQuery(req)
+	if err != nil {
+		tb.Fatalf("PrepareColumnPhysicalQuery(%s): %v", name, err)
+	}
+	defer func() { _ = runner.Close() }()
+	var prepared ColumnPhysicalQueryResult
+	for run := 0; run < 2; run++ {
+		prepared, err = runner.Run()
+		if err != nil {
+			tb.Fatalf("prepared %s run %d: %v", name, run, err)
+		}
+		assertColumnPhysicalJSONBenchTypedColumnDiagnostics1947(tb, fmt.Sprintf("%s prepared %d", name, run), prepared.Diagnostics, 0, wantPredicates, wantMatched, wantReduce)
+		assertNullableFullDataDenseQ1Diagnostics3075(tb, fmt.Sprintf("%s prepared %d", name, run), prepared.Diagnostics)
+		if !reflect.DeepEqual(prepared.Groups, direct.Groups) {
+			tb.Fatalf("%s prepared run %d groups=%+v want direct %+v", name, run, prepared.Groups, direct.Groups)
+		}
+	}
+	return direct
+}
+
 func runNullableFullDataDenseQ2Query2165(tb testing.TB, collection *Collection, name string, req ColumnPhysicalQueryRequest, wantRows, wantPredicates, wantMatched, wantReduce int) ColumnPhysicalQueryResult {
 	tb.Helper()
 	direct, err := collection.RunColumnPhysicalQuery(req)
@@ -858,6 +887,19 @@ func assertNullableFullDataGenericDiagnostics2165(tb testing.TB, label string, d
 	}
 	if diag.DecodedBlocks == 0 || diag.DecodedPayloadBytes == 0 {
 		tb.Fatalf("%s nullable full-data query did not report typed-column decode work: %+v", label, diag)
+	}
+}
+
+func assertNullableFullDataDenseQ1Diagnostics3075(tb testing.TB, label string, diag ColumnPhysicalQueryDiagnostics) {
+	tb.Helper()
+	if !diag.DenseGroupCountUsed || diag.DenseGroupCountDistinctUsed || diag.DenseGroupHourCountUsed || diag.DenseInt64SpanUsed || diag.SortedGroupedDistinctUsed || diag.TimeOrderTopKUsed {
+		tb.Fatalf("%s diagnostics=%+v want only dense q1 group-count fast path", label, diag)
+	}
+	if diag.SortKeyPrefixPlanned || diag.SortKeyMarkChecks != 0 || diag.SortKeyMarkSkips != 0 {
+		tb.Fatalf("%s dense q1 diagnostics used sort-key pruning: %+v", label, diag)
+	}
+	if diag.DecodedBlocks == 0 || diag.DecodedPayloadBytes == 0 {
+		tb.Fatalf("%s dense q1 diagnostics did not report typed-column decode work: %+v", label, diag)
 	}
 }
 

--- a/TreeDB/collections/column_physical_typed_column_1947_test.go
+++ b/TreeDB/collections/column_physical_typed_column_1947_test.go
@@ -243,6 +243,21 @@ func TestColumnPhysicalJSONBenchTypedColumnPartNullableFullDataMissingStrings216
 	}
 }
 
+func TestColumnPhysicalJSONBenchTypedColumnPartNullableFullDataAllMissingQ13075(t *testing.T) {
+	docs := []string{
+		`{"time_us":1000,"kind":"commit","did":"did_a","commit":{"operation":"create"}}`,
+		`{"time_us":2000}`,
+	}
+	_, collection, closeFn := openColumnPhysicalJSONBenchNullableFullDataFixture2165(t, docs)
+	defer closeFn()
+
+	q1 := ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCount, GroupColumn: "event"}
+	q1Result := runNullableFullDataDenseQ1Query3075(t, collection, "q1 all missing", q1, len(docs), 0, 0, len(docs))
+	if got, want := columnPhysicalGroupCountMap2165(q1Result.Groups), map[string]int{"": len(docs)}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("q1 all-missing groups=%v want %v raw=%+v", got, want, q1Result.Groups)
+	}
+}
+
 func TestColumnPhysicalJSONBenchTypedColumnPartNullableFullDataTopKFastPaths2878(t *testing.T) {
 	docs := []string{
 		`{"time_us":1000,"kind":"commit","did":"did_a","commit":{"operation":"create","collection":"app.bsky.feed.post"}}`,

--- a/TreeDB/collections/column_physical_typed_column_query.go
+++ b/TreeDB/collections/column_physical_typed_column_query.go
@@ -41,9 +41,10 @@ type columnTypedColumnPhysicalQueryPlan struct {
 }
 
 type columnTypedColumnDenseGroupCountPart struct {
-	Cardinality      int
-	DictionaryByCode map[int64]string
-	Codes            []uint32
+	Cardinality int
+	Dictionary  []string
+	Codes       []uint32
+	Valid       []bool
 }
 
 type columnTypedColumnDensePredicatePart struct {
@@ -547,8 +548,8 @@ func buildColumnTypedColumnDenseGroupCountSummary(parts []columnTypedColumnPhysi
 		if dense == nil {
 			return nil, fmt.Errorf("collections: dense typed-column group-count missing prepared part %d", partIdx)
 		}
-		if dense.Cardinality == 0 && len(dense.Codes) != 0 {
-			return nil, fmt.Errorf("collections: dense typed-column group-count part %d has empty dictionary", partIdx)
+		if err := validateColumnTypedColumnDenseGroupCountPart(dense, partIdx); err != nil {
+			return nil, err
 		}
 		if cap(localCounts) < dense.Cardinality {
 			localCounts = make([]int, dense.Cardinality)
@@ -556,7 +557,12 @@ func buildColumnTypedColumnDenseGroupCountSummary(parts []columnTypedColumnPhysi
 			localCounts = localCounts[:dense.Cardinality]
 			clear(localCounts)
 		}
+		missingCount := 0
 		for rowIdx, code := range dense.Codes {
+			if !columnTypedColumnDenseCodeValid(dense.Valid, rowIdx) {
+				missingCount++
+				continue
+			}
 			localIdx, ok := columnDictionaryCodeIndex(code, len(localCounts))
 			if !ok {
 				return nil, fmt.Errorf("collections: dense typed-column group-count part %d code[%d]=%d outside cardinality=%d", partIdx, rowIdx, code, len(localCounts))
@@ -564,11 +570,14 @@ func buildColumnTypedColumnDenseGroupCountSummary(parts []columnTypedColumnPhysi
 			localCounts[localIdx]++
 		}
 		reduceRows += len(dense.Codes)
+		if missingCount != 0 {
+			counts[""] += missingCount
+		}
 		for localCode, count := range localCounts {
 			if count == 0 {
 				continue
 			}
-			key, ok := dense.DictionaryByCode[int64(localCode)]
+			key, ok := columnTypedColumnDenseGroupCountDictionaryValue(dense, localCode)
 			if !ok {
 				return nil, fmt.Errorf("collections: dense typed-column group-count part %d dictionary missing local code %d", partIdx, localCode)
 			}
@@ -1456,10 +1465,10 @@ func (r *columnTypedColumnPhysicalQueryRunner) runLatestVisibleDenseGroupCount(v
 			diag.DenseGroupCountUsed = true
 			return ColumnPhysicalQueryResult{Diagnostics: diag}, fmt.Errorf("collections: dense typed-column group-count missing prepared part %d", partIdx)
 		}
-		if dense.Cardinality == 0 && len(dense.Codes) != 0 {
+		if err := validateColumnTypedColumnDenseGroupCountPart(dense, partIdx); err != nil {
 			diag := r.latestVisibleDiagnostics(view, req, state, visibilityBytes, visibilityNanos, rowsScanned, 0, reduceRows, time.Since(start).Nanoseconds())
 			diag.DenseGroupCountUsed = true
-			return ColumnPhysicalQueryResult{Diagnostics: diag}, fmt.Errorf("collections: dense typed-column group-count part %d has empty dictionary", partIdx)
+			return ColumnPhysicalQueryResult{Diagnostics: diag}, err
 		}
 		if cap(r.denseLocalCounts) < dense.Cardinality {
 			r.denseLocalCounts = make([]int, dense.Cardinality)
@@ -1467,9 +1476,15 @@ func (r *columnTypedColumnPhysicalQueryRunner) runLatestVisibleDenseGroupCount(v
 			r.denseLocalCounts = r.denseLocalCounts[:dense.Cardinality]
 			clear(r.denseLocalCounts)
 		}
+		missingCount := 0
 		for rowIdx, code := range dense.Codes {
 			rowsScanned++
 			if !visibility.rowVisible(rowIdx) {
+				continue
+			}
+			if !columnTypedColumnDenseCodeValid(dense.Valid, rowIdx) {
+				missingCount++
+				reduceRows++
 				continue
 			}
 			localIdx, ok := columnDictionaryCodeIndex(code, len(r.denseLocalCounts))
@@ -1481,11 +1496,14 @@ func (r *columnTypedColumnPhysicalQueryRunner) runLatestVisibleDenseGroupCount(v
 			r.denseLocalCounts[localIdx]++
 			reduceRows++
 		}
+		if missingCount != 0 {
+			r.denseGroupCounts[""] += missingCount
+		}
 		for localCode, count := range r.denseLocalCounts {
 			if count == 0 {
 				continue
 			}
-			key, ok := dense.DictionaryByCode[int64(localCode)]
+			key, ok := columnTypedColumnDenseGroupCountDictionaryValue(dense, localCode)
 			if !ok {
 				diag := r.latestVisibleDiagnostics(view, req, state, visibilityBytes, visibilityNanos, rowsScanned, 0, reduceRows, time.Since(start).Nanoseconds())
 				diag.DenseGroupCountUsed = true
@@ -1757,7 +1775,7 @@ func columnTypedColumnPhysicalQueryShapeCanUseDenseGroupCount(req ColumnPhysical
 }
 
 func columnTypedColumnPhysicalQueryUseDenseGroupCount(plan columnTypedColumnPhysicalQueryPlan, req ColumnPhysicalQueryRequest) bool {
-	return !plan.NullableStringValues && plan.DenseGroupCount && columnTypedColumnPhysicalQueryShapeCanUseDenseGroupCount(req)
+	return plan.DenseGroupCount && columnTypedColumnPhysicalQueryShapeCanUseDenseGroupCount(req)
 }
 
 func columnTypedColumnPhysicalQueryShapeCanUseDenseGroupCountDistinct(req ColumnPhysicalQueryRequest) bool {
@@ -2220,10 +2238,10 @@ func (r *columnTypedColumnPhysicalQueryRunner) runDenseGroupCount(view columnPhy
 			diag.DenseGroupCountUsed = true
 			return ColumnPhysicalQueryResult{Diagnostics: diag}, fmt.Errorf("collections: dense typed-column group-count missing prepared part %d", partIdx)
 		}
-		if dense.Cardinality == 0 && len(dense.Codes) != 0 {
+		if err := validateColumnTypedColumnDenseGroupCountPart(dense, partIdx); err != nil {
 			diag := r.diagnostics(view, req, rowsScanned, 0, rowsScanned, time.Since(start).Nanoseconds())
 			diag.DenseGroupCountUsed = true
-			return ColumnPhysicalQueryResult{Diagnostics: diag}, fmt.Errorf("collections: dense typed-column group-count part %d has empty dictionary", partIdx)
+			return ColumnPhysicalQueryResult{Diagnostics: diag}, err
 		}
 		if cap(r.denseLocalCounts) < dense.Cardinality {
 			r.denseLocalCounts = make([]int, dense.Cardinality)
@@ -2231,7 +2249,12 @@ func (r *columnTypedColumnPhysicalQueryRunner) runDenseGroupCount(view columnPhy
 			r.denseLocalCounts = r.denseLocalCounts[:dense.Cardinality]
 			clear(r.denseLocalCounts)
 		}
+		missingCount := 0
 		for rowIdx, code := range dense.Codes {
+			if !columnTypedColumnDenseCodeValid(dense.Valid, rowIdx) {
+				missingCount++
+				continue
+			}
 			localIdx, ok := columnDictionaryCodeIndex(code, len(r.denseLocalCounts))
 			if !ok {
 				diag := r.diagnostics(view, req, rowsScanned, 0, rowsScanned, time.Since(start).Nanoseconds())
@@ -2241,11 +2264,14 @@ func (r *columnTypedColumnPhysicalQueryRunner) runDenseGroupCount(view columnPhy
 			r.denseLocalCounts[localIdx]++
 		}
 		rowsScanned += len(dense.Codes)
+		if missingCount != 0 {
+			r.denseGroupCounts[""] += missingCount
+		}
 		for localCode, count := range r.denseLocalCounts {
 			if count == 0 {
 				continue
 			}
-			key, ok := dense.DictionaryByCode[int64(localCode)]
+			key, ok := columnTypedColumnDenseGroupCountDictionaryValue(dense, localCode)
 			if !ok {
 				diag := r.diagnostics(view, req, rowsScanned, 0, rowsScanned, time.Since(start).Nanoseconds())
 				diag.DenseGroupCountUsed = true
@@ -2269,6 +2295,26 @@ func (r *columnTypedColumnPhysicalQueryRunner) runDenseGroupCount(view columnPhy
 	finalizeColumnPhysicalQueryResultGroups(req, &result)
 	r.resultGroups = result.Groups
 	return result, nil
+}
+
+func validateColumnTypedColumnDenseGroupCountPart(dense *columnTypedColumnDenseGroupCountPart, partIdx int) error {
+	if dense.Cardinality != len(dense.Dictionary) {
+		return fmt.Errorf("collections: dense typed-column group-count part %d dictionary cardinality=%d want %d", partIdx, len(dense.Dictionary), dense.Cardinality)
+	}
+	if dense.Valid != nil && len(dense.Valid) != len(dense.Codes) {
+		return fmt.Errorf("collections: dense typed-column group-count part %d valid rows=%d want codes rows=%d", partIdx, len(dense.Valid), len(dense.Codes))
+	}
+	if dense.Cardinality == 0 && dense.Valid == nil && len(dense.Codes) != 0 {
+		return fmt.Errorf("collections: dense typed-column group-count part %d has empty dictionary", partIdx)
+	}
+	return nil
+}
+
+func columnTypedColumnDenseGroupCountDictionaryValue(dense *columnTypedColumnDenseGroupCountPart, localCode int) (string, bool) {
+	if localCode < 0 || localCode >= len(dense.Dictionary) {
+		return "", false
+	}
+	return dense.Dictionary[localCode], true
 }
 
 func columnTypedColumnDenseGroupCountDistinctBitsetLayout(groupCardinality, distinctCardinality int) (int, int, bool) {

--- a/TreeDB/collections/typed_column_adapter.go
+++ b/TreeDB/collections/typed_column_adapter.go
@@ -1315,70 +1315,9 @@ func decodeTypedColumnPhysicalQueryDenseGroupCountPart(plan columnTypedColumnPhy
 	if plan.SortKeyPrefix.Planned {
 		return columnTypedColumnPhysicalQueryPart{}, fmt.Errorf("%w: dense typed-column group-count does not support sort-key row pruning", ErrColumnQueryPlanUnsupported)
 	}
-	adapterColumn, ok, err := typedColumnStringPredicateAdapterColumn(plan.Fields, plan.GroupColumn)
+	group, decodedBytes, blocks, err := typedColumnDenseGroupCountDistinctCodeColumn(adapterPart, plan.Fields, plan.GroupColumn, summary.Rows, "group-count group")
 	if err != nil {
 		return columnTypedColumnPhysicalQueryPart{}, err
-	}
-	if !ok {
-		return columnTypedColumnPhysicalQueryPart{}, fmt.Errorf("collections: dense typed-column group-count column %q is not owned by typed_column_part", plan.GroupColumn)
-	}
-	for _, candidate := range adapterPart.Columns {
-		if candidate.Definition.Name == adapterColumn.Definition.Name {
-			adapterColumn = candidate
-			break
-		}
-	}
-	if adapterColumn.Field.Nullable || adapterColumn.Definition.Type != typedcolumn.ColumnTypeLowCardinalityCode || adapterColumn.Definition.Encoding != typedcolumn.EncodingLowCardinalityUint32 {
-		return columnTypedColumnPhysicalQueryPart{}, fmt.Errorf("%w: dense typed-column group-count column %q is not a non-null low-cardinality string", ErrColumnQueryPlanUnsupported, plan.GroupColumn)
-	}
-	partColumn, ok := adapterPart.Part.Columns[adapterColumn.Definition.Name]
-	if !ok {
-		return columnTypedColumnPhysicalQueryPart{}, fmt.Errorf("collections: dense typed-column group-count missing column %q", adapterColumn.Definition.Name)
-	}
-	if partColumn.Definition.Type != typedcolumn.ColumnTypeLowCardinalityCode || partColumn.Definition.Encoding != typedcolumn.EncodingLowCardinalityUint32 || partColumn.Definition.Cardinality == 0 {
-		return columnTypedColumnPhysicalQueryPart{}, fmt.Errorf("%w: dense typed-column group-count column %q type=%s encoding=%s cardinality=%d", ErrColumnQueryPlanUnsupported, plan.GroupColumn, partColumn.Definition.Type, partColumn.Definition.Encoding, partColumn.Definition.Cardinality)
-	}
-	if uint64(int(partColumn.Definition.Cardinality)) != uint64(partColumn.Definition.Cardinality) {
-		return columnTypedColumnPhysicalQueryPart{}, fmt.Errorf("collections: dense typed-column group-count cardinality=%d exceeds host int", partColumn.Definition.Cardinality)
-	}
-	cardinality := int(partColumn.Definition.Cardinality)
-	if len(adapterColumn.ReverseDictionary) != cardinality {
-		return columnTypedColumnPhysicalQueryPart{}, fmt.Errorf("collections: dense typed-column group-count dictionary cardinality=%d want %d for column %q", len(adapterColumn.ReverseDictionary), cardinality, adapterColumn.Definition.Name)
-	}
-	for code := 0; code < cardinality; code++ {
-		if _, ok := adapterColumn.ReverseDictionary[int64(code)]; !ok {
-			return columnTypedColumnPhysicalQueryPart{}, fmt.Errorf("collections: dense typed-column group-count dictionary missing local code %d for column %q", code, adapterColumn.Definition.Name)
-		}
-	}
-	codes := make([]uint32, 0, summary.Rows)
-	var scratch []uint32
-	var reader typedcolumn.GranuleReader
-	decodedBytes := uint64(0)
-	for blockIdx, block := range partColumn.Blocks {
-		g := block.Granule
-		if g.HasMinMax {
-			if g.Min < 0 || g.Max < 0 || g.Min > g.Max || uint64(g.Max) >= uint64(cardinality) {
-				return columnTypedColumnPhysicalQueryPart{}, fmt.Errorf("collections: dense typed-column group-count block %d min/max [%d,%d] outside cardinality %d", blockIdx, g.Min, g.Max, cardinality)
-			}
-		}
-		decoded, err := reader.DecodeUint32CodesInto(scratch[:0], g)
-		if err != nil {
-			return columnTypedColumnPhysicalQueryPart{}, err
-		}
-		if len(decoded) != block.Descriptor.RowCount {
-			return columnTypedColumnPhysicalQueryPart{}, fmt.Errorf("collections: dense typed-column group-count decoded rows=%d want %d", len(decoded), block.Descriptor.RowCount)
-		}
-		for i, code := range decoded {
-			if uint64(code) >= uint64(cardinality) {
-				return columnTypedColumnPhysicalQueryPart{}, fmt.Errorf("collections: dense typed-column group-count code[%d]=%d outside cardinality=%d", i, code, cardinality)
-			}
-		}
-		codes = append(codes, decoded...)
-		scratch = decoded
-		decodedBytes += uint64(g.RawBytes)
-	}
-	if len(codes) != summary.Rows {
-		return columnTypedColumnPhysicalQueryPart{}, fmt.Errorf("collections: dense typed-column group-count decoded rows=%d want part rows=%d", len(codes), summary.Rows)
 	}
 	return columnTypedColumnPhysicalQueryPart{
 		Ref:                 typedRef,
@@ -1387,11 +1326,11 @@ func decodeTypedColumnPhysicalQueryDenseGroupCountPart(plan columnTypedColumnPhy
 		Bytes:               int64(len(raw)),
 		Sections:            summary.Sections,
 		SectionBytes:        summary.SectionBytes,
-		GranulesConsidered:  len(partColumn.Blocks),
-		GranulesDecoded:     len(partColumn.Blocks),
-		DecodedBlocks:       len(partColumn.Blocks),
+		GranulesConsidered:  blocks,
+		GranulesDecoded:     blocks,
+		DecodedBlocks:       blocks,
 		DecodedPayloadBytes: decodedBytes,
-		DenseGroupCount:     &columnTypedColumnDenseGroupCountPart{Cardinality: cardinality, DictionaryByCode: adapterColumn.ReverseDictionary, Codes: codes},
+		DenseGroupCount:     &columnTypedColumnDenseGroupCountPart{Cardinality: len(group.Dictionary), Dictionary: group.Dictionary, Codes: group.Codes, Valid: group.Valid},
 	}, nil
 }
 


### PR DESCRIPTION
## Scope

Fixes #3075. Supports #3070.

This PR improves the corrected JSONBench q1 path for:

- query mode: `one_shot_end_to_end`
- metadata mode: `no_aggregate_metadata`
- layout: `column-store-full-prepared` / full-retained typed-column-part storage
- shape: q1 group-count over nullable low-cardinality typed string groups

It is a general no-aggregate-metadata typed-column scan improvement. It is not a hot prepared runner claim, not an aggregate metadata shortcut, and not a broad SQL superiority claim.

## What changed

- Allows the dense q1 group-count route when the group column is nullable.
- Reuses the existing nullable low-cardinality string-code decoder used by dense q2 paths.
- Tracks optional validity for q1 dense codes and counts null/missing group values under the empty-string bucket, matching the generic typed-column accumulator.
- Keeps direct, latest-visible, and prepared aggregate-summary q1 paths consistent.
- Updates the nullable full-data regression so q1 must use dense group-count while preserving result parity for missing strings.

## Evidence

Baseline before this PR, corrected one-shot/no-metadata q1 profile:

- `/tmp/jsonbench_gomap_q1_profile_direct_20260626_024118/result.json`
- q1 best: `0.213953375s`
- rows scanned/reduced: `1,000,000`
- storage source: `typed_column_part_section`
- dense group-count: not used

Candidate benchmark with this PR:

- `/tmp/jsonbench_q1_nullable_dense_1m_20260625_165035/result.json`
- q1 best / total query: `0.115542708s`
- query mode: `one_shot_end_to_end`
- metadata mode: `no_aggregate_metadata`
- storage source: `typed_column_part_section`
- dense group-count: `true`
- rows scanned: `1,000,000`
- reduce rows: `1,000,000`
- typed-column sections: `882`
- typed-column section bytes: `21,560,570`
- decoded payload bytes: `8,210,001`
- physical bytes scanned: `21,632,156`
- aggregate metadata: not used
- profiles:
  - `/tmp/jsonbench_q1_nullable_dense_1m_20260625_165035/profiles/cpu_q1_attempt1.pprof`
  - `/tmp/jsonbench_q1_nullable_dense_1m_20260625_165035/profiles/allocs_q1_attempt1.pprof`

This improves q1 by about 46% on the local 1M corrected one-shot/no-metadata gate while still scanning/reducing 1M typed rows.

## Validation

```sh
git diff --check
```

```sh
go test ./TreeDB/collections -run 'TestColumnPhysicalQ1DenseTypedColumnDirectPreparedParity1950|TestColumnPhysicalJSONBenchTypedColumnPartNullableFullDataMissingStrings2165|TestTypedColumnQ2DenseGroupCountDistinctNoSortLocalDictionaries1950' -count=1
```

```sh
go test ./TreeDB/collections -run 'Test.*DenseGroupCount|TestColumnPhysical.*JSONBench|TestTypedColumn.*Aggregate' -count=1
```

```sh
go test ./TreeDB/collections -count=1
```

JSONBench local-gomap command:

```sh
cd /Users/michaelseiler/dev/snissn/JSONBench/treedb
cp go.mod /tmp/jsonbench_treedb_local_gomap.mod
cp go.sum /tmp/jsonbench_treedb_local_gomap.sum
go mod edit -modfile=/tmp/jsonbench_treedb_local_gomap.mod -replace=github.com/snissn/gomap=/Users/michaelseiler/dev/snissn/gomap-clean
OUT=/tmp/jsonbench_q1_nullable_dense_1m_$(date +%Y%m%d_%H%M%S)
go run -modfile=/tmp/jsonbench_treedb_local_gomap.mod ./cmd/jsonbench_treedb run \
  -data-dir /Users/michaelseiler/data/bluesky \
  -db-dir "$OUT/db" \
  -reset \
  -scale 1m \
  -rows 1000000 \
  -format json \
  -storage-layout column-store-full-prepared \
  -query-mode one_shot_end_to_end \
  -metadata-mode no_aggregate_metadata \
  -projection full \
  -queries q1 \
  -batch-size 16000 \
  -tries 1 \
  -profile fast \
  -data-root fast \
  -allow-errors \
  -query-profile-dir "$OUT/profiles" \
  -out "$OUT/result.json"
```
