### PR TITLE
TreeDB: use dense dictionary slices for q5 one-shot

### DIFF
--- a/TreeDB/collections/column_physical_typed_column_one_shot_cache_3088_test.go
+++ b/TreeDB/collections/column_physical_typed_column_one_shot_cache_3088_test.go
@@ -69,6 +69,7 @@ func TestColumnPhysicalTypedColumnOneShotCacheQ5NoMetadata3088(t *testing.T) {
 	}
 	assertColumnPhysicalQ5DenseResult1950(t, "q5 first one-shot", first, want, len(events), matchedRows, columnTypedColumnDenseInt64SpanReducerLocalMap)
 	assertTypedColumnOneShotCacheSnapshot3088(t, col, "after q5 first", 1, 0, 1, 1, 0)
+	assertTypedColumnQ5OneShotDenseDictionaryValuesByCode3175(t, col, req)
 
 	second, err := col.RunColumnPhysicalQuery(req)
 	if err != nil {
@@ -221,6 +222,47 @@ func TestColumnPhysicalTypedColumnParallelPartDecodeShapes3158(t *testing.T) {
 				t.Fatalf("parallel part decode=%t want %t", got, tc.want)
 			}
 		})
+	}
+}
+
+func assertTypedColumnQ5OneShotDenseDictionaryValuesByCode3175(tb testing.TB, col *Collection, req ColumnPhysicalQueryRequest) {
+	tb.Helper()
+	if col == nil {
+		tb.Fatalf("nil collection")
+	}
+	wantPredicates := collectionTypedColumnOneShotPredicateKey(req)
+	var entry *collectionTypedColumnOneShotCacheEntry
+	col.typedColumnOneShotMu.Lock()
+	for slot, current := range col.typedColumnOneShot {
+		if slot.kind == req.Kind &&
+			slot.groupColumn == req.GroupColumn &&
+			slot.valueColumn == req.ValueColumn &&
+			slot.predicates == wantPredicates {
+			entry = current
+			break
+		}
+	}
+	col.typedColumnOneShotMu.Unlock()
+	if entry == nil {
+		tb.Fatalf("q5 typed-column one-shot cache entry not found")
+	}
+	entry.mu.Lock()
+	defer entry.mu.Unlock()
+	runner := entry.runner
+	if runner == nil {
+		tb.Fatalf("q5 typed-column one-shot cache entry has nil runner")
+	}
+	for partIdx := range runner.parts {
+		dense := runner.parts[partIdx].DenseInt64Span
+		if dense == nil {
+			tb.Fatalf("q5 typed-column one-shot part %d missing dense int64-span state", partIdx)
+		}
+		if len(dense.Dictionary) != dense.Cardinality {
+			tb.Fatalf("q5 typed-column one-shot part %d dictionary values-by-code=%d want cardinality=%d", partIdx, len(dense.Dictionary), dense.Cardinality)
+		}
+		if len(dense.DictionaryByCode) != 0 {
+			tb.Fatalf("q5 typed-column one-shot part %d reverse dictionary retained=%d want 0", partIdx, len(dense.DictionaryByCode))
+		}
 	}
 }
 

--- a/TreeDB/collections/column_physical_typed_column_query.go
+++ b/TreeDB/collections/column_physical_typed_column_query.go
@@ -82,6 +82,7 @@ type columnTypedColumnDenseGroupCountDistinctPart struct {
 
 type columnTypedColumnDenseGroupHourCountPart struct {
 	Cardinality      int
+	Dictionary       []string
 	DictionaryByCode map[int64]string
 	GroupCodes       []uint32
 	GroupValid       []bool
@@ -91,6 +92,7 @@ type columnTypedColumnDenseGroupHourCountPart struct {
 
 type columnTypedColumnDenseInt64SpanPart struct {
 	Cardinality           int
+	Dictionary            []string
 	DictionaryByCode      map[int64]string
 	GroupCodes            []uint32
 	GroupValid            []bool
@@ -1010,7 +1012,7 @@ func buildColumnTypedColumnDenseGroupHourCountSummary(parts []columnTypedColumnP
 				}
 				if !seen {
 					var ok bool
-					key, ok = dense.DictionaryByCode[int64(localCode)]
+					key, ok = columnTypedColumnDenseGroupHourDictionaryValue(dense, localCode)
 					if !ok {
 						return nil, fmt.Errorf("collections: dense typed-column group-hour part %d dictionary missing local code %d", partIdx, localCode)
 					}
@@ -1406,7 +1408,7 @@ func prepareColumnTypedColumnDenseInt64SpanGlobalCodes(parts []columnTypedColumn
 		}
 		globalRanks := make([]uint32, dense.Cardinality)
 		for localCode := 0; localCode < dense.Cardinality; localCode++ {
-			value, ok := dense.DictionaryByCode[int64(localCode)]
+			value, ok := columnTypedColumnDenseInt64SpanDictionaryValue(dense, localCode)
 			if !ok {
 				return fmt.Errorf("collections: dense typed-column int64-span part %d dictionary missing local code %d", partIdx, localCode)
 			}
@@ -1430,7 +1432,7 @@ func columnTypedColumnDenseInt64SpanGlobalDictionary(parts []columnTypedColumnPh
 			return nil, nil, fmt.Errorf("collections: dense typed-column int64-span missing prepared part %d", partIdx)
 		}
 		for localCode := 0; localCode < dense.Cardinality; localCode++ {
-			value, ok := dense.DictionaryByCode[int64(localCode)]
+			value, ok := columnTypedColumnDenseInt64SpanDictionaryValue(dense, localCode)
 			if !ok {
 				return nil, nil, fmt.Errorf("collections: dense typed-column int64-span part %d dictionary missing local code %d", partIdx, localCode)
 			}
@@ -1450,6 +1452,34 @@ func columnTypedColumnDenseInt64SpanGlobalDictionary(parts []columnTypedColumnPh
 		ranks[value] = uint32(rank)
 	}
 	return dictionary, ranks, nil
+}
+
+func columnTypedColumnDenseInt64SpanDictionaryValue(dense *columnTypedColumnDenseInt64SpanPart, localCode int) (string, bool) {
+	if dense == nil || localCode < 0 {
+		return "", false
+	}
+	if localCode < len(dense.Dictionary) {
+		return dense.Dictionary[localCode], true
+	}
+	if dense.DictionaryByCode != nil {
+		value, ok := dense.DictionaryByCode[int64(localCode)]
+		return value, ok
+	}
+	return "", false
+}
+
+func columnTypedColumnDenseGroupHourDictionaryValue(dense *columnTypedColumnDenseGroupHourCountPart, localCode int) (string, bool) {
+	if dense == nil || localCode < 0 {
+		return "", false
+	}
+	if localCode < len(dense.Dictionary) {
+		return dense.Dictionary[localCode], true
+	}
+	if dense.DictionaryByCode != nil {
+		value, ok := dense.DictionaryByCode[int64(localCode)]
+		return value, ok
+	}
+	return "", false
 }
 
 func columnTypedColumnPhysicalQueryTouchesTypedColumnPart(cfg ColumnStoreConfig, req ColumnPhysicalQueryRequest) bool {
@@ -2231,7 +2261,7 @@ func (r *columnTypedColumnPhysicalQueryRunner) runLatestVisibleDenseGroupHourCou
 				}
 				if !seen {
 					var ok bool
-					key, ok = dense.DictionaryByCode[int64(localCode)]
+					key, ok = columnTypedColumnDenseGroupHourDictionaryValue(dense, localCode)
 					if !ok {
 						diag := r.latestVisibleDiagnostics(view, req, state, visibilityBytes, visibilityNanos, rowsScanned, matchedRows, reduceRows, time.Since(start).Nanoseconds())
 						diag.DenseGroupHourCountUsed = true
@@ -2370,7 +2400,7 @@ func (r *columnTypedColumnPhysicalQueryRunner) runLatestVisibleDenseInt64Span(vi
 			if !seen {
 				continue
 			}
-			key, ok := dense.DictionaryByCode[int64(localCode)]
+			key, ok := columnTypedColumnDenseInt64SpanDictionaryValue(dense, localCode)
 			if !ok {
 				diag := r.latestVisibleDiagnostics(view, req, state, visibilityBytes, visibilityNanos, rowsScanned, matchedRows, reduceRows, time.Since(start).Nanoseconds())
 				diag.DenseInt64SpanUsed = true
@@ -3768,7 +3798,7 @@ func (r *columnTypedColumnPhysicalQueryRunner) runDenseGroupHourCount(view colum
 				}
 				if !seen {
 					var ok bool
-					key, ok = dense.DictionaryByCode[int64(localCode)]
+					key, ok = columnTypedColumnDenseGroupHourDictionaryValue(dense, localCode)
 					if !ok {
 						diag := r.diagnostics(view, req, rowsScanned, matchedRows, reduceRows, time.Since(start).Nanoseconds())
 						diag.DenseGroupHourCountUsed = true
@@ -4075,7 +4105,7 @@ func (r *columnTypedColumnPhysicalQueryRunner) runDenseInt64SpanLocalMap(view co
 			if !seen {
 				continue
 			}
-			key, ok := dense.DictionaryByCode[int64(localCode)]
+			key, ok := columnTypedColumnDenseInt64SpanDictionaryValue(dense, localCode)
 			if !ok {
 				diag := r.diagnostics(view, req, rowsScanned, matchedRows, reduceRows, time.Since(start).Nanoseconds())
 				diag.DenseInt64SpanUsed = true

--- a/TreeDB/collections/typed_column_adapter.go
+++ b/TreeDB/collections/typed_column_adapter.go
@@ -148,11 +148,18 @@ type typedColumnAdapterTypeMapping struct {
 }
 
 type typedColumnAdapterColumn struct {
-	Field              TypedStorageField
-	Definition         typedcolumn.ColumnDefinition
-	Dictionary         map[string]int64
-	ReverseDictionary  map[int64]string
-	FixedWidthEncoding ColumnFixedWidthEncoding
+	Field                  TypedStorageField
+	Definition             typedcolumn.ColumnDefinition
+	Dictionary             map[string]int64
+	ReverseDictionary      map[int64]string
+	DictionaryValuesByCode []string
+	FixedWidthEncoding     ColumnFixedWidthEncoding
+}
+
+type typedColumnAdapterDictionaryMode struct {
+	Forward      bool
+	Reverse      bool
+	ValuesByCode bool
 }
 
 type typedColumnAdapterOptions struct {
@@ -170,6 +177,7 @@ type typedColumnAdapterOptions struct {
 	LocatorSectionCompressionSet    bool
 	DictionarySectionCompression    typedcolumn.Compression
 	DictionarySectionCompressionSet bool
+	DictionaryModes                 map[string]typedColumnAdapterDictionaryMode
 	PruningSectionCompression       typedcolumn.Compression
 	PruningSectionCompressionSet    bool
 	Int64Encoding                   typedcolumn.Encoding
@@ -653,6 +661,10 @@ func buildTypedColumnAdapterPartFromSource(opts typedColumnAdapterOptions, rowSo
 			}
 			columns[i].Dictionary = dict
 			columns[i].ReverseDictionary = reverseTypedColumnAdapterDictionary(dict)
+			columns[i].DictionaryValuesByCode, err = typedColumnAdapterDictionaryValuesByCodeFromForward(dict, len(dict))
+			if err != nil {
+				return nil, err
+			}
 			columns[i].Definition.Cardinality = uint32(len(dict))
 		}
 	}
@@ -1036,8 +1048,20 @@ func typedColumnAdapterPartFromDecodedImage(opts typedColumnAdapterOptions, imag
 				return nil, err
 			}
 			columns[i].Definition.Cardinality = partColumn.Definition.Cardinality
-			columns[i].Dictionary = dict
-			columns[i].ReverseDictionary = reverseTypedColumnAdapterDictionary(dict)
+			mode := typedColumnAdapterDictionaryModeForColumn(opts, columns[i].Definition.Name)
+			if mode.Forward {
+				columns[i].Dictionary = dict
+			}
+			if mode.Reverse {
+				columns[i].ReverseDictionary = reverseTypedColumnAdapterDictionary(dict)
+			}
+			if mode.ValuesByCode {
+				valuesByCode, err := typedColumnAdapterDictionaryValuesByCodeFromForward(dict, int(partColumn.Definition.Cardinality))
+				if err != nil {
+					return nil, err
+				}
+				columns[i].DictionaryValuesByCode = valuesByCode
+			}
 		}
 	}
 	return &typedColumnAdapterPart{Options: opts, Columns: columns, Part: part, Dictionary: dictionaries}, nil
@@ -1369,6 +1393,29 @@ func typedColumnSortedGroupedDistinctDictionaryValuesByCode(column typedColumnAd
 	return valuesByCode, nil
 }
 
+func columnTypedColumnPhysicalQueryAdapterDictionaryModes(plan columnTypedColumnPhysicalQueryPlan, valuesByCodeColumns []string, predicateSpecs []columnPhysicalQueryPredicateSpec) map[string]typedColumnAdapterDictionaryMode {
+	modes := make(map[string]typedColumnAdapterDictionaryMode, len(valuesByCodeColumns)+len(predicateSpecs))
+	add := func(column string, mode typedColumnAdapterDictionaryMode) {
+		adapterColumn, ok, err := typedColumnStringPredicateAdapterColumn(plan.Fields, column)
+		if err != nil || !ok {
+			return
+		}
+		name := adapterColumn.Definition.Name
+		current := modes[name]
+		current.Forward = current.Forward || mode.Forward
+		current.Reverse = current.Reverse || mode.Reverse
+		current.ValuesByCode = current.ValuesByCode || mode.ValuesByCode
+		modes[name] = current
+	}
+	for _, column := range valuesByCodeColumns {
+		add(column, typedColumnAdapterDictionaryMode{ValuesByCode: true})
+	}
+	for _, spec := range predicateSpecs {
+		add(spec.column, typedColumnAdapterDictionaryMode{Forward: true})
+	}
+	return modes
+}
+
 // decodeTypedColumnPhysicalQueryDenseGroupCountPart prepares the q1 typed-column
 // section fast path from the adapter seam so production query routing does not
 // import the typedcolumn data plane directly.
@@ -1377,7 +1424,11 @@ func decodeTypedColumnPhysicalQueryDenseGroupCountPart(plan columnTypedColumnPhy
 	if err != nil {
 		return columnTypedColumnPhysicalQueryPart{}, err
 	}
-	adapterPart, err := typedColumnAdapterPartFromImageWithoutRowLocators(typedColumnAdapterOptions{Fields: plan.Fields, SchemaVersion: uint32(schemaHash)}, image)
+	adapterPart, err := typedColumnAdapterPartFromImageWithoutRowLocators(typedColumnAdapterOptions{
+		Fields:          plan.Fields,
+		SchemaVersion:   uint32(schemaHash),
+		DictionaryModes: columnTypedColumnPhysicalQueryAdapterDictionaryModes(plan, []string{plan.GroupColumn}, nil),
+	}, image)
 	if err != nil {
 		return columnTypedColumnPhysicalQueryPart{}, err
 	}
@@ -1427,7 +1478,7 @@ func decodeTypedColumnPhysicalQueryDenseGroupHourCountPart(plan columnTypedColum
 	}
 	predicates := part.DenseInt64Span.Predicates
 	if hasGroupPredicate {
-		predicate, err := densePredicateFromDictionaryCodes(part.DenseInt64Span.GroupCodes, part.DenseInt64Span.GroupValid, part.DenseInt64Span.DictionaryByCode, part.DenseInt64Span.Cardinality, groupPredicate)
+		predicate, err := densePredicateFromDictionaryCodes(part.DenseInt64Span.GroupCodes, part.DenseInt64Span.GroupValid, part.DenseInt64Span.Dictionary, part.DenseInt64Span.DictionaryByCode, part.DenseInt64Span.Cardinality, groupPredicate)
 		if err != nil {
 			return columnTypedColumnPhysicalQueryPart{}, err
 		}
@@ -1435,6 +1486,7 @@ func decodeTypedColumnPhysicalQueryDenseGroupHourCountPart(plan columnTypedColum
 	}
 	part.DenseGroupHourCount = &columnTypedColumnDenseGroupHourCountPart{
 		Cardinality:      part.DenseInt64Span.Cardinality,
+		Dictionary:       part.DenseInt64Span.Dictionary,
 		DictionaryByCode: part.DenseInt64Span.DictionaryByCode,
 		GroupCodes:       part.DenseInt64Span.GroupCodes,
 		GroupValid:       part.DenseInt64Span.GroupValid,
@@ -1646,7 +1698,7 @@ func columnTypedColumnPhysicalQueryDensePreparedRequests(plan columnTypedColumnP
 		return nil, false, nil
 	}
 	requests := make([]typedColumnPreparedColumnRequest, 0, 4+len(plan.PredicateSpecs))
-	addString := func(column string, role typedcolumn.ColumnExecutionRole, op columnsemantics.Operation) error {
+	addString := func(column string, role typedcolumn.ColumnExecutionRole, op columnsemantics.Operation, valuesByCode bool) error {
 		adapterColumn, ok, err := typedColumnStringPredicateAdapterColumn(plan.Fields, column)
 		if err != nil {
 			return err
@@ -1658,10 +1710,11 @@ func columnTypedColumnPhysicalQueryDensePreparedRequests(plan columnTypedColumnP
 			op = columnsemantics.OpCountRows
 		}
 		requests = append(requests, typedColumnPreparedColumnRequest{
-			Field:               adapterColumn.Field,
-			Role:                role,
-			Operation:           op,
-			IncludeDictionaries: true,
+			Field:                  adapterColumn.Field,
+			Role:                   role,
+			Operation:              op,
+			IncludeDictionaries:    true,
+			DictionaryValuesByCode: valuesByCode,
 		})
 		return nil
 	}
@@ -1682,7 +1735,7 @@ func columnTypedColumnPhysicalQueryDensePreparedRequests(plan columnTypedColumnP
 	}
 	addPredicates := func(specs []columnPhysicalQueryPredicateSpec) error {
 		for _, spec := range specs {
-			if err := addString(spec.column, typedcolumn.ColumnRolePredicate, columnTypedColumnPhysicalPredicatePreparedOperation(spec)); err != nil {
+			if err := addString(spec.column, typedcolumn.ColumnRolePredicate, columnTypedColumnPhysicalPredicatePreparedOperation(spec), false); err != nil {
 				return err
 			}
 		}
@@ -1690,17 +1743,17 @@ func columnTypedColumnPhysicalQueryDensePreparedRequests(plan columnTypedColumnP
 	}
 	switch {
 	case columnTypedColumnPhysicalQueryUseDenseGroupCount(plan, req):
-		if err := addString(plan.GroupColumn, typedcolumn.ColumnRoleProjection, columnsemantics.OpDictionaryCount); err != nil {
+		if err := addString(plan.GroupColumn, typedcolumn.ColumnRoleProjection, columnsemantics.OpDictionaryCount, true); err != nil {
 			return nil, true, err
 		}
 	case columnTypedColumnPhysicalQueryUseDenseGroupCountDistinct(plan, req):
 		if !allowDenseGroupCountDistinct {
 			return nil, false, nil
 		}
-		if err := addString(plan.GroupColumn, typedcolumn.ColumnRoleProjection, columnsemantics.OpDictionaryGroupBy); err != nil {
+		if err := addString(plan.GroupColumn, typedcolumn.ColumnRoleProjection, columnsemantics.OpDictionaryGroupBy, true); err != nil {
 			return nil, true, err
 		}
-		if err := addString(plan.DistinctColumn, typedcolumn.ColumnRoleMeasure, columnsemantics.OpDictionaryGroupBy); err != nil {
+		if err := addString(plan.DistinctColumn, typedcolumn.ColumnRoleMeasure, columnsemantics.OpDictionaryGroupBy, true); err != nil {
 			return nil, true, err
 		}
 		if err := addPredicates(plan.PredicateSpecs); err != nil {
@@ -1708,7 +1761,7 @@ func columnTypedColumnPhysicalQueryDensePreparedRequests(plan columnTypedColumnP
 		}
 	case columnTypedColumnPhysicalQueryUseDenseGroupHourCount(plan, req):
 		spanPlan, _, _ := columnTypedColumnPhysicalQueryDenseGroupHourSpanPlan(plan)
-		if err := addString(plan.GroupColumn, typedcolumn.ColumnRoleProjection, columnsemantics.OpDictionaryGroupBy); err != nil {
+		if err := addString(plan.GroupColumn, typedcolumn.ColumnRoleProjection, columnsemantics.OpDictionaryGroupBy, false); err != nil {
 			return nil, true, err
 		}
 		if err := addInt64(plan.ValueColumn); err != nil {
@@ -1718,7 +1771,7 @@ func columnTypedColumnPhysicalQueryDensePreparedRequests(plan columnTypedColumnP
 			return nil, true, err
 		}
 	case columnTypedColumnPhysicalQueryUseDenseInt64Span(plan, req):
-		if err := addString(plan.GroupColumn, typedcolumn.ColumnRoleProjection, columnsemantics.OpDictionaryGroupBy); err != nil {
+		if err := addString(plan.GroupColumn, typedcolumn.ColumnRoleProjection, columnsemantics.OpDictionaryGroupBy, true); err != nil {
 			return nil, true, err
 		}
 		if err := addInt64(plan.ValueColumn); err != nil {
@@ -1728,7 +1781,7 @@ func columnTypedColumnPhysicalQueryDensePreparedRequests(plan columnTypedColumnP
 			return nil, true, err
 		}
 	case columnTypedColumnPhysicalQueryUseTimeOrderTopK(plan, req):
-		if err := addString(plan.GroupColumn, typedcolumn.ColumnRoleProjection, columnsemantics.OpDictionaryGroupBy); err != nil {
+		if err := addString(plan.GroupColumn, typedcolumn.ColumnRoleProjection, columnsemantics.OpDictionaryGroupBy, false); err != nil {
 			return nil, true, err
 		}
 		if err := addInt64(plan.ValueColumn); err != nil {
@@ -1809,6 +1862,15 @@ func typedColumnPhysicalQueryPreparedAdapterPartWithOptions(prepared *typedColum
 		}
 		if preparedColumn.ReverseDictionaries != nil {
 			adapterColumn.ReverseDictionary = preparedColumn.ReverseDictionaries
+		}
+		if preparedColumn.DictionaryValuesByCode != nil {
+			adapterColumn.DictionaryValuesByCode = preparedColumn.DictionaryValuesByCode
+		} else if preparedColumn.Dictionaries != nil {
+			valuesByCode, err := typedColumnAdapterDictionaryValuesByCodeFromForward(preparedColumn.Dictionaries, int(adapterColumn.Definition.Cardinality))
+			if err != nil {
+				return nil, err
+			}
+			adapterColumn.DictionaryValuesByCode = valuesByCode
 		}
 		partColumn, err := typedColumnPreparedColumnWithOptionalPayloads(preparedColumn, readRange, !opts.LazyPayloads)
 		if err != nil {
@@ -1973,7 +2035,7 @@ func decodeTypedColumnPhysicalQueryDenseGroupHourCountPreparedPart(plan columnTy
 	}
 	predicates := part.DenseInt64Span.Predicates
 	if hasGroupPredicate {
-		predicate, err := densePredicateFromDictionaryCodes(part.DenseInt64Span.GroupCodes, part.DenseInt64Span.GroupValid, part.DenseInt64Span.DictionaryByCode, part.DenseInt64Span.Cardinality, groupPredicate)
+		predicate, err := densePredicateFromDictionaryCodes(part.DenseInt64Span.GroupCodes, part.DenseInt64Span.GroupValid, part.DenseInt64Span.Dictionary, part.DenseInt64Span.DictionaryByCode, part.DenseInt64Span.Cardinality, groupPredicate)
 		if err != nil {
 			return columnTypedColumnPhysicalQueryPart{}, err
 		}
@@ -1981,6 +2043,7 @@ func decodeTypedColumnPhysicalQueryDenseGroupHourCountPreparedPart(plan columnTy
 	}
 	part.DenseGroupHourCount = &columnTypedColumnDenseGroupHourCountPart{
 		Cardinality:      part.DenseInt64Span.Cardinality,
+		Dictionary:       part.DenseInt64Span.Dictionary,
 		DictionaryByCode: part.DenseInt64Span.DictionaryByCode,
 		GroupCodes:       part.DenseInt64Span.GroupCodes,
 		GroupValid:       part.DenseInt64Span.GroupValid,
@@ -2077,6 +2140,7 @@ func decodeTypedColumnPhysicalQueryDenseInt64SpanPreparedPart(plan columnTypedCo
 
 	denseSpan := &columnTypedColumnDenseInt64SpanPart{
 		Cardinality:      cardinality,
+		Dictionary:       groupColumn.DictionaryValuesByCode,
 		DictionaryByCode: groupColumn.ReverseDictionary,
 		GroupCodes:       groupCodes,
 		GroupValid:       groupValid,
@@ -2129,12 +2193,12 @@ func preapplyColumnTypedColumnDenseInt64SpanPredicates(dense *columnTypedColumnD
 	dense.PredicateRows = selected
 }
 
-func densePredicateFromDictionaryCodes(codes []uint32, valid []bool, dictionaryByCode map[int64]string, cardinality int, spec columnPhysicalQueryPredicateSpec) (columnTypedColumnDensePredicatePart, error) {
+func densePredicateFromDictionaryCodes(codes []uint32, valid []bool, dictionary []string, dictionaryByCode map[int64]string, cardinality int, spec columnPhysicalQueryPredicateSpec) (columnTypedColumnDensePredicatePart, error) {
 	allowed := make([]uint64, (cardinality+63)/64)
 	matchedLiterals := 0
 	missingMatchesEmpty := false
 	for code := 0; code < cardinality; code++ {
-		value, ok := dictionaryByCode[int64(code)]
+		value, ok := denseDictionaryValue(dictionary, dictionaryByCode, code)
 		if !ok {
 			return columnTypedColumnDensePredicatePart{}, fmt.Errorf("collections: dense typed-column predicate dictionary missing local code %d for column %q", code, spec.column)
 		}
@@ -2157,6 +2221,17 @@ func densePredicateFromDictionaryCodes(codes []uint32, valid []bool, dictionaryB
 		return columnTypedColumnDensePredicatePart{RejectsAll: true}, nil
 	}
 	return columnTypedColumnDensePredicatePart{Codes: codes, Valid: valid, Allowed: allowed, MissingMatchesEmpty: missingMatchesEmpty}, nil
+}
+
+func denseDictionaryValue(dictionary []string, dictionaryByCode map[int64]string, code int) (string, bool) {
+	if code >= 0 && code < len(dictionary) {
+		return dictionary[code], true
+	}
+	if dictionaryByCode != nil {
+		value, ok := dictionaryByCode[int64(code)]
+		return value, ok
+	}
+	return "", false
 }
 
 type columnTypedColumnTimeOrderCodeColumn struct {
@@ -2927,7 +3002,11 @@ func decodeTypedColumnPhysicalQueryDenseInt64SpanPart(plan columnTypedColumnPhys
 	if err != nil {
 		return columnTypedColumnPhysicalQueryPart{}, err
 	}
-	adapterPart, err := typedColumnAdapterPartFromImageWithoutRowLocators(typedColumnAdapterOptions{Fields: plan.Fields, SchemaVersion: uint32(schemaHash)}, image)
+	adapterPart, err := typedColumnAdapterPartFromImageWithoutRowLocators(typedColumnAdapterOptions{
+		Fields:          plan.Fields,
+		SchemaVersion:   uint32(schemaHash),
+		DictionaryModes: columnTypedColumnPhysicalQueryAdapterDictionaryModes(plan, []string{plan.GroupColumn}, plan.PredicateSpecs),
+	}, image)
 	if err != nil {
 		return columnTypedColumnPhysicalQueryPart{}, err
 	}
@@ -3008,6 +3087,7 @@ func decodeTypedColumnPhysicalQueryDenseInt64SpanPart(plan columnTypedColumnPhys
 
 	denseSpan := &columnTypedColumnDenseInt64SpanPart{
 		Cardinality:      cardinality,
+		Dictionary:       groupColumn.DictionaryValuesByCode,
 		DictionaryByCode: groupColumn.ReverseDictionary,
 		GroupCodes:       groupCodes,
 		GroupValid:       groupValid,
@@ -3042,7 +3122,11 @@ func decodeTypedColumnPhysicalQueryDenseGroupCountDistinctPart(plan columnTypedC
 	if err != nil {
 		return columnTypedColumnPhysicalQueryPart{}, err
 	}
-	adapterPart, err := typedColumnAdapterPartFromImageWithoutRowLocators(typedColumnAdapterOptions{Fields: plan.Fields, SchemaVersion: uint32(schemaHash)}, image)
+	adapterPart, err := typedColumnAdapterPartFromImageWithoutRowLocators(typedColumnAdapterOptions{
+		Fields:          plan.Fields,
+		SchemaVersion:   uint32(schemaHash),
+		DictionaryModes: columnTypedColumnPhysicalQueryAdapterDictionaryModes(plan, []string{plan.GroupColumn, plan.DistinctColumn}, plan.PredicateSpecs),
+	}, image)
 	if err != nil {
 		return columnTypedColumnPhysicalQueryPart{}, err
 	}
@@ -3108,13 +3192,9 @@ func typedColumnDenseGroupCountDistinctCodeColumn(adapterPart *typedColumnAdapte
 	if err != nil {
 		return columnTypedColumnDenseStringCodeColumn{}, 0, 0, err
 	}
-	dictionary := make([]string, cardinality)
-	for code := 0; code < cardinality; code++ {
-		value, ok := adapterColumn.ReverseDictionary[int64(code)]
-		if !ok {
-			return columnTypedColumnDenseStringCodeColumn{}, 0, 0, fmt.Errorf("collections: dense typed-column %s dictionary missing local code %d for column %q", role, code, adapterColumn.Definition.Name)
-		}
-		dictionary[code] = value
+	dictionary, err := typedColumnDenseStringValuesByCode(adapterColumn, cardinality, role)
+	if err != nil {
+		return columnTypedColumnDenseStringCodeColumn{}, 0, 0, err
 	}
 	if adapterColumn.Field.Nullable {
 		codes, valid, decodedBytes, blocks, err := decodeTypedColumnDenseNullableUint32Codes(partColumn, cardinality, rows, role)
@@ -3168,11 +3248,29 @@ func typedColumnDenseStringCodeColumn(adapterPart *typedColumnAdapterPart, field
 		}
 	}
 	if typedColumnDenseStringCodeColumnNeedsReverseDictionary(role) {
-		if len(adapterColumn.ReverseDictionary) != cardinality {
-			return typedColumnAdapterColumn{}, typedcolumn.ColumnPartColumn{}, 0, fmt.Errorf("collections: dense typed-column %s dictionary cardinality=%d want %d for column %q", role, len(adapterColumn.ReverseDictionary), cardinality, adapterColumn.Definition.Name)
+		if len(adapterColumn.DictionaryValuesByCode) != cardinality && len(adapterColumn.ReverseDictionary) != cardinality {
+			return typedColumnAdapterColumn{}, typedcolumn.ColumnPartColumn{}, 0, fmt.Errorf("collections: dense typed-column %s dictionary cardinality values_by_code=%d reverse=%d want %d for column %q", role, len(adapterColumn.DictionaryValuesByCode), len(adapterColumn.ReverseDictionary), cardinality, adapterColumn.Definition.Name)
 		}
 	}
 	return adapterColumn, partColumn, cardinality, nil
+}
+
+func typedColumnDenseStringValuesByCode(adapterColumn typedColumnAdapterColumn, cardinality int, role string) ([]string, error) {
+	if len(adapterColumn.DictionaryValuesByCode) == cardinality {
+		return adapterColumn.DictionaryValuesByCode, nil
+	}
+	if len(adapterColumn.ReverseDictionary) != cardinality {
+		return nil, fmt.Errorf("collections: dense typed-column %s dictionary cardinality values_by_code=%d reverse=%d want %d for column %q", role, len(adapterColumn.DictionaryValuesByCode), len(adapterColumn.ReverseDictionary), cardinality, adapterColumn.Definition.Name)
+	}
+	dictionary := make([]string, cardinality)
+	for code := 0; code < cardinality; code++ {
+		value, ok := adapterColumn.ReverseDictionary[int64(code)]
+		if !ok {
+			return nil, fmt.Errorf("collections: dense typed-column %s dictionary missing local code %d for column %q", role, code, adapterColumn.Definition.Name)
+		}
+		dictionary[code] = value
+	}
+	return dictionary, nil
 }
 
 func typedColumnDenseStringCodeColumnNeedsForwardDictionary(role string) bool {
@@ -4705,6 +4803,52 @@ func reverseTypedColumnAdapterDictionary(dict map[string]int64) map[int64]string
 		reverse[code] = value
 	}
 	return reverse
+}
+
+func typedColumnAdapterDictionaryModeForColumn(opts typedColumnAdapterOptions, column string) typedColumnAdapterDictionaryMode {
+	if opts.DictionaryModes != nil {
+		return opts.DictionaryModes[column]
+	}
+	return typedColumnAdapterDictionaryMode{Forward: true, Reverse: true, ValuesByCode: true}
+}
+
+func typedColumnAdapterDictionaryValuesByCodeFromForward(dict map[string]int64, cardinality int) ([]string, error) {
+	if cardinality == 0 && len(dict) == 0 {
+		return nil, nil
+	}
+	if cardinality <= 0 {
+		return nil, fmt.Errorf("collections: typed-column adapter dictionary cardinality=%d is invalid", cardinality)
+	}
+	valuesByCode := make([]string, cardinality)
+	seen := make([]bool, cardinality)
+	for value, code := range dict {
+		if code < 0 || int64(cardinality) <= code {
+			return nil, fmt.Errorf("collections: typed-column adapter dictionary code %d outside cardinality %d", code, cardinality)
+		}
+		codeIdx := int(code)
+		if seen[codeIdx] {
+			return nil, fmt.Errorf("collections: typed-column adapter dictionary duplicate code %d", code)
+		}
+		seen[codeIdx] = true
+		valuesByCode[codeIdx] = value
+	}
+	for code, ok := range seen {
+		if !ok {
+			return nil, fmt.Errorf("collections: typed-column adapter dictionary missing code %d", code)
+		}
+	}
+	return valuesByCode, nil
+}
+
+func typedColumnAdapterDictionaryValueByCode(column typedColumnAdapterColumn, code int) (string, bool) {
+	if code >= 0 && code < len(column.DictionaryValuesByCode) {
+		return column.DictionaryValuesByCode[code], true
+	}
+	if column.ReverseDictionary != nil {
+		value, ok := column.ReverseDictionary[int64(code)]
+		return value, ok
+	}
+	return "", false
 }
 
 func validateTypedColumnAdapterStringDictionary(column typedColumnAdapterColumn, cardinality uint32, dict map[string]int64) error {

--- a/TreeDB/collections/typed_column_adapter.go
+++ b/TreeDB/collections/typed_column_adapter.go
@@ -1508,6 +1508,10 @@ func decodeTypedColumnPhysicalQueryDensePartFromRanges(plan columnTypedColumnPhy
 	if err != nil || !ok {
 		return columnTypedColumnPhysicalQueryPart{}, ok, err
 	}
+	adapterDictionaryModes, err := typedColumnPreparedAdapterDictionaryModesFromRequests(requests)
+	if err != nil {
+		return columnTypedColumnPhysicalQueryPart{}, true, err
+	}
 	reader := &columnTypedColumnPhysicalRangePartReader{
 		readCache:          readCache,
 		ref:                typedRef.Ref,
@@ -1561,7 +1565,10 @@ func decodeTypedColumnPhysicalQueryDensePartFromRanges(plan columnTypedColumnPhy
 		if prepareDiagnostics != nil {
 			adapterStart = time.Now()
 		}
-		adapterPart, err := typedColumnPhysicalQueryPreparedAdapterPartWithOptions(prepared, plan.Fields, reader.readRange, typedColumnPreparedAdapterPartOptions{LazyPayloads: !opts.eagerTimeOrderTopKPayloads})
+		adapterPart, err := typedColumnPhysicalQueryPreparedAdapterPartWithOptions(prepared, plan.Fields, reader.readRange, typedColumnPreparedAdapterPartOptions{
+			LazyPayloads:    !opts.eagerTimeOrderTopKPayloads,
+			DictionaryModes: adapterDictionaryModes,
+		})
 		if prepareDiagnostics != nil {
 			prepareDiagnostics.AdapterNanos += time.Since(adapterStart).Nanoseconds()
 		}
@@ -1587,7 +1594,7 @@ func decodeTypedColumnPhysicalQueryDensePartFromRanges(plan columnTypedColumnPhy
 	if prepareDiagnostics != nil {
 		adapterStart = time.Now()
 	}
-	adapterPart, err := typedColumnPhysicalQueryPreparedAdapterPart(prepared, plan.Fields, reader.readRange)
+	adapterPart, err := typedColumnPhysicalQueryPreparedAdapterPartWithOptions(prepared, plan.Fields, reader.readRange, typedColumnPreparedAdapterPartOptions{DictionaryModes: adapterDictionaryModes})
 	if prepareDiagnostics != nil {
 		prepareDiagnostics.AdapterNanos += time.Since(adapterStart).Nanoseconds()
 	}
@@ -1826,7 +1833,30 @@ func columnTypedColumnPhysicalQueryDenseGroupHourSpanPlan(plan columnTypedColumn
 }
 
 type typedColumnPreparedAdapterPartOptions struct {
-	LazyPayloads bool
+	LazyPayloads    bool
+	DictionaryModes map[string]typedColumnAdapterDictionaryMode
+}
+
+func typedColumnPreparedAdapterDictionaryModesFromRequests(requests []typedColumnPreparedColumnRequest) (map[string]typedColumnAdapterDictionaryMode, error) {
+	requestModes, err := typedColumnPreparedDictionaryRequestModes(requests)
+	if err != nil {
+		return nil, err
+	}
+	if len(requestModes) == 0 {
+		return nil, nil
+	}
+	modes := make(map[string]typedColumnAdapterDictionaryMode, len(requestModes))
+	for name, mode := range requestModes {
+		if name == typedColumnAdapterMetadataDictionary {
+			continue
+		}
+		modes[name] = typedColumnAdapterDictionaryMode{
+			Forward:      mode.Forward,
+			Reverse:      mode.Reverse,
+			ValuesByCode: mode.ValuesByCode,
+		}
+	}
+	return modes, nil
 }
 
 func typedColumnPhysicalQueryPreparedAdapterPart(prepared *typedColumnPreparedPartState, fields []TypedStorageField, readRange typedColumnPreparedRangeReader) (*typedColumnAdapterPart, error) {
@@ -1863,14 +1893,17 @@ func typedColumnPhysicalQueryPreparedAdapterPartWithOptions(prepared *typedColum
 		if preparedColumn.ReverseDictionaries != nil {
 			adapterColumn.ReverseDictionary = preparedColumn.ReverseDictionaries
 		}
-		if preparedColumn.DictionaryValuesByCode != nil {
-			adapterColumn.DictionaryValuesByCode = preparedColumn.DictionaryValuesByCode
-		} else if preparedColumn.Dictionaries != nil {
-			valuesByCode, err := typedColumnAdapterDictionaryValuesByCodeFromForward(preparedColumn.Dictionaries, int(adapterColumn.Definition.Cardinality))
-			if err != nil {
-				return nil, err
+		mode := typedColumnPreparedAdapterDictionaryModeForColumn(opts, adapterColumn.Definition.Name)
+		if mode.ValuesByCode {
+			if preparedColumn.DictionaryValuesByCode != nil {
+				adapterColumn.DictionaryValuesByCode = preparedColumn.DictionaryValuesByCode
+			} else if preparedColumn.Dictionaries != nil {
+				valuesByCode, err := typedColumnAdapterDictionaryValuesByCodeFromForward(preparedColumn.Dictionaries, int(adapterColumn.Definition.Cardinality))
+				if err != nil {
+					return nil, err
+				}
+				adapterColumn.DictionaryValuesByCode = valuesByCode
 			}
-			adapterColumn.DictionaryValuesByCode = valuesByCode
 		}
 		partColumn, err := typedColumnPreparedColumnWithOptionalPayloads(preparedColumn, readRange, !opts.LazyPayloads)
 		if err != nil {
@@ -4806,6 +4839,13 @@ func reverseTypedColumnAdapterDictionary(dict map[string]int64) map[int64]string
 }
 
 func typedColumnAdapterDictionaryModeForColumn(opts typedColumnAdapterOptions, column string) typedColumnAdapterDictionaryMode {
+	if opts.DictionaryModes != nil {
+		return opts.DictionaryModes[column]
+	}
+	return typedColumnAdapterDictionaryMode{Forward: true, Reverse: true, ValuesByCode: true}
+}
+
+func typedColumnPreparedAdapterDictionaryModeForColumn(opts typedColumnPreparedAdapterPartOptions, column string) typedColumnAdapterDictionaryMode {
 	if opts.DictionaryModes != nil {
 		return opts.DictionaryModes[column]
 	}

--- a/TreeDB/collections/typed_column_prepared_state.go
+++ b/TreeDB/collections/typed_column_prepared_state.go
@@ -32,6 +32,7 @@ type typedColumnPreparedColumnRequest struct {
 	Role                     typedcolumn.ColumnExecutionRole
 	Operation                columnsemantics.Operation
 	IncludeDictionaries      bool
+	DictionaryValuesByCode   bool
 	IncludeVisibility        bool
 	IncludeStats             bool
 	IncludePruning           bool
@@ -105,20 +106,21 @@ type typedColumnPreparedBlockPlan struct {
 }
 
 type typedColumnPreparedColumnState struct {
-	Plan                  typedColumnPreparedColumnPlan
-	Column                typedcolumn.ColumnPartColumn
-	Section               typedcolumn.ColumnPartImageSection
-	BlockPlans            []typedColumnPreparedBlockPlan
-	Certification         typedcolumn.ColumnPartLayoutContractColumn
-	AggregateReducer      typedkernel.PreparedReducer
-	AggregateReducerReady bool
-	Int64Stats            typedcolumn.Int64ColumnStats
-	Int64StatsReady       bool
-	StatsFallbackReason   string
-	PruningFallbackReason string
-	Int64PruningReady     bool
-	Dictionaries          map[string]int64
-	ReverseDictionaries   map[int64]string
+	Plan                   typedColumnPreparedColumnPlan
+	Column                 typedcolumn.ColumnPartColumn
+	Section                typedcolumn.ColumnPartImageSection
+	BlockPlans             []typedColumnPreparedBlockPlan
+	Certification          typedcolumn.ColumnPartLayoutContractColumn
+	AggregateReducer       typedkernel.PreparedReducer
+	AggregateReducerReady  bool
+	Int64Stats             typedcolumn.Int64ColumnStats
+	Int64StatsReady        bool
+	StatsFallbackReason    string
+	PruningFallbackReason  string
+	Int64PruningReady      bool
+	Dictionaries           map[string]int64
+	ReverseDictionaries    map[int64]string
+	DictionaryValuesByCode []string
 }
 
 type typedColumnPreparedPartState struct {
@@ -201,6 +203,7 @@ func (c *typedColumnPreparedColumnState) close() {
 	c.Int64PruningReady = false
 	c.Dictionaries = nil
 	c.ReverseDictionaries = nil
+	c.DictionaryValuesByCode = nil
 }
 
 func typedColumnPreparedStatePart(state *typedColumnPreparedScanState, ref ColumnAssetRef) (*typedColumnPreparedPartState, bool) {
@@ -1097,13 +1100,24 @@ func typedColumnAttachPreparedDictionaries(part *typedColumnPreparedPartState, i
 			}
 			column.ReverseDictionaries = reverse
 		}
+		if mode.ValuesByCode {
+			valuesByCode, ok := decoded.ValuesByCode[adapterColumn.Definition.Name]
+			if !ok {
+				return diag, fmt.Errorf("collections: typed-column prepared dictionaries missing values-by-code dictionary for column %q", adapterColumn.Definition.Name)
+			}
+			if err := validateTypedColumnPreparedValuesByCodeDictionaryForColumn(adapterColumn.Definition.Name, column.Column.Definition.Cardinality, valuesByCode); err != nil {
+				return diag, err
+			}
+			column.DictionaryValuesByCode = valuesByCode
+		}
 	}
 	return diag, nil
 }
 
 type typedColumnPreparedDictionaryRequestMode struct {
-	Forward bool
-	Reverse bool
+	Forward      bool
+	Reverse      bool
+	ValuesByCode bool
 }
 
 func typedColumnPreparedDictionaryRequestNames(requests []typedColumnPreparedColumnRequest) (map[string]struct{}, error) {
@@ -1134,6 +1148,9 @@ func typedColumnPreparedDictionaryRequestModes(requests []typedColumnPreparedCol
 		if typedColumnPreparedDictionaryRequestNeedsForward(request) {
 			mode.Forward = true
 		}
+		if request.DictionaryValuesByCode {
+			mode.ValuesByCode = true
+		}
 		if typedColumnPreparedDictionaryRequestNeedsReverse(request) {
 			mode.Reverse = true
 		}
@@ -1156,6 +1173,9 @@ func typedColumnPreparedDictionaryRequestNeedsForward(request typedColumnPrepare
 }
 
 func typedColumnPreparedDictionaryRequestNeedsReverse(request typedColumnPreparedColumnRequest) bool {
+	if request.DictionaryValuesByCode {
+		return false
+	}
 	switch request.Role {
 	case typedcolumn.ColumnRolePredicate:
 		return false
@@ -1252,8 +1272,9 @@ type typedColumnPreparedDictionaryDecoder struct {
 }
 
 type typedColumnPreparedDecodedDictionaries struct {
-	Forward map[string]map[string]int64
-	Reverse map[string]map[int64]string
+	Forward      map[string]map[string]int64
+	Reverse      map[string]map[int64]string
+	ValuesByCode map[string][]string
 }
 
 func decodeTypedColumnPreparedDictionariesSection(raw []byte) (map[string]map[string]int64, error) {
@@ -1294,8 +1315,9 @@ func decodeTypedColumnPreparedRawDictionariesSection(raw []byte, modes map[strin
 		return typedColumnPreparedDecodedDictionaries{}, fmt.Errorf("collections: typed-column prepared dictionaries count=%d exceeds section bytes=%d", count, len(raw))
 	}
 	out := typedColumnPreparedDecodedDictionaries{
-		Forward: make(map[string]map[string]int64, typedColumnPreparedDictionaryDecodeCapacity(int(count), modes, func(mode typedColumnPreparedDictionaryRequestMode) bool { return mode.Forward })),
-		Reverse: make(map[string]map[int64]string, typedColumnPreparedDictionaryDecodeCapacity(int(count), modes, func(mode typedColumnPreparedDictionaryRequestMode) bool { return mode.Reverse })),
+		Forward:      make(map[string]map[string]int64, typedColumnPreparedDictionaryDecodeCapacity(int(count), modes, func(mode typedColumnPreparedDictionaryRequestMode) bool { return mode.Forward })),
+		Reverse:      make(map[string]map[int64]string, typedColumnPreparedDictionaryDecodeCapacity(int(count), modes, func(mode typedColumnPreparedDictionaryRequestMode) bool { return mode.Reverse })),
+		ValuesByCode: make(map[string][]string, typedColumnPreparedDictionaryDecodeCapacity(int(count), modes, func(mode typedColumnPreparedDictionaryRequestMode) bool { return mode.ValuesByCode })),
 	}
 	seenNames := make(map[string]struct{}, int(count))
 	for i := 0; i < int(count); i++ {
@@ -1334,6 +1356,12 @@ func decodeTypedColumnPreparedRawDictionariesSection(raw []byte, modes map[strin
 		if mode.Reverse || mode.Forward {
 			codes = make(map[int64]string, int(entryCount))
 		}
+		var valuesByCode []string
+		var valuesByCodeSeen []bool
+		if mode.ValuesByCode {
+			valuesByCode = make([]string, int(entryCount))
+			valuesByCodeSeen = make([]bool, int(entryCount))
+		}
 		for j := 0; j < int(entryCount); j++ {
 			code, err := dec.i64()
 			if err != nil {
@@ -1355,12 +1383,26 @@ func decodeTypedColumnPreparedRawDictionariesSection(raw []byte, modes map[strin
 				}
 				codes[code] = value
 			}
+			if valuesByCode != nil {
+				if code < 0 || uint64(code) >= uint64(len(valuesByCode)) {
+					return typedColumnPreparedDecodedDictionaries{}, fmt.Errorf("collections: typed-column prepared dictionary code %d in %s outside cardinality=%d", code, name, len(valuesByCode))
+				}
+				codeIdx := int(code)
+				if valuesByCodeSeen[codeIdx] {
+					return typedColumnPreparedDecodedDictionaries{}, fmt.Errorf("collections: typed-column prepared duplicate dictionary code %d in %s", code, name)
+				}
+				valuesByCodeSeen[codeIdx] = true
+				valuesByCode[codeIdx] = value
+			}
 		}
 		if mode.Forward {
 			out.Forward[name] = values
 		}
 		if mode.Reverse {
 			out.Reverse[name] = codes
+		}
+		if mode.ValuesByCode {
+			out.ValuesByCode[name] = valuesByCode
 		}
 	}
 	if dec.off != len(raw) {
@@ -1400,8 +1442,9 @@ func decodeTypedColumnPreparedDenseDictionariesSection(raw []byte, modes map[str
 		return typedColumnPreparedDecodedDictionaries{}, fmt.Errorf("collections: typed-column prepared dense dictionaries count=%d exceeds section bytes=%d", count, len(raw))
 	}
 	out := typedColumnPreparedDecodedDictionaries{
-		Forward: make(map[string]map[string]int64, typedColumnPreparedDictionaryDecodeCapacity(int(count), modes, func(mode typedColumnPreparedDictionaryRequestMode) bool { return mode.Forward })),
-		Reverse: make(map[string]map[int64]string, typedColumnPreparedDictionaryDecodeCapacity(int(count), modes, func(mode typedColumnPreparedDictionaryRequestMode) bool { return mode.Reverse })),
+		Forward:      make(map[string]map[string]int64, typedColumnPreparedDictionaryDecodeCapacity(int(count), modes, func(mode typedColumnPreparedDictionaryRequestMode) bool { return mode.Forward })),
+		Reverse:      make(map[string]map[int64]string, typedColumnPreparedDictionaryDecodeCapacity(int(count), modes, func(mode typedColumnPreparedDictionaryRequestMode) bool { return mode.Reverse })),
+		ValuesByCode: make(map[string][]string, typedColumnPreparedDictionaryDecodeCapacity(int(count), modes, func(mode typedColumnPreparedDictionaryRequestMode) bool { return mode.ValuesByCode })),
 	}
 	seenNames := make(map[string]struct{}, int(count))
 	for i := 0; i < int(count); i++ {
@@ -1437,6 +1480,10 @@ func decodeTypedColumnPreparedDenseDictionariesSection(raw []byte, modes map[str
 		if mode.Reverse {
 			codes = make(map[int64]string, int(entryCount))
 		}
+		var valuesByCode []string
+		if mode.ValuesByCode {
+			valuesByCode = make([]string, int(entryCount))
+		}
 		for j := 0; j < int(entryCount); j++ {
 			value, err := dec.str()
 			if err != nil {
@@ -1451,12 +1498,18 @@ func decodeTypedColumnPreparedDenseDictionariesSection(raw []byte, modes map[str
 			if mode.Reverse {
 				codes[int64(j)] = value
 			}
+			if valuesByCode != nil {
+				valuesByCode[j] = value
+			}
 		}
 		if mode.Forward {
 			out.Forward[name] = values
 		}
 		if mode.Reverse {
 			out.Reverse[name] = codes
+		}
+		if mode.ValuesByCode {
+			out.ValuesByCode[name] = valuesByCode
 		}
 	}
 	if dec.off != len(raw) {
@@ -1484,7 +1537,7 @@ func typedColumnPreparedDictionaryModeFor(modes map[string]typedColumnPreparedDi
 }
 
 func typedColumnPreparedDictionaryModeRequested(mode typedColumnPreparedDictionaryRequestMode) bool {
-	return mode.Forward || mode.Reverse
+	return mode.Forward || mode.Reverse || mode.ValuesByCode
 }
 
 func typedColumnPreparedDictionaryDecodeCapacity(total int, modes map[string]typedColumnPreparedDictionaryRequestMode, include func(typedColumnPreparedDictionaryRequestMode) bool) int {
@@ -1586,6 +1639,23 @@ func validateTypedColumnPreparedReverseDictionaryForColumn(name string, cardinal
 		}
 		if code > 0 && previous >= value {
 			return fmt.Errorf("collections: typed-column prepared reverse dictionary %s is not strictly ordered at code %d (%q >= %q)", name, code, previous, value)
+		}
+		previous = value
+	}
+	return nil
+}
+
+func validateTypedColumnPreparedValuesByCodeDictionaryForColumn(name string, cardinality uint32, valuesByCode []string) error {
+	if cardinality == 0 {
+		return fmt.Errorf("collections: typed-column prepared dictionary %s has zero cardinality", name)
+	}
+	if uint64(len(valuesByCode)) != uint64(cardinality) {
+		return fmt.Errorf("collections: typed-column prepared values-by-code dictionary %s cardinality=%d want %d", name, len(valuesByCode), cardinality)
+	}
+	var previous string
+	for code, value := range valuesByCode {
+		if code > 0 && previous >= value {
+			return fmt.Errorf("collections: typed-column prepared values-by-code dictionary %s is not strictly ordered at code %d (%q >= %q)", name, code, previous, value)
 		}
 		previous = value
 	}

--- a/TreeDB/collections/typed_column_prepared_state.go
+++ b/TreeDB/collections/typed_column_prepared_state.go
@@ -1646,9 +1646,6 @@ func validateTypedColumnPreparedReverseDictionaryForColumn(name string, cardinal
 }
 
 func validateTypedColumnPreparedValuesByCodeDictionaryForColumn(name string, cardinality uint32, valuesByCode []string) error {
-	if cardinality == 0 {
-		return fmt.Errorf("collections: typed-column prepared dictionary %s has zero cardinality", name)
-	}
 	if uint64(len(valuesByCode)) != uint64(cardinality) {
 		return fmt.Errorf("collections: typed-column prepared values-by-code dictionary %s cardinality=%d want %d", name, len(valuesByCode), cardinality)
 	}


### PR DESCRIPTION
Refs #3175.

## Scope

This is a focused q5 production-primary slice for TreeDB JSONBench:

- Improves: q5 `one_shot_end_to_end` / `no_aggregate_metadata` typed-column execution by carrying dense dictionary values as a code-indexed slice for q5 group/render paths.
- Also affects: internal typed-column prepared/full-image dictionary setup where a column role only needs values-by-code or predicate forward lookup.
- Does not improve: insert/load speed, aggregate metadata maintenance/storage cost, automatic metadata acceleration, ClickHouse projections/materialized-summary fairness, first-touch-after-open process-open costs, or broad SQL superiority.

The primary claim is only that this reduces q5 dense typed-column one-shot run-path work. Aggregate metadata remains unused in this lane; bounded TopK remains reported separately from aggregate metadata.

## Implementation Notes

- Adds a values-by-code dictionary request mode for typed-column prepared state.
- Lets physical-query adapter setup request only the dictionary orientations needed by each column role.
- Carries dense dictionary slices into q5 dense int64 span/group-hour parts.
- Uses slice lookup first for dense dictionary value resolution, with map fallback for legacy/prepared shapes.
- Avoids materializing values-by-code slices from forward dictionaries unless the column role explicitly requested values-by-code.
- Allows valid zero-cardinality values-by-code dictionaries while still checking cardinality mismatches.
- Adds a q5 one-shot cache assertion proving dense q5 parts keep the values-by-code slice and avoid retaining `DictionaryByCode` maps.

## Focused Benchmark

Command used on both current `origin/main` (`45b9a8176`) and this branch:

```sh
go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnPhysicalQ5DenseTypedColumn1950/direct_RunColumnPhysicalQuery' -benchmem -count=5
```

Results on Apple M3:

| Revision | ns/op values | Mean | Allocations | Counters |
| --- | --- | ---: | ---: | --- |
| `origin/main` / `45b9a8176` | 111689, 111372, 110246, 111718, 109359 | 110876.8 ns/op | 4448-4450 B/op, 35 allocs/op | 16,384 rows scanned; 5,044 reduce rows; 2,046 TopK candidates; 98,348 decoded bytes/op |
| this branch / `7a7cb3d26` | 85232, 83993, 83947, 82203, 82638 | 83602.6 ns/op | 4449-4450 B/op, 35 allocs/op | same rows/counters/decoded bytes |

Mean delta: `-24.60%` ns/op (`1.326x` faster) for the focused q5 direct run benchmark. This is not a replacement for the standard 1M JSONBench ClickHouse comparison gate.

## Validation

```sh
go test ./TreeDB/collections -run 'TestColumnPhysicalTypedColumnOneShotCacheQ5NoMetadata3088'

go test ./TreeDB/collections -run 'TestColumnPhysicalQ5DenseTypedColumnDirectPreparedParity1950|TestColumnPhysicalTypedColumnOneShotCacheQ1Q3NoMetadata3088|TestColumnPhysicalTypedColumnOneShotCacheQ5NoMetadata3088|TestColumnPhysicalTypedColumnOneShotCacheQ2NoMetadata3123|TestColumnPhysicalTypedColumnParallelPartDecodeShapes3158|TestColumnPhysicalJSONBenchTypedColumnParity1947'

go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnPhysicalQ5DenseTypedColumn1950/direct_RunColumnPhysicalQuery' -benchmem -count=5

go test ./TreeDB/collections

go test -race ./TreeDB/collections -run 'TestColumnPhysicalQ5DenseTypedColumnDirectPreparedParity1950|TestColumnPhysicalTypedColumnOneShotCacheQ5NoMetadata3088' -count=1

git diff --check
```
