### PR TITLE
TreeDB Raft: route Mongo gateway writes through cluster submitter

### DIFF
--- a/TreeDB/mongo_gateway/cluster_submitter.go
+++ b/TreeDB/mongo_gateway/cluster_submitter.go
@@ -79,10 +79,18 @@ func (s *Server) clusterInsertResponse(ctx context.Context, command wire.Documen
 	if err != nil {
 		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
 	}
-	format := s.clusterCollectionFormat(name)
+	format, exists, err := s.clusterCollectionFormat(name)
+	if err != nil {
+		return commandError(commandCodeBadValue, "BadValue", err.Error())
+	}
 	ids, stored, err := prepareInsertDocuments(documents, format)
 	if err != nil {
 		return commandError(commandCodeBadValue, "BadValue", err.Error())
+	}
+	if !exists {
+		if err := s.submitClusterCreateCollection(ctx, *s.defaultCollectionMeta(name)); err != nil {
+			return mongoClusterMutationCommandError(err)
+		}
 	}
 	inserted, err := s.submitClusterInsert(ctx, name, format, ids, stored)
 	if err != nil {
@@ -155,22 +163,44 @@ func (s *Server) clusterDeleteResponse(ctx context.Context, command wire.Documen
 	}
 	ids := make([][]byte, 0, len(deletes))
 	seenIDs := make(map[string]struct{}, len(deletes))
+	submitPendingBeforeError := func() error {
+		if len(ids) == 0 {
+			return nil
+		}
+		_, err := s.submitClusterDelete(ctx, name, ids)
+		return err
+	}
 	for i, deleteItem := range deletes {
 		filter, err := requiredDocumentField(deleteItem, "q")
 		if err != nil {
+			if submitErr := submitPendingBeforeError(); submitErr != nil {
+				return mongoClusterMutationCommandError(submitErr)
+			}
 			return commandError(commandCodeFailedToParse, "FailedToParse", fmt.Sprintf("deletes[%d]: %v", i, err))
 		}
 		id, err := idEqualityFilterValue(filter, "delete")
 		if err != nil {
+			if submitErr := submitPendingBeforeError(); submitErr != nil {
+				return mongoClusterMutationCommandError(submitErr)
+			}
 			return commandError(commandCodeBadValue, "BadValue", fmt.Sprintf("deletes[%d]: %v", i, err))
 		}
 		if limit, err := optionalInt32Field(deleteItem, "limit"); err != nil {
+			if submitErr := submitPendingBeforeError(); submitErr != nil {
+				return mongoClusterMutationCommandError(submitErr)
+			}
 			return commandError(commandCodeFailedToParse, "FailedToParse", fmt.Sprintf("deletes[%d]: %v", i, err))
 		} else if limit != 0 && limit != 1 {
+			if submitErr := submitPendingBeforeError(); submitErr != nil {
+				return mongoClusterMutationCommandError(submitErr)
+			}
 			return commandError(commandCodeBadValue, "BadValue", "Mongo gateway delete limit must be 0 or 1")
 		}
 		key, err := encodePrimaryKey(id)
 		if err != nil {
+			if submitErr := submitPendingBeforeError(); submitErr != nil {
+				return mongoClusterMutationCommandError(submitErr)
+			}
 			return commandError(commandCodeBadValue, "BadValue", fmt.Sprintf("deletes[%d]: %v", i, err))
 		}
 		keyString := string(key)
@@ -187,14 +217,18 @@ func (s *Server) clusterDeleteResponse(ctx context.Context, command wire.Documen
 	return marshalDeleteResponse(deleted)
 }
 
-func (s *Server) clusterCollectionFormat(name string) collections.DocumentFormat {
+func (s *Server) clusterCollectionFormat(name string) (collections.DocumentFormat, bool, error) {
 	format := s.DefaultCollectionOptions.DocumentFormat
 	if s != nil && s.Collections != nil {
-		if col, err := s.Collections.OpenCollection(name); err == nil && col != nil {
-			format = col.MetaView().Options.DocumentFormat
+		col, err := s.Collections.OpenCollection(name)
+		if err == nil && col != nil {
+			return col.MetaView().Options.DocumentFormat, true, nil
+		}
+		if err != nil && !errors.Is(err, collections.ErrCollectionNotFound) {
+			return format, false, err
 		}
 	}
-	return format
+	return format, false, nil
 }
 
 func (s *Server) submitClusterCreateCollection(ctx context.Context, meta collections.CollectionMeta) error {
@@ -205,7 +239,10 @@ func (s *Server) submitClusterCreateCollection(ctx context.Context, meta collect
 	if err != nil {
 		return err
 	}
-	sections, seq := s.clusterCreateCollectionSections(meta, catalogVersion)
+	sections, seq, err := s.clusterCreateCollectionSections(meta, catalogVersion)
+	if err != nil {
+		return err
+	}
 	_, err = s.submitClusterMutation(ctx, iwire.CommandCreateCollection, sections, seq)
 	return err
 }
@@ -215,11 +252,14 @@ func (s *Server) submitClusterInsert(ctx context.Context, name string, format co
 	if err != nil {
 		return 0, err
 	}
-	sections, seq := s.clusterMutationSections(iwire.CommandInsertBatch, "insert_batch", name, catalogVersion,
+	sections, seq, err := s.clusterMutationSections(iwire.CommandInsertBatch, "insert_batch", name, catalogVersion,
 		clusterDocumentFormatSection(format),
 		iwire.Section{ID: iwire.SectionDocumentIDs, Bytes: iwire.AppendByteVector(nil, ids...)},
 		iwire.Section{ID: iwire.SectionDocuments, Bytes: iwire.AppendByteVector(nil, docs...)},
 	)
+	if err != nil {
+		return 0, err
+	}
 	response, err := s.submitClusterMutation(ctx, iwire.CommandInsertBatch, sections, seq)
 	if err != nil {
 		return 0, err
@@ -239,11 +279,14 @@ func (s *Server) submitClusterUpdateBSONSet(ctx context.Context, name string, it
 	if err != nil {
 		return 0, 0, err
 	}
-	sections, seq := s.clusterMutationSections(iwire.CommandUpdateBSONSet, "update_bson_set", name, catalogVersion,
+	sections, seq, err := s.clusterMutationSections(iwire.CommandUpdateBSONSet, "update_bson_set", name, catalogVersion,
 		iwire.Section{ID: iwire.SectionDocumentIDs, Bytes: iwire.AppendByteVector(nil, item.key)},
 		clusterBSONSetFieldNamesSection(item.bsonSetFields),
 		clusterBSONSetFieldValuesSection(item.bsonSetFields),
 	)
+	if err != nil {
+		return 0, 0, err
+	}
 	response, err := s.submitClusterMutation(ctx, iwire.CommandUpdateBSONSet, sections, seq)
 	if err != nil {
 		return 0, 0, err
@@ -273,9 +316,12 @@ func (s *Server) submitClusterDelete(ctx context.Context, name string, ids [][]b
 	if err != nil {
 		return 0, err
 	}
-	sections, seq := s.clusterMutationSections(iwire.CommandDeleteBatch, "delete_batch", name, catalogVersion,
+	sections, seq, err := s.clusterMutationSections(iwire.CommandDeleteBatch, "delete_batch", name, catalogVersion,
 		iwire.Section{ID: iwire.SectionDocumentIDs, Bytes: iwire.AppendByteVector(nil, ids...)},
 	)
+	if err != nil {
+		return 0, err
+	}
 	response, err := s.submitClusterMutation(ctx, iwire.CommandDeleteBatch, sections, seq)
 	if err != nil {
 		return 0, err
@@ -290,27 +336,52 @@ func (s *Server) submitClusterDelete(ctx context.Context, name string, ids [][]b
 	return deleted, nil
 }
 
-func (s *Server) clusterCreateCollectionSections(meta collections.CollectionMeta, catalogVersion uint64) ([]iwire.Section, uint64) {
+func (s *Server) clusterCreateCollectionSections(meta collections.CollectionMeta, catalogVersion uint64) ([]iwire.Section, uint64, error) {
 	seq := s.nextClusterSubmit.Add(1)
+	idempotencyKey, err := s.clusterIdempotencyKey("create_collection", seq)
+	if err != nil {
+		return nil, 0, err
+	}
 	sections := []iwire.Section{
 		{ID: iwire.SectionCommandHeader, Bytes: iwire.AppendCommandHeader(nil, iwire.CommandHeader{ID: iwire.CommandCreateCollection, Version: 1})},
-		{ID: iwire.SectionIdempotencyKey, Bytes: []byte("mongo-gateway/create_collection/" + strconv.FormatUint(seq, 10))},
+		{ID: iwire.SectionIdempotencyKey, Bytes: idempotencyKey},
 		{ID: iwire.SectionExpectedCatalogVersion, Bytes: binary.AppendUvarint(nil, catalogVersion)},
 		clusterCollectionMetaSection(meta),
 	}
-	return sections, seq
+	return sections, seq, nil
 }
 
-func (s *Server) clusterMutationSections(command iwire.CommandID, commandName, collection string, catalogVersion uint64, payload ...iwire.Section) ([]iwire.Section, uint64) {
+func (s *Server) clusterMutationSections(command iwire.CommandID, commandName, collection string, catalogVersion uint64, payload ...iwire.Section) ([]iwire.Section, uint64, error) {
 	seq := s.nextClusterSubmit.Add(1)
+	idempotencyKey, err := s.clusterIdempotencyKey(commandName, seq)
+	if err != nil {
+		return nil, 0, err
+	}
 	sections := make([]iwire.Section, 0, 5+len(payload))
 	sections = append(sections,
 		iwire.Section{ID: iwire.SectionCommandHeader, Bytes: iwire.AppendCommandHeader(nil, iwire.CommandHeader{ID: command, Version: 1})},
-		iwire.Section{ID: iwire.SectionIdempotencyKey, Bytes: []byte("mongo-gateway/" + commandName + "/" + strconv.FormatUint(seq, 10))},
+		iwire.Section{ID: iwire.SectionIdempotencyKey, Bytes: idempotencyKey},
 		iwire.Section{ID: iwire.SectionExpectedCatalogVersion, Bytes: binary.AppendUvarint(nil, catalogVersion)},
 		clusterCollectionNameRefSection(collection),
 	)
-	return append(sections, payload...), seq
+	return append(sections, payload...), seq, nil
+}
+
+func (s *Server) clusterIdempotencyKey(commandName string, seq uint64) ([]byte, error) {
+	if s == nil || s.ClusterIdempotencyNonce == "" {
+		return nil, errors.New("Mongo gateway cluster idempotency nonce is not configured")
+	}
+	key := make([]byte, 0, len("mongo-gateway/")+len(s.ClusterIdempotencyNonce)+1+len(commandName)+1+20)
+	key = append(key, "mongo-gateway/"...)
+	key = append(key, s.ClusterIdempotencyNonce...)
+	key = append(key, '/')
+	key = append(key, commandName...)
+	key = append(key, '/')
+	key = strconv.AppendUint(key, seq, 10)
+	if len(key) > raftentry.MaxIdempotencyKeyBytesV1 {
+		return nil, fmt.Errorf("Mongo gateway cluster idempotency key length %d exceeds %d", len(key), raftentry.MaxIdempotencyKeyBytesV1)
+	}
+	return key, nil
 }
 
 func (s *Server) submitClusterMutation(ctx context.Context, command iwire.CommandID, sections []iwire.Section, seq uint64) ([]iwire.Section, error) {

--- a/TreeDB/mongo_gateway/cluster_submitter.go
+++ b/TreeDB/mongo_gateway/cluster_submitter.go
@@ -350,9 +350,7 @@ func validateMongoClusterSubmitResult(result treenativewire.ClusterSubmitResult)
 	switch result.ActualAck {
 	case iwire.AckVisible, iwire.AckFlushed, iwire.AckSynced:
 	case iwire.AckRaftCommitted:
-		if !result.CommittedRecoverable {
-			return errors.New("cluster submitter returned raft_committed without committed recoverability")
-		}
+		return errors.New("cluster submitter returned raft_committed without proving requested local visibility")
 	default:
 		return fmt.Errorf("cluster submitter returned unsupported ack policy %d", result.ActualAck)
 	}

--- a/TreeDB/mongo_gateway/cluster_submitter.go
+++ b/TreeDB/mongo_gateway/cluster_submitter.go
@@ -1,0 +1,445 @@
+package mongogateway
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"strconv"
+
+	"github.com/snissn/gomap/TreeDB/collections"
+	iwire "github.com/snissn/gomap/TreeDB/internal/nativewire"
+	"github.com/snissn/gomap/TreeDB/internal/raftentry"
+	"github.com/snissn/gomap/TreeDB/mongo_gateway/wire"
+	treenativewire "github.com/snissn/gomap/TreeDB/nativewire"
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+const (
+	clusterCollectionRefNameTag = byte(1)
+	clusterSyntheticCatalogV1   = uint64(0)
+)
+
+func (s *Server) clusterSubmitterConfigured() bool {
+	return s != nil && s.ClusterSubmitter != nil
+}
+
+func (s *Server) clusterInsertResponse(command wire.Document, sequences []wire.DocumentSequence) (wire.Document, error) {
+	if err := rejectClusterWriteConcern(command); err != nil {
+		return commandError(commandCodeBadValue, "BadValue", err.Error())
+	}
+	collection, err := commandString(command, "insert")
+	if err != nil {
+		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
+	}
+	db, err := commandString(command, "$db")
+	if err != nil {
+		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
+	}
+	name, err := gatewayCollectionName(db, collection)
+	if err != nil {
+		return commandError(commandCodeBadValue, "BadValue", err.Error())
+	}
+	documents, err := commandDocuments(command, sequences, "documents")
+	if err != nil {
+		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
+	}
+	format := s.clusterCollectionFormat(name)
+	ids, stored, err := prepareInsertDocuments(documents, format)
+	if err != nil {
+		return commandError(commandCodeBadValue, "BadValue", err.Error())
+	}
+	inserted, err := s.submitClusterInsert(name, format, ids, stored)
+	if err != nil {
+		return mongoClusterMutationCommandError(err)
+	}
+	return marshalDocument(bson.D{
+		{Key: "ok", Value: 1.0},
+		{Key: "n", Value: inserted},
+	})
+}
+
+func (s *Server) clusterUpdateResponse(command wire.Document, sequences []wire.DocumentSequence) (wire.Document, error) {
+	if err := rejectClusterWriteConcern(command); err != nil {
+		return commandError(commandCodeBadValue, "BadValue", err.Error())
+	}
+	collection, err := commandString(command, "update")
+	if err != nil {
+		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
+	}
+	db, err := commandString(command, "$db")
+	if err != nil {
+		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
+	}
+	name, err := gatewayCollectionName(db, collection)
+	if err != nil {
+		return commandError(commandCodeBadValue, "BadValue", err.Error())
+	}
+	updates, err := commandDocuments(command, sequences, "updates")
+	if err != nil {
+		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
+	}
+	parsed := make([]mongoUpdateItem, 0, len(updates))
+	for i, update := range updates {
+		item, err := parseMongoUpdateItem(i, update)
+		if err != nil {
+			return mongoUpdateParseCommandError(err)
+		}
+		if !item.bsonSetFieldsOK {
+			return commandError(commandCodeBadValue, "BadValue", fmt.Sprintf("updates[%d]: cluster Mongo gateway currently supports only top-level BSON $set updateOne by _id", i))
+		}
+		parsed = append(parsed, item)
+	}
+	var matched, modified int32
+	for _, item := range parsed {
+		matchedOne, modifiedOne, err := s.submitClusterUpdateBSONSet(name, item)
+		if err != nil {
+			return mongoClusterMutationCommandError(mongoUpdateErrorWithIndex(item.index, err))
+		}
+		matched += matchedOne
+		modified += modifiedOne
+	}
+	return marshalUpdateResponse(matched, modified)
+}
+
+func (s *Server) clusterDeleteResponse(command wire.Document, sequences []wire.DocumentSequence) (wire.Document, error) {
+	if err := rejectClusterWriteConcern(command); err != nil {
+		return commandError(commandCodeBadValue, "BadValue", err.Error())
+	}
+	collection, err := commandString(command, "delete")
+	if err != nil {
+		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
+	}
+	db, err := commandString(command, "$db")
+	if err != nil {
+		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
+	}
+	name, err := gatewayCollectionName(db, collection)
+	if err != nil {
+		return commandError(commandCodeBadValue, "BadValue", err.Error())
+	}
+	deletes, err := commandDocuments(command, sequences, "deletes")
+	if err != nil {
+		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
+	}
+	ids := make([][]byte, 0, len(deletes))
+	for i, deleteItem := range deletes {
+		filter, err := requiredDocumentField(deleteItem, "q")
+		if err != nil {
+			return commandError(commandCodeFailedToParse, "FailedToParse", fmt.Sprintf("deletes[%d]: %v", i, err))
+		}
+		id, err := idEqualityFilterValue(filter, "delete")
+		if err != nil {
+			return commandError(commandCodeBadValue, "BadValue", fmt.Sprintf("deletes[%d]: %v", i, err))
+		}
+		if limit, err := optionalInt32Field(deleteItem, "limit"); err != nil {
+			return commandError(commandCodeFailedToParse, "FailedToParse", fmt.Sprintf("deletes[%d]: %v", i, err))
+		} else if limit != 0 && limit != 1 {
+			return commandError(commandCodeBadValue, "BadValue", "Mongo gateway delete limit must be 0 or 1")
+		}
+		key, err := encodePrimaryKey(id)
+		if err != nil {
+			return commandError(commandCodeBadValue, "BadValue", fmt.Sprintf("deletes[%d]: %v", i, err))
+		}
+		ids = append(ids, key)
+	}
+	deleted, err := s.submitClusterDelete(name, ids)
+	if err != nil {
+		return mongoClusterMutationCommandError(err)
+	}
+	return marshalDeleteResponse(deleted)
+}
+
+func (s *Server) clusterCollectionFormat(name string) collections.DocumentFormat {
+	format := s.DefaultCollectionOptions.DocumentFormat
+	if s != nil && s.Collections != nil {
+		if col, err := s.Collections.OpenCollection(name); err == nil && col != nil {
+			format = col.MetaView().Options.DocumentFormat
+		}
+	}
+	return format
+}
+
+func (s *Server) submitClusterInsert(name string, format collections.DocumentFormat, ids, docs [][]byte) (int32, error) {
+	sections, seq := s.clusterMutationSections(iwire.CommandInsertBatch, "insert_batch", name,
+		clusterDocumentFormatSection(format),
+		iwire.Section{ID: iwire.SectionDocumentIDs, Bytes: iwire.AppendByteVector(nil, ids...)},
+		iwire.Section{ID: iwire.SectionDocuments, Bytes: iwire.AppendByteVector(nil, docs...)},
+	)
+	response, err := s.submitClusterMutation(iwire.CommandInsertBatch, sections, seq)
+	if err != nil {
+		return 0, err
+	}
+	inserted, ok, err := clusterResponseMetaInt32(response, "inserted_count")
+	if err != nil {
+		return 0, err
+	}
+	if !ok {
+		return int32(len(ids)), nil
+	}
+	return inserted, nil
+}
+
+func (s *Server) submitClusterUpdateBSONSet(name string, item mongoUpdateItem) (int32, int32, error) {
+	sections, seq := s.clusterMutationSections(iwire.CommandUpdateBSONSet, "update_bson_set", name,
+		iwire.Section{ID: iwire.SectionDocumentIDs, Bytes: iwire.AppendByteVector(nil, item.key)},
+		clusterBSONSetFieldNamesSection(item.bsonSetFields),
+		clusterBSONSetFieldValuesSection(item.bsonSetFields),
+	)
+	response, err := s.submitClusterMutation(iwire.CommandUpdateBSONSet, sections, seq)
+	if err != nil {
+		return 0, 0, err
+	}
+	matched, ok, err := clusterResponseMetaInt32(response, "matched_count")
+	if err != nil {
+		return 0, 0, err
+	}
+	if !ok {
+		return 0, 0, errors.New("cluster submitter response_meta missing matched_count")
+	}
+	modified, ok, err := clusterResponseMetaInt32(response, "modified_count")
+	if err != nil {
+		return 0, 0, err
+	}
+	if !ok {
+		return 0, 0, errors.New("cluster submitter response_meta missing modified_count")
+	}
+	return matched, modified, nil
+}
+
+func (s *Server) submitClusterDelete(name string, ids [][]byte) (int32, error) {
+	if len(ids) == 0 {
+		return 0, nil
+	}
+	sections, seq := s.clusterMutationSections(iwire.CommandDeleteBatch, "delete_batch", name,
+		iwire.Section{ID: iwire.SectionDocumentIDs, Bytes: iwire.AppendByteVector(nil, ids...)},
+	)
+	response, err := s.submitClusterMutation(iwire.CommandDeleteBatch, sections, seq)
+	if err != nil {
+		return 0, err
+	}
+	deleted, ok, err := clusterResponseMetaInt32(response, "deleted_count")
+	if err != nil {
+		return 0, err
+	}
+	if !ok {
+		return 0, errors.New("cluster submitter response_meta missing deleted_count")
+	}
+	return deleted, nil
+}
+
+func (s *Server) clusterMutationSections(command iwire.CommandID, commandName, collection string, payload ...iwire.Section) ([]iwire.Section, uint64) {
+	seq := s.nextClusterSubmit.Add(1)
+	sections := make([]iwire.Section, 0, 5+len(payload))
+	sections = append(sections,
+		iwire.Section{ID: iwire.SectionCommandHeader, Bytes: iwire.AppendCommandHeader(nil, iwire.CommandHeader{ID: command, Version: 1})},
+		iwire.Section{ID: iwire.SectionIdempotencyKey, Bytes: []byte("mongo-gateway/" + commandName + "/" + strconv.FormatUint(seq, 10))},
+		iwire.Section{ID: iwire.SectionExpectedCatalogVersion, Bytes: binary.AppendUvarint(nil, clusterSyntheticCatalogV1)},
+		clusterCollectionNameRefSection(collection),
+	)
+	return append(sections, payload...), seq
+}
+
+func (s *Server) submitClusterMutation(command iwire.CommandID, sections []iwire.Section, seq uint64) ([]iwire.Section, error) {
+	if s == nil || s.ClusterSubmitter == nil {
+		return nil, errors.New("Mongo gateway cluster submitter is not configured")
+	}
+	if row := raftentry.ClassifyNativeWireCommandV1(command); !row.Known || row.Decision != raftentry.DecisionAccepted {
+		return nil, fmt.Errorf("cluster submitter command %d is not accepted by R3a v1", command)
+	}
+	cmd, err := iwire.MustV1Registry().ValidateRequestSections(sections)
+	if err != nil {
+		return nil, err
+	}
+	entry, err := iwire.AppendDeterministicEntry(nil, cmd)
+	if err != nil {
+		return nil, err
+	}
+	metadata := treenativewire.ClusterRequestMetadata{
+		RequestID: uint64(seq),
+		AckPolicy: iwire.AckVisible,
+	}
+	if _, err := raftentry.DecodeCommandEntryV1(entry, raftentry.DecodeOptions{RequestMetadata: metadata}); err != nil {
+		return nil, err
+	}
+	result, err := s.ClusterSubmitter.SubmitCommandEntryV1(context.Background(), entry, metadata)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateMongoClusterSubmitResult(result); err != nil {
+		return nil, err
+	}
+	return result.ResponseSections, nil
+}
+
+func validateMongoClusterSubmitResult(result treenativewire.ClusterSubmitResult) error {
+	switch result.ActualAck {
+	case iwire.AckVisible, iwire.AckFlushed, iwire.AckSynced:
+		return nil
+	case iwire.AckRaftCommitted:
+		if result.CommittedRecoverable {
+			return nil
+		}
+		return errors.New("cluster submitter returned raft_committed without committed recoverability")
+	default:
+		return fmt.Errorf("cluster submitter returned unsupported ack policy %d", result.ActualAck)
+	}
+}
+
+func clusterCollectionNameRefSection(name string) iwire.Section {
+	payload := make([]byte, 0, 1+len(name))
+	payload = append(payload, clusterCollectionRefNameTag)
+	payload = append(payload, name...)
+	return iwire.Section{ID: iwire.SectionCollectionRef, Bytes: payload}
+}
+
+func clusterDocumentFormatSection(format collections.DocumentFormat) iwire.Section {
+	return iwire.Section{ID: iwire.SectionDocumentFormat, Bytes: binary.AppendUvarint(nil, uint64(clusterDocumentFormat(format)))}
+}
+
+func clusterDocumentFormat(format collections.DocumentFormat) iwire.DocumentFormat {
+	switch format {
+	case collections.DocumentFormatJSON:
+		return iwire.DocumentFormatJSON
+	case collections.DocumentFormatBSON:
+		return iwire.DocumentFormatBSON
+	case collections.DocumentFormatTemplateV1:
+		return iwire.DocumentFormatTemplateV1
+	default:
+		return iwire.DocumentFormatDefault
+	}
+}
+
+func clusterBSONSetFieldNamesSection(fields []collections.BSONSetField) iwire.Section {
+	return iwire.Section{ID: iwire.SectionUpdateFieldNames, Bytes: clusterAppendByteVectorStrings(nil, fields)}
+}
+
+func clusterAppendByteVectorStrings(dst []byte, fields []collections.BSONSetField) []byte {
+	values := make([][]byte, len(fields))
+	for i := range fields {
+		values[i] = []byte(fields[i].Key)
+	}
+	return iwire.AppendByteVector(dst, values...)
+}
+
+func clusterBSONSetFieldValuesSection(fields []collections.BSONSetField) iwire.Section {
+	values := make([][]byte, len(fields))
+	for i := range fields {
+		value := fields[i].Value
+		raw := make([]byte, 0, 1+len(value.Value))
+		raw = append(raw, byte(value.Type))
+		raw = append(raw, value.Value...)
+		values[i] = raw
+	}
+	return iwire.Section{ID: iwire.SectionUpdateFieldValues, Bytes: iwire.AppendByteVector(nil, values...)}
+}
+
+func clusterResponseMetaInt32(sections []iwire.Section, key string) (int32, bool, error) {
+	values, ok, err := clusterResponseMetaMap(sections)
+	if err != nil || !ok {
+		return 0, false, err
+	}
+	raw, ok := values[key]
+	if !ok {
+		return 0, false, nil
+	}
+	n, err := strconv.ParseInt(raw, 10, 32)
+	if err != nil || n < 0 {
+		return 0, true, fmt.Errorf("cluster submitter response_meta %s is not a non-negative int32", key)
+	}
+	return int32(n), true, nil
+}
+
+func clusterResponseMetaMap(sections []iwire.Section) (map[string]string, bool, error) {
+	var raw []byte
+	found := false
+	for _, section := range sections {
+		if section.ID != iwire.SectionResponseMeta {
+			continue
+		}
+		if found {
+			return nil, false, errors.New("cluster submitter returned duplicate response_meta sections")
+		}
+		raw = section.Bytes
+		found = true
+	}
+	if !found {
+		return nil, false, nil
+	}
+	values, err := clusterDecodeStringMap(raw)
+	return values, true, err
+}
+
+func clusterDecodeStringMap(src []byte) (map[string]string, error) {
+	count, off, err := clusterReadUvarint(src)
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[string]string, int(count))
+	for i := uint64(0); i < count; i++ {
+		key, err := clusterReadString(src, &off)
+		if err != nil {
+			return nil, err
+		}
+		value, err := clusterReadString(src, &off)
+		if err != nil {
+			return nil, err
+		}
+		out[key] = value
+	}
+	if off != len(src) {
+		return nil, errors.New("cluster submitter response_meta has trailing bytes")
+	}
+	return out, nil
+}
+
+func clusterReadString(src []byte, off *int) (string, error) {
+	n, read, err := clusterReadUvarint(src[*off:])
+	if err != nil {
+		return "", err
+	}
+	*off += read
+	if n > uint64(len(src)-*off) {
+		return "", errors.New("cluster submitter response_meta string exceeds remaining bytes")
+	}
+	out := string(src[*off : *off+int(n)])
+	*off += int(n)
+	return out, nil
+}
+
+func clusterReadUvarint(src []byte) (uint64, int, error) {
+	value, n := binary.Uvarint(src)
+	switch {
+	case n > 0:
+		return value, n, nil
+	case n == 0:
+		return 0, 0, errors.New("cluster submitter response_meta contains invalid uvarint")
+	default:
+		return 0, 0, errors.New("cluster submitter response_meta contains uvarint overflow")
+	}
+}
+
+func rejectClusterWriteConcern(command wire.Document) error {
+	if bson.Raw(command).Lookup("writeConcern").IsZero() {
+		return nil
+	}
+	return errors.New("Mongo gateway cluster submitter mode does not implement Mongo writeConcern semantics")
+}
+
+func mongoClusterMutationCommandError(err error) (wire.Document, error) {
+	code, codeName := commandCodeBadValue, "BadValue"
+	if nativeCode, ok := iwire.ErrorCodeOf(err); ok {
+		switch nativeCode {
+		case iwire.ErrUnsupportedFeature:
+			code, codeName = commandCodeBadValue, "BadValue"
+		case iwire.ErrDurabilityUnavailable, iwire.ErrReadOnly, iwire.ErrCatalogVersionMismatch:
+			code, codeName = commandCodeBadValue, "BadValue"
+		case iwire.ErrDuplicateDocumentID, iwire.ErrDocumentExists, iwire.ErrUniqueIndexConflict:
+			code, codeName = commandCodeDuplicateKey, "DuplicateKey"
+		}
+	}
+	if collections.IsDuplicateKeyError(err) {
+		code, codeName = commandCodeDuplicateKey, "DuplicateKey"
+	}
+	return commandError(code, codeName, err.Error())
+}

--- a/TreeDB/mongo_gateway/cluster_submitter.go
+++ b/TreeDB/mongo_gateway/cluster_submitter.go
@@ -17,14 +17,49 @@ import (
 
 const (
 	clusterCollectionRefNameTag = byte(1)
-	clusterSyntheticCatalogV1   = uint64(0)
+	clusterCollectionMetaV5     = uint64(5)
 )
 
 func (s *Server) clusterSubmitterConfigured() bool {
 	return s != nil && s.ClusterSubmitter != nil
 }
 
-func (s *Server) clusterInsertResponse(command wire.Document, sequences []wire.DocumentSequence) (wire.Document, error) {
+func (s *Server) currentClusterCatalogVersion(ctx context.Context) (uint64, error) {
+	if s == nil || s.ClusterCatalogVersion == nil {
+		return 0, errors.New("Mongo gateway cluster catalog version provider is not configured")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return s.ClusterCatalogVersion(ctx)
+}
+
+func (s *Server) clusterCreateCollectionResponse(ctx context.Context, command wire.Document) (wire.Document, error) {
+	if err := rejectClusterWriteConcern(command); err != nil {
+		return commandError(commandCodeBadValue, "BadValue", err.Error())
+	}
+	collection, err := commandString(command, "create")
+	if err != nil {
+		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
+	}
+	db, err := commandString(command, "$db")
+	if err != nil {
+		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
+	}
+	name, err := gatewayCollectionName(db, collection)
+	if err != nil {
+		return commandError(commandCodeBadValue, "BadValue", err.Error())
+	}
+	if err := validateCreateCollectionCommand(command); err != nil {
+		return commandError(commandCodeBadValue, "BadValue", err.Error())
+	}
+	if err := s.submitClusterCreateCollection(ctx, *s.defaultCollectionMeta(name)); err != nil {
+		return mongoClusterMutationCommandError(err)
+	}
+	return marshalDocument(bson.D{{Key: "ok", Value: 1.0}})
+}
+
+func (s *Server) clusterInsertResponse(ctx context.Context, command wire.Document, sequences []wire.DocumentSequence) (wire.Document, error) {
 	if err := rejectClusterWriteConcern(command); err != nil {
 		return commandError(commandCodeBadValue, "BadValue", err.Error())
 	}
@@ -49,7 +84,7 @@ func (s *Server) clusterInsertResponse(command wire.Document, sequences []wire.D
 	if err != nil {
 		return commandError(commandCodeBadValue, "BadValue", err.Error())
 	}
-	inserted, err := s.submitClusterInsert(name, format, ids, stored)
+	inserted, err := s.submitClusterInsert(ctx, name, format, ids, stored)
 	if err != nil {
 		return mongoClusterMutationCommandError(err)
 	}
@@ -59,7 +94,7 @@ func (s *Server) clusterInsertResponse(command wire.Document, sequences []wire.D
 	})
 }
 
-func (s *Server) clusterUpdateResponse(command wire.Document, sequences []wire.DocumentSequence) (wire.Document, error) {
+func (s *Server) clusterUpdateResponse(ctx context.Context, command wire.Document, sequences []wire.DocumentSequence) (wire.Document, error) {
 	if err := rejectClusterWriteConcern(command); err != nil {
 		return commandError(commandCodeBadValue, "BadValue", err.Error())
 	}
@@ -92,7 +127,7 @@ func (s *Server) clusterUpdateResponse(command wire.Document, sequences []wire.D
 	}
 	var matched, modified int32
 	for _, item := range parsed {
-		matchedOne, modifiedOne, err := s.submitClusterUpdateBSONSet(name, item)
+		matchedOne, modifiedOne, err := s.submitClusterUpdateBSONSet(ctx, name, item)
 		if err != nil {
 			return mongoClusterMutationCommandError(mongoUpdateErrorWithIndex(item.index, err))
 		}
@@ -102,7 +137,7 @@ func (s *Server) clusterUpdateResponse(command wire.Document, sequences []wire.D
 	return marshalUpdateResponse(matched, modified)
 }
 
-func (s *Server) clusterDeleteResponse(command wire.Document, sequences []wire.DocumentSequence) (wire.Document, error) {
+func (s *Server) clusterDeleteResponse(ctx context.Context, command wire.Document, sequences []wire.DocumentSequence) (wire.Document, error) {
 	if err := rejectClusterWriteConcern(command); err != nil {
 		return commandError(commandCodeBadValue, "BadValue", err.Error())
 	}
@@ -143,7 +178,7 @@ func (s *Server) clusterDeleteResponse(command wire.Document, sequences []wire.D
 		}
 		ids = append(ids, key)
 	}
-	deleted, err := s.submitClusterDelete(name, ids)
+	deleted, err := s.submitClusterDelete(ctx, name, ids)
 	if err != nil {
 		return mongoClusterMutationCommandError(err)
 	}
@@ -160,13 +195,30 @@ func (s *Server) clusterCollectionFormat(name string) collections.DocumentFormat
 	return format
 }
 
-func (s *Server) submitClusterInsert(name string, format collections.DocumentFormat, ids, docs [][]byte) (int32, error) {
-	sections, seq := s.clusterMutationSections(iwire.CommandInsertBatch, "insert_batch", name,
+func (s *Server) submitClusterCreateCollection(ctx context.Context, meta collections.CollectionMeta) error {
+	if len(meta.Indexes) != 0 || len(meta.VectorIndexes) != 0 || len(meta.TextIndexes) != 0 {
+		return errors.New("Mongo gateway cluster create currently supports only collection metadata without indexes")
+	}
+	catalogVersion, err := s.currentClusterCatalogVersion(ctx)
+	if err != nil {
+		return err
+	}
+	sections, seq := s.clusterCreateCollectionSections(meta, catalogVersion)
+	_, err = s.submitClusterMutation(ctx, iwire.CommandCreateCollection, sections, seq)
+	return err
+}
+
+func (s *Server) submitClusterInsert(ctx context.Context, name string, format collections.DocumentFormat, ids, docs [][]byte) (int32, error) {
+	catalogVersion, err := s.currentClusterCatalogVersion(ctx)
+	if err != nil {
+		return 0, err
+	}
+	sections, seq := s.clusterMutationSections(iwire.CommandInsertBatch, "insert_batch", name, catalogVersion,
 		clusterDocumentFormatSection(format),
 		iwire.Section{ID: iwire.SectionDocumentIDs, Bytes: iwire.AppendByteVector(nil, ids...)},
 		iwire.Section{ID: iwire.SectionDocuments, Bytes: iwire.AppendByteVector(nil, docs...)},
 	)
-	response, err := s.submitClusterMutation(iwire.CommandInsertBatch, sections, seq)
+	response, err := s.submitClusterMutation(ctx, iwire.CommandInsertBatch, sections, seq)
 	if err != nil {
 		return 0, err
 	}
@@ -175,18 +227,22 @@ func (s *Server) submitClusterInsert(name string, format collections.DocumentFor
 		return 0, err
 	}
 	if !ok {
-		return int32(len(ids)), nil
+		return 0, errors.New("cluster submitter response_meta missing inserted_count")
 	}
 	return inserted, nil
 }
 
-func (s *Server) submitClusterUpdateBSONSet(name string, item mongoUpdateItem) (int32, int32, error) {
-	sections, seq := s.clusterMutationSections(iwire.CommandUpdateBSONSet, "update_bson_set", name,
+func (s *Server) submitClusterUpdateBSONSet(ctx context.Context, name string, item mongoUpdateItem) (int32, int32, error) {
+	catalogVersion, err := s.currentClusterCatalogVersion(ctx)
+	if err != nil {
+		return 0, 0, err
+	}
+	sections, seq := s.clusterMutationSections(iwire.CommandUpdateBSONSet, "update_bson_set", name, catalogVersion,
 		iwire.Section{ID: iwire.SectionDocumentIDs, Bytes: iwire.AppendByteVector(nil, item.key)},
 		clusterBSONSetFieldNamesSection(item.bsonSetFields),
 		clusterBSONSetFieldValuesSection(item.bsonSetFields),
 	)
-	response, err := s.submitClusterMutation(iwire.CommandUpdateBSONSet, sections, seq)
+	response, err := s.submitClusterMutation(ctx, iwire.CommandUpdateBSONSet, sections, seq)
 	if err != nil {
 		return 0, 0, err
 	}
@@ -207,14 +263,18 @@ func (s *Server) submitClusterUpdateBSONSet(name string, item mongoUpdateItem) (
 	return matched, modified, nil
 }
 
-func (s *Server) submitClusterDelete(name string, ids [][]byte) (int32, error) {
+func (s *Server) submitClusterDelete(ctx context.Context, name string, ids [][]byte) (int32, error) {
 	if len(ids) == 0 {
 		return 0, nil
 	}
-	sections, seq := s.clusterMutationSections(iwire.CommandDeleteBatch, "delete_batch", name,
+	catalogVersion, err := s.currentClusterCatalogVersion(ctx)
+	if err != nil {
+		return 0, err
+	}
+	sections, seq := s.clusterMutationSections(iwire.CommandDeleteBatch, "delete_batch", name, catalogVersion,
 		iwire.Section{ID: iwire.SectionDocumentIDs, Bytes: iwire.AppendByteVector(nil, ids...)},
 	)
-	response, err := s.submitClusterMutation(iwire.CommandDeleteBatch, sections, seq)
+	response, err := s.submitClusterMutation(ctx, iwire.CommandDeleteBatch, sections, seq)
 	if err != nil {
 		return 0, err
 	}
@@ -228,19 +288,30 @@ func (s *Server) submitClusterDelete(name string, ids [][]byte) (int32, error) {
 	return deleted, nil
 }
 
-func (s *Server) clusterMutationSections(command iwire.CommandID, commandName, collection string, payload ...iwire.Section) ([]iwire.Section, uint64) {
+func (s *Server) clusterCreateCollectionSections(meta collections.CollectionMeta, catalogVersion uint64) ([]iwire.Section, uint64) {
+	seq := s.nextClusterSubmit.Add(1)
+	sections := []iwire.Section{
+		{ID: iwire.SectionCommandHeader, Bytes: iwire.AppendCommandHeader(nil, iwire.CommandHeader{ID: iwire.CommandCreateCollection, Version: 1})},
+		{ID: iwire.SectionIdempotencyKey, Bytes: []byte("mongo-gateway/create_collection/" + strconv.FormatUint(seq, 10))},
+		{ID: iwire.SectionExpectedCatalogVersion, Bytes: binary.AppendUvarint(nil, catalogVersion)},
+		clusterCollectionMetaSection(meta),
+	}
+	return sections, seq
+}
+
+func (s *Server) clusterMutationSections(command iwire.CommandID, commandName, collection string, catalogVersion uint64, payload ...iwire.Section) ([]iwire.Section, uint64) {
 	seq := s.nextClusterSubmit.Add(1)
 	sections := make([]iwire.Section, 0, 5+len(payload))
 	sections = append(sections,
 		iwire.Section{ID: iwire.SectionCommandHeader, Bytes: iwire.AppendCommandHeader(nil, iwire.CommandHeader{ID: command, Version: 1})},
 		iwire.Section{ID: iwire.SectionIdempotencyKey, Bytes: []byte("mongo-gateway/" + commandName + "/" + strconv.FormatUint(seq, 10))},
-		iwire.Section{ID: iwire.SectionExpectedCatalogVersion, Bytes: binary.AppendUvarint(nil, clusterSyntheticCatalogV1)},
+		iwire.Section{ID: iwire.SectionExpectedCatalogVersion, Bytes: binary.AppendUvarint(nil, catalogVersion)},
 		clusterCollectionNameRefSection(collection),
 	)
 	return append(sections, payload...), seq
 }
 
-func (s *Server) submitClusterMutation(command iwire.CommandID, sections []iwire.Section, seq uint64) ([]iwire.Section, error) {
+func (s *Server) submitClusterMutation(ctx context.Context, command iwire.CommandID, sections []iwire.Section, seq uint64) ([]iwire.Section, error) {
 	if s == nil || s.ClusterSubmitter == nil {
 		return nil, errors.New("Mongo gateway cluster submitter is not configured")
 	}
@@ -262,7 +333,10 @@ func (s *Server) submitClusterMutation(command iwire.CommandID, sections []iwire
 	if _, err := raftentry.DecodeCommandEntryV1(entry, raftentry.DecodeOptions{RequestMetadata: metadata}); err != nil {
 		return nil, err
 	}
-	result, err := s.ClusterSubmitter.SubmitCommandEntryV1(context.Background(), entry, metadata)
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	result, err := s.ClusterSubmitter.SubmitCommandEntryV1(ctx, entry, metadata)
 	if err != nil {
 		return nil, err
 	}
@@ -275,15 +349,21 @@ func (s *Server) submitClusterMutation(command iwire.CommandID, sections []iwire
 func validateMongoClusterSubmitResult(result treenativewire.ClusterSubmitResult) error {
 	switch result.ActualAck {
 	case iwire.AckVisible, iwire.AckFlushed, iwire.AckSynced:
-		return nil
 	case iwire.AckRaftCommitted:
-		if result.CommittedRecoverable {
-			return nil
+		if !result.CommittedRecoverable {
+			return errors.New("cluster submitter returned raft_committed without committed recoverability")
 		}
-		return errors.New("cluster submitter returned raft_committed without committed recoverability")
 	default:
 		return fmt.Errorf("cluster submitter returned unsupported ack policy %d", result.ActualAck)
 	}
+	ack, ok, err := clusterResponseMetaAckPolicy(result.ResponseSections)
+	if err != nil || !ok {
+		return err
+	}
+	if ack != result.ActualAck {
+		return fmt.Errorf("cluster submitter response_meta actual_ack_policy %d does not match submit result ack policy %d", ack, result.ActualAck)
+	}
+	return nil
 }
 
 func clusterCollectionNameRefSection(name string) iwire.Section {
@@ -291,6 +371,30 @@ func clusterCollectionNameRefSection(name string) iwire.Section {
 	payload = append(payload, clusterCollectionRefNameTag)
 	payload = append(payload, name...)
 	return iwire.Section{ID: iwire.SectionCollectionRef, Bytes: payload}
+}
+
+func clusterCollectionMetaSection(meta collections.CollectionMeta) iwire.Section {
+	return iwire.Section{ID: iwire.SectionCollectionMeta, Bytes: clusterEncodeCollectionMeta(meta)}
+}
+
+func clusterEncodeCollectionMeta(meta collections.CollectionMeta) []byte {
+	dst := binary.AppendUvarint(nil, clusterCollectionMetaV5)
+	dst = clusterAppendString(dst, meta.Name)
+	dst = binary.AppendUvarint(dst, uint64(clusterDocumentFormat(meta.Options.DocumentFormat)))
+	dst = binary.AppendUvarint(dst, clusterRootStorage(meta.Options.DataRootStoragePolicy))
+	dst = binary.AppendUvarint(dst, clusterRootStorage(meta.Options.IndexStateStoragePolicy))
+	dst = clusterAppendBool(dst, meta.Options.AllowArrayValuesInIndex)
+	dst = clusterAppendBool(dst, meta.Options.DisableIndexedWriteMemtables)
+	dst = clusterAppendBool(dst, meta.Options.BufferedIndexedWrites)
+	dst = binary.AppendVarint(dst, int64(meta.Options.BufferedIndexedWriteMaxDocuments))
+	dst = binary.AppendVarint(dst, meta.Options.BufferedIndexedWriteMaxBytes)
+	dst = binary.AppendVarint(dst, int64(meta.Options.BufferedIndexedWriteMaxRootRuns))
+	dst = clusterAppendBool(dst, meta.Options.BufferedIndexedAsyncFlush)
+	dst = clusterAppendBool(dst, meta.Options.BufferedIndexedOverlayRoots)
+	dst = binary.AppendVarint(dst, int64(meta.Options.BufferedIndexedAsyncFlushMaxQueuedUnits))
+	dst = binary.AppendUvarint(dst, 0)
+	dst = binary.AppendUvarint(dst, 0)
+	return dst
 }
 
 func clusterDocumentFormatSection(format collections.DocumentFormat) iwire.Section {
@@ -308,6 +412,29 @@ func clusterDocumentFormat(format collections.DocumentFormat) iwire.DocumentForm
 	default:
 		return iwire.DocumentFormatDefault
 	}
+}
+
+func clusterRootStorage(policy collections.RootStoragePolicy) uint64 {
+	switch policy {
+	case collections.RootStorageFast:
+		return 1
+	case collections.RootStorageCompressed:
+		return 2
+	default:
+		return 0
+	}
+}
+
+func clusterAppendBool(dst []byte, value bool) []byte {
+	if value {
+		return append(dst, 1)
+	}
+	return append(dst, 0)
+}
+
+func clusterAppendString(dst []byte, value string) []byte {
+	dst = binary.AppendUvarint(dst, uint64(len(value)))
+	return append(dst, value...)
 }
 
 func clusterBSONSetFieldNamesSection(fields []collections.BSONSetField) iwire.Section {
@@ -348,6 +475,22 @@ func clusterResponseMetaInt32(sections []iwire.Section, key string) (int32, bool
 		return 0, true, fmt.Errorf("cluster submitter response_meta %s is not a non-negative int32", key)
 	}
 	return int32(n), true, nil
+}
+
+func clusterResponseMetaAckPolicy(sections []iwire.Section) (iwire.AckPolicy, bool, error) {
+	values, ok, err := clusterResponseMetaMap(sections)
+	if err != nil || !ok {
+		return 0, ok, err
+	}
+	raw, ok := values["actual_ack_policy"]
+	if !ok {
+		return 0, true, errors.New("cluster submitter response_meta missing actual_ack_policy")
+	}
+	value, err := strconv.ParseUint(raw, 10, 64)
+	if err != nil {
+		return 0, true, errors.New("cluster submitter response_meta actual_ack_policy is not a uint64")
+	}
+	return iwire.AckPolicy(value), true, nil
 }
 
 func clusterResponseMetaMap(sections []iwire.Section) (map[string]string, bool, error) {
@@ -442,4 +585,12 @@ func mongoClusterMutationCommandError(err error) (wire.Document, error) {
 		code, codeName = commandCodeDuplicateKey, "DuplicateKey"
 	}
 	return commandError(code, codeName, err.Error())
+}
+
+func mongoClusterUnsupportedLocalMutation(command string) (wire.Document, error) {
+	return commandError(
+		commandCodeBadValue,
+		"BadValue",
+		"Mongo gateway cluster submitter mode does not support local "+command+" mutation",
+	)
 }

--- a/TreeDB/mongo_gateway/cluster_submitter.go
+++ b/TreeDB/mongo_gateway/cluster_submitter.go
@@ -122,6 +122,13 @@ func (s *Server) clusterUpdateResponse(ctx context.Context, command wire.Documen
 	if err != nil {
 		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
 	}
+	exists, err := s.clusterCollectionExists(name)
+	if err != nil {
+		return commandError(commandCodeBadValue, "BadValue", err.Error())
+	}
+	if !exists {
+		return marshalUpdateResponse(0, 0)
+	}
 	var matched, modified int32
 	for i, update := range updates {
 		item, err := parseMongoUpdateItem(i, update)
@@ -160,6 +167,13 @@ func (s *Server) clusterDeleteResponse(ctx context.Context, command wire.Documen
 	deletes, err := commandDocuments(command, sequences, "deletes")
 	if err != nil {
 		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
+	}
+	exists, err := s.clusterCollectionExists(name)
+	if err != nil {
+		return commandError(commandCodeBadValue, "BadValue", err.Error())
+	}
+	if !exists {
+		return marshalDeleteResponse(0)
 	}
 	ids := make([][]byte, 0, len(deletes))
 	seenIDs := make(map[string]struct{}, len(deletes))
@@ -229,6 +243,20 @@ func (s *Server) clusterCollectionFormat(name string) (collections.DocumentForma
 		}
 	}
 	return format, false, nil
+}
+
+func (s *Server) clusterCollectionExists(name string) (bool, error) {
+	if s == nil || s.Collections == nil {
+		return true, nil
+	}
+	col, err := s.Collections.OpenCollection(name)
+	if err == nil && col != nil {
+		return true, nil
+	}
+	if errors.Is(err, collections.ErrCollectionNotFound) {
+		return false, nil
+	}
+	return false, err
 }
 
 func (s *Server) submitClusterCreateCollection(ctx context.Context, meta collections.CollectionMeta) error {

--- a/TreeDB/mongo_gateway/cluster_submitter.go
+++ b/TreeDB/mongo_gateway/cluster_submitter.go
@@ -114,7 +114,7 @@ func (s *Server) clusterUpdateResponse(ctx context.Context, command wire.Documen
 	if err != nil {
 		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
 	}
-	parsed := make([]mongoUpdateItem, 0, len(updates))
+	var matched, modified int32
 	for i, update := range updates {
 		item, err := parseMongoUpdateItem(i, update)
 		if err != nil {
@@ -123,10 +123,6 @@ func (s *Server) clusterUpdateResponse(ctx context.Context, command wire.Documen
 		if !item.bsonSetFieldsOK {
 			return commandError(commandCodeBadValue, "BadValue", fmt.Sprintf("updates[%d]: cluster Mongo gateway currently supports only top-level BSON $set updateOne by _id", i))
 		}
-		parsed = append(parsed, item)
-	}
-	var matched, modified int32
-	for _, item := range parsed {
 		matchedOne, modifiedOne, err := s.submitClusterUpdateBSONSet(ctx, name, item)
 		if err != nil {
 			return mongoClusterMutationCommandError(mongoUpdateErrorWithIndex(item.index, err))
@@ -158,6 +154,7 @@ func (s *Server) clusterDeleteResponse(ctx context.Context, command wire.Documen
 		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
 	}
 	ids := make([][]byte, 0, len(deletes))
+	seenIDs := make(map[string]struct{}, len(deletes))
 	for i, deleteItem := range deletes {
 		filter, err := requiredDocumentField(deleteItem, "q")
 		if err != nil {
@@ -176,6 +173,11 @@ func (s *Server) clusterDeleteResponse(ctx context.Context, command wire.Documen
 		if err != nil {
 			return commandError(commandCodeBadValue, "BadValue", fmt.Sprintf("deletes[%d]: %v", i, err))
 		}
+		keyString := string(key)
+		if _, ok := seenIDs[keyString]; ok {
+			continue
+		}
+		seenIDs[keyString] = struct{}{}
 		ids = append(ids, key)
 	}
 	deleted, err := s.submitClusterDelete(ctx, name, ids)

--- a/TreeDB/mongo_gateway/cluster_submitter_test.go
+++ b/TreeDB/mongo_gateway/cluster_submitter_test.go
@@ -27,6 +27,7 @@ type mongoClusterFakeSubmitter struct {
 	mu                       sync.Mutex
 	calls                    []mongoClusterSubmitterCall
 	actualAck                iwire.AckPolicy
+	committedRecoverable     bool
 	responseSections         []iwire.Section
 	overrideResponseSections bool
 }
@@ -55,8 +56,9 @@ func (f *mongoClusterFakeSubmitter) SubmitCommandEntryV1(ctx context.Context, en
 		responseSections = append([]iwire.Section(nil), f.responseSections...)
 	}
 	return treenativewire.ClusterSubmitResult{
-		ActualAck:        actualAck,
-		ResponseSections: responseSections,
+		ActualAck:            actualAck,
+		CommittedRecoverable: f.committedRecoverable,
+		ResponseSections:     responseSections,
 	}, nil
 }
 
@@ -497,6 +499,26 @@ func TestClusterSubmitterRejectsAckPolicyMismatch(t *testing.T) {
 	setMongoClusterTestSubmitter(server, submitter, 16)
 
 	response := serveCommand(t, server, 325816, bson.D{
+		{Key: "insert", Value: "users"},
+		{Key: "documents", Value: bson.A{bson.D{{Key: "_id", Value: "u1"}}}},
+		{Key: "$db", Value: "app"},
+	})
+	assertCommandError(t, response, "BadValue")
+	if calls := submitter.snapshotCalls(); len(calls) != 1 {
+		t.Fatalf("submit calls=%d want 1", len(calls))
+	}
+}
+
+func TestClusterSubmitterRejectsRaftCommittedForVisibleRequest(t *testing.T) {
+	submitter := &mongoClusterFakeSubmitter{
+		actualAck:            iwire.AckRaftCommitted,
+		committedRecoverable: true,
+	}
+	server := NewServer()
+	server.DefaultCollectionOptions = collections.CollectionOptions{DocumentFormat: collections.DocumentFormatBSON}
+	setMongoClusterTestSubmitter(server, submitter, 17)
+
+	response := serveCommand(t, server, 325817, bson.D{
 		{Key: "insert", Value: "users"},
 		{Key: "documents", Value: bson.A{bson.D{{Key: "_id", Value: "u1"}}}},
 		{Key: "$db", Value: "app"},

--- a/TreeDB/mongo_gateway/cluster_submitter_test.go
+++ b/TreeDB/mongo_gateway/cluster_submitter_test.go
@@ -245,6 +245,37 @@ func TestClusterSubmitterUpdateBSONSetRoutesCountsAndNoLocalMutation(t *testing.
 	}
 }
 
+func TestClusterSubmitterUpdateSubmitsPriorOrderedItemsBeforeUnsupported(t *testing.T) {
+	submitter := &mongoClusterFakeSubmitter{}
+	server := NewServer()
+	server.DefaultCollectionOptions = collections.CollectionOptions{DocumentFormat: collections.DocumentFormatBSON}
+	setMongoClusterTestSubmitter(server, submitter, 18)
+
+	response := serveCommand(t, server, 325818, bson.D{
+		{Key: "update", Value: "users"},
+		{Key: "updates", Value: bson.A{
+			bson.D{
+				{Key: "q", Value: bson.D{{Key: "_id", Value: "u1"}}},
+				{Key: "u", Value: bson.D{{Key: "$set", Value: bson.D{{Key: "name", Value: "Grace"}}}}},
+			},
+			bson.D{
+				{Key: "q", Value: bson.D{{Key: "_id", Value: "u2"}}},
+				{Key: "u", Value: bson.D{{Key: "$inc", Value: bson.D{{Key: "age", Value: int32(1)}}}}},
+			},
+		}},
+		{Key: "$db", Value: "app"},
+	})
+	assertCommandError(t, response, "BadValue")
+
+	calls := submitter.snapshotCalls()
+	if len(calls) != 1 {
+		t.Fatalf("submit calls=%d want 1", len(calls))
+	}
+	if got := calls[0].entry.Decoded.CommandID; got != iwire.CommandUpdateBSONSet {
+		t.Fatalf("command id=%d want update_bson_set", got)
+	}
+}
+
 func TestClusterSubmitterDeleteRoutesCommandEntry(t *testing.T) {
 	submitter := &mongoClusterFakeSubmitter{}
 	server := NewServer()
@@ -265,6 +296,33 @@ func TestClusterSubmitterDeleteRoutesCommandEntry(t *testing.T) {
 	}
 	if got := calls[0].entry.Decoded.CommandID; got != iwire.CommandDeleteBatch {
 		t.Fatalf("command id=%d want delete_batch", got)
+	}
+}
+
+func TestClusterSubmitterDeleteDeduplicatesDuplicateIDs(t *testing.T) {
+	submitter := &mongoClusterFakeSubmitter{}
+	server := NewServer()
+	server.DefaultCollectionOptions = collections.CollectionOptions{DocumentFormat: collections.DocumentFormatBSON}
+	setMongoClusterTestSubmitter(server, submitter, 19)
+
+	response := serveCommand(t, server, 325819, bson.D{
+		{Key: "delete", Value: "users"},
+		{Key: "deletes", Value: bson.A{
+			bson.D{{Key: "q", Value: bson.D{{Key: "_id", Value: "u1"}}}, {Key: "limit", Value: int32(1)}},
+			bson.D{{Key: "q", Value: bson.D{{Key: "_id", Value: "u1"}}}, {Key: "limit", Value: int32(1)}},
+		}},
+		{Key: "$db", Value: "app"},
+	})
+	assertOK(t, response)
+	assertInt32(t, response, "n", 1)
+
+	calls := submitter.snapshotCalls()
+	if len(calls) != 1 {
+		t.Fatalf("submit calls=%d want 1", len(calls))
+	}
+	ids := mongoClusterTestIDs(calls[0].entry.Decoded.Sections)
+	if len(ids) != 1 {
+		t.Fatalf("document ids=%d want 1", len(ids))
 	}
 }
 

--- a/TreeDB/mongo_gateway/cluster_submitter_test.go
+++ b/TreeDB/mongo_gateway/cluster_submitter_test.go
@@ -366,6 +366,36 @@ func TestClusterSubmitterUpdateSubmitsPriorOrderedItemsBeforeUnsupported(t *test
 	}
 }
 
+func TestClusterSubmitterUpdateMissingCollectionReturnsZeroCounts(t *testing.T) {
+	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	submitter := &mongoClusterFakeSubmitter{}
+	server := NewServer()
+	server.Collections = collections.NewCollectionManager(db)
+	server.DefaultCollectionOptions = collections.CollectionOptions{DocumentFormat: collections.DocumentFormatBSON}
+	setMongoClusterTestSubmitter(server, submitter, 23)
+
+	response := serveCommand(t, server, 325823, bson.D{
+		{Key: "update", Value: "missing"},
+		{Key: "updates", Value: bson.A{bson.D{
+			{Key: "q", Value: bson.D{{Key: "_id", Value: "u1"}}},
+			{Key: "u", Value: bson.D{{Key: "$set", Value: bson.D{{Key: "name", Value: "Grace"}}}}},
+		}}},
+		{Key: "$db", Value: "app"},
+	})
+	assertOK(t, response)
+	assertInt32(t, response, "n", 0)
+	assertInt32(t, response, "nModified", 0)
+
+	if calls := submitter.snapshotCalls(); len(calls) != 0 {
+		t.Fatalf("submit calls=%d want 0", len(calls))
+	}
+}
+
 func TestClusterSubmitterDeleteRoutesCommandEntry(t *testing.T) {
 	submitter := &mongoClusterFakeSubmitter{}
 	server := NewServer()
@@ -442,6 +472,32 @@ func TestClusterSubmitterDeleteSubmitsPriorOrderedItemsBeforeUnsupported(t *test
 	ids := mongoClusterTestIDs(calls[0].entry.Decoded.Sections)
 	if len(ids) != 1 {
 		t.Fatalf("document ids=%d want 1", len(ids))
+	}
+}
+
+func TestClusterSubmitterDeleteMissingCollectionReturnsZeroCount(t *testing.T) {
+	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	submitter := &mongoClusterFakeSubmitter{}
+	server := NewServer()
+	server.Collections = collections.NewCollectionManager(db)
+	server.DefaultCollectionOptions = collections.CollectionOptions{DocumentFormat: collections.DocumentFormatBSON}
+	setMongoClusterTestSubmitter(server, submitter, 24)
+
+	response := serveCommand(t, server, 325824, bson.D{
+		{Key: "delete", Value: "missing"},
+		{Key: "deletes", Value: bson.A{bson.D{{Key: "q", Value: bson.D{{Key: "_id", Value: "u1"}}}, {Key: "limit", Value: int32(1)}}}},
+		{Key: "$db", Value: "app"},
+	})
+	assertOK(t, response)
+	assertInt32(t, response, "n", 0)
+
+	if calls := submitter.snapshotCalls(); len(calls) != 0 {
+		t.Fatalf("submit calls=%d want 0", len(calls))
 	}
 }
 

--- a/TreeDB/mongo_gateway/cluster_submitter_test.go
+++ b/TreeDB/mongo_gateway/cluster_submitter_test.go
@@ -3,6 +3,7 @@ package mongogateway
 import (
 	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"sync"
 	"testing"
@@ -11,6 +12,7 @@ import (
 	backenddb "github.com/snissn/gomap/TreeDB/db"
 	iwire "github.com/snissn/gomap/TreeDB/internal/nativewire"
 	"github.com/snissn/gomap/TreeDB/internal/raftentry"
+	"github.com/snissn/gomap/TreeDB/mongo_gateway/wire"
 	treenativewire "github.com/snissn/gomap/TreeDB/nativewire"
 	"go.mongodb.org/mongo-driver/v2/bson"
 )
@@ -18,11 +20,15 @@ import (
 type mongoClusterSubmitterCall struct {
 	entry    raftentry.CommandEntryV1
 	metadata treenativewire.ClusterRequestMetadata
+	ctxErr   error
 }
 
 type mongoClusterFakeSubmitter struct {
-	mu    sync.Mutex
-	calls []mongoClusterSubmitterCall
+	mu                       sync.Mutex
+	calls                    []mongoClusterSubmitterCall
+	actualAck                iwire.AckPolicy
+	responseSections         []iwire.Section
+	overrideResponseSections bool
 }
 
 func (f *mongoClusterFakeSubmitter) SubmitCommandEntryV1(ctx context.Context, entry []byte, metadata treenativewire.ClusterRequestMetadata) (treenativewire.ClusterSubmitResult, error) {
@@ -33,12 +39,24 @@ func (f *mongoClusterFakeSubmitter) SubmitCommandEntryV1(ctx context.Context, en
 	if err != nil {
 		return treenativewire.ClusterSubmitResult{}, err
 	}
+	ctxErr := ctx.Err()
 	f.mu.Lock()
-	f.calls = append(f.calls, mongoClusterSubmitterCall{entry: decoded, metadata: metadata})
+	f.calls = append(f.calls, mongoClusterSubmitterCall{entry: decoded, metadata: metadata, ctxErr: ctxErr})
 	f.mu.Unlock()
+	if ctxErr != nil {
+		return treenativewire.ClusterSubmitResult{}, ctxErr
+	}
+	actualAck := f.actualAck
+	if actualAck == 0 {
+		actualAck = iwire.AckVisible
+	}
+	responseSections := mongoClusterFakeResponseSections(decoded.Decoded)
+	if f.overrideResponseSections {
+		responseSections = append([]iwire.Section(nil), f.responseSections...)
+	}
 	return treenativewire.ClusterSubmitResult{
-		ActualAck:        iwire.AckVisible,
-		ResponseSections: mongoClusterFakeResponseSections(decoded.Decoded),
+		ActualAck:        actualAck,
+		ResponseSections: responseSections,
 	}, nil
 }
 
@@ -99,6 +117,43 @@ func mongoClusterTestIDs(sections []iwire.Section) [][]byte {
 	return nil
 }
 
+func mongoClusterStaticCatalogVersion(version uint64) ClusterCatalogVersionProvider {
+	return func(context.Context) (uint64, error) {
+		return version, nil
+	}
+}
+
+func setMongoClusterTestSubmitter(server *Server, submitter *mongoClusterFakeSubmitter, catalogVersion uint64) {
+	server.ClusterSubmitter = submitter
+	server.ClusterCatalogVersion = mongoClusterStaticCatalogVersion(catalogVersion)
+}
+
+func mongoClusterCallCatalogVersion(tb testing.TB, call mongoClusterSubmitterCall) uint64 {
+	tb.Helper()
+	version, n := binary.Uvarint(call.entry.Target.ExpectedCatalogVersion)
+	if n <= 0 || n != len(call.entry.Target.ExpectedCatalogVersion) {
+		tb.Fatalf("expected_catalog_version bytes=%v decode n=%d", call.entry.Target.ExpectedCatalogVersion, n)
+	}
+	return version
+}
+
+func mongoClusterCallCollectionMetaName(tb testing.TB, call mongoClusterSubmitterCall) string {
+	tb.Helper()
+	raw := call.entry.Target.CollectionMeta
+	version, off, err := clusterReadUvarint(raw)
+	if err != nil {
+		tb.Fatalf("collection_meta version: %v", err)
+	}
+	if version != clusterCollectionMetaV5 {
+		tb.Fatalf("collection_meta version=%d want %d", version, clusterCollectionMetaV5)
+	}
+	name, err := clusterReadString(raw, &off)
+	if err != nil {
+		tb.Fatalf("collection_meta name: %v", err)
+	}
+	return name
+}
+
 func TestClusterSubmitterInsertRoutesCommandEntryNoLocalMutation(t *testing.T) {
 	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {
@@ -110,7 +165,7 @@ func TestClusterSubmitterInsertRoutesCommandEntryNoLocalMutation(t *testing.T) {
 	server := NewServer()
 	server.Collections = collections.NewCollectionManager(db)
 	server.DefaultCollectionOptions = collections.CollectionOptions{DocumentFormat: collections.DocumentFormatBSON}
-	server.ClusterSubmitter = submitter
+	setMongoClusterTestSubmitter(server, submitter, 7)
 
 	response := serveCommand(t, server, 325801, bson.D{
 		{Key: "insert", Value: "users"},
@@ -126,6 +181,9 @@ func TestClusterSubmitterInsertRoutesCommandEntryNoLocalMutation(t *testing.T) {
 	}
 	if got := calls[0].entry.Decoded.CommandID; got != iwire.CommandInsertBatch {
 		t.Fatalf("command id=%d want insert_batch", got)
+	}
+	if got := mongoClusterCallCatalogVersion(t, calls[0]); got != 7 {
+		t.Fatalf("expected catalog version=%d want 7", got)
 	}
 	if _, err := server.Collections.OpenCollection("app.users"); err == nil {
 		t.Fatal("cluster insert created local collection")
@@ -151,7 +209,7 @@ func TestClusterSubmitterUpdateBSONSetRoutesCountsAndNoLocalMutation(t *testing.
 	}))
 
 	submitter := &mongoClusterFakeSubmitter{}
-	server.ClusterSubmitter = submitter
+	setMongoClusterTestSubmitter(server, submitter, 8)
 	response := serveCommand(t, server, 325803, bson.D{
 		{Key: "update", Value: "users"},
 		{Key: "updates", Value: bson.A{bson.D{
@@ -189,7 +247,7 @@ func TestClusterSubmitterDeleteRoutesCommandEntry(t *testing.T) {
 	submitter := &mongoClusterFakeSubmitter{}
 	server := NewServer()
 	server.DefaultCollectionOptions = collections.CollectionOptions{DocumentFormat: collections.DocumentFormatBSON}
-	server.ClusterSubmitter = submitter
+	setMongoClusterTestSubmitter(server, submitter, 9)
 
 	response := serveCommand(t, server, 325805, bson.D{
 		{Key: "delete", Value: "users"},
@@ -212,7 +270,7 @@ func TestClusterSubmitterRejectsWriteConcern(t *testing.T) {
 	submitter := &mongoClusterFakeSubmitter{}
 	server := NewServer()
 	server.DefaultCollectionOptions = collections.CollectionOptions{DocumentFormat: collections.DocumentFormatBSON}
-	server.ClusterSubmitter = submitter
+	setMongoClusterTestSubmitter(server, submitter, 10)
 
 	response := serveCommand(t, server, 325806, bson.D{
 		{Key: "insert", Value: "users"},
@@ -223,6 +281,37 @@ func TestClusterSubmitterRejectsWriteConcern(t *testing.T) {
 	assertCommandError(t, response, "BadValue")
 	if calls := submitter.snapshotCalls(); len(calls) != 0 {
 		t.Fatalf("submit calls=%d want 0", len(calls))
+	}
+}
+
+func TestClusterSubmitterUsesRequestContext(t *testing.T) {
+	submitter := &mongoClusterFakeSubmitter{}
+	server := NewServer()
+	server.DefaultCollectionOptions = collections.CollectionOptions{DocumentFormat: collections.DocumentFormatBSON}
+	setMongoClusterTestSubmitter(server, submitter, 11)
+
+	raw, err := bson.Marshal(bson.D{
+		{Key: "insert", Value: "users"},
+		{Key: "documents", Value: bson.A{bson.D{{Key: "_id", Value: "u1"}}}},
+		{Key: "$db", Value: "app"},
+	})
+	if err != nil {
+		t.Fatalf("marshal command: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	response, err := server.commandResponse(ctx, "insert", wire.Document(raw), nil, 1)
+	if err != nil {
+		t.Fatalf("commandResponse: %v", err)
+	}
+	assertCommandError(t, response, "BadValue")
+
+	calls := submitter.snapshotCalls()
+	if len(calls) != 1 {
+		t.Fatalf("submit calls=%d want 1", len(calls))
+	}
+	if !errors.Is(calls[0].ctxErr, context.Canceled) {
+		t.Fatalf("submit context err=%v want context canceled", calls[0].ctxErr)
 	}
 }
 
@@ -243,7 +332,7 @@ func TestClusterSubmitterRejectsUnsupportedClusterMutationNoLocalMutation(t *tes
 	}))
 
 	submitter := &mongoClusterFakeSubmitter{}
-	server.ClusterSubmitter = submitter
+	setMongoClusterTestSubmitter(server, submitter, 12)
 	response := serveCommand(t, server, 325808, bson.D{
 		{Key: "update", Value: "users"},
 		{Key: "updates", Value: bson.A{bson.D{
@@ -267,5 +356,153 @@ func TestClusterSubmitterRejectsUnsupportedClusterMutationNoLocalMutation(t *tes
 	}
 	if got, ok := batch[0].Lookup("age").Int32OK(); !ok || got != 1 {
 		t.Fatalf("local age after rejected cluster update=%d ok=%v want 1", got, ok)
+	}
+}
+
+func TestClusterSubmitterCreateRoutesCommandEntryNoLocalMutation(t *testing.T) {
+	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	submitter := &mongoClusterFakeSubmitter{}
+	server := NewServer()
+	server.Collections = collections.NewCollectionManager(db)
+	server.DefaultCollectionOptions = collections.CollectionOptions{DocumentFormat: collections.DocumentFormatBSON}
+	setMongoClusterTestSubmitter(server, submitter, 13)
+
+	response := serveCommand(t, server, 325810, bson.D{
+		{Key: "create", Value: "users"},
+		{Key: "$db", Value: "app"},
+	})
+	assertOK(t, response)
+
+	calls := submitter.snapshotCalls()
+	if len(calls) != 1 {
+		t.Fatalf("submit calls=%d want 1", len(calls))
+	}
+	if got := calls[0].entry.Decoded.CommandID; got != iwire.CommandCreateCollection {
+		t.Fatalf("command id=%d want create_collection", got)
+	}
+	if got := mongoClusterCallCatalogVersion(t, calls[0]); got != 13 {
+		t.Fatalf("expected catalog version=%d want 13", got)
+	}
+	if got := mongoClusterCallCollectionMetaName(t, calls[0]); got != "app.users" {
+		t.Fatalf("collection_meta name=%q want app.users", got)
+	}
+	if _, err := server.Collections.OpenCollection("app.users"); err == nil {
+		t.Fatal("cluster create created local collection")
+	} else if err != collections.ErrCollectionNotFound {
+		t.Fatalf("OpenCollection after cluster create err=%v want collection not found", err)
+	}
+}
+
+func TestClusterSubmitterRejectsIndexDDLNoLocalMutation(t *testing.T) {
+	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	server := NewServer()
+	server.Collections = collections.NewCollectionManager(db)
+	server.DefaultCollectionOptions = collections.CollectionOptions{DocumentFormat: collections.DocumentFormatBSON}
+	assertOK(t, serveCommand(t, server, 325811, bson.D{
+		{Key: "createIndexes", Value: "users"},
+		{Key: "indexes", Value: bson.A{bson.D{
+			{Key: "key", Value: bson.D{{Key: "name", Value: int32(1)}}},
+			{Key: "name", Value: "name_1"},
+			{Key: "treedbValueType", Value: "string"},
+		}}},
+		{Key: "$db", Value: "app"},
+	}))
+
+	submitter := &mongoClusterFakeSubmitter{}
+	setMongoClusterTestSubmitter(server, submitter, 14)
+	createResponse := serveCommand(t, server, 325812, bson.D{
+		{Key: "createIndexes", Value: "users"},
+		{Key: "indexes", Value: bson.A{bson.D{
+			{Key: "key", Value: bson.D{{Key: "age", Value: int32(1)}}},
+			{Key: "name", Value: "age_1"},
+			{Key: "treedbValueType", Value: "int64"},
+		}}},
+		{Key: "$db", Value: "app"},
+	})
+	assertCommandError(t, createResponse, "BadValue")
+	dropResponse := serveCommand(t, server, 325813, bson.D{
+		{Key: "dropIndexes", Value: "users"},
+		{Key: "index", Value: "name_1"},
+		{Key: "$db", Value: "app"},
+	})
+	assertCommandError(t, dropResponse, "BadValue")
+	if calls := submitter.snapshotCalls(); len(calls) != 0 {
+		t.Fatalf("submit calls=%d want 0", len(calls))
+	}
+	col, err := server.Collections.OpenCollection("app.users")
+	if err != nil {
+		t.Fatalf("open local collection: %v", err)
+	}
+	indexes := col.MetaView().Indexes
+	if len(indexes) != 1 || indexes[0].Name != "name_1" {
+		t.Fatalf("local indexes after rejected cluster DDL=%+v want only name_1", indexes)
+	}
+}
+
+func TestClusterSubmitterRequiresCatalogVersionProvider(t *testing.T) {
+	submitter := &mongoClusterFakeSubmitter{}
+	server := NewServer()
+	server.DefaultCollectionOptions = collections.CollectionOptions{DocumentFormat: collections.DocumentFormatBSON}
+	server.ClusterSubmitter = submitter
+
+	response := serveCommand(t, server, 325814, bson.D{
+		{Key: "insert", Value: "users"},
+		{Key: "documents", Value: bson.A{bson.D{{Key: "_id", Value: "u1"}}}},
+		{Key: "$db", Value: "app"},
+	})
+	assertCommandError(t, response, "BadValue")
+	if calls := submitter.snapshotCalls(); len(calls) != 0 {
+		t.Fatalf("submit calls=%d want 0", len(calls))
+	}
+}
+
+func TestClusterSubmitterRequiresInsertedCount(t *testing.T) {
+	submitter := &mongoClusterFakeSubmitter{
+		responseSections:         []iwire.Section{mongoClusterTestMeta()},
+		overrideResponseSections: true,
+	}
+	server := NewServer()
+	server.DefaultCollectionOptions = collections.CollectionOptions{DocumentFormat: collections.DocumentFormatBSON}
+	setMongoClusterTestSubmitter(server, submitter, 15)
+
+	response := serveCommand(t, server, 325815, bson.D{
+		{Key: "insert", Value: "users"},
+		{Key: "documents", Value: bson.A{bson.D{{Key: "_id", Value: "u1"}}}},
+		{Key: "$db", Value: "app"},
+	})
+	assertCommandError(t, response, "BadValue")
+	if calls := submitter.snapshotCalls(); len(calls) != 1 {
+		t.Fatalf("submit calls=%d want 1", len(calls))
+	}
+}
+
+func TestClusterSubmitterRejectsAckPolicyMismatch(t *testing.T) {
+	submitter := &mongoClusterFakeSubmitter{
+		actualAck:                iwire.AckSynced,
+		responseSections:         []iwire.Section{mongoClusterTestMeta("inserted_count", 1)},
+		overrideResponseSections: true,
+	}
+	server := NewServer()
+	server.DefaultCollectionOptions = collections.CollectionOptions{DocumentFormat: collections.DocumentFormatBSON}
+	setMongoClusterTestSubmitter(server, submitter, 16)
+
+	response := serveCommand(t, server, 325816, bson.D{
+		{Key: "insert", Value: "users"},
+		{Key: "documents", Value: bson.A{bson.D{{Key: "_id", Value: "u1"}}}},
+		{Key: "$db", Value: "app"},
+	})
+	assertCommandError(t, response, "BadValue")
+	if calls := submitter.snapshotCalls(); len(calls) != 1 {
+		t.Fatalf("submit calls=%d want 1", len(calls))
 	}
 }

--- a/TreeDB/mongo_gateway/cluster_submitter_test.go
+++ b/TreeDB/mongo_gateway/cluster_submitter_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"testing"
 
@@ -139,6 +140,14 @@ func mongoClusterCallCatalogVersion(tb testing.TB, call mongoClusterSubmitterCal
 	return version
 }
 
+func mongoClusterCallIdempotencyKey(tb testing.TB, call mongoClusterSubmitterCall) string {
+	tb.Helper()
+	if len(call.entry.IdempotencyKey) == 0 {
+		tb.Fatal("missing idempotency key")
+	}
+	return string(call.entry.IdempotencyKey)
+}
+
 func mongoClusterCallCollectionMetaName(tb testing.TB, call mongoClusterSubmitterCall) string {
 	tb.Helper()
 	raw := call.entry.Target.CollectionMeta
@@ -178,19 +187,100 @@ func TestClusterSubmitterInsertRoutesCommandEntryNoLocalMutation(t *testing.T) {
 	assertInt32(t, response, "n", 1)
 
 	calls := submitter.snapshotCalls()
+	if len(calls) != 2 {
+		t.Fatalf("submit calls=%d want 2", len(calls))
+	}
+	if got := calls[0].entry.Decoded.CommandID; got != iwire.CommandCreateCollection {
+		t.Fatalf("first command id=%d want create_collection", got)
+	}
+	if got := mongoClusterCallCollectionMetaName(t, calls[0]); got != "app.users" {
+		t.Fatalf("collection_meta name=%q want app.users", got)
+	}
+	if got := calls[1].entry.Decoded.CommandID; got != iwire.CommandInsertBatch {
+		t.Fatalf("command id=%d want insert_batch", got)
+	}
+	if got := mongoClusterCallCatalogVersion(t, calls[0]); got != 7 {
+		t.Fatalf("create expected catalog version=%d want 7", got)
+	}
+	if got := mongoClusterCallCatalogVersion(t, calls[1]); got != 7 {
+		t.Fatalf("insert expected catalog version=%d want 7", got)
+	}
+	if _, err := server.Collections.OpenCollection("app.users"); err == nil {
+		t.Fatal("cluster insert created local collection")
+	} else if err != collections.ErrCollectionNotFound {
+		t.Fatalf("OpenCollection after cluster insert err=%v want collection not found", err)
+	}
+}
+
+func TestClusterSubmitterInsertSkipsAutoCreateForKnownLocalCollection(t *testing.T) {
+	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	server := NewServer()
+	server.Collections = collections.NewCollectionManager(db)
+	server.DefaultCollectionOptions = collections.CollectionOptions{DocumentFormat: collections.DocumentFormatBSON}
+	if _, err := server.Collections.CreateCollection(server.defaultCollectionMeta("app.users")); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+
+	submitter := &mongoClusterFakeSubmitter{}
+	setMongoClusterTestSubmitter(server, submitter, 20)
+	response := serveCommand(t, server, 325820, bson.D{
+		{Key: "insert", Value: "users"},
+		{Key: "documents", Value: bson.A{bson.D{{Key: "_id", Value: "u1"}, {Key: "name", Value: "Ada"}}}},
+		{Key: "$db", Value: "app"},
+	})
+	assertOK(t, response)
+
+	calls := submitter.snapshotCalls()
 	if len(calls) != 1 {
 		t.Fatalf("submit calls=%d want 1", len(calls))
 	}
 	if got := calls[0].entry.Decoded.CommandID; got != iwire.CommandInsertBatch {
 		t.Fatalf("command id=%d want insert_batch", got)
 	}
-	if got := mongoClusterCallCatalogVersion(t, calls[0]); got != 7 {
-		t.Fatalf("expected catalog version=%d want 7", got)
+}
+
+func TestClusterSubmitterIdempotencyKeysIncludeServerNonce(t *testing.T) {
+	serverA := NewServer()
+	serverA.ClusterIdempotencyNonce = "gateway-epoch-a"
+	serverA.DefaultCollectionOptions = collections.CollectionOptions{DocumentFormat: collections.DocumentFormatBSON}
+	submitterA := &mongoClusterFakeSubmitter{}
+	setMongoClusterTestSubmitter(serverA, submitterA, 21)
+
+	serverB := NewServer()
+	serverB.ClusterIdempotencyNonce = "gateway-epoch-b"
+	serverB.DefaultCollectionOptions = collections.CollectionOptions{DocumentFormat: collections.DocumentFormatBSON}
+	submitterB := &mongoClusterFakeSubmitter{}
+	setMongoClusterTestSubmitter(serverB, submitterB, 21)
+
+	for _, server := range []*Server{serverA, serverB} {
+		response := serveCommand(t, server, 325821, bson.D{
+			{Key: "insert", Value: "users"},
+			{Key: "documents", Value: bson.A{bson.D{{Key: "_id", Value: "u1"}}}},
+			{Key: "$db", Value: "app"},
+		})
+		assertOK(t, response)
 	}
-	if _, err := server.Collections.OpenCollection("app.users"); err == nil {
-		t.Fatal("cluster insert created local collection")
-	} else if err != collections.ErrCollectionNotFound {
-		t.Fatalf("OpenCollection after cluster insert err=%v want collection not found", err)
+
+	callsA := submitterA.snapshotCalls()
+	callsB := submitterB.snapshotCalls()
+	if len(callsA) != 2 || len(callsB) != 2 {
+		t.Fatalf("submit calls A=%d B=%d want 2 each", len(callsA), len(callsB))
+	}
+	keyA := mongoClusterCallIdempotencyKey(t, callsA[1])
+	keyB := mongoClusterCallIdempotencyKey(t, callsB[1])
+	if keyA == keyB {
+		t.Fatalf("idempotency keys matched across gateway epochs: %q", keyA)
+	}
+	if !strings.HasPrefix(keyA, "mongo-gateway/gateway-epoch-a/insert_batch/") {
+		t.Fatalf("idempotency key A=%q missing gateway epoch", keyA)
+	}
+	if !strings.HasPrefix(keyB, "mongo-gateway/gateway-epoch-b/insert_batch/") {
+		t.Fatalf("idempotency key B=%q missing gateway epoch", keyB)
 	}
 }
 
@@ -319,6 +409,35 @@ func TestClusterSubmitterDeleteDeduplicatesDuplicateIDs(t *testing.T) {
 	calls := submitter.snapshotCalls()
 	if len(calls) != 1 {
 		t.Fatalf("submit calls=%d want 1", len(calls))
+	}
+	ids := mongoClusterTestIDs(calls[0].entry.Decoded.Sections)
+	if len(ids) != 1 {
+		t.Fatalf("document ids=%d want 1", len(ids))
+	}
+}
+
+func TestClusterSubmitterDeleteSubmitsPriorOrderedItemsBeforeUnsupported(t *testing.T) {
+	submitter := &mongoClusterFakeSubmitter{}
+	server := NewServer()
+	server.DefaultCollectionOptions = collections.CollectionOptions{DocumentFormat: collections.DocumentFormatBSON}
+	setMongoClusterTestSubmitter(server, submitter, 22)
+
+	response := serveCommand(t, server, 325822, bson.D{
+		{Key: "delete", Value: "users"},
+		{Key: "deletes", Value: bson.A{
+			bson.D{{Key: "q", Value: bson.D{{Key: "_id", Value: "u1"}}}, {Key: "limit", Value: int32(1)}},
+			bson.D{{Key: "q", Value: bson.D{{Key: "name", Value: "Ada"}}}, {Key: "limit", Value: int32(1)}},
+		}},
+		{Key: "$db", Value: "app"},
+	})
+	assertCommandError(t, response, "BadValue")
+
+	calls := submitter.snapshotCalls()
+	if len(calls) != 1 {
+		t.Fatalf("submit calls=%d want 1", len(calls))
+	}
+	if got := calls[0].entry.Decoded.CommandID; got != iwire.CommandDeleteBatch {
+		t.Fatalf("command id=%d want delete_batch", got)
 	}
 	ids := mongoClusterTestIDs(calls[0].entry.Decoded.Sections)
 	if len(ids) != 1 {
@@ -541,8 +660,12 @@ func TestClusterSubmitterRequiresInsertedCount(t *testing.T) {
 		{Key: "$db", Value: "app"},
 	})
 	assertCommandError(t, response, "BadValue")
-	if calls := submitter.snapshotCalls(); len(calls) != 1 {
-		t.Fatalf("submit calls=%d want 1", len(calls))
+	calls := submitter.snapshotCalls()
+	if len(calls) != 2 {
+		t.Fatalf("submit calls=%d want 2", len(calls))
+	}
+	if got := calls[1].entry.Decoded.CommandID; got != iwire.CommandInsertBatch {
+		t.Fatalf("second command id=%d want insert_batch", got)
 	}
 }
 

--- a/TreeDB/mongo_gateway/cluster_submitter_test.go
+++ b/TreeDB/mongo_gateway/cluster_submitter_test.go
@@ -1,0 +1,271 @@
+package mongogateway
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/collections"
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+	iwire "github.com/snissn/gomap/TreeDB/internal/nativewire"
+	"github.com/snissn/gomap/TreeDB/internal/raftentry"
+	treenativewire "github.com/snissn/gomap/TreeDB/nativewire"
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+type mongoClusterSubmitterCall struct {
+	entry    raftentry.CommandEntryV1
+	metadata treenativewire.ClusterRequestMetadata
+}
+
+type mongoClusterFakeSubmitter struct {
+	mu    sync.Mutex
+	calls []mongoClusterSubmitterCall
+}
+
+func (f *mongoClusterFakeSubmitter) SubmitCommandEntryV1(ctx context.Context, entry []byte, metadata treenativewire.ClusterRequestMetadata) (treenativewire.ClusterSubmitResult, error) {
+	if ctx == nil {
+		return treenativewire.ClusterSubmitResult{}, fmt.Errorf("nil submit context")
+	}
+	decoded, err := raftentry.DecodeCommandEntryV1(entry, raftentry.DecodeOptions{RequestMetadata: metadata})
+	if err != nil {
+		return treenativewire.ClusterSubmitResult{}, err
+	}
+	f.mu.Lock()
+	f.calls = append(f.calls, mongoClusterSubmitterCall{entry: decoded, metadata: metadata})
+	f.mu.Unlock()
+	return treenativewire.ClusterSubmitResult{
+		ActualAck:        iwire.AckVisible,
+		ResponseSections: mongoClusterFakeResponseSections(decoded.Decoded),
+	}, nil
+}
+
+func (f *mongoClusterFakeSubmitter) snapshotCalls() []mongoClusterSubmitterCall {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]mongoClusterSubmitterCall(nil), f.calls...)
+}
+
+func mongoClusterFakeResponseSections(entry iwire.DeterministicEntry) []iwire.Section {
+	ids := mongoClusterTestIDs(entry.Sections)
+	switch entry.CommandID {
+	case iwire.CommandInsertBatch:
+		return []iwire.Section{mongoClusterTestMeta("inserted_count", len(ids))}
+	case iwire.CommandUpdateBSONSet:
+		return []iwire.Section{mongoClusterTestMeta("matched_count", 1, "modified_count", 1)}
+	case iwire.CommandDeleteBatch:
+		return []iwire.Section{mongoClusterTestMeta("deleted_count", len(ids))}
+	default:
+		return []iwire.Section{mongoClusterTestMeta()}
+	}
+}
+
+func mongoClusterTestMeta(counts ...any) iwire.Section {
+	values := []struct {
+		key   string
+		value string
+	}{{key: "actual_ack_policy", value: "1"}}
+	for i := 0; i+1 < len(counts); i += 2 {
+		values = append(values, struct {
+			key   string
+			value string
+		}{key: counts[i].(string), value: fmt.Sprint(counts[i+1])})
+	}
+	payload := binary.AppendUvarint(nil, uint64(len(values)))
+	for _, value := range values {
+		payload = mongoClusterAppendString(payload, value.key)
+		payload = mongoClusterAppendString(payload, value.value)
+	}
+	return iwire.Section{ID: iwire.SectionResponseMeta, Bytes: payload}
+}
+
+func mongoClusterAppendString(dst []byte, value string) []byte {
+	dst = binary.AppendUvarint(dst, uint64(len(value)))
+	return append(dst, value...)
+}
+
+func mongoClusterTestIDs(sections []iwire.Section) [][]byte {
+	for _, section := range sections {
+		if section.ID == iwire.SectionDocumentIDs {
+			ids, err := iwire.DecodeByteVectorItems(section.Bytes, iwire.Limits{})
+			if err != nil {
+				return nil
+			}
+			return ids
+		}
+	}
+	return nil
+}
+
+func TestClusterSubmitterInsertRoutesCommandEntryNoLocalMutation(t *testing.T) {
+	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	submitter := &mongoClusterFakeSubmitter{}
+	server := NewServer()
+	server.Collections = collections.NewCollectionManager(db)
+	server.DefaultCollectionOptions = collections.CollectionOptions{DocumentFormat: collections.DocumentFormatBSON}
+	server.ClusterSubmitter = submitter
+
+	response := serveCommand(t, server, 325801, bson.D{
+		{Key: "insert", Value: "users"},
+		{Key: "documents", Value: bson.A{bson.D{{Key: "_id", Value: "u1"}, {Key: "name", Value: "Ada"}}}},
+		{Key: "$db", Value: "app"},
+	})
+	assertOK(t, response)
+	assertInt32(t, response, "n", 1)
+
+	calls := submitter.snapshotCalls()
+	if len(calls) != 1 {
+		t.Fatalf("submit calls=%d want 1", len(calls))
+	}
+	if got := calls[0].entry.Decoded.CommandID; got != iwire.CommandInsertBatch {
+		t.Fatalf("command id=%d want insert_batch", got)
+	}
+	if _, err := server.Collections.OpenCollection("app.users"); err == nil {
+		t.Fatal("cluster insert created local collection")
+	} else if err != collections.ErrCollectionNotFound {
+		t.Fatalf("OpenCollection after cluster insert err=%v want collection not found", err)
+	}
+}
+
+func TestClusterSubmitterUpdateBSONSetRoutesCountsAndNoLocalMutation(t *testing.T) {
+	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	server := NewServer()
+	server.Collections = collections.NewCollectionManager(db)
+	server.DefaultCollectionOptions = collections.CollectionOptions{DocumentFormat: collections.DocumentFormatBSON}
+	assertOK(t, serveCommand(t, server, 325802, bson.D{
+		{Key: "insert", Value: "users"},
+		{Key: "documents", Value: bson.A{bson.D{{Key: "_id", Value: "u1"}, {Key: "name", Value: "Ada"}}}},
+		{Key: "$db", Value: "app"},
+	}))
+
+	submitter := &mongoClusterFakeSubmitter{}
+	server.ClusterSubmitter = submitter
+	response := serveCommand(t, server, 325803, bson.D{
+		{Key: "update", Value: "users"},
+		{Key: "updates", Value: bson.A{bson.D{
+			{Key: "q", Value: bson.D{{Key: "_id", Value: "u1"}}},
+			{Key: "u", Value: bson.D{{Key: "$set", Value: bson.D{{Key: "name", Value: "Grace"}}}}},
+		}}},
+		{Key: "$db", Value: "app"},
+	})
+	assertOK(t, response)
+	assertInt32(t, response, "n", 1)
+	assertInt32(t, response, "nModified", 1)
+
+	calls := submitter.snapshotCalls()
+	if len(calls) != 1 {
+		t.Fatalf("submit calls=%d want 1", len(calls))
+	}
+	if got := calls[0].entry.Decoded.CommandID; got != iwire.CommandUpdateBSONSet {
+		t.Fatalf("command id=%d want update_bson_set", got)
+	}
+	found := serveCommand(t, server, 325804, bson.D{
+		{Key: "find", Value: "users"},
+		{Key: "filter", Value: bson.D{{Key: "_id", Value: "u1"}}},
+		{Key: "$db", Value: "app"},
+	})
+	batch := cursorFirstBatch(t, found)
+	if len(batch) != 1 {
+		t.Fatalf("firstBatch len=%d want 1", len(batch))
+	}
+	if got, ok := batch[0].Lookup("name").StringValueOK(); !ok || got != "Ada" {
+		t.Fatalf("local name after cluster update=%q ok=%v want Ada", got, ok)
+	}
+}
+
+func TestClusterSubmitterDeleteRoutesCommandEntry(t *testing.T) {
+	submitter := &mongoClusterFakeSubmitter{}
+	server := NewServer()
+	server.DefaultCollectionOptions = collections.CollectionOptions{DocumentFormat: collections.DocumentFormatBSON}
+	server.ClusterSubmitter = submitter
+
+	response := serveCommand(t, server, 325805, bson.D{
+		{Key: "delete", Value: "users"},
+		{Key: "deletes", Value: bson.A{bson.D{{Key: "q", Value: bson.D{{Key: "_id", Value: "u1"}}}, {Key: "limit", Value: int32(1)}}}},
+		{Key: "$db", Value: "app"},
+	})
+	assertOK(t, response)
+	assertInt32(t, response, "n", 1)
+
+	calls := submitter.snapshotCalls()
+	if len(calls) != 1 {
+		t.Fatalf("submit calls=%d want 1", len(calls))
+	}
+	if got := calls[0].entry.Decoded.CommandID; got != iwire.CommandDeleteBatch {
+		t.Fatalf("command id=%d want delete_batch", got)
+	}
+}
+
+func TestClusterSubmitterRejectsWriteConcern(t *testing.T) {
+	submitter := &mongoClusterFakeSubmitter{}
+	server := NewServer()
+	server.DefaultCollectionOptions = collections.CollectionOptions{DocumentFormat: collections.DocumentFormatBSON}
+	server.ClusterSubmitter = submitter
+
+	response := serveCommand(t, server, 325806, bson.D{
+		{Key: "insert", Value: "users"},
+		{Key: "documents", Value: bson.A{bson.D{{Key: "_id", Value: "u1"}}}},
+		{Key: "writeConcern", Value: bson.D{{Key: "w", Value: "majority"}}},
+		{Key: "$db", Value: "app"},
+	})
+	assertCommandError(t, response, "BadValue")
+	if calls := submitter.snapshotCalls(); len(calls) != 0 {
+		t.Fatalf("submit calls=%d want 0", len(calls))
+	}
+}
+
+func TestClusterSubmitterRejectsUnsupportedClusterMutationNoLocalMutation(t *testing.T) {
+	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	server := NewServer()
+	server.Collections = collections.NewCollectionManager(db)
+	server.DefaultCollectionOptions = collections.CollectionOptions{DocumentFormat: collections.DocumentFormatBSON}
+	assertOK(t, serveCommand(t, server, 325807, bson.D{
+		{Key: "insert", Value: "users"},
+		{Key: "documents", Value: bson.A{bson.D{{Key: "_id", Value: "u1"}, {Key: "age", Value: int32(1)}}}},
+		{Key: "$db", Value: "app"},
+	}))
+
+	submitter := &mongoClusterFakeSubmitter{}
+	server.ClusterSubmitter = submitter
+	response := serveCommand(t, server, 325808, bson.D{
+		{Key: "update", Value: "users"},
+		{Key: "updates", Value: bson.A{bson.D{
+			{Key: "q", Value: bson.D{{Key: "_id", Value: "u1"}}},
+			{Key: "u", Value: bson.D{{Key: "$inc", Value: bson.D{{Key: "age", Value: int32(1)}}}}},
+		}}},
+		{Key: "$db", Value: "app"},
+	})
+	assertCommandError(t, response, "BadValue")
+	if calls := submitter.snapshotCalls(); len(calls) != 0 {
+		t.Fatalf("submit calls=%d want 0", len(calls))
+	}
+	found := serveCommand(t, server, 325809, bson.D{
+		{Key: "find", Value: "users"},
+		{Key: "filter", Value: bson.D{{Key: "_id", Value: "u1"}}},
+		{Key: "$db", Value: "app"},
+	})
+	batch := cursorFirstBatch(t, found)
+	if len(batch) != 1 {
+		t.Fatalf("firstBatch len=%d want 1", len(batch))
+	}
+	if got, ok := batch[0].Lookup("age").Int32OK(); !ok || got != 1 {
+		t.Fatalf("local age after rejected cluster update=%d ok=%v want 1", got, ok)
+	}
+}

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -41,6 +41,9 @@ const primaryKeyPrefixBSONValue byte = 1
 var maxInt = int(^uint(0) >> 1)
 
 func (s *Server) insertResponse(command wire.Document, sequences []wire.DocumentSequence) (wire.Document, error) {
+	if s.clusterSubmitterConfigured() {
+		return s.clusterInsertResponse(command, sequences)
+	}
 	if s.Collections == nil {
 		return commandError(commandCodeBadValue, "BadValue", "Mongo gateway collection manager is not configured")
 	}
@@ -843,6 +846,9 @@ func (s *Server) findSimpleProjectedPrimaryEqualityPayload(col *collections.Coll
 }
 
 func (s *Server) updateResponse(command wire.Document, sequences []wire.DocumentSequence) (wire.Document, error) {
+	if s.clusterSubmitterConfigured() {
+		return s.clusterUpdateResponse(command, sequences)
+	}
 	if s.Collections == nil {
 		return commandError(commandCodeBadValue, "BadValue", "Mongo gateway collection manager is not configured")
 	}
@@ -1691,6 +1697,9 @@ func mongoBSONSetUpdateFields(updateDoc wire.Document) ([]collections.BSONSetFie
 }
 
 func (s *Server) deleteResponse(command wire.Document, sequences []wire.DocumentSequence) (wire.Document, error) {
+	if s.clusterSubmitterConfigured() {
+		return s.clusterDeleteResponse(command, sequences)
+	}
 	if s.Collections == nil {
 		return commandError(commandCodeBadValue, "BadValue", "Mongo gateway collection manager is not configured")
 	}

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -2,6 +2,7 @@ package mongogateway
 
 import (
 	"bytes"
+	"context"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -40,9 +41,9 @@ const primaryKeyPrefixBSONValue byte = 1
 
 var maxInt = int(^uint(0) >> 1)
 
-func (s *Server) insertResponse(command wire.Document, sequences []wire.DocumentSequence) (wire.Document, error) {
+func (s *Server) insertResponse(ctx context.Context, command wire.Document, sequences []wire.DocumentSequence) (wire.Document, error) {
 	if s.clusterSubmitterConfigured() {
-		return s.clusterInsertResponse(command, sequences)
+		return s.clusterInsertResponse(ctx, command, sequences)
 	}
 	if s.Collections == nil {
 		return commandError(commandCodeBadValue, "BadValue", "Mongo gateway collection manager is not configured")
@@ -845,9 +846,9 @@ func (s *Server) findSimpleProjectedPrimaryEqualityPayload(col *collections.Coll
 	}, true, nil
 }
 
-func (s *Server) updateResponse(command wire.Document, sequences []wire.DocumentSequence) (wire.Document, error) {
+func (s *Server) updateResponse(ctx context.Context, command wire.Document, sequences []wire.DocumentSequence) (wire.Document, error) {
 	if s.clusterSubmitterConfigured() {
-		return s.clusterUpdateResponse(command, sequences)
+		return s.clusterUpdateResponse(ctx, command, sequences)
 	}
 	if s.Collections == nil {
 		return commandError(commandCodeBadValue, "BadValue", "Mongo gateway collection manager is not configured")
@@ -1696,9 +1697,9 @@ func mongoBSONSetUpdateFields(updateDoc wire.Document) ([]collections.BSONSetFie
 	return fields, fieldNames, true
 }
 
-func (s *Server) deleteResponse(command wire.Document, sequences []wire.DocumentSequence) (wire.Document, error) {
+func (s *Server) deleteResponse(ctx context.Context, command wire.Document, sequences []wire.DocumentSequence) (wire.Document, error) {
 	if s.clusterSubmitterConfigured() {
-		return s.clusterDeleteResponse(command, sequences)
+		return s.clusterDeleteResponse(ctx, command, sequences)
 	}
 	if s.Collections == nil {
 		return commandError(commandCodeBadValue, "BadValue", "Mongo gateway collection manager is not configured")
@@ -1854,7 +1855,10 @@ func (s *Server) listDatabasesResponse(command wire.Document) (wire.Document, er
 	})
 }
 
-func (s *Server) createCollectionResponse(command wire.Document) (wire.Document, error) {
+func (s *Server) createCollectionResponse(ctx context.Context, command wire.Document) (wire.Document, error) {
+	if s.clusterSubmitterConfigured() {
+		return s.clusterCreateCollectionResponse(ctx, command)
+	}
 	if s.Collections == nil {
 		return commandError(commandCodeBadValue, "BadValue", "Mongo gateway collection manager is not configured")
 	}
@@ -1976,6 +1980,9 @@ func rejectTransactionalCommand(command wire.Document, commandName string) (wire
 }
 
 func (s *Server) createIndexesResponse(command wire.Document) (wire.Document, error) {
+	if s.clusterSubmitterConfigured() {
+		return mongoClusterUnsupportedLocalMutation("createIndexes")
+	}
 	if s.Collections == nil {
 		return commandError(commandCodeBadValue, "BadValue", "Mongo gateway collection manager is not configured")
 	}
@@ -2120,6 +2127,9 @@ func (s *Server) listIndexesResponse(command wire.Document) (wire.Document, erro
 }
 
 func (s *Server) dropIndexesResponse(command wire.Document) (wire.Document, error) {
+	if s.clusterSubmitterConfigured() {
+		return mongoClusterUnsupportedLocalMutation("dropIndexes")
+	}
 	if s.Collections == nil {
 		return commandError(commandCodeBadValue, "BadValue", "Mongo gateway collection manager is not configured")
 	}

--- a/TreeDB/mongo_gateway/server_core.go
+++ b/TreeDB/mongo_gateway/server_core.go
@@ -4,7 +4,9 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"crypto/rand"
 	"encoding/binary"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -55,6 +57,8 @@ var errServerClosed = errors.New("mongo gateway server is closed")
 
 type ClusterCatalogVersionProvider func(context.Context) (uint64, error)
 
+var clusterIdempotencyNonceFallback atomic.Uint64
+
 type Server struct {
 	MaxMessageLength       int32
 	MaxFindScanDocuments   int
@@ -86,6 +90,10 @@ type Server struct {
 	DefaultIndexStoragePolicy collections.RootStoragePolicy
 	ClusterSubmitter          treenativewire.ClusterSubmitter
 	ClusterCatalogVersion     ClusterCatalogVersionProvider
+	// ClusterIdempotencyNonce scopes generated cluster mutation idempotency
+	// keys to one gateway process epoch. NewServer initializes a random nonce
+	// so sequence-based keys are not reused after restart.
+	ClusterIdempotencyNonce string
 
 	nextResponseID    atomic.Int32
 	nextConnectionID  atomic.Int64
@@ -126,9 +134,18 @@ func NewServer() *Server {
 		InsertCoalescingMaxDelay: defaultInsertCoalescingDelay,
 		InsertCoalescingMaxBatch: defaultInsertCoalescingBatch,
 		InsertCoalescingIdleTTL:  defaultInsertCoalescingIdleTTL,
+		ClusterIdempotencyNonce:  newClusterIdempotencyNonce(),
 	}
 	s.nextResponseID.Store(0)
 	return s
+}
+
+func newClusterIdempotencyNonce() string {
+	var nonce [16]byte
+	if _, err := rand.Read(nonce[:]); err == nil {
+		return hex.EncodeToString(nonce[:])
+	}
+	return fmt.Sprintf("fallback-%d-%d", time.Now().UnixNano(), clusterIdempotencyNonceFallback.Add(1))
 }
 
 func (s *Server) openCollectionCached(name string) (*collections.Collection, error) {

--- a/TreeDB/mongo_gateway/server_core.go
+++ b/TreeDB/mongo_gateway/server_core.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/snissn/gomap/TreeDB/collections"
 	"github.com/snissn/gomap/TreeDB/mongo_gateway/wire"
+	treenativewire "github.com/snissn/gomap/TreeDB/nativewire"
 	"go.mongodb.org/mongo-driver/v2/bson"
 )
 
@@ -81,9 +82,11 @@ type Server struct {
 	Collections               *collections.CollectionManager
 	DefaultCollectionOptions  collections.CollectionOptions
 	DefaultIndexStoragePolicy collections.RootStoragePolicy
+	ClusterSubmitter          treenativewire.ClusterSubmitter
 
 	nextResponseID    atomic.Int32
 	nextConnectionID  atomic.Int64
+	nextClusterSubmit atomic.Uint64
 	nextCursorID      atomic.Int64
 	cursorCount       atomic.Int64
 	connMu            sync.Mutex

--- a/TreeDB/mongo_gateway/server_core.go
+++ b/TreeDB/mongo_gateway/server_core.go
@@ -53,6 +53,8 @@ const (
 
 var errServerClosed = errors.New("mongo gateway server is closed")
 
+type ClusterCatalogVersionProvider func(context.Context) (uint64, error)
+
 type Server struct {
 	MaxMessageLength       int32
 	MaxFindScanDocuments   int
@@ -83,6 +85,7 @@ type Server struct {
 	DefaultCollectionOptions  collections.CollectionOptions
 	DefaultIndexStoragePolicy collections.RootStoragePolicy
 	ClusterSubmitter          treenativewire.ClusterSubmitter
+	ClusterCatalogVersion     ClusterCatalogVersionProvider
 
 	nextResponseID    atomic.Int32
 	nextConnectionID  atomic.Int64
@@ -335,7 +338,7 @@ func (s *Server) ServeConn(ctx context.Context, conn net.Conn) error {
 		}
 
 		var err error
-		readBuf, writeBuf, err = s.appendOneWithOwner(rw, owner, readBuf, writeBuf[:0])
+		readBuf, writeBuf, err = s.appendOneWithOwner(ctx, rw, owner, readBuf, writeBuf[:0])
 		if err != nil {
 			if errors.Is(err, io.EOF) {
 				return nil
@@ -347,7 +350,7 @@ func (s *Server) ServeConn(ctx context.Context, conn net.Conn) error {
 		}
 		for coalesced := 1; coalesced < maxCoalescedWireResponses && len(writeBuf) < maxRetainedWireWriteBuffer; coalesced++ {
 			var appended bool
-			writeBuf, appended, err = s.appendBufferedMessageWithOwner(rw.reader, owner, writeBuf)
+			writeBuf, appended, err = s.appendBufferedMessageWithOwner(ctx, rw.reader, owner, writeBuf)
 			if err != nil {
 				if len(writeBuf) > 0 {
 					if flushErr := writeFull(rw, writeBuf); flushErr != nil {
@@ -407,7 +410,7 @@ func (s *Server) ServeOne(rw io.ReadWriter) error {
 }
 
 func (s *Server) ServeOneWithOwner(rw io.ReadWriter, cursorOwner int64) error {
-	_, _, err := s.serveOneWithOwner(rw, cursorOwner, nil, nil)
+	_, _, err := s.serveOneWithOwner(context.Background(), rw, cursorOwner, nil, nil)
 	return err
 }
 
@@ -428,14 +431,14 @@ func (s *Server) ServeOneWithOwnerBuffered(rw io.ReadWriter, cursorOwner int64, 
 	if buffers == nil {
 		return s.ServeOneWithOwner(rw, cursorOwner)
 	}
-	readBuf, writeBuf, err := s.serveOneWithOwner(rw, cursorOwner, buffers.readBuf, buffers.writeBuf)
+	readBuf, writeBuf, err := s.serveOneWithOwner(context.Background(), rw, cursorOwner, buffers.readBuf, buffers.writeBuf)
 	buffers.readBuf = readBuf
 	buffers.writeBuf = writeBuf
 	return err
 }
 
-func (s *Server) serveOneWithOwner(rw io.ReadWriter, cursorOwner int64, readBuf, writeBuf []byte) ([]byte, []byte, error) {
-	readBuf, writeBuf, err := s.appendOneWithOwner(rw, cursorOwner, readBuf, writeBuf[:0])
+func (s *Server) serveOneWithOwner(ctx context.Context, rw io.ReadWriter, cursorOwner int64, readBuf, writeBuf []byte) ([]byte, []byte, error) {
+	readBuf, writeBuf, err := s.appendOneWithOwner(ctx, rw, cursorOwner, readBuf, writeBuf[:0])
 	if err != nil {
 		return readBuf, writeBuf, err
 	}
@@ -453,7 +456,7 @@ func (s *Server) serveOneWithOwner(rw io.ReadWriter, cursorOwner int64, readBuf,
 	return readBuf, writeBuf, nil
 }
 
-func (s *Server) appendOneWithOwner(rw io.Reader, cursorOwner int64, readBuf, writeBuf []byte) ([]byte, []byte, error) {
+func (s *Server) appendOneWithOwner(ctx context.Context, rw io.Reader, cursorOwner int64, readBuf, writeBuf []byte) ([]byte, []byte, error) {
 	if s.isClosed() {
 		return readBuf, writeBuf, errServerClosed
 	}
@@ -464,7 +467,7 @@ func (s *Server) appendOneWithOwner(rw io.Reader, cursorOwner int64, readBuf, wr
 		}
 		return readBuf, writeBuf, err
 	}
-	response, retainRequestBody, err := s.handleMessageInto(writeBuf[:0], h, body, cursorOwner)
+	response, retainRequestBody, err := s.handleMessageInto(ctx, writeBuf[:0], h, body, cursorOwner)
 	if err != nil {
 		return nil, writeBuf, err
 	}
@@ -479,7 +482,7 @@ func (s *Server) appendOneWithOwner(rw io.Reader, cursorOwner int64, readBuf, wr
 	return readBuf, response, nil
 }
 
-func (s *Server) appendBufferedMessageWithOwner(reader *bufio.Reader, cursorOwner int64, writeBuf []byte) ([]byte, bool, error) {
+func (s *Server) appendBufferedMessageWithOwner(ctx context.Context, reader *bufio.Reader, cursorOwner int64, writeBuf []byte) ([]byte, bool, error) {
 	if s.isClosed() {
 		return writeBuf, false, errServerClosed
 	}
@@ -518,7 +521,7 @@ func (s *Server) appendBufferedMessageWithOwner(reader *bufio.Reader, cursorOwne
 	if !bufferedMessageCanRetainRequestBody(h, body) {
 		return writeBuf, false, nil
 	}
-	response, _, err := s.handleMessageInto(writeBuf, h, body, cursorOwner)
+	response, _, err := s.handleMessageInto(ctx, writeBuf, h, body, cursorOwner)
 	if err != nil {
 		return writeBuf, false, err
 	}
@@ -532,7 +535,7 @@ func (s *Server) appendBufferedMessageWithOwner(reader *bufio.Reader, cursorOwne
 }
 
 func (s *Server) handleMessage(h wire.Header, body []byte, cursorOwner int64) ([]byte, error) {
-	response, _, err := s.handleMessageInto(nil, h, body, cursorOwner)
+	response, _, err := s.handleMessageInto(context.Background(), nil, h, body, cursorOwner)
 	return response, err
 }
 
@@ -621,16 +624,16 @@ func bsonDocumentCommandName(doc []byte) (string, bool) {
 	return "", false
 }
 
-func (s *Server) handleMessageInto(dst []byte, h wire.Header, body []byte, cursorOwner int64) ([]byte, bool, error) {
+func (s *Server) handleMessageInto(ctx context.Context, dst []byte, h wire.Header, body []byte, cursorOwner int64) ([]byte, bool, error) {
 	if s.isClosed() {
 		return nil, false, errServerClosed
 	}
 	s.reapExpiredCursors()
 	switch h.OpCode {
 	case wire.OpQuery:
-		return s.handleQueryInto(dst, h, body, cursorOwner)
+		return s.handleQueryInto(ctx, dst, h, body, cursorOwner)
 	case wire.OpMsg:
-		return s.handleMsgInto(dst, h, body, cursorOwner)
+		return s.handleMsgInto(ctx, dst, h, body, cursorOwner)
 	case wire.OpCompressed:
 		return nil, false, fmt.Errorf("%w: OP_COMPRESSED", wire.ErrUnsupported)
 	default:
@@ -639,11 +642,11 @@ func (s *Server) handleMessageInto(dst []byte, h wire.Header, body []byte, curso
 }
 
 func (s *Server) handleQuery(h wire.Header, body []byte, cursorOwner int64) ([]byte, error) {
-	response, _, err := s.handleQueryInto(nil, h, body, cursorOwner)
+	response, _, err := s.handleQueryInto(context.Background(), nil, h, body, cursorOwner)
 	return response, err
 }
 
-func (s *Server) handleQueryInto(dst []byte, h wire.Header, body []byte, cursorOwner int64) ([]byte, bool, error) {
+func (s *Server) handleQueryInto(ctx context.Context, dst []byte, h wire.Header, body []byte, cursorOwner int64) ([]byte, bool, error) {
 	q, err := wire.ParseQuery(body)
 	if err != nil {
 		return nil, false, err
@@ -653,7 +656,7 @@ func (s *Server) handleQueryInto(dst []byte, h wire.Header, body []byte, cursorO
 		return nil, false, err
 	}
 
-	response, err := s.commandResponse(name, q.Query, nil, cursorOwner)
+	response, err := s.commandResponse(ctx, name, q.Query, nil, cursorOwner)
 	if err != nil {
 		return nil, name != "insert", err
 	}
@@ -662,11 +665,11 @@ func (s *Server) handleQueryInto(dst []byte, h wire.Header, body []byte, cursorO
 }
 
 func (s *Server) handleMsg(h wire.Header, body []byte, cursorOwner int64) ([]byte, error) {
-	response, _, err := s.handleMsgInto(nil, h, body, cursorOwner)
+	response, _, err := s.handleMsgInto(context.Background(), nil, h, body, cursorOwner)
 	return response, err
 }
 
-func (s *Server) handleMsgInto(dst []byte, h wire.Header, body []byte, cursorOwner int64) ([]byte, bool, error) {
+func (s *Server) handleMsgInto(ctx context.Context, dst []byte, h wire.Header, body []byte, cursorOwner int64) ([]byte, bool, error) {
 	msg, err := wire.ParseMsg(body)
 	if err != nil {
 		return nil, false, err
@@ -695,7 +698,7 @@ func (s *Server) handleMsgInto(dst []byte, h wire.Header, body []byte, cursorOwn
 		return response, retainRequestBody, nil
 	}
 
-	response, err := s.commandResponse(name, msg.Body, msg.Sequences, cursorOwner)
+	response, err := s.commandResponse(ctx, name, msg.Body, msg.Sequences, cursorOwner)
 	if err != nil {
 		return nil, retainRequestBody, err
 	}
@@ -706,7 +709,7 @@ func (s *Server) handleMsgInto(dst []byte, h wire.Header, body []byte, cursorOwn
 	return msgResponse, retainRequestBody, err
 }
 
-func (s *Server) commandResponse(name string, command wire.Document, sequences []wire.DocumentSequence, cursorOwner int64) (wire.Document, error) {
+func (s *Server) commandResponse(ctx context.Context, name string, command wire.Document, sequences []wire.DocumentSequence, cursorOwner int64) (wire.Document, error) {
 	if commandRejectsTransactionMarkers(name) {
 		if doc, rejected, err := rejectTransactionalCommand(command, name); rejected {
 			return doc, err
@@ -720,7 +723,7 @@ func (s *Server) commandResponse(name string, command wire.Document, sequences [
 	case "connectionStatus":
 		return marshalDocument(connectionStatusResponse())
 	case "create":
-		return s.createCollectionResponse(command)
+		return s.createCollectionResponse(ctx, command)
 	case "endSessions":
 		return endSessionsResponse(command)
 	case "hostInfo":
@@ -728,7 +731,7 @@ func (s *Server) commandResponse(name string, command wire.Document, sequences [
 	case "ping":
 		return marshalDocument(bson.D{{Key: "ok", Value: 1.0}})
 	case "insert":
-		return s.insertResponse(command, sequences)
+		return s.insertResponse(ctx, command, sequences)
 	case "find":
 		return s.findResponse(command, cursorOwner)
 	case "getMore":
@@ -736,9 +739,9 @@ func (s *Server) commandResponse(name string, command wire.Document, sequences [
 	case "killCursors":
 		return s.killCursorsResponse(command, cursorOwner)
 	case "update":
-		return s.updateResponse(command, sequences)
+		return s.updateResponse(ctx, command, sequences)
 	case "delete":
-		return s.deleteResponse(command, sequences)
+		return s.deleteResponse(ctx, command, sequences)
 	case "listCollections":
 		return s.listCollectionsResponse(command)
 	case "listDatabases":

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -262,7 +262,7 @@ func TestServerRetainsReadBufferForSafeCommands(t *testing.T) {
 		t.Fatalf("AppendMsgMessage: %v", err)
 	}
 	server := NewServer()
-	readBuf, _, err := server.serveOneWithOwner(&readWriter{r: bytes.NewReader(req)}, 1, make([]byte, 0, len(req)), nil)
+	readBuf, _, err := server.serveOneWithOwner(context.Background(), &readWriter{r: bytes.NewReader(req)}, 1, make([]byte, 0, len(req)), nil)
 	if err != nil {
 		t.Fatalf("serveOneWithOwner: %v", err)
 	}
@@ -296,7 +296,7 @@ func TestServerDoesNotRetainReadBufferAfterBSONInsert(t *testing.T) {
 		t.Fatalf("AppendMsgMessage: %v", err)
 	}
 	rw := &readWriter{r: bytes.NewReader(req)}
-	readBuf, _, err := server.serveOneWithOwner(rw, 1, make([]byte, 0, len(req)), nil)
+	readBuf, _, err := server.serveOneWithOwner(context.Background(), rw, 1, make([]byte, 0, len(req)), nil)
 	if err != nil {
 		t.Fatalf("serveOneWithOwner: %v", err)
 	}
@@ -5943,14 +5943,14 @@ func TestServeConnBufferedMessageCoalescingAppendsResponses(t *testing.T) {
 
 	server := NewServer()
 	var writeBuf []byte
-	writeBuf, appended, err := server.appendBufferedMessageWithOwner(reader, 1, writeBuf)
+	writeBuf, appended, err := server.appendBufferedMessageWithOwner(context.Background(), reader, 1, writeBuf)
 	if err != nil {
 		t.Fatalf("append first buffered message: %v", err)
 	}
 	if !appended {
 		t.Fatal("first buffered message was not appended")
 	}
-	writeBuf, appended, err = server.appendBufferedMessageWithOwner(reader, 1, writeBuf)
+	writeBuf, appended, err = server.appendBufferedMessageWithOwner(context.Background(), reader, 1, writeBuf)
 	if err != nil {
 		t.Fatalf("append second buffered message: %v", err)
 	}
@@ -6002,7 +6002,7 @@ func TestServeConnBufferedMessageRejectsShortMessageLength(t *testing.T) {
 		t.Fatalf("prime buffered reader: %v", err)
 	}
 
-	_, appended, err := NewServer().appendBufferedMessageWithOwner(reader, 1, nil)
+	_, appended, err := NewServer().appendBufferedMessageWithOwner(context.Background(), reader, 1, nil)
 	if !errors.Is(err, wire.ErrMalformed) {
 		t.Fatalf("append buffered message err=%v want ErrMalformed", err)
 	}

--- a/TreeDB/mongo_gateway/standalone.go
+++ b/TreeDB/mongo_gateway/standalone.go
@@ -50,6 +50,7 @@ type StandaloneOptions struct {
 	InsertCoalescingMaxBatch    int
 	InsertCoalescingIdleTTL     time.Duration
 	ClusterSubmitter            treenativewire.ClusterSubmitter
+	ClusterCatalogVersion       ClusterCatalogVersionProvider
 }
 
 // StandaloneServer owns the TreeDB backend, collection manager, and MongoDB
@@ -147,6 +148,16 @@ func OpenStandaloneServer(opts StandaloneOptions) (*StandaloneServer, error) {
 	server.DefaultCollectionOptions = normalized.DefaultCollectionOptions
 	server.DefaultIndexStoragePolicy = normalized.DefaultIndexStoragePolicy
 	server.ClusterSubmitter = normalized.ClusterSubmitter
+	server.ClusterCatalogVersion = normalized.ClusterCatalogVersion
+	if server.ClusterCatalogVersion == nil && server.ClusterSubmitter != nil {
+		server.ClusterCatalogVersion = func(context.Context) (uint64, error) {
+			state := backend.State()
+			if state == nil {
+				return 0, errors.New("mongo gateway standalone: backend state is unavailable")
+			}
+			return state.CommitSeq, nil
+		}
+	}
 	if normalized.MaxMessageLength > 0 {
 		server.MaxMessageLength = normalized.MaxMessageLength
 	}

--- a/TreeDB/mongo_gateway/standalone.go
+++ b/TreeDB/mongo_gateway/standalone.go
@@ -121,6 +121,9 @@ func NormalizeStandaloneOptions(opts StandaloneOptions) (StandaloneOptions, erro
 	if opts.InsertCoalescingMaxBatch < 0 {
 		return opts, errors.New("mongo gateway standalone: InsertCoalescingMaxBatch must be >= 0")
 	}
+	if opts.ClusterSubmitter != nil && opts.ClusterCatalogVersion == nil {
+		return opts, errors.New("mongo gateway standalone: ClusterCatalogVersion is required when ClusterSubmitter is configured")
+	}
 
 	return opts, nil
 }
@@ -149,15 +152,6 @@ func OpenStandaloneServer(opts StandaloneOptions) (*StandaloneServer, error) {
 	server.DefaultIndexStoragePolicy = normalized.DefaultIndexStoragePolicy
 	server.ClusterSubmitter = normalized.ClusterSubmitter
 	server.ClusterCatalogVersion = normalized.ClusterCatalogVersion
-	if server.ClusterCatalogVersion == nil && server.ClusterSubmitter != nil {
-		server.ClusterCatalogVersion = func(context.Context) (uint64, error) {
-			state := backend.State()
-			if state == nil {
-				return 0, errors.New("mongo gateway standalone: backend state is unavailable")
-			}
-			return state.CommitSeq, nil
-		}
-	}
 	if normalized.MaxMessageLength > 0 {
 		server.MaxMessageLength = normalized.MaxMessageLength
 	}

--- a/TreeDB/mongo_gateway/standalone.go
+++ b/TreeDB/mongo_gateway/standalone.go
@@ -12,6 +12,7 @@ import (
 	treedb "github.com/snissn/gomap/TreeDB"
 	"github.com/snissn/gomap/TreeDB/collections"
 	backenddb "github.com/snissn/gomap/TreeDB/db"
+	treenativewire "github.com/snissn/gomap/TreeDB/nativewire"
 )
 
 const (
@@ -48,6 +49,7 @@ type StandaloneOptions struct {
 	InsertCoalescingMaxBatchSet bool
 	InsertCoalescingMaxBatch    int
 	InsertCoalescingIdleTTL     time.Duration
+	ClusterSubmitter            treenativewire.ClusterSubmitter
 }
 
 // StandaloneServer owns the TreeDB backend, collection manager, and MongoDB
@@ -144,6 +146,7 @@ func OpenStandaloneServer(opts StandaloneOptions) (*StandaloneServer, error) {
 	server.Collections = manager
 	server.DefaultCollectionOptions = normalized.DefaultCollectionOptions
 	server.DefaultIndexStoragePolicy = normalized.DefaultIndexStoragePolicy
+	server.ClusterSubmitter = normalized.ClusterSubmitter
 	if normalized.MaxMessageLength > 0 {
 		server.MaxMessageLength = normalized.MaxMessageLength
 	}

--- a/TreeDB/mongo_gateway/standalone_test.go
+++ b/TreeDB/mongo_gateway/standalone_test.go
@@ -135,6 +135,11 @@ func TestNormalizeStandaloneOptionsDefaultsAndValidation(t *testing.T) {
 			opts: StandaloneOptions{Dir: t.TempDir(), InsertCoalescingMaxBatch: -1},
 			want: "InsertCoalescingMaxBatch must be >= 0",
 		},
+		{
+			name: "cluster submitter missing catalog version",
+			opts: StandaloneOptions{Dir: t.TempDir(), ClusterSubmitter: &mongoClusterFakeSubmitter{}},
+			want: "ClusterCatalogVersion is required",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/TreeDB/nativewire/cluster_submitter_test.go
+++ b/TreeDB/nativewire/cluster_submitter_test.go
@@ -299,11 +299,9 @@ func TestClusterSubmitterUnsupportedCommandFailsBeforeMutation(t *testing.T) {
 		t.Fatalf("seed InsertBatchValidatedBSON: %v", err)
 	}
 
-	_, _, err = client.UpdateBSONSet(ctx, "users", []byte("u1"), []collections.BSONSetField{
-		{Key: "field0", Value: mustNativewireBSONRawValue(t, "new")},
-	}, AckVisible)
+	err = client.FlushCollection(ctx, "users")
 	if !isRemoteError(err, iwire.ErrUnsupportedFeature) {
-		t.Fatalf("UpdateBSONSet cluster err=%v want unsupported feature", err)
+		t.Fatalf("FlushCollection cluster err=%v want unsupported feature", err)
 	}
 	if len(submitter.snapshot()) != 0 {
 		t.Fatalf("unsupported command reached submitter")


### PR DESCRIPTION
## Objective

Route Mongo gateway cluster-mode mutations through the deterministic native-wire `ClusterSubmitter` seam instead of mutating local collections directly.

Closes #3258.
Refs #3044.

## Context

This is the Mongo gateway submitter adapter for the #3044 single-group HA graph. The lower nativewire submitter seam and `update_bson_set` command support are already merged on `main`, so this branch is based on the current post-#3254 head.

## Non-goals

- No real Raft leader routing, failover, redirect, or replica-set personality.
- No Mongo writeConcern implementation for `majority`, `w>1`, `j:true`, or `wtimeout`.
- No cluster support for index DDL; cluster mode rejects `createIndexes` and `dropIndexes` before local mutation.
- No fallback to local writes when a cluster submitter is configured.

## Design

- Adds `Server.ClusterSubmitter` and `StandaloneOptions.ClusterSubmitter` wiring for Mongo gateway cluster mode.
- Adds a `ClusterCatalogVersionProvider`; standalone cluster mode defaults it to the backend `State().CommitSeq` guard.
- Threads request context through command dispatch so submitter calls observe connection/request cancellation.
- Builds deterministic native-wire entries for `create`, `insert`, `_id` equality delete, and top-level BSON `$set` update.
- Requires submitter response metadata counts for write responses and cross-checks `actual_ack_policy` against the submit result.
- Fails closed for unsupported cluster mutations and writeConcern before local mutation.

## Scope

- Includes:
  - `TreeDB/mongo_gateway/cluster_submitter.go`
  - `TreeDB/mongo_gateway/commands.go`
  - `TreeDB/mongo_gateway/server_core.go`
  - `TreeDB/mongo_gateway/standalone.go`
  - focused Mongo gateway cluster submitter tests
- Excludes:
  - Raft FSM execution
  - read routing/snapshots/recovery
  - multi-group routing
  - production Mongo replica-set semantics

## Correctness

Tests run on latest local head `ff55371e3`:

- `git diff --check`
- `GOWORK=off go test ./TreeDB/mongo_gateway -run 'ClusterSubmitter|BufferedMessage|ServeOne' -count=1`
- `GOWORK=off go test ./TreeDB/mongo_gateway ./TreeDB/nativewire ./TreeDB/internal/nativewire ./TreeDB/internal/raftentry -run 'Cluster|Deterministic|Insert|Delete|UpdateBSONSet|Ack' -count=1`
- `GOWORK=off go test ./TreeDB/mongo_gateway ./TreeDB/nativewire -count=1`
- `GOWORK=off go test ./TreeDB/mongo_gateway ./TreeDB/nativewire ./TreeDB/internal/nativewire ./TreeDB/internal/raftentry ./TreeDB/collections -count=1`

Covered edge cases:

- deterministic command entry routing for insert, create, update_bson_set, and delete
- catalog version section sourced from configured provider
- missing catalog provider rejects before submit
- unsupported update shapes reject before submit and before local mutation
- `createIndexes` / `dropIndexes` reject before submit and before local mutation
- canceled request context reaches the submitter
- missing `inserted_count` fails closed
- submit result `actual_ack_policy` mismatch fails closed

## Performance

No benchmarks run. This PR adds cluster-mode branches that are inactive in standalone local mutation mode unless a submitter is configured; the affected local hot-path packages were validated with the package tests above. No format or storage layout change is included.

## Rollout / Toggle Plan

Default setting: unchanged standalone local mutation path unless `ClusterSubmitter` is configured.

Disable quickly: do not configure `ClusterSubmitter`; the gateway keeps existing standalone behavior.

## Follow-ups

- #3257: raft FSM single-group apply loop on the submitter output.
- #3044: wire the single-group HA endpoint through the accepted slices.
- #3045/#3046: read/snapshot/recovery and multi-group routing after the single-group path is stable.
