### PR TITLE
TreeDB: use dense dictionary slices for q3 one-shot

### DIFF
--- a/TreeDB/collections/column_physical_typed_column_one_shot_cache_3088_test.go
+++ b/TreeDB/collections/column_physical_typed_column_one_shot_cache_3088_test.go
@@ -36,6 +36,7 @@ func TestColumnPhysicalTypedColumnOneShotCacheQ1Q3NoMetadata3088(t *testing.T) {
 	}
 	assertColumnPhysicalQ3DenseResult1950(t, "q3 first one-shot", q3First, q3Want, len(events), q3MatchedRows, q3MatchedRows)
 	assertTypedColumnOneShotCacheSnapshot3088(t, col, "after q3 first", 2, 1, 2, 2, 0)
+	assertTypedColumnQ3OneShotDenseDictionaryValuesByCode3175(t, col, q3Req)
 
 	q3Second, err := col.RunColumnPhysicalQuery(q3Req)
 	if err != nil {
@@ -262,6 +263,47 @@ func assertTypedColumnQ5OneShotDenseDictionaryValuesByCode3175(tb testing.TB, co
 		}
 		if len(dense.DictionaryByCode) != 0 {
 			tb.Fatalf("q5 typed-column one-shot part %d reverse dictionary retained=%d want 0", partIdx, len(dense.DictionaryByCode))
+		}
+	}
+}
+
+func assertTypedColumnQ3OneShotDenseDictionaryValuesByCode3175(tb testing.TB, col *Collection, req ColumnPhysicalQueryRequest) {
+	tb.Helper()
+	if col == nil {
+		tb.Fatalf("nil collection")
+	}
+	wantPredicates := collectionTypedColumnOneShotPredicateKey(req)
+	var entry *collectionTypedColumnOneShotCacheEntry
+	col.typedColumnOneShotMu.Lock()
+	for slot, current := range col.typedColumnOneShot {
+		if slot.kind == req.Kind &&
+			slot.groupColumn == req.GroupColumn &&
+			slot.valueColumn == req.ValueColumn &&
+			slot.predicates == wantPredicates {
+			entry = current
+			break
+		}
+	}
+	col.typedColumnOneShotMu.Unlock()
+	if entry == nil {
+		tb.Fatalf("q3 typed-column one-shot cache entry not found")
+	}
+	entry.mu.Lock()
+	defer entry.mu.Unlock()
+	runner := entry.runner
+	if runner == nil {
+		tb.Fatalf("q3 typed-column one-shot cache entry has nil runner")
+	}
+	for partIdx := range runner.parts {
+		dense := runner.parts[partIdx].DenseGroupHourCount
+		if dense == nil {
+			tb.Fatalf("q3 typed-column one-shot part %d missing dense group-hour-count state", partIdx)
+		}
+		if len(dense.Dictionary) != dense.Cardinality {
+			tb.Fatalf("q3 typed-column one-shot part %d dictionary values-by-code=%d want cardinality=%d", partIdx, len(dense.Dictionary), dense.Cardinality)
+		}
+		if len(dense.DictionaryByCode) != 0 {
+			tb.Fatalf("q3 typed-column one-shot part %d reverse dictionary retained=%d want 0", partIdx, len(dense.DictionaryByCode))
 		}
 	}
 }

--- a/TreeDB/collections/typed_column_adapter.go
+++ b/TreeDB/collections/typed_column_adapter.go
@@ -1621,7 +1621,7 @@ func decodeTypedColumnPhysicalQueryDensePartFromRanges(plan columnTypedColumnPhy
 		}
 		return part, true, err
 	case columnTypedColumnPhysicalQueryUseDenseGroupHourCount(plan, req):
-		part, err := decodeTypedColumnPhysicalQueryDenseGroupHourCountPreparedPart(plan, summary, typedRef, physical, adapterPart, reader.bytesRead)
+		part, err := decodeTypedColumnPhysicalQueryDenseGroupHourCountPreparedPart(plan, summary, typedRef, physical, adapterPart, reader.bytesRead, prepareDiagnostics)
 		if prepareDiagnostics != nil {
 			prepareDiagnostics.RangeReadNanos += reader.readNanos
 			prepareDiagnostics.RangeReadBytes += reader.bytesRead
@@ -1768,7 +1768,7 @@ func columnTypedColumnPhysicalQueryDensePreparedRequests(plan columnTypedColumnP
 		}
 	case columnTypedColumnPhysicalQueryUseDenseGroupHourCount(plan, req):
 		spanPlan, _, _ := columnTypedColumnPhysicalQueryDenseGroupHourSpanPlan(plan)
-		if err := addString(plan.GroupColumn, typedcolumn.ColumnRoleProjection, columnsemantics.OpDictionaryGroupBy, false); err != nil {
+		if err := addString(plan.GroupColumn, typedcolumn.ColumnRoleProjection, columnsemantics.OpDictionaryGroupBy, true); err != nil {
 			return nil, true, err
 		}
 		if err := addInt64(plan.ValueColumn); err != nil {
@@ -2057,9 +2057,9 @@ func decodeTypedColumnPhysicalQueryDenseGroupCountDistinctPreparedPart(plan colu
 	}, nil
 }
 
-func decodeTypedColumnPhysicalQueryDenseGroupHourCountPreparedPart(plan columnTypedColumnPhysicalQueryPlan, summary typedColumnAdapterImageSummary, typedRef, physical columnManifestAssetRefForScan, adapterPart *typedColumnAdapterPart, bytesRead int64) (columnTypedColumnPhysicalQueryPart, error) {
+func decodeTypedColumnPhysicalQueryDenseGroupHourCountPreparedPart(plan columnTypedColumnPhysicalQueryPlan, summary typedColumnAdapterImageSummary, typedRef, physical columnManifestAssetRefForScan, adapterPart *typedColumnAdapterPart, bytesRead int64, prepareDiagnostics *columnTypedColumnPhysicalQueryPrepareDiagnostics) (columnTypedColumnPhysicalQueryPart, error) {
 	spanPlan, groupPredicate, hasGroupPredicate := columnTypedColumnPhysicalQueryDenseGroupHourSpanPlan(plan)
-	part, err := decodeTypedColumnPhysicalQueryDenseInt64SpanPreparedPart(spanPlan, summary, typedRef, physical, adapterPart, bytesRead, false, nil)
+	part, err := decodeTypedColumnPhysicalQueryDenseInt64SpanPreparedPart(spanPlan, summary, typedRef, physical, adapterPart, bytesRead, false, prepareDiagnostics)
 	if err != nil {
 		return columnTypedColumnPhysicalQueryPart{}, err
 	}


### PR DESCRIPTION
## Summary

- routes q3 dense group-hour one-shot preparation through values-by-code dictionary slices, matching the q5 one-shot dense int64-span shape
- keeps reverse dictionaries out of cached q3 dense group-hour state and adds a regression assertion
- propagates q3 dense prepare diagnostics so no-metadata one-shot reports show group/value/predicate decode costs

## Scope

- Improves: q3 `one_shot_end_to_end`, `no_aggregate_metadata`, typed-column scan preparation.
- Does not claim: broad TreeDB SQL superiority, aggregate-metadata acceleration, hot prepared runner speed, or insert/load improvement.
- Related tracker: #3000
- Child issue: closes #3189

## Benchmark Evidence

All runs use JSONBench `bd510af`, 1,000,000 loaded Bluesky rows, `column-store-full-prepared`, `QUERY_MODE=one_shot_end_to_end`, `METADATA_MODE=no_aggregate_metadata`, `QUERY_CELLS=q3`, `TRIES=1`.

| Run | gomap | q3 total | prepare | run | scanned | matched/reduced | decoded payload |
|---|---|---:|---:|---:|---:|---:|---:|
| baseline | `1d1b913b4` | 30.539 ms | 19.289 ms | 11.235 ms | 1,000,000 | 588,328 | 26,680,455 B |
| baseline | `1d1b913b4` | 26.323 ms | 15.371 ms | 10.934 ms | 1,000,000 | 588,328 | 26,680,455 B |
| candidate | `ce9327822` | 24.309 ms | 13.763 ms | 10.534 ms | 1,000,000 | 588,328 | 26,680,455 B |
| candidate | `ce9327822` | 24.199 ms | 13.468 ms | 10.720 ms | 1,000,000 | 588,328 | 26,680,455 B |

Artifacts:

- `/tmp/jsonbench_q3_values_baseline_20260627_120831`
- `/tmp/jsonbench_q3_values_baseline2_20260627_121019`
- `/tmp/jsonbench_q3_values_candidate_20260627_120858`
- `/tmp/jsonbench_q3_values_candidate2_20260627_120953`

## Reproduction

```sh
cd /Users/michaelseiler/dev/snissn/JSONBench/treedb
OUT_DIR=/tmp/jsonbench_q3_values_candidate_$(date +%Y%m%d_%H%M%S) \
DATA_DIR=/Users/michaelseiler/data/bluesky \
ROWS=1000000 TRIES=1 STORAGE_LAYOUTS=column-store-full-prepared \
QUERY_MODE=one_shot_end_to_end METADATA_MODE=no_aggregate_metadata \
QUERY_CELLS=q3 SUITE=full TREEDB_ALLOW_ERRORS=1 \
GOMAP_REPLACE=/private/tmp/gomap_3123_q2_next \
./run_columnstore_benchmark.sh
```

## Tests

```sh
go test ./TreeDB/collections -run 'TestColumnPhysicalTypedColumnOneShotCacheQ1Q3NoMetadata3088|TestColumnPhysicalTypedColumnOneShotCacheQ5NoMetadata3088|TestColumnPhysicalQ3Dense'
go test ./TreeDB/collections
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling for a specific dense query path, making cached results more consistent and reliable.
  * Adjusted dictionary-related preparation so certain queries can use the expected values-by-code data during processing.
* **Tests**
  * Added coverage to verify the query cache state after the first run of a related dense query scenario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->