### PR TITLE
treedb: prove current-writable vlog catalog readability

### DIFF
--- a/TreeDB/collections/publication_readability_test.go
+++ b/TreeDB/collections/publication_readability_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -222,41 +223,12 @@ func TestCollectionCatalogRootEOFInsertBatchPostCommitReturnsCommitAmbiguous(t *
 
 func TestCollectionCatalogCachedForcedPointersReadableFromFreshSnapshot(t *testing.T) {
 	const collectionName = "ycsb.usertable"
-	dir := t.TempDir()
-	opts := treedb.OptionsFor(treedb.ProfileCommandWALRelaxed, dir)
-	opts.ValueLog.PointerThreshold = 1
-	opts.ValueLog.ForcePointers = true
-	opts.ValueLog.Generational.Policy = treedb.ValueLogGenerationOff
-
-	d, cleanup, err := treedb.OpenBackendWithCachedLeafLog(opts)
-	if err != nil {
-		t.Fatalf("open cached backend: %v", err)
-	}
+	d, col, opts, cleanup := newForcedPointerCatalogReadabilityCollection(t, collectionName)
 	closeDB := collectionMaintenanceCloseOnce(cleanup)
 	t.Cleanup(func() { _ = closeDB() })
 
-	mgr := NewCollectionManager(d)
-	if _, err := mgr.CreateCollection(&CollectionMeta{
-		Name: collectionName,
-		Options: CollectionOptions{
-			DocumentFormat: DocumentFormatBSON,
-		},
-	}); err != nil {
-		t.Fatalf("create collection: %v", err)
-	}
-	col, err := mgr.OpenCollection(collectionName)
-	if err != nil {
-		t.Fatalf("open collection: %v", err)
-	}
-
 	const docCount = 32
-	ids := make([][]byte, docCount)
-	docs := make([][]byte, docCount)
-	for i := 0; i < docCount; i++ {
-		id := []byte(fmt.Sprintf("user%06d", i))
-		ids[i] = id
-		docs[i] = ycsbBSONDocumentForID(t, string(id), i)
-	}
+	ids, docs := forcedPointerCatalogReadabilityDocuments(t, docCount)
 	inserted, err := col.InsertBatchValidatedBSON(ids, docs)
 	if err != nil {
 		t.Fatalf("InsertBatchValidatedBSON: %v", err)
@@ -269,6 +241,12 @@ func TestCollectionCatalogCachedForcedPointersReadableFromFreshSnapshot(t *testi
 			t.Fatalf("inserted id[%d]=%q want %q", i, inserted[i], ids[i])
 		}
 	}
+
+	requireCollectionCatalogSnapshotDocument(t, d, collectionName, ids[0], docs[0])
+	requireCollectionCatalogSnapshotDocument(t, d, collectionName, ids[docCount-1], docs[docCount-1])
+	ptr := requireCollectionCatalogPrimaryEntryValueLogPointer(t, d, collectionName, ids[docCount-1])
+	requireValueLogFileRegistered(t, d, ptr.FileID)
+
 	if err := col.Flush(); err != nil {
 		t.Fatalf("flush collection: %v", err)
 	}
@@ -304,6 +282,112 @@ func TestCollectionCatalogCachedForcedPointersReadableFromFreshSnapshot(t *testi
 	}
 	requireCollectionCatalogSnapshotDocument(t, reopened, collectionName, ids[docCount-1], docs[docCount-1])
 	requireCollectionCatalogPrimaryEntryValueLogPointer(t, reopened, collectionName, ids[docCount-1])
+}
+
+func TestCollectionCatalogCurrentWritableValueLogReadBarrier(t *testing.T) {
+	const collectionName = "ycsb.usertable"
+
+	t.Run("fresh snapshot reads current-writable forced pointer", func(t *testing.T) {
+		d, col, _, cleanup := newForcedPointerCatalogReadabilityCollection(t, collectionName)
+		closeDB := collectionMaintenanceCloseOnce(cleanup)
+		t.Cleanup(func() { _ = closeDB() })
+
+		ids, docs := forcedPointerCatalogReadabilityDocuments(t, 12)
+		if _, err := col.InsertBatchValidatedBSON(ids, docs); err != nil {
+			t.Fatalf("InsertBatchValidatedBSON: %v", err)
+		}
+
+		ptr := requireCollectionCatalogPrimaryEntryValueLogPointer(t, d, collectionName, ids[len(ids)-1])
+		requireValueLogFileRegistered(t, d, ptr.FileID)
+		requireCollectionCatalogSnapshotDocument(t, d, collectionName, ids[0], docs[0])
+		requireCollectionCatalogSnapshotDocument(t, d, collectionName, ids[len(ids)-1], docs[len(docs)-1])
+	})
+
+	t.Run("unexpected EOF at current-writable read barrier is surfaced", func(t *testing.T) {
+		d, col, _, cleanup := newForcedPointerCatalogReadabilityCollection(t, collectionName)
+		closeDB := collectionMaintenanceCloseOnce(cleanup)
+		t.Cleanup(func() { _ = closeDB() })
+
+		ids, docs := forcedPointerCatalogReadabilityDocuments(t, 12)
+		if _, err := col.InsertBatchValidatedBSON(ids, docs); err != nil {
+			t.Fatalf("InsertBatchValidatedBSON: %v", err)
+		}
+
+		ptr := requireCollectionCatalogPrimaryEntryValueLogPointer(t, d, collectionName, ids[len(ids)-1])
+		requireValueLogFileRegistered(t, d, ptr.FileID)
+
+		var barrierCalls atomic.Int32
+		d.SetCurrentValueLogReadBarrierWithSize(func(fileID uint32) (int64, error) {
+			if fileID == ptr.FileID {
+				barrierCalls.Add(1)
+				return -1, io.ErrUnexpectedEOF
+			}
+			return currentValueLogFileSize(d, fileID)
+		})
+
+		got, found, err := collectionCatalogSnapshotDocument(d, collectionName, ids[len(ids)-1])
+		if err == nil {
+			t.Fatalf("fresh catalog document read succeeded through injected read-boundary EOF: found=%v len=%d", found, len(got))
+		}
+		if !errors.Is(err, io.ErrUnexpectedEOF) {
+			t.Fatalf("fresh catalog document err=%v want io.ErrUnexpectedEOF", err)
+		}
+		if errors.Is(err, ErrCommitAmbiguous) {
+			t.Fatalf("fresh catalog document read err=%v unexpectedly classified as ErrCommitAmbiguous", err)
+		}
+		if !strings.Contains(err.Error(), "collections: fresh catalog document") &&
+			!strings.Contains(err.Error(), "collections: load catalog") {
+			t.Fatalf("fresh catalog document err=%q missing contextual catalog/read boundary", err)
+		}
+		if got := barrierCalls.Load(); got == 0 {
+			t.Fatalf("current-writable read barrier was not reached for value-log file %d", ptr.FileID)
+		}
+	})
+}
+
+func newForcedPointerCatalogReadabilityCollection(t *testing.T, collectionName string) (*backenddb.DB, *Collection, treedb.Options, func() error) {
+	t.Helper()
+	dir := t.TempDir()
+	opts := treedb.OptionsFor(treedb.ProfileCommandWALRelaxed, dir)
+	opts.ValueLog.PointerThreshold = 1
+	opts.ValueLog.ForcePointers = true
+	opts.ValueLog.Generational.Policy = treedb.ValueLogGenerationOff
+
+	d, cleanup, err := treedb.OpenBackendWithCachedLeafLog(opts)
+	if err != nil {
+		t.Fatalf("open cached backend: %v", err)
+	}
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: collectionName,
+		Options: CollectionOptions{
+			DocumentFormat:                   DocumentFormatBSON,
+			BufferedIndexedWriteMaxDocuments: 1,
+			DisableBufferedIndexedAsyncFlush: true,
+		},
+	}); err != nil {
+		_ = cleanup()
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection(collectionName)
+	if err != nil {
+		_ = cleanup()
+		t.Fatalf("open collection: %v", err)
+	}
+	return d, col, opts, cleanup
+}
+
+func forcedPointerCatalogReadabilityDocuments(t *testing.T, count int) ([][]byte, [][]byte) {
+	t.Helper()
+	ids := make([][]byte, count)
+	docs := make([][]byte, count)
+	for i := 0; i < count; i++ {
+		id := []byte(fmt.Sprintf("user%06d", i))
+		ids[i] = id
+		docs[i] = ycsbBSONDocumentForID(t, string(id), i)
+	}
+	return ids, docs
 }
 
 func newCatalogFaultTestCollection(t *testing.T, meta CollectionMeta) (*backenddb.DB, *Collection) {
@@ -345,19 +429,7 @@ func clearCatalogFaultTestCaches(col *Collection) {
 
 func requireCollectionCatalogSnapshotDocument(t *testing.T, d *backenddb.DB, collectionName string, id, want []byte) {
 	t.Helper()
-	snap := d.AcquireSnapshot()
-	if snap == nil {
-		t.Fatal("acquire snapshot")
-	}
-	defer func() { _ = snap.Close() }()
-	catalog, err := loadCollectionCatalog(snap, collectionName)
-	if err != nil {
-		t.Fatalf("load collection catalog: %v", err)
-	}
-	if catalog == nil {
-		t.Fatalf("collection %q not found", collectionName)
-	}
-	got, found, err := collectionGetAppendAtCatalogRoot(snap, catalog, collectionPrimaryRootName(collectionName), id, nil)
+	got, found, err := collectionCatalogSnapshotDocument(d, collectionName, id)
 	if err != nil {
 		t.Fatalf("fresh catalog Get %q: %v", id, err)
 	}
@@ -369,7 +441,27 @@ func requireCollectionCatalogSnapshotDocument(t *testing.T, d *backenddb.DB, col
 	}
 }
 
-func requireCollectionCatalogPrimaryEntryValueLogPointer(t *testing.T, d *backenddb.DB, collectionName string, id []byte) {
+func collectionCatalogSnapshotDocument(d *backenddb.DB, collectionName string, id []byte) ([]byte, bool, error) {
+	snap := d.AcquireSnapshot()
+	if snap == nil {
+		return nil, false, backenddb.ErrClosed
+	}
+	defer func() { _ = snap.Close() }()
+	catalog, err := loadCollectionCatalog(snap, collectionName)
+	if err != nil {
+		return nil, false, err
+	}
+	if catalog == nil {
+		return nil, false, fmt.Errorf("collections: collection %q not found", collectionName)
+	}
+	got, found, err := collectionGetAppendAtCatalogRoot(snap, catalog, collectionPrimaryRootName(collectionName), id, nil)
+	if err != nil {
+		return nil, false, fmt.Errorf("collections: fresh catalog document %q root %q: %w", id, collectionPrimaryRootName(collectionName), err)
+	}
+	return got, found, nil
+}
+
+func requireCollectionCatalogPrimaryEntryValueLogPointer(t *testing.T, d *backenddb.DB, collectionName string, id []byte) page.ValuePtr {
 	t.Helper()
 	snap := d.AcquireSnapshot()
 	if snap == nil {
@@ -393,4 +485,45 @@ func requireCollectionCatalogPrimaryEntryValueLogPointer(t *testing.T, d *backen
 	if entry.Flags&node.FlagPointer == 0 || !page.IsValueLogFileID(entry.ValuePtr.FileID) {
 		t.Fatalf("primary catalog entry %q root=%d flags=%#x ptr=%+v, want value-log pointer", id, rootID, entry.Flags, entry.ValuePtr)
 	}
+	return entry.ValuePtr
+}
+
+func requireValueLogFileRegistered(t *testing.T, d *backenddb.DB, fileID uint32) {
+	t.Helper()
+	if fileID == 0 {
+		t.Fatalf("value-log file id is zero")
+	}
+	state := d.State()
+	if state == nil || state.ValueLogSet == nil {
+		t.Fatalf("state missing value-log set")
+	}
+	if _, ok := state.ValueLogSet.Files[fileID]; !ok {
+		t.Fatalf("state value-log set missing file %d", fileID)
+	}
+}
+
+func currentValueLogFileSize(d *backenddb.DB, fileID uint32) (int64, error) {
+	state := d.State()
+	if state == nil || state.ValueLogSet == nil {
+		return -1, fmt.Errorf("collections: value-log file %d unavailable: missing current set", fileID)
+	}
+	file := state.ValueLogSet.Files[fileID]
+	if file == nil {
+		return -1, fmt.Errorf("collections: value-log file %d unavailable: not registered", fileID)
+	}
+	if file.Path != "" {
+		info, err := os.Stat(file.Path)
+		if err != nil {
+			return -1, fmt.Errorf("collections: stat value-log file %d: %w", fileID, err)
+		}
+		return info.Size(), nil
+	}
+	if file.File != nil {
+		info, err := file.File.Stat()
+		if err != nil {
+			return -1, fmt.Errorf("collections: stat value-log file %d: %w", fileID, err)
+		}
+		return info.Size(), nil
+	}
+	return -1, fmt.Errorf("collections: value-log file %d unavailable: missing path", fileID)
 }

--- a/TreeDB/nativewire/forced_pointer_readability_test.go
+++ b/TreeDB/nativewire/forced_pointer_readability_test.go
@@ -8,6 +8,8 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -66,6 +68,73 @@ func TestNativewireYCSBForcedPointerPublicationReadability(t *testing.T) {
 	requirePublishedValueLogFiles(t, reopened.server.backend)
 }
 
+func TestNativewireYCSBCurrentWritableValueLogReadBarrier(t *testing.T) {
+	const docCount = 16
+	dir := t.TempDir()
+	opts := forcedPointerYCSBNativewireOptions(dir)
+	keys, docs := forcedPointerYCSBDocuments(t, docCount)
+	samples := []int{0, docCount - 1}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	env := newForcedPointerYCSBNativewireCurrentWritableEnv(t, opts, true)
+	clients, handles, cleanups := forcedPointerYCSBNativewireClients(t, ctx, env, 1)
+	loadForcedPointerYCSBThroughNativewire(t, ctx, clients, handles, keys, docs)
+	requirePublishedValueLogFiles(t, env.server.backend)
+	requireNativewireYCSBReadable(t, ctx, clients[0], handles[0], keys, docs, samples, "current-writable before flush")
+	closeForcedPointerYCSBNativewireClients(t, cleanups)
+	if err := env.cleanup(); err != nil {
+		t.Fatalf("close readable env: %v", err)
+	}
+
+	faultDir := t.TempDir()
+	faultOpts := forcedPointerYCSBNativewireOptions(faultDir)
+	faultEnv := newForcedPointerYCSBNativewireCurrentWritableEnv(t, faultOpts, true)
+	defer func() {
+		if err := faultEnv.cleanup(); err != nil {
+			t.Fatalf("close fault env: %v", err)
+		}
+	}()
+	faultClients, faultHandles, faultCleanups := forcedPointerYCSBNativewireClients(t, ctx, faultEnv, 1)
+	defer closeForcedPointerYCSBNativewireClients(t, faultCleanups)
+	loadForcedPointerYCSBThroughNativewire(t, ctx, faultClients, faultHandles, keys, docs)
+	requirePublishedValueLogFiles(t, faultEnv.server.backend)
+
+	var barrierCalls atomic.Int32
+	faultEnv.server.backend.SetCurrentValueLogReadBarrierWithSize(func(fileID uint32) (int64, error) {
+		barrierCalls.Add(1)
+		return -1, io.ErrUnexpectedEOF
+	})
+
+	_, directErr := faultEnv.server.handleGetManyBody(&connState{}, []iwire.Section{
+		collectionNameRef(ycsbBenchCollection),
+		{ID: iwire.SectionDocumentIDs, Bytes: iwire.AppendByteVector(nil, keys[docCount-1])},
+	}, nil, ReadMetadata{})
+	if directErr == nil {
+		t.Fatalf("direct GetMany handler succeeded through injected current-writable read-boundary EOF")
+	}
+	if !errors.Is(directErr, io.ErrUnexpectedEOF) {
+		t.Fatalf("direct GetMany handler err=%v want injected unexpected EOF", directErr)
+	}
+	if errors.Is(directErr, collections.ErrCommitAmbiguous) {
+		t.Fatalf("direct GetMany handler err=%v unexpectedly classified as ErrCommitAmbiguous", directErr)
+	}
+	if !strings.Contains(directErr.Error(), "nativewire metadata") || !strings.Contains(directErr.Error(), "unexpected EOF") {
+		t.Fatalf("direct GetMany handler err=%q missing nativewire unexpected EOF context", directErr)
+	}
+
+	got, present, err := faultClients[0].GetMany(ctx, ycsbBenchCollection, [][]byte{keys[docCount-1]})
+	if err == nil {
+		t.Fatalf("GetMany succeeded through injected current-writable read-boundary EOF: docs=%d present=%v", len(got), present)
+	}
+	if !isRemoteError(err, iwire.ErrInternal) {
+		t.Fatalf("GetMany err=%v want remote internal error", err)
+	}
+	if calls := barrierCalls.Load(); calls == 0 {
+		t.Fatalf("current-writable read barrier was not reached")
+	}
+}
+
 func forcedPointerYCSBNativewireOptions(dir string) treedb.Options {
 	opts := treedb.OptionsFor(treedb.ProfileCommandWALRelaxed, dir)
 	opts.ValueLog.PointerThreshold = 1
@@ -77,6 +146,22 @@ func forcedPointerYCSBNativewireOptions(dir string) treedb.Options {
 
 func newForcedPointerYCSBNativewireEnv(t testing.TB, opts treedb.Options, create bool) *ycsbBenchEnv {
 	t.Helper()
+	return newForcedPointerYCSBNativewireEnvWithOptions(t, opts, create, collections.CollectionOptions{
+		DocumentFormat: collections.DocumentFormatBSON,
+	})
+}
+
+func newForcedPointerYCSBNativewireCurrentWritableEnv(t testing.TB, opts treedb.Options, create bool) *ycsbBenchEnv {
+	t.Helper()
+	return newForcedPointerYCSBNativewireEnvWithOptions(t, opts, create, collections.CollectionOptions{
+		DocumentFormat:                   collections.DocumentFormatBSON,
+		BufferedIndexedWriteMaxDocuments: 1,
+		DisableBufferedIndexedAsyncFlush: true,
+	})
+}
+
+func newForcedPointerYCSBNativewireEnvWithOptions(t testing.TB, opts treedb.Options, create bool, collectionOptions collections.CollectionOptions) *ycsbBenchEnv {
+	t.Helper()
 	db, cleanup, err := treedb.OpenBackendWithCachedLeafLog(opts)
 	if err != nil {
 		t.Fatalf("OpenBackendWithCachedLeafLog: %v", err)
@@ -84,10 +169,8 @@ func newForcedPointerYCSBNativewireEnv(t testing.TB, opts treedb.Options, create
 	mgr := collections.NewCollectionManager(db)
 	if create {
 		if _, err := mgr.CreateCollection(&collections.CollectionMeta{
-			Name: ycsbBenchCollection,
-			Options: collections.CollectionOptions{
-				DocumentFormat: collections.DocumentFormatBSON,
-			},
+			Name:    ycsbBenchCollection,
+			Options: collectionOptions,
 			Indexes: []collections.IndexDefinition{
 				{
 					Name:      ycsbBenchKeyIndex,


### PR DESCRIPTION
## Summary
- add deterministic collection coverage that forced-pointer catalog roots are readable from a fresh snapshot before explicit flush/checkpoint
- add current-writable value-log read-barrier fault coverage that surfaces injected EOF with context instead of classifying it as commit ambiguity
- extend nativewire YCSB-shaped forced-pointer coverage across the same current-writable read-barrier failure mode

Closes #3340
Part of #2026.

## Scope Boundary
This is a deterministic test/proof slice only. It does not claim final #2026 closeout or external 100k/1M go-ycsb evidence.

The injected EOF assertions are scoped by current value-log file ID. They prove the current-writable barrier is reached and fails closed for the catalog/nativewire read paths, while the positive forced-pointer fresh-snapshot reads carry the concrete readability proof. They do not claim exact pointer-offset targeting inside the value-log file.

## Validation
- GOWORK=off go test ./TreeDB/collections -run 'TestCollectionCatalogCachedForcedPointersReadableFromFreshSnapshot|TestCollectionCatalogCurrentWritableValueLogReadBarrier' -count=1\n- GOWORK=off go test ./TreeDB/nativewire -run 'TestNativewireYCSBForcedPointerPublicationReadability|TestNativewireYCSBCurrentWritableValueLogReadBarrier' -count=1\n- GOWORK=off go test ./TreeDB/db -run 'TestPointerCommitRefreshesValueLogSet|TestPublishSystemRootIterator_PointerRefreshesValueLogSet|TestPublishSystemRootIterator_PointerSkipsValueLogRefreshWhenSegmentAlreadyRegistered|TestGetMany_RetriesAfterRefreshingStaleValueLogSet' -count=1\n- GOWORK=off go test ./TreeDB/collections ./TreeDB/nativewire ./TreeDB/db -count=1\n- git diff --check\n\nAdditional independent review validation:\n- GOWORK=off go test ./TreeDB/collections -run 'TestCollectionCatalog(CachedForcedPointersReadableFromFreshSnapshot|CurrentWritableValueLogReadBarrier)$' -count=10\n- GOWORK=off go test ./TreeDB/nativewire -run 'TestNativewireYCSB(ForcedPointerPublicationReadability|CurrentWritableValueLogReadBarrier)$' -count=10\n- GOWORK=off go test -race ./TreeDB/collections -run 'TestCollectionCatalog(CurrentWritableValueLogReadBarrier|CachedForcedPointersReadableFromFreshSnapshot)$' -count=1\n- GOWORK=off go test -race ./TreeDB/nativewire -run 'TestNativewireYCSB(ForcedPointerPublicationReadability|CurrentWritableValueLogReadBarrier)$' -count=1\n