### PR TITLE
Avoid zero-column row asset ID clones

### DIFF
--- a/TreeDB/collections/column_physical_asset_test.go
+++ b/TreeDB/collections/column_physical_asset_test.go
@@ -342,6 +342,79 @@ func TestColumnPhysicalAssetDenseIDRangeEncoding2663(t *testing.T) {
 	}
 }
 
+func TestColumnPhysicalAssetZeroColumnProjectionAliasesIDs3067(t *testing.T) {
+	allColumns := []ColumnStoreColumn{
+		{Name: "kind", Path: "kind", ValueType: ColumnStoreValueString, Owner: TypedStorageOwnerColumnPart, Dictionary: true},
+	}
+	rows := []columnDeclaredRow{
+		{
+			ID: columnPhysicalAssetBigEndianUint64ID(42),
+			Values: []columnDeclaredValue{{
+				Type:    ColumnStoreValueString,
+				Present: true,
+				String:  "like",
+			}},
+		},
+		{
+			ID: columnPhysicalAssetBigEndianUint64ID(43),
+			Values: []columnDeclaredValue{{
+				Type:    ColumnStoreValueString,
+				Present: true,
+				String:  "post",
+			}},
+		},
+	}
+	projected, err := projectColumnDeclaredRowsForColumns(allColumns, nil, rows)
+	if err != nil {
+		t.Fatalf("projectColumnDeclaredRowsForColumns zero columns: %v", err)
+	}
+	if len(projected) != len(rows) {
+		t.Fatalf("projected rows=%d want %d", len(projected), len(rows))
+	}
+	for i := range projected {
+		if len(projected[i].Values) != 0 {
+			t.Fatalf("projected row[%d] values=%d want 0", i, len(projected[i].Values))
+		}
+		if len(projected[i].ID) == 0 || &projected[i].ID[0] != &rows[i].ID[0] {
+			t.Fatalf("projected row[%d] did not alias source id", i)
+		}
+	}
+	if _, err := projectColumnDeclaredRowsForColumns(allColumns, nil, []columnDeclaredRow{{ID: []byte("bad")}}); err == nil || !strings.Contains(err.Error(), "values=0 columns=1") {
+		t.Fatalf("zero-column projection malformed row err=%v want values/columns error", err)
+	}
+
+	cfg := testColumnPhysicalRowReaderFixedIDConfigV7(t)
+	encoded, summary, err := encodeColumnPhysicalAsset(columnPhysicalAssetEncodeInput{
+		Collection:        "events",
+		Namespace:         cfg.AssetManager.Namespace,
+		Generation:        7,
+		PartID:            3,
+		AppliedCommandLSN: 101,
+		Operation:         ColumnPublishOperationInsert,
+		SchemaHash:        cfg.SchemaHash,
+		Columns:           cfg.Columns,
+		Rows:              projected,
+	})
+	if err != nil {
+		t.Fatalf("encodeColumnPhysicalAsset zero-column projected rows: %v", err)
+	}
+	if summary.RowCount != len(rows) || summary.ColumnCount != 0 || summary.PayloadBytes != int64(len(encoded)) {
+		t.Fatalf("summary=%+v len=%d want zero-column row asset", summary, len(encoded))
+	}
+	decoded, err := decodeColumnPhysicalAsset(encoded)
+	if err != nil {
+		t.Fatalf("decodeColumnPhysicalAsset zero-column projected rows: %v", err)
+	}
+	for i, row := range decoded.Rows {
+		if row.Deleted || len(row.Values) != 0 {
+			t.Fatalf("decoded row[%d]=%+v want no projected values", i, row)
+		}
+		if !bytes.Equal(row.ID, rows[i].ID) {
+			t.Fatalf("decoded row[%d] id=%x want %x", i, row.ID, rows[i].ID)
+		}
+	}
+}
+
 func TestColumnPhysicalAssetVectorValueTypesRoundTrip(t *testing.T) {
 	cfg := &ColumnStoreConfig{
 		Enabled: true,

--- a/TreeDB/collections/typed_column_publication.go
+++ b/TreeDB/collections/typed_column_publication.go
@@ -160,6 +160,19 @@ func columnStoreColumnNameSet(columns []ColumnStoreColumn) map[string]struct{} {
 }
 
 func projectColumnDeclaredRowsForColumns(allColumns, selected []ColumnStoreColumn, rows []columnDeclaredRow) ([]columnDeclaredRow, error) {
+	if len(selected) == 0 {
+		out := make([]columnDeclaredRow, len(rows))
+		for rowIdx, row := range rows {
+			out[rowIdx] = columnDeclaredRow{ID: row.ID, Deleted: row.Deleted}
+			if row.Deleted {
+				continue
+			}
+			if len(row.Values) != len(allColumns) {
+				return nil, fmt.Errorf("collections: typed-storage row[%d] values=%d columns=%d", rowIdx, len(row.Values), len(allColumns))
+			}
+		}
+		return out, nil
+	}
 	if len(selected) == len(allColumns) {
 		all := true
 		for i := range selected {

--- a/TreeDB/collections/typed_storage_naming_test.go
+++ b/TreeDB/collections/typed_storage_naming_test.go
@@ -357,7 +357,7 @@ var typedStorageLegacyNameAllowlist = []typedStorageLegacyNameAllowlistEntry{
 	{path: "TreeDB/collections/column_int64_values_asset.go", classification: typedStorageLegacyDerived, matchingLines: 10, occurrences: 10},
 	{path: "TreeDB/collections/column_manifest_format.go", classification: typedStorageLegacyCompatibility, matchingLines: 2, occurrences: 2},
 	{path: "TreeDB/collections/column_physical_asset.go", classification: typedStorageLegacyDeferred, matchingLines: 88, occurrences: 132},
-	{path: "TreeDB/collections/column_physical_asset_test.go", classification: typedStorageLegacyDeferred, matchingLines: 225, occurrences: 237},
+	{path: "TreeDB/collections/column_physical_asset_test.go", classification: typedStorageLegacyDeferred, matchingLines: 229, occurrences: 241},
 	{path: "TreeDB/collections/column_physical_predicate.go", classification: typedStorageLegacyDeferred, matchingLines: 3, occurrences: 3},
 	{path: "TreeDB/collections/column_physical_query.go", classification: typedStorageLegacyDeferred, matchingLines: 40, occurrences: 60},
 	{path: "TreeDB/collections/column_physical_query_1890_bench_test.go", classification: typedStorageLegacyDeferred, matchingLines: 1, occurrences: 2},


### PR DESCRIPTION
## Summary
- Avoid per-row ID byte clones when projecting zero-column row assets for typed column publication.
- Preserve malformed row validation and the row asset encoder contract by returning a fresh zero-value row slice with aliased IDs.
- Update the typed-storage naming allowlist for the added focused test.

## Scope / durability
- No on-disk format change.
- No value-log, WAL, fsync, or persistence-boundary change.
- This is allocation/memory-pressure hygiene only; it does not claim a JSONBench load wall-time win.

## Validation
- `GOWORK=off go test ./TreeDB/collections -run 'TestColumnPhysicalAssetZeroColumnProjectionAliasesIDs3067|TestColumnPhysicalAssetDenseIDRangeEncoding2663|TestColumnPhysicalRowReaderFetchesV7FixedIDRows|TestColumnPhysicalRowReaderFetchesV8DenseIDRangeRows|TestColumnStoreMutationAssetsPublishAndReopenM12C|TestColumnStorePhysicalAccounting|TestTypedStorageLegacyNameAllowlistIsComplete' -count=1`
- `GOWORK=off go test ./TreeDB/collections`
- `git diff --check`

## JSONBench smoke
- Candidate artifact: `/tmp/jsonbench_zero_column_row_asset_q2_20260628_212102/report.json`, q2 one-shot/no-metadata 1M, load `9.896s`, insert `5.687s`, total query `84.403ms`, setup `66.511ms`, run `17.837ms`.
- Baseline artifact: `/tmp/jsonbench_q2_reducer_baseline_20260628_211139/report.json`, load `9.783s`, insert `5.544s`.

Interpretation: no wall-time load win is claimed from this smoke; this PR removes avoidable zero-column row-asset ID clone pressure.

Supersedes #3273, whose branch could not be force-updated under repo rules after `main` advanced.
