### PR TITLE
TreeDB JSONBench: add first-touch after open query lane

### DIFF
--- a/cmd/unified_bench/README.md
+++ b/cmd/unified_bench/README.md
@@ -378,6 +378,13 @@ CPU/allocation profiles. Omit it, or pass `all`, for the default full
 q1-q5/q5_metadata suite. Duplicate query names are rejected so benchprof
 tables and artifact labels stay unambiguous.
 
+Use `-column-store-first-touch-after-open` when collecting the secondary
+`first_touch_after_open` lane. It closes the warmed reopened DB after the main
+query pass, then reopens the DB and collection once per selected query and
+records separate `first_touch_queries` rows with reopen/open time included in
+`prepare_setup_duration_ms`. The primary `queries` rows remain the
+`one_shot_end_to_end` lane.
+
 Column-store non-column retained payloads default to `semantic-stream-v1` so the
 production storage-parity path uses retained semantic-stream side-root blocks.
 Use `-column-store-retained-payload-encoding template-v1`, or set
@@ -392,8 +399,9 @@ The suite writes:
 - `insights.md`, `insights.json`, `insights.html`
 - configured runtime profiles, including `cpu_column_store_treedb_column_store.pprof`, `allocs_column_store_treedb_column_store.pprof`, `checkpoint_cpu_checkpoint_column_store_treedb_column_store.pprof`, `block.pprof`, `mutex.pprof`, `trace.out`, and the query-phase delta `block_column_store_treedb_column_store.pprof` / `mutex_column_store_treedb_column_store.pprof` when those profile classes produce non-empty deltas
 
-`column_store_results.json` includes a `jsonbench_cells` matrix for the in-repo
-synthetic JSONBench-shaped fixture. Each cell records the external-facing label
+`column_store_results.json` includes `query_mode` and `metadata_mode` labels on
+query rows and a `jsonbench_cells` matrix for the in-repo synthetic
+JSONBench-shaped fixture. Each cell records the external-facing label
 (`row-scan`, `column-direct`, `column-prepared`, `column-direct-metadata`, or
 `column-prepared-metadata` when the mode exists), query name, sort layout,
 storage source, direct/prepared mode, metadata-vs-data path, compression mode,

--- a/cmd/unified_bench/suite_column_store.go
+++ b/cmd/unified_bench/suite_column_store.go
@@ -709,6 +709,7 @@ func runColumnStoreSuite(baseCfg BenchConfig, opts columnStoreSuiteOptions) (str
 	}
 	profileFinalizeErr := finishRuntimeProfiles()
 	runtimeProfilesActive = false
+	queryPhaseStats := cloneStringMap(db.Stats())
 
 	var firstTouchQueries []columnStoreQueryMetric
 	var firstTouchParity map[string]columnStoreParity
@@ -855,7 +856,11 @@ func runColumnStoreSuite(baseCfg BenchConfig, opts columnStoreSuiteOptions) (str
 	populateColumnStoreThroughputInterpretations(report.Queries)
 
 	md := renderColumnStoreSuiteMarkdown(report)
-	run := columnStoreBenchRun(baseCfg, profile, dataDir, report, db.Stats(), checkpointDuration)
+	benchRunStats := db.Stats()
+	if firstTouchAfterOpen {
+		benchRunStats = queryPhaseStats
+	}
+	run := columnStoreBenchRun(baseCfg, profile, dataDir, report, benchRunStats, checkpointDuration)
 	if strings.TrimSpace(opts.ProfileDir) != "" {
 		report.Artifacts = columnStoreArtifactPathsForProfileDir(opts.ProfileDir, baseCfg, opts.RunBenchprof)
 		report.Artifacts = columnStoreSuitePruneMissingRuntimeDeltaArtifacts(report.Artifacts)

--- a/cmd/unified_bench/suite_column_store.go
+++ b/cmd/unified_bench/suite_column_store.go
@@ -113,6 +113,7 @@ var (
 	columnStoreSuiteQueryArg                    = flag.String("column-store-query", "", "Optional comma-separated query subset for -suite column_store profiling (q1,q2,q3,q4a,q4b,q5,q5_metadata; empty/all runs the full q1-q5/q5_metadata suite; duplicates are rejected)")
 	columnStoreSuiteAssetReadIntegrityArg       = flag.String("column-store-asset-read-integrity", string(collections.ColumnAssetReadIntegrityVerify), "Column asset hot-read integrity for -suite column_store physical paths (verify, cached_verify, skip_checksums; relaxed modes are unsafe and require -treedb-allow-unsafe)")
 	columnStoreSuiteTypedCompressionArg         = flag.String("column-store-typed-compression", "", "Benchmark-only typed_column_part compression policy for -suite column_store when typed-column assets are published (none,snappy,lz4,zstd,zstd_dict; zstd values fail closed; empty uses production default none)")
+	columnStoreSuiteFirstTouchAfterOpenArg      = flag.Bool("column-store-first-touch-after-open", false, "Also report secondary first_touch_after_open query rows by reopening the DB/collection once per selected query")
 	columnStoreSuiteTypedInt64EncodingArg       = flag.String("column-store-typed-int64-encoding", "", "Benchmark-only typed_column_part int64 encoding override (default,raw_int64,delta_varint,double_delta_varint; empty uses production default)")
 	columnStoreSuiteTypedRowsPerGranuleArg      = flag.Int("column-store-typed-rows-per-granule", 0, "Benchmark-only typed_column_part rows per granule override (0 uses production default)")
 	columnStoreSuiteTypedAdaptiveArg            = flag.Bool("column-store-typed-adaptive", false, "Benchmark-only typed_column_part adaptive rows-per-granule sizing (off by default; public config remains unchanged)")
@@ -153,6 +154,7 @@ type columnStoreSuiteOptions struct {
 	ColumnAssetReadIntegrity collections.ColumnAssetReadIntegrity
 	RunBenchprof             bool
 	CorruptReferenceForTest  string
+	FirstTouchAfterOpen      bool
 }
 
 type columnStoreSuiteReport struct {
@@ -173,8 +175,10 @@ type columnStoreSuiteReport struct {
 	Stages                   []columnStoreStageMetric       `json:"stages"`
 	InsertStats              columnStoreInsertPhaseMetric   `json:"insert_stats"`
 	Queries                  []columnStoreQueryMetric       `json:"queries"`
+	FirstTouchQueries        []columnStoreQueryMetric       `json:"first_touch_queries,omitempty"`
 	JSONBenchCells           []columnStoreJSONBenchCell     `json:"jsonbench_cells"`
 	Parity                   map[string]columnStoreParity   `json:"parity"`
+	FirstTouchParity         map[string]columnStoreParity   `json:"first_touch_parity,omitempty"`
 	ByteAccounting           columnStoreByteAccounting      `json:"byte_accounting"`
 	CodecLayouts             []columnStoreCodecLayoutMetric `json:"codec_layouts"`
 	CompressionMatrixNote    string                         `json:"compression_matrix_note"`
@@ -546,6 +550,7 @@ func runColumnStoreSuite(baseCfg BenchConfig, opts columnStoreSuiteOptions) (str
 	if err != nil {
 		return "", err
 	}
+	firstTouchAfterOpen := opts.FirstTouchAfterOpen || *columnStoreSuiteFirstTouchAfterOpenArg
 	assetReadIntegrity, err := columnStoreSuiteEffectiveAssetReadIntegrity(opts.ColumnAssetReadIntegrity)
 	if err != nil {
 		return "", err
@@ -668,7 +673,11 @@ func runColumnStoreSuite(baseCfg BenchConfig, opts columnStoreSuiteOptions) (str
 	if err != nil {
 		return "", fmt.Errorf("column_store: reopen: %w", err)
 	}
-	defer db.Close()
+	defer func() {
+		if db != nil {
+			_ = db.Close()
+		}
+	}()
 	collection, err = collections.NewCollectionManager(db).OpenCollection("events")
 	if err != nil {
 		return "", fmt.Errorf("column_store: reopen collection: %w", err)
@@ -700,6 +709,31 @@ func runColumnStoreSuite(baseCfg BenchConfig, opts columnStoreSuiteOptions) (str
 	}
 	profileFinalizeErr := finishRuntimeProfiles()
 	runtimeProfilesActive = false
+
+	var firstTouchQueries []columnStoreQueryMetric
+	var firstTouchParity map[string]columnStoreParity
+	if firstTouchAfterOpen {
+		if err := db.Close(); err != nil {
+			return "", fmt.Errorf("column_store: close before first-touch-after-open: %w", err)
+		}
+		db = nil
+		start = time.Now()
+		firstTouchQueries, firstTouchParity, err = runColumnStoreSuiteFirstTouchAfterOpenQueries(dataDir, rows, rawHashes, forcedPath, assetReadIntegrity, queryNames)
+		stages = append(stages, columnStoreStage("first_touch_after_open", start, rows*len(queryNames), 0))
+		if err != nil {
+			return "", err
+		}
+		start = time.Now()
+		db, err = openColumnStoreSuiteDB(dataDir)
+		if err != nil {
+			return "", fmt.Errorf("column_store: reopen after first-touch-after-open: %w", err)
+		}
+		collection, err = collections.NewCollectionManager(db).OpenCollection("events")
+		if err != nil {
+			return "", fmt.Errorf("column_store: reopen collection after first-touch-after-open: %w", err)
+		}
+		stages = append(stages, columnStoreStage("reopen_after_first_touch", start, rows, sourceBytes))
+	}
 
 	totalBytes, totalFiles, err := columnStoreSuiteDirUsage(dataDir)
 	if err != nil {
@@ -769,8 +803,10 @@ func runColumnStoreSuite(baseCfg BenchConfig, opts columnStoreSuiteOptions) (str
 		Stages:                stages,
 		InsertStats:           columnStoreInsertPhaseMetricFromStats(insertStats, insertBatches),
 		Queries:               queries,
+		FirstTouchQueries:     firstTouchQueries,
 		JSONBenchCells:        jsonbenchCells,
 		Parity:                parity,
+		FirstTouchParity:      firstTouchParity,
 		ByteAccounting: columnStoreByteAccounting{
 			SourceDocumentBytes:                sourceBytes,
 			RetainedPayloadBytes:               retainedPayloadBytes,
@@ -1729,6 +1765,74 @@ func runColumnStoreSuiteQueries(collection *collections.Collection, rows int, ra
 		queries = append(queries, metric)
 	}
 	return queries, parity, firstErr
+}
+
+func runColumnStoreSuiteFirstTouchAfterOpenQueries(dataDir string, rows int, rawHashes map[string]uint64, path string, assetReadIntegrity collections.ColumnAssetReadIntegrity, queryNames []string) ([]columnStoreQueryMetric, map[string]columnStoreParity, error) {
+	queryNames, err := columnStoreSuiteEffectiveQueryNames(queryNames, "")
+	if err != nil {
+		return nil, nil, err
+	}
+	queries := make([]columnStoreQueryMetric, 0, len(queryNames))
+	parity := make(map[string]columnStoreParity, len(queryNames))
+	var firstErr error
+	for _, name := range queryNames {
+		openStart := time.Now()
+		db, err := openColumnStoreSuiteDB(dataDir)
+		if err != nil {
+			return queries, parity, fmt.Errorf("column_store: first-touch reopen for %s: %w", name, err)
+		}
+		collection, err := collections.NewCollectionManager(db).OpenCollection("events")
+		openElapsed := time.Since(openStart)
+		if err != nil {
+			closeErr := db.Close()
+			return queries, parity, errors.Join(fmt.Errorf("column_store: first-touch open collection for %s: %w", name, err), closeErr)
+		}
+		queryMetrics, queryParity, queryErr := runColumnStoreSuiteQueries(collection, rows, rawHashes, path, assetReadIntegrity, []string{name})
+		closeErr := db.Close()
+		if closeErr != nil {
+			queryErr = errors.Join(queryErr, fmt.Errorf("column_store: first-touch close for %s: %w", name, closeErr))
+		}
+		for key, value := range queryParity {
+			parity[key] = value
+		}
+		if len(queryMetrics) == 1 {
+			metric := columnStoreFirstTouchQueryMetric(queryMetrics[0], openElapsed)
+			queries = append(queries, metric)
+		} else if queryErr == nil {
+			queryErr = fmt.Errorf("column_store: first-touch query %s metrics=%d want 1", name, len(queryMetrics))
+		}
+		if queryErr != nil && firstErr == nil {
+			firstErr = queryErr
+		}
+	}
+	return queries, parity, firstErr
+}
+
+func columnStoreFirstTouchQueryMetric(metric columnStoreQueryMetric, openElapsed time.Duration) columnStoreQueryMetric {
+	openDurationMS := durationMS(openElapsed)
+	metric.QueryMode = columnStoreQueryModeFirstTouchAfterOpen
+	metric.DurationMS += openDurationMS
+	metric.PrepareSetupDurationMS += openDurationMS
+	metric.TotalQueryDurationMS += openDurationMS
+	metric.duration += openElapsed
+	metric.RowsPerSecond = ratePerSecond(float64(metric.RowsProcessed), metric.duration)
+	metric.MiBPerSecond = ratePerSecond(float64(metric.BytesRead)/(1024*1024), metric.duration)
+	metric.NsPerRow = nsPerRow(metric.duration, metric.RowsProcessed)
+	metric.CacheLabel = "fresh_reopen_per_query"
+	metric.ImplementationNote = columnStoreAppendImplementationNote(metric.ImplementationNote, "first_touch_after_open includes DB reopen and collection open in prepare/setup")
+	return metric
+}
+
+func columnStoreAppendImplementationNote(note, suffix string) string {
+	note = strings.TrimSpace(note)
+	suffix = strings.TrimSpace(suffix)
+	if note == "" {
+		return suffix
+	}
+	if suffix == "" {
+		return note
+	}
+	return note + "; " + suffix
 }
 
 func columnStoreSuitePlanRequest(name string, rows int, forceKind collections.ColumnQueryPlanKind) collections.ColumnQueryPlanRequest {
@@ -3691,34 +3795,8 @@ func renderColumnStoreSuiteMarkdown(report columnStoreSuiteReport) string {
 	renderColumnStoreJSONBenchCellsMarkdown(&sb, report)
 	renderColumnStoreColgranuleReuseMarkdown(&sb, report)
 
-	sb.WriteString("## Query Throughput And Parity\n\n")
-	sb.WriteString("| query | query mode | metadata mode | plan | storage source | fallback | manifest root | active gen/checksum | rows/s | MiB/s | ns/row | prepare/setup ms | run ms | render/hash ms | total query ms | planner ms | scan ms | reduce ms | adapter ms | parity hash ms | workers | scheduled granules | skipped granules | metadata hits | dictionary code hits | int64 value hits | B/read | rows materialized | segment file cache hit/miss | hash parity | note |\n")
-	sb.WriteString("|---|---|---|---|---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|---|---|\n")
-	for _, q := range report.Queries {
-		parity := "pass"
-		if p, ok := report.Parity[q.Name]; ok && !p.Pass {
-			parity = "FAIL"
-		}
-		note := q.ImplementationNote
-		if note == "" && q.AliasOf != "" {
-			note = "alias_of_" + q.AliasOf
-		}
-		noteCell := "-"
-		if note != "" {
-			noteCell = markdownCodeTableText(note)
-		}
-		manifestRootCell := "-"
-		if q.ManifestRootName != "" || q.ManifestRoot != 0 {
-			manifestRootCell = fmt.Sprintf("%s/%d", q.ManifestRootName, q.ManifestRoot)
-		}
-		activeManifestCell := "-"
-		if q.ManifestGeneration != 0 || q.ActiveManifestChecksum != 0 {
-			activeManifestCell = fmt.Sprintf("%d/%d", q.ManifestGeneration, q.ActiveManifestChecksum)
-		}
-		sb.WriteString(fmt.Sprintf("| %s | %s | %s | %s | %s | %s | %s | %s | %.3f | %.3f | %.1f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %d | %d | %d | %d | %d | %d | %d | %d | %d/%d | %s | %s |\n",
-			markdownCodeTableText(q.Name), markdownCodeTableText(q.QueryMode), markdownCodeTableText(q.MetadataMode), markdownCodeTableText(q.PlanLabel), markdownCodeTableText(q.StorageSource), markdownCodeTableText(q.FallbackReason), markdownCodeTableText(manifestRootCell), markdownCodeTableText(activeManifestCell), q.RowsPerSecond, q.MiBPerSecond, q.NsPerRow, q.PrepareSetupDurationMS, q.RunDurationMS, q.RenderHashDurationMS, q.TotalQueryDurationMS, q.PlannerDurationMS, q.ScanDurationMS, q.ReduceDurationMS, q.AdapterDurationMS, q.ParityHashDurationMS, q.WorkerCount, q.ScheduledGranules, q.SkippedGranules, q.MetadataHits, q.DictionaryCodeHits, q.Int64ValueHits, q.BytesRead, q.RowMaterializations, q.SegmentFileCacheHits, q.SegmentFileCacheMisses, parity, noteCell))
-	}
-	sb.WriteString("\n")
+	renderColumnStoreQueryMetricsMarkdown(&sb, "Query Throughput And Parity", report.Queries, report.Parity)
+	renderColumnStoreQueryMetricsMarkdown(&sb, "First Touch After Open Query Throughput And Parity", report.FirstTouchQueries, report.FirstTouchParity)
 
 	renderColumnStoreQueryCompressionAttributionMarkdown(&sb, report)
 	renderColumnStoreCodecLayoutMarkdown(&sb, report)
@@ -3815,6 +3893,40 @@ func renderColumnStoreInsertStatsMarkdown(sb *strings.Builder, stats columnStore
 	sb.WriteString(fmt.Sprintf("| `retained_payload_prepare` | %.3f | %.1f |\n", stats.RetainedPayloadPrepareDurationMS, stats.RetainedPayloadPrepareNsPerRow))
 	sb.WriteString(fmt.Sprintf("| `primary_run_build` | %.3f | %.1f |\n", stats.PrimaryRunBuildDurationMS, stats.PrimaryRunBuildNsPerRow))
 	sb.WriteString(fmt.Sprintf("| `publish` | %.3f | %.1f |\n\n", stats.PublishDurationMS, stats.PublishNsPerRow))
+}
+
+func renderColumnStoreQueryMetricsMarkdown(sb *strings.Builder, title string, queries []columnStoreQueryMetric, parityByName map[string]columnStoreParity) {
+	if len(queries) == 0 {
+		return
+	}
+	sb.WriteString("## " + title + "\n\n")
+	sb.WriteString("| query | query mode | metadata mode | plan | storage source | fallback | manifest root | active gen/checksum | rows/s | MiB/s | ns/row | prepare/setup ms | run ms | render/hash ms | total query ms | planner ms | scan ms | reduce ms | adapter ms | parity hash ms | workers | scheduled granules | skipped granules | metadata hits | dictionary code hits | int64 value hits | B/read | rows materialized | segment file cache hit/miss | hash parity | note |\n")
+	sb.WriteString("|---|---|---|---|---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|---|---|\n")
+	for _, q := range queries {
+		parity := "pass"
+		if p, ok := parityByName[q.Name]; ok && !p.Pass {
+			parity = "FAIL"
+		}
+		note := q.ImplementationNote
+		if note == "" && q.AliasOf != "" {
+			note = "alias_of_" + q.AliasOf
+		}
+		noteCell := "-"
+		if note != "" {
+			noteCell = markdownCodeTableText(note)
+		}
+		manifestRootCell := "-"
+		if q.ManifestRootName != "" || q.ManifestRoot != 0 {
+			manifestRootCell = fmt.Sprintf("%s/%d", q.ManifestRootName, q.ManifestRoot)
+		}
+		activeManifestCell := "-"
+		if q.ManifestGeneration != 0 || q.ActiveManifestChecksum != 0 {
+			activeManifestCell = fmt.Sprintf("%d/%d", q.ManifestGeneration, q.ActiveManifestChecksum)
+		}
+		sb.WriteString(fmt.Sprintf("| %s | %s | %s | %s | %s | %s | %s | %s | %.3f | %.3f | %.1f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %d | %d | %d | %d | %d | %d | %d | %d | %d/%d | %s | %s |\n",
+			markdownCodeTableText(q.Name), markdownCodeTableText(q.QueryMode), markdownCodeTableText(q.MetadataMode), markdownCodeTableText(q.PlanLabel), markdownCodeTableText(q.StorageSource), markdownCodeTableText(q.FallbackReason), markdownCodeTableText(manifestRootCell), markdownCodeTableText(activeManifestCell), q.RowsPerSecond, q.MiBPerSecond, q.NsPerRow, q.PrepareSetupDurationMS, q.RunDurationMS, q.RenderHashDurationMS, q.TotalQueryDurationMS, q.PlannerDurationMS, q.ScanDurationMS, q.ReduceDurationMS, q.AdapterDurationMS, q.ParityHashDurationMS, q.WorkerCount, q.ScheduledGranules, q.SkippedGranules, q.MetadataHits, q.DictionaryCodeHits, q.Int64ValueHits, q.BytesRead, q.RowMaterializations, q.SegmentFileCacheHits, q.SegmentFileCacheMisses, parity, noteCell))
+	}
+	sb.WriteString("\n")
 }
 
 func renderColumnStoreJSONBenchCellsMarkdown(sb *strings.Builder, report columnStoreSuiteReport) {

--- a/cmd/unified_bench/suite_column_store.go
+++ b/cmd/unified_bench/suite_column_store.go
@@ -712,17 +712,15 @@ func runColumnStoreSuite(baseCfg BenchConfig, opts columnStoreSuiteOptions) (str
 
 	var firstTouchQueries []columnStoreQueryMetric
 	var firstTouchParity map[string]columnStoreParity
+	var firstTouchErr error
 	if firstTouchAfterOpen {
 		if err := db.Close(); err != nil {
 			return "", fmt.Errorf("column_store: close before first-touch-after-open: %w", err)
 		}
 		db = nil
 		start = time.Now()
-		firstTouchQueries, firstTouchParity, err = runColumnStoreSuiteFirstTouchAfterOpenQueries(dataDir, rows, rawHashes, forcedPath, assetReadIntegrity, queryNames)
+		firstTouchQueries, firstTouchParity, firstTouchErr = runColumnStoreSuiteFirstTouchAfterOpenQueries(dataDir, rows, rawHashes, forcedPath, assetReadIntegrity, queryNames)
 		stages = append(stages, columnStoreStage("first_touch_after_open", start, rows*len(queryNames), 0))
-		if err != nil {
-			return "", err
-		}
 		start = time.Now()
 		db, err = openColumnStoreSuiteDB(dataDir)
 		if err != nil {
@@ -872,8 +870,8 @@ func runColumnStoreSuite(baseCfg BenchConfig, opts columnStoreSuiteOptions) (str
 		}
 	}
 	// Keep artifacts available for diagnosis even when parity/report-cell gates fail.
-	if parityErr != nil || profileFinalizeErr != nil || jsonbenchCellsErr != nil {
-		return "", errors.Join(parityErr, profileFinalizeErr, jsonbenchCellsErr)
+	if parityErr != nil || firstTouchErr != nil || profileFinalizeErr != nil || jsonbenchCellsErr != nil {
+		return "", errors.Join(parityErr, firstTouchErr, profileFinalizeErr, jsonbenchCellsErr)
 	}
 	return md, nil
 }

--- a/cmd/unified_bench/suite_column_store_test.go
+++ b/cmd/unified_bench/suite_column_store_test.go
@@ -1968,6 +1968,82 @@ func TestColumnStoreSuiteExecutesForcedSerialPhysicalPathM14B(t *testing.T) {
 	}
 }
 
+func TestColumnStoreSuiteReportsFirstTouchAfterOpenLaneM3070(t *testing.T) {
+	dir := t.TempDir()
+	cfg := BenchConfig{Keys: 16, BatchSize: 8, DBsArg: "treedb", Profile: "durable", SeedUsed: 1}
+	_, err := runColumnStoreSuite(cfg, columnStoreSuiteOptions{
+		ProfileDir:          dir,
+		ExecutionPath:       "native-fastpath",
+		ForcedPath:          columnStorePathSerialColumnScan,
+		QueryNames:          []string{columnStoreQueryQ1},
+		FirstTouchAfterOpen: true,
+	})
+	if err != nil {
+		t.Fatalf("runColumnStoreSuite first touch: %v", err)
+	}
+
+	var report columnStoreSuiteReport
+	data, err := os.ReadFile(filepath.Join(dir, "column_store_results.json"))
+	if err != nil {
+		t.Fatalf("read column_store_results.json: %v", err)
+	}
+	if err := json.Unmarshal(data, &report); err != nil {
+		t.Fatalf("unmarshal column_store_results.json: %v", err)
+	}
+	if len(report.Queries) != 1 || len(report.FirstTouchQueries) != 1 {
+		t.Fatalf("queries=%d first_touch_queries=%d want one each", len(report.Queries), len(report.FirstTouchQueries))
+	}
+	oneShot := report.Queries[0]
+	firstTouch := report.FirstTouchQueries[0]
+	if oneShot.QueryMode != columnStoreQueryModeOneShotEndToEnd {
+		t.Fatalf("one-shot query_mode=%q want %q", oneShot.QueryMode, columnStoreQueryModeOneShotEndToEnd)
+	}
+	if firstTouch.QueryMode != columnStoreQueryModeFirstTouchAfterOpen {
+		t.Fatalf("first-touch query_mode=%q want %q", firstTouch.QueryMode, columnStoreQueryModeFirstTouchAfterOpen)
+	}
+	if firstTouch.CacheLabel != "fresh_reopen_per_query" {
+		t.Fatalf("first-touch cache_label=%q want fresh_reopen_per_query", firstTouch.CacheLabel)
+	}
+	if firstTouch.MetadataMode != columnStoreMetadataModeNoAggregate || firstTouch.PlanLabel != oneShot.PlanLabel {
+		t.Fatalf("first-touch mode/plan=%q/%q want no aggregate and one-shot plan %q: %+v", firstTouch.MetadataMode, firstTouch.PlanLabel, oneShot.PlanLabel, firstTouch)
+	}
+	if firstTouch.RawHash != oneShot.RawHash || firstTouch.ProductionHash != oneShot.ProductionHash {
+		t.Fatalf("first-touch hashes raw/prod=%016x/%016x want one-shot %016x/%016x", firstTouch.RawHash, firstTouch.ProductionHash, oneShot.RawHash, oneShot.ProductionHash)
+	}
+	if firstTouch.PrepareSetupDurationMS <= firstTouch.PlannerDurationMS {
+		t.Fatalf("first-touch prepare/setup did not include reopen/open setup: first=%+v one_shot=%+v", firstTouch, oneShot)
+	}
+	if firstTouch.TotalQueryDurationMS+0.000001 < firstTouch.PrepareSetupDurationMS+firstTouch.RunDurationMS+firstTouch.RenderHashDurationMS {
+		t.Fatalf("first-touch total does not cover setup/run/render: first=%+v", firstTouch)
+	}
+	if math.Abs(firstTouch.TotalQueryDurationMS-firstTouch.DurationMS) > 0.000001 {
+		t.Fatalf("first-touch total_query_duration_ms=%f want duration_ms=%f", firstTouch.TotalQueryDurationMS, firstTouch.DurationMS)
+	}
+	if !strings.Contains(firstTouch.ImplementationNote, "first_touch_after_open") {
+		t.Fatalf("first-touch note missing mode explanation: %+v", firstTouch)
+	}
+	parity, ok := report.FirstTouchParity[columnStoreQueryQ1]
+	if !ok || !parity.Pass {
+		t.Fatalf("first-touch parity missing/failing: %+v", report.FirstTouchParity)
+	}
+	stageNames := make([]string, 0, len(report.Stages))
+	for _, stage := range report.Stages {
+		stageNames = append(stageNames, stage.Name)
+	}
+	if !slices.Contains(stageNames, "first_touch_after_open") || !slices.Contains(stageNames, "reopen_after_first_touch") {
+		t.Fatalf("first-touch stages missing from %+v", stageNames)
+	}
+	md, err := os.ReadFile(filepath.Join(dir, "column_store_results.md"))
+	if err != nil {
+		t.Fatalf("read column_store_results.md: %v", err)
+	}
+	for _, want := range []string{"## First Touch After Open Query Throughput And Parity", columnStoreQueryModeFirstTouchAfterOpen} {
+		if !strings.Contains(string(md), want) {
+			t.Fatalf("markdown missing %q:\n%s", want, md)
+		}
+	}
+}
+
 func TestColumnStoreSuiteExecutesForcedAggregateAndParallelPhysicalPathsM14B(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/cmd/unified_bench/suite_column_store_test.go
+++ b/cmd/unified_bench/suite_column_store_test.go
@@ -2044,6 +2044,41 @@ func TestColumnStoreSuiteReportsFirstTouchAfterOpenLaneM3070(t *testing.T) {
 	}
 }
 
+func TestColumnStoreSuiteReportsFirstTouchMismatchAfterArtifactsM3070(t *testing.T) {
+	dir := t.TempDir()
+	cfg := BenchConfig{Keys: 16, BatchSize: 8, DBsArg: "treedb", Profile: "durable", SeedUsed: 1}
+	_, err := runColumnStoreSuite(cfg, columnStoreSuiteOptions{
+		ProfileDir:              dir,
+		ExecutionPath:           "native-fastpath",
+		ForcedPath:              columnStorePathSerialColumnScan,
+		QueryNames:              []string{columnStoreQueryQ1},
+		FirstTouchAfterOpen:     true,
+		CorruptReferenceForTest: columnStoreQueryQ1,
+	})
+	if err == nil || !strings.Contains(err.Error(), "parity mismatch") || !strings.Contains(err.Error(), "q1") {
+		t.Fatalf("expected first-touch parity mismatch error, got %v", err)
+	}
+
+	var report columnStoreSuiteReport
+	data, readErr := os.ReadFile(filepath.Join(dir, "column_store_results.json"))
+	if readErr != nil {
+		t.Fatalf("expected column_store_results.json after first-touch mismatch: %v", readErr)
+	}
+	if err := json.Unmarshal(data, &report); err != nil {
+		t.Fatalf("unmarshal report: %v", err)
+	}
+	if len(report.FirstTouchQueries) != 1 {
+		t.Fatalf("first_touch_queries=%d want one diagnostic row", len(report.FirstTouchQueries))
+	}
+	parity, ok := report.FirstTouchParity[columnStoreQueryQ1]
+	if !ok {
+		t.Fatalf("missing first-touch q1 parity: %+v", report.FirstTouchParity)
+	}
+	if parity.Pass {
+		t.Fatalf("expected first-touch q1 parity to be recorded as failed: %+v", parity)
+	}
+}
+
 func TestColumnStoreSuiteExecutesForcedAggregateAndParallelPhysicalPathsM14B(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/cmd/unified_bench/suite_column_store_test.go
+++ b/cmd/unified_bench/suite_column_store_test.go
@@ -2042,6 +2042,22 @@ func TestColumnStoreSuiteReportsFirstTouchAfterOpenLaneM3070(t *testing.T) {
 			t.Fatalf("markdown missing %q:\n%s", want, md)
 		}
 	}
+
+	var benchprof benchprofExport
+	benchprofData, err := os.ReadFile(filepath.Join(dir, "benchprof_results.json"))
+	if err != nil {
+		t.Fatalf("read benchprof_results.json: %v", err)
+	}
+	if err := json.Unmarshal(benchprofData, &benchprof); err != nil {
+		t.Fatalf("unmarshal benchprof_results.json: %v", err)
+	}
+	if len(benchprof.Runs) != 1 {
+		t.Fatalf("benchprof runs=%d want one", len(benchprof.Runs))
+	}
+	stats := benchprof.Runs[0].TreeDBStats[columnStoreSuiteBenchDisplayName]
+	if got := stats["treedb.vlog.mmap_read.hits"]; got == "" || got == "0" {
+		t.Fatalf("benchprof stats used post-first-touch reopen snapshot; vlog mmap hits=%q stats=%+v", got, stats)
+	}
 }
 
 func TestColumnStoreSuiteReportsFirstTouchMismatchAfterArtifactsM3070(t *testing.T) {


### PR DESCRIPTION
## Summary
- add an opt-in \-column-store-first-touch-after-open lane for column_store reports
- reopen the DB and collection once per selected query, then report separate first_touch_queries rows with reopen/open time counted in prepare_setup_duration_ms
- render first-touch query/parity rows separately from the primary one_shot_end_to_end rows and document the flag

## Scope
Refs #3070. Stacked on #3114.

This is benchmark/reporting support for the secondary first_touch_after_open metric. It does not add arbitrary-expression coverage, metadata-cost accounting, or new ClickHouse performance claims.

## Local verification
- go test ./cmd/unified_bench -run 'FirstTouch|ColumnStore(JSONBench|Suite|Metadata)|ColumnStore.*Query|ColumnStorePhaseDurations|ColumnStoreMetadataMode' -count=1
- go test ./cmd/unified_bench -run ColumnStore -count=1
- go test ./TreeDB/collections -run 'TestColumnPhysicalTypedColumnOneShotCache|TestColumnPhysicalJSONBenchParity' -count=1
- git diff --check