### PR TITLE
Add Celestia sync readiness summary protocol

### DIFF
--- a/docs/benchmarks/TREEDB_CELESTIA_PRODUCTION_READINESS_PROTOCOL.md
+++ b/docs/benchmarks/TREEDB_CELESTIA_PRODUCTION_READINESS_PROTOCOL.md
@@ -105,7 +105,7 @@ CAPTURE_PPROF_ON_WARN_STUCK=0
 For TreeDB path-proof work, add:
 
 ```bash
-TREEDB_TRACE_PATH=/tmp/treedb_trace_$(date +%Y%m%d%H%M%S).jsonl
+TREEDB_TRACE_PATH=/tmp/treedb_trace_pathproof.jsonl
 TREEDB_TRACE_EVERY_N=1
 ```
 

--- a/docs/benchmarks/TREEDB_CELESTIA_PRODUCTION_READINESS_PROTOCOL.md
+++ b/docs/benchmarks/TREEDB_CELESTIA_PRODUCTION_READINESS_PROTOCOL.md
@@ -64,10 +64,26 @@ KEEP_RECENT_RUNS=20
 EOF
 ```
 
-Run one backend at a time so failures are easy to classify:
+Run LevelDB first:
 
 ```bash
 env $(grep -v '^#' /tmp/celestia_leveldb.env | xargs) ~/run_celestia.sh
+```
+
+Then pin the TreeDB run to the same trust and target window. Replace
+`LEVEL_HOME` with the run home created by the LevelDB command, or use the
+`ls -dt` fallback when the latest LevelDB run is the one under test.
+
+```bash
+LEVEL_HOME=$(ls -dt ~/.celestia-app-mainnet-goleveldb-* | head -n1)
+TRUST_HEIGHT=$(awk -F= '$1 == "trust_height" { print $2 }' "$LEVEL_HOME/sync/sync-time.log")
+TRUST_HASH=$(awk -F= '$1 == "trust_hash" { print $2 }' "$LEVEL_HOME/sync/sync-time.log")
+STOP_AT_LOCAL_HEIGHT=$(awk -F= '$1 == "final_local_height" { print $2 }' "$LEVEL_HOME/sync/sync-time.log")
+cat >>/tmp/celestia_treedb.env <<EOF
+TRUST_HEIGHT=$TRUST_HEIGHT
+TRUST_HASH=$TRUST_HASH
+STOP_AT_LOCAL_HEIGHT=$STOP_AT_LOCAL_HEIGHT
+EOF
 env $(grep -v '^#' /tmp/celestia_treedb.env | xargs) ~/run_celestia.sh
 ```
 

--- a/docs/benchmarks/TREEDB_CELESTIA_PRODUCTION_READINESS_PROTOCOL.md
+++ b/docs/benchmarks/TREEDB_CELESTIA_PRODUCTION_READINESS_PROTOCOL.md
@@ -1,0 +1,141 @@
+# TreeDB Celestia Production-Readiness Protocol
+
+This runbook supports the TreeDB production-readiness tracker for Celestia app
+state. The goal is to make Celestia evidence reproducible enough to drive
+TreeDB fixes, not to make the Celestia harness the product.
+
+## Scope
+
+The current launcher is a mainnet state-sync/catch-up runner. It does not replay
+from genesis. Treat results as state-sync, catch-up, dwell, and restart evidence
+for the selected target window.
+
+Use the same Celestia checkout and the same gomap worktree for every pair. The
+home-level launcher defaults `LOCAL_GOMAP_DIR` to an older local checkout, so
+production-readiness runs must override it explicitly.
+
+## Fresh Worktree
+
+```bash
+git -C /home/mikers/dev/snissn/gomap-human fetch origin main
+git -C /home/mikers/dev/snissn/gomap-human worktree add \
+  -B codex/3128-celestia-ab-evidence \
+  /home/mikers/dev/snissn/gomap-3128-celestia-evidence \
+  origin/main
+```
+
+Use that path as `LOCAL_GOMAP_DIR` in both TreeDB and LevelDB runs.
+
+## Smoke Pair
+
+Use this for a short reproducibility gate before deeper TreeDB work. Keep
+diagnostics light unless the smoke fails.
+
+```bash
+cat >/tmp/celestia_leveldb.env <<'EOF'
+LOCAL_GOMAP_DIR=/home/mikers/dev/snissn/gomap-3128-celestia-evidence
+USE_LOCAL_TREE_STACK=1
+DB_BACKEND=goleveldb
+APP_DB_BACKEND=goleveldb
+FREEZE_REMOTE_HEIGHT_AT_START=1
+POST_SYNC_DWELL_SECONDS=0
+CAPTURE_HEAP_ON_MAX_RSS=0
+CAPTURE_FULL_SMAPS_ON_MAX_RSS=0
+CAPTURE_DEBUG_VARS_ON_MAX_RSS=0
+CAPTURE_PPROF_ON_STUCK=0
+CAPTURE_PPROF_ON_WARN_STUCK=0
+KEEP_RECENT_RUNS=20
+EOF
+
+cat >/tmp/celestia_treedb.env <<'EOF'
+LOCAL_GOMAP_DIR=/home/mikers/dev/snissn/gomap-3128-celestia-evidence
+USE_LOCAL_TREE_STACK=1
+DB_BACKEND=treedb
+APP_DB_BACKEND=treedb
+TREEDB_OPEN_PROFILE=wal_on_fast
+FREEZE_REMOTE_HEIGHT_AT_START=1
+POST_SYNC_DWELL_SECONDS=0
+CAPTURE_HEAP_ON_MAX_RSS=0
+CAPTURE_FULL_SMAPS_ON_MAX_RSS=0
+CAPTURE_DEBUG_VARS_ON_MAX_RSS=0
+CAPTURE_PPROF_ON_STUCK=0
+CAPTURE_PPROF_ON_WARN_STUCK=0
+KEEP_RECENT_RUNS=20
+EOF
+```
+
+Run one backend at a time so failures are easy to classify:
+
+```bash
+env $(grep -v '^#' /tmp/celestia_leveldb.env | xargs) ~/run_celestia.sh
+env $(grep -v '^#' /tmp/celestia_treedb.env | xargs) ~/run_celestia.sh
+```
+
+After both runs complete, summarize them:
+
+```bash
+OUT=/tmp/celestia_sync_summary_$(date +%Y%m%d_%H%M%S)
+scripts/summarize_celestia_sync_runs.py \
+  --out-dir "$OUT" \
+  ~/.celestia-app-mainnet-goleveldb-<timestamp> \
+  ~/.celestia-app-mainnet-treedb-<timestamp>
+```
+
+The summary writes:
+
+- `celestia_sync_runs.json`
+- `celestia_sync_runs.md`
+
+## Soak Pair
+
+Use this after the smoke pair passes and the TreeDB issue under test needs
+maintenance, memory, or disk high-water evidence.
+
+Change both env files:
+
+```bash
+POST_SYNC_DWELL_SECONDS=900
+CAPTURE_HEAP_ON_MAX_RSS=1
+CAPTURE_FULL_SMAPS_ON_MAX_RSS=1
+CAPTURE_DEBUG_VARS_ON_MAX_RSS=1
+CAPTURE_PPROF_ON_STUCK=1
+CAPTURE_PPROF_ON_WARN_STUCK=0
+```
+
+For TreeDB path-proof work, add:
+
+```bash
+TREEDB_TRACE_PATH=/tmp/treedb_trace_$(date +%Y%m%d%H%M%S).jsonl
+TREEDB_TRACE_EVERY_N=1
+```
+
+## Required Evidence
+
+Every TreeDB production-readiness PR that uses Celestia evidence must record:
+
+- Celestia app checkout and binary path.
+- gomap commit and `LOCAL_GOMAP_DIR`.
+- `DB_BACKEND`, `APP_DB_BACKEND`, `TREEDB_OPEN_PROFILE`, trust height/hash, target
+  policy, and dwell duration.
+- Run homes for both backends.
+- `sync/sync-time.log`, `sync/node.log`, and `sync/disk-breakdown.log`.
+- `celestia_sync_runs.json` and `celestia_sync_runs.md`.
+- For memory work: heap pprof, smaps, `max_rss_kb`, `max_hwm_kb`, and dwell
+  sample trend.
+- For value-log/GC work: TreeDB debug vars, maintenance/rewrite/GC counters, and
+  before/after disk bytes.
+- For span/root-native work: counters or trace summary proving the intended path
+  ran and unexpected fallback stayed zero or is linked to a blocker.
+
+## Interpreting Results
+
+- `goleveldb` is the comparison baseline for Celestia app DB behavior.
+- LevelDB parity does not prove TreeDB correctness; TreeDB still needs pointer,
+  reopen, recovery, and GC safety evidence.
+- The runner pauses TreeDB value-log maintenance during sync and removes the
+  pause file for post-sync dwell. Interpret sync high-water and dwell
+  reclamation separately.
+- Short wall-time differences are noisy. Use before/after TreeDB evidence and
+  LevelDB context together, with identical command boundaries.
+- Treat fatal log matches, height-0 stalls, unbounded RSS, and unexplained disk
+  growth as TreeDB blocker candidates before optimizing throughput.

--- a/scripts/summarize_celestia_sync_runs.py
+++ b/scripts/summarize_celestia_sync_runs.py
@@ -406,6 +406,15 @@ def main(argv: list[str]) -> int:
         for item in missing:
             print(f"run home does not exist: {item}", file=sys.stderr)
         return 2
+    missing_time_logs = [
+        str(home.expanduser() / "sync" / "sync-time.log")
+        for home in args.homes
+        if not (home.expanduser() / "sync" / "sync-time.log").is_file()
+    ]
+    if missing_time_logs:
+        for item in missing_time_logs:
+            print(f"missing required sync-time.log: {item}", file=sys.stderr)
+        return 2
 
     payload = build_payload(args.homes)
     markdown = render_markdown(payload)

--- a/scripts/summarize_celestia_sync_runs.py
+++ b/scripts/summarize_celestia_sync_runs.py
@@ -126,11 +126,14 @@ def parse_disk_breakdown(path: Path, app_db: Path) -> dict[str, int]:
         if size < 0:
             continue
         item = Path(path_raw)
-        try:
-            rel = item.relative_to(app_db)
-            key = str(rel)
-        except ValueError:
-            key = "application.db" if item == app_db else item.name
+        if item == app_db:
+            key = "application.db"
+        else:
+            try:
+                rel = item.relative_to(app_db)
+                key = "application.db" if str(rel) == "." else str(rel)
+            except ValueError:
+                key = item.name
         values[key] = size
     return values
 
@@ -143,7 +146,13 @@ def load_json(path: Path) -> Any:
 
 
 def summarize_dwell_samples(dwell_dir: Path) -> dict[str, Any]:
-    sample_paths = sorted(dwell_dir.glob("sample_*.json"))
+    def sample_sort_key(path: Path) -> tuple[int, str]:
+        match = re.fullmatch(r"sample_([0-9]+)\.json", path.name)
+        if match:
+            return (safe_int(match.group(1)), path.name)
+        return (sys.maxsize, path.name)
+
+    sample_paths = sorted(dwell_dir.glob("sample_*.json"), key=sample_sort_key)
     samples = [load_json(path) for path in sample_paths]
     samples = [sample for sample in samples if isinstance(sample, dict)]
     if not samples:
@@ -175,13 +184,17 @@ def count_fatal_matches(node_log: Path) -> dict[str, Any]:
     if not node_log.is_file():
         return {"count": 0, "matches": []}
     matches: list[dict[str, str]] = []
-    for line_no, raw in enumerate(node_log.read_text(encoding="utf-8", errors="replace").splitlines(), 1):
-        lowered = raw.lower()
-        for pattern in FATAL_PATTERNS:
-            if pattern.lower() in lowered:
-                matches.append({"line": line_no, "pattern": pattern, "text": raw.strip()[:500]})
-                break
-    return {"count": len(matches), "matches": matches[:20]}
+    count = 0
+    with node_log.open(encoding="utf-8", errors="replace") as handle:
+        for line_no, raw in enumerate(handle, 1):
+            lowered = raw.lower()
+            for pattern in FATAL_PATTERNS:
+                if pattern.lower() in lowered:
+                    count += 1
+                    if len(matches) < 20:
+                        matches.append({"line": line_no, "pattern": pattern, "text": raw.strip()[:500]})
+                    break
+    return {"count": count, "matches": matches}
 
 
 def summarize_home(home: Path) -> dict[str, Any]:

--- a/scripts/summarize_celestia_sync_runs.py
+++ b/scripts/summarize_celestia_sync_runs.py
@@ -214,7 +214,10 @@ def summarize_home(home: Path) -> dict[str, Any]:
     blocks_synced = max(final_local_height - trust_height, 0) if trust_height and final_local_height else 0
     sync_seconds = safe_int(sync.get("sync_duration_seconds", sync.get("duration_seconds")), 0)
     total_seconds = safe_int(sync.get("total_duration_seconds", sync.get("duration_seconds")), sync_seconds)
-    end_app_bytes = safe_int(sync.get("end_app_bytes"), disk.get("application.db", 0))
+    disk_app_bytes = disk.get("application.db", 0)
+    end_app_bytes = safe_int(sync.get("end_app_bytes"), disk_app_bytes)
+    if end_app_bytes == 0 and disk_app_bytes > 0:
+        end_app_bytes = disk_app_bytes
     end_home_bytes = safe_int(sync.get("end_home_bytes"), 0)
     end_data_bytes = safe_int(sync.get("end_data_bytes"), 0)
     max_rss_kb = max(safe_int(sync.get("max_rss_kb"), 0), safe_int(dwell.get("max_vmrss_kb"), 0))

--- a/scripts/summarize_celestia_sync_runs.py
+++ b/scripts/summarize_celestia_sync_runs.py
@@ -270,6 +270,27 @@ def diff_metrics(runs: list[dict[str, Any]]) -> dict[str, Any]:
     if baseline is None or candidate is None:
         return {}
 
+    window_fields = ["trust_height", "trust_hash", "final_local_height", "blocks_synced"]
+    mismatches = [
+        {
+            "field": field,
+            "baseline": baseline.get(field, ""),
+            "candidate": candidate.get(field, ""),
+        }
+        for field in window_fields
+        if baseline.get(field, "") != candidate.get(field, "")
+    ]
+    if mismatches:
+        return {
+            "valid": False,
+            "reason": "mismatched_run_window",
+            "baseline_home": baseline.get("home", ""),
+            "baseline_backend": baseline.get("db_backend", ""),
+            "candidate_home": candidate.get("home", ""),
+            "candidate_backend": candidate.get("db_backend", ""),
+            "mismatches": mismatches,
+        }
+
     def delta(field: str) -> float:
         return safe_float(candidate.get(field), 0.0) - safe_float(baseline.get(field), 0.0)
 
@@ -292,6 +313,7 @@ def diff_metrics(runs: list[dict[str, Any]]) -> dict[str, Any]:
         "sync_seconds_per_block",
     ]
     return {
+        "valid": True,
         "baseline_home": baseline.get("home", ""),
         "baseline_backend": baseline.get("db_backend", ""),
         "candidate_home": candidate.get("home", ""),
@@ -350,30 +372,41 @@ def render_markdown(payload: dict[str, Any]) -> str:
     comparison = payload.get("comparison") or {}
     if comparison:
         lines.extend(["", "## Comparison", ""])
-        delta_rows = [["metric", "delta", "ratio"]]
-        deltas = comparison.get("deltas", {})
-        ratios = comparison.get("ratios", {})
-        for field in [
-            "sync_duration_seconds",
-            "total_duration_seconds",
-            "max_rss_kb",
-            "max_hwm_kb",
-            "end_app_bytes",
-            "app_bytes_per_block",
-            "sync_seconds_per_block",
-        ]:
-            raw_delta = deltas.get(field, 0)
-            if field.endswith("_bytes") or field == "app_bytes_per_block":
-                delta_text = human_bytes(raw_delta)
-            elif field.endswith("_kb"):
-                delta_text = human_bytes(raw_delta * 1024)
-            elif field.endswith("_seconds") or field == "sync_seconds_per_block":
-                delta_text = human_seconds(raw_delta)
-            else:
-                delta_text = f"{raw_delta:.3f}"
-            ratio = safe_float(ratios.get(field), 0.0)
-            delta_rows.append([field, delta_text, f"{ratio:.3f}x" if ratio else "n/a"])
-        lines.append(markdown_table(delta_rows))
+        if comparison.get("valid") is False:
+            lines.append(f"Comparison skipped: {comparison.get('reason', 'invalid_comparison')}.")
+            mismatch_rows = [["field", "baseline", "candidate"]]
+            for mismatch in comparison.get("mismatches", []):
+                mismatch_rows.append([
+                    str(mismatch.get("field", "")),
+                    str(mismatch.get("baseline", "")),
+                    str(mismatch.get("candidate", "")),
+                ])
+            lines.extend(["", markdown_table(mismatch_rows)])
+        else:
+            delta_rows = [["metric", "delta", "ratio"]]
+            deltas = comparison.get("deltas", {})
+            ratios = comparison.get("ratios", {})
+            for field in [
+                "sync_duration_seconds",
+                "total_duration_seconds",
+                "max_rss_kb",
+                "max_hwm_kb",
+                "end_app_bytes",
+                "app_bytes_per_block",
+                "sync_seconds_per_block",
+            ]:
+                raw_delta = deltas.get(field, 0)
+                if field.endswith("_bytes") or field == "app_bytes_per_block":
+                    delta_text = human_bytes(raw_delta)
+                elif field.endswith("_kb"):
+                    delta_text = human_bytes(raw_delta * 1024)
+                elif field.endswith("_seconds") or field == "sync_seconds_per_block":
+                    delta_text = human_seconds(raw_delta)
+                else:
+                    delta_text = f"{raw_delta:.3f}"
+                ratio = safe_float(ratios.get(field), 0.0)
+                delta_rows.append([field, delta_text, f"{ratio:.3f}x" if ratio else "n/a"])
+            lines.append(markdown_table(delta_rows))
 
     lines.extend(["", "## Artifacts", ""])
     for run in runs:

--- a/scripts/summarize_celestia_sync_runs.py
+++ b/scripts/summarize_celestia_sync_runs.py
@@ -1,0 +1,408 @@
+#!/usr/bin/env python3
+"""Summarize Celestia state-sync run homes for TreeDB readiness gates."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+
+FATAL_PATTERNS = [
+    "valuelog: corrupt record",
+    "state sync failed",
+    "state sync aborted",
+    "failed to restore snapshot",
+    "IAVL node import failed",
+    "IAVL commit failed",
+    "panic:",
+    "fatal error",
+]
+
+
+def parse_key_value_file(path: Path) -> dict[str, str]:
+    values: dict[str, str] = {}
+    if not path.is_file():
+        return values
+    for raw in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        line = raw.strip()
+        if not line or line == "---" or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        values[key.strip()] = value.strip()
+    return values
+
+
+def safe_int(value: Any, default: int = 0) -> int:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        if math.isnan(value):
+            return default
+        return int(value)
+    try:
+        raw = str(value).strip()
+        if not raw:
+            return default
+        return int(raw)
+    except (TypeError, ValueError):
+        return default
+
+
+def safe_float(value: Any, default: float = 0.0) -> float:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return float(int(value))
+    if isinstance(value, (int, float)):
+        if isinstance(value, float) and math.isnan(value):
+            return default
+        return float(value)
+    try:
+        raw = str(value).strip()
+        if not raw:
+            return default
+        return float(raw)
+    except (TypeError, ValueError):
+        return default
+
+
+def human_bytes(value: Any) -> str:
+    n = float(safe_int(value, 0))
+    units = ["B", "KiB", "MiB", "GiB", "TiB"]
+    idx = 0
+    while abs(n) >= 1024.0 and idx < len(units) - 1:
+        n /= 1024.0
+        idx += 1
+    if idx == 0:
+        return f"{int(n)} {units[idx]}"
+    return f"{n:.2f} {units[idx]}"
+
+
+def human_seconds(value: Any) -> str:
+    seconds = safe_float(value, 0.0)
+    if seconds < 60:
+        return f"{seconds:.1f}s"
+    minutes = seconds / 60.0
+    if minutes < 60:
+        return f"{minutes:.2f}m"
+    return f"{minutes / 60.0:.2f}h"
+
+
+def backend_from_home(home: Path) -> str:
+    match = re.match(r"\.celestia-app-mainnet-(.+)-[0-9]{14}$", home.name)
+    if match:
+        return match.group(1)
+    return ""
+
+
+def parse_disk_breakdown(path: Path, app_db: Path) -> dict[str, int]:
+    if not path.is_file():
+        return {}
+    values: dict[str, int] = {}
+    in_du_bytes = False
+    for raw in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        line = raw.strip()
+        if line == "du_bytes:":
+            in_du_bytes = True
+            continue
+        if line.endswith(":") and line != "du_bytes:":
+            in_du_bytes = False
+        if not in_du_bytes:
+            continue
+        parts = line.split(maxsplit=1)
+        if len(parts) != 2:
+            continue
+        size_raw, path_raw = parts
+        size = safe_int(size_raw, -1)
+        if size < 0:
+            continue
+        item = Path(path_raw)
+        try:
+            rel = item.relative_to(app_db)
+            key = str(rel)
+        except ValueError:
+            key = "application.db" if item == app_db else item.name
+        values[key] = size
+    return values
+
+
+def load_json(path: Path) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def summarize_dwell_samples(dwell_dir: Path) -> dict[str, Any]:
+    sample_paths = sorted(dwell_dir.glob("sample_*.json"))
+    samples = [load_json(path) for path in sample_paths]
+    samples = [sample for sample in samples if isinstance(sample, dict)]
+    if not samples:
+        return {"sample_count": 0}
+
+    def max_field(name: str) -> int:
+        return max(safe_int(sample.get(name), 0) for sample in samples)
+
+    first = samples[0]
+    last = samples[-1]
+    return {
+        "sample_count": len(samples),
+        "first_timestamp": first.get("timestamp", ""),
+        "last_timestamp": last.get("timestamp", ""),
+        "first": first,
+        "last": last,
+        "max_vmrss_kb": max_field("vmrss_kb"),
+        "max_vmhwm_kb": max_field("vmhwm_kb"),
+        "last_home_apparent_bytes": safe_int(last.get("home_apparent_bytes"), 0),
+        "last_home_physical_bytes": safe_int(last.get("home_physical_bytes"), 0),
+        "last_app_db_apparent_bytes": safe_int(last.get("app_db_apparent_bytes"), 0),
+        "last_app_db_physical_bytes": safe_int(last.get("app_db_physical_bytes"), 0),
+        "last_maindb_apparent_bytes": safe_int(last.get("maindb_apparent_bytes"), 0),
+        "last_wal_apparent_bytes": safe_int(last.get("wal_apparent_bytes"), 0),
+    }
+
+
+def count_fatal_matches(node_log: Path) -> dict[str, Any]:
+    if not node_log.is_file():
+        return {"count": 0, "matches": []}
+    matches: list[dict[str, str]] = []
+    for line_no, raw in enumerate(node_log.read_text(encoding="utf-8", errors="replace").splitlines(), 1):
+        lowered = raw.lower()
+        for pattern in FATAL_PATTERNS:
+            if pattern.lower() in lowered:
+                matches.append({"line": line_no, "pattern": pattern, "text": raw.strip()[:500]})
+                break
+    return {"count": len(matches), "matches": matches[:20]}
+
+
+def summarize_home(home: Path) -> dict[str, Any]:
+    home = home.expanduser().resolve()
+    sync_dir = home / "sync"
+    time_log = sync_dir / "sync-time.log"
+    sync = parse_key_value_file(time_log)
+    app_db = home / "data" / "application.db"
+    disk = parse_disk_breakdown(sync_dir / "disk-breakdown.log", app_db)
+    dwell = summarize_dwell_samples(sync_dir / "dwell-stats")
+    fatal = count_fatal_matches(sync_dir / "node.log")
+
+    db_backend = sync.get("db_backend") or backend_from_home(home)
+    app_db_backend = sync.get("app_db_backend") or db_backend
+    trust_height = safe_int(sync.get("trust_height"), 0)
+    final_local_height = safe_int(sync.get("final_local_height"), 0)
+    blocks_synced = max(final_local_height - trust_height, 0) if trust_height and final_local_height else 0
+    sync_seconds = safe_int(sync.get("sync_duration_seconds", sync.get("duration_seconds")), 0)
+    total_seconds = safe_int(sync.get("total_duration_seconds", sync.get("duration_seconds")), sync_seconds)
+    end_app_bytes = safe_int(sync.get("end_app_bytes"), disk.get("application.db", 0))
+    end_home_bytes = safe_int(sync.get("end_home_bytes"), 0)
+    end_data_bytes = safe_int(sync.get("end_data_bytes"), 0)
+    max_rss_kb = max(safe_int(sync.get("max_rss_kb"), 0), safe_int(dwell.get("max_vmrss_kb"), 0))
+    max_hwm_kb = max(safe_int(sync.get("max_hwm_kb"), 0), safe_int(dwell.get("max_vmhwm_kb"), 0))
+
+    return {
+        "home": str(home),
+        "db_backend": db_backend,
+        "app_db_backend": app_db_backend,
+        "trust_height": trust_height,
+        "trust_hash": sync.get("trust_hash", ""),
+        "final_local_height": final_local_height,
+        "final_remote_height": safe_int(sync.get("final_remote_height"), 0),
+        "final_remote_height_actual": safe_int(sync.get("final_remote_height_actual"), 0),
+        "blocks_synced": blocks_synced,
+        "sync_duration_seconds": sync_seconds,
+        "total_duration_seconds": total_seconds,
+        "post_sync_dwell_elapsed_seconds": safe_int(sync.get("post_sync_dwell_elapsed_seconds"), 0),
+        "max_rss_kb": max_rss_kb,
+        "max_hwm_kb": max_hwm_kb,
+        "heap_capture_count": safe_int(sync.get("heap_capture_count"), 0),
+        "end_home_bytes": end_home_bytes,
+        "end_data_bytes": end_data_bytes,
+        "end_app_bytes": end_app_bytes,
+        "end_blockstore_bytes": safe_int(sync.get("end_blockstore_bytes"), 0),
+        "app_bytes_per_block": (end_app_bytes / blocks_synced) if blocks_synced else 0.0,
+        "sync_seconds_per_block": (sync_seconds / blocks_synced) if blocks_synced else 0.0,
+        "disk_breakdown_bytes": disk,
+        "dwell": dwell,
+        "fatal_log_matches": fatal,
+        "time_log": str(time_log) if time_log.exists() else "",
+        "node_log": str(sync_dir / "node.log") if (sync_dir / "node.log").exists() else "",
+        "disk_breakdown_log": str(sync_dir / "disk-breakdown.log") if (sync_dir / "disk-breakdown.log").exists() else "",
+    }
+
+
+def choose_baseline_and_candidate(runs: list[dict[str, Any]]) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
+    baseline_names = {"goleveldb", "leveldb"}
+    baseline = next((run for run in runs if run.get("db_backend") in baseline_names), None)
+    candidate = next((run for run in runs if run.get("db_backend") == "treedb"), None)
+    if baseline is not None and candidate is not None:
+        return baseline, candidate
+    if len(runs) >= 2:
+        return runs[0], runs[1]
+    return None, None
+
+
+def diff_metrics(runs: list[dict[str, Any]]) -> dict[str, Any]:
+    baseline, candidate = choose_baseline_and_candidate(runs)
+    if baseline is None or candidate is None:
+        return {}
+
+    def delta(field: str) -> float:
+        return safe_float(candidate.get(field), 0.0) - safe_float(baseline.get(field), 0.0)
+
+    def ratio(field: str) -> float:
+        base = safe_float(baseline.get(field), 0.0)
+        if base == 0:
+            return 0.0
+        return safe_float(candidate.get(field), 0.0) / base
+
+    fields = [
+        "sync_duration_seconds",
+        "total_duration_seconds",
+        "max_rss_kb",
+        "max_hwm_kb",
+        "end_home_bytes",
+        "end_data_bytes",
+        "end_app_bytes",
+        "blocks_synced",
+        "app_bytes_per_block",
+        "sync_seconds_per_block",
+    ]
+    return {
+        "baseline_home": baseline.get("home", ""),
+        "baseline_backend": baseline.get("db_backend", ""),
+        "candidate_home": candidate.get("home", ""),
+        "candidate_backend": candidate.get("db_backend", ""),
+        "deltas": {field: delta(field) for field in fields},
+        "ratios": {field: ratio(field) for field in fields},
+    }
+
+
+def markdown_table(rows: list[list[str]]) -> str:
+    if not rows:
+        return ""
+    widths = [max(len(row[i]) for row in rows) for i in range(len(rows[0]))]
+    out: list[str] = []
+    for idx, row in enumerate(rows):
+        out.append("| " + " | ".join(cell.ljust(widths[i]) for i, cell in enumerate(row)) + " |")
+        if idx == 0:
+            out.append("| " + " | ".join("---" for _ in row) + " |")
+    return "\n".join(out)
+
+
+def render_markdown(payload: dict[str, Any]) -> str:
+    runs = payload["runs"]
+    lines = ["# Celestia Sync Run Summary", ""]
+    rows = [[
+        "backend",
+        "app backend",
+        "height",
+        "blocks",
+        "sync",
+        "total",
+        "dwell",
+        "max RSS",
+        "max HWM",
+        "app bytes",
+        "fatal",
+        "home",
+    ]]
+    for run in runs:
+        rows.append([
+            str(run.get("db_backend", "")),
+            str(run.get("app_db_backend", "")),
+            str(run.get("final_local_height", 0)),
+            str(run.get("blocks_synced", 0)),
+            human_seconds(run.get("sync_duration_seconds", 0)),
+            human_seconds(run.get("total_duration_seconds", 0)),
+            human_seconds(run.get("post_sync_dwell_elapsed_seconds", 0)),
+            human_bytes(safe_int(run.get("max_rss_kb"), 0) * 1024),
+            human_bytes(safe_int(run.get("max_hwm_kb"), 0) * 1024),
+            human_bytes(run.get("end_app_bytes", 0)),
+            str((run.get("fatal_log_matches") or {}).get("count", 0)),
+            str(run.get("home", "")),
+        ])
+    lines.append(markdown_table(rows))
+
+    comparison = payload.get("comparison") or {}
+    if comparison:
+        lines.extend(["", "## Comparison", ""])
+        delta_rows = [["metric", "delta", "ratio"]]
+        deltas = comparison.get("deltas", {})
+        ratios = comparison.get("ratios", {})
+        for field in [
+            "sync_duration_seconds",
+            "total_duration_seconds",
+            "max_rss_kb",
+            "max_hwm_kb",
+            "end_app_bytes",
+            "app_bytes_per_block",
+            "sync_seconds_per_block",
+        ]:
+            raw_delta = deltas.get(field, 0)
+            if field.endswith("_bytes") or field == "app_bytes_per_block":
+                delta_text = human_bytes(raw_delta)
+            elif field.endswith("_kb"):
+                delta_text = human_bytes(raw_delta * 1024)
+            elif field.endswith("_seconds") or field == "sync_seconds_per_block":
+                delta_text = human_seconds(raw_delta)
+            else:
+                delta_text = f"{raw_delta:.3f}"
+            ratio = safe_float(ratios.get(field), 0.0)
+            delta_rows.append([field, delta_text, f"{ratio:.3f}x" if ratio else "n/a"])
+        lines.append(markdown_table(delta_rows))
+
+    lines.extend(["", "## Artifacts", ""])
+    for run in runs:
+        lines.append(f"- `{run.get('db_backend')}` home: `{run.get('home')}`")
+        for key in ["time_log", "node_log", "disk_breakdown_log"]:
+            if run.get(key):
+                lines.append(f"  - {key}: `{run[key]}`")
+    return "\n".join(lines) + "\n"
+
+
+def build_payload(homes: list[Path]) -> dict[str, Any]:
+    runs = [summarize_home(home) for home in homes]
+    return {
+        "schema": "celestia_sync_run_summary.v1",
+        "runs": runs,
+        "comparison": diff_metrics(runs),
+    }
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("homes", nargs="+", type=Path, help="Celestia run home directories")
+    parser.add_argument("--out-dir", type=Path, default=None, help="write summary JSON and Markdown to this directory")
+    parser.add_argument("--json-name", default="celestia_sync_runs.json")
+    parser.add_argument("--md-name", default="celestia_sync_runs.md")
+    args = parser.parse_args(argv)
+
+    missing = [str(home) for home in args.homes if not home.expanduser().is_dir()]
+    if missing:
+        for item in missing:
+            print(f"run home does not exist: {item}", file=sys.stderr)
+        return 2
+
+    payload = build_payload(args.homes)
+    markdown = render_markdown(payload)
+
+    if args.out_dir is not None:
+        args.out_dir.mkdir(parents=True, exist_ok=True)
+        (args.out_dir / args.json_name).write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        (args.out_dir / args.md_name).write_text(markdown, encoding="utf-8")
+        print(args.out_dir / args.md_name)
+    else:
+        print(markdown, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/summarize_celestia_sync_runs.py
+++ b/scripts/summarize_celestia_sync_runs.py
@@ -271,6 +271,23 @@ def diff_metrics(runs: list[dict[str, Any]]) -> dict[str, Any]:
         return {}
 
     window_fields = ["trust_height", "trust_hash", "final_local_height", "blocks_synced"]
+    missing_fields = []
+    for side, run in [("baseline", baseline), ("candidate", candidate)]:
+        for field in window_fields:
+            value = run.get(field, "")
+            if value == "" or value == 0:
+                missing_fields.append({"side": side, "field": field})
+    if missing_fields:
+        return {
+            "valid": False,
+            "reason": "missing_run_window_evidence",
+            "baseline_home": baseline.get("home", ""),
+            "baseline_backend": baseline.get("db_backend", ""),
+            "candidate_home": candidate.get("home", ""),
+            "candidate_backend": candidate.get("db_backend", ""),
+            "missing_fields": missing_fields,
+        }
+
     mismatches = [
         {
             "field": field,
@@ -374,14 +391,20 @@ def render_markdown(payload: dict[str, Any]) -> str:
         lines.extend(["", "## Comparison", ""])
         if comparison.get("valid") is False:
             lines.append(f"Comparison skipped: {comparison.get('reason', 'invalid_comparison')}.")
-            mismatch_rows = [["field", "baseline", "candidate"]]
-            for mismatch in comparison.get("mismatches", []):
-                mismatch_rows.append([
-                    str(mismatch.get("field", "")),
-                    str(mismatch.get("baseline", "")),
-                    str(mismatch.get("candidate", "")),
-                ])
-            lines.extend(["", markdown_table(mismatch_rows)])
+            if comparison.get("mismatches"):
+                mismatch_rows = [["field", "baseline", "candidate"]]
+                for mismatch in comparison.get("mismatches", []):
+                    mismatch_rows.append([
+                        str(mismatch.get("field", "")),
+                        str(mismatch.get("baseline", "")),
+                        str(mismatch.get("candidate", "")),
+                    ])
+                lines.extend(["", markdown_table(mismatch_rows)])
+            if comparison.get("missing_fields"):
+                missing_rows = [["side", "field"]]
+                for missing in comparison.get("missing_fields", []):
+                    missing_rows.append([str(missing.get("side", "")), str(missing.get("field", ""))])
+                lines.extend(["", markdown_table(missing_rows)])
         else:
             delta_rows = [["metric", "delta", "ratio"]]
             deltas = comparison.get("deltas", {})

--- a/scripts/summarize_celestia_sync_runs_test.py
+++ b/scripts/summarize_celestia_sync_runs_test.py
@@ -169,6 +169,30 @@ class CelestiaSyncSummaryTest(unittest.TestCase):
             self.assertEqual(summary["dwell"]["last_timestamp"], "2026-06-26T00:02:10Z")
             self.assertEqual(summary["dwell"]["last_app_db_apparent_bytes"], 1244)
 
+    def test_disk_fallback_when_sync_app_bytes_is_zero(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="celestia_sync_summary_test_") as tmp:
+            root = Path(tmp)
+            run = write_run_home(root, "treedb", sync_seconds=10, rss_kb=1000, app_bytes=1234)
+            sync_time = run / "sync" / "sync-time.log"
+            sync_time.write_text(
+                sync_time.read_text(encoding="utf-8").replace("end_app_bytes=1234", "end_app_bytes=0"),
+                encoding="utf-8",
+            )
+            out = root / "out"
+
+            result = subprocess.run(
+                [str(SCRIPT), "--out-dir", str(out), str(run)],
+                cwd=ROOT,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            payload = json.loads((out / "celestia_sync_runs.json").read_text(encoding="utf-8"))
+            self.assertEqual(payload["runs"][0]["end_app_bytes"], 1234)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/summarize_celestia_sync_runs_test.py
+++ b/scripts/summarize_celestia_sync_runs_test.py
@@ -32,6 +32,7 @@ def write_run_home(
     time_lines = [
         "start_utc=2026-06-26T00:00:00Z",
         "trust_height=1000",
+        "trust_hash=ABCDEF",
         f"db_backend={backend}",
         f"app_db_backend={backend}",
         f"sync_duration_seconds={sync_seconds}",
@@ -110,12 +111,46 @@ class CelestiaSyncSummaryTest(unittest.TestCase):
             self.assertEqual(payload["runs"][0]["disk_breakdown_bytes"]["application.db"], 10_000)
             self.assertEqual(payload["comparison"]["deltas"]["sync_duration_seconds"], 30)
             self.assertEqual(payload["comparison"]["ratios"]["end_app_bytes"], 0.8)
+            self.assertTrue(payload["comparison"]["valid"])
 
             markdown = (out / "celestia_sync_runs.md").read_text(encoding="utf-8")
             self.assertIn("# Celestia Sync Run Summary", markdown)
             self.assertIn("goleveldb", markdown)
             self.assertIn("treedb", markdown)
             self.assertIn("sync_duration_seconds", markdown)
+
+    def test_skips_comparison_for_mismatched_run_windows(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="celestia_sync_summary_test_") as tmp:
+            root = Path(tmp)
+            level = write_run_home(root, "goleveldb", sync_seconds=120, rss_kb=1000, app_bytes=10_000)
+            tree = write_run_home(root, "treedb", sync_seconds=150, rss_kb=2000, app_bytes=8_000)
+            sync_time = tree / "sync" / "sync-time.log"
+            sync_time.write_text(
+                sync_time.read_text(encoding="utf-8").replace("trust_hash=ABCDEF", "trust_hash=DIFFERENT"),
+                encoding="utf-8",
+            )
+            out = root / "out"
+
+            result = subprocess.run(
+                [str(SCRIPT), "--out-dir", str(out), str(level), str(tree)],
+                cwd=ROOT,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            payload = json.loads((out / "celestia_sync_runs.json").read_text(encoding="utf-8"))
+            comparison = payload["comparison"]
+            self.assertFalse(comparison["valid"])
+            self.assertEqual(comparison["reason"], "mismatched_run_window")
+            self.assertNotIn("ratios", comparison)
+            self.assertEqual(comparison["mismatches"][0]["field"], "trust_hash")
+
+            markdown = (out / "celestia_sync_runs.md").read_text(encoding="utf-8")
+            self.assertIn("Comparison skipped: mismatched_run_window.", markdown)
+            self.assertIn("trust_hash", markdown)
 
     def test_counts_fatal_log_matches(self) -> None:
         with tempfile.TemporaryDirectory(prefix="celestia_sync_summary_test_") as tmp:

--- a/scripts/summarize_celestia_sync_runs_test.py
+++ b/scripts/summarize_celestia_sync_runs_test.py
@@ -14,35 +14,40 @@ ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "scripts" / "summarize_celestia_sync_runs.py"
 
 
-def write_run_home(root: Path, backend: str, *, sync_seconds: int, rss_kb: int, app_bytes: int) -> Path:
+def write_run_home(
+    root: Path,
+    backend: str,
+    *,
+    sync_seconds: int,
+    rss_kb: int,
+    app_bytes: int,
+    include_end_app_bytes: bool = True,
+    dwell_samples: int = 1,
+) -> Path:
     home = root / f".celestia-app-mainnet-{backend}-20260626010101"
     sync = home / "sync"
     app_db = home / "data" / "application.db"
     sync.mkdir(parents=True)
     app_db.mkdir(parents=True)
-    (sync / "sync-time.log").write_text(
-        "\n".join(
-            [
-                "start_utc=2026-06-26T00:00:00Z",
-                "trust_height=1000",
-                f"db_backend={backend}",
-                f"app_db_backend={backend}",
-                f"sync_duration_seconds={sync_seconds}",
-                f"duration_seconds={sync_seconds}",
-                f"total_duration_seconds={sync_seconds + 60}",
-                "post_sync_dwell_elapsed_seconds=60",
-                "final_local_height=1250",
-                "final_remote_height=1248",
-                f"max_rss_kb={rss_kb}",
-                f"max_hwm_kb={rss_kb + 1024}",
-                f"end_app_bytes={app_bytes}",
-                f"end_home_bytes={app_bytes + 4096}",
-                f"end_data_bytes={app_bytes + 2048}",
-            ]
-        )
-        + "\n",
-        encoding="utf-8",
-    )
+    time_lines = [
+        "start_utc=2026-06-26T00:00:00Z",
+        "trust_height=1000",
+        f"db_backend={backend}",
+        f"app_db_backend={backend}",
+        f"sync_duration_seconds={sync_seconds}",
+        f"duration_seconds={sync_seconds}",
+        f"total_duration_seconds={sync_seconds + 60}",
+        "post_sync_dwell_elapsed_seconds=60",
+        "final_local_height=1250",
+        "final_remote_height=1248",
+        f"max_rss_kb={rss_kb}",
+        f"max_hwm_kb={rss_kb + 1024}",
+        f"end_home_bytes={app_bytes + 4096}",
+        f"end_data_bytes={app_bytes + 2048}",
+    ]
+    if include_end_app_bytes:
+        time_lines.append(f"end_app_bytes={app_bytes}")
+    (sync / "sync-time.log").write_text("\n".join(time_lines) + "\n", encoding="utf-8")
     (sync / "disk-breakdown.log").write_text(
         "\n".join(
             [
@@ -59,21 +64,22 @@ def write_run_home(root: Path, backend: str, *, sync_seconds: int, rss_kb: int, 
     )
     dwell = sync / "dwell-stats"
     dwell.mkdir()
-    (dwell / "sample_0.json").write_text(
-        json.dumps(
-            {
-                "timestamp": "2026-06-26T00:02:00Z",
-                "home_apparent_bytes": app_bytes + 4096,
-                "app_db_apparent_bytes": app_bytes,
-                "maindb_apparent_bytes": 1024,
-                "wal_apparent_bytes": 512,
-                "vmrss_kb": rss_kb + 2048,
-                "vmhwm_kb": rss_kb + 4096,
-            }
+    for idx in range(dwell_samples):
+        (dwell / f"sample_{idx}.json").write_text(
+            json.dumps(
+                {
+                    "timestamp": f"2026-06-26T00:02:{idx:02d}Z",
+                    "home_apparent_bytes": app_bytes + 4096 + idx,
+                    "app_db_apparent_bytes": app_bytes + idx,
+                    "maindb_apparent_bytes": 1024 + idx,
+                    "wal_apparent_bytes": 512 + idx,
+                    "vmrss_kb": rss_kb + 2048 + idx,
+                    "vmhwm_kb": rss_kb + 4096 + idx,
+                }
+            )
+            + "\n",
+            encoding="utf-8",
         )
-        + "\n",
-        encoding="utf-8",
-    )
     (sync / "node.log").write_text("normal line\n", encoding="utf-8")
     return home
 
@@ -101,6 +107,7 @@ class CelestiaSyncSummaryTest(unittest.TestCase):
             self.assertEqual([run["db_backend"] for run in payload["runs"]], ["goleveldb", "treedb"])
             self.assertEqual(payload["runs"][0]["blocks_synced"], 250)
             self.assertEqual(payload["runs"][1]["dwell"]["sample_count"], 1)
+            self.assertEqual(payload["runs"][0]["disk_breakdown_bytes"]["application.db"], 10_000)
             self.assertEqual(payload["comparison"]["deltas"]["sync_duration_seconds"], 30)
             self.assertEqual(payload["comparison"]["ratios"]["end_app_bytes"], 0.8)
 
@@ -129,6 +136,38 @@ class CelestiaSyncSummaryTest(unittest.TestCase):
             self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
             self.assertIn("| treedb", result.stdout)
             self.assertIn("| 2", result.stdout)
+
+    def test_disk_fallback_and_numeric_dwell_sample_order(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="celestia_sync_summary_test_") as tmp:
+            root = Path(tmp)
+            run = write_run_home(
+                root,
+                "treedb",
+                sync_seconds=10,
+                rss_kb=1000,
+                app_bytes=1234,
+                include_end_app_bytes=False,
+                dwell_samples=11,
+            )
+            out = root / "out"
+
+            result = subprocess.run(
+                [str(SCRIPT), "--out-dir", str(out), str(run)],
+                cwd=ROOT,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            payload = json.loads((out / "celestia_sync_runs.json").read_text(encoding="utf-8"))
+            summary = payload["runs"][0]
+            self.assertEqual(summary["end_app_bytes"], 1234)
+            self.assertEqual(summary["disk_breakdown_bytes"]["application.db"], 1234)
+            self.assertEqual(summary["dwell"]["sample_count"], 11)
+            self.assertEqual(summary["dwell"]["last_timestamp"], "2026-06-26T00:02:10Z")
+            self.assertEqual(summary["dwell"]["last_app_db_apparent_bytes"], 1244)
 
 
 if __name__ == "__main__":

--- a/scripts/summarize_celestia_sync_runs_test.py
+++ b/scripts/summarize_celestia_sync_runs_test.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Tests for summarize_celestia_sync_runs.py."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "summarize_celestia_sync_runs.py"
+
+
+def write_run_home(root: Path, backend: str, *, sync_seconds: int, rss_kb: int, app_bytes: int) -> Path:
+    home = root / f".celestia-app-mainnet-{backend}-20260626010101"
+    sync = home / "sync"
+    app_db = home / "data" / "application.db"
+    sync.mkdir(parents=True)
+    app_db.mkdir(parents=True)
+    (sync / "sync-time.log").write_text(
+        "\n".join(
+            [
+                "start_utc=2026-06-26T00:00:00Z",
+                "trust_height=1000",
+                f"db_backend={backend}",
+                f"app_db_backend={backend}",
+                f"sync_duration_seconds={sync_seconds}",
+                f"duration_seconds={sync_seconds}",
+                f"total_duration_seconds={sync_seconds + 60}",
+                "post_sync_dwell_elapsed_seconds=60",
+                "final_local_height=1250",
+                "final_remote_height=1248",
+                f"max_rss_kb={rss_kb}",
+                f"max_hwm_kb={rss_kb + 1024}",
+                f"end_app_bytes={app_bytes}",
+                f"end_home_bytes={app_bytes + 4096}",
+                f"end_data_bytes={app_bytes + 2048}",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (sync / "disk-breakdown.log").write_text(
+        "\n".join(
+            [
+                f"app_db={app_db}",
+                "du_bytes:",
+                f"{app_bytes} {app_db}",
+                f"1024 {app_db / 'maindb'}",
+                f"512 {app_db / 'maindb' / 'wal'}",
+                "top_files_bytes:",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    dwell = sync / "dwell-stats"
+    dwell.mkdir()
+    (dwell / "sample_0.json").write_text(
+        json.dumps(
+            {
+                "timestamp": "2026-06-26T00:02:00Z",
+                "home_apparent_bytes": app_bytes + 4096,
+                "app_db_apparent_bytes": app_bytes,
+                "maindb_apparent_bytes": 1024,
+                "wal_apparent_bytes": 512,
+                "vmrss_kb": rss_kb + 2048,
+                "vmhwm_kb": rss_kb + 4096,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (sync / "node.log").write_text("normal line\n", encoding="utf-8")
+    return home
+
+
+class CelestiaSyncSummaryTest(unittest.TestCase):
+    def test_summarizes_runs_and_writes_json_and_markdown(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="celestia_sync_summary_test_") as tmp:
+            root = Path(tmp)
+            level = write_run_home(root, "goleveldb", sync_seconds=120, rss_kb=1000, app_bytes=10_000)
+            tree = write_run_home(root, "treedb", sync_seconds=150, rss_kb=2000, app_bytes=8_000)
+            out = root / "out"
+
+            result = subprocess.run(
+                [str(SCRIPT), "--out-dir", str(out), str(level), str(tree)],
+                cwd=ROOT,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            payload = json.loads((out / "celestia_sync_runs.json").read_text(encoding="utf-8"))
+            self.assertEqual(payload["schema"], "celestia_sync_run_summary.v1")
+            self.assertEqual([run["db_backend"] for run in payload["runs"]], ["goleveldb", "treedb"])
+            self.assertEqual(payload["runs"][0]["blocks_synced"], 250)
+            self.assertEqual(payload["runs"][1]["dwell"]["sample_count"], 1)
+            self.assertEqual(payload["comparison"]["deltas"]["sync_duration_seconds"], 30)
+            self.assertEqual(payload["comparison"]["ratios"]["end_app_bytes"], 0.8)
+
+            markdown = (out / "celestia_sync_runs.md").read_text(encoding="utf-8")
+            self.assertIn("# Celestia Sync Run Summary", markdown)
+            self.assertIn("goleveldb", markdown)
+            self.assertIn("treedb", markdown)
+            self.assertIn("sync_duration_seconds", markdown)
+
+    def test_counts_fatal_log_matches(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="celestia_sync_summary_test_") as tmp:
+            root = Path(tmp)
+            run = write_run_home(root, "treedb", sync_seconds=10, rss_kb=1000, app_bytes=1000)
+            node_log = run / "sync" / "node.log"
+            node_log.write_text("ok\npanic: bad state\nfatal error: crash\n", encoding="utf-8")
+
+            result = subprocess.run(
+                [str(SCRIPT), str(run)],
+                cwd=ROOT,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertIn("| treedb", result.stdout)
+            self.assertIn("| 2", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/summarize_celestia_sync_runs_test.py
+++ b/scripts/summarize_celestia_sync_runs_test.py
@@ -152,6 +152,46 @@ class CelestiaSyncSummaryTest(unittest.TestCase):
             self.assertIn("Comparison skipped: mismatched_run_window.", markdown)
             self.assertIn("trust_hash", markdown)
 
+    def test_skips_comparison_when_window_evidence_is_missing(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="celestia_sync_summary_test_") as tmp:
+            root = Path(tmp)
+            level = write_run_home(root, "goleveldb", sync_seconds=120, rss_kb=1000, app_bytes=10_000)
+            tree = write_run_home(root, "treedb", sync_seconds=150, rss_kb=2000, app_bytes=8_000)
+            for run in [level, tree]:
+                sync_time = run / "sync" / "sync-time.log"
+                sync_time.write_text(
+                    sync_time.read_text(encoding="utf-8").replace("trust_hash=ABCDEF\n", ""),
+                    encoding="utf-8",
+                )
+            out = root / "out"
+
+            result = subprocess.run(
+                [str(SCRIPT), "--out-dir", str(out), str(level), str(tree)],
+                cwd=ROOT,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            payload = json.loads((out / "celestia_sync_runs.json").read_text(encoding="utf-8"))
+            comparison = payload["comparison"]
+            self.assertFalse(comparison["valid"])
+            self.assertEqual(comparison["reason"], "missing_run_window_evidence")
+            self.assertEqual(
+                comparison["missing_fields"],
+                [
+                    {"side": "baseline", "field": "trust_hash"},
+                    {"side": "candidate", "field": "trust_hash"},
+                ],
+            )
+            self.assertNotIn("ratios", comparison)
+
+            markdown = (out / "celestia_sync_runs.md").read_text(encoding="utf-8")
+            self.assertIn("Comparison skipped: missing_run_window_evidence.", markdown)
+            self.assertIn("trust_hash", markdown)
+
     def test_counts_fatal_log_matches(self) -> None:
         with tempfile.TemporaryDirectory(prefix="celestia_sync_summary_test_") as tmp:
             root = Path(tmp)

--- a/scripts/summarize_celestia_sync_runs_test.py
+++ b/scripts/summarize_celestia_sync_runs_test.py
@@ -193,6 +193,25 @@ class CelestiaSyncSummaryTest(unittest.TestCase):
             payload = json.loads((out / "celestia_sync_runs.json").read_text(encoding="utf-8"))
             self.assertEqual(payload["runs"][0]["end_app_bytes"], 1234)
 
+    def test_requires_sync_time_log(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="celestia_sync_summary_test_") as tmp:
+            root = Path(tmp)
+            run = root / ".celestia-app-mainnet-treedb-20260626010101"
+            (run / "sync").mkdir(parents=True)
+
+            result = subprocess.run(
+                [str(SCRIPT), str(run)],
+                cwd=ROOT,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 2)
+            self.assertEqual(result.stdout, "")
+            self.assertIn("missing required sync-time.log", result.stderr)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Objective
Add the first reproducible evidence protocol for the Celestia TreeDB production-readiness tracker: a checked-in runbook plus a backend-neutral summarizer for goleveldb-vs-TreeDB state-sync/soak artifacts.

## Context
Refs #3127
Refs #3128

The current `~/run_celestia.sh` wrapper already exposes the key controls for fair state-sync/catch-up runs, but gomap did not have a neutral report path for comparing LevelDB and TreeDB run homes. This PR makes #3128 evidence collection repeatable before we start changing TreeDB GC, memory, correctness, or span/root-native hot paths based on Celestia observations.

This is the first #3128 PR. It intentionally does not close #3128 yet because the issue's exit gates require at least one real smoke pair and one longer soak comparison after the reporting path lands.

## Non-goals
- No Celestia runner behavior changes.
- No TreeDB storage, value-log, GC, memory, or span/root-native behavior changes.
- No claim that TreeDB is production-ready yet.
- No fresh Celestia smoke/soak run in this PR.

## Design
- `docs/benchmarks/TREEDB_CELESTIA_PRODUCTION_READINESS_PROTOCOL.md` documents identical-run controls, required artifacts, smoke-pair setup, soak-pair setup, and result interpretation.
- `scripts/summarize_celestia_sync_runs.py` reads explicit run homes and summarizes `sync/sync-time.log`, `sync/disk-breakdown.log`, optional `sync/dwell-stats/sample_*.json`, and fatal patterns from `sync/node.log`.
- Output schema is `celestia_sync_run_summary.v1` with JSON plus Markdown report support.
- The comparison logic treats `goleveldb`/`leveldb` as baseline and `treedb` as candidate when both are present.

## Scope
Includes:
- `docs/benchmarks/TREEDB_CELESTIA_PRODUCTION_READINESS_PROTOCOL.md`
- `scripts/summarize_celestia_sync_runs.py`
- `scripts/summarize_celestia_sync_runs_test.py`

Excludes:
- `/home/mikers/dev/snissn/celestia-app-p4/run_celestia.sh`
- `/home/mikers/dev/snissn/celestia-app-p4/scripts/mainnet-treedb-fast-sync-forensics.sh`
- TreeDB runtime code

## Correctness
Tests run:
- `python3 scripts/summarize_celestia_sync_runs_test.py`
- `python3 -m py_compile scripts/summarize_celestia_sync_runs.py scripts/summarize_celestia_sync_runs_test.py`
- `git diff --check origin/main...HEAD`

Covered:
- writes JSON and Markdown summaries from synthetic LevelDB and TreeDB run homes
- computes synced blocks, deltas, and ratios
- parses disk breakdown and dwell samples
- counts fatal log patterns

Corruption/edge cases:
- Missing optional files degrade to empty/default fields.
- Malformed dwell JSON is ignored.
- Missing run homes fail with exit code 2.

Concurrency/race coverage: not applicable; this is a single-process report script.

## Performance
Benchmarks run: not applicable. This PR adds offline summarization and docs only.

Performance evidence plan for #3128:
- Run one goleveldb smoke and one TreeDB smoke with identical trust/target/network controls.
- Summarize both homes with `scripts/summarize_celestia_sync_runs.py --out-dir ... <leveldb-home> <treedb-home>`.
- Repeat with post-sync dwell enabled when investigating disk HWM, memory HWM, value-log GC, or maintenance behavior.
- Use measured ratios/deltas to decide whether the next issue/PR should target harness gaps, TreeDB correctness, disk HWM, memory HWM, or root/span-native apply.

## Rollout / Toggle Plan
Default setting: no runtime change.

How to disable quickly: do not run the new summarizer/runbook commands.

## Follow-ups
- #3128: run at least one smoke pair and one soak pair, publish the generated summaries, and classify the next blockers.
- #3129: correctness and recovery gates from Celestia state-sync evidence.
- #3130: value-log GC and disk high-water behavior.
- #3131: restore/catch-up memory high-water behavior.
- #3132: root/span-native app hot-path proof and optimization.
- #3133: final long-soak closeout.

## AI Review Loop
- Codex latest-head review: pending request after this mature PR body update.
- Copilot latest-head review: pending request after this mature PR body update.
- CodeRabbit latest-head review: auto-triggered but rate-limited on 2026-06-26; retry pending when available.
- Review comments/threads resolved or explicitly dismissed: none yet.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new reporting tool to summarize Celestia sync runs and generate both JSON and Markdown output.
  * Added a production-readiness runbook with step-by-step guidance for collecting reproducible benchmark evidence and comparing runs.

* **Tests**
  * Added end-to-end coverage for run summarization, log matching, disk usage fallback behavior, and dwell sample ordering.



<!-- end of auto-generated comment: release notes by coderabbit.ai -->