### PR TITLE
TreeDB: build int64 column sidecars in one pass

### DIFF
--- a/TreeDB/collections/column_int64_values_asset.go
+++ b/TreeDB/collections/column_int64_values_asset.go
@@ -63,6 +63,10 @@ func buildColumnInt64ValuesAssetForColumn(cfg ColumnStoreConfig, rows []columnDe
 	if col.ValueType != ColumnStoreValueInt64 || col.Nullable {
 		return columnInt64ValuesAsset{}, false, nil
 	}
+	if len(rows) == 0 {
+		return columnInt64ValuesAsset{}, false, nil
+	}
+	values := make([]int64, len(rows))
 	for rowIdx, row := range rows {
 		if row.Deleted {
 			return columnInt64ValuesAsset{}, false, nil
@@ -77,13 +81,7 @@ func buildColumnInt64ValuesAssetForColumn(cfg ColumnStoreConfig, rows []columnDe
 		if !value.Present || value.Null {
 			return columnInt64ValuesAsset{}, false, nil
 		}
-	}
-	if len(rows) == 0 {
-		return columnInt64ValuesAsset{}, false, nil
-	}
-	values := make([]int64, len(rows))
-	for rowIdx, row := range rows {
-		values[rowIdx] = row.Values[colIdx].Int64
+		values[rowIdx] = value.Int64
 	}
 	return columnInt64ValuesAsset{
 		Collection:        collection,


### PR DESCRIPTION
## Scope

Closes #3104.
Refs #3103, #3102, #3099, #3067, #3000, #3001, #3070.
Stacked on #3103, which is stacked on #3101 and #3098.

This is an insert/load-path optimization only. It changes the non-null int64 sidecar builder to validate and copy each eligible column in one row pass instead of validating all rows and then scanning the same rows again to copy values. The sidecar binary format and fail-closed semantics are unchanged.

## Realigned-goal classification

- Improves: TreeDB column-store insert/load sidecar asset preparation.
- Does not improve or claim evidence for: one-shot SQL execution, first-touch-after-open, hot prepared query execution, no-aggregate-metadata scan speed, metadata storage, or ClickHouse SQL superiority.
- This PR must not be used as broad SQL superiority evidence; it is one load-path slice under the realigned JSONBench/ClickHouse goal.

## Evidence

Compared against #3103 smoke `/tmp/gomap_column_store_direct_typed_publish_20260626_011517/column_store_results.md` using the same 10k durable synthetic column-store command shape:

| metric | #3103 smoke | this PR smoke | delta |
|---|---:|---:|---:|
| `ingest_insert_batch` | 310.382 ms | 282.640 ms | -27.742 ms |
| `publish` | 295.867 ms | 267.928 ms | -27.939 ms |
| `column_publish_build_column_delta_callback` | 244.962 ms | 218.891 ms | -26.071 ms |
| `column_publish_asset_preparation` | 243.714 ms | 217.713 ms | -26.001 ms |
| `column_publish_prepared_assets` | 70 | 70 | unchanged |
| `column_publish_required_asset_bytes` | 2,305,580 | 2,305,580 | unchanged |

This PR smoke artifact: `/tmp/gomap_column_store_int64_single_pass_20260626_012539/column_store_results.md`.

The smoke improvement is directionally useful but still a 10k synthetic slice; full JSONBench load claims require a fresh external run.

## Tests

- `go test ./TreeDB/collections -run 'TestColumnRetainedPayloadSemanticStreamV1(InsertBatchRoundTripReopen|RootFastPathPreparesDeclaredRows)|TestPrepareColumnWritePublishInputUsesPreparedDeclaredRows|TestTypedColumn|TestColumnInt64' -count=1`
- `go test ./TreeDB/collections ./cmd/unified_bench -count=1`
- `git diff --check`
- `go run ./cmd/unified_bench -suite column_store -dbs treedb -keys 10000 -batchsize 1000 -profile durable -profile-dir /tmp/gomap_column_store_int64_single_pass_20260626_012539 -path-label native-fastpath -column-store-path serial_column_scan -column-store-query q1 -progress=false`
