### PR TITLE
TreeDB: split aggregate metadata publish cost

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -501,6 +501,13 @@ type CollectionInsertStats struct {
 	ColumnPublishDocumentExtraction       time.Duration
 	ColumnPublishDeclaredColumnEncoding   time.Duration
 	ColumnPublishAssetPreparation         time.Duration
+	ColumnPublishRowAssetPreparation      time.Duration
+	ColumnPublishTypedColumnPreparation   time.Duration
+	ColumnPublishDictionaryPreparation    time.Duration
+	ColumnPublishInt64Preparation         time.Duration
+	ColumnPublishAggregateMetadataPrepare time.Duration
+	ColumnPublishRowSidecarSharedBuild    time.Duration
+	ColumnPublishAssetAppend              time.Duration
 	ColumnPublishManifestEncode           time.Duration
 	ColumnPublishAssetClosureValidation   time.Duration
 	ColumnPublishRootDeltaConstruction    time.Duration
@@ -508,6 +515,18 @@ type CollectionInsertStats struct {
 	ColumnPublishRootDeltaMaterialization time.Duration
 	ColumnPublishRows                     int
 	ColumnPublishPreparedAssets           int
+	ColumnPublishRowAssetBytes            int64
+	ColumnPublishRowAssetCount            int
+	ColumnPublishTypedColumnBytes         int64
+	ColumnPublishTypedColumnCount         int
+	ColumnPublishDictionaryBytes          int64
+	ColumnPublishDictionaryCount          int
+	ColumnPublishInt64Bytes               int64
+	ColumnPublishInt64Count               int
+	ColumnPublishAggregateMetadataBytes   int64
+	ColumnPublishAggregateMetadataCount   int
+	ColumnPublishSharedAppendBytes        int64
+	ColumnPublishSharedAppendCount        int
 	ColumnPublishRequiredAssetBytes       int64
 	ColumnPublishManifestBytes            int64
 	UniqueIndexPreflight                  time.Duration

--- a/TreeDB/collections/column_publish_plan.go
+++ b/TreeDB/collections/column_publish_plan.go
@@ -148,6 +148,7 @@ type ColumnPublishPreparedAssets struct {
 	CommandBytes       int64
 	RowRemainderBytes  int64
 	ColumnPayloadBytes int64
+	AssetMetrics       ColumnPublishAssetPreparationMetrics
 }
 
 // ColumnPublishManifestEncodeInput is passed to the manifest encoding stage.
@@ -281,10 +282,38 @@ type ColumnPublishStageMetrics struct {
 	DocumentExtraction      time.Duration
 	DeclaredColumnEncoding  time.Duration
 	AssetPreparation        time.Duration
+	AssetMetrics            ColumnPublishAssetPreparationMetrics
 	AssetClosureValidation  time.Duration
 	ManifestEncode          time.Duration
 	RootDeltaConstruction   time.Duration
 	SystemDeltaConstruction time.Duration
+}
+
+// ColumnPublishAssetPreparationMetrics breaks the production asset-preparation
+// stage down by the asset families that make up column-store insert/load cost.
+// Fused row-sidecar build time is byte-attributed to dictionary/int64/aggregate
+// families by the producer; SharedAppendDuration remains separately reported so
+// callers can choose exact upper-bound or byte-share accounting.
+type ColumnPublishAssetPreparationMetrics struct {
+	RowAssetDuration              time.Duration
+	RowAssetBytes                 int64
+	RowAssetCount                 int
+	TypedColumnPartDuration       time.Duration
+	TypedColumnPartBytes          int64
+	TypedColumnPartCount          int
+	DictionarySidecarDuration     time.Duration
+	DictionarySidecarBytes        int64
+	DictionarySidecarCount        int
+	Int64SidecarDuration          time.Duration
+	Int64SidecarBytes             int64
+	Int64SidecarCount             int
+	AggregateMetadataDuration     time.Duration
+	AggregateMetadataBytes        int64
+	AggregateMetadataCount        int
+	RowSidecarSharedBuildDuration time.Duration
+	SharedAppendDuration          time.Duration
+	SharedAppendBytes             int64
+	SharedAppendCount             int
 }
 
 // BuildColumnPublishPlan validates and stages an atomic column manifest publish
@@ -343,6 +372,7 @@ func BuildColumnPublishPlan(input ColumnPublishPlanInput) (ColumnPublishPlan, er
 		return ColumnPublishPlan{}, fmt.Errorf("collections: column publish asset preparation failed: %w", err)
 	}
 	metrics.AssetPreparation = time.Since(start)
+	metrics.AssetMetrics = prepared.AssetMetrics
 	if err := validateColumnPublishPreparedAssets(prepared); err != nil {
 		return ColumnPublishPlan{}, err
 	}

--- a/TreeDB/collections/column_publish_write.go
+++ b/TreeDB/collections/column_publish_write.go
@@ -729,14 +729,15 @@ func (c *Collection) prepareColumnPhysicalAssetRowsForCommand(prepared ColumnPub
 		}
 		var appender *columnPhysicalAssetSegmentAppender
 		closed := false
-		var appendStart time.Time
+		var appendDuration time.Duration
 		if needsAppender {
-			appendStart = time.Now()
+			appendStart := time.Now()
 			var err error
 			appender, err = newColumnPhysicalAssetSegmentAppendWriter(c.db.ColumnAssetRootDir(), hookInput.ColumnStore, columnAssetM12ASegmentFileID)
 			if err != nil {
 				return err
 			}
+			appendDuration += time.Since(appendStart)
 			defer func() {
 				if retErr != nil && !closed {
 					retErr = errors.Join(retErr, appender.abort())
@@ -748,11 +749,13 @@ func (c *Collection) prepareColumnPhysicalAssetRowsForCommand(prepared ColumnPub
 		for _, asset := range pendingAssets {
 			ref := asset.ref
 			if !asset.hasRef {
+				appendStart := time.Now()
 				var err error
 				ref, err = appender.appendKind(asset.payload, asset.kind, generation, asset.partID)
 				if err != nil {
 					return err
 				}
+				appendDuration += time.Since(appendStart)
 				appendedBytes = saturatingAddNonNegativeInt64(appendedBytes, int64(len(asset.payload)))
 				appendedCount++
 				trackCleanupAsset(ref)
@@ -778,13 +781,15 @@ func (c *Collection) prepareColumnPhysicalAssetRowsForCommand(prepared ColumnPub
 			})
 		}
 		if appender != nil {
+			appendStart := time.Now()
 			if err := appender.close(); err != nil {
 				return err
 			}
+			appendDuration += time.Since(appendStart)
 			closed = true
 		}
 		if needsAppender {
-			prepared.AssetMetrics.SharedAppendDuration += time.Since(appendStart)
+			prepared.AssetMetrics.SharedAppendDuration += appendDuration
 			prepared.AssetMetrics.SharedAppendBytes = saturatingAddNonNegativeInt64(prepared.AssetMetrics.SharedAppendBytes, appendedBytes)
 			prepared.AssetMetrics.SharedAppendCount += appendedCount
 		}

--- a/TreeDB/collections/column_publish_write.go
+++ b/TreeDB/collections/column_publish_write.go
@@ -729,7 +729,9 @@ func (c *Collection) prepareColumnPhysicalAssetRowsForCommand(prepared ColumnPub
 		}
 		var appender *columnPhysicalAssetSegmentAppender
 		closed := false
+		var appendStart time.Time
 		if needsAppender {
+			appendStart = time.Now()
 			var err error
 			appender, err = newColumnPhysicalAssetSegmentAppendWriter(c.db.ColumnAssetRootDir(), hookInput.ColumnStore, columnAssetM12ASegmentFileID)
 			if err != nil {
@@ -741,7 +743,6 @@ func (c *Collection) prepareColumnPhysicalAssetRowsForCommand(prepared ColumnPub
 				}
 			}()
 		}
-		appendStart := time.Now()
 		var appendedBytes int64
 		var appendedCount int
 		for _, asset := range pendingAssets {

--- a/TreeDB/collections/column_publish_write.go
+++ b/TreeDB/collections/column_publish_write.go
@@ -437,12 +437,31 @@ func recordColumnPublishPlanStats(stats *CollectionInsertStats, plan ColumnPubli
 	stats.ColumnPublishDocumentExtraction += metrics.DocumentExtraction
 	stats.ColumnPublishDeclaredColumnEncoding += metrics.DeclaredColumnEncoding
 	stats.ColumnPublishAssetPreparation += metrics.AssetPreparation
+	stats.ColumnPublishRowAssetPreparation += metrics.AssetMetrics.RowAssetDuration
+	stats.ColumnPublishTypedColumnPreparation += metrics.AssetMetrics.TypedColumnPartDuration
+	stats.ColumnPublishDictionaryPreparation += metrics.AssetMetrics.DictionarySidecarDuration
+	stats.ColumnPublishInt64Preparation += metrics.AssetMetrics.Int64SidecarDuration
+	stats.ColumnPublishAggregateMetadataPrepare += metrics.AssetMetrics.AggregateMetadataDuration
+	stats.ColumnPublishRowSidecarSharedBuild += metrics.AssetMetrics.RowSidecarSharedBuildDuration
+	stats.ColumnPublishAssetAppend += metrics.AssetMetrics.SharedAppendDuration
 	stats.ColumnPublishManifestEncode += metrics.ManifestEncode
 	stats.ColumnPublishAssetClosureValidation += metrics.AssetClosureValidation
 	stats.ColumnPublishRootDeltaConstruction += metrics.RootDeltaConstruction
 	stats.ColumnPublishSystemDeltaConstruction += metrics.SystemDeltaConstruction
 	stats.ColumnPublishRows += plan.Rows
 	stats.ColumnPublishPreparedAssets += len(plan.PreparedAssets)
+	stats.ColumnPublishRowAssetBytes = saturatingAddNonNegativeInt64(stats.ColumnPublishRowAssetBytes, metrics.AssetMetrics.RowAssetBytes)
+	stats.ColumnPublishRowAssetCount += metrics.AssetMetrics.RowAssetCount
+	stats.ColumnPublishTypedColumnBytes = saturatingAddNonNegativeInt64(stats.ColumnPublishTypedColumnBytes, metrics.AssetMetrics.TypedColumnPartBytes)
+	stats.ColumnPublishTypedColumnCount += metrics.AssetMetrics.TypedColumnPartCount
+	stats.ColumnPublishDictionaryBytes = saturatingAddNonNegativeInt64(stats.ColumnPublishDictionaryBytes, metrics.AssetMetrics.DictionarySidecarBytes)
+	stats.ColumnPublishDictionaryCount += metrics.AssetMetrics.DictionarySidecarCount
+	stats.ColumnPublishInt64Bytes = saturatingAddNonNegativeInt64(stats.ColumnPublishInt64Bytes, metrics.AssetMetrics.Int64SidecarBytes)
+	stats.ColumnPublishInt64Count += metrics.AssetMetrics.Int64SidecarCount
+	stats.ColumnPublishAggregateMetadataBytes = saturatingAddNonNegativeInt64(stats.ColumnPublishAggregateMetadataBytes, metrics.AssetMetrics.AggregateMetadataBytes)
+	stats.ColumnPublishAggregateMetadataCount += metrics.AssetMetrics.AggregateMetadataCount
+	stats.ColumnPublishSharedAppendBytes = saturatingAddNonNegativeInt64(stats.ColumnPublishSharedAppendBytes, metrics.AssetMetrics.SharedAppendBytes)
+	stats.ColumnPublishSharedAppendCount += metrics.AssetMetrics.SharedAppendCount
 	stats.ColumnPublishRequiredAssetBytes = saturatingAddNonNegativeInt64(stats.ColumnPublishRequiredAssetBytes, plan.RequiredAssetBytes)
 	stats.ColumnPublishManifestBytes = saturatingAddNonNegativeInt64(stats.ColumnPublishManifestBytes, plan.ManifestBytes)
 }
@@ -722,6 +741,9 @@ func (c *Collection) prepareColumnPhysicalAssetRowsForCommand(prepared ColumnPub
 				}
 			}()
 		}
+		appendStart := time.Now()
+		var appendedBytes int64
+		var appendedCount int
 		for _, asset := range pendingAssets {
 			ref := asset.ref
 			if !asset.hasRef {
@@ -730,6 +752,8 @@ func (c *Collection) prepareColumnPhysicalAssetRowsForCommand(prepared ColumnPub
 				if err != nil {
 					return err
 				}
+				appendedBytes = saturatingAddNonNegativeInt64(appendedBytes, int64(len(asset.payload)))
+				appendedCount++
 				trackCleanupAsset(ref)
 				if ref.Namespace != hookInput.ColumnStore.AssetManager.Namespace || ref.Kind != asset.kind ||
 					ref.Generation != generation || ref.PartID != asset.partID || ref.Length != int64(len(asset.payload)) {
@@ -758,8 +782,14 @@ func (c *Collection) prepareColumnPhysicalAssetRowsForCommand(prepared ColumnPub
 			}
 			closed = true
 		}
+		if needsAppender {
+			prepared.AssetMetrics.SharedAppendDuration += time.Since(appendStart)
+			prepared.AssetMetrics.SharedAppendBytes = saturatingAddNonNegativeInt64(prepared.AssetMetrics.SharedAppendBytes, appendedBytes)
+			prepared.AssetMetrics.SharedAppendCount += appendedCount
+		}
 		return nil
 	}
+	rowAssetStart := time.Now()
 	rowAssetConfig := columnStoreRowAssetConfig(hookInput.ColumnStore)
 	rowAssetRows, err := projectColumnDeclaredRowsForColumns(hookInput.ColumnStore.Columns, rowAssetConfig.Columns, rows)
 	if err != nil {
@@ -784,10 +814,14 @@ func (c *Collection) prepareColumnPhysicalAssetRowsForCommand(prepared ColumnPub
 	}
 	prepared.RowCount = summary.RowCount
 	prepared.ColumnPayloadBytes = summary.PayloadBytes
+	prepared.AssetMetrics.RowAssetDuration += time.Since(rowAssetStart)
+	prepared.AssetMetrics.RowAssetBytes = saturatingAddNonNegativeInt64(prepared.AssetMetrics.RowAssetBytes, int64(len(encoded)))
+	prepared.AssetMetrics.RowAssetCount++
 	queueRegularManifestAsset(encoded, ColumnAssetKindTCS1PartImage, columnPhysicalRowAssetPartID, summary.RowCount, string(input.operation), role, "", func(ref ColumnAssetRef) error {
 		return validateColumnPhysicalAssetPreparedRefForManifest(ref, rowAssetConfig, generation, columnPhysicalRowAssetPartID, len(encoded))
 	})
 	if hookInput.Operation == ColumnPublishOperationInsert || hookInput.Operation == ColumnPublishOperationUpdate {
+		typedColumnStart := time.Now()
 		typedColumnImage, typedColumnRows, err := buildTypedColumnPartImageForDeclaredRows(hookInput.ColumnStore, generation, typedColumnPartAssetPartID, rows)
 		if err != nil {
 			return ColumnPublishPreparedAssets{}, err
@@ -826,26 +860,43 @@ func (c *Collection) prepareColumnPhysicalAssetRowsForCommand(prepared ColumnPub
 			} else {
 				queueRegularManifestAsset(typedColumnImage, ColumnAssetKindTCS1TypedColumnPart, typedColumnPartAssetPartID, typedColumnRows, string(input.operation), role, columnSortKeyMatchString(typedColumnSortKey), validateTypedColumnRef)
 			}
+			prepared.AssetMetrics.TypedColumnPartDuration += time.Since(typedColumnStart)
+			prepared.AssetMetrics.TypedColumnPartBytes = saturatingAddNonNegativeInt64(prepared.AssetMetrics.TypedColumnPartBytes, int64(len(typedColumnImage)))
+			prepared.AssetMetrics.TypedColumnPartCount++
 		}
 	}
 	if hookInput.Operation == ColumnPublishOperationInsert {
+		typedMetadataStart := time.Now()
 		typedMetadataAssets, err := buildColumnAggregateMetadataAssets(hookInput.ColumnStore, rows, columnStoreTypedColumnPartAggregateMetadata(hookInput.ColumnStore), hookInput.Collection, hookInput.ColumnStore.AssetManager.Namespace, generation, typedColumnPartAssetPartID, hookInput.AppliedCommandLSN)
 		if err != nil {
 			return ColumnPublishPreparedAssets{}, err
 		}
+		var typedMetadataBytes int64
 		for _, metadata := range typedMetadataAssets {
 			encodedMetadata, err := encodeColumnAggregateMetadataAsset(metadata)
 			if err != nil {
 				return ColumnPublishPreparedAssets{}, err
 			}
+			typedMetadataBytes = saturatingAddNonNegativeInt64(typedMetadataBytes, int64(len(encodedMetadata)))
 			queueRegularAsset(encodedMetadata, ColumnAssetKindTCS1AggregateMetadata, typedColumnPartAssetPartID, len(rows), metadata.AggregateName)
 		}
+		if typedMetadataBytes > 0 {
+			prepared.AssetMetrics.AggregateMetadataDuration += time.Since(typedMetadataStart)
+			prepared.AssetMetrics.AggregateMetadataBytes = saturatingAddNonNegativeInt64(prepared.AssetMetrics.AggregateMetadataBytes, typedMetadataBytes)
+			prepared.AssetMetrics.AggregateMetadataCount += len(typedMetadataAssets)
+		}
+		rowSidecarStart := time.Now()
 		rowSidecarAssets, fusedRowSidecars, err := buildColumnRowSidecarAssets(rowAssetConfig, rowAssetRows, rowAssetConfig.AggregateMetadata, hookInput.Collection, hookInput.ColumnStore.AssetManager.Namespace, generation, columnPhysicalRowAssetPartID, hookInput.AppliedCommandLSN)
+		rowSidecarBuildDuration := time.Since(rowSidecarStart)
 		if err != nil {
 			rowSidecarAssets = columnRowSidecarAssets{}
 			fusedRowSidecars = false
 			err = nil
 		}
+		if fusedRowSidecars {
+			prepared.AssetMetrics.RowSidecarSharedBuildDuration += rowSidecarBuildDuration
+		}
+		dictionaryStart := time.Now()
 		dictionaryAssets := rowSidecarAssets.DictionaryCodes
 		if !fusedRowSidecars {
 			dictionaryAssets, err = buildColumnDictionaryCodesAssets(rowAssetConfig, rowAssetRows, hookInput.Collection, hookInput.ColumnStore.AssetManager.Namespace, generation, columnPhysicalRowAssetPartID, hookInput.AppliedCommandLSN)
@@ -853,13 +904,21 @@ func (c *Collection) prepareColumnPhysicalAssetRowsForCommand(prepared ColumnPub
 				return ColumnPublishPreparedAssets{}, err
 			}
 		}
+		var dictionaryBytes int64
 		for _, dictionary := range dictionaryAssets {
 			encodedDictionary, err := encodeColumnDictionaryCodesAsset(dictionary)
 			if err != nil {
 				return ColumnPublishPreparedAssets{}, err
 			}
+			dictionaryBytes = saturatingAddNonNegativeInt64(dictionaryBytes, int64(len(encodedDictionary)))
 			queueRegularAsset(encodedDictionary, ColumnAssetKindTCS1DictionaryCodes, columnPhysicalRowAssetPartID, summary.RowCount, dictionary.ColumnName)
 		}
+		if dictionaryBytes > 0 {
+			prepared.AssetMetrics.DictionarySidecarDuration += time.Since(dictionaryStart)
+			prepared.AssetMetrics.DictionarySidecarBytes = saturatingAddNonNegativeInt64(prepared.AssetMetrics.DictionarySidecarBytes, dictionaryBytes)
+			prepared.AssetMetrics.DictionarySidecarCount += len(dictionaryAssets)
+		}
+		int64Start := time.Now()
 		int64Assets := rowSidecarAssets.Int64Values
 		if !fusedRowSidecars {
 			int64Assets, err = buildColumnInt64ValuesAssets(rowAssetConfig, rowAssetRows, hookInput.Collection, hookInput.ColumnStore.AssetManager.Namespace, generation, columnPhysicalRowAssetPartID, hookInput.AppliedCommandLSN)
@@ -867,13 +926,21 @@ func (c *Collection) prepareColumnPhysicalAssetRowsForCommand(prepared ColumnPub
 				return ColumnPublishPreparedAssets{}, err
 			}
 		}
+		var int64Bytes int64
 		for _, values := range int64Assets {
 			encodedValues, err := encodeColumnInt64ValuesAsset(values)
 			if err != nil {
 				return ColumnPublishPreparedAssets{}, err
 			}
+			int64Bytes = saturatingAddNonNegativeInt64(int64Bytes, int64(len(encodedValues)))
 			queueRegularAsset(encodedValues, ColumnAssetKindTCS1Int64Values, columnPhysicalRowAssetPartID, summary.RowCount, values.ColumnName)
 		}
+		if int64Bytes > 0 {
+			prepared.AssetMetrics.Int64SidecarDuration += time.Since(int64Start)
+			prepared.AssetMetrics.Int64SidecarBytes = saturatingAddNonNegativeInt64(prepared.AssetMetrics.Int64SidecarBytes, int64Bytes)
+			prepared.AssetMetrics.Int64SidecarCount += len(int64Assets)
+		}
+		rowMetadataStart := time.Now()
 		rowMetadataAssets := rowSidecarAssets.AggregateMetadata
 		if !fusedRowSidecars {
 			rowMetadataAssets, err = buildColumnAggregateMetadataAssets(rowAssetConfig, rowAssetRows, rowAssetConfig.AggregateMetadata, hookInput.Collection, hookInput.ColumnStore.AssetManager.Namespace, generation, columnPhysicalRowAssetPartID, hookInput.AppliedCommandLSN)
@@ -881,12 +948,25 @@ func (c *Collection) prepareColumnPhysicalAssetRowsForCommand(prepared ColumnPub
 				return ColumnPublishPreparedAssets{}, err
 			}
 		}
+		var rowMetadataBytes int64
 		for _, metadata := range rowMetadataAssets {
 			encodedMetadata, err := encodeColumnAggregateMetadataAsset(metadata)
 			if err != nil {
 				return ColumnPublishPreparedAssets{}, err
 			}
+			rowMetadataBytes = saturatingAddNonNegativeInt64(rowMetadataBytes, int64(len(encodedMetadata)))
 			queueRegularAsset(encodedMetadata, ColumnAssetKindTCS1AggregateMetadata, columnPhysicalRowAssetPartID, summary.RowCount, metadata.AggregateName)
+		}
+		if rowMetadataBytes > 0 {
+			prepared.AssetMetrics.AggregateMetadataDuration += time.Since(rowMetadataStart)
+			prepared.AssetMetrics.AggregateMetadataBytes = saturatingAddNonNegativeInt64(prepared.AssetMetrics.AggregateMetadataBytes, rowMetadataBytes)
+			prepared.AssetMetrics.AggregateMetadataCount += len(rowMetadataAssets)
+		}
+		if fusedRowSidecars {
+			totalFusedBytes := saturatingAddNonNegativeInt64(saturatingAddNonNegativeInt64(dictionaryBytes, int64Bytes), rowMetadataBytes)
+			prepared.AssetMetrics.DictionarySidecarDuration += columnPublishDurationShare(rowSidecarBuildDuration, dictionaryBytes, totalFusedBytes)
+			prepared.AssetMetrics.Int64SidecarDuration += columnPublishDurationShare(rowSidecarBuildDuration, int64Bytes, totalFusedBytes)
+			prepared.AssetMetrics.AggregateMetadataDuration += columnPublishDurationShare(rowSidecarBuildDuration, rowMetadataBytes, totalFusedBytes)
 		}
 	}
 	if err := flushPendingAssets(); err != nil {
@@ -894,6 +974,13 @@ func (c *Collection) prepareColumnPhysicalAssetRowsForCommand(prepared ColumnPub
 	}
 	cleanupAssets = nil
 	return prepared, nil
+}
+
+func columnPublishDurationShare(total time.Duration, partBytes, totalBytes int64) time.Duration {
+	if total <= 0 || partBytes <= 0 || totalBytes <= 0 {
+		return 0
+	}
+	return time.Duration(float64(total) * (float64(partBytes) / float64(totalBytes)))
 }
 
 func columnManifestPartRoleForPublish(operation ColumnPublishOperation) ColumnManifestPartRole {

--- a/TreeDB/collections/shape_bench_test.go
+++ b/TreeDB/collections/shape_bench_test.go
@@ -42,6 +42,13 @@ func addCollectionInsertStats(dst *collections.CollectionInsertStats, src collec
 	dst.ColumnPublishDocumentExtraction += src.ColumnPublishDocumentExtraction
 	dst.ColumnPublishDeclaredColumnEncoding += src.ColumnPublishDeclaredColumnEncoding
 	dst.ColumnPublishAssetPreparation += src.ColumnPublishAssetPreparation
+	dst.ColumnPublishRowAssetPreparation += src.ColumnPublishRowAssetPreparation
+	dst.ColumnPublishTypedColumnPreparation += src.ColumnPublishTypedColumnPreparation
+	dst.ColumnPublishDictionaryPreparation += src.ColumnPublishDictionaryPreparation
+	dst.ColumnPublishInt64Preparation += src.ColumnPublishInt64Preparation
+	dst.ColumnPublishAggregateMetadataPrepare += src.ColumnPublishAggregateMetadataPrepare
+	dst.ColumnPublishRowSidecarSharedBuild += src.ColumnPublishRowSidecarSharedBuild
+	dst.ColumnPublishAssetAppend += src.ColumnPublishAssetAppend
 	dst.ColumnPublishManifestEncode += src.ColumnPublishManifestEncode
 	dst.ColumnPublishAssetClosureValidation += src.ColumnPublishAssetClosureValidation
 	dst.ColumnPublishRootDeltaConstruction += src.ColumnPublishRootDeltaConstruction
@@ -49,6 +56,18 @@ func addCollectionInsertStats(dst *collections.CollectionInsertStats, src collec
 	dst.ColumnPublishRootDeltaMaterialization += src.ColumnPublishRootDeltaMaterialization
 	dst.ColumnPublishRows += src.ColumnPublishRows
 	dst.ColumnPublishPreparedAssets += src.ColumnPublishPreparedAssets
+	dst.ColumnPublishRowAssetBytes += src.ColumnPublishRowAssetBytes
+	dst.ColumnPublishRowAssetCount += src.ColumnPublishRowAssetCount
+	dst.ColumnPublishTypedColumnBytes += src.ColumnPublishTypedColumnBytes
+	dst.ColumnPublishTypedColumnCount += src.ColumnPublishTypedColumnCount
+	dst.ColumnPublishDictionaryBytes += src.ColumnPublishDictionaryBytes
+	dst.ColumnPublishDictionaryCount += src.ColumnPublishDictionaryCount
+	dst.ColumnPublishInt64Bytes += src.ColumnPublishInt64Bytes
+	dst.ColumnPublishInt64Count += src.ColumnPublishInt64Count
+	dst.ColumnPublishAggregateMetadataBytes += src.ColumnPublishAggregateMetadataBytes
+	dst.ColumnPublishAggregateMetadataCount += src.ColumnPublishAggregateMetadataCount
+	dst.ColumnPublishSharedAppendBytes += src.ColumnPublishSharedAppendBytes
+	dst.ColumnPublishSharedAppendCount += src.ColumnPublishSharedAppendCount
 	dst.ColumnPublishRequiredAssetBytes += src.ColumnPublishRequiredAssetBytes
 	dst.ColumnPublishManifestBytes += src.ColumnPublishManifestBytes
 	dst.UniqueIndexPreflight += src.UniqueIndexPreflight
@@ -83,6 +102,13 @@ func benchmarkReportCollectionInsertStats(b *testing.B, docs, batches int, stats
 	reportDuration("column_publish_document_extraction_ns/doc", stats.ColumnPublishDocumentExtraction)
 	reportDuration("column_publish_declared_column_encoding_ns/doc", stats.ColumnPublishDeclaredColumnEncoding)
 	reportDuration("column_publish_asset_prepare_ns/doc", stats.ColumnPublishAssetPreparation)
+	reportDuration("column_publish_row_asset_prepare_ns/doc", stats.ColumnPublishRowAssetPreparation)
+	reportDuration("column_publish_typed_column_prepare_ns/doc", stats.ColumnPublishTypedColumnPreparation)
+	reportDuration("column_publish_dictionary_prepare_ns/doc", stats.ColumnPublishDictionaryPreparation)
+	reportDuration("column_publish_int64_prepare_ns/doc", stats.ColumnPublishInt64Preparation)
+	reportDuration("column_publish_aggregate_metadata_prepare_ns/doc", stats.ColumnPublishAggregateMetadataPrepare)
+	reportDuration("column_publish_row_sidecar_shared_build_ns/doc", stats.ColumnPublishRowSidecarSharedBuild)
+	reportDuration("column_publish_asset_append_ns/doc", stats.ColumnPublishAssetAppend)
 	reportDuration("column_publish_manifest_encode_ns/doc", stats.ColumnPublishManifestEncode)
 	reportDuration("column_publish_asset_closure_ns/doc", stats.ColumnPublishAssetClosureValidation)
 	reportDuration("column_publish_root_delta_ns/doc", stats.ColumnPublishRootDeltaConstruction)

--- a/TreeDB/collections/typed_storage_naming_test.go
+++ b/TreeDB/collections/typed_storage_naming_test.go
@@ -373,7 +373,7 @@ var typedStorageLegacyNameAllowlist = []typedStorageLegacyNameAllowlistEntry{
 	{path: "TreeDB/collections/column_physical_scan_test.go", classification: typedStorageLegacyDeferred, matchingLines: 36, occurrences: 43},
 	{path: "TreeDB/collections/column_physical_visibility.go", classification: typedStorageLegacyDeferred, matchingLines: 9, occurrences: 9},
 	{path: "TreeDB/collections/column_physical_visibility_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 6, occurrences: 6},
-	{path: "TreeDB/collections/column_publish_plan.go", classification: typedStorageLegacyCompatibility, matchingLines: 46, occurrences: 59},
+	{path: "TreeDB/collections/column_publish_plan.go", classification: typedStorageLegacyCompatibility, matchingLines: 47, occurrences: 60},
 	{path: "TreeDB/collections/column_publish_plan_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 69, occurrences: 90},
 	{path: "TreeDB/collections/column_publish_write.go", classification: typedStorageLegacyCompatibility, matchingLines: 55, occurrences: 62},
 	{path: "TreeDB/collections/column_publish_write_bench_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 35, occurrences: 37},

--- a/cmd/unified_bench/suite_column_store.go
+++ b/cmd/unified_bench/suite_column_store.go
@@ -2072,10 +2072,18 @@ func columnStoreMetadataCostMetricFromAccounting(insert columnStoreInsertPhaseMe
 	if rows <= 0 {
 		rows = insert.Documents
 	}
+	out.AggregateMetadataAppendShareMS = columnStoreDurationShareMS(insert.ColumnPublishAssetAppendDurationMS, insert.ColumnPublishAggregateMetadataBytes, insert.ColumnPublishSharedAppendBytes)
+	splitInsertCostMS := out.AggregateMetadataPrepareMS + out.AggregateMetadataAppendShareMS
+	splitInsertCostAvailable := splitInsertCostMS > 0 && (insert.ColumnPublishAggregateMetadataBytes > 0 || out.AggregateMetadataPrepareMS > 0)
 	if accountingErr != nil {
 		out.StorageCostBasis = "physical_accounting_unavailable: " + accountingErr.Error()
-		out.InsertCostDurationMS = out.InsertCostUpperBoundMS
-		out.InsertCostBasis = "column_publish_asset_preparation_total_upper_bound_all_asset_families"
+		if splitInsertCostAvailable {
+			out.InsertCostDurationMS = splitInsertCostMS
+			out.InsertCostBasis = "aggregate_metadata_prepare_duration_plus_byte_weighted_share_of_shared_batched_asset_append"
+		} else {
+			out.InsertCostDurationMS = out.InsertCostUpperBoundMS
+			out.InsertCostBasis = "column_publish_asset_preparation_total_upper_bound_all_asset_families"
+		}
 		if rows > 0 && out.InsertCostDurationMS > 0 {
 			out.InsertCostNsPerRow = out.InsertCostDurationMS * float64(time.Millisecond) / float64(rows)
 		}
@@ -2087,9 +2095,8 @@ func columnStoreMetadataCostMetricFromAccounting(insert columnStoreInsertPhaseMe
 	out.AggregateMetadataRefs = accounting.AggregateMetadataRefs
 	if out.AggregateMetadataRefs > 0 || out.AggregateMetadataStorageBytes > 0 {
 		out.StorageCostBasis = "active_manifest_aggregate_metadata_sidecars_plus_typed_column_embedded_aggregate_sections"
-		out.AggregateMetadataAppendShareMS = columnStoreDurationShareMS(insert.ColumnPublishAssetAppendDurationMS, insert.ColumnPublishAggregateMetadataBytes, insert.ColumnPublishSharedAppendBytes)
-		out.InsertCostDurationMS = out.AggregateMetadataPrepareMS + out.AggregateMetadataAppendShareMS
-		if out.InsertCostDurationMS > 0 {
+		if splitInsertCostAvailable {
+			out.InsertCostDurationMS = splitInsertCostMS
 			out.InsertCostBasis = "aggregate_metadata_prepare_duration_plus_byte_weighted_share_of_shared_batched_asset_append"
 		} else {
 			out.InsertCostDurationMS = out.InsertCostUpperBoundMS

--- a/cmd/unified_bench/suite_column_store.go
+++ b/cmd/unified_bench/suite_column_store.go
@@ -228,6 +228,13 @@ type columnStoreInsertPhaseMetric struct {
 	ColumnPublishDocumentExtractionDurationMS float64 `json:"column_publish_document_extraction_duration_ms,omitempty"`
 	ColumnPublishDeclaredColumnDurationMS     float64 `json:"column_publish_declared_column_encoding_duration_ms,omitempty"`
 	ColumnPublishAssetPreparationDurationMS   float64 `json:"column_publish_asset_preparation_duration_ms,omitempty"`
+	ColumnPublishRowAssetPrepareDurationMS    float64 `json:"column_publish_row_asset_prepare_duration_ms,omitempty"`
+	ColumnPublishTypedColumnPrepareDurationMS float64 `json:"column_publish_typed_column_prepare_duration_ms,omitempty"`
+	ColumnPublishDictionaryPrepareDurationMS  float64 `json:"column_publish_dictionary_sidecar_prepare_duration_ms,omitempty"`
+	ColumnPublishInt64PrepareDurationMS       float64 `json:"column_publish_int64_sidecar_prepare_duration_ms,omitempty"`
+	ColumnPublishAggregateMetadataDurationMS  float64 `json:"column_publish_aggregate_metadata_prepare_duration_ms,omitempty"`
+	ColumnPublishRowSidecarSharedBuildMS      float64 `json:"column_publish_row_sidecar_shared_build_duration_ms,omitempty"`
+	ColumnPublishAssetAppendDurationMS        float64 `json:"column_publish_asset_append_duration_ms,omitempty"`
 	ColumnPublishManifestEncodeDurationMS     float64 `json:"column_publish_manifest_encode_duration_ms,omitempty"`
 	ColumnPublishAssetClosureDurationMS       float64 `json:"column_publish_asset_closure_validation_duration_ms,omitempty"`
 	ColumnPublishRootDeltaDurationMS          float64 `json:"column_publish_root_delta_construction_duration_ms,omitempty"`
@@ -235,6 +242,18 @@ type columnStoreInsertPhaseMetric struct {
 	ColumnPublishRootDeltaMaterializeMS       float64 `json:"column_publish_root_delta_materialization_duration_ms,omitempty"`
 	ColumnPublishRows                         int     `json:"column_publish_rows,omitempty"`
 	ColumnPublishPreparedAssets               int     `json:"column_publish_prepared_assets,omitempty"`
+	ColumnPublishRowAssetBytes                int64   `json:"column_publish_row_asset_bytes,omitempty"`
+	ColumnPublishRowAssetCount                int     `json:"column_publish_row_asset_count,omitempty"`
+	ColumnPublishTypedColumnBytes             int64   `json:"column_publish_typed_column_bytes,omitempty"`
+	ColumnPublishTypedColumnCount             int     `json:"column_publish_typed_column_count,omitempty"`
+	ColumnPublishDictionaryBytes              int64   `json:"column_publish_dictionary_sidecar_bytes,omitempty"`
+	ColumnPublishDictionaryCount              int     `json:"column_publish_dictionary_sidecar_count,omitempty"`
+	ColumnPublishInt64Bytes                   int64   `json:"column_publish_int64_sidecar_bytes,omitempty"`
+	ColumnPublishInt64Count                   int     `json:"column_publish_int64_sidecar_count,omitempty"`
+	ColumnPublishAggregateMetadataBytes       int64   `json:"column_publish_aggregate_metadata_bytes,omitempty"`
+	ColumnPublishAggregateMetadataCount       int     `json:"column_publish_aggregate_metadata_count,omitempty"`
+	ColumnPublishSharedAppendBytes            int64   `json:"column_publish_shared_asset_append_bytes,omitempty"`
+	ColumnPublishSharedAppendCount            int     `json:"column_publish_shared_asset_append_count,omitempty"`
 	ColumnPublishRequiredAssetBytes           int64   `json:"column_publish_required_asset_bytes,omitempty"`
 	ColumnPublishManifestBytes                int64   `json:"column_publish_manifest_bytes,omitempty"`
 	PrimaryRunBuildDurationMS                 float64 `json:"primary_run_build_duration_ms,omitempty"`
@@ -544,9 +563,13 @@ type columnStoreMetadataCostMetric struct {
 	AggregateMetadataSidecarBytes  int64   `json:"aggregate_metadata_sidecar_bytes"`
 	AggregateMetadataEmbeddedBytes int64   `json:"aggregate_metadata_embedded_bytes"`
 	AggregateMetadataRefs          int     `json:"aggregate_metadata_refs"`
+	AggregateMetadataPrepareMS     float64 `json:"aggregate_metadata_prepare_duration_ms,omitempty"`
+	AggregateMetadataAppendShareMS float64 `json:"aggregate_metadata_append_share_duration_ms,omitempty"`
+	InsertCostUpperBoundMS         float64 `json:"insert_cost_upper_bound_duration_ms,omitempty"`
 	InsertCostDurationMS           float64 `json:"insert_cost_duration_ms,omitempty"`
 	InsertCostNsPerRow             float64 `json:"insert_cost_ns_per_row,omitempty"`
 	InsertCostBasis                string  `json:"insert_cost_basis,omitempty"`
+	InsertCostUpperBoundBasis      string  `json:"insert_cost_upper_bound_basis,omitempty"`
 	StorageCostBasis               string  `json:"storage_cost_basis,omitempty"`
 }
 
@@ -1414,6 +1437,13 @@ func columnStoreAddCollectionInsertStats(dst *collections.CollectionInsertStats,
 	dst.ColumnPublishDocumentExtraction += src.ColumnPublishDocumentExtraction
 	dst.ColumnPublishDeclaredColumnEncoding += src.ColumnPublishDeclaredColumnEncoding
 	dst.ColumnPublishAssetPreparation += src.ColumnPublishAssetPreparation
+	dst.ColumnPublishRowAssetPreparation += src.ColumnPublishRowAssetPreparation
+	dst.ColumnPublishTypedColumnPreparation += src.ColumnPublishTypedColumnPreparation
+	dst.ColumnPublishDictionaryPreparation += src.ColumnPublishDictionaryPreparation
+	dst.ColumnPublishInt64Preparation += src.ColumnPublishInt64Preparation
+	dst.ColumnPublishAggregateMetadataPrepare += src.ColumnPublishAggregateMetadataPrepare
+	dst.ColumnPublishRowSidecarSharedBuild += src.ColumnPublishRowSidecarSharedBuild
+	dst.ColumnPublishAssetAppend += src.ColumnPublishAssetAppend
 	dst.ColumnPublishManifestEncode += src.ColumnPublishManifestEncode
 	dst.ColumnPublishAssetClosureValidation += src.ColumnPublishAssetClosureValidation
 	dst.ColumnPublishRootDeltaConstruction += src.ColumnPublishRootDeltaConstruction
@@ -1421,6 +1451,18 @@ func columnStoreAddCollectionInsertStats(dst *collections.CollectionInsertStats,
 	dst.ColumnPublishRootDeltaMaterialization += src.ColumnPublishRootDeltaMaterialization
 	dst.ColumnPublishRows += src.ColumnPublishRows
 	dst.ColumnPublishPreparedAssets += src.ColumnPublishPreparedAssets
+	dst.ColumnPublishRowAssetBytes += src.ColumnPublishRowAssetBytes
+	dst.ColumnPublishRowAssetCount += src.ColumnPublishRowAssetCount
+	dst.ColumnPublishTypedColumnBytes += src.ColumnPublishTypedColumnBytes
+	dst.ColumnPublishTypedColumnCount += src.ColumnPublishTypedColumnCount
+	dst.ColumnPublishDictionaryBytes += src.ColumnPublishDictionaryBytes
+	dst.ColumnPublishDictionaryCount += src.ColumnPublishDictionaryCount
+	dst.ColumnPublishInt64Bytes += src.ColumnPublishInt64Bytes
+	dst.ColumnPublishInt64Count += src.ColumnPublishInt64Count
+	dst.ColumnPublishAggregateMetadataBytes += src.ColumnPublishAggregateMetadataBytes
+	dst.ColumnPublishAggregateMetadataCount += src.ColumnPublishAggregateMetadataCount
+	dst.ColumnPublishSharedAppendBytes += src.ColumnPublishSharedAppendBytes
+	dst.ColumnPublishSharedAppendCount += src.ColumnPublishSharedAppendCount
 	dst.ColumnPublishRequiredAssetBytes += src.ColumnPublishRequiredAssetBytes
 	dst.ColumnPublishManifestBytes += src.ColumnPublishManifestBytes
 	dst.UniqueIndexPreflight += src.UniqueIndexPreflight
@@ -1459,6 +1501,13 @@ func columnStoreInsertPhaseMetricFromStats(stats collections.CollectionInsertSta
 		ColumnPublishDocumentExtractionDurationMS: durationMS(stats.ColumnPublishDocumentExtraction),
 		ColumnPublishDeclaredColumnDurationMS:     durationMS(stats.ColumnPublishDeclaredColumnEncoding),
 		ColumnPublishAssetPreparationDurationMS:   durationMS(stats.ColumnPublishAssetPreparation),
+		ColumnPublishRowAssetPrepareDurationMS:    durationMS(stats.ColumnPublishRowAssetPreparation),
+		ColumnPublishTypedColumnPrepareDurationMS: durationMS(stats.ColumnPublishTypedColumnPreparation),
+		ColumnPublishDictionaryPrepareDurationMS:  durationMS(stats.ColumnPublishDictionaryPreparation),
+		ColumnPublishInt64PrepareDurationMS:       durationMS(stats.ColumnPublishInt64Preparation),
+		ColumnPublishAggregateMetadataDurationMS:  durationMS(stats.ColumnPublishAggregateMetadataPrepare),
+		ColumnPublishRowSidecarSharedBuildMS:      durationMS(stats.ColumnPublishRowSidecarSharedBuild),
+		ColumnPublishAssetAppendDurationMS:        durationMS(stats.ColumnPublishAssetAppend),
 		ColumnPublishManifestEncodeDurationMS:     durationMS(stats.ColumnPublishManifestEncode),
 		ColumnPublishAssetClosureDurationMS:       durationMS(stats.ColumnPublishAssetClosureValidation),
 		ColumnPublishRootDeltaDurationMS:          durationMS(stats.ColumnPublishRootDeltaConstruction),
@@ -1466,6 +1515,18 @@ func columnStoreInsertPhaseMetricFromStats(stats collections.CollectionInsertSta
 		ColumnPublishRootDeltaMaterializeMS:       durationMS(stats.ColumnPublishRootDeltaMaterialization),
 		ColumnPublishRows:                         stats.ColumnPublishRows,
 		ColumnPublishPreparedAssets:               stats.ColumnPublishPreparedAssets,
+		ColumnPublishRowAssetBytes:                stats.ColumnPublishRowAssetBytes,
+		ColumnPublishRowAssetCount:                stats.ColumnPublishRowAssetCount,
+		ColumnPublishTypedColumnBytes:             stats.ColumnPublishTypedColumnBytes,
+		ColumnPublishTypedColumnCount:             stats.ColumnPublishTypedColumnCount,
+		ColumnPublishDictionaryBytes:              stats.ColumnPublishDictionaryBytes,
+		ColumnPublishDictionaryCount:              stats.ColumnPublishDictionaryCount,
+		ColumnPublishInt64Bytes:                   stats.ColumnPublishInt64Bytes,
+		ColumnPublishInt64Count:                   stats.ColumnPublishInt64Count,
+		ColumnPublishAggregateMetadataBytes:       stats.ColumnPublishAggregateMetadataBytes,
+		ColumnPublishAggregateMetadataCount:       stats.ColumnPublishAggregateMetadataCount,
+		ColumnPublishSharedAppendBytes:            stats.ColumnPublishSharedAppendBytes,
+		ColumnPublishSharedAppendCount:            stats.ColumnPublishSharedAppendCount,
 		ColumnPublishRequiredAssetBytes:           stats.ColumnPublishRequiredAssetBytes,
 		ColumnPublishManifestBytes:                stats.ColumnPublishManifestBytes,
 		PrimaryRunBuildDurationMS:                 durationMS(stats.PrimaryRunBuild),
@@ -2003,18 +2064,21 @@ func columnStoreSortTopKPruningUsed(exec columnStoreQueryExecution) bool {
 
 func columnStoreMetadataCostMetricFromAccounting(insert columnStoreInsertPhaseMetric, accounting collections.ColumnStorePhysicalAccounting, accountingErr error) columnStoreMetadataCostMetric {
 	out := columnStoreMetadataCostMetric{
-		InsertCostDurationMS: insert.ColumnPublishAssetPreparationDurationMS,
-		InsertCostBasis:      "column_publish_asset_preparation_total_current_upper_bound",
+		AggregateMetadataPrepareMS: insert.ColumnPublishAggregateMetadataDurationMS,
+		InsertCostUpperBoundMS:     insert.ColumnPublishAssetPreparationDurationMS,
+		InsertCostUpperBoundBasis:  "column_publish_asset_preparation_total_upper_bound_all_asset_families",
 	}
 	rows := insert.ColumnPublishRows
 	if rows <= 0 {
 		rows = insert.Documents
 	}
-	if rows > 0 && insert.ColumnPublishAssetPreparationDurationMS > 0 {
-		out.InsertCostNsPerRow = insert.ColumnPublishAssetPreparationDurationMS * float64(time.Millisecond) / float64(rows)
-	}
 	if accountingErr != nil {
 		out.StorageCostBasis = "physical_accounting_unavailable: " + accountingErr.Error()
+		out.InsertCostDurationMS = out.InsertCostUpperBoundMS
+		out.InsertCostBasis = "column_publish_asset_preparation_total_upper_bound_all_asset_families"
+		if rows > 0 && out.InsertCostDurationMS > 0 {
+			out.InsertCostNsPerRow = out.InsertCostDurationMS * float64(time.Millisecond) / float64(rows)
+		}
 		return out
 	}
 	out.AggregateMetadataSidecarBytes = accounting.Totals.AggregateMetadataBytes
@@ -2023,10 +2087,28 @@ func columnStoreMetadataCostMetricFromAccounting(insert columnStoreInsertPhaseMe
 	out.AggregateMetadataRefs = accounting.AggregateMetadataRefs
 	if out.AggregateMetadataRefs > 0 || out.AggregateMetadataStorageBytes > 0 {
 		out.StorageCostBasis = "active_manifest_aggregate_metadata_sidecars_plus_typed_column_embedded_aggregate_sections"
+		out.AggregateMetadataAppendShareMS = columnStoreDurationShareMS(insert.ColumnPublishAssetAppendDurationMS, insert.ColumnPublishAggregateMetadataBytes, insert.ColumnPublishSharedAppendBytes)
+		out.InsertCostDurationMS = out.AggregateMetadataPrepareMS + out.AggregateMetadataAppendShareMS
+		if out.InsertCostDurationMS > 0 {
+			out.InsertCostBasis = "aggregate_metadata_prepare_duration_plus_byte_weighted_share_of_shared_batched_asset_append"
+		} else {
+			out.InsertCostDurationMS = out.InsertCostUpperBoundMS
+			out.InsertCostBasis = "column_publish_asset_preparation_total_upper_bound_all_asset_families"
+		}
 	} else {
 		out.StorageCostBasis = "no_aggregate_metadata_refs_in_active_manifest"
 	}
+	if rows > 0 && out.InsertCostDurationMS > 0 {
+		out.InsertCostNsPerRow = out.InsertCostDurationMS * float64(time.Millisecond) / float64(rows)
+	}
 	return out
+}
+
+func columnStoreDurationShareMS(totalMS float64, partBytes, totalBytes int64) float64 {
+	if totalMS <= 0 || partBytes <= 0 || totalBytes <= 0 {
+		return 0
+	}
+	return totalMS * (float64(partBytes) / float64(totalBytes))
 }
 
 func columnStoreApplyMetadataCostToQueries(queries []columnStoreQueryMetric, cost columnStoreMetadataCostMetric) {
@@ -4249,6 +4331,12 @@ func renderColumnStoreInsertStatsMarkdown(sb *strings.Builder, stats columnStore
 	sb.WriteString(fmt.Sprintf("- retained_payload_semantic_stream_blocks_per_run: %.6f\n\n", stats.RetainedPayloadSemanticStreamBlocksPerRun))
 	sb.WriteString(fmt.Sprintf("- column_publish_rows: %d\n", stats.ColumnPublishRows))
 	sb.WriteString(fmt.Sprintf("- column_publish_prepared_assets: %d\n", stats.ColumnPublishPreparedAssets))
+	sb.WriteString(fmt.Sprintf("- column_publish_row_asset_bytes: %d\n", stats.ColumnPublishRowAssetBytes))
+	sb.WriteString(fmt.Sprintf("- column_publish_typed_column_bytes: %d\n", stats.ColumnPublishTypedColumnBytes))
+	sb.WriteString(fmt.Sprintf("- column_publish_dictionary_sidecar_bytes: %d\n", stats.ColumnPublishDictionaryBytes))
+	sb.WriteString(fmt.Sprintf("- column_publish_int64_sidecar_bytes: %d\n", stats.ColumnPublishInt64Bytes))
+	sb.WriteString(fmt.Sprintf("- column_publish_aggregate_metadata_bytes: %d\n", stats.ColumnPublishAggregateMetadataBytes))
+	sb.WriteString(fmt.Sprintf("- column_publish_shared_asset_append_bytes: %d\n", stats.ColumnPublishSharedAppendBytes))
 	sb.WriteString(fmt.Sprintf("- column_publish_required_asset_bytes: %d\n", stats.ColumnPublishRequiredAssetBytes))
 	sb.WriteString(fmt.Sprintf("- column_publish_manifest_bytes: %d\n\n", stats.ColumnPublishManifestBytes))
 
@@ -4269,6 +4357,13 @@ func renderColumnStoreInsertStatsMarkdown(sb *strings.Builder, stats columnStore
 		sb.WriteString(fmt.Sprintf("| `document_extraction` | %.3f |  |\n", stats.ColumnPublishDocumentExtractionDurationMS))
 		sb.WriteString(fmt.Sprintf("| `declared_column_encoding` | %.3f |  |\n", stats.ColumnPublishDeclaredColumnDurationMS))
 		sb.WriteString(fmt.Sprintf("| `asset_preparation` | %.3f |  |\n", stats.ColumnPublishAssetPreparationDurationMS))
+		sb.WriteString(fmt.Sprintf("| `row_asset_prepare` | %.3f |  |\n", stats.ColumnPublishRowAssetPrepareDurationMS))
+		sb.WriteString(fmt.Sprintf("| `typed_column_prepare` | %.3f |  |\n", stats.ColumnPublishTypedColumnPrepareDurationMS))
+		sb.WriteString(fmt.Sprintf("| `dictionary_sidecar_prepare` | %.3f |  |\n", stats.ColumnPublishDictionaryPrepareDurationMS))
+		sb.WriteString(fmt.Sprintf("| `int64_sidecar_prepare` | %.3f |  |\n", stats.ColumnPublishInt64PrepareDurationMS))
+		sb.WriteString(fmt.Sprintf("| `aggregate_metadata_prepare` | %.3f |  |\n", stats.ColumnPublishAggregateMetadataDurationMS))
+		sb.WriteString(fmt.Sprintf("| `row_sidecar_shared_build` | %.3f |  |\n", stats.ColumnPublishRowSidecarSharedBuildMS))
+		sb.WriteString(fmt.Sprintf("| `asset_append` | %.3f |  |\n", stats.ColumnPublishAssetAppendDurationMS))
 		sb.WriteString(fmt.Sprintf("| `manifest_encode` | %.3f |  |\n", stats.ColumnPublishManifestEncodeDurationMS))
 		sb.WriteString(fmt.Sprintf("| `asset_closure_validation` | %.3f |  |\n", stats.ColumnPublishAssetClosureDurationMS))
 		sb.WriteString(fmt.Sprintf("| `root_delta_construction` | %.3f |  |\n", stats.ColumnPublishRootDeltaDurationMS))
@@ -4284,6 +4379,13 @@ func columnStoreInsertStatsHasColumnPublishSubphase(stats columnStoreInsertPhase
 		stats.ColumnPublishDocumentExtractionDurationMS > 0 ||
 		stats.ColumnPublishDeclaredColumnDurationMS > 0 ||
 		stats.ColumnPublishAssetPreparationDurationMS > 0 ||
+		stats.ColumnPublishRowAssetPrepareDurationMS > 0 ||
+		stats.ColumnPublishTypedColumnPrepareDurationMS > 0 ||
+		stats.ColumnPublishDictionaryPrepareDurationMS > 0 ||
+		stats.ColumnPublishInt64PrepareDurationMS > 0 ||
+		stats.ColumnPublishAggregateMetadataDurationMS > 0 ||
+		stats.ColumnPublishRowSidecarSharedBuildMS > 0 ||
+		stats.ColumnPublishAssetAppendDurationMS > 0 ||
 		stats.ColumnPublishManifestEncodeDurationMS > 0 ||
 		stats.ColumnPublishAssetClosureDurationMS > 0 ||
 		stats.ColumnPublishRootDeltaDurationMS > 0 ||
@@ -4297,10 +4399,16 @@ func renderColumnStoreMetadataCostMarkdown(sb *strings.Builder, cost columnStore
 	sb.WriteString(fmt.Sprintf("- aggregate_metadata_sidecar_bytes: %d\n", cost.AggregateMetadataSidecarBytes))
 	sb.WriteString(fmt.Sprintf("- aggregate_metadata_embedded_bytes: %d\n", cost.AggregateMetadataEmbeddedBytes))
 	sb.WriteString(fmt.Sprintf("- aggregate_metadata_refs: %d\n", cost.AggregateMetadataRefs))
+	sb.WriteString(fmt.Sprintf("- aggregate_metadata_prepare_duration_ms: %.3f\n", cost.AggregateMetadataPrepareMS))
+	sb.WriteString(fmt.Sprintf("- aggregate_metadata_append_share_duration_ms: %.3f\n", cost.AggregateMetadataAppendShareMS))
+	sb.WriteString(fmt.Sprintf("- insert_cost_upper_bound_duration_ms: %.3f\n", cost.InsertCostUpperBoundMS))
 	sb.WriteString(fmt.Sprintf("- insert_cost_duration_ms: %.3f\n", cost.InsertCostDurationMS))
 	sb.WriteString(fmt.Sprintf("- insert_cost_ns_per_row: %.1f\n", cost.InsertCostNsPerRow))
 	if cost.InsertCostBasis != "" {
 		sb.WriteString(fmt.Sprintf("- insert_cost_basis: %s\n", cost.InsertCostBasis))
+	}
+	if cost.InsertCostUpperBoundBasis != "" {
+		sb.WriteString(fmt.Sprintf("- insert_cost_upper_bound_basis: %s\n", cost.InsertCostUpperBoundBasis))
 	}
 	if cost.StorageCostBasis != "" {
 		sb.WriteString(fmt.Sprintf("- storage_cost_basis: %s\n", cost.StorageCostBasis))

--- a/cmd/unified_bench/suite_column_store_test.go
+++ b/cmd/unified_bench/suite_column_store_test.go
@@ -580,12 +580,19 @@ func TestRunColumnStoreSuiteWritesArtifactsAndMetricsM11A(t *testing.T) {
 		t.Fatalf("column publish asset preparation timing missing: %+v", report.InsertStats)
 	}
 	if report.InsertStats.ColumnPublishRowAssetPrepareDurationMS <= 0 ||
+		report.InsertStats.ColumnPublishDictionaryPrepareDurationMS <= 0 ||
+		report.InsertStats.ColumnPublishInt64PrepareDurationMS <= 0 ||
 		report.InsertStats.ColumnPublishAggregateMetadataDurationMS <= 0 ||
 		report.InsertStats.ColumnPublishAssetAppendDurationMS <= 0 {
 		t.Fatalf("column publish asset-family timing missing: %+v", report.InsertStats)
 	}
 	if report.InsertStats.ColumnPublishRowAssetBytes <= 0 ||
+		report.InsertStats.ColumnPublishDictionaryBytes <= 0 ||
+		report.InsertStats.ColumnPublishDictionaryCount <= 0 ||
+		report.InsertStats.ColumnPublishInt64Bytes <= 0 ||
+		report.InsertStats.ColumnPublishInt64Count <= 0 ||
 		report.InsertStats.ColumnPublishAggregateMetadataBytes <= 0 ||
+		report.InsertStats.ColumnPublishAggregateMetadataCount <= 0 ||
 		report.InsertStats.ColumnPublishSharedAppendBytes <= 0 {
 		t.Fatalf("column publish asset-family byte counters missing: %+v", report.InsertStats)
 	}
@@ -2575,6 +2582,73 @@ func TestColumnStoreApplyMetadataCostOnlyAggregateRowsM3070(t *testing.T) {
 	}
 }
 
+func TestColumnStoreInsertPhaseMetricFromStatsIncludesAssetFamiliesM3148(t *testing.T) {
+	stats := collections.CollectionInsertStats{
+		Documents:                             10,
+		ColumnPublishRowAssetPreparation:      1 * time.Millisecond,
+		ColumnPublishTypedColumnPreparation:   2 * time.Millisecond,
+		ColumnPublishDictionaryPreparation:    3 * time.Millisecond,
+		ColumnPublishInt64Preparation:         4 * time.Millisecond,
+		ColumnPublishAggregateMetadataPrepare: 5 * time.Millisecond,
+		ColumnPublishRowSidecarSharedBuild:    6 * time.Millisecond,
+		ColumnPublishAssetAppend:              7 * time.Millisecond,
+		ColumnPublishRowAssetBytes:            101,
+		ColumnPublishRowAssetCount:            1,
+		ColumnPublishTypedColumnBytes:         202,
+		ColumnPublishTypedColumnCount:         2,
+		ColumnPublishDictionaryBytes:          303,
+		ColumnPublishDictionaryCount:          3,
+		ColumnPublishInt64Bytes:               404,
+		ColumnPublishInt64Count:               4,
+		ColumnPublishAggregateMetadataBytes:   505,
+		ColumnPublishAggregateMetadataCount:   5,
+		ColumnPublishSharedAppendBytes:        606,
+		ColumnPublishSharedAppendCount:        6,
+	}
+
+	metric := columnStoreInsertPhaseMetricFromStats(stats, 1)
+
+	if got, want := metric.ColumnPublishRowAssetPrepareDurationMS, 1.0; got != want {
+		t.Fatalf("row asset duration ms=%v want %v", got, want)
+	}
+	if got, want := metric.ColumnPublishTypedColumnPrepareDurationMS, 2.0; got != want {
+		t.Fatalf("typed-column duration ms=%v want %v", got, want)
+	}
+	if got, want := metric.ColumnPublishDictionaryPrepareDurationMS, 3.0; got != want {
+		t.Fatalf("dictionary duration ms=%v want %v", got, want)
+	}
+	if got, want := metric.ColumnPublishInt64PrepareDurationMS, 4.0; got != want {
+		t.Fatalf("int64 duration ms=%v want %v", got, want)
+	}
+	if got, want := metric.ColumnPublishAggregateMetadataDurationMS, 5.0; got != want {
+		t.Fatalf("aggregate metadata duration ms=%v want %v", got, want)
+	}
+	if got, want := metric.ColumnPublishRowSidecarSharedBuildMS, 6.0; got != want {
+		t.Fatalf("row sidecar shared duration ms=%v want %v", got, want)
+	}
+	if got, want := metric.ColumnPublishAssetAppendDurationMS, 7.0; got != want {
+		t.Fatalf("shared append duration ms=%v want %v", got, want)
+	}
+	if got, want := metric.ColumnPublishTypedColumnBytes, int64(202); got != want {
+		t.Fatalf("typed-column bytes=%d want %d", got, want)
+	}
+	if got, want := metric.ColumnPublishTypedColumnCount, 2; got != want {
+		t.Fatalf("typed-column count=%d want %d", got, want)
+	}
+	if got, want := metric.ColumnPublishDictionaryBytes, int64(303); got != want {
+		t.Fatalf("dictionary bytes=%d want %d", got, want)
+	}
+	if got, want := metric.ColumnPublishDictionaryCount, 3; got != want {
+		t.Fatalf("dictionary count=%d want %d", got, want)
+	}
+	if got, want := metric.ColumnPublishInt64Bytes, int64(404); got != want {
+		t.Fatalf("int64 bytes=%d want %d", got, want)
+	}
+	if got, want := metric.ColumnPublishInt64Count, 4; got != want {
+		t.Fatalf("int64 count=%d want %d", got, want)
+	}
+}
+
 func TestColumnStoreMetadataCostMetricUsesSplitAggregateAccountingM3148(t *testing.T) {
 	insert := columnStoreInsertPhaseMetric{
 		Documents:                                99,
@@ -2620,6 +2694,20 @@ func TestColumnStoreMetadataCostMetricUsesSplitAggregateAccountingM3148(t *testi
 	}
 	if got, want := cost.StorageCostBasis, "active_manifest_aggregate_metadata_sidecars_plus_typed_column_embedded_aggregate_sections"; got != want {
 		t.Fatalf("metadata storage cost basis=%q want %q", got, want)
+	}
+
+	unavailable := columnStoreMetadataCostMetricFromAccounting(insert, collections.ColumnStorePhysicalAccounting{}, errors.New("unavailable"))
+	if got, want := unavailable.AggregateMetadataAppendShareMS, 8.0; math.Abs(got-want) > 1e-9 {
+		t.Fatalf("unavailable accounting append share ms=%v want %v", got, want)
+	}
+	if got, want := unavailable.InsertCostDurationMS, 15.5; math.Abs(got-want) > 1e-9 {
+		t.Fatalf("unavailable accounting insert cost ms=%v want %v", got, want)
+	}
+	if got, want := unavailable.InsertCostBasis, "aggregate_metadata_prepare_duration_plus_byte_weighted_share_of_shared_batched_asset_append"; got != want {
+		t.Fatalf("unavailable accounting insert cost basis=%q want %q", got, want)
+	}
+	if !strings.Contains(unavailable.StorageCostBasis, "physical_accounting_unavailable") {
+		t.Fatalf("unavailable accounting storage basis=%q", unavailable.StorageCostBasis)
 	}
 }
 

--- a/cmd/unified_bench/suite_column_store_test.go
+++ b/cmd/unified_bench/suite_column_store_test.go
@@ -2575,6 +2575,54 @@ func TestColumnStoreApplyMetadataCostOnlyAggregateRowsM3070(t *testing.T) {
 	}
 }
 
+func TestColumnStoreMetadataCostMetricUsesSplitAggregateAccountingM3148(t *testing.T) {
+	insert := columnStoreInsertPhaseMetric{
+		Documents:                                99,
+		ColumnPublishRows:                        10,
+		ColumnPublishAssetPreparationDurationMS:  100,
+		ColumnPublishAggregateMetadataDurationMS: 7.5,
+		ColumnPublishAssetAppendDurationMS:       20,
+		ColumnPublishAggregateMetadataBytes:      400,
+		ColumnPublishSharedAppendBytes:           1000,
+	}
+	accounting := collections.ColumnStorePhysicalAccounting{
+		AggregateMetadataRefs: 2,
+		Totals: collections.ColumnStorePhysicalAccountingTotals{
+			AggregateMetadataBytes: 300,
+		},
+	}
+
+	cost := columnStoreMetadataCostMetricFromAccounting(insert, accounting, nil)
+
+	if got, want := cost.AggregateMetadataStorageBytes, int64(300); got != want {
+		t.Fatalf("aggregate metadata storage bytes=%d want %d", got, want)
+	}
+	if got, want := cost.AggregateMetadataPrepareMS, 7.5; math.Abs(got-want) > 1e-9 {
+		t.Fatalf("aggregate metadata prepare ms=%v want %v", got, want)
+	}
+	if got, want := cost.AggregateMetadataAppendShareMS, 8.0; math.Abs(got-want) > 1e-9 {
+		t.Fatalf("aggregate metadata append share ms=%v want %v", got, want)
+	}
+	if got, want := cost.InsertCostDurationMS, 15.5; math.Abs(got-want) > 1e-9 {
+		t.Fatalf("metadata insert cost ms=%v want %v", got, want)
+	}
+	if got, want := cost.InsertCostUpperBoundMS, 100.0; math.Abs(got-want) > 1e-9 {
+		t.Fatalf("metadata insert cost upper bound ms=%v want %v", got, want)
+	}
+	if got, want := cost.InsertCostNsPerRow, 1_550_000.0; math.Abs(got-want) > 1e-3 {
+		t.Fatalf("metadata insert cost ns/row=%v want %v", got, want)
+	}
+	if got, want := cost.InsertCostBasis, "aggregate_metadata_prepare_duration_plus_byte_weighted_share_of_shared_batched_asset_append"; got != want {
+		t.Fatalf("metadata insert cost basis=%q want %q", got, want)
+	}
+	if got, want := cost.InsertCostUpperBoundBasis, "column_publish_asset_preparation_total_upper_bound_all_asset_families"; got != want {
+		t.Fatalf("metadata insert cost upper bound basis=%q want %q", got, want)
+	}
+	if got, want := cost.StorageCostBasis, "active_manifest_aggregate_metadata_sidecars_plus_typed_column_embedded_aggregate_sections"; got != want {
+		t.Fatalf("metadata storage cost basis=%q want %q", got, want)
+	}
+}
+
 func TestColumnStorePhaseDurationsUsesMeasuredHotRun1955(t *testing.T) {
 	diag := collections.ColumnPhysicalQueryDiagnostics{
 		ScanNanos:        int64(9 * time.Millisecond),

--- a/cmd/unified_bench/suite_column_store_test.go
+++ b/cmd/unified_bench/suite_column_store_test.go
@@ -579,6 +579,23 @@ func TestRunColumnStoreSuiteWritesArtifactsAndMetricsM11A(t *testing.T) {
 	if report.InsertStats.ColumnPublishAssetPreparationDurationMS <= 0 {
 		t.Fatalf("column publish asset preparation timing missing: %+v", report.InsertStats)
 	}
+	if report.InsertStats.ColumnPublishRowAssetPrepareDurationMS <= 0 ||
+		report.InsertStats.ColumnPublishAggregateMetadataDurationMS <= 0 ||
+		report.InsertStats.ColumnPublishAssetAppendDurationMS <= 0 {
+		t.Fatalf("column publish asset-family timing missing: %+v", report.InsertStats)
+	}
+	if report.InsertStats.ColumnPublishRowAssetBytes <= 0 ||
+		report.InsertStats.ColumnPublishAggregateMetadataBytes <= 0 ||
+		report.InsertStats.ColumnPublishSharedAppendBytes <= 0 {
+		t.Fatalf("column publish asset-family byte counters missing: %+v", report.InsertStats)
+	}
+	if report.MetadataCost.AggregateMetadataPrepareMS <= 0 || report.MetadataCost.InsertCostDurationMS <= 0 || report.MetadataCost.InsertCostUpperBoundMS <= 0 {
+		t.Fatalf("metadata cost missing split insert accounting: %+v", report.MetadataCost)
+	}
+	if report.MetadataCost.InsertCostBasis == "column_publish_asset_preparation_total_current_upper_bound" ||
+		report.MetadataCost.InsertCostBasis == "column_publish_asset_preparation_total_upper_bound_all_asset_families" {
+		t.Fatalf("metadata cost basis should not be full asset-preparation upper bound when metadata refs exist: %+v", report.MetadataCost)
+	}
 	if report.InsertStats.ColumnPublishManifestEncodeDurationMS < 0 || report.InsertStats.ColumnPublishRootDeltaDurationMS < 0 {
 		t.Fatalf("column publish tiny subphase timing invalid: %+v", report.InsertStats)
 	}
@@ -682,12 +699,12 @@ func TestRunColumnStoreSuiteWritesArtifactsAndMetricsM11A(t *testing.T) {
 			t.Fatalf("column store JSON missing WAL-excluded durable storage field %s:\n%s", want, data)
 		}
 	}
-	for _, want := range []string{`"insert_stats"`, `"retained_payload_prepare_duration_ms"`, `"retained_payload_prepare_ns_per_row"`, `"retained_payload_declared_rows"`, `"column_store_declared_row_reuse_coverage_ratio"`, `"column_publish_build_column_delta_duration_ms"`, `"column_publish_commit_duration_ms"`, `"column_publish_asset_preparation_duration_ms"`, `"column_publish_required_asset_bytes"`} {
+	for _, want := range []string{`"insert_stats"`, `"retained_payload_prepare_duration_ms"`, `"retained_payload_prepare_ns_per_row"`, `"retained_payload_declared_rows"`, `"column_store_declared_row_reuse_coverage_ratio"`, `"column_publish_build_column_delta_duration_ms"`, `"column_publish_commit_duration_ms"`, `"column_publish_asset_preparation_duration_ms"`, `"column_publish_row_asset_prepare_duration_ms"`, `"column_publish_aggregate_metadata_prepare_duration_ms"`, `"column_publish_asset_append_duration_ms"`, `"column_publish_aggregate_metadata_bytes"`, `"column_publish_shared_asset_append_bytes"`, `"column_publish_required_asset_bytes"`} {
 		if !strings.Contains(string(data), want) {
 			t.Fatalf("column store JSON missing insert phase field %s:\n%s", want, data)
 		}
 	}
-	for _, want := range []string{`"jsonbench_cells"`, `"cell_label"`, `"sort_layout"`, `"execution_mode"`, `"metadata_data_scan_path"`, `"metadata_cost"`, `"aggregate_metadata_storage_bytes"`, `"aggregate_metadata_sidecar_bytes"`, `"aggregate_metadata_embedded_bytes"`, `"aggregate_metadata_refs"`, `"insert_cost_basis"`, `"storage_cost_basis"`, `"mutation_mode"`, `"retained_payload_policy"`, `"retained_payload_encoding"`, `"retained_payload_encoding_status"`, `"retained_payload_compression"`, `"retained_payload_compression_policy"`, `"retained_payload_compression_status"`, `"typed_storage_owner"`, `"row_count"`, `"reconstruction_status"`, `"full_data_caveat"`, `"storage_accounting_caveat"`, `"external_jsonbench_status"`, `"colgranule_reuse_map"`, `"codec_layouts"`, `"compression_attribution"`, `"codec_layout_label"`, `"compression_policy_label"`, `"compressed_bytes"`, `"decompressed_bytes"`, `"raw_bytes"`, `"compression_ratio"`, `"compression_duration_source"`, `"decompression_duration_source"`, `"benchmark_b_per_op"`, `"benchmark_allocs_per_op"`, `"benchmark_allocation_source"`} {
+	for _, want := range []string{`"jsonbench_cells"`, `"cell_label"`, `"sort_layout"`, `"execution_mode"`, `"metadata_data_scan_path"`, `"metadata_cost"`, `"aggregate_metadata_storage_bytes"`, `"aggregate_metadata_sidecar_bytes"`, `"aggregate_metadata_embedded_bytes"`, `"aggregate_metadata_refs"`, `"aggregate_metadata_prepare_duration_ms"`, `"aggregate_metadata_append_share_duration_ms"`, `"insert_cost_upper_bound_duration_ms"`, `"insert_cost_basis"`, `"insert_cost_upper_bound_basis"`, `"storage_cost_basis"`, `"mutation_mode"`, `"retained_payload_policy"`, `"retained_payload_encoding"`, `"retained_payload_encoding_status"`, `"retained_payload_compression"`, `"retained_payload_compression_policy"`, `"retained_payload_compression_status"`, `"typed_storage_owner"`, `"row_count"`, `"reconstruction_status"`, `"full_data_caveat"`, `"storage_accounting_caveat"`, `"external_jsonbench_status"`, `"colgranule_reuse_map"`, `"codec_layouts"`, `"compression_attribution"`, `"codec_layout_label"`, `"compression_policy_label"`, `"compressed_bytes"`, `"decompressed_bytes"`, `"raw_bytes"`, `"compression_ratio"`, `"compression_duration_source"`, `"decompression_duration_source"`, `"benchmark_b_per_op"`, `"benchmark_allocs_per_op"`, `"benchmark_allocation_source"`} {
 		if !strings.Contains(string(data), want) {
 			t.Fatalf("column store JSON missing reporting field %s:\n%s", want, data)
 		}
@@ -715,12 +732,12 @@ func TestRunColumnStoreSuiteWritesArtifactsAndMetricsM11A(t *testing.T) {
 			t.Fatalf("column store markdown missing WAL-excluded durable storage field %q:\n%s", want, columnMarkdown)
 		}
 	}
-	for _, want := range []string{"## Insert Phase Stats", "retained_payload_prepare", "retained_payload_declared_rows", "column_store_declared_row_reuse_coverage_ratio", "column_publish_rows", "column publish subphase", "build_column_delta_callback", "publish_commit_total"} {
+	for _, want := range []string{"## Insert Phase Stats", "retained_payload_prepare", "retained_payload_declared_rows", "column_store_declared_row_reuse_coverage_ratio", "column_publish_rows", "column_publish_aggregate_metadata_bytes", "column publish subphase", "build_column_delta_callback", "publish_commit_total", "aggregate_metadata_prepare", "asset_append"} {
 		if !strings.Contains(string(columnMarkdown), want) {
 			t.Fatalf("column store markdown missing insert phase field %q:\n%s", want, columnMarkdown)
 		}
 	}
-	for _, want := range []string{"## Metadata Cost", "aggregate_metadata_storage_bytes", "insert_cost_basis", "storage_cost_basis", "## Production JSONBench Synthetic Cells", "## Colgranule Reuse Map", "metadata/data path", "metadata cost B", "metadata cost insert ms", "metadata cost basis", "retained payload", "retained encoding", "retained compression", "typed owner", "typed cells visited", "typed cells basis", "document materializations", "aggregate metadata used", "sort/topk pruning", "json reconstruction", "full-data caveat", "## Query Compression And Allocation Attribution", "## Codec/Layout Matrix", "codec/layout", "compression policy", "compressed bytes", "decompressed bytes", "raw bytes", "B/op", "allocs/op", columnStoreCompressionPolicyOff, columnStoreCompressionPolicyDefault} {
+	for _, want := range []string{"## Metadata Cost", "aggregate_metadata_storage_bytes", "aggregate_metadata_prepare_duration_ms", "aggregate_metadata_append_share_duration_ms", "insert_cost_upper_bound_duration_ms", "insert_cost_basis", "insert_cost_upper_bound_basis", "storage_cost_basis", "## Production JSONBench Synthetic Cells", "## Colgranule Reuse Map", "metadata/data path", "metadata cost B", "metadata cost insert ms", "metadata cost basis", "retained payload", "retained encoding", "retained compression", "typed owner", "typed cells visited", "typed cells basis", "document materializations", "aggregate metadata used", "sort/topk pruning", "json reconstruction", "full-data caveat", "## Query Compression And Allocation Attribution", "## Codec/Layout Matrix", "codec/layout", "compression policy", "compressed bytes", "decompressed bytes", "raw bytes", "B/op", "allocs/op", columnStoreCompressionPolicyOff, columnStoreCompressionPolicyDefault} {
 		if !strings.Contains(string(columnMarkdown), want) {
 			t.Fatalf("column store markdown missing reporting field %q:\n%s", want, columnMarkdown)
 		}


### PR DESCRIPTION
## Objective

Split TreeDB column-store insert/load accounting so aggregate metadata write-side cost is reported separately from row assets, typed-column parts, dictionary-code sidecars, int64 sidecars, and shared batched asset appends.

This closes the instrumentation/accounting slice for #3148 and feeds the realigned JSONBench/ClickHouse trackers #3000, #3001, #3067, and #3099. It does not claim broad TreeDB SQL superiority; it makes metadata-backed query wins carry clearer write-side cost evidence.

## Context

The realigned benchmark goal treats aggregate metadata as an acceleration layer, not proof of general columnar SQL performance. Before this PR, `metadata_cost.insert_cost_duration_ms` used the full `column_publish_asset_preparation_duration_ms` upper bound, which was honest but too coarse to isolate aggregate metadata maintenance cost from other production assets.

## Non-goals

- No query execution changes.
- No new metadata planner eligibility or SQL superiority claim.
- No on-disk format, manifest, or asset-storage behavior changes.
- No attempt to close the remaining TreeDB vs ClickHouse load gap.

## Design

- Adds `ColumnPublishAssetPreparationMetrics` to the existing column publish plan/prepare path.
- Records production-path durations, bytes, and counts for row assets, typed-column parts, dictionary sidecars, int64 sidecars, aggregate metadata, fused row-sidecar shared build, and shared batched append.
- Measures shared batched append around appender setup/open/seek, actual asset append calls, and close, while excluding per-asset validation/bookkeeping for already referenced assets.
- Reports aggregate metadata append cost as a byte-weighted share of shared batched append time.
- Preserves the old full `asset_preparation` number as `metadata_cost.insert_cost_upper_bound_duration_ms` with a clearly labeled basis.
- If physical storage accounting is unavailable, preserves split insert-cost timing when aggregate metadata split metrics exist and marks only the storage basis unavailable.
- Updates `column_store_results.json` and markdown so reports expose both the split cost and the conservative upper bound.

## Scope

Includes:
- `TreeDB/collections` insert/publish metric plumbing and benchmark counters.
- `cmd/unified_bench` JSON/markdown report fields and metadata-cost basis.
- Focused report tests that require split metadata-cost fields when aggregate metadata refs exist.
- Deterministic tests for asset-family metric mapping, the split metadata-cost formula, selected basis, upper-bound basis, fallback behavior, and ns/row accounting.

Excludes:
- Query planner/runtime changes.
- Storage format changes.
- ClickHouse comparator changes.

## Correctness

Tests run locally on latest head `d63673b2e`:

```bash
go test ./cmd/unified_bench -run 'TestColumnStoreInsertPhaseMetricFromStatsIncludesAssetFamiliesM3148|TestColumnStoreMetadataCostMetricUsesSplitAggregateAccountingM3148|TestColumnStoreApplyMetadataCostOnlyAggregateRowsM3070|TestColumnStoreSuiteReports|TestColumnStoreSuiteWALExcludedDurableStorageAccounting1954' -count=1
# ok github.com/snissn/gomap/cmd/unified_bench 1.845s

go test ./TreeDB/collections -run 'TestColumnStoreCommandWALWritesPhysicalColumnAssetsM12A|TestColumnStoreCommandWALInsertPublishesManifestM10B|TestBenchmarkReportCollectionInsertStatsIncludesColumnPublishExtractionM10B' -count=1
# ok github.com/snissn/gomap/TreeDB/collections 0.769s

go test ./TreeDB/collections ./cmd/unified_bench -count=1
# ok github.com/snissn/gomap/TreeDB/collections 52.030s
# ok github.com/snissn/gomap/cmd/unified_bench 34.249s

git diff --check
# clean
```

No corruption/concurrency behavior is changed. This is metric/report wiring over the existing synchronous publish path.

## Performance

Benchmark/report command:

```bash
go build -o ./bin/unified-bench ./cmd/unified_bench
OUT=/tmp/gomap_column_store_metadata_cost_split_100k_reviewfix_20260626_184123
./bin/unified-bench \
  -suite column_store \
  -dbs treedb \
  -profile durable \
  -keys 100000 \
  -batchsize 1000 \
  -profile-dir "$OUT" \
  -path-label native-fastpath \
  -column-store-path serial_column_scan \
  -column-store-query q1 \
  -progress=false
```

100k report evidence from `/tmp/gomap_column_store_metadata_cost_split_100k_reviewfix_20260626_184123/column_store_results.json`:

| Metric | Value |
| --- | ---: |
| `insert_stats.column_publish_asset_preparation_duration_ms` | 415.935 |
| `insert_stats.column_publish_row_asset_prepare_duration_ms` | 19.383 |
| `insert_stats.column_publish_dictionary_sidecar_prepare_duration_ms` | 11.566 |
| `insert_stats.column_publish_int64_sidecar_prepare_duration_ms` | 3.929 |
| `insert_stats.column_publish_aggregate_metadata_prepare_duration_ms` | 45.116 |
| `insert_stats.column_publish_asset_append_duration_ms` | 335.135 |
| `insert_stats.column_publish_aggregate_metadata_bytes` | 9,483,700 B |
| `insert_stats.column_publish_shared_asset_append_bytes` | 23,055,800 B |
| `metadata_cost.aggregate_metadata_append_share_duration_ms` | 137.853 |
| `metadata_cost.insert_cost_duration_ms` | 182.969 |
| `metadata_cost.insert_cost_ns_per_row` | 1,829.7 |
| `metadata_cost.insert_cost_upper_bound_duration_ms` | 415.935 |
| `metadata_cost.insert_cost_basis` | `aggregate_metadata_prepare_duration_plus_byte_weighted_share_of_shared_batched_asset_append` |
| `metadata_cost.insert_cost_upper_bound_basis` | `column_publish_asset_preparation_total_upper_bound_all_asset_families` |

This is a single focused report capture, not a before/after speedup claim. The production load gap remains a blocker for the broader tracker, and this PR makes the next bottleneck visible: shared asset append is the largest reported subphase in this 100k run.

## Rollout / Toggle Plan

Default setting: always-on reporting fields for existing column-store benchmark/report paths.

Disable/revert: revert this PR; it does not add config knobs or behavior-affecting storage/query paths.

## Follow-ups

- Use the new insert subphase counters to target shared asset append/write overhead.
- Keep tracker acceptance focused on one-shot end-to-end, no-aggregate-metadata scans, arbitrary-expression scans, automatic metadata acceleration with write-side cost, and load speed versus ClickHouse.

## AI Review Loop

- Codex latest-head review: requested after `d63673b2e`.
- Copilot latest-head review: requested after `d63673b2e`.
- CodeRabbit latest-head review: requested after `d63673b2e`.
- Review comments/threads resolved or explicitly dismissed: pending latest-head review sweep.
- Re-requested after final meaningful push: yes, after review-fix commit `d63673b2e`.

---

## Optimization PR Checklist (TreeDB)

### Scope
- [x] Single, clear objective for this PR (not a bundle)
- [x] Explicit include list (files/symbols touched)
- [x] Explicit exclude list (files/symbols NOT touched)
- [x] No unwanted feature reintroduction

### Safety / Correctness
- [x] Clear written-vs-durable semantics for any `*Sync` path touched: not applicable, no durability semantics changed
- [x] No new mmap usage on mutable/truncating files
- [x] All new length fields are capped before allocation: no new allocation from untrusted length fields
- [x] CRC/checksum behavior is fail-closed: unchanged
- [x] Any concurrency change has a defined state machine and invariants: no concurrency change

### Tests
- [x] Added/updated deterministic report tests for the targeted accounting behavior
- [x] Tests avoid sleeps where possible
- [x] Added corruption/edge-case tests when format/parsing changes: not applicable, no format/parsing change
- [x] Ran locally targeted packages/benchmarks listed above

### Benchmarks / Measurements
- [x] Added/updated benchmark/report metrics relevant to the change
- [x] Reported results in PR description
- [x] Included incompressible results if compression is involved: not applicable

### Docs
- [x] Updated PR description with new metric basis and caveats
- [x] Documented any new config knobs + defaults: no new knobs
- [x] Called out any format change in PR description: no format change

### Rollout / Toggle Plan
- [x] Safe defaults
- [x] Clear knobs to disable/revert behavior quickly
- [x] Observability: new counters in JSON/markdown reports
