### PR TITLE
TreeDB: specialize q2 dense predicate reduction

### DIFF
--- a/TreeDB/collections/column_physical_typed_column_query.go
+++ b/TreeDB/collections/column_physical_typed_column_query.go
@@ -2529,6 +2529,18 @@ func columnTypedColumnDenseGroupCountDistinctPartsHaveGlobalCodes(parts []column
 	return true
 }
 
+func columnTypedColumnDenseTwoSingleCodePredicates(predicates []columnTypedColumnDensePredicatePart, rows int) (leftCodes, rightCodes []uint32, leftCode, rightCode uint32, ok bool) {
+	if len(predicates) != 2 {
+		return nil, nil, 0, 0, false
+	}
+	left := &predicates[0]
+	right := &predicates[1]
+	if left.RejectsAll || right.RejectsAll || !left.SingleCodeAllowed || !right.SingleCodeAllowed || left.Valid != nil || right.Valid != nil || len(left.Codes) < rows || len(right.Codes) < rows {
+		return nil, nil, 0, 0, false
+	}
+	return left.Codes, right.Codes, left.SingleCode, right.SingleCode, true
+}
+
 func (r *columnTypedColumnPhysicalQueryRunner) runDenseGroupCountDistinctGlobalCodes(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest) (ColumnPhysicalQueryResult, error) {
 	start := time.Now()
 	groupCardinality := 0
@@ -2633,6 +2645,39 @@ func (r *columnTypedColumnPhysicalQueryRunner) runDenseGroupCountDistinctGlobalC
 		}
 		if columnTypedColumnDensePredicatesRejectAll(dense.Predicates) {
 			rowsScanned += dense.Rows
+			continue
+		}
+		leftPredicateCodes, rightPredicateCodes, leftPredicateCode, rightPredicateCode, useTwoSinglePredicates := columnTypedColumnDenseTwoSingleCodePredicates(dense.Predicates, dense.Rows)
+		if usePairBitset && useTwoSinglePredicates {
+			for rowIdx := 0; rowIdx < dense.Rows; rowIdx++ {
+				rowsScanned++
+				if leftPredicateCodes[rowIdx] != leftPredicateCode || rightPredicateCodes[rowIdx] != rightPredicateCode {
+					continue
+				}
+				matchedRows++
+				reduceRows++
+				groupCode := dense.Group.GlobalCodes[rowIdx]
+				distinctCode := dense.Distinct.GlobalCodes[rowIdx]
+				groupIdx, ok := columnDictionaryCodeIndex(groupCode, len(r.denseGroupCountDistinctCounts))
+				if !ok {
+					diag := r.diagnostics(view, req, rowsScanned, matchedRows, reduceRows, time.Since(start).Nanoseconds())
+					diag.DenseGroupCountDistinctUsed = true
+					return ColumnPhysicalQueryResult{Diagnostics: diag}, fmt.Errorf("collections: dense typed-column grouped count-distinct part %d group code[%d]=%d outside cardinality=%d", partIdx, rowIdx, groupCode, len(r.denseGroupCountDistinctCounts))
+				}
+				r.denseGroupCountDistinctCounts[groupIdx]++
+				distinctIdx, ok := columnDictionaryCodeIndex(distinctCode, distinctCardinality)
+				if !ok {
+					diag := r.diagnostics(view, req, rowsScanned, matchedRows, reduceRows, time.Since(start).Nanoseconds())
+					diag.DenseGroupCountDistinctUsed = true
+					return ColumnPhysicalQueryResult{Diagnostics: diag}, fmt.Errorf("collections: dense typed-column grouped count-distinct part %d distinct code[%d]=%d outside cardinality=%d", partIdx, rowIdx, distinctCode, distinctCardinality)
+				}
+				wordIdx := groupIdx*wordsPerGroup + distinctIdx/64
+				mask := uint64(1) << uint(distinctIdx&63)
+				if r.denseGroupCountDistinctPairBits[wordIdx]&mask == 0 {
+					r.denseGroupCountDistinctPairBits[wordIdx] |= mask
+					r.denseGroupCountDistinctDistinctCounts[groupIdx]++
+				}
+			}
 			continue
 		}
 		for rowIdx := 0; rowIdx < dense.Rows; rowIdx++ {


### PR DESCRIPTION
Addresses #3123.
Related trackers: #3070, #3001, #3000, #3067.

## Scope classification

This PR is a q2 no-aggregate typed-column scan/reducer slice. It improves the dense group-count-distinct reducer used by the q2-shaped one-shot typed-column path. It is not an aggregate-metadata change, does not improve insert/load, and does not establish broad TreeDB SQL superiority by itself.

Impacted lanes:

| lane | impact |
| --- | --- |
| one-shot query execution | yes, targeted q2 dense typed-column reducer path |
| no-aggregate-metadata scan | yes, q2 predicate/reduce loop only |
| auto aggregate metadata | no direct change; q2 remains a typed scan when no q2 metadata exists |
| hot prepared execution | yes, same prepared reducer inner loop benefits as a ceiling signal |
| insert/load | no change |
| metadata storage | no change |

## What changed

- Detects the narrow dense predicate shape used by q2: exactly two non-null single-code predicates with decoded code vectors.
- Uses that detector only in the prepared/global-code pair-bitset dense group-count-distinct reducer.
- Avoids the generic predicate matcher in the hot per-row q2 loop while preserving rows scanned/matched/reduced accounting, dictionary cardinality checks, and diagnostics.
- Leaves aggregate metadata, adapter decoding, sorted-prefix reducers, local-code reducers, active-bitset reducers, sorted-pair reducers, and row/document materialization behavior unchanged.

## Correctness gates

```sh
go test ./TreeDB/collections -run 'TestTypedColumnQ2|DenseGroupCountDistinct|ColumnPhysical' -count=1
git diff --check
```

Result:

```text
ok  github.com/snissn/gomap/TreeDB/collections  10.327s
```

## Focused benchmark evidence

Command:

```sh
go test ./TreeDB/collections -run '^$' -bench '^BenchmarkTypedColumnQ2SortedGroupedDistinct1950/(direct|prepared)/(sorted_prefix|primary_id_fallback)$' -benchtime=5x -count=3 -benchmem
```

Current branch, Apple M3:

| benchmark case | result range |
| --- | ---: |
| direct/sorted_prefix | 663.925-677.350 us/op, 5984-5993 B/op, 53 allocs/op |
| prepared/sorted_prefix | 666.225-679.825 us/op, 332 B/op, 2 allocs/op |
| direct/primary_id_fallback | 1.044-1.059 ms/op, 910744 B/op, 117 allocs/op |
| prepared/primary_id_fallback | 126.658-132.875 us/op, 899 B/op, 1 alloc/op |

Prior local baseline on the same benchmark before this patch had `prepared/primary_id_fallback` around 362-369 us/op. This branch reduces that focused prepared reducer case by roughly 2.7x. The full 1M JSONBench q2 gate still needs to be rerun before closing #3123.

## Claim boundary

Do not use this PR as a broad SQL comparison headline. The full realigned goal still requires one-shot end-to-end reporting, no-aggregate typed scans across the benchmark lanes, automatic metadata acceleration with write-side cost, arbitrary-expression scan evidence, and an acceptable insert/load gap versus ClickHouse.
