### PR TITLE
TreeDB #2026: classify nativewire YCSB intermittent INSERT_ERROR

### DIFF
--- a/docs/benchmarks/nativewire_ycsb_closeout_2026-06-30.md
+++ b/docs/benchmarks/nativewire_ycsb_closeout_2026-06-30.md
@@ -171,7 +171,7 @@ for the deeper publication/readability invariant and intermittent-failure proof.
 Follow-up #3374 classification lives in
 `docs/benchmarks/nativewire_ycsb_insert_error_classification_2026-06-30.md`.
 That diagnostic reran current-head 100k and 1M nativewire loads at
-`6a512fdc8786c05895eda991bcc9aca70bca4441` with
+`3f2c712bb700806b29deb872ed90531d4828ab79` with
 `TREEDB_YCSB_LOG_ERRORS=1` and `-p silence=false`; both loads completed with
 zero `INSERT_ERROR`, empty stderr, and zero raw matches for `EOF`, `ambiguous`,
 `panic`, `fatal`, `ERROR`, or `Failed`. The old intermediate artifact remains

--- a/docs/benchmarks/nativewire_ycsb_closeout_2026-06-30.md
+++ b/docs/benchmarks/nativewire_ycsb_closeout_2026-06-30.md
@@ -167,3 +167,14 @@ successful inserts and reported `INSERT_ERROR`; its server log had no panic,
 fatal error, EOF, or ambiguous-commit marker. A clean 1M rerun and the final
 paired capture above both completed with zero `INSERT_ERROR`. Keep #2026 open
 for the deeper publication/readability invariant and intermittent-failure proof.
+
+Follow-up #3374 classification lives in
+`docs/benchmarks/nativewire_ycsb_insert_error_classification_2026-06-30.md`.
+That diagnostic reran current-head 100k and 1M nativewire loads at
+`6a512fdc8786c05895eda991bcc9aca70bca4441` with
+`TREEDB_YCSB_LOG_ERRORS=1` and `-p silence=false`; both loads completed with
+zero `INSERT_ERROR`, empty stderr, and zero raw matches for `EOF`, `ambiguous`,
+`panic`, `fatal`, `ERROR`, or `Failed`. The old intermediate artifact remains
+invalid because it lacks client-side error strings, but it is now classified as
+a non-reproduced client/harness/protocol/server-lifecycle interruption rather
+than evidence of a current catalog/value-log publication failure.

--- a/docs/benchmarks/nativewire_ycsb_insert_error_classification_2026-06-30.md
+++ b/docs/benchmarks/nativewire_ycsb_insert_error_classification_2026-06-30.md
@@ -15,7 +15,7 @@ TreeDB:
 
 - Worktree: `/home/mikers/dev/snissn/gomap-3374-ycsb-diagnostic`
 - Branch: `codex/3374-ycsb-diagnostic`
-- Diagnostic commit: `6a512fdc8786c05895eda991bcc9aca70bca4441`
+- Diagnostic commit: `3f2c712bb700806b29deb872ed90531d4828ab79`
 - Server: `cmd/treedb-native-server`
 - Profile: `command_wal_relaxed`
 
@@ -29,8 +29,8 @@ External client:
 
 Host:
 
-- Captured at: `2026-06-30T08:36:56Z`
-- Local time: `2026-06-29T22:36:56-1000`
+- Captured at: `2026-06-30T08:48:41Z`
+- Local time: `2026-06-29T22:48:41-1000`
 - Host: `mikers-B560-DS3H-AC-Y1`
 - Kernel: `Linux 6.8.0-124-generic x86_64`
 - Go: `go version go1.25.7 linux/amd64`
@@ -59,14 +59,14 @@ INSERT_ERROR|EOF|ambiguous|panic|fatal|ERROR|Failed
 Final artifact root:
 
 ```text
-/tmp/treedb_native_ycsb_diagnostic_20260629_223656
+/tmp/treedb_native_ycsb_diagnostic_20260629_224839
 ```
 
 Expanded commands from `commands.txt`:
 
 ```sh
 /home/mikers/dev/snissn/gomap-3374-ycsb-diagnostic/bin/treedb-native-server \
-  -dir /tmp/treedb_native_ycsb_diagnostic_20260629_223656/100000/db \
+  -dir /tmp/treedb_native_ycsb_diagnostic_20260629_224839/100000/db \
   -profile command_wal_relaxed \
   -addr 127.0.0.1:17370
 
@@ -79,7 +79,7 @@ env TREEDB_YCSB_LOG_ERRORS=1 \
   -p silence=false
 
 /home/mikers/dev/snissn/gomap-3374-ycsb-diagnostic/bin/treedb-native-server \
-  -dir /tmp/treedb_native_ycsb_diagnostic_20260629_223656/1000000/db \
+  -dir /tmp/treedb_native_ycsb_diagnostic_20260629_224839/1000000/db \
   -profile command_wal_relaxed \
   -addr 127.0.0.1:17371
 
@@ -96,8 +96,8 @@ env TREEDB_YCSB_LOG_ERRORS=1 \
 
 | recordcount | exit code | INSERT count | INSERT ops/sec | avg us | p95 us | p99 us | max us | `load.err` bytes | raw scan lines |
 | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-| 100,000 | 0 | 100,000 | 60,851.7 | 245 | 417 | 625 | 10,431 | 0 | 0 |
-| 1,000,000 | 0 | 1,000,000 | 44,289.9 | 341 | 561 | 916 | 1,000,447 | 0 | 0 |
+| 100,000 | 0 | 100,000 | 51,799.5 | 290 | 485 | 864 | 95,295 | 0 | 0 |
+| 1,000,000 | 0 | 1,000,000 | 41,702.6 | 363 | 605 | 1,076 | 1,042,431 | 0 | 0 |
 
 Raw scan counts from `scan_counts.txt`:
 
@@ -175,7 +175,7 @@ fatal, `ERROR`, or `Failed` text.
 | Artifact | Classification | Evidence | Residual Risk |
 | --- | --- | --- | --- |
 | `/tmp/treedb_native_ycsb_current_head_20260629_202356` | Invalid, non-reproduced intermediate client/harness/protocol/server-lifecycle interruption. Not evidence of a current TreeDB catalog/value-log publication/readability failure. | The 1M run reports client-side `INSERT_ERROR` counters, but no server-side `EOF`, ambiguous commit, panic, fatal error, or failure marker. The original command lacked error logging, so it cannot identify the exact client error string. Later clean #3364 evidence and the logged current-head #3374 diagnostic both complete 100k and 1M loads with zero raw scan matches. | The exact old client error is unavailable. If this shape recurs with `TREEDB_YCSB_LOG_ERRORS=1`, preserve the artifact and classify the logged error string as client harness, nativewire protocol, server lifecycle, or storage. |
-| `/tmp/treedb_native_ycsb_diagnostic_20260629_223656` | Current-head diagnostic pass. | 100k and 1M loads both exit 0, complete all requested inserts, produce empty stderr, and scan clean for `INSERT_ERROR`, `EOF`, `ambiguous`, `panic`, `fatal`, `ERROR`, and `Failed`. | This is a single-host developer-machine diagnostic gate, not a distributed HA proof. #2026 remains open for the broader publication/readability invariant and any final closeout decision. |
+| `/tmp/treedb_native_ycsb_diagnostic_20260629_224839` | Current-head diagnostic pass. | 100k and 1M loads both exit 0, complete all requested inserts, produce empty stderr, and scan clean for `INSERT_ERROR`, `EOF`, `ambiguous`, `panic`, `fatal`, `ERROR`, and `Failed`. | This is a single-host developer-machine diagnostic gate, not a distributed HA proof. #2026 remains open for the broader publication/readability invariant and any final closeout decision. |
 
 Conclusion: the preserved intermediate `INSERT_ERROR` artifact should be treated
 as a non-reproduced diagnostic caveat, not as current evidence of a TreeDB-owned

--- a/docs/benchmarks/nativewire_ycsb_insert_error_classification_2026-06-30.md
+++ b/docs/benchmarks/nativewire_ycsb_insert_error_classification_2026-06-30.md
@@ -1,0 +1,185 @@
+# TreeDB Nativewire YCSB INSERT_ERROR Classification
+
+Status: diagnostic classification evidence for #3374 under parent #2026.
+
+This report classifies the invalid intermediate 1M nativewire YCSB load at
+`/tmp/treedb_native_ycsb_current_head_20260629_202356` and records a fresh
+current-head diagnostic gate with client-side operation error logging enabled.
+It only covers the remaining intermittent `INSERT_ERROR` caveat from the #3364
+refresh. It does not claim Raft HA, snapshot/read-index/routing, or full #2026
+root-cause closeout.
+
+## Boundary
+
+TreeDB:
+
+- Worktree: `/home/mikers/dev/snissn/gomap-3374-ycsb-diagnostic`
+- Branch: `codex/3374-ycsb-diagnostic`
+- Diagnostic commit: `6a512fdc8786c05895eda991bcc9aca70bca4441`
+- Server: `cmd/treedb-native-server`
+- Profile: `command_wal_relaxed`
+
+External client:
+
+- Path: `/home/mikers/dev/pingcap/go-ycsb-2026-meta-v5`
+- Commit: `c195a9bc777b6aeb1e2f5550db96d872338f2f40`
+- Branch: `codex/2026-treedb-native-meta-v5`
+- Error logging: `TREEDB_YCSB_LOG_ERRORS=1`
+- Non-silent output: `-p silence=false`
+
+Host:
+
+- Captured at: `2026-06-30T08:36:56Z`
+- Local time: `2026-06-29T22:36:56-1000`
+- Host: `mikers-B560-DS3H-AC-Y1`
+- Kernel: `Linux 6.8.0-124-generic x86_64`
+- Go: `go version go1.25.7 linux/amd64`
+- CPU: `11th Gen Intel(R) Core(TM) i5-11400F @ 2.60GHz`, 12 logical CPUs
+- Memory: 31Gi
+
+## Diagnostic Gate
+
+The committed gate is:
+
+```sh
+OUT_DIR=/tmp/treedb_native_ycsb_diagnostic_$(date +%Y%m%d_%H%M%S) \
+  GOYCSB_DIR=/home/mikers/dev/pingcap/go-ycsb-2026-meta-v5 \
+  scripts/nativewire_ycsb_diagnostic.sh
+```
+
+It starts a fresh nativewire server and data directory per recordcount, runs
+external `go-ycsb load treedb-native`, enables `TREEDB_YCSB_LOG_ERRORS=1`, uses
+`-p silence=false`, preserves `load.out`, `load.err`, and `server.log`, and
+scans those raw files for:
+
+```text
+INSERT_ERROR|EOF|ambiguous|panic|fatal|ERROR|Failed
+```
+
+Final artifact root:
+
+```text
+/tmp/treedb_native_ycsb_diagnostic_20260629_223656
+```
+
+Expanded commands from `commands.txt`:
+
+```sh
+/home/mikers/dev/snissn/gomap-3374-ycsb-diagnostic/bin/treedb-native-server \
+  -dir /tmp/treedb_native_ycsb_diagnostic_20260629_223656/100000/db \
+  -profile command_wal_relaxed \
+  -addr 127.0.0.1:17370
+
+env TREEDB_YCSB_LOG_ERRORS=1 \
+  /home/mikers/dev/pingcap/go-ycsb-2026-meta-v5/bin/go-ycsb load treedb-native \
+  -p treedb.addr=127.0.0.1:17370 \
+  -p recordcount=100000 \
+  -p operationcount=10000 \
+  -p threadcount=16 \
+  -p silence=false
+
+/home/mikers/dev/snissn/gomap-3374-ycsb-diagnostic/bin/treedb-native-server \
+  -dir /tmp/treedb_native_ycsb_diagnostic_20260629_223656/1000000/db \
+  -profile command_wal_relaxed \
+  -addr 127.0.0.1:17371
+
+env TREEDB_YCSB_LOG_ERRORS=1 \
+  /home/mikers/dev/pingcap/go-ycsb-2026-meta-v5/bin/go-ycsb load treedb-native \
+  -p treedb.addr=127.0.0.1:17371 \
+  -p recordcount=1000000 \
+  -p operationcount=10000 \
+  -p threadcount=16 \
+  -p silence=false
+```
+
+## Current-Head Results
+
+| recordcount | exit code | INSERT count | INSERT ops/sec | avg us | p95 us | p99 us | max us | `load.err` bytes | raw scan lines |
+| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 100,000 | 0 | 100,000 | 60,851.7 | 245 | 417 | 625 | 10,431 | 0 | 0 |
+| 1,000,000 | 0 | 1,000,000 | 44,289.9 | 341 | 561 | 916 | 1,000,447 | 0 | 0 |
+
+Raw scan counts from `scan_counts.txt`:
+
+| recordcount | INSERT_ERROR | EOF | ambiguous | panic | fatal | ERROR | Failed |
+| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 100,000 | 0 | 0 | 0 | 0 | 0 | 0 | 0 |
+| 1,000,000 | 0 | 0 | 0 | 0 | 0 | 0 | 0 |
+
+The aggregate `raw_scan.txt`, `100000/raw_scan.txt`, and
+`1000000/raw_scan.txt` files are empty.
+
+## Invalid Intermediate Artifact
+
+Artifact root:
+
+```text
+/tmp/treedb_native_ycsb_current_head_20260629_202356
+```
+
+Captured context from `host.txt`:
+
+- Captured at: `2026-06-29T20:23:56-10:00`
+- gomap commit: `f5206eaa383f9bd43c917712cda88c7128dee367`
+- gomap base commit: `be2cfe6fb0ac4bec62a4b8c89915a910f8ac011a`
+- gomap branch: `codex/2026-current-head-ycsb-20260630`
+- go-ycsb commit: `c195a9bc777b6aeb1e2f5550db96d872338f2f40`
+- go-ycsb branch: `codex/2026-treedb-native-meta-v5`
+
+Original commands from `commands.txt`:
+
+```sh
+/home/mikers/dev/pingcap/go-ycsb-2026-meta-v5/bin/go-ycsb load treedb-native \
+  -p treedb.addr=127.0.0.1:17175 \
+  -p recordcount=100000 \
+  -p operationcount=10000 \
+  -p threadcount=16
+
+/home/mikers/dev/pingcap/go-ycsb-2026-meta-v5/bin/go-ycsb load treedb-native \
+  -p treedb.addr=127.0.0.1:17176 \
+  -p recordcount=1000000 \
+  -p operationcount=10000 \
+  -p threadcount=16
+```
+
+Those commands did not include `TREEDB_YCSB_LOG_ERRORS=1` or
+`-p silence=false`, so the artifact does not contain the client-side operation
+error strings that would distinguish a remote error frame from connection
+closure or another client-side failure.
+
+Observed output:
+
+| recordcount | result |
+| ---: | --- |
+| 100,000 | Completed 100,000 inserts, zero `INSERT_ERROR` lines. |
+| 1,000,000 | Completed the run with 768,001 successful inserts and an `INSERT_ERROR` histogram for the remaining 231,999 operations. |
+
+Raw scan counts over the original `load.out` and `server.log` files:
+
+| term | count |
+| --- | ---: |
+| INSERT_ERROR | 2 |
+| EOF | 0 |
+| ambiguous | 0 |
+| panic | 0 |
+| fatal | 0 |
+| ERROR | 2 |
+| Failed | 0 |
+
+The only raw matches are the two YCSB `INSERT_ERROR` histogram rows in
+`1000000/load.out`. The server log has no `EOF`, ambiguous-commit, panic,
+fatal, `ERROR`, or `Failed` text.
+
+## Classification
+
+| Artifact | Classification | Evidence | Residual Risk |
+| --- | --- | --- | --- |
+| `/tmp/treedb_native_ycsb_current_head_20260629_202356` | Invalid, non-reproduced intermediate client/harness/protocol/server-lifecycle interruption. Not evidence of a current TreeDB catalog/value-log publication/readability failure. | The 1M run reports client-side `INSERT_ERROR` counters, but no server-side `EOF`, ambiguous commit, panic, fatal error, or failure marker. The original command lacked error logging, so it cannot identify the exact client error string. Later clean #3364 evidence and the logged current-head #3374 diagnostic both complete 100k and 1M loads with zero raw scan matches. | The exact old client error is unavailable. If this shape recurs with `TREEDB_YCSB_LOG_ERRORS=1`, preserve the artifact and classify the logged error string as client harness, nativewire protocol, server lifecycle, or storage. |
+| `/tmp/treedb_native_ycsb_diagnostic_20260629_223656` | Current-head diagnostic pass. | 100k and 1M loads both exit 0, complete all requested inserts, produce empty stderr, and scan clean for `INSERT_ERROR`, `EOF`, `ambiguous`, `panic`, `fatal`, `ERROR`, and `Failed`. | This is a single-host developer-machine diagnostic gate, not a distributed HA proof. #2026 remains open for the broader publication/readability invariant and any final closeout decision. |
+
+Conclusion: the preserved intermediate `INSERT_ERROR` artifact should be treated
+as a non-reproduced diagnostic caveat, not as current evidence of a TreeDB-owned
+storage publication bug. The old artifact is still useful because it explains
+why #2026 stayed open after #3364, but the current logged gate makes the caveat
+defensible: if the failure recurs, the harness now captures the missing
+client-side error strings needed to assign ownership.

--- a/docs/benchmarks/ycsb_mongodb_treedb_current.md
+++ b/docs/benchmarks/ycsb_mongodb_treedb_current.md
@@ -34,9 +34,11 @@ That report uses the compatible external `go-ycsb` branch for
 `collection_meta` version 5, runs 100k and 1M `treedb-native` loads on commit
 `61910b8eac108c5f2c35f07a374879d1fb2dc5c8`, and records zero `INSERT_ERROR`
 counts. It includes the later Raft snapshot/route-preflight merges, but does
-not replace the full comparison matrix above. The report also records one
-invalid intermediate 1M run that hit `INSERT_ERROR`; keep #2026 open for the
-deeper publication/readability invariant and intermittent-failure proof.
+not replace the full comparison matrix above. The follow-up #3374 diagnostic
+report, `docs/benchmarks/nativewire_ycsb_insert_error_classification_2026-06-30.md`,
+classifies the previously invalid intermediate 1M `INSERT_ERROR` artifact with
+a current-head rerun using client-side error logging. Keep #2026 open for the
+deeper publication/readability invariant and final closeout decision.
 
 ## Current Headline
 
@@ -57,7 +59,8 @@ UTC latest-main report.
 
 | report | status | use |
 | --- | --- | --- |
-| `docs/benchmarks/nativewire_ycsb_closeout_2026-06-30.md` | #2026 nativewire load-only closeout evidence refreshed after later Raft merges. | Use for the 100k and 1M external `go-ycsb treedb-native` load proof on commit `61910b8eac108c5f2c35f07a374879d1fb2dc5c8` with `collection_meta` v5 compatibility; note the recorded invalid intermediate 1M run before claiming intermittent-failure closure. |
+| `docs/benchmarks/nativewire_ycsb_insert_error_classification_2026-06-30.md` | #3374 classification of the invalid intermediate nativewire `INSERT_ERROR` caveat. | Use for the current-head diagnostic run with `TREEDB_YCSB_LOG_ERRORS=1`, `-p silence=false`, raw scan counts, and the owner/risk classification for `/tmp/treedb_native_ycsb_current_head_20260629_202356`. |
+| `docs/benchmarks/nativewire_ycsb_closeout_2026-06-30.md` | #2026 nativewire load-only closeout evidence refreshed after later Raft merges. | Use for the 100k and 1M external `go-ycsb treedb-native` load proof on commit `61910b8eac108c5f2c35f07a374879d1fb2dc5c8` with `collection_meta` v5 compatibility; use the #3374 classification report for the recorded invalid intermediate 1M run. |
 | `docs/benchmarks/ycsb_latest_main_2026-06-03.md` | Current external YCSB report. | Use for current headline MongoDB / TreeDB nativewire / TreeDB Mongo gateway results on latest `origin/main` after the June 3 rerun. |
 | `docs/benchmarks/ycsb_post_update_stack_2026-06-02.md` | Superseded latest-current report. | Keep for post-update-path-stack evidence before the latest main rerun and for comparison deltas. |
 | `docs/benchmarks/ycsb_mongodb_treedb_2026-05-31.md` | Historical legacy-profile report. | Keep for the original MongoDB / TreeDB native / TreeDB Mongo comparison and the post-load Mongo-gateway cliff attribution. Do not use its `fast` rows as current public-profile guidance. |

--- a/scripts/nativewire_ycsb_diagnostic.sh
+++ b/scripts/nativewire_ycsb_diagnostic.sh
@@ -171,6 +171,7 @@ write_scan_counts() {
 write_host_info
 printf 'recordcount\taddr\texit_code\tinsert_error_lines\terror_scan_lines\tload_out\tload_err\tserver_log\n' >"$OUT_DIR/summary.tsv"
 
+diagnostic_failures=0
 index=0
 for recordcount in $RECORDCOUNTS; do
   addr="$ADDR_BASE_HOST:$((ADDR_BASE_PORT + index))"
@@ -212,6 +213,9 @@ for recordcount in $RECORDCOUNTS; do
   printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
     "$recordcount" "$addr" "$exit_code" "$insert_error_lines" "$error_scan_lines" \
     "$run_dir/load.out" "$run_dir/load.err" "$run_dir/server.log" >>"$OUT_DIR/summary.tsv"
+  if (( exit_code != 0 || insert_error_lines != 0 || error_scan_lines != 0 )); then
+    diagnostic_failures=$((diagnostic_failures + 1))
+  fi
 
   kill "$server_pid" 2>/dev/null || true
   wait "$server_pid" 2>/dev/null || true
@@ -230,3 +234,8 @@ done
 write_scan_counts
 
 printf 'nativewire YCSB diagnostic artifacts: %s\n' "$OUT_DIR"
+if (( diagnostic_failures != 0 )); then
+  printf 'nativewire YCSB diagnostic detected %d failing run(s); inspect %s/summary.tsv and %s/raw_scan.txt\n' \
+    "$diagnostic_failures" "$OUT_DIR" "$OUT_DIR" >&2
+  exit 1
+fi

--- a/scripts/nativewire_ycsb_diagnostic.sh
+++ b/scripts/nativewire_ycsb_diagnostic.sh
@@ -1,0 +1,232 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+cd "$ROOT"
+
+TMP_BASE="${TMPDIR:-/tmp}"
+TMP_BASE="${TMP_BASE%/}"
+OUT_DIR="${OUT_DIR:-$(mktemp -d "$TMP_BASE/treedb_native_ycsb_diagnostic_XXXXXX")}"
+GOYCSB_DIR="${GOYCSB_DIR:-/home/mikers/dev/pingcap/go-ycsb-2026-meta-v5}"
+RECORDCOUNTS="${RECORDCOUNTS:-100000 1000000}"
+OPERATIONCOUNT="${OPERATIONCOUNT:-10000}"
+THREADCOUNT="${THREADCOUNT:-16}"
+TREEDB_PROFILE="${TREEDB_PROFILE:-command_wal_relaxed}"
+ADDR_BASE_HOST="${ADDR_BASE_HOST:-127.0.0.1}"
+ADDR_BASE_PORT="${ADDR_BASE_PORT:-17370}"
+BUILD="${BUILD:-true}"
+BUILD_GOYCSB="${BUILD_GOYCSB:-false}"
+ERROR_PATTERN='INSERT_ERROR|EOF|ambiguous|panic|fatal|ERROR|Failed'
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/nativewire_ycsb_diagnostic.sh
+
+Runs external go-ycsb treedb-native load diagnostics against fresh TreeDB
+nativewire servers. The harness enables client-side operation error logging
+with TREEDB_YCSB_LOG_ERRORS=1 and uses -p silence=false.
+
+Outputs:
+  $OUT_DIR/host.txt
+  $OUT_DIR/commands.txt
+  $OUT_DIR/summary.tsv
+  $OUT_DIR/raw_scan.txt
+  $OUT_DIR/scan_counts.txt
+  $OUT_DIR/<recordcount>/server.log
+  $OUT_DIR/<recordcount>/load.out
+  $OUT_DIR/<recordcount>/load.err
+  $OUT_DIR/<recordcount>/load_exit_code.txt
+
+Environment overrides:
+  OUT_DIR, GOYCSB_DIR, RECORDCOUNTS, OPERATIONCOUNT, THREADCOUNT,
+  TREEDB_PROFILE, ADDR_BASE_HOST, ADDR_BASE_PORT, BUILD, BUILD_GOYCSB.
+
+Examples:
+  scripts/nativewire_ycsb_diagnostic.sh
+  RECORDCOUNTS="100000" OUT_DIR=/tmp/nativewire_diag scripts/nativewire_ycsb_diagnostic.sh
+EOF
+}
+
+if [[ "${1-}" == "-h" || "${1-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+mkdir -p "$OUT_DIR"
+OUT_DIR=$(cd "$OUT_DIR" && pwd)
+: >"$OUT_DIR/commands.txt"
+
+GOYCSB="$GOYCSB_DIR/bin/go-ycsb"
+SERVER="$ROOT/bin/treedb-native-server"
+
+if [[ "$BUILD" == "true" ]]; then
+  GOWORK=off go build -o "$SERVER" ./cmd/treedb-native-server
+fi
+if [[ "$BUILD_GOYCSB" == "true" || ! -x "$GOYCSB" ]]; then
+  (cd "$GOYCSB_DIR" && make build)
+fi
+if [[ ! -x "$GOYCSB" ]]; then
+  echo "go-ycsb binary not found or not executable: $GOYCSB" >&2
+  exit 2
+fi
+
+SERVER_PIDS=()
+
+cleanup() {
+  local pid
+  for pid in "${SERVER_PIDS[@]:-}"; do
+    kill "$pid" 2>/dev/null || true
+  done
+  for pid in "${SERVER_PIDS[@]:-}"; do
+    wait "$pid" 2>/dev/null || true
+  done
+}
+trap cleanup EXIT
+
+wait_tcp() {
+  local addr=$1
+  local host=${addr%:*}
+  local port=${addr##*:}
+  local i
+  for i in $(seq 1 60); do
+    if timeout 1 bash -c "</dev/tcp/$host/$port" 2>/dev/null; then
+      return 0
+    fi
+    sleep 1
+  done
+  echo "timed out waiting for $addr" >&2
+  return 1
+}
+
+log_command() {
+  printf '%q ' "$@" >>"$OUT_DIR/commands.txt"
+  printf '\n' >>"$OUT_DIR/commands.txt"
+}
+
+write_host_info() {
+  {
+    printf 'date_utc='
+    date -u '+%Y-%m-%dT%H:%M:%SZ'
+    printf 'date_local='
+    date '+%Y-%m-%dT%H:%M:%S%z'
+    printf 'host='
+    hostname
+    printf 'uname='
+    uname -a
+    printf 'go_version='
+    go version
+    printf 'gomap_commit='
+    git rev-parse HEAD
+    printf 'gomap_branch='
+    git rev-parse --abbrev-ref HEAD
+    printf 'goycsb_commit='
+    (cd "$GOYCSB_DIR" && git rev-parse HEAD)
+    printf 'goycsb_branch='
+    (cd "$GOYCSB_DIR" && git rev-parse --abbrev-ref HEAD)
+    printf 'recordcounts=%s\n' "$RECORDCOUNTS"
+    printf 'operationcount=%s\n' "$OPERATIONCOUNT"
+    printf 'threadcount=%s\n' "$THREADCOUNT"
+    printf 'treedb_profile=%s\n' "$TREEDB_PROFILE"
+    printf 'goycsb_dir=%s\n' "$GOYCSB_DIR"
+    printf 'server_binary=%s\n' "$SERVER"
+    printf 'goycsb_binary=%s\n' "$GOYCSB"
+    lscpu
+    free -h
+  } >"$OUT_DIR/host.txt"
+}
+
+scan_artifacts() {
+  local output=$1
+  shift
+  if grep -HniE "$ERROR_PATTERN" "$@" >"$output" 2>/dev/null; then
+    return 0
+  fi
+  : >"$output"
+}
+
+count_term() {
+  local term=$1
+  shift
+  (grep -HniE "$term" "$@" 2>/dev/null || true) | wc -l | tr -d ' '
+}
+
+write_scan_counts() {
+  {
+    printf 'scope\tterm\tcount\n'
+    local scope term count load_out load_err server_log
+    for scope in "$OUT_DIR"/*; do
+      [[ -d "$scope" ]] || continue
+      [[ "$(basename "$scope")" =~ ^[0-9]+$ ]] || continue
+      load_out="$scope/load.out"
+      load_err="$scope/load.err"
+      server_log="$scope/server.log"
+      for term in INSERT_ERROR EOF ambiguous panic fatal ERROR Failed; do
+        count=$(count_term "$term" "$load_out" "$load_err" "$server_log")
+        printf '%s\t%s\t%s\n' "$(basename "$scope")" "$term" "$count"
+      done
+    done
+  } >"$OUT_DIR/scan_counts.txt"
+}
+
+write_host_info
+printf 'recordcount\taddr\texit_code\tinsert_error_lines\terror_scan_lines\tload_out\tload_err\tserver_log\n' >"$OUT_DIR/summary.tsv"
+
+index=0
+for recordcount in $RECORDCOUNTS; do
+  addr="$ADDR_BASE_HOST:$((ADDR_BASE_PORT + index))"
+  run_dir="$OUT_DIR/$recordcount"
+  db_dir="$run_dir/db"
+  mkdir -p "$run_dir"
+  rm -rf "$db_dir"
+
+  server_cmd=(
+    "$SERVER"
+    -dir "$db_dir"
+    -profile "$TREEDB_PROFILE"
+    -addr "$addr"
+  )
+  log_command "${server_cmd[@]}"
+  "${server_cmd[@]}" >"$run_dir/server.log" 2>&1 &
+  server_pid=$!
+  SERVER_PIDS+=("$server_pid")
+  wait_tcp "$addr"
+
+  load_cmd=(
+    "$GOYCSB" load treedb-native
+    -p "treedb.addr=$addr"
+    -p "recordcount=$recordcount"
+    -p "operationcount=$OPERATIONCOUNT"
+    -p "threadcount=$THREADCOUNT"
+    -p "silence=false"
+  )
+  log_command env TREEDB_YCSB_LOG_ERRORS=1 "${load_cmd[@]}"
+  set +e
+  TREEDB_YCSB_LOG_ERRORS=1 "${load_cmd[@]}" >"$run_dir/load.out" 2>"$run_dir/load.err"
+  exit_code=$?
+  set -e
+  printf '%s\n' "$exit_code" >"$run_dir/load_exit_code.txt"
+
+  scan_artifacts "$run_dir/raw_scan.txt" "$run_dir/load.out" "$run_dir/load.err" "$run_dir/server.log"
+  insert_error_lines=$(count_term 'INSERT_ERROR' "$run_dir/load.out" "$run_dir/load.err" "$run_dir/server.log")
+  error_scan_lines=$(wc -l <"$run_dir/raw_scan.txt" | tr -d ' ')
+  printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+    "$recordcount" "$addr" "$exit_code" "$insert_error_lines" "$error_scan_lines" \
+    "$run_dir/load.out" "$run_dir/load.err" "$run_dir/server.log" >>"$OUT_DIR/summary.tsv"
+
+  kill "$server_pid" 2>/dev/null || true
+  wait "$server_pid" 2>/dev/null || true
+
+  index=$((index + 1))
+done
+
+: >"$OUT_DIR/raw_scan.txt"
+for scope in "$OUT_DIR"/*; do
+  [[ -d "$scope" ]] || continue
+  [[ "$(basename "$scope")" =~ ^[0-9]+$ ]] || continue
+  if [[ -s "$scope/raw_scan.txt" ]]; then
+    sed "s#^#$(basename "$scope")/#" "$scope/raw_scan.txt" >>"$OUT_DIR/raw_scan.txt"
+  fi
+done
+write_scan_counts
+
+printf 'nativewire YCSB diagnostic artifacts: %s\n' "$OUT_DIR"

--- a/scripts/nativewire_ycsb_diagnostic.sh
+++ b/scripts/nativewire_ycsb_diagnostic.sh
@@ -154,9 +154,7 @@ write_scan_counts() {
   {
     printf 'scope\tterm\tcount\n'
     local scope term count load_out load_err server_log
-    for scope in "$OUT_DIR"/*; do
-      [[ -d "$scope" ]] || continue
-      [[ "$(basename "$scope")" =~ ^[0-9]+$ ]] || continue
+    for scope in "$@"; do
       load_out="$scope/load.out"
       load_err="$scope/load.err"
       server_log="$scope/server.log"
@@ -172,12 +170,14 @@ write_host_info
 printf 'recordcount\taddr\texit_code\tinsert_error_lines\terror_scan_lines\tload_out\tload_err\tserver_log\n' >"$OUT_DIR/summary.tsv"
 
 diagnostic_failures=0
+run_dirs=()
 index=0
 for recordcount in $RECORDCOUNTS; do
   addr="$ADDR_BASE_HOST:$((ADDR_BASE_PORT + index))"
   run_dir="$OUT_DIR/$recordcount"
   db_dir="$run_dir/db"
   mkdir -p "$run_dir"
+  run_dirs+=("$run_dir")
   rm -rf "$db_dir"
 
   server_cmd=(
@@ -224,14 +224,12 @@ for recordcount in $RECORDCOUNTS; do
 done
 
 : >"$OUT_DIR/raw_scan.txt"
-for scope in "$OUT_DIR"/*; do
-  [[ -d "$scope" ]] || continue
-  [[ "$(basename "$scope")" =~ ^[0-9]+$ ]] || continue
+for scope in "${run_dirs[@]}"; do
   if [[ -s "$scope/raw_scan.txt" ]]; then
     sed "s#^#$(basename "$scope")/#" "$scope/raw_scan.txt" >>"$OUT_DIR/raw_scan.txt"
   fi
 done
-write_scan_counts
+write_scan_counts "${run_dirs[@]}"
 
 printf 'nativewire YCSB diagnostic artifacts: %s\n' "$OUT_DIR"
 if (( diagnostic_failures != 0 )); then


### PR DESCRIPTION
Closes #3374
Refs #2026

## Scope Boundary

- Adds a reusable nativewire YCSB diagnostic harness: `scripts/nativewire_ycsb_diagnostic.sh`.
- Adds the #3374 classification report: `docs/benchmarks/nativewire_ycsb_insert_error_classification_2026-06-30.md`.
- Updates the existing nativewire closeout and YCSB index docs to point at the classification report.
- Does not touch Raft snapshot/read-index/routing implementation files.
- Does not claim full #2026 closeout; parent #2026 remains open for the broader publication/readability invariant and final closeout decision.

## Diagnostic Evidence

Artifact root: `/tmp/treedb_native_ycsb_diagnostic_20260629_224839`

- Final branch head: `efca5e2a5`
- Diagnostic run commit recorded by the artifact: `3f2c712bb700806b29deb872ed90531d4828ab79`
- Base after refresh: `origin/main` `204adfc4ab9e3e0e83f40fe9da882a34292b2885`
- External go-ycsb commit: `c195a9bc777b6aeb1e2f5550db96d872338f2f40`
- Host/date: `mikers-B560-DS3H-AC-Y1`, `2026-06-30T08:48:41Z` / `2026-06-29T22:48:41-1000`
- Server profile: `command_wal_relaxed`
- Client diagnostics: `TREEDB_YCSB_LOG_ERRORS=1`, `-p silence=false`

Exact diagnostic command:

```sh
OUT_DIR=/tmp/treedb_native_ycsb_diagnostic_$(date +%Y%m%d_%H%M%S) \
  GOYCSB_DIR=/home/mikers/dev/pingcap/go-ycsb-2026-meta-v5 \
  scripts/nativewire_ycsb_diagnostic.sh
```

Expanded commands are recorded in `/tmp/treedb_native_ycsb_diagnostic_20260629_224839/commands.txt` and copied into the classification report.

## Raw Scan Summary

Current-head diagnostic artifact:

| recordcount | exit code | inserts | INSERT_ERROR | EOF | ambiguous | panic | fatal | ERROR | Failed | stderr bytes |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 100,000 | 0 | 100,000 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 |
| 1,000,000 | 0 | 1,000,000 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 |

Prior invalid intermediate artifact `/tmp/treedb_native_ycsb_current_head_20260629_202356`:

| recordcount | result | raw scan |
| ---: | --- | --- |
| 100,000 | 100,000 inserts, zero `INSERT_ERROR` | no matches |
| 1,000,000 | 768,001 successful inserts, `INSERT_ERROR` histogram for remaining 231,999 operations | `INSERT_ERROR=2`, `ERROR=2`, `EOF=0`, `ambiguous=0`, `panic=0`, `fatal=0`, `Failed=0` |

## Classification Table

| Artifact | Classification | Evidence | Remaining Risk |
| --- | --- | --- | --- |
| `/tmp/treedb_native_ycsb_current_head_20260629_202356` | Invalid, non-reproduced intermediate client/harness/protocol/server-lifecycle interruption. Not evidence of a current TreeDB catalog/value-log publication/readability failure. | The 1M run only has YCSB `INSERT_ERROR` histogram rows. Its server log has no `EOF`, ambiguous commit, panic, fatal error, `ERROR`, or `Failed` marker. The original command lacked `TREEDB_YCSB_LOG_ERRORS=1`, so it cannot identify the exact client error string. | Exact old client error is unavailable. If this shape recurs with the diagnostic harness, the preserved stderr should classify the owner as client harness, nativewire protocol, server lifecycle, or storage. |
| `/tmp/treedb_native_ycsb_diagnostic_20260629_224839` | Current-head diagnostic pass. | 100k and 1M loads exit 0, complete all requested inserts, produce empty stderr, and scan clean for `INSERT_ERROR`, `EOF`, `ambiguous`, `panic`, `fatal`, `ERROR`, and `Failed`. | Single-host developer-machine evidence, not a distributed HA proof. #2026 remains open for the broader invariant and closeout decision. |

## Validation

```sh
git diff --check origin/main...HEAD
GOWORK=off go test ./cmd/treedb-native-server ./TreeDB/nativewire ./TreeDB/collections ./TreeDB/db -count=1
GOWORK=off go build -o bin/treedb-native-server ./cmd/treedb-native-server

cd /home/mikers/dev/pingcap/go-ycsb-2026-meta-v5
go test ./db/treedbnative -count=1
make build
```

Additional local checks:

```sh
GOWORK=off go test ./TreeDB/docs -count=1
bash -n scripts/nativewire_ycsb_diagnostic.sh
```

AI reviews were not requested by this worker; coordinator owns review/merge.
