### PR TITLE
TreeDB: reuse retained semantic-stream path stacks

### DIFF
--- a/TreeDB/collections/column_retained_semantic_stream.go
+++ b/TreeDB/collections/column_retained_semantic_stream.go
@@ -509,8 +509,10 @@ func collectColumnRetainedSemanticStreamV1RootFastPathDocument(cfg ColumnStoreCo
 		slices.SortFunc(retainedRootValues, func(a, b retainedRootValue) int {
 			return strings.Compare(a.path, b.path)
 		})
+		var pathStack [8]string
 		for _, value := range retainedRootValues {
-			if err := collectColumnRetainedSemanticStreamJSONParserPaths(value.raw, value.valueType, []string{value.path}, row, streamEntryCapacity, streams); err != nil {
+			path := append(pathStack[:0], value.path)
+			if err := collectColumnRetainedSemanticStreamJSONParserPaths(value.raw, value.valueType, path, row, streamEntryCapacity, streams); err != nil {
 				return nil, err
 			}
 		}
@@ -1288,8 +1290,14 @@ func collectColumnRetainedSemanticStreamJSONParserObjectPaths(raw []byte, path [
 	slices.SortFunc(retainedObjectValues, func(a, b retainedObjectValue) int {
 		return strings.Compare(a.path, b.path)
 	})
+	var pathStack [8]string
 	for _, value := range retainedObjectValues {
-		nextPath := append(append([]string(nil), path...), value.path)
+		var nextPath []string
+		if len(path) == 0 && cap(path) == 0 {
+			nextPath = append(pathStack[:0], value.path)
+		} else {
+			nextPath = append(path, value.path)
+		}
 		if err := collectColumnRetainedSemanticStreamJSONParserPaths(value.raw, value.valueType, nextPath, row, streamEntryCapacity, streams); err != nil {
 			return err
 		}
@@ -1353,11 +1361,17 @@ func collectColumnRetainedSemanticStreamJSONParserObjectPathsWithSkip(raw []byte
 	slices.SortFunc(retainedObjectValues, func(a, b retainedObjectValue) int {
 		return strings.Compare(a.path, b.path)
 	})
+	var pathStack [8]string
 	for _, value := range retainedObjectValues {
 		if value.deleted {
 			continue
 		}
-		nextPath := append(append([]string(nil), path...), value.path)
+		var nextPath []string
+		if len(path) == 0 && cap(path) == 0 {
+			nextPath = append(pathStack[:0], value.path)
+		} else {
+			nextPath = append(path, value.path)
+		}
 		if value.skip != nil {
 			if err := collectColumnRetainedSemanticStreamJSONParserObjectPathsWithSkip(value.raw, nextPath, row, streamEntryCapacity, value.skip, streams); err != nil {
 				return err
@@ -1383,8 +1397,14 @@ func collectColumnRetainedSemanticStreamObjectPaths(obj map[string]any, path []s
 		keys = append(keys, key)
 	}
 	sort.Strings(keys)
+	var pathStack [8]string
 	for _, key := range keys {
-		nextPath := append(append([]string(nil), path...), key)
+		var nextPath []string
+		if len(path) == 0 && cap(path) == 0 {
+			nextPath = append(pathStack[:0], key)
+		} else {
+			nextPath = append(path, key)
+		}
 		if err := collectColumnRetainedSemanticStreamAnyPaths(obj[key], nextPath, row, streams); err != nil {
 			return err
 		}


### PR DESCRIPTION
Closes #3200.

Links: #3099, #3067, #3000, #3001, predecessor #3198/#3199.

## Scope

This is a narrow TreeDB JSONBench production-shape load-path slice. It reduces retained semantic-stream preparation allocations by reusing recursive path stacks while collecting retained payload semantic-stream values.

It improves insert/load preparation CPU/allocation behavior only. It does not claim broad TreeDB SQL superiority, ClickHouse superiority, one-shot query execution speedup, no-aggregate scan speedup, hot prepared query speedup, arbitrary-expression scan speedup, or metadata acceleration wins.

## What changed

- Reuse a small stack-backed path buffer in retained semantic-stream root fast-path collection.
- Reuse stack-backed path buffers in nested jsonparser retained-path collectors, including skip-aware collection.
- Apply the same allocation pattern to the legacy object-path collector.
- Leave stored block format, JSON raw value wrapping, zstd behavior, persistent value-log semantics, and WAL-excluded storage accounting unchanged.

## Evidence

Focused benchmark, candidate vs `origin/main` (`f7221b889`, post-#3199):

```text
BenchmarkColumnRetainedPayloadSemanticStreamV1PrepareRootFastPath-11        10.185ms -> 8.266ms   -18.84%
BenchmarkColumnRetainedPayloadSemanticStreamV1PrepareRootFastPath-11        18.71MiB -> 15.52MiB -17.04%
BenchmarkColumnRetainedPayloadSemanticStreamV1PrepareRootFastPath-11        176.3k -> 102.5k allocs/op -41.83%

BenchmarkColumnRetainedPayloadSemanticStreamV1PrepareNestedDeclaredPaths-11 9.385ms -> 7.770ms   -17.21%
BenchmarkColumnRetainedPayloadSemanticStreamV1PrepareNestedDeclaredPaths-11 15.67MiB -> 12.61MiB -19.54%
BenchmarkColumnRetainedPayloadSemanticStreamV1PrepareNestedDeclaredPaths-11 155.8k -> 86.1k allocs/op -44.70%

geomean: -18.03% sec/op, -18.30% B/op, -43.28% allocs/op
```

Artifacts:

- Baseline benchmark: `/tmp/treedb_3200_baseline_bench.txt`
- Candidate benchmark: `/tmp/treedb_3200_candidate_bench_final.txt`
- Final CPU profile: `/tmp/treedb_3200_semstream_path_stack_final_cpu.pprof`
- Final memory profile: `/tmp/treedb_3200_semstream_path_stack_final_mem.pprof`

Final allocation profile moved the old path-stack clone out of the top allocation sources. Remaining allocation pressure is now dominated by `columnRetainedSemanticStreamV1JSONParserRawValue`, jsonparser callback/string conversion paths, and locator encoding.

## JSONBench context

Same-wrapper 100k JSONBench context remained noisy at end-to-end scale and did not show a stable external load-time movement for this small slice. Storage was unchanged.

Baseline context:

- Result: `/tmp/jsonbench_semstream_path_stack_baseline_100k_20260627_163545/rows100000_column-store-full-prepared_one_shot_end_to_end_no_aggregate_metadata_json_full_all/result.json`
- Load wall time: `1.776469041s`
- Insert time: `1.398436459s`
- Retained prepare time: `0.477106374s`
- WAL-excluded durable storage: `17568206` bytes

Final isolated candidate context:

- Report: `/tmp/jsonbench_semstream_path_stack_final_isolated_100k_20260627_164044/report.md`
- Result: `/tmp/jsonbench_semstream_path_stack_final_isolated_100k_20260627_164044/rows100000_column-store-full-prepared_one_shot_end_to_end_no_aggregate_metadata_json_full_all/result.json`
- Load wall time: `1.814887084s`
- Insert time: `1.436327457s`
- Retained prepare time: `0.497446709s`
- WAL-excluded durable storage: `17568206` bytes
- Query mode: `one_shot_end_to_end`
- Metadata mode: `no_aggregate_metadata`

The focused retained semantic-stream preparation benchmark is the pass/fail evidence for this PR. Larger blockers for user-visible load time remain durable sync/asset close and compression/write-side costs tracked separately, including #3151.

## Validation

```text
go test ./TreeDB/collections -run 'Test.*(RetainedPayload|SemanticStream|Reconstruction).*' -count=1
go test ./TreeDB/collections -count=1
go test ./cmd/unified_bench -count=1
git diff --check
go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnRetainedPayloadSemanticStreamV1Prepare(RootFastPath|NestedDeclaredPaths)$' -benchmem -count=1
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved how path traversal is handled internally to reduce temporary allocations.
  * This may result in faster semantic stream collection and lower memory usage during nested data processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->