### PR TITLE
Skip retained terminal declared leaves

### DIFF
--- a/TreeDB/collections/column_retained_semantic_stream.go
+++ b/TreeDB/collections/column_retained_semantic_stream.go
@@ -1739,6 +1739,13 @@ func collectColumnRetainedSemanticStreamJSONParserObjectPathsWithSkip(raw []byte
 		if childSkip != nil && childSkip.terminal && childDeclared == nil {
 			return nil
 		}
+		if childSkip != nil && childSkip.terminal && childDeclared != nil && len(childDeclared.children) == 0 {
+			valueRaw := jsonParserIndexValue{raw: value, valueType: dataType}
+			for _, colIdx := range childDeclared.columnIndexes {
+				declaredValues[colIdx] = valueRaw
+			}
+			return nil
+		}
 		valuePath := pathInterner.intern(key)
 		nextValue := retainedObjectValue{
 			path:         valuePath,

--- a/TreeDB/collections/column_retained_vlog_placement_test.go
+++ b/TreeDB/collections/column_retained_vlog_placement_test.go
@@ -690,6 +690,7 @@ func TestColumnRetainedPayloadSemanticStreamV1NestedDeclaredPathsMatchRetainedJS
 		[]byte(`{"a":{"b":"drop"},"commit":{"operation":"drop"}}`),
 		[]byte(`{"a.b":"literal","commit.operation":"literal","a":{"b":"drop","x":"keep"}}`),
 		[]byte(`{"a":{"b":null,"x":"keep"},"commit":{"operation":null,"collection":"keep"},"payload":"nulls"}`),
+		[]byte(`{"a":{"b":"old","b":"drop","x":"keep"},"commit":{"operation":"old","operation":"drop","record":{"text":"keep"}}}`),
 	}
 	ids := [][]byte{
 		[]byte("doc-nested-0"),
@@ -698,6 +699,7 @@ func TestColumnRetainedPayloadSemanticStreamV1NestedDeclaredPathsMatchRetainedJS
 		[]byte("doc-nested-3"),
 		[]byte("doc-nested-4"),
 		[]byte("doc-nested-5"),
+		[]byte("doc-nested-6"),
 	}
 	prepared, err := prepareColumnRetainedPayloadInsertBatchStorageDocumentsWithIDs(cfg, ids, docs, nil)
 	if err != nil {
@@ -751,6 +753,7 @@ func TestColumnRetainedPayloadSemanticStreamV1NestedDeclaredPathsMatchRetainedJS
 	assertNestedRetainedSemanticStreamDeclaredRow(3, "doc-nested-3", "drop", "drop", true, false, true, false)
 	assertNestedRetainedSemanticStreamDeclaredRow(4, "doc-nested-4", "drop", "", true, false, false, true)
 	assertNestedRetainedSemanticStreamDeclaredRow(5, "doc-nested-5", "", "", true, true, true, true)
+	assertNestedRetainedSemanticStreamDeclaredRow(6, "doc-nested-6", "drop", "drop", true, false, true, false)
 	if columnRetainedSemanticStreamV1TestBytesAliasBytes(prepared.declaredRows[0].ID, ids[0]) {
 		t.Fatal("nested prepared declared row ID aliases mutable input ID")
 	}
@@ -835,6 +838,21 @@ func TestColumnRetainedPayloadSemanticStreamV1NestedDeclaredPathsMatchRetainedJS
 	}
 	if got := row4["commit.operation"]; got != "literal" {
 		t.Fatalf("literal dotted root key commit.operation=%v want literal: %s", got, rowsJSON[4])
+	}
+	row6 := decodeRetainedSemanticStreamTestObject(t, rowsJSON[6])
+	a6 := row6["a"].(map[string]any)
+	if _, ok := a6["b"]; ok {
+		t.Fatalf("duplicate terminal declared a.b leaked in row 6: %s", rowsJSON[6])
+	}
+	if got := a6["x"]; got != "keep" {
+		t.Fatalf("duplicate terminal retained a.x=%v want keep: %s", got, rowsJSON[6])
+	}
+	commit6 := row6["commit"].(map[string]any)
+	if _, ok := commit6["operation"]; ok {
+		t.Fatalf("duplicate terminal declared commit.operation leaked in row 6: %s", rowsJSON[6])
+	}
+	if got := commit6["record"].(map[string]any)["text"]; got != "keep" {
+		t.Fatalf("duplicate terminal retained commit.record.text=%v want keep: %s", got, rowsJSON[6])
 	}
 
 	ids[0][0] = 'X'


### PR DESCRIPTION
## Scope

- Skip retained semantic-stream entries for terminal declared paths before path interning/raw-value preparation.
- Preserve declared-row extraction for those terminal paths and retained reconstruction for sibling/non-declared fields.
- Add duplicate terminal declared-leaf coverage to keep last-value-wins behavior and ensure skipped declared leaves do not leak into retained reconstruction.

This is a load/retained-payload preparation slice for #3067/#3099. It is not a q5 query-speed change and does not change value-log durability, WAL behavior, publication visibility, fsync ordering, or storage format semantics.

## Evidence

Latest-base 1M JSONBench, `column-store-full-prepared`, q5, `one_shot_end_to_end`, `no_aggregate_metadata`, rows=1,000,000:

| build | artifact | load | insert | publish | asset prep | retained prep | typed prepare | storage |
| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| main `973323064` | `/tmp/jsonbench_main_973_retained_20260628_180423/report.json` | `10.246s` | `5.963s` | `3.686s` | `2.987s` | `2.060s` | `2.111s` | `137,491,255` |
| this branch | `/tmp/jsonbench_retained_prep_candidate_20260628_180434/report.json` | `10.015s` | `5.732s` | `3.642s` | `2.912s` | `1.873s` | `2.114s` | `137,491,279` |

Focused retained semantic-stream microbenchmark, from `/tmp/gomap-retained-prep-next_benchmark_gate_final.txt`:

- Baseline median: `16.19 ms/op`, `4340 allocs/op`
- Branch median: `14.59 ms/op`, `4338 allocs/op`
- Stored payload metrics unchanged: `0.01494 stored/input`, `19859 stored_block_B/op`
- Caveat: `n=3`, directional but not statistically strong (`benchstat p=0.100`).

## Validation

```sh
GOWORK=off go test ./TreeDB/collections -run 'TestColumnStoreSuiteRetainedPayload|TestAuditCollectionRetainedPayloadDeclaredPathsAbsentSemanticStreamV1|TestTypedColumn|TestColumnPublish|TestColumnPhysicalJSONBench' -count=1
GOWORK=off go test ./TreeDB/collections -count=1
GOWORK=off go test ./TreeDB -run 'TestReopenVerify_WALOn_Checkpoint|TestReopenVerify_WALOn_WriteSync' -count=1
GOWORK=off go test ./TreeDB/db -run 'TestValueLogGC_RemovesUnreferencedSegment' -count=1
GOWORK=off go test ./cmd/unified_bench -count=1
GOWORK=off go test ./TreeDB/collections -bench 'BenchmarkColumnRetainedPayloadSemanticStreamV1PrepareNestedDeclaredPaths|BenchmarkCollectionShapeInsertBatch' -run '^$' -benchtime=1000x -count=3
git diff --check
```
