### PR TITLE
TreeDB: report column publish insert subphases

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -492,17 +492,34 @@ type CollectionInsertStats struct {
 	RetainedPayloadRows                 int
 	RetainedPayloadDeclaredRows         int
 	RetainedPayloadSemanticStreamBlocks int
-	UniqueIndexPreflight                time.Duration
-	TemplateRunBuild                    time.Duration
-	PrimaryRunBuild                     time.Duration
-	IndexStateRunBuild                  time.Duration
-	SecondaryRunBuild                   time.Duration
-	Publish                             time.Duration
-	SecondaryEntries                    int
-	SecondaryKeyBytes                   int
-	SecondarySortedRuns                 int
-	SecondaryUnsortedRuns               int
-	SecondaryRuns                       []CollectionSecondaryRunStats
+	// ColumnPublish* fields are populated for typed-column InsertBatch paths
+	// that route through the command-WAL column manifest publish path.
+	ColumnPublishBuildColumnDelta         time.Duration
+	ColumnPublishBuildSystemDelta         time.Duration
+	ColumnPublishCommit                   time.Duration
+	ColumnPublishDocumentExtraction       time.Duration
+	ColumnPublishDeclaredColumnEncoding   time.Duration
+	ColumnPublishAssetPreparation         time.Duration
+	ColumnPublishManifestEncode           time.Duration
+	ColumnPublishAssetClosureValidation   time.Duration
+	ColumnPublishRootDeltaConstruction    time.Duration
+	ColumnPublishSystemDeltaConstruction  time.Duration
+	ColumnPublishRootDeltaMaterialization time.Duration
+	ColumnPublishRows                     int
+	ColumnPublishPreparedAssets           int
+	ColumnPublishRequiredAssetBytes       int64
+	ColumnPublishManifestBytes            int64
+	UniqueIndexPreflight                  time.Duration
+	TemplateRunBuild                      time.Duration
+	PrimaryRunBuild                       time.Duration
+	IndexStateRunBuild                    time.Duration
+	SecondaryRunBuild                     time.Duration
+	Publish                               time.Duration
+	SecondaryEntries                      int
+	SecondaryKeyBytes                     int
+	SecondarySortedRuns                   int
+	SecondaryUnsortedRuns                 int
+	SecondaryRuns                         []CollectionSecondaryRunStats
 }
 
 // CollectionSecondaryRunStats captures per-secondary-index run construction
@@ -10102,6 +10119,7 @@ func (c *Collection) insertBatchOnceWithLockState(
 				operation:        ColumnPublishOperationInsert,
 				documents:        columnWriteDocumentsFromCommitLog(commandWALDocuments),
 				rows:             len(plan.resultIDs),
+				insertStats:      &plan.stats.CollectionInsertStats,
 			})
 			return err
 		})
@@ -10819,6 +10837,7 @@ func (c *Collection) insertBatchNoIndex(
 				declaredRows:      retainedDeclaredRows,
 				declaredRowsReady: retainedDeclaredRowsReady,
 				rowRemainderBytes: rowRemainderBytes,
+				insertStats:       &stats,
 			})
 			return err
 		})

--- a/TreeDB/collections/column_publish_write.go
+++ b/TreeDB/collections/column_publish_write.go
@@ -3,6 +3,7 @@ package collections
 import (
 	"errors"
 	"fmt"
+	"time"
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
 	"github.com/snissn/gomap/TreeDB/internal/iterator"
@@ -25,6 +26,7 @@ type columnWritePublishInput struct {
 	commandBytes       int64
 	rowRemainderBytes  int64
 	columnPayloadBytes int64
+	insertStats        *CollectionInsertStats
 }
 
 func columnStoreWriteEnabled(meta CollectionMeta) bool {
@@ -147,18 +149,33 @@ func (c *Collection) publishRootDeltaGroupMaybeColumn(ordered []backenddb.Ordere
 	var newSystemRoot uint64
 	var rootIDs []uint64
 	buildColumnDelta := func(ctx backenddb.CommandWALPublishContext) ([]backenddb.OrderedRootDeltaPublishInput, error) {
+		stageStart := time.Now()
+		defer func() {
+			if input.insertStats != nil {
+				input.insertStats.ColumnPublishBuildColumnDelta += time.Since(stageStart)
+			}
+		}()
 		nextPlan, err := c.buildColumnPublishPlanForCommandWALContext(ctx, input, columnBaseRoot)
 		if err != nil {
 			return nil, err
 		}
 		plan = nextPlan
+		recordColumnPublishPlanStats(input.insertStats, plan)
+		materializeStart := time.Now()
 		columnDelta, err := plan.RootDelta.OrderedRootDeltaPublishInput()
+		recordColumnPublishRootDeltaMaterialization(input.insertStats, time.Since(materializeStart))
 		if err != nil {
 			return nil, err
 		}
 		return []backenddb.OrderedRootDeltaPublishInput{columnDelta}, nil
 	}
 	buildSystemDelta := func(ctx backenddb.CommandWALPublishContext, rootIDs []uint64) (iterator.UnsafeIterator, error) {
+		stageStart := time.Now()
+		defer func() {
+			if input.insertStats != nil {
+				input.insertStats.ColumnPublishBuildSystemDelta += time.Since(stageStart)
+			}
+		}()
 		if plan.AppliedCommandLSN != ctx.AppliedCommandLSN {
 			return nil, columnPublishPlanLSNMismatchError(input.meta, ctx.AppliedCommandLSN, plan.AppliedCommandLSN)
 		}
@@ -168,6 +185,7 @@ func (c *Collection) publishRootDeltaGroupMaybeColumn(ordered []backenddb.Ordere
 		}
 		return iter, err
 	}
+	commitStart := time.Now()
 	if input.rawPublishLocked {
 		newSystemRoot, rootIDs, err = c.db.PublishStagedOrderedRootDeltaGroupWithPreflightCommandWALContextRootBuilderAndSystemDeltaBuilder(
 			ordered,
@@ -185,6 +203,7 @@ func (c *Collection) publishRootDeltaGroupMaybeColumn(ordered []backenddb.Ordere
 			buildSystemDelta,
 		)
 	}
+	recordColumnPublishCommit(input.insertStats, time.Since(commitStart))
 	if err != nil {
 		return 0, nil, CollectionMeta{}, nil, err
 	}
@@ -227,12 +246,21 @@ func (c *Collection) publishRootDeltaBatchGroupMaybeColumn(ordered []backenddb.O
 	var updatedMeta CollectionMeta
 	var cleanupColumnDelta func()
 	buildColumnDelta := func(ctx backenddb.CommandWALPublishContext) ([]backenddb.OrderedRootDeltaBatchPublishInput, error) {
+		stageStart := time.Now()
+		defer func() {
+			if input.insertStats != nil {
+				input.insertStats.ColumnPublishBuildColumnDelta += time.Since(stageStart)
+			}
+		}()
 		nextPlan, err := c.buildColumnPublishPlanForCommandWALContext(ctx, input, columnBaseRoot)
 		if err != nil {
 			return nil, err
 		}
 		plan = nextPlan
+		recordColumnPublishPlanStats(input.insertStats, plan)
+		materializeStart := time.Now()
 		columnDelta, cleanup, err := plan.RootDelta.OrderedRootDeltaBatchPublishInput()
+		recordColumnPublishRootDeltaMaterialization(input.insertStats, time.Since(materializeStart))
 		if err != nil {
 			return nil, err
 		}
@@ -240,6 +268,12 @@ func (c *Collection) publishRootDeltaBatchGroupMaybeColumn(ordered []backenddb.O
 		return []backenddb.OrderedRootDeltaBatchPublishInput{columnDelta}, nil
 	}
 	buildSystemDelta := func(ctx backenddb.CommandWALPublishContext, rootIDs []uint64) (iterator.UnsafeIterator, error) {
+		stageStart := time.Now()
+		defer func() {
+			if input.insertStats != nil {
+				input.insertStats.ColumnPublishBuildSystemDelta += time.Since(stageStart)
+			}
+		}()
 		if plan.AppliedCommandLSN != ctx.AppliedCommandLSN {
 			return nil, columnPublishPlanLSNMismatchError(input.meta, ctx.AppliedCommandLSN, plan.AppliedCommandLSN)
 		}
@@ -251,11 +285,13 @@ func (c *Collection) publishRootDeltaBatchGroupMaybeColumn(ordered []backenddb.O
 	}
 	var newSystemRoot uint64
 	var rootIDs []uint64
+	commitStart := time.Now()
 	if input.rawPublishLocked {
 		newSystemRoot, rootIDs, err = c.db.PublishStagedOrderedRootDeltaBatchGroupWithPreflightCommandWALContextRootBuilderAndSystemDeltaBuilder(ordered, preflight, input.commandWALIntent, buildColumnDelta, buildSystemDelta)
 	} else {
 		newSystemRoot, rootIDs, err = c.db.PublishOrderedRootDeltaBatchGroupWithPreflightCommandWALContextRootBuilderAndSystemDeltaBuilder(ordered, preflight, input.commandWALIntent, buildColumnDelta, buildSystemDelta)
 	}
+	recordColumnPublishCommit(input.insertStats, time.Since(commitStart))
 	if err != nil {
 		return 0, nil, CollectionMeta{}, nil, err
 	}
@@ -383,6 +419,38 @@ func prepareColumnWritePublishInputBeforeCommandWAL(input columnWritePublishInpu
 	default:
 		return columnWritePublishInput{}, fmt.Errorf("collections: unsupported column publish operation %q", input.operation)
 	}
+}
+
+func recordColumnPublishPlanStats(stats *CollectionInsertStats, plan ColumnPublishPlan) {
+	if stats == nil || !plan.Enabled {
+		return
+	}
+	metrics := plan.StageMetrics
+	stats.ColumnPublishDocumentExtraction += metrics.DocumentExtraction
+	stats.ColumnPublishDeclaredColumnEncoding += metrics.DeclaredColumnEncoding
+	stats.ColumnPublishAssetPreparation += metrics.AssetPreparation
+	stats.ColumnPublishManifestEncode += metrics.ManifestEncode
+	stats.ColumnPublishAssetClosureValidation += metrics.AssetClosureValidation
+	stats.ColumnPublishRootDeltaConstruction += metrics.RootDeltaConstruction
+	stats.ColumnPublishSystemDeltaConstruction += metrics.SystemDeltaConstruction
+	stats.ColumnPublishRows += plan.Rows
+	stats.ColumnPublishPreparedAssets += len(plan.PreparedAssets)
+	stats.ColumnPublishRequiredAssetBytes = saturatingAddNonNegativeInt64(stats.ColumnPublishRequiredAssetBytes, plan.RequiredAssetBytes)
+	stats.ColumnPublishManifestBytes = saturatingAddNonNegativeInt64(stats.ColumnPublishManifestBytes, plan.ManifestBytes)
+}
+
+func recordColumnPublishRootDeltaMaterialization(stats *CollectionInsertStats, elapsed time.Duration) {
+	if stats == nil {
+		return
+	}
+	stats.ColumnPublishRootDeltaMaterialization += elapsed
+}
+
+func recordColumnPublishCommit(stats *CollectionInsertStats, elapsed time.Duration) {
+	if stats == nil {
+		return
+	}
+	stats.ColumnPublishCommit += elapsed
 }
 
 func (c *Collection) publishRootDeltaGroupWithoutColumn(ordered []backenddb.OrderedRootDeltaPublishInput, input columnWritePublishInput) (uint64, []uint64, error) {

--- a/TreeDB/collections/column_retained_semantic_stream.go
+++ b/TreeDB/collections/column_retained_semantic_stream.go
@@ -394,6 +394,12 @@ func collectColumnRetainedSemanticStreamV1RootFastPathDocument(cfg ColumnStoreCo
 	} else {
 		valuesRaw = valuesRaw[:len(cfg.Columns)]
 	}
+	type retainedRootValue struct {
+		path string
+		raw  []byte
+	}
+	var retainedRootValueStack [8]retainedRootValue
+	retainedRootValues := retainedRootValueStack[:0]
 	err := jsonparser.ObjectEach(document, func(key, value []byte, dataType jsonparser.ValueType, _ int) error {
 		path := string(key)
 		if indexes := plan.declaredColumnIndexesByPath[path]; len(indexes) > 0 {
@@ -408,10 +414,27 @@ func collectColumnRetainedSemanticStreamV1RootFastPathDocument(cfg ColumnStoreCo
 		if err != nil {
 			return err
 		}
-		return collectColumnRetainedSemanticStreamPaths(json.RawMessage(raw), []string{path}, row, streams)
+		for i := range retainedRootValues {
+			if retainedRootValues[i].path == path {
+				retainedRootValues[i].raw = raw
+				return nil
+			}
+		}
+		retainedRootValues = append(retainedRootValues, retainedRootValue{path: path, raw: raw})
+		return nil
 	})
 	if err != nil {
 		return nil, err
+	}
+	if len(retainedRootValues) > 0 {
+		sort.Slice(retainedRootValues, func(i, j int) bool {
+			return retainedRootValues[i].path < retainedRootValues[j].path
+		})
+		for _, value := range retainedRootValues {
+			if err := collectColumnRetainedSemanticStreamPaths(json.RawMessage(value.raw), []string{value.path}, row, streams); err != nil {
+				return nil, err
+			}
+		}
 	}
 	if !plan.declaredRowsReady {
 		return nil, nil

--- a/TreeDB/collections/column_retained_vlog_placement_test.go
+++ b/TreeDB/collections/column_retained_vlog_placement_test.go
@@ -362,6 +362,18 @@ func TestColumnRetainedPayloadSemanticStreamV1InsertBatchRoundTripReopen(t *test
 	if stats.RetainedPayloadSemanticStreamBlocks != 1 {
 		t.Fatalf("retained payload semantic-stream blocks=%d want 1", stats.RetainedPayloadSemanticStreamBlocks)
 	}
+	if stats.ColumnPublishRows != len(docs) {
+		t.Fatalf("column publish rows=%d want %d", stats.ColumnPublishRows, len(docs))
+	}
+	if stats.ColumnPublishPreparedAssets == 0 || stats.ColumnPublishRequiredAssetBytes == 0 || stats.ColumnPublishManifestBytes == 0 {
+		t.Fatalf("column publish asset counters missing: %+v", stats)
+	}
+	if stats.ColumnPublishBuildColumnDelta <= 0 || stats.ColumnPublishCommit <= 0 {
+		t.Fatalf("column publish callback/commit timings missing: %+v", stats)
+	}
+	if stats.ColumnPublishAssetPreparation <= 0 || stats.ColumnPublishManifestEncode <= 0 || stats.ColumnPublishRootDeltaConstruction <= 0 {
+		t.Fatalf("column publish plan timings missing: %+v", stats)
+	}
 	_, whitespaceRow, _ := requireColumnRetainedSemanticStreamLocatorAndBlockPointer(t, d, "events", ids[9])
 	if whitespaceRow != 9 {
 		t.Fatalf("semantic locator row=%d want whitespace-varint row 9", whitespaceRow)

--- a/TreeDB/collections/column_retained_vlog_placement_test.go
+++ b/TreeDB/collections/column_retained_vlog_placement_test.go
@@ -480,6 +480,7 @@ func TestColumnRetainedPayloadSemanticStreamV1RootFastPathPreparesDeclaredRows(t
 	}
 	ids, docs := retainedSemanticStreamDocuments(12)
 	docs[5] = []byte(`{"row_id":5,"kind":"kind-5","payload":"payload-005","note":"quote \" slash \\ smile \u263a","commit":{"cid":"bafy-test-000005"}}`)
+	docs[6] = []byte(`{"row_id":6,"kind":"old-kind","kind":"kind-6","payload":{"old":true},"payload":{"kept":true},"note":"old-note","note":["kept-note"],"commit":{"cid":"old-cid"},"commit":"kept-commit"}`)
 	prepared, err := prepareColumnRetainedPayloadInsertBatchStorageDocumentsWithIDs(cfg, ids, docs, nil)
 	if err != nil {
 		t.Fatalf("prepare semantic-stream-v1 documents with ids: %v", err)
@@ -499,6 +500,10 @@ func TestColumnRetainedPayloadSemanticStreamV1RootFastPathPreparesDeclaredRows(t
 	}
 	if got := row.Values[1].String; got != "kind-5" {
 		t.Fatalf("declared kind=%q want kind-5", got)
+	}
+	duplicateRow := prepared.declaredRows[6]
+	if got := duplicateRow.Values[1].String; got != "kind-6" {
+		t.Fatalf("duplicate declared kind=%q want last duplicate kind-6", got)
 	}
 	if prepared.semanticStreamBlocks == nil {
 		t.Fatal("semantic-stream-v1 root fast path did not return block table")
@@ -531,6 +536,27 @@ func TestColumnRetainedPayloadSemanticStreamV1RootFastPathPreparesDeclaredRows(t
 	}
 	if got, want := retained["note"], "quote \" slash \\ smile \u263a"; got != want {
 		t.Fatalf("retained payload note=%q want %q from escaped JSON string: %s", got, want, rowsJSON[5])
+	}
+	var duplicateRetained map[string]any
+	if err := json.Unmarshal(rowsJSON[6], &duplicateRetained); err != nil {
+		t.Fatalf("decode duplicate retained row JSON: %v", err)
+	}
+	payload, ok := duplicateRetained["payload"].(map[string]any)
+	if !ok {
+		t.Fatalf("duplicate retained payload=%T want object: %s", duplicateRetained["payload"], rowsJSON[6])
+	}
+	if _, ok := payload["old"]; ok {
+		t.Fatalf("duplicate retained payload kept overwritten root object: %s", rowsJSON[6])
+	}
+	if got, ok := payload["kept"].(bool); !ok || !got {
+		t.Fatalf("duplicate retained payload missing last root object: %s", rowsJSON[6])
+	}
+	if got, want := duplicateRetained["commit"], "kept-commit"; got != want {
+		t.Fatalf("duplicate retained commit=%q want %q: %s", got, want, rowsJSON[6])
+	}
+	note, ok := duplicateRetained["note"].([]any)
+	if !ok || len(note) != 1 || note[0] != "kept-note" {
+		t.Fatalf("duplicate retained note=%#v want last duplicate array: %s", duplicateRetained["note"], rowsJSON[6])
 	}
 }
 

--- a/TreeDB/collections/shape_bench_test.go
+++ b/TreeDB/collections/shape_bench_test.go
@@ -36,6 +36,21 @@ func addCollectionInsertStats(dst *collections.CollectionInsertStats, src collec
 	dst.RetainedPayloadRows += src.RetainedPayloadRows
 	dst.RetainedPayloadDeclaredRows += src.RetainedPayloadDeclaredRows
 	dst.RetainedPayloadSemanticStreamBlocks += src.RetainedPayloadSemanticStreamBlocks
+	dst.ColumnPublishBuildColumnDelta += src.ColumnPublishBuildColumnDelta
+	dst.ColumnPublishBuildSystemDelta += src.ColumnPublishBuildSystemDelta
+	dst.ColumnPublishCommit += src.ColumnPublishCommit
+	dst.ColumnPublishDocumentExtraction += src.ColumnPublishDocumentExtraction
+	dst.ColumnPublishDeclaredColumnEncoding += src.ColumnPublishDeclaredColumnEncoding
+	dst.ColumnPublishAssetPreparation += src.ColumnPublishAssetPreparation
+	dst.ColumnPublishManifestEncode += src.ColumnPublishManifestEncode
+	dst.ColumnPublishAssetClosureValidation += src.ColumnPublishAssetClosureValidation
+	dst.ColumnPublishRootDeltaConstruction += src.ColumnPublishRootDeltaConstruction
+	dst.ColumnPublishSystemDeltaConstruction += src.ColumnPublishSystemDeltaConstruction
+	dst.ColumnPublishRootDeltaMaterialization += src.ColumnPublishRootDeltaMaterialization
+	dst.ColumnPublishRows += src.ColumnPublishRows
+	dst.ColumnPublishPreparedAssets += src.ColumnPublishPreparedAssets
+	dst.ColumnPublishRequiredAssetBytes += src.ColumnPublishRequiredAssetBytes
+	dst.ColumnPublishManifestBytes += src.ColumnPublishManifestBytes
 	dst.UniqueIndexPreflight += src.UniqueIndexPreflight
 	dst.TemplateRunBuild += src.TemplateRunBuild
 	dst.PrimaryRunBuild += src.PrimaryRunBuild
@@ -62,6 +77,15 @@ func benchmarkReportCollectionInsertStats(b *testing.B, docs, batches int, stats
 	reportDuration("index_state_extract_ns/doc", stats.IndexStateExtraction)
 	reportDuration("duplicate_preflight_ns/doc", stats.DuplicateDocumentPreflight)
 	reportDuration("retained_payload_prepare_ns/doc", stats.RetainedPayloadPrepare)
+	reportDuration("column_publish_build_column_delta_ns/doc", stats.ColumnPublishBuildColumnDelta)
+	reportDuration("column_publish_build_system_delta_ns/doc", stats.ColumnPublishBuildSystemDelta)
+	reportDuration("column_publish_commit_ns/doc", stats.ColumnPublishCommit)
+	reportDuration("column_publish_asset_prepare_ns/doc", stats.ColumnPublishAssetPreparation)
+	reportDuration("column_publish_manifest_encode_ns/doc", stats.ColumnPublishManifestEncode)
+	reportDuration("column_publish_asset_closure_ns/doc", stats.ColumnPublishAssetClosureValidation)
+	reportDuration("column_publish_root_delta_ns/doc", stats.ColumnPublishRootDeltaConstruction)
+	reportDuration("column_publish_system_delta_ns/doc", stats.ColumnPublishSystemDeltaConstruction)
+	reportDuration("column_publish_root_delta_materialize_ns/doc", stats.ColumnPublishRootDeltaMaterialization)
 	reportDuration("unique_preflight_ns/doc", stats.UniqueIndexPreflight)
 	reportDuration("template_run_ns/doc", stats.TemplateRunBuild)
 	reportDuration("primary_run_ns/doc", stats.PrimaryRunBuild)

--- a/cmd/unified_bench/suite_column_store.go
+++ b/cmd/unified_bench/suite_column_store.go
@@ -208,6 +208,24 @@ type columnStoreInsertPhaseMetric struct {
 	RetainedPayloadRows                       int     `json:"retained_payload_rows,omitempty"`
 	RetainedPayloadDeclaredRows               int     `json:"retained_payload_declared_rows,omitempty"`
 	RetainedPayloadSemanticStreamBlocks       int     `json:"retained_payload_semantic_stream_blocks,omitempty"`
+	ColumnPublishBuildColumnDeltaDurationMS   float64 `json:"column_publish_build_column_delta_duration_ms,omitempty"`
+	ColumnPublishBuildColumnDeltaNsPerRow     float64 `json:"column_publish_build_column_delta_ns_per_row,omitempty"`
+	ColumnPublishBuildSystemDeltaDurationMS   float64 `json:"column_publish_build_system_delta_duration_ms,omitempty"`
+	ColumnPublishBuildSystemDeltaNsPerRow     float64 `json:"column_publish_build_system_delta_ns_per_row,omitempty"`
+	ColumnPublishCommitDurationMS             float64 `json:"column_publish_commit_duration_ms,omitempty"`
+	ColumnPublishCommitNsPerRow               float64 `json:"column_publish_commit_ns_per_row,omitempty"`
+	ColumnPublishDocumentExtractionDurationMS float64 `json:"column_publish_document_extraction_duration_ms,omitempty"`
+	ColumnPublishDeclaredColumnDurationMS     float64 `json:"column_publish_declared_column_encoding_duration_ms,omitempty"`
+	ColumnPublishAssetPreparationDurationMS   float64 `json:"column_publish_asset_preparation_duration_ms,omitempty"`
+	ColumnPublishManifestEncodeDurationMS     float64 `json:"column_publish_manifest_encode_duration_ms,omitempty"`
+	ColumnPublishAssetClosureDurationMS       float64 `json:"column_publish_asset_closure_validation_duration_ms,omitempty"`
+	ColumnPublishRootDeltaDurationMS          float64 `json:"column_publish_root_delta_construction_duration_ms,omitempty"`
+	ColumnPublishSystemDeltaDurationMS        float64 `json:"column_publish_system_delta_construction_duration_ms,omitempty"`
+	ColumnPublishRootDeltaMaterializeMS       float64 `json:"column_publish_root_delta_materialization_duration_ms,omitempty"`
+	ColumnPublishRows                         int     `json:"column_publish_rows,omitempty"`
+	ColumnPublishPreparedAssets               int     `json:"column_publish_prepared_assets,omitempty"`
+	ColumnPublishRequiredAssetBytes           int64   `json:"column_publish_required_asset_bytes,omitempty"`
+	ColumnPublishManifestBytes                int64   `json:"column_publish_manifest_bytes,omitempty"`
 	PrimaryRunBuildDurationMS                 float64 `json:"primary_run_build_duration_ms,omitempty"`
 	PrimaryRunBuildNsPerRow                   float64 `json:"primary_run_build_ns_per_row,omitempty"`
 	PublishDurationMS                         float64 `json:"publish_duration_ms,omitempty"`
@@ -1265,6 +1283,21 @@ func columnStoreAddCollectionInsertStats(dst *collections.CollectionInsertStats,
 	dst.RetainedPayloadRows += src.RetainedPayloadRows
 	dst.RetainedPayloadDeclaredRows += src.RetainedPayloadDeclaredRows
 	dst.RetainedPayloadSemanticStreamBlocks += src.RetainedPayloadSemanticStreamBlocks
+	dst.ColumnPublishBuildColumnDelta += src.ColumnPublishBuildColumnDelta
+	dst.ColumnPublishBuildSystemDelta += src.ColumnPublishBuildSystemDelta
+	dst.ColumnPublishCommit += src.ColumnPublishCommit
+	dst.ColumnPublishDocumentExtraction += src.ColumnPublishDocumentExtraction
+	dst.ColumnPublishDeclaredColumnEncoding += src.ColumnPublishDeclaredColumnEncoding
+	dst.ColumnPublishAssetPreparation += src.ColumnPublishAssetPreparation
+	dst.ColumnPublishManifestEncode += src.ColumnPublishManifestEncode
+	dst.ColumnPublishAssetClosureValidation += src.ColumnPublishAssetClosureValidation
+	dst.ColumnPublishRootDeltaConstruction += src.ColumnPublishRootDeltaConstruction
+	dst.ColumnPublishSystemDeltaConstruction += src.ColumnPublishSystemDeltaConstruction
+	dst.ColumnPublishRootDeltaMaterialization += src.ColumnPublishRootDeltaMaterialization
+	dst.ColumnPublishRows += src.ColumnPublishRows
+	dst.ColumnPublishPreparedAssets += src.ColumnPublishPreparedAssets
+	dst.ColumnPublishRequiredAssetBytes += src.ColumnPublishRequiredAssetBytes
+	dst.ColumnPublishManifestBytes += src.ColumnPublishManifestBytes
 	dst.UniqueIndexPreflight += src.UniqueIndexPreflight
 	dst.TemplateRunBuild += src.TemplateRunBuild
 	dst.PrimaryRunBuild += src.PrimaryRunBuild
@@ -1280,22 +1313,40 @@ func columnStoreAddCollectionInsertStats(dst *collections.CollectionInsertStats,
 func columnStoreInsertPhaseMetricFromStats(stats collections.CollectionInsertStats, batches int) columnStoreInsertPhaseMetric {
 	rows := stats.Documents
 	out := columnStoreInsertPhaseMetric{
-		Documents:                            rows,
-		Batches:                              batches,
-		Runs:                                 stats.Runs,
-		PrepareDocumentsDurationMS:           durationMS(stats.PrepareDocuments),
-		PrepareDocumentsNsPerRow:             nsPerRow(stats.PrepareDocuments, rows),
-		DuplicateDocumentPreflightDurationMS: durationMS(stats.DuplicateDocumentPreflight),
-		DuplicateDocumentPreflightNsPerRow:   nsPerRow(stats.DuplicateDocumentPreflight, rows),
-		RetainedPayloadPrepareDurationMS:     durationMS(stats.RetainedPayloadPrepare),
-		RetainedPayloadPrepareNsPerRow:       nsPerRow(stats.RetainedPayloadPrepare, rows),
-		RetainedPayloadRows:                  stats.RetainedPayloadRows,
-		RetainedPayloadDeclaredRows:          stats.RetainedPayloadDeclaredRows,
-		RetainedPayloadSemanticStreamBlocks:  stats.RetainedPayloadSemanticStreamBlocks,
-		PrimaryRunBuildDurationMS:            durationMS(stats.PrimaryRunBuild),
-		PrimaryRunBuildNsPerRow:              nsPerRow(stats.PrimaryRunBuild, rows),
-		PublishDurationMS:                    durationMS(stats.Publish),
-		PublishNsPerRow:                      nsPerRow(stats.Publish, rows),
+		Documents:                                 rows,
+		Batches:                                   batches,
+		Runs:                                      stats.Runs,
+		PrepareDocumentsDurationMS:                durationMS(stats.PrepareDocuments),
+		PrepareDocumentsNsPerRow:                  nsPerRow(stats.PrepareDocuments, rows),
+		DuplicateDocumentPreflightDurationMS:      durationMS(stats.DuplicateDocumentPreflight),
+		DuplicateDocumentPreflightNsPerRow:        nsPerRow(stats.DuplicateDocumentPreflight, rows),
+		RetainedPayloadPrepareDurationMS:          durationMS(stats.RetainedPayloadPrepare),
+		RetainedPayloadPrepareNsPerRow:            nsPerRow(stats.RetainedPayloadPrepare, rows),
+		RetainedPayloadRows:                       stats.RetainedPayloadRows,
+		RetainedPayloadDeclaredRows:               stats.RetainedPayloadDeclaredRows,
+		RetainedPayloadSemanticStreamBlocks:       stats.RetainedPayloadSemanticStreamBlocks,
+		ColumnPublishBuildColumnDeltaDurationMS:   durationMS(stats.ColumnPublishBuildColumnDelta),
+		ColumnPublishBuildColumnDeltaNsPerRow:     nsPerRow(stats.ColumnPublishBuildColumnDelta, rows),
+		ColumnPublishBuildSystemDeltaDurationMS:   durationMS(stats.ColumnPublishBuildSystemDelta),
+		ColumnPublishBuildSystemDeltaNsPerRow:     nsPerRow(stats.ColumnPublishBuildSystemDelta, rows),
+		ColumnPublishCommitDurationMS:             durationMS(stats.ColumnPublishCommit),
+		ColumnPublishCommitNsPerRow:               nsPerRow(stats.ColumnPublishCommit, rows),
+		ColumnPublishDocumentExtractionDurationMS: durationMS(stats.ColumnPublishDocumentExtraction),
+		ColumnPublishDeclaredColumnDurationMS:     durationMS(stats.ColumnPublishDeclaredColumnEncoding),
+		ColumnPublishAssetPreparationDurationMS:   durationMS(stats.ColumnPublishAssetPreparation),
+		ColumnPublishManifestEncodeDurationMS:     durationMS(stats.ColumnPublishManifestEncode),
+		ColumnPublishAssetClosureDurationMS:       durationMS(stats.ColumnPublishAssetClosureValidation),
+		ColumnPublishRootDeltaDurationMS:          durationMS(stats.ColumnPublishRootDeltaConstruction),
+		ColumnPublishSystemDeltaDurationMS:        durationMS(stats.ColumnPublishSystemDeltaConstruction),
+		ColumnPublishRootDeltaMaterializeMS:       durationMS(stats.ColumnPublishRootDeltaMaterialization),
+		ColumnPublishRows:                         stats.ColumnPublishRows,
+		ColumnPublishPreparedAssets:               stats.ColumnPublishPreparedAssets,
+		ColumnPublishRequiredAssetBytes:           stats.ColumnPublishRequiredAssetBytes,
+		ColumnPublishManifestBytes:                stats.ColumnPublishManifestBytes,
+		PrimaryRunBuildDurationMS:                 durationMS(stats.PrimaryRunBuild),
+		PrimaryRunBuildNsPerRow:                   nsPerRow(stats.PrimaryRunBuild, rows),
+		PublishDurationMS:                         durationMS(stats.Publish),
+		PublishNsPerRow:                           nsPerRow(stats.Publish, rows),
 	}
 	if stats.RetainedPayloadRows > 0 {
 		out.ColumnStoreDeclaredRowReuseCoverageRatio = float64(stats.RetainedPayloadDeclaredRows) / float64(stats.RetainedPayloadRows)
@@ -3741,6 +3792,10 @@ func renderColumnStoreInsertStatsMarkdown(sb *strings.Builder, stats columnStore
 	sb.WriteString(fmt.Sprintf("- retained_payload_semantic_stream_blocks: %d\n", stats.RetainedPayloadSemanticStreamBlocks))
 	sb.WriteString(fmt.Sprintf("- column_store_declared_row_reuse_coverage_ratio: %.6f\n", stats.ColumnStoreDeclaredRowReuseCoverageRatio))
 	sb.WriteString(fmt.Sprintf("- retained_payload_semantic_stream_blocks_per_run: %.6f\n\n", stats.RetainedPayloadSemanticStreamBlocksPerRun))
+	sb.WriteString(fmt.Sprintf("- column_publish_rows: %d\n", stats.ColumnPublishRows))
+	sb.WriteString(fmt.Sprintf("- column_publish_prepared_assets: %d\n", stats.ColumnPublishPreparedAssets))
+	sb.WriteString(fmt.Sprintf("- column_publish_required_asset_bytes: %d\n", stats.ColumnPublishRequiredAssetBytes))
+	sb.WriteString(fmt.Sprintf("- column_publish_manifest_bytes: %d\n\n", stats.ColumnPublishManifestBytes))
 
 	sb.WriteString("| phase | ms | ns/row |\n")
 	sb.WriteString("|---|---:|---:|\n")
@@ -3749,6 +3804,20 @@ func renderColumnStoreInsertStatsMarkdown(sb *strings.Builder, stats columnStore
 	sb.WriteString(fmt.Sprintf("| `retained_payload_prepare` | %.3f | %.1f |\n", stats.RetainedPayloadPrepareDurationMS, stats.RetainedPayloadPrepareNsPerRow))
 	sb.WriteString(fmt.Sprintf("| `primary_run_build` | %.3f | %.1f |\n", stats.PrimaryRunBuildDurationMS, stats.PrimaryRunBuildNsPerRow))
 	sb.WriteString(fmt.Sprintf("| `publish` | %.3f | %.1f |\n\n", stats.PublishDurationMS, stats.PublishNsPerRow))
+
+	if stats.ColumnPublishCommitDurationMS > 0 || stats.ColumnPublishBuildColumnDeltaDurationMS > 0 || stats.ColumnPublishBuildSystemDeltaDurationMS > 0 {
+		sb.WriteString("| column publish subphase | ms | ns/row |\n")
+		sb.WriteString("|---|---:|---:|\n")
+		sb.WriteString(fmt.Sprintf("| `build_column_delta_callback` | %.3f | %.1f |\n", stats.ColumnPublishBuildColumnDeltaDurationMS, stats.ColumnPublishBuildColumnDeltaNsPerRow))
+		sb.WriteString(fmt.Sprintf("| `build_system_delta_callback` | %.3f | %.1f |\n", stats.ColumnPublishBuildSystemDeltaDurationMS, stats.ColumnPublishBuildSystemDeltaNsPerRow))
+		sb.WriteString(fmt.Sprintf("| `publish_commit_total` | %.3f | %.1f |\n", stats.ColumnPublishCommitDurationMS, stats.ColumnPublishCommitNsPerRow))
+		sb.WriteString(fmt.Sprintf("| `asset_preparation` | %.3f |  |\n", stats.ColumnPublishAssetPreparationDurationMS))
+		sb.WriteString(fmt.Sprintf("| `manifest_encode` | %.3f |  |\n", stats.ColumnPublishManifestEncodeDurationMS))
+		sb.WriteString(fmt.Sprintf("| `asset_closure_validation` | %.3f |  |\n", stats.ColumnPublishAssetClosureDurationMS))
+		sb.WriteString(fmt.Sprintf("| `root_delta_construction` | %.3f |  |\n", stats.ColumnPublishRootDeltaDurationMS))
+		sb.WriteString(fmt.Sprintf("| `root_delta_materialization` | %.3f |  |\n", stats.ColumnPublishRootDeltaMaterializeMS))
+		sb.WriteString(fmt.Sprintf("| `system_delta_construction` | %.3f |  |\n\n", stats.ColumnPublishSystemDeltaDurationMS))
+	}
 }
 
 func renderColumnStoreJSONBenchCellsMarkdown(sb *strings.Builder, report columnStoreSuiteReport) {

--- a/cmd/unified_bench/suite_column_store_test.go
+++ b/cmd/unified_bench/suite_column_store_test.go
@@ -547,6 +547,21 @@ func TestRunColumnStoreSuiteWritesArtifactsAndMetricsM11A(t *testing.T) {
 	if report.InsertStats.ColumnStoreDeclaredRowReuseCoverageRatio != 1 {
 		t.Fatalf("declared row reuse coverage=%f want 1: %+v", report.InsertStats.ColumnStoreDeclaredRowReuseCoverageRatio, report.InsertStats)
 	}
+	if report.InsertStats.ColumnPublishRows != report.Rows {
+		t.Fatalf("column publish rows=%d want %d: %+v", report.InsertStats.ColumnPublishRows, report.Rows, report.InsertStats)
+	}
+	if report.InsertStats.ColumnPublishPreparedAssets == 0 || report.InsertStats.ColumnPublishRequiredAssetBytes == 0 || report.InsertStats.ColumnPublishManifestBytes == 0 {
+		t.Fatalf("column publish asset counters missing: %+v", report.InsertStats)
+	}
+	if report.InsertStats.ColumnPublishBuildColumnDeltaDurationMS <= 0 || report.InsertStats.ColumnPublishBuildColumnDeltaNsPerRow <= 0 {
+		t.Fatalf("column publish build-column-delta timing missing: %+v", report.InsertStats)
+	}
+	if report.InsertStats.ColumnPublishCommitDurationMS <= 0 || report.InsertStats.ColumnPublishCommitNsPerRow <= 0 {
+		t.Fatalf("column publish commit timing missing: %+v", report.InsertStats)
+	}
+	if report.InsertStats.ColumnPublishAssetPreparationDurationMS <= 0 || report.InsertStats.ColumnPublishManifestEncodeDurationMS <= 0 || report.InsertStats.ColumnPublishRootDeltaDurationMS <= 0 {
+		t.Fatalf("column publish plan subphase timings missing: %+v", report.InsertStats)
+	}
 	queryMetrics := assertColumnStoreQueryMetricCoverageM11A(t, report.Queries)
 	for _, q := range report.Queries {
 		assertColumnStoreCompressionAttributionM1952(t, q.Name, q.CompressionAttribution, true)
@@ -647,7 +662,7 @@ func TestRunColumnStoreSuiteWritesArtifactsAndMetricsM11A(t *testing.T) {
 			t.Fatalf("column store JSON missing WAL-excluded durable storage field %s:\n%s", want, data)
 		}
 	}
-	for _, want := range []string{`"insert_stats"`, `"retained_payload_prepare_duration_ms"`, `"retained_payload_prepare_ns_per_row"`, `"retained_payload_declared_rows"`, `"column_store_declared_row_reuse_coverage_ratio"`} {
+	for _, want := range []string{`"insert_stats"`, `"retained_payload_prepare_duration_ms"`, `"retained_payload_prepare_ns_per_row"`, `"retained_payload_declared_rows"`, `"column_store_declared_row_reuse_coverage_ratio"`, `"column_publish_build_column_delta_duration_ms"`, `"column_publish_commit_duration_ms"`, `"column_publish_asset_preparation_duration_ms"`, `"column_publish_required_asset_bytes"`} {
 		if !strings.Contains(string(data), want) {
 			t.Fatalf("column store JSON missing insert phase field %s:\n%s", want, data)
 		}
@@ -680,7 +695,7 @@ func TestRunColumnStoreSuiteWritesArtifactsAndMetricsM11A(t *testing.T) {
 			t.Fatalf("column store markdown missing WAL-excluded durable storage field %q:\n%s", want, columnMarkdown)
 		}
 	}
-	for _, want := range []string{"## Insert Phase Stats", "retained_payload_prepare", "retained_payload_declared_rows", "column_store_declared_row_reuse_coverage_ratio"} {
+	for _, want := range []string{"## Insert Phase Stats", "retained_payload_prepare", "retained_payload_declared_rows", "column_store_declared_row_reuse_coverage_ratio", "column_publish_rows", "column publish subphase", "build_column_delta_callback", "publish_commit_total"} {
 		if !strings.Contains(string(columnMarkdown), want) {
 			t.Fatalf("column store markdown missing insert phase field %q:\n%s", want, columnMarkdown)
 		}


### PR DESCRIPTION
## Summary

- Add `CollectionInsertStats` attribution for the typed-column command-WAL publish path: column-delta callback, system-delta callback, backend publish call, plan-stage subphases, rows, assets, required bytes, and manifest bytes.
- Surface those counters in `cmd/unified_bench` JSON/markdown insert stats and collection shape benchmark metrics.
- Add regression coverage that InsertBatch semantic-stream retained-payload runs populate the new publish stats.

## Tracker Scope

Refs #3099, #3096, #3067, #3000, #3070.

This is stacked on #3098 (`codex/3096-semstream-encoder-reuse`) and is a load-path instrumentation slice for the realigned JSONBench/ClickHouse goal. It does not claim broad SQL superiority, does not add one-shot/no-metadata query evidence, and does not close #3099 or #3067 by itself.

Scope classification:

- Insert/load: yes, attribution only.
- One-shot query execution: no.
- Hot prepared query execution: no.
- General no-aggregate typed-column scan performance: no.
- Metadata storage/query acceleration: no.

## Evidence

Tests:

```sh
go test ./TreeDB/collections ./cmd/unified_bench -count=1
git diff --check
```

Synthetic column-store smoke:

```sh
OUT=/tmp/gomap_column_store_publish_stats_smoke_20260626_004810
go run ./cmd/unified_bench -suite column_store -dbs treedb -keys 10000 -batchsize 1000 -profile durable -profile-dir "$OUT" -path-label native-fastpath -column-store-path serial-column-scan -column-store-query q1 -progress=false
```

Artifact: `/tmp/gomap_column_store_publish_stats_smoke_20260626_004810/column_store_results.md`

10k durable synthetic attribution from that run:

| metric | value |
|---|---:|
| ingest_insert_batch | 341.941 ms |
| retained_payload_prepare | 11.606 ms |
| publish | 328.065 ms |
| column_publish_build_column_delta_callback | 268.118 ms |
| column_publish_asset_preparation | 266.840 ms |
| column_publish_manifest_encode | 0.405 ms |
| column_publish_root_delta_construction | 0.031 ms |
| column_publish_root_delta_materialization | 0.059 ms |
| column_publish_build_system_delta_callback | 0.419 ms |
| column_publish_commit_total | 309.022 ms |
| column_publish_rows | 10,000 |
| column_publish_prepared_assets | 70 |
| column_publish_required_asset_bytes | 2,305,580 |
| column_publish_manifest_bytes | 91,090 |

Interpretation: this confirms the next load bottleneck is inside column publish asset preparation/build-column-delta work, not retained-payload prepare. `column_publish_commit_total` is the full backend publish call and includes callback time; use the callback and plan subphase rows for the actionable split.
