### PR TITLE
Reduce q5 typed-column setup work

### DIFF
--- a/TreeDB/collections/column_physical_q5_dense_1950_test.go
+++ b/TreeDB/collections/column_physical_q5_dense_1950_test.go
@@ -2,6 +2,7 @@ package collections
 
 import (
 	"fmt"
+	"slices"
 	"sort"
 	"testing"
 )
@@ -59,6 +60,36 @@ func TestColumnPhysicalQ5DenseTypedColumnDirectPreparedParity1950(t *testing.T) 
 	}
 	if !noPredicate.Diagnostics.DenseInt64SpanUsed || noPredicate.Diagnostics.DenseInt64SpanReducer != columnTypedColumnDenseInt64SpanReducerLocalMap || noPredicate.Diagnostics.RowsScanned != len(events) || noPredicate.Diagnostics.RowsMatched != 0 || noPredicate.Diagnostics.ReduceRows != len(events) {
 		t.Fatalf("no-predicate diagnostics=%+v want dense span with RowsMatched=0 and ReduceRows=%d", noPredicate.Diagnostics, len(events))
+	}
+}
+
+func TestColumnTypedColumnDenseInt64SpanSingleCodeTriplePreapply3175(t *testing.T) {
+	dense := &columnTypedColumnDenseInt64SpanPart{
+		Predicates: []columnTypedColumnDensePredicatePart{
+			{
+				Codes:             []uint32{1, 1, 2, 1, 1, 1},
+				Valid:             []bool{true, true, true, true, false, true},
+				SingleCode:        1,
+				SingleCodeAllowed: true,
+			},
+			{
+				Codes:             []uint32{2, 2, 2, 2, 2, 3},
+				Valid:             []bool{true, true, false, true, true, true},
+				SingleCode:        2,
+				SingleCodeAllowed: true,
+			},
+			{
+				Codes:             []uint32{3, 4, 3, 3, 3, 3},
+				SingleCode:        3,
+				SingleCodeAllowed: true,
+			},
+		},
+	}
+	if !preapplyColumnTypedColumnDenseInt64SpanSingleCodeTriplePredicates(dense, 6) {
+		t.Fatal("single-code triple preapply did not handle q5-shaped predicates")
+	}
+	if want := []uint32{0, 3}; !slices.Equal(dense.PredicateRows, want) {
+		t.Fatalf("predicate rows=%v want %v", dense.PredicateRows, want)
 	}
 }
 

--- a/TreeDB/collections/typed_column_adapter.go
+++ b/TreeDB/collections/typed_column_adapter.go
@@ -2217,6 +2217,9 @@ func preapplyColumnTypedColumnDenseInt64SpanPredicates(dense *columnTypedColumnD
 	if columnTypedColumnDensePredicatesRejectAll(dense.Predicates) {
 		return
 	}
+	if preapplyColumnTypedColumnDenseInt64SpanSingleCodeTriplePredicates(dense, rows) {
+		return
+	}
 	selected := make([]uint32, 0, min(rows, 4096))
 	for rowIdx := 0; rowIdx < rows; rowIdx++ {
 		if columnTypedColumnDensePredicatesMatch(dense.Predicates, rowIdx) {
@@ -2224,6 +2227,46 @@ func preapplyColumnTypedColumnDenseInt64SpanPredicates(dense *columnTypedColumnD
 		}
 	}
 	dense.PredicateRows = selected
+}
+
+func preapplyColumnTypedColumnDenseInt64SpanSingleCodeTriplePredicates(dense *columnTypedColumnDenseInt64SpanPart, rows int) bool {
+	if dense == nil || len(dense.Predicates) != 3 {
+		return false
+	}
+	left := &dense.Predicates[0]
+	mid := &dense.Predicates[1]
+	right := &dense.Predicates[2]
+	if !columnTypedColumnDensePredicateCanUseSingleCodePreapply(left, rows) ||
+		!columnTypedColumnDensePredicateCanUseSingleCodePreapply(mid, rows) ||
+		!columnTypedColumnDensePredicateCanUseSingleCodePreapply(right, rows) {
+		return false
+	}
+	leftCode := left.SingleCode
+	midCode := mid.SingleCode
+	rightCode := right.SingleCode
+	leftValid := left.Valid
+	midValid := mid.Valid
+	rightValid := right.Valid
+	selected := make([]uint32, 0, min(rows, 4096))
+	for rowIdx := 0; rowIdx < rows; rowIdx++ {
+		if (leftValid == nil || leftValid[rowIdx]) &&
+			(midValid == nil || midValid[rowIdx]) &&
+			(rightValid == nil || rightValid[rowIdx]) &&
+			left.Codes[rowIdx] == leftCode &&
+			mid.Codes[rowIdx] == midCode &&
+			right.Codes[rowIdx] == rightCode {
+			selected = append(selected, uint32(rowIdx))
+		}
+	}
+	dense.PredicateRows = selected
+	return true
+}
+
+func columnTypedColumnDensePredicateCanUseSingleCodePreapply(predicate *columnTypedColumnDensePredicatePart, rows int) bool {
+	if predicate == nil || predicate.RejectsAll || !predicate.SingleCodeAllowed || predicate.MissingMatchesEmpty {
+		return false
+	}
+	return rows >= 0 && len(predicate.Codes) >= rows && (predicate.Valid == nil || len(predicate.Valid) >= rows)
 }
 
 func densePredicateFromDictionaryCodes(codes []uint32, valid []bool, dictionary []string, dictionaryByCode map[int64]string, cardinality int, spec columnPhysicalQueryPredicateSpec) (columnTypedColumnDensePredicatePart, error) {

--- a/TreeDB/collections/typed_column_prepared_state.go
+++ b/TreeDB/collections/typed_column_prepared_state.go
@@ -1064,6 +1064,13 @@ func typedColumnAttachPreparedDictionaries(part *typedColumnPreparedPartState, i
 	if err != nil {
 		return diag, err
 	}
+	type preparedDictionaryAttachRequest struct {
+		adapterColumn typedColumnAdapterColumn
+		column        *typedColumnPreparedColumnState
+		mode          typedColumnPreparedDictionaryRequestMode
+	}
+	attachRequests := make([]preparedDictionaryAttachRequest, 0, len(requests))
+	metadataColumns := make([]typedColumnAdapterColumn, 0, len(requests))
 	for _, request := range requests {
 		if !request.IncludeDictionaries {
 			continue
@@ -1076,10 +1083,20 @@ func typedColumnAttachPreparedDictionaries(part *typedColumnPreparedPartState, i
 		if column == nil {
 			return diag, fmt.Errorf("collections: typed-column prepared dictionaries missing column %q", adapterColumn.Definition.Name)
 		}
-		if err := validateTypedColumnAdapterMetadata(decoded.Forward, []typedColumnAdapterColumn{adapterColumn}); err != nil {
-			return diag, err
-		}
-		mode := requestedModes[adapterColumn.Definition.Name]
+		metadataColumns = append(metadataColumns, adapterColumn)
+		attachRequests = append(attachRequests, preparedDictionaryAttachRequest{
+			adapterColumn: adapterColumn,
+			column:        column,
+			mode:          requestedModes[adapterColumn.Definition.Name],
+		})
+	}
+	if err := validateTypedColumnAdapterMetadata(decoded.Forward, metadataColumns); err != nil {
+		return diag, err
+	}
+	for _, attach := range attachRequests {
+		adapterColumn := attach.adapterColumn
+		column := attach.column
+		mode := attach.mode
 		if mode.Forward {
 			dict, ok := decoded.Forward[adapterColumn.Definition.Name]
 			if !ok {


### PR DESCRIPTION
## Summary

- add a q5-shaped fast path for dense int64-span predicate preapply when the three predicates are single-code equality checks, including nullable columns whose missing values do not match
- validate typed-column dictionary metadata once per prepared dictionary attach instead of once per requested dictionary column
- add targeted coverage for the nullable single-code triple preapply helper

## Scope

This is a narrow `q5` / `one_shot_end_to_end` / `no_aggregate_metadata` setup reduction. It is not an aggregate-metadata win, not a hot-prepared headline, and not a broad SQL superiority claim.

Refs #3175.
Refs #3070.

## Validation

```sh
GOWORK=off go test ./TreeDB/collections -run 'TestColumnTypedColumnDenseInt64SpanSingleCodeTriplePreapply3175|TestColumnPhysicalTypedColumnOneShotCacheQ5NoMetadata3088|TestColumnPhysicalQ5DenseTypedColumnDirectPreparedParity1950|TestColumnPhysicalDenseTypedColumnTargetedRangeReads3090/q5_group_int64_span|TestTypedColumnPreparedDictionarySelectiveDenseDecode3175|TestTypedColumnPreparedDictionaryReverseOnlyDenseDecode3175|TestTypedColumnPreparedDictionaryRequestNamesIncludeMetadata3175'
GOWORK=off go test ./TreeDB/collections
GOWORK=off go test ./cmd/unified_bench
git diff --check
```

## Evidence

Compared against current main `de7536f0bc7fdf37ef4479fc5589a15f432c83d0`, using JSONBench 1M Bluesky q5 only:

- layout: `column-store-full-prepared`
- query mode: `one_shot_end_to_end`
- metadata mode: `no_aggregate_metadata`
- projection: `full`
- tries: `1`
- local gomap replace for baseline/candidate

Artifacts:

- baseline: `/tmp/jsonbench_q5_preapply_baseline_20260628_100515/report.json`
- baseline rerun: `/tmp/jsonbench_q5_preapply_baseline2_20260628_100832/report.json`
- candidate: `/tmp/jsonbench_q5_preapply_valid_candidate_20260628_100737/report.json`
- candidate rerun: `/tmp/jsonbench_q5_preapply_candidate2_20260628_100905/report.json`

| run | total | setup | run | typed part decode | dense preapply | dense predicate | dictionary |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| baseline | 52.300ms | 38.419ms | 13.826ms | 38.391ms | 10.865ms | 87.457ms | 113.508ms |
| baseline rerun | 42.914ms | 28.362ms | 14.521ms | 28.340ms | 10.312ms | 63.689ms | 93.782ms |
| candidate | 42.523ms | 27.766ms | 14.727ms | 27.734ms | 5.982ms | 69.689ms | 88.676ms |
| candidate rerun | 49.721ms | 28.666ms | 21.012ms | 28.646ms | 6.449ms | 75.737ms | 87.391ms |

All rows scanned/matched/reduced and TopK candidate counts matched across runs: `1,000,000` scanned, `86,812` matched/reduced, `50,464` TopK candidates. The clearest improvement is the intended setup subphase: dense preapply is consistently lower, while total q5 remains noisy because run time varied in the second candidate run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved handling of dense column filtering for a specific three-condition pattern, enabling faster row precomputation in matching cases.

* **Bug Fixes**
  * Tightened dictionary attachment validation so column metadata is checked consistently before applying prepared dictionaries, reducing the chance of inconsistent column setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->