### PR TITLE
Refresh unsupported cluster admission fixture

### DIFF
--- a/TreeDB/nativewire/cluster_submitter_test.go
+++ b/TreeDB/nativewire/cluster_submitter_test.go
@@ -299,11 +299,10 @@ func TestClusterSubmitterUnsupportedCommandFailsBeforeMutation(t *testing.T) {
 		t.Fatalf("seed InsertBatchValidatedBSON: %v", err)
 	}
 
-	_, _, err = client.UpdateBSONSet(ctx, "users", []byte("u1"), []collections.BSONSetField{
-		{Key: "field0", Value: mustNativewireBSONRawValue(t, "new")},
-	}, AckVisible)
+	body := mustCommandBody(t, iwire.CommandDropCollection, collectionNameRef("users"))
+	_, _, err = client.roundTrip(ctx, iwire.FrameRequest, body, iwire.FrameResponse)
 	if !isRemoteError(err, iwire.ErrUnsupportedFeature) {
-		t.Fatalf("UpdateBSONSet cluster err=%v want unsupported feature", err)
+		t.Fatalf("DropCollection cluster err=%v want unsupported feature", err)
 	}
 	if len(submitter.snapshot()) != 0 {
 		t.Fatalf("unsupported command reached submitter")


### PR DESCRIPTION
Closes #3264.

## Summary

- refresh `TestClusterSubmitterUnsupportedCommandFailsBeforeMutation` to use `drop_collection` as the rejected cluster mutation fixture
- preserve the guard that rejected cluster mutations fail before `ClusterSubmitter` receives deterministic entry bytes
- keep this as a test-only unblock after `UpdateBSONSet` became an accepted R3a/native-wire command

## Validation

- `GOWORK=off go test ./TreeDB/nativewire -run TestClusterSubmitterUnsupportedCommandFailsBeforeMutation -count=5`
- `GOWORK=off go test ./TreeDB/nativewire -count=1`
