### PR TITLE
[codex] Add Mongo writeConcern raft ack mapping

### DIFF
--- a/TreeDB/mongo_gateway/COMPATIBILITY.md
+++ b/TreeDB/mongo_gateway/COMPATIBILITY.md
@@ -117,7 +117,7 @@ throughput check.
 | Command | `hostInfo` | `supported subset` | `TestMongoCompatibilityMatrix`, `TestServerHandlesHostInfo` | Returns minimal local runtime and OS metadata only. |
 | Command | `buildInfo` | `supported subset` | `TestMongoCompatibilityMatrix`, `TestServerHandlesBuildInfo` | Returns minimal MongoDB-compatible gateway version/build metadata only. |
 | Command | `ping` | `supported` | `TestMongoCompatibilityMatrix` | None for MVP. |
-| Command | `insert` / `insertMany` helper path | `supported subset` | `TestMongoCompatibilityMatrix`, `TestServerOfficialGoDriverBasicCRUD` | Write concern is not Mongo-compatible durability semantics yet. |
+| Command | `insert` / `insertMany` helper path | `supported subset` | `TestMongoCompatibilityMatrix`, `TestServerOfficialGoDriverBasicCRUD` | Standalone writeConcern durability remains minimal. In cluster submitter mode, absent/default and `{w: 1}` request visible ack, `{w: "majority"}` requests Raft-committed proof, and unsupported writeConcern options are rejected before submit. |
 | Command | `find` | `supported subset` | `TestMongoCompatibilityMatrix`, find planner tests | Query language is intentionally limited. |
 | Command | `getMore` / `killCursors` | `supported subset` | `TestMongoCompatibilityMatrix`, cursor tests | Server cursor state is in-memory only. |
 | Command | `update` / `updateOne` helper path | `supported subset` | `TestMongoCompatibilityMatrix`, update tests | Only `_id`-targeted updateOne with accepted update shapes. |
@@ -134,6 +134,7 @@ throughput check.
 | Command | collection/database drop | `not implemented` | Command falls through to `CommandNotFound` | Collection lifecycle beyond create and index metadata is not exposed. |
 | Command | logical sessions / `endSessions` | `supported subset` | `TestMongoCompatibilityMatrix`, `TestServerOfficialGoDriverLogicalSession` | Advertises `logicalSessionTimeoutMinutes` and accepts `endSessions`; session IDs are accepted for driver compatibility only. |
 | Command | transactions / retryable writes | `not implemented` | `TestMongoCompatibilityMatrix` rejects transaction and retryable-write markers on supported commands and covers `commitTransaction` absence | Depends on local transaction/WAL/idempotency roadmap. |
+| Command | cluster-mode `hello` primary advertisement | `supported subset` | `TestClusterHelloReflectsAdmissionWritablePrimary` | Uses cluster admission status to avoid advertising writable primary on followers or unavailable admission. |
 | Command | auth / authorization | `not implemented` | Command falls through to `CommandNotFound` | Out of MVP scope. |
 
 ## Desktop Client Check

--- a/TreeDB/mongo_gateway/cluster_submitter.go
+++ b/TreeDB/mongo_gateway/cluster_submitter.go
@@ -18,6 +18,10 @@ import (
 const (
 	clusterCollectionRefNameTag = byte(1)
 	clusterCollectionMetaV5     = uint64(5)
+
+	commandCodeWriteConcernFailed int32 = 64
+	commandCodeShutdownInProgress int32 = 91
+	commandCodeNotWritablePrimary int32 = 10107
 )
 
 func (s *Server) clusterSubmitterConfigured() bool {
@@ -35,7 +39,8 @@ func (s *Server) currentClusterCatalogVersion(ctx context.Context) (uint64, erro
 }
 
 func (s *Server) clusterCreateCollectionResponse(ctx context.Context, command wire.Document) (wire.Document, error) {
-	if err := rejectClusterWriteConcern(command); err != nil {
+	ack, err := parseClusterWriteConcern(command, "create")
+	if err != nil {
 		return commandError(commandCodeBadValue, "BadValue", err.Error())
 	}
 	collection, err := commandString(command, "create")
@@ -53,14 +58,15 @@ func (s *Server) clusterCreateCollectionResponse(ctx context.Context, command wi
 	if err := validateCreateCollectionCommand(command); err != nil {
 		return commandError(commandCodeBadValue, "BadValue", err.Error())
 	}
-	if err := s.submitClusterCreateCollection(ctx, *s.defaultCollectionMeta(name)); err != nil {
+	if err := s.submitClusterCreateCollection(ctx, *s.defaultCollectionMeta(name), ack); err != nil {
 		return mongoClusterMutationCommandError(err)
 	}
 	return marshalDocument(bson.D{{Key: "ok", Value: 1.0}})
 }
 
 func (s *Server) clusterInsertResponse(ctx context.Context, command wire.Document, sequences []wire.DocumentSequence) (wire.Document, error) {
-	if err := rejectClusterWriteConcern(command); err != nil {
+	ack, err := parseClusterWriteConcern(command, "insert")
+	if err != nil {
 		return commandError(commandCodeBadValue, "BadValue", err.Error())
 	}
 	collection, err := commandString(command, "insert")
@@ -88,11 +94,11 @@ func (s *Server) clusterInsertResponse(ctx context.Context, command wire.Documen
 		return commandError(commandCodeBadValue, "BadValue", err.Error())
 	}
 	if !exists {
-		if err := s.submitClusterCreateCollection(ctx, *s.defaultCollectionMeta(name)); err != nil {
+		if err := s.submitClusterCreateCollection(ctx, *s.defaultCollectionMeta(name), ack); err != nil {
 			return mongoClusterMutationCommandError(err)
 		}
 	}
-	inserted, err := s.submitClusterInsert(ctx, name, format, ids, stored)
+	inserted, err := s.submitClusterInsert(ctx, name, format, ids, stored, ack)
 	if err != nil {
 		return mongoClusterMutationCommandError(err)
 	}
@@ -103,7 +109,8 @@ func (s *Server) clusterInsertResponse(ctx context.Context, command wire.Documen
 }
 
 func (s *Server) clusterUpdateResponse(ctx context.Context, command wire.Document, sequences []wire.DocumentSequence) (wire.Document, error) {
-	if err := rejectClusterWriteConcern(command); err != nil {
+	ack, err := parseClusterWriteConcern(command, "update")
+	if err != nil {
 		return commandError(commandCodeBadValue, "BadValue", err.Error())
 	}
 	collection, err := commandString(command, "update")
@@ -141,7 +148,7 @@ func (s *Server) clusterUpdateResponse(ctx context.Context, command wire.Documen
 		if !item.bsonSetFieldsOK {
 			return commandError(commandCodeBadValue, "BadValue", fmt.Sprintf("updates[%d]: cluster Mongo gateway currently supports only top-level BSON $set updateOne by _id", i))
 		}
-		matchedOne, modifiedOne, err := s.submitClusterUpdateBSONSet(ctx, name, item)
+		matchedOne, modifiedOne, err := s.submitClusterUpdateBSONSet(ctx, name, item, ack)
 		if err != nil {
 			return mongoClusterMutationCommandError(mongoUpdateErrorWithIndex(item.index, err))
 		}
@@ -152,7 +159,8 @@ func (s *Server) clusterUpdateResponse(ctx context.Context, command wire.Documen
 }
 
 func (s *Server) clusterDeleteResponse(ctx context.Context, command wire.Document, sequences []wire.DocumentSequence) (wire.Document, error) {
-	if err := rejectClusterWriteConcern(command); err != nil {
+	ack, err := parseClusterWriteConcern(command, "delete")
+	if err != nil {
 		return commandError(commandCodeBadValue, "BadValue", err.Error())
 	}
 	collection, err := commandString(command, "delete")
@@ -187,7 +195,7 @@ func (s *Server) clusterDeleteResponse(ctx context.Context, command wire.Documen
 		if len(ids) == 0 {
 			return nil
 		}
-		_, err := s.submitClusterDelete(ctx, name, ids)
+		_, err := s.submitClusterDelete(ctx, name, ids, ack)
 		return err
 	}
 	for i, deleteItem := range deletes {
@@ -230,7 +238,7 @@ func (s *Server) clusterDeleteResponse(ctx context.Context, command wire.Documen
 		seenIDs[keyString] = struct{}{}
 		ids = append(ids, key)
 	}
-	deleted, err := s.submitClusterDelete(ctx, name, ids)
+	deleted, err := s.submitClusterDelete(ctx, name, ids, ack)
 	if err != nil {
 		return mongoClusterMutationCommandError(err)
 	}
@@ -265,7 +273,7 @@ func (s *Server) clusterCollectionExists(name string) (bool, error) {
 	return false, err
 }
 
-func (s *Server) submitClusterCreateCollection(ctx context.Context, meta collections.CollectionMeta) error {
+func (s *Server) submitClusterCreateCollection(ctx context.Context, meta collections.CollectionMeta, ack iwire.AckPolicy) error {
 	if len(meta.Indexes) != 0 || len(meta.VectorIndexes) != 0 || len(meta.TextIndexes) != 0 {
 		return errors.New("Mongo gateway cluster create currently supports only collection metadata without indexes")
 	}
@@ -277,11 +285,11 @@ func (s *Server) submitClusterCreateCollection(ctx context.Context, meta collect
 	if err != nil {
 		return err
 	}
-	_, err = s.submitClusterMutation(ctx, iwire.CommandCreateCollection, sections, seq)
+	_, err = s.submitClusterMutation(ctx, iwire.CommandCreateCollection, sections, seq, ack)
 	return err
 }
 
-func (s *Server) submitClusterInsert(ctx context.Context, name string, format collections.DocumentFormat, ids, docs [][]byte) (int32, error) {
+func (s *Server) submitClusterInsert(ctx context.Context, name string, format collections.DocumentFormat, ids, docs [][]byte, ack iwire.AckPolicy) (int32, error) {
 	catalogVersion, err := s.currentClusterCatalogVersion(ctx)
 	if err != nil {
 		return 0, err
@@ -294,7 +302,7 @@ func (s *Server) submitClusterInsert(ctx context.Context, name string, format co
 	if err != nil {
 		return 0, err
 	}
-	response, err := s.submitClusterMutation(ctx, iwire.CommandInsertBatch, sections, seq)
+	response, err := s.submitClusterMutation(ctx, iwire.CommandInsertBatch, sections, seq, ack)
 	if err != nil {
 		return 0, err
 	}
@@ -308,7 +316,7 @@ func (s *Server) submitClusterInsert(ctx context.Context, name string, format co
 	return inserted, nil
 }
 
-func (s *Server) submitClusterUpdateBSONSet(ctx context.Context, name string, item mongoUpdateItem) (int32, int32, error) {
+func (s *Server) submitClusterUpdateBSONSet(ctx context.Context, name string, item mongoUpdateItem, ack iwire.AckPolicy) (int32, int32, error) {
 	catalogVersion, err := s.currentClusterCatalogVersion(ctx)
 	if err != nil {
 		return 0, 0, err
@@ -321,7 +329,7 @@ func (s *Server) submitClusterUpdateBSONSet(ctx context.Context, name string, it
 	if err != nil {
 		return 0, 0, err
 	}
-	response, err := s.submitClusterMutation(ctx, iwire.CommandUpdateBSONSet, sections, seq)
+	response, err := s.submitClusterMutation(ctx, iwire.CommandUpdateBSONSet, sections, seq, ack)
 	if err != nil {
 		return 0, 0, err
 	}
@@ -342,7 +350,7 @@ func (s *Server) submitClusterUpdateBSONSet(ctx context.Context, name string, it
 	return matched, modified, nil
 }
 
-func (s *Server) submitClusterDelete(ctx context.Context, name string, ids [][]byte) (int32, error) {
+func (s *Server) submitClusterDelete(ctx context.Context, name string, ids [][]byte, ack iwire.AckPolicy) (int32, error) {
 	if len(ids) == 0 {
 		return 0, nil
 	}
@@ -356,7 +364,7 @@ func (s *Server) submitClusterDelete(ctx context.Context, name string, ids [][]b
 	if err != nil {
 		return 0, err
 	}
-	response, err := s.submitClusterMutation(ctx, iwire.CommandDeleteBatch, sections, seq)
+	response, err := s.submitClusterMutation(ctx, iwire.CommandDeleteBatch, sections, seq, ack)
 	if err != nil {
 		return 0, err
 	}
@@ -418,7 +426,7 @@ func (s *Server) clusterIdempotencyKey(commandName string, seq uint64) ([]byte, 
 	return key, nil
 }
 
-func (s *Server) submitClusterMutation(ctx context.Context, command iwire.CommandID, sections []iwire.Section, seq uint64) ([]iwire.Section, error) {
+func (s *Server) submitClusterMutation(ctx context.Context, command iwire.CommandID, sections []iwire.Section, seq uint64, ack iwire.AckPolicy) ([]iwire.Section, error) {
 	if s == nil || s.ClusterSubmitter == nil {
 		return nil, errors.New("Mongo gateway cluster submitter is not configured")
 	}
@@ -438,7 +446,7 @@ func (s *Server) submitClusterMutation(ctx context.Context, command iwire.Comman
 	}
 	metadata := treenativewire.ClusterRequestMetadata{
 		RequestID: uint64(seq),
-		AckPolicy: iwire.AckVisible,
+		AckPolicy: ack,
 	}
 	if _, err := raftentry.DecodeCommandEntryV1(entry, raftentry.DecodeOptions{RequestMetadata: metadata}); err != nil {
 		return nil, err
@@ -450,7 +458,7 @@ func (s *Server) submitClusterMutation(ctx context.Context, command iwire.Comman
 	if err != nil {
 		return nil, err
 	}
-	if err := validateMongoClusterSubmitResult(result); err != nil {
+	if err := validateMongoClusterSubmitResult(ack, result); err != nil {
 		return nil, err
 	}
 	return result.ResponseSections, nil
@@ -463,13 +471,20 @@ func (s *Server) admitClusterMutation(ctx context.Context) error {
 	return treenativewire.AdmitClusterMutation(ctx, s.ClusterSubmitter)
 }
 
-func validateMongoClusterSubmitResult(result treenativewire.ClusterSubmitResult) error {
+func validateMongoClusterSubmitResult(requested iwire.AckPolicy, result treenativewire.ClusterSubmitResult) error {
 	switch result.ActualAck {
-	case iwire.AckVisible, iwire.AckFlushed, iwire.AckSynced:
-	case iwire.AckRaftCommitted:
-		return errors.New("cluster submitter returned raft_committed without proving requested local visibility")
+	case iwire.AckVisible, iwire.AckFlushed, iwire.AckSynced, iwire.AckRaftCommitted:
 	default:
 		return fmt.Errorf("cluster submitter returned unsupported ack policy %d", result.ActualAck)
+	}
+	if requested == iwire.AckRaftCommitted {
+		if result.ActualAck != iwire.AckRaftCommitted || !result.CommittedRecoverable {
+			return mongoWriteConcernFailedError("cluster submitter did not prove raft_committed durability")
+		}
+	} else if result.ActualAck == iwire.AckRaftCommitted {
+		return mongoWriteConcernFailedError(fmt.Sprintf("cluster submitter returned raft_committed without proving requested local ack policy %d", requested))
+	} else if requested != 0 && result.ActualAck < requested {
+		return mongoWriteConcernFailedError(fmt.Sprintf("cluster submitter actual ack policy %d is below requested policy %d", result.ActualAck, requested))
 	}
 	ack, ok, err := clusterResponseMetaAckPolicy(result.ResponseSections)
 	if err != nil || !ok {
@@ -677,20 +692,85 @@ func clusterReadUvarint(src []byte) (uint64, int, error) {
 	}
 }
 
-func rejectClusterWriteConcern(command wire.Document) error {
-	if bson.Raw(command).Lookup("writeConcern").IsZero() {
-		return nil
+func parseClusterWriteConcern(command wire.Document, commandName string) (iwire.AckPolicy, error) {
+	raw := bson.Raw(command)
+	if !raw.Lookup("startTransaction").IsZero() || !raw.Lookup("autocommit").IsZero() || !raw.Lookup("txnNumber").IsZero() {
+		return 0, fmt.Errorf("Mongo gateway %s does not support transactions or retryable writes", commandName)
 	}
-	return errors.New("Mongo gateway cluster submitter mode does not implement Mongo writeConcern semantics")
+	value := raw.Lookup("writeConcern")
+	if value.IsZero() {
+		return iwire.AckVisible, nil
+	}
+	writeConcern, ok := value.DocumentOK()
+	if !ok {
+		return 0, errors.New("Mongo command field \"writeConcern\" must be a document")
+	}
+	elements, err := writeConcern.Elements()
+	if err != nil {
+		return 0, fmt.Errorf("Mongo command field \"writeConcern\" is malformed: %v", err)
+	}
+	ack := iwire.AckVisible
+	seenW := false
+	for _, elem := range elements {
+		key, err := elem.KeyErr()
+		if err != nil {
+			return 0, fmt.Errorf("Mongo command field \"writeConcern\" is malformed: %v", err)
+		}
+		switch key {
+		case "w":
+			if seenW {
+				return 0, errors.New("Mongo writeConcern field \"w\" is duplicated")
+			}
+			seenW = true
+			ack, err = parseClusterWriteConcernW(elem.Value())
+			if err != nil {
+				return 0, err
+			}
+		case "j", "wtimeout", "wtimeoutMS":
+			return 0, fmt.Errorf("Mongo gateway cluster writeConcern does not support %q", key)
+		default:
+			return 0, fmt.Errorf("Mongo gateway cluster writeConcern does not support %q", key)
+		}
+	}
+	return ack, nil
+}
+
+func parseClusterWriteConcernW(value bson.RawValue) (iwire.AckPolicy, error) {
+	if w, ok := strictBSONInt64(value); ok {
+		switch {
+		case w == 1:
+			return iwire.AckVisible, nil
+		case w == 0:
+			return 0, errors.New("Mongo gateway cluster writeConcern does not support unacknowledged w:0 writes")
+		case w > 1:
+			return 0, errors.New("Mongo gateway cluster writeConcern does not support numeric w greater than 1")
+		default:
+			return 0, errors.New("Mongo gateway cluster writeConcern does not support negative numeric w")
+		}
+	}
+	if w, ok := value.StringValueOK(); ok {
+		if w == "majority" {
+			return iwire.AckRaftCommitted, nil
+		}
+		return 0, fmt.Errorf("Mongo gateway cluster writeConcern does not support tag string w:%q", w)
+	}
+	return 0, errors.New("Mongo command field \"writeConcern.w\" must be integer 1 or string \"majority\"")
 }
 
 func mongoClusterMutationCommandError(err error) (wire.Document, error) {
 	code, codeName := commandCodeBadValue, "BadValue"
-	if nativeCode, ok := iwire.ErrorCodeOf(err); ok {
+	var mongoErr mongoCommandError
+	if errors.As(err, &mongoErr) {
+		code, codeName = mongoErr.code, mongoErr.codeName
+	} else if nativeCode, ok := iwire.ErrorCodeOf(err); ok {
 		switch nativeCode {
 		case iwire.ErrUnsupportedFeature:
 			code, codeName = commandCodeBadValue, "BadValue"
-		case iwire.ErrDurabilityUnavailable, iwire.ErrReadOnly, iwire.ErrCatalogVersionMismatch:
+		case iwire.ErrReadOnly:
+			code, codeName = commandCodeNotWritablePrimary, "NotWritablePrimary"
+		case iwire.ErrDurabilityUnavailable:
+			code, codeName = commandCodeShutdownInProgress, "ShutdownInProgress"
+		case iwire.ErrCatalogVersionMismatch:
 			code, codeName = commandCodeBadValue, "BadValue"
 		case iwire.ErrDuplicateDocumentID, iwire.ErrDocumentExists, iwire.ErrUniqueIndexConflict:
 			code, codeName = commandCodeDuplicateKey, "DuplicateKey"
@@ -700,6 +780,20 @@ func mongoClusterMutationCommandError(err error) (wire.Document, error) {
 		code, codeName = commandCodeDuplicateKey, "DuplicateKey"
 	}
 	return commandError(code, codeName, err.Error())
+}
+
+type mongoCommandError struct {
+	code     int32
+	codeName string
+	message  string
+}
+
+func (e mongoCommandError) Error() string {
+	return e.message
+}
+
+func mongoWriteConcernFailedError(message string) error {
+	return mongoCommandError{code: commandCodeWriteConcernFailed, codeName: "WriteConcernFailed", message: message}
 }
 
 func mongoClusterUnsupportedLocalMutation(command string) (wire.Document, error) {

--- a/TreeDB/mongo_gateway/cluster_submitter.go
+++ b/TreeDB/mongo_gateway/cluster_submitter.go
@@ -137,6 +137,9 @@ func (s *Server) clusterUpdateResponse(ctx context.Context, command wire.Documen
 		return commandError(commandCodeBadValue, "BadValue", err.Error())
 	}
 	if !exists {
+		if err := rejectClusterMissingCollectionMajorityNoop(ack); err != nil {
+			return mongoClusterMutationCommandError(err)
+		}
 		return marshalUpdateResponse(0, 0)
 	}
 	var matched, modified int32
@@ -187,6 +190,9 @@ func (s *Server) clusterDeleteResponse(ctx context.Context, command wire.Documen
 		return commandError(commandCodeBadValue, "BadValue", err.Error())
 	}
 	if !exists {
+		if err := rejectClusterMissingCollectionMajorityNoop(ack); err != nil {
+			return mongoClusterMutationCommandError(err)
+		}
 		return marshalDeleteResponse(0)
 	}
 	ids := make([][]byte, 0, len(deletes))
@@ -376,6 +382,13 @@ func (s *Server) submitClusterDelete(ctx context.Context, name string, ids [][]b
 		return 0, errors.New("cluster submitter response_meta missing deleted_count")
 	}
 	return deleted, nil
+}
+
+func rejectClusterMissingCollectionMajorityNoop(ack iwire.AckPolicy) error {
+	if ack != iwire.AckRaftCommitted {
+		return nil
+	}
+	return mongoWriteConcernFailedError("cluster submitter cannot prove raft_committed durability for missing collection no-op")
 }
 
 func (s *Server) clusterCreateCollectionSections(meta collections.CollectionMeta, catalogVersion uint64) ([]iwire.Section, uint64, error) {

--- a/TreeDB/mongo_gateway/cluster_submitter_test.go
+++ b/TreeDB/mongo_gateway/cluster_submitter_test.go
@@ -786,6 +786,63 @@ func TestClusterSubmitterDeleteMissingCollectionReturnsZeroCount(t *testing.T) {
 	}
 }
 
+func TestClusterSubmitterMajorityWriteConcernRejectsMissingCollectionNoops(t *testing.T) {
+	t.Run("update", func(t *testing.T) {
+		db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+		if err != nil {
+			t.Fatalf("open db: %v", err)
+		}
+		defer func() { _ = db.Close() }()
+
+		submitter := &mongoClusterFakeSubmitter{actualAck: iwire.AckRaftCommitted, committedRecoverable: true}
+		server := NewServer()
+		server.Collections = collections.NewCollectionManager(db)
+		server.DefaultCollectionOptions = collections.CollectionOptions{DocumentFormat: collections.DocumentFormatBSON}
+		setMongoClusterTestSubmitter(server, submitter, 30)
+
+		response := serveCommand(t, server, 325832, bson.D{
+			{Key: "update", Value: "missing"},
+			{Key: "updates", Value: bson.A{bson.D{
+				{Key: "q", Value: bson.D{{Key: "_id", Value: "u1"}}},
+				{Key: "u", Value: bson.D{{Key: "$set", Value: bson.D{{Key: "name", Value: "Grace"}}}}},
+			}}},
+			{Key: "writeConcern", Value: bson.D{{Key: "w", Value: "majority"}}},
+			{Key: "$db", Value: "app"},
+		})
+		assertCommandError(t, response, "WriteConcernFailed")
+		assertErrmsgContains(t, response, "missing collection no-op")
+		if calls := submitter.snapshotCalls(); len(calls) != 0 {
+			t.Fatalf("submit calls=%d want 0", len(calls))
+		}
+	})
+
+	t.Run("delete", func(t *testing.T) {
+		db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+		if err != nil {
+			t.Fatalf("open db: %v", err)
+		}
+		defer func() { _ = db.Close() }()
+
+		submitter := &mongoClusterFakeSubmitter{actualAck: iwire.AckRaftCommitted, committedRecoverable: true}
+		server := NewServer()
+		server.Collections = collections.NewCollectionManager(db)
+		server.DefaultCollectionOptions = collections.CollectionOptions{DocumentFormat: collections.DocumentFormatBSON}
+		setMongoClusterTestSubmitter(server, submitter, 31)
+
+		response := serveCommand(t, server, 325833, bson.D{
+			{Key: "delete", Value: "missing"},
+			{Key: "deletes", Value: bson.A{bson.D{{Key: "q", Value: bson.D{{Key: "_id", Value: "u1"}}}, {Key: "limit", Value: int32(1)}}}},
+			{Key: "writeConcern", Value: bson.D{{Key: "w", Value: "majority"}}},
+			{Key: "$db", Value: "app"},
+		})
+		assertCommandError(t, response, "WriteConcernFailed")
+		assertErrmsgContains(t, response, "missing collection no-op")
+		if calls := submitter.snapshotCalls(); len(calls) != 0 {
+			t.Fatalf("submit calls=%d want 0", len(calls))
+		}
+	})
+}
+
 func TestClusterSubmitterWriteConcernAccepted(t *testing.T) {
 	tests := []struct {
 		name                 string

--- a/TreeDB/mongo_gateway/cluster_submitter_test.go
+++ b/TreeDB/mongo_gateway/cluster_submitter_test.go
@@ -77,7 +77,7 @@ func (f *mongoClusterFakeSubmitter) SubmitCommandEntryV1(ctx context.Context, en
 	if actualAck == 0 {
 		actualAck = iwire.AckVisible
 	}
-	responseSections := mongoClusterFakeResponseSections(decoded.Decoded)
+	responseSections := mongoClusterFakeResponseSections(decoded.Decoded, actualAck)
 	if f.overrideResponseSections {
 		responseSections = append([]iwire.Section(nil), f.responseSections...)
 	}
@@ -94,25 +94,29 @@ func (f *mongoClusterFakeSubmitter) snapshotCalls() []mongoClusterSubmitterCall 
 	return append([]mongoClusterSubmitterCall(nil), f.calls...)
 }
 
-func mongoClusterFakeResponseSections(entry iwire.DeterministicEntry) []iwire.Section {
+func mongoClusterFakeResponseSections(entry iwire.DeterministicEntry, actualAck iwire.AckPolicy) []iwire.Section {
 	ids := mongoClusterTestIDs(entry.Sections)
 	switch entry.CommandID {
 	case iwire.CommandInsertBatch:
-		return []iwire.Section{mongoClusterTestMeta("inserted_count", len(ids))}
+		return []iwire.Section{mongoClusterTestMetaWithAck(actualAck, "inserted_count", len(ids))}
 	case iwire.CommandUpdateBSONSet:
-		return []iwire.Section{mongoClusterTestMeta("matched_count", 1, "modified_count", 1)}
+		return []iwire.Section{mongoClusterTestMetaWithAck(actualAck, "matched_count", 1, "modified_count", 1)}
 	case iwire.CommandDeleteBatch:
-		return []iwire.Section{mongoClusterTestMeta("deleted_count", len(ids))}
+		return []iwire.Section{mongoClusterTestMetaWithAck(actualAck, "deleted_count", len(ids))}
 	default:
-		return []iwire.Section{mongoClusterTestMeta()}
+		return []iwire.Section{mongoClusterTestMetaWithAck(actualAck)}
 	}
 }
 
 func mongoClusterTestMeta(counts ...any) iwire.Section {
+	return mongoClusterTestMetaWithAck(iwire.AckVisible, counts...)
+}
+
+func mongoClusterTestMetaWithAck(actualAck iwire.AckPolicy, counts ...any) iwire.Section {
 	values := []struct {
 		key   string
 		value string
-	}{{key: "actual_ack_policy", value: "1"}}
+	}{{key: "actual_ack_policy", value: fmt.Sprint(actualAck)}}
 	for i := 0; i+1 < len(counts); i += 2 {
 		values = append(values, struct {
 			key   string
@@ -212,6 +216,13 @@ func mongoClusterCallIdempotencyKey(tb testing.TB, call mongoClusterSubmitterCal
 	return string(call.entry.IdempotencyKey)
 }
 
+func assertMongoClusterCallAckPolicy(tb testing.TB, call mongoClusterSubmitterCall, want iwire.AckPolicy) {
+	tb.Helper()
+	if call.metadata.AckPolicy != want {
+		tb.Fatalf("metadata ack policy=%d want %d", call.metadata.AckPolicy, want)
+	}
+}
+
 func TestClusterAdmissionMongoLeaderRoutesThroughSubmitter(t *testing.T) {
 	submitter := &mongoClusterAdmissionSubmitter{
 		mongoClusterFakeSubmitter: &mongoClusterFakeSubmitter{},
@@ -238,6 +249,8 @@ func TestClusterAdmissionMongoLeaderRoutesThroughSubmitter(t *testing.T) {
 	if got := calls[1].entry.Decoded.CommandID; got != iwire.CommandInsertBatch {
 		t.Fatalf("second command id=%d want insert_batch", got)
 	}
+	assertMongoClusterCallAckPolicy(t, calls[0], iwire.AckVisible)
+	assertMongoClusterCallAckPolicy(t, calls[1], iwire.AckVisible)
 }
 
 func TestClusterAdmissionMongoFollowerRejectsWritesBeforeLocalMutation(t *testing.T) {
@@ -266,7 +279,7 @@ func TestClusterAdmissionMongoFollowerRejectsWritesBeforeLocalMutation(t *testin
 		{Key: "create", Value: "admins"},
 		{Key: "$db", Value: "app"},
 	})
-	assertCommandError(t, createResponse, "BadValue")
+	assertCommandError(t, createResponse, "NotWritablePrimary")
 	assertErrmsgContains(t, createResponse, "node-a:27017")
 	if _, err := server.Collections.OpenCollection("app.admins"); !errors.Is(err, collections.ErrCollectionNotFound) {
 		t.Fatalf("OpenCollection app.admins err=%v want collection not found", err)
@@ -277,7 +290,7 @@ func TestClusterAdmissionMongoFollowerRejectsWritesBeforeLocalMutation(t *testin
 		{Key: "documents", Value: bson.A{bson.D{{Key: "_id", Value: "u2"}, {Key: "name", Value: "Grace"}}}},
 		{Key: "$db", Value: "app"},
 	})
-	assertCommandError(t, insertResponse, "BadValue")
+	assertCommandError(t, insertResponse, "NotWritablePrimary")
 	assertMongoUsers(t, server, map[string]string{"u1": "Ada"})
 
 	updateResponse := serveCommand(t, server, 326805, bson.D{
@@ -288,7 +301,7 @@ func TestClusterAdmissionMongoFollowerRejectsWritesBeforeLocalMutation(t *testin
 		}}},
 		{Key: "$db", Value: "app"},
 	})
-	assertCommandError(t, updateResponse, "BadValue")
+	assertCommandError(t, updateResponse, "NotWritablePrimary")
 	assertMongoUsers(t, server, map[string]string{"u1": "Ada"})
 
 	deleteResponse := serveCommand(t, server, 326806, bson.D{
@@ -296,7 +309,7 @@ func TestClusterAdmissionMongoFollowerRejectsWritesBeforeLocalMutation(t *testin
 		{Key: "deletes", Value: bson.A{bson.D{{Key: "q", Value: bson.D{{Key: "_id", Value: "u1"}}}, {Key: "limit", Value: int32(1)}}}},
 		{Key: "$db", Value: "app"},
 	})
-	assertCommandError(t, deleteResponse, "BadValue")
+	assertCommandError(t, deleteResponse, "NotWritablePrimary")
 	assertMongoUsers(t, server, map[string]string{"u1": "Ada"})
 	if calls := submitter.snapshotCalls(); len(calls) != 0 {
 		t.Fatalf("submit calls=%d want 0", len(calls))
@@ -327,7 +340,7 @@ func TestClusterAdmissionMongoFollowerRejectsMissingCollectionNoOps(t *testing.T
 		}}},
 		{Key: "$db", Value: "app"},
 	})
-	assertCommandError(t, updateResponse, "BadValue")
+	assertCommandError(t, updateResponse, "NotWritablePrimary")
 	assertErrmsgContains(t, updateResponse, "node-a:27017")
 
 	deleteResponse := serveCommand(t, server, 326809, bson.D{
@@ -335,7 +348,7 @@ func TestClusterAdmissionMongoFollowerRejectsMissingCollectionNoOps(t *testing.T
 		{Key: "deletes", Value: bson.A{bson.D{{Key: "q", Value: bson.D{{Key: "_id", Value: "u1"}}}, {Key: "limit", Value: int32(1)}}}},
 		{Key: "$db", Value: "app"},
 	})
-	assertCommandError(t, deleteResponse, "BadValue")
+	assertCommandError(t, deleteResponse, "NotWritablePrimary")
 	assertErrmsgContains(t, deleteResponse, "node-a:27017")
 	if calls := submitter.snapshotCalls(); len(calls) != 0 {
 		t.Fatalf("submit calls=%d want 0", len(calls))
@@ -358,10 +371,58 @@ func TestClusterAdmissionMongoUnavailableRejectsBeforeSubmit(t *testing.T) {
 		{Key: "create", Value: "users"},
 		{Key: "$db", Value: "app"},
 	})
-	assertCommandError(t, response, "BadValue")
+	assertCommandError(t, response, "ShutdownInProgress")
 	assertErrmsgContains(t, response, "cluster admission unavailable")
 	if calls := submitter.snapshotCalls(); len(calls) != 0 {
 		t.Fatalf("submit calls=%d want 0", len(calls))
+	}
+}
+
+func TestClusterHelloReflectsAdmissionWritablePrimary(t *testing.T) {
+	tests := []struct {
+		name                string
+		submitter           treenativewire.ClusterSubmitter
+		wantWritablePrimary bool
+	}{
+		{
+			name: "leader",
+			submitter: &mongoClusterAdmissionSubmitter{
+				mongoClusterFakeSubmitter: &mongoClusterFakeSubmitter{},
+				status:                    treenativewire.ClusterLeaderAdmission(),
+			},
+			wantWritablePrimary: true,
+		},
+		{
+			name: "follower",
+			submitter: &mongoClusterAdmissionSubmitter{
+				mongoClusterFakeSubmitter: &mongoClusterFakeSubmitter{},
+				status:                    treenativewire.ClusterFollowerAdmission("node-a:27017", "not leader"),
+			},
+		},
+		{
+			name: "unavailable",
+			submitter: &mongoClusterAdmissionSubmitter{
+				mongoClusterFakeSubmitter: &mongoClusterFakeSubmitter{},
+				status:                    treenativewire.ClusterUnavailableAdmission("cluster unavailable"),
+			},
+		},
+		{
+			name:      "admission error",
+			submitter: &mongoClusterFakeSubmitter{admissionErr: errors.New("admission check failed")},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			server := NewServer()
+			server.ClusterSubmitter = tc.submitter
+			response := serveCommand(t, server, 326810, bson.D{
+				{Key: "hello", Value: int32(1)},
+				{Key: "$db", Value: "admin"},
+			})
+			assertOK(t, response)
+			assertBool(t, response, "isWritablePrimary", tc.wantWritablePrimary)
+			assertBool(t, response, "ismaster", tc.wantWritablePrimary)
+		})
 	}
 }
 
@@ -422,6 +483,8 @@ func TestClusterSubmitterInsertRoutesCommandEntryNoLocalMutation(t *testing.T) {
 	if got := mongoClusterCallCatalogVersion(t, calls[1]); got != 7 {
 		t.Fatalf("insert expected catalog version=%d want 7", got)
 	}
+	assertMongoClusterCallAckPolicy(t, calls[0], iwire.AckVisible)
+	assertMongoClusterCallAckPolicy(t, calls[1], iwire.AckVisible)
 	if _, err := server.Collections.OpenCollection("app.users"); err == nil {
 		t.Fatal("cluster insert created local collection")
 	} else if err != collections.ErrCollectionNotFound {
@@ -459,6 +522,7 @@ func TestClusterSubmitterInsertSkipsAutoCreateForKnownLocalCollection(t *testing
 	if got := calls[0].entry.Decoded.CommandID; got != iwire.CommandInsertBatch {
 		t.Fatalf("command id=%d want insert_batch", got)
 	}
+	assertMongoClusterCallAckPolicy(t, calls[0], iwire.AckVisible)
 }
 
 func TestClusterSubmitterIdempotencyKeysIncludeServerNonce(t *testing.T) {
@@ -538,6 +602,7 @@ func TestClusterSubmitterUpdateBSONSetRoutesCountsAndNoLocalMutation(t *testing.
 	if got := calls[0].entry.Decoded.CommandID; got != iwire.CommandUpdateBSONSet {
 		t.Fatalf("command id=%d want update_bson_set", got)
 	}
+	assertMongoClusterCallAckPolicy(t, calls[0], iwire.AckVisible)
 	found := serveCommand(t, server, 325804, bson.D{
 		{Key: "find", Value: "users"},
 		{Key: "filter", Value: bson.D{{Key: "_id", Value: "u1"}}},
@@ -581,6 +646,7 @@ func TestClusterSubmitterUpdateSubmitsPriorOrderedItemsBeforeUnsupported(t *test
 	if got := calls[0].entry.Decoded.CommandID; got != iwire.CommandUpdateBSONSet {
 		t.Fatalf("command id=%d want update_bson_set", got)
 	}
+	assertMongoClusterCallAckPolicy(t, calls[0], iwire.AckVisible)
 }
 
 func TestClusterSubmitterUpdateMissingCollectionReturnsZeroCounts(t *testing.T) {
@@ -634,6 +700,7 @@ func TestClusterSubmitterDeleteRoutesCommandEntry(t *testing.T) {
 	if got := calls[0].entry.Decoded.CommandID; got != iwire.CommandDeleteBatch {
 		t.Fatalf("command id=%d want delete_batch", got)
 	}
+	assertMongoClusterCallAckPolicy(t, calls[0], iwire.AckVisible)
 }
 
 func TestClusterSubmitterDeleteDeduplicatesDuplicateIDs(t *testing.T) {
@@ -686,6 +753,7 @@ func TestClusterSubmitterDeleteSubmitsPriorOrderedItemsBeforeUnsupported(t *test
 	if got := calls[0].entry.Decoded.CommandID; got != iwire.CommandDeleteBatch {
 		t.Fatalf("command id=%d want delete_batch", got)
 	}
+	assertMongoClusterCallAckPolicy(t, calls[0], iwire.AckVisible)
 	ids := mongoClusterTestIDs(calls[0].entry.Decoded.Sections)
 	if len(ids) != 1 {
 		t.Fatalf("document ids=%d want 1", len(ids))
@@ -718,21 +786,271 @@ func TestClusterSubmitterDeleteMissingCollectionReturnsZeroCount(t *testing.T) {
 	}
 }
 
-func TestClusterSubmitterRejectsWriteConcern(t *testing.T) {
-	submitter := &mongoClusterFakeSubmitter{}
-	server := NewServer()
-	server.DefaultCollectionOptions = collections.CollectionOptions{DocumentFormat: collections.DocumentFormatBSON}
-	setMongoClusterTestSubmitter(server, submitter, 10)
+func TestClusterSubmitterWriteConcernAccepted(t *testing.T) {
+	tests := []struct {
+		name                 string
+		writeConcern         any
+		actualAck            iwire.AckPolicy
+		committedRecoverable bool
+		wantAck              iwire.AckPolicy
+	}{
+		{name: "absent", wantAck: iwire.AckVisible},
+		{name: "default document", writeConcern: bson.D{}, wantAck: iwire.AckVisible},
+		{name: "w one", writeConcern: bson.D{{Key: "w", Value: int32(1)}}, wantAck: iwire.AckVisible},
+		{name: "majority", writeConcern: bson.D{{Key: "w", Value: "majority"}}, actualAck: iwire.AckRaftCommitted, committedRecoverable: true, wantAck: iwire.AckRaftCommitted},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			submitter := &mongoClusterFakeSubmitter{
+				actualAck:            tc.actualAck,
+				committedRecoverable: tc.committedRecoverable,
+			}
+			server := NewServer()
+			server.DefaultCollectionOptions = collections.CollectionOptions{DocumentFormat: collections.DocumentFormatBSON}
+			setMongoClusterTestSubmitter(server, submitter, 10)
 
-	response := serveCommand(t, server, 325806, bson.D{
-		{Key: "insert", Value: "users"},
-		{Key: "documents", Value: bson.A{bson.D{{Key: "_id", Value: "u1"}}}},
-		{Key: "writeConcern", Value: bson.D{{Key: "w", Value: "majority"}}},
-		{Key: "$db", Value: "app"},
+			command := bson.D{
+				{Key: "create", Value: "users"},
+				{Key: "$db", Value: "app"},
+			}
+			if tc.writeConcern != nil {
+				command = append(command, bson.E{Key: "writeConcern", Value: tc.writeConcern})
+			}
+			response := serveCommand(t, server, 325806, command)
+			assertOK(t, response)
+			calls := submitter.snapshotCalls()
+			if len(calls) != 1 {
+				t.Fatalf("submit calls=%d want 1", len(calls))
+			}
+			assertMongoClusterCallAckPolicy(t, calls[0], tc.wantAck)
+		})
+	}
+}
+
+func TestClusterSubmitterRejectsUnsupportedWriteConcernBeforeSubmitOrLocalMutation(t *testing.T) {
+	tests := []struct {
+		name         string
+		writeConcern any
+		extraFields  bson.D
+	}{
+		{name: "writeConcern not document", writeConcern: "majority"},
+		{name: "journaling", writeConcern: bson.D{{Key: "j", Value: true}}},
+		{name: "wtimeout", writeConcern: bson.D{{Key: "wtimeout", Value: int32(1)}}},
+		{name: "wtimeoutMS", writeConcern: bson.D{{Key: "wtimeoutMS", Value: int32(1)}}},
+		{name: "unacknowledged", writeConcern: bson.D{{Key: "w", Value: int32(0)}}},
+		{name: "numeric greater than one", writeConcern: bson.D{{Key: "w", Value: int32(2)}}},
+		{name: "tag string", writeConcern: bson.D{{Key: "w", Value: "rack-a"}}},
+		{name: "malformed w type", writeConcern: bson.D{{Key: "w", Value: true}}},
+		{name: "unknown option", writeConcern: bson.D{{Key: "fsync", Value: true}}},
+		{name: "retryable write marker", extraFields: bson.D{{Key: "txnNumber", Value: int64(1)}}},
+		{name: "transaction start marker", extraFields: bson.D{{Key: "startTransaction", Value: true}}},
+		{name: "transaction autocommit marker", extraFields: bson.D{{Key: "autocommit", Value: false}}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+			if err != nil {
+				t.Fatalf("open db: %v", err)
+			}
+			defer func() { _ = db.Close() }()
+
+			server := NewServer()
+			server.Collections = collections.NewCollectionManager(db)
+			server.DefaultCollectionOptions = collections.CollectionOptions{DocumentFormat: collections.DocumentFormatBSON}
+			assertOK(t, serveCommand(t, server, 325806, bson.D{
+				{Key: "insert", Value: "users"},
+				{Key: "documents", Value: bson.A{bson.D{{Key: "_id", Value: "u1"}, {Key: "name", Value: "Ada"}}}},
+				{Key: "$db", Value: "app"},
+			}))
+
+			submitter := &mongoClusterFakeSubmitter{}
+			setMongoClusterTestSubmitter(server, submitter, 10)
+			command := bson.D{
+				{Key: "insert", Value: "users"},
+				{Key: "documents", Value: bson.A{bson.D{{Key: "_id", Value: "u2"}, {Key: "name", Value: "Grace"}}}},
+				{Key: "$db", Value: "app"},
+			}
+			if tc.writeConcern != nil {
+				command = append(command, bson.E{Key: "writeConcern", Value: tc.writeConcern})
+			}
+			command = append(command, tc.extraFields...)
+			response := serveCommand(t, server, 325807, command)
+			assertCommandError(t, response, "BadValue")
+			if calls := submitter.snapshotCalls(); len(calls) != 0 {
+				t.Fatalf("submit calls=%d want 0", len(calls))
+			}
+			assertMongoUsers(t, server, map[string]string{"u1": "Ada"})
+		})
+	}
+}
+
+func TestClusterSubmitterMajorityWriteConcernRoutesAckPolicy(t *testing.T) {
+	t.Run("create", func(t *testing.T) {
+		submitter := &mongoClusterFakeSubmitter{actualAck: iwire.AckRaftCommitted, committedRecoverable: true}
+		server := NewServer()
+		server.DefaultCollectionOptions = collections.CollectionOptions{DocumentFormat: collections.DocumentFormatBSON}
+		setMongoClusterTestSubmitter(server, submitter, 25)
+
+		response := serveCommand(t, server, 325825, bson.D{
+			{Key: "create", Value: "users"},
+			{Key: "writeConcern", Value: bson.D{{Key: "w", Value: "majority"}}},
+			{Key: "$db", Value: "app"},
+		})
+		assertOK(t, response)
+		calls := submitter.snapshotCalls()
+		if len(calls) != 1 {
+			t.Fatalf("submit calls=%d want 1", len(calls))
+		}
+		if got := calls[0].entry.Decoded.CommandID; got != iwire.CommandCreateCollection {
+			t.Fatalf("command id=%d want create_collection", got)
+		}
+		assertMongoClusterCallAckPolicy(t, calls[0], iwire.AckRaftCommitted)
 	})
-	assertCommandError(t, response, "BadValue")
-	if calls := submitter.snapshotCalls(); len(calls) != 0 {
-		t.Fatalf("submit calls=%d want 0", len(calls))
+
+	t.Run("insert", func(t *testing.T) {
+		submitter := &mongoClusterFakeSubmitter{actualAck: iwire.AckRaftCommitted, committedRecoverable: true}
+		server := NewServer()
+		server.DefaultCollectionOptions = collections.CollectionOptions{DocumentFormat: collections.DocumentFormatBSON}
+		setMongoClusterTestSubmitter(server, submitter, 26)
+
+		response := serveCommand(t, server, 325826, bson.D{
+			{Key: "insert", Value: "users"},
+			{Key: "documents", Value: bson.A{bson.D{{Key: "_id", Value: "u1"}}}},
+			{Key: "writeConcern", Value: bson.D{{Key: "w", Value: "majority"}}},
+			{Key: "$db", Value: "app"},
+		})
+		assertOK(t, response)
+		assertInt32(t, response, "n", 1)
+		calls := submitter.snapshotCalls()
+		if len(calls) != 2 {
+			t.Fatalf("submit calls=%d want create+insert", len(calls))
+		}
+		if got := calls[0].entry.Decoded.CommandID; got != iwire.CommandCreateCollection {
+			t.Fatalf("first command id=%d want create_collection", got)
+		}
+		if got := calls[1].entry.Decoded.CommandID; got != iwire.CommandInsertBatch {
+			t.Fatalf("second command id=%d want insert_batch", got)
+		}
+		assertMongoClusterCallAckPolicy(t, calls[0], iwire.AckRaftCommitted)
+		assertMongoClusterCallAckPolicy(t, calls[1], iwire.AckRaftCommitted)
+	})
+
+	t.Run("update", func(t *testing.T) {
+		db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+		if err != nil {
+			t.Fatalf("open db: %v", err)
+		}
+		defer func() { _ = db.Close() }()
+
+		server := NewServer()
+		server.Collections = collections.NewCollectionManager(db)
+		server.DefaultCollectionOptions = collections.CollectionOptions{DocumentFormat: collections.DocumentFormatBSON}
+		assertOK(t, serveCommand(t, server, 325827, bson.D{
+			{Key: "insert", Value: "users"},
+			{Key: "documents", Value: bson.A{bson.D{{Key: "_id", Value: "u1"}, {Key: "name", Value: "Ada"}}}},
+			{Key: "$db", Value: "app"},
+		}))
+
+		submitter := &mongoClusterFakeSubmitter{actualAck: iwire.AckRaftCommitted, committedRecoverable: true}
+		setMongoClusterTestSubmitter(server, submitter, 27)
+		response := serveCommand(t, server, 325828, bson.D{
+			{Key: "update", Value: "users"},
+			{Key: "updates", Value: bson.A{bson.D{
+				{Key: "q", Value: bson.D{{Key: "_id", Value: "u1"}}},
+				{Key: "u", Value: bson.D{{Key: "$set", Value: bson.D{{Key: "name", Value: "Grace"}}}}},
+			}}},
+			{Key: "writeConcern", Value: bson.D{{Key: "w", Value: "majority"}}},
+			{Key: "$db", Value: "app"},
+		})
+		assertOK(t, response)
+		assertInt32(t, response, "n", 1)
+		assertInt32(t, response, "nModified", 1)
+		calls := submitter.snapshotCalls()
+		if len(calls) != 1 {
+			t.Fatalf("submit calls=%d want 1", len(calls))
+		}
+		if got := calls[0].entry.Decoded.CommandID; got != iwire.CommandUpdateBSONSet {
+			t.Fatalf("command id=%d want update_bson_set", got)
+		}
+		assertMongoClusterCallAckPolicy(t, calls[0], iwire.AckRaftCommitted)
+		assertMongoUsers(t, server, map[string]string{"u1": "Ada"})
+	})
+
+	t.Run("delete", func(t *testing.T) {
+		db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+		if err != nil {
+			t.Fatalf("open db: %v", err)
+		}
+		defer func() { _ = db.Close() }()
+
+		server := NewServer()
+		server.Collections = collections.NewCollectionManager(db)
+		server.DefaultCollectionOptions = collections.CollectionOptions{DocumentFormat: collections.DocumentFormatBSON}
+		assertOK(t, serveCommand(t, server, 325829, bson.D{
+			{Key: "insert", Value: "users"},
+			{Key: "documents", Value: bson.A{bson.D{{Key: "_id", Value: "u1"}, {Key: "name", Value: "Ada"}}}},
+			{Key: "$db", Value: "app"},
+		}))
+
+		submitter := &mongoClusterFakeSubmitter{actualAck: iwire.AckRaftCommitted, committedRecoverable: true}
+		setMongoClusterTestSubmitter(server, submitter, 28)
+		response := serveCommand(t, server, 325830, bson.D{
+			{Key: "delete", Value: "users"},
+			{Key: "deletes", Value: bson.A{bson.D{{Key: "q", Value: bson.D{{Key: "_id", Value: "u1"}}}, {Key: "limit", Value: int32(1)}}}},
+			{Key: "writeConcern", Value: bson.D{{Key: "w", Value: "majority"}}},
+			{Key: "$db", Value: "app"},
+		})
+		assertOK(t, response)
+		assertInt32(t, response, "n", 1)
+		calls := submitter.snapshotCalls()
+		if len(calls) != 1 {
+			t.Fatalf("submit calls=%d want 1", len(calls))
+		}
+		if got := calls[0].entry.Decoded.CommandID; got != iwire.CommandDeleteBatch {
+			t.Fatalf("command id=%d want delete_batch", got)
+		}
+		assertMongoClusterCallAckPolicy(t, calls[0], iwire.AckRaftCommitted)
+		assertMongoUsers(t, server, map[string]string{"u1": "Ada"})
+	})
+}
+
+func TestClusterSubmitterMajorityWriteConcernRequiresRaftCommittedProof(t *testing.T) {
+	tests := []struct {
+		name                 string
+		actualAck            iwire.AckPolicy
+		committedRecoverable bool
+		wantOK               bool
+	}{
+		{name: "raft committed recoverable", actualAck: iwire.AckRaftCommitted, committedRecoverable: true, wantOK: true},
+		{name: "visible ack", actualAck: iwire.AckVisible, committedRecoverable: true},
+		{name: "missing recoverability", actualAck: iwire.AckRaftCommitted},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			submitter := &mongoClusterFakeSubmitter{
+				actualAck:            tc.actualAck,
+				committedRecoverable: tc.committedRecoverable,
+			}
+			server := NewServer()
+			server.DefaultCollectionOptions = collections.CollectionOptions{DocumentFormat: collections.DocumentFormatBSON}
+			setMongoClusterTestSubmitter(server, submitter, 29)
+
+			response := serveCommand(t, server, 325831, bson.D{
+				{Key: "create", Value: "users"},
+				{Key: "writeConcern", Value: bson.D{{Key: "w", Value: "majority"}}},
+				{Key: "$db", Value: "app"},
+			})
+			if tc.wantOK {
+				assertOK(t, response)
+			} else {
+				assertCommandError(t, response, "WriteConcernFailed")
+			}
+			calls := submitter.snapshotCalls()
+			if len(calls) != 1 {
+				t.Fatalf("submit calls=%d want 1", len(calls))
+			}
+			assertMongoClusterCallAckPolicy(t, calls[0], iwire.AckRaftCommitted)
+		})
 	}
 }
 
@@ -843,6 +1161,7 @@ func TestClusterSubmitterCreateRoutesCommandEntryNoLocalMutation(t *testing.T) {
 	if got := mongoClusterCallCollectionMetaName(t, calls[0]); got != "app.users" {
 		t.Fatalf("collection_meta name=%q want app.users", got)
 	}
+	assertMongoClusterCallAckPolicy(t, calls[0], iwire.AckVisible)
 	if _, err := server.Collections.OpenCollection("app.users"); err == nil {
 		t.Fatal("cluster create created local collection")
 	} else if err != collections.ErrCollectionNotFound {
@@ -977,7 +1296,7 @@ func TestClusterSubmitterRejectsRaftCommittedForVisibleRequest(t *testing.T) {
 		{Key: "documents", Value: bson.A{bson.D{{Key: "_id", Value: "u1"}}}},
 		{Key: "$db", Value: "app"},
 	})
-	assertCommandError(t, response, "BadValue")
+	assertCommandError(t, response, "WriteConcernFailed")
 	if calls := submitter.snapshotCalls(); len(calls) != 1 {
 		t.Fatalf("submit calls=%d want 1", len(calls))
 	}

--- a/TreeDB/mongo_gateway/server_core.go
+++ b/TreeDB/mongo_gateway/server_core.go
@@ -734,7 +734,7 @@ func (s *Server) commandResponse(ctx context.Context, name string, command wire.
 	}
 	switch name {
 	case "hello", "isMaster", "ismaster":
-		return marshalDocument(helloResponse(s.maxMessageLength()))
+		return marshalDocument(s.helloResponse(ctx))
 	case "buildInfo":
 		return marshalDocument(buildInfoResponse())
 	case "connectionStatus":
@@ -783,11 +783,23 @@ func commandRejectsTransactionMarkers(name string) bool {
 	}
 }
 
-func helloResponse(maxMessageLength int32) bson.D {
+func (s *Server) helloResponse(ctx context.Context) bson.D {
+	writablePrimary := true
+	if s != nil && s.clusterSubmitterConfigured() {
+		writablePrimary = false
+		if provider, ok := s.ClusterSubmitter.(treenativewire.ClusterAdmissionProvider); ok {
+			status, err := provider.ClusterAdmissionStatus(ctx)
+			writablePrimary = err == nil && status.Leader && !status.Unavailable
+		}
+	}
+	return helloResponse(s.maxMessageLength(), writablePrimary)
+}
+
+func helloResponse(maxMessageLength int32, writablePrimary bool) bson.D {
 	return bson.D{
 		{Key: "ok", Value: 1.0},
-		{Key: "isWritablePrimary", Value: true},
-		{Key: "ismaster", Value: true},
+		{Key: "isWritablePrimary", Value: writablePrimary},
+		{Key: "ismaster", Value: writablePrimary},
 		{Key: "secondary", Value: false},
 		{Key: "helloOk", Value: true},
 		{Key: "minWireVersion", Value: int32(0)},


### PR DESCRIPTION
## Summary

- Parse cluster-mode Mongo `writeConcern` instead of blanket-rejecting it.
- Map absent/default and `{w: 1}` to visible ack, and `{w: "majority"}` to Raft-committed ack metadata.
- Validate majority results using the native submitter proof fields and fail closed when `ActualAck` or recoverability is not proven.
- Fail closed for missing-collection update/delete no-ops when `{w: "majority"}` cannot be proven by a replicated Raft entry.
- Map cluster admission read-only/unavailable errors to primary/unavailable-style Mongo command errors, and make cluster-mode `hello` avoid advertising writable primary without leader admission.

## Dependency / blocker chain

- Refs #3270.
- Built on #3278 after it merged to `main` as `f0d837ba6f2e7109ba78bcae795f51e49adfc277`.
- Refreshed after #3272 merged to `main` as `e232b01e53dd468072da072876a52ca0e5a31e9e`.
- Ready for latest-head CI/review on `main` at head `714336af616d19f346e791618a1f27afbd4a48e2`.
- #2026 remains the publication/readability closeout gate; this PR only maps Mongo writeConcern onto the native Raft ack proof.

## Validation

- `git diff --check`
- `GOWORK=off go test ./TreeDB/mongo_gateway -run 'TestClusterSubmitter(MajorityWriteConcernRejectsMissingCollectionNoops|UpdateMissingCollectionReturnsZeroCounts|DeleteMissingCollectionReturnsZeroCount|MajorityWriteConcernRoutesAckPolicy|MajorityWriteConcernRequiresRaftCommittedProof)' -count=1`
- `GOWORK=off go test ./TreeDB/mongo_gateway -run 'WriteConcern|ClusterAdmission|ClusterSubmitter|Cluster.*Concern' -count=1`
- `GOWORK=off go test ./TreeDB/mongo_gateway ./TreeDB/nativewire -count=1`
- `GOWORK=off go test ./TreeDB/internal/raftharness ./TreeDB/internal/raftfsm ./TreeDB/internal/raftapply ./TreeDB/internal/raftentry ./TreeDB/internal/raftcluster -count=1`

## Scope boundaries

Does not implement read policies, read-index, snapshots, or log truncation (#3045).
Does not implement multi-group routing (#3046).
Does not alter raft FSM committed-entry apply semantics.
