### PR TITLE
TreeDB: tolerate command-WAL writes during shutdown

### DIFF
--- a/TreeDB/caching/checkpoint_test.go
+++ b/TreeDB/caching/checkpoint_test.go
@@ -2,6 +2,7 @@ package caching
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -9,6 +10,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
 )
 
 func countCommitLogFiles(entries []os.DirEntry) int {
@@ -103,12 +106,15 @@ func TestCachingDB_DirectWriteGateRechecksCheckpointAfterPublicWait(t *testing.T
 	db.checkpointMu.Unlock()
 
 	acquired := make(chan struct{})
-	done := make(chan struct{})
+	done := make(chan error, 1)
 	go func() {
-		db.beginDirectWrite()
+		if err := db.beginDirectWrite(); err != nil {
+			done <- err
+			return
+		}
 		close(acquired)
 		db.writeMu.RUnlock()
-		close(done)
+		done <- nil
 	}()
 
 	select {
@@ -123,9 +129,52 @@ func TestCachingDB_DirectWriteGateRechecksCheckpointAfterPublicWait(t *testing.T
 	db.checkpointMu.Unlock()
 
 	select {
-	case <-done:
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("beginDirectWrite: %v", err)
+		}
 	case <-time.After(2 * time.Second):
 		t.Fatalf("direct write gate did not resume after checkpoint")
+	}
+}
+
+func TestCachingDBCommandWALAppendCallbacksRejectAfterCloseStarts(t *testing.T) {
+	db, err := Open(t.TempDir(), NewMockBackend(), Options{
+		DisableWAL:     true,
+		AllowUnsafe:    true,
+		FlushThreshold: 1 << 20,
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	db.closing.Store(true)
+	called := false
+	err = db.SetAfterCommandWALAppend([]byte("k"), []byte("v"), func() error {
+		called = true
+		return nil
+	})
+	if !errors.Is(err, backenddb.ErrClosed) {
+		t.Fatalf("SetAfterCommandWALAppend error=%v, want ErrClosed", err)
+	}
+	if called {
+		t.Fatalf("SetAfterCommandWALAppend called command WAL append after close started")
+	}
+
+	b := db.NewBatch()
+	if err := b.Set([]byte("batch-k"), []byte("batch-v")); err != nil {
+		t.Fatalf("batch Set: %v", err)
+	}
+	err = b.WriteAfterCommandWALAppend(true, func() error {
+		called = true
+		return nil
+	})
+	if !errors.Is(err, backenddb.ErrClosed) {
+		t.Fatalf("WriteAfterCommandWALAppend error=%v, want ErrClosed", err)
+	}
+	if called {
+		t.Fatalf("WriteAfterCommandWALAppend called command WAL append after close started")
 	}
 }
 

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -21500,11 +21500,15 @@ func (db *DB) waitForCheckpoint() {
 	db.checkpointMu.Unlock()
 }
 
-func (db *DB) beginDirectWrite() {
+func (db *DB) beginDirectWrite() error {
 	for {
 		db.writeMu.RLock()
+		if db.closing.Load() {
+			db.writeMu.RUnlock()
+			return backenddb.ErrClosed
+		}
 		if !db.checkpointing.Load() && !db.maintenanceActive.Load() {
-			return
+			return nil
 		}
 		db.writeMu.RUnlock()
 		db.waitForCheckpoint()
@@ -23433,7 +23437,9 @@ func (db *DB) set(key, value []byte, sync bool) error {
 }
 
 func (db *DB) setDirect(key, value []byte, sync bool) error {
-	db.beginDirectWrite()
+	if err := db.beginDirectWrite(); err != nil {
+		return err
+	}
 	needRotate := false
 	needSyncBarrier := false
 	var ptr page.ValuePtr
@@ -23613,7 +23619,9 @@ func (db *DB) setDirectAfterCommandWALAppend(key, value []byte, appendCommand fu
 	if !db.disableJournal {
 		return fmt.Errorf("cachingdb: command wal point writes require disabled cached redo log")
 	}
-	db.beginDirectWrite()
+	if err := db.beginDirectWrite(); err != nil {
+		return err
+	}
 	needRotate := false
 	var ptr page.ValuePtr
 	var retainPath string
@@ -24622,7 +24630,9 @@ func (db *DB) delete(key []byte, sync bool) error {
 }
 
 func (db *DB) deleteDirect(key []byte, sync bool) error {
-	db.beginDirectWrite()
+	if err := db.beginDirectWrite(); err != nil {
+		return err
+	}
 	needRotate := false
 	needSyncBarrier := false
 
@@ -24698,7 +24708,9 @@ func (db *DB) deleteDirectAfterCommandWALAppend(key []byte, appendCommand func()
 	if !db.disableJournal {
 		return fmt.Errorf("cachingdb: command wal point writes require disabled cached redo log")
 	}
-	db.beginDirectWrite()
+	if err := db.beginDirectWrite(); err != nil {
+		return err
+	}
 	needRotate := false
 
 	shard := db.shardForKey(key)
@@ -32594,7 +32606,9 @@ func (b *Batch) tryWriteWALOffStreamBypass(sync bool) (bool, error) {
 }
 
 func (b *Batch) writeRegular(syncWrite bool) error {
-	b.db.beginDirectWrite()
+	if err := b.db.beginDirectWrite(); err != nil {
+		return err
+	}
 	return b.writeRegularLocked(syncWrite, b.db.writeMu.RUnlock)
 }
 

--- a/TreeDB/command_wal_public_cached.go
+++ b/TreeDB/command_wal_public_cached.go
@@ -484,6 +484,13 @@ func (b *commandWALPublicBatch) write(sync bool) error {
 	if b == nil || b.inner == nil {
 		return ErrClosed
 	}
+	if b.db != nil {
+		unlock, err := b.db.beginPublicOperation()
+		if err != nil {
+			return err
+		}
+		defer unlock()
+	}
 	if b.dirty {
 		writer, ok := b.inner.(interface {
 			WriteAfterCommandWALAppend(sync bool, appendCommand func() error) error

--- a/TreeDB/command_wal_public_test.go
+++ b/TreeDB/command_wal_public_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -1844,5 +1845,91 @@ func TestPublicCommandWALBatchDeleteRangeCachedReopen(t *testing.T) {
 	got, err = reopen.Get([]byte("d"))
 	if err != nil || string(got) != "vd" {
 		t.Fatalf("Get(d)=(%q,%v), want vd,nil", got, err)
+	}
+}
+
+func TestPublicCommandWALCloseRejectsLateSetSyncWithErrClosed(t *testing.T) {
+	db, err := Open(Options{
+		Dir:                 t.TempDir(),
+		Durability:          DurabilityWALOnRelaxed,
+		CommandWAL:          true,
+		CommandWALStatsScan: true,
+		DisableSideStores:   true,
+	})
+	if err != nil {
+		t.Fatalf("Open command WAL: %v", err)
+	}
+	if err := db.Set([]byte("seed"), []byte("v1")); err != nil {
+		_ = db.Close()
+		t.Fatalf("Set(seed): %v", err)
+	}
+
+	started := make(chan struct{})
+	done := make(chan error, 1)
+	var once sync.Once
+	testDuringPublicCloseAfterCheckpoint = func() {
+		once.Do(func() {
+			go func() {
+				close(started)
+				done <- db.SetSync([]byte("late-shutdown"), []byte("v2"))
+			}()
+			<-started
+			select {
+			case err := <-done:
+				t.Fatalf("late SetSync completed before Close released lifecycle lock: %v", err)
+			default:
+			}
+		})
+	}
+	defer func() { testDuringPublicCloseAfterCheckpoint = nil }()
+
+	if err := db.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	err = <-done
+	if !errors.Is(err, ErrClosed) {
+		t.Fatalf("late SetSync error=%v, want ErrClosed", err)
+	}
+	if err != nil && strings.Contains(err.Error(), "command wal journal unavailable") {
+		t.Fatalf("late SetSync leaked command journal shutdown error: %v", err)
+	}
+}
+
+func TestPublicCommandWALBatchWriteAfterCloseReturnsErrClosed(t *testing.T) {
+	db, err := Open(Options{
+		Dir:                 t.TempDir(),
+		Durability:          DurabilityWALOnRelaxed,
+		CommandWAL:          true,
+		CommandWALStatsScan: true,
+		DisableSideStores:   true,
+	})
+	if err != nil {
+		t.Fatalf("Open command WAL: %v", err)
+	}
+	b := db.NewBatch()
+	if b == nil {
+		_ = db.Close()
+		t.Fatalf("NewBatch returned nil")
+	}
+	if err := b.Set([]byte("late-batch"), []byte("v1")); err != nil {
+		_ = b.Close()
+		_ = db.Close()
+		t.Fatalf("batch Set: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		_ = b.Close()
+		t.Fatalf("Close: %v", err)
+	}
+	err = b.WriteSync()
+	if !errors.Is(err, ErrClosed) {
+		_ = b.Close()
+		t.Fatalf("batch WriteSync after close error=%v, want ErrClosed", err)
+	}
+	if err != nil && strings.Contains(err.Error(), "command wal journal unavailable") {
+		_ = b.Close()
+		t.Fatalf("batch WriteSync leaked command journal shutdown error: %v", err)
+	}
+	if err := b.Close(); err != nil {
+		t.Fatalf("batch Close: %v", err)
 	}
 }

--- a/TreeDB/db/command_wal_raw.go
+++ b/TreeDB/db/command_wal_raw.go
@@ -30,6 +30,13 @@ type commandWALBatchIntent struct {
 	staged             bool
 }
 
+func (db *DB) commandWALJournalUnavailableError() error {
+	if db == nil || db.closing.Load() {
+		return ErrClosed
+	}
+	return fmt.Errorf("treedb: command wal journal unavailable")
+}
+
 // CommandWALIntent is an opaque command-WAL append/finalize token used by
 // higher-level deterministic command executors such as collections.
 type CommandWALIntent struct {
@@ -704,8 +711,11 @@ func (db *DB) AppendRawKVSingleCommandWAL(op commitlog.RawKVOperation, sync bool
 	if op.Op == commitlog.RawKVOpSetRID {
 		return 0, fmt.Errorf("%w: public single-op command WAL cannot carry external refs", ErrCommandWALUnsupported)
 	}
+	if db.closing.Load() {
+		return 0, ErrClosed
+	}
 	if db.commandJournal == nil {
-		return 0, fmt.Errorf("treedb: command wal journal unavailable")
+		return 0, db.commandWALJournalUnavailableError()
 	}
 	if db.commandWALFlushPoisoned.Load() {
 		return 0, fmt.Errorf("%w: command wal post-append failure; reopen required", ErrRecoveryRequired)
@@ -749,8 +759,11 @@ func (db *DB) AppendRawKVPointCommandWALTrusted(op commitlog.RawKVOp, key, value
 	if err := db.runCommandWALRawPublishBarriers(); err != nil {
 		return 0, err
 	}
+	if db.closing.Load() {
+		return 0, ErrClosed
+	}
 	if db.commandJournal == nil {
-		return 0, fmt.Errorf("treedb: command wal journal unavailable")
+		return 0, db.commandWALJournalUnavailableError()
 	}
 	if db.commandWALFlushPoisoned.Load() {
 		return 0, fmt.Errorf("%w: command wal post-append failure; reopen required", ErrRecoveryRequired)
@@ -804,8 +817,11 @@ func (db *DB) appendRawKVBatchPayloadCommandWAL(payload []byte, sync bool, trust
 	if err := db.runCommandWALRawPublishBarriers(); err != nil {
 		return 0, err
 	}
+	if db.closing.Load() {
+		return 0, ErrClosed
+	}
 	if db.commandJournal == nil {
-		return 0, fmt.Errorf("treedb: command wal journal unavailable")
+		return 0, db.commandWALJournalUnavailableError()
 	}
 	if db.commandWALFlushPoisoned.Load() {
 		return 0, fmt.Errorf("%w: command wal post-append failure; reopen required", ErrRecoveryRequired)
@@ -931,8 +947,11 @@ func (db *DB) appendCommandWALIntent(intent *commandWALBatchIntent, sync bool) (
 		}
 		return intent.lsn, nil
 	}
-	if db == nil || db.commandJournal == nil {
-		return 0, fmt.Errorf("treedb: command wal journal unavailable")
+	if db == nil {
+		return 0, ErrClosed
+	}
+	if db.closing.Load() || db.commandJournal == nil {
+		return 0, db.commandWALJournalUnavailableError()
 	}
 	if db.commandWALFlushPoisoned.Load() {
 		return 0, fmt.Errorf("%w: command wal post-append failure; reopen required", ErrRecoveryRequired)

--- a/TreeDB/public.go
+++ b/TreeDB/public.go
@@ -151,6 +151,7 @@ type DB struct {
 	dictdb                              *db.DB
 	templateDB                          *DB
 	writePath                           writePathInfo
+	lifecycleMu                         sync.RWMutex
 	commandWALCached                    bool
 	commandWALPendingMu                 sync.Mutex
 	commandWALFirst                     atomic.Uint64
@@ -173,6 +174,7 @@ type DB struct {
 var (
 	testAfterPublicCommandWALPointAppend func(commitlog.RawKVOperation)
 	testAfterCachedCheckpoint            func()
+	testDuringPublicCloseAfterCheckpoint func()
 )
 
 type writePathInfo struct {
@@ -295,6 +297,18 @@ func (db *DB) ensureOpen() error {
 		return ErrClosed
 	}
 	return nil
+}
+
+func (db *DB) beginPublicOperation() (func(), error) {
+	if db == nil {
+		return nil, ErrClosed
+	}
+	db.lifecycleMu.RLock()
+	if db.cached == nil && db.backend == nil {
+		db.lifecycleMu.RUnlock()
+		return nil, ErrClosed
+	}
+	return db.lifecycleMu.RUnlock, nil
 }
 
 func (db *DB) beginFullScanMaintenance(op string) (time.Duration, func(success bool)) {
@@ -1367,6 +1381,9 @@ func (db *DB) Close() error {
 		}
 	}
 
+	db.lifecycleMu.Lock()
+	defer db.lifecycleMu.Unlock()
+
 	// Close cached layer first if present
 	if db.cached != nil {
 		if db.commandWALCached {
@@ -1374,6 +1391,9 @@ func (db *DB) Close() error {
 				wrapped := fmt.Errorf("treedb: final command WAL checkpoint during close: %w", e)
 				db.reportError(wrapped)
 				err = errors.Join(err, wrapped)
+			}
+			if testDuringPublicCloseAfterCheckpoint != nil {
+				testDuringPublicCloseAfterCheckpoint()
 			}
 		}
 		err = errors.Join(err, db.cached.Close())
@@ -1560,9 +1580,11 @@ func (db *DB) HasPrefixes(prefixes [][]byte) ([]bool, error) {
 func (db *DB) Set(key, value []byte) error {
 	key = normalizeRawKVPointKey(key)
 	value = normalizeRawKVValue(value)
-	if err := db.ensureOpen(); err != nil {
+	unlock, err := db.beginPublicOperation()
+	if err != nil {
 		return err
 	}
+	defer unlock()
 	if db.cached != nil {
 		if db.commandWALCached {
 			return db.cached.SetAfterCommandWALAppend(key, value, func() error {
@@ -1580,9 +1602,11 @@ func (db *DB) Set(key, value []byte) error {
 func (db *DB) SetSync(key, value []byte) error {
 	key = normalizeRawKVPointKey(key)
 	value = normalizeRawKVValue(value)
-	if err := db.ensureOpen(); err != nil {
+	unlock, err := db.beginPublicOperation()
+	if err != nil {
 		return err
 	}
+	defer unlock()
 	if db.cached != nil {
 		if db.commandWALCached {
 			return db.cached.SetAfterCommandWALAppend(key, value, func() error {
@@ -1604,9 +1628,11 @@ func (db *DB) SetSync(key, value []byte) error {
 // Because fn may be retried, it should avoid externally visible side effects.
 func (db *DB) Update(key []byte, fn UpdateFunc) error {
 	key = normalizeRawKVPointKey(key)
-	if err := db.ensureOpen(); err != nil {
+	unlock, err := db.beginPublicOperation()
+	if err != nil {
 		return err
 	}
+	defer unlock()
 	if db.commandWALCached {
 		db.rawSpanNativePublicUpdateReject.Add(1)
 		return ErrCommandWALRejected
@@ -1627,9 +1653,11 @@ func (db *DB) Update(key []byte, fn UpdateFunc) error {
 // externally visible side effects.
 func (db *DB) UpdateSync(key []byte, fn UpdateFunc) error {
 	key = normalizeRawKVPointKey(key)
-	if err := db.ensureOpen(); err != nil {
+	unlock, err := db.beginPublicOperation()
+	if err != nil {
 		return err
 	}
+	defer unlock()
 	if db.commandWALCached {
 		db.rawSpanNativePublicUpdateSyncReject.Add(1)
 		return ErrCommandWALRejected
@@ -1643,9 +1671,11 @@ func (db *DB) UpdateSync(key []byte, fn UpdateFunc) error {
 // Delete removes a key without forcing an fsync boundary.
 func (db *DB) Delete(key []byte) error {
 	key = normalizeRawKVPointKey(key)
-	if err := db.ensureOpen(); err != nil {
+	unlock, err := db.beginPublicOperation()
+	if err != nil {
 		return err
 	}
+	defer unlock()
 	if db.cached != nil {
 		if db.commandWALCached {
 			return db.cached.DeleteAfterCommandWALAppend(key, func() error {
@@ -1662,9 +1692,11 @@ func (db *DB) Delete(key []byte) error {
 // This is primarily used by benchmark suites and maintenance tooling. In cached
 // mode, it may use fast paths that avoid per-key tombstones when safe.
 func (db *DB) DeleteRange(start, end []byte) error {
-	if err := db.ensureOpen(); err != nil {
+	unlock, err := db.beginPublicOperation()
+	if err != nil {
 		return err
 	}
+	defer unlock()
 	if db.commandWALCached {
 		if batch.IsDeleteRangeNoop(start, end) {
 			return nil
@@ -1711,9 +1743,11 @@ func (db *DB) DeleteRange(start, end []byte) error {
 // DeleteSync removes a key and forces a durability boundary.
 func (db *DB) DeleteSync(key []byte) error {
 	key = normalizeRawKVPointKey(key)
-	if err := db.ensureOpen(); err != nil {
+	unlock, err := db.beginPublicOperation()
+	if err != nil {
 		return err
 	}
+	defer unlock()
 	if db.cached != nil {
 		if db.commandWALCached {
 			return db.cached.DeleteAfterCommandWALAppend(key, func() error {
@@ -1749,9 +1783,11 @@ func (db *DB) ReverseIterator(start, end []byte) (Iterator, error) {
 
 // NewBatch creates a new batch for buffered writes.
 func (db *DB) NewBatch() Batch {
-	if db == nil || (db.cached == nil && db.backend == nil) {
+	unlock, err := db.beginPublicOperation()
+	if err != nil {
 		return nil
 	}
+	defer unlock()
 	if db.cached != nil {
 		inner := db.cached.NewBatch()
 		if db.commandWALCached {
@@ -1772,9 +1808,11 @@ func (db *DB) NewBatch() Batch {
 // Callers must not rely on an exact 1:1 mapping between size and the number of
 // entries or bytes that can be written to the batch.
 func (db *DB) NewBatchWithSize(size int) Batch {
-	if db == nil || (db.cached == nil && db.backend == nil) {
+	unlock, err := db.beginPublicOperation()
+	if err != nil {
 		return nil
 	}
+	defer unlock()
 	if db.cached != nil {
 		inner := db.cached.NewBatchWithSize(size)
 		if db.commandWALCached {
@@ -1899,9 +1937,11 @@ func (db *DB) Print() error {
 // Checkpoint returning nil must also cover pre-cut collection WAL transactions
 // or return/report explicit collection WAL debt.
 func (db *DB) Checkpoint() error {
-	if err := db.ensureOpen(); err != nil {
+	unlock, err := db.beginPublicOperation()
+	if err != nil {
 		return err
 	}
+	defer unlock()
 	if db.cached != nil {
 		return db.checkpointCachedForPublicCommandWAL()
 	}

--- a/kvstore/adapters/treedb/treedb.go
+++ b/kvstore/adapters/treedb/treedb.go
@@ -278,12 +278,19 @@ func (d *DB) GetAppend(key, dst []byte) ([]byte, error) {
 	return val, err
 }
 
+func ignoreClosedWrite(err error) error {
+	if errors.Is(err, treedb.ErrClosed) {
+		return nil
+	}
+	return err
+}
+
 func (d *DB) Set(key, value []byte) error {
-	return d.DB.Set(key, value)
+	return ignoreClosedWrite(d.DB.Set(key, value))
 }
 
 func (d *DB) Delete(key []byte) error {
-	return d.DB.Delete(key)
+	return ignoreClosedWrite(d.DB.Delete(key))
 }
 
 func (d *DB) RangeDeleteMode() string {
@@ -299,11 +306,11 @@ func (d *DB) Has(key []byte) (bool, error) {
 }
 
 func (d *DB) SetSync(key, value []byte) error {
-	return d.DB.SetSync(key, value)
+	return ignoreClosedWrite(d.DB.SetSync(key, value))
 }
 
 func (d *DB) DeleteSync(key []byte) error {
-	return d.DB.DeleteSync(key)
+	return ignoreClosedWrite(d.DB.DeleteSync(key))
 }
 
 // Stats is safe to call after Close. The unified-bench harness uses that
@@ -409,11 +416,11 @@ func (b *batch) DeleteView(key []byte) error {
 }
 
 func (b *batch) Commit() error {
-	return b.b.Write()
+	return ignoreClosedWrite(b.b.Write())
 }
 
 func (b *batch) CommitSync() error {
-	return b.b.WriteSync()
+	return ignoreClosedWrite(b.b.WriteSync())
 }
 
 func (b *batch) Close() error { return b.b.Close() }

--- a/kvstore/adapters/treedb/treedb_close_test.go
+++ b/kvstore/adapters/treedb/treedb_close_test.go
@@ -37,6 +37,68 @@ func TestAdapterGetAfterCloseDoesNotError(t *testing.T) {
 	}
 }
 
+func TestAdapterWritesAfterCloseDoNotError(t *testing.T) {
+	dir := t.TempDir()
+	db, err := treedb.Open(treedb.Options{
+		Dir:                 dir,
+		Durability:          treedb.DurabilityWALOnRelaxed,
+		CommandWAL:          true,
+		CommandWALStatsScan: true,
+		DisableSideStores:   true,
+	})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	adapter := Wrap(db)
+
+	batchWrite, err := adapter.NewBatch()
+	if err != nil {
+		t.Fatalf("new batch: %v", err)
+	}
+	if err := batchWrite.Set([]byte("batch-k"), []byte("batch-v")); err != nil {
+		t.Fatalf("batch set: %v", err)
+	}
+	batchSync, err := adapter.NewBatch()
+	if err != nil {
+		t.Fatalf("new sync batch: %v", err)
+	}
+	if err := batchSync.Set([]byte("batch-sync-k"), []byte("batch-sync-v")); err != nil {
+		t.Fatalf("batch sync set: %v", err)
+	}
+
+	if err := adapter.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	if err := adapter.Set([]byte("late-set"), []byte("v")); err != nil {
+		t.Fatalf("set after close: %v", err)
+	}
+	if err := adapter.SetSync([]byte("late-set-sync"), []byte("v")); err != nil {
+		t.Fatalf("set sync after close: %v", err)
+	}
+	if err := adapter.Delete([]byte("late-delete")); err != nil {
+		t.Fatalf("delete after close: %v", err)
+	}
+	if err := adapter.DeleteSync([]byte("late-delete-sync")); err != nil {
+		t.Fatalf("delete sync after close: %v", err)
+	}
+	if err := batchWrite.Commit(); err != nil {
+		t.Fatalf("batch commit after close: %v", err)
+	}
+	if err := batchSync.CommitSync(); err != nil {
+		t.Fatalf("batch commit sync after close: %v", err)
+	}
+	_ = batchWrite.Close()
+	_ = batchSync.Close()
+}
+
+func TestAdapterWriteErrorsPreserveNonClosedErrors(t *testing.T) {
+	errBoom := errors.New("boom")
+	if err := ignoreClosedWrite(errBoom); !errors.Is(err, errBoom) {
+		t.Fatalf("ignoreClosedWrite(%v)=%v, want original error", errBoom, err)
+	}
+}
+
 func TestAdapterReadBatch_IgnoresMissingAndDuplicates(t *testing.T) {
 	dir := t.TempDir()
 	db, err := treedb.Open(treedb.Options{Dir: dir})


### PR DESCRIPTION
## Summary

Fixes #3138.
Links #3127 and #3130.

This PR makes TreeDB command-WAL cached shutdown writes obey the normal closed-DB contract instead of surfacing `treedb: command wal journal unavailable` while the backend command journal is being torn down. That is the panic signature seen during the Celestia restart-dwell shutdown path after `application.db` close began.

Changes:
- add a public DB lifecycle gate around public write/batch/checkpoint entry points and hold it across the final command-WAL checkpoint plus cached/backend teardown;
- make cached direct writes return `ErrClosed` once cached close starts, before command-WAL append callbacks can run;
- make backend command-WAL append helpers return `ErrClosed` when close is in progress while preserving the live non-close journal-unavailable error;
- make the TreeDB kvstore adapter swallow only `treedb.ErrClosed` for post-close writes and batch commits, preserving recovery/corruption/command-WAL correctness errors.

## Validation

- `GOWORK=off go test ./TreeDB -run 'PublicCommandWAL.*Close|PublicCommandWAL.*AfterClose|PublicCommandWALBatchWriteAfterClose|PublicCommandWALCloseRejectsLateSetSync'`
- `GOWORK=off go test ./TreeDB/caching -run 'DirectWriteGate|CommandWALAppendCallbacksRejectAfterCloseStarts'`
- `GOWORK=off go test ./kvstore/adapters/treedb -run 'AdapterWritesAfterClose|AdapterWriteErrorsPreserveNonClosedErrors|AdapterGetAfterClose'`
- `GOWORK=off go test ./TreeDB ./TreeDB/caching ./kvstore/adapters/treedb`

## Celestia Evidence Boundary

This PR addresses the exact shutdown panic path from #3138 in unit coverage. A focused Celestia restart-dwell rerun should be attached to #3138/#3130 before claiming the dwell gate is complete.
