### PR TITLE
TreeDB: parallelize q1 q3 q5 one-shot typed part decode

### DIFF
--- a/TreeDB/collections/column_physical_typed_column_one_shot_cache_3088_test.go
+++ b/TreeDB/collections/column_physical_typed_column_one_shot_cache_3088_test.go
@@ -118,6 +118,111 @@ func TestColumnPhysicalTypedColumnOneShotCacheQ2NoMetadata3123(t *testing.T) {
 	assertTypedColumnQ2OneShotRankMapsNoGlobalCodes3158(t, col, req)
 }
 
+func TestColumnPhysicalTypedColumnParallelPartDecodeShapes3158(t *testing.T) {
+	readCache := &columnPhysicalAssetReadCache{}
+	baseReq := func(kind ColumnPhysicalQueryKind) ColumnPhysicalQueryRequest {
+		return ColumnPhysicalQueryRequest{
+			Kind:                     kind,
+			GroupColumn:              "collection",
+			ValueColumn:              "time_us",
+			TopK:                     3,
+			TopKOrder:                ColumnPhysicalQueryTopKInt64Asc,
+			ColumnAssetReadIntegrity: ColumnAssetReadIntegrityCachedVerify,
+		}
+	}
+	tests := []struct {
+		name                                      string
+		plan                                      columnTypedColumnPhysicalQueryPlan
+		req                                       ColumnPhysicalQueryRequest
+		allowDenseGroupCountDistinct              bool
+		prepareDenseInt64SpanGlobalCodes          bool
+		prepareDenseGroupCountDistinctGlobalCodes bool
+		prepareDenseGroupCountDistinctGlobalRanks bool
+		includePhysicalRows                       bool
+		want                                      bool
+	}{
+		{
+			name: "q1 dense group-count",
+			plan: columnTypedColumnPhysicalQueryPlan{DenseGroupCount: true, GroupColumn: "collection"},
+			req:  ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCount, GroupColumn: "collection", ColumnAssetReadIntegrity: ColumnAssetReadIntegrityCachedVerify},
+			want: true,
+		},
+		{
+			name: "q3 dense group-hour-count",
+			plan: columnTypedColumnPhysicalQueryPlan{DenseGroupHourCount: true, GroupColumn: "collection", ValueColumn: "time_us"},
+			req:  ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupHourCount, GroupColumn: "collection", ValueColumn: "time_us", ColumnAssetReadIntegrity: ColumnAssetReadIntegrityCachedVerify},
+			want: true,
+		},
+		{
+			name: "q5 dense int64 span",
+			plan: columnTypedColumnPhysicalQueryPlan{DenseInt64Span: true, GroupColumn: "did", ValueColumn: "time_us"},
+			req:  ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupInt64Span, GroupColumn: "did", ValueColumn: "time_us", ColumnAssetReadIntegrity: ColumnAssetReadIntegrityCachedVerify},
+			want: true,
+		},
+		{
+			name:                         "q2 dense group-count-distinct rank maps",
+			plan:                         columnTypedColumnPhysicalQueryPlan{DenseGroupCountDistinct: true, GroupColumn: "collection", DistinctColumn: "did"},
+			req:                          ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCountAndDistinct, GroupColumn: "collection", DistinctColumn: "did", ColumnAssetReadIntegrity: ColumnAssetReadIntegrityCachedVerify},
+			allowDenseGroupCountDistinct: true,
+			prepareDenseGroupCountDistinctGlobalRanks: true,
+			want: true,
+		},
+		{
+			name: "q2 rank maps require insert-only allowance",
+			plan: columnTypedColumnPhysicalQueryPlan{DenseGroupCountDistinct: true, GroupColumn: "collection", DistinctColumn: "did"},
+			req:  ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCountAndDistinct, GroupColumn: "collection", DistinctColumn: "did", ColumnAssetReadIntegrity: ColumnAssetReadIntegrityCachedVerify},
+			prepareDenseGroupCountDistinctGlobalRanks: true,
+		},
+		{
+			name: "q4 time-order TopK keeps serial lazy payload loader",
+			plan: columnTypedColumnPhysicalQueryPlan{TimeOrderTopK: true, GroupColumn: "collection", ValueColumn: "time_us"},
+			req:  baseReq(ColumnPhysicalQueryGroupMinInt64),
+		},
+		{
+			name:                             "global int64 codes stay serial",
+			plan:                             columnTypedColumnPhysicalQueryPlan{DenseInt64Span: true, GroupColumn: "did", ValueColumn: "time_us"},
+			req:                              ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupInt64Span, GroupColumn: "did", ValueColumn: "time_us", ColumnAssetReadIntegrity: ColumnAssetReadIntegrityCachedVerify},
+			prepareDenseInt64SpanGlobalCodes: true,
+		},
+		{
+			name:                         "global count-distinct codes stay serial",
+			plan:                         columnTypedColumnPhysicalQueryPlan{DenseGroupCountDistinct: true, GroupColumn: "collection", DistinctColumn: "did"},
+			req:                          ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCountAndDistinct, GroupColumn: "collection", DistinctColumn: "did", ColumnAssetReadIntegrity: ColumnAssetReadIntegrityCachedVerify},
+			allowDenseGroupCountDistinct: true,
+			prepareDenseGroupCountDistinctGlobalCodes: true,
+		},
+		{
+			name:                "physical rows stay serial",
+			plan:                columnTypedColumnPhysicalQueryPlan{DenseGroupCount: true, GroupColumn: "collection"},
+			req:                 ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCount, GroupColumn: "collection", ColumnAssetReadIntegrity: ColumnAssetReadIntegrityCachedVerify},
+			includePhysicalRows: true,
+		},
+		{
+			name: "verify full reads stay serial",
+			plan: columnTypedColumnPhysicalQueryPlan{DenseGroupCount: true, GroupColumn: "collection"},
+			req:  ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCount, GroupColumn: "collection", ColumnAssetReadIntegrity: ColumnAssetReadIntegrityVerify},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := columnTypedColumnPhysicalQueryUseParallelPartDecode(
+				tc.plan,
+				tc.req,
+				readCache,
+				4,
+				tc.includePhysicalRows,
+				tc.allowDenseGroupCountDistinct,
+				tc.prepareDenseInt64SpanGlobalCodes,
+				tc.prepareDenseGroupCountDistinctGlobalCodes,
+				tc.prepareDenseGroupCountDistinctGlobalRanks,
+			)
+			if got != tc.want {
+				t.Fatalf("parallel part decode=%t want %t", got, tc.want)
+			}
+		})
+	}
+}
+
 func assertTypedColumnQ2OneShotRankMapsNoGlobalCodes3158(tb testing.TB, col *Collection, req ColumnPhysicalQueryRequest) {
 	tb.Helper()
 	if col == nil {

--- a/TreeDB/collections/column_physical_typed_column_query.go
+++ b/TreeDB/collections/column_physical_typed_column_query.go
@@ -631,16 +631,21 @@ func columnTypedColumnPhysicalQueryUseParallelPartDecode(plan columnTypedColumnP
 	if partCount < 2 || readCache == nil || readCache.resourceManager != nil {
 		return false
 	}
-	if includePhysicalRows || prepareDenseInt64SpanGlobalCodes || prepareDenseGroupCountDistinctGlobalCodes || !prepareDenseGroupCountDistinctGlobalRanks {
-		return false
-	}
-	if !allowDenseGroupCountDistinct || !columnTypedColumnPhysicalQueryUseDenseGroupCountDistinct(plan, req) {
+	if includePhysicalRows || prepareDenseInt64SpanGlobalCodes || prepareDenseGroupCountDistinctGlobalCodes {
 		return false
 	}
 	if !typedColumnStringUseTargetedRanges(req.ColumnAssetReadIntegrity) {
 		return false
 	}
-	return columnTypedColumnPhysicalQueryPartDecodeWorkers(partCount) > 1
+	if columnTypedColumnPhysicalQueryPartDecodeWorkers(partCount) <= 1 {
+		return false
+	}
+	if prepareDenseGroupCountDistinctGlobalRanks {
+		return allowDenseGroupCountDistinct && columnTypedColumnPhysicalQueryUseDenseGroupCountDistinct(plan, req)
+	}
+	return columnTypedColumnPhysicalQueryUseDenseGroupCount(plan, req) ||
+		columnTypedColumnPhysicalQueryUseDenseGroupHourCount(plan, req) ||
+		columnTypedColumnPhysicalQueryUseDenseInt64Span(plan, req)
 }
 
 func columnTypedColumnPhysicalQueryPartDecodeWorkers(partCount int) int {


### PR DESCRIPTION
## Summary
- broaden typed-column parallel part decode from the existing q2 rank-map path to q1 dense group-count, q3 dense group-hour-count, and q5 dense int64-span setup
- keep the gate fail-closed for physical-row materialization, global-code preparation, full checksum verify reads, resource-manager-backed caches, and q4 time-order TopK lazy-payload runners
- add a guard-level regression test for the admitted and rejected shapes

## Scope
- Improves: `one_shot_end_to_end` and `first_touch_after_open` setup for no-aggregate typed-column scan paths on q1/q3/q5.
- Does not claim: broad SQL superiority, insert/load speed, storage reduction, metadata acceleration, hot-prepared execution, or q4 TopK setup improvement.
- q2 behavior is functionally unchanged by this slice; the single post-change one-shot run was slower than the prior q2-only best, so this PR should not be described as a q2 performance win.

Refs #3158
Refs #3000

## Evidence
TreeDB 1M full-retained JSON, `column-store-full-prepared`, `metadata_mode=no_aggregate_metadata`, `TRIES=1`, WAL excluded from durable storage, JSONBench `8477b48`, gomap `0e35d93`.

First-touch after open, artifact `/tmp/jsonbench_firsttouch_noagg_paralleldecode_3158_20260627_042703`:

| query | before current-main after #3170 | after this PR | setup / run / render after | rows scanned | physical bytes | decoded payload | notes |
|---|---:|---:|---:|---:|---:|---:|---|
| q1 | 110.151 ms | 24.737 ms | 22.999 / 1.704 / 0.034 ms | 1,000,000 | 12,212,532 | 8,210,001 | no aggregate metadata |
| q3 | 100.716 ms | 33.518 ms | 22.966 / 10.542 / 0.011 ms | 1,000,000 | 14,541,335 | 26,680,455 | no aggregate metadata |
| q5 | 147.808 ms | 51.907 ms | 36.440 / 15.454 / 0.013 ms | 1,000,000 | 17,999,817 | 34,933,080 | no aggregate metadata |
| q4 | 98.351 ms | 101.200 ms | 100.691 / 0.494 / 0.014 ms | 9 | 10,502,828 | 285,914 | intentionally still serial lazy TopK |

Primary one-shot end-to-end, artifact `/tmp/jsonbench_oneshot_noagg_paralleldecode_3158_20260627_042837`:

| query | after this PR | setup / run / render | rows scanned | physical bytes | decoded payload |
|---|---:|---:|---:|---:|---:|
| q1 | 29.515 ms | 26.092 / 3.389 / 0.033 ms | 1,000,000 | 12,212,532 | 8,210,001 |
| q3 | 39.251 ms | 28.023 / 11.211 / 0.017 ms | 1,000,000 | 14,541,335 | 26,680,455 |
| q5 | 54.100 ms | 38.064 / 16.023 / 0.012 ms | 1,000,000 | 17,999,817 | 34,933,080 |
| qexpr | 7.690 ms | 0.000 / 7.685 / 0.005 ms | 1,000,000 | 2,302,520 | 0 | unchanged arbitrary-expression lane |

Load/storage for the one-shot artifact: 1,000,000 rows, insert 15.776s first-touch run / 18.975s one-shot run, load wall 19.164s first-touch / 18.975s one-shot, durable TreeDB storage WAL-excluded 137,491,611 bytes (131.12 MiB).

## Validation
```sh
go test ./TreeDB/collections -run 'TestColumnPhysicalTypedColumnParallelPartDecodeShapes3158|TestColumnPhysicalTypedColumnOneShotCacheQ1Q3NoMetadata3088|TestColumnPhysicalTypedColumnOneShotCacheQ5NoMetadata3088|TestColumnPhysicalTypedColumnOneShotCacheQ2NoMetadata3123|TestColumnPhysicalDenseTypedColumnTargetedRangeReads3090' -count=1
go test -race ./TreeDB/collections -run 'TestColumnPhysicalTypedColumnOneShotCacheQ1Q3NoMetadata3088|TestColumnPhysicalTypedColumnOneShotCacheQ5NoMetadata3088|TestColumnPhysicalTypedColumnOneShotCacheQ2NoMetadata3123' -count=1
git diff --check
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted when parallel decoding is used for typed-column queries, making it more consistent across dense group count, group hour count, int64 span, and distinct-count cases.
  * Improved handling of requests that include physical rows or certain global-code preparations, ensuring these continue to use the safer non-parallel path.
  * Added test coverage for multiple query-shape combinations to verify parallel decode behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->