### PR TITLE
TreeDB Raft: gate cluster admission before local writes

### DIFF
--- a/TreeDB/mongo_gateway/cluster_submitter.go
+++ b/TreeDB/mongo_gateway/cluster_submitter.go
@@ -416,6 +416,9 @@ func (s *Server) submitClusterMutation(ctx context.Context, command iwire.Comman
 	if s == nil || s.ClusterSubmitter == nil {
 		return nil, errors.New("Mongo gateway cluster submitter is not configured")
 	}
+	if err := treenativewire.AdmitClusterMutation(ctx, s.ClusterSubmitter); err != nil {
+		return nil, err
+	}
 	if row := raftentry.ClassifyNativeWireCommandV1(command); !row.Known || row.Decision != raftentry.DecisionAccepted {
 		return nil, fmt.Errorf("cluster submitter command %d is not accepted by R3a v1", command)
 	}

--- a/TreeDB/mongo_gateway/cluster_submitter.go
+++ b/TreeDB/mongo_gateway/cluster_submitter.go
@@ -122,6 +122,9 @@ func (s *Server) clusterUpdateResponse(ctx context.Context, command wire.Documen
 	if err != nil {
 		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
 	}
+	if err := s.admitClusterMutation(ctx); err != nil {
+		return mongoClusterMutationCommandError(err)
+	}
 	exists, err := s.clusterCollectionExists(name)
 	if err != nil {
 		return commandError(commandCodeBadValue, "BadValue", err.Error())
@@ -167,6 +170,9 @@ func (s *Server) clusterDeleteResponse(ctx context.Context, command wire.Documen
 	deletes, err := commandDocuments(command, sequences, "deletes")
 	if err != nil {
 		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
+	}
+	if err := s.admitClusterMutation(ctx); err != nil {
+		return mongoClusterMutationCommandError(err)
 	}
 	exists, err := s.clusterCollectionExists(name)
 	if err != nil {
@@ -416,7 +422,7 @@ func (s *Server) submitClusterMutation(ctx context.Context, command iwire.Comman
 	if s == nil || s.ClusterSubmitter == nil {
 		return nil, errors.New("Mongo gateway cluster submitter is not configured")
 	}
-	if err := treenativewire.AdmitClusterMutation(ctx, s.ClusterSubmitter); err != nil {
+	if err := s.admitClusterMutation(ctx); err != nil {
 		return nil, err
 	}
 	if row := raftentry.ClassifyNativeWireCommandV1(command); !row.Known || row.Decision != raftentry.DecisionAccepted {
@@ -448,6 +454,13 @@ func (s *Server) submitClusterMutation(ctx context.Context, command iwire.Comman
 		return nil, err
 	}
 	return result.ResponseSections, nil
+}
+
+func (s *Server) admitClusterMutation(ctx context.Context) error {
+	if s == nil || s.ClusterSubmitter == nil {
+		return errors.New("Mongo gateway cluster submitter is not configured")
+	}
+	return treenativewire.AdmitClusterMutation(ctx, s.ClusterSubmitter)
 }
 
 func validateMongoClusterSubmitResult(result treenativewire.ClusterSubmitResult) error {

--- a/TreeDB/mongo_gateway/cluster_submitter_test.go
+++ b/TreeDB/mongo_gateway/cluster_submitter_test.go
@@ -303,6 +303,48 @@ func TestClusterAdmissionMongoFollowerRejectsWritesBeforeLocalMutation(t *testin
 	}
 }
 
+func TestClusterAdmissionMongoFollowerRejectsMissingCollectionNoOps(t *testing.T) {
+	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	submitter := &mongoClusterAdmissionSubmitter{
+		mongoClusterFakeSubmitter: &mongoClusterFakeSubmitter{},
+		status:                    treenativewire.ClusterFollowerAdmission("node-a:27017", "not leader"),
+	}
+	server := NewServer()
+	server.Collections = collections.NewCollectionManager(db)
+	server.DefaultCollectionOptions = collections.CollectionOptions{DocumentFormat: collections.DocumentFormatBSON}
+	setMongoClusterAdmissionTestSubmitter(server, submitter, 34)
+
+	updateResponse := serveCommand(t, server, 326808, bson.D{
+		{Key: "update", Value: "missing"},
+		{Key: "updates", Value: bson.A{bson.D{
+			{Key: "q", Value: bson.D{{Key: "_id", Value: "u1"}}},
+			{Key: "u", Value: bson.D{{Key: "$set", Value: bson.D{{Key: "name", Value: "Grace"}}}}},
+		}}},
+		{Key: "$db", Value: "app"},
+	})
+	assertCommandError(t, updateResponse, "BadValue")
+	assertErrmsgContains(t, updateResponse, "node-a:27017")
+
+	deleteResponse := serveCommand(t, server, 326809, bson.D{
+		{Key: "delete", Value: "missing"},
+		{Key: "deletes", Value: bson.A{bson.D{{Key: "q", Value: bson.D{{Key: "_id", Value: "u1"}}}, {Key: "limit", Value: int32(1)}}}},
+		{Key: "$db", Value: "app"},
+	})
+	assertCommandError(t, deleteResponse, "BadValue")
+	assertErrmsgContains(t, deleteResponse, "node-a:27017")
+	if calls := submitter.snapshotCalls(); len(calls) != 0 {
+		t.Fatalf("submit calls=%d want 0", len(calls))
+	}
+	if _, err := server.Collections.OpenCollection("app.missing"); !errors.Is(err, collections.ErrCollectionNotFound) {
+		t.Fatalf("OpenCollection app.missing err=%v want collection not found", err)
+	}
+}
+
 func TestClusterAdmissionMongoUnavailableRejectsBeforeSubmit(t *testing.T) {
 	submitter := &mongoClusterAdmissionSubmitter{
 		mongoClusterFakeSubmitter: &mongoClusterFakeSubmitter{},

--- a/TreeDB/mongo_gateway/cluster_submitter_test.go
+++ b/TreeDB/mongo_gateway/cluster_submitter_test.go
@@ -31,6 +31,31 @@ type mongoClusterFakeSubmitter struct {
 	committedRecoverable     bool
 	responseSections         []iwire.Section
 	overrideResponseSections bool
+	status                   treenativewire.ClusterAdmissionStatus
+	admissionErr             error
+}
+
+type mongoClusterAdmissionSubmitter struct {
+	*mongoClusterFakeSubmitter
+	status treenativewire.ClusterAdmissionStatus
+	err    error
+}
+
+func (f *mongoClusterAdmissionSubmitter) ClusterAdmissionStatus(context.Context) (treenativewire.ClusterAdmissionStatus, error) {
+	if f.err != nil {
+		return treenativewire.ClusterAdmissionStatus{}, f.err
+	}
+	return f.status, nil
+}
+
+func (f *mongoClusterFakeSubmitter) ClusterAdmissionStatus(context.Context) (treenativewire.ClusterAdmissionStatus, error) {
+	if f.admissionErr != nil {
+		return treenativewire.ClusterAdmissionStatus{}, f.admissionErr
+	}
+	if f.status == (treenativewire.ClusterAdmissionStatus{}) {
+		return treenativewire.ClusterLeaderAdmission(), nil
+	}
+	return f.status, nil
 }
 
 func (f *mongoClusterFakeSubmitter) SubmitCommandEntryV1(ctx context.Context, entry []byte, metadata treenativewire.ClusterRequestMetadata) (treenativewire.ClusterSubmitResult, error) {
@@ -131,6 +156,45 @@ func setMongoClusterTestSubmitter(server *Server, submitter *mongoClusterFakeSub
 	server.ClusterCatalogVersion = mongoClusterStaticCatalogVersion(catalogVersion)
 }
 
+func setMongoClusterAdmissionTestSubmitter(server *Server, submitter *mongoClusterAdmissionSubmitter, catalogVersion uint64) {
+	server.ClusterSubmitter = submitter
+	server.ClusterCatalogVersion = mongoClusterStaticCatalogVersion(catalogVersion)
+}
+
+func assertErrmsgContains(tb testing.TB, doc wire.Document, want string) {
+	tb.Helper()
+	got, ok := bson.Raw(doc).Lookup("errmsg").StringValueOK()
+	if !ok || !strings.Contains(got, want) {
+		tb.Fatalf("errmsg=%q typeOK=%v want containing %q", got, ok, want)
+	}
+}
+
+func assertMongoUsers(tb testing.TB, server *Server, want map[string]string) {
+	tb.Helper()
+	found := serveCommand(tb, server, 326899, bson.D{
+		{Key: "find", Value: "users"},
+		{Key: "$db", Value: "app"},
+	})
+	batch := cursorFirstBatch(tb, found)
+	got := make(map[string]string, len(batch))
+	for _, doc := range batch {
+		id, idOK := doc.Lookup("_id").StringValueOK()
+		name, nameOK := doc.Lookup("name").StringValueOK()
+		if !idOK || !nameOK {
+			tb.Fatalf("user doc missing string _id/name: %v", doc)
+		}
+		got[id] = name
+	}
+	if len(got) != len(want) {
+		tb.Fatalf("users=%v want %v", got, want)
+	}
+	for id, wantName := range want {
+		if gotName, ok := got[id]; !ok || gotName != wantName {
+			tb.Fatalf("user %q name=%q present=%v want %q", id, gotName, ok, wantName)
+		}
+	}
+}
+
 func mongoClusterCallCatalogVersion(tb testing.TB, call mongoClusterSubmitterCall) uint64 {
 	tb.Helper()
 	version, n := binary.Uvarint(call.entry.Target.ExpectedCatalogVersion)
@@ -146,6 +210,117 @@ func mongoClusterCallIdempotencyKey(tb testing.TB, call mongoClusterSubmitterCal
 		tb.Fatal("missing idempotency key")
 	}
 	return string(call.entry.IdempotencyKey)
+}
+
+func TestClusterAdmissionMongoLeaderRoutesThroughSubmitter(t *testing.T) {
+	submitter := &mongoClusterAdmissionSubmitter{
+		mongoClusterFakeSubmitter: &mongoClusterFakeSubmitter{},
+		status:                    treenativewire.ClusterLeaderAdmission(),
+	}
+	server := NewServer()
+	server.DefaultCollectionOptions = collections.CollectionOptions{DocumentFormat: collections.DocumentFormatBSON}
+	setMongoClusterAdmissionTestSubmitter(server, submitter, 31)
+
+	response := serveCommand(t, server, 326801, bson.D{
+		{Key: "insert", Value: "users"},
+		{Key: "documents", Value: bson.A{bson.D{{Key: "_id", Value: "u1"}, {Key: "name", Value: "Ada"}}}},
+		{Key: "$db", Value: "app"},
+	})
+	assertOK(t, response)
+	assertInt32(t, response, "n", 1)
+	calls := submitter.snapshotCalls()
+	if len(calls) != 2 {
+		t.Fatalf("submit calls=%d want create+insert", len(calls))
+	}
+	if got := calls[0].entry.Decoded.CommandID; got != iwire.CommandCreateCollection {
+		t.Fatalf("first command id=%d want create_collection", got)
+	}
+	if got := calls[1].entry.Decoded.CommandID; got != iwire.CommandInsertBatch {
+		t.Fatalf("second command id=%d want insert_batch", got)
+	}
+}
+
+func TestClusterAdmissionMongoFollowerRejectsWritesBeforeLocalMutation(t *testing.T) {
+	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	server := NewServer()
+	server.Collections = collections.NewCollectionManager(db)
+	server.DefaultCollectionOptions = collections.CollectionOptions{DocumentFormat: collections.DocumentFormatBSON}
+	assertOK(t, serveCommand(t, server, 326802, bson.D{
+		{Key: "insert", Value: "users"},
+		{Key: "documents", Value: bson.A{bson.D{{Key: "_id", Value: "u1"}, {Key: "name", Value: "Ada"}}}},
+		{Key: "$db", Value: "app"},
+	}))
+
+	submitter := &mongoClusterAdmissionSubmitter{
+		mongoClusterFakeSubmitter: &mongoClusterFakeSubmitter{},
+		status:                    treenativewire.ClusterFollowerAdmission("node-a:27017", "not leader"),
+	}
+	setMongoClusterAdmissionTestSubmitter(server, submitter, 32)
+
+	createResponse := serveCommand(t, server, 326803, bson.D{
+		{Key: "create", Value: "admins"},
+		{Key: "$db", Value: "app"},
+	})
+	assertCommandError(t, createResponse, "BadValue")
+	assertErrmsgContains(t, createResponse, "node-a:27017")
+	if _, err := server.Collections.OpenCollection("app.admins"); !errors.Is(err, collections.ErrCollectionNotFound) {
+		t.Fatalf("OpenCollection app.admins err=%v want collection not found", err)
+	}
+
+	insertResponse := serveCommand(t, server, 326804, bson.D{
+		{Key: "insert", Value: "users"},
+		{Key: "documents", Value: bson.A{bson.D{{Key: "_id", Value: "u2"}, {Key: "name", Value: "Grace"}}}},
+		{Key: "$db", Value: "app"},
+	})
+	assertCommandError(t, insertResponse, "BadValue")
+	assertMongoUsers(t, server, map[string]string{"u1": "Ada"})
+
+	updateResponse := serveCommand(t, server, 326805, bson.D{
+		{Key: "update", Value: "users"},
+		{Key: "updates", Value: bson.A{bson.D{
+			{Key: "q", Value: bson.D{{Key: "_id", Value: "u1"}}},
+			{Key: "u", Value: bson.D{{Key: "$set", Value: bson.D{{Key: "name", Value: "Grace"}}}}},
+		}}},
+		{Key: "$db", Value: "app"},
+	})
+	assertCommandError(t, updateResponse, "BadValue")
+	assertMongoUsers(t, server, map[string]string{"u1": "Ada"})
+
+	deleteResponse := serveCommand(t, server, 326806, bson.D{
+		{Key: "delete", Value: "users"},
+		{Key: "deletes", Value: bson.A{bson.D{{Key: "q", Value: bson.D{{Key: "_id", Value: "u1"}}}, {Key: "limit", Value: int32(1)}}}},
+		{Key: "$db", Value: "app"},
+	})
+	assertCommandError(t, deleteResponse, "BadValue")
+	assertMongoUsers(t, server, map[string]string{"u1": "Ada"})
+	if calls := submitter.snapshotCalls(); len(calls) != 0 {
+		t.Fatalf("submit calls=%d want 0", len(calls))
+	}
+}
+
+func TestClusterAdmissionMongoUnavailableRejectsBeforeSubmit(t *testing.T) {
+	submitter := &mongoClusterAdmissionSubmitter{
+		mongoClusterFakeSubmitter: &mongoClusterFakeSubmitter{},
+		status:                    treenativewire.ClusterUnavailableAdmission("cluster admission unavailable"),
+	}
+	server := NewServer()
+	server.DefaultCollectionOptions = collections.CollectionOptions{DocumentFormat: collections.DocumentFormatBSON}
+	setMongoClusterAdmissionTestSubmitter(server, submitter, 33)
+
+	response := serveCommand(t, server, 326807, bson.D{
+		{Key: "create", Value: "users"},
+		{Key: "$db", Value: "app"},
+	})
+	assertCommandError(t, response, "BadValue")
+	assertErrmsgContains(t, response, "cluster admission unavailable")
+	if calls := submitter.snapshotCalls(); len(calls) != 0 {
+		t.Fatalf("submit calls=%d want 0", len(calls))
+	}
 }
 
 func mongoClusterCallCollectionMetaName(tb testing.TB, call mongoClusterSubmitterCall) string {

--- a/TreeDB/nativewire/cluster_submitter.go
+++ b/TreeDB/nativewire/cluster_submitter.go
@@ -20,6 +20,39 @@ type ClusterSubmitter interface {
 	SubmitCommandEntryV1(ctx context.Context, entry []byte, metadata ClusterRequestMetadata) (ClusterSubmitResult, error)
 }
 
+// ClusterAdmissionProvider exposes the node write-admission state backing a
+// ClusterSubmitter. A configured cluster submitter that does not implement
+// this interface fails closed as admission-unavailable.
+type ClusterAdmissionProvider interface {
+	ClusterAdmissionStatus(ctx context.Context) (ClusterAdmissionStatus, error)
+}
+
+// ClusterAdmissionStatus describes whether this node may accept cluster-owned
+// writes. A provider must set Leader for write admission; the zero value fails
+// closed as not-leader when returned by a configured provider.
+type ClusterAdmissionStatus struct {
+	Leader      bool
+	Unavailable bool
+	LeaderHint  string
+	Reason      string
+}
+
+// ClusterLeaderAdmission returns an admitted leader status.
+func ClusterLeaderAdmission() ClusterAdmissionStatus {
+	return ClusterAdmissionStatus{Leader: true}
+}
+
+// ClusterFollowerAdmission returns a fail-closed not-leader status. leaderHint
+// is optional and may carry a redirect target for callers that can use one.
+func ClusterFollowerAdmission(leaderHint, reason string) ClusterAdmissionStatus {
+	return ClusterAdmissionStatus{LeaderHint: leaderHint, Reason: reason}
+}
+
+// ClusterUnavailableAdmission returns a fail-closed cluster-unavailable status.
+func ClusterUnavailableAdmission(reason string) ClusterAdmissionStatus {
+	return ClusterAdmissionStatus{Unavailable: true, Reason: reason}
+}
+
 // ClusterSubmitResult is the submitter-owned response for an admitted command.
 // CommittedRecoverable must only be true when AckRaftCommitted reflects a real
 // consensus commit plus the serving node's selected local recoverability gate.
@@ -41,8 +74,14 @@ func (s *Server) handleClusterMutation(ctx context.Context, header iwire.Header,
 	if err != nil {
 		return nil, err
 	}
+	if ack == iwire.AckRaftCommitted {
+		return nil, protocolError(iwire.ErrDurabilityUnavailable, "raft_committed ack is deferred to the native Raft committed semantics gate")
+	}
 	metadata, err := clusterRequestMetadata(header, cmd.Header, cmd.Known, ack)
 	if err != nil {
+		return nil, err
+	}
+	if err := AdmitClusterMutation(ctx, s.clusterSubmitter); err != nil {
 		return nil, err
 	}
 	entry, err := iwire.AppendDeterministicEntryWithLimits(nil, cmd, s.limits)
@@ -63,6 +102,50 @@ func (s *Server) handleClusterMutation(ctx context.Context, header iwire.Header,
 		return nil, err
 	}
 	return cloneSections(result.ResponseSections), nil
+}
+
+// AdmitClusterMutation fails closed unless submitter is configured and, when
+// it exposes admission state, the node is currently the leader.
+func AdmitClusterMutation(ctx context.Context, submitter ClusterSubmitter) error {
+	if submitter == nil {
+		return protocolError(iwire.ErrInvalidCommand, "cluster submitter is not configured")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	provider, ok := submitter.(ClusterAdmissionProvider)
+	if !ok {
+		return protocolError(iwire.ErrDurabilityUnavailable, "cluster admission provider is not configured")
+	}
+	status, err := provider.ClusterAdmissionStatus(ctx)
+	if err != nil {
+		return protocolError(iwire.ErrDurabilityUnavailable, "cluster admission unavailable: %v", err)
+	}
+	if status.Unavailable {
+		reason := status.Reason
+		if reason == "" {
+			reason = "cluster admission is unavailable"
+		}
+		return protocolError(iwire.ErrDurabilityUnavailable, "%s", reason)
+	}
+	if status.Leader {
+		return nil
+	}
+	message := "not cluster leader"
+	if status.Reason != "" {
+		message = status.Reason
+	}
+	if status.LeaderHint != "" {
+		message += "; leader_hint=" + status.LeaderHint
+	}
+	return protocolError(iwire.ErrReadOnly, "%s", message)
+}
+
+func (s *Server) rejectClusterLocalMutation(command string) error {
+	if s == nil || s.clusterSubmitter == nil {
+		return nil
+	}
+	return protocolError(iwire.ErrReadOnly, "nativewire cluster submitter mode requires %s through the cluster submitter", command)
 }
 
 func unsupportedClusterMutationError(cmd iwire.ValidatedCommand, row raftentry.CommandRowV1) error {

--- a/TreeDB/nativewire/cluster_submitter.go
+++ b/TreeDB/nativewire/cluster_submitter.go
@@ -66,10 +66,6 @@ func (s *Server) handleClusterMutation(ctx context.Context, header iwire.Header,
 	if s == nil || s.clusterSubmitter == nil {
 		return nil, protocolError(iwire.ErrInvalidCommand, "nativewire cluster submitter is not configured")
 	}
-	row := raftentry.ClassifyNativeWireCommandV1(cmd.Header.ID)
-	if !row.Known || row.Decision != raftentry.DecisionAccepted {
-		return nil, unsupportedClusterMutationError(cmd, row)
-	}
 	ack, err := ackPolicyFromSections(cmd.Known, s.defaultAckPolicy)
 	if err != nil {
 		return nil, err
@@ -77,11 +73,15 @@ func (s *Server) handleClusterMutation(ctx context.Context, header iwire.Header,
 	if ack == iwire.AckRaftCommitted {
 		return nil, protocolError(iwire.ErrDurabilityUnavailable, "raft_committed ack is deferred to the native Raft committed semantics gate")
 	}
-	metadata, err := clusterRequestMetadata(header, cmd.Header, cmd.Known, ack)
-	if err != nil {
+	if err := AdmitClusterMutation(ctx, s.clusterSubmitter); err != nil {
 		return nil, err
 	}
-	if err := AdmitClusterMutation(ctx, s.clusterSubmitter); err != nil {
+	row := raftentry.ClassifyNativeWireCommandV1(cmd.Header.ID)
+	if !row.Known || row.Decision != raftentry.DecisionAccepted {
+		return nil, unsupportedClusterMutationError(cmd, row)
+	}
+	metadata, err := clusterRequestMetadata(header, cmd.Header, cmd.Known, ack)
+	if err != nil {
 		return nil, err
 	}
 	entry, err := iwire.AppendDeterministicEntryWithLimits(nil, cmd, s.limits)

--- a/TreeDB/nativewire/cluster_submitter_test.go
+++ b/TreeDB/nativewire/cluster_submitter_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
+	"errors"
 	"sync"
 	"testing"
 	"time"
@@ -244,6 +245,89 @@ func TestClusterAdmissionFollowerRejectsNativeMutationsBeforeLocalMutation(t *te
 	}
 	if calls := submitter.snapshot(); len(calls) != 0 {
 		t.Fatalf("submitter calls=%d want 0", len(calls))
+	}
+}
+
+func TestClusterAdmissionMetadataMutationsRejectBeforeLocalMutation(t *testing.T) {
+	tests := []struct {
+		name     string
+		status   ClusterAdmissionStatus
+		wantCode iwire.ErrorCode
+	}{
+		{
+			name:     "follower",
+			status:   ClusterFollowerAdmission("node-a:7000", "not leader"),
+			wantCode: iwire.ErrReadOnly,
+		},
+		{
+			name:     "unavailable",
+			status:   ClusterUnavailableAdmission("cluster admission unavailable"),
+			wantCode: iwire.ErrDurabilityUnavailable,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			submitter := &admissionClusterSubmitter{
+				fakeClusterSubmitter: &fakeClusterSubmitter{},
+				status:               tt.status,
+			}
+			client, _, mgr, _ := serveCollectionPipeWithServerAndOptions(t, ServerOptions{ClusterSubmitter: submitter})
+			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+			defer cancel()
+			if err := client.Hello(ctx); err != nil {
+				t.Fatalf("Hello: %v", err)
+			}
+			meta := collections.CollectionMeta{
+				Name: "users",
+				Options: collections.CollectionOptions{
+					DocumentFormat: collections.DocumentFormatBSON,
+				},
+			}
+			if _, err := mgr.CreateCollection(&meta); err != nil {
+				t.Fatalf("direct CreateCollection users: %v", err)
+			}
+			col, err := mgr.OpenCollection("users")
+			if err != nil {
+				t.Fatalf("OpenCollection users: %v", err)
+			}
+			if _, err := col.CreateIndex(collections.IndexDefinition{
+				Name:      "email",
+				Field:     "email",
+				ValueType: collections.IndexValueString,
+			}); err != nil {
+				t.Fatalf("direct CreateIndex email: %v", err)
+			}
+
+			if _, err := client.CreateCollection(ctx, collections.CollectionMeta{Name: "admins"}); !isRemoteError(err, tt.wantCode) {
+				t.Fatalf("CreateCollection err=%v want code %d", err, tt.wantCode)
+			}
+			if _, err := mgr.OpenCollection("admins"); !errors.Is(err, collections.ErrCollectionNotFound) {
+				t.Fatalf("OpenCollection admins err=%v want collection not found", err)
+			}
+
+			if _, err := client.CreateIndex(ctx, "users", collections.IndexDefinition{
+				Name:      "name",
+				Field:     "name",
+				ValueType: collections.IndexValueString,
+			}); !isRemoteError(err, tt.wantCode) {
+				t.Fatalf("CreateIndex err=%v want code %d", err, tt.wantCode)
+			}
+			indexes := col.Meta().Indexes
+			if len(indexes) != 1 || indexes[0].Name != "email" {
+				t.Fatalf("indexes after rejected create_index=%+v want only email", indexes)
+			}
+
+			if _, err := client.DropIndex(ctx, "users", "email"); !isRemoteError(err, tt.wantCode) {
+				t.Fatalf("DropIndex err=%v want code %d", err, tt.wantCode)
+			}
+			indexes = col.Meta().Indexes
+			if len(indexes) != 1 || indexes[0].Name != "email" {
+				t.Fatalf("indexes after rejected drop_index=%+v want email retained", indexes)
+			}
+			if calls := submitter.snapshot(); len(calls) != 0 {
+				t.Fatalf("submitter calls=%d want 0", len(calls))
+			}
+		})
 	}
 }
 

--- a/TreeDB/nativewire/cluster_submitter_test.go
+++ b/TreeDB/nativewire/cluster_submitter_test.go
@@ -15,13 +15,44 @@ import (
 )
 
 type fakeClusterSubmitter struct {
-	mu    sync.Mutex
-	calls []fakeClusterSubmitCall
+	mu           sync.Mutex
+	calls        []fakeClusterSubmitCall
+	status       ClusterAdmissionStatus
+	admissionErr error
+}
+
+type admissionClusterSubmitter struct {
+	*fakeClusterSubmitter
+	status ClusterAdmissionStatus
+	err    error
 }
 
 type fakeClusterSubmitCall struct {
 	entry    raftentry.CommandEntryV1
 	metadata ClusterRequestMetadata
+}
+
+type noAdmissionClusterSubmitter struct{}
+
+func (noAdmissionClusterSubmitter) SubmitCommandEntryV1(context.Context, []byte, ClusterRequestMetadata) (ClusterSubmitResult, error) {
+	panic("unexpected submit")
+}
+
+func (f *admissionClusterSubmitter) ClusterAdmissionStatus(context.Context) (ClusterAdmissionStatus, error) {
+	if f.err != nil {
+		return ClusterAdmissionStatus{}, f.err
+	}
+	return f.status, nil
+}
+
+func (f *fakeClusterSubmitter) ClusterAdmissionStatus(context.Context) (ClusterAdmissionStatus, error) {
+	if f.admissionErr != nil {
+		return ClusterAdmissionStatus{}, f.admissionErr
+	}
+	if f.status == (ClusterAdmissionStatus{}) {
+		return ClusterLeaderAdmission(), nil
+	}
+	return f.status, nil
 }
 
 func (f *fakeClusterSubmitter) SubmitCommandEntryV1(ctx context.Context, entry []byte, metadata ClusterRequestMetadata) (ClusterSubmitResult, error) {
@@ -84,6 +115,15 @@ func fakeClusterSubmitResponse(entry raftentry.CommandEntryV1, metadata ClusterR
 			responseMetaCount{key: "matched_count", value: len(ids)},
 			responseMetaCount{key: "modified_count", value: len(ids)},
 		))
+	case iwire.CommandUpdateBSONSet:
+		ids, err := deterministicEntryDocumentIDs(entry)
+		if err != nil {
+			return ClusterSubmitResult{}, err
+		}
+		sections = append(sections, ackMetaCountsVersion(actualAck, 0, true,
+			responseMetaCount{key: "matched_count", value: len(ids)},
+			responseMetaCount{key: "modified_count", value: len(ids)},
+		))
 	case iwire.CommandDeleteBatch:
 		ids, err := deterministicEntryDocumentIDs(entry)
 		if err != nil {
@@ -110,6 +150,125 @@ func deterministicEntryDocumentIDs(entry raftentry.CommandEntryV1) ([][]byte, er
 func cloneClusterRequestMetadata(metadata ClusterRequestMetadata) ClusterRequestMetadata {
 	metadata.TraceContext = bytes.Clone(metadata.TraceContext)
 	return metadata
+}
+
+func TestClusterAdmissionMissingProviderFailsClosed(t *testing.T) {
+	err := AdmitClusterMutation(context.Background(), noAdmissionClusterSubmitter{})
+	if nativeCodeOf(err) != iwire.ErrDurabilityUnavailable {
+		t.Fatalf("admission err=%v code=%d want durability unavailable", err, nativeCodeOf(err))
+	}
+}
+
+func TestClusterAdmissionLeaderRoutesThroughSubmitter(t *testing.T) {
+	submitter := &admissionClusterSubmitter{
+		fakeClusterSubmitter: &fakeClusterSubmitter{},
+		status:               ClusterLeaderAdmission(),
+	}
+	client, _, _ := serveCollectionPipeWithOptions(t, ServerOptions{ClusterSubmitter: submitter})
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := client.Hello(ctx); err != nil {
+		t.Fatalf("Hello: %v", err)
+	}
+	if _, err := client.InsertBatch(ctx, "users", collections.DocumentFormatJSON,
+		[][]byte{[]byte("u1")},
+		[][]byte{[]byte(`{"name":"Ada"}`)},
+		AckVisible,
+	); err != nil {
+		t.Fatalf("InsertBatch: %v", err)
+	}
+	calls := submitter.snapshot()
+	if len(calls) != 1 {
+		t.Fatalf("submitter calls=%d want 1", len(calls))
+	}
+	if got := calls[0].entry.Decoded.CommandID; got != iwire.CommandInsertBatch {
+		t.Fatalf("command=%d want insert_batch", got)
+	}
+}
+
+func TestClusterAdmissionFollowerRejectsNativeMutationsBeforeLocalMutation(t *testing.T) {
+	submitter := &admissionClusterSubmitter{
+		fakeClusterSubmitter: &fakeClusterSubmitter{},
+		status:               ClusterFollowerAdmission("node-a:7000", "not leader"),
+	}
+	client, _, mgr, _ := serveCollectionPipeWithServerAndOptions(t, ServerOptions{ClusterSubmitter: submitter})
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := client.Hello(ctx); err != nil {
+		t.Fatalf("Hello: %v", err)
+	}
+	meta := collections.CollectionMeta{
+		Name: "users",
+		Options: collections.CollectionOptions{
+			DocumentFormat: collections.DocumentFormatBSON,
+		},
+	}
+	if _, err := mgr.CreateCollection(&meta); err != nil {
+		t.Fatalf("direct CreateCollection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("OpenCollection: %v", err)
+	}
+	original := mustBSONDocument(t, bson.D{{Key: "_id", Value: "u1"}, {Key: "name", Value: "Ada"}})
+	if _, err := col.InsertBatchValidatedBSON([][]byte{[]byte("u1")}, [][]byte{original}); err != nil {
+		t.Fatalf("seed InsertBatchValidatedBSON: %v", err)
+	}
+
+	insertDoc := mustBSONDocument(t, bson.D{{Key: "_id", Value: "u2"}, {Key: "name", Value: "Grace"}})
+	if _, err := client.InsertBatch(ctx, "users", collections.DocumentFormatBSON, [][]byte{[]byte("u2")}, [][]byte{insertDoc}, AckVisible); !isRemoteError(err, iwire.ErrReadOnly) {
+		t.Fatalf("InsertBatch err=%v want read-only", err)
+	}
+	if got, err := col.Get([]byte("u2")); err != nil || got != nil {
+		t.Fatalf("u2 after rejected insert got=%v err=%v want missing", got, err)
+	}
+
+	replaceDoc := mustBSONDocument(t, bson.D{{Key: "_id", Value: "u1"}, {Key: "name", Value: "Grace"}})
+	if _, _, err := client.ReplaceBatch(ctx, "users", collections.DocumentFormatBSON, [][]byte{[]byte("u1")}, [][]byte{replaceDoc}, AckVisible); !isRemoteError(err, iwire.ErrReadOnly) {
+		t.Fatalf("ReplaceBatch err=%v want read-only", err)
+	}
+	if _, _, err := client.UpdateBSONSet(ctx, "users", []byte("u1"), []collections.BSONSetField{
+		{Key: "name", Value: mustNativewireBSONRawValue(t, "Grace")},
+	}, AckVisible); !isRemoteError(err, iwire.ErrReadOnly) {
+		t.Fatalf("UpdateBSONSet err=%v want read-only", err)
+	}
+	if _, err := client.DeleteBatch(ctx, "users", [][]byte{[]byte("u1")}, AckVisible); !isRemoteError(err, iwire.ErrReadOnly) {
+		t.Fatalf("DeleteBatch err=%v want read-only", err)
+	}
+	got, err := col.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("Get u1 after rejected mutations: %v", err)
+	}
+	if !bytes.Equal(got, original) {
+		t.Fatalf("u1 changed after rejected mutations: got %v want %v", got, original)
+	}
+	if calls := submitter.snapshot(); len(calls) != 0 {
+		t.Fatalf("submitter calls=%d want 0", len(calls))
+	}
+}
+
+func TestClusterAdmissionUnavailableRejectsBeforeSubmit(t *testing.T) {
+	submitter := &admissionClusterSubmitter{
+		fakeClusterSubmitter: &fakeClusterSubmitter{},
+		status:               ClusterUnavailableAdmission("cluster admission unavailable"),
+	}
+	client, _, _ := serveCollectionPipeWithOptions(t, ServerOptions{ClusterSubmitter: submitter})
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := client.Hello(ctx); err != nil {
+		t.Fatalf("Hello: %v", err)
+	}
+	_, err := client.InsertBatch(ctx, "users", collections.DocumentFormatJSON,
+		[][]byte{[]byte("u1")},
+		[][]byte{[]byte(`{"name":"Ada"}`)},
+		AckVisible,
+	)
+	if !isRemoteError(err, iwire.ErrDurabilityUnavailable) {
+		t.Fatalf("InsertBatch err=%v want durability unavailable", err)
+	}
+	if calls := submitter.snapshot(); len(calls) != 0 {
+		t.Fatalf("submitter calls=%d want 0", len(calls))
+	}
 }
 
 func TestClusterSubmitterReceivesDecodableDeterministicEntries(t *testing.T) {
@@ -338,8 +497,8 @@ func TestClusterSubmitterRaftCommittedRequiresProvenResult(t *testing.T) {
 	if !isRemoteError(err, iwire.ErrDurabilityUnavailable) {
 		t.Fatalf("InsertBatch raft_committed cluster err=%v want durability unavailable", err)
 	}
-	if got := len(submitter.snapshot()); got != 1 {
-		t.Fatalf("submitter calls=%d want 1", got)
+	if got := len(submitter.snapshot()); got != 0 {
+		t.Fatalf("submitter calls=%d want 0", got)
 	}
 }
 

--- a/TreeDB/nativewire/server_insert_combiner.go
+++ b/TreeDB/nativewire/server_insert_combiner.go
@@ -67,6 +67,9 @@ func canCombineInsertBatchFastRequest(s *Server, req insertBatchFastRequest) boo
 	if s == nil || s.insertBatchCombineMaxBatch <= 1 {
 		return false
 	}
+	if s.clusterSubmitter != nil {
+		return false
+	}
 	if req.collection == nil || req.collectionName == "" {
 		return false
 	}
@@ -133,6 +136,12 @@ func yieldInsertBatchCombiner(s *Server) {
 
 func applyInsertBatchCombineItems(s *Server, batch []*nativewireInsertBatchCombineItem) {
 	if len(batch) == 0 {
+		return
+	}
+	if err := s.rejectClusterLocalMutation("insert_batch combiner"); err != nil {
+		for _, item := range batch {
+			finishInsertBatchCombineItem(item, nativewireInsertBatchCombineResult{err: err})
+		}
 		return
 	}
 	if len(batch) == 1 {

--- a/TreeDB/nativewire/server_insert_combiner_test.go
+++ b/TreeDB/nativewire/server_insert_combiner_test.go
@@ -124,6 +124,39 @@ func TestInsertBatchCombinerSkipsIncompatibleRequests(t *testing.T) {
 	}
 }
 
+func TestInsertBatchCombinerRejectsClusterModeBypass(t *testing.T) {
+	server, col, cleanup := newInsertBatchCombinerTestServer(t)
+	defer cleanup()
+	server.clusterSubmitter = &admissionClusterSubmitter{
+		fakeClusterSubmitter: &fakeClusterSubmitter{},
+		status:               ClusterLeaderAdmission(),
+	}
+
+	req := insertBatchCombinerFastRequest(t, col, "user-cluster", insertBatchCombinerBSONDoc(t, "user-cluster", "cluster@example.com"))
+	if canCombineInsertBatchFastRequest(server, req) {
+		t.Fatal("cluster-owned insert request should not combine locally")
+	}
+	item := &nativewireInsertBatchCombineItem{
+		req:  req,
+		done: make(chan nativewireInsertBatchCombineResult, 1),
+	}
+	applyInsertBatchCombineItems(server, []*nativewireInsertBatchCombineItem{item})
+	select {
+	case result := <-item.done:
+		if nativeCodeOf(result.err) != iwire.ErrReadOnly {
+			t.Fatalf("combiner result err=%v code=%d want read-only", result.err, nativeCodeOf(result.err))
+		}
+	default:
+		t.Fatal("cluster bypass item was not completed")
+	}
+	if got, err := col.Get([]byte("user-cluster")); err != nil || got != nil {
+		t.Fatalf("user-cluster after rejected combiner got=%v err=%v want missing", got, err)
+	}
+	if calls := server.clusterSubmitter.(*admissionClusterSubmitter).snapshot(); len(calls) != 0 {
+		t.Fatalf("submitter calls=%d want 0", len(calls))
+	}
+}
+
 func TestInsertBatchCombinerStatsStartAtZero(t *testing.T) {
 	server := NewServer(ServerOptions{})
 	stats := server.Stats()

--- a/TreeDB/nativewire/server_metadata.go
+++ b/TreeDB/nativewire/server_metadata.go
@@ -9,6 +9,9 @@ func (s *Server) handleCreateCollection(sections []iwire.Section) ([]iwire.Secti
 	if err := managerRequired(s.collections); err != nil {
 		return nil, err
 	}
+	if err := s.rejectClusterLocalMutation("create_collection"); err != nil {
+		return nil, err
+	}
 	s.metadataMu.Lock()
 	defer s.metadataMu.Unlock()
 	replay, remember, err := s.beginMetadataIdempotency(iwire.CommandCreateCollection, sections)
@@ -63,6 +66,9 @@ func (s *Server) handleListCollections() ([]iwire.Section, error) {
 
 func (s *Server) handleCreateIndex(state *connState, sections []iwire.Section) ([]iwire.Section, error) {
 	if err := managerRequired(s.collections); err != nil {
+		return nil, err
+	}
+	if err := s.rejectClusterLocalMutation("create_index"); err != nil {
 		return nil, err
 	}
 	s.metadataMu.Lock()
@@ -122,6 +128,9 @@ func (s *Server) handleListIndexes(state *connState, sections []iwire.Section) (
 
 func (s *Server) handleDropIndex(state *connState, sections []iwire.Section) ([]iwire.Section, error) {
 	if err := managerRequired(s.collections); err != nil {
+		return nil, err
+	}
+	if err := s.rejectClusterLocalMutation("drop_index"); err != nil {
 		return nil, err
 	}
 	s.metadataMu.Lock()

--- a/TreeDB/nativewire/server_mutation.go
+++ b/TreeDB/nativewire/server_mutation.go
@@ -44,6 +44,9 @@ func (s *Server) handleInsertBatchBody(state *connState, sections []iwire.Sectio
 }
 
 func (s *Server) handleInsertBatchFastBody(req insertBatchFastRequest, dst []byte) ([]byte, error) {
+	if err := s.rejectClusterLocalMutation("insert_batch fast path"); err != nil {
+		return nil, err
+	}
 	s.metadataMu.RLock()
 	defer s.metadataMu.RUnlock()
 	if err := s.checkCatalogGuard(req.sections); err != nil {
@@ -124,6 +127,9 @@ func (s *Server) insertBatch(state *connState, sections []iwire.Section, include
 }
 
 func (s *Server) insertBatchDecoded(collection *collections.Collection, format collections.DocumentFormat, ids, docs [][]byte, ack AckPolicy, includeResultIDs bool) ([][]byte, int, iwire.AckPolicy, uint64, bool, error) {
+	if err := s.rejectClusterLocalMutation("insert_batch"); err != nil {
+		return nil, 0, 0, 0, false, err
+	}
 	var err error
 	var resultIDs [][]byte
 	if format == collections.DocumentFormatBSON {
@@ -330,6 +336,9 @@ func (s *Server) handleReplaceBatch(state *connState, sections []iwire.Section) 
 	if err := managerRequired(s.collections); err != nil {
 		return nil, err
 	}
+	if err := s.rejectClusterLocalMutation("replace_batch"); err != nil {
+		return nil, err
+	}
 	s.metadataMu.RLock()
 	defer s.metadataMu.RUnlock()
 	if err := s.checkCatalogGuard(sections); err != nil {
@@ -423,6 +432,9 @@ func replaceBatchDocuments(collection *collections.Collection, ids, docs [][]byt
 
 func (s *Server) handleUpdateBSONSet(state *connState, sections []iwire.Section) ([]iwire.Section, error) {
 	if err := managerRequired(s.collections); err != nil {
+		return nil, err
+	}
+	if err := s.rejectClusterLocalMutation("update_bson_set"); err != nil {
 		return nil, err
 	}
 	s.metadataMu.RLock()
@@ -586,6 +598,9 @@ func boolCount(v bool) int {
 
 func (s *Server) handleDeleteBatch(state *connState, sections []iwire.Section) ([]iwire.Section, error) {
 	if err := managerRequired(s.collections); err != nil {
+		return nil, err
+	}
+	if err := s.rejectClusterLocalMutation("delete_batch"); err != nil {
 		return nil, err
 	}
 	s.metadataMu.Lock()


### PR DESCRIPTION
## Summary

Speculative implementation for #3268, based on #3267 / codex/3257-raftfsm.

- Adds a shared nativewire admission status contract for cluster submitters and fails closed when admission state is missing, unavailable, or not leader.
- Applies that gate before nativewire and Mongo gateway cluster submitter entry construction/submission.
- Blocks direct local nativewire mutation paths in cluster submitter mode, including insert fast path, insert combiner, metadata DDL, replace, update, and delete.
- Leaves standalone behavior unchanged and does not enable native ack_policy=raft_committed or Mongo writeConcern/primary semantics.

## Speculative status

Blocked by #3267 merging first. This PR should be rebased or rebuilt onto the final post-#3267 base and revalidated before mergeability review.

No AI review requested while speculative.

## Validation

- `GOWORK=off go test ./TreeDB/nativewire ./TreeDB/mongo_gateway -count=1`
- `git diff --check`

No benchmark added: the admission provider call is only on cluster submitter paths; standalone local mutation hot paths keep the same behavior with a nil cluster-submit guard.

## Scope boundaries

Refs #3268.

Does not edit `TreeDB/internal/raftfsm`.
Does not implement #3269 raft_committed ack semantics.
Does not implement #3270 Mongo writeConcern/primary semantics.
Does not add the #3271 failover harness.