### PR TITLE
TreeDB: enable nullable dense q3 group-hour

### DIFF
--- a/TreeDB/collections/column_physical_typed_column_1947_test.go
+++ b/TreeDB/collections/column_physical_typed_column_1947_test.go
@@ -225,6 +225,22 @@ func TestColumnPhysicalJSONBenchTypedColumnPartNullableFullDataMissingStrings216
 		t.Fatalf("q2 groups=%v want %v raw=%+v", got, wantQ2, q2Result.Groups)
 	}
 
+	feedCreate := append(append([]ColumnPhysicalQueryPredicate(nil), commitCreate...), ColumnPhysicalQueryPredicate{
+		Column: "event",
+		Kind:   ColumnPhysicalQueryPredicateInList,
+		Values: []string{"app.bsky.feed.post", "app.bsky.feed.repost", "app.bsky.feed.like"},
+	})
+	q3 := ColumnPhysicalQueryRequest{
+		Kind:        ColumnPhysicalQueryGroupHourCount,
+		GroupColumn: "event",
+		ValueColumn: "time_us",
+		Predicates:  feedCreate,
+	}
+	q3Result := runNullableFullDataDenseQ3Query3078(t, collection, "q3", q3, len(docs), len(feedCreate), 3, 3)
+	if got, want := columnPhysicalGroupHourMap3078(q3Result.Groups), map[string]map[int]int{"app.bsky.feed.post": {0: 3}}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("q3 groups=%v want %v raw=%+v", got, want, q3Result.Groups)
+	}
+
 	postCreate := append(append([]ColumnPhysicalQueryPredicate(nil), commitCreate...), ColumnPhysicalQueryPredicate{Column: "event", Value: "app.bsky.feed.post"})
 	q4 := ColumnPhysicalQueryRequest{
 		Kind:        ColumnPhysicalQueryGroupMinInt64,
@@ -255,6 +271,12 @@ func TestColumnPhysicalJSONBenchTypedColumnPartNullableFullDataAllMissingQ13075(
 	q1Result := runNullableFullDataDenseQ1Query3075(t, collection, "q1 all missing", q1, len(docs), 0, 0, len(docs))
 	if got, want := columnPhysicalGroupCountMap2165(q1Result.Groups), map[string]int{"": len(docs)}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("q1 all-missing groups=%v want %v raw=%+v", got, want, q1Result.Groups)
+	}
+
+	q3 := ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupHourCount, GroupColumn: "event", ValueColumn: "time_us"}
+	q3Result := runNullableFullDataDenseQ3Query3078(t, collection, "q3 all missing", q3, len(docs), 0, 0, len(docs))
+	if got, want := columnPhysicalGroupHourMap3078(q3Result.Groups), map[string]map[int]int{"": {0: len(docs)}}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("q3 all-missing groups=%v want %v raw=%+v", got, want, q3Result.Groups)
 	}
 }
 
@@ -845,6 +867,35 @@ func runNullableFullDataDenseQ2Query2165(tb testing.TB, collection *Collection, 
 	return direct
 }
 
+func runNullableFullDataDenseQ3Query3078(tb testing.TB, collection *Collection, name string, req ColumnPhysicalQueryRequest, wantRows, wantPredicates, wantMatched, wantReduce int) ColumnPhysicalQueryResult {
+	tb.Helper()
+	direct, err := collection.RunColumnPhysicalQuery(req)
+	if err != nil {
+		tb.Fatalf("RunColumnPhysicalQuery(%s): %v", name, err)
+	}
+	assertColumnPhysicalJSONBenchTypedColumnDiagnostics1947(tb, name+" direct", direct.Diagnostics, wantRows, wantPredicates, wantMatched, wantReduce)
+	assertNullableFullDataDenseQ3Diagnostics3078(tb, name+" direct", direct.Diagnostics)
+
+	runner, err := collection.PrepareColumnPhysicalQuery(req)
+	if err != nil {
+		tb.Fatalf("PrepareColumnPhysicalQuery(%s): %v", name, err)
+	}
+	defer func() { _ = runner.Close() }()
+	var prepared ColumnPhysicalQueryResult
+	for run := 0; run < 2; run++ {
+		prepared, err = runner.Run()
+		if err != nil {
+			tb.Fatalf("prepared %s run %d: %v", name, run, err)
+		}
+		assertColumnPhysicalJSONBenchTypedColumnDiagnostics1947(tb, fmt.Sprintf("%s prepared %d", name, run), prepared.Diagnostics, 0, wantPredicates, wantMatched, wantReduce)
+		assertNullableFullDataDenseQ3Diagnostics3078(tb, fmt.Sprintf("%s prepared %d", name, run), prepared.Diagnostics)
+		if !reflect.DeepEqual(prepared.Groups, direct.Groups) {
+			tb.Fatalf("%s prepared run %d groups=%+v want direct %+v", name, run, prepared.Groups, direct.Groups)
+		}
+	}
+	return direct
+}
+
 func runNullableFullDataTopKFastPath2878(tb testing.TB, collection *Collection, name string, req ColumnPhysicalQueryRequest, want []ColumnPhysicalQueryGroup, assertDiag func(testing.TB, string, ColumnPhysicalQueryDiagnostics)) {
 	tb.Helper()
 	direct, err := collection.RunColumnPhysicalQuery(req)
@@ -931,10 +982,36 @@ func assertNullableFullDataDenseQ2Diagnostics2165(tb testing.TB, label string, d
 	}
 }
 
+func assertNullableFullDataDenseQ3Diagnostics3078(tb testing.TB, label string, diag ColumnPhysicalQueryDiagnostics) {
+	tb.Helper()
+	if !diag.DenseGroupHourCountUsed || diag.DenseGroupCountUsed || diag.DenseGroupCountDistinctUsed || diag.DenseInt64SpanUsed || diag.SortedGroupedDistinctUsed || diag.TimeOrderTopKUsed {
+		tb.Fatalf("%s diagnostics=%+v want only dense q3 group-hour fast path", label, diag)
+	}
+	if diag.SortKeyPrefixPlanned || diag.SortKeyMarkChecks != 0 || diag.SortKeyMarkSkips != 0 {
+		tb.Fatalf("%s dense q3 diagnostics used sort-key pruning: %+v", label, diag)
+	}
+	if diag.DecodedBlocks == 0 || diag.DecodedPayloadBytes == 0 {
+		tb.Fatalf("%s dense q3 diagnostics did not report typed-column decode work: %+v", label, diag)
+	}
+}
+
 func columnPhysicalGroupCountMap2165(groups []ColumnPhysicalQueryGroup) map[string]int {
 	out := make(map[string]int, len(groups))
 	for _, group := range groups {
 		out[group.Key] = group.Count
+	}
+	return out
+}
+
+func columnPhysicalGroupHourMap3078(groups []ColumnPhysicalQueryGroup) map[string]map[int]int {
+	out := make(map[string]map[int]int, len(groups))
+	for _, group := range groups {
+		byHour := out[group.Key]
+		if byHour == nil {
+			byHour = make(map[int]int, 1)
+			out[group.Key] = byHour
+		}
+		byHour[group.Hour] = group.Count
 	}
 	return out
 }

--- a/TreeDB/collections/column_physical_typed_column_query.go
+++ b/TreeDB/collections/column_physical_typed_column_query.go
@@ -74,6 +74,7 @@ type columnTypedColumnDenseGroupHourCountPart struct {
 	Cardinality      int
 	DictionaryByCode map[int64]string
 	GroupCodes       []uint32
+	GroupValid       []bool
 	Values           []int64
 	Predicates       []columnTypedColumnDensePredicatePart
 }
@@ -609,11 +610,8 @@ func buildColumnTypedColumnDenseGroupHourCountSummary(parts []columnTypedColumnP
 		if dense == nil {
 			return nil, fmt.Errorf("collections: dense typed-column group-hour missing prepared part %d", partIdx)
 		}
-		if dense.Cardinality == 0 && len(dense.GroupCodes) != 0 {
-			return nil, fmt.Errorf("collections: dense typed-column group-hour part %d has empty dictionary", partIdx)
-		}
-		if len(dense.GroupCodes) != len(dense.Values) {
-			return nil, fmt.Errorf("collections: dense typed-column group-hour part %d group/value rows=%d/%d", partIdx, len(dense.GroupCodes), len(dense.Values))
+		if err := validateColumnTypedColumnDenseGroupHourCountPart(dense, partIdx); err != nil {
+			return nil, err
 		}
 		needLocal := dense.Cardinality * 24
 		if cap(localHourCounts) < needLocal {
@@ -625,6 +623,7 @@ func buildColumnTypedColumnDenseGroupHourCountSummary(parts []columnTypedColumnP
 		if columnTypedColumnDensePredicatesRejectAll(dense.Predicates) {
 			continue
 		}
+		var missingHourCounts [24]int
 		for rowIdx, code := range dense.GroupCodes {
 			if !columnTypedColumnDensePredicatesMatch(dense.Predicates, rowIdx) {
 				continue
@@ -633,12 +632,31 @@ func buildColumnTypedColumnDenseGroupHourCountSummary(parts []columnTypedColumnP
 				matchedRows++
 			}
 			reduceRows++
+			hour := columnPhysicalQueryUTCHour(dense.Values[rowIdx])
+			if !columnTypedColumnDenseCodeValid(dense.GroupValid, rowIdx) {
+				missingHourCounts[hour]++
+				continue
+			}
 			localIdx, ok := columnDictionaryCodeIndex(code, dense.Cardinality)
 			if !ok {
 				return nil, fmt.Errorf("collections: dense typed-column group-hour part %d code[%d]=%d outside cardinality=%d", partIdx, rowIdx, code, dense.Cardinality)
 			}
-			hour := columnPhysicalQueryUTCHour(dense.Values[rowIdx])
 			localHourCounts[localIdx*24+hour]++
+		}
+		var missingByHour [24]int
+		missingSeen := false
+		for hour, count := range missingHourCounts {
+			if count == 0 {
+				continue
+			}
+			if !missingSeen {
+				missingByHour = counts[""]
+				missingSeen = true
+			}
+			missingByHour[hour] += count
+		}
+		if missingSeen {
+			counts[""] = missingByHour
 		}
 		for localCode := 0; localCode < dense.Cardinality; localCode++ {
 			key := ""
@@ -1552,15 +1570,10 @@ func (r *columnTypedColumnPhysicalQueryRunner) runLatestVisibleDenseGroupHourCou
 			diag.DenseGroupHourCountUsed = true
 			return ColumnPhysicalQueryResult{Diagnostics: diag}, fmt.Errorf("collections: dense typed-column group-hour missing prepared part %d", partIdx)
 		}
-		if dense.Cardinality == 0 && len(dense.GroupCodes) != 0 {
+		if err := validateColumnTypedColumnDenseGroupHourCountPart(dense, partIdx); err != nil {
 			diag := r.latestVisibleDiagnostics(view, req, state, visibilityBytes, visibilityNanos, rowsScanned, matchedRows, reduceRows, time.Since(start).Nanoseconds())
 			diag.DenseGroupHourCountUsed = true
-			return ColumnPhysicalQueryResult{Diagnostics: diag}, fmt.Errorf("collections: dense typed-column group-hour part %d has empty dictionary", partIdx)
-		}
-		if len(dense.GroupCodes) != len(dense.Values) {
-			diag := r.latestVisibleDiagnostics(view, req, state, visibilityBytes, visibilityNanos, rowsScanned, matchedRows, reduceRows, time.Since(start).Nanoseconds())
-			diag.DenseGroupHourCountUsed = true
-			return ColumnPhysicalQueryResult{Diagnostics: diag}, fmt.Errorf("collections: dense typed-column group-hour part %d group/value rows=%d/%d", partIdx, len(dense.GroupCodes), len(dense.Values))
+			return ColumnPhysicalQueryResult{Diagnostics: diag}, err
 		}
 		needLocal := dense.Cardinality * 24
 		if cap(r.denseLocalHourCounts) < needLocal {
@@ -1573,6 +1586,7 @@ func (r *columnTypedColumnPhysicalQueryRunner) runLatestVisibleDenseGroupHourCou
 			rowsScanned += len(dense.GroupCodes)
 			continue
 		}
+		var missingHourCounts [24]int
 		for rowIdx, code := range dense.GroupCodes {
 			rowsScanned++
 			if !visibility.rowVisible(rowIdx) {
@@ -1585,14 +1599,33 @@ func (r *columnTypedColumnPhysicalQueryRunner) runLatestVisibleDenseGroupHourCou
 				matchedRows++
 			}
 			reduceRows++
+			hour := columnPhysicalQueryUTCHour(dense.Values[rowIdx])
+			if !columnTypedColumnDenseCodeValid(dense.GroupValid, rowIdx) {
+				missingHourCounts[hour]++
+				continue
+			}
 			localIdx, ok := columnDictionaryCodeIndex(code, dense.Cardinality)
 			if !ok {
 				diag := r.latestVisibleDiagnostics(view, req, state, visibilityBytes, visibilityNanos, rowsScanned, matchedRows, reduceRows, time.Since(start).Nanoseconds())
 				diag.DenseGroupHourCountUsed = true
 				return ColumnPhysicalQueryResult{Diagnostics: diag}, fmt.Errorf("collections: dense typed-column group-hour part %d code[%d]=%d outside cardinality=%d", partIdx, rowIdx, code, dense.Cardinality)
 			}
-			hour := columnPhysicalQueryUTCHour(dense.Values[rowIdx])
 			r.denseLocalHourCounts[localIdx*24+hour]++
+		}
+		var missingByHour [24]int
+		missingSeen := false
+		for hour, count := range missingHourCounts {
+			if count == 0 {
+				continue
+			}
+			if !missingSeen {
+				missingByHour = r.denseGroupHourCounts[""]
+				missingSeen = true
+			}
+			missingByHour[hour] += count
+		}
+		if missingSeen {
+			r.denseGroupHourCounts[""] = missingByHour
 		}
 		for localCode := 0; localCode < dense.Cardinality; localCode++ {
 			key := ""
@@ -1791,7 +1824,7 @@ func columnTypedColumnPhysicalQueryShapeCanUseDenseGroupHourCount(req ColumnPhys
 }
 
 func columnTypedColumnPhysicalQueryUseDenseGroupHourCount(plan columnTypedColumnPhysicalQueryPlan, req ColumnPhysicalQueryRequest) bool {
-	return !plan.NullableStringValues && plan.DenseGroupHourCount && columnTypedColumnPhysicalQueryShapeCanUseDenseGroupHourCount(req)
+	return plan.DenseGroupHourCount && columnTypedColumnPhysicalQueryShapeCanUseDenseGroupHourCount(req)
 }
 
 func columnTypedColumnPhysicalQueryShapeCanUseDenseInt64Span(req ColumnPhysicalQueryRequest) bool {
@@ -2310,6 +2343,19 @@ func validateColumnTypedColumnDenseGroupCountPart(dense *columnTypedColumnDenseG
 	return nil
 }
 
+func validateColumnTypedColumnDenseGroupHourCountPart(dense *columnTypedColumnDenseGroupHourCountPart, partIdx int) error {
+	if dense.GroupValid != nil && len(dense.GroupValid) != len(dense.GroupCodes) {
+		return fmt.Errorf("collections: dense typed-column group-hour part %d valid rows=%d want codes rows=%d", partIdx, len(dense.GroupValid), len(dense.GroupCodes))
+	}
+	if dense.Cardinality == 0 && dense.GroupValid == nil && len(dense.GroupCodes) != 0 {
+		return fmt.Errorf("collections: dense typed-column group-hour part %d has empty dictionary", partIdx)
+	}
+	if len(dense.GroupCodes) != len(dense.Values) {
+		return fmt.Errorf("collections: dense typed-column group-hour part %d group/value rows=%d/%d", partIdx, len(dense.GroupCodes), len(dense.Values))
+	}
+	return nil
+}
+
 func columnTypedColumnDenseGroupCountDictionaryValue(dense *columnTypedColumnDenseGroupCountPart, localCode int) (string, bool) {
 	if localCode < 0 || localCode >= len(dense.Dictionary) {
 		return "", false
@@ -2614,15 +2660,10 @@ func (r *columnTypedColumnPhysicalQueryRunner) runDenseGroupHourCount(view colum
 			diag.DenseGroupHourCountUsed = true
 			return ColumnPhysicalQueryResult{Diagnostics: diag}, fmt.Errorf("collections: dense typed-column group-hour missing prepared part %d", partIdx)
 		}
-		if dense.Cardinality == 0 && len(dense.GroupCodes) != 0 {
+		if err := validateColumnTypedColumnDenseGroupHourCountPart(dense, partIdx); err != nil {
 			diag := r.diagnostics(view, req, rowsScanned, matchedRows, reduceRows, time.Since(start).Nanoseconds())
 			diag.DenseGroupHourCountUsed = true
-			return ColumnPhysicalQueryResult{Diagnostics: diag}, fmt.Errorf("collections: dense typed-column group-hour part %d has empty dictionary", partIdx)
-		}
-		if len(dense.GroupCodes) != len(dense.Values) {
-			diag := r.diagnostics(view, req, rowsScanned, matchedRows, reduceRows, time.Since(start).Nanoseconds())
-			diag.DenseGroupHourCountUsed = true
-			return ColumnPhysicalQueryResult{Diagnostics: diag}, fmt.Errorf("collections: dense typed-column group-hour part %d group/value rows=%d/%d", partIdx, len(dense.GroupCodes), len(dense.Values))
+			return ColumnPhysicalQueryResult{Diagnostics: diag}, err
 		}
 		needLocal := dense.Cardinality * 24
 		if cap(r.denseLocalHourCounts) < needLocal {
@@ -2635,6 +2676,7 @@ func (r *columnTypedColumnPhysicalQueryRunner) runDenseGroupHourCount(view colum
 			rowsScanned += len(dense.GroupCodes)
 			continue
 		}
+		var missingHourCounts [24]int
 		for rowIdx, code := range dense.GroupCodes {
 			rowsScanned++
 			if !columnTypedColumnDensePredicatesMatch(dense.Predicates, rowIdx) {
@@ -2644,14 +2686,33 @@ func (r *columnTypedColumnPhysicalQueryRunner) runDenseGroupHourCount(view colum
 				matchedRows++
 			}
 			reduceRows++
+			hour := columnPhysicalQueryUTCHour(dense.Values[rowIdx])
+			if !columnTypedColumnDenseCodeValid(dense.GroupValid, rowIdx) {
+				missingHourCounts[hour]++
+				continue
+			}
 			localIdx, ok := columnDictionaryCodeIndex(code, dense.Cardinality)
 			if !ok {
 				diag := r.diagnostics(view, req, rowsScanned, matchedRows, reduceRows, time.Since(start).Nanoseconds())
 				diag.DenseGroupHourCountUsed = true
 				return ColumnPhysicalQueryResult{Diagnostics: diag}, fmt.Errorf("collections: dense typed-column group-hour part %d code[%d]=%d outside cardinality=%d", partIdx, rowIdx, code, dense.Cardinality)
 			}
-			hour := columnPhysicalQueryUTCHour(dense.Values[rowIdx])
 			r.denseLocalHourCounts[localIdx*24+hour]++
+		}
+		var missingByHour [24]int
+		missingSeen := false
+		for hour, count := range missingHourCounts {
+			if count == 0 {
+				continue
+			}
+			if !missingSeen {
+				missingByHour = r.denseGroupHourCounts[""]
+				missingSeen = true
+			}
+			missingByHour[hour] += count
+		}
+		if missingSeen {
+			r.denseGroupHourCounts[""] = missingByHour
 		}
 		for localCode := 0; localCode < dense.Cardinality; localCode++ {
 			key := ""

--- a/TreeDB/collections/typed_column_adapter.go
+++ b/TreeDB/collections/typed_column_adapter.go
@@ -1358,7 +1358,7 @@ func decodeTypedColumnPhysicalQueryDenseGroupHourCountPart(plan columnTypedColum
 	}
 	predicates := part.DenseInt64Span.Predicates
 	if groupPredicate != nil {
-		predicate, err := densePredicateFromDictionaryCodes(part.DenseInt64Span.GroupCodes, part.DenseInt64Span.DictionaryByCode, part.DenseInt64Span.Cardinality, *groupPredicate)
+		predicate, err := densePredicateFromDictionaryCodes(part.DenseInt64Span.GroupCodes, part.DenseInt64Span.GroupValid, part.DenseInt64Span.DictionaryByCode, part.DenseInt64Span.Cardinality, *groupPredicate)
 		if err != nil {
 			return columnTypedColumnPhysicalQueryPart{}, err
 		}
@@ -1368,6 +1368,7 @@ func decodeTypedColumnPhysicalQueryDenseGroupHourCountPart(plan columnTypedColum
 		Cardinality:      part.DenseInt64Span.Cardinality,
 		DictionaryByCode: part.DenseInt64Span.DictionaryByCode,
 		GroupCodes:       part.DenseInt64Span.GroupCodes,
+		GroupValid:       part.DenseInt64Span.GroupValid,
 		Values:           part.DenseInt64Span.Values,
 		Predicates:       predicates,
 	}
@@ -1375,9 +1376,10 @@ func decodeTypedColumnPhysicalQueryDenseGroupHourCountPart(plan columnTypedColum
 	return part, nil
 }
 
-func densePredicateFromDictionaryCodes(codes []uint32, dictionaryByCode map[int64]string, cardinality int, spec columnPhysicalQueryPredicateSpec) (columnTypedColumnDensePredicatePart, error) {
+func densePredicateFromDictionaryCodes(codes []uint32, valid []bool, dictionaryByCode map[int64]string, cardinality int, spec columnPhysicalQueryPredicateSpec) (columnTypedColumnDensePredicatePart, error) {
 	allowed := make([]uint64, (cardinality+63)/64)
 	matchedLiterals := 0
+	missingMatchesEmpty := false
 	for code := 0; code < cardinality; code++ {
 		value, ok := dictionaryByCode[int64(code)]
 		if !ok {
@@ -1392,10 +1394,16 @@ func densePredicateFromDictionaryCodes(codes []uint32, dictionaryByCode map[int6
 			break
 		}
 	}
-	if matchedLiterals == 0 {
+	for _, target := range spec.values {
+		if target == "" {
+			missingMatchesEmpty = true
+			break
+		}
+	}
+	if matchedLiterals == 0 && !missingMatchesEmpty {
 		return columnTypedColumnDensePredicatePart{RejectsAll: true}, nil
 	}
-	return columnTypedColumnDensePredicatePart{Codes: codes, Allowed: allowed}, nil
+	return columnTypedColumnDensePredicatePart{Codes: codes, Valid: valid, Allowed: allowed, MissingMatchesEmpty: missingMatchesEmpty}, nil
 }
 
 type columnTypedColumnTimeOrderCodeColumn struct {


### PR DESCRIPTION
## Scope

Closes #3078.
Parent tracker: #3070.

This PR enables the typed-column dense group-hour reducer for nullable dictionary string columns so the full-retained JSONBench q3 path can use the production typed-column part instead of the generic nullable scan.

This is a q3 `one_shot_end_to_end` / `no_aggregate_metadata` query-path slice only.

It improves:

- one-shot query execution: yes, q3 only
- no-aggregate-metadata scan: yes, q3 typed-column dense group-hour
- hot prepared execution: same reducer path, but not the headline metric
- insert/load: no
- storage: no
- metadata storage/cost: no
- broad SQL superiority claim: no

## What Changed

- Carry nullable group validity through the dense group-hour prepared part.
- Allow dense q3 on nullable string groups while preserving generic semantics: missing/null group values count under the empty string key.
- Make dictionary-code predicates on nullable group columns match missing/null only when the predicate explicitly includes the empty string value.
- Add nullable full-data q3 regression coverage for filtered q3 and an all-missing group column.

## Benchmark Evidence

1M Bluesky JSONBench, `column-store-full-prepared`, `one_shot_end_to_end`, `no_aggregate_metadata`, q3 only.

| system/path | rows loaded | load wall | storage bytes | query mode | metadata mode | prepare/setup | run/total query | render/hash | rows/cells visited | bytes read/decoded | aggregate metadata | sort/TopK pruning | JSON reconstruction |
| --- | ---: | ---: | ---: | --- | --- | ---: | ---: | ---: | ---: | ---: | --- | --- | --- |
| TreeDB baseline | 1,000,000 | 19.063682417s | 137,488,386 WAL-excluded | `one_shot_end_to_end` | `no_aggregate_metadata` | included in total | 0.473361750s | 26,043ns | scanned 1,000,000 / reduced 588,328 | physical 21,632,156 / decoded 26,680,455 | no | no | no columnar test path |
| TreeDB candidate | 1,000,000 | 19.198096791s | 137,488,386 WAL-excluded | `one_shot_end_to_end` | `no_aggregate_metadata` | included in total | 0.150888125s | 23,750ns | scanned 1,000,000 / reduced 588,328 | physical 21,632,156 / decoded 26,680,455 | no | no | no columnar test path |
| ClickHouse saved context | 1,000,000 | 4.182687997817993s | 102,099,438 | saved JSONBench q3 | n/a | n/a | 0.0140s | n/a | n/a | n/a | none reported | none reported | n/a |

Candidate vs baseline: 3.137x faster q3 total query time, 68.1241% lower.
Candidate remains about 10.78x slower than the saved ClickHouse q3 timing, so this PR does not claim SQL superiority.

Artifacts:

- Baseline TreeDB: `/tmp/jsonbench_one_shot_direct_1m_noagg_20260626_023258/treedb/report.json`
- Candidate TreeDB: `/tmp/jsonbench_q3_nullable_dense_1m_20260625_174153/result.json`
- Candidate profiles: `/tmp/jsonbench_q3_nullable_dense_1m_20260625_174153/profiles/cpu_q3_attempt1.pprof`, `/tmp/jsonbench_q3_nullable_dense_1m_20260625_174153/profiles/allocs_q3_attempt1.pprof`
- Saved ClickHouse context: `/tmp/jsonbench_one_shot_direct_1m_noagg_20260626_023258/clickhouse/result.json`

Candidate command:

```sh
cp go.mod /tmp/jsonbench_treedb_local_gomap_q3.mod
cp go.sum /tmp/jsonbench_treedb_local_gomap_q3.sum
go mod edit -modfile=/tmp/jsonbench_treedb_local_gomap_q3.mod -replace=github.com/snissn/gomap=/Users/michaelseiler/dev/snissn/gomap-clean
OUT=/tmp/jsonbench_q3_nullable_dense_1m_$(date +%Y%m%d_%H%M%S)
mkdir -p "$OUT"
printf '%s\n' "$OUT" > /tmp/jsonbench_q3_nullable_dense_latest.txt
go run -modfile=/tmp/jsonbench_treedb_local_gomap_q3.mod ./cmd/jsonbench_treedb run \
  -data-dir /Users/michaelseiler/data/bluesky \
  -db-dir "$OUT/db" \
  -reset \
  -scale 1m \
  -rows 1000000 \
  -format json \
  -storage-layout column-store-full-prepared \
  -query-mode one_shot_end_to_end \
  -metadata-mode no_aggregate_metadata \
  -projection full \
  -queries q3 \
  -batch-size 16000 \
  -tries 1 \
  -profile fast \
  -data-root fast \
  -allow-errors \
  -query-profile-dir "$OUT/profiles" \
  -out "$OUT/result.json"
```

## Tests

```sh
go test ./TreeDB/collections -run 'TestColumnPhysicalQ3DenseTypedColumnDirectPreparedParity1950|TestColumnPhysicalJSONBenchTypedColumnPartNullableFullDataMissingStrings2165|TestColumnPhysicalJSONBenchTypedColumnPartNullableFullDataAllMissingQ13075|TestColumnPhysicalQ1DenseTypedColumnDirectPreparedParity1950|TestTypedColumnQ2DenseGroupCountDistinctNoSortLocalDictionaries1950' -count=1
go test ./TreeDB/collections -run 'Test.*DenseGroupHour|TestColumnPhysical.*JSONBench|TestColumnPhysical.*Nullable|TestColumnPhysicalLatestVisible.*Q3|TestColumnPhysicalQ3DenseTypedColumnDirectPreparedParity1950' -count=1
go test ./TreeDB/collections -count=1
git diff --check
```

All passed locally before PR creation.
