### PR TITLE
TreeDB: cap public command WAL batch payload retention

### DIFF
--- a/TreeDB/command_wal_public_cached.go
+++ b/TreeDB/command_wal_public_cached.go
@@ -243,16 +243,18 @@ func publicCommandWALPublishSync(durabilityMode string, sync bool) bool {
 }
 
 type commandWALPublicBatch struct {
-	db                *DB
-	inner             Batch
-	innerSetViewFn    func(key, value []byte) error
-	innerDeleteViewFn func(key []byte) error
-	payload           commitlog.RawKVBatchPayloadBuilder
-	payloadOpHint     int
-	payloadByteHint   int
-	opCount           int
-	hasDeleteRange    bool
-	dirty             bool
+	db                  *DB
+	inner               Batch
+	innerSetViewFn      func(key, value []byte) error
+	innerDeleteViewFn   func(key []byte) error
+	payload             commitlog.RawKVBatchPayloadBuilder
+	payloadOpHint       int
+	payloadByteHint     int
+	payloadSoftCapBytes int
+	payloadBypass       bool
+	opCount             int
+	hasDeleteRange      bool
+	dirty               bool
 	// retainPayloadAfterWrite is set by adapter-only replay-view helpers. It
 	// keeps payload-owned key/value views valid after a successful Write until
 	// Reset/Close or the next mutation. Ordinary public Batch callers do not use
@@ -265,6 +267,11 @@ type commandWALPublicBatch struct {
 // bounded, so this avoids repeated grow/copy churn without unbounded retention.
 const commandWALPublicBatchEstimatedKeyValueBytes = 192
 
+// Keep the public command-WAL batch payload builder below the Celestia-observed
+// large-batch peak while preserving the compact fast path for ordinary batches.
+const commandWALPublicBatchPayloadSoftCapBytes = 128 << 20
+const commandWALPublicBatchRawKVOpHeaderBytes = 1 + 4 + 4
+
 func newCommandWALPublicBatch(tdb *DB, inner Batch, opHint int) *commandWALPublicBatch {
 	b := &commandWALPublicBatch{db: tdb, inner: inner}
 	b.disableInnerStreamingBypass()
@@ -276,6 +283,7 @@ func newCommandWALPublicBatch(tdb *DB, inner Batch, opHint int) *commandWALPubli
 	}
 	b.payloadOpHint = opHint
 	b.payloadByteHint = byteHint
+	b.payloadSoftCapBytes = commandWALPublicBatchPayloadSoftCapBytes
 	b.resetPayloadWithHint()
 	return b
 }
@@ -285,6 +293,7 @@ func (b *commandWALPublicBatch) resetPayloadWithHint() {
 		return
 	}
 	_ = b.payload.ResetWithHint(b.payloadOpHint, b.payloadByteHint)
+	b.payloadBypass = false
 	b.hasDeleteRange = false
 }
 
@@ -378,6 +387,16 @@ func (b *commandWALPublicBatch) setView(key, value []byte, retainReplayViews boo
 		// calls, so keep that compact-zero identity tied to an immutable copy.
 		value = append([]byte(nil), value...)
 	}
+	needed := commandWALPublicBatchRawKVOpHeaderBytes + len(key) + len(value)
+	if b.shouldBypassPayloadAppend(needed, retainReplayViews) {
+		if err := b.inner.Set(key, value); err != nil {
+			return nil, nil, err
+		}
+		b.payloadBypass = true
+		b.opCount++
+		b.dirty = true
+		return nil, nil, nil
+	}
 	oldLen, oldCount := b.payload.Len(), b.payload.Count()
 	keyView, valueView, err = b.payload.AppendSet(key, value)
 	if err != nil {
@@ -419,6 +438,16 @@ func (b *commandWALPublicBatch) deleteView(key []byte, retainReplayViews bool) (
 	}
 	b.preparePayloadForAppend()
 	key = normalizeRawKVPointKey(key)
+	needed := commandWALPublicBatchRawKVOpHeaderBytes + len(key)
+	if b.shouldBypassPayloadAppend(needed, retainReplayViews) {
+		if err := b.inner.Delete(key); err != nil {
+			return nil, err
+		}
+		b.payloadBypass = true
+		b.opCount++
+		b.dirty = true
+		return nil, nil
+	}
 	oldLen, oldCount := b.payload.Len(), b.payload.Count()
 	keyView, err = b.payload.AppendDelete(key)
 	if err != nil {
@@ -444,6 +473,17 @@ func (b *commandWALPublicBatch) DeleteRange(start, end []byte) error {
 		return nil
 	}
 	b.preparePayloadForAppend()
+	needed := commandWALPublicBatchRawKVOpHeaderBytes + commandWALPublicRangeBoundBytes(start) + commandWALPublicRangeBoundBytes(end)
+	if b.shouldBypassPayloadAppend(needed, false) {
+		if err := b.inner.DeleteRange(start, end); err != nil {
+			return err
+		}
+		b.payloadBypass = true
+		b.opCount++
+		b.hasDeleteRange = true
+		b.dirty = true
+		return nil
+	}
 	oldLen, oldCount := b.payload.Len(), b.payload.Count()
 	if _, err := b.payload.AppendDeleteRange(start, end); err != nil {
 		return err
@@ -470,6 +510,27 @@ func (b *commandWALPublicBatch) innerDeleteView(key []byte) error {
 		return b.innerDeleteViewFn(key)
 	}
 	return b.inner.Delete(key)
+}
+
+func (b *commandWALPublicBatch) shouldBypassPayloadAppend(needed int, retainReplayViews bool) bool {
+	if b == nil || retainReplayViews || b.payloadSoftCapBytes <= 0 {
+		return false
+	}
+	if b.payloadBypass {
+		return true
+	}
+	current := b.payload.Len()
+	if current >= b.payloadSoftCapBytes {
+		return true
+	}
+	return needed > b.payloadSoftCapBytes-current
+}
+
+func commandWALPublicRangeBoundBytes(bound []byte) int {
+	if bound == nil {
+		return 0
+	}
+	return len(bound)
 }
 
 func (b *commandWALPublicBatch) Write() error {
@@ -590,7 +651,7 @@ func (b *commandWALPublicBatch) commandWALPayload() ([]byte, error) {
 	if b == nil || b.inner == nil {
 		return nil, ErrClosed
 	}
-	if b.payload.Count() == b.opCount && b.payload.Count() > 0 {
+	if !b.payloadBypass && b.payload.Count() == b.opCount && b.payload.Count() > 0 {
 		return b.payload.Payload(), nil
 	}
 	byteHint, _ := b.inner.GetByteSize()

--- a/TreeDB/command_wal_public_cached.go
+++ b/TreeDB/command_wal_public_cached.go
@@ -270,7 +270,6 @@ const commandWALPublicBatchEstimatedKeyValueBytes = 192
 // Keep the public command-WAL batch payload builder below the Celestia-observed
 // large-batch peak while preserving the compact fast path for ordinary batches.
 const commandWALPublicBatchPayloadSoftCapBytes = 128 << 20
-const commandWALPublicBatchRawKVOpHeaderBytes = 1 + 4 + 4
 
 func newCommandWALPublicBatch(tdb *DB, inner Batch, opHint int) *commandWALPublicBatch {
 	b := &commandWALPublicBatch{db: tdb, inner: inner}
@@ -387,8 +386,7 @@ func (b *commandWALPublicBatch) setView(key, value []byte, retainReplayViews boo
 		// calls, so keep that compact-zero identity tied to an immutable copy.
 		value = append([]byte(nil), value...)
 	}
-	needed := commandWALPublicBatchRawKVOpHeaderBytes + len(key) + len(value)
-	if b.shouldBypassPayloadAppend(needed, retainReplayViews) {
+	if b.shouldBypassPayloadAppendSet(key, value, retainReplayViews) {
 		if err := b.inner.Set(key, value); err != nil {
 			return nil, nil, err
 		}
@@ -438,8 +436,7 @@ func (b *commandWALPublicBatch) deleteView(key []byte, retainReplayViews bool) (
 	}
 	b.preparePayloadForAppend()
 	key = normalizeRawKVPointKey(key)
-	needed := commandWALPublicBatchRawKVOpHeaderBytes + len(key)
-	if b.shouldBypassPayloadAppend(needed, retainReplayViews) {
+	if b.shouldBypassPayloadAppendDelete(key, retainReplayViews) {
 		if err := b.inner.Delete(key); err != nil {
 			return nil, err
 		}
@@ -473,8 +470,7 @@ func (b *commandWALPublicBatch) DeleteRange(start, end []byte) error {
 		return nil
 	}
 	b.preparePayloadForAppend()
-	needed := commandWALPublicBatchRawKVOpHeaderBytes + commandWALPublicRangeBoundBytes(start) + commandWALPublicRangeBoundBytes(end)
-	if b.shouldBypassPayloadAppend(needed, false) {
+	if b.shouldBypassPayloadAppendDeleteRange(start, end) {
 		if err := b.inner.DeleteRange(start, end); err != nil {
 			return err
 		}
@@ -512,25 +508,32 @@ func (b *commandWALPublicBatch) innerDeleteView(key []byte) error {
 	return b.inner.Delete(key)
 }
 
-func (b *commandWALPublicBatch) shouldBypassPayloadAppend(needed int, retainReplayViews bool) bool {
+func (b *commandWALPublicBatch) shouldBypassPayloadAppendSet(key, value []byte, retainReplayViews bool) bool {
+	retainedCap, err := b.payload.RetainedCapAfterAppendSet(key, value)
+	return b.shouldBypassPayloadAppendRetainedCap(retainedCap, err, retainReplayViews)
+}
+
+func (b *commandWALPublicBatch) shouldBypassPayloadAppendDelete(key []byte, retainReplayViews bool) bool {
+	retainedCap, err := b.payload.RetainedCapAfterAppendDelete(key)
+	return b.shouldBypassPayloadAppendRetainedCap(retainedCap, err, retainReplayViews)
+}
+
+func (b *commandWALPublicBatch) shouldBypassPayloadAppendDeleteRange(start, end []byte) bool {
+	retainedCap, err := b.payload.RetainedCapAfterAppendDeleteRange(start, end)
+	return b.shouldBypassPayloadAppendRetainedCap(retainedCap, err, false)
+}
+
+func (b *commandWALPublicBatch) shouldBypassPayloadAppendRetainedCap(retainedCap int, predictionErr error, retainReplayViews bool) bool {
 	if b == nil || retainReplayViews || b.payloadSoftCapBytes <= 0 {
 		return false
 	}
 	if b.payloadBypass {
 		return true
 	}
-	retainedCap, err := b.payload.RetainedCapAfterAppend(needed)
-	if err != nil {
+	if predictionErr != nil {
 		return true
 	}
 	return retainedCap > b.payloadSoftCapBytes
-}
-
-func commandWALPublicRangeBoundBytes(bound []byte) int {
-	if bound == nil {
-		return 0
-	}
-	return len(bound)
 }
 
 func (b *commandWALPublicBatch) Write() error {

--- a/TreeDB/command_wal_public_cached.go
+++ b/TreeDB/command_wal_public_cached.go
@@ -519,11 +519,11 @@ func (b *commandWALPublicBatch) shouldBypassPayloadAppend(needed int, retainRepl
 	if b.payloadBypass {
 		return true
 	}
-	current := b.payload.Len()
-	if current >= b.payloadSoftCapBytes {
+	retainedCap, err := b.payload.RetainedCapAfterAppend(needed)
+	if err != nil {
 		return true
 	}
-	return needed > b.payloadSoftCapBytes-current
+	return retainedCap > b.payloadSoftCapBytes
 }
 
 func commandWALPublicRangeBoundBytes(bound []byte) int {
@@ -677,7 +677,8 @@ func (b *commandWALPublicBatch) appendCommandWAL(sync bool) error {
 	if b == nil || b.inner == nil {
 		return ErrClosed
 	}
-	if !b.hasDeleteRange && b.db != nil && b.db.commandWALCached && b.db.backend != nil {
+	usePointerEntries := !b.hasDeleteRange || b.payloadBypass || b.payload.Count() != b.opCount
+	if usePointerEntries && b.db != nil && b.db.commandWALCached && b.db.backend != nil {
 		var entries []batch.Entry
 		hasPointer := false
 		if err := b.inner.Replay(func(entry batch.Entry) error {

--- a/TreeDB/command_wal_public_test.go
+++ b/TreeDB/command_wal_public_test.go
@@ -555,6 +555,70 @@ func TestPublicCommandWALBatchWriteFailureDoesNotAppendFrame(t *testing.T) {
 	}
 }
 
+func TestPublicCommandWALBatchPayloadSoftCapWritesAndReopens(t *testing.T) {
+	dir := t.TempDir()
+	db, err := Open(Options{
+		Dir:                 dir,
+		Durability:          DurabilityWALOnRelaxed,
+		CommandWAL:          true,
+		CommandWALStatsScan: true,
+		DisableSideStores:   true,
+	})
+	if err != nil {
+		t.Fatalf("Open command WAL: %v", err)
+	}
+	b, ok := db.NewBatch().(*commandWALPublicBatch)
+	if !ok {
+		_ = db.Close()
+		t.Fatalf("NewBatch type=%T, want *commandWALPublicBatch", db.NewBatch())
+	}
+	b.payloadSoftCapBytes = 1
+	for _, kv := range []struct {
+		key   string
+		value string
+	}{
+		{"alpha", "one"},
+		{"bravo", "two"},
+	} {
+		if err := b.SetView([]byte(kv.key), []byte(kv.value)); err != nil {
+			_ = b.Close()
+			_ = db.Close()
+			t.Fatalf("SetView(%s): %v", kv.key, err)
+		}
+	}
+	if !b.payloadBypass || b.payload.Count() != 0 || b.opCount != 2 {
+		_ = b.Close()
+		_ = db.Close()
+		t.Fatalf("pre-Write bypass=%t payload_count=%d opCount=%d, want true/0/2", b.payloadBypass, b.payload.Count(), b.opCount)
+	}
+	if err := b.Write(); err != nil {
+		_ = b.Close()
+		_ = db.Close()
+		t.Fatalf("batch Write: %v", err)
+	}
+	if err := b.Close(); err != nil {
+		_ = db.Close()
+		t.Fatalf("batch Close: %v", err)
+	}
+	requireRawKVValue(t, db, []byte("alpha"), []byte("one"))
+	requireRawKVValue(t, db, []byte("bravo"), []byte("two"))
+	if err := db.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	reopen, err := Open(Options{
+		Dir:                 dir,
+		CommandWALStatsScan: true,
+		DisableSideStores:   true,
+	})
+	if err != nil {
+		t.Fatalf("Reopen: %v", err)
+	}
+	defer func() { _ = reopen.Close() }()
+	requireRawKVValue(t, reopen, []byte("alpha"), []byte("one"))
+	requireRawKVValue(t, reopen, []byte("bravo"), []byte("two"))
+}
+
 func TestPublicCommandWALCheckpointPublishesOnlyCoveredLSNs(t *testing.T) {
 	db, err := Open(Options{
 		Dir:                 t.TempDir(),

--- a/TreeDB/command_wal_public_test.go
+++ b/TreeDB/command_wal_public_test.go
@@ -619,6 +619,80 @@ func TestPublicCommandWALBatchPayloadSoftCapWritesAndReopens(t *testing.T) {
 	requireRawKVValue(t, reopen, []byte("bravo"), []byte("two"))
 }
 
+func TestPublicCommandWALBatchPayloadSoftCapRangePointerReopens(t *testing.T) {
+	dir := t.TempDir()
+	opts := Options{
+		Dir:                          dir,
+		Durability:                   DurabilityWALOnRelaxed,
+		CommandWAL:                   true,
+		CommandWALStatsScan:          true,
+		DisableSideStores:            true,
+		BackgroundCheckpointInterval: -1,
+	}
+	opts.ValueLog.PointerThreshold = 1
+	opts.ValueLog.ForcePointers = true
+
+	db, err := Open(opts)
+	if err != nil {
+		t.Fatalf("Open command WAL: %v", err)
+	}
+	if err := db.Set([]byte("b"), []byte("old-pointer-value")); err != nil {
+		_ = db.Close()
+		t.Fatalf("Set old value: %v", err)
+	}
+	if err := db.Checkpoint(); err != nil {
+		_ = db.Close()
+		t.Fatalf("Checkpoint old value: %v", err)
+	}
+
+	b, ok := db.NewBatch().(*commandWALPublicBatch)
+	if !ok {
+		_ = db.Close()
+		t.Fatalf("NewBatch type=%T, want *commandWALPublicBatch", db.NewBatch())
+	}
+	b.payloadSoftCapBytes = 1
+	want := bytes.Repeat([]byte("p"), 2048)
+	if err := b.DeleteRange([]byte("a"), []byte("z")); err != nil {
+		_ = b.Close()
+		_ = db.Close()
+		t.Fatalf("batch DeleteRange: %v", err)
+	}
+	if err := b.Set([]byte("m"), want); err != nil {
+		_ = b.Close()
+		_ = db.Close()
+		t.Fatalf("batch Set: %v", err)
+	}
+	if err := b.Write(); err != nil {
+		_ = b.Close()
+		_ = db.Close()
+		t.Fatalf("batch Write: %v", err)
+	}
+	if err := b.Close(); err != nil {
+		_ = db.Close()
+		t.Fatalf("batch Close: %v", err)
+	}
+	requireRawKVValue(t, db, []byte("m"), want)
+	hasOld, err := db.Has([]byte("b"))
+	if err != nil || hasOld {
+		_ = db.Close()
+		t.Fatalf("Has(b)=(%t,%v), want false,nil before reopen", hasOld, err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	reopen, err := Open(Options{Dir: dir, CommandWALStatsScan: true, DisableSideStores: true, BackgroundCheckpointInterval: -1})
+	if err != nil {
+		t.Fatalf("Reopen: %v", err)
+	}
+	defer reopen.Close()
+	requireRawKVValue(t, reopen, []byte("m"), want)
+	hasOld, err = reopen.Has([]byte("b"))
+	if err != nil || hasOld {
+		t.Fatalf("reopen Has(b)=(%t,%v), want false,nil", hasOld, err)
+	}
+}
+
 func TestPublicCommandWALCheckpointPublishesOnlyCoveredLSNs(t *testing.T) {
 	db, err := Open(Options{
 		Dir:                 t.TempDir(),
@@ -1216,6 +1290,37 @@ func TestPublicCommandWALBatchPayloadSoftCapSwitchesToReplay(t *testing.T) {
 	}
 	if len(got) != 2 || string(got[0].Key) != "a" || string(got[0].Value) != "b" || string(got[1].Key) != "second" || string(got[1].Value) != strings.Repeat("x", 128) {
 		t.Fatalf("replayed payload mismatch: %+v", got)
+	}
+}
+
+func TestPublicCommandWALBatchPayloadSoftCapAccountsForRetainedCapGrowth(t *testing.T) {
+	inner := &commandWALPayloadSoftCapBatch{}
+	wrapped := newCommandWALPublicBatch(nil, inner, 0)
+	wrapped.payloadSoftCapBytes = 100
+
+	if err := wrapped.SetView([]byte("a"), bytes.Repeat([]byte("x"), 70)); err != nil {
+		t.Fatalf("SetView first: %v", err)
+	}
+	firstLen := wrapped.payload.Len()
+	firstCap := wrapped.payload.RetainedCap()
+	if wrapped.payloadBypass {
+		t.Fatal("first append unexpectedly bypassed")
+	}
+	if firstCap <= 0 || firstCap >= wrapped.payloadSoftCapBytes || firstLen >= wrapped.payloadSoftCapBytes {
+		t.Fatalf("first retained len=%d cap=%d soft_cap=%d, want both below cap", firstLen, firstCap, wrapped.payloadSoftCapBytes)
+	}
+
+	if err := wrapped.SetView([]byte("b"), []byte("y")); err != nil {
+		t.Fatalf("SetView second: %v", err)
+	}
+	if !wrapped.payloadBypass {
+		t.Fatal("second append did not bypass retained-cap growth")
+	}
+	if wrapped.payload.Len() != firstLen || wrapped.payload.RetainedCap() != firstCap {
+		t.Fatalf("payload grew after retained-cap bypass: len/cap=%d/%d want %d/%d", wrapped.payload.Len(), wrapped.payload.RetainedCap(), firstLen, firstCap)
+	}
+	if inner.setViewCalls != 1 || inner.setCalls != 1 {
+		t.Fatalf("inner calls after retained-cap bypass: setView=%d set=%d, want 1/1", inner.setViewCalls, inner.setCalls)
 	}
 }
 

--- a/TreeDB/command_wal_public_test.go
+++ b/TreeDB/command_wal_public_test.go
@@ -1360,6 +1360,30 @@ func TestPublicCommandWALBatchPayloadSoftCapAccountsForCompactZeroMaterializatio
 	}
 }
 
+func TestPublicCommandWALBatchPayloadSoftCapAccountsForCompactZeroRetainedBuffers(t *testing.T) {
+	inner := &commandWALPayloadSoftCapBatch{}
+	wrapped := newCommandWALPublicBatch(nil, inner, 0)
+	wrapped.payloadSoftCapBytes = 64
+
+	key := bytes.Repeat([]byte("k"), 80)
+	value := []byte{0}
+	if err := wrapped.SetView(key, value); err != nil {
+		t.Fatalf("SetView large compact-zero key: %v", err)
+	}
+	if !wrapped.payloadBypass {
+		t.Fatal("compact-zero append did not bypass retained compact buffers")
+	}
+	if wrapped.payload.Count() != 0 || wrapped.opCount != 1 {
+		t.Fatalf("payload count=%d opCount=%d, want 0/1", wrapped.payload.Count(), wrapped.opCount)
+	}
+	if inner.setViewCalls != 0 || inner.setCalls != 1 {
+		t.Fatalf("inner calls after compact buffer bypass: setView=%d set=%d, want 0/1", inner.setViewCalls, inner.setCalls)
+	}
+	if got := wrapped.payload.RetainedCap(); got > wrapped.payloadSoftCapBytes {
+		t.Fatalf("retained canonical payload cap=%d, soft_cap=%d", got, wrapped.payloadSoftCapBytes)
+	}
+}
+
 func TestPublicCommandWALBatchPayloadSoftCapBoundsLargeValueBuilder(t *testing.T) {
 	inner := &commandWALPayloadSoftCapBatch{}
 	wrapped := newCommandWALPublicBatch(nil, inner, 0)

--- a/TreeDB/command_wal_public_test.go
+++ b/TreeDB/command_wal_public_test.go
@@ -1324,6 +1324,42 @@ func TestPublicCommandWALBatchPayloadSoftCapAccountsForRetainedCapGrowth(t *test
 	}
 }
 
+func TestPublicCommandWALBatchPayloadSoftCapAccountsForCompactZeroMaterialization(t *testing.T) {
+	inner := &commandWALPayloadSoftCapBatch{}
+	wrapped := newCommandWALPublicBatch(nil, inner, 0)
+	wrapped.payloadSoftCapBytes = 96
+
+	for i := 0; i < 3; i++ {
+		key := []byte(fmt.Sprintf("zero-%03d", i))
+		if err := wrapped.SetView(key, make([]byte, 32)); err != nil {
+			t.Fatalf("SetView compact zero %d: %v", i, err)
+		}
+	}
+	if wrapped.payloadBypass {
+		t.Fatal("compact zero appends bypassed before materialization was required")
+	}
+	firstCap := wrapped.payload.RetainedCap()
+	if firstCap > wrapped.payloadSoftCapBytes {
+		t.Fatalf("compact zero retained cap=%d, soft_cap=%d", firstCap, wrapped.payloadSoftCapBytes)
+	}
+
+	if err := wrapped.SetView([]byte("nz"), []byte("x")); err != nil {
+		t.Fatalf("SetView non-zero after compact zeros: %v", err)
+	}
+	if !wrapped.payloadBypass {
+		t.Fatal("non-zero append did not bypass before compact-zero materialization")
+	}
+	if wrapped.payload.RetainedCap() != firstCap {
+		t.Fatalf("payload retained cap grew after materialization bypass: got %d want %d", wrapped.payload.RetainedCap(), firstCap)
+	}
+	if wrapped.payload.Count() != 3 || wrapped.opCount != 4 {
+		t.Fatalf("payload count=%d opCount=%d, want 3/4", wrapped.payload.Count(), wrapped.opCount)
+	}
+	if inner.setViewCalls != 3 || inner.setCalls != 1 {
+		t.Fatalf("inner calls after compact materialization bypass: setView=%d set=%d, want 3/1", inner.setViewCalls, inner.setCalls)
+	}
+}
+
 func TestPublicCommandWALBatchPayloadSoftCapBoundsLargeValueBuilder(t *testing.T) {
 	inner := &commandWALPayloadSoftCapBatch{}
 	wrapped := newCommandWALPublicBatch(nil, inner, 0)
@@ -1339,8 +1375,8 @@ func TestPublicCommandWALBatchPayloadSoftCapBoundsLargeValueBuilder(t *testing.T
 	if !wrapped.payloadBypass {
 		t.Fatal("large-value batch did not bypass retained payload")
 	}
-	if got := wrapped.payload.Len(); got > wrapped.payloadSoftCapBytes {
-		t.Fatalf("retained payload len=%d, cap=%d", got, wrapped.payloadSoftCapBytes)
+	if got := wrapped.payload.RetainedCap(); got > wrapped.payloadSoftCapBytes {
+		t.Fatalf("retained payload cap=%d, soft_cap=%d", got, wrapped.payloadSoftCapBytes)
 	}
 	if wrapped.payload.Count() != 0 || wrapped.opCount != 8 {
 		t.Fatalf("payload count=%d opCount=%d, want 0/8", wrapped.payload.Count(), wrapped.opCount)

--- a/TreeDB/command_wal_public_test.go
+++ b/TreeDB/command_wal_public_test.go
@@ -1100,6 +1100,121 @@ func TestPublicCommandWALBatchResetPreservesCompactZeroScanFallback(t *testing.T
 	}
 }
 
+func TestPublicCommandWALBatchPayloadSoftCapSwitchesToReplay(t *testing.T) {
+	inner := &commandWALPayloadSoftCapBatch{}
+	wrapped := newCommandWALPublicBatch(nil, inner, 0)
+	wrapped.payloadSoftCapBytes = 64
+
+	if err := wrapped.SetView([]byte("a"), []byte("b")); err != nil {
+		t.Fatalf("SetView below cap: %v", err)
+	}
+	if inner.setViewCalls != 1 || inner.setCalls != 0 {
+		t.Fatalf("inner calls after first set: setView=%d set=%d, want 1/0", inner.setViewCalls, inner.setCalls)
+	}
+	firstPayloadLen := wrapped.payload.Len()
+	if firstPayloadLen <= 0 || firstPayloadLen > wrapped.payloadSoftCapBytes {
+		t.Fatalf("payload len after first set=%d cap=%d", firstPayloadLen, wrapped.payloadSoftCapBytes)
+	}
+
+	key := []byte("second")
+	value := bytes.Repeat([]byte("x"), 128)
+	if err := wrapped.SetView(key, value); err != nil {
+		t.Fatalf("SetView over cap: %v", err)
+	}
+	key[0] = 'X'
+	value[0] = 'Y'
+	if !wrapped.payloadBypass {
+		t.Fatal("payload bypass not set after crossing soft cap")
+	}
+	if wrapped.payload.Count() != 1 || wrapped.opCount != 2 {
+		t.Fatalf("payload count=%d opCount=%d, want 1/2", wrapped.payload.Count(), wrapped.opCount)
+	}
+	if wrapped.payload.Len() != firstPayloadLen {
+		t.Fatalf("payload len grew after bypass: got %d want %d", wrapped.payload.Len(), firstPayloadLen)
+	}
+	if inner.setViewCalls != 1 || inner.setCalls != 1 {
+		t.Fatalf("inner calls after bypass: setView=%d set=%d, want 1/1", inner.setViewCalls, inner.setCalls)
+	}
+	if got := inner.entries[1]; string(got.Key) != "second" || string(got.Value) != strings.Repeat("x", 128) {
+		t.Fatalf("bypassed entry mutated or not copied: key=%q value_prefix=%q", got.Key, got.Value[:1])
+	}
+
+	payload, err := wrapped.commandWALPayload()
+	if err != nil {
+		t.Fatalf("commandWALPayload after bypass: %v", err)
+	}
+	var got []batch.Entry
+	if err := commitlog.ScanRawKVBatchPayload(payload, func(op commitlog.RawKVOp, key, value []byte) error {
+		got = append(got, batch.Entry{Type: batch.OpPut, Key: append([]byte(nil), key...), Value: append([]byte(nil), value...)})
+		return nil
+	}); err != nil {
+		t.Fatalf("ScanRawKVBatchPayload: %v", err)
+	}
+	if len(got) != 2 || string(got[0].Key) != "a" || string(got[0].Value) != "b" || string(got[1].Key) != "second" || string(got[1].Value) != strings.Repeat("x", 128) {
+		t.Fatalf("replayed payload mismatch: %+v", got)
+	}
+}
+
+func TestPublicCommandWALBatchPayloadSoftCapBoundsLargeValueBuilder(t *testing.T) {
+	inner := &commandWALPayloadSoftCapBatch{}
+	wrapped := newCommandWALPublicBatch(nil, inner, 0)
+	wrapped.payloadSoftCapBytes = 256 << 10
+
+	value := bytes.Repeat([]byte("v"), 512<<10)
+	for i := 0; i < 8; i++ {
+		key := []byte(fmt.Sprintf("large-%02d", i))
+		if err := wrapped.SetView(key, value); err != nil {
+			t.Fatalf("SetView large %d: %v", i, err)
+		}
+	}
+	if !wrapped.payloadBypass {
+		t.Fatal("large-value batch did not bypass retained payload")
+	}
+	if got := wrapped.payload.Len(); got > wrapped.payloadSoftCapBytes {
+		t.Fatalf("retained payload len=%d, cap=%d", got, wrapped.payloadSoftCapBytes)
+	}
+	if wrapped.payload.Count() != 0 || wrapped.opCount != 8 {
+		t.Fatalf("payload count=%d opCount=%d, want 0/8", wrapped.payload.Count(), wrapped.opCount)
+	}
+	if inner.setViewCalls != 0 || inner.setCalls != 8 {
+		t.Fatalf("inner calls after large values: setView=%d set=%d, want 0/8", inner.setViewCalls, inner.setCalls)
+	}
+	totalCopied := 0
+	for _, entry := range inner.entries {
+		totalCopied += len(entry.Value)
+	}
+	if totalCopied != 8*len(value) {
+		t.Fatalf("inner copied value bytes=%d, want %d", totalCopied, 8*len(value))
+	}
+}
+
+func TestPublicCommandWALBatchPayloadSoftCapPreservesReplayViews(t *testing.T) {
+	inner := &commandWALPayloadSoftCapBatch{}
+	wrapped := newCommandWALPublicBatch(nil, inner, 0)
+	wrapped.payloadSoftCapBytes = 1
+
+	key := []byte("alpha")
+	value := []byte("value")
+	keyView, valueView, err := wrapped.SetViewWithReplayBytes(key, value)
+	if err != nil {
+		t.Fatalf("SetViewWithReplayBytes: %v", err)
+	}
+	key[0] = 'X'
+	value[0] = 'Y'
+	if wrapped.payloadBypass {
+		t.Fatal("replay-view append used payload bypass")
+	}
+	if inner.setViewCalls != 1 || inner.setCalls != 0 {
+		t.Fatalf("inner calls=%d/%d, want replay views through SetViewValidated", inner.setViewCalls, inner.setCalls)
+	}
+	if string(keyView) != "alpha" || string(valueView) != "value" {
+		t.Fatalf("replay views changed: key=%q value=%q", keyView, valueView)
+	}
+	if wrapped.payload.Count() != 1 || wrapped.opCount != 1 {
+		t.Fatalf("payload count=%d opCount=%d, want 1/1", wrapped.payload.Count(), wrapped.opCount)
+	}
+}
+
 type commandWALNoResetBatch struct {
 	entries []batch.Entry
 }
@@ -1113,12 +1228,29 @@ type commandWALHookBatch struct {
 	writeAfterCalls int
 }
 
+type commandWALPayloadSoftCapBatch struct {
+	commandWALResetBatch
+	setCalls     int
+	setViewCalls int
+}
+
 func (b *commandWALHookBatch) WriteAfterCommandWALAppend(_ bool, appendCommand func() error) error {
 	if err := appendCommand(); err != nil {
 		return err
 	}
 	b.writeAfterCalls++
 	b.Reset()
+	return nil
+}
+
+func (b *commandWALPayloadSoftCapBatch) Set(key, value []byte) error {
+	b.setCalls++
+	return b.commandWALResetBatch.Set(key, value)
+}
+
+func (b *commandWALPayloadSoftCapBatch) SetViewValidated(key, value []byte) error {
+	b.setViewCalls++
+	b.entries = append(b.entries, batch.Entry{Type: batch.OpPut, Key: key, Value: value})
 	return nil
 }
 

--- a/TreeDB/internal/commitlog/command_frame.go
+++ b/TreeDB/internal/commitlog/command_frame.go
@@ -250,8 +250,85 @@ func (b *RawKVBatchPayloadBuilder) RetainedCap() int {
 // RetainedCapAfterAppend returns the backing capacity that would be retained
 // after appending needed bytes with the same growth rule used by Append.
 func (b *RawKVBatchPayloadBuilder) RetainedCapAfterAppend(needed int) (int, error) {
-	_, newCap, err := b.payloadGrowth(needed)
+	if b == nil {
+		return 0, nil
+	}
+	payloadLen, payloadCap := b.payloadLenCapForAppend()
+	_, newCap, err := b.payloadGrowthFrom(payloadLen, payloadCap, needed)
 	return newCap, err
+}
+
+// RetainedCapAfterAppendSet returns the canonical payload backing capacity that
+// AppendSet would retain. If the append must expand compact-zero sets first,
+// the returned capacity includes that materialization.
+func (b *RawKVBatchPayloadBuilder) RetainedCapAfterAppendSet(key, value []byte) (int, error) {
+	if b == nil {
+		return 0, nil
+	}
+	if key == nil || value == nil {
+		return 0, ErrCorrupt
+	}
+	if commandFrameIntExceedsUint32(b.count+1) || commandFrameIntExceedsUint32(len(key)) || commandFrameIntExceedsUint32(len(value)) {
+		return 0, ErrRecordTooLarge
+	}
+	if b.zeroSetCompactOnly && b.canAppendCompactZeroSet(value) {
+		if err := b.validateCompactZeroSetAppend(key); err != nil {
+			return 0, err
+		}
+		_, payloadCap := b.payloadLenCapForAppend()
+		return payloadCap, nil
+	}
+	needed := rawKVOpHeaderSize + len(key) + len(value)
+	if b.zeroSetCompactOnly {
+		return b.retainedCapAfterCompactZeroMaterializeAppend(needed)
+	}
+	return b.RetainedCapAfterAppend(needed)
+}
+
+// RetainedCapAfterAppendDelete returns the canonical payload backing capacity
+// that AppendDelete would retain.
+func (b *RawKVBatchPayloadBuilder) RetainedCapAfterAppendDelete(key []byte) (int, error) {
+	if b == nil {
+		return 0, nil
+	}
+	if key == nil {
+		return 0, ErrCorrupt
+	}
+	if commandFrameIntExceedsUint32(b.count+1) || commandFrameIntExceedsUint32(len(key)) {
+		return 0, ErrRecordTooLarge
+	}
+	needed := rawKVOpHeaderSize + len(key)
+	if b.zeroSetCompactOnly {
+		return b.retainedCapAfterCompactZeroMaterializeAppend(needed)
+	}
+	return b.RetainedCapAfterAppend(needed)
+}
+
+// RetainedCapAfterAppendDeleteRange returns the canonical payload backing
+// capacity that AppendDeleteRange would retain.
+func (b *RawKVBatchPayloadBuilder) RetainedCapAfterAppendDeleteRange(start, end []byte) (int, error) {
+	if b == nil {
+		return 0, nil
+	}
+	if err := validateRawKVDeleteRangeBounds(start, end); err != nil {
+		return 0, err
+	}
+	if commandFrameIntExceedsUint32(b.count + 1) {
+		return 0, ErrRecordTooLarge
+	}
+	_, startBytes, err := rawKVRangeBoundEncodedLen(start)
+	if err != nil {
+		return 0, err
+	}
+	_, endBytes, err := rawKVRangeBoundEncodedLen(end)
+	if err != nil {
+		return 0, err
+	}
+	needed := rawKVOpHeaderSize + startBytes + endBytes
+	if b.zeroSetCompactOnly {
+		return b.retainedCapAfterCompactZeroMaterializeAppend(needed)
+	}
+	return b.RetainedCapAfterAppend(needed)
 }
 
 func (b *RawKVBatchPayloadBuilder) Truncate(payloadLen, count int) {
@@ -467,6 +544,9 @@ func (b *RawKVBatchPayloadBuilder) appendRawKVPayloadSpace(needed int) (int, err
 }
 
 func (b *RawKVBatchPayloadBuilder) payloadGrowth(needed int) (newLen, newCap int, err error) {
+	if b == nil {
+		return 0, 0, ErrCorrupt
+	}
 	if needed > int(^uint32(0))-len(b.payload) || needed > int(^uint(0)>>1)-len(b.payload) {
 		return 0, 0, ErrRecordTooLarge
 	}
@@ -485,6 +565,106 @@ func (b *RawKVBatchPayloadBuilder) payloadGrowth(needed int) (newLen, newCap int
 		}
 	}
 	return newLen, newCap, nil
+}
+
+func (b *RawKVBatchPayloadBuilder) payloadGrowthFrom(payloadLen, payloadCap, needed int) (newLen, newCap int, err error) {
+	if needed < 0 || payloadLen < 0 || payloadCap < 0 {
+		return 0, 0, ErrRecordTooLarge
+	}
+	if needed > int(^uint32(0))-payloadLen || needed > int(^uint(0)>>1)-payloadLen {
+		return 0, 0, ErrRecordTooLarge
+	}
+	newLen = payloadLen + needed
+	newCap = payloadCap
+	if newLen > newCap {
+		newCap *= 2
+		if newCap < newLen {
+			newCap = newLen
+		}
+		if b.payloadCapHint > newCap {
+			newCap = b.payloadCapHint
+		}
+		if newCap < 0 {
+			return 0, 0, ErrRecordTooLarge
+		}
+	}
+	return newLen, newCap, nil
+}
+
+func (b *RawKVBatchPayloadBuilder) payloadLenCapForAppend() (payloadLen, payloadCap int) {
+	if b == nil {
+		return 0, 0
+	}
+	payloadLen = len(b.payload)
+	payloadCap = cap(b.payload)
+	if payloadLen < rawKVBatchHeaderSize {
+		payloadLen = rawKVBatchHeaderSize
+	}
+	if payloadCap < payloadLen {
+		payloadCap = payloadLen
+	}
+	return payloadLen, payloadCap
+}
+
+func (b *RawKVBatchPayloadBuilder) retainedCapAfterCompactZeroMaterializeAppend(needed int) (int, error) {
+	if b == nil {
+		return 0, nil
+	}
+	if !b.zeroSetCompactOnly || b.count == 0 {
+		return b.RetainedCapAfterAppend(needed)
+	}
+	if b.zeroSetValueLen <= 0 || len(b.zeroPayload) < rawKVZeroBatchHeaderSize {
+		return 0, ErrCorrupt
+	}
+	expandedLen, ok := rawKVExpandedZeroBatchPayloadSize(b.count, b.zeroSetKeyBytes, b.zeroSetValueLen)
+	if !ok || commandFrameIntExceedsUint32(expandedLen) {
+		return 0, ErrRecordTooLarge
+	}
+	_, payloadCap := b.payloadLenCapForAppend()
+	if payloadCap < expandedLen {
+		payloadCap = expandedLen
+	}
+	_, newCap, err := b.payloadGrowthFrom(expandedLen, payloadCap, needed)
+	return newCap, err
+}
+
+func (b *RawKVBatchPayloadBuilder) validateCompactZeroSetAppend(key []byte) error {
+	if b == nil {
+		return nil
+	}
+	zeroLen := len(b.zeroPayload)
+	if zeroLen == 0 {
+		zeroLen = rawKVZeroBatchHeaderSize
+	}
+	version := b.zeroSetCompactVersion
+	if version == 0 {
+		version = rawKVZeroBatchPayloadV3
+		if len(key) > int(^uint16(0)) {
+			version = rawKVZeroBatchPayloadV2
+		}
+	}
+	if version == rawKVZeroBatchPayloadV3 && len(key) > int(^uint16(0)) {
+		promotedLen := rawKVZeroBatchHeaderSize
+		if b.count > (int(^uint(0)>>1)-promotedLen)/rawKVZeroOpHeaderSize {
+			return ErrRecordTooLarge
+		}
+		promotedLen += b.count * rawKVZeroOpHeaderSize
+		if b.zeroSetKeyBytes > int(^uint(0)>>1)-promotedLen {
+			return ErrRecordTooLarge
+		}
+		promotedLen += b.zeroSetKeyBytes
+		if commandFrameIntExceedsUint32(promotedLen) {
+			return ErrRecordTooLarge
+		}
+		zeroLen = promotedLen
+		version = rawKVZeroBatchPayloadV2
+	}
+	opHeaderSize := rawKVZeroOpHeaderSizeForVersion(version)
+	needed := opHeaderSize + len(key)
+	if needed > int(^uint32(0))-zeroLen || needed > int(^uint(0)>>1)-zeroLen {
+		return ErrRecordTooLarge
+	}
+	return nil
 }
 
 func (b *RawKVBatchPayloadBuilder) appendValidated(op RawKVOp, key, value []byte) (keyView, valueView []byte, err error) {

--- a/TreeDB/internal/commitlog/command_frame.go
+++ b/TreeDB/internal/commitlog/command_frame.go
@@ -239,6 +239,21 @@ func (b *RawKVBatchPayloadBuilder) Len() int {
 	return len(b.payload)
 }
 
+// RetainedCap returns the backing capacity retained by the canonical payload.
+func (b *RawKVBatchPayloadBuilder) RetainedCap() int {
+	if b == nil {
+		return 0
+	}
+	return cap(b.payload)
+}
+
+// RetainedCapAfterAppend returns the backing capacity that would be retained
+// after appending needed bytes with the same growth rule used by Append.
+func (b *RawKVBatchPayloadBuilder) RetainedCapAfterAppend(needed int) (int, error) {
+	_, newCap, err := b.payloadGrowth(needed)
+	return newCap, err
+}
+
 func (b *RawKVBatchPayloadBuilder) Truncate(payloadLen, count int) {
 	if b == nil || payloadLen < rawKVBatchHeaderSize || payloadLen > len(b.payload) || count < 0 {
 		return
@@ -436,22 +451,12 @@ func (b *RawKVBatchPayloadBuilder) AppendDeleteRange(start, end []byte) (startVi
 }
 
 func (b *RawKVBatchPayloadBuilder) appendRawKVPayloadSpace(needed int) (int, error) {
-	if needed > int(^uint32(0))-len(b.payload) || needed > int(^uint(0)>>1)-len(b.payload) {
-		return 0, ErrRecordTooLarge
-	}
 	off := len(b.payload)
-	newLen := off + needed
+	newLen, newCap, err := b.payloadGrowth(needed)
+	if err != nil {
+		return 0, err
+	}
 	if newLen > cap(b.payload) {
-		newCap := cap(b.payload) * 2
-		if newCap < newLen {
-			newCap = newLen
-		}
-		if b.payloadCapHint > newCap {
-			newCap = b.payloadCapHint
-		}
-		if newCap < 0 {
-			return 0, ErrRecordTooLarge
-		}
 		next := make([]byte, newLen, newCap)
 		copy(next, b.payload)
 		b.payload = next
@@ -459,6 +464,27 @@ func (b *RawKVBatchPayloadBuilder) appendRawKVPayloadSpace(needed int) (int, err
 		b.payload = b.payload[:newLen]
 	}
 	return off, nil
+}
+
+func (b *RawKVBatchPayloadBuilder) payloadGrowth(needed int) (newLen, newCap int, err error) {
+	if needed > int(^uint32(0))-len(b.payload) || needed > int(^uint(0)>>1)-len(b.payload) {
+		return 0, 0, ErrRecordTooLarge
+	}
+	newLen = len(b.payload) + needed
+	newCap = cap(b.payload)
+	if newLen > newCap {
+		newCap *= 2
+		if newCap < newLen {
+			newCap = newLen
+		}
+		if b.payloadCapHint > newCap {
+			newCap = b.payloadCapHint
+		}
+		if newCap < 0 {
+			return 0, 0, ErrRecordTooLarge
+		}
+	}
+	return newLen, newCap, nil
 }
 
 func (b *RawKVBatchPayloadBuilder) appendValidated(op RawKVOp, key, value []byte) (keyView, valueView []byte, err error) {

--- a/TreeDB/internal/commitlog/command_frame.go
+++ b/TreeDB/internal/commitlog/command_frame.go
@@ -258,9 +258,10 @@ func (b *RawKVBatchPayloadBuilder) RetainedCapAfterAppend(needed int) (int, erro
 	return newCap, err
 }
 
-// RetainedCapAfterAppendSet returns the canonical payload backing capacity that
-// AppendSet would retain. If the append must expand compact-zero sets first,
-// the returned capacity includes that materialization.
+// RetainedCapAfterAppendSet returns the payload-builder backing capacity that
+// AppendSet would retain. If the append stays compact-zero, the returned
+// capacity includes the compact-zero payload and zero-value view buffers. If the
+// append must expand compact-zero sets first, it includes that materialization.
 func (b *RawKVBatchPayloadBuilder) RetainedCapAfterAppendSet(key, value []byte) (int, error) {
 	if b == nil {
 		return 0, nil
@@ -272,20 +273,20 @@ func (b *RawKVBatchPayloadBuilder) RetainedCapAfterAppendSet(key, value []byte) 
 		return 0, ErrRecordTooLarge
 	}
 	if b.zeroSetCompactOnly && b.canAppendCompactZeroSet(value) {
-		if err := b.validateCompactZeroSetAppend(key); err != nil {
-			return 0, err
-		}
-		_, payloadCap := b.payloadLenCapForAppend()
-		return payloadCap, nil
+		return b.retainedCapAfterCompactZeroSetAppend(key, value)
 	}
 	needed := rawKVOpHeaderSize + len(key) + len(value)
 	if b.zeroSetCompactOnly {
 		return b.retainedCapAfterCompactZeroMaterializeAppend(needed)
 	}
-	return b.RetainedCapAfterAppend(needed)
+	payloadCap, err := b.RetainedCapAfterAppend(needed)
+	if err != nil {
+		return 0, err
+	}
+	return b.retainedPayloadBufferCap(payloadCap, cap(b.zeroPayload), cap(b.zeroSetValueView))
 }
 
-// RetainedCapAfterAppendDelete returns the canonical payload backing capacity
+// RetainedCapAfterAppendDelete returns the payload-builder backing capacity
 // that AppendDelete would retain.
 func (b *RawKVBatchPayloadBuilder) RetainedCapAfterAppendDelete(key []byte) (int, error) {
 	if b == nil {
@@ -301,11 +302,15 @@ func (b *RawKVBatchPayloadBuilder) RetainedCapAfterAppendDelete(key []byte) (int
 	if b.zeroSetCompactOnly {
 		return b.retainedCapAfterCompactZeroMaterializeAppend(needed)
 	}
-	return b.RetainedCapAfterAppend(needed)
+	payloadCap, err := b.RetainedCapAfterAppend(needed)
+	if err != nil {
+		return 0, err
+	}
+	return b.retainedPayloadBufferCap(payloadCap, cap(b.zeroPayload), cap(b.zeroSetValueView))
 }
 
-// RetainedCapAfterAppendDeleteRange returns the canonical payload backing
-// capacity that AppendDeleteRange would retain.
+// RetainedCapAfterAppendDeleteRange returns the payload-builder backing capacity
+// that AppendDeleteRange would retain.
 func (b *RawKVBatchPayloadBuilder) RetainedCapAfterAppendDeleteRange(start, end []byte) (int, error) {
 	if b == nil {
 		return 0, nil
@@ -328,7 +333,11 @@ func (b *RawKVBatchPayloadBuilder) RetainedCapAfterAppendDeleteRange(start, end 
 	if b.zeroSetCompactOnly {
 		return b.retainedCapAfterCompactZeroMaterializeAppend(needed)
 	}
-	return b.RetainedCapAfterAppend(needed)
+	payloadCap, err := b.RetainedCapAfterAppend(needed)
+	if err != nil {
+		return 0, err
+	}
+	return b.retainedPayloadBufferCap(payloadCap, cap(b.zeroPayload), cap(b.zeroSetValueView))
 }
 
 func (b *RawKVBatchPayloadBuilder) Truncate(payloadLen, count int) {
@@ -625,14 +634,18 @@ func (b *RawKVBatchPayloadBuilder) retainedCapAfterCompactZeroMaterializeAppend(
 		payloadCap = expandedLen
 	}
 	_, newCap, err := b.payloadGrowthFrom(expandedLen, payloadCap, needed)
-	return newCap, err
+	if err != nil {
+		return 0, err
+	}
+	return b.retainedPayloadBufferCap(newCap, cap(b.zeroPayload), cap(b.zeroSetValueView))
 }
 
-func (b *RawKVBatchPayloadBuilder) validateCompactZeroSetAppend(key []byte) error {
+func (b *RawKVBatchPayloadBuilder) retainedCapAfterCompactZeroSetAppend(key, value []byte) (int, error) {
 	if b == nil {
-		return nil
+		return 0, nil
 	}
 	zeroLen := len(b.zeroPayload)
+	zeroCap := cap(b.zeroPayload)
 	if zeroLen == 0 {
 		zeroLen = rawKVZeroBatchHeaderSize
 	}
@@ -642,29 +655,66 @@ func (b *RawKVBatchPayloadBuilder) validateCompactZeroSetAppend(key []byte) erro
 		if len(key) > int(^uint16(0)) {
 			version = rawKVZeroBatchPayloadV2
 		}
+		capHint := rawKVZeroBatchHeaderSize
+		if b.opHint > 0 {
+			if hint, ok := rawKVZeroBatchPayloadSizeHint(b.opHint, len(key)); ok {
+				capHint = hint
+			}
+		}
+		if zeroCap < rawKVZeroBatchHeaderSize {
+			zeroCap = capHint
+		}
 	}
 	if version == rawKVZeroBatchPayloadV3 && len(key) > int(^uint16(0)) {
 		promotedLen := rawKVZeroBatchHeaderSize
 		if b.count > (int(^uint(0)>>1)-promotedLen)/rawKVZeroOpHeaderSize {
-			return ErrRecordTooLarge
+			return 0, ErrRecordTooLarge
 		}
 		promotedLen += b.count * rawKVZeroOpHeaderSize
 		if b.zeroSetKeyBytes > int(^uint(0)>>1)-promotedLen {
-			return ErrRecordTooLarge
+			return 0, ErrRecordTooLarge
 		}
 		promotedLen += b.zeroSetKeyBytes
 		if commandFrameIntExceedsUint32(promotedLen) {
-			return ErrRecordTooLarge
+			return 0, ErrRecordTooLarge
 		}
 		zeroLen = promotedLen
+		zeroCap = promotedLen
 		version = rawKVZeroBatchPayloadV2
 	}
 	opHeaderSize := rawKVZeroOpHeaderSizeForVersion(version)
 	needed := opHeaderSize + len(key)
 	if needed > int(^uint32(0))-zeroLen || needed > int(^uint(0)>>1)-zeroLen {
-		return ErrRecordTooLarge
+		return 0, ErrRecordTooLarge
 	}
-	return nil
+	zeroLen += needed
+	if zeroLen > zeroCap {
+		zeroCap *= 2
+		if zeroCap < zeroLen {
+			zeroCap = zeroLen
+		}
+		if zeroCap < 0 {
+			return 0, ErrRecordTooLarge
+		}
+	}
+	_, payloadCap := b.payloadLenCapForAppend()
+	zeroSetValueViewCap := cap(b.zeroSetValueView)
+	if zeroSetValueViewCap < len(value) {
+		zeroSetValueViewCap = len(value)
+	}
+	return b.retainedPayloadBufferCap(payloadCap, zeroCap, zeroSetValueViewCap)
+}
+
+func (b *RawKVBatchPayloadBuilder) retainedPayloadBufferCap(caps ...int) (int, error) {
+	total := 0
+	maxInt := int(^uint(0) >> 1)
+	for _, retained := range caps {
+		if retained < 0 || retained > maxInt-total {
+			return 0, ErrRecordTooLarge
+		}
+		total += retained
+	}
+	return total, nil
 }
 
 func (b *RawKVBatchPayloadBuilder) appendValidated(op RawKVOp, key, value []byte) (keyView, valueView []byte, err error) {

--- a/TreeDB/internal/commitlog/command_frame_test.go
+++ b/TreeDB/internal/commitlog/command_frame_test.go
@@ -271,6 +271,27 @@ func TestRawKVBatchPayloadBuilderRetainedCapPredictsCompactZeroMaterialization(t
 	}
 }
 
+func TestRawKVBatchPayloadBuilderRetainedCapPredictsCompactZeroBuffers(t *testing.T) {
+	var builder RawKVBatchPayloadBuilder
+	if err := builder.ResetWithHint(0, 0); err != nil {
+		t.Fatalf("ResetWithHint: %v", err)
+	}
+	retainedCap, err := builder.RetainedCapAfterAppendSet([]byte("zero"), make([]byte, 128))
+	if err != nil {
+		t.Fatalf("RetainedCapAfterAppendSet compact zero: %v", err)
+	}
+	wantMin := rawKVBatchHeaderSize + rawKVZeroBatchHeaderSize + rawKVZeroOpHeaderSizeV3 + len("zero") + 128
+	if retainedCap < wantMin {
+		t.Fatalf("compact zero retained cap=%d, want at least %d", retainedCap, wantMin)
+	}
+	if got := builder.RetainedCap(); got != rawKVBatchHeaderSize {
+		t.Fatalf("prediction mutated canonical retained cap=%d, want %d", got, rawKVBatchHeaderSize)
+	}
+	if cap(builder.zeroPayload) != 0 || cap(builder.zeroSetValueView) != 0 {
+		t.Fatalf("prediction mutated compact buffers: zeroPayload cap=%d zeroSetValueView cap=%d", cap(builder.zeroPayload), cap(builder.zeroSetValueView))
+	}
+}
+
 func TestCommandWALCollectionPayloadDecodeBoundsCountBeforeAllocation(t *testing.T) {
 	payload := make([]byte, 10+len("users"))
 	encodeCollectionBatchHeader(payload, "users", int(^uint32(0)))

--- a/TreeDB/internal/commitlog/command_frame_test.go
+++ b/TreeDB/internal/commitlog/command_frame_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -234,6 +235,39 @@ func TestRawKVBatchPayloadBuilderZeroCompactionFallsBackForMixedValues(t *testin
 	}
 	if !bytes.Equal(decoded[0].Value, make([]byte, 4)) {
 		t.Fatalf("materialized omitted zero value = %x, want zeros", decoded[0].Value)
+	}
+}
+
+func TestRawKVBatchPayloadBuilderRetainedCapPredictsCompactZeroMaterialization(t *testing.T) {
+	var nilBuilder *RawKVBatchPayloadBuilder
+	if got, err := nilBuilder.RetainedCapAfterAppend(1); err != nil || got != 0 {
+		t.Fatalf("nil RetainedCapAfterAppend=%d, %v; want 0, nil", got, err)
+	}
+
+	var builder RawKVBatchPayloadBuilder
+	if err := builder.ResetWithHint(0, 0); err != nil {
+		t.Fatalf("ResetWithHint: %v", err)
+	}
+	for i := 0; i < 3; i++ {
+		if _, _, err := builder.AppendSet([]byte(fmt.Sprintf("zero-%03d", i)), make([]byte, 32)); err != nil {
+			t.Fatalf("AppendSet compact zero %d: %v", i, err)
+		}
+	}
+	if got := builder.RetainedCap(); got != rawKVBatchHeaderSize {
+		t.Fatalf("compact zero canonical retained cap=%d, want %d", got, rawKVBatchHeaderSize)
+	}
+
+	retainedCap, err := builder.RetainedCapAfterAppendSet([]byte("nz"), []byte("x"))
+	if err != nil {
+		t.Fatalf("RetainedCapAfterAppendSet non-zero: %v", err)
+	}
+	expandedLen, ok := rawKVExpandedZeroBatchPayloadSize(3, len("zero-000")*3, 32)
+	if !ok {
+		t.Fatal("expanded zero batch size overflow")
+	}
+	wantMin := expandedLen + rawKVOpHeaderSize + len("nz") + len("x")
+	if retainedCap < wantMin {
+		t.Fatalf("retained cap after compact materialization=%d, want at least %d", retainedCap, wantMin)
 	}
 }
 


### PR DESCRIPTION
Refs #3184.

## Summary

- Adds a 128 MiB soft cap for the retained public command-WAL `RawKVBatchPayloadBuilder`.
- Once a public batch would exceed the cap, subsequent ops are staged through the inner batch copying path and command-WAL append falls back to inner replay or the existing pointer-frame fast path.
- Keeps adapter replay-byte calls on the payload-owned view path so their returned key/value slices remain valid until `Reset`/`Close`.

## Evidence

- `GOWORK=off go test ./TreeDB -run 'TestPublicCommandWALBatchPayloadSoftCap|TestPublicCommandWALBatchResetPreservesCompactZeroScanFallback|TestPublicCommandWALBatchReplayBytesSurviveWriteUntilReset|TestPublicCommandWALRawKVWritesUseTypedFrames' -count=1`
- `GOWORK=off go test ./TreeDB -run 'CommandWAL|PublicCommandWAL|RawKV' -count=1`
- `GOWORK=off go test ./TreeDB -count=1`
- `git diff --check`

Quantitative guardrail added in `TestPublicCommandWALBatchPayloadSoftCapBoundsLargeValueBuilder`: with 8 x 512 KiB values and a 256 KiB test cap, retained builder bytes stay under the cap while all 8 entries are staged through copied inner-batch entries. That is the targeted local proof for the #3184 pprof bucket before running another Celestia sync.

## Caveat / next follow-up

This intentionally preserves one public batch as one logical command append and does not split command frames. It caps retained public-batch payload growth and enables the pointer replay fast path for large value-log-backed batches. Inline-only huge batches can still allocate a full replay payload at append time; the safer follow-up is a one-frame, multi-part raw-KV payload writer/builder so recovery still sees one LSN without requiring one contiguous payload allocation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added smarter batch handling that switches between retaining encoded payloads and rebuilding it when batch size grows too large.
  * Improved large write handling so oversized batches are processed more safely and efficiently.

* **Bug Fixes**
  * Preserved replay data and copied batch content more reliably when inputs are reused or modified later.
  * Improved range and value write behavior so reopened data remains consistent after batch processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->