### PR TITLE
Report q1 dense group setup timing

### DIFF
--- a/TreeDB/collections/column_physical_q1_dense_1950_test.go
+++ b/TreeDB/collections/column_physical_q1_dense_1950_test.go
@@ -418,6 +418,9 @@ func assertColumnPhysicalQ1DenseOneShotSetupDiagnostics1950(tb testing.TB, label
 			diag.TypedColumnPrepareDensePreapplyNanos,
 			diag)
 	}
+	if diag.TypedColumnPrepareDenseGroupNanos < 0 {
+		tb.Fatalf("%s setup negative dense group diagnostics=%d diagnostics=%+v", label, diag.TypedColumnPrepareDenseGroupNanos, diag)
+	}
 }
 
 func reportColumnPhysicalQ1DenseBenchMetrics1950(b *testing.B, diag ColumnPhysicalQueryDiagnostics) {
@@ -439,6 +442,13 @@ func reportColumnPhysicalQ1DenseOneShotSetupBenchMetrics1950(b *testing.B, diag 
 	b.ReportMetric(float64(diag.TypedColumnPreparePairingNanos), "typed_column_prepare_pairing_nanos/op")
 	b.ReportMetric(float64(diag.TypedColumnPreparePartDecodeNanos), "typed_column_prepare_part_decode_nanos/op")
 	b.ReportMetric(float64(diag.TypedColumnPreparePostPrepareNanos), "typed_column_prepare_post_prepare_nanos/op")
+	b.ReportMetric(float64(diag.TypedColumnPrepareReadImageNanos), "typed_column_prepare_read_image_nanos/op")
+	b.ReportMetric(float64(diag.TypedColumnPrepareStateBuildNanos), "typed_column_prepare_state_build_nanos/op")
+	b.ReportMetric(float64(diag.TypedColumnPrepareDictionaryNanos), "typed_column_prepare_dictionary_nanos/op")
+	b.ReportMetric(float64(diag.TypedColumnPrepareRangeReadNanos), "typed_column_prepare_range_read_nanos/op")
+	b.ReportMetric(float64(diag.TypedColumnPrepareRangeReadBytes), "typed_column_prepare_range_read_bytes/op")
+	b.ReportMetric(float64(diag.TypedColumnPrepareAdapterNanos), "typed_column_prepare_adapter_nanos/op")
+	b.ReportMetric(float64(diag.TypedColumnPrepareDenseGroupNanos), "typed_column_prepare_dense_group_nanos/op")
 }
 
 func totalQ1DenseRows1950(batches [][]columnPhysicalJSONBenchParityEventP0) int {

--- a/TreeDB/collections/column_physical_typed_column_query.go
+++ b/TreeDB/collections/column_physical_typed_column_query.go
@@ -803,7 +803,7 @@ func decodeColumnTypedColumnPhysicalQueryRunnerPart(view columnPhysicalScanSnaps
 	rawScratch = raw
 	switch {
 	case columnTypedColumnPhysicalQueryUseDenseGroupCount(plan, req):
-		part, err = decodeTypedColumnPhysicalQueryDenseGroupCountPart(plan, view.FullConfig.SchemaHash, typedRef, physical, raw)
+		part, err = decodeTypedColumnPhysicalQueryDenseGroupCountPart(plan, view.FullConfig.SchemaHash, typedRef, physical, raw, prepareDiagnostics)
 	case columnTypedColumnPhysicalQueryUseDenseGroupHourCount(plan, req):
 		part, err = decodeTypedColumnPhysicalQueryDenseGroupHourCountPart(plan, view.FullConfig.SchemaHash, typedRef, physical, raw)
 	case columnTypedColumnPhysicalQueryUseDenseInt64Span(plan, req):

--- a/TreeDB/collections/typed_column_adapter.go
+++ b/TreeDB/collections/typed_column_adapter.go
@@ -1488,7 +1488,7 @@ func columnTypedColumnPhysicalQueryAdapterDictionaryModes(plan columnTypedColumn
 // decodeTypedColumnPhysicalQueryDenseGroupCountPart prepares the q1 typed-column
 // section fast path from the adapter seam so production query routing does not
 // import the typedcolumn data plane directly.
-func decodeTypedColumnPhysicalQueryDenseGroupCountPart(plan columnTypedColumnPhysicalQueryPlan, schemaHash uint64, typedRef, physical columnManifestAssetRefForScan, raw []byte) (columnTypedColumnPhysicalQueryPart, error) {
+func decodeTypedColumnPhysicalQueryDenseGroupCountPart(plan columnTypedColumnPhysicalQueryPlan, schemaHash uint64, typedRef, physical columnManifestAssetRefForScan, raw []byte, prepareDiagnostics *columnTypedColumnPhysicalQueryPrepareDiagnostics) (columnTypedColumnPhysicalQueryPart, error) {
 	image, err := typedcolumn.ParseColumnPartImage(raw)
 	if err != nil {
 		return columnTypedColumnPhysicalQueryPart{}, err
@@ -1514,7 +1514,14 @@ func decodeTypedColumnPhysicalQueryDenseGroupCountPart(plan columnTypedColumnPhy
 	if plan.SortKeyPrefix.Planned {
 		return columnTypedColumnPhysicalQueryPart{}, fmt.Errorf("%w: dense typed-column group-count does not support sort-key row pruning", ErrColumnQueryPlanUnsupported)
 	}
+	var phaseStart time.Time
+	if prepareDiagnostics != nil {
+		phaseStart = time.Now()
+	}
 	group, decodedBytes, blocks, err := typedColumnDenseGroupCountDistinctCodeColumn(adapterPart, plan.Fields, plan.GroupColumn, summary.Rows, "group-count group")
+	if prepareDiagnostics != nil {
+		prepareDiagnostics.DenseGroupNanos += time.Since(phaseStart).Nanoseconds()
+	}
 	if err != nil {
 		return columnTypedColumnPhysicalQueryPart{}, err
 	}
@@ -1708,7 +1715,7 @@ func decodeTypedColumnPhysicalQueryDensePartFromRanges(plan columnTypedColumnPhy
 	}
 	switch {
 	case columnTypedColumnPhysicalQueryUseDenseGroupCount(plan, req):
-		part, err := decodeTypedColumnPhysicalQueryDenseGroupCountPreparedPart(plan, summary, typedRef, physical, adapterPart, reader.bytesRead)
+		part, err := decodeTypedColumnPhysicalQueryDenseGroupCountPreparedPart(plan, summary, typedRef, physical, adapterPart, reader.bytesRead, prepareDiagnostics)
 		if prepareDiagnostics != nil {
 			prepareDiagnostics.RangeReadNanos += reader.readNanos
 			prepareDiagnostics.RangeReadBytes += reader.bytesRead
@@ -2183,11 +2190,18 @@ func typedColumnPhysicalQueryPreparedSummary(prepared *typedColumnPreparedPartSt
 	return summary, nil
 }
 
-func decodeTypedColumnPhysicalQueryDenseGroupCountPreparedPart(plan columnTypedColumnPhysicalQueryPlan, summary typedColumnAdapterImageSummary, typedRef, physical columnManifestAssetRefForScan, adapterPart *typedColumnAdapterPart, bytesRead int64) (columnTypedColumnPhysicalQueryPart, error) {
+func decodeTypedColumnPhysicalQueryDenseGroupCountPreparedPart(plan columnTypedColumnPhysicalQueryPlan, summary typedColumnAdapterImageSummary, typedRef, physical columnManifestAssetRefForScan, adapterPart *typedColumnAdapterPart, bytesRead int64, prepareDiagnostics *columnTypedColumnPhysicalQueryPrepareDiagnostics) (columnTypedColumnPhysicalQueryPart, error) {
 	if plan.SortKeyPrefix.Planned {
 		return columnTypedColumnPhysicalQueryPart{}, fmt.Errorf("%w: dense typed-column group-count does not support sort-key row pruning", ErrColumnQueryPlanUnsupported)
 	}
+	var phaseStart time.Time
+	if prepareDiagnostics != nil {
+		phaseStart = time.Now()
+	}
 	group, decodedBytes, blocks, err := typedColumnDenseGroupCountDistinctCodeColumn(adapterPart, plan.Fields, plan.GroupColumn, summary.Rows, "group-count group")
+	if prepareDiagnostics != nil {
+		prepareDiagnostics.DenseGroupNanos += time.Since(phaseStart).Nanoseconds()
+	}
 	if err != nil {
 		return columnTypedColumnPhysicalQueryPart{}, err
 	}


### PR DESCRIPTION
## Scope

Reports q1 dense group-count setup timing in the typed-column prepare diagnostics.

This is diagnostic/observability work for q1 `one_shot_end_to_end` / `no_aggregate_metadata` setup only. It does not claim a runtime improvement, aggregate metadata acceleration, or ClickHouse superiority.

## Changes

- Threads typed-column prepare diagnostics into the q1 raw dense group-count part decode path.
- Times q1 `typedColumnDenseGroupCountDistinctCodeColumn(...)` work into `TypedColumnPrepareDenseGroupNanos` for both raw-image and prepared-range decode paths.
- Adds the lower-level q1 setup counters to the q1 setup benchmark output, including dense group, read image, state build, dictionary, range read, adapter, and bytes-read counters.

## Validation

```sh
GOWORK=off go test ./TreeDB/collections -run 'TestColumnPhysicalQ1DenseTypedColumn(DirectPreparedParity|OneShotSetupDiagnostics)1950$|TestColumnPhysicalTypedColumnOneShotCacheQ1Q3NoMetadata3088|TestColumnPhysicalDenseTypedColumnTargetedRangeReads3090/q1_group_count' -count=1
GOWORK=off go test ./TreeDB/collections -run 'Q1|Q3|DenseGroupCount|DenseGroupHour|ColumnPhysicalTypedColumnOneShotCache' -count=1
GOWORK=off go test ./cmd/unified_bench -run 'Q1|Q3|ColumnStore.*Setup|TypedColumnSetup|JSONBenchCell' -count=1
git diff --check
GOWORK=off go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnPhysicalQ1DenseTypedColumnOneShotSetup1950$' -benchmem -benchtime=5x -count=1
```

Benchmark signal from the final merged-branch run:

```text
typed_column_prepare_dense_group_nanos/op 80180
```

Refs #3350.
Refs #3070.