### PR TITLE
TreeDB: decode prepared dictionaries by role

### DIFF
--- a/TreeDB/collections/typed_column_adapter.go
+++ b/TreeDB/collections/typed_column_adapter.go
@@ -10,6 +10,7 @@ import (
 	"runtime"
 	"slices"
 	"sort"
+	"strings"
 	"sync"
 
 	"github.com/snissn/gomap/TreeDB/internal/columnsemantics"
@@ -1722,12 +1723,14 @@ func typedColumnPhysicalQueryPreparedAdapterPartWithOptions(prepared *typedColum
 		}
 		adapterColumn.Definition = preparedColumn.Column.Definition
 		if preparedColumn.Dictionaries != nil {
-			if err := validateTypedColumnAdapterStringDictionary(adapterColumn, adapterColumn.Definition.Cardinality, preparedColumn.Dictionaries); err != nil {
-				return nil, err
-			}
 			adapterColumn.Dictionary = preparedColumn.Dictionaries
-			adapterColumn.ReverseDictionary = reverseTypedColumnAdapterDictionary(preparedColumn.Dictionaries)
 			dictionaries[adapterColumn.Definition.Name] = preparedColumn.Dictionaries
+		}
+		if preparedColumn.ReverseDictionaries != nil {
+			adapterColumn.ReverseDictionary = preparedColumn.ReverseDictionaries
+		}
+		if adapterColumn.ReverseDictionary == nil && adapterColumn.Dictionary != nil {
+			adapterColumn.ReverseDictionary = reverseTypedColumnAdapterDictionary(adapterColumn.Dictionary)
 		}
 		partColumn, err := typedColumnPreparedColumnWithOptionalPayloads(preparedColumn, readRange, !opts.LazyPayloads)
 		if err != nil {
@@ -2407,6 +2410,9 @@ func validateTypedColumnTimeOrderTopKMarks(part *typedcolumn.ColumnPart, valueCo
 }
 
 func timeOrderTopKAllowedCodes(column typedColumnAdapterColumn, cardinality int, spec columnPhysicalQueryPredicateSpec) ([]uint64, bool, bool, error) {
+	if column.Dictionary == nil && len(spec.values) != 0 {
+		return nil, false, false, fmt.Errorf("collections: time-order topK predicate column %q missing forward dictionary", column.Definition.Name)
+	}
 	allowed := make([]uint64, (cardinality+63)/64)
 	matchedLiterals := 0
 	missingMatchesEmpty := false
@@ -3045,15 +3051,25 @@ func typedColumnDenseStringCodeColumn(adapterPart *typedColumnAdapterPart, field
 		return typedColumnAdapterColumn{}, typedcolumn.ColumnPartColumn{}, 0, fmt.Errorf("collections: dense typed-column %s cardinality=%d exceeds host int", role, partColumn.Definition.Cardinality)
 	}
 	cardinality := int(partColumn.Definition.Cardinality)
-	if len(adapterColumn.ReverseDictionary) != cardinality {
-		return typedColumnAdapterColumn{}, typedcolumn.ColumnPartColumn{}, 0, fmt.Errorf("collections: dense typed-column %s dictionary cardinality=%d want %d for column %q", role, len(adapterColumn.ReverseDictionary), cardinality, adapterColumn.Definition.Name)
+	if typedColumnDenseStringCodeColumnNeedsForwardDictionary(role) {
+		if err := validateTypedColumnAdapterStringDictionary(adapterColumn, partColumn.Definition.Cardinality, adapterColumn.Dictionary); err != nil {
+			return typedColumnAdapterColumn{}, typedcolumn.ColumnPartColumn{}, 0, fmt.Errorf("collections: dense typed-column %s forward dictionary: %w", role, err)
+		}
 	}
-	for code := 0; code < cardinality; code++ {
-		if _, ok := adapterColumn.ReverseDictionary[int64(code)]; !ok {
-			return typedColumnAdapterColumn{}, typedcolumn.ColumnPartColumn{}, 0, fmt.Errorf("collections: dense typed-column %s dictionary missing local code %d for column %q", role, code, adapterColumn.Definition.Name)
+	if typedColumnDenseStringCodeColumnNeedsReverseDictionary(role) {
+		if len(adapterColumn.ReverseDictionary) != cardinality {
+			return typedColumnAdapterColumn{}, typedcolumn.ColumnPartColumn{}, 0, fmt.Errorf("collections: dense typed-column %s dictionary cardinality=%d want %d for column %q", role, len(adapterColumn.ReverseDictionary), cardinality, adapterColumn.Definition.Name)
 		}
 	}
 	return adapterColumn, partColumn, cardinality, nil
+}
+
+func typedColumnDenseStringCodeColumnNeedsForwardDictionary(role string) bool {
+	return strings.Contains(role, "predicate")
+}
+
+func typedColumnDenseStringCodeColumnNeedsReverseDictionary(role string) bool {
+	return !typedColumnDenseStringCodeColumnNeedsForwardDictionary(role)
 }
 
 func decodeTypedColumnDensePredicatePart(adapterPart *typedColumnAdapterPart, fields []TypedStorageField, spec columnPhysicalQueryPredicateSpec, rows int) (columnTypedColumnDensePredicatePart, uint64, int, error) {

--- a/TreeDB/collections/typed_column_adapter.go
+++ b/TreeDB/collections/typed_column_adapter.go
@@ -2410,7 +2410,15 @@ func validateTypedColumnTimeOrderTopKMarks(part *typedcolumn.ColumnPart, valueCo
 }
 
 func timeOrderTopKAllowedCodes(column typedColumnAdapterColumn, cardinality int, spec columnPhysicalQueryPredicateSpec) ([]uint64, bool, bool, error) {
-	if column.Dictionary == nil && len(spec.values) != 0 {
+	needsDictionary := false
+	for _, value := range spec.values {
+		if column.Field.Nullable && value == "" {
+			continue
+		}
+		needsDictionary = true
+		break
+	}
+	if column.Dictionary == nil && needsDictionary {
 		return nil, false, false, fmt.Errorf("collections: time-order topK predicate column %q missing forward dictionary", column.Definition.Name)
 	}
 	allowed := make([]uint64, (cardinality+63)/64)

--- a/TreeDB/collections/typed_column_adapter_test.go
+++ b/TreeDB/collections/typed_column_adapter_test.go
@@ -22,6 +22,33 @@ import (
 
 var typedColumnNullableBenchSink1784 int64
 
+func TestTimeOrderTopKAllowedCodesNullableEmptyOnlyNoDictionary3175(t *testing.T) {
+	column := typedColumnAdapterColumn{
+		Field:      typedColumnAdapterNullableField("maybe_kind", "string"),
+		Definition: typedcolumn.ColumnDefinition{Name: "maybe_kind", Type: typedcolumn.ColumnTypeLowCardinalityCode, Encoding: typedcolumn.EncodingNullableInt64, Cardinality: 2},
+	}
+	allowed, missingMatchesEmpty, rejectsAll, err := timeOrderTopKAllowedCodes(column, 2, columnPhysicalQueryPredicateSpec{
+		column: "maybe_kind",
+		values: []string{""},
+	})
+	if err != nil {
+		t.Fatalf("nullable empty-only allowed codes: %v", err)
+	}
+	if !missingMatchesEmpty || rejectsAll {
+		t.Fatalf("missingMatchesEmpty=%v rejectsAll=%v want missing match without reject-all", missingMatchesEmpty, rejectsAll)
+	}
+	if len(allowed) != 1 || allowed[0] != 0 {
+		t.Fatalf("allowed=%v want no concrete dictionary codes", allowed)
+	}
+
+	if _, _, _, err := timeOrderTopKAllowedCodes(column, 2, columnPhysicalQueryPredicateSpec{
+		column: "maybe_kind",
+		values: []string{"app.bsky.feed.post"},
+	}); err == nil || !strings.Contains(err.Error(), "missing forward dictionary") {
+		t.Fatalf("non-empty predicate without dictionary err=%v want missing forward dictionary", err)
+	}
+}
+
 func TestTypedColumnAdapterMapsTreeDBDeclaredTypes(t *testing.T) {
 	want := map[ColumnStoreValueType]typedColumnAdapterTypeStatus{
 		ColumnStoreValueBool:          typedColumnAdapterRepresented,

--- a/TreeDB/collections/typed_column_prepared_state.go
+++ b/TreeDB/collections/typed_column_prepared_state.go
@@ -111,6 +111,7 @@ type typedColumnPreparedColumnState struct {
 	PruningFallbackReason string
 	Int64PruningReady     bool
 	Dictionaries          map[string]int64
+	ReverseDictionaries   map[int64]string
 }
 
 type typedColumnPreparedPartState struct {
@@ -192,6 +193,7 @@ func (c *typedColumnPreparedColumnState) close() {
 	c.PruningFallbackReason = ""
 	c.Int64PruningReady = false
 	c.Dictionaries = nil
+	c.ReverseDictionaries = nil
 }
 
 func typedColumnPreparedStatePart(state *typedColumnPreparedScanState, ref ColumnAssetRef) (*typedColumnPreparedPartState, bool) {
@@ -1030,7 +1032,11 @@ func typedColumnAttachPreparedDictionaries(part *typedColumnPreparedPartState, i
 		return diag, err
 	}
 	diag.DecodedMetadataBytes += uint64(len(raw))
-	dictionaries, err := decodeTypedColumnPreparedDictionariesSection(raw)
+	requestedModes, err := typedColumnPreparedDictionaryRequestModes(requests)
+	if err != nil {
+		return diag, err
+	}
+	decoded, err := decodeTypedColumnPreparedDictionariesForModes(section.Encoding, raw, requestedModes)
 	if err != nil {
 		return diag, err
 	}
@@ -1046,19 +1052,95 @@ func typedColumnAttachPreparedDictionaries(part *typedColumnPreparedPartState, i
 		if column == nil {
 			return diag, fmt.Errorf("collections: typed-column prepared dictionaries missing column %q", adapterColumn.Definition.Name)
 		}
-		if err := validateTypedColumnAdapterMetadata(dictionaries, []typedColumnAdapterColumn{adapterColumn}); err != nil {
+		if err := validateTypedColumnAdapterMetadata(decoded.Forward, []typedColumnAdapterColumn{adapterColumn}); err != nil {
 			return diag, err
 		}
-		dict, ok := dictionaries[adapterColumn.Definition.Name]
-		if !ok {
-			return diag, fmt.Errorf("collections: typed-column prepared dictionaries missing dictionary for column %q", adapterColumn.Definition.Name)
+		mode := requestedModes[adapterColumn.Definition.Name]
+		if mode.Forward {
+			dict, ok := decoded.Forward[adapterColumn.Definition.Name]
+			if !ok {
+				return diag, fmt.Errorf("collections: typed-column prepared dictionaries missing dictionary for column %q", adapterColumn.Definition.Name)
+			}
+			if err := validateTypedColumnPreparedDictionaryForColumn(adapterColumn.Definition.Name, column.Column.Definition.Cardinality, dict); err != nil {
+				return diag, err
+			}
+			column.Dictionaries = dict
 		}
-		if err := validateTypedColumnPreparedDictionaryForColumn(adapterColumn.Definition.Name, column.Column.Definition.Cardinality, dict); err != nil {
-			return diag, err
+		if mode.Reverse {
+			reverse, ok := decoded.Reverse[adapterColumn.Definition.Name]
+			if !ok {
+				return diag, fmt.Errorf("collections: typed-column prepared dictionaries missing reverse dictionary for column %q", adapterColumn.Definition.Name)
+			}
+			if err := validateTypedColumnPreparedReverseDictionaryForColumn(adapterColumn.Definition.Name, column.Column.Definition.Cardinality, reverse); err != nil {
+				return diag, err
+			}
+			column.ReverseDictionaries = reverse
 		}
-		column.Dictionaries = dict
 	}
 	return diag, nil
+}
+
+type typedColumnPreparedDictionaryRequestMode struct {
+	Forward bool
+	Reverse bool
+}
+
+func typedColumnPreparedDictionaryRequestNames(requests []typedColumnPreparedColumnRequest) (map[string]struct{}, error) {
+	modes, err := typedColumnPreparedDictionaryRequestModes(requests)
+	if err != nil {
+		return nil, err
+	}
+	names := make(map[string]struct{}, len(modes))
+	for name := range modes {
+		names[name] = struct{}{}
+	}
+	return names, nil
+}
+
+func typedColumnPreparedDictionaryRequestModes(requests []typedColumnPreparedColumnRequest) (map[string]typedColumnPreparedDictionaryRequestMode, error) {
+	names := make(map[string]struct{}, len(requests)+1)
+	modes := make(map[string]typedColumnPreparedDictionaryRequestMode, len(requests)+1)
+	for _, request := range requests {
+		if !request.IncludeDictionaries {
+			continue
+		}
+		adapterColumn, err := typedColumnAdapterMapField(request.Field)
+		if err != nil {
+			return nil, err
+		}
+		name := adapterColumn.Definition.Name
+		mode := modes[name]
+		if typedColumnPreparedDictionaryRequestNeedsForward(request) {
+			mode.Forward = true
+		}
+		if typedColumnPreparedDictionaryRequestNeedsReverse(request) {
+			mode.Reverse = true
+		}
+		modes[name] = mode
+		names[name] = struct{}{}
+	}
+	if len(names) != 0 {
+		modes[typedColumnAdapterMetadataDictionary] = typedColumnPreparedDictionaryRequestMode{Forward: true}
+	}
+	return modes, nil
+}
+
+func typedColumnPreparedDictionaryRequestNeedsForward(request typedColumnPreparedColumnRequest) bool {
+	switch request.Role {
+	case typedcolumn.ColumnRolePredicate:
+		return true
+	default:
+		return false
+	}
+}
+
+func typedColumnPreparedDictionaryRequestNeedsReverse(request typedColumnPreparedColumnRequest) bool {
+	switch request.Role {
+	case typedcolumn.ColumnRolePredicate:
+		return false
+	default:
+		return true
+	}
 }
 
 func decodeTypedColumnPreparedDictionarySectionBytes(section typedcolumn.ColumnPartImageSection, stored []byte) ([]byte, error) {
@@ -1148,57 +1230,262 @@ type typedColumnPreparedDictionaryDecoder struct {
 	off  int
 }
 
+type typedColumnPreparedDecodedDictionaries struct {
+	Forward map[string]map[string]int64
+	Reverse map[string]map[int64]string
+}
+
 func decodeTypedColumnPreparedDictionariesSection(raw []byte) (map[string]map[string]int64, error) {
-	dec := typedColumnPreparedDictionaryDecoder{data: raw}
-	count, err := dec.u32()
+	decoded, err := decodeTypedColumnPreparedRawDictionariesSection(raw, nil)
 	if err != nil {
 		return nil, err
 	}
-	if uint64(int(count)) != uint64(count) || int(count) > len(raw)/8+1 {
-		return nil, fmt.Errorf("collections: typed-column prepared dictionaries count=%d exceeds section bytes=%d", count, len(raw))
+	return decoded.Forward, nil
+}
+
+func decodeTypedColumnPreparedDictionariesSectionForEncoding(encoding typedcolumn.Encoding, raw []byte, requested map[string]struct{}) (map[string]map[string]int64, error) {
+	modes := typedColumnPreparedDictionaryModesFromNames(requested)
+	decoded, err := decodeTypedColumnPreparedDictionariesForModes(encoding, raw, modes)
+	if err != nil {
+		return nil, err
 	}
-	out := make(map[string]map[string]int64, int(count))
+	return decoded.Forward, nil
+}
+
+func decodeTypedColumnPreparedDictionariesForModes(encoding typedcolumn.Encoding, raw []byte, modes map[string]typedColumnPreparedDictionaryRequestMode) (typedColumnPreparedDecodedDictionaries, error) {
+	switch encoding {
+	case 0:
+		return decodeTypedColumnPreparedRawDictionariesSection(raw, modes)
+	case typedcolumn.EncodingDictionaryDense:
+		return decodeTypedColumnPreparedDenseDictionariesSection(raw, modes)
+	default:
+		return typedColumnPreparedDecodedDictionaries{}, fmt.Errorf("collections: typed-column prepared dictionaries encoding=%s is unsupported", encoding)
+	}
+}
+
+func decodeTypedColumnPreparedRawDictionariesSection(raw []byte, modes map[string]typedColumnPreparedDictionaryRequestMode) (typedColumnPreparedDecodedDictionaries, error) {
+	dec := typedColumnPreparedDictionaryDecoder{data: raw}
+	count, err := dec.u32()
+	if err != nil {
+		return typedColumnPreparedDecodedDictionaries{}, err
+	}
+	if uint64(int(count)) != uint64(count) || int(count) > len(raw)/8+1 {
+		return typedColumnPreparedDecodedDictionaries{}, fmt.Errorf("collections: typed-column prepared dictionaries count=%d exceeds section bytes=%d", count, len(raw))
+	}
+	out := typedColumnPreparedDecodedDictionaries{
+		Forward: make(map[string]map[string]int64, typedColumnPreparedDictionaryDecodeCapacity(int(count), modes, func(mode typedColumnPreparedDictionaryRequestMode) bool { return mode.Forward })),
+		Reverse: make(map[string]map[int64]string, typedColumnPreparedDictionaryDecodeCapacity(int(count), modes, func(mode typedColumnPreparedDictionaryRequestMode) bool { return mode.Reverse })),
+	}
+	seenNames := make(map[string]struct{}, int(count))
 	for i := 0; i < int(count); i++ {
 		name, err := dec.str()
 		if err != nil {
-			return nil, err
+			return typedColumnPreparedDecodedDictionaries{}, err
 		}
-		if _, exists := out[name]; exists {
-			return nil, fmt.Errorf("collections: typed-column prepared duplicate dictionary %s", name)
+		if _, exists := seenNames[name]; exists {
+			return typedColumnPreparedDecodedDictionaries{}, fmt.Errorf("collections: typed-column prepared duplicate dictionary %s", name)
 		}
+		seenNames[name] = struct{}{}
 		entryCount, err := dec.u32()
 		if err != nil {
-			return nil, err
+			return typedColumnPreparedDecodedDictionaries{}, err
 		}
 		if uint64(int(entryCount)) != uint64(entryCount) || int(entryCount) > (len(raw)-dec.off)/12+1 {
-			return nil, fmt.Errorf("collections: typed-column prepared dictionary %s entries=%d exceeds remaining bytes=%d", name, entryCount, len(raw)-dec.off)
+			return typedColumnPreparedDecodedDictionaries{}, fmt.Errorf("collections: typed-column prepared dictionary %s entries=%d exceeds remaining bytes=%d", name, entryCount, len(raw)-dec.off)
 		}
-		values := make(map[string]int64, int(entryCount))
-		codes := make(map[int64]string, int(entryCount))
+		mode := typedColumnPreparedDictionaryModeFor(modes, name)
+		if !typedColumnPreparedDictionaryModeRequested(mode) {
+			for j := 0; j < int(entryCount); j++ {
+				if _, err := dec.i64(); err != nil {
+					return typedColumnPreparedDecodedDictionaries{}, err
+				}
+				if err := dec.skipStr(); err != nil {
+					return typedColumnPreparedDecodedDictionaries{}, err
+				}
+			}
+			continue
+		}
+		var values map[string]int64
+		if mode.Forward {
+			values = make(map[string]int64, int(entryCount))
+		}
+		var codes map[int64]string
+		if mode.Reverse || mode.Forward {
+			codes = make(map[int64]string, int(entryCount))
+		}
 		for j := 0; j < int(entryCount); j++ {
 			code, err := dec.i64()
 			if err != nil {
-				return nil, err
+				return typedColumnPreparedDecodedDictionaries{}, err
 			}
 			value, err := dec.str()
 			if err != nil {
-				return nil, err
+				return typedColumnPreparedDecodedDictionaries{}, err
 			}
-			if _, exists := values[value]; exists {
-				return nil, fmt.Errorf("collections: typed-column prepared duplicate dictionary value %s in %s", value, name)
+			if mode.Forward {
+				if _, exists := values[value]; exists {
+					return typedColumnPreparedDecodedDictionaries{}, fmt.Errorf("collections: typed-column prepared duplicate dictionary value %s in %s", value, name)
+				}
+				values[value] = code
 			}
-			if previous, exists := codes[code]; exists {
-				return nil, fmt.Errorf("collections: typed-column prepared duplicate dictionary code %d in %s for %q and %q", code, name, previous, value)
+			if codes != nil {
+				if previous, exists := codes[code]; exists {
+					return typedColumnPreparedDecodedDictionaries{}, fmt.Errorf("collections: typed-column prepared duplicate dictionary code %d in %s for %q and %q", code, name, previous, value)
+				}
+				codes[code] = value
 			}
-			values[value] = code
-			codes[code] = value
 		}
-		out[name] = values
+		if mode.Forward {
+			out.Forward[name] = values
+		}
+		if mode.Reverse {
+			out.Reverse[name] = codes
+		}
 	}
 	if dec.off != len(raw) {
-		return nil, fmt.Errorf("collections: typed-column prepared dictionaries trailing bytes=%d", len(raw)-dec.off)
+		return typedColumnPreparedDecodedDictionaries{}, fmt.Errorf("collections: typed-column prepared dictionaries trailing bytes=%d", len(raw)-dec.off)
 	}
 	return out, nil
+}
+
+func decodeTypedColumnPreparedDenseDictionariesSection(raw []byte, modes map[string]typedColumnPreparedDictionaryRequestMode) (typedColumnPreparedDecodedDictionaries, error) {
+	dec := typedColumnPreparedDictionaryDecoder{data: raw}
+	magic, err := dec.u32()
+	if err != nil {
+		return typedColumnPreparedDecodedDictionaries{}, err
+	}
+	if magic != 0x54434944 {
+		return typedColumnPreparedDecodedDictionaries{}, fmt.Errorf("collections: typed-column prepared dense dictionaries invalid magic 0x%x", magic)
+	}
+	version, err := dec.u16()
+	if err != nil {
+		return typedColumnPreparedDecodedDictionaries{}, err
+	}
+	if version != 1 {
+		return typedColumnPreparedDecodedDictionaries{}, fmt.Errorf("collections: typed-column prepared dense dictionaries unsupported version %d", version)
+	}
+	reserved, err := dec.u16()
+	if err != nil {
+		return typedColumnPreparedDecodedDictionaries{}, err
+	}
+	if reserved != 0 {
+		return typedColumnPreparedDecodedDictionaries{}, fmt.Errorf("collections: typed-column prepared dense dictionaries reserved=%d want 0", reserved)
+	}
+	count, err := dec.u32()
+	if err != nil {
+		return typedColumnPreparedDecodedDictionaries{}, err
+	}
+	if uint64(int(count)) != uint64(count) || int(count) > len(raw)/8+1 {
+		return typedColumnPreparedDecodedDictionaries{}, fmt.Errorf("collections: typed-column prepared dense dictionaries count=%d exceeds section bytes=%d", count, len(raw))
+	}
+	out := typedColumnPreparedDecodedDictionaries{
+		Forward: make(map[string]map[string]int64, typedColumnPreparedDictionaryDecodeCapacity(int(count), modes, func(mode typedColumnPreparedDictionaryRequestMode) bool { return mode.Forward })),
+		Reverse: make(map[string]map[int64]string, typedColumnPreparedDictionaryDecodeCapacity(int(count), modes, func(mode typedColumnPreparedDictionaryRequestMode) bool { return mode.Reverse })),
+	}
+	seenNames := make(map[string]struct{}, int(count))
+	for i := 0; i < int(count); i++ {
+		name, err := dec.str()
+		if err != nil {
+			return typedColumnPreparedDecodedDictionaries{}, err
+		}
+		if _, exists := seenNames[name]; exists {
+			return typedColumnPreparedDecodedDictionaries{}, fmt.Errorf("collections: typed-column prepared duplicate dictionary %s", name)
+		}
+		seenNames[name] = struct{}{}
+		entryCount, err := dec.u32()
+		if err != nil {
+			return typedColumnPreparedDecodedDictionaries{}, err
+		}
+		if uint64(int(entryCount)) != uint64(entryCount) || int(entryCount) > (len(raw)-dec.off)/4+1 {
+			return typedColumnPreparedDecodedDictionaries{}, fmt.Errorf("collections: typed-column prepared dense dictionary %s entries=%d exceeds remaining bytes=%d", name, entryCount, len(raw)-dec.off)
+		}
+		mode := typedColumnPreparedDictionaryModeFor(modes, name)
+		if !typedColumnPreparedDictionaryModeRequested(mode) {
+			for j := 0; j < int(entryCount); j++ {
+				if err := dec.skipStr(); err != nil {
+					return typedColumnPreparedDecodedDictionaries{}, err
+				}
+			}
+			continue
+		}
+		var values map[string]int64
+		if mode.Forward {
+			values = make(map[string]int64, int(entryCount))
+		}
+		var codes map[int64]string
+		if mode.Reverse {
+			codes = make(map[int64]string, int(entryCount))
+		}
+		for j := 0; j < int(entryCount); j++ {
+			value, err := dec.str()
+			if err != nil {
+				return typedColumnPreparedDecodedDictionaries{}, err
+			}
+			if mode.Forward {
+				if _, exists := values[value]; exists {
+					return typedColumnPreparedDecodedDictionaries{}, fmt.Errorf("collections: typed-column prepared duplicate dictionary value %s in %s", value, name)
+				}
+				values[value] = int64(j)
+			}
+			if mode.Reverse {
+				codes[int64(j)] = value
+			}
+		}
+		if mode.Forward {
+			out.Forward[name] = values
+		}
+		if mode.Reverse {
+			out.Reverse[name] = codes
+		}
+	}
+	if dec.off != len(raw) {
+		return typedColumnPreparedDecodedDictionaries{}, fmt.Errorf("collections: typed-column prepared dense dictionaries trailing bytes=%d", len(raw)-dec.off)
+	}
+	return out, nil
+}
+
+func typedColumnPreparedDictionaryModesFromNames(requested map[string]struct{}) map[string]typedColumnPreparedDictionaryRequestMode {
+	if requested == nil {
+		return nil
+	}
+	modes := make(map[string]typedColumnPreparedDictionaryRequestMode, len(requested))
+	for name := range requested {
+		modes[name] = typedColumnPreparedDictionaryRequestMode{Forward: true}
+	}
+	return modes
+}
+
+func typedColumnPreparedDictionaryModeFor(modes map[string]typedColumnPreparedDictionaryRequestMode, name string) typedColumnPreparedDictionaryRequestMode {
+	if modes == nil {
+		return typedColumnPreparedDictionaryRequestMode{Forward: true}
+	}
+	return modes[name]
+}
+
+func typedColumnPreparedDictionaryModeRequested(mode typedColumnPreparedDictionaryRequestMode) bool {
+	return mode.Forward || mode.Reverse
+}
+
+func typedColumnPreparedDictionaryDecodeCapacity(total int, modes map[string]typedColumnPreparedDictionaryRequestMode, include func(typedColumnPreparedDictionaryRequestMode) bool) int {
+	if modes == nil {
+		return total
+	}
+	n := 0
+	for _, mode := range modes {
+		if include(mode) {
+			n++
+		}
+	}
+	return min(total, n)
+}
+
+func (d *typedColumnPreparedDictionaryDecoder) u16() (uint16, error) {
+	if len(d.data)-d.off < 2 {
+		return 0, fmt.Errorf("collections: typed-column prepared dictionary truncated u16 at offset=%d", d.off)
+	}
+	v := binary.LittleEndian.Uint16(d.data[d.off:])
+	d.off += 2
+	return v, nil
 }
 
 func (d *typedColumnPreparedDictionaryDecoder) u32() (uint32, error) {
@@ -1232,6 +1519,18 @@ func (d *typedColumnPreparedDictionaryDecoder) str() (string, error) {
 	return value, nil
 }
 
+func (d *typedColumnPreparedDictionaryDecoder) skipStr() error {
+	n, err := d.u32()
+	if err != nil {
+		return err
+	}
+	if uint64(int(n)) != uint64(n) || int(n) > len(d.data)-d.off {
+		return fmt.Errorf("collections: typed-column prepared dictionary string bytes=%d exceed remaining=%d", n, len(d.data)-d.off)
+	}
+	d.off += int(n)
+	return nil
+}
+
 func validateTypedColumnPreparedDictionaryForColumn(name string, cardinality uint32, dict map[string]int64) error {
 	if cardinality == 0 {
 		return fmt.Errorf("collections: typed-column prepared dictionary %s has zero cardinality", name)
@@ -1247,6 +1546,27 @@ func validateTypedColumnPreparedDictionaryForColumn(name string, cardinality uin
 		if !ok {
 			return fmt.Errorf("collections: typed-column prepared missing dictionary code %d in %s", code, name)
 		}
+	}
+	return nil
+}
+
+func validateTypedColumnPreparedReverseDictionaryForColumn(name string, cardinality uint32, dict map[int64]string) error {
+	if cardinality == 0 {
+		return fmt.Errorf("collections: typed-column prepared dictionary %s has zero cardinality", name)
+	}
+	if uint64(len(dict)) != uint64(cardinality) {
+		return fmt.Errorf("collections: typed-column prepared reverse dictionary %s cardinality=%d want %d", name, len(dict), cardinality)
+	}
+	var previous string
+	for code := int64(0); code < int64(cardinality); code++ {
+		value, ok := dict[code]
+		if !ok {
+			return fmt.Errorf("collections: typed-column prepared missing reverse dictionary code %d in %s", code, name)
+		}
+		if code > 0 && previous >= value {
+			return fmt.Errorf("collections: typed-column prepared reverse dictionary %s is not strictly ordered at code %d (%q >= %q)", name, code, previous, value)
+		}
+		previous = value
 	}
 	return nil
 }

--- a/TreeDB/collections/typed_column_prepared_state_test.go
+++ b/TreeDB/collections/typed_column_prepared_state_test.go
@@ -1,6 +1,7 @@
 package collections
 
 import (
+	"encoding/binary"
 	"strings"
 	"testing"
 
@@ -418,6 +419,195 @@ func TestTypedColumnPreparedPruningFallbackDoesNotInflateEmptyBlockPlans(t *test
 	if diag.PruningFallbackBlocks != 2 || diag.PruningFallbackReason != "unsupported" || column.PruningFallbackReason != "unsupported" {
 		t.Fatalf("fallback diag=%+v column_reason=%q want two blocks and updated reason", diag, column.PruningFallbackReason)
 	}
+}
+
+func TestTypedColumnPreparedDictionarySelectiveRawDecode3175(t *testing.T) {
+	raw := encodePreparedRawDictionarySectionForTest([]preparedDictionaryForTest{
+		{Name: typedColumnAdapterMetadataDictionary, Entries: []preparedDictionaryEntryForTest{{Code: 0, Value: "metadata"}}},
+		{Name: "event", Entries: []preparedDictionaryEntryForTest{{Code: 0, Value: "app.bsky.feed.post"}, {Code: 1, Value: "app.bsky.graph.follow"}}},
+		{Name: "unused", Entries: []preparedDictionaryEntryForTest{{Code: 0, Value: strings.Repeat("skip", 128)}}},
+	})
+	got, err := decodeTypedColumnPreparedDictionariesSectionForEncoding(0, raw, map[string]struct{}{
+		typedColumnAdapterMetadataDictionary: {},
+		"event":                              {},
+	})
+	if err != nil {
+		t.Fatalf("selective raw decode: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("decoded dictionaries=%v want metadata+event only", mapKeysForTest(got))
+	}
+	if got["event"]["app.bsky.feed.post"] != 0 || got["event"]["app.bsky.graph.follow"] != 1 {
+		t.Fatalf("event dictionary=%v want dense event codes", got["event"])
+	}
+	if _, ok := got["unused"]; ok {
+		t.Fatalf("unused dictionary decoded despite selective request: %v", got["unused"])
+	}
+}
+
+func TestTypedColumnPreparedDictionarySelectiveDenseDecode3175(t *testing.T) {
+	raw := encodePreparedDenseDictionarySectionForTest([]preparedDenseDictionaryForTest{
+		{Name: typedColumnAdapterMetadataDictionary, Values: []string{"metadata"}},
+		{Name: "event", Values: []string{"app.bsky.feed.post", "app.bsky.graph.follow"}},
+		{Name: "unused", Values: []string{strings.Repeat("skip", 128)}},
+	})
+	got, err := decodeTypedColumnPreparedDictionariesSectionForEncoding(typedcolumn.EncodingDictionaryDense, raw, map[string]struct{}{
+		"event": {},
+	})
+	if err != nil {
+		t.Fatalf("selective dense decode: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("decoded dictionaries=%v want event only", mapKeysForTest(got))
+	}
+	if got["event"]["app.bsky.feed.post"] != 0 || got["event"]["app.bsky.graph.follow"] != 1 {
+		t.Fatalf("event dictionary=%v want dense event codes", got["event"])
+	}
+	if _, ok := got[typedColumnAdapterMetadataDictionary]; ok {
+		t.Fatalf("metadata dictionary decoded despite selective request: %v", got[typedColumnAdapterMetadataDictionary])
+	}
+}
+
+func TestTypedColumnPreparedDictionaryReverseOnlyDenseDecode3175(t *testing.T) {
+	raw := encodePreparedDenseDictionarySectionForTest([]preparedDenseDictionaryForTest{
+		{Name: "kind", Values: []string{"app.bsky.feed.post", "app.bsky.graph.follow"}},
+	})
+	got, err := decodeTypedColumnPreparedDictionariesForModes(typedcolumn.EncodingDictionaryDense, raw, map[string]typedColumnPreparedDictionaryRequestMode{
+		"kind": {Reverse: true},
+	})
+	if err != nil {
+		t.Fatalf("reverse-only dense decode: %v", err)
+	}
+	if len(got.Forward) != 0 {
+		t.Fatalf("forward dictionaries=%v want none", mapKeysForTest(got.Forward))
+	}
+	if got.Reverse["kind"][0] != "app.bsky.feed.post" || got.Reverse["kind"][1] != "app.bsky.graph.follow" {
+		t.Fatalf("reverse kind dictionary=%v want code-ordered values", got.Reverse["kind"])
+	}
+}
+
+func TestTypedColumnPreparedDictionaryRequestNamesIncludeMetadata3175(t *testing.T) {
+	names, err := typedColumnPreparedDictionaryRequestNames([]typedColumnPreparedColumnRequest{
+		{Field: typedColumnAdapterField("kind", "string"), Role: typedcolumn.ColumnRolePredicate, IncludeDictionaries: true},
+		{Field: typedColumnAdapterField("unused", "string"), IncludeDictionaries: false},
+	})
+	if err != nil {
+		t.Fatalf("request names: %v", err)
+	}
+	if _, ok := names[typedColumnAdapterMetadataDictionary]; !ok {
+		t.Fatalf("request names=%v missing adapter metadata dictionary", names)
+	}
+	adapterColumn, err := typedColumnAdapterMapField(typedColumnAdapterField("kind", "string"))
+	if err != nil {
+		t.Fatalf("map kind field: %v", err)
+	}
+	if _, ok := names[adapterColumn.Definition.Name]; !ok {
+		t.Fatalf("request names=%v missing requested kind dictionary %q", names, adapterColumn.Definition.Name)
+	}
+	if _, ok := names["unused"]; ok {
+		t.Fatalf("request names=%v included non-dictionary request", names)
+	}
+	modes, err := typedColumnPreparedDictionaryRequestModes([]typedColumnPreparedColumnRequest{
+		{Field: typedColumnAdapterField("kind", "string"), Role: typedcolumn.ColumnRolePredicate, IncludeDictionaries: true},
+		{Field: typedColumnAdapterField("type", "string"), Role: typedcolumn.ColumnRoleProjection, IncludeDictionaries: true},
+		{Field: typedColumnAdapterField("type", "string"), Role: typedcolumn.ColumnRolePredicate, IncludeDictionaries: true},
+	})
+	if err != nil {
+		t.Fatalf("request modes: %v", err)
+	}
+	kindColumn, err := typedColumnAdapterMapField(typedColumnAdapterField("kind", "string"))
+	if err != nil {
+		t.Fatalf("map kind field: %v", err)
+	}
+	typeColumn, err := typedColumnAdapterMapField(typedColumnAdapterField("type", "string"))
+	if err != nil {
+		t.Fatalf("map type field: %v", err)
+	}
+	if got := modes[kindColumn.Definition.Name]; !got.Forward || got.Reverse {
+		t.Fatalf("kind predicate mode=%+v want forward-only", got)
+	}
+	if got := modes[typeColumn.Definition.Name]; !got.Forward || !got.Reverse {
+		t.Fatalf("type mixed mode=%+v want forward+reverse", got)
+	}
+	if got := modes[typedColumnAdapterMetadataDictionary]; !got.Forward || got.Reverse {
+		t.Fatalf("metadata mode=%+v want forward-only", got)
+	}
+}
+
+type preparedDictionaryEntryForTest struct {
+	Code  int64
+	Value string
+}
+
+type preparedDictionaryForTest struct {
+	Name    string
+	Entries []preparedDictionaryEntryForTest
+}
+
+type preparedDenseDictionaryForTest struct {
+	Name   string
+	Values []string
+}
+
+func encodePreparedRawDictionarySectionForTest(dictionaries []preparedDictionaryForTest) []byte {
+	var out []byte
+	out = appendPreparedU32ForTest(out, uint32(len(dictionaries)))
+	for _, dict := range dictionaries {
+		out = appendPreparedStringForTest(out, dict.Name)
+		out = appendPreparedU32ForTest(out, uint32(len(dict.Entries)))
+		for _, entry := range dict.Entries {
+			out = appendPreparedI64ForTest(out, entry.Code)
+			out = appendPreparedStringForTest(out, entry.Value)
+		}
+	}
+	return out
+}
+
+func encodePreparedDenseDictionarySectionForTest(dictionaries []preparedDenseDictionaryForTest) []byte {
+	var out []byte
+	out = appendPreparedU32ForTest(out, 0x54434944)
+	out = appendPreparedU16ForTest(out, 1)
+	out = appendPreparedU16ForTest(out, 0)
+	out = appendPreparedU32ForTest(out, uint32(len(dictionaries)))
+	for _, dict := range dictionaries {
+		out = appendPreparedStringForTest(out, dict.Name)
+		out = appendPreparedU32ForTest(out, uint32(len(dict.Values)))
+		for _, value := range dict.Values {
+			out = appendPreparedStringForTest(out, value)
+		}
+	}
+	return out
+}
+
+func appendPreparedU16ForTest(out []byte, v uint16) []byte {
+	var buf [2]byte
+	binary.LittleEndian.PutUint16(buf[:], v)
+	return append(out, buf[:]...)
+}
+
+func appendPreparedU32ForTest(out []byte, v uint32) []byte {
+	var buf [4]byte
+	binary.LittleEndian.PutUint32(buf[:], v)
+	return append(out, buf[:]...)
+}
+
+func appendPreparedI64ForTest(out []byte, v int64) []byte {
+	var buf [8]byte
+	binary.LittleEndian.PutUint64(buf[:], uint64(v))
+	return append(out, buf[:]...)
+}
+
+func appendPreparedStringForTest(out []byte, value string) []byte {
+	out = appendPreparedU32ForTest(out, uint32(len(value)))
+	return append(out, value...)
+}
+
+func mapKeysForTest[V any](m map[string]V) []string {
+	keys := make([]string, 0, len(m))
+	for key := range m {
+		keys = append(keys, key)
+	}
+	return keys
 }
 
 func assertPreparedSelectionRows(t *testing.T, selection typedcolumn.RowSelection, want []int) {

--- a/TreeDB/collections/typed_column_prepared_state_test.go
+++ b/TreeDB/collections/typed_column_prepared_state_test.go
@@ -487,9 +487,10 @@ func TestTypedColumnPreparedDictionaryReverseOnlyDenseDecode3175(t *testing.T) {
 }
 
 func TestTypedColumnPreparedDictionaryRequestNamesIncludeMetadata3175(t *testing.T) {
+	skippedField := typedColumnAdapterField("unused", "string")
 	names, err := typedColumnPreparedDictionaryRequestNames([]typedColumnPreparedColumnRequest{
 		{Field: typedColumnAdapterField("kind", "string"), Role: typedcolumn.ColumnRolePredicate, IncludeDictionaries: true},
-		{Field: typedColumnAdapterField("unused", "string"), IncludeDictionaries: false},
+		{Field: skippedField, IncludeDictionaries: false},
 	})
 	if err != nil {
 		t.Fatalf("request names: %v", err)
@@ -504,8 +505,12 @@ func TestTypedColumnPreparedDictionaryRequestNamesIncludeMetadata3175(t *testing
 	if _, ok := names[adapterColumn.Definition.Name]; !ok {
 		t.Fatalf("request names=%v missing requested kind dictionary %q", names, adapterColumn.Definition.Name)
 	}
-	if _, ok := names["unused"]; ok {
-		t.Fatalf("request names=%v included non-dictionary request", names)
+	skippedColumn, err := typedColumnAdapterMapField(skippedField)
+	if err != nil {
+		t.Fatalf("map skipped field: %v", err)
+	}
+	if _, ok := names[skippedColumn.Definition.Name]; ok {
+		t.Fatalf("request names=%v included non-dictionary request %q", names, skippedColumn.Definition.Name)
 	}
 	modes, err := typedColumnPreparedDictionaryRequestModes([]typedColumnPreparedColumnRequest{
 		{Field: typedColumnAdapterField("kind", "string"), Role: typedcolumn.ColumnRolePredicate, IncludeDictionaries: true},


### PR DESCRIPTION
## Summary

Improves the TreeDB JSONBench q5 `one_shot_end_to_end` / `no_aggregate_metadata` path by avoiding unnecessary prepared-dictionary work during one-shot setup.

This PR is a production-shape q5 setup slice. It does not claim broad TreeDB SQL superiority over ClickHouse, and it keeps the q5 result in the no-aggregate-metadata lane with bounded TopK reported separately.

## What changed

- Decode prepared dictionary sections by requested role:
  - predicate columns decode forward value-to-code maps
  - group/render columns decode reverse code-to-value maps
  - mixed group+predicate columns request both orientations
  - adapter metadata remains forward-decoded for validation
- Skip unrequested dictionary entries while preserving duplicate dictionary-name validation.
- Avoid rebuilding reverse maps from forward maps for group-only prepared columns.
- Remove redundant per-query reverse-dictionary coverage walks after prepared dictionary attach has validated code coverage/order.
- Add focused tests for selective raw/dense dictionary decode, reverse-only dense decode, and request-mode classification.

## Performance Evidence

TreeDB q5, 1M rows, `column-store-full-prepared`, `one_shot_end_to_end`, `no_aggregate_metadata`, full projection, retained JSON shape, WAL-excluded durable storage.

| Build | Artifact | total query | prepare/setup | run | render/hash | rows scanned | cells/rows visited | bytes decoded | physical bytes | result hash |
| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
| after #3178 | `/tmp/jsonbench_q5_predicate_rows_uint32_candidate_3175_20260627_055859` | 47.610 ms | 35.965 ms | 11.634 ms | 0.011 ms | 1,000,000 | 86,812 reduce rows | 34,933,080 | 17,999,817 | `ef6217ce9da3a74fdf600ccbebd333457f017d6012dc0c231338961533f5689c` |
| this PR | `/tmp/jsonbench_q5_reverse_dicts_fastvalidate_3175_20260627_071017` | 40.499 ms | 28.845 ms | 11.623 ms | 0.033 ms | 1,000,000 | 86,812 reduce rows | 34,933,080 | 17,999,817 | `ef6217ce9da3a74fdf600ccbebd333457f017d6012dc0c231338961533f5689c` |
| this PR repeat | `/tmp/jsonbench_q5_reverse_dicts_fastvalidate_retry_3175_20260627_071058` | 40.626 ms | 29.488 ms | 11.108 ms | 0.033 ms | 1,000,000 | 86,812 reduce rows | 34,933,080 | 17,999,817 | `ef6217ce9da3a74fdf600ccbebd333457f017d6012dc0c231338961533f5689c` |

Load/storage for the repeat artifact:

| rows loaded | load wall time | insert time | TreeDB durable storage, WAL excluded | metadata mode | aggregate metadata used | sort marks / TopK pruning | JSON reconstruction |
| ---: | ---: | ---: | ---: | --- | --- | --- | --- |
| 1,000,000 | 17.358 s | 14.230 s | 137,491,627 bytes | `no_aggregate_metadata` | no | bounded TopK used | no row/document materialization on the columnar path |

ClickHouse context from the active tracker baseline remains: q5 around 15 ms, load around 6.292 s, storage around 102,099,438 bytes for the comparable 1M run. This PR narrows TreeDB q5 setup cost but does not close the ClickHouse q5 gap or the load-speed gap.

## Reproduction

```sh
cd /Users/michaelseiler/dev/snissn/JSONBench/treedb
backup_dir=$(mktemp -d /tmp/jsonbench_treedb_gomod_XXXXXX)
cp go.mod "$backup_dir/go.mod"
cp go.sum "$backup_dir/go.sum"
restore() { cp "$backup_dir/go.mod" go.mod; cp "$backup_dir/go.sum" go.sum; rm -rf "$backup_dir"; }
trap restore EXIT
go mod edit -replace=github.com/snissn/gomap=/private/tmp/gomap_main_3174_20260627
OUT=/tmp/jsonbench_q5_reverse_dicts_fastvalidate_$(date +%Y%m%d_%H%M%S)
mkdir -p "$OUT"
go run ./cmd/jsonbench_treedb run \
  -data-dir /Users/michaelseiler/data/bluesky \
  -db-dir "$OUT/db" \
  -reset -scale 1m -format json \
  -storage-layout column-store-full-prepared \
  -query-mode one_shot_end_to_end \
  -metadata-mode no_aggregate_metadata \
  -projection full -queries q5 \
  -batch-size 16000 -tries 1 -profile fast -data-root fast \
  -allow-errors \
  -out "$OUT/result.json"
```

## Tests

- `go test ./TreeDB/collections -run 'TestTimeOrderTopKAllowedCodesNullableEmptyOnlyNoDictionary3175|TestTypedColumnPreparedDictionary|TestColumnPhysicalQ5DenseTypedColumnDirectPreparedParity1950|TestColumnPhysicalTypedColumnOneShotCacheQ5NoMetadata3088|TestColumnPhysicalQ4ATimeOrderTopKDirectPreparedParity1950|TestColumnPhysicalJSONBenchTypedColumnPartNullableFullDataTopKFastPaths2878' -count=1`
- `go test ./TreeDB/collections -run 'TestTimeOrderTopKAllowedCodesNullableEmptyOnlyNoDictionary3175|TestTypedColumnPreparedDictionary|TestTypedStorageLegacyNameAllowlistIsComplete' -count=1`
- `go test ./TreeDB/collections ./cmd/unified_bench -count=1`
- `go test -race ./TreeDB/collections -run 'TestTypedColumnPreparedDictionary|TestColumnPhysicalQ5DenseTypedColumnDirectPreparedParity1950|TestColumnPhysicalTypedColumnOneShotCacheQ5NoMetadata3088|TestColumnPhysicalQ4ATimeOrderTopKDirectPreparedParity1950' -count=1`
- `git diff --check`

Progresses #3175; satisfies the first <=45 ms q5 target only, with the remaining ClickHouse q5 gap still tracked.
Refs #3175.
Refs #3000, #3001, #3070.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved typed-column dictionary handling to support both forward and reverse lookups where needed.
  * Prepared columns now load only the dictionary data required for the current query path, reducing unnecessary work.

* **Bug Fixes**
  * Added stricter validation for dictionary availability and ordering, preventing invalid query results when dictionary data is incomplete.
  * Better handling for dense string/code columns and top-k predicate queries when dictionary data is missing or partial.

* **Tests**
  * Added coverage for selective dictionary decoding and reverse-only dictionary behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

