### PR TITLE
TreeDB: gate adaptive BTree promotion

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -2251,7 +2251,7 @@ const (
 	adaptiveSequentialWritePct                                     = 0.85
 	adaptiveRangeIteratorPct                                       = 0.40
 	adaptiveOverwriteWritePct                                      = 0.25
-	adaptiveBTreeMinIteratorSamplesDefault                         = 0
+	adaptiveBTreeMinIteratorSamplesDefault                         = 64
 	adaptiveWarmupBytes                                            = 16 * 1024 * 1024
 	maxMemtableBytesPerShard                                       = int64(3 << 30)
 	maxOuterLeafArenaPoolCap                                       = 16 << 20

--- a/TreeDB/caching/stats_test.go
+++ b/TreeDB/caching/stats_test.go
@@ -123,18 +123,25 @@ func TestChooseAdaptiveMode(t *testing.T) {
 		t.Errorf("sequential mode = %v, want %v", got, memtable.ModeAppendOnly)
 	}
 
-	// 3. High range scans -> BTree
+	// 3. Sparse range scans are not enough to leave the write-friendly base.
 	// Reset
 	db.memtableStats.writes.Store(adaptiveMinWrites)
 	db.memtableStats.seqWrites.Store(adaptiveMinWrites / 10) // Low seq
 	db.memtableStats.overwriteWrites.Store(0)
-	db.memtableStats.iterators.Store(100)
-	db.memtableStats.rangeIters.Store(80) // 80% range
+	db.memtableStats.iterators.Store(adaptiveBTreeMinIteratorSamplesDefault / 2)
+	db.memtableStats.rangeIters.Store(adaptiveBTreeMinIteratorSamplesDefault / 2)
+	if got := db.chooseAdaptiveMemtableModeLocked(); got != memtable.ModeHashSorted {
+		t.Errorf("sparse range scan mode = %v, want %v", got, memtable.ModeHashSorted)
+	}
+
+	// 4. Sustained high range scans -> BTree
+	db.memtableStats.iterators.Store(adaptiveBTreeMinIteratorSamplesDefault * 2)
+	db.memtableStats.rangeIters.Store(adaptiveBTreeMinIteratorSamplesDefault * 2)
 	if got := db.chooseAdaptiveMemtableModeLocked(); got != memtable.ModeBTree {
 		t.Errorf("range scan mode = %v, want %v", got, memtable.ModeBTree)
 	}
 
-	// 4. High overwrites -> HashSorted
+	// 5. High overwrites -> HashSorted
 	db.memtableStats.writes.Store(adaptiveMinWrites)
 	db.memtableStats.seqWrites.Store(adaptiveMinWrites)
 	db.memtableStats.overwriteWrites.Store(adaptiveMinWrites / 2)

--- a/docs/TREEDB_TUNING.md
+++ b/docs/TREEDB_TUNING.md
@@ -208,6 +208,19 @@ Note on memtable sharding:
 - With `MemtableShards > 1`, `queue_len` counts per-shard immutables, so a queue
   length of 40 may correspond to only ~5 rotations at 8 shards.
 
+### Adaptive BTree promotion
+
+`MemtableMode=adaptive` and `adaptive:<base>` can promote mutable memtables to
+the BTree implementation when range iterators dominate the observed read path.
+BTree memtables are useful for sustained range-heavy workloads, but they carry
+more heap overhead than the write-friendly append-only or hash-sorted modes.
+
+By default, TreeDB now requires at least 64 iterator samples and 64 range
+iterator samples before adaptive mode can choose BTree. This filters sparse
+range-iterator noise during restore or bootstrap phases. Use
+`TREEDB_ADAPTIVE_BTREE_MIN_ITERATOR_SAMPLES` to raise or lower the gate for a
+specific deployment.
+
 ### `Options.IteratorMutableMaxBytes` (cached mode; opt-in)
 
 Allows iterators to read from mutable memtables without forcing a rotation when


### PR DESCRIPTION
## Summary

Part of #3187. This changes adaptive memtable mode so sparse range-iterator observations no longer immediately promote mutable memtables to BTree. The new default requires at least 64 iterator samples and 64 range-iterator samples before adaptive mode may choose BTree; sustained range-heavy workloads still promote, and `TREEDB_ADAPTIVE_BTREE_MIN_ITERATOR_SAMPLES` remains the deployment override.

The post-#3188 Celestia evidence showed 16 mutable BTree memtables at peak RSS with only ~5.9 MiB logical mutable payload, while BTree arena/node allocations accounted for ~629 MiB flat heap (`btreeArena.currentChunk=333.08MB`, `tidwall/btree.Map.nodeSet=295.65MB`). This PR targets that TreeDB-owned RSS bucket while keeping the raw-KV command-WAL payload bucket as a regression guard (`RawKVBatchPayloadBuilder.appendRawKVPayloadSpace=114.71MB` in the same peak).

## Validation

- `GOWORK=off go test ./TreeDB/caching -run 'TestChooseAdaptiveMode|TestAdaptiveMemtableMode' -count=1`\n- `GOWORK=off go test ./TreeDB/caching -count=1`\n- `GOWORK=off go test ./TreeDB ./TreeDB/db ./TreeDB/integration/kvstoreadapter -count=1`\n- `git diff --check`\n\n## Celestia protocol\n\nPending before this leaves draft: rerun the same TreeDB Celestia protocol used after #3188, then run the strict matched goleveldb A/B with the same trust height/hash, stop target, local IAVL checkout, Celestia checkout, and dwell window.\n\nIssue: #3187\n