### PR TITLE
TreeDB: cache q4 one-shot TopK runner

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -403,6 +403,13 @@ type Collection struct {
 	vectorBufferedSearchInvalidations uint64
 	vectorBufferedSearchCloses        uint64
 	vectorBufferedSearchErrors        uint64
+
+	typedColumnOneShotTopKMu            sync.Mutex
+	typedColumnOneShotTopK              *collectionTypedColumnOneShotTopKCacheEntry
+	typedColumnOneShotTopKHits          uint64
+	typedColumnOneShotTopKMisses        uint64
+	typedColumnOneShotTopKBuilds        uint64
+	typedColumnOneShotTopKInvalidations uint64
 }
 
 type CollectionRootOverlayCompactionStats struct {

--- a/TreeDB/collections/column_physical_q4a_time_order_1950_test.go
+++ b/TreeDB/collections/column_physical_q4a_time_order_1950_test.go
@@ -57,6 +57,62 @@ func TestColumnPhysicalQ4ATimeOrderTopKDirectPreparedParity1950(t *testing.T) {
 	}
 }
 
+func TestColumnPhysicalQ4ATimeOrderTopKOneShotCache3085(t *testing.T) {
+	batches := columnPhysicalQ4ATimeOrderBatches1950(9_000)
+	events := flattenColumnPhysicalEvents1950(batches)
+	_, col, closeFn := openTypedColumnSortKeyFixtureBatches1950(t, []ColumnSortKey{{Column: "time_us"}}, batches)
+	defer closeFn()
+
+	scanned := scanColumnPhysicalJSONBenchParityEventsP0(t, col, len(events))
+	req := columnPhysicalQ4ATimeOrderRequest1950()
+	want := columnPhysicalQ4ATimeOrderReferenceGroups1950(scanned, req.TopK)
+	wantCandidates := columnPhysicalQ4ATimeOrderReferenceEarlyCandidates1950(scanned, req.TopK)
+
+	first, err := col.RunColumnPhysicalQuery(req)
+	if err != nil {
+		t.Fatalf("first RunColumnPhysicalQuery(q4a time-order topK): %v", err)
+	}
+	assertColumnPhysicalQ4ATimeOrderResult1950(t, "first one-shot", first, want, len(events), wantCandidates)
+	snapshot := col.typedColumnOneShotTopKCacheSnapshotForTest()
+	if snapshot.Entries != 1 || snapshot.CacheMisses != 1 || snapshot.CacheBuilds != 1 || snapshot.CacheHits != 0 {
+		t.Fatalf("cache after first run=%+v want one miss/build entry", snapshot)
+	}
+
+	second, err := col.RunColumnPhysicalQuery(req)
+	if err != nil {
+		t.Fatalf("second RunColumnPhysicalQuery(q4a time-order topK): %v", err)
+	}
+	assertColumnPhysicalQ4ATimeOrderResult1950(t, "second one-shot", second, want, len(events), wantCandidates)
+	snapshot = col.typedColumnOneShotTopKCacheSnapshotForTest()
+	if snapshot.Entries != 1 || snapshot.CacheMisses != 1 || snapshot.CacheBuilds != 1 || snapshot.CacheHits != 1 {
+		t.Fatalf("cache after second run=%+v want one cache hit", snapshot)
+	}
+
+	smallerTopK := req
+	smallerTopK.TopK = 2
+	smallerWant := columnPhysicalQ4ATimeOrderReferenceGroups1950(scanned, smallerTopK.TopK)
+	smallerCandidates := columnPhysicalQ4ATimeOrderReferenceEarlyCandidates1950(scanned, smallerTopK.TopK)
+	third, err := col.RunColumnPhysicalQuery(smallerTopK)
+	if err != nil {
+		t.Fatalf("third RunColumnPhysicalQuery(q4a time-order topK=2): %v", err)
+	}
+	if len(third.Groups) != len(smallerWant) {
+		t.Fatalf("third one-shot topK=2 groups=%+v want %+v", third.Groups, smallerWant)
+	}
+	for i := range smallerWant {
+		if third.Groups[i].Key != smallerWant[i].Key || third.Groups[i].Int64 != smallerWant[i].Int64 {
+			t.Fatalf("third one-shot topK=2 groups=%+v want %+v", third.Groups, smallerWant)
+		}
+	}
+	if !third.Diagnostics.TimeOrderTopKUsed || third.Diagnostics.TopKLimit != smallerTopK.TopK || third.Diagnostics.TopKCandidates != smallerCandidates || third.Diagnostics.ResultGroups != len(smallerWant) {
+		t.Fatalf("third one-shot topK=2 diagnostics=%+v want time-order topK=%d candidates=%d groups=%d", third.Diagnostics, smallerTopK.TopK, smallerCandidates, len(smallerWant))
+	}
+	snapshot = col.typedColumnOneShotTopKCacheSnapshotForTest()
+	if snapshot.Entries != 1 || snapshot.CacheMisses != 2 || snapshot.CacheBuilds != 2 || snapshot.CacheHits != 1 || snapshot.Invalidations != 1 {
+		t.Fatalf("cache after topK change=%+v want invalidation and rebuild", snapshot)
+	}
+}
+
 func BenchmarkColumnPhysicalQ4ATimeOrderTopK1950(b *testing.B) {
 	batches := columnPhysicalQ4ATimeOrderBatches1950(9_000)
 	events := flattenColumnPhysicalEvents1950(batches)

--- a/TreeDB/collections/column_physical_query.go
+++ b/TreeDB/collections/column_physical_query.go
@@ -974,6 +974,9 @@ func columnManifestScanSidecarsForPhysicalQuery(req ColumnPhysicalQueryRequest) 
 }
 
 func (c *Collection) runColumnPhysicalQueryInSnapshotView(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest) (ColumnPhysicalQueryResult, error) {
+	if result, ok, err := c.runColumnPhysicalQueryTypedColumnOneShotTopKInSnapshotView(view, req); ok {
+		return result, err
+	}
 	if result, ok, err := c.runColumnPhysicalQueryTypedColumnPartInSnapshotView(view, req); ok {
 		return result, err
 	}

--- a/TreeDB/collections/column_physical_typed_column_cache.go
+++ b/TreeDB/collections/column_physical_typed_column_cache.go
@@ -1,0 +1,187 @@
+package collections
+
+import (
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+type collectionTypedColumnOneShotTopKCacheSlot struct {
+	commitSeq                uint64
+	systemRoot               uint64
+	manifestGeneration       uint64
+	activeManifestChecksum   uint64
+	recoveryManifestChecksum uint64
+	appliedCommandLSN        uint64
+	readIntegrity            ColumnAssetReadIntegrity
+	kind                     ColumnPhysicalQueryKind
+	groupColumn              string
+	valueColumn              string
+	distinctColumn           string
+	topK                     int
+	topKOrder                ColumnPhysicalQueryTopKOrder
+	skipEmptyGroupKey        bool
+	predicates               string
+}
+
+type collectionTypedColumnOneShotTopKCacheEntry struct {
+	slot   collectionTypedColumnOneShotTopKCacheSlot
+	runner *columnTypedColumnPhysicalQueryRunner
+	mu     sync.Mutex
+}
+
+type collectionTypedColumnOneShotTopKCacheSnapshot struct {
+	Entries       int
+	CacheHits     uint64
+	CacheMisses   uint64
+	CacheBuilds   uint64
+	Invalidations uint64
+}
+
+func (c *Collection) runColumnTypedColumnOneShotTopKWithCache(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest, plan columnTypedColumnPhysicalQueryPlan, start time.Time) (ColumnPhysicalQueryResult, bool, error) {
+	if c == nil || view.MutationParts != 0 {
+		return ColumnPhysicalQueryResult{}, false, nil
+	}
+	if !columnTypedColumnPhysicalQueryUseTimeOrderTopK(plan, req) || req.AggregateMetadataName != "" {
+		return ColumnPhysicalQueryResult{}, false, nil
+	}
+	slot := collectionTypedColumnOneShotTopKCacheSlotFor(view, req)
+
+	c.typedColumnOneShotTopKMu.Lock()
+	entry := c.typedColumnOneShotTopK
+	if entry != nil && entry.slot == slot {
+		c.typedColumnOneShotTopKHits++
+		c.typedColumnOneShotTopKMu.Unlock()
+		entry.mu.Lock()
+		result, err := entry.runner.run(view, req)
+		entry.mu.Unlock()
+		result.Diagnostics.ScanNanos = time.Since(start).Nanoseconds()
+		return result, true, err
+	}
+	if entry != nil {
+		c.typedColumnOneShotTopKInvalidations++
+		c.typedColumnOneShotTopK = nil
+	}
+	c.typedColumnOneShotTopKMisses++
+	c.typedColumnOneShotTopKBuilds++
+	c.typedColumnOneShotTopKMu.Unlock()
+
+	readCache, err := newColumnPhysicalAssetReadCacheWithIntegrity(view.ColumnAssetRootDir, view.AssetNamespace, req.ColumnAssetReadIntegrity)
+	if err != nil {
+		result := ColumnPhysicalQueryResult{}
+		result.Diagnostics.ScanNanos = time.Since(start).Nanoseconds()
+		return result, true, err
+	}
+	readCache.returnViews = true
+	defer func() { _ = readCache.close() }()
+
+	runner, candidate, err := prepareColumnTypedColumnPhysicalQueryRunner(view, req, &readCache, false)
+	if err != nil || !candidate {
+		result := ColumnPhysicalQueryResult{}
+		result.Diagnostics.ScanNanos = time.Since(start).Nanoseconds()
+		return result, candidate, err
+	}
+	entry = &collectionTypedColumnOneShotTopKCacheEntry{slot: slot, runner: runner}
+
+	c.typedColumnOneShotTopKMu.Lock()
+	if current := c.typedColumnOneShotTopK; current != nil && current.slot != slot {
+		c.typedColumnOneShotTopKInvalidations++
+	}
+	c.typedColumnOneShotTopK = entry
+	c.typedColumnOneShotTopKMu.Unlock()
+
+	entry.mu.Lock()
+	result, err := entry.runner.run(view, req)
+	entry.mu.Unlock()
+	result.Diagnostics.ScanNanos = time.Since(start).Nanoseconds()
+	return result, true, err
+}
+
+func (c *Collection) runColumnPhysicalQueryTypedColumnOneShotTopKInSnapshotView(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest) (ColumnPhysicalQueryResult, bool, error) {
+	if !columnTypedColumnOneShotTopKCacheRequestCandidate(req) || !columnTypedColumnPhysicalQueryTouchesTypedColumnPart(view.FullConfig, req) {
+		return ColumnPhysicalQueryResult{}, false, nil
+	}
+	start := time.Now()
+	plan, candidate, err := planColumnTypedColumnPhysicalQuery(view.FullConfig, req)
+	if err != nil || !candidate {
+		return ColumnPhysicalQueryResult{}, candidate, err
+	}
+	if view.MutationParts != 0 {
+		return ColumnPhysicalQueryResult{}, false, nil
+	}
+	return c.runColumnTypedColumnOneShotTopKWithCache(view, req, plan, start)
+}
+
+func columnTypedColumnOneShotTopKCacheRequestCandidate(req ColumnPhysicalQueryRequest) bool {
+	return req.Kind == ColumnPhysicalQueryGroupMinInt64 &&
+		req.AggregateMetadataName == "" &&
+		req.DistinctColumn == "" &&
+		req.GroupColumn != "" &&
+		req.ValueColumn != "" &&
+		req.TopK > 0 &&
+		req.TopKOrder == ColumnPhysicalQueryTopKInt64Asc
+}
+
+func collectionTypedColumnOneShotTopKCacheSlotFor(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest) collectionTypedColumnOneShotTopKCacheSlot {
+	return collectionTypedColumnOneShotTopKCacheSlot{
+		commitSeq:                view.CommitSeq,
+		systemRoot:               view.SystemRoot,
+		manifestGeneration:       view.Diagnostics.ManifestGeneration,
+		activeManifestChecksum:   view.Diagnostics.ActiveManifestChecksum,
+		recoveryManifestChecksum: view.Diagnostics.RecoveryManifestChecksum,
+		appliedCommandLSN:        view.Diagnostics.AppliedCommandLSN,
+		readIntegrity:            req.ColumnAssetReadIntegrity,
+		kind:                     req.Kind,
+		groupColumn:              req.GroupColumn,
+		valueColumn:              req.ValueColumn,
+		distinctColumn:           req.DistinctColumn,
+		topK:                     req.TopK,
+		topKOrder:                req.TopKOrder,
+		skipEmptyGroupKey:        req.SkipEmptyGroupKey,
+		predicates:               collectionTypedColumnOneShotTopKPredicateKey(req),
+	}
+}
+
+func collectionTypedColumnOneShotTopKPredicateKey(req ColumnPhysicalQueryRequest) string {
+	if len(req.Predicates) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	for _, predicate := range req.Predicates {
+		writeColumnPhysicalCacheKeyPart(&b, predicate.Column)
+		writeColumnPhysicalCacheKeyPart(&b, string(columnPhysicalQueryPredicateKindOrDefault(predicate.Kind)))
+		writeColumnPhysicalCacheKeyPart(&b, predicate.Value)
+		b.WriteString(strconv.Itoa(len(predicate.Values)))
+		b.WriteByte(';')
+		for _, value := range predicate.Values {
+			writeColumnPhysicalCacheKeyPart(&b, value)
+		}
+	}
+	return b.String()
+}
+
+func writeColumnPhysicalCacheKeyPart(b *strings.Builder, value string) {
+	b.WriteString(strconv.Itoa(len(value)))
+	b.WriteByte(':')
+	b.WriteString(value)
+	b.WriteByte(';')
+}
+
+func (c *Collection) typedColumnOneShotTopKCacheSnapshotForTest() collectionTypedColumnOneShotTopKCacheSnapshot {
+	if c == nil {
+		return collectionTypedColumnOneShotTopKCacheSnapshot{}
+	}
+	c.typedColumnOneShotTopKMu.Lock()
+	defer c.typedColumnOneShotTopKMu.Unlock()
+	snapshot := collectionTypedColumnOneShotTopKCacheSnapshot{
+		CacheHits:     c.typedColumnOneShotTopKHits,
+		CacheMisses:   c.typedColumnOneShotTopKMisses,
+		CacheBuilds:   c.typedColumnOneShotTopKBuilds,
+		Invalidations: c.typedColumnOneShotTopKInvalidations,
+	}
+	if c.typedColumnOneShotTopK != nil {
+		snapshot.Entries = 1
+	}
+	return snapshot
+}


### PR DESCRIPTION
## Summary

Implements #3085 by adding a narrow collection-local cache for the internal typed-column time-order TopK runner used by q4/q4a/q4b `one_shot_end_to_end` queries in the production `column-store-full-prepared` layout.

Scope classification:
- Improves: one-shot query execution for repeated normal SQL/API requests that hit the same no-metadata time-order TopK shape.
- Does not claim: first-touch-after-open improvement, insert/load improvement, hot prepared-runner improvement, aggregate-metadata acceleration, or broad raw scan speedup.
- Metadata mode: `no_aggregate_metadata`; aggregate metadata is not used.
- Materialization: no row/document materialization and no JSON reconstruction on the measured q4 path.

## Implementation notes

- Caches one insert-only typed-column TopK runner per collection, keyed by commit/root, manifest generation/checksums, applied command LSN, read-integrity mode, and exact request shape/predicates.
- Routes only `GroupMinInt64` + ascending TopK + no aggregate metadata through the cache before the normal typed-column route.
- Serializes cached runner execution because the runner owns mutable scan scratch.
- Keeps the shared typed-column one-shot runner entrypoint unchanged for q1/q2/q3/q5/qexpr scan-heavy paths.

## Benchmark evidence

Baseline artifact: `/tmp/jsonbench_current_noagg_1m_20260625_192958/result.json`
Candidate q4 artifact: `/tmp/jsonbench_q4_topk_cache_final_1m_20260625_195420/result.json`
Guard artifact: `/tmp/jsonbench_guard4_noagg_1m_3085_20260625_195248/result.json`
Current clean baseline guard artifact: `/tmp/jsonbench_guard_noagg_1m_baseline_20260625_194718/result.json`

Command shape:

```sh
GOWORK=/tmp/jsonbench_gowork_q4_final_3085_20260625_195419/go.work \
  go run ./cmd/jsonbench_treedb run \
  -data-dir /Users/michaelseiler/data/bluesky \
  -db-dir /tmp/jsonbench_q4_topk_cache_final_1m_20260625_195420/db \
  -reset -scale 1m -format json \
  -storage-layout column-store-full-prepared \
  -query-mode one_shot_end_to_end \
  -metadata-mode no_aggregate_metadata \
  -projection full \
  -queries q4,q4a,q4b \
  -batch-size 16000 -tries 3 -profile fast -data-root fast \
  -allow-errors \
  -out /tmp/jsonbench_q4_topk_cache_final_1m_20260625_195420/result.json
```

Rows/load/storage for candidate q4 run:

| rows loaded | insert seconds | load wall seconds | durable storage bytes, WAL excluded |
| ---: | ---: | ---: | ---: |
| 1,000,000 | 15.727865711 | 18.843160458 | 137,488,386 |

q4-family result summary:

| query | mode | metadata | baseline best | candidate best | baseline median | candidate median | attempts | rows/cells visited | decoded bytes | physical bytes | aggregate metadata | TopK/sort marks | row/doc materialization |
| --- | --- | --- | ---: | ---: | ---: | ---: | --- | ---: | ---: | ---: | --- | --- | --- |
| q4 | one_shot_end_to_end | no_aggregate_metadata | 0.095647792s | 0.000406083s | 0.098013042s | 0.000459917s | 0.114407333, 0.000459917, 0.000406083 | 9 | 285,914 | 21,632,156 | no | time_order_topk, 3 candidates | 0 / 0 |
| q4a | one_shot_end_to_end | no_aggregate_metadata | 0.099412125s | 0.000382791s | 0.099626167s | 0.000384458s | 0.000382791, 0.000389500, 0.000384458 | 9 | 285,914 | 21,632,156 | no | time_order_topk, 3 candidates | 0 / 0 |
| q4b | one_shot_end_to_end | no_aggregate_metadata | 0.096743709s | 0.000370666s | 0.100173541s | 0.000388167s | 0.000398125, 0.000388167, 0.000370666 | 9 | 285,914 | 21,632,156 | no | time_order_topk, 3 candidates | 0 / 0 |

Important caveat: q4's first attempt in the final candidate artifact is `0.114407333s`, because first touch still builds the internal runner. This PR improves warm production one-shot requests through an internal cache; it does not satisfy the `first_touch_after_open` lane.

Non-q4 guard versus a clean current `HEAD` worktree under the same-current conditions:

| query | baseline median | candidate median | delta |
| --- | ---: | ---: | ---: |
| q1 | 0.098147167s | 0.102208667s | +4.14% |
| q3 | 0.128061291s | 0.127660542s | -0.31% |
| q5 | 0.139705542s | 0.148738000s | +6.47% |
| qexpr | 0.014295417s | 0.015074875s | +5.45% |

All guard medians are within the 10% regression threshold.

## Validation

```sh
go test ./TreeDB/collections -run 'TestColumnPhysicalQ4ATimeOrderTopKOneShotCache3085|TestColumnPhysicalQ4ATimeOrderTopKDirectPreparedParity1950|TestTypedColumnQ4BTopKMarkPrunedParity1950|TestColumnPhysicalNonMetadataTopKShaping1950' -count=1
go test ./TreeDB/collections -count=1
go test ./TreeDB/... -count=1
git diff --check
```
