### PR TITLE
Reduce aggregate metadata load preparation

### DIFF
--- a/TreeDB/collections/column_aggregate_metadata_asset.go
+++ b/TreeDB/collections/column_aggregate_metadata_asset.go
@@ -4,7 +4,11 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"runtime"
 	"sort"
+	"strconv"
+	"strings"
+	"sync"
 )
 
 const (
@@ -41,6 +45,7 @@ type columnAggregateMetadataBuildSpec struct {
 	valueIdx          int
 	predicateSpecs    []columnAggregateMetadataPredicateSpec
 	predicateCoverage []ColumnPhysicalQueryPredicate
+	predicateKey      string
 }
 
 type columnAggregateMetadataEntryKey struct {
@@ -57,9 +62,10 @@ const (
 )
 
 type columnAggregateMetadataAccumulatorKey struct {
-	kind     columnAggregateMetadataAccumulatorKind
-	groupIdx int
-	valueIdx int
+	kind         columnAggregateMetadataAccumulatorKind
+	groupIdx     int
+	valueIdx     int
+	predicateKey string
 }
 
 type columnAggregateMetadataAccumulator struct {
@@ -324,7 +330,7 @@ func buildColumnAggregateMetadataAssetsWithOptions(cfg ColumnStoreConfig, rows [
 		if err != nil {
 			return nil, err
 		}
-		if !ok || len(spec.predicateSpecs) != 0 {
+		if !ok {
 			return buildColumnAggregateMetadataAssetsSequential(cfg, rows, aggregates, collection, namespace, generation, partID, appliedLSN)
 		}
 		aggregateUsesTypedGranules := columnAggregateMetadataUsesTypedColumnGranules(cfg, aggregate)
@@ -451,7 +457,35 @@ func newColumnAggregateMetadataBuildSpec(cfg ColumnStoreConfig, aggregate Column
 		valueIdx:          valueIdx,
 		predicateSpecs:    predicateSpecs,
 		predicateCoverage: predicateCoverage,
+		predicateKey:      columnAggregateMetadataPredicateAccumulatorKey(predicateCoverage),
 	}, true, nil
+}
+
+func columnAggregateMetadataPredicateAccumulatorKey(predicates []ColumnPhysicalQueryPredicate) string {
+	if len(predicates) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	for _, predicate := range predicates {
+		kind := columnPhysicalQueryPredicateKindOrDefault(predicate.Kind)
+		writeColumnAggregateMetadataPredicateAccumulatorKeyString(&b, predicate.Column)
+		writeColumnAggregateMetadataPredicateAccumulatorKeyString(&b, string(kind))
+		if kind == ColumnPhysicalQueryPredicateInList {
+			for _, value := range predicate.Values {
+				writeColumnAggregateMetadataPredicateAccumulatorKeyString(&b, value)
+			}
+		} else {
+			writeColumnAggregateMetadataPredicateAccumulatorKeyString(&b, predicate.Value)
+		}
+	}
+	return b.String()
+}
+
+func writeColumnAggregateMetadataPredicateAccumulatorKeyString(b *strings.Builder, value string) {
+	b.WriteString(strconv.Itoa(len(value)))
+	b.WriteByte(':')
+	b.WriteString(value)
+	b.WriteByte(';')
 }
 
 func newColumnAggregateMetadataAccumulators(specs []columnAggregateMetadataBuildSpec) ([]columnAggregateMetadataAccumulator, []int) {
@@ -486,64 +520,207 @@ func (spec columnAggregateMetadataBuildSpec) accumulatorKey() columnAggregateMet
 		kind = columnAggregateMetadataAccumulatorMinMax
 	}
 	return columnAggregateMetadataAccumulatorKey{
-		kind:     kind,
-		groupIdx: spec.groupIdx,
-		valueIdx: spec.valueIdx,
+		kind:         kind,
+		groupIdx:     spec.groupIdx,
+		valueIdx:     spec.valueIdx,
+		predicateKey: spec.predicateKey,
 	}
 }
 
 func buildColumnAggregateMetadataEntriesForSpecs(specs []columnAggregateMetadataBuildSpec, rows []columnDeclaredRow, rowsPerMetadataEntrySet int) ([][]columnAggregateMetadataEntry, error) {
+	if rowsPerMetadataEntrySet <= 0 {
+		return nil, errors.New("collections: aggregate metadata rows per entry set must be positive")
+	}
+	entrySets := columnAggregateMetadataEntrySetCount(len(rows), rowsPerMetadataEntrySet)
+	workers := columnAggregateMetadataEntrySetWorkerCount(entrySets)
+	if workers > 1 {
+		return buildColumnAggregateMetadataEntriesForSpecsParallel(specs, rows, rowsPerMetadataEntrySet, entrySets, workers)
+	}
 	entriesBySpec := make([][]columnAggregateMetadataEntry, len(specs))
 	for start := 0; start < len(rows); start += rowsPerMetadataEntrySet {
 		end := start + rowsPerMetadataEntrySet
 		if end > len(rows) {
 			end = len(rows)
 		}
-		accumulators, specAccumulatorIdx := newColumnAggregateMetadataAccumulators(specs)
-		for _, row := range rows[start:end] {
-			if row.Deleted {
-				continue
-			}
-			for idx := range accumulators {
-				if err := accumulators[idx].spec.appendRow(accumulators[idx].entries, row); err != nil {
-					return nil, err
-				}
-			}
+		entrySet, err := buildColumnAggregateMetadataEntrySetForSpecs(specs, rows[start:end])
+		if err != nil {
+			return nil, err
 		}
 		for idx := range specs {
-			entriesBySpec[idx] = append(entriesBySpec[idx], sortedColumnAggregateMetadataEntries(accumulators[specAccumulatorIdx[idx]].entries)...)
+			entriesBySpec[idx] = append(entriesBySpec[idx], entrySet[idx]...)
 		}
 	}
 	return entriesBySpec, nil
 }
 
 func buildColumnAggregateMetadataEntriesForSpecsByRowOrder(specs []columnAggregateMetadataBuildSpec, rows []columnDeclaredRow, order []int, rowsPerMetadataEntrySet int) ([][]columnAggregateMetadataEntry, error) {
+	if rowsPerMetadataEntrySet <= 0 {
+		return nil, errors.New("collections: aggregate metadata rows per entry set must be positive")
+	}
+	entrySets := columnAggregateMetadataEntrySetCount(len(order), rowsPerMetadataEntrySet)
+	workers := columnAggregateMetadataEntrySetWorkerCount(entrySets)
+	if workers > 1 {
+		return buildColumnAggregateMetadataEntriesForSpecsByRowOrderParallel(specs, rows, order, rowsPerMetadataEntrySet, entrySets, workers)
+	}
 	entriesBySpec := make([][]columnAggregateMetadataEntry, len(specs))
 	for start := 0; start < len(order); start += rowsPerMetadataEntrySet {
 		end := start + rowsPerMetadataEntrySet
 		if end > len(order) {
 			end = len(order)
 		}
-		accumulators, specAccumulatorIdx := newColumnAggregateMetadataAccumulators(specs)
-		for _, rowIdx := range order[start:end] {
-			row := rows[rowIdx]
-			if row.Deleted {
-				continue
-			}
-			for idx := range accumulators {
-				if err := accumulators[idx].spec.appendRow(accumulators[idx].entries, row); err != nil {
-					return nil, err
-				}
-			}
+		entrySet, err := buildColumnAggregateMetadataEntrySetForSpecsByRowOrder(specs, rows, order[start:end])
+		if err != nil {
+			return nil, err
 		}
 		for idx := range specs {
-			entriesBySpec[idx] = append(entriesBySpec[idx], sortedColumnAggregateMetadataEntries(accumulators[specAccumulatorIdx[idx]].entries)...)
+			entriesBySpec[idx] = append(entriesBySpec[idx], entrySet[idx]...)
 		}
 	}
 	return entriesBySpec, nil
 }
 
+type columnAggregateMetadataEntrySetResult struct {
+	entriesBySpec [][]columnAggregateMetadataEntry
+	err           error
+}
+
+func columnAggregateMetadataEntrySetCount(rows, rowsPerMetadataEntrySet int) int {
+	if rows <= 0 || rowsPerMetadataEntrySet <= 0 {
+		return 0
+	}
+	return (rows + rowsPerMetadataEntrySet - 1) / rowsPerMetadataEntrySet
+}
+
+func columnAggregateMetadataEntrySetWorkerCount(entrySets int) int {
+	if entrySets < 2 {
+		return 1
+	}
+	workers := runtime.GOMAXPROCS(0)
+	if workers > 8 {
+		workers = 8
+	}
+	if workers > entrySets {
+		workers = entrySets
+	}
+	if workers < 1 {
+		return 1
+	}
+	return workers
+}
+
+func columnAggregateMetadataEntrySetRange(setIdx, rows, rowsPerMetadataEntrySet int) (int, int) {
+	start := setIdx * rowsPerMetadataEntrySet
+	end := start + rowsPerMetadataEntrySet
+	if end > rows {
+		end = rows
+	}
+	return start, end
+}
+
+func buildColumnAggregateMetadataEntriesForSpecsParallel(specs []columnAggregateMetadataBuildSpec, rows []columnDeclaredRow, rowsPerMetadataEntrySet, entrySets, workers int) ([][]columnAggregateMetadataEntry, error) {
+	results := make([]columnAggregateMetadataEntrySetResult, entrySets)
+	jobs := make(chan int)
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for workerIdx := 0; workerIdx < workers; workerIdx++ {
+		go func() {
+			defer wg.Done()
+			for setIdx := range jobs {
+				start, end := columnAggregateMetadataEntrySetRange(setIdx, len(rows), rowsPerMetadataEntrySet)
+				results[setIdx].entriesBySpec, results[setIdx].err = buildColumnAggregateMetadataEntrySetForSpecs(specs, rows[start:end])
+			}
+		}()
+	}
+	for setIdx := 0; setIdx < entrySets; setIdx++ {
+		jobs <- setIdx
+	}
+	close(jobs)
+	wg.Wait()
+	return mergeColumnAggregateMetadataEntrySetResults(specs, results)
+}
+
+func buildColumnAggregateMetadataEntriesForSpecsByRowOrderParallel(specs []columnAggregateMetadataBuildSpec, rows []columnDeclaredRow, order []int, rowsPerMetadataEntrySet, entrySets, workers int) ([][]columnAggregateMetadataEntry, error) {
+	results := make([]columnAggregateMetadataEntrySetResult, entrySets)
+	jobs := make(chan int)
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for workerIdx := 0; workerIdx < workers; workerIdx++ {
+		go func() {
+			defer wg.Done()
+			for setIdx := range jobs {
+				start, end := columnAggregateMetadataEntrySetRange(setIdx, len(order), rowsPerMetadataEntrySet)
+				results[setIdx].entriesBySpec, results[setIdx].err = buildColumnAggregateMetadataEntrySetForSpecsByRowOrder(specs, rows, order[start:end])
+			}
+		}()
+	}
+	for setIdx := 0; setIdx < entrySets; setIdx++ {
+		jobs <- setIdx
+	}
+	close(jobs)
+	wg.Wait()
+	return mergeColumnAggregateMetadataEntrySetResults(specs, results)
+}
+
+func mergeColumnAggregateMetadataEntrySetResults(specs []columnAggregateMetadataBuildSpec, results []columnAggregateMetadataEntrySetResult) ([][]columnAggregateMetadataEntry, error) {
+	entriesBySpec := make([][]columnAggregateMetadataEntry, len(specs))
+	for setIdx := range results {
+		if results[setIdx].err != nil {
+			return nil, results[setIdx].err
+		}
+		for specIdx := range specs {
+			entriesBySpec[specIdx] = append(entriesBySpec[specIdx], results[setIdx].entriesBySpec[specIdx]...)
+		}
+	}
+	return entriesBySpec, nil
+}
+
+func buildColumnAggregateMetadataEntrySetForSpecs(specs []columnAggregateMetadataBuildSpec, rows []columnDeclaredRow) ([][]columnAggregateMetadataEntry, error) {
+	accumulators, specAccumulatorIdx := newColumnAggregateMetadataAccumulators(specs)
+	for _, row := range rows {
+		if row.Deleted {
+			continue
+		}
+		for idx := range accumulators {
+			if err := accumulators[idx].spec.appendRow(accumulators[idx].entries, row); err != nil {
+				return nil, err
+			}
+		}
+	}
+	return sortedColumnAggregateMetadataEntriesBySpec(specs, accumulators, specAccumulatorIdx), nil
+}
+
+func buildColumnAggregateMetadataEntrySetForSpecsByRowOrder(specs []columnAggregateMetadataBuildSpec, rows []columnDeclaredRow, order []int) ([][]columnAggregateMetadataEntry, error) {
+	accumulators, specAccumulatorIdx := newColumnAggregateMetadataAccumulators(specs)
+	for _, rowIdx := range order {
+		row := rows[rowIdx]
+		if row.Deleted {
+			continue
+		}
+		for idx := range accumulators {
+			if err := accumulators[idx].spec.appendRow(accumulators[idx].entries, row); err != nil {
+				return nil, err
+			}
+		}
+	}
+	return sortedColumnAggregateMetadataEntriesBySpec(specs, accumulators, specAccumulatorIdx), nil
+}
+
+func sortedColumnAggregateMetadataEntriesBySpec(specs []columnAggregateMetadataBuildSpec, accumulators []columnAggregateMetadataAccumulator, specAccumulatorIdx []int) [][]columnAggregateMetadataEntry {
+	entriesByAccumulator := make([][]columnAggregateMetadataEntry, len(accumulators))
+	for idx := range accumulators {
+		entriesByAccumulator[idx] = sortedColumnAggregateMetadataEntries(accumulators[idx].entries)
+	}
+	entriesBySpec := make([][]columnAggregateMetadataEntry, len(specs))
+	for idx := range specs {
+		entriesBySpec[idx] = entriesByAccumulator[specAccumulatorIdx[idx]]
+	}
+	return entriesBySpec
+}
+
 func buildColumnAggregateMetadataEntriesForSpec(spec columnAggregateMetadataBuildSpec, rows []columnDeclaredRow, rowsPerMetadataEntrySet int) ([]columnAggregateMetadataEntry, error) {
+	if rowsPerMetadataEntrySet <= 0 {
+		return nil, errors.New("collections: aggregate metadata rows per entry set must be positive")
+	}
 	entries := make([]columnAggregateMetadataEntry, 0)
 	for start := 0; start < len(rows); start += rowsPerMetadataEntrySet {
 		end := start + rowsPerMetadataEntrySet

--- a/TreeDB/collections/column_aggregate_metadata_asset.go
+++ b/TreeDB/collections/column_aggregate_metadata_asset.go
@@ -466,19 +466,28 @@ func columnAggregateMetadataPredicateAccumulatorKey(predicates []ColumnPhysicalQ
 		return ""
 	}
 	var b strings.Builder
+	writeColumnAggregateMetadataPredicateAccumulatorKeyInt(&b, len(predicates))
 	for _, predicate := range predicates {
 		kind := columnPhysicalQueryPredicateKindOrDefault(predicate.Kind)
 		writeColumnAggregateMetadataPredicateAccumulatorKeyString(&b, predicate.Column)
 		writeColumnAggregateMetadataPredicateAccumulatorKeyString(&b, string(kind))
 		if kind == ColumnPhysicalQueryPredicateInList {
+			writeColumnAggregateMetadataPredicateAccumulatorKeyInt(&b, len(predicate.Values))
 			for _, value := range predicate.Values {
 				writeColumnAggregateMetadataPredicateAccumulatorKeyString(&b, value)
 			}
 		} else {
+			writeColumnAggregateMetadataPredicateAccumulatorKeyInt(&b, 1)
 			writeColumnAggregateMetadataPredicateAccumulatorKeyString(&b, predicate.Value)
 		}
 	}
 	return b.String()
+}
+
+func writeColumnAggregateMetadataPredicateAccumulatorKeyInt(b *strings.Builder, value int) {
+	b.WriteByte('#')
+	b.WriteString(strconv.Itoa(value))
+	b.WriteByte(';')
 }
 
 func writeColumnAggregateMetadataPredicateAccumulatorKeyString(b *strings.Builder, value string) {

--- a/TreeDB/collections/column_aggregate_metadata_asset_3121_test.go
+++ b/TreeDB/collections/column_aggregate_metadata_asset_3121_test.go
@@ -146,6 +146,32 @@ func TestAggregateMetadataAssetsPredicateAccumulatorsRemainSeparate3235(t *testi
 	}
 }
 
+func TestColumnAggregateMetadataPredicateAccumulatorKeySeparatesInListBoundaries3236(t *testing.T) {
+	broadInList := []ColumnPhysicalQueryPredicate{{
+		Column: "a_col",
+		Kind:   ColumnPhysicalQueryPredicateInList,
+		Values: []string{"a", "b", string(ColumnPhysicalQueryPredicateEqual), "z"},
+	}}
+	inListAndEqual := []ColumnPhysicalQueryPredicate{
+		{
+			Column: "a_col",
+			Kind:   ColumnPhysicalQueryPredicateInList,
+			Values: []string{"a"},
+		},
+		{
+			Column: "b",
+			Kind:   ColumnPhysicalQueryPredicateEqual,
+			Value:  "z",
+		},
+	}
+
+	broadKey := columnAggregateMetadataPredicateAccumulatorKey(broadInList)
+	narrowKey := columnAggregateMetadataPredicateAccumulatorKey(inListAndEqual)
+	if broadKey == narrowKey {
+		t.Fatalf("ambiguous predicate accumulator keys: %q", broadKey)
+	}
+}
+
 func TestAggregateMetadataAssetsTypedGranuleParallelRowOrderWithPredicatesMatchesSequential3235(t *testing.T) {
 	oldProcs := runtime.GOMAXPROCS(2)
 	defer runtime.GOMAXPROCS(oldProcs)

--- a/TreeDB/collections/column_aggregate_metadata_asset_3121_test.go
+++ b/TreeDB/collections/column_aggregate_metadata_asset_3121_test.go
@@ -3,6 +3,7 @@ package collections
 import (
 	"bytes"
 	"reflect"
+	"runtime"
 	"testing"
 )
 
@@ -73,7 +74,131 @@ func TestAggregateMetadataAssetsTypedGranulePrecomputedOrderMatchesFallback3175(
 	assertColumnAggregateMetadataAssetsEqual3121(t, got, want)
 }
 
-func TestAggregateMetadataAssetsFallbackForPredicateAggregates3121(t *testing.T) {
+func TestAggregateMetadataAssetsTypedGranulePrecomputedOrderWithPredicatesMatchesSequential3235(t *testing.T) {
+	cfg := aggregateMetadataBatchConfig3121()
+	cfg.SortKey = []ColumnSortKey{{Column: "time_us"}}
+	cfg.AssetManager = &ColumnAssetManagerConfig{Namespace: "events/column-assets"}
+	for idx := range cfg.Columns {
+		cfg.Columns[idx].Path = cfg.Columns[idx].Name
+		cfg.Columns[idx].Owner = TypedStorageOwnerColumnPart
+	}
+	cfg.AggregateMetadata = []ColumnAggregateMetadata{{
+		Name:        "like_time_min",
+		Column:      "time_us",
+		GroupColumn: "did",
+		Kind:        ColumnAggregateMin,
+		Predicates:  []ColumnPhysicalQueryPredicate{{Column: "kind", Value: "like"}},
+	}}
+	rows := append([]columnDeclaredRow(nil), aggregateMetadataBatchRows3121()[:3]...)
+
+	typedPart, err := buildTypedColumnPartImageForDeclaredRowsWithResult(cfg, 7, typedColumnPartAssetPartID, rows)
+	if err != nil {
+		t.Fatalf("buildTypedColumnPartImageForDeclaredRowsWithResult: %v", err)
+	}
+	if want := []int{1, 0, 2}; !reflect.DeepEqual(typedPart.TypedGranuleRowOrder, want) {
+		t.Fatalf("typed granule row order=%v want %v", typedPart.TypedGranuleRowOrder, want)
+	}
+
+	got, err := buildColumnAggregateMetadataAssetsWithOptions(cfg, rows, cfg.AggregateMetadata, "events", "events/column-assets", 7, 11, 13, columnAggregateMetadataAssetBuildOptions{
+		TypedGranuleRowOrder: typedPart.TypedGranuleRowOrder,
+	})
+	if err != nil {
+		t.Fatalf("buildColumnAggregateMetadataAssetsWithOptions: %v", err)
+	}
+	want := buildColumnAggregateMetadataAssetsSequential3121(t, cfg, rows, cfg.AggregateMetadata)
+	assertColumnAggregateMetadataAssetsEqual3121(t, got, want)
+}
+
+func TestAggregateMetadataAssetsPredicateAccumulatorsRemainSeparate3235(t *testing.T) {
+	cfg := aggregateMetadataBatchConfig3121()
+	cfg.AggregateMetadata = []ColumnAggregateMetadata{
+		{
+			Name:        "like_time_min",
+			Column:      "time_us",
+			GroupColumn: "did",
+			Kind:        ColumnAggregateMin,
+			Predicates:  []ColumnPhysicalQueryPredicate{{Column: "kind", Value: "like"}},
+		},
+		{
+			Name:        "post_time_min",
+			Column:      "time_us",
+			GroupColumn: "did",
+			Kind:        ColumnAggregateMin,
+			Predicates:  []ColumnPhysicalQueryPredicate{{Column: "kind", Value: "post"}},
+		},
+	}
+	rows := aggregateMetadataBatchRows3121()
+
+	got, err := buildColumnAggregateMetadataAssets(cfg, rows, cfg.AggregateMetadata, "events", "events/column-assets", 7, 11, 13)
+	if err != nil {
+		t.Fatalf("buildColumnAggregateMetadataAssets: %v", err)
+	}
+	want := buildColumnAggregateMetadataAssetsSequential3121(t, cfg, rows, cfg.AggregateMetadata)
+	assertColumnAggregateMetadataAssetsEqual3121(t, got, want)
+	if gotLen, wantLen := len(got), 2; gotLen != wantLen {
+		t.Fatalf("got %d assets want %d", gotLen, wantLen)
+	}
+	if got[0].Entries[0].Group != "did:alpha" || got[0].Entries[0].Min != 10 || got[0].Entries[0].Max != 20 {
+		t.Fatalf("like aggregate entries=%+v", got[0].Entries)
+	}
+	if got[1].Entries[0].Group != "did:beta" || got[1].Entries[0].Min != 5 || got[1].Entries[0].Max != 5 {
+		t.Fatalf("post aggregate entries=%+v", got[1].Entries)
+	}
+}
+
+func TestAggregateMetadataAssetsTypedGranuleParallelRowOrderWithPredicatesMatchesSequential3235(t *testing.T) {
+	oldProcs := runtime.GOMAXPROCS(2)
+	defer runtime.GOMAXPROCS(oldProcs)
+	cfg := aggregateMetadataBatchConfig3121()
+	for idx := range cfg.Columns {
+		cfg.Columns[idx].Owner = TypedStorageOwnerColumnPart
+	}
+	cfg.AggregateMetadata = []ColumnAggregateMetadata{
+		{
+			Name:        "like_time_min",
+			Column:      "time_us",
+			GroupColumn: "did",
+			Kind:        ColumnAggregateMin,
+			Predicates:  []ColumnPhysicalQueryPredicate{{Column: "kind", Value: "like"}},
+		},
+		{
+			Name:        "post_time_min",
+			Column:      "time_us",
+			GroupColumn: "did",
+			Kind:        ColumnAggregateMin,
+			Predicates:  []ColumnPhysicalQueryPredicate{{Column: "kind", Value: "post"}},
+		},
+	}
+	rows := make([]columnDeclaredRow, typedColumnDefaultRowsPerGranule()+3)
+	order := make([]int, len(rows))
+	for idx := range rows {
+		kind := "like"
+		if idx%3 == 0 {
+			kind = "post"
+		}
+		rows[idx] = columnDeclaredRow{ID: []byte("row"), Values: []columnDeclaredValue{
+			{Type: ColumnStoreValueInt64, Present: true, Int64: int64(idx)},
+			{Type: ColumnStoreValueString, Present: true, String: kind},
+			{Type: ColumnStoreValueString, Present: true, String: "did"},
+		}}
+		order[idx] = idx
+	}
+	entrySets := columnAggregateMetadataEntrySetCount(len(rows), typedColumnDefaultRowsPerGranule())
+	if workers := columnAggregateMetadataEntrySetWorkerCount(entrySets); workers < 2 {
+		t.Fatalf("worker count=%d want parallel path for entry_sets=%d", workers, entrySets)
+	}
+
+	got, err := buildColumnAggregateMetadataAssetsWithOptions(cfg, rows, cfg.AggregateMetadata, "events", "events/column-assets", 7, 11, 13, columnAggregateMetadataAssetBuildOptions{
+		TypedGranuleRowOrder: order,
+	})
+	if err != nil {
+		t.Fatalf("buildColumnAggregateMetadataAssetsWithOptions: %v", err)
+	}
+	want := buildColumnAggregateMetadataAssetsSequential3121(t, cfg, rows, cfg.AggregateMetadata)
+	assertColumnAggregateMetadataAssetsEqual3121(t, got, want)
+}
+
+func TestAggregateMetadataAssetsPredicateAggregatesMatchSequential3121(t *testing.T) {
 	cfg := aggregateMetadataBatchConfig3121()
 	cfg.AggregateMetadata = []ColumnAggregateMetadata{{
 		Name:        "post_time_min",

--- a/TreeDB/collections/typed_storage_naming_test.go
+++ b/TreeDB/collections/typed_storage_naming_test.go
@@ -333,7 +333,7 @@ type typedStorageLegacyNameAllowlistEntry struct {
 var typedStorageLegacyNameAllowlist = []typedStorageLegacyNameAllowlistEntry{
 	{path: "TreeDB/collections/api.go", classification: typedStorageLegacyCompatibility, matchingLines: 60, occurrences: 66},
 	{path: "TreeDB/collections/column_aggregate_metadata_asset.go", classification: typedStorageLegacyDerived, matchingLines: 22, occurrences: 24},
-	{path: "TreeDB/collections/column_aggregate_metadata_asset_3121_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 22, occurrences: 22},
+	{path: "TreeDB/collections/column_aggregate_metadata_asset_3121_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 25, occurrences: 25},
 	{path: "TreeDB/collections/column_aggregate_metadata_predicate.go", classification: typedStorageLegacyDerived, matchingLines: 6, occurrences: 6},
 	{path: "TreeDB/collections/column_aggregate_metadata_predicate_1951_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 77, occurrences: 78},
 	{path: "TreeDB/collections/column_aggregate_metadata_typed_column_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 19, occurrences: 21},

--- a/TreeDB/internal/memtable/append_only_pool_test.go
+++ b/TreeDB/internal/memtable/append_only_pool_test.go
@@ -116,11 +116,17 @@ func TestAppendOnlyEntryPoolStatsTrackRetainedBacking(t *testing.T) {
 	if cap(got) != cap(entries) {
 		t.Fatalf("pooled cap=%d want %d", cap(got), cap(entries))
 	}
-	if gotRetained := afterGet.RetainedBytesEstimate; gotRetained != 0 {
-		t.Fatalf("retained bytes after get=%d want 0", gotRetained)
-	}
-	if gotGets := afterGet.GetsTotal; gotGets != before.GetsTotal+1 {
-		t.Fatalf("gets total=%d want %d", gotGets, before.GetsTotal+1)
+	switch gotGets := afterGet.GetsTotal; gotGets {
+	case before.GetsTotal + 1:
+		if gotRetained := afterGet.RetainedBytesEstimate; gotRetained != 0 {
+			t.Fatalf("retained bytes after pooled get=%d want 0", gotRetained)
+		}
+	case before.GetsTotal:
+		if gotRetained := afterGet.RetainedBytesEstimate; gotRetained != wantBytes {
+			t.Fatalf("retained bytes after sync.Pool miss=%d want estimate %d", gotRetained, wantBytes)
+		}
+	default:
+		t.Fatalf("gets total=%d want %d or %d", gotGets, before.GetsTotal, before.GetsTotal+1)
 	}
 
 	putAppendOnlyEntries(got)


### PR DESCRIPTION
## Summary

- Keep predicate-qualified aggregate metadata on the typed-granule row-order build path by keying accumulator sharing with canonical predicate coverage.
- Include explicit predicate and value counts in the accumulator key so in-list boundaries cannot collide with additional predicates.
- Build aggregate metadata entry sets with a bounded worker pool, then merge results back in entry-set order before encoding assets.
- Add regression coverage for predicate separation, ambiguous in-list key boundaries, typed-granule row order with predicates, and the parallel row-order path.
- Harden an existing append-only memtable pool stats test for `sync.Pool` misses under the full race package run; this is test-only and was added after CI reproduced the failure on the PR and `main` with repeated local runs.

The aggregate metadata work is a load/publish preparation improvement. It does not claim a q5 query-speed win, does not change asset encoding, and does not weaken durability boundaries.

## Evidence

Baseline current `main` after #3234:
`/tmp/jsonbench_main_after3234_aggmeta_baseline_1m_20260628_133850/report.json`

Candidate:
`/tmp/jsonbench_aggmeta_predicate_roworder_q5_1m_20260628_134716/report.json`

Both runs: 1M rows, `column-store-full-prepared`, `one_shot_end_to_end`, `no_aggregate_metadata`, q5.

| metric | baseline | candidate |
| --- | ---: | ---: |
| load | 11.837581329s | 10.580763984s |
| insert | 7.357791344s | 6.362185477s |
| column publish asset preparation | 4.276851908s | 3.360546691s |
| aggregate metadata prepare | 1.135177670s | 0.145293519s |
| aggregate metadata storage bytes | 5,860,282 | 5,860,282 |
| q5 total query | 40.482083ms | 40.783280ms |
| q5 prepare/setup | 28.776777ms | 27.073981ms |
| q5 run | 11.676206ms | 13.671103ms |

## Validation

```sh
GOWORK=off go test ./TreeDB/collections -run 'TestAggregateMetadataAssets.*3121|TestAggregateMetadataAssets.*3235|TestColumnAggregateMetadataPredicateAccumulatorKeySeparatesInListBoundaries3236|TestPredicateQualifiedAggregateMetadataBuildsPerTypedGranule1951|TestPredicateQualifiedAggregateMetadataQ4Q5DirectPrepared1951|TestPredicateQualifiedAggregateMetadataQ3GroupHourDirectPrepared2892|TestColumnRowSidecarAssets|TestColumnStoreCompactRebuildsAggregateMetadata1953|TestTypedStorageLegacyNameAllowlistIsComplete' -count=1
GOWORK=off go test ./TreeDB/collections
GOWORK=off go test ./cmd/unified_bench
GOWORK=off go test ./TreeDB/collections -race -run 'TestAggregateMetadataAssets.*3235|TestColumnAggregateMetadataPredicateAccumulatorKeySeparatesInListBoundaries3236' -count=1
GOWORK=off go test ./TreeDB/internal/memtable -race -run TestAppendOnlyEntryPoolStatsTrackRetainedBacking -count=1
GOWORK=off go test ./TreeDB/internal/memtable -race -count=5
```

Refs #3099, #3067, #3151, #3070, #3000.
