### PR TITLE
Parallelize q2 dense rank reference fill

### DIFF
--- a/TreeDB/collections/column_physical_q2_global_rank_prep_bench_test.go
+++ b/TreeDB/collections/column_physical_q2_global_rank_prep_bench_test.go
@@ -275,6 +275,50 @@ func TestTypedColumnQ2DenseGroupCountDistinctShardedReferenceFillNullableEmpty(t
 	}
 }
 
+func TestTypedColumnQ2DenseGroupCountDistinctShardRankRefsParallelMatchesSerial(t *testing.T) {
+	newPart := func(dictionary []string, valid []bool) columnTypedColumnPhysicalQueryPart {
+		return columnTypedColumnPhysicalQueryPart{
+			DenseGroupCountDistinct: &columnTypedColumnDenseGroupCountDistinctPart{
+				Distinct: columnTypedColumnDenseStringCodeColumn{
+					Dictionary: dictionary,
+					Valid:      valid,
+				},
+			},
+		}
+	}
+	parts := []columnTypedColumnPhysicalQueryPart{
+		newPart([]string{"did:shared", "", "did:a"}, []bool{true, false, true}),
+		newPart([]string{"did:b", "did:shared"}, nil),
+		newPart([]string{"did:c", "did:b", "did:c2"}, []bool{true, true, false}),
+		newPart([]string{"", "did:d"}, nil),
+		newPart([]string{"did:e", "did:shared", "did:a"}, []bool{false, true, true}),
+	}
+	capacity := 0
+	for partIdx := range parts {
+		capacity += len(parts[partIdx].DenseGroupCountDistinct.Distinct.Dictionary)
+	}
+	shardCount := 8
+	serialRefs, err := columnTypedColumnDenseGroupCountDistinctCollectShardRankRefsSerial(parts, shardCount, capacity)
+	if err != nil {
+		t.Fatalf("collect serial refs: %v", err)
+	}
+	parallelRefs, err := columnTypedColumnDenseGroupCountDistinctCollectShardRankRefs(parts, shardCount, capacity, 3)
+	if err != nil {
+		t.Fatalf("collect parallel refs: %v", err)
+	}
+	if !reflect.DeepEqual(parallelRefs, serialRefs) {
+		t.Fatalf("parallel refs mismatch\nserial=%v\nparallel=%v", serialRefs, parallelRefs)
+	}
+	wantRanges := []columnTypedColumnDenseGroupCountDistinctShardRankRefWorkerRange{
+		{start: 0, end: 2},
+		{start: 2, end: 4},
+		{start: 4, end: 5},
+	}
+	if got := columnTypedColumnDenseGroupCountDistinctShardRankRefWorkerRanges(len(parts), 3); !reflect.DeepEqual(got, wantRanges) {
+		t.Fatalf("worker ranges=%+v want %+v", got, wantRanges)
+	}
+}
+
 // Dense q2 distinct ranks are reducer-local equality IDs, not externally visible
 // lexical order. This verifies the q2-visible result invariant after rank renumbering.
 func TestTypedColumnQ2DenseGroupCountDistinctShardedHashRankRunEquivalence(t *testing.T) {

--- a/TreeDB/collections/column_physical_typed_column_query.go
+++ b/TreeDB/collections/column_physical_typed_column_query.go
@@ -1505,20 +1505,16 @@ func prepareColumnTypedColumnDenseGroupCountDistinctGlobalRankMapsShardedReferen
 		return timing, err
 	}
 	shardCount := columnTypedColumnDenseGroupCountDistinctShardedRankShardCount(capacity, workers)
-	shardRefs := make([][]uint64, shardCount)
-	shardCapacity := max(1, capacity/shardCount)
-	for shardIdx := range shardRefs {
-		shardRefs[shardIdx] = make([]uint64, 0, shardCapacity)
-	}
 	timing.distinctRankNanos += time.Since(phaseStart).Nanoseconds()
 
+	var shardRefs [][]uint64
 	includeEmpty := false
+	phaseStart = time.Now()
 	for partIdx := range parts {
 		part := parts[partIdx].DenseGroupCountDistinct
 		if part == nil {
 			return timing, fmt.Errorf("collections: dense grouped count-distinct missing prepared part %d", partIdx)
 		}
-		phaseStart := time.Now()
 		if err := prepareColumnTypedColumnDenseGroupCountDistinctGlobalColumnRanks(&part.Group, groupDict, len(groupDict), groupRanks); err != nil {
 			timing.localRankNanos += time.Since(phaseStart).Nanoseconds()
 			return timing, fmt.Errorf("collections: dense grouped count-distinct group part %d: %w", partIdx, err)
@@ -1530,18 +1526,6 @@ func prepareColumnTypedColumnDenseGroupCountDistinctGlobalRankMapsShardedReferen
 		column.GlobalLocalRanks = make([]uint32, len(column.Dictionary))
 		column.GlobalEmptyRank = 0
 		column.GlobalEmptyRankOK = false
-		timing.localRankNanos += time.Since(phaseStart).Nanoseconds()
-
-		phaseStart = time.Now()
-		for localCode, value := range column.Dictionary {
-			ref, err := columnTypedColumnDenseGroupCountDistinctPackRankRef(partIdx, localCode)
-			if err != nil {
-				timing.distinctRankNanos += time.Since(phaseStart).Nanoseconds()
-				return timing, err
-			}
-			shardIdx := int(columnTypedColumnDenseGroupCountDistinctStableRankHash(value) & uint64(shardCount-1))
-			shardRefs[shardIdx] = append(shardRefs[shardIdx], ref)
-		}
 		if !includeEmpty {
 			for _, valid := range column.Valid {
 				if !valid {
@@ -1550,8 +1534,16 @@ func prepareColumnTypedColumnDenseGroupCountDistinctGlobalRankMapsShardedReferen
 				}
 			}
 		}
-		timing.distinctRankNanos += time.Since(phaseStart).Nanoseconds()
 	}
+	timing.localRankNanos += time.Since(phaseStart).Nanoseconds()
+
+	phaseStart = time.Now()
+	shardRefs, err = columnTypedColumnDenseGroupCountDistinctCollectShardRankRefs(parts, shardCount, capacity, workers)
+	if err != nil {
+		timing.distinctRankNanos += time.Since(phaseStart).Nanoseconds()
+		return timing, err
+	}
+	timing.distinctRankNanos += time.Since(phaseStart).Nanoseconds()
 
 	phaseStart = time.Now()
 	emptyShardIdx := -1
@@ -1608,6 +1600,110 @@ func prepareColumnTypedColumnDenseGroupCountDistinctGlobalRankMapsShardedReferen
 	}
 	timing.localRankNanos += time.Since(phaseStart).Nanoseconds()
 	return timing, nil
+}
+
+func columnTypedColumnDenseGroupCountDistinctCollectShardRankRefs(parts []columnTypedColumnPhysicalQueryPart, shardCount, capacity, workers int) ([][]uint64, error) {
+	if workers < 2 || len(parts) < 2 {
+		return columnTypedColumnDenseGroupCountDistinctCollectShardRankRefsSerial(parts, shardCount, capacity)
+	}
+	workerCount := min(workers, len(parts))
+	ranges := columnTypedColumnDenseGroupCountDistinctShardRankRefWorkerRanges(len(parts), workerCount)
+	workerRefs := make([][][]uint64, workerCount)
+	errs := make([]error, workerCount)
+	var wg sync.WaitGroup
+	for workerIdx := 0; workerIdx < workerCount; workerIdx++ {
+		wg.Add(1)
+		go func(workerIdx int) {
+			defer wg.Done()
+			localRefs := columnTypedColumnDenseGroupCountDistinctNewShardRankRefs(shardCount, capacity/workerCount)
+			for partIdx := ranges[workerIdx].start; partIdx < ranges[workerIdx].end; partIdx++ {
+				if err := columnTypedColumnDenseGroupCountDistinctCollectShardRankRefsPart(parts, partIdx, localRefs); err != nil {
+					errs[workerIdx] = err
+					return
+				}
+			}
+			workerRefs[workerIdx] = localRefs
+		}(workerIdx)
+	}
+	wg.Wait()
+	for workerIdx := range errs {
+		if errs[workerIdx] != nil {
+			return nil, errs[workerIdx]
+		}
+	}
+	refs := make([][]uint64, shardCount)
+	for shardIdx := 0; shardIdx < shardCount; shardIdx++ {
+		total := 0
+		for workerIdx := 0; workerIdx < workerCount; workerIdx++ {
+			total += len(workerRefs[workerIdx][shardIdx])
+		}
+		refs[shardIdx] = make([]uint64, 0, total)
+		for workerIdx := 0; workerIdx < workerCount; workerIdx++ {
+			refs[shardIdx] = append(refs[shardIdx], workerRefs[workerIdx][shardIdx]...)
+		}
+	}
+	return refs, nil
+}
+
+type columnTypedColumnDenseGroupCountDistinctShardRankRefWorkerRange struct {
+	start int
+	end   int
+}
+
+func columnTypedColumnDenseGroupCountDistinctShardRankRefWorkerRanges(partCount, workerCount int) []columnTypedColumnDenseGroupCountDistinctShardRankRefWorkerRange {
+	ranges := make([]columnTypedColumnDenseGroupCountDistinctShardRankRefWorkerRange, workerCount)
+	start := 0
+	for workerIdx := 0; workerIdx < workerCount; workerIdx++ {
+		workerParts := partCount / workerCount
+		if workerIdx < partCount%workerCount {
+			workerParts++
+		}
+		end := start + workerParts
+		ranges[workerIdx] = columnTypedColumnDenseGroupCountDistinctShardRankRefWorkerRange{start: start, end: end}
+		start = end
+	}
+	return ranges
+}
+
+func columnTypedColumnDenseGroupCountDistinctCollectShardRankRefsSerial(parts []columnTypedColumnPhysicalQueryPart, shardCount, capacity int) ([][]uint64, error) {
+	refs := columnTypedColumnDenseGroupCountDistinctNewShardRankRefs(shardCount, capacity)
+	for partIdx := range parts {
+		if err := columnTypedColumnDenseGroupCountDistinctCollectShardRankRefsPart(parts, partIdx, refs); err != nil {
+			return nil, err
+		}
+	}
+	return refs, nil
+}
+
+func columnTypedColumnDenseGroupCountDistinctNewShardRankRefs(shardCount, capacity int) [][]uint64 {
+	refs := make([][]uint64, shardCount)
+	shardCapacity := max(1, capacity/shardCount)
+	for shardIdx := range refs {
+		refs[shardIdx] = make([]uint64, 0, shardCapacity)
+	}
+	return refs
+}
+
+func columnTypedColumnDenseGroupCountDistinctCollectShardRankRefsPart(parts []columnTypedColumnPhysicalQueryPart, partIdx int, shardRefs [][]uint64) error {
+	if partIdx < 0 || partIdx >= len(parts) {
+		return fmt.Errorf("collections: dense grouped count-distinct part index=%d outside parts=%d", partIdx, len(parts))
+	}
+	part := parts[partIdx].DenseGroupCountDistinct
+	if part == nil {
+		return fmt.Errorf("collections: dense grouped count-distinct missing prepared part %d", partIdx)
+	}
+	if len(shardRefs) == 0 {
+		return fmt.Errorf("collections: dense grouped count-distinct missing rank shards")
+	}
+	for localCode, value := range part.Distinct.Dictionary {
+		ref, err := columnTypedColumnDenseGroupCountDistinctPackRankRef(partIdx, localCode)
+		if err != nil {
+			return err
+		}
+		shardIdx := int(columnTypedColumnDenseGroupCountDistinctStableRankHash(value) & uint64(len(shardRefs)-1))
+		shardRefs[shardIdx] = append(shardRefs[shardIdx], ref)
+	}
+	return nil
 }
 
 func columnTypedColumnDenseGroupCountDistinctPackRankRef(partIdx, localCode int) (uint64, error) {


### PR DESCRIPTION
## Summary

- parallelize q2 dense grouped-count-distinct distinct-rank reference collection with per-worker shard buffers
- merge worker buffers in deterministic worker/part order so rank assignment preserves the serial reference ordering
- add focused coverage for uneven worker ranges, duplicate/shared values, empty-string values, and nullable parts

## Claim boundary

This is no-aggregate `one_shot_end_to_end` typed-column q2 setup work only. It is not aggregate-metadata acceleration and does not claim TreeDB/ClickHouse superiority without regenerated side-by-side evidence.

## Evidence

Focused correctness:

```sh
TMPDIR=/mnt/fast4tb/tmp GOCACHE=/mnt/fast4tb/tmp/gocache-next-query GOMODCACHE=/mnt/fast4tb/tmp/gomodcache-next-query GOTMPDIR=/mnt/fast4tb/tmp/go-build-next-query GOWORK=off \
  go test ./TreeDB/collections -run 'TestTypedColumnQ2DenseGroupCountDistinct(GlobalRankPrepHarness|ShardedHashRankPrepEquivalence|AdaptiveRankPrepPolicy|OneShotRankPrepMatchesAdaptivePolicy|ShardedReferenceFillNullableEmpty|ShardRankRefsParallelMatchesSerial|ShardedHashRankRunEquivalence|AdaptiveRankRunEquivalence|RankMapCapacity3158)|TestColumnPhysicalTypedColumnOneShotCacheQ2NoMetadata3123' -count=1
```

Passed: `ok github.com/snissn/gomap/TreeDB/collections 8.038s`.

Race check:

```sh
TMPDIR=/mnt/fast4tb/tmp GOCACHE=/mnt/fast4tb/tmp/gocache-next-query-race GOMODCACHE=/mnt/fast4tb/tmp/gomodcache-next-query GOTMPDIR=/mnt/fast4tb/tmp/go-build-next-query-race GOWORK=off \
  go test -race ./TreeDB/collections -run 'TestTypedColumnQ2DenseGroupCountDistinct(ShardedHashRankPrepEquivalence|ShardedReferenceFillNullableEmpty|ShardRankRefsParallelMatchesSerial|ShardedHashRankRunEquivalence)$' -count=1
```

Passed: `ok github.com/snissn/gomap/TreeDB/collections 5.201s`.

Synthetic q2 rank-prep subset:

- baseline artifact: `/mnt/fast4tb/gomap-profiles/q2-rank-ref-baseline-20260630_040043/bench_adaptive.txt`
- branch artifact: `/mnt/fast4tb/gomap-profiles/q2-rank-ref-exactmerge-20260630_042406/bench_adaptive_q2_sharded.txt`
- adaptive sharded rows improved in the subset, including `adaptive/mixed/parts=40` 5.320ms -> 4.064ms and `adaptive/mixed/parts=80` 11.826ms -> 8.112ms.

1M q2 JSONBench, same machine/env, `one_shot_end_to_end` / `no_aggregate_metadata`:

Baseline `894ceb0386c8ed6fdd1e7fc875e4df6d68525821`:

- artifact: `/mnt/fast4tb/gomap-profiles/q2-rank-ref-jsonbench-baseline-20260630_041100`
- total: 87.460ms
- setup: 63.779ms
- post-prepare: 31.709ms
- run: 23.627ms
- rows scanned/matched/reduced: 1,000,000 / 954,611 / 954,611
- result hash: `b63b8e1013c918fcda7c299ef64beb20c4988854cf0671a83803b6951d795860`

Branch `8558c0b7d`:

- artifact: `/mnt/fast4tb/gomap-profiles/q2-rank-ref-jsonbench-exactmerge-20260630_042543`
- total: 75.945ms
- setup: 55.230ms
- post-prepare: 23.151ms
- run: 20.638ms
- q2 dense group global rank: 0.053ms
- q2 dense distinct global rank: 19.484ms
- q2 dense part-local rank: 1.315ms
- rows scanned/matched/reduced: 1,000,000 / 954,611 / 954,611
- result hash: `b63b8e1013c918fcda7c299ef64beb20c4988854cf0671a83803b6951d795860`

Refs #3324.
