### PR TITLE
TreeDB: report retained value-log insert stats

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -493,6 +493,12 @@ type CollectionInsertStats struct {
 	RetainedPayloadRows                 int
 	RetainedPayloadDeclaredRows         int
 	RetainedPayloadSemanticStreamBlocks int
+	RetainedPayloadValueLogPointerize   time.Duration
+	RetainedPayloadValueLogValues       int
+	RetainedPayloadValueLogBytes        int64
+	RetainedStreamValueLogPointerize    time.Duration
+	RetainedStreamValueLogValues        int
+	RetainedStreamValueLogBytes         int64
 	// ColumnPublish* fields are populated for typed-column InsertBatch paths
 	// that route through the command-WAL column manifest publish path.
 	ColumnPublishBuildColumnDelta         time.Duration
@@ -5389,6 +5395,11 @@ type collectionPointerizeOptions struct {
 	packRetainedTemplateV1Values bool
 }
 
+type collectionPointerizeStats struct {
+	Values int
+	Bytes  int64
+}
+
 func collectionRunTableHasStableUnsafeSlices(table memtable.Table) bool {
 	stable, ok := table.(memtable.StableUnsafeIteratorTable)
 	return ok && stable.StableUnsafeIteratorSlices()
@@ -5399,7 +5410,12 @@ func pointerizeCollectionRunTableValues(db *backenddb.DB, table memtable.Table) 
 }
 
 func pointerizeCollectionRunTableValuesForRoot(db *backenddb.DB, meta CollectionMeta, rootName string, table memtable.Table) (memtable.Table, bool, error) {
-	return pointerizeCollectionRunTableValuesWithOptions(db, table, collectionPointerizeOptions{
+	out, pointerized, _, err := pointerizeCollectionRunTableValuesForRootWithStats(db, meta, rootName, table)
+	return out, pointerized, err
+}
+
+func pointerizeCollectionRunTableValuesForRootWithStats(db *backenddb.DB, meta CollectionMeta, rootName string, table memtable.Table) (memtable.Table, bool, collectionPointerizeStats, error) {
+	return pointerizeCollectionRunTableValuesWithOptionsAndStats(db, table, collectionPointerizeOptions{
 		inlineThresholdForKey:        collectionValueLogInlineThresholdResolverForRoot(db, meta, rootName),
 		packRetainedTemplateV1Values: collectionRootStoresRetainedPayloadBodies(meta, rootName) && columnStoreRetainedPayloadUsesTemplateV1(meta.Options.ColumnStore),
 	})
@@ -5447,8 +5463,14 @@ func collectionRootStoresRetainedSemanticStreamBlocks(meta CollectionMeta, rootN
 }
 
 func pointerizeCollectionRunTableValuesWithOptions(db *backenddb.DB, table memtable.Table, opts collectionPointerizeOptions) (memtable.Table, bool, error) {
+	out, pointerized, _, err := pointerizeCollectionRunTableValuesWithOptionsAndStats(db, table, opts)
+	return out, pointerized, err
+}
+
+func pointerizeCollectionRunTableValuesWithOptionsAndStats(db *backenddb.DB, table memtable.Table, opts collectionPointerizeOptions) (memtable.Table, bool, collectionPointerizeStats, error) {
+	var stats collectionPointerizeStats
 	if db == nil || table == nil || !db.HasValueLogAppender() {
-		return table, false, nil
+		return table, false, stats, nil
 	}
 	inlineThresholdForKey := opts.inlineThresholdForKey
 	if inlineThresholdForKey == nil {
@@ -5469,10 +5491,10 @@ func pointerizeCollectionRunTableValuesWithOptions(db *backenddb.DB, table memta
 	probeErr := probe.Error()
 	_ = probe.Close()
 	if probeErr != nil {
-		return table, false, probeErr
+		return table, false, stats, probeErr
 	}
 	if !needsPointer {
-		return table, false, nil
+		return table, false, stats, nil
 	}
 
 	entries := make([]collectionPointerizedRunEntry, 0, table.Len())
@@ -5540,9 +5562,11 @@ func pointerizeCollectionRunTableValuesWithOptions(db *backenddb.DB, table memta
 			batchValues = append(batchValues, appendValue)
 			batchEntryIndexes = append(batchEntryIndexes, len(entries)-1)
 			batchBytes += len(appendValue)
+			stats.Values++
+			stats.Bytes = saturatingAddNonNegativeInt64(stats.Bytes, int64(len(appendValue)))
 			if len(batchValues) >= collectionPointerizeBatchMaxValues || batchBytes >= collectionPointerizeBatchMaxBytes {
 				if err := flushBatch(); err != nil {
-					return table, false, err
+					return table, false, stats, err
 				}
 			}
 		} else if value != nil {
@@ -5554,13 +5578,13 @@ func pointerizeCollectionRunTableValuesWithOptions(db *backenddb.DB, table memta
 		it.Next()
 	}
 	if err := it.Error(); err != nil {
-		return table, false, err
+		return table, false, stats, err
 	}
 	if err := flushBatch(); err != nil {
-		return table, false, err
+		return table, false, stats, err
 	}
 	if !pointerized {
-		return table, false, nil
+		return table, false, stats, nil
 	}
 	out := newCollectionRunTable(len(entries))
 	for i := range entries {
@@ -5569,7 +5593,7 @@ func pointerizeCollectionRunTableValuesWithOptions(db *backenddb.DB, table memta
 	}
 	out.Freeze()
 	success = true
-	return &collectionPointerizedRunTable{Table: out, db: db, ptrs: appendedPtrs}, true, nil
+	return &collectionPointerizedRunTable{Table: out, db: db, ptrs: appendedPtrs}, true, stats, nil
 }
 
 type collectionPointerizedRunTable struct {
@@ -10970,9 +10994,15 @@ func (c *Collection) insertBatchNoIndex(
 	}
 	table.Freeze()
 	stats.PrimaryRunBuild = time.Since(phaseStart)
-	publishTable, pointerized, err := pointerizeCollectionRunTableValuesForRoot(c.db, c.meta, rootName, table)
+	phaseStart = time.Now()
+	publishTable, pointerized, pointerizeStats, err := pointerizeCollectionRunTableValuesForRootWithStats(c.db, c.meta, rootName, table)
 	if err != nil {
 		return nil, err
+	}
+	if columnStoreNeedsRetainedPayloadTransform(c.meta) {
+		stats.RetainedPayloadValueLogPointerize = time.Since(phaseStart)
+		stats.RetainedPayloadValueLogValues = pointerizeStats.Values
+		stats.RetainedPayloadValueLogBytes = pointerizeStats.Bytes
 	}
 	if pointerized {
 		defer resetCollectionRunTable(publishTable)
@@ -11038,12 +11068,16 @@ func (c *Collection) insertBatchNoIndex(
 		}
 		streamPublishTable := retainedSemanticStreamBlocks
 		retainedSemanticStreamTables = append(retainedSemanticStreamTables, retainedSemanticStreamBlocks)
-		if pointerizedStreamTable, pointerized, err := pointerizeCollectionRunTableValuesForRoot(c.db, c.meta, streamRootName, retainedSemanticStreamBlocks); err != nil {
+		phaseStart := time.Now()
+		if pointerizedStreamTable, pointerized, pointerizeStats, err := pointerizeCollectionRunTableValuesForRootWithStats(c.db, c.meta, streamRootName, retainedSemanticStreamBlocks); err != nil {
 			return nil, err
 		} else if pointerized {
 			streamPublishTable = pointerizedStreamTable
 			retainedSemanticStreamTables = append(retainedSemanticStreamTables, pointerizedStreamTable)
+			stats.RetainedStreamValueLogValues = pointerizeStats.Values
+			stats.RetainedStreamValueLogBytes = pointerizeStats.Bytes
 		}
+		stats.RetainedStreamValueLogPointerize = time.Since(phaseStart)
 		streamIter := streamPublishTable.NewIterator(nil, nil)
 		retainedSemanticStreamIters = append(retainedSemanticStreamIters, streamIter)
 		rootNames = append(rootNames, streamRootName)

--- a/TreeDB/collections/shape_bench_test.go
+++ b/TreeDB/collections/shape_bench_test.go
@@ -36,6 +36,12 @@ func addCollectionInsertStats(dst *collections.CollectionInsertStats, src collec
 	dst.RetainedPayloadRows += src.RetainedPayloadRows
 	dst.RetainedPayloadDeclaredRows += src.RetainedPayloadDeclaredRows
 	dst.RetainedPayloadSemanticStreamBlocks += src.RetainedPayloadSemanticStreamBlocks
+	dst.RetainedPayloadValueLogPointerize += src.RetainedPayloadValueLogPointerize
+	dst.RetainedPayloadValueLogValues += src.RetainedPayloadValueLogValues
+	dst.RetainedPayloadValueLogBytes += src.RetainedPayloadValueLogBytes
+	dst.RetainedStreamValueLogPointerize += src.RetainedStreamValueLogPointerize
+	dst.RetainedStreamValueLogValues += src.RetainedStreamValueLogValues
+	dst.RetainedStreamValueLogBytes += src.RetainedStreamValueLogBytes
 	dst.ColumnPublishBuildColumnDelta += src.ColumnPublishBuildColumnDelta
 	dst.ColumnPublishBuildSystemDelta += src.ColumnPublishBuildSystemDelta
 	dst.ColumnPublishCommit += src.ColumnPublishCommit
@@ -99,6 +105,8 @@ func benchmarkReportCollectionInsertStats(b *testing.B, docs, batches int, stats
 	reportDuration("index_state_extract_ns/doc", stats.IndexStateExtraction)
 	reportDuration("duplicate_preflight_ns/doc", stats.DuplicateDocumentPreflight)
 	reportDuration("retained_payload_prepare_ns/doc", stats.RetainedPayloadPrepare)
+	reportDuration("retained_payload_vlog_pointerize_ns/doc", stats.RetainedPayloadValueLogPointerize)
+	reportDuration("retained_stream_vlog_pointerize_ns/doc", stats.RetainedStreamValueLogPointerize)
 	reportDuration("column_publish_build_column_delta_ns/doc", stats.ColumnPublishBuildColumnDelta)
 	reportDuration("column_publish_build_system_delta_ns/doc", stats.ColumnPublishBuildSystemDelta)
 	reportDuration("column_publish_commit_ns/doc", stats.ColumnPublishCommit)
@@ -131,6 +139,18 @@ func benchmarkReportCollectionInsertStats(b *testing.B, docs, batches int, stats
 	}
 	if stats.ColumnPublishManifestBytes > 0 {
 		b.ReportMetric(float64(stats.ColumnPublishManifestBytes)/float64(docs), "column_publish_manifest_bytes/doc")
+	}
+	if stats.RetainedPayloadValueLogValues > 0 {
+		b.ReportMetric(float64(stats.RetainedPayloadValueLogValues)/float64(docs), "retained_payload_vlog_values/doc")
+	}
+	if stats.RetainedPayloadValueLogBytes > 0 {
+		b.ReportMetric(float64(stats.RetainedPayloadValueLogBytes)/float64(docs), "retained_payload_vlog_bytes/doc")
+	}
+	if stats.RetainedStreamValueLogValues > 0 {
+		b.ReportMetric(float64(stats.RetainedStreamValueLogValues)/float64(docs), "retained_stream_vlog_values/doc")
+	}
+	if stats.RetainedStreamValueLogBytes > 0 {
+		b.ReportMetric(float64(stats.RetainedStreamValueLogBytes)/float64(docs), "retained_stream_vlog_bytes/doc")
 	}
 	reportDuration("unique_preflight_ns/doc", stats.UniqueIndexPreflight)
 	reportDuration("template_run_ns/doc", stats.TemplateRunBuild)
@@ -200,6 +220,54 @@ func TestBenchmarkReportCollectionInsertStatsIncludesColumnPublishExtractionM10B
 	}
 	if got := result.Extra["column_publish_manifest_bytes/doc"]; got <= 0 {
 		t.Fatalf("column publish manifest bytes metric=%v want positive", got)
+	}
+}
+
+func TestCollectionShapeInsertStatsIncludesRetainedValueLogPointerization(t *testing.T) {
+	var stats collections.CollectionInsertStats
+	addCollectionInsertStats(&stats, collections.CollectionInsertStats{
+		RetainedPayloadValueLogPointerize: 10 * time.Microsecond,
+		RetainedPayloadValueLogValues:     3,
+		RetainedPayloadValueLogBytes:      300,
+		RetainedStreamValueLogPointerize:  20 * time.Microsecond,
+		RetainedStreamValueLogValues:      4,
+		RetainedStreamValueLogBytes:       400,
+	})
+	addCollectionInsertStats(&stats, collections.CollectionInsertStats{
+		RetainedPayloadValueLogPointerize: 5 * time.Microsecond,
+		RetainedPayloadValueLogValues:     2,
+		RetainedPayloadValueLogBytes:      200,
+		RetainedStreamValueLogPointerize:  7 * time.Microsecond,
+		RetainedStreamValueLogValues:      1,
+		RetainedStreamValueLogBytes:       100,
+	})
+	if stats.RetainedPayloadValueLogPointerize != 15*time.Microsecond {
+		t.Fatalf("payload pointerize=%s want 15us", stats.RetainedPayloadValueLogPointerize)
+	}
+	if stats.RetainedPayloadValueLogValues != 5 || stats.RetainedPayloadValueLogBytes != 500 {
+		t.Fatalf("payload value-log values=%d bytes=%d want 5/500", stats.RetainedPayloadValueLogValues, stats.RetainedPayloadValueLogBytes)
+	}
+	if stats.RetainedStreamValueLogPointerize != 27*time.Microsecond {
+		t.Fatalf("stream pointerize=%s want 27us", stats.RetainedStreamValueLogPointerize)
+	}
+	if stats.RetainedStreamValueLogValues != 5 || stats.RetainedStreamValueLogBytes != 500 {
+		t.Fatalf("stream value-log values=%d bytes=%d want 5/500", stats.RetainedStreamValueLogValues, stats.RetainedStreamValueLogBytes)
+	}
+
+	result := testing.Benchmark(func(b *testing.B) {
+		benchmarkReportCollectionInsertStats(b, 10, 1, stats)
+	})
+	for _, name := range []string{
+		"retained_payload_vlog_pointerize_ns/doc",
+		"retained_payload_vlog_values/doc",
+		"retained_payload_vlog_bytes/doc",
+		"retained_stream_vlog_pointerize_ns/doc",
+		"retained_stream_vlog_values/doc",
+		"retained_stream_vlog_bytes/doc",
+	} {
+		if got := result.Extra[name]; got <= 0 {
+			t.Fatalf("%s metric=%v want positive", name, got)
+		}
 	}
 }
 

--- a/cmd/unified_bench/suite_column_store.go
+++ b/cmd/unified_bench/suite_column_store.go
@@ -219,6 +219,14 @@ type columnStoreInsertPhaseMetric struct {
 	RetainedPayloadRows                       int     `json:"retained_payload_rows,omitempty"`
 	RetainedPayloadDeclaredRows               int     `json:"retained_payload_declared_rows,omitempty"`
 	RetainedPayloadSemanticStreamBlocks       int     `json:"retained_payload_semantic_stream_blocks,omitempty"`
+	RetainedPayloadValueLogPointerizeMS       float64 `json:"retained_payload_value_log_pointerize_duration_ms,omitempty"`
+	RetainedPayloadValueLogPointerizeNsPerRow float64 `json:"retained_payload_value_log_pointerize_ns_per_row,omitempty"`
+	RetainedPayloadValueLogValues             int     `json:"retained_payload_value_log_values,omitempty"`
+	RetainedPayloadValueLogBytes              int64   `json:"retained_payload_value_log_bytes,omitempty"`
+	RetainedStreamValueLogPointerizeMS        float64 `json:"retained_stream_value_log_pointerize_duration_ms,omitempty"`
+	RetainedStreamValueLogPointerizeNsPerRow  float64 `json:"retained_stream_value_log_pointerize_ns_per_row,omitempty"`
+	RetainedStreamValueLogValues              int     `json:"retained_stream_value_log_values,omitempty"`
+	RetainedStreamValueLogBytes               int64   `json:"retained_stream_value_log_bytes,omitempty"`
 	ColumnPublishBuildColumnDeltaDurationMS   float64 `json:"column_publish_build_column_delta_duration_ms,omitempty"`
 	ColumnPublishBuildColumnDeltaNsPerRow     float64 `json:"column_publish_build_column_delta_ns_per_row,omitempty"`
 	ColumnPublishBuildSystemDeltaDurationMS   float64 `json:"column_publish_build_system_delta_duration_ms,omitempty"`
@@ -1506,6 +1514,12 @@ func columnStoreAddCollectionInsertStats(dst *collections.CollectionInsertStats,
 	dst.RetainedPayloadRows += src.RetainedPayloadRows
 	dst.RetainedPayloadDeclaredRows += src.RetainedPayloadDeclaredRows
 	dst.RetainedPayloadSemanticStreamBlocks += src.RetainedPayloadSemanticStreamBlocks
+	dst.RetainedPayloadValueLogPointerize += src.RetainedPayloadValueLogPointerize
+	dst.RetainedPayloadValueLogValues += src.RetainedPayloadValueLogValues
+	dst.RetainedPayloadValueLogBytes += src.RetainedPayloadValueLogBytes
+	dst.RetainedStreamValueLogPointerize += src.RetainedStreamValueLogPointerize
+	dst.RetainedStreamValueLogValues += src.RetainedStreamValueLogValues
+	dst.RetainedStreamValueLogBytes += src.RetainedStreamValueLogBytes
 	dst.ColumnPublishBuildColumnDelta += src.ColumnPublishBuildColumnDelta
 	dst.ColumnPublishBuildSystemDelta += src.ColumnPublishBuildSystemDelta
 	dst.ColumnPublishCommit += src.ColumnPublishCommit
@@ -1570,6 +1584,14 @@ func columnStoreInsertPhaseMetricFromStats(stats collections.CollectionInsertSta
 		RetainedPayloadRows:                       stats.RetainedPayloadRows,
 		RetainedPayloadDeclaredRows:               stats.RetainedPayloadDeclaredRows,
 		RetainedPayloadSemanticStreamBlocks:       stats.RetainedPayloadSemanticStreamBlocks,
+		RetainedPayloadValueLogPointerizeMS:       durationMS(stats.RetainedPayloadValueLogPointerize),
+		RetainedPayloadValueLogPointerizeNsPerRow: nsPerRow(stats.RetainedPayloadValueLogPointerize, rows),
+		RetainedPayloadValueLogValues:             stats.RetainedPayloadValueLogValues,
+		RetainedPayloadValueLogBytes:              stats.RetainedPayloadValueLogBytes,
+		RetainedStreamValueLogPointerizeMS:        durationMS(stats.RetainedStreamValueLogPointerize),
+		RetainedStreamValueLogPointerizeNsPerRow:  nsPerRow(stats.RetainedStreamValueLogPointerize, rows),
+		RetainedStreamValueLogValues:              stats.RetainedStreamValueLogValues,
+		RetainedStreamValueLogBytes:               stats.RetainedStreamValueLogBytes,
 		ColumnPublishBuildColumnDeltaDurationMS:   durationMS(stats.ColumnPublishBuildColumnDelta),
 		ColumnPublishBuildColumnDeltaNsPerRow:     nsPerRow(stats.ColumnPublishBuildColumnDelta, rows),
 		ColumnPublishBuildSystemDeltaDurationMS:   durationMS(stats.ColumnPublishBuildSystemDelta),
@@ -4529,6 +4551,10 @@ func renderColumnStoreInsertStatsMarkdown(sb *strings.Builder, stats columnStore
 	sb.WriteString(fmt.Sprintf("- retained_payload_rows: %d\n", stats.RetainedPayloadRows))
 	sb.WriteString(fmt.Sprintf("- retained_payload_declared_rows: %d\n", stats.RetainedPayloadDeclaredRows))
 	sb.WriteString(fmt.Sprintf("- retained_payload_semantic_stream_blocks: %d\n", stats.RetainedPayloadSemanticStreamBlocks))
+	sb.WriteString(fmt.Sprintf("- retained_payload_value_log_values: %d\n", stats.RetainedPayloadValueLogValues))
+	sb.WriteString(fmt.Sprintf("- retained_payload_value_log_bytes: %d\n", stats.RetainedPayloadValueLogBytes))
+	sb.WriteString(fmt.Sprintf("- retained_stream_value_log_values: %d\n", stats.RetainedStreamValueLogValues))
+	sb.WriteString(fmt.Sprintf("- retained_stream_value_log_bytes: %d\n", stats.RetainedStreamValueLogBytes))
 	sb.WriteString(fmt.Sprintf("- column_store_declared_row_reuse_coverage_ratio: %.6f\n", stats.ColumnStoreDeclaredRowReuseCoverageRatio))
 	sb.WriteString(fmt.Sprintf("- retained_payload_semantic_stream_blocks_per_run: %.6f\n\n", stats.RetainedPayloadSemanticStreamBlocksPerRun))
 	sb.WriteString(fmt.Sprintf("- column_publish_rows: %d\n", stats.ColumnPublishRows))
@@ -4547,6 +4573,8 @@ func renderColumnStoreInsertStatsMarkdown(sb *strings.Builder, stats columnStore
 	sb.WriteString(fmt.Sprintf("| `prepare_documents` | %.3f | %.1f |\n", stats.PrepareDocumentsDurationMS, stats.PrepareDocumentsNsPerRow))
 	sb.WriteString(fmt.Sprintf("| `duplicate_document_preflight` | %.3f | %.1f |\n", stats.DuplicateDocumentPreflightDurationMS, stats.DuplicateDocumentPreflightNsPerRow))
 	sb.WriteString(fmt.Sprintf("| `retained_payload_prepare` | %.3f | %.1f |\n", stats.RetainedPayloadPrepareDurationMS, stats.RetainedPayloadPrepareNsPerRow))
+	sb.WriteString(fmt.Sprintf("| `retained_payload_value_log_pointerize` | %.3f | %.1f |\n", stats.RetainedPayloadValueLogPointerizeMS, stats.RetainedPayloadValueLogPointerizeNsPerRow))
+	sb.WriteString(fmt.Sprintf("| `retained_stream_value_log_pointerize` | %.3f | %.1f |\n", stats.RetainedStreamValueLogPointerizeMS, stats.RetainedStreamValueLogPointerizeNsPerRow))
 	sb.WriteString(fmt.Sprintf("| `primary_run_build` | %.3f | %.1f |\n", stats.PrimaryRunBuildDurationMS, stats.PrimaryRunBuildNsPerRow))
 	sb.WriteString(fmt.Sprintf("| `publish` | %.3f | %.1f |\n\n", stats.PublishDurationMS, stats.PublishNsPerRow))
 

--- a/cmd/unified_bench/suite_column_store_test.go
+++ b/cmd/unified_bench/suite_column_store_test.go
@@ -2703,6 +2703,12 @@ func TestColumnStoreInsertPhaseMetricFromStatsIncludesAssetFamiliesM3148(t *test
 		ColumnPublishAggregateMetadataCount:   5,
 		ColumnPublishSharedAppendBytes:        606,
 		ColumnPublishSharedAppendCount:        6,
+		RetainedPayloadValueLogPointerize:     8 * time.Millisecond,
+		RetainedPayloadValueLogValues:         7,
+		RetainedPayloadValueLogBytes:          707,
+		RetainedStreamValueLogPointerize:      9 * time.Millisecond,
+		RetainedStreamValueLogValues:          8,
+		RetainedStreamValueLogBytes:           808,
 	}
 
 	metric := columnStoreInsertPhaseMetricFromStats(stats, 1)
@@ -2736,6 +2742,24 @@ func TestColumnStoreInsertPhaseMetricFromStatsIncludesAssetFamiliesM3148(t *test
 	}
 	if got, want := metric.ColumnPublishAssetAppendCloseDurationMS, 4.0; got != want {
 		t.Fatalf("shared append close duration ms=%v want %v", got, want)
+	}
+	if got, want := metric.RetainedPayloadValueLogPointerizeMS, 8.0; got != want {
+		t.Fatalf("retained payload pointerize duration ms=%v want %v", got, want)
+	}
+	if got, want := metric.RetainedPayloadValueLogValues, 7; got != want {
+		t.Fatalf("retained payload pointerized values=%d want %d", got, want)
+	}
+	if got, want := metric.RetainedPayloadValueLogBytes, int64(707); got != want {
+		t.Fatalf("retained payload pointerized bytes=%d want %d", got, want)
+	}
+	if got, want := metric.RetainedStreamValueLogPointerizeMS, 9.0; got != want {
+		t.Fatalf("retained stream pointerize duration ms=%v want %v", got, want)
+	}
+	if got, want := metric.RetainedStreamValueLogValues, 8; got != want {
+		t.Fatalf("retained stream pointerized values=%d want %d", got, want)
+	}
+	if got, want := metric.RetainedStreamValueLogBytes, int64(808); got != want {
+		t.Fatalf("retained stream pointerized bytes=%d want %d", got, want)
 	}
 	if got, want := metric.ColumnPublishTypedColumnBytes, int64(202); got != want {
 		t.Fatalf("typed-column bytes=%d want %d", got, want)


### PR DESCRIPTION
## Summary

This PR adds load-path attribution for the production `column-store-full-prepared` collection insert path. It exposes retained value-log pointerization costs through `CollectionInsertStats`, collection shape benchmark metrics, and unified-bench reporting so the JSONBench tracker can distinguish retained semantic-stream preparation, primary retained-payload value-log pointerization, and semantic-stream side-root pointerization.

Scope classification for the realigned TreeDB JSONBench/ClickHouse goal:

- Improves: insert/load observability and next-bottleneck selection.
- Does not claim: one-shot SQL superiority, no-aggregate scan improvement, hot prepared query improvement, or metadata-backed query superiority.
- Does not change: on-disk value-log persistence semantics, WAL accounting, query execution behavior, hashes, locators, or retained payload bytes.

Fixes #3192.

## What changed

- Added primary retained-payload value-log pointerization duration/count/byte stats to `CollectionInsertStats`.
- Added semantic-stream side-root value-log pointerization duration/count/byte stats.
- Preserved existing pointerization APIs and added stats-returning internal variants for insert attribution.
- Surfaced the new fields in `cmd/unified_bench` JSON and markdown insert-stat output.
- Surfaced the new fields in collection shape benchmark aggregation/reporting.
- Extended unified-bench and shape-benchmark coverage for the new metric conversion fields.

## Evidence

GOMAP tests:

```sh
go test ./TreeDB/collections ./cmd/unified_bench -run 'Test.*InsertStats|Test.*SemanticStream|Test.*ValueLog.*Reopen|TestValueLogGC|TestBenchmarkReportCollectionInsertStatsIncludesColumnPublishExtractionM10B' -count=1
# ok github.com/snissn/gomap/TreeDB/collections 2.568s
# ok github.com/snissn/gomap/cmd/unified_bench 1.297s

go test ./TreeDB/collections -run 'TestBenchmarkReportCollectionInsertStatsIncludesColumnPublishExtractionM10B|TestCollectionShapeInsertStatsIncludesRetainedValueLogPointerization' -count=1
# ok github.com/snissn/gomap/TreeDB/collections 1.039s

go test ./TreeDB/collections -count=1
# ok github.com/snissn/gomap/TreeDB/collections 52.625s

go test ./TreeDB/collections ./cmd/unified_bench -count=1
# ok github.com/snissn/gomap/TreeDB/collections 56.996s
# ok github.com/snissn/gomap/cmd/unified_bench 36.155s
```

JSONBench companion harness validation, run with `GOMAP_REPLACE=/private/tmp/gomap_3123_q2_next`:

```sh
go test ./cmd/jsonbench_treedb -count=1
# ok jsonbench-treedb/cmd/jsonbench_treedb 5.786s
```

1M TreeDB-only JSONBench smoke with the companion JSONBench reporting changes:

```sh
OUT_DIR=/tmp/jsonbench_insert_stats_1m_20260627_131126 \
DATA_DIR=/Users/michaelseiler/data/bluesky \
ROWS=1000000 TRIES=1 \
QUERY_MODE=one_shot_end_to_end \
METADATA_MODE=no_aggregate_metadata \
SUITE=full \
STORAGE_LAYOUTS=column-store-full-prepared \
TREEDB_ALLOW_ERRORS=1 \
GOMAP_REPLACE=/private/tmp/gomap_3123_q2_next \
./run_columnstore_benchmark.sh
```

Relevant artifact row:

```text
| 1m | column-store-full-prepared:json/full+retained=semantic-stream-v1 | 19.528s | 16.116s | 6.995s | 1000000 | 0 | 250 | 0.0179s | 0 |  | 0.1821s | 250 | 92.79 MiB |
```

Interpretation: on this 1M smoke, retained semantic-stream preparation is the large exposed load subphase at ~6.995s; semantic-stream value-log pointerization is ~0.182s for 250 blocks / 92.79 MiB; primary retained-payload pointerization is not the bottleneck on the semantic-stream path.
