### PR TITLE
TreeDB: pack semantic stream locators per block

### DIFF
--- a/TreeDB/collections/column_retained_semantic_stream.go
+++ b/TreeDB/collections/column_retained_semantic_stream.go
@@ -427,8 +427,11 @@ func prepareColumnRetainedSemanticStreamV1StorageDocumentsWithIDs(cfg ColumnStor
 		}
 		sum := sha256.Sum256(block)
 		blockKey := append([]byte(nil), sum[:]...)
+		locators := make([]byte, 0, columnRetainedSemanticStreamV1LocatorBlockArenaCapacity(rows))
 		for i := 0; i < rows; i++ {
-			out.documents[start+i] = encodeColumnRetainedSemanticStreamV1Locator(blockKey, uint64(i))
+			locatorStart := len(locators)
+			locators = appendColumnRetainedSemanticStreamV1Locator(locators, blockKey, uint64(i))
+			out.documents[start+i] = locators[locatorStart:len(locators):len(locators)]
 		}
 		setCollectionRunValue(blockTable, blockKey, block)
 	}
@@ -582,11 +585,25 @@ func columnRetainedSemanticStreamV1JSONParserQuotedString(source []byte, value [
 }
 
 func encodeColumnRetainedSemanticStreamV1Locator(blockKey []byte, row uint64) []byte {
-	out := make([]byte, 0, len(columnRetainedSemanticStreamV1LocatorMagic)+sha256.Size+binary.MaxVarintLen64)
+	return appendColumnRetainedSemanticStreamV1Locator(make([]byte, 0, columnRetainedSemanticStreamV1LocatorLen(row)), blockKey, row)
+}
+
+func appendColumnRetainedSemanticStreamV1Locator(out []byte, blockKey []byte, row uint64) []byte {
 	out = append(out, columnRetainedSemanticStreamV1LocatorMagic...)
 	out = append(out, blockKey...)
-	out = binary.AppendUvarint(out, row)
-	return out
+	return binary.AppendUvarint(out, row)
+}
+
+func columnRetainedSemanticStreamV1LocatorBlockArenaCapacity(rows int) int {
+	capacity := 0
+	for row := 0; row < rows; row++ {
+		capacity += columnRetainedSemanticStreamV1LocatorLen(uint64(row))
+	}
+	return capacity
+}
+
+func columnRetainedSemanticStreamV1LocatorLen(row uint64) int {
+	return len(columnRetainedSemanticStreamV1LocatorMagic) + sha256.Size + columnRetainedSemanticStreamV1UvarintSize(row)
 }
 
 func parseColumnRetainedSemanticStreamV1Locator(raw []byte) ([]byte, uint64, bool, error) {

--- a/TreeDB/collections/column_retained_semantic_stream_raw_test.go
+++ b/TreeDB/collections/column_retained_semantic_stream_raw_test.go
@@ -2,6 +2,7 @@ package collections
 
 import (
 	"bytes"
+	"crypto/sha256"
 	"testing"
 	"unsafe"
 
@@ -138,6 +139,54 @@ func TestColumnRetainedSemanticStreamV1LookupStringDoesNotEscapeRetainedPaths320
 	copy(document[start+1:], []byte("mutained"))
 	if got := retainedStream.segments[0]; got != "retained" {
 		t.Fatalf("retained path changed after source mutation: %q", got)
+	}
+}
+
+func TestColumnRetainedSemanticStreamV1LocatorArenaMatchesStandalone3208(t *testing.T) {
+	blockKey := make([]byte, sha256.Size)
+	for i := range blockKey {
+		blockKey[i] = byte(i)
+	}
+	rows := 300
+	arena := make([]byte, 0, columnRetainedSemanticStreamV1LocatorBlockArenaCapacity(rows))
+	locators := make([][]byte, rows)
+	for row := 0; row < rows; row++ {
+		start := len(arena)
+		arena = appendColumnRetainedSemanticStreamV1Locator(arena, blockKey, uint64(row))
+		locators[row] = arena[start:len(arena):len(arena)]
+
+		standalone := encodeColumnRetainedSemanticStreamV1Locator(blockKey, uint64(row))
+		if !bytes.Equal(locators[row], standalone) {
+			t.Fatalf("row %d packed locator=%x want standalone=%x", row, locators[row], standalone)
+		}
+		gotBlockKey, gotRow, ok, err := parseColumnRetainedSemanticStreamV1Locator(locators[row])
+		if err != nil {
+			t.Fatalf("row %d parse packed locator: %v", row, err)
+		}
+		if !ok {
+			t.Fatalf("row %d packed locator not recognized", row)
+		}
+		if gotRow != uint64(row) {
+			t.Fatalf("row %d parsed row=%d", row, gotRow)
+		}
+		if !bytes.Equal(gotBlockKey, blockKey) {
+			t.Fatalf("row %d parsed block key=%x want %x", row, gotBlockKey, blockKey)
+		}
+		if cap(locators[row]) != len(locators[row]) {
+			t.Fatalf("row %d locator cap=%d len=%d; appends must not reach the shared arena", row, cap(locators[row]), len(locators[row]))
+		}
+	}
+	if len(arena) != cap(arena) {
+		t.Fatalf("locator arena len=%d cap=%d; capacity helper should be exact", len(arena), cap(arena))
+	}
+
+	nextBefore := append([]byte(nil), locators[1]...)
+	appended := append(locators[0], 0xff)
+	if unsafe.SliceData(appended) == unsafe.SliceData(locators[0]) {
+		t.Fatal("append to a packed locator reused the shared arena backing")
+	}
+	if !bytes.Equal(locators[1], nextBefore) {
+		t.Fatalf("append to first locator corrupted second locator: got %x want %x", locators[1], nextBefore)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Packs semantic-stream-v1 retained locators into one exact-capacity byte arena per block during InsertBatch preparation.
- Keeps the locator byte format unchanged and preserves the standalone locator encoder for non-batch callers/tests.
- Stores full-capacity-limited locator slices so appending to one row locator cannot mutate the next row's locator bytes.
- Adds a focused regression test proving packed locators match standalone encoding and parse identically.

## Scope

This is a TreeDB JSONBench load-path slice for #3208. It improves retained semantic-stream preparation allocations for production-shaped inserts/load. It does not claim broad SQL superiority and does not change one-shot query execution, hot prepared query execution, metadata storage, or general scan behavior.

## Benchmark Evidence

Baseline commit: `c42b462ab4baac185275f2aa114dfb5fb534f582` (#3207)

Artifacts:
- `/tmp/treedb_semstream_locator_arena_baseline_bench.txt`
- `/tmp/treedb_semstream_locator_arena_candidate_bench.txt`
- `/tmp/treedb_semstream_locator_arena_mem.pprof`

Command:

```sh
go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnRetainedPayloadSemanticStreamV1Prepare(RootFastPath|NestedDeclaredPaths)$' -benchmem -count=5
```

`benchstat /tmp/treedb_semstream_locator_arena_baseline_bench.txt /tmp/treedb_semstream_locator_arena_candidate_bench.txt`:

- RootFastPath: `7.765ms -> 7.832ms`, timing flat; `14.37MiB -> 14.29MiB`, `-0.55% B/op`; `16.52k -> 12.43k`, `-24.79% allocs/op`
- NestedDeclaredPaths: `6.888ms -> 6.853ms`, timing flat; `11.52MiB -> 11.44MiB`, `-0.68% B/op`; `4234 -> 139`, `-96.72% allocs/op`
- Geomean: `+0.17% sec/op` (flat), `-0.61% B/op`, `-84.29% allocs/op`

Candidate allocation profile top buckets:

```text
collectColumnRetainedSemanticStreamV1RootFastPathDocument   33.87%
bytes.Clone                                                 33.79%
convertColumnDeclaredJSONParserValue                        19.81%
fmt.Sprintf                                                  4.50%
retainedSemanticStreamDocumentsFrom                          3.50%
```

`encodeColumnRetainedSemanticStreamV1Locator` is no longer a top alloc_objects site in this focused profile.

## Validation

```sh
go test ./TreeDB/collections -run 'TestColumnRetainedSemanticStreamV1|Test.*(RetainedPayload|SemanticStream|Reconstruction).*' -count=1
go test ./TreeDB/collections -count=1
go test ./cmd/unified_bench -count=1
git diff --check
```

All passed locally.

Fixes #3208.
