### PR TITLE
TreeDB: keep command-WAL restore batches below frame cap

### DIFF
--- a/TreeDB/caching/value_log_appender.go
+++ b/TreeDB/caching/value_log_appender.go
@@ -14,6 +14,7 @@ type cachingValueLogAppender struct {
 }
 
 var _ backenddb.ValueLogAppender = (*cachingValueLogAppender)(nil)
+var _ backenddb.ValueLogExternalRefFlusher = (*cachingValueLogAppender)(nil)
 
 func newCachingValueLogAppender(db *DB, l *lane) backenddb.ValueLogAppender {
 	return &cachingValueLogAppender{db: db, lane: l}
@@ -76,6 +77,43 @@ func (a *cachingValueLogAppender) Sync() error {
 		return nil
 	}
 	return a.db.syncValueLogLane(a.lane)
+}
+
+func (a *cachingValueLogAppender) FlushValueLogExternalRefs(fileIDs []uint32, sync bool) error {
+	if a == nil || a.db == nil || a.lane == nil {
+		return errWALUnavailable
+	}
+	if len(fileIDs) == 0 {
+		if sync {
+			return a.Sync()
+		}
+		return a.Flush()
+	}
+	seen := make(map[int]struct{}, len(fileIDs))
+	for _, fileID := range fileIDs {
+		if fileID == 0 || !page.IsValueLogFileID(fileID) {
+			continue
+		}
+		laneID, _ := valuelog.DecodeFileID(fileID)
+		if laneID >= uint32(len(a.db.lanes)) {
+			continue
+		}
+		id := int(laneID)
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		l := &a.db.lanes[id]
+		if err := a.db.flushValueLogLane(l); err != nil {
+			return err
+		}
+		if sync && !a.db.relaxedSync {
+			if err := a.db.syncValueLogLane(l); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }
 
 func (a *cachingValueLogAppender) CurrentValueLogSegment() (string, uint32, bool) {

--- a/TreeDB/caching/value_log_appender.go
+++ b/TreeDB/caching/value_log_appender.go
@@ -2,6 +2,7 @@ package caching
 
 import (
 	"fmt"
+	"os"
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
 	"github.com/snissn/gomap/TreeDB/internal/valuelog"
@@ -89,38 +90,76 @@ func (a *cachingValueLogAppender) FlushValueLogExternalRefs(fileIDs []uint32, sy
 		}
 		return a.Flush()
 	}
-	seen := make(map[int]struct{}, len(fileIDs))
+	seenLanes := make(map[*lane]struct{}, len(fileIDs))
+	activeFileIDs := make(map[uint32]struct{}, len(fileIDs))
 	for _, fileID := range fileIDs {
 		if fileID == 0 || !page.IsValueLogFileID(fileID) {
 			continue
 		}
-		laneID, _ := valuelog.DecodeFileID(fileID)
-		if laneID >= uint32(len(a.db.lanes)) {
+		l := a.db.valueLogLaneForFileID(fileID)
+		if l == nil {
 			continue
 		}
-		id := int(laneID)
-		if _, ok := seen[id]; ok {
-			continue
-		}
-		seen[id] = struct{}{}
-		l := &a.db.lanes[id]
-		if err := a.db.flushValueLogLane(l); err != nil {
-			return err
-		}
-		if sync && !a.db.relaxedSync {
-			if err := a.db.syncValueLogLane(l); err != nil {
+		if _, ok := seenLanes[l]; !ok {
+			seenLanes[l] = struct{}{}
+			if err := a.db.flushValueLogLane(l); err != nil {
 				return err
 			}
+			if sync && !a.db.relaxedSync {
+				if err := a.db.syncValueLogLane(l); err != nil {
+					return err
+				}
+			}
+		}
+		if _, activeFileID, ok := cachingValueLogSegmentForLane(l); ok {
+			activeFileIDs[activeFileID] = struct{}{}
+		}
+	}
+	if !sync {
+		return nil
+	}
+	seenFiles := make(map[uint32]struct{}, len(fileIDs))
+	for _, fileID := range fileIDs {
+		if fileID == 0 || !page.IsValueLogFileID(fileID) {
+			continue
+		}
+		if _, ok := activeFileIDs[fileID]; ok {
+			continue
+		}
+		if _, ok := seenFiles[fileID]; ok {
+			continue
+		}
+		seenFiles[fileID] = struct{}{}
+		if err := a.syncValueLogExternalRefSegment(fileID); err != nil {
+			return err
 		}
 	}
 	return nil
 }
 
-func (a *cachingValueLogAppender) CurrentValueLogSegment() (string, uint32, bool) {
-	if a == nil || a.db == nil || a.lane == nil {
+func (a *cachingValueLogAppender) syncValueLogExternalRefSegment(fileID uint32) error {
+	if a == nil || a.db == nil || fileID == 0 {
+		return errWALUnavailable
+	}
+	path := valuelog.SegmentPath(a.db.valueLogDir, fileID)
+	if l := a.db.valueLogLaneForFileID(fileID); l != nil {
+		dir := a.db.valueLogDirForLane(l)
+		if dir != "" {
+			path = valuelog.SegmentPath(dir, fileID)
+		}
+	}
+	f, err := os.OpenFile(path, os.O_RDWR, 0)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+	return f.Sync()
+}
+
+func cachingValueLogSegmentForLane(l *lane) (string, uint32, bool) {
+	if l == nil {
 		return "", 0, false
 	}
-	l := a.lane
 	l.vlogMu.Lock()
 	path := l.vlogPath
 	seq := l.vlogSeq
@@ -133,4 +172,11 @@ func (a *cachingValueLogAppender) CurrentValueLogSegment() (string, uint32, bool
 		return "", 0, false
 	}
 	return path, fileID, true
+}
+
+func (a *cachingValueLogAppender) CurrentValueLogSegment() (string, uint32, bool) {
+	if a == nil || a.db == nil || a.lane == nil {
+		return "", 0, false
+	}
+	return cachingValueLogSegmentForLane(a.lane)
 }

--- a/TreeDB/caching/value_log_appender_test.go
+++ b/TreeDB/caching/value_log_appender_test.go
@@ -1,0 +1,43 @@
+package caching
+
+import (
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/internal/valuelog"
+)
+
+func TestCachingValueLogExternalRefFlusherSyncsRotatedSegments(t *testing.T) {
+	dir := t.TempDir()
+	oldFileID, err := valuelog.EncodeFileID(0, 1)
+	if err != nil {
+		t.Fatalf("EncodeFileID old: %v", err)
+	}
+	currentFileID, err := valuelog.EncodeFileID(0, 2)
+	if err != nil {
+		t.Fatalf("EncodeFileID current: %v", err)
+	}
+
+	db := &DB{
+		valueLogDir: dir,
+		lanes:       make([]lane, 1),
+	}
+	db.lanes[0].id = 0
+	db.lanes[0].vlogSeq = 2
+	db.lanes[0].vlogPath = valuelog.SegmentPath(dir, currentFileID)
+	appender := &cachingValueLogAppender{db: db, lane: &db.lanes[0]}
+
+	if err := appender.FlushValueLogExternalRefs([]uint32{currentFileID}, true); err != nil {
+		t.Fatalf("FlushValueLogExternalRefs current segment: %v", err)
+	}
+	if err := appender.FlushValueLogExternalRefs([]uint32{oldFileID}, true); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("FlushValueLogExternalRefs missing rotated segment error=%v, want os.ErrNotExist", err)
+	}
+	if err := os.WriteFile(valuelog.SegmentPath(dir, oldFileID), []byte("old segment"), 0o644); err != nil {
+		t.Fatalf("write old segment: %v", err)
+	}
+	if err := appender.FlushValueLogExternalRefs([]uint32{oldFileID, currentFileID, oldFileID}, true); err != nil {
+		t.Fatalf("FlushValueLogExternalRefs rotated segment: %v", err)
+	}
+}

--- a/TreeDB/command_wal_public_cached.go
+++ b/TreeDB/command_wal_public_cached.go
@@ -41,6 +41,24 @@ func (tdb *DB) appendPublicRawKVCommandPayload(payload []byte, sync bool) error 
 	return err
 }
 
+func (tdb *DB) appendPublicRawKVCommandEntries(entries []batch.Entry, sync bool) error {
+	if tdb == nil || !tdb.commandWALCached || len(entries) == 0 {
+		return nil
+	}
+	if tdb.backend == nil {
+		return ErrClosed
+	}
+	intent, err := tdb.backend.NewRawKVCommandWALIntentFromOrderedEntries(entries)
+	if err != nil {
+		return err
+	}
+	lsn, err := tdb.backend.AppendCommandWALIntent(intent, sync)
+	if lsn != 0 {
+		tdb.recordPublicCommandWALPendingLSN(lsn)
+	}
+	return err
+}
+
 func (tdb *DB) appendPublicRawKVDeleteRangeCommand(start, end []byte, sync bool) error {
 	if tdb == nil || !tdb.commandWALCached || batch.IsDeleteRangeNoop(start, end) {
 		return nil
@@ -581,6 +599,22 @@ func (b *commandWALPublicBatch) commandWALPayload() ([]byte, error) {
 func (b *commandWALPublicBatch) appendCommandWAL(sync bool) error {
 	if b == nil || b.inner == nil {
 		return ErrClosed
+	}
+	if b.db != nil && b.db.commandWALCached && b.db.backend != nil {
+		var entries []batch.Entry
+		hasPointer := false
+		if err := b.inner.Replay(func(entry batch.Entry) error {
+			if entry.Type == batch.OpPut && entry.IsPtr {
+				hasPointer = true
+			}
+			entries = append(entries, entry)
+			return nil
+		}); err != nil {
+			return err
+		}
+		if hasPointer {
+			return b.db.appendPublicRawKVCommandEntries(entries, sync)
+		}
 	}
 	payload, err := b.commandWALPayload()
 	if err != nil {

--- a/TreeDB/command_wal_public_cached.go
+++ b/TreeDB/command_wal_public_cached.go
@@ -251,6 +251,7 @@ type commandWALPublicBatch struct {
 	payloadOpHint     int
 	payloadByteHint   int
 	opCount           int
+	hasDeleteRange    bool
 	dirty             bool
 	// retainPayloadAfterWrite is set by adapter-only replay-view helpers. It
 	// keeps payload-owned key/value views valid after a successful Write until
@@ -284,6 +285,7 @@ func (b *commandWALPublicBatch) resetPayloadWithHint() {
 		return
 	}
 	_ = b.payload.ResetWithHint(b.payloadOpHint, b.payloadByteHint)
+	b.hasDeleteRange = false
 }
 
 func (b *commandWALPublicBatch) preparePayloadForAppend() {
@@ -297,6 +299,7 @@ func (b *commandWALPublicBatch) preparePayloadForAppend() {
 	// path after Write.
 	b.resetPayloadWithHint()
 	b.opCount = 0
+	b.hasDeleteRange = false
 	b.retainPayloadAfterWrite = false
 }
 
@@ -450,6 +453,7 @@ func (b *commandWALPublicBatch) DeleteRange(start, end []byte) error {
 		return err
 	}
 	b.opCount++
+	b.hasDeleteRange = true
 	b.dirty = true
 	return nil
 }
@@ -497,6 +501,7 @@ func (b *commandWALPublicBatch) write(sync bool) error {
 			b.resetPayloadWithHint()
 		}
 		b.opCount = 0
+		b.hasDeleteRange = false
 		b.dirty = false
 		return nil
 	}
@@ -514,6 +519,7 @@ func (b *commandWALPublicBatch) write(sync bool) error {
 		b.resetPayloadWithHint()
 	}
 	b.opCount = 0
+	b.hasDeleteRange = false
 	b.dirty = false
 	return nil
 }
@@ -531,6 +537,7 @@ func (b *commandWALPublicBatch) Close() error {
 	b.innerDeleteViewFn = nil
 	b.resetPayloadWithHint()
 	b.opCount = 0
+	b.hasDeleteRange = false
 	b.dirty = false
 	b.retainPayloadAfterWrite = false
 	b.closed = true
@@ -546,6 +553,7 @@ func (b *commandWALPublicBatch) Reset() {
 		b.disableInnerStreamingBypass()
 		b.resetPayloadWithHint()
 		b.opCount = 0
+		b.hasDeleteRange = false
 		b.dirty = false
 		b.retainPayloadAfterWrite = false
 		b.closed = false
@@ -556,6 +564,7 @@ func (b *commandWALPublicBatch) Reset() {
 	b.disableInnerStreamingBypass()
 	b.resetPayloadWithHint()
 	b.opCount = 0
+	b.hasDeleteRange = false
 	b.dirty = false
 	b.retainPayloadAfterWrite = false
 	b.closed = false
@@ -600,7 +609,7 @@ func (b *commandWALPublicBatch) appendCommandWAL(sync bool) error {
 	if b == nil || b.inner == nil {
 		return ErrClosed
 	}
-	if b.db != nil && b.db.commandWALCached && b.db.backend != nil {
+	if !b.hasDeleteRange && b.db != nil && b.db.commandWALCached && b.db.backend != nil {
 		var entries []batch.Entry
 		hasPointer := false
 		if err := b.inner.Replay(func(entry batch.Entry) error {

--- a/TreeDB/command_wal_public_test.go
+++ b/TreeDB/command_wal_public_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strconv"
 	"sync"
 	"testing"
@@ -1660,6 +1661,80 @@ func TestPublicCommandWALBatchValueLogPointersStayBelowFrameCap(t *testing.T) {
 	for key, value := range values {
 		requireRawKVValue(t, reopen, []byte(key), value)
 	}
+}
+
+func TestPublicCommandWALBatchValueLogPointersFlushMultiLaneRefs(t *testing.T) {
+	dir := t.TempDir()
+	opts := Options{
+		Dir:                          dir,
+		Durability:                   DurabilityWALOnRelaxed,
+		CommandWAL:                   true,
+		CommandWALStatsScan:          true,
+		DisableSideStores:            true,
+		BackgroundCheckpointInterval: -1,
+		FlushThreshold:               1 << 30,
+		WALMaxSegmentBytes:           1 << 20,
+		JournalLanes:                 4,
+		MemtableShards:               16,
+	}
+	opts.ValueLog.PointerThreshold = 1
+	opts.ValueLog.ForcePointers = true
+	opts.ValueLog.Generational.Policy = ValueLogGenerationOff
+	db, err := Open(opts)
+	if err != nil {
+		t.Fatalf("Open command WAL: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	const entries = 1100
+	b := db.NewBatchWithSize(entries)
+	for i := 0; i < entries; i++ {
+		key := []byte(fmt.Sprintf("multi-lane-%06d", i))
+		value := bytes.Repeat([]byte{byte(i%251 + 1)}, 2048)
+		if err := b.Set(key, value); err != nil {
+			_ = b.Close()
+			t.Fatalf("batch Set %d: %v", i, err)
+		}
+	}
+	if err := b.Write(); err != nil {
+		_ = b.Close()
+		t.Fatalf("batch Write: %v", err)
+	}
+	if err := b.Close(); err != nil {
+		t.Fatalf("batch Close: %v", err)
+	}
+
+	lanes := publicCommandWALValueLogLanes(t, dir)
+	if len(lanes) < 2 {
+		t.Fatalf("value-log lanes used=%v, want at least 2 to cover multi-lane SetRID flushing", lanes)
+	}
+	for _, i := range []int{0, entries / 2, entries - 1} {
+		key := []byte(fmt.Sprintf("multi-lane-%06d", i))
+		want := bytes.Repeat([]byte{byte(i%251 + 1)}, 2048)
+		got, err := db.Get(key)
+		if err != nil {
+			t.Fatalf("Get %q: %v", key, err)
+		}
+		if !bytes.Equal(got, want) {
+			t.Fatalf("Get %q len=%d, want len=%d", key, len(got), len(want))
+		}
+	}
+}
+
+func publicCommandWALValueLogLanes(t *testing.T, dir string) map[int]struct{} {
+	t.Helper()
+	paths, err := filepath.Glob(filepath.Join(dir, "value_vlog", "value-l*.log"))
+	if err != nil {
+		t.Fatalf("glob value-log segments: %v", err)
+	}
+	lanes := make(map[int]struct{})
+	for _, path := range paths {
+		var lane, seq int
+		if n, _ := fmt.Sscanf(filepath.Base(path), "value-l%d-%d.log", &lane, &seq); n == 2 {
+			lanes[lane] = struct{}{}
+		}
+	}
+	return lanes
 }
 
 func TestPublicCommandWALBatchDeleteRangeWithPointerUsesCompactRangeFrame(t *testing.T) {

--- a/TreeDB/command_wal_public_test.go
+++ b/TreeDB/command_wal_public_test.go
@@ -1696,9 +1696,9 @@ func TestPublicCommandWALBatchValueLogPointersFlushMultiLaneRefs(t *testing.T) {
 			t.Fatalf("batch Set %d: %v", i, err)
 		}
 	}
-	if err := b.Write(); err != nil {
+	if err := b.WriteSync(); err != nil {
 		_ = b.Close()
-		t.Fatalf("batch Write: %v", err)
+		t.Fatalf("batch WriteSync: %v", err)
 	}
 	if err := b.Close(); err != nil {
 		t.Fatalf("batch Close: %v", err)

--- a/TreeDB/command_wal_public_test.go
+++ b/TreeDB/command_wal_public_test.go
@@ -1637,6 +1637,10 @@ func TestPublicCommandWALBatchValueLogPointersStayBelowFrameCap(t *testing.T) {
 		t.Fatalf("batch Close: %v", err)
 	}
 	assertPublicCommandWALFrames(t, db, 1)
+	if frames := publicCommandWALFrameCount(t, db); frames != 1 {
+		_ = db.Close()
+		t.Fatalf("command_wal.frames=%d, want exactly 1", frames)
+	}
 	for key, value := range values {
 		requireRawKVValue(t, db, []byte(key), value)
 	}
@@ -1655,6 +1659,69 @@ func TestPublicCommandWALBatchValueLogPointersStayBelowFrameCap(t *testing.T) {
 	defer reopen.Close()
 	for key, value := range values {
 		requireRawKVValue(t, reopen, []byte(key), value)
+	}
+}
+
+func TestPublicCommandWALBatchDeleteRangeWithPointerUsesCompactRangeFrame(t *testing.T) {
+	dir := t.TempDir()
+	opts := Options{
+		Dir:                          dir,
+		Durability:                   DurabilityWALOnRelaxed,
+		CommandWAL:                   true,
+		CommandWALStatsScan:          true,
+		DisableSideStores:            true,
+		BackgroundCheckpointInterval: -1,
+		WALMaxSegmentBytes:           4096,
+	}
+	opts.ValueLog.PointerThreshold = 1
+	opts.ValueLog.ForcePointers = true
+
+	db, err := Open(opts)
+	if err != nil {
+		t.Fatalf("Open command WAL: %v", err)
+	}
+	for i := 0; i < 400; i++ {
+		key := []byte(fmt.Sprintf("range-%04d", i))
+		if err := db.Set(key, []byte("seed")); err != nil {
+			_ = db.Close()
+			t.Fatalf("seed Set %q: %v", key, err)
+		}
+	}
+	before := publicCommandWALFrameCount(t, db)
+
+	b := db.NewBatch()
+	if err := b.DeleteRange([]byte("range-"), []byte("range-\xff")); err != nil {
+		_ = b.Close()
+		_ = db.Close()
+		t.Fatalf("batch DeleteRange: %v", err)
+	}
+	wantValue := bytes.Repeat([]byte("z"), 2048)
+	if err := b.Set([]byte("z-pointer"), wantValue); err != nil {
+		_ = b.Close()
+		_ = db.Close()
+		t.Fatalf("batch Set pointer: %v", err)
+	}
+	if err := b.Write(); err != nil {
+		_ = b.Close()
+		_ = db.Close()
+		t.Fatalf("batch Write should log compact DeleteRange instead of materialized point deletes: %v", err)
+	}
+	if err := b.Close(); err != nil {
+		_ = db.Close()
+		t.Fatalf("batch Close: %v", err)
+	}
+	if frames := publicCommandWALFrameCount(t, db); frames != before+1 {
+		_ = db.Close()
+		t.Fatalf("command_wal.frames=%d want %d", frames, before+1)
+	}
+	has, err := db.Has([]byte("range-0000"))
+	if err != nil || has {
+		_ = db.Close()
+		t.Fatalf("Has(range-0000)=(%t,%v), want false,nil", has, err)
+	}
+	requireRawKVValue(t, db, []byte("z-pointer"), wantValue)
+	if err := db.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
 	}
 }
 

--- a/TreeDB/command_wal_public_test.go
+++ b/TreeDB/command_wal_public_test.go
@@ -1,6 +1,7 @@
 package treedb
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -1592,6 +1593,68 @@ func TestPublicCommandWALDeleteRangeValueLogPointersReopen(t *testing.T) {
 	has, err := reopen.Has([]byte("b"))
 	if err != nil || has {
 		t.Fatalf("Has(b)=(%t,%v), want false,nil", has, err)
+	}
+}
+
+func TestPublicCommandWALBatchValueLogPointersStayBelowFrameCap(t *testing.T) {
+	dir := t.TempDir()
+	opts := Options{
+		Dir:                          dir,
+		Durability:                   DurabilityWALOnRelaxed,
+		CommandWAL:                   true,
+		CommandWALStatsScan:          true,
+		DisableSideStores:            true,
+		BackgroundCheckpointInterval: -1,
+		WALMaxSegmentBytes:           4096,
+	}
+	opts.ValueLog.PointerThreshold = 1
+	opts.ValueLog.ForcePointers = true
+
+	db, err := Open(opts)
+	if err != nil {
+		t.Fatalf("Open command WAL: %v", err)
+	}
+
+	values := make(map[string][]byte)
+	b := db.NewBatch()
+	for i := 0; i < 8; i++ {
+		key := fmt.Sprintf("large-%02d", i)
+		value := bytes.Repeat([]byte{byte('a' + i)}, 2048)
+		values[key] = value
+		if err := b.Set([]byte(key), value); err != nil {
+			_ = b.Close()
+			_ = db.Close()
+			t.Fatalf("batch Set %s: %v", key, err)
+		}
+	}
+	if err := b.Write(); err != nil {
+		_ = b.Close()
+		_ = db.Close()
+		t.Fatalf("batch Write should encode pointer ops as SetRID below the command frame cap: %v", err)
+	}
+	if err := b.Close(); err != nil {
+		_ = db.Close()
+		t.Fatalf("batch Close: %v", err)
+	}
+	assertPublicCommandWALFrames(t, db, 1)
+	for key, value := range values {
+		requireRawKVValue(t, db, []byte(key), value)
+	}
+	if err := db.Checkpoint(); err != nil {
+		_ = db.Close()
+		t.Fatalf("Checkpoint: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	reopen, err := Open(Options{Dir: dir, CommandWALStatsScan: true, DisableSideStores: true, BackgroundCheckpointInterval: -1})
+	if err != nil {
+		t.Fatalf("Reopen: %v", err)
+	}
+	defer reopen.Close()
+	for key, value := range values {
+		requireRawKVValue(t, reopen, []byte(key), value)
 	}
 }
 

--- a/TreeDB/db/command_wal_raw.go
+++ b/TreeDB/db/command_wal_raw.go
@@ -604,6 +604,11 @@ func (db *DB) appendPublicCommandWALIntent(intent *CommandWALIntent, sync bool) 
 		return 0, err
 	}
 	if intent.inner.lsn != 0 {
+		if !intent.inner.fromReplay {
+			if err := db.commandWALPoisonedError(); err != nil {
+				return 0, err
+			}
+		}
 		// Replay intents already refer to a durable frame; recovery must only
 		// publish that covered LSN, never append a duplicate command.
 		return intent.inner.lsn, nil
@@ -618,6 +623,8 @@ func commandWALIntentFrameAlreadyAppended(intent *CommandWALIntent) bool {
 // AppendCommandWALIntent appends a deterministic command frame without
 // publishing roots. It is used by cached public command-WAL writers that must
 // make a typed frame replay-visible before inserting the mutation into memory.
+// If the append succeeds but the post-append flush fails, the returned LSN is
+// still the allocated LSN and the open handle is poisoned for recovery.
 func (db *DB) AppendCommandWALIntent(intent *CommandWALIntent, sync bool) (uint64, error) {
 	if db != nil && db.readOnly {
 		return 0, ErrReadOnly
@@ -959,17 +966,19 @@ func (db *DB) appendCommandWALIntent(intent *commandWALBatchIntent, sync bool) (
 	if err != nil {
 		return 0, err
 	}
+	if lsn != 0 {
+		intent.lsn = lsn
+		intent.coveredRange[0] = CommandWALLSNRange{First: lsn, Last: lsn}
+	}
 	if err := db.FlushCommandWAL(sync); err != nil {
 		// AppendCommand already assigned a logical LSN, and the frame may be
 		// replayed if the append reached disk. A later flush/sync failure is
 		// commit-ambiguous: reopen recovery may apply the frame, so this handle
 		// must fail closed instead of allowing a retry to create an LSN gap.
 		// FlushCommandWAL owns the relaxed-sync downgrade and poison state.
-		return 0, err
+		return lsn, err
 	}
 	db.observeCommandWALAccepted(lsn)
-	intent.lsn = lsn
-	intent.coveredRange[0] = CommandWALLSNRange{First: lsn, Last: lsn}
 	return lsn, nil
 }
 
@@ -1000,8 +1009,8 @@ func commandWALFinalizeOptionsForPublicIntent(intent *CommandWALIntent) finalize
 func (db *DB) poisonCommandWALAfterPostAppendFailure(intent *commandWALBatchIntent) {
 	if db == nil || intent == nil || intent.lsn == 0 {
 		// intent.lsn == 0 means the frame was never durably appended
-		// (appendRawKVCommandWALIntent sets lsn only on success). No need
-		// to poison; appendRawKVCommandWALIntent already poisons its own
+		// (appendCommandWALIntent sets lsn once AppendCommand succeeds).
+		// No need to poison; appendCommandWALIntent already poisons its own
 		// flush/sync failures.
 		return
 	}

--- a/TreeDB/db/command_wal_raw.go
+++ b/TreeDB/db/command_wal_raw.go
@@ -390,6 +390,32 @@ func (db *DB) prepareRawKVCommandWALIntent(b *Batch) (*commandWALBatchIntent, er
 	if len(entries) == 0 {
 		return nil, nil
 	}
+	return db.newRawKVCommandWALIntentFromEntries(entries)
+}
+
+// NewRawKVCommandWALIntentFromOrderedEntries builds a public raw-KV command
+// intent from entries that are already in the caller's required application
+// order. Unlike prepareRawKVCommandWALIntent, this does not sort or compact
+// point ops; public cached batches rely on replay order to preserve mixed
+// set/delete/range-delete semantics.
+func (db *DB) NewRawKVCommandWALIntentFromOrderedEntries(entries []batchpkg.Entry) (*CommandWALIntent, error) {
+	if db == nil || !db.commandWAL {
+		return nil, nil
+	}
+	if db.durability == DurabilityWALOffRelaxed {
+		return nil, fmt.Errorf("%w: WAL-off durability is incompatible with command WAL", ErrCommandWALUnsupported)
+	}
+	if len(entries) == 0 {
+		return nil, nil
+	}
+	intent, err := db.newRawKVCommandWALIntentFromEntries(entries)
+	if intent == nil || err != nil {
+		return nil, err
+	}
+	return &CommandWALIntent{inner: *intent}, nil
+}
+
+func (db *DB) newRawKVCommandWALIntentFromEntries(entries []batchpkg.Entry) (*commandWALBatchIntent, error) {
 	externalRefs := false
 	var ridCache map[page.ValuePtr]uint64
 	var smallOps [16]commitlog.RawKVOperation
@@ -424,6 +450,9 @@ func (db *DB) prepareRawKVCommandWALIntent(b *Batch) (*commandWALBatchIntent, er
 		default:
 			return nil, fmt.Errorf("treedb: command wal unknown raw kv batch op %d", entry.Type)
 		}
+	}
+	if len(ops) == 0 {
+		return nil, nil
 	}
 	payload, err := commitlog.EncodeRawKVBatchPayload(ops)
 	if err != nil {

--- a/TreeDB/db/command_wal_raw.go
+++ b/TreeDB/db/command_wal_raw.go
@@ -543,26 +543,23 @@ func (db *DB) flushCommandWALExternalRefs(sync bool, fileIDs []uint32) error {
 	}
 	var activeFileID uint32
 	if appender != nil {
-		usedExternalRefFlusher := false
 		if len(fileIDs) > 0 {
 			if flusher, ok := appender.(ValueLogExternalRefFlusher); ok {
 				if err := flusher.FlushValueLogExternalRefs(fileIDs, sync); err != nil {
 					return err
 				}
-				usedExternalRefFlusher = true
+				return nil
 			}
 		}
-		if !usedExternalRefFlusher {
-			if _, fileID, ok := appender.CurrentValueLogSegment(); ok {
-				activeFileID = fileID
-			}
-			if sync {
-				if err := appender.Sync(); err != nil {
-					return err
-				}
-			} else if err := appender.Flush(); err != nil {
+		if _, fileID, ok := appender.CurrentValueLogSegment(); ok {
+			activeFileID = fileID
+		}
+		if sync {
+			if err := appender.Sync(); err != nil {
 				return err
 			}
+		} else if err := appender.Flush(); err != nil {
+			return err
 		}
 	}
 	if !sync {

--- a/TreeDB/db/command_wal_raw.go
+++ b/TreeDB/db/command_wal_raw.go
@@ -509,7 +509,7 @@ func (db *DB) lookupCommandWALValueLogRID(ptr page.ValuePtr, ridCache map[page.V
 	path := db.valueLogManager.SegmentPath(ptr.FileID)
 	rid, err := readCommandWALValueLogRIDAt(path, ptr)
 	if isCommandWALRIDLookupVisibilityError(err) {
-		if flushErr := db.flushCommandWALExternalRefs(false, nil); flushErr != nil {
+		if flushErr := db.flushCommandWALExternalRefs(false, []uint32{ptr.FileID}); flushErr != nil {
 			return 0, flushErr
 		}
 		rid, err = readCommandWALValueLogRIDAt(path, ptr)
@@ -543,15 +543,26 @@ func (db *DB) flushCommandWALExternalRefs(sync bool, fileIDs []uint32) error {
 	}
 	var activeFileID uint32
 	if appender != nil {
-		if _, fileID, ok := appender.CurrentValueLogSegment(); ok {
-			activeFileID = fileID
+		usedExternalRefFlusher := false
+		if len(fileIDs) > 0 {
+			if flusher, ok := appender.(ValueLogExternalRefFlusher); ok {
+				if err := flusher.FlushValueLogExternalRefs(fileIDs, sync); err != nil {
+					return err
+				}
+				usedExternalRefFlusher = true
+			}
 		}
-		if sync {
-			if err := appender.Sync(); err != nil {
+		if !usedExternalRefFlusher {
+			if _, fileID, ok := appender.CurrentValueLogSegment(); ok {
+				activeFileID = fileID
+			}
+			if sync {
+				if err := appender.Sync(); err != nil {
+					return err
+				}
+			} else if err := appender.Flush(); err != nil {
 				return err
 			}
-		} else if err := appender.Flush(); err != nil {
-			return err
 		}
 	}
 	if !sync {

--- a/TreeDB/db/command_wal_recovery_test.go
+++ b/TreeDB/db/command_wal_recovery_test.go
@@ -823,6 +823,30 @@ func TestCommandWALPointAppendReturnsLSNOnFlushFailure(t *testing.T) {
 	}
 }
 
+func TestAppendCommandWALIntentReturnsLSNOnFlushFailure(t *testing.T) {
+	dir := t.TempDir()
+	enableCommandWALFormat(t, dir)
+	db := openCommandWALDB(t, dir)
+	defer db.Close()
+
+	intent := mustRawKVCommandWALIntent(t, db, "k", "v")
+	db.testFailCommandWALFlush.Store(true)
+	lsn, err := db.AppendCommandWALIntent(intent, true)
+	if !errors.Is(err, errTestCommandWALFlushFailpoint) {
+		t.Fatalf("AppendCommandWALIntent error=%v, want command WAL flush failpoint", err)
+	}
+	if lsn != 1 {
+		t.Fatalf("AppendCommandWALIntent lsn=%d, want allocated LSN 1 on post-append flush failure", lsn)
+	}
+	if got := intent.AssignedLSN(); got != lsn {
+		t.Fatalf("intent AssignedLSN=%d, want %d", got, lsn)
+	}
+	db.testFailCommandWALFlush.Store(false)
+	if _, err := db.AppendCommandWALIntent(intent, true); !errors.Is(err, ErrRecoveryRequired) {
+		t.Fatalf("AppendCommandWALIntent retry error=%v, want ErrRecoveryRequired", err)
+	}
+}
+
 func TestCommandWALPointAppendFlushesAsyncFrame(t *testing.T) {
 	dir := t.TempDir()
 	enableCommandWALFormat(t, dir)

--- a/TreeDB/db/command_wal_recovery_test.go
+++ b/TreeDB/db/command_wal_recovery_test.go
@@ -1376,32 +1376,42 @@ func TestCommandWALExternalRefFlushDoesNotDoubleSyncActiveSegment(t *testing.T) 
 }
 
 func TestCommandWALExternalRefFlushUsesReferencedLaneFlusher(t *testing.T) {
-	db := &DB{}
-	appender := &commandWALExternalRefLaneFlushTestAppender{t: t}
-	db.SetValueLogAppender(appender)
 	fileIDs := []uint32{17, 18}
-	if err := db.flushCommandWALExternalRefs(false, fileIDs); err != nil {
-		t.Fatalf("flushCommandWALExternalRefs referenced lanes: %v", err)
-	}
-	if appender.externalFlushes.Load() != 1 {
-		t.Fatalf("external flushes=%d, want 1", appender.externalFlushes.Load())
-	}
-	if appender.sync {
-		t.Fatal("external flush sync=true, want false")
-	}
-	if len(appender.fileIDs) != len(fileIDs) {
-		t.Fatalf("external flush fileIDs=%v, want %v", appender.fileIDs, fileIDs)
-	}
-	for i := range fileIDs {
-		if appender.fileIDs[i] != fileIDs[i] {
-			t.Fatalf("external flush fileIDs=%v, want %v", appender.fileIDs, fileIDs)
-		}
-	}
-	if appender.flushes.Load() != 0 {
-		t.Fatalf("appender flushes=%d, want 0 when referenced-lane flusher is available", appender.flushes.Load())
-	}
-	if appender.syncs.Load() != 0 {
-		t.Fatalf("appender syncs=%d, want 0 when referenced-lane flusher is available", appender.syncs.Load())
+	for _, tc := range []struct {
+		name string
+		sync bool
+	}{
+		{name: "sync=false", sync: false},
+		{name: "sync=true", sync: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			db := &DB{}
+			appender := &commandWALExternalRefLaneFlushTestAppender{t: t}
+			db.SetValueLogAppender(appender)
+			if err := db.flushCommandWALExternalRefs(tc.sync, fileIDs); err != nil {
+				t.Fatalf("flushCommandWALExternalRefs referenced lanes: %v", err)
+			}
+			if appender.externalFlushes.Load() != 1 {
+				t.Fatalf("external flushes=%d, want 1", appender.externalFlushes.Load())
+			}
+			if appender.sync != tc.sync {
+				t.Fatalf("external flush sync=%v, want %v", appender.sync, tc.sync)
+			}
+			if len(appender.fileIDs) != len(fileIDs) {
+				t.Fatalf("external flush fileIDs=%v, want %v", appender.fileIDs, fileIDs)
+			}
+			for i := range fileIDs {
+				if appender.fileIDs[i] != fileIDs[i] {
+					t.Fatalf("external flush fileIDs=%v, want %v", appender.fileIDs, fileIDs)
+				}
+			}
+			if appender.flushes.Load() != 0 {
+				t.Fatalf("appender flushes=%d, want 0 when referenced-lane flusher is available", appender.flushes.Load())
+			}
+			if appender.syncs.Load() != 0 {
+				t.Fatalf("appender syncs=%d, want 0 when referenced-lane flusher is available", appender.syncs.Load())
+			}
+		})
 	}
 }
 

--- a/TreeDB/db/command_wal_recovery_test.go
+++ b/TreeDB/db/command_wal_recovery_test.go
@@ -1289,6 +1289,43 @@ func (a *commandWALExternalRefSyncTestAppender) CurrentValueLogSegment() (string
 	return "", a.fileID, true
 }
 
+type commandWALExternalRefLaneFlushTestAppender struct {
+	t               *testing.T
+	fileIDs         []uint32
+	sync            bool
+	externalFlushes atomic.Int32
+	syncs           atomic.Int32
+	flushes         atomic.Int32
+}
+
+func (a *commandWALExternalRefLaneFlushTestAppender) AppendValues(values [][]byte) ([]page.ValuePtr, error) {
+	if a.t != nil {
+		a.t.Fatal("AppendValues must not be called during flushCommandWALExternalRefs")
+	}
+	panic("AppendValues must not be called during flushCommandWALExternalRefs")
+}
+
+func (a *commandWALExternalRefLaneFlushTestAppender) Flush() error {
+	a.flushes.Add(1)
+	return nil
+}
+
+func (a *commandWALExternalRefLaneFlushTestAppender) Sync() error {
+	a.syncs.Add(1)
+	return nil
+}
+
+func (a *commandWALExternalRefLaneFlushTestAppender) CurrentValueLogSegment() (string, uint32, bool) {
+	return "", 0, false
+}
+
+func (a *commandWALExternalRefLaneFlushTestAppender) FlushValueLogExternalRefs(fileIDs []uint32, sync bool) error {
+	a.externalFlushes.Add(1)
+	a.sync = sync
+	a.fileIDs = append(a.fileIDs[:0], fileIDs...)
+	return nil
+}
+
 // TestCommandWALExternalRefFlushDoesNotDoubleSyncActiveSegment verifies that
 // flushCommandWALExternalRefs does not sync the active appender segment a
 // second time via the per-fileID loop. With sync=true, exactly one Sync call
@@ -1336,6 +1373,36 @@ func TestCommandWALExternalRefFlushDoesNotDoubleSyncActiveSegment(t *testing.T) 
 			t.Fatalf("appender syncs=%d, want 0 for sync=false", appender.syncs.Load())
 		}
 	})
+}
+
+func TestCommandWALExternalRefFlushUsesReferencedLaneFlusher(t *testing.T) {
+	db := &DB{}
+	appender := &commandWALExternalRefLaneFlushTestAppender{t: t}
+	db.SetValueLogAppender(appender)
+	fileIDs := []uint32{17, 18}
+	if err := db.flushCommandWALExternalRefs(false, fileIDs); err != nil {
+		t.Fatalf("flushCommandWALExternalRefs referenced lanes: %v", err)
+	}
+	if appender.externalFlushes.Load() != 1 {
+		t.Fatalf("external flushes=%d, want 1", appender.externalFlushes.Load())
+	}
+	if appender.sync {
+		t.Fatal("external flush sync=true, want false")
+	}
+	if len(appender.fileIDs) != len(fileIDs) {
+		t.Fatalf("external flush fileIDs=%v, want %v", appender.fileIDs, fileIDs)
+	}
+	for i := range fileIDs {
+		if appender.fileIDs[i] != fileIDs[i] {
+			t.Fatalf("external flush fileIDs=%v, want %v", appender.fileIDs, fileIDs)
+		}
+	}
+	if appender.flushes.Load() != 0 {
+		t.Fatalf("appender flushes=%d, want 0 when referenced-lane flusher is available", appender.flushes.Load())
+	}
+	if appender.syncs.Load() != 0 {
+		t.Fatalf("appender syncs=%d, want 0 when referenced-lane flusher is available", appender.syncs.Load())
+	}
 }
 
 func TestCommandWALMissingRIDFenceFailsRecovery(t *testing.T) {

--- a/TreeDB/db/value_log_appender.go
+++ b/TreeDB/db/value_log_appender.go
@@ -25,9 +25,12 @@ type ValueLogAppender interface {
 }
 
 // ValueLogExternalRefFlusher is an optional extension for appenders that can
-// flush the value-log lanes containing specific file IDs. Command-WAL SetRID
-// logging uses it to make freshly written pointer records visible before RID
-// lookup without flushing unrelated lanes.
+// flush the value-log lanes containing specific file IDs. When sync is true,
+// the implementation owns durability for the referenced file IDs: active
+// segments should follow the appender's sync policy, and older referenced
+// segments should be synced directly if needed. Command-WAL SetRID logging uses
+// it to make freshly written pointer records visible before RID lookup without
+// flushing unrelated lanes.
 type ValueLogExternalRefFlusher interface {
 	FlushValueLogExternalRefs(fileIDs []uint32, sync bool) error
 }

--- a/TreeDB/db/value_log_appender.go
+++ b/TreeDB/db/value_log_appender.go
@@ -24,6 +24,14 @@ type ValueLogAppender interface {
 	CurrentValueLogSegment() (path string, fileID uint32, ok bool)
 }
 
+// ValueLogExternalRefFlusher is an optional extension for appenders that can
+// flush the value-log lanes containing specific file IDs. Command-WAL SetRID
+// logging uses it to make freshly written pointer records visible before RID
+// lookup without flushing unrelated lanes.
+type ValueLogExternalRefFlusher interface {
+	FlushValueLogExternalRefs(fileIDs []uint32, sync bool) error
+}
+
 type valueLogAppenderHolder struct {
 	appender ValueLogAppender
 }

--- a/TreeDB/profiles.go
+++ b/TreeDB/profiles.go
@@ -54,6 +54,8 @@ import (
 // can always override any field directly after applying a profile.
 type Profile string
 
+const commandWALProfileSegmentBytes int64 = 256 << 20
+
 const (
 	// ProfileCommandWALDurable is the explicit command-WAL production profile for
 	// callers that want command-WAL recovery, durable fsync boundaries, corruption
@@ -345,11 +347,22 @@ func applyCommandWALDurableProfile(opts *Options) {
 	opts.CommandWAL = true
 	opts.Durability = DurabilityDurable
 	opts.ValueLog.ReadIntegrity = IntegrityVerify
+	applyCommandWALProfileSegmentDefaults(opts)
 }
 
 func applyCommandWALRelaxedProfile(opts *Options) {
 	applyWALOnFastProfile(opts)
 	opts.CommandWAL = true
+	applyCommandWALProfileSegmentDefaults(opts)
+}
+
+func applyCommandWALProfileSegmentDefaults(opts *Options) {
+	if opts.WALMaxSegmentBytes == 0 {
+		opts.WALMaxSegmentBytes = commandWALProfileSegmentBytes
+	}
+	if opts.CommandWALSegmentTargetBytes == 0 {
+		opts.CommandWALSegmentTargetBytes = opts.WALMaxSegmentBytes
+	}
 }
 
 func applyBenchProfile(opts *Options) {

--- a/TreeDB/profiles_test.go
+++ b/TreeDB/profiles_test.go
@@ -261,6 +261,12 @@ func TestApplyProfile_CommandWALDurableSetsCommandWALAndFastDurablePolicy(t *tes
 	if opts.IndexInternalBaseDelta {
 		t.Fatalf("expected IndexInternalBaseDelta=false for command_wal_durable profile")
 	}
+	if opts.WALMaxSegmentBytes != commandWALProfileSegmentBytes {
+		t.Fatalf("WALMaxSegmentBytes=%d want %d", opts.WALMaxSegmentBytes, commandWALProfileSegmentBytes)
+	}
+	if opts.CommandWALSegmentTargetBytes != commandWALProfileSegmentBytes {
+		t.Fatalf("CommandWALSegmentTargetBytes=%d want %d", opts.CommandWALSegmentTargetBytes, commandWALProfileSegmentBytes)
+	}
 }
 
 func TestApplyProfile_CommandWALRelaxedSetsCommandWALAndRelaxedPolicy(t *testing.T) {
@@ -284,6 +290,31 @@ func TestApplyProfile_CommandWALRelaxedSetsCommandWALAndRelaxedPolicy(t *testing
 	}
 	if opts.IndexInternalBaseDelta {
 		t.Fatalf("expected IndexInternalBaseDelta=false for command_wal_relaxed profile")
+	}
+	if opts.WALMaxSegmentBytes != commandWALProfileSegmentBytes {
+		t.Fatalf("WALMaxSegmentBytes=%d want %d", opts.WALMaxSegmentBytes, commandWALProfileSegmentBytes)
+	}
+	if opts.CommandWALSegmentTargetBytes != commandWALProfileSegmentBytes {
+		t.Fatalf("CommandWALSegmentTargetBytes=%d want %d", opts.CommandWALSegmentTargetBytes, commandWALProfileSegmentBytes)
+	}
+}
+
+func TestApplyProfile_CommandWALPreservesExplicitSegmentOverrides(t *testing.T) {
+	for _, profile := range []Profile{ProfileCommandWALDurable, ProfileCommandWALRelaxed} {
+		t.Run(string(profile), func(t *testing.T) {
+			opts := Options{
+				WALMaxSegmentBytes:           1024,
+				CommandWALSegmentTargetBytes: 2048,
+			}
+			ApplyProfile(&opts, profile)
+
+			if opts.WALMaxSegmentBytes != 1024 {
+				t.Fatalf("WALMaxSegmentBytes=%d want explicit 1024", opts.WALMaxSegmentBytes)
+			}
+			if opts.CommandWALSegmentTargetBytes != 2048 {
+				t.Fatalf("CommandWALSegmentTargetBytes=%d want explicit 2048", opts.CommandWALSegmentTargetBytes)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Refs #3129
Refs #3127

## Summary
- Reuse the backend RawKV command-WAL intent path for public cached batches that already contain value-log pointers, so those ops encode as `SetRID` with external-ref flushing instead of reinflating raw values into the command frame.
- Give `command_wal_durable` and `command_wal_relaxed` profiles a bounded 256 MiB command-WAL frame/target default, preserving explicit caller overrides. This mirrors the existing geth adapter policy and targets large Celestia state-sync restore batches that exceed the historical 64 MiB default.
- Add regression coverage for pointer-backed public batches staying below a tiny frame cap, plus profile default/override tests.

## Validation
- `GOWORK=off go test ./TreeDB -run 'TestPublicCommandWAL(BatchValueLogPointersStayBelowFrameCap|DeleteRangeValueLogPointersReopen|RawKVWritesUseTypedFrames)|TestApplyProfile_CommandWAL'`\n- `GOWORK=off go test ./TreeDB/db -run 'Test.*CommandWAL.*(Raw|Recovery|SetRID|Intent)'`\n- `GOWORK=off go test ./TreeDB -run 'TestApplyProfile|TestPublicCommandWAL' -count=1`\n- `GOWORK=off go test ./TreeDB/integration/kvstoreadapter`\n- `GOWORK=off go test ./TreeDB/db -run '^$'`\n\n## Notes\n- A full `GOWORK=off go test ./TreeDB/db` run was started and stopped after more than two minutes of silence; the focused backend command-WAL recovery/intent tests above passed.\n- I have not rerun the pinned Celestia state-sync smoke yet. That should be the next #3129 gate; if it still hits `commitlog: record too large`, the remaining likely follow-up is true multi-frame transaction grouping for aggregate inline batches.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved handling of large write batches so pointer-backed values are recorded more reliably in the write-ahead log.
  * Added support for building a command log entry directly from ordered writes.

* **Bug Fixes**
  * Prevented empty write batches from being written when they contain only no-op operations.
  * Made default log segment sizing more consistent across command-log profiles while preserving any user-set values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->