### PR TITLE
TreeDB: parallelize q4 TopK setup

### DIFF
--- a/TreeDB/collections/column_physical_q4a_time_order_1950_test.go
+++ b/TreeDB/collections/column_physical_q4a_time_order_1950_test.go
@@ -2,6 +2,7 @@ package collections
 
 import (
 	"fmt"
+	"runtime"
 	"sort"
 	"testing"
 )
@@ -113,6 +114,38 @@ func TestColumnPhysicalQ4ATimeOrderTopKOneShotCache3085(t *testing.T) {
 	}
 }
 
+func TestColumnPhysicalQ4ATimeOrderTopKParallelEagerPayloads3158(t *testing.T) {
+	if oldProcs := runtime.GOMAXPROCS(0); oldProcs < 2 {
+		runtime.GOMAXPROCS(2)
+		defer runtime.GOMAXPROCS(oldProcs)
+	}
+
+	batches := columnPhysicalQ4ATimeOrderBatches1950(9_000)
+	events := flattenColumnPhysicalEvents1950(batches)
+	_, col, closeFn := openTypedColumnSortKeyFixtureBatches1950(t, []ColumnSortKey{{Column: "time_us"}}, batches)
+	defer closeFn()
+
+	scanned := scanColumnPhysicalJSONBenchParityEventsP0(t, col, len(events))
+	req := columnPhysicalQ4ATimeOrderRequest1950()
+	req.ColumnAssetReadIntegrity = ColumnAssetReadIntegrityCachedVerify
+	want := columnPhysicalQ4ATimeOrderReferenceGroups1950(scanned, req.TopK)
+	wantCandidates := columnPhysicalQ4ATimeOrderReferenceEarlyCandidates1950(scanned, req.TopK)
+
+	first, err := col.RunColumnPhysicalQuery(req)
+	if err != nil {
+		t.Fatalf("first RunColumnPhysicalQuery(q4a time-order topK cached-verify): %v", err)
+	}
+	assertColumnPhysicalQ4ATimeOrderResult1950(t, "parallel eager first one-shot", first, want, len(events), wantCandidates)
+	assertColumnPhysicalQ4ATimeOrderOneShotEagerPayloads3158(t, col, req)
+
+	second, err := col.RunColumnPhysicalQuery(req)
+	if err != nil {
+		t.Fatalf("second RunColumnPhysicalQuery(q4a time-order topK cached-verify): %v", err)
+	}
+	assertColumnPhysicalQ4ATimeOrderResult1950(t, "parallel eager second one-shot", second, want, len(events), wantCandidates)
+	assertTypedColumnOneShotCacheSnapshot3088(t, col, "after q4a parallel eager second", 1, 1, 1, 1, 0)
+}
+
 func BenchmarkColumnPhysicalQ4ATimeOrderTopK1950(b *testing.B) {
 	batches := columnPhysicalQ4ATimeOrderBatches1950(9_000)
 	events := flattenColumnPhysicalEvents1950(batches)
@@ -175,6 +208,48 @@ func BenchmarkColumnPhysicalQ4ATimeOrderTopK1950(b *testing.B) {
 			}
 			reportColumnPhysicalQ4ATimeOrderBenchMetrics1950(b, last, len(events))
 		})
+	}
+}
+
+func assertColumnPhysicalQ4ATimeOrderOneShotEagerPayloads3158(tb testing.TB, col *Collection, req ColumnPhysicalQueryRequest) {
+	tb.Helper()
+	if col == nil {
+		tb.Fatalf("nil collection")
+	}
+	wantPredicates := collectionTypedColumnOneShotPredicateKey(req)
+	var entry *collectionTypedColumnOneShotCacheEntry
+	col.typedColumnOneShotMu.Lock()
+	for slot, current := range col.typedColumnOneShot {
+		if slot.kind == req.Kind &&
+			slot.groupColumn == req.GroupColumn &&
+			slot.valueColumn == req.ValueColumn &&
+			slot.topK == req.TopK &&
+			slot.topKOrder == req.TopKOrder &&
+			slot.readIntegrity == req.ColumnAssetReadIntegrity &&
+			slot.predicates == wantPredicates {
+			entry = current
+			break
+		}
+	}
+	col.typedColumnOneShotMu.Unlock()
+	if entry == nil {
+		tb.Fatalf("q4a typed-column one-shot cache entry not found")
+	}
+	entry.mu.Lock()
+	defer entry.mu.Unlock()
+	if entry.runner == nil {
+		tb.Fatalf("q4a typed-column one-shot runner not found")
+	}
+	if got := len(entry.runner.parts); got < 2 {
+		tb.Fatalf("q4a typed-column one-shot runner parts=%d want at least 2 for parallel decode", got)
+	}
+	for partIdx, part := range entry.runner.parts {
+		if part.TimeOrderTopK == nil {
+			tb.Fatalf("q4a runner part %d missing time-order topK state", partIdx)
+		}
+		if part.TimeOrderTopK.PayloadLoader != nil {
+			tb.Fatalf("q4a runner part %d retained lazy payload loader after parallel decode", partIdx)
+		}
 	}
 }
 

--- a/TreeDB/collections/column_physical_typed_column_one_shot_cache_3088_test.go
+++ b/TreeDB/collections/column_physical_typed_column_one_shot_cache_3088_test.go
@@ -174,9 +174,10 @@ func TestColumnPhysicalTypedColumnParallelPartDecodeShapes3158(t *testing.T) {
 			prepareDenseGroupCountDistinctGlobalRanks: true,
 		},
 		{
-			name: "q4 time-order TopK keeps serial lazy payload loader",
+			name: "q4 time-order TopK uses parallel eager payloads",
 			plan: columnTypedColumnPhysicalQueryPlan{TimeOrderTopK: true, GroupColumn: "collection", ValueColumn: "time_us"},
 			req:  baseReq(ColumnPhysicalQueryGroupMinInt64),
+			want: true,
 		},
 		{
 			name:                             "global int64 codes stay serial",

--- a/TreeDB/collections/column_physical_typed_column_query.go
+++ b/TreeDB/collections/column_physical_typed_column_query.go
@@ -198,6 +198,10 @@ type columnTypedColumnPhysicalQueryPartDecodeOutput struct {
 	part columnTypedColumnPhysicalQueryPart
 }
 
+type columnTypedColumnPhysicalQueryPartDecodeOptions struct {
+	eagerTimeOrderTopKPayloads bool
+}
+
 type columnTypedColumnPhysicalAggregateSummary struct {
 	groups              []ColumnPhysicalQueryGroup
 	matchedRows         int
@@ -544,7 +548,12 @@ func decodeColumnTypedColumnPhysicalQueryRunnerParts(view columnPhysicalScanSnap
 		})
 	}
 	if columnTypedColumnPhysicalQueryUseParallelPartDecode(plan, req, readCache, len(inputs), includePhysicalRows, allowDenseGroupCountDistinct, prepareDenseInt64SpanGlobalCodes, prepareDenseGroupCountDistinctGlobalCodes, prepareDenseGroupCountDistinctGlobalRanks) {
-		outputs, hits, misses, err := decodeColumnTypedColumnPhysicalQueryRunnerPartsParallel(view, req, plan, inputs, readCache, includePhysicalRows, allowDenseGroupCountDistinct)
+		// Worker read caches close after decode, so parallel TopK runners must
+		// own payload bytes instead of retaining lazy range readers.
+		decodeOpts := columnTypedColumnPhysicalQueryPartDecodeOptions{
+			eagerTimeOrderTopKPayloads: columnTypedColumnPhysicalQueryUseTimeOrderTopK(plan, req),
+		}
+		outputs, hits, misses, err := decodeColumnTypedColumnPhysicalQueryRunnerPartsParallel(view, req, plan, inputs, readCache, includePhysicalRows, allowDenseGroupCountDistinct, decodeOpts)
 		if err != nil {
 			return nil, err
 		}
@@ -556,7 +565,7 @@ func decodeColumnTypedColumnPhysicalQueryRunnerParts(view columnPhysicalScanSnap
 	} else {
 		var rawScratch []byte
 		for _, input := range inputs {
-			part, scratch, err := decodeColumnTypedColumnPhysicalQueryRunnerPart(view, req, plan, input.typedRef, input.physical, readCache, includePhysicalRows, allowDenseGroupCountDistinct, rawScratch)
+			part, scratch, err := decodeColumnTypedColumnPhysicalQueryRunnerPart(view, req, plan, input.typedRef, input.physical, readCache, includePhysicalRows, allowDenseGroupCountDistinct, columnTypedColumnPhysicalQueryPartDecodeOptions{}, rawScratch)
 			runner.segmentFileCacheHits = readCache.hits
 			runner.segmentFileCacheMisses = readCache.misses
 			if err != nil {
@@ -589,8 +598,8 @@ func decodeColumnTypedColumnPhysicalQueryRunnerParts(view columnPhysicalScanSnap
 	return runner, nil
 }
 
-func decodeColumnTypedColumnPhysicalQueryRunnerPart(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest, plan columnTypedColumnPhysicalQueryPlan, typedRef, physical columnManifestAssetRefForScan, readCache *columnPhysicalAssetReadCache, includePhysicalRows bool, allowDenseGroupCountDistinct bool, rawScratch []byte) (columnTypedColumnPhysicalQueryPart, []byte, error) {
-	part, rangeOK, err := decodeTypedColumnPhysicalQueryDensePartFromRanges(plan, req, view.FullConfig.SchemaHash, typedRef, physical, readCache, allowDenseGroupCountDistinct, includePhysicalRows)
+func decodeColumnTypedColumnPhysicalQueryRunnerPart(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest, plan columnTypedColumnPhysicalQueryPlan, typedRef, physical columnManifestAssetRefForScan, readCache *columnPhysicalAssetReadCache, includePhysicalRows bool, allowDenseGroupCountDistinct bool, opts columnTypedColumnPhysicalQueryPartDecodeOptions, rawScratch []byte) (columnTypedColumnPhysicalQueryPart, []byte, error) {
+	part, rangeOK, err := decodeTypedColumnPhysicalQueryDensePartFromRanges(plan, req, view.FullConfig.SchemaHash, typedRef, physical, readCache, allowDenseGroupCountDistinct, includePhysicalRows, opts)
 	if err != nil {
 		return columnTypedColumnPhysicalQueryPart{}, rawScratch, fmt.Errorf("collections: typed-column part physical query range decode generation=%d part_id=%d: %w", typedRef.Ref.Generation, typedRef.Ref.PartID, err)
 	}
@@ -645,7 +654,8 @@ func columnTypedColumnPhysicalQueryUseParallelPartDecode(plan columnTypedColumnP
 	}
 	return columnTypedColumnPhysicalQueryUseDenseGroupCount(plan, req) ||
 		columnTypedColumnPhysicalQueryUseDenseGroupHourCount(plan, req) ||
-		columnTypedColumnPhysicalQueryUseDenseInt64Span(plan, req)
+		columnTypedColumnPhysicalQueryUseDenseInt64Span(plan, req) ||
+		columnTypedColumnPhysicalQueryUseTimeOrderTopK(plan, req)
 }
 
 func columnTypedColumnPhysicalQueryPartDecodeWorkers(partCount int) int {
@@ -660,7 +670,7 @@ func columnTypedColumnPhysicalQueryPartDecodeWorkers(partCount int) int {
 	return workers
 }
 
-func decodeColumnTypedColumnPhysicalQueryRunnerPartsParallel(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest, plan columnTypedColumnPhysicalQueryPlan, inputs []columnTypedColumnPhysicalQueryPartDecodeInput, readCache *columnPhysicalAssetReadCache, includePhysicalRows bool, allowDenseGroupCountDistinct bool) ([]columnTypedColumnPhysicalQueryPartDecodeOutput, uint64, uint64, error) {
+func decodeColumnTypedColumnPhysicalQueryRunnerPartsParallel(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest, plan columnTypedColumnPhysicalQueryPlan, inputs []columnTypedColumnPhysicalQueryPartDecodeInput, readCache *columnPhysicalAssetReadCache, includePhysicalRows bool, allowDenseGroupCountDistinct bool, opts columnTypedColumnPhysicalQueryPartDecodeOptions) ([]columnTypedColumnPhysicalQueryPartDecodeOutput, uint64, uint64, error) {
 	workers := columnTypedColumnPhysicalQueryPartDecodeWorkers(len(inputs))
 	if workers < 2 {
 		return nil, 0, 0, errors.New("collections: typed-column part physical query parallel decode missing workers")
@@ -700,7 +710,7 @@ func decodeColumnTypedColumnPhysicalQueryRunnerPartsParallel(view columnPhysical
 			}()
 			var rawScratch []byte
 			for input := range jobs {
-				part, scratch, err := decodeColumnTypedColumnPhysicalQueryRunnerPart(view, req, plan, input.typedRef, input.physical, cache, includePhysicalRows, allowDenseGroupCountDistinct, rawScratch)
+				part, scratch, err := decodeColumnTypedColumnPhysicalQueryRunnerPart(view, req, plan, input.typedRef, input.physical, cache, includePhysicalRows, allowDenseGroupCountDistinct, opts, rawScratch)
 				if err != nil {
 					setErr(err)
 					continue

--- a/TreeDB/collections/typed_column_adapter.go
+++ b/TreeDB/collections/typed_column_adapter.go
@@ -1443,7 +1443,7 @@ func decodeTypedColumnPhysicalQueryDenseGroupHourCountPart(plan columnTypedColum
 	return part, nil
 }
 
-func decodeTypedColumnPhysicalQueryDensePartFromRanges(plan columnTypedColumnPhysicalQueryPlan, req ColumnPhysicalQueryRequest, schemaHash uint64, typedRef, physical columnManifestAssetRefForScan, readCache *columnPhysicalAssetReadCache, allowDenseGroupCountDistinct bool, includePhysicalRows bool) (columnTypedColumnPhysicalQueryPart, bool, error) {
+func decodeTypedColumnPhysicalQueryDensePartFromRanges(plan columnTypedColumnPhysicalQueryPlan, req ColumnPhysicalQueryRequest, schemaHash uint64, typedRef, physical columnManifestAssetRefForScan, readCache *columnPhysicalAssetReadCache, allowDenseGroupCountDistinct bool, includePhysicalRows bool, opts columnTypedColumnPhysicalQueryPartDecodeOptions) (columnTypedColumnPhysicalQueryPart, bool, error) {
 	if !typedColumnStringUseTargetedRanges(req.ColumnAssetReadIntegrity) {
 		return columnTypedColumnPhysicalQueryPart{}, false, nil
 	}
@@ -1478,11 +1478,14 @@ func decodeTypedColumnPhysicalQueryDensePartFromRanges(plan columnTypedColumnPhy
 		return columnTypedColumnPhysicalQueryPart{}, true, err
 	}
 	if columnTypedColumnPhysicalQueryUseTimeOrderTopK(plan, req) {
-		adapterPart, err := typedColumnPhysicalQueryPreparedAdapterPartWithOptions(prepared, plan.Fields, reader.readRange, typedColumnPreparedAdapterPartOptions{LazyPayloads: true})
+		adapterPart, err := typedColumnPhysicalQueryPreparedAdapterPartWithOptions(prepared, plan.Fields, reader.readRange, typedColumnPreparedAdapterPartOptions{LazyPayloads: !opts.eagerTimeOrderTopKPayloads})
 		if err != nil {
 			return columnTypedColumnPhysicalQueryPart{}, true, err
 		}
-		payloadLoader := newColumnTypedColumnTimeOrderTopKPayloadLoader(reader.readRangeOwned, prepared)
+		var payloadLoader *columnTypedColumnTimeOrderTopKPayloadLoader
+		if !opts.eagerTimeOrderTopKPayloads {
+			payloadLoader = newColumnTypedColumnTimeOrderTopKPayloadLoader(reader.readRangeOwned, prepared)
+		}
 		part, err := decodeTypedColumnPhysicalQueryTimeOrderTopKPreparedPart(plan, summary, typedRef, physical, adapterPart, reader.bytesRead, payloadLoader)
 		return part, true, err
 	}


### PR DESCRIPTION
Parent tracker: #3158
Root realigned goal: #3000

## Scope

This is a narrow `q4` / time-order TopK setup slice for the realigned JSONBench goal.

It improves production-shape `one_shot_end_to_end` and `first_touch_after_open` setup for `metadata_mode=no_aggregate_metadata` bounded TopK queries by allowing q4 typed-column parts to use the existing parallel part-decode path.

This PR does **not** claim broad SQL superiority, insert/load improvement, storage reduction, aggregate-metadata acceleration, or q1/q2/q3/q5 improvement. q4 remains reported separately as a bounded TopK/sort-mark path, not aggregate metadata.

## Implementation

- Admits `TimeOrderTopK` q4 plans into the existing typed-column parallel part-decode gate when the normal safety checks pass.
- Uses eager payload ownership only for the parallel q4 decode path. Worker read caches close after decode, so parallel q4 runners must not retain lazy payload range readers.
- Leaves the serial path on the existing lazy-payload behavior.
- Adds a cached-verify q4 one-shot test that proves the cached runner has multiple parts and no retained lazy payload loader.

## Evidence

TreeDB 1M full-retained JSON, `column-store-full-prepared`, `metadata_mode=no_aggregate_metadata`, `TRIES=1`, JSONBench `8477b48`, gomap `897422a`, WAL excluded from durable storage.

First-touch artifact: `/tmp/jsonbench_q4_topk_eager_parallel_3158_20260627_045503`

| query | baseline after #3171 total/setup/run | PR total/setup/run | rows scanned | physical bytes | decoded payload bytes | aggregate metadata | TopK/sort path | materializations |
|---|---:|---:|---:|---:|---:|---|---|---:|
| q4 | 101.200 / 100.691 / 0.494 ms | 31.238 / 30.725 / 0.498 ms | 9 | 18,010,957 | 285,914 | no | yes | 0 / 0 |
| q4a | 0.607 / 0 / 0.599 ms | 0.402 / 0 / 0.398 ms | 9 | 18,010,957 | 285,914 | no | yes | 0 / 0 |
| q4b | 0.399 / 0 / 0.396 ms | 0.332 / 0 / 0.330 ms | 9 | 18,010,957 | 285,914 | no | yes | 0 / 0 |

Primary one-shot artifact: `/tmp/jsonbench_oneshot_noagg_q4_eager_parallel_3158_20260627_045601`

| query | baseline after #3171 total/setup/run | PR total/setup/run | rows scanned | physical bytes | decoded payload bytes | aggregate metadata | TopK/sort path | materializations |
|---|---:|---:|---:|---:|---:|---|---|---:|
| q4 | 96.240 / 95.724 / 0.505 ms | 31.800 / 31.282 / 0.506 ms | 9 | 18,010,957 | 285,914 | no | yes | 0 / 0 |
| q4a | 0.406 / 0 / 0.403 ms | 0.422 / 0 / 0.418 ms | 9 | 18,010,957 | 285,914 | no | yes | 0 / 0 |
| q4b | 0.332 / 0 / 0.330 ms | 0.353 / 0 / 0.350 ms | 9 | 18,010,957 | 285,914 | no | yes | 0 / 0 |

Tradeoff: q4 physical bytes increase from the #3171 baseline `10,502,828` bytes to `18,010,957` bytes because the parallel path eagerly owns targeted payloads instead of retaining lazy readers. The wall-time setup reduction is the reason to accept this tradeoff for `one_shot_end_to_end` / `first_touch_after_open`.

Load/storage accounting from the PR evidence runs:

| mode | rows loaded | load wall | insert | WAL-excluded durable storage | aggregate metadata bytes | typed-column part bytes |
|---|---:|---:|---:|---:|---:|---:|
| first_touch_after_open | 1,000,000 | 18.533s | 15.239s | 137,491,619 | 5,860,282 | 21,632,156 |
| one_shot_end_to_end | 1,000,000 | 18.854s | 15.533s | 137,491,619 | 5,860,282 | 21,632,156 |

The full-suite rows in those artifacts keep q1/q2/q3/q5/qexpr in the same general range as #3171. This PR should not be interpreted as closing #3158 by itself; q2 and insert/load remain separate tracker work, and the ClickHouse q4 reference in #3158 remains about 14 ms.

## Validation

```sh
go test ./TreeDB/collections -run 'TestColumnPhysicalTypedColumnParallelPartDecodeShapes3158|TestColumnPhysicalQ4ATimeOrderTopKParallelEagerPayloads3158|TestColumnPhysicalQ4ATimeOrderTopKOneShotCache3085|TestColumnPhysicalQ4ATimeOrderTopKDirectPreparedParity1950|TestColumnPhysicalDenseTypedColumnTargetedRangeReads3090|TestColumnPhysicalTypedColumnOneShotCacheQ1Q3NoMetadata3088|TestColumnPhysicalTypedColumnOneShotCacheQ5NoMetadata3088|TestColumnPhysicalTypedColumnOneShotCacheQ2NoMetadata3123' -count=1

go test -race ./TreeDB/collections -run 'TestColumnPhysicalQ4ATimeOrderTopKParallelEagerPayloads3158|TestColumnPhysicalQ4ATimeOrderTopKOneShotCache3085|TestColumnPhysicalQ4ATimeOrderTopKDirectPreparedParity1950|TestColumnPhysicalTypedColumnOneShotCacheQ1Q3NoMetadata3088|TestColumnPhysicalTypedColumnOneShotCacheQ5NoMetadata3088|TestColumnPhysicalTypedColumnOneShotCacheQ2NoMetadata3123' -count=1

go test ./cmd/unified_bench -run 'FirstTouch|ColumnStore.*Query|ColumnStore.*MetadataMode|ColumnStorePhaseDurations' -count=1

go test ./TreeDB/collections -count=1

git diff --check
```

Benchmark commands:

```sh
cd /Users/michaelseiler/dev/snissn/JSONBench/treedb
OUT_DIR=/tmp/jsonbench_q4_topk_eager_parallel_3158_$(date +%Y%m%d_%H%M%S) \
DATA_DIR=/Users/michaelseiler/data/bluesky ROWS=1000000 TRIES=1 \
QUERY_MODE=first_touch_after_open METADATA_MODE=no_aggregate_metadata \
STORAGE_LAYOUTS=column-store-full-prepared QUERY_CELLS='q4 q4a q4b' \
SUITE=full TREEDB_ALLOW_ERRORS=1 \
GOMAP_REPLACE=/private/tmp/gomap_3158_q2_dict_next_20260627 \
./run_columnstore_benchmark.sh

OUT_DIR=/tmp/jsonbench_oneshot_noagg_q4_eager_parallel_3158_$(date +%Y%m%d_%H%M%S) \
DATA_DIR=/Users/michaelseiler/data/bluesky ROWS=1000000 TRIES=1 \
QUERY_MODE=one_shot_end_to_end METADATA_MODE=no_aggregate_metadata \
STORAGE_LAYOUTS=column-store-full-prepared QUERY_CELLS='q4 q4a q4b' \
SUITE=full TREEDB_ALLOW_ERRORS=1 \
GOMAP_REPLACE=/private/tmp/gomap_3158_q2_dict_next_20260627 \
./run_columnstore_benchmark.sh
```
