### PR TITLE
Refresh nativewire cluster rejection test

### DIFF
--- a/TreeDB/nativewire/cluster_submitter_test.go
+++ b/TreeDB/nativewire/cluster_submitter_test.go
@@ -299,14 +299,19 @@ func TestClusterSubmitterUnsupportedCommandFailsBeforeMutation(t *testing.T) {
 		t.Fatalf("seed InsertBatchValidatedBSON: %v", err)
 	}
 
-	_, _, err = client.UpdateBSONSet(ctx, "users", []byte("u1"), []collections.BSONSetField{
-		{Key: "field0", Value: mustNativewireBSONRawValue(t, "new")},
-	}, AckVisible)
+	_, err = client.CreateIndex(ctx, "users", collections.IndexDefinition{
+		Name:      "field0",
+		Field:     "field0",
+		ValueType: collections.IndexValueString,
+	})
 	if !isRemoteError(err, iwire.ErrUnsupportedFeature) {
-		t.Fatalf("UpdateBSONSet cluster err=%v want unsupported feature", err)
+		t.Fatalf("CreateIndex cluster err=%v want unsupported feature", err)
 	}
 	if len(submitter.snapshot()) != 0 {
 		t.Fatalf("unsupported command reached submitter")
+	}
+	if indexes := col.Meta().Indexes; len(indexes) != 0 {
+		t.Fatalf("index created after unsupported cluster command: %+v", indexes)
 	}
 	got, err := col.Get([]byte("u1"))
 	if err != nil {


### PR DESCRIPTION
## Objective
Refresh the nativewire cluster-submitter rejection regression now that `CommandUpdateBSONSet` is accepted by the R3a v1 matrix.

## Context
Current `origin/main` fails Root vet+test in `TreeDB/nativewire` because `TestClusterSubmitterUnsupportedCommandFailsBeforeMutation` still uses `UpdateBSONSet` as the rejected command. #3254 intentionally made that command accepted, so the request now correctly reaches the submitter.

## Non-goals
- No production behavior change.
- No R3a matrix change.
- No storage, WAL, value-log, or benchmark change.

## Design
The test now uses `CreateIndex`, which remains rejected by `raftentry.ClassifyNativeWireCommandV1`, and asserts both that the fake cluster submitter saw no call and that no index was created locally.

## Scope
- Includes: `TreeDB/nativewire/cluster_submitter_test.go`
- Excludes: server admission behavior, raft apply, storage/durability paths.

## Correctness
- Tests run:
  - `GOWORK=off go test ./TreeDB/nativewire -run 'TestClusterSubmitterUnsupportedCommandFailsBeforeMutation|TestClusterSubmitterReceivesDecodableDeterministicEntries|TestMutationUpdateBSONSetRoundTrip' -count=1`
  - `GOWORK=off go test ./TreeDB/nativewire -count=1`
  - `GOWORK=off go test ./TreeDB/internal/raftentry -count=1`
- Corruption/edge cases covered: not applicable; this is a test-only update.
- Concurrency/race coverage: not applicable.

## Performance
- Benchmarks run: not applicable; test-only CI unblocker.

## Rollout / Toggle Plan
- Default setting: unchanged.
- How to disable quickly: revert this test-only commit.

## Follow-ups
- Rebase/update typed-column load PR #3261 after this mainline CI blocker lands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated coverage for unsupported cluster commands to ensure they fail immediately, do not reach cluster submission, and do not change collection metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->