### PR TITLE
TreeDB Raft: add failover catch-up harness

### DIFF
--- a/TreeDB/internal/raftfsm/fsm.go
+++ b/TreeDB/internal/raftfsm/fsm.go
@@ -186,6 +186,17 @@ func (f *FSM) ValidateAppliedPrefixV1(entries []CommittedEntryV1) (raftentry.App
 	if uint64(len(entries)) != record.EntryID.Index {
 		return reject(raftentry.CommandDigestV1{}, raftentry.ErrorRejectedConflictV1, fmt.Errorf("applied prefix length %d does not match last applied index %d", len(entries), record.EntryID.Index))
 	}
+	if len(entries) > 0 {
+		last := entries[len(entries)-1]
+		lastID := raftentry.ApplyEntryID{Term: last.Term, Index: last.Index}
+		lastDigest := commandDigest(last.Bytes, f.decodeOptions(last, lastID))
+		if err := validateCommittedID(lastID); err != nil {
+			return reject(lastDigest, raftentry.ErrorMalformedEntryV1, err)
+		}
+		if lastID != record.EntryID {
+			return reject(lastDigest, raftentry.ErrorRejectedConflictV1, fmt.Errorf("applied prefix last entry %d/%d does not match durable last applied %d/%d", lastID.Term, lastID.Index, record.EntryID.Term, record.EntryID.Index))
+		}
+	}
 	for i, entry := range entries {
 		id := raftentry.ApplyEntryID{Term: entry.Term, Index: entry.Index}
 		digest := commandDigest(entry.Bytes, f.decodeOptions(entry, id))

--- a/TreeDB/internal/raftfsm/fsm.go
+++ b/TreeDB/internal/raftfsm/fsm.go
@@ -162,6 +162,54 @@ func (f *FSM) LastApplied() (raftentry.ApplyEntryID, bool) {
 	return record.EntryID, true
 }
 
+func (f *FSM) ValidateAppliedPrefixV1(entries []CommittedEntryV1) (raftentry.ApplyResultV1, error) {
+	if f == nil {
+		return reject(raftentry.CommandDigestV1{}, raftentry.ErrorUnsafeDurabilityModeV1, fmt.Errorf("FSM is not open"))
+	}
+	if f.closed {
+		return reject(raftentry.CommandDigestV1{}, raftentry.ErrorUnsafeDurabilityModeV1, fmt.Errorf("FSM is closed"))
+	}
+	if f.db == nil || f.progress == nil || f.results == nil {
+		return reject(raftentry.CommandDigestV1{}, raftentry.ErrorUnsafeDurabilityModeV1, fmt.Errorf("FSM is not open"))
+	}
+	record, ok, err := f.lastAppliedProgressRecord()
+	if err != nil {
+		code, _ := ErrorCodeOf(err)
+		return reject(raftentry.CommandDigestV1{}, code, err)
+	}
+	if !ok {
+		if len(entries) == 0 {
+			return raftentry.ApplyResultV1{}, nil
+		}
+		return reject(raftentry.CommandDigestV1{}, raftentry.ErrorRejectedConflictV1, fmt.Errorf("applied prefix has %d entries but FSM has no applied progress", len(entries)))
+	}
+	if uint64(len(entries)) != record.EntryID.Index {
+		return reject(raftentry.CommandDigestV1{}, raftentry.ErrorRejectedConflictV1, fmt.Errorf("applied prefix length %d does not match last applied index %d", len(entries), record.EntryID.Index))
+	}
+	for i, entry := range entries {
+		id := raftentry.ApplyEntryID{Term: entry.Term, Index: entry.Index}
+		digest := commandDigest(entry.Bytes, f.decodeOptions(entry, id))
+		if err := validateCommittedID(id); err != nil {
+			return reject(digest, raftentry.ErrorMalformedEntryV1, err)
+		}
+		if wantIndex := uint64(i + 1); id.Index != wantIndex {
+			return reject(digest, raftentry.ErrorRejectedConflictV1, fmt.Errorf("applied prefix entry index %d at offset %d; want %d", id.Index, i, wantIndex))
+		}
+		stored, ok, err := f.results.LookupApplyResult(id)
+		if err != nil {
+			code, _ := ErrorCodeOf(err)
+			return reject(digest, code, err)
+		}
+		if !ok {
+			return reject(digest, raftentry.ErrorUnsafeDurabilityModeV1, fmt.Errorf("missing durable result for applied prefix entry %d/%d", id.Term, id.Index))
+		}
+		if stored.CommandDigest != digest {
+			return reject(digest, raftentry.ErrorRejectedConflictV1, fmt.Errorf("applied prefix digest conflicts at %d/%d", id.Term, id.Index))
+		}
+	}
+	return raftentry.ApplyResultV1{}, nil
+}
+
 func (f *FSM) LogicalDigestV1(opts raftapply.LogicalDigestOptionsV1) (raftapply.LogicalDigestV1, error) {
 	if f == nil || f.db == nil {
 		return raftapply.LogicalDigestV1{}, codedError(raftentry.ErrorUnsafeDurabilityModeV1, "nil FSM DB")

--- a/TreeDB/internal/raftharness/doc.go
+++ b/TreeDB/internal/raftharness/doc.go
@@ -1,0 +1,9 @@
+// Package raftharness provides a deterministic in-process harness for the
+// TreeDB single-group Raft apply substrate.
+//
+// The harness records and replays injected committed raftfsm entries across
+// local node directories. It is integration-test scaffolding for failover,
+// restart, and follower catch-up behavior around the committed-entry boundary.
+// It does not run a Raft library, elect leaders, form quorums, replicate logs,
+// or prove production consensus.
+package raftharness

--- a/TreeDB/internal/raftharness/harness.go
+++ b/TreeDB/internal/raftharness/harness.go
@@ -272,15 +272,21 @@ func (h *Harness) CatchUpNode(id raftcluster.NodeID) ([]raftentry.ApplyResultV1,
 		h.mu.Unlock()
 		return nil, fmt.Errorf("%w: %s", ErrNodeNotFound, id)
 	}
-	var after uint64
+	start := 0
 	if last, ok := node.LastApplied(); ok {
-		after = last.Index
-	}
-	entries := make([]raftfsm.CommittedEntryV1, 0, len(h.committed))
-	for _, entry := range h.committed {
-		if entry.Index > after {
-			entries = append(entries, cloneCommittedEntry(entry))
+		if last.Index == 0 {
+			h.mu.Unlock()
+			return nil, fmt.Errorf("%w: node %s has invalid last applied index 0", ErrCommittedLogConflict, id)
 		}
+		if last.Index > uint64(len(h.committed)) {
+			h.mu.Unlock()
+			return nil, fmt.Errorf("%w: node %s last applied index %d beyond committed log length %d", ErrCommittedLogConflict, id, last.Index, len(h.committed))
+		}
+		start = int(last.Index - 1)
+	}
+	entries := make([]raftfsm.CommittedEntryV1, 0, len(h.committed)-start)
+	for _, entry := range h.committed[start:] {
+		entries = append(entries, cloneCommittedEntry(entry))
 	}
 	h.mu.Unlock()
 	return node.ApplyCommittedEntriesV1(entries...)

--- a/TreeDB/internal/raftharness/harness.go
+++ b/TreeDB/internal/raftharness/harness.go
@@ -235,27 +235,52 @@ func (h *Harness) CommitAndApply(nodeIDs []raftcluster.NodeID, entries ...raftfs
 }
 
 func (h *Harness) ApplyCommittedEntriesToNode(id raftcluster.NodeID, entries ...raftfsm.CommittedEntryV1) ([]raftentry.ApplyResultV1, error) {
-	node, err := h.nodeForApply(id)
+	node, committed, err := h.committedEntriesForApply(id, entries)
 	if err != nil {
 		return nil, err
 	}
-	return node.ApplyCommittedEntriesV1(entries...)
+	return node.ApplyCommittedEntriesV1(committed...)
 }
 
-func (h *Harness) nodeForApply(id raftcluster.NodeID) (*Node, error) {
+func (h *Harness) committedEntriesForApply(id raftcluster.NodeID, entries []raftfsm.CommittedEntryV1) (*Node, []raftfsm.CommittedEntryV1, error) {
 	if h == nil {
-		return nil, ErrHarnessClosed
+		return nil, nil, ErrHarnessClosed
 	}
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	if h.closed {
-		return nil, ErrHarnessClosed
+		return nil, nil, ErrHarnessClosed
 	}
 	node, ok := h.nodes[id]
 	if !ok {
-		return nil, fmt.Errorf("%w: %s", ErrNodeNotFound, id)
+		return nil, nil, fmt.Errorf("%w: %s", ErrNodeNotFound, id)
 	}
-	return node, nil
+	committed := make([]raftfsm.CommittedEntryV1, 0, len(entries))
+	var previous raftentry.ApplyEntryID
+	for i, entry := range entries {
+		entryID := raftentry.ApplyEntryID{Term: entry.Term, Index: entry.Index}
+		if entryID.Term == 0 || entryID.Index == 0 {
+			return nil, nil, fmt.Errorf("%w: invalid committed id %+v", ErrCommittedLogGap, entryID)
+		}
+		if i > 0 {
+			if entryID.Index <= previous.Index {
+				return nil, nil, fmt.Errorf("%w: non-increasing apply index %d after %d", ErrCommittedLogConflict, entryID.Index, previous.Index)
+			}
+			if entryID.Index != previous.Index+1 {
+				return nil, nil, fmt.Errorf("%w: got index %d after %d", ErrCommittedLogGap, entryID.Index, previous.Index)
+			}
+		}
+		if entryID.Index > uint64(len(h.committed)) {
+			return nil, nil, fmt.Errorf("%w: apply entry index %d beyond committed log length %d", ErrCommittedLogGap, entryID.Index, len(h.committed))
+		}
+		want := h.committed[entryID.Index-1]
+		if !committedEntriesEqual(want, entry) {
+			return nil, nil, fmt.Errorf("%w: apply entry does not match committed log at index %d", ErrCommittedLogConflict, entryID.Index)
+		}
+		committed = append(committed, cloneCommittedEntry(want))
+		previous = entryID
+	}
+	return node, committed, nil
 }
 
 func (h *Harness) CatchUpNode(id raftcluster.NodeID) ([]raftentry.ApplyResultV1, error) {

--- a/TreeDB/internal/raftharness/harness.go
+++ b/TreeDB/internal/raftharness/harness.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"sort"
+	"strings"
 	"sync"
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
@@ -360,8 +361,8 @@ func normalizeNodeConfigs(configs []NodeConfig) ([]NodeConfig, error) {
 	out := make([]NodeConfig, 0, len(configs))
 	seen := make(map[raftcluster.NodeID]struct{}, len(configs))
 	for _, cfg := range configs {
-		if cfg.ID == "" {
-			return nil, fmt.Errorf("raftharness: missing node id")
+		if err := validateNodeIDPathSegment(cfg.ID); err != nil {
+			return nil, err
 		}
 		if _, ok := seen[cfg.ID]; ok {
 			return nil, fmt.Errorf("raftharness: duplicate node id %s", cfg.ID)
@@ -374,6 +375,30 @@ func normalizeNodeConfigs(configs []NodeConfig) ([]NodeConfig, error) {
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
 	return out, nil
+}
+
+func validateNodeIDPathSegment(id raftcluster.NodeID) error {
+	raw := string(id)
+	if raw == "" {
+		return fmt.Errorf("raftharness: missing node id")
+	}
+	if strings.TrimSpace(raw) != raw {
+		return fmt.Errorf("raftharness: invalid node id %q: leading or trailing whitespace", raw)
+	}
+	if raw == "." || raw == ".." {
+		return fmt.Errorf("raftharness: invalid node id %q: not a valid path segment", raw)
+	}
+	for _, r := range raw {
+		switch {
+		case r >= 'a' && r <= 'z':
+		case r >= 'A' && r <= 'Z':
+		case r >= '0' && r <= '9':
+		case r == '-' || r == '_' || r == '.':
+		default:
+			return fmt.Errorf("raftharness: invalid node id %q: unsupported character %q", raw, r)
+		}
+	}
+	return nil
 }
 
 func peersForNodeConfigs(configs []NodeConfig) []raftcluster.Peer {

--- a/TreeDB/internal/raftharness/harness.go
+++ b/TreeDB/internal/raftharness/harness.go
@@ -1,0 +1,420 @@
+package raftharness
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"sort"
+	"sync"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+	"github.com/snissn/gomap/TreeDB/internal/raftapply"
+	"github.com/snissn/gomap/TreeDB/internal/raftcluster"
+	"github.com/snissn/gomap/TreeDB/internal/raftentry"
+	"github.com/snissn/gomap/TreeDB/internal/raftfsm"
+)
+
+type EvidenceKindV1 string
+
+const (
+	// EvidenceInjectedCommittedEntryReplayV1 means the harness applied entries
+	// that the test injected as already committed. It is not production Raft
+	// consensus evidence.
+	EvidenceInjectedCommittedEntryReplayV1 EvidenceKindV1 = "injected-committed-entry-replay-v1"
+)
+
+var (
+	ErrNodeNotFound         = errors.New("raftharness: node not found")
+	ErrCommittedLogGap      = errors.New("raftharness: committed log gap")
+	ErrCommittedLogConflict = errors.New("raftharness: committed log conflict")
+)
+
+type Options struct {
+	RootDir      string
+	GroupID      raftcluster.GroupID
+	Nodes        []NodeConfig
+	StoreOptions raftapply.DurableApplyStoreOptions
+}
+
+type NodeConfig struct {
+	ID      raftcluster.NodeID
+	Address string
+}
+
+type Harness struct {
+	mu           sync.Mutex
+	rootDir      string
+	groupID      raftcluster.GroupID
+	nodeConfigs  []NodeConfig
+	storeOptions raftapply.DurableApplyStoreOptions
+	nodes        map[raftcluster.NodeID]*Node
+	committed    []raftfsm.CommittedEntryV1
+	closed       bool
+}
+
+type Node struct {
+	id     raftcluster.NodeID
+	db     *backenddb.DB
+	fsm    *raftfsm.FSM
+	closed bool
+}
+
+type CommitEvidenceV1 struct {
+	Kind                EvidenceKindV1
+	Committed           bool
+	ProductionConsensus bool
+	EntryIDs            []raftentry.ApplyEntryID
+	Applied             map[raftcluster.NodeID][]raftentry.ApplyResultV1
+}
+
+func (e CommitEvidenceV1) ProvesProductionConsensus() bool {
+	return e.ProductionConsensus
+}
+
+func (e CommitEvidenceV1) HasCommittedSuccess() bool {
+	if !e.Committed {
+		return false
+	}
+	for _, results := range e.Applied {
+		for _, result := range results {
+			if result.Status == raftentry.ApplyStatusApplied || result.Status == raftentry.ApplyStatusAlreadyApplied {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func Open(opts Options) (*Harness, error) {
+	if opts.RootDir == "" {
+		return nil, fmt.Errorf("raftharness: missing root dir")
+	}
+	groupID := opts.GroupID
+	if groupID == "" {
+		groupID = "default"
+	}
+	nodeConfigs, err := normalizeNodeConfigs(opts.Nodes)
+	if err != nil {
+		return nil, err
+	}
+	h := &Harness{
+		rootDir:      opts.RootDir,
+		groupID:      groupID,
+		nodeConfigs:  nodeConfigs,
+		storeOptions: opts.StoreOptions,
+		nodes:        make(map[raftcluster.NodeID]*Node, len(nodeConfigs)),
+	}
+	for _, cfg := range nodeConfigs {
+		node, err := h.openNode(cfg)
+		if err != nil {
+			_ = h.Close()
+			return nil, err
+		}
+		h.nodes[cfg.ID] = node
+	}
+	return h, nil
+}
+
+func (h *Harness) Close() error {
+	if h == nil {
+		return nil
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.closed {
+		return nil
+	}
+	h.closed = true
+	var err error
+	for _, node := range h.nodes {
+		err = errors.Join(err, node.close())
+	}
+	return err
+}
+
+func (h *Harness) Node(id raftcluster.NodeID) (*Node, bool) {
+	if h == nil {
+		return nil, false
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	node, ok := h.nodes[id]
+	return node, ok
+}
+
+func (h *Harness) CloseNode(id raftcluster.NodeID) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	node, ok := h.nodes[id]
+	if !ok {
+		return fmt.Errorf("%w: %s", ErrNodeNotFound, id)
+	}
+	return node.close()
+}
+
+func (h *Harness) ReopenNode(id raftcluster.NodeID) (*Node, error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for _, cfg := range h.nodeConfigs {
+		if cfg.ID != id {
+			continue
+		}
+		if existing := h.nodes[id]; existing != nil {
+			if err := existing.close(); err != nil {
+				return nil, err
+			}
+		}
+		node, err := h.openNode(cfg)
+		if err != nil {
+			return nil, err
+		}
+		h.nodes[id] = node
+		return node, nil
+	}
+	return nil, fmt.Errorf("%w: %s", ErrNodeNotFound, id)
+}
+
+func (h *Harness) PreCommitEvidence(entries ...raftfsm.CommittedEntryV1) CommitEvidenceV1 {
+	return CommitEvidenceV1{
+		Kind:                EvidenceInjectedCommittedEntryReplayV1,
+		Committed:           false,
+		ProductionConsensus: false,
+		EntryIDs:            applyEntryIDs(entries),
+	}
+}
+
+func (h *Harness) Commit(entries ...raftfsm.CommittedEntryV1) (CommitEvidenceV1, error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	evidence := CommitEvidenceV1{
+		Kind:                EvidenceInjectedCommittedEntryReplayV1,
+		Committed:           false,
+		ProductionConsensus: false,
+		EntryIDs:            applyEntryIDs(entries),
+	}
+	for _, entry := range entries {
+		if err := h.appendCommittedLocked(entry); err != nil {
+			return evidence, err
+		}
+	}
+	evidence.Committed = len(entries) > 0
+	return evidence, nil
+}
+
+func (h *Harness) CommitAndApply(nodeIDs []raftcluster.NodeID, entries ...raftfsm.CommittedEntryV1) (CommitEvidenceV1, error) {
+	evidence, err := h.Commit(entries...)
+	if err != nil {
+		return evidence, err
+	}
+	evidence.Applied = make(map[raftcluster.NodeID][]raftentry.ApplyResultV1, len(nodeIDs))
+	for _, id := range nodeIDs {
+		results, err := h.ApplyCommittedEntriesToNode(id, entries...)
+		evidence.Applied[id] = results
+		if err != nil {
+			return evidence, err
+		}
+	}
+	return evidence, nil
+}
+
+func (h *Harness) ApplyCommittedEntriesToNode(id raftcluster.NodeID, entries ...raftfsm.CommittedEntryV1) ([]raftentry.ApplyResultV1, error) {
+	node, ok := h.Node(id)
+	if !ok {
+		return nil, fmt.Errorf("%w: %s", ErrNodeNotFound, id)
+	}
+	return node.ApplyCommittedEntriesV1(entries...)
+}
+
+func (h *Harness) CatchUpNode(id raftcluster.NodeID) ([]raftentry.ApplyResultV1, error) {
+	node, ok := h.Node(id)
+	if !ok {
+		return nil, fmt.Errorf("%w: %s", ErrNodeNotFound, id)
+	}
+	var after uint64
+	if last, ok := node.LastApplied(); ok {
+		after = last.Index
+	}
+	h.mu.Lock()
+	entries := make([]raftfsm.CommittedEntryV1, 0, len(h.committed))
+	for _, entry := range h.committed {
+		if entry.Index > after {
+			entries = append(entries, cloneCommittedEntry(entry))
+		}
+	}
+	h.mu.Unlock()
+	return node.ApplyCommittedEntriesV1(entries...)
+}
+
+func (h *Harness) openNode(cfg NodeConfig) (*Node, error) {
+	dbDir := filepath.Join(h.rootDir, "nodes", string(cfg.ID), "db")
+	db, err := backenddb.Open(backenddb.Options{
+		Dir:                          dbDir,
+		CommandWAL:                   true,
+		CommandWALStatsScan:          true,
+		CommandWALSegmentTargetBytes: 1 << 20,
+		DisableBackgroundPrune:       true,
+	})
+	if err != nil {
+		return nil, err
+	}
+	cluster := raftcluster.Config{
+		Dir:     dbDir,
+		NodeID:  cfg.ID,
+		GroupID: h.groupID,
+		Peers:   peersForNodeConfigs(h.nodeConfigs),
+	}
+	fsm, err := raftfsm.Open(raftfsm.Options{
+		DB:           db,
+		Cluster:      cluster,
+		StoreOptions: h.storeOptions,
+	})
+	if err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+	return &Node{id: cfg.ID, db: db, fsm: fsm}, nil
+}
+
+func (h *Harness) appendCommittedLocked(entry raftfsm.CommittedEntryV1) error {
+	id := raftentry.ApplyEntryID{Term: entry.Term, Index: entry.Index}
+	if id.Term == 0 || id.Index == 0 {
+		return fmt.Errorf("%w: invalid committed id %+v", ErrCommittedLogGap, id)
+	}
+	wantNext := uint64(len(h.committed) + 1)
+	if id.Index > wantNext {
+		return fmt.Errorf("%w: got index %d after %d", ErrCommittedLogGap, id.Index, len(h.committed))
+	}
+	if id.Index < wantNext {
+		existing := h.committed[id.Index-1]
+		if !committedEntriesEqual(existing, entry) {
+			return fmt.Errorf("%w: divergent entry at index %d", ErrCommittedLogConflict, id.Index)
+		}
+		return nil
+	}
+	h.committed = append(h.committed, cloneCommittedEntry(entry))
+	return nil
+}
+
+func (n *Node) ID() raftcluster.NodeID {
+	if n == nil {
+		return ""
+	}
+	return n.id
+}
+
+func (n *Node) DB() *backenddb.DB {
+	if n == nil {
+		return nil
+	}
+	return n.db
+}
+
+func (n *Node) LastApplied() (raftentry.ApplyEntryID, bool) {
+	if n == nil || n.fsm == nil {
+		return raftentry.ApplyEntryID{}, false
+	}
+	return n.fsm.LastApplied()
+}
+
+func (n *Node) LogicalDigestV1(opts raftapply.LogicalDigestOptionsV1) (raftapply.LogicalDigestV1, error) {
+	if n == nil || n.fsm == nil {
+		return raftapply.LogicalDigestV1{}, fmt.Errorf("%w: nil node", ErrNodeNotFound)
+	}
+	return n.fsm.LogicalDigestV1(opts)
+}
+
+func (n *Node) ApplyCommittedEntriesV1(entries ...raftfsm.CommittedEntryV1) ([]raftentry.ApplyResultV1, error) {
+	if n == nil || n.fsm == nil || n.closed {
+		return nil, fmt.Errorf("%w: closed node", ErrNodeNotFound)
+	}
+	return n.fsm.ApplyCommittedEntriesV1(entries)
+}
+
+func (n *Node) close() error {
+	if n == nil || n.closed {
+		return nil
+	}
+	n.closed = true
+	return errors.Join(n.fsm.Close(), n.db.Close())
+}
+
+func normalizeNodeConfigs(configs []NodeConfig) ([]NodeConfig, error) {
+	if len(configs) == 0 {
+		configs = []NodeConfig{
+			{ID: "node-a"},
+			{ID: "node-b"},
+			{ID: "node-c"},
+		}
+	}
+	out := make([]NodeConfig, 0, len(configs))
+	seen := make(map[raftcluster.NodeID]struct{}, len(configs))
+	for _, cfg := range configs {
+		if cfg.ID == "" {
+			return nil, fmt.Errorf("raftharness: missing node id")
+		}
+		if _, ok := seen[cfg.ID]; ok {
+			return nil, fmt.Errorf("raftharness: duplicate node id %s", cfg.ID)
+		}
+		seen[cfg.ID] = struct{}{}
+		if cfg.Address == "" {
+			cfg.Address = "inprocess://" + string(cfg.ID)
+		}
+		out = append(out, cfg)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
+	return out, nil
+}
+
+func peersForNodeConfigs(configs []NodeConfig) []raftcluster.Peer {
+	peers := make([]raftcluster.Peer, 0, len(configs))
+	for _, cfg := range configs {
+		peers = append(peers, raftcluster.Peer{ID: cfg.ID, Address: cfg.Address})
+	}
+	return peers
+}
+
+func applyEntryIDs(entries []raftfsm.CommittedEntryV1) []raftentry.ApplyEntryID {
+	ids := make([]raftentry.ApplyEntryID, 0, len(entries))
+	for _, entry := range entries {
+		ids = append(ids, raftentry.ApplyEntryID{Term: entry.Term, Index: entry.Index})
+	}
+	return ids
+}
+
+func cloneCommittedEntry(entry raftfsm.CommittedEntryV1) raftfsm.CommittedEntryV1 {
+	entry.Bytes = bytes.Clone(entry.Bytes)
+	entry.RequestMetadata.TraceContext = bytes.Clone(entry.RequestMetadata.TraceContext)
+	if entry.ExpectedTarget != nil {
+		target := entry.ExpectedTarget.Clone()
+		entry.ExpectedTarget = &target
+	}
+	return entry
+}
+
+func committedEntriesEqual(a, b raftfsm.CommittedEntryV1) bool {
+	if a.Type != b.Type ||
+		a.Term != b.Term ||
+		a.Index != b.Index ||
+		a.CurrentCatalogVersion != b.CurrentCatalogVersion ||
+		a.HasCurrentCatalogVersion != b.HasCurrentCatalogVersion ||
+		a.SyncLocalCommandWAL != b.SyncLocalCommandWAL ||
+		a.RequestMetadata.RequestID != b.RequestMetadata.RequestID ||
+		a.RequestMetadata.AckPolicy != b.RequestMetadata.AckPolicy ||
+		a.RequestMetadata.DeadlineUnixNanos != b.RequestMetadata.DeadlineUnixNanos ||
+		a.RequestMetadata.Compression != b.RequestMetadata.Compression ||
+		a.RequestMetadata.OmitResultIDs != b.RequestMetadata.OmitResultIDs ||
+		a.RequestMetadata.OmitResponseMeta != b.RequestMetadata.OmitResponseMeta ||
+		!bytes.Equal(a.RequestMetadata.TraceContext, b.RequestMetadata.TraceContext) ||
+		!bytes.Equal(a.Bytes, b.Bytes) {
+		return false
+	}
+	switch {
+	case a.ExpectedTarget == nil && b.ExpectedTarget == nil:
+		return true
+	case a.ExpectedTarget == nil || b.ExpectedTarget == nil:
+		return false
+	default:
+		return a.ExpectedTarget.Equal(*b.ExpectedTarget)
+	}
+}

--- a/TreeDB/internal/raftharness/harness.go
+++ b/TreeDB/internal/raftharness/harness.go
@@ -27,6 +27,7 @@ const (
 
 var (
 	ErrNodeNotFound         = errors.New("raftharness: node not found")
+	ErrHarnessClosed        = errors.New("raftharness: harness closed")
 	ErrCommittedLogGap      = errors.New("raftharness: committed log gap")
 	ErrCommittedLogConflict = errors.New("raftharness: committed log conflict")
 )
@@ -147,6 +148,9 @@ func (h *Harness) Node(id raftcluster.NodeID) (*Node, bool) {
 func (h *Harness) CloseNode(id raftcluster.NodeID) error {
 	h.mu.Lock()
 	defer h.mu.Unlock()
+	if h.closed {
+		return ErrHarnessClosed
+	}
 	node, ok := h.nodes[id]
 	if !ok {
 		return fmt.Errorf("%w: %s", ErrNodeNotFound, id)
@@ -157,6 +161,9 @@ func (h *Harness) CloseNode(id raftcluster.NodeID) error {
 func (h *Harness) ReopenNode(id raftcluster.NodeID) (*Node, error) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
+	if h.closed {
+		return nil, ErrHarnessClosed
+	}
 	for _, cfg := range h.nodeConfigs {
 		if cfg.ID != id {
 			continue
@@ -194,6 +201,9 @@ func (h *Harness) Commit(entries ...raftfsm.CommittedEntryV1) (CommitEvidenceV1,
 		ProductionConsensus: false,
 		EntryIDs:            applyEntryIDs(entries),
 	}
+	if h.closed {
+		return evidence, ErrHarnessClosed
+	}
 	staged := make([]raftfsm.CommittedEntryV1, len(h.committed), len(h.committed)+len(entries))
 	copy(staged, h.committed)
 	for _, entry := range entries {
@@ -225,23 +235,47 @@ func (h *Harness) CommitAndApply(nodeIDs []raftcluster.NodeID, entries ...raftfs
 }
 
 func (h *Harness) ApplyCommittedEntriesToNode(id raftcluster.NodeID, entries ...raftfsm.CommittedEntryV1) ([]raftentry.ApplyResultV1, error) {
-	node, ok := h.Node(id)
-	if !ok {
-		return nil, fmt.Errorf("%w: %s", ErrNodeNotFound, id)
+	node, err := h.nodeForApply(id)
+	if err != nil {
+		return nil, err
 	}
 	return node.ApplyCommittedEntriesV1(entries...)
 }
 
-func (h *Harness) CatchUpNode(id raftcluster.NodeID) ([]raftentry.ApplyResultV1, error) {
-	node, ok := h.Node(id)
+func (h *Harness) nodeForApply(id raftcluster.NodeID) (*Node, error) {
+	if h == nil {
+		return nil, ErrHarnessClosed
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.closed {
+		return nil, ErrHarnessClosed
+	}
+	node, ok := h.nodes[id]
 	if !ok {
+		return nil, fmt.Errorf("%w: %s", ErrNodeNotFound, id)
+	}
+	return node, nil
+}
+
+func (h *Harness) CatchUpNode(id raftcluster.NodeID) ([]raftentry.ApplyResultV1, error) {
+	if h == nil {
+		return nil, ErrHarnessClosed
+	}
+	h.mu.Lock()
+	if h.closed {
+		h.mu.Unlock()
+		return nil, ErrHarnessClosed
+	}
+	node, ok := h.nodes[id]
+	if !ok {
+		h.mu.Unlock()
 		return nil, fmt.Errorf("%w: %s", ErrNodeNotFound, id)
 	}
 	var after uint64
 	if last, ok := node.LastApplied(); ok {
 		after = last.Index
 	}
-	h.mu.Lock()
 	entries := make([]raftfsm.CommittedEntryV1, 0, len(h.committed))
 	for _, entry := range h.committed {
 		if entry.Index > after {

--- a/TreeDB/internal/raftharness/harness.go
+++ b/TreeDB/internal/raftharness/harness.go
@@ -193,11 +193,16 @@ func (h *Harness) Commit(entries ...raftfsm.CommittedEntryV1) (CommitEvidenceV1,
 		ProductionConsensus: false,
 		EntryIDs:            applyEntryIDs(entries),
 	}
+	staged := make([]raftfsm.CommittedEntryV1, len(h.committed), len(h.committed)+len(entries))
+	copy(staged, h.committed)
 	for _, entry := range entries {
-		if err := h.appendCommittedLocked(entry); err != nil {
+		next, err := appendCommitted(staged, entry)
+		if err != nil {
 			return evidence, err
 		}
+		staged = next
 	}
+	h.committed = staged
 	evidence.Committed = len(entries) > 0
 	return evidence, nil
 }
@@ -276,24 +281,29 @@ func (h *Harness) openNode(cfg NodeConfig) (*Node, error) {
 	return &Node{id: cfg.ID, db: db, fsm: fsm}, nil
 }
 
-func (h *Harness) appendCommittedLocked(entry raftfsm.CommittedEntryV1) error {
+func appendCommitted(committed []raftfsm.CommittedEntryV1, entry raftfsm.CommittedEntryV1) ([]raftfsm.CommittedEntryV1, error) {
 	id := raftentry.ApplyEntryID{Term: entry.Term, Index: entry.Index}
 	if id.Term == 0 || id.Index == 0 {
-		return fmt.Errorf("%w: invalid committed id %+v", ErrCommittedLogGap, id)
+		return nil, fmt.Errorf("%w: invalid committed id %+v", ErrCommittedLogGap, id)
 	}
-	wantNext := uint64(len(h.committed) + 1)
+	wantNext := uint64(len(committed) + 1)
 	if id.Index > wantNext {
-		return fmt.Errorf("%w: got index %d after %d", ErrCommittedLogGap, id.Index, len(h.committed))
+		return nil, fmt.Errorf("%w: got index %d after %d", ErrCommittedLogGap, id.Index, len(committed))
 	}
 	if id.Index < wantNext {
-		existing := h.committed[id.Index-1]
+		existing := committed[id.Index-1]
 		if !committedEntriesEqual(existing, entry) {
-			return fmt.Errorf("%w: divergent entry at index %d", ErrCommittedLogConflict, id.Index)
+			return nil, fmt.Errorf("%w: divergent entry at index %d", ErrCommittedLogConflict, id.Index)
 		}
-		return nil
+		return committed, nil
 	}
-	h.committed = append(h.committed, cloneCommittedEntry(entry))
-	return nil
+	if len(committed) > 0 {
+		previous := committed[len(committed)-1]
+		if id.Term < previous.Term {
+			return nil, fmt.Errorf("%w: term regression at index %d: term %d after term %d", ErrCommittedLogConflict, id.Index, id.Term, previous.Term)
+		}
+	}
+	return append(committed, cloneCommittedEntry(entry)), nil
 }
 
 func (n *Node) ID() raftcluster.NodeID {

--- a/TreeDB/internal/raftharness/harness.go
+++ b/TreeDB/internal/raftharness/harness.go
@@ -273,6 +273,7 @@ func (h *Harness) CatchUpNode(id raftcluster.NodeID) ([]raftentry.ApplyResultV1,
 		return nil, fmt.Errorf("%w: %s", ErrNodeNotFound, id)
 	}
 	start := 0
+	var prefix []raftfsm.CommittedEntryV1
 	if last, ok := node.LastApplied(); ok {
 		if last.Index == 0 {
 			h.mu.Unlock()
@@ -283,12 +284,22 @@ func (h *Harness) CatchUpNode(id raftcluster.NodeID) ([]raftentry.ApplyResultV1,
 			return nil, fmt.Errorf("%w: node %s last applied index %d beyond committed log length %d", ErrCommittedLogConflict, id, last.Index, len(h.committed))
 		}
 		start = int(last.Index - 1)
+		prefix = make([]raftfsm.CommittedEntryV1, 0, last.Index)
+		for _, entry := range h.committed[:last.Index] {
+			prefix = append(prefix, cloneCommittedEntry(entry))
+		}
 	}
 	entries := make([]raftfsm.CommittedEntryV1, 0, len(h.committed)-start)
 	for _, entry := range h.committed[start:] {
 		entries = append(entries, cloneCommittedEntry(entry))
 	}
 	h.mu.Unlock()
+	if len(prefix) > 0 {
+		result, err := node.fsm.ValidateAppliedPrefixV1(prefix)
+		if err != nil {
+			return []raftentry.ApplyResultV1{result}, err
+		}
+	}
 	return node.ApplyCommittedEntriesV1(entries...)
 }
 

--- a/TreeDB/internal/raftharness/harness_test.go
+++ b/TreeDB/internal/raftharness/harness_test.go
@@ -3,6 +3,7 @@ package raftharness
 import (
 	"encoding/binary"
 	"errors"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -286,6 +287,30 @@ func TestMixedMutationSequenceSurvivesReopenAndCatchUp(t *testing.T) {
 	assertDocumentCity(t, h, "node-b", "users", "u1", "sfo")
 	assertDocumentMissing(t, h, "node-a", "users", "u2")
 	assertDocumentMissing(t, h, "node-b", "users", "u2")
+}
+
+func TestOpenRejectsInvalidNodeIDBeforeOpeningPath(t *testing.T) {
+	base := t.TempDir()
+	root := filepath.Join(base, "root")
+	escaped := filepath.Join(base, "outside")
+	h, err := Open(Options{
+		RootDir: root,
+		Nodes: []NodeConfig{
+			{ID: "../../outside"},
+		},
+		StoreOptions: raftapply.DurableApplyStoreOptions{
+			DisableSync: true,
+		},
+	})
+	if err == nil {
+		if h != nil {
+			_ = h.Close()
+		}
+		t.Fatalf("Open with invalid node id succeeded, want error")
+	}
+	if _, statErr := os.Stat(escaped); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("escaped node path stat err=%v, want not exist", statErr)
+	}
 }
 
 func openTestHarness(t testing.TB) *Harness {

--- a/TreeDB/internal/raftharness/harness_test.go
+++ b/TreeDB/internal/raftharness/harness_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/snissn/gomap/TreeDB/collections"
@@ -145,12 +146,22 @@ func TestFollowerCatchUpAppliesMissingContiguousEntriesAndRejectsInvalidSequence
 	}
 
 	gapResults, err := bad.ApplyCommittedEntriesToNode("node-b", entries[2])
-	assertRejectedResult(t, "gap catch-up", gapResults, err, raftentry.ErrorRejectedConflictV1)
+	if !errors.Is(err, ErrCommittedLogGap) {
+		t.Fatalf("gap apply err=%v results=%+v, want ErrCommittedLogGap", err, gapResults)
+	}
+	if len(gapResults) != 0 {
+		t.Fatalf("gap apply results=%+v, want none before node mutation", gapResults)
+	}
 	assertLastApplied(t, bad, "node-b", raftentry.ApplyEntryID{Term: 13, Index: 1})
 	assertCollectionMissing(t, bad, "node-b", "orders")
 
 	divergentResults, err := bad.ApplyCommittedEntriesToNode("node-b", divergent)
-	assertRejectedResult(t, "divergent duplicate catch-up", divergentResults, err, raftentry.ErrorRejectedConflictV1)
+	if !errors.Is(err, ErrCommittedLogConflict) {
+		t.Fatalf("divergent apply err=%v results=%+v, want ErrCommittedLogConflict", err, divergentResults)
+	}
+	if len(divergentResults) != 0 {
+		t.Fatalf("divergent apply results=%+v, want none before node mutation", divergentResults)
+	}
 	assertLastApplied(t, bad, "node-b", raftentry.ApplyEntryID{Term: 13, Index: 1})
 	assertCollectionMissing(t, bad, "node-b", "admins")
 }
@@ -164,10 +175,7 @@ func TestCatchUpNodeRejectsDivergentLastAppliedEntry(t *testing.T) {
 		committedCommand(19, 2, deterministicCreateCollectionEntry(t, "orders", "harness:create:orders:after-divergence")),
 	}
 	divergent := committedCommand(19, 1, deterministicCreateCollectionEntry(t, "admins", "harness:create:admins:divergent-last"))
-	seeded, err := h.ApplyCommittedEntriesToNode("node-b", divergent)
-	if err != nil {
-		t.Fatalf("seed divergent follower: %v results=%+v", err, seeded)
-	}
+	seeded := applyEntriesDirectlyToNode(t, h, "node-b", divergent)
 	assertAppliedResults(t, "node-b divergent seed", seeded, []int64{1})
 	if _, err := h.Commit(committed...); err != nil {
 		t.Fatalf("Commit committed log: %v", err)
@@ -195,10 +203,7 @@ func TestCatchUpNodeRejectsDivergentAppliedPrefix(t *testing.T) {
 		committedCommand(20, 2, deterministicCreateCollectionEntry(t, "admins", "harness:create:admins:divergent-prefix")),
 		committed[2],
 	}
-	seeded, err := h.ApplyCommittedEntriesToNode("node-b", divergent...)
-	if err != nil {
-		t.Fatalf("seed divergent prefix follower: %v results=%+v", err, seeded)
-	}
+	seeded := applyEntriesDirectlyToNode(t, h, "node-b", divergent...)
 	assertAppliedResults(t, "node-b divergent prefix seed", seeded, []int64{1, 1, 1})
 	if _, err := h.Commit(committed...); err != nil {
 		t.Fatalf("Commit committed log: %v", err)
@@ -209,6 +214,63 @@ func TestCatchUpNodeRejectsDivergentAppliedPrefix(t *testing.T) {
 	assertLastApplied(t, h, "node-b", raftentry.ApplyEntryID{Term: 20, Index: 3})
 	assertCollectionMissing(t, h, "node-b", "orders")
 	assertCollectionMissing(t, h, "node-b", "products")
+}
+
+func TestCatchUpNodeRejectsAppliedPrefixTermMismatch(t *testing.T) {
+	h := openTestHarness(t)
+	defer func() { _ = h.Close() }()
+
+	createUsers := deterministicCreateCollectionEntry(t, "users", "harness:create:users:term-prefix")
+	createOrders := deterministicCreateCollectionEntry(t, "orders", "harness:create:orders:term-prefix")
+	local := []raftfsm.CommittedEntryV1{
+		committedCommand(21, 1, createUsers),
+		committedCommand(21, 2, createOrders),
+	}
+	committed := []raftfsm.CommittedEntryV1{
+		committedCommand(20, 1, createUsers),
+		committedCommand(20, 2, createOrders),
+		committedCommand(21, 3, deterministicCreateCollectionEntry(t, "audits", "harness:create:audits:term-prefix")),
+	}
+	seeded := applyEntriesDirectlyToNode(t, h, "node-b", local...)
+	assertAppliedResults(t, "node-b term-mismatch prefix seed", seeded, []int64{1, 1})
+	if _, err := h.Commit(committed...); err != nil {
+		t.Fatalf("Commit committed log: %v", err)
+	}
+
+	catchup, err := h.CatchUpNode("node-b")
+	assertRejectedResult(t, "term-mismatch applied-prefix catch-up", catchup, err, raftentry.ErrorRejectedConflictV1)
+	assertLastApplied(t, h, "node-b", raftentry.ApplyEntryID{Term: 21, Index: 2})
+	assertCollectionMissing(t, h, "node-b", "audits")
+}
+
+func TestCatchUpNodeRejectsLastAppliedBeyondCommittedLog(t *testing.T) {
+	h := openTestHarness(t)
+	defer func() { _ = h.Close() }()
+
+	entries := []raftfsm.CommittedEntryV1{
+		committedCommand(22, 1, deterministicCreateCollectionEntry(t, "users", "harness:create:users:short-log")),
+		committedCommand(22, 2, deterministicCreateCollectionEntry(t, "orders", "harness:create:orders:short-log")),
+	}
+	if _, err := h.Commit(entries...); err != nil {
+		t.Fatalf("Commit committed log: %v", err)
+	}
+	seeded, err := h.ApplyCommittedEntriesToNode("node-b", entries...)
+	if err != nil {
+		t.Fatalf("seed follower through committed log: %v results=%+v", err, seeded)
+	}
+	assertAppliedResults(t, "node-b shortened-log seed", seeded, []int64{1, 1})
+	h.mu.Lock()
+	h.committed = h.committed[:1]
+	h.mu.Unlock()
+
+	catchup, err := h.CatchUpNode("node-b")
+	if !errors.Is(err, ErrCommittedLogConflict) {
+		t.Fatalf("CatchUpNode shortened log err=%v results=%+v, want ErrCommittedLogConflict", err, catchup)
+	}
+	if len(catchup) != 0 {
+		t.Fatalf("CatchUpNode shortened log results=%+v, want none", catchup)
+	}
+	assertLastApplied(t, h, "node-b", raftentry.ApplyEntryID{Term: 22, Index: 2})
 }
 
 func TestCommitRejectsInvalidBatchAtomically(t *testing.T) {
@@ -369,6 +431,9 @@ func TestOpenRejectsInvalidNodeIDBeforeOpeningPath(t *testing.T) {
 		}
 		t.Fatalf("Open with invalid node id succeeded, want error")
 	}
+	if got := err.Error(); !strings.Contains(got, "invalid node id") || !strings.Contains(got, "unsupported character '/'") {
+		t.Fatalf("Open err=%v, want invalid-node-id path-segment diagnostic", err)
+	}
 	if _, statErr := os.Stat(escaped); !errors.Is(statErr, os.ErrNotExist) {
 		t.Fatalf("escaped node path stat err=%v, want not exist", statErr)
 	}
@@ -421,6 +486,19 @@ func openTestHarnessAt(t testing.TB, root string) *Harness {
 		t.Fatalf("Open harness: %v", err)
 	}
 	return h
+}
+
+func applyEntriesDirectlyToNode(t testing.TB, h *Harness, nodeID raftcluster.NodeID, entries ...raftfsm.CommittedEntryV1) []raftentry.ApplyResultV1 {
+	t.Helper()
+	node, ok := h.Node(nodeID)
+	if !ok {
+		t.Fatalf("node %s not found", nodeID)
+	}
+	results, err := node.ApplyCommittedEntriesV1(entries...)
+	if err != nil {
+		t.Fatalf("directly apply entries to %s: %v results=%+v", nodeID, err, results)
+	}
+	return results
 }
 
 func mixedUserEntries(t *testing.T, term uint64) []raftfsm.CommittedEntryV1 {

--- a/TreeDB/internal/raftharness/harness_test.go
+++ b/TreeDB/internal/raftharness/harness_test.go
@@ -113,14 +113,19 @@ func TestFollowerCatchUpAppliesMissingContiguousEntriesAndRejectsInvalidSequence
 	if evidence, err := h.CommitAndApply([]raftcluster.NodeID{"node-a"}, entries...); err != nil {
 		t.Fatalf("CommitAndApply leader: %v evidence=%+v", err, evidence)
 	}
-	if results, err := h.ApplyCommittedEntriesToNode("node-b", entries[0]); err != nil {
-		t.Fatalf("seed follower: %v results=%+v", err, results)
+	seeded, err := h.ApplyCommittedEntriesToNode("node-b", entries[0])
+	if err != nil {
+		t.Fatalf("seed follower: %v results=%+v", err, seeded)
 	}
+	assertAppliedResults(t, "node-b seed", seeded, []int64{1})
 	catchup, err := h.CatchUpNode("node-b")
 	if err != nil {
 		t.Fatalf("CatchUpNode: %v results=%+v", err, catchup)
 	}
-	assertAppliedResults(t, "node-b catchup", catchup, []int64{1, 1})
+	assertAppliedResults(t, "node-b catchup", catchup, []int64{1, 1, 1})
+	if catchup[0] != seeded[0] {
+		t.Fatalf("node-b catchup first result=%+v, want replayed last result %+v", catchup[0], seeded[0])
+	}
 	assertLastApplied(t, h, "node-b", raftentry.ApplyEntryID{Term: 14, Index: 3})
 	if leaderDigest, followerDigest := logicalDigest(t, h, "node-a"), logicalDigest(t, h, "node-b"); leaderDigest != followerDigest {
 		t.Fatalf("digest after catch-up mismatch leader=%s follower=%s", leaderDigest.Hex(), followerDigest.Hex())
@@ -148,6 +153,31 @@ func TestFollowerCatchUpAppliesMissingContiguousEntriesAndRejectsInvalidSequence
 	assertRejectedResult(t, "divergent duplicate catch-up", divergentResults, err, raftentry.ErrorRejectedConflictV1)
 	assertLastApplied(t, bad, "node-b", raftentry.ApplyEntryID{Term: 13, Index: 1})
 	assertCollectionMissing(t, bad, "node-b", "admins")
+}
+
+func TestCatchUpNodeRejectsDivergentLastAppliedEntry(t *testing.T) {
+	h := openTestHarness(t)
+	defer func() { _ = h.Close() }()
+
+	committed := []raftfsm.CommittedEntryV1{
+		committedCommand(19, 1, deterministicCreateCollectionEntry(t, "users", "harness:create:users:committed")),
+		committedCommand(19, 2, deterministicCreateCollectionEntry(t, "orders", "harness:create:orders:after-divergence")),
+	}
+	divergent := committedCommand(19, 1, deterministicCreateCollectionEntry(t, "admins", "harness:create:admins:divergent-last"))
+	seeded, err := h.ApplyCommittedEntriesToNode("node-b", divergent)
+	if err != nil {
+		t.Fatalf("seed divergent follower: %v results=%+v", err, seeded)
+	}
+	assertAppliedResults(t, "node-b divergent seed", seeded, []int64{1})
+	if _, err := h.Commit(committed...); err != nil {
+		t.Fatalf("Commit committed log: %v", err)
+	}
+
+	catchup, err := h.CatchUpNode("node-b")
+	assertRejectedResult(t, "divergent last-applied catch-up", catchup, err, raftentry.ErrorRejectedConflictV1)
+	assertLastApplied(t, h, "node-b", raftentry.ApplyEntryID{Term: 19, Index: 1})
+	assertCollectionMissing(t, h, "node-b", "users")
+	assertCollectionMissing(t, h, "node-b", "orders")
 }
 
 func TestCommitRejectsInvalidBatchAtomically(t *testing.T) {

--- a/TreeDB/internal/raftharness/harness_test.go
+++ b/TreeDB/internal/raftharness/harness_test.go
@@ -149,6 +149,70 @@ func TestFollowerCatchUpAppliesMissingContiguousEntriesAndRejectsInvalidSequence
 	assertCollectionMissing(t, bad, "node-b", "admins")
 }
 
+func TestCommitRejectsInvalidBatchAtomically(t *testing.T) {
+	h := openTestHarness(t)
+	defer func() { _ = h.Close() }()
+
+	valid := committedCommand(16, 1, deterministicCreateCollectionEntry(t, "users", "harness:create:users:atomic"))
+	gap := committedCommand(16, 3, deterministicCreateCollectionEntry(t, "orders", "harness:create:orders:atomic-gap"))
+	evidence, err := h.Commit(valid, gap)
+	if !errors.Is(err, ErrCommittedLogGap) {
+		t.Fatalf("Commit invalid batch err=%v, want ErrCommittedLogGap evidence=%+v", err, evidence)
+	}
+	if evidence.Committed {
+		t.Fatalf("Commit invalid batch evidence=%+v, want not committed", evidence)
+	}
+	catchup, err := h.CatchUpNode("node-a")
+	if err != nil {
+		t.Fatalf("CatchUpNode after rejected batch: %v results=%+v", err, catchup)
+	}
+	if len(catchup) != 0 {
+		t.Fatalf("CatchUpNode after rejected batch results=%+v, want no committed entries", catchup)
+	}
+	assertNoLastApplied(t, h, "node-a")
+	assertCollectionMissing(t, h, "node-a", "users")
+	assertCollectionMissing(t, h, "node-a", "orders")
+}
+
+func TestCommitRejectsTermRegressionBeforeMutation(t *testing.T) {
+	h := openTestHarness(t)
+	defer func() { _ = h.Close() }()
+
+	highTerm := committedCommand(5, 1, deterministicCreateCollectionEntry(t, "users", "harness:create:users:term-regression"))
+	lowerTerm := committedCommand(4, 2, deterministicCreateCollectionEntry(t, "orders", "harness:create:orders:term-regression"))
+	evidence, err := h.Commit(highTerm, lowerTerm)
+	if !errors.Is(err, ErrCommittedLogConflict) {
+		t.Fatalf("Commit term regression batch err=%v, want ErrCommittedLogConflict evidence=%+v", err, evidence)
+	}
+	if evidence.Committed {
+		t.Fatalf("Commit term regression batch evidence=%+v, want not committed", evidence)
+	}
+	catchup, err := h.CatchUpNode("node-a")
+	if err != nil {
+		t.Fatalf("CatchUpNode after rejected term regression: %v results=%+v", err, catchup)
+	}
+	if len(catchup) != 0 {
+		t.Fatalf("CatchUpNode after rejected term regression results=%+v, want no committed entries", catchup)
+	}
+	assertNoLastApplied(t, h, "node-a")
+	assertCollectionMissing(t, h, "node-a", "users")
+	assertCollectionMissing(t, h, "node-a", "orders")
+
+	if _, err := h.Commit(highTerm); err != nil {
+		t.Fatalf("Commit high-term seed after rejected batch: %v", err)
+	}
+	if _, err := h.Commit(lowerTerm); !errors.Is(err, ErrCommittedLogConflict) {
+		t.Fatalf("Commit lower-term continuation err=%v, want ErrCommittedLogConflict", err)
+	}
+	catchup, err = h.CatchUpNode("node-a")
+	if err != nil {
+		t.Fatalf("CatchUpNode after rejected continuation: %v results=%+v", err, catchup)
+	}
+	assertAppliedResults(t, "node-a catchup after rejected continuation", catchup, []int64{1})
+	assertLastApplied(t, h, "node-a", raftentry.ApplyEntryID{Term: 5, Index: 1})
+	assertCollectionMissing(t, h, "node-a", "orders")
+}
+
 func TestPostCommitCrashReadableAndPreCommitCrashNoSuccess(t *testing.T) {
 	h := openTestHarness(t)
 	defer func() { _ = h.Close() }()
@@ -188,6 +252,40 @@ func TestPostCommitCrashReadableAndPreCommitCrashNoSuccess(t *testing.T) {
 		assertDocumentCity(t, h, nodeID, "users", "u1", "hnl")
 		assertLastApplied(t, h, nodeID, raftentry.ApplyEntryID{Term: 15, Index: 2})
 	}
+}
+
+func TestMixedMutationSequenceSurvivesReopenAndCatchUp(t *testing.T) {
+	h := openTestHarness(t)
+	defer func() { _ = h.Close() }()
+
+	entries := mixedUserEntries(t, 17)
+	evidence, err := h.CommitAndApply([]raftcluster.NodeID{"node-a"}, entries...)
+	if err != nil {
+		t.Fatalf("CommitAndApply mixed sequence: %v evidence=%+v", err, evidence)
+	}
+	assertInjectedCommittedEvidence(t, evidence)
+	assertAppliedResults(t, "node-a mixed sequence", evidence.Applied["node-a"], []int64{1, 2, 1, 1})
+	if err := h.CloseNode("node-a"); err != nil {
+		t.Fatalf("CloseNode node-a: %v", err)
+	}
+	if _, err := h.ReopenNode("node-a"); err != nil {
+		t.Fatalf("ReopenNode node-a: %v", err)
+	}
+	assertLastApplied(t, h, "node-a", raftentry.ApplyEntryID{Term: 17, Index: 4})
+
+	catchup, err := h.CatchUpNode("node-b")
+	if err != nil {
+		t.Fatalf("CatchUpNode node-b: %v results=%+v", err, catchup)
+	}
+	assertAppliedResults(t, "node-b mixed catchup", catchup, []int64{1, 2, 1, 1})
+	assertLastApplied(t, h, "node-b", raftentry.ApplyEntryID{Term: 17, Index: 4})
+	if leaderDigest, followerDigest := logicalDigest(t, h, "node-a"), logicalDigest(t, h, "node-b"); leaderDigest != followerDigest {
+		t.Fatalf("digest after mixed reopen/catch-up mismatch leader=%s follower=%s", leaderDigest.Hex(), followerDigest.Hex())
+	}
+	assertDocumentCity(t, h, "node-a", "users", "u1", "sfo")
+	assertDocumentCity(t, h, "node-b", "users", "u1", "sfo")
+	assertDocumentMissing(t, h, "node-a", "users", "u2")
+	assertDocumentMissing(t, h, "node-b", "users", "u2")
 }
 
 func openTestHarness(t testing.TB) *Harness {
@@ -413,6 +511,17 @@ func assertLastApplied(t *testing.T, h *Harness, nodeID raftcluster.NodeID, want
 	}
 }
 
+func assertNoLastApplied(t *testing.T, h *Harness, nodeID raftcluster.NodeID) {
+	t.Helper()
+	node, ok := h.Node(nodeID)
+	if !ok {
+		t.Fatalf("node %s not found", nodeID)
+	}
+	if got, ok := node.LastApplied(); ok {
+		t.Fatalf("%s LastApplied=(%+v,%t), want none", nodeID, got, ok)
+	}
+}
+
 func logicalDigest(t *testing.T, h *Harness, nodeID raftcluster.NodeID) raftapply.LogicalDigestV1 {
 	t.Helper()
 	node, ok := h.Node(nodeID)
@@ -457,5 +566,24 @@ func assertDocumentCity(t *testing.T, h *Harness, nodeID raftcluster.NodeID, col
 	}
 	if city := bson.Raw(got).Lookup("city").StringValue(); city != wantCity {
 		t.Fatalf("%s %s.Get(%q).city=%q, want %q", nodeID, collection, id, city, wantCity)
+	}
+}
+
+func assertDocumentMissing(t *testing.T, h *Harness, nodeID raftcluster.NodeID, collection, id string) {
+	t.Helper()
+	node, ok := h.Node(nodeID)
+	if !ok {
+		t.Fatalf("node %s not found", nodeID)
+	}
+	opened, err := collections.NewCollectionManager(node.DB()).OpenCollection(collection)
+	if err != nil {
+		t.Fatalf("%s OpenCollection %s: %v", nodeID, collection, err)
+	}
+	got, err := opened.Get([]byte(id))
+	if err != nil {
+		t.Fatalf("%s %s.Get(%q): %v", nodeID, collection, id, err)
+	}
+	if got != nil {
+		t.Fatalf("%s %s.Get(%q)=%x, want missing document", nodeID, collection, id, got)
 	}
 }

--- a/TreeDB/internal/raftharness/harness_test.go
+++ b/TreeDB/internal/raftharness/harness_test.go
@@ -180,6 +180,37 @@ func TestCatchUpNodeRejectsDivergentLastAppliedEntry(t *testing.T) {
 	assertCollectionMissing(t, h, "node-b", "orders")
 }
 
+func TestCatchUpNodeRejectsDivergentAppliedPrefix(t *testing.T) {
+	h := openTestHarness(t)
+	defer func() { _ = h.Close() }()
+
+	committed := []raftfsm.CommittedEntryV1{
+		committedCommand(20, 1, deterministicCreateCollectionEntry(t, "users", "harness:create:users:prefix")),
+		committedCommand(20, 2, deterministicCreateCollectionEntry(t, "orders", "harness:create:orders:prefix")),
+		committedCommand(20, 3, deterministicCreateCollectionEntry(t, "audits", "harness:create:audits:prefix")),
+		committedCommand(20, 4, deterministicCreateCollectionEntry(t, "products", "harness:create:products:prefix")),
+	}
+	divergent := []raftfsm.CommittedEntryV1{
+		committed[0],
+		committedCommand(20, 2, deterministicCreateCollectionEntry(t, "admins", "harness:create:admins:divergent-prefix")),
+		committed[2],
+	}
+	seeded, err := h.ApplyCommittedEntriesToNode("node-b", divergent...)
+	if err != nil {
+		t.Fatalf("seed divergent prefix follower: %v results=%+v", err, seeded)
+	}
+	assertAppliedResults(t, "node-b divergent prefix seed", seeded, []int64{1, 1, 1})
+	if _, err := h.Commit(committed...); err != nil {
+		t.Fatalf("Commit committed log: %v", err)
+	}
+
+	catchup, err := h.CatchUpNode("node-b")
+	assertRejectedResult(t, "divergent applied-prefix catch-up", catchup, err, raftentry.ErrorRejectedConflictV1)
+	assertLastApplied(t, h, "node-b", raftentry.ApplyEntryID{Term: 20, Index: 3})
+	assertCollectionMissing(t, h, "node-b", "orders")
+	assertCollectionMissing(t, h, "node-b", "products")
+}
+
 func TestCommitRejectsInvalidBatchAtomically(t *testing.T) {
 	h := openTestHarness(t)
 	defer func() { _ = h.Close() }()

--- a/TreeDB/internal/raftharness/harness_test.go
+++ b/TreeDB/internal/raftharness/harness_test.go
@@ -1,0 +1,461 @@
+package raftharness
+
+import (
+	"encoding/binary"
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/collections"
+	"github.com/snissn/gomap/TreeDB/internal/nativewire"
+	"github.com/snissn/gomap/TreeDB/internal/raftapply"
+	"github.com/snissn/gomap/TreeDB/internal/raftcluster"
+	"github.com/snissn/gomap/TreeDB/internal/raftentry"
+	"github.com/snissn/gomap/TreeDB/internal/raftfsm"
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+const (
+	testCatalogVersionStart        = 7
+	deterministicCollectionRefName = 1
+)
+
+func TestInjectedCommittedSequenceConvergesLeaderFollowerDigest(t *testing.T) {
+	h := openTestHarness(t)
+	defer func() { _ = h.Close() }()
+
+	entries := mixedUserEntries(t, 11)
+	evidence, err := h.CommitAndApply([]raftcluster.NodeID{"node-a", "node-b"}, entries...)
+	if err != nil {
+		t.Fatalf("CommitAndApply: %v evidence=%+v", err, evidence)
+	}
+	assertInjectedCommittedEvidence(t, evidence)
+	for nodeID, results := range evidence.Applied {
+		assertAppliedResults(t, nodeID, results, []int64{1, 2, 1, 1})
+	}
+	assertLastApplied(t, h, "node-a", raftentry.ApplyEntryID{Term: 11, Index: 4})
+	assertLastApplied(t, h, "node-b", raftentry.ApplyEntryID{Term: 11, Index: 4})
+
+	leaderDigest := logicalDigest(t, h, "node-a")
+	followerDigest := logicalDigest(t, h, "node-b")
+	if leaderDigest != followerDigest {
+		t.Fatalf("leader/follower digest mismatch leader=%s follower=%s", leaderDigest.Hex(), followerDigest.Hex())
+	}
+}
+
+func TestCloseReopenPreservesProgressReplayAndIdempotency(t *testing.T) {
+	h := openTestHarness(t)
+	defer func() { _ = h.Close() }()
+
+	raw := deterministicCreateCollectionEntry(t, "users", "harness:create:users:reopen")
+	entry1 := committedCommand(12, 1, raw)
+	evidence, err := h.CommitAndApply([]raftcluster.NodeID{"node-a"}, entry1)
+	if err != nil {
+		t.Fatalf("CommitAndApply entry1: %v evidence=%+v", err, evidence)
+	}
+	first := evidence.Applied["node-a"][0]
+	assertAppliedResult(t, first, raftentry.ApplyStatusApplied, 1)
+	if err := h.CloseNode("node-a"); err != nil {
+		t.Fatalf("CloseNode: %v", err)
+	}
+	if _, err := h.ReopenNode("node-a"); err != nil {
+		t.Fatalf("ReopenNode: %v", err)
+	}
+	assertLastApplied(t, h, "node-a", raftentry.ApplyEntryID{Term: 12, Index: 1})
+
+	replayed, err := h.ApplyCommittedEntriesToNode("node-a", entry1)
+	if err != nil {
+		t.Fatalf("ApplyCommittedEntriesToNode replay: %v results=%+v", err, replayed)
+	}
+	if len(replayed) != 1 || replayed[0] != first {
+		t.Fatalf("replayed=%+v, want stored first result %+v", replayed, first)
+	}
+
+	entry2 := committedCommand(12, 2, raw)
+	evidence, err = h.CommitAndApply([]raftcluster.NodeID{"node-a"}, entry2)
+	if err != nil {
+		t.Fatalf("CommitAndApply duplicate idempotency: %v evidence=%+v", err, evidence)
+	}
+	duplicate := evidence.Applied["node-a"][0]
+	assertAppliedResult(t, duplicate, raftentry.ApplyStatusAlreadyApplied, 0)
+	if duplicate.CommandDigest != first.CommandDigest || duplicate.ResultDigest != first.ResultDigest {
+		t.Fatalf("duplicate result=%+v, want original digest/result %+v", duplicate, first)
+	}
+	assertLastApplied(t, h, "node-a", raftentry.ApplyEntryID{Term: 12, Index: 2})
+
+	if _, err := h.ReopenNode("node-a"); err != nil {
+		t.Fatalf("ReopenNode after duplicate: %v", err)
+	}
+	assertLastApplied(t, h, "node-a", raftentry.ApplyEntryID{Term: 12, Index: 2})
+	replayedDuplicate, err := h.ApplyCommittedEntriesToNode("node-a", entry2)
+	if err != nil {
+		t.Fatalf("ApplyCommittedEntriesToNode duplicate replay: %v results=%+v", err, replayedDuplicate)
+	}
+	if len(replayedDuplicate) != 1 || replayedDuplicate[0] != duplicate {
+		t.Fatalf("replayed duplicate=%+v, want stored duplicate %+v", replayedDuplicate, duplicate)
+	}
+}
+
+func TestFollowerCatchUpAppliesMissingContiguousEntriesAndRejectsInvalidSequences(t *testing.T) {
+	h := openTestHarness(t)
+	defer func() { _ = h.Close() }()
+
+	entries := []raftfsm.CommittedEntryV1{
+		committedCommand(13, 1, deterministicCreateCollectionEntryWithOptions(t, "users", "harness:create:users:catchup", testCreateCollectionMetaOptions{
+			documentFormat: uint64(nativewire.DocumentFormatBSON),
+		})),
+		committedCommand(13, 2, deterministicInsertBatchEntry(t, "users", "harness:insert:users:catchup", nativewire.DocumentFormatBSON, [][]byte{[]byte("u1")}, [][]byte{
+			testBSONDocument(t, bson.D{{Key: "_id", Value: "u1"}, {Key: "city", Value: "hnl"}}),
+		})),
+		committedCommand(14, 3, deterministicCreateCollectionEntry(t, "orders", "harness:create:orders:catchup")),
+	}
+	if evidence, err := h.CommitAndApply([]raftcluster.NodeID{"node-a"}, entries...); err != nil {
+		t.Fatalf("CommitAndApply leader: %v evidence=%+v", err, evidence)
+	}
+	if results, err := h.ApplyCommittedEntriesToNode("node-b", entries[0]); err != nil {
+		t.Fatalf("seed follower: %v results=%+v", err, results)
+	}
+	catchup, err := h.CatchUpNode("node-b")
+	if err != nil {
+		t.Fatalf("CatchUpNode: %v results=%+v", err, catchup)
+	}
+	assertAppliedResults(t, "node-b catchup", catchup, []int64{1, 1})
+	assertLastApplied(t, h, "node-b", raftentry.ApplyEntryID{Term: 14, Index: 3})
+	if leaderDigest, followerDigest := logicalDigest(t, h, "node-a"), logicalDigest(t, h, "node-b"); leaderDigest != followerDigest {
+		t.Fatalf("digest after catch-up mismatch leader=%s follower=%s", leaderDigest.Hex(), followerDigest.Hex())
+	}
+
+	bad := openTestHarnessAt(t, filepath.Join(t.TempDir(), "bad"))
+	defer func() { _ = bad.Close() }()
+	if evidence, err := bad.CommitAndApply([]raftcluster.NodeID{"node-b"}, entries[0]); err != nil {
+		t.Fatalf("seed bad follower: %v evidence=%+v", err, evidence)
+	}
+	if _, err := bad.Commit(entries[2]); !errors.Is(err, ErrCommittedLogGap) {
+		t.Fatalf("Commit gap err=%v, want ErrCommittedLogGap", err)
+	}
+	divergent := committedCommand(13, 1, deterministicCreateCollectionEntry(t, "admins", "harness:create:admins:divergent"))
+	if _, err := bad.Commit(divergent); !errors.Is(err, ErrCommittedLogConflict) {
+		t.Fatalf("Commit divergent err=%v, want ErrCommittedLogConflict", err)
+	}
+
+	gapResults, err := bad.ApplyCommittedEntriesToNode("node-b", entries[2])
+	assertRejectedResult(t, "gap catch-up", gapResults, err, raftentry.ErrorRejectedConflictV1)
+	assertLastApplied(t, bad, "node-b", raftentry.ApplyEntryID{Term: 13, Index: 1})
+	assertCollectionMissing(t, bad, "node-b", "orders")
+
+	divergentResults, err := bad.ApplyCommittedEntriesToNode("node-b", divergent)
+	assertRejectedResult(t, "divergent duplicate catch-up", divergentResults, err, raftentry.ErrorRejectedConflictV1)
+	assertLastApplied(t, bad, "node-b", raftentry.ApplyEntryID{Term: 13, Index: 1})
+	assertCollectionMissing(t, bad, "node-b", "admins")
+}
+
+func TestPostCommitCrashReadableAndPreCommitCrashNoSuccess(t *testing.T) {
+	h := openTestHarness(t)
+	defer func() { _ = h.Close() }()
+
+	create := committedCommand(15, 1, deterministicCreateCollectionEntryWithOptions(t, "users", "harness:create:users:crash", testCreateCollectionMetaOptions{
+		documentFormat: uint64(nativewire.DocumentFormatBSON),
+	}))
+	insert := committedCommand(15, 2, deterministicInsertBatchEntry(t, "users", "harness:insert:users:crash", nativewire.DocumentFormatBSON, [][]byte{[]byte("u1")}, [][]byte{
+		testBSONDocument(t, bson.D{{Key: "_id", Value: "u1"}, {Key: "city", Value: "hnl"}}),
+	}))
+
+	pre := h.PreCommitEvidence(create)
+	if pre.Kind != EvidenceInjectedCommittedEntryReplayV1 || pre.Committed || pre.HasCommittedSuccess() || pre.ProvesProductionConsensus() {
+		t.Fatalf("pre-commit evidence=%+v, want no committed success and no production consensus claim", pre)
+	}
+	if err := h.CloseNode("node-a"); err != nil {
+		t.Fatalf("CloseNode leader before commit: %v", err)
+	}
+	assertCollectionMissing(t, h, "node-b", "users")
+	assertCollectionMissing(t, h, "node-c", "users")
+
+	if _, err := h.ReopenNode("node-a"); err != nil {
+		t.Fatalf("ReopenNode leader: %v", err)
+	}
+	post, err := h.CommitAndApply([]raftcluster.NodeID{"node-b", "node-c"}, create, insert)
+	if err != nil {
+		t.Fatalf("CommitAndApply surviving quorum: %v evidence=%+v", err, post)
+	}
+	assertInjectedCommittedEvidence(t, post)
+	if err := h.CloseNode("node-a"); err != nil {
+		t.Fatalf("CloseNode leader after commit: %v", err)
+	}
+	for _, nodeID := range []raftcluster.NodeID{"node-b", "node-c"} {
+		if _, err := h.ReopenNode(nodeID); err != nil {
+			t.Fatalf("ReopenNode %s: %v", nodeID, err)
+		}
+		assertDocumentCity(t, h, nodeID, "users", "u1", "hnl")
+		assertLastApplied(t, h, nodeID, raftentry.ApplyEntryID{Term: 15, Index: 2})
+	}
+}
+
+func openTestHarness(t testing.TB) *Harness {
+	t.Helper()
+	return openTestHarnessAt(t, t.TempDir())
+}
+
+func openTestHarnessAt(t testing.TB, root string) *Harness {
+	t.Helper()
+	h, err := Open(Options{
+		RootDir: root,
+		StoreOptions: raftapply.DurableApplyStoreOptions{
+			DisableSync: true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Open harness: %v", err)
+	}
+	return h
+}
+
+func mixedUserEntries(t *testing.T, term uint64) []raftfsm.CommittedEntryV1 {
+	t.Helper()
+	create := deterministicCreateCollectionEntryWithOptions(t, "users", "harness:create:users:mixed", testCreateCollectionMetaOptions{
+		documentFormat: uint64(nativewire.DocumentFormatBSON),
+	})
+	insert := deterministicInsertBatchEntry(t, "users", "harness:insert:users:mixed", nativewire.DocumentFormatBSON, [][]byte{[]byte("u1"), []byte("u2")}, [][]byte{
+		testBSONDocument(t, bson.D{{Key: "_id", Value: "u1"}, {Key: "city", Value: "hnl"}}),
+		testBSONDocument(t, bson.D{{Key: "_id", Value: "u2"}, {Key: "city", Value: "sea"}}),
+	})
+	replace := deterministicReplaceBatchEntry(t, "users", "harness:replace:users:mixed", nativewire.DocumentFormatBSON, [][]byte{[]byte("u1")}, [][]byte{
+		testBSONDocument(t, bson.D{{Key: "_id", Value: "u1"}, {Key: "city", Value: "sfo"}}),
+	})
+	deleteEntry := deterministicDeleteBatchEntry(t, "users", "harness:delete:users:mixed", [][]byte{[]byte("u2")})
+	return []raftfsm.CommittedEntryV1{
+		committedCommand(term, 1, create),
+		committedCommand(term, 2, insert),
+		committedCommand(term, 3, replace),
+		committedCommand(term, 4, deleteEntry),
+	}
+}
+
+func committedCommand(term, index uint64, raw []byte) raftfsm.CommittedEntryV1 {
+	return raftfsm.CommittedEntryV1{
+		Type:                     raftfsm.EntryTypeCommandEntryV1,
+		Term:                     term,
+		Index:                    index,
+		Bytes:                    raw,
+		CurrentCatalogVersion:    testCatalogVersionStart,
+		HasCurrentCatalogVersion: true,
+	}
+}
+
+func deterministicCreateCollectionEntry(t *testing.T, collection, idempotency string) []byte {
+	t.Helper()
+	return deterministicCreateCollectionEntryWithOptions(t, collection, idempotency, testCreateCollectionMetaOptions{})
+}
+
+type testCreateCollectionMetaOptions struct {
+	documentFormat uint64
+}
+
+func deterministicCreateCollectionEntryWithOptions(t *testing.T, collection, idempotency string, opts testCreateCollectionMetaOptions) []byte {
+	t.Helper()
+	sections := []nativewire.Section{
+		{ID: nativewire.SectionCommandHeader, Bytes: nativewire.AppendCommandHeader(nil, nativewire.CommandHeader{ID: nativewire.CommandCreateCollection, Version: 1})},
+		{ID: nativewire.SectionIdempotencyKey, Bytes: []byte(idempotency)},
+		{ID: nativewire.SectionCollectionMeta, Bytes: testCreateCollectionMetaPayload(collection, opts)},
+		{ID: nativewire.SectionExpectedCatalogVersion, Bytes: binary.AppendUvarint(nil, testCatalogVersionStart)},
+	}
+	cmd, err := nativewire.MustV1Registry().ValidateRequestSections(sections)
+	if err != nil {
+		t.Fatalf("ValidateRequestSections: %v", err)
+	}
+	entry, err := nativewire.AppendDeterministicEntry(nil, cmd)
+	if err != nil {
+		t.Fatalf("AppendDeterministicEntry: %v", err)
+	}
+	return entry
+}
+
+func testCreateCollectionMetaPayload(collection string, opts testCreateCollectionMetaOptions) []byte {
+	dst := binary.AppendUvarint(nil, 1)
+	dst = appendTestString(dst, collection)
+	dst = binary.AppendUvarint(dst, opts.documentFormat)
+	dst = binary.AppendUvarint(dst, 0)
+	dst = binary.AppendUvarint(dst, 0)
+	dst = append(dst, 0)
+	dst = append(dst, 0)
+	dst = append(dst, 0)
+	dst = binary.AppendVarint(dst, 0)
+	dst = binary.AppendVarint(dst, 0)
+	dst = binary.AppendVarint(dst, 0)
+	dst = append(dst, 0)
+	dst = append(dst, 0)
+	dst = binary.AppendVarint(dst, 0)
+	dst = binary.AppendUvarint(dst, 0)
+	return dst
+}
+
+func deterministicInsertBatchEntry(t *testing.T, collection, idempotency string, format nativewire.DocumentFormat, ids, documents [][]byte) []byte {
+	t.Helper()
+	return deterministicMutationEntry(t, nativewire.CommandInsertBatch, collection, idempotency, format, ids, documents, nil)
+}
+
+func deterministicReplaceBatchEntry(t *testing.T, collection, idempotency string, format nativewire.DocumentFormat, ids, documents [][]byte) []byte {
+	t.Helper()
+	extra := []nativewire.Section{{ID: nativewire.SectionReplacementMode, Bytes: binary.AppendUvarint(nil, 1)}}
+	return deterministicMutationEntry(t, nativewire.CommandReplaceBatch, collection, idempotency, format, ids, documents, extra)
+}
+
+func deterministicDeleteBatchEntry(t *testing.T, collection, idempotency string, ids [][]byte) []byte {
+	t.Helper()
+	sections := []nativewire.Section{
+		{ID: nativewire.SectionCommandHeader, Bytes: nativewire.AppendCommandHeader(nil, nativewire.CommandHeader{ID: nativewire.CommandDeleteBatch, Version: 1})},
+		{ID: nativewire.SectionIdempotencyKey, Bytes: []byte(idempotency)},
+		{ID: nativewire.SectionCollectionRef, Bytes: deterministicTestCollectionNameRef(collection)},
+		{ID: nativewire.SectionDocumentIDs, Bytes: nativewire.AppendByteVector(nil, ids...)},
+		{ID: nativewire.SectionExpectedCatalogVersion, Bytes: binary.AppendUvarint(nil, testCatalogVersionStart)},
+	}
+	cmd, err := nativewire.MustV1Registry().ValidateRequestSections(sections)
+	if err != nil {
+		t.Fatalf("ValidateRequestSections: %v", err)
+	}
+	entry, err := nativewire.AppendDeterministicEntry(nil, cmd)
+	if err != nil {
+		t.Fatalf("AppendDeterministicEntry: %v", err)
+	}
+	return entry
+}
+
+func deterministicMutationEntry(t *testing.T, command nativewire.CommandID, collection, idempotency string, format nativewire.DocumentFormat, ids, documents [][]byte, extra []nativewire.Section) []byte {
+	t.Helper()
+	sections := []nativewire.Section{
+		{ID: nativewire.SectionCommandHeader, Bytes: nativewire.AppendCommandHeader(nil, nativewire.CommandHeader{ID: command, Version: 1})},
+		{ID: nativewire.SectionIdempotencyKey, Bytes: []byte(idempotency)},
+		{ID: nativewire.SectionCollectionRef, Bytes: deterministicTestCollectionNameRef(collection)},
+		{ID: nativewire.SectionDocumentFormat, Bytes: binary.AppendUvarint(nil, uint64(format))},
+		{ID: nativewire.SectionDocumentIDs, Bytes: nativewire.AppendByteVector(nil, ids...)},
+		{ID: nativewire.SectionDocuments, Bytes: nativewire.AppendByteVector(nil, documents...)},
+		{ID: nativewire.SectionExpectedCatalogVersion, Bytes: binary.AppendUvarint(nil, testCatalogVersionStart)},
+	}
+	sections = append(sections, extra...)
+	cmd, err := nativewire.MustV1Registry().ValidateRequestSections(sections)
+	if err != nil {
+		t.Fatalf("ValidateRequestSections: %v", err)
+	}
+	entry, err := nativewire.AppendDeterministicEntry(nil, cmd)
+	if err != nil {
+		t.Fatalf("AppendDeterministicEntry: %v", err)
+	}
+	return entry
+}
+
+func deterministicTestCollectionNameRef(collection string) []byte {
+	return append([]byte{deterministicCollectionRefName}, collection...)
+}
+
+func testBSONDocument(t *testing.T, document bson.D) []byte {
+	t.Helper()
+	encoded, err := bson.Marshal(document)
+	if err != nil {
+		t.Fatalf("Marshal BSON: %v", err)
+	}
+	return encoded
+}
+
+func appendTestString(dst []byte, value string) []byte {
+	dst = binary.AppendUvarint(dst, uint64(len(value)))
+	return append(dst, value...)
+}
+
+func assertInjectedCommittedEvidence(t *testing.T, evidence CommitEvidenceV1) {
+	t.Helper()
+	if evidence.Kind != EvidenceInjectedCommittedEntryReplayV1 || !evidence.Committed || evidence.ProvesProductionConsensus() || !evidence.HasCommittedSuccess() {
+		t.Fatalf("evidence=%+v, want committed injected replay evidence with no production consensus claim", evidence)
+	}
+}
+
+func assertAppliedResults(t *testing.T, label any, results []raftentry.ApplyResultV1, wantAffected []int64) {
+	t.Helper()
+	if len(results) != len(wantAffected) {
+		t.Fatalf("%v results=%d, want %d", label, len(results), len(wantAffected))
+	}
+	for i, want := range wantAffected {
+		assertAppliedResult(t, results[i], raftentry.ApplyStatusApplied, want)
+	}
+}
+
+func assertAppliedResult(t *testing.T, result raftentry.ApplyResultV1, wantStatus raftentry.ApplyStatusV1, wantAffected int64) {
+	t.Helper()
+	if result.Status != wantStatus ||
+		result.DeterministicErrorCode != raftentry.ErrorNoneV1 ||
+		result.AffectedCount != wantAffected ||
+		result.CommandDigest == (raftentry.CommandDigestV1{}) ||
+		result.ResultDigest == (raftentry.CommandDigestV1{}) {
+		t.Fatalf("result=%+v, want status=%s affected=%d non-zero digests", result, wantStatus, wantAffected)
+	}
+}
+
+func assertRejectedResult(t *testing.T, label string, results []raftentry.ApplyResultV1, err error, wantCode raftentry.DeterministicErrorCodeV1) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("%s err=nil results=%+v, want rejection", label, results)
+	}
+	if code, ok := raftfsm.ErrorCodeOf(err); !ok || code != wantCode {
+		t.Fatalf("%s err=%v code=(%s,%t), want %s", label, err, code, ok, wantCode)
+	}
+	if len(results) != 1 || results[0].Status != raftentry.ApplyStatusRejectedConflict || results[0].DeterministicErrorCode != wantCode {
+		t.Fatalf("%s results=%+v, want single rejected-conflict result with %s", label, results, wantCode)
+	}
+}
+
+func assertLastApplied(t *testing.T, h *Harness, nodeID raftcluster.NodeID, want raftentry.ApplyEntryID) {
+	t.Helper()
+	node, ok := h.Node(nodeID)
+	if !ok {
+		t.Fatalf("node %s not found", nodeID)
+	}
+	got, ok := node.LastApplied()
+	if !ok || got != want {
+		t.Fatalf("%s LastApplied=(%+v,%t), want %+v", nodeID, got, ok, want)
+	}
+}
+
+func logicalDigest(t *testing.T, h *Harness, nodeID raftcluster.NodeID) raftapply.LogicalDigestV1 {
+	t.Helper()
+	node, ok := h.Node(nodeID)
+	if !ok {
+		t.Fatalf("node %s not found", nodeID)
+	}
+	digest, err := node.LogicalDigestV1(raftapply.LogicalDigestOptionsV1{})
+	if err != nil {
+		t.Fatalf("%s LogicalDigestV1: %v", nodeID, err)
+	}
+	return digest
+}
+
+func assertCollectionMissing(t *testing.T, h *Harness, nodeID raftcluster.NodeID, collection string) {
+	t.Helper()
+	node, ok := h.Node(nodeID)
+	if !ok {
+		t.Fatalf("node %s not found", nodeID)
+	}
+	_, err := collections.NewCollectionManager(node.DB()).OpenCollection(collection)
+	if !errors.Is(err, collections.ErrCollectionNotFound) {
+		t.Fatalf("%s OpenCollection %s err=%v, want ErrCollectionNotFound", nodeID, collection, err)
+	}
+}
+
+func assertDocumentCity(t *testing.T, h *Harness, nodeID raftcluster.NodeID, collection, id, wantCity string) {
+	t.Helper()
+	node, ok := h.Node(nodeID)
+	if !ok {
+		t.Fatalf("node %s not found", nodeID)
+	}
+	opened, err := collections.NewCollectionManager(node.DB()).OpenCollection(collection)
+	if err != nil {
+		t.Fatalf("%s OpenCollection %s: %v", nodeID, collection, err)
+	}
+	got, err := opened.Get([]byte(id))
+	if err != nil {
+		t.Fatalf("%s %s.Get(%q): %v", nodeID, collection, id, err)
+	}
+	if got == nil {
+		t.Fatalf("%s %s.Get(%q)=nil, want document", nodeID, collection, id)
+	}
+	if city := bson.Raw(got).Lookup("city").StringValue(); city != wantCity {
+		t.Fatalf("%s %s.Get(%q).city=%q, want %q", nodeID, collection, id, city, wantCity)
+	}
+}

--- a/TreeDB/internal/raftharness/harness_test.go
+++ b/TreeDB/internal/raftharness/harness_test.go
@@ -313,6 +313,36 @@ func TestOpenRejectsInvalidNodeIDBeforeOpeningPath(t *testing.T) {
 	}
 }
 
+func TestClosedHarnessRejectsMutatingOperations(t *testing.T) {
+	h := openTestHarness(t)
+	entry := committedCommand(18, 1, deterministicCreateCollectionEntry(t, "users", "harness:create:users:closed"))
+	if err := h.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if _, err := h.ReopenNode("node-a"); !errors.Is(err, ErrHarnessClosed) {
+		t.Fatalf("ReopenNode after Close err=%v, want ErrHarnessClosed", err)
+	}
+	if err := h.CloseNode("node-a"); !errors.Is(err, ErrHarnessClosed) {
+		t.Fatalf("CloseNode after Close err=%v, want ErrHarnessClosed", err)
+	}
+	evidence, err := h.Commit(entry)
+	if !errors.Is(err, ErrHarnessClosed) {
+		t.Fatalf("Commit after Close err=%v, want ErrHarnessClosed evidence=%+v", err, evidence)
+	}
+	if evidence.Committed {
+		t.Fatalf("Commit after Close evidence=%+v, want not committed", evidence)
+	}
+	if _, err := h.ApplyCommittedEntriesToNode("node-a", entry); !errors.Is(err, ErrHarnessClosed) {
+		t.Fatalf("ApplyCommittedEntriesToNode after Close err=%v, want ErrHarnessClosed", err)
+	}
+	if _, err := h.CatchUpNode("node-a"); !errors.Is(err, ErrHarnessClosed) {
+		t.Fatalf("CatchUpNode after Close err=%v, want ErrHarnessClosed", err)
+	}
+	if err := h.Close(); err != nil {
+		t.Fatalf("second Close: %v", err)
+	}
+}
+
 func openTestHarness(t testing.TB) *Harness {
 	t.Helper()
 	return openTestHarnessAt(t, t.TempDir())


### PR DESCRIPTION
Refs #3271
Depends on #3267
Parent tracker: #3044

## Speculative stack status

This PR is intentionally based on `codex/3257-raftfsm` / PR #3267. It is blocked from merge until #3267 lands, then this branch must be updated onto the final post-#3267 base and revalidated.

## Scope

- Adds `TreeDB/internal/raftharness`, a deterministic in-process harness around per-node `raftfsm` instances.
- Opens local node DB/FSM pairs with durable apply progress/result stores under the `raftcluster` layout.
- Records an injected committed-entry log and supports applying committed entries to selected nodes, close/reopen, and follower catch-up from last applied.
- Exposes `CommitEvidenceV1` with `EvidenceInjectedCommittedEntryReplayV1` so tests can distinguish post-commit evidence from pre-commit no-success evidence.

## Honesty boundary

This does not run a Raft library, elect leaders, form quorums, replicate logs, install snapshots, expose native `raft_committed`, or implement Mongo writeConcern. It proves deterministic committed-entry replay through the currently available harness boundary, not production consensus.

## Tests

- `GOWORK=off go test ./TreeDB/internal/raftfsm ./TreeDB/internal/raftapply ./TreeDB/internal/raftentry ./TreeDB/internal/raftcluster ./TreeDB/internal/raftharness -count=1`
- `GOWORK=off go vet ./TreeDB/internal/raftharness`
- `git diff --check origin/codex/3257-raftfsm...HEAD`

`BenchmarkApplyCommittedEntryCloseout3043` was not rerun because this PR does not change `raftapply` or apply-loop code.

## Review status

No Codex/Copilot/CodeRabbit review requested for this speculative PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stronger prefix validation for committed changes, improving consistency checks before data is applied.

* **Bug Fixes**
  * Improved detection of missing, conflicting, or out-of-order committed entries.
  * Added safer node recovery and catch-up behavior after restarts or partial failures.
  * Hardened handling of invalid node configurations and closed-state operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->