### PR TITLE
[codex] Bound leaf generation scan cache offsets

### DIFF
--- a/TreeDB/db/leaf_generation_plan.go
+++ b/TreeDB/db/leaf_generation_plan.go
@@ -599,7 +599,7 @@ type leafGenerationGroupedFrameInfo struct {
 	recordLen uint32
 	k         int
 	rawLen    uint32
-	offsets   [valuelog.MaxFrameK + 1]uint32
+	offsets   []uint32
 }
 
 type leafGenerationGroupedFrameScanCache struct {
@@ -673,6 +673,9 @@ func (info leafGenerationGroupedFrameInfo) liveByteContribution(subIndex uint16)
 			contribution = 1
 		}
 		return contribution, true
+	}
+	if idx+1 >= len(info.offsets) {
+		return 0, false
 	}
 	startRaw := info.offsets[idx]
 	endRaw := info.offsets[idx+1]
@@ -752,7 +755,11 @@ func (db *DB) leafGenerationGroupedFrameInfo(scan *leafGenerationScanContext, pt
 		return leafGenerationGroupedFrameInfo{}, false, err
 	}
 
-	info := leafGenerationGroupedFrameInfo{recordLen: physicalLen, k: k}
+	info := leafGenerationGroupedFrameInfo{
+		recordLen: physicalLen,
+		k:         k,
+		offsets:   make([]uint32, k+1),
+	}
 	ridOff := valuelog.FrameHeaderSize
 	for i := 0; i < k; i++ {
 		if binary.LittleEndian.Uint64(prefix[ridOff:ridOff+8]) == 0 {

--- a/TreeDB/db/leaf_generation_plan_test.go
+++ b/TreeDB/db/leaf_generation_plan_test.go
@@ -186,7 +186,7 @@ func TestCompareDeadPerLive_ClampsNegativeInputs(t *testing.T) {
 }
 
 func TestLeafGenerationGroupedFrameInfo_LiveByteContributionKeepsSparseRefsNonZero(t *testing.T) {
-	info := leafGenerationGroupedFrameInfo{recordLen: 2, k: 4, rawLen: 4096}
+	info := leafGenerationGroupedFrameInfo{recordLen: 2, k: 4, rawLen: 4096, offsets: make([]uint32, 5)}
 	for i := 0; i <= info.k; i++ {
 		info.offsets[i] = uint32(i * 1024)
 	}

--- a/TreeDB/db/leaf_generation_plan_test.go
+++ b/TreeDB/db/leaf_generation_plan_test.go
@@ -201,6 +201,13 @@ func TestLeafGenerationGroupedFrameInfo_LiveByteContributionKeepsSparseRefsNonZe
 	}
 }
 
+func TestLeafGenerationGroupedFrameInfo_LiveByteContributionRejectsShortOffsets(t *testing.T) {
+	info := leafGenerationGroupedFrameInfo{recordLen: 2, k: 4, rawLen: 4096, offsets: make([]uint32, 4)}
+	if got, ok := info.liveByteContribution(3); ok || got != 0 {
+		t.Fatalf("liveByteContribution(3)=(%d,%t), want (0,false)", got, ok)
+	}
+}
+
 func TestLeafGenerationGroupedFrameScanCache_BoundsEntries(t *testing.T) {
 	cache := newLeafGenerationGroupedFrameScanCache(2)
 	first := groupedRecordKey{fileID: 1, start: 100}


### PR DESCRIPTION
## Summary

This narrows a residual TreeDB memory bucket from #3131 by changing the leaf-generation grouped-frame scan cache to retain only the offsets present in each grouped frame instead of embedding a fixed `[MaxFrameK+1]uint32` array in every cached info value.

The live-byte accounting remains the same: grouped frames still validate `k`, read `k+1` offsets, and compute per-subrecord live-byte contribution from adjacent offsets. The change adds a bounds guard for the exact-length offset slice.

Refs #3131
Refs #3127

## Why

The strict post-#3228 Celestia native A/B showed the old command-WAL/raw-KV batch payload blocker was retired, but the remaining TreeDB-owned heap included:

- `leafGenerationGroupedFrameScanCache.store=125.65MB`
- `valuelog.getWriterAppendBuf=80.03MB`
- `leafPageReadCacheSlot.storeLockedWithRecordChecksumState=55.72MB`
- `commitlog.(*Writer).reserveCommandBufferSpace=49.62MB`

The scan cache is bounded by entry count, but its value type carried max-frame offset storage even when each frame uses a much smaller `k`.

## Validation

Focused tests:

```sh
GOWORK=off go test ./TreeDB/db ./TreeDB/internal/valuelog -run 'TestLeafGenerationGroupedFrame|TestLeafGenerationPlan|TestLeafGenerationRecordLengthForPlan|TestLeafGenerationLiveStats|TestGroupedFrame|TestValueLogGrouped|TestManagerReadUnsafeAppendBatch_Grouped' -count=1
```

Full affected packages:

```sh
GOWORK=off go test ./TreeDB/db ./TreeDB/internal/valuelog
```

Celestia production-profile check, same snapshot as the prior TreeDB baseline:

- gomap branch: `codex/3131-leafgen-scan-cache-offsets`
- commit: `aba0d5d96`
- run home: `/home/mikers/.celestia-app-mainnet-treedb-20260628111908`
- accepted snapshot: `11730000`
- targeted error scan: clean for corruption, state-sync failure, snapshot restore failure, IAVL import/commit failure, panic, and fatal error

Comparison to the immediately prior post-#3228 TreeDB baseline (`/home/mikers/.celestia-app-mainnet-treedb-20260628105614`), same accepted snapshot `11730000`:

| Metric | Baseline TreeDB | This PR | Delta |
| --- | ---: | ---: | ---: |
| Sync seconds | 260 | 271 | +4.2% |
| Total seconds incl dwell | 561 | 572 | +2.0% |
| App DB bytes | 2,281,608,334 | 2,300,477,966 | +0.8% |
| App DB `du` bytes | 2,281,608,346 | 2,300,855,481 | +0.8% |
| Max RSS KiB | 9,296,616 | 8,714,560 | -6.3% |
| Max HWM KiB | 9,320,540 | 9,052,796 | -2.9% |
| Final smaps total RSS KiB | 8,300,304 | 7,920,500 | -4.6% |
| TreeDB summary RSS bytes | 8,499,515,392 | 8,114,589,696 | -4.5% |
| TreeDB summary heap_inuse bytes | 6,692,896,768 | 4,556,062,720 | -31.9% |
| Final pprof total | 3,345.19 MB | 3,483.68 MB | +4.1% |
| `leafGenerationGroupedFrameScanCache.store` final heap | 125.65 MB | not listed | eliminated from top profile |

Caveat: the fixture microbenchmark did not move B/op (`~4.20MB/op`, `197 allocs/op` before and after), so the benchmark does not exercise the targeted grouped-frame retention path strongly enough to be success evidence. The real signal is the same-snapshot Celestia final pprof and RSS/smaps movement.

## Residual risk

This is not a full #3131 closeout. The patched Celestia run still has TreeDB-owned heap buckets worth tracking, especially:

- `memtable.getAppendOnlyEntries=217.22MB`
- `valuelog.getWriterAppendBuf=80.03MB`
- `leafPageReadCacheSlot.storeLockedWithRecordChecksumState=72.78MB`
- `valuelog.getDecodeScratch=52.05MB`
- `commitlog.(*Writer).reserveCommandBufferSpace=49.05MB`

The largest absolute heap owners remain shared IAVL/root restore allocations, tracked separately in #3164/#3132.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of grouped frame byte contribution calculations to avoid out-of-range access in edge cases.
  * Made grouped frame offset tracking more robust by using a dynamically sized buffer based on the data being read.
  * Updated related test coverage to reflect the new offset handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->