### PR TITLE
TreeDB: intern semantic stream path segments

### DIFF
--- a/TreeDB/collections/column_retained_semantic_stream.go
+++ b/TreeDB/collections/column_retained_semantic_stream.go
@@ -118,6 +118,25 @@ type columnRetainedSemanticStreamV1RetainedSkipTrie struct {
 	children map[string]*columnRetainedSemanticStreamV1RetainedSkipTrie
 }
 
+type columnRetainedSemanticStreamV1PathSegmentInterner struct {
+	segments map[string]string
+}
+
+func (i *columnRetainedSemanticStreamV1PathSegmentInterner) intern(key []byte) string {
+	if i == nil {
+		return string(key)
+	}
+	if value, ok := i.segments[string(key)]; ok {
+		return value
+	}
+	value := string(key)
+	if i.segments == nil {
+		i.segments = make(map[string]string)
+	}
+	i.segments[value] = value
+	return value
+}
+
 type columnRetainedSemanticStreamV1DecodeCache struct {
 	blocks        map[string]*columnRetainedSemanticStreamV1DecodedBlock
 	order         []string
@@ -380,9 +399,10 @@ func prepareColumnRetainedSemanticStreamV1StorageDocumentsWithIDs(cfg ColumnStor
 		}
 		rows := end - start
 		streams := newColumnRetainedSemanticStreamStreams()
+		pathInterner := &columnRetainedSemanticStreamV1PathSegmentInterner{}
 		for row, i := 0, start; i < end; row, i = row+1, i+1 {
 			if useRootFastPath {
-				declaredValues, err := collectColumnRetainedSemanticStreamV1RootFastPathDocument(cfg, rootPlan, documents[i], uint64(row), rows, streams)
+				declaredValues, err := collectColumnRetainedSemanticStreamV1RootFastPathDocument(cfg, rootPlan, documents[i], uint64(row), rows, streams, pathInterner)
 				if err != nil {
 					resetCollectionRunTable(blockTable)
 					return columnRetainedPayloadStorageDocuments{}, fmt.Errorf("collections: semantic-stream-v1 retained row %d: %w", row, err)
@@ -394,7 +414,7 @@ func prepareColumnRetainedSemanticStreamV1StorageDocumentsWithIDs(cfg ColumnStor
 					}
 				}
 			} else {
-				if err := collectColumnRetainedSemanticStreamV1RetainedJSONParserDocument(cfg, retainedSkipTrie, documents[i], uint64(row), rows, streams); err != nil {
+				if err := collectColumnRetainedSemanticStreamV1RetainedJSONParserDocument(cfg, retainedSkipTrie, documents[i], uint64(row), rows, streams, pathInterner); err != nil {
 					resetCollectionRunTable(blockTable)
 					return columnRetainedPayloadStorageDocuments{}, fmt.Errorf("collections: semantic-stream-v1 retained row %d: %w", row, err)
 				}
@@ -457,7 +477,7 @@ func columnRetainedSemanticStreamV1RetainedSkipTrieForConfig(cfg ColumnStoreConf
 	return root
 }
 
-func collectColumnRetainedSemanticStreamV1RootFastPathDocument(cfg ColumnStoreConfig, plan columnRetainedSemanticStreamV1RootFastPathPlan, document []byte, row uint64, streamEntryCapacity int, streams *columnRetainedSemanticStreamStreams) ([]columnDeclaredValue, error) {
+func collectColumnRetainedSemanticStreamV1RootFastPathDocument(cfg ColumnStoreConfig, plan columnRetainedSemanticStreamV1RootFastPathPlan, document []byte, row uint64, streamEntryCapacity int, streams *columnRetainedSemanticStreamStreams, pathInterner *columnRetainedSemanticStreamV1PathSegmentInterner) ([]columnDeclaredValue, error) {
 	if !gjson.ValidBytes(document) {
 		return nil, errors.New("invalid JSON: invalid JSON")
 	}
@@ -487,7 +507,7 @@ func collectColumnRetainedSemanticStreamV1RootFastPathDocument(cfg ColumnStoreCo
 			}
 			return nil
 		}
-		path := string(key)
+		path := pathInterner.intern(key)
 		raw, err := columnRetainedSemanticStreamV1JSONParserRawValue(document, value, dataType, valueEndOffset)
 		if err != nil {
 			return err
@@ -512,7 +532,7 @@ func collectColumnRetainedSemanticStreamV1RootFastPathDocument(cfg ColumnStoreCo
 		var pathStack [8]string
 		for _, value := range retainedRootValues {
 			path := append(pathStack[:0], value.path)
-			if err := collectColumnRetainedSemanticStreamJSONParserPaths(value.raw, value.valueType, path, row, streamEntryCapacity, streams); err != nil {
+			if err := collectColumnRetainedSemanticStreamJSONParserPaths(value.raw, value.valueType, path, row, streamEntryCapacity, streams, pathInterner); err != nil {
 				return nil, err
 			}
 		}
@@ -1238,7 +1258,7 @@ func collectColumnRetainedSemanticStreamPaths(raw json.RawMessage, path []string
 	return nil
 }
 
-func collectColumnRetainedSemanticStreamV1RetainedJSONParserDocument(cfg ColumnStoreConfig, skip *columnRetainedSemanticStreamV1RetainedSkipTrie, document []byte, row uint64, streamEntryCapacity int, streams *columnRetainedSemanticStreamStreams) error {
+func collectColumnRetainedSemanticStreamV1RetainedJSONParserDocument(cfg ColumnStoreConfig, skip *columnRetainedSemanticStreamV1RetainedSkipTrie, document []byte, row uint64, streamEntryCapacity int, streams *columnRetainedSemanticStreamStreams, pathInterner *columnRetainedSemanticStreamV1PathSegmentInterner) error {
 	if cfg.RetainedPayload != ColumnRetainedPayloadNonColumn {
 		return fmt.Errorf("collections: retained payload policy %q cannot produce object payload", cfg.RetainedPayload)
 	}
@@ -1248,13 +1268,13 @@ func collectColumnRetainedSemanticStreamV1RetainedJSONParserDocument(cfg ColumnS
 	if !jsonDocumentLooksObject(document) {
 		return errors.New("collections: column retained payload root must be a JSON object")
 	}
-	return collectColumnRetainedSemanticStreamJSONParserObjectPathsWithSkip(document, nil, row, streamEntryCapacity, skip, streams)
+	return collectColumnRetainedSemanticStreamJSONParserObjectPathsWithSkip(document, nil, row, streamEntryCapacity, skip, streams, pathInterner)
 }
 
-func collectColumnRetainedSemanticStreamJSONParserPaths(raw []byte, dataType jsonparser.ValueType, path []string, row uint64, streamEntryCapacity int, streams *columnRetainedSemanticStreamStreams) error {
+func collectColumnRetainedSemanticStreamJSONParserPaths(raw []byte, dataType jsonparser.ValueType, path []string, row uint64, streamEntryCapacity int, streams *columnRetainedSemanticStreamStreams, pathInterner *columnRetainedSemanticStreamV1PathSegmentInterner) error {
 	switch dataType {
 	case jsonparser.Object:
-		return collectColumnRetainedSemanticStreamJSONParserObjectPaths(raw, path, row, streamEntryCapacity, streams)
+		return collectColumnRetainedSemanticStreamJSONParserObjectPaths(raw, path, row, streamEntryCapacity, streams, pathInterner)
 	case jsonparser.Array, jsonparser.String, jsonparser.Number, jsonparser.Boolean, jsonparser.Null:
 		if len(path) == 0 {
 			return errors.New("semantic-stream-v1 retained root must be a JSON object")
@@ -1266,7 +1286,7 @@ func collectColumnRetainedSemanticStreamJSONParserPaths(raw []byte, dataType jso
 	}
 }
 
-func collectColumnRetainedSemanticStreamJSONParserObjectPaths(raw []byte, path []string, row uint64, streamEntryCapacity int, streams *columnRetainedSemanticStreamStreams) error {
+func collectColumnRetainedSemanticStreamJSONParserObjectPaths(raw []byte, path []string, row uint64, streamEntryCapacity int, streams *columnRetainedSemanticStreamStreams, pathInterner *columnRetainedSemanticStreamV1PathSegmentInterner) error {
 	type retainedObjectValue struct {
 		path      string
 		raw       []byte
@@ -1279,7 +1299,7 @@ func collectColumnRetainedSemanticStreamJSONParserObjectPaths(raw []byte, path [
 		if err != nil {
 			return err
 		}
-		valuePath := string(key)
+		valuePath := pathInterner.intern(key)
 		for i := range retainedObjectValues {
 			if retainedObjectValues[i].path == valuePath {
 				retainedObjectValues[i] = retainedObjectValue{path: valuePath, raw: valueRaw, valueType: dataType}
@@ -1312,14 +1332,14 @@ func collectColumnRetainedSemanticStreamJSONParserObjectPaths(raw []byte, path [
 		} else {
 			nextPath = append(path, value.path)
 		}
-		if err := collectColumnRetainedSemanticStreamJSONParserPaths(value.raw, value.valueType, nextPath, row, streamEntryCapacity, streams); err != nil {
+		if err := collectColumnRetainedSemanticStreamJSONParserPaths(value.raw, value.valueType, nextPath, row, streamEntryCapacity, streams, pathInterner); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func collectColumnRetainedSemanticStreamJSONParserObjectPathsWithSkip(raw []byte, path []string, row uint64, streamEntryCapacity int, skip *columnRetainedSemanticStreamV1RetainedSkipTrie, streams *columnRetainedSemanticStreamStreams) error {
+func collectColumnRetainedSemanticStreamJSONParserObjectPathsWithSkip(raw []byte, path []string, row uint64, streamEntryCapacity int, skip *columnRetainedSemanticStreamV1RetainedSkipTrie, streams *columnRetainedSemanticStreamStreams, pathInterner *columnRetainedSemanticStreamV1PathSegmentInterner) error {
 	type retainedObjectValue struct {
 		path      string
 		raw       []byte
@@ -1336,7 +1356,7 @@ func collectColumnRetainedSemanticStreamJSONParserObjectPathsWithSkip(raw []byte
 		if childSkip != nil && childSkip.terminal {
 			return nil
 		}
-		valuePath := string(key)
+		valuePath := pathInterner.intern(key)
 		nextValue := retainedObjectValue{path: valuePath}
 		valueRaw, err := columnRetainedSemanticStreamV1JSONParserRawValue(raw, value, dataType, valueEndOffset)
 		if err != nil {
@@ -1376,12 +1396,12 @@ func collectColumnRetainedSemanticStreamJSONParserObjectPathsWithSkip(raw []byte
 			nextPath = append(path, value.path)
 		}
 		if value.skip != nil {
-			if err := collectColumnRetainedSemanticStreamJSONParserObjectPathsWithSkip(value.raw, nextPath, row, streamEntryCapacity, value.skip, streams); err != nil {
+			if err := collectColumnRetainedSemanticStreamJSONParserObjectPathsWithSkip(value.raw, nextPath, row, streamEntryCapacity, value.skip, streams, pathInterner); err != nil {
 				return err
 			}
 			continue
 		}
-		if err := collectColumnRetainedSemanticStreamJSONParserPaths(value.raw, value.valueType, nextPath, row, streamEntryCapacity, streams); err != nil {
+		if err := collectColumnRetainedSemanticStreamJSONParserPaths(value.raw, value.valueType, nextPath, row, streamEntryCapacity, streams, pathInterner); err != nil {
 			return err
 		}
 	}

--- a/TreeDB/collections/column_retained_semantic_stream_raw_test.go
+++ b/TreeDB/collections/column_retained_semantic_stream_raw_test.go
@@ -102,7 +102,8 @@ func TestColumnRetainedSemanticStreamV1LookupStringDoesNotEscapeRetainedPaths320
 	}
 	document := []byte(`{"declared":7,"retained":2,"":3}`)
 	streams := newColumnRetainedSemanticStreamStreams()
-	values, err := collectColumnRetainedSemanticStreamV1RootFastPathDocument(cfg, plan, document, 0, 1, streams)
+	pathInterner := &columnRetainedSemanticStreamV1PathSegmentInterner{}
+	values, err := collectColumnRetainedSemanticStreamV1RootFastPathDocument(cfg, plan, document, 0, 1, streams, pathInterner)
 	if err != nil {
 		t.Fatalf("collect root fast path document: %v", err)
 	}
@@ -138,6 +139,132 @@ func TestColumnRetainedSemanticStreamV1LookupStringDoesNotEscapeRetainedPaths320
 	if got := retainedStream.segments[0]; got != "retained" {
 		t.Fatalf("retained path changed after source mutation: %q", got)
 	}
+}
+
+func TestColumnRetainedSemanticStreamV1PathSegmentInternerOwnsAndReusesSegments3206(t *testing.T) {
+	interner := &columnRetainedSemanticStreamV1PathSegmentInterner{}
+	source := []byte("shared")
+	first := interner.intern(source)
+	copy(source, []byte("mutant"))
+	second := interner.intern([]byte("shared"))
+
+	if first != "shared" || second != "shared" {
+		t.Fatalf("interned values=(%q, %q) want shared", first, second)
+	}
+	if !columnRetainedSemanticStreamV1TestStringsShareBacking(first, second) {
+		t.Fatal("repeated interned segment does not reuse string backing")
+	}
+	if columnRetainedSemanticStreamV1TestStringAliasesBytes(first, source) {
+		t.Fatal("interned path segment aliases mutable source bytes")
+	}
+}
+
+func TestColumnRetainedSemanticStreamV1PathSegmentInternerReusesRetainedTraversalSegments3206(t *testing.T) {
+	cfg := ColumnStoreConfig{
+		Enabled: true,
+		Columns: []ColumnStoreColumn{
+			{Name: "declared", Path: "declared", ValueType: ColumnStoreValueInt64},
+		},
+		RetainedPayload:         ColumnRetainedPayloadNonColumn,
+		RetainedPayloadEncoding: ColumnRetainedPayloadEncodingSemanticStreamV1,
+		Reconstruction:          ColumnReconstructionRetainedPayloadAndColumns,
+	}
+	ids := [][]byte{[]byte("doc-0"), []byte("doc-1")}
+	plan, ok := columnRetainedSemanticStreamV1RootFastPathPlanForConfig(cfg, ids, len(ids))
+	if !ok {
+		t.Fatal("root fast path plan not available")
+	}
+	documents := [][]byte{
+		[]byte(`{"declared":1,"payload":{"shared":1,"shared":10},"meta":{"shared":2}}`),
+		[]byte(`{"declared":2,"payload":{"shared":3},"meta":{"shared":4}}`),
+	}
+	streams := newColumnRetainedSemanticStreamStreams()
+	pathInterner := &columnRetainedSemanticStreamV1PathSegmentInterner{}
+	for row, document := range documents {
+		values, err := collectColumnRetainedSemanticStreamV1RootFastPathDocument(cfg, plan, document, uint64(row), len(documents), streams, pathInterner)
+		if err != nil {
+			t.Fatalf("collect row %d: %v", row, err)
+		}
+		if len(values) != 1 || values[0].Int64 != int64(row+1) {
+			t.Fatalf("row %d declared values=%+v", row, values)
+		}
+	}
+
+	payloadShared := streams.byKey[columnRetainedSemanticStreamPathKey([]string{"payload", "shared"})]
+	if payloadShared == nil {
+		t.Fatal("payload.shared stream missing")
+	}
+	metaShared := streams.byKey[columnRetainedSemanticStreamPathKey([]string{"meta", "shared"})]
+	if metaShared == nil {
+		t.Fatal("meta.shared stream missing")
+	}
+	if got := payloadShared.segments; len(got) != 2 || got[0] != "payload" || got[1] != "shared" {
+		t.Fatalf("payload.shared segments=%q", got)
+	}
+	if got := metaShared.segments; len(got) != 2 || got[0] != "meta" || got[1] != "shared" {
+		t.Fatalf("meta.shared segments=%q", got)
+	}
+	if !columnRetainedSemanticStreamV1TestStringsShareBacking(payloadShared.segments[1], metaShared.segments[1]) {
+		t.Fatal("shared child path segment was not interned across retained streams")
+	}
+	for _, document := range documents {
+		for _, segment := range append(append([]string(nil), payloadShared.segments...), metaShared.segments...) {
+			if columnRetainedSemanticStreamV1TestStringAliasesBytes(segment, document) {
+				t.Fatalf("path segment %q aliases mutable source document", segment)
+			}
+		}
+	}
+	if len(payloadShared.entries) != 2 {
+		t.Fatalf("payload.shared entries=%d want 2", len(payloadShared.entries))
+	}
+	if got := string(payloadShared.entries[0].raw); got != "10" {
+		t.Fatalf("duplicate key retained raw=%q want last value 10", got)
+	}
+	if got := string(payloadShared.entries[1].raw); got != "3" {
+		t.Fatalf("second row retained raw=%q want 3", got)
+	}
+}
+
+func TestColumnRetainedSemanticStreamV1PathSegmentInternerReusesSkipTraversalSegments3206(t *testing.T) {
+	cfg := ColumnStoreConfig{
+		Enabled: true,
+		Columns: []ColumnStoreColumn{
+			{Name: "declared", Path: "declared.nested", ValueType: ColumnStoreValueInt64},
+		},
+		RetainedPayload:         ColumnRetainedPayloadNonColumn,
+		RetainedPayloadEncoding: ColumnRetainedPayloadEncodingSemanticStreamV1,
+		Reconstruction:          ColumnReconstructionRetainedPayloadAndColumns,
+	}
+	document := []byte(`{"declared":{"nested":1},"payload":{"shared":10},"meta":{"shared":11}}`)
+	streams := newColumnRetainedSemanticStreamStreams()
+	pathInterner := &columnRetainedSemanticStreamV1PathSegmentInterner{}
+	if err := collectColumnRetainedSemanticStreamV1RetainedJSONParserDocument(cfg, columnRetainedSemanticStreamV1RetainedSkipTrieForConfig(cfg), document, 0, 1, streams, pathInterner); err != nil {
+		t.Fatalf("collect retained JSON parser document: %v", err)
+	}
+	if stream := streams.byKey[columnRetainedSemanticStreamPathKey([]string{"declared", "nested"})]; stream != nil {
+		t.Fatalf("declared nested path leaked into retained streams: %+v", stream.segments)
+	}
+	payloadShared := streams.byKey[columnRetainedSemanticStreamPathKey([]string{"payload", "shared"})]
+	if payloadShared == nil {
+		t.Fatal("payload.shared stream missing")
+	}
+	metaShared := streams.byKey[columnRetainedSemanticStreamPathKey([]string{"meta", "shared"})]
+	if metaShared == nil {
+		t.Fatal("meta.shared stream missing")
+	}
+	if !columnRetainedSemanticStreamV1TestStringsShareBacking(payloadShared.segments[1], metaShared.segments[1]) {
+		t.Fatal("shared child path segment was not interned through skip traversal")
+	}
+	if columnRetainedSemanticStreamV1TestStringAliasesBytes(payloadShared.segments[1], document) {
+		t.Fatal("skip traversal path segment aliases mutable source document")
+	}
+}
+
+func columnRetainedSemanticStreamV1TestStringsShareBacking(a, b string) bool {
+	if len(a) == 0 || len(b) == 0 {
+		return a == b
+	}
+	return unsafe.StringData(a) == unsafe.StringData(b)
 }
 
 func columnRetainedSemanticStreamV1TestStringAliasesBytes(value string, source []byte) bool {

--- a/TreeDB/collections/typed_storage_naming_test.go
+++ b/TreeDB/collections/typed_storage_naming_test.go
@@ -386,7 +386,7 @@ var typedStorageLegacyNameAllowlist = []typedStorageLegacyNameAllowlistEntry{
 	{path: "TreeDB/collections/column_retained_payload_audit.go", classification: typedStorageLegacyCompatibility, matchingLines: 8, occurrences: 8},
 	{path: "TreeDB/collections/column_retained_payload_audit_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 29, occurrences: 30},
 	{path: "TreeDB/collections/column_retained_semantic_stream.go", classification: typedStorageLegacyCompatibility, matchingLines: 14, occurrences: 14},
-	{path: "TreeDB/collections/column_retained_semantic_stream_raw_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 3, occurrences: 3},
+	{path: "TreeDB/collections/column_retained_semantic_stream_raw_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 9, occurrences: 9},
 	{path: "TreeDB/collections/column_retained_vlog_placement_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 45, occurrences: 45},
 	{path: "TreeDB/collections/column_semantics.go", classification: typedStorageLegacyCompatibility, matchingLines: 34, occurrences: 34},
 	{path: "TreeDB/collections/dense_numeric_vector.go", classification: typedStorageLegacyCompatibility, matchingLines: 32, occurrences: 41},


### PR DESCRIPTION
## Summary

- Adds a per-block retained semantic-stream path segment interner during InsertBatch preparation.
- Reuses owned path segment strings across repeated JSON object keys in the same semantic-stream block.
- Preserves duplicate-key last-write semantics, skip-trie omission of declared paths, and owned/stable retained path strings.
- Updates the typed-storage legacy-name allowlist for new compatibility test scaffolding.

## Scope

This is a TreeDB JSONBench load-path slice for #3206. It improves retained semantic-stream preparation allocations for production-shaped inserts/load. It does not claim broad SQL superiority and does not change one-shot query execution, hot prepared query execution, metadata storage, or general scan behavior.

## Benchmark Evidence

Baseline commit: `1c11642a7539441f222fc39d3d9a03c00621ac1a` (#3205)

Artifacts:
- `/tmp/treedb_semstream_path_intern_baseline_bench.txt`
- `/tmp/treedb_semstream_path_intern_candidate_bench.txt`
- `/tmp/treedb_semstream_path_intern_mem.pprof`

Command:

```sh
go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnRetainedPayloadSemanticStreamV1Prepare(RootFastPath|NestedDeclaredPaths)$' -benchmem -count=5
```

`benchstat /tmp/treedb_semstream_path_intern_baseline_bench.txt /tmp/treedb_semstream_path_intern_candidate_bench.txt`:

- RootFastPath: `8.590ms -> 7.820ms`, `-8.97% sec/op`; `14.65MiB -> 14.37MiB`, `-1.92% B/op`; `61.56k -> 16.52k`, `-73.16% allocs/op`
- NestedDeclaredPaths: `7.065ms -> 7.157ms`, timing flat; `11.76MiB -> 11.52MiB`, `-2.12% B/op`; `45.179k -> 4.234k`, `-90.63% allocs/op`
- Geomean: `-3.97% sec/op`, `-2.02% B/op`, `-84.14% allocs/op`

Candidate allocation profile top buckets:

```text
encodeColumnRetainedSemanticStreamV1Locator                 41.41%
collectColumnRetainedSemanticStreamV1RootFastPathDocument   21.96%
bytes.Clone                                                 20.35%
convertColumnDeclaredJSONParserValue                        10.53%
retainedSemanticStreamDocumentsFrom                          4.12%
```

The prior object-path callback buckets are no longer top allocation-object sites in this focused profile.

## Validation

```sh
go test ./TreeDB/collections -run 'TestColumnRetainedSemanticStreamV1|Test.*(RetainedPayload|SemanticStream|Reconstruction).*' -count=1
go test ./TreeDB/collections -count=1
go test ./cmd/unified_bench -count=1
git diff --check
```

All passed locally.

Fixes #3206.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved retained-stream processing efficiency by reducing repeated string allocations during path handling.

* **Tests**
  * Added coverage for repeated path-segment reuse, including shared traversal paths and skip-path behavior.
  * Expanded validation to ensure reused segments stay safe and do not accidentally share mutable source data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->