### PR TITLE
TreeDB: preapply q5 dense predicates

### DIFF
--- a/TreeDB/collections/column_physical_typed_column_query.go
+++ b/TreeDB/collections/column_physical_typed_column_query.go
@@ -90,14 +90,17 @@ type columnTypedColumnDenseGroupHourCountPart struct {
 }
 
 type columnTypedColumnDenseInt64SpanPart struct {
-	Cardinality      int
-	DictionaryByCode map[int64]string
-	GroupCodes       []uint32
-	GroupValid       []bool
-	GlobalRanks      []uint32
-	GlobalDictionary []string
-	Values           []int64
-	Predicates       []columnTypedColumnDensePredicatePart
+	Cardinality           int
+	DictionaryByCode      map[int64]string
+	GroupCodes            []uint32
+	GroupValid            []bool
+	GlobalRanks           []uint32
+	GlobalDictionary      []string
+	Values                []int64
+	Predicates            []columnTypedColumnDensePredicatePart
+	PredicatesPreApplied  bool
+	PredicateRows         []uint32
+	PreAppliedRowsScanned int
 }
 
 type columnTypedColumnSortedGroupedDistinctCodeColumn struct {
@@ -620,7 +623,7 @@ func decodeColumnTypedColumnPhysicalQueryRunnerPart(view columnPhysicalScanSnaps
 	case columnTypedColumnPhysicalQueryUseDenseGroupHourCount(plan, req):
 		part, err = decodeTypedColumnPhysicalQueryDenseGroupHourCountPart(plan, view.FullConfig.SchemaHash, typedRef, physical, raw)
 	case columnTypedColumnPhysicalQueryUseDenseInt64Span(plan, req):
-		part, err = decodeTypedColumnPhysicalQueryDenseInt64SpanPart(plan, view.FullConfig.SchemaHash, typedRef, physical, raw)
+		part, err = decodeTypedColumnPhysicalQueryDenseInt64SpanPart(plan, view.FullConfig.SchemaHash, typedRef, physical, raw, true)
 	case columnTypedColumnPhysicalQueryUseTimeOrderTopK(plan, req):
 		part, err = decodeTypedColumnPhysicalQueryTimeOrderTopKPart(plan, view.FullConfig.SchemaHash, typedRef, physical, raw, includePhysicalRows)
 	case columnTypedColumnPhysicalQueryUseSortedGroupedDistinct(plan, req):
@@ -2186,22 +2189,35 @@ func (r *columnTypedColumnPhysicalQueryRunner) runLatestVisibleDenseInt64Span(vi
 			r.denseLocalSpanSeen = r.denseLocalSpanSeen[:dense.Cardinality]
 			clear(r.denseLocalSpanSeen)
 		}
-		if columnTypedColumnDensePredicatesRejectAll(dense.Predicates) {
+		preAppliedPredicates := dense.PredicatesPreApplied
+		if preAppliedPredicates {
+			rowsScanned += dense.PreAppliedRowsScanned
+		} else if columnTypedColumnDensePredicatesRejectAll(dense.Predicates) {
 			rowsScanned += len(dense.GroupCodes)
 			continue
 		}
-		for rowIdx, code := range dense.GroupCodes {
-			rowsScanned++
+		rowCount := len(dense.GroupCodes)
+		if preAppliedPredicates {
+			rowCount = len(dense.PredicateRows)
+		}
+		for selectedIdx := 0; selectedIdx < rowCount; selectedIdx++ {
+			rowIdx := selectedIdx
+			if preAppliedPredicates {
+				rowIdx = int(dense.PredicateRows[selectedIdx])
+			} else {
+				rowsScanned++
+			}
 			if !visibility.rowVisible(rowIdx) {
 				continue
 			}
-			if !columnTypedColumnDensePredicatesMatch(dense.Predicates, rowIdx) {
+			if !preAppliedPredicates && !columnTypedColumnDensePredicatesMatch(dense.Predicates, rowIdx) {
 				continue
 			}
 			if len(dense.Predicates) != 0 {
 				matchedRows++
 			}
 			reduceRows++
+			code := dense.GroupCodes[rowIdx]
 			if !columnTypedColumnDenseCodeValid(dense.GroupValid, rowIdx) {
 				if req.SkipEmptyGroupKey {
 					continue
@@ -3740,13 +3756,25 @@ func (r *columnTypedColumnPhysicalQueryRunner) runDenseInt64SpanGlobalCodes(view
 	reduceRows := 0
 	for partIdx := range r.parts {
 		dense := r.parts[partIdx].DenseInt64Span
-		if columnTypedColumnDensePredicatesRejectAll(dense.Predicates) {
+		preAppliedPredicates := dense.PredicatesPreApplied
+		if preAppliedPredicates {
+			rowsScanned += dense.PreAppliedRowsScanned
+		} else if columnTypedColumnDensePredicatesRejectAll(dense.Predicates) {
 			rowsScanned += len(dense.GroupCodes)
 			continue
 		}
-		for rowIdx := range dense.GroupCodes {
-			rowsScanned++
-			if !columnTypedColumnDensePredicatesMatch(dense.Predicates, rowIdx) {
+		rowCount := len(dense.GroupCodes)
+		if preAppliedPredicates {
+			rowCount = len(dense.PredicateRows)
+		}
+		for selectedIdx := 0; selectedIdx < rowCount; selectedIdx++ {
+			rowIdx := selectedIdx
+			if preAppliedPredicates {
+				rowIdx = int(dense.PredicateRows[selectedIdx])
+			} else {
+				rowsScanned++
+			}
+			if !preAppliedPredicates && !columnTypedColumnDensePredicatesMatch(dense.Predicates, rowIdx) {
 				continue
 			}
 			if len(dense.Predicates) != 0 {
@@ -3869,19 +3897,32 @@ func (r *columnTypedColumnPhysicalQueryRunner) runDenseInt64SpanLocalMap(view co
 			r.denseLocalSpanSeen = r.denseLocalSpanSeen[:dense.Cardinality]
 			clear(r.denseLocalSpanSeen)
 		}
-		if columnTypedColumnDensePredicatesRejectAll(dense.Predicates) {
+		preAppliedPredicates := dense.PredicatesPreApplied
+		if preAppliedPredicates {
+			rowsScanned += dense.PreAppliedRowsScanned
+		} else if columnTypedColumnDensePredicatesRejectAll(dense.Predicates) {
 			rowsScanned += len(dense.GroupCodes)
 			continue
 		}
-		for rowIdx, code := range dense.GroupCodes {
-			rowsScanned++
-			if !columnTypedColumnDensePredicatesMatch(dense.Predicates, rowIdx) {
+		rowCount := len(dense.GroupCodes)
+		if preAppliedPredicates {
+			rowCount = len(dense.PredicateRows)
+		}
+		for selectedIdx := 0; selectedIdx < rowCount; selectedIdx++ {
+			rowIdx := selectedIdx
+			if preAppliedPredicates {
+				rowIdx = int(dense.PredicateRows[selectedIdx])
+			} else {
+				rowsScanned++
+			}
+			if !preAppliedPredicates && !columnTypedColumnDensePredicatesMatch(dense.Predicates, rowIdx) {
 				continue
 			}
 			if len(dense.Predicates) != 0 {
 				matchedRows++
 			}
 			reduceRows++
+			code := dense.GroupCodes[rowIdx]
 			if !columnTypedColumnDenseCodeValid(dense.GroupValid, rowIdx) {
 				if req.SkipEmptyGroupKey {
 					continue

--- a/TreeDB/collections/typed_column_adapter.go
+++ b/TreeDB/collections/typed_column_adapter.go
@@ -1416,7 +1416,7 @@ func decodeTypedColumnPhysicalQueryDenseGroupCountPart(plan columnTypedColumnPhy
 // routing does not import the typedcolumn data plane directly.
 func decodeTypedColumnPhysicalQueryDenseGroupHourCountPart(plan columnTypedColumnPhysicalQueryPlan, schemaHash uint64, typedRef, physical columnManifestAssetRefForScan, raw []byte) (columnTypedColumnPhysicalQueryPart, error) {
 	spanPlan, groupPredicate, hasGroupPredicate := columnTypedColumnPhysicalQueryDenseGroupHourSpanPlan(plan)
-	part, err := decodeTypedColumnPhysicalQueryDenseInt64SpanPart(spanPlan, schemaHash, typedRef, physical, raw)
+	part, err := decodeTypedColumnPhysicalQueryDenseInt64SpanPart(spanPlan, schemaHash, typedRef, physical, raw, false)
 	if err != nil {
 		return columnTypedColumnPhysicalQueryPart{}, err
 	}
@@ -1504,7 +1504,7 @@ func decodeTypedColumnPhysicalQueryDensePartFromRanges(plan columnTypedColumnPhy
 		part, err := decodeTypedColumnPhysicalQueryDenseGroupHourCountPreparedPart(plan, summary, typedRef, physical, adapterPart, reader.bytesRead)
 		return part, true, err
 	case columnTypedColumnPhysicalQueryUseDenseInt64Span(plan, req):
-		part, err := decodeTypedColumnPhysicalQueryDenseInt64SpanPreparedPart(plan, summary, typedRef, physical, adapterPart, reader.bytesRead)
+		part, err := decodeTypedColumnPhysicalQueryDenseInt64SpanPreparedPart(plan, summary, typedRef, physical, adapterPart, reader.bytesRead, true)
 		return part, true, err
 	default:
 		return columnTypedColumnPhysicalQueryPart{}, false, nil
@@ -1883,7 +1883,7 @@ func decodeTypedColumnPhysicalQueryDenseGroupCountDistinctPreparedPart(plan colu
 
 func decodeTypedColumnPhysicalQueryDenseGroupHourCountPreparedPart(plan columnTypedColumnPhysicalQueryPlan, summary typedColumnAdapterImageSummary, typedRef, physical columnManifestAssetRefForScan, adapterPart *typedColumnAdapterPart, bytesRead int64) (columnTypedColumnPhysicalQueryPart, error) {
 	spanPlan, groupPredicate, hasGroupPredicate := columnTypedColumnPhysicalQueryDenseGroupHourSpanPlan(plan)
-	part, err := decodeTypedColumnPhysicalQueryDenseInt64SpanPreparedPart(spanPlan, summary, typedRef, physical, adapterPart, bytesRead)
+	part, err := decodeTypedColumnPhysicalQueryDenseInt64SpanPreparedPart(spanPlan, summary, typedRef, physical, adapterPart, bytesRead, false)
 	if err != nil {
 		return columnTypedColumnPhysicalQueryPart{}, err
 	}
@@ -1910,7 +1910,7 @@ func decodeTypedColumnPhysicalQueryDenseGroupHourCountPreparedPart(plan columnTy
 	return part, nil
 }
 
-func decodeTypedColumnPhysicalQueryDenseInt64SpanPreparedPart(plan columnTypedColumnPhysicalQueryPlan, summary typedColumnAdapterImageSummary, typedRef, physical columnManifestAssetRefForScan, adapterPart *typedColumnAdapterPart, bytesRead int64) (columnTypedColumnPhysicalQueryPart, error) {
+func decodeTypedColumnPhysicalQueryDenseInt64SpanPreparedPart(plan columnTypedColumnPhysicalQueryPlan, summary typedColumnAdapterImageSummary, typedRef, physical columnManifestAssetRefForScan, adapterPart *typedColumnAdapterPart, bytesRead int64, preapplyPredicates bool) (columnTypedColumnPhysicalQueryPart, error) {
 	groupColumn, groupPartColumn, cardinality, err := typedColumnDenseStringCodeColumn(adapterPart, plan.Fields, plan.GroupColumn, "int64-span group")
 	if err != nil {
 		return columnTypedColumnPhysicalQueryPart{}, err
@@ -1975,6 +1975,17 @@ func decodeTypedColumnPhysicalQueryDenseInt64SpanPreparedPart(plan columnTypedCo
 		predicateBlocks += blocks
 	}
 
+	denseSpan := &columnTypedColumnDenseInt64SpanPart{
+		Cardinality:      cardinality,
+		DictionaryByCode: groupColumn.ReverseDictionary,
+		GroupCodes:       groupCodes,
+		GroupValid:       groupValid,
+		Values:           values,
+		Predicates:       predicates,
+	}
+	if preapplyPredicates {
+		preapplyColumnTypedColumnDenseInt64SpanPredicates(denseSpan, summary.Rows)
+	}
 	decodedBlocks := groupBlocks + valueBlocks + predicateBlocks
 	return columnTypedColumnPhysicalQueryPart{
 		Ref:                 typedRef,
@@ -1987,15 +1998,29 @@ func decodeTypedColumnPhysicalQueryDenseInt64SpanPreparedPart(plan columnTypedCo
 		GranulesDecoded:     decodedBlocks,
 		DecodedBlocks:       decodedBlocks,
 		DecodedPayloadBytes: groupDecodedBytes + valueDecodedBytes + predicateDecodedBytes,
-		DenseInt64Span: &columnTypedColumnDenseInt64SpanPart{
-			Cardinality:      cardinality,
-			DictionaryByCode: groupColumn.ReverseDictionary,
-			GroupCodes:       groupCodes,
-			GroupValid:       groupValid,
-			Values:           values,
-			Predicates:       predicates,
-		},
+		DenseInt64Span:      denseSpan,
 	}, nil
+}
+
+func preapplyColumnTypedColumnDenseInt64SpanPredicates(dense *columnTypedColumnDenseInt64SpanPart, rows int) {
+	if dense == nil || len(dense.Predicates) == 0 || rows <= 0 {
+		return
+	}
+	if uint64(rows) > uint64(^uint32(0)) {
+		return
+	}
+	dense.PredicatesPreApplied = true
+	dense.PreAppliedRowsScanned = rows
+	if columnTypedColumnDensePredicatesRejectAll(dense.Predicates) {
+		return
+	}
+	selected := make([]uint32, 0, min(rows, 4096))
+	for rowIdx := 0; rowIdx < rows; rowIdx++ {
+		if columnTypedColumnDensePredicatesMatch(dense.Predicates, rowIdx) {
+			selected = append(selected, uint32(rowIdx))
+		}
+	}
+	dense.PredicateRows = selected
 }
 
 func densePredicateFromDictionaryCodes(codes []uint32, valid []bool, dictionaryByCode map[int64]string, cardinality int, spec columnPhysicalQueryPredicateSpec) (columnTypedColumnDensePredicatePart, error) {
@@ -2780,7 +2805,7 @@ func decodeTypedColumnNullableUint32CodesForRowRange(partColumn typedcolumn.Colu
 // decodeTypedColumnPhysicalQueryDenseInt64SpanPart prepares the q5 typed-column
 // section fast path from the adapter seam so production query routing does not
 // import the typedcolumn data plane directly.
-func decodeTypedColumnPhysicalQueryDenseInt64SpanPart(plan columnTypedColumnPhysicalQueryPlan, schemaHash uint64, typedRef, physical columnManifestAssetRefForScan, raw []byte) (columnTypedColumnPhysicalQueryPart, error) {
+func decodeTypedColumnPhysicalQueryDenseInt64SpanPart(plan columnTypedColumnPhysicalQueryPlan, schemaHash uint64, typedRef, physical columnManifestAssetRefForScan, raw []byte, preapplyPredicates bool) (columnTypedColumnPhysicalQueryPart, error) {
 	image, err := typedcolumn.ParseColumnPartImage(raw)
 	if err != nil {
 		return columnTypedColumnPhysicalQueryPart{}, err
@@ -2864,6 +2889,18 @@ func decodeTypedColumnPhysicalQueryDenseInt64SpanPart(plan columnTypedColumnPhys
 		predicateBlocks += blocks
 	}
 
+	denseSpan := &columnTypedColumnDenseInt64SpanPart{
+		Cardinality:      cardinality,
+		DictionaryByCode: groupColumn.ReverseDictionary,
+		GroupCodes:       groupCodes,
+		GroupValid:       groupValid,
+		Values:           values,
+		Predicates:       predicates,
+	}
+	if preapplyPredicates {
+		preapplyColumnTypedColumnDenseInt64SpanPredicates(denseSpan, summary.Rows)
+	}
+
 	decodedBlocks := groupBlocks + valueBlocks + predicateBlocks
 	return columnTypedColumnPhysicalQueryPart{
 		Ref:                 typedRef,
@@ -2876,14 +2913,7 @@ func decodeTypedColumnPhysicalQueryDenseInt64SpanPart(plan columnTypedColumnPhys
 		GranulesDecoded:     decodedBlocks,
 		DecodedBlocks:       decodedBlocks,
 		DecodedPayloadBytes: groupDecodedBytes + valueDecodedBytes + predicateDecodedBytes,
-		DenseInt64Span: &columnTypedColumnDenseInt64SpanPart{
-			Cardinality:      cardinality,
-			DictionaryByCode: groupColumn.ReverseDictionary,
-			GroupCodes:       groupCodes,
-			GroupValid:       groupValid,
-			Values:           values,
-			Predicates:       predicates,
-		},
+		DenseInt64Span:      denseSpan,
 	}, nil
 }
 


### PR DESCRIPTION
## Summary

This PR is a production-shape q5 slice for #3175. It pre-applies q5 dense int64-span predicates while building the q5 typed-column part state, stores the matching row indexes as compact `uint32` row ids, and lets the dense q5 reducers iterate only those selected rows. Diagnostics still report the full scanned row count, and q3's shared span decoder call sites explicitly opt out of the pre-applied predicate list.

Scope under the realigned tracker:

- Improves: `one_shot_end_to_end` q5 and cached one-shot/hot prepared q5 dense int64-span reduction in `no_aggregate_metadata` mode.
- Does not improve: insert/load path, aggregate metadata storage, ClickHouse projection/materialized-summary comparisons, or broad SQL execution claims.
- Metadata mode: no aggregate metadata. This remains a typed-column scan with bounded TopK, not an aggregate metadata win.

## Evidence

Baseline after #3174:

- Artifact: `/tmp/jsonbench_currentmain_after3174_oneshot_noagg_1m_20260627_051650/treedb/report.json`
- q5 `one_shot_end_to_end` / `no_aggregate_metadata`: 70.467 ms total
- setup 49.577 ms, run 20.872 ms, render/hash 0.018 ms
- rows scanned 1,000,000; reduce rows 86,812; TopK candidates 50,464
- physical bytes scanned 17,999,817; decoded payload bytes 34,933,080
- storage 137,491,619 bytes WAL-excluded durable; load 20.410 s; insert 16.577 s

Candidate:

- Artifact: `/tmp/jsonbench_q5_predicate_rows_uint32_candidate_3175_20260627_055859/report.json`
- q5 `one_shot_end_to_end` / `no_aggregate_metadata`: 47.610 ms total
- setup 35.965 ms, run 11.634 ms, render/hash 0.011 ms
- rows scanned 1,000,000; reduce rows 86,812; TopK candidates 50,464
- physical bytes scanned 17,999,817; decoded payload bytes 34,933,080
- storage 137,491,571 bytes WAL-excluded durable; load 17.281 s; insert 14.157 s

Saved ClickHouse comparison from the same baseline bundle remains much faster for q5:

- Artifact: `/tmp/jsonbench_currentmain_after3174_oneshot_noagg_1m_20260627_051650/clickhouse/result.json`
- ClickHouse q5: 15 ms
- ClickHouse load: 6.292 s; storage: 102,099,438 bytes

Microbenchmark, exact reverse-patch comparison:

- `/tmp/q5_predicate_rows_uint32_3175_benchstat.txt`
- `BenchmarkColumnPhysicalQ5DenseTypedColumn1950/direct_RunColumnPhysicalQuery`: 172.6 us/op -> 112.3 us/op, -34.91% (p=0.001, n=7)
- Stable counters: decoded bytes, rows scanned, rows matched, reduce rows, TopK candidates, typed sections, allocs/op.

## Tests

- `go test ./TreeDB/collections -run 'TestColumnPhysicalQ5DenseTypedColumnDirectPreparedParity1950|TestColumnPhysicalTypedColumnOneShotCacheQ5NoMetadata3088|TestColumnPhysicalTypedColumnParallelPartDecodeShapes3158|TestColumnPhysicalDenseTypedColumnTargetedRangeReads3090|TestColumnPhysicalQ3DenseTypedColumnDirectPreparedParity1950|TestColumnPhysicalQ4ATimeOrderTopKDirectPreparedParity1950' -count=1`
- `go test -race ./TreeDB/collections -run 'TestColumnPhysicalQ5DenseTypedColumnDirectPreparedParity1950|TestColumnPhysicalTypedColumnOneShotCacheQ5NoMetadata3088' -count=1`
- `go test ./cmd/unified_bench -run 'FirstTouch|ColumnStore.*Query|ColumnStore.*MetadataMode|ColumnStorePhaseDurations' -count=1`
- `go test ./TreeDB/collections ./cmd/unified_bench -count=1`
