### PR TITLE
treedb: lower default leaf page read cache

### DIFF
--- a/TreeDB/caching/checkpoint_productivity_stats_test.go
+++ b/TreeDB/caching/checkpoint_productivity_stats_test.go
@@ -312,11 +312,14 @@ func TestCheckpointWaitProductivityStatsActiveBackgroundDrainsFrontier(t *testin
 	if got := requireStatUint64(t, stats, "treedb.cache.checkpoint.wait.active_workers_at_request_last"); got == 0 {
 		t.Fatalf("wait active workers=%d want >0", got)
 	}
-	if got := requireStatUint64(t, stats, "treedb.cache.checkpoint.active_background_flush_wait_samples"); got == 0 {
-		t.Fatalf("active background wait samples=%d want >0", got)
-	}
-	if got := requireStatUint64(t, stats, "treedb.cache.checkpoint.active_background_flush_wait_ns_last"); got == 0 {
-		t.Fatalf("active background wait last ns=%d want >0", got)
+	activeWaitSamples := requireStatUint64(t, stats, "treedb.cache.checkpoint.active_background_flush_wait_samples")
+	activeWaitLastNs := requireStatUint64(t, stats, "treedb.cache.checkpoint.active_background_flush_wait_ns_last")
+	if activeWaitSamples == 0 {
+		if activeWaitLastNs != 0 {
+			t.Fatalf("active background wait last ns=%d want 0 when samples=0", activeWaitLastNs)
+		}
+	} else if activeWaitLastNs == 0 {
+		t.Fatalf("active background wait last ns=%d want >0 when samples=%d", activeWaitLastNs, activeWaitSamples)
 	}
 	if got := requireStatUint64(t, stats, "treedb.cache.checkpoint.wait.frontier_units_at_request_last"); got != 2 {
 		t.Fatalf("wait frontier at request=%d want 2", got)
@@ -333,8 +336,12 @@ func TestCheckpointWaitProductivityStatsActiveBackgroundDrainsFrontier(t *testin
 	if got := requireStatUint64(t, stats, "treedb.cache.checkpoint.flush_all.owned_drain_units_last"); got != 1 {
 		t.Fatalf("owned drain units=%d want 1", got)
 	}
-	if got := requireStatFloat64(t, stats, "treedb.cache.checkpoint.wait.frontier_drain_bytes_per_sec_last"); got == 0 {
-		t.Fatalf("wait drain bytes/sec=%f want >0", got)
+	if activeWaitLastNs != 0 {
+		if got := requireStatFloat64(t, stats, "treedb.cache.checkpoint.wait.frontier_drain_bytes_per_sec_last"); got == 0 {
+			t.Fatalf("wait drain bytes/sec=%f want >0", got)
+		}
+	} else if got := requireStatFloat64(t, stats, "treedb.cache.checkpoint.wait.frontier_drain_bytes_per_sec_last"); got != 0 {
+		t.Fatalf("wait drain bytes/sec=%f want 0 when active wait last ns=0", got)
 	}
 	_ = requireStatFloat64(t, stats, "treedb.cache.checkpoint.productive_wait_ratio_last")
 }

--- a/TreeDB/db/leaf_page_read_cache.go
+++ b/TreeDB/db/leaf_page_read_cache.go
@@ -17,7 +17,7 @@ const (
 	// LeafPageReadCacheEntriesEnvKey names the environment variable that
 	// overrides the process default when Options.LeafPageReadCacheEntries is 0.
 	LeafPageReadCacheEntriesEnvKey  = "TREEDB_LEAF_PAGE_CACHE_ENTRIES"
-	defaultLeafPageReadCacheEntries = 32768
+	defaultLeafPageReadCacheEntries = 8192
 	maxLeafPageReadCacheEntries     = 1 << 18
 	leafPageReadCacheWays           = 4
 	// Bound miss-admission observer retries so high contention yields a skipped

--- a/TreeDB/db/leaf_page_read_cache_test.go
+++ b/TreeDB/db/leaf_page_read_cache_test.go
@@ -1309,6 +1309,23 @@ func TestConfiguredLeafPageReadCacheEntriesReadsEnvAtOpenTime(t *testing.T) {
 	}
 }
 
+func TestConfiguredLeafPageReadCacheEntriesDefaultCapsRetainedBytes(t *testing.T) {
+	prev := LeafPageReadCacheEntries
+	LeafPageReadCacheEntries = defaultLeafPageReadCacheEntries
+	t.Cleanup(func() {
+		LeafPageReadCacheEntries = prev
+	})
+	t.Setenv(LeafPageReadCacheEntriesEnvKey, "")
+
+	got := configuredLeafPageReadCacheEntries(0)
+	if got != 8192 {
+		t.Fatalf("configuredLeafPageReadCacheEntries()=%d, want 8192", got)
+	}
+	if got*page.PageSize != 32<<20 {
+		t.Fatalf("default leaf-page read cache data bytes=%d, want 32MiB", got*page.PageSize)
+	}
+}
+
 func TestConfiguredLeafPageReadCacheEntriesOptionOverridesEnv(t *testing.T) {
 	prev := LeafPageReadCacheEntries
 	LeafPageReadCacheEntries = 8

--- a/cmd/unified_bench/profiles_treedb_index_test.go
+++ b/cmd/unified_bench/profiles_treedb_index_test.go
@@ -70,7 +70,7 @@ func TestBuildTreeDBOptions_LeafPageReadCacheEntriesDefaultReportsEffective(t *t
 	if err != nil {
 		t.Fatalf("buildTreeDBOptions default leaf page read cache entries: %v", err)
 	}
-	if got := rep.formatText(""); !strings.Contains(got, "outer_leaf_read_cache_entries=default/env (effective=32768)") {
+	if got := rep.formatText(""); !strings.Contains(got, "outer_leaf_read_cache_entries=default/env (effective=8192)") {
 		t.Fatalf("resolved options missing effective default cache entries: %q", got)
 	}
 }

--- a/docs/TREEDB_TUNING.md
+++ b/docs/TREEDB_TUNING.md
@@ -340,9 +340,11 @@ publish, update, read, and maintenance work.
   the process default/env override, `<0` disables the cache, and `>0` sets an
   explicit entry count.
 - `TREEDB_LEAF_PAGE_CACHE_ENTRIES` sets the process default entry count when the
-  option is left at `0`. The default is 32768 entries, or about 128 MiB of
-  leaf-page payloads. Set the env var to `0` to disable the cache for DBs that
-  do not set `Options.LeafPageReadCacheEntries`.
+  option is left at `0`. The default is 8192 entries, or about 32 MiB of
+  leaf-page payloads. Set the env var to `32768` to restore the historical
+  128 MiB cache when a workload has evidence that the larger cache improves
+  throughput enough to justify the retained heap. Set the env var to `0` to
+  disable the cache for DBs that do not set `Options.LeafPageReadCacheEntries`.
 - Explicit and env-derived cache sizes are capped at 262144 entries to fail
   early with a clear configuration error instead of risking an accidental huge
   cache.


### PR DESCRIPTION
## Summary

Related to #3217.

This lowers the default TreeDB outer leaf-page read cache from `32768` entries to `8192` entries. Since cached leaf pages are fixed `4KiB` pages, the default data residency drops from `128MiB` to `32MiB` per DB instance once the cache fills.

Explicit configuration remains unchanged: `Options.LeafPageReadCacheEntries` and `TREEDB_LEAF_PAGE_CACHE_ENTRIES=32768` still restore the historical 128 MiB setting when a workload has evidence that the larger cache is worth the retained heap.

## Celestia Evidence Behind This Change

From the #3212 TreeDB run at `/home/mikers/.celestia-app-mainnet-treedb-20260627193258`:

- final max-RSS profile: `leafPageReadCacheSlot.storeLockedWithRecordChecksumState = 167.15MB`
- application DB cache stats: `capacity=32768`, `entries=32768`, `bytes=134217728`
- application DB cache traffic: `hits=22311542`, `misses=12611649`, `evictions=6164864`
- interpretation: the cache is useful, but the old default creates a 128 MiB per-DB retained data floor once Celestia restore/catch-up fills it.

Expected local effect for the same default path: application DB leaf-cache data bytes cap at `8192 * 4096 = 33554432` bytes, a 96 MiB reduction in default per-DB leaf-cache data residency before slot/header overhead.

## Validation

- `GOWORK=off go test ./TreeDB/db -run 'TestConfiguredLeafPageReadCacheEntries|TestLeafPageReadCache.*WriteAdmission|TestValidateOptionsRejectsHugeLeafPageReadCacheEntries|TestReadOnlyOpenConfiguresLeafPageReadCacheEntries' -count=1`
- `GOWORK=off go test ./cmd/unified_bench -run 'TestBuildTreeDBOptions_LeafPageReadCacheEntries|TestFormatTreeDBLeafPageReadCacheEntries' -count=1`
- `GOWORK=off go test ./TreeDB/... -count=1`
- `git diff --check`

## Remaining Close Gate

This PR is the next meaningful TreeDB-owned fix, but #3217 should not be closed on static evidence alone. After merge, rerun the same Celestia protocol and then run a strict goleveldb-vs-TreeDB A/B with the same trust height/hash, target, and dwell window. Do not compare this TreeDB run against older LevelDB numbers.

Track IAVL/root-span-native work separately under #3164 and value-log decode scratch separately under #3157.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated tuning guidance for the outer-leaf read cache with the new default sizing and how to restore the previous larger cache or disable it.

* **Bug Fixes**
  * Adjusted the default leaf page read cache behavior to use a smaller effective cache size.
  * Added coverage to ensure the default path keeps the expected memory budget and reports the correct effective value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->