### PR TITLE
[codex] Report typed-column load subphases

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -525,14 +525,20 @@ type CollectionInsertStats struct {
 	RetainedStreamValueLogBytes         int64
 	// ColumnPublish* fields are populated for typed-column InsertBatch paths
 	// that route through the command-WAL column manifest publish path.
-	ColumnPublishBuildColumnDelta         time.Duration
-	ColumnPublishBuildSystemDelta         time.Duration
-	ColumnPublishCommit                   time.Duration
-	ColumnPublishDocumentExtraction       time.Duration
-	ColumnPublishDeclaredColumnEncoding   time.Duration
-	ColumnPublishAssetPreparation         time.Duration
-	ColumnPublishRowAssetPreparation      time.Duration
-	ColumnPublishTypedColumnPreparation   time.Duration
+	ColumnPublishBuildColumnDelta       time.Duration
+	ColumnPublishBuildSystemDelta       time.Duration
+	ColumnPublishCommit                 time.Duration
+	ColumnPublishDocumentExtraction     time.Duration
+	ColumnPublishDeclaredColumnEncoding time.Duration
+	ColumnPublishAssetPreparation       time.Duration
+	ColumnPublishRowAssetPreparation    time.Duration
+	ColumnPublishTypedColumnPreparation time.Duration
+
+	ColumnPublishTypedColumnDictionaryBuild    time.Duration
+	ColumnPublishTypedColumnRowMaterialization time.Duration
+	ColumnPublishTypedColumnPartBuild          time.Duration
+	ColumnPublishTypedColumnImageBuild         time.Duration
+
 	ColumnPublishDictionaryPreparation    time.Duration
 	ColumnPublishInt64Preparation         time.Duration
 	ColumnPublishAggregateMetadataPrepare time.Duration

--- a/TreeDB/collections/column_publish_plan.go
+++ b/TreeDB/collections/column_publish_plan.go
@@ -299,6 +299,10 @@ type ColumnPublishAssetPreparationMetrics struct {
 	RowAssetBytes                 int64
 	RowAssetCount                 int
 	TypedColumnPartDuration       time.Duration
+	TypedColumnDictionaryBuild    time.Duration
+	TypedColumnRowMaterialization time.Duration
+	TypedColumnPartBuild          time.Duration
+	TypedColumnImageBuild         time.Duration
 	TypedColumnPartBytes          int64
 	TypedColumnPartCount          int
 	DictionarySidecarDuration     time.Duration

--- a/TreeDB/collections/column_publish_write.go
+++ b/TreeDB/collections/column_publish_write.go
@@ -439,6 +439,10 @@ func recordColumnPublishPlanStats(stats *CollectionInsertStats, plan ColumnPubli
 	stats.ColumnPublishAssetPreparation += metrics.AssetPreparation
 	stats.ColumnPublishRowAssetPreparation += metrics.AssetMetrics.RowAssetDuration
 	stats.ColumnPublishTypedColumnPreparation += metrics.AssetMetrics.TypedColumnPartDuration
+	stats.ColumnPublishTypedColumnDictionaryBuild += metrics.AssetMetrics.TypedColumnDictionaryBuild
+	stats.ColumnPublishTypedColumnRowMaterialization += metrics.AssetMetrics.TypedColumnRowMaterialization
+	stats.ColumnPublishTypedColumnPartBuild += metrics.AssetMetrics.TypedColumnPartBuild
+	stats.ColumnPublishTypedColumnImageBuild += metrics.AssetMetrics.TypedColumnImageBuild
 	stats.ColumnPublishDictionaryPreparation += metrics.AssetMetrics.DictionarySidecarDuration
 	stats.ColumnPublishInt64Preparation += metrics.AssetMetrics.Int64SidecarDuration
 	stats.ColumnPublishAggregateMetadataPrepare += metrics.AssetMetrics.AggregateMetadataDuration
@@ -928,6 +932,10 @@ func (c *Collection) prepareColumnPhysicalAssetRowsForCommand(prepared ColumnPub
 				queueRegularManifestAsset(typedColumnImage, ColumnAssetKindTCS1TypedColumnPart, typedColumnPartAssetPartID, typedColumnRows, string(input.operation), role, columnSortKeyMatchString(typedColumnSortKey), validateTypedColumnRef)
 			}
 			prepared.AssetMetrics.TypedColumnPartDuration += time.Since(typedColumnStart)
+			prepared.AssetMetrics.TypedColumnDictionaryBuild += typedColumnBuild.Metrics.DictionaryBuild
+			prepared.AssetMetrics.TypedColumnRowMaterialization += typedColumnBuild.Metrics.RowMaterialization
+			prepared.AssetMetrics.TypedColumnPartBuild += typedColumnBuild.Metrics.PartBuild
+			prepared.AssetMetrics.TypedColumnImageBuild += typedColumnBuild.Metrics.ImageBuild
 			prepared.AssetMetrics.TypedColumnPartBytes = saturatingAddNonNegativeInt64(prepared.AssetMetrics.TypedColumnPartBytes, int64(len(typedColumnImage)))
 			prepared.AssetMetrics.TypedColumnPartCount++
 		}

--- a/TreeDB/collections/shape_bench_test.go
+++ b/TreeDB/collections/shape_bench_test.go
@@ -50,6 +50,10 @@ func addCollectionInsertStats(dst *collections.CollectionInsertStats, src collec
 	dst.ColumnPublishAssetPreparation += src.ColumnPublishAssetPreparation
 	dst.ColumnPublishRowAssetPreparation += src.ColumnPublishRowAssetPreparation
 	dst.ColumnPublishTypedColumnPreparation += src.ColumnPublishTypedColumnPreparation
+	dst.ColumnPublishTypedColumnDictionaryBuild += src.ColumnPublishTypedColumnDictionaryBuild
+	dst.ColumnPublishTypedColumnRowMaterialization += src.ColumnPublishTypedColumnRowMaterialization
+	dst.ColumnPublishTypedColumnPartBuild += src.ColumnPublishTypedColumnPartBuild
+	dst.ColumnPublishTypedColumnImageBuild += src.ColumnPublishTypedColumnImageBuild
 	dst.ColumnPublishDictionaryPreparation += src.ColumnPublishDictionaryPreparation
 	dst.ColumnPublishInt64Preparation += src.ColumnPublishInt64Preparation
 	dst.ColumnPublishAggregateMetadataPrepare += src.ColumnPublishAggregateMetadataPrepare
@@ -119,6 +123,10 @@ func benchmarkReportCollectionInsertStats(b *testing.B, docs, batches int, stats
 	reportDuration("column_publish_asset_prepare_ns/doc", stats.ColumnPublishAssetPreparation)
 	reportDuration("column_publish_row_asset_prepare_ns/doc", stats.ColumnPublishRowAssetPreparation)
 	reportDuration("column_publish_typed_column_prepare_ns/doc", stats.ColumnPublishTypedColumnPreparation)
+	reportDuration("column_publish_typed_column_dictionary_build_ns/doc", stats.ColumnPublishTypedColumnDictionaryBuild)
+	reportDuration("column_publish_typed_column_row_materialization_ns/doc", stats.ColumnPublishTypedColumnRowMaterialization)
+	reportDuration("column_publish_typed_column_part_build_ns/doc", stats.ColumnPublishTypedColumnPartBuild)
+	reportDuration("column_publish_typed_column_image_build_ns/doc", stats.ColumnPublishTypedColumnImageBuild)
 	reportDuration("column_publish_dictionary_prepare_ns/doc", stats.ColumnPublishDictionaryPreparation)
 	reportDuration("column_publish_int64_prepare_ns/doc", stats.ColumnPublishInt64Preparation)
 	reportDuration("column_publish_aggregate_metadata_prepare_ns/doc", stats.ColumnPublishAggregateMetadataPrepare)

--- a/TreeDB/collections/typed_column_adapter.go
+++ b/TreeDB/collections/typed_column_adapter.go
@@ -288,6 +288,14 @@ type typedColumnAdapterPart struct {
 	Columns    []typedColumnAdapterColumn
 	Part       *typedcolumn.ColumnPart
 	Dictionary map[string]map[string]int64
+	Metrics    typedColumnAdapterBuildMetrics
+}
+
+type typedColumnAdapterBuildMetrics struct {
+	DictionaryBuild time.Duration
+	BatchAllocation time.Duration
+	BatchFill       time.Duration
+	PartBuild       time.Duration
 }
 
 type typedColumnPartDecodedValues struct {
@@ -680,6 +688,7 @@ func buildTypedColumnAdapterPartFromSource(opts typedColumnAdapterOptions, rowSo
 	if opts.PartID == 0 {
 		opts.PartID = 1
 	}
+	var metrics typedColumnAdapterBuildMetrics
 	columns, err := typedColumnAdapterColumnsForFieldsWithOptions(opts.Fields, opts)
 	if err != nil {
 		return nil, err
@@ -688,6 +697,7 @@ func buildTypedColumnAdapterPartFromSource(opts typedColumnAdapterOptions, rowSo
 	if err != nil {
 		return nil, err
 	}
+	dictionaryStart := time.Now()
 	for i := range columns {
 		if columns[i].Field.ValueType == ColumnStoreValueString {
 			var dict map[string]int64
@@ -713,8 +723,10 @@ func buildTypedColumnAdapterPartFromSource(opts typedColumnAdapterOptions, rowSo
 			columns[i].Definition.Cardinality = uint32(len(dict))
 		}
 	}
+	metrics.DictionaryBuild += time.Since(dictionaryStart)
 
 	rowCount := rowSource.Len()
+	batchAllocStart := time.Now()
 	defs := make([]typedcolumn.ColumnDefinition, 0, len(columns)+1)
 	defs = append(defs, typedColumnAdapterPrimaryIDDefinition(opts))
 	for _, column := range columns {
@@ -833,6 +845,8 @@ func buildTypedColumnAdapterPartFromSource(opts typedColumnAdapterOptions, rowSo
 			}
 		}
 	}
+	metrics.BatchAllocation += time.Since(batchAllocStart)
+	batchFillStart := time.Now()
 	for rowIdx := 0; rowIdx < rowCount; rowIdx++ {
 		batch.Columns[typedColumnAdapterPrimaryIDColumn][rowIdx] = rowSource.PrimaryID(rowIdx)
 		for columnIdx, column := range columns {
@@ -943,6 +957,8 @@ func buildTypedColumnAdapterPartFromSource(opts typedColumnAdapterOptions, rowSo
 			}
 		}
 	}
+	metrics.BatchFill += time.Since(batchFillStart)
+	partBuildStart := time.Now()
 	rowsPerGranule := opts.RowsPerGranule
 	if rowsPerGranule == 0 {
 		rowsPerGranule = typedcolumn.DefaultRowsPerGranule
@@ -966,7 +982,8 @@ func buildTypedColumnAdapterPartFromSource(opts typedColumnAdapterOptions, rowSo
 	if err != nil {
 		return nil, err
 	}
-	return &typedColumnAdapterPart{Options: opts, Columns: columns, Part: part, Dictionary: typedColumnAdapterDictionaries(columns)}, nil
+	metrics.PartBuild += time.Since(partBuildStart)
+	return &typedColumnAdapterPart{Options: opts, Columns: columns, Part: part, Dictionary: typedColumnAdapterDictionaries(columns), Metrics: metrics}, nil
 }
 
 func typedColumnAdapterPartFromBytes(opts typedColumnAdapterOptions, raw []byte) (*typedColumnAdapterPart, error) {

--- a/TreeDB/collections/typed_column_publication.go
+++ b/TreeDB/collections/typed_column_publication.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"time"
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
 )
@@ -287,6 +288,14 @@ type typedColumnPartImageBuildResult struct {
 	Bytes                []byte
 	Rows                 int
 	TypedGranuleRowOrder []int
+	Metrics              typedColumnPartImageBuildMetrics
+}
+
+type typedColumnPartImageBuildMetrics struct {
+	DictionaryBuild    time.Duration
+	RowMaterialization time.Duration
+	PartBuild          time.Duration
+	ImageBuild         time.Duration
 }
 
 func buildTypedColumnPartImageForDeclaredRows(cfg ColumnStoreConfig, generation, partID uint64, rows []columnDeclaredRow) ([]byte, int, error) {
@@ -318,15 +327,22 @@ func buildTypedColumnPartImageForDeclaredRowsWithResult(cfg ColumnStoreConfig, g
 	if err != nil {
 		return typedColumnPartImageBuildResult{}, err
 	}
+	metrics := typedColumnPartImageBuildMetrics{
+		DictionaryBuild:    part.Metrics.DictionaryBuild,
+		RowMaterialization: part.Metrics.BatchAllocation + part.Metrics.BatchFill,
+		PartBuild:          part.Metrics.PartBuild,
+	}
+	imageStart := time.Now()
 	image, err := part.buildImage()
 	if err != nil {
 		return typedColumnPartImageBuildResult{}, err
 	}
+	metrics.ImageBuild += time.Since(imageStart)
 	rowOrder, err := typedColumnPartDeclaredRowOrder(part, image.Rows)
 	if err != nil {
 		return typedColumnPartImageBuildResult{}, err
 	}
-	return typedColumnPartImageBuildResult{Bytes: image.Bytes, Rows: image.Rows, TypedGranuleRowOrder: rowOrder}, nil
+	return typedColumnPartImageBuildResult{Bytes: image.Bytes, Rows: image.Rows, TypedGranuleRowOrder: rowOrder, Metrics: metrics}, nil
 }
 
 func typedColumnPublicationDictionaryModes(fields []TypedStorageField) map[string]typedColumnAdapterDictionaryMode {

--- a/cmd/unified_bench/suite_column_store.go
+++ b/cmd/unified_bench/suite_column_store.go
@@ -238,6 +238,10 @@ type columnStoreInsertPhaseMetric struct {
 	ColumnPublishAssetPreparationDurationMS   float64 `json:"column_publish_asset_preparation_duration_ms,omitempty"`
 	ColumnPublishRowAssetPrepareDurationMS    float64 `json:"column_publish_row_asset_prepare_duration_ms,omitempty"`
 	ColumnPublishTypedColumnPrepareDurationMS float64 `json:"column_publish_typed_column_prepare_duration_ms,omitempty"`
+	ColumnPublishTypedColumnDictionaryBuildMS float64 `json:"column_publish_typed_column_dictionary_build_duration_ms,omitempty"`
+	ColumnPublishTypedColumnRowMaterializeMS  float64 `json:"column_publish_typed_column_row_materialization_duration_ms,omitempty"`
+	ColumnPublishTypedColumnPartBuildMS       float64 `json:"column_publish_typed_column_part_build_duration_ms,omitempty"`
+	ColumnPublishTypedColumnImageBuildMS      float64 `json:"column_publish_typed_column_image_build_duration_ms,omitempty"`
 	ColumnPublishDictionaryPrepareDurationMS  float64 `json:"column_publish_dictionary_sidecar_prepare_duration_ms,omitempty"`
 	ColumnPublishInt64PrepareDurationMS       float64 `json:"column_publish_int64_sidecar_prepare_duration_ms,omitempty"`
 	ColumnPublishAggregateMetadataDurationMS  float64 `json:"column_publish_aggregate_metadata_prepare_duration_ms,omitempty"`
@@ -1535,6 +1539,10 @@ func columnStoreAddCollectionInsertStats(dst *collections.CollectionInsertStats,
 	dst.ColumnPublishAssetPreparation += src.ColumnPublishAssetPreparation
 	dst.ColumnPublishRowAssetPreparation += src.ColumnPublishRowAssetPreparation
 	dst.ColumnPublishTypedColumnPreparation += src.ColumnPublishTypedColumnPreparation
+	dst.ColumnPublishTypedColumnDictionaryBuild += src.ColumnPublishTypedColumnDictionaryBuild
+	dst.ColumnPublishTypedColumnRowMaterialization += src.ColumnPublishTypedColumnRowMaterialization
+	dst.ColumnPublishTypedColumnPartBuild += src.ColumnPublishTypedColumnPartBuild
+	dst.ColumnPublishTypedColumnImageBuild += src.ColumnPublishTypedColumnImageBuild
 	dst.ColumnPublishDictionaryPreparation += src.ColumnPublishDictionaryPreparation
 	dst.ColumnPublishInt64Preparation += src.ColumnPublishInt64Preparation
 	dst.ColumnPublishAggregateMetadataPrepare += src.ColumnPublishAggregateMetadataPrepare
@@ -1614,6 +1622,10 @@ func columnStoreInsertPhaseMetricFromStats(stats collections.CollectionInsertSta
 		ColumnPublishAssetPreparationDurationMS:   durationMS(stats.ColumnPublishAssetPreparation),
 		ColumnPublishRowAssetPrepareDurationMS:    durationMS(stats.ColumnPublishRowAssetPreparation),
 		ColumnPublishTypedColumnPrepareDurationMS: durationMS(stats.ColumnPublishTypedColumnPreparation),
+		ColumnPublishTypedColumnDictionaryBuildMS: durationMS(stats.ColumnPublishTypedColumnDictionaryBuild),
+		ColumnPublishTypedColumnRowMaterializeMS:  durationMS(stats.ColumnPublishTypedColumnRowMaterialization),
+		ColumnPublishTypedColumnPartBuildMS:       durationMS(stats.ColumnPublishTypedColumnPartBuild),
+		ColumnPublishTypedColumnImageBuildMS:      durationMS(stats.ColumnPublishTypedColumnImageBuild),
 		ColumnPublishDictionaryPrepareDurationMS:  durationMS(stats.ColumnPublishDictionaryPreparation),
 		ColumnPublishInt64PrepareDurationMS:       durationMS(stats.ColumnPublishInt64Preparation),
 		ColumnPublishAggregateMetadataDurationMS:  durationMS(stats.ColumnPublishAggregateMetadataPrepare),
@@ -4609,6 +4621,10 @@ func renderColumnStoreInsertStatsMarkdown(sb *strings.Builder, stats columnStore
 		sb.WriteString(fmt.Sprintf("| `asset_preparation` | %.3f |  |\n", stats.ColumnPublishAssetPreparationDurationMS))
 		sb.WriteString(fmt.Sprintf("| `row_asset_prepare` | %.3f |  |\n", stats.ColumnPublishRowAssetPrepareDurationMS))
 		sb.WriteString(fmt.Sprintf("| `typed_column_prepare` | %.3f |  |\n", stats.ColumnPublishTypedColumnPrepareDurationMS))
+		sb.WriteString(fmt.Sprintf("| `typed_column_dictionary_build` | %.3f |  |\n", stats.ColumnPublishTypedColumnDictionaryBuildMS))
+		sb.WriteString(fmt.Sprintf("| `typed_column_row_materialization` | %.3f |  |\n", stats.ColumnPublishTypedColumnRowMaterializeMS))
+		sb.WriteString(fmt.Sprintf("| `typed_column_part_build` | %.3f |  |\n", stats.ColumnPublishTypedColumnPartBuildMS))
+		sb.WriteString(fmt.Sprintf("| `typed_column_image_build` | %.3f |  |\n", stats.ColumnPublishTypedColumnImageBuildMS))
 		sb.WriteString(fmt.Sprintf("| `dictionary_sidecar_prepare` | %.3f |  |\n", stats.ColumnPublishDictionaryPrepareDurationMS))
 		sb.WriteString(fmt.Sprintf("| `int64_sidecar_prepare` | %.3f |  |\n", stats.ColumnPublishInt64PrepareDurationMS))
 		sb.WriteString(fmt.Sprintf("| `aggregate_metadata_prepare` | %.3f |  |\n", stats.ColumnPublishAggregateMetadataDurationMS))
@@ -4638,6 +4654,10 @@ func columnStoreInsertStatsHasColumnPublishSubphase(stats columnStoreInsertPhase
 		stats.ColumnPublishAssetPreparationDurationMS > 0 ||
 		stats.ColumnPublishRowAssetPrepareDurationMS > 0 ||
 		stats.ColumnPublishTypedColumnPrepareDurationMS > 0 ||
+		stats.ColumnPublishTypedColumnDictionaryBuildMS > 0 ||
+		stats.ColumnPublishTypedColumnRowMaterializeMS > 0 ||
+		stats.ColumnPublishTypedColumnPartBuildMS > 0 ||
+		stats.ColumnPublishTypedColumnImageBuildMS > 0 ||
 		stats.ColumnPublishDictionaryPrepareDurationMS > 0 ||
 		stats.ColumnPublishInt64PrepareDurationMS > 0 ||
 		stats.ColumnPublishAggregateMetadataDurationMS > 0 ||

--- a/cmd/unified_bench/suite_column_store_test.go
+++ b/cmd/unified_bench/suite_column_store_test.go
@@ -2682,9 +2682,15 @@ func TestColumnStoreApplyMetadataCostOnlyAggregateRowsM3070(t *testing.T) {
 
 func TestColumnStoreInsertPhaseMetricFromStatsIncludesAssetFamiliesM3148(t *testing.T) {
 	stats := collections.CollectionInsertStats{
-		Documents:                             10,
-		ColumnPublishRowAssetPreparation:      1 * time.Millisecond,
-		ColumnPublishTypedColumnPreparation:   2 * time.Millisecond,
+		Documents:                           10,
+		ColumnPublishRowAssetPreparation:    1 * time.Millisecond,
+		ColumnPublishTypedColumnPreparation: 2 * time.Millisecond,
+
+		ColumnPublishTypedColumnDictionaryBuild:    21 * time.Millisecond,
+		ColumnPublishTypedColumnRowMaterialization: 22 * time.Millisecond,
+		ColumnPublishTypedColumnPartBuild:          23 * time.Millisecond,
+		ColumnPublishTypedColumnImageBuild:         24 * time.Millisecond,
+
 		ColumnPublishDictionaryPreparation:    3 * time.Millisecond,
 		ColumnPublishInt64Preparation:         4 * time.Millisecond,
 		ColumnPublishAggregateMetadataPrepare: 5 * time.Millisecond,
@@ -2724,6 +2730,18 @@ func TestColumnStoreInsertPhaseMetricFromStatsIncludesAssetFamiliesM3148(t *test
 	}
 	if got, want := metric.ColumnPublishTypedColumnPrepareDurationMS, 2.0; got != want {
 		t.Fatalf("typed-column duration ms=%v want %v", got, want)
+	}
+	if got, want := metric.ColumnPublishTypedColumnDictionaryBuildMS, 21.0; got != want {
+		t.Fatalf("typed-column dictionary build ms=%v want %v", got, want)
+	}
+	if got, want := metric.ColumnPublishTypedColumnRowMaterializeMS, 22.0; got != want {
+		t.Fatalf("typed-column row materialization ms=%v want %v", got, want)
+	}
+	if got, want := metric.ColumnPublishTypedColumnPartBuildMS, 23.0; got != want {
+		t.Fatalf("typed-column part build ms=%v want %v", got, want)
+	}
+	if got, want := metric.ColumnPublishTypedColumnImageBuildMS, 24.0; got != want {
+		t.Fatalf("typed-column image build ms=%v want %v", got, want)
 	}
 	if got, want := metric.ColumnPublishDictionaryPrepareDurationMS, 3.0; got != want {
 		t.Fatalf("dictionary duration ms=%v want %v", got, want)


### PR DESCRIPTION
## Summary

Adds reporting-only timing splits for TreeDB typed-column load preparation so the JSONBench load/storage lanes can separate typed-column dictionary build, row materialization, durable part build, and part-image serialization cost.

This does not change value-log/WAL durability, on-disk format, query planning, or runtime execution. It does not claim a load-speed improvement; it gives #3067/#3099/#3070 better evidence for the next load-path optimization.

## What changed

- `CollectionInsertStats` now exposes typed-column load-prep subphase durations:
  - `ColumnPublishTypedColumnDictionaryBuild`
  - `ColumnPublishTypedColumnRowMaterialization`
  - `ColumnPublishTypedColumnPartBuild`
  - `ColumnPublishTypedColumnImageBuild`
- Column publish asset metrics aggregate those subphases from typed-column part publication.
- `cmd/unified_bench` emits the subphases in JSON and markdown insert/load stats.
- The collection insert benchmark reporting helper emits matching per-doc metrics.

## Validation

- `GOWORK=off go test ./TreeDB/collections -run 'TestTypedColumnNativeScalarFixedWidthPublicationCheckpointReopen|TestTypedColumnPublicationCheckpointReopen|TestColumnPublish' -count=1`
- `GOWORK=off go test ./cmd/unified_bench -count=1`
- JSONBench companion validation with local gomap replace:
  - `go test ./cmd/jsonbench_treedb -count=1`
  - fixture smoke: `/tmp/jsonbench_load_subtimers_full_smoke_20260628_231312/report.json`

Fixture smoke emitted nonzero typed-column subphase fields for a 6-row `column-store-full-prepared` functional run:

| field | value |
|---|---:|
| `insert_stats_column_publish_typed_column_prepare_seconds` | 0.003877411 |
| `insert_stats_column_publish_typed_column_dictionary_build_seconds` | 0.000009401 |
| `insert_stats_column_publish_typed_column_row_materialization_seconds` | 0.000010084 |
| `insert_stats_column_publish_typed_column_part_build_seconds` | 0.001322605 |
| `insert_stats_column_publish_typed_column_image_build_seconds` | 0.002351729 |

## Caveats

- Reporting/instrumentation only. No load-time improvement is claimed.
- The JSONBench report-field plumbing is a companion patch and should land after this gomap API is available from `main`.
