### PR TITLE
TreeDB: range-prepare q2 typed-column count distinct

### DIFF
--- a/TreeDB/collections/column_physical_q2_1950_test.go
+++ b/TreeDB/collections/column_physical_q2_1950_test.go
@@ -34,6 +34,15 @@ func TestTypedColumnQ2SortedGroupedDistinctStreaming1950(t *testing.T) {
 	assertTypedColumnQ2SortedGroupedDistinctResult1950(t, "direct", direct, rowHash, wantCounts)
 	assertTypedColumnQ2SortedGroupedDistinctDiagnostics1950(t, "direct", direct.Diagnostics, len(events), matchedRows, true)
 
+	skipChecksumsReq := req
+	skipChecksumsReq.ColumnAssetReadIntegrity = ColumnAssetReadIntegritySkipChecksums
+	skipChecksums, err := col.RunColumnPhysicalQuery(skipChecksumsReq)
+	if err != nil {
+		t.Fatalf("RunColumnPhysicalQuery(q2 skip checksums): %v", err)
+	}
+	assertTypedColumnQ2SortedGroupedDistinctResult1950(t, "skip checksums", skipChecksums, rowHash, wantCounts)
+	assertTypedColumnQ2SortedGroupedDistinctDiagnostics1950(t, "skip checksums", skipChecksums.Diagnostics, len(events), matchedRows, true)
+
 	runner, err := col.PrepareColumnPhysicalQuery(req)
 	if err != nil {
 		t.Fatalf("PrepareColumnPhysicalQuery(q2): %v", err)

--- a/TreeDB/collections/column_physical_typed_column_query.go
+++ b/TreeDB/collections/column_physical_typed_column_query.go
@@ -460,7 +460,7 @@ func decodeColumnTypedColumnPhysicalQueryRunnerParts(view columnPhysicalScanSnap
 			return nil, fmt.Errorf("collections: missing typed_column_part asset for generation=%d", physical.Ref.Generation)
 		}
 		var part columnTypedColumnPhysicalQueryPart
-		part, rangeOK, err := decodeTypedColumnPhysicalQueryDensePartFromRanges(plan, req, view.FullConfig.SchemaHash, typedRef, physical, readCache)
+		part, rangeOK, err := decodeTypedColumnPhysicalQueryDensePartFromRanges(plan, req, view.FullConfig.SchemaHash, typedRef, physical, readCache, allowDenseGroupCountDistinct)
 		runner.segmentFileCacheHits = readCache.hits
 		runner.segmentFileCacheMisses = readCache.misses
 		if err != nil {

--- a/TreeDB/collections/column_physical_typed_column_range_3090_test.go
+++ b/TreeDB/collections/column_physical_typed_column_range_3090_test.go
@@ -29,6 +29,35 @@ func TestColumnPhysicalDenseTypedColumnTargetedRangeReads3090(t *testing.T) {
 		assertColumnPhysicalTargetedRangeBytes3090(t, "q1", full.Diagnostics, ranged.Diagnostics)
 	})
 
+	t.Run("q2_group_count_distinct", func(t *testing.T) {
+		batches := [][]columnPhysicalJSONBenchParityEventP0{typedColumnQ2LocalDictBatchA1950(), typedColumnQ2LocalDictBatchB1950()}
+		events := flattenColumnPhysicalEvents1950(batches)
+		_, col, closeFn := openTypedColumnSortKeyFixtureBatches1950(t, nil, batches)
+		defer closeFn()
+
+		req := typedColumnQ2Request1950()
+		rowHash := columnPhysicalJSONBenchHashLinesP0(columnPhysicalJSONBenchReferenceLinesP0("q2", events))
+		want := columnPhysicalJSONBenchQ2ReferenceCountsP0(events)
+		matchedRows := columnPhysicalJSONBenchReferenceMatchedRowsP0("q2", events)
+
+		req.ColumnAssetReadIntegrity = ColumnAssetReadIntegrityVerify
+		full, err := col.RunColumnPhysicalQuery(req)
+		if err != nil {
+			t.Fatalf("RunColumnPhysicalQuery(q2 verify): %v", err)
+		}
+		assertTypedColumnQ2SortedGroupedDistinctResult1950(t, "q2 verify", full, rowHash, want)
+		assertTypedColumnQ2DenseGroupCountDistinctDiagnostics1950(t, "q2 verify", full.Diagnostics, len(events), matchedRows, columnTypedColumnDenseGroupCountDistinctReducerLocalBitset)
+
+		req.ColumnAssetReadIntegrity = ColumnAssetReadIntegritySkipChecksums
+		ranged, err := col.RunColumnPhysicalQuery(req)
+		if err != nil {
+			t.Fatalf("RunColumnPhysicalQuery(q2 skip checksums): %v", err)
+		}
+		assertTypedColumnQ2SortedGroupedDistinctResult1950(t, "q2 targeted ranges", ranged, rowHash, want)
+		assertTypedColumnQ2DenseGroupCountDistinctDiagnostics1950(t, "q2 targeted ranges", ranged.Diagnostics, len(events), matchedRows, columnTypedColumnDenseGroupCountDistinctReducerLocalBitset)
+		assertColumnPhysicalTargetedRangeBytes3090(t, "q2", full.Diagnostics, ranged.Diagnostics)
+	})
+
 	t.Run("q3_group_hour_count", func(t *testing.T) {
 		batches := [][]columnPhysicalJSONBenchParityEventP0{columnPhysicalQ3DenseBatchA1950(), columnPhysicalQ3DenseBatchB1950()}
 		events := flattenColumnPhysicalEvents1950(batches)

--- a/TreeDB/collections/typed_column_adapter.go
+++ b/TreeDB/collections/typed_column_adapter.go
@@ -1465,6 +1465,9 @@ func (r *columnTypedColumnPhysicalRangePartReader) readRange(offset int, length 
 }
 
 func columnTypedColumnPhysicalQueryDensePreparedRequests(plan columnTypedColumnPhysicalQueryPlan, req ColumnPhysicalQueryRequest, allowDenseGroupCountDistinct bool) ([]typedColumnPreparedColumnRequest, bool, error) {
+	if columnTypedColumnPhysicalQueryUseSortedGroupedDistinct(plan, req) {
+		return nil, false, nil
+	}
 	requests := make([]typedColumnPreparedColumnRequest, 0, 4+len(plan.PredicateSpecs))
 	addString := func(column string, role typedcolumn.ColumnExecutionRole, op columnsemantics.Operation) error {
 		adapterColumn, ok, err := typedColumnStringPredicateAdapterColumn(plan.Fields, column)

--- a/TreeDB/collections/typed_column_adapter.go
+++ b/TreeDB/collections/typed_column_adapter.go
@@ -1374,11 +1374,11 @@ func decodeTypedColumnPhysicalQueryDenseGroupHourCountPart(plan columnTypedColum
 	return part, nil
 }
 
-func decodeTypedColumnPhysicalQueryDensePartFromRanges(plan columnTypedColumnPhysicalQueryPlan, req ColumnPhysicalQueryRequest, schemaHash uint64, typedRef, physical columnManifestAssetRefForScan, readCache *columnPhysicalAssetReadCache) (columnTypedColumnPhysicalQueryPart, bool, error) {
+func decodeTypedColumnPhysicalQueryDensePartFromRanges(plan columnTypedColumnPhysicalQueryPlan, req ColumnPhysicalQueryRequest, schemaHash uint64, typedRef, physical columnManifestAssetRefForScan, readCache *columnPhysicalAssetReadCache, allowDenseGroupCountDistinct bool) (columnTypedColumnPhysicalQueryPart, bool, error) {
 	if !typedColumnStringUseTargetedRanges(req.ColumnAssetReadIntegrity) {
 		return columnTypedColumnPhysicalQueryPart{}, false, nil
 	}
-	requests, ok, err := columnTypedColumnPhysicalQueryDensePreparedRequests(plan, req)
+	requests, ok, err := columnTypedColumnPhysicalQueryDensePreparedRequests(plan, req, allowDenseGroupCountDistinct)
 	if err != nil || !ok {
 		return columnTypedColumnPhysicalQueryPart{}, ok, err
 	}
@@ -1412,6 +1412,9 @@ func decodeTypedColumnPhysicalQueryDensePartFromRanges(plan columnTypedColumnPhy
 	switch {
 	case columnTypedColumnPhysicalQueryUseDenseGroupCount(plan, req):
 		part, err := decodeTypedColumnPhysicalQueryDenseGroupCountPreparedPart(plan, summary, typedRef, physical, adapterPart, reader.bytesRead)
+		return part, true, err
+	case columnTypedColumnPhysicalQueryUseDenseGroupCountDistinct(plan, req):
+		part, err := decodeTypedColumnPhysicalQueryDenseGroupCountDistinctPreparedPart(plan, summary, typedRef, physical, adapterPart, reader.bytesRead)
 		return part, true, err
 	case columnTypedColumnPhysicalQueryUseDenseGroupHourCount(plan, req):
 		part, err := decodeTypedColumnPhysicalQueryDenseGroupHourCountPreparedPart(plan, summary, typedRef, physical, adapterPart, reader.bytesRead)
@@ -1461,7 +1464,7 @@ func (r *columnTypedColumnPhysicalRangePartReader) readRange(offset int, length 
 	return raw, nil
 }
 
-func columnTypedColumnPhysicalQueryDensePreparedRequests(plan columnTypedColumnPhysicalQueryPlan, req ColumnPhysicalQueryRequest) ([]typedColumnPreparedColumnRequest, bool, error) {
+func columnTypedColumnPhysicalQueryDensePreparedRequests(plan columnTypedColumnPhysicalQueryPlan, req ColumnPhysicalQueryRequest, allowDenseGroupCountDistinct bool) ([]typedColumnPreparedColumnRequest, bool, error) {
 	requests := make([]typedColumnPreparedColumnRequest, 0, 4+len(plan.PredicateSpecs))
 	addString := func(column string, role typedcolumn.ColumnExecutionRole, op columnsemantics.Operation) error {
 		adapterColumn, ok, err := typedColumnStringPredicateAdapterColumn(plan.Fields, column)
@@ -1508,6 +1511,19 @@ func columnTypedColumnPhysicalQueryDensePreparedRequests(plan columnTypedColumnP
 	switch {
 	case columnTypedColumnPhysicalQueryUseDenseGroupCount(plan, req):
 		if err := addString(plan.GroupColumn, typedcolumn.ColumnRoleProjection, columnsemantics.OpDictionaryCount); err != nil {
+			return nil, true, err
+		}
+	case columnTypedColumnPhysicalQueryUseDenseGroupCountDistinct(plan, req):
+		if !allowDenseGroupCountDistinct {
+			return nil, false, nil
+		}
+		if err := addString(plan.GroupColumn, typedcolumn.ColumnRoleProjection, columnsemantics.OpDictionaryGroupBy); err != nil {
+			return nil, true, err
+		}
+		if err := addString(plan.DistinctColumn, typedcolumn.ColumnRoleMeasure, columnsemantics.OpDictionaryGroupBy); err != nil {
+			return nil, true, err
+		}
+		if err := addPredicates(plan.PredicateSpecs); err != nil {
 			return nil, true, err
 		}
 	case columnTypedColumnPhysicalQueryUseDenseGroupHourCount(plan, req):
@@ -1683,6 +1699,53 @@ func decodeTypedColumnPhysicalQueryDenseGroupCountPreparedPart(plan columnTypedC
 		DecodedBlocks:       blocks,
 		DecodedPayloadBytes: decodedBytes,
 		DenseGroupCount:     &columnTypedColumnDenseGroupCountPart{Cardinality: len(group.Dictionary), Dictionary: group.Dictionary, Codes: group.Codes, Valid: group.Valid},
+	}, nil
+}
+
+func decodeTypedColumnPhysicalQueryDenseGroupCountDistinctPreparedPart(plan columnTypedColumnPhysicalQueryPlan, summary typedColumnAdapterImageSummary, typedRef, physical columnManifestAssetRefForScan, adapterPart *typedColumnAdapterPart, bytesRead int64) (columnTypedColumnPhysicalQueryPart, error) {
+	group, groupDecodedBytes, groupBlocks, err := typedColumnDenseGroupCountDistinctCodeColumn(adapterPart, plan.Fields, plan.GroupColumn, summary.Rows, "grouped count-distinct group")
+	if err != nil {
+		return columnTypedColumnPhysicalQueryPart{}, err
+	}
+	distinct, distinctDecodedBytes, distinctBlocks, err := typedColumnDenseGroupCountDistinctCodeColumn(adapterPart, plan.Fields, plan.DistinctColumn, summary.Rows, "grouped count-distinct distinct")
+	if err != nil {
+		return columnTypedColumnPhysicalQueryPart{}, err
+	}
+	if len(group.Codes) != len(distinct.Codes) {
+		return columnTypedColumnPhysicalQueryPart{}, fmt.Errorf("collections: dense typed-column grouped count-distinct group/distinct rows=%d/%d", len(group.Codes), len(distinct.Codes))
+	}
+
+	predicates := make([]columnTypedColumnDensePredicatePart, 0, len(plan.PredicateSpecs))
+	predicateDecodedBytes := uint64(0)
+	predicateBlocks := 0
+	for _, spec := range plan.PredicateSpecs {
+		predicate, decodedBytes, blocks, err := decodeTypedColumnDensePredicatePart(adapterPart, plan.Fields, spec, summary.Rows)
+		if err != nil {
+			return columnTypedColumnPhysicalQueryPart{}, err
+		}
+		predicates = append(predicates, predicate)
+		predicateDecodedBytes += decodedBytes
+		predicateBlocks += blocks
+	}
+
+	decodedBlocks := groupBlocks + distinctBlocks + predicateBlocks
+	return columnTypedColumnPhysicalQueryPart{
+		Ref:                 typedRef,
+		PhysicalRef:         physical,
+		Rows:                summary.Rows,
+		Bytes:               bytesRead,
+		Sections:            summary.Sections,
+		SectionBytes:        summary.SectionBytes,
+		GranulesConsidered:  decodedBlocks,
+		GranulesDecoded:     decodedBlocks,
+		DecodedBlocks:       decodedBlocks,
+		DecodedPayloadBytes: groupDecodedBytes + distinctDecodedBytes + predicateDecodedBytes,
+		DenseGroupCountDistinct: &columnTypedColumnDenseGroupCountDistinctPart{
+			Rows:       summary.Rows,
+			Group:      group,
+			Distinct:   distinct,
+			Predicates: predicates,
+		},
 	}, nil
 }
 


### PR DESCRIPTION
## Scope

Closes #3092.

This is a narrow q2 setup/read improvement for TreeDB JSONBench `column-store-full-prepared` in `no_aggregate_metadata` mode. It adds targeted typed-column range preparation for the dense q2 `GroupCountAndDistinct` path so first-touch and one-shot q2 runner setup no longer has to read the full typed-column asset.

This PR does not change insert/load behavior, does not add aggregate metadata acceleration, does not report metadata-cost accounting, and does not claim broad SQL superiority over ClickHouse. The q2 local-code reducer is intentionally unchanged; this slice reduces setup/read bytes only.

## What Changed

- Adds q2 `DenseGroupCountDistinct` support to the existing typed-column prepared-range path.
- Requests q2 group, distinct, and predicate string columns with dictionaries from targeted typed-column ranges.
- Builds the same `DenseGroupCountDistinct` runner part from prepared/ranged payloads.
- Preserves the existing immutable-only guard for dense q2 count-distinct; latest-visible mutation reads remain on their existing supported paths.
- Keeps sorted grouped-distinct q2 on the sorted decode path when that plan is active, including `SkipChecksums` reads.
- Extends targeted-range parity coverage with q2 local-dictionary fixtures and sorted q2 skip-checksum coverage.

## Evidence

Baseline is current head before this PR, after #3091. Patched evidence was refreshed at head commit `450e321d` through `GOWORK=/tmp/jsonbench_gowork_3090_pwY555/go.work`.

The pass/fail gate for this slice is setup/read-byte reduction, not runtime superiority. Runtime is still reported below and can vary at this scale; the q2 reducer is unchanged.

| mode | q2 baseline total | q2 patched total | runtime delta | baseline physical bytes | patched physical bytes | byte reduction |
|---|---:|---:|---:|---:|---:|---:|
| `first_touch_after_open` / `no_aggregate_metadata` | 186.289917ms | 196.366042ms | -5.4% | 21,632,156 | 15,991,989 | 26.1% |
| `one_shot_end_to_end` / `no_aggregate_metadata` | 190.176125ms | 177.995125ms | +6.4% | 21,632,156 | 15,991,989 | 26.1% |

Patched q2 diagnostics in both modes: `aggregate metadata=false`, `dense path=group_count_distinct`, `row mats=0`, `doc mats=0`, `JSON reconstruction=false`, `scanned=1,000,000`, `matched=954,611`, `reduced=954,611`.

Artifacts:

- Baseline first-touch: `/tmp/jsonbench_first_touch_noagg_1m_3090_range2_20260625_214044/report.md`
- Baseline one-shot: `/tmp/jsonbench_oneshot_noagg_1m_current_gowork_20260625_220750/report.md`
- Patched first-touch: `/tmp/jsonbench_q2_first_touch_1m_3092_head_20260625_223433/report.md`
- Patched one-shot: `/tmp/jsonbench_q2_oneshot_1m_3092_head_20260625_223507/report.md`

Commands:

```sh
cd /Users/michaelseiler/dev/snissn/JSONBench/treedb
GOWORK=/tmp/jsonbench_gowork_3090_pwY555/go.work \
OUT_DIR=/tmp/jsonbench_q2_first_touch_1m_3092_head_20260625_223433 \
DATA_DIR=/Users/michaelseiler/data/bluesky \
SCALES=subset SUBSET_ROWS=1000000 TRIES=1 \
STORAGE_LAYOUTS=column-store-full-prepared SUITE=full \
QUERY_CELLS='q2' \
QUERY_MODE=first_touch_after_open \
METADATA_MODE=no_aggregate_metadata \
./run_matrix.sh
```

```sh
cd /Users/michaelseiler/dev/snissn/JSONBench/treedb
GOWORK=/tmp/jsonbench_gowork_3090_pwY555/go.work \
OUT_DIR=/tmp/jsonbench_q2_oneshot_1m_3092_head_20260625_223507 \
DATA_DIR=/Users/michaelseiler/data/bluesky \
SCALES=subset SUBSET_ROWS=1000000 TRIES=1 \
STORAGE_LAYOUTS=column-store-full-prepared SUITE=full \
QUERY_CELLS='q2' \
QUERY_MODE=one_shot_end_to_end \
METADATA_MODE=no_aggregate_metadata \
./run_matrix.sh
```

## Tests

```sh
go test ./TreeDB/collections -run 'TestTypedColumnQ2SortedGroupedDistinctStreaming1950|TestColumnPhysicalDenseTypedColumnTargetedRangeReads3090|TestTypedColumnQ2DenseGroupCountDistinctNoSortLocalDictionaries1950' -count=1
go test ./TreeDB/collections -count=1
git diff --check
```
