### PR TITLE
TreeDB: batch primary column asset publication

### DIFF
--- a/TreeDB/collections/column_physical_asset_test.go
+++ b/TreeDB/collections/column_physical_asset_test.go
@@ -2132,6 +2132,84 @@ func TestColumnPhysicalAssetSegmentAppendWriterBatchesExistingSegment3142(t *tes
 	}
 }
 
+func TestColumnPhysicalAssetSegmentAppendWriterBatchesMixedRegularAssets3145(t *testing.T) {
+	cfg := testColumnStoreConfig(nil)
+	normalized, err := normalizeColumnStoreConfig("events", cfg)
+	if err != nil {
+		t.Fatalf("normalizeColumnStoreConfig: %v", err)
+	}
+	root := backenddb.ColumnAssetRootDirPath(t.TempDir())
+	seedPayload := []byte("seed")
+	seedRef, err := writeColumnAssetToManagerSegment(root, *normalized, seedPayload, ColumnAssetKindTCS1PartImage, 11, 1, columnAssetM12ASegmentFileID)
+	if err != nil {
+		t.Fatalf("seed writeColumnAssetToManagerSegment: %v", err)
+	}
+	appender, err := newColumnPhysicalAssetSegmentAppendWriter(root, *normalized, columnAssetM12ASegmentFileID)
+	if err != nil {
+		t.Fatalf("newColumnPhysicalAssetSegmentAppendWriter: %v", err)
+	}
+	rowPayload := []byte("row-image")
+	rowRef, err := appender.appendKind(rowPayload, ColumnAssetKindTCS1PartImage, 11, 2)
+	if err != nil {
+		_ = appender.abort()
+		t.Fatalf("append row image: %v", err)
+	}
+	typedPayload := []byte("typed-column-part")
+	typedRef, err := appender.appendKind(typedPayload, ColumnAssetKindTCS1TypedColumnPart, 11, 3)
+	if err != nil {
+		_ = appender.abort()
+		t.Fatalf("append typed-column part: %v", err)
+	}
+	dictPayload := []byte("dictionary-codes")
+	dictRef, err := appender.appendKind(dictPayload, ColumnAssetKindTCS1DictionaryCodes, 11, 2)
+	if err != nil {
+		_ = appender.abort()
+		t.Fatalf("append dictionary: %v", err)
+	}
+	intPayload := []byte("int64-values")
+	intRef, err := appender.appendKind(intPayload, ColumnAssetKindTCS1Int64Values, 11, 2)
+	if err != nil {
+		_ = appender.abort()
+		t.Fatalf("append int64: %v", err)
+	}
+	if err := appender.close(); err != nil {
+		t.Fatalf("appender close: %v", err)
+	}
+	refs := []ColumnAssetRef{rowRef, typedRef, dictRef, intRef}
+	for _, ref := range refs {
+		if ref.FileID != columnAssetM12ASegmentFileID {
+			t.Fatalf("ref=%+v want shared regular segment file_id=%d", ref, columnAssetM12ASegmentFileID)
+		}
+	}
+	if rowRef.Offset <= seedRef.Offset || typedRef.Offset <= rowRef.Offset || dictRef.Offset <= typedRef.Offset || intRef.Offset <= dictRef.Offset {
+		t.Fatalf("offsets seed=%+v row=%+v typed=%+v dict=%+v int=%+v want append order", seedRef, rowRef, typedRef, dictRef, intRef)
+	}
+	if dictRef.Offset%int64(dictionaryCodesDirectViewAssetAlignment) != 0 {
+		t.Fatalf("dictionary offset=%d want %d-byte alignment", dictRef.Offset, dictionaryCodesDirectViewAssetAlignment)
+	}
+	if intRef.Offset%int64(int64ValuesDirectViewAssetAlignment) != 0 {
+		t.Fatalf("int64 offset=%d want %d-byte alignment", intRef.Offset, int64ValuesDirectViewAssetAlignment)
+	}
+	segment := readColumnAssetSegmentFileForTest(t, root, seedRef)
+	expectedPayloads := []struct {
+		ref     ColumnAssetRef
+		payload []byte
+		name    string
+	}{
+		{seedRef, seedPayload, "seed"},
+		{rowRef, rowPayload, "row"},
+		{typedRef, typedPayload, "typed"},
+		{dictRef, dictPayload, "dictionary"},
+		{intRef, intPayload, "int64"},
+	}
+	for _, expected := range expectedPayloads {
+		got := segment[expected.ref.Offset : expected.ref.Offset+expected.ref.Length]
+		if !bytes.Equal(got, expected.payload) {
+			t.Fatalf("%s payload=%q want %q", expected.name, got, expected.payload)
+		}
+	}
+}
+
 func TestColumnPhysicalAssetSegmentAppendWriterAbortKeepsExistingSegment3142(t *testing.T) {
 	cfg := testColumnStoreConfig(nil)
 	normalized, err := normalizeColumnStoreConfig("events", cfg)

--- a/TreeDB/collections/column_publish_write.go
+++ b/TreeDB/collections/column_publish_write.go
@@ -753,8 +753,10 @@ func (c *Collection) prepareColumnPhysicalAssetRowsForCommand(prepared ColumnPub
 			})
 		}
 		if appender != nil {
+			if err := appender.close(); err != nil {
+				return err
+			}
 			closed = true
-			return appender.close()
 		}
 		return nil
 	}

--- a/TreeDB/collections/column_publish_write.go
+++ b/TreeDB/collections/column_publish_write.go
@@ -636,16 +636,21 @@ func (c *Collection) prepareColumnPhysicalAssetRowsForCommand(prepared ColumnPub
 		generation = hookInput.CurrentManifest.Generation + 1
 	}
 	role := columnManifestPartRoleForPublish(hookInput.Operation)
-	type pendingColumnRegularAsset struct {
-		payload []byte
-		kind    ColumnAssetKind
-		partID  uint64
-		rows    int
-		reason  string
+	type pendingColumnAsset struct {
+		payload  []byte
+		ref      ColumnAssetRef
+		hasRef   bool
+		kind     ColumnAssetKind
+		partID   uint64
+		rows     int
+		reason   string
+		partRole ColumnManifestPartRole
+		sortKey  string
+		validate func(ColumnAssetRef) error
 	}
-	pendingRegularAssets := make([]pendingColumnRegularAsset, 0, 8)
+	pendingAssets := make([]pendingColumnAsset, 0, 8)
 	queueRegularAsset := func(payload []byte, kind ColumnAssetKind, partID uint64, rows int, reason string) {
-		pendingRegularAssets = append(pendingRegularAssets, pendingColumnRegularAsset{
+		pendingAssets = append(pendingAssets, pendingColumnAsset{
 			payload: payload,
 			kind:    kind,
 			partID:  partID,
@@ -653,29 +658,88 @@ func (c *Collection) prepareColumnPhysicalAssetRowsForCommand(prepared ColumnPub
 			reason:  reason,
 		})
 	}
-	flushRegularAssets := func() (retErr error) {
-		if len(pendingRegularAssets) == 0 {
+	queueRegularManifestAsset := func(payload []byte, kind ColumnAssetKind, partID uint64, rows int, reason string, partRole ColumnManifestPartRole, sortKey string, validate func(ColumnAssetRef) error) {
+		pendingAssets = append(pendingAssets, pendingColumnAsset{
+			payload:  payload,
+			kind:     kind,
+			partID:   partID,
+			rows:     rows,
+			reason:   reason,
+			partRole: partRole,
+			sortKey:  sortKey,
+			validate: validate,
+		})
+	}
+	queuePreparedManifestAsset := func(asset ColumnPreparedAsset) {
+		pendingAssets = append(pendingAssets, pendingColumnAsset{
+			ref:      asset.Ref,
+			hasRef:   true,
+			kind:     asset.Ref.Kind,
+			partID:   asset.Ref.PartID,
+			rows:     asset.Rows,
+			reason:   asset.Reason,
+			partRole: asset.PartRole,
+			sortKey:  asset.SortKey,
+			validate: func(ref ColumnAssetRef) error {
+				if !columnPreparedAssetsEqual(asset, ColumnPreparedAsset{
+					Ref:          ref,
+					Rows:         asset.Rows,
+					Bytes:        ref.Length,
+					PublishID:    asset.PublishID,
+					GenerationID: asset.GenerationID,
+					Reason:       asset.Reason,
+					PartRole:     asset.PartRole,
+					SortKey:      asset.SortKey,
+				}) {
+					return fmt.Errorf("collections: prepared asset ref %+v does not match queued asset %+v", ref, asset)
+				}
+				return nil
+			},
+		})
+	}
+	flushPendingAssets := func() (retErr error) {
+		if len(pendingAssets) == 0 {
 			return nil
 		}
-		appender, err := newColumnPhysicalAssetSegmentAppendWriter(c.db.ColumnAssetRootDir(), hookInput.ColumnStore, columnAssetM12ASegmentFileID)
-		if err != nil {
-			return err
-		}
-		closed := false
-		defer func() {
-			if retErr != nil && !closed {
-				retErr = errors.Join(retErr, appender.abort())
+		needsAppender := false
+		for _, asset := range pendingAssets {
+			if !asset.hasRef {
+				needsAppender = true
+				break
 			}
-		}()
-		for _, asset := range pendingRegularAssets {
-			ref, err := appender.appendKind(asset.payload, asset.kind, generation, asset.partID)
+		}
+		var appender *columnPhysicalAssetSegmentAppender
+		closed := false
+		if needsAppender {
+			var err error
+			appender, err = newColumnPhysicalAssetSegmentAppendWriter(c.db.ColumnAssetRootDir(), hookInput.ColumnStore, columnAssetM12ASegmentFileID)
 			if err != nil {
 				return err
 			}
-			trackCleanupAsset(ref)
-			if ref.Namespace != hookInput.ColumnStore.AssetManager.Namespace || ref.Kind != asset.kind ||
-				ref.Generation != generation || ref.PartID != asset.partID || ref.Length != int64(len(asset.payload)) {
-				return fmt.Errorf("collections: invalid %s asset ref %+v", asset.kind, ref)
+			defer func() {
+				if retErr != nil && !closed {
+					retErr = errors.Join(retErr, appender.abort())
+				}
+			}()
+		}
+		for _, asset := range pendingAssets {
+			ref := asset.ref
+			if !asset.hasRef {
+				var err error
+				ref, err = appender.appendKind(asset.payload, asset.kind, generation, asset.partID)
+				if err != nil {
+					return err
+				}
+				trackCleanupAsset(ref)
+				if ref.Namespace != hookInput.ColumnStore.AssetManager.Namespace || ref.Kind != asset.kind ||
+					ref.Generation != generation || ref.PartID != asset.partID || ref.Length != int64(len(asset.payload)) {
+					return fmt.Errorf("collections: invalid %s asset ref %+v", asset.kind, ref)
+				}
+			}
+			if asset.validate != nil {
+				if err := asset.validate(ref); err != nil {
+					return err
+				}
 			}
 			prepared.Assets = append(prepared.Assets, ColumnPreparedAsset{
 				Ref:          ref,
@@ -684,10 +748,15 @@ func (c *Collection) prepareColumnPhysicalAssetRowsForCommand(prepared ColumnPub
 				PublishID:    hookInput.AppliedCommandLSN,
 				GenerationID: generation,
 				Reason:       asset.reason,
+				PartRole:     asset.partRole,
+				SortKey:      asset.sortKey,
 			})
 		}
-		closed = true
-		return appender.close()
+		if appender != nil {
+			closed = true
+			return appender.close()
+		}
+		return nil
 	}
 	rowAssetConfig := columnStoreRowAssetConfig(hookInput.ColumnStore)
 	rowAssetRows, err := projectColumnDeclaredRowsForColumns(hookInput.ColumnStore.Columns, rowAssetConfig.Columns, rows)
@@ -708,28 +777,14 @@ func (c *Collection) prepareColumnPhysicalAssetRowsForCommand(prepared ColumnPub
 	if err != nil {
 		return ColumnPublishPreparedAssets{}, err
 	}
-	ref, err := writeColumnPhysicalAssetToManager(c.db.ColumnAssetRootDir(), hookInput.ColumnStore, encoded, generation, columnPhysicalRowAssetPartID)
-	if err != nil {
-		return ColumnPublishPreparedAssets{}, err
-	}
-	trackCleanupAsset(ref)
-	if err := validateColumnPhysicalAssetPreparedRefForManifest(ref, rowAssetConfig, generation, columnPhysicalRowAssetPartID, len(encoded)); err != nil {
-		return ColumnPublishPreparedAssets{}, err
-	}
 	if prepared.CommandBytes == 0 {
 		prepared.CommandBytes = columnWriteDocumentsBytes(input.documents)
 	}
 	prepared.RowCount = summary.RowCount
 	prepared.ColumnPayloadBytes = summary.PayloadBytes
-	prepared.Assets = []ColumnPreparedAsset{{
-		Ref:          ref,
-		Rows:         summary.RowCount,
-		Bytes:        ref.Length,
-		PublishID:    hookInput.AppliedCommandLSN,
-		GenerationID: generation,
-		Reason:       string(input.operation),
-		PartRole:     role,
-	}}
+	queueRegularManifestAsset(encoded, ColumnAssetKindTCS1PartImage, columnPhysicalRowAssetPartID, summary.RowCount, string(input.operation), role, "", func(ref ColumnAssetRef) error {
+		return validateColumnPhysicalAssetPreparedRefForManifest(ref, rowAssetConfig, generation, columnPhysicalRowAssetPartID, len(encoded))
+	})
 	if hookInput.Operation == ColumnPublishOperationInsert || hookInput.Operation == ColumnPublishOperationUpdate {
 		typedColumnImage, typedColumnRows, err := buildTypedColumnPartImageForDeclaredRows(hookInput.ColumnStore, generation, typedColumnPartAssetPartID, rows)
 		if err != nil {
@@ -740,26 +795,35 @@ func (c *Collection) prepareColumnPhysicalAssetRowsForCommand(prepared ColumnPub
 			if err != nil {
 				return ColumnPublishPreparedAssets{}, err
 			}
-			typedColumnRef, err := writeTypedColumnPartAssetToManager(c.db.ColumnAssetRootDir(), hookInput.ColumnStore, typedColumnImage, generation, typedColumnPartAssetPartID)
-			if err != nil {
-				return ColumnPublishPreparedAssets{}, err
+			validateTypedColumnRef := func(ref ColumnAssetRef) error {
+				if ref.Namespace != hookInput.ColumnStore.AssetManager.Namespace || ref.Kind != ColumnAssetKindTCS1TypedColumnPart ||
+					ref.Generation != generation || ref.PartID != typedColumnPartAssetPartID || ref.Length != int64(len(typedColumnImage)) {
+					return fmt.Errorf("collections: invalid typed-column part asset ref %+v", ref)
+				}
+				return nil
 			}
-			trackCleanupAsset(typedColumnRef)
-			if typedColumnRef.Namespace != hookInput.ColumnStore.AssetManager.Namespace || typedColumnRef.Kind != ColumnAssetKindTCS1TypedColumnPart ||
-				typedColumnRef.Generation != generation || typedColumnRef.PartID != typedColumnPartAssetPartID || typedColumnRef.Length != int64(len(typedColumnImage)) {
-				return ColumnPublishPreparedAssets{}, fmt.Errorf("collections: invalid typed-column part asset ref %+v", typedColumnRef)
+			if columnStoreConfigNeedsDirectViewTypedColumnAlignment(hookInput.ColumnStore) {
+				typedColumnRef, err := writeTypedColumnPartAssetToManager(c.db.ColumnAssetRootDir(), hookInput.ColumnStore, typedColumnImage, generation, typedColumnPartAssetPartID)
+				if err != nil {
+					return ColumnPublishPreparedAssets{}, err
+				}
+				trackCleanupAsset(typedColumnRef)
+				if err := validateTypedColumnRef(typedColumnRef); err != nil {
+					return ColumnPublishPreparedAssets{}, err
+				}
+				queuePreparedManifestAsset(ColumnPreparedAsset{
+					Ref:          typedColumnRef,
+					Rows:         typedColumnRows,
+					Bytes:        typedColumnRef.Length,
+					PublishID:    hookInput.AppliedCommandLSN,
+					GenerationID: generation,
+					Reason:       string(input.operation),
+					PartRole:     role,
+					SortKey:      columnSortKeyMatchString(typedColumnSortKey),
+				})
+			} else {
+				queueRegularManifestAsset(typedColumnImage, ColumnAssetKindTCS1TypedColumnPart, typedColumnPartAssetPartID, typedColumnRows, string(input.operation), role, columnSortKeyMatchString(typedColumnSortKey), validateTypedColumnRef)
 			}
-			prepped := ColumnPreparedAsset{
-				Ref:          typedColumnRef,
-				Rows:         typedColumnRows,
-				Bytes:        typedColumnRef.Length,
-				PublishID:    hookInput.AppliedCommandLSN,
-				GenerationID: generation,
-				Reason:       string(input.operation),
-				PartRole:     role,
-				SortKey:      columnSortKeyMatchString(typedColumnSortKey),
-			}
-			prepared.Assets = append(prepared.Assets, prepped)
 		}
 	}
 	if hookInput.Operation == ColumnPublishOperationInsert {
@@ -823,7 +887,7 @@ func (c *Collection) prepareColumnPhysicalAssetRowsForCommand(prepared ColumnPub
 			queueRegularAsset(encodedMetadata, ColumnAssetKindTCS1AggregateMetadata, columnPhysicalRowAssetPartID, summary.RowCount, metadata.AggregateName)
 		}
 	}
-	if err := flushRegularAssets(); err != nil {
+	if err := flushPendingAssets(); err != nil {
 		return ColumnPublishPreparedAssets{}, err
 	}
 	cleanupAssets = nil

--- a/TreeDB/collections/typed_storage_naming_test.go
+++ b/TreeDB/collections/typed_storage_naming_test.go
@@ -356,7 +356,7 @@ var typedStorageLegacyNameAllowlist = []typedStorageLegacyNameAllowlistEntry{
 	{path: "TreeDB/collections/column_int64_values_asset.go", classification: typedStorageLegacyDerived, matchingLines: 10, occurrences: 10},
 	{path: "TreeDB/collections/column_manifest_format.go", classification: typedStorageLegacyCompatibility, matchingLines: 2, occurrences: 2},
 	{path: "TreeDB/collections/column_physical_asset.go", classification: typedStorageLegacyDeferred, matchingLines: 87, occurrences: 131},
-	{path: "TreeDB/collections/column_physical_asset_test.go", classification: typedStorageLegacyDeferred, matchingLines: 213, occurrences: 225},
+	{path: "TreeDB/collections/column_physical_asset_test.go", classification: typedStorageLegacyDeferred, matchingLines: 216, occurrences: 228},
 	{path: "TreeDB/collections/column_physical_predicate.go", classification: typedStorageLegacyDeferred, matchingLines: 3, occurrences: 3},
 	{path: "TreeDB/collections/column_physical_query.go", classification: typedStorageLegacyDeferred, matchingLines: 40, occurrences: 60},
 	{path: "TreeDB/collections/column_physical_query_1890_bench_test.go", classification: typedStorageLegacyDeferred, matchingLines: 1, occurrences: 2},


### PR DESCRIPTION
## Summary

- fixes #3145
- batches the primary typed-row compatibility asset through the existing regular column-asset append writer instead of writing it with its own open/sync/close cycle
- lets non-direct-view typed-column part assets use the same regular append queue while preserving direct-view typed-column segment file IDs and alignment
- adds mixed regular-asset append coverage and updates the typed-storage legacy-name allowlist for the new test references

## Scope Boundary

This is an insert/load and column asset publication PR under #3099/#3067. It is not evidence that TreeDB SQL is broadly faster than ClickHouse.

Effect classification:

| area | status |
|---|---|
| insert/load | improved |
| one-shot query execution | regression context only |
| hot prepared execution | not targeted |
| metadata storage/write cost | accounting unchanged; insert-cost upper-bound timer moves with asset preparation |
| general no-metadata scan performance | not targeted |
| storage bytes | unchanged in current evidence |

Direct-view typed-column part assets still use generation-specific direct-view segment IDs. This PR changes batching of writes, not the persisted asset/ref format.

## Tests

```sh
go test ./TreeDB/collections -run 'TestColumnPhysicalAssetSegmentAppendWriter|TestColumnPublish|TestColumnPhysicalAsset|TestColumnDictionary|TestColumnInt64|TestTypedStorageLegacyNameAllowlistIsComplete' -count=1
# ok github.com/snissn/gomap/TreeDB/collections 2.923s

go test ./TreeDB/collections ./cmd/unified_bench -count=1
# ok github.com/snissn/gomap/TreeDB/collections 53.616s
# ok github.com/snissn/gomap/cmd/unified_bench 36.893s

git diff --check
# passed
```

## 100k Synthetic Load-Path Evidence

Command:

```sh
OUT=/tmp/gomap_column_store_row_asset_batch_100k_$(date +%Y%m%d_%H%M%S)
go run ./cmd/unified_bench \
  -suite column_store \
  -dbs treedb \
  -keys 100000 \
  -batchsize 1000 \
  -profile durable \
  -profile-dir "$OUT" \
  -path-label native-fastpath \
  -column-store-path serial-column-scan \
  -column-store-query q1 \
  -progress=false
```

| run | artifact | ingest insert batch | publish | asset preparation | prepared assets | required asset bytes | manifest bytes |
|---|---|---:|---:|---:|---:|---:|---:|
| post-#3143 baseline | `/tmp/gomap_column_store_post3143_100k_20260626_171044/column_store_results.md` | `1054.668 ms` | `939.302 ms` | `726.908 ms` | `700` | `23,055,800` | `8,218,900` |
| candidate | `/tmp/gomap_column_store_3145_row_asset_batch_100k_20260626_172025/column_store_results.md` | `725.817 ms` | `609.125 ms` | `390.889 ms` | `700` | `23,055,800` | `8,218,900` |
| candidate repeat | `/tmp/gomap_column_store_3145_row_asset_batch_100k_repeat_20260626_172044/column_store_results.md` | `837.905 ms` | `727.485 ms` | `520.856 ms` | `700` | `23,055,800` | `8,218,900` |

Interpretation: the PR removes another per-publish asset write/sync path while preserving the same asset count and byte totals. The remaining load gap is not closed by this PR.

## 1M Preferred TreeDB/ClickHouse Context

Command:

```sh
cd /Users/michaelseiler/dev/snissn/JSONBench/treedb
OUT_DIR=/tmp/jsonbench_preferred_noagg_3145_row_asset_batch_1m_20260626_172058 \
DATA_DIR=/Users/michaelseiler/data/bluesky \
ROWS=1000000 TRIES=3 \
TREEDB_QUERY_MODE=one_shot_end_to_end \
TREEDB_METADATA_MODE=no_aggregate_metadata \
GOMAP_REPLACE=/tmp/gomap_realigned_next_20260626_170619 \
CLICKHOUSE_BIN=/Users/michaelseiler/dev/snissn/JSONBench/clickhouse/clickhouse \
TREEDB_ALLOW_ERRORS=1 CLICKHOUSE_ALLOW_ERRORS=1 \
./run_preferred_columnstore_clickhouse_compare.sh
```

Artifacts:

- Summary: `/tmp/jsonbench_preferred_noagg_3145_row_asset_batch_1m_20260626_172058/preferred_summary.md`
- TreeDB report: `/tmp/jsonbench_preferred_noagg_3145_row_asset_batch_1m_20260626_172058/treedb/report.md`
- ClickHouse result: `/tmp/jsonbench_preferred_noagg_3145_row_asset_batch_1m_20260626_172058/clickhouse/result.json`

| system/layout | rows | load | insert | storage | query mode | metadata mode | comparison note |
|---|---:|---:|---:|---:|---|---|---|
| TreeDB column-store-full-prepared baseline post-#3143 | `1.0M` | `20.831s` | `17.344s` | `131.12 MiB` | `one_shot_end_to_end` | `no_aggregate_metadata` | `/tmp/jsonbench_preferred_noagg_post3143_1m_20260626_170650/preferred_summary.md` |
| TreeDB column-store-full-prepared candidate | `1.0M` | `18.906s` | `15.545s` | `131.12 MiB` | `one_shot_end_to_end` | `no_aggregate_metadata` | load-path improvement only |
| ClickHouse JSON candidate run | `1.0M` | `4.677s` | n/a | `97.37 MiB` | `clickhouse_local_sql_end_to_end` | `no_projection_or_materialized_summary` | baseline for this wrapper |

Selected query context from the candidate run:

| query | TreeDB total | ClickHouse total | TreeDB details |
|---|---:|---:|---|
| q1 | `0.0015s` | `0.0030s` | no aggregate metadata, 1.0M cells visited |
| q2 | `0.0073s` | `0.0240s` | no aggregate metadata, 1.0M cells visited |
| q3 | `0.0103s` | `0.0110s` | no aggregate metadata, 1.0M cells visited |
| q4/q4a/q4b | `~314-338us` | `0.0120s` | no aggregate metadata, bounded TopK/sort-mark pruning, 9 cells visited |
| q5 | `0.0134s` | `0.0130s` | no aggregate metadata, about parity/slightly slower |
| qexpr | `0.0071s` | `0.0090s` | arbitrary-expression typed-column scan |

Caveat: query rows are regression/context evidence for #3070/#3001 vocabulary. This PR's claimed improvement is the load-path movement above, not a broad SQL-performance claim.

## Remaining Work

- #3067/#3099 remain open: 1M TreeDB load is still ~4x ClickHouse in this wrapper, and the 10M load gate still needs refreshed evidence after the load stack settles.
- #3070/#3001 remain separate query/final evidence gates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how column assets are queued and written so mixed asset types can share a segment more reliably, with stronger validation of offsets and payload placement.
  * Fixed typed-column handling to better preserve append order and alignment for direct-view data.

* **Tests**
  * Added coverage for batching mixed regular assets into a single segment and verifying the written bytes match the appended data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->