### PR TITLE
TreeDB: reuse retained semantic-stream raw-block scratch

### DIFF
--- a/TreeDB/collections/column_retained_semantic_stream.go
+++ b/TreeDB/collections/column_retained_semantic_stream.go
@@ -25,6 +25,7 @@ import (
 const columnRetainedSemanticStreamV1BlockRows = 4096
 const maxColumnRetainedSemanticStreamV1CompressedRawBlockBytes = 512 << 20
 const columnRetainedSemanticStreamV1ZSTDWindowSize = 1 << 20
+const columnRetainedSemanticStreamV1RawBlockScratchMaxRetainedBytes = 8 << 20
 const defaultColumnRetainedSemanticStreamV1DecodeCacheBlocks = 16
 const minColumnRetainedSemanticStreamV1DecodeCacheRows = 64
 const minColumnRetainedSemanticStreamV1DecodeCacheRowsPerBlock = 512
@@ -123,7 +124,8 @@ type columnRetainedSemanticStreamV1DecodedBlock struct {
 }
 
 type columnRetainedSemanticStreamV1StoredBlockEncoder struct {
-	enc *zstd.Encoder
+	enc             *zstd.Encoder
+	rawBlockScratch []byte
 }
 
 type columnRetainedSemanticStreamV1RootFastPathPlan struct {
@@ -1116,17 +1118,21 @@ func encodeColumnRetainedSemanticStreamV1BlockFromStreams(rows int, streams *col
 }
 
 func encodeColumnRetainedSemanticStreamV1BlockFromStreamsWithEncoder(rows int, streams *columnRetainedSemanticStreamStreams, encoder *columnRetainedSemanticStreamV1StoredBlockEncoder) ([]byte, error) {
+	if encoder != nil {
+		return encoder.encodeStreamsWithRawLimit(rows, streams, maxColumnRetainedSemanticStreamV1CompressedRawBlockBytes)
+	}
 	raw, err := encodeColumnRetainedSemanticStreamV1RawBlockFromStreams(rows, streams)
 	if err != nil {
 		return nil, err
-	}
-	if encoder != nil {
-		return encoder.encodeWithRawLimit(raw, maxColumnRetainedSemanticStreamV1CompressedRawBlockBytes)
 	}
 	return encodeColumnRetainedSemanticStreamV1StoredBlock(raw)
 }
 
 func encodeColumnRetainedSemanticStreamV1RawBlockFromStreams(rows int, streams *columnRetainedSemanticStreamStreams) ([]byte, error) {
+	return encodeColumnRetainedSemanticStreamV1RawBlockFromStreamsInto(rows, streams, nil)
+}
+
+func encodeColumnRetainedSemanticStreamV1RawBlockFromStreamsInto(rows int, streams *columnRetainedSemanticStreamStreams, dst []byte) ([]byte, error) {
 	if rows <= 0 {
 		return nil, errors.New("collections: semantic-stream-v1 retained block requires at least one row")
 	}
@@ -1138,7 +1144,15 @@ func encodeColumnRetainedSemanticStreamV1RawBlockFromStreams(rows int, streams *
 		keys = append(keys, key)
 	}
 	sort.Strings(keys)
-	out := make([]byte, 0, columnRetainedSemanticStreamV1RawBlockSizeHint(rows, keys, streams))
+	sizeHint := columnRetainedSemanticStreamV1RawBlockSizeHint(rows, keys, streams)
+	out := dst[:0]
+	if cap(out) < sizeHint {
+		capacity := sizeHint
+		if dst != nil {
+			capacity += columnRetainedSemanticStreamV1RawBlockScratchGrowthSlack(sizeHint)
+		}
+		out = make([]byte, 0, capacity)
+	}
 	out = append(out, columnRetainedSemanticStreamV1BlockMagic...)
 	out = binary.AppendUvarint(out, uint64(rows))
 	out = binary.AppendUvarint(out, uint64(len(keys)))
@@ -1186,6 +1200,15 @@ func columnRetainedSemanticStreamV1RawBlockSizeHint(rows int, keys []string, str
 	return size
 }
 
+func columnRetainedSemanticStreamV1RawBlockScratchGrowthSlack(sizeHint int) int {
+	const maxSlack = 64 << 10
+	slack := sizeHint / 16
+	if slack > maxSlack {
+		return maxSlack
+	}
+	return slack
+}
+
 func encodeColumnRetainedSemanticStreamV1StoredBlock(raw []byte) ([]byte, error) {
 	return encodeColumnRetainedSemanticStreamV1StoredBlockWithRawLimit(raw, maxColumnRetainedSemanticStreamV1CompressedRawBlockBytes)
 }
@@ -1219,6 +1242,35 @@ func (e *columnRetainedSemanticStreamV1StoredBlockEncoder) close() {
 	}
 	e.enc.Close()
 	e.enc = nil
+	e.rawBlockScratch = nil
+}
+
+func (e *columnRetainedSemanticStreamV1StoredBlockEncoder) encodeStreamsWithRawLimit(rows int, streams *columnRetainedSemanticStreamStreams, compressedRawLimit int) ([]byte, error) {
+	raw, err := encodeColumnRetainedSemanticStreamV1RawBlockFromStreamsInto(rows, streams, e.rawBlockScratch)
+	if err != nil {
+		return nil, err
+	}
+	block, err := e.encodeWithRawLimit(raw, compressedRawLimit)
+	if err != nil {
+		return nil, err
+	}
+	if columnRetainedSemanticStreamSlicesShareStart(block, raw) {
+		block = append([]byte(nil), block...)
+	}
+	e.retainRawBlockScratch(raw)
+	return block, nil
+}
+
+func (e *columnRetainedSemanticStreamV1StoredBlockEncoder) retainRawBlockScratch(raw []byte) {
+	if cap(raw) > columnRetainedSemanticStreamV1RawBlockScratchMaxRetainedBytes {
+		e.rawBlockScratch = nil
+		return
+	}
+	e.rawBlockScratch = raw[:0]
+}
+
+func columnRetainedSemanticStreamSlicesShareStart(a, b []byte) bool {
+	return len(a) > 0 && len(b) > 0 && &a[0] == &b[0]
 }
 
 func (e *columnRetainedSemanticStreamV1StoredBlockEncoder) encodeWithRawLimit(raw []byte, compressedRawLimit int) ([]byte, error) {

--- a/TreeDB/collections/column_retained_vlog_placement_test.go
+++ b/TreeDB/collections/column_retained_vlog_placement_test.go
@@ -480,6 +480,42 @@ func TestColumnRetainedPayloadSemanticStreamV1StoredBlockEncoderReuse(t *testing
 	}
 }
 
+func TestColumnRetainedPayloadSemanticStreamV1StoredBlockEncoderRawFallbackDoesNotAliasScratch3221(t *testing.T) {
+	_, docsA := retainedSemanticStreamDocuments(96)
+	_, docsB := retainedSemanticStreamDocumentsFrom(96, 96)
+	streamsA := retainedSemanticStreamTestStreamsFromDocuments(t, docsA)
+	streamsB := retainedSemanticStreamTestStreamsFromDocuments(t, docsB)
+
+	encoder, err := newColumnRetainedSemanticStreamV1StoredBlockEncoder()
+	if err != nil {
+		t.Fatalf("new stored block encoder: %v", err)
+	}
+	defer encoder.close()
+
+	blockA, err := encoder.encodeStreamsWithRawLimit(len(docsA), streamsA, 1)
+	if err != nil {
+		t.Fatalf("encode raw fallback block A: %v", err)
+	}
+	if !bytes.HasPrefix(blockA, columnRetainedSemanticStreamV1BlockMagic) {
+		t.Fatalf("block A magic=%q want raw semantic-stream block", blockA[:len(columnRetainedSemanticStreamV1BlockMagic)])
+	}
+	blockACopy := append([]byte(nil), blockA...)
+
+	if _, err := encoder.encodeStreamsWithRawLimit(len(docsB), streamsB, 1); err != nil {
+		t.Fatalf("encode raw fallback block B: %v", err)
+	}
+	if !bytes.Equal(blockA, blockACopy) {
+		t.Fatal("raw fallback block A aliases reusable encoder scratch and changed after block B")
+	}
+	decodedA, err := decodeColumnRetainedSemanticStreamV1StoredBlock(blockA)
+	if err != nil {
+		t.Fatalf("decode raw fallback block A after reuse: %v", err)
+	}
+	if !bytes.Equal(decodedA, blockACopy) {
+		t.Fatal("decoded raw fallback block A differs after encoder scratch reuse")
+	}
+}
+
 func TestColumnRetainedPayloadSemanticStreamV1RootFastPathPreparesDeclaredRows(t *testing.T) {
 	cfg := ColumnStoreConfig{
 		Enabled: true,
@@ -1178,6 +1214,45 @@ func BenchmarkColumnRetainedPayloadSemanticStreamV1PrepareRootFastPath(b *testin
 	}
 }
 
+func BenchmarkColumnRetainedPayloadSemanticStreamV1PrepareRootFastPathMultiBlock(b *testing.B) {
+	cfg := ColumnStoreConfig{
+		Enabled: true,
+		Columns: []ColumnStoreColumn{
+			{Name: "row_id", Path: "row_id", ValueType: ColumnStoreValueInt64, Owner: TypedStorageOwnerRowAsset},
+			{Name: "kind", Path: "kind", ValueType: ColumnStoreValueString, Owner: TypedStorageOwnerColumnPart, Dictionary: true},
+		},
+		RetainedPayload:         ColumnRetainedPayloadNonColumn,
+		RetainedPayloadEncoding: ColumnRetainedPayloadEncodingSemanticStreamV1,
+		Reconstruction:          ColumnReconstructionRetainedPayloadAndColumns,
+	}
+	ids, docs := retainedSemanticStreamDocuments(columnRetainedSemanticStreamV1BlockRows * 4)
+	var bytesPerIteration int64
+	for _, doc := range docs {
+		bytesPerIteration += int64(len(doc))
+	}
+	b.ReportAllocs()
+	b.SetBytes(bytesPerIteration)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		prepared, err := prepareColumnRetainedPayloadInsertBatchStorageDocumentsWithIDs(cfg, ids, docs, nil)
+		if err != nil {
+			b.Fatalf("prepare semantic-stream-v1 documents with ids: %v", err)
+		}
+		if !prepared.declaredRowsReady || len(prepared.declaredRows) != len(docs) {
+			b.Fatalf("prepared declared rows ready=%t len=%d want %d", prepared.declaredRowsReady, len(prepared.declaredRows), len(docs))
+		}
+		if prepared.semanticStreamBlocks == nil {
+			b.Fatal("prepare semantic-stream-v1 documents did not return block table")
+		}
+		if i == 0 {
+			b.StopTimer()
+			reportColumnRetainedSemanticStreamBenchmarkStoredBlockBytes(b, prepared.semanticStreamBlocks, bytesPerIteration)
+			b.StartTimer()
+		}
+		resetCollectionRunTable(prepared.semanticStreamBlocks)
+	}
+}
+
 func BenchmarkColumnRetainedPayloadSemanticStreamV1PrepareNestedDeclaredPaths(b *testing.B) {
 	cfg := ColumnStoreConfig{
 		Enabled: true,
@@ -1217,6 +1292,25 @@ func BenchmarkColumnRetainedPayloadSemanticStreamV1PrepareNestedDeclaredPaths(b 
 
 func retainedSemanticStreamDocuments(count int) ([][]byte, [][]byte) {
 	return retainedSemanticStreamDocumentsFrom(0, count)
+}
+
+func retainedSemanticStreamTestStreamsFromDocuments(t testing.TB, docs [][]byte) *columnRetainedSemanticStreamStreams {
+	t.Helper()
+	streams := newColumnRetainedSemanticStreamStreams()
+	for row, document := range docs {
+		trimmed := bytes.TrimSpace(document)
+		if len(trimmed) == 0 {
+			trimmed = []byte("{}")
+		}
+		var root json.RawMessage
+		if err := json.Unmarshal(trimmed, &root); err != nil {
+			t.Fatalf("unmarshal retained semantic stream test row %d: %v", row, err)
+		}
+		if err := collectColumnRetainedSemanticStreamPaths(root, nil, uint64(row), streams); err != nil {
+			t.Fatalf("collect retained semantic stream test row %d: %v", row, err)
+		}
+	}
+	return streams
 }
 
 func retainedSemanticStreamDocumentsFrom(start, count int) ([][]byte, [][]byte) {

--- a/TreeDB/collections/typed_storage_naming_test.go
+++ b/TreeDB/collections/typed_storage_naming_test.go
@@ -387,7 +387,7 @@ var typedStorageLegacyNameAllowlist = []typedStorageLegacyNameAllowlistEntry{
 	{path: "TreeDB/collections/column_retained_payload_audit_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 29, occurrences: 30},
 	{path: "TreeDB/collections/column_retained_semantic_stream.go", classification: typedStorageLegacyCompatibility, matchingLines: 15, occurrences: 15},
 	{path: "TreeDB/collections/column_retained_semantic_stream_raw_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 16, occurrences: 16},
-	{path: "TreeDB/collections/column_retained_vlog_placement_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 45, occurrences: 45},
+	{path: "TreeDB/collections/column_retained_vlog_placement_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 49, occurrences: 49},
 	{path: "TreeDB/collections/column_semantics.go", classification: typedStorageLegacyCompatibility, matchingLines: 34, occurrences: 34},
 	{path: "TreeDB/collections/dense_numeric_vector.go", classification: typedStorageLegacyCompatibility, matchingLines: 32, occurrences: 41},
 	{path: "TreeDB/collections/dense_numeric_vector_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 35, occurrences: 38},


### PR DESCRIPTION
## Summary

Closes #3221.
Refs #3099, #3067, #3000, #3001, #3070.

This is an insert/load-prep slice for retained semantic-stream payloads. It does not claim one-shot SQL execution, no-aggregate-metadata scan, ClickHouse comparison, or broad SQL superiority evidence.

What changed:
- Reuse the retained semantic-stream raw-block encode buffer across blocks inside one stored-block encoder.
- Keep raw fallback blocks safe by copying them when they share the reusable scratch backing array.
- Drop retained scratch above an 8 MiB cap so oversized batches do not pin large buffers.
- Add a raw-fallback aliasing regression test and a multi-block root-fast-path benchmark.
- Update the typed-storage legacy-name allowlist for the new compatibility-retained benchmark names.

Scope classification for the realigned tracker:
- Insert/load: yes, narrower retained semantic-stream load-prep allocation slice.
- One-shot query execution: no.
- Hot prepared query execution: no.
- Metadata storage/query acceleration: no.
- General typed-column scan performance: no.
- On-disk format/storage bytes: unchanged.

## Benchmark Evidence

Baseline worktree: `/tmp/gomap_3221_baseline_20260627_213646` at `origin/main` (`d6e36ebe7`).

Commands:

```sh
go test ./TreeDB/collections \
  -run '^$' \
  -bench 'BenchmarkColumnRetainedPayloadSemanticStreamV1Prepare(RootFastPath|RootFastPathMultiBlock|NestedDeclaredPaths)$' \
  -benchmem -count=8 \
  > /tmp/treedb_semstream_rawscratch_3221_before.txt

go test ./TreeDB/collections \
  -run '^$' \
  -bench 'BenchmarkColumnRetainedPayloadSemanticStreamV1Prepare(RootFastPath|RootFastPathMultiBlock|NestedDeclaredPaths)$' \
  -benchmem -count=8 \
  > /tmp/treedb_semstream_rawscratch_3221_after_slack.txt

benchstat /tmp/treedb_semstream_rawscratch_3221_before.txt /tmp/treedb_semstream_rawscratch_3221_after_slack.txt
```

Key results on darwin/arm64 Apple M3:

```text
RootFastPathMultiBlock sec/op: 30.98ms -> 29.66ms, -4.26% (p=0.000, n=8)
RootFastPathMultiBlock B/op:   18.87MiB -> 17.23MiB, -8.69% (p=0.000, n=8)
RootFastPathMultiBlock allocs: 466 -> 464, -0.43% (p=0.000, n=8)
RootFastPathMultiBlock stored_block_B/op: 89.82k -> 89.82k, unchanged
RootFastPathMultiBlock stored/input:      16.83m -> 16.83m, unchanged

RootFastPath one-block B/op: 5.956MiB -> 5.957MiB, no significant change
NestedDeclaredPaths one-block B/op: 3.466MiB -> 3.466MiB, no significant change
Geomean B/op: 7.304MiB -> 7.086MiB, -2.98%
```

## Validation

```sh
go test ./TreeDB/collections -run 'TestColumnRetainedPayloadSemanticStreamV1|TestColumnRetainedSemanticStream|TestColumnRetainedPayload|TestRetainedPayload|TestColumnStoreRetained' -count=1
go test ./TreeDB/collections -count=1
git diff --check
```
