### PR TITLE
TreeDB: pack semantic stream declared rows

### DIFF
--- a/TreeDB/collections/column_retained_semantic_stream.go
+++ b/TreeDB/collections/column_retained_semantic_stream.go
@@ -380,9 +380,13 @@ func prepareColumnRetainedSemanticStreamV1StorageDocumentsWithIDs(cfg ColumnStor
 		return out, nil
 	}
 	rootPlan, useRootFastPath := columnRetainedSemanticStreamV1RootFastPathPlanForConfig(cfg, ids, len(documents))
+	var declaredRowIDBytes []byte
+	var declaredRowValues []columnDeclaredValue
 	if useRootFastPath && rootPlan.declaredRowsReady {
 		out.declaredRows = make([]columnDeclaredRow, len(documents))
 		out.declaredRowsReady = true
+		declaredRowIDBytes = make([]byte, 0, columnRetainedSemanticStreamV1DeclaredRowIDArenaCapacity(ids))
+		declaredRowValues = make([]columnDeclaredValue, len(documents)*len(cfg.Columns))
 	}
 	retainedSkipTrie := columnRetainedSemanticStreamV1RetainedSkipTrieForConfig(cfg)
 	blockTable := newCollectionRunTable((len(documents) + columnRetainedSemanticStreamV1BlockRows - 1) / columnRetainedSemanticStreamV1BlockRows)
@@ -402,14 +406,21 @@ func prepareColumnRetainedSemanticStreamV1StorageDocumentsWithIDs(cfg ColumnStor
 		pathInterner := &columnRetainedSemanticStreamV1PathSegmentInterner{}
 		for row, i := 0, start; i < end; row, i = row+1, i+1 {
 			if useRootFastPath {
-				declaredValues, err := collectColumnRetainedSemanticStreamV1RootFastPathDocument(cfg, rootPlan, documents[i], uint64(row), rows, streams, pathInterner)
+				var declaredValuesDest []columnDeclaredValue
+				if rootPlan.declaredRowsReady {
+					valuesStart := i * len(cfg.Columns)
+					declaredValuesDest = declaredRowValues[valuesStart : valuesStart+len(cfg.Columns) : valuesStart+len(cfg.Columns)]
+				}
+				declaredValues, err := collectColumnRetainedSemanticStreamV1RootFastPathDocument(cfg, rootPlan, documents[i], uint64(row), rows, streams, pathInterner, declaredValuesDest)
 				if err != nil {
 					resetCollectionRunTable(blockTable)
 					return columnRetainedPayloadStorageDocuments{}, fmt.Errorf("collections: semantic-stream-v1 retained row %d: %w", row, err)
 				}
 				if rootPlan.declaredRowsReady {
+					idStart := len(declaredRowIDBytes)
+					declaredRowIDBytes = append(declaredRowIDBytes, ids[i]...)
 					out.declaredRows[i] = columnDeclaredRow{
-						ID:     bytes.Clone(ids[i]),
+						ID:     declaredRowIDBytes[idStart:len(declaredRowIDBytes):len(declaredRowIDBytes)],
 						Values: declaredValues,
 					}
 				}
@@ -438,6 +449,14 @@ func prepareColumnRetainedSemanticStreamV1StorageDocumentsWithIDs(cfg ColumnStor
 	blockTable.Freeze()
 	out.semanticStreamBlocks = blockTable
 	return out, nil
+}
+
+func columnRetainedSemanticStreamV1DeclaredRowIDArenaCapacity(ids [][]byte) int {
+	capacity := 0
+	for _, id := range ids {
+		capacity += len(id)
+	}
+	return capacity
 }
 
 func columnRetainedSemanticStreamV1RootFastPathPlanForConfig(cfg ColumnStoreConfig, ids [][]byte, documentCount int) (columnRetainedSemanticStreamV1RootFastPathPlan, bool) {
@@ -480,7 +499,7 @@ func columnRetainedSemanticStreamV1RetainedSkipTrieForConfig(cfg ColumnStoreConf
 	return root
 }
 
-func collectColumnRetainedSemanticStreamV1RootFastPathDocument(cfg ColumnStoreConfig, plan columnRetainedSemanticStreamV1RootFastPathPlan, document []byte, row uint64, streamEntryCapacity int, streams *columnRetainedSemanticStreamStreams, pathInterner *columnRetainedSemanticStreamV1PathSegmentInterner) ([]columnDeclaredValue, error) {
+func collectColumnRetainedSemanticStreamV1RootFastPathDocument(cfg ColumnStoreConfig, plan columnRetainedSemanticStreamV1RootFastPathPlan, document []byte, row uint64, streamEntryCapacity int, streams *columnRetainedSemanticStreamStreams, pathInterner *columnRetainedSemanticStreamV1PathSegmentInterner, declaredValues []columnDeclaredValue) ([]columnDeclaredValue, error) {
 	if !gjson.ValidBytes(document) {
 		return nil, errors.New("invalid JSON: invalid JSON")
 	}
@@ -543,7 +562,13 @@ func collectColumnRetainedSemanticStreamV1RootFastPathDocument(cfg ColumnStoreCo
 	if !plan.declaredRowsReady {
 		return nil, nil
 	}
-	values := make([]columnDeclaredValue, len(cfg.Columns))
+	values := declaredValues
+	if values == nil && len(cfg.Columns) == 0 {
+		values = make([]columnDeclaredValue, 0)
+	}
+	if len(values) != len(cfg.Columns) {
+		values = make([]columnDeclaredValue, len(cfg.Columns))
+	}
 	var scratch []byte
 	for colIdx, col := range cfg.Columns {
 		value, err := convertColumnDeclaredJSONParserValue(col, valuesRaw[colIdx], &scratch)

--- a/TreeDB/collections/column_retained_semantic_stream_raw_test.go
+++ b/TreeDB/collections/column_retained_semantic_stream_raw_test.go
@@ -104,7 +104,7 @@ func TestColumnRetainedSemanticStreamV1LookupStringDoesNotEscapeRetainedPaths320
 	document := []byte(`{"declared":7,"retained":2,"":3}`)
 	streams := newColumnRetainedSemanticStreamStreams()
 	pathInterner := &columnRetainedSemanticStreamV1PathSegmentInterner{}
-	values, err := collectColumnRetainedSemanticStreamV1RootFastPathDocument(cfg, plan, document, 0, 1, streams, pathInterner)
+	values, err := collectColumnRetainedSemanticStreamV1RootFastPathDocument(cfg, plan, document, 0, 1, streams, pathInterner, nil)
 	if err != nil {
 		t.Fatalf("collect root fast path document: %v", err)
 	}
@@ -190,6 +190,89 @@ func TestColumnRetainedSemanticStreamV1LocatorArenaMatchesStandalone3208(t *test
 	}
 }
 
+func TestColumnRetainedSemanticStreamV1DeclaredRowArenaOwnsAndCapsRows3210(t *testing.T) {
+	cfg := ColumnStoreConfig{
+		Enabled: true,
+		Columns: []ColumnStoreColumn{
+			{Name: "declared", Path: "declared", ValueType: ColumnStoreValueInt64},
+			{Name: "label", Path: "label", ValueType: ColumnStoreValueString},
+		},
+		RetainedPayload:         ColumnRetainedPayloadNonColumn,
+		RetainedPayloadEncoding: ColumnRetainedPayloadEncodingSemanticStreamV1,
+		Reconstruction:          ColumnReconstructionRetainedPayloadAndColumns,
+	}
+	ids := [][]byte{[]byte("doc-0"), []byte("doc-1")}
+	documents := [][]byte{
+		[]byte(`{"declared":7,"label":"alpha","retained":1}`),
+		[]byte(`{"declared":8,"label":"bravo","retained":2}`),
+	}
+	prepared, err := prepareColumnRetainedSemanticStreamV1StorageDocumentsWithIDs(cfg, ids, documents)
+	if err != nil {
+		t.Fatalf("prepare semantic-stream-v1 documents: %v", err)
+	}
+	defer resetCollectionRunTable(prepared.semanticStreamBlocks)
+
+	if !prepared.declaredRowsReady {
+		t.Fatal("declared rows were not prepared")
+	}
+	if len(prepared.declaredRows) != len(documents) {
+		t.Fatalf("declared rows=%d want %d", len(prepared.declaredRows), len(documents))
+	}
+	first := prepared.declaredRows[0]
+	second := prepared.declaredRows[1]
+	if got := string(first.ID); got != "doc-0" {
+		t.Fatalf("first row ID=%q want doc-0", got)
+	}
+	if len(first.Values) != 2 || first.Values[0].Int64 != 7 || first.Values[1].String != "alpha" {
+		t.Fatalf("first row values=%+v want declared=7 label=alpha", first.Values)
+	}
+	if len(second.Values) != 2 || second.Values[0].Int64 != 8 || second.Values[1].String != "bravo" {
+		t.Fatalf("second row values=%+v want declared=8 label=bravo", second.Values)
+	}
+	if columnRetainedSemanticStreamV1TestBytesAliasBytes(first.ID, ids[0]) {
+		t.Fatal("declared row ID aliases mutable input ID")
+	}
+	if columnRetainedSemanticStreamV1TestStringAliasesBytes(first.Values[1].String, documents[0]) {
+		t.Fatal("declared string aliases mutable input document")
+	}
+	if cap(first.ID) != len(first.ID) {
+		t.Fatalf("first row ID cap=%d len=%d; appends must not reach the shared arena", cap(first.ID), len(first.ID))
+	}
+	if cap(first.Values) != len(first.Values) {
+		t.Fatalf("first row values cap=%d len=%d; appends must not reach the shared arena", cap(first.Values), len(first.Values))
+	}
+
+	secondIDBefore := append([]byte(nil), second.ID...)
+	secondValuesBefore := append([]columnDeclaredValue(nil), second.Values...)
+	appendedID := append(first.ID, 'x')
+	if unsafe.SliceData(appendedID) == unsafe.SliceData(first.ID) {
+		t.Fatal("append to declared row ID reused the shared arena backing")
+	}
+	appendedValues := append(first.Values, columnDeclaredValue{Int64: 99})
+	if unsafe.SliceData(appendedValues) == unsafe.SliceData(first.Values) {
+		t.Fatal("append to declared row values reused the shared arena backing")
+	}
+	if !bytes.Equal(second.ID, secondIDBefore) {
+		t.Fatalf("append to first row ID corrupted second ID: got %q want %q", second.ID, secondIDBefore)
+	}
+	if len(second.Values) != len(secondValuesBefore) || second.Values[0].Int64 != secondValuesBefore[0].Int64 || second.Values[1].String != secondValuesBefore[1].String {
+		t.Fatalf("append to first row values corrupted second values: got %+v want %+v", second.Values, secondValuesBefore)
+	}
+
+	ids[0][0] = 'X'
+	labelStart := bytes.Index(documents[0], []byte("alpha"))
+	if labelStart < 0 {
+		t.Fatal("label token not found in source document")
+	}
+	copy(documents[0][labelStart:], []byte("omega"))
+	if got := string(first.ID); got != "doc-0" {
+		t.Fatalf("declared row ID changed after source ID mutation: %q", got)
+	}
+	if got := first.Values[1].String; got != "alpha" {
+		t.Fatalf("declared string changed after source document mutation: %q", got)
+	}
+}
+
 func TestColumnRetainedSemanticStreamV1PathSegmentInternerOwnsAndReusesSegments3206(t *testing.T) {
 	interner := &columnRetainedSemanticStreamV1PathSegmentInterner{}
 	source := []byte("shared")
@@ -230,7 +313,7 @@ func TestColumnRetainedSemanticStreamV1PathSegmentInternerReusesRetainedTraversa
 	streams := newColumnRetainedSemanticStreamStreams()
 	pathInterner := &columnRetainedSemanticStreamV1PathSegmentInterner{}
 	for row, document := range documents {
-		values, err := collectColumnRetainedSemanticStreamV1RootFastPathDocument(cfg, plan, document, uint64(row), len(documents), streams, pathInterner)
+		values, err := collectColumnRetainedSemanticStreamV1RootFastPathDocument(cfg, plan, document, uint64(row), len(documents), streams, pathInterner, nil)
 		if err != nil {
 			t.Fatalf("collect row %d: %v", row, err)
 		}
@@ -321,6 +404,15 @@ func columnRetainedSemanticStreamV1TestStringAliasesBytes(value string, source [
 		return false
 	}
 	valuePtr := uintptr(unsafe.Pointer(unsafe.StringData(value)))
+	sourcePtr := uintptr(unsafe.Pointer(unsafe.SliceData(source)))
+	return valuePtr >= sourcePtr && valuePtr < sourcePtr+uintptr(len(source))
+}
+
+func columnRetainedSemanticStreamV1TestBytesAliasBytes(value, source []byte) bool {
+	if len(value) == 0 || len(source) == 0 {
+		return false
+	}
+	valuePtr := uintptr(unsafe.Pointer(unsafe.SliceData(value)))
 	sourcePtr := uintptr(unsafe.Pointer(unsafe.SliceData(source)))
 	return valuePtr >= sourcePtr && valuePtr < sourcePtr+uintptr(len(source))
 }

--- a/TreeDB/collections/typed_storage_naming_test.go
+++ b/TreeDB/collections/typed_storage_naming_test.go
@@ -386,7 +386,7 @@ var typedStorageLegacyNameAllowlist = []typedStorageLegacyNameAllowlistEntry{
 	{path: "TreeDB/collections/column_retained_payload_audit.go", classification: typedStorageLegacyCompatibility, matchingLines: 8, occurrences: 8},
 	{path: "TreeDB/collections/column_retained_payload_audit_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 29, occurrences: 30},
 	{path: "TreeDB/collections/column_retained_semantic_stream.go", classification: typedStorageLegacyCompatibility, matchingLines: 14, occurrences: 14},
-	{path: "TreeDB/collections/column_retained_semantic_stream_raw_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 9, occurrences: 9},
+	{path: "TreeDB/collections/column_retained_semantic_stream_raw_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 13, occurrences: 13},
 	{path: "TreeDB/collections/column_retained_vlog_placement_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 45, occurrences: 45},
 	{path: "TreeDB/collections/column_semantics.go", classification: typedStorageLegacyCompatibility, matchingLines: 34, occurrences: 34},
 	{path: "TreeDB/collections/dense_numeric_vector.go", classification: typedStorageLegacyCompatibility, matchingLines: 32, occurrences: 41},


### PR DESCRIPTION
Fixes #3210.

Parent tracker: #3099. Load lane: #3067. Root tracker: #3000. Final report tracker: #3001. Predecessor: #3208 / #3209.

## Scope

This PR is a retained semantic-stream InsertBatch/load-path preparation slice only. It improves production-shape load preparation by packing declared-row IDs and declared-value row slices into batch-owned arenas.

It does not claim one-shot SQL superiority, no-metadata scan performance, ClickHouse parity, query-path speedups, metadata-cost fairness, or final JSONBench acceptance.

## Changes

- Copies prepared declared row IDs into one batch-owned byte arena instead of one `bytes.Clone` allocation per row.
- Pre-slices declared-value storage for root-fast-path declared rows instead of allocating one `[]columnDeclaredValue` per row.
- Keeps standalone collector behavior safe by allocating when no destination slice is supplied.
- Adds regression coverage for declared-row ID ownership, declared string stability after source document mutation, and cap-limited row views that prevent append corruption.
- Updates the typed-storage legacy naming allowlist for the new compatibility test usage.

## Local Gates

```sh
go test ./TreeDB/collections -run 'TestColumnRetainedSemanticStreamV1|Test.*(RetainedPayload|SemanticStream|Reconstruction).*' -count=1
go test ./TreeDB/collections -count=1
go test ./cmd/unified_bench -count=1
git diff --check
```

All passed locally.

## Performance Evidence

Baseline: `8b8480fdf72c11b52ec558db8964eaa40177ce30` (#3209)
Candidate: `54fc7ebb6`

Command:

```sh
go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnRetainedPayloadSemanticStreamV1Prepare(RootFastPath|NestedDeclaredPaths)$' -benchmem -count=5
```

Benchstat artifacts:

- Baseline: `/tmp/treedb_semstream_declared_row_arena_baseline_bench.txt`
- Candidate: `/tmp/treedb_semstream_declared_row_arena_candidate_bench.txt`
- Benchstat: `/tmp/treedb_semstream_declared_row_arena_benchstat.txt`
- Alloc profile: `/tmp/treedb_semstream_declared_row_arena_mem.pprof`
- Alloc top: `/tmp/treedb_semstream_declared_row_arena_alloc_objects_top.txt`

Results:

| benchmark | sec/op | B/op | allocs/op |
| --- | ---: | ---: | ---: |
| RootFastPath | 7.833ms -> 7.524ms, -3.94% | 14.29MiB -> 14.08MiB, -1.47% | 12.428k -> 4.239k, -65.89% |
| NestedDeclaredPaths | 6.866ms -> 6.844ms, flat | 11.44MiB -> 11.44MiB, flat | 139 -> 139, flat |
| geomean | -2.14% | -0.74% | -41.60% |

Allocation profile after this PR no longer shows the old `bytes.Clone` row-ID bucket. The top remaining retained-prep allocation bucket is now `convertColumnDeclaredJSONParserValue` at 72.17% of alloc_objects, followed by fixture/string formatting and retained document fixture generation.
