### PR TITLE
TreeDB Raft: add document-id token route preflight

### DIFF
--- a/TreeDB/docs/spec/raftplacement.md
+++ b/TreeDB/docs/spec/raftplacement.md
@@ -79,27 +79,52 @@ Route decisions MUST fail closed for:
 Token route decisions include the matched token partition metadata. Collection
 route decisions do not infer shard keys or scatter across token partitions.
 
+## Document-ID Token Rule
+
+`DocumentIDTokenV1` maps a deterministic document ID byte identity to a uint64
+token by hashing:
+
+- the fixed domain string `TreeDB/RaftPlacement/DocumentIDTokenV1\0`;
+- the exact document ID bytes.
+
+The hash is SHA-256, and the token is the first eight digest bytes interpreted
+as a big-endian uint64. The rule is stable across processes and platforms and
+MUST NOT use Go's randomized `maphash` seed. Native-wire document IDs use the
+bytes in `SectionDocumentIDs`. Mongo gateway document IDs use the already
+encoded TreeDB primary-key bytes, not the raw BSON value display form.
+
 ## Cluster Submitter Adapter Preflight
 
 Native-wire and Mongo gateway cluster submitter adapters MAY run an optional
-collection-route preflight before handing an accepted R3a command entry to the
-submitter. The preflight is adapter metadata only. It records the catalog route
-identity, target group ID, group members, leader hint, and placement mode in
-request metadata that is excluded from deterministic command entry bytes.
+route preflight before handing an accepted R3a command entry to the submitter.
+The preflight is adapter metadata only. It records the catalog route identity,
+route shape, target group ID, group members, leader hint, placement mode, and,
+for token/ring decisions, the document token and token partition ID in request
+metadata that is excluded from deterministic command entry bytes and command
+digests.
 
 Native-wire route preflight uses the default database and catalog plus the
 collection name encoded in the deterministic command sections. `create_collection`
-uses the collection metadata name; mutation commands use the collection-name ref.
+uses the collection metadata name; mutation commands use the collection-name
+ref. Exactly-one-ID `insert_batch`, `replace_batch`, `delete_batch`, and
+`update_bson_set` requests carry a document-token route request. Multi-ID
+native-wire batches remain collection-shaped so token/ring placements fail
+closed instead of being split or fanned out.
 
 Mongo gateway route preflight uses the original Mongo namespace: `$db` plus the
 command collection name before the gateway flattens it to TreeDB's internal
-`db.collection` collection name.
+`db.collection` collection name. Exactly-one-ID insert, update, and delete
+writes carry a document-token route request derived from the prepared encoded
+primary key. Multi-document insert/delete batches and multi-update commands
+remain collection-shaped so token/ring placements fail closed before submit.
 
 If no route provider is configured, adapters keep the previous submitter
 behavior. If a route provider is configured, the provider MUST fail closed for
-unplaced collections and for token/ring placements that cannot be routed by the
-current collection-only adapter contract. Leader hints remain hints; they are
-not live leadership proof, read-index evidence, or a network routing guarantee.
+unplaced collections, missing token/ring token metadata, and multi-ID token/ring
+requests. Collection placements may still accept token-capable single-ID
+requests by returning a collection route decision, preserving collection-mode
+write behavior. Leader hints remain hints; they are not live leadership proof,
+read-index evidence, or a network routing guarantee.
 
 ## Token/Ring Catalog Placements
 
@@ -145,8 +170,10 @@ read/snapshot dependencies are ready for production routing.
 
 `ResolveToken` maps a token to its simulated virtual partition only after the
 plan has passed validation. `RouteToken` can wrap catalog-backed token/ring
-placements in a route decision when the caller supplies an explicit token. It
-MUST NOT be treated as native-wire or Mongo request routing.
+placements in a route decision when the caller supplies an explicit token.
+Native-wire and Mongo gateway adapters may use that decision as fail-closed
+request preflight metadata only; it is not live network routing or leadership
+proof.
 
 ## Deferred Scope
 

--- a/TreeDB/internal/raftentry/contract.go
+++ b/TreeDB/internal/raftentry/contract.go
@@ -54,10 +54,14 @@ type RequestMetadataV1 struct {
 	ClusterRouteDatabase      string
 	ClusterRouteCatalog       string
 	ClusterRouteCollection    string
+	ClusterRouteShape         string
 	ClusterRouteGroupID       string
 	ClusterRouteMembers       []string
 	ClusterRouteLeaderHint    string
 	ClusterRoutePlacementMode string
+	ClusterRouteTokenKnown    bool
+	ClusterRouteToken         uint64
+	ClusterRoutePartitionID   string
 }
 
 type CommandDigestV1 [32]byte

--- a/TreeDB/internal/raftentry/contract_test.go
+++ b/TreeDB/internal/raftentry/contract_test.go
@@ -71,10 +71,14 @@ func TestDigestV1StabilityAcrossMetadataAndApplyEntryID(t *testing.T) {
 			ClusterRouteDatabase:      "default",
 			ClusterRouteCatalog:       "default",
 			ClusterRouteCollection:    "users",
+			ClusterRouteShape:         "token",
 			ClusterRouteGroupID:       "group-a",
 			ClusterRouteMembers:       []string{"node-a", "node-b"},
 			ClusterRouteLeaderHint:    "node-a",
 			ClusterRoutePlacementMode: "collection",
+			ClusterRouteTokenKnown:    true,
+			ClusterRouteToken:         11,
+			ClusterRoutePartitionID:   "token-000000",
 		},
 	})
 	if err != nil {
@@ -94,10 +98,14 @@ func TestDigestV1StabilityAcrossMetadataAndApplyEntryID(t *testing.T) {
 			ClusterRouteDatabase:      "tenant",
 			ClusterRouteCatalog:       "catalog-b",
 			ClusterRouteCollection:    "events",
+			ClusterRouteShape:         "collection",
 			ClusterRouteGroupID:       "group-b",
 			ClusterRouteMembers:       []string{"node-c", "node-d"},
 			ClusterRouteLeaderHint:    "node-c",
 			ClusterRoutePlacementMode: "collection",
+			ClusterRouteTokenKnown:    true,
+			ClusterRouteToken:         99,
+			ClusterRoutePartitionID:   "token-000099",
 		},
 	})
 	if err != nil {

--- a/TreeDB/internal/raftharness/harness.go
+++ b/TreeDB/internal/raftharness/harness.go
@@ -539,9 +539,13 @@ func committedEntriesEqual(a, b raftfsm.CommittedEntryV1) bool {
 		a.RequestMetadata.ClusterRouteDatabase != b.RequestMetadata.ClusterRouteDatabase ||
 		a.RequestMetadata.ClusterRouteCatalog != b.RequestMetadata.ClusterRouteCatalog ||
 		a.RequestMetadata.ClusterRouteCollection != b.RequestMetadata.ClusterRouteCollection ||
+		a.RequestMetadata.ClusterRouteShape != b.RequestMetadata.ClusterRouteShape ||
 		a.RequestMetadata.ClusterRouteGroupID != b.RequestMetadata.ClusterRouteGroupID ||
 		a.RequestMetadata.ClusterRouteLeaderHint != b.RequestMetadata.ClusterRouteLeaderHint ||
 		a.RequestMetadata.ClusterRoutePlacementMode != b.RequestMetadata.ClusterRoutePlacementMode ||
+		a.RequestMetadata.ClusterRouteTokenKnown != b.RequestMetadata.ClusterRouteTokenKnown ||
+		a.RequestMetadata.ClusterRouteToken != b.RequestMetadata.ClusterRouteToken ||
+		a.RequestMetadata.ClusterRoutePartitionID != b.RequestMetadata.ClusterRoutePartitionID ||
 		!equalStringSlices(a.RequestMetadata.ClusterRouteMembers, b.RequestMetadata.ClusterRouteMembers) ||
 		!bytes.Equal(a.RequestMetadata.TraceContext, b.RequestMetadata.TraceContext) ||
 		!bytes.Equal(a.Bytes, b.Bytes) {

--- a/TreeDB/internal/raftharness/harness_test.go
+++ b/TreeDB/internal/raftharness/harness_test.go
@@ -199,10 +199,14 @@ func TestCommitClonesAndComparesClusterRouteMetadata(t *testing.T) {
 		ClusterRouteDatabase:      "default",
 		ClusterRouteCatalog:       "default",
 		ClusterRouteCollection:    "users",
+		ClusterRouteShape:         "token",
 		ClusterRouteGroupID:       "group-a",
 		ClusterRouteMembers:       []string{"node-a", "node-b"},
 		ClusterRouteLeaderHint:    "node-a",
 		ClusterRoutePlacementMode: "collection",
+		ClusterRouteTokenKnown:    true,
+		ClusterRouteToken:         42,
+		ClusterRoutePartitionID:   "token-000042",
 	}
 	if _, err := h.Commit(entry); err != nil {
 		t.Fatalf("Commit route metadata entry: %v", err)
@@ -215,10 +219,14 @@ func TestCommitClonesAndComparesClusterRouteMetadata(t *testing.T) {
 		ClusterRouteDatabase:      "default",
 		ClusterRouteCatalog:       "default",
 		ClusterRouteCollection:    "users",
+		ClusterRouteShape:         "token",
 		ClusterRouteGroupID:       "group-a",
 		ClusterRouteMembers:       []string{"node-a", "node-b"},
 		ClusterRouteLeaderHint:    "node-a",
 		ClusterRoutePlacementMode: "collection",
+		ClusterRouteTokenKnown:    true,
+		ClusterRouteToken:         42,
+		ClusterRoutePartitionID:   "token-000042",
 	}
 	results, err := h.ApplyCommittedEntriesToNode("node-a", want)
 	if err != nil {
@@ -227,7 +235,7 @@ func TestCommitClonesAndComparesClusterRouteMetadata(t *testing.T) {
 	assertAppliedResults(t, "route metadata apply", results, []int64{1})
 
 	divergent := want
-	divergent.RequestMetadata.ClusterRouteGroupID = "group-b"
+	divergent.RequestMetadata.ClusterRoutePartitionID = "token-000043"
 	if _, err := h.Commit(divergent); !errors.Is(err, ErrCommittedLogConflict) {
 		t.Fatalf("Commit divergent route metadata err=%v want ErrCommittedLogConflict", err)
 	}

--- a/TreeDB/internal/raftplacement/route.go
+++ b/TreeDB/internal/raftplacement/route.go
@@ -1,6 +1,8 @@
 package raftplacement
 
 import (
+	"crypto/sha256"
+	"encoding/binary"
 	"errors"
 	"fmt"
 
@@ -12,6 +14,8 @@ var (
 	ErrUnsupportedRouteShape = errors.New("raftplacement: unsupported route shape")
 	ErrMissingRouteToken     = errors.New("raftplacement: missing route token")
 )
+
+const documentIDTokenDomainV1 = "TreeDB/RaftPlacement/DocumentIDTokenV1\x00"
 
 type RouteShapeV1 string
 
@@ -122,6 +126,39 @@ func (c ResolvedCatalogV1) RouteToken(database, catalog, collection string, toke
 		Shape:      RouteShapeTokenV1,
 		Token:      &token,
 	})
+}
+
+// DocumentIDTokenV1 maps a deterministic document ID byte identity to the v1
+// uint64 token space. The rule is stable across processes and platforms.
+func DocumentIDTokenV1(documentID []byte) uint64 {
+	h := sha256.New()
+	_, _ = h.Write([]byte(documentIDTokenDomainV1))
+	_, _ = h.Write(documentID)
+	sum := h.Sum(nil)
+	return binary.BigEndian.Uint64(sum[:8])
+}
+
+func (c ResolvedCatalogV1) RouteDocumentID(database, catalog, collection string, documentID []byte) (RouteDecisionV1, error) {
+	return c.RouteDocumentToken(database, catalog, collection, DocumentIDTokenV1(documentID))
+}
+
+func (c ResolvedCatalogV1) RouteDocumentToken(database, catalog, collection string, token uint64) (RouteDecisionV1, error) {
+	ref := CollectionRefV1{Database: database, Catalog: catalog, Collection: collection}
+	if err := validateCollectionRef(ref); err != nil {
+		return RouteDecisionV1{}, errors.Join(ErrInvalidRouteRequest, err)
+	}
+	placement, ok := c.placements[ref]
+	if !ok {
+		return RouteDecisionV1{}, errors.Join(ErrInvalidRouteRequest, ErrUnplacedCollection, fmt.Errorf("%s/%s/%s", ref.Database, ref.Catalog, ref.Collection))
+	}
+	switch placement.Mode {
+	case PlacementModeCollectionV1:
+		return c.RouteCollection(database, catalog, collection)
+	case PlacementModeTokenV1, PlacementModeRingV1:
+		return c.RouteToken(database, catalog, collection, token)
+	default:
+		return RouteDecisionV1{}, errors.Join(ErrInvalidRouteRequest, ErrUnsupportedPlacementMode, fmt.Errorf("%s/%s/%s mode %q", ref.Database, ref.Catalog, ref.Collection, placement.Mode))
+	}
 }
 
 func (c ResolvedCatalogV1) routeGroup(id raftcluster.GroupID) (ResolvedGroupV1, error) {

--- a/TreeDB/internal/raftplacement/route_test.go
+++ b/TreeDB/internal/raftplacement/route_test.go
@@ -92,6 +92,73 @@ func TestRouteTokenDecisionIncludesPartitionAndGroupMetadata(t *testing.T) {
 	}
 }
 
+func TestDocumentIDTokenV1IsStable(t *testing.T) {
+	tests := []struct {
+		name string
+		id   []byte
+		want uint64
+	}{
+		{name: "ascii", id: []byte("u1"), want: 0x0cda0b01b1a4d746},
+		{name: "binary", id: []byte("mongo-key\x00"), want: 0xb50bd7be8fa239a1},
+		{name: "empty", id: nil, want: 0xddb8fc2412a24a19},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := DocumentIDTokenV1(tc.id); got != tc.want {
+				t.Fatalf("DocumentIDTokenV1(%q)=%#x want %#x", tc.id, got, tc.want)
+			}
+			if got := DocumentIDTokenV1(append([]byte(nil), tc.id...)); got != tc.want {
+				t.Fatalf("DocumentIDTokenV1 cloned input=%#x want %#x", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRouteDocumentTokenPreservesCollectionModeAndRoutesTokenModes(t *testing.T) {
+	t.Run("collection", func(t *testing.T) {
+		resolved, err := Validate(validCatalog())
+		if err != nil {
+			t.Fatalf("Validate: %v", err)
+		}
+		decision, err := resolved.RouteDocumentID(DefaultDatabase, DefaultCatalog, "users", []byte("u1"))
+		if err != nil {
+			t.Fatalf("RouteDocumentID collection: %v", err)
+		}
+		if decision.Shape != RouteShapeCollectionV1 || decision.PlacementMode != PlacementModeCollectionV1 {
+			t.Fatalf("decision shape/mode=%q/%q want collection/collection", decision.Shape, decision.PlacementMode)
+		}
+		if decision.Token.Present {
+			t.Fatalf("collection route should not expose token metadata: %+v", decision.Token)
+		}
+	})
+
+	for _, mode := range []PlacementModeV1{PlacementModeTokenV1, PlacementModeRingV1} {
+		t.Run(string(mode), func(t *testing.T) {
+			ref := CollectionRefV1{Database: DefaultDatabase, Catalog: DefaultCatalog, Collection: "events"}
+			catalog := validCatalog()
+			catalog.Placements = append(catalog.Placements, tokenPlacement(ref, mode))
+			resolved, err := Validate(catalog)
+			if err != nil {
+				t.Fatalf("Validate: %v", err)
+			}
+			token := maxTokenV1
+			decision, err := resolved.RouteDocumentToken(DefaultDatabase, DefaultCatalog, "events", token)
+			if err != nil {
+				t.Fatalf("RouteDocumentToken: %v", err)
+			}
+			if decision.Shape != RouteShapeTokenV1 || decision.PlacementMode != mode {
+				t.Fatalf("decision shape/mode=%q/%q want token/%q", decision.Shape, decision.PlacementMode, mode)
+			}
+			if !decision.Token.Present || decision.Token.Token != token {
+				t.Fatalf("token metadata=%+v want token %d", decision.Token, token)
+			}
+			if decision.Token.Partition.ID != "token-000001" || decision.Token.Partition.GroupID != "group-b" {
+				t.Fatalf("partition=(%q,%q) want (token-000001,group-b)", decision.Token.Partition.ID, decision.Token.Partition.GroupID)
+			}
+		})
+	}
+}
+
 func TestRouteFailsClosed(t *testing.T) {
 	ref := CollectionRefV1{Database: DefaultDatabase, Catalog: DefaultCatalog, Collection: "events"}
 	catalog := validCatalog()

--- a/TreeDB/mongo_gateway/cluster_submitter.go
+++ b/TreeDB/mongo_gateway/cluster_submitter.go
@@ -10,6 +10,7 @@ import (
 	"github.com/snissn/gomap/TreeDB/collections"
 	iwire "github.com/snissn/gomap/TreeDB/internal/nativewire"
 	"github.com/snissn/gomap/TreeDB/internal/raftentry"
+	"github.com/snissn/gomap/TreeDB/internal/raftplacement"
 	"github.com/snissn/gomap/TreeDB/mongo_gateway/wire"
 	treenativewire "github.com/snissn/gomap/TreeDB/nativewire"
 	"go.mongodb.org/mongo-driver/v2/bson"
@@ -98,7 +99,7 @@ func (s *Server) clusterInsertResponse(ctx context.Context, command wire.Documen
 			return mongoClusterMutationCommandError(err)
 		}
 	}
-	inserted, err := s.submitClusterInsert(ctx, name, format, ids, stored, ack, mongoClusterRouteRequest(db, collection, iwire.CommandInsertBatch, "insert_batch"))
+	inserted, err := s.submitClusterInsert(ctx, name, format, ids, stored, ack, mongoClusterDocumentIDsRouteRequest(db, collection, iwire.CommandInsertBatch, "insert_batch", ids))
 	if err != nil {
 		return mongoClusterMutationCommandError(err)
 	}
@@ -142,6 +143,11 @@ func (s *Server) clusterUpdateResponse(ctx context.Context, command wire.Documen
 		}
 		return marshalUpdateResponse(0, 0)
 	}
+	if len(updates) != 1 {
+		if err := s.preflightClusterRoute(ctx, mongoClusterRouteRequest(db, collection, iwire.CommandUpdateBSONSet, "update_bson_set")); err != nil {
+			return mongoClusterMutationCommandError(err)
+		}
+	}
 	var matched, modified int32
 	for i, update := range updates {
 		item, err := parseMongoUpdateItem(i, update)
@@ -151,7 +157,11 @@ func (s *Server) clusterUpdateResponse(ctx context.Context, command wire.Documen
 		if !item.bsonSetFieldsOK {
 			return commandError(commandCodeBadValue, "BadValue", fmt.Sprintf("updates[%d]: cluster Mongo gateway currently supports only top-level BSON $set updateOne by _id", i))
 		}
-		matchedOne, modifiedOne, err := s.submitClusterUpdateBSONSet(ctx, name, item, ack, mongoClusterRouteRequest(db, collection, iwire.CommandUpdateBSONSet, "update_bson_set"))
+		route := mongoClusterRouteRequest(db, collection, iwire.CommandUpdateBSONSet, "update_bson_set")
+		if len(updates) == 1 {
+			route = mongoClusterDocumentIDRouteRequest(db, collection, iwire.CommandUpdateBSONSet, "update_bson_set", item.key)
+		}
+		matchedOne, modifiedOne, err := s.submitClusterUpdateBSONSet(ctx, name, item, ack, route)
 		if err != nil {
 			return mongoClusterMutationCommandError(mongoUpdateErrorWithIndex(item.index, err))
 		}
@@ -195,13 +205,18 @@ func (s *Server) clusterDeleteResponse(ctx context.Context, command wire.Documen
 		}
 		return marshalDeleteResponse(0)
 	}
+	if len(deletes) != 1 {
+		if err := s.preflightClusterRoute(ctx, mongoClusterRouteRequest(db, collection, iwire.CommandDeleteBatch, "delete_batch")); err != nil {
+			return mongoClusterMutationCommandError(err)
+		}
+	}
 	ids := make([][]byte, 0, len(deletes))
 	seenIDs := make(map[string]struct{}, len(deletes))
 	submitPendingBeforeError := func() error {
 		if len(ids) == 0 {
 			return nil
 		}
-		_, err := s.submitClusterDelete(ctx, name, ids, ack, mongoClusterRouteRequest(db, collection, iwire.CommandDeleteBatch, "delete_batch"))
+		_, err := s.submitClusterDelete(ctx, name, ids, ack, mongoClusterDocumentIDsRouteRequest(db, collection, iwire.CommandDeleteBatch, "delete_batch", ids))
 		return err
 	}
 	for i, deleteItem := range deletes {
@@ -244,7 +259,7 @@ func (s *Server) clusterDeleteResponse(ctx context.Context, command wire.Documen
 		seenIDs[keyString] = struct{}{}
 		ids = append(ids, key)
 	}
-	deleted, err := s.submitClusterDelete(ctx, name, ids, ack, mongoClusterRouteRequest(db, collection, iwire.CommandDeleteBatch, "delete_batch"))
+	deleted, err := s.submitClusterDelete(ctx, name, ids, ack, mongoClusterDocumentIDsRouteRequest(db, collection, iwire.CommandDeleteBatch, "delete_batch", ids))
 	if err != nil {
 		return mongoClusterMutationCommandError(err)
 	}
@@ -475,10 +490,14 @@ func (s *Server) submitClusterMutation(ctx context.Context, command iwire.Comman
 		metadata.ClusterRouteDatabase = routeReq.Database
 		metadata.ClusterRouteCatalog = routeReq.Catalog
 		metadata.ClusterRouteCollection = routeReq.Collection
+		metadata.ClusterRouteShape = string(route.Shape)
 		metadata.ClusterRouteGroupID = route.GroupID
 		metadata.ClusterRouteMembers = append([]string(nil), route.Members...)
 		metadata.ClusterRouteLeaderHint = route.LeaderHint
 		metadata.ClusterRoutePlacementMode = route.PlacementMode
+		metadata.ClusterRouteTokenKnown = route.TokenKnown
+		metadata.ClusterRouteToken = route.Token
+		metadata.ClusterRoutePartitionID = route.PartitionID
 	}
 	if _, err := raftentry.DecodeCommandEntryV1(entry, raftentry.DecodeOptions{RequestMetadata: metadata}); err != nil {
 		return nil, err
@@ -503,6 +522,14 @@ func (s *Server) admitClusterMutation(ctx context.Context) error {
 	return treenativewire.AdmitClusterMutation(ctx, s.ClusterSubmitter)
 }
 
+func (s *Server) preflightClusterRoute(ctx context.Context, routeReq *treenativewire.ClusterRouteRequest) error {
+	if routeReq == nil || s == nil || s.ClusterSubmitter == nil {
+		return nil
+	}
+	_, _, err := treenativewire.PreflightClusterRoute(ctx, s.ClusterSubmitter, *routeReq)
+	return err
+}
+
 func mongoClusterRouteRequest(db, collection string, command iwire.CommandID, commandName string) *treenativewire.ClusterRouteRequest {
 	return &treenativewire.ClusterRouteRequest{
 		Database:    db,
@@ -510,7 +537,23 @@ func mongoClusterRouteRequest(db, collection string, command iwire.CommandID, co
 		Collection:  collection,
 		CommandID:   command,
 		CommandName: commandName,
+		Shape:       treenativewire.ClusterRouteShapeCollection,
 	}
+}
+
+func mongoClusterDocumentIDRouteRequest(db, collection string, command iwire.CommandID, commandName string, id []byte) *treenativewire.ClusterRouteRequest {
+	req := mongoClusterRouteRequest(db, collection, command, commandName)
+	req.Shape = treenativewire.ClusterRouteShapeToken
+	req.TokenKnown = true
+	req.Token = raftplacement.DocumentIDTokenV1(id)
+	return req
+}
+
+func mongoClusterDocumentIDsRouteRequest(db, collection string, command iwire.CommandID, commandName string, ids [][]byte) *treenativewire.ClusterRouteRequest {
+	if len(ids) == 1 {
+		return mongoClusterDocumentIDRouteRequest(db, collection, command, commandName, ids[0])
+	}
+	return mongoClusterRouteRequest(db, collection, command, commandName)
 }
 
 func validateMongoClusterSubmitResult(requested iwire.AckPolicy, result treenativewire.ClusterSubmitResult) error {

--- a/TreeDB/mongo_gateway/cluster_submitter_test.go
+++ b/TreeDB/mongo_gateway/cluster_submitter_test.go
@@ -12,7 +12,9 @@ import (
 	"github.com/snissn/gomap/TreeDB/collections"
 	backenddb "github.com/snissn/gomap/TreeDB/db"
 	iwire "github.com/snissn/gomap/TreeDB/internal/nativewire"
+	"github.com/snissn/gomap/TreeDB/internal/raftcluster"
 	"github.com/snissn/gomap/TreeDB/internal/raftentry"
+	"github.com/snissn/gomap/TreeDB/internal/raftplacement"
 	"github.com/snissn/gomap/TreeDB/mongo_gateway/wire"
 	treenativewire "github.com/snissn/gomap/TreeDB/nativewire"
 	"go.mongodb.org/mongo-driver/v2/bson"
@@ -66,6 +68,53 @@ func (r *mongoRoutingClusterSubmitter) snapshotRoutes() []treenativewire.Cluster
 	r.routeMu.Lock()
 	defer r.routeMu.Unlock()
 	return append([]treenativewire.ClusterRouteRequest(nil), r.routes...)
+}
+
+type mongoPlacementRouteClusterSubmitter struct {
+	*mongoClusterFakeSubmitter
+
+	routeMu sync.Mutex
+	catalog raftplacement.ResolvedCatalogV1
+	routes  []treenativewire.ClusterRouteRequest
+}
+
+func (p *mongoPlacementRouteClusterSubmitter) ClusterRoute(ctx context.Context, req treenativewire.ClusterRouteRequest) (treenativewire.ClusterRouteTarget, error) {
+	p.routeMu.Lock()
+	p.routes = append(p.routes, req)
+	p.routeMu.Unlock()
+	var decision raftplacement.RouteDecisionV1
+	var err error
+	if req.Shape == treenativewire.ClusterRouteShapeToken && req.TokenKnown {
+		decision, err = p.catalog.RouteDocumentToken(req.Database, req.Catalog, req.Collection, req.Token)
+	} else {
+		decision, err = p.catalog.RouteCollection(req.Database, req.Catalog, req.Collection)
+	}
+	if err != nil {
+		return treenativewire.ClusterRouteTarget{}, err
+	}
+	members := make([]string, len(decision.Group.Members))
+	for i, member := range decision.Group.Members {
+		members[i] = string(member)
+	}
+	target := treenativewire.ClusterRouteTarget{
+		GroupID:       string(decision.GroupID()),
+		Members:       members,
+		LeaderHint:    string(decision.LeaderHint()),
+		PlacementMode: string(decision.PlacementMode),
+		Shape:         treenativewire.ClusterRouteShape(decision.Shape),
+	}
+	if decision.Token.Present {
+		target.TokenKnown = true
+		target.Token = decision.Token.Token
+		target.PartitionID = string(decision.Token.Partition.ID)
+	}
+	return target, nil
+}
+
+func (p *mongoPlacementRouteClusterSubmitter) snapshotRoutes() []treenativewire.ClusterRouteRequest {
+	p.routeMu.Lock()
+	defer p.routeMu.Unlock()
+	return append([]treenativewire.ClusterRouteRequest(nil), p.routes...)
 }
 
 func (f *mongoClusterAdmissionSubmitter) ClusterAdmissionStatus(context.Context) (treenativewire.ClusterAdmissionStatus, error) {
@@ -259,12 +308,108 @@ func assertMongoClusterRouteMetadata(tb testing.TB, call mongoClusterSubmitterCa
 	if meta.ClusterRouteDatabase != database || meta.ClusterRouteCatalog != "default" || meta.ClusterRouteCollection != collection {
 		tb.Fatalf("metadata route identity=%s/%s/%s want %s/default/%s", meta.ClusterRouteDatabase, meta.ClusterRouteCatalog, meta.ClusterRouteCollection, database, collection)
 	}
+	if meta.ClusterRouteShape != string(treenativewire.ClusterRouteShapeCollection) {
+		tb.Fatalf("metadata route shape=%q want collection", meta.ClusterRouteShape)
+	}
 	if meta.ClusterRouteGroupID != "group-a" || meta.ClusterRouteLeaderHint != "node-a" || meta.ClusterRoutePlacementMode != "collection" {
 		tb.Fatalf("metadata route target group=%q leader=%q mode=%q", meta.ClusterRouteGroupID, meta.ClusterRouteLeaderHint, meta.ClusterRoutePlacementMode)
+	}
+	if meta.ClusterRouteTokenKnown || meta.ClusterRouteToken != 0 || meta.ClusterRoutePartitionID != "" {
+		tb.Fatalf("collection route unexpectedly included token metadata known/token/partition=%v/%d/%q", meta.ClusterRouteTokenKnown, meta.ClusterRouteToken, meta.ClusterRoutePartitionID)
 	}
 	if len(meta.ClusterRouteMembers) != 2 || meta.ClusterRouteMembers[0] != "node-a" || meta.ClusterRouteMembers[1] != "node-b" {
 		tb.Fatalf("metadata route members=%v want [node-a node-b]", meta.ClusterRouteMembers)
 	}
+}
+
+func assertMongoClusterTokenRouteMetadata(tb testing.TB, call mongoClusterSubmitterCall, database, collection string, mode raftplacement.PlacementModeV1, partition string, token uint64) {
+	tb.Helper()
+	meta := call.metadata
+	if !meta.ClusterRouteKnown {
+		tb.Fatal("metadata missing cluster route")
+	}
+	if meta.ClusterRouteDatabase != database || meta.ClusterRouteCatalog != "default" || meta.ClusterRouteCollection != collection {
+		tb.Fatalf("metadata route identity=%s/%s/%s want %s/default/%s", meta.ClusterRouteDatabase, meta.ClusterRouteCatalog, meta.ClusterRouteCollection, database, collection)
+	}
+	if meta.ClusterRouteShape != string(treenativewire.ClusterRouteShapeToken) {
+		tb.Fatalf("route shape=%q want token", meta.ClusterRouteShape)
+	}
+	if meta.ClusterRouteGroupID != "group-a" || meta.ClusterRouteLeaderHint != "node-a" || meta.ClusterRoutePlacementMode != string(mode) {
+		tb.Fatalf("metadata route target group=%q leader=%q mode=%q", meta.ClusterRouteGroupID, meta.ClusterRouteLeaderHint, meta.ClusterRoutePlacementMode)
+	}
+	if !meta.ClusterRouteTokenKnown || meta.ClusterRouteToken != token || meta.ClusterRoutePartitionID != partition {
+		tb.Fatalf("metadata token known/token/partition=%v/%d/%q want true/%d/%q", meta.ClusterRouteTokenKnown, meta.ClusterRouteToken, meta.ClusterRoutePartitionID, token, partition)
+	}
+}
+
+func mongoClusterRouteTokenForValue(tb testing.TB, value any) uint64 {
+	tb.Helper()
+	key, err := encodePrimaryKey(mustRawValue(tb, value))
+	if err != nil {
+		tb.Fatalf("encode primary key: %v", err)
+	}
+	return raftplacement.DocumentIDTokenV1(key)
+}
+
+func newMongoPlacementRouteTestServer(tb testing.TB, mode raftplacement.PlacementModeV1) (*Server, *mongoPlacementRouteClusterSubmitter) {
+	tb.Helper()
+	db, err := backenddb.Open(backenddb.Options{Dir: tb.TempDir()})
+	if err != nil {
+		tb.Fatalf("open db: %v", err)
+	}
+	tb.Cleanup(func() { _ = db.Close() })
+	server := NewServer()
+	server.Collections = collections.NewCollectionManager(db)
+	server.DefaultCollectionOptions = collections.CollectionOptions{DocumentFormat: collections.DocumentFormatBSON}
+	if _, err := server.Collections.CreateCollection(server.defaultCollectionMeta("app.users")); err != nil {
+		tb.Fatalf("create app.users: %v", err)
+	}
+	submitter := &mongoPlacementRouteClusterSubmitter{
+		mongoClusterFakeSubmitter: &mongoClusterFakeSubmitter{},
+		catalog:                   mustMongoRouteTestCatalog(tb, mode),
+	}
+	server.ClusterSubmitter = submitter
+	server.ClusterCatalogVersion = mongoClusterStaticCatalogVersion(60)
+	return server, submitter
+}
+
+func mustMongoRouteTestCatalog(tb testing.TB, mode raftplacement.PlacementModeV1) raftplacement.ResolvedCatalogV1 {
+	tb.Helper()
+	placement := raftplacement.CollectionPlacementV1{
+		Collection: raftplacement.CollectionRefV1{
+			Database:   "app",
+			Catalog:    "default",
+			Collection: "users",
+		},
+		Mode: mode,
+	}
+	if mode == raftplacement.PlacementModeCollectionV1 {
+		placement.GroupID = "group-a"
+	} else {
+		placement.TokenPartitions = []raftplacement.TokenPartitionV1{
+			{
+				ID:      "p0",
+				GroupID: "group-a",
+				Start:   0,
+				End:     ^uint64(0),
+			},
+		}
+	}
+	catalog, err := raftplacement.Validate(raftplacement.CatalogV1{
+		Features: raftplacement.DefaultFeatureSet(),
+		Groups: []raftplacement.GroupV1{
+			{
+				ID:         "group-a",
+				Members:    []raftcluster.NodeID{"node-a", "node-b"},
+				LeaderHint: "node-a",
+			},
+		},
+		Placements: []raftplacement.CollectionPlacementV1{placement},
+	})
+	if err != nil {
+		tb.Fatalf("Validate route test catalog: %v", err)
+	}
+	return catalog
 }
 
 func TestClusterAdmissionMongoLeaderRoutesThroughSubmitter(t *testing.T) {
@@ -326,8 +471,13 @@ func TestClusterRoutePreflightMongoUsesNamespaceBeforeGatewayName(t *testing.T) 
 	if got := routes[0]; got.Database != "app" || got.Catalog != "default" || got.Collection != "users" || got.CommandID != iwire.CommandCreateCollection || got.CommandName != "create_collection" {
 		t.Fatalf("first route request=%+v want app/default/users create_collection", got)
 	}
-	if got := routes[1]; got.Database != "app" || got.Catalog != "default" || got.Collection != "users" || got.CommandID != iwire.CommandInsertBatch || got.CommandName != "insert_batch" {
-		t.Fatalf("second route request=%+v want app/default/users insert_batch", got)
+	insertKey, err := encodePrimaryKey(mustRawValue(t, "u1"))
+	if err != nil {
+		t.Fatalf("encode primary key: %v", err)
+	}
+	insertToken := raftplacement.DocumentIDTokenV1(insertKey)
+	if got := routes[1]; got.Database != "app" || got.Catalog != "default" || got.Collection != "users" || got.CommandID != iwire.CommandInsertBatch || got.CommandName != "insert_batch" || got.Shape != treenativewire.ClusterRouteShapeToken || !got.TokenKnown || got.Token != insertToken {
+		t.Fatalf("second route request=%+v want app/default/users insert_batch token=%d", got, insertToken)
 	}
 	calls := submitter.snapshotCalls()
 	if len(calls) != 2 {
@@ -362,6 +512,150 @@ func TestClusterRoutePreflightMongoRejectsBeforeSubmitter(t *testing.T) {
 	}
 	if calls := submitter.snapshotCalls(); len(calls) != 0 {
 		t.Fatalf("submit calls=%d want 0", len(calls))
+	}
+}
+
+func TestClusterRoutePreflightMongoTokenPlacementSingleIDWrites(t *testing.T) {
+	tests := []struct {
+		name        string
+		command     iwire.CommandID
+		commandName string
+		run         func(testing.TB, *Server) wire.Document
+	}{
+		{
+			name:        "insert",
+			command:     iwire.CommandInsertBatch,
+			commandName: "insert_batch",
+			run: func(tb testing.TB, server *Server) wire.Document {
+				return serveCommand(tb, server, 336101, bson.D{
+					{Key: "insert", Value: "users"},
+					{Key: "documents", Value: bson.A{bson.D{{Key: "_id", Value: "u1"}, {Key: "name", Value: "Ada"}}}},
+					{Key: "$db", Value: "app"},
+				})
+			},
+		},
+		{
+			name:        "update",
+			command:     iwire.CommandUpdateBSONSet,
+			commandName: "update_bson_set",
+			run: func(tb testing.TB, server *Server) wire.Document {
+				return serveCommand(tb, server, 336102, bson.D{
+					{Key: "update", Value: "users"},
+					{Key: "updates", Value: bson.A{bson.D{
+						{Key: "q", Value: bson.D{{Key: "_id", Value: "u1"}}},
+						{Key: "u", Value: bson.D{{Key: "$set", Value: bson.D{{Key: "name", Value: "Ada"}}}}},
+					}}},
+					{Key: "$db", Value: "app"},
+				})
+			},
+		},
+		{
+			name:        "delete",
+			command:     iwire.CommandDeleteBatch,
+			commandName: "delete_batch",
+			run: func(tb testing.TB, server *Server) wire.Document {
+				return serveCommand(tb, server, 336103, bson.D{
+					{Key: "delete", Value: "users"},
+					{Key: "deletes", Value: bson.A{bson.D{{Key: "q", Value: bson.D{{Key: "_id", Value: "u1"}}}, {Key: "limit", Value: int32(1)}}}},
+					{Key: "$db", Value: "app"},
+				})
+			},
+		},
+	}
+	for _, mode := range []raftplacement.PlacementModeV1{raftplacement.PlacementModeTokenV1, raftplacement.PlacementModeRingV1} {
+		for _, tc := range tests {
+			t.Run(string(mode)+"/"+tc.name, func(t *testing.T) {
+				server, submitter := newMongoPlacementRouteTestServer(t, mode)
+				response := tc.run(t, server)
+				assertOK(t, response)
+				token := mongoClusterRouteTokenForValue(t, "u1")
+				routes := submitter.snapshotRoutes()
+				if len(routes) != 1 {
+					t.Fatalf("route calls=%d want 1", len(routes))
+				}
+				if got := routes[0]; got.Database != "app" || got.Catalog != "default" || got.Collection != "users" || got.CommandID != tc.command || got.CommandName != tc.commandName || got.Shape != treenativewire.ClusterRouteShapeToken || !got.TokenKnown || got.Token != token {
+					t.Fatalf("route request=%+v want app/default/users %s token=%d", got, tc.commandName, token)
+				}
+				calls := submitter.snapshotCalls()
+				if len(calls) != 1 {
+					t.Fatalf("submit calls=%d want 1", len(calls))
+				}
+				if got := calls[0].entry.Decoded.CommandID; got != tc.command {
+					t.Fatalf("submitted command id=%d want %d", got, tc.command)
+				}
+				assertMongoClusterTokenRouteMetadata(t, calls[0], "app", "users", mode, "p0", token)
+			})
+		}
+	}
+}
+
+func TestClusterRoutePreflightMongoTokenPlacementRejectsMultiIDWrites(t *testing.T) {
+	tests := []struct {
+		name string
+		run  func(testing.TB, *Server) wire.Document
+	}{
+		{
+			name: "insert",
+			run: func(tb testing.TB, server *Server) wire.Document {
+				return serveCommand(tb, server, 336104, bson.D{
+					{Key: "insert", Value: "users"},
+					{Key: "documents", Value: bson.A{
+						bson.D{{Key: "_id", Value: "u1"}},
+						bson.D{{Key: "_id", Value: "u2"}},
+					}},
+					{Key: "$db", Value: "app"},
+				})
+			},
+		},
+		{
+			name: "update",
+			run: func(tb testing.TB, server *Server) wire.Document {
+				return serveCommand(tb, server, 336105, bson.D{
+					{Key: "update", Value: "users"},
+					{Key: "updates", Value: bson.A{
+						bson.D{
+							{Key: "q", Value: bson.D{{Key: "_id", Value: "u1"}}},
+							{Key: "u", Value: bson.D{{Key: "$set", Value: bson.D{{Key: "name", Value: "Ada"}}}}},
+						},
+						bson.D{
+							{Key: "q", Value: bson.D{{Key: "_id", Value: "u2"}}},
+							{Key: "u", Value: bson.D{{Key: "$set", Value: bson.D{{Key: "name", Value: "Grace"}}}}},
+						},
+					}},
+					{Key: "$db", Value: "app"},
+				})
+			},
+		},
+		{
+			name: "delete",
+			run: func(tb testing.TB, server *Server) wire.Document {
+				return serveCommand(tb, server, 336106, bson.D{
+					{Key: "delete", Value: "users"},
+					{Key: "deletes", Value: bson.A{
+						bson.D{{Key: "q", Value: bson.D{{Key: "_id", Value: "u1"}}}, {Key: "limit", Value: int32(1)}},
+						bson.D{{Key: "q", Value: bson.D{{Key: "_id", Value: "u2"}}}, {Key: "limit", Value: int32(1)}},
+					}},
+					{Key: "$db", Value: "app"},
+				})
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			server, submitter := newMongoPlacementRouteTestServer(t, raftplacement.PlacementModeRingV1)
+			response := tc.run(t, server)
+			assertCommandError(t, response, "NotWritablePrimary")
+			routes := submitter.snapshotRoutes()
+			if len(routes) != 1 {
+				t.Fatalf("route calls=%d want 1", len(routes))
+			}
+			if got := routes[0]; got.Shape != treenativewire.ClusterRouteShapeCollection || got.TokenKnown {
+				t.Fatalf("multi-ID route request=%+v want collection-shaped without token", got)
+			}
+			if calls := submitter.snapshotCalls(); len(calls) != 0 {
+				t.Fatalf("submit calls=%d want 0", len(calls))
+			}
+		})
 	}
 }
 

--- a/TreeDB/nativewire/cluster_submitter.go
+++ b/TreeDB/nativewire/cluster_submitter.go
@@ -7,6 +7,7 @@ import (
 
 	iwire "github.com/snissn/gomap/TreeDB/internal/nativewire"
 	"github.com/snissn/gomap/TreeDB/internal/raftentry"
+	"github.com/snissn/gomap/TreeDB/internal/raftplacement"
 )
 
 // ClusterRequestMetadata carries request-scoped fields that influence response
@@ -27,12 +28,22 @@ type ClusterRouteProvider interface {
 	ClusterRoute(ctx context.Context, request ClusterRouteRequest) (ClusterRouteTarget, error)
 }
 
+type ClusterRouteShape string
+
+const (
+	ClusterRouteShapeCollection ClusterRouteShape = "collection"
+	ClusterRouteShapeToken      ClusterRouteShape = "token"
+)
+
 type ClusterRouteRequest struct {
 	Database    string
 	Catalog     string
 	Collection  string
 	CommandID   iwire.CommandID
 	CommandName string
+	Shape       ClusterRouteShape
+	TokenKnown  bool
+	Token       uint64
 }
 
 type ClusterRouteTarget struct {
@@ -41,6 +52,10 @@ type ClusterRouteTarget struct {
 	LeaderHint    string
 	PlacementMode string
 	Reason        string
+	Shape         ClusterRouteShape
+	TokenKnown    bool
+	Token         uint64
+	PartitionID   string
 }
 
 // ClusterAdmissionProvider exposes the node write-admission state backing a
@@ -180,11 +195,22 @@ func AdmitClusterMutation(ctx context.Context, submitter ClusterSubmitter) error
 
 // PreflightClusterRoute checks the optional cluster route provider. A missing
 // provider preserves existing submitter behavior; a configured provider must
-// return a collection-mode route target with a group ID.
+// return a supported route target with a group ID. Token/ring targets require
+// an exactly-one-ID token route request.
 func PreflightClusterRoute(ctx context.Context, submitter ClusterSubmitter, request ClusterRouteRequest) (ClusterRouteTarget, bool, error) {
 	provider, ok := submitter.(ClusterRouteProvider)
 	if !ok {
 		return ClusterRouteTarget{}, false, nil
+	}
+	request.Shape = normalizeClusterRouteShape(request.Shape)
+	switch request.Shape {
+	case ClusterRouteShapeCollection:
+	case ClusterRouteShapeToken:
+		if !request.TokenKnown {
+			return ClusterRouteTarget{}, true, protocolError(iwire.ErrReadOnly, "cluster token route request missing document token")
+		}
+	default:
+		return ClusterRouteTarget{}, true, protocolError(iwire.ErrReadOnly, "cluster route shape %q is not supported", request.Shape)
 	}
 	if ctx == nil {
 		ctx = context.Background()
@@ -207,15 +233,80 @@ func PreflightClusterRoute(ctx context.Context, submitter ClusterSubmitter, requ
 		}
 		return ClusterRouteTarget{}, true, protocolError(iwire.ErrReadOnly, "%s", reason)
 	}
-	if target.PlacementMode != "collection" {
+	target.Shape = normalizeClusterRouteTargetShape(target.Shape, target.PlacementMode)
+	switch target.PlacementMode {
+	case "collection":
+		if target.Shape != ClusterRouteShapeCollection {
+			reason := target.Reason
+			if reason == "" {
+				reason = "cluster collection route target must use collection route shape"
+			}
+			return ClusterRouteTarget{}, true, protocolError(iwire.ErrReadOnly, "%s", reason)
+		}
+	case "token", "ring":
+		if request.Shape != ClusterRouteShapeToken || !request.TokenKnown {
+			reason := target.Reason
+			if reason == "" {
+				reason = "cluster token/ring route target requires exactly one document id"
+			}
+			return ClusterRouteTarget{}, true, protocolError(iwire.ErrReadOnly, "%s", reason)
+		}
+		if target.Shape != ClusterRouteShapeToken {
+			reason := target.Reason
+			if reason == "" {
+				reason = "cluster token/ring route target must use token route shape"
+			}
+			return ClusterRouteTarget{}, true, protocolError(iwire.ErrReadOnly, "%s", reason)
+		}
+		if !target.TokenKnown {
+			reason := target.Reason
+			if reason == "" {
+				reason = "cluster token/ring route target missing document token"
+			}
+			return ClusterRouteTarget{}, true, protocolError(iwire.ErrReadOnly, "%s", reason)
+		}
+		if target.Token != request.Token {
+			reason := target.Reason
+			if reason == "" {
+				reason = "cluster token/ring route target token does not match request token"
+			}
+			return ClusterRouteTarget{}, true, protocolError(iwire.ErrReadOnly, "%s", reason)
+		}
+		if target.PartitionID == "" {
+			reason := target.Reason
+			if reason == "" {
+				reason = "cluster token/ring route target missing token partition id"
+			}
+			return ClusterRouteTarget{}, true, protocolError(iwire.ErrReadOnly, "%s", reason)
+		}
+	default:
 		reason := target.Reason
 		if reason == "" {
-			reason = "cluster route target placement mode " + target.PlacementMode + " is not supported by collection preflight"
+			reason = "cluster route target placement mode " + target.PlacementMode + " is not supported"
 		}
 		return ClusterRouteTarget{}, true, protocolError(iwire.ErrReadOnly, "%s", reason)
 	}
 	target.Members = append([]string(nil), target.Members...)
 	return target, true, nil
+}
+
+func normalizeClusterRouteShape(shape ClusterRouteShape) ClusterRouteShape {
+	if shape == "" {
+		return ClusterRouteShapeCollection
+	}
+	return shape
+}
+
+func normalizeClusterRouteTargetShape(shape ClusterRouteShape, placementMode string) ClusterRouteShape {
+	if shape != "" {
+		return shape
+	}
+	switch placementMode {
+	case "token", "ring":
+		return ClusterRouteShapeToken
+	default:
+		return ClusterRouteShapeCollection
+	}
 }
 
 func (s *Server) rejectClusterLocalMutation(command string) error {
@@ -246,13 +337,44 @@ func clusterMutationRouteRequest(cmd iwire.ValidatedCommand) (ClusterRouteReques
 	if err != nil {
 		return ClusterRouteRequest{}, err
 	}
-	return ClusterRouteRequest{
+	req := ClusterRouteRequest{
 		Database:    "default",
 		Catalog:     "default",
 		Collection:  collection,
 		CommandID:   cmd.Header.ID,
 		CommandName: name,
-	}, nil
+		Shape:       ClusterRouteShapeCollection,
+	}
+	token, ok, err := clusterMutationDocumentToken(cmd)
+	if err != nil {
+		return ClusterRouteRequest{}, err
+	}
+	if ok {
+		req.Shape = ClusterRouteShapeToken
+		req.TokenKnown = true
+		req.Token = token
+	}
+	return req, nil
+}
+
+func clusterMutationDocumentToken(cmd iwire.ValidatedCommand) (uint64, bool, error) {
+	switch cmd.Header.ID {
+	case iwire.CommandInsertBatch, iwire.CommandReplaceBatch, iwire.CommandDeleteBatch, iwire.CommandUpdateBSONSet:
+	default:
+		return 0, false, nil
+	}
+	raw, err := metadataSection(cmd.Known, iwire.SectionDocumentIDs)
+	if err != nil {
+		return 0, false, err
+	}
+	ids, err := iwire.DecodeByteVectorItems(raw, iwire.Limits{})
+	if err != nil {
+		return 0, false, err
+	}
+	if len(ids) != 1 {
+		return 0, false, nil
+	}
+	return raftplacement.DocumentIDTokenV1(ids[0]), true, nil
 }
 
 func clusterMutationRouteCollection(cmd iwire.ValidatedCommand) (string, error) {
@@ -315,10 +437,14 @@ func applyClusterRouteMetadata(metadata *ClusterRequestMetadata, request Cluster
 	metadata.ClusterRouteDatabase = request.Database
 	metadata.ClusterRouteCatalog = request.Catalog
 	metadata.ClusterRouteCollection = request.Collection
+	metadata.ClusterRouteShape = string(target.Shape)
 	metadata.ClusterRouteGroupID = target.GroupID
 	metadata.ClusterRouteMembers = append([]string(nil), target.Members...)
 	metadata.ClusterRouteLeaderHint = target.LeaderHint
 	metadata.ClusterRoutePlacementMode = target.PlacementMode
+	metadata.ClusterRouteTokenKnown = target.TokenKnown
+	metadata.ClusterRouteToken = target.Token
+	metadata.ClusterRoutePartitionID = target.PartitionID
 }
 
 func deadlineUnixNanosFromSections(sections []iwire.Section) (int64, error) {

--- a/TreeDB/nativewire/cluster_submitter.go
+++ b/TreeDB/nativewire/cluster_submitter.go
@@ -134,7 +134,7 @@ func (s *Server) handleClusterMutation(ctx context.Context, header iwire.Header,
 	var routed bool
 	if _, ok := s.clusterSubmitter.(ClusterRouteProvider); ok {
 		var err error
-		routeReq, err = clusterMutationRouteRequest(cmd)
+		routeReq, err = clusterMutationRouteRequest(cmd, s.limits)
 		if err != nil {
 			return nil, err
 		}
@@ -328,7 +328,7 @@ func unsupportedClusterMutationError(cmd iwire.ValidatedCommand, row raftentry.C
 	return protocolError(iwire.ErrUnsupportedFeature, "cluster submitter does not support %s: %s", name, reason)
 }
 
-func clusterMutationRouteRequest(cmd iwire.ValidatedCommand) (ClusterRouteRequest, error) {
+func clusterMutationRouteRequest(cmd iwire.ValidatedCommand, limits iwire.Limits) (ClusterRouteRequest, error) {
 	name := ""
 	if cmd.Schema != nil {
 		name = cmd.Schema.Name
@@ -345,7 +345,7 @@ func clusterMutationRouteRequest(cmd iwire.ValidatedCommand) (ClusterRouteReques
 		CommandName: name,
 		Shape:       ClusterRouteShapeCollection,
 	}
-	token, ok, err := clusterMutationDocumentToken(cmd)
+	token, ok, err := clusterMutationDocumentToken(cmd, limits)
 	if err != nil {
 		return ClusterRouteRequest{}, err
 	}
@@ -357,7 +357,7 @@ func clusterMutationRouteRequest(cmd iwire.ValidatedCommand) (ClusterRouteReques
 	return req, nil
 }
 
-func clusterMutationDocumentToken(cmd iwire.ValidatedCommand) (uint64, bool, error) {
+func clusterMutationDocumentToken(cmd iwire.ValidatedCommand, limits iwire.Limits) (uint64, bool, error) {
 	switch cmd.Header.ID {
 	case iwire.CommandInsertBatch, iwire.CommandReplaceBatch, iwire.CommandDeleteBatch, iwire.CommandUpdateBSONSet:
 	default:
@@ -367,7 +367,7 @@ func clusterMutationDocumentToken(cmd iwire.ValidatedCommand) (uint64, bool, err
 	if err != nil {
 		return 0, false, err
 	}
-	ids, err := iwire.DecodeByteVectorItems(raw, iwire.Limits{})
+	ids, err := iwire.DecodeByteVectorItems(raw, limits)
 	if err != nil {
 		return 0, false, err
 	}

--- a/TreeDB/nativewire/cluster_submitter_test.go
+++ b/TreeDB/nativewire/cluster_submitter_test.go
@@ -702,6 +702,28 @@ func TestClusterRoutePreflightTokenPlacementAcceptsSingleID(t *testing.T) {
 	assertNativeClusterTokenRouteMetadata(t, calls[0], raftplacement.PlacementModeTokenV1, "p0", raftplacement.DocumentIDTokenV1([]byte("u1")))
 }
 
+func TestClusterMutationDocumentTokenHonorsDecodeLimits(t *testing.T) {
+	id := []byte("configured-limit-id")
+	rawIDs := iwire.AppendByteVector(nil, id)
+	cmd := iwire.ValidatedCommand{
+		Header: iwire.CommandHeader{ID: iwire.CommandInsertBatch},
+		Known: []iwire.Section{
+			{ID: iwire.SectionDocumentIDs, Bytes: rawIDs},
+		},
+	}
+
+	if _, _, err := clusterMutationDocumentToken(cmd, iwire.Limits{MaxByteVectorBytes: uint64(len(id) - 1)}); codeOf(err) != iwire.ErrResourceExhausted {
+		t.Fatalf("clusterMutationDocumentToken low limit err=%v code=%d want resource exhausted", err, codeOf(err))
+	}
+	token, ok, err := clusterMutationDocumentToken(cmd, iwire.Limits{MaxByteVectorBytes: uint64(len(id))})
+	if err != nil {
+		t.Fatalf("clusterMutationDocumentToken configured limit: %v", err)
+	}
+	if !ok || token != raftplacement.DocumentIDTokenV1(id) {
+		t.Fatalf("token ok/token=%v/%d want true/%d", ok, token, raftplacement.DocumentIDTokenV1(id))
+	}
+}
+
 func TestClusterRoutePreflightTokenPlacementSingleIDMutationCommands(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/TreeDB/nativewire/cluster_submitter_test.go
+++ b/TreeDB/nativewire/cluster_submitter_test.go
@@ -82,7 +82,13 @@ func (p *placementRouteClusterSubmitter) ClusterRoute(ctx context.Context, req C
 	p.routeMu.Lock()
 	p.routes = append(p.routes, req)
 	p.routeMu.Unlock()
-	decision, err := p.catalog.RouteCollection(req.Database, req.Catalog, req.Collection)
+	var decision raftplacement.RouteDecisionV1
+	var err error
+	if req.Shape == ClusterRouteShapeToken && req.TokenKnown {
+		decision, err = p.catalog.RouteDocumentToken(req.Database, req.Catalog, req.Collection, req.Token)
+	} else {
+		decision, err = p.catalog.RouteCollection(req.Database, req.Catalog, req.Collection)
+	}
 	if err != nil {
 		return ClusterRouteTarget{}, err
 	}
@@ -90,12 +96,19 @@ func (p *placementRouteClusterSubmitter) ClusterRoute(ctx context.Context, req C
 	for i, member := range decision.Group.Members {
 		members[i] = string(member)
 	}
-	return ClusterRouteTarget{
+	target := ClusterRouteTarget{
 		GroupID:       string(decision.GroupID()),
 		Members:       members,
 		LeaderHint:    string(decision.LeaderHint()),
 		PlacementMode: string(decision.PlacementMode),
-	}, nil
+		Shape:         ClusterRouteShape(decision.Shape),
+	}
+	if decision.Token.Present {
+		target.TokenKnown = true
+		target.Token = decision.Token.Token
+		target.PartitionID = string(decision.Token.Partition.ID)
+	}
+	return target, nil
 }
 
 func (p *placementRouteClusterSubmitter) snapshotRoutes() []ClusterRouteRequest {
@@ -224,6 +237,23 @@ func cloneClusterRequestMetadata(metadata ClusterRequestMetadata) ClusterRequest
 	metadata.TraceContext = bytes.Clone(metadata.TraceContext)
 	metadata.ClusterRouteMembers = append([]string(nil), metadata.ClusterRouteMembers...)
 	return metadata
+}
+
+func assertNativeClusterTokenRouteMetadata(tb testing.TB, call fakeClusterSubmitCall, mode raftplacement.PlacementModeV1, partition string, token uint64) {
+	tb.Helper()
+	meta := call.metadata
+	if !meta.ClusterRouteKnown {
+		tb.Fatal("metadata missing cluster route")
+	}
+	if meta.ClusterRouteShape != string(ClusterRouteShapeToken) {
+		tb.Fatalf("route shape=%q want token", meta.ClusterRouteShape)
+	}
+	if meta.ClusterRouteGroupID != "group-a" || meta.ClusterRouteLeaderHint != "node-a" || meta.ClusterRoutePlacementMode != string(mode) {
+		tb.Fatalf("metadata route target group=%q leader=%q mode=%q", meta.ClusterRouteGroupID, meta.ClusterRouteLeaderHint, meta.ClusterRoutePlacementMode)
+	}
+	if !meta.ClusterRouteTokenKnown || meta.ClusterRouteToken != token || meta.ClusterRoutePartitionID != partition {
+		tb.Fatalf("metadata token known/token/partition=%v/%d/%q want true/%d/%q", meta.ClusterRouteTokenKnown, meta.ClusterRouteToken, meta.ClusterRoutePartitionID, token, partition)
+	}
 }
 
 func TestClusterAdmissionMissingProviderFailsClosed(t *testing.T) {
@@ -529,8 +559,14 @@ func TestClusterRoutePreflightAddsMetadata(t *testing.T) {
 	if meta.ClusterRouteDatabase != "default" || meta.ClusterRouteCatalog != "default" || meta.ClusterRouteCollection != "users" {
 		t.Fatalf("metadata route identity=%s/%s/%s want default/default/users", meta.ClusterRouteDatabase, meta.ClusterRouteCatalog, meta.ClusterRouteCollection)
 	}
+	if meta.ClusterRouteShape != string(ClusterRouteShapeCollection) {
+		t.Fatalf("metadata route shape=%q want collection", meta.ClusterRouteShape)
+	}
 	if meta.ClusterRouteGroupID != "group-a" || meta.ClusterRouteLeaderHint != "node-a" || meta.ClusterRoutePlacementMode != "collection" {
 		t.Fatalf("metadata route target group=%q leader=%q mode=%q", meta.ClusterRouteGroupID, meta.ClusterRouteLeaderHint, meta.ClusterRoutePlacementMode)
+	}
+	if meta.ClusterRouteTokenKnown || meta.ClusterRouteToken != 0 || meta.ClusterRoutePartitionID != "" {
+		t.Fatalf("collection route unexpectedly included token metadata known/token/partition=%v/%d/%q", meta.ClusterRouteTokenKnown, meta.ClusterRouteToken, meta.ClusterRoutePartitionID)
 	}
 	if !reflect.DeepEqual(meta.ClusterRouteMembers, []string{"node-a", "node-b"}) {
 		t.Fatalf("metadata route members=%v want [node-a node-b]", meta.ClusterRouteMembers)
@@ -631,7 +667,7 @@ func TestClusterRoutePreflightSkipsMalformedDeterministicEntry(t *testing.T) {
 	}
 }
 
-func TestClusterRoutePreflightRejectsTokenPlacementWithoutTokenContract(t *testing.T) {
+func TestClusterRoutePreflightTokenPlacementAcceptsSingleID(t *testing.T) {
 	catalog := mustNativewireRouteTestCatalog(t, raftplacement.PlacementModeTokenV1)
 	submitter := &placementRouteClusterSubmitter{
 		fakeClusterSubmitter: &fakeClusterSubmitter{},
@@ -648,14 +684,171 @@ func TestClusterRoutePreflightRejectsTokenPlacementWithoutTokenContract(t *testi
 		[][]byte{[]byte(`{"name":"Ada"}`)},
 		AckVisible,
 	)
-	if !isRemoteError(err, iwire.ErrReadOnly) {
-		t.Fatalf("InsertBatch err=%v want read-only", err)
+	if err != nil {
+		t.Fatalf("InsertBatch token placement: %v", err)
 	}
 	if routes := submitter.snapshotRoutes(); len(routes) != 1 {
 		t.Fatalf("route calls=%d want 1", len(routes))
+	} else {
+		token := raftplacement.DocumentIDTokenV1([]byte("u1"))
+		if routes[0].Shape != ClusterRouteShapeToken || !routes[0].TokenKnown || routes[0].Token != token {
+			t.Fatalf("route request=%+v want token route token=%d", routes[0], token)
+		}
 	}
-	if calls := submitter.snapshot(); len(calls) != 0 {
-		t.Fatalf("submitter calls=%d want 0", len(calls))
+	calls := submitter.snapshot()
+	if len(calls) != 1 {
+		t.Fatalf("submitter calls=%d want 1", len(calls))
+	}
+	assertNativeClusterTokenRouteMetadata(t, calls[0], raftplacement.PlacementModeTokenV1, "p0", raftplacement.DocumentIDTokenV1([]byte("u1")))
+}
+
+func TestClusterRoutePreflightTokenPlacementSingleIDMutationCommands(t *testing.T) {
+	tests := []struct {
+		name    string
+		command iwire.CommandID
+		run     func(context.Context, *Client) error
+	}{
+		{
+			name:    "insert_batch",
+			command: iwire.CommandInsertBatch,
+			run: func(ctx context.Context, client *Client) error {
+				_, err := client.InsertBatch(ctx, "users", collections.DocumentFormatJSON,
+					[][]byte{[]byte("u1")},
+					[][]byte{[]byte(`{"name":"Ada"}`)},
+					AckVisible,
+				)
+				return err
+			},
+		},
+		{
+			name:    "replace_batch",
+			command: iwire.CommandReplaceBatch,
+			run: func(ctx context.Context, client *Client) error {
+				_, _, err := client.ReplaceBatch(ctx, "users", collections.DocumentFormatJSON,
+					[][]byte{[]byte("u1")},
+					[][]byte{[]byte(`{"name":"Ada"}`)},
+					AckVisible,
+				)
+				return err
+			},
+		},
+		{
+			name:    "delete_batch",
+			command: iwire.CommandDeleteBatch,
+			run: func(ctx context.Context, client *Client) error {
+				_, err := client.DeleteBatch(ctx, "users", [][]byte{[]byte("u1")}, AckVisible)
+				return err
+			},
+		},
+		{
+			name:    "update_bson_set",
+			command: iwire.CommandUpdateBSONSet,
+			run: func(ctx context.Context, client *Client) error {
+				_, _, err := client.UpdateBSONSet(ctx, "users", []byte("u1"), []collections.BSONSetField{
+					{Key: "name", Value: mustNativewireBSONRawValue(t, "Ada")},
+				}, AckVisible)
+				return err
+			},
+		},
+	}
+	for _, mode := range []raftplacement.PlacementModeV1{raftplacement.PlacementModeTokenV1, raftplacement.PlacementModeRingV1} {
+		for _, tc := range tests {
+			t.Run(string(mode)+"/"+tc.name, func(t *testing.T) {
+				catalog := mustNativewireRouteTestCatalog(t, mode)
+				submitter := &placementRouteClusterSubmitter{
+					fakeClusterSubmitter: &fakeClusterSubmitter{},
+					catalog:              catalog,
+				}
+				client, _, _ := serveCollectionPipeWithOptions(t, ServerOptions{ClusterSubmitter: submitter})
+				ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+				defer cancel()
+				if err := client.Hello(ctx); err != nil {
+					t.Fatalf("Hello: %v", err)
+				}
+				if err := tc.run(ctx, client); err != nil {
+					t.Fatalf("%s: %v", tc.name, err)
+				}
+				token := raftplacement.DocumentIDTokenV1([]byte("u1"))
+				routes := submitter.snapshotRoutes()
+				if len(routes) != 1 {
+					t.Fatalf("route calls=%d want 1", len(routes))
+				}
+				if got := routes[0]; got.CommandID != tc.command || got.CommandName != tc.name || got.Shape != ClusterRouteShapeToken || !got.TokenKnown || got.Token != token {
+					t.Fatalf("route request=%+v want command=%d name=%s token=%d", got, tc.command, tc.name, token)
+				}
+				calls := submitter.snapshot()
+				if len(calls) != 1 {
+					t.Fatalf("submitter calls=%d want 1", len(calls))
+				}
+				if calls[0].entry.Decoded.CommandID != tc.command {
+					t.Fatalf("submitted command=%d want %d", calls[0].entry.Decoded.CommandID, tc.command)
+				}
+				assertNativeClusterTokenRouteMetadata(t, calls[0], mode, "p0", token)
+			})
+		}
+	}
+}
+
+func TestClusterRoutePreflightTokenPlacementRejectsMultiID(t *testing.T) {
+	tests := []struct {
+		name string
+		run  func(context.Context, *Client) error
+	}{
+		{
+			name: "insert_batch",
+			run: func(ctx context.Context, client *Client) error {
+				_, err := client.InsertBatch(ctx, "users", collections.DocumentFormatJSON,
+					[][]byte{[]byte("u1"), []byte("u2")},
+					[][]byte{[]byte(`{"name":"Ada"}`), []byte(`{"name":"Grace"}`)},
+					AckVisible,
+				)
+				return err
+			},
+		},
+		{
+			name: "replace_batch",
+			run: func(ctx context.Context, client *Client) error {
+				_, _, err := client.ReplaceBatch(ctx, "users", collections.DocumentFormatJSON,
+					[][]byte{[]byte("u1"), []byte("u2")},
+					[][]byte{[]byte(`{"name":"Ada"}`), []byte(`{"name":"Grace"}`)},
+					AckVisible,
+				)
+				return err
+			},
+		},
+		{
+			name: "delete_batch",
+			run: func(ctx context.Context, client *Client) error {
+				_, err := client.DeleteBatch(ctx, "users", [][]byte{[]byte("u1"), []byte("u2")}, AckVisible)
+				return err
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			catalog := mustNativewireRouteTestCatalog(t, raftplacement.PlacementModeRingV1)
+			submitter := &placementRouteClusterSubmitter{
+				fakeClusterSubmitter: &fakeClusterSubmitter{},
+				catalog:              catalog,
+			}
+			client, _, _ := serveCollectionPipeWithOptions(t, ServerOptions{ClusterSubmitter: submitter})
+			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+			defer cancel()
+			if err := client.Hello(ctx); err != nil {
+				t.Fatalf("Hello: %v", err)
+			}
+			if err := tc.run(ctx, client); !isRemoteError(err, iwire.ErrReadOnly) {
+				t.Fatalf("%s multi-ID token placement err=%v want read-only", tc.name, err)
+			}
+			if routes := submitter.snapshotRoutes(); len(routes) != 1 {
+				t.Fatalf("route calls=%d want 1", len(routes))
+			} else if routes[0].Shape != ClusterRouteShapeCollection || routes[0].TokenKnown {
+				t.Fatalf("multi-ID route request=%+v want collection-shaped without token", routes[0])
+			}
+			if calls := submitter.snapshot(); len(calls) != 0 {
+				t.Fatalf("submitter calls=%d want 0", len(calls))
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Closes #3356.

## Summary

- Adds `raftplacement.DocumentIDTokenV1`, a stable SHA-256 domain-separated document-id token rule.
- Extends cluster route preflight metadata with route shape, token, and token partition identity as request-only metadata excluded from command digest bytes.
- Routes exactly-one-ID nativewire and Mongo writes through token/ring preflight, while multi-ID token/ring writes fail closed without fanout.
- Updates the raft placement spec and focused route/digest/harness tests.

## Scope Boundaries

- No live network routing, leader proof, meta-group replication, rebalance, query routing, fanout, or benchmark claim.
- Snapshot files under `TreeDB/internal/raftcluster` and `TreeDB/internal/raftfsm` were not touched.

## Tests

```sh
GOWORK=off go test ./TreeDB/internal/raftplacement -run 'Test(Route|Token)' -count=1\nGOWORK=off go test ./TreeDB/nativewire -run 'TestClusterRoute' -count=1\nGOWORK=off go test ./TreeDB/mongo_gateway -run 'TestClusterRoute' -count=1\nGOWORK=off go test ./TreeDB/internal/raftentry ./TreeDB/internal/raftfsm ./TreeDB/internal/raftharness ./TreeDB/internal/raftplacement ./TreeDB/nativewire ./TreeDB/mongo_gateway -count=1\ngit diff --check origin/main...HEAD\n```\n\nAll passed locally on head `4816db1fc108106a70675ee690f5e505290dc08e`.\n\n## Benchmarks\n\nNot run. Issue #3356 defines this as route/admission contract work and does not require benchmarks unless the implementation changes hot-path behavior beyond request preflight.\n\n## Review Status\n\n- AI reviews have not been requested.\n- Latest-head CI is expected to start from this PR head.\n