### PR TITLE
[codex] cap append-only entry pool retention under pressure

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -366,6 +366,7 @@ const (
 	postCheckpointEntrySliceLeaseKeepPerBucket = 8
 	postFlushAppendOnlyMemLeaseKeep            = 24
 	postCheckpointAppendOnlyMemLeaseKeep       = 8
+	appendOnlyEntryPoolHighPressureDropBytes   = uint64(32 << 20)
 )
 
 func computeBatchArenaPoolBudgetBytes() int64 {
@@ -723,6 +724,22 @@ func maybeTrimEntrySliceLeasesUnderPressure(level poolPressureLevel, sampledAt t
 	if droppedBytes > 0 {
 		entrySlicePoolTrimDropBytesTotal.Add(uint64(droppedBytes))
 	}
+	maybeDropAppendOnlyEntryPoolsUnderPressure(level)
+}
+
+func maybeDropAppendOnlyEntryPoolsUnderPressure(level poolPressureLevel) {
+	if level == poolPressureNormal {
+		return
+	}
+	stats := memtable.AppendOnlyEntryPoolStatsSnapshot()
+	retainedBytes := stats.RetainedBytesEstimate
+	if retainedBytes == 0 {
+		return
+	}
+	if level != poolPressureCritical && retainedBytes < appendOnlyEntryPoolHighPressureDropBytes {
+		return
+	}
+	memtable.DropAppendOnlyEntryPools()
 }
 
 func publishPoolPressureSnapshot(snap poolPressureSnapshot, sampledAt time.Time) {
@@ -28910,14 +28927,19 @@ func (db *DB) Stats() map[string]string {
 	appendOnlyMemNewAllocWithQueue := db.appendOnlyMemNewAllocWithQueue.Load()
 	appendOnlyMemNewAllocQueueBytes := db.appendOnlyMemNewAllocQueueBytes.Load()
 	appendOnlyMemPoolDropTotal := db.appendOnlyMemPoolDropTotal.Load()
-	appendOnlyEntryPoolDropTotal := memtable.AppendOnlyEntryPoolDropTotal()
+	appendOnlyEntryPoolStats := memtable.AppendOnlyEntryPoolStatsSnapshot()
 	appendOnlyMemLeaseCount, appendOnlyMemLeaseEntryCapacity, appendOnlyMemLeaseEntryBackingBytes := db.appendOnlyMemLeaseStats()
 	appendOnlyMutableCount, appendOnlyMutableEntryCapacity, appendOnlyMutableEntryBackingBytes := db.appendOnlyMutableShardEntryStats()
 	appendOnlyMutableTrimTotal := db.appendOnlyMutableTrimTotal.Load()
 	appendOnlyMutableTrimDropped := db.appendOnlyMutableTrimDropped.Load()
 	stats["treedb.cache.append_only.entry_hint_entries"] = fmt.Sprintf("%d", appendOnlyEntryHint)
 	stats["treedb.cache.append_only.entry_hint_capacity_bytes"] = fmt.Sprintf("%d", appendOnlyHintCapacity)
-	stats["treedb.cache.append_only.entry_pool_drops_total"] = fmt.Sprintf("%d", appendOnlyEntryPoolDropTotal)
+	stats["treedb.cache.append_only.entry_pool_retained_bytes_estimate"] = fmt.Sprintf("%d", appendOnlyEntryPoolStats.RetainedBytesEstimate)
+	stats["treedb.cache.append_only.entry_pool_retained_bytes_max_estimate"] = fmt.Sprintf("%d", appendOnlyEntryPoolStats.RetainedBytesMaxEstimate)
+	stats["treedb.cache.append_only.entry_pool_gets_total"] = fmt.Sprintf("%d", appendOnlyEntryPoolStats.GetsTotal)
+	stats["treedb.cache.append_only.entry_pool_puts_total"] = fmt.Sprintf("%d", appendOnlyEntryPoolStats.PutsTotal)
+	stats["treedb.cache.append_only.entry_pool_drops_total"] = fmt.Sprintf("%d", appendOnlyEntryPoolStats.DropsTotal)
+	stats["treedb.cache.append_only.entry_pool_drop_bytes_total"] = fmt.Sprintf("%d", appendOnlyEntryPoolStats.DropBytesTotal)
 	stats["treedb.cache.append_only.mem_lease_count"] = fmt.Sprintf("%d", appendOnlyMemLeaseCount)
 	stats["treedb.cache.append_only.mem_lease_entry_capacity"] = fmt.Sprintf("%d", appendOnlyMemLeaseEntryCapacity)
 	stats["treedb.cache.append_only.mem_lease_entry_backing_bytes"] = fmt.Sprintf("%d", appendOnlyMemLeaseEntryBackingBytes)
@@ -28934,7 +28956,12 @@ func (db *DB) Stats() map[string]string {
 	stats["treedb.cache.append_only.mutable_new_alloc_queue_bytes_sum"] = fmt.Sprintf("%d", appendOnlyMemNewAllocQueueBytes)
 	stats["treedb.process.append_only.entry_hint_entries"] = fmt.Sprintf("%d", appendOnlyEntryHint)
 	stats["treedb.process.append_only.entry_hint_capacity_bytes"] = fmt.Sprintf("%d", appendOnlyHintCapacity)
-	stats["treedb.process.append_only.entry_pool_drops_total"] = fmt.Sprintf("%d", appendOnlyEntryPoolDropTotal)
+	stats["treedb.process.append_only.entry_pool_retained_bytes_estimate"] = fmt.Sprintf("%d", appendOnlyEntryPoolStats.RetainedBytesEstimate)
+	stats["treedb.process.append_only.entry_pool_retained_bytes_max_estimate"] = fmt.Sprintf("%d", appendOnlyEntryPoolStats.RetainedBytesMaxEstimate)
+	stats["treedb.process.append_only.entry_pool_gets_total"] = fmt.Sprintf("%d", appendOnlyEntryPoolStats.GetsTotal)
+	stats["treedb.process.append_only.entry_pool_puts_total"] = fmt.Sprintf("%d", appendOnlyEntryPoolStats.PutsTotal)
+	stats["treedb.process.append_only.entry_pool_drops_total"] = fmt.Sprintf("%d", appendOnlyEntryPoolStats.DropsTotal)
+	stats["treedb.process.append_only.entry_pool_drop_bytes_total"] = fmt.Sprintf("%d", appendOnlyEntryPoolStats.DropBytesTotal)
 	stats["treedb.process.append_only.mem_lease_count"] = fmt.Sprintf("%d", appendOnlyMemLeaseCount)
 	stats["treedb.process.append_only.mem_lease_entry_capacity"] = fmt.Sprintf("%d", appendOnlyMemLeaseEntryCapacity)
 	stats["treedb.process.append_only.mem_lease_entry_backing_bytes"] = fmt.Sprintf("%d", appendOnlyMemLeaseEntryBackingBytes)

--- a/TreeDB/caching/memory_stats_test.go
+++ b/TreeDB/caching/memory_stats_test.go
@@ -130,9 +130,21 @@ func TestProcessMemoryStatsIncludeRuntimeBreakdown(t *testing.T) {
 		"treedb.cache.append_only.mutable_from_lease_total",
 		"treedb.cache.append_only.mutable_from_pool_total",
 		"treedb.cache.append_only.mutable_new_alloc_total",
+		"treedb.cache.append_only.entry_pool_retained_bytes_estimate",
+		"treedb.cache.append_only.entry_pool_retained_bytes_max_estimate",
+		"treedb.cache.append_only.entry_pool_gets_total",
+		"treedb.cache.append_only.entry_pool_puts_total",
+		"treedb.cache.append_only.entry_pool_drops_total",
+		"treedb.cache.append_only.entry_pool_drop_bytes_total",
 		"treedb.process.append_only.mutable_from_lease_total",
 		"treedb.process.append_only.mutable_from_pool_total",
 		"treedb.process.append_only.mutable_new_alloc_total",
+		"treedb.process.append_only.entry_pool_retained_bytes_estimate",
+		"treedb.process.append_only.entry_pool_retained_bytes_max_estimate",
+		"treedb.process.append_only.entry_pool_gets_total",
+		"treedb.process.append_only.entry_pool_puts_total",
+		"treedb.process.append_only.entry_pool_drops_total",
+		"treedb.process.append_only.entry_pool_drop_bytes_total",
 	}
 	for _, key := range requiredInt {
 		if got := mustStatInt64(t, stats, key); got < 0 {
@@ -154,6 +166,12 @@ func TestProcessMemoryStatsIncludeRuntimeBreakdown(t *testing.T) {
 	}
 	if got := mustStatInt64(t, stats, "treedb.process.append_only.mutable_new_alloc_total"); got != mustStatInt64(t, stats, "treedb.cache.append_only.mutable_new_alloc_total") {
 		t.Fatalf("append_only new source mismatch process=%d cache=%d", got, mustStatInt64(t, stats, "treedb.cache.append_only.mutable_new_alloc_total"))
+	}
+	if got := mustStatInt64(t, stats, "treedb.process.append_only.entry_pool_retained_bytes_estimate"); got != mustStatInt64(t, stats, "treedb.cache.append_only.entry_pool_retained_bytes_estimate") {
+		t.Fatalf("append_only entry pool retained mismatch process=%d cache=%d", got, mustStatInt64(t, stats, "treedb.cache.append_only.entry_pool_retained_bytes_estimate"))
+	}
+	if got := mustStatInt64(t, stats, "treedb.process.append_only.entry_pool_drop_bytes_total"); got != mustStatInt64(t, stats, "treedb.cache.append_only.entry_pool_drop_bytes_total") {
+		t.Fatalf("append_only entry pool drop bytes mismatch process=%d cache=%d", got, mustStatInt64(t, stats, "treedb.cache.append_only.entry_pool_drop_bytes_total"))
 	}
 
 	rawGCFraction, ok := stats["treedb.process.memory.gc_cpu_fraction"]

--- a/TreeDB/caching/pool_pressure_test.go
+++ b/TreeDB/caching/pool_pressure_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/snissn/gomap/TreeDB/batch"
+	"github.com/snissn/gomap/TreeDB/internal/memtable"
 )
 
 var poolPressureTestMu sync.Mutex
@@ -147,6 +148,43 @@ func TestPoolPressureTrimsEntrySliceLeases(t *testing.T) {
 	_ = currentPoolPressureSnapshot()
 	if got := len(entrySliceLeases[0]); got != 0 {
 		t.Fatalf("critical pressure leases=%d want 0", got)
+	}
+}
+
+func TestPoolPressureDropsAppendOnlyEntryPools(t *testing.T) {
+	poolPressureTestMu.Lock()
+	defer poolPressureTestMu.Unlock()
+
+	resetPoolPressureStateForTest()
+	memtable.DropAppendOnlyEntryPools()
+	t.Cleanup(func() {
+		memtable.DropAppendOnlyEntryPools()
+		resetPoolPressureStateForTest()
+	})
+
+	mt := memtable.NewAppendOnlyWithEntryCapacity(128)
+	for i := 0; i < 1024; i++ {
+		key := []byte{byte(i), byte(i >> 8)}
+		mt.Set(key, []byte("value"))
+	}
+	mt.Reset()
+
+	before := memtable.AppendOnlyEntryPoolStatsSnapshot()
+	if before.RetainedBytesEstimate == 0 {
+		t.Fatal("test setup did not retain append-only entry pool bytes")
+	}
+
+	maybeTrimEntrySliceLeasesUnderPressure(poolPressureCritical, time.Unix(1, 0))
+
+	after := memtable.AppendOnlyEntryPoolStatsSnapshot()
+	if got := after.RetainedBytesEstimate; got != 0 {
+		t.Fatalf("append-only entry pool retained bytes=%d want 0", got)
+	}
+	if got := after.DropsTotal; got != before.DropsTotal+1 {
+		t.Fatalf("append-only entry pool drops=%d want %d", got, before.DropsTotal+1)
+	}
+	if got := after.DropBytesTotal; got < before.DropBytesTotal+before.RetainedBytesEstimate {
+		t.Fatalf("append-only entry pool drop bytes=%d want at least %d", got, before.DropBytesTotal+before.RetainedBytesEstimate)
 	}
 }
 

--- a/TreeDB/internal/memtable/append_only.go
+++ b/TreeDB/internal/memtable/append_only.go
@@ -53,7 +53,12 @@ const (
 )
 
 var appendOnlyEntryPoolPtrs [appendOnlyEntryPoolClassCount]atomic.Pointer[sync.Pool]
+var appendOnlyEntryPoolRetainedBytes atomic.Uint64
+var appendOnlyEntryPoolRetainedBytesMax atomic.Uint64
+var appendOnlyEntryPoolGetTotal atomic.Uint64
+var appendOnlyEntryPoolPutTotal atomic.Uint64
 var appendOnlyEntryPoolDropTotal atomic.Uint64
+var appendOnlyEntryPoolDropBytesTotal atomic.Uint64
 var appendOnlyIteratorPool sync.Pool
 var appendOnlyIteratorPtrPool sync.Pool
 var appendOnlyValueArenaPools [appendOnlyValueArenaClassCount]sync.Pool
@@ -124,6 +129,15 @@ type AppendOnly struct {
 	iteratorLeaseMu   sync.Mutex
 	iteratorLeaseCond *sync.Cond
 	iteratorLeases    int
+}
+
+type AppendOnlyEntryPoolStats struct {
+	RetainedBytesEstimate    uint64
+	RetainedBytesMaxEstimate uint64
+	GetsTotal                uint64
+	PutsTotal                uint64
+	DropsTotal               uint64
+	DropBytesTotal           uint64
 }
 
 func (*AppendOnly) StableUnsafeIteratorSlices() bool { return true }
@@ -211,6 +225,45 @@ func appendOnlyEntryPoolForClass(class int) *sync.Pool {
 	return appendOnlyEntryPoolPtrs[class].Load()
 }
 
+func appendOnlyEntryPoolBytes(capacity int) uint64 {
+	if capacity <= 0 {
+		return 0
+	}
+	return uint64(capacity) * uint64(unsafe.Sizeof(appendOnlyEntry{}))
+}
+
+func addAppendOnlyEntryPoolRetainedBytes(bytes uint64) {
+	if bytes == 0 {
+		return
+	}
+	current := appendOnlyEntryPoolRetainedBytes.Add(bytes)
+	for {
+		prev := appendOnlyEntryPoolRetainedBytesMax.Load()
+		if current <= prev || appendOnlyEntryPoolRetainedBytesMax.CompareAndSwap(prev, current) {
+			return
+		}
+	}
+}
+
+func subtractAppendOnlyEntryPoolRetainedBytes(bytes uint64) {
+	if bytes == 0 {
+		return
+	}
+	for {
+		current := appendOnlyEntryPoolRetainedBytes.Load()
+		if current == 0 {
+			return
+		}
+		next := uint64(0)
+		if current > bytes {
+			next = current - bytes
+		}
+		if appendOnlyEntryPoolRetainedBytes.CompareAndSwap(current, next) {
+			return
+		}
+	}
+}
+
 // DropAppendOnlyEntryPools abandons package-level append-only entry slice pools.
 // It is intended for cold transitions away from append-only mutable memtables,
 // where retaining restore-sized warm buffers hurts steady-state RSS more than it
@@ -219,11 +272,25 @@ func DropAppendOnlyEntryPools() {
 	for i := range appendOnlyEntryPoolPtrs {
 		appendOnlyEntryPoolPtrs[i].Store(&sync.Pool{})
 	}
+	if dropped := appendOnlyEntryPoolRetainedBytes.Swap(0); dropped > 0 {
+		appendOnlyEntryPoolDropBytesTotal.Add(dropped)
+	}
 	appendOnlyEntryPoolDropTotal.Add(1)
 }
 
 func AppendOnlyEntryPoolDropTotal() uint64 {
 	return appendOnlyEntryPoolDropTotal.Load()
+}
+
+func AppendOnlyEntryPoolStatsSnapshot() AppendOnlyEntryPoolStats {
+	return AppendOnlyEntryPoolStats{
+		RetainedBytesEstimate:    appendOnlyEntryPoolRetainedBytes.Load(),
+		RetainedBytesMaxEstimate: appendOnlyEntryPoolRetainedBytesMax.Load(),
+		GetsTotal:                appendOnlyEntryPoolGetTotal.Load(),
+		PutsTotal:                appendOnlyEntryPoolPutTotal.Load(),
+		DropsTotal:               appendOnlyEntryPoolDropTotal.Load(),
+		DropBytesTotal:           appendOnlyEntryPoolDropBytesTotal.Load(),
+	}
 }
 
 func getAppendOnlyEntriesFromPool(length int, pool *sync.Pool) []appendOnlyEntry {
@@ -259,8 +326,10 @@ func getAppendOnlyEntries(length int) []appendOnlyEntry {
 	}
 	if pool := appendOnlyEntryPoolForClass(class); pool != nil {
 		if v := pool.Get(); v != nil {
-			if entries, ok := v.([]appendOnlyEntry); ok && cap(entries) >= length {
-				if cap(entries) <= appendOnlyMaxReuseEntries(length) {
+			if entries, ok := v.([]appendOnlyEntry); ok {
+				appendOnlyEntryPoolGetTotal.Add(1)
+				subtractAppendOnlyEntryPoolRetainedBytes(appendOnlyEntryPoolBytes(cap(entries)))
+				if cap(entries) >= length && cap(entries) <= appendOnlyMaxReuseEntries(length) {
 					return entries[:length]
 				}
 			}
@@ -280,6 +349,8 @@ func putAppendOnlyEntries(entries []appendOnlyEntry) {
 		return
 	}
 	if pool := appendOnlyEntryPoolForClass(class); pool != nil {
+		appendOnlyEntryPoolPutTotal.Add(1)
+		addAppendOnlyEntryPoolRetainedBytes(appendOnlyEntryPoolBytes(cap(full)))
 		pool.Put(full[:0])
 	}
 }

--- a/TreeDB/internal/memtable/append_only.go
+++ b/TreeDB/internal/memtable/append_only.go
@@ -52,6 +52,9 @@ const (
 	appendOnlyAggressiveGrowCutoff      = appendOnlyResetDropThresholdEntries * 2
 )
 
+// Serializes package-pool replacement with retained-byte accounting. sync.Pool
+// is concurrent, but the estimate is for the currently reachable pool set.
+var appendOnlyEntryPoolMu sync.Mutex
 var appendOnlyEntryPoolPtrs [appendOnlyEntryPoolClassCount]atomic.Pointer[sync.Pool]
 var appendOnlyEntryPoolRetainedBytes atomic.Uint64
 var appendOnlyEntryPoolRetainedBytesMax atomic.Uint64
@@ -269,6 +272,9 @@ func subtractAppendOnlyEntryPoolRetainedBytes(bytes uint64) {
 // where retaining restore-sized warm buffers hurts steady-state RSS more than it
 // helps near-term reuse.
 func DropAppendOnlyEntryPools() {
+	appendOnlyEntryPoolMu.Lock()
+	defer appendOnlyEntryPoolMu.Unlock()
+
 	for i := range appendOnlyEntryPoolPtrs {
 		appendOnlyEntryPoolPtrs[i].Store(&sync.Pool{})
 	}
@@ -324,17 +330,20 @@ func getAppendOnlyEntries(length int) []appendOnlyEntry {
 	if !ok {
 		return make([]appendOnlyEntry, length)
 	}
+	appendOnlyEntryPoolMu.Lock()
 	if pool := appendOnlyEntryPoolForClass(class); pool != nil {
 		if v := pool.Get(); v != nil {
 			if entries, ok := v.([]appendOnlyEntry); ok {
 				appendOnlyEntryPoolGetTotal.Add(1)
 				subtractAppendOnlyEntryPoolRetainedBytes(appendOnlyEntryPoolBytes(cap(entries)))
 				if cap(entries) >= length && cap(entries) <= appendOnlyMaxReuseEntries(length) {
+					appendOnlyEntryPoolMu.Unlock()
 					return entries[:length]
 				}
 			}
 		}
 	}
+	appendOnlyEntryPoolMu.Unlock()
 	return make([]appendOnlyEntry, length)
 }
 
@@ -348,6 +357,8 @@ func putAppendOnlyEntries(entries []appendOnlyEntry) {
 	if !ok {
 		return
 	}
+	appendOnlyEntryPoolMu.Lock()
+	defer appendOnlyEntryPoolMu.Unlock()
 	if pool := appendOnlyEntryPoolForClass(class); pool != nil {
 		appendOnlyEntryPoolPutTotal.Add(1)
 		addAppendOnlyEntryPoolRetainedBytes(appendOnlyEntryPoolBytes(cap(full)))

--- a/TreeDB/internal/memtable/append_only_pool_test.go
+++ b/TreeDB/internal/memtable/append_only_pool_test.go
@@ -94,6 +94,50 @@ func TestDropAppendOnlyEntryPoolsReplacesPools(t *testing.T) {
 	}
 }
 
+func TestAppendOnlyEntryPoolStatsTrackRetainedBacking(t *testing.T) {
+	DropAppendOnlyEntryPools()
+	t.Cleanup(DropAppendOnlyEntryPools)
+
+	before := AppendOnlyEntryPoolStatsSnapshot()
+	entries := make([]appendOnlyEntry, 0, appendOnlyMinInitialEntries)
+	wantBytes := appendOnlyEntryPoolBytes(cap(entries))
+
+	putAppendOnlyEntries(entries)
+	afterPut := AppendOnlyEntryPoolStatsSnapshot()
+	if got := afterPut.RetainedBytesEstimate; got != wantBytes {
+		t.Fatalf("retained bytes after put=%d want %d", got, wantBytes)
+	}
+	if got := afterPut.PutsTotal; got != before.PutsTotal+1 {
+		t.Fatalf("puts total=%d want %d", got, before.PutsTotal+1)
+	}
+
+	got := getAppendOnlyEntries(appendOnlyMinInitialEntries)
+	afterGet := AppendOnlyEntryPoolStatsSnapshot()
+	if cap(got) != cap(entries) {
+		t.Fatalf("pooled cap=%d want %d", cap(got), cap(entries))
+	}
+	if gotRetained := afterGet.RetainedBytesEstimate; gotRetained != 0 {
+		t.Fatalf("retained bytes after get=%d want 0", gotRetained)
+	}
+	if gotGets := afterGet.GetsTotal; gotGets != before.GetsTotal+1 {
+		t.Fatalf("gets total=%d want %d", gotGets, before.GetsTotal+1)
+	}
+
+	putAppendOnlyEntries(got)
+	beforeDrop := AppendOnlyEntryPoolStatsSnapshot()
+	DropAppendOnlyEntryPools()
+	afterDrop := AppendOnlyEntryPoolStatsSnapshot()
+	if gotRetained := afterDrop.RetainedBytesEstimate; gotRetained != 0 {
+		t.Fatalf("retained bytes after drop=%d want 0", gotRetained)
+	}
+	if gotDrops := afterDrop.DropsTotal; gotDrops != beforeDrop.DropsTotal+1 {
+		t.Fatalf("drops total=%d want %d", gotDrops, beforeDrop.DropsTotal+1)
+	}
+	if gotDropBytes := afterDrop.DropBytesTotal; gotDropBytes < beforeDrop.DropBytesTotal+beforeDrop.RetainedBytesEstimate {
+		t.Fatalf("drop bytes total=%d want at least %d", gotDropBytes, beforeDrop.DropBytesTotal+beforeDrop.RetainedBytesEstimate)
+	}
+}
+
 func TestAppendOnlyIteratorCloseClearsPooledEntries(t *testing.T) {
 	entries := make([]appendOnlyEntry, 2)
 	entries[0].key = []byte("k0")

--- a/TreeDB/internal/valuelog/grouped_frame_cache_test.go
+++ b/TreeDB/internal/valuelog/grouped_frame_cache_test.go
@@ -471,6 +471,18 @@ func TestGroupedFrameCache_ConcurrentReadsAndEvictions(t *testing.T) {
 	if got, _, err, hit := f.groupedFrameCacheReadTo(1, false, 2, baseOffsets, uint32(len(baseRaw)), 0, nil); err != nil || !hit || !bytes.Equal(got, []byte("left")) {
 		t.Fatalf("warm cache hit failed: hit=%v err=%v got=%q", hit, err, got)
 	}
+	if _, _, err, hit := f.groupedFrameCacheReadTo(2, false, 2, baseOffsets, uint32(len(baseRaw)), 0, nil); err != nil || hit {
+		t.Fatalf("expected deterministic cache miss before concurrent phase: hit=%v err=%v", hit, err)
+	}
+
+	cache := f.ensureGroupedFrameCache()
+	baseShard := cache.shardFor(1, false)
+	evictStarts := make([]int64, 0, 200)
+	for start := int64(100); len(evictStarts) < cap(evictStarts); start++ {
+		if cache.shardFor(start, false) == baseShard {
+			evictStarts = append(evictStarts, start)
+		}
+	}
 
 	var wg sync.WaitGroup
 	for g := 0; g < 16; g++ {
@@ -499,10 +511,10 @@ func TestGroupedFrameCache_ConcurrentReadsAndEvictions(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		for i := 0; i < 200; i++ {
+		for i, start := range evictStarts {
 			raw := bytes.Repeat([]byte{byte(i)}, 32)
 			offsets := groupedCacheOffsets(32)
-			_ = f.groupedFrameCacheStore(int64(100+i), false, 1, offsets, raw, false)
+			_ = f.groupedFrameCacheStore(start, false, 1, offsets, raw, false)
 		}
 	}()
 	wg.Wait()


### PR DESCRIPTION
## Summary

This PR targets the next measured TreeDB-owned Celestia heap blocker after #3230: `TreeDB/internal/memtable.getAppendOnlyEntries`, which was still `217.22MB` of `inuse_space` in the final post-sync heap profile.

The final Celestia debug vars showed active append-only mutable and lease backing were already low (`~7.4MB` in the current DB, with queue residency at zero), while pprof still attributed `217.22MB` to the append-only entry allocator. That points at package-level append-only entry slice pool retention, which previously had only a drop counter and was only abandoned when adaptive mode left append-only.

## Changes

- Track append-only entry pool retained bytes, max retained bytes, gets, puts, drops, and dropped bytes.
- Expose those counters under both `treedb.cache.append_only.*` and `treedb.process.append_only.*` so existing Celestia debug-var captures can prove whether this pool was the retained owner.
- Drop append-only entry pools from the existing heap-pressure trim cadence when pressure is critical, or when high pressure has at least 32MiB retained in the pool.
- Add focused tests for pool accounting, pressure-triggered pool drops, and stats coverage.

## Celestia Evidence

Source run: `/home/mikers/.celestia-app-mainnet-treedb-20260628111908`

Final heap profile:

- Type: `inuse_space`
- Total: `3483.68MB`
- `TreeDB/internal/memtable.getAppendOnlyEntries`: `217.22MB`
- `TreeDB/internal/valuelog.getWriterAppendBuf`: `80.03MB`
- `TreeDB/db.(*leafPageReadCacheSlot).storeLockedWithRecordChecksumState`: `72.78MB`
- `TreeDB/internal/valuelog.getDecodeScratch`: `52.05MB`
- `TreeDB/internal/commitlog.(*Writer).reserveCommandBufferSpace`: `49.05MB`

Final debug vars from the same run:

- `treedb.process.append_only.mem_lease_entry_backing_bytes`: `436480`
- `treedb.process.append_only.mutable_entry_backing_bytes`: `6990080`
- `treedb.process.memtable_residency.queue.total.size_bytes`: `0`
- `treedb.process.append_only.entry_pool_drops_total`: `0`
- `treedb.process.memory.pool_pressure_level`: `high`

This PR is intentionally scoped to the pool-retention hypothesis and adds the telemetry required for the next Celestia rerun to either confirm the reduction or move the next fix to frozen/view retention.

Refs #3131

## Validation

- `GOWORK=off go test ./TreeDB/internal/memtable -run 'TestAppendOnlyEntryPoolStatsTrackRetainedBacking|TestDropAppendOnlyEntryPoolsReplacesPools|TestAppendOnlyResetWithCapacityHard|TestAppendOnlyReleaseDropEntries' -count=1`
- `GOWORK=off go test ./TreeDB/caching -run 'TestPoolPressureDropsAppendOnlyEntryPools|TestPoolPressureTrimsEntrySliceLeases|TestTreeDBMemoryStatsIncludeProcessWideCounters' -count=1`
- `GOWORK=off go test ./TreeDB/internal/memtable ./TreeDB/caching -count=1`
- `git diff --check`
