### PR TITLE
treedb: admit checkpoint command-WAL publish chunks to span-native apply

### DIFF
--- a/TreeDB/caching/flush_backlog_coalescing.go
+++ b/TreeDB/caching/flush_backlog_coalescing.go
@@ -110,10 +110,7 @@ func flushRangeOnlySpanNativeFallbackReasonForCollectionMode(mode flushCollectio
 	return backenddb.FlushSpanRunFallbackRangeDeleteBarrier
 }
 
-func flushPointChunkSpanNativeFallbackReasonForCollectionMode(mode flushCollectionMode, commandPublish *checkpointCommandWALPublish, attachesCommandPublish bool) backenddb.FlushSpanRunFallbackReason {
-	if attachesCommandPublish && commandPublish != nil && commandPublish.appliedLSN != 0 && !commandPublish.consumed {
-		return backenddb.FlushSpanRunFallbackCommandWALBarrier
-	}
+func flushPointChunkSpanNativeFallbackReasonForCollectionMode(mode flushCollectionMode, _ *checkpointCommandWALPublish, _ bool) backenddb.FlushSpanRunFallbackReason {
 	return flushSpanNativeFallbackReasonForCollectionMode(mode)
 }
 

--- a/TreeDB/caching/flush_backlog_coalescing_test.go
+++ b/TreeDB/caching/flush_backlog_coalescing_test.go
@@ -433,7 +433,7 @@ func TestFlushCollectionModeSpanNativeFallbackOnlyForClose(t *testing.T) {
 	}
 }
 
-func TestFlushCollectionModeCheckpointCommandWALPublishForcesFallback(t *testing.T) {
+func TestFlushCollectionModeCheckpointCommandWALPublishKeepsSpanNativeEligible(t *testing.T) {
 	db, backend := newCoalescingTestDB(t, Options{
 		FlushApplySpanNative:  true,
 		FlushApplyConcurrency: 4,
@@ -454,12 +454,12 @@ func TestFlushCollectionModeCheckpointCommandWALPublishForcesFallback(t *testing
 	backend.mu.RLock()
 	got := backend.lastSpanNativeFallbackReason
 	backend.mu.RUnlock()
-	if got != backenddb.FlushSpanRunFallbackCommandWALBarrier {
-		t.Fatalf("command WAL checkpoint fallback reason=%s want %s", got, backenddb.FlushSpanRunFallbackCommandWALBarrier)
+	if got.Valid() && got != backenddb.FlushSpanRunFallbackUnknown {
+		t.Fatalf("command WAL checkpoint fallback reason=%s want none", got)
 	}
 }
 
-func TestFlushCollectionModeCheckpointCommandWALPublishOnlyFencesPublishChunk(t *testing.T) {
+func TestFlushCollectionModeCheckpointCommandWALPublishDoesNotFencePublishChunk(t *testing.T) {
 	db, backend := newCoalescingTestDB(t, Options{
 		FlushApplySpanNative:       true,
 		FlushApplyConcurrency:      4,
@@ -487,11 +487,8 @@ func TestFlushCollectionModeCheckpointCommandWALPublishOnlyFencesPublishChunk(t 
 	if writeCalls < 2 {
 		t.Fatalf("backend write calls=%d want multi-chunk flush", writeCalls)
 	}
-	if len(reasons) != 1 {
-		t.Fatalf("explicit fallback reasons=%v want only final publish chunk fenced", reasons)
-	}
-	if got := reasons[0]; got != backenddb.FlushSpanRunFallbackCommandWALBarrier {
-		t.Fatalf("publish chunk fallback reason=%s want %s", got, backenddb.FlushSpanRunFallbackCommandWALBarrier)
+	if len(reasons) != 0 {
+		t.Fatalf("explicit fallback reasons=%v want none for command WAL publish chunk", reasons)
 	}
 }
 

--- a/TreeDB/db/raw_span_native_route_test.go
+++ b/TreeDB/db/raw_span_native_route_test.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"bytes"
 	"errors"
 	"runtime"
 	"strconv"
@@ -303,21 +304,34 @@ func TestRawSpanNativeRouteStatsUnsupportedRowsHaveNamedFallbacks(t *testing.T) 
 	})
 }
 
-func TestRawSpanNativeRouteStatsCommandWALCheckpointPiggybackPreservesBarrierReason(t *testing.T) {
-	d := openExplicitRawSpanNativeRouteTestDB(t)
+func TestRawSpanNativeRouteStatsCommandWALCheckpointPiggybackUsesSpanNativeApply(t *testing.T) {
+	dir := t.TempDir()
+	d, err := Open(Options{
+		Dir:                   dir,
+		FlushAdmissionPolicy:  FlushAdmissionPolicyExplicit,
+		FlushApplySpanNative:  true,
+		FlushApplyConcurrency: 4,
+		FlushApplyMinEntries:  1,
+		FlushApplyMinSpans:    1,
+		FlushApplyMinBytes:    1,
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	key := []byte("checkpoint-command-wal-piggyback")
+	value := []byte("v")
 	batch := d.NewPhysicalBatch()
 	b, ok := batch.(*Batch)
 	if !ok {
 		t.Fatalf("NewPhysicalBatch type=%T, want *Batch", batch)
 	}
-	if err := b.Set([]byte("checkpoint-command-wal-piggyback"), []byte("v")); err != nil {
+	if err := b.Set(key, value); err != nil {
 		t.Fatalf("Set: %v", err)
 	}
-	b.SetFlushApplySpanNativeFallback(FlushSpanRunFallbackCommandWALBarrier)
 	if err := b.SetCommandWALPublish(1, []CommandWALLSNRange{{First: 1, Last: 1}}); err != nil {
 		t.Fatalf("SetCommandWALPublish: %v", err)
 	}
-	if err := b.Write(); err != nil {
+	if err := b.WriteSync(); err != nil {
 		t.Fatalf("Write: %v", err)
 	}
 	if err := b.Close(); err != nil {
@@ -325,17 +339,41 @@ func TestRawSpanNativeRouteStatsCommandWALCheckpointPiggybackPreservesBarrierRea
 	}
 
 	stats := d.Stats()
-	if got := rawSpanNativeRouteStatUint(t, stats, "treedb.raw.span_native.route.point_put.fallback.reason.command_wal_barrier.count_total"); got != 1 {
-		t.Fatalf("point_put command_wal_barrier count=%d, want 1 for raw route stats", got)
+	if got := rawSpanNativeRouteStatUint(t, stats, "treedb.raw.span_native.route.point_put.used_ops_total"); got == 0 {
+		t.Fatalf("point_put used_ops_total=0, want command WAL publish piggyback to use span-native apply")
+	}
+	if got := rawSpanNativeRouteStatUint(t, stats, "treedb.raw.span_native.route.point_put.fallback.reason.command_wal_barrier.count_total"); got != 0 {
+		t.Fatalf("point_put command_wal_barrier count=%d, want 0 for span-native command WAL publish", got)
 	}
 	if got := rawSpanNativeRouteStatUint(t, stats, "treedb.raw.span_native.route.point_put.fallback.reason.span_native_not_implemented.count_total"); got != 0 {
 		t.Fatalf("point_put span_native_not_implemented count=%d, want 0 for explicit command WAL barrier", got)
 	}
-	if got := rawSpanNativeRouteStatUint(t, stats, "treedb.raw.span_native.fallback.reason.command_wal_barrier.count_total"); got != 1 {
-		t.Fatalf("raw command_wal_barrier count=%d, want 1", got)
+	if got := rawSpanNativeRouteStatUint(t, stats, "treedb.raw.span_native.fallback.reason.command_wal_barrier.count_total"); got != 0 {
+		t.Fatalf("raw command_wal_barrier count=%d, want 0", got)
 	}
 	if got := rawSpanNativeRouteStatUint(t, stats, "treedb.raw.span_native.fallback.reason.span_native_not_implemented.count_total"); got != 0 {
 		t.Fatalf("raw span_native_not_implemented count=%d, want 0", got)
+	}
+	if got := d.State().AppliedCommandLSN; got != 1 {
+		t.Fatalf("AppliedCommandLSN=%d, want 1", got)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	reopened, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer func() { _ = reopened.Close() }()
+	if got := reopened.State().AppliedCommandLSN; got != 1 {
+		t.Fatalf("reopened AppliedCommandLSN=%d, want 1", got)
+	}
+	got, err := reopened.Get(key)
+	if err != nil {
+		t.Fatalf("reopened Get: %v", err)
+	}
+	if !bytes.Equal(got, value) {
+		t.Fatalf("reopened value=%q want %q", got, value)
 	}
 }
 


### PR DESCRIPTION
## Linked Issues

- Fixes #3362
- Part of #3317
- Updates #3314
- Evidence lane: #3320

## Celestia Evidence Boundary

This PR targets the post-#3361 strict TreeDB finding that Celestia raw point-put traffic was mostly span-native, but checkpoint command-WAL publish/finalization still forced `command_wal_barrier` fallback for otherwise eligible chunks.

This is not a LevelDB comparison. The evidence below is a strict TreeDB-vs-TreeDB same-snapshot pair.

## Strict Same-Snapshot Evidence

Protocol for both runs:

- trust height/hash: `11714074` / `AC2679168CE4DCFA9AA7355E52A265A2CA6250C9A9392B3EF3BFACA284B5104E`
- required accepted snapshot: `11749500`
- stop target: `11715650`
- dwell: `300s`
- backend: `DB_BACKEND=treedb APP_DB_BACKEND=treedb`

Baseline origin/main:

- gomap: `2a00800bed23252e92a83029a55f1d40d130ff09`
- home: `/home/mikers/.celestia-app-mainnet-treedb-20260629195245`
- sync/total: `284s` / `584s`
- max RSS/HWM: `6,729,240 KiB` / `7,109,412 KiB`
- end app/home/data bytes: `2,260,637,054` / `3,184,338,709` / `3,061,411,617`
- raw candidate/used: `47,345,010` / `43,455,357`
- raw command-WAL barrier fallback: `502` counts, `3,889,653` ops, `127,306` spans
- point-put command-WAL barrier fallback: `36` counts, `2,688,694` ops
- mixed-point command-WAL barrier fallback: `466` counts, `1,200,959` ops
- apply/backend/backlog: `22.858s` apply, `57.696s` backend write, process backlog `0`

Candidate branch run:

- gomap: `7826079b833750964d5e736e994c4ab3539032ab`
- home: `/home/mikers/.celestia-app-mainnet-treedb-20260629200259`
- sync/total: `271s` / `571s`
- max RSS/HWM: `5,926,656 KiB` / `6,739,964 KiB`
- end app/home/data bytes: `2,332,485,486` / `3,256,411,993` / `3,133,866,868`
- raw candidate/used: `47,439,114` / `46,145,556`
- raw command-WAL barrier fallback: `0` counts, `0` ops, `0` spans
- point-put used/candidate: `46,145,556` / `46,145,556`
- remaining raw fallback: `mixed_point` maintenance, `503` counts, `1,293,558` ops, `71,174` spans
- ordered-root/root-native counters: `0` candidate, `0` used
- apply/backend/backlog: `23.288s` apply, `65.457s` backend write, process backlog `0`

Classification:

- Admission question: Celestia is admitted into the raw span-native point-put path after this PR; ordered/root-native is still not exercised.
- Apply limiter question: apply is still single-digit percent of sync (`~8.6%` on the candidate) and process backlog is `0`, so memtable-to-B-tree apply is not the current dominant wall-time limiter in this window.
- HWM/copy pressure: max RSS improved by `802,584 KiB`; max HWM improved by `369,448 KiB`. Treat the `13s` sync/total improvement as directional only because backend write time increased and the final local heights differ during dwell.
- Disk/GC: app DB ended about `71.8MB` larger on the candidate in this short run; no storage win is claimed. Value-log stale/zombie bytes were `0`; leaf-pack GC ran and deleted/reclaimed data in both runs.
- Remaining #3317 blocker: the post-fix nonzero raw fallback is now precisely `mixed_point` maintenance fallback, not command-WAL barrier.

The branch was later merge-updated onto current `origin/main` as `d37399e72` because repository rules block force-push. The merge-updated tree is identical to the rebased tree that passed local tests; the current-base changes are collections/query/docs changes outside the touched command-WAL/caching/db path.

## Change

- Stop forcing `FlushSpanRunFallbackCommandWALBarrier` for the final checkpoint flush chunk solely because it attaches command-WAL checkpoint publish metadata.
- Keep close-drain and range-delete barriers unchanged.
- Keep command-WAL publish metadata on the same physical batch via `SetCommandWALPublish`; the existing `Batch` finalize path still validates contiguous `AppliedCommandLSN` and commits roots plus `AppliedCommandLSN` atomically.

## Correctness Assessment

This does not change command-WAL append ordering, publish locking, replay scanning, cleanup, root validation, range-delete barriers, value-log pointer lifetime, or GC/rewrite behavior.

The new DB-level test proves a physical batch with `SetCommandWALPublish`:

- uses raw span-native apply;
- emits zero raw `command_wal_barrier` fallback;
- publishes `AppliedCommandLSN=1`;
- reopens with the value readable and `AppliedCommandLSN` preserved.

## Local Tests

- `GOWORK=off go test ./TreeDB/caching -run 'TestFlushCollectionModeCheckpointCommandWALPublish(KeepsSpanNativeEligible|DoesNotFencePublishChunk)$' -count=1`
- `GOWORK=off go test ./TreeDB/db -run 'TestRawSpanNativeRouteStatsCommandWALCheckpointPiggybackUsesSpanNativeApply$' -count=1`
- `GOWORK=off go test ./TreeDB/caching -run 'Test(FlushCollectionMode|CanPiggybackCommandWALCheckpointPublish)' -count=1`
- `GOWORK=off go test ./TreeDB/db -run 'Test(RawSpanNativeRouteStats|CommandWALRootsAndAppliedCommandLSNPublishAtomically|CommandWALPublishHelperRejectsRootsWithoutAppliedLSN|CommandWALAppliedLSN|CommandWALOpen|RawKV|CommandWALRawKV)' -count=1`
- `GOWORK=off go test ./TreeDB -run 'TestPublicCommandWALCheckpointPiggybacksAppliedLSN' -count=1`
- `GOWORK=off go test ./TreeDB/caching ./TreeDB/db ./TreeDB -count=1`
- after current-base merge update: `GOWORK=off go test ./TreeDB/caching ./TreeDB/db ./TreeDB -count=1` passed on an identical tree (`TreeDB/caching` `105.728s`, `TreeDB/db` `361.838s`, `TreeDB` `79.876s`)
- `git diff --check`

## PR State

Ready for latest-head CI/review. Do not claim a strict LevelDB-vs-TreeDB result from this PR; the next clean A/B still needs matching trust target, accepted snapshot, stop target, dwell window, local deps, and measurement protocol.
