### PR TITLE
[codex] docs: reconcile publication readability closeout

### DIFF
--- a/TreeDB/docs/spec/publication-readability-3245.md
+++ b/TreeDB/docs/spec/publication-readability-3245.md
@@ -1,8 +1,10 @@
-# Publication Readability Map (#3245)
+# Publication Readability Map (#3245, #3382 Closeout)
 
 This note maps the current TreeDB publication/readability contract for #2026 M0
-and the #3044 production gate. It describes existing commit surfaces and the
-current behavior fault model that tests should preserve.
+and the #3382 closeout reconciliation. It describes the local commit surfaces
+and current behavior fault model that tests should preserve. It does not claim
+distributed Raft HA, read-index, snapshot/rejoin, or routing/fanout readiness;
+those remain owned by #3044, #3045, and #3046.
 
 ## Invariant
 
@@ -10,6 +12,36 @@ A published commit MUST NOT make roots, catalog metadata, or value-log pointers
 visible unless the bytes needed to read them are also readable by snapshots that
 observe that commit. A snapshot sees the commit sequence, user root, system root,
 value-log set, and `AppliedCommandLSN` as one published state tuple.
+
+## #2026 Closeout State
+
+As of the #3382 reconciliation, #2026 has one final local state:
+
+- Local collection catalog publication/readability is covered by deterministic
+  EOF fault tests that separate bounded pre-commit catalog retries from
+  post-commit `ErrCommitAmbiguous` failures.
+- Local forced-pointer value-log readability is covered at the collection,
+  nativewire, snapshot, reopen, and current-writable value-log boundaries.
+- External nativewire YCSB load evidence completed 100k and 1M insert loads with
+  zero `INSERT_ERROR` on the recorded current-head evidence commit.
+- The remaining invalid intermediate 1M nativewire YCSB artifact is classified
+  as a non-reproduced client/harness/protocol/server-lifecycle interruption, not
+  current evidence of a TreeDB catalog/value-log publication failure.
+
+The closeout load evidence was recorded on gomap commit
+`61910b8eac108c5f2c35f07a374879d1fb2dc5c8`. The diagnostic classification gate
+was recorded on commit `3f2c712bb700806b29deb872ed90531d4828ab79`. #3382 does
+not rerun that diagnostic because the delta from the diagnostic commit to the
+current `origin/main` base `f42a7002b` is Raft snapshot-tail work, diagnostic
+script/docs updates, and Q2 query benchmark/reference-fill work; it does not
+change the nativewire insert path, collection catalog publication path, or
+value-log pointer read-boundary code that #2026 owns.
+
+After #3382 merges, #2026 can close for local single-node
+publication/readability and the nativewire YCSB caveat. That closeout must not
+be used as a distributed-cluster claim: #3044 owns single-group HA and honest
+`raft_committed` write semantics, #3045 owns read-index/snapshot/rejoin
+semantics, and #3046 owns multi-group routing and ring/token partitioning.
 
 ## Collection Catalog Publication
 
@@ -72,16 +104,31 @@ marker is not a recovery source of truth for command visibility.
 - `TreeDB/collections/publication_readability_test.go`
   - pre-commit catalog metadata/root EOF retries through `InsertBatch`,
   - retry exhaustion preserves the contextual catalog load error,
-  - post-commit catalog EOF from vector-index maintenance returns
-    `ErrCommitAmbiguous` while the document remains visible.
+  - post-commit catalog metadata/root EOF from vector-index maintenance returns
+    `ErrCommitAmbiguous` while the document remains visible,
+  - cached forced-pointer catalog documents are readable from a fresh snapshot,
+  - current-writable value-log pointer reads are either readable through the
+    read barrier or fail with explicit unexpected-EOF context rather than being
+    misclassified as commit ambiguity.
 - `TreeDB/caching/vlog_current_segment_readbarrier_test.go`
   - cached-mode value-log pointer read barrier is installed/invocable and
     backend-visible pointer roots resolve through backend, cached, and snapshot
     reads.
+- `TreeDB/nativewire/forced_pointer_readability_test.go`
+  - nativewire YCSB-shaped forced-pointer inserts are readable before flush,
+    after `FlushAll`/`Checkpoint`, and after close/reopen,
+  - nativewire current-writable value-log reads hit the read barrier and surface
+    explicit read-boundary EOF when injected.
+- `docs/benchmarks/nativewire_ycsb_closeout_2026-06-30.md`
+  - external 100k and 1M nativewire load evidence with zero `INSERT_ERROR`.
+- `docs/benchmarks/nativewire_ycsb_insert_error_classification_2026-06-30.md`
+  - diagnostic-gate classification of the invalid intermediate nativewire YCSB
+    caveat.
 
 ## Non-Goals
 
 This note does not define migrations, cross-version compatibility, Raft
-ordering, native-wire submitter behavior, or Mongo gateway request semantics.
-Those surfaces may cite this map, but #3245 owns only the local publication and
-readability model above.
+ordering, distributed HA, read-index/snapshot/rejoin behavior, multi-group
+routing, native-wire cluster submitter behavior, or Mongo gateway cluster
+semantics. Those surfaces may cite this map, but #3245/#3382 own only the local
+publication/readability model and evidence reconciliation above.

--- a/TreeDB/docs/spec/verification.md
+++ b/TreeDB/docs/spec/verification.md
@@ -42,6 +42,12 @@ Invariant:
   value-log pointers, snapshots, and `AppliedCommandLSN` as a readable state
   tuple. Bounded pre-commit catalog EOF is retriable; post-commit readability
   failure is commit-ambiguous.
+- The #2026 local closeout state is final after #3382: collection catalog
+  publication/readability, forced-pointer value-log readability, current-writable
+  value-log read barriers, nativewire forced-pointer publication, and external
+  nativewire YCSB diagnostic evidence are covered locally. Distributed HA,
+  read-index/snapshot/rejoin, and routing/fanout remain owned by #3044, #3045,
+  and #3046.
 
 Coverage:
 - `TreeDB/docs/spec/publication-readability-3245.md`
@@ -49,8 +55,25 @@ Coverage:
   - `TestCollectionCatalogEOFInsertBatchPreCommitRetryUsesCatalogLoadFaults`
   - `TestCollectionCatalogEOFInsertBatchRetryExhaustionIncludesCatalogContext`
   - `TestCollectionCatalogEOFInsertBatchPostCommitReturnsCommitAmbiguous`
+  - `TestCollectionCatalogRootEOFInsertBatchPostCommitReturnsCommitAmbiguous`
+  - `TestCollectionCatalogCachedForcedPointersReadableFromFreshSnapshot`
+  - `TestCollectionCatalogCurrentWritableValueLogReadBarrier`
 - `TreeDB/caching/vlog_current_segment_readbarrier_test.go`:
   - `TestCachedModeValueLogPointerReadBarrierResolvesBackendRootRead`
+- `TreeDB/nativewire/forced_pointer_readability_test.go`:
+  - `TestNativewireYCSBForcedPointerPublicationReadability`
+  - `TestNativewireYCSBCurrentWritableValueLogReadBarrier`
+- `docs/benchmarks/nativewire_ycsb_closeout_2026-06-30.md`:
+  - current-head external 100k and 1M nativewire load evidence with zero
+    `INSERT_ERROR`.
+- `docs/benchmarks/nativewire_ycsb_insert_error_classification_2026-06-30.md`:
+  - diagnostic gate with `TREEDB_YCSB_LOG_ERRORS=1`, `-p silence=false`, empty
+    stderr, zero raw matches for `INSERT_ERROR`, `EOF`, `ambiguous`, `panic`,
+    `fatal`, `ERROR`, and `Failed`, and classification of the invalid
+    intermediate artifact as non-current TreeDB publication evidence.
+- `scripts/nativewire_ycsb_diagnostic.sh`:
+  - reusable diagnostic gate that exits nonzero on detected load failures,
+    `INSERT_ERROR`, or raw error-scan matches.
 
 ## 3. Value-Log Reachability GC
 

--- a/docs/benchmarks/nativewire_ycsb_closeout_2026-06-30.md
+++ b/docs/benchmarks/nativewire_ycsb_closeout_2026-06-30.md
@@ -1,8 +1,10 @@
 # TreeDB Nativewire YCSB Closeout Evidence
 
 Status: external `go-ycsb` nativewire load-only closeout evidence for #2026
-and #3355 refreshed on current `origin/main` commit
-`61910b8eac108c5f2c35f07a374879d1fb2dc5c8`.
+and #3355 refreshed on `origin/main` commit
+`61910b8eac108c5f2c35f07a374879d1fb2dc5c8`; reconciled by #3382 with the
+#3374 diagnostic classification at
+`3f2c712bb700806b29deb872ed90531d4828ab79`.
 
 This refresh includes the later Raft snapshot/route-preflight merges that the
 first closeout capture predated, including
@@ -15,8 +17,35 @@ coverage at `61910b8eac108c5f2c35f07a374879d1fb2dc5c8`.
 This report records the final 100k and 1M nativewire YCSB load checks requested
 by #2026 after the deterministic publication/readability slices landed. It is
 developer-machine correctness and throughput evidence for the nativewire load
-path. It does not replace the full MongoDB / TreeDB comparison matrix in
-`docs/benchmarks/ycsb_latest_main_2026-06-03.md`.
+path, and #3382 classifies the remaining invalid intermediate YCSB caveat as
+non-current TreeDB publication evidence. It does not replace the full MongoDB /
+TreeDB comparison matrix in `docs/benchmarks/ycsb_latest_main_2026-06-03.md`,
+and it does not claim distributed Raft HA, read-index/snapshot/rejoin, or
+routing/fanout readiness.
+
+## #3382 Reconciliation
+
+The local #2026 closeout state is:
+
+- deterministic publication/readability tests cover collection catalog EOF
+  fault boundaries, forced value-log pointers, current-writable value-log read
+  barriers, snapshot/reopen readability, and the nativewire YCSB-shaped path;
+- this report covers the external 100k and 1M nativewire load evidence with
+  zero `INSERT_ERROR`;
+- `docs/benchmarks/nativewire_ycsb_insert_error_classification_2026-06-30.md`
+  classifies the invalid intermediate 1M `INSERT_ERROR` artifact as a
+  non-reproduced client/harness/protocol/server-lifecycle interruption, not as
+  evidence of a current catalog/value-log publication failure.
+
+#3382 did not rerun `scripts/nativewire_ycsb_diagnostic.sh`. The diagnostic
+evidence at `3f2c712bb700806b29deb872ed90531d4828ab79` already includes the
+later route-preflight context that made the original `61910b8e...` evidence
+worth refreshing. The remaining delta to current `origin/main` `f42a7002b` is
+Raft snapshot-tail work, diagnostic script/docs changes, and Q2 query
+benchmark/reference-fill work, not changes to the nativewire insert path,
+collection catalog publication path, or value-log pointer read-boundary code.
+That makes #3382 a docs-only closeout reconciliation rather than a fresh
+benchmark run.
 
 ## Benchmark Boundary
 
@@ -157,16 +186,17 @@ This closeout run proves the compatible external nativewire YCSB client can load
 100k and 1M records against the current `command_wal_relaxed` TreeDB nativewire
 server with zero insert errors on this host. The refreshed capture removes the
 stale-head caveat from the earlier `2b784debb05028f706b46127a41f6d578c3d4c13`
-run. It supports #2026 closeout for the external YCSB evidence requirement,
-while the deterministic publication and readability proof remains documented by
-the issue and its earlier test PRs.
+run. Together with the deterministic publication/readability tests and the
+#3374 diagnostic classification, it supports closing #2026 for the local
+single-node publication/readability invariant after #3382 merges.
 
 During the current-base refresh, an invalid intermediate 1M run at
 `/tmp/treedb_native_ycsb_current_head_20260629_202356` stopped at 768,001
 successful inserts and reported `INSERT_ERROR`; its server log had no panic,
 fatal error, EOF, or ambiguous-commit marker. A clean 1M rerun and the final
-paired capture above both completed with zero `INSERT_ERROR`. Keep #2026 open
-for the deeper publication/readability invariant and intermittent-failure proof.
+paired capture above both completed with zero `INSERT_ERROR`. The #3374
+diagnostic below classifies that artifact, so it no longer blocks local #2026
+publication/readability closeout.
 
 Follow-up #3374 classification lives in
 `docs/benchmarks/nativewire_ycsb_insert_error_classification_2026-06-30.md`.
@@ -178,3 +208,7 @@ zero `INSERT_ERROR`, empty stderr, and zero raw matches for `EOF`, `ambiguous`,
 invalid because it lacks client-side error strings, but it is now classified as
 a non-reproduced client/harness/protocol/server-lifecycle interruption rather
 than evidence of a current catalog/value-log publication failure.
+
+This remains single-host nativewire load evidence. Distributed single-group HA,
+linearizable reads/snapshots/rejoin, and multi-group routing/ring partitioning
+remain owned by #3044, #3045, and #3046 respectively.

--- a/docs/benchmarks/nativewire_ycsb_insert_error_classification_2026-06-30.md
+++ b/docs/benchmarks/nativewire_ycsb_insert_error_classification_2026-06-30.md
@@ -1,13 +1,34 @@
 # TreeDB Nativewire YCSB INSERT_ERROR Classification
 
-Status: diagnostic classification evidence for #3374 under parent #2026.
+Status: diagnostic classification evidence for #3374 under parent #2026,
+reconciled by #3382 as the final nativewire YCSB caveat classification for
+local publication/readability closeout.
 
 This report classifies the invalid intermediate 1M nativewire YCSB load at
 `/tmp/treedb_native_ycsb_current_head_20260629_202356` and records a fresh
 current-head diagnostic gate with client-side operation error logging enabled.
 It only covers the remaining intermittent `INSERT_ERROR` caveat from the #3364
-refresh. It does not claim Raft HA, snapshot/read-index/routing, or full #2026
-root-cause closeout.
+refresh. By itself it does not claim Raft HA, snapshot/read-index/routing, or a
+full #2026 closeout. Combined with the deterministic local
+publication/readability tests and the #3382 verification-matrix update, it
+removes the nativewire YCSB caveat as a blocker to closing #2026 for local
+single-node storage publication/readability.
+
+## #3382 Reconciliation
+
+The diagnostic commit recorded by this artifact is
+`3f2c712bb700806b29deb872ed90531d4828ab79`. #3382 did not rerun the diagnostic
+script because the delta to current `origin/main` `f42a7002b` is Raft
+snapshot-tail work, this diagnostic script/docs merge, and Q2 query
+benchmark/reference-fill work; it does not modify the nativewire insert path,
+collection catalog publication path, or value-log pointer read-boundary code
+that #2026 owns.
+
+After #3382 merges, this classification should be read as final for the invalid
+intermediate YCSB artifact: it is a non-reproduced
+client/harness/protocol/server-lifecycle interruption, not current evidence of
+a TreeDB catalog/value-log publication failure. The residual distributed
+cluster work remains outside #2026 and is owned by #3044, #3045, and #3046.
 
 ## Boundary
 
@@ -175,11 +196,11 @@ fatal, `ERROR`, or `Failed` text.
 | Artifact | Classification | Evidence | Residual Risk |
 | --- | --- | --- | --- |
 | `/tmp/treedb_native_ycsb_current_head_20260629_202356` | Invalid, non-reproduced intermediate client/harness/protocol/server-lifecycle interruption. Not evidence of a current TreeDB catalog/value-log publication/readability failure. | The 1M run reports client-side `INSERT_ERROR` counters, but no server-side `EOF`, ambiguous commit, panic, fatal error, or failure marker. The original command lacked error logging, so it cannot identify the exact client error string. Later clean #3364 evidence and the logged current-head #3374 diagnostic both complete 100k and 1M loads with zero raw scan matches. | The exact old client error is unavailable. If this shape recurs with `TREEDB_YCSB_LOG_ERRORS=1`, preserve the artifact and classify the logged error string as client harness, nativewire protocol, server lifecycle, or storage. |
-| `/tmp/treedb_native_ycsb_diagnostic_20260629_224839` | Current-head diagnostic pass. | 100k and 1M loads both exit 0, complete all requested inserts, produce empty stderr, and scan clean for `INSERT_ERROR`, `EOF`, `ambiguous`, `panic`, `fatal`, `ERROR`, and `Failed`. | This is a single-host developer-machine diagnostic gate, not a distributed HA proof. #2026 remains open for the broader publication/readability invariant and any final closeout decision. |
+| `/tmp/treedb_native_ycsb_diagnostic_20260629_224839` | Current-head diagnostic pass. | 100k and 1M loads both exit 0, complete all requested inserts, produce empty stderr, and scan clean for `INSERT_ERROR`, `EOF`, `ambiguous`, `panic`, `fatal`, `ERROR`, and `Failed`. | This is a single-host developer-machine diagnostic gate, not a distributed HA proof. After #3382 merges it supports #2026 local closeout, while #3044/#3045/#3046 retain distributed HA/read/routing scope. |
 
 Conclusion: the preserved intermediate `INSERT_ERROR` artifact should be treated
 as a non-reproduced diagnostic caveat, not as current evidence of a TreeDB-owned
 storage publication bug. The old artifact is still useful because it explains
 why #2026 stayed open after #3364, but the current logged gate makes the caveat
-defensible: if the failure recurs, the harness now captures the missing
-client-side error strings needed to assign ownership.
+defensible and final for #3382: if the failure recurs, the harness now captures
+the missing client-side error strings needed to assign ownership.

--- a/docs/benchmarks/ycsb_mongodb_treedb_current.md
+++ b/docs/benchmarks/ycsb_mongodb_treedb_current.md
@@ -37,8 +37,11 @@ counts. It includes the later Raft snapshot/route-preflight merges, but does
 not replace the full comparison matrix above. The follow-up #3374 diagnostic
 report, `docs/benchmarks/nativewire_ycsb_insert_error_classification_2026-06-30.md`,
 classifies the previously invalid intermediate 1M `INSERT_ERROR` artifact with
-a current-head rerun using client-side error logging. Keep #2026 open for the
-deeper publication/readability invariant and final closeout decision.
+a current-head rerun using client-side error logging. The #3382 reconciliation
+combines those reports with the deterministic local publication/readability
+tests and treats the nativewire YCSB caveat as closed for #2026 local
+publication/readability. Distributed HA, read-index/snapshot/rejoin, and
+routing/fanout remain owned by #3044, #3045, and #3046.
 
 ## Current Headline
 
@@ -59,8 +62,8 @@ UTC latest-main report.
 
 | report | status | use |
 | --- | --- | --- |
-| `docs/benchmarks/nativewire_ycsb_insert_error_classification_2026-06-30.md` | #3374 classification of the invalid intermediate nativewire `INSERT_ERROR` caveat. | Use for the current-head diagnostic run with `TREEDB_YCSB_LOG_ERRORS=1`, `-p silence=false`, raw scan counts, and the owner/risk classification for `/tmp/treedb_native_ycsb_current_head_20260629_202356`. |
-| `docs/benchmarks/nativewire_ycsb_closeout_2026-06-30.md` | #2026 nativewire load-only closeout evidence refreshed after later Raft merges. | Use for the 100k and 1M external `go-ycsb treedb-native` load proof on commit `61910b8eac108c5f2c35f07a374879d1fb2dc5c8` with `collection_meta` v5 compatibility; use the #3374 classification report for the recorded invalid intermediate 1M run. |
+| `docs/benchmarks/nativewire_ycsb_insert_error_classification_2026-06-30.md` | #3374 classification of the invalid intermediate nativewire `INSERT_ERROR` caveat; final for #3382 local closeout. | Use for the current-head diagnostic run with `TREEDB_YCSB_LOG_ERRORS=1`, `-p silence=false`, raw scan counts, and the owner/risk classification for `/tmp/treedb_native_ycsb_current_head_20260629_202356`. |
+| `docs/benchmarks/nativewire_ycsb_closeout_2026-06-30.md` | #2026 nativewire load-only closeout evidence refreshed after later Raft merges; reconciled by #3382. | Use for the 100k and 1M external `go-ycsb treedb-native` load proof on commit `61910b8eac108c5f2c35f07a374879d1fb2dc5c8` with `collection_meta` v5 compatibility; use the #3374 classification report for the recorded invalid intermediate 1M run. |
 | `docs/benchmarks/ycsb_latest_main_2026-06-03.md` | Current external YCSB report. | Use for current headline MongoDB / TreeDB nativewire / TreeDB Mongo gateway results on latest `origin/main` after the June 3 rerun. |
 | `docs/benchmarks/ycsb_post_update_stack_2026-06-02.md` | Superseded latest-current report. | Keep for post-update-path-stack evidence before the latest main rerun and for comparison deltas. |
 | `docs/benchmarks/ycsb_mongodb_treedb_2026-05-31.md` | Historical legacy-profile report. | Keep for the original MongoDB / TreeDB native / TreeDB Mongo comparison and the post-load Mongo-gateway cliff attribution. Do not use its `fast` rows as current public-profile guidance. |


### PR DESCRIPTION
## Summary

- Reconcile #2026/#3382 docs to one local final state: local publication/readability covered, nativewire YCSB caveat classified, and #3044/#3045/#3046 kept as distributed scope.
- Update the verification matrix with current-writable value-log, nativewire forced-pointer, and diagnostic-gate evidence.
- Refresh the nativewire YCSB reports and benchmark index with the evidence commit delta and why this PR is docs-only instead of a fresh diagnostic rerun.

Closes #3382.
Refs #2026, #3044, #3045, #3046.

## Validation

- `GOWORK=off go test ./TreeDB/collections ./TreeDB/nativewire ./TreeDB/caching ./TreeDB/docs -count=1`
- `GOWORK=off go test ./TreeDB/collections -run 'TestCollectionCommandWALBSONYCSBPointLookupAfterLoad|TestCollectionCatalog' -count=1`
- `git diff --check origin/main...HEAD`

## Notes

- Did not rerun `scripts/nativewire_ycsb_diagnostic.sh`: the diagnostic evidence at `3f2c712bb700806b29deb872ed90531d4828ab79` is still current for the #2026-owned nativewire insert, collection catalog publication, and value-log read-boundary paths. The delta to current `origin/main` `f42a7002b` is Raft snapshot-tail work, diagnostic script/docs changes, and Q2 query benchmark/reference-fill work.
- After this PR merges, #2026 can close for local single-node publication/readability and the nativewire YCSB caveat, while distributed HA/read/routing work remains in #3044/#3045/#3046.
