### PR TITLE
Reuse typed-column row order for metadata publish

### DIFF
--- a/TreeDB/collections/column_aggregate_metadata_asset.go
+++ b/TreeDB/collections/column_aggregate_metadata_asset.go
@@ -304,7 +304,15 @@ func buildColumnAggregateMetadataAsset(cfg ColumnStoreConfig, rows []columnDecla
 	return spec.asset(cfg.SchemaHash, collection, namespace, generation, partID, appliedLSN, len(metadataRows), entries), true, nil
 }
 
+type columnAggregateMetadataAssetBuildOptions struct {
+	TypedGranuleRowOrder []int
+}
+
 func buildColumnAggregateMetadataAssets(cfg ColumnStoreConfig, rows []columnDeclaredRow, aggregates []ColumnAggregateMetadata, collection, namespace string, generation, partID, appliedLSN uint64) ([]columnAggregateMetadataAsset, error) {
+	return buildColumnAggregateMetadataAssetsWithOptions(cfg, rows, aggregates, collection, namespace, generation, partID, appliedLSN, columnAggregateMetadataAssetBuildOptions{})
+}
+
+func buildColumnAggregateMetadataAssetsWithOptions(cfg ColumnStoreConfig, rows []columnDeclaredRow, aggregates []ColumnAggregateMetadata, collection, namespace string, generation, partID, appliedLSN uint64, opts columnAggregateMetadataAssetBuildOptions) ([]columnAggregateMetadataAsset, error) {
 	if len(aggregates) == 0 {
 		return nil, nil
 	}
@@ -330,17 +338,31 @@ func buildColumnAggregateMetadataAssets(cfg ColumnStoreConfig, rows []columnDecl
 	}
 	rowsPerMetadataEntrySet := len(rows)
 	metadataRows := rows
+	var typedGranuleRowOrder []int
 	if usesTypedGranules {
-		var err error
-		metadataRows, err = columnAggregateMetadataRowsForTypedColumnGranules(cfg, aggregates[0], rows)
-		if err != nil {
-			return nil, fmt.Errorf("collections: aggregate metadata %q typed-column granule rows: %w", aggregates[0].Name, err)
+		if len(opts.TypedGranuleRowOrder) != 0 {
+			if err := validateColumnAggregateMetadataTypedGranuleRowOrder(opts.TypedGranuleRowOrder, len(rows)); err != nil {
+				return nil, fmt.Errorf("collections: aggregate metadata %q typed-column granule row order: %w", aggregates[0].Name, err)
+			}
+			typedGranuleRowOrder = opts.TypedGranuleRowOrder
+		} else {
+			var err error
+			metadataRows, err = columnAggregateMetadataRowsForTypedColumnGranules(cfg, aggregates[0], rows)
+			if err != nil {
+				return nil, fmt.Errorf("collections: aggregate metadata %q typed-column granule rows: %w", aggregates[0].Name, err)
+			}
 		}
 		rowsPerMetadataEntrySet = typedColumnDefaultRowsPerGranule()
 	} else if rowsPerMetadataEntrySet == 0 {
 		rowsPerMetadataEntrySet = typedColumnDefaultRowsPerGranule()
 	}
-	entriesBySpec, err := buildColumnAggregateMetadataEntriesForSpecs(specs, metadataRows, rowsPerMetadataEntrySet)
+	var entriesBySpec [][]columnAggregateMetadataEntry
+	var err error
+	if typedGranuleRowOrder != nil {
+		entriesBySpec, err = buildColumnAggregateMetadataEntriesForSpecsByRowOrder(specs, rows, typedGranuleRowOrder, rowsPerMetadataEntrySet)
+	} else {
+		entriesBySpec, err = buildColumnAggregateMetadataEntriesForSpecs(specs, metadataRows, rowsPerMetadataEntrySet)
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -349,6 +371,23 @@ func buildColumnAggregateMetadataAssets(cfg ColumnStoreConfig, rows []columnDecl
 		assets = append(assets, specs[idx].asset(cfg.SchemaHash, collection, namespace, generation, partID, appliedLSN, len(metadataRows), entries))
 	}
 	return assets, nil
+}
+
+func validateColumnAggregateMetadataTypedGranuleRowOrder(order []int, rows int) error {
+	if len(order) != rows {
+		return fmt.Errorf("order rows=%d want %d", len(order), rows)
+	}
+	seen := make([]bool, rows)
+	for partRow, rowIdx := range order {
+		if rowIdx < 0 || rowIdx >= rows {
+			return fmt.Errorf("order[%d]=%d outside rows=%d", partRow, rowIdx, rows)
+		}
+		if seen[rowIdx] {
+			return fmt.Errorf("duplicate source row=%d", rowIdx)
+		}
+		seen[rowIdx] = true
+	}
+	return nil
 }
 
 func buildColumnAggregateMetadataAssetsSequential(cfg ColumnStoreConfig, rows []columnDeclaredRow, aggregates []ColumnAggregateMetadata, collection, namespace string, generation, partID, appliedLSN uint64) ([]columnAggregateMetadataAsset, error) {
@@ -462,6 +501,32 @@ func buildColumnAggregateMetadataEntriesForSpecs(specs []columnAggregateMetadata
 		}
 		accumulators, specAccumulatorIdx := newColumnAggregateMetadataAccumulators(specs)
 		for _, row := range rows[start:end] {
+			if row.Deleted {
+				continue
+			}
+			for idx := range accumulators {
+				if err := accumulators[idx].spec.appendRow(accumulators[idx].entries, row); err != nil {
+					return nil, err
+				}
+			}
+		}
+		for idx := range specs {
+			entriesBySpec[idx] = append(entriesBySpec[idx], sortedColumnAggregateMetadataEntries(accumulators[specAccumulatorIdx[idx]].entries)...)
+		}
+	}
+	return entriesBySpec, nil
+}
+
+func buildColumnAggregateMetadataEntriesForSpecsByRowOrder(specs []columnAggregateMetadataBuildSpec, rows []columnDeclaredRow, order []int, rowsPerMetadataEntrySet int) ([][]columnAggregateMetadataEntry, error) {
+	entriesBySpec := make([][]columnAggregateMetadataEntry, len(specs))
+	for start := 0; start < len(order); start += rowsPerMetadataEntrySet {
+		end := start + rowsPerMetadataEntrySet
+		if end > len(order) {
+			end = len(order)
+		}
+		accumulators, specAccumulatorIdx := newColumnAggregateMetadataAccumulators(specs)
+		for _, rowIdx := range order[start:end] {
+			row := rows[rowIdx]
 			if row.Deleted {
 				continue
 			}

--- a/TreeDB/collections/column_aggregate_metadata_asset_3121_test.go
+++ b/TreeDB/collections/column_aggregate_metadata_asset_3121_test.go
@@ -39,6 +39,40 @@ func TestAggregateMetadataAssetsTypedGranulePassMatchesPerAggregate3121(t *testi
 	assertColumnAggregateMetadataAssetsEqual3121(t, got, want)
 }
 
+func TestAggregateMetadataAssetsTypedGranulePrecomputedOrderMatchesFallback3175(t *testing.T) {
+	cfg := aggregateMetadataBatchConfig3121()
+	cfg.SortKey = []ColumnSortKey{{Column: "time_us"}}
+	cfg.AssetManager = &ColumnAssetManagerConfig{Namespace: "events/column-assets"}
+	for idx := range cfg.Columns {
+		cfg.Columns[idx].Path = cfg.Columns[idx].Name
+		cfg.Columns[idx].Owner = TypedStorageOwnerColumnPart
+	}
+	rows := append([]columnDeclaredRow(nil), aggregateMetadataBatchRows3121()[:3]...)
+
+	typedPart, err := buildTypedColumnPartImageForDeclaredRowsWithResult(cfg, 7, typedColumnPartAssetPartID, rows)
+	if err != nil {
+		t.Fatalf("buildTypedColumnPartImageForDeclaredRowsWithResult: %v", err)
+	}
+	if typedPart.Rows != len(rows) {
+		t.Fatalf("typed part rows=%d want %d", typedPart.Rows, len(rows))
+	}
+	if want := []int{1, 0, 2}; !reflect.DeepEqual(typedPart.TypedGranuleRowOrder, want) {
+		t.Fatalf("typed granule row order=%v want %v", typedPart.TypedGranuleRowOrder, want)
+	}
+
+	got, err := buildColumnAggregateMetadataAssetsWithOptions(cfg, rows, cfg.AggregateMetadata, "events", "events/column-assets", 7, 11, 13, columnAggregateMetadataAssetBuildOptions{
+		TypedGranuleRowOrder: typedPart.TypedGranuleRowOrder,
+	})
+	if err != nil {
+		t.Fatalf("buildColumnAggregateMetadataAssetsWithOptions: %v", err)
+	}
+	want, err := buildColumnAggregateMetadataAssets(cfg, rows, cfg.AggregateMetadata, "events", "events/column-assets", 7, 11, 13)
+	if err != nil {
+		t.Fatalf("buildColumnAggregateMetadataAssets: %v", err)
+	}
+	assertColumnAggregateMetadataAssetsEqual3121(t, got, want)
+}
+
 func TestAggregateMetadataAssetsFallbackForPredicateAggregates3121(t *testing.T) {
 	cfg := aggregateMetadataBatchConfig3121()
 	cfg.AggregateMetadata = []ColumnAggregateMetadata{{

--- a/TreeDB/collections/column_publish_write.go
+++ b/TreeDB/collections/column_publish_write.go
@@ -883,12 +883,16 @@ func (c *Collection) prepareColumnPhysicalAssetRowsForCommand(prepared ColumnPub
 	queueRegularManifestAsset(encoded, ColumnAssetKindTCS1PartImage, columnPhysicalRowAssetPartID, summary.RowCount, string(input.operation), role, "", func(ref ColumnAssetRef) error {
 		return validateColumnPhysicalAssetPreparedRefForManifest(ref, rowAssetConfig, generation, columnPhysicalRowAssetPartID, len(encoded))
 	})
+	var typedGranuleRowOrder []int
 	if hookInput.Operation == ColumnPublishOperationInsert || hookInput.Operation == ColumnPublishOperationUpdate {
 		typedColumnStart := time.Now()
-		typedColumnImage, typedColumnRows, err := buildTypedColumnPartImageForDeclaredRows(hookInput.ColumnStore, generation, typedColumnPartAssetPartID, rows)
+		typedColumnBuild, err := buildTypedColumnPartImageForDeclaredRowsWithResult(hookInput.ColumnStore, generation, typedColumnPartAssetPartID, rows)
 		if err != nil {
 			return ColumnPublishPreparedAssets{}, err
 		}
+		typedColumnImage := typedColumnBuild.Bytes
+		typedColumnRows := typedColumnBuild.Rows
+		typedGranuleRowOrder = typedColumnBuild.TypedGranuleRowOrder
 		if len(typedColumnImage) != 0 {
 			typedColumnSortKey, err := typedColumnPartPublicationSortKey(hookInput.ColumnStore, columnStoreTypedColumnPartFields(hookInput.ColumnStore))
 			if err != nil {
@@ -930,7 +934,9 @@ func (c *Collection) prepareColumnPhysicalAssetRowsForCommand(prepared ColumnPub
 	}
 	if hookInput.Operation == ColumnPublishOperationInsert {
 		typedMetadataStart := time.Now()
-		typedMetadataAssets, err := buildColumnAggregateMetadataAssets(hookInput.ColumnStore, rows, columnStoreTypedColumnPartAggregateMetadata(hookInput.ColumnStore), hookInput.Collection, hookInput.ColumnStore.AssetManager.Namespace, generation, typedColumnPartAssetPartID, hookInput.AppliedCommandLSN)
+		typedMetadataAssets, err := buildColumnAggregateMetadataAssetsWithOptions(hookInput.ColumnStore, rows, columnStoreTypedColumnPartAggregateMetadata(hookInput.ColumnStore), hookInput.Collection, hookInput.ColumnStore.AssetManager.Namespace, generation, typedColumnPartAssetPartID, hookInput.AppliedCommandLSN, columnAggregateMetadataAssetBuildOptions{
+			TypedGranuleRowOrder: typedGranuleRowOrder,
+		})
 		if err != nil {
 			return ColumnPublishPreparedAssets{}, err
 		}

--- a/TreeDB/collections/typed_column_publication.go
+++ b/TreeDB/collections/typed_column_publication.go
@@ -270,31 +270,82 @@ func typedColumnAdapterRowsFromDeclaredRows(allColumns []ColumnStoreColumn, fiel
 	return out, nil
 }
 
+type typedColumnPartImageBuildResult struct {
+	Bytes                []byte
+	Rows                 int
+	TypedGranuleRowOrder []int
+}
+
 func buildTypedColumnPartImageForDeclaredRows(cfg ColumnStoreConfig, generation, partID uint64, rows []columnDeclaredRow) ([]byte, int, error) {
+	result, err := buildTypedColumnPartImageForDeclaredRowsWithResult(cfg, generation, partID, rows)
+	if err != nil {
+		return nil, 0, err
+	}
+	return result.Bytes, result.Rows, nil
+}
+
+func buildTypedColumnPartImageForDeclaredRowsWithResult(cfg ColumnStoreConfig, generation, partID uint64, rows []columnDeclaredRow) (typedColumnPartImageBuildResult, error) {
 	if !columnStoreHasTypedColumnPartOwners(cfg) {
-		return nil, 0, nil
+		return typedColumnPartImageBuildResult{}, nil
 	}
 	fields := columnStoreTypedColumnPartFields(cfg)
 	if len(fields) == 0 {
-		return nil, 0, nil
+		return typedColumnPartImageBuildResult{}, nil
 	}
 	sortKey, err := typedColumnPartPublicationSortKey(cfg, fields)
 	if err != nil {
-		return nil, 0, err
+		return typedColumnPartImageBuildResult{}, err
 	}
 	adapterOpts, err := typedColumnPublicationAdapterOptionsFromConfig(cfg, partID, fields, sortKey)
 	if err != nil {
-		return nil, 0, err
+		return typedColumnPartImageBuildResult{}, err
 	}
 	part, err := buildTypedColumnAdapterPartFromDeclaredRows(adapterOpts, cfg.Columns, rows)
 	if err != nil {
-		return nil, 0, err
+		return typedColumnPartImageBuildResult{}, err
 	}
 	image, err := part.buildImage()
 	if err != nil {
-		return nil, 0, err
+		return typedColumnPartImageBuildResult{}, err
 	}
-	return image.Bytes, image.Rows, nil
+	rowOrder, err := typedColumnPartDeclaredRowOrder(part, image.Rows)
+	if err != nil {
+		return typedColumnPartImageBuildResult{}, err
+	}
+	return typedColumnPartImageBuildResult{Bytes: image.Bytes, Rows: image.Rows, TypedGranuleRowOrder: rowOrder}, nil
+}
+
+func typedColumnPartDeclaredRowOrder(part *typedColumnAdapterPart, rows int) ([]int, error) {
+	if rows == 0 {
+		return nil, nil
+	}
+	if part == nil || part.Part == nil {
+		return nil, errors.New("collections: typed-column part row order requires built part")
+	}
+	if len(part.Part.Locators) != rows {
+		return nil, fmt.Errorf("collections: typed-column part locators=%d want rows=%d", len(part.Part.Locators), rows)
+	}
+	order := make([]int, rows)
+	seen := make([]bool, rows)
+	for _, locator := range part.Part.Locators {
+		if locator.PartRow < 0 || locator.PartRow >= rows {
+			return nil, fmt.Errorf("collections: typed-column part row order part_row=%d outside rows=%d", locator.PartRow, rows)
+		}
+		if locator.PrimaryID < 0 || locator.PrimaryID >= int64(rows) {
+			return nil, fmt.Errorf("collections: typed-column part row order primary_id=%d outside rows=%d", locator.PrimaryID, rows)
+		}
+		if seen[locator.PartRow] {
+			return nil, fmt.Errorf("collections: typed-column part row order duplicate part_row=%d", locator.PartRow)
+		}
+		order[locator.PartRow] = int(locator.PrimaryID)
+		seen[locator.PartRow] = true
+	}
+	for idx, ok := range seen {
+		if !ok {
+			return nil, fmt.Errorf("collections: typed-column part row order missing part_row=%d", idx)
+		}
+	}
+	return order, nil
 }
 
 type typedColumnPartVisibleValues struct {

--- a/TreeDB/collections/typed_storage_naming_test.go
+++ b/TreeDB/collections/typed_storage_naming_test.go
@@ -332,7 +332,7 @@ type typedStorageLegacyNameAllowlistEntry struct {
 
 var typedStorageLegacyNameAllowlist = []typedStorageLegacyNameAllowlistEntry{
 	{path: "TreeDB/collections/api.go", classification: typedStorageLegacyCompatibility, matchingLines: 60, occurrences: 66},
-	{path: "TreeDB/collections/column_aggregate_metadata_asset.go", classification: typedStorageLegacyDerived, matchingLines: 21, occurrences: 23},
+	{path: "TreeDB/collections/column_aggregate_metadata_asset.go", classification: typedStorageLegacyDerived, matchingLines: 22, occurrences: 24},
 	{path: "TreeDB/collections/column_aggregate_metadata_asset_3121_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 22, occurrences: 22},
 	{path: "TreeDB/collections/column_aggregate_metadata_predicate.go", classification: typedStorageLegacyDerived, matchingLines: 6, occurrences: 6},
 	{path: "TreeDB/collections/column_aggregate_metadata_predicate_1951_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 77, occurrences: 78},
@@ -461,7 +461,7 @@ var typedStorageLegacyNameAllowlist = []typedStorageLegacyNameAllowlistEntry{
 	{path: "TreeDB/collections/typed_column_string_scan.go", classification: typedStorageLegacyCompatibility, matchingLines: 13, occurrences: 18},
 	{path: "TreeDB/collections/typed_column_string_scan_bench_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 9, occurrences: 9},
 	{path: "TreeDB/collections/typed_column_string_scan_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 13, occurrences: 14},
-	{path: "TreeDB/collections/typed_column_publication.go", classification: typedStorageLegacyCompatibility, matchingLines: 20, occurrences: 22},
+	{path: "TreeDB/collections/typed_column_publication.go", classification: typedStorageLegacyCompatibility, matchingLines: 21, occurrences: 23},
 	{path: "TreeDB/collections/typed_column_publication_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 96, occurrences: 99},
 	{path: "TreeDB/collections/typed_column_semantics_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 28, occurrences: 30},
 	{path: "TreeDB/collections/typed_storage_layout.go", classification: typedStorageLegacyCompatibility, matchingLines: 26, occurrences: 52},


### PR DESCRIPTION
## Summary
- carry the typed-column part row order out of part-image publication
- use that order to build typed-granule aggregate metadata without sorting the same rows again
- keep the existing aggregate metadata fallback path and add parity coverage for order-fed metadata

## Evidence
- baseline artifact: `/tmp/jsonbench_q5_firsttouch_baseline_20260628_110154/report.json`
- patched artifact: `/tmp/jsonbench_q5_after_order_only_1m_20260628_115204/report.json`
- lane: `first_touch_after_open`, `no_aggregate_metadata`, `column-store-full-prepared`, q5, 1M Bluesky rows
- load: 21.213s -> 19.886s
- insert: 16.440s -> 15.527s
- publish: 11.672s -> 10.961s
- aggregate metadata prepare: 1.266s -> 1.177s
- q5 stayed on the no-metadata typed-column scan path: prepare workers 8, rows scanned 1,000,000, aggregate metadata not used

## Rejected adjacent experiment
- enabling prepared global-codes setup for one-shot q5 was tested and not kept
- artifact: `/tmp/jsonbench_q5_after_order_global_1m_20260628_114824/report.json`
- q5 regressed from 49.101ms to 263.151ms because setup became serial, so this PR excludes that change

## Validation
- `GOWORK=off go test ./TreeDB/collections -run 'TestAggregateMetadataAssets(TypedGranulePassMatchesPerAggregate3121|SingleRowPassMatchesPerAggregate3121|TypedGranulePrecomputedOrderMatchesFallback3175)$' -count=1`\n- `GOWORK=off go test ./TreeDB/collections -run '^TestTypedStorageLegacyNameAllowlistIsComplete$' -count=1`\n- `GOWORK=off go test ./TreeDB/collections`\n- `GOWORK=off go test ./cmd/unified_bench`\n- `git diff --check`\n\nTracks #3067, #3099, #3151, #3070, #3000.