### PR TITLE
TreeDB: drop pooled append-only entry backing

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -8061,6 +8061,8 @@ type DB struct {
 	appendOnlyMemLeases              []*memtable.AppendOnly
 	appendOnlyMemLeaseHitTotal       atomic.Uint64
 	appendOnlyMemPoolHitTotal        atomic.Uint64
+	appendOnlyMemPoolPutTotal        atomic.Uint64
+	appendOnlyMemPoolEntryDropBytes  atomic.Uint64
 	appendOnlyMemNewAllocTotal       atomic.Uint64
 	appendOnlyMemNewAllocWithQueue   atomic.Uint64
 	appendOnlyMemNewAllocQueueBytes  atomic.Uint64
@@ -10023,6 +10025,20 @@ func (db *DB) putAppendOnlyMemLease(mt *memtable.AppendOnly) bool {
 	return true
 }
 
+func (db *DB) putAppendOnlyMemPoolDropEntries(mt *memtable.AppendOnly) {
+	if db == nil || mt == nil {
+		return
+	}
+	if before := mt.EntryBackingBytes(); before > 0 {
+		db.appendOnlyMemPoolEntryDropBytes.Add(uint64(before))
+	}
+	mt.ReleaseDropEntries()
+	if pool := db.appendOnlyMemtablePool(); pool != nil {
+		db.appendOnlyMemPoolPutTotal.Add(1)
+		pool.Put(mt)
+	}
+}
+
 func (db *DB) recycleMemtables(mems []memtable.Table) {
 	if db == nil || len(mems) == 0 {
 		return
@@ -10042,9 +10058,7 @@ func (db *DB) recycleMemtables(mems []memtable.Table) {
 			typed.ResetWithCapacityHard(appendOnlyResetCapacity, estimate)
 			db.releaseAppendOnlyDirectArenaLeaseForMemtableWithPolicy(typed, true)
 			if !db.putAppendOnlyMemLease(typed) {
-				if pool := db.appendOnlyMemtablePool(); pool != nil {
-					pool.Put(typed)
-				}
+				db.putAppendOnlyMemPoolDropEntries(typed)
 			}
 		}
 	}
@@ -10082,10 +10096,7 @@ func (db *DB) trimAppendOnlyMemLeases(maxLeases int, _ int) int {
 		if dropped[i] != nil {
 			if retainAppendOnly {
 				db.releaseAppendOnlyDirectArenaLeaseForMemtableWithPolicy(dropped[i], true)
-				dropped[i].ReleaseDropEntries()
-				if pool := db.appendOnlyMemtablePool(); pool != nil {
-					pool.Put(dropped[i])
-				}
+				db.putAppendOnlyMemPoolDropEntries(dropped[i])
 			} else {
 				db.releaseAppendOnlyDirectArenaLeaseForMemtableWithPolicy(dropped[i], false)
 				dropped[i].ReleaseDropEntries()
@@ -28923,6 +28934,8 @@ func (db *DB) Stats() map[string]string {
 	appendOnlyHintCapacity := appendOnlyEntriesToCapacity(appendOnlyEntryHint, appendOnlyEstimatedBytesPerEntryDefault)
 	appendOnlyMemLeaseHitTotal := db.appendOnlyMemLeaseHitTotal.Load()
 	appendOnlyMemPoolHitTotal := db.appendOnlyMemPoolHitTotal.Load()
+	appendOnlyMemPoolPutTotal := db.appendOnlyMemPoolPutTotal.Load()
+	appendOnlyMemPoolEntryDropBytes := db.appendOnlyMemPoolEntryDropBytes.Load()
 	appendOnlyMemNewAllocTotal := db.appendOnlyMemNewAllocTotal.Load()
 	appendOnlyMemNewAllocWithQueue := db.appendOnlyMemNewAllocWithQueue.Load()
 	appendOnlyMemNewAllocQueueBytes := db.appendOnlyMemNewAllocQueueBytes.Load()
@@ -28949,6 +28962,8 @@ func (db *DB) Stats() map[string]string {
 	stats["treedb.cache.append_only.mutable_trim_total"] = fmt.Sprintf("%d", appendOnlyMutableTrimTotal)
 	stats["treedb.cache.append_only.mutable_trim_dropped_bytes_total"] = fmt.Sprintf("%d", appendOnlyMutableTrimDropped)
 	stats["treedb.cache.append_only.mutable_pool_drops_total"] = fmt.Sprintf("%d", appendOnlyMemPoolDropTotal)
+	stats["treedb.cache.append_only.mutable_pool_puts_total"] = fmt.Sprintf("%d", appendOnlyMemPoolPutTotal)
+	stats["treedb.cache.append_only.mutable_pool_entry_backing_dropped_bytes_total"] = fmt.Sprintf("%d", appendOnlyMemPoolEntryDropBytes)
 	stats["treedb.cache.append_only.mutable_from_lease_total"] = fmt.Sprintf("%d", appendOnlyMemLeaseHitTotal)
 	stats["treedb.cache.append_only.mutable_from_pool_total"] = fmt.Sprintf("%d", appendOnlyMemPoolHitTotal)
 	stats["treedb.cache.append_only.mutable_new_alloc_total"] = fmt.Sprintf("%d", appendOnlyMemNewAllocTotal)
@@ -28971,6 +28986,8 @@ func (db *DB) Stats() map[string]string {
 	stats["treedb.process.append_only.mutable_trim_total"] = fmt.Sprintf("%d", appendOnlyMutableTrimTotal)
 	stats["treedb.process.append_only.mutable_trim_dropped_bytes_total"] = fmt.Sprintf("%d", appendOnlyMutableTrimDropped)
 	stats["treedb.process.append_only.mutable_pool_drops_total"] = fmt.Sprintf("%d", appendOnlyMemPoolDropTotal)
+	stats["treedb.process.append_only.mutable_pool_puts_total"] = fmt.Sprintf("%d", appendOnlyMemPoolPutTotal)
+	stats["treedb.process.append_only.mutable_pool_entry_backing_dropped_bytes_total"] = fmt.Sprintf("%d", appendOnlyMemPoolEntryDropBytes)
 	stats["treedb.process.append_only.mutable_from_lease_total"] = fmt.Sprintf("%d", appendOnlyMemLeaseHitTotal)
 	stats["treedb.process.append_only.mutable_from_pool_total"] = fmt.Sprintf("%d", appendOnlyMemPoolHitTotal)
 	stats["treedb.process.append_only.mutable_new_alloc_total"] = fmt.Sprintf("%d", appendOnlyMemNewAllocTotal)

--- a/TreeDB/caching/memory_stats_test.go
+++ b/TreeDB/caching/memory_stats_test.go
@@ -129,6 +129,8 @@ func TestProcessMemoryStatsIncludeRuntimeBreakdown(t *testing.T) {
 		"treedb.process.read_path.snapshot_get_caller.samples_total",
 		"treedb.cache.append_only.mutable_from_lease_total",
 		"treedb.cache.append_only.mutable_from_pool_total",
+		"treedb.cache.append_only.mutable_pool_puts_total",
+		"treedb.cache.append_only.mutable_pool_entry_backing_dropped_bytes_total",
 		"treedb.cache.append_only.mutable_new_alloc_total",
 		"treedb.cache.append_only.entry_pool_retained_bytes_estimate",
 		"treedb.cache.append_only.entry_pool_retained_bytes_max_estimate",
@@ -138,6 +140,8 @@ func TestProcessMemoryStatsIncludeRuntimeBreakdown(t *testing.T) {
 		"treedb.cache.append_only.entry_pool_drop_bytes_total",
 		"treedb.process.append_only.mutable_from_lease_total",
 		"treedb.process.append_only.mutable_from_pool_total",
+		"treedb.process.append_only.mutable_pool_puts_total",
+		"treedb.process.append_only.mutable_pool_entry_backing_dropped_bytes_total",
 		"treedb.process.append_only.mutable_new_alloc_total",
 		"treedb.process.append_only.entry_pool_retained_bytes_estimate",
 		"treedb.process.append_only.entry_pool_retained_bytes_max_estimate",
@@ -163,6 +167,12 @@ func TestProcessMemoryStatsIncludeRuntimeBreakdown(t *testing.T) {
 	}
 	if got := mustStatInt64(t, stats, "treedb.process.append_only.mutable_from_pool_total"); got != mustStatInt64(t, stats, "treedb.cache.append_only.mutable_from_pool_total") {
 		t.Fatalf("append_only pool source mismatch process=%d cache=%d", got, mustStatInt64(t, stats, "treedb.cache.append_only.mutable_from_pool_total"))
+	}
+	if got := mustStatInt64(t, stats, "treedb.process.append_only.mutable_pool_puts_total"); got != mustStatInt64(t, stats, "treedb.cache.append_only.mutable_pool_puts_total") {
+		t.Fatalf("append_only pool puts mismatch process=%d cache=%d", got, mustStatInt64(t, stats, "treedb.cache.append_only.mutable_pool_puts_total"))
+	}
+	if got := mustStatInt64(t, stats, "treedb.process.append_only.mutable_pool_entry_backing_dropped_bytes_total"); got != mustStatInt64(t, stats, "treedb.cache.append_only.mutable_pool_entry_backing_dropped_bytes_total") {
+		t.Fatalf("append_only pool entry backing dropped bytes mismatch process=%d cache=%d", got, mustStatInt64(t, stats, "treedb.cache.append_only.mutable_pool_entry_backing_dropped_bytes_total"))
 	}
 	if got := mustStatInt64(t, stats, "treedb.process.append_only.mutable_new_alloc_total"); got != mustStatInt64(t, stats, "treedb.cache.append_only.mutable_new_alloc_total") {
 		t.Fatalf("append_only new source mismatch process=%d cache=%d", got, mustStatInt64(t, stats, "treedb.cache.append_only.mutable_new_alloc_total"))

--- a/TreeDB/caching/retained_arena_trim_test.go
+++ b/TreeDB/caching/retained_arena_trim_test.go
@@ -142,13 +142,12 @@ func TestRecycleAppendOnlyMemtables_DropsOverflowEntryBackingBeforePool(t *testi
 		t.Fatal("append-only mem pool entry backing dropped bytes=0 want >0")
 	}
 
-	v := db.appendOnlyMemtablePool().Get()
-	mt, ok := v.(*memtable.AppendOnly)
-	if !ok || mt == nil {
-		t.Fatalf("append-only mem pool Get returned %T, want *AppendOnly", v)
+	overflow, ok := mems[maxAppendOnlyMemLeases].(*memtable.AppendOnly)
+	if !ok || overflow == nil {
+		t.Fatalf("overflow memtable is %T, want *AppendOnly", mems[maxAppendOnlyMemLeases])
 	}
-	if got := mt.EntryBackingBytes(); got != 0 {
-		t.Fatalf("pooled append-only entry backing bytes=%d want 0", got)
+	if got := overflow.EntryBackingBytes(); got != 0 {
+		t.Fatalf("overflow append-only entry backing bytes=%d want 0", got)
 	}
 }
 

--- a/TreeDB/caching/retained_arena_trim_test.go
+++ b/TreeDB/caching/retained_arena_trim_test.go
@@ -116,6 +116,42 @@ func TestRecycleAppendOnlyMemtables_DropsColdWhenModeNotAppendOnly(t *testing.T)
 	}
 }
 
+func TestRecycleAppendOnlyMemtables_DropsOverflowEntryBackingBeforePool(t *testing.T) {
+	var db DB
+	db.storeMemtableMode(memtable.ModeAppendOnly)
+
+	const capacityBytes = 4 << 20
+	mems := make([]memtable.Table, 0, maxAppendOnlyMemLeases+1)
+	for i := 0; i < cap(mems); i++ {
+		mt := memtable.NewAppendOnlyWithCapacityEstimatedEntryBytes(capacityBytes, appendOnlyEstimatedBytesPerEntryDefault)
+		if mt.EntryBackingBytes() == 0 {
+			t.Fatal("test setup produced zero append-only entry backing")
+		}
+		mems = append(mems, mt)
+	}
+
+	db.recycleMemtables(mems)
+
+	if got := len(db.appendOnlyMemLeases); got != maxAppendOnlyMemLeases {
+		t.Fatalf("append-only mem leases=%d want %d", got, maxAppendOnlyMemLeases)
+	}
+	if got := db.appendOnlyMemPoolPutTotal.Load(); got != 1 {
+		t.Fatalf("append-only mem pool puts=%d want 1", got)
+	}
+	if got := db.appendOnlyMemPoolEntryDropBytes.Load(); got == 0 {
+		t.Fatal("append-only mem pool entry backing dropped bytes=0 want >0")
+	}
+
+	v := db.appendOnlyMemtablePool().Get()
+	mt, ok := v.(*memtable.AppendOnly)
+	if !ok || mt == nil {
+		t.Fatalf("append-only mem pool Get returned %T, want *AppendOnly", v)
+	}
+	if got := mt.EntryBackingBytes(); got != 0 {
+		t.Fatalf("pooled append-only entry backing bytes=%d want 0", got)
+	}
+}
+
 func TestStoreMemtableMode_DropsAppendOnlyPoolsOnColdTransition(t *testing.T) {
 	var db DB
 	db.storeMemtableMode(memtable.ModeAppendOnly)

--- a/cmd/unified_bench/main.go
+++ b/cmd/unified_bench/main.go
@@ -1641,6 +1641,8 @@ func printTreeDBCacheStats(w io.Writer, inst *DBInstance, prefix string) {
 		"treedb.cache.flush_merge.parallel.shadowed_per_applied",
 		"treedb.cache.append_only.mutable_from_lease_total",
 		"treedb.cache.append_only.mutable_from_pool_total",
+		"treedb.cache.append_only.mutable_pool_puts_total",
+		"treedb.cache.append_only.mutable_pool_entry_backing_dropped_bytes_total",
 		"treedb.cache.append_only.mutable_new_alloc_total",
 		"treedb.cache.append_only.mutable_new_alloc_with_queue_total",
 		"treedb.cache.append_only.mutable_new_alloc_queue_bytes_sum",


### PR DESCRIPTION
## Summary

Refs #3238.

This keeps recycled append-only memtable objects from retaining entry backing when they overflow the explicit bounded memtable lease list and fall back to the DB-local object pool. The hot bounded lease path still retains warm entry backing and remains visible through existing lease stats; overflow object-pool entries now call `ReleaseDropEntries()` before pooling.

The patch also adds stats so Celestia/profile runs can prove the behavior in-process:

- `treedb.cache.append_only.mutable_pool_puts_total`
- `treedb.cache.append_only.mutable_pool_entry_backing_dropped_bytes_total`
- process mirrors for both keys

## Why

Post-#3235 Celestia heap evidence showed `TreeDB/internal/memtable.getAppendOnlyEntries` still at 261.35MB final `inuse_space`, while visible append-only entry-pool, mutable-shard, and mem-lease counters were much lower. One unaccounted retention path was recycled append-only memtable objects parked in `appendOnlyMemPool` with entry backing still attached.

## Celestia Evidence

Protocol for both runs:

- `TRUST_HEIGHT=11714074`
- `TRUST_HASH=AC2679168CE4DCFA9AA7355E52A265A2CA6250C9A9392B3EF3BFACA284B5104E`
- `STOP_AT_LOCAL_HEIGHT=11715650`
- `POST_SYNC_DWELL_SECONDS=300`

TreeDB branch run:

- Home: `/home/mikers/.celestia-app-mainnet-treedb-20260628150527`
- `sync_duration_seconds=270`
- `max_rss_kb=9032624`
- `end_app_bytes=2362626269`
- Final pprof: `/home/mikers/.celestia-app-mainnet-treedb-20260628150527/sync/diagnostics/pprof-heap-max-rss-final-9032624k-20260628151512.top.txt`

Post-#3235 baseline comparison:

- Final `getAppendOnlyEntries`: 261.35MB -> 207.70MB (-53.65MB, -20.5%)
- Captured peak `getAppendOnlyEntries`: 574.47MB -> 470.05MB (-104.42MB, -18.2%)
- Max RSS: 9,254,152 KiB -> 9,032,624 KiB (-221,528 KiB, -2.4%)
- Sync duration: 289s -> 270s (-19s, -6.6%)
- New final application counter: `mutable_pool_entry_backing_dropped_bytes_total=855744960`

Strict LevelDB-vs-TreeDB A/B:

- LevelDB home: `/home/mikers/.celestia-app-mainnet-goleveldb-20260628151631`
- LevelDB `sync_duration_seconds=773`, `max_rss_kb=11365804`, `end_app_bytes=2931679340`
- TreeDB was 2.86x faster by sync duration, 20.5% lower max RSS, and 19.4% smaller by script `end_app_bytes`.

Interpretation: this is a successful incremental reduction, not a full closeout of #3238. Final `getAppendOnlyEntries` remains 207.70MB and should stay tracked for the next iteration.

## Validation

- `GOWORK=off go test ./TreeDB/caching -run 'Test(RecycleAppendOnlyMemtables|TrimAppendOnlyMemLeases|ProcessMemoryStatsIncludeRuntimeBreakdown|SelectTreeDBExpvarStats)'`
- `GOWORK=off go test ./cmd/unified_bench`
- `GOWORK=off go test ./TreeDB/caching -run 'Test(BatchArena|PutBatchArena|CurrentBatchArena|ShouldBorrowBatchArena|ComputeBatchArena|NoteBatchArena)'`
- `GOWORK=off go test ./TreeDB/internal/commitlog -run 'Test(Writer(DeferredCommandBuffer|LargeBatchPayloadBypasses|AppendRawKVBatchPayloadScan)|RawKVBatchPayloadBuilder|CommandWALRawKVBatchScanUsesPayloadBackedViews)'`
- `GOWORK=off go test ./TreeDB/db -run 'Test(RawKVCommandWALIntentUsesDirectEntries|AppendRawKVCommandWALOrderedEntryScanStreamsReplay|TrustedCommandWALIntentAppendsCanonicalCollectionPayload)'`
- `GOWORK=off go test ./TreeDB -run 'TestPublicCommandWALBatch(OrdinarySetBypassesPayloadBuilder|BypassStreamsReplayToCommandWAL|OrdinaryRetainedCapDoesNotGrow|PayloadSoftCap.*|ValueLogPointers.*)'`
- `GOWORK=off go test ./TreeDB/caching`
- `GOWORK=off go test ./TreeDB/caching -run TestRecycleAppendOnlyMemtables_DropsOverflowEntryBackingBeforePool -count=100`
- `GOWORK=off go test -race ./TreeDB/caching -run TestRecycleAppendOnlyMemtables_DropsOverflowEntryBackingBeforePool -count=20`
- `git diff --check`