### PR TITLE
TreeDB: speed qexpr no-metadata typed scans

### DIFF
--- a/TreeDB/collections/column_physical_query.go
+++ b/TreeDB/collections/column_physical_query.go
@@ -2062,7 +2062,7 @@ func (e *columnPhysicalQueryExecutor) visitDirectSumSecondOfDaySquare(value int6
 
 func (e *columnPhysicalQueryExecutor) addSumSecondOfDaySquareValue(value int64) error {
 	result := TypedColumnInt64PredicateAggregateResult{Sum: e.int64Sum}
-	if err := addTypedColumnInt64PredicateAggregateExpressionValue(&result, TypedColumnInt64AggregateSecondOfDaySquare, value); err != nil {
+	if err := addTypedColumnInt64PredicateAggregateSecondOfDaySquareValue(&result, value); err != nil {
 		return err
 	}
 	e.int64Sum = result.Sum

--- a/TreeDB/collections/column_physical_typed_column_1947_test.go
+++ b/TreeDB/collections/column_physical_typed_column_1947_test.go
@@ -614,6 +614,13 @@ func BenchmarkColumnPhysicalJSONBenchTypedColumnPartDirectSmoke1947(b *testing.B
 				},
 			},
 		},
+		{
+			name: "qexpr_typed_column_part_section_no_fallback",
+			req: ColumnPhysicalQueryRequest{
+				Kind:        ColumnPhysicalQuerySumSecondOfDaySquare,
+				ValueColumn: "time_us",
+			},
+		},
 	}
 	for _, tc := range cases {
 		b.Run(tc.name, func(b *testing.B) {

--- a/TreeDB/collections/column_physical_typed_column_query.go
+++ b/TreeDB/collections/column_physical_typed_column_query.go
@@ -1410,6 +1410,9 @@ func (r *columnTypedColumnPhysicalQueryRunner) run(view columnPhysicalScanSnapsh
 	if columnTypedColumnPhysicalQueryUseDenseGroupCountDistinct(r.plan, req) {
 		return r.runDenseGroupCountDistinct(view, req)
 	}
+	if columnTypedColumnPhysicalQueryUseSumSecondOfDaySquare(req) {
+		return r.runSumSecondOfDaySquare(view, req)
+	}
 
 	start := time.Now()
 	acc := newColumnTypedColumnPhysicalQueryAccumulator(req.Kind)
@@ -1441,6 +1444,65 @@ func (r *columnTypedColumnPhysicalQueryRunner) run(view columnPhysicalScanSnapsh
 	groups := acc.groups(req, r.resultGroups)
 	r.resultGroups = groups
 	diag := r.diagnostics(view, req, rowsScanned, matchedRows, acc.reduceRows, time.Since(start).Nanoseconds())
+	result := ColumnPhysicalQueryResult{Groups: groups, Diagnostics: diag}
+	finalizeColumnPhysicalQueryResultGroups(req, &result)
+	r.resultGroups = result.Groups
+	return result, nil
+}
+
+func columnTypedColumnPhysicalQueryUseSumSecondOfDaySquare(req ColumnPhysicalQueryRequest) bool {
+	return req.Kind == ColumnPhysicalQuerySumSecondOfDaySquare &&
+		req.ValueColumn != "" &&
+		req.GroupColumn == "" &&
+		req.DistinctColumn == "" &&
+		req.AggregateMetadataName == "" &&
+		req.TopK == 0
+}
+
+func (r *columnTypedColumnPhysicalQueryRunner) runSumSecondOfDaySquare(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest) (ColumnPhysicalQueryResult, error) {
+	start := time.Now()
+	rowsScanned := 0
+	matchedRows := 0
+	var sum TypedColumnInt64PredicateAggregateResult
+	for _, part := range r.parts {
+		partRows := len(part.RowIndexes)
+		if part.RowIndexes == nil {
+			partRows = part.Rows
+		}
+		values, err := typedColumnPhysicalQueryInt64ColumnValues(part.Values, req.ValueColumn, partRows)
+		if err != nil {
+			return ColumnPhysicalQueryResult{Diagnostics: r.diagnostics(view, req, rowsScanned, matchedRows, int(sum.Count), time.Since(start).Nanoseconds())}, err
+		}
+		if len(values) != partRows {
+			return ColumnPhysicalQueryResult{Diagnostics: r.diagnostics(view, req, rowsScanned, matchedRows, int(sum.Count), time.Since(start).Nanoseconds())}, fmt.Errorf("collections: typed-column part physical query column %q rows=%d want %d", req.ValueColumn, len(values), partRows)
+		}
+		for rowIdx := 0; rowIdx < partRows; rowIdx++ {
+			rowsScanned++
+			matched, err := typedColumnPhysicalQueryPredicatesMatch(part.Values, r.plan.PredicateSpecs, rowIdx)
+			if err != nil {
+				return ColumnPhysicalQueryResult{Diagnostics: r.diagnostics(view, req, rowsScanned, matchedRows, int(sum.Count), time.Since(start).Nanoseconds())}, err
+			}
+			if !matched {
+				continue
+			}
+			if len(r.plan.PredicateSpecs) != 0 {
+				matchedRows++
+			}
+			value, err := typedColumnPhysicalQueryInt64ColumnValue(values, req.ValueColumn, rowIdx)
+			if err != nil {
+				return ColumnPhysicalQueryResult{Diagnostics: r.diagnostics(view, req, rowsScanned, matchedRows, int(sum.Count), time.Since(start).Nanoseconds())}, err
+			}
+			if err := addTypedColumnInt64PredicateAggregateSecondOfDaySquareValue(&sum, value); err != nil {
+				return ColumnPhysicalQueryResult{Diagnostics: r.diagnostics(view, req, rowsScanned, matchedRows, int(sum.Count), time.Since(start).Nanoseconds())}, err
+			}
+		}
+	}
+	groups := r.resultGroups[:0]
+	if sum.Count > 0 {
+		groups = append(groups, ColumnPhysicalQueryGroup{Key: columnPhysicalQuerySumSecondOfDaySquareKey(req.ValueColumn), Count: int(sum.Count), Int64: sum.Sum})
+	}
+	r.resultGroups = groups
+	diag := r.diagnostics(view, req, rowsScanned, matchedRows, int(sum.Count), time.Since(start).Nanoseconds())
 	result := ColumnPhysicalQueryResult{Groups: groups, Diagnostics: diag}
 	finalizeColumnPhysicalQueryResultGroups(req, &result)
 	r.resultGroups = result.Groups
@@ -4396,10 +4458,25 @@ func typedColumnPhysicalQueryStringValueAt(values map[string][]columnDeclaredVal
 }
 
 func typedColumnPhysicalQueryInt64At(values map[string][]columnDeclaredValue, column string, rowIdx int) (int64, error) {
+	columnValues, err := typedColumnPhysicalQueryInt64ColumnValues(values, column, rowIdx+1)
+	if err != nil {
+		return 0, err
+	}
+	return typedColumnPhysicalQueryInt64ColumnValue(columnValues, column, rowIdx)
+}
+
+func typedColumnPhysicalQueryInt64ColumnValues(values map[string][]columnDeclaredValue, column string, wantRows int) ([]columnDeclaredValue, error) {
 	columnValues, ok := values[column]
 	if !ok {
-		return 0, fmt.Errorf("collections: typed-column part physical query missing int64 column %q", column)
+		return nil, fmt.Errorf("collections: typed-column part physical query missing int64 column %q", column)
 	}
+	if len(columnValues) < wantRows {
+		return nil, fmt.Errorf("collections: typed-column part physical query column %q rows=%d want at least %d", column, len(columnValues), wantRows)
+	}
+	return columnValues, nil
+}
+
+func typedColumnPhysicalQueryInt64ColumnValue(columnValues []columnDeclaredValue, column string, rowIdx int) (int64, error) {
 	if rowIdx < 0 || rowIdx >= len(columnValues) {
 		return 0, fmt.Errorf("collections: typed-column part physical query row_index=%d outside column %q rows=%d", rowIdx, column, len(columnValues))
 	}

--- a/TreeDB/collections/typed_column_adapter.go
+++ b/TreeDB/collections/typed_column_adapter.go
@@ -6101,6 +6101,9 @@ func typedColumnInt64VisibilitySelectionForBlock(visibility *typedColumnLatestPh
 }
 
 func addTypedColumnInt64AggregateSelectedValues(result *TypedColumnInt64PredicateAggregateResult, values []int64, selection typedcolumn.RowSelection, expression TypedColumnInt64AggregateExpression) error {
+	if expression == TypedColumnInt64AggregateSecondOfDaySquare {
+		return addTypedColumnInt64AggregateSecondOfDaySquareSelectedValues(result, values, selection)
+	}
 	switch selection.Kind() {
 	case typedcolumn.RowSelectionEmpty:
 		return nil
@@ -6167,6 +6170,118 @@ func addTypedColumnInt64AggregateSelectedValues(result *TypedColumnInt64Predicat
 	default:
 		return fmt.Errorf("typed-column int64 aggregate unsupported selection shape %s", selection.Shape().Kind)
 	}
+}
+
+func addTypedColumnInt64AggregateSecondOfDaySquareSelectedValues(result *TypedColumnInt64PredicateAggregateResult, values []int64, selection typedcolumn.RowSelection) error {
+	switch selection.Kind() {
+	case typedcolumn.RowSelectionEmpty:
+		return nil
+	case typedcolumn.RowSelectionAll:
+		return addTypedColumnInt64AggregateSecondOfDaySquareValueRange(result, values, 0, len(values))
+	case typedcolumn.RowSelectionRange:
+		start, end, ok := selection.SingleRange()
+		if !ok || start < 0 || end > len(values) {
+			return fmt.Errorf("typed-column int64 aggregate invalid range selection [%d,%d) values=%d", start, end, len(values))
+		}
+		return addTypedColumnInt64AggregateSecondOfDaySquareValueRange(result, values, start, end)
+	case typedcolumn.RowSelectionRanges:
+		for _, r := range selection.Ranges() {
+			if r.Start < 0 || r.End < r.Start || r.End > len(values) {
+				return fmt.Errorf("typed-column int64 aggregate invalid ranges selection [%d,%d) values=%d", r.Start, r.End, len(values))
+			}
+			if err := addTypedColumnInt64AggregateSecondOfDaySquareValueRange(result, values, r.Start, r.End); err != nil {
+				return err
+			}
+		}
+		return nil
+	case typedcolumn.RowSelectionSparse:
+		return addTypedColumnInt64AggregateSecondOfDaySquareSparseValues(result, values, selection.SparseRows())
+	case typedcolumn.RowSelectionBitmap:
+		return addTypedColumnInt64AggregateSecondOfDaySquareBitmapValues(result, values, selection.BitmapWords())
+	default:
+		return fmt.Errorf("typed-column int64 aggregate unsupported selection shape %s", selection.Shape().Kind)
+	}
+}
+
+func addTypedColumnInt64AggregateSecondOfDaySquareValueRange(result *TypedColumnInt64PredicateAggregateResult, values []int64, start int, end int) error {
+	if start < 0 || end < start || end > len(values) {
+		return fmt.Errorf("typed-column int64 aggregate invalid second-of-day-square range [%d,%d) values=%d", start, end, len(values))
+	}
+	count := end - start
+	if count == 0 {
+		return nil
+	}
+	checkOverflow := typedColumnInt64AggregateSecondOfDaySquareCountCanOverflow(count)
+	var sum int64
+	for _, value := range values[start:end] {
+		if err := addTypedColumnInt64AggregateSecondOfDaySquareLocal(&sum, value, checkOverflow); err != nil {
+			return err
+		}
+	}
+	return addTypedColumnInt64AggregateSecondOfDaySquareBatch(result, count, sum)
+}
+
+func addTypedColumnInt64AggregateSecondOfDaySquareSparseValues(result *TypedColumnInt64PredicateAggregateResult, values []int64, rows []int) error {
+	if len(rows) == 0 {
+		return nil
+	}
+	checkOverflow := typedColumnInt64AggregateSecondOfDaySquareCountCanOverflow(len(rows))
+	var sum int64
+	for _, row := range rows {
+		if row < 0 || row >= len(values) {
+			return fmt.Errorf("typed-column int64 aggregate sparse row=%d values=%d", row, len(values))
+		}
+		if err := addTypedColumnInt64AggregateSecondOfDaySquareLocal(&sum, values[row], checkOverflow); err != nil {
+			return err
+		}
+	}
+	return addTypedColumnInt64AggregateSecondOfDaySquareBatch(result, len(rows), sum)
+}
+
+func addTypedColumnInt64AggregateSecondOfDaySquareBitmapValues(result *TypedColumnInt64PredicateAggregateResult, values []int64, bitmap []uint64) error {
+	count := 0
+	for _, word := range bitmap {
+		count += bits.OnesCount64(word)
+	}
+	if count == 0 {
+		return nil
+	}
+	checkOverflow := typedColumnInt64AggregateSecondOfDaySquareCountCanOverflow(count)
+	var sum int64
+	for wordIndex, word := range bitmap {
+		for word != 0 {
+			bit := bits.TrailingZeros64(word)
+			row := wordIndex*64 + bit
+			if row >= len(values) {
+				break
+			}
+			if err := addTypedColumnInt64AggregateSecondOfDaySquareLocal(&sum, values[row], checkOverflow); err != nil {
+				return err
+			}
+			word &^= uint64(1) << uint(bit)
+		}
+	}
+	return addTypedColumnInt64AggregateSecondOfDaySquareBatch(result, count, sum)
+}
+
+func addTypedColumnInt64AggregateSecondOfDaySquareBatch(result *TypedColumnInt64PredicateAggregateResult, count int, sum int64) error {
+	if count == 0 {
+		return nil
+	}
+	return addTypedColumnInt64AggregateKernelResult(result, typedkernel.AggregateResult{NonNulls: int64(count), Sum: sum, HasValue: true})
+}
+
+func typedColumnInt64AggregateSecondOfDaySquareCountCanOverflow(count int) bool {
+	return int64(count) > typedColumnInt64PredicateAggregateMaxSum/typedColumnInt64AggregateSecondOfDaySquareMaxValue
+}
+
+func addTypedColumnInt64AggregateSecondOfDaySquareLocal(sum *int64, value int64, checkOverflow bool) error {
+	transformed := typedColumnInt64AggregateSecondOfDaySquareValue(value)
+	if checkOverflow && transformed > 0 && *sum > typedColumnInt64PredicateAggregateMaxSum-transformed {
+		return fmt.Errorf("collections: typed-column int64 predicate aggregate sum overflow current=%d value=%d", *sum, transformed)
+	}
+	*sum += transformed
+	return nil
 }
 
 func recordTypedColumnSelectionDiagnostics(diag *TypedColumnInt64PredicateScanDiagnostics, selection typedcolumn.RowSelection) {

--- a/TreeDB/collections/typed_column_int64_scan.go
+++ b/TreeDB/collections/typed_column_int64_scan.go
@@ -209,8 +209,9 @@ type TypedColumnInt64PredicateAggregateSessionDiagnostics struct {
 var errTypedColumnInt64PredicateAggregateSessionClosed = errors.New("collections: typed-column int64 predicate aggregate session is closed")
 
 const (
-	typedColumnInt64PredicateAggregateMaxSum = int64(1<<63 - 1)
-	typedColumnInt64PredicateAggregateMinSum = -typedColumnInt64PredicateAggregateMaxSum - 1
+	typedColumnInt64PredicateAggregateMaxSum           = int64(1<<63 - 1)
+	typedColumnInt64PredicateAggregateMinSum           = -typedColumnInt64PredicateAggregateMaxSum - 1
+	typedColumnInt64AggregateSecondOfDaySquareMaxValue = (typedColumnInt64AggregateDaySecond - 1) * (typedColumnInt64AggregateDaySecond - 1)
 )
 
 func addTypedColumnInt64PredicateAggregateValue(result *TypedColumnInt64PredicateAggregateResult, value int64) error {
@@ -229,11 +230,18 @@ func addTypedColumnInt64PredicateAggregateValue(result *TypedColumnInt64Predicat
 }
 
 func addTypedColumnInt64PredicateAggregateExpressionValue(result *TypedColumnInt64PredicateAggregateResult, expression TypedColumnInt64AggregateExpression, value int64) error {
+	if expression == TypedColumnInt64AggregateSecondOfDaySquare {
+		return addTypedColumnInt64PredicateAggregateSecondOfDaySquareValue(result, value)
+	}
 	transformed, err := typedColumnInt64AggregateExpressionValue(expression, value)
 	if err != nil {
 		return err
 	}
 	return addTypedColumnInt64PredicateAggregateValue(result, transformed)
+}
+
+func addTypedColumnInt64PredicateAggregateSecondOfDaySquareValue(result *TypedColumnInt64PredicateAggregateResult, value int64) error {
+	return addTypedColumnInt64PredicateAggregateValue(result, typedColumnInt64AggregateSecondOfDaySquareValue(value))
 }
 
 // RunTypedColumnInt64PredicateScan executes the scoped #1757 scalar predicate MVP.
@@ -422,15 +430,19 @@ func typedColumnInt64AggregateExpressionValue(expression TypedColumnInt64Aggrega
 	case TypedColumnInt64AggregateIdentity:
 		return value, nil
 	case TypedColumnInt64AggregateSecondOfDaySquare:
-		seconds := typedColumnInt64AggregateFloorUnixSeconds(value)
-		secondOfDay := seconds % typedColumnInt64AggregateDaySecond
-		if secondOfDay < 0 {
-			secondOfDay += typedColumnInt64AggregateDaySecond
-		}
-		return secondOfDay * secondOfDay, nil
+		return typedColumnInt64AggregateSecondOfDaySquareValue(value), nil
 	default:
 		return 0, fmt.Errorf("%w: unsupported typed-column int64 aggregate expression %q", ErrColumnQueryPlanUnsupported, expression)
 	}
+}
+
+func typedColumnInt64AggregateSecondOfDaySquareValue(value int64) int64 {
+	seconds := typedColumnInt64AggregateFloorUnixSeconds(value)
+	secondOfDay := seconds % typedColumnInt64AggregateDaySecond
+	if secondOfDay < 0 {
+		secondOfDay += typedColumnInt64AggregateDaySecond
+	}
+	return secondOfDay * secondOfDay
 }
 
 func typedColumnInt64AggregateFloorUnixSeconds(timeUS int64) int64 {

--- a/TreeDB/collections/typed_column_int64_scan_test.go
+++ b/TreeDB/collections/typed_column_int64_scan_test.go
@@ -570,6 +570,28 @@ func TestTypedColumnInt64AggregateSecondOfDaySquareExpression(t *testing.T) {
 	assertTypedColumnInt64AggregateNoMaterializationDiagnostics(t, result.Diagnostics, "second-of-day-square expression aggregate")
 }
 
+func TestTypedColumnInt64AggregateSecondOfDaySquareExpressionRange(t *testing.T) {
+	d, col := setupTypedColumnInt64ScanCollection(t)
+	defer func() { _ = d.Close() }()
+	insertTypedColumnInt64ScanRows(t, col, []int64{-1, 0, 1_000_000, 2_000_000})
+
+	result, err := col.RunTypedColumnInt64PredicateAggregate(TypedColumnInt64PredicateAggregateRequest{
+		Column:     "time_us",
+		Kind:       TypedColumnInt64PredicateRange,
+		Low:        0,
+		High:       2_000_000,
+		Expression: TypedColumnInt64AggregateSecondOfDaySquare,
+	})
+	if err != nil {
+		t.Fatalf("RunTypedColumnInt64PredicateAggregate range expression: %v", err)
+	}
+	assertTypedColumnInt64Aggregate(t, result, 3, 0+1+4)
+	if result.Diagnostics.RowsScanned != 4 || result.Diagnostics.RowsMatched != 3 || result.Diagnostics.StatsBlocks != 0 {
+		t.Fatalf("diagnostics=%+v want range expression to scan typed-column rows without aggregate stats", result.Diagnostics)
+	}
+	assertTypedColumnInt64AggregateNoMaterializationDiagnostics(t, result.Diagnostics, "second-of-day-square range expression aggregate")
+}
+
 func TestTypedColumnInt64PreparedAggregateSecondOfDaySquareExpression(t *testing.T) {
 	d, col := setupTypedColumnInt64ScanCollection(t)
 	defer func() { _ = d.Close() }()

--- a/TreeDB/collections/typed_column_prepared_int64.go
+++ b/TreeDB/collections/typed_column_prepared_int64.go
@@ -387,6 +387,9 @@ func addTypedColumnInt64AggregateKernelValues(result *TypedColumnInt64PredicateA
 }
 
 func addTypedColumnInt64AggregateKernelCursor(result *TypedColumnInt64PredicateAggregateResult, reducer typedkernel.PreparedReducer, cursor *typedcolumn.Int64Cursor, rows int, selection typedcolumn.RowSelection, expression TypedColumnInt64AggregateExpression, scratch *typedkernel.Scratch) error {
+	if expression == TypedColumnInt64AggregateSecondOfDaySquare {
+		return addTypedColumnInt64AggregateSecondOfDaySquareSelectedCursor(result, cursor, rows, selection)
+	}
 	if !typedColumnInt64AggregateExpressionIsIdentity(expression) {
 		for row := 0; row < rows; row++ {
 			value, err := cursor.Next()
@@ -408,6 +411,121 @@ func addTypedColumnInt64AggregateKernelCursor(result *TypedColumnInt64PredicateA
 		return err
 	}
 	return addTypedColumnInt64AggregateKernelResult(result, out)
+}
+
+func addTypedColumnInt64AggregateSecondOfDaySquareSelectedCursor(result *TypedColumnInt64PredicateAggregateResult, cursor *typedcolumn.Int64Cursor, rows int, selection typedcolumn.RowSelection) error {
+	if cursor == nil {
+		return errors.New("collections: nil typed-column int64 aggregate cursor")
+	}
+	if cursor.Rows() != rows {
+		return fmt.Errorf("collections: typed-column int64 aggregate cursor rows=%d want %d", cursor.Rows(), rows)
+	}
+	count := selection.Count()
+	if count == 0 {
+		for row := 0; row < rows; row++ {
+			if _, err := cursor.Next(); err != nil {
+				return err
+			}
+		}
+		return cursor.Finish()
+	}
+	checkOverflow := typedColumnInt64AggregateSecondOfDaySquareCountCanOverflow(count)
+	var sum int64
+	switch selection.Kind() {
+	case typedcolumn.RowSelectionAll:
+		for row := 0; row < rows; row++ {
+			value, err := cursor.Next()
+			if err != nil {
+				return err
+			}
+			if err := addTypedColumnInt64AggregateSecondOfDaySquareLocal(&sum, value, checkOverflow); err != nil {
+				return err
+			}
+		}
+	case typedcolumn.RowSelectionRange:
+		start, end, ok := selection.SingleRange()
+		if !ok || start < 0 || end < start || end > rows {
+			return fmt.Errorf("typed-column int64 aggregate invalid cursor range selection [%d,%d) rows=%d", start, end, rows)
+		}
+		for row := 0; row < rows; row++ {
+			value, err := cursor.Next()
+			if err != nil {
+				return err
+			}
+			if row >= start && row < end {
+				if err := addTypedColumnInt64AggregateSecondOfDaySquareLocal(&sum, value, checkOverflow); err != nil {
+					return err
+				}
+			}
+		}
+	case typedcolumn.RowSelectionRanges:
+		ranges := selection.Ranges()
+		rangeIndex := 0
+		for row := 0; row < rows; row++ {
+			value, err := cursor.Next()
+			if err != nil {
+				return err
+			}
+			for rangeIndex < len(ranges) && row >= ranges[rangeIndex].End {
+				rangeIndex++
+			}
+			if rangeIndex >= len(ranges) {
+				continue
+			}
+			r := ranges[rangeIndex]
+			if r.Start < 0 || r.End < r.Start || r.End > rows {
+				return fmt.Errorf("typed-column int64 aggregate invalid cursor ranges selection [%d,%d) rows=%d", r.Start, r.End, rows)
+			}
+			if row >= r.Start {
+				if err := addTypedColumnInt64AggregateSecondOfDaySquareLocal(&sum, value, checkOverflow); err != nil {
+					return err
+				}
+			}
+		}
+	case typedcolumn.RowSelectionSparse:
+		sparse := selection.SparseRows()
+		sparseIndex := 0
+		for row := 0; row < rows; row++ {
+			value, err := cursor.Next()
+			if err != nil {
+				return err
+			}
+			if sparseIndex >= len(sparse) {
+				continue
+			}
+			selected := sparse[sparseIndex]
+			if selected < 0 || selected >= rows {
+				return fmt.Errorf("typed-column int64 aggregate sparse row=%d rows=%d", selected, rows)
+			}
+			if row == selected {
+				if err := addTypedColumnInt64AggregateSecondOfDaySquareLocal(&sum, value, checkOverflow); err != nil {
+					return err
+				}
+				sparseIndex++
+			}
+		}
+	case typedcolumn.RowSelectionBitmap:
+		words := selection.BitmapWords()
+		for row := 0; row < rows; row++ {
+			value, err := cursor.Next()
+			if err != nil {
+				return err
+			}
+			wordIndex := row / 64
+			if wordIndex >= len(words) || words[wordIndex]&(uint64(1)<<uint(row%64)) == 0 {
+				continue
+			}
+			if err := addTypedColumnInt64AggregateSecondOfDaySquareLocal(&sum, value, checkOverflow); err != nil {
+				return err
+			}
+		}
+	default:
+		return fmt.Errorf("typed-column int64 aggregate unsupported cursor selection shape %s", selection.Shape().Kind)
+	}
+	if err := cursor.Finish(); err != nil {
+		return err
+	}
+	return addTypedColumnInt64AggregateSecondOfDaySquareBatch(result, count, sum)
 }
 
 func recordTypedColumnInt64KernelBlock(diag *TypedColumnInt64PredicateScanDiagnostics, fullCovered bool, cursor bool) {
@@ -614,6 +732,18 @@ func addTypedColumnInt64AggregateStreamingValues(result *TypedColumnInt64Predica
 			return err
 		}
 		recordTypedColumnInt64KernelBlock(&result.Diagnostics, visibility == nil && selection.IsAll(), true)
+		return nil
+	}
+	if selection.IsAll() && !block.NeedsPredicate && visibility == nil && expression == TypedColumnInt64AggregateSecondOfDaySquare {
+		recordTypedColumnInt64KernelFallbackBlock(&result.Diagnostics)
+		cursor, err := scratch.reader.Int64Cursor(granule)
+		if err != nil {
+			return err
+		}
+		if err := addTypedColumnInt64AggregateSecondOfDaySquareSelectedCursor(result, &cursor, rows, selection); err != nil {
+			return err
+		}
+		recordTypedColumnSelectionDiagnostics(&result.Diagnostics, selection)
 		return nil
 	}
 	recordTypedColumnInt64KernelFallbackBlock(&result.Diagnostics)


### PR DESCRIPTION
## Summary

- Speeds the TreeDB JSONBench arbitrary-expression qexpr lane by adding a dedicated typed-column int64 `second_of_day_square` batch reducer.
- Keeps the lane as a no-aggregate-metadata typed-cell scan: it still visits the relevant `time_us` column cells, does not use aggregate metadata, does not reconstruct JSON, and does not materialize rows/documents.
- Adds a matching physical-query fast path and regression coverage for filtered qexpr ranges.

## Scope

- Improves: `one_shot_end_to_end`, `no_aggregate_metadata`, arbitrary-expression typed-column scan/evaluation.
- Does not improve: insert/load speed, aggregate metadata storage, metadata-backed q1/q3/q5, bounded TopK q4/q4a/q4b, or broad SQL superiority claims.
- Tracker: fixes #3125; related #3070, #3001, #3000.

## Performance Evidence

Baseline from preferred 1M no-aggregate summary:

- Artifact: `/tmp/jsonbench_preferred_standard_noagg_1m_20260626_180018/preferred_summary.md`
- TreeDB qexpr best: `0.014823s`
- ClickHouse qexpr best: `0.0090s`
- TreeDB was about `1.6x` slower than ClickHouse.

Current branch final 1M run:

- Artifact: `/tmp/jsonbench_treedb_qexpr_3125_noagg_1m_final_20260626_094422/report.md`
- Command:

```sh
OUT_DIR=/tmp/jsonbench_treedb_qexpr_3125_noagg_1m_final_20260626_094422 \
  DATA_DIR=/Users/michaelseiler/data/bluesky ROWS=1000000 TRIES=5 \
  GOMAP_REPLACE=/tmp/gomap_3125_qexpr \
  STORAGE_LAYOUTS=column-store-full-prepared \
  QUERY_MODE=one_shot_end_to_end METADATA_MODE=no_aggregate_metadata \
  SUITE=full QUERY_CELLS=qexpr TREEDB_ALLOW_ERRORS=1 \
  ./run_columnstore_benchmark.sh
```

qexpr detailed counters:

- Attempts: `0.007297792s`, `0.006895625s`, `0.007053334s`, `0.007051292s`, `0.007137959s`
- Best / median: `0.006895625s` / `0.007053334s`
- Query mode: `one_shot_end_to_end`
- Metadata mode: `no_aggregate_metadata`
- Query path/source: `typed_column_int64_aggregate` / `typed_column_part`
- Rows scanned/matched/reduced: `1000000 / 1000000 / 1000000`
- Physical bytes scanned: `2302520`
- Decoded metadata bytes: `294692`
- Row/document materializations: `0 / 0`
- Aggregate metadata used: `false`
- JSON reconstruction: `false`

Acceptance status for #3125:

- Target was `<=11.5ms` or `<=1.25x` ClickHouse qexpr.
- Branch measured `6.895625ms`, about `0.77x` the preferred ClickHouse qexpr reference (`9.0ms`).
- This satisfies the qexpr no-aggregate lane target without using aggregate metadata.

## Validation

```sh
go test ./TreeDB/collections -run 'TestColumnPhysicalQuerySumSecondOfDaySquare|TestColumnPhysicalJSONBenchTypedColumnPart|TestTypedColumnInt64AggregateSecondOfDaySquare|TestTypedColumnInt64PreparedAggregateSecondOfDaySquare' -count=1

go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnPhysicalJSONBenchTypedColumnPartDirectSmoke1947/qexpr' -benchtime=200ms -count=3

go test ./TreeDB/collections -count=1

git diff --check
```

<!-- latest-head-refresh-20260626 -->
## Latest-Head Refresh

After PR #3122 merged, this branch was updated with a normal merge from `origin/main`. Latest head: `1200b4e3b64ba58d4e69d74c06b7d29d3eb0d162`.

Additional latest-head local validation:

```sh
go test ./TreeDB/collections -run 'AggregateMetadataAssets|TestTypedStorageLegacyNameAllowlistIsComplete|AggregateMetadata|ColumnPublish|TestColumnPhysicalQuerySumSecondOfDaySquare|TestColumnPhysicalJSONBenchTypedColumnPart|TestTypedColumnInt64AggregateSecondOfDaySquare|TestTypedColumnInt64PreparedAggregateSecondOfDaySquare' -count=1

go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnPhysicalJSONBenchTypedColumnPartDirectSmoke1947/qexpr' -benchtime=200ms -count=3

git diff --check origin/codex/3125-qexpr-noagg-typed-scan..HEAD
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new time-based aggregate calculation across more query paths and selection types.

* **Performance**
  * Improved execution speed for matching queries by using a more direct processing path.

* **Bug Fixes**
  * Strengthened validation and error handling for out-of-range row access.
  * Expanded test coverage for range-based aggregate queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->