### PR TITLE
TreeDB: fence only the command-WAL publish flush chunk

### DIFF
--- a/TreeDB/caching/db_test.go
+++ b/TreeDB/caching/db_test.go
@@ -46,6 +46,7 @@ type MockBackend struct {
 	pointerEntries               map[string]page.ValuePtr
 	setOpsInlineValueLimit       int
 	lastSpanNativeFallbackReason db.FlushSpanRunFallbackReason
+	spanNativeFallbackReasons    []db.FlushSpanRunFallbackReason
 	fragReport                   map[string]string
 	fragErr                      error
 	vacuumErr                    error
@@ -770,6 +771,7 @@ func (b *MockBatch) WriteSync() error {
 func (b *MockBatch) SetFlushApplySpanNativeFallback(reason db.FlushSpanRunFallbackReason) {
 	b.mb.mu.Lock()
 	b.mb.lastSpanNativeFallbackReason = reason
+	b.mb.spanNativeFallbackReasons = append(b.mb.spanNativeFallbackReasons, reason)
 	b.mb.mu.Unlock()
 }
 

--- a/TreeDB/caching/flush_backlog_coalescing.go
+++ b/TreeDB/caching/flush_backlog_coalescing.go
@@ -110,8 +110,8 @@ func flushRangeOnlySpanNativeFallbackReasonForCollectionMode(mode flushCollectio
 	return backenddb.FlushSpanRunFallbackRangeDeleteBarrier
 }
 
-func flushPointRunSpanNativeFallbackReasonForCollectionMode(mode flushCollectionMode, commandPublish *checkpointCommandWALPublish) backenddb.FlushSpanRunFallbackReason {
-	if commandPublish != nil && commandPublish.appliedLSN != 0 && !commandPublish.consumed {
+func flushPointChunkSpanNativeFallbackReasonForCollectionMode(mode flushCollectionMode, commandPublish *checkpointCommandWALPublish, attachesCommandPublish bool) backenddb.FlushSpanRunFallbackReason {
+	if attachesCommandPublish && commandPublish != nil && commandPublish.appliedLSN != 0 && !commandPublish.consumed {
 		return backenddb.FlushSpanRunFallbackCommandWALBarrier
 	}
 	return flushSpanNativeFallbackReasonForCollectionMode(mode)

--- a/TreeDB/caching/flush_backlog_coalescing_test.go
+++ b/TreeDB/caching/flush_backlog_coalescing_test.go
@@ -459,6 +459,42 @@ func TestFlushCollectionModeCheckpointCommandWALPublishForcesFallback(t *testing
 	}
 }
 
+func TestFlushCollectionModeCheckpointCommandWALPublishOnlyFencesPublishChunk(t *testing.T) {
+	db, backend := newCoalescingTestDB(t, Options{
+		FlushApplySpanNative:       true,
+		FlushApplyConcurrency:      4,
+		FlushApplyMinEntries:       1,
+		FlushApplyMinSpans:         1,
+		FlushApplyMinBytes:         1,
+		FlushBackendMaxEntries:     2,
+		FlushBackendMaxBatches:     -1,
+		FlushSpanRunTargetPlanning: true,
+	}, highSingleOpCoalescingSnapshot())
+	enqueuePointMemtablesWithOps(t, db, []int{5}, "commandwal-chunk")
+	db.checkpointing.Store(true)
+	publish := &checkpointCommandWALPublish{appliedLSN: 7, ranges: []backenddb.CommandWALLSNRange{{First: 1, Last: 7}}}
+	if !db.flushLaneOnceWithCollectionMode(false, 0, publish, flushCollectionBackground) {
+		t.Fatalf("flushLaneOnceWithCollectionMode returned false")
+	}
+	db.checkpointing.Store(false)
+	if !publish.consumed {
+		t.Fatalf("command WAL publish was not consumed")
+	}
+	backend.mu.RLock()
+	writeCalls := backend.writeCalls
+	reasons := append([]backenddb.FlushSpanRunFallbackReason(nil), backend.spanNativeFallbackReasons...)
+	backend.mu.RUnlock()
+	if writeCalls < 2 {
+		t.Fatalf("backend write calls=%d want multi-chunk flush", writeCalls)
+	}
+	if len(reasons) != 1 {
+		t.Fatalf("explicit fallback reasons=%v want only final publish chunk fenced", reasons)
+	}
+	if got := reasons[0]; got != backenddb.FlushSpanRunFallbackCommandWALBarrier {
+		t.Fatalf("publish chunk fallback reason=%s want %s", got, backenddb.FlushSpanRunFallbackCommandWALBarrier)
+	}
+}
+
 func TestFlushCollectionModeRangeOnlyCheckpointFallbackReason(t *testing.T) {
 	db, backend := newCoalescingTestDB(t, Options{
 		DisableWAL:                 true,

--- a/TreeDB/caching/flush_run_planner.go
+++ b/TreeDB/caching/flush_run_planner.go
@@ -719,11 +719,13 @@ func appendCanonicalFlushRunChunkToBackendBatch(backendBatch batch.Interface, op
 	return nil
 }
 
-func (db *DB) writeCanonicalFlushRunOpsChunk(ops []batch.Entry, syncFlush bool, commandPublish *checkpointCommandWALPublish, last bool, spanNativeFallbackReason backenddb.FlushSpanRunFallbackReason) error {
+func (db *DB) writeCanonicalFlushRunOpsChunk(ops []batch.Entry, syncFlush bool, commandPublish *checkpointCommandWALPublish, last bool, mode flushCollectionMode) error {
 	if db == nil || len(ops) == 0 {
 		return nil
 	}
 	backendBatch := db.newBackendBatchWithSize(len(ops))
+	attachesCommandPublish := last && commandPublish != nil && commandPublish.appliedLSN != 0 && !commandPublish.consumed
+	spanNativeFallbackReason := flushPointChunkSpanNativeFallbackReasonForCollectionMode(mode, commandPublish, attachesCommandPublish)
 	setBackendBatchSpanNativeFallback(backendBatch, spanNativeFallbackReason)
 	reserveBackendBatchOps(backendBatch, len(ops))
 	if err := appendCanonicalFlushRunChunkToBackendBatch(backendBatch, ops); err != nil {
@@ -761,7 +763,7 @@ func (db *DB) writeCanonicalFlushRunOpsChunk(ops []batch.Entry, syncFlush bool, 
 	return nil
 }
 
-func (db *DB) writeCanonicalFlushRunChunks(run *canonicalFlushRun, chunks []backenddb.FlushSpanRunBackendChunk, syncFlush bool, commandPublish *checkpointCommandWALPublish, spanNativeFallbackReason backenddb.FlushSpanRunFallbackReason) (int, error) {
+func (db *DB) writeCanonicalFlushRunChunks(run *canonicalFlushRun, chunks []backenddb.FlushSpanRunBackendChunk, syncFlush bool, commandPublish *checkpointCommandWALPublish, mode flushCollectionMode) (int, error) {
 	if db == nil || run == nil || len(run.pointOps) == 0 {
 		return 0, nil
 	}
@@ -784,7 +786,7 @@ func (db *DB) writeCanonicalFlushRunChunks(run *canonicalFlushRun, chunks []back
 				break
 			}
 		}
-		if err := db.writeCanonicalFlushRunOpsChunk(run.pointOps[chunk.PointOpStart:chunk.PointOpEnd], syncFlush, commandPublish, last, spanNativeFallbackReason); err != nil {
+		if err := db.writeCanonicalFlushRunOpsChunk(run.pointOps[chunk.PointOpStart:chunk.PointOpEnd], syncFlush, commandPublish, last, mode); err != nil {
 			return emitted, err
 		}
 		emitted++
@@ -794,7 +796,6 @@ func (db *DB) writeCanonicalFlushRunChunks(run *canonicalFlushRun, chunks []back
 
 func (db *DB) flushCanonicalPointUnitsStreamed(syncFlush bool, laneID int, commandPublish *checkpointCommandWALPublish, units []flushUnit, ids []uint64, totalBytes int64, totalLen int, totalSpans int, mode flushCollectionMode) bool {
 	flushStart := time.Now()
-	spanNativeFallbackReason := flushPointRunSpanNativeFallbackReasonForCollectionMode(mode, commandPublish)
 	buildStart := flushStart
 	build, err := db.buildCanonicalUnitRuns(units, totalLen, totalSpans)
 	if err != nil {
@@ -862,7 +863,7 @@ func (db *DB) flushCanonicalPointUnitsStreamed(syncFlush bool, laneID int, comma
 		if err := flushValueLogIfNeeded(); err != nil {
 			return fmt.Errorf("vlog: %w", err)
 		}
-		if err := db.writeCanonicalFlushRunOpsChunk(ops, syncFlush, commandPublish, last, spanNativeFallbackReason); err != nil {
+		if err := db.writeCanonicalFlushRunOpsChunk(ops, syncFlush, commandPublish, last, mode); err != nil {
 			return err
 		}
 		putEntrySlice(ops)
@@ -990,7 +991,6 @@ func (db *DB) flushCanonicalPointUnits(syncFlush bool, laneID int, commandPublis
 		return db.flushCanonicalPointUnitsStreamed(syncFlush, laneID, commandPublish, units, ids, totalBytes, totalLen, totalSpans, mode)
 	}
 	flushStart := time.Now()
-	spanNativeFallbackReason := flushPointRunSpanNativeFallbackReasonForCollectionMode(mode, commandPublish)
 	buildStart := flushStart
 	run, err := db.buildCanonicalFlushRun(units, totalLen, totalSpans)
 	if err != nil {
@@ -1038,7 +1038,7 @@ func (db *DB) flushCanonicalPointUnits(syncFlush bool, laneID int, commandPublis
 	}
 
 	writeStart := time.Now()
-	if _, err := db.writeCanonicalFlushRunChunks(run, chunks, syncFlush, commandPublish, spanNativeFallbackReason); err != nil {
+	if _, err := db.writeCanonicalFlushRunChunks(run, chunks, syncFlush, commandPublish, mode); err != nil {
 		db.reportError(fmt.Errorf("cachingdb: flush failed: %w", err))
 		return false
 	}


### PR DESCRIPTION
## Summary

- Keep the `command_wal_barrier` span-native fallback on the backend chunk that actually publishes the command-WAL applied LSN.
- Stop applying that forced fallback to earlier point chunks in the same multi-chunk checkpoint flush.
- Add a focused multi-chunk checkpoint test proving only the final publish chunk receives the explicit barrier.

## Evidence framing

This PR separates the two current Celestia questions:

- Route admission: the post-#3328 strict TreeDB run already showed raw point-put span-native admission/use for 23,455,204 ops, while another 22,688,576 point-put ops fell back. This change targets one TreeDB-owned over-fencing path that can convert non-publish checkpoint chunks back to ordinary span-native admission.
- Apply wall time: this PR does not claim a wall-time win. The same run reported `treedb.flush_apply.apply_ns_total ~= 23.7s` during a 274s sync, with backend write time around 61.0s. The next strict Celestia rerun should quantify whether more admission changes wall time or whether apply is no longer the limiter.

Next evidence gate: rerun the same Celestia protocol and compare `treedb.raw.span_native.route.point_put.used_ops_total`, `fallback.reason.span_native_not_implemented.ops_total`, `treedb.flush_apply.span_native.used_ops_total`, `fallback.reason.command_wal_barrier.ops_total`, backend write/apply ns totals, queue backlog, HWM/RSS, and strict LevelDB-vs-TreeDB A/B only on the same snapshot/window.

Refs #3317.

## Tests

- `GOWORK=off go test ./TreeDB/caching -run 'TestFlushCollectionModeCheckpointCommandWALPublish|TestFlushCollectionModeRangeOnlyCheckpointFallbackReason|TestFlushBacklogCoalescing'`\n- `GOWORK=off go test ./TreeDB/db -run 'TestRawSpanNativeRouteStats|TestFlushApplySpanNative|TestFlushApplyRootMismatchRetriesWithoutPublishingAbandonedWork'`\n- `GOWORK=off go test -count=1 ./TreeDB/caching`\n- `GOWORK=off go test -count=1 ./TreeDB/db`