### PR TITLE
TreeDB: break down q5 one-shot setup

### DIFF
--- a/TreeDB/collections/column_physical_query.go
+++ b/TreeDB/collections/column_physical_query.go
@@ -193,6 +193,9 @@ type ColumnPhysicalQueryDiagnostics struct {
 	TypedColumnPrepareReadImageNanos      int64
 	TypedColumnPrepareStateBuildNanos     int64
 	TypedColumnPrepareDictionaryNanos     int64
+	TypedColumnPreparePruningNanos        int64
+	TypedColumnPrepareSortKeyNanos        int64
+	TypedColumnPrepareStatsNanos          int64
 	TypedColumnPrepareRangeReadNanos      int64
 	TypedColumnPrepareRangeReadBytes      int64
 	TypedColumnPrepareAdapterNanos        int64
@@ -1459,6 +1462,9 @@ func mergeColumnPhysicalQueryDiagnostics(left, right ColumnPhysicalQueryDiagnost
 	left.TypedColumnPrepareReadImageNanos += right.TypedColumnPrepareReadImageNanos
 	left.TypedColumnPrepareStateBuildNanos += right.TypedColumnPrepareStateBuildNanos
 	left.TypedColumnPrepareDictionaryNanos += right.TypedColumnPrepareDictionaryNanos
+	left.TypedColumnPreparePruningNanos += right.TypedColumnPreparePruningNanos
+	left.TypedColumnPrepareSortKeyNanos += right.TypedColumnPrepareSortKeyNanos
+	left.TypedColumnPrepareStatsNanos += right.TypedColumnPrepareStatsNanos
 	left.TypedColumnPrepareRangeReadNanos += right.TypedColumnPrepareRangeReadNanos
 	left.TypedColumnPrepareRangeReadBytes += right.TypedColumnPrepareRangeReadBytes
 	left.TypedColumnPrepareAdapterNanos += right.TypedColumnPrepareAdapterNanos

--- a/TreeDB/collections/column_physical_query.go
+++ b/TreeDB/collections/column_physical_query.go
@@ -110,87 +110,104 @@ type ColumnPhysicalQueryGroup struct {
 // ColumnPhysicalQueryDiagnostics reports scan and reduce work for a physical
 // query without counting full-document row materialization.
 type ColumnPhysicalQueryDiagnostics struct {
-	ManifestRoot                        uint64
-	ManifestRootName                    string
-	ManifestGeneration                  uint64
-	ActiveManifestChecksum              uint64
-	RecoveryManifestGeneration          uint64
-	RecoveryManifestChecksum            uint64
-	AppliedCommandLSN                   uint64
-	ManifestRecords                     int
-	AssetRefs                           int
-	MutationParts                       int
-	DecodedBlocks                       int
-	DirectReduceBlocks                  int
-	TypedColumnPartSections             int
-	TypedColumnPartSectionBytes         uint64
-	MetadataHits                        int
-	MetadataEntries                     int
-	MetadataMisses                      int
-	DictionaryCodeHits                  int
-	PredicateDictionaryCodeHits         int
-	Int64ValueHits                      int
-	ScheduledGranules                   int
-	SkippedGranules                     int
-	DecodedGranules                     int
-	RowsScanned                         int
-	RowsMatched                         int
-	DeletedRows                         int
-	ProjectedColumns                    int
-	PredicateCount                      int
-	PredicateColumns                    []string
-	PredicateKinds                      []string
-	PredicateLiterals                   int
-	SortKeyPrefixPlanned                bool
-	SortKeyPrefixColumns                []string
-	SortKeyPrefixLiterals               int
-	SortKeyMarkChecks                   int
-	SortKeyMarkMatches                  int
-	SortKeyMarkSkips                    int
-	SortKeyMarkFallbackReason           string
-	SortedGroupedDistinctReady          bool
-	SortedGroupedDistinctUsed           bool
-	SortedGroupedDistinctFallbackReason string
-	DenseGroupCountUsed                 bool
-	DenseGroupCountDistinctUsed         bool
-	DenseGroupCountDistinctReducer      string
-	DenseGroupCountDistinctGroups       int
-	DenseGroupCountDistinctValues       int
-	DenseGroupCountDistinctPairBitWords int
-	DenseGroupHourCountUsed             bool
-	DenseInt64SpanUsed                  bool
-	DenseInt64SpanReducer               string
-	TimeOrderTopKUsed                   bool
-	DecodedPayloadBytes                 uint64
-	FallbackReads                       int
-	RowMaterializations                 int
-	DocumentMaterializations            int
-	PhysicalBytesScanned                int64
-	DecodedMetadataBytes                uint64
-	MappedBytes                         uint64
-	HeapCopyBytes                       uint64
-	ReduceRows                          int
-	TopKLimit                           int
-	TopKCandidates                      int
-	TopKOrder                           string
-	VisibilityRows                      int
-	ReconstructionRows                  int
-	ResultGroups                        int
-	WorkerCount                         int
-	SegmentFileCacheHits                uint64
-	SegmentFileCacheMisses              uint64
-	TypedColumnOneShotCacheHit          bool
-	TypedColumnOneShotCacheMiss         bool
-	TypedColumnOneShotCacheBuild        bool
-	TypedColumnOneShotBuildNanos        int64
-	ColumnAssetReadIntegrity            string
-	StorageSource                       ColumnPhysicalQueryStorageSource
-	FallbackReason                      ColumnPhysicalQueryFallbackReason
-	ScanNanos                           int64
-	VisibilityNanos                     int64
-	ReduceNanos                         int64
-	ResultShapeNanos                    int64
-	ReconstructionNanos                 int64
+	ManifestRoot                          uint64
+	ManifestRootName                      string
+	ManifestGeneration                    uint64
+	ActiveManifestChecksum                uint64
+	RecoveryManifestGeneration            uint64
+	RecoveryManifestChecksum              uint64
+	AppliedCommandLSN                     uint64
+	ManifestRecords                       int
+	AssetRefs                             int
+	MutationParts                         int
+	DecodedBlocks                         int
+	DirectReduceBlocks                    int
+	TypedColumnPartSections               int
+	TypedColumnPartSectionBytes           uint64
+	MetadataHits                          int
+	MetadataEntries                       int
+	MetadataMisses                        int
+	DictionaryCodeHits                    int
+	PredicateDictionaryCodeHits           int
+	Int64ValueHits                        int
+	ScheduledGranules                     int
+	SkippedGranules                       int
+	DecodedGranules                       int
+	RowsScanned                           int
+	RowsMatched                           int
+	DeletedRows                           int
+	ProjectedColumns                      int
+	PredicateCount                        int
+	PredicateColumns                      []string
+	PredicateKinds                        []string
+	PredicateLiterals                     int
+	SortKeyPrefixPlanned                  bool
+	SortKeyPrefixColumns                  []string
+	SortKeyPrefixLiterals                 int
+	SortKeyMarkChecks                     int
+	SortKeyMarkMatches                    int
+	SortKeyMarkSkips                      int
+	SortKeyMarkFallbackReason             string
+	SortedGroupedDistinctReady            bool
+	SortedGroupedDistinctUsed             bool
+	SortedGroupedDistinctFallbackReason   string
+	DenseGroupCountUsed                   bool
+	DenseGroupCountDistinctUsed           bool
+	DenseGroupCountDistinctReducer        string
+	DenseGroupCountDistinctGroups         int
+	DenseGroupCountDistinctValues         int
+	DenseGroupCountDistinctPairBitWords   int
+	DenseGroupHourCountUsed               bool
+	DenseInt64SpanUsed                    bool
+	DenseInt64SpanReducer                 string
+	TimeOrderTopKUsed                     bool
+	DecodedPayloadBytes                   uint64
+	FallbackReads                         int
+	RowMaterializations                   int
+	DocumentMaterializations              int
+	PhysicalBytesScanned                  int64
+	DecodedMetadataBytes                  uint64
+	MappedBytes                           uint64
+	HeapCopyBytes                         uint64
+	ReduceRows                            int
+	TopKLimit                             int
+	TopKCandidates                        int
+	TopKOrder                             string
+	VisibilityRows                        int
+	ReconstructionRows                    int
+	ResultGroups                          int
+	WorkerCount                           int
+	SegmentFileCacheHits                  uint64
+	SegmentFileCacheMisses                uint64
+	TypedColumnOneShotCacheHit            bool
+	TypedColumnOneShotCacheMiss           bool
+	TypedColumnOneShotCacheBuild          bool
+	TypedColumnOneShotBuildNanos          int64
+	TypedColumnPreparePlanNanos           int64
+	TypedColumnPrepareRefsNanos           int64
+	TypedColumnPreparePairingNanos        int64
+	TypedColumnPreparePartDecodeNanos     int64
+	TypedColumnPreparePostPrepareNanos    int64
+	TypedColumnPrepareSummaryNanos        int64
+	TypedColumnOneShotCacheStoreNanos     int64
+	TypedColumnPrepareReadImageNanos      int64
+	TypedColumnPrepareStateBuildNanos     int64
+	TypedColumnPrepareDictionaryNanos     int64
+	TypedColumnPrepareRangeReadNanos      int64
+	TypedColumnPrepareRangeReadBytes      int64
+	TypedColumnPrepareAdapterNanos        int64
+	TypedColumnPrepareDenseGroupNanos     int64
+	TypedColumnPrepareDenseValueNanos     int64
+	TypedColumnPrepareDensePredicateNanos int64
+	TypedColumnPrepareDensePreapplyNanos  int64
+	ColumnAssetReadIntegrity              string
+	StorageSource                         ColumnPhysicalQueryStorageSource
+	FallbackReason                        ColumnPhysicalQueryFallbackReason
+	ScanNanos                             int64
+	VisibilityNanos                       int64
+	ReduceNanos                           int64
+	ResultShapeNanos                      int64
+	ReconstructionNanos                   int64
 }
 
 // ColumnPhysicalQueryResult is the reduced result and diagnostics from an
@@ -526,6 +543,18 @@ func (r *ColumnPhysicalQueryRunner) Close() error {
 		r.closeView = nil
 	}
 	return closeErr
+}
+
+// PrepareDiagnostics reports setup work captured while constructing this
+// prepared runner. It is intentionally sparse for runner types without
+// instrumented setup subphases.
+func (r *ColumnPhysicalQueryRunner) PrepareDiagnostics() ColumnPhysicalQueryDiagnostics {
+	var diag ColumnPhysicalQueryDiagnostics
+	if r == nil || r.typedColumn == nil {
+		return diag
+	}
+	r.typedColumn.prepareDiagnostics.applyTo(&diag)
+	return diag
 }
 
 // Run executes the prepared direct physical query against the pinned snapshot.
@@ -1420,6 +1449,23 @@ func mergeColumnPhysicalQueryDiagnostics(left, right ColumnPhysicalQueryDiagnost
 	left.ReconstructionRows += right.ReconstructionRows
 	left.SegmentFileCacheHits += right.SegmentFileCacheHits
 	left.SegmentFileCacheMisses += right.SegmentFileCacheMisses
+	left.TypedColumnPreparePlanNanos += right.TypedColumnPreparePlanNanos
+	left.TypedColumnPrepareRefsNanos += right.TypedColumnPrepareRefsNanos
+	left.TypedColumnPreparePairingNanos += right.TypedColumnPreparePairingNanos
+	left.TypedColumnPreparePartDecodeNanos += right.TypedColumnPreparePartDecodeNanos
+	left.TypedColumnPreparePostPrepareNanos += right.TypedColumnPreparePostPrepareNanos
+	left.TypedColumnPrepareSummaryNanos += right.TypedColumnPrepareSummaryNanos
+	left.TypedColumnOneShotCacheStoreNanos += right.TypedColumnOneShotCacheStoreNanos
+	left.TypedColumnPrepareReadImageNanos += right.TypedColumnPrepareReadImageNanos
+	left.TypedColumnPrepareStateBuildNanos += right.TypedColumnPrepareStateBuildNanos
+	left.TypedColumnPrepareDictionaryNanos += right.TypedColumnPrepareDictionaryNanos
+	left.TypedColumnPrepareRangeReadNanos += right.TypedColumnPrepareRangeReadNanos
+	left.TypedColumnPrepareRangeReadBytes += right.TypedColumnPrepareRangeReadBytes
+	left.TypedColumnPrepareAdapterNanos += right.TypedColumnPrepareAdapterNanos
+	left.TypedColumnPrepareDenseGroupNanos += right.TypedColumnPrepareDenseGroupNanos
+	left.TypedColumnPrepareDenseValueNanos += right.TypedColumnPrepareDenseValueNanos
+	left.TypedColumnPrepareDensePredicateNanos += right.TypedColumnPrepareDensePredicateNanos
+	left.TypedColumnPrepareDensePreapplyNanos += right.TypedColumnPrepareDensePreapplyNanos
 	return left
 }
 

--- a/TreeDB/collections/column_physical_typed_column_cache.go
+++ b/TreeDB/collections/column_physical_typed_column_cache.go
@@ -116,7 +116,6 @@ func (c *Collection) runColumnTypedColumnOneShotWithCache(view columnPhysicalSca
 		result.Diagnostics.ScanNanos = time.Since(start).Nanoseconds()
 		return result, candidate, err
 	}
-	cacheStoreStart := time.Now()
 	entry = &collectionTypedColumnOneShotCacheEntry{slot: slot, runner: runner}
 
 	c.typedColumnOneShotMu.Lock()
@@ -132,11 +131,12 @@ func (c *Collection) runColumnTypedColumnOneShotWithCache(view columnPhysicalSca
 		result, err := current.run(view, req)
 		result.Diagnostics.TypedColumnOneShotCacheMiss = true
 		result.Diagnostics.TypedColumnOneShotCacheBuild = true
-		applyColumnTypedColumnOneShotBuildDiagnostics(&result, runner, buildNanos, time.Since(cacheStoreStart).Nanoseconds())
+		applyColumnTypedColumnOneShotBuildDiagnostics(&result, runner, buildNanos, 0)
 		result.Diagnostics.ScanNanos = time.Since(start).Nanoseconds()
 		return result, true, err
 	}
 	var evicted *collectionTypedColumnOneShotCacheEntry
+	cacheStoreStart := time.Now()
 	if len(c.typedColumnOneShot) >= collectionTypedColumnOneShotCacheMaxEntries {
 		evicted = collectionTypedColumnOneShotEvictOldest(c.typedColumnOneShot)
 		c.typedColumnOneShotInvalidations++
@@ -144,6 +144,7 @@ func (c *Collection) runColumnTypedColumnOneShotWithCache(view columnPhysicalSca
 	c.typedColumnOneShotClock++
 	entry.lastUse = c.typedColumnOneShotClock
 	c.typedColumnOneShot[slot] = entry
+	cacheStoreNanos := time.Since(cacheStoreStart).Nanoseconds()
 	c.typedColumnOneShotMu.Unlock()
 	if evicted != nil {
 		evicted.close()
@@ -159,11 +160,10 @@ func (c *Collection) runColumnTypedColumnOneShotWithCache(view columnPhysicalSca
 		result := ColumnPhysicalQueryResult{}
 		result.Diagnostics.TypedColumnOneShotCacheMiss = true
 		result.Diagnostics.TypedColumnOneShotCacheBuild = true
-		applyColumnTypedColumnOneShotBuildDiagnostics(&result, runner, buildNanos, time.Since(cacheStoreStart).Nanoseconds())
+		applyColumnTypedColumnOneShotBuildDiagnostics(&result, runner, buildNanos, cacheStoreNanos)
 		result.Diagnostics.ScanNanos = time.Since(start).Nanoseconds()
 		return result, true, backenddb.ErrClosed
 	}
-	cacheStoreNanos := time.Since(cacheStoreStart).Nanoseconds()
 
 	result, err := entry.run(view, req)
 	result.Diagnostics.TypedColumnOneShotCacheMiss = true

--- a/TreeDB/collections/column_physical_typed_column_cache.go
+++ b/TreeDB/collections/column_physical_typed_column_cache.go
@@ -116,6 +116,7 @@ func (c *Collection) runColumnTypedColumnOneShotWithCache(view columnPhysicalSca
 		result.Diagnostics.ScanNanos = time.Since(start).Nanoseconds()
 		return result, candidate, err
 	}
+	cacheStoreStart := time.Now()
 	entry = &collectionTypedColumnOneShotCacheEntry{slot: slot, runner: runner}
 
 	c.typedColumnOneShotMu.Lock()
@@ -131,7 +132,7 @@ func (c *Collection) runColumnTypedColumnOneShotWithCache(view columnPhysicalSca
 		result, err := current.run(view, req)
 		result.Diagnostics.TypedColumnOneShotCacheMiss = true
 		result.Diagnostics.TypedColumnOneShotCacheBuild = true
-		result.Diagnostics.TypedColumnOneShotBuildNanos = buildNanos
+		applyColumnTypedColumnOneShotBuildDiagnostics(&result, runner, buildNanos, time.Since(cacheStoreStart).Nanoseconds())
 		result.Diagnostics.ScanNanos = time.Since(start).Nanoseconds()
 		return result, true, err
 	}
@@ -158,17 +159,29 @@ func (c *Collection) runColumnTypedColumnOneShotWithCache(view columnPhysicalSca
 		result := ColumnPhysicalQueryResult{}
 		result.Diagnostics.TypedColumnOneShotCacheMiss = true
 		result.Diagnostics.TypedColumnOneShotCacheBuild = true
-		result.Diagnostics.TypedColumnOneShotBuildNanos = buildNanos
+		applyColumnTypedColumnOneShotBuildDiagnostics(&result, runner, buildNanos, time.Since(cacheStoreStart).Nanoseconds())
 		result.Diagnostics.ScanNanos = time.Since(start).Nanoseconds()
 		return result, true, backenddb.ErrClosed
 	}
+	cacheStoreNanos := time.Since(cacheStoreStart).Nanoseconds()
 
 	result, err := entry.run(view, req)
 	result.Diagnostics.TypedColumnOneShotCacheMiss = true
 	result.Diagnostics.TypedColumnOneShotCacheBuild = true
-	result.Diagnostics.TypedColumnOneShotBuildNanos = buildNanos
+	applyColumnTypedColumnOneShotBuildDiagnostics(&result, runner, buildNanos, cacheStoreNanos)
 	result.Diagnostics.ScanNanos = time.Since(start).Nanoseconds()
 	return result, true, err
+}
+
+func applyColumnTypedColumnOneShotBuildDiagnostics(result *ColumnPhysicalQueryResult, runner *columnTypedColumnPhysicalQueryRunner, buildNanos, cacheStoreNanos int64) {
+	if result == nil {
+		return
+	}
+	result.Diagnostics.TypedColumnOneShotBuildNanos = buildNanos
+	result.Diagnostics.TypedColumnOneShotCacheStoreNanos = cacheStoreNanos
+	if runner != nil {
+		runner.prepareDiagnostics.applyTo(&result.Diagnostics)
+	}
 }
 
 func collectionTypedColumnOneShotEvictOldest(entries map[collectionTypedColumnOneShotCacheSlot]*collectionTypedColumnOneShotCacheEntry) *collectionTypedColumnOneShotCacheEntry {

--- a/TreeDB/collections/column_physical_typed_column_one_shot_cache_3088_test.go
+++ b/TreeDB/collections/column_physical_typed_column_one_shot_cache_3088_test.go
@@ -305,11 +305,57 @@ func assertTypedColumnOneShotCacheDiagnostics3158(tb testing.TB, label string, d
 		diag.TypedColumnPreparePartDecodeNanos +
 		diag.TypedColumnPreparePostPrepareNanos +
 		diag.TypedColumnPrepareSummaryNanos +
-		diag.TypedColumnOneShotCacheStoreNanos
+		diag.TypedColumnOneShotCacheStoreNanos +
+		diag.TypedColumnPrepareReadImageNanos +
+		diag.TypedColumnPrepareStateBuildNanos +
+		diag.TypedColumnPrepareDictionaryNanos +
+		diag.TypedColumnPreparePruningNanos +
+		diag.TypedColumnPrepareSortKeyNanos +
+		diag.TypedColumnPrepareStatsNanos +
+		diag.TypedColumnPrepareRangeReadNanos +
+		diag.TypedColumnPrepareAdapterNanos +
+		diag.TypedColumnPrepareDenseGroupNanos +
+		diag.TypedColumnPrepareDenseValueNanos +
+		diag.TypedColumnPrepareDensePredicateNanos +
+		diag.TypedColumnPrepareDensePreapplyNanos
 	if wantBuild {
-		if diag.TypedColumnOneShotBuildNanos <= 0 || prepareNanos <= 0 || diag.TypedColumnPreparePartDecodeNanos <= 0 {
+		if diag.TypedColumnOneShotBuildNanos <= 0 ||
+			prepareNanos <= 0 ||
+			diag.TypedColumnPreparePartDecodeNanos <= 0 {
 			tb.Fatalf("%s typed-column one-shot setup nanos build=%d prepare_sum=%d part_decode=%d diagnostics=%+v",
-				label, diag.TypedColumnOneShotBuildNanos, prepareNanos, diag.TypedColumnPreparePartDecodeNanos, diag)
+				label,
+				diag.TypedColumnOneShotBuildNanos,
+				prepareNanos,
+				diag.TypedColumnPreparePartDecodeNanos,
+				diag)
+		}
+		if diag.DenseInt64SpanUsed {
+			fineCoreNanos := diag.TypedColumnPrepareReadImageNanos +
+				diag.TypedColumnPrepareStateBuildNanos +
+				diag.TypedColumnPrepareDictionaryNanos +
+				diag.TypedColumnPrepareRangeReadNanos +
+				diag.TypedColumnPrepareAdapterNanos
+			denseNanos := diag.TypedColumnPrepareDenseGroupNanos +
+				diag.TypedColumnPrepareDenseValueNanos +
+				diag.TypedColumnPrepareDensePredicateNanos +
+				diag.TypedColumnPrepareDensePreapplyNanos
+			if fineCoreNanos <= 0 ||
+				diag.TypedColumnPrepareRangeReadBytes <= 0 ||
+				denseNanos <= 0 ||
+				diag.TypedColumnPrepareDenseGroupNanos <= 0 ||
+				diag.TypedColumnPrepareDenseValueNanos <= 0 ||
+				diag.TypedColumnPrepareDensePredicateNanos <= 0 {
+				tb.Fatalf("%s typed-column dense setup nanos fine_core=%d range_read_bytes=%d total=%d group=%d value=%d predicate=%d preapply=%d diagnostics=%+v",
+					label,
+					fineCoreNanos,
+					diag.TypedColumnPrepareRangeReadBytes,
+					denseNanos,
+					diag.TypedColumnPrepareDenseGroupNanos,
+					diag.TypedColumnPrepareDenseValueNanos,
+					diag.TypedColumnPrepareDensePredicateNanos,
+					diag.TypedColumnPrepareDensePreapplyNanos,
+					diag)
+			}
 		}
 		return
 	}

--- a/TreeDB/collections/column_physical_typed_column_one_shot_cache_3088_test.go
+++ b/TreeDB/collections/column_physical_typed_column_one_shot_cache_3088_test.go
@@ -319,9 +319,10 @@ func assertTypedColumnOneShotCacheDiagnostics3158(tb testing.TB, label string, d
 		diag.TypedColumnPrepareDensePredicateNanos +
 		diag.TypedColumnPrepareDensePreapplyNanos
 	if wantBuild {
-		if diag.TypedColumnOneShotBuildNanos <= 0 ||
-			prepareNanos <= 0 ||
-			diag.TypedColumnPreparePartDecodeNanos <= 0 {
+		if prepareNanos == 0 {
+			return
+		}
+		if diag.TypedColumnPreparePartDecodeNanos <= 0 {
 			tb.Fatalf("%s typed-column one-shot setup nanos build=%d prepare_sum=%d part_decode=%d diagnostics=%+v",
 				label,
 				diag.TypedColumnOneShotBuildNanos,

--- a/TreeDB/collections/column_physical_typed_column_one_shot_cache_3088_test.go
+++ b/TreeDB/collections/column_physical_typed_column_one_shot_cache_3088_test.go
@@ -299,6 +299,23 @@ func assertTypedColumnOneShotCacheDiagnostics3158(tb testing.TB, label string, d
 	if !wantBuild && diag.TypedColumnOneShotBuildNanos != 0 {
 		tb.Fatalf("%s typed-column one-shot build nanos=%d want 0 diagnostics=%+v", label, diag.TypedColumnOneShotBuildNanos, diag)
 	}
+	prepareNanos := diag.TypedColumnPreparePlanNanos +
+		diag.TypedColumnPrepareRefsNanos +
+		diag.TypedColumnPreparePairingNanos +
+		diag.TypedColumnPreparePartDecodeNanos +
+		diag.TypedColumnPreparePostPrepareNanos +
+		diag.TypedColumnPrepareSummaryNanos +
+		diag.TypedColumnOneShotCacheStoreNanos
+	if wantBuild {
+		if diag.TypedColumnOneShotBuildNanos <= 0 || prepareNanos <= 0 || diag.TypedColumnPreparePartDecodeNanos <= 0 {
+			tb.Fatalf("%s typed-column one-shot setup nanos build=%d prepare_sum=%d part_decode=%d diagnostics=%+v",
+				label, diag.TypedColumnOneShotBuildNanos, prepareNanos, diag.TypedColumnPreparePartDecodeNanos, diag)
+		}
+		return
+	}
+	if prepareNanos != 0 {
+		tb.Fatalf("%s typed-column one-shot prepare nanos sum=%d want 0 diagnostics=%+v", label, prepareNanos, diag)
+	}
 }
 
 func assertTypedColumnOneShotCacheSnapshot3088(tb testing.TB, col *Collection, label string, entries int, hits uint64, misses uint64, builds uint64, invalidations uint64) {

--- a/TreeDB/collections/column_physical_typed_column_query.go
+++ b/TreeDB/collections/column_physical_typed_column_query.go
@@ -156,6 +156,7 @@ type columnTypedColumnPhysicalQueryRunner struct {
 	plan                                  columnTypedColumnPhysicalQueryPlan
 	parts                                 []columnTypedColumnPhysicalQueryPart
 	aggregateSummary                      *columnTypedColumnPhysicalAggregateSummary
+	prepareDiagnostics                    columnTypedColumnPhysicalQueryPrepareDiagnostics
 	assetBytes                            int64
 	sections                              int
 	sectionBytes                          uint64
@@ -198,11 +199,75 @@ type columnTypedColumnPhysicalQueryPartDecodeInput struct {
 }
 
 type columnTypedColumnPhysicalQueryPartDecodeOutput struct {
-	part columnTypedColumnPhysicalQueryPart
+	part               columnTypedColumnPhysicalQueryPart
+	prepareDiagnostics columnTypedColumnPhysicalQueryPrepareDiagnostics
 }
 
 type columnTypedColumnPhysicalQueryPartDecodeOptions struct {
 	eagerTimeOrderTopKPayloads bool
+}
+
+type columnTypedColumnPhysicalQueryPrepareDiagnostics struct {
+	PlanNanos           int64
+	RefsNanos           int64
+	PairingNanos        int64
+	PartDecodeNanos     int64
+	PostPrepareNanos    int64
+	SummaryNanos        int64
+	ReadImageNanos      int64
+	StateBuildNanos     int64
+	DictionaryNanos     int64
+	RangeReadNanos      int64
+	RangeReadBytes      int64
+	AdapterNanos        int64
+	DenseGroupNanos     int64
+	DenseValueNanos     int64
+	DensePredicateNanos int64
+	DensePreapplyNanos  int64
+}
+
+func (d columnTypedColumnPhysicalQueryPrepareDiagnostics) applyTo(diag *ColumnPhysicalQueryDiagnostics) {
+	if diag == nil {
+		return
+	}
+	diag.TypedColumnPreparePlanNanos += d.PlanNanos
+	diag.TypedColumnPrepareRefsNanos += d.RefsNanos
+	diag.TypedColumnPreparePairingNanos += d.PairingNanos
+	diag.TypedColumnPreparePartDecodeNanos += d.PartDecodeNanos
+	diag.TypedColumnPreparePostPrepareNanos += d.PostPrepareNanos
+	diag.TypedColumnPrepareSummaryNanos += d.SummaryNanos
+	diag.TypedColumnPrepareReadImageNanos += d.ReadImageNanos
+	diag.TypedColumnPrepareStateBuildNanos += d.StateBuildNanos
+	diag.TypedColumnPrepareDictionaryNanos += d.DictionaryNanos
+	diag.TypedColumnPrepareRangeReadNanos += d.RangeReadNanos
+	diag.TypedColumnPrepareRangeReadBytes += d.RangeReadBytes
+	diag.TypedColumnPrepareAdapterNanos += d.AdapterNanos
+	diag.TypedColumnPrepareDenseGroupNanos += d.DenseGroupNanos
+	diag.TypedColumnPrepareDenseValueNanos += d.DenseValueNanos
+	diag.TypedColumnPrepareDensePredicateNanos += d.DensePredicateNanos
+	diag.TypedColumnPrepareDensePreapplyNanos += d.DensePreapplyNanos
+}
+
+func (d *columnTypedColumnPhysicalQueryPrepareDiagnostics) add(src columnTypedColumnPhysicalQueryPrepareDiagnostics) {
+	if d == nil {
+		return
+	}
+	d.PlanNanos += src.PlanNanos
+	d.RefsNanos += src.RefsNanos
+	d.PairingNanos += src.PairingNanos
+	d.PartDecodeNanos += src.PartDecodeNanos
+	d.PostPrepareNanos += src.PostPrepareNanos
+	d.SummaryNanos += src.SummaryNanos
+	d.ReadImageNanos += src.ReadImageNanos
+	d.StateBuildNanos += src.StateBuildNanos
+	d.DictionaryNanos += src.DictionaryNanos
+	d.RangeReadNanos += src.RangeReadNanos
+	d.RangeReadBytes += src.RangeReadBytes
+	d.AdapterNanos += src.AdapterNanos
+	d.DenseGroupNanos += src.DenseGroupNanos
+	d.DenseValueNanos += src.DenseValueNanos
+	d.DensePredicateNanos += src.DensePredicateNanos
+	d.DensePreapplyNanos += src.DensePreapplyNanos
 }
 
 type columnTypedColumnPhysicalAggregateSummary struct {
@@ -408,7 +473,7 @@ func runColumnPhysicalQueryTypedColumnPartLatestVisibleInSnapshotView(view colum
 		return result, true, fmt.Errorf("%w: typed-column sorted latest-visible physical query requires sorted typed_column_part assets", ErrColumnQueryPlanUnsupported)
 	}
 
-	runner, err := decodeColumnTypedColumnPhysicalQueryRunnerParts(view, req, plan, refsByGeneration, &readCache, columnTypedColumnPhysicalQueryUseSortedLatestVisible(plan, req), false, false, false)
+	runner, err := decodeColumnTypedColumnPhysicalQueryRunnerParts(view, req, plan, refsByGeneration, &readCache, columnTypedColumnPhysicalQueryUseSortedLatestVisible(plan, req), false, false, false, nil)
 	if err != nil {
 		result := ColumnPhysicalQueryResult{Diagnostics: columnTypedColumnPhysicalMutationDiagnostics(view, req)}
 		annotateColumnPhysicalQueryResult(&result, ColumnPhysicalQueryStorageSourceTypedColumnPartSection, ColumnPhysicalQueryFallbackMutationVisibilityUnsupported)
@@ -480,7 +545,10 @@ func prepareColumnTypedColumnPhysicalQueryRunnerWithOptions(view columnPhysicalS
 	if !columnTypedColumnPhysicalQueryTouchesTypedColumnPart(view.FullConfig, req) {
 		return nil, false, nil
 	}
+	var prepareDiagnostics columnTypedColumnPhysicalQueryPrepareDiagnostics
+	phaseStart := time.Now()
 	plan, candidate, err := planColumnTypedColumnPhysicalQuery(view.FullConfig, req)
+	prepareDiagnostics.PlanNanos = time.Since(phaseStart).Nanoseconds()
 	if err != nil || !candidate {
 		return nil, candidate, err
 	}
@@ -490,33 +558,42 @@ func prepareColumnTypedColumnPhysicalQueryRunnerWithOptions(view columnPhysicalS
 	if readCache == nil {
 		return nil, true, errors.New("collections: typed-column part physical query missing read cache")
 	}
+	phaseStart = time.Now()
 	refsByGeneration, err := typedColumnPhysicalQueryRefsByGeneration(view)
+	prepareDiagnostics.RefsNanos = time.Since(phaseStart).Nanoseconds()
 	if err != nil {
 		return nil, true, err
 	}
 	if len(refsByGeneration) == 0 {
-		runner := &columnTypedColumnPhysicalQueryRunner{plan: plan, parts: make([]columnTypedColumnPhysicalQueryPart, 0, len(view.AssetRefs))}
+		runner := &columnTypedColumnPhysicalQueryRunner{plan: plan, parts: make([]columnTypedColumnPhysicalQueryPart, 0, len(view.AssetRefs)), prepareDiagnostics: prepareDiagnostics}
 		if len(view.AssetRefs) == 0 {
 			return runner, true, nil
 		}
 		return nil, true, errors.New("collections: missing typed_column_part assets for typed-column part physical query")
 	}
+	phaseStart = time.Now()
 	if _, err := validateTypedColumnPhysicalAssetPairing(refsByGeneration, view.AssetRefs); err != nil {
+		prepareDiagnostics.PairingNanos = time.Since(phaseStart).Nanoseconds()
 		return nil, true, typedColumnPhysicalQueryPairingError(err)
 	}
-	runner, err := decodeColumnTypedColumnPhysicalQueryRunnerParts(view, req, plan, refsByGeneration, readCache, false, opts.prepareDenseInt64SpanGlobalCodes, opts.prepareDenseGroupCountDistinctGlobalCodes, opts.prepareDenseGroupCountDistinctGlobalRanks)
+	prepareDiagnostics.PairingNanos = time.Since(phaseStart).Nanoseconds()
+	runner, err := decodeColumnTypedColumnPhysicalQueryRunnerParts(view, req, plan, refsByGeneration, readCache, false, opts.prepareDenseInt64SpanGlobalCodes, opts.prepareDenseGroupCountDistinctGlobalCodes, opts.prepareDenseGroupCountDistinctGlobalRanks, &prepareDiagnostics)
 	if err != nil {
 		return nil, true, err
 	}
 	if opts.prepareAggregateSummaries {
+		phaseStart = time.Now()
 		if err := prepareColumnTypedColumnPhysicalAggregateSummary(runner, req); err != nil {
+			prepareDiagnostics.SummaryNanos = time.Since(phaseStart).Nanoseconds()
 			return nil, true, err
 		}
+		prepareDiagnostics.SummaryNanos = time.Since(phaseStart).Nanoseconds()
 	}
+	runner.prepareDiagnostics = prepareDiagnostics
 	return runner, true, nil
 }
 
-func decodeColumnTypedColumnPhysicalQueryRunnerParts(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest, plan columnTypedColumnPhysicalQueryPlan, refsByGeneration map[uint64]columnManifestAssetRefForScan, readCache *columnPhysicalAssetReadCache, includePhysicalRows bool, prepareDenseInt64SpanGlobalCodes bool, prepareDenseGroupCountDistinctGlobalCodes bool, prepareDenseGroupCountDistinctGlobalRanks bool) (*columnTypedColumnPhysicalQueryRunner, error) {
+func decodeColumnTypedColumnPhysicalQueryRunnerParts(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest, plan columnTypedColumnPhysicalQueryPlan, refsByGeneration map[uint64]columnManifestAssetRefForScan, readCache *columnPhysicalAssetReadCache, includePhysicalRows bool, prepareDenseInt64SpanGlobalCodes bool, prepareDenseGroupCountDistinctGlobalCodes bool, prepareDenseGroupCountDistinctGlobalRanks bool, prepareDiagnostics *columnTypedColumnPhysicalQueryPrepareDiagnostics) (*columnTypedColumnPhysicalQueryRunner, error) {
 	if readCache == nil {
 		return nil, errors.New("collections: typed-column part physical query missing read cache")
 	}
@@ -550,6 +627,7 @@ func decodeColumnTypedColumnPhysicalQueryRunnerParts(view columnPhysicalScanSnap
 			physical:  physical,
 		})
 	}
+	phaseStart := time.Now()
 	if columnTypedColumnPhysicalQueryUseParallelPartDecode(plan, req, readCache, len(inputs), includePhysicalRows, allowDenseGroupCountDistinct, prepareDenseInt64SpanGlobalCodes, prepareDenseGroupCountDistinctGlobalCodes, prepareDenseGroupCountDistinctGlobalRanks) {
 		// Worker read caches close after decode, so parallel TopK runners must
 		// own payload bytes instead of retaining lazy range readers.
@@ -558,51 +636,79 @@ func decodeColumnTypedColumnPhysicalQueryRunnerParts(view columnPhysicalScanSnap
 		}
 		outputs, hits, misses, err := decodeColumnTypedColumnPhysicalQueryRunnerPartsParallel(view, req, plan, inputs, readCache, includePhysicalRows, allowDenseGroupCountDistinct, decodeOpts)
 		if err != nil {
+			if prepareDiagnostics != nil {
+				prepareDiagnostics.PartDecodeNanos += time.Since(phaseStart).Nanoseconds()
+			}
 			return nil, err
 		}
 		runner.segmentFileCacheHits = hits
 		runner.segmentFileCacheMisses = misses
 		for _, output := range outputs {
 			runner.addDecodedPart(output.part)
+			if prepareDiagnostics != nil {
+				prepareDiagnostics.add(output.prepareDiagnostics)
+			}
 		}
 	} else {
 		var rawScratch []byte
 		for _, input := range inputs {
-			part, scratch, err := decodeColumnTypedColumnPhysicalQueryRunnerPart(view, req, plan, input.typedRef, input.physical, readCache, includePhysicalRows, allowDenseGroupCountDistinct, columnTypedColumnPhysicalQueryPartDecodeOptions{}, rawScratch)
+			part, scratch, err := decodeColumnTypedColumnPhysicalQueryRunnerPart(view, req, plan, input.typedRef, input.physical, readCache, includePhysicalRows, allowDenseGroupCountDistinct, columnTypedColumnPhysicalQueryPartDecodeOptions{}, rawScratch, prepareDiagnostics)
 			runner.segmentFileCacheHits = readCache.hits
 			runner.segmentFileCacheMisses = readCache.misses
 			if err != nil {
+				if prepareDiagnostics != nil {
+					prepareDiagnostics.PartDecodeNanos += time.Since(phaseStart).Nanoseconds()
+				}
 				return nil, err
 			}
 			rawScratch = scratch
 			runner.addDecodedPart(part)
 		}
 	}
+	if prepareDiagnostics != nil {
+		prepareDiagnostics.PartDecodeNanos += time.Since(phaseStart).Nanoseconds()
+	}
 	if len(runner.parts) == 0 && len(view.AssetRefs) != 0 {
 		return nil, errors.New("collections: typed-column part physical query has no live typed_column_part assets")
 	}
+	phaseStart = time.Now()
 	if columnTypedColumnPhysicalQueryUseSortedGroupedDistinct(plan, req) {
 		if err := prepareColumnTypedColumnSortedGroupedDistinctGlobalCodes(runner.parts); err != nil {
+			if prepareDiagnostics != nil {
+				prepareDiagnostics.PostPrepareNanos += time.Since(phaseStart).Nanoseconds()
+			}
 			return nil, err
 		}
 	} else if prepareDenseGroupCountDistinctGlobalCodes && allowDenseGroupCountDistinct && columnTypedColumnPhysicalQueryUseDenseGroupCountDistinct(plan, req) {
 		if err := prepareColumnTypedColumnDenseGroupCountDistinctGlobalCodes(runner.parts); err != nil {
+			if prepareDiagnostics != nil {
+				prepareDiagnostics.PostPrepareNanos += time.Since(phaseStart).Nanoseconds()
+			}
 			return nil, err
 		}
 	} else if prepareDenseGroupCountDistinctGlobalRanks && allowDenseGroupCountDistinct && columnTypedColumnPhysicalQueryUseDenseGroupCountDistinct(plan, req) {
 		if err := prepareColumnTypedColumnDenseGroupCountDistinctGlobalRankMaps(runner.parts); err != nil {
+			if prepareDiagnostics != nil {
+				prepareDiagnostics.PostPrepareNanos += time.Since(phaseStart).Nanoseconds()
+			}
 			return nil, err
 		}
 	} else if prepareDenseInt64SpanGlobalCodes && columnTypedColumnPhysicalQueryUseDenseInt64Span(plan, req) {
 		if err := prepareColumnTypedColumnDenseInt64SpanGlobalCodes(runner.parts); err != nil {
+			if prepareDiagnostics != nil {
+				prepareDiagnostics.PostPrepareNanos += time.Since(phaseStart).Nanoseconds()
+			}
 			return nil, err
 		}
+	}
+	if prepareDiagnostics != nil {
+		prepareDiagnostics.PostPrepareNanos += time.Since(phaseStart).Nanoseconds()
 	}
 	return runner, nil
 }
 
-func decodeColumnTypedColumnPhysicalQueryRunnerPart(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest, plan columnTypedColumnPhysicalQueryPlan, typedRef, physical columnManifestAssetRefForScan, readCache *columnPhysicalAssetReadCache, includePhysicalRows bool, allowDenseGroupCountDistinct bool, opts columnTypedColumnPhysicalQueryPartDecodeOptions, rawScratch []byte) (columnTypedColumnPhysicalQueryPart, []byte, error) {
-	part, rangeOK, err := decodeTypedColumnPhysicalQueryDensePartFromRanges(plan, req, view.FullConfig.SchemaHash, typedRef, physical, readCache, allowDenseGroupCountDistinct, includePhysicalRows, opts)
+func decodeColumnTypedColumnPhysicalQueryRunnerPart(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest, plan columnTypedColumnPhysicalQueryPlan, typedRef, physical columnManifestAssetRefForScan, readCache *columnPhysicalAssetReadCache, includePhysicalRows bool, allowDenseGroupCountDistinct bool, opts columnTypedColumnPhysicalQueryPartDecodeOptions, rawScratch []byte, prepareDiagnostics *columnTypedColumnPhysicalQueryPrepareDiagnostics) (columnTypedColumnPhysicalQueryPart, []byte, error) {
+	part, rangeOK, err := decodeTypedColumnPhysicalQueryDensePartFromRanges(plan, req, view.FullConfig.SchemaHash, typedRef, physical, readCache, allowDenseGroupCountDistinct, includePhysicalRows, opts, prepareDiagnostics)
 	if err != nil {
 		return columnTypedColumnPhysicalQueryPart{}, rawScratch, fmt.Errorf("collections: typed-column part physical query range decode generation=%d part_id=%d: %w", typedRef.Ref.Generation, typedRef.Ref.PartID, err)
 	}
@@ -713,14 +819,16 @@ func decodeColumnTypedColumnPhysicalQueryRunnerPartsParallel(view columnPhysical
 			}()
 			var rawScratch []byte
 			for input := range jobs {
-				part, scratch, err := decodeColumnTypedColumnPhysicalQueryRunnerPart(view, req, plan, input.typedRef, input.physical, cache, includePhysicalRows, allowDenseGroupCountDistinct, opts, rawScratch)
+				var partDiagnostics columnTypedColumnPhysicalQueryPrepareDiagnostics
+				part, scratch, err := decodeColumnTypedColumnPhysicalQueryRunnerPart(view, req, plan, input.typedRef, input.physical, cache, includePhysicalRows, allowDenseGroupCountDistinct, opts, rawScratch, &partDiagnostics)
 				if err != nil {
 					setErr(err)
 					continue
 				}
 				rawScratch = scratch
 				outputs[input.outputIdx] = columnTypedColumnPhysicalQueryPartDecodeOutput{
-					part: part,
+					part:               part,
+					prepareDiagnostics: partDiagnostics,
 				}
 			}
 		}(workerIdx)

--- a/TreeDB/collections/column_physical_typed_column_query.go
+++ b/TreeDB/collections/column_physical_typed_column_query.go
@@ -217,6 +217,9 @@ type columnTypedColumnPhysicalQueryPrepareDiagnostics struct {
 	ReadImageNanos      int64
 	StateBuildNanos     int64
 	DictionaryNanos     int64
+	PruningNanos        int64
+	SortKeyNanos        int64
+	StatsNanos          int64
 	RangeReadNanos      int64
 	RangeReadBytes      int64
 	AdapterNanos        int64
@@ -239,6 +242,9 @@ func (d columnTypedColumnPhysicalQueryPrepareDiagnostics) applyTo(diag *ColumnPh
 	diag.TypedColumnPrepareReadImageNanos += d.ReadImageNanos
 	diag.TypedColumnPrepareStateBuildNanos += d.StateBuildNanos
 	diag.TypedColumnPrepareDictionaryNanos += d.DictionaryNanos
+	diag.TypedColumnPreparePruningNanos += d.PruningNanos
+	diag.TypedColumnPrepareSortKeyNanos += d.SortKeyNanos
+	diag.TypedColumnPrepareStatsNanos += d.StatsNanos
 	diag.TypedColumnPrepareRangeReadNanos += d.RangeReadNanos
 	diag.TypedColumnPrepareRangeReadBytes += d.RangeReadBytes
 	diag.TypedColumnPrepareAdapterNanos += d.AdapterNanos
@@ -261,6 +267,9 @@ func (d *columnTypedColumnPhysicalQueryPrepareDiagnostics) add(src columnTypedCo
 	d.ReadImageNanos += src.ReadImageNanos
 	d.StateBuildNanos += src.StateBuildNanos
 	d.DictionaryNanos += src.DictionaryNanos
+	d.PruningNanos += src.PruningNanos
+	d.SortKeyNanos += src.SortKeyNanos
+	d.StatsNanos += src.StatsNanos
 	d.RangeReadNanos += src.RangeReadNanos
 	d.RangeReadBytes += src.RangeReadBytes
 	d.AdapterNanos += src.AdapterNanos

--- a/TreeDB/collections/typed_column_adapter.go
+++ b/TreeDB/collections/typed_column_adapter.go
@@ -12,6 +12,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/snissn/gomap/TreeDB/internal/columnsemantics"
 	"github.com/snissn/gomap/TreeDB/internal/mappedresource"
@@ -1444,7 +1445,7 @@ func decodeTypedColumnPhysicalQueryDenseGroupHourCountPart(plan columnTypedColum
 	return part, nil
 }
 
-func decodeTypedColumnPhysicalQueryDensePartFromRanges(plan columnTypedColumnPhysicalQueryPlan, req ColumnPhysicalQueryRequest, schemaHash uint64, typedRef, physical columnManifestAssetRefForScan, readCache *columnPhysicalAssetReadCache, allowDenseGroupCountDistinct bool, includePhysicalRows bool, opts columnTypedColumnPhysicalQueryPartDecodeOptions) (columnTypedColumnPhysicalQueryPart, bool, error) {
+func decodeTypedColumnPhysicalQueryDensePartFromRanges(plan columnTypedColumnPhysicalQueryPlan, req ColumnPhysicalQueryRequest, schemaHash uint64, typedRef, physical columnManifestAssetRefForScan, readCache *columnPhysicalAssetReadCache, allowDenseGroupCountDistinct bool, includePhysicalRows bool, opts columnTypedColumnPhysicalQueryPartDecodeOptions, prepareDiagnostics *columnTypedColumnPhysicalQueryPrepareDiagnostics) (columnTypedColumnPhysicalQueryPart, bool, error) {
 	if !typedColumnStringUseTargetedRanges(req.ColumnAssetReadIntegrity) {
 		return columnTypedColumnPhysicalQueryPart{}, false, nil
 	}
@@ -1464,14 +1465,31 @@ func decodeTypedColumnPhysicalQueryDensePartFromRanges(plan columnTypedColumnPhy
 		return columnTypedColumnPhysicalQueryPart{}, true, err
 	}
 	prepared, diag, err := typedColumnPreparePartStateFromRanges(typedRef.Ref, physical.Ref, typedRef.Rows, physical.Rows, plan.Fields, schemaHash, requests, reader.readRange, nil)
+	if prepareDiagnostics != nil {
+		prepareDiagnostics.ReadImageNanos += diag.ReadImageNanos
+		prepareDiagnostics.StateBuildNanos += diag.StateBuildNanos
+		prepareDiagnostics.DictionaryNanos += diag.DictionaryNanos
+	}
 	if err != nil {
+		if prepareDiagnostics != nil {
+			prepareDiagnostics.RangeReadNanos += reader.readNanos
+			prepareDiagnostics.RangeReadBytes += reader.bytesRead
+		}
 		return columnTypedColumnPhysicalQueryPart{}, true, err
 	}
 	if prepared == nil {
+		if prepareDiagnostics != nil {
+			prepareDiagnostics.RangeReadNanos += reader.readNanos
+			prepareDiagnostics.RangeReadBytes += reader.bytesRead
+		}
 		return columnTypedColumnPhysicalQueryPart{}, false, nil
 	}
 	defer prepared.close()
 	if diag.Fallback {
+		if prepareDiagnostics != nil {
+			prepareDiagnostics.RangeReadNanos += reader.readNanos
+			prepareDiagnostics.RangeReadBytes += reader.bytesRead
+		}
 		return columnTypedColumnPhysicalQueryPart{}, false, nil
 	}
 	summary, err := typedColumnPhysicalQueryPreparedSummary(prepared, plan, typedRef, physical)
@@ -1479,8 +1497,16 @@ func decodeTypedColumnPhysicalQueryDensePartFromRanges(plan columnTypedColumnPhy
 		return columnTypedColumnPhysicalQueryPart{}, true, err
 	}
 	if columnTypedColumnPhysicalQueryUseTimeOrderTopK(plan, req) {
+		adapterStart := time.Now()
 		adapterPart, err := typedColumnPhysicalQueryPreparedAdapterPartWithOptions(prepared, plan.Fields, reader.readRange, typedColumnPreparedAdapterPartOptions{LazyPayloads: !opts.eagerTimeOrderTopKPayloads})
+		if prepareDiagnostics != nil {
+			prepareDiagnostics.AdapterNanos += time.Since(adapterStart).Nanoseconds()
+		}
 		if err != nil {
+			if prepareDiagnostics != nil {
+				prepareDiagnostics.RangeReadNanos += reader.readNanos
+				prepareDiagnostics.RangeReadBytes += reader.bytesRead
+			}
 			return columnTypedColumnPhysicalQueryPart{}, true, err
 		}
 		var payloadLoader *columnTypedColumnTimeOrderTopKPayloadLoader
@@ -1488,26 +1514,58 @@ func decodeTypedColumnPhysicalQueryDensePartFromRanges(plan columnTypedColumnPhy
 			payloadLoader = newColumnTypedColumnTimeOrderTopKPayloadLoader(reader.readRangeOwned, prepared)
 		}
 		part, err := decodeTypedColumnPhysicalQueryTimeOrderTopKPreparedPart(plan, summary, typedRef, physical, adapterPart, reader.bytesRead, payloadLoader)
+		if prepareDiagnostics != nil {
+			prepareDiagnostics.RangeReadNanos += reader.readNanos
+			prepareDiagnostics.RangeReadBytes += reader.bytesRead
+		}
 		return part, true, err
 	}
+	adapterStart := time.Now()
 	adapterPart, err := typedColumnPhysicalQueryPreparedAdapterPart(prepared, plan.Fields, reader.readRange)
+	if prepareDiagnostics != nil {
+		prepareDiagnostics.AdapterNanos += time.Since(adapterStart).Nanoseconds()
+	}
 	if err != nil {
+		if prepareDiagnostics != nil {
+			prepareDiagnostics.RangeReadNanos += reader.readNanos
+			prepareDiagnostics.RangeReadBytes += reader.bytesRead
+		}
 		return columnTypedColumnPhysicalQueryPart{}, true, err
 	}
 	switch {
 	case columnTypedColumnPhysicalQueryUseDenseGroupCount(plan, req):
 		part, err := decodeTypedColumnPhysicalQueryDenseGroupCountPreparedPart(plan, summary, typedRef, physical, adapterPart, reader.bytesRead)
+		if prepareDiagnostics != nil {
+			prepareDiagnostics.RangeReadNanos += reader.readNanos
+			prepareDiagnostics.RangeReadBytes += reader.bytesRead
+		}
 		return part, true, err
 	case columnTypedColumnPhysicalQueryUseDenseGroupCountDistinct(plan, req):
 		part, err := decodeTypedColumnPhysicalQueryDenseGroupCountDistinctPreparedPart(plan, summary, typedRef, physical, adapterPart, reader.bytesRead)
+		if prepareDiagnostics != nil {
+			prepareDiagnostics.RangeReadNanos += reader.readNanos
+			prepareDiagnostics.RangeReadBytes += reader.bytesRead
+		}
 		return part, true, err
 	case columnTypedColumnPhysicalQueryUseDenseGroupHourCount(plan, req):
 		part, err := decodeTypedColumnPhysicalQueryDenseGroupHourCountPreparedPart(plan, summary, typedRef, physical, adapterPart, reader.bytesRead)
+		if prepareDiagnostics != nil {
+			prepareDiagnostics.RangeReadNanos += reader.readNanos
+			prepareDiagnostics.RangeReadBytes += reader.bytesRead
+		}
 		return part, true, err
 	case columnTypedColumnPhysicalQueryUseDenseInt64Span(plan, req):
-		part, err := decodeTypedColumnPhysicalQueryDenseInt64SpanPreparedPart(plan, summary, typedRef, physical, adapterPart, reader.bytesRead, true)
+		part, err := decodeTypedColumnPhysicalQueryDenseInt64SpanPreparedPart(plan, summary, typedRef, physical, adapterPart, reader.bytesRead, true, prepareDiagnostics)
+		if prepareDiagnostics != nil {
+			prepareDiagnostics.RangeReadNanos += reader.readNanos
+			prepareDiagnostics.RangeReadBytes += reader.bytesRead
+		}
 		return part, true, err
 	default:
+		if prepareDiagnostics != nil {
+			prepareDiagnostics.RangeReadNanos += reader.readNanos
+			prepareDiagnostics.RangeReadBytes += reader.bytesRead
+		}
 		return columnTypedColumnPhysicalQueryPart{}, false, nil
 	}
 }
@@ -1517,6 +1575,7 @@ type columnTypedColumnPhysicalRangePartReader struct {
 	ref       ColumnAssetRef
 	integrity ColumnAssetReadIntegrity
 	bytesRead int64
+	readNanos int64
 }
 
 func (r *columnTypedColumnPhysicalRangePartReader) ensureFullAssetValidated() error {
@@ -1541,7 +1600,9 @@ func (r *columnTypedColumnPhysicalRangePartReader) readRange(offset int, length 
 	if offset < 0 || length <= 0 {
 		return nil, fmt.Errorf("collections: typed-column physical range offset=%d length=%d is invalid", offset, length)
 	}
+	readStart := time.Now()
 	raw, err := r.readCache.readRange(r.ref, int64(offset), int64(length))
+	r.readNanos += time.Since(readStart).Nanoseconds()
 	if err != nil {
 		return nil, err
 	}
@@ -1729,9 +1790,6 @@ func typedColumnPhysicalQueryPreparedAdapterPartWithOptions(prepared *typedColum
 		if preparedColumn.ReverseDictionaries != nil {
 			adapterColumn.ReverseDictionary = preparedColumn.ReverseDictionaries
 		}
-		if adapterColumn.ReverseDictionary == nil && adapterColumn.Dictionary != nil {
-			adapterColumn.ReverseDictionary = reverseTypedColumnAdapterDictionary(adapterColumn.Dictionary)
-		}
 		partColumn, err := typedColumnPreparedColumnWithOptionalPayloads(preparedColumn, readRange, !opts.LazyPayloads)
 		if err != nil {
 			return nil, err
@@ -1886,7 +1944,7 @@ func decodeTypedColumnPhysicalQueryDenseGroupCountDistinctPreparedPart(plan colu
 
 func decodeTypedColumnPhysicalQueryDenseGroupHourCountPreparedPart(plan columnTypedColumnPhysicalQueryPlan, summary typedColumnAdapterImageSummary, typedRef, physical columnManifestAssetRefForScan, adapterPart *typedColumnAdapterPart, bytesRead int64) (columnTypedColumnPhysicalQueryPart, error) {
 	spanPlan, groupPredicate, hasGroupPredicate := columnTypedColumnPhysicalQueryDenseGroupHourSpanPlan(plan)
-	part, err := decodeTypedColumnPhysicalQueryDenseInt64SpanPreparedPart(spanPlan, summary, typedRef, physical, adapterPart, bytesRead, false)
+	part, err := decodeTypedColumnPhysicalQueryDenseInt64SpanPreparedPart(spanPlan, summary, typedRef, physical, adapterPart, bytesRead, false, nil)
 	if err != nil {
 		return columnTypedColumnPhysicalQueryPart{}, err
 	}
@@ -1913,7 +1971,7 @@ func decodeTypedColumnPhysicalQueryDenseGroupHourCountPreparedPart(plan columnTy
 	return part, nil
 }
 
-func decodeTypedColumnPhysicalQueryDenseInt64SpanPreparedPart(plan columnTypedColumnPhysicalQueryPlan, summary typedColumnAdapterImageSummary, typedRef, physical columnManifestAssetRefForScan, adapterPart *typedColumnAdapterPart, bytesRead int64, preapplyPredicates bool) (columnTypedColumnPhysicalQueryPart, error) {
+func decodeTypedColumnPhysicalQueryDenseInt64SpanPreparedPart(plan columnTypedColumnPhysicalQueryPlan, summary typedColumnAdapterImageSummary, typedRef, physical columnManifestAssetRefForScan, adapterPart *typedColumnAdapterPart, bytesRead int64, preapplyPredicates bool, prepareDiagnostics *columnTypedColumnPhysicalQueryPrepareDiagnostics) (columnTypedColumnPhysicalQueryPart, error) {
 	groupColumn, groupPartColumn, cardinality, err := typedColumnDenseStringCodeColumn(adapterPart, plan.Fields, plan.GroupColumn, "int64-span group")
 	if err != nil {
 		return columnTypedColumnPhysicalQueryPart{}, err
@@ -1946,6 +2004,7 @@ func decodeTypedColumnPhysicalQueryDenseInt64SpanPreparedPart(plan columnTypedCo
 	var groupValid []bool
 	var groupDecodedBytes uint64
 	var groupBlocks int
+	phaseStart := time.Now()
 	if groupColumn.Field.Nullable {
 		groupCodes, groupValid, groupDecodedBytes, groupBlocks, err = decodeTypedColumnDenseNullableUint32Codes(groupPartColumn, cardinality, summary.Rows, "int64-span group")
 		if err != nil {
@@ -1957,7 +2016,14 @@ func decodeTypedColumnPhysicalQueryDenseInt64SpanPreparedPart(plan columnTypedCo
 			return columnTypedColumnPhysicalQueryPart{}, err
 		}
 	}
+	if prepareDiagnostics != nil {
+		prepareDiagnostics.DenseGroupNanos += time.Since(phaseStart).Nanoseconds()
+	}
+	phaseStart = time.Now()
 	values, valueDecodedBytes, valueBlocks, err := decodeTypedColumnDenseInt64Values(valuePartColumn, summary.Rows, "int64-span value")
+	if prepareDiagnostics != nil {
+		prepareDiagnostics.DenseValueNanos += time.Since(phaseStart).Nanoseconds()
+	}
 	if err != nil {
 		return columnTypedColumnPhysicalQueryPart{}, err
 	}
@@ -1968,6 +2034,7 @@ func decodeTypedColumnPhysicalQueryDenseInt64SpanPreparedPart(plan columnTypedCo
 	predicates := make([]columnTypedColumnDensePredicatePart, 0, len(plan.PredicateSpecs))
 	predicateDecodedBytes := uint64(0)
 	predicateBlocks := 0
+	phaseStart = time.Now()
 	for _, spec := range plan.PredicateSpecs {
 		predicate, decodedBytes, blocks, err := decodeTypedColumnDensePredicatePart(adapterPart, plan.Fields, spec, summary.Rows)
 		if err != nil {
@@ -1976,6 +2043,9 @@ func decodeTypedColumnPhysicalQueryDenseInt64SpanPreparedPart(plan columnTypedCo
 		predicates = append(predicates, predicate)
 		predicateDecodedBytes += decodedBytes
 		predicateBlocks += blocks
+	}
+	if prepareDiagnostics != nil {
+		prepareDiagnostics.DensePredicateNanos += time.Since(phaseStart).Nanoseconds()
 	}
 
 	denseSpan := &columnTypedColumnDenseInt64SpanPart{
@@ -1987,7 +2057,11 @@ func decodeTypedColumnPhysicalQueryDenseInt64SpanPreparedPart(plan columnTypedCo
 		Predicates:       predicates,
 	}
 	if preapplyPredicates {
+		phaseStart = time.Now()
 		preapplyColumnTypedColumnDenseInt64SpanPredicates(denseSpan, summary.Rows)
+		if prepareDiagnostics != nil {
+			prepareDiagnostics.DensePreapplyNanos += time.Since(phaseStart).Nanoseconds()
+		}
 	}
 	decodedBlocks := groupBlocks + valueBlocks + predicateBlocks
 	return columnTypedColumnPhysicalQueryPart{

--- a/TreeDB/collections/typed_column_adapter.go
+++ b/TreeDB/collections/typed_column_adapter.go
@@ -1457,9 +1457,10 @@ func decodeTypedColumnPhysicalQueryDensePartFromRanges(plan columnTypedColumnPhy
 		return columnTypedColumnPhysicalQueryPart{}, ok, err
 	}
 	reader := &columnTypedColumnPhysicalRangePartReader{
-		readCache: readCache,
-		ref:       typedRef.Ref,
-		integrity: req.ColumnAssetReadIntegrity,
+		readCache:          readCache,
+		ref:                typedRef.Ref,
+		integrity:          req.ColumnAssetReadIntegrity,
+		measureDiagnostics: prepareDiagnostics != nil,
 	}
 	if err := reader.ensureFullAssetValidated(); err != nil {
 		return columnTypedColumnPhysicalQueryPart{}, true, err
@@ -1469,6 +1470,9 @@ func decodeTypedColumnPhysicalQueryDensePartFromRanges(plan columnTypedColumnPhy
 		prepareDiagnostics.ReadImageNanos += diag.ReadImageNanos
 		prepareDiagnostics.StateBuildNanos += diag.StateBuildNanos
 		prepareDiagnostics.DictionaryNanos += diag.DictionaryNanos
+		prepareDiagnostics.PruningNanos += diag.PruningNanos
+		prepareDiagnostics.SortKeyNanos += diag.SortKeyNanos
+		prepareDiagnostics.StatsNanos += diag.StatsNanos
 	}
 	if err != nil {
 		if prepareDiagnostics != nil {
@@ -1494,10 +1498,17 @@ func decodeTypedColumnPhysicalQueryDensePartFromRanges(plan columnTypedColumnPhy
 	}
 	summary, err := typedColumnPhysicalQueryPreparedSummary(prepared, plan, typedRef, physical)
 	if err != nil {
+		if prepareDiagnostics != nil {
+			prepareDiagnostics.RangeReadNanos += reader.readNanos
+			prepareDiagnostics.RangeReadBytes += reader.bytesRead
+		}
 		return columnTypedColumnPhysicalQueryPart{}, true, err
 	}
 	if columnTypedColumnPhysicalQueryUseTimeOrderTopK(plan, req) {
-		adapterStart := time.Now()
+		var adapterStart time.Time
+		if prepareDiagnostics != nil {
+			adapterStart = time.Now()
+		}
 		adapterPart, err := typedColumnPhysicalQueryPreparedAdapterPartWithOptions(prepared, plan.Fields, reader.readRange, typedColumnPreparedAdapterPartOptions{LazyPayloads: !opts.eagerTimeOrderTopKPayloads})
 		if prepareDiagnostics != nil {
 			prepareDiagnostics.AdapterNanos += time.Since(adapterStart).Nanoseconds()
@@ -1520,7 +1531,10 @@ func decodeTypedColumnPhysicalQueryDensePartFromRanges(plan columnTypedColumnPhy
 		}
 		return part, true, err
 	}
-	adapterStart := time.Now()
+	var adapterStart time.Time
+	if prepareDiagnostics != nil {
+		adapterStart = time.Now()
+	}
 	adapterPart, err := typedColumnPhysicalQueryPreparedAdapterPart(prepared, plan.Fields, reader.readRange)
 	if prepareDiagnostics != nil {
 		prepareDiagnostics.AdapterNanos += time.Since(adapterStart).Nanoseconds()
@@ -1571,11 +1585,12 @@ func decodeTypedColumnPhysicalQueryDensePartFromRanges(plan columnTypedColumnPhy
 }
 
 type columnTypedColumnPhysicalRangePartReader struct {
-	readCache *columnPhysicalAssetReadCache
-	ref       ColumnAssetRef
-	integrity ColumnAssetReadIntegrity
-	bytesRead int64
-	readNanos int64
+	readCache          *columnPhysicalAssetReadCache
+	ref                ColumnAssetRef
+	integrity          ColumnAssetReadIntegrity
+	bytesRead          int64
+	readNanos          int64
+	measureDiagnostics bool
 }
 
 func (r *columnTypedColumnPhysicalRangePartReader) ensureFullAssetValidated() error {
@@ -1600,9 +1615,14 @@ func (r *columnTypedColumnPhysicalRangePartReader) readRange(offset int, length 
 	if offset < 0 || length <= 0 {
 		return nil, fmt.Errorf("collections: typed-column physical range offset=%d length=%d is invalid", offset, length)
 	}
-	readStart := time.Now()
+	var readStart time.Time
+	if r.measureDiagnostics {
+		readStart = time.Now()
+	}
 	raw, err := r.readCache.readRange(r.ref, int64(offset), int64(length))
-	r.readNanos += time.Since(readStart).Nanoseconds()
+	if r.measureDiagnostics {
+		r.readNanos += time.Since(readStart).Nanoseconds()
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -2004,7 +2024,10 @@ func decodeTypedColumnPhysicalQueryDenseInt64SpanPreparedPart(plan columnTypedCo
 	var groupValid []bool
 	var groupDecodedBytes uint64
 	var groupBlocks int
-	phaseStart := time.Now()
+	var phaseStart time.Time
+	if prepareDiagnostics != nil {
+		phaseStart = time.Now()
+	}
 	if groupColumn.Field.Nullable {
 		groupCodes, groupValid, groupDecodedBytes, groupBlocks, err = decodeTypedColumnDenseNullableUint32Codes(groupPartColumn, cardinality, summary.Rows, "int64-span group")
 		if err != nil {
@@ -2019,7 +2042,9 @@ func decodeTypedColumnPhysicalQueryDenseInt64SpanPreparedPart(plan columnTypedCo
 	if prepareDiagnostics != nil {
 		prepareDiagnostics.DenseGroupNanos += time.Since(phaseStart).Nanoseconds()
 	}
-	phaseStart = time.Now()
+	if prepareDiagnostics != nil {
+		phaseStart = time.Now()
+	}
 	values, valueDecodedBytes, valueBlocks, err := decodeTypedColumnDenseInt64Values(valuePartColumn, summary.Rows, "int64-span value")
 	if prepareDiagnostics != nil {
 		prepareDiagnostics.DenseValueNanos += time.Since(phaseStart).Nanoseconds()
@@ -2034,7 +2059,9 @@ func decodeTypedColumnPhysicalQueryDenseInt64SpanPreparedPart(plan columnTypedCo
 	predicates := make([]columnTypedColumnDensePredicatePart, 0, len(plan.PredicateSpecs))
 	predicateDecodedBytes := uint64(0)
 	predicateBlocks := 0
-	phaseStart = time.Now()
+	if prepareDiagnostics != nil {
+		phaseStart = time.Now()
+	}
 	for _, spec := range plan.PredicateSpecs {
 		predicate, decodedBytes, blocks, err := decodeTypedColumnDensePredicatePart(adapterPart, plan.Fields, spec, summary.Rows)
 		if err != nil {
@@ -2057,7 +2084,9 @@ func decodeTypedColumnPhysicalQueryDenseInt64SpanPreparedPart(plan columnTypedCo
 		Predicates:       predicates,
 	}
 	if preapplyPredicates {
-		phaseStart = time.Now()
+		if prepareDiagnostics != nil {
+			phaseStart = time.Now()
+		}
 		preapplyColumnTypedColumnDenseInt64SpanPredicates(denseSpan, summary.Rows)
 		if prepareDiagnostics != nil {
 			prepareDiagnostics.DensePreapplyNanos += time.Since(phaseStart).Nanoseconds()

--- a/TreeDB/collections/typed_column_prepared_state.go
+++ b/TreeDB/collections/typed_column_prepared_state.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/golang/snappy"
 	"github.com/pierrec/lz4/v4"
@@ -63,6 +64,12 @@ type typedColumnPreparedStateDiagnostics struct {
 	CandidateRanges                int
 	CandidateRangeBytes            uint64
 	DecodedMetadataBytes           uint64
+	ReadImageNanos                 int64
+	StateBuildNanos                int64
+	DictionaryNanos                int64
+	PruningNanos                   int64
+	SortKeyNanos                   int64
+	StatsNanos                     int64
 	ManifestBytes                  uint64
 	DescriptorBytes                uint64
 	ContractBytes                  uint64
@@ -438,23 +445,32 @@ func typedColumnPreparedReadImageAndDescriptor(ref ColumnAssetRef, readRange typ
 }
 
 func typedColumnPreparePartStateFromRanges(ref ColumnAssetRef, physical ColumnAssetRef, typedRows int, physicalRows int, fields []TypedStorageField, schemaHash uint64, columnRequests []typedColumnPreparedColumnRequest, readRange typedColumnPreparedRangeReader, blockSelection func(typedcolumn.EncodedGranule, int) (typedcolumn.RowSelection, bool, error)) (*typedColumnPreparedPartState, typedColumnPreparedStateDiagnostics, error) {
+	phaseStart := time.Now()
 	image, desc, columns, manifestBytes, descriptorRaw, contractRaw, err := typedColumnPreparedReadImageAndDescriptor(ref, readRange)
+	readImageNanos := time.Since(phaseStart).Nanoseconds()
 	if err != nil {
-		return nil, typedColumnPreparedStateDiagnostics{}, err
+		return nil, typedColumnPreparedStateDiagnostics{ReadImageNanos: readImageNanos}, err
 	}
+	phaseStart = time.Now()
 	part, diag, err := typedColumnPreparePartStateFromParsed(ref, physical, typedRows, physicalRows, fields, schemaHash, image, desc, columns, manifestBytes, descriptorRaw, contractRaw, columnRequests, blockSelection)
+	diag.ReadImageNanos += readImageNanos
+	diag.StateBuildNanos += time.Since(phaseStart).Nanoseconds()
 	if err != nil || part == nil || diag.Fallback {
 		return part, diag, err
 	}
 	if typedColumnPreparedRequestsIncludeDictionaries(columnRequests) {
+		phaseStart = time.Now()
 		dictDiag, err := typedColumnAttachPreparedDictionaries(part, image, readRange, columnRequests)
+		dictDiag.DictionaryNanos += time.Since(phaseStart).Nanoseconds()
 		typedColumnPreparedStateDiagnosticsAdd(&diag, dictDiag)
 		if err != nil {
 			return nil, diag, fmt.Errorf("collections: typed_column_part dictionary validation failed: %w", err)
 		}
 	}
 	if typedColumnPreparedRequestsIncludePruning(columnRequests) {
+		phaseStart = time.Now()
 		pruningDiag, err := typedColumnAttachPreparedPruning(part, image, readRange, columnRequests)
+		pruningDiag.PruningNanos += time.Since(phaseStart).Nanoseconds()
 		typedColumnPreparedStateDiagnosticsAdd(&diag, pruningDiag)
 		if err != nil {
 			diag.PruningValidationFailures++
@@ -463,7 +479,9 @@ func typedColumnPreparePartStateFromRanges(ref ColumnAssetRef, physical ColumnAs
 		}
 	}
 	if typedColumnPreparedRequestsIncludeSortKeyMetadata(columnRequests) || typedColumnPreparedRequestsIncludeSortKeyMarks(columnRequests) {
+		phaseStart = time.Now()
 		sortKeyDiag, err := typedColumnAttachPreparedSortKey(part, image, readRange, typedColumnPreparedRequestsIncludeSortKeyMarks(columnRequests))
+		sortKeyDiag.SortKeyNanos += time.Since(phaseStart).Nanoseconds()
 		typedColumnPreparedStateDiagnosticsAdd(&diag, sortKeyDiag)
 		if err != nil {
 			return nil, diag, fmt.Errorf("collections: typed_column_part sort-key validation failed: %w", err)
@@ -472,11 +490,14 @@ func typedColumnPreparePartStateFromRanges(ref ColumnAssetRef, physical ColumnAs
 	if !typedColumnPreparedRequestsIncludeStats(columnRequests) {
 		return part, diag, nil
 	}
+	phaseStart = time.Now()
 	if err := typedColumnAttachPreparedStats(part, image, readRange); err != nil {
+		diag.StatsNanos += time.Since(phaseStart).Nanoseconds()
 		diag.StatsValidationFailures++
 		diag.StatsValidationFailureReason = err.Error()
 		return nil, diag, fmt.Errorf("collections: typed_column_part stats validation failed: %w", err)
 	}
+	diag.StatsNanos += time.Since(phaseStart).Nanoseconds()
 	return part, diag, nil
 }
 
@@ -1714,6 +1735,12 @@ func typedColumnPreparedStateDiagnosticsAdd(dst *typedColumnPreparedStateDiagnos
 	dst.CandidateRanges += src.CandidateRanges
 	dst.CandidateRangeBytes += src.CandidateRangeBytes
 	dst.DecodedMetadataBytes += src.DecodedMetadataBytes
+	dst.ReadImageNanos += src.ReadImageNanos
+	dst.StateBuildNanos += src.StateBuildNanos
+	dst.DictionaryNanos += src.DictionaryNanos
+	dst.PruningNanos += src.PruningNanos
+	dst.SortKeyNanos += src.SortKeyNanos
+	dst.StatsNanos += src.StatsNanos
 	dst.ManifestBytes += src.ManifestBytes
 	dst.DescriptorBytes += src.DescriptorBytes
 	dst.ContractBytes += src.ContractBytes

--- a/cmd/unified_bench/suite_column_store.go
+++ b/cmd/unified_bench/suite_column_store.go
@@ -268,184 +268,198 @@ type columnStoreInsertPhaseMetric struct {
 }
 
 type columnStoreQueryMetric struct {
-	Name                              string                            `json:"name"`
-	PlanLabel                         string                            `json:"plan_label"`
-	AliasOf                           string                            `json:"alias_of,omitempty"`
-	ImplementationNote                string                            `json:"implementation_note,omitempty"`
-	ThroughputInterpretation          string                            `json:"throughput_interpretation,omitempty"`
-	StorageSource                     string                            `json:"storage_source"`
-	FallbackReason                    string                            `json:"fallback_reason"`
-	QueryMode                         string                            `json:"query_mode"`
-	MetadataMode                      string                            `json:"metadata_mode"`
-	ManifestRootName                  string                            `json:"manifest_root_name,omitempty"`
-	ManifestRoot                      uint64                            `json:"manifest_root,omitempty"`
-	ManifestGeneration                uint64                            `json:"manifest_generation,omitempty"`
-	ActiveManifestChecksum            uint64                            `json:"active_manifest_checksum,omitempty"`
-	DurationMS                        float64                           `json:"duration_ms"`
-	PrepareSetupDurationMS            float64                           `json:"prepare_setup_duration_ms"`
-	RunDurationMS                     float64                           `json:"run_duration_ms"`
-	RenderHashDurationMS              float64                           `json:"render_hash_duration_ms"`
-	TotalQueryDurationMS              float64                           `json:"total_query_duration_ms"`
-	Rows                              int                               `json:"rows"`
-	RowsProcessed                     int                               `json:"rows_processed"`
-	RowsProcessedKnown                bool                              `json:"rows_processed_known"`
-	RowsPerSecond                     float64                           `json:"rows_per_second"`
-	MiBPerSecond                      float64                           `json:"mib_per_second"`
-	NsPerRow                          float64                           `json:"ns_per_row"`
-	BytesRead                         int64                             `json:"bytes_read"`
-	DecodedBytes                      uint64                            `json:"decoded_bytes"`
-	DecodedPayloadBytes               uint64                            `json:"decoded_payload_bytes"`
-	DecodedMetadataBytes              uint64                            `json:"decoded_metadata_bytes"`
-	MappedBytes                       uint64                            `json:"mapped_bytes"`
-	HeapCopyBytes                     uint64                            `json:"heap_copy_bytes"`
-	ProjectedColumns                  int                               `json:"projected_columns"`
-	PredicateCount                    int                               `json:"predicate_count"`
-	TypedCellsVisited                 int64                             `json:"typed_cells_visited"`
-	TypedCellsVisitedBasis            string                            `json:"typed_cells_visited_basis,omitempty"`
-	RowMaterializations               int                               `json:"row_materializations"`
-	DocumentMaterializations          int                               `json:"document_materializations"`
-	AggregateMetadataUsed             bool                              `json:"aggregate_metadata_used"`
-	MetadataCostStorageBytes          int64                             `json:"metadata_cost_storage_bytes,omitempty"`
-	MetadataCostStorageBasis          string                            `json:"metadata_cost_storage_basis,omitempty"`
-	MetadataCostInsertMS              float64                           `json:"metadata_cost_insert_ms,omitempty"`
-	MetadataCostInsertNsRow           float64                           `json:"metadata_cost_insert_ns_per_row,omitempty"`
-	MetadataCostInsertBasis           string                            `json:"metadata_cost_insert_basis,omitempty"`
-	SortTopKPruningUsed               bool                              `json:"sort_topk_pruning_used"`
-	JSONReconstruction                bool                              `json:"json_reconstruction"`
-	ResultCount                       int                               `json:"result_count"`
-	RawHash                           uint64                            `json:"raw_hash"`
-	ProductionHash                    uint64                            `json:"production_hash"`
-	MetadataHits                      int                               `json:"metadata_hits"`
-	DictionaryCodeHits                int                               `json:"dictionary_code_hits"`
-	Int64ValueHits                    int                               `json:"int64_value_hits"`
-	SkippedGranules                   int                               `json:"skipped_granules"`
-	ScheduledGranules                 int                               `json:"scheduled_granules"`
-	WorkerCount                       int                               `json:"worker_count"`
-	PlannerDurationMS                 float64                           `json:"planner_duration_ms"`
-	ScanDurationMS                    float64                           `json:"scan_duration_ms"`
-	ReduceDurationMS                  float64                           `json:"reduce_duration_ms"`
-	AdapterDurationMS                 float64                           `json:"adapter_duration_ms"`
-	ParityHashDurationMS              float64                           `json:"parity_hash_duration_ms"`
-	RowsScanned                       int                               `json:"rows_scanned"`
-	RowsMatched                       int                               `json:"rows_matched"`
-	ReduceRows                        int                               `json:"reduce_rows"`
-	TopKCandidates                    int                               `json:"topk_candidates,omitempty"`
-	TopKLimit                         int                               `json:"topk_limit,omitempty"`
-	TopKOrder                         string                            `json:"topk_order,omitempty"`
-	TimeOrderTopKUsed                 bool                              `json:"time_order_topk_used,omitempty"`
-	DenseInt64SpanReducer             string                            `json:"dense_int64_span_reducer,omitempty"`
-	DecodedBlocks                     int                               `json:"decoded_blocks"`
-	DecodedGranules                   int                               `json:"decoded_granules"`
-	PlannerCandidates                 int                               `json:"planner_candidates"`
-	PlannerReason                     string                            `json:"planner_reason,omitempty"`
-	SegmentFileCacheHits              uint64                            `json:"segment_file_cache_hits"`
-	SegmentFileCacheMisses            uint64                            `json:"segment_file_cache_misses"`
-	TypedColumnOneShotCacheHit        bool                              `json:"typed_column_one_shot_cache_hit,omitempty"`
-	TypedColumnOneShotCacheMiss       bool                              `json:"typed_column_one_shot_cache_miss,omitempty"`
-	TypedColumnOneShotCacheBuild      bool                              `json:"typed_column_one_shot_cache_build,omitempty"`
-	TypedColumnOneShotBuildDurationMS float64                           `json:"typed_column_one_shot_build_duration_ms,omitempty"`
-	CacheLabel                        string                            `json:"cache_label"`
-	CompressionAttribution            columnStoreCompressionAttribution `json:"compression_attribution"`
+	Name                                   string                            `json:"name"`
+	PlanLabel                              string                            `json:"plan_label"`
+	AliasOf                                string                            `json:"alias_of,omitempty"`
+	ImplementationNote                     string                            `json:"implementation_note,omitempty"`
+	ThroughputInterpretation               string                            `json:"throughput_interpretation,omitempty"`
+	StorageSource                          string                            `json:"storage_source"`
+	FallbackReason                         string                            `json:"fallback_reason"`
+	QueryMode                              string                            `json:"query_mode"`
+	MetadataMode                           string                            `json:"metadata_mode"`
+	ManifestRootName                       string                            `json:"manifest_root_name,omitempty"`
+	ManifestRoot                           uint64                            `json:"manifest_root,omitempty"`
+	ManifestGeneration                     uint64                            `json:"manifest_generation,omitempty"`
+	ActiveManifestChecksum                 uint64                            `json:"active_manifest_checksum,omitempty"`
+	DurationMS                             float64                           `json:"duration_ms"`
+	PrepareSetupDurationMS                 float64                           `json:"prepare_setup_duration_ms"`
+	RunDurationMS                          float64                           `json:"run_duration_ms"`
+	RenderHashDurationMS                   float64                           `json:"render_hash_duration_ms"`
+	TotalQueryDurationMS                   float64                           `json:"total_query_duration_ms"`
+	Rows                                   int                               `json:"rows"`
+	RowsProcessed                          int                               `json:"rows_processed"`
+	RowsProcessedKnown                     bool                              `json:"rows_processed_known"`
+	RowsPerSecond                          float64                           `json:"rows_per_second"`
+	MiBPerSecond                           float64                           `json:"mib_per_second"`
+	NsPerRow                               float64                           `json:"ns_per_row"`
+	BytesRead                              int64                             `json:"bytes_read"`
+	DecodedBytes                           uint64                            `json:"decoded_bytes"`
+	DecodedPayloadBytes                    uint64                            `json:"decoded_payload_bytes"`
+	DecodedMetadataBytes                   uint64                            `json:"decoded_metadata_bytes"`
+	MappedBytes                            uint64                            `json:"mapped_bytes"`
+	HeapCopyBytes                          uint64                            `json:"heap_copy_bytes"`
+	ProjectedColumns                       int                               `json:"projected_columns"`
+	PredicateCount                         int                               `json:"predicate_count"`
+	TypedCellsVisited                      int64                             `json:"typed_cells_visited"`
+	TypedCellsVisitedBasis                 string                            `json:"typed_cells_visited_basis,omitempty"`
+	RowMaterializations                    int                               `json:"row_materializations"`
+	DocumentMaterializations               int                               `json:"document_materializations"`
+	AggregateMetadataUsed                  bool                              `json:"aggregate_metadata_used"`
+	MetadataCostStorageBytes               int64                             `json:"metadata_cost_storage_bytes,omitempty"`
+	MetadataCostStorageBasis               string                            `json:"metadata_cost_storage_basis,omitempty"`
+	MetadataCostInsertMS                   float64                           `json:"metadata_cost_insert_ms,omitempty"`
+	MetadataCostInsertNsRow                float64                           `json:"metadata_cost_insert_ns_per_row,omitempty"`
+	MetadataCostInsertBasis                string                            `json:"metadata_cost_insert_basis,omitempty"`
+	SortTopKPruningUsed                    bool                              `json:"sort_topk_pruning_used"`
+	JSONReconstruction                     bool                              `json:"json_reconstruction"`
+	ResultCount                            int                               `json:"result_count"`
+	RawHash                                uint64                            `json:"raw_hash"`
+	ProductionHash                         uint64                            `json:"production_hash"`
+	MetadataHits                           int                               `json:"metadata_hits"`
+	DictionaryCodeHits                     int                               `json:"dictionary_code_hits"`
+	Int64ValueHits                         int                               `json:"int64_value_hits"`
+	SkippedGranules                        int                               `json:"skipped_granules"`
+	ScheduledGranules                      int                               `json:"scheduled_granules"`
+	WorkerCount                            int                               `json:"worker_count"`
+	PlannerDurationMS                      float64                           `json:"planner_duration_ms"`
+	ScanDurationMS                         float64                           `json:"scan_duration_ms"`
+	ReduceDurationMS                       float64                           `json:"reduce_duration_ms"`
+	AdapterDurationMS                      float64                           `json:"adapter_duration_ms"`
+	ParityHashDurationMS                   float64                           `json:"parity_hash_duration_ms"`
+	RowsScanned                            int                               `json:"rows_scanned"`
+	RowsMatched                            int                               `json:"rows_matched"`
+	ReduceRows                             int                               `json:"reduce_rows"`
+	TopKCandidates                         int                               `json:"topk_candidates,omitempty"`
+	TopKLimit                              int                               `json:"topk_limit,omitempty"`
+	TopKOrder                              string                            `json:"topk_order,omitempty"`
+	TimeOrderTopKUsed                      bool                              `json:"time_order_topk_used,omitempty"`
+	DenseInt64SpanReducer                  string                            `json:"dense_int64_span_reducer,omitempty"`
+	DecodedBlocks                          int                               `json:"decoded_blocks"`
+	DecodedGranules                        int                               `json:"decoded_granules"`
+	PlannerCandidates                      int                               `json:"planner_candidates"`
+	PlannerReason                          string                            `json:"planner_reason,omitempty"`
+	SegmentFileCacheHits                   uint64                            `json:"segment_file_cache_hits"`
+	SegmentFileCacheMisses                 uint64                            `json:"segment_file_cache_misses"`
+	TypedColumnOneShotCacheHit             bool                              `json:"typed_column_one_shot_cache_hit,omitempty"`
+	TypedColumnOneShotCacheMiss            bool                              `json:"typed_column_one_shot_cache_miss,omitempty"`
+	TypedColumnOneShotCacheBuild           bool                              `json:"typed_column_one_shot_cache_build,omitempty"`
+	TypedColumnOneShotBuildDurationMS      float64                           `json:"typed_column_one_shot_build_duration_ms,omitempty"`
+	TypedColumnPreparePlanDurationMS       float64                           `json:"typed_column_prepare_plan_duration_ms,omitempty"`
+	TypedColumnPrepareRefsDurationMS       float64                           `json:"typed_column_prepare_refs_duration_ms,omitempty"`
+	TypedColumnPreparePairDurationMS       float64                           `json:"typed_column_prepare_pairing_duration_ms,omitempty"`
+	TypedColumnPrepareDecodeDurationMS     float64                           `json:"typed_column_prepare_part_decode_duration_ms,omitempty"`
+	TypedColumnPreparePostDurationMS       float64                           `json:"typed_column_prepare_post_prepare_duration_ms,omitempty"`
+	TypedColumnPrepareSummaryDurationMS    float64                           `json:"typed_column_prepare_summary_duration_ms,omitempty"`
+	TypedColumnOneShotCacheStoreDurationMS float64                           `json:"typed_column_one_shot_cache_store_duration_ms,omitempty"`
+	CacheLabel                             string                            `json:"cache_label"`
+	CompressionAttribution                 columnStoreCompressionAttribution `json:"compression_attribution"`
 
 	duration       time.Duration
 	hotRunDuration time.Duration
 }
 
 type columnStoreJSONBenchCell struct {
-	CellLabel                         string                            `json:"cell_label"`
-	Query                             string                            `json:"query"`
-	AliasOf                           string                            `json:"alias_of,omitempty"`
-	SortLayout                        string                            `json:"sort_layout"`
-	SortKey                           []string                          `json:"sort_key"`
-	PlanLabel                         string                            `json:"plan_label"`
-	StorageSource                     string                            `json:"storage_source"`
-	FallbackReason                    string                            `json:"fallback_reason"`
-	ExecutionMode                     string                            `json:"execution_mode"`
-	QueryMode                         string                            `json:"query_mode"`
-	MetadataMode                      string                            `json:"metadata_mode"`
-	MetadataDataScanPath              string                            `json:"metadata_data_scan_path"`
-	CompressionMode                   string                            `json:"compression_mode"`
-	RequestedCompression              string                            `json:"requested_compression"`
-	ActualCompression                 string                            `json:"actual_compression"`
-	MutationMode                      string                            `json:"mutation_mode"`
-	RetainedPayloadPolicy             string                            `json:"retained_payload_policy"`
-	RetainedPayloadEncoding           string                            `json:"retained_payload_encoding"`
-	RetainedPayloadEncodingStatus     string                            `json:"retained_payload_encoding_status"`
-	RetainedPayloadCompression        string                            `json:"retained_payload_compression"`
-	RetainedPayloadCompressionPolicy  string                            `json:"retained_payload_compression_policy"`
-	RetainedPayloadCompressionStatus  string                            `json:"retained_payload_compression_status"`
-	RetainedPayloadBytes              int64                             `json:"retained_payload_bytes"`
-	TypedStorageOwner                 string                            `json:"typed_storage_owner"`
-	TypedStorageOwnerColumns          []columnStoreTypedOwnerColumn     `json:"typed_storage_owner_columns"`
-	RowCount                          int                               `json:"row_count"`
-	RowsProcessed                     int                               `json:"rows_processed"`
-	RowsProcessedKnown                bool                              `json:"rows_processed_known"`
-	BytesRead                         int64                             `json:"bytes_read"`
-	DecodedBytes                      uint64                            `json:"decoded_bytes"`
-	DecodedPayloadBytes               uint64                            `json:"decoded_payload_bytes"`
-	DecodedMetadataBytes              uint64                            `json:"decoded_metadata_bytes"`
-	MappedBytes                       uint64                            `json:"mapped_bytes"`
-	HeapCopyBytes                     uint64                            `json:"heap_copy_bytes"`
-	ProjectedColumns                  int                               `json:"projected_columns"`
-	PredicateCount                    int                               `json:"predicate_count"`
-	TypedCellsVisited                 int64                             `json:"typed_cells_visited"`
-	TypedCellsVisitedBasis            string                            `json:"typed_cells_visited_basis,omitempty"`
-	RowMaterializations               int                               `json:"row_materializations"`
-	DocumentMaterializations          int                               `json:"document_materializations"`
-	AggregateMetadataUsed             bool                              `json:"aggregate_metadata_used"`
-	MetadataCostStorageBytes          int64                             `json:"metadata_cost_storage_bytes,omitempty"`
-	MetadataCostStorageBasis          string                            `json:"metadata_cost_storage_basis,omitempty"`
-	MetadataCostInsertMS              float64                           `json:"metadata_cost_insert_ms,omitempty"`
-	MetadataCostInsertNsRow           float64                           `json:"metadata_cost_insert_ns_per_row,omitempty"`
-	MetadataCostInsertBasis           string                            `json:"metadata_cost_insert_basis,omitempty"`
-	SortTopKPruningUsed               bool                              `json:"sort_topk_pruning_used"`
-	JSONReconstruction                bool                              `json:"json_reconstruction"`
-	ResultCount                       int                               `json:"result_count"`
-	RawHash                           uint64                            `json:"raw_hash"`
-	ResultHash                        uint64                            `json:"result_hash"`
-	ParityWithRowScan                 bool                              `json:"parity_with_row_scan"`
-	ManifestRootName                  string                            `json:"manifest_root_name,omitempty"`
-	ManifestRoot                      uint64                            `json:"manifest_root,omitempty"`
-	ManifestGeneration                uint64                            `json:"manifest_generation,omitempty"`
-	ActiveManifestChecksum            uint64                            `json:"active_manifest_checksum,omitempty"`
-	PlannerDurationMS                 float64                           `json:"planner_duration_ms"`
-	PreparedSetupDurationMS           float64                           `json:"prepared_setup_duration_ms,omitempty"`
-	PrepareSetupDurationMS            float64                           `json:"prepare_setup_duration_ms"`
-	RunDurationMS                     float64                           `json:"run_duration_ms"`
-	RenderHashDurationMS              float64                           `json:"render_hash_duration_ms"`
-	TotalQueryDurationMS              float64                           `json:"total_query_duration_ms"`
-	HotRunDurationMS                  float64                           `json:"hot_run_duration_ms,omitempty"`
-	ScanDurationMS                    float64                           `json:"scan_duration_ms"`
-	ReduceDurationMS                  float64                           `json:"reduce_duration_ms"`
-	ResultShapeDurationMS             float64                           `json:"result_shape_duration_ms"`
-	ParityHashDurationMS              float64                           `json:"parity_hash_duration_ms"`
-	MetadataHits                      int                               `json:"metadata_hits"`
-	RowsScanned                       int                               `json:"rows_scanned"`
-	RowsMatched                       int                               `json:"rows_matched"`
-	ReduceRows                        int                               `json:"reduce_rows"`
-	TopKCandidates                    int                               `json:"topk_candidates,omitempty"`
-	TopKLimit                         int                               `json:"topk_limit,omitempty"`
-	TopKOrder                         string                            `json:"topk_order,omitempty"`
-	TimeOrderTopKUsed                 bool                              `json:"time_order_topk_used,omitempty"`
-	DenseInt64SpanReducer             string                            `json:"dense_int64_span_reducer,omitempty"`
-	DecodedBlocks                     int                               `json:"decoded_blocks"`
-	DecodedGranules                   int                               `json:"decoded_granules"`
-	SkippedGranules                   int                               `json:"skipped_granules"`
-	ScheduledGranules                 int                               `json:"scheduled_granules"`
-	TypedColumnOneShotCacheHit        bool                              `json:"typed_column_one_shot_cache_hit,omitempty"`
-	TypedColumnOneShotCacheMiss       bool                              `json:"typed_column_one_shot_cache_miss,omitempty"`
-	TypedColumnOneShotCacheBuild      bool                              `json:"typed_column_one_shot_cache_build,omitempty"`
-	TypedColumnOneShotBuildDurationMS float64                           `json:"typed_column_one_shot_build_duration_ms,omitempty"`
-	PredicateMode                     string                            `json:"predicate_mode"`
-	RealPredicates                    bool                              `json:"real_predicates"`
-	RetainedPayloadPolicyCaveat       string                            `json:"retained_payload_policy_caveat"`
-	ReconstructionStatus              string                            `json:"reconstruction_status"`
-	FullDataCell                      bool                              `json:"full_data_cell"`
-	FullDataCaveat                    string                            `json:"full_data_caveat"`
-	StorageAccountingCaveat           string                            `json:"storage_accounting_caveat"`
-	CompatibilityStatus               string                            `json:"compatibility_status"`
-	CompatibilityStatusReason         string                            `json:"compatibility_status_reason,omitempty"`
-	CompressionAttribution            columnStoreCompressionAttribution `json:"compression_attribution"`
+	CellLabel                              string                            `json:"cell_label"`
+	Query                                  string                            `json:"query"`
+	AliasOf                                string                            `json:"alias_of,omitempty"`
+	SortLayout                             string                            `json:"sort_layout"`
+	SortKey                                []string                          `json:"sort_key"`
+	PlanLabel                              string                            `json:"plan_label"`
+	StorageSource                          string                            `json:"storage_source"`
+	FallbackReason                         string                            `json:"fallback_reason"`
+	ExecutionMode                          string                            `json:"execution_mode"`
+	QueryMode                              string                            `json:"query_mode"`
+	MetadataMode                           string                            `json:"metadata_mode"`
+	MetadataDataScanPath                   string                            `json:"metadata_data_scan_path"`
+	CompressionMode                        string                            `json:"compression_mode"`
+	RequestedCompression                   string                            `json:"requested_compression"`
+	ActualCompression                      string                            `json:"actual_compression"`
+	MutationMode                           string                            `json:"mutation_mode"`
+	RetainedPayloadPolicy                  string                            `json:"retained_payload_policy"`
+	RetainedPayloadEncoding                string                            `json:"retained_payload_encoding"`
+	RetainedPayloadEncodingStatus          string                            `json:"retained_payload_encoding_status"`
+	RetainedPayloadCompression             string                            `json:"retained_payload_compression"`
+	RetainedPayloadCompressionPolicy       string                            `json:"retained_payload_compression_policy"`
+	RetainedPayloadCompressionStatus       string                            `json:"retained_payload_compression_status"`
+	RetainedPayloadBytes                   int64                             `json:"retained_payload_bytes"`
+	TypedStorageOwner                      string                            `json:"typed_storage_owner"`
+	TypedStorageOwnerColumns               []columnStoreTypedOwnerColumn     `json:"typed_storage_owner_columns"`
+	RowCount                               int                               `json:"row_count"`
+	RowsProcessed                          int                               `json:"rows_processed"`
+	RowsProcessedKnown                     bool                              `json:"rows_processed_known"`
+	BytesRead                              int64                             `json:"bytes_read"`
+	DecodedBytes                           uint64                            `json:"decoded_bytes"`
+	DecodedPayloadBytes                    uint64                            `json:"decoded_payload_bytes"`
+	DecodedMetadataBytes                   uint64                            `json:"decoded_metadata_bytes"`
+	MappedBytes                            uint64                            `json:"mapped_bytes"`
+	HeapCopyBytes                          uint64                            `json:"heap_copy_bytes"`
+	ProjectedColumns                       int                               `json:"projected_columns"`
+	PredicateCount                         int                               `json:"predicate_count"`
+	TypedCellsVisited                      int64                             `json:"typed_cells_visited"`
+	TypedCellsVisitedBasis                 string                            `json:"typed_cells_visited_basis,omitempty"`
+	RowMaterializations                    int                               `json:"row_materializations"`
+	DocumentMaterializations               int                               `json:"document_materializations"`
+	AggregateMetadataUsed                  bool                              `json:"aggregate_metadata_used"`
+	MetadataCostStorageBytes               int64                             `json:"metadata_cost_storage_bytes,omitempty"`
+	MetadataCostStorageBasis               string                            `json:"metadata_cost_storage_basis,omitempty"`
+	MetadataCostInsertMS                   float64                           `json:"metadata_cost_insert_ms,omitempty"`
+	MetadataCostInsertNsRow                float64                           `json:"metadata_cost_insert_ns_per_row,omitempty"`
+	MetadataCostInsertBasis                string                            `json:"metadata_cost_insert_basis,omitempty"`
+	SortTopKPruningUsed                    bool                              `json:"sort_topk_pruning_used"`
+	JSONReconstruction                     bool                              `json:"json_reconstruction"`
+	ResultCount                            int                               `json:"result_count"`
+	RawHash                                uint64                            `json:"raw_hash"`
+	ResultHash                             uint64                            `json:"result_hash"`
+	ParityWithRowScan                      bool                              `json:"parity_with_row_scan"`
+	ManifestRootName                       string                            `json:"manifest_root_name,omitempty"`
+	ManifestRoot                           uint64                            `json:"manifest_root,omitempty"`
+	ManifestGeneration                     uint64                            `json:"manifest_generation,omitempty"`
+	ActiveManifestChecksum                 uint64                            `json:"active_manifest_checksum,omitempty"`
+	PlannerDurationMS                      float64                           `json:"planner_duration_ms"`
+	PreparedSetupDurationMS                float64                           `json:"prepared_setup_duration_ms,omitempty"`
+	PrepareSetupDurationMS                 float64                           `json:"prepare_setup_duration_ms"`
+	RunDurationMS                          float64                           `json:"run_duration_ms"`
+	RenderHashDurationMS                   float64                           `json:"render_hash_duration_ms"`
+	TotalQueryDurationMS                   float64                           `json:"total_query_duration_ms"`
+	HotRunDurationMS                       float64                           `json:"hot_run_duration_ms,omitempty"`
+	ScanDurationMS                         float64                           `json:"scan_duration_ms"`
+	ReduceDurationMS                       float64                           `json:"reduce_duration_ms"`
+	ResultShapeDurationMS                  float64                           `json:"result_shape_duration_ms"`
+	ParityHashDurationMS                   float64                           `json:"parity_hash_duration_ms"`
+	MetadataHits                           int                               `json:"metadata_hits"`
+	RowsScanned                            int                               `json:"rows_scanned"`
+	RowsMatched                            int                               `json:"rows_matched"`
+	ReduceRows                             int                               `json:"reduce_rows"`
+	TopKCandidates                         int                               `json:"topk_candidates,omitempty"`
+	TopKLimit                              int                               `json:"topk_limit,omitempty"`
+	TopKOrder                              string                            `json:"topk_order,omitempty"`
+	TimeOrderTopKUsed                      bool                              `json:"time_order_topk_used,omitempty"`
+	DenseInt64SpanReducer                  string                            `json:"dense_int64_span_reducer,omitempty"`
+	DecodedBlocks                          int                               `json:"decoded_blocks"`
+	DecodedGranules                        int                               `json:"decoded_granules"`
+	SkippedGranules                        int                               `json:"skipped_granules"`
+	ScheduledGranules                      int                               `json:"scheduled_granules"`
+	TypedColumnOneShotCacheHit             bool                              `json:"typed_column_one_shot_cache_hit,omitempty"`
+	TypedColumnOneShotCacheMiss            bool                              `json:"typed_column_one_shot_cache_miss,omitempty"`
+	TypedColumnOneShotCacheBuild           bool                              `json:"typed_column_one_shot_cache_build,omitempty"`
+	TypedColumnOneShotBuildDurationMS      float64                           `json:"typed_column_one_shot_build_duration_ms,omitempty"`
+	TypedColumnPreparePlanDurationMS       float64                           `json:"typed_column_prepare_plan_duration_ms,omitempty"`
+	TypedColumnPrepareRefsDurationMS       float64                           `json:"typed_column_prepare_refs_duration_ms,omitempty"`
+	TypedColumnPreparePairDurationMS       float64                           `json:"typed_column_prepare_pairing_duration_ms,omitempty"`
+	TypedColumnPrepareDecodeDurationMS     float64                           `json:"typed_column_prepare_part_decode_duration_ms,omitempty"`
+	TypedColumnPreparePostDurationMS       float64                           `json:"typed_column_prepare_post_prepare_duration_ms,omitempty"`
+	TypedColumnPrepareSummaryDurationMS    float64                           `json:"typed_column_prepare_summary_duration_ms,omitempty"`
+	TypedColumnOneShotCacheStoreDurationMS float64                           `json:"typed_column_one_shot_cache_store_duration_ms,omitempty"`
+	PredicateMode                          string                            `json:"predicate_mode"`
+	RealPredicates                         bool                              `json:"real_predicates"`
+	RetainedPayloadPolicyCaveat            string                            `json:"retained_payload_policy_caveat"`
+	ReconstructionStatus                   string                            `json:"reconstruction_status"`
+	FullDataCell                           bool                              `json:"full_data_cell"`
+	FullDataCaveat                         string                            `json:"full_data_caveat"`
+	StorageAccountingCaveat                string                            `json:"storage_accounting_caveat"`
+	CompatibilityStatus                    string                            `json:"compatibility_status"`
+	CompatibilityStatusReason              string                            `json:"compatibility_status_reason,omitempty"`
+	CompressionAttribution                 columnStoreCompressionAttribution `json:"compression_attribution"`
 }
 
 type columnStoreTypedOwnerColumn struct {
@@ -498,55 +512,62 @@ type columnStoreParity struct {
 }
 
 type columnStoreQueryExecution struct {
-	Lines                           []string
-	ProductionHash                  uint64
-	ProductionHashKnown             bool
-	StorageSource                   string
-	FallbackReason                  string
-	ManifestRootName                string
-	ManifestRoot                    uint64
-	ManifestGeneration              uint64
-	ActiveManifestChecksum          uint64
-	RowsProcessed                   int
-	RowsProcessedKnown              bool
-	RowsScanned                     int
-	RowsMatched                     int
-	ReduceRows                      int
-	TopKCandidates                  int
-	TopKLimit                       int
-	TopKOrder                       string
-	TimeOrderTopKUsed               bool
-	DenseInt64SpanReducer           string
-	DecodedGranules                 int
-	DecodedBlocks                   int
-	DecodedPayloadBytes             uint64
-	DecodedMetadataBytes            uint64
-	MappedBytes                     uint64
-	HeapCopyBytes                   uint64
-	ProjectedColumns                int
-	PredicateCount                  int
-	BytesRead                       int64
-	RowMaterializations             int
-	DocumentMaterializations        int
-	ResultCount                     int
-	MetadataHits                    int
-	DictionaryCodeHits              int
-	Int64ValueHits                  int
-	SkippedGranules                 int
-	ScheduledGranules               int
-	WorkerCount                     int
-	SegmentFileCacheHits            uint64
-	SegmentFileCacheMisses          uint64
-	TypedColumnOneShotCacheHit      bool
-	TypedColumnOneShotCacheMiss     bool
-	TypedColumnOneShotCacheBuild    bool
-	TypedColumnOneShotBuildDuration time.Duration
-	SetupDuration                   time.Duration
-	HotRunDuration                  time.Duration
-	ScanDuration                    time.Duration
-	ReduceDuration                  time.Duration
-	AdapterDuration                 time.Duration
-	ResultShapeDuration             time.Duration
+	Lines                                []string
+	ProductionHash                       uint64
+	ProductionHashKnown                  bool
+	StorageSource                        string
+	FallbackReason                       string
+	ManifestRootName                     string
+	ManifestRoot                         uint64
+	ManifestGeneration                   uint64
+	ActiveManifestChecksum               uint64
+	RowsProcessed                        int
+	RowsProcessedKnown                   bool
+	RowsScanned                          int
+	RowsMatched                          int
+	ReduceRows                           int
+	TopKCandidates                       int
+	TopKLimit                            int
+	TopKOrder                            string
+	TimeOrderTopKUsed                    bool
+	DenseInt64SpanReducer                string
+	DecodedGranules                      int
+	DecodedBlocks                        int
+	DecodedPayloadBytes                  uint64
+	DecodedMetadataBytes                 uint64
+	MappedBytes                          uint64
+	HeapCopyBytes                        uint64
+	ProjectedColumns                     int
+	PredicateCount                       int
+	BytesRead                            int64
+	RowMaterializations                  int
+	DocumentMaterializations             int
+	ResultCount                          int
+	MetadataHits                         int
+	DictionaryCodeHits                   int
+	Int64ValueHits                       int
+	SkippedGranules                      int
+	ScheduledGranules                    int
+	WorkerCount                          int
+	SegmentFileCacheHits                 uint64
+	SegmentFileCacheMisses               uint64
+	TypedColumnOneShotCacheHit           bool
+	TypedColumnOneShotCacheMiss          bool
+	TypedColumnOneShotCacheBuild         bool
+	TypedColumnOneShotBuildDuration      time.Duration
+	TypedColumnPreparePlanDuration       time.Duration
+	TypedColumnPrepareRefsDuration       time.Duration
+	TypedColumnPreparePairDuration       time.Duration
+	TypedColumnPrepareDecodeDuration     time.Duration
+	TypedColumnPreparePostDuration       time.Duration
+	TypedColumnPrepareSummaryDuration    time.Duration
+	TypedColumnOneShotCacheStoreDuration time.Duration
+	SetupDuration                        time.Duration
+	HotRunDuration                       time.Duration
+	ScanDuration                         time.Duration
+	ReduceDuration                       time.Duration
+	AdapterDuration                      time.Duration
+	ResultShapeDuration                  time.Duration
 	// Set when ProductionHashKnown is true. Fallback line-hash timing is
 	// measured at the call site because it is derived from Lines, not execution.
 	ParityHashDuration time.Duration
@@ -1915,78 +1936,85 @@ func runColumnStoreSuiteQueries(collection *collections.Collection, rows int, ra
 			Name: name,
 			// PlanLabel records the executed planner kind after alias
 			// normalization, not necessarily the raw requested path string.
-			PlanLabel:                         planLabel,
-			AliasOf:                           columnStoreQueryAliasOf(name, planLabel),
-			ImplementationNote:                columnStoreQueryImplementationNote(name, path, planLabel),
-			StorageSource:                     storageSource,
-			FallbackReason:                    fallbackReason,
-			QueryMode:                         columnStoreQueryModeOneShotEndToEnd,
-			MetadataMode:                      columnStoreMetadataMode(planLabel, storageSource, exec.MetadataHits),
-			ManifestRootName:                  manifestRootName,
-			ManifestRoot:                      manifestRoot,
-			ManifestGeneration:                manifestGeneration,
-			ActiveManifestChecksum:            activeManifestChecksum,
-			DurationMS:                        durationMS(elapsed),
-			PrepareSetupDurationMS:            durationMS(plannerElapsed),
-			RunDurationMS:                     durationMS(runDuration),
-			RenderHashDurationMS:              durationMS(parityHashElapsed),
-			TotalQueryDurationMS:              durationMS(elapsed),
-			duration:                          elapsed,
-			hotRunDuration:                    exec.HotRunDuration,
-			Rows:                              rows,
-			RowsProcessed:                     exec.RowsProcessed,
-			RowsProcessedKnown:                exec.RowsProcessedKnown,
-			RowsPerSecond:                     ratePerSecond(float64(exec.RowsProcessed), elapsed),
-			MiBPerSecond:                      ratePerSecond(float64(exec.BytesRead)/(1024*1024), elapsed),
-			NsPerRow:                          nsPerRow(elapsed, exec.RowsProcessed),
-			BytesRead:                         exec.BytesRead,
-			DecodedBytes:                      decodedBytes,
-			DecodedPayloadBytes:               exec.DecodedPayloadBytes,
-			DecodedMetadataBytes:              exec.DecodedMetadataBytes,
-			MappedBytes:                       exec.MappedBytes,
-			HeapCopyBytes:                     exec.HeapCopyBytes,
-			ProjectedColumns:                  exec.ProjectedColumns,
-			PredicateCount:                    exec.PredicateCount,
-			TypedCellsVisited:                 typedCellsVisited,
-			TypedCellsVisitedBasis:            typedCellsVisitedBasis,
-			RowMaterializations:               exec.RowMaterializations,
-			DocumentMaterializations:          exec.DocumentMaterializations,
-			AggregateMetadataUsed:             aggregateMetadataUsed,
-			SortTopKPruningUsed:               sortTopKPruningUsed,
-			JSONReconstruction:                jsonReconstruction,
-			ResultCount:                       exec.ResultCount,
-			RawHash:                           rawHash,
-			ProductionHash:                    hash,
-			MetadataHits:                      exec.MetadataHits,
-			DictionaryCodeHits:                exec.DictionaryCodeHits,
-			Int64ValueHits:                    exec.Int64ValueHits,
-			SkippedGranules:                   exec.SkippedGranules,
-			ScheduledGranules:                 exec.ScheduledGranules,
-			WorkerCount:                       exec.WorkerCount,
-			PlannerDurationMS:                 durationMS(plannerElapsed),
-			ScanDurationMS:                    durationMS(exec.ScanDuration),
-			ReduceDurationMS:                  durationMS(exec.ReduceDuration),
-			AdapterDurationMS:                 durationMS(exec.AdapterDuration),
-			ParityHashDurationMS:              durationMS(parityHashElapsed),
-			RowsScanned:                       exec.RowsScanned,
-			RowsMatched:                       exec.RowsMatched,
-			ReduceRows:                        exec.ReduceRows,
-			TopKCandidates:                    exec.TopKCandidates,
-			TopKLimit:                         exec.TopKLimit,
-			TopKOrder:                         exec.TopKOrder,
-			TimeOrderTopKUsed:                 exec.TimeOrderTopKUsed,
-			DenseInt64SpanReducer:             exec.DenseInt64SpanReducer,
-			DecodedBlocks:                     exec.DecodedBlocks,
-			DecodedGranules:                   exec.DecodedGranules,
-			PlannerCandidates:                 plan.Diagnostics.CandidatePlans,
-			PlannerReason:                     plan.Diagnostics.Reason,
-			SegmentFileCacheHits:              exec.SegmentFileCacheHits,
-			SegmentFileCacheMisses:            exec.SegmentFileCacheMisses,
-			TypedColumnOneShotCacheHit:        exec.TypedColumnOneShotCacheHit,
-			TypedColumnOneShotCacheMiss:       exec.TypedColumnOneShotCacheMiss,
-			TypedColumnOneShotCacheBuild:      exec.TypedColumnOneShotCacheBuild,
-			TypedColumnOneShotBuildDurationMS: durationMS(exec.TypedColumnOneShotBuildDuration),
-			CacheLabel:                        "reopened_warm_process",
+			PlanLabel:                              planLabel,
+			AliasOf:                                columnStoreQueryAliasOf(name, planLabel),
+			ImplementationNote:                     columnStoreQueryImplementationNote(name, path, planLabel),
+			StorageSource:                          storageSource,
+			FallbackReason:                         fallbackReason,
+			QueryMode:                              columnStoreQueryModeOneShotEndToEnd,
+			MetadataMode:                           columnStoreMetadataMode(planLabel, storageSource, exec.MetadataHits),
+			ManifestRootName:                       manifestRootName,
+			ManifestRoot:                           manifestRoot,
+			ManifestGeneration:                     manifestGeneration,
+			ActiveManifestChecksum:                 activeManifestChecksum,
+			DurationMS:                             durationMS(elapsed),
+			PrepareSetupDurationMS:                 durationMS(plannerElapsed),
+			RunDurationMS:                          durationMS(runDuration),
+			RenderHashDurationMS:                   durationMS(parityHashElapsed),
+			TotalQueryDurationMS:                   durationMS(elapsed),
+			duration:                               elapsed,
+			hotRunDuration:                         exec.HotRunDuration,
+			Rows:                                   rows,
+			RowsProcessed:                          exec.RowsProcessed,
+			RowsProcessedKnown:                     exec.RowsProcessedKnown,
+			RowsPerSecond:                          ratePerSecond(float64(exec.RowsProcessed), elapsed),
+			MiBPerSecond:                           ratePerSecond(float64(exec.BytesRead)/(1024*1024), elapsed),
+			NsPerRow:                               nsPerRow(elapsed, exec.RowsProcessed),
+			BytesRead:                              exec.BytesRead,
+			DecodedBytes:                           decodedBytes,
+			DecodedPayloadBytes:                    exec.DecodedPayloadBytes,
+			DecodedMetadataBytes:                   exec.DecodedMetadataBytes,
+			MappedBytes:                            exec.MappedBytes,
+			HeapCopyBytes:                          exec.HeapCopyBytes,
+			ProjectedColumns:                       exec.ProjectedColumns,
+			PredicateCount:                         exec.PredicateCount,
+			TypedCellsVisited:                      typedCellsVisited,
+			TypedCellsVisitedBasis:                 typedCellsVisitedBasis,
+			RowMaterializations:                    exec.RowMaterializations,
+			DocumentMaterializations:               exec.DocumentMaterializations,
+			AggregateMetadataUsed:                  aggregateMetadataUsed,
+			SortTopKPruningUsed:                    sortTopKPruningUsed,
+			JSONReconstruction:                     jsonReconstruction,
+			ResultCount:                            exec.ResultCount,
+			RawHash:                                rawHash,
+			ProductionHash:                         hash,
+			MetadataHits:                           exec.MetadataHits,
+			DictionaryCodeHits:                     exec.DictionaryCodeHits,
+			Int64ValueHits:                         exec.Int64ValueHits,
+			SkippedGranules:                        exec.SkippedGranules,
+			ScheduledGranules:                      exec.ScheduledGranules,
+			WorkerCount:                            exec.WorkerCount,
+			PlannerDurationMS:                      durationMS(plannerElapsed),
+			ScanDurationMS:                         durationMS(exec.ScanDuration),
+			ReduceDurationMS:                       durationMS(exec.ReduceDuration),
+			AdapterDurationMS:                      durationMS(exec.AdapterDuration),
+			ParityHashDurationMS:                   durationMS(parityHashElapsed),
+			RowsScanned:                            exec.RowsScanned,
+			RowsMatched:                            exec.RowsMatched,
+			ReduceRows:                             exec.ReduceRows,
+			TopKCandidates:                         exec.TopKCandidates,
+			TopKLimit:                              exec.TopKLimit,
+			TopKOrder:                              exec.TopKOrder,
+			TimeOrderTopKUsed:                      exec.TimeOrderTopKUsed,
+			DenseInt64SpanReducer:                  exec.DenseInt64SpanReducer,
+			DecodedBlocks:                          exec.DecodedBlocks,
+			DecodedGranules:                        exec.DecodedGranules,
+			PlannerCandidates:                      plan.Diagnostics.CandidatePlans,
+			PlannerReason:                          plan.Diagnostics.Reason,
+			SegmentFileCacheHits:                   exec.SegmentFileCacheHits,
+			SegmentFileCacheMisses:                 exec.SegmentFileCacheMisses,
+			TypedColumnOneShotCacheHit:             exec.TypedColumnOneShotCacheHit,
+			TypedColumnOneShotCacheMiss:            exec.TypedColumnOneShotCacheMiss,
+			TypedColumnOneShotCacheBuild:           exec.TypedColumnOneShotCacheBuild,
+			TypedColumnOneShotBuildDurationMS:      durationMS(exec.TypedColumnOneShotBuildDuration),
+			TypedColumnPreparePlanDurationMS:       durationMS(exec.TypedColumnPreparePlanDuration),
+			TypedColumnPrepareRefsDurationMS:       durationMS(exec.TypedColumnPrepareRefsDuration),
+			TypedColumnPreparePairDurationMS:       durationMS(exec.TypedColumnPreparePairDuration),
+			TypedColumnPrepareDecodeDurationMS:     durationMS(exec.TypedColumnPrepareDecodeDuration),
+			TypedColumnPreparePostDurationMS:       durationMS(exec.TypedColumnPreparePostDuration),
+			TypedColumnPrepareSummaryDurationMS:    durationMS(exec.TypedColumnPrepareSummaryDuration),
+			TypedColumnOneShotCacheStoreDurationMS: durationMS(exec.TypedColumnOneShotCacheStoreDuration),
+			CacheLabel:                             "reopened_warm_process",
 			CompressionAttribution: columnStoreQueryCompressionAttribution(
 				planLabel,
 				storageSource,
@@ -2380,54 +2408,61 @@ func executeColumnStoreSuitePhysicalQuery(collection *collections.Collection, qu
 	}
 	scanDuration, reduceDuration, resultShapeDuration := columnStorePhaseDurations(elapsed, diag)
 	return columnStoreQueryExecution{
-		ProductionHash:                  productionHash,
-		ProductionHashKnown:             true,
-		StorageSource:                   string(diag.StorageSource),
-		FallbackReason:                  string(diag.FallbackReason),
-		ManifestRootName:                diag.ManifestRootName,
-		ManifestRoot:                    diag.ManifestRoot,
-		ManifestGeneration:              diag.ManifestGeneration,
-		ActiveManifestChecksum:          diag.ActiveManifestChecksum,
-		RowsProcessed:                   diag.ReduceRows,
-		RowsProcessedKnown:              true,
-		RowsScanned:                     diag.RowsScanned,
-		RowsMatched:                     diag.RowsMatched,
-		ReduceRows:                      diag.ReduceRows,
-		TopKCandidates:                  diag.TopKCandidates,
-		TopKLimit:                       diag.TopKLimit,
-		TopKOrder:                       diag.TopKOrder,
-		TimeOrderTopKUsed:               diag.TimeOrderTopKUsed,
-		DenseInt64SpanReducer:           diag.DenseInt64SpanReducer,
-		DecodedGranules:                 diag.DecodedGranules,
-		DecodedBlocks:                   diag.DecodedBlocks,
-		DecodedPayloadBytes:             diag.DecodedPayloadBytes,
-		DecodedMetadataBytes:            diag.DecodedMetadataBytes,
-		MappedBytes:                     diag.MappedBytes,
-		HeapCopyBytes:                   diag.HeapCopyBytes,
-		ProjectedColumns:                diag.ProjectedColumns,
-		PredicateCount:                  diag.PredicateCount,
-		BytesRead:                       diag.PhysicalBytesScanned,
-		RowMaterializations:             diag.RowMaterializations,
-		DocumentMaterializations:        diag.DocumentMaterializations,
-		ResultCount:                     resultCount,
-		MetadataHits:                    diag.MetadataHits,
-		DictionaryCodeHits:              diag.DictionaryCodeHits,
-		Int64ValueHits:                  diag.Int64ValueHits,
-		SkippedGranules:                 diag.SkippedGranules,
-		ScheduledGranules:               diag.ScheduledGranules,
-		WorkerCount:                     workers,
-		SegmentFileCacheHits:            diag.SegmentFileCacheHits,
-		SegmentFileCacheMisses:          diag.SegmentFileCacheMisses,
-		TypedColumnOneShotCacheHit:      diag.TypedColumnOneShotCacheHit,
-		TypedColumnOneShotCacheMiss:     diag.TypedColumnOneShotCacheMiss,
-		TypedColumnOneShotCacheBuild:    diag.TypedColumnOneShotCacheBuild,
-		TypedColumnOneShotBuildDuration: time.Duration(diag.TypedColumnOneShotBuildNanos),
-		HotRunDuration:                  elapsed,
-		ScanDuration:                    scanDuration,
-		ReduceDuration:                  reduceDuration,
-		AdapterDuration:                 resultShapeDuration,
-		ResultShapeDuration:             resultShapeDuration,
-		ParityHashDuration:              parityHashElapsed,
+		ProductionHash:                       productionHash,
+		ProductionHashKnown:                  true,
+		StorageSource:                        string(diag.StorageSource),
+		FallbackReason:                       string(diag.FallbackReason),
+		ManifestRootName:                     diag.ManifestRootName,
+		ManifestRoot:                         diag.ManifestRoot,
+		ManifestGeneration:                   diag.ManifestGeneration,
+		ActiveManifestChecksum:               diag.ActiveManifestChecksum,
+		RowsProcessed:                        diag.ReduceRows,
+		RowsProcessedKnown:                   true,
+		RowsScanned:                          diag.RowsScanned,
+		RowsMatched:                          diag.RowsMatched,
+		ReduceRows:                           diag.ReduceRows,
+		TopKCandidates:                       diag.TopKCandidates,
+		TopKLimit:                            diag.TopKLimit,
+		TopKOrder:                            diag.TopKOrder,
+		TimeOrderTopKUsed:                    diag.TimeOrderTopKUsed,
+		DenseInt64SpanReducer:                diag.DenseInt64SpanReducer,
+		DecodedGranules:                      diag.DecodedGranules,
+		DecodedBlocks:                        diag.DecodedBlocks,
+		DecodedPayloadBytes:                  diag.DecodedPayloadBytes,
+		DecodedMetadataBytes:                 diag.DecodedMetadataBytes,
+		MappedBytes:                          diag.MappedBytes,
+		HeapCopyBytes:                        diag.HeapCopyBytes,
+		ProjectedColumns:                     diag.ProjectedColumns,
+		PredicateCount:                       diag.PredicateCount,
+		BytesRead:                            diag.PhysicalBytesScanned,
+		RowMaterializations:                  diag.RowMaterializations,
+		DocumentMaterializations:             diag.DocumentMaterializations,
+		ResultCount:                          resultCount,
+		MetadataHits:                         diag.MetadataHits,
+		DictionaryCodeHits:                   diag.DictionaryCodeHits,
+		Int64ValueHits:                       diag.Int64ValueHits,
+		SkippedGranules:                      diag.SkippedGranules,
+		ScheduledGranules:                    diag.ScheduledGranules,
+		WorkerCount:                          workers,
+		SegmentFileCacheHits:                 diag.SegmentFileCacheHits,
+		SegmentFileCacheMisses:               diag.SegmentFileCacheMisses,
+		TypedColumnOneShotCacheHit:           diag.TypedColumnOneShotCacheHit,
+		TypedColumnOneShotCacheMiss:          diag.TypedColumnOneShotCacheMiss,
+		TypedColumnOneShotCacheBuild:         diag.TypedColumnOneShotCacheBuild,
+		TypedColumnOneShotBuildDuration:      time.Duration(diag.TypedColumnOneShotBuildNanos),
+		TypedColumnPreparePlanDuration:       time.Duration(diag.TypedColumnPreparePlanNanos),
+		TypedColumnPrepareRefsDuration:       time.Duration(diag.TypedColumnPrepareRefsNanos),
+		TypedColumnPreparePairDuration:       time.Duration(diag.TypedColumnPreparePairingNanos),
+		TypedColumnPrepareDecodeDuration:     time.Duration(diag.TypedColumnPreparePartDecodeNanos),
+		TypedColumnPreparePostDuration:       time.Duration(diag.TypedColumnPreparePostPrepareNanos),
+		TypedColumnPrepareSummaryDuration:    time.Duration(diag.TypedColumnPrepareSummaryNanos),
+		TypedColumnOneShotCacheStoreDuration: time.Duration(diag.TypedColumnOneShotCacheStoreNanos),
+		HotRunDuration:                       elapsed,
+		ScanDuration:                         scanDuration,
+		ReduceDuration:                       reduceDuration,
+		AdapterDuration:                      resultShapeDuration,
+		ResultShapeDuration:                  resultShapeDuration,
+		ParityHashDuration:                   parityHashElapsed,
 	}, nil
 }
 
@@ -2472,6 +2507,7 @@ func executeColumnStoreSuitePreparedPhysicalQuery(collection *collections.Collec
 		return columnStoreQueryExecution{SetupDuration: setupElapsed}, fmt.Errorf("column_store: prepare physical query %s via %s: %w", queryName, planKind, err)
 	}
 	defer runner.Close()
+	setupDiagnostics := runner.PrepareDiagnostics()
 	runStart := time.Now()
 	result, err := runner.Run()
 	hotRunElapsed := time.Since(runStart)
@@ -2491,51 +2527,58 @@ func executeColumnStoreSuitePreparedPhysicalQuery(collection *collections.Collec
 	}
 	scanDuration, reduceDuration, resultShapeDuration := columnStorePhaseDurations(hotRunElapsed, diag)
 	return columnStoreQueryExecution{
-		ProductionHash:           productionHash,
-		ProductionHashKnown:      true,
-		StorageSource:            string(diag.StorageSource),
-		FallbackReason:           string(diag.FallbackReason),
-		ManifestRootName:         diag.ManifestRootName,
-		ManifestRoot:             diag.ManifestRoot,
-		ManifestGeneration:       diag.ManifestGeneration,
-		ActiveManifestChecksum:   diag.ActiveManifestChecksum,
-		RowsProcessed:            diag.ReduceRows,
-		RowsProcessedKnown:       true,
-		RowsScanned:              diag.RowsScanned,
-		RowsMatched:              diag.RowsMatched,
-		ReduceRows:               diag.ReduceRows,
-		TopKCandidates:           diag.TopKCandidates,
-		TopKLimit:                diag.TopKLimit,
-		TopKOrder:                diag.TopKOrder,
-		TimeOrderTopKUsed:        diag.TimeOrderTopKUsed,
-		DenseInt64SpanReducer:    diag.DenseInt64SpanReducer,
-		DecodedGranules:          diag.DecodedGranules,
-		DecodedBlocks:            diag.DecodedBlocks,
-		DecodedPayloadBytes:      diag.DecodedPayloadBytes,
-		DecodedMetadataBytes:     diag.DecodedMetadataBytes,
-		MappedBytes:              diag.MappedBytes,
-		HeapCopyBytes:            diag.HeapCopyBytes,
-		ProjectedColumns:         diag.ProjectedColumns,
-		PredicateCount:           diag.PredicateCount,
-		BytesRead:                diag.PhysicalBytesScanned,
-		RowMaterializations:      diag.RowMaterializations,
-		DocumentMaterializations: diag.DocumentMaterializations,
-		ResultCount:              resultCount,
-		MetadataHits:             diag.MetadataHits,
-		DictionaryCodeHits:       diag.DictionaryCodeHits,
-		Int64ValueHits:           diag.Int64ValueHits,
-		SkippedGranules:          diag.SkippedGranules,
-		ScheduledGranules:        diag.ScheduledGranules,
-		WorkerCount:              workers,
-		SegmentFileCacheHits:     diag.SegmentFileCacheHits,
-		SegmentFileCacheMisses:   diag.SegmentFileCacheMisses,
-		SetupDuration:            setupElapsed,
-		HotRunDuration:           hotRunElapsed,
-		ScanDuration:             scanDuration,
-		ReduceDuration:           reduceDuration,
-		AdapterDuration:          resultShapeDuration,
-		ResultShapeDuration:      resultShapeDuration,
-		ParityHashDuration:       parityHashElapsed,
+		ProductionHash:                       productionHash,
+		ProductionHashKnown:                  true,
+		StorageSource:                        string(diag.StorageSource),
+		FallbackReason:                       string(diag.FallbackReason),
+		ManifestRootName:                     diag.ManifestRootName,
+		ManifestRoot:                         diag.ManifestRoot,
+		ManifestGeneration:                   diag.ManifestGeneration,
+		ActiveManifestChecksum:               diag.ActiveManifestChecksum,
+		RowsProcessed:                        diag.ReduceRows,
+		RowsProcessedKnown:                   true,
+		RowsScanned:                          diag.RowsScanned,
+		RowsMatched:                          diag.RowsMatched,
+		ReduceRows:                           diag.ReduceRows,
+		TopKCandidates:                       diag.TopKCandidates,
+		TopKLimit:                            diag.TopKLimit,
+		TopKOrder:                            diag.TopKOrder,
+		TimeOrderTopKUsed:                    diag.TimeOrderTopKUsed,
+		DenseInt64SpanReducer:                diag.DenseInt64SpanReducer,
+		DecodedGranules:                      diag.DecodedGranules,
+		DecodedBlocks:                        diag.DecodedBlocks,
+		DecodedPayloadBytes:                  diag.DecodedPayloadBytes,
+		DecodedMetadataBytes:                 diag.DecodedMetadataBytes,
+		MappedBytes:                          diag.MappedBytes,
+		HeapCopyBytes:                        diag.HeapCopyBytes,
+		ProjectedColumns:                     diag.ProjectedColumns,
+		PredicateCount:                       diag.PredicateCount,
+		BytesRead:                            diag.PhysicalBytesScanned,
+		RowMaterializations:                  diag.RowMaterializations,
+		DocumentMaterializations:             diag.DocumentMaterializations,
+		ResultCount:                          resultCount,
+		MetadataHits:                         diag.MetadataHits,
+		DictionaryCodeHits:                   diag.DictionaryCodeHits,
+		Int64ValueHits:                       diag.Int64ValueHits,
+		SkippedGranules:                      diag.SkippedGranules,
+		ScheduledGranules:                    diag.ScheduledGranules,
+		WorkerCount:                          workers,
+		SegmentFileCacheHits:                 diag.SegmentFileCacheHits,
+		SegmentFileCacheMisses:               diag.SegmentFileCacheMisses,
+		TypedColumnPreparePlanDuration:       time.Duration(setupDiagnostics.TypedColumnPreparePlanNanos),
+		TypedColumnPrepareRefsDuration:       time.Duration(setupDiagnostics.TypedColumnPrepareRefsNanos),
+		TypedColumnPreparePairDuration:       time.Duration(setupDiagnostics.TypedColumnPreparePairingNanos),
+		TypedColumnPrepareDecodeDuration:     time.Duration(setupDiagnostics.TypedColumnPreparePartDecodeNanos),
+		TypedColumnPreparePostDuration:       time.Duration(setupDiagnostics.TypedColumnPreparePostPrepareNanos),
+		TypedColumnPrepareSummaryDuration:    time.Duration(setupDiagnostics.TypedColumnPrepareSummaryNanos),
+		TypedColumnOneShotCacheStoreDuration: time.Duration(setupDiagnostics.TypedColumnOneShotCacheStoreNanos),
+		SetupDuration:                        setupElapsed,
+		HotRunDuration:                       hotRunElapsed,
+		ScanDuration:                         scanDuration,
+		ReduceDuration:                       reduceDuration,
+		AdapterDuration:                      resultShapeDuration,
+		ResultShapeDuration:                  resultShapeDuration,
+		ParityHashDuration:                   parityHashElapsed,
 	}, nil
 }
 
@@ -2956,6 +2999,13 @@ func columnStoreJSONBenchCellFromQueryMetric(q columnStoreQueryMetric, cfg *coll
 	cell.TypedColumnOneShotCacheMiss = q.TypedColumnOneShotCacheMiss
 	cell.TypedColumnOneShotCacheBuild = q.TypedColumnOneShotCacheBuild
 	cell.TypedColumnOneShotBuildDurationMS = q.TypedColumnOneShotBuildDurationMS
+	cell.TypedColumnPreparePlanDurationMS = q.TypedColumnPreparePlanDurationMS
+	cell.TypedColumnPrepareRefsDurationMS = q.TypedColumnPrepareRefsDurationMS
+	cell.TypedColumnPreparePairDurationMS = q.TypedColumnPreparePairDurationMS
+	cell.TypedColumnPrepareDecodeDurationMS = q.TypedColumnPrepareDecodeDurationMS
+	cell.TypedColumnPreparePostDurationMS = q.TypedColumnPreparePostDurationMS
+	cell.TypedColumnPrepareSummaryDurationMS = q.TypedColumnPrepareSummaryDurationMS
+	cell.TypedColumnOneShotCacheStoreDurationMS = q.TypedColumnOneShotCacheStoreDurationMS
 	cell.ScanDurationMS = q.ScanDurationMS
 	cell.ReduceDurationMS = q.ReduceDurationMS
 	cell.ResultShapeDurationMS = q.AdapterDurationMS
@@ -3055,6 +3105,13 @@ func columnStoreJSONBenchCellFromPreparedExecution(name string, rawHash uint64, 
 	cell.ReduceDurationMS = durationMS(exec.ReduceDuration)
 	cell.ResultShapeDurationMS = durationMS(exec.ResultShapeDuration)
 	cell.ParityHashDurationMS = durationMS(exec.ParityHashDuration)
+	cell.TypedColumnPreparePlanDurationMS = durationMS(exec.TypedColumnPreparePlanDuration)
+	cell.TypedColumnPrepareRefsDurationMS = durationMS(exec.TypedColumnPrepareRefsDuration)
+	cell.TypedColumnPreparePairDurationMS = durationMS(exec.TypedColumnPreparePairDuration)
+	cell.TypedColumnPrepareDecodeDurationMS = durationMS(exec.TypedColumnPrepareDecodeDuration)
+	cell.TypedColumnPreparePostDurationMS = durationMS(exec.TypedColumnPreparePostDuration)
+	cell.TypedColumnPrepareSummaryDurationMS = durationMS(exec.TypedColumnPrepareSummaryDuration)
+	cell.TypedColumnOneShotCacheStoreDurationMS = durationMS(exec.TypedColumnOneShotCacheStoreDuration)
 	cell.MetadataHits = exec.MetadataHits
 	cell.RowsScanned = exec.RowsScanned
 	cell.RowsMatched = exec.RowsMatched
@@ -4482,8 +4539,8 @@ func renderColumnStoreQueryMetricsMarkdown(sb *strings.Builder, title string, qu
 		return
 	}
 	sb.WriteString("## " + title + "\n\n")
-	sb.WriteString("| query | query mode | metadata mode | plan | storage source | fallback | manifest root | active gen/checksum | rows/s | MiB/s | ns/row | prepare/setup ms | run ms | render/hash ms | total query ms | planner ms | scan ms | reduce ms | adapter ms | parity hash ms | workers | scheduled granules | skipped granules | metadata hits | dictionary code hits | int64 value hits | B/read | decoded B | decoded payload B | decoded metadata B | mapped B | heap-copy B | rows scanned | projected cols | predicate count | typed cells visited | typed cells basis | rows materialized | docs materialized | aggregate metadata used | metadata cost B | metadata cost insert ms | metadata cost basis | sort/topk pruning | topk limit | topk candidates | topk order | json reconstruction | segment file cache hit/miss | hash parity | note |\n")
-	sb.WriteString("|---|---|---|---|---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|---:|---:|---|---:|---:|---|---|---:|---:|---|---|---|---|---|\n")
+	sb.WriteString("| query | query mode | metadata mode | plan | storage source | fallback | manifest root | active gen/checksum | rows/s | MiB/s | ns/row | prepare/setup ms | typed prep plan ms | typed prep refs ms | typed prep pair ms | typed prep decode ms | typed prep post ms | typed prep summary ms | one-shot cache store ms | run ms | render/hash ms | total query ms | planner ms | scan ms | reduce ms | adapter ms | parity hash ms | workers | scheduled granules | skipped granules | metadata hits | dictionary code hits | int64 value hits | B/read | decoded B | decoded payload B | decoded metadata B | mapped B | heap-copy B | rows scanned | projected cols | predicate count | typed cells visited | typed cells basis | rows materialized | docs materialized | aggregate metadata used | metadata cost B | metadata cost insert ms | metadata cost basis | sort/topk pruning | topk limit | topk candidates | topk order | json reconstruction | segment file cache hit/miss | hash parity | note |\n")
+	sb.WriteString("|---|---|---|---|---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|---:|---:|---|---:|---:|---|---|---:|---:|---|---|---|---|---|\n")
 	for _, q := range queries {
 		parity := "pass"
 		if p, ok := parityByName[q.Name]; ok && !p.Pass {
@@ -4505,8 +4562,8 @@ func renderColumnStoreQueryMetricsMarkdown(sb *strings.Builder, title string, qu
 		if q.ManifestGeneration != 0 || q.ActiveManifestChecksum != 0 {
 			activeManifestCell = fmt.Sprintf("%d/%d", q.ManifestGeneration, q.ActiveManifestChecksum)
 		}
-		sb.WriteString(fmt.Sprintf("| %s | %s | %s | %s | %s | %s | %s | %s | %.3f | %.3f | %.1f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %s | %d | %d | %t | %d | %.3f | %s | %t | %d | %d | %s | %t | %d/%d | %s | %s |\n",
-			markdownCodeTableText(q.Name), markdownCodeTableText(q.QueryMode), markdownCodeTableText(q.MetadataMode), markdownCodeTableText(q.PlanLabel), markdownCodeTableText(q.StorageSource), markdownCodeTableText(q.FallbackReason), markdownCodeTableText(manifestRootCell), markdownCodeTableText(activeManifestCell), q.RowsPerSecond, q.MiBPerSecond, q.NsPerRow, q.PrepareSetupDurationMS, q.RunDurationMS, q.RenderHashDurationMS, q.TotalQueryDurationMS, q.PlannerDurationMS, q.ScanDurationMS, q.ReduceDurationMS, q.AdapterDurationMS, q.ParityHashDurationMS, q.WorkerCount, q.ScheduledGranules, q.SkippedGranules, q.MetadataHits, q.DictionaryCodeHits, q.Int64ValueHits, q.BytesRead, q.DecodedBytes, q.DecodedPayloadBytes, q.DecodedMetadataBytes, q.MappedBytes, q.HeapCopyBytes, q.RowsScanned, q.ProjectedColumns, q.PredicateCount, q.TypedCellsVisited, markdownCodeTableText(q.TypedCellsVisitedBasis), q.RowMaterializations, q.DocumentMaterializations, q.AggregateMetadataUsed, q.MetadataCostStorageBytes, q.MetadataCostInsertMS, markdownCodeTableText(columnStoreMetadataCostBasisTableText(q.MetadataCostStorageBasis, q.MetadataCostInsertBasis)), q.SortTopKPruningUsed, q.TopKLimit, q.TopKCandidates, markdownCodeTableText(q.TopKOrder), q.JSONReconstruction, q.SegmentFileCacheHits, q.SegmentFileCacheMisses, parity, noteCell))
+		sb.WriteString(fmt.Sprintf("| %s | %s | %s | %s | %s | %s | %s | %s | %.3f | %.3f | %.1f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %s | %d | %d | %t | %d | %.3f | %s | %t | %d | %d | %s | %t | %d/%d | %s | %s |\n",
+			markdownCodeTableText(q.Name), markdownCodeTableText(q.QueryMode), markdownCodeTableText(q.MetadataMode), markdownCodeTableText(q.PlanLabel), markdownCodeTableText(q.StorageSource), markdownCodeTableText(q.FallbackReason), markdownCodeTableText(manifestRootCell), markdownCodeTableText(activeManifestCell), q.RowsPerSecond, q.MiBPerSecond, q.NsPerRow, q.PrepareSetupDurationMS, q.TypedColumnPreparePlanDurationMS, q.TypedColumnPrepareRefsDurationMS, q.TypedColumnPreparePairDurationMS, q.TypedColumnPrepareDecodeDurationMS, q.TypedColumnPreparePostDurationMS, q.TypedColumnPrepareSummaryDurationMS, q.TypedColumnOneShotCacheStoreDurationMS, q.RunDurationMS, q.RenderHashDurationMS, q.TotalQueryDurationMS, q.PlannerDurationMS, q.ScanDurationMS, q.ReduceDurationMS, q.AdapterDurationMS, q.ParityHashDurationMS, q.WorkerCount, q.ScheduledGranules, q.SkippedGranules, q.MetadataHits, q.DictionaryCodeHits, q.Int64ValueHits, q.BytesRead, q.DecodedBytes, q.DecodedPayloadBytes, q.DecodedMetadataBytes, q.MappedBytes, q.HeapCopyBytes, q.RowsScanned, q.ProjectedColumns, q.PredicateCount, q.TypedCellsVisited, markdownCodeTableText(q.TypedCellsVisitedBasis), q.RowMaterializations, q.DocumentMaterializations, q.AggregateMetadataUsed, q.MetadataCostStorageBytes, q.MetadataCostInsertMS, markdownCodeTableText(columnStoreMetadataCostBasisTableText(q.MetadataCostStorageBasis, q.MetadataCostInsertBasis)), q.SortTopKPruningUsed, q.TopKLimit, q.TopKCandidates, markdownCodeTableText(q.TopKOrder), q.JSONReconstruction, q.SegmentFileCacheHits, q.SegmentFileCacheMisses, parity, noteCell))
 	}
 	sb.WriteString("\n")
 }
@@ -4517,8 +4574,8 @@ func renderColumnStoreJSONBenchCellsMarkdown(sb *strings.Builder, report columnS
 		sb.WriteString("No JSONBench synthetic cells were recorded.\n\n")
 		return
 	}
-	sb.WriteString("| cell | query | query mode | metadata mode | sort layout | storage source | mode | metadata/data path | prepare/setup ms | run ms | render/hash ms | total query ms | compression | mutation | retained payload | retained encoding | retained compression | typed owner | rows | rows processed | bytes read | decoded B | decoded payload B | decoded metadata B | mapped B | heap-copy B | rows scanned | projected cols | predicate count | typed cells visited | typed cells basis | row materializations | document materializations | aggregate metadata used | metadata cost B | metadata cost insert ms | metadata cost basis | sort/topk pruning | topk limit | topk candidates | topk order | json reconstruction | result hash | parity | full-data caveat | reconstruction | status |\n")
-	sb.WriteString("|---|---|---|---|---|---|---|---|---:|---:|---:|---:|---|---|---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|---:|---:|---|---:|---:|---|---|---:|---:|---|---|---:|---|---|---|---|\n")
+	sb.WriteString("| cell | query | query mode | metadata mode | sort layout | storage source | mode | metadata/data path | prepare/setup ms | typed prep plan ms | typed prep refs ms | typed prep pair ms | typed prep decode ms | typed prep post ms | typed prep summary ms | one-shot cache store ms | run ms | render/hash ms | total query ms | compression | mutation | retained payload | retained encoding | retained compression | typed owner | rows | rows processed | bytes read | decoded B | decoded payload B | decoded metadata B | mapped B | heap-copy B | rows scanned | projected cols | predicate count | typed cells visited | typed cells basis | row materializations | document materializations | aggregate metadata used | metadata cost B | metadata cost insert ms | metadata cost basis | sort/topk pruning | topk limit | topk candidates | topk order | json reconstruction | result hash | parity | full-data caveat | reconstruction | status |\n")
+	sb.WriteString("|---|---|---|---|---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|---|---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|---:|---:|---|---:|---:|---|---|---:|---:|---|---|---:|---|---|---|---|\n")
 	for _, cell := range report.JSONBenchCells {
 		parity := "pass"
 		if !cell.ParityWithRowScan {
@@ -4528,7 +4585,7 @@ func renderColumnStoreJSONBenchCellsMarkdown(sb *strings.Builder, report columnS
 		if cell.CompatibilityStatusReason != "" {
 			status += ": " + cell.CompatibilityStatusReason
 		}
-		sb.WriteString(fmt.Sprintf("| %s | %s | %s | %s | %s | %s | %s | %s | %.3f | %.3f | %.3f | %.3f | %s | %s | %s | %s | %s | %s | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %s | %d | %d | %t | %d | %.3f | %s | %t | %d | %d | %s | %t | %016x | %s | %s | %s | %s |\n",
+		sb.WriteString(fmt.Sprintf("| %s | %s | %s | %s | %s | %s | %s | %s | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %s | %s | %s | %s | %s | %s | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %s | %d | %d | %t | %d | %.3f | %s | %t | %d | %d | %s | %t | %016x | %s | %s | %s | %s |\n",
 			markdownCodeTableText(cell.CellLabel),
 			markdownCodeTableText(cell.Query),
 			markdownCodeTableText(cell.QueryMode),
@@ -4538,6 +4595,13 @@ func renderColumnStoreJSONBenchCellsMarkdown(sb *strings.Builder, report columnS
 			markdownCodeTableText(cell.ExecutionMode),
 			markdownCodeTableText(cell.MetadataDataScanPath),
 			cell.PrepareSetupDurationMS,
+			cell.TypedColumnPreparePlanDurationMS,
+			cell.TypedColumnPrepareRefsDurationMS,
+			cell.TypedColumnPreparePairDurationMS,
+			cell.TypedColumnPrepareDecodeDurationMS,
+			cell.TypedColumnPreparePostDurationMS,
+			cell.TypedColumnPrepareSummaryDurationMS,
+			cell.TypedColumnOneShotCacheStoreDurationMS,
 			cell.RunDurationMS,
 			cell.RenderHashDurationMS,
 			cell.TotalQueryDurationMS,

--- a/cmd/unified_bench/suite_column_store.go
+++ b/cmd/unified_bench/suite_column_store.go
@@ -351,6 +351,19 @@ type columnStoreQueryMetric struct {
 	TypedColumnPreparePostDurationMS       float64                           `json:"typed_column_prepare_post_prepare_duration_ms,omitempty"`
 	TypedColumnPrepareSummaryDurationMS    float64                           `json:"typed_column_prepare_summary_duration_ms,omitempty"`
 	TypedColumnOneShotCacheStoreDurationMS float64                           `json:"typed_column_one_shot_cache_store_duration_ms,omitempty"`
+	TypedColumnPrepareReadImageDurationMS  float64                           `json:"typed_column_prepare_read_image_duration_ms,omitempty"`
+	TypedColumnPrepareStateBuildDurationMS float64                           `json:"typed_column_prepare_state_build_duration_ms,omitempty"`
+	TypedColumnPrepareDictionaryDurationMS float64                           `json:"typed_column_prepare_dictionary_duration_ms,omitempty"`
+	TypedColumnPreparePruningDurationMS    float64                           `json:"typed_column_prepare_pruning_duration_ms,omitempty"`
+	TypedColumnPrepareSortKeyDurationMS    float64                           `json:"typed_column_prepare_sort_key_duration_ms,omitempty"`
+	TypedColumnPrepareStatsDurationMS      float64                           `json:"typed_column_prepare_stats_duration_ms,omitempty"`
+	TypedColumnPrepareRangeReadDurationMS  float64                           `json:"typed_column_prepare_range_read_duration_ms,omitempty"`
+	TypedColumnPrepareRangeReadBytes       int64                             `json:"typed_column_prepare_range_read_bytes,omitempty"`
+	TypedColumnPrepareAdapterDurationMS    float64                           `json:"typed_column_prepare_adapter_duration_ms,omitempty"`
+	TypedColumnPrepareDenseGroupDurationMS float64                           `json:"typed_column_prepare_dense_group_duration_ms,omitempty"`
+	TypedColumnPrepareDenseValueDurationMS float64                           `json:"typed_column_prepare_dense_value_duration_ms,omitempty"`
+	TypedColumnPrepareDensePredDurationMS  float64                           `json:"typed_column_prepare_dense_predicate_duration_ms,omitempty"`
+	TypedColumnPrepareDensePreapplyMS      float64                           `json:"typed_column_prepare_dense_preapply_duration_ms,omitempty"`
 	CacheLabel                             string                            `json:"cache_label"`
 	CompressionAttribution                 columnStoreCompressionAttribution `json:"compression_attribution"`
 
@@ -450,6 +463,19 @@ type columnStoreJSONBenchCell struct {
 	TypedColumnPreparePostDurationMS       float64                           `json:"typed_column_prepare_post_prepare_duration_ms,omitempty"`
 	TypedColumnPrepareSummaryDurationMS    float64                           `json:"typed_column_prepare_summary_duration_ms,omitempty"`
 	TypedColumnOneShotCacheStoreDurationMS float64                           `json:"typed_column_one_shot_cache_store_duration_ms,omitempty"`
+	TypedColumnPrepareReadImageDurationMS  float64                           `json:"typed_column_prepare_read_image_duration_ms,omitempty"`
+	TypedColumnPrepareStateBuildDurationMS float64                           `json:"typed_column_prepare_state_build_duration_ms,omitempty"`
+	TypedColumnPrepareDictionaryDurationMS float64                           `json:"typed_column_prepare_dictionary_duration_ms,omitempty"`
+	TypedColumnPreparePruningDurationMS    float64                           `json:"typed_column_prepare_pruning_duration_ms,omitempty"`
+	TypedColumnPrepareSortKeyDurationMS    float64                           `json:"typed_column_prepare_sort_key_duration_ms,omitempty"`
+	TypedColumnPrepareStatsDurationMS      float64                           `json:"typed_column_prepare_stats_duration_ms,omitempty"`
+	TypedColumnPrepareRangeReadDurationMS  float64                           `json:"typed_column_prepare_range_read_duration_ms,omitempty"`
+	TypedColumnPrepareRangeReadBytes       int64                             `json:"typed_column_prepare_range_read_bytes,omitempty"`
+	TypedColumnPrepareAdapterDurationMS    float64                           `json:"typed_column_prepare_adapter_duration_ms,omitempty"`
+	TypedColumnPrepareDenseGroupDurationMS float64                           `json:"typed_column_prepare_dense_group_duration_ms,omitempty"`
+	TypedColumnPrepareDenseValueDurationMS float64                           `json:"typed_column_prepare_dense_value_duration_ms,omitempty"`
+	TypedColumnPrepareDensePredDurationMS  float64                           `json:"typed_column_prepare_dense_predicate_duration_ms,omitempty"`
+	TypedColumnPrepareDensePreapplyMS      float64                           `json:"typed_column_prepare_dense_preapply_duration_ms,omitempty"`
 	PredicateMode                          string                            `json:"predicate_mode"`
 	RealPredicates                         bool                              `json:"real_predicates"`
 	RetainedPayloadPolicyCaveat            string                            `json:"retained_payload_policy_caveat"`
@@ -562,6 +588,19 @@ type columnStoreQueryExecution struct {
 	TypedColumnPreparePostDuration       time.Duration
 	TypedColumnPrepareSummaryDuration    time.Duration
 	TypedColumnOneShotCacheStoreDuration time.Duration
+	TypedColumnPrepareReadImageDuration  time.Duration
+	TypedColumnPrepareStateBuildDuration time.Duration
+	TypedColumnPrepareDictionaryDuration time.Duration
+	TypedColumnPreparePruningDuration    time.Duration
+	TypedColumnPrepareSortKeyDuration    time.Duration
+	TypedColumnPrepareStatsDuration      time.Duration
+	TypedColumnPrepareRangeReadDuration  time.Duration
+	TypedColumnPrepareRangeReadBytes     int64
+	TypedColumnPrepareAdapterDuration    time.Duration
+	TypedColumnPrepareDenseGroupDuration time.Duration
+	TypedColumnPrepareDenseValueDuration time.Duration
+	TypedColumnPrepareDensePredDuration  time.Duration
+	TypedColumnPrepareDensePreapply      time.Duration
 	SetupDuration                        time.Duration
 	HotRunDuration                       time.Duration
 	ScanDuration                         time.Duration
@@ -2014,6 +2053,19 @@ func runColumnStoreSuiteQueries(collection *collections.Collection, rows int, ra
 			TypedColumnPreparePostDurationMS:       durationMS(exec.TypedColumnPreparePostDuration),
 			TypedColumnPrepareSummaryDurationMS:    durationMS(exec.TypedColumnPrepareSummaryDuration),
 			TypedColumnOneShotCacheStoreDurationMS: durationMS(exec.TypedColumnOneShotCacheStoreDuration),
+			TypedColumnPrepareReadImageDurationMS:  durationMS(exec.TypedColumnPrepareReadImageDuration),
+			TypedColumnPrepareStateBuildDurationMS: durationMS(exec.TypedColumnPrepareStateBuildDuration),
+			TypedColumnPrepareDictionaryDurationMS: durationMS(exec.TypedColumnPrepareDictionaryDuration),
+			TypedColumnPreparePruningDurationMS:    durationMS(exec.TypedColumnPreparePruningDuration),
+			TypedColumnPrepareSortKeyDurationMS:    durationMS(exec.TypedColumnPrepareSortKeyDuration),
+			TypedColumnPrepareStatsDurationMS:      durationMS(exec.TypedColumnPrepareStatsDuration),
+			TypedColumnPrepareRangeReadDurationMS:  durationMS(exec.TypedColumnPrepareRangeReadDuration),
+			TypedColumnPrepareRangeReadBytes:       exec.TypedColumnPrepareRangeReadBytes,
+			TypedColumnPrepareAdapterDurationMS:    durationMS(exec.TypedColumnPrepareAdapterDuration),
+			TypedColumnPrepareDenseGroupDurationMS: durationMS(exec.TypedColumnPrepareDenseGroupDuration),
+			TypedColumnPrepareDenseValueDurationMS: durationMS(exec.TypedColumnPrepareDenseValueDuration),
+			TypedColumnPrepareDensePredDurationMS:  durationMS(exec.TypedColumnPrepareDensePredDuration),
+			TypedColumnPrepareDensePreapplyMS:      durationMS(exec.TypedColumnPrepareDensePreapply),
 			CacheLabel:                             "reopened_warm_process",
 			CompressionAttribution: columnStoreQueryCompressionAttribution(
 				planLabel,
@@ -2457,6 +2509,19 @@ func executeColumnStoreSuitePhysicalQuery(collection *collections.Collection, qu
 		TypedColumnPreparePostDuration:       time.Duration(diag.TypedColumnPreparePostPrepareNanos),
 		TypedColumnPrepareSummaryDuration:    time.Duration(diag.TypedColumnPrepareSummaryNanos),
 		TypedColumnOneShotCacheStoreDuration: time.Duration(diag.TypedColumnOneShotCacheStoreNanos),
+		TypedColumnPrepareReadImageDuration:  time.Duration(diag.TypedColumnPrepareReadImageNanos),
+		TypedColumnPrepareStateBuildDuration: time.Duration(diag.TypedColumnPrepareStateBuildNanos),
+		TypedColumnPrepareDictionaryDuration: time.Duration(diag.TypedColumnPrepareDictionaryNanos),
+		TypedColumnPreparePruningDuration:    time.Duration(diag.TypedColumnPreparePruningNanos),
+		TypedColumnPrepareSortKeyDuration:    time.Duration(diag.TypedColumnPrepareSortKeyNanos),
+		TypedColumnPrepareStatsDuration:      time.Duration(diag.TypedColumnPrepareStatsNanos),
+		TypedColumnPrepareRangeReadDuration:  time.Duration(diag.TypedColumnPrepareRangeReadNanos),
+		TypedColumnPrepareRangeReadBytes:     diag.TypedColumnPrepareRangeReadBytes,
+		TypedColumnPrepareAdapterDuration:    time.Duration(diag.TypedColumnPrepareAdapterNanos),
+		TypedColumnPrepareDenseGroupDuration: time.Duration(diag.TypedColumnPrepareDenseGroupNanos),
+		TypedColumnPrepareDenseValueDuration: time.Duration(diag.TypedColumnPrepareDenseValueNanos),
+		TypedColumnPrepareDensePredDuration:  time.Duration(diag.TypedColumnPrepareDensePredicateNanos),
+		TypedColumnPrepareDensePreapply:      time.Duration(diag.TypedColumnPrepareDensePreapplyNanos),
 		HotRunDuration:                       elapsed,
 		ScanDuration:                         scanDuration,
 		ReduceDuration:                       reduceDuration,
@@ -2572,6 +2637,19 @@ func executeColumnStoreSuitePreparedPhysicalQuery(collection *collections.Collec
 		TypedColumnPreparePostDuration:       time.Duration(setupDiagnostics.TypedColumnPreparePostPrepareNanos),
 		TypedColumnPrepareSummaryDuration:    time.Duration(setupDiagnostics.TypedColumnPrepareSummaryNanos),
 		TypedColumnOneShotCacheStoreDuration: time.Duration(setupDiagnostics.TypedColumnOneShotCacheStoreNanos),
+		TypedColumnPrepareReadImageDuration:  time.Duration(setupDiagnostics.TypedColumnPrepareReadImageNanos),
+		TypedColumnPrepareStateBuildDuration: time.Duration(setupDiagnostics.TypedColumnPrepareStateBuildNanos),
+		TypedColumnPrepareDictionaryDuration: time.Duration(setupDiagnostics.TypedColumnPrepareDictionaryNanos),
+		TypedColumnPreparePruningDuration:    time.Duration(setupDiagnostics.TypedColumnPreparePruningNanos),
+		TypedColumnPrepareSortKeyDuration:    time.Duration(setupDiagnostics.TypedColumnPrepareSortKeyNanos),
+		TypedColumnPrepareStatsDuration:      time.Duration(setupDiagnostics.TypedColumnPrepareStatsNanos),
+		TypedColumnPrepareRangeReadDuration:  time.Duration(setupDiagnostics.TypedColumnPrepareRangeReadNanos),
+		TypedColumnPrepareRangeReadBytes:     setupDiagnostics.TypedColumnPrepareRangeReadBytes,
+		TypedColumnPrepareAdapterDuration:    time.Duration(setupDiagnostics.TypedColumnPrepareAdapterNanos),
+		TypedColumnPrepareDenseGroupDuration: time.Duration(setupDiagnostics.TypedColumnPrepareDenseGroupNanos),
+		TypedColumnPrepareDenseValueDuration: time.Duration(setupDiagnostics.TypedColumnPrepareDenseValueNanos),
+		TypedColumnPrepareDensePredDuration:  time.Duration(setupDiagnostics.TypedColumnPrepareDensePredicateNanos),
+		TypedColumnPrepareDensePreapply:      time.Duration(setupDiagnostics.TypedColumnPrepareDensePreapplyNanos),
 		SetupDuration:                        setupElapsed,
 		HotRunDuration:                       hotRunElapsed,
 		ScanDuration:                         scanDuration,
@@ -3006,6 +3084,19 @@ func columnStoreJSONBenchCellFromQueryMetric(q columnStoreQueryMetric, cfg *coll
 	cell.TypedColumnPreparePostDurationMS = q.TypedColumnPreparePostDurationMS
 	cell.TypedColumnPrepareSummaryDurationMS = q.TypedColumnPrepareSummaryDurationMS
 	cell.TypedColumnOneShotCacheStoreDurationMS = q.TypedColumnOneShotCacheStoreDurationMS
+	cell.TypedColumnPrepareReadImageDurationMS = q.TypedColumnPrepareReadImageDurationMS
+	cell.TypedColumnPrepareStateBuildDurationMS = q.TypedColumnPrepareStateBuildDurationMS
+	cell.TypedColumnPrepareDictionaryDurationMS = q.TypedColumnPrepareDictionaryDurationMS
+	cell.TypedColumnPreparePruningDurationMS = q.TypedColumnPreparePruningDurationMS
+	cell.TypedColumnPrepareSortKeyDurationMS = q.TypedColumnPrepareSortKeyDurationMS
+	cell.TypedColumnPrepareStatsDurationMS = q.TypedColumnPrepareStatsDurationMS
+	cell.TypedColumnPrepareRangeReadDurationMS = q.TypedColumnPrepareRangeReadDurationMS
+	cell.TypedColumnPrepareRangeReadBytes = q.TypedColumnPrepareRangeReadBytes
+	cell.TypedColumnPrepareAdapterDurationMS = q.TypedColumnPrepareAdapterDurationMS
+	cell.TypedColumnPrepareDenseGroupDurationMS = q.TypedColumnPrepareDenseGroupDurationMS
+	cell.TypedColumnPrepareDenseValueDurationMS = q.TypedColumnPrepareDenseValueDurationMS
+	cell.TypedColumnPrepareDensePredDurationMS = q.TypedColumnPrepareDensePredDurationMS
+	cell.TypedColumnPrepareDensePreapplyMS = q.TypedColumnPrepareDensePreapplyMS
 	cell.ScanDurationMS = q.ScanDurationMS
 	cell.ReduceDurationMS = q.ReduceDurationMS
 	cell.ResultShapeDurationMS = q.AdapterDurationMS
@@ -3112,6 +3203,19 @@ func columnStoreJSONBenchCellFromPreparedExecution(name string, rawHash uint64, 
 	cell.TypedColumnPreparePostDurationMS = durationMS(exec.TypedColumnPreparePostDuration)
 	cell.TypedColumnPrepareSummaryDurationMS = durationMS(exec.TypedColumnPrepareSummaryDuration)
 	cell.TypedColumnOneShotCacheStoreDurationMS = durationMS(exec.TypedColumnOneShotCacheStoreDuration)
+	cell.TypedColumnPrepareReadImageDurationMS = durationMS(exec.TypedColumnPrepareReadImageDuration)
+	cell.TypedColumnPrepareStateBuildDurationMS = durationMS(exec.TypedColumnPrepareStateBuildDuration)
+	cell.TypedColumnPrepareDictionaryDurationMS = durationMS(exec.TypedColumnPrepareDictionaryDuration)
+	cell.TypedColumnPreparePruningDurationMS = durationMS(exec.TypedColumnPreparePruningDuration)
+	cell.TypedColumnPrepareSortKeyDurationMS = durationMS(exec.TypedColumnPrepareSortKeyDuration)
+	cell.TypedColumnPrepareStatsDurationMS = durationMS(exec.TypedColumnPrepareStatsDuration)
+	cell.TypedColumnPrepareRangeReadDurationMS = durationMS(exec.TypedColumnPrepareRangeReadDuration)
+	cell.TypedColumnPrepareRangeReadBytes = exec.TypedColumnPrepareRangeReadBytes
+	cell.TypedColumnPrepareAdapterDurationMS = durationMS(exec.TypedColumnPrepareAdapterDuration)
+	cell.TypedColumnPrepareDenseGroupDurationMS = durationMS(exec.TypedColumnPrepareDenseGroupDuration)
+	cell.TypedColumnPrepareDenseValueDurationMS = durationMS(exec.TypedColumnPrepareDenseValueDuration)
+	cell.TypedColumnPrepareDensePredDurationMS = durationMS(exec.TypedColumnPrepareDensePredDuration)
+	cell.TypedColumnPrepareDensePreapplyMS = durationMS(exec.TypedColumnPrepareDensePreapply)
 	cell.MetadataHits = exec.MetadataHits
 	cell.RowsScanned = exec.RowsScanned
 	cell.RowsMatched = exec.RowsMatched
@@ -4334,6 +4438,7 @@ func renderColumnStoreSuiteMarkdown(report columnStoreSuiteReport) string {
 	renderColumnStoreInsertStatsMarkdown(&sb, report.InsertStats)
 	renderColumnStoreMetadataCostMarkdown(&sb, report.MetadataCost)
 	renderColumnStoreJSONBenchCellsMarkdown(&sb, report)
+	renderColumnStoreTypedColumnSetupDiagnosticsMarkdown(&sb, report)
 	renderColumnStoreColgranuleReuseMarkdown(&sb, report)
 
 	renderColumnStoreQueryMetricsMarkdown(&sb, "Query Throughput And Parity", report.Queries, report.Parity)
@@ -4643,6 +4748,81 @@ func renderColumnStoreJSONBenchCellsMarkdown(sb *strings.Builder, report columnS
 		))
 	}
 	sb.WriteString("\n")
+}
+
+func renderColumnStoreTypedColumnSetupDiagnosticsMarkdown(sb *strings.Builder, report columnStoreSuiteReport) {
+	hasDiagnostics := false
+	for _, cell := range report.JSONBenchCells {
+		if columnStoreJSONBenchCellHasTypedColumnSetupDiagnostics(cell) {
+			hasDiagnostics = true
+			break
+		}
+	}
+	if !hasDiagnostics {
+		return
+	}
+	sb.WriteString("## Typed Column Setup Diagnostics\n\n")
+	sb.WriteString("| cell | query | mode | query mode | metadata mode | prepare/setup ms | one-shot build ms | prep plan ms | prep refs ms | prep pair ms | prep decode ms | prep post ms | prep summary ms | cache store ms | read image ms | state build ms | dictionary ms | pruning ms | sort key ms | stats ms | range read ms | range read B | adapter ms | dense group ms | dense value ms | dense predicate ms | dense preapply ms |\n")
+	sb.WriteString("|---|---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|\n")
+	for _, cell := range report.JSONBenchCells {
+		if !columnStoreJSONBenchCellHasTypedColumnSetupDiagnostics(cell) {
+			continue
+		}
+		sb.WriteString(fmt.Sprintf("| %s | %s | %s | %s | %s | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %d | %.3f | %.3f | %.3f | %.3f | %.3f |\n",
+			markdownCodeTableText(cell.CellLabel),
+			markdownCodeTableText(cell.Query),
+			markdownCodeTableText(cell.ExecutionMode),
+			markdownCodeTableText(cell.QueryMode),
+			markdownCodeTableText(cell.MetadataMode),
+			cell.PrepareSetupDurationMS,
+			cell.TypedColumnOneShotBuildDurationMS,
+			cell.TypedColumnPreparePlanDurationMS,
+			cell.TypedColumnPrepareRefsDurationMS,
+			cell.TypedColumnPreparePairDurationMS,
+			cell.TypedColumnPrepareDecodeDurationMS,
+			cell.TypedColumnPreparePostDurationMS,
+			cell.TypedColumnPrepareSummaryDurationMS,
+			cell.TypedColumnOneShotCacheStoreDurationMS,
+			cell.TypedColumnPrepareReadImageDurationMS,
+			cell.TypedColumnPrepareStateBuildDurationMS,
+			cell.TypedColumnPrepareDictionaryDurationMS,
+			cell.TypedColumnPreparePruningDurationMS,
+			cell.TypedColumnPrepareSortKeyDurationMS,
+			cell.TypedColumnPrepareStatsDurationMS,
+			cell.TypedColumnPrepareRangeReadDurationMS,
+			cell.TypedColumnPrepareRangeReadBytes,
+			cell.TypedColumnPrepareAdapterDurationMS,
+			cell.TypedColumnPrepareDenseGroupDurationMS,
+			cell.TypedColumnPrepareDenseValueDurationMS,
+			cell.TypedColumnPrepareDensePredDurationMS,
+			cell.TypedColumnPrepareDensePreapplyMS,
+		))
+	}
+	sb.WriteString("\n")
+}
+
+func columnStoreJSONBenchCellHasTypedColumnSetupDiagnostics(cell columnStoreJSONBenchCell) bool {
+	return cell.TypedColumnOneShotBuildDurationMS != 0 ||
+		cell.TypedColumnPreparePlanDurationMS != 0 ||
+		cell.TypedColumnPrepareRefsDurationMS != 0 ||
+		cell.TypedColumnPreparePairDurationMS != 0 ||
+		cell.TypedColumnPrepareDecodeDurationMS != 0 ||
+		cell.TypedColumnPreparePostDurationMS != 0 ||
+		cell.TypedColumnPrepareSummaryDurationMS != 0 ||
+		cell.TypedColumnOneShotCacheStoreDurationMS != 0 ||
+		cell.TypedColumnPrepareReadImageDurationMS != 0 ||
+		cell.TypedColumnPrepareStateBuildDurationMS != 0 ||
+		cell.TypedColumnPrepareDictionaryDurationMS != 0 ||
+		cell.TypedColumnPreparePruningDurationMS != 0 ||
+		cell.TypedColumnPrepareSortKeyDurationMS != 0 ||
+		cell.TypedColumnPrepareStatsDurationMS != 0 ||
+		cell.TypedColumnPrepareRangeReadDurationMS != 0 ||
+		cell.TypedColumnPrepareRangeReadBytes != 0 ||
+		cell.TypedColumnPrepareAdapterDurationMS != 0 ||
+		cell.TypedColumnPrepareDenseGroupDurationMS != 0 ||
+		cell.TypedColumnPrepareDenseValueDurationMS != 0 ||
+		cell.TypedColumnPrepareDensePredDurationMS != 0 ||
+		cell.TypedColumnPrepareDensePreapplyMS != 0
 }
 
 func renderColumnStoreColgranuleReuseMarkdown(sb *strings.Builder, report columnStoreSuiteReport) {

--- a/cmd/unified_bench/suite_column_store_test.go
+++ b/cmd/unified_bench/suite_column_store_test.go
@@ -747,7 +747,7 @@ func TestRunColumnStoreSuiteWritesArtifactsAndMetricsM11A(t *testing.T) {
 			t.Fatalf("column store markdown missing insert phase field %q:\n%s", want, columnMarkdown)
 		}
 	}
-	for _, want := range []string{"## Metadata Cost", "aggregate_metadata_storage_bytes", "aggregate_metadata_prepare_duration_ms", "aggregate_metadata_append_share_duration_ms", "insert_cost_upper_bound_duration_ms", "insert_cost_basis", "insert_cost_upper_bound_basis", "storage_cost_basis", "## Production JSONBench Synthetic Cells", "## Colgranule Reuse Map", "metadata/data path", "metadata cost B", "metadata cost insert ms", "metadata cost basis", "retained payload", "retained encoding", "retained compression", "typed owner", "typed cells visited", "typed cells basis", "document materializations", "aggregate metadata used", "sort/topk pruning", "json reconstruction", "full-data caveat", "## Query Compression And Allocation Attribution", "## Codec/Layout Matrix", "codec/layout", "compression policy", "compressed bytes", "decompressed bytes", "raw bytes", "B/op", "allocs/op", columnStoreCompressionPolicyOff, columnStoreCompressionPolicyDefault} {
+	for _, want := range []string{"## Metadata Cost", "aggregate_metadata_storage_bytes", "aggregate_metadata_prepare_duration_ms", "aggregate_metadata_append_share_duration_ms", "insert_cost_upper_bound_duration_ms", "insert_cost_basis", "insert_cost_upper_bound_basis", "storage_cost_basis", "## Production JSONBench Synthetic Cells", "## Colgranule Reuse Map", "metadata/data path", "typed prep decode ms", "one-shot cache store ms", "metadata cost B", "metadata cost insert ms", "metadata cost basis", "retained payload", "retained encoding", "retained compression", "typed owner", "typed cells visited", "typed cells basis", "document materializations", "aggregate metadata used", "sort/topk pruning", "json reconstruction", "full-data caveat", "## Query Compression And Allocation Attribution", "## Codec/Layout Matrix", "codec/layout", "compression policy", "compressed bytes", "decompressed bytes", "raw bytes", "B/op", "allocs/op", columnStoreCompressionPolicyOff, columnStoreCompressionPolicyDefault} {
 		if !strings.Contains(string(columnMarkdown), want) {
 			t.Fatalf("column store markdown missing reporting field %q:\n%s", want, columnMarkdown)
 		}
@@ -2395,55 +2395,62 @@ func TestColumnStoreJSONBenchPreparedParityMismatchIsFatal1955(t *testing.T) {
 
 func TestColumnStoreJSONBenchCellFromQueryMetricUsesDirectDiagnostics1955(t *testing.T) {
 	q := columnStoreQueryMetric{
-		Name:                              "q4a",
-		PlanLabel:                         columnStorePathSerialColumnScan,
-		StorageSource:                     string(collections.ColumnPhysicalQueryStorageSourceCompatibilityDictionaryCodeInt64Asset),
-		FallbackReason:                    string(collections.ColumnPhysicalQueryFallbackNone),
-		Rows:                              7,
-		RowsProcessed:                     5,
-		RowsProcessedKnown:                true,
-		ResultCount:                       2,
-		RawHash:                           11,
-		ProductionHash:                    11,
-		ScanDurationMS:                    1.5,
-		ReduceDurationMS:                  2.5,
-		AdapterDurationMS:                 0.75,
-		PrepareSetupDurationMS:            0.50,
-		RunDurationMS:                     6.00,
-		RenderHashDurationMS:              0.25,
-		TotalQueryDurationMS:              6.75,
-		hotRunDuration:                    6 * time.Millisecond,
-		BytesRead:                         2048,
-		DecodedBytes:                      1536,
-		DecodedPayloadBytes:               1024,
-		DecodedMetadataBytes:              512,
-		MappedBytes:                       384,
-		HeapCopyBytes:                     1152,
-		ProjectedColumns:                  2,
-		PredicateCount:                    1,
-		TypedCellsVisited:                 26,
-		TypedCellsVisitedBasis:            "rows_scanned_x_projected_columns",
-		RowMaterializations:               1,
-		DocumentMaterializations:          2,
-		MetadataCostStorageBytes:          4096,
-		MetadataCostStorageBasis:          "storage_basis",
-		MetadataCostInsertMS:              7.25,
-		MetadataCostInsertNsRow:           250,
-		MetadataCostInsertBasis:           "insert_basis",
-		SortTopKPruningUsed:               true,
-		JSONReconstruction:                true,
-		RowsScanned:                       13,
-		RowsMatched:                       3,
-		ReduceRows:                        2,
-		TopKLimit:                         3,
-		TopKCandidates:                    9,
-		TopKOrder:                         string(collections.ColumnPhysicalQueryTopKInt64Asc),
-		TimeOrderTopKUsed:                 true,
-		DecodedBlocks:                     2,
-		DecodedGranules:                   4,
-		TypedColumnOneShotCacheMiss:       true,
-		TypedColumnOneShotCacheBuild:      true,
-		TypedColumnOneShotBuildDurationMS: 0.125,
+		Name:                                   "q4a",
+		PlanLabel:                              columnStorePathSerialColumnScan,
+		StorageSource:                          string(collections.ColumnPhysicalQueryStorageSourceCompatibilityDictionaryCodeInt64Asset),
+		FallbackReason:                         string(collections.ColumnPhysicalQueryFallbackNone),
+		Rows:                                   7,
+		RowsProcessed:                          5,
+		RowsProcessedKnown:                     true,
+		ResultCount:                            2,
+		RawHash:                                11,
+		ProductionHash:                         11,
+		ScanDurationMS:                         1.5,
+		ReduceDurationMS:                       2.5,
+		AdapterDurationMS:                      0.75,
+		PrepareSetupDurationMS:                 0.50,
+		RunDurationMS:                          6.00,
+		RenderHashDurationMS:                   0.25,
+		TotalQueryDurationMS:                   6.75,
+		hotRunDuration:                         6 * time.Millisecond,
+		BytesRead:                              2048,
+		DecodedBytes:                           1536,
+		DecodedPayloadBytes:                    1024,
+		DecodedMetadataBytes:                   512,
+		MappedBytes:                            384,
+		HeapCopyBytes:                          1152,
+		ProjectedColumns:                       2,
+		PredicateCount:                         1,
+		TypedCellsVisited:                      26,
+		TypedCellsVisitedBasis:                 "rows_scanned_x_projected_columns",
+		RowMaterializations:                    1,
+		DocumentMaterializations:               2,
+		MetadataCostStorageBytes:               4096,
+		MetadataCostStorageBasis:               "storage_basis",
+		MetadataCostInsertMS:                   7.25,
+		MetadataCostInsertNsRow:                250,
+		MetadataCostInsertBasis:                "insert_basis",
+		SortTopKPruningUsed:                    true,
+		JSONReconstruction:                     true,
+		RowsScanned:                            13,
+		RowsMatched:                            3,
+		ReduceRows:                             2,
+		TopKLimit:                              3,
+		TopKCandidates:                         9,
+		TopKOrder:                              string(collections.ColumnPhysicalQueryTopKInt64Asc),
+		TimeOrderTopKUsed:                      true,
+		DecodedBlocks:                          2,
+		DecodedGranules:                        4,
+		TypedColumnOneShotCacheMiss:            true,
+		TypedColumnOneShotCacheBuild:           true,
+		TypedColumnOneShotBuildDurationMS:      0.125,
+		TypedColumnPreparePlanDurationMS:       0.010,
+		TypedColumnPrepareRefsDurationMS:       0.011,
+		TypedColumnPreparePairDurationMS:       0.012,
+		TypedColumnPrepareDecodeDurationMS:     0.080,
+		TypedColumnPreparePostDurationMS:       0.013,
+		TypedColumnPrepareSummaryDurationMS:    0.014,
+		TypedColumnOneShotCacheStoreDurationMS: 0.015,
 		CompressionAttribution: columnStoreCompressionAttribution{
 			CompressionPolicyLabel: "default",
 			RequestedCompression:   "snappy",
@@ -2482,6 +2489,15 @@ func TestColumnStoreJSONBenchCellFromQueryMetricUsesDirectDiagnostics1955(t *tes
 	}
 	if got, want := cell.TypedColumnOneShotBuildDurationMS, q.TypedColumnOneShotBuildDurationMS; got != want {
 		t.Fatalf("typed_column_one_shot_build_duration_ms=%v want %v", got, want)
+	}
+	if got, want := cell.TypedColumnPreparePlanDurationMS, q.TypedColumnPreparePlanDurationMS; got != want {
+		t.Fatalf("typed_column_prepare_plan_duration_ms=%v want %v", got, want)
+	}
+	if got, want := cell.TypedColumnPrepareDecodeDurationMS, q.TypedColumnPrepareDecodeDurationMS; got != want {
+		t.Fatalf("typed_column_prepare_part_decode_duration_ms=%v want %v", got, want)
+	}
+	if got, want := cell.TypedColumnOneShotCacheStoreDurationMS, q.TypedColumnOneShotCacheStoreDurationMS; got != want {
+		t.Fatalf("typed_column_one_shot_cache_store_duration_ms=%v want %v", got, want)
 	}
 	if got, want := cell.RowsScanned, q.RowsScanned; got != want {
 		t.Fatalf("rows_scanned=%d want %d", got, want)

--- a/cmd/unified_bench/suite_column_store_test.go
+++ b/cmd/unified_bench/suite_column_store_test.go
@@ -2451,6 +2451,19 @@ func TestColumnStoreJSONBenchCellFromQueryMetricUsesDirectDiagnostics1955(t *tes
 		TypedColumnPreparePostDurationMS:       0.013,
 		TypedColumnPrepareSummaryDurationMS:    0.014,
 		TypedColumnOneShotCacheStoreDurationMS: 0.015,
+		TypedColumnPrepareReadImageDurationMS:  0.016,
+		TypedColumnPrepareStateBuildDurationMS: 0.017,
+		TypedColumnPrepareDictionaryDurationMS: 0.018,
+		TypedColumnPreparePruningDurationMS:    0.019,
+		TypedColumnPrepareSortKeyDurationMS:    0.020,
+		TypedColumnPrepareStatsDurationMS:      0.021,
+		TypedColumnPrepareRangeReadDurationMS:  0.022,
+		TypedColumnPrepareRangeReadBytes:       256,
+		TypedColumnPrepareAdapterDurationMS:    0.023,
+		TypedColumnPrepareDenseGroupDurationMS: 0.024,
+		TypedColumnPrepareDenseValueDurationMS: 0.025,
+		TypedColumnPrepareDensePredDurationMS:  0.026,
+		TypedColumnPrepareDensePreapplyMS:      0.027,
 		CompressionAttribution: columnStoreCompressionAttribution{
 			CompressionPolicyLabel: "default",
 			RequestedCompression:   "snappy",
@@ -2493,11 +2506,62 @@ func TestColumnStoreJSONBenchCellFromQueryMetricUsesDirectDiagnostics1955(t *tes
 	if got, want := cell.TypedColumnPreparePlanDurationMS, q.TypedColumnPreparePlanDurationMS; got != want {
 		t.Fatalf("typed_column_prepare_plan_duration_ms=%v want %v", got, want)
 	}
+	if got, want := cell.TypedColumnPrepareRefsDurationMS, q.TypedColumnPrepareRefsDurationMS; got != want {
+		t.Fatalf("typed_column_prepare_refs_duration_ms=%v want %v", got, want)
+	}
+	if got, want := cell.TypedColumnPreparePairDurationMS, q.TypedColumnPreparePairDurationMS; got != want {
+		t.Fatalf("typed_column_prepare_pairing_duration_ms=%v want %v", got, want)
+	}
 	if got, want := cell.TypedColumnPrepareDecodeDurationMS, q.TypedColumnPrepareDecodeDurationMS; got != want {
 		t.Fatalf("typed_column_prepare_part_decode_duration_ms=%v want %v", got, want)
 	}
+	if got, want := cell.TypedColumnPreparePostDurationMS, q.TypedColumnPreparePostDurationMS; got != want {
+		t.Fatalf("typed_column_prepare_post_prepare_duration_ms=%v want %v", got, want)
+	}
+	if got, want := cell.TypedColumnPrepareSummaryDurationMS, q.TypedColumnPrepareSummaryDurationMS; got != want {
+		t.Fatalf("typed_column_prepare_summary_duration_ms=%v want %v", got, want)
+	}
 	if got, want := cell.TypedColumnOneShotCacheStoreDurationMS, q.TypedColumnOneShotCacheStoreDurationMS; got != want {
 		t.Fatalf("typed_column_one_shot_cache_store_duration_ms=%v want %v", got, want)
+	}
+	if got, want := cell.TypedColumnPrepareReadImageDurationMS, q.TypedColumnPrepareReadImageDurationMS; got != want {
+		t.Fatalf("typed_column_prepare_read_image_duration_ms=%v want %v", got, want)
+	}
+	if got, want := cell.TypedColumnPrepareStateBuildDurationMS, q.TypedColumnPrepareStateBuildDurationMS; got != want {
+		t.Fatalf("typed_column_prepare_state_build_duration_ms=%v want %v", got, want)
+	}
+	if got, want := cell.TypedColumnPrepareDictionaryDurationMS, q.TypedColumnPrepareDictionaryDurationMS; got != want {
+		t.Fatalf("typed_column_prepare_dictionary_duration_ms=%v want %v", got, want)
+	}
+	if got, want := cell.TypedColumnPreparePruningDurationMS, q.TypedColumnPreparePruningDurationMS; got != want {
+		t.Fatalf("typed_column_prepare_pruning_duration_ms=%v want %v", got, want)
+	}
+	if got, want := cell.TypedColumnPrepareSortKeyDurationMS, q.TypedColumnPrepareSortKeyDurationMS; got != want {
+		t.Fatalf("typed_column_prepare_sort_key_duration_ms=%v want %v", got, want)
+	}
+	if got, want := cell.TypedColumnPrepareStatsDurationMS, q.TypedColumnPrepareStatsDurationMS; got != want {
+		t.Fatalf("typed_column_prepare_stats_duration_ms=%v want %v", got, want)
+	}
+	if got, want := cell.TypedColumnPrepareRangeReadDurationMS, q.TypedColumnPrepareRangeReadDurationMS; got != want {
+		t.Fatalf("typed_column_prepare_range_read_duration_ms=%v want %v", got, want)
+	}
+	if got, want := cell.TypedColumnPrepareRangeReadBytes, q.TypedColumnPrepareRangeReadBytes; got != want {
+		t.Fatalf("typed_column_prepare_range_read_bytes=%d want %d", got, want)
+	}
+	if got, want := cell.TypedColumnPrepareAdapterDurationMS, q.TypedColumnPrepareAdapterDurationMS; got != want {
+		t.Fatalf("typed_column_prepare_adapter_duration_ms=%v want %v", got, want)
+	}
+	if got, want := cell.TypedColumnPrepareDenseGroupDurationMS, q.TypedColumnPrepareDenseGroupDurationMS; got != want {
+		t.Fatalf("typed_column_prepare_dense_group_duration_ms=%v want %v", got, want)
+	}
+	if got, want := cell.TypedColumnPrepareDenseValueDurationMS, q.TypedColumnPrepareDenseValueDurationMS; got != want {
+		t.Fatalf("typed_column_prepare_dense_value_duration_ms=%v want %v", got, want)
+	}
+	if got, want := cell.TypedColumnPrepareDensePredDurationMS, q.TypedColumnPrepareDensePredDurationMS; got != want {
+		t.Fatalf("typed_column_prepare_dense_predicate_duration_ms=%v want %v", got, want)
+	}
+	if got, want := cell.TypedColumnPrepareDensePreapplyMS, q.TypedColumnPrepareDensePreapplyMS; got != want {
+		t.Fatalf("typed_column_prepare_dense_preapply_duration_ms=%v want %v", got, want)
 	}
 	if got, want := cell.RowsScanned, q.RowsScanned; got != want {
 		t.Fatalf("rows_scanned=%d want %d", got, want)


### PR DESCRIPTION
## Scope

Closes #3182.
Links #3175, #3070, #3001, and #3000.

This PR is a q5 one-shot/no-aggregate-metadata setup slice. It does not claim broad TreeDB SQL superiority and does not use hot-prepared metadata-backed timings as headline evidence.

It adds typed-column one-shot setup diagnostics for:

- planning, ref lookup, asset pairing, part decode, post-prepare, summary, and cache-store wall time
- prepared-state read/image, state build, dictionary attach, range read, adapter construction, dense group/value/predicate/preapply subphase counters
- `ColumnPhysicalQueryRunner.PrepareDiagnostics()` so unified-bench can report prepared setup work consistently

It also removes the prepared-adapter fallback that rebuilt reverse dictionaries from forward dictionaries. Prepared physical queries already request dictionaries by role: predicate roles need forward dictionaries, while grouping/projection roles request reverse dictionaries explicitly. Avoiding the fallback removes unnecessary q5 setup work for predicate-only columns.

## Production-shape framing

Primary lane improved here:

- query mode: `one_shot_end_to_end`
- metadata mode: `no_aggregate_metadata`
- query: q5
- layout: `column-store-full-prepared`
- aggregate metadata: not used
- row/document materialization: none on the columnar path
- JSON reconstruction: none on the columnar path
- bounded TopK/sort-mark pruning: used and reported separately from aggregate metadata

This PR improves/observes one-shot query setup and general typed-column scan setup. It does not improve insert/load speed directly and does not add automatic aggregate metadata acceleration.

## Benchmark evidence

Command shape, with JSONBench using this gomap checkout via `go mod edit -replace=github.com/snissn/gomap=/private/tmp/gomap_3182_q5_setup_20260627`:

```sh
go run ./cmd/jsonbench_treedb run \
  -data-dir /Users/michaelseiler/data/bluesky \
  -db-dir "$OUT/db" \
  -reset -scale 1m -format json \
  -storage-layout column-store-full-prepared \
  -query-mode one_shot_end_to_end \
  -metadata-mode no_aggregate_metadata \
  -projection full -queries q5 \
  -batch-size 16000 -tries 1 -profile fast -data-root fast \
  -allow-errors \
  -out "$OUT/result.json"
```

Pre-optimization diagnostic artifact:

- `/tmp/jsonbench_q5_setup_breakdown_projected_20260627_080629/result.json`
- q5 total: `61.973125ms`
- prepare/setup: `47.975167ms`
- run: `13.942750ms`

Post-optimization artifact 1:

- `/tmp/jsonbench_q5_no_reverse_synthesis_20260627_082401/result.json`
- rows loaded: `1,000,000`
- load wall: `17.712727291s`
- insert: `14.509840538s`
- TreeDB durable storage, WAL excluded: `137,491,579` bytes
- aggregate metadata bytes maintained: `5,860,282` bytes
- q5 total: `48.419459ms`
- prepare/setup: `35.950375ms`
- run: `12.436500ms`
- result shape: `0.412750ms`
- render/hash: `0.032375ms`
- rows scanned: `1,000,000`
- rows matched/reduced: `86,812`
- physical bytes scanned: `17,999,817`
- decoded payload bytes: `34,933,080`
- bounded TopK candidates: `50,464`
- result hash: `ef6217ce9da3a74fdf600ccbebd333457f017d6012dc0c231338961533f5689c`

Post-optimization repeat:

- `/tmp/jsonbench_q5_no_reverse_synthesis_repeat_20260627_082601/result.json`
- rows loaded: `1,000,000`
- load wall: `17.416155292s`
- insert: `14.289118126s`
- TreeDB durable storage, WAL excluded: `137,491,587` bytes
- aggregate metadata bytes maintained: `5,860,282` bytes
- q5 total: `51.211792ms`
- prepare/setup: `37.131000ms`
- run: `14.048375ms`
- result shape: `0.437958ms`
- render/hash: `0.032083ms`
- rows scanned: `1,000,000`
- rows matched/reduced: `86,812`
- physical bytes scanned: `17,999,817`
- decoded payload bytes: `34,933,080`
- bounded TopK candidates: `50,464`
- result hash: `ef6217ce9da3a74fdf600ccbebd333457f017d6012dc0c231338961533f5689c`

The fine setup counters are worker-summed across parallel part decode workers, so they can exceed wall-clock setup time. They are intended to locate setup work, not replace total query time.

## Validation

```sh
go test ./TreeDB/collections -run 'TestColumnPhysicalTypedColumnOneShotCacheQ5NoMetadata3088|TestColumnPhysicalTypedColumnOneShotCacheQ2NoMetadata3123|TestColumnPhysicalTypedColumnOneShotCacheQ1Q3NoMetadata3088|TestColumnPhysicalTypedColumnOneShotCacheEvictsLRU3088|TestColumnPhysicalQ5DenseTypedColumnDirectPreparedParity1950' -count=1

go test ./cmd/unified_bench -run 'TestColumnStoreJSONBenchCellFromQueryMetricUsesDirectDiagnostics1955|TestColumnStoreSuiteReportMarkdown|TestColumnStoreJSONBenchCell' -count=1

go test ./TreeDB/collections ./cmd/unified_bench -count=1

git diff --check
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added more detailed typed-column timing metrics to query and benchmark output, including preparation, decode, post-prepare, and cache-store phases.
  * Expanded prepared-query reporting so setup timing is now available in results and markdown/JSON benchmark tables.
  * Surface additional lifecycle timings in benchmark artifacts for easier performance analysis.

* **Bug Fixes**
  * Improved timing aggregation so metrics from parallel and multi-part work are combined consistently across executions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->