### PR TITLE
treedb: pool semantic-stream raw block scratch

### DIFF
--- a/TreeDB/collections/column_retained_semantic_stream.go
+++ b/TreeDB/collections/column_retained_semantic_stream.go
@@ -26,6 +26,7 @@ const columnRetainedSemanticStreamV1BlockRows = 4096
 const maxColumnRetainedSemanticStreamV1CompressedRawBlockBytes = 512 << 20
 const columnRetainedSemanticStreamV1ZSTDWindowSize = 1 << 20
 const columnRetainedSemanticStreamV1RawBlockScratchMaxRetainedBytes = 8 << 20
+const columnRetainedSemanticStreamV1RawBlockScratchPoolSlots = 4
 const defaultColumnRetainedSemanticStreamV1DecodeCacheBlocks = 16
 const minColumnRetainedSemanticStreamV1DecodeCacheRows = 64
 const minColumnRetainedSemanticStreamV1DecodeCacheRowsPerBlock = 512
@@ -39,6 +40,8 @@ var (
 	columnRetainedSemanticStreamV1BlockZSTDMagic = []byte("crss1zst\x00")
 	columnRetainedSemanticStreamV1LocatorMagic   = []byte("crss1loc\x00")
 )
+
+var columnRetainedSemanticStreamV1RawBlockScratchPool = make(chan []byte, columnRetainedSemanticStreamV1RawBlockScratchPoolSlots)
 
 type columnRetainedSemanticStreamPath struct {
 	segments                []string
@@ -1233,16 +1236,43 @@ func newColumnRetainedSemanticStreamV1StoredBlockEncoder() (*columnRetainedSeman
 	if err != nil {
 		return nil, fmt.Errorf("collections: create semantic-stream-v1 retained block zstd encoder: %w", err)
 	}
-	return &columnRetainedSemanticStreamV1StoredBlockEncoder{enc: enc}, nil
+	return &columnRetainedSemanticStreamV1StoredBlockEncoder{
+		enc:             enc,
+		rawBlockScratch: getColumnRetainedSemanticStreamV1RawBlockScratch(),
+	}, nil
 }
 
 func (e *columnRetainedSemanticStreamV1StoredBlockEncoder) close() {
-	if e == nil || e.enc == nil {
+	if e == nil {
 		return
 	}
-	e.enc.Close()
-	e.enc = nil
+	putColumnRetainedSemanticStreamV1RawBlockScratch(e.rawBlockScratch)
 	e.rawBlockScratch = nil
+	if e.enc != nil {
+		e.enc.Close()
+		e.enc = nil
+	}
+}
+
+func getColumnRetainedSemanticStreamV1RawBlockScratch() []byte {
+	select {
+	case pooled := <-columnRetainedSemanticStreamV1RawBlockScratchPool:
+		if cap(pooled) <= columnRetainedSemanticStreamV1RawBlockScratchMaxRetainedBytes {
+			return pooled[:0]
+		}
+	default:
+	}
+	return nil
+}
+
+func putColumnRetainedSemanticStreamV1RawBlockScratch(scratch []byte) {
+	if scratch == nil || cap(scratch) == 0 || cap(scratch) > columnRetainedSemanticStreamV1RawBlockScratchMaxRetainedBytes {
+		return
+	}
+	select {
+	case columnRetainedSemanticStreamV1RawBlockScratchPool <- scratch[:0]:
+	default:
+	}
 }
 
 func (e *columnRetainedSemanticStreamV1StoredBlockEncoder) encodeStreamsWithRawLimit(rows int, streams *columnRetainedSemanticStreamStreams, compressedRawLimit int) ([]byte, error) {

--- a/TreeDB/collections/column_retained_vlog_placement_test.go
+++ b/TreeDB/collections/column_retained_vlog_placement_test.go
@@ -516,6 +516,62 @@ func TestColumnRetainedPayloadSemanticStreamV1StoredBlockEncoderRawFallbackDoesN
 	}
 }
 
+func TestColumnRetainedPayloadSemanticStreamV1StoredBlockEncoderRawFallbackDoesNotAliasPooledScratch3223(t *testing.T) {
+	previousPool := columnRetainedSemanticStreamV1RawBlockScratchPool
+	columnRetainedSemanticStreamV1RawBlockScratchPool = make(chan []byte, columnRetainedSemanticStreamV1RawBlockScratchPoolSlots)
+	t.Cleanup(func() {
+		columnRetainedSemanticStreamV1RawBlockScratchPool = previousPool
+	})
+
+	_, docsA := retainedSemanticStreamDocuments(96)
+	_, docsB := retainedSemanticStreamDocumentsFrom(96, 96)
+	streamsA := retainedSemanticStreamTestStreamsFromDocuments(t, docsA)
+	streamsB := retainedSemanticStreamTestStreamsFromDocuments(t, docsB)
+
+	encoderA, err := newColumnRetainedSemanticStreamV1StoredBlockEncoder()
+	if err != nil {
+		t.Fatalf("new stored block encoder A: %v", err)
+	}
+	blockA, err := encoderA.encodeStreamsWithRawLimit(len(docsA), streamsA, 1)
+	if err != nil {
+		encoderA.close()
+		t.Fatalf("encode raw fallback block A: %v", err)
+	}
+	if !bytes.HasPrefix(blockA, columnRetainedSemanticStreamV1BlockMagic) {
+		encoderA.close()
+		t.Fatalf("block A magic=%q want raw semantic-stream block", blockA[:len(columnRetainedSemanticStreamV1BlockMagic)])
+	}
+	blockACopy := append([]byte(nil), blockA...)
+	returnedScratchCap := cap(encoderA.rawBlockScratch)
+	if returnedScratchCap == 0 {
+		encoderA.close()
+		t.Fatal("encoder A did not retain raw block scratch")
+	}
+	encoderA.close()
+
+	encoderB, err := newColumnRetainedSemanticStreamV1StoredBlockEncoder()
+	if err != nil {
+		t.Fatalf("new stored block encoder B: %v", err)
+	}
+	defer encoderB.close()
+	if cap(encoderB.rawBlockScratch) != returnedScratchCap {
+		t.Fatalf("encoder B scratch cap=%d want pooled cap %d", cap(encoderB.rawBlockScratch), returnedScratchCap)
+	}
+	if _, err := encoderB.encodeStreamsWithRawLimit(len(docsB), streamsB, 1); err != nil {
+		t.Fatalf("encode raw fallback block B: %v", err)
+	}
+	if !bytes.Equal(blockA, blockACopy) {
+		t.Fatal("raw fallback block A aliases pooled encoder scratch and changed after block B")
+	}
+	decodedA, err := decodeColumnRetainedSemanticStreamV1StoredBlock(blockA)
+	if err != nil {
+		t.Fatalf("decode raw fallback block A after pooled reuse: %v", err)
+	}
+	if !bytes.Equal(decodedA, blockACopy) {
+		t.Fatal("decoded raw fallback block A differs after pooled scratch reuse")
+	}
+}
+
 func TestColumnRetainedPayloadSemanticStreamV1RootFastPathPreparesDeclaredRows(t *testing.T) {
 	cfg := ColumnStoreConfig{
 		Enabled: true,


### PR DESCRIPTION
## Summary

- Reuses retained semantic-stream V1 raw-block encode scratch across preparation calls with a small bounded typed pool.
- Returns scratch on encoder close and discards oversized buffers above the existing 8 MiB retention cap.
- Adds a raw-fallback regression test that reuses pooled scratch in a later encoder and verifies the previously returned block remains immutable/decodable.

Closes #3223.

## Scope / claim boundary

This is a TreeDB insert/load preparation allocation improvement only. It does not provide one-shot SQL-style query evidence, no-aggregate-metadata scan evidence, or a TreeDB-vs-ClickHouse SQL superiority claim. It supports #3099/#3067/#3000 as a load-path slice.

## Benchmark evidence

Baseline: `origin/main` at the #3222 merge.

```sh
go test ./TreeDB/collections \
  -run '^$' \
  -bench 'BenchmarkColumnRetainedPayloadSemanticStreamV1Prepare(RootFastPath|RootFastPathMultiBlock|NestedDeclaredPaths)$' \
  -benchmem -count=8 \
  > /tmp/treedb_semstream_scratchpool_3223_before.txt
```

Candidate:

```sh
go test ./TreeDB/collections \
  -run '^$' \
  -bench 'BenchmarkColumnRetainedPayloadSemanticStreamV1Prepare(RootFastPath|RootFastPathMultiBlock|NestedDeclaredPaths)$' \
  -benchmem -count=8 \
  > /tmp/treedb_semstream_scratchpool_3223_after_typedpool.txt
```

`benchstat /tmp/treedb_semstream_scratchpool_3223_before.txt /tmp/treedb_semstream_scratchpool_3223_after_typedpool.txt`:

```text
ColumnRetainedPayloadSemanticStreamV1PrepareRootFastPath-8
  B/op:      5.956Mi -> 5.113Mi  -14.17% (p=0.000 n=8)
  allocs/op: 176.0   -> 174.0    -1.14%  (p=0.000 n=8)
  sec/op:    7.579ms -> 7.529ms  ~       (p=0.959 n=8)

ColumnRetainedPayloadSemanticStreamV1PrepareRootFastPathMultiBlock-8
  B/op:      17.23Mi -> 15.49Mi  -10.12% (p=0.000 n=8)
  allocs/op: 464.0   -> 461.0    -0.65%  (p=0.000 n=8)
  sec/op:    30.14ms -> 29.97ms  ~       (p=0.574 n=8)

ColumnRetainedPayloadSemanticStreamV1PrepareNestedDeclaredPaths-8
  B/op:      3.466Mi -> 2.708Mi  -21.87% (p=0.000 n=8)
  allocs/op: 163.0   -> 162.0    -0.61%  (p=0.000 n=8)
  sec/op:    6.763ms -> 6.657ms  -1.57%  (p=0.038 n=8)

stored/input and stored_block_B/op were unchanged for all three benchmarks.
```

## Validation

```sh
go test ./TreeDB/collections \
  -run 'TestColumnRetainedPayloadSemanticStreamV1StoredBlockEncoder(RawFallbackDoesNotAliasScratch3221|RawFallbackDoesNotAliasPooledScratch3223|Reuse)$' \
  -count=1

go test ./TreeDB/collections -count=1

git diff --check
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of semantic-stream block encoding by reusing bounded scratch buffers safely, reducing the chance of data being affected when encoders are reused.
  * Tightened buffer handling to avoid unexpected memory reuse issues during raw-fallback encoding.

* **Tests**
  * Added coverage for encoder reuse to verify previously encoded data remains unchanged when scratch buffers are returned and reused.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->