### PR TITLE
perf: bound TreeDB append-only reserve overshoot

### DIFF
--- a/TreeDB/internal/memtable/append_only.go
+++ b/TreeDB/internal/memtable/append_only.go
@@ -50,6 +50,7 @@ const (
 	appendOnlyReuseOversizeFactor       = 4
 	appendOnlyResetDropThresholdEntries = 1 << 15
 	appendOnlyAggressiveGrowCutoff      = appendOnlyResetDropThresholdEntries * 2
+	appendOnlyReserveHeadroomDivisor    = 4
 )
 
 // Serializes package-pool replacement with retained-byte accounting. sync.Pool
@@ -751,6 +752,22 @@ func appendOnlyReserveTargetCapacity(current, needed int) (target int, skippedGr
 			skippedGrowthBytes += appendOnlyEntryPoolBytes(next)
 		}
 		target = next
+	}
+	if target > needed {
+		headroom := needed / appendOnlyReserveHeadroomDivisor
+		if headroom < appendOnlyMinInitialEntries {
+			headroom = appendOnlyMinInitialEntries
+		}
+		maxInt := int(^uint(0) >> 1)
+		boundedTarget := needed
+		if needed > maxInt-headroom {
+			boundedTarget = maxInt
+		} else {
+			boundedTarget += headroom
+		}
+		if target > boundedTarget {
+			target = boundedTarget
+		}
 	}
 	return target, skippedGrowthAllocs, skippedGrowthBytes
 }

--- a/TreeDB/internal/memtable/append_only_pool_test.go
+++ b/TreeDB/internal/memtable/append_only_pool_test.go
@@ -151,6 +151,7 @@ func TestAppendOnlyReserveAdditionalEntriesAvoidsIntermediateGrowth(t *testing.T
 
 	m := NewAppendOnlyWithEntryCapacity(appendOnlyMinInitialEntries)
 	additional := appendOnlyMinInitialEntries * 8
+	needed := m.count + additional
 	before := AppendOnlyEntryReserveStatsSnapshot()
 
 	m.ReserveAdditionalEntries(additional)
@@ -174,6 +175,16 @@ func TestAppendOnlyReserveAdditionalEntriesAvoidsIntermediateGrowth(t *testing.T
 	if got := after.SkippedGrowthBytesTotal - before.SkippedGrowthBytesTotal; got == 0 {
 		t.Fatalf("reserve skipped growth bytes did not increase")
 	}
+	maxHeadroom := needed / appendOnlyReserveHeadroomDivisor
+	if maxHeadroom < appendOnlyMinInitialEntries {
+		maxHeadroom = appendOnlyMinInitialEntries
+	}
+	if got, max := cap(m.entries), needed+maxHeadroom; got > max {
+		t.Fatalf("reserve cap(entries)=%d want<=%d", got, max)
+	}
+	if got := cap(m.entries); got < needed {
+		t.Fatalf("reserve cap(entries)=%d want>=%d", got, needed)
+	}
 
 	reservedLen := len(m.entries)
 	reservedCap := cap(m.entries)
@@ -189,6 +200,30 @@ func TestAppendOnlyReserveAdditionalEntriesAvoidsIntermediateGrowth(t *testing.T
 	}
 	if got := cap(m.entries); got != reservedCap {
 		t.Fatalf("entry slice cap changed during reserved appends: got %d want %d", got, reservedCap)
+	}
+}
+
+func TestAppendOnlyReserveTargetCapacityBoundsOvershoot(t *testing.T) {
+	current := appendOnlyMinInitialEntries
+	needed := appendOnlyAggressiveGrowCutoff + 1
+
+	target, skippedAllocs, skippedBytes := appendOnlyReserveTargetCapacity(current, needed)
+
+	if target < needed {
+		t.Fatalf("target=%d want >= needed %d", target, needed)
+	}
+	maxHeadroom := needed / appendOnlyReserveHeadroomDivisor
+	if maxHeadroom < appendOnlyMinInitialEntries {
+		maxHeadroom = appendOnlyMinInitialEntries
+	}
+	if max := needed + maxHeadroom; target > max {
+		t.Fatalf("target=%d want <= %d", target, max)
+	}
+	if skippedAllocs == 0 {
+		t.Fatalf("skippedAllocs=0 want >0")
+	}
+	if skippedBytes == 0 {
+		t.Fatalf("skippedBytes=0 want >0")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Bounds append-only reserve growth to `needed + max(needed/4, appendOnlyMinInitialEntries)` when TreeDB already knows the batch entry count.
- Keeps the existing aggressive append growth policy for unreserved single-entry appends, but prevents reserve from accepting a large 4x target that materially exceeds the known write burst.
- Extends append-only reserve tests to prove reserve still skips intermediate growth, does not grow again while appending reserved entries, and now caps overshoot.

## Celestia Evidence / Context

Follow-up for #3238 via #3282.

The latest Celestia TreeDB run with IAVL PR snissn/iavl#12 showed the root/native `SetView` path was mechanically active, but the largest TreeDB-owned peak was append-only memtable reserve/write burst memory, not public `SetView` borrow blocking:

- Run home: `/home/mikers/.celestia-app-mainnet-treedb-20260629024027`
- Protocol: trust height `11714074`, target `11715650`, `POST_SYNC_DWELL_SECONDS=300`
- Max RSS: `6,569,708 KiB`; max HWM: `7,631,164 KiB`
- Peak pprof total: `2387.40MB`
- `TreeDB/internal/memtable.getAppendOnlyEntries`: `514.68MB`
- `TreeDB/caching.getEntrySlice`: `219.20MB`
- `TreeDB/internal/memtable.getAppendOnlyValueArenaChunk`: `128.95MB`
- `github.com/cosmos/cosmos-db.(*TreeDB).withSerializedBatchWrite`: `879.05MB` cumulative
- `treedb.process.batch_arena.borrow_view_ops_blocked_total=0`

Peak counters showed 48 active append-only memtables with substantial entry overcapacity:

- Mutable: `560,000` entries, `2,796,192` entry capacity, `223,695,360` backing bytes
- Queue: `2,820,000` entries, `5,592,384` entry capacity, `447,390,720` backing bytes
- Combined: `3,380,000` live entries, `8,388,576` capacity, `671,086,080` backing bytes

The new reserve bound would cap that shape around `4,225,000` entry capacity before secondary effects, roughly a `333MB` entry-backing reduction opportunity at 80 bytes/entry. This still needs the same Celestia protocol rerun before claiming production success.

## Validation

- `GOWORK=off go test ./TreeDB/internal/memtable -run 'TestAppendOnly(Reserve|NextCapacity|Reset|Release)|TestAppendOnlyReserveTargetCapacityBoundsOvershoot' -count=1`
- `GOWORK=off go test ./TreeDB/caching -run 'TestBatchWriteSortedSetViewCopiesExternalValues|TestAppendOnlyBatchSetViewCopiesValuesToDirectArenaAcrossMutationAndCheckpoint|TestBatchSetView_MutationAfterWriteDoesNotCorruptStoredValue|Test.*BatchArena|Test.*AppendOnly' -count=1`
- `GOWORK=off go test ./TreeDB/... -count=1`

## Follow-up

After this merges, rerun the same Celestia TreeDB protocol and compare append-only entry backing/capacity, `getAppendOnlyEntries`, max RSS, and max HWM. Then run the strict same-window LevelDB-vs-TreeDB A/B requested in #3238/#3131.

Execution note: subagent dispatch is available in this environment, but the current tool policy requires explicit delegation wording. This focused fix was executed locally against the live tracker evidence.
