### PR TITLE
raftharness: add read-index provider path

### DIFF
--- a/TreeDB/docs/spec/raftcluster.md
+++ b/TreeDB/docs/spec/raftcluster.md
@@ -98,6 +98,12 @@ The package exposes a small read-index contract for future Raft adapters:
 This is only a contract. It does not implement a real Raft read-index provider,
 leader transfer handling, lease reads, follower reads, or production routing.
 
+`raftharness.ReadIndexProvider` is the in-process test adapter for this
+contract. It derives read-index proofs from an injected committed-entry log so
+tests can exercise nativewire read-index/read-barrier composition, but that
+evidence is not production quorum evidence and the provider does not apply
+entries by itself.
+
 ## Value Log Boundary
 
 `<main-db>/value_vlog/` is persistent value storage for large values

--- a/TreeDB/internal/raftharness/read_index.go
+++ b/TreeDB/internal/raftharness/read_index.go
@@ -1,0 +1,74 @@
+package raftharness
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/snissn/gomap/TreeDB/internal/raftcluster"
+)
+
+// ReadIndexProvider is a test-only adapter for injected committed-entry
+// harnesses. It reports the latest injected committed entry as read-index
+// evidence for a configured node/group, but it does not prove production
+// consensus and it does not apply entries locally.
+type ReadIndexProvider struct {
+	h      *Harness
+	nodeID raftcluster.NodeID
+}
+
+func (h *Harness) ReadIndexProvider(nodeID raftcluster.NodeID) *ReadIndexProvider {
+	return &ReadIndexProvider{h: h, nodeID: nodeID}
+}
+
+func (p *ReadIndexProvider) ReadIndex(ctx context.Context, target raftcluster.ReadIndexBarrier) (raftcluster.ReadIndexProof, error) {
+	ctx = readBarrierContext(ctx)
+	if err := ctx.Err(); err != nil {
+		return raftcluster.ReadIndexProof{}, err
+	}
+	if p == nil || p.h == nil {
+		return raftcluster.ReadIndexProof{}, ErrHarnessClosed
+	}
+	if target.NodeID == "" {
+		return raftcluster.ReadIndexProof{}, fmt.Errorf("%w: read-index target missing node id", raftcluster.ErrReadBarrierTargetMismatch)
+	}
+	if target.GroupID == "" {
+		return raftcluster.ReadIndexProof{}, fmt.Errorf("%w: read-index target missing group id", raftcluster.ErrReadBarrierTargetMismatch)
+	}
+
+	p.h.mu.Lock()
+	defer p.h.mu.Unlock()
+	if p.h.closed {
+		return raftcluster.ReadIndexProof{}, ErrHarnessClosed
+	}
+	node, ok := p.h.nodes[p.nodeID]
+	if !ok {
+		return raftcluster.ReadIndexProof{}, fmt.Errorf("%w: %s", ErrNodeNotFound, p.nodeID)
+	}
+	if node == nil || node.closed {
+		return raftcluster.ReadIndexProof{}, fmt.Errorf("%w: %s", ErrNodeClosed, p.nodeID)
+	}
+	if target.NodeID != p.nodeID {
+		return raftcluster.ReadIndexProof{}, fmt.Errorf("%w: read-index target node %q does not match harness node %q", raftcluster.ErrReadBarrierTargetMismatch, target.NodeID, p.nodeID)
+	}
+	if target.GroupID != p.h.groupID {
+		return raftcluster.ReadIndexProof{}, fmt.Errorf("%w: read-index target group %q does not match harness group %q", raftcluster.ErrReadBarrierTargetMismatch, target.GroupID, p.h.groupID)
+	}
+	if len(p.h.committed) == 0 {
+		return raftcluster.ReadIndexProof{}, fmt.Errorf("%w: read-index has no committed entries", raftcluster.ErrReadBarrierNotSatisfied)
+	}
+	last := p.h.committed[len(p.h.committed)-1]
+	proof := raftcluster.ReadIndexProof{
+		NodeID:    p.nodeID,
+		GroupID:   p.h.groupID,
+		Term:      last.Term,
+		Index:     last.Index,
+		HasQuorum: true,
+	}
+	if err := target.Check(proof); err != nil {
+		return raftcluster.ReadIndexProof{}, fmt.Errorf("raftharness: %w", err)
+	}
+	if err := ctx.Err(); err != nil {
+		return raftcluster.ReadIndexProof{}, err
+	}
+	return proof, nil
+}

--- a/TreeDB/internal/raftharness/read_index.go
+++ b/TreeDB/internal/raftharness/read_index.go
@@ -28,12 +28,6 @@ func (p *ReadIndexProvider) ReadIndex(ctx context.Context, target raftcluster.Re
 	if p == nil || p.h == nil {
 		return raftcluster.ReadIndexProof{}, ErrHarnessClosed
 	}
-	if target.NodeID == "" {
-		return raftcluster.ReadIndexProof{}, fmt.Errorf("%w: read-index target missing node id", raftcluster.ErrReadBarrierTargetMismatch)
-	}
-	if target.GroupID == "" {
-		return raftcluster.ReadIndexProof{}, fmt.Errorf("%w: read-index target missing group id", raftcluster.ErrReadBarrierTargetMismatch)
-	}
 
 	p.h.mu.Lock()
 	defer p.h.mu.Unlock()
@@ -46,12 +40,6 @@ func (p *ReadIndexProvider) ReadIndex(ctx context.Context, target raftcluster.Re
 	}
 	if node == nil || node.closed {
 		return raftcluster.ReadIndexProof{}, fmt.Errorf("%w: %s", ErrNodeClosed, p.nodeID)
-	}
-	if target.NodeID != p.nodeID {
-		return raftcluster.ReadIndexProof{}, fmt.Errorf("%w: read-index target node %q does not match harness node %q", raftcluster.ErrReadBarrierTargetMismatch, target.NodeID, p.nodeID)
-	}
-	if target.GroupID != p.h.groupID {
-		return raftcluster.ReadIndexProof{}, fmt.Errorf("%w: read-index target group %q does not match harness group %q", raftcluster.ErrReadBarrierTargetMismatch, target.GroupID, p.h.groupID)
 	}
 	if len(p.h.committed) == 0 {
 		return raftcluster.ReadIndexProof{}, fmt.Errorf("%w: read-index has no committed entries", raftcluster.ErrReadBarrierNotSatisfied)

--- a/TreeDB/internal/raftharness/read_index_test.go
+++ b/TreeDB/internal/raftharness/read_index_test.go
@@ -1,0 +1,225 @@
+package raftharness
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/internal/raftcluster"
+	"github.com/snissn/gomap/TreeDB/internal/raftentry"
+	"github.com/snissn/gomap/TreeDB/internal/raftfsm"
+)
+
+func TestReadIndexProviderReturnsLatestCommittedProofWithoutApplying(t *testing.T) {
+	h := openTestHarness(t)
+	defer func() { _ = h.Close() }()
+
+	entries := []raftfsm.CommittedEntryV1{
+		committedCommand(30, 1, deterministicCreateCollectionEntry(t, "users", "harness:create:users:read-index")),
+		committedCommand(31, 2, deterministicCreateCollectionEntry(t, "orders", "harness:create:orders:read-index")),
+	}
+	if evidence, err := h.Commit(entries...); err != nil {
+		t.Fatalf("Commit: %v evidence=%+v", err, evidence)
+	}
+	assertNoLastApplied(t, h, "node-b")
+
+	proof, err := h.ReadIndexProvider("node-b").ReadIndex(context.Background(), raftcluster.ReadIndexBarrier{
+		NodeID:  "node-b",
+		GroupID: "default",
+	})
+	if err != nil {
+		t.Fatalf("ReadIndex: %v proof=%+v", err, proof)
+	}
+	if proof.NodeID != "node-b" || proof.GroupID != "default" || proof.Term != 31 || proof.Index != 2 || !proof.HasQuorum {
+		t.Fatalf("proof=%+v, want node-b/default 31/2 quorum", proof)
+	}
+	assertNoLastApplied(t, h, "node-b")
+	assertCollectionMissing(t, h, "node-b", "users")
+	assertCollectionMissing(t, h, "node-b", "orders")
+}
+
+func TestReadIndexProviderFailsClosed(t *testing.T) {
+	t.Run("empty log", func(t *testing.T) {
+		h := openTestHarness(t)
+		defer func() { _ = h.Close() }()
+
+		_, err := h.ReadIndexProvider("node-a").ReadIndex(context.Background(), raftcluster.ReadIndexBarrier{
+			NodeID:  "node-a",
+			GroupID: "default",
+		})
+		if !errors.Is(err, raftcluster.ErrReadBarrierNotSatisfied) {
+			t.Fatalf("ReadIndex err=%v, want ErrReadBarrierNotSatisfied", err)
+		}
+	})
+
+	t.Run("missing target node", func(t *testing.T) {
+		h := openTestHarness(t)
+		defer func() { _ = h.Close() }()
+
+		_, err := h.ReadIndexProvider("node-a").ReadIndex(context.Background(), raftcluster.ReadIndexBarrier{
+			GroupID: "default",
+		})
+		if !errors.Is(err, raftcluster.ErrReadBarrierTargetMismatch) {
+			t.Fatalf("ReadIndex err=%v, want ErrReadBarrierTargetMismatch", err)
+		}
+	})
+
+	t.Run("missing target group", func(t *testing.T) {
+		h := openTestHarness(t)
+		defer func() { _ = h.Close() }()
+
+		_, err := h.ReadIndexProvider("node-a").ReadIndex(context.Background(), raftcluster.ReadIndexBarrier{
+			NodeID: "node-a",
+		})
+		if !errors.Is(err, raftcluster.ErrReadBarrierTargetMismatch) {
+			t.Fatalf("ReadIndex err=%v, want ErrReadBarrierTargetMismatch", err)
+		}
+	})
+
+	t.Run("target node mismatch", func(t *testing.T) {
+		h := openTestHarness(t)
+		defer func() { _ = h.Close() }()
+		commitReadIndexEntry(t, h, 32, 1, "users", "target-node-mismatch")
+
+		_, err := h.ReadIndexProvider("node-a").ReadIndex(context.Background(), raftcluster.ReadIndexBarrier{
+			NodeID:  "node-b",
+			GroupID: "default",
+		})
+		if !errors.Is(err, raftcluster.ErrReadBarrierTargetMismatch) {
+			t.Fatalf("ReadIndex err=%v, want ErrReadBarrierTargetMismatch", err)
+		}
+	})
+
+	t.Run("target group mismatch", func(t *testing.T) {
+		h := openTestHarness(t)
+		defer func() { _ = h.Close() }()
+		commitReadIndexEntry(t, h, 32, 1, "users", "target-group-mismatch")
+
+		_, err := h.ReadIndexProvider("node-a").ReadIndex(context.Background(), raftcluster.ReadIndexBarrier{
+			NodeID:  "node-a",
+			GroupID: "group-b",
+		})
+		if !errors.Is(err, raftcluster.ErrReadBarrierTargetMismatch) {
+			t.Fatalf("ReadIndex err=%v, want ErrReadBarrierTargetMismatch", err)
+		}
+	})
+
+	t.Run("unknown node", func(t *testing.T) {
+		h := openTestHarness(t)
+		defer func() { _ = h.Close() }()
+		commitReadIndexEntry(t, h, 32, 1, "users", "unknown-node")
+
+		_, err := h.ReadIndexProvider("node-z").ReadIndex(context.Background(), raftcluster.ReadIndexBarrier{
+			NodeID:  "node-z",
+			GroupID: "default",
+		})
+		if !errors.Is(err, ErrNodeNotFound) {
+			t.Fatalf("ReadIndex err=%v, want ErrNodeNotFound", err)
+		}
+	})
+
+	t.Run("closed node", func(t *testing.T) {
+		h := openTestHarness(t)
+		defer func() { _ = h.Close() }()
+		commitReadIndexEntry(t, h, 32, 1, "users", "closed-node")
+		if err := h.CloseNode("node-a"); err != nil {
+			t.Fatalf("CloseNode: %v", err)
+		}
+
+		_, err := h.ReadIndexProvider("node-a").ReadIndex(context.Background(), raftcluster.ReadIndexBarrier{
+			NodeID:  "node-a",
+			GroupID: "default",
+		})
+		if !errors.Is(err, ErrNodeClosed) || errors.Is(err, ErrNodeNotFound) {
+			t.Fatalf("ReadIndex err=%v, want ErrNodeClosed and not ErrNodeNotFound", err)
+		}
+	})
+
+	t.Run("closed harness", func(t *testing.T) {
+		h := openTestHarness(t)
+		commitReadIndexEntry(t, h, 32, 1, "users", "closed-harness")
+		if err := h.Close(); err != nil {
+			t.Fatalf("Close: %v", err)
+		}
+
+		_, err := h.ReadIndexProvider("node-a").ReadIndex(context.Background(), raftcluster.ReadIndexBarrier{
+			NodeID:  "node-a",
+			GroupID: "default",
+		})
+		if !errors.Is(err, ErrHarnessClosed) {
+			t.Fatalf("ReadIndex err=%v, want ErrHarnessClosed", err)
+		}
+	})
+
+	t.Run("canceled context", func(t *testing.T) {
+		h := openTestHarness(t)
+		defer func() { _ = h.Close() }()
+		commitReadIndexEntry(t, h, 32, 1, "users", "canceled")
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		_, err := h.ReadIndexProvider("node-a").ReadIndex(ctx, raftcluster.ReadIndexBarrier{
+			NodeID:  "node-a",
+			GroupID: "default",
+		})
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("ReadIndex err=%v, want context.Canceled", err)
+		}
+	})
+
+	t.Run("zero index proof", func(t *testing.T) {
+		h := openTestHarness(t)
+		defer func() { _ = h.Close() }()
+		h.mu.Lock()
+		h.committed = []raftfsm.CommittedEntryV1{{Term: 32}}
+		h.mu.Unlock()
+
+		_, err := h.ReadIndexProvider("node-a").ReadIndex(context.Background(), raftcluster.ReadIndexBarrier{
+			NodeID:  "node-a",
+			GroupID: "default",
+		})
+		if !errors.Is(err, raftcluster.ErrReadBarrierNotSatisfied) {
+			t.Fatalf("ReadIndex err=%v, want ErrReadBarrierNotSatisfied", err)
+		}
+	})
+}
+
+func TestReadIndexProviderComposesWithReadBarrierCatchUp(t *testing.T) {
+	h := openTestHarness(t)
+	defer func() { _ = h.Close() }()
+
+	entries := []raftfsm.CommittedEntryV1{
+		committedCommand(33, 1, deterministicCreateCollectionEntry(t, "users", "harness:create:users:read-index-catchup")),
+		committedCommand(33, 2, deterministicCreateCollectionEntry(t, "orders", "harness:create:orders:read-index-catchup")),
+	}
+	if evidence, err := h.Commit(entries...); err != nil {
+		t.Fatalf("Commit: %v evidence=%+v", err, evidence)
+	}
+	assertNoLastApplied(t, h, "node-c")
+
+	proof, err := h.ReadIndexProvider("node-c").ReadIndex(context.Background(), raftcluster.ReadIndexBarrier{
+		NodeID:  "node-c",
+		GroupID: "default",
+	})
+	if err != nil {
+		t.Fatalf("ReadIndex: %v proof=%+v", err, proof)
+	}
+	assertNoLastApplied(t, h, "node-c")
+
+	progress, err := h.ReadBarrier("node-c").WaitAppliedIndex(context.Background(), proof.AppliedIndexBarrier())
+	if err != nil {
+		t.Fatalf("WaitAppliedIndex: %v progress=%+v", err, progress)
+	}
+	if progress.NodeID != "node-c" || progress.GroupID != "default" || progress.Term != 33 || progress.Index != 2 || !progress.HasApplied {
+		t.Fatalf("progress=%+v, want node-c/default 33/2", progress)
+	}
+	assertLastApplied(t, h, "node-c", raftentry.ApplyEntryID{Term: 33, Index: 2})
+}
+
+func commitReadIndexEntry(t *testing.T, h *Harness, term, index uint64, collection, suffix string) {
+	t.Helper()
+	entry := committedCommand(term, index, deterministicCreateCollectionEntry(t, collection, "harness:create:"+collection+":read-index-"+suffix))
+	if evidence, err := h.Commit(entry); err != nil {
+		t.Fatalf("Commit: %v evidence=%+v", err, evidence)
+	}
+}

--- a/TreeDB/internal/raftharness/read_index_test.go
+++ b/TreeDB/internal/raftharness/read_index_test.go
@@ -38,6 +38,20 @@ func TestReadIndexProviderReturnsLatestCommittedProofWithoutApplying(t *testing.
 	assertCollectionMissing(t, h, "node-b", "orders")
 }
 
+func TestReadIndexProviderAllowsUnconstrainedTargetFields(t *testing.T) {
+	h := openTestHarness(t)
+	defer func() { _ = h.Close() }()
+	commitReadIndexEntry(t, h, 32, 1, "users", "unconstrained-target")
+
+	proof, err := h.ReadIndexProvider("node-a").ReadIndex(context.Background(), raftcluster.ReadIndexBarrier{})
+	if err != nil {
+		t.Fatalf("ReadIndex unconstrained target: %v proof=%+v", err, proof)
+	}
+	if proof.NodeID != "node-a" || proof.GroupID != "default" || proof.Term != 32 || proof.Index != 1 || !proof.HasQuorum {
+		t.Fatalf("proof=%+v, want node-a/default 32/1 quorum", proof)
+	}
+}
+
 func TestReadIndexProviderFailsClosed(t *testing.T) {
 	t.Run("empty log", func(t *testing.T) {
 		h := openTestHarness(t)
@@ -49,30 +63,6 @@ func TestReadIndexProviderFailsClosed(t *testing.T) {
 		})
 		if !errors.Is(err, raftcluster.ErrReadBarrierNotSatisfied) {
 			t.Fatalf("ReadIndex err=%v, want ErrReadBarrierNotSatisfied", err)
-		}
-	})
-
-	t.Run("missing target node", func(t *testing.T) {
-		h := openTestHarness(t)
-		defer func() { _ = h.Close() }()
-
-		_, err := h.ReadIndexProvider("node-a").ReadIndex(context.Background(), raftcluster.ReadIndexBarrier{
-			GroupID: "default",
-		})
-		if !errors.Is(err, raftcluster.ErrReadBarrierTargetMismatch) {
-			t.Fatalf("ReadIndex err=%v, want ErrReadBarrierTargetMismatch", err)
-		}
-	})
-
-	t.Run("missing target group", func(t *testing.T) {
-		h := openTestHarness(t)
-		defer func() { _ = h.Close() }()
-
-		_, err := h.ReadIndexProvider("node-a").ReadIndex(context.Background(), raftcluster.ReadIndexBarrier{
-			NodeID: "node-a",
-		})
-		if !errors.Is(err, raftcluster.ErrReadBarrierTargetMismatch) {
-			t.Fatalf("ReadIndex err=%v, want ErrReadBarrierTargetMismatch", err)
 		}
 	})
 

--- a/TreeDB/nativewire/cluster_read_barrier_test.go
+++ b/TreeDB/nativewire/cluster_read_barrier_test.go
@@ -2,12 +2,16 @@ package nativewire
 
 import (
 	"context"
+	"encoding/binary"
 	"errors"
 	"testing"
 	"time"
 
+	"github.com/snissn/gomap/TreeDB/collections"
 	iwire "github.com/snissn/gomap/TreeDB/internal/nativewire"
 	"github.com/snissn/gomap/TreeDB/internal/raftcluster"
+	"github.com/snissn/gomap/TreeDB/internal/raftfsm"
+	"github.com/snissn/gomap/TreeDB/internal/raftharness"
 )
 
 type fakeAppliedIndexBarrierProvider struct {
@@ -255,6 +259,69 @@ func TestAppliedIndexReadCoordinatorProvesLinearizableReadMetadata(t *testing.T)
 	}
 	if len(waiter.calls) != 1 || waiter.calls[0] != wantBarrier {
 		t.Fatalf("waiter calls=%+v want %+v", waiter.calls, wantBarrier)
+	}
+}
+
+func TestAppliedIndexReadCoordinatorLinearizableUsesHarnessReadIndexAndWaiter(t *testing.T) {
+	h, err := raftharness.Open(raftharness.Options{
+		RootDir: t.TempDir(),
+		GroupID: "group-a",
+		Nodes: []raftharness.NodeConfig{
+			{ID: "node-a"},
+			{ID: "node-b"},
+			{ID: "node-c"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Open harness: %v", err)
+	}
+	defer func() { _ = h.Close() }()
+
+	entry := nativewireHarnessCommittedCreateCollectionEntry(t, 41, 1, "users", "nativewire:harness-read-index:users")
+	evidence, err := h.Commit(entry)
+	if err != nil {
+		t.Fatalf("Commit harness entry: %v evidence=%+v", err, evidence)
+	}
+	node, ok := h.Node("node-b")
+	if !ok {
+		t.Fatal("node-b not found")
+	}
+	if last, ok := node.LastApplied(); ok {
+		t.Fatalf("node-b last applied before read=%+v, want none", last)
+	}
+
+	target := raftcluster.ReadIndexBarrier{NodeID: "node-b", GroupID: "group-a"}
+	client, mgr, _ := serveCollectionPipeWithOptions(t, ServerOptions{
+		ClusterReadCoordinator: AppliedIndexReadCoordinator{
+			Waiter:            h.ReadBarrier("node-b"),
+			ReadIndexTarget:   target,
+			ReadIndexProvider: h.ReadIndexProvider("node-b"),
+		},
+	})
+	seedReadCollection(t, mgr)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := client.Hello(ctx); err != nil {
+		t.Fatalf("Hello: %v", err)
+	}
+
+	result, err := client.GetManyWithOptions(ctx, "users", [][]byte{[]byte("u1")}, ReadOptions{ConsistencyPolicy: ConsistencyLinearizable})
+	if err != nil {
+		t.Fatalf("GetManyWithOptions: %v", err)
+	}
+	if got, want := result.Present, []bool{true}; !boolSlicesEqual(got, want) {
+		t.Fatalf("present=%v want %v", got, want)
+	}
+	if !result.ReadMeta.Valid ||
+		result.ReadMeta.ActualConsistency != ConsistencyLinearizable ||
+		result.ReadMeta.ServingNode != "node-b" ||
+		result.ReadMeta.LeaderNode != "node-b" ||
+		!result.ReadMeta.HasAppliedIndex ||
+		result.ReadMeta.AppliedIndex != 1 {
+		t.Fatalf("read meta=%+v", result.ReadMeta)
+	}
+	if last, ok := node.LastApplied(); !ok || last.Term != 41 || last.Index != 1 {
+		t.Fatalf("node-b last applied after read=%+v ok=%t, want 41/1", last, ok)
 	}
 }
 
@@ -535,5 +602,38 @@ func TestAppliedIndexReadCoordinatorPropagatesWaiterFailure(t *testing.T) {
 	}).CoordinateRead(context.Background(), ClusterReadRequest{Policy: ConsistencyLeaderRead})
 	if !errors.Is(err, waiterErr) {
 		t.Fatalf("CoordinateRead err=%v want waiter error", err)
+	}
+}
+
+const nativewireHarnessCatalogVersionStart = 7
+
+func nativewireHarnessCommittedCreateCollectionEntry(t *testing.T, term, index uint64, collection, idempotency string) raftfsm.CommittedEntryV1 {
+	t.Helper()
+	sections := []iwire.Section{
+		{ID: iwire.SectionCommandHeader, Bytes: iwire.AppendCommandHeader(nil, iwire.CommandHeader{ID: iwire.CommandCreateCollection, Version: 1})},
+		{ID: iwire.SectionIdempotencyKey, Bytes: []byte(idempotency)},
+		{ID: iwire.SectionCollectionMeta, Bytes: encodeCollectionMeta(collections.CollectionMeta{
+			Name: collection,
+			Options: collections.CollectionOptions{
+				DocumentFormat: collections.DocumentFormatJSON,
+			},
+		})},
+		{ID: iwire.SectionExpectedCatalogVersion, Bytes: binary.AppendUvarint(nil, nativewireHarnessCatalogVersionStart)},
+	}
+	cmd, err := iwire.MustV1Registry().ValidateRequestSections(sections)
+	if err != nil {
+		t.Fatalf("ValidateRequestSections: %v", err)
+	}
+	raw, err := iwire.AppendDeterministicEntry(nil, cmd)
+	if err != nil {
+		t.Fatalf("AppendDeterministicEntry: %v", err)
+	}
+	return raftfsm.CommittedEntryV1{
+		Type:                     raftfsm.EntryTypeCommandEntryV1,
+		Term:                     term,
+		Index:                    index,
+		Bytes:                    raw,
+		CurrentCatalogVersion:    nativewireHarnessCatalogVersionStart,
+		HasCurrentCatalogVersion: true,
 	}
 }


### PR DESCRIPTION
## Summary
- add a test-only raftharness ReadIndexProvider over the committed-entry log
- cover fail-closed proof paths, unconstrained target fields, and read-barrier composition
- wire nativewire linearizable read coordinator coverage to the harness provider
- document the provider as an in-process harness adapter, not production consensus evidence

Closes #3338
Part of #3045.
Supersedes #3339; the original branch could not be force-pushed under repo rules after main advanced, and its GitHub diff widened to include unrelated main commits.

## Validation
- GOWORK=off go test ./TreeDB/internal/raftharness -run 'TestReadIndex|TestReadBarrier' -count=1\n- GOWORK=off go test ./TreeDB/nativewire -run 'TestAppliedIndexReadCoordinator|TestReadCoordinator|TestCursorNextUsesOpenScanReadMetadata' -count=1\n- GOWORK=off go test ./TreeDB/internal/raftcluster ./TreeDB/internal/raftfsm ./TreeDB/internal/raftharness ./TreeDB/nativewire -count=1\n- git diff --check origin/main...HEAD\n