### PR TITLE
TreeDB: speed q5 dense predicate scans

### DIFF
--- a/TreeDB/collections/column_physical_typed_column_query.go
+++ b/TreeDB/collections/column_physical_typed_column_query.go
@@ -52,6 +52,8 @@ type columnTypedColumnDensePredicatePart struct {
 	Codes               []uint32
 	Valid               []bool
 	Allowed             []uint64
+	SingleCode          uint32
+	SingleCodeAllowed   bool
 	MissingMatchesEmpty bool
 	RejectsAll          bool
 }
@@ -3384,12 +3386,18 @@ func columnTypedColumnDensePredicatesMatch(predicates []columnTypedColumnDensePr
 		if predicate.RejectsAll || rowIdx < 0 || rowIdx >= len(predicate.Codes) {
 			return false
 		}
+		if predicate.SingleCodeAllowed {
+			return columnTypedColumnDensePredicateSingleCodeMatchesAfterBounds(predicate, rowIdx)
+		}
 		return columnTypedColumnDensePredicateMatchesAfterBounds(predicate, rowIdx)
 	case 2:
 		left := &predicates[0]
 		right := &predicates[1]
 		if left.RejectsAll || right.RejectsAll || rowIdx < 0 || rowIdx >= len(left.Codes) || rowIdx >= len(right.Codes) {
 			return false
+		}
+		if left.SingleCodeAllowed && right.SingleCodeAllowed {
+			return columnTypedColumnDensePredicateSingleCodeMatchesAfterBounds(left, rowIdx) && columnTypedColumnDensePredicateSingleCodeMatchesAfterBounds(right, rowIdx)
 		}
 		if left.Valid == nil && right.Valid == nil {
 			if !columnTypedColumnCodeAllowed(left.Allowed, left.Codes[rowIdx]) {
@@ -3398,6 +3406,18 @@ func columnTypedColumnDensePredicatesMatch(predicates []columnTypedColumnDensePr
 			return columnTypedColumnCodeAllowed(right.Allowed, right.Codes[rowIdx])
 		}
 		return columnTypedColumnDensePredicateMatchesAfterBounds(left, rowIdx) && columnTypedColumnDensePredicateMatchesAfterBounds(right, rowIdx)
+	case 3:
+		left := &predicates[0]
+		mid := &predicates[1]
+		right := &predicates[2]
+		if left.RejectsAll || mid.RejectsAll || right.RejectsAll || rowIdx < 0 || rowIdx >= len(left.Codes) || rowIdx >= len(mid.Codes) || rowIdx >= len(right.Codes) {
+			return false
+		}
+		if left.SingleCodeAllowed && mid.SingleCodeAllowed && right.SingleCodeAllowed {
+			return columnTypedColumnDensePredicateSingleCodeMatchesAfterBounds(left, rowIdx) &&
+				columnTypedColumnDensePredicateSingleCodeMatchesAfterBounds(mid, rowIdx) &&
+				columnTypedColumnDensePredicateSingleCodeMatchesAfterBounds(right, rowIdx)
+		}
 	}
 	for _, predicate := range predicates {
 		if predicate.RejectsAll {
@@ -3424,6 +3444,13 @@ func columnTypedColumnDensePredicateMatchesAfterBounds(predicate *columnTypedCol
 		return predicate.MissingMatchesEmpty
 	}
 	return columnTypedColumnCodeAllowed(predicate.Allowed, predicate.Codes[rowIdx])
+}
+
+func columnTypedColumnDensePredicateSingleCodeMatchesAfterBounds(predicate *columnTypedColumnDensePredicatePart, rowIdx int) bool {
+	if !columnTypedColumnDenseCodeValid(predicate.Valid, rowIdx) {
+		return false
+	}
+	return predicate.Codes[rowIdx] == predicate.SingleCode
 }
 
 func columnTypedColumnDenseCodeValid(valid []bool, rowIdx int) bool {

--- a/TreeDB/collections/typed_column_adapter.go
+++ b/TreeDB/collections/typed_column_adapter.go
@@ -2232,6 +2232,9 @@ func decodeTypedColumnDensePredicatePart(adapterPart *typedColumnAdapterPart, fi
 	}
 	allowed := make([]uint64, (cardinality+63)/64)
 	matchedLiterals := 0
+	singleCode := uint32(0)
+	singleCodeAllowed := false
+	multipleCodesAllowed := false
 	missingMatchesEmpty := false
 	for _, value := range spec.values {
 		if adapterColumn.Field.Nullable && value == "" {
@@ -2245,24 +2248,34 @@ func decodeTypedColumnDensePredicatePart(adapterPart *typedColumnAdapterPart, fi
 			return columnTypedColumnDensePredicatePart{}, 0, 0, fmt.Errorf("collections: dense typed-column predicate dictionary code %d outside cardinality %d for column %q", code, cardinality, adapterColumn.Definition.Name)
 		}
 		idx := int(code)
-		allowed[idx/64] |= uint64(1) << uint(idx%64)
+		mask := uint64(1) << uint(idx%64)
+		if allowed[idx/64]&mask == 0 {
+			if singleCodeAllowed && singleCode != uint32(idx) {
+				multipleCodesAllowed = true
+			} else {
+				singleCode = uint32(idx)
+				singleCodeAllowed = true
+			}
+		}
+		allowed[idx/64] |= mask
 		matchedLiterals++
 	}
 	if matchedLiterals == 0 && !missingMatchesEmpty {
 		return columnTypedColumnDensePredicatePart{RejectsAll: true}, 0, 0, nil
 	}
+	singleCodeAllowed = singleCodeAllowed && !multipleCodesAllowed && !missingMatchesEmpty
 	if adapterColumn.Field.Nullable {
 		codes, valid, decodedBytes, blocks, err := decodeTypedColumnDenseNullableUint32Codes(partColumn, cardinality, rows, "predicate")
 		if err != nil {
 			return columnTypedColumnDensePredicatePart{}, 0, 0, err
 		}
-		return columnTypedColumnDensePredicatePart{Codes: codes, Valid: valid, Allowed: allowed, MissingMatchesEmpty: missingMatchesEmpty}, decodedBytes, blocks, nil
+		return columnTypedColumnDensePredicatePart{Codes: codes, Valid: valid, Allowed: allowed, SingleCode: singleCode, SingleCodeAllowed: singleCodeAllowed, MissingMatchesEmpty: missingMatchesEmpty}, decodedBytes, blocks, nil
 	}
 	codes, decodedBytes, blocks, err := decodeTypedColumnDenseUint32Codes(partColumn, cardinality, rows, "predicate")
 	if err != nil {
 		return columnTypedColumnDensePredicatePart{}, 0, 0, err
 	}
-	return columnTypedColumnDensePredicatePart{Codes: codes, Allowed: allowed}, decodedBytes, blocks, nil
+	return columnTypedColumnDensePredicatePart{Codes: codes, Allowed: allowed, SingleCode: singleCode, SingleCodeAllowed: singleCodeAllowed}, decodedBytes, blocks, nil
 }
 
 func decodeTypedColumnDenseUint32Codes(partColumn typedcolumn.ColumnPartColumn, cardinality int, rows int, role string) ([]uint32, uint64, int, error) {


### PR DESCRIPTION
## Summary

- record single-literal dictionary codes while decoding dense typed-column predicate parts
- use direct single-code comparisons for one-, two-, and three-predicate dense scans instead of rechecking predicate bitsets on every row
- improves the q5 `one_shot_end_to_end` / `no_aggregate_metadata` typed-column scan path without using aggregate metadata or a reused prepared runner

## Scope

Improves: one-shot query execution, no-aggregate-metadata typed-column scan predicate evaluation, q5 dense int64-span scan/reduce.

Does not improve: insert/load speed, metadata storage cost, hot prepared execution, automatic aggregate metadata acceleration.

This PR does not support a broad "TreeDB SQL is faster than ClickHouse" claim. It is a q5 no-metadata scan slice under tracker #3070 and child issue #3082.

Closes #3082.

## Benchmark Evidence

Baseline from #3082:

- artifact: `/tmp/jsonbench_one_shot_direct_1m_noagg_20260626_023258/treedb/1m_column-store-full-prepared_one_shot_end_to_end_no_aggregate_metadata_json_full_all/result.json`
- q5 total: `0.183331791s`
- q5 gate: `<=0.146665433s` (20% faster)

Candidate on this branch:

- artifact: `/tmp/jsonbench_q5_single_pred_1m_20260625_190704/result.json`
- query mode: `one_shot_end_to_end`
- metadata mode: `no_aggregate_metadata`
- attempts: `[0.160538291s, 0.142589792s, 0.141637084s]`
- best: `0.141637084s`
- median: `0.142589792s`
- improvement versus baseline best: ~22.7%
- rows scanned: `1,000,000`
- rows matched/reduced: `86,812`
- result rows: `3`
- TopK candidates: `50,464`
- decoded payload bytes: `34,933,080`
- physical bytes scanned: `21,632,156`
- aggregate metadata used: no
- bounded TopK used: yes
- JSON reconstruction: no
- result hash: `ef6217ce9da3a74fdf600ccbebd333457f017d6012dc0c231338961533f5689c`

Load/storage context from the candidate artifact:

- rows loaded: `1,000,000`
- insert time: `15.887754453s`
- load wall time: `18.995820417s`
- TreeDB durable storage, WAL excluded: `137,488,386` bytes

ClickHouse q5 context from #3082 remains `0.0140s`, so TreeDB q5 one-shot/no-metadata is still slower than ClickHouse. This PR only reduces the current TreeDB gap.

## Reproduction

```sh
cd /Users/michaelseiler/dev/snissn/JSONBench/treedb
backup_dir=$(mktemp -d /tmp/jsonbench_treedb_gomod_XXXXXX)
cp go.mod "$backup_dir/go.mod"
cp go.sum "$backup_dir/go.sum"
trap 'cp "$backup_dir/go.mod" go.mod; cp "$backup_dir/go.sum" go.sum; rm -rf "$backup_dir"' EXIT
go mod edit -replace=github.com/snissn/gomap=/Users/michaelseiler/dev/snissn/gomap-clean
OUT=/tmp/jsonbench_q5_single_pred_1m_$(date +%Y%m%d_%H%M%S)
go run ./cmd/jsonbench_treedb run \
  -data-dir /Users/michaelseiler/data/bluesky \
  -db-dir "$OUT/db" \
  -reset \
  -scale 1m \
  -format json \
  -storage-layout column-store-full-prepared \
  -query-mode one_shot_end_to_end \
  -metadata-mode no_aggregate_metadata \
  -projection full \
  -queries q5 \
  -batch-size 16000 \
  -tries 3 \
  -profile fast \
  -data-root fast \
  -allow-errors \
  -out "$OUT/result.json"
```

## Tests

```sh
go test ./TreeDB/collections -run 'TestColumnPhysicalQ5DenseTypedColumnDirectPreparedParity1950|TestColumnPhysicalJSONBenchTypedColumnPartNullableFullDataTopKFastPaths2878' -count=1
go test ./TreeDB/collections -count=1
go test ./TreeDB/... -count=1
git diff --check
```
