### PR TITLE
Report qexpr typed-cell evidence

### DIFF
--- a/cmd/unified_bench/suite_column_store.go
+++ b/cmd/unified_bench/suite_column_store.go
@@ -40,6 +40,7 @@ const (
 	columnStoreQueryQ5                 = "q5"
 	columnStoreQueryQ5Metadata         = "q5_metadata"
 	columnStoreQuerySumSecondOfDaySq   = "sum_time_second_of_day_square"
+	columnStoreExpressionSecondOfDaySq = "sum(second_of_day_square(time_us))"
 	columnStoreSuiteBenchMetricPrefix  = "column_store_"
 	columnStoreSuiteAliasFullScanQ1    = "alias_full_scan_from_" + columnStoreQueryQ1
 	columnStoreSuiteAliasPrefixQ4A     = "alias_prefix_scan_from_" + columnStoreQueryQ4A
@@ -321,6 +322,8 @@ type columnStoreQueryMetric struct {
 	PredicateCount                         int                               `json:"predicate_count"`
 	TypedCellsVisited                      int64                             `json:"typed_cells_visited"`
 	TypedCellsVisitedBasis                 string                            `json:"typed_cells_visited_basis,omitempty"`
+	ExpressionKind                         string                            `json:"expression_kind,omitempty"`
+	PrecomputedExpressionUsed              *bool                             `json:"precomputed_expression_used,omitempty"`
 	RowMaterializations                    int                               `json:"row_materializations"`
 	DocumentMaterializations               int                               `json:"document_materializations"`
 	AggregateMetadataUsed                  bool                              `json:"aggregate_metadata_used"`
@@ -433,6 +436,8 @@ type columnStoreJSONBenchCell struct {
 	PredicateCount                         int                               `json:"predicate_count"`
 	TypedCellsVisited                      int64                             `json:"typed_cells_visited"`
 	TypedCellsVisitedBasis                 string                            `json:"typed_cells_visited_basis,omitempty"`
+	ExpressionKind                         string                            `json:"expression_kind,omitempty"`
+	PrecomputedExpressionUsed              *bool                             `json:"precomputed_expression_used,omitempty"`
 	RowMaterializations                    int                               `json:"row_materializations"`
 	DocumentMaterializations               int                               `json:"document_materializations"`
 	AggregateMetadataUsed                  bool                              `json:"aggregate_metadata_used"`
@@ -2036,6 +2041,7 @@ func runColumnStoreSuiteQueries(collection *collections.Collection, rows int, ra
 		typedCellsVisited := columnStoreTypedCellsVisited(exec.RowsScanned, exec.ProjectedColumns)
 		typedCellsVisitedBasis := columnStoreTypedCellsVisitedBasis(exec.RowsScanned, exec.ProjectedColumns)
 		aggregateMetadataUsed := columnStoreAggregateMetadataUsed(storageSource, exec.MetadataHits)
+		expressionKind, precomputedExpressionUsed := columnStoreExpressionEvidence(name, aggregateMetadataUsed, typedCellsVisited)
 		sortTopKPruningUsed := columnStoreSortTopKPruningUsed(exec)
 		jsonReconstruction := exec.DocumentMaterializations > 0
 		metric := columnStoreQueryMetric{
@@ -2076,6 +2082,8 @@ func runColumnStoreSuiteQueries(collection *collections.Collection, rows int, ra
 			PredicateCount:                         exec.PredicateCount,
 			TypedCellsVisited:                      typedCellsVisited,
 			TypedCellsVisitedBasis:                 typedCellsVisitedBasis,
+			ExpressionKind:                         expressionKind,
+			PrecomputedExpressionUsed:              precomputedExpressionUsed,
 			RowMaterializations:                    exec.RowMaterializations,
 			DocumentMaterializations:               exec.DocumentMaterializations,
 			AggregateMetadataUsed:                  aggregateMetadataUsed,
@@ -2225,6 +2233,14 @@ func columnStoreTypedCellsVisitedBasis(rowsScanned, projectedColumns int) string
 		return "no_typed_cell_scan_reported"
 	}
 	return "rows_scanned_x_projected_columns"
+}
+
+func columnStoreExpressionEvidence(query string, aggregateMetadataUsed bool, typedCellsVisited int64) (string, *bool) {
+	if query != columnStoreQuerySumSecondOfDaySq || aggregateMetadataUsed || typedCellsVisited <= 0 {
+		return "", nil
+	}
+	precomputed := false
+	return columnStoreExpressionSecondOfDaySq, &precomputed
 }
 
 func columnStoreAggregateMetadataUsed(storageSource string, metadataHits int) bool {
@@ -3129,6 +3145,8 @@ func columnStoreJSONBenchCellFromQueryMetric(q columnStoreQueryMetric, cfg *coll
 	cell.PredicateCount = q.PredicateCount
 	cell.TypedCellsVisited = q.TypedCellsVisited
 	cell.TypedCellsVisitedBasis = q.TypedCellsVisitedBasis
+	cell.ExpressionKind = q.ExpressionKind
+	cell.PrecomputedExpressionUsed = q.PrecomputedExpressionUsed
 	cell.RowMaterializations = q.RowMaterializations
 	cell.DocumentMaterializations = q.DocumentMaterializations
 	cell.AggregateMetadataUsed = q.AggregateMetadataUsed
@@ -3239,6 +3257,7 @@ func columnStoreJSONBenchCellFromPreparedExecution(name string, rawHash uint64, 
 	cell.RowMaterializations = exec.RowMaterializations
 	cell.DocumentMaterializations = exec.DocumentMaterializations
 	cell.AggregateMetadataUsed = columnStoreAggregateMetadataUsed(cell.StorageSource, exec.MetadataHits)
+	cell.ExpressionKind, cell.PrecomputedExpressionUsed = columnStoreExpressionEvidence(name, cell.AggregateMetadataUsed, cell.TypedCellsVisited)
 	if cell.AggregateMetadataUsed {
 		directCost := columnStoreMetadataCostFromQuery(direct)
 		if directCost.StorageCostBasis != "" || directCost.InsertCostBasis != "" || directCost.AggregateMetadataStorageBytes != 0 {
@@ -4756,8 +4775,8 @@ func renderColumnStoreQueryMetricsMarkdown(sb *strings.Builder, title string, qu
 		return
 	}
 	sb.WriteString("## " + title + "\n\n")
-	sb.WriteString("| query | query mode | metadata mode | plan | storage source | fallback | manifest root | active gen/checksum | rows/s | MiB/s | ns/row | prepare/setup ms | typed prep plan ms | typed prep refs ms | typed prep pair ms | typed prep decode ms | typed prep post ms | typed prep summary ms | one-shot cache store ms | run ms | render/hash ms | total query ms | planner ms | scan ms | reduce ms | adapter ms | parity hash ms | workers | typed prep workers | scheduled granules | skipped granules | metadata hits | dictionary code hits | int64 value hits | B/read | decoded B | decoded payload B | decoded metadata B | mapped B | heap-copy B | rows scanned | projected cols | predicate count | typed cells visited | typed cells basis | rows materialized | docs materialized | aggregate metadata used | metadata cost B | metadata cost insert ms | metadata cost basis | sort/topk pruning | topk limit | topk candidates | topk order | json reconstruction | segment file cache hit/miss | hash parity | note |\n")
-	sb.WriteString("|---|---|---|---|---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|---:|---:|---|---:|---:|---|---|---:|---:|---|---|---|---|---|---|\n")
+	sb.WriteString("| query | query mode | metadata mode | plan | storage source | fallback | manifest root | active gen/checksum | rows/s | MiB/s | ns/row | prepare/setup ms | typed prep plan ms | typed prep refs ms | typed prep pair ms | typed prep decode ms | typed prep post ms | typed prep summary ms | one-shot cache store ms | run ms | render/hash ms | total query ms | planner ms | scan ms | reduce ms | adapter ms | parity hash ms | workers | typed prep workers | scheduled granules | skipped granules | metadata hits | dictionary code hits | int64 value hits | B/read | decoded B | decoded payload B | decoded metadata B | mapped B | heap-copy B | rows scanned | projected cols | predicate count | typed cells visited | typed cells basis | expression kind | precomputed expression used | rows materialized | docs materialized | aggregate metadata used | metadata cost B | metadata cost insert ms | metadata cost basis | sort/topk pruning | topk limit | topk candidates | topk order | json reconstruction | segment file cache hit/miss | hash parity | note |\n")
+	sb.WriteString("|---|---|---|---|---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|---|---|---:|---:|---|---:|---:|---|---|---:|---:|---|---|---|---|---|---|\n")
 	for _, q := range queries {
 		parity := "pass"
 		if p, ok := parityByName[q.Name]; ok && !p.Pass {
@@ -4779,8 +4798,8 @@ func renderColumnStoreQueryMetricsMarkdown(sb *strings.Builder, title string, qu
 		if q.ManifestGeneration != 0 || q.ActiveManifestChecksum != 0 {
 			activeManifestCell = fmt.Sprintf("%d/%d", q.ManifestGeneration, q.ActiveManifestChecksum)
 		}
-		sb.WriteString(fmt.Sprintf("| %s | %s | %s | %s | %s | %s | %s | %s | %.3f | %.3f | %.1f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %s | %d | %d | %t | %d | %.3f | %s | %t | %d | %d | %s | %t | %d/%d | %s | %s |\n",
-			markdownCodeTableText(q.Name), markdownCodeTableText(q.QueryMode), markdownCodeTableText(q.MetadataMode), markdownCodeTableText(q.PlanLabel), markdownCodeTableText(q.StorageSource), markdownCodeTableText(q.FallbackReason), markdownCodeTableText(manifestRootCell), markdownCodeTableText(activeManifestCell), q.RowsPerSecond, q.MiBPerSecond, q.NsPerRow, q.PrepareSetupDurationMS, q.TypedColumnPreparePlanDurationMS, q.TypedColumnPrepareRefsDurationMS, q.TypedColumnPreparePairDurationMS, q.TypedColumnPrepareDecodeDurationMS, q.TypedColumnPreparePostDurationMS, q.TypedColumnPrepareSummaryDurationMS, q.TypedColumnOneShotCacheStoreDurationMS, q.RunDurationMS, q.RenderHashDurationMS, q.TotalQueryDurationMS, q.PlannerDurationMS, q.ScanDurationMS, q.ReduceDurationMS, q.AdapterDurationMS, q.ParityHashDurationMS, q.WorkerCount, q.TypedColumnPrepareWorkerCount, q.ScheduledGranules, q.SkippedGranules, q.MetadataHits, q.DictionaryCodeHits, q.Int64ValueHits, q.BytesRead, q.DecodedBytes, q.DecodedPayloadBytes, q.DecodedMetadataBytes, q.MappedBytes, q.HeapCopyBytes, q.RowsScanned, q.ProjectedColumns, q.PredicateCount, q.TypedCellsVisited, markdownCodeTableText(q.TypedCellsVisitedBasis), q.RowMaterializations, q.DocumentMaterializations, q.AggregateMetadataUsed, q.MetadataCostStorageBytes, q.MetadataCostInsertMS, markdownCodeTableText(columnStoreMetadataCostBasisTableText(q.MetadataCostStorageBasis, q.MetadataCostInsertBasis)), q.SortTopKPruningUsed, q.TopKLimit, q.TopKCandidates, markdownCodeTableText(q.TopKOrder), q.JSONReconstruction, q.SegmentFileCacheHits, q.SegmentFileCacheMisses, parity, noteCell))
+		sb.WriteString(fmt.Sprintf("| %s | %s | %s | %s | %s | %s | %s | %s | %.3f | %.3f | %.1f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %s | %s | %s | %d | %d | %t | %d | %.3f | %s | %t | %d | %d | %s | %t | %d/%d | %s | %s |\n",
+			markdownCodeTableText(q.Name), markdownCodeTableText(q.QueryMode), markdownCodeTableText(q.MetadataMode), markdownCodeTableText(q.PlanLabel), markdownCodeTableText(q.StorageSource), markdownCodeTableText(q.FallbackReason), markdownCodeTableText(manifestRootCell), markdownCodeTableText(activeManifestCell), q.RowsPerSecond, q.MiBPerSecond, q.NsPerRow, q.PrepareSetupDurationMS, q.TypedColumnPreparePlanDurationMS, q.TypedColumnPrepareRefsDurationMS, q.TypedColumnPreparePairDurationMS, q.TypedColumnPrepareDecodeDurationMS, q.TypedColumnPreparePostDurationMS, q.TypedColumnPrepareSummaryDurationMS, q.TypedColumnOneShotCacheStoreDurationMS, q.RunDurationMS, q.RenderHashDurationMS, q.TotalQueryDurationMS, q.PlannerDurationMS, q.ScanDurationMS, q.ReduceDurationMS, q.AdapterDurationMS, q.ParityHashDurationMS, q.WorkerCount, q.TypedColumnPrepareWorkerCount, q.ScheduledGranules, q.SkippedGranules, q.MetadataHits, q.DictionaryCodeHits, q.Int64ValueHits, q.BytesRead, q.DecodedBytes, q.DecodedPayloadBytes, q.DecodedMetadataBytes, q.MappedBytes, q.HeapCopyBytes, q.RowsScanned, q.ProjectedColumns, q.PredicateCount, q.TypedCellsVisited, markdownCodeTableText(q.TypedCellsVisitedBasis), markdownCodeTableText(q.ExpressionKind), markdownBoolPtrTableText(q.PrecomputedExpressionUsed), q.RowMaterializations, q.DocumentMaterializations, q.AggregateMetadataUsed, q.MetadataCostStorageBytes, q.MetadataCostInsertMS, markdownCodeTableText(columnStoreMetadataCostBasisTableText(q.MetadataCostStorageBasis, q.MetadataCostInsertBasis)), q.SortTopKPruningUsed, q.TopKLimit, q.TopKCandidates, markdownCodeTableText(q.TopKOrder), q.JSONReconstruction, q.SegmentFileCacheHits, q.SegmentFileCacheMisses, parity, noteCell))
 	}
 	sb.WriteString("\n")
 }
@@ -4791,8 +4810,8 @@ func renderColumnStoreJSONBenchCellsMarkdown(sb *strings.Builder, report columnS
 		sb.WriteString("No JSONBench synthetic cells were recorded.\n\n")
 		return
 	}
-	sb.WriteString("| cell | query | query mode | metadata mode | sort layout | storage source | mode | metadata/data path | prepare/setup ms | typed prep plan ms | typed prep refs ms | typed prep pair ms | typed prep decode ms | typed prep post ms | typed prep summary ms | one-shot cache store ms | run ms | render/hash ms | total query ms | compression | mutation | retained payload | retained encoding | retained compression | typed owner | rows | rows processed | bytes read | decoded B | decoded payload B | decoded metadata B | mapped B | heap-copy B | rows scanned | projected cols | predicate count | typed cells visited | typed cells basis | row materializations | document materializations | aggregate metadata used | metadata cost B | metadata cost insert ms | metadata cost basis | sort/topk pruning | topk limit | topk candidates | topk order | json reconstruction | result hash | parity | full-data caveat | reconstruction | status |\n")
-	sb.WriteString("|---|---|---|---|---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|---|---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|---:|---:|---|---:|---:|---|---|---:|---:|---|---|---:|---|---|---|---|\n")
+	sb.WriteString("| cell | query | query mode | metadata mode | sort layout | storage source | mode | metadata/data path | prepare/setup ms | typed prep plan ms | typed prep refs ms | typed prep pair ms | typed prep decode ms | typed prep post ms | typed prep summary ms | one-shot cache store ms | run ms | render/hash ms | total query ms | compression | mutation | retained payload | retained encoding | retained compression | typed owner | rows | rows processed | bytes read | decoded B | decoded payload B | decoded metadata B | mapped B | heap-copy B | rows scanned | projected cols | predicate count | typed cells visited | typed cells basis | expression kind | precomputed expression used | row materializations | document materializations | aggregate metadata used | metadata cost B | metadata cost insert ms | metadata cost basis | sort/topk pruning | topk limit | topk candidates | topk order | json reconstruction | result hash | parity | full-data caveat | reconstruction | status |\n")
+	sb.WriteString("|---|---|---|---|---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|---|---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|---|---|---:|---:|---|---:|---:|---|---|---:|---:|---|---|---:|---|---|---|---|\n")
 	for _, cell := range report.JSONBenchCells {
 		parity := "pass"
 		if !cell.ParityWithRowScan {
@@ -4802,7 +4821,7 @@ func renderColumnStoreJSONBenchCellsMarkdown(sb *strings.Builder, report columnS
 		if cell.CompatibilityStatusReason != "" {
 			status += ": " + cell.CompatibilityStatusReason
 		}
-		sb.WriteString(fmt.Sprintf("| %s | %s | %s | %s | %s | %s | %s | %s | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %s | %s | %s | %s | %s | %s | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %s | %d | %d | %t | %d | %.3f | %s | %t | %d | %d | %s | %t | %016x | %s | %s | %s | %s |\n",
+		sb.WriteString(fmt.Sprintf("| %s | %s | %s | %s | %s | %s | %s | %s | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %s | %s | %s | %s | %s | %s | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %d | %s | %s | %s | %d | %d | %t | %d | %.3f | %s | %t | %d | %d | %s | %t | %016x | %s | %s | %s | %s |\n",
 			markdownCodeTableText(cell.CellLabel),
 			markdownCodeTableText(cell.Query),
 			markdownCodeTableText(cell.QueryMode),
@@ -4841,6 +4860,8 @@ func renderColumnStoreJSONBenchCellsMarkdown(sb *strings.Builder, report columnS
 			cell.PredicateCount,
 			cell.TypedCellsVisited,
 			markdownCodeTableText(cell.TypedCellsVisitedBasis),
+			markdownCodeTableText(cell.ExpressionKind),
+			markdownBoolPtrTableText(cell.PrecomputedExpressionUsed),
 			cell.RowMaterializations,
 			cell.DocumentMaterializations,
 			cell.AggregateMetadataUsed,
@@ -5077,6 +5098,16 @@ func markdownCodeTableText(value string) string {
 		padding = " "
 	}
 	return delimiter + padding + value + padding + delimiter
+}
+
+func markdownBoolPtrTableText(value *bool) string {
+	if value == nil {
+		return markdownCodeTableText("")
+	}
+	if *value {
+		return "true"
+	}
+	return "false"
 }
 
 func markdownNormalizeTableCell(value string, escapeHTML bool) string {

--- a/cmd/unified_bench/suite_column_store_test.go
+++ b/cmd/unified_bench/suite_column_store_test.go
@@ -749,7 +749,7 @@ func TestRunColumnStoreSuiteWritesArtifactsAndMetricsM11A(t *testing.T) {
 			t.Fatalf("column store markdown missing insert phase field %q:\n%s", want, columnMarkdown)
 		}
 	}
-	for _, want := range []string{"## Metadata Cost", "aggregate_metadata_storage_bytes", "aggregate_metadata_prepare_duration_ms", "aggregate_metadata_append_share_duration_ms", "insert_cost_upper_bound_duration_ms", "insert_cost_basis", "insert_cost_upper_bound_basis", "storage_cost_basis", "## Production JSONBench Synthetic Cells", "## Colgranule Reuse Map", "metadata/data path", "typed prep decode ms", "one-shot cache store ms", "metadata cost B", "metadata cost insert ms", "metadata cost basis", "retained payload", "retained encoding", "retained compression", "typed owner", "typed cells visited", "typed cells basis", "document materializations", "aggregate metadata used", "sort/topk pruning", "json reconstruction", "full-data caveat", "## Query Compression And Allocation Attribution", "## Codec/Layout Matrix", "codec/layout", "compression policy", "compressed bytes", "decompressed bytes", "raw bytes", "B/op", "allocs/op", columnStoreCompressionPolicyOff, columnStoreCompressionPolicyDefault} {
+	for _, want := range []string{"## Metadata Cost", "aggregate_metadata_storage_bytes", "aggregate_metadata_prepare_duration_ms", "aggregate_metadata_append_share_duration_ms", "insert_cost_upper_bound_duration_ms", "insert_cost_basis", "insert_cost_upper_bound_basis", "storage_cost_basis", "## Production JSONBench Synthetic Cells", "## Colgranule Reuse Map", "metadata/data path", "typed prep decode ms", "one-shot cache store ms", "metadata cost B", "metadata cost insert ms", "metadata cost basis", "retained payload", "retained encoding", "retained compression", "typed owner", "typed cells visited", "typed cells basis", "expression kind", "precomputed expression used", "document materializations", "aggregate metadata used", "sort/topk pruning", "json reconstruction", "full-data caveat", "## Query Compression And Allocation Attribution", "## Codec/Layout Matrix", "codec/layout", "compression policy", "compressed bytes", "decompressed bytes", "raw bytes", "B/op", "allocs/op", columnStoreCompressionPolicyOff, columnStoreCompressionPolicyDefault} {
 		if !strings.Contains(string(columnMarkdown), want) {
 			t.Fatalf("column store markdown missing reporting field %q:\n%s", want, columnMarkdown)
 		}
@@ -2396,6 +2396,7 @@ func TestColumnStoreJSONBenchPreparedParityMismatchIsFatal1955(t *testing.T) {
 }
 
 func TestColumnStoreJSONBenchCellFromQueryMetricUsesDirectDiagnostics1955(t *testing.T) {
+	precomputedExpressionUsed := false
 	q := columnStoreQueryMetric{
 		Name:                                   "q4a",
 		PlanLabel:                              columnStorePathSerialColumnScan,
@@ -2425,6 +2426,8 @@ func TestColumnStoreJSONBenchCellFromQueryMetricUsesDirectDiagnostics1955(t *tes
 		PredicateCount:                         1,
 		TypedCellsVisited:                      26,
 		TypedCellsVisitedBasis:                 "rows_scanned_x_projected_columns",
+		ExpressionKind:                         columnStoreExpressionSecondOfDaySq,
+		PrecomputedExpressionUsed:              &precomputedExpressionUsed,
 		RowMaterializations:                    1,
 		DocumentMaterializations:               2,
 		MetadataCostStorageBytes:               4096,
@@ -2585,6 +2588,12 @@ func TestColumnStoreJSONBenchCellFromQueryMetricUsesDirectDiagnostics1955(t *tes
 	}
 	if got, want := cell.TypedCellsVisitedBasis, q.TypedCellsVisitedBasis; got != want {
 		t.Fatalf("typed_cells_visited_basis=%q want %q", got, want)
+	}
+	if got, want := cell.ExpressionKind, q.ExpressionKind; got != want {
+		t.Fatalf("expression_kind=%q want %q", got, want)
+	}
+	if cell.PrecomputedExpressionUsed == nil || *cell.PrecomputedExpressionUsed != *q.PrecomputedExpressionUsed {
+		t.Fatalf("precomputed_expression_used=%v want %v", cell.PrecomputedExpressionUsed, q.PrecomputedExpressionUsed)
 	}
 	if got, want := cell.DecodedBytes, q.DecodedBytes; got != want {
 		t.Fatalf("decoded_bytes=%d want %d", got, want)
@@ -3751,6 +3760,12 @@ func TestRunColumnStoreSuiteExpressionQueryReportsNoMetadataTypedScanM3116(t *te
 	if q.RowsScanned != report.Rows || q.ReduceRows != report.Rows || q.BytesRead <= 0 {
 		t.Fatalf("expression query scan diagnostics=%+v want full typed value scan over %d rows", q, report.Rows)
 	}
+	if q.TypedCellsVisited != int64(report.Rows) || q.TypedCellsVisitedBasis != "rows_scanned_x_projected_columns" {
+		t.Fatalf("expression query typed-cell evidence=%d/%q want one typed cell per row", q.TypedCellsVisited, q.TypedCellsVisitedBasis)
+	}
+	if q.ExpressionKind != columnStoreExpressionSecondOfDaySq || q.PrecomputedExpressionUsed == nil || *q.PrecomputedExpressionUsed {
+		t.Fatalf("expression query expression evidence kind=%q precomputed=%v want typed-cell non-precomputed expression", q.ExpressionKind, q.PrecomputedExpressionUsed)
+	}
 	if !strings.Contains(q.ImplementationNote, "arbitrary_expression_second_of_day_square_no_aggregate_metadata_physical_cell_scan") {
 		t.Fatalf("expression query implementation note=%q", q.ImplementationNote)
 	}
@@ -3769,6 +3784,12 @@ func TestRunColumnStoreSuiteExpressionQueryReportsNoMetadataTypedScanM3116(t *te
 		}
 		if cell.StorageSource != string(collections.ColumnPhysicalQueryStorageSourceTypedColumnPartSection) || cell.ResultCount != 1 || !cell.ParityWithRowScan {
 			t.Fatalf("expression JSONBench cell diagnostics=%+v", cell)
+		}
+		if cell.TypedCellsVisited != int64(report.Rows) || cell.TypedCellsVisitedBasis != "rows_scanned_x_projected_columns" {
+			t.Fatalf("expression JSONBench cell typed-cell evidence=%d/%q want one typed cell per row: %+v", cell.TypedCellsVisited, cell.TypedCellsVisitedBasis, cell)
+		}
+		if cell.ExpressionKind != columnStoreExpressionSecondOfDaySq || cell.PrecomputedExpressionUsed == nil || *cell.PrecomputedExpressionUsed {
+			t.Fatalf("expression JSONBench cell expression evidence kind=%q precomputed=%v want typed-cell non-precomputed expression: %+v", cell.ExpressionKind, cell.PrecomputedExpressionUsed, cell)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- add unified-bench `expression_kind` and `precomputed_expression_used` fields for the qexpr typed-cell lane
- carry the fields into JSONBench-shaped synthetic cells and markdown report tables
- assert qexpr remains `one_shot_end_to_end` / `no_aggregate_metadata`, scans typed cells, and does not use a precomputed expression

## Scope
Reporting/evidence only. This does not change qexpr execution, runtime behavior, aggregate metadata behavior, or durability boundaries. It should not be described as broad arbitrary SQL expression support; the current lane proves the fixed `sum(second_of_day_square(time_us))` typed-cell expression.

## Validation
- `git diff --check`
- `GOWORK=off go test ./cmd/unified_bench -run 'TestRunColumnStoreSuiteExpressionQueryReportsNoMetadataTypedScanM3116|TestColumnStoreJSONBenchCellFromQueryMetricUsesDirectDiagnostics1955|TestColumnStoreSuiteMarkdownReportIncludesM1955Sections' -count=1`\n- `GOWORK=off go test ./cmd/unified_bench -count=1`\n- `GOWORK=off go test ./TreeDB/collections -run 'TestColumnPhysicalQuerySumSecondOfDaySquare|TestTypedColumnInt64.*SecondOfDaySquare|TestColumnPhysicalJSONBenchTypedColumnPart|TestColumnPhysicalJSONBenchParity' -count=1`\n\nRefs #3125, #3070, #3000, #3001