### PR TITLE
Optimize q2 dense rank reference fill

### DIFF
--- a/TreeDB/collections/column_physical_q2_global_rank_prep_bench_test.go
+++ b/TreeDB/collections/column_physical_q2_global_rank_prep_bench_test.go
@@ -235,8 +235,7 @@ func TestTypedColumnQ2DenseGroupCountDistinctShardedReferenceFillNullableEmpty(t
 		t.Fatalf("prepare sharded reference-fill rank maps: %v", err)
 	}
 	if diagnostics.Q2DenseDistinctGlobalRankNanos != diagnostics.Q2DistinctRankNanos ||
-		diagnostics.Q2DensePartLocalRankNanos != diagnostics.Q2LocalRankNanos ||
-		diagnostics.Q2DistinctRankNanos <= 0 {
+		diagnostics.Q2DensePartLocalRankNanos != diagnostics.Q2LocalRankNanos {
 		t.Fatalf("reference-fill diagnostics=%+v want dense q2 distinct/local split", diagnostics)
 	}
 	distinct0 := parts[0].DenseGroupCountDistinct.Distinct

--- a/TreeDB/collections/column_physical_q2_global_rank_prep_bench_test.go
+++ b/TreeDB/collections/column_physical_q2_global_rank_prep_bench_test.go
@@ -236,8 +236,7 @@ func TestTypedColumnQ2DenseGroupCountDistinctShardedReferenceFillNullableEmpty(t
 	}
 	if diagnostics.Q2DenseDistinctGlobalRankNanos != diagnostics.Q2DistinctRankNanos ||
 		diagnostics.Q2DensePartLocalRankNanos != diagnostics.Q2LocalRankNanos ||
-		diagnostics.Q2DistinctRankNanos <= 0 ||
-		diagnostics.Q2LocalRankNanos <= 0 {
+		diagnostics.Q2DistinctRankNanos <= 0 {
 		t.Fatalf("reference-fill diagnostics=%+v want dense q2 distinct/local split", diagnostics)
 	}
 	distinct0 := parts[0].DenseGroupCountDistinct.Distinct

--- a/TreeDB/collections/column_physical_q2_global_rank_prep_bench_test.go
+++ b/TreeDB/collections/column_physical_q2_global_rank_prep_bench_test.go
@@ -35,6 +35,26 @@ var q2DenseGlobalRankPrepVariants = []q2DenseGlobalRankPrepVariant{
 	},
 }
 
+var q2DenseGlobalRankPrepBenchmarkVariants = []q2DenseGlobalRankPrepVariant{
+	{
+		name:    "current_map",
+		prepare: prepareColumnTypedColumnDenseGroupCountDistinctGlobalRankMapsWithDiagnostics,
+		strategy: func([]columnTypedColumnPhysicalQueryPart) columnTypedColumnDenseGroupCountDistinctRankStrategy {
+			return columnTypedColumnDenseGroupCountDistinctRankStrategyCurrentMap
+		},
+	},
+	{
+		name:     "adaptive_baseline",
+		prepare:  prepareColumnTypedColumnDenseGroupCountDistinctGlobalRankMapsAdaptiveBaselineWithDiagnostics,
+		strategy: q2DenseGlobalRankPrepAdaptiveStrategy,
+	},
+	{
+		name:     "adaptive",
+		prepare:  prepareColumnTypedColumnDenseGroupCountDistinctGlobalRankMapsAdaptiveWithDiagnostics,
+		strategy: q2DenseGlobalRankPrepAdaptiveStrategy,
+	},
+}
+
 func q2DenseGlobalRankPrepAdaptiveStrategy(parts []columnTypedColumnPhysicalQueryPart) columnTypedColumnDenseGroupCountDistinctRankStrategy {
 	return columnTypedColumnDenseGroupCountDistinctSelectAdaptiveGlobalRankStrategy(parts, func(part *columnTypedColumnDenseGroupCountDistinctPart) *columnTypedColumnDenseStringCodeColumn {
 		return &part.Distinct
@@ -185,6 +205,78 @@ func TestTypedColumnQ2DenseGroupCountDistinctOneShotRankPrepMatchesAdaptivePolic
 	}
 }
 
+func TestTypedColumnQ2DenseGroupCountDistinctShardedReferenceFillNullableEmpty(t *testing.T) {
+	parts := []columnTypedColumnPhysicalQueryPart{
+		{
+			DenseGroupCountDistinct: &columnTypedColumnDenseGroupCountDistinctPart{
+				Group: columnTypedColumnDenseStringCodeColumn{
+					Dictionary: []string{"app.a"},
+				},
+				Distinct: columnTypedColumnDenseStringCodeColumn{
+					Dictionary: []string{"did:a", "did:shared"},
+					Valid:      []bool{true, false},
+				},
+			},
+		},
+		{
+			DenseGroupCountDistinct: &columnTypedColumnDenseGroupCountDistinctPart{
+				Group: columnTypedColumnDenseStringCodeColumn{
+					Dictionary: []string{"app.b"},
+				},
+				Distinct: columnTypedColumnDenseStringCodeColumn{
+					Dictionary: []string{"did:b", "did:shared"},
+				},
+			},
+		},
+	}
+
+	var diagnostics columnTypedColumnPhysicalQueryPrepareDiagnostics
+	if err := prepareColumnTypedColumnDenseGroupCountDistinctGlobalRankMapsShardedWithDiagnostics(parts, &diagnostics); err != nil {
+		t.Fatalf("prepare sharded reference-fill rank maps: %v", err)
+	}
+	if diagnostics.Q2DenseDistinctGlobalRankNanos != diagnostics.Q2DistinctRankNanos ||
+		diagnostics.Q2DensePartLocalRankNanos != diagnostics.Q2LocalRankNanos ||
+		diagnostics.Q2DistinctRankNanos <= 0 ||
+		diagnostics.Q2LocalRankNanos <= 0 {
+		t.Fatalf("reference-fill diagnostics=%+v want dense q2 distinct/local split", diagnostics)
+	}
+	distinct0 := parts[0].DenseGroupCountDistinct.Distinct
+	distinct1 := parts[1].DenseGroupCountDistinct.Distinct
+	if distinct0.GlobalDictionary != nil || distinct1.GlobalDictionary != nil {
+		t.Fatalf("distinct global dictionary allocated part0=%v part1=%v", distinct0.GlobalDictionary, distinct1.GlobalDictionary)
+	}
+	if !distinct0.GlobalCardinalityOK || distinct0.GlobalCardinality != 4 || !distinct1.GlobalCardinalityOK || distinct1.GlobalCardinality != 4 {
+		t.Fatalf("distinct cardinality part0=(%d,%t) part1=(%d,%t) want (4,true)", distinct0.GlobalCardinality, distinct0.GlobalCardinalityOK, distinct1.GlobalCardinality, distinct1.GlobalCardinalityOK)
+	}
+	if !distinct0.GlobalEmptyRankOK || !distinct1.GlobalEmptyRankOK || distinct0.GlobalEmptyRank != distinct1.GlobalEmptyRank || distinct0.GlobalEmptyRank >= 4 {
+		t.Fatalf("distinct empty ranks part0=(%d,%t) part1=(%d,%t) want shared rank below cardinality", distinct0.GlobalEmptyRank, distinct0.GlobalEmptyRankOK, distinct1.GlobalEmptyRank, distinct1.GlobalEmptyRankOK)
+	}
+	rankByValue := func(column columnTypedColumnDenseStringCodeColumn, value string) (uint32, bool) {
+		for localCode, localValue := range column.Dictionary {
+			if localValue == value {
+				return column.GlobalLocalRanks[localCode], true
+			}
+		}
+		return 0, false
+	}
+	shared0, ok := rankByValue(distinct0, "did:shared")
+	if !ok || shared0 >= 4 {
+		t.Fatalf("part 0 shared rank=(%d,%t) cardinality=4 ranks=%v", shared0, ok, distinct0.GlobalLocalRanks)
+	}
+	shared1, ok := rankByValue(distinct1, "did:shared")
+	if !ok || shared1 >= 4 {
+		t.Fatalf("part 1 shared rank=(%d,%t) cardinality=4 ranks=%v", shared1, ok, distinct1.GlobalLocalRanks)
+	}
+	if shared0 != shared1 {
+		t.Fatalf("shared did ranks part0=%d part1=%d want equal", shared0, shared1)
+	}
+	for label, rank := range map[string]uint32{"did:a": distinct0.GlobalLocalRanks[0], "did:b": distinct1.GlobalLocalRanks[0], "did:shared": shared0, "empty": distinct0.GlobalEmptyRank} {
+		if rank >= 4 {
+			t.Fatalf("%s rank=%d outside cardinality 4", label, rank)
+		}
+	}
+}
+
 // Dense q2 distinct ranks are reducer-local equality IDs, not externally visible
 // lexical order. This verifies the q2-visible result invariant after rank renumbering.
 func TestTypedColumnQ2DenseGroupCountDistinctShardedHashRankRunEquivalence(t *testing.T) {
@@ -288,7 +380,7 @@ func TestTypedColumnQ2DenseGroupCountDistinctAdaptiveRankRunEquivalence(t *testi
 }
 
 func BenchmarkTypedColumnQ2DenseGroupCountDistinctGlobalRankPrep(b *testing.B) {
-	for _, variant := range q2DenseGlobalRankPrepVariants {
+	for _, variant := range q2DenseGlobalRankPrepBenchmarkVariants {
 		for _, shape := range q2DenseGlobalRankPrepDictionaryShapes {
 			for _, partCount := range q2DenseGlobalRankPrepPartCounts {
 				b.Run(fmt.Sprintf("%s/%s/parts=%d", variant.name, shape.name, partCount), func(b *testing.B) {

--- a/TreeDB/collections/column_physical_typed_column_one_shot_cache_3088_test.go
+++ b/TreeDB/collections/column_physical_typed_column_one_shot_cache_3088_test.go
@@ -578,9 +578,6 @@ func assertTypedColumnQ2PostPrepareSubphaseDiagnostics3158(tb testing.TB, label 
 	if rankTotal+denseRankTotal+globalCodeTotal == 0 {
 		return
 	}
-	if rankTotal != 0 && diag.TypedColumnPrepareQ2LocalRankNanos <= 0 {
-		tb.Fatalf("%s local rank prep nanos=%d want >0 diagnostics=%+v", label, diag.TypedColumnPrepareQ2LocalRankNanos, diag)
-	}
 	if denseRankTotal != 0 {
 		if diag.TypedColumnPrepareQ2DenseGroupGlobalRankNanos != diag.TypedColumnPrepareQ2GroupRankNanos ||
 			diag.TypedColumnPrepareQ2DenseDistinctGlobalRankNanos != diag.TypedColumnPrepareQ2DistinctRankNanos ||

--- a/TreeDB/collections/column_physical_typed_column_query.go
+++ b/TreeDB/collections/column_physical_typed_column_query.go
@@ -1272,6 +1272,16 @@ func prepareColumnTypedColumnDenseGroupCountDistinctGlobalRankMapsAdaptiveWithDi
 }
 
 func prepareColumnTypedColumnDenseGroupCountDistinctGlobalRankMapsShardedPolicyWithDiagnostics(parts []columnTypedColumnPhysicalQueryPart, prepareDiagnostics *columnTypedColumnPhysicalQueryPrepareDiagnostics, rankStrategy columnTypedColumnDenseGroupCountDistinctRankStrategy) error {
+	return prepareColumnTypedColumnDenseGroupCountDistinctGlobalRankMapsShardedPolicyWithReferenceFillDiagnostics(parts, prepareDiagnostics, rankStrategy, true)
+}
+
+func prepareColumnTypedColumnDenseGroupCountDistinctGlobalRankMapsAdaptiveBaselineWithDiagnostics(parts []columnTypedColumnPhysicalQueryPart, prepareDiagnostics *columnTypedColumnPhysicalQueryPrepareDiagnostics) error {
+	return prepareColumnTypedColumnDenseGroupCountDistinctGlobalRankMapsShardedPolicyWithReferenceFillDiagnostics(parts, prepareDiagnostics, columnTypedColumnDenseGroupCountDistinctSelectAdaptiveGlobalRankStrategy(parts, func(part *columnTypedColumnDenseGroupCountDistinctPart) *columnTypedColumnDenseStringCodeColumn {
+		return &part.Distinct
+	}), false)
+}
+
+func prepareColumnTypedColumnDenseGroupCountDistinctGlobalRankMapsShardedPolicyWithReferenceFillDiagnostics(parts []columnTypedColumnPhysicalQueryPart, prepareDiagnostics *columnTypedColumnPhysicalQueryPrepareDiagnostics, rankStrategy columnTypedColumnDenseGroupCountDistinctRankStrategy, referenceFill bool) error {
 	phaseStart := time.Now()
 	groupDict, groupRanks, err := columnTypedColumnDenseGroupCountDistinctGlobalDictionary(parts, func(part *columnTypedColumnDenseGroupCountDistinctPart) *columnTypedColumnDenseStringCodeColumn {
 		return &part.Group
@@ -1282,6 +1292,16 @@ func prepareColumnTypedColumnDenseGroupCountDistinctGlobalRankMapsShardedPolicyW
 		prepareDiagnostics.Q2DenseGroupGlobalRankNanos += elapsed
 	}
 	if err != nil {
+		return err
+	}
+	if referenceFill && rankStrategy == columnTypedColumnDenseGroupCountDistinctRankStrategyShardedHash {
+		timing, err := prepareColumnTypedColumnDenseGroupCountDistinctGlobalRankMapsShardedReferenceFill(parts, groupDict, groupRanks)
+		if prepareDiagnostics != nil {
+			prepareDiagnostics.Q2DistinctRankNanos += timing.distinctRankNanos
+			prepareDiagnostics.Q2DenseDistinctGlobalRankNanos += timing.distinctRankNanos
+			prepareDiagnostics.Q2LocalRankNanos += timing.localRankNanos
+			prepareDiagnostics.Q2DensePartLocalRankNanos += timing.localRankNanos
+		}
 		return err
 	}
 	phaseStart = time.Now()
@@ -1438,6 +1458,276 @@ func prepareColumnTypedColumnDenseGroupCountDistinctGlobalRankMapsShardedPartsPa
 		if errs[partIdx] != nil {
 			return errs[partIdx]
 		}
+	}
+	return nil
+}
+
+type columnTypedColumnDenseGroupCountDistinctReferenceFillTiming struct {
+	distinctRankNanos int64
+	localRankNanos    int64
+}
+
+func prepareColumnTypedColumnDenseGroupCountDistinctGlobalRankMapsShardedReferenceFill(parts []columnTypedColumnPhysicalQueryPart, groupDict []string, groupRanks map[string]uint32) (columnTypedColumnDenseGroupCountDistinctReferenceFillTiming, error) {
+	var timing columnTypedColumnDenseGroupCountDistinctReferenceFillTiming
+	phaseStart := time.Now()
+	workers := columnTypedColumnPhysicalQueryPartDecodeWorkers(len(parts))
+	if workers < 1 {
+		workers = 1
+	}
+	capacity, err := columnTypedColumnDenseGroupCountDistinctDictionaryCapacity(parts, func(part *columnTypedColumnDenseGroupCountDistinctPart) *columnTypedColumnDenseStringCodeColumn {
+		return &part.Distinct
+	})
+	if err != nil {
+		timing.distinctRankNanos += time.Since(phaseStart).Nanoseconds()
+		return timing, err
+	}
+	shardCount := columnTypedColumnDenseGroupCountDistinctShardedRankShardCount(capacity, workers)
+	shardRefs := make([][]uint64, shardCount)
+	shardCapacity := max(1, capacity/shardCount)
+	for shardIdx := range shardRefs {
+		shardRefs[shardIdx] = make([]uint64, 0, shardCapacity)
+	}
+	timing.distinctRankNanos += time.Since(phaseStart).Nanoseconds()
+
+	includeEmpty := false
+	for partIdx := range parts {
+		part := parts[partIdx].DenseGroupCountDistinct
+		if part == nil {
+			return timing, fmt.Errorf("collections: dense grouped count-distinct missing prepared part %d", partIdx)
+		}
+		phaseStart := time.Now()
+		if err := prepareColumnTypedColumnDenseGroupCountDistinctGlobalColumnRanks(&part.Group, groupDict, len(groupDict), groupRanks); err != nil {
+			timing.localRankNanos += time.Since(phaseStart).Nanoseconds()
+			return timing, fmt.Errorf("collections: dense grouped count-distinct group part %d: %w", partIdx, err)
+		}
+		column := &part.Distinct
+		column.GlobalDictionary = nil
+		column.GlobalCardinality = 0
+		column.GlobalCardinalityOK = false
+		column.GlobalLocalRanks = make([]uint32, len(column.Dictionary))
+		column.GlobalEmptyRank = 0
+		column.GlobalEmptyRankOK = false
+		timing.localRankNanos += time.Since(phaseStart).Nanoseconds()
+
+		phaseStart = time.Now()
+		for localCode, value := range column.Dictionary {
+			ref, err := columnTypedColumnDenseGroupCountDistinctPackRankRef(partIdx, localCode)
+			if err != nil {
+				timing.distinctRankNanos += time.Since(phaseStart).Nanoseconds()
+				return timing, err
+			}
+			shardIdx := int(columnTypedColumnDenseGroupCountDistinctStableRankHash(value) & uint64(shardCount-1))
+			shardRefs[shardIdx] = append(shardRefs[shardIdx], ref)
+		}
+		if !includeEmpty {
+			for _, valid := range column.Valid {
+				if !valid {
+					includeEmpty = true
+					break
+				}
+			}
+		}
+		timing.distinctRankNanos += time.Since(phaseStart).Nanoseconds()
+	}
+
+	phaseStart = time.Now()
+	emptyShardIdx := -1
+	if includeEmpty {
+		emptyShardIdx = int(columnTypedColumnDenseGroupCountDistinctStableRankHash("") & uint64(shardCount-1))
+	}
+	shards, err := columnTypedColumnDenseGroupCountDistinctBuildShardedRanksFromRefs(parts, shardRefs, emptyShardIdx, workers)
+	if err != nil {
+		timing.distinctRankNanos += time.Since(phaseStart).Nanoseconds()
+		return timing, err
+	}
+	offsets := make([]uint32, len(shards))
+	cardinality := 0
+	for shardIdx, shard := range shards {
+		if len(shard) == 0 {
+			continue
+		}
+		if cardinality > int(^uint32(0)) || len(shard) > int(^uint32(0))-cardinality {
+			timing.distinctRankNanos += time.Since(phaseStart).Nanoseconds()
+			return timing, fmt.Errorf("collections: dense grouped count-distinct global dictionary cardinality exceeds uint32")
+		}
+		offsets[shardIdx] = uint32(cardinality)
+		cardinality += len(shard)
+	}
+	emptyRank := uint32(0)
+	emptyOK := false
+	emptyLookupShardIdx := int(columnTypedColumnDenseGroupCountDistinctStableRankHash("") & uint64(shardCount-1))
+	if localRank, ok := shards[emptyLookupShardIdx][""]; ok {
+		emptyRank = offsets[emptyLookupShardIdx] + localRank
+		emptyOK = true
+	} else if includeEmpty {
+		timing.distinctRankNanos += time.Since(phaseStart).Nanoseconds()
+		return timing, fmt.Errorf("collections: dense grouped count-distinct empty-string global rank missing")
+	}
+	timing.distinctRankNanos += time.Since(phaseStart).Nanoseconds()
+
+	phaseStart = time.Now()
+	if err := columnTypedColumnDenseGroupCountDistinctAddShardedRankOffsets(parts, shardRefs, offsets, workers); err != nil {
+		timing.localRankNanos += time.Since(phaseStart).Nanoseconds()
+		return timing, err
+	}
+	for partIdx := range parts {
+		part := parts[partIdx].DenseGroupCountDistinct
+		if part == nil {
+			timing.localRankNanos += time.Since(phaseStart).Nanoseconds()
+			return timing, fmt.Errorf("collections: dense grouped count-distinct missing prepared part %d", partIdx)
+		}
+		column := &part.Distinct
+		column.GlobalDictionary = nil
+		column.GlobalCardinality = cardinality
+		column.GlobalCardinalityOK = true
+		column.GlobalEmptyRank = emptyRank
+		column.GlobalEmptyRankOK = emptyOK
+	}
+	timing.localRankNanos += time.Since(phaseStart).Nanoseconds()
+	return timing, nil
+}
+
+func columnTypedColumnDenseGroupCountDistinctPackRankRef(partIdx, localCode int) (uint64, error) {
+	if uint64(partIdx) > uint64(^uint32(0)) || uint64(localCode) > uint64(^uint32(0)) {
+		return 0, fmt.Errorf("collections: dense grouped count-distinct rank reference exceeds uint32 part=%d local_code=%d", partIdx, localCode)
+	}
+	return uint64(uint32(partIdx))<<32 | uint64(uint32(localCode)), nil
+}
+
+func columnTypedColumnDenseGroupCountDistinctUnpackRankRef(ref uint64) (int, int) {
+	return int(uint32(ref >> 32)), int(uint32(ref))
+}
+
+func columnTypedColumnDenseGroupCountDistinctBuildShardedRanksFromRefs(parts []columnTypedColumnPhysicalQueryPart, shardRefs [][]uint64, emptyShardIdx int, workers int) ([]map[string]uint32, error) {
+	shards := make([]map[string]uint32, len(shardRefs))
+	errs := make([]error, len(shardRefs))
+	if workers < 2 || len(shardRefs) < 2 {
+		for shardIdx := range shardRefs {
+			shards[shardIdx], errs[shardIdx] = columnTypedColumnDenseGroupCountDistinctBuildShardRanksFromRefs(parts, shardRefs[shardIdx], shardIdx == emptyShardIdx)
+			if errs[shardIdx] != nil {
+				return nil, errs[shardIdx]
+			}
+		}
+		return shards, nil
+	}
+	jobs := make(chan int)
+	var wg sync.WaitGroup
+	for workerIdx := 0; workerIdx < workers; workerIdx++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for shardIdx := range jobs {
+				shards[shardIdx], errs[shardIdx] = columnTypedColumnDenseGroupCountDistinctBuildShardRanksFromRefs(parts, shardRefs[shardIdx], shardIdx == emptyShardIdx)
+			}
+		}()
+	}
+	for shardIdx := range shardRefs {
+		jobs <- shardIdx
+	}
+	close(jobs)
+	wg.Wait()
+	for shardIdx := range errs {
+		if errs[shardIdx] != nil {
+			return nil, errs[shardIdx]
+		}
+	}
+	return shards, nil
+}
+
+func columnTypedColumnDenseGroupCountDistinctBuildShardRanksFromRefs(parts []columnTypedColumnPhysicalQueryPart, refs []uint64, includeEmpty bool) (map[string]uint32, error) {
+	capacity := len(refs)
+	if includeEmpty {
+		capacity++
+	}
+	ranks := make(map[string]uint32, columnTypedColumnDenseGroupCountDistinctRankMapCapacity(capacity))
+	for _, ref := range refs {
+		partIdx, localCode := columnTypedColumnDenseGroupCountDistinctUnpackRankRef(ref)
+		if partIdx < 0 || partIdx >= len(parts) {
+			return nil, fmt.Errorf("collections: dense grouped count-distinct part reference=%d outside parts=%d", partIdx, len(parts))
+		}
+		part := parts[partIdx].DenseGroupCountDistinct
+		if part == nil {
+			return nil, fmt.Errorf("collections: dense grouped count-distinct missing prepared part %d", partIdx)
+		}
+		if localCode < 0 || localCode >= len(part.Distinct.Dictionary) || localCode >= len(part.Distinct.GlobalLocalRanks) {
+			return nil, fmt.Errorf("collections: dense grouped count-distinct distinct part %d local code=%d outside dictionary=%d ranks=%d", partIdx, localCode, len(part.Distinct.Dictionary), len(part.Distinct.GlobalLocalRanks))
+		}
+		value := part.Distinct.Dictionary[localCode]
+		rank, ok := ranks[value]
+		if !ok {
+			if uint64(len(ranks)) > uint64(^uint32(0)) {
+				return nil, fmt.Errorf("collections: dense grouped count-distinct global dictionary cardinality exceeds uint32")
+			}
+			rank = uint32(len(ranks))
+			ranks[value] = rank
+		}
+		part.Distinct.GlobalLocalRanks[localCode] = rank
+	}
+	if includeEmpty {
+		if _, ok := ranks[""]; !ok {
+			if uint64(len(ranks)) > uint64(^uint32(0)) {
+				return nil, fmt.Errorf("collections: dense grouped count-distinct global dictionary cardinality exceeds uint32")
+			}
+			ranks[""] = uint32(len(ranks))
+		}
+	}
+	return ranks, nil
+}
+
+func columnTypedColumnDenseGroupCountDistinctAddShardedRankOffsets(parts []columnTypedColumnPhysicalQueryPart, shardRefs [][]uint64, offsets []uint32, workers int) error {
+	if len(offsets) != len(shardRefs) {
+		return fmt.Errorf("collections: dense grouped count-distinct shard offsets=%d refs=%d", len(offsets), len(shardRefs))
+	}
+	errs := make([]error, len(shardRefs))
+	if workers < 2 || len(shardRefs) < 2 {
+		for shardIdx := range shardRefs {
+			if err := columnTypedColumnDenseGroupCountDistinctAddShardRankOffset(parts, shardRefs[shardIdx], offsets[shardIdx]); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	jobs := make(chan int)
+	var wg sync.WaitGroup
+	for workerIdx := 0; workerIdx < workers; workerIdx++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for shardIdx := range jobs {
+				errs[shardIdx] = columnTypedColumnDenseGroupCountDistinctAddShardRankOffset(parts, shardRefs[shardIdx], offsets[shardIdx])
+			}
+		}()
+	}
+	for shardIdx := range shardRefs {
+		jobs <- shardIdx
+	}
+	close(jobs)
+	wg.Wait()
+	for shardIdx := range errs {
+		if errs[shardIdx] != nil {
+			return errs[shardIdx]
+		}
+	}
+	return nil
+}
+
+func columnTypedColumnDenseGroupCountDistinctAddShardRankOffset(parts []columnTypedColumnPhysicalQueryPart, refs []uint64, offset uint32) error {
+	if offset == 0 {
+		return nil
+	}
+	for _, ref := range refs {
+		partIdx, localCode := columnTypedColumnDenseGroupCountDistinctUnpackRankRef(ref)
+		if partIdx < 0 || partIdx >= len(parts) {
+			return fmt.Errorf("collections: dense grouped count-distinct part reference=%d outside parts=%d", partIdx, len(parts))
+		}
+		part := parts[partIdx].DenseGroupCountDistinct
+		if part == nil {
+			return fmt.Errorf("collections: dense grouped count-distinct missing prepared part %d", partIdx)
+		}
+		if localCode < 0 || localCode >= len(part.Distinct.GlobalLocalRanks) {
+			return fmt.Errorf("collections: dense grouped count-distinct distinct part %d local code=%d outside ranks=%d", partIdx, localCode, len(part.Distinct.GlobalLocalRanks))
+		}
+		part.Distinct.GlobalLocalRanks[localCode] += offset
 	}
 	return nil
 }


### PR DESCRIPTION
## Scope

Refs #3324 and #3070.

This is no-aggregate one-shot typed-column q2 setup work only. It does not use aggregate metadata, does not change insert/load behavior, and does not make any ClickHouse superiority claim.

## Changes

- Use a packed-reference fill path for dense q2 sharded-rank setup when the adaptive q2 setup policy selects the sharded hash strategy.
- Avoid a second per-local-dictionary lookup/remap pass for distinct local ranks by filling local ranks from shard-owned packed part/local-code references, then applying shard offsets.
- Keep the existing current-map path for shared-heavy adaptive cases.
- Keep q2 post-prepare diagnostics split into group rank, distinct rank, and local rank phases; capacity/shard setup is included in the distinct-rank phase.
- Add a benchmark-only `adaptive_baseline` variant so production `adaptive` can be compared with the prior adaptive sharded behavior.

## Evidence

Microbench, `GOWORK=off go test ./TreeDB/collections -run '^$' -bench 'BenchmarkTypedColumnQ2DenseGroupCountDistinctGlobalRankPrep/(adaptive_baseline|adaptive)/(mixed|mostly_disjoint)/parts=160$' -benchtime=10x -count=3 -benchmem`:

| shape | baseline median | branch median | alloc B/op median | note |
| --- | ---: | ---: | ---: | --- |
| mostly_disjoint | 30.93ms | 24.14ms | 27.35MB -> 22.80MB | sharded strategy |
| mixed | 20.79ms | 18.35ms | 25.69MB -> 21.46MB | sharded strategy |

1M q2 same-host JSONBench, `one_shot_end_to_end` / `no_aggregate_metadata`, TreeDB only:

| build | total | setup | run | render/hash | post-prepare | group rank | distinct rank | local rank | rows scanned/matched/reduced |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
| origin/main 6a512fdc8 | 93.642ms | 70.884ms | 22.713ms | 0.045ms | 38.278ms | 0.069ms | 21.382ms | 13.544ms | 1,000,000 / 954,611 / 954,611 |
| branch 05afcc4f8 | 76.486ms | 56.581ms | 19.841ms | 0.063ms | 29.787ms | 0.044ms | 26.775ms | 0.877ms | 1,000,000 / 954,611 / 954,611 |

Artifacts:

- baseline q2: `/tmp/jsonbench_q2_baseline_main_20260629_225159/report.json`
- branch q2: `/tmp/jsonbench_q2_reference_fill_20260629_225045/report.json`

q1/q3 no-regression samples, same-host 1M `one_shot_end_to_end` / `no_aggregate_metadata`:

| query | origin/main total/setup/run | branch total/setup/run | rows scanned/matched/reduced |
| --- | ---: | ---: | --- |
| q1 | 13.685ms / 11.949ms / 1.701ms | 13.280ms / 11.668ms / 1.577ms | 1,000,000 / null / 1,000,000 |
| q3 | 37.820ms / 20.516ms / 17.286ms | 38.261ms / 20.631ms / 17.608ms | 1,000,000 / 588,328 / 588,328 |

Artifacts:

- baseline q1/q3: `/tmp/jsonbench_q1q3_baseline_main_20260629_225317/report.json`
- branch q1/q3: `/tmp/jsonbench_q1q3_reference_fill_20260629_225249/report.json`

`result_hash` is currently `null` in these JSONBench report rows; row counts and result groups are preserved in the q2 report row.

## Validation

- `GOWORK=off go test ./TreeDB/collections -run 'TestTypedColumnQ2(DenseGroupCountDistinct(GlobalRankPrepHarness|ShardedHashRankPrepEquivalence|AdaptiveRankPrepPolicy|OneShotRankPrepMatchesAdaptivePolicy|ShardedReferenceFillNullableEmpty|ShardedHashRankRunEquivalence|AdaptiveRankRunEquivalence|RankMapCapacity3158)|SortedGroupedDistinctLocalDictionariesAndEmptyValues1950|DenseGroupCountDistinctNoSortLocalDictionaries1950|DenseGroupCountDistinctLocalCodesNullableValues3080)' -count=1`
- `GOWORK=off go test ./TreeDB/collections -count=1`
- `GOWORK=off go test ./cmd/unified_bench -count=1`
- `GOWORK=off go test -race ./TreeDB/collections -run 'TestTypedColumnQ2DenseGroupCountDistinct(ShardedReferenceFillNullableEmpty|ShardedHashRankRunEquivalence|AdaptiveRankRunEquivalence)' -count=1`
- `git diff --check`