### PR TITLE
TreeDB: bound leaf-generation grouped frame scan cache

### DIFF
--- a/TreeDB/db/leaf_generation_plan.go
+++ b/TreeDB/db/leaf_generation_plan.go
@@ -30,6 +30,8 @@ const (
 	leafGenerationPlanSkipWholeGenerationGC  = "whole_generation_gc_candidate"
 	leafGenerationPlanSkipFreshGeneration    = "fresh_generation"
 	leafGenerationPlanSkipNoDeadBytes        = "no_dead_bytes"
+
+	leafGenerationGroupedFrameScanCacheEntries = 2048
 )
 
 type LeafGenerationPlanOptions struct {
@@ -116,7 +118,7 @@ type leafGenerationScanContext struct {
 	lastFileID    uint32
 	lastFileState *leafGenerationScanFileState
 	childStacks   [][]uint64
-	groupedFrames map[groupedRecordKey]leafGenerationGroupedFrameInfo
+	groupedFrames leafGenerationGroupedFrameScanCache
 }
 
 type leafGenerationLiveStatsScanOptions struct {
@@ -600,6 +602,58 @@ type leafGenerationGroupedFrameInfo struct {
 	offsets   [valuelog.MaxFrameK + 1]uint32
 }
 
+type leafGenerationGroupedFrameScanCache struct {
+	max    int
+	frames map[groupedRecordKey]leafGenerationGroupedFrameInfo
+	order  []groupedRecordKey
+	next   int
+}
+
+func newLeafGenerationGroupedFrameScanCache(max int) leafGenerationGroupedFrameScanCache {
+	return leafGenerationGroupedFrameScanCache{max: max}
+}
+
+func (cache *leafGenerationGroupedFrameScanCache) get(key groupedRecordKey) (leafGenerationGroupedFrameInfo, bool) {
+	if cache == nil || cache.frames == nil {
+		return leafGenerationGroupedFrameInfo{}, false
+	}
+	info, ok := cache.frames[key]
+	return info, ok
+}
+
+func (cache *leafGenerationGroupedFrameScanCache) store(key groupedRecordKey, info leafGenerationGroupedFrameInfo) {
+	if cache == nil || cache.max <= 0 {
+		return
+	}
+	if cache.frames == nil {
+		cache.frames = make(map[groupedRecordKey]leafGenerationGroupedFrameInfo, min(cache.max, 64))
+	}
+	if _, ok := cache.frames[key]; ok {
+		cache.frames[key] = info
+		return
+	}
+	if len(cache.frames) < cache.max {
+		cache.frames[key] = info
+		cache.order = append(cache.order, key)
+		return
+	}
+	if cache.next < 0 || cache.next >= len(cache.order) {
+		cache.next = 0
+	}
+	evict := cache.order[cache.next]
+	delete(cache.frames, evict)
+	cache.order[cache.next] = key
+	cache.next = (cache.next + 1) % len(cache.order)
+	cache.frames[key] = info
+}
+
+func (cache *leafGenerationGroupedFrameScanCache) len() int {
+	if cache == nil {
+		return 0
+	}
+	return len(cache.frames)
+}
+
 func (info leafGenerationGroupedFrameInfo) liveByteContribution(subIndex uint16) (uint32, bool) {
 	if info.k <= 1 {
 		if info.recordLen == 0 {
@@ -643,10 +697,8 @@ func (db *DB) leafGenerationGroupedFrameInfo(scan *leafGenerationScanContext, pt
 	if err != nil {
 		return leafGenerationGroupedFrameInfo{}, false, err
 	}
-	if scan.groupedFrames != nil {
-		if info, ok := scan.groupedFrames[key]; ok {
-			return info, true, nil
-		}
+	if info, ok := scan.groupedFrames.get(key); ok {
+		return info, true, nil
 	}
 	f := scan.snap.state.ValueLogSet.Files[vptr.FileID]
 	if f == nil || f.File == nil {
@@ -720,10 +772,7 @@ func (db *DB) leafGenerationGroupedFrameInfo(scan *leafGenerationScanContext, pt
 		off += 4
 	}
 	info.rawLen = info.offsets[k]
-	if scan.groupedFrames == nil {
-		scan.groupedFrames = make(map[groupedRecordKey]leafGenerationGroupedFrameInfo, 64)
-	}
-	scan.groupedFrames[key] = info
+	scan.groupedFrames.store(key, info)
 	return info, true, nil
 }
 
@@ -913,6 +962,7 @@ func (db *DB) scanLeafGenerationLiveStatsWithOptions(ctx context.Context, snap *
 		fileStateByID: fileStateByID,
 		memo:          make(map[uint64]leafGenerationSubtreeStats, 64),
 		cacheEnabled:  !opts.DisableCache && !verifyAlways,
+		groupedFrames: newLeafGenerationGroupedFrameScanCache(leafGenerationGroupedFrameScanCacheEntries),
 	}
 	roots, err := maintenanceRootsForSnapshotWithContext(ctx, snap)
 	if err != nil {

--- a/TreeDB/db/leaf_generation_plan_test.go
+++ b/TreeDB/db/leaf_generation_plan_test.go
@@ -201,6 +201,37 @@ func TestLeafGenerationGroupedFrameInfo_LiveByteContributionKeepsSparseRefsNonZe
 	}
 }
 
+func TestLeafGenerationGroupedFrameScanCache_BoundsEntries(t *testing.T) {
+	cache := newLeafGenerationGroupedFrameScanCache(2)
+	first := groupedRecordKey{fileID: 1, start: 100}
+	second := groupedRecordKey{fileID: 1, start: 200}
+	third := groupedRecordKey{fileID: 1, start: 300}
+
+	cache.store(first, leafGenerationGroupedFrameInfo{recordLen: 10, k: 2})
+	cache.store(second, leafGenerationGroupedFrameInfo{recordLen: 20, k: 2})
+	cache.store(first, leafGenerationGroupedFrameInfo{recordLen: 11, k: 2})
+	if got := cache.len(); got != 2 {
+		t.Fatalf("cache len after update=%d, want 2", got)
+	}
+	if info, ok := cache.get(first); !ok || info.recordLen != 11 {
+		t.Fatalf("updated first entry=(%+v,%t), want recordLen 11 hit", info, ok)
+	}
+
+	cache.store(third, leafGenerationGroupedFrameInfo{recordLen: 30, k: 2})
+	if got := cache.len(); got != 2 {
+		t.Fatalf("cache len after eviction=%d, want 2", got)
+	}
+	if _, ok := cache.get(first); ok {
+		t.Fatalf("first entry still cached after bounded FIFO eviction")
+	}
+	if _, ok := cache.get(second); !ok {
+		t.Fatalf("second entry missing after eviction")
+	}
+	if _, ok := cache.get(third); !ok {
+		t.Fatalf("third entry missing after insert")
+	}
+}
+
 func TestLeafGenerationPlan_SeparatesWholeGenerationGCFromPack(t *testing.T) {
 	db, leafLog := openLeafGenerationGCTestDB(t)
 


### PR DESCRIPTION
## Summary

- replace the leaf-generation live-scan grouped-frame metadata map with a capped FIFO cache
- keep grouped-frame live-byte accounting semantics unchanged while bounding retained scan-only metadata
- add a focused regression for cache boundedness and eviction

## Evidence

Baseline from #3176 post-PR #3173 Celestia run:

- final heap profile: `leafGenerationGroupedFrameInfo` `816.09MB` flat, `scanLeafGenerationPtrTotals` `824.59MB` cumulative
- run home: `/home/mikers/.celestia-app-mainnet-treedb-20260627053115`
- final process RSS / heap in-use: `11196502016 B` / `7574102016 B`

Expected effect: the scan can retain at most `2048` grouped-frame metadata entries instead of one entry per unique grouped record encountered across the full live-stat scan. The cache remains operation-local and only avoids repeat prefix/header reads; liveness accounting still comes from the same `liveByteContribution` calculation.

## Local Validation

- `GOWORK=off go test ./TreeDB/db -run 'TestLeafGenerationGroupedFrameInfo|TestLeafGenerationGroupedFrameScanCache|TestLeafGenerationPlan_ReportsZeroBytesForMissingManifestFile|TestLeafGenerationPlan_AgeGateAndForceOnSparseGeneration|TestLeafGenerationPlan_SeparatesWholeGenerationGCFromPack' -count=1`
- `GOWORK=off go test ./TreeDB/db -count=1`
- `git diff --check`

Refs #3176.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability and memory usage during live-tree scanning by limiting cached grouped-frame results.
  * Ensured repeated lookups reuse stored scan results efficiently, with older entries automatically evicted when the cache fills.
* **Tests**
  * Added coverage for cache size limits, entry updates, and eviction behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->