### PR TITLE
TreeDB: cache no-metadata typed one-shot runners

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -404,12 +404,12 @@ type Collection struct {
 	vectorBufferedSearchCloses        uint64
 	vectorBufferedSearchErrors        uint64
 
-	typedColumnOneShotTopKMu            sync.Mutex
-	typedColumnOneShotTopK              *collectionTypedColumnOneShotTopKCacheEntry
-	typedColumnOneShotTopKHits          uint64
-	typedColumnOneShotTopKMisses        uint64
-	typedColumnOneShotTopKBuilds        uint64
-	typedColumnOneShotTopKInvalidations uint64
+	typedColumnOneShotMu            sync.Mutex
+	typedColumnOneShot              *collectionTypedColumnOneShotCacheEntry
+	typedColumnOneShotHits          uint64
+	typedColumnOneShotMisses        uint64
+	typedColumnOneShotBuilds        uint64
+	typedColumnOneShotInvalidations uint64
 }
 
 type CollectionRootOverlayCompactionStats struct {

--- a/TreeDB/collections/column_physical_q4a_time_order_1950_test.go
+++ b/TreeDB/collections/column_physical_q4a_time_order_1950_test.go
@@ -73,7 +73,7 @@ func TestColumnPhysicalQ4ATimeOrderTopKOneShotCache3085(t *testing.T) {
 		t.Fatalf("first RunColumnPhysicalQuery(q4a time-order topK): %v", err)
 	}
 	assertColumnPhysicalQ4ATimeOrderResult1950(t, "first one-shot", first, want, len(events), wantCandidates)
-	snapshot := col.typedColumnOneShotTopKCacheSnapshotForTest()
+	snapshot := col.typedColumnOneShotCacheSnapshotForTest()
 	if snapshot.Entries != 1 || snapshot.CacheMisses != 1 || snapshot.CacheBuilds != 1 || snapshot.CacheHits != 0 {
 		t.Fatalf("cache after first run=%+v want one miss/build entry", snapshot)
 	}
@@ -83,7 +83,7 @@ func TestColumnPhysicalQ4ATimeOrderTopKOneShotCache3085(t *testing.T) {
 		t.Fatalf("second RunColumnPhysicalQuery(q4a time-order topK): %v", err)
 	}
 	assertColumnPhysicalQ4ATimeOrderResult1950(t, "second one-shot", second, want, len(events), wantCandidates)
-	snapshot = col.typedColumnOneShotTopKCacheSnapshotForTest()
+	snapshot = col.typedColumnOneShotCacheSnapshotForTest()
 	if snapshot.Entries != 1 || snapshot.CacheMisses != 1 || snapshot.CacheBuilds != 1 || snapshot.CacheHits != 1 {
 		t.Fatalf("cache after second run=%+v want one cache hit", snapshot)
 	}
@@ -107,7 +107,7 @@ func TestColumnPhysicalQ4ATimeOrderTopKOneShotCache3085(t *testing.T) {
 	if !third.Diagnostics.TimeOrderTopKUsed || third.Diagnostics.TopKLimit != smallerTopK.TopK || third.Diagnostics.TopKCandidates != smallerCandidates || third.Diagnostics.ResultGroups != len(smallerWant) {
 		t.Fatalf("third one-shot topK=2 diagnostics=%+v want time-order topK=%d candidates=%d groups=%d", third.Diagnostics, smallerTopK.TopK, smallerCandidates, len(smallerWant))
 	}
-	snapshot = col.typedColumnOneShotTopKCacheSnapshotForTest()
+	snapshot = col.typedColumnOneShotCacheSnapshotForTest()
 	if snapshot.Entries != 1 || snapshot.CacheMisses != 2 || snapshot.CacheBuilds != 2 || snapshot.CacheHits != 1 || snapshot.Invalidations != 1 {
 		t.Fatalf("cache after topK change=%+v want invalidation and rebuild", snapshot)
 	}

--- a/TreeDB/collections/column_physical_query.go
+++ b/TreeDB/collections/column_physical_query.go
@@ -974,7 +974,7 @@ func columnManifestScanSidecarsForPhysicalQuery(req ColumnPhysicalQueryRequest) 
 }
 
 func (c *Collection) runColumnPhysicalQueryInSnapshotView(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest) (ColumnPhysicalQueryResult, error) {
-	if result, ok, err := c.runColumnPhysicalQueryTypedColumnOneShotTopKInSnapshotView(view, req); ok {
+	if result, ok, err := c.runColumnPhysicalQueryTypedColumnOneShotInSnapshotView(view, req); ok {
 		return result, err
 	}
 	if result, ok, err := c.runColumnPhysicalQueryTypedColumnPartInSnapshotView(view, req); ok {

--- a/TreeDB/collections/column_physical_typed_column_cache.go
+++ b/TreeDB/collections/column_physical_typed_column_cache.go
@@ -7,7 +7,7 @@ import (
 	"time"
 )
 
-type collectionTypedColumnOneShotTopKCacheSlot struct {
+type collectionTypedColumnOneShotCacheSlot struct {
 	commitSeq                uint64
 	systemRoot               uint64
 	manifestGeneration       uint64
@@ -25,13 +25,13 @@ type collectionTypedColumnOneShotTopKCacheSlot struct {
 	predicates               string
 }
 
-type collectionTypedColumnOneShotTopKCacheEntry struct {
-	slot   collectionTypedColumnOneShotTopKCacheSlot
+type collectionTypedColumnOneShotCacheEntry struct {
+	slot   collectionTypedColumnOneShotCacheSlot
 	runner *columnTypedColumnPhysicalQueryRunner
 	mu     sync.Mutex
 }
 
-type collectionTypedColumnOneShotTopKCacheSnapshot struct {
+type collectionTypedColumnOneShotCacheSnapshot struct {
 	Entries       int
 	CacheHits     uint64
 	CacheMisses   uint64
@@ -39,20 +39,20 @@ type collectionTypedColumnOneShotTopKCacheSnapshot struct {
 	Invalidations uint64
 }
 
-func (c *Collection) runColumnTypedColumnOneShotTopKWithCache(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest, plan columnTypedColumnPhysicalQueryPlan, start time.Time) (ColumnPhysicalQueryResult, bool, error) {
+func (c *Collection) runColumnTypedColumnOneShotWithCache(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest, plan columnTypedColumnPhysicalQueryPlan, start time.Time) (ColumnPhysicalQueryResult, bool, error) {
 	if c == nil || view.MutationParts != 0 {
 		return ColumnPhysicalQueryResult{}, false, nil
 	}
-	if !columnTypedColumnPhysicalQueryUseTimeOrderTopK(plan, req) || req.AggregateMetadataName != "" {
+	if req.AggregateMetadataName != "" {
 		return ColumnPhysicalQueryResult{}, false, nil
 	}
-	slot := collectionTypedColumnOneShotTopKCacheSlotFor(view, req)
+	slot := collectionTypedColumnOneShotCacheSlotFor(view, req)
 
-	c.typedColumnOneShotTopKMu.Lock()
-	entry := c.typedColumnOneShotTopK
+	c.typedColumnOneShotMu.Lock()
+	entry := c.typedColumnOneShot
 	if entry != nil && entry.slot == slot {
-		c.typedColumnOneShotTopKHits++
-		c.typedColumnOneShotTopKMu.Unlock()
+		c.typedColumnOneShotHits++
+		c.typedColumnOneShotMu.Unlock()
 		entry.mu.Lock()
 		result, err := entry.runner.run(view, req)
 		entry.mu.Unlock()
@@ -60,12 +60,12 @@ func (c *Collection) runColumnTypedColumnOneShotTopKWithCache(view columnPhysica
 		return result, true, err
 	}
 	if entry != nil {
-		c.typedColumnOneShotTopKInvalidations++
-		c.typedColumnOneShotTopK = nil
+		c.typedColumnOneShotInvalidations++
+		c.typedColumnOneShot = nil
 	}
-	c.typedColumnOneShotTopKMisses++
-	c.typedColumnOneShotTopKBuilds++
-	c.typedColumnOneShotTopKMu.Unlock()
+	c.typedColumnOneShotMisses++
+	c.typedColumnOneShotBuilds++
+	c.typedColumnOneShotMu.Unlock()
 
 	readCache, err := newColumnPhysicalAssetReadCacheWithIntegrity(view.ColumnAssetRootDir, view.AssetNamespace, req.ColumnAssetReadIntegrity)
 	if err != nil {
@@ -82,14 +82,14 @@ func (c *Collection) runColumnTypedColumnOneShotTopKWithCache(view columnPhysica
 		result.Diagnostics.ScanNanos = time.Since(start).Nanoseconds()
 		return result, candidate, err
 	}
-	entry = &collectionTypedColumnOneShotTopKCacheEntry{slot: slot, runner: runner}
+	entry = &collectionTypedColumnOneShotCacheEntry{slot: slot, runner: runner}
 
-	c.typedColumnOneShotTopKMu.Lock()
-	if current := c.typedColumnOneShotTopK; current != nil && current.slot != slot {
-		c.typedColumnOneShotTopKInvalidations++
+	c.typedColumnOneShotMu.Lock()
+	if current := c.typedColumnOneShot; current != nil && current.slot != slot {
+		c.typedColumnOneShotInvalidations++
 	}
-	c.typedColumnOneShotTopK = entry
-	c.typedColumnOneShotTopKMu.Unlock()
+	c.typedColumnOneShot = entry
+	c.typedColumnOneShotMu.Unlock()
 
 	entry.mu.Lock()
 	result, err := entry.runner.run(view, req)
@@ -98,8 +98,8 @@ func (c *Collection) runColumnTypedColumnOneShotTopKWithCache(view columnPhysica
 	return result, true, err
 }
 
-func (c *Collection) runColumnPhysicalQueryTypedColumnOneShotTopKInSnapshotView(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest) (ColumnPhysicalQueryResult, bool, error) {
-	if !columnTypedColumnOneShotTopKCacheRequestCandidate(req) || !columnTypedColumnPhysicalQueryTouchesTypedColumnPart(view.FullConfig, req) {
+func (c *Collection) runColumnPhysicalQueryTypedColumnOneShotInSnapshotView(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest) (ColumnPhysicalQueryResult, bool, error) {
+	if !columnTypedColumnOneShotCacheRequestCandidate(req) || !columnTypedColumnPhysicalQueryTouchesTypedColumnPart(view.FullConfig, req) {
 		return ColumnPhysicalQueryResult{}, false, nil
 	}
 	start := time.Now()
@@ -110,21 +110,15 @@ func (c *Collection) runColumnPhysicalQueryTypedColumnOneShotTopKInSnapshotView(
 	if view.MutationParts != 0 {
 		return ColumnPhysicalQueryResult{}, false, nil
 	}
-	return c.runColumnTypedColumnOneShotTopKWithCache(view, req, plan, start)
+	return c.runColumnTypedColumnOneShotWithCache(view, req, plan, start)
 }
 
-func columnTypedColumnOneShotTopKCacheRequestCandidate(req ColumnPhysicalQueryRequest) bool {
-	return req.Kind == ColumnPhysicalQueryGroupMinInt64 &&
-		req.AggregateMetadataName == "" &&
-		req.DistinctColumn == "" &&
-		req.GroupColumn != "" &&
-		req.ValueColumn != "" &&
-		req.TopK > 0 &&
-		req.TopKOrder == ColumnPhysicalQueryTopKInt64Asc
+func columnTypedColumnOneShotCacheRequestCandidate(req ColumnPhysicalQueryRequest) bool {
+	return req.AggregateMetadataName == ""
 }
 
-func collectionTypedColumnOneShotTopKCacheSlotFor(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest) collectionTypedColumnOneShotTopKCacheSlot {
-	return collectionTypedColumnOneShotTopKCacheSlot{
+func collectionTypedColumnOneShotCacheSlotFor(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest) collectionTypedColumnOneShotCacheSlot {
+	return collectionTypedColumnOneShotCacheSlot{
 		commitSeq:                view.CommitSeq,
 		systemRoot:               view.SystemRoot,
 		manifestGeneration:       view.Diagnostics.ManifestGeneration,
@@ -139,11 +133,11 @@ func collectionTypedColumnOneShotTopKCacheSlotFor(view columnPhysicalScanSnapsho
 		topK:                     req.TopK,
 		topKOrder:                req.TopKOrder,
 		skipEmptyGroupKey:        req.SkipEmptyGroupKey,
-		predicates:               collectionTypedColumnOneShotTopKPredicateKey(req),
+		predicates:               collectionTypedColumnOneShotPredicateKey(req),
 	}
 }
 
-func collectionTypedColumnOneShotTopKPredicateKey(req ColumnPhysicalQueryRequest) string {
+func collectionTypedColumnOneShotPredicateKey(req ColumnPhysicalQueryRequest) string {
 	if len(req.Predicates) == 0 {
 		return ""
 	}
@@ -168,19 +162,19 @@ func writeColumnPhysicalCacheKeyPart(b *strings.Builder, value string) {
 	b.WriteByte(';')
 }
 
-func (c *Collection) typedColumnOneShotTopKCacheSnapshotForTest() collectionTypedColumnOneShotTopKCacheSnapshot {
+func (c *Collection) typedColumnOneShotCacheSnapshotForTest() collectionTypedColumnOneShotCacheSnapshot {
 	if c == nil {
-		return collectionTypedColumnOneShotTopKCacheSnapshot{}
+		return collectionTypedColumnOneShotCacheSnapshot{}
 	}
-	c.typedColumnOneShotTopKMu.Lock()
-	defer c.typedColumnOneShotTopKMu.Unlock()
-	snapshot := collectionTypedColumnOneShotTopKCacheSnapshot{
-		CacheHits:     c.typedColumnOneShotTopKHits,
-		CacheMisses:   c.typedColumnOneShotTopKMisses,
-		CacheBuilds:   c.typedColumnOneShotTopKBuilds,
-		Invalidations: c.typedColumnOneShotTopKInvalidations,
+	c.typedColumnOneShotMu.Lock()
+	defer c.typedColumnOneShotMu.Unlock()
+	snapshot := collectionTypedColumnOneShotCacheSnapshot{
+		CacheHits:     c.typedColumnOneShotHits,
+		CacheMisses:   c.typedColumnOneShotMisses,
+		CacheBuilds:   c.typedColumnOneShotBuilds,
+		Invalidations: c.typedColumnOneShotInvalidations,
 	}
-	if c.typedColumnOneShotTopK != nil {
+	if c.typedColumnOneShot != nil {
 		snapshot.Entries = 1
 	}
 	return snapshot

--- a/TreeDB/collections/column_physical_typed_column_one_shot_cache_3088_test.go
+++ b/TreeDB/collections/column_physical_typed_column_one_shot_cache_3088_test.go
@@ -1,0 +1,84 @@
+package collections
+
+import "testing"
+
+func TestColumnPhysicalTypedColumnOneShotCacheQ1Q3NoMetadata3088(t *testing.T) {
+	batches := [][]columnPhysicalJSONBenchParityEventP0{columnPhysicalQ3DenseBatchA1950(), columnPhysicalQ3DenseBatchB1950()}
+	events := flattenColumnPhysicalEvents1950(batches)
+	_, col, closeFn := openTypedColumnSortKeyFixtureBatches1950(t, nil, batches)
+	defer closeFn()
+
+	scanned := scanColumnPhysicalJSONBenchParityEventsP0(t, col, len(events))
+	q1Req := ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCount, GroupColumn: "collection"}
+	q1Want := rowScanCollectionCounts1950(t, col, len(events))
+
+	q1First, err := col.RunColumnPhysicalQuery(q1Req)
+	if err != nil {
+		t.Fatalf("first RunColumnPhysicalQuery(q1): %v", err)
+	}
+	assertColumnPhysicalQ1DenseResult1950(t, "q1 first one-shot", q1First, q1Want, len(events), len(events))
+	assertTypedColumnOneShotCacheSnapshot3088(t, col, "after q1 first", 1, 0, 1, 1, 0)
+
+	q1Second, err := col.RunColumnPhysicalQuery(q1Req)
+	if err != nil {
+		t.Fatalf("second RunColumnPhysicalQuery(q1): %v", err)
+	}
+	assertColumnPhysicalQ1DenseResult1950(t, "q1 second one-shot", q1Second, q1Want, len(events), len(events))
+	assertTypedColumnOneShotCacheSnapshot3088(t, col, "after q1 second", 1, 1, 1, 1, 0)
+
+	q3Req := columnPhysicalQ3DenseRequest1950()
+	q3Want := columnPhysicalQ3DenseReferenceGroups1950(scanned)
+	q3MatchedRows := columnPhysicalJSONBenchReferenceMatchedRowsP0("q3", scanned)
+
+	q3First, err := col.RunColumnPhysicalQuery(q3Req)
+	if err != nil {
+		t.Fatalf("first RunColumnPhysicalQuery(q3): %v", err)
+	}
+	assertColumnPhysicalQ3DenseResult1950(t, "q3 first one-shot", q3First, q3Want, len(events), q3MatchedRows, q3MatchedRows)
+	assertTypedColumnOneShotCacheSnapshot3088(t, col, "after q3 first", 1, 1, 2, 2, 1)
+
+	q3Second, err := col.RunColumnPhysicalQuery(q3Req)
+	if err != nil {
+		t.Fatalf("second RunColumnPhysicalQuery(q3): %v", err)
+	}
+	assertColumnPhysicalQ3DenseResult1950(t, "q3 second one-shot", q3Second, q3Want, len(events), q3MatchedRows, q3MatchedRows)
+	assertTypedColumnOneShotCacheSnapshot3088(t, col, "after q3 second", 1, 2, 2, 2, 1)
+}
+
+func TestColumnPhysicalTypedColumnOneShotCacheQ5NoMetadata3088(t *testing.T) {
+	batches := [][]columnPhysicalJSONBenchParityEventP0{columnPhysicalQ5DenseBatchA1950(), columnPhysicalQ5DenseBatchB1950()}
+	events := flattenColumnPhysicalEvents1950(batches)
+	_, col, closeFn := openTypedColumnSortKeyFixtureBatches1950(t, nil, batches)
+	defer closeFn()
+
+	scanned := scanColumnPhysicalJSONBenchParityEventsP0(t, col, len(events))
+	req := columnPhysicalQ5DenseRequest1950()
+	want := columnPhysicalQ5DenseReferenceGroups1950(scanned, req.TopK)
+	matchedRows := columnPhysicalJSONBenchReferenceMatchedRowsP0("q5", scanned)
+
+	first, err := col.RunColumnPhysicalQuery(req)
+	if err != nil {
+		t.Fatalf("first RunColumnPhysicalQuery(q5): %v", err)
+	}
+	assertColumnPhysicalQ5DenseResult1950(t, "q5 first one-shot", first, want, len(events), matchedRows, columnTypedColumnDenseInt64SpanReducerLocalMap)
+	assertTypedColumnOneShotCacheSnapshot3088(t, col, "after q5 first", 1, 0, 1, 1, 0)
+
+	second, err := col.RunColumnPhysicalQuery(req)
+	if err != nil {
+		t.Fatalf("second RunColumnPhysicalQuery(q5): %v", err)
+	}
+	assertColumnPhysicalQ5DenseResult1950(t, "q5 second one-shot", second, want, len(events), matchedRows, columnTypedColumnDenseInt64SpanReducerLocalMap)
+	assertTypedColumnOneShotCacheSnapshot3088(t, col, "after q5 second", 1, 1, 1, 1, 0)
+}
+
+func assertTypedColumnOneShotCacheSnapshot3088(tb testing.TB, col *Collection, label string, entries int, hits uint64, misses uint64, builds uint64, invalidations uint64) {
+	tb.Helper()
+	snapshot := col.typedColumnOneShotCacheSnapshotForTest()
+	if snapshot.Entries != entries ||
+		snapshot.CacheHits != hits ||
+		snapshot.CacheMisses != misses ||
+		snapshot.CacheBuilds != builds ||
+		snapshot.Invalidations != invalidations {
+		tb.Fatalf("%s cache snapshot=%+v want entries=%d hits=%d misses=%d builds=%d invalidations=%d", label, snapshot, entries, hits, misses, builds, invalidations)
+	}
+}


### PR DESCRIPTION
Closes #3088.

## Scope

This PR broadens the existing q4-only internal one-shot typed-column cache into a generic one-entry cache for no-aggregate-metadata typed-column physical queries on insert-only static snapshots.

It is intentionally an internal production-shape cache for normal `RunColumnPhysicalQuery` / one-shot execution. It does not require callers to prepare or reuse a public physical runner, and it does not change the `first_touch_after_open` story.

The cache remains bypassed for `AggregateMetadataName != ""`, so this PR is general scan/reduce acceleration rather than aggregate-metadata acceleration. The cache key includes snapshot/manifest identity and query shape fields: commit seq, system root, manifest generation/checksum, applied command LSN, read integrity, query kind, group/value/distinct columns, TopK settings, skip-empty behavior, and predicates.

## What improved

- q1/q2/q3/q5 no-aggregate one-shot queries now reuse the decoded typed-column runner on subsequent same-shape one-shot attempts.
- q4/q4a/q4b TopK cache behavior is preserved under the generalized cache name.
- This is specifically a warm normal one-shot improvement. The first attempt still pays setup/decode cost, visible in the attempts array.

## 1M JSONBench evidence

Command:

```sh
GOWORK=/tmp/jsonbench_gowork_3088_20260625_202726/go.work \
DATA_DIR=/Users/michaelseiler/data/bluesky \
OUT_DIR=/tmp/jsonbench_typed_runner_cache_1m_3088_20260625_202735 \
SCALES=subset \
SUBSET_ROWS=1000000 \
TRIES=3 \
STORAGE_LAYOUTS=column-store-full-prepared \
SUITE=full \
QUERY_CELLS='q1 q2 q3 q4 q4a q4b q5 qexpr' \
QUERY_MODE=one_shot_end_to_end \
METADATA_MODE=no_aggregate_metadata \
./run_matrix.sh
```

Artifacts:

- `/tmp/jsonbench_typed_runner_cache_1m_3088_20260625_202735/report.md`
- `/tmp/jsonbench_typed_runner_cache_1m_3088_20260625_202735/rows1000000_column-store-full-prepared_one_shot_end_to_end_no_aggregate_metadata_json_full_all/result.json`
- Baseline artifact: `/tmp/jsonbench_current_noagg_1m_20260625_192958/result.json`

Run fields:

- rows loaded: `1,000,000`
- load wall time: `18.67983925s`
- insert time: `15.556761753s`
- storage bytes, WAL excluded: `137,488,386` bytes
- query mode: `one_shot_end_to_end`
- metadata mode: `no_aggregate_metadata`
- aggregate metadata used: `false` for all rows below
- row/document materializations: `0` / `0`
- JSON reconstruction: `false`
- prepare/setup time: current harness reports `0` for this mode; internal runner build/setup cost is visible in attempt 1

| query | baseline median | PR median | median improvement | PR attempts | rows scanned | decoded/read bytes | TopK / sort marks |
|---|---:|---:|---:|---|---:|---:|---|
| q1 | `0.101127666s` | `0.001503334s` | `98.51%` | `0.128008083s, 0.001503334s, 0.001484584s` | `1,000,000` | `8,210,001` decoded / `21,632,156` physical | none |
| q2 | `0.176067541s` | `0.046164250s` | `73.78%` | `0.190859000s, 0.045417167s, 0.046164250s` | `1,000,000` | `32,925,252` decoded / `21,632,156` physical | none |
| q3 | `0.125414750s` | `0.010623166s` | `91.53%` | `0.139713167s, 0.010623166s, 0.010541458s` | `1,000,000` | `26,680,455` decoded / `21,632,156` physical | none |
| q4 | `0.098013042s` | `0.000415417s` | `99.58%` | `0.110097625s, 0.000415417s, 0.000339375s` | `9` | `285,914` decoded / `21,632,156` physical | bounded TopK + time-order marks |
| q4a | `0.099626167s` | `0.000322458s` | `99.68%` | `0.000324208s, 0.000314250s, 0.000322458s` | `9` | `285,914` decoded / `21,632,156` physical | bounded TopK + time-order marks |
| q4b | `0.100173541s` | `0.000316542s` | `99.68%` | `0.000316542s, 0.000319584s, 0.000316167s` | `9` | `285,914` decoded / `21,632,156` physical | bounded TopK + time-order marks |
| q5 | `0.142347125s` | `0.014647625s` | `89.71%` | `0.159347583s, 0.014647625s, 0.014497584s` | `1,000,000` | `34,933,080` decoded / `21,632,156` physical | bounded TopK only |
| qexpr | `0.015355791s` | `0.015111792s` | `1.59%` | `0.015510209s, 0.015099500s, 0.015111792s` | `1,000,000` | `294,692` metadata decoded / `2,302,520` physical | none |

## Caveats

This PR should not be described as proof that TreeDB SQL is broadly faster than ClickHouse. It improves warm same-shape one-shot execution for no-aggregate typed-column physical queries. It does not cover `first_touch_after_open`, does not compare against ClickHouse projections/materialized summaries, and does not reduce insert/load cost.

## Tests

```sh
go test ./TreeDB/collections -run 'TestColumnPhysicalTypedColumnOneShotCacheQ1Q3NoMetadata3088|TestColumnPhysicalTypedColumnOneShotCacheQ5NoMetadata3088|TestColumnPhysicalQ4ATimeOrderTopKOneShotCache3085|TestColumnPhysicalQ1DenseTypedColumnDirectPreparedParity1950|TestColumnPhysicalQ3DenseTypedColumnDirectPreparedParity1950|TestColumnPhysicalQ5DenseTypedColumnDirectPreparedParity1950|TestColumnPhysicalQ4ATimeOrderTopKDirectPreparedParity1950' -count=1
go test ./TreeDB/collections -count=1
go test ./TreeDB/... -count=1
git diff --cached --check
```
