### PR TITLE
TreeDB: expose command-WAL checkpoint counters in expvar

### DIFF
--- a/TreeDB/caching/expvar_stats.go
+++ b/TreeDB/caching/expvar_stats.go
@@ -145,6 +145,7 @@ func selectTreeDBExpvarStats(stats map[string]string) map[string]any {
 			strings.HasPrefix(k, "treedb.cache.flush_apply.") ||
 			strings.HasPrefix(k, "treedb.cache.flush_span_run.") ||
 			strings.HasPrefix(k, "treedb.cache.flush_backlog_coalescing.") ||
+			strings.HasPrefix(k, "treedb.cache.command_wal.") ||
 			strings.HasPrefix(k, "treedb.cache.vlog_mmap.") ||
 			strings.HasPrefix(k, "treedb.cache.vlog_grouped_frame_cache.") ||
 			strings.HasPrefix(k, "treedb.cache.vlog_decode_buffer_grow.") ||

--- a/TreeDB/caching/expvar_stats_test.go
+++ b/TreeDB/caching/expvar_stats_test.go
@@ -71,6 +71,8 @@ func TestSelectTreeDBExpvarStatsFiltersAndCoerces(t *testing.T) {
 		"treedb.cache.flush_apply.foreground_assist_wait_ns_total":                                    "12345",
 		"treedb.cache.flush_span_run.ops_per_span":                                                    "8.5",
 		"treedb.cache.flush_backlog_coalescing.skip.reason.not_enough_backlog_total":                  "6",
+		"treedb.cache.command_wal.checkpoint_publish.piggybacked":                                     "2",
+		"treedb.cache.command_wal.checkpoint_publish.separate":                                        "1",
 		"treedb.cache.backpressure_mode":                                                              "adaptive",
 		"treedb.cache.entry_slice.trim_runs_total":                                                    "77",
 		"treedb.process.memory.pool_pressure_high_pct":                                                "85.5",
@@ -245,6 +247,12 @@ func TestSelectTreeDBExpvarStatsFiltersAndCoerces(t *testing.T) {
 	}
 	if v, ok := got["treedb.cache.flush_backlog_coalescing.skip.reason.not_enough_backlog_total"].(int64); !ok || v != 6 {
 		t.Fatalf("cache flush_backlog_coalescing skip=%T(%v) want int64(6)", got["treedb.cache.flush_backlog_coalescing.skip.reason.not_enough_backlog_total"], got["treedb.cache.flush_backlog_coalescing.skip.reason.not_enough_backlog_total"])
+	}
+	if v, ok := got["treedb.cache.command_wal.checkpoint_publish.piggybacked"].(int64); !ok || v != 2 {
+		t.Fatalf("command WAL checkpoint piggybacked=%T(%v) want int64(2)", got["treedb.cache.command_wal.checkpoint_publish.piggybacked"], got["treedb.cache.command_wal.checkpoint_publish.piggybacked"])
+	}
+	if v, ok := got["treedb.cache.command_wal.checkpoint_publish.separate"].(int64); !ok || v != 1 {
+		t.Fatalf("command WAL checkpoint separate=%T(%v) want int64(1)", got["treedb.cache.command_wal.checkpoint_publish.separate"], got["treedb.cache.command_wal.checkpoint_publish.separate"])
 	}
 	if _, ok := got["treedb.cache.backpressure_mode"]; ok {
 		t.Fatalf("unexpected backpressure_mode key in expvar selection")


### PR DESCRIPTION
Fixes #3360
Related: #3317, #3314, #3320

## Summary
- export the existing `treedb.cache.command_wal.*` stats family through TreeDB expvar
- add regression coverage for command-WAL checkpoint publish counters in the expvar selector

## Why
The strict post-#3354 Celestia run correctly attributes the remaining raw span-native fallback ops to `command_wal_barrier`, but the per-run `treedb_application_vars` file cannot currently say how many checkpoint AppliedLSN publishes were piggybacked vs separate. The counters already exist in `Stats()`; expvar was filtering them out.

This PR is instrumentation-only. It does not change command-WAL durability, checkpoint policy, raw KV admission, or span-native apply behavior.

## Validation
- `GOWORK=off go test ./TreeDB/caching -run TestSelectTreeDBExpvarStatsFiltersAndCoerces -count=1`
- `GOWORK=off go test ./TreeDB -run TestPublicCommandWALCheckpointPiggybacksAppliedLSN -count=1`