### PR TITLE
treedb: classify raw mixed-point maintenance fallback

### DIFF
--- a/TreeDB/db/raw_span_native_route_test.go
+++ b/TreeDB/db/raw_span_native_route_test.go
@@ -95,6 +95,54 @@ func TestRawSpanNativeRouteStatsPointShapeMatrix(t *testing.T) {
 	}
 }
 
+func TestRawSpanNativeRouteStatsMixedPointDeleteMaintenanceFallback(t *testing.T) {
+	d := openExplicitRawSpanNativeRouteTestDB(t)
+	if err := d.Set([]byte("delete-me"), []byte("old")); err != nil {
+		t.Fatalf("Set delete-me seed: %v", err)
+	}
+
+	b := d.NewBatch()
+	if err := b.Set([]byte("new"), []byte("value")); err != nil {
+		t.Fatalf("batch Set: %v", err)
+	}
+	if err := b.Delete([]byte("delete-me")); err != nil {
+		t.Fatalf("batch Delete: %v", err)
+	}
+	if err := b.Write(); err != nil {
+		t.Fatalf("batch Write: %v", err)
+	}
+	if err := b.Close(); err != nil {
+		t.Fatalf("batch Close: %v", err)
+	}
+
+	stats := d.Stats()
+	prefix := "treedb.raw.span_native.route.mixed_point."
+	if got := rawSpanNativeRouteStatUint(t, stats, prefix+"observations_total"); got == 0 {
+		t.Fatalf("mixed_point observations=0, want observed route")
+	}
+	if got := rawSpanNativeRouteStatUint(t, stats, prefix+"candidate_ops_total"); got == 0 {
+		t.Fatalf("mixed_point candidate_ops_total=0, want delete-maintenance batch to remain a visible candidate")
+	}
+	if got := rawSpanNativeRouteStatUint(t, stats, prefix+"used_ops_total"); got != 0 {
+		t.Fatalf("mixed_point used_ops_total=%d, want raw delete-maintenance fallback", got)
+	}
+	if got := rawSpanNativeRouteStatUint(t, stats, prefix+"fallback.reason."+FlushSpanRunFallbackMaintenance.String()+".count_total"); got == 0 {
+		t.Fatalf("mixed_point maintenance fallback count=0, want raw delete-maintenance fallback")
+	}
+	if got := rawSpanNativeRouteStatUint(t, stats, prefix+"fallback.reason.unknown.count_total"); got != 0 {
+		t.Fatalf("mixed_point unknown fallback count=%d, want classified maintenance fallback", got)
+	}
+	if got := rawSpanNativeRouteStatUint(t, stats, "treedb.raw.span_native.fallback.reason."+FlushSpanRunFallbackMaintenance.String()+".ops_total"); got == 0 {
+		t.Fatalf("raw maintenance fallback ops=0, want aggregate maintenance fallback")
+	}
+	if got, err := d.Get([]byte("new")); err != nil || !bytes.Equal(got, []byte("value")) {
+		t.Fatalf("Get new=%q err=%v, want value", got, err)
+	}
+	if got, err := d.Get([]byte("delete-me")); err != nil || got != nil {
+		t.Fatalf("Get delete-me=%q err=%v, want deleted key", got, err)
+	}
+}
+
 func TestRawSpanNativeRouteStatsUnsupportedRowsHaveNamedFallbacks(t *testing.T) {
 	t.Run("range delete barrier", func(t *testing.T) {
 		d := openExplicitRawSpanNativeRouteTestDB(t)


### PR DESCRIPTION
## Linked Issues

- Closes #3365
- Updates #3317
- Updates #3314
- Evidence lane: #3320
- Follows #3362 / PR #3363

## Goal

Classify the remaining Celestia raw span-native fallback after PR #3363. The strict #3363 run removed `command_wal_barrier` fallback from raw point-put publish chunks, leaving only:

- `treedb.raw.span_native.route.mixed_point.fallback.reason.maintenance`: `503` counts, `1,293,558` ops, `71,174` spans

This PR does not try to force that path into raw span-native apply. It records the precise contract blocker in a route-level test.

## Classification

The remaining counter means:

- route `mixed_point`: a raw backend batch has point puts and point deletes, with no range deletes;
- fallback `maintenance`: the zipper marks point-delete-containing raw batches as maintenance;
- raw apply intentionally leaves `SpanNativeAllowMaintenancePointOps=false`, while ordered-root apply opts into it for trusted ordered-root paths.

So this is not command-WAL publish fencing anymore, and it is not proof that ordered/root-native is exercised. It is a raw delete-maintenance contract boundary: raw apply still uses the recursive maintenance path for point-delete batches because that path owns pruning/rebalancing semantics for empty or underfull pages.

## Change

- Add `TestRawSpanNativeRouteStatsMixedPointDeleteMaintenanceFallback`.
- The test builds a raw mixed put/delete batch against an existing root and asserts:
  - `mixed_point` is observed;
  - it remains a candidate;
  - `used_ops_total` stays zero;
  - fallback is classified as `maintenance`, not `unknown`;
  - aggregate raw maintenance fallback ops increment;
  - resulting put/delete visibility is correct.

## Evidence Boundary

No Celestia rerun is required for this PR because it is test/contract-only and does not change runtime behavior. Use the #3363 strict run as the current Celestia evidence source for the counter being classified.

Separated questions:

- Raw span-native admission: point-put traffic is admitted after #3363; mixed put/delete raw maintenance is blocked by the raw maintenance contract.
- Ordered/root-native admission: still not exercised by the Celestia app-state path in the current evidence (`0 / 0` counters).
- Apply bottleneck: unchanged from #3363; candidate apply was `23.288s` of `271s` sync with process backlog `0`, so memtable-to-B-tree apply was not the dominant limiter in that window.

No strict LevelDB-vs-TreeDB A/B is claimed here.

## Tests

- `GOWORK=off go test ./TreeDB/db -run 'TestRawSpanNativeRouteStats(MixedPointDeleteMaintenanceFallback|PointShapeMatrix|CommandWALCheckpointPiggybackUsesSpanNativeApply)$' -count=1`
- `GOWORK=off go test ./TreeDB/zipper ./TreeDB/db -run 'TestSpanNativeApplyEligibilityFallbackReasons|TestSpanNativeApplyPointDeleteAndOverwriteEdgeParity|TestOrderedRootSpanNative(DefaultAutoAdmissionEnablesApplyOptions|PublishUsesSpanNativeWhenAdmitted)' -count=1`
- `GOWORK=off go test ./TreeDB/db -count=1` (`337.937s`)
- `git diff --check`
