### PR TITLE
[codex] require production read-index evidence

### DIFF
--- a/TreeDB/docs/spec/native-query-raft-roadmap.md
+++ b/TreeDB/docs/spec/native-query-raft-roadmap.md
@@ -274,10 +274,13 @@ fresh read-index barrier.
 implementation before reading.
 
 The current nativewire bridge for `linearizable` is a contract-only substrate:
-a configured read-index provider must return a quorum-backed read-index proof,
-then the existing applied-index waiter must prove the local node has applied
-through that read index. If either proof is unavailable, missing quorum, targets
-the wrong node/group, or local apply lags the read index, the read fails closed.
+a configured read-index provider must return a read-index proof marked with
+production evidence provenance, then the existing applied-index waiter must
+prove the local node has applied through that read index. Harness and other
+test-only evidence can exercise lower-level composition but must not satisfy
+nativewire `linearizable`. If either proof is unavailable, non-production,
+missing quorum, targets the wrong node/group, or local apply lags the read
+index, the read fails closed.
 
 `lease_read` is allowed only if leader leases are implemented and the server can
 prove the lease is valid.

--- a/TreeDB/docs/spec/raftcluster.md
+++ b/TreeDB/docs/spec/raftcluster.md
@@ -132,8 +132,11 @@ The package exposes a small read-index contract for future Raft adapters:
 
 - `ReadIndexProvider` obtains a quorum-backed `ReadIndexProof`;
 - `ReadIndexBarrier` optionally pins the proof to an expected node/group;
-- `ReadIndexProof` must include node ID, group ID, a non-zero read index, and
-  `HasQuorum=true`;
+- `ReadIndexProof` must include node ID, group ID, a non-zero read index,
+  `HasQuorum=true`, and explicit evidence provenance;
+- production linearizable reads accept only `ReadIndexEvidenceProduction`,
+  which a real Raft adapter may set only after a read-index or equivalent
+  production quorum proof;
 - linearizable nativewire reads must convert the proof into an
   `AppliedIndexReadBarrier` and wait until the local node has applied through
   that index before reading local state.
@@ -145,7 +148,8 @@ leader transfer handling, lease reads, follower reads, or production routing.
 contract. It derives read-index proofs from an injected committed-entry log so
 tests can exercise nativewire read-index/read-barrier composition, but that
 evidence is not production quorum evidence and the provider does not apply
-entries by itself.
+entries by itself. Harness proofs are marked `ReadIndexEvidenceTestHarness` and
+must fail closed at nativewire's production `linearizable` read boundary.
 
 ## Recovery Status Boundary
 

--- a/TreeDB/internal/raftcluster/read_index.go
+++ b/TreeDB/internal/raftcluster/read_index.go
@@ -13,14 +13,40 @@ type ReadIndexBarrier struct {
 	GroupID GroupID
 }
 
+// ReadIndexEvidenceKind records where a read-index proof came from. Production
+// linearizable reads only accept ReadIndexEvidenceProduction.
+type ReadIndexEvidenceKind uint8
+
+const (
+	ReadIndexEvidenceUnknown ReadIndexEvidenceKind = iota
+	ReadIndexEvidenceTestHarness
+	ReadIndexEvidenceProduction
+)
+
+func (k ReadIndexEvidenceKind) String() string {
+	switch k {
+	case ReadIndexEvidenceTestHarness:
+		return "test_harness"
+	case ReadIndexEvidenceProduction:
+		return "production"
+	default:
+		return "unknown"
+	}
+}
+
 // ReadIndexProof is the minimal result a Raft adapter must provide before a
-// linearizable local read can wait for local application.
+// linearizable local read can wait for local application. Production Raft
+// adapters must set EvidenceKind to ReadIndexEvidenceProduction only after a
+// real read-index or equivalent quorum proof. Harness and fake providers should
+// use non-production evidence unless a narrow test deliberately exercises the
+// production path.
 type ReadIndexProof struct {
-	NodeID    NodeID
-	GroupID   GroupID
-	Term      uint64
-	Index     uint64
-	HasQuorum bool
+	NodeID       NodeID
+	GroupID      GroupID
+	Term         uint64
+	Index        uint64
+	HasQuorum    bool
+	EvidenceKind ReadIndexEvidenceKind
 }
 
 // ReadIndexProvider obtains a read-index proof from the selected Raft adapter.
@@ -32,7 +58,17 @@ func (b ReadIndexBarrier) SatisfiedBy(proof ReadIndexProof) bool {
 	return b.Check(proof) == nil
 }
 
+// ReadIndexCheckOptions allows deterministic harnesses to validate target and
+// quorum shape without pretending their evidence is production-consensus proof.
+type ReadIndexCheckOptions struct {
+	AllowNonProductionEvidence bool
+}
+
 func (b ReadIndexBarrier) Check(proof ReadIndexProof) error {
+	return b.CheckWithOptions(proof, ReadIndexCheckOptions{})
+}
+
+func (b ReadIndexBarrier) CheckWithOptions(proof ReadIndexProof, opts ReadIndexCheckOptions) error {
 	if b.NodeID != "" && proof.NodeID != b.NodeID {
 		return fmt.Errorf("%w: node %q proof came from node %q", ErrReadBarrierTargetMismatch, b.NodeID, proof.NodeID)
 	}
@@ -51,7 +87,17 @@ func (b ReadIndexBarrier) Check(proof ReadIndexProof) error {
 	if proof.Index == 0 {
 		return fmt.Errorf("%w: read-index proof missing index", ErrReadBarrierNotSatisfied)
 	}
-	return nil
+	switch proof.EvidenceKind {
+	case ReadIndexEvidenceProduction:
+		return nil
+	case ReadIndexEvidenceTestHarness:
+		if opts.AllowNonProductionEvidence {
+			return nil
+		}
+		return fmt.Errorf("%w: read-index proof evidence %s is not production", ErrReadBarrierNotSatisfied, proof.EvidenceKind)
+	default:
+		return fmt.Errorf("%w: read-index proof missing evidence kind", ErrReadBarrierNotSatisfied)
+	}
 }
 
 func (p ReadIndexProof) AppliedIndexBarrier() AppliedIndexReadBarrier {

--- a/TreeDB/internal/raftcluster/read_index_test.go
+++ b/TreeDB/internal/raftcluster/read_index_test.go
@@ -5,14 +5,15 @@ import (
 	"testing"
 )
 
-func TestReadIndexBarrierAcceptsQuorumProof(t *testing.T) {
+func TestReadIndexBarrierAcceptsProductionQuorumProof(t *testing.T) {
 	barrier := ReadIndexBarrier{NodeID: "node-a", GroupID: "group-a"}
 	proof := ReadIndexProof{
-		NodeID:    "node-a",
-		GroupID:   "group-a",
-		Term:      7,
-		Index:     42,
-		HasQuorum: true,
+		NodeID:       "node-a",
+		GroupID:      "group-a",
+		Term:         7,
+		Index:        42,
+		HasQuorum:    true,
+		EvidenceKind: ReadIndexEvidenceProduction,
 	}
 	if err := barrier.Check(proof); err != nil {
 		t.Fatalf("Check: %v", err)
@@ -29,13 +30,51 @@ func TestReadIndexBarrierAcceptsQuorumProof(t *testing.T) {
 	}
 }
 
+func TestReadIndexBarrierRejectsNonProductionEvidence(t *testing.T) {
+	barrier := ReadIndexBarrier{NodeID: "node-a", GroupID: "group-a"}
+	proof := ReadIndexProof{
+		NodeID:       "node-a",
+		GroupID:      "group-a",
+		Term:         7,
+		Index:        42,
+		HasQuorum:    true,
+		EvidenceKind: ReadIndexEvidenceTestHarness,
+	}
+	err := barrier.Check(proof)
+	if !errors.Is(err, ErrReadBarrierNotSatisfied) {
+		t.Fatalf("Check err=%v want ErrReadBarrierNotSatisfied", err)
+	}
+	if barrier.SatisfiedBy(proof) {
+		t.Fatalf("SatisfiedBy=true want false")
+	}
+	if err := barrier.CheckWithOptions(proof, ReadIndexCheckOptions{AllowNonProductionEvidence: true}); err != nil {
+		t.Fatalf("CheckWithOptions allow non-production: %v", err)
+	}
+}
+
+func TestReadIndexBarrierRejectsMissingEvidenceKind(t *testing.T) {
+	barrier := ReadIndexBarrier{NodeID: "node-a", GroupID: "group-a"}
+	proof := ReadIndexProof{
+		NodeID:    "node-a",
+		GroupID:   "group-a",
+		Term:      7,
+		Index:     42,
+		HasQuorum: true,
+	}
+	err := barrier.Check(proof)
+	if !errors.Is(err, ErrReadBarrierNotSatisfied) {
+		t.Fatalf("Check err=%v want ErrReadBarrierNotSatisfied", err)
+	}
+}
+
 func TestReadIndexBarrierRejectsMissingQuorumProof(t *testing.T) {
 	barrier := ReadIndexBarrier{NodeID: "node-a", GroupID: "group-a"}
 	proof := ReadIndexProof{
-		NodeID:  "node-a",
-		GroupID: "group-a",
-		Term:    7,
-		Index:   42,
+		NodeID:       "node-a",
+		GroupID:      "group-a",
+		Term:         7,
+		Index:        42,
+		EvidenceKind: ReadIndexEvidenceProduction,
 	}
 	err := barrier.Check(proof)
 	if !errors.Is(err, ErrReadBarrierNotSatisfied) {
@@ -49,10 +88,11 @@ func TestReadIndexBarrierRejectsMissingQuorumProof(t *testing.T) {
 func TestReadIndexBarrierRejectsMissingReadIndex(t *testing.T) {
 	barrier := ReadIndexBarrier{NodeID: "node-a", GroupID: "group-a"}
 	proof := ReadIndexProof{
-		NodeID:    "node-a",
-		GroupID:   "group-a",
-		Term:      7,
-		HasQuorum: true,
+		NodeID:       "node-a",
+		GroupID:      "group-a",
+		Term:         7,
+		HasQuorum:    true,
+		EvidenceKind: ReadIndexEvidenceProduction,
 	}
 	err := barrier.Check(proof)
 	if !errors.Is(err, ErrReadBarrierNotSatisfied) {
@@ -70,42 +110,46 @@ func TestReadIndexBarrierRejectsTargetMismatch(t *testing.T) {
 			name:    "node",
 			barrier: ReadIndexBarrier{NodeID: "node-a", GroupID: "group-a"},
 			proof: ReadIndexProof{
-				NodeID:    "node-b",
-				GroupID:   "group-a",
-				Term:      7,
-				Index:     42,
-				HasQuorum: true,
+				NodeID:       "node-b",
+				GroupID:      "group-a",
+				Term:         7,
+				Index:        42,
+				HasQuorum:    true,
+				EvidenceKind: ReadIndexEvidenceProduction,
 			},
 		},
 		{
 			name:    "group",
 			barrier: ReadIndexBarrier{NodeID: "node-a", GroupID: "group-a"},
 			proof: ReadIndexProof{
-				NodeID:    "node-a",
-				GroupID:   "group-b",
-				Term:      7,
-				Index:     42,
-				HasQuorum: true,
+				NodeID:       "node-a",
+				GroupID:      "group-b",
+				Term:         7,
+				Index:        42,
+				HasQuorum:    true,
+				EvidenceKind: ReadIndexEvidenceProduction,
 			},
 		},
 		{
 			name:    "missing-node",
 			barrier: ReadIndexBarrier{GroupID: "group-a"},
 			proof: ReadIndexProof{
-				GroupID:   "group-a",
-				Term:      7,
-				Index:     42,
-				HasQuorum: true,
+				GroupID:      "group-a",
+				Term:         7,
+				Index:        42,
+				HasQuorum:    true,
+				EvidenceKind: ReadIndexEvidenceProduction,
 			},
 		},
 		{
 			name:    "missing-group",
 			barrier: ReadIndexBarrier{NodeID: "node-a"},
 			proof: ReadIndexProof{
-				NodeID:    "node-a",
-				Term:      7,
-				Index:     42,
-				HasQuorum: true,
+				NodeID:       "node-a",
+				Term:         7,
+				Index:        42,
+				HasQuorum:    true,
+				EvidenceKind: ReadIndexEvidenceProduction,
 			},
 		},
 	}

--- a/TreeDB/internal/raftharness/read_index.go
+++ b/TreeDB/internal/raftharness/read_index.go
@@ -46,13 +46,14 @@ func (p *ReadIndexProvider) ReadIndex(ctx context.Context, target raftcluster.Re
 	}
 	last := p.h.committed[len(p.h.committed)-1]
 	proof := raftcluster.ReadIndexProof{
-		NodeID:    p.nodeID,
-		GroupID:   p.h.groupID,
-		Term:      last.Term,
-		Index:     last.Index,
-		HasQuorum: true,
+		NodeID:       p.nodeID,
+		GroupID:      p.h.groupID,
+		Term:         last.Term,
+		Index:        last.Index,
+		HasQuorum:    true,
+		EvidenceKind: raftcluster.ReadIndexEvidenceTestHarness,
 	}
-	if err := target.Check(proof); err != nil {
+	if err := target.CheckWithOptions(proof, raftcluster.ReadIndexCheckOptions{AllowNonProductionEvidence: true}); err != nil {
 		return raftcluster.ReadIndexProof{}, fmt.Errorf("raftharness: %w", err)
 	}
 	if err := ctx.Err(); err != nil {

--- a/TreeDB/internal/raftharness/read_index_test.go
+++ b/TreeDB/internal/raftharness/read_index_test.go
@@ -30,8 +30,9 @@ func TestReadIndexProviderReturnsLatestCommittedProofWithoutApplying(t *testing.
 	if err != nil {
 		t.Fatalf("ReadIndex: %v proof=%+v", err, proof)
 	}
-	if proof.NodeID != "node-b" || proof.GroupID != "default" || proof.Term != 31 || proof.Index != 2 || !proof.HasQuorum {
-		t.Fatalf("proof=%+v, want node-b/default 31/2 quorum", proof)
+	if proof.NodeID != "node-b" || proof.GroupID != "default" || proof.Term != 31 || proof.Index != 2 ||
+		!proof.HasQuorum || proof.EvidenceKind != raftcluster.ReadIndexEvidenceTestHarness {
+		t.Fatalf("proof=%+v, want node-b/default 31/2 quorum test_harness evidence", proof)
 	}
 	assertNoLastApplied(t, h, "node-b")
 	assertCollectionMissing(t, h, "node-b", "users")
@@ -47,8 +48,9 @@ func TestReadIndexProviderAllowsUnconstrainedTargetFields(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReadIndex unconstrained target: %v proof=%+v", err, proof)
 	}
-	if proof.NodeID != "node-a" || proof.GroupID != "default" || proof.Term != 32 || proof.Index != 1 || !proof.HasQuorum {
-		t.Fatalf("proof=%+v, want node-a/default 32/1 quorum", proof)
+	if proof.NodeID != "node-a" || proof.GroupID != "default" || proof.Term != 32 || proof.Index != 1 ||
+		!proof.HasQuorum || proof.EvidenceKind != raftcluster.ReadIndexEvidenceTestHarness {
+		t.Fatalf("proof=%+v, want node-a/default 32/1 quorum test_harness evidence", proof)
 	}
 }
 
@@ -193,6 +195,9 @@ func TestReadIndexProviderComposesWithReadBarrierCatchUp(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatalf("ReadIndex: %v proof=%+v", err, proof)
+	}
+	if proof.EvidenceKind != raftcluster.ReadIndexEvidenceTestHarness {
+		t.Fatalf("proof evidence=%s want test_harness", proof.EvidenceKind)
 	}
 	assertNoLastApplied(t, h, "node-c")
 

--- a/TreeDB/nativewire/cluster_read_barrier.go
+++ b/TreeDB/nativewire/cluster_read_barrier.go
@@ -16,8 +16,9 @@ type AppliedIndexReadBarrierProvider interface {
 
 // AppliedIndexReadCoordinator bridges nativewire leader_read requests to the
 // raftcluster applied-index read barrier foundation. Linearizable reads require
-// a configured read-index provider and then wait for local apply through the
-// proven read index. Lease reads remain unsupported until a lease proof exists.
+// a configured read-index provider with production evidence and then wait for
+// local apply through the proven read index. Lease reads remain unsupported
+// until a lease proof exists.
 type AppliedIndexReadCoordinator struct {
 	BarrierProvider   AppliedIndexReadBarrierProvider
 	Waiter            raftcluster.AppliedIndexReadBarrierWaiter

--- a/TreeDB/nativewire/cluster_read_barrier_test.go
+++ b/TreeDB/nativewire/cluster_read_barrier_test.go
@@ -200,14 +200,15 @@ func TestAppliedIndexReadCoordinatorFailsClosedForTargetMismatch(t *testing.T) {
 	}
 }
 
-func TestAppliedIndexReadCoordinatorProvesLinearizableReadMetadata(t *testing.T) {
+func TestAppliedIndexReadCoordinatorProvesLinearizableReadMetadataWithProductionProof(t *testing.T) {
 	readIndex := &fakeReadIndexProvider{
 		proof: raftcluster.ReadIndexProof{
-			NodeID:    "node-a",
-			GroupID:   "group-a",
-			Term:      7,
-			Index:     42,
-			HasQuorum: true,
+			NodeID:       "node-a",
+			GroupID:      "group-a",
+			Term:         7,
+			Index:        42,
+			HasQuorum:    true,
+			EvidenceKind: raftcluster.ReadIndexEvidenceProduction,
 		},
 	}
 	waiter := &fakeAppliedIndexWaiter{
@@ -262,7 +263,7 @@ func TestAppliedIndexReadCoordinatorProvesLinearizableReadMetadata(t *testing.T)
 	}
 }
 
-func TestAppliedIndexReadCoordinatorLinearizableUsesHarnessReadIndexAndWaiter(t *testing.T) {
+func TestAppliedIndexReadCoordinatorLinearizableRejectsHarnessReadIndexEvidence(t *testing.T) {
 	h, err := raftharness.Open(raftharness.Options{
 		RootDir: t.TempDir(),
 		GroupID: "group-a",
@@ -305,23 +306,12 @@ func TestAppliedIndexReadCoordinatorLinearizableUsesHarnessReadIndexAndWaiter(t 
 		t.Fatalf("Hello: %v", err)
 	}
 
-	result, err := client.GetManyWithOptions(ctx, "users", [][]byte{[]byte("u1")}, ReadOptions{ConsistencyPolicy: ConsistencyLinearizable})
-	if err != nil {
-		t.Fatalf("GetManyWithOptions: %v", err)
+	_, err = client.GetManyWithOptions(ctx, "users", [][]byte{[]byte("u1")}, ReadOptions{ConsistencyPolicy: ConsistencyLinearizable})
+	if !isRemoteError(err, iwire.ErrConsistencyUnavailable) {
+		t.Fatalf("GetManyWithOptions err=%v want consistency_unavailable", err)
 	}
-	if got, want := result.Present, []bool{true}; !boolSlicesEqual(got, want) {
-		t.Fatalf("present=%v want %v", got, want)
-	}
-	if !result.ReadMeta.Valid ||
-		result.ReadMeta.ActualConsistency != ConsistencyLinearizable ||
-		result.ReadMeta.ServingNode != "node-b" ||
-		result.ReadMeta.LeaderNode != "node-b" ||
-		!result.ReadMeta.HasAppliedIndex ||
-		result.ReadMeta.AppliedIndex != 1 {
-		t.Fatalf("read meta=%+v", result.ReadMeta)
-	}
-	if last, ok := node.LastApplied(); !ok || last.Term != 41 || last.Index != 1 {
-		t.Fatalf("node-b last applied after read=%+v ok=%t, want 41/1", last, ok)
+	if last, ok := node.LastApplied(); ok {
+		t.Fatalf("node-b last applied after failed read=%+v, want none", last)
 	}
 }
 
@@ -357,10 +347,11 @@ func TestAppliedIndexReadCoordinatorLinearizableFailsClosedWithoutReadIndexProvi
 func TestAppliedIndexReadCoordinatorLinearizableFailsClosedWithoutQuorumProof(t *testing.T) {
 	readIndex := &fakeReadIndexProvider{
 		proof: raftcluster.ReadIndexProof{
-			NodeID:  "node-a",
-			GroupID: "group-a",
-			Term:    7,
-			Index:   42,
+			NodeID:       "node-a",
+			GroupID:      "group-a",
+			Term:         7,
+			Index:        42,
+			EvidenceKind: raftcluster.ReadIndexEvidenceProduction,
 		},
 	}
 	waiter := &fakeAppliedIndexWaiter{}
@@ -419,11 +410,12 @@ func TestAppliedIndexReadCoordinatorLinearizableFailsClosedForTargetMismatch(t *
 		t.Run(tt.name, func(t *testing.T) {
 			readIndex := &fakeReadIndexProvider{
 				proof: raftcluster.ReadIndexProof{
-					NodeID:    "node-a",
-					GroupID:   "group-a",
-					Term:      7,
-					Index:     42,
-					HasQuorum: true,
+					NodeID:       "node-a",
+					GroupID:      "group-a",
+					Term:         7,
+					Index:        42,
+					HasQuorum:    true,
+					EvidenceKind: raftcluster.ReadIndexEvidenceProduction,
 				},
 			}
 			waiter := &fakeAppliedIndexWaiter{progress: tt.progress}
@@ -454,11 +446,12 @@ func TestAppliedIndexReadCoordinatorLinearizableFailsClosedForTargetMismatch(t *
 func TestAppliedIndexReadCoordinatorLinearizableFailsClosedForLocalApplyLag(t *testing.T) {
 	readIndex := &fakeReadIndexProvider{
 		proof: raftcluster.ReadIndexProof{
-			NodeID:    "node-a",
-			GroupID:   "group-a",
-			Term:      7,
-			Index:     42,
-			HasQuorum: true,
+			NodeID:       "node-a",
+			GroupID:      "group-a",
+			Term:         7,
+			Index:        42,
+			HasQuorum:    true,
+			EvidenceKind: raftcluster.ReadIndexEvidenceProduction,
 		},
 	}
 	waiter := &fakeAppliedIndexWaiter{
@@ -495,11 +488,12 @@ func TestAppliedIndexReadCoordinatorLinearizableFailsClosedForLocalApplyLag(t *t
 func TestAppliedIndexReadCoordinatorKeepsLeaseReadFailClosed(t *testing.T) {
 	readIndex := &fakeReadIndexProvider{
 		proof: raftcluster.ReadIndexProof{
-			NodeID:    "node-a",
-			GroupID:   "group-a",
-			Term:      7,
-			Index:     42,
-			HasQuorum: true,
+			NodeID:       "node-a",
+			GroupID:      "group-a",
+			Term:         7,
+			Index:        42,
+			HasQuorum:    true,
+			EvidenceKind: raftcluster.ReadIndexEvidenceProduction,
 		},
 	}
 	waiter := &fakeAppliedIndexWaiter{


### PR DESCRIPTION
Closes #3395

## Summary

- adds explicit `ReadIndexEvidenceKind` provenance to `raftcluster.ReadIndexProof`
- makes `ReadIndexBarrier.Check` accept only production read-index evidence for nativewire `linearizable` reads
- marks `raftharness.ReadIndexProvider` proofs as deterministic test-harness evidence and validates them only through the optioned harness path
- updates nativewire tests and Raft/native query docs to document the production-evidence boundary

## Validation

- `GOWORK=off TMPDIR=/mnt/fast4tb/tmp/gomap-3395-cache/tmp GOCACHE=/mnt/fast4tb/tmp/gomap-3395-cache/gocache GOMODCACHE=/mnt/fast4tb/tmp/gomap-3395-cache/gomodcache go test ./TreeDB/internal/raftcluster ./TreeDB/internal/raftharness ./TreeDB/nativewire`
- `git diff --check`

## Notes

No benchmark was run; this is a contract/provenance-only slice and does not change the read hot path beyond proof validation.

AI review has not been requested.
