### PR TITLE
raftcluster: add read-index linearizable read barrier

### DIFF
--- a/TreeDB/docs/spec/native-query-raft-roadmap.md
+++ b/TreeDB/docs/spec/native-query-raft-roadmap.md
@@ -271,6 +271,12 @@ fresh read-index barrier.
 `linearizable` performs the consensus read barrier required by the selected Raft
 implementation before reading.
 
+The current nativewire bridge for `linearizable` is a contract-only substrate:
+a configured read-index provider must return a quorum-backed read-index proof,
+then the existing applied-index waiter must prove the local node has applied
+through that read index. If either proof is unavailable, missing quorum, targets
+the wrong node/group, or local apply lags the read index, the read fails closed.
+
 `lease_read` is allowed only if leader leases are implemented and the server can
 prove the lease is valid.
 

--- a/TreeDB/docs/spec/raftcluster.md
+++ b/TreeDB/docs/spec/raftcluster.md
@@ -83,6 +83,21 @@ command-WAL recoverability rule before that node can report local durability,
 advance durable applied-index/idempotency metadata, or return
 `ack_policy=raft_committed` success.
 
+## Read-Index Boundary
+
+The package exposes a small read-index contract for future Raft adapters:
+
+- `ReadIndexProvider` obtains a quorum-backed `ReadIndexProof`;
+- `ReadIndexBarrier` optionally pins the proof to an expected node/group;
+- `ReadIndexProof` must include node ID, group ID, a non-zero read index, and
+  `HasQuorum=true`;
+- linearizable nativewire reads must convert the proof into an
+  `AppliedIndexReadBarrier` and wait until the local node has applied through
+  that index before reading local state.
+
+This is only a contract. It does not implement a real Raft read-index provider,
+leader transfer handling, lease reads, follower reads, or production routing.
+
 ## Value Log Boundary
 
 `<main-db>/value_vlog/` is persistent value storage for large values
@@ -96,7 +111,7 @@ unreachable.
 - no real consensus loop;
 - no server write admission or redirects;
 - no `ack_policy=raft_committed` behavior;
-- no read-index or follower read semantics;
+- no real read-index provider, lease-read provider, or follower read routing;
 - no snapshot install/export behavior beyond reserving a local path;
 - no Raft log truncation;
 - no multi-group routing.

--- a/TreeDB/internal/raftcluster/read_index.go
+++ b/TreeDB/internal/raftcluster/read_index.go
@@ -1,0 +1,63 @@
+package raftcluster
+
+import (
+	"context"
+	"fmt"
+)
+
+// ReadIndexBarrier requests a quorum-backed read-index proof for a node/group.
+// Empty NodeID or GroupID fields do not constrain the proof target, but callers
+// that know the intended target should set them so mismatches fail closed.
+type ReadIndexBarrier struct {
+	NodeID  NodeID
+	GroupID GroupID
+}
+
+// ReadIndexProof is the minimal result a Raft adapter must provide before a
+// linearizable local read can wait for local application.
+type ReadIndexProof struct {
+	NodeID    NodeID
+	GroupID   GroupID
+	Term      uint64
+	Index     uint64
+	HasQuorum bool
+}
+
+// ReadIndexProvider obtains a read-index proof from the selected Raft adapter.
+type ReadIndexProvider interface {
+	ReadIndex(context.Context, ReadIndexBarrier) (ReadIndexProof, error)
+}
+
+func (b ReadIndexBarrier) SatisfiedBy(proof ReadIndexProof) bool {
+	return b.Check(proof) == nil
+}
+
+func (b ReadIndexBarrier) Check(proof ReadIndexProof) error {
+	if b.NodeID != "" && proof.NodeID != b.NodeID {
+		return fmt.Errorf("%w: node %q proof came from node %q", ErrReadBarrierTargetMismatch, b.NodeID, proof.NodeID)
+	}
+	if b.GroupID != "" && proof.GroupID != b.GroupID {
+		return fmt.Errorf("%w: group %q proof came from group %q", ErrReadBarrierTargetMismatch, b.GroupID, proof.GroupID)
+	}
+	if proof.NodeID == "" {
+		return fmt.Errorf("%w: read-index proof missing node id", ErrReadBarrierTargetMismatch)
+	}
+	if proof.GroupID == "" {
+		return fmt.Errorf("%w: read-index proof missing group id", ErrReadBarrierTargetMismatch)
+	}
+	if !proof.HasQuorum {
+		return fmt.Errorf("%w: read-index proof missing quorum", ErrReadBarrierNotSatisfied)
+	}
+	if proof.Index == 0 {
+		return fmt.Errorf("%w: read-index proof missing index", ErrReadBarrierNotSatisfied)
+	}
+	return nil
+}
+
+func (p ReadIndexProof) AppliedIndexBarrier() AppliedIndexReadBarrier {
+	return AppliedIndexReadBarrier{
+		NodeID:          p.NodeID,
+		GroupID:         p.GroupID,
+		MinAppliedIndex: p.Index,
+	}
+}

--- a/TreeDB/internal/raftcluster/read_index_test.go
+++ b/TreeDB/internal/raftcluster/read_index_test.go
@@ -1,0 +1,120 @@
+package raftcluster
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestReadIndexBarrierAcceptsQuorumProof(t *testing.T) {
+	barrier := ReadIndexBarrier{NodeID: "node-a", GroupID: "group-a"}
+	proof := ReadIndexProof{
+		NodeID:    "node-a",
+		GroupID:   "group-a",
+		Term:      7,
+		Index:     42,
+		HasQuorum: true,
+	}
+	if err := barrier.Check(proof); err != nil {
+		t.Fatalf("Check: %v", err)
+	}
+	if !barrier.SatisfiedBy(proof) {
+		t.Fatalf("SatisfiedBy=false want true")
+	}
+
+	applied := proof.AppliedIndexBarrier()
+	if applied.NodeID != proof.NodeID ||
+		applied.GroupID != proof.GroupID ||
+		applied.MinAppliedIndex != proof.Index {
+		t.Fatalf("AppliedIndexBarrier=%+v proof=%+v", applied, proof)
+	}
+}
+
+func TestReadIndexBarrierRejectsMissingQuorumProof(t *testing.T) {
+	barrier := ReadIndexBarrier{NodeID: "node-a", GroupID: "group-a"}
+	proof := ReadIndexProof{
+		NodeID:  "node-a",
+		GroupID: "group-a",
+		Term:    7,
+		Index:   42,
+	}
+	err := barrier.Check(proof)
+	if !errors.Is(err, ErrReadBarrierNotSatisfied) {
+		t.Fatalf("Check err=%v want ErrReadBarrierNotSatisfied", err)
+	}
+	if barrier.SatisfiedBy(proof) {
+		t.Fatalf("SatisfiedBy=true want false")
+	}
+}
+
+func TestReadIndexBarrierRejectsMissingReadIndex(t *testing.T) {
+	barrier := ReadIndexBarrier{NodeID: "node-a", GroupID: "group-a"}
+	proof := ReadIndexProof{
+		NodeID:    "node-a",
+		GroupID:   "group-a",
+		Term:      7,
+		HasQuorum: true,
+	}
+	err := barrier.Check(proof)
+	if !errors.Is(err, ErrReadBarrierNotSatisfied) {
+		t.Fatalf("Check err=%v want ErrReadBarrierNotSatisfied", err)
+	}
+}
+
+func TestReadIndexBarrierRejectsTargetMismatch(t *testing.T) {
+	tests := []struct {
+		name    string
+		barrier ReadIndexBarrier
+		proof   ReadIndexProof
+	}{
+		{
+			name:    "node",
+			barrier: ReadIndexBarrier{NodeID: "node-a", GroupID: "group-a"},
+			proof: ReadIndexProof{
+				NodeID:    "node-b",
+				GroupID:   "group-a",
+				Term:      7,
+				Index:     42,
+				HasQuorum: true,
+			},
+		},
+		{
+			name:    "group",
+			barrier: ReadIndexBarrier{NodeID: "node-a", GroupID: "group-a"},
+			proof: ReadIndexProof{
+				NodeID:    "node-a",
+				GroupID:   "group-b",
+				Term:      7,
+				Index:     42,
+				HasQuorum: true,
+			},
+		},
+		{
+			name:    "missing-node",
+			barrier: ReadIndexBarrier{GroupID: "group-a"},
+			proof: ReadIndexProof{
+				GroupID:   "group-a",
+				Term:      7,
+				Index:     42,
+				HasQuorum: true,
+			},
+		},
+		{
+			name:    "missing-group",
+			barrier: ReadIndexBarrier{NodeID: "node-a"},
+			proof: ReadIndexProof{
+				NodeID:    "node-a",
+				Term:      7,
+				Index:     42,
+				HasQuorum: true,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.barrier.Check(tt.proof)
+			if !errors.Is(err, ErrReadBarrierTargetMismatch) {
+				t.Fatalf("Check err=%v want ErrReadBarrierTargetMismatch", err)
+			}
+		})
+	}
+}

--- a/TreeDB/nativewire/cluster_read_barrier.go
+++ b/TreeDB/nativewire/cluster_read_barrier.go
@@ -15,12 +15,14 @@ type AppliedIndexReadBarrierProvider interface {
 }
 
 // AppliedIndexReadCoordinator bridges nativewire leader_read requests to the
-// raftcluster applied-index read barrier foundation. It intentionally does not
-// claim linearizable or lease-read safety; those require a real read-index or
-// lease proof outside this adapter.
+// raftcluster applied-index read barrier foundation. Linearizable reads require
+// a configured read-index provider and then wait for local apply through the
+// proven read index. Lease reads remain unsupported until a lease proof exists.
 type AppliedIndexReadCoordinator struct {
-	BarrierProvider AppliedIndexReadBarrierProvider
-	Waiter          raftcluster.AppliedIndexReadBarrierWaiter
+	BarrierProvider   AppliedIndexReadBarrierProvider
+	Waiter            raftcluster.AppliedIndexReadBarrierWaiter
+	ReadIndexTarget   raftcluster.ReadIndexBarrier
+	ReadIndexProvider raftcluster.ReadIndexProvider
 }
 
 func (c AppliedIndexReadCoordinator) CoordinateRead(ctx context.Context, request ClusterReadRequest) (ClusterReadResult, error) {
@@ -29,13 +31,17 @@ func (c AppliedIndexReadCoordinator) CoordinateRead(ctx context.Context, request
 	}
 	switch request.Policy {
 	case ConsistencyLeaderRead:
+		return c.coordinateLeaderRead(ctx, request)
 	case ConsistencyLinearizable:
-		return ClusterReadResult{}, errors.New("nativewire: linearizable reads require a read-index proof")
+		return c.coordinateLinearizableRead(ctx)
 	case ConsistencyLeaseRead:
 		return ClusterReadResult{}, errors.New("nativewire: lease reads require a lease proof")
 	default:
 		return ClusterReadResult{}, fmt.Errorf("nativewire: unsupported coordinated read policy %s", consistencyPolicyName(request.Policy))
 	}
+}
+
+func (c AppliedIndexReadCoordinator) coordinateLeaderRead(ctx context.Context, request ClusterReadRequest) (ClusterReadResult, error) {
 	if c.BarrierProvider == nil {
 		return ClusterReadResult{}, errors.New("nativewire: applied-index read barrier provider is not configured")
 	}
@@ -63,6 +69,40 @@ func (c AppliedIndexReadCoordinator) CoordinateRead(ctx context.Context, request
 		ActualConsistency: ConsistencyLeaderRead,
 		ServingNode:       string(progress.NodeID),
 		LeaderNode:        string(barrier.NodeID),
+		AppliedIndex:      progress.Index,
+		HasAppliedIndex:   true,
+	}, nil
+}
+
+func (c AppliedIndexReadCoordinator) coordinateLinearizableRead(ctx context.Context) (ClusterReadResult, error) {
+	if c.ReadIndexProvider == nil {
+		return ClusterReadResult{}, errors.New("nativewire: read-index provider is not configured")
+	}
+	if c.Waiter == nil {
+		return ClusterReadResult{}, errors.New("nativewire: applied-index read barrier waiter is not configured")
+	}
+	proof, err := c.ReadIndexProvider.ReadIndex(ctx, c.ReadIndexTarget)
+	if err != nil {
+		return ClusterReadResult{}, err
+	}
+	if err := c.ReadIndexTarget.Check(proof); err != nil {
+		return ClusterReadResult{}, err
+	}
+	barrier := proof.AppliedIndexBarrier()
+	progress, err := c.Waiter.WaitAppliedIndex(ctx, barrier)
+	if err != nil {
+		return ClusterReadResult{}, err
+	}
+	if err := barrier.Check(progress); err != nil {
+		return ClusterReadResult{}, err
+	}
+	if !progress.HasApplied {
+		return ClusterReadResult{}, fmt.Errorf("%w: no applied progress for linearizable read", raftcluster.ErrReadBarrierNotSatisfied)
+	}
+	return ClusterReadResult{
+		ActualConsistency: ConsistencyLinearizable,
+		ServingNode:       string(progress.NodeID),
+		LeaderNode:        string(proof.NodeID),
 		AppliedIndex:      progress.Index,
 		HasAppliedIndex:   true,
 	}, nil

--- a/TreeDB/nativewire/cluster_read_barrier_test.go
+++ b/TreeDB/nativewire/cluster_read_barrier_test.go
@@ -32,6 +32,17 @@ func (f *fakeAppliedIndexWaiter) WaitAppliedIndex(ctx context.Context, barrier r
 	return f.progress, f.err
 }
 
+type fakeReadIndexProvider struct {
+	proof raftcluster.ReadIndexProof
+	err   error
+	calls []raftcluster.ReadIndexBarrier
+}
+
+func (f *fakeReadIndexProvider) ReadIndex(ctx context.Context, barrier raftcluster.ReadIndexBarrier) (raftcluster.ReadIndexProof, error) {
+	f.calls = append(f.calls, barrier)
+	return f.proof, f.err
+}
+
 func TestAppliedIndexReadCoordinatorProvesLeaderReadMetadata(t *testing.T) {
 	provider := &fakeAppliedIndexBarrierProvider{
 		barrier: raftcluster.AppliedIndexReadBarrier{
@@ -185,36 +196,174 @@ func TestAppliedIndexReadCoordinatorFailsClosedForTargetMismatch(t *testing.T) {
 	}
 }
 
-func TestAppliedIndexReadCoordinatorKeepsStrongReadPoliciesFailClosed(t *testing.T) {
+func TestAppliedIndexReadCoordinatorProvesLinearizableReadMetadata(t *testing.T) {
+	readIndex := &fakeReadIndexProvider{
+		proof: raftcluster.ReadIndexProof{
+			NodeID:    "node-a",
+			GroupID:   "group-a",
+			Term:      7,
+			Index:     42,
+			HasQuorum: true,
+		},
+	}
+	waiter := &fakeAppliedIndexWaiter{
+		progress: raftcluster.AppliedProgress{
+			NodeID:     "node-a",
+			GroupID:    "group-a",
+			Term:       7,
+			Index:      44,
+			HasApplied: true,
+		},
+	}
+	target := raftcluster.ReadIndexBarrier{NodeID: "node-a", GroupID: "group-a"}
+	client, mgr, _ := serveCollectionPipeWithOptions(t, ServerOptions{
+		ClusterReadCoordinator: AppliedIndexReadCoordinator{
+			Waiter:            waiter,
+			ReadIndexTarget:   target,
+			ReadIndexProvider: readIndex,
+		},
+	})
+	seedReadCollection(t, mgr)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := client.Hello(ctx); err != nil {
+		t.Fatalf("Hello: %v", err)
+	}
+
+	result, err := client.GetManyWithOptions(ctx, "users", [][]byte{[]byte("u1")}, ReadOptions{ConsistencyPolicy: ConsistencyLinearizable})
+	if err != nil {
+		t.Fatalf("GetManyWithOptions: %v", err)
+	}
+	if got, want := result.Present, []bool{true}; !boolSlicesEqual(got, want) {
+		t.Fatalf("present=%v want %v", got, want)
+	}
+	if !result.ReadMeta.Valid ||
+		result.ReadMeta.ActualConsistency != ConsistencyLinearizable ||
+		result.ReadMeta.ServingNode != "node-a" ||
+		result.ReadMeta.LeaderNode != "node-a" ||
+		!result.ReadMeta.HasAppliedIndex ||
+		result.ReadMeta.AppliedIndex != 44 {
+		t.Fatalf("read meta=%+v", result.ReadMeta)
+	}
+	if len(readIndex.calls) != 1 || readIndex.calls[0] != target {
+		t.Fatalf("read index calls=%+v want %+v", readIndex.calls, target)
+	}
+	wantBarrier := raftcluster.AppliedIndexReadBarrier{
+		NodeID:          "node-a",
+		GroupID:         "group-a",
+		MinAppliedIndex: 42,
+	}
+	if len(waiter.calls) != 1 || waiter.calls[0] != wantBarrier {
+		t.Fatalf("waiter calls=%+v want %+v", waiter.calls, wantBarrier)
+	}
+}
+
+func TestAppliedIndexReadCoordinatorLinearizableFailsClosedWithoutReadIndexProvider(t *testing.T) {
+	waiter := &fakeAppliedIndexWaiter{
+		progress: raftcluster.AppliedProgress{
+			NodeID:     "node-a",
+			GroupID:    "group-a",
+			Term:       7,
+			Index:      44,
+			HasApplied: true,
+		},
+	}
+	client, mgr, _ := serveCollectionPipeWithOptions(t, ServerOptions{
+		ClusterReadCoordinator: AppliedIndexReadCoordinator{Waiter: waiter},
+	})
+	seedReadCollection(t, mgr)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := client.Hello(ctx); err != nil {
+		t.Fatalf("Hello: %v", err)
+	}
+
+	_, err := client.IndexLookupWithOptions(ctx, "users", "email", "ada@example.com", CursorLimits{}, ReadOptions{ConsistencyPolicy: ConsistencyLinearizable})
+	if !isRemoteError(err, iwire.ErrConsistencyUnavailable) {
+		t.Fatalf("IndexLookupWithOptions err=%v want consistency_unavailable", err)
+	}
+	if len(waiter.calls) != 0 {
+		t.Fatalf("waiter calls=%d want none", len(waiter.calls))
+	}
+}
+
+func TestAppliedIndexReadCoordinatorLinearizableFailsClosedWithoutQuorumProof(t *testing.T) {
+	readIndex := &fakeReadIndexProvider{
+		proof: raftcluster.ReadIndexProof{
+			NodeID:  "node-a",
+			GroupID: "group-a",
+			Term:    7,
+			Index:   42,
+		},
+	}
+	waiter := &fakeAppliedIndexWaiter{}
+	client, mgr, _ := serveCollectionPipeWithOptions(t, ServerOptions{
+		ClusterReadCoordinator: AppliedIndexReadCoordinator{
+			Waiter:            waiter,
+			ReadIndexProvider: readIndex,
+		},
+	})
+	seedReadCollection(t, mgr)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := client.Hello(ctx); err != nil {
+		t.Fatalf("Hello: %v", err)
+	}
+
+	_, err := client.GetManyWithOptions(ctx, "users", [][]byte{[]byte("u1")}, ReadOptions{ConsistencyPolicy: ConsistencyLinearizable})
+	if !isRemoteError(err, iwire.ErrConsistencyUnavailable) {
+		t.Fatalf("GetManyWithOptions err=%v want consistency_unavailable", err)
+	}
+	if len(readIndex.calls) != 1 {
+		t.Fatalf("read index calls=%d want 1", len(readIndex.calls))
+	}
+	if len(waiter.calls) != 0 {
+		t.Fatalf("waiter calls=%d want none", len(waiter.calls))
+	}
+}
+
+func TestAppliedIndexReadCoordinatorLinearizableFailsClosedForTargetMismatch(t *testing.T) {
 	tests := []struct {
-		name   string
-		policy ConsistencyPolicy
+		name     string
+		progress raftcluster.AppliedProgress
 	}{
-		{name: "linearizable", policy: ConsistencyLinearizable},
-		{name: "lease-read", policy: ConsistencyLeaseRead},
+		{
+			name: "node",
+			progress: raftcluster.AppliedProgress{
+				NodeID:     "node-b",
+				GroupID:    "group-a",
+				Term:       7,
+				Index:      44,
+				HasApplied: true,
+			},
+		},
+		{
+			name: "group",
+			progress: raftcluster.AppliedProgress{
+				NodeID:     "node-a",
+				GroupID:    "group-b",
+				Term:       7,
+				Index:      44,
+				HasApplied: true,
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			provider := &fakeAppliedIndexBarrierProvider{
-				barrier: raftcluster.AppliedIndexReadBarrier{
-					NodeID:          "node-a",
-					GroupID:         "group-a",
-					MinAppliedIndex: 42,
+			readIndex := &fakeReadIndexProvider{
+				proof: raftcluster.ReadIndexProof{
+					NodeID:    "node-a",
+					GroupID:   "group-a",
+					Term:      7,
+					Index:     42,
+					HasQuorum: true,
 				},
 			}
-			waiter := &fakeAppliedIndexWaiter{
-				progress: raftcluster.AppliedProgress{
-					NodeID:     "node-a",
-					GroupID:    "group-a",
-					Term:       7,
-					Index:      44,
-					HasApplied: true,
-				},
-			}
+			waiter := &fakeAppliedIndexWaiter{progress: tt.progress}
 			client, mgr, _ := serveCollectionPipeWithOptions(t, ServerOptions{
 				ClusterReadCoordinator: AppliedIndexReadCoordinator{
-					BarrierProvider: provider,
-					Waiter:          waiter,
+					Waiter:            waiter,
+					ReadIndexProvider: readIndex,
 				},
 			})
 			seedReadCollection(t, mgr)
@@ -224,14 +373,96 @@ func TestAppliedIndexReadCoordinatorKeepsStrongReadPoliciesFailClosed(t *testing
 				t.Fatalf("Hello: %v", err)
 			}
 
-			_, err := client.IndexLookupWithOptions(ctx, "users", "email", "ada@example.com", CursorLimits{}, ReadOptions{ConsistencyPolicy: tt.policy})
+			_, err := client.GetManyWithOptions(ctx, "users", [][]byte{[]byte("u1")}, ReadOptions{ConsistencyPolicy: ConsistencyLinearizable})
 			if !isRemoteError(err, iwire.ErrConsistencyUnavailable) {
-				t.Fatalf("IndexLookupWithOptions err=%v want consistency_unavailable", err)
+				t.Fatalf("GetManyWithOptions err=%v want consistency_unavailable", err)
 			}
-			if len(provider.calls) != 0 || len(waiter.calls) != 0 {
-				t.Fatalf("provider calls=%d waiter calls=%d want none", len(provider.calls), len(waiter.calls))
+			if len(readIndex.calls) != 1 || len(waiter.calls) != 1 {
+				t.Fatalf("read index calls=%d waiter calls=%d want one each", len(readIndex.calls), len(waiter.calls))
 			}
 		})
+	}
+}
+
+func TestAppliedIndexReadCoordinatorLinearizableFailsClosedForLocalApplyLag(t *testing.T) {
+	readIndex := &fakeReadIndexProvider{
+		proof: raftcluster.ReadIndexProof{
+			NodeID:    "node-a",
+			GroupID:   "group-a",
+			Term:      7,
+			Index:     42,
+			HasQuorum: true,
+		},
+	}
+	waiter := &fakeAppliedIndexWaiter{
+		progress: raftcluster.AppliedProgress{
+			NodeID:     "node-a",
+			GroupID:    "group-a",
+			Term:       7,
+			Index:      41,
+			HasApplied: true,
+		},
+	}
+	client, mgr, _ := serveCollectionPipeWithOptions(t, ServerOptions{
+		ClusterReadCoordinator: AppliedIndexReadCoordinator{
+			Waiter:            waiter,
+			ReadIndexProvider: readIndex,
+		},
+	})
+	seedReadCollection(t, mgr)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := client.Hello(ctx); err != nil {
+		t.Fatalf("Hello: %v", err)
+	}
+
+	_, err := client.IndexLookupWithOptions(ctx, "users", "email", "ada@example.com", CursorLimits{}, ReadOptions{ConsistencyPolicy: ConsistencyLinearizable})
+	if !isRemoteError(err, iwire.ErrConsistencyUnavailable) {
+		t.Fatalf("IndexLookupWithOptions err=%v want consistency_unavailable", err)
+	}
+	if len(readIndex.calls) != 1 || len(waiter.calls) != 1 {
+		t.Fatalf("read index calls=%d waiter calls=%d want one each", len(readIndex.calls), len(waiter.calls))
+	}
+}
+
+func TestAppliedIndexReadCoordinatorKeepsLeaseReadFailClosed(t *testing.T) {
+	readIndex := &fakeReadIndexProvider{
+		proof: raftcluster.ReadIndexProof{
+			NodeID:    "node-a",
+			GroupID:   "group-a",
+			Term:      7,
+			Index:     42,
+			HasQuorum: true,
+		},
+	}
+	waiter := &fakeAppliedIndexWaiter{
+		progress: raftcluster.AppliedProgress{
+			NodeID:     "node-a",
+			GroupID:    "group-a",
+			Term:       7,
+			Index:      44,
+			HasApplied: true,
+		},
+	}
+	client, mgr, _ := serveCollectionPipeWithOptions(t, ServerOptions{
+		ClusterReadCoordinator: AppliedIndexReadCoordinator{
+			Waiter:            waiter,
+			ReadIndexProvider: readIndex,
+		},
+	})
+	seedReadCollection(t, mgr)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := client.Hello(ctx); err != nil {
+		t.Fatalf("Hello: %v", err)
+	}
+
+	_, err := client.IndexLookupWithOptions(ctx, "users", "email", "ada@example.com", CursorLimits{}, ReadOptions{ConsistencyPolicy: ConsistencyLeaseRead})
+	if !isRemoteError(err, iwire.ErrConsistencyUnavailable) {
+		t.Fatalf("IndexLookupWithOptions err=%v want consistency_unavailable", err)
+	}
+	if len(readIndex.calls) != 0 || len(waiter.calls) != 0 {
+		t.Fatalf("read index calls=%d waiter calls=%d want none", len(readIndex.calls), len(waiter.calls))
 	}
 }
 


### PR DESCRIPTION
## Summary

- add a `raftcluster` read-index proof contract that requires node/group identity, quorum, and a non-zero read index
- bridge nativewire `linearizable` reads through read-index proof plus the existing applied-index waiter before serving local state
- keep `leader_read` behavior intact and keep `lease_read` fail-closed until a lease proof exists
- document this as contract substrate only, not a real Raft provider, follower-read route, snapshot, or log-truncation closeout

Closes #3331.
Parent tracker: #3045 remains open.

## Tests

- `git diff --check origin/main...HEAD`
- `GOWORK=off go test ./TreeDB/internal/raftcluster ./TreeDB/nativewire -run 'Test(ReadIndex|AppliedIndex|Linearizable|ClusterRead)' -count=1`\n- `GOWORK=off go test ./TreeDB/internal/raftcluster ./TreeDB/nativewire ./TreeDB/internal/raftfsm ./TreeDB/internal/raftharness -count=1`\n\n## Scope Boundary\n\nNo production read-index provider, no lease-read proof, no follower-read routing, no snapshot install/export, no log truncation, and no rejoin/read-routing benchmark claim. This only makes the linearizable read contract fail-closed until a real Raft adapter provides a quorum read-index proof.\n