### PR TITLE
TreeDB: lower semantic-stream retained zstd memory

### DIFF
--- a/TreeDB/collections/column_retained_semantic_stream.go
+++ b/TreeDB/collections/column_retained_semantic_stream.go
@@ -24,6 +24,7 @@ import (
 
 const columnRetainedSemanticStreamV1BlockRows = 4096
 const maxColumnRetainedSemanticStreamV1CompressedRawBlockBytes = 512 << 20
+const columnRetainedSemanticStreamV1ZSTDWindowSize = 1 << 20
 const defaultColumnRetainedSemanticStreamV1DecodeCacheBlocks = 16
 const minColumnRetainedSemanticStreamV1DecodeCacheRows = 64
 const minColumnRetainedSemanticStreamV1DecodeCacheRowsPerBlock = 512
@@ -1184,6 +1185,8 @@ func newColumnRetainedSemanticStreamV1StoredBlockEncoder() (*columnRetainedSeman
 		zstd.WithEncoderLevel(zstd.SpeedFastest),
 		zstd.WithEncoderCRC(false),
 		zstd.WithEncoderConcurrency(1),
+		zstd.WithWindowSize(columnRetainedSemanticStreamV1ZSTDWindowSize),
+		zstd.WithLowerEncoderMem(true),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("collections: create semantic-stream-v1 retained block zstd encoder: %w", err)

--- a/TreeDB/collections/column_retained_vlog_placement_test.go
+++ b/TreeDB/collections/column_retained_vlog_placement_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
+	"github.com/snissn/gomap/TreeDB/internal/memtable"
 	"github.com/snissn/gomap/TreeDB/internal/valuelog"
 	"github.com/snissn/gomap/TreeDB/node"
 	"github.com/snissn/gomap/TreeDB/page"
@@ -1118,6 +1119,26 @@ func retainedPlacementDocument(payload string, rowID int) []byte {
 	return []byte(fmt.Sprintf(`{"row_id":%d,"kind":"kind-%d","payload":"%s"}`, rowID, rowID, strings.Repeat(payload, 10)))
 }
 
+func reportColumnRetainedSemanticStreamBenchmarkStoredBlockBytes(b *testing.B, table memtable.Table, inputBytes int64) {
+	b.Helper()
+	iter := table.NewIterator(nil, nil)
+	defer func() { _ = iter.Close() }()
+	var storedBytes int64
+	var blocks int
+	for ; iter.Valid(); iter.Next() {
+		blocks++
+		storedBytes += int64(len(iter.UnsafeValue()))
+	}
+	if err := iter.Error(); err != nil {
+		b.Fatalf("iterate semantic-stream-v1 benchmark block table: %v", err)
+	}
+	if blocks == 0 {
+		b.Fatal("semantic-stream-v1 benchmark block table is empty")
+	}
+	b.ReportMetric(float64(storedBytes), "stored_block_B/op")
+	b.ReportMetric(float64(storedBytes)/float64(inputBytes), "stored/input")
+}
+
 func BenchmarkColumnRetainedPayloadSemanticStreamV1PrepareRootFastPath(b *testing.B) {
 	cfg := ColumnStoreConfig{
 		Enabled: true,
@@ -1147,6 +1168,11 @@ func BenchmarkColumnRetainedPayloadSemanticStreamV1PrepareRootFastPath(b *testin
 		}
 		if prepared.semanticStreamBlocks == nil {
 			b.Fatal("prepare semantic-stream-v1 documents did not return block table")
+		}
+		if i == 0 {
+			b.StopTimer()
+			reportColumnRetainedSemanticStreamBenchmarkStoredBlockBytes(b, prepared.semanticStreamBlocks, bytesPerIteration)
+			b.StartTimer()
 		}
 		resetCollectionRunTable(prepared.semanticStreamBlocks)
 	}
@@ -1179,6 +1205,11 @@ func BenchmarkColumnRetainedPayloadSemanticStreamV1PrepareNestedDeclaredPaths(b 
 		}
 		if prepared.semanticStreamBlocks == nil {
 			b.Fatal("prepare semantic-stream-v1 documents did not return block table")
+		}
+		if i == 0 {
+			b.StopTimer()
+			reportColumnRetainedSemanticStreamBenchmarkStoredBlockBytes(b, prepared.semanticStreamBlocks, bytesPerIteration)
+			b.StartTimer()
 		}
 		resetCollectionRunTable(prepared.semanticStreamBlocks)
 	}


### PR DESCRIPTION
Closes #3215.

Parent tracker: #3099
Storage/load lane: #3067
Root tracker: #3000
Final report tracker: #3001
Predecessor: #3213 / #3214

## Scope

This PR reduces retained semantic-stream InsertBatch/load-preparation memory pressure by configuring the semantic-stream stored-block zstd encoder with a 1 MiB window and `WithLowerEncoderMem(true)`.

It also adds benchmark reporting for retained semantic-stream stored block bytes and stored/input ratio so compression movement is visible in the standard benchmark output.

It does not change the semantic-stream block wrapper format, locator format, declared-row format, typed-column dictionary encoding, query behavior, or JSON parser semantics.

## Claim Boundary

This is insert/load-preparation evidence only. It is not one-shot SQL execution evidence, first-touch-after-open evidence, no-aggregate typed-column scan evidence, arbitrary-expression scan evidence, metadata-cost evidence, ClickHouse comparison evidence, or proof of broad TreeDB SQL superiority.

## Tests

```sh
go test ./TreeDB/collections -run 'TestColumnRetainedPayloadSemanticStreamV1StoredBlockEncoderReuse|TestColumnRetainedPayloadSemanticStreamV1|Test.*(RetainedPayload|SemanticStream|Reconstruction).*|TestTypedStorageLegacyNameAllowlistIsComplete' -count=1
go test ./TreeDB/collections -count=1
go test ./cmd/unified_bench -count=1
git diff --check
```

All passed locally on Apple M3 / darwin arm64.

## Benchmark Evidence

Baseline: `ecc36b2e39a177673664da0426af05ca275ed8e6` (#3214 merge) in `/tmp/gomap_3215_baseline` with the benchmark-metric helper applied for stored-byte reporting only.
Candidate: `9a5c4f7ee`.

Command:

```sh
go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnRetainedPayloadSemanticStreamV1Prepare(RootFastPath|NestedDeclaredPaths)$' -benchmem -count=8
```

Artifacts:

- `/tmp/treedb_semstream_zstd_lowmem_baseline_bench.txt`
- `/tmp/treedb_semstream_zstd_lowmem_candidate_bench.txt`
- `/tmp/treedb_semstream_zstd_lowmem_benchstat.txt`
- `/tmp/treedb_semstream_zstd_lowmem_baseline_mem.pprof`
- `/tmp/treedb_semstream_zstd_lowmem_mem.pprof`
- `/tmp/treedb_semstream_zstd_lowmem_baseline_alloc_space_top.txt`
- `/tmp/treedb_semstream_zstd_lowmem_alloc_space_top.txt`
- `/tmp/treedb_semstream_zstd_lowmem_alloc_objects_top.txt`

| Benchmark | Metric | Baseline | Candidate | Delta | Notes |
| --- | ---: | ---: | ---: | ---: | --- |
| RootFastPath | sec/op | 7.506ms | 7.405ms | -1.34%, p=0.050 | Slight improvement at threshold. |
| NestedDeclaredPaths | sec/op | 6.862ms | 6.728ms | -1.96%, p=0.028 | Slight improvement. |
| RootFastPath | B/op | 14.047 MiB | 6.207 MiB | -55.81%, p=0.000 | Intended effect. |
| NestedDeclaredPaths | B/op | 11.437 MiB | 3.684 MiB | -67.79%, p=0.000 | Intended effect. |
| RootFastPath | allocs/op | 154 | 176 | +14.29%, p=0.000 | Tradeoff from lower-memory zstd mode. |
| NestedDeclaredPaths | allocs/op | 139 | 163 | +17.27%, p=0.000 | Tradeoff from lower-memory zstd mode. |
| RootFastPath | stored_block_B/op | 19.44 KiB | 19.44 KiB | unchanged | No compression-size regression in this workload. |
| NestedDeclaredPaths | stored_block_B/op | 19.86 KiB | 19.86 KiB | unchanged | No compression-size regression in this workload. |
| RootFastPath | stored/input | 0.01463 | 0.01463 | unchanged | Reported by benchmark as 14.63m. |
| NestedDeclaredPaths | stored/input | 0.01494 | 0.01494 | unchanged | Reported by benchmark as 14.94m. |

Profile comparison at `-count=3`:

- Baseline zstd `(*fastBase).ensureHist`: 12,808 MiB sampled alloc_space, 62.80% flat.
- Candidate zstd `(*fastBase).ensureHist`: 1,788.23 MiB sampled alloc_space, 22.35% flat.
- Baseline `encodeWithRawLimit` cumulative: 15,312.14 MiB sampled alloc_space.
- Candidate `encodeWithRawLimit` cumulative: 2,834.27 MiB sampled alloc_space.

## Regression Assessment

No correctness regressions were found in focused retained semantic-stream tests, full `TreeDB/collections`, or `cmd/unified_bench`. The measured storage/compression output is unchanged for the retained semantic-stream benchmark fixture. Object allocation count increases modestly, but total allocated bytes and sampled zstd history allocation drop substantially, and prep wall time does not regress.
