### PR TITLE
[codex] add R3a deterministic apply harness

### DIFF
--- a/TreeDB/internal/raftapply/apply.go
+++ b/TreeDB/internal/raftapply/apply.go
@@ -1,0 +1,209 @@
+package raftapply
+
+import (
+	"errors"
+	"fmt"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+	"github.com/snissn/gomap/TreeDB/internal/commandwalapply"
+	"github.com/snissn/gomap/TreeDB/internal/nativewire"
+	"github.com/snissn/gomap/TreeDB/internal/raftentry"
+)
+
+// LocalDurabilityBoundaryV1 names the local durability boundary a committed
+// deterministic entry is allowed to use before it becomes locally visible.
+type LocalDurabilityBoundaryV1 string
+
+const (
+	// LocalDurabilityCommandWALV1 requires a local command-WAL frame before any
+	// visible mutation, result/idempotency record, or apply-progress advance.
+	LocalDurabilityCommandWALV1 LocalDurabilityBoundaryV1 = "local-command-wal-v1"
+)
+
+// ApplyMetadataV1 is explicit per-entry metadata carried beside committed
+// deterministic entry bytes. None of these fields are native-wire request
+// structs or handler inputs.
+type ApplyMetadataV1 struct {
+	EntryID                 raftentry.ApplyEntryID
+	LocalDurabilityBoundary LocalDurabilityBoundaryV1
+	SyncLocalCommandWAL     bool
+
+	ScopeRule       raftentry.ScopeRuleV1
+	DatabaseScope   string
+	CatalogScope    string
+	RequestMetadata raftentry.RequestMetadataV1
+	ExpectedTarget  *raftentry.TargetIdentityV1
+}
+
+// CommandWALApplySeam is the local command-WAL append/finalize boundary added
+// by commandwalapply. Rejection tests inject a counting seam to prove this
+// boundary is not called before fail-closed validation completes.
+type CommandWALApplySeam interface {
+	Append(*backenddb.DB, commandwalapply.LoweredFrame, commandwalapply.ApplyMetadata, commandwalapply.Options) (commandwalapply.Handle, commandwalapply.Result, error)
+	Finalize(*backenddb.DB, commandwalapply.Handle, commandwalapply.ApplyMetadata, commandwalapply.Options) (commandwalapply.Result, error)
+}
+
+type defaultCommandWALApplySeam struct{}
+
+func (defaultCommandWALApplySeam) Append(db *backenddb.DB, frame commandwalapply.LoweredFrame, meta commandwalapply.ApplyMetadata, opts commandwalapply.Options) (commandwalapply.Handle, commandwalapply.Result, error) {
+	return commandwalapply.Append(db, frame, meta, opts)
+}
+
+func (defaultCommandWALApplySeam) Finalize(db *backenddb.DB, handle commandwalapply.Handle, meta commandwalapply.ApplyMetadata, opts commandwalapply.Options) (commandwalapply.Result, error) {
+	return commandwalapply.Finalize(db, handle, meta, opts)
+}
+
+// Options wires the harness to deterministic decode limits, fake or durable
+// stores, and the command-WAL seam. Nil stores are allowed for early tests but
+// mean duplicates/progress cannot be durably recorded.
+type Options struct {
+	DecodeLimits        nativewire.Limits
+	ProgressStore       ApplyProgressStore
+	ResultStore         ApplyResultStore
+	CommandWALApplySeam CommandWALApplySeam
+}
+
+// Harness applies committed deterministic entry bytes to one local DB handle.
+type Harness struct {
+	db       *backenddb.DB
+	opts     Options
+	walApply CommandWALApplySeam
+}
+
+// NewHarness constructs an R3a apply harness for committed deterministic bytes.
+func NewHarness(db *backenddb.DB, opts Options) *Harness {
+	walApply := opts.CommandWALApplySeam
+	if walApply == nil {
+		walApply = defaultCommandWALApplySeam{}
+	}
+	return &Harness{db: db, opts: opts, walApply: walApply}
+}
+
+// ApplyCommittedEntryV1 applies committed deterministic entry bytes through a
+// short-lived harness.
+func ApplyCommittedEntryV1(db *backenddb.DB, entryBytes []byte, meta ApplyMetadataV1, opts Options) (raftentry.ApplyResultV1, error) {
+	return NewHarness(db, opts).ApplyCommittedEntryV1(entryBytes, meta)
+}
+
+// ApplyCommittedEntryV1 decodes, validates, classifies, and fail-closed rejects
+// committed deterministic entry bytes. This slice deliberately does not lower
+// any command to a local command-WAL frame yet.
+func (h *Harness) ApplyCommittedEntryV1(entryBytes []byte, meta ApplyMetadataV1) (raftentry.ApplyResultV1, error) {
+	if h == nil {
+		return reject(raftentry.CommandDigestV1{}, raftentry.ErrorUnsafeDurabilityModeV1, fmt.Errorf("raftapply: nil harness"))
+	}
+	if err := h.preflightLocalBoundary(meta); err != nil {
+		code, _ := ErrorCodeOf(err)
+		return reject(raftentry.CommandDigestV1{}, code, err)
+	}
+	if err := validateApplyEntryID(meta.EntryID); err != nil {
+		code, _ := ErrorCodeOf(err)
+		return reject(raftentry.CommandDigestV1{}, code, err)
+	}
+	if h.opts.ProgressStore != nil {
+		if err := h.opts.ProgressStore.CheckCanApply(meta.EntryID); err != nil {
+			code, _ := ErrorCodeOf(err)
+			return reject(raftentry.CommandDigestV1{}, code, err)
+		}
+	}
+
+	decodeOpts := raftentry.DecodeOptions{
+		Limits:          h.opts.DecodeLimits,
+		ScopeRule:       meta.ScopeRule,
+		DatabaseScope:   meta.DatabaseScope,
+		CatalogScope:    meta.CatalogScope,
+		ApplyEntryID:    meta.EntryID,
+		RequestMetadata: meta.RequestMetadata,
+		ExpectedTarget:  meta.ExpectedTarget,
+	}
+	entry, err := raftentry.DecodeCommandEntryV1(entryBytes, decodeOpts)
+	if err != nil {
+		code := codeFromDecodeError(err)
+		digest, _ := raftentry.ValidateCommandDigestInputV1(entryBytes, decodeOpts)
+		return reject(digest, code, err)
+	}
+
+	if h.opts.ResultStore != nil {
+		record, ok, err := h.opts.ResultStore.LookupApplyResult(meta.EntryID)
+		if err != nil {
+			code, _ := ErrorCodeOf(err)
+			return reject(entry.Digest, code, err)
+		}
+		if ok {
+			if record.CommandDigest != entry.Digest {
+				return reject(entry.Digest, raftentry.ErrorRejectedConflictV1, fmt.Errorf("raftapply: apply entry %d/%d digest conflicts with existing result", meta.EntryID.Term, meta.EntryID.Index))
+			}
+			return reject(entry.Digest, raftentry.ErrorResultReplayRequiredV1, fmt.Errorf("raftapply: apply entry %d/%d result replay is not implemented", meta.EntryID.Term, meta.EntryID.Index))
+		}
+	}
+
+	return reject(entry.Digest, raftentry.ErrorUnsupportedCommandV1, fmt.Errorf("raftapply: %s decoded but command lowering is deferred", entry.Row.NativeWireCommand))
+}
+
+func (h *Harness) preflightLocalBoundary(meta ApplyMetadataV1) error {
+	if meta.LocalDurabilityBoundary != LocalDurabilityCommandWALV1 {
+		if meta.LocalDurabilityBoundary == "" {
+			return codedError(raftentry.ErrorUnsafeDurabilityModeV1, "missing local durability boundary")
+		}
+		return codedError(raftentry.ErrorUnsafeDurabilityModeV1, "unsupported local durability boundary %q", meta.LocalDurabilityBoundary)
+	}
+	if h.db == nil {
+		return codedError(raftentry.ErrorUnsafeDurabilityModeV1, "nil DB cannot provide local command WAL durability")
+	}
+	if !h.db.CommandWALEnabled() {
+		return codedError(raftentry.ErrorUnsafeDurabilityModeV1, "local command WAL is disabled")
+	}
+	if err := h.db.CheckStorageMaintenanceReady(); err != nil {
+		if errors.Is(err, backenddb.ErrReadOnly) {
+			return codedError(raftentry.ErrorReadOnlyV1, "read-only DB rejects deterministic apply")
+		}
+		if errors.Is(err, backenddb.ErrClosed) {
+			return codedError(raftentry.ErrorUnsafeDurabilityModeV1, "closed DB rejects deterministic apply")
+		}
+		return codedError(raftentry.ErrorUnsafeDurabilityModeV1, "local command WAL boundary is not writable: %v", err)
+	}
+	return nil
+}
+
+func validateApplyEntryID(id raftentry.ApplyEntryID) error {
+	if id.Term == 0 || id.Index == 0 {
+		return codedError(raftentry.ErrorMalformedEntryV1, "apply entry id must have non-zero term and index")
+	}
+	return nil
+}
+
+func codeFromDecodeError(err error) raftentry.DeterministicErrorCodeV1 {
+	if code, ok := raftentry.ErrorCodeOf(err); ok {
+		return code
+	}
+	return raftentry.ErrorMalformedEntryV1
+}
+
+func reject(digest raftentry.CommandDigestV1, code raftentry.DeterministicErrorCodeV1, err error) (raftentry.ApplyResultV1, error) {
+	if code == "" {
+		code = raftentry.ErrorMalformedEntryV1
+	}
+	result := raftentry.ApplyResultV1{
+		Status:                 statusForCode(code),
+		CommandDigest:          digest,
+		DeterministicErrorCode: code,
+	}
+	return result, &Error{Code: code, Err: err}
+}
+
+func statusForCode(code raftentry.DeterministicErrorCodeV1) raftentry.ApplyStatusV1 {
+	switch code {
+	case raftentry.ErrorMalformedEntryV1:
+		return raftentry.ApplyStatusRejectedMalformed
+	case raftentry.ErrorUnsupportedCommandV1,
+		raftentry.ErrorUnsupportedVersionV1,
+		raftentry.ErrorUnsupportedFeatureV1,
+		raftentry.ErrorUnknownRequiredFieldV1,
+		raftentry.ErrorUnsupportedScopeRuleV1:
+		return raftentry.ApplyStatusRejectedUnsupported
+	case raftentry.ErrorRejectedConflictV1:
+		return raftentry.ApplyStatusRejectedConflict
+	default:
+		return raftentry.ApplyStatusDeterministicGuardFailure
+	}
+}

--- a/TreeDB/internal/raftapply/apply_test.go
+++ b/TreeDB/internal/raftapply/apply_test.go
@@ -1,0 +1,379 @@
+package raftapply
+
+import (
+	"encoding/hex"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/collections"
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+	"github.com/snissn/gomap/TreeDB/internal/commandwalapply"
+	"github.com/snissn/gomap/TreeDB/internal/commitlog"
+	"github.com/snissn/gomap/TreeDB/internal/raftentry"
+)
+
+func TestUnsupportedDeterministicEntryRejectsBeforeAppendAndStores(t *testing.T) {
+	dir := t.TempDir()
+	db := openApplyHarnessDB(t, dir)
+	defer func() { _ = db.Close() }()
+
+	progress := NewMemoryApplyProgressStore(8, 8)
+	results := NewMemoryApplyResultStore(8)
+	seam := &countingCommandWALApplySeam{}
+	raw := readHexFixture(t, "../nativewire/testdata/v1/insert_batch_entry.hex")
+
+	beforeLSN := db.State().AppliedCommandLSN
+	result, err := ApplyCommittedEntryV1(db, raw, applyMeta(1, 1), Options{
+		ProgressStore:       progress,
+		ResultStore:         results,
+		CommandWALApplySeam: seam,
+	})
+	assertRejected(t, result, err, raftentry.ApplyStatusRejectedUnsupported, raftentry.ErrorUnsupportedCommandV1)
+	if result.CommandDigest == (raftentry.CommandDigestV1{}) {
+		t.Fatal("unsupported deterministic entry should still report a digest")
+	}
+	if seam.appendCalls != 0 || seam.finalizeCalls != 0 {
+		t.Fatalf("command-WAL seam calls append=%d finalize=%d, want 0", seam.appendCalls, seam.finalizeCalls)
+	}
+	if got := len(readCommandWALFrames(t, dir)); got != 0 {
+		t.Fatalf("command WAL frames=%d, want 0", got)
+	}
+	if got := db.State().AppliedCommandLSN; got != beforeLSN {
+		t.Fatalf("AppliedCommandLSN=%d, want %d", got, beforeLSN)
+	}
+	if progress.Len() != 0 {
+		t.Fatalf("progress records=%d, want 0", progress.Len())
+	}
+	if results.Len() != 0 {
+		t.Fatalf("result records=%d, want 0", results.Len())
+	}
+}
+
+func TestCreateCollectionDecodedButNotLoweredDoesNotMutateCatalog(t *testing.T) {
+	dir := t.TempDir()
+	db := openApplyHarnessDB(t, dir)
+	defer func() { _ = db.Close() }()
+
+	seam := &countingCommandWALApplySeam{}
+	raw := readHexFixture(t, "../nativewire/testdata/v1/create_collection_entry.hex")
+	result, err := ApplyCommittedEntryV1(db, raw, applyMeta(1, 1), Options{
+		ProgressStore:       NewMemoryApplyProgressStore(8, 8),
+		ResultStore:         NewMemoryApplyResultStore(8),
+		CommandWALApplySeam: seam,
+	})
+	assertRejected(t, result, err, raftentry.ApplyStatusRejectedUnsupported, raftentry.ErrorUnsupportedCommandV1)
+	if seam.appendCalls != 0 || len(readCommandWALFrames(t, dir)) != 0 {
+		t.Fatalf("create_collection rejection reached command WAL seam/files append=%d frames=%d", seam.appendCalls, len(readCommandWALFrames(t, dir)))
+	}
+	_, openErr := collections.NewCollectionManager(db).OpenCollection("users")
+	if !errors.Is(openErr, collections.ErrCollectionNotFound) {
+		t.Fatalf("OpenCollection users error=%v, want ErrCollectionNotFound", openErr)
+	}
+	if got := db.State().AppliedCommandLSN; got != 0 {
+		t.Fatalf("AppliedCommandLSN=%d, want 0", got)
+	}
+}
+
+func TestMalformedBytesReturnDeterministicErrorWithoutAppend(t *testing.T) {
+	dir := t.TempDir()
+	db := openApplyHarnessDB(t, dir)
+	defer func() { _ = db.Close() }()
+
+	seam := &countingCommandWALApplySeam{}
+	result, err := ApplyCommittedEntryV1(db, []byte("bad"), applyMeta(1, 1), Options{CommandWALApplySeam: seam})
+	assertRejected(t, result, err, raftentry.ApplyStatusRejectedMalformed, raftentry.ErrorMalformedEntryV1)
+	if result.CommandDigest != (raftentry.CommandDigestV1{}) {
+		t.Fatalf("malformed digest=%s, want zero digest", result.CommandDigest.Hex())
+	}
+	if seam.appendCalls != 0 || len(readCommandWALFrames(t, dir)) != 0 {
+		t.Fatalf("malformed input reached append path append=%d frames=%d", seam.appendCalls, len(readCommandWALFrames(t, dir)))
+	}
+}
+
+func TestHarnessApplyAPIAcceptsDeterministicBytesOnly(t *testing.T) {
+	method := reflect.TypeOf((*Harness).ApplyCommittedEntryV1)
+	if method.NumIn() != 3 {
+		t.Fatalf("Harness.ApplyCommittedEntryV1 inputs=%d, want receiver+bytes+metadata", method.NumIn())
+	}
+	bytesType := method.In(1)
+	if bytesType.Kind() != reflect.Slice || bytesType.Elem().Kind() != reflect.Uint8 {
+		t.Fatalf("ApplyCommittedEntryV1 input=%s, want []byte deterministic entry", bytesType)
+	}
+	if got := method.In(2); got != reflect.TypeOf(ApplyMetadataV1{}) {
+		t.Fatalf("ApplyCommittedEntryV1 metadata input=%s, want ApplyMetadataV1", got)
+	}
+}
+
+func TestProgressBoundOverflowFailsBeforeAppendOrMutation(t *testing.T) {
+	dir := t.TempDir()
+	db := openApplyHarnessDB(t, dir)
+	defer func() { _ = db.Close() }()
+
+	seam := &countingCommandWALApplySeam{}
+	raw := readHexFixture(t, "../nativewire/testdata/v1/create_collection_entry.hex")
+	result, err := ApplyCommittedEntryV1(db, raw, applyMeta(1, 2), Options{
+		ProgressStore:       NewMemoryApplyProgressStore(8, 1),
+		CommandWALApplySeam: seam,
+	})
+	assertRejected(t, result, err, raftentry.ApplyStatusDeterministicGuardFailure, raftentry.ErrorResourceExhaustedV1)
+	if seam.appendCalls != 0 || len(readCommandWALFrames(t, dir)) != 0 {
+		t.Fatalf("overflow reached append path append=%d frames=%d", seam.appendCalls, len(readCommandWALFrames(t, dir)))
+	}
+	_, openErr := collections.NewCollectionManager(db).OpenCollection("users")
+	if !errors.Is(openErr, collections.ErrCollectionNotFound) {
+		t.Fatalf("OpenCollection users after overflow error=%v, want ErrCollectionNotFound", openErr)
+	}
+}
+
+func TestProgressGapFailsBeforeAppendOrMutation(t *testing.T) {
+	dir := t.TempDir()
+	db := openApplyHarnessDB(t, dir)
+	defer func() { _ = db.Close() }()
+
+	seam := &countingCommandWALApplySeam{}
+	raw := readHexFixture(t, "../nativewire/testdata/v1/create_collection_entry.hex")
+	result, err := ApplyCommittedEntryV1(db, raw, applyMeta(1, 2), Options{
+		ProgressStore:       NewMemoryApplyProgressStore(8, 8),
+		CommandWALApplySeam: seam,
+	})
+	assertRejected(t, result, err, raftentry.ApplyStatusRejectedConflict, raftentry.ErrorRejectedConflictV1)
+	if seam.appendCalls != 0 || len(readCommandWALFrames(t, dir)) != 0 {
+		t.Fatalf("gap reached append path append=%d frames=%d", seam.appendCalls, len(readCommandWALFrames(t, dir)))
+	}
+	if got := db.State().AppliedCommandLSN; got != 0 {
+		t.Fatalf("AppliedCommandLSN after gap=%d, want 0", got)
+	}
+	_, openErr := collections.NewCollectionManager(db).OpenCollection("users")
+	if !errors.Is(openErr, collections.ErrCollectionNotFound) {
+		t.Fatalf("OpenCollection users after gap error=%v, want ErrCollectionNotFound", openErr)
+	}
+}
+
+func TestReadOnlyDBApplyFailsBeforeAppendOrMutation(t *testing.T) {
+	dir := t.TempDir()
+	db := openApplyHarnessDB(t, dir)
+	if err := db.Close(); err != nil {
+		t.Fatalf("Close writable DB: %v", err)
+	}
+	ro, err := backenddb.Open(backenddb.Options{Dir: dir, ReadOnly: true, CommandWAL: true, DisableBackgroundPrune: true})
+	if err != nil {
+		t.Fatalf("Open read-only DB: %v", err)
+	}
+	defer func() { _ = ro.Close() }()
+
+	seam := &countingCommandWALApplySeam{}
+	raw := readHexFixture(t, "../nativewire/testdata/v1/create_collection_entry.hex")
+	result, applyErr := ApplyCommittedEntryV1(ro, raw, applyMeta(1, 1), Options{CommandWALApplySeam: seam})
+	assertRejected(t, result, applyErr, raftentry.ApplyStatusDeterministicGuardFailure, raftentry.ErrorReadOnlyV1)
+	if seam.appendCalls != 0 || len(readCommandWALFrames(t, dir)) != 0 {
+		t.Fatalf("read-only apply reached append path append=%d frames=%d", seam.appendCalls, len(readCommandWALFrames(t, dir)))
+	}
+	_, openErr := collections.NewCollectionManager(ro).OpenCollection("users")
+	if !errors.Is(openErr, collections.ErrCollectionNotFound) {
+		t.Fatalf("OpenCollection users after read-only apply error=%v, want ErrCollectionNotFound", openErr)
+	}
+}
+
+func TestUnsafeDurabilityFailsBeforeAppend(t *testing.T) {
+	dir := t.TempDir()
+	db := openApplyHarnessDB(t, dir)
+	defer func() { _ = db.Close() }()
+
+	meta := applyMeta(1, 1)
+	meta.LocalDurabilityBoundary = LocalDurabilityBoundaryV1("local-visible-only-v1")
+	seam := &countingCommandWALApplySeam{}
+	raw := readHexFixture(t, "../nativewire/testdata/v1/create_collection_entry.hex")
+	result, err := ApplyCommittedEntryV1(db, raw, meta, Options{CommandWALApplySeam: seam})
+	assertRejected(t, result, err, raftentry.ApplyStatusDeterministicGuardFailure, raftentry.ErrorUnsafeDurabilityModeV1)
+	if seam.appendCalls != 0 || len(readCommandWALFrames(t, dir)) != 0 {
+		t.Fatalf("unsafe durability reached append path append=%d frames=%d", seam.appendCalls, len(readCommandWALFrames(t, dir)))
+	}
+}
+
+func TestSameApplyEntryIDDifferentDigestConflictsBeforeAppend(t *testing.T) {
+	dir := t.TempDir()
+	db := openApplyHarnessDB(t, dir)
+	defer func() { _ = db.Close() }()
+
+	id := raftentry.ApplyEntryID{Term: 1, Index: 1}
+	results := NewMemoryApplyResultStore(8)
+	var otherDigest raftentry.CommandDigestV1
+	otherDigest[0] = 1
+	if err := results.RecordApplyResult(ApplyResultRecordV1{
+		EntryID:       id,
+		CommandDigest: otherDigest,
+		Result: raftentry.ApplyResultV1{
+			Status:                 raftentry.ApplyStatusApplied,
+			CommandDigest:          otherDigest,
+			DeterministicErrorCode: raftentry.ErrorNoneV1,
+		},
+	}); err != nil {
+		t.Fatalf("seed result record: %v", err)
+	}
+
+	seam := &countingCommandWALApplySeam{}
+	raw := readHexFixture(t, "../nativewire/testdata/v1/create_collection_entry.hex")
+	result, err := ApplyCommittedEntryV1(db, raw, applyMeta(id.Term, id.Index), Options{
+		ResultStore:         results,
+		CommandWALApplySeam: seam,
+	})
+	assertRejected(t, result, err, raftentry.ApplyStatusRejectedConflict, raftentry.ErrorRejectedConflictV1)
+	if seam.appendCalls != 0 || len(readCommandWALFrames(t, dir)) != 0 {
+		t.Fatalf("conflict reached append path append=%d frames=%d", seam.appendCalls, len(readCommandWALFrames(t, dir)))
+	}
+	if results.Len() != 1 {
+		t.Fatalf("result records after conflict=%d, want seeded record only", results.Len())
+	}
+}
+
+func TestMemoryStoresAreBounded(t *testing.T) {
+	id1 := raftentry.ApplyEntryID{Term: 1, Index: 1}
+	id2 := raftentry.ApplyEntryID{Term: 1, Index: 2}
+	var digest raftentry.CommandDigestV1
+	digest[0] = 7
+
+	results := NewMemoryApplyResultStore(1)
+	if err := results.RecordApplyResult(ApplyResultRecordV1{EntryID: id1, CommandDigest: digest}); err != nil {
+		t.Fatalf("RecordApplyResult id1: %v", err)
+	}
+	if err := results.RecordApplyResult(ApplyResultRecordV1{EntryID: id2, CommandDigest: digest}); codeOf(err) != raftentry.ErrorResourceExhaustedV1 {
+		t.Fatalf("RecordApplyResult id2 error=%v code=%s, want resource exhausted", err, codeOf(err))
+	}
+
+	progress := NewMemoryApplyProgressStore(1, 8)
+	if err := progress.RecordApplied(ApplyProgressRecordV1{EntryID: id1, CommandDigest: digest}); err != nil {
+		t.Fatalf("RecordApplied id1: %v", err)
+	}
+	if err := progress.RecordApplied(ApplyProgressRecordV1{EntryID: id2, CommandDigest: digest}); codeOf(err) != raftentry.ErrorResourceExhaustedV1 {
+		t.Fatalf("RecordApplied id2 error=%v code=%s, want resource exhausted", err, codeOf(err))
+	}
+
+	progress = NewMemoryApplyProgressStore(8, 8)
+	if err := progress.RecordApplied(ApplyProgressRecordV1{EntryID: id1, CommandDigest: digest}); err != nil {
+		t.Fatalf("RecordApplied lower-index setup: %v", err)
+	}
+	if err := progress.CheckCanApply(id1); codeOf(err) != raftentry.ErrorRejectedConflictV1 {
+		t.Fatalf("CheckCanApply duplicate/lower error=%v code=%s, want conflict", err, codeOf(err))
+	}
+	id3 := raftentry.ApplyEntryID{Term: 1, Index: 3}
+	if err := progress.CheckCanApply(id3); codeOf(err) != raftentry.ErrorRejectedConflictV1 {
+		t.Fatalf("CheckCanApply gap error=%v code=%s, want conflict", err, codeOf(err))
+	}
+}
+
+func openApplyHarnessDB(t *testing.T, dir string) *backenddb.DB {
+	t.Helper()
+	db, err := backenddb.Open(backenddb.Options{
+		Dir:                          dir,
+		CommandWAL:                   true,
+		DisableBackgroundPrune:       true,
+		CommandWALStatsScan:          true,
+		CommandWALSegmentTargetBytes: 1 << 20,
+	})
+	if err != nil {
+		t.Fatalf("Open DB: %v", err)
+	}
+	return db
+}
+
+func applyMeta(term, index uint64) ApplyMetadataV1 {
+	return ApplyMetadataV1{
+		EntryID:                 raftentry.ApplyEntryID{Term: term, Index: index},
+		LocalDurabilityBoundary: LocalDurabilityCommandWALV1,
+	}
+}
+
+func assertRejected(t *testing.T, result raftentry.ApplyResultV1, err error, wantStatus raftentry.ApplyStatusV1, wantCode raftentry.DeterministicErrorCodeV1) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("ApplyCommittedEntryV1 returned nil error for rejected result %+v", result)
+	}
+	if result.Status != wantStatus || result.DeterministicErrorCode != wantCode {
+		t.Fatalf("result status/code=%s/%s, want %s/%s (err=%v)", result.Status, result.DeterministicErrorCode, wantStatus, wantCode, err)
+	}
+	if got := codeOf(err); got != wantCode {
+		t.Fatalf("error code=%s, want %s (err=%v)", got, wantCode, err)
+	}
+}
+
+func codeOf(err error) raftentry.DeterministicErrorCodeV1 {
+	code, _ := ErrorCodeOf(err)
+	return code
+}
+
+func readHexFixture(t *testing.T, rel string) []byte {
+	t.Helper()
+	raw, err := os.ReadFile(rel)
+	if err != nil {
+		t.Fatalf("read fixture %s: %v", rel, err)
+	}
+	hexText := strings.Join(strings.Fields(string(raw)), "")
+	out, err := hex.DecodeString(hexText)
+	if err != nil {
+		t.Fatalf("decode fixture %s: %v", rel, err)
+	}
+	return out
+}
+
+func readCommandWALFrames(t *testing.T, dir string) []commitlog.CommandEnvelope {
+	t.Helper()
+	walDir := backenddb.WALDirPath(dir)
+	entries, err := os.ReadDir(walDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		t.Fatalf("ReadDir %s: %v", walDir, err)
+	}
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if !entry.IsDir() && commitlog.IsCommandSegmentName(entry.Name()) {
+			names = append(names, entry.Name())
+		}
+	}
+	sort.Strings(names)
+	var frames []commitlog.CommandEnvelope
+	for _, name := range names {
+		path := filepath.Join(walDir, name)
+		r, err := commitlog.NewReader(path)
+		if err != nil {
+			t.Fatalf("NewReader %s: %v", name, err)
+		}
+		for {
+			env, err := r.ReadCommandFrame()
+			if err != nil {
+				if errors.Is(err, io.EOF) {
+					break
+				}
+				_ = r.Close()
+				t.Fatalf("ReadCommandFrame %s: %v", name, err)
+			}
+			frames = append(frames, env)
+		}
+		if err := r.Close(); err != nil {
+			t.Fatalf("Close reader %s: %v", name, err)
+		}
+	}
+	return frames
+}
+
+type countingCommandWALApplySeam struct {
+	appendCalls   int
+	finalizeCalls int
+}
+
+func (s *countingCommandWALApplySeam) Append(db *backenddb.DB, frame commandwalapply.LoweredFrame, meta commandwalapply.ApplyMetadata, opts commandwalapply.Options) (commandwalapply.Handle, commandwalapply.Result, error) {
+	s.appendCalls++
+	return commandwalapply.Handle{}, commandwalapply.Result{}, errors.New("unexpected append")
+}
+
+func (s *countingCommandWALApplySeam) Finalize(db *backenddb.DB, handle commandwalapply.Handle, meta commandwalapply.ApplyMetadata, opts commandwalapply.Options) (commandwalapply.Result, error) {
+	s.finalizeCalls++
+	return commandwalapply.Result{}, errors.New("unexpected finalize")
+}

--- a/TreeDB/internal/raftapply/doc.go
+++ b/TreeDB/internal/raftapply/doc.go
@@ -1,0 +1,8 @@
+// Package raftapply applies committed R3a deterministic entry bytes to a local
+// TreeDB replica.
+//
+// This package is intentionally a skeleton. It owns the committed-bytes apply
+// boundary, deterministic rejection results, and fake bounded stores used by
+// tests while real durable apply progress/result storage and command lowering
+// are implemented in later slices.
+package raftapply

--- a/TreeDB/internal/raftapply/stores.go
+++ b/TreeDB/internal/raftapply/stores.go
@@ -1,0 +1,229 @@
+package raftapply
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/snissn/gomap/TreeDB/internal/raftentry"
+)
+
+// Error carries stable deterministic apply error names through fake stores and
+// the harness boundary.
+type Error struct {
+	Code raftentry.DeterministicErrorCodeV1
+	Err  error
+}
+
+func (e *Error) Error() string {
+	if e == nil {
+		return "raftapply: <nil>"
+	}
+	if e.Err == nil {
+		return fmt.Sprintf("raftapply: %s", e.Code)
+	}
+	return fmt.Sprintf("raftapply: %s: %v", e.Code, e.Err)
+}
+
+func (e *Error) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+// ErrorCodeOf extracts stable deterministic error names returned by this
+// package or by the predecessor raftentry decoder.
+func ErrorCodeOf(err error) (raftentry.DeterministicErrorCodeV1, bool) {
+	var e *Error
+	if errors.As(err, &e) {
+		return e.Code, true
+	}
+	return raftentry.ErrorCodeOf(err)
+}
+
+func codedError(code raftentry.DeterministicErrorCodeV1, format string, args ...any) error {
+	return &Error{Code: code, Err: fmt.Errorf(format, args...)}
+}
+
+// ApplyResultRecordV1 is the fake/durable result-store unit keyed by
+// ApplyEntryID. The result payload is intentionally bounded separately from the
+// deterministic entry bytes.
+type ApplyResultRecordV1 struct {
+	EntryID       raftentry.ApplyEntryID
+	CommandDigest raftentry.CommandDigestV1
+	Result        raftentry.ApplyResultV1
+}
+
+// ApplyResultStore records deterministic apply results for idempotency/replay.
+type ApplyResultStore interface {
+	LookupApplyResult(raftentry.ApplyEntryID) (ApplyResultRecordV1, bool, error)
+	RecordApplyResult(ApplyResultRecordV1) error
+}
+
+// ApplyProgressRecordV1 records the apply-progress transition made after an
+// entry has reached the selected local durability and visibility boundary.
+type ApplyProgressRecordV1 struct {
+	EntryID       raftentry.ApplyEntryID
+	CommandDigest raftentry.CommandDigestV1
+}
+
+// ApplyProgressStore checks monotonic apply order and records durable progress.
+type ApplyProgressStore interface {
+	CheckCanApply(raftentry.ApplyEntryID) error
+	RecordApplied(ApplyProgressRecordV1) error
+	LastApplied() (raftentry.ApplyEntryID, bool)
+}
+
+// MemoryApplyResultStore is a bounded fake result/idempotency store for tests
+// and early harness wiring. It is not durable.
+type MemoryApplyResultStore struct {
+	mu      sync.Mutex
+	max     int
+	records map[raftentry.ApplyEntryID]ApplyResultRecordV1
+}
+
+func NewMemoryApplyResultStore(maxRecords int) *MemoryApplyResultStore {
+	if maxRecords < 0 {
+		maxRecords = 0
+	}
+	return &MemoryApplyResultStore{max: maxRecords, records: make(map[raftentry.ApplyEntryID]ApplyResultRecordV1)}
+}
+
+func (s *MemoryApplyResultStore) LookupApplyResult(id raftentry.ApplyEntryID) (ApplyResultRecordV1, bool, error) {
+	if s == nil {
+		return ApplyResultRecordV1{}, false, nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	record, ok := s.records[id]
+	return record, ok, nil
+}
+
+func (s *MemoryApplyResultStore) RecordApplyResult(record ApplyResultRecordV1) error {
+	if s == nil {
+		return nil
+	}
+	if err := validateApplyEntryID(record.EntryID); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if existing, ok := s.records[record.EntryID]; ok {
+		if existing.CommandDigest != record.CommandDigest {
+			return codedError(raftentry.ErrorRejectedConflictV1, "apply result digest conflict for %d/%d", record.EntryID.Term, record.EntryID.Index)
+		}
+		s.records[record.EntryID] = record
+		return nil
+	}
+	if len(s.records) >= s.max {
+		return codedError(raftentry.ErrorResourceExhaustedV1, "apply result store capacity %d reached", s.max)
+	}
+	s.records[record.EntryID] = record
+	return nil
+}
+
+func (s *MemoryApplyResultStore) Len() int {
+	if s == nil {
+		return 0
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.records)
+}
+
+// MemoryApplyProgressStore is a bounded fake apply-progress store for tests and
+// early harness wiring. It enforces contiguous indexes and non-decreasing terms.
+type MemoryApplyProgressStore struct {
+	mu       sync.Mutex
+	max      int
+	maxIndex uint64
+	last     raftentry.ApplyEntryID
+	records  map[raftentry.ApplyEntryID]ApplyProgressRecordV1
+}
+
+func NewMemoryApplyProgressStore(maxRecords int, maxIndex uint64) *MemoryApplyProgressStore {
+	if maxRecords < 0 {
+		maxRecords = 0
+	}
+	return &MemoryApplyProgressStore{max: maxRecords, maxIndex: maxIndex, records: make(map[raftentry.ApplyEntryID]ApplyProgressRecordV1)}
+}
+
+func (s *MemoryApplyProgressStore) CheckCanApply(id raftentry.ApplyEntryID) error {
+	if s == nil {
+		return nil
+	}
+	if err := validateApplyEntryID(id); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.checkCanApplyLocked(id)
+}
+
+func (s *MemoryApplyProgressStore) RecordApplied(record ApplyProgressRecordV1) error {
+	if s == nil {
+		return nil
+	}
+	if err := validateApplyEntryID(record.EntryID); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if existing, ok := s.records[record.EntryID]; ok {
+		if existing.CommandDigest != record.CommandDigest {
+			return codedError(raftentry.ErrorRejectedConflictV1, "apply progress digest conflict for %d/%d", record.EntryID.Term, record.EntryID.Index)
+		}
+		s.records[record.EntryID] = record
+		return nil
+	}
+	if err := s.checkCanApplyLocked(record.EntryID); err != nil {
+		return err
+	}
+	if len(s.records) >= s.max {
+		return codedError(raftentry.ErrorResourceExhaustedV1, "apply progress store capacity %d reached", s.max)
+	}
+	s.records[record.EntryID] = record
+	s.last = record.EntryID
+	return nil
+}
+
+func (s *MemoryApplyProgressStore) LastApplied() (raftentry.ApplyEntryID, bool) {
+	if s == nil {
+		return raftentry.ApplyEntryID{}, false
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.last, s.last.Index != 0
+}
+
+func (s *MemoryApplyProgressStore) Len() int {
+	if s == nil {
+		return 0
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.records)
+}
+
+func (s *MemoryApplyProgressStore) checkCanApplyLocked(id raftentry.ApplyEntryID) error {
+	if s.maxIndex != 0 && id.Index > s.maxIndex {
+		return codedError(raftentry.ErrorResourceExhaustedV1, "apply entry index %d exceeds bound %d", id.Index, s.maxIndex)
+	}
+	if s.last.Index == 0 {
+		if id.Index != 1 {
+			return codedError(raftentry.ErrorRejectedConflictV1, "apply entry starts at index %d; want 1", id.Index)
+		}
+		return nil
+	}
+	if id.Index <= s.last.Index {
+		return codedError(raftentry.ErrorRejectedConflictV1, "apply entry index %d is not after last applied %d", id.Index, s.last.Index)
+	}
+	if id.Index != s.last.Index+1 {
+		return codedError(raftentry.ErrorRejectedConflictV1, "apply entry index gap: got %d after %d", id.Index, s.last.Index)
+	}
+	if id.Term < s.last.Term {
+		return codedError(raftentry.ErrorRejectedConflictV1, "apply entry term %d is below last applied term %d", id.Term, s.last.Term)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

- Adds `TreeDB/internal/raftapply` as the R3a internal apply harness for committed deterministic entry bytes.
- Carries explicit `ApplyEntryID` and local durability metadata, decodes through `raftentry.DecodeCommandEntryV1`, and fail-closed rejects before command-WAL append.
- Adds bounded in-memory apply progress/result stores for the deferred durable-store phase.
- Keeps accepted command lowering deferred: `create_collection` is decoded/classified but still rejected as not lowered in this slice.

Closes #3040
Refs #1654
Supersedes #3059

## Graph / Merge Notes

This is the clean replacement for draft #3059 after #3038 merged as `83663f98562ddcf6cfbbd31b25fac97538dc08fa` and #3039 merged as `bc486e2aff19fc5ac9271adc426f771d52c9c41c`.

The branch was updated without rewriting by merging current `main` (`9d60c2979`, #3083) into the PR branch. Current PR head validated locally: `27120daa38ae2e582a5da95125be5fd9c51cf2cc`.

## Start-Phase Test Plan

- Add a committed-bytes-only harness API rather than native-wire request or handler replay entry points.
- Prove unsupported and malformed deterministic bytes return stable `ApplyResultV1` status/error names before command-WAL append.
- Prove rejected entries do not advance `AppliedCommandLSN`, fake apply progress, result/idempotency stores, or catalog state.
- Cover read-only, unsafe local durability boundary, progress bound/gap rejection, and same `ApplyEntryID` digest conflict paths.
- Re-run predecessor packages that own deterministic entry contracts and the command-WAL append path.

## Close-Phase Test Evidence

- `GOWORK=off go test ./TreeDB/internal/raftapply ./TreeDB/internal/raftentry ./TreeDB/internal/commandwalapply -count=1 -timeout=3m`
- `GOWORK=off go test ./TreeDB/internal/nativewire ./TreeDB/internal/raftentry ./TreeDB/internal/commandwalapply ./TreeDB/internal/raftapply -count=1 -timeout=3m`
- `GOWORK=off go vet ./TreeDB/internal/raftapply ./TreeDB/internal/raftentry ./TreeDB/internal/commandwalapply ./TreeDB/internal/nativewire`
- `git diff --check origin/main`

## Benchmark Evidence / Rationale

No benchmark was run. This slice adds a new internal harness and rejection tests only; it is not wired into hot write/read paths, and tests assert rejected paths keep command-WAL append count at zero. The decode/classification rejection path can be benchmarked when a later slice wires accepted lowering or a caller-facing apply loop.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a deterministic apply flow for committed entries, with strict validation and reject-on-error behavior.
  * Introduced bounded in-memory tracking for apply progress and apply results, including conflict detection and ordering checks.

* **Tests**
  * Added coverage for malformed inputs, unsupported commands, read-only/unsafe modes, progress gaps, and digest conflicts.
  * Verified that rejected entries do not mutate state or write command data.

* **Documentation**
  * Added package-level documentation describing the supported apply behavior and current limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->