### PR TITLE
[codex] Finalize #2026 closeout docs

### DIFF
--- a/docs/benchmarks/nativewire_ycsb_closeout_2026-06-30.md
+++ b/docs/benchmarks/nativewire_ycsb_closeout_2026-06-30.md
@@ -2,8 +2,8 @@
 
 Status: external `go-ycsb` nativewire load-only closeout evidence for #2026
 and #3355 refreshed on `origin/main` commit
-`61910b8eac108c5f2c35f07a374879d1fb2dc5c8`; reconciled by #3382 with the
-#3374 diagnostic classification at
+`61910b8eac108c5f2c35f07a374879d1fb2dc5c8`; reconciled by merged PR #3385
+with the #3374 diagnostic classification at
 `3f2c712bb700806b29deb872ed90531d4828ab79`.
 
 This refresh includes the later Raft snapshot/route-preflight merges that the
@@ -17,13 +17,17 @@ coverage at `61910b8eac108c5f2c35f07a374879d1fb2dc5c8`.
 This report records the final 100k and 1M nativewire YCSB load checks requested
 by #2026 after the deterministic publication/readability slices landed. It is
 developer-machine correctness and throughput evidence for the nativewire load
-path, and #3382 classifies the remaining invalid intermediate YCSB caveat as
-non-current TreeDB publication evidence. It does not replace the full MongoDB /
-TreeDB comparison matrix in `docs/benchmarks/ycsb_latest_main_2026-06-03.md`,
-and it does not claim distributed Raft HA, read-index/snapshot/rejoin, or
-routing/fanout readiness.
+path, and #3385 classifies the remaining invalid intermediate YCSB caveat as
+non-current TreeDB publication evidence. Together with the deterministic
+publication/readability proofs and #3374 classification, this is sufficient to
+close the local storage-publication/readability tracker #2026. It does not
+replace the full MongoDB / TreeDB comparison matrix in
+`docs/benchmarks/ycsb_latest_main_2026-06-03.md`, and it does not claim
+distributed HA, Raft read-index/snapshots/rejoin, or routing/fanout readiness.
+Those distributed scopes remain out of #2026 and are tracked by
+#3044/#3045/#3046.
 
-## #3382 Reconciliation
+## #3385 Reconciliation
 
 The local #2026 closeout state is:
 
@@ -37,14 +41,14 @@ The local #2026 closeout state is:
   non-reproduced client/harness/protocol/server-lifecycle interruption, not as
   evidence of a current catalog/value-log publication failure.
 
-#3382 did not rerun `scripts/nativewire_ycsb_diagnostic.sh`. The diagnostic
+#3385 did not rerun `scripts/nativewire_ycsb_diagnostic.sh`. The diagnostic
 evidence at `3f2c712bb700806b29deb872ed90531d4828ab79` already includes the
 later route-preflight context that made the original `61910b8e...` evidence
 worth refreshing. The remaining delta to current `origin/main` `f42a7002b` is
 Raft snapshot-tail work, diagnostic script/docs changes, and Q2 query
 benchmark/reference-fill work, not changes to the nativewire insert path,
 collection catalog publication path, or value-log pointer read-boundary code.
-That makes #3382 a docs-only closeout reconciliation rather than a fresh
+That makes #3385 a docs-only closeout reconciliation rather than a fresh
 benchmark run.
 
 ## Benchmark Boundary
@@ -188,7 +192,7 @@ server with zero insert errors on this host. The refreshed capture removes the
 stale-head caveat from the earlier `2b784debb05028f706b46127a41f6d578c3d4c13`
 run. Together with the deterministic publication/readability tests and the
 #3374 diagnostic classification, it supports closing #2026 for the local
-single-node publication/readability invariant after #3382 merges.
+single-node publication/readability invariant now that PR #3385 has merged.
 
 During the current-base refresh, an invalid intermediate 1M run at
 `/tmp/treedb_native_ycsb_current_head_20260629_202356` stopped at 768,001
@@ -211,4 +215,5 @@ than evidence of a current catalog/value-log publication failure.
 
 This remains single-host nativewire load evidence. Distributed single-group HA,
 linearizable reads/snapshots/rejoin, and multi-group routing/ring partitioning
-remain owned by #3044, #3045, and #3046 respectively.
+remain out of scope for #2026 and are tracked by #3044, #3045, and #3046
+respectively.

--- a/docs/benchmarks/nativewire_ycsb_closeout_2026-06-30.md
+++ b/docs/benchmarks/nativewire_ycsb_closeout_2026-06-30.md
@@ -44,12 +44,13 @@ The local #2026 closeout state is:
 #3385 did not rerun `scripts/nativewire_ycsb_diagnostic.sh`. The diagnostic
 evidence at `3f2c712bb700806b29deb872ed90531d4828ab79` already includes the
 later route-preflight context that made the original `61910b8e...` evidence
-worth refreshing. The remaining delta to current `origin/main` `f42a7002b` is
-Raft snapshot-tail work, diagnostic script/docs changes, and Q2 query
-benchmark/reference-fill work, not changes to the nativewire insert path,
-collection catalog publication path, or value-log pointer read-boundary code.
-That makes #3385 a docs-only closeout reconciliation rather than a fresh
-benchmark run.
+worth refreshing. #3385 merged after the #3384 catalog-backed cluster route
+provider delta (`2e03fb95`) and on top of `origin/main` `fef8b711`, so this
+no-rerun boundary already includes that nativewire route-provider change. The
+remaining delta introduced here is docs-only closeout text, not changes to the
+nativewire insert path, collection catalog publication path, route-provider
+selection path, or value-log pointer read-boundary code. That makes this PR a
+docs-only closeout reconciliation rather than a fresh benchmark run.
 
 ## Benchmark Boundary
 

--- a/docs/benchmarks/nativewire_ycsb_insert_error_classification_2026-06-30.md
+++ b/docs/benchmarks/nativewire_ycsb_insert_error_classification_2026-06-30.md
@@ -1,34 +1,36 @@
 # TreeDB Nativewire YCSB INSERT_ERROR Classification
 
 Status: diagnostic classification evidence for #3374 under parent #2026,
-reconciled by #3382 as the final nativewire YCSB caveat classification for
-local publication/readability closeout.
+reconciled by merged PR #3385 as the final nativewire YCSB caveat
+classification for local publication/readability closeout.
 
 This report classifies the invalid intermediate 1M nativewire YCSB load at
 `/tmp/treedb_native_ycsb_current_head_20260629_202356` and records a fresh
 current-head diagnostic gate with client-side operation error logging enabled.
 It only covers the remaining intermittent `INSERT_ERROR` caveat from the #3364
-refresh. By itself it does not claim Raft HA, snapshot/read-index/routing, or a
-full #2026 closeout. Combined with the deterministic local
-publication/readability tests and the #3382 verification-matrix update, it
-removes the nativewire YCSB caveat as a blocker to closing #2026 for local
-single-node storage publication/readability.
+refresh. By itself it does not claim distributed HA, Raft
+read-index/snapshots/rejoin, or routing/fanout readiness, and it does not
+independently close #2026. Combined with the deterministic local
+publication/readability tests, the current-head nativewire YCSB evidence, and
+the #3385 verification-matrix update, it removes the nativewire YCSB caveat as
+a blocker to closing #2026 as the local single-node storage
+publication/readability tracker.
 
-## #3382 Reconciliation
+## #3385 Reconciliation
 
 The diagnostic commit recorded by this artifact is
-`3f2c712bb700806b29deb872ed90531d4828ab79`. #3382 did not rerun the diagnostic
+`3f2c712bb700806b29deb872ed90531d4828ab79`. #3385 did not rerun the diagnostic
 script because the delta to current `origin/main` `f42a7002b` is Raft
 snapshot-tail work, this diagnostic script/docs merge, and Q2 query
 benchmark/reference-fill work; it does not modify the nativewire insert path,
 collection catalog publication path, or value-log pointer read-boundary code
 that #2026 owns.
 
-After #3382 merges, this classification should be read as final for the invalid
+After PR #3385 merged, this classification should be read as final for the invalid
 intermediate YCSB artifact: it is a non-reproduced
 client/harness/protocol/server-lifecycle interruption, not current evidence of
 a TreeDB catalog/value-log publication failure. The residual distributed
-cluster work remains outside #2026 and is owned by #3044, #3045, and #3046.
+cluster work remains outside #2026 and is tracked by #3044, #3045, and #3046.
 
 ## Boundary
 
@@ -196,11 +198,11 @@ fatal, `ERROR`, or `Failed` text.
 | Artifact | Classification | Evidence | Residual Risk |
 | --- | --- | --- | --- |
 | `/tmp/treedb_native_ycsb_current_head_20260629_202356` | Invalid, non-reproduced intermediate client/harness/protocol/server-lifecycle interruption. Not evidence of a current TreeDB catalog/value-log publication/readability failure. | The 1M run reports client-side `INSERT_ERROR` counters, but no server-side `EOF`, ambiguous commit, panic, fatal error, or failure marker. The original command lacked error logging, so it cannot identify the exact client error string. Later clean #3364 evidence and the logged current-head #3374 diagnostic both complete 100k and 1M loads with zero raw scan matches. | The exact old client error is unavailable. If this shape recurs with `TREEDB_YCSB_LOG_ERRORS=1`, preserve the artifact and classify the logged error string as client harness, nativewire protocol, server lifecycle, or storage. |
-| `/tmp/treedb_native_ycsb_diagnostic_20260629_224839` | Current-head diagnostic pass. | 100k and 1M loads both exit 0, complete all requested inserts, produce empty stderr, and scan clean for `INSERT_ERROR`, `EOF`, `ambiguous`, `panic`, `fatal`, `ERROR`, and `Failed`. | This is a single-host developer-machine diagnostic gate, not a distributed HA proof. After #3382 merges it supports #2026 local closeout, while #3044/#3045/#3046 retain distributed HA/read/routing scope. |
+| `/tmp/treedb_native_ycsb_diagnostic_20260629_224839` | Current-head diagnostic pass. | 100k and 1M loads both exit 0, complete all requested inserts, produce empty stderr, and scan clean for `INSERT_ERROR`, `EOF`, `ambiguous`, `panic`, `fatal`, `ERROR`, and `Failed`. | This is a single-host developer-machine diagnostic gate, not a distributed HA proof. After PR #3385 merged it supports closing #2026 for local storage publication/readability, while #3044/#3045/#3046 retain distributed HA, Raft read-index/snapshots/rejoin, and routing/fanout scope. |
 
 Conclusion: the preserved intermediate `INSERT_ERROR` artifact should be treated
 as a non-reproduced diagnostic caveat, not as current evidence of a TreeDB-owned
 storage publication bug. The old artifact is still useful because it explains
 why #2026 stayed open after #3364, but the current logged gate makes the caveat
-defensible and final for #3382: if the failure recurs, the harness now captures
+defensible and final for #3385: if the failure recurs, the harness now captures
 the missing client-side error strings needed to assign ownership.

--- a/docs/benchmarks/ycsb_mongodb_treedb_current.md
+++ b/docs/benchmarks/ycsb_mongodb_treedb_current.md
@@ -37,11 +37,12 @@ counts. It includes the later Raft snapshot/route-preflight merges, but does
 not replace the full comparison matrix above. The follow-up #3374 diagnostic
 report, `docs/benchmarks/nativewire_ycsb_insert_error_classification_2026-06-30.md`,
 classifies the previously invalid intermediate 1M `INSERT_ERROR` artifact with
-a current-head rerun using client-side error logging. The #3382 reconciliation
-combines those reports with the deterministic local publication/readability
-tests and treats the nativewire YCSB caveat as closed for #2026 local
-publication/readability. Distributed HA, read-index/snapshot/rejoin, and
-routing/fanout remain owned by #3044, #3045, and #3046.
+a current-head rerun using client-side error logging. The merged PR #3385
+reconciliation combines those reports with the deterministic local
+publication/readability tests and the #3374 classification, and it is
+sufficient to close #2026 as the local storage-publication/readability tracker.
+Distributed HA, Raft read-index/snapshots/rejoin, and routing/fanout remain out
+of scope for #2026 and are tracked by #3044, #3045, and #3046.
 
 ## Current Headline
 
@@ -62,8 +63,8 @@ UTC latest-main report.
 
 | report | status | use |
 | --- | --- | --- |
-| `docs/benchmarks/nativewire_ycsb_insert_error_classification_2026-06-30.md` | #3374 classification of the invalid intermediate nativewire `INSERT_ERROR` caveat; final for #3382 local closeout. | Use for the current-head diagnostic run with `TREEDB_YCSB_LOG_ERRORS=1`, `-p silence=false`, raw scan counts, and the owner/risk classification for `/tmp/treedb_native_ycsb_current_head_20260629_202356`. |
-| `docs/benchmarks/nativewire_ycsb_closeout_2026-06-30.md` | #2026 nativewire load-only closeout evidence refreshed after later Raft merges; reconciled by #3382. | Use for the 100k and 1M external `go-ycsb treedb-native` load proof on commit `61910b8eac108c5f2c35f07a374879d1fb2dc5c8` with `collection_meta` v5 compatibility; use the #3374 classification report for the recorded invalid intermediate 1M run. |
+| `docs/benchmarks/nativewire_ycsb_insert_error_classification_2026-06-30.md` | #3374 classification of the invalid intermediate nativewire `INSERT_ERROR` caveat; final for the #3385 local closeout. | Use for the current-head diagnostic run with `TREEDB_YCSB_LOG_ERRORS=1`, `-p silence=false`, raw scan counts, and the owner/risk classification for `/tmp/treedb_native_ycsb_current_head_20260629_202356`. |
+| `docs/benchmarks/nativewire_ycsb_closeout_2026-06-30.md` | #2026 nativewire load-only closeout evidence refreshed after later Raft merges; reconciled by #3385. | Use for the 100k and 1M external `go-ycsb treedb-native` load proof on commit `61910b8eac108c5f2c35f07a374879d1fb2dc5c8` with `collection_meta` v5 compatibility; use the #3374 classification report for the recorded invalid intermediate 1M run. |
 | `docs/benchmarks/ycsb_latest_main_2026-06-03.md` | Current external YCSB report. | Use for current headline MongoDB / TreeDB nativewire / TreeDB Mongo gateway results on latest `origin/main` after the June 3 rerun. |
 | `docs/benchmarks/ycsb_post_update_stack_2026-06-02.md` | Superseded latest-current report. | Keep for post-update-path-stack evidence before the latest main rerun and for comparison deltas. |
 | `docs/benchmarks/ycsb_mongodb_treedb_2026-05-31.md` | Historical legacy-profile report. | Keep for the original MongoDB / TreeDB native / TreeDB Mongo comparison and the post-load Mongo-gateway cliff attribution. Do not use its `fast` rows as current public-profile guidance. |


### PR DESCRIPTION
## Summary

- Update the #2026 YCSB closeout docs to state that the local storage-publication/readability tracker can close after merged PR #3385.
- Tie the closeout to the deterministic publication/readability proofs, current-head nativewire YCSB evidence, and #3374 classification.
- Keep distributed HA, Raft read-index/snapshots/rejoin, and routing/fanout explicitly out of #2026 and tracked by #3044/#3045/#3046.
- Preserve the guidance to recapture future failures with `TREEDB_YCSB_LOG_ERRORS=1`.

## Validation

```sh
$ GOWORK=off go test ./TreeDB/docs -count=1
ok  	github.com/snissn/gomap/TreeDB/docs	1.115s
```

```sh
$ git diff --check origin/main...HEAD
```

No output; command exited 0.
