### PR TITLE
[codex] Add catalog-backed cluster route provider

### DIFF
--- a/TreeDB/docs/spec/raftplacement.md
+++ b/TreeDB/docs/spec/raftplacement.md
@@ -117,6 +117,16 @@ for token/ring decisions, the document token and token partition ID in request
 metadata that is excluded from deterministic command entry bytes and command
 digests.
 
+`nativewire.CatalogClusterRouteProvider` is the reusable adapter from
+`ResolvedCatalogV1` to `nativewire.ClusterRouteTarget`. It converts collection
+route decisions to collection targets, exactly-one-token token/ring decisions to
+token targets with partition metadata, and token-batch decisions to
+`token_batch` targets that carry the catalog classification
+(`same_partition`, `same_group_multi_partition`, or `fanout_required`).
+Non-fanout token-batch targets may include the single resolved group metadata,
+but adapters still reject token/ring multi-ID writes before submit until command
+split or fanout execution exists.
+
 Native-wire route preflight uses the default database and catalog plus the
 collection name encoded in the deterministic command sections. `create_collection`
 uses the collection metadata name; mutation commands use the collection-name

--- a/TreeDB/docs/spec/verification.md
+++ b/TreeDB/docs/spec/verification.md
@@ -256,6 +256,32 @@ Coverage:
   - `TestSearchTextReopenParityM4`
   - `BenchmarkSearchTextM4`
 
+## 11.2 Raft Placement Route Preflight
+
+Invariant:
+- Catalog-backed route preflight converts validated placement decisions to
+  request-only cluster route metadata, supports collection and single-token
+  token/ring targets, classifies token batches, and fails closed before submit
+  for token/ring multi-ID writes until split/fanout exists.
+
+Coverage:
+- `TreeDB/internal/raftplacement/route_test.go`:
+  - `TestRouteCollectionDecisionIncludesGroupMetadata`
+  - `TestRouteTokenDecisionIncludesPartitionAndGroupMetadata`
+  - `TestRouteDocumentTokenPreservesCollectionModeAndRoutesTokenModes`
+  - `TestRouteTokenBatchClassifiesDocumentTokens`
+  - `TestRouteTokenBatchFailsClosed`
+- `TreeDB/nativewire/cluster_submitter_test.go`:
+  - `TestCatalogClusterRouteProviderRoutesResolvedCatalog`
+  - `TestClusterRoutePreflightTokenPlacementSingleIDMutationCommands`
+  - `TestClusterRoutePreflightTokenPlacementRejectsMultiID`
+  - `TestClusterSubmitterRequestOnlyFieldsDoNotAlterDeterministicEntry`
+- `TreeDB/mongo_gateway/cluster_submitter_test.go`:
+  - `TestClusterRoutePreflightMongoTokenPlacementSingleIDWrites`
+  - `TestClusterRoutePreflightMongoTokenPlacementRejectsMultiIDWrites`
+- `TreeDB/internal/raftentry/contract_test.go`:
+  - `TestDigestV1StabilityAcrossMetadataAndApplyEntryID`
+
 ## 11.5 Planned User-Command WAL Durability Gate
 
 This section owns the canonical planned test matrix for the user-command WAL

--- a/TreeDB/mongo_gateway/cluster_submitter_test.go
+++ b/TreeDB/mongo_gateway/cluster_submitter_test.go
@@ -73,82 +73,16 @@ func (r *mongoRoutingClusterSubmitter) snapshotRoutes() []treenativewire.Cluster
 type mongoPlacementRouteClusterSubmitter struct {
 	*mongoClusterFakeSubmitter
 
-	routeMu sync.Mutex
-	catalog raftplacement.ResolvedCatalogV1
-	routes  []treenativewire.ClusterRouteRequest
+	routeMu  sync.Mutex
+	provider treenativewire.CatalogClusterRouteProvider
+	routes   []treenativewire.ClusterRouteRequest
 }
 
 func (p *mongoPlacementRouteClusterSubmitter) ClusterRoute(ctx context.Context, req treenativewire.ClusterRouteRequest) (treenativewire.ClusterRouteTarget, error) {
 	p.routeMu.Lock()
 	p.routes = append(p.routes, req)
 	p.routeMu.Unlock()
-	var decision raftplacement.RouteDecisionV1
-	var err error
-	switch {
-	case req.Shape == treenativewire.ClusterRouteShapeToken && req.TokenKnown:
-		decision, err = p.catalog.RouteDocumentToken(req.Database, req.Catalog, req.Collection, req.Token)
-	case req.Shape == treenativewire.ClusterRouteShapeTokenBatch:
-		return p.clusterRouteTokenBatch(req)
-	default:
-		decision, err = p.catalog.RouteCollection(req.Database, req.Catalog, req.Collection)
-	}
-	if err != nil {
-		return treenativewire.ClusterRouteTarget{}, err
-	}
-	target := mongoClusterRouteTargetFromDecision(decision)
-	if decision.Token.Present {
-		target.TokenKnown = true
-		target.Token = decision.Token.Token
-		target.PartitionID = string(decision.Token.Partition.ID)
-	}
-	return target, nil
-}
-
-func (p *mongoPlacementRouteClusterSubmitter) clusterRouteTokenBatch(req treenativewire.ClusterRouteRequest) (treenativewire.ClusterRouteTarget, error) {
-	ref := raftplacement.CollectionRefV1{Database: req.Database, Catalog: req.Catalog, Collection: req.Collection}
-	if placement, ok := p.catalog.Placement(ref); ok && placement.Mode == raftplacement.PlacementModeCollectionV1 {
-		decision, err := p.catalog.RouteCollection(req.Database, req.Catalog, req.Collection)
-		if err != nil {
-			return treenativewire.ClusterRouteTarget{}, err
-		}
-		return mongoClusterRouteTargetFromDecision(decision), nil
-	}
-	decision, err := p.catalog.ClassifyDocumentTokenBatch(req.Database, req.Catalog, req.Collection, req.Tokens)
-	if err != nil {
-		return treenativewire.ClusterRouteTarget{}, err
-	}
-	return mongoClusterRouteTargetFromTokenBatch(decision), nil
-}
-
-func mongoClusterRouteTargetFromDecision(decision raftplacement.RouteDecisionV1) treenativewire.ClusterRouteTarget {
-	members := make([]string, len(decision.Group.Members))
-	for i, member := range decision.Group.Members {
-		members[i] = string(member)
-	}
-	return treenativewire.ClusterRouteTarget{
-		GroupID:       string(decision.GroupID()),
-		Members:       members,
-		LeaderHint:    string(decision.LeaderHint()),
-		PlacementMode: string(decision.PlacementMode),
-		Shape:         treenativewire.ClusterRouteShape(decision.Shape),
-	}
-}
-
-func mongoClusterRouteTargetFromTokenBatch(decision raftplacement.RouteTokenBatchDecisionV1) treenativewire.ClusterRouteTarget {
-	target := treenativewire.ClusterRouteTarget{
-		PlacementMode:   string(decision.PlacementMode),
-		Shape:           treenativewire.ClusterRouteShapeTokenBatch,
-		TokenBatchClass: string(decision.Class),
-	}
-	if !decision.FanoutRequired() {
-		target.GroupID = string(decision.GroupID())
-		target.LeaderHint = string(decision.LeaderHint())
-		target.Members = make([]string, len(decision.Group.Members))
-		for i, member := range decision.Group.Members {
-			target.Members[i] = string(member)
-		}
-	}
-	return target
+	return p.provider.ClusterRoute(ctx, req)
 }
 
 func (p *mongoPlacementRouteClusterSubmitter) snapshotRoutes() []treenativewire.ClusterRouteRequest {
@@ -406,7 +340,7 @@ func newMongoPlacementRouteTestServer(tb testing.TB, mode raftplacement.Placemen
 	}
 	submitter := &mongoPlacementRouteClusterSubmitter{
 		mongoClusterFakeSubmitter: &mongoClusterFakeSubmitter{},
-		catalog:                   mustMongoRouteTestCatalog(tb, mode),
+		provider:                  treenativewire.NewCatalogClusterRouteProvider(mustMongoRouteTestCatalog(tb, mode)),
 	}
 	server.ClusterSubmitter = submitter
 	server.ClusterCatalogVersion = mongoClusterStaticCatalogVersion(60)

--- a/TreeDB/nativewire/cluster_route_provider.go
+++ b/TreeDB/nativewire/cluster_route_provider.go
@@ -1,0 +1,117 @@
+package nativewire
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/snissn/gomap/TreeDB/internal/raftplacement"
+)
+
+// CatalogClusterRouteProvider adapts a validated raftplacement catalog to the
+// nativewire route-preflight interface. It only returns catalog-derived
+// metadata; it does not prove live leadership or submit routed commands.
+type CatalogClusterRouteProvider struct {
+	catalog raftplacement.ResolvedCatalogV1
+}
+
+// NewCatalogClusterRouteProvider returns a route provider backed by a validated
+// raftplacement catalog.
+func NewCatalogClusterRouteProvider(catalog raftplacement.ResolvedCatalogV1) CatalogClusterRouteProvider {
+	return CatalogClusterRouteProvider{catalog: catalog}
+}
+
+// ClusterRoute resolves the request against the provider's catalog. Collection
+// placements can satisfy collection, single-token, and token-batch requests with
+// a collection target. Token/ring placements require a single token for submit
+// targets; multi-token batches return classification metadata so preflight can
+// fail closed before submit until split/fanout execution exists.
+func (p CatalogClusterRouteProvider) ClusterRoute(_ context.Context, request ClusterRouteRequest) (ClusterRouteTarget, error) {
+	switch normalizeClusterRouteShape(request.Shape) {
+	case ClusterRouteShapeCollection:
+		decision, err := p.catalog.RouteCollection(request.Database, request.Catalog, request.Collection)
+		if err != nil {
+			return ClusterRouteTarget{}, err
+		}
+		return clusterRouteTargetFromCatalogDecision(decision), nil
+	case ClusterRouteShapeToken:
+		if !request.TokenKnown {
+			return ClusterRouteTarget{}, errors.Join(
+				raftplacement.ErrInvalidRouteRequest,
+				raftplacement.ErrMissingRouteToken,
+				fmt.Errorf("%s/%s/%s token route request requires explicit token", request.Database, request.Catalog, request.Collection),
+			)
+		}
+		decision, err := p.catalog.RouteDocumentToken(request.Database, request.Catalog, request.Collection, request.Token)
+		if err != nil {
+			return ClusterRouteTarget{}, err
+		}
+		return clusterRouteTargetFromCatalogDecision(decision), nil
+	case ClusterRouteShapeTokenBatch:
+		return p.clusterRouteTokenBatch(request)
+	default:
+		return ClusterRouteTarget{}, errors.Join(
+			raftplacement.ErrInvalidRouteRequest,
+			raftplacement.ErrUnsupportedRouteShape,
+			fmt.Errorf("%s/%s/%s route shape %q", request.Database, request.Catalog, request.Collection, request.Shape),
+		)
+	}
+}
+
+func (p CatalogClusterRouteProvider) clusterRouteTokenBatch(request ClusterRouteRequest) (ClusterRouteTarget, error) {
+	ref := raftplacement.CollectionRefV1{
+		Database:   request.Database,
+		Catalog:    request.Catalog,
+		Collection: request.Collection,
+	}
+	if placement, ok := p.catalog.Placement(ref); ok && placement.Mode == raftplacement.PlacementModeCollectionV1 {
+		decision, err := p.catalog.RouteCollection(request.Database, request.Catalog, request.Collection)
+		if err != nil {
+			return ClusterRouteTarget{}, err
+		}
+		return clusterRouteTargetFromCatalogDecision(decision), nil
+	}
+	decision, err := p.catalog.ClassifyDocumentTokenBatch(request.Database, request.Catalog, request.Collection, request.Tokens)
+	if err != nil {
+		return ClusterRouteTarget{}, err
+	}
+	return clusterRouteTargetFromCatalogTokenBatch(decision), nil
+}
+
+func clusterRouteTargetFromCatalogDecision(decision raftplacement.RouteDecisionV1) ClusterRouteTarget {
+	target := ClusterRouteTarget{
+		GroupID:       string(decision.GroupID()),
+		Members:       clusterRouteGroupMembers(decision.Group.Members),
+		LeaderHint:    string(decision.LeaderHint()),
+		PlacementMode: string(decision.PlacementMode),
+		Shape:         ClusterRouteShape(decision.Shape),
+	}
+	if decision.Token.Present {
+		target.TokenKnown = true
+		target.Token = decision.Token.Token
+		target.PartitionID = string(decision.Token.Partition.ID)
+	}
+	return target
+}
+
+func clusterRouteTargetFromCatalogTokenBatch(decision raftplacement.RouteTokenBatchDecisionV1) ClusterRouteTarget {
+	target := ClusterRouteTarget{
+		PlacementMode:   string(decision.PlacementMode),
+		Shape:           ClusterRouteShapeTokenBatch,
+		TokenBatchClass: string(decision.Class),
+	}
+	if !decision.FanoutRequired() {
+		target.GroupID = string(decision.GroupID())
+		target.LeaderHint = string(decision.LeaderHint())
+		target.Members = clusterRouteGroupMembers(decision.Group.Members)
+	}
+	return target
+}
+
+func clusterRouteGroupMembers[T ~string](members []T) []string {
+	out := make([]string, len(members))
+	for i, member := range members {
+		out[i] = string(member)
+	}
+	return out
+}

--- a/TreeDB/nativewire/cluster_submitter_test.go
+++ b/TreeDB/nativewire/cluster_submitter_test.go
@@ -74,82 +74,16 @@ func (r *routingClusterSubmitter) snapshotRoutes() []ClusterRouteRequest {
 type placementRouteClusterSubmitter struct {
 	*fakeClusterSubmitter
 
-	routeMu sync.Mutex
-	catalog raftplacement.ResolvedCatalogV1
-	routes  []ClusterRouteRequest
+	routeMu  sync.Mutex
+	provider CatalogClusterRouteProvider
+	routes   []ClusterRouteRequest
 }
 
 func (p *placementRouteClusterSubmitter) ClusterRoute(ctx context.Context, req ClusterRouteRequest) (ClusterRouteTarget, error) {
 	p.routeMu.Lock()
 	p.routes = append(p.routes, req)
 	p.routeMu.Unlock()
-	var decision raftplacement.RouteDecisionV1
-	var err error
-	switch {
-	case req.Shape == ClusterRouteShapeToken && req.TokenKnown:
-		decision, err = p.catalog.RouteDocumentToken(req.Database, req.Catalog, req.Collection, req.Token)
-	case req.Shape == ClusterRouteShapeTokenBatch:
-		return p.clusterRouteTokenBatch(req)
-	default:
-		decision, err = p.catalog.RouteCollection(req.Database, req.Catalog, req.Collection)
-	}
-	if err != nil {
-		return ClusterRouteTarget{}, err
-	}
-	target := nativeClusterRouteTargetFromDecision(decision)
-	if decision.Token.Present {
-		target.TokenKnown = true
-		target.Token = decision.Token.Token
-		target.PartitionID = string(decision.Token.Partition.ID)
-	}
-	return target, nil
-}
-
-func (p *placementRouteClusterSubmitter) clusterRouteTokenBatch(req ClusterRouteRequest) (ClusterRouteTarget, error) {
-	ref := raftplacement.CollectionRefV1{Database: req.Database, Catalog: req.Catalog, Collection: req.Collection}
-	if placement, ok := p.catalog.Placement(ref); ok && placement.Mode == raftplacement.PlacementModeCollectionV1 {
-		decision, err := p.catalog.RouteCollection(req.Database, req.Catalog, req.Collection)
-		if err != nil {
-			return ClusterRouteTarget{}, err
-		}
-		return nativeClusterRouteTargetFromDecision(decision), nil
-	}
-	decision, err := p.catalog.ClassifyDocumentTokenBatch(req.Database, req.Catalog, req.Collection, req.Tokens)
-	if err != nil {
-		return ClusterRouteTarget{}, err
-	}
-	return nativeClusterRouteTargetFromTokenBatch(decision), nil
-}
-
-func nativeClusterRouteTargetFromDecision(decision raftplacement.RouteDecisionV1) ClusterRouteTarget {
-	members := make([]string, len(decision.Group.Members))
-	for i, member := range decision.Group.Members {
-		members[i] = string(member)
-	}
-	return ClusterRouteTarget{
-		GroupID:       string(decision.GroupID()),
-		Members:       members,
-		LeaderHint:    string(decision.LeaderHint()),
-		PlacementMode: string(decision.PlacementMode),
-		Shape:         ClusterRouteShape(decision.Shape),
-	}
-}
-
-func nativeClusterRouteTargetFromTokenBatch(decision raftplacement.RouteTokenBatchDecisionV1) ClusterRouteTarget {
-	target := ClusterRouteTarget{
-		PlacementMode:   string(decision.PlacementMode),
-		Shape:           ClusterRouteShapeTokenBatch,
-		TokenBatchClass: string(decision.Class),
-	}
-	if !decision.FanoutRequired() {
-		target.GroupID = string(decision.GroupID())
-		target.LeaderHint = string(decision.LeaderHint())
-		target.Members = make([]string, len(decision.Group.Members))
-		for i, member := range decision.Group.Members {
-			target.Members[i] = string(member)
-		}
-	}
-	return target
+	return p.provider.ClusterRoute(ctx, req)
 }
 
 func (p *placementRouteClusterSubmitter) snapshotRoutes() []ClusterRouteRequest {
@@ -700,6 +634,96 @@ func TestClusterRoutePreflightRejectsFanoutTokenBatch(t *testing.T) {
 	}
 }
 
+func TestCatalogClusterRouteProviderRoutesResolvedCatalog(t *testing.T) {
+	collectionProvider := NewCatalogClusterRouteProvider(mustNativewireRouteTestCatalog(t, raftplacement.PlacementModeCollectionV1))
+	collectionTarget, err := collectionProvider.ClusterRoute(context.Background(), ClusterRouteRequest{
+		Database:   "default",
+		Catalog:    "default",
+		Collection: "users",
+		Shape:      ClusterRouteShapeCollection,
+	})
+	if err != nil {
+		t.Fatalf("ClusterRoute collection: %v", err)
+	}
+	if collectionTarget.GroupID != "group-a" || collectionTarget.LeaderHint != "node-a" || collectionTarget.PlacementMode != string(raftplacement.PlacementModeCollectionV1) || collectionTarget.Shape != ClusterRouteShapeCollection {
+		t.Fatalf("collection target=%+v want group-a/node-a collection", collectionTarget)
+	}
+	if !reflect.DeepEqual(collectionTarget.Members, []string{"node-a", "node-b"}) {
+		t.Fatalf("collection members=%v want [node-a node-b]", collectionTarget.Members)
+	}
+
+	for _, mode := range []raftplacement.PlacementModeV1{raftplacement.PlacementModeTokenV1, raftplacement.PlacementModeRingV1} {
+		t.Run(string(mode), func(t *testing.T) {
+			provider := NewCatalogClusterRouteProvider(mustNativewireRouteBatchTestCatalog(t, mode))
+			tokenTarget, err := provider.ClusterRoute(context.Background(), ClusterRouteRequest{
+				Database:   "default",
+				Catalog:    "default",
+				Collection: "users",
+				Shape:      ClusterRouteShapeToken,
+				TokenKnown: true,
+				Token:      12,
+			})
+			if err != nil {
+				t.Fatalf("ClusterRoute token: %v", err)
+			}
+			if tokenTarget.GroupID != "group-a" || tokenTarget.LeaderHint != "node-a" || tokenTarget.PlacementMode != string(mode) || tokenTarget.Shape != ClusterRouteShapeToken {
+				t.Fatalf("token target=%+v want group-a/node-a %s token", tokenTarget, mode)
+			}
+			if !tokenTarget.TokenKnown || tokenTarget.Token != 12 || tokenTarget.PartitionID != "p1" {
+				t.Fatalf("token target token known/token/partition=%v/%d/%q want true/12/p1", tokenTarget.TokenKnown, tokenTarget.Token, tokenTarget.PartitionID)
+			}
+
+			tests := []struct {
+				name      string
+				tokens    []uint64
+				wantClass raftplacement.TokenBatchRouteClassV1
+				wantGroup string
+			}{
+				{
+					name:      "same_partition",
+					tokens:    []uint64{1, 2},
+					wantClass: raftplacement.TokenBatchRouteSamePartitionV1,
+					wantGroup: "group-a",
+				},
+				{
+					name:      "same_group_multi_partition",
+					tokens:    []uint64{1, 12},
+					wantClass: raftplacement.TokenBatchRouteSameGroupV1,
+					wantGroup: "group-a",
+				},
+				{
+					name:      "fanout_required",
+					tokens:    []uint64{1, 20},
+					wantClass: raftplacement.TokenBatchRouteFanoutRequiredV1,
+				},
+			}
+			for _, tc := range tests {
+				t.Run(tc.name, func(t *testing.T) {
+					target, err := provider.ClusterRoute(context.Background(), ClusterRouteRequest{
+						Database:   "default",
+						Catalog:    "default",
+						Collection: "users",
+						Shape:      ClusterRouteShapeTokenBatch,
+						Tokens:     tc.tokens,
+					})
+					if err != nil {
+						t.Fatalf("ClusterRoute token batch: %v", err)
+					}
+					if target.PlacementMode != string(mode) || target.Shape != ClusterRouteShapeTokenBatch || target.TokenBatchClass != string(tc.wantClass) {
+						t.Fatalf("token batch target=%+v want mode=%s class=%s", target, mode, tc.wantClass)
+					}
+					if target.GroupID != tc.wantGroup {
+						t.Fatalf("token batch group=%q want %q", target.GroupID, tc.wantGroup)
+					}
+					if tc.wantClass == raftplacement.TokenBatchRouteFanoutRequiredV1 && (target.LeaderHint != "" || len(target.Members) != 0) {
+						t.Fatalf("fanout target unexpectedly selected leader/members: %+v", target)
+					}
+				})
+			}
+		})
+	}
+}
+
 func TestClusterRoutePreflightSkipsMalformedDeterministicEntry(t *testing.T) {
 	submitter := &routingClusterSubmitter{
 		fakeClusterSubmitter: &fakeClusterSubmitter{},
@@ -741,7 +765,7 @@ func TestClusterRoutePreflightTokenPlacementAcceptsSingleID(t *testing.T) {
 	catalog := mustNativewireRouteTestCatalog(t, raftplacement.PlacementModeTokenV1)
 	submitter := &placementRouteClusterSubmitter{
 		fakeClusterSubmitter: &fakeClusterSubmitter{},
-		catalog:              catalog,
+		provider:             NewCatalogClusterRouteProvider(catalog),
 	}
 	client, _, _ := serveCollectionPipeWithOptions(t, ServerOptions{ClusterSubmitter: submitter})
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
@@ -849,7 +873,7 @@ func TestClusterRoutePreflightTokenPlacementSingleIDMutationCommands(t *testing.
 				catalog := mustNativewireRouteTestCatalog(t, mode)
 				submitter := &placementRouteClusterSubmitter{
 					fakeClusterSubmitter: &fakeClusterSubmitter{},
-					catalog:              catalog,
+					provider:             NewCatalogClusterRouteProvider(catalog),
 				}
 				client, _, _ := serveCollectionPipeWithOptions(t, ServerOptions{ClusterSubmitter: submitter})
 				ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
@@ -885,7 +909,7 @@ func TestClusterRoutePreflightCollectionPlacementAcceptsMultiIDBatch(t *testing.
 	catalog := mustNativewireRouteTestCatalog(t, raftplacement.PlacementModeCollectionV1)
 	submitter := &placementRouteClusterSubmitter{
 		fakeClusterSubmitter: &fakeClusterSubmitter{},
-		catalog:              catalog,
+		provider:             NewCatalogClusterRouteProvider(catalog),
 	}
 	client, _, _ := serveCollectionPipeWithOptions(t, ServerOptions{ClusterSubmitter: submitter})
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
@@ -958,7 +982,7 @@ func TestClusterRoutePreflightTokenPlacementRejectsMultiID(t *testing.T) {
 			catalog := mustNativewireRouteTestCatalog(t, raftplacement.PlacementModeRingV1)
 			submitter := &placementRouteClusterSubmitter{
 				fakeClusterSubmitter: &fakeClusterSubmitter{},
-				catalog:              catalog,
+				provider:             NewCatalogClusterRouteProvider(catalog),
 			}
 			client, _, _ := serveCollectionPipeWithOptions(t, ServerOptions{ClusterSubmitter: submitter})
 			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
@@ -998,6 +1022,44 @@ func mustNativewireRouteTestCatalog(tb testing.TB, mode raftplacement.PlacementM
 	})
 	if err != nil {
 		tb.Fatalf("Validate route test catalog: %v", err)
+	}
+	return catalog
+}
+
+func mustNativewireRouteBatchTestCatalog(tb testing.TB, mode raftplacement.PlacementModeV1) raftplacement.ResolvedCatalogV1 {
+	tb.Helper()
+	catalog, err := raftplacement.Validate(raftplacement.CatalogV1{
+		Features: raftplacement.DefaultFeatureSet(),
+		Groups: []raftplacement.GroupV1{
+			{
+				ID:         "group-a",
+				Members:    []raftcluster.NodeID{"node-a", "node-b"},
+				LeaderHint: "node-a",
+			},
+			{
+				ID:         "group-b",
+				Members:    []raftcluster.NodeID{"node-c", "node-d"},
+				LeaderHint: "node-c",
+			},
+		},
+		Placements: []raftplacement.CollectionPlacementV1{
+			{
+				Collection: raftplacement.CollectionRefV1{
+					Database:   "default",
+					Catalog:    "default",
+					Collection: "users",
+				},
+				Mode: mode,
+				TokenPartitions: []raftplacement.TokenPartitionV1{
+					{ID: "p0", GroupID: "group-a", Start: 0, End: 9},
+					{ID: "p1", GroupID: "group-a", Start: 10, End: 19},
+					{ID: "p2", GroupID: "group-b", Start: 20, End: ^uint64(0)},
+				},
+			},
+		},
+	})
+	if err != nil {
+		tb.Fatalf("Validate batch route test catalog: %v", err)
 	}
 	return catalog
 }


### PR DESCRIPTION
## Summary

- add `nativewire.CatalogClusterRouteProvider` backed by `raftplacement.ResolvedCatalogV1`
- route collection and single-token token/ring requests to `ClusterRouteTarget` metadata
- expose token-batch classes for same-partition, same-group, and fanout-required batches while preserving fail-closed submitter behavior
- update nativewire and Mongo tests to exercise the shared provider instead of duplicate catalog fakes
- document the provider boundary and verification coverage

Closes #3381
Part of #3046

## Tests

- `GOWORK=off go test ./TreeDB/internal/raftplacement -count=1`
- `GOWORK=off go test ./TreeDB/nativewire -run 'TestClusterRoute|TestClusterSubmitter' -count=1`
- `GOWORK=off go test ./TreeDB/mongo_gateway -run 'TestClusterRoute|TestClusterSubmitter|TestClusterAdmission' -count=1`
- `GOWORK=off go test ./TreeDB/internal/raftentry -count=1`
- `git diff --check origin/main...HEAD`