### PR TITLE
Expose command-WAL stats in TreeDB expvar

### DIFF
--- a/TreeDB/caching/expvar_stats.go
+++ b/TreeDB/caching/expvar_stats.go
@@ -133,6 +133,7 @@ func selectTreeDBExpvarStats(stats map[string]string) map[string]any {
 		// compression, vlog zombie accounting, and live maintenance tracking.
 		if isProcessWideExpvarKey(k) ||
 			strings.HasPrefix(k, "treedb.process.identity.") ||
+			strings.HasPrefix(k, "treedb.command_wal.") ||
 			strings.HasPrefix(k, "treedb.vlog.mmap") ||
 			strings.HasPrefix(k, "treedb.vlog.decode_buffer_grow.") ||
 			strings.HasPrefix(k, "treedb.vlog.decode_scratch.") ||

--- a/TreeDB/caching/expvar_stats_test.go
+++ b/TreeDB/caching/expvar_stats_test.go
@@ -17,6 +17,12 @@ func containsAll(s string, subs ...string) bool {
 func TestSelectTreeDBExpvarStatsFiltersAndCoerces(t *testing.T) {
 	stats := map[string]string{
 		"treedb.process.identity.wal_dir":                                         "/tmp/app.db/wal",
+		"treedb.command_wal.enabled":                                              "true",
+		"treedb.command_wal.writer.command_buffer.capacity_bytes":                 "4194304",
+		"treedb.command_wal.writer.command_buffer.retain_limit_bytes":             "4194304",
+		"treedb.command_wal.writer.command_buffer.trim_count":                     "7",
+		"treedb.command_wal.writer.command_buffer.dropped_bytes_total":            "67108864",
+		"treedb.command_wal.writer.pending_batch.capacity_bytes":                  "32768",
 		"treedb.vlog.mmap_active_bytes":                                           "22222",
 		"treedb.vlog.mmap_max_mapped_leaf_sealed_bytes":                           "1610612736",
 		"treedb.vlog.decode_buffer_grow.read_append_decoded_payload.calls_total":  "17",
@@ -147,6 +153,24 @@ func TestSelectTreeDBExpvarStatsFiltersAndCoerces(t *testing.T) {
 	if v, ok := got["treedb.process.identity.wal_dir"].(string); !ok || v != "/tmp/app.db/wal" {
 		t.Fatalf("identity.wal_dir=%T(%v) want /tmp/app.db/wal", got["treedb.process.identity.wal_dir"], got["treedb.process.identity.wal_dir"])
 	}
+	if v, ok := got["treedb.command_wal.enabled"].(bool); !ok || !v {
+		t.Fatalf("command_wal.enabled=%T(%v) want bool(true)", got["treedb.command_wal.enabled"], got["treedb.command_wal.enabled"])
+	}
+	if v, ok := got["treedb.command_wal.writer.command_buffer.capacity_bytes"].(int64); !ok || v != 4194304 {
+		t.Fatalf("command_buffer.capacity_bytes=%T(%v) want int64(4194304)", got["treedb.command_wal.writer.command_buffer.capacity_bytes"], got["treedb.command_wal.writer.command_buffer.capacity_bytes"])
+	}
+	if v, ok := got["treedb.command_wal.writer.command_buffer.retain_limit_bytes"].(int64); !ok || v != 4194304 {
+		t.Fatalf("command_buffer.retain_limit_bytes=%T(%v) want int64(4194304)", got["treedb.command_wal.writer.command_buffer.retain_limit_bytes"], got["treedb.command_wal.writer.command_buffer.retain_limit_bytes"])
+	}
+	if v, ok := got["treedb.command_wal.writer.command_buffer.trim_count"].(int64); !ok || v != 7 {
+		t.Fatalf("command_buffer.trim_count=%T(%v) want int64(7)", got["treedb.command_wal.writer.command_buffer.trim_count"], got["treedb.command_wal.writer.command_buffer.trim_count"])
+	}
+	if v, ok := got["treedb.command_wal.writer.command_buffer.dropped_bytes_total"].(int64); !ok || v != 67108864 {
+		t.Fatalf("command_buffer.dropped_bytes_total=%T(%v) want int64(67108864)", got["treedb.command_wal.writer.command_buffer.dropped_bytes_total"], got["treedb.command_wal.writer.command_buffer.dropped_bytes_total"])
+	}
+	if v, ok := got["treedb.command_wal.writer.pending_batch.capacity_bytes"].(int64); !ok || v != 32768 {
+		t.Fatalf("pending_batch.capacity_bytes=%T(%v) want int64(32768)", got["treedb.command_wal.writer.pending_batch.capacity_bytes"], got["treedb.command_wal.writer.pending_batch.capacity_bytes"])
+	}
 	if v, ok := got["treedb.process.memory.pool_pressure_level"].(string); !ok || v != "critical" {
 		t.Fatalf("pool_pressure_level=%T(%v) want string(critical)", got["treedb.process.memory.pool_pressure_level"], got["treedb.process.memory.pool_pressure_level"])
 	}
@@ -234,9 +258,11 @@ func TestCurrentTreeDBExpvarStatsIncludesInstances(t *testing.T) {
 		backend: &mockBackendWithStats{
 			MockBackend: NewMockBackend(),
 			stats: map[string]string{
-				"treedb.process.identity.wal_dir":        "/tmp/b/wal",
-				"treedb.process.memory.heap_inuse_bytes": "222",
-				"treedb.vlog.mmap_active_bytes":          "9",
+				"treedb.process.identity.wal_dir":                              "/tmp/b/wal",
+				"treedb.process.memory.heap_inuse_bytes":                       "222",
+				"treedb.command_wal.writer.command_buffer.capacity_bytes":      "4194304",
+				"treedb.command_wal.writer.command_buffer.dropped_bytes_total": "67108864",
+				"treedb.vlog.mmap_active_bytes":                                "9",
 			},
 		},
 	}
@@ -274,6 +300,12 @@ func TestCurrentTreeDBExpvarStatsIncludesInstances(t *testing.T) {
 	}
 	if instA["treedb.expvar.wal_dir"] != "/tmp/a/wal" || instB["treedb.expvar.wal_dir"] != "/tmp/b/wal" {
 		t.Fatalf("unexpected instance wal dirs: a=%v b=%v", instA["treedb.expvar.wal_dir"], instB["treedb.expvar.wal_dir"])
+	}
+	if instB["treedb.command_wal.writer.command_buffer.capacity_bytes"] != int64(4194304) {
+		t.Fatalf("instance b command buffer capacity=%T(%v) want int64(4194304)", instB["treedb.command_wal.writer.command_buffer.capacity_bytes"], instB["treedb.command_wal.writer.command_buffer.capacity_bytes"])
+	}
+	if instB["treedb.command_wal.writer.command_buffer.dropped_bytes_total"] != int64(67108864) {
+		t.Fatalf("instance b command buffer dropped bytes=%T(%v) want int64(67108864)", instB["treedb.command_wal.writer.command_buffer.dropped_bytes_total"], instB["treedb.command_wal.writer.command_buffer.dropped_bytes_total"])
 	}
 }
 


### PR DESCRIPTION
## Objective

Expose backend `treedb.command_wal.*` counters through TreeDB `/debug/vars` expvar diagnostics so Celestia app-state runs can prove the command-WAL writer-buffer state added by #3252.

Fixes #3255. Supports #3238.

## Context

The post-#3252 Celestia run showed `reserveCommandBufferSpace` gone from the final heap top, but `/debug/vars` contained no `command_wal` keys, so #3238 could not prove the command-buffer cap from production-style artifacts. `cmd/internal/treedbstats.Selected` already kept `treedb.command_wal.*`; the missing link was `TreeDB/caching/expvar_stats.go`, which has a separate selector for `/debug/vars`.

## Non-goals

- No command-WAL behavior, durability, or on-disk format change.
- No append-only heap optimization in this PR.
- No LevelDB-vs-TreeDB A/B claim from this run.
- No harness special-case for command-WAL stats; the existing `treedb_application_vars.json` path now receives the stats through normal expvar selection.

## Design

- Add `treedb.command_wal.` to `selectTreeDBExpvarStats`.
- Extend expvar selector tests for the exact counters needed by #3238:
  - `treedb.command_wal.writer.command_buffer.capacity_bytes`
  - `retain_limit_bytes`
  - `trim_count`
  - `dropped_bytes_total`
  - `pending_batch.capacity_bytes`
- Extend the expvar instance test so per-DB instance snapshots preserve command-WAL counters, not only the top-level current DB snapshot.

## Scope

- Includes: `TreeDB/caching/expvar_stats.go`, `TreeDB/caching/expvar_stats_test.go`
- Excludes: command-WAL writer internals, cached write path, Celestia harness scripts, value-log maintenance

## Correctness

Tests run:

```sh
GOWORK=off go test ./TreeDB/caching -run 'TestSelectTreeDBExpvarStats|TestCurrentTreeDBExpvarStats' -count=1
GOWORK=off go test ./TreeDB/db -run 'TestCommandWALStats' -count=1
GOWORK=off go test ./TreeDB -run 'TestCommandWAL|Test.*CommandWAL' -count=1
git diff --check origin/main...HEAD
```

Results: all passed.

Celestia build-only validation:

```sh
RUN_CELESTIA_BUILD_ONLY=1 \
LOCAL_GOMAP_DIR=/tmp/gomap-celestia-main-9733230 \
TRUST_HEIGHT=11714074 \
TRUST_HASH=AC2679168CE4DCFA9AA7355E52A265A2CA6250C9A9392B3EF3BFACA284B5104E \
STOP_AT_LOCAL_HEIGHT=11715650 \
POST_SYNC_DWELL_SECONDS=300 \
~/run_celestia.sh
```

Result: build-only validation completed; build info showed local `github.com/snissn/gomap (devel)` and local `treemap` from `/tmp/gomap-celestia-main-9733230`.

## Performance / Production Evidence

This is instrumentation-only. No performance improvement is claimed. I reran the same #3238 TreeDB Celestia protocol to prove the diagnostic path now carries the counters:

```sh
LOCAL_GOMAP_DIR=/tmp/gomap-celestia-main-9733230 \
TRUST_HEIGHT=11714074 \
TRUST_HASH=AC2679168CE4DCFA9AA7355E52A265A2CA6250C9A9392B3EF3BFACA284B5104E \
STOP_AT_LOCAL_HEIGHT=11715650 \
POST_SYNC_DWELL_SECONDS=300 \
~/run_celestia.sh
```

Run home: `/home/mikers/.celestia-app-mainnet-treedb-20260628180757`

Summary:

| Metric | Value |
| --- | ---: |
| sync duration | `272s` |
| total duration incl. dwell | `573s` |
| dwell elapsed | `301s` |
| final local height | `11734522` |
| final remote height | `11734673` |
| max RSS | `8,682,652 KiB` |
| max HWM | `9,055,812 KiB` |
| final app DB bytes | `2,238,657,046` |
| final home bytes | `3,091,399,168` |

Error scan:

```sh
rg -n 'valuelog: corrupt record|state sync failed|state sync aborted|failed to restore snapshot|IAVL node import failed|IAVL commit failed|panic:|fatal error' \
  /home/mikers/.celestia-app-mainnet-treedb-20260628180757/sync/node.log
```

Result: no matches.

Command-WAL counters now appear in final `treedb_application_vars.json`:

| Counter | Final value |
| --- | ---: |
| `treedb.command_wal.enabled` | `true` |
| `treedb.command_wal.live_accepted_frames` | `27985` |
| `treedb.command_wal.live_covered_frames` | `27985` |
| `treedb.command_wal.applied_lsn` | `27985` |
| `treedb.command_wal.writer.command_buffer.length_bytes` | `0` |
| `treedb.command_wal.writer.command_buffer.capacity_bytes` | `127392` |
| `treedb.command_wal.writer.command_buffer.retain_limit_bytes` | `4194304` |
| `treedb.command_wal.writer.command_buffer.limit_bytes` | `67108864` |
| `treedb.command_wal.writer.command_buffer.trim_count` | `0` |
| `treedb.command_wal.writer.command_buffer.dropped_bytes_total` | `0` |
| `treedb.command_wal.writer.pending_batch.capacity_bytes` | `0` |
| `treedb.command_wal.cleanup.removed_bytes` | `5093261951` |
| `treedb.command_wal.segment_files` | `0` |

Dwell samples also carried the counters:

| Sample | RSS KiB | App DB bytes | Command buffer cap | Retain limit | Live accepted frames |
| --- | ---: | ---: | ---: | ---: | ---: |
| 0 | `8393156` | `4057541660` | `63696` | `4194304` | `22526` |
| 1 | `8557288` | `3145912246` | `127392` | `4194304` | `26852` |
| 2 | `7026484` | `2401727777` | `127392` | `4194304` | `27175` |
| 3 | `7269440` | `2229184950` | `127392` | `4194304` | `27445` |
| 4 | `7289680` | `2236422630` | `127392` | `4194304` | `27688` |

Heap notes from the same run, final pprof:

| Bucket | Final in-use |
| --- | ---: |
| `reserveCommandBufferSpace` | not present |
| `getAppendOnlyEntries` | `165.57 MiB` |
| `getDecodeScratch` | `145.21 MiB` |
| `bufio.NewWriterSize` | `86.91 MiB` |
| `leafPageReadCache...store` | `52.71 MiB` |
| `getBatchArena` | `35.67 MiB` |

Peak captured `getAppendOnlyEntries` was `755.78 MiB`; that remains the likely next TreeDB-owned memory-high-water blocker for #3238, while IAVL restore heap is still the largest final retained class.

## Rollout / Toggle Plan

Default behavior: more diagnostic keys are exported under the existing TreeDB expvar object. Disable remains the existing `TREEDB_ENABLE_EXPVAR_STATS=0` path.

## Follow-ups

- Update #3238 with this evidence and keep it open.
- Next TreeDB-owned work should classify/fix peak append-only allocation / live residency using the now-visible command-WAL counters.
- Root-span-native/IAVL importer work remains tracked separately and should not be blocked by this instrumentation slice.

## AI Review Loop

- Codex latest-head review: not yet requested.
- Copilot latest-head review: not yet requested.
- CodeRabbit latest-head review: not yet requested.
- Review comments/threads resolved or explicitly dismissed: none yet.
