### PR TITLE
TreeDB: bound command-WAL buffer retention

### DIFF
--- a/TreeDB/db/command_wal_stats.go
+++ b/TreeDB/db/command_wal_stats.go
@@ -90,6 +90,17 @@ func writeCommandWALStatsZeroCounters(stats map[string]string) {
 	stats["treedb.command_wal.cleanup.scans"] = "0"
 	stats["treedb.command_wal.cleanup.removed_segments"] = "0"
 	stats["treedb.command_wal.cleanup.removed_bytes"] = "0"
+	stats["treedb.command_wal.writer.buffer_size_bytes"] = "0"
+	stats["treedb.command_wal.writer.buffered_bytes"] = "0"
+	stats["treedb.command_wal.writer.scratch_capacity_bytes"] = "0"
+	stats["treedb.command_wal.writer.command_buffer.length_bytes"] = "0"
+	stats["treedb.command_wal.writer.command_buffer.capacity_bytes"] = "0"
+	stats["treedb.command_wal.writer.command_buffer.limit_bytes"] = "0"
+	stats["treedb.command_wal.writer.command_buffer.retain_limit_bytes"] = "0"
+	stats["treedb.command_wal.writer.command_buffer.trim_count"] = "0"
+	stats["treedb.command_wal.writer.command_buffer.dropped_bytes_total"] = "0"
+	stats["treedb.command_wal.writer.pending_batch.length_bytes"] = "0"
+	stats["treedb.command_wal.writer.pending_batch.capacity_bytes"] = "0"
 }
 
 func writeCommandWALLiveStats(stats map[string]string, db *DB) {
@@ -110,6 +121,25 @@ func writeCommandWALLifecycleStats(stats map[string]string, db *DB) {
 	stats["treedb.command_wal.cleanup.scans"] = fmt.Sprintf("%d", db.commandWALCleanupScans.Load())
 	stats["treedb.command_wal.cleanup.removed_segments"] = fmt.Sprintf("%d", db.commandWALCleanupRemoved.Load())
 	stats["treedb.command_wal.cleanup.removed_bytes"] = fmt.Sprintf("%d", db.commandWALCleanupBytes.Load())
+	writeCommandWALWriterBufferStats(stats, db)
+}
+
+func writeCommandWALWriterBufferStats(stats map[string]string, db *DB) {
+	if stats == nil || db == nil || db.commandJournal == nil {
+		return
+	}
+	snap := db.commandJournal.WriterBufferStats()
+	stats["treedb.command_wal.writer.buffer_size_bytes"] = fmt.Sprintf("%d", snap.BufferedWriterSize)
+	stats["treedb.command_wal.writer.buffered_bytes"] = fmt.Sprintf("%d", snap.BufferedWriterBufferedBytes)
+	stats["treedb.command_wal.writer.scratch_capacity_bytes"] = fmt.Sprintf("%d", snap.ScratchCapacity)
+	stats["treedb.command_wal.writer.command_buffer.length_bytes"] = fmt.Sprintf("%d", snap.CommandBufferLength)
+	stats["treedb.command_wal.writer.command_buffer.capacity_bytes"] = fmt.Sprintf("%d", snap.CommandBufferCapacity)
+	stats["treedb.command_wal.writer.command_buffer.limit_bytes"] = fmt.Sprintf("%d", snap.CommandBufferLimit)
+	stats["treedb.command_wal.writer.command_buffer.retain_limit_bytes"] = fmt.Sprintf("%d", snap.CommandBufferRetainLimit)
+	stats["treedb.command_wal.writer.command_buffer.trim_count"] = fmt.Sprintf("%d", snap.CommandBufferTrimCount)
+	stats["treedb.command_wal.writer.command_buffer.dropped_bytes_total"] = fmt.Sprintf("%d", snap.CommandBufferDroppedBytes)
+	stats["treedb.command_wal.writer.pending_batch.length_bytes"] = fmt.Sprintf("%d", snap.PendingBatchLength)
+	stats["treedb.command_wal.writer.pending_batch.capacity_bytes"] = fmt.Sprintf("%d", snap.PendingBatchCapacity)
 }
 
 func (db *DB) observeCommandWALAccepted(lsn uint64) {

--- a/TreeDB/db/command_wal_stats_test.go
+++ b/TreeDB/db/command_wal_stats_test.go
@@ -1,9 +1,13 @@
 package db
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
+
+	"github.com/snissn/gomap/TreeDB/internal/commitlog"
 )
 
 func TestCommandWALStatsProveModeAndFrames(t *testing.T) {
@@ -52,6 +56,15 @@ func TestCommandWALStatsProveModeAndFrames(t *testing.T) {
 	}
 	if got := stats["treedb.command_wal.stats_error"]; got != "" {
 		t.Fatalf("unexpected command WAL stats error %q (stats=%#v)", got, stats)
+	}
+	if got := stats["treedb.command_wal.writer.command_buffer.limit_bytes"]; got != "67108864" {
+		t.Fatalf("command WAL command buffer limit=%q, want 67108864 (stats=%#v)", got, stats)
+	}
+	if got := stats["treedb.command_wal.writer.command_buffer.retain_limit_bytes"]; got != "4194304" {
+		t.Fatalf("command WAL command buffer retain limit=%q, want 4194304 (stats=%#v)", got, stats)
+	}
+	if got := stats["treedb.command_wal.writer.buffer_size_bytes"]; got != "16777216" {
+		t.Fatalf("command WAL writer buffer size=%q, want 16777216 (stats=%#v)", got, stats)
 	}
 	if err := db.Close(); err != nil {
 		t.Fatalf("Close: %v", err)
@@ -108,6 +121,46 @@ func TestCommandWALStatsDefaultDoesNotScanWAL(t *testing.T) {
 	}
 	if got := stats["treedb.command_wal.live_covered_max_lsn"]; got != "1" {
 		t.Fatalf("live covered max lsn=%q, want 1 without diagnostic scan (stats=%#v)", got, stats)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	dbClosed = true
+}
+
+func TestCommandWALStatsExposeDeferredCommandBufferTrim(t *testing.T) {
+	db, err := Open(Options{Dir: t.TempDir(), CommandWAL: true, DisableBackgroundPrune: true})
+	if err != nil {
+		t.Fatalf("Open command WAL: %v", err)
+	}
+	dbClosed := false
+	t.Cleanup(func() {
+		if !dbClosed {
+			_ = db.Close()
+		}
+	})
+
+	value := bytes.Repeat([]byte("x"), commandWALDeferredPointBufferRetainSize+8192)
+	if _, err := db.AppendRawKVPointCommandWALTrusted(commitlog.RawKVOpSet, []byte("large"), value, false); err != nil {
+		t.Fatalf("AppendRawKVPointCommandWALTrusted: %v", err)
+	}
+
+	stats := db.Stats()
+	if got := stats["treedb.command_wal.writer.command_buffer.length_bytes"]; got != "0" {
+		t.Fatalf("command buffer len=%q, want 0 after append flush (stats=%#v)", got, stats)
+	}
+	if got, want := stats["treedb.command_wal.writer.command_buffer.capacity_bytes"], strconv.Itoa(commandWALDeferredPointBufferRetainSize); got != want {
+		t.Fatalf("command buffer cap=%q, want retain cap %s (stats=%#v)", got, want, stats)
+	}
+	if got := stats["treedb.command_wal.writer.command_buffer.trim_count"]; got != "1" {
+		t.Fatalf("command buffer trim count=%q, want 1 (stats=%#v)", got, stats)
+	}
+	dropped, err := strconv.ParseUint(stats["treedb.command_wal.writer.command_buffer.dropped_bytes_total"], 10, 64)
+	if err != nil {
+		t.Fatalf("parse dropped bytes: %v (stats=%#v)", err, stats)
+	}
+	if dropped == 0 {
+		t.Fatalf("command buffer dropped bytes=0, want retained capacity drop accounted (stats=%#v)", stats)
 	}
 	if err := db.Close(); err != nil {
 		t.Fatalf("Close: %v", err)

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -503,8 +503,9 @@ var errTestCommandWALFlushFailpoint = errors.New("treedb: command wal flush fail
 var errTestWriteMetaFailpoint = errors.New("treedb: write meta failpoint")
 
 const (
-	commandWALWriterBufferSize        = 16 << 20
-	commandWALDeferredPointBufferSize = 64 << 20
+	commandWALWriterBufferSize              = 16 << 20
+	commandWALDeferredPointBufferSize       = 64 << 20
+	commandWALDeferredPointBufferRetainSize = 4 << 20
 )
 
 type finalizeCommitError struct {
@@ -1863,14 +1864,15 @@ func openWithLock(opts Options, lock *lockfile.Lock) (*DB, error) {
 			commandSegmentSeq++
 		}
 		journal, err := commitlog.OpenCommandJournal(WALDirPath(opts.Dir), commitlog.CommandJournalOptions{
-			MaxSegmentSize:            opts.WALMaxSegmentBytes,
-			SegmentTargetBytes:        opts.CommandWALSegmentTargetBytes,
-			BufferSize:                commandWALWriterBufferSize,
-			DeferredCommandBufferSize: commandWALDeferredPointBufferSize,
-			Compress:                  opts.JournalCompression,
-			OnSegmentRotated:          db.observeCommandWALSegmentRotated,
-			InitialLSN:                db.meta.AppliedCommandLSN,
-			SegmentSeq:                commandSegmentSeq,
+			MaxSegmentSize:                  opts.WALMaxSegmentBytes,
+			SegmentTargetBytes:              opts.CommandWALSegmentTargetBytes,
+			BufferSize:                      commandWALWriterBufferSize,
+			DeferredCommandBufferSize:       commandWALDeferredPointBufferSize,
+			DeferredCommandBufferRetainSize: commandWALDeferredPointBufferRetainSize,
+			Compress:                        opts.JournalCompression,
+			OnSegmentRotated:                db.observeCommandWALSegmentRotated,
+			InitialLSN:                      db.meta.AppliedCommandLSN,
+			SegmentSeq:                      commandSegmentSeq,
 		})
 		if err != nil {
 			_ = db.Close()

--- a/TreeDB/internal/commitlog/command_frame_test.go
+++ b/TreeDB/internal/commitlog/command_frame_test.go
@@ -1129,6 +1129,61 @@ func TestWriterDeferredCommandBufferAllocatesLazily(t *testing.T) {
 	}
 }
 
+func TestWriterDeferredCommandBufferTrimsRetainedCapacityAfterFlush(t *testing.T) {
+	payload, err := EncodeRawKVBatchPayload([]RawKVOperation{
+		{Op: RawKVOpSet, Key: []byte("small"), Value: bytes.Repeat([]byte("x"), 2048)},
+	})
+	if err != nil {
+		t.Fatalf("EncodeRawKVBatchPayload: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "commit-l0-000001.log")
+	w, err := NewWriterWithOptions(path, Options{DeferredCommandBufferSize: 64 << 10, DeferredCommandBufferRetainSize: 1024})
+	if err != nil {
+		t.Fatalf("NewWriterWithOptions: %v", err)
+	}
+	defer w.Close()
+	for i := uint64(1); i <= 8; i++ {
+		if err := w.AppendRawKVBatchPayloadCommandDirectTrusted(i, 0, payload); err != nil {
+			t.Fatalf("AppendRawKVBatchPayloadCommandDirectTrusted %d: %v", i, err)
+		}
+	}
+	before := w.BufferStats()
+	if before.CommandBufferCapacity <= before.CommandBufferRetainLimit {
+		t.Fatalf("command buffer cap before flush=%d, want above retain limit %d", before.CommandBufferCapacity, before.CommandBufferRetainLimit)
+	}
+	if err := w.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+	after := w.BufferStats()
+	if after.CommandBufferLength != 0 {
+		t.Fatalf("command buffer len after flush=%d, want 0", after.CommandBufferLength)
+	}
+	if after.CommandBufferCapacity != 1024 {
+		t.Fatalf("command buffer cap after flush=%d, want retained cap 1024", after.CommandBufferCapacity)
+	}
+	if after.CommandBufferTrimCount != 1 {
+		t.Fatalf("command buffer trim count=%d, want 1", after.CommandBufferTrimCount)
+	}
+	if after.CommandBufferDroppedBytes == 0 {
+		t.Fatal("command buffer dropped bytes=0, want dropped capacity accounted")
+	}
+}
+
+func TestWriterScratchAllocatesLazily(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "commit-l0-000001.log")
+	w, err := NewWriterWithOptions(path, Options{})
+	if err != nil {
+		t.Fatalf("NewWriterWithOptions: %v", err)
+	}
+	defer w.Close()
+	if got := cap(w.scratch); got != 0 {
+		t.Fatalf("scratch cap after open=%d, want 0", got)
+	}
+	if got := w.BufferStats().ScratchCapacity; got != 0 {
+		t.Fatalf("scratch stat after open=%d, want 0", got)
+	}
+}
+
 func TestWriterLargeBatchPayloadBypassesDeferredCommandBufferAndPreservesOrder(t *testing.T) {
 	smallPayload, err := EncodeRawKVBatchPayload([]RawKVOperation{
 		{Op: RawKVOpSet, Key: []byte("small"), Value: []byte("value")},

--- a/TreeDB/internal/commitlog/commitlog.go
+++ b/TreeDB/internal/commitlog/commitlog.go
@@ -64,10 +64,14 @@ type Options struct {
 	// commitlog default.
 	BufferSize int
 
-	// DeferredCommandBufferSize preallocates an internal command-frame buffer
-	// used by trusted public command appends. Values <= 0 disable deferred
-	// command-frame finalization.
+	// DeferredCommandBufferSize caps the internal command-frame buffer used by
+	// trusted public command appends. Values <= 0 disable deferred command-frame
+	// finalization.
 	DeferredCommandBufferSize int
+
+	// DeferredCommandBufferRetainSize bounds command-frame buffer capacity kept
+	// after flush. Values <= 0 retain the full allocated capacity.
+	DeferredCommandBufferRetainSize int
 
 	// Compress enables best-effort zstd compression for commitlog segments.
 	// Segments are only stored compressed when the compressed payload (plus a

--- a/TreeDB/internal/commitlog/journal_owner.go
+++ b/TreeDB/internal/commitlog/journal_owner.go
@@ -180,9 +180,12 @@ type CommandJournalOptions struct {
 	// BufferSize controls this command journal's buffered writer size. Zero
 	// uses the commitlog default.
 	BufferSize int
-	// DeferredCommandBufferSize preallocates a writer-owned buffer used to
-	// finalize trusted public command frames at flush/sync boundaries.
+	// DeferredCommandBufferSize caps the writer-owned buffer used to finalize
+	// trusted public command frames at flush/sync boundaries.
 	DeferredCommandBufferSize int
+	// DeferredCommandBufferRetainSize bounds retained command buffer capacity
+	// after flush. Zero keeps the writer default.
+	DeferredCommandBufferRetainSize int
 	// Compress enables commitlog frame compression.
 	Compress bool
 	// OnSegmentRotated is called after a successful active segment rotation with
@@ -260,7 +263,13 @@ func OpenCommandJournal(walDir string, opts CommandJournalOptions) (*CommandJour
 		_ = owner.Close()
 		return nil, err
 	}
-	writer, err := NewWriterWithOptions(path, Options{MaxSegmentSize: opts.MaxSegmentSize, BufferSize: opts.BufferSize, DeferredCommandBufferSize: opts.DeferredCommandBufferSize, Compress: opts.Compress})
+	writer, err := NewWriterWithOptions(path, Options{
+		MaxSegmentSize:                  opts.MaxSegmentSize,
+		BufferSize:                      opts.BufferSize,
+		DeferredCommandBufferSize:       opts.DeferredCommandBufferSize,
+		DeferredCommandBufferRetainSize: opts.DeferredCommandBufferRetainSize,
+		Compress:                        opts.Compress,
+	})
 	if err != nil {
 		_ = owner.Close()
 		return nil, err
@@ -523,6 +532,18 @@ func (j *CommandJournal) RotateActiveSegment(syncCurrent bool) error {
 func (j *CommandJournal) ActiveBytes() int64 {
 	_, bytes := j.ActiveSegmentSnapshot()
 	return bytes
+}
+
+func (j *CommandJournal) WriterBufferStats() WriterBufferStats {
+	if j == nil {
+		return WriterBufferStats{}
+	}
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	if j.writer == nil {
+		return WriterBufferStats{}
+	}
+	return j.writer.BufferStats()
 }
 
 // ActiveSegmentSnapshot reports the active segment path and accepted bytes under

--- a/TreeDB/internal/commitlog/writer.go
+++ b/TreeDB/internal/commitlog/writer.go
@@ -67,23 +67,40 @@ func sameNonEmptyBytesData(a, b []byte) bool {
 }
 
 type Writer struct {
-	f                *os.File
-	bw               *bufio.Writer
-	scratch          []byte
-	encScratch       []byte
-	commandBuf       []byte
-	commandBufLimit  int
-	commandErr       error
-	pendingBatch     []byte
-	pendingBatchSeq  uint64
-	pendingBatchRecs uint32
-	headerBuf        [segmentHeaderSize]byte
-	rawLenPrefix     [4]byte
-	size             int64
-	maxSegmentSize   int64
-	compress         bool
-	enc              *zstd.Encoder
-	syncFn           func(*os.File) error
+	f                      *os.File
+	bw                     *bufio.Writer
+	scratch                []byte
+	encScratch             []byte
+	commandBuf             []byte
+	commandBufLimit        int
+	commandBufRetain       int
+	commandBufTrims        uint64
+	commandBufDroppedBytes uint64
+	commandErr             error
+	pendingBatch           []byte
+	pendingBatchSeq        uint64
+	pendingBatchRecs       uint32
+	headerBuf              [segmentHeaderSize]byte
+	rawLenPrefix           [4]byte
+	size                   int64
+	maxSegmentSize         int64
+	compress               bool
+	enc                    *zstd.Encoder
+	syncFn                 func(*os.File) error
+}
+
+type WriterBufferStats struct {
+	BufferedWriterSize          int
+	BufferedWriterBufferedBytes int
+	ScratchCapacity             int
+	CommandBufferLength         int
+	CommandBufferCapacity       int
+	CommandBufferLimit          int
+	CommandBufferRetainLimit    int
+	CommandBufferTrimCount      uint64
+	CommandBufferDroppedBytes   uint64
+	PendingBatchLength          int
+	PendingBatchCapacity        int
 }
 
 func (w *Writer) ActiveBytes() int64 {
@@ -125,17 +142,50 @@ func NewWriterWithOptions(path string, opts Options) (*Writer, error) {
 	if opts.DeferredCommandBufferSize > 0 {
 		commandBufLimit = opts.DeferredCommandBufferSize
 	}
+	commandBufRetain := normalizeCommandBufferRetainSize(opts.DeferredCommandBufferRetainSize, commandBufLimit)
 	return &Writer{
-		f:               f,
-		bw:              bufio.NewWriterSize(f, normalizeBufferSize(opts.BufferSize)),
-		scratch:         make([]byte, 0, defaultBufferSize),
-		commandBuf:      commandBuf,
-		commandBufLimit: commandBufLimit,
-		size:            info.Size(),
-		maxSegmentSize:  normalizeMaxSegmentSize(opts.MaxSegmentSize),
-		compress:        opts.Compress,
-		syncFn:          func(file *os.File) error { return file.Sync() },
+		f:                f,
+		bw:               bufio.NewWriterSize(f, normalizeBufferSize(opts.BufferSize)),
+		commandBuf:       commandBuf,
+		commandBufLimit:  commandBufLimit,
+		commandBufRetain: commandBufRetain,
+		size:             info.Size(),
+		maxSegmentSize:   normalizeMaxSegmentSize(opts.MaxSegmentSize),
+		compress:         opts.Compress,
+		syncFn:           func(file *os.File) error { return file.Sync() },
 	}, nil
+}
+
+func normalizeCommandBufferRetainSize(retain, limit int) int {
+	if retain <= 0 || limit <= 0 {
+		return 0
+	}
+	if retain > limit {
+		return limit
+	}
+	return retain
+}
+
+func (w *Writer) BufferStats() WriterBufferStats {
+	if w == nil {
+		return WriterBufferStats{}
+	}
+	stats := WriterBufferStats{
+		ScratchCapacity:           cap(w.scratch),
+		CommandBufferLength:       len(w.commandBuf),
+		CommandBufferCapacity:     cap(w.commandBuf),
+		CommandBufferLimit:        w.commandBufferLimit(),
+		CommandBufferRetainLimit:  w.commandBufRetain,
+		CommandBufferTrimCount:    w.commandBufTrims,
+		CommandBufferDroppedBytes: w.commandBufDroppedBytes,
+		PendingBatchLength:        len(w.pendingBatch),
+		PendingBatchCapacity:      cap(w.pendingBatch),
+	}
+	if w.bw != nil {
+		stats.BufferedWriterSize = w.bw.Size()
+		stats.BufferedWriterBufferedBytes = w.bw.Buffered()
+	}
+	return stats
 }
 
 func newEncoder() (*zstd.Encoder, error) {
@@ -1221,8 +1271,23 @@ func (w *Writer) flushBufferedCommandFrames() error {
 		return w.poisonCommandBuffer(err)
 	}
 	w.size += int64(flushed)
-	w.commandBuf = w.commandBuf[:0]
+	w.trimCommandBufferAfterFlush()
 	return nil
+}
+
+func (w *Writer) trimCommandBufferAfterFlush() {
+	if w == nil || w.commandBuf == nil {
+		return
+	}
+	retain := w.commandBufRetain
+	if retain <= 0 || cap(w.commandBuf) <= retain {
+		w.commandBuf = w.commandBuf[:0]
+		return
+	}
+	dropped := cap(w.commandBuf) - retain
+	w.commandBuf = make([]byte, 0, retain)
+	w.commandBufTrims++
+	w.commandBufDroppedBytes += uint64(dropped)
 }
 
 func (w *Writer) commandBufferError() error {
@@ -1245,7 +1310,7 @@ func (w *Writer) poisonCommandBuffer(err error) error {
 		w.commandErr = err
 	}
 	if w.commandBuf != nil {
-		w.commandBuf = w.commandBuf[:0]
+		w.commandBuf = nil
 	}
 	return w.commandErr
 }


### PR DESCRIPTION
## Summary

Fixes #3251.

This targets the command-WAL heap node from the post-#3241 Celestia TreeDB run, where final pprof still showed `TreeDB/internal/commitlog.(*Writer).reserveCommandBufferSpace` retaining about `49.05 MiB` after command bytes had already flushed.

Changes:

- Bound retained deferred command-frame buffer capacity after flush with a 4 MiB TreeDB command-WAL retain cap.
- Keep the existing 64 MiB command-frame buffer limit so accepted frame shape does not change.
- Make commitlog writer scratch allocation lazy instead of allocating 4 MiB per writer at open.
- Add locked command-WAL writer buffer stats for buffer size, scratch capacity, command-buffer len/cap/limit/retain, trim count, dropped bytes, and pending batch capacity.
- Expose those stats through `DB.Stats()` so the next Celestia `application_vars` capture can verify the retained cap directly.

Expected production effect for the same Celestia protocol:

- `treedb.command_wal.writer.command_buffer.capacity_bytes` should be bounded at `4194304` after a flushed large point command.
- The final heap bucket attributed to `reserveCommandBufferSpace` should drop materially from the observed `49.05 MiB`, barring another active in-flight command at capture time.
- Existing command-WAL format, LSN assignment, flush/sync behavior, and replay semantics are unchanged.

## Validation

- `GOWORK=off go test ./TreeDB/internal/commitlog -count=1`
- `GOWORK=off go test ./TreeDB/db -run 'TestCommandWALStats|TestCommandWAL.*Flush|TestCommandWAL.*Replay|TestRawKVCommandWAL|TestAppendRawKVCommandWAL' -count=1`
- `GOWORK=off go test ./TreeDB -run 'TestPublicCommandWAL|TestCompactStoragePublicCommandWAL|TestCommandWAL' -count=1`
- `git diff --check`

## Follow-up

After merge, rerun the same Celestia TreeDB protocol from #3251, then do a strict same-window LevelDB-vs-TreeDB A/B before treating the numbers as comparative evidence.
