### PR TITLE
TreeDB: speed q2 one-shot no-metadata reducer

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -405,7 +405,8 @@ type Collection struct {
 	vectorBufferedSearchErrors        uint64
 
 	typedColumnOneShotMu            sync.Mutex
-	typedColumnOneShot              *collectionTypedColumnOneShotCacheEntry
+	typedColumnOneShot              map[collectionTypedColumnOneShotCacheSlot]*collectionTypedColumnOneShotCacheEntry
+	typedColumnOneShotClock         uint64
 	typedColumnOneShotHits          uint64
 	typedColumnOneShotMisses        uint64
 	typedColumnOneShotBuilds        uint64

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -1331,6 +1331,7 @@ func (m *CollectionManager) closeForBackend() error {
 		}
 	}()
 	m.stopUpdateCombiners()
+	m.closeCollectionTypedColumnOneShotCaches()
 	cacheErr := m.closeCollectionVectorIndexPreparedSearchCaches()
 	flushErr := m.FlushAll()
 	return errors.Join(cacheErr, flushErr)

--- a/TreeDB/collections/collection_vector_index_prepared_search_cache.go
+++ b/TreeDB/collections/collection_vector_index_prepared_search_cache.go
@@ -1135,7 +1135,7 @@ func (c *Collection) closeCollectionVectorIndexPreparedSearchCache() error {
 			closeErr = errors.Join(closeErr, entry.prepared.Close())
 		}
 	}
-	if c.manager != nil && !c.hasDirtyNativeVectorIndex() {
+	if c.manager != nil && !c.hasDirtyNativeVectorIndex() && !c.hasCollectionTypedColumnOneShotCacheEntries() {
 		c.manager.unregisterCollectionHandle(c)
 	}
 	return closeErr

--- a/TreeDB/collections/column_physical_q2_1950_test.go
+++ b/TreeDB/collections/column_physical_q2_1950_test.go
@@ -136,7 +136,7 @@ func TestTypedColumnQ2DenseGroupCountDistinctNoSortLocalDictionaries1950(t *test
 		t.Fatalf("RunColumnPhysicalQuery(q2 dense no-sort): %v", err)
 	}
 	assertTypedColumnQ2SortedGroupedDistinctResult1950(t, "dense no-sort", direct, rowHash, want)
-	assertTypedColumnQ2DenseGroupCountDistinctDiagnostics1950(t, "dense no-sort", direct.Diagnostics, len(events), matchedRows, columnTypedColumnDenseGroupCountDistinctReducerLocalBitset)
+	assertTypedColumnQ2DenseGroupCountDistinctDiagnostics1950(t, "dense no-sort", direct.Diagnostics, len(events), matchedRows, columnTypedColumnDenseGroupCountDistinctReducerPairBitset)
 
 	runner, err := col.PrepareColumnPhysicalQuery(req)
 	if err != nil {

--- a/TreeDB/collections/column_physical_q4a_time_order_1950_test.go
+++ b/TreeDB/collections/column_physical_q4a_time_order_1950_test.go
@@ -108,8 +108,8 @@ func TestColumnPhysicalQ4ATimeOrderTopKOneShotCache3085(t *testing.T) {
 		t.Fatalf("third one-shot topK=2 diagnostics=%+v want time-order topK=%d candidates=%d groups=%d", third.Diagnostics, smallerTopK.TopK, smallerCandidates, len(smallerWant))
 	}
 	snapshot = col.typedColumnOneShotCacheSnapshotForTest()
-	if snapshot.Entries != 1 || snapshot.CacheMisses != 2 || snapshot.CacheBuilds != 2 || snapshot.CacheHits != 1 || snapshot.Invalidations != 1 {
-		t.Fatalf("cache after topK change=%+v want invalidation and rebuild", snapshot)
+	if snapshot.Entries != 2 || snapshot.CacheMisses != 2 || snapshot.CacheBuilds != 2 || snapshot.CacheHits != 1 || snapshot.Invalidations != 0 {
+		t.Fatalf("cache after topK change=%+v want retained prior entry and new build", snapshot)
 	}
 }
 

--- a/TreeDB/collections/column_physical_typed_column_cache.go
+++ b/TreeDB/collections/column_physical_typed_column_cache.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
 )
 
 const collectionTypedColumnOneShotCacheMaxEntries = 8
@@ -42,6 +44,30 @@ type collectionTypedColumnOneShotCacheSnapshot struct {
 	Invalidations uint64
 }
 
+func (entry *collectionTypedColumnOneShotCacheEntry) run(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest) (ColumnPhysicalQueryResult, error) {
+	if entry == nil {
+		return ColumnPhysicalQueryResult{}, backenddb.ErrClosed
+	}
+	entry.mu.Lock()
+	defer entry.mu.Unlock()
+	if entry.runner == nil {
+		return ColumnPhysicalQueryResult{}, backenddb.ErrClosed
+	}
+	return entry.runner.run(view, req)
+}
+
+func (entry *collectionTypedColumnOneShotCacheEntry) close() {
+	if entry == nil {
+		return
+	}
+	entry.mu.Lock()
+	defer entry.mu.Unlock()
+	if entry.runner != nil {
+		entry.runner.close()
+		entry.runner = nil
+	}
+}
+
 func (c *Collection) runColumnTypedColumnOneShotWithCache(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest, plan columnTypedColumnPhysicalQueryPlan, start time.Time) (ColumnPhysicalQueryResult, bool, error) {
 	if c == nil || view.MutationParts != 0 {
 		return ColumnPhysicalQueryResult{}, false, nil
@@ -58,9 +84,7 @@ func (c *Collection) runColumnTypedColumnOneShotWithCache(view columnPhysicalSca
 		c.typedColumnOneShotClock++
 		entry.lastUse = c.typedColumnOneShotClock
 		c.typedColumnOneShotMu.Unlock()
-		entry.mu.Lock()
-		result, err := entry.runner.run(view, req)
-		entry.mu.Unlock()
+		result, err := entry.run(view, req)
 		result.Diagnostics.ScanNanos = time.Since(start).Nanoseconds()
 		return result, true, err
 	}
@@ -96,36 +120,49 @@ func (c *Collection) runColumnTypedColumnOneShotWithCache(view columnPhysicalSca
 		c.typedColumnOneShotClock++
 		current.lastUse = c.typedColumnOneShotClock
 		c.typedColumnOneShotMu.Unlock()
-		current.mu.Lock()
-		result, err := current.runner.run(view, req)
-		current.mu.Unlock()
+		entry.close()
+		result, err := current.run(view, req)
 		result.Diagnostics.ScanNanos = time.Since(start).Nanoseconds()
 		return result, true, err
 	}
+	var evicted *collectionTypedColumnOneShotCacheEntry
 	if len(c.typedColumnOneShot) >= collectionTypedColumnOneShotCacheMaxEntries {
-		collectionTypedColumnOneShotEvictOldest(c.typedColumnOneShot)
+		evicted = collectionTypedColumnOneShotEvictOldest(c.typedColumnOneShot)
 		c.typedColumnOneShotInvalidations++
 	}
 	c.typedColumnOneShotClock++
 	entry.lastUse = c.typedColumnOneShotClock
 	c.typedColumnOneShot[slot] = entry
 	c.typedColumnOneShotMu.Unlock()
+	if evicted != nil {
+		evicted.close()
+	}
+	if c.manager != nil && !c.manager.registerCollectionHandleIfOpen(c) {
+		c.typedColumnOneShotMu.Lock()
+		if c.typedColumnOneShot[slot] == entry {
+			delete(c.typedColumnOneShot, slot)
+			c.typedColumnOneShotInvalidations++
+		}
+		c.typedColumnOneShotMu.Unlock()
+		entry.close()
+		result := ColumnPhysicalQueryResult{}
+		result.Diagnostics.ScanNanos = time.Since(start).Nanoseconds()
+		return result, true, backenddb.ErrClosed
+	}
 
-	entry.mu.Lock()
-	result, err := entry.runner.run(view, req)
-	entry.mu.Unlock()
+	result, err := entry.run(view, req)
 	result.Diagnostics.ScanNanos = time.Since(start).Nanoseconds()
 	return result, true, err
 }
 
-func collectionTypedColumnOneShotEvictOldest(entries map[collectionTypedColumnOneShotCacheSlot]*collectionTypedColumnOneShotCacheEntry) {
+func collectionTypedColumnOneShotEvictOldest(entries map[collectionTypedColumnOneShotCacheSlot]*collectionTypedColumnOneShotCacheEntry) *collectionTypedColumnOneShotCacheEntry {
 	var oldestSlot collectionTypedColumnOneShotCacheSlot
 	var oldestUse uint64
 	haveOldest := false
 	for slot, entry := range entries {
 		if entry == nil {
 			delete(entries, slot)
-			return
+			return nil
 		}
 		if !haveOldest || entry.lastUse < oldestUse {
 			oldestSlot = slot
@@ -134,7 +171,57 @@ func collectionTypedColumnOneShotEvictOldest(entries map[collectionTypedColumnOn
 		}
 	}
 	if haveOldest {
+		entry := entries[oldestSlot]
 		delete(entries, oldestSlot)
+		return entry
+	}
+	return nil
+}
+
+func (c *Collection) hasCollectionTypedColumnOneShotCacheEntries() bool {
+	if c == nil {
+		return false
+	}
+	c.typedColumnOneShotMu.Lock()
+	defer c.typedColumnOneShotMu.Unlock()
+	return len(c.typedColumnOneShot) > 0
+}
+
+func (c *Collection) closeCollectionTypedColumnOneShotCache() {
+	if c == nil {
+		return
+	}
+	var entries []*collectionTypedColumnOneShotCacheEntry
+	c.typedColumnOneShotMu.Lock()
+	for _, entry := range c.typedColumnOneShot {
+		if entry != nil {
+			entries = append(entries, entry)
+		}
+	}
+	c.typedColumnOneShot = nil
+	c.typedColumnOneShotMu.Unlock()
+	for _, entry := range entries {
+		entry.close()
+	}
+	if c.manager != nil && !c.hasDirtyNativeVectorIndex() && !c.hasCollectionVectorIndexPreparedSearchCacheEntries() {
+		c.manager.unregisterCollectionHandle(c)
+	}
+}
+
+func (m *CollectionManager) closeCollectionTypedColumnOneShotCaches() {
+	if m == nil {
+		return
+	}
+	m.collectionsMu.RLock()
+	collections := make([]*Collection, 0, len(m.collections))
+	for collection := range m.collections {
+		if collection != nil {
+			collections = append(collections, collection)
+		}
+	}
+	m.collectionsMu.RUnlock()
+	for _, collection := range collections {
+		collection.closeCollectionTypedColumnOneShotCache()
 	}
 }
 

--- a/TreeDB/collections/column_physical_typed_column_cache.go
+++ b/TreeDB/collections/column_physical_typed_column_cache.go
@@ -7,6 +7,8 @@ import (
 	"time"
 )
 
+const collectionTypedColumnOneShotCacheMaxEntries = 8
+
 type collectionTypedColumnOneShotCacheSlot struct {
 	commitSeq                uint64
 	systemRoot               uint64
@@ -26,9 +28,10 @@ type collectionTypedColumnOneShotCacheSlot struct {
 }
 
 type collectionTypedColumnOneShotCacheEntry struct {
-	slot   collectionTypedColumnOneShotCacheSlot
-	runner *columnTypedColumnPhysicalQueryRunner
-	mu     sync.Mutex
+	slot    collectionTypedColumnOneShotCacheSlot
+	runner  *columnTypedColumnPhysicalQueryRunner
+	mu      sync.Mutex
+	lastUse uint64
 }
 
 type collectionTypedColumnOneShotCacheSnapshot struct {
@@ -49,19 +52,17 @@ func (c *Collection) runColumnTypedColumnOneShotWithCache(view columnPhysicalSca
 	slot := collectionTypedColumnOneShotCacheSlotFor(view, req)
 
 	c.typedColumnOneShotMu.Lock()
-	entry := c.typedColumnOneShot
-	if entry != nil && entry.slot == slot {
+	entry := c.typedColumnOneShot[slot]
+	if entry != nil {
 		c.typedColumnOneShotHits++
+		c.typedColumnOneShotClock++
+		entry.lastUse = c.typedColumnOneShotClock
 		c.typedColumnOneShotMu.Unlock()
 		entry.mu.Lock()
 		result, err := entry.runner.run(view, req)
 		entry.mu.Unlock()
 		result.Diagnostics.ScanNanos = time.Since(start).Nanoseconds()
 		return result, true, err
-	}
-	if entry != nil {
-		c.typedColumnOneShotInvalidations++
-		c.typedColumnOneShot = nil
 	}
 	c.typedColumnOneShotMisses++
 	c.typedColumnOneShotBuilds++
@@ -76,7 +77,9 @@ func (c *Collection) runColumnTypedColumnOneShotWithCache(view columnPhysicalSca
 	readCache.returnViews = true
 	defer func() { _ = readCache.close() }()
 
-	runner, candidate, err := prepareColumnTypedColumnPhysicalQueryRunner(view, req, &readCache, false)
+	runner, candidate, err := prepareColumnTypedColumnPhysicalQueryRunnerWithOptions(view, req, &readCache, columnTypedColumnPhysicalQueryRunnerPrepareOptions{
+		prepareDenseGroupCountDistinctGlobalCodes: columnTypedColumnPhysicalQueryUseDenseGroupCountDistinct(plan, req),
+	})
 	if err != nil || !candidate {
 		result := ColumnPhysicalQueryResult{}
 		result.Diagnostics.ScanNanos = time.Since(start).Nanoseconds()
@@ -85,10 +88,27 @@ func (c *Collection) runColumnTypedColumnOneShotWithCache(view columnPhysicalSca
 	entry = &collectionTypedColumnOneShotCacheEntry{slot: slot, runner: runner}
 
 	c.typedColumnOneShotMu.Lock()
-	if current := c.typedColumnOneShot; current != nil && current.slot != slot {
+	if c.typedColumnOneShot == nil {
+		c.typedColumnOneShot = make(map[collectionTypedColumnOneShotCacheSlot]*collectionTypedColumnOneShotCacheEntry, collectionTypedColumnOneShotCacheMaxEntries)
+	}
+	if current := c.typedColumnOneShot[slot]; current != nil {
+		c.typedColumnOneShotHits++
+		c.typedColumnOneShotClock++
+		current.lastUse = c.typedColumnOneShotClock
+		c.typedColumnOneShotMu.Unlock()
+		current.mu.Lock()
+		result, err := current.runner.run(view, req)
+		current.mu.Unlock()
+		result.Diagnostics.ScanNanos = time.Since(start).Nanoseconds()
+		return result, true, err
+	}
+	if len(c.typedColumnOneShot) >= collectionTypedColumnOneShotCacheMaxEntries {
+		collectionTypedColumnOneShotEvictOldest(c.typedColumnOneShot)
 		c.typedColumnOneShotInvalidations++
 	}
-	c.typedColumnOneShot = entry
+	c.typedColumnOneShotClock++
+	entry.lastUse = c.typedColumnOneShotClock
+	c.typedColumnOneShot[slot] = entry
 	c.typedColumnOneShotMu.Unlock()
 
 	entry.mu.Lock()
@@ -96,6 +116,26 @@ func (c *Collection) runColumnTypedColumnOneShotWithCache(view columnPhysicalSca
 	entry.mu.Unlock()
 	result.Diagnostics.ScanNanos = time.Since(start).Nanoseconds()
 	return result, true, err
+}
+
+func collectionTypedColumnOneShotEvictOldest(entries map[collectionTypedColumnOneShotCacheSlot]*collectionTypedColumnOneShotCacheEntry) {
+	var oldestSlot collectionTypedColumnOneShotCacheSlot
+	var oldestUse uint64
+	haveOldest := false
+	for slot, entry := range entries {
+		if entry == nil {
+			delete(entries, slot)
+			return
+		}
+		if !haveOldest || entry.lastUse < oldestUse {
+			oldestSlot = slot
+			oldestUse = entry.lastUse
+			haveOldest = true
+		}
+	}
+	if haveOldest {
+		delete(entries, oldestSlot)
+	}
 }
 
 func (c *Collection) runColumnPhysicalQueryTypedColumnOneShotInSnapshotView(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest) (ColumnPhysicalQueryResult, bool, error) {
@@ -175,7 +215,7 @@ func (c *Collection) typedColumnOneShotCacheSnapshotForTest() collectionTypedCol
 		Invalidations: c.typedColumnOneShotInvalidations,
 	}
 	if c.typedColumnOneShot != nil {
-		snapshot.Entries = 1
+		snapshot.Entries = len(c.typedColumnOneShot)
 	}
 	return snapshot
 }

--- a/TreeDB/collections/column_physical_typed_column_one_shot_cache_3088_test.go
+++ b/TreeDB/collections/column_physical_typed_column_one_shot_cache_3088_test.go
@@ -35,14 +35,21 @@ func TestColumnPhysicalTypedColumnOneShotCacheQ1Q3NoMetadata3088(t *testing.T) {
 		t.Fatalf("first RunColumnPhysicalQuery(q3): %v", err)
 	}
 	assertColumnPhysicalQ3DenseResult1950(t, "q3 first one-shot", q3First, q3Want, len(events), q3MatchedRows, q3MatchedRows)
-	assertTypedColumnOneShotCacheSnapshot3088(t, col, "after q3 first", 1, 1, 2, 2, 1)
+	assertTypedColumnOneShotCacheSnapshot3088(t, col, "after q3 first", 2, 1, 2, 2, 0)
 
 	q3Second, err := col.RunColumnPhysicalQuery(q3Req)
 	if err != nil {
 		t.Fatalf("second RunColumnPhysicalQuery(q3): %v", err)
 	}
 	assertColumnPhysicalQ3DenseResult1950(t, "q3 second one-shot", q3Second, q3Want, len(events), q3MatchedRows, q3MatchedRows)
-	assertTypedColumnOneShotCacheSnapshot3088(t, col, "after q3 second", 1, 2, 2, 2, 1)
+	assertTypedColumnOneShotCacheSnapshot3088(t, col, "after q3 second", 2, 2, 2, 2, 0)
+
+	q1Third, err := col.RunColumnPhysicalQuery(q1Req)
+	if err != nil {
+		t.Fatalf("third RunColumnPhysicalQuery(q1): %v", err)
+	}
+	assertColumnPhysicalQ1DenseResult1950(t, "q1 third one-shot", q1Third, q1Want, len(events), len(events))
+	assertTypedColumnOneShotCacheSnapshot3088(t, col, "after q1 third", 2, 3, 2, 2, 0)
 }
 
 func TestColumnPhysicalTypedColumnOneShotCacheQ5NoMetadata3088(t *testing.T) {
@@ -69,6 +76,42 @@ func TestColumnPhysicalTypedColumnOneShotCacheQ5NoMetadata3088(t *testing.T) {
 	}
 	assertColumnPhysicalQ5DenseResult1950(t, "q5 second one-shot", second, want, len(events), matchedRows, columnTypedColumnDenseInt64SpanReducerLocalMap)
 	assertTypedColumnOneShotCacheSnapshot3088(t, col, "after q5 second", 1, 1, 1, 1, 0)
+}
+
+func TestColumnPhysicalTypedColumnOneShotCacheQ2NoMetadata3123(t *testing.T) {
+	batches := [][]columnPhysicalJSONBenchParityEventP0{typedColumnQ2LocalDictBatchA1950(), typedColumnQ2LocalDictBatchB1950()}
+	events := flattenColumnPhysicalEvents1950(batches)
+	_, col, closeFn := openTypedColumnSortKeyFixtureBatches1950(t, nil, batches)
+	defer closeFn()
+
+	req := typedColumnQ2Request1950()
+	rowHash := columnPhysicalJSONBenchHashLinesP0(columnPhysicalJSONBenchReferenceLinesP0("q2", events))
+	want := columnPhysicalJSONBenchQ2ReferenceCountsP0(events)
+	matchedRows := columnPhysicalJSONBenchReferenceMatchedRowsP0("q2", events)
+
+	first, err := col.RunColumnPhysicalQuery(req)
+	if err != nil {
+		t.Fatalf("first RunColumnPhysicalQuery(q2): %v", err)
+	}
+	assertTypedColumnQ2SortedGroupedDistinctResult1950(t, "q2 first one-shot", first, rowHash, want)
+	assertTypedColumnQ2DenseGroupCountDistinctDiagnostics1950(t, "q2 first one-shot", first.Diagnostics, len(events), matchedRows, columnTypedColumnDenseGroupCountDistinctReducerPairBitset)
+	assertTypedColumnOneShotCacheSnapshot3088(t, col, "after q2 first", 1, 0, 1, 1, 0)
+
+	q1Req := ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCount, GroupColumn: "collection"}
+	q1, err := col.RunColumnPhysicalQuery(q1Req)
+	if err != nil {
+		t.Fatalf("RunColumnPhysicalQuery(q1 between q2 runs): %v", err)
+	}
+	assertColumnPhysicalQ1DenseResult1950(t, "q1 between q2 runs", q1, rowScanCollectionCounts1950(t, col, len(events)), len(events), len(events))
+	assertTypedColumnOneShotCacheSnapshot3088(t, col, "after q1 between q2 runs", 2, 0, 2, 2, 0)
+
+	second, err := col.RunColumnPhysicalQuery(req)
+	if err != nil {
+		t.Fatalf("second RunColumnPhysicalQuery(q2): %v", err)
+	}
+	assertTypedColumnQ2SortedGroupedDistinctResult1950(t, "q2 second one-shot", second, rowHash, want)
+	assertTypedColumnQ2DenseGroupCountDistinctDiagnostics1950(t, "q2 second one-shot", second.Diagnostics, len(events), matchedRows, columnTypedColumnDenseGroupCountDistinctReducerPairBitset)
+	assertTypedColumnOneShotCacheSnapshot3088(t, col, "after q2 second", 2, 1, 2, 2, 0)
 }
 
 func assertTypedColumnOneShotCacheSnapshot3088(tb testing.TB, col *Collection, label string, entries int, hits uint64, misses uint64, builds uint64, invalidations uint64) {

--- a/TreeDB/collections/column_physical_typed_column_query.go
+++ b/TreeDB/collections/column_physical_typed_column_query.go
@@ -189,6 +189,32 @@ type columnTypedColumnPhysicalAggregateSummary struct {
 	denseGroupHourCount bool
 }
 
+func (r *columnTypedColumnPhysicalQueryRunner) close() {
+	if r == nil {
+		return
+	}
+	r.parts = nil
+	r.aggregateSummary = nil
+	r.denseGroupCounts = nil
+	r.denseLocalCounts = nil
+	r.denseGroupCountDistinctCounts = nil
+	r.denseGroupCountDistinctDistinctCounts = nil
+	r.denseGroupCountDistinctPairBits = nil
+	r.denseGroupCountDistinctGroupActive = nil
+	r.denseGroupCountDistinctGroupOffsets = nil
+	r.denseGroupCountDistinctActiveGroups = nil
+	r.denseGroupCountDistinctPairList = nil
+	r.denseGroupHourCounts = nil
+	r.denseLocalHourCounts = nil
+	r.denseSpanValues = nil
+	r.denseLocalSpans = nil
+	r.denseLocalSpanSeen = nil
+	r.timeOrderMinValues = nil
+	r.timeOrderHeap.items = nil
+	r.timeOrderTopKScratch = nil
+	r.resultGroups = nil
+}
+
 func (c *Collection) runColumnPhysicalQueryTypedColumnPartInSnapshotView(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest) (ColumnPhysicalQueryResult, bool, error) {
 	if !columnTypedColumnPhysicalQueryTouchesTypedColumnPart(view.FullConfig, req) {
 		return ColumnPhysicalQueryResult{}, false, nil
@@ -2965,6 +2991,7 @@ func (r *columnTypedColumnPhysicalQueryRunner) runDenseGroupCountDistinctLocalCo
 		}
 		leftPredicateCodes, rightPredicateCodes, leftPredicateCode, rightPredicateCode, useTwoSinglePredicates := columnTypedColumnDenseTwoSingleCodePredicates(dense.Predicates, dense.Rows)
 		if usePairBitset && useTwoSinglePredicates && dense.Group.Valid == nil && dense.Distinct.Valid == nil {
+			reducer = columnTypedColumnDenseGroupCountDistinctReducerPairBitset
 			for rowIdx := 0; rowIdx < dense.Rows; rowIdx++ {
 				rowsScanned++
 				if leftPredicateCodes[rowIdx] != leftPredicateCode || rightPredicateCodes[rowIdx] != rightPredicateCode {

--- a/TreeDB/collections/column_physical_typed_column_query.go
+++ b/TreeDB/collections/column_physical_typed_column_query.go
@@ -392,7 +392,21 @@ func applyTypedColumnLatestVisibilityDiagnostics(diag *ColumnPhysicalQueryDiagno
 	diag.VisibilityNanos = visibilityNanos
 }
 
+type columnTypedColumnPhysicalQueryRunnerPrepareOptions struct {
+	prepareAggregateSummaries                 bool
+	prepareDenseInt64SpanGlobalCodes          bool
+	prepareDenseGroupCountDistinctGlobalCodes bool
+}
+
 func prepareColumnTypedColumnPhysicalQueryRunner(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest, readCache *columnPhysicalAssetReadCache, prepareSummaries bool) (*columnTypedColumnPhysicalQueryRunner, bool, error) {
+	return prepareColumnTypedColumnPhysicalQueryRunnerWithOptions(view, req, readCache, columnTypedColumnPhysicalQueryRunnerPrepareOptions{
+		prepareAggregateSummaries:                 prepareSummaries,
+		prepareDenseInt64SpanGlobalCodes:          prepareSummaries,
+		prepareDenseGroupCountDistinctGlobalCodes: prepareSummaries,
+	})
+}
+
+func prepareColumnTypedColumnPhysicalQueryRunnerWithOptions(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest, readCache *columnPhysicalAssetReadCache, opts columnTypedColumnPhysicalQueryRunnerPrepareOptions) (*columnTypedColumnPhysicalQueryRunner, bool, error) {
 	if !columnTypedColumnPhysicalQueryTouchesTypedColumnPart(view.FullConfig, req) {
 		return nil, false, nil
 	}
@@ -420,11 +434,11 @@ func prepareColumnTypedColumnPhysicalQueryRunner(view columnPhysicalScanSnapshot
 	if _, err := validateTypedColumnPhysicalAssetPairing(refsByGeneration, view.AssetRefs); err != nil {
 		return nil, true, typedColumnPhysicalQueryPairingError(err)
 	}
-	runner, err := decodeColumnTypedColumnPhysicalQueryRunnerParts(view, req, plan, refsByGeneration, readCache, false, prepareSummaries, prepareSummaries)
+	runner, err := decodeColumnTypedColumnPhysicalQueryRunnerParts(view, req, plan, refsByGeneration, readCache, false, opts.prepareDenseInt64SpanGlobalCodes, opts.prepareDenseGroupCountDistinctGlobalCodes)
 	if err != nil {
 		return nil, true, err
 	}
-	if prepareSummaries {
+	if opts.prepareAggregateSummaries {
 		if err := prepareColumnTypedColumnPhysicalAggregateSummary(runner, req); err != nil {
 			return nil, true, err
 		}
@@ -2947,6 +2961,51 @@ func (r *columnTypedColumnPhysicalQueryRunner) runDenseGroupCountDistinctLocalCo
 		}
 		if columnTypedColumnDensePredicatesRejectAll(dense.Predicates) {
 			rowsScanned += dense.Rows
+			continue
+		}
+		leftPredicateCodes, rightPredicateCodes, leftPredicateCode, rightPredicateCode, useTwoSinglePredicates := columnTypedColumnDenseTwoSingleCodePredicates(dense.Predicates, dense.Rows)
+		if usePairBitset && useTwoSinglePredicates && dense.Group.Valid == nil && dense.Distinct.Valid == nil {
+			for rowIdx := 0; rowIdx < dense.Rows; rowIdx++ {
+				rowsScanned++
+				if leftPredicateCodes[rowIdx] != leftPredicateCode || rightPredicateCodes[rowIdx] != rightPredicateCode {
+					continue
+				}
+				matchedRows++
+				reduceRows++
+				groupLocalCode := dense.Group.Codes[rowIdx]
+				if uint64(groupLocalCode) >= uint64(len(groupLocalRanks)) {
+					diag := r.diagnostics(view, req, rowsScanned, matchedRows, reduceRows, time.Since(start).Nanoseconds())
+					diag.DenseGroupCountDistinctUsed = true
+					return ColumnPhysicalQueryResult{Diagnostics: diag}, fmt.Errorf("collections: dense typed-column grouped count-distinct part %d group code[%d]=%d outside cardinality=%d", partIdx, rowIdx, groupLocalCode, len(groupLocalRanks))
+				}
+				groupCode := groupLocalRanks[groupLocalCode]
+				groupIdx, ok := columnDictionaryCodeIndex(groupCode, len(r.denseGroupCountDistinctCounts))
+				if !ok {
+					diag := r.diagnostics(view, req, rowsScanned, matchedRows, reduceRows, time.Since(start).Nanoseconds())
+					diag.DenseGroupCountDistinctUsed = true
+					return ColumnPhysicalQueryResult{Diagnostics: diag}, fmt.Errorf("collections: dense typed-column grouped count-distinct part %d group rank[%d]=%d outside cardinality=%d", partIdx, rowIdx, groupCode, len(r.denseGroupCountDistinctCounts))
+				}
+				r.denseGroupCountDistinctCounts[groupIdx]++
+				distinctLocalCode := dense.Distinct.Codes[rowIdx]
+				if uint64(distinctLocalCode) >= uint64(len(distinctLocalRanks)) {
+					diag := r.diagnostics(view, req, rowsScanned, matchedRows, reduceRows, time.Since(start).Nanoseconds())
+					diag.DenseGroupCountDistinctUsed = true
+					return ColumnPhysicalQueryResult{Diagnostics: diag}, fmt.Errorf("collections: dense typed-column grouped count-distinct part %d distinct code[%d]=%d outside cardinality=%d", partIdx, rowIdx, distinctLocalCode, len(distinctLocalRanks))
+				}
+				distinctCode := distinctLocalRanks[distinctLocalCode]
+				distinctIdx, ok := columnDictionaryCodeIndex(distinctCode, distinctCardinality)
+				if !ok {
+					diag := r.diagnostics(view, req, rowsScanned, matchedRows, reduceRows, time.Since(start).Nanoseconds())
+					diag.DenseGroupCountDistinctUsed = true
+					return ColumnPhysicalQueryResult{Diagnostics: diag}, fmt.Errorf("collections: dense typed-column grouped count-distinct part %d distinct rank[%d]=%d outside cardinality=%d", partIdx, rowIdx, distinctCode, distinctCardinality)
+				}
+				wordIdx := groupIdx*wordsPerGroup + distinctIdx/64
+				mask := uint64(1) << uint(distinctIdx&63)
+				if r.denseGroupCountDistinctPairBits[wordIdx]&mask == 0 {
+					r.denseGroupCountDistinctPairBits[wordIdx] |= mask
+					r.denseGroupCountDistinctDistinctCounts[groupIdx]++
+				}
+			}
 			continue
 		}
 		for rowIdx := 0; rowIdx < dense.Rows; rowIdx++ {

--- a/TreeDB/collections/column_physical_typed_column_range_3090_test.go
+++ b/TreeDB/collections/column_physical_typed_column_range_3090_test.go
@@ -46,7 +46,7 @@ func TestColumnPhysicalDenseTypedColumnTargetedRangeReads3090(t *testing.T) {
 			t.Fatalf("RunColumnPhysicalQuery(q2 verify): %v", err)
 		}
 		assertTypedColumnQ2SortedGroupedDistinctResult1950(t, "q2 verify", full, rowHash, want)
-		assertTypedColumnQ2DenseGroupCountDistinctDiagnostics1950(t, "q2 verify", full.Diagnostics, len(events), matchedRows, columnTypedColumnDenseGroupCountDistinctReducerLocalBitset)
+		assertTypedColumnQ2DenseGroupCountDistinctDiagnostics1950(t, "q2 verify", full.Diagnostics, len(events), matchedRows, columnTypedColumnDenseGroupCountDistinctReducerPairBitset)
 
 		req.ColumnAssetReadIntegrity = ColumnAssetReadIntegritySkipChecksums
 		ranged, err := col.RunColumnPhysicalQuery(req)
@@ -54,7 +54,7 @@ func TestColumnPhysicalDenseTypedColumnTargetedRangeReads3090(t *testing.T) {
 			t.Fatalf("RunColumnPhysicalQuery(q2 skip checksums): %v", err)
 		}
 		assertTypedColumnQ2SortedGroupedDistinctResult1950(t, "q2 targeted ranges", ranged, rowHash, want)
-		assertTypedColumnQ2DenseGroupCountDistinctDiagnostics1950(t, "q2 targeted ranges", ranged.Diagnostics, len(events), matchedRows, columnTypedColumnDenseGroupCountDistinctReducerLocalBitset)
+		assertTypedColumnQ2DenseGroupCountDistinctDiagnostics1950(t, "q2 targeted ranges", ranged.Diagnostics, len(events), matchedRows, columnTypedColumnDenseGroupCountDistinctReducerPairBitset)
 		assertColumnPhysicalTargetedRangeBytes3090(t, "q2", full.Diagnostics, ranged.Diagnostics)
 	})
 

--- a/TreeDB/collections/vector_index.go
+++ b/TreeDB/collections/vector_index.go
@@ -900,7 +900,7 @@ func (c *Collection) persistDirtyNativeVectorIndexes() error {
 			return err
 		}
 	}
-	if c.manager != nil && !c.hasDirtyNativeVectorIndex() && !c.hasCollectionVectorIndexPreparedSearchCacheEntries() {
+	if c.manager != nil && !c.hasDirtyNativeVectorIndex() && !c.hasCollectionVectorIndexPreparedSearchCacheEntries() && !c.hasCollectionTypedColumnOneShotCacheEntries() {
 		c.manager.unregisterCollectionHandle(c)
 	}
 	return nil


### PR DESCRIPTION
Refs #3123
Refs #3070
Refs #3001
Refs #3000

## Scope

This PR improves the TreeDB JSONBench q2 production-shaped path:

- query mode: `one_shot_end_to_end`
- metadata mode: `no_aggregate_metadata` and `auto_aggregate_metadata` when q2 does not use aggregate metadata
- path: typed-column dense group-count-distinct over `typed_column_part_section`

It does not improve insert/load speed, metadata storage cost, first-touch setup cost, or prove broad SQL superiority. The first-touch q2 setup cost remains an open parent-tracker gap.

## Changes

- Make the collection typed-column one-shot cache hold multiple query slots instead of evicting the previous q1/q2/q3/q4/q5 entry on every different request.
- Prepare q2 dense group-count-distinct global code arrays for the internal one-shot cache without enabling q1/q3 aggregate summaries.
- Keep the no-aggregate path scanning typed column cells; q2 still reports 1M rows scanned/reduced through `typed_column_part_section`, with no row/document materialization and no JSON reconstruction.
- Add/adjust tests for q2 cache retention, q2 global pair-bitset diagnostics, and q4a TopK cache-key coexistence.

## Evidence

Focused/unit tests:

```sh
go test ./TreeDB/collections -run 'TestColumnPhysicalTypedColumnOneShotCache(Q1Q3NoMetadata3088|Q2NoMetadata3123|Q5NoMetadata3088)$|TestColumnPhysicalQ4ATimeOrderTopKOneShotCache3085$|TestTypedColumnQ2(DenseGroupCountDistinctNoSortLocalDictionaries1950|DenseGroupCountDistinctLocalCodesNullableValues3080|DenseGroupCountDistinctActiveGroupBitset1950)$' -count=1

go test ./TreeDB/collections -run 'TestTypedColumnQ2|TestColumnPhysicalTypedColumnOneShotCache|TestColumnPhysicalQ4ATimeOrderTopKOneShotCache' -count=1

go test ./TreeDB/collections -run 'TestColumnPhysicalDenseTypedColumnTargetedRangeReads3090|TestColumnPhysicalTypedColumnOneShotCache|TestTypedColumnQ2' -count=1

go test ./TreeDB/collections -count=1

git diff --check
```

Microbench:

```sh
go test ./TreeDB/collections -run '^$' \
  -bench 'BenchmarkTypedColumnQ2SortedGroupedDistinct1950/(direct|prepared)/(sorted_prefix|primary_id_fallback)$' \
  -benchtime=5x -count=3 -benchmem
```

1M preferred TreeDB vs ClickHouse artifact:

- `/tmp/jsonbench_preferred_q2_3123_globalcodes_20260627_004123/preferred_summary.md`
- TreeDB report: `/tmp/jsonbench_preferred_q2_3123_globalcodes_20260627_004123/treedb/report.json`
- ClickHouse report: `/tmp/jsonbench_preferred_q2_3123_globalcodes_20260627_004123/clickhouse/result.json`

q2 standard comparison row, full-retained `column-store-full-prepared`:

| system | query mode | metadata mode | best | median | loaded rows | scanned/reduced | materialization | aggregate metadata | JSON reconstruction | storage | load | insert |
|---|---|---|---:|---:|---:|---:|---|---|---|---:|---:|---:|
| TreeDB | `one_shot_end_to_end` | `no_aggregate_metadata` | `0.007216708s` | `0.007892458s` | `1,000,000` | `1,000,000 / 954,611` | row `0`, doc `0` | no | no | `137,491,619` bytes | `19.399127417s` | `16.252901204s` |
| ClickHouse JSON | `clickhouse_local_sql_end_to_end` | `no_projection_or_materialized_summary` | `0.0230s` | `0.0250s` | `1,000,000` | `1,000,000` | n/a | no | `JSONAsObject` | `97.37 MiB` | `4.877s` | n/a |

Auto-metadata q2 guardrail:

- Artifact: `/tmp/jsonbench_treedb_q2_3123_auto_20260627_004650/report.json`
- q2 best/median: `0.007286125s` / `0.007329583s`
- q2 still uses `typed_column_part_section`, scans `1,000,000` rows, reduces `954,611`, and does not use aggregate metadata.

First-touch caveat:

- Artifact: `/tmp/jsonbench_treedb_q2_3123_firsttouch_20260627_004022/report.json`
- q2 `first_touch_after_open` / `no_aggregate_metadata`: `0.205211083s`
- The preferred one-shot attempts were `0.205628s, 0.007216708s, 0.007892458s`, so this PR materially improves normal repeated one-shot submissions through an internal production cache, but does not solve first-touch setup cost.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Typed-column queries now keep multiple cached results, improving reuse across different query patterns.
  * Added support for a more efficient path when running certain dense group-count distinct queries.

* **Bug Fixes**
  * Cache behavior now preserves earlier results more reliably instead of replacing them too early.
  * Query diagnostics and expected results were updated for several typed-column scenarios.

* **Tests**
  * Expanded test coverage for typed-column caching, distinct counts, and targeted range reads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->