### PR TITLE
Pre-size dense q2 rank maps

### DIFF
--- a/TreeDB/collections/column_physical_typed_column_query.go
+++ b/TreeDB/collections/column_physical_typed_column_query.go
@@ -879,7 +879,11 @@ func prepareColumnTypedColumnDenseGroupCountDistinctGlobal(parts []columnTypedCo
 }
 
 func columnTypedColumnDenseGroupCountDistinctGlobalDictionary(parts []columnTypedColumnPhysicalQueryPart, selectColumn func(*columnTypedColumnDenseGroupCountDistinctPart) *columnTypedColumnDenseStringCodeColumn) ([]string, map[string]uint32, error) {
-	values := make(map[string]struct{})
+	capacity, err := columnTypedColumnDenseGroupCountDistinctDictionaryCapacity(parts, selectColumn)
+	if err != nil {
+		return nil, nil, err
+	}
+	values := make(map[string]struct{}, capacity)
 	for partIdx := range parts {
 		part := parts[partIdx].DenseGroupCountDistinct
 		if part == nil {
@@ -912,7 +916,11 @@ func columnTypedColumnDenseGroupCountDistinctGlobalDictionary(parts []columnType
 }
 
 func columnTypedColumnDenseGroupCountDistinctGlobalRanks(parts []columnTypedColumnPhysicalQueryPart, selectColumn func(*columnTypedColumnDenseGroupCountDistinctPart) *columnTypedColumnDenseStringCodeColumn) (map[string]uint32, int, error) {
-	ranks := make(map[string]uint32)
+	capacity, err := columnTypedColumnDenseGroupCountDistinctDictionaryCapacity(parts, selectColumn)
+	if err != nil {
+		return nil, 0, err
+	}
+	ranks := make(map[string]uint32, capacity)
 	addValue := func(value string) error {
 		if _, ok := ranks[value]; ok {
 			return nil
@@ -944,6 +952,26 @@ func columnTypedColumnDenseGroupCountDistinctGlobalRanks(parts []columnTypedColu
 		}
 	}
 	return ranks, len(ranks), nil
+}
+
+func columnTypedColumnDenseGroupCountDistinctDictionaryCapacity(parts []columnTypedColumnPhysicalQueryPart, selectColumn func(*columnTypedColumnDenseGroupCountDistinctPart) *columnTypedColumnDenseStringCodeColumn) (int, error) {
+	capacity := 1 // reserve one optional empty-string slot for nullable values.
+	maxInt := int(^uint(0) >> 1)
+	for partIdx := range parts {
+		part := parts[partIdx].DenseGroupCountDistinct
+		if part == nil {
+			return 0, fmt.Errorf("collections: dense grouped count-distinct missing prepared part %d", partIdx)
+		}
+		column := selectColumn(part)
+		if column == nil {
+			return 0, fmt.Errorf("collections: dense grouped count-distinct missing selected column for part %d", partIdx)
+		}
+		if len(column.Dictionary) > maxInt-capacity {
+			return 0, fmt.Errorf("collections: dense grouped count-distinct dictionary capacity exceeds int")
+		}
+		capacity += len(column.Dictionary)
+	}
+	return capacity, nil
 }
 
 func prepareColumnTypedColumnDenseGroupCountDistinctGlobalColumnCodes(column *columnTypedColumnDenseStringCodeColumn, globalDictionary []string, cardinality int, ranks map[string]uint32) error {


### PR DESCRIPTION
## Scope

Refs #3158.

This is a narrow q2 `one_shot_end_to_end` / `first_touch_after_open` setup slice for the `no_aggregate_metadata` typed-column lane. It pre-sizes the dense grouped count-distinct global dictionary/rank maps from the sum of per-part local dictionary sizes, avoiding repeated map growth while preserving the existing bitset reducer and full-rank semantics.

This PR does **not** claim broad SQL superiority. It does not change insert/load behavior, metadata storage, aggregate metadata, q1/q3/q4/q4a/q4b/q5, qexpr, or explicit hot-prepared execution semantics.

## Evidence

Environment:
- JSONBench `8477b48`
- gomap branch `codex/3158-q2-rankcap` at `14167b968`
- `ROWS=1000000 TRIES=1 STORAGE_LAYOUTS=column-store-full-prepared QUERY_CELLS=q2 SUITE=full METADATA_MODE=no_aggregate_metadata`

`one_shot_end_to_end` q2:
- artifact: `/tmp/jsonbench_q2_oneshot_rankcap_only_3158_20260627_012713/report.md`
- total: `188.653333ms`
- prepare/setup: `177.323083ms`
- run: `11.305918ms`
- rows scanned/matched/reduced: `1,000,000 / 954,611 / 954,611`
- load wall time in same cell: `18.373s`
- storage: `131.12 MiB`

`first_touch_after_open` q2:
- artifact: `/tmp/jsonbench_q2_firsttouch_rankcap_only_3158_20260627_012754/report.md`
- total: `187.870083ms`
- prepare/setup: `176.555083ms`
- run: `11.291542ms`
- rows scanned/matched/reduced: `1,000,000 / 954,611 / 954,611`
- load wall time in same cell: `17.693s`
- storage: `131.12 MiB`

Context from the prior #3162 q2 evidence in #3158:
- one-shot: `205.795ms` total / `194.602ms` setup / `11.173ms` run
- first-touch: `188.094ms` total / `174.577ms` setup / `13.497ms` run

## Validation

- `go test ./TreeDB/collections -run 'TestColumnPhysicalTypedColumnOneShotCacheQ2NoMetadata3123|TestTypedColumnQ2DenseGroupCountDistinctNoSortLocalDictionaries1950|TestTypedColumnQ2DenseGroupCountDistinctLocalCodesNullableValues3080|TestTypedColumnQ2DenseGroupCountDistinctActiveGroupBitset1950' -count=1`
- `go test ./TreeDB/collections -count=1`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved count-distinct processing by preallocating internal lookup structures more efficiently.
  * Reduced unnecessary resizing during large data operations, which may speed up queries and lower memory churn.
  * Added safer handling for very large inputs to avoid capacity-related failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->