### PR TITLE
[codex] raft: add recovery readiness status

### DIFF
--- a/TreeDB/docs/spec/native-query-raft-roadmap.md
+++ b/TreeDB/docs/spec/native-query-raft-roadmap.md
@@ -248,7 +248,9 @@ Acceptance:
 - the same committed entry sequence applied to fresh DBs in separate processes
   produces the same logical state digest,
 - snapshot restore plus log-tail replay produces the same logical state digest
-  as full log replay,
+  as full log replay, with `RecoveryStatusV1` reporting `tail_pending`,
+  `tail_complete`, and `ready_applied_index` from local durable evidence rather
+  than claiming production snapshot transfer, log truncation, or rejoin support,
 - mixed-version clusters refuse to advertise or append command versions that any
   voting replica cannot decode and apply.
 

--- a/TreeDB/docs/spec/raftcluster.md
+++ b/TreeDB/docs/spec/raftcluster.md
@@ -4,8 +4,9 @@ Status: normative for the initial `TreeDB/internal/raftcluster` package.
 
 This document records the #3044-0 storage and configuration boundary that later
 single-group Raft slices may depend on. It does not choose a Raft library, start
-a consensus loop, admit writes, enable `ack_policy=raft_committed`, install
-snapshots, truncate logs, or route multiple groups.
+a consensus loop, admit writes, enable `ack_policy=raft_committed`, perform
+production snapshot transfer, truncate logs, rejoin nodes, or route multiple
+groups.
 
 ## Scope
 
@@ -104,6 +105,69 @@ tests can exercise nativewire read-index/read-barrier composition, but that
 evidence is not production quorum evidence and the provider does not apply
 entries by itself.
 
+## Recovery Status Boundary
+
+`RecoveryStatusV1` is the report-only readiness contract for snapshot/tail
+replay recovery work. It is derived from local durable evidence:
+
+- durable FSM apply progress in `apply-progress-v1.log`;
+- local TreeDB `AppliedCommandLSN` coverage;
+- snapshot manifest validation and durable boundary-result digest checks;
+- optional `AppliedIndexReadBarrier` state for the local read-safety proof.
+
+The stable readiness labels are:
+
+```text
+unsafe_no_snapshot
+unsafe_manifest_unverified
+tail_pending
+tail_complete
+read_safety_pending
+ready_applied_index
+unsupported
+```
+
+`ready_applied_index` is the only label that may set `safe_to_serve_reads=true`,
+and only after a manifest is verified, the requested tail target is locally
+applied, and the applied-index read barrier is satisfied. `tail_complete`
+without an applied-index proof is not a read-serving claim.
+
+The stable snapshot, tail, and read-safety labels are:
+
+```text
+snapshot: no_snapshot, manifest_verified, manifest_rejected
+tail: no_snapshot, pending, complete, unknown
+read_safety: not_requested, applied_index_satisfied, applied_index_lagging, target_mismatch
+```
+
+`RecoveryMetricsV1` freezes the metric keys and low-cardinality labels exported
+from the status object. The required metric keys are:
+
+```text
+treedb.raftcluster.recovery.safe_to_serve_reads
+treedb.raftcluster.recovery.applied_index
+treedb.raftcluster.recovery.required_applied_index
+treedb.raftcluster.recovery.snapshot_last_included_index
+treedb.raftcluster.recovery.tail_target_index
+treedb.raftcluster.recovery.tail_lag_entries
+treedb.raftcluster.recovery.applied_command_lsn
+```
+
+Unsupported production operations must fail closed with explicit status instead
+of silently implying support. Current unsupported operation labels are:
+
+```text
+log_truncation
+production_rejoin
+production_snapshot_transfer
+```
+
+`raftharness` may report recovery status for injected committed-entry tests. Its
+snapshot install helper reconstructs a snapshot cut by replaying the committed
+prefix and then uses `ReplaySnapshotTailToNodeV1` for the tail. That is harness
+evidence only: it is not production Raft snapshot transfer, does not delete Raft
+log entries, and does not implement node replacement/rejoin.
+
 ## Value Log Boundary
 
 `<main-db>/value_vlog/` is persistent value storage for large values
@@ -118,6 +182,8 @@ unreachable.
 - no server write admission or redirects;
 - no `ack_policy=raft_committed` behavior;
 - no real read-index provider, lease-read provider, or follower read routing;
-- no snapshot install/export behavior beyond reserving a local path;
+- no production snapshot transfer/install beyond metadata contracts and injected
+  harness evidence;
 - no Raft log truncation;
+- no production node replacement or rejoin protocol;
 - no multi-group routing.

--- a/TreeDB/docs/spec/storage-format.md
+++ b/TreeDB/docs/spec/storage-format.md
@@ -214,6 +214,7 @@ u64       DeterministicErrorCodeLen
 bytes     DeterministicErrorCode
 i64       AffectedCount
 bytes[32] ResultDigest   // LogicalDigestV1 bytes when apply succeeded
+bytes[32] ProgressLogicalDigestV1 // logical digest to repair missing progress
 ```
 
 Open-time recovery scans complete frames and rebuilds in-memory lookup indexes.

--- a/TreeDB/docs/spec/storage-format.md
+++ b/TreeDB/docs/spec/storage-format.md
@@ -195,6 +195,7 @@ u64       ApplyTerm
 u64       ApplyIndex
 bytes[32] CommandDigestV1
 u64       AppliedCommandLSN
+bytes[32] LogicalDigestV1 // logical DB digest at this apply boundary
 ```
 
 Result payload:

--- a/TreeDB/internal/raftapply/apply.go
+++ b/TreeDB/internal/raftapply/apply.go
@@ -182,11 +182,15 @@ func (h *Harness) ApplyCommittedEntryV1(entryBytes []byte, meta ApplyMetadataV1)
 				return recoveryRequired(entry.Digest, code, err)
 			}
 			if h.opts.ProgressStore != nil {
+				progressDigest := record.ProgressLogicalDigestV1
+				if progressDigest == (LogicalDigestV1{}) {
+					progressDigest = LogicalDigestV1(record.Result.ResultDigest)
+				}
 				if err := h.opts.ProgressStore.RecordApplied(ApplyProgressRecordV1{
 					EntryID:           meta.EntryID,
 					CommandDigest:     entry.Digest,
 					AppliedCommandLSN: record.AppliedCommandLSN,
-					LogicalDigestV1:   LogicalDigestV1(record.Result.ResultDigest),
+					LogicalDigestV1:   progressDigest,
 				}); err != nil {
 					code, _ := ErrorCodeOf(err)
 					return recoveryRequired(entry.Digest, code, err)
@@ -226,11 +230,12 @@ func (h *Harness) ApplyCommittedEntryV1(entryBytes []byte, meta ApplyMetadataV1)
 			duplicate.Status = raftentry.ApplyStatusAlreadyApplied
 			duplicate.AffectedCount = 0
 			if err := h.opts.ResultStore.RecordApplyResult(ApplyResultRecordV1{
-				EntryID:           meta.EntryID,
-				CommandDigest:     entry.Digest,
-				IdempotencyKey:    entry.IdempotencyKey,
-				AppliedCommandLSN: duplicateLSN,
-				Result:            duplicate,
+				EntryID:                 meta.EntryID,
+				CommandDigest:           entry.Digest,
+				IdempotencyKey:          entry.IdempotencyKey,
+				AppliedCommandLSN:       duplicateLSN,
+				ProgressLogicalDigestV1: logical,
+				Result:                  duplicate,
 			}); err != nil {
 				code, _ := ErrorCodeOf(err)
 				return recoveryRequired(entry.Digest, code, err)
@@ -291,11 +296,12 @@ func (h *Harness) ApplyCommittedEntryV1(entryBytes []byte, meta ApplyMetadataV1)
 	}
 	if h.opts.ResultStore != nil {
 		if err := h.opts.ResultStore.RecordApplyResult(ApplyResultRecordV1{
-			EntryID:           meta.EntryID,
-			CommandDigest:     entry.Digest,
-			IdempotencyKey:    entry.IdempotencyKey,
-			AppliedCommandLSN: appliedLSN,
-			Result:            result,
+			EntryID:                 meta.EntryID,
+			CommandDigest:           entry.Digest,
+			IdempotencyKey:          entry.IdempotencyKey,
+			AppliedCommandLSN:       appliedLSN,
+			ProgressLogicalDigestV1: LogicalDigestV1(result.ResultDigest),
+			Result:                  result,
 		}); err != nil {
 			code, _ := ErrorCodeOf(err)
 			return recoveryRequired(entry.Digest, code, err)

--- a/TreeDB/internal/raftapply/apply.go
+++ b/TreeDB/internal/raftapply/apply.go
@@ -182,10 +182,16 @@ func (h *Harness) ApplyCommittedEntryV1(entryBytes []byte, meta ApplyMetadataV1)
 				return recoveryRequired(entry.Digest, code, err)
 			}
 			if h.opts.ProgressStore != nil {
+				logical, err := h.logicalDigestForProgressV1(meta)
+				if err != nil {
+					code, _ := ErrorCodeOf(err)
+					return recoveryRequired(entry.Digest, code, err)
+				}
 				if err := h.opts.ProgressStore.RecordApplied(ApplyProgressRecordV1{
 					EntryID:           meta.EntryID,
 					CommandDigest:     entry.Digest,
 					AppliedCommandLSN: record.AppliedCommandLSN,
+					LogicalDigestV1:   logical,
 				}); err != nil {
 					code, _ := ErrorCodeOf(err)
 					return recoveryRequired(entry.Digest, code, err)
@@ -216,6 +222,11 @@ func (h *Harness) ApplyCommittedEntryV1(entryBytes []byte, meta ApplyMetadataV1)
 				code, _ := ErrorCodeOf(err)
 				return recoveryRequired(entry.Digest, code, err)
 			}
+			logical, err := h.logicalDigestForProgressV1(meta)
+			if err != nil {
+				code, _ := ErrorCodeOf(err)
+				return recoveryRequired(entry.Digest, code, err)
+			}
 			duplicate := record.Result
 			duplicate.Status = raftentry.ApplyStatusAlreadyApplied
 			duplicate.AffectedCount = 0
@@ -234,6 +245,7 @@ func (h *Harness) ApplyCommittedEntryV1(entryBytes []byte, meta ApplyMetadataV1)
 					EntryID:           meta.EntryID,
 					CommandDigest:     entry.Digest,
 					AppliedCommandLSN: duplicateLSN,
+					LogicalDigestV1:   logical,
 				}); err != nil {
 					code, _ := ErrorCodeOf(err)
 					return recoveryRequired(entry.Digest, code, err)
@@ -303,6 +315,7 @@ func (h *Harness) ApplyCommittedEntryV1(entryBytes []byte, meta ApplyMetadataV1)
 			EntryID:           meta.EntryID,
 			CommandDigest:     entry.Digest,
 			AppliedCommandLSN: appliedLSN,
+			LogicalDigestV1:   LogicalDigestV1(result.ResultDigest),
 		}); err != nil {
 			code, _ := ErrorCodeOf(err)
 			return recoveryRequired(entry.Digest, code, err)
@@ -366,6 +379,14 @@ func (h *Harness) appliedCommandLSN() uint64 {
 		return 0
 	}
 	return h.db.State().AppliedCommandLSN
+}
+
+func (h *Harness) logicalDigestForProgressV1(meta ApplyMetadataV1) (LogicalDigestV1, error) {
+	return h.logicalDigestV1(LogicalDigestOptionsV1{
+		ScopeRule:     meta.ScopeRule,
+		DatabaseScope: meta.DatabaseScope,
+		CatalogScope:  meta.CatalogScope,
+	})
 }
 
 func (h *Harness) requireApplyRecordCoverage(appliedLSN uint64) error {

--- a/TreeDB/internal/raftapply/apply.go
+++ b/TreeDB/internal/raftapply/apply.go
@@ -182,16 +182,11 @@ func (h *Harness) ApplyCommittedEntryV1(entryBytes []byte, meta ApplyMetadataV1)
 				return recoveryRequired(entry.Digest, code, err)
 			}
 			if h.opts.ProgressStore != nil {
-				logical, err := h.logicalDigestForProgressV1(meta)
-				if err != nil {
-					code, _ := ErrorCodeOf(err)
-					return recoveryRequired(entry.Digest, code, err)
-				}
 				if err := h.opts.ProgressStore.RecordApplied(ApplyProgressRecordV1{
 					EntryID:           meta.EntryID,
 					CommandDigest:     entry.Digest,
 					AppliedCommandLSN: record.AppliedCommandLSN,
-					LogicalDigestV1:   logical,
+					LogicalDigestV1:   LogicalDigestV1(record.Result.ResultDigest),
 				}); err != nil {
 					code, _ := ErrorCodeOf(err)
 					return recoveryRequired(entry.Digest, code, err)

--- a/TreeDB/internal/raftapply/apply_test.go
+++ b/TreeDB/internal/raftapply/apply_test.go
@@ -2350,6 +2350,10 @@ func (recordProgressStoreFailAfterPreflight) RecordApplied(ApplyProgressRecordV1
 	return codedError(raftentry.ErrorUnsafeDurabilityModeV1, "progress store unavailable after apply")
 }
 
+func (recordProgressStoreFailAfterPreflight) LookupApplyProgress(raftentry.ApplyEntryID) (ApplyProgressRecordV1, bool, error) {
+	return ApplyProgressRecordV1{}, false, nil
+}
+
 func (recordProgressStoreFailAfterPreflight) LastApplied() (raftentry.ApplyEntryID, bool) {
 	return raftentry.ApplyEntryID{}, false
 }

--- a/TreeDB/internal/raftapply/apply_test.go
+++ b/TreeDB/internal/raftapply/apply_test.go
@@ -323,9 +323,20 @@ func TestStoredResultReplayRecordsMissingProgress(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ApplyCommittedEntryV1 seed result: %v result=%+v", err, result)
 	}
+	laterID := raftentry.ApplyEntryID{Term: 1, Index: 2}
+	laterRaw := deterministicCreateCollectionEntry(t, "orders", "client-a:create:orders", testCreateCollectionMetaOptions{})
+	later, err := ApplyCommittedEntryV1(db, laterRaw, applyMeta(laterID.Term, laterID.Index), Options{
+		ResultStore: results,
+	})
+	if err != nil {
+		t.Fatalf("ApplyCommittedEntryV1 later result: %v result=%+v", err, later)
+	}
+	if later.ResultDigest == result.ResultDigest {
+		t.Fatalf("later result digest=%s unexpectedly equals first boundary", later.ResultDigest.Hex())
+	}
 	beforeFrames := readCommandWALFrames(t, dir)
-	if len(beforeFrames) != 1 {
-		t.Fatalf("seed command WAL frames=%d, want 1", len(beforeFrames))
+	if len(beforeFrames) != 2 {
+		t.Fatalf("seed command WAL frames=%d, want 2", len(beforeFrames))
 	}
 	progress := NewMemoryApplyProgressStore(8, 8)
 
@@ -343,6 +354,16 @@ func TestStoredResultReplayRecordsMissingProgress(t *testing.T) {
 	}
 	if progress.Len() != 1 {
 		t.Fatalf("progress records after stored result replay=%d, want 1", progress.Len())
+	}
+	progressRecord, ok, err := progress.LookupApplyProgress(id)
+	if err != nil || !ok {
+		t.Fatalf("LookupApplyProgress stored result=(%+v,%t,%v), want repaired progress", progressRecord, ok, err)
+	}
+	if progressRecord.LogicalDigestV1 != LogicalDigestV1(result.ResultDigest) {
+		t.Fatalf("stored result progress digest=%s, want stored boundary %s", progressRecord.LogicalDigestV1.Hex(), result.ResultDigest.Hex())
+	}
+	if progressRecord.LogicalDigestV1 == LogicalDigestV1(later.ResultDigest) {
+		t.Fatalf("stored result progress digest=%s used later DB boundary", progressRecord.LogicalDigestV1.Hex())
 	}
 	if seam.appendCalls != 0 || seam.finalizeCalls != 0 {
 		t.Fatalf("stored result replay reached command WAL seam append=%d finalize=%d, want 0/0", seam.appendCalls, seam.finalizeCalls)

--- a/TreeDB/internal/raftapply/apply_test.go
+++ b/TreeDB/internal/raftapply/apply_test.go
@@ -373,6 +373,84 @@ func TestStoredResultReplayRecordsMissingProgress(t *testing.T) {
 	}
 }
 
+func TestStoredDuplicateResultReplayRecordsBoundaryProgressDigest(t *testing.T) {
+	dir := t.TempDir()
+	db := openApplyHarnessDB(t, dir)
+	defer func() { _ = db.Close() }()
+
+	progress := NewMemoryApplyProgressStore(8, 8)
+	results := NewMemoryApplyResultStore(8)
+	rawUsers := deterministicCreateCollectionEntry(t, "users", "client-a:create:users:stored-duplicate-replay", testCreateCollectionMetaOptions{})
+	first, err := ApplyCommittedEntryV1(db, rawUsers, applyMeta(1, 1), Options{
+		ProgressStore: progress,
+		ResultStore:   results,
+	})
+	assertApplied(t, first, raftentry.ApplyStatusApplied, 1)
+
+	rawOrders := deterministicCreateCollectionEntry(t, "orders", "client-a:create:orders:stored-duplicate-replay", testCreateCollectionMetaOptions{})
+	advanced, err := ApplyCommittedEntryV1(db, rawOrders, applyMeta(1, 2), Options{
+		ProgressStore: progress,
+		ResultStore:   results,
+	})
+	assertApplied(t, advanced, raftentry.ApplyStatusApplied, 1)
+	if advanced.ResultDigest == first.ResultDigest {
+		t.Fatalf("advanced result digest=%s unexpectedly equals original boundary", advanced.ResultDigest.Hex())
+	}
+	beforeFrames := readCommandWALFrames(t, dir)
+	if len(beforeFrames) != 2 {
+		t.Fatalf("seed command WAL frames=%d, want 2", len(beforeFrames))
+	}
+
+	duplicateID := raftentry.ApplyEntryID{Term: 1, Index: 3}
+	failed, err := ApplyCommittedEntryV1(db, rawUsers, applyMeta(duplicateID.Term, duplicateID.Index), Options{
+		ProgressStore: recordProgressStoreFailAfterPreflight{},
+		ResultStore:   results,
+	})
+	assertRecoveryRequired(t, failed, err, raftentry.ErrorUnsafeDurabilityModeV1)
+	record, ok, err := results.LookupApplyResult(duplicateID)
+	if err != nil || !ok {
+		t.Fatalf("LookupApplyResult duplicate=(%+v,%t,%v), want stored duplicate result", record, ok, err)
+	}
+	if record.Result.ResultDigest != first.ResultDigest {
+		t.Fatalf("stored duplicate result digest=%s, want original result boundary %s", record.Result.ResultDigest.Hex(), first.ResultDigest.Hex())
+	}
+	if record.ProgressLogicalDigestV1 != LogicalDigestV1(advanced.ResultDigest) {
+		t.Fatalf("stored duplicate progress digest=%s, want duplicate boundary %s", record.ProgressLogicalDigestV1.Hex(), advanced.ResultDigest.Hex())
+	}
+	if progress.Len() != 2 {
+		t.Fatalf("progress records after duplicate progress failure=%d, want original two records", progress.Len())
+	}
+
+	seam := &countingCommandWALApplySeam{}
+	replayed, err := ApplyCommittedEntryV1(db, rawUsers, applyMeta(duplicateID.Term, duplicateID.Index), Options{
+		ProgressStore:       progress,
+		ResultStore:         results,
+		CommandWALApplySeam: seam,
+	})
+	if err != nil {
+		t.Fatalf("ApplyCommittedEntryV1 stored duplicate replay: %v result=%+v", err, replayed)
+	}
+	if replayed != record.Result {
+		t.Fatalf("stored duplicate replay=%+v, want stored duplicate %+v", replayed, record.Result)
+	}
+	progressRecord, ok, err := progress.LookupApplyProgress(duplicateID)
+	if err != nil || !ok {
+		t.Fatalf("LookupApplyProgress duplicate=(%+v,%t,%v), want repaired progress", progressRecord, ok, err)
+	}
+	if progressRecord.LogicalDigestV1 != LogicalDigestV1(advanced.ResultDigest) {
+		t.Fatalf("repaired duplicate progress digest=%s, want duplicate boundary %s", progressRecord.LogicalDigestV1.Hex(), advanced.ResultDigest.Hex())
+	}
+	if progressRecord.LogicalDigestV1 == LogicalDigestV1(first.ResultDigest) {
+		t.Fatalf("repaired duplicate progress digest=%s used original result boundary", progressRecord.LogicalDigestV1.Hex())
+	}
+	if seam.appendCalls != 0 || seam.finalizeCalls != 0 {
+		t.Fatalf("stored duplicate replay reached command WAL seam append=%d finalize=%d, want 0/0", seam.appendCalls, seam.finalizeCalls)
+	}
+	if got := len(readCommandWALFrames(t, dir)); got != len(beforeFrames) {
+		t.Fatalf("command WAL frames after stored duplicate replay=%d, want %d", got, len(beforeFrames))
+	}
+}
+
 func TestStoredResultReplayProgressFailureRequiresRecovery(t *testing.T) {
 	dir := t.TempDir()
 	db := openApplyHarnessDB(t, dir)

--- a/TreeDB/internal/raftapply/durable_stores.go
+++ b/TreeDB/internal/raftapply/durable_stores.go
@@ -209,6 +209,11 @@ func (s *DurableApplyResultStore) replayApplyResultRecord(record ApplyResultReco
 		if existing.CommandDigest != record.CommandDigest {
 			return codedError(raftentry.ErrorRejectedConflictV1, "raftapply: durable result metadata digest conflict for %d/%d", record.EntryID.Term, record.EntryID.Index)
 		}
+		if existing.ProgressLogicalDigestV1 != (LogicalDigestV1{}) &&
+			record.ProgressLogicalDigestV1 != (LogicalDigestV1{}) &&
+			existing.ProgressLogicalDigestV1 != record.ProgressLogicalDigestV1 {
+			return codedError(raftentry.ErrorRejectedConflictV1, "raftapply: durable result metadata progress logical digest conflict for %d/%d", record.EntryID.Term, record.EntryID.Index)
+		}
 		return nil
 	}
 	if err := s.checkCanRecordApplyResultLocked(record); err != nil {
@@ -225,6 +230,11 @@ func (s *DurableApplyResultStore) checkCanRecordApplyResultLocked(record ApplyRe
 	if existing, ok := s.records[record.EntryID]; ok {
 		if existing.CommandDigest != record.CommandDigest {
 			return codedError(raftentry.ErrorRejectedConflictV1, "apply result digest conflict for %d/%d", record.EntryID.Term, record.EntryID.Index)
+		}
+		if existing.ProgressLogicalDigestV1 != (LogicalDigestV1{}) &&
+			record.ProgressLogicalDigestV1 != (LogicalDigestV1{}) &&
+			existing.ProgressLogicalDigestV1 != record.ProgressLogicalDigestV1 {
+			return codedError(raftentry.ErrorRejectedConflictV1, "apply result progress logical digest conflict for %d/%d", record.EntryID.Term, record.EntryID.Index)
 		}
 		return nil
 	}
@@ -745,6 +755,7 @@ func encodeDurableApplyResultRecordV1(record ApplyResultRecordV1) ([]byte, error
 	dst = appendBytes(dst, []byte(record.Result.DeterministicErrorCode))
 	dst = appendI64(dst, record.Result.AffectedCount)
 	dst = append(dst, record.Result.ResultDigest[:]...)
+	dst = append(dst, record.ProgressLogicalDigestV1[:]...)
 	if len(dst) > raftentry.MaxResultRecordBytesV1 {
 		return nil, codedError(raftentry.ErrorResourceExhaustedV1, "raftapply: durable result record payload %d exceeds %d", len(dst), raftentry.MaxResultRecordBytesV1)
 	}
@@ -789,14 +800,19 @@ func decodeDurableApplyResultRecordV1(payload []byte) (ApplyResultRecordV1, erro
 	if err != nil {
 		return ApplyResultRecordV1{}, err
 	}
+	progressLogicalDigest, err := r.logicalDigest()
+	if err != nil {
+		return ApplyResultRecordV1{}, err
+	}
 	if err := r.done(); err != nil {
 		return ApplyResultRecordV1{}, err
 	}
 	return ApplyResultRecordV1{
-		EntryID:           id,
-		CommandDigest:     digest,
-		IdempotencyKey:    key,
-		AppliedCommandLSN: lsn,
+		EntryID:                 id,
+		CommandDigest:           digest,
+		IdempotencyKey:          key,
+		AppliedCommandLSN:       lsn,
+		ProgressLogicalDigestV1: progressLogicalDigest,
 		Result: raftentry.ApplyResultV1{
 			Status:                 raftentry.ApplyStatusV1(status),
 			CommandDigest:          resultDigest,

--- a/TreeDB/internal/raftapply/durable_stores.go
+++ b/TreeDB/internal/raftapply/durable_stores.go
@@ -379,6 +379,19 @@ func (s *DurableApplyProgressStore) LastApplied() (raftentry.ApplyEntryID, bool)
 	return s.last, s.last.Index != 0
 }
 
+func (s *DurableApplyProgressStore) LookupApplyProgress(id raftentry.ApplyEntryID) (ApplyProgressRecordV1, bool, error) {
+	if s == nil {
+		return ApplyProgressRecordV1{}, false, nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err := s.checkOpenLocked("lookup apply progress"); err != nil {
+		return ApplyProgressRecordV1{}, false, err
+	}
+	record, ok := s.records[id]
+	return record, ok, nil
+}
+
 func (s *DurableApplyProgressStore) LastAppliedRecord() (ApplyProgressRecordV1, bool) {
 	if s == nil {
 		return ApplyProgressRecordV1{}, false
@@ -424,6 +437,11 @@ func (s *DurableApplyProgressStore) replayApplyProgressRecord(record ApplyProgre
 		if existing.CommandDigest != record.CommandDigest {
 			return codedError(raftentry.ErrorRejectedConflictV1, "raftapply: durable progress metadata digest conflict for %d/%d", record.EntryID.Term, record.EntryID.Index)
 		}
+		if existing.LogicalDigestV1 != (LogicalDigestV1{}) &&
+			record.LogicalDigestV1 != (LogicalDigestV1{}) &&
+			existing.LogicalDigestV1 != record.LogicalDigestV1 {
+			return codedError(raftentry.ErrorRejectedConflictV1, "raftapply: durable progress metadata logical digest conflict for %d/%d", record.EntryID.Term, record.EntryID.Index)
+		}
 		return nil
 	}
 	if err := s.checkCanRecordAppliedLocked(record); err != nil {
@@ -440,6 +458,11 @@ func (s *DurableApplyProgressStore) checkCanRecordAppliedLocked(record ApplyProg
 	if existing, ok := s.records[record.EntryID]; ok {
 		if existing.CommandDigest != record.CommandDigest {
 			return codedError(raftentry.ErrorRejectedConflictV1, "apply progress digest conflict for %d/%d", record.EntryID.Term, record.EntryID.Index)
+		}
+		if existing.LogicalDigestV1 != (LogicalDigestV1{}) &&
+			record.LogicalDigestV1 != (LogicalDigestV1{}) &&
+			existing.LogicalDigestV1 != record.LogicalDigestV1 {
+			return codedError(raftentry.ErrorRejectedConflictV1, "apply progress logical digest conflict for %d/%d", record.EntryID.Term, record.EntryID.Index)
 		}
 		return nil
 	}
@@ -683,6 +706,7 @@ func encodeDurableApplyProgressRecordV1(record ApplyProgressRecordV1) ([]byte, e
 	dst = appendApplyEntryID(dst, record.EntryID)
 	dst = append(dst, record.CommandDigest[:]...)
 	dst = appendU64(dst, record.AppliedCommandLSN)
+	dst = append(dst, record.LogicalDigestV1[:]...)
 	return dst, nil
 }
 
@@ -700,10 +724,14 @@ func decodeDurableApplyProgressRecordV1(payload []byte) (ApplyProgressRecordV1, 
 	if err != nil {
 		return ApplyProgressRecordV1{}, err
 	}
+	logical, err := r.logicalDigest()
+	if err != nil {
+		return ApplyProgressRecordV1{}, err
+	}
 	if err := r.done(); err != nil {
 		return ApplyProgressRecordV1{}, err
 	}
-	return ApplyProgressRecordV1{EntryID: id, CommandDigest: digest, AppliedCommandLSN: lsn}, nil
+	return ApplyProgressRecordV1{EntryID: id, CommandDigest: digest, AppliedCommandLSN: lsn, LogicalDigestV1: logical}, nil
 }
 
 func encodeDurableApplyResultRecordV1(record ApplyResultRecordV1) ([]byte, error) {
@@ -802,6 +830,16 @@ func (r *durableApplyPayloadReader) digest() (raftentry.CommandDigestV1, error) 
 		return raftentry.CommandDigestV1{}, err
 	}
 	var out raftentry.CommandDigestV1
+	copy(out[:], b)
+	return out, nil
+}
+
+func (r *durableApplyPayloadReader) logicalDigest() (LogicalDigestV1, error) {
+	b, err := r.fixed(32)
+	if err != nil {
+		return LogicalDigestV1{}, err
+	}
+	var out LogicalDigestV1
 	copy(out[:], b)
 	return out, nil
 }

--- a/TreeDB/internal/raftapply/durable_stores_test.go
+++ b/TreeDB/internal/raftapply/durable_stores_test.go
@@ -109,6 +109,38 @@ func TestDurableApplyStoresIdempotencyDuplicateSameDigestAndDifferentDigest(t *t
 	assertRejected(t, rejected, err, raftentry.ApplyStatusRejectedConflict, raftentry.ErrorRejectedConflictV1)
 }
 
+func TestDurableApplyResultStorePreservesProgressLogicalDigest(t *testing.T) {
+	dir := t.TempDir()
+	results, err := OpenDurableApplyResultStore(dir, DurableApplyStoreOptions{DisableSync: true})
+	if err != nil {
+		t.Fatalf("OpenDurableApplyResultStore: %v", err)
+	}
+	record := testDurableApplyResultRecord(9, 1, "durable:progress-digest")
+	record.ProgressLogicalDigestV1 = LogicalDigestV1(testDurableDigest(200))
+	if err := results.RecordApplyResult(record); err != nil {
+		t.Fatalf("RecordApplyResult: %v", err)
+	}
+	if err := results.Close(); err != nil {
+		t.Fatalf("Close results: %v", err)
+	}
+
+	reopened, err := OpenDurableApplyResultStore(dir, DurableApplyStoreOptions{DisableSync: true})
+	if err != nil {
+		t.Fatalf("Reopen DurableApplyResultStore: %v", err)
+	}
+	defer func() { _ = reopened.Close() }()
+	got, ok, err := reopened.LookupApplyResult(record.EntryID)
+	if err != nil || !ok {
+		t.Fatalf("LookupApplyResult after reopen=(%+v,%t,%v), want record", got, ok, err)
+	}
+	if got.ProgressLogicalDigestV1 != record.ProgressLogicalDigestV1 {
+		t.Fatalf("progress logical digest after reopen=%s, want %s", got.ProgressLogicalDigestV1.Hex(), record.ProgressLogicalDigestV1.Hex())
+	}
+	if got.Result.ResultDigest != record.Result.ResultDigest {
+		t.Fatalf("result digest after reopen=%s, want %s", got.Result.ResultDigest.Hex(), record.Result.ResultDigest.Hex())
+	}
+}
+
 func TestDurableApplyProgressStoreRejectsGapAndLowerIndex(t *testing.T) {
 	dir := t.TempDir()
 	progress, err := OpenDurableApplyProgressStore(dir, DurableApplyStoreOptions{DisableSync: true})
@@ -431,10 +463,11 @@ func testDurableApplyResultRecord(seed byte, index uint64, key string) ApplyResu
 func testDurableApplyResultRecordBytes(seed byte, index uint64, key []byte) ApplyResultRecordV1 {
 	digest := testDurableDigest(seed)
 	return ApplyResultRecordV1{
-		EntryID:           raftentry.ApplyEntryID{Term: 1, Index: index},
-		CommandDigest:     digest,
-		IdempotencyKey:    append([]byte(nil), key...),
-		AppliedCommandLSN: index,
+		EntryID:                 raftentry.ApplyEntryID{Term: 1, Index: index},
+		CommandDigest:           digest,
+		IdempotencyKey:          append([]byte(nil), key...),
+		AppliedCommandLSN:       index,
+		ProgressLogicalDigestV1: LogicalDigestV1(testDurableDigest(seed + 100)),
 		Result: raftentry.ApplyResultV1{
 			Status:        raftentry.ApplyStatusApplied,
 			CommandDigest: digest,

--- a/TreeDB/internal/raftapply/stores.go
+++ b/TreeDB/internal/raftapply/stores.go
@@ -74,6 +74,7 @@ type ApplyProgressRecordV1 struct {
 	EntryID           raftentry.ApplyEntryID
 	CommandDigest     raftentry.CommandDigestV1
 	AppliedCommandLSN uint64
+	LogicalDigestV1   LogicalDigestV1
 }
 
 // ApplyProgressStore checks monotonic apply order and records durable progress.
@@ -81,6 +82,7 @@ type ApplyProgressStore interface {
 	CheckCanApply(raftentry.ApplyEntryID) error
 	CheckCanRecordApplied(ApplyProgressRecordV1) error
 	RecordApplied(ApplyProgressRecordV1) error
+	LookupApplyProgress(raftentry.ApplyEntryID) (ApplyProgressRecordV1, bool, error)
 	LastApplied() (raftentry.ApplyEntryID, bool)
 }
 
@@ -263,6 +265,11 @@ func (s *MemoryApplyProgressStore) checkCanRecordAppliedLocked(record ApplyProgr
 		if existing.CommandDigest != record.CommandDigest {
 			return codedError(raftentry.ErrorRejectedConflictV1, "apply progress digest conflict for %d/%d", record.EntryID.Term, record.EntryID.Index)
 		}
+		if existing.LogicalDigestV1 != (LogicalDigestV1{}) &&
+			record.LogicalDigestV1 != (LogicalDigestV1{}) &&
+			existing.LogicalDigestV1 != record.LogicalDigestV1 {
+			return codedError(raftentry.ErrorRejectedConflictV1, "apply progress logical digest conflict for %d/%d", record.EntryID.Term, record.EntryID.Index)
+		}
 		return nil
 	}
 	if err := s.checkCanApplyLocked(record.EntryID); err != nil {
@@ -281,6 +288,16 @@ func (s *MemoryApplyProgressStore) LastApplied() (raftentry.ApplyEntryID, bool) 
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.last, s.last.Index != 0
+}
+
+func (s *MemoryApplyProgressStore) LookupApplyProgress(id raftentry.ApplyEntryID) (ApplyProgressRecordV1, bool, error) {
+	if s == nil {
+		return ApplyProgressRecordV1{}, false, nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	record, ok := s.records[id]
+	return record, ok, nil
 }
 
 func (s *MemoryApplyProgressStore) LastAppliedRecord() (ApplyProgressRecordV1, bool) {

--- a/TreeDB/internal/raftapply/stores.go
+++ b/TreeDB/internal/raftapply/stores.go
@@ -53,11 +53,12 @@ func codedError(code raftentry.DeterministicErrorCodeV1, format string, args ...
 // ApplyEntryID. The result payload is intentionally bounded separately from the
 // deterministic entry bytes.
 type ApplyResultRecordV1 struct {
-	EntryID           raftentry.ApplyEntryID
-	CommandDigest     raftentry.CommandDigestV1
-	IdempotencyKey    []byte
-	AppliedCommandLSN uint64
-	Result            raftentry.ApplyResultV1
+	EntryID                 raftentry.ApplyEntryID
+	CommandDigest           raftentry.CommandDigestV1
+	IdempotencyKey          []byte
+	AppliedCommandLSN       uint64
+	ProgressLogicalDigestV1 LogicalDigestV1
+	Result                  raftentry.ApplyResultV1
 }
 
 // ApplyResultStore records deterministic apply results for idempotency/replay.
@@ -171,6 +172,11 @@ func (s *MemoryApplyResultStore) checkCanRecordApplyResultLocked(record ApplyRes
 	if existing, ok := s.records[record.EntryID]; ok {
 		if existing.CommandDigest != record.CommandDigest {
 			return codedError(raftentry.ErrorRejectedConflictV1, "apply result digest conflict for %d/%d", record.EntryID.Term, record.EntryID.Index)
+		}
+		if existing.ProgressLogicalDigestV1 != (LogicalDigestV1{}) &&
+			record.ProgressLogicalDigestV1 != (LogicalDigestV1{}) &&
+			existing.ProgressLogicalDigestV1 != record.ProgressLogicalDigestV1 {
+			return codedError(raftentry.ErrorRejectedConflictV1, "apply result progress logical digest conflict for %d/%d", record.EntryID.Term, record.EntryID.Index)
 		}
 		return nil
 	}
@@ -378,7 +384,7 @@ func validateApplyProgressRecordV1(record ApplyProgressRecordV1, requireCoverage
 
 func applyResultRecordSizeV1(record ApplyResultRecordV1) int {
 	return 8 + 8 + 32 + len(record.IdempotencyKey) + 8 +
-		len(record.Result.Status) + 32 + len(record.Result.DeterministicErrorCode) + 8 + 32
+		len(record.Result.Status) + 32 + len(record.Result.DeterministicErrorCode) + 8 + 32 + 32
 }
 
 func cloneApplyResultRecord(record ApplyResultRecordV1) ApplyResultRecordV1 {

--- a/TreeDB/internal/raftcluster/recovery_status.go
+++ b/TreeDB/internal/raftcluster/recovery_status.go
@@ -1,0 +1,174 @@
+package raftcluster
+
+import (
+	"errors"
+	"fmt"
+)
+
+const (
+	RecoveryStatusFormatV1 = "treedb.raftcluster.recovery-status"
+	RecoveryStatusVersion1 = uint16(1)
+
+	RecoveryMetricsFormatV1 = "treedb.raftcluster.recovery-metrics"
+	RecoveryMetricsVersion1 = uint16(1)
+)
+
+var ErrRecoveryOperationUnsupported = errors.New("raftcluster: recovery operation unsupported")
+
+type RecoveryReadinessV1 string
+
+const (
+	RecoveryReadinessUnsafeNoSnapshotV1         RecoveryReadinessV1 = "unsafe_no_snapshot"
+	RecoveryReadinessUnsafeManifestUnverifiedV1 RecoveryReadinessV1 = "unsafe_manifest_unverified"
+	RecoveryReadinessTailPendingV1              RecoveryReadinessV1 = "tail_pending"
+	RecoveryReadinessTailCompleteV1             RecoveryReadinessV1 = "tail_complete"
+	RecoveryReadinessReadSafetyPendingV1        RecoveryReadinessV1 = "read_safety_pending"
+	RecoveryReadinessReadyAppliedIndexV1        RecoveryReadinessV1 = "ready_applied_index"
+	RecoveryReadinessUnsupportedV1              RecoveryReadinessV1 = "unsupported"
+)
+
+type RecoverySnapshotStateV1 string
+
+const (
+	RecoverySnapshotStateNoneV1             RecoverySnapshotStateV1 = "no_snapshot"
+	RecoverySnapshotStateManifestVerifiedV1 RecoverySnapshotStateV1 = "manifest_verified"
+	RecoverySnapshotStateManifestRejectedV1 RecoverySnapshotStateV1 = "manifest_rejected"
+)
+
+type RecoveryTailStateV1 string
+
+const (
+	RecoveryTailStateNoSnapshotV1 RecoveryTailStateV1 = "no_snapshot"
+	RecoveryTailStatePendingV1    RecoveryTailStateV1 = "pending"
+	RecoveryTailStateCompleteV1   RecoveryTailStateV1 = "complete"
+	RecoveryTailStateUnknownV1    RecoveryTailStateV1 = "unknown"
+)
+
+type RecoveryReadSafetyStateV1 string
+
+const (
+	RecoveryReadSafetyNotRequestedV1          RecoveryReadSafetyStateV1 = "not_requested"
+	RecoveryReadSafetyAppliedIndexSatisfiedV1 RecoveryReadSafetyStateV1 = "applied_index_satisfied"
+	RecoveryReadSafetyAppliedIndexLaggingV1   RecoveryReadSafetyStateV1 = "applied_index_lagging"
+	RecoveryReadSafetyTargetMismatchV1        RecoveryReadSafetyStateV1 = "target_mismatch"
+)
+
+type RecoveryUnsupportedOperationV1 string
+
+const (
+	RecoveryUnsupportedLogTruncationV1              RecoveryUnsupportedOperationV1 = "log_truncation"
+	RecoveryUnsupportedProductionRejoinV1           RecoveryUnsupportedOperationV1 = "production_rejoin"
+	RecoveryUnsupportedProductionSnapshotTransferV1 RecoveryUnsupportedOperationV1 = "production_snapshot_transfer"
+)
+
+type RecoveryMetricKeyV1 string
+
+const (
+	RecoveryMetricSafeToServeReadsV1      RecoveryMetricKeyV1 = "treedb.raftcluster.recovery.safe_to_serve_reads"
+	RecoveryMetricAppliedIndexV1          RecoveryMetricKeyV1 = "treedb.raftcluster.recovery.applied_index"
+	RecoveryMetricRequiredAppliedIndexV1  RecoveryMetricKeyV1 = "treedb.raftcluster.recovery.required_applied_index"
+	RecoveryMetricSnapshotIncludedIndexV1 RecoveryMetricKeyV1 = "treedb.raftcluster.recovery.snapshot_last_included_index"
+	RecoveryMetricTailTargetIndexV1       RecoveryMetricKeyV1 = "treedb.raftcluster.recovery.tail_target_index"
+	RecoveryMetricTailLagEntriesV1        RecoveryMetricKeyV1 = "treedb.raftcluster.recovery.tail_lag_entries"
+	RecoveryMetricAppliedCommandLSNV1     RecoveryMetricKeyV1 = "treedb.raftcluster.recovery.applied_command_lsn"
+)
+
+// RecoveryStatusV1 is a report-only status contract. It describes whether a
+// local node can prove snapshot/tail/read safety from durable local evidence; it
+// does not install snapshots, truncate Raft logs, or rejoin replicas.
+type RecoveryStatusV1 struct {
+	Format  string `json:"format"`
+	Version uint16 `json:"version"`
+
+	NodeID  NodeID  `json:"node_id"`
+	GroupID GroupID `json:"group_id"`
+
+	Readiness        RecoveryReadinessV1              `json:"readiness"`
+	SafeToServeReads bool                             `json:"safe_to_serve_reads"`
+	SnapshotState    RecoverySnapshotStateV1          `json:"snapshot_state"`
+	TailState        RecoveryTailStateV1              `json:"tail_state"`
+	ReadSafetyState  RecoveryReadSafetyStateV1        `json:"read_safety_state"`
+	Unsupported      []RecoveryUnsupportedOperationV1 `json:"unsupported,omitempty"`
+
+	AppliedProgress      AppliedProgress     `json:"applied_progress"`
+	AppliedCommandLSN    uint64              `json:"applied_command_lsn"`
+	HasAppliedCommandLSN bool                `json:"has_applied_command_lsn"`
+	SnapshotManifest     *SnapshotManifestV1 `json:"snapshot_manifest,omitempty"`
+	RequiredAppliedIndex uint64              `json:"required_applied_index"`
+	TailTargetIndex      uint64              `json:"tail_target_index"`
+	TailLagEntries       uint64              `json:"tail_lag_entries"`
+	Errors               []string            `json:"errors,omitempty"`
+}
+
+type RecoveryMetricSampleV1 struct {
+	Key   RecoveryMetricKeyV1 `json:"key"`
+	Value uint64              `json:"value"`
+}
+
+// RecoveryMetricsV1 freezes the metric keys and low-cardinality status labels
+// exported by RecoveryStatusV1. Callers may map samples into their metrics
+// backend, but should not derive new keys from error strings.
+type RecoveryMetricsV1 struct {
+	Format  string `json:"format"`
+	Version uint16 `json:"version"`
+
+	StatusLabel     RecoveryReadinessV1       `json:"status_label"`
+	SnapshotLabel   RecoverySnapshotStateV1   `json:"snapshot_label"`
+	TailLabel       RecoveryTailStateV1       `json:"tail_label"`
+	ReadSafetyLabel RecoveryReadSafetyStateV1 `json:"read_safety_label"`
+
+	Samples []RecoveryMetricSampleV1 `json:"samples"`
+}
+
+func NewRecoveryStatusV1(nodeID NodeID, groupID GroupID) RecoveryStatusV1 {
+	return RecoveryStatusV1{
+		Format:          RecoveryStatusFormatV1,
+		Version:         RecoveryStatusVersion1,
+		NodeID:          nodeID,
+		GroupID:         groupID,
+		Readiness:       RecoveryReadinessUnsafeNoSnapshotV1,
+		SnapshotState:   RecoverySnapshotStateNoneV1,
+		TailState:       RecoveryTailStateNoSnapshotV1,
+		ReadSafetyState: RecoveryReadSafetyNotRequestedV1,
+	}
+}
+
+func UnsupportedRecoveryStatusV1(nodeID NodeID, groupID GroupID, operation RecoveryUnsupportedOperationV1) RecoveryStatusV1 {
+	status := NewRecoveryStatusV1(nodeID, groupID)
+	status.Readiness = RecoveryReadinessUnsupportedV1
+	status.Unsupported = []RecoveryUnsupportedOperationV1{operation}
+	status.Errors = []string{fmt.Sprintf("%s: %s", ErrRecoveryOperationUnsupported.Error(), operation)}
+	return status
+}
+
+func (s RecoveryStatusV1) MetricsV1() RecoveryMetricsV1 {
+	appliedIndex := uint64(0)
+	if s.AppliedProgress.HasApplied {
+		appliedIndex = s.AppliedProgress.Index
+	}
+	snapshotIndex := uint64(0)
+	if s.SnapshotManifest != nil {
+		snapshotIndex = s.SnapshotManifest.LastIncludedIndex
+	}
+	safe := uint64(0)
+	if s.SafeToServeReads {
+		safe = 1
+	}
+	return RecoveryMetricsV1{
+		Format:          RecoveryMetricsFormatV1,
+		Version:         RecoveryMetricsVersion1,
+		StatusLabel:     s.Readiness,
+		SnapshotLabel:   s.SnapshotState,
+		TailLabel:       s.TailState,
+		ReadSafetyLabel: s.ReadSafetyState,
+		Samples: []RecoveryMetricSampleV1{
+			{Key: RecoveryMetricSafeToServeReadsV1, Value: safe},
+			{Key: RecoveryMetricAppliedIndexV1, Value: appliedIndex},
+			{Key: RecoveryMetricRequiredAppliedIndexV1, Value: s.RequiredAppliedIndex},
+			{Key: RecoveryMetricSnapshotIncludedIndexV1, Value: snapshotIndex},
+			{Key: RecoveryMetricTailTargetIndexV1, Value: s.TailTargetIndex},
+			{Key: RecoveryMetricTailLagEntriesV1, Value: s.TailLagEntries},
+			{Key: RecoveryMetricAppliedCommandLSNV1, Value: s.AppliedCommandLSN},
+		},
+	}
+}

--- a/TreeDB/internal/raftcluster/recovery_status_test.go
+++ b/TreeDB/internal/raftcluster/recovery_status_test.go
@@ -1,0 +1,85 @@
+package raftcluster
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestRecoveryStatusV1MetricsUseStableKeysAndLabels(t *testing.T) {
+	manifest := validSnapshotManifestV1()
+	status := NewRecoveryStatusV1("node-a", "group-a")
+	status.Readiness = RecoveryReadinessReadyAppliedIndexV1
+	status.SafeToServeReads = true
+	status.SnapshotState = RecoverySnapshotStateManifestVerifiedV1
+	status.TailState = RecoveryTailStateCompleteV1
+	status.ReadSafetyState = RecoveryReadSafetyAppliedIndexSatisfiedV1
+	status.AppliedProgress = AppliedProgress{
+		NodeID:     "node-a",
+		GroupID:    "group-a",
+		Term:       7,
+		Index:      12,
+		HasApplied: true,
+	}
+	status.AppliedCommandLSN = 19
+	status.HasAppliedCommandLSN = true
+	status.SnapshotManifest = &manifest
+	status.RequiredAppliedIndex = 12
+	status.TailTargetIndex = 12
+
+	metrics := status.MetricsV1()
+	if metrics.Format != RecoveryMetricsFormatV1 || metrics.Version != RecoveryMetricsVersion1 {
+		t.Fatalf("metrics contract=(%q,%d), want (%q,%d)", metrics.Format, metrics.Version, RecoveryMetricsFormatV1, RecoveryMetricsVersion1)
+	}
+	if metrics.StatusLabel != RecoveryReadinessReadyAppliedIndexV1 ||
+		metrics.SnapshotLabel != RecoverySnapshotStateManifestVerifiedV1 ||
+		metrics.TailLabel != RecoveryTailStateCompleteV1 ||
+		metrics.ReadSafetyLabel != RecoveryReadSafetyAppliedIndexSatisfiedV1 {
+		t.Fatalf("metric labels=%+v, want ready/verified/complete/applied-index", metrics)
+	}
+	gotKeys := make([]RecoveryMetricKeyV1, 0, len(metrics.Samples))
+	for _, sample := range metrics.Samples {
+		gotKeys = append(gotKeys, sample.Key)
+	}
+	wantKeys := []RecoveryMetricKeyV1{
+		RecoveryMetricSafeToServeReadsV1,
+		RecoveryMetricAppliedIndexV1,
+		RecoveryMetricRequiredAppliedIndexV1,
+		RecoveryMetricSnapshotIncludedIndexV1,
+		RecoveryMetricTailTargetIndexV1,
+		RecoveryMetricTailLagEntriesV1,
+		RecoveryMetricAppliedCommandLSNV1,
+	}
+	if !reflect.DeepEqual(gotKeys, wantKeys) {
+		t.Fatalf("metric keys=%+v, want %+v", gotKeys, wantKeys)
+	}
+	values := map[RecoveryMetricKeyV1]uint64{}
+	for _, sample := range metrics.Samples {
+		values[sample.Key] = sample.Value
+	}
+	if values[RecoveryMetricSafeToServeReadsV1] != 1 ||
+		values[RecoveryMetricAppliedIndexV1] != 12 ||
+		values[RecoveryMetricRequiredAppliedIndexV1] != 12 ||
+		values[RecoveryMetricSnapshotIncludedIndexV1] != manifest.LastIncludedIndex ||
+		values[RecoveryMetricTailTargetIndexV1] != 12 ||
+		values[RecoveryMetricTailLagEntriesV1] != 0 ||
+		values[RecoveryMetricAppliedCommandLSNV1] != 19 {
+		t.Fatalf("metric values=%+v", values)
+	}
+}
+
+func TestUnsupportedRecoveryStatusV1FailsClosed(t *testing.T) {
+	status := UnsupportedRecoveryStatusV1("node-b", "group-a", RecoveryUnsupportedLogTruncationV1)
+	if status.Format != RecoveryStatusFormatV1 || status.Version != RecoveryStatusVersion1 {
+		t.Fatalf("status contract=(%q,%d), want (%q,%d)", status.Format, status.Version, RecoveryStatusFormatV1, RecoveryStatusVersion1)
+	}
+	if status.Readiness != RecoveryReadinessUnsupportedV1 || status.SafeToServeReads {
+		t.Fatalf("status=%+v, want unsupported and unsafe", status)
+	}
+	if !reflect.DeepEqual(status.Unsupported, []RecoveryUnsupportedOperationV1{RecoveryUnsupportedLogTruncationV1}) {
+		t.Fatalf("unsupported=%+v", status.Unsupported)
+	}
+	if len(status.Errors) != 1 || !strings.Contains(status.Errors[0], ErrRecoveryOperationUnsupported.Error()) {
+		t.Fatalf("errors=%+v, want unsupported error", status.Errors)
+	}
+}

--- a/TreeDB/internal/raftfsm/recovery_status.go
+++ b/TreeDB/internal/raftfsm/recovery_status.go
@@ -1,0 +1,187 @@
+package raftfsm
+
+import (
+	"context"
+	"errors"
+
+	"github.com/snissn/gomap/TreeDB/internal/raftcluster"
+	"github.com/snissn/gomap/TreeDB/internal/raftentry"
+)
+
+type RecoveryStatusOptionsV1 struct {
+	SnapshotManifest *raftcluster.SnapshotManifestV1
+	TailTargetIndex  uint64
+
+	RequireReadSafety bool
+	ReadBarrier       raftcluster.AppliedIndexReadBarrier
+}
+
+// RecoveryStatusV1 derives local recovery readiness from durable FSM state. It
+// is a report-only status path: it does not install snapshots, replay tails,
+// truncate logs, rejoin nodes, or prove production snapshot transfer.
+func (f *FSM) RecoveryStatusV1(ctx context.Context, opts RecoveryStatusOptionsV1) (raftcluster.RecoveryStatusV1, error) {
+	ctx = readBarrierContext(ctx)
+	status := raftcluster.NewRecoveryStatusV1("", "")
+	if f != nil {
+		status = raftcluster.NewRecoveryStatusV1(f.cluster.NodeID, f.cluster.GroupID)
+	}
+	if err := ctx.Err(); err != nil {
+		return status, err
+	}
+	if f == nil {
+		return status, codedError(raftentry.ErrorUnsafeDurabilityModeV1, "FSM is not open")
+	}
+	if f.closed {
+		return status, codedError(raftentry.ErrorUnsafeDurabilityModeV1, "FSM is closed")
+	}
+	if f.db == nil || f.progress == nil || f.results == nil {
+		return status, codedError(raftentry.ErrorUnsafeDurabilityModeV1, "FSM is not open")
+	}
+	progress, err := f.AppliedProgress(ctx)
+	if err != nil {
+		return status, err
+	}
+	status.AppliedProgress = progress
+	localLSN, err := localAppliedCommandLSN(f.db)
+	if err != nil {
+		return status, err
+	}
+	status.AppliedCommandLSN = localLSN
+	status.HasAppliedCommandLSN = localLSN != 0
+	status.TailTargetIndex = opts.TailTargetIndex
+
+	if opts.SnapshotManifest == nil {
+		status = applyRecoveryReadSafety(status, opts, progress)
+		return finalizeRecoveryStatus(status), nil
+	}
+
+	manifest := *opts.SnapshotManifest
+	status.SnapshotManifest = &manifest
+	if opts.TailTargetIndex == 0 || opts.TailTargetIndex < manifest.LastIncludedIndex {
+		opts.TailTargetIndex = manifest.LastIncludedIndex
+	}
+	status.TailTargetIndex = opts.TailTargetIndex
+
+	if err := f.verifyRecoverySnapshotManifestV1(manifest); err != nil {
+		status.SnapshotState = raftcluster.RecoverySnapshotStateManifestRejectedV1
+		status.TailState = raftcluster.RecoveryTailStateUnknownV1
+		status.Errors = append(status.Errors, err.Error())
+		status = applyRecoveryReadSafety(status, opts, progress)
+		return finalizeRecoveryStatus(status), nil
+	}
+
+	status.SnapshotState = raftcluster.RecoverySnapshotStateManifestVerifiedV1
+	if !progress.HasApplied {
+		status.TailState = raftcluster.RecoveryTailStatePendingV1
+		status.TailLagEntries = opts.TailTargetIndex
+	} else if progress.Index < opts.TailTargetIndex {
+		status.TailState = raftcluster.RecoveryTailStatePendingV1
+		status.TailLagEntries = opts.TailTargetIndex - progress.Index
+	} else {
+		status.TailState = raftcluster.RecoveryTailStateCompleteV1
+	}
+
+	status = applyRecoveryReadSafety(status, opts, progress)
+	return finalizeRecoveryStatus(status), nil
+}
+
+func (f *FSM) verifyRecoverySnapshotManifestV1(manifest raftcluster.SnapshotManifestV1) error {
+	if err := f.VerifyInstalledSnapshotManifestV1(manifest); err == nil {
+		return nil
+	}
+	if err := manifest.Validate(f.snapshotScopeIdentityV1()); err != nil {
+		return codedError(raftentry.ErrorRejectedConflictV1, "snapshot manifest is not valid for FSM scope: %v", err)
+	}
+	if manifest.GroupID != f.cluster.GroupID {
+		return codedError(raftentry.ErrorRejectedConflictV1, "snapshot manifest group %q does not match FSM group %q", manifest.GroupID, f.cluster.GroupID)
+	}
+	record, ok, err := f.lastAppliedProgressRecord()
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return codedError(raftentry.ErrorUnsafeDurabilityModeV1, "FSM has no durable applied progress for recovery status")
+	}
+	if record.EntryID.Index < manifest.LastIncludedIndex {
+		return codedError(raftentry.ErrorRejectedConflictV1, "snapshot manifest last included index %d is ahead of durable progress %d", manifest.LastIncludedIndex, record.EntryID.Index)
+	}
+	if record.AppliedCommandLSN < manifest.AppliedCommandLSN {
+		return codedError(raftentry.ErrorUnsafeDurabilityModeV1, "snapshot manifest AppliedCommandLSN %d is ahead of durable progress coverage %d", manifest.AppliedCommandLSN, record.AppliedCommandLSN)
+	}
+	localLSN, err := localAppliedCommandLSN(f.db)
+	if err != nil {
+		return err
+	}
+	if localLSN < manifest.AppliedCommandLSN {
+		return codedError(raftentry.ErrorUnsafeDurabilityModeV1, "snapshot manifest AppliedCommandLSN %d is ahead of local coverage %d", manifest.AppliedCommandLSN, localLSN)
+	}
+	result, ok, err := f.results.LookupApplyResult(raftentry.ApplyEntryID{
+		Term:  manifest.LastIncludedTerm,
+		Index: manifest.LastIncludedIndex,
+	})
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return codedError(raftentry.ErrorUnsafeDurabilityModeV1, "missing durable result for snapshot boundary %d/%d", manifest.LastIncludedTerm, manifest.LastIncludedIndex)
+	}
+	if result.AppliedCommandLSN != manifest.AppliedCommandLSN {
+		return codedError(raftentry.ErrorRejectedConflictV1, "snapshot manifest AppliedCommandLSN %d does not match boundary result coverage %d", manifest.AppliedCommandLSN, result.AppliedCommandLSN)
+	}
+	if result.Result.ResultDigest.Hex() != manifest.LogicalDigestV1 {
+		return codedError(raftentry.ErrorRejectedConflictV1, "snapshot manifest logical digest %s does not match boundary result digest %s", manifest.LogicalDigestV1, result.Result.ResultDigest.Hex())
+	}
+	return nil
+}
+
+func applyRecoveryReadSafety(status raftcluster.RecoveryStatusV1, opts RecoveryStatusOptionsV1, progress raftcluster.AppliedProgress) raftcluster.RecoveryStatusV1 {
+	if !opts.RequireReadSafety && opts.ReadBarrier == (raftcluster.AppliedIndexReadBarrier{}) {
+		return status
+	}
+	barrier := opts.ReadBarrier
+	if barrier.NodeID == "" {
+		barrier.NodeID = status.NodeID
+	}
+	if barrier.GroupID == "" {
+		barrier.GroupID = status.GroupID
+	}
+	if barrier.MinAppliedIndex == 0 {
+		barrier.MinAppliedIndex = status.TailTargetIndex
+	}
+	status.RequiredAppliedIndex = barrier.MinAppliedIndex
+	if err := barrier.Check(progress); err != nil {
+		if errors.Is(err, raftcluster.ErrReadBarrierTargetMismatch) {
+			status.ReadSafetyState = raftcluster.RecoveryReadSafetyTargetMismatchV1
+		} else {
+			status.ReadSafetyState = raftcluster.RecoveryReadSafetyAppliedIndexLaggingV1
+		}
+		status.Errors = append(status.Errors, err.Error())
+		return status
+	}
+	status.ReadSafetyState = raftcluster.RecoveryReadSafetyAppliedIndexSatisfiedV1
+	return status
+}
+
+func finalizeRecoveryStatus(status raftcluster.RecoveryStatusV1) raftcluster.RecoveryStatusV1 {
+	status.SafeToServeReads = false
+	switch {
+	case status.Readiness == raftcluster.RecoveryReadinessUnsupportedV1:
+		return status
+	case status.SnapshotState == raftcluster.RecoverySnapshotStateNoneV1:
+		status.Readiness = raftcluster.RecoveryReadinessUnsafeNoSnapshotV1
+	case status.SnapshotState == raftcluster.RecoverySnapshotStateManifestRejectedV1:
+		status.Readiness = raftcluster.RecoveryReadinessUnsafeManifestUnverifiedV1
+	case status.TailState == raftcluster.RecoveryTailStatePendingV1:
+		status.Readiness = raftcluster.RecoveryReadinessTailPendingV1
+	case status.TailState != raftcluster.RecoveryTailStateCompleteV1:
+		status.Readiness = raftcluster.RecoveryReadinessUnsafeManifestUnverifiedV1
+	case status.ReadSafetyState == raftcluster.RecoveryReadSafetyAppliedIndexSatisfiedV1:
+		status.Readiness = raftcluster.RecoveryReadinessReadyAppliedIndexV1
+		status.SafeToServeReads = true
+	case status.ReadSafetyState == raftcluster.RecoveryReadSafetyNotRequestedV1:
+		status.Readiness = raftcluster.RecoveryReadinessTailCompleteV1
+	default:
+		status.Readiness = raftcluster.RecoveryReadinessReadSafetyPendingV1
+	}
+	return status
+}

--- a/TreeDB/internal/raftfsm/recovery_status.go
+++ b/TreeDB/internal/raftfsm/recovery_status.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 
+	"github.com/snissn/gomap/TreeDB/internal/raftapply"
 	"github.com/snissn/gomap/TreeDB/internal/raftcluster"
 	"github.com/snissn/gomap/TreeDB/internal/raftentry"
 )
@@ -115,7 +116,7 @@ func (f *FSM) verifyRecoverySnapshotManifestV1(manifest raftcluster.SnapshotMani
 	if localLSN < manifest.AppliedCommandLSN {
 		return codedError(raftentry.ErrorUnsafeDurabilityModeV1, "snapshot manifest AppliedCommandLSN %d is ahead of local coverage %d", manifest.AppliedCommandLSN, localLSN)
 	}
-	result, ok, err := f.results.LookupApplyResult(raftentry.ApplyEntryID{
+	boundary, ok, err := f.progress.LookupApplyProgress(raftentry.ApplyEntryID{
 		Term:  manifest.LastIncludedTerm,
 		Index: manifest.LastIncludedIndex,
 	})
@@ -123,13 +124,16 @@ func (f *FSM) verifyRecoverySnapshotManifestV1(manifest raftcluster.SnapshotMani
 		return err
 	}
 	if !ok {
-		return codedError(raftentry.ErrorUnsafeDurabilityModeV1, "missing durable result for snapshot boundary %d/%d", manifest.LastIncludedTerm, manifest.LastIncludedIndex)
+		return codedError(raftentry.ErrorUnsafeDurabilityModeV1, "missing durable progress for snapshot boundary %d/%d", manifest.LastIncludedTerm, manifest.LastIncludedIndex)
 	}
-	if result.AppliedCommandLSN != manifest.AppliedCommandLSN {
-		return codedError(raftentry.ErrorRejectedConflictV1, "snapshot manifest AppliedCommandLSN %d does not match boundary result coverage %d", manifest.AppliedCommandLSN, result.AppliedCommandLSN)
+	if boundary.AppliedCommandLSN != manifest.AppliedCommandLSN {
+		return codedError(raftentry.ErrorRejectedConflictV1, "snapshot manifest AppliedCommandLSN %d does not match boundary progress coverage %d", manifest.AppliedCommandLSN, boundary.AppliedCommandLSN)
 	}
-	if result.Result.ResultDigest.Hex() != manifest.LogicalDigestV1 {
-		return codedError(raftentry.ErrorRejectedConflictV1, "snapshot manifest logical digest %s does not match boundary result digest %s", manifest.LogicalDigestV1, result.Result.ResultDigest.Hex())
+	if boundary.LogicalDigestV1 == (raftapply.LogicalDigestV1{}) {
+		return codedError(raftentry.ErrorUnsafeDurabilityModeV1, "missing durable logical digest for snapshot boundary %d/%d", manifest.LastIncludedTerm, manifest.LastIncludedIndex)
+	}
+	if boundary.LogicalDigestV1.Hex() != manifest.LogicalDigestV1 {
+		return codedError(raftentry.ErrorRejectedConflictV1, "snapshot manifest logical digest %s does not match boundary logical digest %s", manifest.LogicalDigestV1, boundary.LogicalDigestV1.Hex())
 	}
 	return nil
 }

--- a/TreeDB/internal/raftfsm/recovery_status.go
+++ b/TreeDB/internal/raftfsm/recovery_status.go
@@ -113,6 +113,9 @@ func (f *FSM) verifyRecoverySnapshotManifestV1(manifest raftcluster.SnapshotMani
 	if err != nil {
 		return err
 	}
+	if localLSN != record.AppliedCommandLSN {
+		return codedError(raftentry.ErrorUnsafeDurabilityModeV1, "local AppliedCommandLSN coverage %d does not match durable progress coverage %d for recovery status", localLSN, record.AppliedCommandLSN)
+	}
 	if localLSN < manifest.AppliedCommandLSN {
 		return codedError(raftentry.ErrorUnsafeDurabilityModeV1, "snapshot manifest AppliedCommandLSN %d is ahead of local coverage %d", manifest.AppliedCommandLSN, localLSN)
 	}

--- a/TreeDB/internal/raftfsm/recovery_status_test.go
+++ b/TreeDB/internal/raftfsm/recovery_status_test.go
@@ -94,6 +94,55 @@ func TestRecoveryStatusV1TracksSnapshotTailAndAppliedIndexReadiness(t *testing.T
 	}
 }
 
+func TestRecoveryStatusV1VerifiesDuplicateSnapshotBoundaryLogicalDigest(t *testing.T) {
+	root := t.TempDir()
+	dbDir := filepath.Join(root, "db")
+	db := openFSMTestDB(t, dbDir)
+	defer func() { _ = db.Close() }()
+	fsm := openFSMForTest(t, db, dbDir)
+	defer func() { _ = fsm.Close() }()
+
+	users := deterministicCreateCollectionEntry(t, "users", "fsm:recovery-status:duplicate-users")
+	if result, err := fsm.ApplyCommittedEntryV1(committedCommand(9, 1, users)); err != nil {
+		t.Fatalf("ApplyCommittedEntryV1 users: %v result=%+v", err, result)
+	}
+	orders := deterministicCreateCollectionEntry(t, "orders", "fsm:recovery-status:orders-before-duplicate")
+	if result, err := fsm.ApplyCommittedEntryV1(committedCommand(9, 2, orders)); err != nil {
+		t.Fatalf("ApplyCommittedEntryV1 orders: %v result=%+v", err, result)
+	}
+	duplicate, err := fsm.ApplyCommittedEntryV1(committedCommand(9, 3, users))
+	if err != nil {
+		t.Fatalf("ApplyCommittedEntryV1 duplicate users: %v result=%+v", err, duplicate)
+	}
+	manifest, err := fsm.ExportSnapshotManifestV1(SnapshotManifestExportOptionsV1{CreatedAt: time.Unix(1712347002, 0).UTC()})
+	if err != nil {
+		t.Fatalf("ExportSnapshotManifestV1: %v", err)
+	}
+	if duplicate.ResultDigest.Hex() == manifest.LogicalDigestV1 {
+		t.Fatalf("duplicate result digest unexpectedly equals manifest digest %s", manifest.LogicalDigestV1)
+	}
+
+	audits := deterministicCreateCollectionEntry(t, "audits", "fsm:recovery-status:tail-after-duplicate")
+	if result, err := fsm.ApplyCommittedEntryV1(committedCommand(9, 4, audits)); err != nil {
+		t.Fatalf("ApplyCommittedEntryV1 audits: %v result=%+v", err, result)
+	}
+	status, err := fsm.RecoveryStatusV1(context.Background(), RecoveryStatusOptionsV1{
+		SnapshotManifest:  &manifest,
+		TailTargetIndex:   4,
+		RequireReadSafety: true,
+	})
+	if err != nil {
+		t.Fatalf("RecoveryStatusV1 duplicate boundary: %v", err)
+	}
+	if status.Readiness != raftcluster.RecoveryReadinessReadyAppliedIndexV1 ||
+		status.SnapshotState != raftcluster.RecoverySnapshotStateManifestVerifiedV1 ||
+		status.TailState != raftcluster.RecoveryTailStateCompleteV1 ||
+		status.ReadSafetyState != raftcluster.RecoveryReadSafetyAppliedIndexSatisfiedV1 ||
+		!status.SafeToServeReads {
+		t.Fatalf("status=%+v, want verified duplicate snapshot boundary with complete tail and safe reads", status)
+	}
+}
+
 func TestRecoveryStatusV1MismatchedManifestRemainsUnsafe(t *testing.T) {
 	root := t.TempDir()
 	dbDir := filepath.Join(root, "db")

--- a/TreeDB/internal/raftfsm/recovery_status_test.go
+++ b/TreeDB/internal/raftfsm/recovery_status_test.go
@@ -7,7 +7,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/snissn/gomap/TreeDB/internal/raftapply"
 	"github.com/snissn/gomap/TreeDB/internal/raftcluster"
+	"github.com/snissn/gomap/TreeDB/internal/raftentry"
 )
 
 func TestRecoveryStatusV1BeforeSnapshotInstallIsUnsafe(t *testing.T) {
@@ -140,6 +142,69 @@ func TestRecoveryStatusV1VerifiesDuplicateSnapshotBoundaryLogicalDigest(t *testi
 		status.ReadSafetyState != raftcluster.RecoveryReadSafetyAppliedIndexSatisfiedV1 ||
 		!status.SafeToServeReads {
 		t.Fatalf("status=%+v, want verified duplicate snapshot boundary with complete tail and safe reads", status)
+	}
+}
+
+func TestRecoveryStatusV1RejectsLocalCoverageBeyondDurableProgress(t *testing.T) {
+	root := t.TempDir()
+	dbDir := filepath.Join(root, "db")
+	db := openFSMTestDB(t, dbDir)
+	defer func() { _ = db.Close() }()
+	fsm := openFSMForTest(t, db, dbDir)
+	defer func() { _ = fsm.Close() }()
+
+	users := deterministicCreateCollectionEntry(t, "users", "fsm:recovery-status:coverage-users")
+	if result, err := fsm.ApplyCommittedEntryV1(committedCommand(9, 1, users)); err != nil {
+		t.Fatalf("ApplyCommittedEntryV1 users: %v result=%+v", err, result)
+	}
+	manifest, err := fsm.ExportSnapshotManifestV1(SnapshotManifestExportOptionsV1{CreatedAt: time.Unix(1712347003, 0).UTC()})
+	if err != nil {
+		t.Fatalf("ExportSnapshotManifestV1: %v", err)
+	}
+	progressBefore, ok, err := fsm.lastAppliedProgressRecord()
+	if err != nil {
+		t.Fatalf("lastAppliedProgressRecord before uncovered apply: %v", err)
+	}
+	if !ok {
+		t.Fatal("missing progress after first apply")
+	}
+
+	ordersEntry := committedCommand(9, 2, deterministicCreateCollectionEntry(t, "orders", "fsm:recovery-status:coverage-orders"))
+	ordersID := raftentry.ApplyEntryID{Term: ordersEntry.Term, Index: ordersEntry.Index}
+	meta, err := fsm.applyMetadata(ordersEntry, ordersID)
+	if err != nil {
+		t.Fatalf("applyMetadata orders: %v", err)
+	}
+	if result, err := raftapply.ApplyCommittedEntryV1(db, ordersEntry.Bytes, meta, raftapply.Options{DecodeLimits: fsm.decodeLimits}); err != nil {
+		t.Fatalf("lower ApplyCommittedEntryV1 orders: %v result=%+v", err, result)
+	}
+	if got := db.State().AppliedCommandLSN; got <= progressBefore.AppliedCommandLSN {
+		t.Fatalf("AppliedCommandLSN after uncovered apply=%d, want greater than durable progress %d", got, progressBefore.AppliedCommandLSN)
+	}
+	progressAfter, ok, err := fsm.lastAppliedProgressRecord()
+	if err != nil {
+		t.Fatalf("lastAppliedProgressRecord after uncovered apply: %v", err)
+	}
+	if !ok || progressAfter != progressBefore {
+		t.Fatalf("progress after uncovered apply=%+v ok=%v, want unchanged %+v", progressAfter, ok, progressBefore)
+	}
+
+	status, err := fsm.RecoveryStatusV1(context.Background(), RecoveryStatusOptionsV1{
+		SnapshotManifest:  &manifest,
+		TailTargetIndex:   1,
+		RequireReadSafety: true,
+	})
+	if err != nil {
+		t.Fatalf("RecoveryStatusV1 uncovered coverage: %v", err)
+	}
+	if status.Readiness != raftcluster.RecoveryReadinessUnsafeManifestUnverifiedV1 ||
+		status.SnapshotState != raftcluster.RecoverySnapshotStateManifestRejectedV1 ||
+		status.SafeToServeReads ||
+		len(status.Errors) == 0 {
+		t.Fatalf("status=%+v, want unsafe rejected manifest after uncovered local coverage", status)
+	}
+	if !strings.Contains(strings.Join(status.Errors, "\n"), "does not match durable progress coverage") {
+		t.Fatalf("status errors=%v, want durable progress coverage mismatch", status.Errors)
 	}
 }
 

--- a/TreeDB/internal/raftfsm/recovery_status_test.go
+++ b/TreeDB/internal/raftfsm/recovery_status_test.go
@@ -1,0 +1,129 @@
+package raftfsm
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/snissn/gomap/TreeDB/internal/raftcluster"
+)
+
+func TestRecoveryStatusV1BeforeSnapshotInstallIsUnsafe(t *testing.T) {
+	root := t.TempDir()
+	dbDir := filepath.Join(root, "db")
+	db := openFSMTestDB(t, dbDir)
+	defer func() { _ = db.Close() }()
+	fsm := openFSMForTest(t, db, dbDir)
+	defer func() { _ = fsm.Close() }()
+
+	status, err := fsm.RecoveryStatusV1(context.Background(), RecoveryStatusOptionsV1{
+		TailTargetIndex:   1,
+		RequireReadSafety: true,
+	})
+	if err != nil {
+		t.Fatalf("RecoveryStatusV1: %v", err)
+	}
+	if status.Readiness != raftcluster.RecoveryReadinessUnsafeNoSnapshotV1 ||
+		status.SnapshotState != raftcluster.RecoverySnapshotStateNoneV1 ||
+		status.TailState != raftcluster.RecoveryTailStateNoSnapshotV1 ||
+		status.ReadSafetyState != raftcluster.RecoveryReadSafetyAppliedIndexLaggingV1 ||
+		status.SafeToServeReads {
+		t.Fatalf("status=%+v, want unsafe no-snapshot with lagging applied-index read safety", status)
+	}
+}
+
+func TestRecoveryStatusV1TracksSnapshotTailAndAppliedIndexReadiness(t *testing.T) {
+	root := t.TempDir()
+	dbDir := filepath.Join(root, "db")
+	db := openFSMTestDB(t, dbDir)
+	defer func() { _ = db.Close() }()
+	fsm := openFSMForTest(t, db, dbDir)
+	defer func() { _ = fsm.Close() }()
+
+	users := deterministicCreateCollectionEntry(t, "users", "fsm:recovery-status:users")
+	if result, err := fsm.ApplyCommittedEntryV1(committedCommand(9, 1, users)); err != nil {
+		t.Fatalf("ApplyCommittedEntryV1 users: %v result=%+v", err, result)
+	}
+	manifest, err := fsm.ExportSnapshotManifestV1(SnapshotManifestExportOptionsV1{CreatedAt: time.Unix(1712347000, 0).UTC()})
+	if err != nil {
+		t.Fatalf("ExportSnapshotManifestV1: %v", err)
+	}
+
+	status, err := fsm.RecoveryStatusV1(context.Background(), RecoveryStatusOptionsV1{
+		SnapshotManifest:  &manifest,
+		TailTargetIndex:   2,
+		RequireReadSafety: true,
+	})
+	if err != nil {
+		t.Fatalf("RecoveryStatusV1 pending tail: %v", err)
+	}
+	if status.Readiness != raftcluster.RecoveryReadinessTailPendingV1 ||
+		status.SnapshotState != raftcluster.RecoverySnapshotStateManifestVerifiedV1 ||
+		status.TailState != raftcluster.RecoveryTailStatePendingV1 ||
+		status.TailLagEntries != 1 ||
+		status.ReadSafetyState != raftcluster.RecoveryReadSafetyAppliedIndexLaggingV1 ||
+		status.RequiredAppliedIndex != 2 ||
+		status.SafeToServeReads {
+		t.Fatalf("pending status=%+v", status)
+	}
+
+	orders := deterministicCreateCollectionEntry(t, "orders", "fsm:recovery-status:orders")
+	if result, err := fsm.ApplyCommittedEntryV1(committedCommand(9, 2, orders)); err != nil {
+		t.Fatalf("ApplyCommittedEntryV1 orders: %v result=%+v", err, result)
+	}
+	status, err = fsm.RecoveryStatusV1(context.Background(), RecoveryStatusOptionsV1{
+		SnapshotManifest:  &manifest,
+		TailTargetIndex:   2,
+		RequireReadSafety: true,
+	})
+	if err != nil {
+		t.Fatalf("RecoveryStatusV1 tail complete: %v", err)
+	}
+	if status.Readiness != raftcluster.RecoveryReadinessReadyAppliedIndexV1 ||
+		status.SnapshotState != raftcluster.RecoverySnapshotStateManifestVerifiedV1 ||
+		status.TailState != raftcluster.RecoveryTailStateCompleteV1 ||
+		status.TailLagEntries != 0 ||
+		status.ReadSafetyState != raftcluster.RecoveryReadSafetyAppliedIndexSatisfiedV1 ||
+		!status.SafeToServeReads {
+		t.Fatalf("tail-complete status=%+v", status)
+	}
+	if status.SnapshotManifest == nil || status.SnapshotManifest.LogicalDigestV1 != manifest.LogicalDigestV1 {
+		t.Fatalf("status manifest=%+v, want copied manifest digest %s", status.SnapshotManifest, manifest.LogicalDigestV1)
+	}
+}
+
+func TestRecoveryStatusV1MismatchedManifestRemainsUnsafe(t *testing.T) {
+	root := t.TempDir()
+	dbDir := filepath.Join(root, "db")
+	db := openFSMTestDB(t, dbDir)
+	defer func() { _ = db.Close() }()
+	fsm := openFSMForTest(t, db, dbDir)
+	defer func() { _ = fsm.Close() }()
+
+	raw := deterministicCreateCollectionEntry(t, "users", "fsm:recovery-status:mismatch")
+	if result, err := fsm.ApplyCommittedEntryV1(committedCommand(10, 1, raw)); err != nil {
+		t.Fatalf("ApplyCommittedEntryV1: %v result=%+v", err, result)
+	}
+	manifest, err := fsm.ExportSnapshotManifestV1(SnapshotManifestExportOptionsV1{CreatedAt: time.Unix(1712347001, 0).UTC()})
+	if err != nil {
+		t.Fatalf("ExportSnapshotManifestV1: %v", err)
+	}
+	manifest.LogicalDigestV1 = strings.Repeat("0", 64)
+
+	status, err := fsm.RecoveryStatusV1(context.Background(), RecoveryStatusOptionsV1{
+		SnapshotManifest:  &manifest,
+		TailTargetIndex:   1,
+		RequireReadSafety: true,
+	})
+	if err != nil {
+		t.Fatalf("RecoveryStatusV1 mismatched manifest: %v", err)
+	}
+	if status.Readiness != raftcluster.RecoveryReadinessUnsafeManifestUnverifiedV1 ||
+		status.SnapshotState != raftcluster.RecoverySnapshotStateManifestRejectedV1 ||
+		status.SafeToServeReads ||
+		len(status.Errors) == 0 {
+		t.Fatalf("status=%+v, want unsafe rejected manifest with error detail", status)
+	}
+}

--- a/TreeDB/internal/raftharness/recovery_status.go
+++ b/TreeDB/internal/raftharness/recovery_status.go
@@ -38,17 +38,28 @@ func (h *Harness) RecoveryStatusV1(ctx context.Context, nodeID raftcluster.NodeI
 	if opts.TailTargetIndex == 0 && len(h.committed) > 0 {
 		opts.TailTargetIndex = h.committed[len(h.committed)-1].Index
 	}
+	committed := make([]raftfsm.CommittedEntryV1, 0, len(h.committed))
+	for _, entry := range h.committed {
+		committed = append(committed, cloneCommittedEntry(entry))
+	}
 	h.mu.Unlock()
 
 	if opts.RequireReadSafety && opts.ReadBarrier.MinAppliedIndex == 0 {
 		opts.ReadBarrier.MinAppliedIndex = opts.TailTargetIndex
 	}
-	return node.fsm.RecoveryStatusV1(ctx, raftfsm.RecoveryStatusOptionsV1{
+	status, err := node.fsm.RecoveryStatusV1(ctx, raftfsm.RecoveryStatusOptionsV1{
 		SnapshotManifest:  opts.SnapshotManifest,
 		TailTargetIndex:   opts.TailTargetIndex,
 		RequireReadSafety: opts.RequireReadSafety,
 		ReadBarrier:       opts.ReadBarrier,
 	})
+	if err != nil {
+		return status, err
+	}
+	if opts.RequireReadSafety && status.SafeToServeReads {
+		status = validateHarnessReadSafetyPrefixV1(status, node, committed)
+	}
+	return status, nil
 }
 
 func (h *Harness) LogTruncationRecoveryStatusV1(nodeID raftcluster.NodeID) (raftcluster.RecoveryStatusV1, error) {
@@ -72,4 +83,33 @@ func (h *Harness) unsupportedRecoveryStatusV1(nodeID raftcluster.NodeID, op raft
 	}
 	status := raftcluster.UnsupportedRecoveryStatusV1(nodeID, groupID, op)
 	return status, fmt.Errorf("%w: %s", raftcluster.ErrRecoveryOperationUnsupported, op)
+}
+
+func validateHarnessReadSafetyPrefixV1(status raftcluster.RecoveryStatusV1, node *Node, committed []raftfsm.CommittedEntryV1) raftcluster.RecoveryStatusV1 {
+	progress := status.AppliedProgress
+	if node == nil || node.fsm == nil {
+		return failHarnessReadSafetyPrefixV1(status, fmt.Errorf("%w: closed node", ErrNodeClosed))
+	}
+	if !progress.HasApplied || progress.Index == 0 {
+		return failHarnessReadSafetyPrefixV1(status, fmt.Errorf("%w: node %s has no applied progress", ErrCommittedLogConflict, status.NodeID))
+	}
+	if progress.Index > uint64(len(committed)) {
+		return failHarnessReadSafetyPrefixV1(status, fmt.Errorf("%w: node %s applied index %d beyond committed log length %d", ErrCommittedLogConflict, status.NodeID, progress.Index, len(committed)))
+	}
+	prefix := make([]raftfsm.CommittedEntryV1, 0, progress.Index)
+	for _, entry := range committed[:progress.Index] {
+		prefix = append(prefix, cloneCommittedEntry(entry))
+	}
+	if _, err := node.fsm.ValidateAppliedPrefixV1(prefix); err != nil {
+		return failHarnessReadSafetyPrefixV1(status, err)
+	}
+	return status
+}
+
+func failHarnessReadSafetyPrefixV1(status raftcluster.RecoveryStatusV1, err error) raftcluster.RecoveryStatusV1 {
+	status.SafeToServeReads = false
+	status.Readiness = raftcluster.RecoveryReadinessReadSafetyPendingV1
+	status.ReadSafetyState = raftcluster.RecoveryReadSafetyTargetMismatchV1
+	status.Errors = append(status.Errors, fmt.Sprintf("raftharness: committed-prefix read safety validation failed: %v", err))
+	return status
 }

--- a/TreeDB/internal/raftharness/recovery_status.go
+++ b/TreeDB/internal/raftharness/recovery_status.go
@@ -1,0 +1,75 @@
+package raftharness
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/snissn/gomap/TreeDB/internal/raftcluster"
+	"github.com/snissn/gomap/TreeDB/internal/raftfsm"
+)
+
+type RecoveryStatusOptionsV1 struct {
+	SnapshotManifest *raftcluster.SnapshotManifestV1
+	TailTargetIndex  uint64
+
+	RequireReadSafety bool
+	ReadBarrier       raftcluster.AppliedIndexReadBarrier
+}
+
+func (h *Harness) RecoveryStatusV1(ctx context.Context, nodeID raftcluster.NodeID, opts RecoveryStatusOptionsV1) (raftcluster.RecoveryStatusV1, error) {
+	ctx = readBarrierContext(ctx)
+	if err := ctx.Err(); err != nil {
+		return raftcluster.NewRecoveryStatusV1(nodeID, ""), err
+	}
+	if h == nil {
+		return raftcluster.NewRecoveryStatusV1(nodeID, ""), ErrHarnessClosed
+	}
+	h.mu.Lock()
+	if h.closed {
+		h.mu.Unlock()
+		return raftcluster.NewRecoveryStatusV1(nodeID, h.groupID), ErrHarnessClosed
+	}
+	node, ok := h.nodes[nodeID]
+	groupID := h.groupID
+	if !ok {
+		h.mu.Unlock()
+		return raftcluster.NewRecoveryStatusV1(nodeID, groupID), fmt.Errorf("%w: %s", ErrNodeNotFound, nodeID)
+	}
+	if opts.TailTargetIndex == 0 && len(h.committed) > 0 {
+		opts.TailTargetIndex = h.committed[len(h.committed)-1].Index
+	}
+	h.mu.Unlock()
+
+	if opts.RequireReadSafety && opts.ReadBarrier.MinAppliedIndex == 0 {
+		opts.ReadBarrier.MinAppliedIndex = opts.TailTargetIndex
+	}
+	return node.fsm.RecoveryStatusV1(ctx, raftfsm.RecoveryStatusOptionsV1{
+		SnapshotManifest:  opts.SnapshotManifest,
+		TailTargetIndex:   opts.TailTargetIndex,
+		RequireReadSafety: opts.RequireReadSafety,
+		ReadBarrier:       opts.ReadBarrier,
+	})
+}
+
+func (h *Harness) LogTruncationRecoveryStatusV1(nodeID raftcluster.NodeID) (raftcluster.RecoveryStatusV1, error) {
+	return h.unsupportedRecoveryStatusV1(nodeID, raftcluster.RecoveryUnsupportedLogTruncationV1)
+}
+
+func (h *Harness) ProductionRejoinRecoveryStatusV1(nodeID raftcluster.NodeID) (raftcluster.RecoveryStatusV1, error) {
+	return h.unsupportedRecoveryStatusV1(nodeID, raftcluster.RecoveryUnsupportedProductionRejoinV1)
+}
+
+func (h *Harness) ProductionSnapshotTransferRecoveryStatusV1(nodeID raftcluster.NodeID) (raftcluster.RecoveryStatusV1, error) {
+	return h.unsupportedRecoveryStatusV1(nodeID, raftcluster.RecoveryUnsupportedProductionSnapshotTransferV1)
+}
+
+func (h *Harness) unsupportedRecoveryStatusV1(nodeID raftcluster.NodeID, op raftcluster.RecoveryUnsupportedOperationV1) (raftcluster.RecoveryStatusV1, error) {
+	groupID := raftcluster.GroupID("")
+	if h != nil {
+		h.mu.Lock()
+		groupID = h.groupID
+		h.mu.Unlock()
+	}
+	status := raftcluster.UnsupportedRecoveryStatusV1(nodeID, groupID, op)
+	return status, fmt.Errorf("%w: %s", raftcluster.ErrRecoveryOperationUnsupported, op)
+}

--- a/TreeDB/internal/raftharness/recovery_status.go
+++ b/TreeDB/internal/raftharness/recovery_status.go
@@ -56,10 +56,14 @@ func (h *Harness) RecoveryStatusV1(ctx context.Context, nodeID raftcluster.NodeI
 	if err != nil {
 		return status, err
 	}
-	if opts.RequireReadSafety && status.SafeToServeReads {
+	if harnessRecoveryReadSafetyRequestedV1(opts) && status.SafeToServeReads {
 		status = validateHarnessReadSafetyPrefixV1(status, node, committed)
 	}
 	return status, nil
+}
+
+func harnessRecoveryReadSafetyRequestedV1(opts RecoveryStatusOptionsV1) bool {
+	return opts.RequireReadSafety || opts.ReadBarrier != (raftcluster.AppliedIndexReadBarrier{})
 }
 
 func (h *Harness) LogTruncationRecoveryStatusV1(nodeID raftcluster.NodeID) (raftcluster.RecoveryStatusV1, error) {

--- a/TreeDB/internal/raftharness/recovery_status_test.go
+++ b/TreeDB/internal/raftharness/recovery_status_test.go
@@ -173,6 +173,11 @@ func TestRecoveryStatusUnsupportedOperationsFailClosed(t *testing.T) {
 			run:  func() (raftcluster.RecoveryStatusV1, error) { return h.ProductionRejoinRecoveryStatusV1("node-b") },
 			want: raftcluster.RecoveryUnsupportedProductionRejoinV1,
 		},
+		{
+			name: "production snapshot transfer",
+			run:  func() (raftcluster.RecoveryStatusV1, error) { return h.ProductionSnapshotTransferRecoveryStatusV1("node-b") },
+			want: raftcluster.RecoveryUnsupportedProductionSnapshotTransferV1,
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/TreeDB/internal/raftharness/recovery_status_test.go
+++ b/TreeDB/internal/raftharness/recovery_status_test.go
@@ -154,6 +154,49 @@ func TestRecoveryStatusDirtyTargetAndMismatchedManifestRemainUnsafe(t *testing.T
 	}
 }
 
+func TestRecoveryStatusReadSafetyRejectsDivergentAppliedTail(t *testing.T) {
+	h := openTestHarness(t)
+	defer func() { _ = h.Close() }()
+
+	committed := []raftfsm.CommittedEntryV1{
+		committedCommand(43, 1, deterministicCreateCollectionEntry(t, "users", "harness:create:users:recovery-status-prefix")),
+		committedCommand(43, 2, deterministicCreateCollectionEntry(t, "orders", "harness:create:orders:recovery-status-tail")),
+	}
+	if _, err := h.Commit(committed...); err != nil {
+		t.Fatalf("Commit committed log: %v", err)
+	}
+	if _, err := h.ApplyCommittedEntriesToNode("node-a", committed[:1]...); err != nil {
+		t.Fatalf("apply source prefix: %v", err)
+	}
+	manifest, err := mustNode(t, h, "node-a").fsm.ExportSnapshotManifestV1(raftfsm.SnapshotManifestExportOptionsV1{CreatedAt: time.Unix(1712348002, 0).UTC()})
+	if err != nil {
+		t.Fatalf("ExportSnapshotManifestV1: %v", err)
+	}
+	if install, err := h.InstallSnapshotPrefixToNodeV1("node-b", manifest); err != nil {
+		t.Fatalf("InstallSnapshotPrefixToNodeV1: %v evidence=%+v", err, install)
+	}
+
+	divergentTail := committedCommand(43, 2, deterministicCreateCollectionEntry(t, "admins", "harness:create:admins:recovery-status-divergent-tail"))
+	seeded := applyEntriesDirectlyToNode(t, h, "node-b", divergentTail)
+	assertAppliedResults(t, "node-b divergent recovery-status tail", seeded, []int64{1})
+
+	status, err := h.RecoveryStatusV1(context.Background(), "node-b", RecoveryStatusOptionsV1{
+		SnapshotManifest:  &manifest,
+		RequireReadSafety: true,
+	})
+	if err != nil {
+		t.Fatalf("RecoveryStatusV1 divergent tail: %v", err)
+	}
+	if status.Readiness == raftcluster.RecoveryReadinessReadyAppliedIndexV1 ||
+		status.SafeToServeReads ||
+		status.ReadSafetyState != raftcluster.RecoveryReadSafetyTargetMismatchV1 {
+		t.Fatalf("divergent tail status=%+v, want unsafe read-safety mismatch", status)
+	}
+	if got := strings.Join(status.Errors, "\n"); !strings.Contains(got, "committed-prefix read safety validation failed") {
+		t.Fatalf("divergent tail errors=%q, want committed-prefix validation error", got)
+	}
+}
+
 func TestRecoveryStatusUnsupportedOperationsFailClosed(t *testing.T) {
 	h := openTestHarness(t)
 	defer func() { _ = h.Close() }()

--- a/TreeDB/internal/raftharness/recovery_status_test.go
+++ b/TreeDB/internal/raftharness/recovery_status_test.go
@@ -195,6 +195,21 @@ func TestRecoveryStatusReadSafetyRejectsDivergentAppliedTail(t *testing.T) {
 	if got := strings.Join(status.Errors, "\n"); !strings.Contains(got, "committed-prefix read safety validation failed") {
 		t.Fatalf("divergent tail errors=%q, want committed-prefix validation error", got)
 	}
+
+	status, err = h.RecoveryStatusV1(context.Background(), "node-b", RecoveryStatusOptionsV1{
+		SnapshotManifest: &manifest,
+		ReadBarrier: raftcluster.AppliedIndexReadBarrier{
+			MinAppliedIndex: 2,
+		},
+	})
+	if err != nil {
+		t.Fatalf("RecoveryStatusV1 explicit read barrier divergent tail: %v", err)
+	}
+	if status.Readiness == raftcluster.RecoveryReadinessReadyAppliedIndexV1 ||
+		status.SafeToServeReads ||
+		status.ReadSafetyState != raftcluster.RecoveryReadSafetyTargetMismatchV1 {
+		t.Fatalf("divergent tail explicit barrier status=%+v, want unsafe read-safety mismatch", status)
+	}
 }
 
 func TestRecoveryStatusUnsupportedOperationsFailClosed(t *testing.T) {

--- a/TreeDB/internal/raftharness/recovery_status_test.go
+++ b/TreeDB/internal/raftharness/recovery_status_test.go
@@ -1,0 +1,208 @@
+package raftharness
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/snissn/gomap/TreeDB/collections"
+	"github.com/snissn/gomap/TreeDB/internal/raftcluster"
+	"github.com/snissn/gomap/TreeDB/internal/raftfsm"
+)
+
+func TestRecoveryStatusTransitionsAcrossSnapshotInstallTailReplayAndReopen(t *testing.T) {
+	h := openTestHarness(t)
+	defer func() { _ = h.Close() }()
+
+	entries := mixedUserEntries(t, 41)
+	if _, err := h.Commit(entries...); err != nil {
+		t.Fatalf("Commit mixed entries: %v", err)
+	}
+
+	status, err := h.RecoveryStatusV1(context.Background(), "node-b", RecoveryStatusOptionsV1{
+		RequireReadSafety: true,
+	})
+	if err != nil {
+		t.Fatalf("RecoveryStatusV1 before install: %v", err)
+	}
+	if status.Readiness != raftcluster.RecoveryReadinessUnsafeNoSnapshotV1 ||
+		status.SnapshotState != raftcluster.RecoverySnapshotStateNoneV1 ||
+		status.TailState != raftcluster.RecoveryTailStateNoSnapshotV1 ||
+		status.ReadSafetyState != raftcluster.RecoveryReadSafetyAppliedIndexLaggingV1 ||
+		status.TailTargetIndex != 4 ||
+		status.SafeToServeReads {
+		t.Fatalf("before-install status=%+v", status)
+	}
+
+	if _, err := h.ApplyCommittedEntriesToNode("node-a", entries[:2]...); err != nil {
+		t.Fatalf("apply source prefix: %v", err)
+	}
+	source := mustNode(t, h, "node-a")
+	manifest, err := source.fsm.ExportSnapshotManifestV1(raftfsm.SnapshotManifestExportOptionsV1{CreatedAt: time.Unix(1712348000, 0).UTC()})
+	if err != nil {
+		t.Fatalf("ExportSnapshotManifestV1: %v", err)
+	}
+	install, err := h.InstallSnapshotPrefixToNodeV1("node-b", manifest)
+	if err != nil {
+		t.Fatalf("InstallSnapshotPrefixToNodeV1: %v evidence=%+v", err, install)
+	}
+	assertAppliedResults(t, "snapshot prefix install", install.Applied, []int64{1, 2})
+
+	status, err = h.RecoveryStatusV1(context.Background(), "node-b", RecoveryStatusOptionsV1{
+		SnapshotManifest:  &manifest,
+		RequireReadSafety: true,
+	})
+	if err != nil {
+		t.Fatalf("RecoveryStatusV1 after install: %v", err)
+	}
+	assertRecoveryTailPending(t, status, 4, 2)
+
+	if _, err := h.ReopenNode("node-b"); err != nil {
+		t.Fatalf("ReopenNode node-b: %v", err)
+	}
+	status, err = h.RecoveryStatusV1(context.Background(), "node-b", RecoveryStatusOptionsV1{
+		SnapshotManifest:  &manifest,
+		RequireReadSafety: true,
+	})
+	if err != nil {
+		t.Fatalf("RecoveryStatusV1 after reopen: %v", err)
+	}
+	assertRecoveryTailPending(t, status, 4, 2)
+
+	tail, err := h.ReplaySnapshotTailToNodeV1("node-b", manifest)
+	if err != nil {
+		t.Fatalf("ReplaySnapshotTailToNodeV1: %v results=%+v", err, tail)
+	}
+	assertAppliedResults(t, "snapshot tail replay", tail, []int64{1, 1})
+	fullReplay, err := h.ApplyCommittedEntriesToNode("node-c", entries...)
+	if err != nil {
+		t.Fatalf("ApplyCommittedEntriesToNode full replay: %v results=%+v", err, fullReplay)
+	}
+	assertAppliedResults(t, "full replay", fullReplay, []int64{1, 2, 1, 1})
+	if fullDigest, targetDigest := logicalDigest(t, h, "node-c"), logicalDigest(t, h, "node-b"); fullDigest != targetDigest {
+		t.Fatalf("snapshot+tail digest mismatch full=%s target=%s", fullDigest.Hex(), targetDigest.Hex())
+	}
+
+	status, err = h.RecoveryStatusV1(context.Background(), "node-b", RecoveryStatusOptionsV1{
+		SnapshotManifest:  &manifest,
+		RequireReadSafety: true,
+	})
+	if err != nil {
+		t.Fatalf("RecoveryStatusV1 after tail: %v", err)
+	}
+	if status.Readiness != raftcluster.RecoveryReadinessReadyAppliedIndexV1 ||
+		status.SnapshotState != raftcluster.RecoverySnapshotStateManifestVerifiedV1 ||
+		status.TailState != raftcluster.RecoveryTailStateCompleteV1 ||
+		status.ReadSafetyState != raftcluster.RecoveryReadSafetyAppliedIndexSatisfiedV1 ||
+		status.TailLagEntries != 0 ||
+		!status.SafeToServeReads {
+		t.Fatalf("after-tail status=%+v", status)
+	}
+}
+
+func TestRecoveryStatusDirtyTargetAndMismatchedManifestRemainUnsafe(t *testing.T) {
+	h := openTestHarness(t)
+	defer func() { _ = h.Close() }()
+
+	entries := mixedUserEntries(t, 42)
+	if _, err := h.Commit(entries...); err != nil {
+		t.Fatalf("Commit mixed entries: %v", err)
+	}
+	if _, err := h.ApplyCommittedEntriesToNode("node-a", entries[:2]...); err != nil {
+		t.Fatalf("apply source prefix: %v", err)
+	}
+	manifest, err := mustNode(t, h, "node-a").fsm.ExportSnapshotManifestV1(raftfsm.SnapshotManifestExportOptionsV1{CreatedAt: time.Unix(1712348001, 0).UTC()})
+	if err != nil {
+		t.Fatalf("ExportSnapshotManifestV1: %v", err)
+	}
+
+	target := mustNode(t, h, "node-b")
+	if _, err := collections.NewCollectionManager(target.DB()).CreateCollection(&collections.CollectionMeta{Name: "localdirty"}); err != nil {
+		t.Fatalf("dirty target CreateCollection: %v", err)
+	}
+	status, err := h.RecoveryStatusV1(context.Background(), "node-b", RecoveryStatusOptionsV1{
+		SnapshotManifest:  &manifest,
+		RequireReadSafety: true,
+	})
+	if err != nil {
+		t.Fatalf("RecoveryStatusV1 dirty target: %v", err)
+	}
+	if status.Readiness != raftcluster.RecoveryReadinessUnsafeManifestUnverifiedV1 ||
+		status.SnapshotState != raftcluster.RecoverySnapshotStateManifestRejectedV1 ||
+		status.SafeToServeReads {
+		t.Fatalf("dirty target status=%+v, want unsafe rejected manifest", status)
+	}
+
+	mismatched := manifest
+	mismatched.LogicalDigestV1 = strings.Repeat("0", 64)
+	status, err = h.RecoveryStatusV1(context.Background(), "node-a", RecoveryStatusOptionsV1{
+		SnapshotManifest:  &mismatched,
+		TailTargetIndex:   manifest.LastIncludedIndex,
+		RequireReadSafety: true,
+	})
+	if err != nil {
+		t.Fatalf("RecoveryStatusV1 mismatched manifest: %v", err)
+	}
+	if status.Readiness != raftcluster.RecoveryReadinessUnsafeManifestUnverifiedV1 ||
+		status.SnapshotState != raftcluster.RecoverySnapshotStateManifestRejectedV1 ||
+		len(status.Errors) == 0 ||
+		status.SafeToServeReads {
+		t.Fatalf("mismatched manifest status=%+v, want unsafe rejected manifest", status)
+	}
+}
+
+func TestRecoveryStatusUnsupportedOperationsFailClosed(t *testing.T) {
+	h := openTestHarness(t)
+	defer func() { _ = h.Close() }()
+
+	tests := []struct {
+		name string
+		run  func() (raftcluster.RecoveryStatusV1, error)
+		want raftcluster.RecoveryUnsupportedOperationV1
+	}{
+		{
+			name: "log truncation",
+			run:  func() (raftcluster.RecoveryStatusV1, error) { return h.LogTruncationRecoveryStatusV1("node-b") },
+			want: raftcluster.RecoveryUnsupportedLogTruncationV1,
+		},
+		{
+			name: "production rejoin",
+			run:  func() (raftcluster.RecoveryStatusV1, error) { return h.ProductionRejoinRecoveryStatusV1("node-b") },
+			want: raftcluster.RecoveryUnsupportedProductionRejoinV1,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			status, err := tc.run()
+			if !errors.Is(err, raftcluster.ErrRecoveryOperationUnsupported) {
+				t.Fatalf("err=%v, want ErrRecoveryOperationUnsupported", err)
+			}
+			if status.Readiness != raftcluster.RecoveryReadinessUnsupportedV1 ||
+				status.SafeToServeReads ||
+				!reflect.DeepEqual(status.Unsupported, []raftcluster.RecoveryUnsupportedOperationV1{tc.want}) {
+				t.Fatalf("status=%+v, want unsupported %s", status, tc.want)
+			}
+		})
+	}
+}
+
+func assertRecoveryTailPending(t *testing.T, status raftcluster.RecoveryStatusV1, target, lag uint64) {
+	t.Helper()
+	if status.Readiness != raftcluster.RecoveryReadinessTailPendingV1 ||
+		status.SnapshotState != raftcluster.RecoverySnapshotStateManifestVerifiedV1 ||
+		status.TailState != raftcluster.RecoveryTailStatePendingV1 ||
+		status.ReadSafetyState != raftcluster.RecoveryReadSafetyAppliedIndexLaggingV1 ||
+		status.TailTargetIndex != target ||
+		status.TailLagEntries != lag ||
+		status.SafeToServeReads {
+		t.Fatalf("tail-pending status=%+v", status)
+	}
+	if status.AppliedProgress.Index != target-lag ||
+		status.AppliedCommandLSN == 0 ||
+		status.SnapshotManifest == nil {
+		t.Fatalf("tail-pending progress=%+v lsn=%d manifest=%+v", status.AppliedProgress, status.AppliedCommandLSN, status.SnapshotManifest)
+	}
+}

--- a/TreeDB/internal/raftharness/recovery_status_test.go
+++ b/TreeDB/internal/raftharness/recovery_status_test.go
@@ -175,7 +175,9 @@ func TestRecoveryStatusUnsupportedOperationsFailClosed(t *testing.T) {
 		},
 		{
 			name: "production snapshot transfer",
-			run:  func() (raftcluster.RecoveryStatusV1, error) { return h.ProductionSnapshotTransferRecoveryStatusV1("node-b") },
+			run: func() (raftcluster.RecoveryStatusV1, error) {
+				return h.ProductionSnapshotTransferRecoveryStatusV1("node-b")
+			},
 			want: raftcluster.RecoveryUnsupportedProductionSnapshotTransferV1,
 		},
 	}


### PR DESCRIPTION
Closes #3380

Parent: #3045. This PR does not close the parent tracker.

## Summary

- Add versioned `RecoveryStatusV1` and `RecoveryMetricsV1` contracts in `raftcluster`, including stable readiness labels, metric keys, and explicit unsupported operation labels.
- Add `raftfsm.RecoveryStatusV1` derivation from durable apply progress, local `AppliedCommandLSN`, snapshot manifest/boundary digest verification, tail target state, and applied-index read safety.
- Add `raftharness` recovery status helpers and transition tests for no snapshot, injected prefix install, close/reopen before tail replay, tail completion, dirty/mismatched manifests, and unsupported log truncation/rejoin states.
- Document the recovery status boundary and metrics labels while preserving the no-production-transfer/truncation/rejoin scope.

## Validation

- `GOCACHE=/mnt/fast4tb/tmp/gocache-codex-3380 GOTMPDIR=/mnt/fast4tb/tmp/gotmp-codex-3380 GOWORK=off go test ./TreeDB/internal/raftcluster ./TreeDB/internal/raftfsm ./TreeDB/internal/raftharness -count=1`
- `GOCACHE=/mnt/fast4tb/tmp/gocache-codex-3380 GOTMPDIR=/mnt/fast4tb/tmp/gotmp-codex-3380 GOWORK=off go test ./TreeDB/internal/raftapply ./TreeDB/internal/raftentry -count=1`
- `GOCACHE=/mnt/fast4tb/tmp/gocache-codex-3380 GOTMPDIR=/mnt/fast4tb/tmp/gotmp-codex-3380 GOWORK=off go test ./TreeDB/docs -count=1`
- `git diff --check origin/main...HEAD`

## Scope Boundary

No production snapshot transfer, Raft log truncation, production rejoin, nativewire, Mongo, or raftplacement behavior is implemented here.