### PR TITLE
TreeDB: bound value-log decode scratch retention

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -29859,6 +29859,11 @@ func (db *DB) Stats() map[string]string {
 	if growStats.RequestedBytesTotal > 0 {
 		stats["treedb.cache.vlog_decode_buffer_grow.overalloc_ratio"] = fmt.Sprintf("%.6f", float64(growStats.AllocatedBytesTotal)/float64(growStats.RequestedBytesTotal))
 	}
+	scratchStats := valuelog.DecodeScratchStatsSnapshot()
+	if db.valueLogReader != nil {
+		scratchStats = db.valueLogReader.DecodeScratchStats()
+	}
+	valuelog.AppendDecodeScratchStats(stats, "treedb.cache.vlog_decode_scratch", scratchStats)
 	cacheVlogMmap := cacheVlogMmapStatsSnapshot(db.valueLogReader)
 	if db.valueLogReader != nil {
 		remaps, deadMappings := db.valueLogReader.RemapStats()

--- a/TreeDB/caching/expvar_stats.go
+++ b/TreeDB/caching/expvar_stats.go
@@ -134,9 +134,11 @@ func selectTreeDBExpvarStats(stats map[string]string) map[string]any {
 		if isProcessWideExpvarKey(k) ||
 			strings.HasPrefix(k, "treedb.process.identity.") ||
 			strings.HasPrefix(k, "treedb.vlog.mmap") ||
+			strings.HasPrefix(k, "treedb.vlog.decode_scratch.") ||
 			strings.HasPrefix(k, "treedb.cache.vlog_mmap.") ||
 			strings.HasPrefix(k, "treedb.cache.vlog_grouped_frame_cache.") ||
 			strings.HasPrefix(k, "treedb.cache.vlog_decode_buffer_grow.") ||
+			strings.HasPrefix(k, "treedb.cache.vlog_decode_scratch.") ||
 			strings.HasPrefix(k, "treedb.cache.vlog_write_mode.") ||
 			strings.HasPrefix(k, "treedb.cache.vlog_payload_split.") ||
 			strings.HasPrefix(k, "treedb.cache.vlog_auto.") ||

--- a/TreeDB/caching/expvar_stats_test.go
+++ b/TreeDB/caching/expvar_stats_test.go
@@ -19,6 +19,7 @@ func TestSelectTreeDBExpvarStatsFiltersAndCoerces(t *testing.T) {
 		"treedb.process.identity.wal_dir":                               "/tmp/app.db/wal",
 		"treedb.vlog.mmap_active_bytes":                                 "22222",
 		"treedb.vlog.mmap_max_mapped_leaf_sealed_bytes":                 "8589934592",
+		"treedb.vlog.decode_scratch.small_pool.retained_bytes":          "16384",
 		"treedb.cache.vlog_mmap.active_bytes":                           "12345",
 		"treedb.cache.vlog_mmap.max_mapped_leaf_sealed_segments":        "512",
 		"treedb.cache.vlog_mmap.read.hit_ratio":                         "0.625000",
@@ -27,6 +28,7 @@ func TestSelectTreeDBExpvarStatsFiltersAndCoerces(t *testing.T) {
 		"treedb.cache.vlog_grouped_frame_cache.allocated_slots":         "64",
 		"treedb.cache.vlog_grouped_frame_cache.hit_ratio":               "0.750000",
 		"treedb.cache.vlog_decode_buffer_grow.calls_total":              "42",
+		"treedb.cache.vlog_decode_scratch.small_pool.retained_bytes":    "32768",
 		"treedb.cache.vlog_write_mode.raw_bytes.dict":                   "40960",
 		"treedb.cache.vlog_payload_split.raw_bytes.outer_leaf":          "1024",
 		"treedb.cache.vlog_auto.bytes.dict":                             "8192",
@@ -64,6 +66,9 @@ func TestSelectTreeDBExpvarStatsFiltersAndCoerces(t *testing.T) {
 	if v, ok := got["treedb.vlog.mmap_max_mapped_leaf_sealed_bytes"].(int64); !ok || v != 8589934592 {
 		t.Fatalf("backend leaf mmap byte cap=%T(%v) want int64(8589934592)", got["treedb.vlog.mmap_max_mapped_leaf_sealed_bytes"], got["treedb.vlog.mmap_max_mapped_leaf_sealed_bytes"])
 	}
+	if v, ok := got["treedb.vlog.decode_scratch.small_pool.retained_bytes"].(int64); !ok || v != 16384 {
+		t.Fatalf("backend decode_scratch.small_pool.retained_bytes=%T(%v) want int64(16384)", got["treedb.vlog.decode_scratch.small_pool.retained_bytes"], got["treedb.vlog.decode_scratch.small_pool.retained_bytes"])
+	}
 	if v, ok := got["treedb.cache.vlog_mmap.max_mapped_leaf_sealed_segments"].(int64); !ok || v != 512 {
 		t.Fatalf("cache leaf mmap segment cap=%T(%v) want int64(512)", got["treedb.cache.vlog_mmap.max_mapped_leaf_sealed_segments"], got["treedb.cache.vlog_mmap.max_mapped_leaf_sealed_segments"])
 	}
@@ -84,6 +89,9 @@ func TestSelectTreeDBExpvarStatsFiltersAndCoerces(t *testing.T) {
 	}
 	if v, ok := got["treedb.cache.vlog_decode_buffer_grow.calls_total"].(int64); !ok || v != 42 {
 		t.Fatalf("decode_buffer_grow.calls_total=%T(%v) want int64(42)", got["treedb.cache.vlog_decode_buffer_grow.calls_total"], got["treedb.cache.vlog_decode_buffer_grow.calls_total"])
+	}
+	if v, ok := got["treedb.cache.vlog_decode_scratch.small_pool.retained_bytes"].(int64); !ok || v != 32768 {
+		t.Fatalf("decode_scratch.small_pool.retained_bytes=%T(%v) want int64(32768)", got["treedb.cache.vlog_decode_scratch.small_pool.retained_bytes"], got["treedb.cache.vlog_decode_scratch.small_pool.retained_bytes"])
 	}
 	if v, ok := got["treedb.cache.vlog_write_mode.raw_bytes.dict"].(int64); !ok || v != 40960 {
 		t.Fatalf("vlog_write_mode.raw_bytes.dict=%T(%v) want int64(40960)", got["treedb.cache.vlog_write_mode.raw_bytes.dict"], got["treedb.cache.vlog_write_mode.raw_bytes.dict"])

--- a/TreeDB/caching/vlog_shape_stats_test.go
+++ b/TreeDB/caching/vlog_shape_stats_test.go
@@ -71,4 +71,11 @@ func TestStats_ExportsVlogShapeKeys(t *testing.T) {
 	needInt("treedb.cache.vlog_shape.lane.0.bytes_live")
 	needUint("treedb.cache.vlog_shape.lane.0.rotations_total")
 	needUint("treedb.cache.vlog_shape.lane.0.rotations_idle_total")
+
+	needUint("treedb.cache.vlog_decode_scratch.small_pool.max_entries")
+	needUint("treedb.cache.vlog_decode_scratch.small_pool.retained_bytes")
+	needUint("treedb.cache.vlog_decode_scratch.large_pool.max_entries")
+	needUint("treedb.cache.vlog_decode_scratch.large_pool.retained_bytes")
+	needUint("treedb.cache.vlog_decode_scratch.file_stash.retain_max_bytes")
+	needUint("treedb.cache.vlog_decode_scratch.file_stash.retained_bytes")
 }

--- a/TreeDB/db/api.go
+++ b/TreeDB/db/api.go
@@ -838,6 +838,8 @@ func (db *DB) Stats() map[string]string {
 		readStats := db.valueLogManager.ReadStats()
 		stats["treedb.vlog.read.crc32_checks_total"] = fmt.Sprintf("%d", readStats.RecordCRCChecks)
 
+		valuelog.AppendDecodeScratchStats(stats, "treedb.vlog.decode_scratch", db.valueLogManager.DecodeScratchStats())
+
 		gStats := db.valueLogManager.GroupedFrameCacheDetailedStats()
 		stats["treedb.vlog.grouped_frame_cache.hits"] = fmt.Sprintf("%d", gStats.Hits)
 		stats["treedb.vlog.grouped_frame_cache.misses"] = fmt.Sprintf("%d", gStats.Misses)

--- a/TreeDB/internal/valuelog/decode_scratch_pool_test.go
+++ b/TreeDB/internal/valuelog/decode_scratch_pool_test.go
@@ -171,6 +171,32 @@ func TestFileDecodeScratch_BoundsPerFileSmallSpares(t *testing.T) {
 	}
 }
 
+func TestFileDecodeScratch_TrimsAfterPrimaryRefill(t *testing.T) {
+	t.Cleanup(drainDecodeScratchPoolsForTest)
+
+	f := &File{}
+	f.releaseDecodeScratch(make([]byte, 0, fileDecodeScratchRetainMaxBytes/2))
+	f.releaseDecodeScratch(make([]byte, 0, fileDecodeScratchRetainMaxBytes/2))
+	checkedOut := f.takeDecodeScratch(fileDecodeScratchRetainMaxBytes / 2)
+	if cap(checkedOut) < fileDecodeScratchRetainMaxBytes/2 {
+		t.Fatalf("checkedOut cap=%d want >=%d", cap(checkedOut), fileDecodeScratchRetainMaxBytes/2)
+	}
+	if cap(f.decodeScratch) != 0 {
+		t.Fatalf("expected empty primary after take, got cap=%d", cap(f.decodeScratch))
+	}
+	if got := len(f.decodeScratchSpare); got == 0 {
+		t.Fatalf("expected retained spare after primary take")
+	}
+
+	f.releaseDecodeScratch(make([]byte, 0, fileDecodeScratchRetainMaxBytes))
+
+	stats := DecodeScratchStats{}
+	f.addDecodeScratchStats(&stats)
+	if got := stats.FileRetainedBytes; got > fileDecodeScratchRetainMaxBytes {
+		t.Fatalf("file retained bytes=%d want <=%d", got, fileDecodeScratchRetainMaxBytes)
+	}
+}
+
 func TestFileDecodeScratch_ReusesLargeBuffer(t *testing.T) {
 	minCap := maxDecodeScratchKeep + (64 << 10) // 320KiB
 	if minCap > maxLargeDecodeScratchKeep {

--- a/TreeDB/internal/valuelog/decode_scratch_pool_test.go
+++ b/TreeDB/internal/valuelog/decode_scratch_pool_test.go
@@ -69,6 +69,46 @@ func TestDecodeScratchPool_BoundsSmallRetainedBytes(t *testing.T) {
 	}
 }
 
+func TestDecodeScratchPool_DropRollsBackRetainedGauge(t *testing.T) {
+	drainDecodeScratchPoolsForTest()
+	t.Cleanup(drainDecodeScratchPoolsForTest)
+
+	for i := 0; i < smallDecodeScratchPoolEntries; i++ {
+		putDecodeScratch(make([]byte, 0, maxDecodeScratchKeep))
+	}
+	before := DecodeScratchStatsSnapshot()
+	putDecodeScratch(make([]byte, 0, maxDecodeScratchKeep))
+	after := DecodeScratchStatsSnapshot()
+
+	if got := after.SmallPoolRetainedBuffers; got != before.SmallPoolRetainedBuffers {
+		t.Fatalf("small retained buffers changed after drop: got %d want %d", got, before.SmallPoolRetainedBuffers)
+	}
+	if got := after.SmallPoolRetainedBytes; got != before.SmallPoolRetainedBytes {
+		t.Fatalf("small retained bytes changed after drop: got %d want %d", got, before.SmallPoolRetainedBytes)
+	}
+	if got := after.SmallPoolDropsTotal - before.SmallPoolDropsTotal; got != 1 {
+		t.Fatalf("small pool drops delta=%d want 1", got)
+	}
+
+	drainDecodeScratchPoolsForTest()
+	for i := 0; i < largeDecodeScratchPoolEntries; i++ {
+		putDecodeScratch(make([]byte, 0, maxDecodeScratchKeep+1))
+	}
+	before = DecodeScratchStatsSnapshot()
+	putDecodeScratch(make([]byte, 0, maxDecodeScratchKeep+1))
+	after = DecodeScratchStatsSnapshot()
+
+	if got := after.LargePoolRetainedBuffers; got != before.LargePoolRetainedBuffers {
+		t.Fatalf("large retained buffers changed after drop: got %d want %d", got, before.LargePoolRetainedBuffers)
+	}
+	if got := after.LargePoolRetainedBytes; got != before.LargePoolRetainedBytes {
+		t.Fatalf("large retained bytes changed after drop: got %d want %d", got, before.LargePoolRetainedBytes)
+	}
+	if got := after.LargePoolDropsTotal - before.LargePoolDropsTotal; got != 1 {
+		t.Fatalf("large pool drops delta=%d want 1", got)
+	}
+}
+
 func TestDecodeScratchPool_ReusesLargeBuffer(t *testing.T) {
 	// Ensure we exercise the large-scratch pool path (>maxDecodeScratchKeep).
 	minCap := maxDecodeScratchKeep + (64 << 10) // 320KiB

--- a/TreeDB/internal/valuelog/decode_scratch_pool_test.go
+++ b/TreeDB/internal/valuelog/decode_scratch_pool_test.go
@@ -2,6 +2,27 @@ package valuelog
 
 import "testing"
 
+func drainDecodeScratchPoolsForTest() {
+	for {
+		select {
+		case buf := <-smallDecodeScratchPool:
+			noteDecodeScratchSmallPoolTake(cap(buf))
+		default:
+			goto drainLarge
+		}
+	}
+
+drainLarge:
+	for {
+		select {
+		case buf := <-largeDecodeScratchPool:
+			noteDecodeScratchLargePoolTake(cap(buf))
+		default:
+			return
+		}
+	}
+}
+
 func TestDecodeScratchPool_ReusesSmallBuffer_NoAllocsAfterWarmup(t *testing.T) {
 	minCap := 1024
 
@@ -20,6 +41,31 @@ func TestDecodeScratchPool_ReusesSmallBuffer_NoAllocsAfterWarmup(t *testing.T) {
 	})
 	if allocs != 0 {
 		t.Fatalf("expected 0 allocs after warm-up, got %f", allocs)
+	}
+}
+
+func TestDecodeScratchPool_BoundsSmallRetainedBytes(t *testing.T) {
+	drainDecodeScratchPoolsForTest()
+	t.Cleanup(drainDecodeScratchPoolsForTest)
+
+	before := DecodeScratchStatsSnapshot()
+	for i := 0; i < smallDecodeScratchPoolEntries+7; i++ {
+		putDecodeScratch(make([]byte, 0, maxDecodeScratchKeep))
+	}
+	after := DecodeScratchStatsSnapshot()
+
+	if got := after.SmallPoolEntries; got != smallDecodeScratchPoolEntries {
+		t.Fatalf("small pool entries=%d want %d", got, smallDecodeScratchPoolEntries)
+	}
+	if got := after.SmallPoolRetainedBuffers; got != uint64(smallDecodeScratchPoolEntries) {
+		t.Fatalf("small retained buffers=%d want %d", got, smallDecodeScratchPoolEntries)
+	}
+	wantBytes := uint64(smallDecodeScratchPoolEntries * maxDecodeScratchKeep)
+	if got := after.SmallPoolRetainedBytes; got != wantBytes {
+		t.Fatalf("small retained bytes=%d want %d", got, wantBytes)
+	}
+	if got := after.SmallPoolDropsTotal - before.SmallPoolDropsTotal; got != 7 {
+		t.Fatalf("small pool drops delta=%d want 7", got)
 	}
 }
 
@@ -70,13 +116,18 @@ func TestFileDecodeScratch_RetainsParallelSmallBuffers(t *testing.T) {
 func TestFileDecodeScratch_BoundsPerFileSmallSpares(t *testing.T) {
 	f := &File{}
 	for i := 0; i < fileDecodeScratchSpareKeep+4; i++ {
-		f.releaseDecodeScratch(make([]byte, 0, (i+1)<<10))
+		f.releaseDecodeScratch(make([]byte, 0, fileDecodeScratchRetainMaxBytes/2))
 	}
 	if cap(f.decodeScratch) == 0 {
 		t.Fatalf("expected primary decode scratch")
 	}
 	if got := len(f.decodeScratchSpare); got > fileDecodeScratchSpareKeep {
 		t.Fatalf("decodeScratchSpare len=%d want <=%d", got, fileDecodeScratchSpareKeep)
+	}
+	stats := DecodeScratchStats{}
+	f.addDecodeScratchStats(&stats)
+	if got := stats.FileRetainedBytes; got > fileDecodeScratchRetainMaxBytes {
+		t.Fatalf("file retained bytes=%d want <=%d", got, fileDecodeScratchRetainMaxBytes)
 	}
 }
 

--- a/TreeDB/internal/valuelog/decode_scratch_stats.go
+++ b/TreeDB/internal/valuelog/decode_scratch_stats.go
@@ -1,0 +1,191 @@
+package valuelog
+
+import (
+	"fmt"
+	"sync/atomic"
+)
+
+// DecodeScratchStats reports process-global decode scratch pool activity plus
+// optional per-manager file stash retention filled by Manager.DecodeScratchStats.
+type DecodeScratchStats struct {
+	SmallPoolMaxEntries      int
+	SmallPoolEntries         int
+	SmallPoolRetainedBuffers uint64
+	SmallPoolRetainedBytes   uint64
+	SmallPoolGetsTotal       uint64
+	SmallPoolHitsTotal       uint64
+	SmallPoolMissesTotal     uint64
+	SmallPoolTooSmallTotal   uint64
+	SmallPoolPutsTotal       uint64
+	SmallPoolDropsTotal      uint64
+	SmallPoolDroppedBytes    uint64
+	SmallAllocCallsTotal     uint64
+	SmallAllocatedBytesTotal uint64
+
+	LargePoolMaxEntries      int
+	LargePoolEntries         int
+	LargePoolRetainedBuffers uint64
+	LargePoolRetainedBytes   uint64
+	LargePoolGetsTotal       uint64
+	LargePoolHitsTotal       uint64
+	LargePoolMissesTotal     uint64
+	LargePoolTooSmallTotal   uint64
+	LargePoolPutsTotal       uint64
+	LargePoolDropsTotal      uint64
+	LargePoolDroppedBytes    uint64
+	LargeAllocCallsTotal     uint64
+	LargeAllocatedBytesTotal uint64
+
+	OversizeAllocCallsTotal     uint64
+	OversizeAllocatedBytesTotal uint64
+	OversizeDropsTotal          uint64
+	OversizeDroppedBytesTotal   uint64
+
+	FileRetainMaxBytes  uint64
+	FileSpareMaxCount   uint64
+	FileRetainedFiles   uint64
+	FileRetainedBuffers uint64
+	FileRetainedBytes   uint64
+}
+
+var decodeScratchSmallPoolRetainedBytes atomic.Uint64
+var decodeScratchSmallPoolRetainedBuffers atomic.Uint64
+var decodeScratchSmallPoolGetsTotal atomic.Uint64
+var decodeScratchSmallPoolHitsTotal atomic.Uint64
+var decodeScratchSmallPoolMissesTotal atomic.Uint64
+var decodeScratchSmallPoolTooSmallTotal atomic.Uint64
+var decodeScratchSmallPoolPutsTotal atomic.Uint64
+var decodeScratchSmallPoolDropsTotal atomic.Uint64
+var decodeScratchSmallPoolDroppedBytesTotal atomic.Uint64
+var decodeScratchSmallAllocCallsTotal atomic.Uint64
+var decodeScratchSmallAllocatedBytesTotal atomic.Uint64
+
+var decodeScratchLargePoolRetainedBytes atomic.Uint64
+var decodeScratchLargePoolRetainedBuffers atomic.Uint64
+var decodeScratchLargePoolGetsTotal atomic.Uint64
+var decodeScratchLargePoolHitsTotal atomic.Uint64
+var decodeScratchLargePoolMissesTotal atomic.Uint64
+var decodeScratchLargePoolTooSmallTotal atomic.Uint64
+var decodeScratchLargePoolPutsTotal atomic.Uint64
+var decodeScratchLargePoolDropsTotal atomic.Uint64
+var decodeScratchLargePoolDroppedBytesTotal atomic.Uint64
+var decodeScratchLargeAllocCallsTotal atomic.Uint64
+var decodeScratchLargeAllocatedBytesTotal atomic.Uint64
+
+var decodeScratchOversizeAllocCallsTotal atomic.Uint64
+var decodeScratchOversizeAllocatedBytesTotal atomic.Uint64
+var decodeScratchOversizeDropsTotal atomic.Uint64
+var decodeScratchOversizeDroppedBytesTotal atomic.Uint64
+
+func DecodeScratchStatsSnapshot() DecodeScratchStats {
+	return DecodeScratchStats{
+		SmallPoolMaxEntries:      smallDecodeScratchPoolEntries,
+		SmallPoolEntries:         len(smallDecodeScratchPool),
+		SmallPoolRetainedBuffers: decodeScratchSmallPoolRetainedBuffers.Load(),
+		SmallPoolRetainedBytes:   decodeScratchSmallPoolRetainedBytes.Load(),
+		SmallPoolGetsTotal:       decodeScratchSmallPoolGetsTotal.Load(),
+		SmallPoolHitsTotal:       decodeScratchSmallPoolHitsTotal.Load(),
+		SmallPoolMissesTotal:     decodeScratchSmallPoolMissesTotal.Load(),
+		SmallPoolTooSmallTotal:   decodeScratchSmallPoolTooSmallTotal.Load(),
+		SmallPoolPutsTotal:       decodeScratchSmallPoolPutsTotal.Load(),
+		SmallPoolDropsTotal:      decodeScratchSmallPoolDropsTotal.Load(),
+		SmallPoolDroppedBytes:    decodeScratchSmallPoolDroppedBytesTotal.Load(),
+		SmallAllocCallsTotal:     decodeScratchSmallAllocCallsTotal.Load(),
+		SmallAllocatedBytesTotal: decodeScratchSmallAllocatedBytesTotal.Load(),
+
+		LargePoolMaxEntries:      largeDecodeScratchPoolEntries,
+		LargePoolEntries:         len(largeDecodeScratchPool),
+		LargePoolRetainedBuffers: decodeScratchLargePoolRetainedBuffers.Load(),
+		LargePoolRetainedBytes:   decodeScratchLargePoolRetainedBytes.Load(),
+		LargePoolGetsTotal:       decodeScratchLargePoolGetsTotal.Load(),
+		LargePoolHitsTotal:       decodeScratchLargePoolHitsTotal.Load(),
+		LargePoolMissesTotal:     decodeScratchLargePoolMissesTotal.Load(),
+		LargePoolTooSmallTotal:   decodeScratchLargePoolTooSmallTotal.Load(),
+		LargePoolPutsTotal:       decodeScratchLargePoolPutsTotal.Load(),
+		LargePoolDropsTotal:      decodeScratchLargePoolDropsTotal.Load(),
+		LargePoolDroppedBytes:    decodeScratchLargePoolDroppedBytesTotal.Load(),
+		LargeAllocCallsTotal:     decodeScratchLargeAllocCallsTotal.Load(),
+		LargeAllocatedBytesTotal: decodeScratchLargeAllocatedBytesTotal.Load(),
+
+		OversizeAllocCallsTotal:     decodeScratchOversizeAllocCallsTotal.Load(),
+		OversizeAllocatedBytesTotal: decodeScratchOversizeAllocatedBytesTotal.Load(),
+		OversizeDropsTotal:          decodeScratchOversizeDropsTotal.Load(),
+		OversizeDroppedBytesTotal:   decodeScratchOversizeDroppedBytesTotal.Load(),
+
+		FileRetainMaxBytes: uint64(fileDecodeScratchRetainMaxBytes),
+		FileSpareMaxCount:  uint64(fileDecodeScratchSpareKeep),
+	}
+}
+
+func AppendDecodeScratchStats(out map[string]string, prefix string, stats DecodeScratchStats) {
+	if out == nil || prefix == "" {
+		return
+	}
+	out[prefix+".small_pool.max_entries"] = fmt.Sprintf("%d", stats.SmallPoolMaxEntries)
+	out[prefix+".small_pool.entries"] = fmt.Sprintf("%d", stats.SmallPoolEntries)
+	out[prefix+".small_pool.retained_buffers"] = fmt.Sprintf("%d", stats.SmallPoolRetainedBuffers)
+	out[prefix+".small_pool.retained_bytes"] = fmt.Sprintf("%d", stats.SmallPoolRetainedBytes)
+	out[prefix+".small_pool.gets_total"] = fmt.Sprintf("%d", stats.SmallPoolGetsTotal)
+	out[prefix+".small_pool.hits_total"] = fmt.Sprintf("%d", stats.SmallPoolHitsTotal)
+	out[prefix+".small_pool.misses_total"] = fmt.Sprintf("%d", stats.SmallPoolMissesTotal)
+	out[prefix+".small_pool.too_small_total"] = fmt.Sprintf("%d", stats.SmallPoolTooSmallTotal)
+	out[prefix+".small_pool.puts_total"] = fmt.Sprintf("%d", stats.SmallPoolPutsTotal)
+	out[prefix+".small_pool.drops_total"] = fmt.Sprintf("%d", stats.SmallPoolDropsTotal)
+	out[prefix+".small_pool.dropped_bytes_total"] = fmt.Sprintf("%d", stats.SmallPoolDroppedBytes)
+	out[prefix+".small_pool.alloc_calls_total"] = fmt.Sprintf("%d", stats.SmallAllocCallsTotal)
+	out[prefix+".small_pool.allocated_bytes_total"] = fmt.Sprintf("%d", stats.SmallAllocatedBytesTotal)
+	out[prefix+".large_pool.max_entries"] = fmt.Sprintf("%d", stats.LargePoolMaxEntries)
+	out[prefix+".large_pool.entries"] = fmt.Sprintf("%d", stats.LargePoolEntries)
+	out[prefix+".large_pool.retained_buffers"] = fmt.Sprintf("%d", stats.LargePoolRetainedBuffers)
+	out[prefix+".large_pool.retained_bytes"] = fmt.Sprintf("%d", stats.LargePoolRetainedBytes)
+	out[prefix+".large_pool.gets_total"] = fmt.Sprintf("%d", stats.LargePoolGetsTotal)
+	out[prefix+".large_pool.hits_total"] = fmt.Sprintf("%d", stats.LargePoolHitsTotal)
+	out[prefix+".large_pool.misses_total"] = fmt.Sprintf("%d", stats.LargePoolMissesTotal)
+	out[prefix+".large_pool.too_small_total"] = fmt.Sprintf("%d", stats.LargePoolTooSmallTotal)
+	out[prefix+".large_pool.puts_total"] = fmt.Sprintf("%d", stats.LargePoolPutsTotal)
+	out[prefix+".large_pool.drops_total"] = fmt.Sprintf("%d", stats.LargePoolDropsTotal)
+	out[prefix+".large_pool.dropped_bytes_total"] = fmt.Sprintf("%d", stats.LargePoolDroppedBytes)
+	out[prefix+".large_pool.alloc_calls_total"] = fmt.Sprintf("%d", stats.LargeAllocCallsTotal)
+	out[prefix+".large_pool.allocated_bytes_total"] = fmt.Sprintf("%d", stats.LargeAllocatedBytesTotal)
+	out[prefix+".oversize.alloc_calls_total"] = fmt.Sprintf("%d", stats.OversizeAllocCallsTotal)
+	out[prefix+".oversize.allocated_bytes_total"] = fmt.Sprintf("%d", stats.OversizeAllocatedBytesTotal)
+	out[prefix+".oversize.drops_total"] = fmt.Sprintf("%d", stats.OversizeDropsTotal)
+	out[prefix+".oversize.dropped_bytes_total"] = fmt.Sprintf("%d", stats.OversizeDroppedBytesTotal)
+	out[prefix+".file_stash.retain_max_bytes"] = fmt.Sprintf("%d", stats.FileRetainMaxBytes)
+	out[prefix+".file_stash.spare_max_count"] = fmt.Sprintf("%d", stats.FileSpareMaxCount)
+	out[prefix+".file_stash.retained_files"] = fmt.Sprintf("%d", stats.FileRetainedFiles)
+	out[prefix+".file_stash.retained_buffers"] = fmt.Sprintf("%d", stats.FileRetainedBuffers)
+	out[prefix+".file_stash.retained_bytes"] = fmt.Sprintf("%d", stats.FileRetainedBytes)
+}
+
+func noteDecodeScratchSmallPoolPut(capacity int) {
+	if capacity <= 0 {
+		return
+	}
+	decodeScratchSmallPoolRetainedBuffers.Add(1)
+	decodeScratchSmallPoolRetainedBytes.Add(uint64(capacity))
+}
+
+func noteDecodeScratchSmallPoolTake(capacity int) {
+	if capacity <= 0 {
+		return
+	}
+	decodeScratchSmallPoolRetainedBuffers.Add(^uint64(0))
+	decodeScratchSmallPoolRetainedBytes.Add(^uint64(capacity - 1))
+}
+
+func noteDecodeScratchLargePoolPut(capacity int) {
+	if capacity <= 0 {
+		return
+	}
+	decodeScratchLargePoolRetainedBuffers.Add(1)
+	decodeScratchLargePoolRetainedBytes.Add(uint64(capacity))
+}
+
+func noteDecodeScratchLargePoolTake(capacity int) {
+	if capacity <= 0 {
+		return
+	}
+	decodeScratchLargePoolRetainedBuffers.Add(^uint64(0))
+	decodeScratchLargePoolRetainedBytes.Add(^uint64(capacity - 1))
+}

--- a/TreeDB/internal/valuelog/manager.go
+++ b/TreeDB/internal/valuelog/manager.go
@@ -1068,7 +1068,7 @@ func (f *File) readAtWithDictTo(ptr page.ValuePtr, verifyCRC bool, dst []byte) (
 	if verifyCRC {
 		f.noteRecordCRCCheck()
 	}
-	return ReadAtWithDictTo(f.File, ptr, verifyCRC, f.dictLookup, f.templateLookup, f.templateDefCache, f.templateDecodeOpts, dst)
+	return readAtWithDictToScratch(f.File, ptr, verifyCRC, f.dictLookup, f.templateLookup, f.templateDefCache, f.templateDecodeOpts, dst, f.takeDecodeScratch, f.releaseDecodeScratch)
 }
 
 func (f *File) appendDecodedRecordTo(ptr page.ValuePtr, verifyCRC bool, dst []byte) ([]byte, error) {

--- a/TreeDB/internal/valuelog/manager.go
+++ b/TreeDB/internal/valuelog/manager.go
@@ -214,7 +214,10 @@ func (f *File) setCacheRawLocked(raw []byte, pooled bool) {
 	f.cacheRawPooled = pooled
 }
 
-const fileDecodeScratchSpareKeep = 2
+const (
+	fileDecodeScratchSpareKeep      = 2
+	fileDecodeScratchRetainMaxBytes = 128 << 10
+)
 
 func (f *File) stashDecodeScratch(buf []byte) {
 	if cap(buf) == 0 {
@@ -233,6 +236,10 @@ func (f *File) stashDecodeScratchLocked(buf []byte) {
 	if cap(buf) == 0 {
 		return
 	}
+	if cap(buf) > fileDecodeScratchRetainMaxBytes {
+		putDecodeScratch(buf)
+		return
+	}
 	if cap(f.decodeScratch) == 0 {
 		f.decodeScratch = buf
 		return
@@ -244,9 +251,61 @@ func (f *File) stashDecodeScratchLocked(buf []byte) {
 	}
 	if len(f.decodeScratchSpare) < fileDecodeScratchSpareKeep {
 		f.decodeScratchSpare = append(f.decodeScratchSpare, buf[:0])
+		f.trimDecodeScratchLocked()
 		return
 	}
 	putDecodeScratch(buf)
+	f.trimDecodeScratchLocked()
+}
+
+func (f *File) trimDecodeScratchLocked() {
+	total := cap(f.decodeScratch)
+	for _, spare := range f.decodeScratchSpare {
+		total += cap(spare)
+	}
+	for total > fileDecodeScratchRetainMaxBytes && len(f.decodeScratchSpare) > 0 {
+		last := len(f.decodeScratchSpare) - 1
+		buf := f.decodeScratchSpare[last]
+		f.decodeScratchSpare[last] = nil
+		f.decodeScratchSpare = f.decodeScratchSpare[:last]
+		total -= cap(buf)
+		putDecodeScratch(buf)
+	}
+	if total > fileDecodeScratchRetainMaxBytes && cap(f.decodeScratch) > 0 {
+		buf := f.decodeScratch
+		f.decodeScratch = nil
+		putDecodeScratch(buf)
+	}
+}
+
+func (f *File) decodeScratchRetainedLocked() (buffers int, bytes uint64) {
+	if cap(f.decodeScratch) > 0 {
+		buffers++
+		bytes += uint64(cap(f.decodeScratch))
+	}
+	for _, buf := range f.decodeScratchSpare {
+		if cap(buf) == 0 {
+			continue
+		}
+		buffers++
+		bytes += uint64(cap(buf))
+	}
+	return buffers, bytes
+}
+
+func (f *File) addDecodeScratchStats(stats *DecodeScratchStats) {
+	if f == nil || stats == nil {
+		return
+	}
+	f.scratchMu.Lock()
+	buffers, bytes := f.decodeScratchRetainedLocked()
+	f.scratchMu.Unlock()
+	if buffers == 0 {
+		return
+	}
+	stats.FileRetainedFiles++
+	stats.FileRetainedBuffers += uint64(buffers)
+	stats.FileRetainedBytes += bytes
 }
 
 func (f *File) takeDecodeScratch(minCap int) []byte {
@@ -2290,6 +2349,23 @@ func (m *Manager) GroupedFrameCacheDetailedStats() GroupedFrameCacheStats {
 	if m.groupedFrameCacheBudget != nil {
 		stats.RetainedBytes = m.groupedFrameCacheBudget.retainedBytes()
 		stats.BudgetBytes = m.groupedFrameCacheBudget.budgetBytes()
+	}
+	return stats
+}
+
+func (m *Manager) DecodeScratchStats() DecodeScratchStats {
+	stats := DecodeScratchStatsSnapshot()
+	if m == nil {
+		return stats
+	}
+	m.mu.RLock()
+	files := make([]*File, 0, len(m.files))
+	for _, f := range m.files {
+		files = append(files, f)
+	}
+	m.mu.RUnlock()
+	for _, f := range files {
+		f.addDecodeScratchStats(&stats)
 	}
 	return stats
 }

--- a/TreeDB/internal/valuelog/manager.go
+++ b/TreeDB/internal/valuelog/manager.go
@@ -242,6 +242,9 @@ func (f *File) stashDecodeScratchLocked(buf []byte) {
 	}
 	if cap(f.decodeScratch) == 0 {
 		f.decodeScratch = buf
+		if len(f.decodeScratchSpare) != 0 {
+			f.trimDecodeScratchLocked()
+		}
 		return
 	}
 	if cap(buf) > cap(f.decodeScratch) {

--- a/TreeDB/internal/valuelog/reader.go
+++ b/TreeDB/internal/valuelog/reader.go
@@ -984,8 +984,18 @@ func ReadAtWithDict(f *os.File, ptr page.ValuePtr, verifyCRC bool, dictLookup Di
 // The returned slice may alias dst when usedDst is true. The returned bytes are
 // immutable from the caller perspective.
 func ReadAtWithDictTo(f *os.File, ptr page.ValuePtr, verifyCRC bool, dictLookup DictLookup, templateLookup TemplateLookup, templateCache *templateDefCache, templateOpts templ.DecodeOptions, dst []byte) ([]byte, bool, error) {
+	return readAtWithDictToScratch(f, ptr, verifyCRC, dictLookup, templateLookup, templateCache, templateOpts, dst, getDecodeScratch, putDecodeScratch)
+}
+
+func readAtWithDictToScratch(f *os.File, ptr page.ValuePtr, verifyCRC bool, dictLookup DictLookup, templateLookup TemplateLookup, templateCache *templateDefCache, templateOpts templ.DecodeOptions, dst []byte, getScratch func(int) []byte, putScratch func([]byte)) ([]byte, bool, error) {
 	if f == nil {
 		return nil, false, errors.New("valuelog: nil file")
+	}
+	if getScratch == nil {
+		getScratch = getDecodeScratch
+	}
+	if putScratch == nil {
+		putScratch = putDecodeScratch
 	}
 	if ptr.Offset < 4 {
 		return nil, false, ErrCorrupt
@@ -1171,27 +1181,27 @@ func ReadAtWithDictTo(f *os.File, ptr page.ValuePtr, verifyCRC bool, dictLookup 
 		return payload, usedDst, nil
 	}
 
-	payloadScratch := getDecodeScratch(int(valueLen))
+	payloadScratch := getScratch(int(valueLen))
 	payload := payloadScratch[:int(valueLen)]
 	if _, err := f.ReadAt(payload, start+HeaderSize); err != nil {
-		putDecodeScratch(payloadScratch)
+		putScratch(payloadScratch)
 		return nil, false, err
 	}
 	if verifyCRC {
 		sum := crc.ChecksumParts(header[4:], payload)
 		if sum != crcVal {
-			putDecodeScratch(payloadScratch)
+			putScratch(payloadScratch)
 			return nil, false, ErrCorrupt
 		}
 	}
-	val, usedDst, err := decodeRecordTo(header, payload, ptr, false, dictLookup, templateLookup, templateCache, templateOpts, dst)
+	val, usedDst, err := decodeRecordToScratch(header, payload, ptr, false, dictLookup, templateLookup, templateCache, templateOpts, dst, getScratch, putScratch)
 	if err != nil {
-		putDecodeScratch(payloadScratch)
+		putScratch(payloadScratch)
 		return nil, false, err
 	}
 	val, compactUsedDst, compactDecoded, err := maybeDecodeLeafLogPayloadTo(ptr.FileID, f.Name(), val, dst)
 	if err != nil {
-		putDecodeScratch(payloadScratch)
+		putScratch(payloadScratch)
 		return nil, false, err
 	}
 	// Safe to return payload scratch to the pool whenever the returned slice
@@ -1201,7 +1211,7 @@ func ReadAtWithDictTo(f *os.File, ptr page.ValuePtr, verifyCRC bool, dictLookup 
 		finalUsedDst = compactUsedDst
 	}
 	if finalUsedDst || !sliceAliasesBytes(payload, val) {
-		putDecodeScratch(payloadScratch)
+		putScratch(payloadScratch)
 	}
 	return val, finalUsedDst, nil
 }
@@ -1313,8 +1323,18 @@ func decodeRecord(header []byte, payload []byte, ptr page.ValuePtr, verifyCRC bo
 }
 
 func decodeRecordTo(header *[HeaderSize]byte, payload []byte, ptr page.ValuePtr, verifyCRC bool, dictLookup DictLookup, templateLookup TemplateLookup, templateCache *templateDefCache, templateOpts templ.DecodeOptions, dst []byte) ([]byte, bool, error) {
+	return decodeRecordToScratch(header, payload, ptr, verifyCRC, dictLookup, templateLookup, templateCache, templateOpts, dst, getDecodeScratch, putDecodeScratch)
+}
+
+func decodeRecordToScratch(header *[HeaderSize]byte, payload []byte, ptr page.ValuePtr, verifyCRC bool, dictLookup DictLookup, templateLookup TemplateLookup, templateCache *templateDefCache, templateOpts templ.DecodeOptions, dst []byte, getScratch func(int) []byte, putScratch func([]byte)) ([]byte, bool, error) {
 	if header == nil {
 		return nil, false, ErrCorrupt
+	}
+	if getScratch == nil {
+		getScratch = getDecodeScratch
+	}
+	if putScratch == nil {
+		putScratch = putDecodeScratch
 	}
 	crcVal := binary.LittleEndian.Uint32(header[0:4])
 	version := header[4]
@@ -1404,19 +1424,19 @@ func decodeRecordTo(header *[HeaderSize]byte, payload []byte, ptr page.ValuePtr,
 				return val, true, nil
 			}
 
-			scratch := getDecodeScratch(int(rawLen))
+			scratch := getScratch(int(rawLen))
 			raw, err := decodeFramePayloadTo(frameHeader, framePayload, dictLookup, rawLen, scratch)
 			if err != nil {
-				putDecodeScratch(scratch)
+				putScratch(scratch)
 				return nil, false, err
 			}
 			if uint32(len(raw)) != rawLen {
-				putDecodeScratch(raw)
+				putScratch(raw)
 				return nil, false, ErrCorrupt
 			}
 			val := dst[:outLen]
 			copy(val, raw[start:end])
-			putDecodeScratch(raw)
+			putScratch(raw)
 			if templateLookup != nil && templ.IsEncodedPayload(val) {
 				decoded, err := templ.DecodePayloadAppend(nil, val, func(id uint64) (templ.TemplateDef, error) {
 					return resolveTemplateDef(id, templateLookup, templateCache)
@@ -1431,19 +1451,19 @@ func decodeRecordTo(header *[HeaderSize]byte, payload []byte, ptr page.ValuePtr,
 
 		// Fallback: keep existing behavior (decode into pooled scratch, then copy
 		// into a fresh allocation so we don't retain the full frame).
-		scratch := getDecodeScratch(int(rawLen))
+		scratch := getScratch(int(rawLen))
 		raw, err := decodeFramePayloadTo(frameHeader, framePayload, dictLookup, rawLen, scratch)
 		if err != nil {
-			putDecodeScratch(scratch)
+			putScratch(scratch)
 			return nil, false, err
 		}
 		if uint32(len(raw)) != rawLen {
-			putDecodeScratch(raw)
+			putScratch(raw)
 			return nil, false, ErrCorrupt
 		}
 		val := make([]byte, outLen)
 		copy(val, raw[start:end])
-		putDecodeScratch(raw)
+		putScratch(raw)
 		if templateLookup != nil && templ.IsEncodedPayload(val) {
 			decoded, err := templ.DecodePayloadAppend(nil, val, func(id uint64) (templ.TemplateDef, error) {
 				return resolveTemplateDef(id, templateLookup, templateCache)

--- a/TreeDB/internal/valuelog/reader.go
+++ b/TreeDB/internal/valuelog/reader.go
@@ -148,10 +148,11 @@ func putDecodeScratch(buf []byte) {
 	buf = buf[:0]
 	if c <= maxDecodeScratchKeep {
 		decodeScratchSmallPoolPutsTotal.Add(1)
+		noteDecodeScratchSmallPoolPut(c)
 		select {
 		case smallDecodeScratchPool <- buf:
-			noteDecodeScratchSmallPoolPut(c)
 		default:
+			noteDecodeScratchSmallPoolTake(c)
 			decodeScratchSmallPoolDropsTotal.Add(1)
 			decodeScratchSmallPoolDroppedBytesTotal.Add(uint64(c))
 		}
@@ -159,10 +160,11 @@ func putDecodeScratch(buf []byte) {
 	}
 	if c <= maxLargeDecodeScratchKeep {
 		decodeScratchLargePoolPutsTotal.Add(1)
+		noteDecodeScratchLargePoolPut(c)
 		select {
 		case largeDecodeScratchPool <- buf:
-			noteDecodeScratchLargePoolPut(c)
 		default:
+			noteDecodeScratchLargePoolTake(c)
 			decodeScratchLargePoolDropsTotal.Add(1)
 			decodeScratchLargePoolDroppedBytesTotal.Add(uint64(c))
 		}

--- a/TreeDB/internal/valuelog/reader.go
+++ b/TreeDB/internal/valuelog/reader.go
@@ -17,27 +17,21 @@ import (
 )
 
 const (
-	maxDecodeScratchKeep      = 256 << 10 // 256KiB (small scratch, sync.Pool + per-file stash)
+	maxDecodeScratchKeep      = 256 << 10 // 256KiB (small scratch, bounded pool + per-file stash)
 	maxLargeDecodeScratchKeep = 4 << 20   // 4MiB (bounded pool to cap RSS overhead)
 	decodeScratchDefaultCap   = 8 << 10   // 8KiB default small scratch cap
 )
 
-const largeDecodeScratchPoolEntries = 8
+const (
+	smallDecodeScratchPoolEntries = 128
+	largeDecodeScratchPoolEntries = 8
+)
 
 const discardScratchSize = 32 << 10 // 32KiB
 
-type decodeScratchHolder struct {
-	buf []byte
-}
-
-// decodeScratchValuePool stores holders with populated small scratch buffers.
-// Holders are pointer-typed to avoid interface boxing allocations on Put/Get.
-var decodeScratchValuePool sync.Pool
-
-// decodeScratchHolderPool stores empty holders used by decodeScratchValuePool.
-var decodeScratchHolderPool = sync.Pool{
-	New: func() any { return &decodeScratchHolder{} },
-}
+// smallDecodeScratchPool is bounded because Celestia opens many value-log
+// segments; an unbounded sync.Pool can retain large final-heap plateaus.
+var smallDecodeScratchPool = make(chan []byte, smallDecodeScratchPoolEntries)
 
 // largeDecodeScratchPool is a bounded pool for larger decode scratch buffers.
 // We avoid sync.Pool here to keep a hard cap on retained multi-MiB slices.
@@ -91,31 +85,53 @@ func getDecodeScratch(minCap int) []byte {
 		// Bounded large-slice pool to reduce alloc churn on large grouped frames.
 		// If empty, fall back to allocating; we intentionally don't block.
 		if minCap <= maxLargeDecodeScratchKeep {
+			decodeScratchLargePoolGetsTotal.Add(1)
 			select {
 			case buf := <-largeDecodeScratchPool:
+				noteDecodeScratchLargePoolTake(cap(buf))
 				if cap(buf) < minCap {
+					decodeScratchLargePoolTooSmallTotal.Add(1)
+					decodeScratchLargePoolMissesTotal.Add(1)
+					decodeScratchLargeAllocCallsTotal.Add(1)
+					decodeScratchLargeAllocatedBytesTotal.Add(uint64(minCap))
 					buf = make([]byte, 0, minCap)
+				} else {
+					decodeScratchLargePoolHitsTotal.Add(1)
 				}
 				return buf[:0]
 			default:
+				decodeScratchLargePoolMissesTotal.Add(1)
+				decodeScratchLargeAllocCallsTotal.Add(1)
+				decodeScratchLargeAllocatedBytesTotal.Add(uint64(minCap))
 				return make([]byte, 0, minCap)
 			}
 		}
+		decodeScratchOversizeAllocCallsTotal.Add(1)
+		decodeScratchOversizeAllocatedBytesTotal.Add(uint64(minCap))
 		return make([]byte, 0, minCap)
 	}
 	var buf []byte
-	if v := decodeScratchValuePool.Get(); v != nil {
-		if h, ok := v.(*decodeScratchHolder); ok && h != nil {
-			buf = h.buf
-			h.buf = nil
-			decodeScratchHolderPool.Put(h)
+	decodeScratchSmallPoolGetsTotal.Add(1)
+	select {
+	case buf = <-smallDecodeScratchPool:
+		noteDecodeScratchSmallPoolTake(cap(buf))
+		if cap(buf) < minCap {
+			decodeScratchSmallPoolTooSmallTotal.Add(1)
+			decodeScratchSmallPoolMissesTotal.Add(1)
+			buf = nil
+		} else {
+			decodeScratchSmallPoolHitsTotal.Add(1)
 		}
+	default:
+		decodeScratchSmallPoolMissesTotal.Add(1)
 	}
 	if cap(buf) < minCap {
 		capHint := minCap
 		if capHint < decodeScratchDefaultCap {
 			capHint = decodeScratchDefaultCap
 		}
+		decodeScratchSmallAllocCallsTotal.Add(1)
+		decodeScratchSmallAllocatedBytesTotal.Add(uint64(capHint))
 		buf = make([]byte, 0, capHint)
 	}
 	return buf[:0]
@@ -131,21 +147,29 @@ func putDecodeScratch(buf []byte) {
 	}
 	buf = buf[:0]
 	if c <= maxDecodeScratchKeep {
-		h, _ := decodeScratchHolderPool.Get().(*decodeScratchHolder)
-		if h == nil {
-			h = &decodeScratchHolder{}
+		decodeScratchSmallPoolPutsTotal.Add(1)
+		select {
+		case smallDecodeScratchPool <- buf:
+			noteDecodeScratchSmallPoolPut(c)
+		default:
+			decodeScratchSmallPoolDropsTotal.Add(1)
+			decodeScratchSmallPoolDroppedBytesTotal.Add(uint64(c))
 		}
-		h.buf = buf
-		decodeScratchValuePool.Put(h)
 		return
 	}
 	if c <= maxLargeDecodeScratchKeep {
+		decodeScratchLargePoolPutsTotal.Add(1)
 		select {
 		case largeDecodeScratchPool <- buf:
+			noteDecodeScratchLargePoolPut(c)
 		default:
+			decodeScratchLargePoolDropsTotal.Add(1)
+			decodeScratchLargePoolDroppedBytesTotal.Add(uint64(c))
 		}
 		return
 	}
+	decodeScratchOversizeDropsTotal.Add(1)
+	decodeScratchOversizeDroppedBytesTotal.Add(uint64(c))
 }
 
 func sliceDataPtr(b []byte) (uintptr, bool) {


### PR DESCRIPTION
## Linked Issues

Part of #3157
Parent tracker: #3131

## Summary

This PR bounds TreeDB value-log decode scratch retention and makes the retained buffers visible in stats:

- Replaces the small decode scratch `sync.Pool` with a bounded non-blocking pool.
- Keeps the existing large scratch bounded pool and adds matching counters.
- Caps each open value-log file's local decode scratch stash to `128 KiB` total while preserving the largest useful local buffer.
- Exposes decode scratch retained bytes, retained buffers, hits/misses, drops, and allocation counters in backend and caching stats.
- Adds tests for the global small-pool hard cap, per-file retained-byte cap, stats export, and expvar filtering.

## Root-Cause Classification

| Candidate | Finding | Action in this PR |
| --- | --- | --- |
| Scratch retention policy keeps oversized buffers | Confirmed for the `getDecodeScratch` side: small scratch used an unbounded `sync.Pool`, and per-file stashes could accumulate across many open value-log files. | Bound small global pool to 128 entries, keep large pool bounded at 8 entries, and cap per-file retained scratch at 128 KiB. |
| Missing append-to-caller-buffer path / `growRealloc` | Not fully solved here. Current counters suggest much of `growRealloc` is append-buffer growth, with incomplete per-site attribution. | Preserve existing grow stats and add decode-scratch stats so the next Celestia run can distinguish retained scratch from grow-buffer churn. |
| Instrumentation gap | Confirmed: grouped-frame cache had retained-byte stats, but decode scratch did not. | Add `treedb.cache.vlog_decode_scratch.*` and `treedb.vlog.decode_scratch.*`. |

## Quantitative Bound

- Small global decode scratch pool: at most `128 * 256 KiB = 32 MiB` retained.
- Large global decode scratch pool: at most `8 * 4 MiB = 32 MiB` retained.
- Per open value-log file scratch stash: at most `128 KiB` retained.

These are hard caps enforced by tests; this PR does not yet claim the #3157 Celestia north-star heap targets are met.

## Validation

- `git diff --check`
- `GOWORK=off go test ./TreeDB/internal/valuelog -run 'TestDecodeScratchPool|TestFileDecodeScratch|TestGrowBufferStatsSnapshotTracksReadAppendSites|TestFileReadAppend_CompressedFallbackNilDstAvoidsExtraGrow'`
- `GOWORK=off go test ./TreeDB/caching -run 'TestStats_ExportsVlogShapeKeys|TestSelectTreeDBExpvarStatsFiltersAndCoerces'`
- `GOWORK=off go test ./TreeDB/db -run TestNonExistent`
- `GOWORK=off go test ./TreeDB/internal/valuelog ./TreeDB/caching ./TreeDB/db`

## Celestia Evidence

Not run in this PR yet. The next validation step is a same-boundary `~/run_celestia.sh` run to compare final heap top, max RSS/HWM, debug-vars decode counters, disk/GC counters, and log sweep against the post-#3155 baseline in #3157.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added broader cache and value-log statistics, including decode-scratch retention metrics.
  * Exposed additional storage-memory usage details for small, large, and oversize scratch buffers.

* **Bug Fixes**
  * Improved scratch-buffer reuse limits to keep retained memory bounded.
  * Oversized scratch buffers are now dropped instead of being kept around.
  * Updated exported stats so cache reporting includes the new decode-scratch fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->