### PR TITLE
raftcluster: add single-group submit/apply bridge

### DIFF
--- a/TreeDB/docs/spec/raftcluster.md
+++ b/TreeDB/docs/spec/raftcluster.md
@@ -2,10 +2,10 @@
 
 Status: normative for the initial `TreeDB/internal/raftcluster` package.
 
-This document records the #3044-0 storage and configuration boundary that later
-single-group Raft slices may depend on. It does not choose a Raft library, start
-a consensus loop, admit writes, enable `ack_policy=raft_committed`, install
-snapshots, truncate logs, or route multiple groups.
+This document records the single-group Raft storage/configuration boundary and
+the first submit/apply bridge that later #3044 slices may depend on. It does
+not choose a Raft library, start a consensus loop, install snapshots, truncate
+logs, implement recovery-status reporting, or route multiple groups.
 
 ## Scope
 
@@ -16,7 +16,10 @@ The initial boundary owns:
 - a peer membership set that must include the local node;
 - a fail-closed config format and required-feature floor;
 - deterministic local storage paths for Raft log, stable metadata, apply
-  metadata, snapshots, and peer metadata.
+  metadata, snapshots, and peer metadata;
+- a single-group write-admission boundary;
+- a commit-source boundary for deterministic `CommandEntryV1` bytes;
+- a committed-entry applier boundary for applying locally through R3a/raftfsm.
 
 ## Feature And Version Floor
 
@@ -77,11 +80,43 @@ TreeDB's local command WAL.
 ## Local Command WAL Boundary
 
 The TreeDB command WAL is local physical crash-recovery state and is not a Raft
-log. A future Raft provider may commit deterministic command entries by quorum,
-but applying those entries to a local TreeDB still has to satisfy the local
+log. A Raft provider may commit deterministic command entries by quorum, but
+applying those entries to a local TreeDB still has to satisfy the local
 command-WAL recoverability rule before that node can report local durability,
 advance durable applied-index/idempotency metadata, or return
 `ack_policy=raft_committed` success.
+
+## Submit/Apply Bridge
+
+`SingleGroupSubmitter` is the first production-facing submit/apply bridge. It
+is intentionally one group only:
+
+- admission is checked through `AdmissionProvider` and fails closed for
+  follower or unavailable states;
+- submitted deterministic native-wire `CommandEntryV1` bytes are decoded before
+  commit so unsupported or malformed R3a commands fail before local mutation;
+- the commit source must return a committed entry with a non-zero term/index
+  and explicit `CommitEvidenceProductionConsensusV1` evidence;
+- deterministic harness evidence is a separate evidence kind and never proves
+  production quorum commitment;
+- the committed entry is applied through a `CommittedCommandApplierV1`, currently
+  provided by the raftfsm adapter;
+- `AckRaftCommitted` is returned only after production-consensus evidence plus
+  local recoverability are both true;
+- lower ack requests may pass through the same bridge but must not be upgraded
+  to `raft_committed` in the adapter response.
+
+The bridge is a provider boundary, not a complete consensus integration. The
+`SequencedCommitSource` helper supplies deterministic in-process term/index
+assignment and is useful for adapter tests and smoke wiring. It only proves
+`AckRaftCommitted` when the caller explicitly sets production-consensus
+evidence; a production Raft adapter is responsible for setting that evidence
+only after quorum commit.
+
+Nativewire and Mongo gateway cluster submitter adapters use this bridge for the
+single-group create/insert slice. Response metadata carries the post-apply
+catalog version so follow-on guarded commands do not build entries from a stale
+catalog guard.
 
 ## Read-Index Boundary
 
@@ -114,10 +149,10 @@ unreachable.
 
 ## Non-Goals
 
-- no real consensus loop;
-- no server write admission or redirects;
-- no `ack_policy=raft_committed` behavior;
+- no full consensus loop or selected Raft library in this package;
+- no leader transfer, redirect handling, or lease reads;
 - no real read-index provider, lease-read provider, or follower read routing;
 - no snapshot install/export behavior beyond reserving a local path;
+- no recovery-status endpoint or rejoin protocol;
 - no Raft log truncation;
 - no multi-group routing.

--- a/TreeDB/docs/spec/raftcluster.md
+++ b/TreeDB/docs/spec/raftcluster.md
@@ -105,7 +105,9 @@ is intentionally one group only:
 - deterministic harness evidence is a separate evidence kind and never proves
   production quorum commitment;
 - the committed entry is applied through a `CommittedCommandApplierV1`, currently
-  provided by the raftfsm adapter;
+  provided by the raftfsm adapter, and local apply acknowledgements are
+  serialized by the single-group bridge so a later committed index cannot race
+  ahead of an earlier committed index;
 - `AckRaftCommitted` is returned only after production-consensus evidence plus
   local recoverability are both true;
 - every accepted submit currently requires production-consensus evidence; lower

--- a/TreeDB/docs/spec/raftcluster.md
+++ b/TreeDB/docs/spec/raftcluster.md
@@ -4,9 +4,9 @@ Status: normative for the initial `TreeDB/internal/raftcluster` package.
 
 This document records the single-group Raft storage/configuration boundary,
 recovery-status reporting boundary, and first submit/apply bridge that later
-#3044 slices may depend on. It does not choose a Raft library, start a consensus
-loop, perform production snapshot transfer, truncate logs, rejoin nodes, or route
-multiple groups.
+issue `#3044` slices may depend on. It does not choose a Raft library, start a
+consensus loop, perform production snapshot transfer, truncate logs, rejoin
+nodes, or route multiple groups.
 
 ## Scope
 

--- a/TreeDB/docs/spec/raftcluster.md
+++ b/TreeDB/docs/spec/raftcluster.md
@@ -19,6 +19,7 @@ The initial boundary owns:
 - deterministic local storage paths for Raft log, stable metadata, apply
   metadata, snapshots, and peer metadata;
 - a single-group write-admission boundary;
+- a pre-commit deterministic/catalog preflight boundary;
 - a commit-source boundary for deterministic `CommandEntryV1` bytes;
 - a committed-entry applier boundary for applying locally through R3a/raftfsm.
 
@@ -96,6 +97,9 @@ is intentionally one group only:
   follower or unavailable states;
 - submitted deterministic native-wire `CommandEntryV1` bytes are decoded before
   commit so unsupported or malformed R3a commands fail before local mutation;
+- decoded entries are preflighted against the local deterministic apply/catalog
+  boundary before the commit source assigns a Raft log identity, so conflicts
+  such as missing collections reject without consuming an index;
 - the commit source must return a committed entry with a non-zero term/index
   and explicit `CommitEvidenceProductionConsensusV1` evidence;
 - deterministic harness evidence is a separate evidence kind and never proves

--- a/TreeDB/docs/spec/raftcluster.md
+++ b/TreeDB/docs/spec/raftcluster.md
@@ -103,8 +103,9 @@ is intentionally one group only:
   provided by the raftfsm adapter;
 - `AckRaftCommitted` is returned only after production-consensus evidence plus
   local recoverability are both true;
-- lower ack requests may pass through the same bridge but must not be upgraded
-  to `raft_committed` in the adapter response.
+- every accepted submit currently requires production-consensus evidence; lower
+  ack policies only control the response durability level after that commit and
+  must not be upgraded to `raft_committed` in the adapter response.
 
 The bridge is a provider boundary, not a complete consensus integration. The
 `SequencedCommitSource` helper supplies deterministic in-process term/index

--- a/TreeDB/docs/spec/storage-format.md
+++ b/TreeDB/docs/spec/storage-format.md
@@ -212,6 +212,7 @@ bytes[32] ResultCommandDigest
 u64       DeterministicErrorCodeLen
 bytes     DeterministicErrorCode
 i64       AffectedCount
+i64       MatchedCount
 bytes[32] ResultDigest   // LogicalDigestV1 bytes when apply succeeded
 ```
 

--- a/TreeDB/docs/spec/storage-format.md
+++ b/TreeDB/docs/spec/storage-format.md
@@ -216,6 +216,10 @@ i64       MatchedCount
 bytes[32] ResultDigest   // LogicalDigestV1 bytes when apply succeeded
 ```
 
+New v1 writers include `MatchedCount`. V1 decoders MUST also accept legacy
+records where `ResultDigest` follows `AffectedCount` directly; those records
+decode with `MatchedCount=0`.
+
 Open-time recovery scans complete frames and rebuilds in-memory lookup indexes.
 Frame truncation, checksum mismatch, unsupported file or frame versions, kind
 mismatches, malformed payloads, same-`ApplyEntryID` different-digest conflicts,

--- a/TreeDB/internal/nativewire/schema.go
+++ b/TreeDB/internal/nativewire/schema.go
@@ -371,6 +371,7 @@ func v1CommandSchemas() []CommandSchema {
 			Version:              1,
 			Name:                 "create_collection",
 			Kind:                 CommandKindMutation,
+			AllowedCommandFlags:  CommandFlagOmitResponseMeta,
 			Replicated:           true,
 			RequiresIdempotency:  true,
 			RequiresCatalogGuard: true,

--- a/TreeDB/internal/nativewire/schema_test.go
+++ b/TreeDB/internal/nativewire/schema_test.go
@@ -76,6 +76,21 @@ func TestRegistryValidatesRequestSections(t *testing.T) {
 	}
 }
 
+func TestCreateCollectionAllowsOmitResponseMetaFlag(t *testing.T) {
+	registry := MustV1Registry()
+	sections := createCollectionSections()
+	sections[0].Bytes = AppendCommandHeader(nil, CommandHeader{ID: CommandCreateCollection, Version: 1, Flags: CommandFlagOmitResponseMeta})
+	if _, err := registry.ValidateRequestSections(sections); err != nil {
+		t.Fatalf("create_collection omit response_meta: %v", err)
+	}
+
+	sections = createCollectionSections()
+	sections[0].Bytes = AppendCommandHeader(nil, CommandHeader{ID: CommandCreateCollection, Version: 1, Flags: CommandFlagOmitResultIDs})
+	if _, err := registry.ValidateRequestSections(sections); codeOf(err) != ErrUnsupportedFeature {
+		t.Fatalf("create_collection omit result IDs err=%v code=%d", err, codeOf(err))
+	}
+}
+
 func TestNilRegistryRejectsValidation(t *testing.T) {
 	var registry *Registry
 	_, err := registry.ValidateRequestSections(insertBatchSections())
@@ -263,6 +278,15 @@ func insertBatchSections() []Section {
 		{ID: SectionDocumentFormat, Bytes: []byte{byte(DocumentFormatBSON)}},
 		{ID: SectionDocumentIDs, Bytes: []byte("doc-id-vector")},
 		{ID: SectionDocuments, Bytes: []byte("document-vector")},
+		{ID: SectionExpectedCatalogVersion, Bytes: []byte{7}},
+	}
+}
+
+func createCollectionSections() []Section {
+	return []Section{
+		{ID: SectionCommandHeader, Bytes: AppendCommandHeader(nil, CommandHeader{ID: CommandCreateCollection, Version: 1})},
+		{ID: SectionIdempotencyKey, Bytes: []byte("id1")},
+		{ID: SectionCollectionMeta, Bytes: []byte("meta")},
 		{ID: SectionExpectedCatalogVersion, Bytes: []byte{7}},
 	}
 }

--- a/TreeDB/internal/raftapply/apply.go
+++ b/TreeDB/internal/raftapply/apply.go
@@ -219,6 +219,7 @@ func (h *Harness) ApplyCommittedEntryV1(entryBytes []byte, meta ApplyMetadataV1)
 			duplicate := record.Result
 			duplicate.Status = raftentry.ApplyStatusAlreadyApplied
 			duplicate.AffectedCount = 0
+			duplicate.MatchedCount = 0
 			if err := h.opts.ResultStore.RecordApplyResult(ApplyResultRecordV1{
 				EntryID:           meta.EntryID,
 				CommandDigest:     entry.Digest,

--- a/TreeDB/internal/raftapply/apply.go
+++ b/TreeDB/internal/raftapply/apply.go
@@ -138,25 +138,29 @@ func ApplyCommittedEntryV1(db *backenddb.DB, entryBytes []byte, meta ApplyMetada
 
 // PreflightCommandEntryV1 validates deterministic/catalog apply acceptability
 // without assigning, recording, or advancing an apply entry ID.
-func PreflightCommandEntryV1(db *backenddb.DB, entryBytes []byte, meta ApplyMetadataV1, opts Options) error {
+func PreflightCommandEntryV1(db *backenddb.DB, entryBytes []byte, meta ApplyMetadataV1, opts Options) (PreflightResultV1, error) {
 	return NewHarness(db, opts).PreflightCommandEntryV1(entryBytes, meta)
 }
 
 // PreflightDecodedCommandEntryV1 validates an entry that the submitter already
 // decoded with the same deterministic limits used for this apply boundary.
-func PreflightDecodedCommandEntryV1(db *backenddb.DB, entry raftentry.CommandEntryV1, meta ApplyMetadataV1, opts Options) error {
+func PreflightDecodedCommandEntryV1(db *backenddb.DB, entry raftentry.CommandEntryV1, meta ApplyMetadataV1, opts Options) (PreflightResultV1, error) {
 	return NewHarness(db, opts).PreflightDecodedCommandEntryV1(entry, meta)
+}
+
+type PreflightResultV1 struct {
+	KnownIdempotencyReplay bool
 }
 
 // PreflightCommandEntryV1 decodes and checks the local deterministic boundary
 // a command would need to pass before visible apply. It does not append local
 // command-WAL frames, record idempotency/results, or advance apply progress.
-func (h *Harness) PreflightCommandEntryV1(entryBytes []byte, meta ApplyMetadataV1) error {
+func (h *Harness) PreflightCommandEntryV1(entryBytes []byte, meta ApplyMetadataV1) (PreflightResultV1, error) {
 	if h == nil {
-		return codedError(raftentry.ErrorUnsafeDurabilityModeV1, "raftapply: nil harness")
+		return PreflightResultV1{}, codedError(raftentry.ErrorUnsafeDurabilityModeV1, "raftapply: nil harness")
 	}
 	if err := h.preflightLocalBoundary(meta); err != nil {
-		return err
+		return PreflightResultV1{}, err
 	}
 	entry, err := raftentry.DecodeCommandEntryV1(entryBytes, raftentry.DecodeOptions{
 		Limits:          h.opts.DecodeLimits,
@@ -167,60 +171,65 @@ func (h *Harness) PreflightCommandEntryV1(entryBytes []byte, meta ApplyMetadataV
 		ExpectedTarget:  meta.ExpectedTarget,
 	})
 	if err != nil {
-		return err
+		return PreflightResultV1{}, err
 	}
 	return h.preflightDecodedCommandEntryV1(entry, meta)
 }
 
 // PreflightDecodedCommandEntryV1 checks a caller-provided decoded entry against
 // the local deterministic boundary without re-decoding entry bytes.
-func (h *Harness) PreflightDecodedCommandEntryV1(entry raftentry.CommandEntryV1, meta ApplyMetadataV1) error {
+func (h *Harness) PreflightDecodedCommandEntryV1(entry raftentry.CommandEntryV1, meta ApplyMetadataV1) (PreflightResultV1, error) {
 	if h == nil {
-		return codedError(raftentry.ErrorUnsafeDurabilityModeV1, "raftapply: nil harness")
+		return PreflightResultV1{}, codedError(raftentry.ErrorUnsafeDurabilityModeV1, "raftapply: nil harness")
 	}
 	if err := h.preflightLocalBoundary(meta); err != nil {
-		return err
+		return PreflightResultV1{}, err
 	}
 	return h.preflightDecodedCommandEntryV1(entry, meta)
 }
 
-func (h *Harness) preflightDecodedCommandEntryV1(entry raftentry.CommandEntryV1, meta ApplyMetadataV1) error {
+func (h *Harness) preflightDecodedCommandEntryV1(entry raftentry.CommandEntryV1, meta ApplyMetadataV1) (PreflightResultV1, error) {
 	if ok, err := h.preflightKnownIdempotencyReplayV1(entry); err != nil || ok {
-		return err
+		return PreflightResultV1{KnownIdempotencyReplay: ok}, err
 	}
 	switch entry.Target.CommandID {
 	case nativewire.CommandCreateCollection:
 		expectedCatalogVersion, err := decodeExpectedCatalogVersionV1(entry.Target.ExpectedCatalogVersion)
 		if err != nil {
-			return err
+			return PreflightResultV1{}, err
 		}
 		collectionMeta, payload, err := lowerCreateCollectionV1(entry)
 		if err != nil {
-			return err
+			return PreflightResultV1{}, err
 		}
 		alreadyExisting, err := h.preflightCreateCollectionV1(collectionMeta, payload)
 		if err != nil {
-			return err
+			return PreflightResultV1{}, err
 		}
 		if !alreadyExisting {
-			return checkCatalogVersionGuardV1(meta, expectedCatalogVersion)
+			if err := checkCatalogVersionGuardV1(meta, expectedCatalogVersion); err != nil {
+				return PreflightResultV1{}, err
+			}
 		}
-		return nil
+		return PreflightResultV1{}, nil
 	case nativewire.CommandInsertBatch, nativewire.CommandReplaceBatch, nativewire.CommandDeleteBatch, nativewire.CommandUpdateBSONSet:
 		expectedCatalogVersion, err := decodeExpectedCatalogVersionV1(entry.Target.ExpectedCatalogVersion)
 		if err != nil {
-			return err
+			return PreflightResultV1{}, err
 		}
 		if err := checkCatalogVersionGuardV1(meta, expectedCatalogVersion); err != nil {
-			return err
+			return PreflightResultV1{}, err
 		}
 		mutation, err := lowerCollectionMutationV1(entry, h.opts.DecodeLimits)
 		if err != nil {
-			return err
+			return PreflightResultV1{}, err
 		}
-		return h.preflightCollectionMutationOnlyV1(&mutation)
+		if err := h.preflightCollectionMutationOnlyV1(&mutation); err != nil {
+			return PreflightResultV1{}, err
+		}
+		return PreflightResultV1{}, nil
 	default:
-		return codedError(raftentry.ErrorUnsupportedCommandV1, "raftapply: %s is not accepted by R3a apply", entry.Row.NativeWireCommand)
+		return PreflightResultV1{}, codedError(raftentry.ErrorUnsupportedCommandV1, "raftapply: %s is not accepted by R3a apply", entry.Row.NativeWireCommand)
 	}
 }
 

--- a/TreeDB/internal/raftapply/apply.go
+++ b/TreeDB/internal/raftapply/apply.go
@@ -136,6 +136,91 @@ func ApplyCommittedEntryV1(db *backenddb.DB, entryBytes []byte, meta ApplyMetada
 	return NewHarness(db, opts).ApplyCommittedEntryV1(entryBytes, meta)
 }
 
+// PreflightCommandEntryV1 validates deterministic/catalog apply acceptability
+// without assigning, recording, or advancing an apply entry ID.
+func PreflightCommandEntryV1(db *backenddb.DB, entryBytes []byte, meta ApplyMetadataV1, opts Options) error {
+	return NewHarness(db, opts).PreflightCommandEntryV1(entryBytes, meta)
+}
+
+// PreflightDecodedCommandEntryV1 validates an entry that the submitter already
+// decoded with the same deterministic limits used for this apply boundary.
+func PreflightDecodedCommandEntryV1(db *backenddb.DB, entry raftentry.CommandEntryV1, meta ApplyMetadataV1, opts Options) error {
+	return NewHarness(db, opts).PreflightDecodedCommandEntryV1(entry, meta)
+}
+
+// PreflightCommandEntryV1 decodes and checks the local deterministic boundary
+// a command would need to pass before visible apply. It does not append local
+// command-WAL frames, record idempotency/results, or advance apply progress.
+func (h *Harness) PreflightCommandEntryV1(entryBytes []byte, meta ApplyMetadataV1) error {
+	if h == nil {
+		return codedError(raftentry.ErrorUnsafeDurabilityModeV1, "raftapply: nil harness")
+	}
+	if err := h.preflightLocalBoundary(meta); err != nil {
+		return err
+	}
+	entry, err := raftentry.DecodeCommandEntryV1(entryBytes, raftentry.DecodeOptions{
+		Limits:          h.opts.DecodeLimits,
+		ScopeRule:       meta.ScopeRule,
+		DatabaseScope:   meta.DatabaseScope,
+		CatalogScope:    meta.CatalogScope,
+		RequestMetadata: meta.RequestMetadata,
+		ExpectedTarget:  meta.ExpectedTarget,
+	})
+	if err != nil {
+		return err
+	}
+	return h.preflightDecodedCommandEntryV1(entry, meta)
+}
+
+// PreflightDecodedCommandEntryV1 checks a caller-provided decoded entry against
+// the local deterministic boundary without re-decoding entry bytes.
+func (h *Harness) PreflightDecodedCommandEntryV1(entry raftentry.CommandEntryV1, meta ApplyMetadataV1) error {
+	if h == nil {
+		return codedError(raftentry.ErrorUnsafeDurabilityModeV1, "raftapply: nil harness")
+	}
+	if err := h.preflightLocalBoundary(meta); err != nil {
+		return err
+	}
+	return h.preflightDecodedCommandEntryV1(entry, meta)
+}
+
+func (h *Harness) preflightDecodedCommandEntryV1(entry raftentry.CommandEntryV1, meta ApplyMetadataV1) error {
+	switch entry.Target.CommandID {
+	case nativewire.CommandCreateCollection:
+		expectedCatalogVersion, err := decodeExpectedCatalogVersionV1(entry.Target.ExpectedCatalogVersion)
+		if err != nil {
+			return err
+		}
+		collectionMeta, payload, err := lowerCreateCollectionV1(entry)
+		if err != nil {
+			return err
+		}
+		alreadyExisting, err := h.preflightCreateCollectionV1(collectionMeta, payload)
+		if err != nil {
+			return err
+		}
+		if !alreadyExisting {
+			return checkCatalogVersionGuardV1(meta, expectedCatalogVersion)
+		}
+		return nil
+	case nativewire.CommandInsertBatch, nativewire.CommandReplaceBatch, nativewire.CommandDeleteBatch, nativewire.CommandUpdateBSONSet:
+		expectedCatalogVersion, err := decodeExpectedCatalogVersionV1(entry.Target.ExpectedCatalogVersion)
+		if err != nil {
+			return err
+		}
+		if err := checkCatalogVersionGuardV1(meta, expectedCatalogVersion); err != nil {
+			return err
+		}
+		mutation, err := lowerCollectionMutationV1(entry, h.opts.DecodeLimits)
+		if err != nil {
+			return err
+		}
+		return h.preflightCollectionMutationOnlyV1(&mutation)
+	default:
+		return codedError(raftentry.ErrorUnsupportedCommandV1, "raftapply: %s is not accepted by R3a apply", entry.Row.NativeWireCommand)
+	}
+}
+
 // ApplyCommittedEntryV1 decodes, validates, classifies, and applies the first
 // R3a command slice through local command WAL and normal catalog executors.
 func (h *Harness) ApplyCommittedEntryV1(entryBytes []byte, meta ApplyMetadataV1) (raftentry.ApplyResultV1, error) {

--- a/TreeDB/internal/raftapply/apply.go
+++ b/TreeDB/internal/raftapply/apply.go
@@ -185,6 +185,9 @@ func (h *Harness) PreflightDecodedCommandEntryV1(entry raftentry.CommandEntryV1,
 }
 
 func (h *Harness) preflightDecodedCommandEntryV1(entry raftentry.CommandEntryV1, meta ApplyMetadataV1) error {
+	if ok, err := h.preflightKnownIdempotencyReplayV1(entry); err != nil || ok {
+		return err
+	}
 	switch entry.Target.CommandID {
 	case nativewire.CommandCreateCollection:
 		expectedCatalogVersion, err := decodeExpectedCatalogVersionV1(entry.Target.ExpectedCatalogVersion)
@@ -219,6 +222,26 @@ func (h *Harness) preflightDecodedCommandEntryV1(entry raftentry.CommandEntryV1,
 	default:
 		return codedError(raftentry.ErrorUnsupportedCommandV1, "raftapply: %s is not accepted by R3a apply", entry.Row.NativeWireCommand)
 	}
+}
+
+func (h *Harness) preflightKnownIdempotencyReplayV1(entry raftentry.CommandEntryV1) (bool, error) {
+	if h == nil || h.opts.ResultStore == nil || len(entry.IdempotencyKey) == 0 {
+		return false, nil
+	}
+	record, ok, err := h.opts.ResultStore.LookupApplyResultByIdempotencyKey(entry.IdempotencyKey)
+	if err != nil {
+		return false, err
+	}
+	if !ok {
+		return false, nil
+	}
+	if record.CommandDigest != entry.Digest {
+		return false, codedError(raftentry.ErrorRejectedConflictV1, "raftapply: preflight idempotency key conflicts with existing result")
+	}
+	if err := h.requireApplyRecordCoverage(record.AppliedCommandLSN); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 // ApplyCommittedEntryV1 decodes, validates, classifies, and applies the first

--- a/TreeDB/internal/raftapply/apply_test.go
+++ b/TreeDB/internal/raftapply/apply_test.go
@@ -638,6 +638,9 @@ func TestCollectionMutationApplyInsertReplaceDeleteFramesAndDigest(t *testing.T)
 	assertApplied(t, insertResult, raftentry.ApplyStatusApplied, 2)
 	replaceResult := apply(3, replace)
 	assertApplied(t, replaceResult, raftentry.ApplyStatusApplied, 1)
+	if replaceResult.MatchedCount != 1 {
+		t.Fatalf("replace matched=%d want 1", replaceResult.MatchedCount)
+	}
 	deleteResult := apply(4, deleteEntry)
 	assertApplied(t, deleteResult, raftentry.ApplyStatusApplied, 1)
 	if insertResult.ResultDigest == replaceResult.ResultDigest || replaceResult.ResultDigest == deleteResult.ResultDigest {
@@ -1090,6 +1093,9 @@ func TestUpdateBSONSetApplyReplayNoopAffectedCountAndLogicalDigest(t *testing.T)
 	})
 	applied, err := ApplyCommittedEntryV1(db, update, applyMeta(1, 3), Options{ResultStore: results})
 	assertApplied(t, applied, raftentry.ApplyStatusApplied, 1)
+	if applied.MatchedCount != 1 {
+		t.Fatalf("update matched=%d want 1", applied.MatchedCount)
+	}
 	frames := readCommandWALFrames(t, dir)
 	if len(frames) != 3 {
 		t.Fatalf("command WAL frames after update=%d, want 3", len(frames))
@@ -1116,6 +1122,9 @@ func TestUpdateBSONSetApplyReplayNoopAffectedCountAndLogicalDigest(t *testing.T)
 	}
 	duplicate, err := ApplyCommittedEntryV1(db, update, applyMeta(1, 4), Options{ResultStore: results})
 	assertApplied(t, duplicate, raftentry.ApplyStatusAlreadyApplied, 0)
+	if duplicate.MatchedCount != 0 {
+		t.Fatalf("duplicate matched=%d want 0", duplicate.MatchedCount)
+	}
 	if duplicate.ResultDigest != applied.ResultDigest {
 		t.Fatalf("duplicate digest=%s, want %s", duplicate.ResultDigest.Hex(), applied.ResultDigest.Hex())
 	}
@@ -1128,6 +1137,9 @@ func TestUpdateBSONSetApplyReplayNoopAffectedCountAndLogicalDigest(t *testing.T)
 	})
 	noOpResult, err := ApplyCommittedEntryV1(db, noOp, applyMeta(1, 5), Options{ResultStore: results})
 	assertApplied(t, noOpResult, raftentry.ApplyStatusApplied, 0)
+	if noOpResult.MatchedCount != 1 {
+		t.Fatalf("no-op update matched=%d want 1", noOpResult.MatchedCount)
+	}
 	frames = readCommandWALFrames(t, dir)
 	if len(frames) != 4 {
 		t.Fatalf("command WAL frames after no-op update=%d, want 4", len(frames))
@@ -1139,6 +1151,9 @@ func TestUpdateBSONSetApplyReplayNoopAffectedCountAndLogicalDigest(t *testing.T)
 	})
 	missingResult, err := ApplyCommittedEntryV1(db, missing, applyMeta(1, 6), Options{ResultStore: results})
 	assertApplied(t, missingResult, raftentry.ApplyStatusApplied, 0)
+	if missingResult.MatchedCount != 0 {
+		t.Fatalf("missing update matched=%d want 0", missingResult.MatchedCount)
+	}
 	frames = readCommandWALFrames(t, dir)
 	if len(frames) != 5 {
 		t.Fatalf("command WAL frames after missing update=%d, want 5", len(frames))

--- a/TreeDB/internal/raftapply/apply_test.go
+++ b/TreeDB/internal/raftapply/apply_test.go
@@ -1335,6 +1335,30 @@ func TestUpdateBSONSetNoIdempotencyRejectsBeforeAppend(t *testing.T) {
 	}
 }
 
+func TestUpdateBSONSetPreflightRejectsJSONNoIndexBeforeCommit(t *testing.T) {
+	dir := t.TempDir()
+	db := openApplyHarnessDB(t, dir)
+	defer func() { _ = db.Close() }()
+
+	create := deterministicCreateCollectionEntry(t, "users", "client-a:create:users-json", testCreateCollectionMetaOptions{})
+	insert := deterministicInsertBatchEntry(t, "users", "client-a:insert:users-json", nativewire.DocumentFormatJSON,
+		[][]byte{[]byte("u1")},
+		[][]byte{[]byte(`{"name":"Ada","city":"hnl"}`)},
+	)
+	applyCreateSequence(t, db, create, insert)
+
+	update := deterministicUpdateBSONSetEntry(t, "users", "client-a:update-bson-set:json-no-index", []byte("u1"), []collections.BSONSetField{
+		{Key: "city", Value: testBSONSetRawValue(t, "sfo")},
+	})
+	err := PreflightCommandEntryV1(db, update, applyMeta(1, 3), Options{})
+	if got := codeOf(err); got != raftentry.ErrorRejectedConflictV1 {
+		t.Fatalf("PreflightCommandEntryV1 code=%s err=%v, want rejected-conflict", got, err)
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "bson") {
+		t.Fatalf("PreflightCommandEntryV1 err=%v, want BSON format rejection", err)
+	}
+}
+
 func TestLowerCollectionMutationRejectsInvalidIDs(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/TreeDB/internal/raftapply/apply_test.go
+++ b/TreeDB/internal/raftapply/apply_test.go
@@ -1350,7 +1350,7 @@ func TestUpdateBSONSetPreflightRejectsJSONNoIndexBeforeCommit(t *testing.T) {
 	update := deterministicUpdateBSONSetEntry(t, "users", "client-a:update-bson-set:json-no-index", []byte("u1"), []collections.BSONSetField{
 		{Key: "city", Value: testBSONSetRawValue(t, "sfo")},
 	})
-	err := PreflightCommandEntryV1(db, update, applyMeta(1, 3), Options{})
+	_, err := PreflightCommandEntryV1(db, update, applyMeta(1, 3), Options{})
 	if got := codeOf(err); got != raftentry.ErrorRejectedConflictV1 {
 		t.Fatalf("PreflightCommandEntryV1 code=%s err=%v, want rejected-conflict", got, err)
 	}

--- a/TreeDB/internal/raftapply/collection_mutation.go
+++ b/TreeDB/internal/raftapply/collection_mutation.go
@@ -350,12 +350,14 @@ func (h *Harness) preflightCollectionMutationWithOptionsV1(mutation *collectionM
 		if err := collection.PreflightCommandWALMutation(collections.ColumnPublishOperationUpdate); err != nil {
 			return nil, codeCollectionApplyError(err)
 		}
-		if !prepareFrameDocuments && collectionHasNoSecondaryIndexesV1(collection) {
-			return collection, nil
-		}
 		results, docs, err := collection.PrepareBSONSetUpdateBatchCommandWAL(mutation.bsonSetItems)
 		if err != nil {
 			return nil, codeCollectionApplyError(err)
+		}
+		// No-index preflight can skip retaining command-WAL frame documents,
+		// but it must still run the BSON-set prepare validation above.
+		if !prepareFrameDocuments && collectionHasNoSecondaryIndexesV1(collection) {
+			return collection, nil
 		}
 		mutation.bsonSetMatched = countMatchedUpdateBatchResultsV1(results)
 		mutation.frameDocuments = docs

--- a/TreeDB/internal/raftapply/collection_mutation.go
+++ b/TreeDB/internal/raftapply/collection_mutation.go
@@ -29,6 +29,7 @@ type collectionMutationV1 struct {
 	ids              [][]byte
 	documents        [][]byte
 	bsonSetItems     []collections.BSONSetUpdateBatchItem
+	bsonSetMatched   int
 	frameDocuments   []commitlog.CollectionDocument
 }
 
@@ -81,6 +82,7 @@ func (h *Harness) applyCollectionMutationV1(entry raftentry.CommandEntryV1, meta
 	}
 
 	var affected int64
+	var matched int64
 	switch mutation.command {
 	case nativewire.CommandInsertBatch:
 		if len(mutation.documents) == 0 {
@@ -95,16 +97,18 @@ func (h *Harness) applyCollectionMutationV1(entry raftentry.CommandEntryV1, meta
 		}
 		affected = int64(len(resultIDs))
 	case nativewire.CommandReplaceBatch:
-		_, modified, err := collection.ReplaceBatchWithCommandWALIntent(mutation.ids, mutation.documents, intent)
+		matchedCount, modified, err := collection.ReplaceBatchWithCommandWALIntent(mutation.ids, mutation.documents, intent)
 		if err != nil {
 			return h.collectionMutationApplyError(entry, handle, err)
 		}
+		matched = int64(matchedCount)
 		affected = int64(modified)
 	case nativewire.CommandUpdateBSONSet:
 		results, err := collection.UpdateBSONSetBatchWithCommandWALIntent(mutation.bsonSetItems, mutation.frameDocuments, intent)
 		if err != nil {
 			return h.collectionMutationApplyError(entry, handle, err)
 		}
+		matched = int64(mutation.bsonSetMatched)
 		affected = int64(countModifiedUpdateBatchResultsV1(results))
 	case nativewire.CommandDeleteBatch:
 		deleted, err := collection.DeleteBatchWithCommandWALIntent(mutation.ids, intent)
@@ -135,6 +139,7 @@ func (h *Harness) applyCollectionMutationV1(entry raftentry.CommandEntryV1, meta
 		CommandDigest:          entry.Digest,
 		DeterministicErrorCode: raftentry.ErrorNoneV1,
 		AffectedCount:          affected,
+		MatchedCount:           matched,
 		ResultDigest:           raftentry.CommandDigestV1(logical),
 	}, nil
 }
@@ -331,10 +336,11 @@ func (h *Harness) preflightCollectionMutationV1(mutation *collectionMutationV1) 
 		if err := collection.PreflightCommandWALMutation(collections.ColumnPublishOperationUpdate); err != nil {
 			return nil, codeCollectionApplyError(err)
 		}
-		_, docs, err := collection.PrepareBSONSetUpdateBatchCommandWAL(mutation.bsonSetItems)
+		results, docs, err := collection.PrepareBSONSetUpdateBatchCommandWAL(mutation.bsonSetItems)
 		if err != nil {
 			return nil, codeCollectionApplyError(err)
 		}
+		mutation.bsonSetMatched = countMatchedUpdateBatchResultsV1(results)
 		mutation.frameDocuments = docs
 	case nativewire.CommandDeleteBatch:
 		if err := collection.PreflightCommandWALMutation(collections.ColumnPublishOperationDelete); err != nil {
@@ -473,6 +479,16 @@ func countModifiedUpdateBatchResultsV1(results []collections.UpdateBatchResult) 
 		}
 	}
 	return modified
+}
+
+func countMatchedUpdateBatchResultsV1(results []collections.UpdateBatchResult) int {
+	matched := 0
+	for _, result := range results {
+		if result.Matched {
+			matched++
+		}
+	}
+	return matched
 }
 
 func lowerDocumentFormatV1(entry raftentry.CommandEntryV1) (collections.DocumentFormat, error) {

--- a/TreeDB/internal/raftapply/collection_mutation.go
+++ b/TreeDB/internal/raftapply/collection_mutation.go
@@ -266,6 +266,15 @@ func lowerCollectionMutationV1(entry raftentry.CommandEntryV1, limits nativewire
 }
 
 func (h *Harness) preflightCollectionMutationV1(mutation *collectionMutationV1) (*collections.Collection, error) {
+	return h.preflightCollectionMutationWithOptionsV1(mutation, true)
+}
+
+func (h *Harness) preflightCollectionMutationOnlyV1(mutation *collectionMutationV1) error {
+	_, err := h.preflightCollectionMutationWithOptionsV1(mutation, false)
+	return err
+}
+
+func (h *Harness) preflightCollectionMutationWithOptionsV1(mutation *collectionMutationV1, prepareFrameDocuments bool) (*collections.Collection, error) {
 	if h == nil || h.db == nil {
 		return nil, codedError(raftentry.ErrorUnsafeDurabilityModeV1, "raftapply: nil DB cannot preflight collection mutation")
 	}
@@ -299,7 +308,9 @@ func (h *Harness) preflightCollectionMutationV1(mutation *collectionMutationV1) 
 		if err := collection.PreflightCommandWALMutation(collections.ColumnPublishOperationInsert); err != nil {
 			return nil, codeCollectionApplyError(err)
 		}
-		mutation.frameDocuments = collectionDocumentsFromMutationV1(mutation.ids, mutation.documents)
+		if prepareFrameDocuments {
+			mutation.frameDocuments = collectionDocumentsFromMutationV1(mutation.ids, mutation.documents)
+		}
 		if err := collection.PreflightInsertBatchConflicts(mutation.ids, mutation.documents, mutation.trustedValidBSON); err != nil {
 			return nil, codeCollectionApplyError(err)
 		}
@@ -307,7 +318,10 @@ func (h *Harness) preflightCollectionMutationV1(mutation *collectionMutationV1) 
 		if err := collection.PreflightCommandWALMutation(collections.ColumnPublishOperationUpdate); err != nil {
 			return nil, codeCollectionApplyError(err)
 		}
-		changed := make([]commitlog.CollectionDocument, 0, len(mutation.ids))
+		var changed []commitlog.CollectionDocument
+		if prepareFrameDocuments {
+			changed = make([]commitlog.CollectionDocument, 0, len(mutation.ids))
+		}
 		for i, id := range mutation.ids {
 			current, err := collection.Get(id)
 			if err != nil {
@@ -321,7 +335,7 @@ func (h *Harness) preflightCollectionMutationV1(mutation *collectionMutationV1) 
 					return nil, err
 				}
 			}
-			if !bytes.Equal(current, mutation.documents[i]) {
+			if prepareFrameDocuments && !bytes.Equal(current, mutation.documents[i]) {
 				changed = append(changed, commitlog.CollectionDocument{
 					ID:       mutation.ids[i],
 					Document: mutation.documents[i],
@@ -335,6 +349,9 @@ func (h *Harness) preflightCollectionMutationV1(mutation *collectionMutationV1) 
 	case nativewire.CommandUpdateBSONSet:
 		if err := collection.PreflightCommandWALMutation(collections.ColumnPublishOperationUpdate); err != nil {
 			return nil, codeCollectionApplyError(err)
+		}
+		if !prepareFrameDocuments && collectionHasNoSecondaryIndexesV1(collection) {
+			return collection, nil
 		}
 		results, docs, err := collection.PrepareBSONSetUpdateBatchCommandWAL(mutation.bsonSetItems)
 		if err != nil {
@@ -350,6 +367,11 @@ func (h *Harness) preflightCollectionMutationV1(mutation *collectionMutationV1) 
 		return nil, codedError(raftentry.ErrorUnsupportedCommandV1, "raftapply: unsupported mutation command %d", mutation.command)
 	}
 	return collection, nil
+}
+
+func collectionHasNoSecondaryIndexesV1(collection *collections.Collection) bool {
+	meta := collection.MetaView()
+	return len(meta.Indexes) == 0 && len(meta.VectorIndexes) == 0 && len(meta.TextIndexes) == 0
 }
 
 func (m collectionMutationV1) loweredFrame() (commandwalapply.LoweredFrame, error) {

--- a/TreeDB/internal/raftapply/durable_stores.go
+++ b/TreeDB/internal/raftapply/durable_stores.go
@@ -758,9 +758,12 @@ func decodeDurableApplyResultRecordV1(payload []byte) (ApplyResultRecordV1, erro
 	if err != nil {
 		return ApplyResultRecordV1{}, err
 	}
-	matched, err := r.i64()
-	if err != nil {
-		return ApplyResultRecordV1{}, err
+	var matched int64
+	if r.remaining() != 32 {
+		matched, err = r.i64()
+		if err != nil {
+			return ApplyResultRecordV1{}, err
+		}
 	}
 	logicalDigest, err := r.digest()
 	if err != nil {
@@ -855,6 +858,10 @@ func (r *durableApplyPayloadReader) done() error {
 		return codedError(raftentry.ErrorUnsafeDurabilityModeV1, "raftapply: durable metadata payload has %d trailing bytes", len(r.buf)-r.off)
 	}
 	return nil
+}
+
+func (r *durableApplyPayloadReader) remaining() int {
+	return len(r.buf) - r.off
 }
 
 func appendApplyEntryID(dst []byte, id raftentry.ApplyEntryID) []byte {

--- a/TreeDB/internal/raftapply/durable_stores.go
+++ b/TreeDB/internal/raftapply/durable_stores.go
@@ -716,6 +716,7 @@ func encodeDurableApplyResultRecordV1(record ApplyResultRecordV1) ([]byte, error
 	dst = append(dst, record.Result.CommandDigest[:]...)
 	dst = appendBytes(dst, []byte(record.Result.DeterministicErrorCode))
 	dst = appendI64(dst, record.Result.AffectedCount)
+	dst = appendI64(dst, record.Result.MatchedCount)
 	dst = append(dst, record.Result.ResultDigest[:]...)
 	if len(dst) > raftentry.MaxResultRecordBytesV1 {
 		return nil, codedError(raftentry.ErrorResourceExhaustedV1, "raftapply: durable result record payload %d exceeds %d", len(dst), raftentry.MaxResultRecordBytesV1)
@@ -757,6 +758,10 @@ func decodeDurableApplyResultRecordV1(payload []byte) (ApplyResultRecordV1, erro
 	if err != nil {
 		return ApplyResultRecordV1{}, err
 	}
+	matched, err := r.i64()
+	if err != nil {
+		return ApplyResultRecordV1{}, err
+	}
 	logicalDigest, err := r.digest()
 	if err != nil {
 		return ApplyResultRecordV1{}, err
@@ -774,6 +779,7 @@ func decodeDurableApplyResultRecordV1(payload []byte) (ApplyResultRecordV1, erro
 			CommandDigest:          resultDigest,
 			DeterministicErrorCode: raftentry.DeterministicErrorCodeV1(code),
 			AffectedCount:          affected,
+			MatchedCount:           matched,
 			ResultDigest:           logicalDigest,
 		},
 	}, nil

--- a/TreeDB/internal/raftapply/durable_stores.go
+++ b/TreeDB/internal/raftapply/durable_stores.go
@@ -734,9 +734,12 @@ func decodeDurableApplyProgressRecordV1(payload []byte) (ApplyProgressRecordV1, 
 	if err != nil {
 		return ApplyProgressRecordV1{}, err
 	}
-	logical, err := r.logicalDigest()
-	if err != nil {
-		return ApplyProgressRecordV1{}, err
+	var logical LogicalDigestV1
+	if r.remaining() > 0 {
+		logical, err = r.logicalDigest()
+		if err != nil {
+			return ApplyProgressRecordV1{}, err
+		}
 	}
 	if err := r.done(); err != nil {
 		return ApplyProgressRecordV1{}, err

--- a/TreeDB/internal/raftapply/durable_stores_test.go
+++ b/TreeDB/internal/raftapply/durable_stores_test.go
@@ -133,6 +133,33 @@ func TestDecodeDurableApplyResultRecordV1ToleratesLegacyMissingMatchedCount(t *t
 	}
 }
 
+func TestDecodeDurableApplyProgressRecordV1ToleratesLegacyMissingLogicalDigest(t *testing.T) {
+	record := ApplyProgressRecordV1{
+		EntryID:           raftentry.ApplyEntryID{Term: 1, Index: 1},
+		CommandDigest:     testDurableDigest(1),
+		AppliedCommandLSN: 7,
+		LogicalDigestV1:   LogicalDigestV1(testDurableDigest(101)),
+	}
+	payload, err := encodeDurableApplyProgressRecordV1(record)
+	if err != nil {
+		t.Fatalf("encodeDurableApplyProgressRecordV1: %v", err)
+	}
+	if len(payload) < 32 {
+		t.Fatalf("encoded payload length=%d, want logical digest tail", len(payload))
+	}
+	legacy := append([]byte(nil), payload[:len(payload)-32]...)
+
+	decoded, err := decodeDurableApplyProgressRecordV1(legacy)
+	if err != nil {
+		t.Fatalf("decodeDurableApplyProgressRecordV1 legacy: %v", err)
+	}
+	want := record
+	want.LogicalDigestV1 = LogicalDigestV1{}
+	if decoded != want {
+		t.Fatalf("decoded legacy progress=%+v want %+v", decoded, want)
+	}
+}
+
 func TestDurableApplyResultStorePreservesProgressLogicalDigest(t *testing.T) {
 	dir := t.TempDir()
 	results, err := OpenDurableApplyResultStore(dir, DurableApplyStoreOptions{DisableSync: true})

--- a/TreeDB/internal/raftapply/durable_stores_test.go
+++ b/TreeDB/internal/raftapply/durable_stores_test.go
@@ -89,7 +89,7 @@ func TestDurableApplyStoresIdempotencyDuplicateSameDigestAndDifferentDigest(t *t
 	if err != nil {
 		t.Fatalf("ApplyCommittedEntryV1 duplicate: %v result=%+v", err, duplicate)
 	}
-	if duplicate.Status != raftentry.ApplyStatusAlreadyApplied || duplicate.CommandDigest != first.CommandDigest || duplicate.AffectedCount != 0 {
+	if duplicate.Status != raftentry.ApplyStatusAlreadyApplied || duplicate.CommandDigest != first.CommandDigest || duplicate.AffectedCount != 0 || duplicate.MatchedCount != 0 {
 		t.Fatalf("duplicate result=%+v, want already-applied replay of digest %s", duplicate, first.CommandDigest.Hex())
 	}
 	record, ok, err := results.LookupApplyResult(raftentry.ApplyEntryID{Term: 1, Index: 2})
@@ -439,6 +439,7 @@ func testDurableApplyResultRecordBytes(seed byte, index uint64, key []byte) Appl
 			Status:        raftentry.ApplyStatusApplied,
 			CommandDigest: digest,
 			AffectedCount: 1,
+			MatchedCount:  2,
 			ResultDigest:  testDurableDigest(seed + 100),
 		},
 	}

--- a/TreeDB/internal/raftapply/durable_stores_test.go
+++ b/TreeDB/internal/raftapply/durable_stores_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/snissn/gomap/TreeDB/internal/raftentry"
@@ -130,6 +131,30 @@ func TestDecodeDurableApplyResultRecordV1ToleratesLegacyMissingMatchedCount(t *t
 	want.Result.MatchedCount = 0
 	if !reflect.DeepEqual(decoded, want) {
 		t.Fatalf("decoded legacy record=%+v want %+v", decoded, want)
+	}
+}
+
+func TestDurableApplyResultStorePreflightRejectsEncodedRecordOverLimit(t *testing.T) {
+	results, err := OpenDurableApplyResultStore(t.TempDir(), DurableApplyStoreOptions{DisableSync: true})
+	if err != nil {
+		t.Fatalf("OpenDurableApplyResultStore: %v", err)
+	}
+	defer func() { _ = results.Close() }()
+
+	record := testDurableApplyResultRecord(1, 1, "durable:oversized")
+	base := applyResultRecordSizeV1(record) - len(record.Result.Status)
+	if base >= raftentry.MaxResultRecordBytesV1 {
+		t.Fatalf("base result record size=%d unexpectedly exceeds max %d", base, raftentry.MaxResultRecordBytesV1)
+	}
+	record.Result.Status = raftentry.ApplyStatusV1(strings.Repeat("s", raftentry.MaxResultRecordBytesV1-base+1))
+	if oldSize := applyResultRecordSizeV1(record) - int64SizeV1; oldSize > raftentry.MaxResultRecordBytesV1 {
+		t.Fatalf("test record would not cover missed matched_count: old estimated size=%d max=%d", oldSize, raftentry.MaxResultRecordBytesV1)
+	}
+	if err := results.CheckCanRecordApplyResult(record); codeOf(err) != raftentry.ErrorResourceExhaustedV1 {
+		t.Fatalf("CheckCanRecordApplyResult oversized error=%v code=%s, want resource exhausted", err, codeOf(err))
+	}
+	if _, ok, err := results.LookupApplyResult(record.EntryID); err != nil || ok {
+		t.Fatalf("LookupApplyResult after oversized preflight=(ok=%t, err=%v), want absent without store error", ok, err)
 	}
 }
 

--- a/TreeDB/internal/raftapply/durable_stores_test.go
+++ b/TreeDB/internal/raftapply/durable_stores_test.go
@@ -5,6 +5,7 @@ import (
 	"hash/crc32"
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 
 	"github.com/snissn/gomap/TreeDB/internal/raftentry"
@@ -107,6 +108,29 @@ func TestDurableApplyStoresIdempotencyDuplicateSameDigestAndDifferentDigest(t *t
 		ResultStore:   results,
 	})
 	assertRejected(t, rejected, err, raftentry.ApplyStatusRejectedConflict, raftentry.ErrorRejectedConflictV1)
+}
+
+func TestDecodeDurableApplyResultRecordV1ToleratesLegacyMissingMatchedCount(t *testing.T) {
+	record := testDurableApplyResultRecord(1, 1, "durable:legacy-result")
+	payload, err := encodeDurableApplyResultRecordV1(record)
+	if err != nil {
+		t.Fatalf("encodeDurableApplyResultRecordV1: %v", err)
+	}
+	if len(payload) < 40 {
+		t.Fatalf("encoded payload length=%d, want at least matched count plus digest", len(payload))
+	}
+	legacy := append([]byte(nil), payload[:len(payload)-40]...)
+	legacy = append(legacy, payload[len(payload)-32:]...)
+
+	decoded, err := decodeDurableApplyResultRecordV1(legacy)
+	if err != nil {
+		t.Fatalf("decodeDurableApplyResultRecordV1 legacy: %v", err)
+	}
+	want := record
+	want.Result.MatchedCount = 0
+	if !reflect.DeepEqual(decoded, want) {
+		t.Fatalf("decoded legacy record=%+v want %+v", decoded, want)
+	}
 }
 
 func TestDurableApplyProgressStoreRejectsGapAndLowerIndex(t *testing.T) {

--- a/TreeDB/internal/raftapply/stores.go
+++ b/TreeDB/internal/raftapply/stores.go
@@ -383,8 +383,27 @@ func validateApplyProgressRecordV1(record ApplyProgressRecordV1, requireCoverage
 }
 
 func applyResultRecordSizeV1(record ApplyResultRecordV1) int {
-	return 8 + 8 + 32 + len(record.IdempotencyKey) + 8 +
-		len(record.Result.Status) + 32 + len(record.Result.DeterministicErrorCode) + 8 + 32 + 32
+	return applyEntryIDSizeV1 +
+		len(record.CommandDigest) +
+		uint64SizeV1 +
+		encodedBytesSizeV1(record.IdempotencyKey) +
+		encodedBytesSizeV1([]byte(record.Result.Status)) +
+		len(record.Result.CommandDigest) +
+		encodedBytesSizeV1([]byte(record.Result.DeterministicErrorCode)) +
+		int64SizeV1 +
+		int64SizeV1 +
+		len(record.Result.ResultDigest) +
+		len(record.ProgressLogicalDigestV1)
+}
+
+const (
+	applyEntryIDSizeV1 = uint64SizeV1 + uint64SizeV1
+	uint64SizeV1       = 8
+	int64SizeV1        = 8
+)
+
+func encodedBytesSizeV1(value []byte) int {
+	return uint64SizeV1 + len(value)
 }
 
 func cloneApplyResultRecord(record ApplyResultRecordV1) ApplyResultRecordV1 {

--- a/TreeDB/internal/raftcluster/doc.go
+++ b/TreeDB/internal/raftcluster/doc.go
@@ -1,16 +1,18 @@
 // Package raftcluster defines the single-group Raft cluster boundary for
 // TreeDB.
 //
-// This package is intentionally only a configuration, provider, and storage
-// layout contract. It does not start a consensus loop, admit client writes,
-// enable ack_policy=raft_committed, install snapshots, truncate logs, or route
-// multiple groups.
+// This package owns the configuration/storage layout contract plus the first
+// single-group submit/apply bridge. It does not start a consensus loop, choose
+// a Raft library, install snapshots, truncate logs, or route multiple groups.
+// AckRaftCommitted is only satisfied when a commit source provides explicit
+// production-consensus evidence and the local committed-entry applier reports
+// recoverable local coverage.
 //
 // The local TreeDB command WAL remains node-local crash-recovery state. It is
-// not a Raft log. Future providers may append deterministic command entries to
-// a Raft log and then apply committed entries through R3a, but the application
-// of a committed entry still has to satisfy TreeDB's local command-WAL
-// recoverability rules before the node reports local durability.
+// not a Raft log. Commit sources may append deterministic command entries to a
+// Raft log and then apply committed entries through R3a, but the application of
+// a committed entry still has to satisfy TreeDB's local command-WAL
+// recoverability rules before the node reports raft-committed durability.
 //
 // The TreeDB value log under maindb/value_vlog is persistent value storage.
 // Raft storage must not treat value_vlog segments as temporary WAL bytes or

--- a/TreeDB/internal/raftcluster/doc.go
+++ b/TreeDB/internal/raftcluster/doc.go
@@ -11,8 +11,9 @@
 // The local TreeDB command WAL remains node-local crash-recovery state. It is
 // not a Raft log. Commit sources may append deterministic command entries to a
 // Raft log and then apply committed entries through R3a, but the application of
-// a committed entry still has to satisfy TreeDB's local command-WAL
-// recoverability rules before the node reports raft-committed durability.
+// a committed entry is serialized by this single-group bridge and still has to
+// satisfy TreeDB's local command-WAL recoverability rules before the node
+// reports raft-committed durability.
 //
 // The TreeDB value log under maindb/value_vlog is persistent value storage.
 // Raft storage must not treat value_vlog segments as temporary WAL bytes or

--- a/TreeDB/internal/raftcluster/submit.go
+++ b/TreeDB/internal/raftcluster/submit.go
@@ -259,7 +259,7 @@ type SingleGroupSubmitterOptions struct {
 
 	// DisableLocalCommandWALSync is for tests that intentionally model weaker
 	// local recovery. The default bridge syncs local command-WAL coverage before
-	// reporting CommittedRecoverable.
+	// reporting CommittedRecoverable; when disabled, AckRaftCommitted is rejected.
 	DisableLocalCommandWALSync bool
 }
 
@@ -363,7 +363,7 @@ func (s *SingleGroupSubmitter) SubmitCommandEntryV1(ctx context.Context, entry [
 	if err != nil {
 		return SubmitResultV1{}, err
 	}
-	actualAck, err := actualSubmitAck(metadata.AckPolicy)
+	actualAck, err := actualSubmitAck(metadata.AckPolicy, s.syncLocalWAL)
 	if err != nil {
 		return SubmitResultV1{}, err
 	}
@@ -442,7 +442,7 @@ func (s *SingleGroupSubmitter) SubmitCommandEntryV1(ctx context.Context, entry [
 	}
 	result := SubmitResultV1{
 		ActualAck:            actualAck,
-		CommittedRecoverable: actualAck == iwire.AckRaftCommitted,
+		CommittedRecoverable: actualAck == iwire.AckRaftCommitted && s.syncLocalWAL,
 		DecodedEntry:         decoded,
 		ApplyResult:          applyResult,
 		CommittedEntry:       committed,
@@ -547,11 +547,16 @@ func (s *SingleGroupSubmitter) validateCommitResult(request CommitCommandEntryV1
 	return committed, nil
 }
 
-func actualSubmitAck(requested iwire.AckPolicy) (iwire.AckPolicy, error) {
+func actualSubmitAck(requested iwire.AckPolicy, syncLocalWAL bool) (iwire.AckPolicy, error) {
 	switch requested {
 	case 0:
 		return iwire.AckVisible, nil
-	case iwire.AckVisible, iwire.AckRaftCommitted:
+	case iwire.AckVisible:
+		return requested, nil
+	case iwire.AckRaftCommitted:
+		if !syncLocalWAL {
+			return 0, errors.Join(ErrLocalAckUnavailable, fmt.Errorf("ack policy %d requires local command-WAL sync", requested))
+		}
 		return requested, nil
 	case iwire.AckFlushed, iwire.AckSynced:
 		return 0, errors.Join(ErrLocalAckUnavailable, fmt.Errorf("ack policy %d requires a local flush/sync barrier", requested))

--- a/TreeDB/internal/raftcluster/submit.go
+++ b/TreeDB/internal/raftcluster/submit.go
@@ -218,14 +218,18 @@ func (f CommitSourceFunc) CommitCommandEntryV1(ctx context.Context, req CommitCo
 // before the entry is admitted to the commit source. Implementations must treat
 // the request as read-only and clone any data retained after return.
 type CommandEntryPreflightV1 interface {
-	PreflightCommandEntryV1(context.Context, CommandEntryPreflightRequestV1) error
+	PreflightCommandEntryV1(context.Context, CommandEntryPreflightRequestV1) (CommandEntryPreflightResultV1, error)
 }
 
-type CommandEntryPreflightFunc func(context.Context, CommandEntryPreflightRequestV1) error
+type CommandEntryPreflightResultV1 struct {
+	KnownIdempotencyReplay bool
+}
 
-func (f CommandEntryPreflightFunc) PreflightCommandEntryV1(ctx context.Context, req CommandEntryPreflightRequestV1) error {
+type CommandEntryPreflightFunc func(context.Context, CommandEntryPreflightRequestV1) (CommandEntryPreflightResultV1, error)
+
+func (f CommandEntryPreflightFunc) PreflightCommandEntryV1(ctx context.Context, req CommandEntryPreflightRequestV1) (CommandEntryPreflightResultV1, error) {
 	if f == nil {
-		return ErrInvalidSubmitter
+		return CommandEntryPreflightResultV1{}, ErrInvalidSubmitter
 	}
 	return f(ctx, req)
 }
@@ -396,12 +400,17 @@ func (s *SingleGroupSubmitter) SubmitCommandEntryV1(ctx context.Context, entry [
 		RequestMetadata:          metadata,
 		ExpectedTarget:           &expectedTarget,
 	}
-	if err := s.preflight.PreflightCommandEntryV1(ctx, preflightRequest); err != nil {
+	preflightResult, err := s.preflight.PreflightCommandEntryV1(ctx, preflightRequest)
+	if err != nil {
 		s.submitMu.Unlock()
 		if allowStaleCreateRetry {
 			return SubmitResultV1{}, guardErr
 		}
 		return SubmitResultV1{}, err
+	}
+	if allowStaleCreateRetry && !preflightResult.KnownIdempotencyReplay {
+		s.submitMu.Unlock()
+		return SubmitResultV1{}, guardErr
 	}
 	request := CommitCommandEntryV1Request{
 		GroupID:                  s.cluster.GroupID,

--- a/TreeDB/internal/raftcluster/submit.go
+++ b/TreeDB/internal/raftcluster/submit.go
@@ -3,6 +3,7 @@ package raftcluster
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"slices"
@@ -21,6 +22,7 @@ var (
 	ErrInvalidCommittedEntry     = errors.New("raftcluster: invalid committed entry")
 	ErrUnsupportedSubmitAck      = errors.New("raftcluster: unsupported submit ack")
 	ErrMissingCatalogVersion     = errors.New("raftcluster: missing catalog version")
+	ErrCatalogVersionMismatch    = errors.New("raftcluster: catalog version mismatch")
 	ErrUnexpectedCommittedTarget = errors.New("raftcluster: committed target mismatch")
 )
 
@@ -322,6 +324,9 @@ func (s *SingleGroupSubmitter) SubmitCommandEntryV1(ctx context.Context, entry [
 	if err != nil {
 		return SubmitResultV1{}, err
 	}
+	if err := checkSubmitCatalogGuardV1(decoded, catalogVersion); err != nil {
+		return SubmitResultV1{}, err
+	}
 	expectedTarget := decoded.Target.Clone()
 	request := CommitCommandEntryV1Request{
 		GroupID:                  s.cluster.GroupID,
@@ -365,6 +370,31 @@ func (s *SingleGroupSubmitter) SubmitCommandEntryV1(ctx context.Context, entry [
 		CatalogVersion:       postCatalogVersion,
 		HasCatalogVersion:    postHasCatalogVersion,
 	}, nil
+}
+
+func checkSubmitCatalogGuardV1(entry raftentry.CommandEntryV1, catalogVersion uint64) error {
+	expected, err := decodeSubmitExpectedCatalogVersionV1(entry.Target.ExpectedCatalogVersion)
+	if err != nil {
+		return err
+	}
+	if catalogVersion != expected {
+		return errors.Join(ErrCatalogVersionMismatch, fmt.Errorf("catalog version %d does not match expected %d", catalogVersion, expected))
+	}
+	return nil
+}
+
+func decodeSubmitExpectedCatalogVersionV1(raw []byte) (uint64, error) {
+	if len(raw) == 0 {
+		return 0, errors.Join(ErrInvalidCommittedEntry, &raftentry.ValidationError{Code: raftentry.ErrorMissingGuardV1, Err: fmt.Errorf("raftcluster: missing expected catalog version")})
+	}
+	value, n := binary.Uvarint(raw)
+	if n <= 0 {
+		return 0, errors.Join(ErrInvalidCommittedEntry, &raftentry.ValidationError{Code: raftentry.ErrorMalformedEntryV1, Err: fmt.Errorf("raftcluster: malformed expected catalog version")})
+	}
+	if n != len(raw) {
+		return 0, errors.Join(ErrInvalidCommittedEntry, &raftentry.ValidationError{Code: raftentry.ErrorMalformedEntryV1, Err: fmt.Errorf("raftcluster: expected catalog version has %d trailing bytes", len(raw)-n)})
+	}
+	return value, nil
 }
 
 func (s *SingleGroupSubmitter) admit(ctx context.Context) error {

--- a/TreeDB/internal/raftcluster/submit.go
+++ b/TreeDB/internal/raftcluster/submit.go
@@ -235,6 +235,7 @@ type SingleGroupSubmitter struct {
 type SubmitResultV1 struct {
 	ActualAck            iwire.AckPolicy
 	CommittedRecoverable bool
+	DecodedEntry         raftentry.CommandEntryV1
 	ApplyResult          raftentry.ApplyResultV1
 	CommittedEntry       CommittedCommandEntryV1
 	Evidence             CommitEvidenceV1
@@ -317,6 +318,10 @@ func (s *SingleGroupSubmitter) SubmitCommandEntryV1(ctx context.Context, entry [
 	if err != nil {
 		return SubmitResultV1{}, err
 	}
+	actualAck, err := actualSubmitAck(metadata.AckPolicy)
+	if err != nil {
+		return SubmitResultV1{}, err
+	}
 	expectedTarget := decoded.Target.Clone()
 	request := CommitCommandEntryV1Request{
 		GroupID:                  s.cluster.GroupID,
@@ -347,13 +352,10 @@ func (s *SingleGroupSubmitter) SubmitCommandEntryV1(ctx context.Context, entry [
 	if err != nil {
 		return SubmitResultV1{ApplyResult: applyResult, CommittedEntry: committed, Evidence: commitResult.Evidence}, errors.Join(ErrLocalApplyNotRecoverable, err)
 	}
-	actualAck, err := actualSubmitAck(metadata.AckPolicy)
-	if err != nil {
-		return SubmitResultV1{ApplyResult: applyResult, CommittedEntry: committed, Evidence: commitResult.Evidence}, err
-	}
 	return SubmitResultV1{
 		ActualAck:            actualAck,
 		CommittedRecoverable: actualAck == iwire.AckRaftCommitted,
+		DecodedEntry:         decoded,
 		ApplyResult:          applyResult,
 		CommittedEntry:       committed,
 		Evidence:             commitResult.Evidence,

--- a/TreeDB/internal/raftcluster/submit.go
+++ b/TreeDB/internal/raftcluster/submit.go
@@ -19,6 +19,7 @@ var (
 	ErrNotLeader                 = errors.New("raftcluster: not leader")
 	ErrCommitNotProven           = errors.New("raftcluster: commit not proven")
 	ErrLocalApplyNotRecoverable  = errors.New("raftcluster: local apply not recoverable")
+	ErrLocalAckUnavailable       = errors.New("raftcluster: local ack policy unavailable")
 	ErrInvalidCommittedEntry     = errors.New("raftcluster: invalid committed entry")
 	ErrUnsupportedSubmitAck      = errors.New("raftcluster: unsupported submit ack")
 	ErrMissingCatalogVersion     = errors.New("raftcluster: missing catalog version")
@@ -463,8 +464,10 @@ func actualSubmitAck(requested iwire.AckPolicy) (iwire.AckPolicy, error) {
 	switch requested {
 	case 0:
 		return iwire.AckVisible, nil
-	case iwire.AckVisible, iwire.AckFlushed, iwire.AckSynced, iwire.AckRaftCommitted:
+	case iwire.AckVisible, iwire.AckRaftCommitted:
 		return requested, nil
+	case iwire.AckFlushed, iwire.AckSynced:
+		return 0, errors.Join(ErrLocalAckUnavailable, fmt.Errorf("ack policy %d requires a local flush/sync barrier", requested))
 	default:
 		return 0, errors.Join(ErrUnsupportedSubmitAck, fmt.Errorf("ack policy %d", requested))
 	}

--- a/TreeDB/internal/raftcluster/submit.go
+++ b/TreeDB/internal/raftcluster/submit.go
@@ -264,6 +264,8 @@ type SingleGroupSubmitterOptions struct {
 }
 
 type SingleGroupSubmitter struct {
+	submitMu sync.Mutex
+
 	cluster         ResolvedConfig
 	admission       AdmissionProvider
 	commit          CommitSource
@@ -351,13 +353,6 @@ func (s *SingleGroupSubmitter) SubmitCommandEntryV1(ctx context.Context, entry [
 	if err := s.admit(ctx); err != nil {
 		return SubmitResultV1{}, err
 	}
-	catalogVersion, hasCatalogVersion, err := s.catalogProvider.CurrentCatalogVersion(ctx)
-	if err != nil {
-		return SubmitResultV1{}, errors.Join(ErrMissingCatalogVersion, err)
-	}
-	if !hasCatalogVersion {
-		return SubmitResultV1{}, ErrMissingCatalogVersion
-	}
 	decoded, err := raftentry.DecodeCommandEntryV1(entry, raftentry.DecodeOptions{
 		Limits:          s.decodeLimits,
 		ScopeRule:       s.scopeRule,
@@ -372,10 +367,23 @@ func (s *SingleGroupSubmitter) SubmitCommandEntryV1(ctx context.Context, entry [
 	if err != nil {
 		return SubmitResultV1{}, err
 	}
-	if err := checkSubmitCatalogGuardV1(decoded, catalogVersion); err != nil {
-		return SubmitResultV1{}, err
-	}
 	expectedTarget := decoded.Target.Clone()
+
+	s.submitMu.Lock()
+	catalogVersion, hasCatalogVersion, err := s.catalogProvider.CurrentCatalogVersion(ctx)
+	if err != nil {
+		s.submitMu.Unlock()
+		return SubmitResultV1{}, errors.Join(ErrMissingCatalogVersion, err)
+	}
+	if !hasCatalogVersion {
+		s.submitMu.Unlock()
+		return SubmitResultV1{}, ErrMissingCatalogVersion
+	}
+	guardErr := checkSubmitCatalogGuardV1(decoded, catalogVersion)
+	if guardErr != nil && !canPreflightIdempotentCreateRetryV1(decoded) {
+		s.submitMu.Unlock()
+		return SubmitResultV1{}, guardErr
+	}
 	preflightRequest := CommandEntryPreflightRequestV1{
 		GroupID:                  s.cluster.GroupID,
 		NodeID:                   s.cluster.NodeID,
@@ -388,6 +396,10 @@ func (s *SingleGroupSubmitter) SubmitCommandEntryV1(ctx context.Context, entry [
 		ExpectedTarget:           &expectedTarget,
 	}
 	if err := s.preflight.PreflightCommandEntryV1(ctx, preflightRequest); err != nil {
+		s.submitMu.Unlock()
+		if guardErr != nil {
+			return SubmitResultV1{}, guardErr
+		}
 		return SubmitResultV1{}, err
 	}
 	request := CommitCommandEntryV1Request{
@@ -402,27 +414,33 @@ func (s *SingleGroupSubmitter) SubmitCommandEntryV1(ctx context.Context, entry [
 	}
 	commitResult, err := s.commit.CommitCommandEntryV1(ctx, request.Clone())
 	if err != nil {
+		s.submitMu.Unlock()
 		return SubmitResultV1{}, err
 	}
 	committed, err := s.validateCommitResult(request, commitResult)
 	if err != nil {
+		s.submitMu.Unlock()
 		return SubmitResultV1{}, err
 	}
 	applyResult, err := s.applier.ApplyCommittedCommandEntryV1(ctx, committed.Clone())
 	if err != nil {
+		s.submitMu.Unlock()
 		return SubmitResultV1{ApplyResult: applyResult, CommittedEntry: committed, Evidence: commitResult.Evidence}, errors.Join(ErrLocalApplyNotRecoverable, err)
 	}
 	if applyResult.Status != raftentry.ApplyStatusApplied && applyResult.Status != raftentry.ApplyStatusAlreadyApplied {
+		s.submitMu.Unlock()
 		return SubmitResultV1{ApplyResult: applyResult, CommittedEntry: committed, Evidence: commitResult.Evidence}, errors.Join(ErrLocalApplyNotRecoverable, fmt.Errorf("apply status %s", applyResult.Status))
 	}
 	postCatalogVersion, postHasCatalogVersion, err := s.catalogProvider.CurrentCatalogVersion(ctx)
 	if err != nil {
+		s.submitMu.Unlock()
 		return SubmitResultV1{ApplyResult: applyResult, CommittedEntry: committed, Evidence: commitResult.Evidence}, errors.Join(ErrLocalApplyNotRecoverable, err)
 	}
 	if !postHasCatalogVersion {
+		s.submitMu.Unlock()
 		return SubmitResultV1{ApplyResult: applyResult, CommittedEntry: committed, Evidence: commitResult.Evidence}, errors.Join(ErrLocalApplyNotRecoverable, ErrMissingCatalogVersion)
 	}
-	return SubmitResultV1{
+	result := SubmitResultV1{
 		ActualAck:            actualAck,
 		CommittedRecoverable: actualAck == iwire.AckRaftCommitted,
 		DecodedEntry:         decoded,
@@ -431,7 +449,15 @@ func (s *SingleGroupSubmitter) SubmitCommandEntryV1(ctx context.Context, entry [
 		Evidence:             commitResult.Evidence,
 		CatalogVersion:       postCatalogVersion,
 		HasCatalogVersion:    postHasCatalogVersion,
-	}, nil
+	}
+	s.submitMu.Unlock()
+	return result, nil
+}
+
+func canPreflightIdempotentCreateRetryV1(entry raftentry.CommandEntryV1) bool {
+	return entry.Target.CommandID == iwire.CommandCreateCollection &&
+		entry.Idempotency == raftentry.IdempotencyRequiredV1 &&
+		len(entry.IdempotencyKey) > 0
 }
 
 func checkSubmitCatalogGuardV1(entry raftentry.CommandEntryV1, catalogVersion uint64) error {

--- a/TreeDB/internal/raftcluster/submit.go
+++ b/TreeDB/internal/raftcluster/submit.go
@@ -125,6 +125,31 @@ type CommitCommandEntryV1Request struct {
 	ExpectedTarget           *raftentry.TargetIdentityV1
 }
 
+// CommandEntryPreflightRequestV1 asks the local deterministic apply provider
+// to reject commands that cannot apply against the current local catalog and
+// collection state before the commit source assigns a Raft log identity.
+type CommandEntryPreflightRequestV1 struct {
+	GroupID GroupID
+	NodeID  NodeID
+
+	EntryBytes   []byte
+	DecodedEntry raftentry.CommandEntryV1
+
+	CurrentCatalogVersion    uint64
+	HasCurrentCatalogVersion bool
+	SyncLocalCommandWAL      bool
+	RequestMetadata          raftentry.RequestMetadataV1
+	ExpectedTarget           *raftentry.TargetIdentityV1
+}
+
+func (r CommandEntryPreflightRequestV1) Clone() CommandEntryPreflightRequestV1 {
+	r.EntryBytes = bytes.Clone(r.EntryBytes)
+	r.DecodedEntry = cloneCommandEntryV1(r.DecodedEntry)
+	r.RequestMetadata = cloneRequestMetadataV1(r.RequestMetadata)
+	r.ExpectedTarget = cloneExpectedTargetV1(r.ExpectedTarget)
+	return r
+}
+
 func (r CommitCommandEntryV1Request) Clone() CommitCommandEntryV1Request {
 	r.EntryBytes = bytes.Clone(r.EntryBytes)
 	r.RequestMetadata = cloneRequestMetadataV1(r.RequestMetadata)
@@ -189,6 +214,22 @@ func (f CommitSourceFunc) CommitCommandEntryV1(ctx context.Context, req CommitCo
 	return f(ctx, req)
 }
 
+// CommandEntryPreflightV1 validates deterministic/catalog apply acceptability
+// before the entry is admitted to the commit source. Implementations must treat
+// the request as read-only and clone any data retained after return.
+type CommandEntryPreflightV1 interface {
+	PreflightCommandEntryV1(context.Context, CommandEntryPreflightRequestV1) error
+}
+
+type CommandEntryPreflightFunc func(context.Context, CommandEntryPreflightRequestV1) error
+
+func (f CommandEntryPreflightFunc) PreflightCommandEntryV1(ctx context.Context, req CommandEntryPreflightRequestV1) error {
+	if f == nil {
+		return ErrInvalidSubmitter
+	}
+	return f(ctx, req)
+}
+
 // CommittedCommandApplierV1 is implemented by the local raftfsm adapter.
 type CommittedCommandApplierV1 interface {
 	ApplyCommittedCommandEntryV1(context.Context, CommittedCommandEntryV1) (raftentry.ApplyResultV1, error)
@@ -207,6 +248,7 @@ type SingleGroupSubmitterOptions struct {
 	Cluster                Config
 	AdmissionProvider      AdmissionProvider
 	CommitSource           CommitSource
+	Preflight              CommandEntryPreflightV1
 	Applier                CommittedCommandApplierV1
 	CatalogVersionProvider CatalogVersionProvider
 
@@ -225,6 +267,7 @@ type SingleGroupSubmitter struct {
 	cluster         ResolvedConfig
 	admission       AdmissionProvider
 	commit          CommitSource
+	preflight       CommandEntryPreflightV1
 	applier         CommittedCommandApplierV1
 	catalogProvider CatalogVersionProvider
 
@@ -257,6 +300,9 @@ func NewSingleGroupSubmitter(opts SingleGroupSubmitterOptions) (*SingleGroupSubm
 	if opts.CommitSource == nil {
 		return nil, errors.Join(ErrInvalidSubmitter, fmt.Errorf("commit source is required"))
 	}
+	if opts.Preflight == nil {
+		return nil, errors.Join(ErrInvalidSubmitter, fmt.Errorf("command preflight provider is required"))
+	}
 	if opts.Applier == nil {
 		return nil, errors.Join(ErrInvalidSubmitter, fmt.Errorf("committed command applier is required"))
 	}
@@ -267,6 +313,7 @@ func NewSingleGroupSubmitter(opts SingleGroupSubmitterOptions) (*SingleGroupSubm
 		cluster:         cluster,
 		admission:       opts.AdmissionProvider,
 		commit:          opts.CommitSource,
+		preflight:       opts.Preflight,
 		applier:         opts.Applier,
 		catalogProvider: opts.CatalogVersionProvider,
 		decodeLimits:    opts.DecodeLimits,
@@ -295,7 +342,7 @@ func (s *SingleGroupSubmitter) ClusterAdmissionStatus(ctx context.Context) (Admi
 }
 
 func (s *SingleGroupSubmitter) SubmitCommandEntryV1(ctx context.Context, entry []byte, metadata raftentry.RequestMetadataV1) (SubmitResultV1, error) {
-	if s == nil || s.commit == nil || s.applier == nil || s.catalogProvider == nil {
+	if s == nil || s.commit == nil || s.preflight == nil || s.applier == nil || s.catalogProvider == nil {
 		return SubmitResultV1{}, ErrInvalidSubmitter
 	}
 	if ctx == nil {
@@ -329,6 +376,20 @@ func (s *SingleGroupSubmitter) SubmitCommandEntryV1(ctx context.Context, entry [
 		return SubmitResultV1{}, err
 	}
 	expectedTarget := decoded.Target.Clone()
+	preflightRequest := CommandEntryPreflightRequestV1{
+		GroupID:                  s.cluster.GroupID,
+		NodeID:                   s.cluster.NodeID,
+		EntryBytes:               entry,
+		DecodedEntry:             decoded,
+		CurrentCatalogVersion:    catalogVersion,
+		HasCurrentCatalogVersion: true,
+		SyncLocalCommandWAL:      s.syncLocalWAL,
+		RequestMetadata:          metadata,
+		ExpectedTarget:           &expectedTarget,
+	}
+	if err := s.preflight.PreflightCommandEntryV1(ctx, preflightRequest); err != nil {
+		return SubmitResultV1{}, err
+	}
 	request := CommitCommandEntryV1Request{
 		GroupID:                  s.cluster.GroupID,
 		NodeID:                   s.cluster.NodeID,
@@ -579,6 +640,26 @@ func (s *SequencedCommitSource) CommitCommandEntryV1(ctx context.Context, req Co
 			ProductionConsensus: productionConsensus,
 		},
 	}, nil
+}
+
+func cloneCommandEntryV1(entry raftentry.CommandEntryV1) raftentry.CommandEntryV1 {
+	entry.Bytes = bytes.Clone(entry.Bytes)
+	entry.Decoded.Sections = cloneSections(entry.Decoded.Sections)
+	entry.Target = entry.Target.Clone()
+	entry.IdempotencyKey = bytes.Clone(entry.IdempotencyKey)
+	return entry
+}
+
+func cloneSections(sections []iwire.Section) []iwire.Section {
+	if len(sections) == 0 {
+		return nil
+	}
+	out := make([]iwire.Section, len(sections))
+	for i := range sections {
+		out[i] = sections[i]
+		out[i].Bytes = bytes.Clone(sections[i].Bytes)
+	}
+	return out
 }
 
 func cloneRequestMetadataV1(meta raftentry.RequestMetadataV1) raftentry.RequestMetadataV1 {

--- a/TreeDB/internal/raftcluster/submit.go
+++ b/TreeDB/internal/raftcluster/submit.go
@@ -352,6 +352,9 @@ func (s *SingleGroupSubmitter) SubmitCommandEntryV1(ctx context.Context, entry [
 	if err != nil {
 		return SubmitResultV1{ApplyResult: applyResult, CommittedEntry: committed, Evidence: commitResult.Evidence}, errors.Join(ErrLocalApplyNotRecoverable, err)
 	}
+	if !postHasCatalogVersion {
+		return SubmitResultV1{ApplyResult: applyResult, CommittedEntry: committed, Evidence: commitResult.Evidence}, errors.Join(ErrLocalApplyNotRecoverable, ErrMissingCatalogVersion)
+	}
 	return SubmitResultV1{
 		ActualAck:            actualAck,
 		CommittedRecoverable: actualAck == iwire.AckRaftCommitted,

--- a/TreeDB/internal/raftcluster/submit.go
+++ b/TreeDB/internal/raftcluster/submit.go
@@ -1,0 +1,591 @@
+package raftcluster
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"sync"
+
+	iwire "github.com/snissn/gomap/TreeDB/internal/nativewire"
+	"github.com/snissn/gomap/TreeDB/internal/raftentry"
+)
+
+var (
+	ErrInvalidSubmitter          = errors.New("raftcluster: invalid submitter")
+	ErrAdmissionUnavailable      = errors.New("raftcluster: admission unavailable")
+	ErrNotLeader                 = errors.New("raftcluster: not leader")
+	ErrCommitNotProven           = errors.New("raftcluster: commit not proven")
+	ErrLocalApplyNotRecoverable  = errors.New("raftcluster: local apply not recoverable")
+	ErrInvalidCommittedEntry     = errors.New("raftcluster: invalid committed entry")
+	ErrUnsupportedSubmitAck      = errors.New("raftcluster: unsupported submit ack")
+	ErrMissingCatalogVersion     = errors.New("raftcluster: missing catalog version")
+	ErrUnexpectedCommittedTarget = errors.New("raftcluster: committed target mismatch")
+)
+
+// AdmissionProvider exposes the single-group write-admission state. Returning
+// the zero AdmissionStatus fails closed as not-leader.
+type AdmissionProvider interface {
+	ClusterAdmissionStatus(context.Context) (AdmissionStatus, error)
+}
+
+// AdmissionStatus reports whether this node may submit single-group writes.
+type AdmissionStatus struct {
+	Leader      bool
+	Unavailable bool
+	LeaderHint  NodeID
+	Reason      string
+}
+
+func LeaderAdmission() AdmissionStatus {
+	return AdmissionStatus{Leader: true}
+}
+
+func FollowerAdmission(leaderHint NodeID, reason string) AdmissionStatus {
+	return AdmissionStatus{LeaderHint: leaderHint, Reason: reason}
+}
+
+func UnavailableAdmission(reason string) AdmissionStatus {
+	return AdmissionStatus{Unavailable: true, Reason: reason}
+}
+
+// StaticAdmissionProvider is a small deterministic AdmissionProvider useful
+// for tests and single-node smoke wiring. Production providers should surface
+// live leader/follower/unavailable state from the selected consensus adapter.
+type StaticAdmissionProvider struct {
+	Status AdmissionStatus
+	Err    error
+}
+
+func (p StaticAdmissionProvider) ClusterAdmissionStatus(context.Context) (AdmissionStatus, error) {
+	if p.Err != nil {
+		return AdmissionStatus{}, p.Err
+	}
+	return p.Status, nil
+}
+
+// CatalogVersionProvider returns the local catalog version used for
+// deterministic catalog guards. ok=false fails closed before commit.
+type CatalogVersionProvider interface {
+	CurrentCatalogVersion(context.Context) (version uint64, ok bool, err error)
+}
+
+type CatalogVersionProviderFunc func(context.Context) (uint64, bool, error)
+
+func (f CatalogVersionProviderFunc) CurrentCatalogVersion(ctx context.Context) (uint64, bool, error) {
+	if f == nil {
+		return 0, false, nil
+	}
+	return f(ctx)
+}
+
+// CommittedCommandEntryV1 is a deterministic command entry after the
+// single-group commit source has assigned a Raft log identity.
+type CommittedCommandEntryV1 struct {
+	Term  uint64
+	Index uint64
+	Bytes []byte
+
+	CurrentCatalogVersion    uint64
+	HasCurrentCatalogVersion bool
+	SyncLocalCommandWAL      bool
+	RequestMetadata          raftentry.RequestMetadataV1
+	ExpectedTarget           *raftentry.TargetIdentityV1
+}
+
+func (e CommittedCommandEntryV1) EntryID() raftentry.ApplyEntryID {
+	return raftentry.ApplyEntryID{Term: e.Term, Index: e.Index}
+}
+
+func (e CommittedCommandEntryV1) Clone() CommittedCommandEntryV1 {
+	e.Bytes = bytes.Clone(e.Bytes)
+	e.RequestMetadata = cloneRequestMetadataV1(e.RequestMetadata)
+	e.ExpectedTarget = cloneExpectedTargetV1(e.ExpectedTarget)
+	return e
+}
+
+// CommitCommandEntryV1Request is the provider boundary between submit
+// admission and a concrete single-group commit source. The entry bytes are the
+// deterministic native-wire CommandEntryV1 payload already validated by the
+// submitter.
+type CommitCommandEntryV1Request struct {
+	GroupID GroupID
+	NodeID  NodeID
+
+	EntryBytes []byte
+
+	CurrentCatalogVersion    uint64
+	HasCurrentCatalogVersion bool
+	SyncLocalCommandWAL      bool
+	RequestMetadata          raftentry.RequestMetadataV1
+	ExpectedTarget           *raftentry.TargetIdentityV1
+}
+
+func (r CommitCommandEntryV1Request) Clone() CommitCommandEntryV1Request {
+	r.EntryBytes = bytes.Clone(r.EntryBytes)
+	r.RequestMetadata = cloneRequestMetadataV1(r.RequestMetadata)
+	r.ExpectedTarget = cloneExpectedTargetV1(r.ExpectedTarget)
+	return r
+}
+
+type CommitEvidenceKindV1 string
+
+const (
+	// CommitEvidenceProductionConsensusV1 is the only evidence kind that may
+	// satisfy AckRaftCommitted. The selected consensus adapter is responsible
+	// for setting ProductionConsensus=true only after quorum commitment.
+	CommitEvidenceProductionConsensusV1 CommitEvidenceKindV1 = "production-consensus-v1"
+
+	// CommitEvidenceDeterministicHarnessV1 records deterministic local/test
+	// commit ordering. It never proves production quorum commitment.
+	CommitEvidenceDeterministicHarnessV1 CommitEvidenceKindV1 = "deterministic-harness-v1"
+)
+
+type CommitEvidenceV1 struct {
+	Kind                CommitEvidenceKindV1
+	GroupID             GroupID
+	NodeID              NodeID
+	LeaderID            NodeID
+	Term                uint64
+	Index               uint64
+	Committed           bool
+	ProductionConsensus bool
+}
+
+func (e CommitEvidenceV1) EntryID() raftentry.ApplyEntryID {
+	return raftentry.ApplyEntryID{Term: e.Term, Index: e.Index}
+}
+
+func (e CommitEvidenceV1) ProvesProductionConsensus() bool {
+	return e.Kind == CommitEvidenceProductionConsensusV1 &&
+		e.Committed &&
+		e.ProductionConsensus &&
+		e.Term != 0 &&
+		e.Index != 0
+}
+
+type CommitCommandEntryV1Result struct {
+	Entry    CommittedCommandEntryV1
+	Evidence CommitEvidenceV1
+}
+
+// CommitSource commits deterministic command entries and returns the committed
+// log identity plus evidence. A test/harness source may implement this
+// interface, but only production-consensus evidence can satisfy raft_committed.
+type CommitSource interface {
+	CommitCommandEntryV1(context.Context, CommitCommandEntryV1Request) (CommitCommandEntryV1Result, error)
+}
+
+type CommitSourceFunc func(context.Context, CommitCommandEntryV1Request) (CommitCommandEntryV1Result, error)
+
+func (f CommitSourceFunc) CommitCommandEntryV1(ctx context.Context, req CommitCommandEntryV1Request) (CommitCommandEntryV1Result, error) {
+	if f == nil {
+		return CommitCommandEntryV1Result{}, ErrInvalidSubmitter
+	}
+	return f(ctx, req)
+}
+
+// CommittedCommandApplierV1 is implemented by the local raftfsm adapter.
+type CommittedCommandApplierV1 interface {
+	ApplyCommittedCommandEntryV1(context.Context, CommittedCommandEntryV1) (raftentry.ApplyResultV1, error)
+}
+
+type CommittedCommandApplierFunc func(context.Context, CommittedCommandEntryV1) (raftentry.ApplyResultV1, error)
+
+func (f CommittedCommandApplierFunc) ApplyCommittedCommandEntryV1(ctx context.Context, entry CommittedCommandEntryV1) (raftentry.ApplyResultV1, error) {
+	if f == nil {
+		return raftentry.ApplyResultV1{}, ErrInvalidSubmitter
+	}
+	return f(ctx, entry)
+}
+
+type SingleGroupSubmitterOptions struct {
+	Cluster                Config
+	AdmissionProvider      AdmissionProvider
+	CommitSource           CommitSource
+	Applier                CommittedCommandApplierV1
+	CatalogVersionProvider CatalogVersionProvider
+
+	DecodeLimits  iwire.Limits
+	ScopeRule     raftentry.ScopeRuleV1
+	DatabaseScope string
+	CatalogScope  string
+
+	// DisableLocalCommandWALSync is for tests that intentionally model weaker
+	// local recovery. The default bridge syncs local command-WAL coverage before
+	// reporting CommittedRecoverable.
+	DisableLocalCommandWALSync bool
+}
+
+type SingleGroupSubmitter struct {
+	cluster         ResolvedConfig
+	admission       AdmissionProvider
+	commit          CommitSource
+	applier         CommittedCommandApplierV1
+	catalogProvider CatalogVersionProvider
+
+	decodeLimits iwire.Limits
+	scopeRule    raftentry.ScopeRuleV1
+	database     string
+	catalog      string
+	syncLocalWAL bool
+}
+
+type SubmitResultV1 struct {
+	ActualAck            iwire.AckPolicy
+	CommittedRecoverable bool
+	ApplyResult          raftentry.ApplyResultV1
+	CommittedEntry       CommittedCommandEntryV1
+	Evidence             CommitEvidenceV1
+	CatalogVersion       uint64
+	HasCatalogVersion    bool
+}
+
+func NewSingleGroupSubmitter(opts SingleGroupSubmitterOptions) (*SingleGroupSubmitter, error) {
+	cluster, err := Validate(opts.Cluster)
+	if err != nil {
+		return nil, errors.Join(ErrInvalidSubmitter, err)
+	}
+	if opts.AdmissionProvider == nil {
+		return nil, errors.Join(ErrInvalidSubmitter, fmt.Errorf("admission provider is required"))
+	}
+	if opts.CommitSource == nil {
+		return nil, errors.Join(ErrInvalidSubmitter, fmt.Errorf("commit source is required"))
+	}
+	if opts.Applier == nil {
+		return nil, errors.Join(ErrInvalidSubmitter, fmt.Errorf("committed command applier is required"))
+	}
+	if opts.CatalogVersionProvider == nil {
+		return nil, errors.Join(ErrInvalidSubmitter, fmt.Errorf("catalog version provider is required"))
+	}
+	return &SingleGroupSubmitter{
+		cluster:         cluster,
+		admission:       opts.AdmissionProvider,
+		commit:          opts.CommitSource,
+		applier:         opts.Applier,
+		catalogProvider: opts.CatalogVersionProvider,
+		decodeLimits:    opts.DecodeLimits,
+		scopeRule:       opts.ScopeRule,
+		database:        opts.DatabaseScope,
+		catalog:         opts.CatalogScope,
+		syncLocalWAL:    !opts.DisableLocalCommandWALSync,
+	}, nil
+}
+
+func (s *SingleGroupSubmitter) Config() ResolvedConfig {
+	if s == nil {
+		return ResolvedConfig{}
+	}
+	return s.cluster
+}
+
+func (s *SingleGroupSubmitter) ClusterAdmissionStatus(ctx context.Context) (AdmissionStatus, error) {
+	if s == nil || s.admission == nil {
+		return AdmissionStatus{}, ErrInvalidSubmitter
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return s.admission.ClusterAdmissionStatus(ctx)
+}
+
+func (s *SingleGroupSubmitter) SubmitCommandEntryV1(ctx context.Context, entry []byte, metadata raftentry.RequestMetadataV1) (SubmitResultV1, error) {
+	if s == nil || s.commit == nil || s.applier == nil || s.catalogProvider == nil {
+		return SubmitResultV1{}, ErrInvalidSubmitter
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := s.admit(ctx); err != nil {
+		return SubmitResultV1{}, err
+	}
+	catalogVersion, hasCatalogVersion, err := s.catalogProvider.CurrentCatalogVersion(ctx)
+	if err != nil {
+		return SubmitResultV1{}, errors.Join(ErrMissingCatalogVersion, err)
+	}
+	if !hasCatalogVersion {
+		return SubmitResultV1{}, ErrMissingCatalogVersion
+	}
+	decoded, err := raftentry.DecodeCommandEntryV1(entry, raftentry.DecodeOptions{
+		Limits:          s.decodeLimits,
+		ScopeRule:       s.scopeRule,
+		DatabaseScope:   s.database,
+		CatalogScope:    s.catalog,
+		RequestMetadata: cloneRequestMetadataV1(metadata),
+	})
+	if err != nil {
+		return SubmitResultV1{}, err
+	}
+	expectedTarget := decoded.Target.Clone()
+	request := CommitCommandEntryV1Request{
+		GroupID:                  s.cluster.GroupID,
+		NodeID:                   s.cluster.NodeID,
+		EntryBytes:               bytes.Clone(entry),
+		CurrentCatalogVersion:    catalogVersion,
+		HasCurrentCatalogVersion: true,
+		SyncLocalCommandWAL:      s.syncLocalWAL,
+		RequestMetadata:          cloneRequestMetadataV1(metadata),
+		ExpectedTarget:           &expectedTarget,
+	}
+	commitResult, err := s.commit.CommitCommandEntryV1(ctx, request.Clone())
+	if err != nil {
+		return SubmitResultV1{}, err
+	}
+	committed, err := s.validateCommitResult(request, commitResult)
+	if err != nil {
+		return SubmitResultV1{}, err
+	}
+	applyResult, err := s.applier.ApplyCommittedCommandEntryV1(ctx, committed.Clone())
+	if err != nil {
+		return SubmitResultV1{ApplyResult: applyResult, CommittedEntry: committed, Evidence: commitResult.Evidence}, errors.Join(ErrLocalApplyNotRecoverable, err)
+	}
+	if applyResult.Status != raftentry.ApplyStatusApplied && applyResult.Status != raftentry.ApplyStatusAlreadyApplied {
+		return SubmitResultV1{ApplyResult: applyResult, CommittedEntry: committed, Evidence: commitResult.Evidence}, errors.Join(ErrLocalApplyNotRecoverable, fmt.Errorf("apply status %s", applyResult.Status))
+	}
+	postCatalogVersion, postHasCatalogVersion, err := s.catalogProvider.CurrentCatalogVersion(ctx)
+	if err != nil {
+		return SubmitResultV1{ApplyResult: applyResult, CommittedEntry: committed, Evidence: commitResult.Evidence}, errors.Join(ErrLocalApplyNotRecoverable, err)
+	}
+	actualAck, err := actualSubmitAck(metadata.AckPolicy)
+	if err != nil {
+		return SubmitResultV1{ApplyResult: applyResult, CommittedEntry: committed, Evidence: commitResult.Evidence}, err
+	}
+	return SubmitResultV1{
+		ActualAck:            actualAck,
+		CommittedRecoverable: actualAck == iwire.AckRaftCommitted,
+		ApplyResult:          applyResult,
+		CommittedEntry:       committed,
+		Evidence:             commitResult.Evidence,
+		CatalogVersion:       postCatalogVersion,
+		HasCatalogVersion:    postHasCatalogVersion,
+	}, nil
+}
+
+func (s *SingleGroupSubmitter) admit(ctx context.Context) error {
+	status, err := s.ClusterAdmissionStatus(ctx)
+	if err != nil {
+		return errors.Join(ErrAdmissionUnavailable, err)
+	}
+	if status.Unavailable {
+		if status.Reason == "" {
+			return ErrAdmissionUnavailable
+		}
+		return errors.Join(ErrAdmissionUnavailable, fmt.Errorf("%s", status.Reason))
+	}
+	if !status.Leader {
+		if status.Reason == "" && status.LeaderHint == "" {
+			return ErrNotLeader
+		}
+		msg := status.Reason
+		if msg == "" {
+			msg = "not leader"
+		}
+		if status.LeaderHint != "" {
+			msg += "; leader_hint=" + string(status.LeaderHint)
+		}
+		return errors.Join(ErrNotLeader, fmt.Errorf("%s", msg))
+	}
+	return nil
+}
+
+func (s *SingleGroupSubmitter) validateCommitResult(request CommitCommandEntryV1Request, result CommitCommandEntryV1Result) (CommittedCommandEntryV1, error) {
+	if !result.Evidence.ProvesProductionConsensus() {
+		return CommittedCommandEntryV1{}, ErrCommitNotProven
+	}
+	if result.Evidence.GroupID != "" && result.Evidence.GroupID != s.cluster.GroupID {
+		return CommittedCommandEntryV1{}, errors.Join(ErrCommitNotProven, fmt.Errorf("evidence group %q does not match local group %q", result.Evidence.GroupID, s.cluster.GroupID))
+	}
+	if result.Evidence.NodeID != "" && result.Evidence.NodeID != s.cluster.NodeID {
+		return CommittedCommandEntryV1{}, errors.Join(ErrCommitNotProven, fmt.Errorf("evidence node %q does not match local node %q", result.Evidence.NodeID, s.cluster.NodeID))
+	}
+	committed := result.Entry.Clone()
+	if committed.Term == 0 || committed.Index == 0 {
+		return CommittedCommandEntryV1{}, errors.Join(ErrInvalidCommittedEntry, fmt.Errorf("missing term/index"))
+	}
+	if committed.Term != result.Evidence.Term || committed.Index != result.Evidence.Index {
+		return CommittedCommandEntryV1{}, errors.Join(ErrCommitNotProven, fmt.Errorf("committed entry id %d/%d does not match evidence %d/%d", committed.Term, committed.Index, result.Evidence.Term, result.Evidence.Index))
+	}
+	if !bytes.Equal(committed.Bytes, request.EntryBytes) {
+		return CommittedCommandEntryV1{}, errors.Join(ErrInvalidCommittedEntry, fmt.Errorf("committed entry bytes differ from submitted entry"))
+	}
+	if committed.CurrentCatalogVersion != request.CurrentCatalogVersion || committed.HasCurrentCatalogVersion != request.HasCurrentCatalogVersion {
+		return CommittedCommandEntryV1{}, errors.Join(ErrInvalidCommittedEntry, fmt.Errorf("committed catalog guard differs from submit request"))
+	}
+	if committed.SyncLocalCommandWAL != request.SyncLocalCommandWAL {
+		return CommittedCommandEntryV1{}, errors.Join(ErrInvalidCommittedEntry, fmt.Errorf("committed local command-WAL sync flag differs from submit request"))
+	}
+	if !requestMetadataEqual(committed.RequestMetadata, request.RequestMetadata) {
+		return CommittedCommandEntryV1{}, errors.Join(ErrInvalidCommittedEntry, fmt.Errorf("committed request metadata differs from submit request"))
+	}
+	if !expectedTargetsEqual(committed.ExpectedTarget, request.ExpectedTarget) {
+		return CommittedCommandEntryV1{}, errors.Join(ErrUnexpectedCommittedTarget, fmt.Errorf("committed target differs from submit request"))
+	}
+	return committed, nil
+}
+
+func actualSubmitAck(requested iwire.AckPolicy) (iwire.AckPolicy, error) {
+	switch requested {
+	case 0:
+		return iwire.AckVisible, nil
+	case iwire.AckVisible, iwire.AckFlushed, iwire.AckSynced, iwire.AckRaftCommitted:
+		return requested, nil
+	default:
+		return 0, errors.Join(ErrUnsupportedSubmitAck, fmt.Errorf("ack policy %d", requested))
+	}
+}
+
+// SequencedCommitSource is a deterministic in-process CommitSource. By
+// default it returns deterministic-harness evidence; ProductionConsensus must
+// be set by a caller that is wrapping an actual quorum source or by tests that
+// are explicitly exercising downstream raft_committed gates.
+type SequencedCommitSource struct {
+	mu sync.Mutex
+
+	groupID             GroupID
+	nodeID              NodeID
+	leaderID            NodeID
+	term                uint64
+	nextIndex           uint64
+	evidenceKind        CommitEvidenceKindV1
+	productionConsensus bool
+}
+
+type SequencedCommitSourceOptions struct {
+	GroupID             GroupID
+	NodeID              NodeID
+	LeaderID            NodeID
+	Term                uint64
+	FirstIndex          uint64
+	EvidenceKind        CommitEvidenceKindV1
+	ProductionConsensus bool
+}
+
+func NewSequencedCommitSource(opts SequencedCommitSourceOptions) *SequencedCommitSource {
+	term := opts.Term
+	if term == 0 {
+		term = 1
+	}
+	firstIndex := opts.FirstIndex
+	if firstIndex == 0 {
+		firstIndex = 1
+	}
+	kind := opts.EvidenceKind
+	if kind == "" {
+		kind = CommitEvidenceDeterministicHarnessV1
+	}
+	return &SequencedCommitSource{
+		groupID:             opts.GroupID,
+		nodeID:              opts.NodeID,
+		leaderID:            opts.LeaderID,
+		term:                term,
+		nextIndex:           firstIndex,
+		evidenceKind:        kind,
+		productionConsensus: opts.ProductionConsensus,
+	}
+}
+
+func (s *SequencedCommitSource) CommitCommandEntryV1(ctx context.Context, req CommitCommandEntryV1Request) (CommitCommandEntryV1Result, error) {
+	if s == nil {
+		return CommitCommandEntryV1Result{}, ErrInvalidSubmitter
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	select {
+	case <-ctx.Done():
+		return CommitCommandEntryV1Result{}, ctx.Err()
+	default:
+	}
+	request := req.Clone()
+	s.mu.Lock()
+	term := s.term
+	index := s.nextIndex
+	s.nextIndex++
+	groupID := s.groupID
+	if groupID == "" {
+		groupID = request.GroupID
+	}
+	nodeID := s.nodeID
+	if nodeID == "" {
+		nodeID = request.NodeID
+	}
+	leaderID := s.leaderID
+	if leaderID == "" {
+		leaderID = nodeID
+	}
+	kind := s.evidenceKind
+	productionConsensus := s.productionConsensus
+	s.mu.Unlock()
+
+	entry := CommittedCommandEntryV1{
+		Term:                     term,
+		Index:                    index,
+		Bytes:                    bytes.Clone(request.EntryBytes),
+		CurrentCatalogVersion:    request.CurrentCatalogVersion,
+		HasCurrentCatalogVersion: request.HasCurrentCatalogVersion,
+		SyncLocalCommandWAL:      request.SyncLocalCommandWAL,
+		RequestMetadata:          cloneRequestMetadataV1(request.RequestMetadata),
+		ExpectedTarget:           cloneExpectedTargetV1(request.ExpectedTarget),
+	}
+	return CommitCommandEntryV1Result{
+		Entry: entry,
+		Evidence: CommitEvidenceV1{
+			Kind:                kind,
+			GroupID:             groupID,
+			NodeID:              nodeID,
+			LeaderID:            leaderID,
+			Term:                term,
+			Index:               index,
+			Committed:           true,
+			ProductionConsensus: productionConsensus,
+		},
+	}, nil
+}
+
+func cloneRequestMetadataV1(meta raftentry.RequestMetadataV1) raftentry.RequestMetadataV1 {
+	meta.TraceContext = bytes.Clone(meta.TraceContext)
+	meta.ClusterRouteMembers = slices.Clone(meta.ClusterRouteMembers)
+	return meta
+}
+
+func cloneExpectedTargetV1(target *raftentry.TargetIdentityV1) *raftentry.TargetIdentityV1 {
+	if target == nil {
+		return nil
+	}
+	cloned := target.Clone()
+	return &cloned
+}
+
+func expectedTargetsEqual(a, b *raftentry.TargetIdentityV1) bool {
+	switch {
+	case a == nil && b == nil:
+		return true
+	case a == nil || b == nil:
+		return false
+	default:
+		return a.Equal(*b)
+	}
+}
+
+func requestMetadataEqual(a, b raftentry.RequestMetadataV1) bool {
+	return a.RequestID == b.RequestID &&
+		a.AckPolicy == b.AckPolicy &&
+		a.DeadlineUnixNanos == b.DeadlineUnixNanos &&
+		bytes.Equal(a.TraceContext, b.TraceContext) &&
+		a.Compression == b.Compression &&
+		a.OmitResultIDs == b.OmitResultIDs &&
+		a.OmitResponseMeta == b.OmitResponseMeta &&
+		a.ClusterRouteKnown == b.ClusterRouteKnown &&
+		a.ClusterRouteDatabase == b.ClusterRouteDatabase &&
+		a.ClusterRouteCatalog == b.ClusterRouteCatalog &&
+		a.ClusterRouteCollection == b.ClusterRouteCollection &&
+		a.ClusterRouteShape == b.ClusterRouteShape &&
+		a.ClusterRouteGroupID == b.ClusterRouteGroupID &&
+		slices.Equal(a.ClusterRouteMembers, b.ClusterRouteMembers) &&
+		a.ClusterRouteLeaderHint == b.ClusterRouteLeaderHint &&
+		a.ClusterRoutePlacementMode == b.ClusterRoutePlacementMode &&
+		a.ClusterRouteTokenKnown == b.ClusterRouteTokenKnown &&
+		a.ClusterRouteToken == b.ClusterRouteToken &&
+		a.ClusterRoutePartitionID == b.ClusterRoutePartitionID
+}

--- a/TreeDB/internal/raftcluster/submit.go
+++ b/TreeDB/internal/raftcluster/submit.go
@@ -380,7 +380,8 @@ func (s *SingleGroupSubmitter) SubmitCommandEntryV1(ctx context.Context, entry [
 		return SubmitResultV1{}, ErrMissingCatalogVersion
 	}
 	guardErr := checkSubmitCatalogGuardV1(decoded, catalogVersion)
-	if guardErr != nil && !canPreflightIdempotentCreateRetryV1(decoded) {
+	allowStaleCreateRetry := allowPreflightIdempotentCreateRetryV1(decoded, guardErr)
+	if guardErr != nil && !allowStaleCreateRetry {
 		s.submitMu.Unlock()
 		return SubmitResultV1{}, guardErr
 	}
@@ -397,7 +398,7 @@ func (s *SingleGroupSubmitter) SubmitCommandEntryV1(ctx context.Context, entry [
 	}
 	if err := s.preflight.PreflightCommandEntryV1(ctx, preflightRequest); err != nil {
 		s.submitMu.Unlock()
-		if guardErr != nil {
+		if allowStaleCreateRetry {
 			return SubmitResultV1{}, guardErr
 		}
 		return SubmitResultV1{}, err
@@ -452,6 +453,12 @@ func (s *SingleGroupSubmitter) SubmitCommandEntryV1(ctx context.Context, entry [
 	}
 	s.submitMu.Unlock()
 	return result, nil
+}
+
+func allowPreflightIdempotentCreateRetryV1(entry raftentry.CommandEntryV1, guardErr error) bool {
+	return guardErr != nil &&
+		errors.Is(guardErr, ErrCatalogVersionMismatch) &&
+		canPreflightIdempotentCreateRetryV1(entry)
 }
 
 func canPreflightIdempotentCreateRetryV1(entry raftentry.CommandEntryV1) bool {

--- a/TreeDB/internal/raftcluster/submit_test.go
+++ b/TreeDB/internal/raftcluster/submit_test.go
@@ -100,6 +100,32 @@ func TestSingleGroupSubmitterLowerAckDoesNotClaimRaftCommitted(t *testing.T) {
 	}
 }
 
+func TestSingleGroupSubmitterRejectsUnsupportedAckBeforeCommitApply(t *testing.T) {
+	entry := testClusterCommandEntry(t, 7)
+	commitCalls := 0
+	applier := &recordingClusterApplier{result: raftentry.ApplyResultV1{Status: raftentry.ApplyStatusApplied, AffectedCount: 1}}
+	submitter := newTestSingleGroupSubmitter(t, SingleGroupSubmitterOptions{
+		AdmissionProvider: StaticAdmissionProvider{Status: LeaderAdmission()},
+		CommitSource: CommitSourceFunc(func(context.Context, CommitCommandEntryV1Request) (CommitCommandEntryV1Result, error) {
+			commitCalls++
+			return CommitCommandEntryV1Result{}, nil
+		}),
+		Applier:                applier,
+		CatalogVersionProvider: staticCatalogVersion(7),
+	})
+
+	_, err := submitter.SubmitCommandEntryV1(context.Background(), entry, raftentry.RequestMetadataV1{AckPolicy: iwire.AckPolicy(99)})
+	if !errors.Is(err, ErrUnsupportedSubmitAck) {
+		t.Fatalf("SubmitCommandEntryV1 err=%v want unsupported submit ack", err)
+	}
+	if commitCalls != 0 {
+		t.Fatalf("commit calls=%d want 0", commitCalls)
+	}
+	if got := len(applier.snapshot()); got != 0 {
+		t.Fatalf("apply calls=%d want 0", got)
+	}
+}
+
 func TestSingleGroupSubmitterAdmissionRejectsBeforeCommitApply(t *testing.T) {
 	for _, tc := range []struct {
 		name    string

--- a/TreeDB/internal/raftcluster/submit_test.go
+++ b/TreeDB/internal/raftcluster/submit_test.go
@@ -297,6 +297,42 @@ func TestSingleGroupSubmitterRejectsStaleIdempotentCreateWhenPreflightRejects(t 
 	}
 }
 
+func TestAllowPreflightIdempotentCreateRetryRequiresCatalogMismatch(t *testing.T) {
+	entry := raftentry.CommandEntryV1{
+		Target: raftentry.TargetIdentityV1{
+			CommandID:              iwire.CommandCreateCollection,
+			ExpectedCatalogVersion: []byte{0x80},
+		},
+		Idempotency:    raftentry.IdempotencyRequiredV1,
+		IdempotencyKey: []byte("raftcluster/create/users"),
+	}
+	guardErr := checkSubmitCatalogGuardV1(entry, 8)
+	if guardErr == nil || errors.Is(guardErr, ErrCatalogVersionMismatch) {
+		t.Fatalf("malformed guard err=%v, want non-mismatch guard error", guardErr)
+	}
+	if allowPreflightIdempotentCreateRetryV1(entry, guardErr) {
+		t.Fatal("malformed create guard was allowed through stale-create retry path")
+	}
+
+	entry.Target.ExpectedCatalogVersion = nil
+	guardErr = checkSubmitCatalogGuardV1(entry, 8)
+	if guardErr == nil || errors.Is(guardErr, ErrCatalogVersionMismatch) {
+		t.Fatalf("missing guard err=%v, want non-mismatch guard error", guardErr)
+	}
+	if allowPreflightIdempotentCreateRetryV1(entry, guardErr) {
+		t.Fatal("missing create guard was allowed through stale-create retry path")
+	}
+
+	entry.Target.ExpectedCatalogVersion = binary.AppendUvarint(nil, 7)
+	guardErr = checkSubmitCatalogGuardV1(entry, 8)
+	if !errors.Is(guardErr, ErrCatalogVersionMismatch) {
+		t.Fatalf("stale guard err=%v, want catalog-version mismatch", guardErr)
+	}
+	if !allowPreflightIdempotentCreateRetryV1(entry, guardErr) {
+		t.Fatal("stale idempotent create guard was not allowed to reach preflight")
+	}
+}
+
 func TestSingleGroupSubmitterSerializesLocalApplyByCommittedIndex(t *testing.T) {
 	entry := testClusterCommandEntry(t, 7)
 	applier := newOrderedBlockingApplier()

--- a/TreeDB/internal/raftcluster/submit_test.go
+++ b/TreeDB/internal/raftcluster/submit_test.go
@@ -7,7 +7,9 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"sync"
 	"testing"
+	"time"
 
 	iwire "github.com/snissn/gomap/TreeDB/internal/nativewire"
 	"github.com/snissn/gomap/TreeDB/internal/raftentry"
@@ -179,6 +181,145 @@ func TestSingleGroupSubmitterRejectsStaleCatalogGuardBeforeCommitApply(t *testin
 	}
 	if got := len(applier.snapshot()); got != 0 {
 		t.Fatalf("apply calls=%d want 0", got)
+	}
+}
+
+func TestSingleGroupSubmitterLetsIdempotentCreateRetryReachPreflightApply(t *testing.T) {
+	entry := testClusterCreateCollectionEntry(t, 7)
+	commitCalls := 0
+	preflightCalls := 0
+	applier := &recordingClusterApplier{result: raftentry.ApplyResultV1{Status: raftentry.ApplyStatusAlreadyApplied}}
+	submitter := newTestSingleGroupSubmitter(t, SingleGroupSubmitterOptions{
+		AdmissionProvider: StaticAdmissionProvider{Status: LeaderAdmission()},
+		CommitSource: CommitSourceFunc(func(ctx context.Context, req CommitCommandEntryV1Request) (CommitCommandEntryV1Result, error) {
+			commitCalls++
+			return productionCommittedResult(req, 3, uint64(commitCalls)), nil
+		}),
+		Preflight: CommandEntryPreflightFunc(func(ctx context.Context, req CommandEntryPreflightRequestV1) error {
+			preflightCalls++
+			if req.DecodedEntry.Target.CommandID != iwire.CommandCreateCollection {
+				t.Fatalf("preflight command=%d want create_collection", req.DecodedEntry.Target.CommandID)
+			}
+			if req.CurrentCatalogVersion != 8 || !req.HasCurrentCatalogVersion {
+				t.Fatalf("preflight catalog=%d/%v want 8/true", req.CurrentCatalogVersion, req.HasCurrentCatalogVersion)
+			}
+			return nil
+		}),
+		Applier:                applier,
+		CatalogVersionProvider: staticCatalogVersion(8),
+	})
+
+	result, err := submitter.SubmitCommandEntryV1(context.Background(), entry, raftentry.RequestMetadataV1{AckPolicy: iwire.AckRaftCommitted})
+	if err != nil {
+		t.Fatalf("SubmitCommandEntryV1 idempotent create retry: %v", err)
+	}
+	if result.ApplyResult.Status != raftentry.ApplyStatusAlreadyApplied {
+		t.Fatalf("apply status=%s want already-applied", result.ApplyResult.Status)
+	}
+	if preflightCalls != 1 || commitCalls != 1 {
+		t.Fatalf("preflight/commit calls=%d/%d want 1/1", preflightCalls, commitCalls)
+	}
+	if got := len(applier.snapshot()); got != 1 {
+		t.Fatalf("apply calls=%d want 1", got)
+	}
+}
+
+func TestSingleGroupSubmitterRejectsStaleIdempotentCreateWhenPreflightRejects(t *testing.T) {
+	entry := testClusterCreateCollectionEntry(t, 7)
+	commitCalls := 0
+	preflightCalls := 0
+	preflightErr := errors.New("create preflight rejected")
+	applier := &recordingClusterApplier{result: raftentry.ApplyResultV1{Status: raftentry.ApplyStatusAlreadyApplied}}
+	submitter := newTestSingleGroupSubmitter(t, SingleGroupSubmitterOptions{
+		AdmissionProvider: StaticAdmissionProvider{Status: LeaderAdmission()},
+		CommitSource: CommitSourceFunc(func(context.Context, CommitCommandEntryV1Request) (CommitCommandEntryV1Result, error) {
+			commitCalls++
+			return CommitCommandEntryV1Result{}, nil
+		}),
+		Preflight: CommandEntryPreflightFunc(func(context.Context, CommandEntryPreflightRequestV1) error {
+			preflightCalls++
+			return preflightErr
+		}),
+		Applier:                applier,
+		CatalogVersionProvider: staticCatalogVersion(8),
+	})
+
+	_, err := submitter.SubmitCommandEntryV1(context.Background(), entry, raftentry.RequestMetadataV1{AckPolicy: iwire.AckRaftCommitted})
+	if !errors.Is(err, ErrCatalogVersionMismatch) {
+		t.Fatalf("SubmitCommandEntryV1 err=%v want catalog-version-mismatch", err)
+	}
+	if errors.Is(err, preflightErr) {
+		t.Fatalf("SubmitCommandEntryV1 err=%v should preserve stale guard mismatch over preflight rejection", err)
+	}
+	if preflightCalls != 1 {
+		t.Fatalf("preflight calls=%d want 1", preflightCalls)
+	}
+	if commitCalls != 0 {
+		t.Fatalf("commit calls=%d want 0", commitCalls)
+	}
+	if got := len(applier.snapshot()); got != 0 {
+		t.Fatalf("apply calls=%d want 0", got)
+	}
+}
+
+func TestSingleGroupSubmitterSerializesLocalApplyByCommittedIndex(t *testing.T) {
+	entry := testClusterCommandEntry(t, 7)
+	applier := newOrderedBlockingApplier()
+	submitter := newTestSingleGroupSubmitter(t, SingleGroupSubmitterOptions{
+		AdmissionProvider: StaticAdmissionProvider{Status: LeaderAdmission()},
+		CommitSource: NewSequencedCommitSource(SequencedCommitSourceOptions{
+			GroupID:             "group-a",
+			NodeID:              "node-a",
+			LeaderID:            "node-a",
+			Term:                3,
+			EvidenceKind:        CommitEvidenceProductionConsensusV1,
+			ProductionConsensus: true,
+		}),
+		Applier:                applier,
+		CatalogVersionProvider: staticCatalogVersion(7),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	firstErr := make(chan error, 1)
+	go func() {
+		_, err := submitter.SubmitCommandEntryV1(ctx, entry, raftentry.RequestMetadataV1{RequestID: 1, AckPolicy: iwire.AckRaftCommitted})
+		firstErr <- err
+	}()
+	select {
+	case <-applier.firstEntered:
+	case <-ctx.Done():
+		t.Fatalf("first submit did not reach apply: %v", ctx.Err())
+	}
+
+	secondErr := make(chan error, 1)
+	go func() {
+		_, err := submitter.SubmitCommandEntryV1(ctx, entry, raftentry.RequestMetadataV1{RequestID: 2, AckPolicy: iwire.AckRaftCommitted})
+		secondErr <- err
+	}()
+	select {
+	case index := <-applier.outOfOrder:
+		t.Fatalf("submitter let index %d reach local apply before index 1 completed", index)
+	case <-time.After(100 * time.Millisecond):
+	}
+	close(applier.releaseFirst)
+
+	for name, ch := range map[string]<-chan error{"first": firstErr, "second": secondErr} {
+		select {
+		case err := <-ch:
+			if err != nil {
+				t.Fatalf("%s submit err=%v", name, err)
+			}
+		case <-ctx.Done():
+			t.Fatalf("%s submit timed out: %v", name, ctx.Err())
+		}
+	}
+	entries := applier.snapshot()
+	if len(entries) != 2 {
+		t.Fatalf("applied entries=%d want 2", len(entries))
+	}
+	if entries[0].Index != 1 || entries[1].Index != 2 {
+		t.Fatalf("applied indexes=%d,%d want 1,2", entries[0].Index, entries[1].Index)
 	}
 }
 
@@ -406,6 +547,32 @@ func staticCatalogVersion(version uint64) CatalogVersionProvider {
 	})
 }
 
+func productionCommittedResult(req CommitCommandEntryV1Request, term, index uint64) CommitCommandEntryV1Result {
+	entry := CommittedCommandEntryV1{
+		Term:                     term,
+		Index:                    index,
+		Bytes:                    bytes.Clone(req.EntryBytes),
+		CurrentCatalogVersion:    req.CurrentCatalogVersion,
+		HasCurrentCatalogVersion: req.HasCurrentCatalogVersion,
+		SyncLocalCommandWAL:      req.SyncLocalCommandWAL,
+		RequestMetadata:          cloneRequestMetadataV1(req.RequestMetadata),
+		ExpectedTarget:           cloneExpectedTargetV1(req.ExpectedTarget),
+	}
+	return CommitCommandEntryV1Result{
+		Entry: entry,
+		Evidence: CommitEvidenceV1{
+			Kind:                CommitEvidenceProductionConsensusV1,
+			GroupID:             req.GroupID,
+			NodeID:              req.NodeID,
+			LeaderID:            req.NodeID,
+			Term:                term,
+			Index:               index,
+			Committed:           true,
+			ProductionConsensus: true,
+		},
+	}
+}
+
 func testClusterCommandEntry(tb testing.TB, catalogVersion uint64) []byte {
 	tb.Helper()
 	sections := []iwire.Section{
@@ -426,4 +593,101 @@ func testClusterCommandEntry(tb testing.TB, catalogVersion uint64) []byte {
 		tb.Fatalf("AppendDeterministicEntry: %v", err)
 	}
 	return entry
+}
+
+func testClusterCreateCollectionEntry(tb testing.TB, catalogVersion uint64) []byte {
+	tb.Helper()
+	sections := []iwire.Section{
+		{ID: iwire.SectionCommandHeader, Bytes: iwire.AppendCommandHeader(nil, iwire.CommandHeader{ID: iwire.CommandCreateCollection, Version: 1})},
+		{ID: iwire.SectionIdempotencyKey, Bytes: []byte("raftcluster/create/users")},
+		{ID: iwire.SectionCollectionMeta, Bytes: testClusterCollectionMetaPayload("users")},
+		{ID: iwire.SectionExpectedCatalogVersion, Bytes: binary.AppendUvarint(nil, catalogVersion)},
+	}
+	cmd, err := iwire.MustV1Registry().ValidateRequestSections(sections)
+	if err != nil {
+		tb.Fatalf("ValidateRequestSections: %v", err)
+	}
+	entry, err := iwire.AppendDeterministicEntry(nil, cmd)
+	if err != nil {
+		tb.Fatalf("AppendDeterministicEntry: %v", err)
+	}
+	return entry
+}
+
+func testClusterCollectionMetaPayload(collection string) []byte {
+	dst := binary.AppendUvarint(nil, 1) // collection_meta version
+	dst = appendTestString(dst, collection)
+	dst = binary.AppendUvarint(dst, 0) // document_format
+	dst = binary.AppendUvarint(dst, 0) // data_root_storage_policy
+	dst = binary.AppendUvarint(dst, 0) // index_state_storage_policy
+	dst = append(dst, 0)               // allow_array_values_in_index
+	dst = append(dst, 0)               // disable_indexed_write_memtables
+	dst = append(dst, 0)               // buffered_indexed_writes
+	dst = binary.AppendVarint(dst, 0)  // buffered_indexed_write_max_documents
+	dst = binary.AppendVarint(dst, 0)  // buffered_indexed_write_max_bytes
+	dst = binary.AppendVarint(dst, 0)  // buffered_indexed_write_max_root_runs
+	dst = append(dst, 0)               // buffered_indexed_async_flush
+	dst = append(dst, 0)               // buffered_indexed_overlay_roots
+	dst = binary.AppendVarint(dst, 0)  // buffered_indexed_async_flush_max_queued_units
+	dst = binary.AppendUvarint(dst, 0) // index_count
+	return dst
+}
+
+func appendTestString(dst []byte, value string) []byte {
+	dst = binary.AppendUvarint(dst, uint64(len(value)))
+	return append(dst, value...)
+}
+
+type orderedBlockingApplier struct {
+	mu           sync.Mutex
+	entries      []CommittedCommandEntryV1
+	firstEntered chan struct{}
+	releaseFirst chan struct{}
+	outOfOrder   chan uint64
+	firstDone    bool
+}
+
+func newOrderedBlockingApplier() *orderedBlockingApplier {
+	return &orderedBlockingApplier{
+		firstEntered: make(chan struct{}),
+		releaseFirst: make(chan struct{}),
+		outOfOrder:   make(chan uint64, 1),
+	}
+}
+
+func (a *orderedBlockingApplier) ApplyCommittedCommandEntryV1(ctx context.Context, entry CommittedCommandEntryV1) (raftentry.ApplyResultV1, error) {
+	clone := entry.Clone()
+	a.mu.Lock()
+	a.entries = append(a.entries, clone)
+	if clone.Index == 1 && len(a.entries) == 1 {
+		close(a.firstEntered)
+		a.mu.Unlock()
+		select {
+		case <-a.releaseFirst:
+		case <-ctx.Done():
+			return raftentry.ApplyResultV1{}, ctx.Err()
+		}
+		a.mu.Lock()
+		a.firstDone = true
+		a.mu.Unlock()
+		return raftentry.ApplyResultV1{Status: raftentry.ApplyStatusApplied, AffectedCount: 1}, nil
+	}
+	if clone.Index != uint64(len(a.entries)) || !a.firstDone {
+		select {
+		case a.outOfOrder <- clone.Index:
+		default:
+		}
+	}
+	a.mu.Unlock()
+	return raftentry.ApplyResultV1{Status: raftentry.ApplyStatusApplied, AffectedCount: 1}, nil
+}
+
+func (a *orderedBlockingApplier) snapshot() []CommittedCommandEntryV1 {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	out := make([]CommittedCommandEntryV1, len(a.entries))
+	for i := range a.entries {
+		out[i] = a.entries[i].Clone()
+	}
+	return out
 }

--- a/TreeDB/internal/raftcluster/submit_test.go
+++ b/TreeDB/internal/raftcluster/submit_test.go
@@ -126,6 +126,32 @@ func TestSingleGroupSubmitterRejectsUnsupportedAckBeforeCommitApply(t *testing.T
 	}
 }
 
+func TestSingleGroupSubmitterRejectsStaleCatalogGuardBeforeCommitApply(t *testing.T) {
+	entry := testClusterCommandEntry(t, 6)
+	commitCalls := 0
+	applier := &recordingClusterApplier{result: raftentry.ApplyResultV1{Status: raftentry.ApplyStatusApplied, AffectedCount: 1}}
+	submitter := newTestSingleGroupSubmitter(t, SingleGroupSubmitterOptions{
+		AdmissionProvider: StaticAdmissionProvider{Status: LeaderAdmission()},
+		CommitSource: CommitSourceFunc(func(context.Context, CommitCommandEntryV1Request) (CommitCommandEntryV1Result, error) {
+			commitCalls++
+			return CommitCommandEntryV1Result{}, nil
+		}),
+		Applier:                applier,
+		CatalogVersionProvider: staticCatalogVersion(7),
+	})
+
+	_, err := submitter.SubmitCommandEntryV1(context.Background(), entry, raftentry.RequestMetadataV1{AckPolicy: iwire.AckRaftCommitted})
+	if !errors.Is(err, ErrCatalogVersionMismatch) {
+		t.Fatalf("SubmitCommandEntryV1 err=%v want catalog-version-mismatch", err)
+	}
+	if commitCalls != 0 {
+		t.Fatalf("commit calls=%d want 0", commitCalls)
+	}
+	if got := len(applier.snapshot()); got != 0 {
+		t.Fatalf("apply calls=%d want 0", got)
+	}
+}
+
 func TestSingleGroupSubmitterAdmissionRejectsBeforeCommitApply(t *testing.T) {
 	for _, tc := range []struct {
 		name    string

--- a/TreeDB/internal/raftcluster/submit_test.go
+++ b/TreeDB/internal/raftcluster/submit_test.go
@@ -169,9 +169,9 @@ func TestSingleGroupSubmitterRejectsRaftCommittedWhenLocalCommandWALSyncDisabled
 			commitCalls++
 			return CommitCommandEntryV1Result{}, nil
 		}),
-		Preflight: CommandEntryPreflightFunc(func(context.Context, CommandEntryPreflightRequestV1) error {
+		Preflight: CommandEntryPreflightFunc(func(context.Context, CommandEntryPreflightRequestV1) (CommandEntryPreflightResultV1, error) {
 			preflightCalls++
-			return nil
+			return CommandEntryPreflightResultV1{}, nil
 		}),
 		Applier:                    applier,
 		CatalogVersionProvider:     staticCatalogVersion(7),
@@ -230,7 +230,7 @@ func TestSingleGroupSubmitterLetsIdempotentCreateRetryReachPreflightApply(t *tes
 			commitCalls++
 			return productionCommittedResult(req, 3, uint64(commitCalls)), nil
 		}),
-		Preflight: CommandEntryPreflightFunc(func(ctx context.Context, req CommandEntryPreflightRequestV1) error {
+		Preflight: CommandEntryPreflightFunc(func(ctx context.Context, req CommandEntryPreflightRequestV1) (CommandEntryPreflightResultV1, error) {
 			preflightCalls++
 			if req.DecodedEntry.Target.CommandID != iwire.CommandCreateCollection {
 				t.Fatalf("preflight command=%d want create_collection", req.DecodedEntry.Target.CommandID)
@@ -238,7 +238,7 @@ func TestSingleGroupSubmitterLetsIdempotentCreateRetryReachPreflightApply(t *tes
 			if req.CurrentCatalogVersion != 8 || !req.HasCurrentCatalogVersion {
 				t.Fatalf("preflight catalog=%d/%v want 8/true", req.CurrentCatalogVersion, req.HasCurrentCatalogVersion)
 			}
-			return nil
+			return CommandEntryPreflightResultV1{KnownIdempotencyReplay: true}, nil
 		}),
 		Applier:                applier,
 		CatalogVersionProvider: staticCatalogVersion(8),
@@ -271,9 +271,9 @@ func TestSingleGroupSubmitterRejectsStaleIdempotentCreateWhenPreflightRejects(t 
 			commitCalls++
 			return CommitCommandEntryV1Result{}, nil
 		}),
-		Preflight: CommandEntryPreflightFunc(func(context.Context, CommandEntryPreflightRequestV1) error {
+		Preflight: CommandEntryPreflightFunc(func(context.Context, CommandEntryPreflightRequestV1) (CommandEntryPreflightResultV1, error) {
 			preflightCalls++
-			return preflightErr
+			return CommandEntryPreflightResultV1{}, preflightErr
 		}),
 		Applier:                applier,
 		CatalogVersionProvider: staticCatalogVersion(8),
@@ -285,6 +285,40 @@ func TestSingleGroupSubmitterRejectsStaleIdempotentCreateWhenPreflightRejects(t 
 	}
 	if errors.Is(err, preflightErr) {
 		t.Fatalf("SubmitCommandEntryV1 err=%v should preserve stale guard mismatch over preflight rejection", err)
+	}
+	if preflightCalls != 1 {
+		t.Fatalf("preflight calls=%d want 1", preflightCalls)
+	}
+	if commitCalls != 0 {
+		t.Fatalf("commit calls=%d want 0", commitCalls)
+	}
+	if got := len(applier.snapshot()); got != 0 {
+		t.Fatalf("apply calls=%d want 0", got)
+	}
+}
+
+func TestSingleGroupSubmitterRejectsStaleIdempotentCreateWithoutKnownReplay(t *testing.T) {
+	entry := testClusterCreateCollectionEntry(t, 7)
+	commitCalls := 0
+	preflightCalls := 0
+	applier := &recordingClusterApplier{result: raftentry.ApplyResultV1{Status: raftentry.ApplyStatusAlreadyApplied}}
+	submitter := newTestSingleGroupSubmitter(t, SingleGroupSubmitterOptions{
+		AdmissionProvider: StaticAdmissionProvider{Status: LeaderAdmission()},
+		CommitSource: CommitSourceFunc(func(context.Context, CommitCommandEntryV1Request) (CommitCommandEntryV1Result, error) {
+			commitCalls++
+			return CommitCommandEntryV1Result{}, nil
+		}),
+		Preflight: CommandEntryPreflightFunc(func(context.Context, CommandEntryPreflightRequestV1) (CommandEntryPreflightResultV1, error) {
+			preflightCalls++
+			return CommandEntryPreflightResultV1{}, nil
+		}),
+		Applier:                applier,
+		CatalogVersionProvider: staticCatalogVersion(8),
+	})
+
+	_, err := submitter.SubmitCommandEntryV1(context.Background(), entry, raftentry.RequestMetadataV1{AckPolicy: iwire.AckRaftCommitted})
+	if !errors.Is(err, ErrCatalogVersionMismatch) {
+		t.Fatalf("SubmitCommandEntryV1 err=%v want catalog-version-mismatch", err)
 	}
 	if preflightCalls != 1 {
 		t.Fatalf("preflight calls=%d want 1", preflightCalls)
@@ -406,7 +440,7 @@ func TestSingleGroupSubmitterPreflightsBeforeCommitApply(t *testing.T) {
 			commitCalls++
 			return CommitCommandEntryV1Result{}, nil
 		}),
-		Preflight: CommandEntryPreflightFunc(func(ctx context.Context, req CommandEntryPreflightRequestV1) error {
+		Preflight: CommandEntryPreflightFunc(func(ctx context.Context, req CommandEntryPreflightRequestV1) (CommandEntryPreflightResultV1, error) {
 			preflightCalls++
 			if req.GroupID != "group-a" || req.NodeID != "node-a" {
 				t.Fatalf("preflight group/node=%q/%q want group-a/node-a", req.GroupID, req.NodeID)
@@ -417,7 +451,7 @@ func TestSingleGroupSubmitterPreflightsBeforeCommitApply(t *testing.T) {
 			if req.CurrentCatalogVersion != 7 || !req.HasCurrentCatalogVersion {
 				t.Fatalf("preflight catalog=%d/%v want 7/true", req.CurrentCatalogVersion, req.HasCurrentCatalogVersion)
 			}
-			return preflightErr
+			return CommandEntryPreflightResultV1{}, preflightErr
 		}),
 		Applier:                applier,
 		CatalogVersionProvider: staticCatalogVersion(7),
@@ -601,8 +635,8 @@ func newTestSingleGroupSubmitter(tb testing.TB, opts SingleGroupSubmitterOptions
 		},
 	}
 	if opts.Preflight == nil {
-		opts.Preflight = CommandEntryPreflightFunc(func(context.Context, CommandEntryPreflightRequestV1) error {
-			return nil
+		opts.Preflight = CommandEntryPreflightFunc(func(context.Context, CommandEntryPreflightRequestV1) (CommandEntryPreflightResultV1, error) {
+			return CommandEntryPreflightResultV1{}, nil
 		})
 	}
 	submitter, err := NewSingleGroupSubmitter(opts)

--- a/TreeDB/internal/raftcluster/submit_test.go
+++ b/TreeDB/internal/raftcluster/submit_test.go
@@ -1,0 +1,259 @@
+package raftcluster
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	iwire "github.com/snissn/gomap/TreeDB/internal/nativewire"
+	"github.com/snissn/gomap/TreeDB/internal/raftentry"
+)
+
+func TestSingleGroupSubmitterLeaderCommitsAppliesAndReturnsRaftCommitted(t *testing.T) {
+	entry := testClusterCommandEntry(t, 7)
+	catalogVersion := uint64(7)
+	applier := &recordingClusterApplier{
+		result: raftentry.ApplyResultV1{Status: raftentry.ApplyStatusApplied, AffectedCount: 1},
+		hook: func(CommittedCommandEntryV1) {
+			catalogVersion = 8
+		},
+	}
+	submitter := newTestSingleGroupSubmitter(t, SingleGroupSubmitterOptions{
+		AdmissionProvider: StaticAdmissionProvider{Status: LeaderAdmission()},
+		CommitSource: NewSequencedCommitSource(SequencedCommitSourceOptions{
+			GroupID:             "group-a",
+			NodeID:              "node-a",
+			LeaderID:            "node-a",
+			Term:                3,
+			EvidenceKind:        CommitEvidenceProductionConsensusV1,
+			ProductionConsensus: true,
+		}),
+		Applier: applier,
+		CatalogVersionProvider: CatalogVersionProviderFunc(func(context.Context) (uint64, bool, error) {
+			return catalogVersion, true, nil
+		}),
+	})
+
+	result, err := submitter.SubmitCommandEntryV1(context.Background(), entry, raftentry.RequestMetadataV1{
+		RequestID: 17,
+		AckPolicy: iwire.AckRaftCommitted,
+	})
+	if err != nil {
+		t.Fatalf("SubmitCommandEntryV1: %v", err)
+	}
+	if result.ActualAck != iwire.AckRaftCommitted || !result.CommittedRecoverable {
+		t.Fatalf("ack/recoverable=%d/%v want raft_committed/true", result.ActualAck, result.CommittedRecoverable)
+	}
+	if result.Evidence.Kind != CommitEvidenceProductionConsensusV1 || !result.Evidence.ProvesProductionConsensus() {
+		t.Fatalf("evidence=%+v does not prove production consensus", result.Evidence)
+	}
+	if result.CommittedEntry.Term != 3 || result.CommittedEntry.Index != 1 {
+		t.Fatalf("committed entry id=%d/%d want 3/1", result.CommittedEntry.Term, result.CommittedEntry.Index)
+	}
+	if result.CatalogVersion != 8 || !result.HasCatalogVersion {
+		t.Fatalf("post catalog=%d/%v want 8/true", result.CatalogVersion, result.HasCatalogVersion)
+	}
+	entries := applier.snapshot()
+	if len(entries) != 1 {
+		t.Fatalf("applied entries=%d want 1", len(entries))
+	}
+	applied := entries[0]
+	if !bytes.Equal(applied.Bytes, entry) {
+		t.Fatal("applied entry bytes differ from submitted entry")
+	}
+	if applied.CurrentCatalogVersion != 7 || !applied.HasCurrentCatalogVersion || !applied.SyncLocalCommandWAL {
+		t.Fatalf("applied catalog/sync=%d/%v/%v want 7/true/true", applied.CurrentCatalogVersion, applied.HasCurrentCatalogVersion, applied.SyncLocalCommandWAL)
+	}
+	if applied.ExpectedTarget == nil || applied.ExpectedTarget.CommandID != iwire.CommandInsertBatch {
+		t.Fatalf("applied expected target=%+v want insert_batch target", applied.ExpectedTarget)
+	}
+}
+
+func TestSingleGroupSubmitterLowerAckDoesNotClaimRaftCommitted(t *testing.T) {
+	entry := testClusterCommandEntry(t, 7)
+	applier := &recordingClusterApplier{result: raftentry.ApplyResultV1{Status: raftentry.ApplyStatusApplied, AffectedCount: 1}}
+	submitter := newTestSingleGroupSubmitter(t, SingleGroupSubmitterOptions{
+		AdmissionProvider: StaticAdmissionProvider{Status: LeaderAdmission()},
+		CommitSource: NewSequencedCommitSource(SequencedCommitSourceOptions{
+			GroupID:             "group-a",
+			NodeID:              "node-a",
+			EvidenceKind:        CommitEvidenceProductionConsensusV1,
+			ProductionConsensus: true,
+		}),
+		Applier:                applier,
+		CatalogVersionProvider: staticCatalogVersion(7),
+	})
+
+	result, err := submitter.SubmitCommandEntryV1(context.Background(), entry, raftentry.RequestMetadataV1{AckPolicy: iwire.AckVisible})
+	if err != nil {
+		t.Fatalf("SubmitCommandEntryV1 visible: %v", err)
+	}
+	if result.ActualAck != iwire.AckVisible || result.CommittedRecoverable {
+		t.Fatalf("ack/recoverable=%d/%v want visible/false", result.ActualAck, result.CommittedRecoverable)
+	}
+	if len(applier.snapshot()) != 1 {
+		t.Fatal("visible submit did not apply through committed bridge")
+	}
+}
+
+func TestSingleGroupSubmitterAdmissionRejectsBeforeCommitApply(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		status  AdmissionStatus
+		wantErr error
+	}{
+		{name: "follower", status: FollowerAdmission("node-b", "not leader"), wantErr: ErrNotLeader},
+		{name: "unavailable", status: UnavailableAdmission("election pending"), wantErr: ErrAdmissionUnavailable},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			commitCalls := 0
+			applier := &recordingClusterApplier{result: raftentry.ApplyResultV1{Status: raftentry.ApplyStatusApplied}}
+			submitter := newTestSingleGroupSubmitter(t, SingleGroupSubmitterOptions{
+				AdmissionProvider: StaticAdmissionProvider{Status: tc.status},
+				CommitSource: CommitSourceFunc(func(context.Context, CommitCommandEntryV1Request) (CommitCommandEntryV1Result, error) {
+					commitCalls++
+					return CommitCommandEntryV1Result{}, nil
+				}),
+				Applier:                applier,
+				CatalogVersionProvider: staticCatalogVersion(7),
+			})
+
+			_, err := submitter.SubmitCommandEntryV1(context.Background(), testClusterCommandEntry(t, 7), raftentry.RequestMetadataV1{AckPolicy: iwire.AckRaftCommitted})
+			if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("SubmitCommandEntryV1 err=%v want %v", err, tc.wantErr)
+			}
+			if commitCalls != 0 {
+				t.Fatalf("commit calls=%d want 0", commitCalls)
+			}
+			if got := len(applier.snapshot()); got != 0 {
+				t.Fatalf("apply calls=%d want 0", got)
+			}
+		})
+	}
+}
+
+func TestSingleGroupSubmitterRejectsNonProductionEvidenceBeforeApply(t *testing.T) {
+	applier := &recordingClusterApplier{result: raftentry.ApplyResultV1{Status: raftentry.ApplyStatusApplied}}
+	submitter := newTestSingleGroupSubmitter(t, SingleGroupSubmitterOptions{
+		AdmissionProvider: StaticAdmissionProvider{Status: LeaderAdmission()},
+		CommitSource: NewSequencedCommitSource(SequencedCommitSourceOptions{
+			GroupID: "group-a",
+			NodeID:  "node-a",
+		}),
+		Applier:                applier,
+		CatalogVersionProvider: staticCatalogVersion(7),
+	})
+
+	_, err := submitter.SubmitCommandEntryV1(context.Background(), testClusterCommandEntry(t, 7), raftentry.RequestMetadataV1{AckPolicy: iwire.AckRaftCommitted})
+	if !errors.Is(err, ErrCommitNotProven) {
+		t.Fatalf("SubmitCommandEntryV1 err=%v want commit-not-proven", err)
+	}
+	if got := len(applier.snapshot()); got != 0 {
+		t.Fatalf("apply calls=%d want 0", got)
+	}
+}
+
+func TestSingleGroupSubmitterRequiresLocalRecoverability(t *testing.T) {
+	applier := &recordingClusterApplier{
+		result: raftentry.ApplyResultV1{Status: raftentry.ApplyStatusDeterministicGuardFailure, DeterministicErrorCode: raftentry.ErrorUnsafeDurabilityModeV1},
+		err:    fmt.Errorf("local coverage missing"),
+	}
+	submitter := newTestSingleGroupSubmitter(t, SingleGroupSubmitterOptions{
+		AdmissionProvider: StaticAdmissionProvider{Status: LeaderAdmission()},
+		CommitSource: NewSequencedCommitSource(SequencedCommitSourceOptions{
+			GroupID:             "group-a",
+			NodeID:              "node-a",
+			EvidenceKind:        CommitEvidenceProductionConsensusV1,
+			ProductionConsensus: true,
+		}),
+		Applier:                applier,
+		CatalogVersionProvider: staticCatalogVersion(7),
+	})
+
+	result, err := submitter.SubmitCommandEntryV1(context.Background(), testClusterCommandEntry(t, 7), raftentry.RequestMetadataV1{AckPolicy: iwire.AckRaftCommitted})
+	if !errors.Is(err, ErrLocalApplyNotRecoverable) {
+		t.Fatalf("SubmitCommandEntryV1 err=%v want local-apply-not-recoverable", err)
+	}
+	if result.CommittedRecoverable {
+		t.Fatal("failed local apply reported committed recoverable")
+	}
+	if got := len(applier.snapshot()); got != 1 {
+		t.Fatalf("apply calls=%d want 1", got)
+	}
+}
+
+type recordingClusterApplier struct {
+	entries []CommittedCommandEntryV1
+	result  raftentry.ApplyResultV1
+	err     error
+	hook    func(CommittedCommandEntryV1)
+}
+
+func (a *recordingClusterApplier) ApplyCommittedCommandEntryV1(ctx context.Context, entry CommittedCommandEntryV1) (raftentry.ApplyResultV1, error) {
+	clone := entry.Clone()
+	a.entries = append(a.entries, clone)
+	if a.hook != nil {
+		a.hook(clone)
+	}
+	return a.result, a.err
+}
+
+func (a *recordingClusterApplier) snapshot() []CommittedCommandEntryV1 {
+	out := make([]CommittedCommandEntryV1, len(a.entries))
+	for i := range a.entries {
+		out[i] = a.entries[i].Clone()
+	}
+	return out
+}
+
+func newTestSingleGroupSubmitter(tb testing.TB, opts SingleGroupSubmitterOptions) *SingleGroupSubmitter {
+	tb.Helper()
+	root := tb.TempDir()
+	opts.Cluster = Config{
+		Dir:     filepath.Join(root, "db"),
+		NodeID:  "node-a",
+		GroupID: "group-a",
+		Peers: []Peer{
+			{ID: "node-a", Address: "127.0.0.1:7000"},
+			{ID: "node-b", Address: "127.0.0.1:7001"},
+			{ID: "node-c", Address: "127.0.0.1:7002"},
+		},
+	}
+	submitter, err := NewSingleGroupSubmitter(opts)
+	if err != nil {
+		tb.Fatalf("NewSingleGroupSubmitter: %v", err)
+	}
+	return submitter
+}
+
+func staticCatalogVersion(version uint64) CatalogVersionProvider {
+	return CatalogVersionProviderFunc(func(context.Context) (uint64, bool, error) {
+		return version, true, nil
+	})
+}
+
+func testClusterCommandEntry(tb testing.TB, catalogVersion uint64) []byte {
+	tb.Helper()
+	sections := []iwire.Section{
+		{ID: iwire.SectionCommandHeader, Bytes: iwire.AppendCommandHeader(nil, iwire.CommandHeader{ID: iwire.CommandInsertBatch, Version: 1})},
+		{ID: iwire.SectionIdempotencyKey, Bytes: []byte("raftcluster/insert/u1")},
+		{ID: iwire.SectionExpectedCatalogVersion, Bytes: binary.AppendUvarint(nil, catalogVersion)},
+		{ID: iwire.SectionCollectionRef, Bytes: append([]byte{1}, "users"...)},
+		{ID: iwire.SectionDocumentFormat, Bytes: binary.AppendUvarint(nil, uint64(iwire.DocumentFormatJSON))},
+		{ID: iwire.SectionDocumentIDs, Bytes: iwire.AppendByteVector(nil, []byte("u1"))},
+		{ID: iwire.SectionDocuments, Bytes: iwire.AppendByteVector(nil, []byte(`{"name":"Ada"}`))},
+	}
+	cmd, err := iwire.MustV1Registry().ValidateRequestSections(sections)
+	if err != nil {
+		tb.Fatalf("ValidateRequestSections: %v", err)
+	}
+	entry, err := iwire.AppendDeterministicEntry(nil, cmd)
+	if err != nil {
+		tb.Fatalf("AppendDeterministicEntry: %v", err)
+	}
+	return entry
+}

--- a/TreeDB/internal/raftcluster/submit_test.go
+++ b/TreeDB/internal/raftcluster/submit_test.go
@@ -158,6 +158,41 @@ func TestSingleGroupSubmitterRejectsUnsatisfiedLocalAckBeforeCommitApply(t *test
 	}
 }
 
+func TestSingleGroupSubmitterRejectsRaftCommittedWhenLocalCommandWALSyncDisabled(t *testing.T) {
+	entry := testClusterCommandEntry(t, 7)
+	preflightCalls := 0
+	commitCalls := 0
+	applier := &recordingClusterApplier{result: raftentry.ApplyResultV1{Status: raftentry.ApplyStatusApplied, AffectedCount: 1}}
+	submitter := newTestSingleGroupSubmitter(t, SingleGroupSubmitterOptions{
+		AdmissionProvider: StaticAdmissionProvider{Status: LeaderAdmission()},
+		CommitSource: CommitSourceFunc(func(context.Context, CommitCommandEntryV1Request) (CommitCommandEntryV1Result, error) {
+			commitCalls++
+			return CommitCommandEntryV1Result{}, nil
+		}),
+		Preflight: CommandEntryPreflightFunc(func(context.Context, CommandEntryPreflightRequestV1) error {
+			preflightCalls++
+			return nil
+		}),
+		Applier:                    applier,
+		CatalogVersionProvider:     staticCatalogVersion(7),
+		DisableLocalCommandWALSync: true,
+	})
+
+	_, err := submitter.SubmitCommandEntryV1(context.Background(), entry, raftentry.RequestMetadataV1{AckPolicy: iwire.AckRaftCommitted})
+	if !errors.Is(err, ErrLocalAckUnavailable) {
+		t.Fatalf("SubmitCommandEntryV1 err=%v want local ack unavailable", err)
+	}
+	if preflightCalls != 0 {
+		t.Fatalf("preflight calls=%d want 0", preflightCalls)
+	}
+	if commitCalls != 0 {
+		t.Fatalf("commit calls=%d want 0", commitCalls)
+	}
+	if got := len(applier.snapshot()); got != 0 {
+		t.Fatalf("apply calls=%d want 0", got)
+	}
+}
+
 func TestSingleGroupSubmitterRejectsStaleCatalogGuardBeforeCommitApply(t *testing.T) {
 	entry := testClusterCommandEntry(t, 6)
 	commitCalls := 0

--- a/TreeDB/internal/raftcluster/submit_test.go
+++ b/TreeDB/internal/raftcluster/submit_test.go
@@ -126,6 +126,36 @@ func TestSingleGroupSubmitterRejectsUnsupportedAckBeforeCommitApply(t *testing.T
 	}
 }
 
+func TestSingleGroupSubmitterRejectsUnsatisfiedLocalAckBeforeCommitApply(t *testing.T) {
+	for _, ack := range []iwire.AckPolicy{iwire.AckFlushed, iwire.AckSynced} {
+		t.Run(fmt.Sprintf("ack_%d", ack), func(t *testing.T) {
+			entry := testClusterCommandEntry(t, 7)
+			commitCalls := 0
+			applier := &recordingClusterApplier{result: raftentry.ApplyResultV1{Status: raftentry.ApplyStatusApplied, AffectedCount: 1}}
+			submitter := newTestSingleGroupSubmitter(t, SingleGroupSubmitterOptions{
+				AdmissionProvider: StaticAdmissionProvider{Status: LeaderAdmission()},
+				CommitSource: CommitSourceFunc(func(context.Context, CommitCommandEntryV1Request) (CommitCommandEntryV1Result, error) {
+					commitCalls++
+					return CommitCommandEntryV1Result{}, nil
+				}),
+				Applier:                applier,
+				CatalogVersionProvider: staticCatalogVersion(7),
+			})
+
+			_, err := submitter.SubmitCommandEntryV1(context.Background(), entry, raftentry.RequestMetadataV1{AckPolicy: ack})
+			if !errors.Is(err, ErrLocalAckUnavailable) {
+				t.Fatalf("SubmitCommandEntryV1 err=%v want local ack unavailable", err)
+			}
+			if commitCalls != 0 {
+				t.Fatalf("commit calls=%d want 0", commitCalls)
+			}
+			if got := len(applier.snapshot()); got != 0 {
+				t.Fatalf("apply calls=%d want 0", got)
+			}
+		})
+	}
+}
+
 func TestSingleGroupSubmitterRejectsStaleCatalogGuardBeforeCommitApply(t *testing.T) {
 	entry := testClusterCommandEntry(t, 6)
 	commitCalls := 0

--- a/TreeDB/internal/raftcluster/submit_test.go
+++ b/TreeDB/internal/raftcluster/submit_test.go
@@ -212,6 +212,45 @@ func TestSingleGroupSubmitterRequiresLocalRecoverability(t *testing.T) {
 	}
 }
 
+func TestSingleGroupSubmitterRejectsMissingPostApplyCatalogVersion(t *testing.T) {
+	applier := &recordingClusterApplier{result: raftentry.ApplyResultV1{Status: raftentry.ApplyStatusApplied, AffectedCount: 1}}
+	catalogCalls := 0
+	submitter := newTestSingleGroupSubmitter(t, SingleGroupSubmitterOptions{
+		AdmissionProvider: StaticAdmissionProvider{Status: LeaderAdmission()},
+		CommitSource: NewSequencedCommitSource(SequencedCommitSourceOptions{
+			GroupID:             "group-a",
+			NodeID:              "node-a",
+			EvidenceKind:        CommitEvidenceProductionConsensusV1,
+			ProductionConsensus: true,
+		}),
+		Applier: applier,
+		CatalogVersionProvider: CatalogVersionProviderFunc(func(context.Context) (uint64, bool, error) {
+			catalogCalls++
+			if catalogCalls == 1 {
+				return 7, true, nil
+			}
+			return 0, false, nil
+		}),
+	})
+
+	result, err := submitter.SubmitCommandEntryV1(context.Background(), testClusterCommandEntry(t, 7), raftentry.RequestMetadataV1{AckPolicy: iwire.AckRaftCommitted})
+	if !errors.Is(err, ErrLocalApplyNotRecoverable) || !errors.Is(err, ErrMissingCatalogVersion) {
+		t.Fatalf("SubmitCommandEntryV1 err=%v want local-apply-not-recoverable and missing-catalog-version", err)
+	}
+	if result.CommittedRecoverable {
+		t.Fatal("missing post-apply catalog version reported committed recoverable")
+	}
+	if result.HasCatalogVersion {
+		t.Fatalf("result HasCatalogVersion=%v want false", result.HasCatalogVersion)
+	}
+	if got := len(applier.snapshot()); got != 1 {
+		t.Fatalf("apply calls=%d want 1", got)
+	}
+	if catalogCalls != 2 {
+		t.Fatalf("catalog calls=%d want 2", catalogCalls)
+	}
+}
+
 type recordingClusterApplier struct {
 	entries []CommittedCommandEntryV1
 	result  raftentry.ApplyResultV1

--- a/TreeDB/internal/raftcluster/submit_test.go
+++ b/TreeDB/internal/raftcluster/submit_test.go
@@ -182,6 +182,50 @@ func TestSingleGroupSubmitterRejectsStaleCatalogGuardBeforeCommitApply(t *testin
 	}
 }
 
+func TestSingleGroupSubmitterPreflightsBeforeCommitApply(t *testing.T) {
+	entry := testClusterCommandEntry(t, 7)
+	commitCalls := 0
+	preflightCalls := 0
+	preflightErr := errors.New("missing collection preflight")
+	applier := &recordingClusterApplier{result: raftentry.ApplyResultV1{Status: raftentry.ApplyStatusApplied, AffectedCount: 1}}
+	submitter := newTestSingleGroupSubmitter(t, SingleGroupSubmitterOptions{
+		AdmissionProvider: StaticAdmissionProvider{Status: LeaderAdmission()},
+		CommitSource: CommitSourceFunc(func(context.Context, CommitCommandEntryV1Request) (CommitCommandEntryV1Result, error) {
+			commitCalls++
+			return CommitCommandEntryV1Result{}, nil
+		}),
+		Preflight: CommandEntryPreflightFunc(func(ctx context.Context, req CommandEntryPreflightRequestV1) error {
+			preflightCalls++
+			if req.GroupID != "group-a" || req.NodeID != "node-a" {
+				t.Fatalf("preflight group/node=%q/%q want group-a/node-a", req.GroupID, req.NodeID)
+			}
+			if req.DecodedEntry.Target.CommandID != iwire.CommandInsertBatch {
+				t.Fatalf("preflight command=%d want insert_batch", req.DecodedEntry.Target.CommandID)
+			}
+			if req.CurrentCatalogVersion != 7 || !req.HasCurrentCatalogVersion {
+				t.Fatalf("preflight catalog=%d/%v want 7/true", req.CurrentCatalogVersion, req.HasCurrentCatalogVersion)
+			}
+			return preflightErr
+		}),
+		Applier:                applier,
+		CatalogVersionProvider: staticCatalogVersion(7),
+	})
+
+	_, err := submitter.SubmitCommandEntryV1(context.Background(), entry, raftentry.RequestMetadataV1{AckPolicy: iwire.AckRaftCommitted})
+	if !errors.Is(err, preflightErr) {
+		t.Fatalf("SubmitCommandEntryV1 err=%v want preflight error", err)
+	}
+	if preflightCalls != 1 {
+		t.Fatalf("preflight calls=%d want 1", preflightCalls)
+	}
+	if commitCalls != 0 {
+		t.Fatalf("commit calls=%d want 0", commitCalls)
+	}
+	if got := len(applier.snapshot()); got != 0 {
+		t.Fatalf("apply calls=%d want 0", got)
+	}
+}
+
 func TestSingleGroupSubmitterAdmissionRejectsBeforeCommitApply(t *testing.T) {
 	for _, tc := range []struct {
 		name    string
@@ -343,6 +387,11 @@ func newTestSingleGroupSubmitter(tb testing.TB, opts SingleGroupSubmitterOptions
 			{ID: "node-b", Address: "127.0.0.1:7001"},
 			{ID: "node-c", Address: "127.0.0.1:7002"},
 		},
+	}
+	if opts.Preflight == nil {
+		opts.Preflight = CommandEntryPreflightFunc(func(context.Context, CommandEntryPreflightRequestV1) error {
+			return nil
+		})
 	}
 	submitter, err := NewSingleGroupSubmitter(opts)
 	if err != nil {

--- a/TreeDB/internal/raftentry/contract.go
+++ b/TreeDB/internal/raftentry/contract.go
@@ -114,6 +114,7 @@ type ApplyResultV1 struct {
 	CommandDigest          CommandDigestV1
 	DeterministicErrorCode DeterministicErrorCodeV1
 	AffectedCount          int64
+	MatchedCount           int64
 	ResultDigest           CommandDigestV1
 }
 

--- a/TreeDB/internal/raftfsm/cluster_adapter.go
+++ b/TreeDB/internal/raftfsm/cluster_adapter.go
@@ -3,9 +3,63 @@ package raftfsm
 import (
 	"context"
 
+	"github.com/snissn/gomap/TreeDB/internal/raftapply"
 	"github.com/snissn/gomap/TreeDB/internal/raftcluster"
 	"github.com/snissn/gomap/TreeDB/internal/raftentry"
 )
+
+// PreflightCommandEntryV1 adapts the raftcluster pre-commit deterministic
+// preflight request into the local FSM apply preflight shape.
+func (f *FSM) PreflightCommandEntryV1(ctx context.Context, req raftcluster.CommandEntryPreflightRequestV1) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+	if f == nil {
+		return codedError(raftentry.ErrorUnsafeDurabilityModeV1, "FSM is not open")
+	}
+	if f.closed {
+		return codedError(raftentry.ErrorUnsafeDurabilityModeV1, "FSM is closed")
+	}
+	if f.db == nil {
+		return codedError(raftentry.ErrorUnsafeDurabilityModeV1, "FSM is not open")
+	}
+	if req.GroupID != "" && req.GroupID != f.cluster.GroupID {
+		return codedError(raftentry.ErrorRejectedConflictV1, "preflight group %q does not match local group %q", req.GroupID, f.cluster.GroupID)
+	}
+	if req.NodeID != "" && req.NodeID != f.cluster.NodeID {
+		return codedError(raftentry.ErrorRejectedConflictV1, "preflight node %q does not match local node %q", req.NodeID, f.cluster.NodeID)
+	}
+	if len(req.EntryBytes) == 0 {
+		return codedError(raftentry.ErrorMalformedEntryV1, "empty command entry")
+	}
+	meta := raftapply.ApplyMetadataV1{
+		LocalDurabilityBoundary:  raftapply.LocalDurabilityCommandWALV1,
+		SyncLocalCommandWAL:      req.SyncLocalCommandWAL,
+		CurrentCatalogVersion:    req.CurrentCatalogVersion,
+		HasCurrentCatalogVersion: req.HasCurrentCatalogVersion,
+		ScopeRule:                f.scopeRule,
+		DatabaseScope:            f.database,
+		CatalogScope:             f.catalog,
+		RequestMetadata:          cloneRequestMetadataV1(req.RequestMetadata),
+		ExpectedTarget:           cloneExpectedTargetV1(req.ExpectedTarget),
+	}
+	opts := raftapply.Options{DecodeLimits: f.decodeLimits}
+	if len(req.DecodedEntry.Bytes) != 0 {
+		if err := raftapply.PreflightDecodedCommandEntryV1(f.db, req.DecodedEntry, meta, opts); err != nil {
+			return err
+		}
+		return nil
+	}
+	if err := raftapply.PreflightCommandEntryV1(f.db, req.EntryBytes, meta, opts); err != nil {
+		return err
+	}
+	return nil
+}
 
 // ApplyCommittedCommandEntryV1 adapts the raftcluster provider-delivered
 // committed command shape into the local FSM committed-entry shape.

--- a/TreeDB/internal/raftfsm/cluster_adapter.go
+++ b/TreeDB/internal/raftfsm/cluster_adapter.go
@@ -49,7 +49,7 @@ func (f *FSM) PreflightCommandEntryV1(ctx context.Context, req raftcluster.Comma
 		RequestMetadata:          cloneRequestMetadataV1(req.RequestMetadata),
 		ExpectedTarget:           cloneExpectedTargetV1(req.ExpectedTarget),
 	}
-	opts := raftapply.Options{DecodeLimits: f.decodeLimits}
+	opts := raftapply.Options{DecodeLimits: f.decodeLimits, ResultStore: f.results}
 	if len(req.DecodedEntry.Bytes) != 0 {
 		if !bytes.Equal(req.DecodedEntry.Bytes, req.EntryBytes) {
 			return codedError(raftentry.ErrorMalformedEntryV1, "decoded command entry does not match raw entry bytes")

--- a/TreeDB/internal/raftfsm/cluster_adapter.go
+++ b/TreeDB/internal/raftfsm/cluster_adapter.go
@@ -11,32 +11,32 @@ import (
 
 // PreflightCommandEntryV1 adapts the raftcluster pre-commit deterministic
 // preflight request into the local FSM apply preflight shape.
-func (f *FSM) PreflightCommandEntryV1(ctx context.Context, req raftcluster.CommandEntryPreflightRequestV1) error {
+func (f *FSM) PreflightCommandEntryV1(ctx context.Context, req raftcluster.CommandEntryPreflightRequestV1) (raftcluster.CommandEntryPreflightResultV1, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
 	select {
 	case <-ctx.Done():
-		return ctx.Err()
+		return raftcluster.CommandEntryPreflightResultV1{}, ctx.Err()
 	default:
 	}
 	if f == nil {
-		return codedError(raftentry.ErrorUnsafeDurabilityModeV1, "FSM is not open")
+		return raftcluster.CommandEntryPreflightResultV1{}, codedError(raftentry.ErrorUnsafeDurabilityModeV1, "FSM is not open")
 	}
 	if f.closed {
-		return codedError(raftentry.ErrorUnsafeDurabilityModeV1, "FSM is closed")
+		return raftcluster.CommandEntryPreflightResultV1{}, codedError(raftentry.ErrorUnsafeDurabilityModeV1, "FSM is closed")
 	}
 	if f.db == nil {
-		return codedError(raftentry.ErrorUnsafeDurabilityModeV1, "FSM is not open")
+		return raftcluster.CommandEntryPreflightResultV1{}, codedError(raftentry.ErrorUnsafeDurabilityModeV1, "FSM is not open")
 	}
 	if req.GroupID != "" && req.GroupID != f.cluster.GroupID {
-		return codedError(raftentry.ErrorRejectedConflictV1, "preflight group %q does not match local group %q", req.GroupID, f.cluster.GroupID)
+		return raftcluster.CommandEntryPreflightResultV1{}, codedError(raftentry.ErrorRejectedConflictV1, "preflight group %q does not match local group %q", req.GroupID, f.cluster.GroupID)
 	}
 	if req.NodeID != "" && req.NodeID != f.cluster.NodeID {
-		return codedError(raftentry.ErrorRejectedConflictV1, "preflight node %q does not match local node %q", req.NodeID, f.cluster.NodeID)
+		return raftcluster.CommandEntryPreflightResultV1{}, codedError(raftentry.ErrorRejectedConflictV1, "preflight node %q does not match local node %q", req.NodeID, f.cluster.NodeID)
 	}
 	if len(req.EntryBytes) == 0 {
-		return codedError(raftentry.ErrorMalformedEntryV1, "empty command entry")
+		return raftcluster.CommandEntryPreflightResultV1{}, codedError(raftentry.ErrorMalformedEntryV1, "empty command entry")
 	}
 	meta := raftapply.ApplyMetadataV1{
 		LocalDurabilityBoundary:  raftapply.LocalDurabilityCommandWALV1,
@@ -50,19 +50,20 @@ func (f *FSM) PreflightCommandEntryV1(ctx context.Context, req raftcluster.Comma
 		ExpectedTarget:           cloneExpectedTargetV1(req.ExpectedTarget),
 	}
 	opts := raftapply.Options{DecodeLimits: f.decodeLimits, ResultStore: f.results}
+	var result raftapply.PreflightResultV1
+	var err error
 	if len(req.DecodedEntry.Bytes) != 0 {
 		if !bytes.Equal(req.DecodedEntry.Bytes, req.EntryBytes) {
-			return codedError(raftentry.ErrorMalformedEntryV1, "decoded command entry does not match raw entry bytes")
+			return raftcluster.CommandEntryPreflightResultV1{}, codedError(raftentry.ErrorMalformedEntryV1, "decoded command entry does not match raw entry bytes")
 		}
-		if err := raftapply.PreflightDecodedCommandEntryV1(f.db, req.DecodedEntry, meta, opts); err != nil {
-			return err
-		}
-		return nil
+		result, err = raftapply.PreflightDecodedCommandEntryV1(f.db, req.DecodedEntry, meta, opts)
+	} else {
+		result, err = raftapply.PreflightCommandEntryV1(f.db, req.EntryBytes, meta, opts)
 	}
-	if err := raftapply.PreflightCommandEntryV1(f.db, req.EntryBytes, meta, opts); err != nil {
-		return err
+	if err != nil {
+		return raftcluster.CommandEntryPreflightResultV1{}, err
 	}
-	return nil
+	return raftcluster.CommandEntryPreflightResultV1{KnownIdempotencyReplay: result.KnownIdempotencyReplay}, nil
 }
 
 // ApplyCommittedCommandEntryV1 adapts the raftcluster provider-delivered

--- a/TreeDB/internal/raftfsm/cluster_adapter.go
+++ b/TreeDB/internal/raftfsm/cluster_adapter.go
@@ -1,0 +1,28 @@
+package raftfsm
+
+import (
+	"context"
+
+	"github.com/snissn/gomap/TreeDB/internal/raftcluster"
+	"github.com/snissn/gomap/TreeDB/internal/raftentry"
+)
+
+// ApplyCommittedCommandEntryV1 adapts the raftcluster provider-delivered
+// committed command shape into the local FSM committed-entry shape.
+func (f *FSM) ApplyCommittedCommandEntryV1(ctx context.Context, entry raftcluster.CommittedCommandEntryV1) (raftentry.ApplyResultV1, error) {
+	return f.ApplyCommittedEntryV1(CommittedEntryFromClusterV1(entry))
+}
+
+func CommittedEntryFromClusterV1(entry raftcluster.CommittedCommandEntryV1) CommittedEntryV1 {
+	return CommittedEntryV1{
+		Type:                     EntryTypeCommandEntryV1,
+		Term:                     entry.Term,
+		Index:                    entry.Index,
+		Bytes:                    append([]byte(nil), entry.Bytes...),
+		CurrentCatalogVersion:    entry.CurrentCatalogVersion,
+		HasCurrentCatalogVersion: entry.HasCurrentCatalogVersion,
+		SyncLocalCommandWAL:      entry.SyncLocalCommandWAL,
+		RequestMetadata:          cloneRequestMetadataV1(entry.RequestMetadata),
+		ExpectedTarget:           cloneExpectedTargetV1(entry.ExpectedTarget),
+	}
+}

--- a/TreeDB/internal/raftfsm/cluster_adapter.go
+++ b/TreeDB/internal/raftfsm/cluster_adapter.go
@@ -1,6 +1,7 @@
 package raftfsm
 
 import (
+	"bytes"
 	"context"
 
 	"github.com/snissn/gomap/TreeDB/internal/raftapply"
@@ -50,6 +51,9 @@ func (f *FSM) PreflightCommandEntryV1(ctx context.Context, req raftcluster.Comma
 	}
 	opts := raftapply.Options{DecodeLimits: f.decodeLimits}
 	if len(req.DecodedEntry.Bytes) != 0 {
+		if !bytes.Equal(req.DecodedEntry.Bytes, req.EntryBytes) {
+			return codedError(raftentry.ErrorMalformedEntryV1, "decoded command entry does not match raw entry bytes")
+		}
 		if err := raftapply.PreflightDecodedCommandEntryV1(f.db, req.DecodedEntry, meta, opts); err != nil {
 			return err
 		}

--- a/TreeDB/internal/raftfsm/cluster_adapter_test.go
+++ b/TreeDB/internal/raftfsm/cluster_adapter_test.go
@@ -1,0 +1,99 @@
+package raftfsm
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/collections"
+	"github.com/snissn/gomap/TreeDB/internal/raftcluster"
+	"github.com/snissn/gomap/TreeDB/internal/raftentry"
+)
+
+func TestClusterAdapterAppliesProviderCommittedEntryDurably(t *testing.T) {
+	root := t.TempDir()
+	dbDir := filepath.Join(root, "db")
+
+	db := openFSMTestDB(t, dbDir)
+	fsm := openFSMForTest(t, db, dbDir)
+	raw := deterministicCreateCollectionEntry(t, "users", "fsm:cluster-adapter:create:users")
+	entry := clusterCommittedCommand(2, 1, raw)
+
+	result, err := fsm.ApplyCommittedCommandEntryV1(context.Background(), entry)
+	if err != nil {
+		t.Fatalf("ApplyCommittedCommandEntryV1: %v result=%+v", err, result)
+	}
+	assertApplied(t, result, raftentry.ApplyStatusApplied, 1)
+	if _, err := collections.NewCollectionManager(db).OpenCollection("users"); err != nil {
+		t.Fatalf("OpenCollection users: %v", err)
+	}
+	if err := fsm.Close(); err != nil {
+		t.Fatalf("Close FSM: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("Close DB: %v", err)
+	}
+
+	reopenedDB := openFSMTestDB(t, dbDir)
+	defer func() { _ = reopenedDB.Close() }()
+	reopenedFSM := openFSMForTest(t, reopenedDB, dbDir)
+	defer func() { _ = reopenedFSM.Close() }()
+	assertLastApplied(t, reopenedFSM, raftentry.ApplyEntryID{Term: 2, Index: 1})
+	if _, err := collections.NewCollectionManager(reopenedDB).OpenCollection("users"); err != nil {
+		t.Fatalf("OpenCollection users after reopen: %v", err)
+	}
+
+	replayed, err := reopenedFSM.ApplyCommittedCommandEntryV1(context.Background(), entry)
+	if err != nil {
+		t.Fatalf("ApplyCommittedCommandEntryV1 replay: %v result=%+v", err, replayed)
+	}
+	if replayed != result {
+		t.Fatalf("replayed result=%+v want stored %+v", replayed, result)
+	}
+	duplicate, err := reopenedFSM.ApplyCommittedCommandEntryV1(context.Background(), clusterCommittedCommand(2, 2, raw))
+	if err != nil {
+		t.Fatalf("ApplyCommittedCommandEntryV1 duplicate idempotency replay: %v result=%+v", err, duplicate)
+	}
+	if duplicate.Status != raftentry.ApplyStatusAlreadyApplied || duplicate.ResultDigest != result.ResultDigest {
+		t.Fatalf("duplicate result=%+v want already-applied with original digest %s", duplicate, result.ResultDigest.Hex())
+	}
+}
+
+func TestClusterAdapterPreservesOrderingRejections(t *testing.T) {
+	root := t.TempDir()
+	dbDir := filepath.Join(root, "db")
+
+	db := openFSMTestDB(t, dbDir)
+	defer func() { _ = db.Close() }()
+	fsm := openFSMForTest(t, db, dbDir)
+	defer func() { _ = fsm.Close() }()
+
+	firstRaw := deterministicCreateCollectionEntry(t, "users", "fsm:cluster-adapter:ordering:users")
+	first, err := fsm.ApplyCommittedCommandEntryV1(context.Background(), clusterCommittedCommand(2, 1, firstRaw))
+	if err != nil {
+		t.Fatalf("ApplyCommittedCommandEntryV1 first: %v result=%+v", err, first)
+	}
+	assertApplied(t, first, raftentry.ApplyStatusApplied, 1)
+
+	gapRaw := deterministicCreateCollectionEntry(t, "orders", "fsm:cluster-adapter:ordering:gap")
+	gap, err := fsm.ApplyCommittedCommandEntryV1(context.Background(), clusterCommittedCommand(2, 3, gapRaw))
+	assertRejected(t, gap, err, raftentry.ApplyStatusRejectedConflict, raftentry.ErrorRejectedConflictV1)
+
+	regressionRaw := deterministicCreateCollectionEntry(t, "orders", "fsm:cluster-adapter:ordering:term")
+	regression, err := fsm.ApplyCommittedCommandEntryV1(context.Background(), clusterCommittedCommand(1, 2, regressionRaw))
+	assertRejected(t, regression, err, raftentry.ApplyStatusRejectedConflict, raftentry.ErrorRejectedConflictV1)
+}
+
+func clusterCommittedCommand(term, index uint64, raw []byte) raftcluster.CommittedCommandEntryV1 {
+	targetEntry := committedCommand(term, index, raw)
+	return raftcluster.CommittedCommandEntryV1{
+		Term:                     targetEntry.Term,
+		Index:                    targetEntry.Index,
+		Bytes:                    targetEntry.Bytes,
+		CurrentCatalogVersion:    targetEntry.CurrentCatalogVersion,
+		HasCurrentCatalogVersion: targetEntry.HasCurrentCatalogVersion,
+		SyncLocalCommandWAL:      true,
+		RequestMetadata:          targetEntry.RequestMetadata,
+		ExpectedTarget:           targetEntry.ExpectedTarget,
+	}
+}

--- a/TreeDB/internal/raftfsm/cluster_adapter_test.go
+++ b/TreeDB/internal/raftfsm/cluster_adapter_test.go
@@ -77,7 +77,7 @@ func TestClusterAdapterPreflightRejectsDecodedRawMismatch(t *testing.T) {
 		t.Fatalf("DecodeCommandEntryV1 decodedRaw: %v", err)
 	}
 
-	err = fsm.PreflightCommandEntryV1(context.Background(), raftcluster.CommandEntryPreflightRequestV1{
+	_, err = fsm.PreflightCommandEntryV1(context.Background(), raftcluster.CommandEntryPreflightRequestV1{
 		GroupID:                  fsm.cluster.GroupID,
 		NodeID:                   fsm.cluster.NodeID,
 		EntryBytes:               raw,
@@ -119,7 +119,7 @@ func TestClusterAdapterPreflightAllowsKnownIdempotencyReplay(t *testing.T) {
 	}
 
 	for _, currentCatalogVersion := range []uint64{testCatalogVersionStart, testCatalogVersionStart + 1} {
-		err := fsm.PreflightCommandEntryV1(context.Background(), raftcluster.CommandEntryPreflightRequestV1{
+		result, err := fsm.PreflightCommandEntryV1(context.Background(), raftcluster.CommandEntryPreflightRequestV1{
 			GroupID:                  fsm.cluster.GroupID,
 			NodeID:                   fsm.cluster.NodeID,
 			EntryBytes:               insert,
@@ -130,6 +130,9 @@ func TestClusterAdapterPreflightAllowsKnownIdempotencyReplay(t *testing.T) {
 		})
 		if err != nil {
 			t.Fatalf("PreflightCommandEntryV1 known retry catalog %d: %v", currentCatalogVersion, err)
+		}
+		if !result.KnownIdempotencyReplay {
+			t.Fatalf("PreflightCommandEntryV1 known retry catalog %d replay=%v want true", currentCatalogVersion, result.KnownIdempotencyReplay)
 		}
 	}
 }

--- a/TreeDB/internal/raftfsm/cluster_adapter_test.go
+++ b/TreeDB/internal/raftfsm/cluster_adapter_test.go
@@ -6,8 +6,10 @@ import (
 	"testing"
 
 	"github.com/snissn/gomap/TreeDB/collections"
+	"github.com/snissn/gomap/TreeDB/internal/nativewire"
 	"github.com/snissn/gomap/TreeDB/internal/raftcluster"
 	"github.com/snissn/gomap/TreeDB/internal/raftentry"
+	"go.mongodb.org/mongo-driver/v2/bson"
 )
 
 func TestClusterAdapterAppliesProviderCommittedEntryDurably(t *testing.T) {
@@ -86,6 +88,49 @@ func TestClusterAdapterPreflightRejectsDecodedRawMismatch(t *testing.T) {
 	})
 	if code, ok := ErrorCodeOf(err); !ok || code != raftentry.ErrorMalformedEntryV1 {
 		t.Fatalf("PreflightCommandEntryV1 mismatch code=(%s,%t) err=%v, want malformed", code, ok, err)
+	}
+}
+
+func TestClusterAdapterPreflightAllowsKnownIdempotencyReplay(t *testing.T) {
+	root := t.TempDir()
+	dbDir := filepath.Join(root, "db")
+
+	db := openFSMTestDB(t, dbDir)
+	defer func() { _ = db.Close() }()
+	fsm := openFSMForTest(t, db, dbDir)
+	defer func() { _ = fsm.Close() }()
+
+	create := deterministicCreateCollectionEntryWithOptions(t, "users", "fsm:cluster-adapter:preflight-replay:create", testCreateCollectionMetaOptions{
+		documentFormat: uint64(nativewire.DocumentFormatBSON),
+	})
+	if result, err := fsm.ApplyCommittedCommandEntryV1(context.Background(), clusterCommittedCommand(2, 1, create)); err != nil {
+		t.Fatalf("ApplyCommittedCommandEntryV1 create: %v result=%+v", err, result)
+	}
+	doc := testBSONDocument(t, bson.D{{Key: "_id", Value: "u1"}, {Key: "city", Value: "hnl"}})
+	insert := deterministicInsertBatchEntry(t, "users", "fsm:cluster-adapter:preflight-replay:insert", nativewire.DocumentFormatBSON, [][]byte{[]byte("u1")}, [][]byte{doc})
+	insertResult, err := fsm.ApplyCommittedCommandEntryV1(context.Background(), clusterCommittedCommand(2, 2, insert))
+	if err != nil {
+		t.Fatalf("ApplyCommittedCommandEntryV1 insert: %v result=%+v", err, insertResult)
+	}
+	assertApplied(t, insertResult, raftentry.ApplyStatusApplied, 1)
+	decoded, err := raftentry.DecodeCommandEntryV1(insert, raftentry.DecodeOptions{})
+	if err != nil {
+		t.Fatalf("DecodeCommandEntryV1 insert: %v", err)
+	}
+
+	for _, currentCatalogVersion := range []uint64{testCatalogVersionStart, testCatalogVersionStart + 1} {
+		err := fsm.PreflightCommandEntryV1(context.Background(), raftcluster.CommandEntryPreflightRequestV1{
+			GroupID:                  fsm.cluster.GroupID,
+			NodeID:                   fsm.cluster.NodeID,
+			EntryBytes:               insert,
+			DecodedEntry:             decoded,
+			CurrentCatalogVersion:    currentCatalogVersion,
+			HasCurrentCatalogVersion: true,
+			SyncLocalCommandWAL:      true,
+		})
+		if err != nil {
+			t.Fatalf("PreflightCommandEntryV1 known retry catalog %d: %v", currentCatalogVersion, err)
+		}
 	}
 }
 

--- a/TreeDB/internal/raftfsm/cluster_adapter_test.go
+++ b/TreeDB/internal/raftfsm/cluster_adapter_test.go
@@ -59,6 +59,36 @@ func TestClusterAdapterAppliesProviderCommittedEntryDurably(t *testing.T) {
 	}
 }
 
+func TestClusterAdapterPreflightRejectsDecodedRawMismatch(t *testing.T) {
+	root := t.TempDir()
+	dbDir := filepath.Join(root, "db")
+
+	db := openFSMTestDB(t, dbDir)
+	defer func() { _ = db.Close() }()
+	fsm := openFSMForTest(t, db, dbDir)
+	defer func() { _ = fsm.Close() }()
+
+	raw := deterministicCreateCollectionEntry(t, "users", "fsm:cluster-adapter:preflight-raw")
+	decodedRaw := deterministicCreateCollectionEntry(t, "orders", "fsm:cluster-adapter:preflight-decoded")
+	decoded, err := raftentry.DecodeCommandEntryV1(decodedRaw, raftentry.DecodeOptions{})
+	if err != nil {
+		t.Fatalf("DecodeCommandEntryV1 decodedRaw: %v", err)
+	}
+
+	err = fsm.PreflightCommandEntryV1(context.Background(), raftcluster.CommandEntryPreflightRequestV1{
+		GroupID:                  fsm.cluster.GroupID,
+		NodeID:                   fsm.cluster.NodeID,
+		EntryBytes:               raw,
+		DecodedEntry:             decoded,
+		CurrentCatalogVersion:    testCatalogVersionStart,
+		HasCurrentCatalogVersion: true,
+		SyncLocalCommandWAL:      true,
+	})
+	if code, ok := ErrorCodeOf(err); !ok || code != raftentry.ErrorMalformedEntryV1 {
+		t.Fatalf("PreflightCommandEntryV1 mismatch code=(%s,%t) err=%v, want malformed", code, ok, err)
+	}
+}
+
 func TestClusterAdapterPreservesOrderingRejections(t *testing.T) {
 	root := t.TempDir()
 	dbDir := filepath.Join(root, "db")

--- a/TreeDB/mongo_gateway/cluster_submitter_test.go
+++ b/TreeDB/mongo_gateway/cluster_submitter_test.go
@@ -12,8 +12,10 @@ import (
 	"github.com/snissn/gomap/TreeDB/collections"
 	backenddb "github.com/snissn/gomap/TreeDB/db"
 	iwire "github.com/snissn/gomap/TreeDB/internal/nativewire"
+	"github.com/snissn/gomap/TreeDB/internal/raftapply"
 	"github.com/snissn/gomap/TreeDB/internal/raftcluster"
 	"github.com/snissn/gomap/TreeDB/internal/raftentry"
+	"github.com/snissn/gomap/TreeDB/internal/raftfsm"
 	"github.com/snissn/gomap/TreeDB/internal/raftplacement"
 	"github.com/snissn/gomap/TreeDB/mongo_gateway/wire"
 	treenativewire "github.com/snissn/gomap/TreeDB/nativewire"
@@ -411,6 +413,89 @@ func newMongoPlacementRouteTestServer(tb testing.TB, mode raftplacement.Placemen
 	server.ClusterSubmitter = submitter
 	server.ClusterCatalogVersion = mongoClusterStaticCatalogVersion(60)
 	return server, submitter
+}
+
+func newMongoRaftBridgeTestServer(tb testing.TB, admission raftcluster.AdmissionStatus) *Server {
+	tb.Helper()
+	db, err := backenddb.Open(backenddb.Options{
+		Dir:                          tb.TempDir(),
+		CommandWAL:                   true,
+		CommandWALStatsScan:          true,
+		CommandWALSegmentTargetBytes: 1 << 20,
+		DisableBackgroundPrune:       true,
+	})
+	if err != nil {
+		tb.Fatalf("open command WAL db: %v", err)
+	}
+	cluster := mongoRaftBridgeTestConfig(db)
+	fsm, err := raftfsm.Open(raftfsm.Options{
+		DB:      db,
+		Cluster: cluster,
+		StoreOptions: raftapply.DurableApplyStoreOptions{
+			DisableSync: true,
+		},
+	})
+	if err != nil {
+		_ = db.Close()
+		tb.Fatalf("open raft FSM: %v", err)
+	}
+	bridge, err := raftcluster.NewSingleGroupSubmitter(raftcluster.SingleGroupSubmitterOptions{
+		Cluster:           cluster,
+		AdmissionProvider: raftcluster.StaticAdmissionProvider{Status: admission},
+		CommitSource: raftcluster.NewSequencedCommitSource(raftcluster.SequencedCommitSourceOptions{
+			GroupID:             cluster.GroupID,
+			NodeID:              cluster.NodeID,
+			LeaderID:            cluster.NodeID,
+			EvidenceKind:        raftcluster.CommitEvidenceProductionConsensusV1,
+			ProductionConsensus: true,
+		}),
+		Applier: fsm,
+		CatalogVersionProvider: raftcluster.CatalogVersionProviderFunc(func(context.Context) (uint64, bool, error) {
+			state := db.State()
+			if state == nil {
+				return 0, false, nil
+			}
+			return state.CommitSeq, true, nil
+		}),
+	})
+	if err != nil {
+		_ = fsm.Close()
+		_ = db.Close()
+		tb.Fatalf("NewSingleGroupSubmitter: %v", err)
+	}
+	server := NewServer()
+	server.Collections = collections.NewCollectionManager(db)
+	server.DefaultCollectionOptions = collections.CollectionOptions{DocumentFormat: collections.DocumentFormatBSON}
+	server.ClusterSubmitter = treenativewire.NewRaftClusterSubmitter(bridge)
+	server.ClusterCatalogVersion = func(context.Context) (uint64, error) {
+		state := db.State()
+		if state == nil {
+			return 0, errors.New("missing DB state")
+		}
+		return state.CommitSeq, nil
+	}
+	tb.Cleanup(func() {
+		_ = fsm.Close()
+		_ = db.Close()
+	})
+	return server
+}
+
+func mongoRaftBridgeTestConfig(db *backenddb.DB) raftcluster.Config {
+	dir := ""
+	if db != nil {
+		dir = db.Dir()
+	}
+	return raftcluster.Config{
+		Dir:     dir,
+		NodeID:  "node-a",
+		GroupID: "group-a",
+		Peers: []raftcluster.Peer{
+			{ID: "node-a", Address: "127.0.0.1:9401"},
+			{ID: "node-b", Address: "127.0.0.1:9402"},
+			{ID: "node-c", Address: "127.0.0.1:9403"},
+		},
+	}
 }
 
 func mustMongoRouteTestCatalog(tb testing.TB, mode raftplacement.PlacementModeV1) raftplacement.ResolvedCatalogV1 {
@@ -1359,6 +1444,22 @@ func TestClusterSubmitterWriteConcernAccepted(t *testing.T) {
 			assertMongoClusterCallAckPolicy(t, calls[0], tc.wantAck)
 		})
 	}
+}
+
+func TestClusterSubmitterConcreteBridgeMajorityInsert(t *testing.T) {
+	server := newMongoRaftBridgeTestServer(t, raftcluster.LeaderAdmission())
+
+	response := serveCommand(t, server, 325807, bson.D{
+		{Key: "insert", Value: "users"},
+		{Key: "documents", Value: bson.A{bson.D{{Key: "_id", Value: "u1"}, {Key: "name", Value: "Ada"}}}},
+		{Key: "writeConcern", Value: bson.D{{Key: "w", Value: "majority"}}},
+		{Key: "$db", Value: "app"},
+	})
+	assertOK(t, response)
+	if got, ok := bson.Raw(response).Lookup("n").Int32OK(); !ok || got != 1 {
+		t.Fatalf("insert n=%d ok=%v want 1/true", got, ok)
+	}
+	assertMongoUsers(t, server, map[string]string{"u1": "Ada"})
 }
 
 func TestClusterSubmitterRejectsUnsupportedWriteConcernBeforeSubmitOrLocalMutation(t *testing.T) {

--- a/TreeDB/mongo_gateway/cluster_submitter_test.go
+++ b/TreeDB/mongo_gateway/cluster_submitter_test.go
@@ -383,7 +383,8 @@ func newMongoRaftBridgeTestServer(tb testing.TB, admission raftcluster.Admission
 			EvidenceKind:        raftcluster.CommitEvidenceProductionConsensusV1,
 			ProductionConsensus: true,
 		}),
-		Applier: fsm,
+		Preflight: fsm,
+		Applier:   fsm,
 		CatalogVersionProvider: raftcluster.CatalogVersionProviderFunc(func(context.Context) (uint64, bool, error) {
 			state := db.State()
 			if state == nil {

--- a/TreeDB/mongo_gateway/cluster_submitter_test.go
+++ b/TreeDB/mongo_gateway/cluster_submitter_test.go
@@ -401,7 +401,7 @@ func newMongoRaftBridgeTestServer(tb testing.TB, admission raftcluster.Admission
 	server := NewServer()
 	server.Collections = collections.NewCollectionManager(db)
 	server.DefaultCollectionOptions = collections.CollectionOptions{DocumentFormat: collections.DocumentFormatBSON}
-	server.ClusterSubmitter = treenativewire.NewRaftClusterSubmitter(bridge)
+	server.ClusterSubmitter = treenativewire.NewRaftClusterSubmitter(bridge, server.Collections)
 	server.ClusterCatalogVersion = func(context.Context) (uint64, error) {
 		state := db.State()
 		if state == nil {

--- a/TreeDB/nativewire/cluster_raft_submitter.go
+++ b/TreeDB/nativewire/cluster_raft_submitter.go
@@ -48,6 +48,9 @@ func (s *RaftClusterSubmitter) SubmitCommandEntryV1(ctx context.Context, entry [
 	if s == nil || s.Bridge == nil {
 		return ClusterSubmitResult{}, protocolError(iwire.ErrInvalidCommand, "raft cluster submitter is not configured")
 	}
+	if s.Collections == nil {
+		return ClusterSubmitResult{}, protocolError(iwire.ErrInvalidCommand, "raft cluster submitter collection manager is not configured")
+	}
 	result, err := s.Bridge.SubmitCommandEntryV1(ctx, entry, metadata)
 	if err != nil {
 		return ClusterSubmitResult{}, nativeErrorForRaftClusterSubmit(err)

--- a/TreeDB/nativewire/cluster_raft_submitter.go
+++ b/TreeDB/nativewire/cluster_raft_submitter.go
@@ -152,6 +152,7 @@ func nativeErrorForRaftClusterSubmit(err error) error {
 	case errors.Is(err, raftcluster.ErrAdmissionUnavailable),
 		errors.Is(err, raftcluster.ErrCommitNotProven),
 		errors.Is(err, raftcluster.ErrLocalApplyNotRecoverable),
+		errors.Is(err, raftcluster.ErrLocalAckUnavailable),
 		errors.Is(err, raftcluster.ErrInvalidSubmitter),
 		errors.Is(err, raftcluster.ErrMissingCatalogVersion):
 		return protocolError(iwire.ErrDurabilityUnavailable, "%v", err)

--- a/TreeDB/nativewire/cluster_raft_submitter.go
+++ b/TreeDB/nativewire/cluster_raft_submitter.go
@@ -59,6 +59,8 @@ func (s *RaftClusterSubmitter) SubmitCommandEntryV1(ctx context.Context, entry [
 		ActualAck:            AckPolicy(result.ActualAck),
 		CommittedRecoverable: result.CommittedRecoverable,
 		ResponseSections:     sections,
+		CatalogVersion:       result.CatalogVersion,
+		HasCatalogVersion:    result.HasCatalogVersion,
 	}, nil
 }
 

--- a/TreeDB/nativewire/cluster_raft_submitter.go
+++ b/TreeDB/nativewire/cluster_raft_submitter.go
@@ -16,11 +16,16 @@ import (
 // RaftClusterSubmitter adapts the internal single-group raftcluster bridge to
 // the public nativewire ClusterSubmitter contract.
 type RaftClusterSubmitter struct {
-	Bridge *raftcluster.SingleGroupSubmitter
+	Bridge      *raftcluster.SingleGroupSubmitter
+	Collections *collections.CollectionManager
 }
 
-func NewRaftClusterSubmitter(bridge *raftcluster.SingleGroupSubmitter) *RaftClusterSubmitter {
-	return &RaftClusterSubmitter{Bridge: bridge}
+func NewRaftClusterSubmitter(bridge *raftcluster.SingleGroupSubmitter, managers ...*collections.CollectionManager) *RaftClusterSubmitter {
+	submitter := &RaftClusterSubmitter{Bridge: bridge}
+	if len(managers) > 0 {
+		submitter.Collections = managers[0]
+	}
+	return submitter
 }
 
 func (s *RaftClusterSubmitter) ClusterAdmissionStatus(ctx context.Context) (ClusterAdmissionStatus, error) {
@@ -47,7 +52,7 @@ func (s *RaftClusterSubmitter) SubmitCommandEntryV1(ctx context.Context, entry [
 	if err != nil {
 		return ClusterSubmitResult{}, nativeErrorForRaftClusterSubmit(err)
 	}
-	sections, err := raftClusterResponseSections(result.DecodedEntry, metadata, result)
+	sections, err := raftClusterResponseSections(result.DecodedEntry, metadata, result, s.Collections)
 	if err != nil {
 		return ClusterSubmitResult{}, err
 	}
@@ -60,7 +65,7 @@ func (s *RaftClusterSubmitter) SubmitCommandEntryV1(ctx context.Context, entry [
 	}, nil
 }
 
-func raftClusterResponseSections(entry raftentry.CommandEntryV1, metadata ClusterRequestMetadata, result raftcluster.SubmitResultV1) ([]iwire.Section, error) {
+func raftClusterResponseSections(entry raftentry.CommandEntryV1, metadata ClusterRequestMetadata, result raftcluster.SubmitResultV1, manager *collections.CollectionManager) ([]iwire.Section, error) {
 	actualAck := AckPolicy(result.ActualAck)
 	catalogVersion := result.CatalogVersion
 	hasCatalogVersion := result.HasCatalogVersion
@@ -70,7 +75,7 @@ func raftClusterResponseSections(entry raftentry.CommandEntryV1, metadata Cluste
 	}
 	switch entry.Decoded.CommandID {
 	case iwire.CommandCreateCollection:
-		rawMeta, err := raftClusterCreateCollectionResponseMeta(entry)
+		rawMeta, err := raftClusterCreateCollectionResponseMeta(entry, manager)
 		if err != nil {
 			return nil, err
 		}
@@ -110,7 +115,7 @@ func raftClusterResponseSections(entry raftentry.CommandEntryV1, metadata Cluste
 	}
 }
 
-func raftClusterCreateCollectionResponseMeta(entry raftentry.CommandEntryV1) ([]byte, error) {
+func raftClusterCreateCollectionResponseMeta(entry raftentry.CommandEntryV1, manager *collections.CollectionManager) ([]byte, error) {
 	rawMeta, err := metadataSection(entry.Decoded.Sections, iwire.SectionCollectionMeta)
 	if err != nil {
 		return nil, err
@@ -123,12 +128,14 @@ func raftClusterCreateCollectionResponseMeta(entry raftentry.CommandEntryV1) ([]
 	if err != nil {
 		return nil, err
 	}
-	meta.Options.DataRootStoragePolicy = collections.RootStorageFast
-	meta.Options.IndexStateStoragePolicy = collections.RootStorageFast
-	for i := range meta.Indexes {
-		meta.Indexes[i].StoragePolicy = collections.RootStorageFast
+	if manager == nil {
+		return nil, protocolError(iwire.ErrInternal, "raft cluster submitter cannot return applied create_collection metadata without a collection manager")
 	}
-	return encodeCollectionMeta(meta), nil
+	collection, err := manager.OpenCollection(meta.Name)
+	if err != nil {
+		return nil, protocolError(iwire.ErrInternal, "raft cluster submitter applied create_collection but collection %q is not readable: %v", meta.Name, err)
+	}
+	return encodeCollectionMeta(collection.Meta()), nil
 }
 
 func raftClusterMatchedAndAffectedCounts(result raftentry.ApplyResultV1) (int, int, error) {

--- a/TreeDB/nativewire/cluster_raft_submitter.go
+++ b/TreeDB/nativewire/cluster_raft_submitter.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/snissn/gomap/TreeDB/collections"
 	iwire "github.com/snissn/gomap/TreeDB/internal/nativewire"
 	"github.com/snissn/gomap/TreeDB/internal/raftcluster"
 	"github.com/snissn/gomap/TreeDB/internal/raftentry"
@@ -65,13 +66,13 @@ func raftClusterResponseSections(entry raftentry.CommandEntryV1, metadata Cluste
 	actualAck := AckPolicy(result.ActualAck)
 	catalogVersion := result.CatalogVersion
 	hasCatalogVersion := result.HasCatalogVersion
-	affected, err := raftClusterAffectedCount(result.ApplyResult)
+	affected, matched, err := raftClusterMatchedAndAffectedCounts(result.ApplyResult)
 	if err != nil {
 		return nil, err
 	}
 	switch entry.Decoded.CommandID {
 	case iwire.CommandCreateCollection:
-		rawMeta, err := metadataSection(entry.Decoded.Sections, iwire.SectionCollectionMeta)
+		rawMeta, err := raftClusterCreateCollectionResponseMeta(entry)
 		if err != nil {
 			return nil, err
 		}
@@ -98,7 +99,7 @@ func raftClusterResponseSections(entry raftentry.CommandEntryV1, metadata Cluste
 			return nil, nil
 		}
 		return []iwire.Section{ackMetaCountsVersion(actualAck, catalogVersion, hasCatalogVersion,
-			responseMetaCount{key: "matched_count", value: affected},
+			responseMetaCount{key: "matched_count", value: matched},
 			responseMetaCount{key: "modified_count", value: affected},
 		)}, nil
 	case iwire.CommandDeleteBatch:
@@ -111,11 +112,35 @@ func raftClusterResponseSections(entry raftentry.CommandEntryV1, metadata Cluste
 	}
 }
 
-func raftClusterAffectedCount(result raftentry.ApplyResultV1) (int, error) {
-	if result.AffectedCount < 0 || result.AffectedCount > int64(maxInt) {
-		return 0, protocolError(iwire.ErrInternal, "raft cluster apply affected count %d is outside int range", result.AffectedCount)
+func raftClusterCreateCollectionResponseMeta(entry raftentry.CommandEntryV1) ([]byte, error) {
+	rawMeta, err := metadataSection(entry.Decoded.Sections, iwire.SectionCollectionMeta)
+	if err != nil {
+		return nil, err
 	}
-	return int(result.AffectedCount), nil
+	meta, err := decodeCollectionMeta(rawMeta)
+	if err != nil {
+		return nil, err
+	}
+	meta, err = normalizeClientCollectionMeta(meta)
+	if err != nil {
+		return nil, err
+	}
+	meta.Options.DataRootStoragePolicy = collections.RootStorageFast
+	meta.Options.IndexStateStoragePolicy = collections.RootStorageFast
+	for i := range meta.Indexes {
+		meta.Indexes[i].StoragePolicy = collections.RootStorageFast
+	}
+	return encodeCollectionMeta(meta), nil
+}
+
+func raftClusterMatchedAndAffectedCounts(result raftentry.ApplyResultV1) (int, int, error) {
+	if result.AffectedCount < 0 || result.AffectedCount > int64(maxInt) {
+		return 0, 0, protocolError(iwire.ErrInternal, "raft cluster apply affected count %d is outside int range", result.AffectedCount)
+	}
+	if result.MatchedCount < 0 || result.MatchedCount > int64(maxInt) {
+		return 0, 0, protocolError(iwire.ErrInternal, "raft cluster apply matched count %d is outside int range", result.MatchedCount)
+	}
+	return int(result.AffectedCount), int(result.MatchedCount), nil
 }
 
 func nativeErrorForRaftClusterSubmit(err error) error {

--- a/TreeDB/nativewire/cluster_raft_submitter.go
+++ b/TreeDB/nativewire/cluster_raft_submitter.go
@@ -178,6 +178,9 @@ func nativeErrorForRaftClusterSubmit(err error) error {
 }
 
 func nativeErrorForDeterministicCode(code raftentry.DeterministicErrorCodeV1, err error) error {
+	if wireCode, ok := nativeCollectionConflictCode(err); ok {
+		return protocolError(wireCode, "%v", err)
+	}
 	switch code {
 	case raftentry.ErrorUnsupportedCommandV1, raftentry.ErrorReadOnlyV1, raftentry.ErrorUnsupportedFeatureV1:
 		return protocolError(iwire.ErrUnsupportedFeature, "%v", err)
@@ -189,5 +192,18 @@ func nativeErrorForDeterministicCode(code raftentry.DeterministicErrorCodeV1, er
 		return protocolError(iwire.ErrDurabilityUnavailable, "%v", err)
 	default:
 		return protocolError(iwire.ErrInvalidCommand, "%v", err)
+	}
+}
+
+func nativeCollectionConflictCode(err error) (iwire.ErrorCode, bool) {
+	switch {
+	case errors.Is(err, collections.ErrDuplicateDocumentID):
+		return iwire.ErrDuplicateDocumentID, true
+	case errors.Is(err, collections.ErrDocumentExists):
+		return iwire.ErrDocumentExists, true
+	case errors.Is(err, collections.ErrUniqueIndexConflict):
+		return iwire.ErrUniqueIndexConflict, true
+	default:
+		return 0, false
 	}
 }

--- a/TreeDB/nativewire/cluster_raft_submitter.go
+++ b/TreeDB/nativewire/cluster_raft_submitter.go
@@ -147,6 +147,8 @@ func nativeErrorForRaftClusterSubmit(err error) error {
 		return nil
 	case errors.Is(err, raftcluster.ErrNotLeader):
 		return protocolError(iwire.ErrReadOnly, "%v", err)
+	case errors.Is(err, raftcluster.ErrCatalogVersionMismatch):
+		return protocolError(iwire.ErrCatalogVersionMismatch, "%v", err)
 	case errors.Is(err, raftcluster.ErrAdmissionUnavailable),
 		errors.Is(err, raftcluster.ErrCommitNotProven),
 		errors.Is(err, raftcluster.ErrLocalApplyNotRecoverable),

--- a/TreeDB/nativewire/cluster_raft_submitter.go
+++ b/TreeDB/nativewire/cluster_raft_submitter.go
@@ -1,0 +1,160 @@
+package nativewire
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+
+	iwire "github.com/snissn/gomap/TreeDB/internal/nativewire"
+	"github.com/snissn/gomap/TreeDB/internal/raftcluster"
+	"github.com/snissn/gomap/TreeDB/internal/raftentry"
+	"github.com/snissn/gomap/TreeDB/internal/raftfsm"
+)
+
+// RaftClusterSubmitter adapts the internal single-group raftcluster bridge to
+// the public nativewire ClusterSubmitter contract.
+type RaftClusterSubmitter struct {
+	Bridge *raftcluster.SingleGroupSubmitter
+}
+
+func NewRaftClusterSubmitter(bridge *raftcluster.SingleGroupSubmitter) *RaftClusterSubmitter {
+	return &RaftClusterSubmitter{Bridge: bridge}
+}
+
+func (s *RaftClusterSubmitter) ClusterAdmissionStatus(ctx context.Context) (ClusterAdmissionStatus, error) {
+	if s == nil || s.Bridge == nil {
+		return ClusterAdmissionStatus{}, raftcluster.ErrInvalidSubmitter
+	}
+	status, err := s.Bridge.ClusterAdmissionStatus(ctx)
+	if err != nil {
+		return ClusterAdmissionStatus{}, err
+	}
+	return ClusterAdmissionStatus{
+		Leader:      status.Leader,
+		Unavailable: status.Unavailable,
+		LeaderHint:  string(status.LeaderHint),
+		Reason:      status.Reason,
+	}, nil
+}
+
+func (s *RaftClusterSubmitter) SubmitCommandEntryV1(ctx context.Context, entry []byte, metadata ClusterRequestMetadata) (ClusterSubmitResult, error) {
+	if s == nil || s.Bridge == nil {
+		return ClusterSubmitResult{}, protocolError(iwire.ErrInvalidCommand, "raft cluster submitter is not configured")
+	}
+	result, err := s.Bridge.SubmitCommandEntryV1(ctx, entry, metadata)
+	if err != nil {
+		return ClusterSubmitResult{}, nativeErrorForRaftClusterSubmit(err)
+	}
+	decoded, err := raftentry.DecodeCommandEntryV1(entry, raftentry.DecodeOptions{RequestMetadata: metadata})
+	if err != nil {
+		return ClusterSubmitResult{}, nativeErrorForRaftEntryValidation(err)
+	}
+	sections, err := raftClusterResponseSections(decoded, metadata, result)
+	if err != nil {
+		return ClusterSubmitResult{}, err
+	}
+	return ClusterSubmitResult{
+		ActualAck:            AckPolicy(result.ActualAck),
+		CommittedRecoverable: result.CommittedRecoverable,
+		ResponseSections:     sections,
+	}, nil
+}
+
+func raftClusterResponseSections(entry raftentry.CommandEntryV1, metadata ClusterRequestMetadata, result raftcluster.SubmitResultV1) ([]iwire.Section, error) {
+	actualAck := AckPolicy(result.ActualAck)
+	catalogVersion := result.CatalogVersion
+	hasCatalogVersion := result.HasCatalogVersion
+	affected, err := raftClusterAffectedCount(result.ApplyResult)
+	if err != nil {
+		return nil, err
+	}
+	switch entry.Decoded.CommandID {
+	case iwire.CommandCreateCollection:
+		rawMeta, err := metadataSection(entry.Decoded.Sections, iwire.SectionCollectionMeta)
+		if err != nil {
+			return nil, err
+		}
+		sections := []iwire.Section{{ID: iwire.SectionCollectionMeta, Bytes: bytes.Clone(rawMeta)}}
+		if !metadata.OmitResponseMeta {
+			sections = append(sections, ackMetaCountsVersion(actualAck, catalogVersion, hasCatalogVersion))
+		}
+		return sections, nil
+	case iwire.CommandInsertBatch:
+		var sections []iwire.Section
+		if !metadata.OmitResultIDs {
+			rawIDs, err := metadataSection(entry.Decoded.Sections, iwire.SectionDocumentIDs)
+			if err != nil {
+				return nil, err
+			}
+			sections = append(sections, iwire.Section{ID: iwire.SectionDocumentIDs, Bytes: bytes.Clone(rawIDs)})
+		}
+		if !metadata.OmitResponseMeta {
+			sections = append(sections, ackMetaCountsVersion(actualAck, catalogVersion, hasCatalogVersion, responseMetaCount{key: "inserted_count", value: affected}))
+		}
+		return sections, nil
+	case iwire.CommandReplaceBatch, iwire.CommandUpdateBSONSet:
+		if metadata.OmitResponseMeta {
+			return nil, nil
+		}
+		return []iwire.Section{ackMetaCountsVersion(actualAck, catalogVersion, hasCatalogVersion,
+			responseMetaCount{key: "matched_count", value: affected},
+			responseMetaCount{key: "modified_count", value: affected},
+		)}, nil
+	case iwire.CommandDeleteBatch:
+		if metadata.OmitResponseMeta {
+			return nil, nil
+		}
+		return []iwire.Section{ackMetaCountsVersion(actualAck, catalogVersion, hasCatalogVersion, responseMetaCount{key: "deleted_count", value: affected})}, nil
+	default:
+		return nil, protocolError(iwire.ErrUnsupportedFeature, "raft cluster submitter response does not support command %d", entry.Decoded.CommandID)
+	}
+}
+
+func raftClusterAffectedCount(result raftentry.ApplyResultV1) (int, error) {
+	if result.AffectedCount < 0 || result.AffectedCount > int64(maxInt) {
+		return 0, protocolError(iwire.ErrInternal, "raft cluster apply affected count %d is outside int range", result.AffectedCount)
+	}
+	return int(result.AffectedCount), nil
+}
+
+func nativeErrorForRaftClusterSubmit(err error) error {
+	switch {
+	case err == nil:
+		return nil
+	case errors.Is(err, raftcluster.ErrNotLeader):
+		return protocolError(iwire.ErrReadOnly, "%v", err)
+	case errors.Is(err, raftcluster.ErrAdmissionUnavailable),
+		errors.Is(err, raftcluster.ErrCommitNotProven),
+		errors.Is(err, raftcluster.ErrLocalApplyNotRecoverable),
+		errors.Is(err, raftcluster.ErrInvalidSubmitter),
+		errors.Is(err, raftcluster.ErrMissingCatalogVersion):
+		return protocolError(iwire.ErrDurabilityUnavailable, "%v", err)
+	case errors.Is(err, raftcluster.ErrUnsupportedSubmitAck),
+		errors.Is(err, raftcluster.ErrInvalidCommittedEntry),
+		errors.Is(err, raftcluster.ErrUnexpectedCommittedTarget):
+		return protocolError(iwire.ErrInvalidCommand, "%v", err)
+	}
+	if code, ok := raftentry.ErrorCodeOf(err); ok {
+		return nativeErrorForDeterministicCode(code, err)
+	}
+	if code, ok := raftfsm.ErrorCodeOf(err); ok {
+		return nativeErrorForDeterministicCode(code, err)
+	}
+	return fmt.Errorf("raft cluster submitter: %w", err)
+}
+
+func nativeErrorForDeterministicCode(code raftentry.DeterministicErrorCodeV1, err error) error {
+	switch code {
+	case raftentry.ErrorUnsupportedCommandV1, raftentry.ErrorReadOnlyV1, raftentry.ErrorUnsupportedFeatureV1:
+		return protocolError(iwire.ErrUnsupportedFeature, "%v", err)
+	case raftentry.ErrorUnsupportedVersionV1:
+		return protocolError(iwire.ErrUnsupportedVersion, "%v", err)
+	case raftentry.ErrorResourceExhaustedV1:
+		return protocolError(iwire.ErrResourceExhausted, "%v", err)
+	case raftentry.ErrorUnsafeDurabilityModeV1, raftentry.ErrorResultReplayRequiredV1:
+		return protocolError(iwire.ErrDurabilityUnavailable, "%v", err)
+	default:
+		return protocolError(iwire.ErrInvalidCommand, "%v", err)
+	}
+}

--- a/TreeDB/nativewire/cluster_raft_submitter.go
+++ b/TreeDB/nativewire/cluster_raft_submitter.go
@@ -47,11 +47,7 @@ func (s *RaftClusterSubmitter) SubmitCommandEntryV1(ctx context.Context, entry [
 	if err != nil {
 		return ClusterSubmitResult{}, nativeErrorForRaftClusterSubmit(err)
 	}
-	decoded, err := raftentry.DecodeCommandEntryV1(entry, raftentry.DecodeOptions{RequestMetadata: metadata})
-	if err != nil {
-		return ClusterSubmitResult{}, nativeErrorForRaftEntryValidation(err)
-	}
-	sections, err := raftClusterResponseSections(decoded, metadata, result)
+	sections, err := raftClusterResponseSections(result.DecodedEntry, metadata, result)
 	if err != nil {
 		return ClusterSubmitResult{}, err
 	}

--- a/TreeDB/nativewire/cluster_submitter.go
+++ b/TreeDB/nativewire/cluster_submitter.go
@@ -101,6 +101,10 @@ type ClusterSubmitResult struct {
 	ActualAck            AckPolicy
 	CommittedRecoverable bool
 	ResponseSections     []iwire.Section
+	// CatalogVersion is internal post-apply evidence. It lets response shaping
+	// omit response_meta without hiding catalog-cache progress from the server.
+	CatalogVersion    uint64
+	HasCatalogVersion bool
 }
 
 func (s *Server) handleClusterMutation(ctx context.Context, header iwire.Header, cmd iwire.ValidatedCommand) ([]iwire.Section, error) {
@@ -156,14 +160,20 @@ func (s *Server) handleClusterMutation(ctx context.Context, header iwire.Header,
 	if err := validateClusterSubmitResult(metadata, result); err != nil {
 		return nil, err
 	}
-	if err := s.updateCatalogVersionFromClusterSubmitResult(result.ResponseSections); err != nil {
+	if err := s.updateCatalogVersionFromClusterSubmitResult(result); err != nil {
 		return nil, err
 	}
 	return cloneSections(result.ResponseSections), nil
 }
 
-func (s *Server) updateCatalogVersionFromClusterSubmitResult(sections []iwire.Section) error {
-	version, ok, err := catalogVersionFromResponseMeta(sections)
+func (s *Server) updateCatalogVersionFromClusterSubmitResult(result ClusterSubmitResult) error {
+	if result.HasCatalogVersion {
+		if s != nil {
+			s.catalogVersion.Store(result.CatalogVersion)
+		}
+		return nil
+	}
+	version, ok, err := catalogVersionFromResponseMeta(result.ResponseSections)
 	if err != nil {
 		return err
 	}
@@ -547,6 +557,15 @@ func validateClusterSubmitResult(metadata ClusterRequestMetadata, result Cluster
 		return err
 	} else if ok && ack != result.ActualAck {
 		return protocolError(iwire.ErrInternal, "cluster submitter response ack policy %d does not match result ack policy %d", ack, result.ActualAck)
+	}
+	if result.HasCatalogVersion {
+		version, ok, err := catalogVersionFromResponseMeta(result.ResponseSections)
+		if err != nil {
+			return err
+		}
+		if ok && version != result.CatalogVersion {
+			return protocolError(iwire.ErrInternal, "cluster submitter response catalog version %d does not match result catalog version %d", version, result.CatalogVersion)
+		}
 	}
 	return nil
 }

--- a/TreeDB/nativewire/cluster_submitter.go
+++ b/TreeDB/nativewire/cluster_submitter.go
@@ -156,7 +156,21 @@ func (s *Server) handleClusterMutation(ctx context.Context, header iwire.Header,
 	if err := validateClusterSubmitResult(metadata, result); err != nil {
 		return nil, err
 	}
+	if err := s.updateCatalogVersionFromClusterSubmitResult(result.ResponseSections); err != nil {
+		return nil, err
+	}
 	return cloneSections(result.ResponseSections), nil
+}
+
+func (s *Server) updateCatalogVersionFromClusterSubmitResult(sections []iwire.Section) error {
+	version, ok, err := catalogVersionFromResponseMeta(sections)
+	if err != nil {
+		return err
+	}
+	if ok && s != nil {
+		s.catalogVersion.Store(version)
+	}
+	return nil
 }
 
 // AdmitClusterMutation fails closed unless submitter is configured and, when

--- a/TreeDB/nativewire/cluster_submitter.go
+++ b/TreeDB/nativewire/cluster_submitter.go
@@ -168,19 +168,32 @@ func (s *Server) handleClusterMutation(ctx context.Context, header iwire.Header,
 
 func (s *Server) updateCatalogVersionFromClusterSubmitResult(result ClusterSubmitResult) error {
 	if result.HasCatalogVersion {
-		if s != nil {
-			s.catalogVersion.Store(result.CatalogVersion)
-		}
+		s.advanceCatalogVersion(result.CatalogVersion)
 		return nil
 	}
 	version, ok, err := catalogVersionFromResponseMeta(result.ResponseSections)
 	if err != nil {
 		return err
 	}
-	if ok && s != nil {
-		s.catalogVersion.Store(version)
+	if ok {
+		s.advanceCatalogVersion(version)
 	}
 	return nil
+}
+
+func (s *Server) advanceCatalogVersion(version uint64) {
+	if s == nil {
+		return
+	}
+	for {
+		current := s.catalogVersion.Load()
+		if version <= current {
+			return
+		}
+		if s.catalogVersion.CompareAndSwap(current, version) {
+			return
+		}
+	}
 }
 
 // AdmitClusterMutation fails closed unless submitter is configured and, when

--- a/TreeDB/nativewire/cluster_submitter_test.go
+++ b/TreeDB/nativewire/cluster_submitter_test.go
@@ -1564,6 +1564,30 @@ func TestRaftClusterSubmitterConcreteBridgeOmitResponseMetaAdvancesCatalogVersio
 	}
 }
 
+func TestRaftClusterSubmitterConcreteBridgeMissingCollectionPreflightDoesNotConsumeIndex(t *testing.T) {
+	client, _, mgr, _ := serveRaftClusterBridgePipe(t, raftcluster.LeaderAdmission())
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := client.Hello(ctx); err != nil {
+		t.Fatalf("Hello: %v", err)
+	}
+	_, err := client.InsertBatch(ctx, "users", collections.DocumentFormatJSON, [][]byte{[]byte("u-missing")}, [][]byte{[]byte(`{"name":"Missing"}`)}, AckRaftCommitted)
+	if err == nil {
+		t.Fatal("InsertBatch missing collection unexpectedly succeeded")
+	}
+	if _, openErr := mgr.OpenCollection("users"); !errors.Is(openErr, collections.ErrCollectionNotFound) {
+		t.Fatalf("OpenCollection users after rejected insert err=%v want ErrCollectionNotFound", openErr)
+	}
+	version := clientCatalogVersion(t, client, ctx)
+	if _, err := client.commandSections(ctx, iwire.CommandCreateCollection, raftClusterCreateCollectionSections("users", version, AckRaftCommitted)...); err != nil {
+		t.Fatalf("CreateCollection after rejected insert: %v", err)
+	}
+	_ = clientCatalogVersion(t, client, ctx)
+	if _, err := client.InsertBatch(ctx, "users", collections.DocumentFormatJSON, [][]byte{[]byte("u1")}, [][]byte{[]byte(`{"name":"Ada"}`)}, AckRaftCommitted); err != nil {
+		t.Fatalf("InsertBatch after create: %v", err)
+	}
+}
+
 func TestRaftClusterSubmitterShapesResponseFromBridgeDecodedEntry(t *testing.T) {
 	defaultLimits := iwire.DefaultLimits()
 	limits := defaultLimits
@@ -1582,6 +1606,7 @@ func TestRaftClusterSubmitterShapesResponseFromBridgeDecodedEntry(t *testing.T) 
 			EvidenceKind:        raftcluster.CommitEvidenceProductionConsensusV1,
 			ProductionConsensus: true,
 		}),
+		Preflight:              raftcluster.CommandEntryPreflightFunc(func(context.Context, raftcluster.CommandEntryPreflightRequestV1) error { return nil }),
 		Applier:                applier,
 		CatalogVersionProvider: raftcluster.CatalogVersionProviderFunc(func(context.Context) (uint64, bool, error) { return 7, true, nil }),
 		DecodeLimits:           limits,
@@ -1720,7 +1745,8 @@ func serveRaftClusterBridgePipe(t testing.TB, admission raftcluster.AdmissionSta
 			EvidenceKind:        raftcluster.CommitEvidenceProductionConsensusV1,
 			ProductionConsensus: true,
 		}),
-		Applier: fsm,
+		Preflight: fsm,
+		Applier:   fsm,
 		CatalogVersionProvider: raftcluster.CatalogVersionProviderFunc(func(context.Context) (uint64, bool, error) {
 			state := db.State()
 			if state == nil {

--- a/TreeDB/nativewire/cluster_submitter_test.go
+++ b/TreeDB/nativewire/cluster_submitter_test.go
@@ -1619,9 +1619,9 @@ func TestRaftClusterSubmitterRequiresCollectionManagerBeforeSubmit(t *testing.T)
 				},
 			}, nil
 		}),
-		Preflight: raftcluster.CommandEntryPreflightFunc(func(context.Context, raftcluster.CommandEntryPreflightRequestV1) error {
+		Preflight: raftcluster.CommandEntryPreflightFunc(func(context.Context, raftcluster.CommandEntryPreflightRequestV1) (raftcluster.CommandEntryPreflightResultV1, error) {
 			preflightCalls++
-			return nil
+			return raftcluster.CommandEntryPreflightResultV1{}, nil
 		}),
 		Applier:                applier,
 		CatalogVersionProvider: raftcluster.CatalogVersionProviderFunc(func(context.Context) (uint64, bool, error) { return 7, true, nil }),
@@ -1691,7 +1691,9 @@ func TestRaftClusterSubmitterShapesResponseFromBridgeDecodedEntry(t *testing.T) 
 			EvidenceKind:        raftcluster.CommitEvidenceProductionConsensusV1,
 			ProductionConsensus: true,
 		}),
-		Preflight:              raftcluster.CommandEntryPreflightFunc(func(context.Context, raftcluster.CommandEntryPreflightRequestV1) error { return nil }),
+		Preflight: raftcluster.CommandEntryPreflightFunc(func(context.Context, raftcluster.CommandEntryPreflightRequestV1) (raftcluster.CommandEntryPreflightResultV1, error) {
+			return raftcluster.CommandEntryPreflightResultV1{}, nil
+		}),
 		Applier:                applier,
 		CatalogVersionProvider: raftcluster.CatalogVersionProviderFunc(func(context.Context) (uint64, bool, error) { return 7, true, nil }),
 		DecodeLimits:           limits,

--- a/TreeDB/nativewire/cluster_submitter_test.go
+++ b/TreeDB/nativewire/cluster_submitter_test.go
@@ -1622,6 +1622,13 @@ func TestRaftClusterSubmitterCatalogVersionMismatchMapsToNativeError(t *testing.
 	}
 }
 
+func TestRaftClusterSubmitterLocalAckUnavailableMapsToNativeError(t *testing.T) {
+	err := nativeErrorForRaftClusterSubmit(raftcluster.ErrLocalAckUnavailable)
+	if code, ok := iwire.ErrorCodeOf(err); !ok || code != iwire.ErrDurabilityUnavailable {
+		t.Fatalf("nativeErrorForRaftClusterSubmit code=%v ok=%v err=%v, want durability-unavailable", code, ok, err)
+	}
+}
+
 func TestRaftClusterSubmitterConcreteBridgeFollowerRejectsBeforeApply(t *testing.T) {
 	client, _, mgr, _ := serveRaftClusterBridgePipe(t, raftcluster.FollowerAdmission("node-b", "not leader"))
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)

--- a/TreeDB/nativewire/cluster_submitter_test.go
+++ b/TreeDB/nativewire/cluster_submitter_test.go
@@ -1615,6 +1615,13 @@ func TestRaftClusterSubmitterShapesResponseFromBridgeDecodedEntry(t *testing.T) 
 	}
 }
 
+func TestRaftClusterSubmitterCatalogVersionMismatchMapsToNativeError(t *testing.T) {
+	err := nativeErrorForRaftClusterSubmit(raftcluster.ErrCatalogVersionMismatch)
+	if code, ok := iwire.ErrorCodeOf(err); !ok || code != iwire.ErrCatalogVersionMismatch {
+		t.Fatalf("nativeErrorForRaftClusterSubmit code=%v ok=%v err=%v, want catalog-version-mismatch", code, ok, err)
+	}
+}
+
 func TestRaftClusterSubmitterConcreteBridgeFollowerRejectsBeforeApply(t *testing.T) {
 	client, _, mgr, _ := serveRaftClusterBridgePipe(t, raftcluster.FollowerAdmission("node-b", "not leader"))
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)

--- a/TreeDB/nativewire/cluster_submitter_test.go
+++ b/TreeDB/nativewire/cluster_submitter_test.go
@@ -1508,6 +1508,35 @@ func TestRaftClusterSubmitterConcreteBridgeVisibleAckDoesNotClaimRaft(t *testing
 	}
 }
 
+func TestRaftClusterSubmitterConcreteBridgeOmitResponseMetaAdvancesCatalogVersion(t *testing.T) {
+	client, server, _, _ := serveRaftClusterBridgePipe(t, raftcluster.LeaderAdmission())
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := client.Hello(ctx); err != nil {
+		t.Fatalf("Hello: %v", err)
+	}
+	before := clientCatalogVersion(t, client, ctx)
+	createSections := raftClusterCreateCollectionSections("users", before, AckRaftCommitted)
+	response := commandSectionsWithFlags(t, client, ctx, iwire.CommandCreateCollection, iwire.CommandFlagOmitResponseMeta, createSections...)
+	if _, ok, err := responseMetaAckPolicy(response); err != nil || ok {
+		t.Fatalf("response meta ack=(%v,%v) want omitted", ok, err)
+	}
+	meta, err := firstMetaFromResponse(response)
+	if err != nil {
+		t.Fatalf("CreateCollection response meta: %v", err)
+	}
+	if meta.Name != "users" {
+		t.Fatalf("created collection=%q want users", meta.Name)
+	}
+	afterCreate, err := server.currentCatalogVersion()
+	if err != nil {
+		t.Fatalf("server currentCatalogVersion: %v", err)
+	}
+	if afterCreate <= before {
+		t.Fatalf("catalog version after omitted response_meta create=%d want > %d", afterCreate, before)
+	}
+}
+
 func TestRaftClusterSubmitterConcreteBridgeFollowerRejectsBeforeApply(t *testing.T) {
 	client, _, mgr, _ := serveRaftClusterBridgePipe(t, raftcluster.FollowerAdmission("node-b", "not leader"))
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
@@ -1523,6 +1552,29 @@ func TestRaftClusterSubmitterConcreteBridgeFollowerRejectsBeforeApply(t *testing
 	if _, openErr := mgr.OpenCollection("users"); !errors.Is(openErr, collections.ErrCollectionNotFound) {
 		t.Fatalf("OpenCollection users after follower rejection err=%v want ErrCollectionNotFound", openErr)
 	}
+}
+
+func commandSectionsWithFlags(t testing.TB, client *Client, ctx context.Context, commandID iwire.CommandID, flags uint64, sections ...iwire.Section) []iwire.Section {
+	t.Helper()
+	body, err := appendCommandHeaderSectionFlags(nil, commandID, flags)
+	if err != nil {
+		t.Fatalf("append command header: %v", err)
+	}
+	for _, section := range sections {
+		body, err = iwire.AppendSection(body, section)
+		if err != nil {
+			t.Fatalf("append section %d: %v", section.ID, err)
+		}
+	}
+	_, response, err := client.roundTrip(ctx, iwire.FrameRequest, body, iwire.FrameResponse)
+	if err != nil {
+		t.Fatalf("roundTrip: %v", err)
+	}
+	decoded, err := iwire.DecodeSections(response, client.limits)
+	if err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	return decoded
 }
 
 func clusterInsertBatchSections(t *testing.T, client *Client, ctx context.Context, ack AckPolicy, id string) []iwire.Section {

--- a/TreeDB/nativewire/cluster_submitter_test.go
+++ b/TreeDB/nativewire/cluster_submitter_test.go
@@ -1573,6 +1573,75 @@ func TestRaftClusterSubmitterConcreteBridgeOmitResponseMetaAdvancesCatalogVersio
 	}
 }
 
+func TestRaftClusterSubmitterRequiresCollectionManagerBeforeSubmit(t *testing.T) {
+	sections := append([]iwire.Section{
+		{ID: iwire.SectionCommandHeader, Bytes: iwire.AppendCommandHeader(nil, iwire.CommandHeader{ID: iwire.CommandCreateCollection, Version: 1})},
+	}, raftClusterCreateCollectionSections("users", 7, AckRaftCommitted)...)
+	cmd, err := iwire.MustV1Registry().ValidateRequestSections(sections)
+	if err != nil {
+		t.Fatalf("ValidateRequestSections: %v", err)
+	}
+	entry, err := iwire.AppendDeterministicEntry(nil, cmd)
+	if err != nil {
+		t.Fatalf("AppendDeterministicEntry: %v", err)
+	}
+
+	cluster := raftClusterBridgeTestConfig(nil)
+	cluster.Dir = t.TempDir()
+	preflightCalls := 0
+	commitCalls := 0
+	applier := &recordingRaftClusterApplier{result: raftentry.ApplyResultV1{Status: raftentry.ApplyStatusApplied}}
+	bridge, err := raftcluster.NewSingleGroupSubmitter(raftcluster.SingleGroupSubmitterOptions{
+		Cluster:           cluster,
+		AdmissionProvider: raftcluster.StaticAdmissionProvider{Status: raftcluster.LeaderAdmission()},
+		CommitSource: raftcluster.CommitSourceFunc(func(_ context.Context, req raftcluster.CommitCommandEntryV1Request) (raftcluster.CommitCommandEntryV1Result, error) {
+			commitCalls++
+			return raftcluster.CommitCommandEntryV1Result{
+				Entry: raftcluster.CommittedCommandEntryV1{
+					Term:                     1,
+					Index:                    1,
+					Bytes:                    bytes.Clone(req.EntryBytes),
+					CurrentCatalogVersion:    req.CurrentCatalogVersion,
+					HasCurrentCatalogVersion: req.HasCurrentCatalogVersion,
+					SyncLocalCommandWAL:      req.SyncLocalCommandWAL,
+					RequestMetadata:          req.RequestMetadata,
+					ExpectedTarget:           req.ExpectedTarget,
+				},
+				Evidence: raftcluster.CommitEvidenceV1{
+					Kind:                raftcluster.CommitEvidenceProductionConsensusV1,
+					GroupID:             cluster.GroupID,
+					NodeID:              cluster.NodeID,
+					LeaderID:            cluster.NodeID,
+					Term:                1,
+					Index:               1,
+					Committed:           true,
+					ProductionConsensus: true,
+				},
+			}, nil
+		}),
+		Preflight: raftcluster.CommandEntryPreflightFunc(func(context.Context, raftcluster.CommandEntryPreflightRequestV1) error {
+			preflightCalls++
+			return nil
+		}),
+		Applier:                applier,
+		CatalogVersionProvider: raftcluster.CatalogVersionProviderFunc(func(context.Context) (uint64, bool, error) { return 7, true, nil }),
+	})
+	if err != nil {
+		t.Fatalf("NewSingleGroupSubmitter: %v", err)
+	}
+
+	_, err = NewRaftClusterSubmitter(bridge).SubmitCommandEntryV1(context.Background(), entry, ClusterRequestMetadata{
+		RequestID: 17,
+		AckPolicy: AckRaftCommitted,
+	})
+	if nativeCodeOf(err) != iwire.ErrInvalidCommand {
+		t.Fatalf("SubmitCommandEntryV1 err=%v code=%d want invalid-command", err, nativeCodeOf(err))
+	}
+	if preflightCalls != 0 || commitCalls != 0 || applier.calls != 0 {
+		t.Fatalf("bridge touched before collection-manager validation: preflight=%d commit=%d apply=%d", preflightCalls, commitCalls, applier.calls)
+	}
+}
+
 func TestRaftClusterSubmitterConcreteBridgeMissingCollectionPreflightDoesNotConsumeIndex(t *testing.T) {
 	client, _, mgr, _ := serveRaftClusterBridgePipe(t, raftcluster.LeaderAdmission())
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
@@ -1598,6 +1667,13 @@ func TestRaftClusterSubmitterConcreteBridgeMissingCollectionPreflightDoesNotCons
 }
 
 func TestRaftClusterSubmitterShapesResponseFromBridgeDecodedEntry(t *testing.T) {
+	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("Open DB: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	manager := collections.NewCollectionManager(db)
+
 	defaultLimits := iwire.DefaultLimits()
 	limits := defaultLimits
 	limits.MaxSectionLen = defaultLimits.MaxSectionLen + (1 << 20)
@@ -1624,7 +1700,7 @@ func TestRaftClusterSubmitterShapesResponseFromBridgeDecodedEntry(t *testing.T) 
 		t.Fatalf("NewSingleGroupSubmitter: %v", err)
 	}
 
-	result, err := NewRaftClusterSubmitter(bridge).SubmitCommandEntryV1(context.Background(), entry, ClusterRequestMetadata{
+	result, err := NewRaftClusterSubmitter(bridge, manager).SubmitCommandEntryV1(context.Background(), entry, ClusterRequestMetadata{
 		RequestID: 17,
 		AckPolicy: AckRaftCommitted,
 	})

--- a/TreeDB/nativewire/cluster_submitter_test.go
+++ b/TreeDB/nativewire/cluster_submitter_test.go
@@ -1445,6 +1445,14 @@ func TestRaftClusterSubmitterConcreteBridgeCreateInsertRaftCommitted(t *testing.
 		meta.Indexes[0].StoragePolicy != collections.RootStorageFast {
 		t.Fatalf("created storage policies data=%q index=%q indexes=%+v, want fast policies", meta.Options.DataRootStoragePolicy, meta.Options.IndexStateStoragePolicy, meta.Indexes)
 	}
+	created, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("OpenCollection users after create: %v", err)
+	}
+	applied := created.Meta()
+	if got, want := encodeCollectionMeta(meta), encodeCollectionMeta(applied); !bytes.Equal(got, want) {
+		t.Fatalf("create response meta=%+v want applied catalog meta=%+v", meta, applied)
+	}
 	if ack, ok, err := responseMetaAckPolicy(createResponse); err != nil || !ok || ack != AckRaftCommitted {
 		t.Fatalf("create response ack=(%d,%v,%v) want raft_committed", ack, ok, err)
 	}
@@ -1763,7 +1771,7 @@ func serveRaftClusterBridgePipe(t testing.TB, admission raftcluster.AdmissionSta
 	server := NewServer(ServerOptions{
 		Collections:      mgr,
 		Backend:          db,
-		ClusterSubmitter: NewRaftClusterSubmitter(bridge),
+		ClusterSubmitter: NewRaftClusterSubmitter(bridge, mgr),
 	})
 	client, _ := servePipe(t, server)
 	t.Cleanup(func() {

--- a/TreeDB/nativewire/cluster_submitter_test.go
+++ b/TreeDB/nativewire/cluster_submitter_test.go
@@ -12,9 +12,12 @@ import (
 	"time"
 
 	"github.com/snissn/gomap/TreeDB/collections"
+	backenddb "github.com/snissn/gomap/TreeDB/db"
 	iwire "github.com/snissn/gomap/TreeDB/internal/nativewire"
+	"github.com/snissn/gomap/TreeDB/internal/raftapply"
 	"github.com/snissn/gomap/TreeDB/internal/raftcluster"
 	"github.com/snissn/gomap/TreeDB/internal/raftentry"
+	"github.com/snissn/gomap/TreeDB/internal/raftfsm"
 	"github.com/snissn/gomap/TreeDB/internal/raftplacement"
 	"go.mongodb.org/mongo-driver/v2/bson"
 )
@@ -1320,6 +1323,101 @@ func TestClusterSubmitterRaftCommittedAdmissionFailsBeforeSubmit(t *testing.T) {
 	}
 }
 
+func TestRaftClusterSubmitterConcreteBridgeCreateInsertRaftCommitted(t *testing.T) {
+	client, server, mgr, _ := serveRaftClusterBridgePipe(t, raftcluster.LeaderAdmission())
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := client.Hello(ctx); err != nil {
+		t.Fatalf("Hello: %v", err)
+	}
+	before := clientCatalogVersion(t, client, ctx)
+	createSections := raftClusterCreateCollectionSections("users", before, AckRaftCommitted)
+	createResponse, err := client.commandSections(ctx, iwire.CommandCreateCollection, createSections...)
+	if err != nil {
+		t.Fatalf("CreateCollection raft bridge: %v", err)
+	}
+	meta, err := firstMetaFromResponse(createResponse)
+	if err != nil {
+		t.Fatalf("CreateCollection response meta: %v", err)
+	}
+	if meta.Name != "users" {
+		t.Fatalf("created collection=%q want users", meta.Name)
+	}
+	if ack, ok, err := responseMetaAckPolicy(createResponse); err != nil || !ok || ack != AckRaftCommitted {
+		t.Fatalf("create response ack=(%d,%v,%v) want raft_committed", ack, ok, err)
+	}
+	afterCreate, err := server.currentCatalogVersion()
+	if err != nil {
+		t.Fatalf("server currentCatalogVersion: %v", err)
+	}
+	if afterCreate <= before {
+		t.Fatalf("catalog version after create=%d want > %d", afterCreate, before)
+	}
+
+	insertResponse, err := client.commandSections(ctx, iwire.CommandInsertBatch, clusterInsertBatchSections(t, client, ctx, AckRaftCommitted, "u1")...)
+	if err != nil {
+		t.Fatalf("InsertBatch raft bridge: %v", err)
+	}
+	if ack, ok, err := responseMetaAckPolicy(insertResponse); err != nil || !ok || ack != AckRaftCommitted {
+		t.Fatalf("insert response ack=(%d,%v,%v) want raft_committed", ack, ok, err)
+	}
+	inserted, err := responseCount(insertResponse, "inserted_count")
+	if err != nil {
+		t.Fatalf("inserted_count: %v", err)
+	}
+	if inserted != 1 {
+		t.Fatalf("inserted_count=%d want 1", inserted)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("OpenCollection users: %v", err)
+	}
+	got, err := col.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("Get u1: %v", err)
+	}
+	if !bytes.Equal(got, []byte(`{"name":"Ada"}`)) {
+		t.Fatalf("stored doc=%s want Ada JSON", got)
+	}
+}
+
+func TestRaftClusterSubmitterConcreteBridgeVisibleAckDoesNotClaimRaft(t *testing.T) {
+	client, _, _, _ := serveRaftClusterBridgePipe(t, raftcluster.LeaderAdmission())
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := client.Hello(ctx); err != nil {
+		t.Fatalf("Hello: %v", err)
+	}
+	version := clientCatalogVersion(t, client, ctx)
+	if _, err := client.commandSections(ctx, iwire.CommandCreateCollection, raftClusterCreateCollectionSections("users", version, AckRaftCommitted)...); err != nil {
+		t.Fatalf("CreateCollection raft bridge: %v", err)
+	}
+	insertResponse, err := client.commandSections(ctx, iwire.CommandInsertBatch, clusterInsertBatchSections(t, client, ctx, AckVisible, "u1")...)
+	if err != nil {
+		t.Fatalf("InsertBatch visible bridge: %v", err)
+	}
+	if ack, ok, err := responseMetaAckPolicy(insertResponse); err != nil || !ok || ack != AckVisible {
+		t.Fatalf("visible response ack=(%d,%v,%v) want visible", ack, ok, err)
+	}
+}
+
+func TestRaftClusterSubmitterConcreteBridgeFollowerRejectsBeforeApply(t *testing.T) {
+	client, _, mgr, _ := serveRaftClusterBridgePipe(t, raftcluster.FollowerAdmission("node-b", "not leader"))
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := client.Hello(ctx); err != nil {
+		t.Fatalf("Hello: %v", err)
+	}
+	version := clientCatalogVersion(t, client, ctx)
+	_, err := client.commandSections(ctx, iwire.CommandCreateCollection, raftClusterCreateCollectionSections("users", version, AckRaftCommitted)...)
+	if !isRemoteError(err, iwire.ErrReadOnly) {
+		t.Fatalf("CreateCollection follower err=%v want read-only", err)
+	}
+	if _, openErr := mgr.OpenCollection("users"); !errors.Is(openErr, collections.ErrCollectionNotFound) {
+		t.Fatalf("OpenCollection users after follower rejection err=%v want ErrCollectionNotFound", openErr)
+	}
+}
+
 func clusterInsertBatchSections(t *testing.T, client *Client, ctx context.Context, ack AckPolicy, id string) []iwire.Section {
 	t.Helper()
 	sections := []iwire.Section{
@@ -1329,6 +1427,97 @@ func clusterInsertBatchSections(t *testing.T, client *Client, ctx context.Contex
 		documentFormatSection(collections.DocumentFormatJSON),
 		iwire.Section{ID: iwire.SectionDocumentIDs, Bytes: iwire.AppendByteVector(nil, []byte(id))},
 		iwire.Section{ID: iwire.SectionDocuments, Bytes: iwire.AppendByteVector(nil, []byte(`{"name":"Ada"}`))},
+	}
+	if ack != 0 {
+		sections = append(sections, ackSection(ack))
+	}
+	return sections
+}
+
+func serveRaftClusterBridgePipe(t *testing.T, admission raftcluster.AdmissionStatus) (*Client, *Server, *collections.CollectionManager, *backenddb.DB) {
+	t.Helper()
+	db, err := backenddb.Open(backenddb.Options{
+		Dir:                          t.TempDir(),
+		CommandWAL:                   true,
+		CommandWALStatsScan:          true,
+		CommandWALSegmentTargetBytes: 1 << 20,
+		DisableBackgroundPrune:       true,
+	})
+	if err != nil {
+		t.Fatalf("open command WAL db: %v", err)
+	}
+	mgr := collections.NewCollectionManager(db)
+	cluster := raftClusterBridgeTestConfig(db)
+	fsm, err := raftfsm.Open(raftfsm.Options{
+		DB:      db,
+		Cluster: cluster,
+		StoreOptions: raftapply.DurableApplyStoreOptions{
+			DisableSync: true,
+		},
+	})
+	if err != nil {
+		_ = db.Close()
+		t.Fatalf("open raft FSM: %v", err)
+	}
+	bridge, err := raftcluster.NewSingleGroupSubmitter(raftcluster.SingleGroupSubmitterOptions{
+		Cluster:           cluster,
+		AdmissionProvider: raftcluster.StaticAdmissionProvider{Status: admission},
+		CommitSource: raftcluster.NewSequencedCommitSource(raftcluster.SequencedCommitSourceOptions{
+			GroupID:             cluster.GroupID,
+			NodeID:              cluster.NodeID,
+			LeaderID:            cluster.NodeID,
+			EvidenceKind:        raftcluster.CommitEvidenceProductionConsensusV1,
+			ProductionConsensus: true,
+		}),
+		Applier: fsm,
+		CatalogVersionProvider: raftcluster.CatalogVersionProviderFunc(func(context.Context) (uint64, bool, error) {
+			state := db.State()
+			if state == nil {
+				return 0, false, nil
+			}
+			return state.CommitSeq, true, nil
+		}),
+	})
+	if err != nil {
+		_ = fsm.Close()
+		_ = db.Close()
+		t.Fatalf("NewSingleGroupSubmitter: %v", err)
+	}
+	server := NewServer(ServerOptions{
+		Collections:      mgr,
+		Backend:          db,
+		ClusterSubmitter: NewRaftClusterSubmitter(bridge),
+	})
+	client, _ := servePipe(t, server)
+	t.Cleanup(func() {
+		_ = fsm.Close()
+		_ = db.Close()
+	})
+	return client, server, mgr, db
+}
+
+func raftClusterBridgeTestConfig(db *backenddb.DB) raftcluster.Config {
+	dir := ""
+	if db != nil {
+		dir = db.Dir()
+	}
+	return raftcluster.Config{
+		Dir:     dir,
+		NodeID:  "node-a",
+		GroupID: "group-a",
+		Peers: []raftcluster.Peer{
+			{ID: "node-a", Address: "127.0.0.1:9301"},
+			{ID: "node-b", Address: "127.0.0.1:9302"},
+			{ID: "node-c", Address: "127.0.0.1:9303"},
+		},
+	}
+}
+
+func raftClusterCreateCollectionSections(name string, catalogVersion uint64, ack AckPolicy) []iwire.Section {
+	sections := []iwire.Section{
+		{ID: iwire.SectionIdempotencyKey, Bytes: []byte("cluster-create-" + name)},
+		{ID: iwire.SectionExpectedCatalogVersion, Bytes: binary.AppendUvarint(nil, catalogVersion)},
+		{ID: iwire.SectionCollectionMeta, Bytes: encodeCollectionMeta(collections.CollectionMeta{Name: name})},
 	}
 	if ack != 0 {
 		sections = append(sections, ackSection(ack))

--- a/TreeDB/nativewire/cluster_submitter_test.go
+++ b/TreeDB/nativewire/cluster_submitter_test.go
@@ -1393,7 +1393,14 @@ func TestRaftClusterSubmitterConcreteBridgeCreateInsertRaftCommitted(t *testing.
 		t.Fatalf("Hello: %v", err)
 	}
 	before := clientCatalogVersion(t, client, ctx)
-	createSections := raftClusterCreateCollectionSections("users", before, AckRaftCommitted)
+	createSections := raftClusterCreateCollectionSectionsWithMeta(collections.CollectionMeta{
+		Name: "users",
+		Indexes: []collections.IndexDefinition{{
+			Name:      "by_name",
+			Field:     "name",
+			ValueType: collections.IndexValueString,
+		}},
+	}, before, AckRaftCommitted)
 	createResponse, err := client.commandSections(ctx, iwire.CommandCreateCollection, createSections...)
 	if err != nil {
 		t.Fatalf("CreateCollection raft bridge: %v", err)
@@ -1404,6 +1411,12 @@ func TestRaftClusterSubmitterConcreteBridgeCreateInsertRaftCommitted(t *testing.
 	}
 	if meta.Name != "users" {
 		t.Fatalf("created collection=%q want users", meta.Name)
+	}
+	if meta.Options.DataRootStoragePolicy != collections.RootStorageFast ||
+		meta.Options.IndexStateStoragePolicy != collections.RootStorageFast ||
+		len(meta.Indexes) != 1 ||
+		meta.Indexes[0].StoragePolicy != collections.RootStorageFast {
+		t.Fatalf("created storage policies data=%q index=%q indexes=%+v, want fast policies", meta.Options.DataRootStoragePolicy, meta.Options.IndexStateStoragePolicy, meta.Indexes)
 	}
 	if ack, ok, err := responseMetaAckPolicy(createResponse); err != nil || !ok || ack != AckRaftCommitted {
 		t.Fatalf("create response ack=(%d,%v,%v) want raft_committed", ack, ok, err)
@@ -1440,6 +1453,38 @@ func TestRaftClusterSubmitterConcreteBridgeCreateInsertRaftCommitted(t *testing.
 	}
 	if !bytes.Equal(got, []byte(`{"name":"Ada"}`)) {
 		t.Fatalf("stored doc=%s want Ada JSON", got)
+	}
+	_ = clientCatalogVersion(t, client, ctx)
+
+	replaceMatched, replaceModified, err := client.ReplaceBatch(ctx, "users", collections.DocumentFormatJSON, [][]byte{[]byte("u1")}, [][]byte{[]byte(`{"name":"Ada"}`)}, AckRaftCommitted)
+	if err != nil {
+		t.Fatalf("ReplaceBatch no-op raft bridge: %v", err)
+	}
+	if replaceMatched != 1 || replaceModified != 0 {
+		t.Fatalf("ReplaceBatch no-op matched/modified=%d/%d want 1/0", replaceMatched, replaceModified)
+	}
+
+	bsonCreateVersion := clientCatalogVersion(t, client, ctx)
+	bsonCreateSections := raftClusterCreateCollectionSectionsWithMeta(collections.CollectionMeta{
+		Name: "bson_users",
+		Options: collections.CollectionOptions{
+			DocumentFormat: collections.DocumentFormatBSON,
+		},
+	}, bsonCreateVersion, AckRaftCommitted)
+	if _, err := client.commandSections(ctx, iwire.CommandCreateCollection, bsonCreateSections...); err != nil {
+		t.Fatalf("CreateCollection BSON raft bridge: %v", err)
+	}
+	_ = clientCatalogVersion(t, client, ctx)
+	bsonDoc := testNativewireBSONDocument(t, bson.D{{Key: "_id", Value: "b1"}, {Key: "city", Value: "hnl"}})
+	if _, err := client.InsertBatch(ctx, "bson_users", collections.DocumentFormatBSON, [][]byte{[]byte("b1")}, [][]byte{bsonDoc}, AckRaftCommitted); err != nil {
+		t.Fatalf("InsertBatch BSON raft bridge: %v", err)
+	}
+	updateMatched, updateModified, err := client.UpdateBSONSet(ctx, "bson_users", []byte("b1"), []collections.BSONSetField{{Key: "city", Value: testNativewireBSONSetRawValue(t, "hnl")}}, AckRaftCommitted)
+	if err != nil {
+		t.Fatalf("UpdateBSONSet no-op raft bridge: %v", err)
+	}
+	if updateMatched != 1 || updateModified != 0 {
+		t.Fatalf("UpdateBSONSet no-op matched/modified=%d/%d want 1/0", updateMatched, updateModified)
 	}
 }
 
@@ -1496,7 +1541,7 @@ func clusterInsertBatchSections(t *testing.T, client *Client, ctx context.Contex
 	return sections
 }
 
-func serveRaftClusterBridgePipe(t *testing.T, admission raftcluster.AdmissionStatus) (*Client, *Server, *collections.CollectionManager, *backenddb.DB) {
+func serveRaftClusterBridgePipe(t testing.TB, admission raftcluster.AdmissionStatus) (*Client, *Server, *collections.CollectionManager, *backenddb.DB) {
 	t.Helper()
 	db, err := backenddb.Open(backenddb.Options{
 		Dir:                          t.TempDir(),
@@ -1576,15 +1621,74 @@ func raftClusterBridgeTestConfig(db *backenddb.DB) raftcluster.Config {
 }
 
 func raftClusterCreateCollectionSections(name string, catalogVersion uint64, ack AckPolicy) []iwire.Section {
+	return raftClusterCreateCollectionSectionsWithMeta(collections.CollectionMeta{Name: name}, catalogVersion, ack)
+}
+
+func raftClusterCreateCollectionSectionsWithMeta(meta collections.CollectionMeta, catalogVersion uint64, ack AckPolicy) []iwire.Section {
 	sections := []iwire.Section{
-		{ID: iwire.SectionIdempotencyKey, Bytes: []byte("cluster-create-" + name)},
+		{ID: iwire.SectionIdempotencyKey, Bytes: []byte("cluster-create-" + meta.Name)},
 		{ID: iwire.SectionExpectedCatalogVersion, Bytes: binary.AppendUvarint(nil, catalogVersion)},
-		{ID: iwire.SectionCollectionMeta, Bytes: encodeCollectionMeta(collections.CollectionMeta{Name: name})},
+		{ID: iwire.SectionCollectionMeta, Bytes: encodeCollectionMeta(meta)},
 	}
 	if ack != 0 {
 		sections = append(sections, ackSection(ack))
 	}
 	return sections
+}
+
+func BenchmarkRaftClusterSubmitterConcreteBridgeUpdateBSONSet(b *testing.B) {
+	client, _, _, _ := serveRaftClusterBridgePipe(b, raftcluster.LeaderAdmission())
+	ctx := context.Background()
+	if err := client.Hello(ctx); err != nil {
+		b.Fatalf("Hello: %v", err)
+	}
+	version := clientCatalogVersion(b, client, ctx)
+	createSections := raftClusterCreateCollectionSectionsWithMeta(collections.CollectionMeta{
+		Name: "users",
+		Options: collections.CollectionOptions{
+			DocumentFormat: collections.DocumentFormatBSON,
+		},
+	}, version, AckRaftCommitted)
+	if _, err := client.commandSections(ctx, iwire.CommandCreateCollection, createSections...); err != nil {
+		b.Fatalf("CreateCollection raft bridge: %v", err)
+	}
+	_ = clientCatalogVersion(b, client, ctx)
+	id := []byte("u1")
+	doc := testNativewireBSONDocument(b, bson.D{{Key: "_id", Value: "u1"}, {Key: "city", Value: "hnl"}})
+	if _, err := client.InsertBatch(ctx, "users", collections.DocumentFormatBSON, [][]byte{id}, [][]byte{doc}, AckRaftCommitted); err != nil {
+		b.Fatalf("InsertBatch seed raft bridge: %v", err)
+	}
+	fields := []collections.BSONSetField{{Key: "city", Value: testNativewireBSONSetRawValue(b, "hnl")}}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		matched, modified, err := client.UpdateBSONSet(ctx, "users", id, fields, AckRaftCommitted)
+		if err != nil {
+			b.Fatalf("UpdateBSONSet raft bridge: %v", err)
+		}
+		if matched != 1 || modified != 0 {
+			b.Fatalf("UpdateBSONSet matched/modified=%d/%d want 1/0", matched, modified)
+		}
+	}
+	b.ReportMetric(float64(b.N), "ops_total")
+}
+
+func testNativewireBSONDocument(tb testing.TB, document bson.D) []byte {
+	tb.Helper()
+	encoded, err := bson.Marshal(document)
+	if err != nil {
+		tb.Fatalf("Marshal BSON: %v", err)
+	}
+	return encoded
+}
+
+func testNativewireBSONSetRawValue(tb testing.TB, value any) bson.RawValue {
+	tb.Helper()
+	typ, raw, err := bson.MarshalValue(value)
+	if err != nil {
+		tb.Fatalf("MarshalValue(%T): %v", value, err)
+	}
+	return bson.RawValue{Type: typ, Value: raw}
 }
 
 func replaceResponseAckPolicy(result ClusterSubmitResult, policy AckPolicy) ClusterSubmitResult {

--- a/TreeDB/nativewire/cluster_submitter_test.go
+++ b/TreeDB/nativewire/cluster_submitter_test.go
@@ -1537,6 +1537,57 @@ func TestRaftClusterSubmitterConcreteBridgeOmitResponseMetaAdvancesCatalogVersio
 	}
 }
 
+func TestRaftClusterSubmitterShapesResponseFromBridgeDecodedEntry(t *testing.T) {
+	defaultLimits := iwire.DefaultLimits()
+	limits := defaultLimits
+	limits.MaxSectionLen = defaultLimits.MaxSectionLen + (1 << 20)
+	entry := raftClusterLargeInsertBatchEntry(t, limits, int(defaultLimits.MaxSectionLen)+1)
+	applier := &recordingRaftClusterApplier{result: raftentry.ApplyResultV1{Status: raftentry.ApplyStatusApplied, AffectedCount: 1}}
+	cluster := raftClusterBridgeTestConfig(nil)
+	cluster.Dir = t.TempDir()
+	bridge, err := raftcluster.NewSingleGroupSubmitter(raftcluster.SingleGroupSubmitterOptions{
+		Cluster:           cluster,
+		AdmissionProvider: raftcluster.StaticAdmissionProvider{Status: raftcluster.LeaderAdmission()},
+		CommitSource: raftcluster.NewSequencedCommitSource(raftcluster.SequencedCommitSourceOptions{
+			GroupID:             cluster.GroupID,
+			NodeID:              cluster.NodeID,
+			LeaderID:            cluster.NodeID,
+			EvidenceKind:        raftcluster.CommitEvidenceProductionConsensusV1,
+			ProductionConsensus: true,
+		}),
+		Applier:                applier,
+		CatalogVersionProvider: raftcluster.CatalogVersionProviderFunc(func(context.Context) (uint64, bool, error) { return 7, true, nil }),
+		DecodeLimits:           limits,
+	})
+	if err != nil {
+		t.Fatalf("NewSingleGroupSubmitter: %v", err)
+	}
+
+	result, err := NewRaftClusterSubmitter(bridge).SubmitCommandEntryV1(context.Background(), entry, ClusterRequestMetadata{
+		RequestID: 17,
+		AckPolicy: AckRaftCommitted,
+	})
+	if err != nil {
+		t.Fatalf("SubmitCommandEntryV1: %v", err)
+	}
+	if result.ActualAck != AckRaftCommitted || !result.CommittedRecoverable {
+		t.Fatalf("ack/recoverable=%d/%v want raft_committed/true", result.ActualAck, result.CommittedRecoverable)
+	}
+	if applier.calls != 1 {
+		t.Fatalf("apply calls=%d want 1", applier.calls)
+	}
+	if _, err := metadataSection(result.ResponseSections, iwire.SectionDocumentIDs); err != nil {
+		t.Fatalf("document_ids response section: %v", err)
+	}
+	inserted, err := responseCount(result.ResponseSections, "inserted_count")
+	if err != nil {
+		t.Fatalf("inserted_count: %v", err)
+	}
+	if inserted != 1 {
+		t.Fatalf("inserted_count=%d want 1", inserted)
+	}
+}
+
 func TestRaftClusterSubmitterConcreteBridgeFollowerRejectsBeforeApply(t *testing.T) {
 	client, _, mgr, _ := serveRaftClusterBridgePipe(t, raftcluster.FollowerAdmission("node-b", "not leader"))
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
@@ -1655,6 +1706,17 @@ func serveRaftClusterBridgePipe(t testing.TB, admission raftcluster.AdmissionSta
 	return client, server, mgr, db
 }
 
+type recordingRaftClusterApplier struct {
+	calls  int
+	result raftentry.ApplyResultV1
+	err    error
+}
+
+func (a *recordingRaftClusterApplier) ApplyCommittedCommandEntryV1(context.Context, raftcluster.CommittedCommandEntryV1) (raftentry.ApplyResultV1, error) {
+	a.calls++
+	return a.result, a.err
+}
+
 func raftClusterBridgeTestConfig(db *backenddb.DB) raftcluster.Config {
 	dir := ""
 	if db != nil {
@@ -1670,6 +1732,29 @@ func raftClusterBridgeTestConfig(db *backenddb.DB) raftcluster.Config {
 			{ID: "node-c", Address: "127.0.0.1:9303"},
 		},
 	}
+}
+
+func raftClusterLargeInsertBatchEntry(tb testing.TB, limits iwire.Limits, documentLen int) []byte {
+	tb.Helper()
+	document := bytes.Repeat([]byte{'x'}, documentLen)
+	sections := []iwire.Section{
+		{ID: iwire.SectionCommandHeader, Bytes: iwire.AppendCommandHeader(nil, iwire.CommandHeader{ID: iwire.CommandInsertBatch, Version: 1})},
+		{ID: iwire.SectionIdempotencyKey, Bytes: []byte("raftcluster/large-insert")},
+		{ID: iwire.SectionExpectedCatalogVersion, Bytes: binary.AppendUvarint(nil, 7)},
+		collectionNameRef("users"),
+		documentFormatSection(collections.DocumentFormatJSON),
+		{ID: iwire.SectionDocumentIDs, Bytes: iwire.AppendByteVector(nil, []byte("large-1"))},
+		{ID: iwire.SectionDocuments, Bytes: iwire.AppendByteVector(nil, document)},
+	}
+	cmd, err := iwire.MustV1Registry().ValidateRequestSections(sections)
+	if err != nil {
+		tb.Fatalf("ValidateRequestSections: %v", err)
+	}
+	entry, err := iwire.AppendDeterministicEntryWithLimits(nil, cmd, limits)
+	if err != nil {
+		tb.Fatalf("AppendDeterministicEntryWithLimits: %v", err)
+	}
+	return entry
 }
 
 func raftClusterCreateCollectionSections(name string, catalogVersion uint64, ack AckPolicy) []iwire.Section {

--- a/TreeDB/nativewire/cluster_submitter_test.go
+++ b/TreeDB/nativewire/cluster_submitter_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"reflect"
 	"strings"
 	"sync"
@@ -1659,6 +1660,38 @@ func TestRaftClusterSubmitterLocalAckUnavailableMapsToNativeError(t *testing.T) 
 	err := nativeErrorForRaftClusterSubmit(raftcluster.ErrLocalAckUnavailable)
 	if code, ok := iwire.ErrorCodeOf(err); !ok || code != iwire.ErrDurabilityUnavailable {
 		t.Fatalf("nativeErrorForRaftClusterSubmit code=%v ok=%v err=%v, want durability-unavailable", code, ok, err)
+	}
+}
+
+func TestRaftClusterSubmitterPreservesCollectionConflictCodes(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want iwire.ErrorCode
+	}{
+		{
+			name: "duplicate_document_id",
+			err:  fmt.Errorf("raftapply: %w", collections.ErrDuplicateDocumentID),
+			want: iwire.ErrDuplicateDocumentID,
+		},
+		{
+			name: "document_exists",
+			err:  fmt.Errorf("raftapply: %w", collections.ErrDocumentExists),
+			want: iwire.ErrDocumentExists,
+		},
+		{
+			name: "unique_index_conflict",
+			err:  fmt.Errorf("raftapply: %w", collections.ErrUniqueIndexConflict),
+			want: iwire.ErrUniqueIndexConflict,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := nativeErrorForDeterministicCode(raftentry.ErrorRejectedConflictV1, tt.err)
+			if code, ok := iwire.ErrorCodeOf(err); !ok || code != tt.want {
+				t.Fatalf("nativeErrorForDeterministicCode code=%v ok=%v err=%v, want %v", code, ok, err, tt.want)
+			}
+		})
 	}
 }
 

--- a/TreeDB/nativewire/cluster_submitter_test.go
+++ b/TreeDB/nativewire/cluster_submitter_test.go
@@ -1189,6 +1189,33 @@ func TestClusterSubmitterCatalogGuardDoesNotBlockSubmitterReplay(t *testing.T) {
 	}
 }
 
+func TestClusterSubmitterCatalogVersionUpdateIsMonotonic(t *testing.T) {
+	server := NewServer(ServerOptions{})
+	if err := server.updateCatalogVersionFromClusterSubmitResult(ClusterSubmitResult{HasCatalogVersion: true, CatalogVersion: 10}); err != nil {
+		t.Fatalf("update explicit version 10: %v", err)
+	}
+	if err := server.updateCatalogVersionFromClusterSubmitResult(ClusterSubmitResult{HasCatalogVersion: true, CatalogVersion: 8}); err != nil {
+		t.Fatalf("update explicit version 8: %v", err)
+	}
+	if got := server.catalogVersion.Load(); got != 10 {
+		t.Fatalf("catalog version after stale explicit update=%d want 10", got)
+	}
+
+	if err := server.updateCatalogVersionFromClusterSubmitResult(ClusterSubmitResult{
+		ResponseSections: []iwire.Section{ackMetaCountsVersion(AckVisible, 12, true)},
+	}); err != nil {
+		t.Fatalf("update response-meta version 12: %v", err)
+	}
+	if err := server.updateCatalogVersionFromClusterSubmitResult(ClusterSubmitResult{
+		ResponseSections: []iwire.Section{ackMetaCountsVersion(AckVisible, 11, true)},
+	}); err != nil {
+		t.Fatalf("update response-meta version 11: %v", err)
+	}
+	if got := server.catalogVersion.Load(); got != 12 {
+		t.Fatalf("catalog version after stale response-meta update=%d want 12", got)
+	}
+}
+
 func TestClusterSubmitterUnsupportedCommandFailsBeforeMutation(t *testing.T) {
 	submitter := &fakeClusterSubmitter{}
 	client, _, mgr, _ := serveCollectionPipeWithServerAndOptions(t, ServerOptions{ClusterSubmitter: submitter})

--- a/TreeDB/nativewire/metadata_test.go
+++ b/TreeDB/nativewire/metadata_test.go
@@ -596,7 +596,7 @@ func catalogVersion(t *testing.T, db *backenddb.DB) uint64 {
 	return snap.State().CommitSeq
 }
 
-func clientCatalogVersion(t *testing.T, client *Client, ctx context.Context) uint64 {
+func clientCatalogVersion(t testing.TB, client *Client, ctx context.Context) uint64 {
 	t.Helper()
 	version, err := client.CurrentCatalogVersion(ctx)
 	if err != nil {

--- a/TreeDB/nativewire/server_test.go
+++ b/TreeDB/nativewire/server_test.go
@@ -12,7 +12,7 @@ import (
 	iwire "github.com/snissn/gomap/TreeDB/internal/nativewire"
 )
 
-func servePipe(t *testing.T, server *Server) (*Client, <-chan error) {
+func servePipe(t testing.TB, server *Server) (*Client, <-chan error) {
 	t.Helper()
 	left, right := net.Pipe()
 	errCh := make(chan error, 1)


### PR DESCRIPTION
## Summary
- add a single-group raftcluster submitter boundary with admission, commit-source evidence checks, catalog guards, and local apply/recoverability gating
- add a raftfsm committed-entry adapter plus a concrete nativewire cluster submitter wrapper
- add nativewire create/insert and Mongo majority insert coverage using the concrete bridge, and update the raftcluster spec

## Tests
- `GOWORK=off go test ./TreeDB/internal/raftcluster ./TreeDB/internal/raftfsm ./TreeDB/internal/raftapply ./TreeDB/internal/raftharness -count=1`
- `GOWORK=off go test ./TreeDB/nativewire -run 'TestClusterSubmitter|TestMutation.*Raft' -count=1`
- `GOWORK=off go test ./TreeDB/mongo_gateway -run 'TestClusterSubmitter|TestClusterAdmission' -count=1`
- `git diff --check origin/main...HEAD`

## Scope
Fixes #3383
Refs #3044

This does not implement #3045 recovery-status files, #3046 route-provider/multi-group fanout, read-index, snapshots/rejoin, or performance closeout.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a deterministic single-group Raft submit/apply bridge for cluster writes with preflight validation.
* **Bug Fixes**
  * Apply results and durable apply records now track `matched_count`, including correct normalization on idempotent replays (`matched_count = 0` for duplicates).
  * `create_collection` now correctly honors omitting response metadata during request validation.
  * Legacy durable apply result records remain readable, defaulting `matched_count` to `0`.
* **Documentation**
  * Updated Raft boundary and storage-format specifications for the new submit/apply contract and payload layout.
* **Tests**
  * Expanded coverage for admission, evidence gating, ordering, catalog-version progression, and end-to-end Raft submitter behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->