### PR TITLE
TreeDB Raft: add single-group FSM apply loop

### DIFF
--- a/TreeDB/docs/spec/raftcluster.md
+++ b/TreeDB/docs/spec/raftcluster.md
@@ -15,8 +15,8 @@ The initial boundary owns:
 - one `GroupID`;
 - a peer membership set that must include the local node;
 - a fail-closed config format and required-feature floor;
-- deterministic local storage paths for Raft log, stable metadata, snapshots,
-  and peer metadata.
+- deterministic local storage paths for Raft log, stable metadata, apply
+  metadata, snapshots, and peer metadata.
 
 ## Feature And Version Floor
 
@@ -41,6 +41,7 @@ Validation first resolves TreeDB's storage root and main DB directory from
     groups/<group-id>/
       log/
       stable/
+      apply/
       snapshots/
       peers/<peer-id>/
 ```
@@ -66,6 +67,12 @@ The Raft paths must be distinct from:
 
 The Raft log directory stores consensus-log bytes for the selected future Raft
 provider. It is not the TreeDB command WAL.
+
+The `apply/` directory stores durable R3a/FSM apply metadata for this local
+node/group, including `apply-progress-v1.log` and `apply-results-v1.log`. These
+files are part of the Raft group storage layout and must be backed up/restored
+with the group; they are not consensus log bytes and are not stored under
+TreeDB's local command WAL.
 
 ## Local Command WAL Boundary
 

--- a/TreeDB/docs/spec/storage-format.md
+++ b/TreeDB/docs/spec/storage-format.md
@@ -28,10 +28,10 @@ A TreeDB deployment uses:
   typed-storage physical assets (`column_assets` remains the compatibility
   directory name),
 - R3a/Raft apply metadata logs `apply-progress-v1.log` and
-  `apply-results-v1.log` under the caller-owned Raft/apply metadata directory,
+  `apply-results-v1.log` under the per-group Raft `apply/` metadata directory,
 - optional single-group Raft provider state under
   `raftcluster/nodes/<node-id>/groups/<group-id>/` with separate `log/`,
-  `stable/`, `snapshots/`, and `peers/<peer-id>/` directories,
+  `stable/`, `apply/`, `snapshots/`, and `peers/<peer-id>/` directories,
 - optional side-store DBs (`dictdb`, `templatedb`) using their own `index.db` files.
 
 The old collection root-delta WAL storage class (`wal/collection-l*.log`,
@@ -148,17 +148,24 @@ Rules:
 ## 3.1.1 R3a Apply Metadata Logs
 
 Durable R3a apply stores persist metadata beside the future Raft node state, not
-inside `index.db`, `wal/`, or the value log. The current implementation accepts
-a caller-owned metadata directory. The default file names are:
+inside `index.db`, `wal/`, or the value log. For the single-group Raft layout the
+directory is:
+
+```text
+raftcluster/nodes/<node-id>/groups/<group-id>/apply/
+```
+
+The default file names are:
 
 - `apply-progress-v1.log` for `raftapply.ApplyProgressStore`;
 - `apply-results-v1.log` for `raftapply.ApplyResultStore`.
 
-The parent path is intentionally narrow and caller-owned so the #3044 storage
-boundary can place it under the final node/group directory without changing the
-record format. These files are not part of the local command WAL. They record
-the applied-index and idempotency/result replay metadata that lets a later Raft
-FSM recover after restart.
+The parent path is intentionally narrow so the #3044 storage boundary can place
+it under the node/group directory without changing the record format. These
+files are part of the local Raft group storage set for backup/restore purposes,
+but they are not part of the local command WAL and are not consensus-log bytes.
+They record the applied-index and idempotency/result replay metadata that lets a
+later Raft FSM recover after restart.
 
 Each file starts with a 20-byte header:
 

--- a/TreeDB/internal/raftapply/durable_stores.go
+++ b/TreeDB/internal/raftapply/durable_stores.go
@@ -379,6 +379,19 @@ func (s *DurableApplyProgressStore) LastApplied() (raftentry.ApplyEntryID, bool)
 	return s.last, s.last.Index != 0
 }
 
+func (s *DurableApplyProgressStore) LastAppliedRecord() (ApplyProgressRecordV1, bool) {
+	if s == nil {
+		return ApplyProgressRecordV1{}, false
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.last.Index == 0 {
+		return ApplyProgressRecordV1{}, false
+	}
+	record, ok := s.records[s.last]
+	return record, ok
+}
+
 func (s *DurableApplyProgressStore) Close() error {
 	if s == nil {
 		return nil

--- a/TreeDB/internal/raftapply/stores.go
+++ b/TreeDB/internal/raftapply/stores.go
@@ -283,6 +283,19 @@ func (s *MemoryApplyProgressStore) LastApplied() (raftentry.ApplyEntryID, bool) 
 	return s.last, s.last.Index != 0
 }
 
+func (s *MemoryApplyProgressStore) LastAppliedRecord() (ApplyProgressRecordV1, bool) {
+	if s == nil {
+		return ApplyProgressRecordV1{}, false
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.last.Index == 0 {
+		return ApplyProgressRecordV1{}, false
+	}
+	record, ok := s.records[s.last]
+	return record, ok
+}
+
 func (s *MemoryApplyProgressStore) Len() int {
 	if s == nil {
 		return 0

--- a/TreeDB/internal/raftcluster/config.go
+++ b/TreeDB/internal/raftcluster/config.go
@@ -118,6 +118,7 @@ type StorageLayout struct {
 	GroupDir    string
 	LogDir      string
 	StableDir   string
+	ApplyDir    string
 	SnapshotDir string
 	PeerDirs    []PeerStorageDir
 }
@@ -503,6 +504,7 @@ func storageLayout(clusterDir string, nodeID NodeID, groupID GroupID, peers []Pe
 		GroupDir:    groupDir,
 		LogDir:      filepath.Join(groupDir, "log"),
 		StableDir:   filepath.Join(groupDir, "stable"),
+		ApplyDir:    filepath.Join(groupDir, "apply"),
 		SnapshotDir: filepath.Join(groupDir, "snapshots"),
 		PeerDirs:    peerDirs,
 	}

--- a/TreeDB/internal/raftcluster/config_test.go
+++ b/TreeDB/internal/raftcluster/config_test.go
@@ -328,10 +328,15 @@ func TestStorageLayoutDeterministicAndSeparated(t *testing.T) {
 	if a.Layout.RootDir != DefaultClusterDir(cfg.Dir) {
 		t.Fatalf("root dir=%q want %q", a.Layout.RootDir, DefaultClusterDir(cfg.Dir))
 	}
-	if a.Layout.LogDir == a.Layout.StableDir || a.Layout.LogDir == a.Layout.SnapshotDir || a.Layout.StableDir == a.Layout.SnapshotDir {
-		t.Fatalf("log/stable/snapshot dirs must be distinct: %+v", a.Layout)
+	if a.Layout.LogDir == a.Layout.StableDir ||
+		a.Layout.LogDir == a.Layout.ApplyDir ||
+		a.Layout.LogDir == a.Layout.SnapshotDir ||
+		a.Layout.StableDir == a.Layout.ApplyDir ||
+		a.Layout.StableDir == a.Layout.SnapshotDir ||
+		a.Layout.ApplyDir == a.Layout.SnapshotDir {
+		t.Fatalf("log/stable/apply/snapshot dirs must be distinct: %+v", a.Layout)
 	}
-	for _, path := range []string{a.Layout.RootDir, a.Layout.NodeDir, a.Layout.GroupDir, a.Layout.LogDir, a.Layout.StableDir, a.Layout.SnapshotDir} {
+	for _, path := range []string{a.Layout.RootDir, a.Layout.NodeDir, a.Layout.GroupDir, a.Layout.LogDir, a.Layout.StableDir, a.Layout.ApplyDir, a.Layout.SnapshotDir} {
 		if sameOrUnder(path, CommandWALDir(cfg.Dir)) {
 			t.Fatalf("layout path %q overlaps command WAL dir %q", path, CommandWALDir(cfg.Dir))
 		}

--- a/TreeDB/internal/raftfsm/doc.go
+++ b/TreeDB/internal/raftfsm/doc.go
@@ -1,0 +1,8 @@
+// Package raftfsm wires the single-group R3a committed-entry apply loop.
+//
+// This package is intentionally narrow. It consumes already-committed
+// deterministic CommandEntryV1 bytes, maps the Raft term/index directly to
+// raftentry.ApplyEntryID, and delegates command execution to raftapply. It does
+// not provide leader routing, failover, snapshots, read-index, or
+// client-visible raft_committed semantics.
+package raftfsm

--- a/TreeDB/internal/raftfsm/fsm.go
+++ b/TreeDB/internal/raftfsm/fsm.go
@@ -327,6 +327,9 @@ func validateApplyProgressCoverage(db *backenddb.DB, record raftapply.ApplyProgr
 	if record.AppliedCommandLSN > localLSN {
 		return codedError(raftentry.ErrorUnsafeDurabilityModeV1, "apply progress metadata AppliedCommandLSN %d outruns local coverage %d", record.AppliedCommandLSN, localLSN)
 	}
+	if record.AppliedCommandLSN < localLSN {
+		return codedError(raftentry.ErrorUnsafeDurabilityModeV1, "local AppliedCommandLSN coverage %d outruns apply progress metadata %d", localLSN, record.AppliedCommandLSN)
+	}
 	return nil
 }
 

--- a/TreeDB/internal/raftfsm/fsm.go
+++ b/TreeDB/internal/raftfsm/fsm.go
@@ -286,6 +286,9 @@ func (f *FSM) lastAppliedProgressRecord() (raftapply.ApplyProgressRecordV1, bool
 	}
 	record, ok := f.progress.LastAppliedRecord()
 	if !ok {
+		if err := validateMissingApplyProgressCoverage(f.db); err != nil {
+			return raftapply.ApplyProgressRecordV1{}, false, err
+		}
 		return raftapply.ApplyProgressRecordV1{}, false, nil
 	}
 	if err := validateApplyProgressCoverage(f.db, record); err != nil {
@@ -300,9 +303,20 @@ func validateProgressCoverage(db *backenddb.DB, progress *raftapply.DurableApply
 	}
 	record, ok := progress.LastAppliedRecord()
 	if !ok {
-		return nil
+		return validateMissingApplyProgressCoverage(db)
 	}
 	return validateApplyProgressCoverage(db, record)
+}
+
+func validateMissingApplyProgressCoverage(db *backenddb.DB) error {
+	if db == nil {
+		return codedError(raftentry.ErrorUnsafeDurabilityModeV1, "nil FSM DB")
+	}
+	localLSN := db.State().AppliedCommandLSN
+	if localLSN != 0 {
+		return codedError(raftentry.ErrorUnsafeDurabilityModeV1, "missing apply progress metadata for local AppliedCommandLSN coverage %d", localLSN)
+	}
+	return nil
 }
 
 func validateApplyProgressCoverage(db *backenddb.DB, record raftapply.ApplyProgressRecordV1) error {

--- a/TreeDB/internal/raftfsm/fsm.go
+++ b/TreeDB/internal/raftfsm/fsm.go
@@ -1,0 +1,287 @@
+package raftfsm
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"strings"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+	"github.com/snissn/gomap/TreeDB/internal/nativewire"
+	"github.com/snissn/gomap/TreeDB/internal/raftapply"
+	"github.com/snissn/gomap/TreeDB/internal/raftentry"
+)
+
+type EntryTypeV1 string
+
+const (
+	EntryTypeCommandEntryV1 EntryTypeV1 = "command-entry-v1"
+)
+
+// CommittedEntryV1 is the deterministic payload delivered by the single-group
+// Raft log after commitment.
+type CommittedEntryV1 struct {
+	Type  EntryTypeV1
+	Term  uint64
+	Index uint64
+	Bytes []byte
+
+	// CurrentCatalogVersion is the caller-observed local catalog version for
+	// deterministic catalog guards. Missing guard context is left missing so
+	// raftapply can fail closed before a visible mutation.
+	CurrentCatalogVersion    uint64
+	HasCurrentCatalogVersion bool
+	SyncLocalCommandWAL      bool
+}
+
+// Options configures one local single-group FSM instance.
+type Options struct {
+	DB          *backenddb.DB
+	MetadataDir string
+
+	DecodeLimits nativewire.Limits
+	StoreOptions raftapply.DurableApplyStoreOptions
+
+	ScopeRule     raftentry.ScopeRuleV1
+	DatabaseScope string
+	CatalogScope  string
+}
+
+// FSM applies committed deterministic entries to one local DB.
+type FSM struct {
+	db          *backenddb.DB
+	metadataDir string
+
+	decodeLimits nativewire.Limits
+	storeOptions raftapply.DurableApplyStoreOptions
+	scopeRule    raftentry.ScopeRuleV1
+	database     string
+	catalog      string
+
+	progress *raftapply.DurableApplyProgressStore
+	results  *raftapply.DurableApplyResultStore
+	closed   bool
+}
+
+type Error struct {
+	Code raftentry.DeterministicErrorCodeV1
+	Err  error
+}
+
+func (e *Error) Error() string {
+	if e == nil {
+		return "raftfsm: <nil>"
+	}
+	if e.Err == nil {
+		return fmt.Sprintf("raftfsm: %s", e.Code)
+	}
+	return fmt.Sprintf("raftfsm: %s: %v", e.Code, e.Err)
+}
+
+func (e *Error) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+func ErrorCodeOf(err error) (raftentry.DeterministicErrorCodeV1, bool) {
+	var e *Error
+	if errors.As(err, &e) {
+		return e.Code, true
+	}
+	return raftapply.ErrorCodeOf(err)
+}
+
+// Open creates the durable progress/result stores for one single-group FSM.
+func Open(opts Options) (*FSM, error) {
+	if opts.DB == nil {
+		return nil, codedError(raftentry.ErrorUnsafeDurabilityModeV1, "nil DB")
+	}
+	metadataDir := strings.TrimSpace(opts.MetadataDir)
+	if metadataDir == "" {
+		return nil, codedError(raftentry.ErrorUnsafeDurabilityModeV1, "missing metadata dir")
+	}
+	progress, err := raftapply.OpenDurableApplyProgressStore(metadataDir, opts.StoreOptions)
+	if err != nil {
+		return nil, err
+	}
+	results, err := raftapply.OpenDurableApplyResultStore(metadataDir, opts.StoreOptions)
+	if err != nil {
+		_ = progress.Close()
+		return nil, err
+	}
+	return &FSM{
+		db:           opts.DB,
+		metadataDir:  metadataDir,
+		decodeLimits: opts.DecodeLimits,
+		storeOptions: opts.StoreOptions,
+		scopeRule:    opts.ScopeRule,
+		database:     opts.DatabaseScope,
+		catalog:      opts.CatalogScope,
+		progress:     progress,
+		results:      results,
+	}, nil
+}
+
+func (f *FSM) Close() error {
+	if f == nil || f.closed {
+		return nil
+	}
+	f.closed = true
+	return errors.Join(f.progress.Close(), f.results.Close())
+}
+
+func (f *FSM) LastApplied() (raftentry.ApplyEntryID, bool) {
+	if f == nil || f.progress == nil {
+		return raftentry.ApplyEntryID{}, false
+	}
+	return f.progress.LastApplied()
+}
+
+func (f *FSM) LogicalDigestV1(opts raftapply.LogicalDigestOptionsV1) (raftapply.LogicalDigestV1, error) {
+	if f == nil || f.db == nil {
+		return raftapply.LogicalDigestV1{}, codedError(raftentry.ErrorUnsafeDurabilityModeV1, "nil FSM DB")
+	}
+	return raftapply.LogicalDigestV1ForDB(f.db, opts)
+}
+
+// ApplyCommittedEntriesV1 applies entries in caller order and stops at the
+// first fail-closed rejection.
+func (f *FSM) ApplyCommittedEntriesV1(entries []CommittedEntryV1) ([]raftentry.ApplyResultV1, error) {
+	results := make([]raftentry.ApplyResultV1, 0, len(entries))
+	for _, entry := range entries {
+		result, err := f.ApplyCommittedEntryV1(entry)
+		results = append(results, result)
+		if err != nil {
+			return results, err
+		}
+	}
+	return results, nil
+}
+
+func (f *FSM) ApplyCommittedEntryV1(entry CommittedEntryV1) (raftentry.ApplyResultV1, error) {
+	if f == nil || f.closed {
+		return reject(raftentry.CommandDigestV1{}, raftentry.ErrorUnsafeDurabilityModeV1, fmt.Errorf("FSM is closed"))
+	}
+	if entry.Type != EntryTypeCommandEntryV1 {
+		return reject(raftentry.CommandDigestV1{}, raftentry.ErrorUnsupportedVersionV1, fmt.Errorf("unsupported committed entry type %q", entry.Type))
+	}
+	id := raftentry.ApplyEntryID{Term: entry.Term, Index: entry.Index}
+	if err := validateCommittedID(id); err != nil {
+		return reject(commandDigest(entry.Bytes, f.decodeOptions(id)), raftentry.ErrorMalformedEntryV1, err)
+	}
+	if err := f.checkCommittedOrder(id); err != nil {
+		code, _ := ErrorCodeOf(err)
+		return reject(commandDigest(entry.Bytes, f.decodeOptions(id)), code, err)
+	}
+	meta, err := f.applyMetadata(entry, id)
+	if err != nil {
+		code, _ := ErrorCodeOf(err)
+		return reject(commandDigest(entry.Bytes, f.decodeOptions(id)), code, err)
+	}
+	return raftapply.ApplyCommittedEntryV1(f.db, entry.Bytes, meta, raftapply.Options{
+		DecodeLimits:  f.decodeLimits,
+		ProgressStore: f.progress,
+		ResultStore:   f.results,
+	})
+}
+
+func (f *FSM) applyMetadata(entry CommittedEntryV1, id raftentry.ApplyEntryID) (raftapply.ApplyMetadataV1, error) {
+	return raftapply.ApplyMetadataV1{
+		EntryID:                  id,
+		LocalDurabilityBoundary:  raftapply.LocalDurabilityCommandWALV1,
+		SyncLocalCommandWAL:      entry.SyncLocalCommandWAL,
+		CurrentCatalogVersion:    entry.CurrentCatalogVersion,
+		HasCurrentCatalogVersion: entry.HasCurrentCatalogVersion,
+		ScopeRule:                f.scopeRule,
+		DatabaseScope:            f.database,
+		CatalogScope:             f.catalog,
+	}, nil
+}
+
+func (f *FSM) decodeOptions(id raftentry.ApplyEntryID) raftentry.DecodeOptions {
+	if f == nil {
+		return raftentry.DecodeOptions{ApplyEntryID: id}
+	}
+	return raftentry.DecodeOptions{
+		Limits:        f.decodeLimits,
+		ScopeRule:     f.scopeRule,
+		DatabaseScope: f.database,
+		CatalogScope:  f.catalog,
+		ApplyEntryID:  id,
+	}
+}
+
+func (f *FSM) checkCommittedOrder(id raftentry.ApplyEntryID) error {
+	last, ok := f.progress.LastApplied()
+	if !ok {
+		if id.Index != 1 {
+			return codedError(raftentry.ErrorRejectedConflictV1, "apply entry starts at index %d; want 1", id.Index)
+		}
+		return nil
+	}
+	if id.Index < last.Index {
+		return codedError(raftentry.ErrorRejectedConflictV1, "apply entry index %d is below last applied %d", id.Index, last.Index)
+	}
+	if id.Index > last.Index+1 {
+		return codedError(raftentry.ErrorRejectedConflictV1, "apply entry index gap: got %d after %d", id.Index, last.Index)
+	}
+	if id.Index == last.Index {
+		return nil
+	}
+	if id.Term < last.Term {
+		return codedError(raftentry.ErrorRejectedConflictV1, "apply entry term %d is below last applied term %d", id.Term, last.Term)
+	}
+	return nil
+}
+
+func validateCommittedID(id raftentry.ApplyEntryID) error {
+	if id.Term == 0 || id.Index == 0 {
+		return fmt.Errorf("apply entry id must have non-zero term and index")
+	}
+	return nil
+}
+
+func commandDigest(src []byte, opts raftentry.DecodeOptions) raftentry.CommandDigestV1 {
+	if len(src) == 0 {
+		return raftentry.CommandDigestV1{}
+	}
+	digest, err := raftentry.ValidateCommandDigestInputV1(src, opts)
+	if err == nil {
+		return digest
+	}
+	return raftentry.CommandDigestV1ForBytes(bytes.Clone(src), opts)
+}
+
+func codedError(code raftentry.DeterministicErrorCodeV1, format string, args ...any) error {
+	return &Error{Code: code, Err: fmt.Errorf(format, args...)}
+}
+
+func reject(digest raftentry.CommandDigestV1, code raftentry.DeterministicErrorCodeV1, err error) (raftentry.ApplyResultV1, error) {
+	if code == "" {
+		code = raftentry.ErrorMalformedEntryV1
+	}
+	return raftentry.ApplyResultV1{
+		Status:                 statusForCode(code),
+		CommandDigest:          digest,
+		DeterministicErrorCode: code,
+	}, &Error{Code: code, Err: err}
+}
+
+func statusForCode(code raftentry.DeterministicErrorCodeV1) raftentry.ApplyStatusV1 {
+	switch code {
+	case raftentry.ErrorMalformedEntryV1:
+		return raftentry.ApplyStatusRejectedMalformed
+	case raftentry.ErrorUnsupportedCommandV1,
+		raftentry.ErrorUnsupportedVersionV1,
+		raftentry.ErrorUnsupportedFeatureV1,
+		raftentry.ErrorUnknownRequiredFieldV1,
+		raftentry.ErrorUnsupportedScopeRuleV1:
+		return raftentry.ApplyStatusRejectedUnsupported
+	case raftentry.ErrorRejectedConflictV1:
+		return raftentry.ApplyStatusRejectedConflict
+	default:
+		return raftentry.ApplyStatusDeterministicGuardFailure
+	}
+}

--- a/TreeDB/internal/raftfsm/fsm.go
+++ b/TreeDB/internal/raftfsm/fsm.go
@@ -4,11 +4,11 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"strings"
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
 	"github.com/snissn/gomap/TreeDB/internal/nativewire"
 	"github.com/snissn/gomap/TreeDB/internal/raftapply"
+	"github.com/snissn/gomap/TreeDB/internal/raftcluster"
 	"github.com/snissn/gomap/TreeDB/internal/raftentry"
 )
 
@@ -32,12 +32,14 @@ type CommittedEntryV1 struct {
 	CurrentCatalogVersion    uint64
 	HasCurrentCatalogVersion bool
 	SyncLocalCommandWAL      bool
+	RequestMetadata          raftentry.RequestMetadataV1
+	ExpectedTarget           *raftentry.TargetIdentityV1
 }
 
 // Options configures one local single-group FSM instance.
 type Options struct {
-	DB          *backenddb.DB
-	MetadataDir string
+	DB      *backenddb.DB
+	Cluster raftcluster.Config
 
 	DecodeLimits nativewire.Limits
 	StoreOptions raftapply.DurableApplyStoreOptions
@@ -57,6 +59,7 @@ type FSM struct {
 	scopeRule    raftentry.ScopeRuleV1
 	database     string
 	catalog      string
+	cluster      raftcluster.ResolvedConfig
 
 	progress *raftapply.DurableApplyProgressStore
 	results  *raftapply.DurableApplyResultStore
@@ -98,9 +101,13 @@ func Open(opts Options) (*FSM, error) {
 	if opts.DB == nil {
 		return nil, codedError(raftentry.ErrorUnsafeDurabilityModeV1, "nil DB")
 	}
-	metadataDir := strings.TrimSpace(opts.MetadataDir)
+	cluster, err := raftcluster.Validate(opts.Cluster)
+	if err != nil {
+		return nil, errors.Join(codedError(raftentry.ErrorUnsafeDurabilityModeV1, "invalid raftcluster config"), err)
+	}
+	metadataDir := cluster.Layout.ApplyDir
 	if metadataDir == "" {
-		return nil, codedError(raftentry.ErrorUnsafeDurabilityModeV1, "missing metadata dir")
+		return nil, codedError(raftentry.ErrorUnsafeDurabilityModeV1, "missing raftcluster apply dir")
 	}
 	progress, err := raftapply.OpenDurableApplyProgressStore(metadataDir, opts.StoreOptions)
 	if err != nil {
@@ -119,6 +126,7 @@ func Open(opts Options) (*FSM, error) {
 		scopeRule:    opts.ScopeRule,
 		database:     opts.DatabaseScope,
 		catalog:      opts.CatalogScope,
+		cluster:      cluster,
 		progress:     progress,
 		results:      results,
 	}, nil
@@ -169,16 +177,16 @@ func (f *FSM) ApplyCommittedEntryV1(entry CommittedEntryV1) (raftentry.ApplyResu
 	}
 	id := raftentry.ApplyEntryID{Term: entry.Term, Index: entry.Index}
 	if err := validateCommittedID(id); err != nil {
-		return reject(commandDigest(entry.Bytes, f.decodeOptions(id)), raftentry.ErrorMalformedEntryV1, err)
+		return reject(commandDigest(entry.Bytes, f.decodeOptions(entry, id)), raftentry.ErrorMalformedEntryV1, err)
 	}
 	if err := f.checkCommittedOrder(id); err != nil {
 		code, _ := ErrorCodeOf(err)
-		return reject(commandDigest(entry.Bytes, f.decodeOptions(id)), code, err)
+		return reject(commandDigest(entry.Bytes, f.decodeOptions(entry, id)), code, err)
 	}
 	meta, err := f.applyMetadata(entry, id)
 	if err != nil {
 		code, _ := ErrorCodeOf(err)
-		return reject(commandDigest(entry.Bytes, f.decodeOptions(id)), code, err)
+		return reject(commandDigest(entry.Bytes, f.decodeOptions(entry, id)), code, err)
 	}
 	return raftapply.ApplyCommittedEntryV1(f.db, entry.Bytes, meta, raftapply.Options{
 		DecodeLimits:  f.decodeLimits,
@@ -197,19 +205,27 @@ func (f *FSM) applyMetadata(entry CommittedEntryV1, id raftentry.ApplyEntryID) (
 		ScopeRule:                f.scopeRule,
 		DatabaseScope:            f.database,
 		CatalogScope:             f.catalog,
+		RequestMetadata:          cloneRequestMetadataV1(entry.RequestMetadata),
+		ExpectedTarget:           cloneExpectedTargetV1(entry.ExpectedTarget),
 	}, nil
 }
 
-func (f *FSM) decodeOptions(id raftentry.ApplyEntryID) raftentry.DecodeOptions {
+func (f *FSM) decodeOptions(entry CommittedEntryV1, id raftentry.ApplyEntryID) raftentry.DecodeOptions {
 	if f == nil {
-		return raftentry.DecodeOptions{ApplyEntryID: id}
+		return raftentry.DecodeOptions{
+			ApplyEntryID:    id,
+			RequestMetadata: cloneRequestMetadataV1(entry.RequestMetadata),
+			ExpectedTarget:  cloneExpectedTargetV1(entry.ExpectedTarget),
+		}
 	}
 	return raftentry.DecodeOptions{
-		Limits:        f.decodeLimits,
-		ScopeRule:     f.scopeRule,
-		DatabaseScope: f.database,
-		CatalogScope:  f.catalog,
-		ApplyEntryID:  id,
+		Limits:          f.decodeLimits,
+		ScopeRule:       f.scopeRule,
+		DatabaseScope:   f.database,
+		CatalogScope:    f.catalog,
+		ApplyEntryID:    id,
+		RequestMetadata: cloneRequestMetadataV1(entry.RequestMetadata),
+		ExpectedTarget:  cloneExpectedTargetV1(entry.ExpectedTarget),
 	}
 }
 
@@ -228,6 +244,9 @@ func (f *FSM) checkCommittedOrder(id raftentry.ApplyEntryID) error {
 		return codedError(raftentry.ErrorRejectedConflictV1, "apply entry index gap: got %d after %d", id.Index, last.Index)
 	}
 	if id.Index == last.Index {
+		if id.Term != last.Term {
+			return codedError(raftentry.ErrorRejectedConflictV1, "apply entry term %d conflicts with last applied term %d at index %d", id.Term, last.Term, id.Index)
+		}
 		return nil
 	}
 	if id.Term < last.Term {
@@ -252,6 +271,19 @@ func commandDigest(src []byte, opts raftentry.DecodeOptions) raftentry.CommandDi
 		return digest
 	}
 	return raftentry.CommandDigestV1ForBytes(bytes.Clone(src), opts)
+}
+
+func cloneRequestMetadataV1(meta raftentry.RequestMetadataV1) raftentry.RequestMetadataV1 {
+	meta.TraceContext = bytes.Clone(meta.TraceContext)
+	return meta
+}
+
+func cloneExpectedTargetV1(target *raftentry.TargetIdentityV1) *raftentry.TargetIdentityV1 {
+	if target == nil {
+		return nil
+	}
+	cloned := target.Clone()
+	return &cloned
 }
 
 func codedError(code raftentry.DeterministicErrorCodeV1, format string, args ...any) error {

--- a/TreeDB/internal/raftfsm/fsm.go
+++ b/TreeDB/internal/raftfsm/fsm.go
@@ -118,7 +118,7 @@ func Open(opts Options) (*FSM, error) {
 		_ = progress.Close()
 		return nil, err
 	}
-	if err := validateProgressCoverage(opts.DB, progress); err != nil {
+	if err := validateProgressCoverage(opts.DB, progress, results); err != nil {
 		_ = errors.Join(progress.Close(), results.Close())
 		return nil, err
 	}
@@ -204,10 +204,15 @@ func (f *FSM) ApplyCommittedEntryV1(entry CommittedEntryV1) (raftentry.ApplyResu
 		code, _ := ErrorCodeOf(err)
 		return reject(commandDigest(entry.Bytes, f.decodeOptions(entry, id)), code, err)
 	}
+	digest := commandDigest(entry.Bytes, f.decodeOptions(entry, id))
+	if err := f.requireStoredResultForLocalCoverageGap(id, digest); err != nil {
+		code, _ := ErrorCodeOf(err)
+		return reject(digest, code, err)
+	}
 	meta, err := f.applyMetadata(entry, id)
 	if err != nil {
 		code, _ := ErrorCodeOf(err)
-		return reject(commandDigest(entry.Bytes, f.decodeOptions(entry, id)), code, err)
+		return reject(digest, code, err)
 	}
 	return raftapply.ApplyCommittedEntryV1(f.db, entry.Bytes, meta, raftapply.Options{
 		DecodeLimits:  f.decodeLimits,
@@ -286,9 +291,6 @@ func (f *FSM) lastAppliedProgressRecord() (raftapply.ApplyProgressRecordV1, bool
 	}
 	record, ok := f.progress.LastAppliedRecord()
 	if !ok {
-		if err := validateMissingApplyProgressCoverage(f.db); err != nil {
-			return raftapply.ApplyProgressRecordV1{}, false, err
-		}
 		return raftapply.ApplyProgressRecordV1{}, false, nil
 	}
 	if err := validateApplyProgressCoverage(f.db, record); err != nil {
@@ -297,38 +299,88 @@ func (f *FSM) lastAppliedProgressRecord() (raftapply.ApplyProgressRecordV1, bool
 	return record, true, nil
 }
 
-func validateProgressCoverage(db *backenddb.DB, progress *raftapply.DurableApplyProgressStore) error {
+func validateProgressCoverage(db *backenddb.DB, progress *raftapply.DurableApplyProgressStore, results *raftapply.DurableApplyResultStore) error {
 	if progress == nil {
 		return nil
 	}
+	localLSN, err := localAppliedCommandLSN(db)
+	if err != nil {
+		return err
+	}
 	record, ok := progress.LastAppliedRecord()
 	if !ok {
-		return validateMissingApplyProgressCoverage(db)
+		if localLSN != 0 && (results == nil || results.Len() == 0) {
+			return codedError(raftentry.ErrorUnsafeDurabilityModeV1, "missing apply progress metadata for local AppliedCommandLSN coverage %d without durable result metadata", localLSN)
+		}
+		return nil
 	}
-	return validateApplyProgressCoverage(db, record)
-}
-
-func validateMissingApplyProgressCoverage(db *backenddb.DB) error {
-	if db == nil {
-		return codedError(raftentry.ErrorUnsafeDurabilityModeV1, "nil FSM DB")
+	if record.AppliedCommandLSN > localLSN {
+		return codedError(raftentry.ErrorUnsafeDurabilityModeV1, "apply progress metadata AppliedCommandLSN %d outruns local coverage %d", record.AppliedCommandLSN, localLSN)
 	}
-	localLSN := db.State().AppliedCommandLSN
-	if localLSN != 0 {
-		return codedError(raftentry.ErrorUnsafeDurabilityModeV1, "missing apply progress metadata for local AppliedCommandLSN coverage %d", localLSN)
+	if record.AppliedCommandLSN < localLSN && (results == nil || results.Len() <= progress.Len()) {
+		return codedError(raftentry.ErrorUnsafeDurabilityModeV1, "local AppliedCommandLSN coverage %d outruns apply progress metadata %d without durable result metadata beyond progress", localLSN, record.AppliedCommandLSN)
 	}
 	return nil
 }
 
-func validateApplyProgressCoverage(db *backenddb.DB, record raftapply.ApplyProgressRecordV1) error {
+func localAppliedCommandLSN(db *backenddb.DB) (uint64, error) {
 	if db == nil {
-		return codedError(raftentry.ErrorUnsafeDurabilityModeV1, "nil FSM DB")
+		return 0, codedError(raftentry.ErrorUnsafeDurabilityModeV1, "nil FSM DB")
 	}
-	localLSN := db.State().AppliedCommandLSN
+	return db.State().AppliedCommandLSN, nil
+}
+
+func validateApplyProgressCoverage(db *backenddb.DB, record raftapply.ApplyProgressRecordV1) error {
+	localLSN, err := localAppliedCommandLSN(db)
+	if err != nil {
+		return err
+	}
 	if record.AppliedCommandLSN > localLSN {
 		return codedError(raftentry.ErrorUnsafeDurabilityModeV1, "apply progress metadata AppliedCommandLSN %d outruns local coverage %d", record.AppliedCommandLSN, localLSN)
 	}
-	if record.AppliedCommandLSN < localLSN {
-		return codedError(raftentry.ErrorUnsafeDurabilityModeV1, "local AppliedCommandLSN coverage %d outruns apply progress metadata %d", localLSN, record.AppliedCommandLSN)
+	return nil
+}
+
+func (f *FSM) requireStoredResultForLocalCoverageGap(id raftentry.ApplyEntryID, digest raftentry.CommandDigestV1) error {
+	if f == nil || f.db == nil || f.progress == nil || f.results == nil {
+		return codedError(raftentry.ErrorUnsafeDurabilityModeV1, "FSM is not open")
+	}
+	localLSN, err := localAppliedCommandLSN(f.db)
+	if err != nil {
+		return err
+	}
+	record, ok := f.progress.LastAppliedRecord()
+	if !ok {
+		if localLSN == 0 {
+			return nil
+		}
+		if id.Index != 1 {
+			return nil
+		}
+		return f.requireStoredResultCoveredByLocalLSN(id, digest, localLSN, 0)
+	}
+	if err := validateApplyProgressCoverage(f.db, record); err != nil {
+		return err
+	}
+	if localLSN <= record.AppliedCommandLSN || id.Index <= record.EntryID.Index {
+		return nil
+	}
+	return f.requireStoredResultCoveredByLocalLSN(id, digest, localLSN, record.AppliedCommandLSN)
+}
+
+func (f *FSM) requireStoredResultCoveredByLocalLSN(id raftentry.ApplyEntryID, digest raftentry.CommandDigestV1, localLSN, progressLSN uint64) error {
+	record, ok, err := f.results.LookupApplyResult(id)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return codedError(raftentry.ErrorUnsafeDurabilityModeV1, "local AppliedCommandLSN coverage %d outruns apply progress metadata %d without durable result for apply entry %d/%d", localLSN, progressLSN, id.Term, id.Index)
+	}
+	if record.CommandDigest != digest {
+		return codedError(raftentry.ErrorRejectedConflictV1, "durable result digest conflicts with apply entry %d/%d", id.Term, id.Index)
+	}
+	if record.AppliedCommandLSN > localLSN {
+		return codedError(raftentry.ErrorUnsafeDurabilityModeV1, "durable result AppliedCommandLSN %d outruns local coverage %d for apply entry %d/%d", record.AppliedCommandLSN, localLSN, id.Term, id.Index)
 	}
 	return nil
 }

--- a/TreeDB/internal/raftfsm/fsm.go
+++ b/TreeDB/internal/raftfsm/fsm.go
@@ -118,6 +118,10 @@ func Open(opts Options) (*FSM, error) {
 		_ = progress.Close()
 		return nil, err
 	}
+	if err := validateProgressCoverage(opts.DB, progress); err != nil {
+		_ = errors.Join(progress.Close(), results.Close())
+		return nil, err
+	}
 	return &FSM{
 		db:           opts.DB,
 		metadataDir:  metadataDir,
@@ -151,7 +155,11 @@ func (f *FSM) LastApplied() (raftentry.ApplyEntryID, bool) {
 	if f == nil || f.progress == nil {
 		return raftentry.ApplyEntryID{}, false
 	}
-	return f.progress.LastApplied()
+	record, ok, err := f.lastAppliedProgressRecord()
+	if err != nil || !ok {
+		return raftentry.ApplyEntryID{}, false
+	}
+	return record.EntryID, true
 }
 
 func (f *FSM) LogicalDigestV1(opts raftapply.LogicalDigestOptionsV1) (raftapply.LogicalDigestV1, error) {
@@ -243,13 +251,17 @@ func (f *FSM) decodeOptions(entry CommittedEntryV1, id raftentry.ApplyEntryID) r
 }
 
 func (f *FSM) checkCommittedOrder(id raftentry.ApplyEntryID) error {
-	last, ok := f.progress.LastApplied()
+	record, ok, err := f.lastAppliedProgressRecord()
+	if err != nil {
+		return err
+	}
 	if !ok {
 		if id.Index != 1 {
 			return codedError(raftentry.ErrorRejectedConflictV1, "apply entry starts at index %d; want 1", id.Index)
 		}
 		return nil
 	}
+	last := record.EntryID
 	if id.Index < last.Index {
 		return codedError(raftentry.ErrorRejectedConflictV1, "apply entry index %d is below last applied %d", id.Index, last.Index)
 	}
@@ -264,6 +276,42 @@ func (f *FSM) checkCommittedOrder(id raftentry.ApplyEntryID) error {
 	}
 	if id.Term < last.Term {
 		return codedError(raftentry.ErrorRejectedConflictV1, "apply entry term %d is below last applied term %d", id.Term, last.Term)
+	}
+	return nil
+}
+
+func (f *FSM) lastAppliedProgressRecord() (raftapply.ApplyProgressRecordV1, bool, error) {
+	if f == nil || f.db == nil || f.progress == nil {
+		return raftapply.ApplyProgressRecordV1{}, false, codedError(raftentry.ErrorUnsafeDurabilityModeV1, "FSM is not open")
+	}
+	record, ok := f.progress.LastAppliedRecord()
+	if !ok {
+		return raftapply.ApplyProgressRecordV1{}, false, nil
+	}
+	if err := validateApplyProgressCoverage(f.db, record); err != nil {
+		return raftapply.ApplyProgressRecordV1{}, false, err
+	}
+	return record, true, nil
+}
+
+func validateProgressCoverage(db *backenddb.DB, progress *raftapply.DurableApplyProgressStore) error {
+	if progress == nil {
+		return nil
+	}
+	record, ok := progress.LastAppliedRecord()
+	if !ok {
+		return nil
+	}
+	return validateApplyProgressCoverage(db, record)
+}
+
+func validateApplyProgressCoverage(db *backenddb.DB, record raftapply.ApplyProgressRecordV1) error {
+	if db == nil {
+		return codedError(raftentry.ErrorUnsafeDurabilityModeV1, "nil FSM DB")
+	}
+	localLSN := db.State().AppliedCommandLSN
+	if record.AppliedCommandLSN > localLSN {
+		return codedError(raftentry.ErrorUnsafeDurabilityModeV1, "apply progress metadata AppliedCommandLSN %d outruns local coverage %d", record.AppliedCommandLSN, localLSN)
 	}
 	return nil
 }

--- a/TreeDB/internal/raftfsm/fsm.go
+++ b/TreeDB/internal/raftfsm/fsm.go
@@ -137,7 +137,14 @@ func (f *FSM) Close() error {
 		return nil
 	}
 	f.closed = true
-	return errors.Join(f.progress.Close(), f.results.Close())
+	var errs []error
+	if f.progress != nil {
+		errs = append(errs, f.progress.Close())
+	}
+	if f.results != nil {
+		errs = append(errs, f.results.Close())
+	}
+	return errors.Join(errs...)
 }
 
 func (f *FSM) LastApplied() (raftentry.ApplyEntryID, bool) {
@@ -169,8 +176,14 @@ func (f *FSM) ApplyCommittedEntriesV1(entries []CommittedEntryV1) ([]raftentry.A
 }
 
 func (f *FSM) ApplyCommittedEntryV1(entry CommittedEntryV1) (raftentry.ApplyResultV1, error) {
-	if f == nil || f.closed {
+	if f == nil {
+		return reject(raftentry.CommandDigestV1{}, raftentry.ErrorUnsafeDurabilityModeV1, fmt.Errorf("FSM is not open"))
+	}
+	if f.closed {
 		return reject(raftentry.CommandDigestV1{}, raftentry.ErrorUnsafeDurabilityModeV1, fmt.Errorf("FSM is closed"))
+	}
+	if f.db == nil || f.progress == nil || f.results == nil {
+		return reject(raftentry.CommandDigestV1{}, raftentry.ErrorUnsafeDurabilityModeV1, fmt.Errorf("FSM is not open"))
 	}
 	if entry.Type != EntryTypeCommandEntryV1 {
 		return reject(raftentry.CommandDigestV1{}, raftentry.ErrorUnsupportedVersionV1, fmt.Errorf("unsupported committed entry type %q", entry.Type))

--- a/TreeDB/internal/raftfsm/fsm_test.go
+++ b/TreeDB/internal/raftfsm/fsm_test.go
@@ -85,6 +85,59 @@ func TestSingleGroupApplyLoopCloseReopenDurableProgressResult(t *testing.T) {
 	assertLastApplied(t, reopenedFSM, raftentry.ApplyEntryID{Term: 2, Index: 2})
 }
 
+func TestSingleGroupApplyLoopRejectsProgressAheadOfLocalCoverage(t *testing.T) {
+	root := t.TempDir()
+	dbDir := filepath.Join(root, "db")
+
+	db := openFSMTestDB(t, dbDir)
+	fsm := openFSMForTest(t, db, dbDir)
+	beforeLSN := db.State().AppliedCommandLSN
+	staleID := raftentry.ApplyEntryID{Term: 1, Index: 1}
+	if err := fsm.progress.RecordApplied(raftapply.ApplyProgressRecordV1{
+		EntryID:           staleID,
+		AppliedCommandLSN: beforeLSN + 1,
+	}); err != nil {
+		t.Fatalf("RecordApplied stale progress: %v", err)
+	}
+
+	if got, ok := fsm.LastApplied(); ok {
+		t.Fatalf("LastApplied with uncovered progress=(%+v,%t), want unset", got, ok)
+	}
+
+	raw := deterministicCreateCollectionEntry(t, "users", "fsm:create:users:uncovered-progress")
+	result, err := fsm.ApplyCommittedEntryV1(committedCommand(1, 2, raw))
+	assertRejected(t, result, err, raftentry.ApplyStatusDeterministicGuardFailure, raftentry.ErrorUnsafeDurabilityModeV1)
+	if got := db.State().AppliedCommandLSN; got != beforeLSN {
+		t.Fatalf("AppliedCommandLSN after uncovered progress=%d, want unchanged %d", got, beforeLSN)
+	}
+	if _, openErr := collections.NewCollectionManager(db).OpenCollection("users"); !errors.Is(openErr, collections.ErrCollectionNotFound) {
+		t.Fatalf("OpenCollection users after uncovered progress err=%v, want ErrCollectionNotFound", openErr)
+	}
+	if err := fsm.Close(); err != nil {
+		t.Fatalf("Close FSM: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("Close DB: %v", err)
+	}
+
+	reopenedDB := openFSMTestDB(t, dbDir)
+	defer func() { _ = reopenedDB.Close() }()
+	reopenedFSM, openErr := Open(Options{
+		DB:      reopenedDB,
+		Cluster: validFSMClusterConfig(dbDir),
+		StoreOptions: raftapply.DurableApplyStoreOptions{
+			DisableSync: true,
+		},
+	})
+	if openErr == nil {
+		_ = reopenedFSM.Close()
+		t.Fatal("Open with uncovered progress succeeded, want unsafe durability error")
+	}
+	if code, ok := ErrorCodeOf(openErr); !ok || code != raftentry.ErrorUnsafeDurabilityModeV1 {
+		t.Fatalf("ErrorCodeOf(Open uncovered progress)=(%s,%t), want %s err=%v", code, ok, raftentry.ErrorUnsafeDurabilityModeV1, openErr)
+	}
+}
+
 func TestSingleGroupApplyLoopFailsClosedOnOrderingAndUnsupportedEntries(t *testing.T) {
 	root := t.TempDir()
 	dbDir := filepath.Join(root, "db")

--- a/TreeDB/internal/raftfsm/fsm_test.go
+++ b/TreeDB/internal/raftfsm/fsm_test.go
@@ -187,6 +187,75 @@ func TestSingleGroupApplyLoopRejectsMissingProgressWithLocalCoverage(t *testing.
 	}
 }
 
+func TestSingleGroupApplyLoopRejectsProgressBehindLocalCoverage(t *testing.T) {
+	root := t.TempDir()
+	dbDir := filepath.Join(root, "db")
+
+	db := openFSMTestDB(t, dbDir)
+	fsm := openFSMForTest(t, db, dbDir)
+	users := deterministicCreateCollectionEntry(t, "users", "fsm:create:users:progress-behind")
+	first, err := fsm.ApplyCommittedEntryV1(committedCommand(1, 1, users))
+	if err != nil {
+		t.Fatalf("ApplyCommittedEntryV1 first: %v result=%+v", err, first)
+	}
+	assertApplied(t, first, raftentry.ApplyStatusApplied, 1)
+	firstProgress, ok := fsm.progress.LastAppliedRecord()
+	if !ok {
+		t.Fatal("LastAppliedRecord after first apply missing")
+	}
+
+	orders := deterministicCreateCollectionEntry(t, "orders", "fsm:create:orders:progress-behind")
+	second, err := fsm.ApplyCommittedEntryV1(committedCommand(1, 2, orders))
+	if err != nil {
+		t.Fatalf("ApplyCommittedEntryV1 second: %v result=%+v", err, second)
+	}
+	assertApplied(t, second, raftentry.ApplyStatusApplied, 1)
+	coveredLSN := db.State().AppliedCommandLSN
+	if coveredLSN <= firstProgress.AppliedCommandLSN {
+		t.Fatalf("AppliedCommandLSN after second apply=%d, want greater than first progress %d", coveredLSN, firstProgress.AppliedCommandLSN)
+	}
+	progressPath := raftapply.DurableApplyProgressStorePath(fsm.metadataDir)
+	if err := fsm.Close(); err != nil {
+		t.Fatalf("Close FSM: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("Close DB: %v", err)
+	}
+	if err := os.Remove(progressPath); err != nil {
+		t.Fatalf("Remove progress metadata: %v", err)
+	}
+	progress, err := raftapply.OpenDurableApplyProgressStoreFile(progressPath, raftapply.DurableApplyStoreOptions{DisableSync: true})
+	if err != nil {
+		t.Fatalf("Open rolled-back progress store: %v", err)
+	}
+	if err := progress.RecordApplied(firstProgress); err != nil {
+		t.Fatalf("Record rolled-back progress: %v", err)
+	}
+	if err := progress.Close(); err != nil {
+		t.Fatalf("Close rolled-back progress store: %v", err)
+	}
+
+	reopenedDB := openFSMTestDB(t, dbDir)
+	defer func() { _ = reopenedDB.Close() }()
+	if got := reopenedDB.State().AppliedCommandLSN; got != coveredLSN {
+		t.Fatalf("reopened AppliedCommandLSN=%d, want %d", got, coveredLSN)
+	}
+	reopenedFSM, openErr := Open(Options{
+		DB:      reopenedDB,
+		Cluster: validFSMClusterConfig(dbDir),
+		StoreOptions: raftapply.DurableApplyStoreOptions{
+			DisableSync: true,
+		},
+	})
+	if openErr == nil {
+		_ = reopenedFSM.Close()
+		t.Fatal("Open with progress behind local coverage succeeded, want unsafe durability error")
+	}
+	if code, ok := ErrorCodeOf(openErr); !ok || code != raftentry.ErrorUnsafeDurabilityModeV1 {
+		t.Fatalf("ErrorCodeOf(Open progress behind local coverage)=(%s,%t), want %s err=%v", code, ok, raftentry.ErrorUnsafeDurabilityModeV1, openErr)
+	}
+}
+
 func TestSingleGroupApplyLoopFailsClosedOnOrderingAndUnsupportedEntries(t *testing.T) {
 	root := t.TempDir()
 	dbDir := filepath.Join(root, "db")

--- a/TreeDB/internal/raftfsm/fsm_test.go
+++ b/TreeDB/internal/raftfsm/fsm_test.go
@@ -139,7 +139,7 @@ func TestSingleGroupApplyLoopRejectsProgressAheadOfLocalCoverage(t *testing.T) {
 	}
 }
 
-func TestSingleGroupApplyLoopRejectsMissingProgressWithLocalCoverage(t *testing.T) {
+func TestSingleGroupApplyLoopRepairsMissingProgressWithStoredResult(t *testing.T) {
 	root := t.TempDir()
 	dbDir := filepath.Join(root, "db")
 
@@ -179,15 +179,24 @@ func TestSingleGroupApplyLoopRejectsMissingProgressWithLocalCoverage(t *testing.
 		},
 	})
 	if openErr == nil {
-		_ = reopenedFSM.Close()
-		t.Fatal("Open with missing progress and local coverage succeeded, want unsafe durability error")
+		defer func() { _ = reopenedFSM.Close() }()
+	} else {
+		t.Fatalf("Open with missing progress and stored result: %v", openErr)
 	}
-	if code, ok := ErrorCodeOf(openErr); !ok || code != raftentry.ErrorUnsafeDurabilityModeV1 {
-		t.Fatalf("ErrorCodeOf(Open missing progress)=(%s,%t), want %s err=%v", code, ok, raftentry.ErrorUnsafeDurabilityModeV1, openErr)
+	if got, ok := reopenedFSM.LastApplied(); ok {
+		t.Fatalf("LastApplied with missing progress=(%+v,%t), want unset before replay repair", got, ok)
 	}
+	replayed, err := reopenedFSM.ApplyCommittedEntryV1(committedCommand(1, 1, raw))
+	if err != nil {
+		t.Fatalf("ApplyCommittedEntryV1 result-backed replay repair: %v result=%+v", err, replayed)
+	}
+	if replayed != result {
+		t.Fatalf("replayed result=%+v, want stored %+v", replayed, result)
+	}
+	assertLastApplied(t, reopenedFSM, raftentry.ApplyEntryID{Term: 1, Index: 1})
 }
 
-func TestSingleGroupApplyLoopRejectsProgressBehindLocalCoverage(t *testing.T) {
+func TestSingleGroupApplyLoopRepairsProgressBehindLocalCoverageWithStoredResult(t *testing.T) {
 	root := t.TempDir()
 	dbDir := filepath.Join(root, "db")
 
@@ -248,11 +257,105 @@ func TestSingleGroupApplyLoopRejectsProgressBehindLocalCoverage(t *testing.T) {
 		},
 	})
 	if openErr == nil {
+		defer func() { _ = reopenedFSM.Close() }()
+	} else {
+		t.Fatalf("Open with progress behind local coverage and stored result: %v", openErr)
+	}
+	assertLastApplied(t, reopenedFSM, firstProgress.EntryID)
+	replayed, err := reopenedFSM.ApplyCommittedEntryV1(committedCommand(1, 2, orders))
+	if err != nil {
+		t.Fatalf("ApplyCommittedEntryV1 result-backed progress repair: %v result=%+v", err, replayed)
+	}
+	if replayed != second {
+		t.Fatalf("replayed second result=%+v, want stored %+v", replayed, second)
+	}
+	assertLastApplied(t, reopenedFSM, raftentry.ApplyEntryID{Term: 1, Index: 2})
+}
+
+func TestSingleGroupApplyLoopRejectsProgressBehindLocalCoverageWithoutStoredResult(t *testing.T) {
+	root := t.TempDir()
+	dbDir := filepath.Join(root, "db")
+
+	db := openFSMTestDB(t, dbDir)
+	fsm := openFSMForTest(t, db, dbDir)
+	users := deterministicCreateCollectionEntry(t, "users", "fsm:create:users:progress-behind-missing-result")
+	first, err := fsm.ApplyCommittedEntryV1(committedCommand(1, 1, users))
+	if err != nil {
+		t.Fatalf("ApplyCommittedEntryV1 first: %v result=%+v", err, first)
+	}
+	assertApplied(t, first, raftentry.ApplyStatusApplied, 1)
+	firstProgress, ok := fsm.progress.LastAppliedRecord()
+	if !ok {
+		t.Fatal("LastAppliedRecord after first apply missing")
+	}
+	firstResult, ok, err := fsm.results.LookupApplyResult(firstProgress.EntryID)
+	if err != nil || !ok {
+		t.Fatalf("LookupApplyResult first=(%+v,%t,%v), want stored result", firstResult, ok, err)
+	}
+
+	orders := deterministicCreateCollectionEntry(t, "orders", "fsm:create:orders:progress-behind-missing-result")
+	second, err := fsm.ApplyCommittedEntryV1(committedCommand(1, 2, orders))
+	if err != nil {
+		t.Fatalf("ApplyCommittedEntryV1 second: %v result=%+v", err, second)
+	}
+	assertApplied(t, second, raftentry.ApplyStatusApplied, 1)
+	coveredLSN := db.State().AppliedCommandLSN
+	if coveredLSN <= firstProgress.AppliedCommandLSN {
+		t.Fatalf("AppliedCommandLSN after second apply=%d, want greater than first progress %d", coveredLSN, firstProgress.AppliedCommandLSN)
+	}
+	progressPath := raftapply.DurableApplyProgressStorePath(fsm.metadataDir)
+	resultPath := raftapply.DurableApplyResultStorePath(fsm.metadataDir)
+	if err := fsm.Close(); err != nil {
+		t.Fatalf("Close FSM: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("Close DB: %v", err)
+	}
+	if err := os.Remove(progressPath); err != nil {
+		t.Fatalf("Remove progress metadata: %v", err)
+	}
+	progress, err := raftapply.OpenDurableApplyProgressStoreFile(progressPath, raftapply.DurableApplyStoreOptions{DisableSync: true})
+	if err != nil {
+		t.Fatalf("Open rolled-back progress store: %v", err)
+	}
+	if err := progress.RecordApplied(firstProgress); err != nil {
+		t.Fatalf("Record rolled-back progress: %v", err)
+	}
+	if err := progress.Close(); err != nil {
+		t.Fatalf("Close rolled-back progress store: %v", err)
+	}
+	if err := os.Remove(resultPath); err != nil {
+		t.Fatalf("Remove result metadata: %v", err)
+	}
+	results, err := raftapply.OpenDurableApplyResultStoreFile(resultPath, raftapply.DurableApplyStoreOptions{DisableSync: true})
+	if err != nil {
+		t.Fatalf("Open rolled-back result store: %v", err)
+	}
+	if err := results.RecordApplyResult(firstResult); err != nil {
+		t.Fatalf("Record rolled-back result: %v", err)
+	}
+	if err := results.Close(); err != nil {
+		t.Fatalf("Close rolled-back result store: %v", err)
+	}
+
+	reopenedDB := openFSMTestDB(t, dbDir)
+	defer func() { _ = reopenedDB.Close() }()
+	if got := reopenedDB.State().AppliedCommandLSN; got != coveredLSN {
+		t.Fatalf("reopened AppliedCommandLSN=%d, want %d", got, coveredLSN)
+	}
+	reopenedFSM, openErr := Open(Options{
+		DB:      reopenedDB,
+		Cluster: validFSMClusterConfig(dbDir),
+		StoreOptions: raftapply.DurableApplyStoreOptions{
+			DisableSync: true,
+		},
+	})
+	if openErr == nil {
 		_ = reopenedFSM.Close()
-		t.Fatal("Open with progress behind local coverage succeeded, want unsafe durability error")
+		t.Fatal("Open with progress behind local coverage and missing result succeeded, want unsafe durability error")
 	}
 	if code, ok := ErrorCodeOf(openErr); !ok || code != raftentry.ErrorUnsafeDurabilityModeV1 {
-		t.Fatalf("ErrorCodeOf(Open progress behind local coverage)=(%s,%t), want %s err=%v", code, ok, raftentry.ErrorUnsafeDurabilityModeV1, openErr)
+		t.Fatalf("ErrorCodeOf(Open progress behind missing result)=(%s,%t), want %s err=%v", code, ok, raftentry.ErrorUnsafeDurabilityModeV1, openErr)
 	}
 }
 

--- a/TreeDB/internal/raftfsm/fsm_test.go
+++ b/TreeDB/internal/raftfsm/fsm_test.go
@@ -104,20 +104,21 @@ func TestSingleGroupApplyLoopFailsClosedOnOrderingAndUnsupportedEntries(t *testi
 	orders := deterministicCreateCollectionEntry(t, "orders", "fsm:create:orders:gap")
 	gap, err := fsm.ApplyCommittedEntryV1(committedCommand(3, 3, orders))
 	assertRejected(t, gap, err, raftentry.ApplyStatusRejectedConflict, raftentry.ErrorRejectedConflictV1)
-	assertNoApplyProgress(t, db, beforeLSN, fsm, raftentry.ApplyEntryID{Term: 3, Index: 1})
+	assertNoApplyProgress(t, db, beforeLSN, fsm, raftentry.ApplyEntryID{Term: 3, Index: 1}, "orders")
 
 	lowerTerm, err := fsm.ApplyCommittedEntryV1(committedCommand(2, 2, orders))
 	assertRejected(t, lowerTerm, err, raftentry.ApplyStatusRejectedConflict, raftentry.ErrorRejectedConflictV1)
-	assertNoApplyProgress(t, db, beforeLSN, fsm, raftentry.ApplyEntryID{Term: 3, Index: 1})
+	assertNoApplyProgress(t, db, beforeLSN, fsm, raftentry.ApplyEntryID{Term: 3, Index: 1}, "orders")
 
 	differentSameIndex := deterministicCreateCollectionEntry(t, "admins", "fsm:create:admins:duplicate-index")
 	duplicateConflict, err := fsm.ApplyCommittedEntryV1(committedCommand(3, 1, differentSameIndex))
 	assertRejected(t, duplicateConflict, err, raftentry.ApplyStatusRejectedConflict, raftentry.ErrorRejectedConflictV1)
-	assertNoApplyProgress(t, db, beforeLSN, fsm, raftentry.ApplyEntryID{Term: 3, Index: 1})
+	assertNoApplyProgress(t, db, beforeLSN, fsm, raftentry.ApplyEntryID{Term: 3, Index: 1}, "admins")
 
-	sameIndexDifferentTerm, err := fsm.ApplyCommittedEntryV1(committedCommand(4, 1, users))
+	audits := deterministicCreateCollectionEntry(t, "audits", "fsm:create:audits:duplicate-term")
+	sameIndexDifferentTerm, err := fsm.ApplyCommittedEntryV1(committedCommand(4, 1, audits))
 	assertRejected(t, sameIndexDifferentTerm, err, raftentry.ApplyStatusRejectedConflict, raftentry.ErrorRejectedConflictV1)
-	assertNoApplyProgress(t, db, beforeLSN, fsm, raftentry.ApplyEntryID{Term: 3, Index: 1})
+	assertNoApplyProgress(t, db, beforeLSN, fsm, raftentry.ApplyEntryID{Term: 3, Index: 1}, "audits")
 
 	profiles := deterministicCreateCollectionEntry(t, "profiles", "fsm:create:profiles:advance")
 	advanced, err := fsm.ApplyCommittedEntryV1(committedCommand(3, 2, profiles))
@@ -129,11 +130,11 @@ func TestSingleGroupApplyLoopFailsClosedOnOrderingAndUnsupportedEntries(t *testi
 
 	lowerIndex, err := fsm.ApplyCommittedEntryV1(committedCommand(3, 1, orders))
 	assertRejected(t, lowerIndex, err, raftentry.ApplyStatusRejectedConflict, raftentry.ErrorRejectedConflictV1)
-	assertNoApplyProgress(t, db, advancedLSN, fsm, raftentry.ApplyEntryID{Term: 3, Index: 2})
+	assertNoApplyProgress(t, db, advancedLSN, fsm, raftentry.ApplyEntryID{Term: 3, Index: 2}, "orders")
 
 	unsupported, err := fsm.ApplyCommittedEntryV1(CommittedEntryV1{Type: EntryTypeV1("snapshot-v1"), Term: 3, Index: 2, Bytes: orders})
 	assertRejected(t, unsupported, err, raftentry.ApplyStatusRejectedUnsupported, raftentry.ErrorUnsupportedVersionV1)
-	assertNoApplyProgress(t, db, advancedLSN, fsm, raftentry.ApplyEntryID{Term: 3, Index: 2})
+	assertNoApplyProgress(t, db, advancedLSN, fsm, raftentry.ApplyEntryID{Term: 3, Index: 2}, "orders")
 }
 
 func TestSingleGroupApplyLoopLogicalDigestConvergesAcrossDBs(t *testing.T) {
@@ -253,6 +254,7 @@ func TestSingleGroupApplyLoopRejectsExpectedTargetMismatch(t *testing.T) {
 	defer func() { _ = db.Close() }()
 	fsm := openFSMForTest(t, db, dbDir)
 	defer func() { _ = fsm.Close() }()
+	beforeLSN := db.State().AppliedCommandLSN
 
 	raw := deterministicCreateCollectionEntry(t, "users", "fsm:create:users:target-mismatch")
 	expected := decodedTargetForTest(t, raw)
@@ -269,9 +271,31 @@ func TestSingleGroupApplyLoopRejectsExpectedTargetMismatch(t *testing.T) {
 		ExpectedTarget:           &expected,
 	})
 	assertRejected(t, result, err, raftentry.ApplyStatusDeterministicGuardFailure, raftentry.ErrorTargetMismatchV1)
+	if got := db.State().AppliedCommandLSN; got != beforeLSN {
+		t.Fatalf("AppliedCommandLSN after target mismatch=%d, want unchanged %d", got, beforeLSN)
+	}
+	if got, ok := fsm.LastApplied(); ok {
+		t.Fatalf("LastApplied after target mismatch=(%+v,%t), want unset", got, ok)
+	}
+	if record, ok, lookupErr := fsm.results.LookupApplyResult(raftentry.ApplyEntryID{Term: 1, Index: 1}); lookupErr != nil || ok {
+		t.Fatalf("LookupApplyResult after target mismatch=(%+v,%t,%v), want miss", record, ok, lookupErr)
+	}
 	if _, openErr := collections.NewCollectionManager(db).OpenCollection("users"); !errors.Is(openErr, collections.ErrCollectionNotFound) {
 		t.Fatalf("OpenCollection users after target mismatch err=%v, want ErrCollectionNotFound", openErr)
 	}
+}
+
+func TestSingleGroupApplyLoopZeroValueFSMFailsClosed(t *testing.T) {
+	var fsm FSM
+	if err := fsm.Close(); err != nil {
+		t.Fatalf("zero-value Close: %v", err)
+	}
+	result, err := fsm.ApplyCommittedEntryV1(CommittedEntryV1{
+		Type:  EntryTypeCommandEntryV1,
+		Term:  1,
+		Index: 1,
+	})
+	assertRejected(t, result, err, raftentry.ApplyStatusDeterministicGuardFailure, raftentry.ErrorUnsafeDurabilityModeV1)
 }
 
 func TestSingleGroupApplyLoopMixedMutationEntriesContiguous(t *testing.T) {
@@ -543,15 +567,15 @@ func assertLastApplied(t testing.TB, fsm *FSM, want raftentry.ApplyEntryID) {
 	}
 }
 
-func assertNoApplyProgress(t *testing.T, db *backenddb.DB, wantLSN uint64, fsm *FSM, wantLast raftentry.ApplyEntryID) {
+func assertNoApplyProgress(t *testing.T, db *backenddb.DB, wantLSN uint64, fsm *FSM, wantLast raftentry.ApplyEntryID, absentCollection string) {
 	t.Helper()
 	if got := db.State().AppliedCommandLSN; got != wantLSN {
 		t.Fatalf("AppliedCommandLSN=%d, want unchanged %d", got, wantLSN)
 	}
 	assertLastApplied(t, fsm, wantLast)
-	if _, err := collections.NewCollectionManager(db).OpenCollection("orders"); err == nil {
-		t.Fatal("orders collection exists after rejected apply")
+	if _, err := collections.NewCollectionManager(db).OpenCollection(absentCollection); err == nil {
+		t.Fatalf("%s collection exists after rejected apply", absentCollection)
 	} else if !errors.Is(err, collections.ErrCollectionNotFound) {
-		t.Fatalf("OpenCollection orders: %v", err)
+		t.Fatalf("OpenCollection %s: %v", absentCollection, err)
 	}
 }

--- a/TreeDB/internal/raftfsm/fsm_test.go
+++ b/TreeDB/internal/raftfsm/fsm_test.go
@@ -1,0 +1,290 @@
+package raftfsm
+
+import (
+	"encoding/binary"
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/collections"
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+	"github.com/snissn/gomap/TreeDB/internal/nativewire"
+	"github.com/snissn/gomap/TreeDB/internal/raftapply"
+	"github.com/snissn/gomap/TreeDB/internal/raftentry"
+)
+
+const testCatalogVersionStart = 7
+
+func TestSingleGroupApplyLoopCloseReopenDurableProgressResult(t *testing.T) {
+	root := t.TempDir()
+	dbDir := filepath.Join(root, "db")
+	metadataDir := filepath.Join(root, "raftapply")
+
+	db := openFSMTestDB(t, dbDir)
+	fsm := openFSMForTest(t, db, metadataDir)
+	raw := deterministicCreateCollectionEntry(t, "users", "fsm:create:users")
+
+	results, err := fsm.ApplyCommittedEntriesV1([]CommittedEntryV1{committedCommand(2, 1, raw)})
+	if err != nil {
+		t.Fatalf("ApplyCommittedEntriesV1: %v results=%+v", err, results)
+	}
+	if len(results) != 1 {
+		t.Fatalf("results=%d, want 1", len(results))
+	}
+	assertApplied(t, results[0], raftentry.ApplyStatusApplied, 1)
+	assertLastApplied(t, fsm, raftentry.ApplyEntryID{Term: 2, Index: 1})
+	if _, err := collections.NewCollectionManager(db).OpenCollection("users"); err != nil {
+		t.Fatalf("OpenCollection users: %v", err)
+	}
+	record, ok, err := fsm.results.LookupApplyResult(raftentry.ApplyEntryID{Term: 2, Index: 1})
+	if err != nil || !ok {
+		t.Fatalf("LookupApplyResult before reopen=(%+v,%t,%v), want durable record", record, ok, err)
+	}
+	if record.Result != results[0] || record.AppliedCommandLSN == 0 {
+		t.Fatalf("record before reopen=%+v lsn=%d, want result %+v with coverage", record.Result, record.AppliedCommandLSN, results[0])
+	}
+	if err := fsm.Close(); err != nil {
+		t.Fatalf("Close FSM: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("Close DB: %v", err)
+	}
+
+	reopenedDB := openFSMTestDB(t, dbDir)
+	defer func() { _ = reopenedDB.Close() }()
+	reopenedFSM := openFSMForTest(t, reopenedDB, metadataDir)
+	defer func() { _ = reopenedFSM.Close() }()
+	assertLastApplied(t, reopenedFSM, raftentry.ApplyEntryID{Term: 2, Index: 1})
+	reopenedRecord, ok, err := reopenedFSM.results.LookupApplyResult(record.EntryID)
+	if err != nil || !ok {
+		t.Fatalf("LookupApplyResult after reopen=(%+v,%t,%v), want durable record", reopenedRecord, ok, err)
+	}
+	if reopenedRecord.Result != results[0] || reopenedRecord.AppliedCommandLSN != record.AppliedCommandLSN {
+		t.Fatalf("reopened record=%+v, want result %+v lsn %d", reopenedRecord, results[0], record.AppliedCommandLSN)
+	}
+
+	replayed, err := reopenedFSM.ApplyCommittedEntryV1(committedCommand(2, 1, raw))
+	if err != nil {
+		t.Fatalf("ApplyCommittedEntryV1 replay after reopen: %v result=%+v", err, replayed)
+	}
+	if replayed != results[0] {
+		t.Fatalf("replayed result=%+v, want stored %+v", replayed, results[0])
+	}
+
+	duplicate, err := reopenedFSM.ApplyCommittedEntryV1(committedCommand(2, 2, raw))
+	if err != nil {
+		t.Fatalf("ApplyCommittedEntryV1 idempotency replay: %v result=%+v", err, duplicate)
+	}
+	if duplicate.Status != raftentry.ApplyStatusAlreadyApplied || duplicate.ResultDigest != results[0].ResultDigest {
+		t.Fatalf("duplicate result=%+v, want already-applied with original digest %s", duplicate, results[0].ResultDigest.Hex())
+	}
+	assertLastApplied(t, reopenedFSM, raftentry.ApplyEntryID{Term: 2, Index: 2})
+}
+
+func TestSingleGroupApplyLoopFailsClosedOnOrderingAndUnsupportedEntries(t *testing.T) {
+	root := t.TempDir()
+	db := openFSMTestDB(t, filepath.Join(root, "db"))
+	defer func() { _ = db.Close() }()
+	fsm := openFSMForTest(t, db, filepath.Join(root, "raftapply"))
+	defer func() { _ = fsm.Close() }()
+
+	users := deterministicCreateCollectionEntry(t, "users", "fsm:create:users:ordering")
+	seed, err := fsm.ApplyCommittedEntryV1(committedCommand(3, 1, users))
+	if err != nil {
+		t.Fatalf("seed apply: %v result=%+v", err, seed)
+	}
+	assertApplied(t, seed, raftentry.ApplyStatusApplied, 1)
+	beforeLSN := db.State().AppliedCommandLSN
+
+	orders := deterministicCreateCollectionEntry(t, "orders", "fsm:create:orders:gap")
+	gap, err := fsm.ApplyCommittedEntryV1(committedCommand(3, 3, orders))
+	assertRejected(t, gap, err, raftentry.ApplyStatusRejectedConflict, raftentry.ErrorRejectedConflictV1)
+	assertNoApplyProgress(t, db, beforeLSN, fsm, raftentry.ApplyEntryID{Term: 3, Index: 1})
+
+	lowerTerm, err := fsm.ApplyCommittedEntryV1(committedCommand(2, 2, orders))
+	assertRejected(t, lowerTerm, err, raftentry.ApplyStatusRejectedConflict, raftentry.ErrorRejectedConflictV1)
+	assertNoApplyProgress(t, db, beforeLSN, fsm, raftentry.ApplyEntryID{Term: 3, Index: 1})
+
+	differentSameIndex := deterministicCreateCollectionEntry(t, "admins", "fsm:create:admins:duplicate-index")
+	duplicateConflict, err := fsm.ApplyCommittedEntryV1(committedCommand(3, 1, differentSameIndex))
+	assertRejected(t, duplicateConflict, err, raftentry.ApplyStatusRejectedConflict, raftentry.ErrorRejectedConflictV1)
+	assertNoApplyProgress(t, db, beforeLSN, fsm, raftentry.ApplyEntryID{Term: 3, Index: 1})
+
+	profiles := deterministicCreateCollectionEntry(t, "profiles", "fsm:create:profiles:advance")
+	advanced, err := fsm.ApplyCommittedEntryV1(committedCommand(3, 2, profiles))
+	if err != nil {
+		t.Fatalf("advance apply: %v result=%+v", err, advanced)
+	}
+	assertApplied(t, advanced, raftentry.ApplyStatusApplied, 1)
+	advancedLSN := db.State().AppliedCommandLSN
+
+	lowerIndex, err := fsm.ApplyCommittedEntryV1(committedCommand(3, 1, orders))
+	assertRejected(t, lowerIndex, err, raftentry.ApplyStatusRejectedConflict, raftentry.ErrorRejectedConflictV1)
+	assertNoApplyProgress(t, db, advancedLSN, fsm, raftentry.ApplyEntryID{Term: 3, Index: 2})
+
+	unsupported, err := fsm.ApplyCommittedEntryV1(CommittedEntryV1{Type: EntryTypeV1("snapshot-v1"), Term: 3, Index: 2, Bytes: orders})
+	assertRejected(t, unsupported, err, raftentry.ApplyStatusRejectedUnsupported, raftentry.ErrorUnsupportedVersionV1)
+	assertNoApplyProgress(t, db, advancedLSN, fsm, raftentry.ApplyEntryID{Term: 3, Index: 2})
+}
+
+func TestSingleGroupApplyLoopLogicalDigestConvergesAcrossDBs(t *testing.T) {
+	raw := deterministicCreateCollectionEntry(t, "users", "fsm:create:users:converge")
+	entries := []CommittedEntryV1{committedCommand(5, 1, raw)}
+
+	root := t.TempDir()
+	dbA := openFSMTestDB(t, filepath.Join(root, "a", "db"))
+	defer func() { _ = dbA.Close() }()
+	fsmA := openFSMForTest(t, dbA, filepath.Join(root, "a", "raftapply"))
+	defer func() { _ = fsmA.Close() }()
+	if results, err := fsmA.ApplyCommittedEntriesV1(entries); err != nil {
+		t.Fatalf("ApplyCommittedEntriesV1 A: %v results=%+v", err, results)
+	}
+	digestA, err := fsmA.LogicalDigestV1(raftapply.LogicalDigestOptionsV1{})
+	if err != nil {
+		t.Fatalf("LogicalDigestV1 A: %v", err)
+	}
+
+	dbB := openFSMTestDB(t, filepath.Join(root, "b", "db"))
+	defer func() { _ = dbB.Close() }()
+	fsmB := openFSMForTest(t, dbB, filepath.Join(root, "b", "raftapply"))
+	defer func() { _ = fsmB.Close() }()
+	if results, err := fsmB.ApplyCommittedEntriesV1(entries); err != nil {
+		t.Fatalf("ApplyCommittedEntriesV1 B: %v results=%+v", err, results)
+	}
+	digestB, err := fsmB.LogicalDigestV1(raftapply.LogicalDigestOptionsV1{})
+	if err != nil {
+		t.Fatalf("LogicalDigestV1 B: %v", err)
+	}
+	if digestA != digestB {
+		t.Fatalf("logical digest mismatch A=%s B=%s", digestA.Hex(), digestB.Hex())
+	}
+}
+
+func openFSMTestDB(t testing.TB, dir string) *backenddb.DB {
+	t.Helper()
+	db, err := backenddb.Open(backenddb.Options{
+		Dir:                          dir,
+		CommandWAL:                   true,
+		CommandWALStatsScan:          true,
+		CommandWALSegmentTargetBytes: 1 << 20,
+		DisableBackgroundPrune:       true,
+	})
+	if err != nil {
+		t.Fatalf("Open DB: %v", err)
+	}
+	return db
+}
+
+func openFSMForTest(t testing.TB, db *backenddb.DB, metadataDir string) *FSM {
+	t.Helper()
+	fsm, err := Open(Options{
+		DB:          db,
+		MetadataDir: metadataDir,
+		StoreOptions: raftapply.DurableApplyStoreOptions{
+			DisableSync: true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Open FSM: %v", err)
+	}
+	return fsm
+}
+
+func committedCommand(term, index uint64, raw []byte) CommittedEntryV1 {
+	return CommittedEntryV1{
+		Type:                     EntryTypeCommandEntryV1,
+		Term:                     term,
+		Index:                    index,
+		Bytes:                    raw,
+		CurrentCatalogVersion:    testCatalogVersionStart,
+		HasCurrentCatalogVersion: true,
+	}
+}
+
+func deterministicCreateCollectionEntry(t *testing.T, collection, idempotency string) []byte {
+	t.Helper()
+	sections := []nativewire.Section{
+		{ID: nativewire.SectionCommandHeader, Bytes: nativewire.AppendCommandHeader(nil, nativewire.CommandHeader{ID: nativewire.CommandCreateCollection, Version: 1})},
+		{ID: nativewire.SectionIdempotencyKey, Bytes: []byte(idempotency)},
+		{ID: nativewire.SectionCollectionMeta, Bytes: testCreateCollectionMetaPayload(collection)},
+		{ID: nativewire.SectionExpectedCatalogVersion, Bytes: binary.AppendUvarint(nil, testCatalogVersionStart)},
+	}
+	cmd, err := nativewire.MustV1Registry().ValidateRequestSections(sections)
+	if err != nil {
+		t.Fatalf("ValidateRequestSections: %v", err)
+	}
+	entry, err := nativewire.AppendDeterministicEntry(nil, cmd)
+	if err != nil {
+		t.Fatalf("AppendDeterministicEntry: %v", err)
+	}
+	return entry
+}
+
+func testCreateCollectionMetaPayload(collection string) []byte {
+	dst := binary.AppendUvarint(nil, 1) // collection_meta version
+	dst = appendTestString(dst, collection)
+	dst = binary.AppendUvarint(dst, 0) // document_format
+	dst = binary.AppendUvarint(dst, 0) // data_root_storage_policy
+	dst = binary.AppendUvarint(dst, 0) // index_state_storage_policy
+	dst = append(dst, 0)               // allow_array_values_in_index
+	dst = append(dst, 0)               // disable_indexed_write_memtables
+	dst = append(dst, 0)               // buffered_indexed_writes
+	dst = binary.AppendVarint(dst, 0)  // buffered_indexed_write_max_documents
+	dst = binary.AppendVarint(dst, 0)  // buffered_indexed_write_max_bytes
+	dst = binary.AppendVarint(dst, 0)  // buffered_indexed_write_max_root_runs
+	dst = append(dst, 0)               // buffered_indexed_async_flush
+	dst = append(dst, 0)               // buffered_indexed_overlay_roots
+	dst = binary.AppendVarint(dst, 0)  // buffered_indexed_async_flush_max_queued_units
+	dst = binary.AppendUvarint(dst, 0) // index_count
+	return dst
+}
+
+func appendTestString(dst []byte, value string) []byte {
+	dst = binary.AppendUvarint(dst, uint64(len(value)))
+	return append(dst, value...)
+}
+
+func assertApplied(t *testing.T, result raftentry.ApplyResultV1, wantStatus raftentry.ApplyStatusV1, wantAffected int64) {
+	t.Helper()
+	if result.Status != wantStatus ||
+		result.DeterministicErrorCode != raftentry.ErrorNoneV1 ||
+		result.AffectedCount != wantAffected ||
+		result.CommandDigest == (raftentry.CommandDigestV1{}) ||
+		result.ResultDigest == (raftentry.CommandDigestV1{}) {
+		t.Fatalf("applied result=%+v, want status=%s affected=%d non-zero digests", result, wantStatus, wantAffected)
+	}
+}
+
+func assertRejected(t *testing.T, result raftentry.ApplyResultV1, err error, wantStatus raftentry.ApplyStatusV1, wantCode raftentry.DeterministicErrorCodeV1) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("got nil error for rejected result %+v", result)
+	}
+	if result.Status != wantStatus || result.DeterministicErrorCode != wantCode {
+		t.Fatalf("rejected result=%+v err=%v, want status=%s code=%s", result, err, wantStatus, wantCode)
+	}
+	if code, ok := ErrorCodeOf(err); !ok || code != wantCode {
+		t.Fatalf("ErrorCodeOf(%v)=(%s,%t), want %s", err, code, ok, wantCode)
+	}
+}
+
+func assertLastApplied(t testing.TB, fsm *FSM, want raftentry.ApplyEntryID) {
+	t.Helper()
+	got, ok := fsm.LastApplied()
+	if !ok || got != want {
+		t.Fatalf("LastApplied=(%+v,%t), want %+v", got, ok, want)
+	}
+}
+
+func assertNoApplyProgress(t *testing.T, db *backenddb.DB, wantLSN uint64, fsm *FSM, wantLast raftentry.ApplyEntryID) {
+	t.Helper()
+	if got := db.State().AppliedCommandLSN; got != wantLSN {
+		t.Fatalf("AppliedCommandLSN=%d, want unchanged %d", got, wantLSN)
+	}
+	assertLastApplied(t, fsm, wantLast)
+	if _, err := collections.NewCollectionManager(db).OpenCollection("orders"); err == nil {
+		t.Fatal("orders collection exists after rejected apply")
+	} else if !errors.Is(err, collections.ErrCollectionNotFound) {
+		t.Fatalf("OpenCollection orders: %v", err)
+	}
+}

--- a/TreeDB/internal/raftfsm/fsm_test.go
+++ b/TreeDB/internal/raftfsm/fsm_test.go
@@ -3,6 +3,7 @@ package raftfsm
 import (
 	"encoding/binary"
 	"errors"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -135,6 +136,54 @@ func TestSingleGroupApplyLoopRejectsProgressAheadOfLocalCoverage(t *testing.T) {
 	}
 	if code, ok := ErrorCodeOf(openErr); !ok || code != raftentry.ErrorUnsafeDurabilityModeV1 {
 		t.Fatalf("ErrorCodeOf(Open uncovered progress)=(%s,%t), want %s err=%v", code, ok, raftentry.ErrorUnsafeDurabilityModeV1, openErr)
+	}
+}
+
+func TestSingleGroupApplyLoopRejectsMissingProgressWithLocalCoverage(t *testing.T) {
+	root := t.TempDir()
+	dbDir := filepath.Join(root, "db")
+
+	db := openFSMTestDB(t, dbDir)
+	fsm := openFSMForTest(t, db, dbDir)
+	raw := deterministicCreateCollectionEntry(t, "users", "fsm:create:users:missing-progress")
+	result, err := fsm.ApplyCommittedEntryV1(committedCommand(1, 1, raw))
+	if err != nil {
+		t.Fatalf("ApplyCommittedEntryV1: %v result=%+v", err, result)
+	}
+	assertApplied(t, result, raftentry.ApplyStatusApplied, 1)
+	coveredLSN := db.State().AppliedCommandLSN
+	if coveredLSN == 0 {
+		t.Fatal("AppliedCommandLSN after apply is zero, want local coverage")
+	}
+	progressPath := raftapply.DurableApplyProgressStorePath(fsm.metadataDir)
+	if err := fsm.Close(); err != nil {
+		t.Fatalf("Close FSM: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("Close DB: %v", err)
+	}
+	if err := os.Remove(progressPath); err != nil {
+		t.Fatalf("Remove progress metadata: %v", err)
+	}
+
+	reopenedDB := openFSMTestDB(t, dbDir)
+	defer func() { _ = reopenedDB.Close() }()
+	if got := reopenedDB.State().AppliedCommandLSN; got != coveredLSN {
+		t.Fatalf("reopened AppliedCommandLSN=%d, want %d", got, coveredLSN)
+	}
+	reopenedFSM, openErr := Open(Options{
+		DB:      reopenedDB,
+		Cluster: validFSMClusterConfig(dbDir),
+		StoreOptions: raftapply.DurableApplyStoreOptions{
+			DisableSync: true,
+		},
+	})
+	if openErr == nil {
+		_ = reopenedFSM.Close()
+		t.Fatal("Open with missing progress and local coverage succeeded, want unsafe durability error")
+	}
+	if code, ok := ErrorCodeOf(openErr); !ok || code != raftentry.ErrorUnsafeDurabilityModeV1 {
+		t.Fatalf("ErrorCodeOf(Open missing progress)=(%s,%t), want %s err=%v", code, ok, raftentry.ErrorUnsafeDurabilityModeV1, openErr)
 	}
 }
 

--- a/TreeDB/internal/raftfsm/fsm_test.go
+++ b/TreeDB/internal/raftfsm/fsm_test.go
@@ -10,18 +10,22 @@ import (
 	backenddb "github.com/snissn/gomap/TreeDB/db"
 	"github.com/snissn/gomap/TreeDB/internal/nativewire"
 	"github.com/snissn/gomap/TreeDB/internal/raftapply"
+	"github.com/snissn/gomap/TreeDB/internal/raftcluster"
 	"github.com/snissn/gomap/TreeDB/internal/raftentry"
+	"go.mongodb.org/mongo-driver/v2/bson"
 )
 
-const testCatalogVersionStart = 7
+const (
+	testCatalogVersionStart        = 7
+	deterministicCollectionRefName = 1
+)
 
 func TestSingleGroupApplyLoopCloseReopenDurableProgressResult(t *testing.T) {
 	root := t.TempDir()
 	dbDir := filepath.Join(root, "db")
-	metadataDir := filepath.Join(root, "raftapply")
 
 	db := openFSMTestDB(t, dbDir)
-	fsm := openFSMForTest(t, db, metadataDir)
+	fsm := openFSMForTest(t, db, dbDir)
 	raw := deterministicCreateCollectionEntry(t, "users", "fsm:create:users")
 
 	results, err := fsm.ApplyCommittedEntriesV1([]CommittedEntryV1{committedCommand(2, 1, raw)})
@@ -52,7 +56,7 @@ func TestSingleGroupApplyLoopCloseReopenDurableProgressResult(t *testing.T) {
 
 	reopenedDB := openFSMTestDB(t, dbDir)
 	defer func() { _ = reopenedDB.Close() }()
-	reopenedFSM := openFSMForTest(t, reopenedDB, metadataDir)
+	reopenedFSM := openFSMForTest(t, reopenedDB, dbDir)
 	defer func() { _ = reopenedFSM.Close() }()
 	assertLastApplied(t, reopenedFSM, raftentry.ApplyEntryID{Term: 2, Index: 1})
 	reopenedRecord, ok, err := reopenedFSM.results.LookupApplyResult(record.EntryID)
@@ -83,9 +87,10 @@ func TestSingleGroupApplyLoopCloseReopenDurableProgressResult(t *testing.T) {
 
 func TestSingleGroupApplyLoopFailsClosedOnOrderingAndUnsupportedEntries(t *testing.T) {
 	root := t.TempDir()
-	db := openFSMTestDB(t, filepath.Join(root, "db"))
+	dbDir := filepath.Join(root, "db")
+	db := openFSMTestDB(t, dbDir)
 	defer func() { _ = db.Close() }()
-	fsm := openFSMForTest(t, db, filepath.Join(root, "raftapply"))
+	fsm := openFSMForTest(t, db, dbDir)
 	defer func() { _ = fsm.Close() }()
 
 	users := deterministicCreateCollectionEntry(t, "users", "fsm:create:users:ordering")
@@ -110,6 +115,10 @@ func TestSingleGroupApplyLoopFailsClosedOnOrderingAndUnsupportedEntries(t *testi
 	assertRejected(t, duplicateConflict, err, raftentry.ApplyStatusRejectedConflict, raftentry.ErrorRejectedConflictV1)
 	assertNoApplyProgress(t, db, beforeLSN, fsm, raftentry.ApplyEntryID{Term: 3, Index: 1})
 
+	sameIndexDifferentTerm, err := fsm.ApplyCommittedEntryV1(committedCommand(4, 1, users))
+	assertRejected(t, sameIndexDifferentTerm, err, raftentry.ApplyStatusRejectedConflict, raftentry.ErrorRejectedConflictV1)
+	assertNoApplyProgress(t, db, beforeLSN, fsm, raftentry.ApplyEntryID{Term: 3, Index: 1})
+
 	profiles := deterministicCreateCollectionEntry(t, "profiles", "fsm:create:profiles:advance")
 	advanced, err := fsm.ApplyCommittedEntryV1(committedCommand(3, 2, profiles))
 	if err != nil {
@@ -132,9 +141,10 @@ func TestSingleGroupApplyLoopLogicalDigestConvergesAcrossDBs(t *testing.T) {
 	entries := []CommittedEntryV1{committedCommand(5, 1, raw)}
 
 	root := t.TempDir()
-	dbA := openFSMTestDB(t, filepath.Join(root, "a", "db"))
+	dbADir := filepath.Join(root, "a", "db")
+	dbA := openFSMTestDB(t, dbADir)
 	defer func() { _ = dbA.Close() }()
-	fsmA := openFSMForTest(t, dbA, filepath.Join(root, "a", "raftapply"))
+	fsmA := openFSMForTest(t, dbA, dbADir)
 	defer func() { _ = fsmA.Close() }()
 	if results, err := fsmA.ApplyCommittedEntriesV1(entries); err != nil {
 		t.Fatalf("ApplyCommittedEntriesV1 A: %v results=%+v", err, results)
@@ -144,9 +154,10 @@ func TestSingleGroupApplyLoopLogicalDigestConvergesAcrossDBs(t *testing.T) {
 		t.Fatalf("LogicalDigestV1 A: %v", err)
 	}
 
-	dbB := openFSMTestDB(t, filepath.Join(root, "b", "db"))
+	dbBDir := filepath.Join(root, "b", "db")
+	dbB := openFSMTestDB(t, dbBDir)
 	defer func() { _ = dbB.Close() }()
-	fsmB := openFSMForTest(t, dbB, filepath.Join(root, "b", "raftapply"))
+	fsmB := openFSMForTest(t, dbB, dbBDir)
 	defer func() { _ = fsmB.Close() }()
 	if results, err := fsmB.ApplyCommittedEntriesV1(entries); err != nil {
 		t.Fatalf("ApplyCommittedEntriesV1 B: %v results=%+v", err, results)
@@ -157,6 +168,164 @@ func TestSingleGroupApplyLoopLogicalDigestConvergesAcrossDBs(t *testing.T) {
 	}
 	if digestA != digestB {
 		t.Fatalf("logical digest mismatch A=%s B=%s", digestA.Hex(), digestB.Hex())
+	}
+}
+
+func TestOpenDerivesApplyStoresFromValidatedRaftClusterLayout(t *testing.T) {
+	root := t.TempDir()
+	dbDir := filepath.Join(root, "db")
+	db := openFSMTestDB(t, dbDir)
+	defer func() { _ = db.Close() }()
+
+	fsm := openFSMForTest(t, db, dbDir)
+	defer func() { _ = fsm.Close() }()
+
+	resolved, err := raftcluster.Validate(validFSMClusterConfig(dbDir))
+	if err != nil {
+		t.Fatalf("Validate cluster config: %v", err)
+	}
+	if fsm.metadataDir != resolved.Layout.ApplyDir {
+		t.Fatalf("metadataDir=%q want cluster apply dir %q", fsm.metadataDir, resolved.Layout.ApplyDir)
+	}
+
+	overlapping := validFSMClusterConfig(dbDir)
+	overlapping.ClusterDir = raftcluster.CommandWALDir(dbDir)
+	_, err = Open(Options{
+		DB:      db,
+		Cluster: overlapping,
+		StoreOptions: raftapply.DurableApplyStoreOptions{
+			DisableSync: true,
+		},
+	})
+	if err == nil {
+		t.Fatal("Open with cluster dir overlapping command WAL returned nil error")
+	}
+}
+
+func TestCommittedEntryMetadataPreservedIntoApplyMetadata(t *testing.T) {
+	trace := []byte("trace-a")
+	target := raftentry.TargetIdentityV1{
+		ScopeRule:     raftentry.ScopeRuleSingleGroupV1,
+		DatabaseScope: "database/default",
+		CatalogScope:  "catalog/default",
+		CommandID:     nativewire.CommandCreateCollection,
+	}
+	entry := CommittedEntryV1{
+		Type: EntryTypeCommandEntryV1,
+		RequestMetadata: raftentry.RequestMetadataV1{
+			RequestID:     42,
+			AckPolicy:     nativewire.AckVisible,
+			TraceContext:  trace,
+			Compression:   "none",
+			OmitResultIDs: true,
+		},
+		ExpectedTarget: &target,
+	}
+	fsm := &FSM{}
+	meta, err := fsm.applyMetadata(entry, raftentry.ApplyEntryID{Term: 1, Index: 1})
+	if err != nil {
+		t.Fatalf("applyMetadata: %v", err)
+	}
+	if meta.RequestMetadata.RequestID != entry.RequestMetadata.RequestID ||
+		meta.RequestMetadata.AckPolicy != entry.RequestMetadata.AckPolicy ||
+		meta.RequestMetadata.Compression != entry.RequestMetadata.Compression ||
+		!meta.RequestMetadata.OmitResultIDs ||
+		string(meta.RequestMetadata.TraceContext) != string(trace) {
+		t.Fatalf("RequestMetadata=%+v, want preserved %+v", meta.RequestMetadata, entry.RequestMetadata)
+	}
+	trace[0] = 'X'
+	if string(meta.RequestMetadata.TraceContext) != "trace-a" {
+		t.Fatalf("RequestMetadata trace was not cloned: %q", meta.RequestMetadata.TraceContext)
+	}
+	if meta.ExpectedTarget == nil || !meta.ExpectedTarget.Equal(target) {
+		t.Fatalf("ExpectedTarget=%+v, want %+v", meta.ExpectedTarget, target)
+	}
+	target.CommandID = nativewire.CommandInsertBatch
+	if meta.ExpectedTarget.CommandID != nativewire.CommandCreateCollection {
+		t.Fatalf("ExpectedTarget was not cloned: %+v", meta.ExpectedTarget)
+	}
+}
+
+func TestSingleGroupApplyLoopRejectsExpectedTargetMismatch(t *testing.T) {
+	root := t.TempDir()
+	dbDir := filepath.Join(root, "db")
+	db := openFSMTestDB(t, dbDir)
+	defer func() { _ = db.Close() }()
+	fsm := openFSMForTest(t, db, dbDir)
+	defer func() { _ = fsm.Close() }()
+
+	raw := deterministicCreateCollectionEntry(t, "users", "fsm:create:users:target-mismatch")
+	expected := decodedTargetForTest(t, raw)
+	expected.CollectionMeta = append([]byte(nil), expected.CollectionMeta...)
+	expected.CollectionMeta = append(expected.CollectionMeta, 0)
+
+	result, err := fsm.ApplyCommittedEntryV1(CommittedEntryV1{
+		Type:                     EntryTypeCommandEntryV1,
+		Term:                     1,
+		Index:                    1,
+		Bytes:                    raw,
+		CurrentCatalogVersion:    testCatalogVersionStart,
+		HasCurrentCatalogVersion: true,
+		ExpectedTarget:           &expected,
+	})
+	assertRejected(t, result, err, raftentry.ApplyStatusDeterministicGuardFailure, raftentry.ErrorTargetMismatchV1)
+	if _, openErr := collections.NewCollectionManager(db).OpenCollection("users"); !errors.Is(openErr, collections.ErrCollectionNotFound) {
+		t.Fatalf("OpenCollection users after target mismatch err=%v, want ErrCollectionNotFound", openErr)
+	}
+}
+
+func TestSingleGroupApplyLoopMixedMutationEntriesContiguous(t *testing.T) {
+	root := t.TempDir()
+	dbDir := filepath.Join(root, "db")
+	db := openFSMTestDB(t, dbDir)
+	defer func() { _ = db.Close() }()
+	fsm := openFSMForTest(t, db, dbDir)
+	defer func() { _ = fsm.Close() }()
+
+	create := deterministicCreateCollectionEntryWithOptions(t, "users", "fsm:create:users:mixed", testCreateCollectionMetaOptions{
+		documentFormat: uint64(nativewire.DocumentFormatBSON),
+	})
+	docU1 := testBSONDocument(t, bson.D{{Key: "_id", Value: "u1"}, {Key: "city", Value: "hnl"}})
+	docU2 := testBSONDocument(t, bson.D{{Key: "_id", Value: "u2"}, {Key: "city", Value: "sea"}})
+	insert := deterministicInsertBatchEntry(t, "users", "fsm:insert:users:mixed", nativewire.DocumentFormatBSON, [][]byte{[]byte("u1"), []byte("u2")}, [][]byte{docU1, docU2})
+	docU1Replace := testBSONDocument(t, bson.D{{Key: "_id", Value: "u1"}, {Key: "city", Value: "sfo"}})
+	replace := deterministicReplaceBatchEntry(t, "users", "fsm:replace:users:mixed", nativewire.DocumentFormatBSON, [][]byte{[]byte("u1")}, [][]byte{docU1Replace})
+	deleteEntry := deterministicDeleteBatchEntry(t, "users", "fsm:delete:users:mixed", [][]byte{[]byte("u2")})
+
+	results, err := fsm.ApplyCommittedEntriesV1([]CommittedEntryV1{
+		committedCommand(4, 1, create),
+		committedCommand(4, 2, insert),
+		committedCommand(4, 3, replace),
+		committedCommand(4, 4, deleteEntry),
+	})
+	if err != nil {
+		t.Fatalf("ApplyCommittedEntriesV1 mixed: %v results=%+v", err, results)
+	}
+	if len(results) != 4 {
+		t.Fatalf("mixed results=%d, want 4", len(results))
+	}
+	for i, wantAffected := range []int64{1, 2, 1, 1} {
+		assertApplied(t, results[i], raftentry.ApplyStatusApplied, wantAffected)
+	}
+	assertLastApplied(t, fsm, raftentry.ApplyEntryID{Term: 4, Index: 4})
+
+	opened, err := collections.NewCollectionManager(db).OpenCollection("users")
+	if err != nil {
+		t.Fatalf("OpenCollection users: %v", err)
+	}
+	gotU1, err := opened.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("Get u1: %v", err)
+	}
+	if got := bson.Raw(gotU1).Lookup("city").StringValue(); got != "sfo" {
+		t.Fatalf("u1 city=%q, want sfo", got)
+	}
+	gotU2, err := opened.Get([]byte("u2"))
+	if err != nil {
+		t.Fatalf("Get u2: %v", err)
+	}
+	if gotU2 != nil {
+		t.Fatalf("u2 after delete=%x, want nil", gotU2)
 	}
 }
 
@@ -175,11 +344,11 @@ func openFSMTestDB(t testing.TB, dir string) *backenddb.DB {
 	return db
 }
 
-func openFSMForTest(t testing.TB, db *backenddb.DB, metadataDir string) *FSM {
+func openFSMForTest(t testing.TB, db *backenddb.DB, dbDir string) *FSM {
 	t.Helper()
 	fsm, err := Open(Options{
-		DB:          db,
-		MetadataDir: metadataDir,
+		DB:      db,
+		Cluster: validFSMClusterConfig(dbDir),
 		StoreOptions: raftapply.DurableApplyStoreOptions{
 			DisableSync: true,
 		},
@@ -188,6 +357,19 @@ func openFSMForTest(t testing.TB, db *backenddb.DB, metadataDir string) *FSM {
 		t.Fatalf("Open FSM: %v", err)
 	}
 	return fsm
+}
+
+func validFSMClusterConfig(dbDir string) raftcluster.Config {
+	return raftcluster.Config{
+		Dir:     dbDir,
+		NodeID:  "node-a",
+		GroupID: "default",
+		Peers: []raftcluster.Peer{
+			{ID: "node-a", Address: "127.0.0.1:9201"},
+			{ID: "node-b", Address: "127.0.0.1:9202"},
+			{ID: "node-c", Address: "127.0.0.1:9203"},
+		},
+	}
 }
 
 func committedCommand(term, index uint64, raw []byte) CommittedEntryV1 {
@@ -203,10 +385,19 @@ func committedCommand(term, index uint64, raw []byte) CommittedEntryV1 {
 
 func deterministicCreateCollectionEntry(t *testing.T, collection, idempotency string) []byte {
 	t.Helper()
+	return deterministicCreateCollectionEntryWithOptions(t, collection, idempotency, testCreateCollectionMetaOptions{})
+}
+
+type testCreateCollectionMetaOptions struct {
+	documentFormat uint64
+}
+
+func deterministicCreateCollectionEntryWithOptions(t *testing.T, collection, idempotency string, opts testCreateCollectionMetaOptions) []byte {
+	t.Helper()
 	sections := []nativewire.Section{
 		{ID: nativewire.SectionCommandHeader, Bytes: nativewire.AppendCommandHeader(nil, nativewire.CommandHeader{ID: nativewire.CommandCreateCollection, Version: 1})},
 		{ID: nativewire.SectionIdempotencyKey, Bytes: []byte(idempotency)},
-		{ID: nativewire.SectionCollectionMeta, Bytes: testCreateCollectionMetaPayload(collection)},
+		{ID: nativewire.SectionCollectionMeta, Bytes: testCreateCollectionMetaPayload(collection, opts)},
 		{ID: nativewire.SectionExpectedCatalogVersion, Bytes: binary.AppendUvarint(nil, testCatalogVersionStart)},
 	}
 	cmd, err := nativewire.MustV1Registry().ValidateRequestSections(sections)
@@ -220,23 +411,99 @@ func deterministicCreateCollectionEntry(t *testing.T, collection, idempotency st
 	return entry
 }
 
-func testCreateCollectionMetaPayload(collection string) []byte {
+func testCreateCollectionMetaPayload(collection string, opts testCreateCollectionMetaOptions) []byte {
 	dst := binary.AppendUvarint(nil, 1) // collection_meta version
 	dst = appendTestString(dst, collection)
-	dst = binary.AppendUvarint(dst, 0) // document_format
-	dst = binary.AppendUvarint(dst, 0) // data_root_storage_policy
-	dst = binary.AppendUvarint(dst, 0) // index_state_storage_policy
-	dst = append(dst, 0)               // allow_array_values_in_index
-	dst = append(dst, 0)               // disable_indexed_write_memtables
-	dst = append(dst, 0)               // buffered_indexed_writes
-	dst = binary.AppendVarint(dst, 0)  // buffered_indexed_write_max_documents
-	dst = binary.AppendVarint(dst, 0)  // buffered_indexed_write_max_bytes
-	dst = binary.AppendVarint(dst, 0)  // buffered_indexed_write_max_root_runs
-	dst = append(dst, 0)               // buffered_indexed_async_flush
-	dst = append(dst, 0)               // buffered_indexed_overlay_roots
-	dst = binary.AppendVarint(dst, 0)  // buffered_indexed_async_flush_max_queued_units
-	dst = binary.AppendUvarint(dst, 0) // index_count
+	dst = binary.AppendUvarint(dst, opts.documentFormat) // document_format
+	dst = binary.AppendUvarint(dst, 0)                   // data_root_storage_policy
+	dst = binary.AppendUvarint(dst, 0)                   // index_state_storage_policy
+	dst = append(dst, 0)                                 // allow_array_values_in_index
+	dst = append(dst, 0)                                 // disable_indexed_write_memtables
+	dst = append(dst, 0)                                 // buffered_indexed_writes
+	dst = binary.AppendVarint(dst, 0)                    // buffered_indexed_write_max_documents
+	dst = binary.AppendVarint(dst, 0)                    // buffered_indexed_write_max_bytes
+	dst = binary.AppendVarint(dst, 0)                    // buffered_indexed_write_max_root_runs
+	dst = append(dst, 0)                                 // buffered_indexed_async_flush
+	dst = append(dst, 0)                                 // buffered_indexed_overlay_roots
+	dst = binary.AppendVarint(dst, 0)                    // buffered_indexed_async_flush_max_queued_units
+	dst = binary.AppendUvarint(dst, 0)                   // index_count
 	return dst
+}
+
+func deterministicInsertBatchEntry(t *testing.T, collection, idempotency string, format nativewire.DocumentFormat, ids, documents [][]byte) []byte {
+	t.Helper()
+	return deterministicMutationEntry(t, nativewire.CommandInsertBatch, collection, idempotency, format, ids, documents, nil)
+}
+
+func deterministicReplaceBatchEntry(t *testing.T, collection, idempotency string, format nativewire.DocumentFormat, ids, documents [][]byte) []byte {
+	t.Helper()
+	extra := []nativewire.Section{{ID: nativewire.SectionReplacementMode, Bytes: binary.AppendUvarint(nil, 1)}}
+	return deterministicMutationEntry(t, nativewire.CommandReplaceBatch, collection, idempotency, format, ids, documents, extra)
+}
+
+func deterministicDeleteBatchEntry(t *testing.T, collection, idempotency string, ids [][]byte) []byte {
+	t.Helper()
+	sections := []nativewire.Section{
+		{ID: nativewire.SectionCommandHeader, Bytes: nativewire.AppendCommandHeader(nil, nativewire.CommandHeader{ID: nativewire.CommandDeleteBatch, Version: 1})},
+		{ID: nativewire.SectionIdempotencyKey, Bytes: []byte(idempotency)},
+		{ID: nativewire.SectionCollectionRef, Bytes: deterministicTestCollectionNameRef(collection)},
+		{ID: nativewire.SectionDocumentIDs, Bytes: nativewire.AppendByteVector(nil, ids...)},
+		{ID: nativewire.SectionExpectedCatalogVersion, Bytes: binary.AppendUvarint(nil, testCatalogVersionStart)},
+	}
+	cmd, err := nativewire.MustV1Registry().ValidateRequestSections(sections)
+	if err != nil {
+		t.Fatalf("ValidateRequestSections: %v", err)
+	}
+	entry, err := nativewire.AppendDeterministicEntry(nil, cmd)
+	if err != nil {
+		t.Fatalf("AppendDeterministicEntry: %v", err)
+	}
+	return entry
+}
+
+func deterministicMutationEntry(t *testing.T, command nativewire.CommandID, collection, idempotency string, format nativewire.DocumentFormat, ids, documents [][]byte, extra []nativewire.Section) []byte {
+	t.Helper()
+	sections := []nativewire.Section{
+		{ID: nativewire.SectionCommandHeader, Bytes: nativewire.AppendCommandHeader(nil, nativewire.CommandHeader{ID: command, Version: 1})},
+		{ID: nativewire.SectionIdempotencyKey, Bytes: []byte(idempotency)},
+		{ID: nativewire.SectionCollectionRef, Bytes: deterministicTestCollectionNameRef(collection)},
+		{ID: nativewire.SectionDocumentFormat, Bytes: binary.AppendUvarint(nil, uint64(format))},
+		{ID: nativewire.SectionDocumentIDs, Bytes: nativewire.AppendByteVector(nil, ids...)},
+		{ID: nativewire.SectionDocuments, Bytes: nativewire.AppendByteVector(nil, documents...)},
+		{ID: nativewire.SectionExpectedCatalogVersion, Bytes: binary.AppendUvarint(nil, testCatalogVersionStart)},
+	}
+	sections = append(sections, extra...)
+	cmd, err := nativewire.MustV1Registry().ValidateRequestSections(sections)
+	if err != nil {
+		t.Fatalf("ValidateRequestSections: %v", err)
+	}
+	entry, err := nativewire.AppendDeterministicEntry(nil, cmd)
+	if err != nil {
+		t.Fatalf("AppendDeterministicEntry: %v", err)
+	}
+	return entry
+}
+
+func deterministicTestCollectionNameRef(collection string) []byte {
+	return append([]byte{deterministicCollectionRefName}, collection...)
+}
+
+func decodedTargetForTest(t *testing.T, raw []byte) raftentry.TargetIdentityV1 {
+	t.Helper()
+	entry, err := raftentry.DecodeCommandEntryV1(raw, raftentry.DecodeOptions{})
+	if err != nil {
+		t.Fatalf("DecodeCommandEntryV1: %v", err)
+	}
+	return entry.Target
+}
+
+func testBSONDocument(t *testing.T, document bson.D) []byte {
+	t.Helper()
+	encoded, err := bson.Marshal(document)
+	if err != nil {
+		t.Fatalf("Marshal BSON: %v", err)
+	}
+	return encoded
 }
 
 func appendTestString(dst []byte, value string) []byte {


### PR DESCRIPTION
Refs #3257
Parent: #3044
Depends on merged #3248, #3250, #3249, and #3266.

## Summary

- Add `TreeDB/internal/raftfsm` as the narrow single-group R3a FSM apply loop for already-committed deterministic `CommandEntryV1` bytes.
- Map Raft term/index directly to `raftentry.ApplyEntryID` and apply through `raftapply.ApplyCommittedEntryV1` with durable progress/result stores.
- Bind FSM apply metadata storage to the validated `raftcluster` storage layout via a new per-group `ApplyDir`.
- Preserve request metadata and expected-target identity into apply metadata/decode options, including clone protection for trace/target data.
- Document `groups/<group-id>/apply/` in the normative Raft/storage specs.
- Keep scope intentionally limited: no leader routing, failover, snapshots, read-index, or client-visible `raft_committed` semantics.

## Correctness Notes

- The FSM enforces contiguous indexes, non-decreasing terms for new indexes, exact same term/index for replay, and fail-closed behavior for same-index/different-term conflicts.
- Close/reopen tests cover durable progress/result replay.
- Logical digest convergence is covered across two DBs applying the same committed sequence.
- Review-fix head `146e173d3` adds zero-value/partially initialized FSM guards and stronger rejection assertions proving target mismatches do not advance `AppliedCommandLSN`, `LastApplied`, result records, or collection state.

## Local Validation

On review-fix head `146e173d3`:

- `git diff --check`
- `GOWORK=off go test ./TreeDB/internal/raftfsm ./TreeDB/internal/raftapply ./TreeDB/internal/raftentry ./TreeDB/internal/raftcluster -count=1`
- `GOWORK=off go test ./TreeDB/internal/raftfsm ./TreeDB/internal/raftapply ./TreeDB/internal/raftentry ./TreeDB/internal/raftcluster ./TreeDB/collections ./TreeDB/db -count=1`

## Benchmark Evidence

This PR wraps the existing `raftapply` path rather than changing mutation execution internals. Current review-fix-head apply-path benchmark evidence:

Command:

```sh
GOWORK=off go test ./TreeDB/internal/raftapply -run '^$' -bench 'BenchmarkApplyCommittedEntryCloseout3043' -benchmem -count=1
```

Hardware/context from Go benchmark output: linux/amd64, Intel i5-11400F.

| Case | ns/op | ops/sec | B/op | allocs/op |
| --- | ---: | ---: | ---: | ---: |
| supported_create_collection | 26,815,041 | 37.3 | 18,099,480 | 1,693 |
| rejected_unsupported_before_append | 4,479 | 223,264.1 | 1,792 | 55 |
| duplicate_result_replay | 2,967 | 337,040.8 | 1,280 | 45 |
| close_reopen_replay_boundary | 56,523,260 | 17.7 | 36,109,536 | 3,031 |

The review-fix commit adds guards/tests/docs around the FSM wrapper and does not change the `raftapply` mutation executor internals.

## Review And CI

Codex, Copilot, and CodeRabbit reviews were requested on the mature initial head. Review findings were addressed in `146e173d3`; fresh review requests are posted for the new head. Latest-head CI must pass before merge.
