### PR TITLE
TreeDB: honor value-log maintenance pause file

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -436,6 +436,21 @@ func loadPositiveInt64EnvDefault(key string, def int64) int64 {
 	return v
 }
 
+func vlogGenerationMaintenancePauseFilePath() string {
+	return strings.TrimSpace(os.Getenv(envVlogGenerationMaintenancePauseFile))
+}
+
+func vlogGenerationMaintenancePausedByFile() (bool, string) {
+	path := vlogGenerationMaintenancePauseFilePath()
+	if path == "" {
+		return false, ""
+	}
+	if _, err := os.Stat(path); err == nil {
+		return true, path
+	}
+	return false, path
+}
+
 type leafGenerationPackMaintenanceAdmission struct {
 	allowed bool
 	reason  string
@@ -2189,6 +2204,7 @@ const (
 	envDisableVlogGenerationCheckpointKickHotDebtOnly = "TREEDB_DISABLE_VLOG_GENERATION_CHECKPOINT_KICK_HOT_DEBT_ONLY"
 	envDisableVlogGenerationPeriodicRewritePlanBudget = "TREEDB_DISABLE_VLOG_GENERATION_PERIODIC_REWRITE_PLAN_BUDGET"
 	envVlogGenerationPeriodicRewritePlanBudgetMillis  = "TREEDB_VLOG_GENERATION_PERIODIC_REWRITE_PLAN_BUDGET_MS"
+	envVlogGenerationMaintenancePauseFile             = "TREEDB_VLOG_MAINTENANCE_PAUSE_FILE"
 	// Experimental immutable-leaf maintenance hook. Disabled by default until
 	// the cached scheduler policy and dwell behavior are validated.
 	envEnableLeafGenerationPackMaintenance                     = "TREEDB_ENABLE_LEAF_GENERATION_PACK_MAINTENANCE"
@@ -8692,6 +8708,7 @@ type DB struct {
 	vlogGenerationMaintenanceCollisions                          atomic.Uint64
 	vlogGenerationMaintenanceSkipWALOnPeriodic                   atomic.Uint64
 	vlogGenerationMaintenanceSkipPhase                           atomic.Uint64
+	vlogGenerationMaintenanceSkipPauseFile                       atomic.Uint64
 	vlogGenerationMaintenanceSkipStageGate                       atomic.Uint64
 	vlogGenerationMaintenanceSkipStageNotDue                     atomic.Uint64
 	vlogGenerationMaintenanceSkipStageDue                        atomic.Uint64
@@ -18913,6 +18930,19 @@ func (db *DB) maybeRunVlogGenerationMaintenanceWithOptions(runGC bool, opts vlog
 		return
 	}
 	db.vlogGenerationMaintenanceAttempts.Add(1)
+	if paused, path := vlogGenerationMaintenancePausedByFile(); paused {
+		db.vlogGenerationMaintenanceSkipPauseFile.Add(1)
+		if opts.debugSource != "" {
+			db.debugVlogMaintf(
+				"maintenance_skip reason=pause_file source=%s path=%s checkpoint_pending=%t deferred_pending=%t",
+				opts.debugSource,
+				path,
+				db.vlogGenerationCheckpointKickPending.Load(),
+				db.vlogGenerationDeferredMaintenancePending.Load(),
+			)
+		}
+		return
+	}
 	// In WAL-on mode, the periodic "runGC" tick must not enter the maintenance
 	// engine at all. Checkpoint-coupled work belongs to the explicit
 	// checkpoint-kick/deferred paths; letting the periodic GC tick even acquire
@@ -29239,6 +29269,11 @@ func (db *DB) Stats() map[string]string {
 	stats["treedb.cache.vlog_generation.maintenance.attempts"] = fmt.Sprintf("%d", db.vlogGenerationMaintenanceAttempts.Load())
 	stats["treedb.cache.vlog_generation.maintenance.acquired"] = fmt.Sprintf("%d", db.vlogGenerationMaintenanceAcquired.Load())
 	stats["treedb.cache.vlog_generation.maintenance.collisions"] = fmt.Sprintf("%d", db.vlogGenerationMaintenanceCollisions.Load())
+	pauseFilePath := vlogGenerationMaintenancePauseFilePath()
+	pauseFilePaused, _ := vlogGenerationMaintenancePausedByFile()
+	stats["treedb.cache.vlog_generation.maintenance.pause_file.configured"] = fmt.Sprintf("%t", pauseFilePath != "")
+	stats["treedb.cache.vlog_generation.maintenance.pause_file.paused"] = fmt.Sprintf("%t", pauseFilePaused)
+	stats["treedb.cache.vlog_generation.maintenance.skip.pause_file"] = fmt.Sprintf("%d", db.vlogGenerationMaintenanceSkipPauseFile.Load())
 	stats["treedb.cache.vlog_generation.maintenance.skip.wal_on_periodic"] = fmt.Sprintf("%d", db.vlogGenerationMaintenanceSkipWALOnPeriodic.Load())
 	stats["treedb.cache.vlog_generation.maintenance.skip.maintenance_phase"] = fmt.Sprintf("%d", db.vlogGenerationMaintenanceSkipPhase.Load())
 	stats["treedb.cache.vlog_generation.maintenance.skip.stage_gate"] = fmt.Sprintf("%d", db.vlogGenerationMaintenanceSkipStageGate.Load())

--- a/TreeDB/caching/vlog_generation_scheduler_test.go
+++ b/TreeDB/caching/vlog_generation_scheduler_test.go
@@ -2033,6 +2033,68 @@ func TestLeafGenerationPackMaintenance_RequiresExplicitEnv(t *testing.T) {
 	}
 }
 
+func TestVlogGenerationMaintenance_PauseFileSkipsAndResumes(t *testing.T) {
+	t.Setenv(envEnableLeafGenerationPackMaintenance, "1")
+	pauseFile := filepath.Join(t.TempDir(), "vlog-maintenance.pause")
+	if err := os.WriteFile(pauseFile, []byte("pause"), 0o600); err != nil {
+		t.Fatalf("write pause file: %v", err)
+	}
+	t.Setenv(envVlogGenerationMaintenancePauseFile, pauseFile)
+
+	backend, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open backend: %v", err)
+	}
+	recorder := &rewriteBudgetRecordingBackend{
+		DB:           backend,
+		leafPackResp: leafPackWindowExhaustingStats(1, 1024, 4096),
+	}
+	defer recorder.Close()
+	db := &DB{
+		backend:                    recorder,
+		indexOuterLeavesInValueLog: true,
+		valueLogGenerationPolicy:   uint8(backenddb.ValueLogGenerationHotWarmCold),
+		closeCh:                    make(chan struct{}),
+	}
+	db.checkpointCond = sync.NewCond(&db.checkpointMu)
+
+	acquired := db.maybeRunVlogGenerationMaintenanceWithOptions(false, vlogGenerationMaintenanceOptions{skipCheckpoint: true})
+	if acquired {
+		t.Fatalf("paused maintenance acquired slot")
+	}
+	if got := db.vlogGenerationMaintenanceSkipPauseFile.Load(); got != 1 {
+		t.Fatalf("pause-file skips=%d want 1", got)
+	}
+	if _, calls := recorder.recordedLeafPack(); calls != 0 {
+		t.Fatalf("paused leaf-pack calls=%d want 0", calls)
+	}
+	stats := db.Stats()
+	if got := stats["treedb.cache.vlog_generation.maintenance.pause_file.configured"]; got != "true" {
+		t.Fatalf("pause_file.configured=%q want true", got)
+	}
+	if got := stats["treedb.cache.vlog_generation.maintenance.pause_file.paused"]; got != "true" {
+		t.Fatalf("pause_file.paused=%q want true", got)
+	}
+	if got := stats["treedb.cache.vlog_generation.maintenance.skip.pause_file"]; got != "1" {
+		t.Fatalf("skip.pause_file=%q want 1", got)
+	}
+
+	if err := os.Remove(pauseFile); err != nil {
+		t.Fatalf("remove pause file: %v", err)
+	}
+	acquired = db.maybeRunVlogGenerationMaintenanceWithOptions(false, vlogGenerationMaintenanceOptions{skipCheckpoint: true})
+	if !acquired {
+		t.Fatalf("unpaused maintenance did not acquire slot")
+	}
+	if _, calls := recorder.recordedLeafPack(); calls != 1 {
+		t.Fatalf("unpaused leaf-pack calls=%d want 1", calls)
+	}
+	stats = db.Stats()
+	if got := stats["treedb.cache.vlog_generation.maintenance.pause_file.paused"]; got != "false" {
+		t.Fatalf("pause_file.paused after remove=%q want false", got)
+	}
+}
+
 func TestLeafGenerationPackMaintenance_RunsWithDefaultBounds(t *testing.T) {
 	t.Setenv(envEnableLeafGenerationPackMaintenance, "1")
 	backend, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})


### PR DESCRIPTION
## Summary

- Honor `TREEDB_VLOG_MAINTENANCE_PAUSE_FILE` in the TreeDB value-log generation scheduler before acquiring the maintenance slot.
- Add pause-file stats: configured, currently paused, and skip count.
- Add a scheduler-level test proving maintenance is skipped while the pause file exists and resumes after it is removed.

Closes #3144.

## Validation

- `GOWORK=off go test ./TreeDB/caching -run 'TestVlogGenerationMaintenance_PauseFileSkipsAndResumes|TestLeafGenerationPackMaintenance_RunsWithDefaultBounds|TestLeafGenerationPackMaintenance_RequiresExplicitEnv'`
- `GOWORK=off go test ./TreeDB/db ./TreeDB/caching ./TreeDB/zipper`
- `git diff --check`
- Celestia v8 build-only smoke with local gomap: `RUN_CELESTIA_BUILD_ONLY=1 LOCAL_GOMAP_DIR=/home/mikers/dev/snissn/gomap-3144-vlog-maintenance-pause USE_LOCAL_TREE_STACK=1 USE_LOCAL_COSMOS_STORE=1 DB_BACKEND=treedb APP_DB_BACKEND=treedb /home/mikers/run_celestia.sh`

## Celestia Evidence

Pre-fix stale-run baseline: `/home/mikers/.celestia-app-mainnet-treedb-20260626165154` restored snapshot `11705000` and reached `11705240` after about 28 minutes, while `/treedb-vlog-maintenance.pause` still existed. The live catch-up CPU profile showed `DB.scanLeafGenerationPtrTotals`, `Node.WalkInternalChildren`, and `DB.leafGenerationGroupedFrameInfo` dominating sampled TreeDB CPU despite the harness pause file.

Fixed-run sample: `/home/mikers/.celestia-app-mainnet-treedb-20260626172101`, frozen target `11705747`, local gomap commit `7be6bb40d`. During paused restore/live catch-up, app DB stats showed:

```
pause_file.paused=true
maintenance.attempts=166
maintenance.skip.pause_file=166
maintenance.acquired=0
leaf_pack.attempts=0
leaf_pack.runs=0
rss_hwm_bytes=15056875520
peak_heap_alloc_bytes=11842745304
```

The fixed live-catch-up profile is saved at `/home/mikers/.celestia-app-mainnet-treedb-20260626172101/sync/manual-live-catchup-fixed/cpu-live-catchup-30s.pprof` with top output beside it. It no longer shows the old leaf-generation scan functions as the sampled CPU top.

## Residual Risk / Follow-up

This PR fixes the missing pause-file contract and removes incorrect background maintenance admission during sync. It does not claim full Celestia throughput or memory readiness: the fixed sample still advanced live catch-up slowly and hit about 15.1 GB RSS high-water. Those remain active parent-graph follow-ups under #3127/#3131/#3132/#3130.
