### PR TITLE
Split q1 raw typed-column setup diagnostics

### DIFF
--- a/TreeDB/collections/column_physical_q1_dense_1950_test.go
+++ b/TreeDB/collections/column_physical_q1_dense_1950_test.go
@@ -421,6 +421,23 @@ func assertColumnPhysicalQ1DenseOneShotSetupDiagnostics1950(tb testing.TB, label
 	if diag.TypedColumnPrepareDenseGroupNanos < 0 {
 		tb.Fatalf("%s setup negative dense group diagnostics=%d diagnostics=%+v", label, diag.TypedColumnPrepareDenseGroupNanos, diag)
 	}
+	rawSetupNanos := diag.TypedColumnPrepareReadImageNanos +
+		diag.TypedColumnPrepareStateBuildNanos +
+		diag.TypedColumnPrepareDictionaryNanos +
+		diag.TypedColumnPrepareAdapterNanos
+	if rawSetupNanos != 0 &&
+		(diag.TypedColumnPrepareReadImageNanos <= 0 ||
+			diag.TypedColumnPrepareStateBuildNanos <= 0 ||
+			diag.TypedColumnPrepareDictionaryNanos <= 0 ||
+			diag.TypedColumnPrepareAdapterNanos <= 0) {
+		tb.Fatalf("%s setup raw split diagnostics read_image=%d state_build=%d dictionary=%d adapter=%d diagnostics=%+v",
+			label,
+			diag.TypedColumnPrepareReadImageNanos,
+			diag.TypedColumnPrepareStateBuildNanos,
+			diag.TypedColumnPrepareDictionaryNanos,
+			diag.TypedColumnPrepareAdapterNanos,
+			diag)
+	}
 }
 
 func reportColumnPhysicalQ1DenseBenchMetrics1950(b *testing.B, diag ColumnPhysicalQueryDiagnostics) {

--- a/TreeDB/collections/column_physical_q1_dense_1950_test.go
+++ b/TreeDB/collections/column_physical_q1_dense_1950_test.go
@@ -425,12 +425,15 @@ func assertColumnPhysicalQ1DenseOneShotSetupDiagnostics1950(tb testing.TB, label
 		diag.TypedColumnPrepareStateBuildNanos +
 		diag.TypedColumnPrepareDictionaryNanos +
 		diag.TypedColumnPrepareAdapterNanos
-	if rawSetupNanos != 0 &&
-		(diag.TypedColumnPrepareReadImageNanos <= 0 ||
-			diag.TypedColumnPrepareStateBuildNanos <= 0 ||
-			diag.TypedColumnPrepareDictionaryNanos <= 0 ||
-			diag.TypedColumnPrepareAdapterNanos <= 0) {
-		tb.Fatalf("%s setup raw split diagnostics read_image=%d state_build=%d dictionary=%d adapter=%d diagnostics=%+v",
+	if diag.TypedColumnPrepareRangeReadNanos != 0 || diag.TypedColumnPrepareRangeReadBytes != 0 {
+		tb.Fatalf("%s setup range-read diagnostics=%d/%d want 0 for raw q1 setup diagnostics=%+v",
+			label,
+			diag.TypedColumnPrepareRangeReadNanos,
+			diag.TypedColumnPrepareRangeReadBytes,
+			diag)
+	}
+	if diag.TypedColumnPreparePartDecodeNanos != 0 && rawSetupNanos == 0 {
+		tb.Fatalf("%s setup missing raw split diagnostics read_image=%d state_build=%d dictionary=%d adapter=%d diagnostics=%+v",
 			label,
 			diag.TypedColumnPrepareReadImageNanos,
 			diag.TypedColumnPrepareStateBuildNanos,

--- a/TreeDB/collections/column_physical_typed_column_query.go
+++ b/TreeDB/collections/column_physical_typed_column_query.go
@@ -799,7 +799,14 @@ func decodeColumnTypedColumnPhysicalQueryRunnerPart(view columnPhysicalScanSnaps
 	if rangeOK {
 		return part, rawScratch, nil
 	}
+	var phaseStart time.Time
+	if prepareDiagnostics != nil {
+		phaseStart = time.Now()
+	}
 	raw, err := readCache.read(typedRef.Ref, rawScratch)
+	if prepareDiagnostics != nil {
+		prepareDiagnostics.ReadImageNanos += time.Since(phaseStart).Nanoseconds()
+	}
 	if err != nil {
 		if errors.Is(err, io.ErrUnexpectedEOF) {
 			return columnTypedColumnPhysicalQueryPart{}, rawScratch, fmt.Errorf("collections: typed-column part physical query read generation=%d part_id=%d short read: %w", typedRef.Ref.Generation, typedRef.Ref.PartID, err)

--- a/TreeDB/collections/typed_column_adapter.go
+++ b/TreeDB/collections/typed_column_adapter.go
@@ -1026,15 +1026,26 @@ func typedColumnAdapterPartFromImage(opts typedColumnAdapterOptions, image typed
 }
 
 func typedColumnAdapterPartFromImageWithoutRowLocators(opts typedColumnAdapterOptions, image typedcolumn.ColumnPartImage) (*typedColumnAdapterPart, error) {
+	return typedColumnAdapterPartFromImageWithoutRowLocatorsWithDiagnostics(opts, image, nil)
+}
+
+func typedColumnAdapterPartFromImageWithoutRowLocatorsWithDiagnostics(opts typedColumnAdapterOptions, image typedcolumn.ColumnPartImage, prepareDiagnostics *columnTypedColumnPhysicalQueryPrepareDiagnostics) (*typedColumnAdapterPart, error) {
+	var phaseStart time.Time
+	if prepareDiagnostics != nil {
+		phaseStart = time.Now()
+	}
 	part, err := typedcolumn.ColumnPartFromImageWithOptions(image, typedcolumn.ColumnPartImageReadOptions{
 		IncludeRowLocators:       false,
 		ValidateRowLocators:      false,
 		IncludeAggregateMetadata: false,
 	})
+	if prepareDiagnostics != nil {
+		prepareDiagnostics.StateBuildNanos += time.Since(phaseStart).Nanoseconds()
+	}
 	if err != nil {
 		return nil, err
 	}
-	return typedColumnAdapterPartFromDecodedImage(opts, image, part)
+	return typedColumnAdapterPartFromDecodedImageWithDiagnostics(opts, image, part, prepareDiagnostics)
 }
 
 func typedColumnAdapterPartFromImageForInt64PredicateScan(opts typedColumnAdapterOptions, image typedcolumn.ColumnPartImage) (*typedColumnAdapterPart, error) {
@@ -1091,19 +1102,43 @@ func validateTypedColumnAdapterInt64AggregateImage(part *typedcolumn.ColumnPart,
 }
 
 func typedColumnAdapterPartFromDecodedImage(opts typedColumnAdapterOptions, image typedcolumn.ColumnPartImage, part *typedcolumn.ColumnPart) (*typedColumnAdapterPart, error) {
+	return typedColumnAdapterPartFromDecodedImageWithDiagnostics(opts, image, part, nil)
+}
+
+func typedColumnAdapterPartFromDecodedImageWithDiagnostics(opts typedColumnAdapterOptions, image typedcolumn.ColumnPartImage, part *typedcolumn.ColumnPart, prepareDiagnostics *columnTypedColumnPhysicalQueryPrepareDiagnostics) (*typedColumnAdapterPart, error) {
+	var phaseStart time.Time
+	if prepareDiagnostics != nil {
+		phaseStart = time.Now()
+	}
 	columns, err := typedColumnAdapterColumnsForFieldsWithOptions(opts.Fields, opts)
 	if err != nil {
+		if prepareDiagnostics != nil {
+			prepareDiagnostics.AdapterNanos += time.Since(phaseStart).Nanoseconds()
+		}
 		return nil, err
 	}
 	if err := validateTypedColumnAdapterImageSchema(part, columns, opts.SchemaVersion); err != nil {
+		if prepareDiagnostics != nil {
+			prepareDiagnostics.AdapterNanos += time.Since(phaseStart).Nanoseconds()
+		}
 		return nil, err
 	}
 	applyTypedColumnAdapterStoredDefinitions(columns, part)
+	if prepareDiagnostics != nil {
+		prepareDiagnostics.AdapterNanos += time.Since(phaseStart).Nanoseconds()
+		phaseStart = time.Now()
+	}
 	dictionaries, err := image.Dictionaries()
 	if err != nil {
+		if prepareDiagnostics != nil {
+			prepareDiagnostics.DictionaryNanos += time.Since(phaseStart).Nanoseconds()
+		}
 		return nil, err
 	}
 	if err := validateTypedColumnAdapterMetadata(dictionaries, columns); err != nil {
+		if prepareDiagnostics != nil {
+			prepareDiagnostics.DictionaryNanos += time.Since(phaseStart).Nanoseconds()
+		}
 		return nil, err
 	}
 	for i := range columns {
@@ -1114,6 +1149,9 @@ func typedColumnAdapterPartFromDecodedImage(opts typedColumnAdapterOptions, imag
 				return nil, fmt.Errorf("collections: typed-column adapter image missing dictionary for %q", columns[i].Definition.Name)
 			}
 			if err := validateTypedColumnAdapterStringDictionary(columns[i], partColumn.Definition.Cardinality, dict); err != nil {
+				if prepareDiagnostics != nil {
+					prepareDiagnostics.DictionaryNanos += time.Since(phaseStart).Nanoseconds()
+				}
 				return nil, err
 			}
 			columns[i].Definition.Cardinality = partColumn.Definition.Cardinality
@@ -1127,11 +1165,17 @@ func typedColumnAdapterPartFromDecodedImage(opts typedColumnAdapterOptions, imag
 			if mode.ValuesByCode {
 				valuesByCode, err := typedColumnAdapterDictionaryValuesByCodeFromForward(dict, int(partColumn.Definition.Cardinality))
 				if err != nil {
+					if prepareDiagnostics != nil {
+						prepareDiagnostics.DictionaryNanos += time.Since(phaseStart).Nanoseconds()
+					}
 					return nil, err
 				}
 				columns[i].DictionaryValuesByCode = valuesByCode
 			}
 		}
+	}
+	if prepareDiagnostics != nil {
+		prepareDiagnostics.DictionaryNanos += time.Since(phaseStart).Nanoseconds()
 	}
 	return &typedColumnAdapterPart{Options: opts, Columns: columns, Part: part, Dictionary: dictionaries}, nil
 }
@@ -1489,15 +1533,22 @@ func columnTypedColumnPhysicalQueryAdapterDictionaryModes(plan columnTypedColumn
 // section fast path from the adapter seam so production query routing does not
 // import the typedcolumn data plane directly.
 func decodeTypedColumnPhysicalQueryDenseGroupCountPart(plan columnTypedColumnPhysicalQueryPlan, schemaHash uint64, typedRef, physical columnManifestAssetRefForScan, raw []byte, prepareDiagnostics *columnTypedColumnPhysicalQueryPrepareDiagnostics) (columnTypedColumnPhysicalQueryPart, error) {
+	var phaseStart time.Time
+	if prepareDiagnostics != nil {
+		phaseStart = time.Now()
+	}
 	image, err := typedcolumn.ParseColumnPartImage(raw)
+	if prepareDiagnostics != nil {
+		prepareDiagnostics.ReadImageNanos += time.Since(phaseStart).Nanoseconds()
+	}
 	if err != nil {
 		return columnTypedColumnPhysicalQueryPart{}, err
 	}
-	adapterPart, err := typedColumnAdapterPartFromImageWithoutRowLocators(typedColumnAdapterOptions{
+	adapterPart, err := typedColumnAdapterPartFromImageWithoutRowLocatorsWithDiagnostics(typedColumnAdapterOptions{
 		Fields:          plan.Fields,
 		SchemaVersion:   uint32(schemaHash),
 		DictionaryModes: columnTypedColumnPhysicalQueryAdapterDictionaryModes(plan, []string{plan.GroupColumn}, nil),
-	}, image)
+	}, image, prepareDiagnostics)
 	if err != nil {
 		return columnTypedColumnPhysicalQueryPart{}, err
 	}
@@ -1514,7 +1565,6 @@ func decodeTypedColumnPhysicalQueryDenseGroupCountPart(plan columnTypedColumnPhy
 	if plan.SortKeyPrefix.Planned {
 		return columnTypedColumnPhysicalQueryPart{}, fmt.Errorf("%w: dense typed-column group-count does not support sort-key row pruning", ErrColumnQueryPlanUnsupported)
 	}
-	var phaseStart time.Time
 	if prepareDiagnostics != nil {
 		phaseStart = time.Now()
 	}


### PR DESCRIPTION
## Summary
- split q1 raw typed-column one-shot setup diagnostics across full raw image read/verify + image parse, decoded state build, dictionary setup, adapter validation, and dense group setup
- route the existing q1 raw setup path through the diagnostic-aware adapter helper without changing query semantics
- tighten the q1 setup diagnostic test so the raw split is present when timing is recorded, while preserving the raw-path `range_read=0` invariant

## Claim boundary
This is q1 `one_shot_end_to_end` / `no_aggregate_metadata` setup observability only. It is not a runtime speedup claim, not metadata acceleration, not load evidence, and not a ClickHouse comparison.

## Local validation
- `GOWORK=off go test ./TreeDB/collections -run 'TestColumnPhysicalQ1DenseTypedColumnOneShotSetupDiagnostics1950|TestColumnPhysicalTypedColumnOneShotCacheQ1Q3NoMetadata3088|TestColumnPhysicalDenseTypedColumnTargetedRangeReads3090' -count=1`\n- `GOWORK=off go test ./TreeDB/internal/typedcolumn -count=1`\n- `GOWORK=off go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnPhysicalQ1DenseTypedColumnOneShotSetup1950$' -benchmem -benchtime=5x -count=1`\n- `git diff --check`\n\n## Benchmark diagnostic signal\nLocal q1 setup smoke (`benchtime=5x`) populated the split after including raw asset read/verify in read-image: `read_image=43.611us/op`, `state_build=53.722us/op`, `dictionary=806.012us/op`, `adapter=17.111us/op`, `dense_group=50.848us/op`, `part_decode=1.010ms/op`, `build=1.025ms/op`, `range_read=0`.\n\nRefs #3350. Contributes to #3070.