### PR TITLE
Refresh current-head nativewire YCSB closeout evidence

### DIFF
--- a/docs/benchmarks/nativewire_ycsb_closeout_2026-06-30.md
+++ b/docs/benchmarks/nativewire_ycsb_closeout_2026-06-30.md
@@ -1,13 +1,13 @@
 # TreeDB Nativewire YCSB Closeout Evidence
 
 Status: external `go-ycsb` nativewire load-only closeout evidence for #2026
-and #3355 captured on then-current `origin/main` commit
-`2b784debb05028f706b46127a41f6d578c3d4c13`.
+and #3355 refreshed on current `origin/main` commit
+`1e0450fd06aaea5669150c5c744a3e1d1c6880e2`.
 
-This evidence predates later Raft snapshot/route-preflight merges, including
+This refresh includes the later Raft snapshot/route-preflight merges that the
+first closeout capture predated, including
 `febc1992e58307d8b1edd2c68657faef9bd67c88` and
-`66819cd00fe10aaae2f0da3b7dbfc1ebc0c4113d`; rerun the closeout before using it
-as proof for those newer heads.
+`66819cd00fe10aaae2f0da3b7dbfc1ebc0c4113d`.
 
 This report records the final 100k and 1M nativewire YCSB load checks requested
 by #2026 after the deterministic publication/readability slices landed. It is
@@ -31,8 +31,8 @@ TreeDB:
 
 - profile: `command_wal_relaxed`
 - server: `cmd/treedb-native-server`
-- gomap commit: `2b784debb05028f706b46127a41f6d578c3d4c13`
-- gomap branch: `codex/2026-ycsb-closeout`
+- gomap commit: `1e0450fd06aaea5669150c5c744a3e1d1c6880e2`
+- gomap branch: `codex/2026-current-head-ycsb-20260630`
 
 External client:
 
@@ -64,18 +64,20 @@ clocksource: tsc
 Primary artifact root:
 
 ```text
-/tmp/treedb_native_ycsb_closeout_20260629_173744
+/tmp/treedb_native_ycsb_current_head_20260629_195546
 ```
 
 Primary artifacts:
 
 ```text
-/tmp/treedb_native_ycsb_closeout_20260629_173744/host.txt
-/tmp/treedb_native_ycsb_closeout_20260629_173744/commands.txt
-/tmp/treedb_native_ycsb_closeout_20260629_173744/summary.tsv
-/tmp/treedb_native_ycsb_closeout_20260629_173744/summary.md
-/tmp/treedb_native_ycsb_closeout_20260629_173744/100000/load.out
-/tmp/treedb_native_ycsb_closeout_20260629_173744/1000000/load.out
+/tmp/treedb_native_ycsb_current_head_20260629_195546/host.txt
+/tmp/treedb_native_ycsb_current_head_20260629_195546/commands.txt
+/tmp/treedb_native_ycsb_current_head_20260629_195546/summary.tsv
+/tmp/treedb_native_ycsb_current_head_20260629_195546/error_counts.txt
+/tmp/treedb_native_ycsb_current_head_20260629_195546/100000/load.out
+/tmp/treedb_native_ycsb_current_head_20260629_195546/100000/server.log
+/tmp/treedb_native_ycsb_current_head_20260629_195546/1000000/load.out
+/tmp/treedb_native_ycsb_current_head_20260629_195546/1000000/server.log
 ```
 
 ## Focused Gates
@@ -102,8 +104,8 @@ make build
 
 | recordcount | INSERT count | INSERT ops/sec | INSERT avg us | INSERT p50 us | INSERT p95 us | INSERT p99 us | INSERT p99.9 us | INSERT max us | INSERT_ERROR |
 | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-| 100,000 | 100,000 | 69,863.1 | 211.0 | 187.0 | 348.0 | 544.0 | 3,149.0 | 8,767.0 | 0 |
-| 1,000,000 | 1,000,000 | 44,118.3 | 346.0 | 203.0 | 370.0 | 537.0 | 1,521.0 | 6,717,439.0 | 0 |
+| 100,000 | 100,000 | 54,929.6 | 274.0 | 224.0 | 511.0 | 1,156.0 | 4,255.0 | 19,103.0 | 0 |
+| 1,000,000 | 1,000,000 | 39,299.1 | 389.0 | 233.0 | 447.0 | 700.0 | 2,623.0 | 6,946,815.0 | 0 |
 
 The 1M load emitted periodic progress rows at 10s and 20s before the final
 1,000,000-row summary. The table above uses the final post-run row.
@@ -115,31 +117,31 @@ server command and keep it running while executing the matching `go-ycsb load`
 command, then stop it before starting the next recordcount:
 
 ```sh
-cd /home/mikers/dev/snissn/gomap-2026-ycsb-closeout
+cd /home/mikers/dev/snissn/gomap-2026-current-head-ycsb-20260630
 
 GOWORK=off go build -o bin/treedb-native-server ./cmd/treedb-native-server
 
 cd /home/mikers/dev/pingcap/go-ycsb-2026-meta-v5
 make build
 
-/home/mikers/dev/snissn/gomap-2026-ycsb-closeout/bin/treedb-native-server \
-  -dir /tmp/treedb_native_ycsb_closeout_20260629_173744/100000/db \
+/home/mikers/dev/snissn/gomap-2026-current-head-ycsb-20260630/bin/treedb-native-server \
+  -dir /tmp/treedb_native_ycsb_current_head_20260629_195546/100000/db \
   -profile command_wal_relaxed \
-  -addr 127.0.0.1:17155
+  -addr 127.0.0.1:17165
 
 /home/mikers/dev/pingcap/go-ycsb-2026-meta-v5/bin/go-ycsb load treedb-native \
-  -p treedb.addr=127.0.0.1:17155 \
+  -p treedb.addr=127.0.0.1:17165 \
   -p recordcount=100000 \
   -p operationcount=10000 \
   -p threadcount=16
 
-/home/mikers/dev/snissn/gomap-2026-ycsb-closeout/bin/treedb-native-server \
-  -dir /tmp/treedb_native_ycsb_closeout_20260629_173744/1000000/db \
+/home/mikers/dev/snissn/gomap-2026-current-head-ycsb-20260630/bin/treedb-native-server \
+  -dir /tmp/treedb_native_ycsb_current_head_20260629_195546/1000000/db \
   -profile command_wal_relaxed \
-  -addr 127.0.0.1:17156
+  -addr 127.0.0.1:17166
 
 /home/mikers/dev/pingcap/go-ycsb-2026-meta-v5/bin/go-ycsb load treedb-native \
-  -p treedb.addr=127.0.0.1:17156 \
+  -p treedb.addr=127.0.0.1:17166 \
   -p recordcount=1000000 \
   -p operationcount=10000 \
   -p threadcount=16
@@ -149,6 +151,8 @@ make build
 
 This closeout run proves the compatible external nativewire YCSB client can load
 100k and 1M records against the current `command_wal_relaxed` TreeDB nativewire
-server with zero insert errors on this host. It supports #2026 closeout for the
-external YCSB evidence requirement, while the deterministic publication and
-readability proof remains documented by the issue and its earlier test PRs.
+server with zero insert errors on this host. The refreshed capture removes the
+stale-head caveat from the earlier `2b784debb05028f706b46127a41f6d578c3d4c13`
+run. It supports #2026 closeout for the external YCSB evidence requirement,
+while the deterministic publication and readability proof remains documented by
+the issue and its earlier test PRs.

--- a/docs/benchmarks/nativewire_ycsb_closeout_2026-06-30.md
+++ b/docs/benchmarks/nativewire_ycsb_closeout_2026-06-30.md
@@ -2,12 +2,14 @@
 
 Status: external `go-ycsb` nativewire load-only closeout evidence for #2026
 and #3355 refreshed on current `origin/main` commit
-`be2cfe6fb0ac4bec62a4b8c89915a910f8ac011a`.
+`12b2bf3b17ea3455551a9c47243f0194a59ee1a0`.
 
 This refresh includes the later Raft snapshot/route-preflight merges that the
 first closeout capture predated, including
 `febc1992e58307d8b1edd2c68657faef9bd67c88` and
-`66819cd00fe10aaae2f0da3b7dbfc1ebc0c4113d`.
+`66819cd00fe10aaae2f0da3b7dbfc1ebc0c4113d`, plus the latest
+span-native command-WAL publish merge at
+`12b2bf3b17ea3455551a9c47243f0194a59ee1a0`.
 
 This report records the final 100k and 1M nativewire YCSB load checks requested
 by #2026 after the deterministic publication/readability slices landed. It is
@@ -31,8 +33,8 @@ TreeDB:
 
 - profile: `command_wal_relaxed`
 - server: `cmd/treedb-native-server`
-- gomap code base: `be2cfe6fb0ac4bec62a4b8c89915a910f8ac011a`
-- capture branch commit: `f5206eaa383f9bd43c917712cda88c7128dee367`
+- gomap code base: `12b2bf3b17ea3455551a9c47243f0194a59ee1a0`
+- capture branch commit: `73678ffa9b65ece9c02bd4cab88a8793768e05ca`
 - gomap branch: `codex/2026-current-head-ycsb-20260630`
 
 External client:
@@ -65,20 +67,20 @@ clocksource: tsc
 Primary artifact root:
 
 ```text
-/tmp/treedb_native_ycsb_current_head_20260629_202633
+/tmp/treedb_native_ycsb_current_head_20260629_210053
 ```
 
 Primary artifacts:
 
 ```text
-/tmp/treedb_native_ycsb_current_head_20260629_202633/host.txt
-/tmp/treedb_native_ycsb_current_head_20260629_202633/commands.txt
-/tmp/treedb_native_ycsb_current_head_20260629_202633/summary.tsv
-/tmp/treedb_native_ycsb_current_head_20260629_202633/error_counts.txt
-/tmp/treedb_native_ycsb_current_head_20260629_202633/100000/load.out
-/tmp/treedb_native_ycsb_current_head_20260629_202633/100000/server.log
-/tmp/treedb_native_ycsb_current_head_20260629_202633/1000000/load.out
-/tmp/treedb_native_ycsb_current_head_20260629_202633/1000000/server.log
+/tmp/treedb_native_ycsb_current_head_20260629_210053/host.txt
+/tmp/treedb_native_ycsb_current_head_20260629_210053/commands.txt
+/tmp/treedb_native_ycsb_current_head_20260629_210053/summary_raw.tsv
+/tmp/treedb_native_ycsb_current_head_20260629_210053/error_counts.txt
+/tmp/treedb_native_ycsb_current_head_20260629_210053/100000/load.out
+/tmp/treedb_native_ycsb_current_head_20260629_210053/100000/server.log
+/tmp/treedb_native_ycsb_current_head_20260629_210053/1000000/load.out
+/tmp/treedb_native_ycsb_current_head_20260629_210053/1000000/server.log
 ```
 
 ## Focused Gates
@@ -105,8 +107,8 @@ make build
 
 | recordcount | INSERT count | INSERT ops/sec | INSERT avg us | INSERT p50 us | INSERT p95 us | INSERT p99 us | INSERT p99.9 us | INSERT max us | INSERT_ERROR |
 | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-| 100,000 | 100,000 | 51,139.8 | 292.0 | 255.0 | 534.0 | 879.0 | 2,537.0 | 8,447.0 | 0 |
-| 1,000,000 | 1,000,000 | 40,783.7 | 369.0 | 260.0 | 548.0 | 922.0 | 2,941.0 | 960,511.0 | 0 |
+| 100,000 | 100,000 | 61,837.1 | 241.0 | 217.0 | 405.0 | 586.0 | 1,269.0 | 17,887.0 | 0 |
+| 1,000,000 | 1,000,000 | 44,379.0 | 340.0 | 265.0 | 560.0 | 925.0 | 2,611.0 | 1,030,655.0 | 0 |
 
 The 1M load emitted periodic progress rows at 10s and 20s before the final
 1,000,000-row summary. The table above uses the final post-run row.
@@ -126,23 +128,23 @@ cd /home/mikers/dev/pingcap/go-ycsb-2026-meta-v5
 make build
 
 /home/mikers/dev/snissn/gomap-2026-current-head-ycsb-20260630/bin/treedb-native-server \
-  -dir /tmp/treedb_native_ycsb_current_head_20260629_202633/100000/db \
+  -dir /tmp/treedb_native_ycsb_current_head_20260629_210053/100000/db \
   -profile command_wal_relaxed \
-  -addr 127.0.0.1:17178
+  -addr 127.0.0.1:17280
 
 /home/mikers/dev/pingcap/go-ycsb-2026-meta-v5/bin/go-ycsb load treedb-native \
-  -p treedb.addr=127.0.0.1:17178 \
+  -p treedb.addr=127.0.0.1:17280 \
   -p recordcount=100000 \
   -p operationcount=10000 \
   -p threadcount=16
 
 /home/mikers/dev/snissn/gomap-2026-current-head-ycsb-20260630/bin/treedb-native-server \
-  -dir /tmp/treedb_native_ycsb_current_head_20260629_202633/1000000/db \
+  -dir /tmp/treedb_native_ycsb_current_head_20260629_210053/1000000/db \
   -profile command_wal_relaxed \
-  -addr 127.0.0.1:17179
+  -addr 127.0.0.1:17281
 
 /home/mikers/dev/pingcap/go-ycsb-2026-meta-v5/bin/go-ycsb load treedb-native \
-  -p treedb.addr=127.0.0.1:17179 \
+  -p treedb.addr=127.0.0.1:17281 \
   -p recordcount=1000000 \
   -p operationcount=10000 \
   -p threadcount=16

--- a/docs/benchmarks/nativewire_ycsb_closeout_2026-06-30.md
+++ b/docs/benchmarks/nativewire_ycsb_closeout_2026-06-30.md
@@ -2,7 +2,7 @@
 
 Status: external `go-ycsb` nativewire load-only closeout evidence for #2026
 and #3355 refreshed on current `origin/main` commit
-`1e0450fd06aaea5669150c5c744a3e1d1c6880e2`.
+`be2cfe6fb0ac4bec62a4b8c89915a910f8ac011a`.
 
 This refresh includes the later Raft snapshot/route-preflight merges that the
 first closeout capture predated, including
@@ -31,7 +31,8 @@ TreeDB:
 
 - profile: `command_wal_relaxed`
 - server: `cmd/treedb-native-server`
-- gomap commit: `1e0450fd06aaea5669150c5c744a3e1d1c6880e2`
+- gomap code base: `be2cfe6fb0ac4bec62a4b8c89915a910f8ac011a`
+- capture branch commit: `f5206eaa383f9bd43c917712cda88c7128dee367`
 - gomap branch: `codex/2026-current-head-ycsb-20260630`
 
 External client:
@@ -64,20 +65,20 @@ clocksource: tsc
 Primary artifact root:
 
 ```text
-/tmp/treedb_native_ycsb_current_head_20260629_195546
+/tmp/treedb_native_ycsb_current_head_20260629_202633
 ```
 
 Primary artifacts:
 
 ```text
-/tmp/treedb_native_ycsb_current_head_20260629_195546/host.txt
-/tmp/treedb_native_ycsb_current_head_20260629_195546/commands.txt
-/tmp/treedb_native_ycsb_current_head_20260629_195546/summary.tsv
-/tmp/treedb_native_ycsb_current_head_20260629_195546/error_counts.txt
-/tmp/treedb_native_ycsb_current_head_20260629_195546/100000/load.out
-/tmp/treedb_native_ycsb_current_head_20260629_195546/100000/server.log
-/tmp/treedb_native_ycsb_current_head_20260629_195546/1000000/load.out
-/tmp/treedb_native_ycsb_current_head_20260629_195546/1000000/server.log
+/tmp/treedb_native_ycsb_current_head_20260629_202633/host.txt
+/tmp/treedb_native_ycsb_current_head_20260629_202633/commands.txt
+/tmp/treedb_native_ycsb_current_head_20260629_202633/summary.tsv
+/tmp/treedb_native_ycsb_current_head_20260629_202633/error_counts.txt
+/tmp/treedb_native_ycsb_current_head_20260629_202633/100000/load.out
+/tmp/treedb_native_ycsb_current_head_20260629_202633/100000/server.log
+/tmp/treedb_native_ycsb_current_head_20260629_202633/1000000/load.out
+/tmp/treedb_native_ycsb_current_head_20260629_202633/1000000/server.log
 ```
 
 ## Focused Gates
@@ -104,8 +105,8 @@ make build
 
 | recordcount | INSERT count | INSERT ops/sec | INSERT avg us | INSERT p50 us | INSERT p95 us | INSERT p99 us | INSERT p99.9 us | INSERT max us | INSERT_ERROR |
 | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-| 100,000 | 100,000 | 54,929.6 | 274.0 | 224.0 | 511.0 | 1,156.0 | 4,255.0 | 19,103.0 | 0 |
-| 1,000,000 | 1,000,000 | 39,299.1 | 389.0 | 233.0 | 447.0 | 700.0 | 2,623.0 | 6,946,815.0 | 0 |
+| 100,000 | 100,000 | 51,139.8 | 292.0 | 255.0 | 534.0 | 879.0 | 2,537.0 | 8,447.0 | 0 |
+| 1,000,000 | 1,000,000 | 40,783.7 | 369.0 | 260.0 | 548.0 | 922.0 | 2,941.0 | 960,511.0 | 0 |
 
 The 1M load emitted periodic progress rows at 10s and 20s before the final
 1,000,000-row summary. The table above uses the final post-run row.
@@ -125,23 +126,23 @@ cd /home/mikers/dev/pingcap/go-ycsb-2026-meta-v5
 make build
 
 /home/mikers/dev/snissn/gomap-2026-current-head-ycsb-20260630/bin/treedb-native-server \
-  -dir /tmp/treedb_native_ycsb_current_head_20260629_195546/100000/db \
+  -dir /tmp/treedb_native_ycsb_current_head_20260629_202633/100000/db \
   -profile command_wal_relaxed \
-  -addr 127.0.0.1:17165
+  -addr 127.0.0.1:17178
 
 /home/mikers/dev/pingcap/go-ycsb-2026-meta-v5/bin/go-ycsb load treedb-native \
-  -p treedb.addr=127.0.0.1:17165 \
+  -p treedb.addr=127.0.0.1:17178 \
   -p recordcount=100000 \
   -p operationcount=10000 \
   -p threadcount=16
 
 /home/mikers/dev/snissn/gomap-2026-current-head-ycsb-20260630/bin/treedb-native-server \
-  -dir /tmp/treedb_native_ycsb_current_head_20260629_195546/1000000/db \
+  -dir /tmp/treedb_native_ycsb_current_head_20260629_202633/1000000/db \
   -profile command_wal_relaxed \
-  -addr 127.0.0.1:17166
+  -addr 127.0.0.1:17179
 
 /home/mikers/dev/pingcap/go-ycsb-2026-meta-v5/bin/go-ycsb load treedb-native \
-  -p treedb.addr=127.0.0.1:17166 \
+  -p treedb.addr=127.0.0.1:17179 \
   -p recordcount=1000000 \
   -p operationcount=10000 \
   -p threadcount=16
@@ -156,3 +157,10 @@ stale-head caveat from the earlier `2b784debb05028f706b46127a41f6d578c3d4c13`
 run. It supports #2026 closeout for the external YCSB evidence requirement,
 while the deterministic publication and readability proof remains documented by
 the issue and its earlier test PRs.
+
+During the current-base refresh, an invalid intermediate 1M run at
+`/tmp/treedb_native_ycsb_current_head_20260629_202356` stopped at 768,001
+successful inserts and reported `INSERT_ERROR`; its server log had no panic,
+fatal error, EOF, or ambiguous-commit marker. A clean 1M rerun and the final
+paired capture above both completed with zero `INSERT_ERROR`. Keep #2026 open
+for the deeper publication/readability invariant and intermittent-failure proof.

--- a/docs/benchmarks/nativewire_ycsb_closeout_2026-06-30.md
+++ b/docs/benchmarks/nativewire_ycsb_closeout_2026-06-30.md
@@ -2,14 +2,15 @@
 
 Status: external `go-ycsb` nativewire load-only closeout evidence for #2026
 and #3355 refreshed on current `origin/main` commit
-`12b2bf3b17ea3455551a9c47243f0194a59ee1a0`.
+`61910b8eac108c5f2c35f07a374879d1fb2dc5c8`.
 
 This refresh includes the later Raft snapshot/route-preflight merges that the
 first closeout capture predated, including
 `febc1992e58307d8b1edd2c68657faef9bd67c88` and
 `66819cd00fe10aaae2f0da3b7dbfc1ebc0c4113d`, plus the latest
 span-native command-WAL publish merge at
-`12b2bf3b17ea3455551a9c47243f0194a59ee1a0`.
+`12b2bf3b17ea3455551a9c47243f0194a59ee1a0` and mixed-maintenance fallback
+coverage at `61910b8eac108c5f2c35f07a374879d1fb2dc5c8`.
 
 This report records the final 100k and 1M nativewire YCSB load checks requested
 by #2026 after the deterministic publication/readability slices landed. It is
@@ -33,8 +34,8 @@ TreeDB:
 
 - profile: `command_wal_relaxed`
 - server: `cmd/treedb-native-server`
-- gomap code base: `12b2bf3b17ea3455551a9c47243f0194a59ee1a0`
-- capture branch commit: `73678ffa9b65ece9c02bd4cab88a8793768e05ca`
+- gomap code base: `61910b8eac108c5f2c35f07a374879d1fb2dc5c8`
+- capture branch commit: `2041a2a2de55e0bb8b6d7d6201c57c989fa4e272`
 - gomap branch: `codex/2026-current-head-ycsb-20260630`
 
 External client:
@@ -67,20 +68,20 @@ clocksource: tsc
 Primary artifact root:
 
 ```text
-/tmp/treedb_native_ycsb_current_head_20260629_210053
+/tmp/treedb_native_ycsb_current_head_20260629_212711
 ```
 
 Primary artifacts:
 
 ```text
-/tmp/treedb_native_ycsb_current_head_20260629_210053/host.txt
-/tmp/treedb_native_ycsb_current_head_20260629_210053/commands.txt
-/tmp/treedb_native_ycsb_current_head_20260629_210053/summary_raw.tsv
-/tmp/treedb_native_ycsb_current_head_20260629_210053/error_counts.txt
-/tmp/treedb_native_ycsb_current_head_20260629_210053/100000/load.out
-/tmp/treedb_native_ycsb_current_head_20260629_210053/100000/server.log
-/tmp/treedb_native_ycsb_current_head_20260629_210053/1000000/load.out
-/tmp/treedb_native_ycsb_current_head_20260629_210053/1000000/server.log
+/tmp/treedb_native_ycsb_current_head_20260629_212711/host.txt
+/tmp/treedb_native_ycsb_current_head_20260629_212711/commands.txt
+/tmp/treedb_native_ycsb_current_head_20260629_212711/summary_raw.tsv
+/tmp/treedb_native_ycsb_current_head_20260629_212711/error_counts.txt
+/tmp/treedb_native_ycsb_current_head_20260629_212711/100000/load.out
+/tmp/treedb_native_ycsb_current_head_20260629_212711/100000/server.log
+/tmp/treedb_native_ycsb_current_head_20260629_212711/1000000/load.out
+/tmp/treedb_native_ycsb_current_head_20260629_212711/1000000/server.log
 ```
 
 ## Focused Gates
@@ -107,8 +108,8 @@ make build
 
 | recordcount | INSERT count | INSERT ops/sec | INSERT avg us | INSERT p50 us | INSERT p95 us | INSERT p99 us | INSERT p99.9 us | INSERT max us | INSERT_ERROR |
 | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-| 100,000 | 100,000 | 61,837.1 | 241.0 | 217.0 | 405.0 | 586.0 | 1,269.0 | 17,887.0 | 0 |
-| 1,000,000 | 1,000,000 | 44,379.0 | 340.0 | 265.0 | 560.0 | 925.0 | 2,611.0 | 1,030,655.0 | 0 |
+| 100,000 | 100,000 | 59,711.0 | 250.0 | 222.0 | 439.0 | 714.0 | 1,523.0 | 14,607.0 | 0 |
+| 1,000,000 | 1,000,000 | 45,196.8 | 334.0 | 259.0 | 538.0 | 902.0 | 2,539.0 | 939,007.0 | 0 |
 
 The 1M load emitted periodic progress rows at 10s and 20s before the final
 1,000,000-row summary. The table above uses the final post-run row.
@@ -128,23 +129,23 @@ cd /home/mikers/dev/pingcap/go-ycsb-2026-meta-v5
 make build
 
 /home/mikers/dev/snissn/gomap-2026-current-head-ycsb-20260630/bin/treedb-native-server \
-  -dir /tmp/treedb_native_ycsb_current_head_20260629_210053/100000/db \
+  -dir /tmp/treedb_native_ycsb_current_head_20260629_212711/100000/db \
   -profile command_wal_relaxed \
-  -addr 127.0.0.1:17280
+  -addr 127.0.0.1:17282
 
 /home/mikers/dev/pingcap/go-ycsb-2026-meta-v5/bin/go-ycsb load treedb-native \
-  -p treedb.addr=127.0.0.1:17280 \
+  -p treedb.addr=127.0.0.1:17282 \
   -p recordcount=100000 \
   -p operationcount=10000 \
   -p threadcount=16
 
 /home/mikers/dev/snissn/gomap-2026-current-head-ycsb-20260630/bin/treedb-native-server \
-  -dir /tmp/treedb_native_ycsb_current_head_20260629_210053/1000000/db \
+  -dir /tmp/treedb_native_ycsb_current_head_20260629_212711/1000000/db \
   -profile command_wal_relaxed \
-  -addr 127.0.0.1:17281
+  -addr 127.0.0.1:17283
 
 /home/mikers/dev/pingcap/go-ycsb-2026-meta-v5/bin/go-ycsb load treedb-native \
-  -p treedb.addr=127.0.0.1:17281 \
+  -p treedb.addr=127.0.0.1:17283 \
   -p recordcount=1000000 \
   -p operationcount=10000 \
   -p threadcount=16

--- a/docs/benchmarks/ycsb_mongodb_treedb_current.md
+++ b/docs/benchmarks/ycsb_mongodb_treedb_current.md
@@ -32,7 +32,7 @@ For the #2026 publication/readability closeout, use
 nativewire load-only closeout evidence refreshed on current `origin/main`.
 That report uses the compatible external `go-ycsb` branch for
 `collection_meta` version 5, runs 100k and 1M `treedb-native` loads on commit
-`be2cfe6fb0ac4bec62a4b8c89915a910f8ac011a`, and records zero `INSERT_ERROR`
+`12b2bf3b17ea3455551a9c47243f0194a59ee1a0`, and records zero `INSERT_ERROR`
 counts. It includes the later Raft snapshot/route-preflight merges, but does
 not replace the full comparison matrix above. The report also records one
 invalid intermediate 1M run that hit `INSERT_ERROR`; keep #2026 open for the
@@ -57,7 +57,7 @@ UTC latest-main report.
 
 | report | status | use |
 | --- | --- | --- |
-| `docs/benchmarks/nativewire_ycsb_closeout_2026-06-30.md` | #2026 nativewire load-only closeout evidence refreshed after later Raft merges. | Use for the 100k and 1M external `go-ycsb treedb-native` load proof on commit `be2cfe6fb0ac4bec62a4b8c89915a910f8ac011a` with `collection_meta` v5 compatibility; note the recorded invalid intermediate 1M run before claiming intermittent-failure closure. |
+| `docs/benchmarks/nativewire_ycsb_closeout_2026-06-30.md` | #2026 nativewire load-only closeout evidence refreshed after later Raft merges. | Use for the 100k and 1M external `go-ycsb treedb-native` load proof on commit `12b2bf3b17ea3455551a9c47243f0194a59ee1a0` with `collection_meta` v5 compatibility; note the recorded invalid intermediate 1M run before claiming intermittent-failure closure. |
 | `docs/benchmarks/ycsb_latest_main_2026-06-03.md` | Current external YCSB report. | Use for current headline MongoDB / TreeDB nativewire / TreeDB Mongo gateway results on latest `origin/main` after the June 3 rerun. |
 | `docs/benchmarks/ycsb_post_update_stack_2026-06-02.md` | Superseded latest-current report. | Keep for post-update-path-stack evidence before the latest main rerun and for comparison deltas. |
 | `docs/benchmarks/ycsb_mongodb_treedb_2026-05-31.md` | Historical legacy-profile report. | Keep for the original MongoDB / TreeDB native / TreeDB Mongo comparison and the post-load Mongo-gateway cliff attribution. Do not use its `fast` rows as current public-profile guidance. |

--- a/docs/benchmarks/ycsb_mongodb_treedb_current.md
+++ b/docs/benchmarks/ycsb_mongodb_treedb_current.md
@@ -32,9 +32,11 @@ For the #2026 publication/readability closeout, use
 nativewire load-only closeout evidence refreshed on current `origin/main`.
 That report uses the compatible external `go-ycsb` branch for
 `collection_meta` version 5, runs 100k and 1M `treedb-native` loads on commit
-`1e0450fd06aaea5669150c5c744a3e1d1c6880e2`, and records zero `INSERT_ERROR`
+`be2cfe6fb0ac4bec62a4b8c89915a910f8ac011a`, and records zero `INSERT_ERROR`
 counts. It includes the later Raft snapshot/route-preflight merges, but does
-not replace the full comparison matrix above.
+not replace the full comparison matrix above. The report also records one
+invalid intermediate 1M run that hit `INSERT_ERROR`; keep #2026 open for the
+deeper publication/readability invariant and intermittent-failure proof.
 
 ## Current Headline
 
@@ -55,7 +57,7 @@ UTC latest-main report.
 
 | report | status | use |
 | --- | --- | --- |
-| `docs/benchmarks/nativewire_ycsb_closeout_2026-06-30.md` | #2026 nativewire load-only closeout evidence refreshed after later Raft merges. | Use for the 100k and 1M external `go-ycsb treedb-native` load proof on commit `1e0450fd06aaea5669150c5c744a3e1d1c6880e2` with `collection_meta` v5 compatibility. |
+| `docs/benchmarks/nativewire_ycsb_closeout_2026-06-30.md` | #2026 nativewire load-only closeout evidence refreshed after later Raft merges. | Use for the 100k and 1M external `go-ycsb treedb-native` load proof on commit `be2cfe6fb0ac4bec62a4b8c89915a910f8ac011a` with `collection_meta` v5 compatibility; note the recorded invalid intermediate 1M run before claiming intermittent-failure closure. |
 | `docs/benchmarks/ycsb_latest_main_2026-06-03.md` | Current external YCSB report. | Use for current headline MongoDB / TreeDB nativewire / TreeDB Mongo gateway results on latest `origin/main` after the June 3 rerun. |
 | `docs/benchmarks/ycsb_post_update_stack_2026-06-02.md` | Superseded latest-current report. | Keep for post-update-path-stack evidence before the latest main rerun and for comparison deltas. |
 | `docs/benchmarks/ycsb_mongodb_treedb_2026-05-31.md` | Historical legacy-profile report. | Keep for the original MongoDB / TreeDB native / TreeDB Mongo comparison and the post-load Mongo-gateway cliff attribution. Do not use its `fast` rows as current public-profile guidance. |

--- a/docs/benchmarks/ycsb_mongodb_treedb_current.md
+++ b/docs/benchmarks/ycsb_mongodb_treedb_current.md
@@ -29,12 +29,12 @@ this rerun used a temporary external `go-ycsb` compatibility patch so the
 
 For the #2026 publication/readability closeout, use
 `docs/benchmarks/nativewire_ycsb_closeout_2026-06-30.md` as the #2026
-nativewire load-only closeout evidence captured on then-current `origin/main`.
+nativewire load-only closeout evidence refreshed on current `origin/main`.
 That report uses the compatible external `go-ycsb` branch for
 `collection_meta` version 5, runs 100k and 1M `treedb-native` loads on commit
-`2b784debb05028f706b46127a41f6d578c3d4c13`, and records zero `INSERT_ERROR`
-counts. It predates later Raft snapshot/route-preflight merges and does not
-replace the full comparison matrix above.
+`1e0450fd06aaea5669150c5c744a3e1d1c6880e2`, and records zero `INSERT_ERROR`
+counts. It includes the later Raft snapshot/route-preflight merges, but does
+not replace the full comparison matrix above.
 
 ## Current Headline
 
@@ -55,7 +55,7 @@ UTC latest-main report.
 
 | report | status | use |
 | --- | --- | --- |
-| `docs/benchmarks/nativewire_ycsb_closeout_2026-06-30.md` | #2026 nativewire load-only closeout evidence captured before later Raft merges. | Use for the 100k and 1M external `go-ycsb treedb-native` load proof on commit `2b784debb05028f706b46127a41f6d578c3d4c13` with `collection_meta` v5 compatibility; rerun before treating it as proof for newer heads. |
+| `docs/benchmarks/nativewire_ycsb_closeout_2026-06-30.md` | #2026 nativewire load-only closeout evidence refreshed after later Raft merges. | Use for the 100k and 1M external `go-ycsb treedb-native` load proof on commit `1e0450fd06aaea5669150c5c744a3e1d1c6880e2` with `collection_meta` v5 compatibility. |
 | `docs/benchmarks/ycsb_latest_main_2026-06-03.md` | Current external YCSB report. | Use for current headline MongoDB / TreeDB nativewire / TreeDB Mongo gateway results on latest `origin/main` after the June 3 rerun. |
 | `docs/benchmarks/ycsb_post_update_stack_2026-06-02.md` | Superseded latest-current report. | Keep for post-update-path-stack evidence before the latest main rerun and for comparison deltas. |
 | `docs/benchmarks/ycsb_mongodb_treedb_2026-05-31.md` | Historical legacy-profile report. | Keep for the original MongoDB / TreeDB native / TreeDB Mongo comparison and the post-load Mongo-gateway cliff attribution. Do not use its `fast` rows as current public-profile guidance. |

--- a/docs/benchmarks/ycsb_mongodb_treedb_current.md
+++ b/docs/benchmarks/ycsb_mongodb_treedb_current.md
@@ -32,7 +32,7 @@ For the #2026 publication/readability closeout, use
 nativewire load-only closeout evidence refreshed on current `origin/main`.
 That report uses the compatible external `go-ycsb` branch for
 `collection_meta` version 5, runs 100k and 1M `treedb-native` loads on commit
-`12b2bf3b17ea3455551a9c47243f0194a59ee1a0`, and records zero `INSERT_ERROR`
+`61910b8eac108c5f2c35f07a374879d1fb2dc5c8`, and records zero `INSERT_ERROR`
 counts. It includes the later Raft snapshot/route-preflight merges, but does
 not replace the full comparison matrix above. The report also records one
 invalid intermediate 1M run that hit `INSERT_ERROR`; keep #2026 open for the
@@ -57,7 +57,7 @@ UTC latest-main report.
 
 | report | status | use |
 | --- | --- | --- |
-| `docs/benchmarks/nativewire_ycsb_closeout_2026-06-30.md` | #2026 nativewire load-only closeout evidence refreshed after later Raft merges. | Use for the 100k and 1M external `go-ycsb treedb-native` load proof on commit `12b2bf3b17ea3455551a9c47243f0194a59ee1a0` with `collection_meta` v5 compatibility; note the recorded invalid intermediate 1M run before claiming intermittent-failure closure. |
+| `docs/benchmarks/nativewire_ycsb_closeout_2026-06-30.md` | #2026 nativewire load-only closeout evidence refreshed after later Raft merges. | Use for the 100k and 1M external `go-ycsb treedb-native` load proof on commit `61910b8eac108c5f2c35f07a374879d1fb2dc5c8` with `collection_meta` v5 compatibility; note the recorded invalid intermediate 1M run before claiming intermittent-failure closure. |
 | `docs/benchmarks/ycsb_latest_main_2026-06-03.md` | Current external YCSB report. | Use for current headline MongoDB / TreeDB nativewire / TreeDB Mongo gateway results on latest `origin/main` after the June 3 rerun. |
 | `docs/benchmarks/ycsb_post_update_stack_2026-06-02.md` | Superseded latest-current report. | Keep for post-update-path-stack evidence before the latest main rerun and for comparison deltas. |
 | `docs/benchmarks/ycsb_mongodb_treedb_2026-05-31.md` | Historical legacy-profile report. | Keep for the original MongoDB / TreeDB native / TreeDB Mongo comparison and the post-load Mongo-gateway cliff attribution. Do not use its `fast` rows as current public-profile guidance. |


### PR DESCRIPTION
Refs #2026
Refs #3044
Refs #3045
Refs #3046

## Summary

- Refresh `docs/benchmarks/nativewire_ycsb_closeout_2026-06-30.md` to current `origin/main` code base `61910b8eac108c5f2c35f07a374879d1fb2dc5c8`.
- Record fresh 100k and 1M external `go-ycsb load treedb-native` runs against `command_wal_relaxed` with zero `INSERT_ERROR` in the accepted paired capture.
- Update `docs/benchmarks/ycsb_mongodb_treedb_current.md` so the #2026 closeout entry points at the latest current-head proof.
- Preserve the #2026 caveat: one invalid intermediate restack run reported `INSERT_ERROR`, so this PR does not close the deeper intermittent-failure/root-cause proof.

## Evidence

Accepted artifact root:

```text
/tmp/treedb_native_ycsb_current_head_20260629_212711
```

Load results:

| recordcount | INSERT count | INSERT ops/sec | INSERT avg us | INSERT p50 us | INSERT p95 us | INSERT p99 us | INSERT p99.9 us | INSERT max us | INSERT_ERROR |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 100,000 | 100,000 | 59,711.0 | 250.0 | 222.0 | 439.0 | 714.0 | 1,523.0 | 14,607.0 | 0 |
| 1,000,000 | 1,000,000 | 45,196.8 | 334.0 | 259.0 | 538.0 | 902.0 | 2,539.0 | 939,007.0 | 0 |

Invalid intermediate artifact still recorded in the docs:

```text
/tmp/treedb_native_ycsb_current_head_20260629_202356
```

That invalid 1M run stopped at 768,001 successful inserts and reported `INSERT_ERROR`; its server log had no panic, fatal error, EOF, or ambiguous-commit marker. Later clean 1M reruns and the accepted final paired capture completed with zero `INSERT_ERROR`.

## Validation

```sh
GOWORK=off go test ./cmd/treedb-native-server ./TreeDB/nativewire ./TreeDB/collections ./TreeDB/db -count=1
GOWORK=off go build -o bin/treedb-native-server ./cmd/treedb-native-server

cd /home/mikers/dev/pingcap/go-ycsb-2026-meta-v5
go test ./db/treedbnative -count=1
make build

/home/mikers/dev/pingcap/go-ycsb-2026-meta-v5/bin/go-ycsb load treedb-native \
  -p treedb.addr=127.0.0.1:17282 \
  -p recordcount=100000 \
  -p operationcount=10000 \
  -p threadcount=16

/home/mikers/dev/pingcap/go-ycsb-2026-meta-v5/bin/go-ycsb load treedb-native \
  -p treedb.addr=127.0.0.1:17283 \
  -p recordcount=1000000 \
  -p operationcount=10000 \
  -p threadcount=16

grep -c INSERT_ERROR /tmp/treedb_native_ycsb_current_head_20260629_212711/100000/load.out
# 0
grep -c INSERT_ERROR /tmp/treedb_native_ycsb_current_head_20260629_212711/1000000/load.out
# 0

grep -R "ERROR\\|panic\\|fatal\\|Failed\\|EOF\\|ambiguous" -n \
  /tmp/treedb_native_ycsb_current_head_20260629_212711/*/server.log \
  /tmp/treedb_native_ycsb_current_head_20260629_212711/*/load.out
# no output

git diff --check
```
