### PR TITLE
Parallelize dense q2 rank map setup

### DIFF
--- a/TreeDB/collections/column_physical_typed_column_query.go
+++ b/TreeDB/collections/column_physical_typed_column_query.go
@@ -988,34 +988,87 @@ func prepareColumnTypedColumnDenseGroupCountDistinctGlobalCodes(parts []columnTy
 }
 
 func prepareColumnTypedColumnDenseGroupCountDistinctGlobalRankMaps(parts []columnTypedColumnPhysicalQueryPart) error {
-	return prepareColumnTypedColumnDenseGroupCountDistinctGlobal(parts, prepareColumnTypedColumnDenseGroupCountDistinctGlobalColumnRanks)
+	groupDict, groupRanks, distinctRanks, distinctCardinality, err := columnTypedColumnDenseGroupCountDistinctGlobalPrep(parts)
+	if err != nil {
+		return err
+	}
+	workers := columnTypedColumnPhysicalQueryPartDecodeWorkers(len(parts))
+	if workers < 2 {
+		return prepareColumnTypedColumnDenseGroupCountDistinctGlobalParts(parts, groupDict, groupRanks, distinctRanks, distinctCardinality, prepareColumnTypedColumnDenseGroupCountDistinctGlobalColumnRanks)
+	}
+	return prepareColumnTypedColumnDenseGroupCountDistinctGlobalRankMapsParallel(parts, groupDict, groupRanks, distinctRanks, distinctCardinality, workers)
 }
 
 type columnTypedColumnDenseGroupCountDistinctColumnPrep func(column *columnTypedColumnDenseStringCodeColumn, globalDictionary []string, cardinality int, ranks map[string]uint32) error
 
 func prepareColumnTypedColumnDenseGroupCountDistinctGlobal(parts []columnTypedColumnPhysicalQueryPart, prepareColumn columnTypedColumnDenseGroupCountDistinctColumnPrep) error {
+	groupDict, groupRanks, distinctRanks, distinctCardinality, err := columnTypedColumnDenseGroupCountDistinctGlobalPrep(parts)
+	if err != nil {
+		return err
+	}
+	return prepareColumnTypedColumnDenseGroupCountDistinctGlobalParts(parts, groupDict, groupRanks, distinctRanks, distinctCardinality, prepareColumn)
+}
+
+func columnTypedColumnDenseGroupCountDistinctGlobalPrep(parts []columnTypedColumnPhysicalQueryPart) ([]string, map[string]uint32, map[string]uint32, int, error) {
 	groupDict, groupRanks, err := columnTypedColumnDenseGroupCountDistinctGlobalDictionary(parts, func(part *columnTypedColumnDenseGroupCountDistinctPart) *columnTypedColumnDenseStringCodeColumn {
 		return &part.Group
 	})
 	if err != nil {
-		return err
+		return nil, nil, nil, 0, err
 	}
 	distinctRanks, distinctCardinality, err := columnTypedColumnDenseGroupCountDistinctGlobalRanks(parts, func(part *columnTypedColumnDenseGroupCountDistinctPart) *columnTypedColumnDenseStringCodeColumn {
 		return &part.Distinct
 	})
 	if err != nil {
-		return err
+		return nil, nil, nil, 0, err
+	}
+	return groupDict, groupRanks, distinctRanks, distinctCardinality, nil
+}
+
+func prepareColumnTypedColumnDenseGroupCountDistinctGlobalParts(parts []columnTypedColumnPhysicalQueryPart, groupDict []string, groupRanks map[string]uint32, distinctRanks map[string]uint32, distinctCardinality int, prepareColumn columnTypedColumnDenseGroupCountDistinctColumnPrep) error {
+	for partIdx := range parts {
+		if err := prepareColumnTypedColumnDenseGroupCountDistinctGlobalPart(parts, partIdx, groupDict, groupRanks, distinctRanks, distinctCardinality, prepareColumn); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func prepareColumnTypedColumnDenseGroupCountDistinctGlobalPart(parts []columnTypedColumnPhysicalQueryPart, partIdx int, groupDict []string, groupRanks map[string]uint32, distinctRanks map[string]uint32, distinctCardinality int, prepareColumn columnTypedColumnDenseGroupCountDistinctColumnPrep) error {
+	part := parts[partIdx].DenseGroupCountDistinct
+	if part == nil {
+		return fmt.Errorf("collections: dense grouped count-distinct missing prepared part %d", partIdx)
+	}
+	if err := prepareColumn(&part.Group, groupDict, len(groupDict), groupRanks); err != nil {
+		return fmt.Errorf("collections: dense grouped count-distinct group part %d: %w", partIdx, err)
+	}
+	if err := prepareColumn(&part.Distinct, nil, distinctCardinality, distinctRanks); err != nil {
+		return fmt.Errorf("collections: dense grouped count-distinct distinct part %d: %w", partIdx, err)
+	}
+	return nil
+}
+
+func prepareColumnTypedColumnDenseGroupCountDistinctGlobalRankMapsParallel(parts []columnTypedColumnPhysicalQueryPart, groupDict []string, groupRanks map[string]uint32, distinctRanks map[string]uint32, distinctCardinality int, workers int) error {
+	errs := make([]error, len(parts))
+	jobs := make(chan int)
+	var wg sync.WaitGroup
+	for workerIdx := 0; workerIdx < workers; workerIdx++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for partIdx := range jobs {
+				errs[partIdx] = prepareColumnTypedColumnDenseGroupCountDistinctGlobalPart(parts, partIdx, groupDict, groupRanks, distinctRanks, distinctCardinality, prepareColumnTypedColumnDenseGroupCountDistinctGlobalColumnRanks)
+			}
+		}()
 	}
 	for partIdx := range parts {
-		part := parts[partIdx].DenseGroupCountDistinct
-		if part == nil {
-			return fmt.Errorf("collections: dense grouped count-distinct missing prepared part %d", partIdx)
-		}
-		if err := prepareColumn(&part.Group, groupDict, len(groupDict), groupRanks); err != nil {
-			return fmt.Errorf("collections: dense grouped count-distinct group part %d: %w", partIdx, err)
-		}
-		if err := prepareColumn(&part.Distinct, nil, distinctCardinality, distinctRanks); err != nil {
-			return fmt.Errorf("collections: dense grouped count-distinct distinct part %d: %w", partIdx, err)
+		jobs <- partIdx
+	}
+	close(jobs)
+	wg.Wait()
+	for partIdx := range errs {
+		if errs[partIdx] != nil {
+			return errs[partIdx]
 		}
 	}
 	return nil


### PR DESCRIPTION
Refs #3158
Refs #3000

## Scope

This PR narrows the next q2 one-shot setup slice after #3168. It parallelizes per-part global rank-map preparation for the dense typed-column group/count-distinct path used by q2 in `column-store-full-prepared` with `metadata_mode=no_aggregate_metadata`.

The shared global dictionaries/rank maps are still built once. The per-part local rank-map fill now runs through the same bounded worker count used by parallel typed-column part decode, with deterministic first-error reporting by part order.

## Claim boundary

This is a production-shape query setup improvement for:

- `q2`
- `query_mode=one_shot_end_to_end` and `first_touch_after_open`
- `metadata_mode=no_aggregate_metadata`
- dense typed-column group/count-distinct path

It does not claim insert/load improvement, storage reduction, aggregate-metadata acceleration, hot-prepared improvement, q1/q3/q4/q4a/q4b/q5 improvement, qexpr improvement, or broad SQL superiority versus ClickHouse.

## Evidence

Baseline after #3168 on clean main:

- artifact: `/tmp/jsonbench_q2_profile_next_baseline_3158_20260627_024451/.../result.json`
- q2 one-shot total/setup/run: `96.418ms / 85.029ms / 11.363ms`
- rows scanned/matched/reduced: `1,000,000 / 954,611 / 954,611`
- physical bytes scanned: `15,991,989`
- decoded payload bytes: `32,925,252`
- typed-column sections/bytes: `882 / 21,560,570`

Candidate one-shot:

- command:
  ```sh
  env OUT_DIR=/tmp/jsonbench_q2_oneshot_rankprep_3158_20260627_025203 \
    ROWS=1000000 TRIES=1 QUERY_MODE=one_shot_end_to_end \
    METADATA_MODE=no_aggregate_metadata STORAGE_LAYOUTS=column-store-full-prepared \
    QUERY_CELLS=q2 SUITE=full TREEDB_ALLOW_ERRORS=1 \
    GOMAP_REPLACE=/private/tmp/gomap_3158_q2_rankmap_next_20260627 \
    ./run_columnstore_benchmark.sh
  ```
- artifact: `/tmp/jsonbench_q2_oneshot_rankprep_3158_20260627_025203/1m_column-store-full-prepared_one_shot_end_to_end_no_aggregate_metadata_json_full_all/result.json`
- q2 total/setup/run/render-hash: `75.091ms / 63.628ms / 11.441ms / 0.022ms`
- rows scanned/matched/reduced: `1,000,000 / 954,611 / 954,611`
- physical bytes scanned: `15,991,989`
- decoded payload bytes: `32,925,252`
- typed-column sections/bytes: `882 / 21,560,570`
- segment cache hits/misses: `807 / 8`
- result rows/hash: `13 / b63b8e1013c918fcda7c299ef64beb20c4988854cf0671a83803b6951d795860`

Candidate first-touch:

- command:
  ```sh
  env OUT_DIR=/tmp/jsonbench_q2_firsttouch_rankprep_3158_20260627_025237 \
    ROWS=1000000 TRIES=1 QUERY_MODE=first_touch_after_open \
    METADATA_MODE=no_aggregate_metadata STORAGE_LAYOUTS=column-store-full-prepared \
    QUERY_CELLS=q2 SUITE=full TREEDB_ALLOW_ERRORS=1 \
    GOMAP_REPLACE=/private/tmp/gomap_3158_q2_rankmap_next_20260627 \
    ./run_columnstore_benchmark.sh
  ```
- artifact: `/tmp/jsonbench_q2_firsttouch_rankprep_3158_20260627_025237/1m_column-store-full-prepared_first_touch_after_open_no_aggregate_metadata_json_full_all/result.json`
- q2 total/setup/run/render-hash: `89.980ms / 78.792ms / 11.164ms / 0.024ms`
- rows scanned/matched/reduced: `1,000,000 / 954,611 / 954,611`
- physical bytes scanned: `15,991,989`
- decoded payload bytes: `32,925,252`
- typed-column sections/bytes: `882 / 21,560,570`
- segment cache hits/misses: `807 / 8`
- result rows/hash: `13 / b63b8e1013c918fcda7c299ef64beb20c4988854cf0671a83803b6951d795860`

Load/storage accounting from the candidate one-shot run:

- rows loaded: `1,000,000`
- insert/wall/checkpoint: `15.205s / 18.552s / 0.373s`
- durable storage bytes, WAL excluded: `137,491,627`
- aggregate metadata bytes present: `5,860,282`
- typed-column part bytes: `21,632,156`

## Validation

```sh
go test ./TreeDB/collections -run 'TestColumnPhysicalTypedColumnOneShotCacheQ2NoMetadata3123|TestTypedColumnQ2DenseGroupCountDistinctNoSortLocalDictionaries1950|TestTypedColumnQ2DenseGroupCountDistinctLocalCodesNullableValues3080|TestTypedColumnQ2DenseGroupCountDistinctActiveGroupBitset1950|TestColumnPhysicalDenseTypedColumnTargetedRangeReads3090' -count=1
go test -race ./TreeDB/collections -run TestColumnPhysicalTypedColumnOneShotCacheQ2NoMetadata3123 -count=1
git diff --check
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability of typed-column group and distinct rank calculations.
  * Added safer handling for missing parts and better error reporting during processing.
  * Enhanced processing so work across multiple parts can run in parallel when available, which may improve performance on larger datasets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->