### PR TITLE
TreeDB: avoid transient semantic-stream path lookup allocations

### DIFF
--- a/TreeDB/collections/column_retained_semantic_stream.go
+++ b/TreeDB/collections/column_retained_semantic_stream.go
@@ -11,6 +11,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"unsafe"
 
 	"github.com/buger/jsonparser"
 	"github.com/golang/snappy"
@@ -479,8 +480,8 @@ func collectColumnRetainedSemanticStreamV1RootFastPathDocument(cfg ColumnStoreCo
 	var retainedRootValueStack [8]retainedRootValue
 	retainedRootValues := retainedRootValueStack[:0]
 	err := jsonparser.ObjectEach(document, func(key, value []byte, dataType jsonparser.ValueType, valueEndOffset int) error {
-		path := string(key)
-		if indexes := plan.declaredColumnIndexesByPath[path]; len(indexes) > 0 {
+		lookupPath := columnRetainedSemanticStreamV1LookupString(key)
+		if indexes := plan.declaredColumnIndexesByPath[lookupPath]; len(indexes) > 0 {
 			if plan.declaredRowsReady {
 				for _, colIdx := range indexes {
 					valuesRaw[colIdx] = jsonParserIndexValue{raw: value, valueType: dataType}
@@ -488,6 +489,7 @@ func collectColumnRetainedSemanticStreamV1RootFastPathDocument(cfg ColumnStoreCo
 			}
 			return nil
 		}
+		path := string(key)
 		raw, err := columnRetainedSemanticStreamV1JSONParserRawValue(document, value, dataType, valueEndOffset)
 		if err != nil {
 			return err
@@ -559,6 +561,14 @@ func columnRetainedSemanticStreamV1JSONParserQuotedString(source []byte, value [
 		return nil, false
 	}
 	return source[valueStartOffset:valueEndOffset], true
+}
+
+func columnRetainedSemanticStreamV1LookupString(value []byte) string {
+	if len(value) == 0 {
+		return ""
+	}
+	// Borrow only for immediate map lookups; callers must not retain the string.
+	return unsafe.String(unsafe.SliceData(value), len(value))
 }
 
 func encodeColumnRetainedSemanticStreamV1Locator(blockKey []byte, row uint64) []byte {
@@ -1325,29 +1335,28 @@ func collectColumnRetainedSemanticStreamJSONParserObjectPathsWithSkip(raw []byte
 		raw       []byte
 		valueType jsonparser.ValueType
 		skip      *columnRetainedSemanticStreamV1RetainedSkipTrie
-		deleted   bool
 	}
 	var retainedObjectValueStack [8]retainedObjectValue
 	retainedObjectValues := retainedObjectValueStack[:0]
 	if err := jsonparser.ObjectEach(raw, func(key, value []byte, dataType jsonparser.ValueType, valueEndOffset int) error {
-		valuePath := string(key)
+		lookupPath := columnRetainedSemanticStreamV1LookupString(key)
 		var childSkip *columnRetainedSemanticStreamV1RetainedSkipTrie
 		if skip != nil {
-			childSkip = skip.children[valuePath]
+			childSkip = skip.children[lookupPath]
 		}
-		nextValue := retainedObjectValue{path: valuePath}
 		if childSkip != nil && childSkip.terminal {
-			nextValue.deleted = true
-		} else {
-			valueRaw, err := columnRetainedSemanticStreamV1JSONParserRawValue(raw, value, dataType, valueEndOffset)
-			if err != nil {
-				return err
-			}
-			nextValue.raw = valueRaw
-			nextValue.valueType = dataType
-			if childSkip != nil && len(childSkip.children) > 0 && dataType == jsonparser.Object {
-				nextValue.skip = childSkip
-			}
+			return nil
+		}
+		valuePath := string(key)
+		nextValue := retainedObjectValue{path: valuePath}
+		valueRaw, err := columnRetainedSemanticStreamV1JSONParserRawValue(raw, value, dataType, valueEndOffset)
+		if err != nil {
+			return err
+		}
+		nextValue.raw = valueRaw
+		nextValue.valueType = dataType
+		if childSkip != nil && len(childSkip.children) > 0 && dataType == jsonparser.Object {
+			nextValue.skip = childSkip
 		}
 		for i := range retainedObjectValues {
 			if retainedObjectValues[i].path == valuePath {
@@ -1360,13 +1369,7 @@ func collectColumnRetainedSemanticStreamJSONParserObjectPathsWithSkip(raw []byte
 	}); err != nil {
 		return err
 	}
-	retainedCount := 0
-	for _, value := range retainedObjectValues {
-		if !value.deleted {
-			retainedCount++
-		}
-	}
-	if retainedCount == 0 {
+	if len(retainedObjectValues) == 0 {
 		if len(path) > 0 {
 			appendColumnRetainedSemanticStreamValueNoCopy(path, row, []byte("{}"), streamEntryCapacity, streams)
 		}
@@ -1377,9 +1380,6 @@ func collectColumnRetainedSemanticStreamJSONParserObjectPathsWithSkip(raw []byte
 	})
 	var pathStack [8]string
 	for _, value := range retainedObjectValues {
-		if value.deleted {
-			continue
-		}
 		var nextPath []string
 		if len(path) == 0 && cap(path) == 0 {
 			nextPath = append(pathStack[:0], value.path)

--- a/TreeDB/collections/column_retained_semantic_stream.go
+++ b/TreeDB/collections/column_retained_semantic_stream.go
@@ -11,7 +11,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"unsafe"
 
 	"github.com/buger/jsonparser"
 	"github.com/golang/snappy"
@@ -480,8 +479,7 @@ func collectColumnRetainedSemanticStreamV1RootFastPathDocument(cfg ColumnStoreCo
 	var retainedRootValueStack [8]retainedRootValue
 	retainedRootValues := retainedRootValueStack[:0]
 	err := jsonparser.ObjectEach(document, func(key, value []byte, dataType jsonparser.ValueType, valueEndOffset int) error {
-		lookupPath := columnRetainedSemanticStreamV1LookupString(key)
-		if indexes := plan.declaredColumnIndexesByPath[lookupPath]; len(indexes) > 0 {
+		if indexes := plan.declaredColumnIndexesByPath[string(key)]; len(indexes) > 0 {
 			if plan.declaredRowsReady {
 				for _, colIdx := range indexes {
 					valuesRaw[colIdx] = jsonParserIndexValue{raw: value, valueType: dataType}
@@ -561,14 +559,6 @@ func columnRetainedSemanticStreamV1JSONParserQuotedString(source []byte, value [
 		return nil, false
 	}
 	return source[valueStartOffset:valueEndOffset], true
-}
-
-func columnRetainedSemanticStreamV1LookupString(value []byte) string {
-	if len(value) == 0 {
-		return ""
-	}
-	// Borrow only for immediate map lookups; callers must not retain the string.
-	return unsafe.String(unsafe.SliceData(value), len(value))
 }
 
 func encodeColumnRetainedSemanticStreamV1Locator(blockKey []byte, row uint64) []byte {
@@ -1339,10 +1329,9 @@ func collectColumnRetainedSemanticStreamJSONParserObjectPathsWithSkip(raw []byte
 	var retainedObjectValueStack [8]retainedObjectValue
 	retainedObjectValues := retainedObjectValueStack[:0]
 	if err := jsonparser.ObjectEach(raw, func(key, value []byte, dataType jsonparser.ValueType, valueEndOffset int) error {
-		lookupPath := columnRetainedSemanticStreamV1LookupString(key)
 		var childSkip *columnRetainedSemanticStreamV1RetainedSkipTrie
 		if skip != nil {
-			childSkip = skip.children[lookupPath]
+			childSkip = skip.children[string(key)]
 		}
 		if childSkip != nil && childSkip.terminal {
 			return nil

--- a/TreeDB/collections/column_retained_semantic_stream_raw_test.go
+++ b/TreeDB/collections/column_retained_semantic_stream_raw_test.go
@@ -3,6 +3,7 @@ package collections
 import (
 	"bytes"
 	"testing"
+	"unsafe"
 
 	"github.com/buger/jsonparser"
 )
@@ -82,4 +83,68 @@ func TestColumnRetainedSemanticStreamV1JSONParserRawValueFallsBackOnInvalidStrin
 	if string(raw) != `"value"` {
 		t.Fatalf("fallback raw=%q want quoted value", raw)
 	}
+}
+
+func TestColumnRetainedSemanticStreamV1LookupStringDoesNotEscapeRetainedPaths3204(t *testing.T) {
+	cfg := ColumnStoreConfig{
+		Enabled: true,
+		Columns: []ColumnStoreColumn{
+			{Name: "declared", Path: "declared", ValueType: ColumnStoreValueInt64},
+		},
+		RetainedPayload:         ColumnRetainedPayloadNonColumn,
+		RetainedPayloadEncoding: ColumnRetainedPayloadEncodingSemanticStreamV1,
+		Reconstruction:          ColumnReconstructionRetainedPayloadAndColumns,
+	}
+	ids := [][]byte{[]byte("doc-0")}
+	plan, ok := columnRetainedSemanticStreamV1RootFastPathPlanForConfig(cfg, ids, 1)
+	if !ok {
+		t.Fatal("root fast path plan not available")
+	}
+	document := []byte(`{"declared":7,"retained":2,"":3}`)
+	streams := newColumnRetainedSemanticStreamStreams()
+	values, err := collectColumnRetainedSemanticStreamV1RootFastPathDocument(cfg, plan, document, 0, 1, streams)
+	if err != nil {
+		t.Fatalf("collect root fast path document: %v", err)
+	}
+	if len(values) != 1 || values[0].Int64 != 7 {
+		t.Fatalf("declared values=%+v want declared int64 7", values)
+	}
+	if stream := streams.byKey[columnRetainedSemanticStreamPathKey([]string{"declared"})]; stream != nil {
+		t.Fatalf("declared key leaked into retained streams: %+v", stream.segments)
+	}
+	retainedStream := streams.byKey[columnRetainedSemanticStreamPathKey([]string{"retained"})]
+	if retainedStream == nil {
+		t.Fatal("retained key missing from retained streams")
+	}
+	emptyKeyStream := streams.byKey[columnRetainedSemanticStreamPathKey([]string{""})]
+	if emptyKeyStream == nil {
+		t.Fatal("empty JSON key missing from retained streams")
+	}
+	if got := retainedStream.segments; len(got) != 1 || got[0] != "retained" {
+		t.Fatalf("retained stream segments=%q want [retained]", got)
+	}
+	if got := emptyKeyStream.segments; len(got) != 1 || got[0] != "" {
+		t.Fatalf("empty-key stream segments=%q want empty segment", got)
+	}
+	if columnRetainedSemanticStreamV1TestStringAliasesBytes(retainedStream.segments[0], document) {
+		t.Fatal("retained path segment aliases mutable JSON source")
+	}
+
+	start := bytes.Index(document, []byte(`"retained"`))
+	if start < 0 {
+		t.Fatal("retained key not found in source document")
+	}
+	copy(document[start+1:], []byte("mutained"))
+	if got := retainedStream.segments[0]; got != "retained" {
+		t.Fatalf("retained path changed after source mutation: %q", got)
+	}
+}
+
+func columnRetainedSemanticStreamV1TestStringAliasesBytes(value string, source []byte) bool {
+	if len(value) == 0 || len(source) == 0 {
+		return false
+	}
+	valuePtr := uintptr(unsafe.Pointer(unsafe.StringData(value)))
+	sourcePtr := uintptr(unsafe.Pointer(unsafe.SliceData(source)))
+	return valuePtr >= sourcePtr && valuePtr < sourcePtr+uintptr(len(source))
 }

--- a/TreeDB/collections/typed_storage_naming_test.go
+++ b/TreeDB/collections/typed_storage_naming_test.go
@@ -386,6 +386,7 @@ var typedStorageLegacyNameAllowlist = []typedStorageLegacyNameAllowlistEntry{
 	{path: "TreeDB/collections/column_retained_payload_audit.go", classification: typedStorageLegacyCompatibility, matchingLines: 8, occurrences: 8},
 	{path: "TreeDB/collections/column_retained_payload_audit_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 29, occurrences: 30},
 	{path: "TreeDB/collections/column_retained_semantic_stream.go", classification: typedStorageLegacyCompatibility, matchingLines: 14, occurrences: 14},
+	{path: "TreeDB/collections/column_retained_semantic_stream_raw_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 3, occurrences: 3},
 	{path: "TreeDB/collections/column_retained_vlog_placement_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 45, occurrences: 45},
 	{path: "TreeDB/collections/column_semantics.go", classification: typedStorageLegacyCompatibility, matchingLines: 34, occurrences: 34},
 	{path: "TreeDB/collections/dense_numeric_vector.go", classification: typedStorageLegacyCompatibility, matchingLines: 32, occurrences: 41},


### PR DESCRIPTION
## Summary

- Use direct `map[string(key)]` lookups for transient semantic-stream JSON key checks so declared-column and skip-trie probes do not allocate retained path strings on hits.
- Keep owned `string(key)` conversion only for retained path segments that outlive the jsonparser callback.
- Return early for terminal skipped nested retained keys so skipped declared fields do not allocate retained path entries.
- Add regression coverage for declared root lookup, retained path ownership, empty JSON keys, and source-buffer mutation after collection.
- Update the typed-storage legacy-name allowlist for the new focused test file.

Closes #3204.
Refs #3099, #3067, #3000, #3001, #3202, #3203.

## Scope and claim boundary

This is an insert/load preparation slice for retained semantic-stream allocation pressure. It does not change stored block format, value-log format, query semantics, one-shot SQL execution, hot prepared query execution, metadata behavior, or typed-column scan execution.

Impact classification:

- Insert/load: yes, through retained semantic-stream preparation allocation reduction.
- One-shot query execution: no direct evidence in this PR.
- Hot prepared query execution: no direct evidence in this PR.
- Metadata storage/query acceleration: unchanged.
- General typed-column scan performance: unchanged.
- Stored block format/value log/on-disk format: unchanged.

## Performance evidence

Baseline: detached `origin/main` at #3203 merge `507130d4a`.
Candidate: this branch at `a15fb49f8`.

Command:

```sh
go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnRetainedPayloadSemanticStreamV1Prepare(RootFastPath|NestedDeclaredPaths)$' -benchmem -count=5
benchstat /tmp/treedb_3204_baseline_bench.txt /tmp/treedb_3204_candidate_direct_lookup_bench.txt
```

Artifacts:

- `/tmp/treedb_3204_baseline_bench.txt`
- `/tmp/treedb_3204_candidate_direct_lookup_bench.txt`
- `/tmp/treedb_3204_direct_lookup_final_profile_bench.txt`
- `/tmp/treedb_3204_direct_lookup_final_mem.pprof`

Result:

```text
RootFastPath sec/op:             8.134ms -> 8.573ms, ~ p=0.056 n=5
NestedDeclaredPaths sec/op:      7.367ms -> 7.561ms, ~ p=1.000 n=5
geomean sec/op:                  +4.01%

RootFastPath B/op:               14.68MiB -> 14.65MiB, -0.21% p=0.008 n=5
NestedDeclaredPaths B/op:        11.83MiB -> 11.76MiB, -0.53% p=0.008 n=5
geomean B/op:                    -0.37%

RootFastPath allocs/op:          69.76k -> 61.56k, -11.74% p=0.008 n=5
NestedDeclaredPaths allocs/op:   57.47k -> 45.18k, -21.38% p=0.008 n=5
geomean allocs/op:               -16.70%
```

This PR is therefore carried as an allocation-pressure/load-path slice. The timing sample is noisy and is not claimed as a query or broad throughput win.

Final candidate allocation profile:

```sh
go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnRetainedPayloadSemanticStreamV1Prepare(RootFastPath|NestedDeclaredPaths)$' -benchmem -count=1 -memprofile /tmp/treedb_3204_direct_lookup_final_mem.pprof

go tool pprof -top -alloc_objects /tmp/treedb_3204_direct_lookup_final_mem.pprof
```

Top remaining alloc_objects buckets are retained object path callbacks, locator encoding, bytes.Clone, and the root callback. These are candidates for later slices.

## Review resolution

CodeRabbit's unsafe-helper finding was addressed in follow-up commit `a15fb49f8`: the helper and production `unsafe` import were removed, and the two transient lookups now use direct `map[string(key)]` indexing.

## Validation

```sh
go test ./TreeDB/collections -run 'TestColumnRetainedSemanticStreamV1|Test.*(RetainedPayload|SemanticStream|Reconstruction).*' -count=1
go test ./TreeDB/collections -count=1
go test ./cmd/unified_bench -count=1
git diff --check
```
