### PR TITLE
[codex] Reduce TreeDB Celestia memory high-water

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -22430,7 +22430,10 @@ func (db *DB) Checkpoint() error {
 			db.TriggerFlush()
 		}
 	}
-	activeBackgroundFlushBeforeWait := db.flushCoordinatorActive.Load() > 0 && db.flushCoordinatorInFlightBytes.Load() > 0
+	// Attribute the wait using the same request-time debt snapshot reported in
+	// checkpoint stats; live coordinator flags can clear before slow platforms
+	// take the flushMu sample.
+	activeBackgroundFlushBeforeWait := checkpointDebt.activeWorkers > 0 && checkpointDebt.activeInFlightBytes > 0
 	db.checkpointFlushPreemptActive.Add(1)
 	db.checkpointFlushPreemptRequests.Add(1)
 	defer addAtomicInt64FloorZero(&db.checkpointFlushPreemptActive, -1)

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -2193,7 +2193,7 @@ const (
 	envDebugFlushPointers = "TREEDB_DEBUG_FLUSH_PTRS"
 	envDebugFlushTiming   = "TREEDB_DEBUG_FLUSH_TIMING"
 	// Optional adaptive-memtable tuning knob for BTree selection safety.
-	// 0 keeps legacy behavior (no iterator-sample gate).
+	// Explicit 0 keeps legacy behavior (no iterator-sample gate).
 	envAdaptiveBTreeMinIteratorSamples = "TREEDB_ADAPTIVE_BTREE_MIN_ITERATOR_SAMPLES"
 	// Generational maintenance toggles (forensics / isolation).
 	envDisableVlogGenerationRewrite                   = "TREEDB_DISABLE_VLOG_GENERATION_REWRITE"
@@ -2247,11 +2247,13 @@ const (
 	maxMemtablePrealloc                                            = 256 << 20
 	appendOnlyEntryHintMinEntries                                  = 128
 	appendOnlyEntryHintMaxEntries                                  = 1 << 20
+	appendOnlyIdleMutableRetainCapacity                            = 512 << 10
+	hashSortedMutablePreallocCap                                   = 8 << 20
 	adaptiveMinWrites                                              = 1024
 	adaptiveSequentialWritePct                                     = 0.85
 	adaptiveRangeIteratorPct                                       = 0.40
 	adaptiveOverwriteWritePct                                      = 0.25
-	adaptiveBTreeMinIteratorSamplesDefault                         = 0
+	adaptiveBTreeMinIteratorSamplesDefault                         = 4096
 	adaptiveWarmupBytes                                            = 16 * 1024 * 1024
 	maxMemtableBytesPerShard                                       = int64(3 << 30)
 	maxOuterLeafArenaPoolCap                                       = 16 << 20
@@ -2305,6 +2307,22 @@ func envUint64(name string, fallback uint64) uint64 {
 		return fallback
 	}
 	return n
+}
+
+func envUint64Optional(name string) (uint64, bool) {
+	v, ok := os.LookupEnv(name)
+	if !ok {
+		return 0, false
+	}
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return 0, false
+	}
+	n, err := strconv.ParseUint(v, 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	return n, true
 }
 
 func updateAtomicMaxUint64(dst *atomic.Uint64, value uint64) {
@@ -8019,7 +8037,7 @@ type DB struct {
 	dirtyRootPublishGroupPending     bool
 	rootPublishRetryPending          bool
 	hashSortedIndexer                *memtable.HashSortedIndexer
-	appendOnlyMemPool                sync.Pool
+	appendOnlyMemPool                atomic.Pointer[sync.Pool]
 	appendOnlyMemLeaseMu             sync.Mutex
 	appendOnlyMemLeases              []*memtable.AppendOnly
 	appendOnlyMemLeaseHitTotal       atomic.Uint64
@@ -8027,6 +8045,9 @@ type DB struct {
 	appendOnlyMemNewAllocTotal       atomic.Uint64
 	appendOnlyMemNewAllocWithQueue   atomic.Uint64
 	appendOnlyMemNewAllocQueueBytes  atomic.Uint64
+	appendOnlyMemPoolDropTotal       atomic.Uint64
+	appendOnlyMutableTrimTotal       atomic.Uint64
+	appendOnlyMutableTrimDropped     atomic.Uint64
 	appendOnlyDirectArenaLeaseMu     sync.Mutex
 	appendOnlyDirectArenaLeasesByMem map[memtable.Table]*appendOnlyDirectArenaLease
 	pendingRetiredMems               []memtable.Table
@@ -8240,6 +8261,7 @@ type DB struct {
 	memtableAdaptive                                  bool
 	memtableAdaptiveObserve                           atomic.Bool
 	memtableAdaptiveBTreeMinIters                     uint64
+	memtableAdaptiveBTreeMinItersSet                  bool
 	memtableAdaptiveDecisionTotal                     atomic.Uint64
 	memtableAdaptiveDecisionReason                    atomic.Uint32
 	memtableAdaptiveDecisionMode                      atomic.Uint32
@@ -9873,6 +9895,10 @@ func (db *DB) retainAppendOnlyDirectArenaChunksForMemtable(shardID int, mt memta
 }
 
 func (db *DB) releaseAppendOnlyDirectArenaLeaseForMemtable(mt memtable.Table) {
+	db.releaseAppendOnlyDirectArenaLeaseForMemtableWithPolicy(mt, db.currentMemtableMode() == memtable.ModeAppendOnly)
+}
+
+func (db *DB) releaseAppendOnlyDirectArenaLeaseForMemtableWithPolicy(mt memtable.Table, retain bool) {
 	if db == nil || mt == nil {
 		return
 	}
@@ -9884,6 +9910,10 @@ func (db *DB) releaseAppendOnlyDirectArenaLeaseForMemtable(mt memtable.Table) {
 	}
 	db.appendOnlyDirectArenaLeaseMu.Unlock()
 	if lease == nil || len(lease.chunks) == 0 {
+		return
+	}
+	if !retain {
+		putAppendOnlyDirectValueArenaChunks(lease.chunks)
 		return
 	}
 	if int(lease.shardID) >= len(db.mutableShards) {
@@ -9923,6 +9953,29 @@ func (db *DB) queueRetiredMemtablesLocked(mems []memtable.Table) {
 	}
 }
 
+func (db *DB) appendOnlyMemtablePool() *sync.Pool {
+	if db == nil {
+		return nil
+	}
+	if pool := db.appendOnlyMemPool.Load(); pool != nil {
+		return pool
+	}
+	pool := &sync.Pool{}
+	if db.appendOnlyMemPool.CompareAndSwap(nil, pool) {
+		return pool
+	}
+	return db.appendOnlyMemPool.Load()
+}
+
+func (db *DB) dropColdAppendOnlyPools() {
+	if db == nil {
+		return
+	}
+	db.appendOnlyMemPool.Store(&sync.Pool{})
+	db.appendOnlyMemPoolDropTotal.Add(1)
+	memtable.DropAppendOnlyEntryPools()
+}
+
 func (db *DB) popAppendOnlyMemLease() *memtable.AppendOnly {
 	if db == nil {
 		return nil
@@ -9959,23 +10012,35 @@ func (db *DB) recycleMemtables(mems []memtable.Table) {
 	resetCapacity := db.checkpointRotateCapacity()
 	estimate := appendOnlyEstimatedBytesPerEntryDefault
 	appendOnlyResetCapacity := db.appendOnlyMemtableCapacityHint(resetCapacity, estimate)
+	retainAppendOnly := db.currentMemtableMode() == memtable.ModeAppendOnly
 	for _, mt := range mems {
 		switch typed := mt.(type) {
 		case *memtable.AppendOnly:
+			if !retainAppendOnly {
+				db.releaseAppendOnlyDirectArenaLeaseForMemtableWithPolicy(typed, false)
+				typed.ReleaseDropEntries()
+				continue
+			}
 			typed.ResetWithCapacityHard(appendOnlyResetCapacity, estimate)
-			db.releaseAppendOnlyDirectArenaLeaseForMemtable(typed)
+			db.releaseAppendOnlyDirectArenaLeaseForMemtableWithPolicy(typed, true)
 			if !db.putAppendOnlyMemLease(typed) {
-				db.appendOnlyMemPool.Put(typed)
+				if pool := db.appendOnlyMemtablePool(); pool != nil {
+					pool.Put(typed)
+				}
 			}
 		}
 	}
 }
 
-func (db *DB) trimAppendOnlyMemLeases(maxLeases int, resetCapacity int) int {
+func (db *DB) trimAppendOnlyMemLeases(maxLeases int, _ int) int {
 	if db == nil {
 		return 0
 	}
 	if maxLeases < 0 {
+		maxLeases = 0
+	}
+	retainAppendOnly := db.currentMemtableMode() == memtable.ModeAppendOnly
+	if !retainAppendOnly {
 		maxLeases = 0
 	}
 	var dropped []*memtable.AppendOnly
@@ -9994,17 +10059,90 @@ func (db *DB) trimAppendOnlyMemLeases(maxLeases int, resetCapacity int) int {
 	if len(dropped) == 0 {
 		return 0
 	}
-	effectiveResetCapacity := db.appendOnlyMemtableCapacityHint(resetCapacity, appendOnlyEstimatedBytesPerEntryDefault)
 	returned := 0
 	for i := range dropped {
 		if dropped[i] != nil {
-			dropped[i].ResetWithCapacityHard(effectiveResetCapacity, appendOnlyEstimatedBytesPerEntryDefault)
-			db.releaseAppendOnlyDirectArenaLeaseForMemtable(dropped[i])
-			db.appendOnlyMemPool.Put(dropped[i])
+			if retainAppendOnly {
+				db.releaseAppendOnlyDirectArenaLeaseForMemtableWithPolicy(dropped[i], true)
+				dropped[i].ReleaseDropEntries()
+				if pool := db.appendOnlyMemtablePool(); pool != nil {
+					pool.Put(dropped[i])
+				}
+			} else {
+				db.releaseAppendOnlyDirectArenaLeaseForMemtableWithPolicy(dropped[i], false)
+				dropped[i].ReleaseDropEntries()
+			}
 			returned++
 		}
 	}
 	return returned
+}
+
+func (db *DB) appendOnlyMemLeaseStats() (count int, entryCapacity int64, entryBackingBytes int64) {
+	if db == nil {
+		return 0, 0, 0
+	}
+	db.appendOnlyMemLeaseMu.Lock()
+	defer db.appendOnlyMemLeaseMu.Unlock()
+	for _, mt := range db.appendOnlyMemLeases {
+		if mt == nil {
+			continue
+		}
+		count++
+		entryCapacity += int64(mt.EntryCapacity())
+		entryBackingBytes += mt.EntryBackingBytes()
+	}
+	return count, entryCapacity, entryBackingBytes
+}
+
+func (db *DB) appendOnlyMutableShardEntryStats() (count int, entryCapacity int64, entryBackingBytes int64) {
+	if db == nil {
+		return 0, 0, 0
+	}
+	for i := range db.mutableShards {
+		shard := &db.mutableShards[i]
+		shard.mu.Lock()
+		if mt, ok := shard.mem.(*memtable.AppendOnly); ok && mt != nil {
+			count++
+			entryCapacity += int64(mt.EntryCapacity())
+			entryBackingBytes += mt.EntryBackingBytes()
+		}
+		shard.mu.Unlock()
+	}
+	return count, entryCapacity, entryBackingBytes
+}
+
+func (db *DB) trimEmptyAppendOnlyMutableShards(capacity int) int {
+	if db == nil || db.currentMemtableMode() != memtable.ModeAppendOnly || len(db.mutableShards) == 0 {
+		return 0
+	}
+	estimate := appendOnlyEstimatedBytesPerEntryDefault
+	trimmed := 0
+	var droppedBytes uint64
+	for i := range db.mutableShards {
+		shard := &db.mutableShards[i]
+		shard.mu.Lock()
+		mt, ok := shard.mem.(*memtable.AppendOnly)
+		if !ok || mt == nil || mt.Len() != 0 {
+			shard.mu.Unlock()
+			continue
+		}
+		before := mt.EntryBackingBytes()
+		mt.ResetWithCapacityHard(capacity, estimate)
+		after := mt.EntryBackingBytes()
+		shard.mu.Unlock()
+		if before > after {
+			droppedBytes += uint64(before - after)
+		}
+		trimmed++
+	}
+	if trimmed > 0 {
+		db.appendOnlyMutableTrimTotal.Add(uint64(trimmed))
+		if droppedBytes > 0 {
+			db.appendOnlyMutableTrimDropped.Add(droppedBytes)
+		}
+	}
+	return trimmed
 }
 
 func (db *DB) trimMutableShardAppendOnlyDirectArenas(checkpoint bool) {
@@ -10013,7 +10151,10 @@ func (db *DB) trimMutableShardAppendOnlyDirectArenas(checkpoint bool) {
 	}
 	level := currentPoolPressureSnapshot().level
 	maxChunks, maxBytes := appendOnlyDirectArenaRetentionLimitsForPressure(level)
-	if checkpoint {
+	if db.currentMemtableMode() != memtable.ModeAppendOnly {
+		maxChunks = 0
+		maxBytes = 0
+	} else if checkpoint {
 		checkpointBytes := int64(appendOnlyDirectValueArenaRetainMaxBytes / 4)
 		if maxBytes > checkpointBytes {
 			maxBytes = checkpointBytes
@@ -10094,6 +10235,7 @@ func (db *DB) trimRetainedArenasAfterFlush(checkpoint bool) {
 	}
 
 	db.trimMutableShardAppendOnlyDirectArenas(checkpoint)
+	db.trimEmptyAppendOnlyMutableShards(db.appendOnlyIdleMutableRetainCapacity())
 	db.trimAppendOnlyMemLeases(appendOnlyLeaseKeep, db.checkpointRotateCapacity())
 }
 
@@ -10105,11 +10247,13 @@ func (db *DB) newMutableMemtableWithCapacityMode(capacity int, mode memtable.Mod
 			mt.ResetWithCapacity(capacity, estimate)
 			return mt, nil
 		}
-		if v := db.appendOnlyMemPool.Get(); v != nil {
-			if mt, ok := v.(*memtable.AppendOnly); ok && mt != nil {
-				db.appendOnlyMemPoolHitTotal.Add(1)
-				mt.ResetWithCapacity(capacity, estimate)
-				return mt, nil
+		if pool := db.appendOnlyMemtablePool(); pool != nil {
+			if v := pool.Get(); v != nil {
+				if mt, ok := v.(*memtable.AppendOnly); ok && mt != nil {
+					db.appendOnlyMemPoolHitTotal.Add(1)
+					mt.ResetWithCapacity(capacity, estimate)
+					return mt, nil
+				}
 			}
 		}
 		if backlog := db.queueBacklogBytes.Load(); backlog > 0 {
@@ -10121,7 +10265,15 @@ func (db *DB) newMutableMemtableWithCapacityMode(capacity int, mode memtable.Mod
 		db.appendOnlyMemNewAllocTotal.Add(1)
 		return memtable.NewAppendOnlyWithCapacityEstimatedEntryBytes(capacity, estimate), nil
 	}
+	capacity = mutableMemtableCapacityForMode(capacity, mode)
 	return memtable.NewWithCapacityModeAndIndexer(capacity, mode, db.hashSortedIndexer)
+}
+
+func mutableMemtableCapacityForMode(capacity int, mode memtable.Mode) int {
+	if mode == memtable.ModeHashSorted && capacity > hashSortedMutablePreallocCap {
+		return hashSortedMutablePreallocCap
+	}
+	return capacity
 }
 
 // publishMemtablesLocked publishes a new memtable snapshot.
@@ -10571,6 +10723,9 @@ func (db *DB) adaptiveBTreeMinIteratorSamples() uint64 {
 	if db == nil {
 		return adaptiveBTreeMinIteratorSamplesDefault
 	}
+	if db.memtableAdaptiveBTreeMinItersSet {
+		return db.memtableAdaptiveBTreeMinIters
+	}
 	if db.memtableAdaptiveBTreeMinIters > 0 {
 		return db.memtableAdaptiveBTreeMinIters
 	}
@@ -10652,6 +10807,10 @@ func (db *DB) chooseAdaptiveMemtableModeLocked() memtable.Mode {
 	}
 
 	// 2) Mostly increasing writes with low overwrite pressure favor append-only.
+	if btreeBlockedByMinIters && overwriteWritePct < adaptiveOverwriteWritePct {
+		db.noteAdaptiveMemtableDecision(memtable.ModeAppendOnly, adaptiveDecisionBTreeBlockedMinIters, writes, seqWrites, overwriteWrites, iters, rangeIters, rangeIterPct)
+		return memtable.ModeAppendOnly
+	}
 	if seqWritePct >= adaptiveSequentialWritePct && overwriteWritePct < adaptiveOverwriteWritePct {
 		db.noteAdaptiveMemtableDecision(memtable.ModeAppendOnly, adaptiveDecisionAppendSequential, writes, seqWrites, overwriteWrites, iters, rangeIters, rangeIterPct)
 		return memtable.ModeAppendOnly
@@ -10692,7 +10851,10 @@ func (db *DB) storeMemtableMode(mode memtable.Mode) {
 	if db == nil {
 		return
 	}
-	db.memtableMode.Store(uint32(mode))
+	prev := memtable.Mode(db.memtableMode.Swap(uint32(mode)))
+	if prev == memtable.ModeAppendOnly && mode != memtable.ModeAppendOnly {
+		db.dropColdAppendOnlyPools()
+	}
 }
 
 func validateValueLogDomainThresholds(domains []backenddb.ValueLogDomainThreshold) error {
@@ -11081,7 +11243,12 @@ func Open(dir string, backend BackendDB, opts Options) (*DB, error) {
 	valueLogReader := reader
 	debugFlushPointers := envBool(envDebugFlushPointers)
 	debugFlushTiming := envBool(envDebugFlushTiming)
-	adaptiveBTreeMinIters := envUint64(envAdaptiveBTreeMinIteratorSamples, adaptiveBTreeMinIteratorSamplesDefault)
+	adaptiveBTreeMinIters := uint64(adaptiveBTreeMinIteratorSamplesDefault)
+	adaptiveBTreeMinItersSet := false
+	if v, ok := envUint64Optional(envAdaptiveBTreeMinIteratorSamples); ok {
+		adaptiveBTreeMinIters = v
+		adaptiveBTreeMinItersSet = true
+	}
 
 	valueLogCompressionMode := normalizeVlogCompressionMode(opts.ValueLogCompression)
 	if valueLogCompressionMode == vlogCompressionDefault {
@@ -11281,6 +11448,7 @@ func Open(dir string, backend BackendDB, opts Options) (*DB, error) {
 		memtableCap:                                memCap,
 		memtableAdaptive:                           adaptive,
 		memtableAdaptiveBTreeMinIters:              adaptiveBTreeMinIters,
+		memtableAdaptiveBTreeMinItersSet:           adaptiveBTreeMinItersSet,
 		memtableWarmupActive:                       adaptive && warmupThreshold < opts.FlushThreshold,
 		memtableWarmupThreshold:                    warmupThreshold,
 		domainIngressWorkers:                       domainIngressWorkers,
@@ -22185,6 +22353,14 @@ func (db *DB) checkpointRotateCapacity() int {
 	return capacity
 }
 
+func (db *DB) appendOnlyIdleMutableRetainCapacity() int {
+	capacity := db.checkpointRotateCapacity()
+	if db == nil || db.currentMemtableMode() != memtable.ModeAppendOnly || capacity <= appendOnlyIdleMutableRetainCapacity {
+		return capacity
+	}
+	return appendOnlyIdleMutableRetainCapacity
+}
+
 func (db *DB) observePublishWatermarkLagDrift(backlogBytes int64, now time.Time) float64 {
 	if db == nil {
 		return 0
@@ -22350,6 +22526,7 @@ func (db *DB) Checkpoint() error {
 		}
 		db.checkValueLogRetention()
 		db.scheduleRetainedValueLogPrune()
+		db.trimRetainedArenasAfterFlush(true)
 		return nil
 	} else if db.disableJournal && !hasQueue && !hasDirtyVLog {
 		// Checkpoint-kick retries may need to rotate current value-log segments
@@ -22378,6 +22555,7 @@ func (db *DB) Checkpoint() error {
 			}
 			db.checkValueLogRetention()
 			db.scheduleRetainedValueLogPrune()
+			db.trimRetainedArenasAfterFlush(true)
 			return nil
 		}
 	}
@@ -28712,8 +28890,24 @@ func (db *DB) Stats() map[string]string {
 	appendOnlyMemNewAllocTotal := db.appendOnlyMemNewAllocTotal.Load()
 	appendOnlyMemNewAllocWithQueue := db.appendOnlyMemNewAllocWithQueue.Load()
 	appendOnlyMemNewAllocQueueBytes := db.appendOnlyMemNewAllocQueueBytes.Load()
+	appendOnlyMemPoolDropTotal := db.appendOnlyMemPoolDropTotal.Load()
+	appendOnlyEntryPoolDropTotal := memtable.AppendOnlyEntryPoolDropTotal()
+	appendOnlyMemLeaseCount, appendOnlyMemLeaseEntryCapacity, appendOnlyMemLeaseEntryBackingBytes := db.appendOnlyMemLeaseStats()
+	appendOnlyMutableCount, appendOnlyMutableEntryCapacity, appendOnlyMutableEntryBackingBytes := db.appendOnlyMutableShardEntryStats()
+	appendOnlyMutableTrimTotal := db.appendOnlyMutableTrimTotal.Load()
+	appendOnlyMutableTrimDropped := db.appendOnlyMutableTrimDropped.Load()
 	stats["treedb.cache.append_only.entry_hint_entries"] = fmt.Sprintf("%d", appendOnlyEntryHint)
 	stats["treedb.cache.append_only.entry_hint_capacity_bytes"] = fmt.Sprintf("%d", appendOnlyHintCapacity)
+	stats["treedb.cache.append_only.entry_pool_drops_total"] = fmt.Sprintf("%d", appendOnlyEntryPoolDropTotal)
+	stats["treedb.cache.append_only.mem_lease_count"] = fmt.Sprintf("%d", appendOnlyMemLeaseCount)
+	stats["treedb.cache.append_only.mem_lease_entry_capacity"] = fmt.Sprintf("%d", appendOnlyMemLeaseEntryCapacity)
+	stats["treedb.cache.append_only.mem_lease_entry_backing_bytes"] = fmt.Sprintf("%d", appendOnlyMemLeaseEntryBackingBytes)
+	stats["treedb.cache.append_only.mutable_count"] = fmt.Sprintf("%d", appendOnlyMutableCount)
+	stats["treedb.cache.append_only.mutable_entry_capacity"] = fmt.Sprintf("%d", appendOnlyMutableEntryCapacity)
+	stats["treedb.cache.append_only.mutable_entry_backing_bytes"] = fmt.Sprintf("%d", appendOnlyMutableEntryBackingBytes)
+	stats["treedb.cache.append_only.mutable_trim_total"] = fmt.Sprintf("%d", appendOnlyMutableTrimTotal)
+	stats["treedb.cache.append_only.mutable_trim_dropped_bytes_total"] = fmt.Sprintf("%d", appendOnlyMutableTrimDropped)
+	stats["treedb.cache.append_only.mutable_pool_drops_total"] = fmt.Sprintf("%d", appendOnlyMemPoolDropTotal)
 	stats["treedb.cache.append_only.mutable_from_lease_total"] = fmt.Sprintf("%d", appendOnlyMemLeaseHitTotal)
 	stats["treedb.cache.append_only.mutable_from_pool_total"] = fmt.Sprintf("%d", appendOnlyMemPoolHitTotal)
 	stats["treedb.cache.append_only.mutable_new_alloc_total"] = fmt.Sprintf("%d", appendOnlyMemNewAllocTotal)
@@ -28721,6 +28915,16 @@ func (db *DB) Stats() map[string]string {
 	stats["treedb.cache.append_only.mutable_new_alloc_queue_bytes_sum"] = fmt.Sprintf("%d", appendOnlyMemNewAllocQueueBytes)
 	stats["treedb.process.append_only.entry_hint_entries"] = fmt.Sprintf("%d", appendOnlyEntryHint)
 	stats["treedb.process.append_only.entry_hint_capacity_bytes"] = fmt.Sprintf("%d", appendOnlyHintCapacity)
+	stats["treedb.process.append_only.entry_pool_drops_total"] = fmt.Sprintf("%d", appendOnlyEntryPoolDropTotal)
+	stats["treedb.process.append_only.mem_lease_count"] = fmt.Sprintf("%d", appendOnlyMemLeaseCount)
+	stats["treedb.process.append_only.mem_lease_entry_capacity"] = fmt.Sprintf("%d", appendOnlyMemLeaseEntryCapacity)
+	stats["treedb.process.append_only.mem_lease_entry_backing_bytes"] = fmt.Sprintf("%d", appendOnlyMemLeaseEntryBackingBytes)
+	stats["treedb.process.append_only.mutable_count"] = fmt.Sprintf("%d", appendOnlyMutableCount)
+	stats["treedb.process.append_only.mutable_entry_capacity"] = fmt.Sprintf("%d", appendOnlyMutableEntryCapacity)
+	stats["treedb.process.append_only.mutable_entry_backing_bytes"] = fmt.Sprintf("%d", appendOnlyMutableEntryBackingBytes)
+	stats["treedb.process.append_only.mutable_trim_total"] = fmt.Sprintf("%d", appendOnlyMutableTrimTotal)
+	stats["treedb.process.append_only.mutable_trim_dropped_bytes_total"] = fmt.Sprintf("%d", appendOnlyMutableTrimDropped)
+	stats["treedb.process.append_only.mutable_pool_drops_total"] = fmt.Sprintf("%d", appendOnlyMemPoolDropTotal)
 	stats["treedb.process.append_only.mutable_from_lease_total"] = fmt.Sprintf("%d", appendOnlyMemLeaseHitTotal)
 	stats["treedb.process.append_only.mutable_from_pool_total"] = fmt.Sprintf("%d", appendOnlyMemPoolHitTotal)
 	stats["treedb.process.append_only.mutable_new_alloc_total"] = fmt.Sprintf("%d", appendOnlyMemNewAllocTotal)
@@ -30948,6 +31152,10 @@ type Batch struct {
 	batchRange       keyRange
 	hasDeleteRanges  bool
 	commandWALAppend func() error
+
+	commandWALCompactReplay     bool
+	commandWALCompactRanges     []batch.DeleteRange
+	commandWALCompactPointStart int
 }
 
 func (db *DB) NewBatch() *Batch {
@@ -31478,6 +31686,9 @@ func (b *Batch) Reset() {
 	b.hasDeleteRanges = false
 	b.maxEntries = 0
 	b.commandWALAppend = nil
+	b.commandWALCompactReplay = false
+	b.commandWALCompactRanges = nil
+	b.commandWALCompactPointStart = 0
 	if b.ptrValueIdxs != nil {
 		b.ptrValueIdxs = b.ptrValueIdxs[:0]
 	}
@@ -32475,9 +32686,15 @@ func (b *Batch) writeRangeBatch(sync bool) error {
 	origHasRanges := b.hasDeleteRanges
 	origStreamEligible := b.streamEligible
 	origHasViewOps := b.hasViewOps
+	origCommandWALCompactReplay := b.commandWALCompactReplay
+	origCommandWALCompactRanges := b.commandWALCompactRanges
+	origCommandWALCompactPointStart := b.commandWALCompactPointStart
 	b.entries = materialized
 	b.hasDeleteRanges = false
 	b.streamEligible = false
+	b.commandWALCompactReplay = len(ranges) > 0
+	b.commandWALCompactRanges = ranges
+	b.commandWALCompactPointStart = len(materialized) - len(points)
 	// Materialization reallocates and reorders entries, so any ptrValueIdxs still
 	// refer to the original entry indexes. Force the safe copy path for this write
 	// instead of retaining batch arenas by stale indexes.
@@ -32488,6 +32705,9 @@ func (b *Batch) writeRangeBatch(sync bool) error {
 		b.hasDeleteRanges = origHasRanges
 		b.streamEligible = origStreamEligible
 		b.hasViewOps = origHasViewOps
+		b.commandWALCompactReplay = origCommandWALCompactReplay
+		b.commandWALCompactRanges = origCommandWALCompactRanges
+		b.commandWALCompactPointStart = origCommandWALCompactPointStart
 	}
 	return err
 }
@@ -33938,6 +34158,9 @@ func (b *Batch) Close() error {
 	b.firstKey = nil
 	b.lastKey = nil
 	b.ptrValueIdxs = nil
+	b.commandWALCompactReplay = false
+	b.commandWALCompactRanges = nil
+	b.commandWALCompactPointStart = 0
 	return nil
 }
 
@@ -33947,6 +34170,30 @@ func (b *Batch) Replay(fn func(batch.Entry) error) error {
 	}
 	if b.backend != nil {
 		return b.backend.Replay(fn)
+	}
+
+	if b.commandWALCompactReplay {
+		for _, r := range b.commandWALCompactRanges {
+			if batch.IsDeleteRangeNoop(r.Start, r.End) {
+				continue
+			}
+			if err := fn(batch.Entry{Type: batch.OpDeleteRange, Key: r.Start, Value: r.End}); err != nil {
+				return err
+			}
+		}
+		pointStart := b.commandWALCompactPointStart
+		if pointStart < 0 {
+			pointStart = 0
+		}
+		if pointStart > len(b.entries) {
+			pointStart = len(b.entries)
+		}
+		for _, entry := range b.entries[pointStart:] {
+			if err := fn(entry); err != nil {
+				return err
+			}
+		}
+		return nil
 	}
 
 	for _, entry := range b.entries {

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -11215,6 +11215,7 @@ func Open(dir string, backend BackendDB, opts Options) (*DB, error) {
 	}
 	memCap = shardCapacity(memCap, shardCount)
 	warmupCap := shardCapacity(memtableCapacity(warmupThreshold), shardCount)
+	warmupCap = mutableMemtableCapacityForMode(warmupCap, mode)
 	indexer := memtable.NewHashSortedIndexer()
 	mutableShards := make([]memShard, shardCount)
 	appendOnlyEstimate := appendOnlyEstimatedBytesPerEntryDefault

--- a/TreeDB/caching/expvar_stats_test.go
+++ b/TreeDB/caching/expvar_stats_test.go
@@ -18,7 +18,7 @@ func TestSelectTreeDBExpvarStatsFiltersAndCoerces(t *testing.T) {
 	stats := map[string]string{
 		"treedb.process.identity.wal_dir":                                        "/tmp/app.db/wal",
 		"treedb.vlog.mmap_active_bytes":                                          "22222",
-		"treedb.vlog.mmap_max_mapped_leaf_sealed_bytes":                          "2147483648",
+		"treedb.vlog.mmap_max_mapped_leaf_sealed_bytes":                          "1610612736",
 		"treedb.vlog.decode_buffer_grow.read_append_decoded_payload.calls_total": "17",
 		"treedb.vlog.decode_scratch.small_pool.retained_bytes":                   "16384",
 		"treedb.cache.vlog_mmap.active_bytes":                                    "12345",
@@ -66,8 +66,8 @@ func TestSelectTreeDBExpvarStatsFiltersAndCoerces(t *testing.T) {
 	if v, ok := got["treedb.cache.vlog_mmap.active_bytes"].(int64); !ok || v != 12345 {
 		t.Fatalf("active_bytes=%T(%v) want int64(12345)", got["treedb.cache.vlog_mmap.active_bytes"], got["treedb.cache.vlog_mmap.active_bytes"])
 	}
-	if v, ok := got["treedb.vlog.mmap_max_mapped_leaf_sealed_bytes"].(int64); !ok || v != 2147483648 {
-		t.Fatalf("backend leaf mmap byte cap=%T(%v) want int64(2147483648)", got["treedb.vlog.mmap_max_mapped_leaf_sealed_bytes"], got["treedb.vlog.mmap_max_mapped_leaf_sealed_bytes"])
+	if v, ok := got["treedb.vlog.mmap_max_mapped_leaf_sealed_bytes"].(int64); !ok || v != 1610612736 {
+		t.Fatalf("backend leaf mmap byte cap=%T(%v) want int64(1610612736)", got["treedb.vlog.mmap_max_mapped_leaf_sealed_bytes"], got["treedb.vlog.mmap_max_mapped_leaf_sealed_bytes"])
 	}
 	if v, ok := got["treedb.vlog.decode_buffer_grow.read_append_decoded_payload.calls_total"].(int64); !ok || v != 17 {
 		t.Fatalf("backend decoded payload calls=%T(%v) want int64(17)", got["treedb.vlog.decode_buffer_grow.read_append_decoded_payload.calls_total"], got["treedb.vlog.decode_buffer_grow.read_append_decoded_payload.calls_total"])

--- a/TreeDB/caching/flush_pool_helpers_test.go
+++ b/TreeDB/caching/flush_pool_helpers_test.go
@@ -833,6 +833,7 @@ func TestEntrySliceMaxReuseCapClampOverflow(t *testing.T) {
 
 func TestAppendOnlyMemtableLeaseReuse(t *testing.T) {
 	db := &DB{}
+	db.storeMemtableMode(memtable.ModeAppendOnly)
 	mt := memtable.NewAppendOnlyWithCapacity(4096)
 
 	db.recycleMemtables([]memtable.Table{mt})

--- a/TreeDB/caching/memory_stats_test.go
+++ b/TreeDB/caching/memory_stats_test.go
@@ -308,7 +308,7 @@ func TestProcessMemoryStatsIncludeBackendVlogMmap(t *testing.T) {
 			"treedb.vlog.mmap_current_segments":                "2",
 			"treedb.vlog.mmap_sealed_segments":                 "3",
 			"treedb.vlog.mmap_max_mapped_leaf_sealed_segments": "512",
-			"treedb.vlog.mmap_max_mapped_leaf_sealed_bytes":    "2147483648",
+			"treedb.vlog.mmap_max_mapped_leaf_sealed_bytes":    "1610612736",
 		},
 	}
 
@@ -340,8 +340,8 @@ func TestProcessMemoryStatsIncludeBackendVlogMmap(t *testing.T) {
 	if got := mustStatInt64(t, stats, "treedb.vlog.mmap_max_mapped_leaf_sealed_segments"); got != 512 {
 		t.Fatalf("backend leaf sealed segment cap=%d want 512", got)
 	}
-	if got := mustStatInt64(t, stats, "treedb.vlog.mmap_max_mapped_leaf_sealed_bytes"); got != 2147483648 {
-		t.Fatalf("backend leaf sealed byte cap=%d want 2147483648", got)
+	if got := mustStatInt64(t, stats, "treedb.vlog.mmap_max_mapped_leaf_sealed_bytes"); got != 1610612736 {
+		t.Fatalf("backend leaf sealed byte cap=%d want 1610612736", got)
 	}
 	if got := mustStatInt64(t, stats, "treedb.process.memory.vlog_mmap_cache_active_bytes"); got != 0 {
 		t.Fatalf("cache active_bytes=%d want 0", got)

--- a/TreeDB/caching/memtable_adaptive_test.go
+++ b/TreeDB/caching/memtable_adaptive_test.go
@@ -135,6 +135,28 @@ func TestAdaptiveMemtableMode_DefaultAdaptiveStartsWarmup(t *testing.T) {
 	}
 }
 
+func TestAdaptiveMemtableMode_BTreeMinIteratorSamplesEnvExplicitZero(t *testing.T) {
+	t.Setenv(envAdaptiveBTreeMinIteratorSamples, "0")
+
+	db, err := Open(t.TempDir(), NewMockBackend(), Options{
+		AllowUnsafe:              true,
+		DisableWAL:               true,
+		FlushThreshold:           1 << 30,
+		MemtableMode:             "adaptive",
+		MemtableShards:           1,
+		ValueLogPointerThreshold: 1 << 20,
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer db.Close()
+
+	stats := db.Stats()
+	if got := stats["treedb.cache.memtable_adaptive.btree_min_iterator_samples_effective"]; got != "0" {
+		t.Fatalf("expected explicit env zero to keep legacy BTree guard, got %q", got)
+	}
+}
+
 func TestAdaptiveMemtableMode_DefaultAdaptiveOverwriteHeavySwitchesToHashSorted(t *testing.T) {
 	dir := t.TempDir()
 	backend := NewMockBackend()

--- a/TreeDB/caching/memtable_view_refs_test.go
+++ b/TreeDB/caching/memtable_view_refs_test.go
@@ -48,6 +48,7 @@ func TestRetainMemtableViewSelfHealsZeroRefPublishedView(t *testing.T) {
 
 func TestPublishMemtablesDefersRetiredMemtableRecycleUntilFinalRelease(t *testing.T) {
 	db := &DB{}
+	db.storeMemtableMode(memtable.ModeAppendOnly)
 	retired := memtable.NewAppendOnlyWithCapacity(0)
 	retired.Set([]byte("k"), []byte("v"))
 	retired.Freeze()

--- a/TreeDB/caching/retained_arena_trim_test.go
+++ b/TreeDB/caching/retained_arena_trim_test.go
@@ -16,6 +16,7 @@ func TestTrimRetainedArenasAfterFlush_CheckpointPathTrimsAppendOnlyCaches(t *tes
 	db := &DB{
 		mutableShards: make([]memShard, 1),
 	}
+	db.storeMemtableMode(memtable.ModeAppendOnly)
 
 	leaseCount := postCheckpointAppendOnlyMemLeaseKeep + 6
 	for i := 0; i < leaseCount; i++ {
@@ -43,6 +44,7 @@ func TestTrimRetainedArenasAfterFlush_CheckpointPathTrimsAppendOnlyCaches(t *tes
 
 func TestTrimAppendOnlyMemLeases_DroppedLeasesReturnToPool(t *testing.T) {
 	var db DB
+	db.storeMemtableMode(memtable.ModeAppendOnly)
 
 	keep := 2
 	leaseCount := keep + 6
@@ -58,5 +60,156 @@ func TestTrimAppendOnlyMemLeases_DroppedLeasesReturnToPool(t *testing.T) {
 	}
 	if want := leaseCount - keep; returned != want {
 		t.Fatalf("returned append-only leases=%d want %d", returned, want)
+	}
+}
+
+func TestTrimAppendOnlyMemLeases_DropsColdWhenModeNotAppendOnly(t *testing.T) {
+	var db DB
+	db.storeMemtableMode(memtable.ModeBTree)
+
+	const leaseCount = 6
+	leases := make([]*memtable.AppendOnly, 0, leaseCount)
+	for i := 0; i < leaseCount; i++ {
+		mt := memtable.NewAppendOnlyWithCapacityEstimatedEntryBytes(4<<20, appendOnlyEstimatedBytesPerEntryDefault)
+		if mt.EntryCapacity() == 0 {
+			t.Fatal("test setup produced zero append-only entry capacity")
+		}
+		leases = append(leases, mt)
+		db.appendOnlyMemLeases = append(db.appendOnlyMemLeases, mt)
+	}
+
+	returned := db.trimAppendOnlyMemLeases(2, 4<<20)
+
+	if got := len(db.appendOnlyMemLeases); got != 0 {
+		t.Fatalf("append-only mem leases=%d want 0 after non-append-only trim", got)
+	}
+	if returned != leaseCount {
+		t.Fatalf("returned append-only leases=%d want %d", returned, leaseCount)
+	}
+	for i, mt := range leases {
+		if got := mt.EntryCapacity(); got != 0 {
+			t.Fatalf("lease %d retained entry capacity=%d want 0", i, got)
+		}
+	}
+}
+
+func TestRecycleAppendOnlyMemtables_DropsColdWhenModeNotAppendOnly(t *testing.T) {
+	var db DB
+	db.storeMemtableMode(memtable.ModeBTree)
+
+	mt := memtable.NewAppendOnlyWithCapacityEstimatedEntryBytes(4<<20, appendOnlyEstimatedBytesPerEntryDefault)
+	if mt.EntryCapacity() == 0 || mt.EntryBackingBytes() == 0 {
+		t.Fatal("test setup produced zero append-only entry backing")
+	}
+
+	db.recycleMemtables([]memtable.Table{mt})
+
+	if got := len(db.appendOnlyMemLeases); got != 0 {
+		t.Fatalf("append-only mem leases=%d want 0", got)
+	}
+	if got := mt.EntryCapacity(); got != 0 {
+		t.Fatalf("released append-only entry capacity=%d want 0", got)
+	}
+	count, entryCapacity, entryBackingBytes := db.appendOnlyMemLeaseStats()
+	if count != 0 || entryCapacity != 0 || entryBackingBytes != 0 {
+		t.Fatalf("append-only lease stats count=%d capacity=%d bytes=%d want all zero", count, entryCapacity, entryBackingBytes)
+	}
+}
+
+func TestStoreMemtableMode_DropsAppendOnlyPoolsOnColdTransition(t *testing.T) {
+	var db DB
+	db.storeMemtableMode(memtable.ModeAppendOnly)
+	beforePool := db.appendOnlyMemtablePool()
+	if beforePool == nil {
+		t.Fatal("expected append-only memtable pool")
+	}
+	beforeEntryPoolDrops := memtable.AppendOnlyEntryPoolDropTotal()
+
+	db.storeMemtableMode(memtable.ModeBTree)
+
+	afterPool := db.appendOnlyMemtablePool()
+	if afterPool == nil {
+		t.Fatal("expected replacement append-only memtable pool")
+	}
+	if afterPool == beforePool {
+		t.Fatal("append-only memtable pool was not replaced on cold transition")
+	}
+	if got := db.appendOnlyMemPoolDropTotal.Load(); got != 1 {
+		t.Fatalf("append-only memtable pool drops=%d want 1", got)
+	}
+	if got := memtable.AppendOnlyEntryPoolDropTotal(); got != beforeEntryPoolDrops+1 {
+		t.Fatalf("append-only entry pool drops=%d want %d", got, beforeEntryPoolDrops+1)
+	}
+}
+
+func TestTrimEmptyAppendOnlyMutableShards_DropsWarmEntryBacking(t *testing.T) {
+	const capacityBytes = 4 << 10
+	var db DB
+	db.storeMemtableMode(memtable.ModeAppendOnly)
+	db.mutableShards = make([]memShard, 1)
+	db.memtableCap = capacityBytes
+
+	mt := memtable.NewAppendOnlyWithCapacityEstimatedEntryBytes(capacityBytes, appendOnlyEstimatedBytesPerEntryDefault)
+	for i := 0; i < 1024; i++ {
+		mt.Set([]byte{byte(i), byte(i >> 8)}, []byte("value"))
+	}
+	mt.ResetWithCapacity(capacityBytes, appendOnlyEstimatedBytesPerEntryDefault)
+	warmCap := mt.EntryCapacity()
+	if warmCap <= 0 {
+		t.Fatal("test setup produced zero warm entry capacity")
+	}
+	db.mutableShards[0].mem = mt
+
+	trimmed := db.trimEmptyAppendOnlyMutableShards(capacityBytes)
+
+	if trimmed != 1 {
+		t.Fatalf("trimmed mutable shards=%d want 1", trimmed)
+	}
+	if got := mt.EntryCapacity(); got >= warmCap {
+		t.Fatalf("entry capacity after trim=%d want below warm capacity=%d", got, warmCap)
+	}
+	if got := db.appendOnlyMutableTrimTotal.Load(); got != 1 {
+		t.Fatalf("mutable trim total=%d want 1", got)
+	}
+	if got := db.appendOnlyMutableTrimDropped.Load(); got == 0 {
+		t.Fatal("mutable trim dropped bytes=0 want >0")
+	}
+}
+
+func TestAppendOnlyIdleMutableRetainCapacity_CapsEmptyShardBacking(t *testing.T) {
+	var db DB
+	db.storeMemtableMode(memtable.ModeAppendOnly)
+	db.memtableCap = 64 << 20
+	db.mutableShards = make([]memShard, 1)
+
+	activeCap := db.checkpointRotateCapacity()
+	if activeCap <= appendOnlyIdleMutableRetainCapacity {
+		t.Fatalf("checkpoint rotate capacity=%d want above idle cap=%d", activeCap, appendOnlyIdleMutableRetainCapacity)
+	}
+	idleCap := db.appendOnlyIdleMutableRetainCapacity()
+	if idleCap != appendOnlyIdleMutableRetainCapacity {
+		t.Fatalf("idle mutable retain capacity=%d want %d", idleCap, appendOnlyIdleMutableRetainCapacity)
+	}
+
+	mt := memtable.NewAppendOnlyWithCapacityEstimatedEntryBytes(activeCap, appendOnlyEstimatedBytesPerEntryDefault)
+	for i := 0; i < 4096; i++ {
+		mt.Set([]byte{byte(i), byte(i >> 8)}, []byte("value"))
+	}
+	mt.ResetWithCapacity(activeCap, appendOnlyEstimatedBytesPerEntryDefault)
+	before := mt.EntryBackingBytes()
+	if before <= 0 {
+		t.Fatal("test setup produced zero append-only entry backing")
+	}
+	db.mutableShards[0].mem = mt
+
+	if trimmed := db.trimEmptyAppendOnlyMutableShards(idleCap); trimmed != 1 {
+		t.Fatalf("trimmed mutable shards=%d want 1", trimmed)
+	}
+	after := mt.EntryBackingBytes()
+	if after >= before {
+		t.Fatalf("entry backing after trim=%d want below before=%d", after, before)
+	}
+	if after > int64(appendOnlyIdleMutableRetainCapacity) {
+		t.Fatalf("entry backing after trim=%d want <= idle cap=%d", after, appendOnlyIdleMutableRetainCapacity)
 	}
 }

--- a/TreeDB/caching/stats_test.go
+++ b/TreeDB/caching/stats_test.go
@@ -123,18 +123,39 @@ func TestChooseAdaptiveMode(t *testing.T) {
 		t.Errorf("sequential mode = %v, want %v", got, memtable.ModeAppendOnly)
 	}
 
-	// 3. High range scans -> BTree
+	// 3. Shallow range scans should not force BTree or hash-sorted on a small
+	// absolute sample when overwrite pressure is low.
 	// Reset
 	db.memtableStats.writes.Store(adaptiveMinWrites)
 	db.memtableStats.seqWrites.Store(adaptiveMinWrites / 10) // Low seq
 	db.memtableStats.overwriteWrites.Store(0)
 	db.memtableStats.iterators.Store(100)
 	db.memtableStats.rangeIters.Store(80) // 80% range
+	if got := db.chooseAdaptiveMemtableModeLocked(); got != memtable.ModeAppendOnly {
+		t.Errorf("shallow range scan mode = %v, want %v", got, memtable.ModeAppendOnly)
+	}
+
+	// 4. High range scans with enough absolute samples -> BTree
+	db.memtableStats.writes.Store(adaptiveMinWrites)
+	db.memtableStats.seqWrites.Store(adaptiveMinWrites / 10) // Low seq
+	db.memtableStats.overwriteWrites.Store(0)
+	db.memtableStats.iterators.Store(adaptiveBTreeMinIteratorSamplesDefault * 2)
+	db.memtableStats.rangeIters.Store(adaptiveBTreeMinIteratorSamplesDefault)
 	if got := db.chooseAdaptiveMemtableModeLocked(); got != memtable.ModeBTree {
 		t.Errorf("range scan mode = %v, want %v", got, memtable.ModeBTree)
 	}
 
-	// 4. High overwrites -> HashSorted
+	// 5. Blocked BTree with high overwrites -> HashSorted
+	db.memtableStats.writes.Store(adaptiveMinWrites)
+	db.memtableStats.seqWrites.Store(adaptiveMinWrites / 10)
+	db.memtableStats.overwriteWrites.Store(adaptiveMinWrites / 2)
+	db.memtableStats.iterators.Store(100)
+	db.memtableStats.rangeIters.Store(80)
+	if got := db.chooseAdaptiveMemtableModeLocked(); got != memtable.ModeHashSorted {
+		t.Errorf("blocked range overwrite mode = %v, want %v", got, memtable.ModeHashSorted)
+	}
+
+	// 6. High overwrites -> HashSorted
 	db.memtableStats.writes.Store(adaptiveMinWrites)
 	db.memtableStats.seqWrites.Store(adaptiveMinWrites)
 	db.memtableStats.overwriteWrites.Store(adaptiveMinWrites / 2)
@@ -142,6 +163,25 @@ func TestChooseAdaptiveMode(t *testing.T) {
 	db.memtableStats.rangeIters.Store(0)
 	if got := db.chooseAdaptiveMemtableModeLocked(); got != memtable.ModeHashSorted {
 		t.Errorf("overwrite mode = %v, want %v", got, memtable.ModeHashSorted)
+	}
+}
+
+func TestChooseAdaptiveMode_BTreeMinIteratorSamplesExplicitZero(t *testing.T) {
+	db := newAdaptiveStatsDB(memtable.ModeSkiplist)
+	db.memtableAdaptiveBTreeMinItersSet = true
+
+	if got := db.adaptiveBTreeMinIteratorSamples(); got != 0 {
+		t.Fatalf("effective min iterator samples=%d want 0", got)
+	}
+
+	db.memtableStats.writes.Store(adaptiveMinWrites)
+	db.memtableStats.seqWrites.Store(adaptiveMinWrites / 10)
+	db.memtableStats.overwriteWrites.Store(0)
+	db.memtableStats.iterators.Store(100)
+	db.memtableStats.rangeIters.Store(80)
+
+	if got := db.chooseAdaptiveMemtableModeLocked(); got != memtable.ModeBTree {
+		t.Fatalf("explicit-zero range-heavy mode = %v, want %v", got, memtable.ModeBTree)
 	}
 }
 
@@ -155,8 +195,8 @@ func TestChooseAdaptiveMode_BTreeMinIteratorSamplesOverride(t *testing.T) {
 	db.memtableStats.iterators.Store(32)
 	db.memtableStats.rangeIters.Store(32)
 
-	if got := db.chooseAdaptiveMemtableModeLocked(); got != memtable.ModeHashSorted {
-		t.Fatalf("blocked-btree mode = %v, want %v", got, memtable.ModeHashSorted)
+	if got := db.chooseAdaptiveMemtableModeLocked(); got != memtable.ModeAppendOnly {
+		t.Fatalf("blocked-btree mode = %v, want %v", got, memtable.ModeAppendOnly)
 	}
 	if got := db.memtableAdaptiveDecisionBTreeBlockedMinItersTotal.Load(); got != 1 {
 		t.Fatalf("blocked-min-iters count=%d want 1", got)
@@ -175,6 +215,16 @@ func TestChooseAdaptiveMode_BTreeMinIteratorSamplesOverride(t *testing.T) {
 	}
 	if got := adaptiveDecisionReasonString(db.memtableAdaptiveDecisionReason.Load()); got != "btree_range" {
 		t.Fatalf("last reason=%q want btree_range", got)
+	}
+}
+
+func TestMutableMemtableCapacityForMode_CapsHashSortedPrealloc(t *testing.T) {
+	oversized := hashSortedMutablePreallocCap * 32
+	if got := mutableMemtableCapacityForMode(oversized, memtable.ModeHashSorted); got != hashSortedMutablePreallocCap {
+		t.Fatalf("hash_sorted capacity hint=%d want %d", got, hashSortedMutablePreallocCap)
+	}
+	if got := mutableMemtableCapacityForMode(oversized, memtable.ModeAppendOnly); got != oversized {
+		t.Fatalf("append_only capacity hint=%d want %d", got, oversized)
 	}
 }
 

--- a/TreeDB/collections/column_physical_typed_column_one_shot_cache_3088_test.go
+++ b/TreeDB/collections/column_physical_typed_column_one_shot_cache_3088_test.go
@@ -406,12 +406,11 @@ func assertTypedColumnOneShotCacheDiagnostics3158(tb testing.TB, label string, d
 		if prepareNanos == 0 {
 			return
 		}
-		if diag.TypedColumnPreparePartDecodeNanos <= 0 {
-			tb.Fatalf("%s typed-column one-shot setup nanos build=%d prepare_sum=%d part_decode=%d diagnostics=%+v",
+		if diag.TypedColumnOneShotBuildNanos <= 0 {
+			tb.Fatalf("%s typed-column one-shot build nanos=%d want >0 prepare_sum=%d diagnostics=%+v",
 				label,
 				diag.TypedColumnOneShotBuildNanos,
 				prepareNanos,
-				diag.TypedColumnPreparePartDecodeNanos,
 				diag)
 		}
 		if diag.DenseInt64SpanUsed {

--- a/TreeDB/command_wal_public_cached.go
+++ b/TreeDB/command_wal_public_cached.go
@@ -48,11 +48,21 @@ func (tdb *DB) appendPublicRawKVCommandEntries(entries []batch.Entry, sync bool)
 	if tdb.backend == nil {
 		return ErrClosed
 	}
-	intent, err := tdb.backend.NewRawKVCommandWALIntentFromOrderedEntries(entries)
-	if err != nil {
-		return err
+	lsn, err := tdb.backend.AppendRawKVCommandWALOrderedEntries(entries, sync)
+	if lsn != 0 {
+		tdb.recordPublicCommandWALPendingLSN(lsn)
 	}
-	lsn, err := tdb.backend.AppendCommandWALIntent(intent, sync)
+	return err
+}
+
+func (tdb *DB) appendPublicRawKVCommandEntryScan(scanEntries func(func(batch.Entry) error) error, sync bool) error {
+	if tdb == nil || !tdb.commandWALCached || scanEntries == nil {
+		return nil
+	}
+	if tdb.backend == nil {
+		return ErrClosed
+	}
+	lsn, err := tdb.backend.AppendRawKVCommandWALOrderedEntryScan(scanEntries, sync)
 	if lsn != 0 {
 		tdb.recordPublicCommandWALPendingLSN(lsn)
 	}
@@ -63,12 +73,11 @@ func (tdb *DB) appendPublicRawKVDeleteRangeCommand(start, end []byte, sync bool)
 	if tdb == nil || !tdb.commandWALCached || batch.IsDeleteRangeNoop(start, end) {
 		return nil
 	}
-	var payload commitlog.RawKVBatchPayloadBuilder
-	_ = payload.ResetWithHint(1, len(start)+len(end))
-	if _, err := payload.AppendDeleteRange(start, end); err != nil {
-		return err
-	}
-	return tdb.appendPublicRawKVCommandPayload(payload.Payload(), sync)
+	return tdb.appendPublicRawKVCommandEntries([]batch.Entry{{
+		Type:  batch.OpDeleteRange,
+		Key:   start,
+		Value: end,
+	}}, sync)
 }
 
 func (tdb *DB) recordPublicCommandWALPendingLSN(lsn uint64) {
@@ -379,6 +388,15 @@ func (b *commandWALPublicBatch) setView(key, value []byte, retainReplayViews boo
 	b.preparePayloadForAppend()
 	key = normalizeRawKVPointKey(key)
 	value = normalizeRawKVValue(value)
+	if !retainReplayViews {
+		if err := b.inner.Set(key, value); err != nil {
+			return nil, nil, err
+		}
+		b.payloadBypass = true
+		b.opCount++
+		b.dirty = true
+		return nil, nil, nil
+	}
 	if retainReplayViews && commandWALPublicAllZeroBytes(value) {
 		// The raw-KV payload builder tracks the first zero value by backing-array
 		// identity so repeated immutable zero buffers can avoid rescanning. Adapter
@@ -436,6 +454,15 @@ func (b *commandWALPublicBatch) deleteView(key []byte, retainReplayViews bool) (
 	}
 	b.preparePayloadForAppend()
 	key = normalizeRawKVPointKey(key)
+	if !retainReplayViews {
+		if err := b.inner.Delete(key); err != nil {
+			return nil, err
+		}
+		b.payloadBypass = true
+		b.opCount++
+		b.dirty = true
+		return nil, nil
+	}
 	if b.shouldBypassPayloadAppendDelete(key, retainReplayViews) {
 		if err := b.inner.Delete(key); err != nil {
 			return nil, err
@@ -470,24 +497,10 @@ func (b *commandWALPublicBatch) DeleteRange(start, end []byte) error {
 		return nil
 	}
 	b.preparePayloadForAppend()
-	if b.shouldBypassPayloadAppendDeleteRange(start, end) {
-		if err := b.inner.DeleteRange(start, end); err != nil {
-			return err
-		}
-		b.payloadBypass = true
-		b.opCount++
-		b.hasDeleteRange = true
-		b.dirty = true
-		return nil
-	}
-	oldLen, oldCount := b.payload.Len(), b.payload.Count()
-	if _, err := b.payload.AppendDeleteRange(start, end); err != nil {
-		return err
-	}
 	if err := b.inner.DeleteRange(start, end); err != nil {
-		b.payload.Truncate(oldLen, oldCount)
 		return err
 	}
+	b.payloadBypass = true
 	b.opCount++
 	b.hasDeleteRange = true
 	b.dirty = true
@@ -680,28 +693,14 @@ func (b *commandWALPublicBatch) appendCommandWAL(sync bool) error {
 	if b == nil || b.inner == nil {
 		return ErrClosed
 	}
-	usePointerEntries := !b.hasDeleteRange || b.payloadBypass || b.payload.Count() != b.opCount
-	if usePointerEntries && b.db != nil && b.db.commandWALCached && b.db.backend != nil {
-		var entries []batch.Entry
-		hasPointer := false
-		if err := b.inner.Replay(func(entry batch.Entry) error {
-			if entry.Type == batch.OpPut && entry.IsPtr {
-				hasPointer = true
-			}
-			entries = append(entries, entry)
-			return nil
-		}); err != nil {
+	if !b.payloadBypass && b.payload.Count() == b.opCount && b.payload.Count() > 0 {
+		payload, err := b.commandWALPayload()
+		if err != nil {
 			return err
 		}
-		if hasPointer {
-			return b.db.appendPublicRawKVCommandEntries(entries, sync)
-		}
+		return b.db.appendPublicRawKVCommandPayload(payload, sync)
 	}
-	payload, err := b.commandWALPayload()
-	if err != nil {
-		return err
-	}
-	return b.db.appendPublicRawKVCommandPayload(payload, sync)
+	return b.db.appendPublicRawKVCommandEntryScan(b.inner.Replay, sync)
 }
 
 func (b *commandWALPublicBatch) Replay(fn func(batch.Entry) error) error {

--- a/TreeDB/command_wal_public_test.go
+++ b/TreeDB/command_wal_public_test.go
@@ -1238,40 +1238,32 @@ func TestPublicCommandWALBatchResetPreservesCompactZeroScanFallback(t *testing.T
 	}
 }
 
-func TestPublicCommandWALBatchPayloadSoftCapSwitchesToReplay(t *testing.T) {
+func TestPublicCommandWALBatchOrdinarySetBypassesPayloadBuilder(t *testing.T) {
 	inner := &commandWALPayloadSoftCapBatch{}
 	wrapped := newCommandWALPublicBatch(nil, inner, 0)
 	wrapped.payloadSoftCapBytes = 64
+	initialPayloadLen := wrapped.payload.Len()
+	initialPayloadCap := wrapped.payload.RetainedCap()
 
 	if err := wrapped.SetView([]byte("a"), []byte("b")); err != nil {
-		t.Fatalf("SetView below cap: %v", err)
+		t.Fatalf("SetView first: %v", err)
 	}
-	if inner.setViewCalls != 1 || inner.setCalls != 0 {
-		t.Fatalf("inner calls after first set: setView=%d set=%d, want 1/0", inner.setViewCalls, inner.setCalls)
-	}
-	firstPayloadLen := wrapped.payload.Len()
-	if firstPayloadLen <= 0 || firstPayloadLen > wrapped.payloadSoftCapBytes {
-		t.Fatalf("payload len after first set=%d cap=%d", firstPayloadLen, wrapped.payloadSoftCapBytes)
+	if !wrapped.payloadBypass || wrapped.payload.Count() != 0 || wrapped.payload.Len() != initialPayloadLen || wrapped.payload.RetainedCap() != initialPayloadCap {
+		t.Fatalf("payload after first set: bypass=%t count=%d len/cap=%d/%d, want true/0/%d/%d", wrapped.payloadBypass, wrapped.payload.Count(), wrapped.payload.Len(), wrapped.payload.RetainedCap(), initialPayloadLen, initialPayloadCap)
 	}
 
 	key := []byte("second")
 	value := bytes.Repeat([]byte("x"), 128)
 	if err := wrapped.SetView(key, value); err != nil {
-		t.Fatalf("SetView over cap: %v", err)
+		t.Fatalf("SetView second: %v", err)
 	}
 	key[0] = 'X'
 	value[0] = 'Y'
-	if !wrapped.payloadBypass {
-		t.Fatal("payload bypass not set after crossing soft cap")
+	if wrapped.payload.Count() != 0 || wrapped.opCount != 2 || wrapped.payload.Len() != initialPayloadLen || wrapped.payload.RetainedCap() != initialPayloadCap {
+		t.Fatalf("payload count=%d opCount=%d len/cap=%d/%d, want 0/2/%d/%d", wrapped.payload.Count(), wrapped.opCount, wrapped.payload.Len(), wrapped.payload.RetainedCap(), initialPayloadLen, initialPayloadCap)
 	}
-	if wrapped.payload.Count() != 1 || wrapped.opCount != 2 {
-		t.Fatalf("payload count=%d opCount=%d, want 1/2", wrapped.payload.Count(), wrapped.opCount)
-	}
-	if wrapped.payload.Len() != firstPayloadLen {
-		t.Fatalf("payload len grew after bypass: got %d want %d", wrapped.payload.Len(), firstPayloadLen)
-	}
-	if inner.setViewCalls != 1 || inner.setCalls != 1 {
-		t.Fatalf("inner calls after bypass: setView=%d set=%d, want 1/1", inner.setViewCalls, inner.setCalls)
+	if inner.setViewCalls != 0 || inner.setCalls != 2 {
+		t.Fatalf("inner calls: setView=%d set=%d, want 0/2", inner.setViewCalls, inner.setCalls)
 	}
 	if got := inner.entries[1]; string(got.Key) != "second" || string(got.Value) != strings.Repeat("x", 128) {
 		t.Fatalf("bypassed entry mutated or not copied: key=%q value_prefix=%q", got.Key, got.Value[:1])
@@ -1293,41 +1285,101 @@ func TestPublicCommandWALBatchPayloadSoftCapSwitchesToReplay(t *testing.T) {
 	}
 }
 
-func TestPublicCommandWALBatchPayloadSoftCapAccountsForRetainedCapGrowth(t *testing.T) {
+func TestPublicCommandWALBatchBypassStreamsReplayToCommandWAL(t *testing.T) {
+	dir := t.TempDir()
+	db, err := Open(Options{
+		Dir:                 dir,
+		Durability:          DurabilityWALOnRelaxed,
+		CommandWAL:          true,
+		CommandWALStatsScan: true,
+		DisableSideStores:   true,
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	inner := &commandWALPayloadSoftCapBatch{}
+	wrapped := newCommandWALPublicBatch(db, inner, 0)
+	wrapped.payloadSoftCapBytes = 64
+
+	if err := wrapped.SetView([]byte("alpha"), []byte("one")); err != nil {
+		t.Fatalf("SetView alpha: %v", err)
+	}
+	if err := wrapped.SetView([]byte("bravo"), bytes.Repeat([]byte("v"), 128)); err != nil {
+		t.Fatalf("SetView bravo: %v", err)
+	}
+	if !wrapped.payloadBypass {
+		t.Fatal("batch did not take payload-bypass path")
+	}
+	if err := wrapped.appendCommandWAL(false); err != nil {
+		t.Fatalf("appendCommandWAL: %v", err)
+	}
+	if inner.replayCalls != 2 {
+		t.Fatalf("inner replay calls=%d, want 2 planning/writing scans", inner.replayCalls)
+	}
+
+	r, err := commitlog.NewReader(filepath.Join(backenddb.WALDirPath(dir), "commit-l0-000001.log"))
+	if err != nil {
+		_ = db.Close()
+		t.Fatalf("NewReader: %v", err)
+	}
+	env, err := r.ReadCommandFrame()
+	if err != nil {
+		_ = r.Close()
+		_ = db.Close()
+		t.Fatalf("ReadCommandFrame: %v", err)
+	}
+	var got []batch.Entry
+	if err := commitlog.ScanRawKVBatchPayload(env.Payload, func(op commitlog.RawKVOp, key, value []byte) error {
+		got = append(got, batch.Entry{Type: batch.OpPut, Key: append([]byte(nil), key...), Value: append([]byte(nil), value...)})
+		return nil
+	}); err != nil {
+		_ = r.Close()
+		_ = db.Close()
+		t.Fatalf("ScanRawKVBatchPayload: %v", err)
+	}
+	if err := r.Close(); err != nil {
+		_ = db.Close()
+		t.Fatalf("reader Close: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if len(got) != 2 || string(got[0].Key) != "alpha" || string(got[0].Value) != "one" || string(got[1].Key) != "bravo" || string(got[1].Value) != strings.Repeat("v", 128) {
+		t.Fatalf("decoded streamed command WAL ops=%+v", got)
+	}
+}
+
+func TestPublicCommandWALBatchOrdinaryRetainedCapDoesNotGrow(t *testing.T) {
 	inner := &commandWALPayloadSoftCapBatch{}
 	wrapped := newCommandWALPublicBatch(nil, inner, 0)
 	wrapped.payloadSoftCapBytes = 100
+	initialPayloadLen := wrapped.payload.Len()
+	initialPayloadCap := wrapped.payload.RetainedCap()
 
 	if err := wrapped.SetView([]byte("a"), bytes.Repeat([]byte("x"), 70)); err != nil {
 		t.Fatalf("SetView first: %v", err)
 	}
-	firstLen := wrapped.payload.Len()
-	firstCap := wrapped.payload.RetainedCap()
-	if wrapped.payloadBypass {
-		t.Fatal("first append unexpectedly bypassed")
-	}
-	if firstCap <= 0 || firstCap >= wrapped.payloadSoftCapBytes || firstLen >= wrapped.payloadSoftCapBytes {
-		t.Fatalf("first retained len=%d cap=%d soft_cap=%d, want both below cap", firstLen, firstCap, wrapped.payloadSoftCapBytes)
+	if !wrapped.payloadBypass || wrapped.payload.Len() != initialPayloadLen || wrapped.payload.RetainedCap() != initialPayloadCap {
+		t.Fatalf("payload after first ordinary set: bypass=%t len/cap=%d/%d, want true/%d/%d", wrapped.payloadBypass, wrapped.payload.Len(), wrapped.payload.RetainedCap(), initialPayloadLen, initialPayloadCap)
 	}
 
 	if err := wrapped.SetView([]byte("b"), []byte("y")); err != nil {
 		t.Fatalf("SetView second: %v", err)
 	}
-	if !wrapped.payloadBypass {
-		t.Fatal("second append did not bypass retained-cap growth")
+	if wrapped.payload.Count() != 0 || wrapped.payload.Len() != initialPayloadLen || wrapped.payload.RetainedCap() != initialPayloadCap || wrapped.opCount != 2 {
+		t.Fatalf("payload after second ordinary set: count=%d len/cap=%d/%d opCount=%d, want 0/%d/%d/2", wrapped.payload.Count(), wrapped.payload.Len(), wrapped.payload.RetainedCap(), wrapped.opCount, initialPayloadLen, initialPayloadCap)
 	}
-	if wrapped.payload.Len() != firstLen || wrapped.payload.RetainedCap() != firstCap {
-		t.Fatalf("payload grew after retained-cap bypass: len/cap=%d/%d want %d/%d", wrapped.payload.Len(), wrapped.payload.RetainedCap(), firstLen, firstCap)
-	}
-	if inner.setViewCalls != 1 || inner.setCalls != 1 {
-		t.Fatalf("inner calls after retained-cap bypass: setView=%d set=%d, want 1/1", inner.setViewCalls, inner.setCalls)
+	if inner.setViewCalls != 0 || inner.setCalls != 2 {
+		t.Fatalf("inner calls: setView=%d set=%d, want 0/2", inner.setViewCalls, inner.setCalls)
 	}
 }
 
-func TestPublicCommandWALBatchPayloadSoftCapAccountsForCompactZeroMaterialization(t *testing.T) {
+func TestPublicCommandWALBatchOrdinaryCompactZeroDoesNotRetainPayload(t *testing.T) {
 	inner := &commandWALPayloadSoftCapBatch{}
 	wrapped := newCommandWALPublicBatch(nil, inner, 0)
 	wrapped.payloadSoftCapBytes = 96
+	initialPayloadLen := wrapped.payload.Len()
+	initialPayloadCap := wrapped.payload.RetainedCap()
 
 	for i := 0; i < 3; i++ {
 		key := []byte(fmt.Sprintf("zero-%03d", i))
@@ -1335,28 +1387,18 @@ func TestPublicCommandWALBatchPayloadSoftCapAccountsForCompactZeroMaterializatio
 			t.Fatalf("SetView compact zero %d: %v", i, err)
 		}
 	}
-	if wrapped.payloadBypass {
-		t.Fatal("compact zero appends bypassed before materialization was required")
-	}
-	firstCap := wrapped.payload.RetainedCap()
-	if firstCap > wrapped.payloadSoftCapBytes {
-		t.Fatalf("compact zero retained cap=%d, soft_cap=%d", firstCap, wrapped.payloadSoftCapBytes)
+	if !wrapped.payloadBypass || wrapped.payload.Count() != 0 || wrapped.payload.Len() != initialPayloadLen || wrapped.payload.RetainedCap() != initialPayloadCap {
+		t.Fatalf("payload after compact zeros: bypass=%t count=%d len/cap=%d/%d, want true/0/%d/%d", wrapped.payloadBypass, wrapped.payload.Count(), wrapped.payload.Len(), wrapped.payload.RetainedCap(), initialPayloadLen, initialPayloadCap)
 	}
 
 	if err := wrapped.SetView([]byte("nz"), []byte("x")); err != nil {
 		t.Fatalf("SetView non-zero after compact zeros: %v", err)
 	}
-	if !wrapped.payloadBypass {
-		t.Fatal("non-zero append did not bypass before compact-zero materialization")
+	if wrapped.payload.Count() != 0 || wrapped.opCount != 4 || wrapped.payload.Len() != initialPayloadLen || wrapped.payload.RetainedCap() != initialPayloadCap {
+		t.Fatalf("payload count=%d opCount=%d len/cap=%d/%d, want 0/4/%d/%d", wrapped.payload.Count(), wrapped.opCount, wrapped.payload.Len(), wrapped.payload.RetainedCap(), initialPayloadLen, initialPayloadCap)
 	}
-	if wrapped.payload.RetainedCap() != firstCap {
-		t.Fatalf("payload retained cap grew after materialization bypass: got %d want %d", wrapped.payload.RetainedCap(), firstCap)
-	}
-	if wrapped.payload.Count() != 3 || wrapped.opCount != 4 {
-		t.Fatalf("payload count=%d opCount=%d, want 3/4", wrapped.payload.Count(), wrapped.opCount)
-	}
-	if inner.setViewCalls != 3 || inner.setCalls != 1 {
-		t.Fatalf("inner calls after compact materialization bypass: setView=%d set=%d, want 3/1", inner.setViewCalls, inner.setCalls)
+	if inner.setViewCalls != 0 || inner.setCalls != 4 {
+		t.Fatalf("inner calls after compact zeros: setView=%d set=%d, want 0/4", inner.setViewCalls, inner.setCalls)
 	}
 }
 
@@ -1445,7 +1487,8 @@ func TestPublicCommandWALBatchPayloadSoftCapPreservesReplayViews(t *testing.T) {
 }
 
 type commandWALNoResetBatch struct {
-	entries []batch.Entry
+	entries     []batch.Entry
+	replayCalls int
 }
 
 type commandWALResetBatch struct {
@@ -1516,6 +1559,7 @@ func (b *commandWALNoResetBatch) WriteSync() error { return nil }
 func (b *commandWALNoResetBatch) Close() error { return nil }
 
 func (b *commandWALNoResetBatch) Replay(fn func(batch.Entry) error) error {
+	b.replayCalls++
 	for _, entry := range b.entries {
 		if err := fn(entry); err != nil {
 			return err

--- a/TreeDB/db/command_wal_raw.go
+++ b/TreeDB/db/command_wal_raw.go
@@ -19,6 +19,11 @@ type commandWALBatchIntent struct {
 	scope              commitlog.CommandScope
 	payloadFormat      commitlog.PayloadFormat
 	payload            []byte
+	rawKVEntries       []batchpkg.Entry
+	rawKVScan          commitlog.RawKVBatchOperationScanner
+	rawKVPlan          commitlog.RawKVBatchPayloadPlan
+	rawKVRIDCache      map[page.ValuePtr]uint64
+	rawKVDirect        bool
 	trustedPayload     bool
 	externalRefs       bool
 	externalRefFileIDs []uint32
@@ -415,53 +420,108 @@ func (db *DB) NewRawKVCommandWALIntentFromOrderedEntries(entries []batchpkg.Entr
 	if len(entries) == 0 {
 		return nil, nil
 	}
-	intent, err := db.newRawKVCommandWALIntentFromEntries(entries)
+	intent, err := db.newRawKVCommandWALPayloadIntentFromEntries(entries)
 	if intent == nil || err != nil {
 		return nil, err
 	}
 	return &CommandWALIntent{inner: *intent}, nil
 }
 
+// AppendRawKVCommandWALOrderedEntries appends a raw-KV command frame directly
+// from entries that are already in the caller's required application order. The
+// caller must keep entries and their key/value buffers immutable until this
+// method returns.
+func (db *DB) AppendRawKVCommandWALOrderedEntries(entries []batchpkg.Entry, sync bool) (uint64, error) {
+	if db == nil || !db.commandWAL {
+		return 0, nil
+	}
+	if db.durability == DurabilityWALOffRelaxed {
+		return 0, fmt.Errorf("%w: WAL-off durability is incompatible with command WAL", ErrCommandWALUnsupported)
+	}
+	if len(entries) == 0 {
+		return 0, nil
+	}
+	intent, err := db.newRawKVCommandWALIntentFromEntries(entries)
+	if intent == nil || err != nil {
+		return 0, err
+	}
+	return db.AppendCommandWALIntent(&CommandWALIntent{inner: *intent}, sync)
+}
+
+// AppendRawKVCommandWALOrderedEntryScan appends a raw-KV command frame by
+// replaying already-ordered entries directly into the command encoder. The
+// replay source must be deterministic and replayable because planning and
+// writing scan it separately. Callers must keep replayed entry buffers immutable
+// until this method returns.
+func (db *DB) AppendRawKVCommandWALOrderedEntryScan(scanEntries func(func(batchpkg.Entry) error) error, sync bool) (uint64, error) {
+	if db == nil || !db.commandWAL {
+		return 0, nil
+	}
+	if db.durability == DurabilityWALOffRelaxed {
+		return 0, fmt.Errorf("%w: WAL-off durability is incompatible with command WAL", ErrCommandWALUnsupported)
+	}
+	if scanEntries == nil {
+		return 0, nil
+	}
+	intent, err := db.newRawKVCommandWALIntentFromEntryScan(scanEntries)
+	if intent == nil || err != nil {
+		return 0, err
+	}
+	return db.AppendCommandWALIntent(&CommandWALIntent{inner: *intent}, sync)
+}
+
 func (db *DB) newRawKVCommandWALIntentFromEntries(entries []batchpkg.Entry) (*commandWALBatchIntent, error) {
-	externalRefs := false
-	var ridCache map[page.ValuePtr]uint64
-	var smallOps [16]commitlog.RawKVOperation
-	ops := smallOps[:0]
-	if len(entries) > len(smallOps) {
-		ops = make([]commitlog.RawKVOperation, 0, len(entries))
-	}
-	for i := range entries {
-		entry := entries[i]
-		switch entry.Type {
-		case batchpkg.OpDeleteRange:
-			if batchpkg.IsDeleteRangeNoop(entry.Key, entry.Value) {
-				continue
-			}
-			ops = append(ops, commitlog.RawKVOperation{Op: commitlog.RawKVOpDeleteRange, Key: entry.Key, Value: entry.Value})
-		case batchpkg.OpDelete:
-			ops = append(ops, commitlog.RawKVOperation{Op: commitlog.RawKVOpDelete, Key: entry.Key})
-		case batchpkg.OpPut:
-			if entry.IsPtr {
-				externalRefs = true
-				if ridCache == nil {
-					ridCache = make(map[page.ValuePtr]uint64)
-				}
-				rid, err := db.lookupCommandWALValueLogRID(entry.ValuePtr, ridCache)
-				if err != nil {
-					return nil, err
-				}
-				ops = append(ops, commitlog.RawKVOperation{Op: commitlog.RawKVOpSetRID, Key: entry.Key, RID: rid})
-				continue
-			}
-			ops = append(ops, commitlog.RawKVOperation{Op: commitlog.RawKVOpSet, Key: entry.Key, Value: entry.Value})
-		default:
-			return nil, fmt.Errorf("treedb: command wal unknown raw kv batch op %d", entry.Type)
-		}
-	}
-	if len(ops) == 0 {
+	if len(entries) == 0 {
 		return nil, nil
 	}
-	payload, err := commitlog.EncodeRawKVBatchPayload(ops)
+	return db.newRawKVCommandWALIntentFromEntryScan(func(emit func(batchpkg.Entry) error) error {
+		for i := range entries {
+			if err := emit(entries[i]); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+func (db *DB) newRawKVCommandWALIntentFromEntryScan(scanEntries func(func(batchpkg.Entry) error) error) (*commandWALBatchIntent, error) {
+	externalRefs := false
+	var ridCache map[page.ValuePtr]uint64
+	var externalRefFileIDs []uint32
+	planScan := db.rawKVCommandWALOperationScannerFromEntryScan(scanEntries, &ridCache, &externalRefs, &externalRefFileIDs)
+	plan, err := commitlog.PlanRawKVBatchPayloadScan(planScan)
+	if err != nil {
+		return nil, err
+	}
+	if plan.Count == 0 {
+		return nil, nil
+	}
+	writeScan := db.rawKVCommandWALOperationScannerFromEntryScan(scanEntries, &ridCache, nil, nil)
+	return &commandWALBatchIntent{
+		kind:               commitlog.CommandKindRawKVBatch,
+		scope:              commitlog.CommandScopeRawKV,
+		payloadFormat:      commitlog.PayloadFormatRawKVBatchV1,
+		rawKVScan:          writeScan,
+		rawKVPlan:          plan,
+		rawKVRIDCache:      ridCache,
+		rawKVDirect:        true,
+		externalRefs:       externalRefs,
+		externalRefFileIDs: externalRefFileIDs,
+	}, nil
+}
+
+func (db *DB) newRawKVCommandWALPayloadIntentFromEntries(entries []batchpkg.Entry) (*commandWALBatchIntent, error) {
+	externalRefs := false
+	var ridCache map[page.ValuePtr]uint64
+	scan := db.rawKVCommandWALOperationScanner(entries, &ridCache, &externalRefs)
+	plan, err := commitlog.PlanRawKVBatchPayloadScan(scan)
+	if err != nil {
+		return nil, err
+	}
+	if plan.Count == 0 {
+		return nil, nil
+	}
+	payload, err := commitlog.EncodeRawKVBatchPayloadScanWithHint(scan, plan.Count, 0)
 	if err != nil {
 		return nil, err
 	}
@@ -479,6 +539,70 @@ func (db *DB) newRawKVCommandWALIntentFromEntries(entries []batchpkg.Entry) (*co
 	}, nil
 }
 
+func (db *DB) rawKVCommandWALOperationScanner(entries []batchpkg.Entry, ridCache *map[page.ValuePtr]uint64, externalRefs *bool) commitlog.RawKVBatchOperationScanner {
+	return db.rawKVCommandWALOperationScannerFromEntryScan(func(emit func(batchpkg.Entry) error) error {
+		for i := range entries {
+			if err := emit(entries[i]); err != nil {
+				return err
+			}
+		}
+		return nil
+	}, ridCache, externalRefs, nil)
+}
+
+func (db *DB) rawKVCommandWALOperationScannerFromEntryScan(scanEntries func(func(batchpkg.Entry) error) error, ridCache *map[page.ValuePtr]uint64, externalRefs *bool, externalRefFileIDs *[]uint32) commitlog.RawKVBatchOperationScanner {
+	return func(emit func(commitlog.RawKVOperation) error) error {
+		if scanEntries == nil {
+			return nil
+		}
+		return scanEntries(func(entry batchpkg.Entry) error {
+			op, ok, err := db.rawKVCommandWALOperationFromEntry(entry, ridCache, externalRefs, externalRefFileIDs)
+			if err != nil {
+				return err
+			}
+			if !ok {
+				return nil
+			}
+			return emit(op)
+		})
+	}
+}
+
+func (db *DB) rawKVCommandWALOperationFromEntry(entry batchpkg.Entry, ridCache *map[page.ValuePtr]uint64, externalRefs *bool, externalRefFileIDs *[]uint32) (commitlog.RawKVOperation, bool, error) {
+	switch entry.Type {
+	case batchpkg.OpDeleteRange:
+		if batchpkg.IsDeleteRangeNoop(entry.Key, entry.Value) {
+			return commitlog.RawKVOperation{}, false, nil
+		}
+		return commitlog.RawKVOperation{Op: commitlog.RawKVOpDeleteRange, Key: entry.Key, Value: entry.Value}, true, nil
+	case batchpkg.OpDelete:
+		return commitlog.RawKVOperation{Op: commitlog.RawKVOpDelete, Key: entry.Key}, true, nil
+	case batchpkg.OpPut:
+		if entry.IsPtr {
+			if externalRefs != nil {
+				*externalRefs = true
+			}
+			if externalRefFileIDs != nil {
+				appendRawKVCommandWALExternalRefFileID(externalRefFileIDs, entry.ValuePtr.FileID)
+			}
+			if ridCache == nil {
+				return commitlog.RawKVOperation{}, false, fmt.Errorf("treedb: command wal raw kv rid cache unavailable")
+			}
+			if *ridCache == nil {
+				*ridCache = make(map[page.ValuePtr]uint64)
+			}
+			rid, err := db.lookupCommandWALValueLogRID(entry.ValuePtr, *ridCache)
+			if err != nil {
+				return commitlog.RawKVOperation{}, false, err
+			}
+			return commitlog.RawKVOperation{Op: commitlog.RawKVOpSetRID, Key: entry.Key, RID: rid}, true, nil
+		}
+		return commitlog.RawKVOperation{Op: commitlog.RawKVOpSet, Key: entry.Key, Value: entry.Value}, true, nil
+	default:
+		return commitlog.RawKVOperation{}, false, fmt.Errorf("treedb: command wal unknown raw kv batch op %d", entry.Type)
+	}
+}
+
 func rawKVCommandWALExternalRefFileIDs(entries []batchpkg.Entry) []uint32 {
 	var ids []uint32
 	for i := range entries {
@@ -486,18 +610,21 @@ func rawKVCommandWALExternalRefFileIDs(entries []batchpkg.Entry) []uint32 {
 		if entry.Type != batchpkg.OpPut || !entry.IsPtr || entry.ValuePtr.FileID == 0 {
 			continue
 		}
-		seen := false
-		for _, id := range ids {
-			if id == entry.ValuePtr.FileID {
-				seen = true
-				break
-			}
-		}
-		if !seen {
-			ids = append(ids, entry.ValuePtr.FileID)
-		}
+		appendRawKVCommandWALExternalRefFileID(&ids, entry.ValuePtr.FileID)
 	}
 	return ids
+}
+
+func appendRawKVCommandWALExternalRefFileID(ids *[]uint32, fileID uint32) {
+	if ids == nil || fileID == 0 {
+		return
+	}
+	for _, id := range *ids {
+		if id == fileID {
+			return
+		}
+	}
+	*ids = append(*ids, fileID)
 }
 
 func (db *DB) lookupCommandWALValueLogRID(ptr page.ValuePtr, ridCache map[page.ValuePtr]uint64) (uint64, error) {
@@ -971,7 +1098,13 @@ func (db *DB) appendCommandWALIntent(intent *commandWALBatchIntent, sync bool) (
 	db.mu.RUnlock()
 	var lsn uint64
 	var err error
-	if intent.trustedPayload && !intent.externalRefs {
+	if intent.rawKVDirect {
+		scan := intent.rawKVScan
+		if scan == nil {
+			scan = db.rawKVCommandWALOperationScanner(intent.rawKVEntries, &intent.rawKVRIDCache, nil)
+		}
+		lsn, err = db.commandJournal.AppendRawKVBatchPayloadScanCommandTrusted(baseAppliedLSN, intent.rawKVPlan, scan)
+	} else if intent.trustedPayload && !intent.externalRefs {
 		lsn, err = db.commandJournal.AppendCommandPayloadTrusted(intent.kind, intent.scope, intent.payloadFormat, baseAppliedLSN, intent.payload)
 	} else {
 		lsn, err = db.commandJournal.AppendCommand(commitlog.CommandEnvelope{

--- a/TreeDB/db/command_wal_raw_test.go
+++ b/TreeDB/db/command_wal_raw_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	batchpkg "github.com/snissn/gomap/TreeDB/batch"
 	"github.com/snissn/gomap/TreeDB/internal/commitlog"
 )
 
@@ -121,6 +122,207 @@ func TestAppendRawKVSingleCommandWALSupportsDeleteRange(t *testing.T) {
 	}
 	if len(ops) != 1 || ops[0].Op != commitlog.RawKVOpDeleteRange || ops[0].Key != nil || string(ops[0].Value) != "m" {
 		t.Fatalf("decoded DeleteRange ops=%+v, want single [nil,m)", ops)
+	}
+}
+
+func TestRawKVCommandWALIntentUsesDirectEntries(t *testing.T) {
+	dir := t.TempDir()
+	d, err := Open(Options{Dir: dir, CommandWAL: true, DisableBackgroundPrune: true})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	bi := d.NewBatch()
+	b, ok := bi.(*Batch)
+	if !ok {
+		_ = d.Close()
+		t.Fatalf("NewBatch type=%T, want *Batch", bi)
+	}
+	if err := b.Set([]byte("alpha"), []byte("one")); err != nil {
+		_ = b.Close()
+		_ = d.Close()
+		t.Fatalf("Set alpha: %v", err)
+	}
+	if err := b.Delete([]byte("bravo")); err != nil {
+		_ = b.Close()
+		_ = d.Close()
+		t.Fatalf("Delete bravo: %v", err)
+	}
+	if err := b.DeleteRange(nil, []byte("charlie")); err != nil {
+		_ = b.Close()
+		_ = d.Close()
+		t.Fatalf("DeleteRange: %v", err)
+	}
+	intent, err := d.prepareRawKVCommandWALIntent(b)
+	if err != nil {
+		_ = b.Close()
+		_ = d.Close()
+		t.Fatalf("prepareRawKVCommandWALIntent: %v", err)
+	}
+	if intent == nil || !intent.rawKVDirect || len(intent.payload) != 0 || intent.rawKVPlan.Count != 3 {
+		_ = b.Close()
+		_ = d.Close()
+		t.Fatalf("intent direct=%t payload_len=%d plan=%+v", intent != nil && intent.rawKVDirect, len(intent.payload), intent.rawKVPlan)
+	}
+	lsn, err := d.appendRawKVCommandWALIntent(intent, false)
+	if err != nil {
+		_ = b.Close()
+		_ = d.Close()
+		t.Fatalf("appendRawKVCommandWALIntent: %v", err)
+	}
+	if lsn == 0 || intent.lsn != lsn {
+		_ = b.Close()
+		_ = d.Close()
+		t.Fatalf("lsn=%d intent=%d, want non-zero match", lsn, intent.lsn)
+	}
+	if err := b.Close(); err != nil {
+		_ = d.Close()
+		t.Fatalf("batch Close: %v", err)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	r, err := commitlog.NewReader(filepath.Join(WALDirPath(dir), "commit-l0-000001.log"))
+	if err != nil {
+		t.Fatalf("NewReader: %v", err)
+	}
+	defer r.Close()
+	env, err := r.ReadCommandFrame()
+	if err != nil {
+		t.Fatalf("ReadCommandFrame: %v", err)
+	}
+	if env.LSN != lsn || env.Kind != commitlog.CommandKindRawKVBatch || env.Scope != commitlog.CommandScopeRawKV || env.PayloadFormat != commitlog.PayloadFormatRawKVBatchV1 {
+		t.Fatalf("decoded direct command identity mismatch: %+v", env)
+	}
+	var got []batchpkg.Entry
+	if err := commitlog.ScanRawKVBatchPayload(env.Payload, func(op commitlog.RawKVOp, key, value []byte) error {
+		got = append(got, batchpkg.Entry{Type: rawKVOpTypeForTest(op), Key: append([]byte(nil), key...), Value: append([]byte(nil), value...)})
+		return nil
+	}); err != nil {
+		t.Fatalf("ScanRawKVBatchPayload: %v", err)
+	}
+	if len(got) != 3 || got[0].Type != batchpkg.OpPut || string(got[0].Key) != "alpha" || string(got[0].Value) != "one" || got[1].Type != batchpkg.OpDelete || string(got[1].Key) != "bravo" || got[2].Type != batchpkg.OpDeleteRange || got[2].Key != nil || string(got[2].Value) != "charlie" {
+		t.Fatalf("decoded direct ops=%+v", got)
+	}
+}
+
+func TestAppendRawKVCommandWALOrderedEntryScanStreamsReplay(t *testing.T) {
+	dir := t.TempDir()
+	d, err := Open(Options{Dir: dir, CommandWAL: true, DisableBackgroundPrune: true})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	entries := []batchpkg.Entry{
+		{Type: batchpkg.OpPut, Key: []byte("alpha"), Value: []byte("one")},
+		{Type: batchpkg.OpDelete, Key: []byte("bravo")},
+		{Type: batchpkg.OpPut, Key: []byte("charlie"), Value: []byte(strings.Repeat("x", 128))},
+	}
+	replayCalls := 0
+	lsn, err := d.AppendRawKVCommandWALOrderedEntryScan(func(emit func(batchpkg.Entry) error) error {
+		replayCalls++
+		for i := range entries {
+			if err := emit(entries[i]); err != nil {
+				return err
+			}
+		}
+		return nil
+	}, false)
+	if err != nil {
+		_ = d.Close()
+		t.Fatalf("AppendRawKVCommandWALOrderedEntryScan: %v", err)
+	}
+	if lsn == 0 {
+		_ = d.Close()
+		t.Fatal("AppendRawKVCommandWALOrderedEntryScan lsn=0")
+	}
+	if replayCalls != 2 {
+		_ = d.Close()
+		t.Fatalf("replay calls=%d, want 2 planning/writing scans", replayCalls)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	r, err := commitlog.NewReader(filepath.Join(WALDirPath(dir), "commit-l0-000001.log"))
+	if err != nil {
+		t.Fatalf("NewReader: %v", err)
+	}
+	defer r.Close()
+	env, err := r.ReadCommandFrame()
+	if err != nil {
+		t.Fatalf("ReadCommandFrame: %v", err)
+	}
+	var got []batchpkg.Entry
+	if err := commitlog.ScanRawKVBatchPayload(env.Payload, func(op commitlog.RawKVOp, key, value []byte) error {
+		got = append(got, batchpkg.Entry{Type: rawKVOpTypeForTest(op), Key: append([]byte(nil), key...), Value: append([]byte(nil), value...)})
+		return nil
+	}); err != nil {
+		t.Fatalf("ScanRawKVBatchPayload: %v", err)
+	}
+	if len(got) != 3 || got[0].Type != batchpkg.OpPut || string(got[0].Key) != "alpha" || string(got[0].Value) != "one" || got[1].Type != batchpkg.OpDelete || string(got[1].Key) != "bravo" || got[2].Type != batchpkg.OpPut || string(got[2].Key) != "charlie" || string(got[2].Value) != strings.Repeat("x", 128) {
+		t.Fatalf("decoded scan ops=%+v", got)
+	}
+}
+
+func TestRawKVOrderedEntriesIntentOwnsPayloadBytes(t *testing.T) {
+	dir := t.TempDir()
+	d, err := Open(Options{Dir: dir, CommandWAL: true, DisableBackgroundPrune: true})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	key := []byte("alpha")
+	value := []byte("one")
+	entries := []batchpkg.Entry{{Type: batchpkg.OpPut, Key: key, Value: value}}
+	intent, err := d.NewRawKVCommandWALIntentFromOrderedEntries(entries)
+	if err != nil {
+		_ = d.Close()
+		t.Fatalf("NewRawKVCommandWALIntentFromOrderedEntries: %v", err)
+	}
+	key[0] = 'X'
+	value[0] = 'Y'
+	entries[0] = batchpkg.Entry{Type: batchpkg.OpDelete, Key: []byte("mutated")}
+
+	lsn, err := d.AppendCommandWALIntent(intent, false)
+	if err != nil {
+		_ = d.Close()
+		t.Fatalf("AppendCommandWALIntent: %v", err)
+	}
+	if lsn == 0 {
+		_ = d.Close()
+		t.Fatal("AppendCommandWALIntent lsn=0")
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	r, err := commitlog.NewReader(filepath.Join(WALDirPath(dir), "commit-l0-000001.log"))
+	if err != nil {
+		t.Fatalf("NewReader: %v", err)
+	}
+	defer r.Close()
+	env, err := r.ReadCommandFrame()
+	if err != nil {
+		t.Fatalf("ReadCommandFrame: %v", err)
+	}
+	ops, err := commitlog.DecodeRawKVBatchPayload(env.Payload)
+	if err != nil {
+		t.Fatalf("DecodeRawKVBatchPayload: %v", err)
+	}
+	if len(ops) != 1 || ops[0].Op != commitlog.RawKVOpSet || string(ops[0].Key) != "alpha" || string(ops[0].Value) != "one" {
+		t.Fatalf("decoded mutable ordered-entry intent ops=%+v, want alpha=one", ops)
+	}
+}
+
+func rawKVOpTypeForTest(op commitlog.RawKVOp) batchpkg.OpType {
+	switch op {
+	case commitlog.RawKVOpSet, commitlog.RawKVOpSetRID:
+		return batchpkg.OpPut
+	case commitlog.RawKVOpDelete:
+		return batchpkg.OpDelete
+	case commitlog.RawKVOpDeleteRange:
+		return batchpkg.OpDeleteRange
+	default:
+		return batchpkg.OpPut
 	}
 }
 

--- a/TreeDB/internal/commitlog/command_frame.go
+++ b/TreeDB/internal/commitlog/command_frame.go
@@ -123,6 +123,19 @@ type RawKVOperation struct {
 	RID   uint64
 }
 
+// RawKVBatchOperationScanner replays RawKV operations in deterministic command
+// order. Implementations must be replayable: planning and writing scan the
+// same operations separately so large command frames do not need to materialize
+// a canonical payload slice.
+type RawKVBatchOperationScanner func(func(RawKVOperation) error) error
+
+// RawKVBatchPayloadPlan is the exact RawKVBatchV1 payload shape for a replayable
+// operation source.
+type RawKVBatchPayloadPlan struct {
+	Count      int
+	PayloadLen int
+}
+
 // RawKVBatchPayloadBuilder incrementally constructs a canonical RawKVBatch
 // payload while returning stable key/value views into the owned payload bytes.
 type RawKVBatchPayloadBuilder struct {
@@ -1672,72 +1685,198 @@ func validateCommandEnvelopePayload(env CommandEnvelope) error {
 }
 
 func EncodeRawKVBatchPayload(ops []RawKVOperation) ([]byte, error) {
-	if commandFrameIntExceedsUint32(len(ops)) {
-		return nil, ErrRecordTooLarge
+	scan := func(emit func(RawKVOperation) error) error {
+		for i := range ops {
+			if err := emit(ops[i]); err != nil {
+				return err
+			}
+		}
+		return nil
 	}
-	total := rawKVBatchHeaderSize
-	for i := range ops {
-		op := &ops[i]
-		if err := validateRawKVOperation(op); err != nil {
-			return nil, err
-		}
-		keyBytes := len(op.Key)
-		valueLen := len(op.Value)
-		if op.Op == RawKVOpSetRID {
-			valueLen = 8
-		} else if op.Op == RawKVOpDeleteRange {
-			_, startBytes, err := rawKVRangeBoundEncodedLen(op.Key)
-			if err != nil {
-				return nil, err
-			}
-			_, endBytes, err := rawKVRangeBoundEncodedLen(op.Value)
-			if err != nil {
-				return nil, err
-			}
-			keyBytes = startBytes
-			valueLen = endBytes
-		}
-		if commandFrameIntExceedsUint32(keyBytes) || commandFrameIntExceedsUint32(valueLen) {
-			return nil, ErrRecordTooLarge
-		}
-		total += rawKVOpHeaderSize + keyBytes + valueLen
+	plan, err := PlanRawKVBatchPayloadScan(scan)
+	if err != nil {
+		return nil, err
 	}
-	payload := make([]byte, total)
-	binary.LittleEndian.PutUint16(payload[0:2], rawKVBatchPayloadVersion)
-	binary.LittleEndian.PutUint32(payload[2:6], uint32(len(ops)))
-	off := rawKVBatchHeaderSize
-	for i := range ops {
-		op := &ops[i]
-		key := op.Key
-		value := op.Value
-		keyLen := uint32(len(key))
-		valueLen := uint32(len(value))
-		var ridBuf [8]byte
-		if op.Op == RawKVOpSetRID {
-			binary.LittleEndian.PutUint64(ridBuf[:], op.RID)
-			value = ridBuf[:]
-			valueLen = uint32(len(value))
-		} else if op.Op == RawKVOpDeleteRange {
-			var err error
-			keyLen, _, err = rawKVRangeBoundEncodedLen(key)
-			if err != nil {
-				return nil, err
-			}
-			valueLen, _, err = rawKVRangeBoundEncodedLen(value)
-			if err != nil {
-				return nil, err
-			}
-		}
-		payload[off] = byte(op.Op)
-		binary.LittleEndian.PutUint32(payload[off+1:off+5], keyLen)
-		binary.LittleEndian.PutUint32(payload[off+5:off+9], valueLen)
-		off += rawKVOpHeaderSize
-		copy(payload[off:], key)
-		off += len(key)
-		copy(payload[off:], value)
-		off += len(value)
+	return encodeRawKVBatchPayloadPlannedTo(nil, plan, scan)
+}
+
+// PlanRawKVBatchPayloadScan validates a replayable operation source and returns
+// the exact RawKVBatchV1 payload length needed to encode it.
+func PlanRawKVBatchPayloadScan(scan RawKVBatchOperationScanner) (RawKVBatchPayloadPlan, error) {
+	plan := RawKVBatchPayloadPlan{PayloadLen: rawKVBatchHeaderSize}
+	if scan == nil {
+		return plan, nil
 	}
-	return payload, nil
+	if err := scan(func(op RawKVOperation) error {
+		keyBytes, valueBytes, err := rawKVOperationPayloadLens(&op)
+		if err != nil {
+			return err
+		}
+		if commandFrameIntExceedsUint32(plan.Count + 1) {
+			return ErrRecordTooLarge
+		}
+		needed := rawKVOpHeaderSize + keyBytes + valueBytes
+		if needed < rawKVOpHeaderSize || plan.PayloadLen > int(^uint(0)>>1)-needed {
+			return ErrRecordTooLarge
+		}
+		plan.Count++
+		plan.PayloadLen += needed
+		if commandFrameIntExceedsUint32(plan.PayloadLen) {
+			return ErrRecordTooLarge
+		}
+		return nil
+	}); err != nil {
+		return RawKVBatchPayloadPlan{}, err
+	}
+	return plan, nil
+}
+
+func rawKVOperationPayloadLens(op *RawKVOperation) (keyBytes, valueBytes int, err error) {
+	if err := validateRawKVOperation(op); err != nil {
+		return 0, 0, err
+	}
+	keyBytes = len(op.Key)
+	valueBytes = len(op.Value)
+	if op.Op == RawKVOpSetRID {
+		valueBytes = 8
+	} else if op.Op == RawKVOpDeleteRange {
+		_, startBytes, err := rawKVRangeBoundEncodedLen(op.Key)
+		if err != nil {
+			return 0, 0, err
+		}
+		_, endBytes, err := rawKVRangeBoundEncodedLen(op.Value)
+		if err != nil {
+			return 0, 0, err
+		}
+		keyBytes = startBytes
+		valueBytes = endBytes
+	}
+	if commandFrameIntExceedsUint32(keyBytes) || commandFrameIntExceedsUint32(valueBytes) {
+		return 0, 0, ErrRecordTooLarge
+	}
+	return keyBytes, valueBytes, nil
+}
+
+func (plan RawKVBatchPayloadPlan) validate() error {
+	if plan.Count < 0 || plan.PayloadLen < rawKVBatchHeaderSize {
+		return ErrCorrupt
+	}
+	if commandFrameIntExceedsUint32(plan.Count) || commandFrameIntExceedsUint32(plan.PayloadLen) {
+		return ErrRecordTooLarge
+	}
+	if plan.Count == 0 && plan.PayloadLen != rawKVBatchHeaderSize {
+		return ErrCorrupt
+	}
+	if plan.Count > 0 && plan.PayloadLen == rawKVBatchHeaderSize {
+		return ErrCorrupt
+	}
+	return nil
+}
+
+func encodeRawKVBatchPayloadPlannedTo(dst []byte, plan RawKVBatchPayloadPlan, scan RawKVBatchOperationScanner) ([]byte, error) {
+	if err := plan.validate(); err != nil {
+		return nil, err
+	}
+	if cap(dst) < plan.PayloadLen {
+		dst = make([]byte, plan.PayloadLen)
+	} else {
+		dst = dst[:plan.PayloadLen]
+		clear(dst)
+	}
+	off := 0
+	if err := writeRawKVBatchPayloadPieces(plan, scan, func(part []byte) error {
+		copy(dst[off:], part)
+		off += len(part)
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	if off != plan.PayloadLen {
+		return nil, ErrCorrupt
+	}
+	return dst, nil
+}
+
+func writeRawKVBatchPayloadPieces(plan RawKVBatchPayloadPlan, scan RawKVBatchOperationScanner, write func([]byte) error) error {
+	if err := plan.validate(); err != nil {
+		return err
+	}
+	if write == nil {
+		return ErrCorrupt
+	}
+	var header [rawKVBatchHeaderSize]byte
+	binary.LittleEndian.PutUint16(header[0:2], rawKVBatchPayloadVersion)
+	binary.LittleEndian.PutUint32(header[2:6], uint32(plan.Count))
+	if err := write(header[:]); err != nil {
+		return err
+	}
+	if scan == nil {
+		if plan.Count != 0 {
+			return ErrCorrupt
+		}
+		return nil
+	}
+	count := 0
+	written := rawKVBatchHeaderSize
+	if err := scan(func(op RawKVOperation) error {
+		n, err := writeRawKVOperationPayloadPieces(op, write)
+		if err != nil {
+			return err
+		}
+		count++
+		written += n
+		return nil
+	}); err != nil {
+		return err
+	}
+	if count != plan.Count || written != plan.PayloadLen {
+		return ErrCorrupt
+	}
+	return nil
+}
+
+func writeRawKVOperationPayloadPieces(op RawKVOperation, write func([]byte) error) (int, error) {
+	keyBytes, valueBytes, err := rawKVOperationPayloadLens(&op)
+	if err != nil {
+		return 0, err
+	}
+	key := op.Key
+	value := op.Value
+	keyLen := uint32(len(key))
+	valueLen := uint32(len(value))
+	var ridBuf [8]byte
+	if op.Op == RawKVOpSetRID {
+		binary.LittleEndian.PutUint64(ridBuf[:], op.RID)
+		value = ridBuf[:]
+		valueLen = uint32(len(value))
+	} else if op.Op == RawKVOpDeleteRange {
+		keyLen, _, err = rawKVRangeBoundEncodedLen(key)
+		if err != nil {
+			return 0, err
+		}
+		valueLen, _, err = rawKVRangeBoundEncodedLen(value)
+		if err != nil {
+			return 0, err
+		}
+	}
+	var header [rawKVOpHeaderSize]byte
+	header[0] = byte(op.Op)
+	binary.LittleEndian.PutUint32(header[1:5], keyLen)
+	binary.LittleEndian.PutUint32(header[5:9], valueLen)
+	if err := write(header[:]); err != nil {
+		return 0, err
+	}
+	if len(key) > 0 {
+		if err := write(key); err != nil {
+			return 0, err
+		}
+	}
+	if len(value) > 0 {
+		if err := write(value); err != nil {
+			return 0, err
+		}
+	}
+	return rawKVOpHeaderSize + keyBytes + valueBytes, nil
 }
 
 // EncodeRawKVSingleOperationPayload encodes the common one-op RawKVBatch

--- a/TreeDB/internal/commitlog/command_frame_test.go
+++ b/TreeDB/internal/commitlog/command_frame_test.go
@@ -873,6 +873,108 @@ func TestWriterAppendRawKVBatchPayloadCommandDirect(t *testing.T) {
 	}
 }
 
+func TestWriterAppendRawKVBatchPayloadScanCommandDirectBuffered(t *testing.T) {
+	ops := []RawKVOperation{
+		{Op: RawKVOpSet, Key: []byte("alpha"), Value: []byte("one")},
+		{Op: RawKVOpDelete, Key: []byte("bravo")},
+		{Op: RawKVOpDeleteRange, Key: nil, Value: []byte("delta")},
+		{Op: RawKVOpSetRID, Key: []byte("external"), RID: 42},
+	}
+	payload, err := EncodeRawKVBatchPayload(ops)
+	if err != nil {
+		t.Fatalf("EncodeRawKVBatchPayload: %v", err)
+	}
+	scan := rawKVOperationSliceScanner(ops)
+	plan, err := PlanRawKVBatchPayloadScan(scan)
+	if err != nil {
+		t.Fatalf("PlanRawKVBatchPayloadScan: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "commit-l0-000001.log")
+	w, err := NewWriterWithOptions(path, Options{DeferredCommandBufferSize: 4096})
+	if err != nil {
+		t.Fatalf("NewWriterWithOptions: %v", err)
+	}
+	if err := w.AppendRawKVBatchPayloadScanCommandDirectTrusted(7, 3, plan, scan); err != nil {
+		_ = w.Close()
+		t.Fatalf("AppendRawKVBatchPayloadScanCommandDirectTrusted: %v", err)
+	}
+	if got := len(w.commandBuf); got == 0 {
+		_ = w.Close()
+		t.Fatal("direct scan command frame was not buffered")
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close writer: %v", err)
+	}
+	assertRawKVCommandFramePayload(t, path, 7, 3, payload)
+}
+
+func TestWriterAppendRawKVBatchPayloadScanCommandDirectLarge(t *testing.T) {
+	ops := []RawKVOperation{
+		{Op: RawKVOpSet, Key: []byte("large"), Value: bytes.Repeat([]byte("x"), directCommandPayloadMinLen)},
+		{Op: RawKVOpDeleteRange, Key: []byte("m"), Value: nil},
+	}
+	payload, err := EncodeRawKVBatchPayload(ops)
+	if err != nil {
+		t.Fatalf("EncodeRawKVBatchPayload: %v", err)
+	}
+	scan := rawKVOperationSliceScanner(ops)
+	plan, err := PlanRawKVBatchPayloadScan(scan)
+	if err != nil {
+		t.Fatalf("PlanRawKVBatchPayloadScan: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "commit-l0-000001.log")
+	w, err := NewWriterWithOptions(path, Options{DeferredCommandBufferSize: 64 << 20})
+	if err != nil {
+		t.Fatalf("NewWriterWithOptions: %v", err)
+	}
+	if err := w.AppendRawKVBatchPayloadScanCommandDirectTrusted(9, 4, plan, scan); err != nil {
+		_ = w.Close()
+		t.Fatalf("AppendRawKVBatchPayloadScanCommandDirectTrusted: %v", err)
+	}
+	if got := len(w.commandBuf); got != 0 {
+		_ = w.Close()
+		t.Fatalf("deferred command buffer len=%d, want 0 for large direct scan frame", got)
+	}
+	if got := w.Size(); got == 0 {
+		_ = w.Close()
+		t.Fatal("writer size after large direct scan append=0, want direct bytes accounted")
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close writer: %v", err)
+	}
+	assertRawKVCommandFramePayload(t, path, 9, 4, payload)
+}
+
+func rawKVOperationSliceScanner(ops []RawKVOperation) RawKVBatchOperationScanner {
+	return func(emit func(RawKVOperation) error) error {
+		for i := range ops {
+			if err := emit(ops[i]); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}
+
+func assertRawKVCommandFramePayload(t *testing.T, path string, lsn, baseAppliedLSN uint64, payload []byte) {
+	t.Helper()
+	r, err := NewReader(path)
+	if err != nil {
+		t.Fatalf("NewReader: %v", err)
+	}
+	defer r.Close()
+	env, err := r.ReadCommandFrame()
+	if err != nil {
+		t.Fatalf("ReadCommandFrame: %v", err)
+	}
+	if env.LSN != lsn || env.BaseAppliedLSN != baseAppliedLSN || env.Kind != CommandKindRawKVBatch || env.Scope != CommandScopeRawKV || env.PayloadFormat != PayloadFormatRawKVBatchV1 {
+		t.Fatalf("decoded command identity mismatch: %+v", env)
+	}
+	if !bytes.Equal(env.Payload, payload) {
+		t.Fatalf("payload mismatch\ngot  %x\nwant %x", env.Payload, payload)
+	}
+}
+
 func TestWriterAppendCommandPayloadDirectTrustedCollectionInsert(t *testing.T) {
 	payload, err := EncodeCollectionInsertBatchByIDPayload("users", []CollectionDocument{
 		{ID: []byte("user-001"), Document: []byte(`{"_id":"user-001","field0":"value0"}`)},

--- a/TreeDB/internal/commitlog/journal_owner.go
+++ b/TreeDB/internal/commitlog/journal_owner.go
@@ -803,6 +803,47 @@ func (j *CommandJournal) AppendRawKVBatchPayloadCommandTrusted(baseAppliedLSN ui
 	return lsn, nil
 }
 
+// AppendRawKVBatchPayloadScanCommandTrusted appends a caller-validated
+// replayable RawKVBatch operation source without materializing the canonical
+// payload slice.
+func (j *CommandJournal) AppendRawKVBatchPayloadScanCommandTrusted(baseAppliedLSN uint64, plan RawKVBatchPayloadPlan, scan RawKVBatchOperationScanner) (uint64, error) {
+	if j == nil {
+		return 0, errors.New("commitlog: command journal is closed")
+	}
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	if j.writer == nil || j.owner == nil {
+		return 0, errors.New("commitlog: command journal is closed")
+	}
+	if err := plan.validate(); err != nil {
+		return 0, err
+	}
+	size, err := commandFrameEncodedSizeFromLengths(plan.PayloadLen, 0, 0, 0)
+	if err != nil {
+		return 0, err
+	}
+	if j.writer.maxSegmentSize > 0 && int64(size) > j.writer.maxSegmentSize {
+		return 0, ErrRecordTooLarge
+	}
+	if size > int(segmentLenMask) {
+		return 0, ErrRecordTooLarge
+	}
+	if err := j.maybeRotateForFrameLocked(size, false); err != nil {
+		return 0, err
+	}
+	lsn, err := j.reserveLSNLocked()
+	if err != nil {
+		return 0, err
+	}
+	if err := j.writer.AppendRawKVBatchPayloadScanCommandDirectTrusted(lsn, baseAppliedLSN, plan, scan); err != nil {
+		if rollbackErr := j.owner.rollbackReservedLSN(lsn); rollbackErr != nil {
+			return 0, errors.Join(err, rollbackErr)
+		}
+		return 0, err
+	}
+	return lsn, nil
+}
+
 // AppendCommandPayloadTrusted appends a caller-validated canonical command
 // payload. It validates only command identity and frame size; callers must use
 // this only for payloads built by the matching commitlog encoder.
@@ -891,6 +932,51 @@ func (j *CommandJournal) AppendRawKVBatchPayloadCommandTrustedAndFlush(baseAppli
 		return 0, err
 	}
 	if err := j.writer.AppendRawKVBatchPayloadCommandDirectTrusted(lsn, baseAppliedLSN, payload); err != nil {
+		if rollbackErr := j.owner.rollbackReservedLSN(lsn); rollbackErr != nil {
+			return 0, errors.Join(err, rollbackErr)
+		}
+		return 0, err
+	}
+	err = j.flushLocked(sync)
+	if err != nil {
+		return lsn, err
+	}
+	return lsn, nil
+}
+
+// AppendRawKVBatchPayloadScanCommandTrustedAndFlush appends a caller-validated
+// replayable RawKVBatch operation source and flushes/syncs the writer while
+// holding the journal lock.
+func (j *CommandJournal) AppendRawKVBatchPayloadScanCommandTrustedAndFlush(baseAppliedLSN uint64, plan RawKVBatchPayloadPlan, scan RawKVBatchOperationScanner, sync bool) (uint64, error) {
+	if j == nil {
+		return 0, errors.New("commitlog: command journal is closed")
+	}
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	if j.writer == nil || j.owner == nil {
+		return 0, errors.New("commitlog: command journal is closed")
+	}
+	if err := plan.validate(); err != nil {
+		return 0, err
+	}
+	size, err := commandFrameEncodedSizeFromLengths(plan.PayloadLen, 0, 0, 0)
+	if err != nil {
+		return 0, err
+	}
+	if j.writer.maxSegmentSize > 0 && int64(size) > j.writer.maxSegmentSize {
+		return 0, ErrRecordTooLarge
+	}
+	if size > int(segmentLenMask) {
+		return 0, ErrRecordTooLarge
+	}
+	if err := j.maybeRotateForFrameLocked(size, sync); err != nil {
+		return 0, err
+	}
+	lsn, err := j.reserveLSNLocked()
+	if err != nil {
+		return 0, err
+	}
+	if err := j.writer.AppendRawKVBatchPayloadScanCommandDirectTrusted(lsn, baseAppliedLSN, plan, scan); err != nil {
 		if rollbackErr := j.owner.rollbackReservedLSN(lsn); rollbackErr != nil {
 			return 0, errors.Join(err, rollbackErr)
 		}

--- a/TreeDB/internal/commitlog/writer.go
+++ b/TreeDB/internal/commitlog/writer.go
@@ -853,6 +853,66 @@ func (w *Writer) AppendRawKVBatchPayloadCommandDirectTrusted(lsn, baseAppliedLSN
 	return w.appendRawKVBatchPayloadCommandDirect(lsn, baseAppliedLSN, payload, size)
 }
 
+// AppendRawKVBatchPayloadScanCommandDirectTrusted appends a RawKVBatch command
+// from a replayable operation scanner without materializing the canonical
+// payload slice first.
+func (w *Writer) AppendRawKVBatchPayloadScanCommandDirectTrusted(lsn, baseAppliedLSN uint64, plan RawKVBatchPayloadPlan, scan RawKVBatchOperationScanner) error {
+	if err := w.commandBufferError(); err != nil {
+		return err
+	}
+	if lsn == 0 {
+		return fmt.Errorf("%w: zero lsn", ErrCorrupt)
+	}
+	if err := plan.validate(); err != nil {
+		return err
+	}
+	size, err := commandFrameEncodedSizeFromLengths(plan.PayloadLen, 0, 0, 0)
+	if err != nil {
+		return err
+	}
+	if w.maxSegmentSize > 0 && int64(size) > w.maxSegmentSize {
+		return ErrRecordTooLarge
+	}
+	if size > int(segmentLenMask) {
+		return ErrRecordTooLarge
+	}
+	if w.pendingBatchRecs != 0 {
+		if err := w.flushPendingBatch(); err != nil {
+			return err
+		}
+	}
+	total := segmentHeaderSize + size
+	if plan.PayloadLen >= directCommandPayloadMinLen {
+		return w.appendRawKVBatchPayloadScanCommandDirect(lsn, baseAppliedLSN, plan, scan, size)
+	}
+	if w.canBufferCommandFrame(total) {
+		off, err := w.reserveCommandBufferSpace(total)
+		if err != nil {
+			return err
+		}
+		newLen := off + total
+		buf := w.commandBuf[off:newLen]
+		frame := buf[segmentHeaderSize : segmentHeaderSize+size]
+		fillRawKVCommandFrameHeader(frame[:commandFrameHeaderSize], lsn, baseAppliedLSN, plan.PayloadLen)
+		payloadOff := commandFrameHeaderSize
+		if err := writeRawKVBatchPayloadPieces(plan, scan, func(part []byte) error {
+			copy(frame[payloadOff:], part)
+			payloadOff += len(part)
+			return nil
+		}); err != nil {
+			w.commandBuf = w.commandBuf[:off]
+			return err
+		}
+		if payloadOff != size {
+			w.commandBuf = w.commandBuf[:off]
+			return ErrCorrupt
+		}
+		binary.LittleEndian.PutUint32(buf[0:4], uint32(size))
+		return nil
+	}
+	return w.appendRawKVBatchPayloadScanCommandDirect(lsn, baseAppliedLSN, plan, scan, size)
+}
+
 // AppendCommandPayloadDirectTrusted appends a canonical command payload whose
 // bytes were constructed by the matching payload encoder.
 func (w *Writer) AppendCommandPayloadDirectTrusted(lsn, baseAppliedLSN uint64, kind CommandKind, scope CommandScope, format PayloadFormat, payload []byte) error {
@@ -916,10 +976,7 @@ func (w *Writer) appendRawKVBatchPayloadCommandDirect(lsn, baseAppliedLSN uint64
 	}
 	var prefix [segmentHeaderSize + commandFrameHeaderSize]byte
 	frameHeader := prefix[segmentHeaderSize:]
-	copy(frameHeader, rawKVCommandFrameHeaderTemplate[:])
-	binary.LittleEndian.PutUint64(frameHeader[20:28], lsn)
-	binary.LittleEndian.PutUint64(frameHeader[44:52], baseAppliedLSN)
-	binary.LittleEndian.PutUint32(frameHeader[56:60], uint32(len(payload)))
+	fillRawKVCommandFrameHeader(frameHeader, lsn, baseAppliedLSN, len(payload))
 	binary.LittleEndian.PutUint32(prefix[0:4], uint32(size))
 	binary.LittleEndian.PutUint32(prefix[4:8], crc.ChecksumParts(frameHeader, payload))
 	if len(payload) >= directCommandPayloadMinLen {
@@ -939,6 +996,76 @@ func (w *Writer) appendRawKVBatchPayloadCommandDirect(lsn, baseAppliedLSN uint64
 	if _, err := w.bw.Write(payload); err != nil {
 		return err
 	}
+	w.size += int64(segmentHeaderSize + size)
+	return nil
+}
+
+func (w *Writer) appendRawKVBatchPayloadScanCommandDirect(lsn, baseAppliedLSN uint64, plan RawKVBatchPayloadPlan, scan RawKVBatchOperationScanner, size int) error {
+	if w.pendingBatchRecs != 0 {
+		if err := w.flushPendingBatch(); err != nil {
+			return err
+		}
+	}
+	if err := w.flushBufferedCommandFrames(); err != nil {
+		return err
+	}
+	var prefix [segmentHeaderSize + commandFrameHeaderSize]byte
+	frameHeader := prefix[segmentHeaderSize:]
+	fillRawKVCommandFrameHeader(frameHeader, lsn, baseAppliedLSN, plan.PayloadLen)
+	sum := crc.Checksum(frameHeader)
+	if err := writeRawKVBatchPayloadPieces(plan, scan, func(part []byte) error {
+		sum = crc.Update(sum, part)
+		return nil
+	}); err != nil {
+		return err
+	}
+	binary.LittleEndian.PutUint32(prefix[0:4], uint32(size))
+	binary.LittleEndian.PutUint32(prefix[4:8], sum)
+	if err := w.bw.Flush(); err != nil {
+		return err
+	}
+	if err := writeFull(w.f, prefix[:]); err != nil {
+		return w.poisonCommandBuffer(err)
+	}
+	scratch := w.scratch[:0]
+	if cap(scratch) < batchChecksumChunkBytes {
+		scratch = make([]byte, 0, batchChecksumChunkBytes)
+	}
+	flushScratch := func() error {
+		if len(scratch) == 0 {
+			return nil
+		}
+		if err := writeFull(w.f, scratch); err != nil {
+			return err
+		}
+		scratch = scratch[:0]
+		return nil
+	}
+	if err := writeRawKVBatchPayloadPieces(plan, scan, func(part []byte) error {
+		for len(part) > 0 {
+			free := cap(scratch) - len(scratch)
+			if free == 0 {
+				if err := flushScratch(); err != nil {
+					return err
+				}
+				free = cap(scratch)
+			}
+			if free > len(part) {
+				free = len(part)
+			}
+			scratch = append(scratch, part[:free]...)
+			part = part[free:]
+		}
+		return nil
+	}); err != nil {
+		w.scratch = scratch[:0]
+		return w.poisonCommandBuffer(err)
+	}
+	if err := flushScratch(); err != nil {
+		w.scratch = scratch[:0]
+		return w.poisonCommandBuffer(err)
+	}
+	w.scratch = scratch[:0]
 	w.size += int64(segmentHeaderSize + size)
 	return nil
 }
@@ -976,6 +1103,13 @@ func (w *Writer) appendCommandPayloadDirectTrusted(lsn, baseAppliedLSN uint64, k
 	}
 	w.size += int64(segmentHeaderSize + size)
 	return nil
+}
+
+func fillRawKVCommandFrameHeader(frame []byte, lsn, baseAppliedLSN uint64, payloadLen int) {
+	copy(frame, rawKVCommandFrameHeaderTemplate[:])
+	binary.LittleEndian.PutUint64(frame[20:28], lsn)
+	binary.LittleEndian.PutUint64(frame[44:52], baseAppliedLSN)
+	binary.LittleEndian.PutUint32(frame[56:60], uint32(payloadLen))
 }
 
 func fillTrustedCommandFrameHeader(frame []byte, lsn, baseAppliedLSN uint64, kind CommandKind, scope CommandScope, format PayloadFormat, payloadLen int) {

--- a/TreeDB/internal/memtable/append_only.go
+++ b/TreeDB/internal/memtable/append_only.go
@@ -52,7 +52,8 @@ const (
 	appendOnlyAggressiveGrowCutoff      = appendOnlyResetDropThresholdEntries * 2
 )
 
-var appendOnlyEntryPools [appendOnlyEntryPoolClassCount]sync.Pool
+var appendOnlyEntryPoolPtrs [appendOnlyEntryPoolClassCount]atomic.Pointer[sync.Pool]
+var appendOnlyEntryPoolDropTotal atomic.Uint64
 var appendOnlyIteratorPool sync.Pool
 var appendOnlyIteratorPtrPool sync.Pool
 var appendOnlyValueArenaPools [appendOnlyValueArenaClassCount]sync.Pool
@@ -196,6 +197,35 @@ func appendOnlyEntryPoolClassForReusableCapacity(capacity int) (int, bool) {
 	return class, true
 }
 
+func appendOnlyEntryPoolForClass(class int) *sync.Pool {
+	if class < 0 || class >= len(appendOnlyEntryPoolPtrs) {
+		return nil
+	}
+	if pool := appendOnlyEntryPoolPtrs[class].Load(); pool != nil {
+		return pool
+	}
+	pool := &sync.Pool{}
+	if appendOnlyEntryPoolPtrs[class].CompareAndSwap(nil, pool) {
+		return pool
+	}
+	return appendOnlyEntryPoolPtrs[class].Load()
+}
+
+// DropAppendOnlyEntryPools abandons package-level append-only entry slice pools.
+// It is intended for cold transitions away from append-only mutable memtables,
+// where retaining restore-sized warm buffers hurts steady-state RSS more than it
+// helps near-term reuse.
+func DropAppendOnlyEntryPools() {
+	for i := range appendOnlyEntryPoolPtrs {
+		appendOnlyEntryPoolPtrs[i].Store(&sync.Pool{})
+	}
+	appendOnlyEntryPoolDropTotal.Add(1)
+}
+
+func AppendOnlyEntryPoolDropTotal() uint64 {
+	return appendOnlyEntryPoolDropTotal.Load()
+}
+
 func getAppendOnlyEntriesFromPool(length int, pool *sync.Pool) []appendOnlyEntry {
 	if length < 0 {
 		length = 0
@@ -227,10 +257,12 @@ func getAppendOnlyEntries(length int) []appendOnlyEntry {
 	if !ok {
 		return make([]appendOnlyEntry, length)
 	}
-	if v := appendOnlyEntryPools[class].Get(); v != nil {
-		if entries, ok := v.([]appendOnlyEntry); ok && cap(entries) >= length {
-			if cap(entries) <= appendOnlyMaxReuseEntries(length) {
-				return entries[:length]
+	if pool := appendOnlyEntryPoolForClass(class); pool != nil {
+		if v := pool.Get(); v != nil {
+			if entries, ok := v.([]appendOnlyEntry); ok && cap(entries) >= length {
+				if cap(entries) <= appendOnlyMaxReuseEntries(length) {
+					return entries[:length]
+				}
 			}
 		}
 	}
@@ -247,7 +279,9 @@ func putAppendOnlyEntries(entries []appendOnlyEntry) {
 	if !ok {
 		return
 	}
-	appendOnlyEntryPools[class].Put(full[:0])
+	if pool := appendOnlyEntryPoolForClass(class); pool != nil {
+		pool.Put(full[:0])
+	}
 }
 
 func getAppendOnlyIteratorEntries(length int) []appendOnlyEntry {
@@ -1522,6 +1556,26 @@ func (m *AppendOnly) Len() int {
 	return m.count
 }
 
+// EntryCapacity reports the retained append-only entry-slot capacity.
+func (m *AppendOnly) EntryCapacity() int {
+	if m == nil {
+		return 0
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return cap(m.entries)
+}
+
+// EntryBackingBytes reports the retained backing bytes for entry slots.
+func (m *AppendOnly) EntryBackingBytes() int64 {
+	if m == nil {
+		return 0
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return int64(cap(m.entries)) * int64(unsafe.Sizeof(appendOnlyEntry{}))
+}
+
 func (m *AppendOnly) Freeze() {
 	m.mu.Lock()
 	if m.frozen {
@@ -1597,6 +1651,17 @@ func (m *AppendOnly) Reset() {
 // longer needed. Unlike Reset, it does not retain warm capacity on the table
 // itself, so callers should only use it for short-lived tables they will drop.
 func (m *AppendOnly) Release() {
+	m.release(true)
+}
+
+// ReleaseDropEntries releases the table without returning its entry backing
+// slice to the package pool. Use this for cold paths where the caller does not
+// expect near-term append-only reuse and wants to shed post-spike heap.
+func (m *AppendOnly) ReleaseDropEntries() {
+	m.release(false)
+}
+
+func (m *AppendOnly) release(poolEntries bool) {
 	if m == nil {
 		return
 	}
@@ -1627,7 +1692,9 @@ func (m *AppendOnly) Release() {
 	m.frozenFast.Store(false)
 	m.hasLast = false
 	m.lastIdx = -1
-	putAppendOnlyEntries(entries)
+	if poolEntries {
+		putAppendOnlyEntries(entries)
+	}
 }
 
 // ResetWithCapacity resets the memtable and, when needed, shrinks retained
@@ -1731,6 +1798,17 @@ func (m *AppendOnly) resetLockedWithPolicy(capacity, estimatedBytesPerEntry int,
 	m.hasLast = false
 	m.lastIdx = -1
 
+	if !retainObserved {
+		if cap(m.entries) != retainedEntries {
+			m.replaceEntriesSliceWithPolicy(retainedEntries, false)
+			return
+		}
+		if len(m.entries) != retainedEntries {
+			m.entries = m.entries[:retainedEntries]
+		}
+		return
+	}
+
 	// If the entry slice grew far beyond the configured baseline, shrink it.
 	// This avoids permanently ratcheting heap high-water when a workload briefly
 	// spikes in write volume (common during state-sync restore), while still
@@ -1754,12 +1832,18 @@ func (m *AppendOnly) resetLockedWithPolicy(capacity, estimatedBytesPerEntry int,
 }
 
 func (m *AppendOnly) replaceEntriesSlice(length int) {
+	m.replaceEntriesSliceWithPolicy(length, true)
+}
+
+func (m *AppendOnly) replaceEntriesSliceWithPolicy(length int, poolPrev bool) {
 	if length < 0 {
 		length = 0
 	}
 	prev := m.entries
 	m.entries = getAppendOnlyEntries(length)
-	putAppendOnlyEntries(prev)
+	if poolPrev {
+		putAppendOnlyEntries(prev)
+	}
 }
 
 func (m *AppendOnly) buildSortedLatestSnapshotLocked() []*appendOnlyEntry {

--- a/TreeDB/internal/memtable/append_only_pool_test.go
+++ b/TreeDB/internal/memtable/append_only_pool_test.go
@@ -69,6 +69,31 @@ func TestAppendOnlyEntryPoolClassForReusableCapacity(t *testing.T) {
 	}
 }
 
+func TestDropAppendOnlyEntryPoolsReplacesPools(t *testing.T) {
+	class, _, ok := appendOnlyEntryPoolClassForLength(1024)
+	if !ok {
+		t.Fatal("test setup failed to map entry length to pool class")
+	}
+	before := appendOnlyEntryPoolForClass(class)
+	if before == nil {
+		t.Fatal("expected initial append-only entry pool")
+	}
+	beforeDrop := AppendOnlyEntryPoolDropTotal()
+
+	DropAppendOnlyEntryPools()
+
+	after := appendOnlyEntryPoolForClass(class)
+	if after == nil {
+		t.Fatal("expected replacement append-only entry pool")
+	}
+	if before == after {
+		t.Fatal("drop did not replace append-only entry pool")
+	}
+	if got := AppendOnlyEntryPoolDropTotal(); got != beforeDrop+1 {
+		t.Fatalf("entry pool drop total=%d want %d", got, beforeDrop+1)
+	}
+}
+
 func TestAppendOnlyIteratorCloseClearsPooledEntries(t *testing.T) {
 	entries := make([]appendOnlyEntry, 2)
 	entries[0].key = []byte("k0")

--- a/TreeDB/internal/memtable/append_only_reset_hard_test.go
+++ b/TreeDB/internal/memtable/append_only_reset_hard_test.go
@@ -34,3 +34,51 @@ func TestAppendOnlyResetWithCapacityHard_DropsObservedSpike(t *testing.T) {
 		t.Fatalf("hard reset retained bytes=%d want=0", got)
 	}
 }
+
+func TestAppendOnlyResetWithCapacityHard_ClampsWarmReuseCapacity(t *testing.T) {
+	const (
+		capacityBytes          = 4 << 10
+		estimatedBytesPerEntry = 96
+	)
+
+	mt := NewAppendOnlyWithCapacityEstimatedEntryBytes(capacityBytes, estimatedBytesPerEntry)
+	base := appendOnlyInitialEntriesForCapacity(capacityBytes, estimatedBytesPerEntry)
+
+	for i := 0; i < base*2; i++ {
+		key := []byte(fmt.Sprintf("k-%06d", i))
+		mt.Set(key, []byte("value"))
+	}
+	mt.ResetWithCapacity(capacityBytes, estimatedBytesPerEntry)
+	warmCap := cap(mt.entries)
+	if warmCap <= base {
+		t.Fatalf("test setup did not retain warm capacity: cap(entries)=%d want>%d", warmCap, base)
+	}
+	if warmCap > base*appendOnlyReuseOversizeFactor {
+		t.Fatalf("test setup grew beyond reuse ceiling: cap(entries)=%d want<=%d", warmCap, base*appendOnlyReuseOversizeFactor)
+	}
+
+	mt.ResetWithCapacityHard(capacityBytes, estimatedBytesPerEntry)
+
+	if got := cap(mt.entries); got != base {
+		t.Fatalf("hard reset cap(entries)=%d want=%d", got, base)
+	}
+}
+
+func TestAppendOnlyReleaseDropEntries_DropsEntryBacking(t *testing.T) {
+	mt := NewAppendOnlyWithCapacityEstimatedEntryBytes(4<<20, 96)
+	if got := mt.EntryCapacity(); got == 0 {
+		t.Fatal("test setup produced zero entry capacity")
+	}
+	for i := 0; i < 1024; i++ {
+		mt.Set([]byte(fmt.Sprintf("k-%06d", i)), []byte("value"))
+	}
+
+	mt.ReleaseDropEntries()
+
+	if got := mt.EntryCapacity(); got != 0 {
+		t.Fatalf("entry capacity after cold release=%d want 0", got)
+	}
+	if got := mt.EntryBackingBytes(); got != 0 {
+		t.Fatalf("entry backing bytes after cold release=%d want 0", got)
+	}
+}

--- a/TreeDB/internal/valuelog/manager_test.go
+++ b/TreeDB/internal/valuelog/manager_test.go
@@ -119,8 +119,11 @@ func TestDefaultLeafMmapPolicyBudget(t *testing.T) {
 	if got, want := MaxMappedLeafSealedSegments, 512; got != want {
 		t.Fatalf("MaxMappedLeafSealedSegments=%d want %d", got, want)
 	}
-	if got, want := MaxMappedLeafSealedBytes, int64(2<<30); got != want {
+	if got, want := MaxMappedLeafSealedBytes, int64(1536<<20); got != want {
 		t.Fatalf("MaxMappedLeafSealedBytes=%d want %d", got, want)
+	}
+	if enableCurrentLeafWritableMmap {
+		t.Fatalf("enableCurrentLeafWritableMmap=true, want false by default")
 	}
 }
 

--- a/TreeDB/internal/valuelog/reader_mmap.go
+++ b/TreeDB/internal/valuelog/reader_mmap.go
@@ -77,11 +77,11 @@ const (
 	defaultMaxMappedSealed           = 8
 	defaultMaxMappedSealedBytes      = 64 << 20
 	defaultMaxMappedLeafSealed       = defaultMaxMappedSealed * 64
-	defaultLeafSealedBytesMultiplier = 32
+	defaultLeafSealedBytesMultiplier = 24
 	// Leaf-log reads are on the BTree traversal hot path, but long sync/restore
 	// workloads can keep multiple GiB of sealed leaf generations mapped into the
-	// process RSS. Keep a bounded 2GiB sealed-leaf window by default and let older
-	// generations fall back to ReadAt; operators can raise the env cap for
+	// process RSS. Keep a bounded 1.5GiB sealed-leaf window by default and let
+	// older generations fall back to ReadAt; operators can raise the env cap for
 	// throughput-biased experiments.
 	defaultMaxMappedLeafSealedBytes = defaultMaxMappedSealedBytes * defaultLeafSealedBytesMultiplier
 	defaultCurrentWritableMapTarget = 32 << 20
@@ -91,7 +91,7 @@ var (
 	maxDeadMappingsExplicit        bool
 	adaptiveDeadMappings                 = defaultAdaptiveCapEnabled
 	enableCurrentWritableMmap            = false
-	enableCurrentLeafWritableMmap        = true
+	enableCurrentLeafWritableMmap        = false
 	CurrentWritableMmapTargetBytes       = int64(defaultCurrentWritableMapTarget)
 	MaxMappedSealedSegments              = defaultMaxMappedSealed
 	MaxMappedSealedBytes           int64 = defaultMaxMappedSealedBytes

--- a/TreeDB/profiles.go
+++ b/TreeDB/profiles.go
@@ -347,12 +347,14 @@ func applyCommandWALDurableProfile(opts *Options) {
 	opts.CommandWAL = true
 	opts.Durability = DurabilityDurable
 	opts.ValueLog.ReadIntegrity = IntegrityVerify
+	opts.ValueLog.CurrentWritableMmap = false
 	applyCommandWALProfileSegmentDefaults(opts)
 }
 
 func applyCommandWALRelaxedProfile(opts *Options) {
 	applyWALOnFastProfile(opts)
 	opts.CommandWAL = true
+	opts.ValueLog.CurrentWritableMmap = false
 	applyCommandWALProfileSegmentDefaults(opts)
 }
 

--- a/TreeDB/profiles_test.go
+++ b/TreeDB/profiles_test.go
@@ -255,8 +255,8 @@ func TestApplyProfile_CommandWALDurableSetsCommandWALAndFastDurablePolicy(t *tes
 	if !opts.IndexOuterLeavesInValueLog || !opts.LeafPrefixCompression || !opts.IndexColumnarLeaves || !opts.IndexPackedValuePtr {
 		t.Fatalf("expected command_wal_durable to keep the fast collection/index layout bundle: %+v", opts)
 	}
-	if !opts.ValueLog.CurrentWritableMmap {
-		t.Fatalf("expected command_wal_durable to keep fast value-log mmap policy")
+	if opts.ValueLog.CurrentWritableMmap {
+		t.Fatalf("expected command_wal_durable to disable current writable mmap for production memory bounds")
 	}
 	if opts.IndexInternalBaseDelta {
 		t.Fatalf("expected IndexInternalBaseDelta=false for command_wal_durable profile")
@@ -285,8 +285,8 @@ func TestApplyProfile_CommandWALRelaxedSetsCommandWALAndRelaxedPolicy(t *testing
 	if !opts.IndexOuterLeavesInValueLog || !opts.LeafPrefixCompression || !opts.IndexColumnarLeaves || !opts.IndexPackedValuePtr {
 		t.Fatalf("expected command_wal_relaxed to keep the fast collection/index layout bundle: %+v", opts)
 	}
-	if !opts.ValueLog.CurrentWritableMmap {
-		t.Fatalf("expected command_wal_relaxed to keep fast value-log mmap policy")
+	if opts.ValueLog.CurrentWritableMmap {
+		t.Fatalf("expected command_wal_relaxed to disable current writable mmap for production memory bounds")
 	}
 	if opts.IndexInternalBaseDelta {
 		t.Fatalf("expected IndexInternalBaseDelta=false for command_wal_relaxed profile")


### PR DESCRIPTION
## Summary

Refs #3187.

This PR reduces TreeDB peak memory for the Celestia state-sync/catch-up path using the current production evidence rather than generic benchmark tuning.

Main changes:

- streams public cached batch replay directly into raw-KV command-WAL scan/write planning, avoiding the reusable raw-KV payload builder on the hot path;
- preserves compact command-WAL replay records for mixed delete-range and point operations;
- drops and trims cold append-only memtable backing/pools after mode transitions, flushes, and checkpoints;
- lowers the default sealed leaf value-log mmap budget from 2.0 GiB to 1.5 GiB;
- disables current-writable value-log mmap by default for command-WAL production profiles, with env opt-in retained;
- raises adaptive B-tree selection evidence requirements and caps hash-sorted mutable preallocation.

IAVL importer/root-span-native work remains tracked separately in #3164.

## Celestia Evidence

Matched TreeDB-vs-goleveldb A/B after the latest production-profile change:

- TreeDB run: `/home/mikers/.celestia-app-mainnet-treedb-20260627193258`
- goleveldb run: `/home/mikers/.celestia-app-mainnet-goleveldb-20260627191511`
- accepted snapshot: `11721000`
- trust height/hash: `11714074` / `AC2679168CE4DCFA9AA7355E52A265A2CA6250C9A9392B3EF3BFACA284B5104E`
- stop target: `11715650`
- dwell: `300s` for both runs
- targeted fatal storage scan: clean for `panic|fatal|corrupt|leveldb: closed` in both runs

| Metric | TreeDB | goleveldb | Result |
| --- | ---: | ---: | ---: |
| sync duration | `249s` | `723s` | TreeDB `2.904x` faster |
| total including dwell | `549s` | `1023s` | TreeDB `1.863x` faster |
| max RSS | `7305500 KiB` | `4677812 KiB` | TreeDB `1.562x` goleveldb, passes `<1.75x` |
| max HWM | `7997916 KiB` | `4677824 KiB` | TreeDB `1.710x` goleveldb, passes `<1.75x` |
| app DB bytes | `2547652739B` | `2753369850B` | TreeDB `7.47%` smaller |

TreeDB final capture:

- `treedb.vlog.mmap_current_bytes=0`
- `treedb.process.memory.peak_vlog_mmap_current_bytes=0`
- `treedb.vlog.mmap_dead_bytes=0`
- `treedb.vlog.mmap_active_bytes=1234100335`, all sealed, under the 1.5 GiB leaf sealed cap
- `RawKVBatchPayloadBuilder.appendRawKVPayloadSpace` absent from the final top profile

## Validation

- `GOWORK=off go test ./TreeDB/...`
- `GOWORK=off go test ./TreeDB/caching -count=1`
- `GOWORK=off go test ./TreeDB/caching -run 'TestChooseAdaptiveMode|TestAdaptiveMemtableMode|TestMutableMemtableCapacityForMode' -count=1`
- `GOWORK=off go test ./TreeDB -run 'TestApplyProfile_.*(CommandWAL|Fast|WALOnFast|Bench|Durable)|TestParseProfile|TestParsePublicProfile' -count=1`
- `GOWORK=off go test ./TreeDB/internal/valuelog -run 'TestDefaultLeafMmapPolicyBudget|TestReadUnsafe_CurrentLeafWritableMmapDisabledFallsBackToReadAt|TestReadUnsafe_DefaultSealedLeafBudgetUsesMmapWithCurrentMmapDisabled|TestCurrentWritableMmapTarget|TestManagerCurrentWritableMmapOptionMapsNormalSegment|TestManagerPromoteCurrentWritable' -count=1`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for more efficient command log replay and appending, improving handling of large batches and ordered changes.
  * Improved adaptive memory-table selection so an explicitly set zero value is respected.

* **Bug Fixes**
  * Fixed append-only memory cleanup when switching modes, helping release unused memory more reliably.
  * Updated default memory-mapping settings to be more conservative, including disabling writable mapping by default.

* **Tests**
  * Expanded coverage for command log, adaptive mode, trimming, and memory statistics behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->