### PR TITLE
Parallelize dense q2 one-shot part decode

### DIFF
--- a/TreeDB/collections/column_physical_typed_column_query.go
+++ b/TreeDB/collections/column_physical_typed_column_query.go
@@ -6,8 +6,10 @@ import (
 	"fmt"
 	"io"
 	"math/bits"
+	"runtime"
 	"slices"
 	"sort"
+	"sync"
 	"time"
 )
 
@@ -186,6 +188,16 @@ type columnTypedColumnPhysicalQueryRunner struct {
 	resultGroups                          []ColumnPhysicalQueryGroup
 }
 
+type columnTypedColumnPhysicalQueryPartDecodeInput struct {
+	outputIdx int
+	typedRef  columnManifestAssetRefForScan
+	physical  columnManifestAssetRefForScan
+}
+
+type columnTypedColumnPhysicalQueryPartDecodeOutput struct {
+	part columnTypedColumnPhysicalQueryPart
+}
+
 type columnTypedColumnPhysicalAggregateSummary struct {
 	groups              []ColumnPhysicalQueryGroup
 	matchedRows         int
@@ -218,6 +230,25 @@ func (r *columnTypedColumnPhysicalQueryRunner) close() {
 	r.timeOrderHeap.items = nil
 	r.timeOrderTopKScratch = nil
 	r.resultGroups = nil
+}
+
+func (r *columnTypedColumnPhysicalQueryRunner) addDecodedPart(part columnTypedColumnPhysicalQueryPart) {
+	if r == nil {
+		return
+	}
+	r.assetBytes += part.Bytes
+	r.sections += part.Sections
+	r.sectionBytes += part.SectionBytes
+	r.granulesConsidered += part.GranulesConsidered
+	r.granulesDecoded += part.GranulesDecoded
+	r.granulesSkipped += part.GranulesSkipped
+	r.decodedBlocks += part.DecodedBlocks
+	r.decodedPayloadBytes += part.DecodedPayloadBytes
+	r.sortKeyMarkChecks += part.SortKeyMarkChecks
+	r.sortKeyMarkMatches += part.SortKeyMarkMatches
+	r.sortKeyMarkSkips += part.SortKeyMarkSkips
+	r.sortKeyMarkFallbackReason = mergeColumnPhysicalSortKeyFallbackReason(r.sortKeyMarkFallbackReason, part.SortKeyMarkFallbackReason)
+	r.parts = append(r.parts, part)
 }
 
 func (c *Collection) runColumnPhysicalQueryTypedColumnPartInSnapshotView(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest) (ColumnPhysicalQueryResult, bool, error) {
@@ -496,8 +527,8 @@ func decodeColumnTypedColumnPhysicalQueryRunnerParts(view columnPhysicalScanSnap
 	readCache.returnViews = false
 	defer func() { readCache.returnViews = savedReturnViews }()
 
-	var rawScratch []byte
 	allowDenseGroupCountDistinct := view.MutationParts == 0
+	inputs := make([]columnTypedColumnPhysicalQueryPartDecodeInput, 0, len(view.AssetRefs))
 	for _, physical := range view.AssetRefs {
 		if physical.Role == ColumnManifestPartRoleTombstone || physical.Reason == ColumnPublishOperationDelete {
 			continue
@@ -506,57 +537,34 @@ func decodeColumnTypedColumnPhysicalQueryRunnerParts(view columnPhysicalScanSnap
 		if !ok {
 			return nil, fmt.Errorf("collections: missing typed_column_part asset for generation=%d", physical.Ref.Generation)
 		}
-		var part columnTypedColumnPhysicalQueryPart
-		part, rangeOK, err := decodeTypedColumnPhysicalQueryDensePartFromRanges(plan, req, view.FullConfig.SchemaHash, typedRef, physical, readCache, allowDenseGroupCountDistinct, includePhysicalRows)
-		runner.segmentFileCacheHits = readCache.hits
-		runner.segmentFileCacheMisses = readCache.misses
+		inputs = append(inputs, columnTypedColumnPhysicalQueryPartDecodeInput{
+			outputIdx: len(inputs),
+			typedRef:  typedRef,
+			physical:  physical,
+		})
+	}
+	if columnTypedColumnPhysicalQueryUseParallelPartDecode(plan, req, readCache, len(inputs), includePhysicalRows, allowDenseGroupCountDistinct, prepareDenseInt64SpanGlobalCodes, prepareDenseGroupCountDistinctGlobalCodes, prepareDenseGroupCountDistinctGlobalRanks) {
+		outputs, hits, misses, err := decodeColumnTypedColumnPhysicalQueryRunnerPartsParallel(view, req, plan, inputs, readCache, includePhysicalRows, allowDenseGroupCountDistinct)
 		if err != nil {
-			return nil, fmt.Errorf("collections: typed-column part physical query range decode generation=%d part_id=%d: %w", typedRef.Ref.Generation, typedRef.Ref.PartID, err)
+			return nil, err
 		}
-		if !rangeOK {
-			raw, err := readCache.read(typedRef.Ref, rawScratch)
+		runner.segmentFileCacheHits = hits
+		runner.segmentFileCacheMisses = misses
+		for _, output := range outputs {
+			runner.addDecodedPart(output.part)
+		}
+	} else {
+		var rawScratch []byte
+		for _, input := range inputs {
+			part, scratch, err := decodeColumnTypedColumnPhysicalQueryRunnerPart(view, req, plan, input.typedRef, input.physical, readCache, includePhysicalRows, allowDenseGroupCountDistinct, rawScratch)
 			runner.segmentFileCacheHits = readCache.hits
 			runner.segmentFileCacheMisses = readCache.misses
 			if err != nil {
-				if errors.Is(err, io.ErrUnexpectedEOF) {
-					return nil, fmt.Errorf("collections: typed-column part physical query read generation=%d part_id=%d short read: %w", typedRef.Ref.Generation, typedRef.Ref.PartID, err)
-				}
-				return nil, fmt.Errorf("collections: typed-column part physical query read generation=%d part_id=%d: %w", typedRef.Ref.Generation, typedRef.Ref.PartID, err)
+				return nil, err
 			}
-			rawScratch = raw
-			switch {
-			case columnTypedColumnPhysicalQueryUseDenseGroupCount(plan, req):
-				part, err = decodeTypedColumnPhysicalQueryDenseGroupCountPart(plan, view.FullConfig.SchemaHash, typedRef, physical, raw)
-			case columnTypedColumnPhysicalQueryUseDenseGroupHourCount(plan, req):
-				part, err = decodeTypedColumnPhysicalQueryDenseGroupHourCountPart(plan, view.FullConfig.SchemaHash, typedRef, physical, raw)
-			case columnTypedColumnPhysicalQueryUseDenseInt64Span(plan, req):
-				part, err = decodeTypedColumnPhysicalQueryDenseInt64SpanPart(plan, view.FullConfig.SchemaHash, typedRef, physical, raw)
-			case columnTypedColumnPhysicalQueryUseTimeOrderTopK(plan, req):
-				part, err = decodeTypedColumnPhysicalQueryTimeOrderTopKPart(plan, view.FullConfig.SchemaHash, typedRef, physical, raw, includePhysicalRows)
-			case columnTypedColumnPhysicalQueryUseSortedGroupedDistinct(plan, req):
-				part, err = decodeTypedColumnPhysicalQuerySortedGroupedDistinctPart(plan, view.FullConfig.SchemaHash, typedRef, physical, raw, includePhysicalRows)
-			case allowDenseGroupCountDistinct && columnTypedColumnPhysicalQueryUseDenseGroupCountDistinct(plan, req):
-				part, err = decodeTypedColumnPhysicalQueryDenseGroupCountDistinctPart(plan, view.FullConfig.SchemaHash, typedRef, physical, raw)
-			default:
-				part, err = decodeTypedColumnPhysicalQueryPart(plan, view.FullConfig.SchemaHash, typedRef, physical, raw, includePhysicalRows)
-			}
+			rawScratch = scratch
+			runner.addDecodedPart(part)
 		}
-		if err != nil {
-			return nil, fmt.Errorf("collections: typed-column part physical query decode generation=%d part_id=%d: %w", typedRef.Ref.Generation, typedRef.Ref.PartID, err)
-		}
-		runner.assetBytes += part.Bytes
-		runner.sections += part.Sections
-		runner.sectionBytes += part.SectionBytes
-		runner.granulesConsidered += part.GranulesConsidered
-		runner.granulesDecoded += part.GranulesDecoded
-		runner.granulesSkipped += part.GranulesSkipped
-		runner.decodedBlocks += part.DecodedBlocks
-		runner.decodedPayloadBytes += part.DecodedPayloadBytes
-		runner.sortKeyMarkChecks += part.SortKeyMarkChecks
-		runner.sortKeyMarkMatches += part.SortKeyMarkMatches
-		runner.sortKeyMarkSkips += part.SortKeyMarkSkips
-		runner.sortKeyMarkFallbackReason = mergeColumnPhysicalSortKeyFallbackReason(runner.sortKeyMarkFallbackReason, part.SortKeyMarkFallbackReason)
-		runner.parts = append(runner.parts, part)
 	}
 	if len(runner.parts) == 0 && len(view.AssetRefs) != 0 {
 		return nil, errors.New("collections: typed-column part physical query has no live typed_column_part assets")
@@ -579,6 +587,141 @@ func decodeColumnTypedColumnPhysicalQueryRunnerParts(view columnPhysicalScanSnap
 		}
 	}
 	return runner, nil
+}
+
+func decodeColumnTypedColumnPhysicalQueryRunnerPart(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest, plan columnTypedColumnPhysicalQueryPlan, typedRef, physical columnManifestAssetRefForScan, readCache *columnPhysicalAssetReadCache, includePhysicalRows bool, allowDenseGroupCountDistinct bool, rawScratch []byte) (columnTypedColumnPhysicalQueryPart, []byte, error) {
+	part, rangeOK, err := decodeTypedColumnPhysicalQueryDensePartFromRanges(plan, req, view.FullConfig.SchemaHash, typedRef, physical, readCache, allowDenseGroupCountDistinct, includePhysicalRows)
+	if err != nil {
+		return columnTypedColumnPhysicalQueryPart{}, rawScratch, fmt.Errorf("collections: typed-column part physical query range decode generation=%d part_id=%d: %w", typedRef.Ref.Generation, typedRef.Ref.PartID, err)
+	}
+	if rangeOK {
+		return part, rawScratch, nil
+	}
+	raw, err := readCache.read(typedRef.Ref, rawScratch)
+	if err != nil {
+		if errors.Is(err, io.ErrUnexpectedEOF) {
+			return columnTypedColumnPhysicalQueryPart{}, rawScratch, fmt.Errorf("collections: typed-column part physical query read generation=%d part_id=%d short read: %w", typedRef.Ref.Generation, typedRef.Ref.PartID, err)
+		}
+		return columnTypedColumnPhysicalQueryPart{}, rawScratch, fmt.Errorf("collections: typed-column part physical query read generation=%d part_id=%d: %w", typedRef.Ref.Generation, typedRef.Ref.PartID, err)
+	}
+	rawScratch = raw
+	switch {
+	case columnTypedColumnPhysicalQueryUseDenseGroupCount(plan, req):
+		part, err = decodeTypedColumnPhysicalQueryDenseGroupCountPart(plan, view.FullConfig.SchemaHash, typedRef, physical, raw)
+	case columnTypedColumnPhysicalQueryUseDenseGroupHourCount(plan, req):
+		part, err = decodeTypedColumnPhysicalQueryDenseGroupHourCountPart(plan, view.FullConfig.SchemaHash, typedRef, physical, raw)
+	case columnTypedColumnPhysicalQueryUseDenseInt64Span(plan, req):
+		part, err = decodeTypedColumnPhysicalQueryDenseInt64SpanPart(plan, view.FullConfig.SchemaHash, typedRef, physical, raw)
+	case columnTypedColumnPhysicalQueryUseTimeOrderTopK(plan, req):
+		part, err = decodeTypedColumnPhysicalQueryTimeOrderTopKPart(plan, view.FullConfig.SchemaHash, typedRef, physical, raw, includePhysicalRows)
+	case columnTypedColumnPhysicalQueryUseSortedGroupedDistinct(plan, req):
+		part, err = decodeTypedColumnPhysicalQuerySortedGroupedDistinctPart(plan, view.FullConfig.SchemaHash, typedRef, physical, raw, includePhysicalRows)
+	case allowDenseGroupCountDistinct && columnTypedColumnPhysicalQueryUseDenseGroupCountDistinct(plan, req):
+		part, err = decodeTypedColumnPhysicalQueryDenseGroupCountDistinctPart(plan, view.FullConfig.SchemaHash, typedRef, physical, raw)
+	default:
+		part, err = decodeTypedColumnPhysicalQueryPart(plan, view.FullConfig.SchemaHash, typedRef, physical, raw, includePhysicalRows)
+	}
+	if err != nil {
+		return columnTypedColumnPhysicalQueryPart{}, rawScratch, fmt.Errorf("collections: typed-column part physical query decode generation=%d part_id=%d: %w", typedRef.Ref.Generation, typedRef.Ref.PartID, err)
+	}
+	return part, rawScratch, nil
+}
+
+func columnTypedColumnPhysicalQueryUseParallelPartDecode(plan columnTypedColumnPhysicalQueryPlan, req ColumnPhysicalQueryRequest, readCache *columnPhysicalAssetReadCache, partCount int, includePhysicalRows bool, allowDenseGroupCountDistinct bool, prepareDenseInt64SpanGlobalCodes bool, prepareDenseGroupCountDistinctGlobalCodes bool, prepareDenseGroupCountDistinctGlobalRanks bool) bool {
+	if partCount < 2 || readCache == nil || readCache.resourceManager != nil {
+		return false
+	}
+	if includePhysicalRows || prepareDenseInt64SpanGlobalCodes || prepareDenseGroupCountDistinctGlobalCodes || !prepareDenseGroupCountDistinctGlobalRanks {
+		return false
+	}
+	if !allowDenseGroupCountDistinct || !columnTypedColumnPhysicalQueryUseDenseGroupCountDistinct(plan, req) {
+		return false
+	}
+	if !typedColumnStringUseTargetedRanges(req.ColumnAssetReadIntegrity) {
+		return false
+	}
+	return columnTypedColumnPhysicalQueryPartDecodeWorkers(partCount) > 1
+}
+
+func columnTypedColumnPhysicalQueryPartDecodeWorkers(partCount int) int {
+	if partCount < 2 {
+		return 0
+	}
+	workers := min(runtime.GOMAXPROCS(0), partCount)
+	workers = min(workers, typedColumnDenseParallelMaxWorkers)
+	if workers < 2 {
+		return 0
+	}
+	return workers
+}
+
+func decodeColumnTypedColumnPhysicalQueryRunnerPartsParallel(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest, plan columnTypedColumnPhysicalQueryPlan, inputs []columnTypedColumnPhysicalQueryPartDecodeInput, readCache *columnPhysicalAssetReadCache, includePhysicalRows bool, allowDenseGroupCountDistinct bool) ([]columnTypedColumnPhysicalQueryPartDecodeOutput, uint64, uint64, error) {
+	workers := columnTypedColumnPhysicalQueryPartDecodeWorkers(len(inputs))
+	if workers < 2 {
+		return nil, 0, 0, errors.New("collections: typed-column part physical query parallel decode missing workers")
+	}
+	workerCaches := make([]columnPhysicalAssetReadCache, workers)
+	for workerIdx := range workerCaches {
+		workerCache, err := newColumnPhysicalAssetReadCacheWithIntegrity(readCache.rootDir, readCache.namespace, readCache.readIntegrity)
+		if err != nil {
+			return nil, 0, 0, err
+		}
+		workerCache.returnViews = false
+		workerCache.forceReadAtFallback = readCache.forceReadAtFallback
+		workerCache.trustCachedVerifyFileIdentity = readCache.trustCachedVerifyFileIdentity
+		workerCaches[workerIdx] = workerCache
+	}
+
+	outputs := make([]columnTypedColumnPhysicalQueryPartDecodeOutput, len(inputs))
+	jobs := make(chan columnTypedColumnPhysicalQueryPartDecodeInput)
+	var wg sync.WaitGroup
+	var firstErr error
+	var errOnce sync.Once
+	setErr := func(err error) {
+		if err == nil {
+			return
+		}
+		errOnce.Do(func() {
+			firstErr = err
+		})
+	}
+	for workerIdx := range workerCaches {
+		wg.Add(1)
+		go func(workerIdx int) {
+			defer wg.Done()
+			cache := &workerCaches[workerIdx]
+			defer func() {
+				setErr(cache.close())
+			}()
+			var rawScratch []byte
+			for input := range jobs {
+				part, scratch, err := decodeColumnTypedColumnPhysicalQueryRunnerPart(view, req, plan, input.typedRef, input.physical, cache, includePhysicalRows, allowDenseGroupCountDistinct, rawScratch)
+				if err != nil {
+					setErr(err)
+					continue
+				}
+				rawScratch = scratch
+				outputs[input.outputIdx] = columnTypedColumnPhysicalQueryPartDecodeOutput{
+					part: part,
+				}
+			}
+		}(workerIdx)
+	}
+	for _, input := range inputs {
+		jobs <- input
+	}
+	close(jobs)
+	wg.Wait()
+	if firstErr != nil {
+		return nil, 0, 0, firstErr
+	}
+	var hits uint64
+	var misses uint64
+	for _, cache := range workerCaches {
+		hits += cache.hits
+		misses += cache.misses
+	}
+	return outputs, hits, misses, nil
 }
 
 func prepareColumnTypedColumnPhysicalAggregateSummary(runner *columnTypedColumnPhysicalQueryRunner, req ColumnPhysicalQueryRequest) error {


### PR DESCRIPTION
## Summary

This is a scoped #3158 setup-cost slice for the production-shaped q2 no-aggregate typed-column lane.

It parallelizes typed-column part decode only for the dense group-count-distinct one-shot rank-map path:

- applies to normal `one_shot_end_to_end` / `first_touch_after_open` q2-style execution that prepares dense group-count-distinct rank maps
- keeps hot prepared/global-code paths on the existing serial path
- keeps resource-manager-backed read caches on the existing serial path
- uses one asset read cache per worker, then merges decoded parts back in manifest order before global rank-map preparation

## Scope classification

- Insert/load: no change
- One-shot query execution: improves q2 setup cost in the no-aggregate typed-column lane
- First-touch after open: improves q2 setup cost, but does not yet meet the #3158 target
- Hot prepared execution: no intended change
- Aggregate metadata/storage: no change
- General scan semantics: no row/document materialization added; same typed-column cells and byte counters

This PR does not claim broad SQL superiority over ClickHouse. It is one setup-cost slice for q2 no-aggregate one-shot/first-touch execution.

## Evidence

Candidate worktree: `/private/tmp/gomap_3158_q2_setup_next_20260627` at `b668226e9`.

Baseline from `origin/main` after #3166:

- artifact: `/tmp/jsonbench_q2_oneshot_baseline_compare_3158_20260627_122650/1m_column-store-full-prepared_one_shot_end_to_end_no_aggregate_metadata_json_full_all/result.json`
- q2 `one_shot_end_to_end` total/setup/run: `211.617ms / 200.006ms / 11.586ms`
- rows scanned/matched/reduced: `1,000,000 / 954,611 / 954,611`
- physical bytes / decoded payload / sections / section bytes: `15,991,989 / 32,925,252 / 882 / 21,560,570`
- segment cache hits/misses: `814 / 1`

Candidate `one_shot_end_to_end`:

- command:
  `env OUT_DIR=/tmp/jsonbench_q2_oneshot_parallel_3158_20260627_021921 ROWS=1000000 TRIES=1 QUERY_MODE=one_shot_end_to_end METADATA_MODE=no_aggregate_metadata STORAGE_LAYOUTS=column-store-full-prepared QUERY_CELLS=q2 SUITE=full TREEDB_ALLOW_ERRORS=1 GOMAP_REPLACE=/private/tmp/gomap_3158_q2_setup_next_20260627 ./run_columnstore_benchmark.sh`
- artifact: `/tmp/jsonbench_q2_oneshot_parallel_3158_20260627_021921/1m_column-store-full-prepared_one_shot_end_to_end_no_aggregate_metadata_json_full_all/result.json`
- q2 total/setup/run: `107.836ms / 96.322ms / 11.486ms`
- rows scanned/matched/reduced: `1,000,000 / 954,611 / 954,611`
- physical bytes / decoded payload / sections / section bytes: `15,991,989 / 32,925,252 / 882 / 21,560,570`
- segment cache hits/misses: `807 / 8` because worker read caches open the shared segment independently

Candidate `first_touch_after_open`:

- command:
  `env OUT_DIR=/tmp/jsonbench_q2_firsttouch_parallel_3158_20260627_022007 ROWS=1000000 TRIES=1 QUERY_MODE=first_touch_after_open METADATA_MODE=no_aggregate_metadata STORAGE_LAYOUTS=column-store-full-prepared QUERY_CELLS=q2 SUITE=full TREEDB_ALLOW_ERRORS=1 GOMAP_REPLACE=/private/tmp/gomap_3158_q2_setup_next_20260627 ./run_columnstore_benchmark.sh`
- artifact: `/tmp/jsonbench_q2_firsttouch_parallel_3158_20260627_022007/1m_column-store-full-prepared_first_touch_after_open_no_aggregate_metadata_json_full_all/result.json`
- q2 total/setup/run: `163.833ms / 152.122ms / 11.683ms`
- rows scanned/matched/reduced: `1,000,000 / 954,611 / 954,611`
- physical bytes / decoded payload / sections / section bytes: `15,991,989 / 32,925,252 / 882 / 21,560,570`
- segment cache hits/misses: `807 / 8`

Profile after this change:

- artifact: `/tmp/jsonbench_q2_profile_parallel_3158_20260627_022136/profiles/cpu_q2_attempt1.pprof`
- direct q2 profile total/setup/run: `106.565ms / 93.635ms / 12.894ms`
- remaining visible setup costs include parallel typed-column range decode, read syscalls, and dense q2 rank-map preparation.

## Tests

- `go test ./TreeDB/collections -run 'TestColumnPhysicalTypedColumnOneShotCacheQ2NoMetadata3123|TestTypedColumnQ2DenseGroupCountDistinctNoSortLocalDictionaries1950|TestTypedColumnQ2DenseGroupCountDistinctLocalCodesNullableValues3080|TestTypedColumnQ2DenseGroupCountDistinctActiveGroupBitset1950|TestColumnPhysicalDenseTypedColumnTargetedRangeReads3090' -count=1`
- `go test ./TreeDB/collections -count=1`
- `go test -race ./TreeDB/collections -run TestColumnPhysicalTypedColumnOneShotCacheQ2NoMetadata3123 -count=1`

Refs #3158
Refs #3000
