### PR TITLE
Optimize q2 sorted global rank prep

### DIFF
--- a/TreeDB/collections/column_physical_q2_1950_test.go
+++ b/TreeDB/collections/column_physical_q2_1950_test.go
@@ -259,6 +259,93 @@ func TestTypedColumnQ2DenseGroupCountDistinctRankMapCapacity3158(t *testing.T) {
 	if got, want := columnTypedColumnDenseGroupCountDistinctRankMapCapacity(627_647), 209_215; got != want {
 		t.Fatalf("large rank map capacity=%d want %d", got, want)
 	}
+
+	parts := []columnTypedColumnPhysicalQueryPart{
+		{
+			DenseGroupCountDistinct: &columnTypedColumnDenseGroupCountDistinctPart{
+				Group: columnTypedColumnDenseStringCodeColumn{
+					Dictionary: []string{"app.a", "app.c"},
+					Valid:      []bool{true, false},
+				},
+				Distinct: columnTypedColumnDenseStringCodeColumn{
+					Dictionary: []string{"did:a", "did:c"},
+				},
+			},
+		},
+		{
+			DenseGroupCountDistinct: &columnTypedColumnDenseGroupCountDistinctPart{
+				Group: columnTypedColumnDenseStringCodeColumn{
+					Dictionary: []string{"app.a", "app.b"},
+				},
+				Distinct: columnTypedColumnDenseStringCodeColumn{
+					Dictionary: []string{"did:b", "did:c"},
+				},
+			},
+		},
+	}
+	groupDictionary, groupRanks, err := columnTypedColumnDenseGroupCountDistinctGlobalDictionary(parts, func(part *columnTypedColumnDenseGroupCountDistinctPart) *columnTypedColumnDenseStringCodeColumn {
+		return &part.Group
+	})
+	if err != nil {
+		t.Fatalf("global group dictionary: %v", err)
+	}
+	if want := []string{"", "app.a", "app.b", "app.c"}; !reflect.DeepEqual(groupDictionary, want) {
+		t.Fatalf("global group dictionary=%v want %v", groupDictionary, want)
+	}
+	for rank, value := range groupDictionary {
+		if groupRanks[value] != uint32(rank) {
+			t.Fatalf("group rank[%q]=%d want %d ranks=%v", value, groupRanks[value], rank, groupRanks)
+		}
+	}
+	distinctRanks, distinctCardinality, err := columnTypedColumnDenseGroupCountDistinctGlobalRanks(parts, func(part *columnTypedColumnDenseGroupCountDistinctPart) *columnTypedColumnDenseStringCodeColumn {
+		return &part.Distinct
+	})
+	if err != nil {
+		t.Fatalf("global distinct ranks: %v", err)
+	}
+	if distinctCardinality != 3 {
+		t.Fatalf("distinct cardinality=%d want 3 ranks=%v", distinctCardinality, distinctRanks)
+	}
+	for value, want := range map[string]uint32{"did:a": 0, "did:b": 1, "did:c": 2} {
+		if got := distinctRanks[value]; got != want {
+			t.Fatalf("distinct rank[%q]=%d want %d ranks=%v", value, got, want, distinctRanks)
+		}
+	}
+
+	if err := prepareColumnTypedColumnDenseGroupCountDistinctGlobalRankMaps(parts); err != nil {
+		t.Fatalf("prepare sorted global rank maps: %v", err)
+	}
+	group0 := parts[0].DenseGroupCountDistinct.Group
+	group1 := parts[1].DenseGroupCountDistinct.Group
+	if !reflect.DeepEqual(group0.GlobalDictionary, []string{"", "app.a", "app.b", "app.c"}) {
+		t.Fatalf("part 0 group global dictionary=%v", group0.GlobalDictionary)
+	}
+	if !reflect.DeepEqual(group1.GlobalDictionary, group0.GlobalDictionary) {
+		t.Fatalf("part 1 group global dictionary=%v want %v", group1.GlobalDictionary, group0.GlobalDictionary)
+	}
+	if !reflect.DeepEqual(group0.GlobalLocalRanks, []uint32{1, 3}) {
+		t.Fatalf("part 0 group local ranks=%v want [1 3]", group0.GlobalLocalRanks)
+	}
+	if !reflect.DeepEqual(group1.GlobalLocalRanks, []uint32{1, 2}) {
+		t.Fatalf("part 1 group local ranks=%v want [1 2]", group1.GlobalLocalRanks)
+	}
+	if !group0.GlobalEmptyRankOK || group0.GlobalEmptyRank != 0 || !group1.GlobalEmptyRankOK || group1.GlobalEmptyRank != 0 {
+		t.Fatalf("group empty ranks part0=(%d,%t) part1=(%d,%t) want (0,true)", group0.GlobalEmptyRank, group0.GlobalEmptyRankOK, group1.GlobalEmptyRank, group1.GlobalEmptyRankOK)
+	}
+	distinct0 := parts[0].DenseGroupCountDistinct.Distinct
+	distinct1 := parts[1].DenseGroupCountDistinct.Distinct
+	if distinct0.GlobalDictionary != nil || distinct1.GlobalDictionary != nil {
+		t.Fatalf("distinct global dictionary allocated part0=%v part1=%v", distinct0.GlobalDictionary, distinct1.GlobalDictionary)
+	}
+	if distinct0.GlobalCardinality != 3 || distinct1.GlobalCardinality != 3 || !distinct0.GlobalCardinalityOK || !distinct1.GlobalCardinalityOK {
+		t.Fatalf("distinct cardinality part0=(%d,%t) part1=(%d,%t) want (3,true)", distinct0.GlobalCardinality, distinct0.GlobalCardinalityOK, distinct1.GlobalCardinality, distinct1.GlobalCardinalityOK)
+	}
+	if !reflect.DeepEqual(distinct0.GlobalLocalRanks, []uint32{0, 2}) {
+		t.Fatalf("part 0 distinct local ranks=%v want [0 2]", distinct0.GlobalLocalRanks)
+	}
+	if !reflect.DeepEqual(distinct1.GlobalLocalRanks, []uint32{1, 2}) {
+		t.Fatalf("part 1 distinct local ranks=%v want [1 2]", distinct1.GlobalLocalRanks)
+	}
 }
 
 func TestTypedColumnQ2DenseGroupCountDistinctActiveGroupBitset1950(t *testing.T) {

--- a/TreeDB/collections/column_physical_typed_column_query.go
+++ b/TreeDB/collections/column_physical_typed_column_query.go
@@ -13,7 +13,10 @@ import (
 	"time"
 )
 
-const columnTypedColumnDenseGroupCountDistinctMaxBitsetWords = 2 << 20
+const (
+	columnTypedColumnDenseGroupCountDistinctMaxBitsetWords      = 2 << 20
+	columnTypedColumnDenseGroupCountDistinctSortedMergeMaxParts = 32
+)
 
 const (
 	columnTypedColumnDenseGroupCountDistinctReducerPairBitset   = "pair_bitset"
@@ -1230,6 +1233,17 @@ func columnTypedColumnDenseGroupCountDistinctGlobalDictionary(parts []columnType
 	if err != nil {
 		return nil, nil, err
 	}
+	dictionary, ranks, ok, err := columnTypedColumnDenseGroupCountDistinctSortedGlobalRanks(parts, selectColumn, capacity, true)
+	if err != nil {
+		return nil, nil, err
+	}
+	if ok {
+		return dictionary, ranks, nil
+	}
+	return columnTypedColumnDenseGroupCountDistinctGlobalDictionaryMap(parts, selectColumn, capacity)
+}
+
+func columnTypedColumnDenseGroupCountDistinctGlobalDictionaryMap(parts []columnTypedColumnPhysicalQueryPart, selectColumn func(*columnTypedColumnDenseGroupCountDistinctPart) *columnTypedColumnDenseStringCodeColumn, capacity int) ([]string, map[string]uint32, error) {
 	values := make(map[string]struct{}, capacity)
 	for partIdx := range parts {
 		part := parts[partIdx].DenseGroupCountDistinct
@@ -1267,8 +1281,18 @@ func columnTypedColumnDenseGroupCountDistinctGlobalRanks(parts []columnTypedColu
 	if err != nil {
 		return nil, 0, err
 	}
-	capacity = columnTypedColumnDenseGroupCountDistinctRankMapCapacity(capacity)
-	ranks := make(map[string]uint32, capacity)
+	_, ranks, ok, err := columnTypedColumnDenseGroupCountDistinctSortedGlobalRanks(parts, selectColumn, capacity, false)
+	if err != nil {
+		return nil, 0, err
+	}
+	if ok {
+		return ranks, len(ranks), nil
+	}
+	return columnTypedColumnDenseGroupCountDistinctGlobalRanksMap(parts, selectColumn, capacity)
+}
+
+func columnTypedColumnDenseGroupCountDistinctGlobalRanksMap(parts []columnTypedColumnPhysicalQueryPart, selectColumn func(*columnTypedColumnDenseGroupCountDistinctPart) *columnTypedColumnDenseStringCodeColumn, capacity int) (map[string]uint32, int, error) {
+	ranks := make(map[string]uint32, columnTypedColumnDenseGroupCountDistinctRankMapCapacity(capacity))
 	addValue := func(value string) error {
 		if _, ok := ranks[value]; ok {
 			return nil
@@ -1300,6 +1324,85 @@ func columnTypedColumnDenseGroupCountDistinctGlobalRanks(parts []columnTypedColu
 		}
 	}
 	return ranks, len(ranks), nil
+}
+
+func columnTypedColumnDenseGroupCountDistinctSortedGlobalRanks(parts []columnTypedColumnPhysicalQueryPart, selectColumn func(*columnTypedColumnDenseGroupCountDistinctPart) *columnTypedColumnDenseStringCodeColumn, capacity int, keepDictionary bool) ([]string, map[string]uint32, bool, error) {
+	if len(parts) > columnTypedColumnDenseGroupCountDistinctSortedMergeMaxParts {
+		return nil, nil, false, nil
+	}
+	columns := make([]*columnTypedColumnDenseStringCodeColumn, 0, len(parts))
+	includeEmpty := false
+	for partIdx := range parts {
+		part := parts[partIdx].DenseGroupCountDistinct
+		if part == nil {
+			return nil, nil, false, fmt.Errorf("collections: dense grouped count-distinct missing prepared part %d", partIdx)
+		}
+		column := selectColumn(part)
+		if column == nil {
+			return nil, nil, false, fmt.Errorf("collections: dense grouped count-distinct missing selected column for part %d", partIdx)
+		}
+		columns = append(columns, column)
+		if !includeEmpty {
+			for _, valid := range column.Valid {
+				if !valid {
+					includeEmpty = true
+					break
+				}
+			}
+		}
+	}
+
+	positions := make([]int, len(columns))
+	ranks := make(map[string]uint32, columnTypedColumnDenseGroupCountDistinctRankMapCapacity(capacity))
+	var dictionary []string
+	if keepDictionary {
+		dictionary = make([]string, 0, min(capacity, 64))
+	}
+	for {
+		next := ""
+		haveNext := false
+		if includeEmpty {
+			next = ""
+			haveNext = true
+		}
+		for columnIdx, column := range columns {
+			pos := positions[columnIdx]
+			if pos >= len(column.Dictionary) {
+				continue
+			}
+			if pos > 0 && column.Dictionary[pos-1] >= column.Dictionary[pos] {
+				return nil, nil, false, nil
+			}
+			value := column.Dictionary[pos]
+			if !haveNext || value < next {
+				next = value
+				haveNext = true
+			}
+		}
+		if !haveNext {
+			break
+		}
+		if _, exists := ranks[next]; !exists {
+			if uint64(len(ranks)) > uint64(^uint32(0)) {
+				return nil, nil, false, fmt.Errorf("collections: dense grouped count-distinct global dictionary cardinality exceeds uint32")
+			}
+			ranks[next] = uint32(len(ranks))
+			if keepDictionary {
+				dictionary = append(dictionary, next)
+			}
+		}
+		if includeEmpty && next == "" {
+			includeEmpty = false
+		}
+		for columnIdx, column := range columns {
+			pos := positions[columnIdx]
+			for pos < len(column.Dictionary) && column.Dictionary[pos] == next {
+				pos++
+			}
+			positions[columnIdx] = pos
+		}
+	}
+	return dictionary, ranks, true, nil
 }
 
 func columnTypedColumnDenseGroupCountDistinctDictionaryCapacity(parts []columnTypedColumnPhysicalQueryPart, selectColumn func(*columnTypedColumnDenseGroupCountDistinctPart) *columnTypedColumnDenseStringCodeColumn) (int, error) {


### PR DESCRIPTION
## Summary
- add a sorted-merge path for dense q2 group/count-distinct global dictionary and rank construction when local dictionaries are already sorted
- retain the existing map/sort implementation as the fallback for fragmented or non-sorted dictionaries
- extend q2 rank-map coverage for overlapping dictionaries, nullable empty-string handling, and prepared local rank state

## Evidence
- `GOWORK=off go test ./TreeDB/collections -run 'TestColumnPhysicalTypedColumnOneShotCacheQ2NoMetadata3123|TestTypedColumnQ2DenseGroupCountDistinctNoSortLocalDictionaries1950|TestTypedColumnQ2DenseGroupCountDistinctLocalCodesNullableValues3080|TestTypedColumnQ2DenseGroupCountDistinctActiveGroupBitset1950|TestTypedColumnQ2DenseGroupCountDistinctRankMapCapacity3158|TestColumnPhysicalDenseTypedColumnTargetedRangeReads3090' -count=1`
- `GOWORK=off go test -race ./TreeDB/collections -run TestColumnPhysicalTypedColumnOneShotCacheQ2NoMetadata3123 -count=1`
- `GOWORK=off go test ./TreeDB/collections`
- `GOWORK=off go test ./cmd/unified_bench`

## q2 smoke
1M q2-only JSONBench, `one_shot_end_to_end`, `no_aggregate_metadata`, `column-store-full-prepared`, same machine:

- clean `origin/main`: total 96.010ms, setup 75.947ms, run 20.016ms, post_prepare 47.178ms
  - `/tmp/jsonbench_q2_main_baseline_20260628_153021/report.json`
- this branch: total 94.862ms, setup 76.390ms, run 18.434ms, post_prepare 49.619ms
  - `/tmp/jsonbench_q2_sorted_global_ranks_20260628_152930/report.json`

This should be treated as neutral/small movement, not as closing #3158 or the q2 ClickHouse gap. Direct local-rank-map variants were also tested and rejected because they regressed the q2 smoke:

- scan-based direct local rank maps: total 96.037ms, setup 79.229ms, post_prepare 53.512ms
  - `/tmp/jsonbench_q2_sorted_rank_maps_20260628_152745/report.json`
- heap-based direct local rank maps: total 118.977ms, setup 87.827ms, post_prepare 55.329ms
  - `/tmp/jsonbench_q2_heap_rank_maps_20260628_153243/report.json`

Refs #3158, #3070, #3001.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved handling of dense typed-column group-count-distinct queries with faster global dictionary/rank construction when per-part data is already sorted.
  * Empty values are now included correctly in global ordering and rank mappings when present.

* **Bug Fixes**
  * Fixed global group and distinct rank calculations across multiple parts.
  * Improved fallback handling for cases where sorted merging is not possible, preserving correct results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->