### PR TITLE
TreeDB: widen leaf generation pack maintenance

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -2210,6 +2210,7 @@ const (
 	envEnableLeafGenerationPackMaintenance                     = "TREEDB_ENABLE_LEAF_GENERATION_PACK_MAINTENANCE"
 	envLeafGenerationPackMaintenanceMaxBytesToCopy             = "TREEDB_LEAF_GENERATION_PACK_MAINTENANCE_MAX_BYTES_TO_COPY"
 	envLeafGenerationPackMaintenanceMaxGenerations             = "TREEDB_LEAF_GENERATION_PACK_MAINTENANCE_MAX_GENERATIONS"
+	envLeafGenerationPackMaintenanceMinIntervalMillis          = "TREEDB_LEAF_GENERATION_PACK_MAINTENANCE_MIN_INTERVAL_MS"
 	envLeafGenerationPackMaintenanceMinPublishedAgeSeq         = "TREEDB_LEAF_GENERATION_PACK_MAINTENANCE_MIN_PUBLISHED_AGE_COMMITS"
 	envLeafGenerationPackMaintenanceMinCandidateGenerations    = "TREEDB_LEAF_GENERATION_PACK_MAINTENANCE_MIN_CANDIDATE_GENERATIONS"
 	envLeafGenerationPackMaintenanceTimeoutSeconds             = "TREEDB_LEAF_GENERATION_PACK_MAINTENANCE_TIMEOUT_SECONDS"
@@ -2237,7 +2238,8 @@ const (
 	envDisableCheckpointAutoVacuum                                 = "TREEDB_DISABLE_CHECKPOINT_AUTO_VACUUM"
 	minMemtablePrealloc                                            = 64 * 1024
 	leafGenerationPackMaintenanceDefaultMaxBytesToCopy             = 256 << 20
-	leafGenerationPackMaintenanceDefaultMaxGenerations             = 8
+	leafGenerationPackMaintenanceDefaultMaxGenerations             = 32
+	leafGenerationPackMaintenanceDefaultMinInterval                = 30 * time.Second
 	leafGenerationPackMaintenanceDefaultMinPublishedAgeSeq         = 1
 	leafGenerationPackMaintenanceDefaultMinCandidateGenerations    = 2
 	leafGenerationPackMaintenanceDefaultTimeout                    = 30 * time.Second
@@ -8995,11 +8997,10 @@ const (
 )
 
 const (
-	vlogGenerationLoopInterval               = 1 * time.Second
-	vlogGenerationGCEvery                    = 5
-	vlogGenerationGCMinBytes                 = int64(1 << 20)
-	vlogGenerationRewriteMinInterval         = 30 * time.Second
-	leafGenerationPackMaintenanceMinInterval = 30 * time.Second
+	vlogGenerationLoopInterval       = 1 * time.Second
+	vlogGenerationGCEvery            = 5
+	vlogGenerationGCMinBytes         = int64(1 << 20)
+	vlogGenerationRewriteMinInterval = 30 * time.Second
 	// Rewrite staging uses a two-pass confirm flow: the first pass stages a plan,
 	// then a later pass re-plans and executes only if a stable subset persists.
 	//
@@ -12085,6 +12086,22 @@ func leafGenerationPackMaintenanceWriteBurstGrace() time.Duration {
 
 func leafGenerationPackMaintenanceMaxForegroundQueue() int {
 	return int(loadUintEnvDefault(envLeafGenerationPackMaintenanceMaxForegroundQueue, leafGenerationPackMaintenanceDefaultMaxForegroundQueue))
+}
+
+func leafGenerationPackMaintenanceMaxGenerations() int {
+	maxGenerations := int(envUint64(envLeafGenerationPackMaintenanceMaxGenerations, leafGenerationPackMaintenanceDefaultMaxGenerations))
+	if maxGenerations <= 0 {
+		return leafGenerationPackMaintenanceDefaultMaxGenerations
+	}
+	return maxGenerations
+}
+
+func leafGenerationPackMaintenanceMinInterval() time.Duration {
+	intervalMS := envUint64(envLeafGenerationPackMaintenanceMinIntervalMillis, uint64(leafGenerationPackMaintenanceDefaultMinInterval/time.Millisecond))
+	if intervalMS == 0 {
+		return 0
+	}
+	return time.Duration(intervalMS) * time.Millisecond
 }
 
 func leafGenerationPackMaintenanceMinReclaimPerByteCopiedPPM() int {
@@ -27884,18 +27901,16 @@ func (db *DB) maybeRunLeafGenerationPackMaintenance(runGC bool, quiet bool, admi
 	}
 	gcRunner, _ := db.backend.(backendLeafGenerationGCRunner)
 	lastRunNS := db.vlogGenerationLeafPackLastUnixNano.Load()
+	minInterval := leafGenerationPackMaintenanceMinInterval()
 	if lastRunNS > 0 {
-		if since := time.Since(time.Unix(0, lastRunNS)); since >= 0 && since < leafGenerationPackMaintenanceMinInterval {
+		if since := time.Since(time.Unix(0, lastRunNS)); since >= 0 && since < minInterval {
 			db.vlogGenerationLeafPackSkipMinInterval.Add(1)
 			db.storeVlogGenerationLeafPackLastSkipReason("min_interval")
 			return false, false, nil
 		}
 	}
 
-	maxGenerations := int(envUint64(envLeafGenerationPackMaintenanceMaxGenerations, leafGenerationPackMaintenanceDefaultMaxGenerations))
-	if maxGenerations <= 0 {
-		maxGenerations = leafGenerationPackMaintenanceDefaultMaxGenerations
-	}
+	maxGenerations := leafGenerationPackMaintenanceMaxGenerations()
 	maxBytesToCopy := int64(envUint64(envLeafGenerationPackMaintenanceMaxBytesToCopy, leafGenerationPackMaintenanceDefaultMaxBytesToCopy))
 	if maxBytesToCopy <= 0 {
 		maxBytesToCopy = leafGenerationPackMaintenanceDefaultMaxBytesToCopy
@@ -29547,11 +29562,11 @@ func (db *DB) Stats() map[string]string {
 	stats["treedb.cache.vlog_generation.leaf_pack.selection.bytes_dead"] = fmt.Sprintf("%d", db.vlogGenerationLeafPackSelectionBytesDead.Load())
 	stats["treedb.cache.vlog_generation.leaf_pack.selection.generations"] = fmt.Sprintf("%d", db.vlogGenerationLeafPackSelectionGenerations.Load())
 	stats["treedb.cache.vlog_generation.leaf_pack.last_wall_ms"] = fmt.Sprintf("%.3f", float64(db.vlogGenerationLeafPackLastWallNanos.Load())/float64(time.Millisecond))
-	stats["treedb.cache.vlog_generation.leaf_pack.min_interval_ms"] = fmt.Sprintf("%d", leafGenerationPackMaintenanceMinInterval.Milliseconds())
+	stats["treedb.cache.vlog_generation.leaf_pack.min_interval_ms"] = fmt.Sprintf("%d", leafGenerationPackMaintenanceMinInterval().Milliseconds())
 	stats["treedb.cache.vlog_generation.leaf_pack.timeout_ms"] = fmt.Sprintf("%d", leafGenerationPackMaintenanceTimeout().Milliseconds())
 	stats["treedb.cache.vlog_generation.leaf_pack.write_burst_grace_ms"] = fmt.Sprintf("%d", leafGenerationPackMaintenanceWriteBurstGrace().Milliseconds())
 	stats["treedb.cache.vlog_generation.leaf_pack.max_foreground_queue"] = fmt.Sprintf("%d", leafGenerationPackMaintenanceMaxForegroundQueue())
-	stats["treedb.cache.vlog_generation.leaf_pack.max_generations"] = fmt.Sprintf("%d", int(envUint64(envLeafGenerationPackMaintenanceMaxGenerations, leafGenerationPackMaintenanceDefaultMaxGenerations)))
+	stats["treedb.cache.vlog_generation.leaf_pack.max_generations"] = fmt.Sprintf("%d", leafGenerationPackMaintenanceMaxGenerations())
 	stats["treedb.cache.vlog_generation.leaf_pack.max_bytes_to_copy"] = fmt.Sprintf("%d", int64(envUint64(envLeafGenerationPackMaintenanceMaxBytesToCopy, leafGenerationPackMaintenanceDefaultMaxBytesToCopy)))
 	stats["treedb.cache.vlog_generation.leaf_pack.min_candidate_generations"] = fmt.Sprintf("%d", loadPositiveIntEnvDefault(envLeafGenerationPackMaintenanceMinCandidateGenerations, leafGenerationPackMaintenanceDefaultMinCandidateGenerations))
 	stats["treedb.cache.vlog_generation.leaf_pack.min_reclaim_per_byte_copied_ppm"] = fmt.Sprintf("%d", leafGenerationPackMaintenanceMinReclaimPerByteCopiedPPM())

--- a/TreeDB/caching/vlog_generation_scheduler_test.go
+++ b/TreeDB/caching/vlog_generation_scheduler_test.go
@@ -2470,6 +2470,46 @@ func TestLeafGenerationPackMaintenance_SkipsWithinMinInterval(t *testing.T) {
 	}
 }
 
+func TestLeafGenerationPackMaintenance_ConfigurableMinInterval(t *testing.T) {
+	t.Setenv(envEnableLeafGenerationPackMaintenance, "1")
+	t.Setenv(envLeafGenerationPackMaintenanceMinIntervalMillis, "1")
+	backend, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open backend: %v", err)
+	}
+	recorder := &rewriteBudgetRecordingBackend{DB: backend, leafPackResp: leafPackWindowExhaustingStats(2, 1024, 4096)}
+	defer recorder.Close()
+	db := &DB{
+		backend:                    recorder,
+		indexOuterLeavesInValueLog: true,
+		valueLogGenerationPolicy:   uint8(backenddb.ValueLogGenerationHotWarmCold),
+		closeCh:                    make(chan struct{}),
+	}
+	db.checkpointCond = sync.NewCond(&db.checkpointMu)
+	attempted, ran, err := db.maybeRunLeafGenerationPackMaintenance(false, true, leafGenerationPackMaintenanceAdmission{allowed: true}, vlogGenerationMaintenanceOptions{skipCheckpoint: true})
+	if err != nil {
+		t.Fatalf("first maybeRunLeafGenerationPackMaintenance: %v", err)
+	}
+	if !attempted || !ran {
+		t.Fatalf("first attempted=%t ran=%t want true/true", attempted, ran)
+	}
+	time.Sleep(2 * time.Millisecond)
+	attempted, ran, err = db.maybeRunLeafGenerationPackMaintenance(false, true, leafGenerationPackMaintenanceAdmission{allowed: true}, vlogGenerationMaintenanceOptions{skipCheckpoint: true})
+	if err != nil {
+		t.Fatalf("second maybeRunLeafGenerationPackMaintenance: %v", err)
+	}
+	if !attempted || !ran {
+		t.Fatalf("second attempted=%t ran=%t want true/true with configured min interval", attempted, ran)
+	}
+	_, calls := recorder.recordedLeafPack()
+	if calls != 2 {
+		t.Fatalf("leaf pack calls=%d want 2 after configured min interval", calls)
+	}
+	if got := db.Stats()["treedb.cache.vlog_generation.leaf_pack.min_interval_ms"]; got != "1" {
+		t.Fatalf("min_interval_ms=%q want 1", got)
+	}
+}
+
 func TestVlogGenerationRewritePlanContext_BudgetsPeriodicFreshPlans(t *testing.T) {
 	prepareDirectSchedulerTest(t)
 	t.Setenv(envVlogGenerationPeriodicRewritePlanBudgetMillis, "25")

--- a/scripts/leafgen_cached_dwell_validate.sh
+++ b/scripts/leafgen_cached_dwell_validate.sh
@@ -11,7 +11,8 @@ DWELL_SECONDS=${LEAFGEN_DWELL_SECONDS:-180}
 SAMPLE_INTERVAL_SECONDS=${LEAFGEN_SAMPLE_INTERVAL_SECONDS:-15}
 PACK_ENABLED=${TREEDB_ENABLE_LEAF_GENERATION_PACK_MAINTENANCE:-1}
 PACK_MAX_BYTES=${TREEDB_LEAF_GENERATION_PACK_MAINTENANCE_MAX_BYTES_TO_COPY:-268435456}
-PACK_MAX_GENERATIONS=${TREEDB_LEAF_GENERATION_PACK_MAINTENANCE_MAX_GENERATIONS:-8}
+PACK_MAX_GENERATIONS=${TREEDB_LEAF_GENERATION_PACK_MAINTENANCE_MAX_GENERATIONS:-32}
+PACK_MIN_INTERVAL_MS=${TREEDB_LEAF_GENERATION_PACK_MAINTENANCE_MIN_INTERVAL_MS:-30000}
 PACK_MIN_AGE_COMMITS=${TREEDB_LEAF_GENERATION_PACK_MAINTENANCE_MIN_PUBLISHED_AGE_COMMITS:-1}
 
 mkdir -p "$OUT"
@@ -56,6 +57,7 @@ capture_sizes() {
   echo "pack_enabled=$PACK_ENABLED"
   echo "pack_max_bytes=$PACK_MAX_BYTES"
   echo "pack_max_generations=$PACK_MAX_GENERATIONS"
+  echo "pack_min_interval_ms=$PACK_MIN_INTERVAL_MS"
   echo "pack_min_age_commits=$PACK_MIN_AGE_COMMITS"
 } > "$OUT/run.txt"
 
@@ -336,6 +338,7 @@ EOF
 TREEDB_ENABLE_LEAF_GENERATION_PACK_MAINTENANCE="$PACK_ENABLED" \
 TREEDB_LEAF_GENERATION_PACK_MAINTENANCE_MAX_BYTES_TO_COPY="$PACK_MAX_BYTES" \
 TREEDB_LEAF_GENERATION_PACK_MAINTENANCE_MAX_GENERATIONS="$PACK_MAX_GENERATIONS" \
+TREEDB_LEAF_GENERATION_PACK_MAINTENANCE_MIN_INTERVAL_MS="$PACK_MIN_INTERVAL_MS" \
 TREEDB_LEAF_GENERATION_PACK_MAINTENANCE_MIN_PUBLISHED_AGE_COMMITS="$PACK_MIN_AGE_COMMITS" \
 GOWORK=off go run "$OUT/leafgen_cached_dwell.go" \
   -db "$DST" \
@@ -359,6 +362,7 @@ jq -n \
   --argjson pack_enabled "$PACK_ENABLED" \
   --argjson pack_max_bytes "$PACK_MAX_BYTES" \
   --argjson pack_max_generations "$PACK_MAX_GENERATIONS" \
+  --argjson pack_min_interval_ms "$PACK_MIN_INTERVAL_MS" \
   --argjson pack_min_age_commits "$PACK_MIN_AGE_COMMITS" \
   --slurpfile before "$OUT/size-before.json" \
   --slurpfile after_dwell "$OUT/size-after-dwell.json" \
@@ -377,6 +381,7 @@ jq -n \
       enabled: ($pack_enabled != 0),
       max_bytes_to_copy: $pack_max_bytes,
       max_generations: $pack_max_generations,
+      min_interval_ms: $pack_min_interval_ms,
       min_published_age_commits: $pack_min_age_commits
     },
     sizes: {


### PR DESCRIPTION
## Objective

Reduce TreeDB/Celestia native-IAVL disk high-water caused by leaf-vlog maintenance lag by widening the default leaf-generation pack window and making the maintenance cooldown harness-tunable.

Closes #3227 after final review/merge.

## Context

The saved pre-change native-IAVL run showed TreeDB was faster and lower RSS/HWM than matched goleveldb, but final app DB size was larger. Final disk ownership pointed at leaf-vlog maintenance lag, not persistent value-log payload growth:

| Pre-change evidence | Value |
| --- | ---: |
| TreeDB final app DB bytes | `3,471,830,603` |
| TreeDB final `leaf_vlog` bytes | `3,238,437,971` |
| TreeDB final `value_vlog` bytes | `149,225,650` |
| Leaf-pack GC deleted bytes | `1,107,186,966` |
| Leaf-pack GC deleted files | `61` |
| Remaining leafgen-plan expected reclaim | `1,090,359,447` |

The old default selected only 8 generations per pass. Replaying the saved plan under the unchanged 256 MiB copy budget showed the generation cap, not copy bytes, was the next limiter:

| Max generations | Selected | Expected reclaim | Bytes to copy |
| ---: | ---: | ---: | ---: |
| 8 | 8 | `223,972,170` | `44,450,378` |
| 16 | 16 | `426,305,654` | `110,528,228` |
| 32 | 32 | `739,022,972` | `268,414,058` |

## Design

- Raise `leafGenerationPackMaintenanceDefaultMaxGenerations` from `8` to `32` while keeping the default max copy budget at `256 MiB`.
- Add `TREEDB_LEAF_GENERATION_PACK_MAINTENANCE_MIN_INTERVAL_MS` so Celestia/dwell validation can tune cooldown without code changes.
- Report the effective max generations and min interval through existing `Stats()` counters.
- Align `scripts/leafgen_cached_dwell_validate.sh` with the new default and include min-interval metadata.

## Scope

Includes: `TreeDB/caching/db.go`, `TreeDB/caching/vlog_generation_scheduler_test.go`, `scripts/leafgen_cached_dwell_validate.sh`.

Excludes: value-log GC reachability, on-disk formats, command-WAL recovery, root-span-native, IAVL importer behavior.

## Correctness

Local tests run:

```sh
bash -n scripts/leafgen_cached_dwell_validate.sh
GOWORK=off go test ./TreeDB/caching -run 'TestLeafGenerationPackMaintenance|TestVlogGenerationMaintenance_PeriodicPassRunsLeafPack|TestVlogGenerationMaintenance_PeriodicLeafPackDoesNotBlockOnScheduledRetainedPruneQuietWait'
GOWORK=off go test ./TreeDB/caching ./TreeDB/db ./TreeDB/cmd/treemap
git diff --check
```

Results:

- `TreeDB/caching`: passed
- `TreeDB/db`: passed in `280.057s`
- `TreeDB/cmd/treemap`: passed
- `bash -n`: passed
- `git diff --check`: clean
- Latest-head CI on PR head `2a675bb4221564aae0d4cba0ffd1e43a06ecc266`: green, including Format, Root, TreeDB, HashDB, read-snapshot guardrail, unified_bench gates/tests, redis protocol bench, and CodeRabbit status.

## Celestia Validation

### TreeDB candidate run

Run home: `/home/mikers/.celestia-app-mainnet-treedb-20260628095053`

Protocol:

- wrapper: `/home/mikers/run_celestia.sh`
- `LOCAL_GOMAP_DIR=/home/mikers/dev/snissn/gomap-3227-vlog-disk`
- `DB_BACKEND=treedb APP_DB_BACKEND=treedb`
- trust height/hash: `11714074` / `AC2679168CE4DCFA9AA7355E52A265A2CA6250C9A9392B3EF3BFACA284B5104E`
- `STOP_AT_LOCAL_HEIGHT=11715650`
- `POST_SYNC_DWELL_SECONDS=300`
- `BOOTSTRAP_FETCH_MODE=remote_first BOOTSTRAP_FALLBACK_MODE=config_only`
- accepted snapshot: `11729000`

Results:

| Metric | Value |
| --- | ---: |
| Sync duration | `299s` |
| Total duration | `600s` |
| Dwell elapsed | `301s` |
| Final local/remote | `11729014` / `11729770` |
| Max RSS / HWM | `9,370,024 KiB` / `9,486,196 KiB` |
| Final app DB bytes, post-shutdown `du` | `2,335,331,418` |
| `leaf_vlog` bytes | `2,114,887,149` |
| `value_vlog` bytes | `148,896,473` |
| `index.db` bytes | `71,303,168` |
| Targeted TreeDB error scan | `0` matches |

Leaf-pack counters at final dwell sample:

| Counter | Value |
| --- | ---: |
| `leaf_pack.max_generations` | `32` |
| `leaf_pack.runs` | `2` |
| `leaf_pack.selection.generations` | `63` |
| `leaf_pack.selection.bytes_dead` | `1,709,855,802` |
| `leaf_pack.selection.bytes_to_copy` | `303,782,142` |
| `leaf_pack.gc.deleted_bytes` | `2,047,173,127` |
| `leaf_pack.gc.deleted_files` | `74` |

Post-run `leafgen-plan` reports `Admission=reclaim_per_copy_too_low`, `ExpectedReclaimBytes=14,360,265`, and `ExpectedReclaimPerByteCopiedPPM=7,934`, so the remaining backlog is low-yield rather than the prior high-yield maintenance debt.

### Current goleveldb comparator run

Run home: `/home/mikers/.celestia-app-mainnet-goleveldb-20260628100245`

Same trust/target/dwell protocol; accepted snapshot was `11728500`.

| Metric | TreeDB candidate | goleveldb comparator | TreeDB delta |
| --- | ---: | ---: | ---: |
| Sync duration | `299s` | `766s` | `2.56x` faster |
| Max RSS | `9,370,024 KiB` | `11,203,004 KiB` | `16.36%` lower |
| Max HWM | `9,486,196 KiB` | `11,334,196 KiB` | `16.30%` lower |
| Final app DB bytes, post-shutdown `du` | `2,335,331,418` | `3,016,275,507` | `22.58%` smaller |
| Final local height | `11729014` | `11728539` | TreeDB `+475` blocks |

A/B caveats:

- The settings were the same, but live state-sync accepted different snapshots: TreeDB `11729000`, goleveldb `11728500`. TreeDB ended at the higher local height and still had lower disk/RSS and faster sync.
- The goleveldb run produced a shutdown-time comparator panic after the harness stopped the node: `snapshot failed; exporter error err="iavl export failed for version 11730000: leveldb: closed"`, followed by `panic: leveldb: closed`. TreeDB’s targeted scan was clean. The goleveldb metrics are still useful for size/time context, but the comparator log scan is not clean.

### Improvement versus pre-change TreeDB

| Metric | Pre-change TreeDB | Candidate TreeDB | Delta |
| --- | ---: | ---: | ---: |
| Final app DB bytes | `3,471,830,603` | `2,335,331,418` | `32.73%` lower |
| Final `leaf_vlog` bytes | `3,238,437,971` | `2,114,887,149` | `34.69%` lower |
| Leaf-pack GC deleted bytes | `1,107,186,966` | `2,047,173,127` | `+939,986,161` |

## Rollout / Toggle Plan

- Default setting: leaf-pack maintenance remains opt-in via `TREEDB_ENABLE_LEAF_GENERATION_PACK_MAINTENANCE`; when enabled, default max generations is now `32`.
- To reduce the window: set `TREEDB_LEAF_GENERATION_PACK_MAINTENANCE_MAX_GENERATIONS=8` or lower.
- To slow cadence: set `TREEDB_LEAF_GENERATION_PACK_MAINTENANCE_MIN_INTERVAL_MS=30000` or higher.
- To disable the maintenance path: set `TREEDB_ENABLE_LEAF_GENERATION_PACK_MAINTENANCE=0`.

## Follow-ups

- Continue root-span-native/IAVL importer work separately.
- Track the goleveldb shutdown snapshot panic as comparator/harness hygiene if it keeps contaminating strict A/B log scans.
