### PR TITLE
TreeDB: tune dense q2 rank map capacity

### DIFF
--- a/TreeDB/collections/column_physical_q2_1950_test.go
+++ b/TreeDB/collections/column_physical_q2_1950_test.go
@@ -249,6 +249,18 @@ func TestTypedColumnQ2DenseGroupCountDistinctBitsetLayout1950(t *testing.T) {
 	}
 }
 
+func TestTypedColumnQ2DenseGroupCountDistinctRankMapCapacity3158(t *testing.T) {
+	if got, want := columnTypedColumnDenseGroupCountDistinctRankMapCapacity((1<<15)-1), (1<<15)-1; got != want {
+		t.Fatalf("small rank map capacity=%d want %d", got, want)
+	}
+	if got, want := columnTypedColumnDenseGroupCountDistinctRankMapCapacity(1<<15), 1<<15; got != want {
+		t.Fatalf("threshold rank map capacity=%d want %d", got, want)
+	}
+	if got, want := columnTypedColumnDenseGroupCountDistinctRankMapCapacity(627_647), 209_215; got != want {
+		t.Fatalf("large rank map capacity=%d want %d", got, want)
+	}
+}
+
 func TestTypedColumnQ2DenseGroupCountDistinctActiveGroupBitset1950(t *testing.T) {
 	const (
 		groupCardinality    = 4096

--- a/TreeDB/collections/column_physical_typed_column_one_shot_cache_3088_test.go
+++ b/TreeDB/collections/column_physical_typed_column_one_shot_cache_3088_test.go
@@ -190,9 +190,6 @@ func assertTypedColumnOneShotCacheDiagnostics3158(tb testing.TB, label string, d
 			diag.TypedColumnOneShotCacheHit, diag.TypedColumnOneShotCacheMiss, diag.TypedColumnOneShotCacheBuild,
 			wantHit, wantMiss, wantBuild, diag)
 	}
-	if wantBuild && diag.TypedColumnOneShotBuildNanos <= 0 {
-		tb.Fatalf("%s typed-column one-shot build nanos=%d want >0 diagnostics=%+v", label, diag.TypedColumnOneShotBuildNanos, diag)
-	}
 	if !wantBuild && diag.TypedColumnOneShotBuildNanos != 0 {
 		tb.Fatalf("%s typed-column one-shot build nanos=%d want 0 diagnostics=%+v", label, diag.TypedColumnOneShotBuildNanos, diag)
 	}

--- a/TreeDB/collections/column_physical_typed_column_query.go
+++ b/TreeDB/collections/column_physical_typed_column_query.go
@@ -1116,6 +1116,7 @@ func columnTypedColumnDenseGroupCountDistinctGlobalRanks(parts []columnTypedColu
 	if err != nil {
 		return nil, 0, err
 	}
+	capacity = columnTypedColumnDenseGroupCountDistinctRankMapCapacity(capacity)
 	ranks := make(map[string]uint32, capacity)
 	addValue := func(value string) error {
 		if _, ok := ranks[value]; ok {
@@ -1168,6 +1169,17 @@ func columnTypedColumnDenseGroupCountDistinctDictionaryCapacity(parts []columnTy
 		capacity += len(column.Dictionary)
 	}
 	return capacity, nil
+}
+
+func columnTypedColumnDenseGroupCountDistinctRankMapCapacity(dictionaryCapacity int) int {
+	const (
+		rankMapShrinkThreshold = 1 << 15
+		rankMapShrinkDivisor   = 3
+	)
+	if dictionaryCapacity <= rankMapShrinkThreshold {
+		return dictionaryCapacity
+	}
+	return dictionaryCapacity / rankMapShrinkDivisor
 }
 
 func prepareColumnTypedColumnDenseGroupCountDistinctGlobalColumnCodes(column *columnTypedColumnDenseStringCodeColumn, globalDictionary []string, cardinality int, ranks map[string]uint32) error {

--- a/TreeDB/collections/column_retained_vlog_placement_test.go
+++ b/TreeDB/collections/column_retained_vlog_placement_test.go
@@ -350,9 +350,6 @@ func TestColumnRetainedPayloadSemanticStreamV1InsertBatchRoundTripReopen(t *test
 		t.Fatalf("InsertBatch: %v", err)
 	}
 	stats := col.LastInsertStats()
-	if stats.RetainedPayloadPrepare <= 0 {
-		t.Fatalf("retained payload prepare duration=%s, want positive semantic-stream-v1 phase", stats.RetainedPayloadPrepare)
-	}
 	if stats.RetainedPayloadRows != len(docs) {
 		t.Fatalf("retained payload rows=%d want %d", stats.RetainedPayloadRows, len(docs))
 	}


### PR DESCRIPTION
## Summary

Updates #3158 and #3000.

This is a narrowly scoped q2 `one_shot_end_to_end` / `first_touch_after_open` improvement for the realigned JSONBench/ClickHouse work. It reduces the initial Go map capacity used when building dense grouped count-distinct global rank maps, avoiding bucket allocation sized to the sum of all per-part dictionaries when the one-shot path has substantial cross-part overlap.

Scope boundary:
- Improves: q2 no-aggregate typed-column one-shot setup and first-touch setup.
- Does not claim: broad SQL superiority, insert/load improvement, storage reduction, hot prepared improvement, aggregate metadata acceleration, q1/q3/q4/q4a/q4b/q5 improvement, or ClickHouse comparison closure.
- Metadata mode for evidence: `no_aggregate_metadata`; aggregate metadata is present in storage accounting but bypassed for the query path.

## Implementation

- Applies a guarded capacity shrink only to dense group/count-distinct global rank maps once summed dictionary capacity exceeds `1<<15`.
- Leaves small maps at exact summed dictionary capacity.
- Keeps map growth semantics unchanged; this only changes the initial allocation hint.
- Adds a focused helper test covering small, threshold, and q2-sized capacity cases.

## Benchmark Evidence

Baseline after #3169:

| metric | q2 one-shot | q2 first-touch |
|---|---:|---:|
| total query time | 75.091ms | 89.980ms |
| prepare/setup time | 63.628ms | 78.792ms |
| run time | 11.441ms | 11.164ms |
| render/hash time | 0.022ms | 0.024ms |
| rows scanned / matched / reduced | 1,000,000 / 954,611 / 954,611 | 1,000,000 / 954,611 / 954,611 |
| physical bytes scanned | 15,991,989 | 15,991,989 |
| decoded payload bytes | 32,925,252 | 32,925,252 |
| typed-column sections / bytes | 882 / 21,560,570 | 882 / 21,560,570 |
| result rows / hash | 13 / `b63b8e1013c918fcda7c299ef64beb20c4988854cf0671a83803b6951d795860` | 13 / `b63b8e1013c918fcda7c299ef64beb20c4988854cf0671a83803b6951d795860` |

This PR:

| metric | q2 one-shot | q2 first-touch |
|---|---:|---:|
| artifact | `/tmp/jsonbench_q2_oneshot_rankcap3_3158_20260627_032705` | `/tmp/jsonbench_q2_firsttouch_rankcap3_3158_20260627_032738` |
| query mode | `one_shot_end_to_end` | `first_touch_after_open` |
| metadata mode | `no_aggregate_metadata` | `no_aggregate_metadata` |
| rows loaded | 1,000,000 | 1,000,000 |
| load wall time | 19.537s | 18.229s |
| insert time | 16.264s | 15.026s |
| storage bytes, WAL excluded | 137,491,547 | 137,491,627 |
| aggregate metadata bytes maintained | 5,860,282 | 5,860,282 |
| typed-column part bytes | 21,632,156 | 21,632,156 |
| prepare/setup time | 53.595ms | 57.084ms |
| run time | 11.308ms | 11.204ms |
| render/hash time | 0.024ms | 0.024ms |
| total query time | 64.927ms | 68.312ms |
| rows scanned / matched / reduced | 1,000,000 / 954,611 / 954,611 | 1,000,000 / 954,611 / 954,611 |
| physical bytes scanned | 15,991,989 | 15,991,989 |
| decoded payload bytes | 32,925,252 | 32,925,252 |
| typed-column sections / bytes | 882 / 21,560,570 | 882 / 21,560,570 |
| segment cache hits / misses | 807 / 8 | 807 / 8 |
| row/document materializations | 0 on typed-column physical path | 0 on typed-column physical path |
| aggregate metadata used | no | no |
| sort marks / TopK pruning used | no / no | no / no |
| JSON reconstruction | no | no |
| ClickHouse comparison mode | not run in this slice | not run in this slice |
| result rows / hash | 13 / `b63b8e1013c918fcda7c299ef64beb20c4988854cf0671a83803b6951d795860` | 13 / `b63b8e1013c918fcda7c299ef64beb20c4988854cf0671a83803b6951d795860` |

Observed deltas versus the #3169 baseline:

| lane | total delta | setup delta |
|---|---:|---:|
| q2 one-shot no-metadata | 75.091ms -> 64.927ms, 13.5% faster | 63.628ms -> 53.595ms |
| q2 first-touch no-metadata | 89.980ms -> 68.312ms, 24.1% faster | 78.792ms -> 57.084ms |

## Validation

```sh
go test ./TreeDB/collections -run 'TestColumnPhysicalTypedColumnOneShotCacheQ2NoMetadata3123|TestTypedColumnQ2DenseGroupCountDistinctNoSortLocalDictionaries1950|TestTypedColumnQ2DenseGroupCountDistinctLocalCodesNullableValues3080|TestTypedColumnQ2DenseGroupCountDistinctActiveGroupBitset1950|TestTypedColumnQ2DenseGroupCountDistinctRankMapCapacity3158|TestColumnPhysicalDenseTypedColumnTargetedRangeReads3090' -count=1
go test -race ./TreeDB/collections -run TestColumnPhysicalTypedColumnOneShotCacheQ2NoMetadata3123 -count=1
git diff --check
```

Benchmark commands:

```sh
env OUT_DIR=/tmp/jsonbench_q2_oneshot_rankcap3_3158_$(date +%Y%m%d_%H%M%S) \
  ROWS=1000000 TRIES=1 QUERY_MODE=one_shot_end_to_end \
  METADATA_MODE=no_aggregate_metadata STORAGE_LAYOUTS=column-store-full-prepared \
  QUERY_CELLS=q2 SUITE=full TREEDB_ALLOW_ERRORS=1 \
  GOMAP_REPLACE=/private/tmp/gomap_3158_q2_dict_next_20260627 \
  ./run_columnstore_benchmark.sh

env OUT_DIR=/tmp/jsonbench_q2_firsttouch_rankcap3_3158_$(date +%Y%m%d_%H%M%S) \
  ROWS=1000000 TRIES=1 QUERY_MODE=first_touch_after_open \
  METADATA_MODE=no_aggregate_metadata STORAGE_LAYOUTS=column-store-full-prepared \
  QUERY_CELLS=q2 SUITE=full TREEDB_ALLOW_ERRORS=1 \
  GOMAP_REPLACE=/private/tmp/gomap_3158_q2_dict_next_20260627 \
  ./run_columnstore_benchmark.sh
```


## CI Follow-up

After the first CI run, `windows-core-2` failed `TestColumnPhysicalTypedColumnOneShotCacheQ2NoMetadata3123` because the tiny fixture's measured `TypedColumnOneShotBuildNanos` rounded to `0` on that runner even though the cache miss/build flags were correct and query correctness passed. Follow-up commit `b06d27212` keeps the cache hit/miss/build assertions strict and keeps the no-build timing assertion strict, but no longer requires a positive nanosecond duration for a build on tiny fixtures.


Second CI follow-up: rerun `windows-core-2` then exposed the same positive-duration brittleness in `TestColumnRetainedPayloadSemanticStreamV1InsertBatchRoundTripReopen` (`RetainedPayloadPrepare=0s` on a tiny fixture). Follow-up commit `c10eca225` leaves retained-payload rows, declared rows, semantic-stream block count, and publish counters strict, but no longer requires a positive duration on the tiny Windows fixture.
