### PR TITLE
TreeDB: stream vacuum leaf-ref rebuild

### DIFF
--- a/TreeDB/db/vacuum_collection_roots.go
+++ b/TreeDB/db/vacuum_collection_roots.go
@@ -320,12 +320,12 @@ func vacuumCopyCollectionRoot(oldPager *pager.Pager, rootID uint64, alloc vacuum
 		return 0, errors.New("vacuum: missing pager/allocator")
 	}
 
-	children, allLeafRefs, err := vacuumCollectLeafRefChildrenIfComplete(oldPager, rootID)
+	allLeafRefs, err := vacuumTreeAllLeafRefsIfComplete(oldPager, rootID)
 	if err != nil {
 		return 0, err
 	}
 	if allLeafRefs {
-		return vacuumBuildInternalTreeFromChildren(newPager, alloc, children, false)
+		return vacuumBuildInternalTreeFromLeafRefs(oldPager, rootID, newPager, alloc, false)
 	}
 	return vacuumClonePagerTreeWithLeafRefs(oldPager, rootID, alloc, newPager, false)
 }

--- a/TreeDB/db/vacuum_offline.go
+++ b/TreeDB/db/vacuum_offline.go
@@ -147,14 +147,14 @@ func vacuumIndexOffline(opts Options, fail vacuumFailpoint) error {
 				return err
 			}
 		} else {
-			leafChildren, allLeafRefs, err := vacuumCollectLeafRefChildrenIfComplete(d.Pager(), state.RootPageID)
+			allLeafRefs, err := vacuumTreeAllLeafRefsIfComplete(d.Pager(), state.RootPageID)
 			if err != nil {
 				_ = newPager.Close()
 				_ = d.Close()
 				return err
 			}
 			if allLeafRefs {
-				userRoot, err = vacuumBuildInternalTreeFromChildren(newPager, alloc, leafChildren, effectiveInternalBaseDelta)
+				userRoot, err = vacuumBuildInternalTreeFromLeafRefs(d.Pager(), state.RootPageID, newPager, alloc, effectiveInternalBaseDelta)
 			} else {
 				userRoot, err = vacuumClonePagerTreeWithLeafRefs(d.Pager(), state.RootPageID, alloc, newPager, effectiveInternalBaseDelta)
 			}

--- a/TreeDB/db/vacuum_online.go
+++ b/TreeDB/db/vacuum_online.go
@@ -300,13 +300,7 @@ func (db *DB) vacuumIndexOnline(ctx context.Context, lockMaintenance bool) error
 				return err
 			}
 		} else {
-			leafChildren, err := vacuumCollectLeafRefChildren(basePager, baseState.RootPageID)
-			if err != nil {
-				_ = baseSnap.Close()
-				cleanupNewPager()
-				return err
-			}
-			newRoot, err = vacuumBuildInternalTreeFromChildren(newPager, newAlloc, leafChildren, effectiveInternalBaseDelta)
+			newRoot, err = vacuumBuildInternalTreeFromLeafRefs(basePager, baseState.RootPageID, newPager, newAlloc, effectiveInternalBaseDelta)
 			if err != nil {
 				_ = baseSnap.Close()
 				cleanupNewPager()
@@ -765,17 +759,198 @@ type vacuumLeafChild struct {
 	childRef page.ChildRef
 }
 
-func vacuumCollectLeafRefChildren(p *pager.Pager, rootID uint64) ([]vacuumLeafChild, error) {
-	if p == nil {
-		return nil, errors.New("vacuum: missing pager")
+type vacuumInternalTreeLevelBuilder struct {
+	builder  *node.Builder
+	startKey []byte
+}
+
+type vacuumInternalTreeBuilder struct {
+	p     *pager.Pager
+	alloc interface {
+		Alloc(hint uint64) (uint64, error)
+	}
+	internalBaseDelta bool
+	levels            []*vacuumInternalTreeLevelBuilder
+	children          int
+}
+
+func newVacuumInternalTreeBuilder(p *pager.Pager, alloc interface {
+	Alloc(hint uint64) (uint64, error)
+}, internalBaseDelta bool) (*vacuumInternalTreeBuilder, error) {
+	if p == nil || alloc == nil {
+		return nil, errors.New("vacuum: missing pager/allocator")
+	}
+	b := &vacuumInternalTreeBuilder{
+		p:                 p,
+		alloc:             alloc,
+		internalBaseDelta: internalBaseDelta,
+	}
+	if err := b.ensureLevel(0); err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+func (b *vacuumInternalTreeBuilder) newNodeBuilder() (*node.Builder, error) {
+	buf := make([]byte, page.PageSize)
+	var nb *node.Builder
+	if b.internalBaseDelta {
+		nb = node.NewBuilderWithOptions(buf, page.PageTypeInternal, node.BuilderOptions{InternalBaseDelta: true})
+	} else {
+		nb = node.NewBuilder(buf, page.PageTypeInternal)
+	}
+	pid, err := b.alloc.Alloc(0)
+	if err != nil {
+		return nil, err
+	}
+	nb.SetPageID(pid)
+	return nb, nil
+}
+
+func (b *vacuumInternalTreeBuilder) ensureLevel(lvl int) error {
+	for len(b.levels) <= lvl {
+		nb, err := b.newNodeBuilder()
+		if err != nil {
+			return err
+		}
+		b.levels = append(b.levels, &vacuumInternalTreeLevelBuilder{builder: nb})
+	}
+	return nil
+}
+
+func (b *vacuumInternalTreeBuilder) addParentChild(lvl int, key []byte, childID uint64) error {
+	if err := b.ensureLevel(lvl + 1); err != nil {
+		return err
+	}
+	parent := b.levels[lvl+1]
+	if parent.startKey == nil {
+		parent.startKey = append([]byte(nil), key...)
+	}
+	err := parent.builder.AddInternalChild(key, childID)
+	if err == node.ErrNodeFull {
+		if err := b.flush(lvl + 1); err != nil {
+			return err
+		}
+		parent = b.levels[lvl+1]
+		if parent.startKey == nil {
+			parent.startKey = append([]byte(nil), key...)
+		}
+		err = parent.builder.AddInternalChild(key, childID)
+	}
+	return err
+}
+
+func (b *vacuumInternalTreeBuilder) flush(lvl int) error {
+	lb := b.levels[lvl]
+	if lb.builder.Count() == 0 {
+		return nil
+	}
+	n := lb.builder.Finish()
+	childID := lb.builder.PageID()
+	if err := b.p.Write(childID, n.Data()); err != nil {
+		return err
+	}
+
+	key := lb.startKey
+	if key == nil {
+		key = []byte{}
+	}
+	if err := b.addParentChild(lvl, key, childID); err != nil {
+		return err
+	}
+
+	nb, err := b.newNodeBuilder()
+	if err != nil {
+		return err
+	}
+	lb.builder = nb
+	lb.startKey = nil
+	return nil
+}
+
+func (b *vacuumInternalTreeBuilder) append(key []byte, childRef page.ChildRef) error {
+	lb := b.levels[0]
+	if lb.startKey == nil {
+		lb.startKey = append([]byte(nil), key...)
+	}
+	err := lb.builder.AddInternalChildRef(key, childRef)
+	if err == node.ErrNodeFull {
+		if err := b.flush(0); err != nil {
+			return err
+		}
+		lb = b.levels[0]
+		if lb.startKey == nil {
+			lb.startKey = append([]byte(nil), key...)
+		}
+		err = lb.builder.AddInternalChildRef(key, childRef)
+	}
+	if err != nil {
+		return err
+	}
+	b.children++
+	return nil
+}
+
+func (b *vacuumInternalTreeBuilder) finish() (uint64, error) {
+	if b.children == 0 {
+		return 0, errors.New("vacuum: missing children")
+	}
+
+	currID := uint64(0)
+	var root *node.Node
+	for i := 0; i < len(b.levels); i++ {
+		lb := b.levels[i]
+		if lb.builder.Count() == 0 {
+			continue
+		}
+		n := lb.builder.Finish()
+		childID := lb.builder.PageID()
+		if err := b.p.Write(childID, n.Data()); err != nil {
+			return 0, err
+		}
+		currID = childID
+		root = n
+
+		if i < len(b.levels)-1 {
+			key := lb.startKey
+			if key == nil {
+				key = []byte{}
+			}
+			if err := b.addParentChild(i, key, currID); err != nil {
+				return 0, err
+			}
+		}
+	}
+	if currID == 0 {
+		return 0, errors.New("vacuum: missing children")
+	}
+
+	if len(b.levels) > 1 && root != nil && root.Count() == 1 {
+		childRef, err := root.GetInternalChildRef(0)
+		if err == nil && childRef.Kind == page.ChildRefPage {
+			return childRef.Page, nil
+		}
+	}
+
+	return currID, nil
+}
+
+func vacuumBuildInternalTreeFromLeafRefs(src *pager.Pager, rootID uint64, dst *pager.Pager, alloc interface {
+	Alloc(hint uint64) (uint64, error)
+}, internalBaseDelta bool) (uint64, error) {
+	if src == nil {
+		return 0, errors.New("vacuum: missing pager")
 	}
 	if rootID == 0 {
-		return nil, errors.New("vacuum: missing root id")
+		return 0, errors.New("vacuum: missing root id")
 	}
-	out := make([]vacuumLeafChild, 0, 1024)
+	builder, err := newVacuumInternalTreeBuilder(dst, alloc, internalBaseDelta)
+	if err != nil {
+		return 0, err
+	}
 	var walk func(uint64) error
 	walk = func(id uint64) error {
-		data, err := p.Get(id)
+		data, err := src.Get(id)
 		if err != nil {
 			return err
 		}
@@ -788,199 +963,80 @@ func vacuumCollectLeafRefChildren(p *pager.Pager, rootID uint64) ([]vacuumLeafCh
 				if err != nil {
 					return err
 				}
-				if childRef.Kind == page.ChildRefLeafLog {
-					out = append(out, vacuumLeafChild{
-						key:      append([]byte(nil), keyView...),
-						childRef: childRef,
-					})
-					continue
-				}
-				if err := walk(childRef.Page); err != nil {
-					return err
+				switch childRef.Kind {
+				case page.ChildRefLeafLog:
+					if err := builder.append(keyView, childRef); err != nil {
+						return err
+					}
+				case page.ChildRefPage:
+					if err := walk(childRef.Page); err != nil {
+						return err
+					}
+				default:
+					return fmt.Errorf("vacuum: unexpected child ref kind %d at page %d", childRef.Kind, id)
 				}
 			}
 			return nil
 		case page.PageTypeLeaf:
-			// In outer-leaf-in-vlog mode, leaves should be leafrefs, not pager pages.
 			return fmt.Errorf("vacuum: unexpected pager-backed leaf page %d while collecting leafrefs", id)
 		default:
 			return fmt.Errorf("vacuum: unexpected page type %d at page %d", n.Type(), id)
 		}
 	}
 	if err := walk(rootID); err != nil {
-		return nil, err
-	}
-	if len(out) == 0 {
-		return nil, errors.New("vacuum: collected zero leafref children")
-	}
-	return out, nil
-}
-
-func vacuumBuildInternalTreeFromChildren(p *pager.Pager, alloc interface {
-	Alloc(hint uint64) (uint64, error)
-}, children []vacuumLeafChild, internalBaseDelta bool) (uint64, error) {
-	if p == nil || alloc == nil {
-		return 0, errors.New("vacuum: missing pager/allocator")
-	}
-	if len(children) == 0 {
-		return 0, errors.New("vacuum: missing children")
-	}
-
-	type levelBuilder struct {
-		builder  *node.Builder
-		startKey []byte
-	}
-	var levels []*levelBuilder
-
-	newBuilder := func() (*node.Builder, error) {
-		buf := make([]byte, page.PageSize)
-		var b *node.Builder
-		if internalBaseDelta {
-			b = node.NewBuilderWithOptions(buf, page.PageTypeInternal, node.BuilderOptions{InternalBaseDelta: true})
-		} else {
-			b = node.NewBuilder(buf, page.PageTypeInternal)
-		}
-		pid, err := alloc.Alloc(0)
-		if err != nil {
-			return nil, err
-		}
-		b.SetPageID(pid)
-		return b, nil
-	}
-
-	ensureLevel := func(lvl int) error {
-		for len(levels) <= lvl {
-			b, err := newBuilder()
-			if err != nil {
-				return err
-			}
-			levels = append(levels, &levelBuilder{builder: b})
-		}
-		return nil
-	}
-	if err := ensureLevel(0); err != nil {
 		return 0, err
 	}
+	return builder.finish()
+}
 
-	var flush func(int) error
-	flush = func(lvl int) error {
-		lb := levels[lvl]
-		n := lb.builder.Finish()
-		childID := lb.builder.PageID()
-		if err := p.Write(childID, n.Data()); err != nil {
-			return err
-		}
+func vacuumTreeAllLeafRefsIfComplete(p *pager.Pager, rootID uint64) (bool, error) {
+	if p == nil {
+		return false, errors.New("vacuum: missing pager")
+	}
+	if rootID == 0 {
+		return false, errors.New("vacuum: missing root id")
+	}
 
-		if err := ensureLevel(lvl + 1); err != nil {
-			return err
-		}
-		parent := levels[lvl+1]
-		key := lb.startKey
-		if key == nil {
-			key = []byte{}
-		}
-		if parent.startKey == nil {
-			parent.startKey = append([]byte(nil), key...)
-		}
-
-		err := parent.builder.AddInternalChild(key, childID)
-		if err == node.ErrNodeFull {
-			if err := flush(lvl + 1); err != nil {
-				return err
-			}
-			parent = levels[lvl+1]
-			if parent.startKey == nil {
-				parent.startKey = append([]byte(nil), key...)
-			}
-			if err := parent.builder.AddInternalChild(key, childID); err != nil {
-				return err
-			}
-		} else if err != nil {
-			return err
-		}
-
-		// Reset this level.
-		b, err := newBuilder()
+	leafRefs := 0
+	var walk func(uint64) (bool, error)
+	walk = func(id uint64) (bool, error) {
+		data, err := p.Get(id)
 		if err != nil {
-			return err
+			return false, err
 		}
-		lb.builder = b
-		lb.startKey = nil
-		return nil
-	}
-
-	for _, child := range children {
-		key := child.key
-		lb := levels[0]
-		if lb.startKey == nil {
-			lb.startKey = append([]byte(nil), key...)
-		}
-		err := lb.builder.AddInternalChildRef(key, child.childRef)
-		if err == node.ErrNodeFull {
-			if err := flush(0); err != nil {
-				return 0, err
-			}
-			lb = levels[0]
-			if lb.startKey == nil {
-				lb.startKey = append([]byte(nil), key...)
-			}
-			err = lb.builder.AddInternalChildRef(key, child.childRef)
-		}
-		if err != nil {
-			return 0, err
-		}
-	}
-
-	// Finalize all levels (same promotion logic as bulk builder).
-	currID := uint64(0)
-	for i := 0; i < len(levels); i++ {
-		lb := levels[i]
-		n := lb.builder.Finish()
-		childID := lb.builder.PageID()
-		if err := p.Write(childID, n.Data()); err != nil {
-			return 0, err
-		}
-		currID = childID
-
-		if i < len(levels)-1 {
-			parent := levels[i+1]
-			key := lb.startKey
-			if key == nil {
-				key = []byte{}
-			}
-			if parent.startKey == nil {
-				parent.startKey = append([]byte(nil), key...)
-			}
-			err := parent.builder.AddInternalChild(key, currID)
-			if err == node.ErrNodeFull {
-				if err := flush(i + 1); err != nil {
-					return 0, err
+		n := node.NewNode(data)
+		switch n.Type() {
+		case page.PageTypeInternal:
+			count := n.Count()
+			for i := uint16(0); i < count; i++ {
+				_, childRef, err := n.GetInternalEntryRefView(i)
+				if err != nil {
+					return false, err
 				}
-				parent = levels[i+1]
-				if parent.startKey == nil {
-					parent.startKey = append([]byte(nil), key...)
+				if childRef.Kind == page.ChildRefLeafLog {
+					leafRefs++
+					continue
 				}
-				if err := parent.builder.AddInternalChild(key, currID); err != nil {
-					return 0, err
+				if childRef.Kind != page.ChildRefPage {
+					return false, fmt.Errorf("vacuum: unexpected child ref kind %d at page %d", childRef.Kind, id)
 				}
-			} else if err != nil {
-				return 0, err
+				allLeafRefs, err := walk(childRef.Page)
+				if err != nil || !allLeafRefs {
+					return allLeafRefs, err
+				}
 			}
+			return true, nil
+		case page.PageTypeLeaf:
+			return false, nil
+		default:
+			return false, fmt.Errorf("vacuum: unexpected page type %d at page %d", n.Type(), id)
 		}
 	}
-
-	// Reduce root if possible.
-	if len(levels) > 1 {
-		root := levels[len(levels)-1].builder.Finish()
-		if root.Count() == 1 {
-			childRef, err := root.GetInternalChildRef(0)
-			if err == nil && childRef.Kind == page.ChildRefPage {
-				return childRef.Page, nil
-			}
-		}
+	allLeafRefs, err := walk(rootID)
+	if err != nil || !allLeafRefs || leafRefs == 0 {
+		return false, err
 	}
-
-	return currID, nil
+	return true, nil
 }
 
 func vacuumClonePagerTreeWithLeafRefs(oldPager *pager.Pager, rootID uint64, alloc interface {

--- a/TreeDB/db/vacuum_online_swap_test.go
+++ b/TreeDB/db/vacuum_online_swap_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/snissn/gomap/TreeDB/internal/leafrefscan"
 	"github.com/snissn/gomap/TreeDB/node"
 	"github.com/snissn/gomap/TreeDB/page"
+	"github.com/snissn/gomap/TreeDB/pager"
 )
 
 func collectLeafRefIDsFromRoot(t *testing.T, d *DB, rootID uint64) map[page.LeafLogPtr]struct{} {
@@ -36,6 +37,91 @@ func collectLeafRefIDsFromRoot(t *testing.T, d *DB, rootID uint64) map[page.Leaf
 		t.Fatalf("collect leaf refs: %v", err)
 	}
 	return out
+}
+
+func TestVacuumBuildInternalTreeFromLeafRefs_StreamsChildren(t *testing.T) {
+	dir := t.TempDir()
+
+	d, err := Open(Options{
+		Dir:                        dir,
+		ChunkSize:                  64 * 1024,
+		KeepRecent:                 1,
+		Durability:                 DurabilityWALOffRelaxed,
+		IndexOuterLeavesInValueLog: true,
+		PreferAppendAlloc:          true,
+	})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+	leafLog := &registeredLeafPageLog{db: d, dir: dir}
+	if err := leafLog.ensureWriter(); err != nil {
+		t.Fatalf("ensure leaf writer: %v", err)
+	}
+	d.SetLeafPageLog(leafLog)
+
+	val := bytes.Repeat([]byte("v"), 64)
+	for version := 1; version <= 16; version++ {
+		b := d.NewBatch()
+		for i := 0; i < 512; i++ {
+			key := []byte(fmt.Sprintf("stream/k/%08d/%08d", version, i))
+			val[0] = byte(version)
+			if err := b.Set(key, val); err != nil {
+				t.Fatalf("set version=%d key=%d: %v", version, i, err)
+			}
+		}
+		if err := b.WriteSync(); err != nil {
+			t.Fatalf("writesync version=%d: %v", version, err)
+		}
+		_ = b.Close()
+	}
+
+	state := d.State()
+	if state == nil || state.RootPageID == 0 {
+		t.Fatalf("missing root")
+	}
+	allLeafRefs, err := vacuumTreeAllLeafRefsIfComplete(d.Pager(), state.RootPageID)
+	if err != nil {
+		t.Fatalf("classify leaf-ref root: %v", err)
+	}
+	if !allLeafRefs {
+		t.Fatalf("expected fixture root to contain only leaf refs")
+	}
+	before, allLeafRefs, err := vacuumCollectLeafRefChildrenIfComplete(d.Pager(), state.RootPageID)
+	if err != nil {
+		t.Fatalf("collect source leaf refs: %v", err)
+	}
+	if !allLeafRefs || len(before) == 0 {
+		t.Fatalf("source leaf refs all=%v len=%d", allLeafRefs, len(before))
+	}
+
+	streamPager, err := pager.Open(filepath.Join(t.TempDir(), "streamed-index.db"), 64*1024)
+	if err != nil {
+		t.Fatalf("open stream pager: %v", err)
+	}
+	defer func() { _ = streamPager.Close() }()
+	if _, err := streamPager.Alloc(2); err != nil {
+		t.Fatalf("alloc stream pager metadata pages: %v", err)
+	}
+	streamRoot, err := vacuumBuildInternalTreeFromLeafRefs(d.Pager(), state.RootPageID, streamPager, &pagerAllocator{p: streamPager}, false)
+	if err != nil {
+		t.Fatalf("stream leaf refs: %v", err)
+	}
+	after, allLeafRefs, err := vacuumCollectLeafRefChildrenIfComplete(streamPager, streamRoot)
+	if err != nil {
+		t.Fatalf("collect streamed leaf refs: %v", err)
+	}
+	if !allLeafRefs {
+		t.Fatalf("streamed root is not leaf-ref complete")
+	}
+	if len(after) != len(before) {
+		t.Fatalf("leaf-ref count mismatch: before=%d after=%d", len(before), len(after))
+	}
+	for i := range before {
+		if !bytes.Equal(after[i].key, before[i].key) || after[i].childRef != before[i].childRef {
+			t.Fatalf("leaf child %d mismatch: before=%+v after=%+v", i, before[i], after[i])
+		}
+	}
 }
 
 type countingLeafPageLog struct {

--- a/TreeDB/db/vacuum_online_swap_test.go
+++ b/TreeDB/db/vacuum_online_swap_test.go
@@ -39,6 +39,19 @@ func collectLeafRefIDsFromRoot(t *testing.T, d *DB, rootID uint64) map[page.Leaf
 	return out
 }
 
+func closeVacuumTestLeafPageLog(t *testing.T, d *DB, leafLog *registeredLeafPageLog) {
+	t.Helper()
+	if d != nil {
+		d.SetLeafPageLog(nil)
+	}
+	if leafLog == nil {
+		return
+	}
+	if err := leafLog.Close(); err != nil {
+		t.Errorf("close leaf page log: %v", err)
+	}
+}
+
 func TestVacuumBuildInternalTreeFromLeafRefs_StreamsChildren(t *testing.T) {
 	dir := t.TempDir()
 
@@ -59,6 +72,7 @@ func TestVacuumBuildInternalTreeFromLeafRefs_StreamsChildren(t *testing.T) {
 		t.Fatalf("ensure leaf writer: %v", err)
 	}
 	d.SetLeafPageLog(leafLog)
+	defer closeVacuumTestLeafPageLog(t, d, leafLog)
 
 	val := bytes.Repeat([]byte("v"), 64)
 	for version := 1; version <= 16; version++ {
@@ -223,6 +237,7 @@ func TestVacuumIndexOnline_OuterLeavesInValueLog_DoesNotRewriteLeafPages(t *test
 	}
 	leafLog := &countingLeafPageLog{inner: baseLeafLog}
 	d.SetLeafPageLog(leafLog)
+	defer closeVacuumTestLeafPageLog(t, d, baseLeafLog)
 
 	val := bytes.Repeat([]byte("v"), 64)
 	for version := 1; version <= 24; version++ {
@@ -466,6 +481,7 @@ func TestVacuumIndexOnline_RebuildsPackedInternalTreeForLeafRefs(t *testing.T) {
 		t.Fatalf("ensure leaf writer: %v", err)
 	}
 	d.SetLeafPageLog(leafLog)
+	defer closeVacuumTestLeafPageLog(t, d, leafLog)
 
 	val := bytes.Repeat([]byte("v"), 64)
 	const (
@@ -558,6 +574,7 @@ func TestVacuumIndexOnline_PreservesOuterLeafRefsAndDataWhenOuterLeavesInValueLo
 		t.Fatalf("ensure leaf writer: %v", err)
 	}
 	d.SetLeafPageLog(leafLog)
+	defer closeVacuumTestLeafPageLog(t, d, leafLog)
 
 	val := bytes.Repeat([]byte("v"), 64)
 	for version := 1; version <= 48; version++ {


### PR DESCRIPTION
## Summary

Fixes #3172.

This replaces the production leaf-ref rebuild path used by online vacuum, offline vacuum, and collection-root copy with a streaming internal-tree builder. The previous path first materialized every leaf-log child ref into a `[]vacuumLeafChild`; the Celestia soak profile attributed `471.52MB` of final heap to `TreeDB/db.vacuumCollectLeafRefChildren.func1` (`433.02MB` in the output slice backing arrays and `38.50MB` in copied child keys) while `VacuumIndexOnline` rebuilt a leaf-ref tree.

The new path walks the source tree and appends each leaf-log child ref directly into destination internal pages. It keeps only active page builders and copied start keys for the current tree levels, while mixed pager-backed roots still use the clone fallback.

## Evidence

- Prior Celestia evidence from #3164/#3172: `vacuumCollectLeafRefChildren.func1 = 471.52MB` in final heap after the merged IAVL PR #8 run.
- New asymptotic behavior: removes the O(number of leaf refs) production child list and replaces it with O(tree height) active builders plus traversal stack.
- Added regression coverage that compares streamed leaf-ref output with the existing collector on a multi-version leaf-ref fixture.

## Validation

- `GOWORK=off go test ./TreeDB/db -run 'TestVacuumBuildInternalTreeFromLeafRefs_StreamsChildren|TestVacuumIndexOnline_RebuildsPackedInternalTreeForLeafRefs|TestVacuumIndexOnline_PreservesOuterLeafRefsAndDataWhenOuterLeavesInValueLog|TestVacuumIndexOffline_OuterLeavesInValueLog_PreservesLeafRefs|TestVacuumIndexOffline_OuterLeavesInValueLog_MixedUserRootFallsBackToClone|TestVacuumIndexOffline_PreservesCollectionRootFromPointerBackedDescriptor|TestVacuumIndexOnline_PreservesCollectionRootFromPointerBackedDescriptor' -count=1` (`40.816s`)
- `GOWORK=off go test ./TreeDB/db -count=1` (`260.563s`)
- `git diff --check`

## Remaining follow-up

A fresh Celestia sync/soak should confirm the `vacuumCollectLeafRefChildren` bucket disappears from the final heap profile and then expose the next memory high-water bucket.
