### PR TITLE
TreeDB: compact retained semantic stream prep rows

### DIFF
--- a/TreeDB/collections/column_retained_semantic_stream.go
+++ b/TreeDB/collections/column_retained_semantic_stream.go
@@ -39,14 +39,10 @@ var (
 	columnRetainedSemanticStreamV1LocatorMagic   = []byte("crss1loc\x00")
 )
 
-type columnRetainedSemanticStreamEntry struct {
-	row uint64
-	raw []byte
-}
-
 type columnRetainedSemanticStreamPath struct {
 	segments                []string
-	entries                 []columnRetainedSemanticStreamEntry
+	rows                    []uint64
+	rawValues               [][]byte
 	rawValueBytes           int
 	valueLengthUvarintBytes int
 }
@@ -86,19 +82,40 @@ func (s *columnRetainedSemanticStreamStreams) appendValue(path []string, row uin
 		stream = s.byKey[key]
 		if stream == nil {
 			stream = &columnRetainedSemanticStreamPath{
-				segments: append([]string(nil), path...),
-				entries:  make([]columnRetainedSemanticStreamEntry, 0, streamEntryCapacity),
+				segments:  append([]string(nil), path...),
+				rawValues: make([][]byte, 0, streamEntryCapacity),
 			}
 			s.byKey[key] = stream
 		}
 		current.stream = stream
 	}
-	stream.rawValueBytes += len(raw)
-	stream.valueLengthUvarintBytes += columnRetainedSemanticStreamV1UvarintSize(uint64(len(raw)))
-	stream.entries = append(stream.entries, columnRetainedSemanticStreamEntry{
-		row: row,
-		raw: raw,
-	})
+	stream.appendValue(row, raw)
+}
+
+func (p *columnRetainedSemanticStreamPath) appendValue(row uint64, raw []byte) {
+	if p.rows != nil {
+		p.rows = append(p.rows, row)
+	} else if row != uint64(len(p.rawValues)) {
+		p.rows = make([]uint64, len(p.rawValues), cap(p.rawValues))
+		for i := range p.rawValues {
+			p.rows[i] = uint64(i)
+		}
+		p.rows = append(p.rows, row)
+	}
+	p.rawValueBytes += len(raw)
+	p.valueLengthUvarintBytes += columnRetainedSemanticStreamV1UvarintSize(uint64(len(raw)))
+	p.rawValues = append(p.rawValues, raw)
+}
+
+func (p *columnRetainedSemanticStreamPath) entryCount() int {
+	return len(p.rawValues)
+}
+
+func (p *columnRetainedSemanticStreamPath) rowAt(idx int) uint64 {
+	if p.rows == nil {
+		return uint64(idx)
+	}
+	return p.rows[idx]
 }
 
 type columnRetainedSemanticStreamV1DecodedBlock struct {
@@ -1132,17 +1149,18 @@ func encodeColumnRetainedSemanticStreamV1RawBlockFromStreams(rows int, streams *
 			out = binary.AppendUvarint(out, uint64(len(segment)))
 			out = append(out, segment...)
 		}
-		out = binary.AppendUvarint(out, uint64(len(stream.entries)))
+		out = binary.AppendUvarint(out, uint64(stream.entryCount()))
 		var last uint64
-		for i, entry := range stream.entries {
+		for i, raw := range stream.rawValues {
+			row := stream.rowAt(i)
 			if i == 0 {
-				out = binary.AppendUvarint(out, entry.row)
+				out = binary.AppendUvarint(out, row)
 			} else {
-				out = binary.AppendUvarint(out, entry.row-last)
+				out = binary.AppendUvarint(out, row-last)
 			}
-			last = entry.row
-			out = binary.AppendUvarint(out, uint64(len(entry.raw)))
-			out = append(out, entry.raw...)
+			last = row
+			out = binary.AppendUvarint(out, uint64(len(raw)))
+			out = append(out, raw...)
 		}
 	}
 	return out, nil
@@ -1158,11 +1176,12 @@ func columnRetainedSemanticStreamV1RawBlockSizeHint(rows int, keys []string, str
 		for _, segment := range stream.segments {
 			size += columnRetainedSemanticStreamV1UvarintSize(uint64(len(segment))) + len(segment)
 		}
-		size += columnRetainedSemanticStreamV1UvarintSize(uint64(len(stream.entries)))
+		entryCount := stream.entryCount()
+		size += columnRetainedSemanticStreamV1UvarintSize(uint64(entryCount))
 		// Row deltas are bounded by the per-block row count. At 4096 rows this is
 		// at most two bytes per entry, and value-length uvarint bytes are tracked
 		// when entries are appended.
-		size += len(stream.entries)*2 + stream.valueLengthUvarintBytes + stream.rawValueBytes
+		size += entryCount*2 + stream.valueLengthUvarintBytes + stream.rawValueBytes
 	}
 	return size
 }

--- a/TreeDB/collections/column_retained_semantic_stream_raw_test.go
+++ b/TreeDB/collections/column_retained_semantic_stream_raw_test.go
@@ -3,6 +3,7 @@ package collections
 import (
 	"bytes"
 	"crypto/sha256"
+	"slices"
 	"testing"
 	"unsafe"
 
@@ -402,14 +403,37 @@ func TestColumnRetainedSemanticStreamV1PathSegmentInternerReusesRetainedTraversa
 			}
 		}
 	}
-	if len(payloadShared.entries) != 2 {
-		t.Fatalf("payload.shared entries=%d want 2", len(payloadShared.entries))
+	if payloadShared.entryCount() != 2 {
+		t.Fatalf("payload.shared entries=%d want 2", payloadShared.entryCount())
 	}
-	if got := string(payloadShared.entries[0].raw); got != "10" {
+	if got := string(payloadShared.rawValues[0]); got != "10" {
 		t.Fatalf("duplicate key retained raw=%q want last value 10", got)
 	}
-	if got := string(payloadShared.entries[1].raw); got != "3" {
+	if got := string(payloadShared.rawValues[1]); got != "3" {
 		t.Fatalf("second row retained raw=%q want 3", got)
+	}
+}
+
+func TestColumnRetainedSemanticStreamV1DenseRowsStayImplicit3218(t *testing.T) {
+	stream := &columnRetainedSemanticStreamPath{
+		segments:  []string{"payload", "value"},
+		rawValues: make([][]byte, 0, 3),
+	}
+	stream.appendValue(0, []byte("a"))
+	stream.appendValue(1, []byte("b"))
+	if stream.rows != nil {
+		t.Fatalf("dense stream allocated explicit rows: %v", stream.rows)
+	}
+	if got := stream.rowAt(1); got != 1 {
+		t.Fatalf("dense rowAt(1)=%d want 1", got)
+	}
+
+	stream.appendValue(3, []byte("d"))
+	if got, want := stream.rows, []uint64{0, 1, 3}; !slices.Equal(got, want) {
+		t.Fatalf("sparse rows=%v want %v", got, want)
+	}
+	if got := stream.rowAt(2); got != 3 {
+		t.Fatalf("sparse rowAt(2)=%d want 3", got)
 	}
 }
 


### PR DESCRIPTION
Closes #3218
Refs #3099, #3067, #3000, #3001, #3070

## Scope classification

- Insert/load-prep: yes. This compactly represents retained semantic-stream prep rows before stored-block encoding.
- Storage density: no intended format/storage change; stored block bytes/input are unchanged in focused benchmarks.
- One-shot query execution: no.
- Hot prepared query execution: no.
- No-aggregate typed scan performance: no.
- Metadata/materialized-summary evidence: no.
- ClickHouse parity or SQL superiority evidence: no.

## What changed

Retained semantic-stream prep no longer stores a `row uint64` next to every raw retained value. Dense streams now infer row ordinals from the value index, and sparse streams lazily materialize an explicit row slice only when the stream first skips a row.

This keeps the encoded semantic-stream block format unchanged: row deltas are still emitted into the raw block, and locators/reconstruction continue to use the same stored representation.

## Focused benchmark evidence

Baseline worktree: `/tmp/gomap_3218_baseline_20260627_211252` at `origin/main` (`e46d654cb`).

Artifacts:

- Before: `/tmp/treedb_semstream_prep_buffers_3218_before.txt`
- After: `/tmp/treedb_semstream_prep_buffers_3218_after.txt`
- Benchstat: `benchstat /tmp/treedb_semstream_prep_buffers_3218_before.txt /tmp/treedb_semstream_prep_buffers_3218_after.txt`

| benchmark | sec/op | B/op | allocs/op | stored_block_B/op | stored/input |
| --- | ---: | ---: | ---: | ---: | ---: |
| RootFastPath | `7.456ms -> 7.418ms` no significant change | `6.207MiB -> 5.957MiB` (`-4.03%`, p=0.000) | `176 -> 176` | `19.44k -> 19.44k` unchanged | `0.01463 -> 0.01463` unchanged |
| NestedDeclaredPaths | `6.666ms -> 6.777ms` no significant change | `3.684MiB -> 3.466MiB` (`-5.93%`, p=0.000) | `163 -> 163` | `19.86k -> 19.86k` unchanged | `0.01494 -> 0.01494` unchanged |

Geomean `B/op` improved `4.782MiB -> 4.544MiB` (`-4.98%`). Runtime movement was not statistically significant.

## Allocation profile note

After-change profile artifacts:

- `/tmp/treedb_semstream_prep_buffers_3218_after_mem.pprof`
- `/tmp/treedb_semstream_prep_buffers_3218_after_alloc_top.txt`
- `/tmp/treedb_semstream_prep_buffers_3218_after_append_list.txt`

The changed append path now allocates the raw slice header buffer at `column_retained_semantic_stream.go:86`:

- `(*columnRetainedSemanticStreamStreams).appendValue`: `73,684.86kB` sampled flat/cum in the after profile.
- `rawValues: make([][]byte, 0, streamEntryCapacity)`: `71.72MiB` sampled.

The larger remaining allocators are still raw-block output and zstd state:

- `prepareColumnRetainedSemanticStreamV1StorageDocumentsWithIDs`: `148,923.19kB` flat.
- `zstd.(*fastBase).ensureHist`: `117,504kB` flat.
- `encodeColumnRetainedSemanticStreamV1RawBlockFromStreams`: `83,651.95kB` flat.

## Validation

```sh
go test ./TreeDB/collections \
  -run 'TestColumnRetainedPayloadSemanticStreamV1|TestColumnRetainedSemanticStream|TestColumnRetainedPayload|TestRetainedPayload|TestColumnStoreRetained' \
  -count=1
# ok github.com/snissn/gomap/TreeDB/collections 1.655s

go test ./TreeDB/collections -count=1
# ok github.com/snissn/gomap/TreeDB/collections 45.494s

git diff --check
# clean
```
