### PR TITLE
TreeDB: trim sparse append-only mutable backing

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -8080,41 +8080,43 @@ type DB struct {
 
 	// memtables is an RCU-style snapshot of (mutable, queue, queueRanges).
 	// Readers load it atomically to avoid holding db.mu around memtable access.
-	memtables                        atomic.Pointer[memtableView]
-	rootDomainVersion                atomic.Uint64
-	rootPointStates                  []rootDomainState
-	rootSystemState                  rootDomainState
-	rootIteratorState                rootDomainState
-	rootPublishedSet                 *publishedRootSet
-	rootPublishStats                 rootDomainPublishTelemetry
-	rootPublishHook                  func(*rootPublishGroup) error
-	commandWALCheckpointPublish      atomic.Pointer[commandWALCheckpointPublishHookBox]
-	commandWALCheckpointCutover      atomic.Pointer[commandWALCheckpointCutoverHookBox]
-	commandWALCheckpointCleanup      atomic.Pointer[commandWALCheckpointCleanupHookBox]
-	dirtyRootPublishGroupID          uint64
-	dirtyRootPublishGroupPending     bool
-	rootPublishRetryPending          bool
-	hashSortedIndexer                *memtable.HashSortedIndexer
-	appendOnlyMemPool                atomic.Pointer[sync.Pool]
-	appendOnlyMemLeaseMu             sync.Mutex
-	appendOnlyMemLeases              []*memtable.AppendOnly
-	appendOnlyMemLeaseHitTotal       atomic.Uint64
-	appendOnlyMemPoolHitTotal        atomic.Uint64
-	appendOnlyMemPoolPutTotal        atomic.Uint64
-	appendOnlyMemPoolEntryDropBytes  atomic.Uint64
-	appendOnlyMemNewAllocTotal       atomic.Uint64
-	appendOnlyMemNewAllocWithQueue   atomic.Uint64
-	appendOnlyMemNewAllocQueueBytes  atomic.Uint64
-	appendOnlyMemPoolDropTotal       atomic.Uint64
-	appendOnlyMutableTrimTotal       atomic.Uint64
-	appendOnlyMutableTrimDropped     atomic.Uint64
-	appendOnlyDirectArenaLeaseMu     sync.Mutex
-	appendOnlyDirectArenaLeasesByMem map[memtable.Table]*appendOnlyDirectArenaLease
-	pendingRetiredMems               []memtable.Table
-	retiredMemtablesMu               sync.Mutex
-	retainedMemtableViews            map[*memtableView]int
-	deferredRetiredMemtables         []deferredRetiredMemtablesHold
-	memtableViewReaders              atomic.Int64
+	memtables                          atomic.Pointer[memtableView]
+	rootDomainVersion                  atomic.Uint64
+	rootPointStates                    []rootDomainState
+	rootSystemState                    rootDomainState
+	rootIteratorState                  rootDomainState
+	rootPublishedSet                   *publishedRootSet
+	rootPublishStats                   rootDomainPublishTelemetry
+	rootPublishHook                    func(*rootPublishGroup) error
+	commandWALCheckpointPublish        atomic.Pointer[commandWALCheckpointPublishHookBox]
+	commandWALCheckpointCutover        atomic.Pointer[commandWALCheckpointCutoverHookBox]
+	commandWALCheckpointCleanup        atomic.Pointer[commandWALCheckpointCleanupHookBox]
+	dirtyRootPublishGroupID            uint64
+	dirtyRootPublishGroupPending       bool
+	rootPublishRetryPending            bool
+	hashSortedIndexer                  *memtable.HashSortedIndexer
+	appendOnlyMemPool                  atomic.Pointer[sync.Pool]
+	appendOnlyMemLeaseMu               sync.Mutex
+	appendOnlyMemLeases                []*memtable.AppendOnly
+	appendOnlyMemLeaseHitTotal         atomic.Uint64
+	appendOnlyMemPoolHitTotal          atomic.Uint64
+	appendOnlyMemPoolPutTotal          atomic.Uint64
+	appendOnlyMemPoolEntryDropBytes    atomic.Uint64
+	appendOnlyMemNewAllocTotal         atomic.Uint64
+	appendOnlyMemNewAllocWithQueue     atomic.Uint64
+	appendOnlyMemNewAllocQueueBytes    atomic.Uint64
+	appendOnlyMemPoolDropTotal         atomic.Uint64
+	appendOnlyMutableTrimTotal         atomic.Uint64
+	appendOnlyMutableTrimDropped       atomic.Uint64
+	appendOnlyMutableSparseTrimTotal   atomic.Uint64
+	appendOnlyMutableSparseTrimDropped atomic.Uint64
+	appendOnlyDirectArenaLeaseMu       sync.Mutex
+	appendOnlyDirectArenaLeasesByMem   map[memtable.Table]*appendOnlyDirectArenaLease
+	pendingRetiredMems                 []memtable.Table
+	retiredMemtablesMu                 sync.Mutex
+	retainedMemtableViews              map[*memtableView]int
+	deferredRetiredMemtables           []deferredRetiredMemtablesHold
+	memtableViewReaders                atomic.Int64
 	// closingEmptyMemsMu guards closingEmptyByView. The map holds per-view
 	// lists of mutable memtables that should be released once the last reader
 	// drops the view, registered by releaseClosingEmptyMemtables at DB close.
@@ -10227,6 +10229,75 @@ func (db *DB) trimEmptyAppendOnlyMutableShards(capacity int) int {
 	return trimmed
 }
 
+func appendOnlyEntryCapacityForBytes(capacity, estimatedBytesPerEntry int) int {
+	if capacity <= 0 {
+		return 0
+	}
+	if estimatedBytesPerEntry <= 0 {
+		estimatedBytesPerEntry = appendOnlyEstimatedBytesPerEntryDefault
+	}
+	entries := capacity / estimatedBytesPerEntry
+	if entries < appendOnlyEntryHintMinEntries {
+		entries = appendOnlyEntryHintMinEntries
+	}
+	return entries
+}
+
+func appendOnlySparseMutableTrimTargetEntries(liveEntries, retainCapacity, estimatedBytesPerEntry int) int {
+	if liveEntries <= 0 {
+		return 0
+	}
+	headroom := liveEntries / 4
+	if headroom < appendOnlyEntryHintMinEntries {
+		headroom = appendOnlyEntryHintMinEntries
+	}
+	target := liveEntries + headroom
+	if retainEntries := appendOnlyEntryCapacityForBytes(retainCapacity, estimatedBytesPerEntry); retainEntries > target {
+		target = retainEntries
+	}
+	return target
+}
+
+func (db *DB) trimSparseAppendOnlyMutableShards(capacity int) int {
+	if db == nil || db.currentMemtableMode() != memtable.ModeAppendOnly || len(db.mutableShards) == 0 {
+		return 0
+	}
+	estimate := appendOnlyEstimatedBytesPerEntryDefault
+	trimmed := 0
+	var droppedBytes uint64
+	for i := range db.mutableShards {
+		shard := &db.mutableShards[i]
+		shard.mu.Lock()
+		mt, ok := shard.mem.(*memtable.AppendOnly)
+		if !ok || mt == nil {
+			shard.mu.Unlock()
+			continue
+		}
+		liveEntries := mt.Len()
+		if liveEntries == 0 {
+			shard.mu.Unlock()
+			continue
+		}
+		targetEntries := appendOnlySparseMutableTrimTargetEntries(liveEntries, capacity, estimate)
+		before, after := mt.TrimEntryCapacity(targetEntries)
+		shard.mu.Unlock()
+		if before <= after {
+			continue
+		}
+		trimmed++
+		droppedBytes += uint64(before - after)
+	}
+	if trimmed > 0 {
+		db.appendOnlyMutableTrimTotal.Add(uint64(trimmed))
+		db.appendOnlyMutableSparseTrimTotal.Add(uint64(trimmed))
+		if droppedBytes > 0 {
+			db.appendOnlyMutableTrimDropped.Add(droppedBytes)
+			db.appendOnlyMutableSparseTrimDropped.Add(droppedBytes)
+		}
+	}
+	return trimmed
+}
+
 func (db *DB) trimMutableShardAppendOnlyDirectArenas(checkpoint bool) {
 	if db == nil || len(db.mutableShards) == 0 {
 		return
@@ -10322,6 +10393,7 @@ func (db *DB) trimRetainedArenasAfterFlush(checkpoint bool) {
 		idleMutableRetainCapacity = 0
 	}
 	db.trimEmptyAppendOnlyMutableShards(idleMutableRetainCapacity)
+	db.trimSparseAppendOnlyMutableShards(idleMutableRetainCapacity)
 	db.trimAppendOnlyMemLeases(appendOnlyLeaseKeep, db.checkpointRotateCapacity())
 }
 
@@ -29009,6 +29081,8 @@ func (db *DB) Stats() map[string]string {
 	appendOnlyMutableCount, appendOnlyMutableEntryCapacity, appendOnlyMutableEntryBackingBytes := db.appendOnlyMutableShardEntryStats()
 	appendOnlyMutableTrimTotal := db.appendOnlyMutableTrimTotal.Load()
 	appendOnlyMutableTrimDropped := db.appendOnlyMutableTrimDropped.Load()
+	appendOnlyMutableSparseTrimTotal := db.appendOnlyMutableSparseTrimTotal.Load()
+	appendOnlyMutableSparseTrimDropped := db.appendOnlyMutableSparseTrimDropped.Load()
 	stats["treedb.cache.append_only.entry_hint_entries"] = fmt.Sprintf("%d", appendOnlyEntryHint)
 	stats["treedb.cache.append_only.entry_hint_capacity_bytes"] = fmt.Sprintf("%d", appendOnlyHintCapacity)
 	stats["treedb.cache.append_only.entry_pool_retained_bytes_estimate"] = fmt.Sprintf("%d", appendOnlyEntryPoolStats.RetainedBytesEstimate)
@@ -29033,6 +29107,8 @@ func (db *DB) Stats() map[string]string {
 	stats["treedb.cache.append_only.mutable_entry_backing_bytes"] = fmt.Sprintf("%d", appendOnlyMutableEntryBackingBytes)
 	stats["treedb.cache.append_only.mutable_trim_total"] = fmt.Sprintf("%d", appendOnlyMutableTrimTotal)
 	stats["treedb.cache.append_only.mutable_trim_dropped_bytes_total"] = fmt.Sprintf("%d", appendOnlyMutableTrimDropped)
+	stats["treedb.cache.append_only.mutable_sparse_trim_total"] = fmt.Sprintf("%d", appendOnlyMutableSparseTrimTotal)
+	stats["treedb.cache.append_only.mutable_sparse_trim_dropped_bytes_total"] = fmt.Sprintf("%d", appendOnlyMutableSparseTrimDropped)
 	stats["treedb.cache.append_only.mutable_pool_drops_total"] = fmt.Sprintf("%d", appendOnlyMemPoolDropTotal)
 	stats["treedb.cache.append_only.mutable_pool_puts_total"] = fmt.Sprintf("%d", appendOnlyMemPoolPutTotal)
 	stats["treedb.cache.append_only.mutable_pool_entry_backing_dropped_bytes_total"] = fmt.Sprintf("%d", appendOnlyMemPoolEntryDropBytes)
@@ -29065,6 +29141,8 @@ func (db *DB) Stats() map[string]string {
 	stats["treedb.process.append_only.mutable_entry_backing_bytes"] = fmt.Sprintf("%d", appendOnlyMutableEntryBackingBytes)
 	stats["treedb.process.append_only.mutable_trim_total"] = fmt.Sprintf("%d", appendOnlyMutableTrimTotal)
 	stats["treedb.process.append_only.mutable_trim_dropped_bytes_total"] = fmt.Sprintf("%d", appendOnlyMutableTrimDropped)
+	stats["treedb.process.append_only.mutable_sparse_trim_total"] = fmt.Sprintf("%d", appendOnlyMutableSparseTrimTotal)
+	stats["treedb.process.append_only.mutable_sparse_trim_dropped_bytes_total"] = fmt.Sprintf("%d", appendOnlyMutableSparseTrimDropped)
 	stats["treedb.process.append_only.mutable_pool_drops_total"] = fmt.Sprintf("%d", appendOnlyMemPoolDropTotal)
 	stats["treedb.process.append_only.mutable_pool_puts_total"] = fmt.Sprintf("%d", appendOnlyMemPoolPutTotal)
 	stats["treedb.process.append_only.mutable_pool_entry_backing_dropped_bytes_total"] = fmt.Sprintf("%d", appendOnlyMemPoolEntryDropBytes)

--- a/TreeDB/caching/retained_arena_trim_test.go
+++ b/TreeDB/caching/retained_arena_trim_test.go
@@ -249,6 +249,52 @@ func TestAppendOnlyIdleMutableRetainCapacity_CapsEmptyShardBacking(t *testing.T)
 	}
 }
 
+func TestTrimRetainedArenasAfterFlush_TrimsSparseAppendOnlyMutableBacking(t *testing.T) {
+	var db DB
+	db.storeMemtableMode(memtable.ModeAppendOnly)
+	db.memtableCap = 64 << 20
+	db.mutableShards = make([]memShard, 1)
+
+	mt := memtable.NewAppendOnlyWithCapacityEstimatedEntryBytes(db.checkpointRotateCapacity(), appendOnlyEstimatedBytesPerEntryDefault)
+	for i := 0; i < 1024; i++ {
+		mt.Set([]byte{byte(i >> 8), byte(i)}, []byte("value"))
+	}
+	before := mt.EntryBackingBytes()
+	if before <= int64(appendOnlyIdleMutableRetainCapacity) {
+		t.Fatalf("test setup entry backing=%d want above idle cap=%d", before, appendOnlyIdleMutableRetainCapacity)
+	}
+	db.mutableShards[0].mem = mt
+
+	db.trimRetainedArenasAfterFlush(false)
+
+	after := mt.EntryBackingBytes()
+	if after >= before {
+		t.Fatalf("entry backing after sparse trim=%d want below before=%d", after, before)
+	}
+	if after > int64(appendOnlyIdleMutableRetainCapacity) {
+		t.Fatalf("entry backing after sparse trim=%d want <= idle cap=%d", after, appendOnlyIdleMutableRetainCapacity)
+	}
+	if got := mt.Len(); got != 1024 {
+		t.Fatalf("len after sparse trim=%d want 1024", got)
+	}
+	value, deleted, found := mt.Get([]byte{0, 42})
+	if !found || deleted || string(value) != "value" {
+		t.Fatalf("Get after sparse trim=(%q,%t,%t), want value", value, deleted, found)
+	}
+	if got := db.appendOnlyMutableTrimTotal.Load(); got != 1 {
+		t.Fatalf("mutable trim total=%d want 1", got)
+	}
+	if got := db.appendOnlyMutableSparseTrimTotal.Load(); got != 1 {
+		t.Fatalf("mutable sparse trim total=%d want 1", got)
+	}
+	if got := db.appendOnlyMutableTrimDropped.Load(); got == 0 {
+		t.Fatal("mutable trim dropped bytes=0 want >0")
+	}
+	if got := db.appendOnlyMutableSparseTrimDropped.Load(); got == 0 {
+		t.Fatal("mutable sparse trim dropped bytes=0 want >0")
+	}
+}
+
 func TestTrimRetainedArenasAfterFlush_CheckpointDropsEmptyMutableBacking(t *testing.T) {
 	var db DB
 	db.storeMemtableMode(memtable.ModeAppendOnly)

--- a/TreeDB/internal/memtable/append_only.go
+++ b/TreeDB/internal/memtable/append_only.go
@@ -1825,6 +1825,43 @@ func (m *AppendOnly) EntryBackingBytes() int64 {
 	return int64(cap(m.entries)) * int64(unsafe.Sizeof(appendOnlyEntry{}))
 }
 
+// TrimEntryCapacity shrinks retained entry-slot backing while preserving active
+// entries. It is intended for maintenance boundaries after a transient ingest
+// spike has left a live append-only memtable with large unused capacity.
+func (m *AppendOnly) TrimEntryCapacity(maxEntries int) (before, after int64) {
+	if m == nil {
+		return 0, 0
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.waitIteratorLeasesLocked()
+
+	before = int64(cap(m.entries)) * int64(unsafe.Sizeof(appendOnlyEntry{}))
+	if maxEntries < m.count {
+		maxEntries = m.count
+	}
+	if maxEntries > 0 && maxEntries < appendOnlyMinInitialEntries {
+		maxEntries = appendOnlyMinInitialEntries
+	}
+	if cap(m.entries) <= maxEntries {
+		return before, before
+	}
+
+	prev := m.entries
+	next := getAppendOnlyEntries(maxEntries)
+	copy(next, m.entries[:m.count])
+	m.entries = next
+	if m.baseEntriesLen > maxEntries {
+		m.baseEntriesLen = maxEntries
+	}
+	m.snapshot = nil
+	m.snapCount = 0
+	putAppendOnlyEntries(prev)
+
+	after = int64(cap(m.entries)) * int64(unsafe.Sizeof(appendOnlyEntry{}))
+	return before, after
+}
+
 func (m *AppendOnly) Freeze() {
 	m.mu.Lock()
 	if m.frozen {

--- a/TreeDB/internal/memtable/append_only_test.go
+++ b/TreeDB/internal/memtable/append_only_test.go
@@ -114,6 +114,73 @@ func TestAppendOnlyInitialEntriesForCount(t *testing.T) {
 	})
 }
 
+func TestAppendOnlyTrimEntryCapacityPreservesUnorderedEntries(t *testing.T) {
+	m := NewAppendOnlyWithEntryCapacity(4096)
+
+	m.Set([]byte("k3"), []byte("old3"))
+	m.Set([]byte("k1"), []byte("old1"))
+	m.Set([]byte("k2"), []byte("v2"))
+	m.Set([]byte("k1"), []byte("new1"))
+	m.Delete([]byte("k3"))
+
+	beforeCap := m.EntryCapacity()
+	beforeBytes := m.EntryBackingBytes()
+	if beforeCap <= appendOnlyMinInitialEntries {
+		t.Fatalf("test setup capacity=%d want above min=%d", beforeCap, appendOnlyMinInitialEntries)
+	}
+
+	before, after := m.TrimEntryCapacity(1)
+	if before != beforeBytes {
+		t.Fatalf("trim before bytes=%d want %d", before, beforeBytes)
+	}
+	if after >= before {
+		t.Fatalf("trim after bytes=%d want below before=%d", after, before)
+	}
+	if got := m.EntryCapacity(); got < m.Len() {
+		t.Fatalf("entry capacity after trim=%d below len=%d", got, m.Len())
+	}
+
+	if got, del, ok := m.Get([]byte("k1")); !ok || del || string(got) != "new1" {
+		t.Fatalf("Get(k1)=(%q,%v,%v), want (new1,false,true)", string(got), del, ok)
+	}
+	if got, del, ok := m.Get([]byte("k2")); !ok || del || string(got) != "v2" {
+		t.Fatalf("Get(k2)=(%q,%v,%v), want (v2,false,true)", string(got), del, ok)
+	}
+	if got, del, ok := m.Get([]byte("k3")); !ok || !del || got != nil {
+		t.Fatalf("Get(k3)=(%v,%v,%v), want tombstone", got, del, ok)
+	}
+
+	it := m.NewIterator(nil, nil)
+	defer func() { _ = it.Close() }()
+	want := []struct {
+		key     string
+		value   string
+		deleted bool
+	}{
+		{key: "k1", value: "new1"},
+		{key: "k2", value: "v2"},
+		{key: "k3", deleted: true},
+	}
+	for i, w := range want {
+		if !it.Valid() {
+			t.Fatalf("iterator ended at %d", i)
+		}
+		if got := string(it.Key()); got != w.key {
+			t.Fatalf("iterator key[%d]=%q want %q", i, got, w.key)
+		}
+		if got := it.IsDeleted(); got != w.deleted {
+			t.Fatalf("iterator deleted[%d]=%v want %v", i, got, w.deleted)
+		}
+		if !w.deleted && string(it.Value()) != w.value {
+			t.Fatalf("iterator value[%d]=%q want %q", i, string(it.Value()), w.value)
+		}
+		it.Next()
+	}
+	if it.Valid() {
+		t.Fatalf("iterator has extra key %q", string(it.Key()))
+	}
+}
+
 func TestAppendOnlyCRUD(t *testing.T) {
 	m := NewAppendOnlyWithCapacity(0)
 


### PR DESCRIPTION
## Summary

Refs #3299.

This targets the current post-#3302 Celestia HWM owner: live append-only mutable entry backing that stayed oversized after restore bursts drained.

Post-#3302 HWM evidence from `/home/mikers/.celestia-app-mainnet-treedb-20260629083049/sync/diagnostics/pprof-heap-max-hwm-5506576k-20260629083447.*` showed:

- `TreeDB/internal/memtable.getAppendOnlyEntries=471.62MB` in the heap profile.
- `treedb.process.memtable_residency.mutable.append_only.entries=40000`.
- `treedb.process.memtable_residency.mutable.append_only.entry_capacity=2796192`.
- `treedb.process.memtable_residency.mutable.append_only.entry_backing_bytes=223695360`.
- `treedb.process.memtable_residency.queue.append_only.count=0`, so this was active mutable overcapacity, not queued memtable residency.

## Change

- Add `AppendOnly.TrimEntryCapacity`, which shrinks entry backing while preserving active entries, ordered/unordered state, tombstones, and iterator safety.
- Extend post-flush/checkpoint retained-arena trimming to compact sparse non-empty append-only mutable shards, not only empty shards.
- Keep regular post-flush trimming conservative: each sparse mutable keeps at least the idle retain target (`512KiB`, about `5461` estimated entries) or live entries plus headroom, whichever is larger.
- Add `mutable_sparse_trim_*` stats under both `treedb.cache.append_only.*` and `treedb.process.append_only.*` so Celestia runs can prove whether this path fired and how many bytes it dropped.

For the observed HWM shape, if live entries are roughly spread across 16 shards, the new post-flush target would cut mutable entry backing from `223695360` bytes toward roughly `16 * 5461 * 80 ~= 6.99MB`; skewed shards keep `live + 25%` headroom instead of forcing the idle cap.

## Candidate Celestia Evidence

Candidate run: `/home/mikers/.celestia-app-mainnet-treedb-20260629092407`, using PR head `8c719a482276ac6b74c33696ba11c9eda73de8c0`, harness commit `ce730ba7da567bedea4ab894df492d20b9da6e89`, local IAVL `/tmp/iavl-3238-importer-setview-20260629023257`, trust height/hash `11714074` / `AC2679168CE4DCFA9AA7355E52A265A2CA6250C9A9392B3EF3BFACA284B5104E`, requested stop target `11715650`, dwell `300s`.

Caveat: this run selected snapshot `11743500`, while the previous post-#3302 TreeDB baseline selected `11742500`; treat this as directional PR-head evidence, not a strict same-snapshot A/B.

| Metric | Post-#3302 TreeDB | PR-head TreeDB | Directional delta |
| --- | ---: | ---: | ---: |
| sync duration | `322s` | `307s` | `-15s` / `-4.7%` |
| total duration incl. dwell | `623s` | `608s` | `-15s` / `-2.4%` |
| max RSS | `6351800 KiB` | `6326068 KiB` | `-25732 KiB` / `-0.4%` |
| max HWM | `7185204 KiB` | `7071852 KiB` | `-113352 KiB` / `-1.6%` |
| app DB bytes | `2275065293` | `2238769966` | `-36295327` / `-1.6%` |
| home bytes | `3241247841` | `3103043590` | `-138204251` / `-4.3%` |

Targeted owner movement at the HWM capture:

| Evidence | Post-#3302 TreeDB | PR-head TreeDB | Directional delta |
| --- | ---: | ---: | ---: |
| `getAppendOnlyEntries` heap bucket | `471.62MB` | `90.32MB` | `-80.8%` |
| mutable append-only entry backing | `223695360` | `55923200` | `-75.0%` |
| mutable append-only entry capacity | `2796192` | `699040` | `-75.0%` |
| entry-slice retained estimate | `201278720` | `73483520` | `-63.5%` |

Run-end trim evidence from `pprof-heap-max-memory-final-6326068k-20260629093429.treedb_application_vars.json`:

- `treedb.process.append_only.mutable_sparse_trim_total=64`.
- `treedb.process.append_only.mutable_sparse_trim_dropped_bytes_total=704627200`.
- `treedb.process.append_only.mutable_trim_total=9568`.
- `treedb.process.append_only.mutable_trim_dropped_bytes_total=18637034240`.
- `treedb.process.memtable_residency.mutable.append_only.entry_backing_bytes=0`.
- `treedb.cache.vlog_zombie.bytes=0`.

Remaining HWM attribution is no longer primarily mutable entry backing. The PR-head HWM profile still shows TreeDB-owned/value-path buckets such as `getAppendOnlyValueArenaChunk=210.96MB`, `valuelog.getDecodeScratch=68.60MB`, `caching.getEntrySlice=62.53MB`, `getAppendOnlyDirectValueArenaChunk=26.31MB`, and `ReadOnlyPrepareResult.ensureInitialCapacity=23.32MB`, plus IAVL/CometBFT/runtime owners.

## Validation

- `git diff --check`
- `GOWORK=off go test ./TreeDB/internal/memtable ./TreeDB/caching -run 'TestAppendOnlyTrimEntryCapacityPreservesUnorderedEntries|TestTrimRetainedArenasAfterFlush_TrimsSparseAppendOnlyMutableBacking|TestTrimEmptyAppendOnlyMutableShards_DropsWarmEntryBacking|TestCheckpointDropsEmptyAppendOnlyMutableBackingStats'`
- `GOWORK=off go test ./TreeDB/internal/memtable ./TreeDB/caching`
- `GOWORK=off go test -race ./TreeDB/internal/memtable ./TreeDB/caching -run 'TestAppendOnlyTrimEntryCapacityPreservesUnorderedEntries|TestTrimRetainedArenasAfterFlush_TrimsSparseAppendOnlyMutableBacking|TestTrimEmptyAppendOnlyMutableShards_DropsWarmEntryBacking|TestCheckpointDropsEmptyAppendOnlyMutableBackingStats'`
- Celestia PR-head candidate rerun above.

## Still Required

This PR materially moves the measured direct owner, but does not close #3299 by itself. After CI/review gates and merge, rerun or reuse the same PR-head code as the post-fix TreeDB evidence, then run strict LevelDB-vs-TreeDB A/B only when trust target, accepted snapshot, target/dwell window, and measurement protocol match.
