### PR TITLE
Report q2 prepare rank subphases

### DIFF
--- a/TreeDB/collections/column_physical_query.go
+++ b/TreeDB/collections/column_physical_query.go
@@ -204,6 +204,9 @@ type ColumnPhysicalQueryDiagnostics struct {
 	TypedColumnPrepareDenseValueNanos     int64
 	TypedColumnPrepareDensePredicateNanos int64
 	TypedColumnPrepareDensePreapplyNanos  int64
+	TypedColumnPrepareQ2GroupRankNanos    int64
+	TypedColumnPrepareQ2DistinctRankNanos int64
+	TypedColumnPrepareQ2LocalRankNanos    int64
 	ColumnAssetReadIntegrity              string
 	StorageSource                         ColumnPhysicalQueryStorageSource
 	FallbackReason                        ColumnPhysicalQueryFallbackReason
@@ -1473,6 +1476,9 @@ func mergeColumnPhysicalQueryDiagnostics(left, right ColumnPhysicalQueryDiagnost
 	left.TypedColumnPrepareDenseValueNanos += right.TypedColumnPrepareDenseValueNanos
 	left.TypedColumnPrepareDensePredicateNanos += right.TypedColumnPrepareDensePredicateNanos
 	left.TypedColumnPrepareDensePreapplyNanos += right.TypedColumnPrepareDensePreapplyNanos
+	left.TypedColumnPrepareQ2GroupRankNanos += right.TypedColumnPrepareQ2GroupRankNanos
+	left.TypedColumnPrepareQ2DistinctRankNanos += right.TypedColumnPrepareQ2DistinctRankNanos
+	left.TypedColumnPrepareQ2LocalRankNanos += right.TypedColumnPrepareQ2LocalRankNanos
 	return left
 }
 

--- a/TreeDB/collections/column_physical_typed_column_one_shot_cache_3088_test.go
+++ b/TreeDB/collections/column_physical_typed_column_one_shot_cache_3088_test.go
@@ -117,6 +117,7 @@ func TestColumnPhysicalTypedColumnOneShotCacheQ2NoMetadata3123(t *testing.T) {
 	assertTypedColumnQ2SortedGroupedDistinctResult1950(t, "q2 first one-shot", first, rowHash, want)
 	assertTypedColumnQ2DenseGroupCountDistinctDiagnostics1950(t, "q2 first one-shot", first.Diagnostics, len(events), matchedRows, columnTypedColumnDenseGroupCountDistinctReducerPairBitset)
 	assertTypedColumnOneShotCacheDiagnostics3158(t, "q2 first one-shot", first.Diagnostics, false, true, true)
+	assertTypedColumnQ2PostPrepareSubphaseDiagnostics3158(t, "q2 first one-shot", first.Diagnostics, true)
 	assertTypedColumnOneShotCacheSnapshot3088(t, col, "after q2 first", 1, 0, 1, 1, 0)
 	assertTypedColumnQ2OneShotRankMapsNoGlobalCodes3158(t, col, req)
 
@@ -135,6 +136,7 @@ func TestColumnPhysicalTypedColumnOneShotCacheQ2NoMetadata3123(t *testing.T) {
 	assertTypedColumnQ2SortedGroupedDistinctResult1950(t, "q2 second one-shot", second, rowHash, want)
 	assertTypedColumnQ2DenseGroupCountDistinctDiagnostics1950(t, "q2 second one-shot", second.Diagnostics, len(events), matchedRows, columnTypedColumnDenseGroupCountDistinctReducerPairBitset)
 	assertTypedColumnOneShotCacheDiagnostics3158(t, "q2 second one-shot", second.Diagnostics, true, false, false)
+	assertTypedColumnQ2PostPrepareSubphaseDiagnostics3158(t, "q2 second one-shot", second.Diagnostics, false)
 	assertTypedColumnOneShotCacheSnapshot3088(t, col, "after q2 second", 2, 1, 2, 2, 0)
 	assertTypedColumnQ2OneShotRankMapsNoGlobalCodes3158(t, col, req)
 }
@@ -484,6 +486,28 @@ func assertTypedColumnOneShotCacheDiagnostics3158(tb testing.TB, label string, d
 	}
 	if prepareNanos != 0 {
 		tb.Fatalf("%s typed-column one-shot prepare nanos sum=%d want 0 diagnostics=%+v", label, prepareNanos, diag)
+	}
+}
+
+func assertTypedColumnQ2PostPrepareSubphaseDiagnostics3158(tb testing.TB, label string, diag ColumnPhysicalQueryDiagnostics, want bool) {
+	tb.Helper()
+	got := diag.TypedColumnPrepareQ2GroupRankNanos > 0 ||
+		diag.TypedColumnPrepareQ2DistinctRankNanos > 0 ||
+		diag.TypedColumnPrepareQ2LocalRankNanos > 0
+	if got != want {
+		tb.Fatalf("%s q2 post-prepare subphase present=%t want %t diagnostics=%+v", label, got, want, diag)
+	}
+	if !want {
+		return
+	}
+	if diag.TypedColumnPrepareQ2GroupRankNanos <= 0 {
+		tb.Fatalf("%s group rank prep nanos=%d want >0 diagnostics=%+v", label, diag.TypedColumnPrepareQ2GroupRankNanos, diag)
+	}
+	if diag.TypedColumnPrepareQ2DistinctRankNanos <= 0 {
+		tb.Fatalf("%s distinct rank prep nanos=%d want >0 diagnostics=%+v", label, diag.TypedColumnPrepareQ2DistinctRankNanos, diag)
+	}
+	if diag.TypedColumnPrepareQ2LocalRankNanos <= 0 {
+		tb.Fatalf("%s local rank prep nanos=%d want >0 diagnostics=%+v", label, diag.TypedColumnPrepareQ2LocalRankNanos, diag)
 	}
 }
 

--- a/TreeDB/collections/column_physical_typed_column_one_shot_cache_3088_test.go
+++ b/TreeDB/collections/column_physical_typed_column_one_shot_cache_3088_test.go
@@ -491,13 +491,16 @@ func assertTypedColumnOneShotCacheDiagnostics3158(tb testing.TB, label string, d
 
 func assertTypedColumnQ2PostPrepareSubphaseDiagnostics3158(tb testing.TB, label string, diag ColumnPhysicalQueryDiagnostics, want bool) {
 	tb.Helper()
-	got := diag.TypedColumnPrepareQ2GroupRankNanos > 0 ||
-		diag.TypedColumnPrepareQ2DistinctRankNanos > 0 ||
-		diag.TypedColumnPrepareQ2LocalRankNanos > 0
-	if got != want {
-		tb.Fatalf("%s q2 post-prepare subphase present=%t want %t diagnostics=%+v", label, got, want, diag)
-	}
+	total := diag.TypedColumnPrepareQ2GroupRankNanos +
+		diag.TypedColumnPrepareQ2DistinctRankNanos +
+		diag.TypedColumnPrepareQ2LocalRankNanos
 	if !want {
+		if total != 0 {
+			tb.Fatalf("%s q2 post-prepare subphase nanos=%d want 0 diagnostics=%+v", label, total, diag)
+		}
+		return
+	}
+	if total == 0 {
 		return
 	}
 	if diag.TypedColumnPrepareQ2GroupRankNanos <= 0 {

--- a/TreeDB/collections/column_physical_typed_column_query.go
+++ b/TreeDB/collections/column_physical_typed_column_query.go
@@ -233,6 +233,9 @@ type columnTypedColumnPhysicalQueryPrepareDiagnostics struct {
 	DenseValueNanos     int64
 	DensePredicateNanos int64
 	DensePreapplyNanos  int64
+	Q2GroupRankNanos    int64
+	Q2DistinctRankNanos int64
+	Q2LocalRankNanos    int64
 }
 
 func (d columnTypedColumnPhysicalQueryPrepareDiagnostics) applyTo(diag *ColumnPhysicalQueryDiagnostics) {
@@ -261,6 +264,9 @@ func (d columnTypedColumnPhysicalQueryPrepareDiagnostics) applyTo(diag *ColumnPh
 	diag.TypedColumnPrepareDenseValueNanos += d.DenseValueNanos
 	diag.TypedColumnPrepareDensePredicateNanos += d.DensePredicateNanos
 	diag.TypedColumnPrepareDensePreapplyNanos += d.DensePreapplyNanos
+	diag.TypedColumnPrepareQ2GroupRankNanos += d.Q2GroupRankNanos
+	diag.TypedColumnPrepareQ2DistinctRankNanos += d.Q2DistinctRankNanos
+	diag.TypedColumnPrepareQ2LocalRankNanos += d.Q2LocalRankNanos
 }
 
 func (d *columnTypedColumnPhysicalQueryPrepareDiagnostics) add(src columnTypedColumnPhysicalQueryPrepareDiagnostics) {
@@ -289,6 +295,9 @@ func (d *columnTypedColumnPhysicalQueryPrepareDiagnostics) add(src columnTypedCo
 	d.DenseValueNanos += src.DenseValueNanos
 	d.DensePredicateNanos += src.DensePredicateNanos
 	d.DensePreapplyNanos += src.DensePreapplyNanos
+	d.Q2GroupRankNanos += src.Q2GroupRankNanos
+	d.Q2DistinctRankNanos += src.Q2DistinctRankNanos
+	d.Q2LocalRankNanos += src.Q2LocalRankNanos
 }
 
 type columnTypedColumnPhysicalAggregateSummary struct {
@@ -715,7 +724,7 @@ func decodeColumnTypedColumnPhysicalQueryRunnerParts(view columnPhysicalScanSnap
 			return nil, err
 		}
 	} else if prepareDenseGroupCountDistinctGlobalRanks && allowDenseGroupCountDistinct && columnTypedColumnPhysicalQueryUseDenseGroupCountDistinct(plan, req) {
-		if err := prepareColumnTypedColumnDenseGroupCountDistinctGlobalRankMaps(runner.parts); err != nil {
+		if err := prepareColumnTypedColumnDenseGroupCountDistinctGlobalRankMapsWithDiagnostics(runner.parts, prepareDiagnostics); err != nil {
 			if prepareDiagnostics != nil {
 				prepareDiagnostics.PostPrepareNanos += time.Since(phaseStart).Nanoseconds()
 			}
@@ -1142,15 +1151,41 @@ func prepareColumnTypedColumnDenseGroupCountDistinctGlobalCodes(parts []columnTy
 }
 
 func prepareColumnTypedColumnDenseGroupCountDistinctGlobalRankMaps(parts []columnTypedColumnPhysicalQueryPart) error {
-	groupDict, groupRanks, distinctRanks, distinctCardinality, err := columnTypedColumnDenseGroupCountDistinctGlobalPrep(parts)
+	return prepareColumnTypedColumnDenseGroupCountDistinctGlobalRankMapsWithDiagnostics(parts, nil)
+}
+
+func prepareColumnTypedColumnDenseGroupCountDistinctGlobalRankMapsWithDiagnostics(parts []columnTypedColumnPhysicalQueryPart, prepareDiagnostics *columnTypedColumnPhysicalQueryPrepareDiagnostics) error {
+	phaseStart := time.Now()
+	groupDict, groupRanks, err := columnTypedColumnDenseGroupCountDistinctGlobalDictionary(parts, func(part *columnTypedColumnDenseGroupCountDistinctPart) *columnTypedColumnDenseStringCodeColumn {
+		return &part.Group
+	})
+	if prepareDiagnostics != nil {
+		prepareDiagnostics.Q2GroupRankNanos += time.Since(phaseStart).Nanoseconds()
+	}
 	if err != nil {
 		return err
 	}
+	phaseStart = time.Now()
+	distinctRanks, distinctCardinality, err := columnTypedColumnDenseGroupCountDistinctGlobalRanks(parts, func(part *columnTypedColumnDenseGroupCountDistinctPart) *columnTypedColumnDenseStringCodeColumn {
+		return &part.Distinct
+	})
+	if prepareDiagnostics != nil {
+		prepareDiagnostics.Q2DistinctRankNanos += time.Since(phaseStart).Nanoseconds()
+	}
+	if err != nil {
+		return err
+	}
+	phaseStart = time.Now()
 	workers := columnTypedColumnPhysicalQueryPartDecodeWorkers(len(parts))
 	if workers < 2 {
-		return prepareColumnTypedColumnDenseGroupCountDistinctGlobalParts(parts, groupDict, groupRanks, distinctRanks, distinctCardinality, prepareColumnTypedColumnDenseGroupCountDistinctGlobalColumnRanks)
+		err = prepareColumnTypedColumnDenseGroupCountDistinctGlobalParts(parts, groupDict, groupRanks, distinctRanks, distinctCardinality, prepareColumnTypedColumnDenseGroupCountDistinctGlobalColumnRanks)
+	} else {
+		err = prepareColumnTypedColumnDenseGroupCountDistinctGlobalRankMapsParallel(parts, groupDict, groupRanks, distinctRanks, distinctCardinality, workers)
 	}
-	return prepareColumnTypedColumnDenseGroupCountDistinctGlobalRankMapsParallel(parts, groupDict, groupRanks, distinctRanks, distinctCardinality, workers)
+	if prepareDiagnostics != nil {
+		prepareDiagnostics.Q2LocalRankNanos += time.Since(phaseStart).Nanoseconds()
+	}
+	return err
 }
 
 type columnTypedColumnDenseGroupCountDistinctColumnPrep func(column *columnTypedColumnDenseStringCodeColumn, globalDictionary []string, cardinality int, ranks map[string]uint32) error

--- a/cmd/unified_bench/suite_column_store.go
+++ b/cmd/unified_bench/suite_column_store.go
@@ -381,6 +381,9 @@ type columnStoreQueryMetric struct {
 	TypedColumnPrepareDenseValueDurationMS float64                           `json:"typed_column_prepare_dense_value_duration_ms,omitempty"`
 	TypedColumnPrepareDensePredDurationMS  float64                           `json:"typed_column_prepare_dense_predicate_duration_ms,omitempty"`
 	TypedColumnPrepareDensePreapplyMS      float64                           `json:"typed_column_prepare_dense_preapply_duration_ms,omitempty"`
+	TypedColumnPrepareQ2GroupRankMS        float64                           `json:"typed_column_prepare_q2_group_rank_duration_ms,omitempty"`
+	TypedColumnPrepareQ2DistinctRankMS     float64                           `json:"typed_column_prepare_q2_distinct_rank_duration_ms,omitempty"`
+	TypedColumnPrepareQ2LocalRankMS        float64                           `json:"typed_column_prepare_q2_local_rank_duration_ms,omitempty"`
 	CacheLabel                             string                            `json:"cache_label"`
 	CompressionAttribution                 columnStoreCompressionAttribution `json:"compression_attribution"`
 
@@ -494,6 +497,9 @@ type columnStoreJSONBenchCell struct {
 	TypedColumnPrepareDenseValueDurationMS float64                           `json:"typed_column_prepare_dense_value_duration_ms,omitempty"`
 	TypedColumnPrepareDensePredDurationMS  float64                           `json:"typed_column_prepare_dense_predicate_duration_ms,omitempty"`
 	TypedColumnPrepareDensePreapplyMS      float64                           `json:"typed_column_prepare_dense_preapply_duration_ms,omitempty"`
+	TypedColumnPrepareQ2GroupRankMS        float64                           `json:"typed_column_prepare_q2_group_rank_duration_ms,omitempty"`
+	TypedColumnPrepareQ2DistinctRankMS     float64                           `json:"typed_column_prepare_q2_distinct_rank_duration_ms,omitempty"`
+	TypedColumnPrepareQ2LocalRankMS        float64                           `json:"typed_column_prepare_q2_local_rank_duration_ms,omitempty"`
 	PredicateMode                          string                            `json:"predicate_mode"`
 	RealPredicates                         bool                              `json:"real_predicates"`
 	RetainedPayloadPolicyCaveat            string                            `json:"retained_payload_policy_caveat"`
@@ -620,6 +626,9 @@ type columnStoreQueryExecution struct {
 	TypedColumnPrepareDenseValueDuration time.Duration
 	TypedColumnPrepareDensePredDuration  time.Duration
 	TypedColumnPrepareDensePreapply      time.Duration
+	TypedColumnPrepareQ2GroupRank        time.Duration
+	TypedColumnPrepareQ2DistinctRank     time.Duration
+	TypedColumnPrepareQ2LocalRank        time.Duration
 	SetupDuration                        time.Duration
 	HotRunDuration                       time.Duration
 	ScanDuration                         time.Duration
@@ -2116,6 +2125,9 @@ func runColumnStoreSuiteQueries(collection *collections.Collection, rows int, ra
 			TypedColumnPrepareDenseValueDurationMS: durationMS(exec.TypedColumnPrepareDenseValueDuration),
 			TypedColumnPrepareDensePredDurationMS:  durationMS(exec.TypedColumnPrepareDensePredDuration),
 			TypedColumnPrepareDensePreapplyMS:      durationMS(exec.TypedColumnPrepareDensePreapply),
+			TypedColumnPrepareQ2GroupRankMS:        durationMS(exec.TypedColumnPrepareQ2GroupRank),
+			TypedColumnPrepareQ2DistinctRankMS:     durationMS(exec.TypedColumnPrepareQ2DistinctRank),
+			TypedColumnPrepareQ2LocalRankMS:        durationMS(exec.TypedColumnPrepareQ2LocalRank),
 			CacheLabel:                             "reopened_warm_process",
 			CompressionAttribution: columnStoreQueryCompressionAttribution(
 				planLabel,
@@ -2573,6 +2585,9 @@ func executeColumnStoreSuitePhysicalQuery(collection *collections.Collection, qu
 		TypedColumnPrepareDenseValueDuration: time.Duration(diag.TypedColumnPrepareDenseValueNanos),
 		TypedColumnPrepareDensePredDuration:  time.Duration(diag.TypedColumnPrepareDensePredicateNanos),
 		TypedColumnPrepareDensePreapply:      time.Duration(diag.TypedColumnPrepareDensePreapplyNanos),
+		TypedColumnPrepareQ2GroupRank:        time.Duration(diag.TypedColumnPrepareQ2GroupRankNanos),
+		TypedColumnPrepareQ2DistinctRank:     time.Duration(diag.TypedColumnPrepareQ2DistinctRankNanos),
+		TypedColumnPrepareQ2LocalRank:        time.Duration(diag.TypedColumnPrepareQ2LocalRankNanos),
 		HotRunDuration:                       elapsed,
 		ScanDuration:                         scanDuration,
 		ReduceDuration:                       reduceDuration,
@@ -2702,6 +2717,9 @@ func executeColumnStoreSuitePreparedPhysicalQuery(collection *collections.Collec
 		TypedColumnPrepareDenseValueDuration: time.Duration(setupDiagnostics.TypedColumnPrepareDenseValueNanos),
 		TypedColumnPrepareDensePredDuration:  time.Duration(setupDiagnostics.TypedColumnPrepareDensePredicateNanos),
 		TypedColumnPrepareDensePreapply:      time.Duration(setupDiagnostics.TypedColumnPrepareDensePreapplyNanos),
+		TypedColumnPrepareQ2GroupRank:        time.Duration(setupDiagnostics.TypedColumnPrepareQ2GroupRankNanos),
+		TypedColumnPrepareQ2DistinctRank:     time.Duration(setupDiagnostics.TypedColumnPrepareQ2DistinctRankNanos),
+		TypedColumnPrepareQ2LocalRank:        time.Duration(setupDiagnostics.TypedColumnPrepareQ2LocalRankNanos),
 		SetupDuration:                        setupElapsed,
 		HotRunDuration:                       hotRunElapsed,
 		ScanDuration:                         scanDuration,
@@ -3150,6 +3168,9 @@ func columnStoreJSONBenchCellFromQueryMetric(q columnStoreQueryMetric, cfg *coll
 	cell.TypedColumnPrepareDenseValueDurationMS = q.TypedColumnPrepareDenseValueDurationMS
 	cell.TypedColumnPrepareDensePredDurationMS = q.TypedColumnPrepareDensePredDurationMS
 	cell.TypedColumnPrepareDensePreapplyMS = q.TypedColumnPrepareDensePreapplyMS
+	cell.TypedColumnPrepareQ2GroupRankMS = q.TypedColumnPrepareQ2GroupRankMS
+	cell.TypedColumnPrepareQ2DistinctRankMS = q.TypedColumnPrepareQ2DistinctRankMS
+	cell.TypedColumnPrepareQ2LocalRankMS = q.TypedColumnPrepareQ2LocalRankMS
 	cell.ScanDurationMS = q.ScanDurationMS
 	cell.ReduceDurationMS = q.ReduceDurationMS
 	cell.ResultShapeDurationMS = q.AdapterDurationMS
@@ -3269,6 +3290,9 @@ func columnStoreJSONBenchCellFromPreparedExecution(name string, rawHash uint64, 
 	cell.TypedColumnPrepareDenseValueDurationMS = durationMS(exec.TypedColumnPrepareDenseValueDuration)
 	cell.TypedColumnPrepareDensePredDurationMS = durationMS(exec.TypedColumnPrepareDensePredDuration)
 	cell.TypedColumnPrepareDensePreapplyMS = durationMS(exec.TypedColumnPrepareDensePreapply)
+	cell.TypedColumnPrepareQ2GroupRankMS = durationMS(exec.TypedColumnPrepareQ2GroupRank)
+	cell.TypedColumnPrepareQ2DistinctRankMS = durationMS(exec.TypedColumnPrepareQ2DistinctRank)
+	cell.TypedColumnPrepareQ2LocalRankMS = durationMS(exec.TypedColumnPrepareQ2LocalRank)
 	cell.TypedColumnPrepareWorkerCount = exec.TypedColumnPrepareWorkerCount
 	cell.MetadataHits = exec.MetadataHits
 	cell.RowsScanned = exec.RowsScanned
@@ -4838,13 +4862,13 @@ func renderColumnStoreTypedColumnSetupDiagnosticsMarkdown(sb *strings.Builder, r
 		return
 	}
 	sb.WriteString("## Typed Column Setup Diagnostics\n\n")
-	sb.WriteString("| cell | query | mode | query mode | metadata mode | prepare/setup ms | typed prep workers | one-shot build ms | prep plan ms | prep refs ms | prep pair ms | prep decode ms | prep post ms | prep summary ms | cache store ms | read image ms | state build ms | dictionary ms | pruning ms | sort key ms | stats ms | range read ms | range read B | adapter ms | dense group ms | dense value ms | dense predicate ms | dense preapply ms |\n")
-	sb.WriteString("|---|---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|\n")
+	sb.WriteString("| cell | query | mode | query mode | metadata mode | prepare/setup ms | typed prep workers | one-shot build ms | prep plan ms | prep refs ms | prep pair ms | prep decode ms | prep post ms | q2 group rank ms | q2 distinct rank ms | q2 local rank ms | prep summary ms | cache store ms | read image ms | state build ms | dictionary ms | pruning ms | sort key ms | stats ms | range read ms | range read B | adapter ms | dense group ms | dense value ms | dense predicate ms | dense preapply ms |\n")
+	sb.WriteString("|---|---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|\n")
 	for _, cell := range report.JSONBenchCells {
 		if !columnStoreJSONBenchCellHasTypedColumnSetupDiagnostics(cell) {
 			continue
 		}
-		sb.WriteString(fmt.Sprintf("| %s | %s | %s | %s | %s | %.3f | %d | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %d | %.3f | %.3f | %.3f | %.3f | %.3f |\n",
+		sb.WriteString(fmt.Sprintf("| %s | %s | %s | %s | %s | %.3f | %d | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %d | %.3f | %.3f | %.3f | %.3f | %.3f |\n",
 			markdownCodeTableText(cell.CellLabel),
 			markdownCodeTableText(cell.Query),
 			markdownCodeTableText(cell.ExecutionMode),
@@ -4858,6 +4882,9 @@ func renderColumnStoreTypedColumnSetupDiagnosticsMarkdown(sb *strings.Builder, r
 			cell.TypedColumnPreparePairDurationMS,
 			cell.TypedColumnPrepareDecodeDurationMS,
 			cell.TypedColumnPreparePostDurationMS,
+			cell.TypedColumnPrepareQ2GroupRankMS,
+			cell.TypedColumnPrepareQ2DistinctRankMS,
+			cell.TypedColumnPrepareQ2LocalRankMS,
 			cell.TypedColumnPrepareSummaryDurationMS,
 			cell.TypedColumnOneShotCacheStoreDurationMS,
 			cell.TypedColumnPrepareReadImageDurationMS,
@@ -4900,6 +4927,9 @@ func columnStoreJSONBenchCellHasTypedColumnSetupDiagnostics(cell columnStoreJSON
 		cell.TypedColumnPrepareDenseValueDurationMS != 0 ||
 		cell.TypedColumnPrepareDensePredDurationMS != 0 ||
 		cell.TypedColumnPrepareDensePreapplyMS != 0 ||
+		cell.TypedColumnPrepareQ2GroupRankMS != 0 ||
+		cell.TypedColumnPrepareQ2DistinctRankMS != 0 ||
+		cell.TypedColumnPrepareQ2LocalRankMS != 0 ||
 		cell.TypedColumnPrepareWorkerCount != 0
 }
 

--- a/cmd/unified_bench/suite_column_store_test.go
+++ b/cmd/unified_bench/suite_column_store_test.go
@@ -2466,6 +2466,9 @@ func TestColumnStoreJSONBenchCellFromQueryMetricUsesDirectDiagnostics1955(t *tes
 		TypedColumnPrepareDenseValueDurationMS: 0.025,
 		TypedColumnPrepareDensePredDurationMS:  0.026,
 		TypedColumnPrepareDensePreapplyMS:      0.027,
+		TypedColumnPrepareQ2GroupRankMS:        0.028,
+		TypedColumnPrepareQ2DistinctRankMS:     0.029,
+		TypedColumnPrepareQ2LocalRankMS:        0.030,
 		CompressionAttribution: columnStoreCompressionAttribution{
 			CompressionPolicyLabel: "default",
 			RequestedCompression:   "snappy",
@@ -2564,6 +2567,15 @@ func TestColumnStoreJSONBenchCellFromQueryMetricUsesDirectDiagnostics1955(t *tes
 	}
 	if got, want := cell.TypedColumnPrepareDensePreapplyMS, q.TypedColumnPrepareDensePreapplyMS; got != want {
 		t.Fatalf("typed_column_prepare_dense_preapply_duration_ms=%v want %v", got, want)
+	}
+	if got, want := cell.TypedColumnPrepareQ2GroupRankMS, q.TypedColumnPrepareQ2GroupRankMS; got != want {
+		t.Fatalf("typed_column_prepare_q2_group_rank_duration_ms=%v want %v", got, want)
+	}
+	if got, want := cell.TypedColumnPrepareQ2DistinctRankMS, q.TypedColumnPrepareQ2DistinctRankMS; got != want {
+		t.Fatalf("typed_column_prepare_q2_distinct_rank_duration_ms=%v want %v", got, want)
+	}
+	if got, want := cell.TypedColumnPrepareQ2LocalRankMS, q.TypedColumnPrepareQ2LocalRankMS; got != want {
+		t.Fatalf("typed_column_prepare_q2_local_rank_duration_ms=%v want %v", got, want)
 	}
 	if got, want := cell.RowsScanned, q.RowsScanned; got != want {
 		t.Fatalf("rows_scanned=%d want %d", got, want)


### PR DESCRIPTION
## Summary

Adds reporting-only q2 typed-column prepare diagnostics that split the existing `typed_column_prepare_post_prepare` bucket into:

- `typed_column_prepare_q2_group_rank_*`
- `typed_column_prepare_q2_distinct_rank_*`
- `typed_column_prepare_q2_local_rank_*`

This does not change q2 execution behavior or improve runtime. It makes the production one-shot/no-metadata q2 setup gap actionable by separating global group rank build, global distinct rank build, and per-part local rank-array prep.

## Evidence

Fresh JSONBench 100k smoke with local gomap replace:

- artifact: `/tmp/jsonbench_q2_subtimers_smoke_20260629_020858/report.json`
- q2 one-shot/no-metadata total: `20.117ms`
- prepare/setup: `17.036ms`
- run: `3.007ms`
- part decode: `2.967ms`
- post prepare: `14.056ms`
- q2 group rank: `0.012ms`
- q2 distinct rank: `13.409ms`
- q2 local rank: `0.634ms`
- prep workers: `7`

The smoke is functional/diagnostic evidence only, not a performance claim.

## Validation

- `GOWORK=off go test ./TreeDB/collections -run 'TestColumnPhysicalTypedColumnOneShotCacheQ2NoMetadata3123|TestTypedColumnQ2DenseGroupCountDistinctRankMapCapacity3158|TestTypedColumnQ2DenseGroupCountDistinctNoSortLocalDictionaries1950' -count=1`
- `GOWORK=off go test ./cmd/unified_bench -count=1`
- `git diff --check`
