### PR TITLE
TreeDB: cap sealed leaf mmap RSS by default

### DIFF
--- a/TreeDB/caching/expvar_stats_test.go
+++ b/TreeDB/caching/expvar_stats_test.go
@@ -18,7 +18,7 @@ func TestSelectTreeDBExpvarStatsFiltersAndCoerces(t *testing.T) {
 	stats := map[string]string{
 		"treedb.process.identity.wal_dir":                                        "/tmp/app.db/wal",
 		"treedb.vlog.mmap_active_bytes":                                          "22222",
-		"treedb.vlog.mmap_max_mapped_leaf_sealed_bytes":                          "8589934592",
+		"treedb.vlog.mmap_max_mapped_leaf_sealed_bytes":                          "2147483648",
 		"treedb.vlog.decode_buffer_grow.read_append_decoded_payload.calls_total": "17",
 		"treedb.vlog.decode_scratch.small_pool.retained_bytes":                   "16384",
 		"treedb.cache.vlog_mmap.active_bytes":                                    "12345",
@@ -66,8 +66,8 @@ func TestSelectTreeDBExpvarStatsFiltersAndCoerces(t *testing.T) {
 	if v, ok := got["treedb.cache.vlog_mmap.active_bytes"].(int64); !ok || v != 12345 {
 		t.Fatalf("active_bytes=%T(%v) want int64(12345)", got["treedb.cache.vlog_mmap.active_bytes"], got["treedb.cache.vlog_mmap.active_bytes"])
 	}
-	if v, ok := got["treedb.vlog.mmap_max_mapped_leaf_sealed_bytes"].(int64); !ok || v != 8589934592 {
-		t.Fatalf("backend leaf mmap byte cap=%T(%v) want int64(8589934592)", got["treedb.vlog.mmap_max_mapped_leaf_sealed_bytes"], got["treedb.vlog.mmap_max_mapped_leaf_sealed_bytes"])
+	if v, ok := got["treedb.vlog.mmap_max_mapped_leaf_sealed_bytes"].(int64); !ok || v != 2147483648 {
+		t.Fatalf("backend leaf mmap byte cap=%T(%v) want int64(2147483648)", got["treedb.vlog.mmap_max_mapped_leaf_sealed_bytes"], got["treedb.vlog.mmap_max_mapped_leaf_sealed_bytes"])
 	}
 	if v, ok := got["treedb.vlog.decode_buffer_grow.read_append_decoded_payload.calls_total"].(int64); !ok || v != 17 {
 		t.Fatalf("backend decoded payload calls=%T(%v) want int64(17)", got["treedb.vlog.decode_buffer_grow.read_append_decoded_payload.calls_total"], got["treedb.vlog.decode_buffer_grow.read_append_decoded_payload.calls_total"])

--- a/TreeDB/caching/memory_stats_test.go
+++ b/TreeDB/caching/memory_stats_test.go
@@ -308,7 +308,7 @@ func TestProcessMemoryStatsIncludeBackendVlogMmap(t *testing.T) {
 			"treedb.vlog.mmap_current_segments":                "2",
 			"treedb.vlog.mmap_sealed_segments":                 "3",
 			"treedb.vlog.mmap_max_mapped_leaf_sealed_segments": "512",
-			"treedb.vlog.mmap_max_mapped_leaf_sealed_bytes":    "8589934592",
+			"treedb.vlog.mmap_max_mapped_leaf_sealed_bytes":    "2147483648",
 		},
 	}
 
@@ -340,8 +340,8 @@ func TestProcessMemoryStatsIncludeBackendVlogMmap(t *testing.T) {
 	if got := mustStatInt64(t, stats, "treedb.vlog.mmap_max_mapped_leaf_sealed_segments"); got != 512 {
 		t.Fatalf("backend leaf sealed segment cap=%d want 512", got)
 	}
-	if got := mustStatInt64(t, stats, "treedb.vlog.mmap_max_mapped_leaf_sealed_bytes"); got != 8589934592 {
-		t.Fatalf("backend leaf sealed byte cap=%d want 8589934592", got)
+	if got := mustStatInt64(t, stats, "treedb.vlog.mmap_max_mapped_leaf_sealed_bytes"); got != 2147483648 {
+		t.Fatalf("backend leaf sealed byte cap=%d want 2147483648", got)
 	}
 	if got := mustStatInt64(t, stats, "treedb.process.memory.vlog_mmap_cache_active_bytes"); got != 0 {
 		t.Fatalf("cache active_bytes=%d want 0", got)

--- a/TreeDB/internal/valuelog/manager_test.go
+++ b/TreeDB/internal/valuelog/manager_test.go
@@ -119,7 +119,7 @@ func TestDefaultLeafMmapPolicyBudget(t *testing.T) {
 	if got, want := MaxMappedLeafSealedSegments, 512; got != want {
 		t.Fatalf("MaxMappedLeafSealedSegments=%d want %d", got, want)
 	}
-	if got, want := MaxMappedLeafSealedBytes, int64(8<<30); got != want {
+	if got, want := MaxMappedLeafSealedBytes, int64(2<<30); got != want {
 		t.Fatalf("MaxMappedLeafSealedBytes=%d want %d", got, want)
 	}
 }

--- a/TreeDB/internal/valuelog/reader_mmap.go
+++ b/TreeDB/internal/valuelog/reader_mmap.go
@@ -77,11 +77,12 @@ const (
 	defaultMaxMappedSealed           = 8
 	defaultMaxMappedSealedBytes      = 64 << 20
 	defaultMaxMappedLeafSealed       = defaultMaxMappedSealed * 64
-	defaultLeafSealedBytesMultiplier = 128
-	// Leaf-log reads are on the BTree traversal hot path. Keep a bounded 8GiB
-	// mapped virtual-address window for sealed leaf generations so large native
-	// fast-path datasets do not fall back to ReadAt once a few generations rotate;
-	// OS page-cache policy still controls physical memory residency.
+	defaultLeafSealedBytesMultiplier = 32
+	// Leaf-log reads are on the BTree traversal hot path, but long sync/restore
+	// workloads can keep multiple GiB of sealed leaf generations mapped into the
+	// process RSS. Keep a bounded 2GiB sealed-leaf window by default and let older
+	// generations fall back to ReadAt; operators can raise the env cap for
+	// throughput-biased experiments.
 	defaultMaxMappedLeafSealedBytes = defaultMaxMappedSealedBytes * defaultLeafSealedBytesMultiplier
 	defaultCurrentWritableMapTarget = 32 << 20
 )

--- a/cmd/internal/treedbstats/selected_test.go
+++ b/cmd/internal/treedbstats/selected_test.go
@@ -11,7 +11,7 @@ func TestSelectedKeepsSharedTreeDBStats(t *testing.T) {
 		"treedb.process.read_path.backend_tree.get_append_pointer_hits_total":                           "5",
 		"treedb.process.read_path.outer_leaf.cache.hits":                                                "11",
 		"treedb.vlog.mmap_read.fallback_readat":                                                         "13",
-		"treedb.vlog.mmap_max_mapped_leaf_sealed_bytes":                                                 "8589934592",
+		"treedb.vlog.mmap_max_mapped_leaf_sealed_bytes":                                                 "2147483648",
 		"treedb.vlog.grouped_frame_cache.retained_bytes":                                                "67108864",
 		"treedb.vlog.grouped_frame_cache.allocated_slots":                                               "512",
 		"treedb.cache.vlog_grouped_frame_cache.retained_bytes":                                          "33554432",

--- a/cmd/unified_bench/main_test.go
+++ b/cmd/unified_bench/main_test.go
@@ -3363,7 +3363,7 @@ func TestRenderTreeDBSelectedStatsString_PrefersBackendMmapReadFamily(t *testing
 			"treedb.vlog.mmap_read.miss_no_mapping":         "10",
 			"treedb.vlog.mmap_read.fallback_readat":         "0",
 			"treedb.vlog.mmap_read.hit_ratio":               "1.000000",
-			"treedb.vlog.mmap_max_mapped_leaf_sealed_bytes": "8589934592",
+			"treedb.vlog.mmap_max_mapped_leaf_sealed_bytes": "2147483648",
 		},
 	}
 
@@ -3372,7 +3372,7 @@ func TestRenderTreeDBSelectedStatsString_PrefersBackendMmapReadFamily(t *testing
 		"vlog_mmap.read.hits: 10626606",
 		"vlog_mmap.read.miss_no_mapping: 10",
 		"vlog_mmap.read.hit_ratio: 1.000000",
-		"vlog_mmap.max_mapped_leaf_sealed_bytes: 8589934592",
+		"vlog_mmap.max_mapped_leaf_sealed_bytes: 2147483648",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("expected %q in selected stats, got:\n%s", want, got)
@@ -3539,7 +3539,7 @@ func TestWriteBenchprofArtifacts_WritesJSONAndMarkdown(t *testing.T) {
 			TreeDBStats: map[string]map[string]string{
 				"TreeDB": {
 					"treedb.cache.vlog_mmap.read.hits":                                                                                        "10",
-					"treedb.cache.vlog_mmap.max_mapped_leaf_sealed_bytes":                                                                     "8589934592",
+					"treedb.cache.vlog_mmap.max_mapped_leaf_sealed_bytes":                                                                     "2147483648",
 					"treedb.vlog.mmap_max_mapped_leaf_sealed_segments":                                                                        "512",
 					"treedb.cache.flush_apply.planning_ns_total":                                                                              "11",
 					"treedb.cache.flush_span_run.source_point_ops_total":                                                                      "11",
@@ -3622,7 +3622,7 @@ func TestWriteBenchprofArtifacts_WritesJSONAndMarkdown(t *testing.T) {
 	if got := parsed.Runs[0].TreeDBStats["TreeDB"]["treedb.publish.ordered_root_delta_group.publish_prepare_ns_total"]; got != "66" {
 		t.Fatalf("unexpected TreeDB selected stat publish_prepare_ns_total=%q", got)
 	}
-	if got := parsed.Runs[0].TreeDBStats["TreeDB"]["treedb.cache.vlog_mmap.max_mapped_leaf_sealed_bytes"]; got != "8589934592" {
+	if got := parsed.Runs[0].TreeDBStats["TreeDB"]["treedb.cache.vlog_mmap.max_mapped_leaf_sealed_bytes"]; got != "2147483648" {
 		t.Fatalf("unexpected cache leaf mmap budget stat=%q", got)
 	}
 	if got := parsed.Runs[0].TreeDBStats["TreeDB"]["treedb.vlog.mmap_max_mapped_leaf_sealed_segments"]; got != "512" {

--- a/docs/TREEDB_TUNING.md
+++ b/docs/TREEDB_TUNING.md
@@ -312,11 +312,18 @@ remapping on every append.
 - `TREEDB_VLOG_CURRENT_WRITABLE_MMAP_TARGET_BYTES` sets the map-ahead target
   for current writable value-log files. The default is 32 MiB, matching the
   default leaf segment scale. Set to `0` to map only the current file size.
+- `TREEDB_VLOG_MAX_MAPPED_LEAF_SEALED_BYTES` caps sealed `leaf_vlog` files kept
+  on the mmap read path. The default is 2 GiB, after which older sealed leaf
+  generations use `ReadAt` fallback to reduce process RSS high-water during
+  long sync/restore workloads. Raise it to restore the older throughput-biased
+  larger mmap window when memory headroom is not the limiting factor.
 - `TREEDB_VLOG_MAX_DEAD_MAPPINGS` still caps retained stale mappings for safety;
   frequent current-writable remaps can hit this cap and force `ReadAt` fallback.
 
 Useful stats:
 - `treedb.vlog.mmap_current_writable_map_target_bytes`
+- `treedb.vlog.mmap_max_mapped_leaf_sealed_bytes`
+- `treedb.vlog.mmap_sealed_bytes`
 - `treedb.vlog.mmap_remaps`
 - `treedb.vlog.mmap_dead_mappings`
 - `treedb.vlog.mmap_read.fallback_readat`


### PR DESCRIPTION
## Summary
- lower the default sealed `leaf_vlog` mmap byte cap from 8 GiB to 2 GiB while keeping the 512 segment cap and existing `TREEDB_VLOG_MAX_MAPPED_LEAF_SEALED_BYTES` override
- keep older sealed leaf generations on the existing `ReadAt` fallback path once the RSS-oriented cap is reached
- update selected-stat fixtures and tuning docs so Celestia diagnostics report the new default cap clearly

## Celestia evidence this targets
Post-#3185 strict-protocol TreeDB evidence showed TreeDB still had the largest production-readiness gap in RSS, not raw-KV payload heap:

- TreeDB sync duration: 285s vs goleveldb 700s, so TreeDB was 2.46x faster in the clean A/B
- TreeDB max RSS/HWM: 11,236,580 / 11,319,164 KiB vs goleveldb 4,874,332 / 4,883,424 KiB, so TreeDB was 2.31x higher RSS
- TreeDB restore peak `treedb.vlog.mmap_active_bytes`: 3,791,506,240 B, including 3,455,961,920 B sealed mappings
- post-#3185 `RawKVBatchPayloadBuilder.appendRawKVPayloadSpace` was down to 16.85 MiB at restore peak and 65.96 MiB at final max-RSS, so this PR does not reopen that bucket

This PR is the first #3187 fix. It is not treated as success until the same Celestia protocol is rerun and followed by a strict goleveldb A/B with the same trust height/hash, stop target, and dwell window.

Part of #3187.

## Tests
- `GOWORK=off go test ./TreeDB/internal/valuelog -run 'TestDefaultLeafMmapPolicyBudget|TestReadUnsafe_SealedLazyMmapByteBudgetFallsBackToReadAt|TestReadUnsafe_LeafLaneUsesLeafSealedMmapByteBudget|TestReadUnsafe_LeafLaneDenyCacheRechecksWhenLeafBudgetChanges|TestReadUnsafe_DefaultSealedLeafBudgetUsesMmapWithCurrentMmapDisabled|TestManagerPromoteCurrentWritable_RetiresDemotedLeafWhenFileGrewPastSealedBytesBudget' -count=1`
- `GOWORK=off go test ./TreeDB/caching -run 'TestProcessMemoryStatsIncludeBackendVlogMmap|TestSelectTreeDBExpvarStatsFiltersAndCoerces' -count=1`
- `GOWORK=off go test ./cmd/internal/treedbstats -run TestSelectedKeepsSharedTreeDBStats -count=1`
- `GOWORK=off go test ./cmd/unified_bench -run 'TestRenderTreeDBSelectedStatsString_PrefersBackendMmapReadFamily|TestWriteBenchprofArtifacts_WritesJSONAndMarkdown' -count=1`
- `GOWORK=off go test ./TreeDB/internal/valuelog ./TreeDB/caching ./cmd/internal/treedbstats ./cmd/unified_bench -count=1`
- `GOWORK=off go test ./TreeDB ./TreeDB/db -count=1`
- `GOWORK=off go test ./TreeDB/cmd/treemap -run 'Test' -count=1`
- `git diff --check`