### PR TITLE
Speed typed-column publication prep

### DIFF
--- a/TreeDB/collections/column_aggregate_metadata_asset_3121_test.go
+++ b/TreeDB/collections/column_aggregate_metadata_asset_3121_test.go
@@ -40,6 +40,27 @@ func TestAggregateMetadataAssetsTypedGranulePassMatchesPerAggregate3121(t *testi
 	assertColumnAggregateMetadataAssetsEqual3121(t, got, want)
 }
 
+func TestAggregateMetadataAssetsTypedGranulePrimaryIDOrderUsesFallback3175(t *testing.T) {
+	cfg := aggregateMetadataBatchConfig3121()
+	cfg.AssetManager = &ColumnAssetManagerConfig{Namespace: "events/column-assets"}
+	for idx := range cfg.Columns {
+		cfg.Columns[idx].Path = cfg.Columns[idx].Name
+		cfg.Columns[idx].Owner = TypedStorageOwnerColumnPart
+	}
+	rows := append([]columnDeclaredRow(nil), aggregateMetadataBatchRows3121()[:3]...)
+
+	typedPart, err := buildTypedColumnPartImageForDeclaredRowsWithResult(cfg, 7, typedColumnPartAssetPartID, rows)
+	if err != nil {
+		t.Fatalf("buildTypedColumnPartImageForDeclaredRowsWithResult: %v", err)
+	}
+	if typedPart.Rows != len(rows) {
+		t.Fatalf("typed part rows=%d want %d", typedPart.Rows, len(rows))
+	}
+	if len(typedPart.TypedGranuleRowOrder) != 0 {
+		t.Fatalf("typed granule row order=%v want empty primary-id fallback", typedPart.TypedGranuleRowOrder)
+	}
+}
+
 func TestAggregateMetadataAssetsTypedGranulePrecomputedOrderMatchesFallback3175(t *testing.T) {
 	cfg := aggregateMetadataBatchConfig3121()
 	cfg.SortKey = []ColumnSortKey{{Column: "time_us"}}

--- a/TreeDB/collections/typed_column_adapter.go
+++ b/TreeDB/collections/typed_column_adapter.go
@@ -198,6 +198,12 @@ type typedColumnAdapterRowSource interface {
 	Value(rowIdx int, column typedColumnAdapterColumn) (columnDeclaredValue, bool, error)
 }
 
+type typedColumnAdapterIndexedRowSource interface {
+	typedColumnAdapterRowSource
+	ValueIndex(column typedColumnAdapterColumn) (int, error)
+	ValueAt(rowIdx, valueIdx int) (columnDeclaredValue, bool, error)
+}
+
 type typedColumnAdapterRowsSource []typedColumnAdapterRow
 
 func (s typedColumnAdapterRowsSource) Len() int {
@@ -250,6 +256,31 @@ func (s typedColumnDeclaredRowSource) Value(rowIdx int, column typedColumnAdapte
 		return columnDeclaredValue{}, false, fmt.Errorf("typed-column part field %q not found", column.Field.Path)
 	}
 	return row.Values[allIdx], true, nil
+}
+
+func (s typedColumnDeclaredRowSource) ValueIndex(column typedColumnAdapterColumn) (int, error) {
+	allIdx, ok := s.indexByPath[column.Field.Path]
+	if !ok {
+		return -1, fmt.Errorf("typed-column part field %q not found", column.Field.Path)
+	}
+	return allIdx, nil
+}
+
+func (s typedColumnDeclaredRowSource) ValueAt(rowIdx, valueIdx int) (columnDeclaredValue, bool, error) {
+	if rowIdx < 0 || rowIdx >= len(s.rows) {
+		return columnDeclaredValue{}, false, fmt.Errorf("row index=%d outside rows=%d", rowIdx, len(s.rows))
+	}
+	if valueIdx < 0 || valueIdx >= len(s.allColumns) {
+		return columnDeclaredValue{}, false, fmt.Errorf("value index=%d outside columns=%d", valueIdx, len(s.allColumns))
+	}
+	row := s.rows[rowIdx]
+	if row.Deleted {
+		return columnDeclaredValue{}, false, fmt.Errorf("row[%d] is deleted", rowIdx)
+	}
+	if len(row.Values) != len(s.allColumns) {
+		return columnDeclaredValue{}, false, fmt.Errorf("row[%d] values=%d columns=%d", rowIdx, len(row.Values), len(s.allColumns))
+	}
+	return row.Values[valueIdx], true, nil
 }
 
 type typedColumnAdapterPart struct {
@@ -653,17 +684,31 @@ func buildTypedColumnAdapterPartFromSource(opts typedColumnAdapterOptions, rowSo
 	if err != nil {
 		return nil, err
 	}
+	indexedSource, valueIndexes, err := typedColumnAdapterIndexedSourceColumns(rowSource, columns)
+	if err != nil {
+		return nil, err
+	}
 	for i := range columns {
 		if columns[i].Field.ValueType == ColumnStoreValueString {
-			dict, err := buildTypedColumnAdapterStringDictionaryFromSource(columns[i], rowSource)
+			var dict map[string]int64
+			if indexedSource != nil {
+				dict, err = buildTypedColumnAdapterStringDictionaryFromIndexedSource(columns[i], indexedSource, valueIndexes[i])
+			} else {
+				dict, err = buildTypedColumnAdapterStringDictionaryFromSource(columns[i], rowSource)
+			}
 			if err != nil {
 				return nil, err
 			}
 			columns[i].Dictionary = dict
-			columns[i].ReverseDictionary = reverseTypedColumnAdapterDictionary(dict)
-			columns[i].DictionaryValuesByCode, err = typedColumnAdapterDictionaryValuesByCodeFromForward(dict, len(dict))
-			if err != nil {
-				return nil, err
+			mode := typedColumnAdapterBuildDictionaryModeForColumn(opts, columns[i].Definition.Name)
+			if mode.Reverse {
+				columns[i].ReverseDictionary = reverseTypedColumnAdapterDictionary(dict)
+			}
+			if mode.ValuesByCode {
+				columns[i].DictionaryValuesByCode, err = typedColumnAdapterDictionaryValuesByCodeFromForward(dict, len(dict))
+				if err != nil {
+					return nil, err
+				}
 			}
 			columns[i].Definition.Cardinality = uint32(len(dict))
 		}
@@ -790,8 +835,15 @@ func buildTypedColumnAdapterPartFromSource(opts typedColumnAdapterOptions, rowSo
 	}
 	for rowIdx := 0; rowIdx < rowCount; rowIdx++ {
 		batch.Columns[typedColumnAdapterPrimaryIDColumn][rowIdx] = rowSource.PrimaryID(rowIdx)
-		for _, column := range columns {
-			value, ok, err := rowSource.Value(rowIdx, column)
+		for columnIdx, column := range columns {
+			var value columnDeclaredValue
+			var ok bool
+			var err error
+			if indexedSource != nil {
+				value, ok, err = indexedSource.ValueAt(rowIdx, valueIndexes[columnIdx])
+			} else {
+				value, ok, err = rowSource.Value(rowIdx, column)
+			}
 			if err != nil {
 				return nil, fmt.Errorf("collections: typed-column adapter row %d field %q: %w", rowIdx, column.Field.Path, err)
 			}
@@ -5161,10 +5213,49 @@ func buildTypedColumnAdapterStringDictionary(column typedColumnAdapterColumn, ro
 	return buildTypedColumnAdapterStringDictionaryFromSource(column, typedColumnAdapterRowsSource(rows))
 }
 
+func typedColumnAdapterIndexedSourceColumns(rowSource typedColumnAdapterRowSource, columns []typedColumnAdapterColumn) (typedColumnAdapterIndexedRowSource, []int, error) {
+	indexed, ok := rowSource.(typedColumnAdapterIndexedRowSource)
+	if !ok {
+		return nil, nil, nil
+	}
+	indexes := make([]int, len(columns))
+	for i, column := range columns {
+		valueIdx, err := indexed.ValueIndex(column)
+		if err != nil {
+			return nil, nil, err
+		}
+		indexes[i] = valueIdx
+	}
+	return indexed, indexes, nil
+}
+
 func buildTypedColumnAdapterStringDictionaryFromSource(column typedColumnAdapterColumn, rowSource typedColumnAdapterRowSource) (map[string]int64, error) {
 	seen := make(map[string]struct{})
 	for rowIdx := 0; rowIdx < rowSource.Len(); rowIdx++ {
 		value, ok, err := rowSource.Value(rowIdx, column)
+		if err != nil {
+			return nil, fmt.Errorf("collections: typed-column adapter row %d field %q: %w", rowIdx, column.Field.Path, err)
+		}
+		if ok && value.Present && !value.Null {
+			seen[value.String] = struct{}{}
+		}
+	}
+	values := make([]string, 0, len(seen))
+	for value := range seen {
+		values = append(values, value)
+	}
+	sort.Strings(values)
+	dict := make(map[string]int64, len(values))
+	for i, value := range values {
+		dict[value] = int64(i)
+	}
+	return dict, nil
+}
+
+func buildTypedColumnAdapterStringDictionaryFromIndexedSource(column typedColumnAdapterColumn, rowSource typedColumnAdapterIndexedRowSource, valueIdx int) (map[string]int64, error) {
+	seen := make(map[string]struct{})
+	for rowIdx := 0; rowIdx < rowSource.Len(); rowIdx++ {
+		value, ok, err := rowSource.ValueAt(rowIdx, valueIdx)
 		if err != nil {
 			return nil, fmt.Errorf("collections: typed-column adapter row %d field %q: %w", rowIdx, column.Field.Path, err)
 		}
@@ -5197,6 +5288,19 @@ func typedColumnAdapterDictionaryModeForColumn(opts typedColumnAdapterOptions, c
 		return opts.DictionaryModes[column]
 	}
 	return typedColumnAdapterDictionaryMode{Forward: true, Reverse: true, ValuesByCode: true}
+}
+
+func typedColumnAdapterBuildDictionaryModeForColumn(opts typedColumnAdapterOptions, column string) typedColumnAdapterDictionaryMode {
+	mode := typedColumnAdapterDictionaryMode{Forward: true, Reverse: true, ValuesByCode: true}
+	if opts.DictionaryModes != nil {
+		if requested, ok := opts.DictionaryModes[column]; ok {
+			mode = requested
+		} else {
+			mode = typedColumnAdapterDictionaryMode{}
+		}
+	}
+	mode.Forward = true
+	return mode
 }
 
 func typedColumnPreparedAdapterDictionaryModeForColumn(opts typedColumnPreparedAdapterPartOptions, column string) typedColumnAdapterDictionaryMode {

--- a/TreeDB/collections/typed_column_publication.go
+++ b/TreeDB/collections/typed_column_publication.go
@@ -300,6 +300,7 @@ func buildTypedColumnPartImageForDeclaredRowsWithResult(cfg ColumnStoreConfig, g
 	if err != nil {
 		return typedColumnPartImageBuildResult{}, err
 	}
+	adapterOpts.DictionaryModes = typedColumnPublicationDictionaryModes(fields)
 	part, err := buildTypedColumnAdapterPartFromDeclaredRows(adapterOpts, cfg.Columns, rows)
 	if err != nil {
 		return typedColumnPartImageBuildResult{}, err
@@ -315,12 +316,36 @@ func buildTypedColumnPartImageForDeclaredRowsWithResult(cfg ColumnStoreConfig, g
 	return typedColumnPartImageBuildResult{Bytes: image.Bytes, Rows: image.Rows, TypedGranuleRowOrder: rowOrder}, nil
 }
 
+func typedColumnPublicationDictionaryModes(fields []TypedStorageField) map[string]typedColumnAdapterDictionaryMode {
+	modes := make(map[string]typedColumnAdapterDictionaryMode)
+	for _, field := range fields {
+		if field.ValueType != "string" {
+			continue
+		}
+		name := field.Name
+		if name == "" {
+			name = field.Path
+		}
+		if name == "" {
+			continue
+		}
+		modes[name] = typedColumnAdapterDictionaryMode{Forward: true}
+	}
+	if len(modes) == 0 {
+		return nil
+	}
+	return modes
+}
+
 func typedColumnPartDeclaredRowOrder(part *typedColumnAdapterPart, rows int) ([]int, error) {
 	if rows == 0 {
 		return nil, nil
 	}
 	if part == nil || part.Part == nil {
 		return nil, errors.New("collections: typed-column part row order requires built part")
+	}
+	if !typedColumnAdapterPartHasLogicalSortKey(part) {
+		return nil, nil
 	}
 	if len(part.Part.Locators) != rows {
 		return nil, fmt.Errorf("collections: typed-column part locators=%d want rows=%d", len(part.Part.Locators), rows)


### PR DESCRIPTION
## Summary

Refs #3067, #3099, #3001.

This is a scoped load-path cleanup for typed-column publication prep. It does not change durability boundaries, persistent formats, or query execution, and it does not claim a query-speed improvement.

Changes:
- avoid repeated declared-row path lookups while building typed-column publication parts by resolving typed-column value indexes once per part
- skip publication-time reverse dictionary and values-by-code helper construction for string dictionaries; the stored forward dictionary remains available for image encoding and later query decode
- avoid constructing a precomputed typed-granule row order when the typed-column part only uses the synthetic primary-id order
- add regression coverage for primary-id typed-granule order fallback while preserving the existing logical sort-key row-order tests

## Scope

Includes:
- `TreeDB/collections/typed_column_adapter.go`
- `TreeDB/collections/typed_column_publication.go`
- `TreeDB/collections/column_aggregate_metadata_asset_3121_test.go`

Excludes:
- query execution changes
- on-disk format changes
- durability or sync semantics changes
- aggregate-metadata acceleration semantics

## Evidence

Focused benchmark, candidate versus `origin/main` (`0e14b1ec3`), `GOWORK=off go test ./TreeDB/collections -run '^$' -bench '^BenchmarkTypedColumnPartSortKeyPublication1948$' -benchtime=50x -count=8`:

| Case | main sec/op | candidate sec/op | delta | main ops/sec | candidate ops/sec | alloc delta | bytes |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |
| `primary_id` | 7.070ms | 6.091ms | -13.85% | 141.4 | 164.2 | -3.58% | unchanged |
| `time_us` | 7.806ms | 7.188ms | -7.92% | 128.1 | 139.1 | -3.40% | unchanged |
| geomean | 7.429ms | 6.617ms | -10.93% | 134.6 | 151.1 | -3.49% | unchanged |

Same-machine JSONBench q5 1M smoke, `column-store-full-prepared`, `one_shot_end_to_end`, `no_aggregate_metadata`, WAL-excluded durable storage:

```text
main:      /tmp/jsonbench_main_3067_q5_1m_20260628_161909/report.json
candidate: /tmp/jsonbench_candidate_3067_q5_1m_20260628_161839/report.json

insert_seconds:                         6.427918673 -> 6.321017553  -1.66%
insert_stats_publish_seconds:           4.145606229 -> 3.857544274  -6.95%
asset_preparation_seconds:               3.413032276 -> 3.031932980 -11.17%
typed_column_prepare_seconds:            2.456256436 -> 2.310673996  -5.93%
storage_durable_bytes_wal_excluded:      137491239 -> 137491151      -88 bytes
```

The q5 one-shot query timing in that smoke was noisy/worse on the candidate (`40.672ms -> 49.029ms`), so this PR should be evaluated as load/publish prep work only.

## Validation

```text
GOWORK=off go test ./TreeDB/collections
GOWORK=off go test ./cmd/unified_bench
git diff --check
```

## Review Notes

Internal review checked dictionary mode keying, indexed declared-row source bounds checks, and primary-id versus logical sort-key row-order behavior. No known correctness blocker remains. Latest-head CI and AI review are still required before this is mergeable.
