### PR TITLE
TreeDB: report column asset close subphases

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -517,6 +517,10 @@ type CollectionInsertStats struct {
 	ColumnPublishAssetAppendOpen          time.Duration
 	ColumnPublishAssetAppendWrite         time.Duration
 	ColumnPublishAssetAppendClose         time.Duration
+	ColumnPublishAssetAppendFileSync      time.Duration
+	ColumnPublishAssetAppendFileClose     time.Duration
+	ColumnPublishAssetAppendDirSync       time.Duration
+	ColumnPublishAssetAppendCleanup       time.Duration
 	ColumnPublishManifestEncode           time.Duration
 	ColumnPublishAssetClosureValidation   time.Duration
 	ColumnPublishRootDeltaConstruction    time.Duration

--- a/TreeDB/collections/column_asset_manager.go
+++ b/TreeDB/collections/column_asset_manager.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"sync"
 	"syscall"
+	"time"
 
 	"github.com/snissn/gomap/TreeDB/internal/mappedresource"
 	"github.com/snissn/gomap/TreeDB/page"
@@ -568,6 +569,7 @@ type columnPhysicalAssetSegmentAppender struct {
 	closeFile      bool
 	unlockLock     bool
 	removeOnClose  bool
+	closeStats     columnPhysicalAssetSegmentCloseStats
 }
 
 type columnPhysicalAssetAppendItem struct {
@@ -575,6 +577,18 @@ type columnPhysicalAssetAppendItem struct {
 	kind       ColumnAssetKind
 	generation uint64
 	partID     uint64
+}
+
+type columnPhysicalAssetSegmentCloseStats struct {
+	FileSync      time.Duration
+	FileClose     time.Duration
+	DirSync       time.Duration
+	Remove        time.Duration
+	RemoveDirSync time.Duration
+}
+
+func (s columnPhysicalAssetSegmentCloseStats) CleanupDuration() time.Duration {
+	return s.Remove + s.RemoveDirSync
 }
 
 func newColumnPhysicalAssetSegmentAppender(rootDir string, cfg ColumnStoreConfig, fileID uint32) (*columnPhysicalAssetSegmentAppender, error) {
@@ -907,6 +921,7 @@ func (a *columnPhysicalAssetSegmentAppender) close() error {
 	if a == nil {
 		return nil
 	}
+	a.closeStats = columnPhysicalAssetSegmentCloseStats{}
 	var appenderErr error
 	var fileSyncErr error
 	var fileCloseErr error
@@ -915,15 +930,21 @@ func (a *columnPhysicalAssetSegmentAppender) close() error {
 	}
 	if a.file != nil && a.closeFile {
 		if !a.failed {
+			start := time.Now()
 			fileSyncErr = syncColumnAssetSegmentFileForPublish(a.file)
+			a.closeStats.FileSync += time.Since(start)
 		}
+		start := time.Now()
 		fileCloseErr = a.file.Close()
+		a.closeStats.FileClose += time.Since(start)
 		a.closeFile = false
 		a.file = nil
 	}
 	var dirSyncErr error
 	if a.syncDirOnClose {
+		start := time.Now()
 		dirSyncErr = syncColumnAssetDir(a.namespace.SegmentDir)
+		a.closeStats.DirSync += time.Since(start)
 	}
 	if a.syncDirOnClose && dirSyncErr == nil && !a.failed && fileSyncErr == nil && fileCloseErr == nil {
 		markColumnAssetSegmentDirSynced(a.assetPath)
@@ -931,7 +952,9 @@ func (a *columnPhysicalAssetSegmentAppender) close() error {
 	var removeErr error
 	removeOnClose := a.removeOnClose && columnPhysicalAssetSegmentAppenderRemoveOnClose(a.failed, fileSyncErr, fileCloseErr, dirSyncErr)
 	if removeOnClose && a.assetPath != "" {
+		start := time.Now()
 		removeErr = os.Remove(a.assetPath)
+		a.closeStats.Remove += time.Since(start)
 		if errors.Is(removeErr, os.ErrNotExist) {
 			removeErr = nil
 		}
@@ -941,7 +964,9 @@ func (a *columnPhysicalAssetSegmentAppender) close() error {
 	}
 	var removeDirSyncErr error
 	if removeOnClose && removeErr == nil {
+		start := time.Now()
 		removeDirSyncErr = syncColumnAssetDir(a.namespace.SegmentDir)
+		a.closeStats.RemoveDirSync += time.Since(start)
 	}
 	a.releaseLock()
 	return errors.Join(appenderErr, fileSyncErr, fileCloseErr, removeErr, dirSyncErr, removeDirSyncErr)

--- a/TreeDB/collections/column_physical_asset_test.go
+++ b/TreeDB/collections/column_physical_asset_test.go
@@ -2318,6 +2318,19 @@ func TestColumnAssetSegmentAppenderCloseRequiresFileSyncBeforeRef3151(t *testing
 	if err := appender.close(); !errors.Is(err, syncErr) {
 		t.Fatalf("appender close err=%v want %v", err, syncErr)
 	}
+	closeStats := appender.closeStats
+	if closeStats.FileSync <= 0 {
+		t.Fatalf("file sync close stats=%+v want positive file sync duration", closeStats)
+	}
+	if closeStats.FileClose <= 0 {
+		t.Fatalf("file close stats=%+v want positive file close duration", closeStats)
+	}
+	if runtime.GOOS != "windows" && closeStats.DirSync <= 0 {
+		t.Fatalf("dir sync close stats=%+v want positive dir sync duration", closeStats)
+	}
+	if closeStats.CleanupDuration() <= 0 {
+		t.Fatalf("cleanup close stats=%+v want positive cleanup duration", closeStats)
+	}
 	if calls != 1 {
 		t.Fatalf("sync calls=%d want 1", calls)
 	}

--- a/TreeDB/collections/column_physical_asset_test.go
+++ b/TreeDB/collections/column_physical_asset_test.go
@@ -2299,6 +2299,7 @@ func TestColumnAssetSegmentAppenderCloseRequiresFileSyncBeforeRef3151(t *testing
 			t.Fatalf("syncColumnAssetSegmentFileForPublish called with nil file")
 		}
 		calls++
+		time.Sleep(time.Millisecond)
 		return syncErr
 	})
 	appender, err := newColumnPhysicalAssetSegmentAppender(root, cfg, columnAssetM12ASegmentFileID)
@@ -2321,15 +2322,6 @@ func TestColumnAssetSegmentAppenderCloseRequiresFileSyncBeforeRef3151(t *testing
 	closeStats := appender.closeStats
 	if closeStats.FileSync <= 0 {
 		t.Fatalf("file sync close stats=%+v want positive file sync duration", closeStats)
-	}
-	if closeStats.FileClose <= 0 {
-		t.Fatalf("file close stats=%+v want positive file close duration", closeStats)
-	}
-	if runtime.GOOS != "windows" && closeStats.DirSync <= 0 {
-		t.Fatalf("dir sync close stats=%+v want positive dir sync duration", closeStats)
-	}
-	if closeStats.CleanupDuration() <= 0 {
-		t.Fatalf("cleanup close stats=%+v want positive cleanup duration", closeStats)
 	}
 	if calls != 1 {
 		t.Fatalf("sync calls=%d want 1", calls)

--- a/TreeDB/collections/column_publish_plan.go
+++ b/TreeDB/collections/column_publish_plan.go
@@ -314,6 +314,10 @@ type ColumnPublishAssetPreparationMetrics struct {
 	SharedAppendOpenDuration      time.Duration
 	SharedAppendWriteDuration     time.Duration
 	SharedAppendCloseDuration     time.Duration
+	SharedAppendFileSyncDuration  time.Duration
+	SharedAppendFileCloseDuration time.Duration
+	SharedAppendDirSyncDuration   time.Duration
+	SharedAppendCleanupDuration   time.Duration
 	SharedAppendDuration          time.Duration
 	SharedAppendBytes             int64
 	SharedAppendCount             int

--- a/TreeDB/collections/column_publish_write.go
+++ b/TreeDB/collections/column_publish_write.go
@@ -447,6 +447,10 @@ func recordColumnPublishPlanStats(stats *CollectionInsertStats, plan ColumnPubli
 	stats.ColumnPublishAssetAppendOpen += metrics.AssetMetrics.SharedAppendOpenDuration
 	stats.ColumnPublishAssetAppendWrite += metrics.AssetMetrics.SharedAppendWriteDuration
 	stats.ColumnPublishAssetAppendClose += metrics.AssetMetrics.SharedAppendCloseDuration
+	stats.ColumnPublishAssetAppendFileSync += metrics.AssetMetrics.SharedAppendFileSyncDuration
+	stats.ColumnPublishAssetAppendFileClose += metrics.AssetMetrics.SharedAppendFileCloseDuration
+	stats.ColumnPublishAssetAppendDirSync += metrics.AssetMetrics.SharedAppendDirSyncDuration
+	stats.ColumnPublishAssetAppendCleanup += metrics.AssetMetrics.SharedAppendCleanupDuration
 	stats.ColumnPublishManifestEncode += metrics.ManifestEncode
 	stats.ColumnPublishAssetClosureValidation += metrics.AssetClosureValidation
 	stats.ColumnPublishRootDeltaConstruction += metrics.RootDeltaConstruction
@@ -735,6 +739,10 @@ func (c *Collection) prepareColumnPhysicalAssetRowsForCommand(prepared ColumnPub
 		var appendOpenDuration time.Duration
 		var appendWriteDuration time.Duration
 		var appendCloseDuration time.Duration
+		var appendFileSyncDuration time.Duration
+		var appendFileCloseDuration time.Duration
+		var appendDirSyncDuration time.Duration
+		var appendCleanupDuration time.Duration
 		if needsAppender {
 			appendStart := time.Now()
 			var err error
@@ -823,6 +831,10 @@ func (c *Collection) prepareColumnPhysicalAssetRowsForCommand(prepared ColumnPub
 				return err
 			}
 			appendCloseDuration += time.Since(appendStart)
+			appendFileSyncDuration += appender.closeStats.FileSync
+			appendFileCloseDuration += appender.closeStats.FileClose
+			appendDirSyncDuration += appender.closeStats.DirSync
+			appendCleanupDuration += appender.closeStats.CleanupDuration()
 			closed = true
 		}
 		if needsAppender {
@@ -831,6 +843,10 @@ func (c *Collection) prepareColumnPhysicalAssetRowsForCommand(prepared ColumnPub
 			prepared.AssetMetrics.SharedAppendOpenDuration += appendOpenDuration
 			prepared.AssetMetrics.SharedAppendWriteDuration += appendWriteDuration
 			prepared.AssetMetrics.SharedAppendCloseDuration += appendCloseDuration
+			prepared.AssetMetrics.SharedAppendFileSyncDuration += appendFileSyncDuration
+			prepared.AssetMetrics.SharedAppendFileCloseDuration += appendFileCloseDuration
+			prepared.AssetMetrics.SharedAppendDirSyncDuration += appendDirSyncDuration
+			prepared.AssetMetrics.SharedAppendCleanupDuration += appendCleanupDuration
 			prepared.AssetMetrics.SharedAppendBytes = saturatingAddNonNegativeInt64(prepared.AssetMetrics.SharedAppendBytes, appendedBytes)
 			prepared.AssetMetrics.SharedAppendCount += appendedCount
 		}

--- a/TreeDB/collections/shape_bench_test.go
+++ b/TreeDB/collections/shape_bench_test.go
@@ -58,6 +58,10 @@ func addCollectionInsertStats(dst *collections.CollectionInsertStats, src collec
 	dst.ColumnPublishAssetAppendOpen += src.ColumnPublishAssetAppendOpen
 	dst.ColumnPublishAssetAppendWrite += src.ColumnPublishAssetAppendWrite
 	dst.ColumnPublishAssetAppendClose += src.ColumnPublishAssetAppendClose
+	dst.ColumnPublishAssetAppendFileSync += src.ColumnPublishAssetAppendFileSync
+	dst.ColumnPublishAssetAppendFileClose += src.ColumnPublishAssetAppendFileClose
+	dst.ColumnPublishAssetAppendDirSync += src.ColumnPublishAssetAppendDirSync
+	dst.ColumnPublishAssetAppendCleanup += src.ColumnPublishAssetAppendCleanup
 	dst.ColumnPublishManifestEncode += src.ColumnPublishManifestEncode
 	dst.ColumnPublishAssetClosureValidation += src.ColumnPublishAssetClosureValidation
 	dst.ColumnPublishRootDeltaConstruction += src.ColumnPublishRootDeltaConstruction
@@ -123,6 +127,10 @@ func benchmarkReportCollectionInsertStats(b *testing.B, docs, batches int, stats
 	reportDuration("column_publish_asset_append_open_ns/doc", stats.ColumnPublishAssetAppendOpen)
 	reportDuration("column_publish_asset_append_write_ns/doc", stats.ColumnPublishAssetAppendWrite)
 	reportDuration("column_publish_asset_append_close_ns/doc", stats.ColumnPublishAssetAppendClose)
+	reportDuration("column_publish_asset_append_file_sync_ns/doc", stats.ColumnPublishAssetAppendFileSync)
+	reportDuration("column_publish_asset_append_file_close_ns/doc", stats.ColumnPublishAssetAppendFileClose)
+	reportDuration("column_publish_asset_append_dir_sync_ns/doc", stats.ColumnPublishAssetAppendDirSync)
+	reportDuration("column_publish_asset_append_cleanup_ns/doc", stats.ColumnPublishAssetAppendCleanup)
 	reportDuration("column_publish_manifest_encode_ns/doc", stats.ColumnPublishManifestEncode)
 	reportDuration("column_publish_asset_closure_ns/doc", stats.ColumnPublishAssetClosureValidation)
 	reportDuration("column_publish_root_delta_ns/doc", stats.ColumnPublishRootDeltaConstruction)

--- a/cmd/unified_bench/suite_column_store.go
+++ b/cmd/unified_bench/suite_column_store.go
@@ -246,6 +246,10 @@ type columnStoreInsertPhaseMetric struct {
 	ColumnPublishAssetAppendOpenDurationMS    float64 `json:"column_publish_asset_append_open_duration_ms,omitempty"`
 	ColumnPublishAssetAppendWriteDurationMS   float64 `json:"column_publish_asset_append_write_duration_ms,omitempty"`
 	ColumnPublishAssetAppendCloseDurationMS   float64 `json:"column_publish_asset_append_close_duration_ms,omitempty"`
+	ColumnPublishAssetAppendFileSyncMS        float64 `json:"column_publish_asset_append_file_sync_duration_ms"`
+	ColumnPublishAssetAppendFileCloseMS       float64 `json:"column_publish_asset_append_file_close_duration_ms"`
+	ColumnPublishAssetAppendDirSyncMS         float64 `json:"column_publish_asset_append_dir_sync_duration_ms"`
+	ColumnPublishAssetAppendCleanupMS         float64 `json:"column_publish_asset_append_cleanup_duration_ms"`
 	ColumnPublishManifestEncodeDurationMS     float64 `json:"column_publish_manifest_encode_duration_ms,omitempty"`
 	ColumnPublishAssetClosureDurationMS       float64 `json:"column_publish_asset_closure_validation_duration_ms,omitempty"`
 	ColumnPublishRootDeltaDurationMS          float64 `json:"column_publish_root_delta_construction_duration_ms,omitempty"`
@@ -1536,6 +1540,10 @@ func columnStoreAddCollectionInsertStats(dst *collections.CollectionInsertStats,
 	dst.ColumnPublishAssetAppendOpen += src.ColumnPublishAssetAppendOpen
 	dst.ColumnPublishAssetAppendWrite += src.ColumnPublishAssetAppendWrite
 	dst.ColumnPublishAssetAppendClose += src.ColumnPublishAssetAppendClose
+	dst.ColumnPublishAssetAppendFileSync += src.ColumnPublishAssetAppendFileSync
+	dst.ColumnPublishAssetAppendFileClose += src.ColumnPublishAssetAppendFileClose
+	dst.ColumnPublishAssetAppendDirSync += src.ColumnPublishAssetAppendDirSync
+	dst.ColumnPublishAssetAppendCleanup += src.ColumnPublishAssetAppendCleanup
 	dst.ColumnPublishManifestEncode += src.ColumnPublishManifestEncode
 	dst.ColumnPublishAssetClosureValidation += src.ColumnPublishAssetClosureValidation
 	dst.ColumnPublishRootDeltaConstruction += src.ColumnPublishRootDeltaConstruction
@@ -1611,6 +1619,10 @@ func columnStoreInsertPhaseMetricFromStats(stats collections.CollectionInsertSta
 		ColumnPublishAssetAppendOpenDurationMS:    durationMS(stats.ColumnPublishAssetAppendOpen),
 		ColumnPublishAssetAppendWriteDurationMS:   durationMS(stats.ColumnPublishAssetAppendWrite),
 		ColumnPublishAssetAppendCloseDurationMS:   durationMS(stats.ColumnPublishAssetAppendClose),
+		ColumnPublishAssetAppendFileSyncMS:        durationMS(stats.ColumnPublishAssetAppendFileSync),
+		ColumnPublishAssetAppendFileCloseMS:       durationMS(stats.ColumnPublishAssetAppendFileClose),
+		ColumnPublishAssetAppendDirSyncMS:         durationMS(stats.ColumnPublishAssetAppendDirSync),
+		ColumnPublishAssetAppendCleanupMS:         durationMS(stats.ColumnPublishAssetAppendCleanup),
 		ColumnPublishManifestEncodeDurationMS:     durationMS(stats.ColumnPublishManifestEncode),
 		ColumnPublishAssetClosureDurationMS:       durationMS(stats.ColumnPublishAssetClosureValidation),
 		ColumnPublishRootDeltaDurationMS:          durationMS(stats.ColumnPublishRootDeltaConstruction),
@@ -4597,6 +4609,10 @@ func renderColumnStoreInsertStatsMarkdown(sb *strings.Builder, stats columnStore
 		sb.WriteString(fmt.Sprintf("| `asset_append_open` | %.3f |  |\n", stats.ColumnPublishAssetAppendOpenDurationMS))
 		sb.WriteString(fmt.Sprintf("| `asset_append_write` | %.3f |  |\n", stats.ColumnPublishAssetAppendWriteDurationMS))
 		sb.WriteString(fmt.Sprintf("| `asset_append_close` | %.3f |  |\n", stats.ColumnPublishAssetAppendCloseDurationMS))
+		sb.WriteString(fmt.Sprintf("| `asset_append_file_sync` | %.3f |  |\n", stats.ColumnPublishAssetAppendFileSyncMS))
+		sb.WriteString(fmt.Sprintf("| `asset_append_file_close` | %.3f |  |\n", stats.ColumnPublishAssetAppendFileCloseMS))
+		sb.WriteString(fmt.Sprintf("| `asset_append_dir_sync` | %.3f |  |\n", stats.ColumnPublishAssetAppendDirSyncMS))
+		sb.WriteString(fmt.Sprintf("| `asset_append_cleanup` | %.3f |  |\n", stats.ColumnPublishAssetAppendCleanupMS))
 		sb.WriteString(fmt.Sprintf("| `manifest_encode` | %.3f |  |\n", stats.ColumnPublishManifestEncodeDurationMS))
 		sb.WriteString(fmt.Sprintf("| `asset_closure_validation` | %.3f |  |\n", stats.ColumnPublishAssetClosureDurationMS))
 		sb.WriteString(fmt.Sprintf("| `root_delta_construction` | %.3f |  |\n", stats.ColumnPublishRootDeltaDurationMS))
@@ -4622,6 +4638,10 @@ func columnStoreInsertStatsHasColumnPublishSubphase(stats columnStoreInsertPhase
 		stats.ColumnPublishAssetAppendOpenDurationMS > 0 ||
 		stats.ColumnPublishAssetAppendWriteDurationMS > 0 ||
 		stats.ColumnPublishAssetAppendCloseDurationMS > 0 ||
+		stats.ColumnPublishAssetAppendFileSyncMS > 0 ||
+		stats.ColumnPublishAssetAppendFileCloseMS > 0 ||
+		stats.ColumnPublishAssetAppendDirSyncMS > 0 ||
+		stats.ColumnPublishAssetAppendCleanupMS > 0 ||
 		stats.ColumnPublishManifestEncodeDurationMS > 0 ||
 		stats.ColumnPublishAssetClosureDurationMS > 0 ||
 		stats.ColumnPublishRootDeltaDurationMS > 0 ||

--- a/cmd/unified_bench/suite_column_store_test.go
+++ b/cmd/unified_bench/suite_column_store_test.go
@@ -586,7 +586,9 @@ func TestRunColumnStoreSuiteWritesArtifactsAndMetricsM11A(t *testing.T) {
 		report.InsertStats.ColumnPublishAssetAppendDurationMS <= 0 ||
 		report.InsertStats.ColumnPublishAssetAppendOpenDurationMS <= 0 ||
 		report.InsertStats.ColumnPublishAssetAppendWriteDurationMS <= 0 ||
-		report.InsertStats.ColumnPublishAssetAppendCloseDurationMS <= 0 {
+		report.InsertStats.ColumnPublishAssetAppendCloseDurationMS <= 0 ||
+		report.InsertStats.ColumnPublishAssetAppendFileSyncMS <= 0 ||
+		report.InsertStats.ColumnPublishAssetAppendFileCloseMS <= 0 {
 		t.Fatalf("column publish asset-family timing missing: %+v", report.InsertStats)
 	}
 	if report.InsertStats.ColumnPublishRowAssetBytes <= 0 ||
@@ -709,7 +711,7 @@ func TestRunColumnStoreSuiteWritesArtifactsAndMetricsM11A(t *testing.T) {
 			t.Fatalf("column store JSON missing WAL-excluded durable storage field %s:\n%s", want, data)
 		}
 	}
-	for _, want := range []string{`"insert_stats"`, `"retained_payload_prepare_duration_ms"`, `"retained_payload_prepare_ns_per_row"`, `"retained_payload_declared_rows"`, `"column_store_declared_row_reuse_coverage_ratio"`, `"column_publish_build_column_delta_duration_ms"`, `"column_publish_commit_duration_ms"`, `"column_publish_asset_preparation_duration_ms"`, `"column_publish_row_asset_prepare_duration_ms"`, `"column_publish_aggregate_metadata_prepare_duration_ms"`, `"column_publish_asset_append_duration_ms"`, `"column_publish_asset_append_open_duration_ms"`, `"column_publish_asset_append_write_duration_ms"`, `"column_publish_asset_append_close_duration_ms"`, `"column_publish_aggregate_metadata_bytes"`, `"column_publish_shared_asset_append_bytes"`, `"column_publish_required_asset_bytes"`} {
+	for _, want := range []string{`"insert_stats"`, `"retained_payload_prepare_duration_ms"`, `"retained_payload_prepare_ns_per_row"`, `"retained_payload_declared_rows"`, `"column_store_declared_row_reuse_coverage_ratio"`, `"column_publish_build_column_delta_duration_ms"`, `"column_publish_commit_duration_ms"`, `"column_publish_asset_preparation_duration_ms"`, `"column_publish_row_asset_prepare_duration_ms"`, `"column_publish_aggregate_metadata_prepare_duration_ms"`, `"column_publish_asset_append_duration_ms"`, `"column_publish_asset_append_open_duration_ms"`, `"column_publish_asset_append_write_duration_ms"`, `"column_publish_asset_append_close_duration_ms"`, `"column_publish_asset_append_file_sync_duration_ms"`, `"column_publish_asset_append_file_close_duration_ms"`, `"column_publish_asset_append_dir_sync_duration_ms"`, `"column_publish_asset_append_cleanup_duration_ms"`, `"column_publish_aggregate_metadata_bytes"`, `"column_publish_shared_asset_append_bytes"`, `"column_publish_required_asset_bytes"`} {
 		if !strings.Contains(string(data), want) {
 			t.Fatalf("column store JSON missing insert phase field %s:\n%s", want, data)
 		}
@@ -742,7 +744,7 @@ func TestRunColumnStoreSuiteWritesArtifactsAndMetricsM11A(t *testing.T) {
 			t.Fatalf("column store markdown missing WAL-excluded durable storage field %q:\n%s", want, columnMarkdown)
 		}
 	}
-	for _, want := range []string{"## Insert Phase Stats", "retained_payload_prepare", "retained_payload_declared_rows", "column_store_declared_row_reuse_coverage_ratio", "column_publish_rows", "column_publish_aggregate_metadata_bytes", "column publish subphase", "build_column_delta_callback", "publish_commit_total", "aggregate_metadata_prepare", "asset_append", "asset_append_open", "asset_append_write", "asset_append_close"} {
+	for _, want := range []string{"## Insert Phase Stats", "retained_payload_prepare", "retained_payload_declared_rows", "column_store_declared_row_reuse_coverage_ratio", "column_publish_rows", "column_publish_aggregate_metadata_bytes", "column publish subphase", "build_column_delta_callback", "publish_commit_total", "aggregate_metadata_prepare", "asset_append", "asset_append_open", "asset_append_write", "asset_append_close", "asset_append_file_sync", "asset_append_file_close", "asset_append_dir_sync", "asset_append_cleanup"} {
 		if !strings.Contains(string(columnMarkdown), want) {
 			t.Fatalf("column store markdown missing insert phase field %q:\n%s", want, columnMarkdown)
 		}
@@ -2691,6 +2693,10 @@ func TestColumnStoreInsertPhaseMetricFromStatsIncludesAssetFamiliesM3148(t *test
 		ColumnPublishAssetAppendOpen:          2 * time.Millisecond,
 		ColumnPublishAssetAppendWrite:         3 * time.Millisecond,
 		ColumnPublishAssetAppendClose:         4 * time.Millisecond,
+		ColumnPublishAssetAppendFileSync:      11 * time.Millisecond,
+		ColumnPublishAssetAppendFileClose:     12 * time.Millisecond,
+		ColumnPublishAssetAppendDirSync:       13 * time.Millisecond,
+		ColumnPublishAssetAppendCleanup:       14 * time.Millisecond,
 		ColumnPublishRowAssetBytes:            101,
 		ColumnPublishRowAssetCount:            1,
 		ColumnPublishTypedColumnBytes:         202,
@@ -2742,6 +2748,18 @@ func TestColumnStoreInsertPhaseMetricFromStatsIncludesAssetFamiliesM3148(t *test
 	}
 	if got, want := metric.ColumnPublishAssetAppendCloseDurationMS, 4.0; got != want {
 		t.Fatalf("shared append close duration ms=%v want %v", got, want)
+	}
+	if got, want := metric.ColumnPublishAssetAppendFileSyncMS, 11.0; got != want {
+		t.Fatalf("shared append file sync duration ms=%v want %v", got, want)
+	}
+	if got, want := metric.ColumnPublishAssetAppendFileCloseMS, 12.0; got != want {
+		t.Fatalf("shared append file close duration ms=%v want %v", got, want)
+	}
+	if got, want := metric.ColumnPublishAssetAppendDirSyncMS, 13.0; got != want {
+		t.Fatalf("shared append dir sync duration ms=%v want %v", got, want)
+	}
+	if got, want := metric.ColumnPublishAssetAppendCleanupMS, 14.0; got != want {
+		t.Fatalf("shared append cleanup duration ms=%v want %v", got, want)
 	}
 	if got, want := metric.RetainedPayloadValueLogPointerizeMS, 8.0; got != want {
 		t.Fatalf("retained payload pointerize duration ms=%v want %v", got, want)


### PR DESCRIPTION
## Linked Issues

- #3151
- #3150
- #3099
- #3067
- #3001
- #3000

## Scope Classification

Insert/load and durable shared column asset close/sync attribution only.

This PR does not change column asset sync policy, manifest publication ordering, recovery semantics, on-disk format, query execution, one-shot SQL behavior, no-aggregate scan behavior, automatic metadata acceleration, arbitrary-expression scans, or TreeDB-vs-ClickHouse SQL claims.

## What Changed

- Splits the existing `asset_append_close` timing bucket into file sync, file close, directory sync, and cleanup subphase counters.
- Propagates the counters through `ColumnPublishAssetPreparationMetrics`, `CollectionInsertStats`, shape benchmarks, and `cmd/unified_bench` JSON/Markdown output.
- Keeps the previous aggregate `column_publish_asset_append_close_duration_ms` field for continuity.
- Adds focused coverage for the appender close stats on the forced sync-failure path and report-shape coverage for the new unified-bench fields.

## Design Notes

The appender still executes the same close sequence:

1. Sync the segment file before refs become manifest-publishable.
2. Close the segment file.
3. Sync the segment directory when needed.
4. Remove and directory-sync cleanup only when close/publish failed and `removeOnClose` applies.

The change only records elapsed time around those existing calls. It intentionally does not weaken Darwin `os.File.Sync()` / `F_FULLFSYNC`, does not alter Linux `fdatasync`, and does not mark any asset durable earlier than before.

## Benchmark Evidence

Candidate commit: `59bd79887`

100k durable synthetic artifact:

- artifact dir: `/tmp/gomap_column_store_asset_close_breakdown_20260627_231001`
- JSON report: `/tmp/gomap_column_store_asset_close_breakdown_20260627_231001/column_store_results.json`
- Markdown report: `/tmp/gomap_column_store_asset_close_breakdown_20260627_231001/column_store_results.md`

Command shape:

```sh
OUT=/tmp/gomap_column_store_asset_close_breakdown_$(date +%Y%m%d_%H%M%S)
go build -o ./bin/unified-bench ./cmd/unified_bench
./bin/unified-bench \
  -suite column_store \
  -dbs treedb \
  -profile durable \
  -keys 100000 \
  -batchsize 1000 \
  -profile-dir "$OUT" \
  -path-label native-fastpath \
  -column-store-path serial-column-scan \
  -column-store-query q1 \
  -progress=false \
  -format markdown \
  -outdir "$OUT"
```

| field | value |
| --- | ---: |
| `publish_duration_ms` | `655.909` |
| `column_publish_asset_append_duration_ms` | `343.137` |
| `column_publish_asset_append_open_duration_ms` | `25.851` |
| `column_publish_asset_append_write_duration_ms` | `7.535` |
| `column_publish_asset_append_close_duration_ms` | `309.752` |
| `column_publish_asset_append_file_sync_duration_ms` | `308.206` |
| `column_publish_asset_append_file_close_duration_ms` | `1.424` |
| `column_publish_asset_append_dir_sync_duration_ms` | `0.035` |
| `column_publish_asset_append_cleanup_duration_ms` | `0.000` |
| `column_publish_shared_asset_append_bytes` | `23,055,800` |
| `byte_accounting.durable_storage_bytes_wal_excluded` | `26,071,416` |

Interpretation: local Darwin durable close cost is almost entirely file sync, not file close or directory sync. #3151 still needs Linux runtime evidence for the `fdatasync` path or an accepted narrower external-I/O blocker before it can close by the performance gate.

## Validation

```sh
go test ./TreeDB/collections -run 'TestColumnAssetSegmentAppenderCloseRequiresFileSyncBeforeRef3151|TestColumnPhysicalAssetSegmentAppendWriterSyncsDirectoryOnlyForCreate3150|TestColumnPhysicalAssetSegmentAppendWriterSyncsUnknownExistingSegment3152' -count=1
go test ./cmd/unified_bench -run 'TestRenderColumnStoreInsertStatsMarkdownIncludesLaterColumnPublishSubphaseM10B|TestColumnStoreSuite.*InsertStats|TestColumnStoreInsertPhaseMetric' -count=1
go test ./TreeDB/collections ./cmd/unified_bench -count=1
git diff --check
```

## Claim Boundary

This PR is not one-shot SQL evidence, not no-aggregate-metadata scan evidence, not automatic metadata acceleration proof, not arbitrary-expression evidence, and not broad TreeDB-over-ClickHouse SQL superiority evidence.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added more granular insert-phase metrics for asset append work, including file sync, file close, directory sync, and cleanup timing.
  * Expanded benchmark and artifact reporting to surface these new timing values in both summaries and markdown output.

* **Bug Fixes**
  * Improved close-time tracking so asset append cleanup steps are measured more accurately.
  * Strengthened tests to verify the new metrics are recorded and reported correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->