### PR TITLE
treedb: lazy q4 topk range payload reads

### DIFF
--- a/TreeDB/collections/column_physical_typed_column_query.go
+++ b/TreeDB/collections/column_physical_typed_column_query.go
@@ -158,6 +158,7 @@ type columnTypedColumnPhysicalQueryRunner struct {
 	sortKeyMarkMatches                    int
 	sortKeyMarkSkips                      int
 	sortKeyMarkFallbackReason             string
+	timeOrderTopKRunLazyPayloadBytesBase  int64
 	segmentFileCacheHits                  uint64
 	segmentFileCacheMisses                uint64
 	denseGroupCounts                      map[string]int
@@ -460,7 +461,7 @@ func decodeColumnTypedColumnPhysicalQueryRunnerParts(view columnPhysicalScanSnap
 			return nil, fmt.Errorf("collections: missing typed_column_part asset for generation=%d", physical.Ref.Generation)
 		}
 		var part columnTypedColumnPhysicalQueryPart
-		part, rangeOK, err := decodeTypedColumnPhysicalQueryDensePartFromRanges(plan, req, view.FullConfig.SchemaHash, typedRef, physical, readCache, allowDenseGroupCountDistinct)
+		part, rangeOK, err := decodeTypedColumnPhysicalQueryDensePartFromRanges(plan, req, view.FullConfig.SchemaHash, typedRef, physical, readCache, allowDenseGroupCountDistinct, includePhysicalRows)
 		runner.segmentFileCacheHits = readCache.hits
 		runner.segmentFileCacheMisses = readCache.misses
 		if err != nil {
@@ -1936,6 +1937,7 @@ func columnTypedColumnPhysicalQueryNullableStringsAllowedForTopK(plan columnType
 
 func (r *columnTypedColumnPhysicalQueryRunner) runTimeOrderTopK(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest) (ColumnPhysicalQueryResult, error) {
 	start := time.Now()
+	r.timeOrderTopKRunLazyPayloadBytesBase = r.timeOrderTopKLazyPayloadBytes()
 	if r.timeOrderMinValues == nil {
 		r.timeOrderMinValues = make(map[string]int64, req.TopK+1)
 	} else {
@@ -2026,6 +2028,7 @@ func (r *columnTypedColumnPhysicalQueryRunner) runTimeOrderTopK(view columnPhysi
 
 func (r *columnTypedColumnPhysicalQueryRunner) runLatestVisibleTimeOrderTopK(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest, state *typedColumnLatestVisibilityState, visibilityBytes int64, visibilityNanos int64) (ColumnPhysicalQueryResult, error) {
 	start := time.Now()
+	r.timeOrderTopKRunLazyPayloadBytesBase = r.timeOrderTopKLazyPayloadBytes()
 	if r.timeOrderMinValues == nil {
 		r.timeOrderMinValues = make(map[string]int64, req.TopK+1)
 	} else {
@@ -2120,6 +2123,7 @@ func (r *columnTypedColumnPhysicalQueryRunner) runLatestVisibleTimeOrderTopK(vie
 func (r *columnTypedColumnPhysicalQueryRunner) timeOrderTopKDiagnostics(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest, rowsScanned, matchedRows, reduceRows, decodedGranules, decodedBlocks int, decodedBytes uint64, scanNanos int64) ColumnPhysicalQueryDiagnostics {
 	diag := r.diagnostics(view, req, rowsScanned, matchedRows, reduceRows, scanNanos)
 	diag.TimeOrderTopKUsed = true
+	diag.PhysicalBytesScanned += r.timeOrderTopKRunLazyPayloadBytes()
 	decodedGranules += r.granulesDecoded
 	decodedBlocks += r.decodedBlocks
 	decodedBytes += r.decodedPayloadBytes
@@ -2133,6 +2137,29 @@ func (r *columnTypedColumnPhysicalQueryRunner) timeOrderTopKDiagnostics(view col
 		diag.SkippedGranules = 0
 	}
 	return diag
+}
+
+func (r *columnTypedColumnPhysicalQueryRunner) timeOrderTopKLazyPayloadBytes() int64 {
+	if r == nil {
+		return 0
+	}
+	var bytesRead int64
+	for idx := range r.parts {
+		part := r.parts[idx].TimeOrderTopK
+		if part == nil || part.PayloadLoader == nil {
+			continue
+		}
+		bytesRead += part.PayloadLoader.bytesRead
+	}
+	return bytesRead
+}
+
+func (r *columnTypedColumnPhysicalQueryRunner) timeOrderTopKRunLazyPayloadBytes() int64 {
+	current := r.timeOrderTopKLazyPayloadBytes()
+	if current < r.timeOrderTopKRunLazyPayloadBytesBase {
+		return 0
+	}
+	return current - r.timeOrderTopKRunLazyPayloadBytesBase
 }
 
 func (r *columnTypedColumnPhysicalQueryRunner) latestVisibleTimeOrderTopKDiagnostics(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest, state *typedColumnLatestVisibilityState, visibilityBytes int64, visibilityNanos int64, rowsScanned, matchedRows, reduceRows, decodedGranules, decodedBlocks int, decodedBytes uint64, scanNanos int64) ColumnPhysicalQueryDiagnostics {

--- a/TreeDB/collections/column_physical_typed_column_range_3090_test.go
+++ b/TreeDB/collections/column_physical_typed_column_range_3090_test.go
@@ -85,6 +85,33 @@ func TestColumnPhysicalDenseTypedColumnTargetedRangeReads3090(t *testing.T) {
 		assertColumnPhysicalTargetedRangeBytes3090(t, "q3", full.Diagnostics, ranged.Diagnostics)
 	})
 
+	t.Run("q4_time_order_topk", func(t *testing.T) {
+		batches := columnPhysicalQ4ATimeOrderBatches1950(9_000)
+		events := flattenColumnPhysicalEvents1950(batches)
+		_, col, closeFn := openTypedColumnSortKeyFixtureBatches1950(t, []ColumnSortKey{{Column: "time_us"}}, batches)
+		defer closeFn()
+
+		scanned := scanColumnPhysicalJSONBenchParityEventsP0(t, col, len(events))
+		req := columnPhysicalQ4ATimeOrderRequest1950()
+		want := columnPhysicalQ4ATimeOrderReferenceGroups1950(scanned, req.TopK)
+		wantCandidates := columnPhysicalQ4ATimeOrderReferenceEarlyCandidates1950(scanned, req.TopK)
+
+		req.ColumnAssetReadIntegrity = ColumnAssetReadIntegrityVerify
+		full, err := col.RunColumnPhysicalQuery(req)
+		if err != nil {
+			t.Fatalf("RunColumnPhysicalQuery(q4 verify): %v", err)
+		}
+		assertColumnPhysicalQ4ATimeOrderResult1950(t, "q4 verify", full, want, len(events), wantCandidates)
+
+		req.ColumnAssetReadIntegrity = ColumnAssetReadIntegritySkipChecksums
+		ranged, err := col.RunColumnPhysicalQuery(req)
+		if err != nil {
+			t.Fatalf("RunColumnPhysicalQuery(q4 skip checksums): %v", err)
+		}
+		assertColumnPhysicalQ4ATimeOrderResult1950(t, "q4 targeted ranges", ranged, want, len(events), wantCandidates)
+		assertColumnPhysicalTargetedRangeBytes3090(t, "q4", full.Diagnostics, ranged.Diagnostics)
+	})
+
 	t.Run("q5_group_int64_span", func(t *testing.T) {
 		batches := [][]columnPhysicalJSONBenchParityEventP0{columnPhysicalQ5DenseBatchA1950(), columnPhysicalQ5DenseBatchB1950()}
 		events := flattenColumnPhysicalEvents1950(batches)

--- a/TreeDB/collections/typed_column_adapter.go
+++ b/TreeDB/collections/typed_column_adapter.go
@@ -1374,8 +1374,11 @@ func decodeTypedColumnPhysicalQueryDenseGroupHourCountPart(plan columnTypedColum
 	return part, nil
 }
 
-func decodeTypedColumnPhysicalQueryDensePartFromRanges(plan columnTypedColumnPhysicalQueryPlan, req ColumnPhysicalQueryRequest, schemaHash uint64, typedRef, physical columnManifestAssetRefForScan, readCache *columnPhysicalAssetReadCache, allowDenseGroupCountDistinct bool) (columnTypedColumnPhysicalQueryPart, bool, error) {
+func decodeTypedColumnPhysicalQueryDensePartFromRanges(plan columnTypedColumnPhysicalQueryPlan, req ColumnPhysicalQueryRequest, schemaHash uint64, typedRef, physical columnManifestAssetRefForScan, readCache *columnPhysicalAssetReadCache, allowDenseGroupCountDistinct bool, includePhysicalRows bool) (columnTypedColumnPhysicalQueryPart, bool, error) {
 	if !typedColumnStringUseTargetedRanges(req.ColumnAssetReadIntegrity) {
+		return columnTypedColumnPhysicalQueryPart{}, false, nil
+	}
+	if includePhysicalRows && columnTypedColumnPhysicalQueryUseTimeOrderTopK(plan, req) {
 		return columnTypedColumnPhysicalQueryPart{}, false, nil
 	}
 	requests, ok, err := columnTypedColumnPhysicalQueryDensePreparedRequests(plan, req, allowDenseGroupCountDistinct)
@@ -1401,11 +1404,20 @@ func decodeTypedColumnPhysicalQueryDensePartFromRanges(plan columnTypedColumnPhy
 	if diag.Fallback {
 		return columnTypedColumnPhysicalQueryPart{}, false, nil
 	}
-	adapterPart, err := typedColumnPhysicalQueryPreparedAdapterPart(prepared, plan.Fields, reader.readRange)
+	summary, err := typedColumnPhysicalQueryPreparedSummary(prepared, plan, typedRef, physical)
 	if err != nil {
 		return columnTypedColumnPhysicalQueryPart{}, true, err
 	}
-	summary, err := typedColumnPhysicalQueryPreparedSummary(prepared, plan, typedRef, physical)
+	if columnTypedColumnPhysicalQueryUseTimeOrderTopK(plan, req) {
+		adapterPart, err := typedColumnPhysicalQueryPreparedAdapterPartWithOptions(prepared, plan.Fields, reader.readRange, typedColumnPreparedAdapterPartOptions{LazyPayloads: true})
+		if err != nil {
+			return columnTypedColumnPhysicalQueryPart{}, true, err
+		}
+		payloadLoader := newColumnTypedColumnTimeOrderTopKPayloadLoader(reader.readRangeOwned, prepared)
+		part, err := decodeTypedColumnPhysicalQueryTimeOrderTopKPreparedPart(plan, summary, typedRef, physical, adapterPart, reader.bytesRead, payloadLoader)
+		return part, true, err
+	}
+	adapterPart, err := typedColumnPhysicalQueryPreparedAdapterPart(prepared, plan.Fields, reader.readRange)
 	if err != nil {
 		return columnTypedColumnPhysicalQueryPart{}, true, err
 	}
@@ -1462,6 +1474,17 @@ func (r *columnTypedColumnPhysicalRangePartReader) readRange(offset int, length 
 	}
 	r.bytesRead += int64(len(raw))
 	return raw, nil
+}
+
+func (r *columnTypedColumnPhysicalRangePartReader) readRangeOwned(offset int, length int, section bool) ([]byte, error) {
+	if r == nil || r.readCache == nil {
+		return nil, errors.New("collections: typed-column physical range reader missing read cache")
+	}
+	savedReturnViews := r.readCache.returnViews
+	r.readCache.returnViews = false
+	raw, err := r.readRange(offset, length, section)
+	r.readCache.returnViews = savedReturnViews
+	return raw, err
 }
 
 func columnTypedColumnPhysicalQueryDensePreparedRequests(plan columnTypedColumnPhysicalQueryPlan, req ColumnPhysicalQueryRequest, allowDenseGroupCountDistinct bool) ([]typedColumnPreparedColumnRequest, bool, error) {
@@ -1550,6 +1573,20 @@ func columnTypedColumnPhysicalQueryDensePreparedRequests(plan columnTypedColumnP
 		if err := addPredicates(plan.PredicateSpecs); err != nil {
 			return nil, true, err
 		}
+	case columnTypedColumnPhysicalQueryUseTimeOrderTopK(plan, req):
+		if err := addString(plan.GroupColumn, typedcolumn.ColumnRoleProjection, columnsemantics.OpDictionaryGroupBy); err != nil {
+			return nil, true, err
+		}
+		if err := addInt64(plan.ValueColumn); err != nil {
+			return nil, true, err
+		}
+		if err := addPredicates(plan.PredicateSpecs); err != nil {
+			return nil, true, err
+		}
+		if len(requests) != 0 {
+			requests[0].IncludeSortKeyMetadata = true
+			requests[0].IncludeSortKeyMarks = true
+		}
 	default:
 		return nil, false, nil
 	}
@@ -1581,11 +1618,19 @@ func columnTypedColumnPhysicalQueryDenseGroupHourSpanPlan(plan columnTypedColumn
 	return spanPlan, groupPredicate, hasGroupPredicate
 }
 
+type typedColumnPreparedAdapterPartOptions struct {
+	LazyPayloads bool
+}
+
 func typedColumnPhysicalQueryPreparedAdapterPart(prepared *typedColumnPreparedPartState, fields []TypedStorageField, readRange typedColumnPreparedRangeReader) (*typedColumnAdapterPart, error) {
+	return typedColumnPhysicalQueryPreparedAdapterPartWithOptions(prepared, fields, readRange, typedColumnPreparedAdapterPartOptions{})
+}
+
+func typedColumnPhysicalQueryPreparedAdapterPartWithOptions(prepared *typedColumnPreparedPartState, fields []TypedStorageField, readRange typedColumnPreparedRangeReader, opts typedColumnPreparedAdapterPartOptions) (*typedColumnAdapterPart, error) {
 	if prepared == nil {
 		return nil, errors.New("collections: dense typed-column prepared range missing part")
 	}
-	if readRange == nil {
+	if readRange == nil && !opts.LazyPayloads {
 		return nil, errors.New("collections: dense typed-column prepared range missing payload reader")
 	}
 	columns := make([]typedColumnAdapterColumn, 0, len(prepared.Columns))
@@ -1612,31 +1657,43 @@ func typedColumnPhysicalQueryPreparedAdapterPart(prepared *typedColumnPreparedPa
 			adapterColumn.ReverseDictionary = reverseTypedColumnAdapterDictionary(preparedColumn.Dictionaries)
 			dictionaries[adapterColumn.Definition.Name] = preparedColumn.Dictionaries
 		}
-		partColumn, err := typedColumnPreparedColumnWithPayloads(preparedColumn, readRange)
+		partColumn, err := typedColumnPreparedColumnWithOptionalPayloads(preparedColumn, readRange, !opts.LazyPayloads)
 		if err != nil {
 			return nil, err
 		}
 		columns = append(columns, adapterColumn)
 		partColumns[adapterColumn.Definition.Name] = partColumn
 	}
+	descriptor := prepared.Descriptor
+	if len(descriptor.SortKey) != 0 {
+		descriptor.SortKey = append([]typedcolumn.SortKeyColumn(nil), descriptor.SortKey...)
+	}
+	marks := append([]typedcolumn.SortKeyMark(nil), prepared.Marks...)
 	return &typedColumnAdapterPart{
 		Options:    typedColumnAdapterOptions{Fields: fields, SchemaVersion: prepared.Descriptor.SchemaVersion},
 		Columns:    columns,
-		Part:       &typedcolumn.ColumnPart{Descriptor: prepared.Descriptor, Columns: partColumns},
+		Part:       &typedcolumn.ColumnPart{Descriptor: descriptor, Columns: partColumns, Marks: marks},
 		Dictionary: dictionaries,
 	}, nil
 }
 
 func typedColumnPreparedColumnWithPayloads(preparedColumn *typedColumnPreparedColumnState, readRange typedColumnPreparedRangeReader) (typedcolumn.ColumnPartColumn, error) {
+	return typedColumnPreparedColumnWithOptionalPayloads(preparedColumn, readRange, true)
+}
+
+func typedColumnPreparedColumnWithOptionalPayloads(preparedColumn *typedColumnPreparedColumnState, readRange typedColumnPreparedRangeReader, includePayloads bool) (typedcolumn.ColumnPartColumn, error) {
 	if preparedColumn == nil {
 		return typedcolumn.ColumnPartColumn{}, errors.New("collections: dense typed-column prepared range missing column")
-	}
-	if len(preparedColumn.BlockPlans) != len(preparedColumn.Column.Blocks) {
-		return typedcolumn.ColumnPartColumn{}, fmt.Errorf("collections: dense typed-column prepared range column %q block plans=%d want blocks=%d", preparedColumn.Column.Definition.Name, len(preparedColumn.BlockPlans), len(preparedColumn.Column.Blocks))
 	}
 	column := preparedColumn.Column
 	if len(column.Blocks) != 0 {
 		column.Blocks = append([]typedcolumn.ColumnBlock(nil), column.Blocks...)
+	}
+	if !includePayloads {
+		return column, nil
+	}
+	if len(preparedColumn.BlockPlans) != len(column.Blocks) {
+		return typedcolumn.ColumnPartColumn{}, fmt.Errorf("collections: dense typed-column prepared range column %q block plans=%d want blocks=%d", preparedColumn.Column.Definition.Name, len(preparedColumn.BlockPlans), len(column.Blocks))
 	}
 	for _, blockPlan := range preparedColumn.BlockPlans {
 		if blockPlan.Index < 0 || blockPlan.Index >= len(column.Blocks) {
@@ -1919,6 +1976,7 @@ type columnTypedColumnTimeOrderTopKPart struct {
 	Granules       []typedcolumn.GranuleDescriptor
 	Marks          []typedcolumn.SortKeyMark
 	PhysicalRows   []int
+	PayloadLoader  *columnTypedColumnTimeOrderTopKPayloadLoader
 	ValueColumn    typedcolumn.ColumnPartColumn
 	Group          columnTypedColumnTimeOrderCodeColumn
 	Predicates     []columnTypedColumnTimeOrderPredicateColumn
@@ -1928,6 +1986,78 @@ type columnTypedColumnTimeOrderTopKPart struct {
 	groupValid     []bool
 	predicateCodes [][]uint32
 	predicateValid [][]bool
+}
+
+type columnTypedColumnTimeOrderTopKPayloadLoader struct {
+	readRange typedColumnPreparedRangeReader
+	plans     map[string][]typedColumnPreparedBlockPlan
+	bytesRead int64
+}
+
+func newColumnTypedColumnTimeOrderTopKPayloadLoader(readRange typedColumnPreparedRangeReader, prepared *typedColumnPreparedPartState) *columnTypedColumnTimeOrderTopKPayloadLoader {
+	if readRange == nil || prepared == nil || len(prepared.Columns) == 0 {
+		return nil
+	}
+	plans := make(map[string][]typedColumnPreparedBlockPlan, len(prepared.Columns))
+	for name, column := range prepared.Columns {
+		if column == nil {
+			continue
+		}
+		plans[name] = append([]typedColumnPreparedBlockPlan(nil), column.BlockPlans...)
+	}
+	return &columnTypedColumnTimeOrderTopKPayloadLoader{readRange: readRange, plans: plans}
+}
+
+func (l *columnTypedColumnTimeOrderTopKPayloadLoader) ensureColumnPayloadsForRowRange(column *typedcolumn.ColumnPartColumn, firstRow, rowCount int, role string) error {
+	if l == nil {
+		return nil
+	}
+	if l.readRange == nil {
+		return errors.New("collections: time-order topK payload loader missing range reader")
+	}
+	if column == nil {
+		return fmt.Errorf("collections: time-order topK payload loader missing %s column", role)
+	}
+	plans, ok := l.plans[column.Definition.Name]
+	if !ok {
+		return fmt.Errorf("collections: time-order topK payload loader missing block plans for %s column %q", role, column.Definition.Name)
+	}
+	if len(plans) != len(column.Blocks) {
+		return fmt.Errorf("collections: time-order topK payload loader column %q block plans=%d want blocks=%d", column.Definition.Name, len(plans), len(column.Blocks))
+	}
+	limit := firstRow + rowCount
+	for blockIdx := range column.Blocks {
+		block := &column.Blocks[blockIdx]
+		blockFirst := block.Descriptor.FirstRow
+		blockLimit := blockFirst + block.Descriptor.RowCount
+		if blockLimit <= firstRow {
+			continue
+		}
+		if blockFirst >= limit {
+			break
+		}
+		if len(block.Granule.Payload) != 0 {
+			continue
+		}
+		plan := plans[blockIdx]
+		if plan.Index != blockIdx {
+			return fmt.Errorf("collections: time-order topK payload loader column %q plan index=%d want %d", column.Definition.Name, plan.Index, blockIdx)
+		}
+		if plan.PayloadLength == 0 {
+			continue
+		}
+		payload, err := l.readRange(plan.PayloadOffset, plan.PayloadLength, false)
+		if err != nil {
+			return fmt.Errorf("collections: time-order topK payload loader read %s column %q block %d: %w", role, column.Definition.Name, blockIdx, err)
+		}
+		if len(payload) != plan.PayloadLength {
+			return fmt.Errorf("collections: time-order topK payload loader column %q block %d payload bytes=%d want %d", column.Definition.Name, blockIdx, len(payload), plan.PayloadLength)
+		}
+		block.Granule.Payload = payload
+		block.Granule.PayloadRef = typedcolumn.PayloadRef{Kind: typedcolumn.PayloadRefInline, Length: len(payload)}
+		l.bytesRead += int64(len(payload))
+	}
+	return nil
 }
 
 // decodeTypedColumnPhysicalQueryTimeOrderTopKPart prepares the q4a
@@ -2043,6 +2173,87 @@ func decodeTypedColumnPhysicalQueryTimeOrderTopKPart(plan columnTypedColumnPhysi
 			Granules:       append([]typedcolumn.GranuleDescriptor(nil), adapterPart.Part.Descriptor.Granules...),
 			Marks:          append([]typedcolumn.SortKeyMark(nil), adapterPart.Part.Marks...),
 			PhysicalRows:   physicalRows,
+			ValueColumn:    valuePartColumn,
+			Group:          group,
+			Predicates:     predicates,
+			decodedGranule: -1,
+		},
+	}, nil
+}
+
+func decodeTypedColumnPhysicalQueryTimeOrderTopKPreparedPart(plan columnTypedColumnPhysicalQueryPlan, summary typedColumnAdapterImageSummary, typedRef, physical columnManifestAssetRefForScan, adapterPart *typedColumnAdapterPart, bytesRead int64, payloadLoader *columnTypedColumnTimeOrderTopKPayloadLoader) (columnTypedColumnPhysicalQueryPart, error) {
+	groupColumn, groupPartColumn, cardinality, err := typedColumnDenseStringCodeColumn(adapterPart, plan.Fields, plan.GroupColumn, "time-order topK group")
+	if err != nil {
+		return columnTypedColumnPhysicalQueryPart{}, err
+	}
+	valueColumn, ok, err := typedColumnInt64PredicateAdapterColumn(plan.Fields, plan.ValueColumn)
+	if err != nil {
+		return columnTypedColumnPhysicalQueryPart{}, err
+	}
+	if !ok {
+		return columnTypedColumnPhysicalQueryPart{}, fmt.Errorf("collections: time-order topK value column %q is not owned by typed_column_part", plan.ValueColumn)
+	}
+	for _, candidate := range adapterPart.Columns {
+		if candidate.Definition.Name == valueColumn.Definition.Name {
+			valueColumn = candidate
+			break
+		}
+	}
+	if valueColumn.Field.Nullable || valueColumn.Definition.Type != typedcolumn.ColumnTypeInt64 {
+		return columnTypedColumnPhysicalQueryPart{}, fmt.Errorf("%w: time-order topK value column %q is not a non-null int64", ErrColumnQueryPlanUnsupported, plan.ValueColumn)
+	}
+	valuePartColumn, ok := adapterPart.Part.Columns[valueColumn.Definition.Name]
+	if !ok {
+		return columnTypedColumnPhysicalQueryPart{}, fmt.Errorf("collections: time-order topK missing value column %q", valueColumn.Definition.Name)
+	}
+	if valuePartColumn.Definition.Type != typedcolumn.ColumnTypeInt64 {
+		return columnTypedColumnPhysicalQueryPart{}, fmt.Errorf("%w: time-order topK value column %q type=%s", ErrColumnQueryPlanUnsupported, plan.ValueColumn, valuePartColumn.Definition.Type)
+	}
+	if err := validateTypedColumnTimeOrderTopKMarks(adapterPart.Part, valueColumn.Definition.Name); err != nil {
+		return columnTypedColumnPhysicalQueryPart{}, err
+	}
+
+	group := columnTypedColumnTimeOrderCodeColumn{PartColumn: groupPartColumn, Cardinality: cardinality, DictionaryByCode: groupColumn.ReverseDictionary, Nullable: groupColumn.Field.Nullable}
+	predicates := make([]columnTypedColumnTimeOrderPredicateColumn, 0, len(plan.PredicateSpecs))
+	for _, spec := range plan.PredicateSpecs {
+		if spec.column == plan.GroupColumn {
+			allowed, missingMatchesEmpty, rejectsAll, err := timeOrderTopKAllowedCodes(groupColumn, cardinality, spec)
+			if err != nil {
+				return columnTypedColumnPhysicalQueryPart{}, err
+			}
+			predicates = append(predicates, columnTypedColumnTimeOrderPredicateColumn{CodeColumn: group, Allowed: allowed, MissingMatchesEmpty: missingMatchesEmpty, RejectsAll: rejectsAll, UsesGroupCode: true})
+			continue
+		}
+		predicateColumn, predicatePartColumn, predicateCardinality, err := typedColumnDenseStringCodeColumn(adapterPart, plan.Fields, spec.column, "time-order topK predicate")
+		if err != nil {
+			return columnTypedColumnPhysicalQueryPart{}, err
+		}
+		allowed, missingMatchesEmpty, rejectsAll, err := timeOrderTopKAllowedCodes(predicateColumn, predicateCardinality, spec)
+		if err != nil {
+			return columnTypedColumnPhysicalQueryPart{}, err
+		}
+		predicates = append(predicates, columnTypedColumnTimeOrderPredicateColumn{
+			CodeColumn:          columnTypedColumnTimeOrderCodeColumn{PartColumn: predicatePartColumn, Cardinality: predicateCardinality, DictionaryByCode: predicateColumn.ReverseDictionary, Nullable: predicateColumn.Field.Nullable},
+			Allowed:             allowed,
+			MissingMatchesEmpty: missingMatchesEmpty,
+			RejectsAll:          rejectsAll,
+		})
+	}
+
+	return columnTypedColumnPhysicalQueryPart{
+		Ref:                typedRef,
+		PhysicalRef:        physical,
+		Rows:               summary.Rows,
+		Bytes:              bytesRead,
+		Sections:           summary.Sections,
+		SectionBytes:       summary.SectionBytes,
+		GranulesConsidered: len(adapterPart.Part.Descriptor.Granules),
+		SortKeyMarkChecks:  len(adapterPart.Part.Marks),
+		TimeOrderTopK: &columnTypedColumnTimeOrderTopKPart{
+			Rows:           summary.Rows,
+			Granules:       append([]typedcolumn.GranuleDescriptor(nil), adapterPart.Part.Descriptor.Granules...),
+			Marks:          append([]typedcolumn.SortKeyMark(nil), adapterPart.Part.Marks...),
+			PayloadLoader:  payloadLoader,
 			ValueColumn:    valuePartColumn,
 			Group:          group,
 			Predicates:     predicates,
@@ -2238,6 +2449,9 @@ func (p *columnTypedColumnTimeOrderTopKPart) ensureTimeOrderTopKGranuleDecoded(g
 		return false, 0, 0, fmt.Errorf("collections: time-order topK granule %d outside %d", granuleIdx, len(p.Granules))
 	}
 	granule := p.Granules[granuleIdx]
+	if err := p.ensureTimeOrderTopKGranulePayloads(granuleIdx, granule); err != nil {
+		return false, 0, 0, err
+	}
 	blocks := 0
 	decodedBytes := uint64(0)
 	var err error
@@ -2294,6 +2508,28 @@ func (p *columnTypedColumnTimeOrderTopKPart) ensureTimeOrderTopKGranuleDecoded(g
 	}
 	p.decodedGranule = granuleIdx
 	return true, blocks, decodedBytes, nil
+}
+
+func (p *columnTypedColumnTimeOrderTopKPart) ensureTimeOrderTopKGranulePayloads(granuleIdx int, granule typedcolumn.GranuleDescriptor) error {
+	if p == nil || p.PayloadLoader == nil {
+		return nil
+	}
+	if err := p.PayloadLoader.ensureColumnPayloadsForRowRange(&p.ValueColumn, granule.FirstRow, granule.RowCount, "value"); err != nil {
+		return fmt.Errorf("collections: time-order topK granule %d: %w", granuleIdx, err)
+	}
+	if err := p.PayloadLoader.ensureColumnPayloadsForRowRange(&p.Group.PartColumn, granule.FirstRow, granule.RowCount, "group"); err != nil {
+		return fmt.Errorf("collections: time-order topK granule %d: %w", granuleIdx, err)
+	}
+	for idx := range p.Predicates {
+		predicate := &p.Predicates[idx]
+		if predicate.UsesGroupCode {
+			continue
+		}
+		if err := p.PayloadLoader.ensureColumnPayloadsForRowRange(&predicate.CodeColumn.PartColumn, granule.FirstRow, granule.RowCount, "predicate"); err != nil {
+			return fmt.Errorf("collections: time-order topK granule %d: %w", granuleIdx, err)
+		}
+	}
+	return nil
 }
 
 func decodeTypedColumnInt64ValuesForRowRange(partColumn typedcolumn.ColumnPartColumn, firstRow, rowCount int, role string, dst []int64) ([]int64, uint64, int, error) {

--- a/TreeDB/collections/typed_column_prepared_state.go
+++ b/TreeDB/collections/typed_column_prepared_state.go
@@ -34,6 +34,8 @@ type typedColumnPreparedColumnRequest struct {
 	IncludeVisibility        bool
 	IncludeStats             bool
 	IncludePruning           bool
+	IncludeSortKeyMetadata   bool
+	IncludeSortKeyMarks      bool
 	HasInt64PruningPredicate bool
 	Int64PruningPredicate    typedcolumn.Int64PruningPredicate
 	IncludeVectorPayload     bool
@@ -119,6 +121,7 @@ type typedColumnPreparedPartState struct {
 	RowSpan         typedcolumn.RowSpan
 	PhysicalColumns map[string]typedcolumn.ColumnPartColumn
 	Columns         map[string]*typedColumnPreparedColumnState
+	Marks           []typedcolumn.SortKeyMark
 	Certification   typedcolumn.ColumnPartLayoutCertification
 	Dependencies    []typedcolumn.SectionDependencyDescriptor
 	ManifestBytes   int
@@ -158,6 +161,7 @@ func (p *typedColumnPreparedPartState) close() {
 		delete(p.PhysicalColumns, name)
 	}
 	p.PhysicalColumns = nil
+	p.Marks = nil
 	p.Certification = typedcolumn.ColumnPartLayoutCertification{}
 	for name, column := range p.Columns {
 		if column != nil {
@@ -454,6 +458,13 @@ func typedColumnPreparePartStateFromRanges(ref ColumnAssetRef, physical ColumnAs
 			diag.PruningValidationFailures++
 			diag.PruningValidationFailureReason = err.Error()
 			return nil, diag, fmt.Errorf("collections: typed_column_part pruning validation failed: %w", err)
+		}
+	}
+	if typedColumnPreparedRequestsIncludeSortKeyMetadata(columnRequests) || typedColumnPreparedRequestsIncludeSortKeyMarks(columnRequests) {
+		sortKeyDiag, err := typedColumnAttachPreparedSortKey(part, image, readRange, typedColumnPreparedRequestsIncludeSortKeyMarks(columnRequests))
+		typedColumnPreparedStateDiagnosticsAdd(&diag, sortKeyDiag)
+		if err != nil {
+			return nil, diag, fmt.Errorf("collections: typed_column_part sort-key validation failed: %w", err)
 		}
 	}
 	if !typedColumnPreparedRequestsIncludeStats(columnRequests) {
@@ -771,6 +782,69 @@ func typedColumnPreparedColumnWantsPruning(column *typedColumnPreparedColumnStat
 		}
 	}
 	return false
+}
+
+func typedColumnPreparedRequestsIncludeSortKeyMetadata(requests []typedColumnPreparedColumnRequest) bool {
+	for _, request := range requests {
+		if request.IncludeSortKeyMetadata || request.IncludeSortKeyMarks {
+			return true
+		}
+	}
+	return false
+}
+
+func typedColumnPreparedRequestsIncludeSortKeyMarks(requests []typedColumnPreparedColumnRequest) bool {
+	for _, request := range requests {
+		if request.IncludeSortKeyMarks {
+			return true
+		}
+	}
+	return false
+}
+
+func typedColumnAttachPreparedSortKey(part *typedColumnPreparedPartState, image typedcolumn.ColumnPartImage, readRange typedColumnPreparedRangeReader, includeMarks bool) (typedColumnPreparedStateDiagnostics, error) {
+	var diag typedColumnPreparedStateDiagnostics
+	if part == nil {
+		return diag, errors.New("collections: typed-column prepared sort-key missing part")
+	}
+	if readRange == nil {
+		return diag, errors.New("collections: typed-column prepared sort-key requires range reader")
+	}
+	metadataSection, err := typedColumnAdapterImageSingleSection(image, typedcolumn.ColumnPartImageSectionSortKeyMetadata)
+	if err != nil {
+		return diag, err
+	}
+	metadataRaw, err := readRange(metadataSection.Offset, metadataSection.Length, true)
+	if err != nil {
+		return diag, err
+	}
+	sortKey, err := typedcolumn.DecodeColumnPartSortKeyMetadataSectionPayload(metadataRaw)
+	if err != nil {
+		return diag, err
+	}
+	diag.DecodedMetadataBytes += uint64(len(metadataRaw))
+	part.Descriptor.SortKey = sortKey
+	if !includeMarks {
+		return diag, nil
+	}
+	marksSection, err := typedColumnAdapterImageSingleSection(image, typedcolumn.ColumnPartImageSectionSortKeyMarks)
+	if err != nil {
+		return diag, err
+	}
+	marksRaw, err := readRange(marksSection.Offset, marksSection.Length, true)
+	if err != nil {
+		return diag, err
+	}
+	marks, err := typedcolumn.DecodeColumnPartSortKeyMarksSectionPayload(marksRaw)
+	if err != nil {
+		return diag, err
+	}
+	if err := typedcolumn.ValidateColumnPartSortKeyMarks(part.Descriptor, marks); err != nil {
+		return diag, err
+	}
+	diag.DecodedMetadataBytes += uint64(len(marksRaw))
+	part.Marks = append(part.Marks[:0], marks...)
+	return diag, nil
 }
 
 func typedColumnAttachPreparedPruning(part *typedColumnPreparedPartState, image typedcolumn.ColumnPartImage, readRange typedColumnPreparedRangeReader, requests []typedColumnPreparedColumnRequest) (typedColumnPreparedStateDiagnostics, error) {

--- a/TreeDB/internal/typedcolumn/part_image_decode.go
+++ b/TreeDB/internal/typedcolumn/part_image_decode.go
@@ -1331,7 +1331,11 @@ func decodeSortKeyMetadataSection(image ColumnPartImage) ([]SortKeyColumn, error
 	if err != nil {
 		return nil, err
 	}
-	dec := columnPartImageDecoder{data: image.sectionBytes(section)}
+	return DecodeColumnPartSortKeyMetadataSectionPayload(image.sectionBytes(section))
+}
+
+func DecodeColumnPartSortKeyMetadataSectionPayload(data []byte) ([]SortKeyColumn, error) {
+	dec := columnPartImageDecoder{data: data}
 	count, err := dec.u32()
 	if err != nil {
 		return nil, err
@@ -1367,7 +1371,11 @@ func decodeSortKeyMarksSection(image ColumnPartImage) ([]SortKeyMark, error) {
 	if err != nil {
 		return nil, err
 	}
-	dec := columnPartImageDecoder{data: image.sectionBytes(section)}
+	return DecodeColumnPartSortKeyMarksSectionPayload(image.sectionBytes(section))
+}
+
+func DecodeColumnPartSortKeyMarksSectionPayload(data []byte) ([]SortKeyMark, error) {
+	dec := columnPartImageDecoder{data: data}
 	count, err := dec.u32()
 	if err != nil {
 		return nil, err
@@ -1511,6 +1519,10 @@ func validateDecodedSortKeyMarks(desc ColumnPartDescriptor, marks []SortKeyMark)
 		}
 	}
 	return nil
+}
+
+func ValidateColumnPartSortKeyMarks(desc ColumnPartDescriptor, marks []SortKeyMark) error {
+	return validateDecodedSortKeyMarks(desc, marks)
 }
 
 func decodeSortKeyBound(dec *columnPartImageDecoder) (SortKeyBound, error) {


### PR DESCRIPTION
## Summary

Fixes #3094.

This PR reduces the q4 first-submitted-query typed-column setup/read footprint for the no-aggregate-metadata `column-store-full-prepared` path. It keeps the q4 time-order TopK runner production-shaped for normal one-shot and first-touch execution, but defers typed-column payload reads until the TopK scan actually decodes a needed granule.

Changes:
- teach typed-column prepared range state to attach sort-key metadata and sort-key marks without reading the full part image;
- build time-order TopK prepared parts with lazy payload columns and an owned range payload loader;
- charge lazy payload reads into q4 diagnostics without double-counting repeated hot runs;
- add q4 coverage to the targeted-range regression test alongside q1/q2/q3/q5.

## Scope / non-goals

This is a q4 first-submitted-query read-byte/setup slice only.

It improves:
- `one_shot_end_to_end`: q4 no-aggregate physical bytes read/decoded for the time-order TopK path.
- `first_touch_after_open`: same q4 no-aggregate physical bytes reduction after reopen.
- General scan materialization discipline: q4 remains typed-column, no row/document materialization, no JSON reconstruction.

It does not claim to improve:
- insert/load speed;
- aggregate metadata storage or maintenance cost;
- arbitrary-expression scans;
- q1/q2/q3/q5 runtime;
- broad SQL superiority versus ClickHouse.

ClickHouse comparison mode: not run in this targeted PR. No ClickHouse projections/materialized summaries are used or claimed here.

## Evidence

Baseline from #3094 issue body:
- q4 `one_shot_end_to_end`, `no_aggregate_metadata`: physical bytes `21,632,156`, total `96.683250ms`.
- q4 `first_touch_after_open`, `no_aggregate_metadata`: physical bytes `21,632,156`, total `97.137417ms`.

New TreeDB 1M-row q4 evidence, `column-store-full-prepared`, WAL-excluded durable storage shown by JSONBench:

| query mode | metadata mode | rows loaded | load wall time | storage | prepare/setup | run | render/hash | total | rows scanned | decoded payload | physical bytes | row/doc mats | aggregate metadata | sort/TopK pruning | JSON reconstruction | report |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|---|---|---|
| `one_shot_end_to_end` | `no_aggregate_metadata` | 1,000,000 | 19.042s | 131.12 MiB | 0ns | 99.865375ms | 9.709us | 99.875209ms | 9 | 285,914 | 10,502,828 | 0/0 | false | bounded TopK + time-order TopK | false | `/tmp/jsonbench_q4_oneshot_1m_3094_20260625_231811/report.md` |
| `first_touch_after_open` | `no_aggregate_metadata` | 1,000,000 | 18.585s | 131.12 MiB | 0ns | 97.453042ms | 12.000us | 97.465166ms | 9 | 285,914 | 10,502,828 | 0/0 | false | bounded TopK + time-order TopK | false | `/tmp/jsonbench_q4_first_touch_1m_3094_20260625_231847/report.md` |

Gate result:
- physical bytes: `21,632,156 -> 10,502,828`, about `51.45%` lower, passing the #3094 >=20% physical-byte reduction gate.
- total wall time is roughly flat/noisy, so this PR is not presented as a q4 runtime win.

## Reproduction

```sh
go test ./TreeDB/collections -run 'TestColumnPhysicalDenseTypedColumnTargetedRangeReads3090|TestColumnPhysicalQ4ATimeOrderTopKDirectPreparedParity1950|TestColumnPhysicalQ4ATimeOrderTopKOneShotCache3085' -count=1
go test ./TreeDB/collections -count=1
go test ./TreeDB/internal/typedcolumn -count=1
```

```sh
cd /Users/michaelseiler/dev/snissn/JSONBench/treedb
OUT_DIR=/tmp/jsonbench_q4_oneshot_1m_3094_$(date +%Y%m%d_%H%M%S) \
DATA_DIR=/Users/michaelseiler/data/bluesky \
SCALES=subset SUBSET_ROWS=1000000 TRIES=1 \
STORAGE_LAYOUTS=column-store-full-prepared SUITE=full \
QUERY_CELLS='q4' \
QUERY_MODE=one_shot_end_to_end \
METADATA_MODE=no_aggregate_metadata \
GOWORK=/tmp/jsonbench_gowork_3090_pwY555/go.work \
./run_matrix.sh
```

```sh
cd /Users/michaelseiler/dev/snissn/JSONBench/treedb
OUT_DIR=/tmp/jsonbench_q4_first_touch_1m_3094_$(date +%Y%m%d_%H%M%S) \
DATA_DIR=/Users/michaelseiler/data/bluesky \
SCALES=subset SUBSET_ROWS=1000000 TRIES=1 \
STORAGE_LAYOUTS=column-store-full-prepared SUITE=full \
QUERY_CELLS='q4' \
QUERY_MODE=first_touch_after_open \
METADATA_MODE=no_aggregate_metadata \
GOWORK=/tmp/jsonbench_gowork_3090_pwY555/go.work \
./run_matrix.sh
```
