### PR TITLE
TreeDB: batch shared column asset appends

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -508,6 +508,9 @@ type CollectionInsertStats struct {
 	ColumnPublishAggregateMetadataPrepare time.Duration
 	ColumnPublishRowSidecarSharedBuild    time.Duration
 	ColumnPublishAssetAppend              time.Duration
+	ColumnPublishAssetAppendOpen          time.Duration
+	ColumnPublishAssetAppendWrite         time.Duration
+	ColumnPublishAssetAppendClose         time.Duration
 	ColumnPublishManifestEncode           time.Duration
 	ColumnPublishAssetClosureValidation   time.Duration
 	ColumnPublishRootDeltaConstruction    time.Duration

--- a/TreeDB/collections/column_asset_manager.go
+++ b/TreeDB/collections/column_asset_manager.go
@@ -390,7 +390,7 @@ func writeColumnAssetToManagerSegment(rootDir string, cfg ColumnStoreConfig, pay
 	segmentLock := columnAssetSegmentWriteLock(assetPath)
 	segmentLock.Lock()
 	defer segmentLock.Unlock()
-	file, err := os.OpenFile(assetPath, os.O_CREATE|os.O_RDWR|os.O_APPEND, 0o600)
+	file, created, err := openColumnAssetSegmentAppendFile(assetPath)
 	if err != nil {
 		return ColumnAssetRef{}, err
 	}
@@ -430,8 +430,10 @@ func writeColumnAssetToManagerSegment(rootDir string, cfg ColumnStoreConfig, pay
 		return ColumnAssetRef{}, err
 	}
 	closeFile = false
-	if err := syncColumnAssetDir(namespace.SegmentDir); err != nil {
-		return ColumnAssetRef{}, err
+	if created {
+		if err := syncColumnAssetDir(namespace.SegmentDir); err != nil {
+			return ColumnAssetRef{}, err
+		}
 	}
 	ref.Offset = offset
 	return ref, nil
@@ -545,17 +547,25 @@ func advanceColumnAssetSegmentFileIDCache(cleanSegmentDir string, cache *columnA
 }
 
 type columnPhysicalAssetSegmentAppender struct {
-	cfg           ColumnStoreConfig
-	namespace     columnAssetManagerNamespace
-	fileID        uint32
-	assetPath     string
-	file          *os.File
-	offset        int64
-	failed        bool
-	lock          *sync.Mutex
-	closeFile     bool
-	unlockLock    bool
-	removeOnClose bool
+	cfg            ColumnStoreConfig
+	namespace      columnAssetManagerNamespace
+	fileID         uint32
+	assetPath      string
+	file           *os.File
+	offset         int64
+	failed         bool
+	lock           *sync.Mutex
+	syncDirOnClose bool
+	closeFile      bool
+	unlockLock     bool
+	removeOnClose  bool
+}
+
+type columnPhysicalAssetAppendItem struct {
+	payload    []byte
+	kind       ColumnAssetKind
+	generation uint64
+	partID     uint64
 }
 
 func newColumnPhysicalAssetSegmentAppender(rootDir string, cfg ColumnStoreConfig, fileID uint32) (*columnPhysicalAssetSegmentAppender, error) {
@@ -592,13 +602,14 @@ func newColumnPhysicalAssetSegmentAppender(rootDir string, cfg ColumnStoreConfig
 	segmentLock := columnAssetSegmentWriteLock(assetPath)
 	segmentLock.Lock()
 	appender := &columnPhysicalAssetSegmentAppender{
-		cfg:           cfg,
-		namespace:     namespace,
-		fileID:        fileID,
-		assetPath:     assetPath,
-		lock:          segmentLock,
-		unlockLock:    true,
-		removeOnClose: true,
+		cfg:            cfg,
+		namespace:      namespace,
+		fileID:         fileID,
+		assetPath:      assetPath,
+		lock:           segmentLock,
+		syncDirOnClose: true,
+		unlockLock:     true,
+		removeOnClose:  true,
 	}
 	file, err := os.OpenFile(assetPath, os.O_CREATE|os.O_EXCL|os.O_RDWR, 0o600)
 	if err != nil {
@@ -651,7 +662,7 @@ func newColumnPhysicalAssetSegmentAppendWriter(rootDir string, cfg ColumnStoreCo
 		lock:       segmentLock,
 		unlockLock: true,
 	}
-	file, err := os.OpenFile(assetPath, os.O_CREATE|os.O_RDWR|os.O_APPEND, 0o600)
+	file, created, err := openColumnAssetSegmentAppendFile(assetPath)
 	if err != nil {
 		appender.releaseLock()
 		return nil, err
@@ -664,8 +675,24 @@ func newColumnPhysicalAssetSegmentAppendWriter(rootDir string, cfg ColumnStoreCo
 	}
 	appender.file = file
 	appender.offset = offset
+	appender.syncDirOnClose = created
 	appender.closeFile = true
 	return appender, nil
+}
+
+func openColumnAssetSegmentAppendFile(assetPath string) (*os.File, bool, error) {
+	file, err := os.OpenFile(assetPath, os.O_CREATE|os.O_EXCL|os.O_RDWR|os.O_APPEND, 0o600)
+	if err == nil {
+		return file, true, nil
+	}
+	if !errors.Is(err, os.ErrExist) {
+		return nil, false, err
+	}
+	file, err = os.OpenFile(assetPath, os.O_RDWR|os.O_APPEND, 0o600)
+	if err != nil {
+		return nil, false, err
+	}
+	return file, false, nil
 }
 
 func (a *columnPhysicalAssetSegmentAppender) append(payload []byte, generation, partID uint64) (ColumnAssetRef, error) {
@@ -723,6 +750,79 @@ func (a *columnPhysicalAssetSegmentAppender) appendKindWithAlignment(payload []b
 		return ColumnAssetRef{}, err
 	}
 	return ref, nil
+}
+
+func (a *columnPhysicalAssetSegmentAppender) appendKinds(items []columnPhysicalAssetAppendItem) ([]ColumnAssetRef, error) {
+	if len(items) == 0 {
+		return nil, nil
+	}
+	if a == nil || a.file == nil {
+		return nil, errors.New("collections: nil column physical asset appender")
+	}
+	if a.failed {
+		return nil, errors.New("collections: column physical asset appender is failed")
+	}
+	const maxInt64 = int64(1<<63 - 1)
+	maxInt := int(^uint(0) >> 1)
+	refs := make([]ColumnAssetRef, len(items))
+	totalLength := 0
+	nextOffset := a.offset
+	for i, item := range items {
+		if len(item.payload) == 0 {
+			return nil, errors.New("collections: column physical asset payload is empty")
+		}
+		if item.generation == 0 || item.partID == 0 {
+			return nil, errors.New("collections: column physical asset append requires generation and part_id")
+		}
+		padding := columnAssetSegmentPrefixPadding(nextOffset, columnAssetSegmentPayloadAlignment(item.kind, a.cfg))
+		if totalLength > maxInt-padding-len(item.payload) {
+			return nil, errors.New("collections: column physical asset append batch is too large")
+		}
+		if nextOffset > maxInt64-int64(padding)-int64(len(item.payload)) {
+			return nil, errors.New("collections: column physical asset append offset overflow")
+		}
+		nextOffset += int64(padding)
+		refs[i] = ColumnAssetRef{
+			Kind:       item.kind,
+			Namespace:  a.cfg.AssetManager.Namespace,
+			Generation: item.generation,
+			PartID:     item.partID,
+			FileID:     a.fileID,
+			Offset:     nextOffset,
+			Length:     int64(len(item.payload)),
+			Checksum:   page.Checksum(item.payload),
+		}
+		nextOffset += int64(len(item.payload))
+		totalLength += padding + len(item.payload)
+	}
+	payload := make([]byte, 0, totalLength)
+	cursor := a.offset
+	var zeros [typedColumnPartDirectViewAssetAlignment]byte
+	for i, item := range items {
+		padding := int(refs[i].Offset - cursor)
+		for padding > 0 {
+			chunk := padding
+			if chunk > len(zeros) {
+				chunk = len(zeros)
+			}
+			payload = append(payload, zeros[:chunk]...)
+			padding -= chunk
+		}
+		payload = append(payload, item.payload...)
+		cursor = refs[i].Offset + refs[i].Length
+	}
+	written, err := writeColumnAssetSegmentPayload(a.file, payload)
+	a.offset += int64(written)
+	if err != nil {
+		a.failed = true
+		return nil, err
+	}
+	if written != len(payload) {
+		a.failed = true
+		return nil, io.ErrShortWrite
+	}
+	a.offset = nextOffset
+	return refs, nil
 }
 
 func columnAssetSegmentPayloadAlignment(kind ColumnAssetKind, cfg ColumnStoreConfig) int64 {
@@ -812,7 +912,10 @@ func (a *columnPhysicalAssetSegmentAppender) close() error {
 		a.closeFile = false
 		a.file = nil
 	}
-	dirSyncErr := syncColumnAssetDir(a.namespace.SegmentDir)
+	var dirSyncErr error
+	if a.syncDirOnClose {
+		dirSyncErr = syncColumnAssetDir(a.namespace.SegmentDir)
+	}
 	var removeErr error
 	removeOnClose := a.removeOnClose && columnPhysicalAssetSegmentAppenderRemoveOnClose(a.failed, fileSyncErr, fileCloseErr, dirSyncErr)
 	if removeOnClose && a.assetPath != "" {

--- a/TreeDB/collections/column_asset_manager.go
+++ b/TreeDB/collections/column_asset_manager.go
@@ -61,6 +61,7 @@ var columnAssetVerifiedChecksumCache = struct {
 }{}
 
 var columnAssetManagerNamespacePathCaches [columnAssetSegmentWriteLockStripes]columnAssetManagerNamespacePathCache
+var columnAssetSegmentDirSyncCaches [columnAssetSegmentWriteLockStripes]columnAssetSegmentDirSyncCache
 
 type columnAssetVerifiedChecksumEntry struct {
 	key   columnAssetVerifiedChecksumKey
@@ -95,6 +96,12 @@ type columnAssetSegmentAllocationCache struct {
 	segmentDir string
 	nextFileID uint32
 	valid      bool
+}
+
+type columnAssetSegmentDirSyncCache struct {
+	sync.Mutex
+	assetPath string
+	known     bool
 }
 
 type columnAssetManagerNamespacePathCache struct {
@@ -394,6 +401,7 @@ func writeColumnAssetToManagerSegment(rootDir string, cfg ColumnStoreConfig, pay
 	if err != nil {
 		return ColumnAssetRef{}, err
 	}
+	needsDirSync := created || !columnAssetSegmentDirSyncKnown(assetPath)
 	closeFile := true
 	defer func() {
 		if closeFile {
@@ -430,10 +438,11 @@ func writeColumnAssetToManagerSegment(rootDir string, cfg ColumnStoreConfig, pay
 		return ColumnAssetRef{}, err
 	}
 	closeFile = false
-	if created {
+	if needsDirSync {
 		if err := syncColumnAssetDir(namespace.SegmentDir); err != nil {
 			return ColumnAssetRef{}, err
 		}
+		markColumnAssetSegmentDirSynced(assetPath)
 	}
 	ref.Offset = offset
 	return ref, nil
@@ -675,7 +684,7 @@ func newColumnPhysicalAssetSegmentAppendWriter(rootDir string, cfg ColumnStoreCo
 	}
 	appender.file = file
 	appender.offset = offset
-	appender.syncDirOnClose = created
+	appender.syncDirOnClose = created || !columnAssetSegmentDirSyncKnown(assetPath)
 	appender.closeFile = true
 	return appender, nil
 }
@@ -916,6 +925,9 @@ func (a *columnPhysicalAssetSegmentAppender) close() error {
 	if a.syncDirOnClose {
 		dirSyncErr = syncColumnAssetDir(a.namespace.SegmentDir)
 	}
+	if a.syncDirOnClose && dirSyncErr == nil && !a.failed && fileSyncErr == nil && fileCloseErr == nil {
+		markColumnAssetSegmentDirSynced(a.assetPath)
+	}
 	var removeErr error
 	removeOnClose := a.removeOnClose && columnPhysicalAssetSegmentAppenderRemoveOnClose(a.failed, fileSyncErr, fileCloseErr, dirSyncErr)
 	if removeOnClose && a.assetPath != "" {
@@ -923,6 +935,9 @@ func (a *columnPhysicalAssetSegmentAppender) close() error {
 		if errors.Is(removeErr, os.ErrNotExist) {
 			removeErr = nil
 		}
+	}
+	if removeOnClose && removeErr == nil {
+		clearColumnAssetSegmentDirSyncKnown(a.assetPath)
 	}
 	var removeDirSyncErr error
 	if removeOnClose && removeErr == nil {
@@ -952,6 +967,9 @@ func (a *columnPhysicalAssetSegmentAppender) abort() error {
 		if errors.Is(removeErr, os.ErrNotExist) {
 			removeErr = nil
 		}
+	}
+	if a.removeOnClose && removeErr == nil {
+		clearColumnAssetSegmentDirSyncKnown(a.assetPath)
 	}
 	var syncErr error
 	if a.removeOnClose {
@@ -1790,6 +1808,40 @@ func columnAssetSegmentAllocationLockIndex(segmentDir string) uint64 {
 
 func columnAssetSegmentWriteLock(assetPath string) *sync.Mutex {
 	return &columnAssetSegmentWriteLocks[columnAssetSegmentLockIndex(filepath.Clean(assetPath))]
+}
+
+func columnAssetSegmentDirSyncKnown(assetPath string) bool {
+	cleanPath := filepath.Clean(assetPath)
+	cache := &columnAssetSegmentDirSyncCaches[columnAssetSegmentLockIndex(cleanPath)]
+	cache.Lock()
+	defer cache.Unlock()
+	return cache.known && cache.assetPath == cleanPath
+}
+
+func markColumnAssetSegmentDirSynced(assetPath string) {
+	if assetPath == "" {
+		return
+	}
+	cleanPath := filepath.Clean(assetPath)
+	cache := &columnAssetSegmentDirSyncCaches[columnAssetSegmentLockIndex(cleanPath)]
+	cache.Lock()
+	cache.assetPath = cleanPath
+	cache.known = true
+	cache.Unlock()
+}
+
+func clearColumnAssetSegmentDirSyncKnown(assetPath string) {
+	if assetPath == "" {
+		return
+	}
+	cleanPath := filepath.Clean(assetPath)
+	cache := &columnAssetSegmentDirSyncCaches[columnAssetSegmentLockIndex(cleanPath)]
+	cache.Lock()
+	if cache.known && cache.assetPath == cleanPath {
+		cache.known = false
+		cache.assetPath = ""
+	}
+	cache.Unlock()
 }
 
 func columnAssetSegmentLockIndex(name string) uint64 {

--- a/TreeDB/collections/column_asset_manager.go
+++ b/TreeDB/collections/column_asset_manager.go
@@ -397,11 +397,10 @@ func writeColumnAssetToManagerSegment(rootDir string, cfg ColumnStoreConfig, pay
 	segmentLock := columnAssetSegmentWriteLock(assetPath)
 	segmentLock.Lock()
 	defer segmentLock.Unlock()
-	file, created, err := openColumnAssetSegmentAppendFile(assetPath)
+	file, needsDirSync, err := openColumnAssetSegmentAppendFile(assetPath)
 	if err != nil {
 		return ColumnAssetRef{}, err
 	}
-	needsDirSync := created || !columnAssetSegmentDirSyncKnown(assetPath)
 	closeFile := true
 	defer func() {
 		if closeFile {
@@ -671,7 +670,7 @@ func newColumnPhysicalAssetSegmentAppendWriter(rootDir string, cfg ColumnStoreCo
 		lock:       segmentLock,
 		unlockLock: true,
 	}
-	file, created, err := openColumnAssetSegmentAppendFile(assetPath)
+	file, needsDirSync, err := openColumnAssetSegmentAppendFile(assetPath)
 	if err != nil {
 		appender.releaseLock()
 		return nil, err
@@ -684,7 +683,7 @@ func newColumnPhysicalAssetSegmentAppendWriter(rootDir string, cfg ColumnStoreCo
 	}
 	appender.file = file
 	appender.offset = offset
-	appender.syncDirOnClose = created || !columnAssetSegmentDirSyncKnown(assetPath)
+	appender.syncDirOnClose = needsDirSync
 	appender.closeFile = true
 	return appender, nil
 }
@@ -701,7 +700,7 @@ func openColumnAssetSegmentAppendFile(assetPath string) (*os.File, bool, error) 
 	if err != nil {
 		return nil, false, err
 	}
-	return file, false, nil
+	return file, !columnAssetSegmentDirSyncKnown(assetPath), nil
 }
 
 func (a *columnPhysicalAssetSegmentAppender) append(payload []byte, generation, partID uint64) (ColumnAssetRef, error) {

--- a/TreeDB/collections/column_physical_asset_test.go
+++ b/TreeDB/collections/column_physical_asset_test.go
@@ -2132,6 +2132,46 @@ func TestColumnPhysicalAssetSegmentAppendWriterBatchesExistingSegment3142(t *tes
 	}
 }
 
+func TestColumnPhysicalAssetSegmentAppendWriterSyncsDirectoryOnlyForCreate3150(t *testing.T) {
+	cfg := testColumnStoreConfig(nil)
+	normalized, err := normalizeColumnStoreConfig("events", cfg)
+	if err != nil {
+		t.Fatalf("normalizeColumnStoreConfig: %v", err)
+	}
+	root := backenddb.ColumnAssetRootDirPath(t.TempDir())
+	first, err := newColumnPhysicalAssetSegmentAppendWriter(root, *normalized, columnAssetM12ASegmentFileID)
+	if err != nil {
+		t.Fatalf("newColumnPhysicalAssetSegmentAppendWriter first: %v", err)
+	}
+	if !first.syncDirOnClose {
+		_ = first.abort()
+		t.Fatalf("new segment append writer should sync segment directory on close")
+	}
+	if _, err := first.appendKind([]byte("first"), ColumnAssetKindTCS1PartImage, 7, 1); err != nil {
+		_ = first.abort()
+		t.Fatalf("first appendKind: %v", err)
+	}
+	if err := first.close(); err != nil {
+		t.Fatalf("first close: %v", err)
+	}
+
+	second, err := newColumnPhysicalAssetSegmentAppendWriter(root, *normalized, columnAssetM12ASegmentFileID)
+	if err != nil {
+		t.Fatalf("newColumnPhysicalAssetSegmentAppendWriter second: %v", err)
+	}
+	if second.syncDirOnClose {
+		_ = second.abort()
+		t.Fatalf("existing segment append writer should not sync unchanged segment directory on close")
+	}
+	if _, err := second.appendKind([]byte("second"), ColumnAssetKindTCS1PartImage, 7, 2); err != nil {
+		_ = second.abort()
+		t.Fatalf("second appendKind: %v", err)
+	}
+	if err := second.close(); err != nil {
+		t.Fatalf("second close: %v", err)
+	}
+}
+
 func TestColumnPhysicalAssetSegmentAppendWriterBatchesMixedRegularAssets3145(t *testing.T) {
 	cfg := testColumnStoreConfig(nil)
 	normalized, err := normalizeColumnStoreConfig("events", cfg)
@@ -2206,6 +2246,98 @@ func TestColumnPhysicalAssetSegmentAppendWriterBatchesMixedRegularAssets3145(t *
 		got := segment[expected.ref.Offset : expected.ref.Offset+expected.ref.Length]
 		if !bytes.Equal(got, expected.payload) {
 			t.Fatalf("%s payload=%q want %q", expected.name, got, expected.payload)
+		}
+	}
+}
+
+func TestColumnPhysicalAssetSegmentAppendWriterBatchMatchesSequential3150(t *testing.T) {
+	cfg := testColumnStoreConfig(nil)
+	normalized, err := normalizeColumnStoreConfig("events", cfg)
+	if err != nil {
+		t.Fatalf("normalizeColumnStoreConfig: %v", err)
+	}
+	type appendCase struct {
+		payload []byte
+		kind    ColumnAssetKind
+		partID  uint64
+	}
+	cases := []appendCase{
+		{[]byte("row-image"), ColumnAssetKindTCS1PartImage, 2},
+		{[]byte("typed-column-part"), ColumnAssetKindTCS1TypedColumnPart, 3},
+		{[]byte("dictionary-codes"), ColumnAssetKindTCS1DictionaryCodes, 4},
+		{[]byte("int64-values"), ColumnAssetKindTCS1Int64Values, 5},
+		{[]byte("aggregate-metadata"), ColumnAssetKindTCS1AggregateMetadata, 6},
+	}
+	writeSequential := func(t *testing.T, root string) ([]byte, []ColumnAssetRef) {
+		t.Helper()
+		seedRef, err := writeColumnAssetToManagerSegment(root, *normalized, []byte("seed"), ColumnAssetKindTCS1PartImage, 13, 1, columnAssetM12ASegmentFileID)
+		if err != nil {
+			t.Fatalf("seed writeColumnAssetToManagerSegment: %v", err)
+		}
+		appender, err := newColumnPhysicalAssetSegmentAppendWriter(root, *normalized, columnAssetM12ASegmentFileID)
+		if err != nil {
+			t.Fatalf("newColumnPhysicalAssetSegmentAppendWriter: %v", err)
+		}
+		refs := make([]ColumnAssetRef, 0, len(cases))
+		for _, tc := range cases {
+			ref, err := appender.appendKind(tc.payload, tc.kind, 13, tc.partID)
+			if err != nil {
+				_ = appender.abort()
+				t.Fatalf("appendKind %s: %v", tc.kind, err)
+			}
+			refs = append(refs, ref)
+		}
+		if err := appender.close(); err != nil {
+			t.Fatalf("appender close: %v", err)
+		}
+		return readColumnAssetSegmentFileForTest(t, root, seedRef), refs
+	}
+	writeBatch := func(t *testing.T, root string) ([]byte, []ColumnAssetRef) {
+		t.Helper()
+		seedRef, err := writeColumnAssetToManagerSegment(root, *normalized, []byte("seed"), ColumnAssetKindTCS1PartImage, 13, 1, columnAssetM12ASegmentFileID)
+		if err != nil {
+			t.Fatalf("seed writeColumnAssetToManagerSegment: %v", err)
+		}
+		appender, err := newColumnPhysicalAssetSegmentAppendWriter(root, *normalized, columnAssetM12ASegmentFileID)
+		if err != nil {
+			t.Fatalf("newColumnPhysicalAssetSegmentAppendWriter: %v", err)
+		}
+		items := make([]columnPhysicalAssetAppendItem, 0, len(cases))
+		for _, tc := range cases {
+			items = append(items, columnPhysicalAssetAppendItem{
+				payload:    tc.payload,
+				kind:       tc.kind,
+				generation: 13,
+				partID:     tc.partID,
+			})
+		}
+		refs, err := appender.appendKinds(items)
+		if err != nil {
+			_ = appender.abort()
+			t.Fatalf("appendKinds: %v", err)
+		}
+		if err := appender.close(); err != nil {
+			t.Fatalf("appender close: %v", err)
+		}
+		return readColumnAssetSegmentFileForTest(t, root, seedRef), refs
+	}
+	sequentialSegment, sequentialRefs := writeSequential(t, backenddb.ColumnAssetRootDirPath(t.TempDir()))
+	batchSegment, batchRefs := writeBatch(t, backenddb.ColumnAssetRootDirPath(t.TempDir()))
+	if !bytes.Equal(batchSegment, sequentialSegment) {
+		t.Fatalf("batch segment bytes differ from sequential append")
+	}
+	if len(batchRefs) != len(sequentialRefs) {
+		t.Fatalf("batch refs=%d want sequential refs=%d", len(batchRefs), len(sequentialRefs))
+	}
+	for i := range sequentialRefs {
+		if batchRefs[i] != sequentialRefs[i] {
+			t.Fatalf("ref[%d]=%+v want sequential %+v", i, batchRefs[i], sequentialRefs[i])
+		}
+		if got, want := batchRefs[i].Checksum, page.Checksum(cases[i].payload); got != want {
+			t.Fatalf("ref[%d] checksum=%d want %d", i, got, want)
+		}
+		if got := batchSegment[batchRefs[i].Offset : batchRefs[i].Offset+batchRefs[i].Length]; !bytes.Equal(got, cases[i].payload) {
+			t.Fatalf("ref[%d] payload=%q want %q", i, got, cases[i].payload)
 		}
 	}
 }
@@ -2483,8 +2615,9 @@ func TestColumnAssetSegmentAppenderDirSyncErrorRemovesSegmentM15C(t *testing.T) 
 		namespace: columnAssetManagerNamespace{
 			SegmentDir: filepath.Join(root, "missing-segment-dir"),
 		},
-		assetPath:     assetPath,
-		removeOnClose: true,
+		assetPath:      assetPath,
+		syncDirOnClose: true,
+		removeOnClose:  true,
 	}
 	if err := appender.close(); err == nil {
 		t.Fatalf("close err=nil want dir sync error")

--- a/TreeDB/collections/column_physical_asset_test.go
+++ b/TreeDB/collections/column_physical_asset_test.go
@@ -2172,6 +2172,77 @@ func TestColumnPhysicalAssetSegmentAppendWriterSyncsDirectoryOnlyForCreate3150(t
 	}
 }
 
+func TestColumnPhysicalAssetSegmentAppendWriterSyncsUnknownExistingSegment3152(t *testing.T) {
+	cfg := testColumnStoreConfig(nil)
+	normalized, err := normalizeColumnStoreConfig("events", cfg)
+	if err != nil {
+		t.Fatalf("normalizeColumnStoreConfig: %v", err)
+	}
+	root := backenddb.ColumnAssetRootDirPath(t.TempDir())
+	namespace, err := columnAssetManagerNamespaceForRoot(root, normalized.AssetManager.Namespace)
+	if err != nil {
+		t.Fatalf("columnAssetManagerNamespaceForRoot: %v", err)
+	}
+	if err := ensureColumnAssetManagerNamespace(namespace); err != nil {
+		t.Fatalf("ensureColumnAssetManagerNamespace: %v", err)
+	}
+	seedRef := ColumnAssetRef{
+		Kind:      ColumnAssetKindTCS1PartImage,
+		Namespace: normalized.AssetManager.Namespace,
+		FileID:    columnAssetM12ASegmentFileID,
+		Length:    1,
+	}
+	assetPath, err := columnAssetSegmentPath(root, seedRef)
+	if err != nil {
+		t.Fatalf("columnAssetSegmentPath: %v", err)
+	}
+	clearColumnAssetSegmentDirSyncKnown(assetPath)
+	if err := os.WriteFile(assetPath, []byte("left-by-prior-dir-sync-failure"), 0o600); err != nil {
+		t.Fatalf("write existing segment: %v", err)
+	}
+	if columnAssetSegmentDirSyncKnown(assetPath) {
+		t.Fatalf("manually-created segment should not start as dir-sync known")
+	}
+	if _, err := writeColumnAssetToManagerSegment(root, *normalized, []byte("direct"), ColumnAssetKindTCS1PartImage, 7, 1, columnAssetM12ASegmentFileID); err != nil {
+		t.Fatalf("writeColumnAssetToManagerSegment: %v", err)
+	}
+	if !columnAssetSegmentDirSyncKnown(assetPath) {
+		t.Fatalf("direct segment write should mark unknown existing segment dir-sync known")
+	}
+
+	clearColumnAssetSegmentDirSyncKnown(assetPath)
+	appender, err := newColumnPhysicalAssetSegmentAppendWriter(root, *normalized, columnAssetM12ASegmentFileID)
+	if err != nil {
+		t.Fatalf("newColumnPhysicalAssetSegmentAppendWriter: %v", err)
+	}
+	if !appender.syncDirOnClose {
+		_ = appender.abort()
+		t.Fatalf("unknown existing segment append writer should sync segment directory on close")
+	}
+	if _, err := appender.appendKind([]byte("batched"), ColumnAssetKindTCS1PartImage, 7, 2); err != nil {
+		_ = appender.abort()
+		t.Fatalf("appendKind: %v", err)
+	}
+	if err := appender.close(); err != nil {
+		t.Fatalf("appender close: %v", err)
+	}
+	if !columnAssetSegmentDirSyncKnown(assetPath) {
+		t.Fatalf("successful append close should mark segment dir-sync known")
+	}
+
+	next, err := newColumnPhysicalAssetSegmentAppendWriter(root, *normalized, columnAssetM12ASegmentFileID)
+	if err != nil {
+		t.Fatalf("newColumnPhysicalAssetSegmentAppendWriter next: %v", err)
+	}
+	if next.syncDirOnClose {
+		_ = next.abort()
+		t.Fatalf("known durable existing segment append writer should skip unchanged segment directory sync")
+	}
+	if err := next.abort(); err != nil {
+		t.Fatalf("next abort: %v", err)
+	}
+}
+
 func TestColumnPhysicalAssetSegmentAppendWriterBatchesMixedRegularAssets3145(t *testing.T) {
 	cfg := testColumnStoreConfig(nil)
 	normalized, err := normalizeColumnStoreConfig("events", cfg)

--- a/TreeDB/collections/column_publish_plan.go
+++ b/TreeDB/collections/column_publish_plan.go
@@ -311,6 +311,9 @@ type ColumnPublishAssetPreparationMetrics struct {
 	AggregateMetadataBytes        int64
 	AggregateMetadataCount        int
 	RowSidecarSharedBuildDuration time.Duration
+	SharedAppendOpenDuration      time.Duration
+	SharedAppendWriteDuration     time.Duration
+	SharedAppendCloseDuration     time.Duration
 	SharedAppendDuration          time.Duration
 	SharedAppendBytes             int64
 	SharedAppendCount             int

--- a/TreeDB/collections/column_publish_write.go
+++ b/TreeDB/collections/column_publish_write.go
@@ -444,6 +444,9 @@ func recordColumnPublishPlanStats(stats *CollectionInsertStats, plan ColumnPubli
 	stats.ColumnPublishAggregateMetadataPrepare += metrics.AssetMetrics.AggregateMetadataDuration
 	stats.ColumnPublishRowSidecarSharedBuild += metrics.AssetMetrics.RowSidecarSharedBuildDuration
 	stats.ColumnPublishAssetAppend += metrics.AssetMetrics.SharedAppendDuration
+	stats.ColumnPublishAssetAppendOpen += metrics.AssetMetrics.SharedAppendOpenDuration
+	stats.ColumnPublishAssetAppendWrite += metrics.AssetMetrics.SharedAppendWriteDuration
+	stats.ColumnPublishAssetAppendClose += metrics.AssetMetrics.SharedAppendCloseDuration
 	stats.ColumnPublishManifestEncode += metrics.ManifestEncode
 	stats.ColumnPublishAssetClosureValidation += metrics.AssetClosureValidation
 	stats.ColumnPublishRootDeltaConstruction += metrics.RootDeltaConstruction
@@ -729,7 +732,9 @@ func (c *Collection) prepareColumnPhysicalAssetRowsForCommand(prepared ColumnPub
 		}
 		var appender *columnPhysicalAssetSegmentAppender
 		closed := false
-		var appendDuration time.Duration
+		var appendOpenDuration time.Duration
+		var appendWriteDuration time.Duration
+		var appendCloseDuration time.Duration
 		if needsAppender {
 			appendStart := time.Now()
 			var err error
@@ -737,7 +742,7 @@ func (c *Collection) prepareColumnPhysicalAssetRowsForCommand(prepared ColumnPub
 			if err != nil {
 				return err
 			}
-			appendDuration += time.Since(appendStart)
+			appendOpenDuration += time.Since(appendStart)
 			defer func() {
 				if retErr != nil && !closed {
 					retErr = errors.Join(retErr, appender.abort())
@@ -746,16 +751,37 @@ func (c *Collection) prepareColumnPhysicalAssetRowsForCommand(prepared ColumnPub
 		}
 		var appendedBytes int64
 		var appendedCount int
-		for _, asset := range pendingAssets {
-			ref := asset.ref
-			if !asset.hasRef {
-				appendStart := time.Now()
-				var err error
-				ref, err = appender.appendKind(asset.payload, asset.kind, generation, asset.partID)
-				if err != nil {
-					return err
+		appendedRefs := make([]ColumnAssetRef, len(pendingAssets))
+		appendedRefSet := make([]bool, len(pendingAssets))
+		if needsAppender {
+			appendIndexes := make([]int, 0, len(pendingAssets))
+			appendItems := make([]columnPhysicalAssetAppendItem, 0, len(pendingAssets))
+			for i, asset := range pendingAssets {
+				if asset.hasRef {
+					continue
 				}
-				appendDuration += time.Since(appendStart)
+				appendIndexes = append(appendIndexes, i)
+				appendItems = append(appendItems, columnPhysicalAssetAppendItem{
+					payload:    asset.payload,
+					kind:       asset.kind,
+					generation: generation,
+					partID:     asset.partID,
+				})
+			}
+			appendStart := time.Now()
+			refs, err := appender.appendKinds(appendItems)
+			if err != nil {
+				return err
+			}
+			appendWriteDuration += time.Since(appendStart)
+			if len(refs) != len(appendIndexes) {
+				return fmt.Errorf("collections: column physical asset append refs=%d want %d", len(refs), len(appendIndexes))
+			}
+			for i, ref := range refs {
+				assetIndex := appendIndexes[i]
+				asset := pendingAssets[assetIndex]
+				appendedRefs[assetIndex] = ref
+				appendedRefSet[assetIndex] = true
 				appendedBytes = saturatingAddNonNegativeInt64(appendedBytes, int64(len(asset.payload)))
 				appendedCount++
 				trackCleanupAsset(ref)
@@ -763,6 +789,15 @@ func (c *Collection) prepareColumnPhysicalAssetRowsForCommand(prepared ColumnPub
 					ref.Generation != generation || ref.PartID != asset.partID || ref.Length != int64(len(asset.payload)) {
 					return fmt.Errorf("collections: invalid %s asset ref %+v", asset.kind, ref)
 				}
+			}
+		}
+		for i, asset := range pendingAssets {
+			ref := asset.ref
+			if !asset.hasRef {
+				if !appendedRefSet[i] {
+					return fmt.Errorf("collections: missing appended ref for %s asset part_id=%d", asset.kind, asset.partID)
+				}
+				ref = appendedRefs[i]
 			}
 			if asset.validate != nil {
 				if err := asset.validate(ref); err != nil {
@@ -785,11 +820,15 @@ func (c *Collection) prepareColumnPhysicalAssetRowsForCommand(prepared ColumnPub
 			if err := appender.close(); err != nil {
 				return err
 			}
-			appendDuration += time.Since(appendStart)
+			appendCloseDuration += time.Since(appendStart)
 			closed = true
 		}
 		if needsAppender {
+			appendDuration := appendOpenDuration + appendWriteDuration + appendCloseDuration
 			prepared.AssetMetrics.SharedAppendDuration += appendDuration
+			prepared.AssetMetrics.SharedAppendOpenDuration += appendOpenDuration
+			prepared.AssetMetrics.SharedAppendWriteDuration += appendWriteDuration
+			prepared.AssetMetrics.SharedAppendCloseDuration += appendCloseDuration
 			prepared.AssetMetrics.SharedAppendBytes = saturatingAddNonNegativeInt64(prepared.AssetMetrics.SharedAppendBytes, appendedBytes)
 			prepared.AssetMetrics.SharedAppendCount += appendedCount
 		}

--- a/TreeDB/collections/column_publish_write.go
+++ b/TreeDB/collections/column_publish_write.go
@@ -777,6 +777,9 @@ func (c *Collection) prepareColumnPhysicalAssetRowsForCommand(prepared ColumnPub
 			if len(refs) != len(appendIndexes) {
 				return fmt.Errorf("collections: column physical asset append refs=%d want %d", len(refs), len(appendIndexes))
 			}
+			for _, ref := range refs {
+				trackCleanupAsset(ref)
+			}
 			for i, ref := range refs {
 				assetIndex := appendIndexes[i]
 				asset := pendingAssets[assetIndex]
@@ -784,7 +787,6 @@ func (c *Collection) prepareColumnPhysicalAssetRowsForCommand(prepared ColumnPub
 				appendedRefSet[assetIndex] = true
 				appendedBytes = saturatingAddNonNegativeInt64(appendedBytes, int64(len(asset.payload)))
 				appendedCount++
-				trackCleanupAsset(ref)
 				if ref.Namespace != hookInput.ColumnStore.AssetManager.Namespace || ref.Kind != asset.kind ||
 					ref.Generation != generation || ref.PartID != asset.partID || ref.Length != int64(len(asset.payload)) {
 					return fmt.Errorf("collections: invalid %s asset ref %+v", asset.kind, ref)

--- a/TreeDB/collections/shape_bench_test.go
+++ b/TreeDB/collections/shape_bench_test.go
@@ -49,6 +49,9 @@ func addCollectionInsertStats(dst *collections.CollectionInsertStats, src collec
 	dst.ColumnPublishAggregateMetadataPrepare += src.ColumnPublishAggregateMetadataPrepare
 	dst.ColumnPublishRowSidecarSharedBuild += src.ColumnPublishRowSidecarSharedBuild
 	dst.ColumnPublishAssetAppend += src.ColumnPublishAssetAppend
+	dst.ColumnPublishAssetAppendOpen += src.ColumnPublishAssetAppendOpen
+	dst.ColumnPublishAssetAppendWrite += src.ColumnPublishAssetAppendWrite
+	dst.ColumnPublishAssetAppendClose += src.ColumnPublishAssetAppendClose
 	dst.ColumnPublishManifestEncode += src.ColumnPublishManifestEncode
 	dst.ColumnPublishAssetClosureValidation += src.ColumnPublishAssetClosureValidation
 	dst.ColumnPublishRootDeltaConstruction += src.ColumnPublishRootDeltaConstruction
@@ -109,6 +112,9 @@ func benchmarkReportCollectionInsertStats(b *testing.B, docs, batches int, stats
 	reportDuration("column_publish_aggregate_metadata_prepare_ns/doc", stats.ColumnPublishAggregateMetadataPrepare)
 	reportDuration("column_publish_row_sidecar_shared_build_ns/doc", stats.ColumnPublishRowSidecarSharedBuild)
 	reportDuration("column_publish_asset_append_ns/doc", stats.ColumnPublishAssetAppend)
+	reportDuration("column_publish_asset_append_open_ns/doc", stats.ColumnPublishAssetAppendOpen)
+	reportDuration("column_publish_asset_append_write_ns/doc", stats.ColumnPublishAssetAppendWrite)
+	reportDuration("column_publish_asset_append_close_ns/doc", stats.ColumnPublishAssetAppendClose)
 	reportDuration("column_publish_manifest_encode_ns/doc", stats.ColumnPublishManifestEncode)
 	reportDuration("column_publish_asset_closure_ns/doc", stats.ColumnPublishAssetClosureValidation)
 	reportDuration("column_publish_root_delta_ns/doc", stats.ColumnPublishRootDeltaConstruction)

--- a/TreeDB/collections/typed_storage_naming_test.go
+++ b/TreeDB/collections/typed_storage_naming_test.go
@@ -356,7 +356,7 @@ var typedStorageLegacyNameAllowlist = []typedStorageLegacyNameAllowlistEntry{
 	{path: "TreeDB/collections/column_int64_values_asset.go", classification: typedStorageLegacyDerived, matchingLines: 10, occurrences: 10},
 	{path: "TreeDB/collections/column_manifest_format.go", classification: typedStorageLegacyCompatibility, matchingLines: 2, occurrences: 2},
 	{path: "TreeDB/collections/column_physical_asset.go", classification: typedStorageLegacyDeferred, matchingLines: 87, occurrences: 131},
-	{path: "TreeDB/collections/column_physical_asset_test.go", classification: typedStorageLegacyDeferred, matchingLines: 216, occurrences: 228},
+	{path: "TreeDB/collections/column_physical_asset_test.go", classification: typedStorageLegacyDeferred, matchingLines: 222, occurrences: 234},
 	{path: "TreeDB/collections/column_physical_predicate.go", classification: typedStorageLegacyDeferred, matchingLines: 3, occurrences: 3},
 	{path: "TreeDB/collections/column_physical_query.go", classification: typedStorageLegacyDeferred, matchingLines: 40, occurrences: 60},
 	{path: "TreeDB/collections/column_physical_query_1890_bench_test.go", classification: typedStorageLegacyDeferred, matchingLines: 1, occurrences: 2},

--- a/TreeDB/collections/typed_storage_naming_test.go
+++ b/TreeDB/collections/typed_storage_naming_test.go
@@ -356,7 +356,7 @@ var typedStorageLegacyNameAllowlist = []typedStorageLegacyNameAllowlistEntry{
 	{path: "TreeDB/collections/column_int64_values_asset.go", classification: typedStorageLegacyDerived, matchingLines: 10, occurrences: 10},
 	{path: "TreeDB/collections/column_manifest_format.go", classification: typedStorageLegacyCompatibility, matchingLines: 2, occurrences: 2},
 	{path: "TreeDB/collections/column_physical_asset.go", classification: typedStorageLegacyDeferred, matchingLines: 87, occurrences: 131},
-	{path: "TreeDB/collections/column_physical_asset_test.go", classification: typedStorageLegacyDeferred, matchingLines: 222, occurrences: 234},
+	{path: "TreeDB/collections/column_physical_asset_test.go", classification: typedStorageLegacyDeferred, matchingLines: 225, occurrences: 237},
 	{path: "TreeDB/collections/column_physical_predicate.go", classification: typedStorageLegacyDeferred, matchingLines: 3, occurrences: 3},
 	{path: "TreeDB/collections/column_physical_query.go", classification: typedStorageLegacyDeferred, matchingLines: 40, occurrences: 60},
 	{path: "TreeDB/collections/column_physical_query_1890_bench_test.go", classification: typedStorageLegacyDeferred, matchingLines: 1, occurrences: 2},

--- a/cmd/unified_bench/suite_column_store.go
+++ b/cmd/unified_bench/suite_column_store.go
@@ -235,6 +235,9 @@ type columnStoreInsertPhaseMetric struct {
 	ColumnPublishAggregateMetadataDurationMS  float64 `json:"column_publish_aggregate_metadata_prepare_duration_ms,omitempty"`
 	ColumnPublishRowSidecarSharedBuildMS      float64 `json:"column_publish_row_sidecar_shared_build_duration_ms,omitempty"`
 	ColumnPublishAssetAppendDurationMS        float64 `json:"column_publish_asset_append_duration_ms,omitempty"`
+	ColumnPublishAssetAppendOpenDurationMS    float64 `json:"column_publish_asset_append_open_duration_ms,omitempty"`
+	ColumnPublishAssetAppendWriteDurationMS   float64 `json:"column_publish_asset_append_write_duration_ms,omitempty"`
+	ColumnPublishAssetAppendCloseDurationMS   float64 `json:"column_publish_asset_append_close_duration_ms,omitempty"`
 	ColumnPublishManifestEncodeDurationMS     float64 `json:"column_publish_manifest_encode_duration_ms,omitempty"`
 	ColumnPublishAssetClosureDurationMS       float64 `json:"column_publish_asset_closure_validation_duration_ms,omitempty"`
 	ColumnPublishRootDeltaDurationMS          float64 `json:"column_publish_root_delta_construction_duration_ms,omitempty"`
@@ -1444,6 +1447,9 @@ func columnStoreAddCollectionInsertStats(dst *collections.CollectionInsertStats,
 	dst.ColumnPublishAggregateMetadataPrepare += src.ColumnPublishAggregateMetadataPrepare
 	dst.ColumnPublishRowSidecarSharedBuild += src.ColumnPublishRowSidecarSharedBuild
 	dst.ColumnPublishAssetAppend += src.ColumnPublishAssetAppend
+	dst.ColumnPublishAssetAppendOpen += src.ColumnPublishAssetAppendOpen
+	dst.ColumnPublishAssetAppendWrite += src.ColumnPublishAssetAppendWrite
+	dst.ColumnPublishAssetAppendClose += src.ColumnPublishAssetAppendClose
 	dst.ColumnPublishManifestEncode += src.ColumnPublishManifestEncode
 	dst.ColumnPublishAssetClosureValidation += src.ColumnPublishAssetClosureValidation
 	dst.ColumnPublishRootDeltaConstruction += src.ColumnPublishRootDeltaConstruction
@@ -1508,6 +1514,9 @@ func columnStoreInsertPhaseMetricFromStats(stats collections.CollectionInsertSta
 		ColumnPublishAggregateMetadataDurationMS:  durationMS(stats.ColumnPublishAggregateMetadataPrepare),
 		ColumnPublishRowSidecarSharedBuildMS:      durationMS(stats.ColumnPublishRowSidecarSharedBuild),
 		ColumnPublishAssetAppendDurationMS:        durationMS(stats.ColumnPublishAssetAppend),
+		ColumnPublishAssetAppendOpenDurationMS:    durationMS(stats.ColumnPublishAssetAppendOpen),
+		ColumnPublishAssetAppendWriteDurationMS:   durationMS(stats.ColumnPublishAssetAppendWrite),
+		ColumnPublishAssetAppendCloseDurationMS:   durationMS(stats.ColumnPublishAssetAppendClose),
 		ColumnPublishManifestEncodeDurationMS:     durationMS(stats.ColumnPublishManifestEncode),
 		ColumnPublishAssetClosureDurationMS:       durationMS(stats.ColumnPublishAssetClosureValidation),
 		ColumnPublishRootDeltaDurationMS:          durationMS(stats.ColumnPublishRootDeltaConstruction),
@@ -4371,6 +4380,9 @@ func renderColumnStoreInsertStatsMarkdown(sb *strings.Builder, stats columnStore
 		sb.WriteString(fmt.Sprintf("| `aggregate_metadata_prepare` | %.3f |  |\n", stats.ColumnPublishAggregateMetadataDurationMS))
 		sb.WriteString(fmt.Sprintf("| `row_sidecar_shared_build` | %.3f |  |\n", stats.ColumnPublishRowSidecarSharedBuildMS))
 		sb.WriteString(fmt.Sprintf("| `asset_append` | %.3f |  |\n", stats.ColumnPublishAssetAppendDurationMS))
+		sb.WriteString(fmt.Sprintf("| `asset_append_open` | %.3f |  |\n", stats.ColumnPublishAssetAppendOpenDurationMS))
+		sb.WriteString(fmt.Sprintf("| `asset_append_write` | %.3f |  |\n", stats.ColumnPublishAssetAppendWriteDurationMS))
+		sb.WriteString(fmt.Sprintf("| `asset_append_close` | %.3f |  |\n", stats.ColumnPublishAssetAppendCloseDurationMS))
 		sb.WriteString(fmt.Sprintf("| `manifest_encode` | %.3f |  |\n", stats.ColumnPublishManifestEncodeDurationMS))
 		sb.WriteString(fmt.Sprintf("| `asset_closure_validation` | %.3f |  |\n", stats.ColumnPublishAssetClosureDurationMS))
 		sb.WriteString(fmt.Sprintf("| `root_delta_construction` | %.3f |  |\n", stats.ColumnPublishRootDeltaDurationMS))
@@ -4393,6 +4405,9 @@ func columnStoreInsertStatsHasColumnPublishSubphase(stats columnStoreInsertPhase
 		stats.ColumnPublishAggregateMetadataDurationMS > 0 ||
 		stats.ColumnPublishRowSidecarSharedBuildMS > 0 ||
 		stats.ColumnPublishAssetAppendDurationMS > 0 ||
+		stats.ColumnPublishAssetAppendOpenDurationMS > 0 ||
+		stats.ColumnPublishAssetAppendWriteDurationMS > 0 ||
+		stats.ColumnPublishAssetAppendCloseDurationMS > 0 ||
 		stats.ColumnPublishManifestEncodeDurationMS > 0 ||
 		stats.ColumnPublishAssetClosureDurationMS > 0 ||
 		stats.ColumnPublishRootDeltaDurationMS > 0 ||

--- a/cmd/unified_bench/suite_column_store_test.go
+++ b/cmd/unified_bench/suite_column_store_test.go
@@ -583,7 +583,10 @@ func TestRunColumnStoreSuiteWritesArtifactsAndMetricsM11A(t *testing.T) {
 		report.InsertStats.ColumnPublishDictionaryPrepareDurationMS <= 0 ||
 		report.InsertStats.ColumnPublishInt64PrepareDurationMS <= 0 ||
 		report.InsertStats.ColumnPublishAggregateMetadataDurationMS <= 0 ||
-		report.InsertStats.ColumnPublishAssetAppendDurationMS <= 0 {
+		report.InsertStats.ColumnPublishAssetAppendDurationMS <= 0 ||
+		report.InsertStats.ColumnPublishAssetAppendOpenDurationMS <= 0 ||
+		report.InsertStats.ColumnPublishAssetAppendWriteDurationMS <= 0 ||
+		report.InsertStats.ColumnPublishAssetAppendCloseDurationMS <= 0 {
 		t.Fatalf("column publish asset-family timing missing: %+v", report.InsertStats)
 	}
 	if report.InsertStats.ColumnPublishRowAssetBytes <= 0 ||
@@ -706,7 +709,7 @@ func TestRunColumnStoreSuiteWritesArtifactsAndMetricsM11A(t *testing.T) {
 			t.Fatalf("column store JSON missing WAL-excluded durable storage field %s:\n%s", want, data)
 		}
 	}
-	for _, want := range []string{`"insert_stats"`, `"retained_payload_prepare_duration_ms"`, `"retained_payload_prepare_ns_per_row"`, `"retained_payload_declared_rows"`, `"column_store_declared_row_reuse_coverage_ratio"`, `"column_publish_build_column_delta_duration_ms"`, `"column_publish_commit_duration_ms"`, `"column_publish_asset_preparation_duration_ms"`, `"column_publish_row_asset_prepare_duration_ms"`, `"column_publish_aggregate_metadata_prepare_duration_ms"`, `"column_publish_asset_append_duration_ms"`, `"column_publish_aggregate_metadata_bytes"`, `"column_publish_shared_asset_append_bytes"`, `"column_publish_required_asset_bytes"`} {
+	for _, want := range []string{`"insert_stats"`, `"retained_payload_prepare_duration_ms"`, `"retained_payload_prepare_ns_per_row"`, `"retained_payload_declared_rows"`, `"column_store_declared_row_reuse_coverage_ratio"`, `"column_publish_build_column_delta_duration_ms"`, `"column_publish_commit_duration_ms"`, `"column_publish_asset_preparation_duration_ms"`, `"column_publish_row_asset_prepare_duration_ms"`, `"column_publish_aggregate_metadata_prepare_duration_ms"`, `"column_publish_asset_append_duration_ms"`, `"column_publish_asset_append_open_duration_ms"`, `"column_publish_asset_append_write_duration_ms"`, `"column_publish_asset_append_close_duration_ms"`, `"column_publish_aggregate_metadata_bytes"`, `"column_publish_shared_asset_append_bytes"`, `"column_publish_required_asset_bytes"`} {
 		if !strings.Contains(string(data), want) {
 			t.Fatalf("column store JSON missing insert phase field %s:\n%s", want, data)
 		}
@@ -739,7 +742,7 @@ func TestRunColumnStoreSuiteWritesArtifactsAndMetricsM11A(t *testing.T) {
 			t.Fatalf("column store markdown missing WAL-excluded durable storage field %q:\n%s", want, columnMarkdown)
 		}
 	}
-	for _, want := range []string{"## Insert Phase Stats", "retained_payload_prepare", "retained_payload_declared_rows", "column_store_declared_row_reuse_coverage_ratio", "column_publish_rows", "column_publish_aggregate_metadata_bytes", "column publish subphase", "build_column_delta_callback", "publish_commit_total", "aggregate_metadata_prepare", "asset_append"} {
+	for _, want := range []string{"## Insert Phase Stats", "retained_payload_prepare", "retained_payload_declared_rows", "column_store_declared_row_reuse_coverage_ratio", "column_publish_rows", "column_publish_aggregate_metadata_bytes", "column publish subphase", "build_column_delta_callback", "publish_commit_total", "aggregate_metadata_prepare", "asset_append", "asset_append_open", "asset_append_write", "asset_append_close"} {
 		if !strings.Contains(string(columnMarkdown), want) {
 			t.Fatalf("column store markdown missing insert phase field %q:\n%s", want, columnMarkdown)
 		}
@@ -2592,6 +2595,9 @@ func TestColumnStoreInsertPhaseMetricFromStatsIncludesAssetFamiliesM3148(t *test
 		ColumnPublishAggregateMetadataPrepare: 5 * time.Millisecond,
 		ColumnPublishRowSidecarSharedBuild:    6 * time.Millisecond,
 		ColumnPublishAssetAppend:              7 * time.Millisecond,
+		ColumnPublishAssetAppendOpen:          2 * time.Millisecond,
+		ColumnPublishAssetAppendWrite:         3 * time.Millisecond,
+		ColumnPublishAssetAppendClose:         4 * time.Millisecond,
 		ColumnPublishRowAssetBytes:            101,
 		ColumnPublishRowAssetCount:            1,
 		ColumnPublishTypedColumnBytes:         202,
@@ -2628,6 +2634,15 @@ func TestColumnStoreInsertPhaseMetricFromStatsIncludesAssetFamiliesM3148(t *test
 	}
 	if got, want := metric.ColumnPublishAssetAppendDurationMS, 7.0; got != want {
 		t.Fatalf("shared append duration ms=%v want %v", got, want)
+	}
+	if got, want := metric.ColumnPublishAssetAppendOpenDurationMS, 2.0; got != want {
+		t.Fatalf("shared append open duration ms=%v want %v", got, want)
+	}
+	if got, want := metric.ColumnPublishAssetAppendWriteDurationMS, 3.0; got != want {
+		t.Fatalf("shared append write duration ms=%v want %v", got, want)
+	}
+	if got, want := metric.ColumnPublishAssetAppendCloseDurationMS, 4.0; got != want {
+		t.Fatalf("shared append close duration ms=%v want %v", got, want)
 	}
 	if got, want := metric.ColumnPublishTypedColumnBytes, int64(202); got != want {
 		t.Fatalf("typed-column bytes=%d want %d", got, want)


### PR DESCRIPTION
## Objective

Batch pending shared column-asset segment writes during column publish and expose append open/write/close timings so the load path reports the remaining durable sync cost clearly.

Closes #3150 as a bounded load-path slice. Follow-up #3151 owns the measured close/file-sync blocker. This PR does not claim one-shot SQL superiority or no-aggregate query speed.

## Context

PR #3149 made shared asset append visible as the largest reported column-publish subphase in a 100k synthetic run. This PR coalesces multiple pending assets into one contiguous append buffer, preserves the existing segment format and ref layout, skips directory fsync when appending to an already-existing segment, and reports open/write/close timing separately.

## Non-goals

- No on-disk column asset segment format change.
- No change to manifest semantics, asset checksum semantics, or persistent value-log/WAL behavior.
- No claim for `one_shot_end_to_end`, `first_touch_after_open`, `no_aggregate_metadata`, hot prepared query speed, or broad ClickHouse SQL superiority.
- No attempt to amortize file sync in this PR; that needs #3151 durability/recovery proof.

## Design

- Adds `appendKinds` on the shared segment appender to compute the same refs, offsets, padding, lengths, and checksums as sequential `appendKind` calls, then writes one combined buffer.
- Keeps the segment write lock over layout computation and the physical write.
- Tracks generated refs before validation so publish cleanup can still remove/quarantine written refs on downstream failure.
- Uses exclusive create first and syncs the segment directory for newly created or unknown existing segment files. After a successful file sync/close plus directory sync, later appends to the same segment in this process can skip directory sync while still file-syncing on close.
- Splits `CollectionInsertStats` / `unified_bench` reporting into `asset_append_open`, `asset_append_write`, and `asset_append_close` while preserving total `asset_append`.

## Scope

Includes:

- `TreeDB/collections/column_asset_manager.go`
- `TreeDB/collections/column_publish_write.go`
- `TreeDB/collections/*stats*/shape_bench_test.go` insert-stat propagation
- `cmd/unified_bench/suite_column_store.go`
- focused tests in `TreeDB/collections/column_physical_asset_test.go`

Excludes:

- query planner/runtime changes
- JSONBench harness changes
- file-sync amortization/recovery changes

## Correctness

Tests run:

```sh
go test ./TreeDB/collections -run 'TestColumnPhysicalAssetSegmentAppendWriter|TestColumnPhysicalAssetSegmentAppender|TestColumnPublish|TestColumnAssetSegmentAppender' -count=1
go test ./cmd/unified_bench -run 'TestColumnStore.*Insert|TestColumnStoreInsertPhaseMetricFromStats|TestColumnStoreMetadataCostMetricUsesSplitAggregateAccounting' -count=1
go test ./TreeDB/collections ./cmd/unified_bench -count=1
git diff --check
```

Covered cases:

- batched mixed asset writes produce identical segment bytes and refs to sequential append writes;
- checksums and payload slices match each logical asset;
- unknown existing segment append writers request one directory sync, while known durable existing segment append writers skip directory sync on close;
- existing append writer close/remove behavior remains covered.

## Performance

Synthetic command:

```sh
OUT=/tmp/gomap_column_store_shared_append_$(date +%Y%m%d_%H%M%S)
go build -o ./bin/unified-bench ./cmd/unified_bench
./bin/unified-bench \
  -suite column_store \
  -dbs treedb \
  -profile durable \
  -keys 100000 \
  -batchsize 1000 \
  -profile-dir "$OUT" \
  -path-label native-fastpath \
  -column-store-path serial_column_scan \
  -column-store-query q1 \
  -progress=false
```

| run | artifact | insert batch | publish | asset append | open | write | close | storage |
| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| clean origin/main baseline | `/tmp/gomap_column_store_shared_append_origin_baseline_20260626_191251/column_store_results.json` | `693.686 ms` | `584.049 ms` | `303.161 ms` | n/a | n/a | n/a | `26,071,416` bytes |
| instrumented pre-dir-sync candidate | `/tmp/gomap_column_store_shared_append_instrumented_20260626_191751/column_store_results.json` | `748.926 ms` | `634.807 ms` | `346.039 ms` | `25.059 ms` | `6.469 ms` | `314.511 ms` | `26,071,416` bytes |
| current candidate | `/tmp/gomap_column_store_shared_append_dirsync_20260626_192329/column_store_results.json` | `676.257 ms` | `566.207 ms` | `295.438 ms` | `9.914 ms` | `6.249 ms` | `279.276 ms` | `26,071,416` bytes |
| current candidate repeat | `/tmp/gomap_column_store_shared_append_dirsync_repeat_20260626_192359/column_store_results.json` | `734.426 ms` | `611.555 ms` | `319.294 ms` | `12.170 ms` | `6.523 ms` | `300.601 ms` | `26,071,416` bytes |

Byte counters stayed stable: `shared_append_bytes=23,055,800`; `aggregate_metadata_bytes=9,483,700`.

Assessment: useful load-path slice and reporting improvement, but not a clean 25% #3150 target closure against the clean baseline. The new split shows writes are only about `6.2-6.5 ms`; close/file-sync dominates at about `279-301 ms`. #3151 owns that follow-up with crash/reopen safety gates.

## Rollout / Toggle Plan

Default behavior changes only inside the existing shared column asset append writer. There is no new user-facing knob. The conservative fallback is to revert this PR; the on-disk format is unchanged.

## Follow-ups

- #3151: durable shared column asset file-sync amortization, requiring written-vs-durable design and recovery tests.
- #3099/#3067 remain open for the broader TreeDB-vs-ClickHouse load gap.
- #3001/#3000 remain open for the realigned one-shot/no-metadata/final comparison gates.

## AI Review Loop

- Codex latest-head review: passed on 2ca46a12ce with no major issues.
- Copilot latest-head review: not available as a blocking signal for this PR.
- CodeRabbit status: pass; latest manual rerun hit the service review limit after prior incremental review, with no material findings reported.
- Review comments/threads resolved or explicitly dismissed: Codex P2 comments addressed in b9ea66316 and 2ca46a12ce; latest Codex review found no major issues.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added more detailed insert and publish timing metrics, including separate open, write, and close durations for asset appends.
  * Batch appends now support writing multiple items at once, improving consistency in segment writes.

* **Bug Fixes**
  * Improved directory sync handling so metadata is only synced when needed, helping avoid unnecessary work while preserving durability.
  * Strengthened validation to ensure all expected references are produced during batch appends.

* **Tests**
  * Expanded coverage for batch append behavior, directory syncing, and benchmark/reporting metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->