### PR TITLE
TreeDB: speed q2 one-shot count-distinct

### DIFF
--- a/TreeDB/collections/column_physical_q2_1950_test.go
+++ b/TreeDB/collections/column_physical_q2_1950_test.go
@@ -127,7 +127,7 @@ func TestTypedColumnQ2DenseGroupCountDistinctNoSortLocalDictionaries1950(t *test
 		t.Fatalf("RunColumnPhysicalQuery(q2 dense no-sort): %v", err)
 	}
 	assertTypedColumnQ2SortedGroupedDistinctResult1950(t, "dense no-sort", direct, rowHash, want)
-	assertTypedColumnQ2DenseGroupCountDistinctDiagnostics1950(t, "dense no-sort", direct.Diagnostics, len(events), matchedRows)
+	assertTypedColumnQ2DenseGroupCountDistinctDiagnostics1950(t, "dense no-sort", direct.Diagnostics, len(events), matchedRows, columnTypedColumnDenseGroupCountDistinctReducerLocalBitset)
 
 	runner, err := col.PrepareColumnPhysicalQuery(req)
 	if err != nil {
@@ -140,7 +140,7 @@ func TestTypedColumnQ2DenseGroupCountDistinctNoSortLocalDictionaries1950(t *test
 	}
 	assertTypedColumnQ2DensePreparedGlobalCodes1950(t, runner)
 	assertTypedColumnQ2SortedGroupedDistinctResult1950(t, "prepared dense no-sort", prepared, rowHash, want)
-	assertTypedColumnQ2DenseGroupCountDistinctDiagnostics1950(t, "prepared dense no-sort", prepared.Diagnostics, len(events), matchedRows)
+	assertTypedColumnQ2DenseGroupCountDistinctDiagnostics1950(t, "prepared dense no-sort", prepared.Diagnostics, len(events), matchedRows, columnTypedColumnDenseGroupCountDistinctReducerPairBitset)
 
 	got := columnPhysicalJSONBenchQ2CountsP0(prepared.Groups)
 	if got["app.z"].Count != 4 || got["app.z"].Distinct != 2 {
@@ -151,6 +151,72 @@ func TestTypedColumnQ2DenseGroupCountDistinctNoSortLocalDictionaries1950(t *test
 	}
 	if got["app.emptydid"].Count != 2 || got["app.emptydid"].Distinct != 1 {
 		t.Fatalf("empty did counts=%+v want empty distinct value counted once", got["app.emptydid"])
+	}
+}
+
+func TestTypedColumnQ2DenseGroupCountDistinctLocalCodesNullableValues3080(t *testing.T) {
+	req := ColumnPhysicalQueryRequest{
+		Kind:           ColumnPhysicalQueryGroupCountAndDistinct,
+		GroupColumn:    "collection",
+		DistinctColumn: "did",
+		Predicates: []ColumnPhysicalQueryPredicate{
+			{Column: "kind", Value: "commit"},
+			{Column: "operation", Value: "create"},
+		},
+	}
+	predicateCodes := []uint32{1, 1, 1, 1, 0}
+	allowed := []uint64{2}
+	runner := &columnTypedColumnPhysicalQueryRunner{
+		plan: columnTypedColumnPhysicalQueryPlan{
+			ProjectedColumns:        []string{"collection", "did", "kind", "operation"},
+			PredicateDiagnostics:    newColumnPhysicalQueryPredicateDiagnosticPlan(req),
+			DenseGroupCountDistinct: true,
+		},
+		parts: []columnTypedColumnPhysicalQueryPart{
+			{
+				Rows: len(predicateCodes),
+				DenseGroupCountDistinct: &columnTypedColumnDenseGroupCountDistinctPart{
+					Rows: len(predicateCodes),
+					Group: columnTypedColumnDenseStringCodeColumn{
+						Codes:      []uint32{0, 0, 0, 1, 0},
+						Valid:      []bool{true, false, true, true, true},
+						Dictionary: []string{"app.a", "app.b"},
+					},
+					Distinct: columnTypedColumnDenseStringCodeColumn{
+						Codes:      []uint32{0, 1, 0, 0, 1},
+						Valid:      []bool{true, true, false, true, true},
+						Dictionary: []string{"did:x", "did:y"},
+					},
+					Predicates: []columnTypedColumnDensePredicatePart{
+						{Codes: predicateCodes, Allowed: allowed},
+						{Codes: predicateCodes, Allowed: allowed},
+					},
+				},
+			},
+		},
+	}
+
+	result, err := runner.runDenseGroupCountDistinct(columnPhysicalScanSnapshotView{}, req)
+	if err != nil {
+		t.Fatalf("runDenseGroupCountDistinct local nullable: %v", err)
+	}
+	if result.Diagnostics.DenseGroupCountDistinctReducer != columnTypedColumnDenseGroupCountDistinctReducerLocalBitset {
+		t.Fatalf("reducer=%q want %q diagnostics=%+v", result.Diagnostics.DenseGroupCountDistinctReducer, columnTypedColumnDenseGroupCountDistinctReducerLocalBitset, result.Diagnostics)
+	}
+	if result.Diagnostics.RowsScanned != len(predicateCodes) || result.Diagnostics.RowsMatched != 4 || result.Diagnostics.ReduceRows != 4 {
+		t.Fatalf("row diagnostics=%+v want scanned=%d matched/reduced=4", result.Diagnostics, len(predicateCodes))
+	}
+	if len(runner.parts[0].DenseGroupCountDistinct.Group.GlobalCodes) != 0 || len(runner.parts[0].DenseGroupCountDistinct.Distinct.GlobalCodes) != 0 {
+		t.Fatalf("local reducer populated global codes: group=%d distinct=%d", len(runner.parts[0].DenseGroupCountDistinct.Group.GlobalCodes), len(runner.parts[0].DenseGroupCountDistinct.Distinct.GlobalCodes))
+	}
+	got := columnPhysicalJSONBenchQ2CountsP0(result.Groups)
+	want := map[string]columnPhysicalJSONBenchQ2CountP0{
+		"":      {Count: 1, Distinct: 1},
+		"app.a": {Count: 2, Distinct: 2},
+		"app.b": {Count: 1, Distinct: 1},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("groups=%v want %v raw=%+v", got, want, result.Groups)
 	}
 }
 
@@ -816,7 +882,7 @@ func assertTypedColumnQ2SortedGroupedDistinctDiagnostics1950(tb testing.TB, labe
 	}
 }
 
-func assertTypedColumnQ2DenseGroupCountDistinctDiagnostics1950(tb testing.TB, label string, diag ColumnPhysicalQueryDiagnostics, totalRows, matchedRows int) {
+func assertTypedColumnQ2DenseGroupCountDistinctDiagnostics1950(tb testing.TB, label string, diag ColumnPhysicalQueryDiagnostics, totalRows, matchedRows int, wantReducer string) {
 	tb.Helper()
 	if diag.StorageSource != ColumnPhysicalQueryStorageSourceTypedColumnPartSection || diag.FallbackReason != ColumnPhysicalQueryFallbackNone {
 		tb.Fatalf("%s diagnostics=%+v want typed-column source without storage fallback", label, diag)
@@ -833,8 +899,8 @@ func assertTypedColumnQ2DenseGroupCountDistinctDiagnostics1950(tb testing.TB, la
 	if !diag.DenseGroupCountDistinctUsed || diag.SortedGroupedDistinctUsed || diag.DenseGroupCountUsed || diag.DenseGroupHourCountUsed || diag.DenseInt64SpanUsed || diag.TimeOrderTopKUsed {
 		tb.Fatalf("%s diagnostics=%+v want only dense grouped count-distinct path", label, diag)
 	}
-	if diag.DenseGroupCountDistinctReducer != columnTypedColumnDenseGroupCountDistinctReducerPairBitset || diag.DenseGroupCountDistinctGroups == 0 || diag.DenseGroupCountDistinctValues == 0 || diag.DenseGroupCountDistinctPairBitWords == 0 {
-		tb.Fatalf("%s dense grouped count-distinct reducer diagnostics=%+v want pair bitset with cardinalities", label, diag)
+	if diag.DenseGroupCountDistinctReducer != wantReducer || diag.DenseGroupCountDistinctGroups == 0 || diag.DenseGroupCountDistinctValues == 0 || diag.DenseGroupCountDistinctPairBitWords == 0 {
+		tb.Fatalf("%s dense grouped count-distinct reducer diagnostics=%+v want %s with cardinalities", label, diag, wantReducer)
 	}
 	if diag.SortKeyMarkChecks != 0 || diag.SortKeyMarkSkips != 0 {
 		tb.Fatalf("%s mark diagnostics=%+v want no sort-key pruning in dense no-sort path", label, diag)

--- a/TreeDB/collections/column_physical_typed_column_query.go
+++ b/TreeDB/collections/column_physical_typed_column_query.go
@@ -15,6 +15,7 @@ const columnTypedColumnDenseGroupCountDistinctMaxBitsetWords = 2 << 20
 
 const (
 	columnTypedColumnDenseGroupCountDistinctReducerPairBitset   = "pair_bitset"
+	columnTypedColumnDenseGroupCountDistinctReducerLocalBitset  = "local_dictionary_pair_bitset"
 	columnTypedColumnDenseGroupCountDistinctReducerActiveBitset = "active_group_bitset"
 	columnTypedColumnDenseGroupCountDistinctReducerSortedPairs  = "sorted_packed_pairs"
 	columnTypedColumnDenseInt64SpanReducerGlobalCodes           = "global_codes"
@@ -335,7 +336,7 @@ func runColumnPhysicalQueryTypedColumnPartLatestVisibleInSnapshotView(view colum
 		return result, true, fmt.Errorf("%w: typed-column sorted latest-visible physical query requires sorted typed_column_part assets", ErrColumnQueryPlanUnsupported)
 	}
 
-	runner, err := decodeColumnTypedColumnPhysicalQueryRunnerParts(view, req, plan, refsByGeneration, &readCache, columnTypedColumnPhysicalQueryUseSortedLatestVisible(plan, req), false)
+	runner, err := decodeColumnTypedColumnPhysicalQueryRunnerParts(view, req, plan, refsByGeneration, &readCache, columnTypedColumnPhysicalQueryUseSortedLatestVisible(plan, req), false, false)
 	if err != nil {
 		result := ColumnPhysicalQueryResult{Diagnostics: columnTypedColumnPhysicalMutationDiagnostics(view, req)}
 		annotateColumnPhysicalQueryResult(&result, ColumnPhysicalQueryStorageSourceTypedColumnPartSection, ColumnPhysicalQueryFallbackMutationVisibilityUnsupported)
@@ -416,7 +417,7 @@ func prepareColumnTypedColumnPhysicalQueryRunner(view columnPhysicalScanSnapshot
 	if _, err := validateTypedColumnPhysicalAssetPairing(refsByGeneration, view.AssetRefs); err != nil {
 		return nil, true, typedColumnPhysicalQueryPairingError(err)
 	}
-	runner, err := decodeColumnTypedColumnPhysicalQueryRunnerParts(view, req, plan, refsByGeneration, readCache, false, prepareSummaries)
+	runner, err := decodeColumnTypedColumnPhysicalQueryRunnerParts(view, req, plan, refsByGeneration, readCache, false, prepareSummaries, prepareSummaries)
 	if err != nil {
 		return nil, true, err
 	}
@@ -428,7 +429,7 @@ func prepareColumnTypedColumnPhysicalQueryRunner(view columnPhysicalScanSnapshot
 	return runner, true, nil
 }
 
-func decodeColumnTypedColumnPhysicalQueryRunnerParts(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest, plan columnTypedColumnPhysicalQueryPlan, refsByGeneration map[uint64]columnManifestAssetRefForScan, readCache *columnPhysicalAssetReadCache, includePhysicalRows bool, prepareDenseInt64SpanGlobalCodes bool) (*columnTypedColumnPhysicalQueryRunner, error) {
+func decodeColumnTypedColumnPhysicalQueryRunnerParts(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest, plan columnTypedColumnPhysicalQueryPlan, refsByGeneration map[uint64]columnManifestAssetRefForScan, readCache *columnPhysicalAssetReadCache, includePhysicalRows bool, prepareDenseInt64SpanGlobalCodes bool, prepareDenseGroupCountDistinctGlobalCodes bool) (*columnTypedColumnPhysicalQueryRunner, error) {
 	if readCache == nil {
 		return nil, errors.New("collections: typed-column part physical query missing read cache")
 	}
@@ -507,7 +508,7 @@ func decodeColumnTypedColumnPhysicalQueryRunnerParts(view columnPhysicalScanSnap
 		if err := prepareColumnTypedColumnSortedGroupedDistinctGlobalCodes(runner.parts); err != nil {
 			return nil, err
 		}
-	} else if allowDenseGroupCountDistinct && columnTypedColumnPhysicalQueryUseDenseGroupCountDistinct(plan, req) {
+	} else if prepareDenseGroupCountDistinctGlobalCodes && allowDenseGroupCountDistinct && columnTypedColumnPhysicalQueryUseDenseGroupCountDistinct(plan, req) {
 		if err := prepareColumnTypedColumnDenseGroupCountDistinctGlobalCodes(runner.parts); err != nil {
 			return nil, err
 		}
@@ -839,6 +840,41 @@ func columnTypedColumnDenseGroupCountDistinctGlobalDictionary(parts []columnType
 	return dictionary, ranks, nil
 }
 
+func columnTypedColumnDenseGroupCountDistinctGlobalRanks(parts []columnTypedColumnPhysicalQueryPart, selectColumn func(*columnTypedColumnDenseGroupCountDistinctPart) *columnTypedColumnDenseStringCodeColumn) (map[string]uint32, int, error) {
+	ranks := make(map[string]uint32)
+	addValue := func(value string) error {
+		if _, ok := ranks[value]; ok {
+			return nil
+		}
+		if uint64(len(ranks)) > uint64(^uint32(0)) {
+			return fmt.Errorf("collections: dense grouped count-distinct global dictionary cardinality exceeds uint32")
+		}
+		ranks[value] = uint32(len(ranks))
+		return nil
+	}
+	for partIdx := range parts {
+		part := parts[partIdx].DenseGroupCountDistinct
+		if part == nil {
+			return nil, 0, fmt.Errorf("collections: dense grouped count-distinct missing prepared part %d", partIdx)
+		}
+		column := selectColumn(part)
+		for _, value := range column.Dictionary {
+			if err := addValue(value); err != nil {
+				return nil, 0, err
+			}
+		}
+		for _, valid := range column.Valid {
+			if !valid {
+				if err := addValue(""); err != nil {
+					return nil, 0, err
+				}
+				break
+			}
+		}
+	}
+	return ranks, len(ranks), nil
+}
+
 func prepareColumnTypedColumnDenseGroupCountDistinctGlobalColumnCodes(column *columnTypedColumnDenseStringCodeColumn, globalDictionary []string, ranks map[string]uint32) error {
 	localRanks := make([]uint32, len(column.Dictionary))
 	for localCode, value := range column.Dictionary {
@@ -866,6 +902,36 @@ func prepareColumnTypedColumnDenseGroupCountDistinctGlobalColumnCodes(column *co
 	column.GlobalCodes = globalCodes
 	column.GlobalDictionary = globalDictionary
 	return nil
+}
+
+func columnTypedColumnDenseGroupCountDistinctLocalRanks(column *columnTypedColumnDenseStringCodeColumn, ranks map[string]uint32) ([]uint32, uint32, bool, error) {
+	localRanks := make([]uint32, len(column.Dictionary))
+	for localCode, value := range column.Dictionary {
+		rank, ok := ranks[value]
+		if !ok {
+			return nil, 0, false, fmt.Errorf("local dictionary value %q missing from global dictionary", value)
+		}
+		localRanks[localCode] = rank
+	}
+	emptyRank, emptyOK := ranks[""]
+	return localRanks, emptyRank, emptyOK, nil
+}
+
+func columnTypedColumnDenseGroupCountDistinctRowRank(column *columnTypedColumnDenseStringCodeColumn, localRanks []uint32, emptyRank uint32, emptyOK bool, rowIdx int) (uint32, error) {
+	if !columnTypedColumnDenseCodeValid(column.Valid, rowIdx) {
+		if !emptyOK {
+			return 0, fmt.Errorf("row=%d nullable missing value has no empty-string global rank", rowIdx)
+		}
+		return emptyRank, nil
+	}
+	if rowIdx < 0 || rowIdx >= len(column.Codes) {
+		return 0, fmt.Errorf("row=%d outside codes length=%d", rowIdx, len(column.Codes))
+	}
+	localCode := column.Codes[rowIdx]
+	if uint64(localCode) >= uint64(len(localRanks)) {
+		return 0, fmt.Errorf("row=%d code=%d outside cardinality=%d", rowIdx, localCode, len(localRanks))
+	}
+	return localRanks[localCode], nil
 }
 
 func prepareColumnTypedColumnDenseInt64SpanGlobalCodes(parts []columnTypedColumnPhysicalQueryPart) error {
@@ -2400,6 +2466,29 @@ func columnTypedColumnDenseGroupCountDistinctBitsetWords(groups, wordsPerGroup i
 }
 
 func (r *columnTypedColumnPhysicalQueryRunner) runDenseGroupCountDistinct(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest) (ColumnPhysicalQueryResult, error) {
+	if columnTypedColumnDenseGroupCountDistinctPartsHaveGlobalCodes(r.parts) {
+		return r.runDenseGroupCountDistinctGlobalCodes(view, req)
+	}
+	return r.runDenseGroupCountDistinctLocalCodes(view, req)
+}
+
+func columnTypedColumnDenseGroupCountDistinctPartsHaveGlobalCodes(parts []columnTypedColumnPhysicalQueryPart) bool {
+	for partIdx := range parts {
+		dense := parts[partIdx].DenseGroupCountDistinct
+		if dense == nil {
+			return false
+		}
+		if dense.Group.GlobalDictionary == nil || dense.Distinct.GlobalDictionary == nil {
+			return false
+		}
+		if len(dense.Group.GlobalCodes) != dense.Rows || len(dense.Distinct.GlobalCodes) != dense.Rows {
+			return false
+		}
+	}
+	return true
+}
+
+func (r *columnTypedColumnPhysicalQueryRunner) runDenseGroupCountDistinctGlobalCodes(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest) (ColumnPhysicalQueryResult, error) {
 	start := time.Now()
 	groupCardinality := 0
 	distinctCardinality := 0
@@ -2528,6 +2617,223 @@ func (r *columnTypedColumnPhysicalQueryRunner) runDenseGroupCountDistinct(view c
 				diag := r.diagnostics(view, req, rowsScanned, matchedRows, reduceRows, time.Since(start).Nanoseconds())
 				diag.DenseGroupCountDistinctUsed = true
 				return ColumnPhysicalQueryResult{Diagnostics: diag}, fmt.Errorf("collections: dense typed-column grouped count-distinct part %d distinct code[%d]=%d outside cardinality=%d", partIdx, rowIdx, distinctCode, distinctCardinality)
+			}
+			if usePairBitset {
+				wordIdx := groupIdx*wordsPerGroup + distinctIdx/64
+				mask := uint64(1) << uint(distinctIdx&63)
+				if r.denseGroupCountDistinctPairBits[wordIdx]&mask == 0 {
+					r.denseGroupCountDistinctPairBits[wordIdx] |= mask
+					r.denseGroupCountDistinctDistinctCounts[groupIdx]++
+				}
+			} else if useActivePairBitset {
+				if !r.denseGroupCountDistinctGroupActive[groupIdx] {
+					nextPairBitWords, ok := columnTypedColumnDenseGroupCountDistinctBitsetWords(len(r.denseGroupCountDistinctActiveGroups)+1, wordsPerGroup)
+					if !ok {
+						r.convertDenseGroupCountDistinctActiveBitsToPairs(wordsPerGroup, distinctCardinality)
+						clear(r.denseGroupCountDistinctDistinctCounts)
+						reducer = columnTypedColumnDenseGroupCountDistinctReducerSortedPairs
+						useActivePairBitset = false
+						useSortedPairs = true
+						pairBitWords = 0
+					} else {
+						offset := len(r.denseGroupCountDistinctPairBits)
+						if cap(r.denseGroupCountDistinctPairBits) < nextPairBitWords {
+							nextBits := make([]uint64, nextPairBitWords)
+							copy(nextBits, r.denseGroupCountDistinctPairBits)
+							r.denseGroupCountDistinctPairBits = nextBits
+						} else {
+							r.denseGroupCountDistinctPairBits = r.denseGroupCountDistinctPairBits[:nextPairBitWords]
+							clear(r.denseGroupCountDistinctPairBits[offset:nextPairBitWords])
+						}
+						r.denseGroupCountDistinctGroupActive[groupIdx] = true
+						r.denseGroupCountDistinctGroupOffsets[groupIdx] = offset
+						r.denseGroupCountDistinctActiveGroups = append(r.denseGroupCountDistinctActiveGroups, groupIdx)
+						pairBitWords = nextPairBitWords
+					}
+				}
+				if useActivePairBitset {
+					wordIdx := r.denseGroupCountDistinctGroupOffsets[groupIdx] + distinctIdx/64
+					mask := uint64(1) << uint(distinctIdx&63)
+					if r.denseGroupCountDistinctPairBits[wordIdx]&mask == 0 {
+						r.denseGroupCountDistinctPairBits[wordIdx] |= mask
+						r.denseGroupCountDistinctDistinctCounts[groupIdx]++
+					}
+				} else {
+					r.denseGroupCountDistinctPairList = append(r.denseGroupCountDistinctPairList, uint64(groupIdx)<<32|uint64(distinctIdx))
+				}
+			} else {
+				r.denseGroupCountDistinctPairList = append(r.denseGroupCountDistinctPairList, uint64(groupIdx)<<32|uint64(distinctIdx))
+			}
+		}
+	}
+	if useSortedPairs {
+		slices.Sort(r.denseGroupCountDistinctPairList)
+		var previous uint64
+		havePrevious := false
+		for _, pair := range r.denseGroupCountDistinctPairList {
+			if havePrevious && pair == previous {
+				continue
+			}
+			groupIdx := int(pair >> 32)
+			r.denseGroupCountDistinctDistinctCounts[groupIdx]++
+			previous = pair
+			havePrevious = true
+		}
+	}
+	r.resultGroups = r.resultGroups[:0]
+	for groupIdx, count := range r.denseGroupCountDistinctCounts {
+		distinct := r.denseGroupCountDistinctDistinctCounts[groupIdx]
+		if count == 0 && distinct == 0 {
+			continue
+		}
+		if groupIdx >= len(groupDictionary) {
+			diag := r.diagnostics(view, req, rowsScanned, matchedRows, reduceRows, time.Since(start).Nanoseconds())
+			diag.DenseGroupCountDistinctUsed = true
+			return ColumnPhysicalQueryResult{Diagnostics: diag}, fmt.Errorf("collections: dense typed-column grouped count-distinct group index=%d outside dictionary=%d", groupIdx, len(groupDictionary))
+		}
+		r.resultGroups = append(r.resultGroups, ColumnPhysicalQueryGroup{Key: groupDictionary[groupIdx], Count: count, DistinctCount: distinct})
+	}
+	sortColumnPhysicalQueryGroupsByKey(r.resultGroups)
+	diag := r.diagnostics(view, req, rowsScanned, matchedRows, reduceRows, time.Since(start).Nanoseconds())
+	diag.DenseGroupCountDistinctUsed = true
+	annotateColumnTypedColumnDenseGroupCountDistinctDiagnostics(&diag, groupCardinality, distinctCardinality, pairBitWords, reducer)
+	diag.ResultGroups = len(r.resultGroups)
+	result := ColumnPhysicalQueryResult{Groups: r.resultGroups, Diagnostics: diag}
+	finalizeColumnPhysicalQueryResultGroups(req, &result)
+	r.resultGroups = result.Groups
+	return result, nil
+}
+
+func (r *columnTypedColumnPhysicalQueryRunner) runDenseGroupCountDistinctLocalCodes(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest) (ColumnPhysicalQueryResult, error) {
+	start := time.Now()
+	groupDictionary, groupRanks, err := columnTypedColumnDenseGroupCountDistinctGlobalDictionary(r.parts, func(part *columnTypedColumnDenseGroupCountDistinctPart) *columnTypedColumnDenseStringCodeColumn {
+		return &part.Group
+	})
+	if err != nil {
+		diag := r.diagnostics(view, req, 0, 0, 0, time.Since(start).Nanoseconds())
+		diag.DenseGroupCountDistinctUsed = true
+		return ColumnPhysicalQueryResult{Diagnostics: diag}, err
+	}
+	distinctRanks, distinctCardinality, err := columnTypedColumnDenseGroupCountDistinctGlobalRanks(r.parts, func(part *columnTypedColumnDenseGroupCountDistinctPart) *columnTypedColumnDenseStringCodeColumn {
+		return &part.Distinct
+	})
+	if err != nil {
+		diag := r.diagnostics(view, req, 0, 0, 0, time.Since(start).Nanoseconds())
+		diag.DenseGroupCountDistinctUsed = true
+		return ColumnPhysicalQueryResult{Diagnostics: diag}, err
+	}
+	groupCardinality := len(groupDictionary)
+	if cap(r.denseGroupCountDistinctCounts) < groupCardinality {
+		r.denseGroupCountDistinctCounts = make([]int, groupCardinality)
+	} else {
+		r.denseGroupCountDistinctCounts = r.denseGroupCountDistinctCounts[:groupCardinality]
+		clear(r.denseGroupCountDistinctCounts)
+	}
+	if cap(r.denseGroupCountDistinctDistinctCounts) < groupCardinality {
+		r.denseGroupCountDistinctDistinctCounts = make([]int, groupCardinality)
+	} else {
+		r.denseGroupCountDistinctDistinctCounts = r.denseGroupCountDistinctDistinctCounts[:groupCardinality]
+		clear(r.denseGroupCountDistinctDistinctCounts)
+	}
+	wordsPerGroup, pairBitWords, usePairBitset := columnTypedColumnDenseGroupCountDistinctBitsetLayout(groupCardinality, distinctCardinality)
+	reducer := columnTypedColumnDenseGroupCountDistinctReducerLocalBitset
+	useActivePairBitset := false
+	useSortedPairs := false
+	if usePairBitset {
+		if cap(r.denseGroupCountDistinctPairBits) < pairBitWords {
+			r.denseGroupCountDistinctPairBits = make([]uint64, pairBitWords)
+		} else {
+			r.denseGroupCountDistinctPairBits = r.denseGroupCountDistinctPairBits[:pairBitWords]
+			clear(r.denseGroupCountDistinctPairBits)
+		}
+	} else if wordsPerGroup > 0 && wordsPerGroup <= columnTypedColumnDenseGroupCountDistinctMaxBitsetWords {
+		reducer = columnTypedColumnDenseGroupCountDistinctReducerActiveBitset
+		useActivePairBitset = true
+		pairBitWords = 0
+		r.denseGroupCountDistinctPairBits = r.denseGroupCountDistinctPairBits[:0]
+		if cap(r.denseGroupCountDistinctGroupActive) < groupCardinality {
+			r.denseGroupCountDistinctGroupActive = make([]bool, groupCardinality)
+		} else {
+			r.denseGroupCountDistinctGroupActive = r.denseGroupCountDistinctGroupActive[:groupCardinality]
+			clear(r.denseGroupCountDistinctGroupActive)
+		}
+		if cap(r.denseGroupCountDistinctGroupOffsets) < groupCardinality {
+			r.denseGroupCountDistinctGroupOffsets = make([]int, groupCardinality)
+		} else {
+			r.denseGroupCountDistinctGroupOffsets = r.denseGroupCountDistinctGroupOffsets[:groupCardinality]
+		}
+		r.denseGroupCountDistinctActiveGroups = r.denseGroupCountDistinctActiveGroups[:0]
+	} else {
+		reducer = columnTypedColumnDenseGroupCountDistinctReducerSortedPairs
+		useSortedPairs = true
+		pairBitWords = 0
+		r.denseGroupCountDistinctPairList = r.denseGroupCountDistinctPairList[:0]
+	}
+
+	rowsScanned := 0
+	matchedRows := 0
+	reduceRows := 0
+	for partIdx := range r.parts {
+		dense := r.parts[partIdx].DenseGroupCountDistinct
+		if dense == nil {
+			diag := r.diagnostics(view, req, rowsScanned, matchedRows, reduceRows, time.Since(start).Nanoseconds())
+			diag.DenseGroupCountDistinctUsed = true
+			return ColumnPhysicalQueryResult{Diagnostics: diag}, fmt.Errorf("collections: dense typed-column grouped count-distinct missing prepared part %d", partIdx)
+		}
+		if dense.Rows != len(dense.Group.Codes) || dense.Rows != len(dense.Distinct.Codes) {
+			diag := r.diagnostics(view, req, rowsScanned, matchedRows, reduceRows, time.Since(start).Nanoseconds())
+			diag.DenseGroupCountDistinctUsed = true
+			return ColumnPhysicalQueryResult{Diagnostics: diag}, fmt.Errorf("collections: dense typed-column grouped count-distinct part %d rows=%d group_local=%d distinct_local=%d", partIdx, dense.Rows, len(dense.Group.Codes), len(dense.Distinct.Codes))
+		}
+		groupLocalRanks, groupEmptyRank, groupEmptyOK, err := columnTypedColumnDenseGroupCountDistinctLocalRanks(&dense.Group, groupRanks)
+		if err != nil {
+			diag := r.diagnostics(view, req, rowsScanned, matchedRows, reduceRows, time.Since(start).Nanoseconds())
+			diag.DenseGroupCountDistinctUsed = true
+			return ColumnPhysicalQueryResult{Diagnostics: diag}, fmt.Errorf("collections: dense typed-column grouped count-distinct group part %d: %w", partIdx, err)
+		}
+		distinctLocalRanks, distinctEmptyRank, distinctEmptyOK, err := columnTypedColumnDenseGroupCountDistinctLocalRanks(&dense.Distinct, distinctRanks)
+		if err != nil {
+			diag := r.diagnostics(view, req, rowsScanned, matchedRows, reduceRows, time.Since(start).Nanoseconds())
+			diag.DenseGroupCountDistinctUsed = true
+			return ColumnPhysicalQueryResult{Diagnostics: diag}, fmt.Errorf("collections: dense typed-column grouped count-distinct distinct part %d: %w", partIdx, err)
+		}
+		if columnTypedColumnDensePredicatesRejectAll(dense.Predicates) {
+			rowsScanned += dense.Rows
+			continue
+		}
+		for rowIdx := 0; rowIdx < dense.Rows; rowIdx++ {
+			rowsScanned++
+			if !columnTypedColumnDensePredicatesMatch(dense.Predicates, rowIdx) {
+				continue
+			}
+			if len(dense.Predicates) != 0 {
+				matchedRows++
+			}
+			reduceRows++
+			groupCode, err := columnTypedColumnDenseGroupCountDistinctRowRank(&dense.Group, groupLocalRanks, groupEmptyRank, groupEmptyOK, rowIdx)
+			if err != nil {
+				diag := r.diagnostics(view, req, rowsScanned, matchedRows, reduceRows, time.Since(start).Nanoseconds())
+				diag.DenseGroupCountDistinctUsed = true
+				return ColumnPhysicalQueryResult{Diagnostics: diag}, fmt.Errorf("collections: dense typed-column grouped count-distinct part %d group: %w", partIdx, err)
+			}
+			groupIdx, ok := columnDictionaryCodeIndex(groupCode, len(r.denseGroupCountDistinctCounts))
+			if !ok {
+				diag := r.diagnostics(view, req, rowsScanned, matchedRows, reduceRows, time.Since(start).Nanoseconds())
+				diag.DenseGroupCountDistinctUsed = true
+				return ColumnPhysicalQueryResult{Diagnostics: diag}, fmt.Errorf("collections: dense typed-column grouped count-distinct part %d group rank[%d]=%d outside cardinality=%d", partIdx, rowIdx, groupCode, len(r.denseGroupCountDistinctCounts))
+			}
+			r.denseGroupCountDistinctCounts[groupIdx]++
+			distinctCode, err := columnTypedColumnDenseGroupCountDistinctRowRank(&dense.Distinct, distinctLocalRanks, distinctEmptyRank, distinctEmptyOK, rowIdx)
+			if err != nil {
+				diag := r.diagnostics(view, req, rowsScanned, matchedRows, reduceRows, time.Since(start).Nanoseconds())
+				diag.DenseGroupCountDistinctUsed = true
+				return ColumnPhysicalQueryResult{Diagnostics: diag}, fmt.Errorf("collections: dense typed-column grouped count-distinct part %d distinct: %w", partIdx, err)
+			}
+			distinctIdx, ok := columnDictionaryCodeIndex(distinctCode, distinctCardinality)
+			if !ok {
+				diag := r.diagnostics(view, req, rowsScanned, matchedRows, reduceRows, time.Since(start).Nanoseconds())
+				diag.DenseGroupCountDistinctUsed = true
+				return ColumnPhysicalQueryResult{Diagnostics: diag}, fmt.Errorf("collections: dense typed-column grouped count-distinct part %d distinct rank[%d]=%d outside cardinality=%d", partIdx, rowIdx, distinctCode, distinctCardinality)
 			}
 			if usePairBitset {
 				wordIdx := groupIdx*wordsPerGroup + distinctIdx/64


### PR DESCRIPTION
Closes #3080.

## Scope

This is a focused q2 `one_shot_end_to_end` / `no_aggregate_metadata` improvement for the production direct typed-column path. It does not claim broad SQL superiority, does not use aggregate metadata, and does not change insert/load/storage behavior or on-disk formats.

## Changes

- Split dense q2 global-code preparation so direct one-shot execution no longer prepares per-row global code arrays.
- Added a direct local-dictionary q2 reducer that builds sorted global ranks only for the rendered group column.
- Uses insertion-order ranks for the high-cardinality internal distinct column, since q2 only needs distinct cardinality, not distinct value rendering.
- Keeps prepared/hot q2 on the existing global-code reducer with sorted global dictionaries.
- Added tests for direct vs prepared reducer selection, local-dictionary correctness, and nullable/missing value normalization.

## Evidence

Baseline saved in #3080 from `/tmp/jsonbench_one_shot_direct_1m_noagg_20260626_023258/treedb/1m_column-store-full-prepared_one_shot_end_to_end_no_aggregate_metadata_json_full_all/result.json`:

- q2 best: `0.227146334s`
- run: `227125208ns`, scan: `226977000ns`, render/hash: `21000ns`
- rows scanned: `1,000,000`; rows matched/reduced: `954,611`; groups: `13`
- decoded payload: `32,925,252` bytes; physical bytes scanned: `21,632,156`
- TreeDB WAL-excluded durable storage: `137,488,386` bytes

Candidate no-profile acceptance run: `/tmp/jsonbench_q2_local_ranks_noprofile_1m_20260626_043116/result.json`

- q2 attempts: `0.197800417s`, `0.179336583s`, `0.174565375s`
- q2 best: `0.174565375s`; median: `0.179336583s`
- run: `174545874ns`, scan: `174389042ns`, render/hash: `19375ns`
- rows scanned: `1,000,000`; rows matched/reduced: `954,611`; groups: `13`
- decoded payload: `32,925,252` bytes; physical bytes scanned: `21,632,156`
- load rows: `1,000,000`; insert: `16.057243874s`; load wall: `19.217634042s`
- TreeDB WAL-excluded durable storage: `137,488,386` bytes

Improvement versus the saved q2 baseline: `23.15%` lower total time. This clears the #3080 gate of `<= 0.181717067s`.

Profiled diagnostic run, with expected profiling overhead: `/tmp/jsonbench_q2_local_ranks_1m_20260626_042756/result.json`

- q2 best: `0.184774041s`; attempts: `0.210914792s`, `0.193122958s`, `0.184774041s`
- profiles: `/tmp/jsonbench_q2_local_ranks_1m_20260626_042756/profiles/cpu_q2_attempt1.pprof`, `/tmp/jsonbench_q2_local_ranks_1m_20260626_042756/profiles/allocs_q2_attempt1.pprof`

ClickHouse context from #3080 remains `0.0250s` for q2, so TreeDB remains about `6.98x` slower than the saved ClickHouse q2 number even after this improvement.

Note: the current JSONBench result JSON does not flatten the new q2 reducer label/cardinality fields from gomap diagnostics; the gomap tests assert direct uses `local_dictionary_pair_bitset` and prepared uses `pair_bitset`.

## Validation

- `go test ./TreeDB/collections -run 'TestTypedColumnQ2DenseGroupCountDistinct|TestTypedColumnQ2SortedGroupedDistinctLocalDictionariesAndEmptyValues1950' -count=1`
- `go test ./TreeDB/collections -count=1`
- `go test ./TreeDB/... -count=1`
- `git diff --check`
