### PR TITLE
Optimize retained semantic stream preparation

### DIFF
--- a/TreeDB/collections/column_retained_semantic_stream.go
+++ b/TreeDB/collections/column_retained_semantic_stream.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -43,8 +44,10 @@ type columnRetainedSemanticStreamEntry struct {
 }
 
 type columnRetainedSemanticStreamPath struct {
-	segments []string
-	entries  []columnRetainedSemanticStreamEntry
+	segments                []string
+	entries                 []columnRetainedSemanticStreamEntry
+	rawValueBytes           int
+	valueLengthUvarintBytes int
 }
 
 type columnRetainedSemanticStreamV1DecodedBlock struct {
@@ -453,8 +456,8 @@ func collectColumnRetainedSemanticStreamV1RootFastPathDocument(cfg ColumnStoreCo
 		return nil, err
 	}
 	if len(retainedRootValues) > 0 {
-		sort.Slice(retainedRootValues, func(i, j int) bool {
-			return retainedRootValues[i].path < retainedRootValues[j].path
+		slices.SortFunc(retainedRootValues, func(a, b retainedRootValue) int {
+			return strings.Compare(a.path, b.path)
 		})
 		for _, value := range retainedRootValues {
 			if err := collectColumnRetainedSemanticStreamJSONParserPaths(value.raw, value.valueType, []string{value.path}, row, streamEntryCapacity, streams); err != nil {
@@ -620,9 +623,7 @@ func columnRetainedSemanticStreamV1ReclaimDeleteKeys(
 	for _, key := range candidates {
 		deleteKeys = append(deleteKeys, key)
 	}
-	sort.Slice(deleteKeys, func(i, j int) bool {
-		return bytes.Compare(deleteKeys[i], deleteKeys[j]) < 0
-	})
+	slices.SortFunc(deleteKeys, bytes.Compare)
 	return deleteKeys, nil
 }
 
@@ -983,7 +984,7 @@ func encodeColumnRetainedSemanticStreamV1RawBlockFromStreams(rows int, streams m
 		keys = append(keys, key)
 	}
 	sort.Strings(keys)
-	out := make([]byte, 0, len(columnRetainedSemanticStreamV1BlockMagic)+rows*16)
+	out := make([]byte, 0, columnRetainedSemanticStreamV1RawBlockSizeHint(rows, keys, streams))
 	out = append(out, columnRetainedSemanticStreamV1BlockMagic...)
 	out = binary.AppendUvarint(out, uint64(rows))
 	out = binary.AppendUvarint(out, uint64(len(keys)))
@@ -1008,6 +1009,25 @@ func encodeColumnRetainedSemanticStreamV1RawBlockFromStreams(rows int, streams m
 		}
 	}
 	return out, nil
+}
+
+func columnRetainedSemanticStreamV1RawBlockSizeHint(rows int, keys []string, streams map[string]*columnRetainedSemanticStreamPath) int {
+	size := len(columnRetainedSemanticStreamV1BlockMagic) +
+		columnRetainedSemanticStreamV1UvarintSize(uint64(rows)) +
+		columnRetainedSemanticStreamV1UvarintSize(uint64(len(keys)))
+	for _, key := range keys {
+		stream := streams[key]
+		size += columnRetainedSemanticStreamV1UvarintSize(uint64(len(stream.segments)))
+		for _, segment := range stream.segments {
+			size += columnRetainedSemanticStreamV1UvarintSize(uint64(len(segment))) + len(segment)
+		}
+		size += columnRetainedSemanticStreamV1UvarintSize(uint64(len(stream.entries)))
+		// Row deltas are bounded by the per-block row count. At 4096 rows this is
+		// at most two bytes per entry, and value-length uvarint bytes are tracked
+		// when entries are appended.
+		size += len(stream.entries)*2 + stream.valueLengthUvarintBytes + stream.rawValueBytes
+	}
+	return size
 }
 
 func encodeColumnRetainedSemanticStreamV1StoredBlock(raw []byte) ([]byte, error) {
@@ -1215,8 +1235,8 @@ func collectColumnRetainedSemanticStreamJSONParserObjectPaths(raw []byte, path [
 		}
 		return nil
 	}
-	sort.Slice(retainedObjectValues, func(i, j int) bool {
-		return retainedObjectValues[i].path < retainedObjectValues[j].path
+	slices.SortFunc(retainedObjectValues, func(a, b retainedObjectValue) int {
+		return strings.Compare(a.path, b.path)
 	})
 	for _, value := range retainedObjectValues {
 		nextPath := append(append([]string(nil), path...), value.path)
@@ -1280,8 +1300,8 @@ func collectColumnRetainedSemanticStreamJSONParserObjectPathsWithSkip(raw []byte
 		}
 		return nil
 	}
-	sort.Slice(retainedObjectValues, func(i, j int) bool {
-		return retainedObjectValues[i].path < retainedObjectValues[j].path
+	slices.SortFunc(retainedObjectValues, func(a, b retainedObjectValue) int {
+		return strings.Compare(a.path, b.path)
 	})
 	for _, value := range retainedObjectValues {
 		if value.deleted {
@@ -1358,6 +1378,8 @@ func appendColumnRetainedSemanticStreamValueWithOwnership(path []string, row uin
 		}
 		streams[key] = stream
 	}
+	stream.rawValueBytes += len(raw)
+	stream.valueLengthUvarintBytes += columnRetainedSemanticStreamV1UvarintSize(uint64(len(raw)))
 	stream.entries = append(stream.entries, columnRetainedSemanticStreamEntry{
 		row: row,
 		raw: raw,
@@ -1365,7 +1387,11 @@ func appendColumnRetainedSemanticStreamValueWithOwnership(path []string, row uin
 }
 
 func columnRetainedSemanticStreamPathKey(path []string) string {
-	var out []byte
+	capacity := 0
+	for _, segment := range path {
+		capacity += columnRetainedSemanticStreamDecimalSize(len(segment)) + 1 + len(segment) + 1
+	}
+	out := make([]byte, 0, capacity)
 	for _, segment := range path {
 		out = strconv.AppendInt(out, int64(len(segment)), 10)
 		out = append(out, ':')
@@ -1373,6 +1399,27 @@ func columnRetainedSemanticStreamPathKey(path []string) string {
 		out = append(out, 0)
 	}
 	return string(out)
+}
+
+func columnRetainedSemanticStreamDecimalSize(n int) int {
+	if n < 10 {
+		return 1
+	}
+	size := 0
+	for n > 0 {
+		size++
+		n /= 10
+	}
+	return size
+}
+
+func columnRetainedSemanticStreamV1UvarintSize(v uint64) int {
+	size := 1
+	for v >= 0x80 {
+		size++
+		v >>= 7
+	}
+	return size
 }
 
 func decodeColumnRetainedSemanticStreamV1BlockRowJSON(block []byte, row uint64) ([]byte, error) {
@@ -1901,17 +1948,23 @@ func (c *columnRetainedSemanticStreamV1BlockLayoutCollector) result(rows, maxPat
 		out.PathZSTDEncodedBytes += stat.ZSTDBytes
 		paths = append(paths, pathLayoutResult{key: pathKey, stat: stat})
 	}
-	sort.Slice(paths, func(i, j int) bool {
-		if paths[i].stat.TotalBytes != paths[j].stat.TotalBytes {
-			return paths[i].stat.TotalBytes > paths[j].stat.TotalBytes
+	slices.SortFunc(paths, func(a, b pathLayoutResult) int {
+		if a.stat.TotalBytes != b.stat.TotalBytes {
+			if a.stat.TotalBytes > b.stat.TotalBytes {
+				return -1
+			}
+			return 1
 		}
-		if paths[i].stat.Occurrences != paths[j].stat.Occurrences {
-			return paths[i].stat.Occurrences > paths[j].stat.Occurrences
+		if a.stat.Occurrences != b.stat.Occurrences {
+			if a.stat.Occurrences > b.stat.Occurrences {
+				return -1
+			}
+			return 1
 		}
-		if paths[i].stat.Path != paths[j].stat.Path {
-			return paths[i].stat.Path < paths[j].stat.Path
+		if a.stat.Path != b.stat.Path {
+			return strings.Compare(a.stat.Path, b.stat.Path)
 		}
-		return paths[i].key < paths[j].key
+		return strings.Compare(a.key, b.key)
 	})
 	outPaths := make([]ColumnRetainedSemanticStreamV1PathLayoutStat, 0, len(paths))
 	for _, path := range paths {


### PR DESCRIPTION
Refs #3196
Refs #3067
Refs #3099
Refs #3000
Refs #3001

## Scope

This is a narrow TreeDB JSONBench load-path slice for the `column-store-full-prepared` full-retained JSON layout. It reduces retained semantic-stream preparation allocation/copy overhead by:

- sizing semantic-stream path keys before appending length-prefixed path segments
- tracking raw value bytes and value-length uvarint bytes so raw block encoding can pre-size its output buffer
- replacing reflection-backed `sort.Slice` comparators on hot retained-stream slices with typed `slices.SortFunc` comparators

## Metric classification

- Improves: insert/load path, retained semantic-stream preparation cost, allocation pressure during full-retained JSON load.
- Does not change: query planning semantics, one-shot query execution behavior, metadata storage behavior, general scan operators, ClickHouse comparison mode.
- This PR is not evidence that TreeDB SQL is broadly faster than ClickHouse. It is a production-shape load-path improvement under the realigned #3067/#3099/#3000/#3001 goals.

## Evidence

Focused retained semantic-stream prepare benchmark on this branch:

```text
go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnRetainedPayloadSemanticStreamV1Prepare(RootFastPath|NestedDeclaredPaths)$' -benchmem -count=5
```

Candidate output saved at `/tmp/treedb_3196_semstream_prepare_bench_candidate.txt`:

```text
BenchmarkColumnRetainedPayloadSemanticStreamV1PrepareRootFastPath-8           11.05-11.39 ms/op   20,991,924-20,991,937 B/op   217,182 allocs/op
BenchmarkColumnRetainedPayloadSemanticStreamV1PrepareNestedDeclaredPaths-8   10.09-10.69 ms/op   17,741,178-17,741,184 B/op   192,607 allocs/op
```

Baseline on `origin/main` before this patch from the same local workflow:

```text
Root fast path:          ~15.17-16.10 ms/op   ~34,353,0xx B/op   368,745 allocs/op
Nested declared paths:   ~14.65-15.69 ms/op   ~32,240,9xx B/op   335,978 allocs/op
```

JSONBench 100k direct before/after, both `one_shot_end_to_end` / `no_aggregate_metadata`, `column-store-full-prepared`, `SUITE=full`, `TRIES=1`:

```text
baseline gomap 735e3e8 / JSONBench 38d2fba:
  report: /tmp/jsonbench_insert_stats_pr27_3195_100k_20260627_151426/report.md
  load: 1.873s
  insert: 1.464s
  retained prepare: 0.5117s
  storage: 16.75 MiB

candidate local gomap / JSONBench 6b962d1:
  report: /tmp/jsonbench_semstream_prepare_100k_20260627_153103/report.md
  load: 1.641s
  insert: 1.297s
  retained prepare: 0.3804s
  storage: 16.75 MiB

candidate rerun local gomap / JSONBench 6b962d1:
  report: /tmp/jsonbench_semstream_prepare_100k_rerun_20260627_153127/report.md
  load: 1.646s
  insert: 1.279s
  retained prepare: 0.3788s
  storage: 16.75 MiB
```

Larger candidate smoke, same query and metadata modes:

```text
report: /tmp/jsonbench_semstream_prepare_1m_20260627_153149/report.md
rows: 1,000,000
load: 16.131s
insert: 12.743s
retained prepare: 3.909s
storage: 131.13 MiB
qexpr: 0.0082s, scanned 1.0M cells, aggregate metadata false, JSON reconstruction false
```

## Reproduction

```sh
go test ./TreeDB/collections -count=1
go test ./cmd/unified_bench -count=1
go test ./TreeDB/collections -run 'Test.*(SemanticStream|RetainedPayload|Reconstruction).*' -count=1
go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnRetainedPayloadSemanticStreamV1Prepare(RootFastPath|NestedDeclaredPaths)$' -benchmem -count=5
git diff --check
```

JSONBench 100k candidate command:

```sh
cd /Users/michaelseiler/dev/snissn/JSONBench/treedb
OUT_DIR=/tmp/jsonbench_semstream_prepare_100k_$(date +%Y%m%d_%H%M%S) \
  DATA_DIR=/Users/michaelseiler/data/bluesky \
  ROWS=100000 TRIES=1 \
  QUERY_MODE=one_shot_end_to_end \
  METADATA_MODE=no_aggregate_metadata \
  SUITE=full \
  STORAGE_LAYOUTS=column-store-full-prepared \
  TREEDB_ALLOW_ERRORS=1 \
  GOMAP_REPLACE=/Users/michaelseiler/dev/snissn/gomap-clean \
  ./run_columnstore_benchmark.sh
```

## Validation run locally

- `go test ./TreeDB/collections -run 'Test.*(SemanticStream|RetainedPayload|Reconstruction).*' -count=1`
- `go test ./TreeDB/collections -count=1`
- `go test ./cmd/unified_bench -count=1`
- `git diff --check`
- focused benchmark above
- JSONBench 100k candidate plus rerun above
- JSONBench 1M candidate smoke above


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal data handling for semantic stream processing.
  * Optimized buffer sizing and ordering logic to reduce unnecessary allocations and make serialization more efficient.
  * Kept output behavior the same while improving processing efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->