### PR TITLE
TreeDB: use Linux data sync for column asset segment flushes

### DIFF
--- a/TreeDB/collections/column_asset_file_sync_darwin.go
+++ b/TreeDB/collections/column_asset_file_sync_darwin.go
@@ -2,30 +2,12 @@
 
 package collections
 
-import (
-	"os"
-	"runtime"
-
-	"golang.org/x/sys/unix"
-)
+import "os"
 
 func syncColumnAssetSegmentFile(file *os.File) error {
 	if file == nil {
 		return nil
 	}
-	fd := file.Fd()
-	for {
-		_, _, errno := unix.Syscall(unix.SYS_FDATASYNC, fd, 0, 0)
-		runtime.KeepAlive(file)
-		if errno == 0 {
-			return nil
-		}
-		if errno == unix.EINTR {
-			continue
-		}
-		if errno == unix.ENOSYS || errno == unix.EINVAL {
-			return file.Sync()
-		}
-		return errno
-	}
+	// Go uses F_FULLFSYNC for os.File.Sync on Darwin; keep that publish barrier.
+	return file.Sync()
 }

--- a/TreeDB/collections/column_asset_file_sync_darwin.go
+++ b/TreeDB/collections/column_asset_file_sync_darwin.go
@@ -1,0 +1,31 @@
+//go:build darwin
+
+package collections
+
+import (
+	"os"
+	"runtime"
+
+	"golang.org/x/sys/unix"
+)
+
+func syncColumnAssetSegmentFile(file *os.File) error {
+	if file == nil {
+		return nil
+	}
+	fd := file.Fd()
+	for {
+		_, _, errno := unix.Syscall(unix.SYS_FDATASYNC, fd, 0, 0)
+		runtime.KeepAlive(file)
+		if errno == 0 {
+			return nil
+		}
+		if errno == unix.EINTR {
+			continue
+		}
+		if errno == unix.ENOSYS || errno == unix.EINVAL {
+			return file.Sync()
+		}
+		return errno
+	}
+}

--- a/TreeDB/collections/column_asset_file_sync_default.go
+++ b/TreeDB/collections/column_asset_file_sync_default.go
@@ -1,0 +1,12 @@
+//go:build !linux && !darwin
+
+package collections
+
+import "os"
+
+func syncColumnAssetSegmentFile(file *os.File) error {
+	if file == nil {
+		return nil
+	}
+	return file.Sync()
+}

--- a/TreeDB/collections/column_asset_file_sync_linux.go
+++ b/TreeDB/collections/column_asset_file_sync_linux.go
@@ -1,0 +1,28 @@
+//go:build linux
+
+package collections
+
+import (
+	"os"
+	"runtime"
+
+	"golang.org/x/sys/unix"
+)
+
+func syncColumnAssetSegmentFile(file *os.File) error {
+	if file == nil {
+		return nil
+	}
+	fd := int(file.Fd())
+	for {
+		err := unix.Fdatasync(fd)
+		runtime.KeepAlive(file)
+		if err == unix.EINTR {
+			continue
+		}
+		if err == unix.ENOSYS || err == unix.EINVAL {
+			return file.Sync()
+		}
+		return err
+	}
+}

--- a/TreeDB/collections/column_asset_manager.go
+++ b/TreeDB/collections/column_asset_manager.go
@@ -430,7 +430,7 @@ func writeColumnAssetToManagerSegment(rootDir string, cfg ColumnStoreConfig, pay
 	if written != len(payload) {
 		return ColumnAssetRef{}, io.ErrShortWrite
 	}
-	if err := file.Sync(); err != nil {
+	if err := syncColumnAssetSegmentFile(file); err != nil {
 		return ColumnAssetRef{}, err
 	}
 	if err := file.Close(); err != nil {
@@ -914,7 +914,7 @@ func (a *columnPhysicalAssetSegmentAppender) close() error {
 	}
 	if a.file != nil && a.closeFile {
 		if !a.failed {
-			fileSyncErr = a.file.Sync()
+			fileSyncErr = syncColumnAssetSegmentFile(a.file)
 		}
 		fileCloseErr = a.file.Close()
 		a.closeFile = false

--- a/TreeDB/collections/column_asset_manager.go
+++ b/TreeDB/collections/column_asset_manager.go
@@ -62,6 +62,7 @@ var columnAssetVerifiedChecksumCache = struct {
 
 var columnAssetManagerNamespacePathCaches [columnAssetSegmentWriteLockStripes]columnAssetManagerNamespacePathCache
 var columnAssetSegmentDirSyncCaches [columnAssetSegmentWriteLockStripes]columnAssetSegmentDirSyncCache
+var syncColumnAssetSegmentFileForPublish = syncColumnAssetSegmentFile
 
 type columnAssetVerifiedChecksumEntry struct {
 	key   columnAssetVerifiedChecksumKey
@@ -430,7 +431,7 @@ func writeColumnAssetToManagerSegment(rootDir string, cfg ColumnStoreConfig, pay
 	if written != len(payload) {
 		return ColumnAssetRef{}, io.ErrShortWrite
 	}
-	if err := syncColumnAssetSegmentFile(file); err != nil {
+	if err := syncColumnAssetSegmentFileForPublish(file); err != nil {
 		return ColumnAssetRef{}, err
 	}
 	if err := file.Close(); err != nil {
@@ -914,7 +915,7 @@ func (a *columnPhysicalAssetSegmentAppender) close() error {
 	}
 	if a.file != nil && a.closeFile {
 		if !a.failed {
-			fileSyncErr = syncColumnAssetSegmentFile(a.file)
+			fileSyncErr = syncColumnAssetSegmentFileForPublish(a.file)
 		}
 		fileCloseErr = a.file.Close()
 		a.closeFile = false

--- a/TreeDB/collections/column_physical_asset_test.go
+++ b/TreeDB/collections/column_physical_asset_test.go
@@ -2243,6 +2243,34 @@ func TestColumnPhysicalAssetSegmentAppendWriterSyncsUnknownExistingSegment3152(t
 	}
 }
 
+func TestColumnAssetSegmentFileDataSyncKeepsBytesReadable3151(t *testing.T) {
+	dir := t.TempDir()
+	file, err := os.CreateTemp(dir, "segment-*.tca")
+	if err != nil {
+		t.Fatalf("CreateTemp: %v", err)
+	}
+	path := file.Name()
+	payload := []byte("durable column asset payload")
+	if _, err := file.Write(payload); err != nil {
+		_ = file.Close()
+		t.Fatalf("Write: %v", err)
+	}
+	if err := syncColumnAssetSegmentFile(file); err != nil {
+		_ = file.Close()
+		t.Fatalf("syncColumnAssetSegmentFile: %v", err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatalf("payload=%q want %q", got, payload)
+	}
+}
+
 func TestColumnPhysicalAssetSegmentAppendWriterBatchesMixedRegularAssets3145(t *testing.T) {
 	cfg := testColumnStoreConfig(nil)
 	normalized, err := normalizeColumnStoreConfig("events", cfg)

--- a/TreeDB/collections/column_physical_asset_test.go
+++ b/TreeDB/collections/column_physical_asset_test.go
@@ -2243,31 +2243,89 @@ func TestColumnPhysicalAssetSegmentAppendWriterSyncsUnknownExistingSegment3152(t
 	}
 }
 
-func TestColumnAssetSegmentFileDataSyncKeepsBytesReadable3151(t *testing.T) {
-	dir := t.TempDir()
-	file, err := os.CreateTemp(dir, "segment-*.tca")
+func withColumnAssetSegmentFileSyncForTest(t *testing.T, fn func(*os.File) error) {
+	t.Helper()
+	old := syncColumnAssetSegmentFileForPublish
+	syncColumnAssetSegmentFileForPublish = fn
+	t.Cleanup(func() {
+		syncColumnAssetSegmentFileForPublish = old
+	})
+}
+
+func TestColumnAssetSegmentDirectWriteRequiresFileSyncBeforeRef3151(t *testing.T) {
+	cfg, _ := columnAssetDirectViewAlignmentTestPayloads(t)
+	root := backenddb.ColumnAssetRootDirPath(t.TempDir())
+	refForPath := ColumnAssetRef{
+		Kind:      ColumnAssetKindTCS1PartImage,
+		Namespace: cfg.AssetManager.Namespace,
+		FileID:    columnAssetM12ASegmentFileID,
+		Length:    1,
+	}
+	assetPath, err := columnAssetSegmentPath(root, refForPath)
 	if err != nil {
-		t.Fatalf("CreateTemp: %v", err)
+		t.Fatalf("columnAssetSegmentPath: %v", err)
 	}
-	path := file.Name()
-	payload := []byte("durable column asset payload")
-	if _, err := file.Write(payload); err != nil {
-		_ = file.Close()
-		t.Fatalf("Write: %v", err)
+	syncErr := errors.New("forced segment data sync failure")
+	calls := 0
+	withColumnAssetSegmentFileSyncForTest(t, func(file *os.File) error {
+		if file == nil {
+			t.Fatalf("syncColumnAssetSegmentFileForPublish called with nil file")
+		}
+		calls++
+		return syncErr
+	})
+	ref, err := writeColumnAssetToManagerSegment(root, cfg, []byte("direct"), ColumnAssetKindTCS1PartImage, 7, 1, columnAssetM12ASegmentFileID)
+	if !errors.Is(err, syncErr) {
+		t.Fatalf("writeColumnAssetToManagerSegment err=%v want %v", err, syncErr)
 	}
-	if err := syncColumnAssetSegmentFile(file); err != nil {
-		_ = file.Close()
-		t.Fatalf("syncColumnAssetSegmentFile: %v", err)
+	if ref != (ColumnAssetRef{}) {
+		t.Fatalf("writeColumnAssetToManagerSegment ref=%+v want zero ref after sync failure", ref)
 	}
-	if err := file.Close(); err != nil {
-		t.Fatalf("Close: %v", err)
+	if calls != 1 {
+		t.Fatalf("sync calls=%d want 1", calls)
 	}
-	got, err := os.ReadFile(path)
+	if columnAssetSegmentDirSyncKnown(assetPath) {
+		t.Fatalf("failed direct segment write should not mark segment dir-sync known")
+	}
+}
+
+func TestColumnAssetSegmentAppenderCloseRequiresFileSyncBeforeRef3151(t *testing.T) {
+	cfg, _ := columnAssetDirectViewAlignmentTestPayloads(t)
+	root := backenddb.ColumnAssetRootDirPath(t.TempDir())
+	syncErr := errors.New("forced appender data sync failure")
+	calls := 0
+	withColumnAssetSegmentFileSyncForTest(t, func(file *os.File) error {
+		if file == nil {
+			t.Fatalf("syncColumnAssetSegmentFileForPublish called with nil file")
+		}
+		calls++
+		return syncErr
+	})
+	appender, err := newColumnPhysicalAssetSegmentAppender(root, cfg, columnAssetM12ASegmentFileID)
 	if err != nil {
-		t.Fatalf("ReadFile: %v", err)
+		t.Fatalf("newColumnPhysicalAssetSegmentAppender: %v", err)
 	}
-	if !bytes.Equal(got, payload) {
-		t.Fatalf("payload=%q want %q", got, payload)
+	ref, err := appender.appendKind([]byte("batched"), ColumnAssetKindTCS1PartImage, 7, 1)
+	if err != nil {
+		_ = appender.abort()
+		t.Fatalf("appendKind: %v", err)
+	}
+	assetPath, err := columnAssetSegmentPath(root, ref)
+	if err != nil {
+		_ = appender.abort()
+		t.Fatalf("columnAssetSegmentPath: %v", err)
+	}
+	if err := appender.close(); !errors.Is(err, syncErr) {
+		t.Fatalf("appender close err=%v want %v", err, syncErr)
+	}
+	if calls != 1 {
+		t.Fatalf("sync calls=%d want 1", calls)
+	}
+	if _, err := os.Stat(assetPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("asset path after failed close err=%v want not exist", err)
+	}
+	if columnAssetSegmentDirSyncKnown(assetPath) {
+		t.Fatalf("failed appender close should not mark segment dir-sync known")
 	}
 }
 


### PR DESCRIPTION
## Summary

Part of #3151.

This PR keeps the shared column-asset segment publication barrier explicit while narrowing the platform sync primitive where it is safe:

- Linux: `unix.Fdatasync`, with EINTR retry and `file.Sync()` fallback for ENOSYS/EINVAL.
- Darwin: `file.Sync()` retained because Go's Darwin implementation uses `F_FULLFSYNC`; using `SYS_FDATASYNC` before publishing manifest refs is not durable enough for the current safety contract.
- Other platforms: existing `file.Sync()` fallback.

Directory sync behavior is unchanged. New or previously unknown segment directory entries still sync the containing segment directory, and the append path still flushes the file before returning refs that can be published in the manifest.

## Scope / Claim Boundary

This is an insert/load and column asset segment flush slice only.

It may improve:

- Linux shared column asset append close/sync time.
- Linux insert/load publish time where the file data-sync barrier dominates.
- sync-boundary test coverage for direct and batched segment publication.

It does not claim:

- a measured macOS close/sync improvement;
- completion of #3151's 25% measured close/sync gate;
- one-shot SQL superiority;
- no-aggregate-metadata query improvement;
- hot prepared query improvement;
- arbitrary-expression scan improvement;
- ClickHouse superiority.

Those remain tracked by the broader realigned JSONBench/ClickHouse performance goal.

## Durability Finding

A latest-head Codex review found that the initial Darwin `SYS_FDATASYNC` path weakened the publish barrier. Local Go source confirms Darwin `os.File.Sync()` uses `F_FULLFSYNC` (`internal/poll/fd_fsync_darwin.go`). This PR therefore keeps Darwin on `file.Sync()` and treats the previous Darwin fdatasync timing as a rejected diagnostic upper bound, not mergeable durable evidence.

## Performance Evidence

Required 100k synthetic command shape:

```sh
OUT=/tmp/gomap_column_store_asset_sync_$(date +%Y%m%d_%H%M%S)
go build -o ./bin/unified-bench ./cmd/unified_bench
./bin/unified-bench \
  -suite column_store \
  -dbs treedb \
  -profile durable \
  -keys 100000 \
  -batchsize 1000 \
  -profile-dir "$OUT" \
  -path-label native-fastpath \
  -column-store-path serial_column_scan \
  -column-store-query q1 \
  -progress=false
```

| run | platform/sync mode | artifact | ingest_insert_batch ms | publish ms | asset_append ms | open ms | write ms | close ms | shared bytes | aggregate metadata bytes | durable WAL-excluded storage |
| --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| baseline main | Darwin `file.Sync()` / `F_FULLFSYNC` | `/tmp/gomap_column_store_asset_sync_main_20260626_203511/column_store_results.json` | 741.647 | 623.986 | 325.229 | 23.122 | 6.649 | 295.458 | 23,055,800 | 9,483,700 | 26,071,416 |
| current PR, durable Darwin | Darwin `file.Sync()` / `F_FULLFSYNC` | `/tmp/gomap_column_store_asset_sync_darwin_fullsync_20260626_210930/column_store_results.json` | 699.172 | 588.937 | 311.497 | 10.678 | 6.636 | 294.183 | 23,055,800 | 9,483,700 | 26,071,416 |

Interpretation: the local macOS-safe close/sync bucket remains about `294 ms`, so #3151's measured local 25% close/sync reduction is not satisfied by this PR. The remaining macOS blocker is the required `F_FULLFSYNC` publish barrier. Linux keeps the `fdatasync` implementation path, but Linux runtime evidence is still required before using this PR as measured #3151 closeout evidence.

Rejected diagnostic upper bound from the initial unsafe Darwin fdatasync experiment:

- `/tmp/gomap_column_store_asset_sync_fdatasync_20260626_203637/column_store_results.json`: close `15.543 ms`, asset_append `49.475 ms`.
- `/tmp/gomap_column_store_asset_sync_fdatasync_repeat_20260626_203841/column_store_results.json`: close `24.302 ms`, asset_append `56.469 ms`.

Those numbers explain the size of the sync barrier but are not durable Darwin evidence and are not used as the acceptance claim.

## Tests

```sh
go test ./TreeDB/collections -run 'TestColumnAssetSegment.*3151|TestTypedStorageLegacyNameAllowlistIsComplete' -count=1
go test ./TreeDB/collections ./cmd/unified_bench -count=1
GOOS=linux GOARCH=amd64 go test -c ./TreeDB/collections -o /tmp/treedb_collections_linux_3151.test
git diff --check
```
