### PR TITLE
TreeDB: lazily allocate command WAL frame buffer

### DIFF
--- a/TreeDB/internal/commitlog/command_frame_test.go
+++ b/TreeDB/internal/commitlog/command_frame_test.go
@@ -942,6 +942,36 @@ func TestWriterDeferredCommandBufferHonorsConfiguredLimit(t *testing.T) {
 	}
 }
 
+func TestWriterDeferredCommandBufferAllocatesLazily(t *testing.T) {
+	payload, err := EncodeRawKVBatchPayload([]RawKVOperation{
+		{Op: RawKVOpSet, Key: []byte("small"), Value: []byte("value")},
+	})
+	if err != nil {
+		t.Fatalf("EncodeRawKVBatchPayload: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "commit-l0-000001.log")
+	w, err := NewWriterWithOptions(path, Options{DeferredCommandBufferSize: 64 << 20})
+	if err != nil {
+		t.Fatalf("NewWriterWithOptions: %v", err)
+	}
+	defer w.Close()
+	if got := w.commandBufferLimit(); got != 64<<20 {
+		t.Fatalf("commandBufferLimit=%d want %d", got, 64<<20)
+	}
+	if got := cap(w.commandBuf); got != 0 {
+		t.Fatalf("deferred command buffer cap after open=%d, want 0", got)
+	}
+	if err := w.AppendRawKVBatchPayloadCommandDirectTrusted(1, 0, payload); err != nil {
+		t.Fatalf("AppendRawKVBatchPayloadCommandDirectTrusted: %v", err)
+	}
+	if got := len(w.commandBuf); got == 0 {
+		t.Fatal("small command frame was not buffered")
+	}
+	if got := cap(w.commandBuf); got >= 1<<20 {
+		t.Fatalf("deferred command buffer cap after first small frame=%d, want below 1MiB", got)
+	}
+}
+
 func TestWriterLargeBatchPayloadBypassesDeferredCommandBufferAndPreservesOrder(t *testing.T) {
 	smallPayload, err := EncodeRawKVBatchPayload([]RawKVOperation{
 		{Op: RawKVOpSet, Key: []byte("small"), Value: []byte("value")},

--- a/TreeDB/internal/commitlog/writer.go
+++ b/TreeDB/internal/commitlog/writer.go
@@ -123,7 +123,6 @@ func NewWriterWithOptions(path string, opts Options) (*Writer, error) {
 	var commandBuf []byte
 	commandBufLimit := 0
 	if opts.DeferredCommandBufferSize > 0 {
-		commandBuf = make([]byte, 0, opts.DeferredCommandBufferSize)
 		commandBufLimit = opts.DeferredCommandBufferSize
 	}
 	return &Writer{
@@ -1029,7 +1028,7 @@ func (w *Writer) canBufferCommandFrame(total int) bool {
 }
 
 func (w *Writer) commandBufferLimit() int {
-	if w == nil || w.commandBufLimit <= 0 || cap(w.commandBuf) == 0 {
+	if w == nil || w.commandBufLimit <= 0 {
 		return 0
 	}
 	return w.commandBufLimit


### PR DESCRIPTION
## Summary

- Lazily allocate the command WAL deferred command-frame buffer instead of reserving its full configured capacity during writer open.
- Preserve the configured `DeferredCommandBufferSize` as the buffering ceiling; large command frames still bypass the deferred buffer.
- Add a regression test proving a 64 MiB configured ceiling does not allocate backing storage until the first buffered frame.

## #3131 evidence

- The #3131 Celestia profile from `/home/mikers/.celestia-app-mainnet-treedb-20260626151249` attributed `340.01MB` flat heap to `github.com/snissn/gomap/TreeDB/internal/commitlog.NewWriterWithOptions`.
- TreeDB command WAL currently configures `commandWALDeferredPointBufferSize = 64 << 20`, so the previous writer open path reserved 64 MiB of heap per command WAL writer before any deferred frame needed that capacity.
- This change removes that fixed open-time cost while keeping the 64 MiB ceiling. With four command WAL handles open, the expected fixed heap reduction is about 256 MiB.
- No Celestia rerun is included in this PR. #3131 should remain open for post-merge RSS/HWM validation and the remaining contributors: IAVL importer/MakeNode, grouped frame cache, memtable/B-tree arena, leaf cache, and value-log decode scratch.

## Validation

- `GOWORK=off go test ./TreeDB/internal/commitlog -run 'TestWriterDeferredCommandBufferAllocatesLazily|TestWriterDeferredCommandBufferHonorsConfiguredLimit|TestWriterLargeBatchPayloadBypassesDeferredCommandBufferAndPreservesOrder|TestWriterBufferedCommandSizeAdvancesOnFlush|TestWriterPoisonCommandBufferTruncatesUnaccountedTail'`
- `GOWORK=off go test ./TreeDB/internal/commitlog ./TreeDB/db ./TreeDB/caching`
- `git diff --check`

## Storage compatibility

- No on-disk format or durability semantics change. This only changes when the in-memory command frame buffer backing array is allocated.

