### PR TITLE
docs: record nativewire YCSB closeout evidence

### DIFF
--- a/docs/benchmarks/nativewire_ycsb_closeout_2026-06-30.md
+++ b/docs/benchmarks/nativewire_ycsb_closeout_2026-06-30.md
@@ -1,0 +1,149 @@
+# TreeDB Nativewire YCSB Closeout Evidence
+
+Status: external `go-ycsb` nativewire load-only closeout evidence for #2026
+and #3355 on current `origin/main` commit
+`2b784debb05028f706b46127a41f6d578c3d4c13`.
+
+This report records the final 100k and 1M nativewire YCSB load checks requested
+by #2026 after the deterministic publication/readability slices landed. It is
+developer-machine correctness and throughput evidence for the nativewire load
+path. It does not replace the full MongoDB / TreeDB comparison matrix in
+`docs/benchmarks/ycsb_latest_main_2026-06-03.md`.
+
+## Benchmark Boundary
+
+Workload:
+
+- `go-ycsb load treedb-native`
+- `recordcount=100000` and `recordcount=1000000`
+- `operationcount=10000`
+- `threadcount=16`
+- collection/table: `usertable`
+- local loopback TCP
+- fresh TreeDB data directory per recordcount
+
+TreeDB:
+
+- profile: `command_wal_relaxed`
+- server: `cmd/treedb-native-server`
+- gomap commit: `2b784debb05028f706b46127a41f6d578c3d4c13`
+- gomap branch: `codex/2026-ycsb-closeout`
+
+External client:
+
+- path: `/home/mikers/dev/pingcap/go-ycsb-2026-meta-v5`
+- commit: `c195a9bc777b6aeb1e2f5550db96d872338f2f40`
+- branch: `codex/2026-treedb-native-meta-v5`
+
+Validity:
+
+- Both load phases completed the requested insert count.
+- Raw output contained no `INSERT_ERROR` lines; `grep -c INSERT_ERROR` returned
+  `0` for both load outputs.
+- The summary records `INSERT_ERROR=0` for both load phases.
+
+## Host Context
+
+Captured on 2026-06-29 HST / 2026-06-30 UTC.
+
+```text
+host: mikers-B560-DS3H-AC-Y1
+kernel: Linux 6.8.0-124-generic x86_64
+go: go version go1.25.7 linux/amd64
+cpu: 11th Gen Intel(R) Core(TM) i5-11400F @ 2.60GHz
+logical CPUs: 12
+memory: 31Gi
+clocksource: tsc
+```
+
+Primary artifact root:
+
+```text
+/tmp/treedb_native_ycsb_closeout_20260629_173744
+```
+
+Primary artifacts:
+
+```text
+/tmp/treedb_native_ycsb_closeout_20260629_173744/host.txt
+/tmp/treedb_native_ycsb_closeout_20260629_173744/commands.txt
+/tmp/treedb_native_ycsb_closeout_20260629_173744/summary.tsv
+/tmp/treedb_native_ycsb_closeout_20260629_173744/summary.md
+/tmp/treedb_native_ycsb_closeout_20260629_173744/100000/load.out
+/tmp/treedb_native_ycsb_closeout_20260629_173744/1000000/load.out
+```
+
+## Focused Gates
+
+These gates passed before the external load runs:
+
+```sh
+GOWORK=off go test ./cmd/treedb-native-server ./TreeDB/nativewire ./TreeDB/collections ./TreeDB/db -count=1
+
+cd /home/mikers/dev/pingcap/go-ycsb-2026-meta-v5
+go test ./db/treedbnative -count=1
+```
+
+Build commands:
+
+```sh
+GOWORK=off go build -o bin/treedb-native-server ./cmd/treedb-native-server
+
+cd /home/mikers/dev/pingcap/go-ycsb-2026-meta-v5
+make build
+```
+
+## Load Results
+
+| recordcount | INSERT count | INSERT ops/sec | INSERT avg us | INSERT p50 us | INSERT p95 us | INSERT p99 us | INSERT p99.9 us | INSERT max us | INSERT_ERROR |
+| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 100,000 | 100,000 | 69,863.1 | 211.0 | 187.0 | 348.0 | 544.0 | 3,149.0 | 8,767.0 | 0 |
+| 1,000,000 | 1,000,000 | 44,118.3 | 346.0 | 203.0 | 370.0 | 537.0 | 1,521.0 | 6,717,439.0 | 0 |
+
+The 1M load emitted periodic progress rows at 10s and 20s before the final
+1,000,000-row summary. The table above uses the final post-run row.
+
+## Reproduction
+
+Each load used a fresh data directory and an isolated loopback port. Start each
+server command and keep it running while executing the matching `go-ycsb load`
+command, then stop it before starting the next recordcount:
+
+```sh
+cd /home/mikers/dev/snissn/gomap-2026-ycsb-closeout
+
+GOWORK=off go build -o bin/treedb-native-server ./cmd/treedb-native-server
+
+cd /home/mikers/dev/pingcap/go-ycsb-2026-meta-v5
+make build
+
+/home/mikers/dev/snissn/gomap-2026-ycsb-closeout/bin/treedb-native-server \
+  -dir /tmp/treedb_native_ycsb_closeout_20260629_173744/100000/db \
+  -profile command_wal_relaxed \
+  -addr 127.0.0.1:17155
+
+/home/mikers/dev/pingcap/go-ycsb-2026-meta-v5/bin/go-ycsb load treedb-native \
+  -p treedb.addr=127.0.0.1:17155 \
+  -p recordcount=100000 \
+  -p operationcount=10000 \
+  -p threadcount=16
+
+/home/mikers/dev/snissn/gomap-2026-ycsb-closeout/bin/treedb-native-server \
+  -dir /tmp/treedb_native_ycsb_closeout_20260629_173744/1000000/db \
+  -profile command_wal_relaxed \
+  -addr 127.0.0.1:17156
+
+/home/mikers/dev/pingcap/go-ycsb-2026-meta-v5/bin/go-ycsb load treedb-native \
+  -p treedb.addr=127.0.0.1:17156 \
+  -p recordcount=1000000 \
+  -p operationcount=10000 \
+  -p threadcount=16
+```
+
+## Interpretation
+
+This closeout run proves the compatible external nativewire YCSB client can load
+100k and 1M records against the current `command_wal_relaxed` TreeDB nativewire
+server with zero insert errors on this host. It supports #2026 closeout for the
+external YCSB evidence requirement, while the deterministic publication and
+readability proof remains documented by the issue and its earlier test PRs.

--- a/docs/benchmarks/nativewire_ycsb_closeout_2026-06-30.md
+++ b/docs/benchmarks/nativewire_ycsb_closeout_2026-06-30.md
@@ -1,8 +1,13 @@
 # TreeDB Nativewire YCSB Closeout Evidence
 
 Status: external `go-ycsb` nativewire load-only closeout evidence for #2026
-and #3355 on current `origin/main` commit
+and #3355 captured on then-current `origin/main` commit
 `2b784debb05028f706b46127a41f6d578c3d4c13`.
+
+This evidence predates later Raft snapshot/route-preflight merges, including
+`febc1992e58307d8b1edd2c68657faef9bd67c88` and
+`66819cd00fe10aaae2f0da3b7dbfc1ebc0c4113d`; rerun the closeout before using it
+as proof for those newer heads.
 
 This report records the final 100k and 1M nativewire YCSB load checks requested
 by #2026 after the deterministic publication/readability slices landed. It is

--- a/docs/benchmarks/ycsb_mongodb_treedb_current.md
+++ b/docs/benchmarks/ycsb_mongodb_treedb_current.md
@@ -88,11 +88,16 @@ Any nonzero YCSB operation error counter such as `INSERT_ERROR`, `READ_ERROR`,
 or `UPDATE_ERROR` invalidates that phase unless the report explicitly marks it
 as exploratory known-bad evidence.
 
-As of gomap `d7407b81cc5712374ca8c1588cfb05f6f7d8490d`, the external
-`go-ycsb` `treedb-native` binding must understand `collection_meta` version 3.
-If upstream `go-ycsb` has not yet been updated, apply the one-line compatibility
-patch recorded in `docs/benchmarks/ycsb_latest_main_2026-06-03.md` before
-rerunning the nativewire cells.
+The June 3 report was captured against gomap
+`d7407b81cc5712374ca8c1588cfb05f6f7d8490d`, where the external `go-ycsb`
+`treedb-native` binding needed the version 3 `collection_meta` compatibility
+patch recorded in `docs/benchmarks/ycsb_latest_main_2026-06-03.md`.
+
+Current nativewire reruns for the #2026 closeout must use a `go-ycsb` client
+that accepts `collection_meta` version 5. The June 30 closeout used
+`/home/mikers/dev/pingcap/go-ycsb-2026-meta-v5` on branch
+`codex/2026-treedb-native-meta-v5`; use that branch or an upstream client with
+equivalent v5 support before rerunning current nativewire cells.
 
 ## Standard Full Rerun Matrix
 

--- a/docs/benchmarks/ycsb_mongodb_treedb_current.md
+++ b/docs/benchmarks/ycsb_mongodb_treedb_current.md
@@ -28,12 +28,13 @@ this rerun used a temporary external `go-ycsb` compatibility patch so the
 `treedb-native` binding accepts TreeDB `collection_meta` version 3.
 
 For the #2026 publication/readability closeout, use
-`docs/benchmarks/nativewire_ycsb_closeout_2026-06-30.md` as the current
-nativewire load-only evidence. That report uses the compatible external
-`go-ycsb` branch for `collection_meta` version 5, runs 100k and 1M
-`treedb-native` loads on `origin/main` commit
+`docs/benchmarks/nativewire_ycsb_closeout_2026-06-30.md` as the #2026
+nativewire load-only closeout evidence captured on then-current `origin/main`.
+That report uses the compatible external `go-ycsb` branch for
+`collection_meta` version 5, runs 100k and 1M `treedb-native` loads on commit
 `2b784debb05028f706b46127a41f6d578c3d4c13`, and records zero `INSERT_ERROR`
-counts. It does not replace the full comparison matrix above.
+counts. It predates later Raft snapshot/route-preflight merges and does not
+replace the full comparison matrix above.
 
 ## Current Headline
 
@@ -54,7 +55,7 @@ UTC latest-main report.
 
 | report | status | use |
 | --- | --- | --- |
-| `docs/benchmarks/nativewire_ycsb_closeout_2026-06-30.md` | Current #2026 nativewire load-only closeout evidence. | Use for the 100k and 1M external `go-ycsb treedb-native` load proof on current `origin/main` with `collection_meta` v5 compatibility. |
+| `docs/benchmarks/nativewire_ycsb_closeout_2026-06-30.md` | #2026 nativewire load-only closeout evidence captured before later Raft merges. | Use for the 100k and 1M external `go-ycsb treedb-native` load proof on commit `2b784debb05028f706b46127a41f6d578c3d4c13` with `collection_meta` v5 compatibility; rerun before treating it as proof for newer heads. |
 | `docs/benchmarks/ycsb_latest_main_2026-06-03.md` | Current external YCSB report. | Use for current headline MongoDB / TreeDB nativewire / TreeDB Mongo gateway results on latest `origin/main` after the June 3 rerun. |
 | `docs/benchmarks/ycsb_post_update_stack_2026-06-02.md` | Superseded latest-current report. | Keep for post-update-path-stack evidence before the latest main rerun and for comparison deltas. |
 | `docs/benchmarks/ycsb_mongodb_treedb_2026-05-31.md` | Historical legacy-profile report. | Keep for the original MongoDB / TreeDB native / TreeDB Mongo comparison and the post-load Mongo-gateway cliff attribution. Do not use its `fast` rows as current public-profile guidance. |

--- a/docs/benchmarks/ycsb_mongodb_treedb_current.md
+++ b/docs/benchmarks/ycsb_mongodb_treedb_current.md
@@ -27,6 +27,14 @@ profile, and refreshes the June 2 post-update-path-stack numbers on latest
 this rerun used a temporary external `go-ycsb` compatibility patch so the
 `treedb-native` binding accepts TreeDB `collection_meta` version 3.
 
+For the #2026 publication/readability closeout, use
+`docs/benchmarks/nativewire_ycsb_closeout_2026-06-30.md` as the current
+nativewire load-only evidence. That report uses the compatible external
+`go-ycsb` branch for `collection_meta` version 5, runs 100k and 1M
+`treedb-native` loads on `origin/main` commit
+`2b784debb05028f706b46127a41f6d578c3d4c13`, and records zero `INSERT_ERROR`
+counts. It does not replace the full comparison matrix above.
+
 ## Current Headline
 
 Run rows use the median total-throughput repeat from the June 3 HST / June 4
@@ -46,6 +54,7 @@ UTC latest-main report.
 
 | report | status | use |
 | --- | --- | --- |
+| `docs/benchmarks/nativewire_ycsb_closeout_2026-06-30.md` | Current #2026 nativewire load-only closeout evidence. | Use for the 100k and 1M external `go-ycsb treedb-native` load proof on current `origin/main` with `collection_meta` v5 compatibility. |
 | `docs/benchmarks/ycsb_latest_main_2026-06-03.md` | Current external YCSB report. | Use for current headline MongoDB / TreeDB nativewire / TreeDB Mongo gateway results on latest `origin/main` after the June 3 rerun. |
 | `docs/benchmarks/ycsb_post_update_stack_2026-06-02.md` | Superseded latest-current report. | Keep for post-update-path-stack evidence before the latest main rerun and for comparison deltas. |
 | `docs/benchmarks/ycsb_mongodb_treedb_2026-05-31.md` | Historical legacy-profile report. | Keep for the original MongoDB / TreeDB native / TreeDB Mongo comparison and the post-load Mongo-gateway cliff attribution. Do not use its `fast` rows as current public-profile guidance. |


### PR DESCRIPTION
## Summary

- Adds #2026/#3355 external nativewire YCSB closeout evidence for current `origin/main`.
- Records exact gomap/go-ycsb commits, host, commands, focused gates, artifact paths, and load metrics.
- Updates the YCSB benchmark status page to link the closeout report without replacing the full MongoDB / TreeDB comparison matrix.

Closes #3355.
Refs #2026.

## Evidence

Gomap commit: `2b784debb05028f706b46127a41f6d578c3d4c13`
Go-ycsb commit: `c195a9bc777b6aeb1e2f5550db96d872338f2f40`
Host: `mikers-B560-DS3H-AC-Y1`, Linux `6.8.0-124-generic`, i5-11400F, 12 logical CPUs, 31Gi memory
Artifact root: `/tmp/treedb_native_ycsb_closeout_20260629_173744`

| recordcount | INSERT count | INSERT ops/sec | avg us | p95 us | p99 us | max us | INSERT_ERROR |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 100,000 | 100,000 | 69,863.1 | 211.0 | 348.0 | 544.0 | 8,767.0 | 0 |
| 1,000,000 | 1,000,000 | 44,118.3 | 346.0 | 370.0 | 537.0 | 6,717,439.0 | 0 |

Raw-output check: `grep -c INSERT_ERROR` returned `0` for both `100000/load.out` and `1000000/load.out`.

## Commands run

```sh
GOWORK=off go test ./cmd/treedb-native-server ./TreeDB/nativewire ./TreeDB/collections ./TreeDB/db -count=1

cd /home/mikers/dev/pingcap/go-ycsb-2026-meta-v5
go test ./db/treedbnative -count=1
make build

cd /home/mikers/dev/snissn/gomap-2026-ycsb-closeout
GOWORK=off go build -o bin/treedb-native-server ./cmd/treedb-native-server

/home/mikers/dev/pingcap/go-ycsb-2026-meta-v5/bin/go-ycsb load treedb-native \
  -p treedb.addr=127.0.0.1:17155 \
  -p recordcount=100000 \
  -p operationcount=10000 \
  -p threadcount=16

/home/mikers/dev/pingcap/go-ycsb-2026-meta-v5/bin/go-ycsb load treedb-native \
  -p treedb.addr=127.0.0.1:17156 \
  -p recordcount=1000000 \
  -p operationcount=10000 \
  -p threadcount=16

git diff --cached --check
```

## Scope and handoff

Docs/evidence only. No Raft snapshot/routing files touched. No AI reviews requested. No merge attempted by this worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new benchmark closeout report with load results, environment details, and reproduction steps for nativewire testing.
  * Updated the benchmark guidance page to point to the new closeout evidence and clarify when to use it.
  * Refreshed the benchmark inventory and compatibility notes to reflect newer nativewire load requirements and current validation expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->