### PR TITLE
raftplacement: add shard route decision boundary

### DIFF
--- a/TreeDB/docs/spec/raftplacement.md
+++ b/TreeDB/docs/spec/raftplacement.md
@@ -3,13 +3,12 @@
 Status: normative for the initial `TreeDB/internal/raftplacement` package.
 
 This document records the first executable slices of #3046. The package defines
-a v1 placement catalog and a pure route resolver for collection-level Raft
-groups. It also accepts token/ring placement entries as validated internal
+a v1 placement catalog and a pure route-decision boundary for collection-level
+Raft groups. It also accepts token/ring placement entries as validated internal
 catalog data and includes token-ring helpers that validate virtual partition
 coverage against known groups. It does not change native-wire read policies,
-Mongo gateway
-behavior, `raftentry` single-group scope handling, server routing, submitter
-APIs, meta-group replication, rebalancing, or production token/ring routing.
+Mongo gateway behavior, `raftentry` single-group scope handling, server routing,
+submitter APIs, meta-group replication, rebalancing, or horizontal-scale claims.
 
 ## V1 Catalog Shape
 
@@ -52,6 +51,33 @@ The v1 resolver maps each placed `{database, catalog, collection}` identity to
 exactly one owning `GroupID`. Resolving an unplaced collection MUST fail closed.
 Collection-only resolution MUST also fail closed for token/ring placements;
 callers must use an explicit token-aware helper to resolve those placements.
+
+## Route Decision Boundary
+
+`ResolvedCatalogV1.Route` accepts a `RouteRequestV1` with an explicit
+collection identity and route shape. It returns a `RouteDecisionV1` that carries
+the target group metadata, including group members and the current leader hint,
+for future submitter adapters. The decision is only a catalog-derived answer; it
+does not submit to Raft, open a network route, choose a live leader, or prove
+that native-wire or Mongo request routing is production-ready.
+
+Supported v1 route shapes are:
+
+- `collection`: routes collection-scoped requests only when the placement mode
+  is `collection`;
+- `token`: routes token/ring placements only when the request supplies an
+  explicit uint64 token.
+
+Route decisions MUST fail closed for:
+
+- unplaced collections;
+- `collection` route requests against `token` or `ring` placements;
+- `token` route requests without an explicit token;
+- `token` route requests against collection-mode placements;
+- unsupported query, scatter-gather, range, or otherwise multi-group shapes.
+
+Token route decisions include the matched token partition metadata. Collection
+route decisions do not infer shard keys or scatter across token partitions.
 
 ## Token/Ring Catalog Placements
 
@@ -96,14 +122,16 @@ read/snapshot dependencies are ready for production routing.
 - plans that do not cover the full uint64 token space exactly once.
 
 `ResolveToken` maps a token to its simulated virtual partition only after the
-plan has passed validation. It MUST NOT be treated as native-wire or Mongo
-request routing.
+plan has passed validation. `RouteToken` can wrap catalog-backed token/ring
+placements in a route decision when the caller supplies an explicit token. It
+MUST NOT be treated as native-wire or Mongo request routing.
 
 ## Deferred Scope
 
-The v1 catalog validates token/ring placement shape only. It makes no
-production routing, meta-group replication, rebalance execution, or
-horizontal-scale claim. Future production token/ring work needs shard-key rules,
-query routing contracts, unique-index semantics, rebalance execution,
-native-wire and Mongo gateway integration, and benchmark evidence before those
-fields can be used for request routing.
+The v1 catalog validates token/ring placement shape and can return explicit
+route decisions over that validated catalog. It makes no server-routing,
+meta-group replication, rebalance execution, or horizontal-scale claim. Future
+production token/ring work needs shard-key rules, query routing contracts,
+unique-index semantics, rebalance execution, native-wire and Mongo gateway
+integration, and benchmark evidence before those fields can be used to route
+live requests.

--- a/TreeDB/internal/raftplacement/doc.go
+++ b/TreeDB/internal/raftplacement/doc.go
@@ -1,9 +1,9 @@
 // Package raftplacement validates the first TreeDB multi-group placement
-// catalog shapes and resolves collection identities to Raft group IDs or
-// token partitions through explicit helper APIs.
+// catalog shapes and resolves explicit route requests to Raft group decisions
+// or token partitions through explicit helper APIs.
 //
-// This package is deliberately pure catalog validation and simulation logic. It
-// does not route requests, start Raft groups, expose submitter APIs, choose
-// leaders, maintain a meta Raft group, rebalance data, or enable token/ring
-// production request routing.
+// This package is deliberately pure catalog validation, simulation, and
+// route-decision logic. It does not submit routed requests, start Raft groups,
+// expose submitter APIs, choose leaders, maintain a meta Raft group, rebalance
+// data, or provide native-wire/Mongo server routing.
 package raftplacement

--- a/TreeDB/internal/raftplacement/route.go
+++ b/TreeDB/internal/raftplacement/route.go
@@ -1,0 +1,133 @@
+package raftplacement
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/snissn/gomap/TreeDB/internal/raftcluster"
+)
+
+var (
+	ErrInvalidRouteRequest   = errors.New("raftplacement: invalid route request")
+	ErrUnsupportedRouteShape = errors.New("raftplacement: unsupported route shape")
+	ErrMissingRouteToken     = errors.New("raftplacement: missing route token")
+)
+
+type RouteShapeV1 string
+
+const (
+	RouteShapeCollectionV1    RouteShapeV1 = "collection"
+	RouteShapeTokenV1         RouteShapeV1 = "token"
+	RouteShapeQueryV1         RouteShapeV1 = "query"
+	RouteShapeScatterGatherV1 RouteShapeV1 = "scatter_gather"
+)
+
+type RouteRequestV1 struct {
+	Collection CollectionRefV1
+	Shape      RouteShapeV1
+	Token      *uint64
+}
+
+type RouteTokenDecisionV1 struct {
+	Present   bool
+	Token     uint64
+	Partition ResolvedTokenPartitionV1
+}
+
+type RouteDecisionV1 struct {
+	Collection    CollectionRefV1
+	Shape         RouteShapeV1
+	PlacementMode PlacementModeV1
+	Group         ResolvedGroupV1
+	Token         RouteTokenDecisionV1
+}
+
+func (d RouteDecisionV1) GroupID() raftcluster.GroupID {
+	return d.Group.ID
+}
+
+func (d RouteDecisionV1) LeaderHint() raftcluster.NodeID {
+	return d.Group.LeaderHint
+}
+
+func (c ResolvedCatalogV1) Route(req RouteRequestV1) (RouteDecisionV1, error) {
+	if err := validateCollectionRef(req.Collection); err != nil {
+		return RouteDecisionV1{}, errors.Join(ErrInvalidRouteRequest, err)
+	}
+	placement, ok := c.placements[req.Collection]
+	if !ok {
+		return RouteDecisionV1{}, errors.Join(ErrInvalidRouteRequest, ErrUnplacedCollection, fmt.Errorf("%s/%s/%s", req.Collection.Database, req.Collection.Catalog, req.Collection.Collection))
+	}
+
+	switch req.Shape {
+	case RouteShapeCollectionV1:
+		if placement.Mode != PlacementModeCollectionV1 {
+			return RouteDecisionV1{}, errors.Join(ErrInvalidRouteRequest, ErrUnsupportedPlacementMode, fmt.Errorf("%s/%s/%s mode %q requires explicit token route request", req.Collection.Database, req.Collection.Catalog, req.Collection.Collection, placement.Mode))
+		}
+		group, err := c.routeGroup(placement.GroupID)
+		if err != nil {
+			return RouteDecisionV1{}, err
+		}
+		return RouteDecisionV1{
+			Collection:    req.Collection,
+			Shape:         req.Shape,
+			PlacementMode: placement.Mode,
+			Group:         group,
+		}, nil
+	case RouteShapeTokenV1:
+		if req.Token == nil {
+			return RouteDecisionV1{}, errors.Join(ErrInvalidRouteRequest, ErrMissingRouteToken, fmt.Errorf("%s/%s/%s token route request requires explicit token", req.Collection.Database, req.Collection.Catalog, req.Collection.Collection))
+		}
+		if placement.Mode != PlacementModeTokenV1 && placement.Mode != PlacementModeRingV1 {
+			return RouteDecisionV1{}, errors.Join(ErrInvalidRouteRequest, ErrUnsupportedPlacementMode, fmt.Errorf("%s/%s/%s mode %q has no token partitions", req.Collection.Database, req.Collection.Catalog, req.Collection.Collection, placement.Mode))
+		}
+		plan, ok := c.tokens[req.Collection]
+		if !ok {
+			return RouteDecisionV1{}, errors.Join(ErrInvalidRouteRequest, ErrInvalidTokenRing, fmt.Errorf("%s/%s/%s has no resolved token plan", req.Collection.Database, req.Collection.Catalog, req.Collection.Collection))
+		}
+		partition, err := plan.ResolveToken(*req.Token)
+		if err != nil {
+			return RouteDecisionV1{}, errors.Join(ErrInvalidRouteRequest, err)
+		}
+		group, err := c.routeGroup(partition.GroupID)
+		if err != nil {
+			return RouteDecisionV1{}, err
+		}
+		return RouteDecisionV1{
+			Collection:    req.Collection,
+			Shape:         req.Shape,
+			PlacementMode: placement.Mode,
+			Group:         group,
+			Token: RouteTokenDecisionV1{
+				Present:   true,
+				Token:     *req.Token,
+				Partition: partition,
+			},
+		}, nil
+	default:
+		return RouteDecisionV1{}, errors.Join(ErrInvalidRouteRequest, ErrUnsupportedRouteShape, fmt.Errorf("%s/%s/%s route shape %q", req.Collection.Database, req.Collection.Catalog, req.Collection.Collection, req.Shape))
+	}
+}
+
+func (c ResolvedCatalogV1) RouteCollection(database, catalog, collection string) (RouteDecisionV1, error) {
+	return c.Route(RouteRequestV1{
+		Collection: CollectionRefV1{Database: database, Catalog: catalog, Collection: collection},
+		Shape:      RouteShapeCollectionV1,
+	})
+}
+
+func (c ResolvedCatalogV1) RouteToken(database, catalog, collection string, token uint64) (RouteDecisionV1, error) {
+	return c.Route(RouteRequestV1{
+		Collection: CollectionRefV1{Database: database, Catalog: catalog, Collection: collection},
+		Shape:      RouteShapeTokenV1,
+		Token:      &token,
+	})
+}
+
+func (c ResolvedCatalogV1) routeGroup(id raftcluster.GroupID) (ResolvedGroupV1, error) {
+	group, ok := c.Group(id)
+	if !ok {
+		return ResolvedGroupV1{}, errors.Join(ErrInvalidRouteRequest, ErrUnknownGroup, fmt.Errorf("route target group %q is not present in resolved catalog", id))
+	}
+	return group, nil
+}

--- a/TreeDB/internal/raftplacement/route_test.go
+++ b/TreeDB/internal/raftplacement/route_test.go
@@ -1,0 +1,197 @@
+package raftplacement
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/internal/raftcluster"
+)
+
+func TestRouteCollectionDecisionIncludesGroupMetadata(t *testing.T) {
+	resolved, err := Validate(validCatalog())
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+
+	decision, err := resolved.RouteCollection(DefaultDatabase, DefaultCatalog, "orders")
+	if err != nil {
+		t.Fatalf("RouteCollection: %v", err)
+	}
+
+	if decision.Collection.Collection != "orders" {
+		t.Fatalf("collection=%q want orders", decision.Collection.Collection)
+	}
+	if decision.Shape != RouteShapeCollectionV1 {
+		t.Fatalf("shape=%q want %q", decision.Shape, RouteShapeCollectionV1)
+	}
+	if decision.PlacementMode != PlacementModeCollectionV1 {
+		t.Fatalf("placement mode=%q want %q", decision.PlacementMode, PlacementModeCollectionV1)
+	}
+	if decision.GroupID() != "group-b" {
+		t.Fatalf("group=%q want group-b", decision.GroupID())
+	}
+	if decision.LeaderHint() != "node-b" {
+		t.Fatalf("leader hint=%q want node-b", decision.LeaderHint())
+	}
+	wantMembers := []raftcluster.NodeID{"node-b", "node-c"}
+	if !reflect.DeepEqual(decision.Group.Members, wantMembers) {
+		t.Fatalf("members=%v want %v", decision.Group.Members, wantMembers)
+	}
+	if decision.Token.Present {
+		t.Fatalf("collection decision unexpectedly includes token metadata: %+v", decision.Token)
+	}
+
+	decision.Group.Members[0] = "mutated"
+	again, err := resolved.RouteCollection(DefaultDatabase, DefaultCatalog, "orders")
+	if err != nil {
+		t.Fatalf("RouteCollection after mutation: %v", err)
+	}
+	if again.Group.Members[0] != "node-b" {
+		t.Fatalf("route decision exposed mutable catalog group members: %v", again.Group.Members)
+	}
+}
+
+func TestRouteTokenDecisionIncludesPartitionAndGroupMetadata(t *testing.T) {
+	for _, mode := range []PlacementModeV1{PlacementModeTokenV1, PlacementModeRingV1} {
+		t.Run(string(mode), func(t *testing.T) {
+			ref := CollectionRefV1{Database: DefaultDatabase, Catalog: DefaultCatalog, Collection: "events"}
+			catalog := validCatalog()
+			catalog.Placements = append(catalog.Placements, tokenPlacement(ref, mode))
+			resolved, err := Validate(catalog)
+			if err != nil {
+				t.Fatalf("Validate: %v", err)
+			}
+
+			decision, err := resolved.RouteToken(DefaultDatabase, DefaultCatalog, "events", maxTokenV1)
+			if err != nil {
+				t.Fatalf("RouteToken: %v", err)
+			}
+			if decision.Shape != RouteShapeTokenV1 {
+				t.Fatalf("shape=%q want %q", decision.Shape, RouteShapeTokenV1)
+			}
+			if decision.PlacementMode != mode {
+				t.Fatalf("placement mode=%q want %q", decision.PlacementMode, mode)
+			}
+			if decision.GroupID() != "group-b" {
+				t.Fatalf("group=%q want group-b", decision.GroupID())
+			}
+			if decision.LeaderHint() != "node-b" {
+				t.Fatalf("leader hint=%q want node-b", decision.LeaderHint())
+			}
+			if !decision.Token.Present {
+				t.Fatalf("token decision missing token metadata")
+			}
+			if decision.Token.Token != maxTokenV1 {
+				t.Fatalf("token=%d want %d", decision.Token.Token, uint64(maxTokenV1))
+			}
+			if decision.Token.Partition.ID != "token-000001" || decision.Token.Partition.GroupID != "group-b" {
+				t.Fatalf("partition=(%q,%q) want (token-000001,group-b)", decision.Token.Partition.ID, decision.Token.Partition.GroupID)
+			}
+		})
+	}
+}
+
+func TestRouteFailsClosed(t *testing.T) {
+	ref := CollectionRefV1{Database: DefaultDatabase, Catalog: DefaultCatalog, Collection: "events"}
+	catalog := validCatalog()
+	catalog.Placements = append(catalog.Placements, tokenPlacement(ref, PlacementModeRingV1))
+	resolved, err := Validate(catalog)
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	token := uint64(0)
+
+	tests := []struct {
+		name string
+		req  RouteRequestV1
+		want error
+	}{
+		{
+			name: "unplaced collection",
+			req: RouteRequestV1{
+				Collection: CollectionRefV1{Database: DefaultDatabase, Catalog: DefaultCatalog, Collection: "missing"},
+				Shape:      RouteShapeCollectionV1,
+			},
+			want: ErrUnplacedCollection,
+		},
+		{
+			name: "collection shape against token placement",
+			req: RouteRequestV1{
+				Collection: ref,
+				Shape:      RouteShapeCollectionV1,
+			},
+			want: ErrUnsupportedPlacementMode,
+		},
+		{
+			name: "token request without token",
+			req: RouteRequestV1{
+				Collection: ref,
+				Shape:      RouteShapeTokenV1,
+			},
+			want: ErrMissingRouteToken,
+		},
+		{
+			name: "token request against collection placement",
+			req: RouteRequestV1{
+				Collection: CollectionRefV1{Database: DefaultDatabase, Catalog: DefaultCatalog, Collection: "users"},
+				Shape:      RouteShapeTokenV1,
+				Token:      &token,
+			},
+			want: ErrUnsupportedPlacementMode,
+		},
+		{
+			name: "query shape unsupported",
+			req: RouteRequestV1{
+				Collection: CollectionRefV1{Database: DefaultDatabase, Catalog: DefaultCatalog, Collection: "users"},
+				Shape:      RouteShapeQueryV1,
+			},
+			want: ErrUnsupportedRouteShape,
+		},
+		{
+			name: "scatter gather unsupported",
+			req: RouteRequestV1{
+				Collection: CollectionRefV1{Database: DefaultDatabase, Catalog: DefaultCatalog, Collection: "users"},
+				Shape:      RouteShapeScatterGatherV1,
+			},
+			want: ErrUnsupportedRouteShape,
+		},
+		{
+			name: "unknown route shape unsupported",
+			req: RouteRequestV1{
+				Collection: CollectionRefV1{Database: DefaultDatabase, Catalog: DefaultCatalog, Collection: "users"},
+				Shape:      "range_scan",
+			},
+			want: ErrUnsupportedRouteShape,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := resolved.Route(tc.req)
+			if !errors.Is(err, tc.want) {
+				t.Fatalf("Route err=%v want errors.Is(%v)", err, tc.want)
+			}
+			if !errors.Is(err, ErrInvalidRouteRequest) {
+				t.Fatalf("Route err=%v want ErrInvalidRouteRequest", err)
+			}
+		})
+	}
+}
+
+func TestRouteInvalidCollectionFailsClosed(t *testing.T) {
+	resolved, err := Validate(validCatalog())
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+
+	_, err = resolved.Route(RouteRequestV1{
+		Collection: CollectionRefV1{Database: DefaultDatabase, Catalog: DefaultCatalog, Collection: "bad/name"},
+		Shape:      RouteShapeCollectionV1,
+	})
+	if !errors.Is(err, ErrInvalidRouteRequest) {
+		t.Fatalf("Route err=%v want ErrInvalidRouteRequest", err)
+	}
+	if !errors.Is(err, ErrInvalidCollection) {
+		t.Fatalf("Route err=%v want ErrInvalidCollection", err)
+	}
+}


### PR DESCRIPTION
## Summary

- add a pure `raftplacement` route request/decision API over validated catalogs
- return group/member/leader-hint metadata for collection routes and explicit token/ring routes
- fail closed for unplaced collections, token/ring requests without tokens, collection-only resolution against token/ring placements, and unsupported query/scatter shapes
- update placement docs to keep this as route-decision substrate only, not server routing or horizontal-scale evidence

Closes #3329.
Parent tracker: 3046 remains open.

## Tests

- `git diff --check origin/main...HEAD`
- `GOWORK=off go test ./TreeDB/internal/raftplacement -count=1`
- `GOWORK=off go test ./TreeDB/internal/raftplacement ./TreeDB/internal/raftcluster ./TreeDB/docs -count=1`

## Scope Boundary

No nativewire or Mongo request routing, no meta-group replication, no rebalance execution, no global unique index semantics, and no horizontal-scale benchmark claim.
