### PR TITLE
Report typed-column prepare workers

### DIFF
--- a/TreeDB/collections/column_physical_query.go
+++ b/TreeDB/collections/column_physical_query.go
@@ -183,6 +183,7 @@ type ColumnPhysicalQueryDiagnostics struct {
 	TypedColumnOneShotCacheMiss           bool
 	TypedColumnOneShotCacheBuild          bool
 	TypedColumnOneShotBuildNanos          int64
+	TypedColumnPrepareWorkerCount         int
 	TypedColumnPreparePlanNanos           int64
 	TypedColumnPrepareRefsNanos           int64
 	TypedColumnPreparePairingNanos        int64

--- a/TreeDB/collections/column_physical_typed_column_one_shot_cache_3088_test.go
+++ b/TreeDB/collections/column_physical_typed_column_one_shot_cache_3088_test.go
@@ -1,6 +1,9 @@
 package collections
 
-import "testing"
+import (
+	"runtime"
+	"testing"
+)
 
 func TestColumnPhysicalTypedColumnOneShotCacheQ1Q3NoMetadata3088(t *testing.T) {
 	batches := [][]columnPhysicalJSONBenchParityEventP0{columnPhysicalQ3DenseBatchA1950(), columnPhysicalQ3DenseBatchB1950()}
@@ -54,6 +57,11 @@ func TestColumnPhysicalTypedColumnOneShotCacheQ1Q3NoMetadata3088(t *testing.T) {
 }
 
 func TestColumnPhysicalTypedColumnOneShotCacheQ5NoMetadata3088(t *testing.T) {
+	oldGOMAXPROCS := runtime.GOMAXPROCS(2)
+	t.Cleanup(func() {
+		runtime.GOMAXPROCS(oldGOMAXPROCS)
+	})
+
 	batches := [][]columnPhysicalJSONBenchParityEventP0{columnPhysicalQ5DenseBatchA1950(), columnPhysicalQ5DenseBatchB1950()}
 	events := flattenColumnPhysicalEvents1950(batches)
 	_, col, closeFn := openTypedColumnSortKeyFixtureBatches1950(t, nil, batches)
@@ -61,8 +69,13 @@ func TestColumnPhysicalTypedColumnOneShotCacheQ5NoMetadata3088(t *testing.T) {
 
 	scanned := scanColumnPhysicalJSONBenchParityEventsP0(t, col, len(events))
 	req := columnPhysicalQ5DenseRequest1950()
+	req.ColumnAssetReadIntegrity = ColumnAssetReadIntegritySkipChecksums
 	want := columnPhysicalQ5DenseReferenceGroups1950(scanned, req.TopK)
 	matchedRows := columnPhysicalJSONBenchReferenceMatchedRowsP0("q5", scanned)
+	wantPrepareWorkers := columnTypedColumnPhysicalQueryPartDecodeWorkers(len(batches))
+	if wantPrepareWorkers < 2 {
+		t.Fatalf("q5 test setup prepare workers=%d want parallel decode workers", wantPrepareWorkers)
+	}
 
 	first, err := col.RunColumnPhysicalQuery(req)
 	if err != nil {
@@ -70,6 +83,9 @@ func TestColumnPhysicalTypedColumnOneShotCacheQ5NoMetadata3088(t *testing.T) {
 	}
 	assertColumnPhysicalQ5DenseResult1950(t, "q5 first one-shot", first, want, len(events), matchedRows, columnTypedColumnDenseInt64SpanReducerLocalMap)
 	assertTypedColumnOneShotCacheSnapshot3088(t, col, "after q5 first", 1, 0, 1, 1, 0)
+	if got := first.Diagnostics.TypedColumnPrepareWorkerCount; got != wantPrepareWorkers {
+		t.Fatalf("q5 first one-shot typed-column prepare workers=%d want %d diagnostics=%+v", got, wantPrepareWorkers, first.Diagnostics)
+	}
 	assertTypedColumnQ5OneShotDenseDictionaryValuesByCode3175(t, col, req)
 
 	second, err := col.RunColumnPhysicalQuery(req)
@@ -78,6 +94,9 @@ func TestColumnPhysicalTypedColumnOneShotCacheQ5NoMetadata3088(t *testing.T) {
 	}
 	assertColumnPhysicalQ5DenseResult1950(t, "q5 second one-shot", second, want, len(events), matchedRows, columnTypedColumnDenseInt64SpanReducerLocalMap)
 	assertTypedColumnOneShotCacheSnapshot3088(t, col, "after q5 second", 1, 1, 1, 1, 0)
+	if got := second.Diagnostics.TypedColumnPrepareWorkerCount; got != 0 {
+		t.Fatalf("q5 second cache-hit typed-column prepare workers=%d want 0 diagnostics=%+v", got, second.Diagnostics)
+	}
 }
 
 func TestColumnPhysicalTypedColumnOneShotCacheQ2NoMetadata3123(t *testing.T) {

--- a/TreeDB/collections/column_physical_typed_column_query.go
+++ b/TreeDB/collections/column_physical_typed_column_query.go
@@ -210,6 +210,7 @@ type columnTypedColumnPhysicalQueryPartDecodeOptions struct {
 }
 
 type columnTypedColumnPhysicalQueryPrepareDiagnostics struct {
+	WorkerCount         int
 	PlanNanos           int64
 	RefsNanos           int64
 	PairingNanos        int64
@@ -235,6 +236,9 @@ func (d columnTypedColumnPhysicalQueryPrepareDiagnostics) applyTo(diag *ColumnPh
 	if diag == nil {
 		return
 	}
+	if d.WorkerCount > diag.TypedColumnPrepareWorkerCount {
+		diag.TypedColumnPrepareWorkerCount = d.WorkerCount
+	}
 	diag.TypedColumnPreparePlanNanos += d.PlanNanos
 	diag.TypedColumnPrepareRefsNanos += d.RefsNanos
 	diag.TypedColumnPreparePairingNanos += d.PairingNanos
@@ -259,6 +263,9 @@ func (d columnTypedColumnPhysicalQueryPrepareDiagnostics) applyTo(diag *ColumnPh
 func (d *columnTypedColumnPhysicalQueryPrepareDiagnostics) add(src columnTypedColumnPhysicalQueryPrepareDiagnostics) {
 	if d == nil {
 		return
+	}
+	if src.WorkerCount > d.WorkerCount {
+		d.WorkerCount = src.WorkerCount
 	}
 	d.PlanNanos += src.PlanNanos
 	d.RefsNanos += src.RefsNanos
@@ -640,6 +647,10 @@ func decodeColumnTypedColumnPhysicalQueryRunnerParts(view columnPhysicalScanSnap
 	}
 	phaseStart := time.Now()
 	if columnTypedColumnPhysicalQueryUseParallelPartDecode(plan, req, readCache, len(inputs), includePhysicalRows, allowDenseGroupCountDistinct, prepareDenseInt64SpanGlobalCodes, prepareDenseGroupCountDistinctGlobalCodes, prepareDenseGroupCountDistinctGlobalRanks) {
+		workers := columnTypedColumnPhysicalQueryPartDecodeWorkers(len(inputs))
+		if prepareDiagnostics != nil && workers > prepareDiagnostics.WorkerCount {
+			prepareDiagnostics.WorkerCount = workers
+		}
 		// Worker read caches close after decode, so parallel TopK runners must
 		// own payload bytes instead of retaining lazy range readers.
 		decodeOpts := columnTypedColumnPhysicalQueryPartDecodeOptions{
@@ -661,6 +672,9 @@ func decodeColumnTypedColumnPhysicalQueryRunnerParts(view columnPhysicalScanSnap
 			}
 		}
 	} else {
+		if prepareDiagnostics != nil && len(inputs) > 0 && prepareDiagnostics.WorkerCount < 1 {
+			prepareDiagnostics.WorkerCount = 1
+		}
 		var rawScratch []byte
 		for _, input := range inputs {
 			part, scratch, err := decodeColumnTypedColumnPhysicalQueryRunnerPart(view, req, plan, input.typedRef, input.physical, readCache, includePhysicalRows, allowDenseGroupCountDistinct, columnTypedColumnPhysicalQueryPartDecodeOptions{}, rawScratch, prepareDiagnostics)

--- a/cmd/unified_bench/suite_column_store.go
+++ b/cmd/unified_bench/suite_column_store.go
@@ -356,6 +356,7 @@ type columnStoreQueryMetric struct {
 	TypedColumnOneShotCacheMiss            bool                              `json:"typed_column_one_shot_cache_miss,omitempty"`
 	TypedColumnOneShotCacheBuild           bool                              `json:"typed_column_one_shot_cache_build,omitempty"`
 	TypedColumnOneShotBuildDurationMS      float64                           `json:"typed_column_one_shot_build_duration_ms,omitempty"`
+	TypedColumnPrepareWorkerCount          int                               `json:"typed_column_prepare_worker_count,omitempty"`
 	TypedColumnPreparePlanDurationMS       float64                           `json:"typed_column_prepare_plan_duration_ms,omitempty"`
 	TypedColumnPrepareRefsDurationMS       float64                           `json:"typed_column_prepare_refs_duration_ms,omitempty"`
 	TypedColumnPreparePairDurationMS       float64                           `json:"typed_column_prepare_pairing_duration_ms,omitempty"`
@@ -468,6 +469,7 @@ type columnStoreJSONBenchCell struct {
 	TypedColumnOneShotCacheMiss            bool                              `json:"typed_column_one_shot_cache_miss,omitempty"`
 	TypedColumnOneShotCacheBuild           bool                              `json:"typed_column_one_shot_cache_build,omitempty"`
 	TypedColumnOneShotBuildDurationMS      float64                           `json:"typed_column_one_shot_build_duration_ms,omitempty"`
+	TypedColumnPrepareWorkerCount          int                               `json:"typed_column_prepare_worker_count,omitempty"`
 	TypedColumnPreparePlanDurationMS       float64                           `json:"typed_column_prepare_plan_duration_ms,omitempty"`
 	TypedColumnPrepareRefsDurationMS       float64                           `json:"typed_column_prepare_refs_duration_ms,omitempty"`
 	TypedColumnPreparePairDurationMS       float64                           `json:"typed_column_prepare_pairing_duration_ms,omitempty"`
@@ -593,6 +595,7 @@ type columnStoreQueryExecution struct {
 	TypedColumnOneShotCacheMiss          bool
 	TypedColumnOneShotCacheBuild         bool
 	TypedColumnOneShotBuildDuration      time.Duration
+	TypedColumnPrepareWorkerCount        int
 	TypedColumnPreparePlanDuration       time.Duration
 	TypedColumnPrepareRefsDuration       time.Duration
 	TypedColumnPreparePairDuration       time.Duration
@@ -2057,6 +2060,7 @@ func runColumnStoreSuiteQueries(collection *collections.Collection, rows int, ra
 			SkippedGranules:                        exec.SkippedGranules,
 			ScheduledGranules:                      exec.ScheduledGranules,
 			WorkerCount:                            exec.WorkerCount,
+			TypedColumnPrepareWorkerCount:          exec.TypedColumnPrepareWorkerCount,
 			PlannerDurationMS:                      durationMS(plannerElapsed),
 			ScanDurationMS:                         durationMS(exec.ScanDuration),
 			ReduceDurationMS:                       durationMS(exec.ReduceDuration),
@@ -2536,6 +2540,7 @@ func executeColumnStoreSuitePhysicalQuery(collection *collections.Collection, qu
 		TypedColumnOneShotCacheMiss:          diag.TypedColumnOneShotCacheMiss,
 		TypedColumnOneShotCacheBuild:         diag.TypedColumnOneShotCacheBuild,
 		TypedColumnOneShotBuildDuration:      time.Duration(diag.TypedColumnOneShotBuildNanos),
+		TypedColumnPrepareWorkerCount:        diag.TypedColumnPrepareWorkerCount,
 		TypedColumnPreparePlanDuration:       time.Duration(diag.TypedColumnPreparePlanNanos),
 		TypedColumnPrepareRefsDuration:       time.Duration(diag.TypedColumnPrepareRefsNanos),
 		TypedColumnPreparePairDuration:       time.Duration(diag.TypedColumnPreparePairingNanos),
@@ -2664,6 +2669,7 @@ func executeColumnStoreSuitePreparedPhysicalQuery(collection *collections.Collec
 		WorkerCount:                          workers,
 		SegmentFileCacheHits:                 diag.SegmentFileCacheHits,
 		SegmentFileCacheMisses:               diag.SegmentFileCacheMisses,
+		TypedColumnPrepareWorkerCount:        setupDiagnostics.TypedColumnPrepareWorkerCount,
 		TypedColumnPreparePlanDuration:       time.Duration(setupDiagnostics.TypedColumnPreparePlanNanos),
 		TypedColumnPrepareRefsDuration:       time.Duration(setupDiagnostics.TypedColumnPrepareRefsNanos),
 		TypedColumnPreparePairDuration:       time.Duration(setupDiagnostics.TypedColumnPreparePairingNanos),
@@ -3111,6 +3117,7 @@ func columnStoreJSONBenchCellFromQueryMetric(q columnStoreQueryMetric, cfg *coll
 	cell.TypedColumnOneShotCacheMiss = q.TypedColumnOneShotCacheMiss
 	cell.TypedColumnOneShotCacheBuild = q.TypedColumnOneShotCacheBuild
 	cell.TypedColumnOneShotBuildDurationMS = q.TypedColumnOneShotBuildDurationMS
+	cell.TypedColumnPrepareWorkerCount = q.TypedColumnPrepareWorkerCount
 	cell.TypedColumnPreparePlanDurationMS = q.TypedColumnPreparePlanDurationMS
 	cell.TypedColumnPrepareRefsDurationMS = q.TypedColumnPrepareRefsDurationMS
 	cell.TypedColumnPreparePairDurationMS = q.TypedColumnPreparePairDurationMS
@@ -3250,6 +3257,7 @@ func columnStoreJSONBenchCellFromPreparedExecution(name string, rawHash uint64, 
 	cell.TypedColumnPrepareDenseValueDurationMS = durationMS(exec.TypedColumnPrepareDenseValueDuration)
 	cell.TypedColumnPrepareDensePredDurationMS = durationMS(exec.TypedColumnPrepareDensePredDuration)
 	cell.TypedColumnPrepareDensePreapplyMS = durationMS(exec.TypedColumnPrepareDensePreapply)
+	cell.TypedColumnPrepareWorkerCount = exec.TypedColumnPrepareWorkerCount
 	cell.MetadataHits = exec.MetadataHits
 	cell.RowsScanned = exec.RowsScanned
 	cell.RowsMatched = exec.RowsMatched
@@ -4692,8 +4700,8 @@ func renderColumnStoreQueryMetricsMarkdown(sb *strings.Builder, title string, qu
 		return
 	}
 	sb.WriteString("## " + title + "\n\n")
-	sb.WriteString("| query | query mode | metadata mode | plan | storage source | fallback | manifest root | active gen/checksum | rows/s | MiB/s | ns/row | prepare/setup ms | typed prep plan ms | typed prep refs ms | typed prep pair ms | typed prep decode ms | typed prep post ms | typed prep summary ms | one-shot cache store ms | run ms | render/hash ms | total query ms | planner ms | scan ms | reduce ms | adapter ms | parity hash ms | workers | scheduled granules | skipped granules | metadata hits | dictionary code hits | int64 value hits | B/read | decoded B | decoded payload B | decoded metadata B | mapped B | heap-copy B | rows scanned | projected cols | predicate count | typed cells visited | typed cells basis | rows materialized | docs materialized | aggregate metadata used | metadata cost B | metadata cost insert ms | metadata cost basis | sort/topk pruning | topk limit | topk candidates | topk order | json reconstruction | segment file cache hit/miss | hash parity | note |\n")
-	sb.WriteString("|---|---|---|---|---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|---:|---:|---|---:|---:|---|---|---:|---:|---|---|---|---|---|\n")
+	sb.WriteString("| query | query mode | metadata mode | plan | storage source | fallback | manifest root | active gen/checksum | rows/s | MiB/s | ns/row | prepare/setup ms | typed prep plan ms | typed prep refs ms | typed prep pair ms | typed prep decode ms | typed prep post ms | typed prep summary ms | one-shot cache store ms | run ms | render/hash ms | total query ms | planner ms | scan ms | reduce ms | adapter ms | parity hash ms | workers | typed prep workers | scheduled granules | skipped granules | metadata hits | dictionary code hits | int64 value hits | B/read | decoded B | decoded payload B | decoded metadata B | mapped B | heap-copy B | rows scanned | projected cols | predicate count | typed cells visited | typed cells basis | rows materialized | docs materialized | aggregate metadata used | metadata cost B | metadata cost insert ms | metadata cost basis | sort/topk pruning | topk limit | topk candidates | topk order | json reconstruction | segment file cache hit/miss | hash parity | note |\n")
+	sb.WriteString("|---|---|---|---|---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|---:|---:|---|---:|---:|---|---|---:|---:|---|---|---|---|---|---|\n")
 	for _, q := range queries {
 		parity := "pass"
 		if p, ok := parityByName[q.Name]; ok && !p.Pass {
@@ -4715,8 +4723,8 @@ func renderColumnStoreQueryMetricsMarkdown(sb *strings.Builder, title string, qu
 		if q.ManifestGeneration != 0 || q.ActiveManifestChecksum != 0 {
 			activeManifestCell = fmt.Sprintf("%d/%d", q.ManifestGeneration, q.ActiveManifestChecksum)
 		}
-		sb.WriteString(fmt.Sprintf("| %s | %s | %s | %s | %s | %s | %s | %s | %.3f | %.3f | %.1f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %s | %d | %d | %t | %d | %.3f | %s | %t | %d | %d | %s | %t | %d/%d | %s | %s |\n",
-			markdownCodeTableText(q.Name), markdownCodeTableText(q.QueryMode), markdownCodeTableText(q.MetadataMode), markdownCodeTableText(q.PlanLabel), markdownCodeTableText(q.StorageSource), markdownCodeTableText(q.FallbackReason), markdownCodeTableText(manifestRootCell), markdownCodeTableText(activeManifestCell), q.RowsPerSecond, q.MiBPerSecond, q.NsPerRow, q.PrepareSetupDurationMS, q.TypedColumnPreparePlanDurationMS, q.TypedColumnPrepareRefsDurationMS, q.TypedColumnPreparePairDurationMS, q.TypedColumnPrepareDecodeDurationMS, q.TypedColumnPreparePostDurationMS, q.TypedColumnPrepareSummaryDurationMS, q.TypedColumnOneShotCacheStoreDurationMS, q.RunDurationMS, q.RenderHashDurationMS, q.TotalQueryDurationMS, q.PlannerDurationMS, q.ScanDurationMS, q.ReduceDurationMS, q.AdapterDurationMS, q.ParityHashDurationMS, q.WorkerCount, q.ScheduledGranules, q.SkippedGranules, q.MetadataHits, q.DictionaryCodeHits, q.Int64ValueHits, q.BytesRead, q.DecodedBytes, q.DecodedPayloadBytes, q.DecodedMetadataBytes, q.MappedBytes, q.HeapCopyBytes, q.RowsScanned, q.ProjectedColumns, q.PredicateCount, q.TypedCellsVisited, markdownCodeTableText(q.TypedCellsVisitedBasis), q.RowMaterializations, q.DocumentMaterializations, q.AggregateMetadataUsed, q.MetadataCostStorageBytes, q.MetadataCostInsertMS, markdownCodeTableText(columnStoreMetadataCostBasisTableText(q.MetadataCostStorageBasis, q.MetadataCostInsertBasis)), q.SortTopKPruningUsed, q.TopKLimit, q.TopKCandidates, markdownCodeTableText(q.TopKOrder), q.JSONReconstruction, q.SegmentFileCacheHits, q.SegmentFileCacheMisses, parity, noteCell))
+		sb.WriteString(fmt.Sprintf("| %s | %s | %s | %s | %s | %s | %s | %s | %.3f | %.3f | %.1f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %s | %d | %d | %t | %d | %.3f | %s | %t | %d | %d | %s | %t | %d/%d | %s | %s |\n",
+			markdownCodeTableText(q.Name), markdownCodeTableText(q.QueryMode), markdownCodeTableText(q.MetadataMode), markdownCodeTableText(q.PlanLabel), markdownCodeTableText(q.StorageSource), markdownCodeTableText(q.FallbackReason), markdownCodeTableText(manifestRootCell), markdownCodeTableText(activeManifestCell), q.RowsPerSecond, q.MiBPerSecond, q.NsPerRow, q.PrepareSetupDurationMS, q.TypedColumnPreparePlanDurationMS, q.TypedColumnPrepareRefsDurationMS, q.TypedColumnPreparePairDurationMS, q.TypedColumnPrepareDecodeDurationMS, q.TypedColumnPreparePostDurationMS, q.TypedColumnPrepareSummaryDurationMS, q.TypedColumnOneShotCacheStoreDurationMS, q.RunDurationMS, q.RenderHashDurationMS, q.TotalQueryDurationMS, q.PlannerDurationMS, q.ScanDurationMS, q.ReduceDurationMS, q.AdapterDurationMS, q.ParityHashDurationMS, q.WorkerCount, q.TypedColumnPrepareWorkerCount, q.ScheduledGranules, q.SkippedGranules, q.MetadataHits, q.DictionaryCodeHits, q.Int64ValueHits, q.BytesRead, q.DecodedBytes, q.DecodedPayloadBytes, q.DecodedMetadataBytes, q.MappedBytes, q.HeapCopyBytes, q.RowsScanned, q.ProjectedColumns, q.PredicateCount, q.TypedCellsVisited, markdownCodeTableText(q.TypedCellsVisitedBasis), q.RowMaterializations, q.DocumentMaterializations, q.AggregateMetadataUsed, q.MetadataCostStorageBytes, q.MetadataCostInsertMS, markdownCodeTableText(columnStoreMetadataCostBasisTableText(q.MetadataCostStorageBasis, q.MetadataCostInsertBasis)), q.SortTopKPruningUsed, q.TopKLimit, q.TopKCandidates, markdownCodeTableText(q.TopKOrder), q.JSONReconstruction, q.SegmentFileCacheHits, q.SegmentFileCacheMisses, parity, noteCell))
 	}
 	sb.WriteString("\n")
 }
@@ -4810,19 +4818,20 @@ func renderColumnStoreTypedColumnSetupDiagnosticsMarkdown(sb *strings.Builder, r
 		return
 	}
 	sb.WriteString("## Typed Column Setup Diagnostics\n\n")
-	sb.WriteString("| cell | query | mode | query mode | metadata mode | prepare/setup ms | one-shot build ms | prep plan ms | prep refs ms | prep pair ms | prep decode ms | prep post ms | prep summary ms | cache store ms | read image ms | state build ms | dictionary ms | pruning ms | sort key ms | stats ms | range read ms | range read B | adapter ms | dense group ms | dense value ms | dense predicate ms | dense preapply ms |\n")
-	sb.WriteString("|---|---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|\n")
+	sb.WriteString("| cell | query | mode | query mode | metadata mode | prepare/setup ms | typed prep workers | one-shot build ms | prep plan ms | prep refs ms | prep pair ms | prep decode ms | prep post ms | prep summary ms | cache store ms | read image ms | state build ms | dictionary ms | pruning ms | sort key ms | stats ms | range read ms | range read B | adapter ms | dense group ms | dense value ms | dense predicate ms | dense preapply ms |\n")
+	sb.WriteString("|---|---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|\n")
 	for _, cell := range report.JSONBenchCells {
 		if !columnStoreJSONBenchCellHasTypedColumnSetupDiagnostics(cell) {
 			continue
 		}
-		sb.WriteString(fmt.Sprintf("| %s | %s | %s | %s | %s | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %d | %.3f | %.3f | %.3f | %.3f | %.3f |\n",
+		sb.WriteString(fmt.Sprintf("| %s | %s | %s | %s | %s | %.3f | %d | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %d | %.3f | %.3f | %.3f | %.3f | %.3f |\n",
 			markdownCodeTableText(cell.CellLabel),
 			markdownCodeTableText(cell.Query),
 			markdownCodeTableText(cell.ExecutionMode),
 			markdownCodeTableText(cell.QueryMode),
 			markdownCodeTableText(cell.MetadataMode),
 			cell.PrepareSetupDurationMS,
+			cell.TypedColumnPrepareWorkerCount,
 			cell.TypedColumnOneShotBuildDurationMS,
 			cell.TypedColumnPreparePlanDurationMS,
 			cell.TypedColumnPrepareRefsDurationMS,
@@ -4870,7 +4879,8 @@ func columnStoreJSONBenchCellHasTypedColumnSetupDiagnostics(cell columnStoreJSON
 		cell.TypedColumnPrepareDenseGroupDurationMS != 0 ||
 		cell.TypedColumnPrepareDenseValueDurationMS != 0 ||
 		cell.TypedColumnPrepareDensePredDurationMS != 0 ||
-		cell.TypedColumnPrepareDensePreapplyMS != 0
+		cell.TypedColumnPrepareDensePreapplyMS != 0 ||
+		cell.TypedColumnPrepareWorkerCount != 0
 }
 
 func renderColumnStoreColgranuleReuseMarkdown(sb *strings.Builder, report columnStoreSuiteReport) {


### PR DESCRIPTION
## Summary
- add `TypedColumnPrepareWorkerCount` to TreeDB column physical query diagnostics
- propagate the field into unified-bench JSON and markdown for one-shot and prepared query cells
- protect the q5 no-aggregate-metadata one-shot cache path with an assertion that first-miss setup reports prepare workers and cache-hit execution reports none

## Scope
This is evidence/reporting for the production-shape JSONBench work. It does not claim a query-speed improvement by itself, and it should not be used as evidence that TreeDB SQL is broadly faster than ClickHouse. The point is to separate scan worker count from typed-column physical preparation parallelism while investigating #3175/#3158/#3070.

## Validation
- `go test ./TreeDB/collections -run 'TestColumnPhysicalTypedColumnOneShotCacheQ5NoMetadata3088|TestColumnPhysicalTypedColumnParallelPartDecodeShapes3158|TestColumnPhysicalDenseTypedColumnTargetedRangeReads3090/q5_group_int64_span'`
- `go test ./cmd/unified_bench`
- JSONBench smoke with local gomap replace and JSONBench reporting branch: `/tmp/jsonbench_prepare_workers_q5_20260628_090721/report.json`
  - 100k rows, `column-store-full-prepared`, `q5`, `one_shot_end_to_end`, `no_aggregate_metadata`
  - total 18.156958ms, prepare/setup 10.811583ms, run 7.323292ms, render/hash 0.021750ms
  - `typed_column_prepare_worker_count=7`, `typed_column_prepare_part_decode_nanos=10279792`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visibility into typed-column preparation worker counts in query diagnostics and benchmark reports.
  * Expanded benchmark output to show a new “typed prep workers” value in query and setup tables.

* **Bug Fixes**
  * Improved diagnostic reporting so worker counts reflect actual execution behavior, including cache hits and parallel vs. sequential preparation paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->