### PR TITLE
TreeDB Raft: honor native raft_committed ack proof

### DIFF
--- a/TreeDB/nativewire/cluster_submitter.go
+++ b/TreeDB/nativewire/cluster_submitter.go
@@ -70,9 +70,6 @@ func (s *Server) handleClusterMutation(ctx context.Context, header iwire.Header,
 	if err != nil {
 		return nil, err
 	}
-	if ack == iwire.AckRaftCommitted {
-		return nil, protocolError(iwire.ErrDurabilityUnavailable, "raft_committed ack is deferred to the native Raft committed semantics gate")
-	}
 	if err := AdmitClusterMutation(ctx, s.clusterSubmitter); err != nil {
 		return nil, err
 	}

--- a/TreeDB/nativewire/cluster_submitter_test.go
+++ b/TreeDB/nativewire/cluster_submitter_test.go
@@ -20,6 +20,7 @@ type fakeClusterSubmitter struct {
 	calls        []fakeClusterSubmitCall
 	status       ClusterAdmissionStatus
 	admissionErr error
+	resultHook   func(raftentry.CommandEntryV1, ClusterRequestMetadata, ClusterSubmitResult) (ClusterSubmitResult, error)
 }
 
 type admissionClusterSubmitter struct {
@@ -68,7 +69,14 @@ func (f *fakeClusterSubmitter) SubmitCommandEntryV1(ctx context.Context, entry [
 	f.mu.Lock()
 	f.calls = append(f.calls, call)
 	f.mu.Unlock()
-	return fakeClusterSubmitResponse(decoded, metadata)
+	result, err := fakeClusterSubmitResponse(decoded, metadata)
+	if err != nil {
+		return ClusterSubmitResult{}, err
+	}
+	if f.resultHook != nil {
+		return f.resultHook(decoded, metadata, result)
+	}
+	return result, nil
 }
 
 func (f *fakeClusterSubmitter) snapshot() []fakeClusterSubmitCall {
@@ -565,7 +573,41 @@ func TestClusterSubmitterUnsupportedCommandFailsBeforeMutation(t *testing.T) {
 	}
 }
 
-func TestClusterSubmitterRaftCommittedRequiresProvenResult(t *testing.T) {
+func TestClusterSubmitterRaftCommittedSucceedsWithRecoverableCommit(t *testing.T) {
+	submitter := &fakeClusterSubmitter{
+		resultHook: func(entry raftentry.CommandEntryV1, metadata ClusterRequestMetadata, result ClusterSubmitResult) (ClusterSubmitResult, error) {
+			result.ActualAck = AckRaftCommitted
+			result.CommittedRecoverable = true
+			return replaceResponseAckPolicy(result, AckRaftCommitted), nil
+		},
+	}
+	client, _, _ := serveCollectionPipeWithOptions(t, ServerOptions{ClusterSubmitter: submitter})
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := client.Hello(ctx); err != nil {
+		t.Fatalf("Hello: %v", err)
+	}
+	sections, err := client.commandSections(ctx, iwire.CommandInsertBatch, clusterInsertBatchSections(t, client, ctx, AckRaftCommitted, "u1")...)
+	if err != nil {
+		t.Fatalf("InsertBatch raft_committed cluster: %v", err)
+	}
+	actualAck, err := responseAckPolicy(sections)
+	if err != nil {
+		t.Fatalf("responseAckPolicy: %v", err)
+	}
+	if actualAck != AckRaftCommitted {
+		t.Fatalf("actual ack=%d want raft_committed", actualAck)
+	}
+	calls := submitter.snapshot()
+	if len(calls) != 1 {
+		t.Fatalf("submitter calls=%d want 1", len(calls))
+	}
+	if calls[0].metadata.AckPolicy != AckRaftCommitted {
+		t.Fatalf("submitter ack=%d want raft_committed", calls[0].metadata.AckPolicy)
+	}
+}
+
+func TestClusterSubmitterRaftCommittedRequiresRecoverableCommit(t *testing.T) {
 	submitter := &fakeClusterSubmitter{}
 	client, _, _ := serveCollectionPipeWithOptions(t, ServerOptions{ClusterSubmitter: submitter})
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
@@ -573,26 +615,134 @@ func TestClusterSubmitterRaftCommittedRequiresProvenResult(t *testing.T) {
 	if err := client.Hello(ctx); err != nil {
 		t.Fatalf("Hello: %v", err)
 	}
-	_, err := client.InsertBatch(ctx, "users", collections.DocumentFormatJSON,
-		[][]byte{[]byte("u1")},
-		[][]byte{[]byte(`{"name":"Ada"}`)},
-		AckRaftCommitted,
-	)
+	_, err := client.commandSections(ctx, iwire.CommandInsertBatch, clusterInsertBatchSections(t, client, ctx, AckRaftCommitted, "u1")...)
 	if !isRemoteError(err, iwire.ErrDurabilityUnavailable) {
 		t.Fatalf("InsertBatch raft_committed cluster err=%v want durability unavailable", err)
+	}
+	calls := submitter.snapshot()
+	if len(calls) != 1 {
+		t.Fatalf("submitter calls=%d want 1", len(calls))
+	}
+	if calls[0].metadata.AckPolicy != AckRaftCommitted {
+		t.Fatalf("submitter ack=%d want raft_committed", calls[0].metadata.AckPolicy)
+	}
+}
+
+func TestClusterSubmitterRaftCommittedRequiresConsensusAck(t *testing.T) {
+	submitter := &fakeClusterSubmitter{
+		resultHook: func(entry raftentry.CommandEntryV1, metadata ClusterRequestMetadata, result ClusterSubmitResult) (ClusterSubmitResult, error) {
+			result.ActualAck = AckSynced
+			result.CommittedRecoverable = true
+			return replaceResponseAckPolicy(result, AckSynced), nil
+		},
+	}
+	client, _, _ := serveCollectionPipeWithOptions(t, ServerOptions{ClusterSubmitter: submitter})
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := client.Hello(ctx); err != nil {
+		t.Fatalf("Hello: %v", err)
+	}
+	_, err := client.commandSections(ctx, iwire.CommandInsertBatch, clusterInsertBatchSections(t, client, ctx, AckRaftCommitted, "u1")...)
+	if !isRemoteError(err, iwire.ErrDurabilityUnavailable) {
+		t.Fatalf("InsertBatch uncommitted raft ack err=%v want durability unavailable", err)
+	}
+	if got := len(submitter.snapshot()); got != 1 {
+		t.Fatalf("submitter calls=%d want 1", got)
+	}
+}
+
+func TestClusterSubmitterRaftCommittedRejectsLyingResponseMetadata(t *testing.T) {
+	submitter := &fakeClusterSubmitter{
+		resultHook: func(entry raftentry.CommandEntryV1, metadata ClusterRequestMetadata, result ClusterSubmitResult) (ClusterSubmitResult, error) {
+			result.ActualAck = AckRaftCommitted
+			result.CommittedRecoverable = true
+			return replaceResponseAckPolicy(result, AckSynced), nil
+		},
+	}
+	client, _, _ := serveCollectionPipeWithOptions(t, ServerOptions{ClusterSubmitter: submitter})
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := client.Hello(ctx); err != nil {
+		t.Fatalf("Hello: %v", err)
+	}
+	_, err := client.commandSections(ctx, iwire.CommandInsertBatch, clusterInsertBatchSections(t, client, ctx, AckRaftCommitted, "u1")...)
+	if !isRemoteError(err, iwire.ErrInternal) {
+		t.Fatalf("InsertBatch lying raft ack metadata err=%v want internal", err)
+	}
+	if got := len(submitter.snapshot()); got != 1 {
+		t.Fatalf("submitter calls=%d want 1", got)
+	}
+}
+
+func TestClusterSubmitterRaftCommittedDoesNotSatisfyLocalAck(t *testing.T) {
+	submitter := &fakeClusterSubmitter{
+		resultHook: func(entry raftentry.CommandEntryV1, metadata ClusterRequestMetadata, result ClusterSubmitResult) (ClusterSubmitResult, error) {
+			result.ActualAck = AckRaftCommitted
+			result.CommittedRecoverable = true
+			return replaceResponseAckPolicy(result, AckRaftCommitted), nil
+		},
+	}
+	client, _, _ := serveCollectionPipeWithOptions(t, ServerOptions{ClusterSubmitter: submitter})
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := client.Hello(ctx); err != nil {
+		t.Fatalf("Hello: %v", err)
+	}
+	_, err := client.commandSections(ctx, iwire.CommandInsertBatch, clusterInsertBatchSections(t, client, ctx, AckVisible, "u1")...)
+	if !isRemoteError(err, iwire.ErrDurabilityUnavailable) {
+		t.Fatalf("InsertBatch visible upgraded to raft_committed err=%v want durability unavailable", err)
+	}
+	calls := submitter.snapshot()
+	if len(calls) != 1 {
+		t.Fatalf("submitter calls=%d want 1", len(calls))
+	}
+	if calls[0].metadata.AckPolicy != AckVisible {
+		t.Fatalf("submitter ack=%d want visible", calls[0].metadata.AckPolicy)
+	}
+}
+
+func TestClusterSubmitterRaftCommittedAdmissionFailsBeforeSubmit(t *testing.T) {
+	submitter := &fakeClusterSubmitter{
+		status: ClusterFollowerAdmission("node-a:7000", "not leader"),
+	}
+	client, _, _ := serveCollectionPipeWithOptions(t, ServerOptions{ClusterSubmitter: submitter})
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := client.Hello(ctx); err != nil {
+		t.Fatalf("Hello: %v", err)
+	}
+	_, err := client.commandSections(ctx, iwire.CommandInsertBatch, clusterInsertBatchSections(t, client, ctx, AckRaftCommitted, "u1")...)
+	if !isRemoteError(err, iwire.ErrReadOnly) {
+		t.Fatalf("InsertBatch follower raft_committed err=%v want read-only", err)
 	}
 	if got := len(submitter.snapshot()); got != 0 {
 		t.Fatalf("submitter calls=%d want 0", got)
 	}
 }
 
-func TestClusterSubmitterRaftCommittedDoesNotSatisfyLocalAck(t *testing.T) {
-	err := validateClusterSubmitResult(ClusterRequestMetadata{AckPolicy: AckSynced}, ClusterSubmitResult{
-		ActualAck:            AckRaftCommitted,
-		CommittedRecoverable: true,
-		ResponseSections:     []iwire.Section{ackMeta(AckRaftCommitted)},
-	})
-	if nativeCodeOf(err) != iwire.ErrDurabilityUnavailable {
-		t.Fatalf("validateClusterSubmitResult err=%v want durability unavailable", err)
+func clusterInsertBatchSections(t *testing.T, client *Client, ctx context.Context, ack AckPolicy, id string) []iwire.Section {
+	t.Helper()
+	sections := []iwire.Section{
+		{ID: iwire.SectionIdempotencyKey, Bytes: []byte("cluster-insert-" + id)},
+		{ID: iwire.SectionExpectedCatalogVersion, Bytes: binary.AppendUvarint(nil, clientCatalogVersion(t, client, ctx))},
+		collectionNameRef("users"),
+		documentFormatSection(collections.DocumentFormatJSON),
+		iwire.Section{ID: iwire.SectionDocumentIDs, Bytes: iwire.AppendByteVector(nil, []byte(id))},
+		iwire.Section{ID: iwire.SectionDocuments, Bytes: iwire.AppendByteVector(nil, []byte(`{"name":"Ada"}`))},
 	}
+	if ack != 0 {
+		sections = append(sections, ackSection(ack))
+	}
+	return sections
+}
+
+func replaceResponseAckPolicy(result ClusterSubmitResult, policy AckPolicy) ClusterSubmitResult {
+	for i, section := range result.ResponseSections {
+		if section.ID == iwire.SectionResponseMeta {
+			result.ResponseSections[i] = ackMeta(policy)
+			return result
+		}
+	}
+	result.ResponseSections = append(result.ResponseSections, ackMeta(policy))
+	return result
 }


### PR DESCRIPTION
## Summary

Implements #3269 on top of merged #3274 / main.

- Allows native cluster mutation requests with `ack_policy=raft_committed` to reach the admitted cluster submitter instead of being pre-rejected.
- Accepts `raft_committed` only when the submit result reports `ActualAck=AckRaftCommitted` and `CommittedRecoverable=true`.
- Keeps fail-closed validation for missing consensus commit, missing local recoverability, lying `response_meta.actual_ack_policy`, and attempts to silently upgrade visible/flushed/synced requests.
- Preserves standalone single-node rejection for `raft_committed`.

## Status

Ready for latest-head review on `main` after #3274 merged.

#2026 remains a production closeout gate for publication/readability evidence; this PR does not claim production Raft closeout.

## Validation

- `git diff --check`
- `GOWORK=off go test ./TreeDB/nativewire -run 'TestClusterSubmitterRaftCommitted|TestMutationRaftAckRejected' -count=1`
- `GOWORK=off go test ./TreeDB/nativewire ./TreeDB/internal/raftfsm ./TreeDB/internal/raftapply ./TreeDB/internal/raftcluster -count=1`

No benchmark added: this is a semantic gate on the already-cluster-owned submitter path. Non-cluster local mutation paths still reject `raft_committed` before local writes, and the only runtime change is allowing admitted cluster `raft_committed` requests to reach existing result validation.

## Scope boundaries

Refs #3269.

Depends on merged #3274 admission gates.
Does not implement Mongo writeConcern / primary semantics (#3270).
Does not implement read policies, read-index, snapshots, or log truncation (#3045).
Does not implement multi-group routing (#3046).
Does not edit `TreeDB/internal/raftfsm` or `raftharness`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted cluster mutation handling so requests with raft-committed acknowledgment settings are no longer rejected upfront.
  * Improved validation behavior for commit responses, including better handling of inconsistent or missing acknowledgment metadata.

* **Tests**
  * Expanded end-to-end coverage for raft-committed cluster submits.
  * Added scenarios for successful recovery, durability failures, consensus acknowledgment checks, invalid response metadata, and admission failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->