### PR TITLE
TreeDB: reuse retained semantic-stream string tokens

### DIFF
--- a/TreeDB/collections/column_retained_semantic_stream.go
+++ b/TreeDB/collections/column_retained_semantic_stream.go
@@ -478,7 +478,7 @@ func collectColumnRetainedSemanticStreamV1RootFastPathDocument(cfg ColumnStoreCo
 	}
 	var retainedRootValueStack [8]retainedRootValue
 	retainedRootValues := retainedRootValueStack[:0]
-	err := jsonparser.ObjectEach(document, func(key, value []byte, dataType jsonparser.ValueType, _ int) error {
+	err := jsonparser.ObjectEach(document, func(key, value []byte, dataType jsonparser.ValueType, valueEndOffset int) error {
 		path := string(key)
 		if indexes := plan.declaredColumnIndexesByPath[path]; len(indexes) > 0 {
 			if plan.declaredRowsReady {
@@ -488,7 +488,7 @@ func collectColumnRetainedSemanticStreamV1RootFastPathDocument(cfg ColumnStoreCo
 			}
 			return nil
 		}
-		raw, err := columnRetainedSemanticStreamV1JSONParserRawValue(value, dataType)
+		raw, err := columnRetainedSemanticStreamV1JSONParserRawValue(document, value, dataType, valueEndOffset)
 		if err != nil {
 			return err
 		}
@@ -532,9 +532,12 @@ func collectColumnRetainedSemanticStreamV1RootFastPathDocument(cfg ColumnStoreCo
 	return values, nil
 }
 
-func columnRetainedSemanticStreamV1JSONParserRawValue(value []byte, dataType jsonparser.ValueType) ([]byte, error) {
+func columnRetainedSemanticStreamV1JSONParserRawValue(source []byte, value []byte, dataType jsonparser.ValueType, valueEndOffset int) ([]byte, error) {
 	switch dataType {
 	case jsonparser.String:
+		if raw, ok := columnRetainedSemanticStreamV1JSONParserQuotedString(source, value, valueEndOffset); ok {
+			return raw, nil
+		}
 		out := make([]byte, 0, len(value)+2)
 		out = append(out, '"')
 		out = append(out, value...)
@@ -545,6 +548,17 @@ func columnRetainedSemanticStreamV1JSONParserRawValue(value []byte, dataType jso
 	default:
 		return nil, fmt.Errorf("unsupported semantic-stream-v1 retained value type %s", dataType)
 	}
+}
+
+func columnRetainedSemanticStreamV1JSONParserQuotedString(source []byte, value []byte, valueEndOffset int) ([]byte, bool) {
+	valueStartOffset := valueEndOffset - len(value) - 2
+	if valueStartOffset < 0 || valueEndOffset > len(source) || valueStartOffset >= valueEndOffset {
+		return nil, false
+	}
+	if source[valueStartOffset] != '"' || source[valueEndOffset-1] != '"' {
+		return nil, false
+	}
+	return source[valueStartOffset:valueEndOffset], true
 }
 
 func encodeColumnRetainedSemanticStreamV1Locator(blockKey []byte, row uint64) []byte {
@@ -1260,8 +1274,8 @@ func collectColumnRetainedSemanticStreamJSONParserObjectPaths(raw []byte, path [
 	}
 	var retainedObjectValueStack [8]retainedObjectValue
 	retainedObjectValues := retainedObjectValueStack[:0]
-	if err := jsonparser.ObjectEach(raw, func(key, value []byte, dataType jsonparser.ValueType, _ int) error {
-		valueRaw, err := columnRetainedSemanticStreamV1JSONParserRawValue(value, dataType)
+	if err := jsonparser.ObjectEach(raw, func(key, value []byte, dataType jsonparser.ValueType, valueEndOffset int) error {
+		valueRaw, err := columnRetainedSemanticStreamV1JSONParserRawValue(raw, value, dataType, valueEndOffset)
 		if err != nil {
 			return err
 		}
@@ -1315,7 +1329,7 @@ func collectColumnRetainedSemanticStreamJSONParserObjectPathsWithSkip(raw []byte
 	}
 	var retainedObjectValueStack [8]retainedObjectValue
 	retainedObjectValues := retainedObjectValueStack[:0]
-	if err := jsonparser.ObjectEach(raw, func(key, value []byte, dataType jsonparser.ValueType, _ int) error {
+	if err := jsonparser.ObjectEach(raw, func(key, value []byte, dataType jsonparser.ValueType, valueEndOffset int) error {
 		valuePath := string(key)
 		var childSkip *columnRetainedSemanticStreamV1RetainedSkipTrie
 		if skip != nil {
@@ -1325,7 +1339,7 @@ func collectColumnRetainedSemanticStreamJSONParserObjectPathsWithSkip(raw []byte
 		if childSkip != nil && childSkip.terminal {
 			nextValue.deleted = true
 		} else {
-			valueRaw, err := columnRetainedSemanticStreamV1JSONParserRawValue(value, dataType)
+			valueRaw, err := columnRetainedSemanticStreamV1JSONParserRawValue(raw, value, dataType, valueEndOffset)
 			if err != nil {
 				return err
 			}

--- a/TreeDB/collections/column_retained_semantic_stream_raw_test.go
+++ b/TreeDB/collections/column_retained_semantic_stream_raw_test.go
@@ -1,0 +1,85 @@
+package collections
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/buger/jsonparser"
+)
+
+func TestColumnRetainedSemanticStreamV1JSONParserRawValueUsesQuotedSource3202(t *testing.T) {
+	document := []byte(`{"plain":"value","escaped":"a\"b\\c","empty":"","num":17}`)
+	got := make(map[string][]byte)
+	if err := jsonparser.ObjectEach(document, func(key, value []byte, dataType jsonparser.ValueType, valueEndOffset int) error {
+		raw, err := columnRetainedSemanticStreamV1JSONParserRawValue(document, value, dataType, valueEndOffset)
+		if err != nil {
+			return err
+		}
+		got[string(key)] = raw
+		return nil
+	}); err != nil {
+		t.Fatalf("ObjectEach: %v", err)
+	}
+
+	for key, want := range map[string]string{
+		"plain":   `"value"`,
+		"escaped": `"a\"b\\c"`,
+		"empty":   `""`,
+		"num":     `17`,
+	} {
+		raw := got[key]
+		if string(raw) != want {
+			t.Fatalf("%s raw=%q want %q", key, raw, want)
+		}
+		start := bytes.Index(document, []byte(want))
+		if start < 0 {
+			t.Fatalf("%s token %q not found in document", key, want)
+		}
+		if len(raw) > 0 && &raw[0] != &document[start] {
+			t.Fatalf("%s raw value does not alias source token", key)
+		}
+	}
+}
+
+func TestColumnRetainedSemanticStreamV1JSONParserRawValueUsesNestedQuotedSource3202(t *testing.T) {
+	document := []byte(`{"outer":{"nested":"value"}}`)
+	object, dataType, _, err := jsonparser.Get(document, "outer")
+	if err != nil {
+		t.Fatalf("Get outer: %v", err)
+	}
+	if dataType != jsonparser.Object {
+		t.Fatalf("outer type=%s want object", dataType)
+	}
+
+	var raw []byte
+	if err := jsonparser.ObjectEach(object, func(key, value []byte, dataType jsonparser.ValueType, valueEndOffset int) error {
+		if string(key) != "nested" {
+			return nil
+		}
+		var err error
+		raw, err = columnRetainedSemanticStreamV1JSONParserRawValue(object, value, dataType, valueEndOffset)
+		return err
+	}); err != nil {
+		t.Fatalf("ObjectEach nested: %v", err)
+	}
+	if string(raw) != `"value"` {
+		t.Fatalf("nested raw=%q want quoted value", raw)
+	}
+	start := bytes.Index(object, []byte(`"value"`))
+	if start < 0 {
+		t.Fatalf("nested token not found in object")
+	}
+	if len(raw) > 0 && &raw[0] != &object[start] {
+		t.Fatalf("nested raw value does not alias object token")
+	}
+}
+
+func TestColumnRetainedSemanticStreamV1JSONParserRawValueFallsBackOnInvalidStringOffset3202(t *testing.T) {
+	raw, err := columnRetainedSemanticStreamV1JSONParserRawValue([]byte(`{"s":"value"}`), []byte("value"), jsonparser.String, 0)
+	if err != nil {
+		t.Fatalf("raw value fallback: %v", err)
+	}
+	if string(raw) != `"value"` {
+		t.Fatalf("fallback raw=%q want quoted value", raw)
+	}
+}


### PR DESCRIPTION
## Summary

- Reuse validated quoted string tokens from the jsonparser source buffer when preparing retained semantic-stream raw values.
- Preserve the existing allocation fallback when the callback offset cannot be validated.
- Add regression coverage for top-level, nested object, escaped string, empty string, numeric, and invalid-offset fallback cases.

Closes #3202.
Refs #3099, #3067, #3000, #3001, #3200, #3201.

## Scope and claim boundary

This is an insert/load-path slice for retained semantic-stream preparation. It reduces allocation pressure while preserving the stored raw value bytes. It does not add or claim one-shot SQL execution evidence, no-aggregate-metadata scan evidence, arbitrary-expression scan evidence, metadata-cost accounting, or broad SQL superiority versus ClickHouse.

Impact classification:

- Insert/load: yes, through retained semantic-stream preparation allocation reduction.
- One-shot query execution: no direct evidence in this PR.
- Hot prepared query execution: no direct evidence in this PR.
- Metadata storage/query acceleration: unchanged.
- General typed-column scan performance: unchanged.
- Stored block format/value log/on-disk format: unchanged.

## Performance evidence

Baseline: detached `origin/main` at #3201 merge `2dd868e0b`.
Candidate: this branch at `c67d2c450`.

Command:

```sh
go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnRetainedPayloadSemanticStreamV1Prepare(RootFastPath|NestedDeclaredPaths)$' -benchmem -count=5
benchstat /tmp/treedb_3202_baseline_bench.txt /tmp/treedb_3202_candidate_bench.txt
```

Artifacts:

- `/tmp/treedb_3202_baseline_bench.txt`
- `/tmp/treedb_3202_candidate_bench.txt`
- `/tmp/treedb_3202_semstream_string_raw_profile_bench.txt`
- `/tmp/treedb_3202_semstream_string_raw_mem.pprof`

Result:

```text
RootFastPath sec/op:             8.280ms -> 8.134ms, ~ p=0.421 n=5
NestedDeclaredPaths sec/op:      7.684ms -> 7.428ms, ~ p=0.151 n=5
geomean sec/op:                  -2.54%

RootFastPath B/op:               15.52MiB -> 14.68MiB, -5.43% p=0.008 n=5
NestedDeclaredPaths B/op:        12.61MiB -> 11.83MiB, -6.20% p=0.008 n=5
geomean B/op:                    -5.82%

RootFastPath allocs/op:          102.53k -> 69.76k, -31.96% p=0.008 n=5
NestedDeclaredPaths allocs/op:    86.14k -> 57.47k, -33.29% p=0.008 n=5
geomean allocs/op:               -32.63%
```

Allocation profile gate:

```sh
go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnRetainedPayloadSemanticStreamV1Prepare(RootFastPath|NestedDeclaredPaths)$' -benchmem -count=1 -memprofile /tmp/treedb_3202_semstream_string_raw_mem.pprof

go tool pprof -top -alloc_objects /tmp/treedb_3202_semstream_string_raw_mem.pprof
```

`columnRetainedSemanticStreamV1JSONParserRawValue` no longer appears in the alloc_objects top table after this change. The leading buckets are now retained path callbacks and locator encoding.

## Validation

```sh
go test ./TreeDB/collections -run 'TestColumnRetainedSemanticStreamV1JSONParserRawValue|Test.*(RetainedPayload|SemanticStream|Reconstruction).*' -count=1
go test ./TreeDB/collections -count=1
go test ./cmd/unified_bench -count=1
git diff --check
```
