### PR TITLE
TreeDB: narrow entry-slice reuse under pressure

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -13231,6 +13231,11 @@ func entrySliceMaxReuseCapForPressure(capacity int, level poolPressureLevel) int
 		return 1 << entrySliceLeaseMinShift
 	}
 
+	minClassCap := 1 << entrySliceLeaseMinShift
+	if _, classCap, ok := entrySliceLeaseClassForLen(capacity); ok {
+		minClassCap = classCap
+	}
+
 	factor := 8
 	minReuseCap := 1 << 12
 	switch level {
@@ -13239,6 +13244,7 @@ func entrySliceMaxReuseCapForPressure(capacity int, level poolPressureLevel) int
 		minReuseCap = 0
 	case poolPressureHigh:
 		factor = 2
+		minReuseCap = 0
 	}
 
 	// Clamp before multiplication to avoid potential integer overflow.
@@ -13246,6 +13252,9 @@ func entrySliceMaxReuseCapForPressure(capacity int, level poolPressureLevel) int
 		return maxEntryPoolCap
 	}
 	maxCap := capacity * factor
+	if maxCap < minClassCap {
+		maxCap = minClassCap
+	}
 	if minReuseCap > 0 && maxCap < minReuseCap {
 		maxCap = minReuseCap
 	}
@@ -13280,7 +13289,7 @@ func getEntrySlice(capacity int) []batch.Entry {
 			entrySliceLeaseMu.Unlock()
 			leaseBytes := int64(cap(s)) * entrySliceEntrySizeBytes
 			releaseEntrySlicePoolBytes(leaseBytes)
-			if cap(s) >= capacity {
+			if cap(s) >= capacity && cap(s) <= maxReuseCap {
 				entrySliceLeaseHitTotal.Add(1)
 				entrySliceLeaseHitBytesTotal.Add(uint64(leaseBytes))
 				entrySliceLeaseHitRequestedBytesTotal.Add(requestedBytes)
@@ -13289,14 +13298,16 @@ func getEntrySlice(capacity int) []batch.Entry {
 				}
 				return s[:0]
 			}
-			if capIdx, ok := entrySliceLeaseClassForCap(cap(s)); ok {
+			if cap(s) < capacity {
 				// The slice is too small for this request; return it to the pool if
 				// we're within budget so smaller requests can reuse it.
-				if ok, transitioned := reserveEntrySlicePoolBytes(leaseBytes); ok {
-					if transitioned {
-						noteEntrySlicePoolGC(entrySlicePoolNumGC())
+				if capIdx, ok := entrySliceLeaseClassForCap(cap(s)); ok {
+					if ok, transitioned := reserveEntrySlicePoolBytes(leaseBytes); ok {
+						if transitioned {
+							noteEntrySlicePoolGC(entrySlicePoolNumGC())
+						}
+						entrySlicePools[capIdx].Put(s[:0])
 					}
-					entrySlicePools[capIdx].Put(s[:0])
 				}
 			}
 			entrySliceFreshAllocTotal.Add(1)

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -13226,17 +13226,28 @@ func entrySliceLeaseClassForCap(capacity int) (idx int, ok bool) {
 	return idx, true
 }
 
-func entrySliceMaxReuseCap(capacity int) int {
+func entrySliceMaxReuseCapForPressure(capacity int, level poolPressureLevel) int {
 	if capacity <= 0 {
 		return 1 << entrySliceLeaseMinShift
 	}
+
+	factor := 8
+	minReuseCap := 1 << 12
+	switch level {
+	case poolPressureCritical:
+		factor = 1
+		minReuseCap = 0
+	case poolPressureHigh:
+		factor = 2
+	}
+
 	// Clamp before multiplication to avoid potential integer overflow.
-	if capacity > maxEntryPoolCap/8 {
+	if capacity > maxEntryPoolCap/factor {
 		return maxEntryPoolCap
 	}
-	maxCap := capacity * 8
-	if maxCap < 1<<12 {
-		maxCap = 1 << 12
+	maxCap := capacity * factor
+	if minReuseCap > 0 && maxCap < minReuseCap {
+		maxCap = minReuseCap
 	}
 	if maxCap > maxEntryPoolCap {
 		maxCap = maxEntryPoolCap
@@ -13253,7 +13264,8 @@ func getEntrySlice(capacity int) []batch.Entry {
 	if !ok {
 		return make([]batch.Entry, 0, capacity)
 	}
-	maxReuseCap := entrySliceMaxReuseCap(capacity)
+	pressure := currentPoolPressureLevelFast()
+	maxReuseCap := entrySliceMaxReuseCapForPressure(capacity, pressure)
 	maxIdx, _, maxOK := entrySliceLeaseClassForLen(maxReuseCap)
 	if !maxOK {
 		maxIdx = idx

--- a/TreeDB/caching/flush_pool_helpers_test.go
+++ b/TreeDB/caching/flush_pool_helpers_test.go
@@ -607,6 +607,66 @@ func TestEntrySliceLeaseBoundCapsOversizedReuse(t *testing.T) {
 	}
 }
 
+func TestEntrySliceLeaseOversizeReuseNarrowsUnderPressure(t *testing.T) {
+	lockEntrySlicePoolStateForTest(t)
+	resetEntrySlicePoolStateForTest(t)
+	poolPressureTestMu.Lock()
+	defer poolPressureTestMu.Unlock()
+
+	resetPoolPressureStateForTest()
+	savedNow := poolPressureNow
+	savedReadMemStats := poolPressureReadMemStats
+	savedMemLimit := poolPressureMemoryLimit
+	savedBudget := entrySlicePoolBudgetBytes
+	entrySlicePoolBudgetBytes = 512 << 20
+	t.Cleanup(func() {
+		poolPressureNow = savedNow
+		poolPressureReadMemStats = savedReadMemStats
+		poolPressureMemoryLimit = savedMemLimit
+		entrySlicePoolBudgetBytes = savedBudget
+		resetPoolPressureStateForTest()
+	})
+
+	now := time.Unix(1, 0)
+	poolPressureNow = func() time.Time { return now }
+	poolPressureMemoryLimit = func() int64 { return -1 }
+
+	const requestCap = 1 << 15
+	normalOversize := make([]batch.Entry, 1, 1<<18)
+	normalFirst := &normalOversize[0]
+	putEntrySlice(normalOversize)
+
+	publishPoolPressureSnapshot(poolPressureSnapshot{
+		sampledUnixNano: now.UnixNano(),
+		level:           poolPressureNormal,
+	}, now)
+	got := getEntrySlice(requestCap)
+	got = append(got, batch.Entry{})
+	if &got[0] != normalFirst {
+		t.Fatalf("normal pressure should preserve bounded oversize lease reuse")
+	}
+
+	entrySliceLeaseMu.Lock()
+	entrySliceLeases = [entrySliceLeaseClassCount][][]batch.Entry{}
+	entrySliceLeaseMu.Unlock()
+	entrySlicePoolBytes.Store(0)
+	for i := range entrySlicePools {
+		entrySlicePools[i] = sync.Pool{}
+	}
+	now = now.Add(poolPressureRefreshInterval + time.Millisecond)
+	highOversize := make([]batch.Entry, 0, 1<<18)
+	putEntrySlice(highOversize)
+	publishPoolPressureSnapshot(poolPressureSnapshot{
+		sampledUnixNano: now.UnixNano(),
+		level:           poolPressureHigh,
+	}, now)
+
+	got = getEntrySlice(requestCap)
+	if cap(got) > requestCap*2 {
+		t.Fatalf("high pressure reused oversized lease cap=%d want <=%d", cap(got), requestCap*2)
+	}
+}
+
 func TestPutEntrySliceClearsEntriesOnEarlyReturn(t *testing.T) {
 	lockEntrySlicePoolStateForTest(t)
 	resetEntrySlicePoolStateForTest(t)
@@ -826,8 +886,28 @@ func TestOuterLeafArenaMaxReuseCapClampOverflow(t *testing.T) {
 
 func TestEntrySliceMaxReuseCapClampOverflow(t *testing.T) {
 	huge := int(^uint(0) >> 1)
-	if got := entrySliceMaxReuseCap(huge); got != maxEntryPoolCap {
-		t.Fatalf("entrySliceMaxReuseCap(huge)=%d want=%d", got, maxEntryPoolCap)
+	if got := entrySliceMaxReuseCapForPressure(huge, poolPressureNormal); got != maxEntryPoolCap {
+		t.Fatalf("entrySliceMaxReuseCapForPressure(huge, normal)=%d want=%d", got, maxEntryPoolCap)
+	}
+}
+
+func TestEntrySliceMaxReuseCapScalesWithPressure(t *testing.T) {
+	const capacity = 1 << 15
+	tests := []struct {
+		name  string
+		level poolPressureLevel
+		want  int
+	}{
+		{name: "normal", level: poolPressureNormal, want: capacity * 8},
+		{name: "high", level: poolPressureHigh, want: capacity * 2},
+		{name: "critical", level: poolPressureCritical, want: capacity},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := entrySliceMaxReuseCapForPressure(capacity, tc.level); got != tc.want {
+				t.Fatalf("entrySliceMaxReuseCapForPressure(%d, %s)=%d want=%d", capacity, tc.name, got, tc.want)
+			}
+		})
 	}
 }
 

--- a/TreeDB/caching/flush_pool_helpers_test.go
+++ b/TreeDB/caching/flush_pool_helpers_test.go
@@ -667,6 +667,53 @@ func TestEntrySliceLeaseOversizeReuseNarrowsUnderPressure(t *testing.T) {
 	}
 }
 
+func TestEntrySliceLeaseRejectsRoundedBucketAbovePressureCap(t *testing.T) {
+	lockEntrySlicePoolStateForTest(t)
+	resetEntrySlicePoolStateForTest(t)
+	poolPressureTestMu.Lock()
+	defer poolPressureTestMu.Unlock()
+
+	resetPoolPressureStateForTest()
+	savedNow := poolPressureNow
+	savedReadMemStats := poolPressureReadMemStats
+	savedMemLimit := poolPressureMemoryLimit
+	savedBudget := entrySlicePoolBudgetBytes
+	entrySlicePoolBudgetBytes = 512 << 20
+	t.Cleanup(func() {
+		poolPressureNow = savedNow
+		poolPressureReadMemStats = savedReadMemStats
+		poolPressureMemoryLimit = savedMemLimit
+		entrySlicePoolBudgetBytes = savedBudget
+		resetPoolPressureStateForTest()
+	})
+
+	now := time.Unix(2, 0)
+	poolPressureNow = func() time.Time { return now }
+	poolPressureMemoryLimit = func() int64 { return -1 }
+	publishPoolPressureSnapshot(poolPressureSnapshot{
+		sampledUnixNano: now.UnixNano(),
+		level:           poolPressureHigh,
+	}, now)
+
+	const requestCap = (1 << 16) + 1
+	maxReuseCap := entrySliceMaxReuseCapForPressure(requestCap, poolPressureHigh)
+	roundedBucketLease := make([]batch.Entry, 1, 1<<18)
+	roundedBucketFirst := &roundedBucketLease[0]
+	putEntrySlice(roundedBucketLease)
+
+	got := getEntrySlice(requestCap)
+	got = append(got, batch.Entry{})
+	if &got[0] == roundedBucketFirst {
+		t.Fatalf("reused rounded bucket cap=%d above high-pressure max=%d", cap(roundedBucketLease), maxReuseCap)
+	}
+	if cap(got) > maxReuseCap {
+		t.Fatalf("entry slice cap=%d exceeds high-pressure max=%d", cap(got), maxReuseCap)
+	}
+	if gotPoolBytes := entrySlicePoolBytes.Load(); gotPoolBytes != 0 {
+		t.Fatalf("entrySlicePoolBytes=%d after dropping over-cap lease, want 0", gotPoolBytes)
+	}
+}
+
 func TestPutEntrySliceClearsEntriesOnEarlyReturn(t *testing.T) {
 	lockEntrySlicePoolStateForTest(t)
 	resetEntrySlicePoolStateForTest(t)
@@ -893,19 +940,31 @@ func TestEntrySliceMaxReuseCapClampOverflow(t *testing.T) {
 
 func TestEntrySliceMaxReuseCapScalesWithPressure(t *testing.T) {
 	const capacity = 1 << 15
+	const smallCapacity = 1
+	const nonPowerOfTwoCapacity = (1 << 16) + 1
+	_, nonPowerOfTwoClassCap, ok := entrySliceLeaseClassForLen(nonPowerOfTwoCapacity)
+	if !ok {
+		t.Fatalf("entrySliceLeaseClassForLen(%d) failed", nonPowerOfTwoCapacity)
+	}
 	tests := []struct {
-		name  string
-		level poolPressureLevel
-		want  int
+		name     string
+		capacity int
+		level    poolPressureLevel
+		want     int
 	}{
-		{name: "normal", level: poolPressureNormal, want: capacity * 8},
-		{name: "high", level: poolPressureHigh, want: capacity * 2},
-		{name: "critical", level: poolPressureCritical, want: capacity},
+		{name: "normal", capacity: capacity, level: poolPressureNormal, want: capacity * 8},
+		{name: "high", capacity: capacity, level: poolPressureHigh, want: capacity * 2},
+		{name: "critical", capacity: capacity, level: poolPressureCritical, want: capacity},
+		{name: "normal-small-keeps-floor", capacity: smallCapacity, level: poolPressureNormal, want: 1 << 12},
+		{name: "high-small-drops-floor", capacity: smallCapacity, level: poolPressureHigh, want: 1 << entrySliceLeaseMinShift},
+		{name: "critical-small-uses-request-class", capacity: smallCapacity, level: poolPressureCritical, want: 1 << entrySliceLeaseMinShift},
+		{name: "high-non-power-of-two", capacity: nonPowerOfTwoCapacity, level: poolPressureHigh, want: nonPowerOfTwoCapacity * 2},
+		{name: "critical-non-power-of-two-uses-request-class", capacity: nonPowerOfTwoCapacity, level: poolPressureCritical, want: nonPowerOfTwoClassCap},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := entrySliceMaxReuseCapForPressure(capacity, tc.level); got != tc.want {
-				t.Fatalf("entrySliceMaxReuseCapForPressure(%d, %s)=%d want=%d", capacity, tc.name, got, tc.want)
+			if got := entrySliceMaxReuseCapForPressure(tc.capacity, tc.level); got != tc.want {
+				t.Fatalf("entrySliceMaxReuseCapForPressure(%d, %s)=%d want=%d", tc.capacity, tc.name, got, tc.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- make entry-slice lease reuse pressure-sensitive: normal pressure keeps the existing bounded oversize reuse, high pressure narrows reuse to 2x request size, and critical pressure only reuses the requested class
- use the existing fast pressure-level atomic in `getEntrySlice` so the hot path follows the pool-pressure sampler without adding fresh memstats sampling
- add focused coverage for pressure-scaled reuse caps and for avoiding oversized lease reuse under high pressure

## Celestia evidence anchor

This targets the current strict Celestia HWM evidence from #3238/#3317, not a generic benchmark result:

- latest strict TreeDB run: `/home/mikers/.celestia-app-mainnet-treedb-20260629134833`
- HWM pprof includes `TreeDB/caching.getEntrySlice=204.64MB`
- HWM counters show `entry_slice.get.lease_hit_bytes_total=13058796800` for `entry_slice.get.lease_hit_requested_bytes_total=2897376160`, or about `10161420640` excess leased bytes at the peak capture
- final counters still show large entry-slice traffic: `entry_slice.get.lease_hit_bytes_total=33064624640`, `entry_slice.get.fresh_alloc_bytes_total=3568354560`

This is intentionally a small TreeDB-owned memory/high-water patch. It does not change command-WAL semantics, root-native eligibility, or flush/apply routing.

## Route/apply split

This PR keeps the two current production questions separate:

1. Celestia route admission: the post-#3337 strict run already shows raw KV point-put span-native admission for most raw KV traffic, while ordered-root/root-native counters remain zero. This PR does not claim to improve those counters.
2. Apply/backlog wall-time: the same run shows `flush_apply.apply_ns_total=19.12s` (`6.76%` of sync) and backend write time `48.58s` (`17.17%` of sync), with final backlog at zero. This PR does not claim apply is the wall-time limiter.

The expected validation for this PR is reduced `getEntrySlice` / lease excess pressure in the next strict Celestia run, without moving memory into batch arenas, command-WAL buffers, value-log mmap, or disk high-water.

## Validation

- `GOWORK=off go test -count=1 ./TreeDB/caching -run 'TestEntrySlice|TestPoolPressure'`
- `GOWORK=off go test -count=1 ./TreeDB/caching`
- `git diff --check`

Refs #3238
Refs #3317
