### PR TITLE
Optimize dense q2 distinct rank setup

### DIFF
--- a/TreeDB/collections/column_physical_q2_1950_test.go
+++ b/TreeDB/collections/column_physical_q2_1950_test.go
@@ -357,6 +357,126 @@ func TestTypedColumnQ2DenseGroupCountDistinctRankMapCapacity3158(t *testing.T) {
 	}
 }
 
+func TestTypedColumnQ2DenseGroupCountDistinctManyPartSortedDistinctRanks3324(t *testing.T) {
+	const partCount = columnTypedColumnDenseGroupCountDistinctSortedMergeMaxParts + 8
+	parts := make([]columnTypedColumnPhysicalQueryPart, partCount)
+	for partIdx := range parts {
+		groupDictionary := []string{
+			fmt.Sprintf("app.%02d", (partCount-partIdx)%7),
+			fmt.Sprintf("app.%02d", 20+(partIdx%3)),
+		}
+		sort.Strings(groupDictionary)
+		distinctDictionary := []string{
+			fmt.Sprintf("did:%03d", (partIdx+7)%11),
+			fmt.Sprintf("did:%03d", 100+(partIdx%5)),
+		}
+		sort.Strings(distinctDictionary)
+		distinctValid := []bool{true}
+		if partIdx == partCount/2 {
+			distinctValid = []bool{true, false}
+		}
+		parts[partIdx].DenseGroupCountDistinct = &columnTypedColumnDenseGroupCountDistinctPart{
+			Group: columnTypedColumnDenseStringCodeColumn{
+				Dictionary: groupDictionary,
+			},
+			Distinct: columnTypedColumnDenseStringCodeColumn{
+				Dictionary: distinctDictionary,
+				Valid:      distinctValid,
+			},
+		}
+	}
+
+	expectedDistinctRanks := map[string]uint32{"": 0}
+	nextRank := uint32(1)
+	for valueIdx := 0; valueIdx < 11; valueIdx++ {
+		expectedDistinctRanks[fmt.Sprintf("did:%03d", valueIdx)] = nextRank
+		nextRank++
+	}
+	for valueIdx := 100; valueIdx < 105; valueIdx++ {
+		expectedDistinctRanks[fmt.Sprintf("did:%03d", valueIdx)] = nextRank
+		nextRank++
+	}
+
+	ranks, cardinality, err := columnTypedColumnDenseGroupCountDistinctGlobalRanks(parts, func(part *columnTypedColumnDenseGroupCountDistinctPart) *columnTypedColumnDenseStringCodeColumn {
+		return &part.Distinct
+	})
+	if err != nil {
+		t.Fatalf("many-part global distinct ranks: %v", err)
+	}
+	if cardinality != len(expectedDistinctRanks) {
+		t.Fatalf("many-part distinct cardinality=%d want %d ranks=%v", cardinality, len(expectedDistinctRanks), ranks)
+	}
+	for value, want := range expectedDistinctRanks {
+		if got, ok := ranks[value]; !ok || got != want {
+			t.Fatalf("many-part distinct rank[%q]=%d ok=%t want %d ranks=%v", value, got, ok, want, ranks)
+		}
+	}
+
+	var prepareDiagnostics columnTypedColumnPhysicalQueryPrepareDiagnostics
+	if err := prepareColumnTypedColumnDenseGroupCountDistinctGlobalRankMapsWithDiagnostics(parts, &prepareDiagnostics); err != nil {
+		t.Fatalf("prepare many-part sorted global rank maps: %v", err)
+	}
+	for partIdx := range parts {
+		column := parts[partIdx].DenseGroupCountDistinct.Distinct
+		if column.GlobalDictionary != nil {
+			t.Fatalf("part %d distinct global dictionary allocated=%v want nil", partIdx, column.GlobalDictionary)
+		}
+		if !column.GlobalCardinalityOK || column.GlobalCardinality != len(expectedDistinctRanks) {
+			t.Fatalf("part %d distinct cardinality=(%d,%t) want %d", partIdx, column.GlobalCardinality, column.GlobalCardinalityOK, len(expectedDistinctRanks))
+		}
+		if !column.GlobalEmptyRankOK || column.GlobalEmptyRank != 0 {
+			t.Fatalf("part %d empty rank=(%d,%t) want (0,true)", partIdx, column.GlobalEmptyRank, column.GlobalEmptyRankOK)
+		}
+		if len(column.GlobalLocalRanks) != len(column.Dictionary) {
+			t.Fatalf("part %d distinct local ranks=%d want dictionary=%d", partIdx, len(column.GlobalLocalRanks), len(column.Dictionary))
+		}
+		for localCode, value := range column.Dictionary {
+			if got, want := column.GlobalLocalRanks[localCode], expectedDistinctRanks[value]; got != want {
+				t.Fatalf("part %d local code %d value=%q rank=%d want %d", partIdx, localCode, value, got, want)
+			}
+		}
+	}
+}
+
+func TestTypedColumnQ2DenseGroupCountDistinctSortedRanksRejectUnsortedDictionary3324(t *testing.T) {
+	parts := []columnTypedColumnPhysicalQueryPart{
+		{
+			DenseGroupCountDistinct: &columnTypedColumnDenseGroupCountDistinctPart{
+				Distinct: columnTypedColumnDenseStringCodeColumn{
+					Dictionary: []string{"did:z", "did:a"},
+				},
+			},
+		},
+		{
+			DenseGroupCountDistinct: &columnTypedColumnDenseGroupCountDistinctPart{
+				Distinct: columnTypedColumnDenseStringCodeColumn{
+					Dictionary: []string{"did:b"},
+				},
+			},
+		},
+	}
+	capacity, err := columnTypedColumnDenseGroupCountDistinctDictionaryCapacity(parts, func(part *columnTypedColumnDenseGroupCountDistinctPart) *columnTypedColumnDenseStringCodeColumn {
+		return &part.Distinct
+	})
+	if err != nil {
+		t.Fatalf("dictionary capacity: %v", err)
+	}
+	if _, _, ok, err := columnTypedColumnDenseGroupCountDistinctSortedGlobalRanks(parts, func(part *columnTypedColumnDenseGroupCountDistinctPart) *columnTypedColumnDenseStringCodeColumn {
+		return &part.Distinct
+	}, capacity, false); err != nil || ok {
+		t.Fatalf("sorted global ranks ok=%t err=%v want rejected unsorted local dictionary", ok, err)
+	}
+	ranks, cardinality, err := columnTypedColumnDenseGroupCountDistinctGlobalRanks(parts, func(part *columnTypedColumnDenseGroupCountDistinctPart) *columnTypedColumnDenseStringCodeColumn {
+		return &part.Distinct
+	})
+	if err != nil {
+		t.Fatalf("global distinct ranks map fallback: %v", err)
+	}
+	if cardinality != 3 || ranks["did:z"] != 0 || ranks["did:a"] != 1 || ranks["did:b"] != 2 {
+		t.Fatalf("fallback ranks cardinality=%d ranks=%v want existing map path order", cardinality, ranks)
+	}
+}
+
 func TestTypedColumnQ2DenseGroupCountDistinctActiveGroupBitset1950(t *testing.T) {
 	const (
 		groupCardinality    = 4096

--- a/TreeDB/collections/column_physical_typed_column_query.go
+++ b/TreeDB/collections/column_physical_typed_column_query.go
@@ -2,6 +2,7 @@ package collections
 
 import (
 	"bytes"
+	"container/heap"
 	"errors"
 	"fmt"
 	"io"
@@ -14,7 +15,9 @@ import (
 )
 
 const (
-	columnTypedColumnDenseGroupCountDistinctMaxBitsetWords      = 2 << 20
+	columnTypedColumnDenseGroupCountDistinctMaxBitsetWords = 2 << 20
+	// Above this threshold, sorted q2 rank setup uses a heap merge instead of
+	// repeatedly scanning every local dictionary head.
 	columnTypedColumnDenseGroupCountDistinctSortedMergeMaxParts = 32
 )
 
@@ -1428,9 +1431,6 @@ func columnTypedColumnDenseGroupCountDistinctGlobalRanksMap(parts []columnTypedC
 }
 
 func columnTypedColumnDenseGroupCountDistinctSortedGlobalRanks(parts []columnTypedColumnPhysicalQueryPart, selectColumn func(*columnTypedColumnDenseGroupCountDistinctPart) *columnTypedColumnDenseStringCodeColumn, capacity int, keepDictionary bool) ([]string, map[string]uint32, bool, error) {
-	if len(parts) > columnTypedColumnDenseGroupCountDistinctSortedMergeMaxParts {
-		return nil, nil, false, nil
-	}
 	columns := make([]*columnTypedColumnDenseStringCodeColumn, 0, len(parts))
 	includeEmpty := false
 	for partIdx := range parts {
@@ -1442,6 +1442,9 @@ func columnTypedColumnDenseGroupCountDistinctSortedGlobalRanks(parts []columnTyp
 		if column == nil {
 			return nil, nil, false, fmt.Errorf("collections: dense grouped count-distinct missing selected column for part %d", partIdx)
 		}
+		if !columnTypedColumnDenseGroupCountDistinctDictionarySorted(column.Dictionary) {
+			return nil, nil, false, nil
+		}
 		columns = append(columns, column)
 		if !includeEmpty {
 			for _, valid := range column.Valid {
@@ -1452,7 +1455,22 @@ func columnTypedColumnDenseGroupCountDistinctSortedGlobalRanks(parts []columnTyp
 			}
 		}
 	}
+	if len(parts) > columnTypedColumnDenseGroupCountDistinctSortedMergeMaxParts {
+		return columnTypedColumnDenseGroupCountDistinctHeapGlobalRanks(columns, includeEmpty, capacity, keepDictionary)
+	}
+	return columnTypedColumnDenseGroupCountDistinctLinearGlobalRanks(columns, includeEmpty, capacity, keepDictionary)
+}
 
+func columnTypedColumnDenseGroupCountDistinctDictionarySorted(dictionary []string) bool {
+	for idx := 1; idx < len(dictionary); idx++ {
+		if dictionary[idx-1] >= dictionary[idx] {
+			return false
+		}
+	}
+	return true
+}
+
+func columnTypedColumnDenseGroupCountDistinctLinearGlobalRanks(columns []*columnTypedColumnDenseStringCodeColumn, includeEmpty bool, capacity int, keepDictionary bool) ([]string, map[string]uint32, bool, error) {
 	positions := make([]int, len(columns))
 	ranks := make(map[string]uint32, columnTypedColumnDenseGroupCountDistinctRankMapCapacity(capacity))
 	var dictionary []string
@@ -1470,9 +1488,6 @@ func columnTypedColumnDenseGroupCountDistinctSortedGlobalRanks(parts []columnTyp
 			pos := positions[columnIdx]
 			if pos >= len(column.Dictionary) {
 				continue
-			}
-			if pos > 0 && column.Dictionary[pos-1] >= column.Dictionary[pos] {
-				return nil, nil, false, nil
 			}
 			value := column.Dictionary[pos]
 			if !haveNext || value < next {
@@ -1504,6 +1519,106 @@ func columnTypedColumnDenseGroupCountDistinctSortedGlobalRanks(parts []columnTyp
 		}
 	}
 	return dictionary, ranks, true, nil
+}
+
+func columnTypedColumnDenseGroupCountDistinctHeapGlobalRanks(columns []*columnTypedColumnDenseStringCodeColumn, includeEmpty bool, capacity int, keepDictionary bool) ([]string, map[string]uint32, bool, error) {
+	ranks := make(map[string]uint32, columnTypedColumnDenseGroupCountDistinctRankMapCapacity(capacity))
+	var dictionary []string
+	if keepDictionary {
+		dictionary = make([]string, 0, min(capacity, 64))
+	}
+	addValue := func(value string) error {
+		if _, exists := ranks[value]; exists {
+			return nil
+		}
+		if uint64(len(ranks)) > uint64(^uint32(0)) {
+			return fmt.Errorf("collections: dense grouped count-distinct global dictionary cardinality exceeds uint32")
+		}
+		ranks[value] = uint32(len(ranks))
+		if keepDictionary {
+			dictionary = append(dictionary, value)
+		}
+		return nil
+	}
+
+	positions := make([]int, len(columns))
+	if includeEmpty {
+		if err := addValue(""); err != nil {
+			return nil, nil, false, err
+		}
+		for columnIdx, column := range columns {
+			if len(column.Dictionary) > 0 && column.Dictionary[0] == "" {
+				positions[columnIdx] = 1
+			}
+		}
+	}
+
+	items := make(columnTypedColumnDenseGroupCountDistinctRankMergeHeap, 0, len(columns))
+	for columnIdx, column := range columns {
+		pos := positions[columnIdx]
+		if pos < len(column.Dictionary) {
+			items = append(items, columnTypedColumnDenseGroupCountDistinctRankMergeItem{
+				value:     column.Dictionary[pos],
+				columnIdx: columnIdx,
+				pos:       pos,
+			})
+		}
+	}
+	heap.Init(&items)
+	for items.Len() > 0 {
+		value := items[0].value
+		if err := addValue(value); err != nil {
+			return nil, nil, false, err
+		}
+		for items.Len() > 0 && items[0].value == value {
+			item := heap.Pop(&items).(columnTypedColumnDenseGroupCountDistinctRankMergeItem)
+			nextPos := item.pos + 1
+			column := columns[item.columnIdx]
+			if nextPos < len(column.Dictionary) {
+				heap.Push(&items, columnTypedColumnDenseGroupCountDistinctRankMergeItem{
+					value:     column.Dictionary[nextPos],
+					columnIdx: item.columnIdx,
+					pos:       nextPos,
+				})
+			}
+		}
+	}
+	return dictionary, ranks, true, nil
+}
+
+type columnTypedColumnDenseGroupCountDistinctRankMergeItem struct {
+	value     string
+	columnIdx int
+	pos       int
+}
+
+type columnTypedColumnDenseGroupCountDistinctRankMergeHeap []columnTypedColumnDenseGroupCountDistinctRankMergeItem
+
+func (h columnTypedColumnDenseGroupCountDistinctRankMergeHeap) Len() int {
+	return len(h)
+}
+
+func (h columnTypedColumnDenseGroupCountDistinctRankMergeHeap) Less(i, j int) bool {
+	if h[i].value != h[j].value {
+		return h[i].value < h[j].value
+	}
+	return h[i].columnIdx < h[j].columnIdx
+}
+
+func (h columnTypedColumnDenseGroupCountDistinctRankMergeHeap) Swap(i, j int) {
+	h[i], h[j] = h[j], h[i]
+}
+
+func (h *columnTypedColumnDenseGroupCountDistinctRankMergeHeap) Push(x any) {
+	*h = append(*h, x.(columnTypedColumnDenseGroupCountDistinctRankMergeItem))
+}
+
+func (h *columnTypedColumnDenseGroupCountDistinctRankMergeHeap) Pop() any {
+	old := *h
+	n := len(old)
+	item := old[n-1]
+	*h = old[:n-1]
+	return item
 }
 
 func columnTypedColumnDenseGroupCountDistinctDictionaryCapacity(parts []columnTypedColumnPhysicalQueryPart, selectColumn func(*columnTypedColumnDenseGroupCountDistinctPart) *columnTypedColumnDenseStringCodeColumn) (int, error) {


### PR DESCRIPTION
## Summary

- stack on #3333 to prototype the production dense grouped-count-distinct q2 setup optimization from #3324
- replace the previous >32-part sorted-rank cutoff with a deterministic heap/k-way merge over sorted local dictionaries
- preserve the existing map fallback when local dictionaries are unsorted or required dense state is missing
- keep q2 one-shot rank prep on per-part local-rank maps; this does not materialize row-wide global-code arrays

## Current Stack

- Base: #3333 head `0ee80a48936a70de28e88a003636a91dea7af65f`
- Head: `96c8152a85a5a2e2f160ca062d30fdabdd66ae15`

## Scope And Claim Boundary

This is no-aggregate one-shot typed-column q2 setup work only. It is not aggregate-metadata acceleration, not a load/insert improvement, and not a TreeDB-vs-ClickHouse superiority claim.

The PR should stay draft until #3326/#3333 land and current 1M q2 `one_shot_end_to_end` / `no_aggregate_metadata` evidence reports setup, dense post-prepare split, run, total, rows scanned/matched/reduced, and result hash. Include q1/q3 no-regression samples if any shared setup risk appears during final validation.

## Validation

Current-head local validation after refreshing onto #3333 head:

- `GOWORK=off go test ./TreeDB/collections -run 'TestTypedColumnQ2DenseGroupCountDistinctManyPartSortedDistinctRanks3324|TestTypedColumnQ2DenseGroupCountDistinctSortedRanksRejectUnsortedDictionary3324|TestTypedColumnQ2DenseGroupCountDistinctRankMapCapacity3158|TestColumnPhysicalTypedColumnOneShotCacheQ2NoMetadata3123' -count=1`\n- `GOWORK=off go test ./TreeDB/collections -run 'Test.*Q2' -count=1`\n- `git diff --check origin/codex/q2-distinct-rank-kmerge-prototype-20260629..HEAD`\n\n## Tracker\n\n- #3324\n- #3070\n