### PR TITLE
collections: tolerate coarse q2 rank timers

### DIFF
--- a/TreeDB/collections/column_physical_typed_column_one_shot_cache_3088_test.go
+++ b/TreeDB/collections/column_physical_typed_column_one_shot_cache_3088_test.go
@@ -587,10 +587,6 @@ func assertTypedColumnQ2PostPrepareSubphaseDiagnostics3158(tb testing.TB, label 
 			diag.TypedColumnPrepareQ2DensePartLocalRankNanos != diag.TypedColumnPrepareQ2LocalRankNanos {
 			tb.Fatalf("%s dense q2 rank split diagnostics=%+v want explicit dense phases to mirror legacy rank phases", label, diag)
 		}
-		if diag.TypedColumnPrepareQ2DenseDistinctGlobalRankNanos <= 0 ||
-			diag.TypedColumnPrepareQ2DensePartLocalRankNanos <= 0 {
-			tb.Fatalf("%s dense q2 rank split diagnostics=%+v want distinct-global and part-local rank phases >0 when timer resolution records dense rank work", label, diag)
-		}
 	}
 	if globalCodeTotal != 0 {
 		assertTypedColumnQ2SortedGroupedDistinctPostPrepareDiagnostics3324(tb, label, diag, true)


### PR DESCRIPTION
## Summary
- keeps the dense Q2 rank split mirror assertion against the legacy timer fields
- removes the brittle per-subphase positivity assertion that failed twice on the #3345 Windows `windows-core-2` shard when Windows timer granularity recorded only the local-rank phase
- intended as a small base stabilization dependency before restacking the Raft read-index PR (#3345)

## Tests
- `GOWORK=off go test ./TreeDB/collections -run TestColumnPhysicalTypedColumnOneShotCacheQ2NoMetadata3123 -count=1`
- `GOWORK=off go test ./TreeDB/collections -count=1`
- `git diff --check`

## Scope
Test-only stabilization; no production code or on-disk format changes.