### PR TITLE
[codex] Bind route group at submit admission

### DIFF
--- a/TreeDB/docs/spec/raftcluster.md
+++ b/TreeDB/docs/spec/raftcluster.md
@@ -95,6 +95,9 @@ is intentionally one group only:
 
 - admission is checked through `AdmissionProvider` and fails closed for
   follower or unavailable states;
+- request route metadata, when present, is binding: `ClusterRouteGroupID` must
+  match the local single-group submitter before command preflight, commit, or
+  local apply can run;
 - submitted deterministic native-wire `CommandEntryV1` bytes are decoded before
   commit so unsupported or malformed R3a commands fail before local mutation;
 - decoded entries are preflighted against the local deterministic apply/catalog

--- a/TreeDB/docs/spec/raftplacement.md
+++ b/TreeDB/docs/spec/raftplacement.md
@@ -111,11 +111,13 @@ encoded TreeDB primary-key bytes, not the raw BSON value display form.
 
 Native-wire and Mongo gateway cluster submitter adapters MAY run an optional
 route preflight before handing an accepted R3a command entry to the submitter.
-The preflight is adapter metadata only. It records the catalog route identity,
-route shape, target group ID, group members, leader hint, placement mode, and,
-for token/ring decisions, the document token and token partition ID in request
-metadata that is excluded from deterministic command entry bytes and command
-digests.
+The preflight records request-only metadata: catalog route identity, route
+shape, target group ID, group members, leader hint, placement mode, and, for
+token/ring decisions, the document token and token partition ID. That metadata
+is excluded from deterministic command entry bytes and command digests, but it
+is binding at the single-group submit boundary. A `SingleGroupSubmitter` for
+`group-a` must reject a request whose route metadata targets `group-b` before
+command preflight, commit-source invocation, or local apply.
 
 `nativewire.CatalogClusterRouteProvider` is the reusable adapter from
 `ResolvedCatalogV1` to `nativewire.ClusterRouteTarget`. It converts collection
@@ -154,7 +156,9 @@ token-batch classifications. Collection placements may still accept
 token-capable single-ID and multi-ID requests by returning a collection route
 decision, preserving collection-mode write behavior. Leader hints remain hints;
 they are not live leadership proof, read-index evidence, or a network routing
-guarantee.
+guarantee. Route group mismatches are local not-owned/not-writable rejections;
+this layer does not forward writes, fan out token batches, or choose another
+network target.
 
 ## Token/Ring Catalog Placements
 

--- a/TreeDB/docs/spec/verification.md
+++ b/TreeDB/docs/spec/verification.md
@@ -286,6 +286,10 @@ Invariant:
   request-only cluster route metadata, supports collection and single-token
   token/ring targets, classifies token batches, and fails closed before submit
   for token/ring multi-ID writes until split/fanout exists.
+- Once route metadata is present, the single-group submitter treats the target
+  group as binding and rejects group mismatches before command preflight,
+  commit-source invocation, or local apply. Route metadata remains excluded
+  from deterministic entry bytes and command digests.
 
 Coverage:
 - `TreeDB/internal/raftplacement/route_test.go`:
@@ -298,10 +302,16 @@ Coverage:
   - `TestCatalogClusterRouteProviderRoutesResolvedCatalog`
   - `TestClusterRoutePreflightTokenPlacementSingleIDMutationCommands`
   - `TestClusterRoutePreflightTokenPlacementRejectsMultiID`
+  - `TestRaftClusterSubmitterRouteGroupMismatchRejectsBeforeLocalMutation`
   - `TestClusterSubmitterRequestOnlyFieldsDoNotAlterDeterministicEntry`
 - `TreeDB/mongo_gateway/cluster_submitter_test.go`:
   - `TestClusterRoutePreflightMongoTokenPlacementSingleIDWrites`
   - `TestClusterRoutePreflightMongoTokenPlacementRejectsMultiIDWrites`
+  - `TestClusterSubmitterConcreteBridgeRouteGroupMismatchNotWritablePrimary`
+- `TreeDB/internal/raftcluster/submit_test.go`:
+  - `TestSingleGroupSubmitterRejectsRouteGroupMismatchBeforePreflightCommitApply`
+  - `TestSingleGroupSubmitterAllowsMatchingRouteGroup`
+  - `TestSingleGroupSubmitterPreservesNoRouteMetadataBehavior`
 - `TreeDB/internal/raftentry/contract_test.go`:
   - `TestDigestV1StabilityAcrossMetadataAndApplyEntryID`
 
@@ -344,7 +354,7 @@ to the V1 in-page-marked meta-page storage field.
 | Native-wire deterministic command schemas align with local command WAL payload schemas. | `native-wire-protocol.md`, `user-command-wal.md` Raft/native-wire relationship | `TestCommandWALNativeWireAlignmentManifestCoverage`, `TestNativeWireAndLocalCommandDigestStable` | planned |
 | Raft/local recoverability is not reported before local command WAL publish and `AppliedLSN`. | `native-query-raft-roadmap.md` local apply layering | `TestRaftApplyDoesNotReportRecoverableBeforeCommandWALAppliedLSN` | future |
 | R3a durable apply metadata preserves applied progress, idempotency/result replay, and logical digests across reopen and fails closed on corrupt metadata. | `storage-format.md` R3a apply metadata logs, `native-query-raft-roadmap.md` local apply layering | `TestDurableApplyStoresCloseReopenPreservesApplyProgressIdempotencyAndResult`, `TestDurableApplyStoresIdempotencyDuplicateSameDigestAndDifferentDigest`, `TestDurableApplyStoresFailClosedOnTruncatedAndCorruptMetadata`, `TestDurableApplyStoresLogicalDigestIndependentOfMetadataFiles` | implemented |
-| Collection-level Raft placement resolves each placed `{database,catalog,collection}` to exactly one group and fails closed for unplaced collections, duplicate placements, unknown groups/features, and invalid leader hints. Token/ring catalog placements validate partition coverage, exactly-one-ID token routes resolve one partition/group, token batches classify single-token, same-partition, same-group, and fanout-required cases, and adapters reject multi-ID token/ring writes before submit until explicit split/fanout execution exists. | `raftplacement.md` #3046 first slice, token-partition catalog slice, and token-batch preflight slice | `TestValidateResolvesCollectionLevelPlacements`, `TestValidateRejectsInvalidCatalog`, `TestValidateFeatureFloorFailsClosed`, `TestResolveFailsClosedForUnplacedCollection`, `TestValidateAcceptsTokenRingCatalogPlacements`, `TestValidateRejectsInvalidTokenRingCatalogPlacements`, `TestValidateRejectsDuplicateCollectionAcrossTokenAndCollectionPlacement`, `TestRouteTokenDecisionIncludesPartitionAndGroupMetadata`, `TestRouteTokenBatchClassifiesDocumentTokens`, `TestRouteTokenBatchFailsClosed`, `TestClusterRoutePreflightTokenPlacementRejectsMultiID`, `TestClusterRoutePreflightMongoTokenPlacementRejectsMultiIDWrites` | implemented |
+| Collection-level Raft placement resolves each placed `{database,catalog,collection}` to exactly one group and fails closed for unplaced collections, duplicate placements, unknown groups/features, and invalid leader hints. Token/ring catalog placements validate partition coverage, exactly-one-ID token routes resolve one partition/group, token batches classify single-token, same-partition, same-group, and fanout-required cases, adapters reject multi-ID token/ring writes before submit until explicit split/fanout execution exists, and single-group submit admission rejects mismatched route group metadata before preflight/commit/apply. | `raftplacement.md` #3046 first slice, token-partition catalog slice, token-batch preflight slice, and route-binding admission slice | `TestValidateResolvesCollectionLevelPlacements`, `TestValidateRejectsInvalidCatalog`, `TestValidateFeatureFloorFailsClosed`, `TestResolveFailsClosedForUnplacedCollection`, `TestValidateAcceptsTokenRingCatalogPlacements`, `TestValidateRejectsInvalidTokenRingCatalogPlacements`, `TestValidateRejectsDuplicateCollectionAcrossTokenAndCollectionPlacement`, `TestRouteTokenDecisionIncludesPartitionAndGroupMetadata`, `TestRouteTokenBatchClassifiesDocumentTokens`, `TestRouteTokenBatchFailsClosed`, `TestClusterRoutePreflightTokenPlacementRejectsMultiID`, `TestClusterRoutePreflightMongoTokenPlacementRejectsMultiIDWrites`, `TestSingleGroupSubmitterRejectsRouteGroupMismatchBeforePreflightCommitApply`, `TestRaftClusterSubmitterRouteGroupMismatchRejectsBeforeLocalMutation`, `TestClusterSubmitterConcreteBridgeRouteGroupMismatchNotWritablePrimary` | implemented |
 | Simulation-only token-ring plans cover the uint64 token space exactly once, assign each virtual partition to a known catalog group, and fail closed for empty plans, invalid or duplicate partition IDs, unknown groups, invalid ranges, gaps, overlaps, and incomplete coverage. | `raftplacement.md` #3046 token-ring simulation slice | `TestPlanTokenRingDistributesVirtualPartitions`, `TestPlanTokenRingRejectsInvalidInputs`, `TestValidateTokenRingPlanRejectsInvalidPlans`, `TestValidateTokenRingPlanSortsAndProtectsResolvedPlan` | implemented |
 
 ### 11.5.2 Milestone Test Slices

--- a/TreeDB/internal/raftcluster/submit.go
+++ b/TreeDB/internal/raftcluster/submit.go
@@ -25,6 +25,7 @@ var (
 	ErrMissingCatalogVersion     = errors.New("raftcluster: missing catalog version")
 	ErrCatalogVersionMismatch    = errors.New("raftcluster: catalog version mismatch")
 	ErrUnexpectedCommittedTarget = errors.New("raftcluster: committed target mismatch")
+	ErrRouteGroupMismatch        = errors.New("raftcluster: route group mismatch")
 )
 
 // AdmissionProvider exposes the single-group write-admission state. Returning
@@ -357,6 +358,9 @@ func (s *SingleGroupSubmitter) SubmitCommandEntryV1(ctx context.Context, entry [
 	if err := s.admit(ctx); err != nil {
 		return SubmitResultV1{}, err
 	}
+	if err := s.checkRouteBinding(metadata); err != nil {
+		return SubmitResultV1{}, err
+	}
 	decoded, err := raftentry.DecodeCommandEntryV1(entry, raftentry.DecodeOptions{
 		Limits:          s.decodeLimits,
 		ScopeRule:       s.scopeRule,
@@ -524,6 +528,20 @@ func (s *SingleGroupSubmitter) admit(ctx context.Context) error {
 			msg += "; leader_hint=" + string(status.LeaderHint)
 		}
 		return errors.Join(ErrNotLeader, fmt.Errorf("%s", msg))
+	}
+	return nil
+}
+
+func (s *SingleGroupSubmitter) checkRouteBinding(metadata raftentry.RequestMetadataV1) error {
+	if !metadata.ClusterRouteKnown {
+		return nil
+	}
+	localGroup := string(s.cluster.GroupID)
+	if metadata.ClusterRouteGroupID == "" {
+		return errors.Join(ErrRouteGroupMismatch, fmt.Errorf("route metadata missing group id for local group %q", localGroup))
+	}
+	if metadata.ClusterRouteGroupID != localGroup {
+		return errors.Join(ErrRouteGroupMismatch, fmt.Errorf("route group %q does not match local group %q", metadata.ClusterRouteGroupID, localGroup))
 	}
 	return nil
 }

--- a/TreeDB/internal/raftcluster/submit_test.go
+++ b/TreeDB/internal/raftcluster/submit_test.go
@@ -219,6 +219,97 @@ func TestSingleGroupSubmitterRejectsStaleCatalogGuardBeforeCommitApply(t *testin
 	}
 }
 
+func TestSingleGroupSubmitterRejectsRouteGroupMismatchBeforePreflightCommitApply(t *testing.T) {
+	entry := testClusterCommandEntry(t, 7)
+	preflightCalls := 0
+	commitCalls := 0
+	applier := &recordingClusterApplier{result: raftentry.ApplyResultV1{Status: raftentry.ApplyStatusApplied, AffectedCount: 1}}
+	submitter := newTestSingleGroupSubmitter(t, SingleGroupSubmitterOptions{
+		AdmissionProvider: StaticAdmissionProvider{Status: LeaderAdmission()},
+		CommitSource: CommitSourceFunc(func(context.Context, CommitCommandEntryV1Request) (CommitCommandEntryV1Result, error) {
+			commitCalls++
+			return CommitCommandEntryV1Result{}, nil
+		}),
+		Preflight: CommandEntryPreflightFunc(func(context.Context, CommandEntryPreflightRequestV1) (CommandEntryPreflightResultV1, error) {
+			preflightCalls++
+			return CommandEntryPreflightResultV1{}, nil
+		}),
+		Applier:                applier,
+		CatalogVersionProvider: staticCatalogVersion(7),
+	})
+
+	_, err := submitter.SubmitCommandEntryV1(context.Background(), entry, routeMetadata("group-b", iwire.AckRaftCommitted))
+	if !errors.Is(err, ErrRouteGroupMismatch) {
+		t.Fatalf("SubmitCommandEntryV1 err=%v want route group mismatch", err)
+	}
+	if preflightCalls != 0 {
+		t.Fatalf("preflight calls=%d want 0", preflightCalls)
+	}
+	if commitCalls != 0 {
+		t.Fatalf("commit calls=%d want 0", commitCalls)
+	}
+	if got := len(applier.snapshot()); got != 0 {
+		t.Fatalf("apply calls=%d want 0", got)
+	}
+}
+
+func TestSingleGroupSubmitterAllowsMatchingRouteGroup(t *testing.T) {
+	entry := testClusterCommandEntry(t, 7)
+	applier := &recordingClusterApplier{result: raftentry.ApplyResultV1{Status: raftentry.ApplyStatusApplied, AffectedCount: 1}}
+	submitter := newTestSingleGroupSubmitter(t, SingleGroupSubmitterOptions{
+		AdmissionProvider: StaticAdmissionProvider{Status: LeaderAdmission()},
+		CommitSource: NewSequencedCommitSource(SequencedCommitSourceOptions{
+			GroupID:             "group-a",
+			NodeID:              "node-a",
+			EvidenceKind:        CommitEvidenceProductionConsensusV1,
+			ProductionConsensus: true,
+		}),
+		Applier:                applier,
+		CatalogVersionProvider: staticCatalogVersion(7),
+	})
+
+	result, err := submitter.SubmitCommandEntryV1(context.Background(), entry, routeMetadata("group-a", iwire.AckRaftCommitted))
+	if err != nil {
+		t.Fatalf("SubmitCommandEntryV1 matching route group: %v", err)
+	}
+	if result.ActualAck != iwire.AckRaftCommitted || !result.CommittedRecoverable {
+		t.Fatalf("ack/recoverable=%d/%v want raft_committed/true", result.ActualAck, result.CommittedRecoverable)
+	}
+	if result.CommittedEntry.RequestMetadata.ClusterRouteGroupID != "group-a" {
+		t.Fatalf("committed route group=%q want group-a", result.CommittedEntry.RequestMetadata.ClusterRouteGroupID)
+	}
+	if got := len(applier.snapshot()); got != 1 {
+		t.Fatalf("apply calls=%d want 1", got)
+	}
+}
+
+func TestSingleGroupSubmitterPreservesNoRouteMetadataBehavior(t *testing.T) {
+	entry := testClusterCommandEntry(t, 7)
+	applier := &recordingClusterApplier{result: raftentry.ApplyResultV1{Status: raftentry.ApplyStatusApplied, AffectedCount: 1}}
+	submitter := newTestSingleGroupSubmitter(t, SingleGroupSubmitterOptions{
+		AdmissionProvider: StaticAdmissionProvider{Status: LeaderAdmission()},
+		CommitSource: NewSequencedCommitSource(SequencedCommitSourceOptions{
+			GroupID:             "group-a",
+			NodeID:              "node-a",
+			EvidenceKind:        CommitEvidenceProductionConsensusV1,
+			ProductionConsensus: true,
+		}),
+		Applier:                applier,
+		CatalogVersionProvider: staticCatalogVersion(7),
+	})
+
+	metadata := raftentry.RequestMetadataV1{
+		AckPolicy:           iwire.AckRaftCommitted,
+		ClusterRouteGroupID: "group-b",
+	}
+	if _, err := submitter.SubmitCommandEntryV1(context.Background(), entry, metadata); err != nil {
+		t.Fatalf("SubmitCommandEntryV1 without known route metadata: %v", err)
+	}
+	if got := len(applier.snapshot()); got != 1 {
+		t.Fatalf("apply calls=%d want 1", got)
+	}
+}
+
 func TestSingleGroupSubmitterLetsIdempotentCreateRetryReachPreflightApply(t *testing.T) {
 	entry := testClusterCreateCollectionEntry(t, 7)
 	commitCalls := 0
@@ -650,6 +741,21 @@ func staticCatalogVersion(version uint64) CatalogVersionProvider {
 	return CatalogVersionProviderFunc(func(context.Context) (uint64, bool, error) {
 		return version, true, nil
 	})
+}
+
+func routeMetadata(group string, ack iwire.AckPolicy) raftentry.RequestMetadataV1 {
+	return raftentry.RequestMetadataV1{
+		AckPolicy:                 ack,
+		ClusterRouteKnown:         true,
+		ClusterRouteDatabase:      "default",
+		ClusterRouteCatalog:       "default",
+		ClusterRouteCollection:    "users",
+		ClusterRouteShape:         "collection",
+		ClusterRouteGroupID:       group,
+		ClusterRouteMembers:       []string{"node-a", "node-b"},
+		ClusterRouteLeaderHint:    "node-a",
+		ClusterRoutePlacementMode: "collection",
+	}
 }
 
 func productionCommittedResult(req CommitCommandEntryV1Request, term, index uint64) CommitCommandEntryV1Result {

--- a/TreeDB/internal/raftentry/contract.go
+++ b/TreeDB/internal/raftentry/contract.go
@@ -48,8 +48,9 @@ type RequestMetadataV1 struct {
 	OmitResultIDs     bool
 	OmitResponseMeta  bool
 
-	// ClusterRoute* fields are adapter metadata for cluster submitters. They
-	// are intentionally excluded from deterministic command entry bytes.
+	// ClusterRoute* fields are request-only metadata for cluster submitters.
+	// They are intentionally excluded from deterministic command entry bytes,
+	// but submit admission may still treat them as binding local-route guards.
 	ClusterRouteKnown         bool
 	ClusterRouteDatabase      string
 	ClusterRouteCatalog       string

--- a/TreeDB/mongo_gateway/cluster_submitter_test.go
+++ b/TreeDB/mongo_gateway/cluster_submitter_test.go
@@ -351,6 +351,11 @@ func newMongoPlacementRouteTestServer(tb testing.TB, mode raftplacement.Placemen
 
 func newMongoRaftBridgeTestServer(tb testing.TB, admission raftcluster.AdmissionStatus) *Server {
 	tb.Helper()
+	return newMongoRaftBridgeTestServerWithRoute(tb, admission, nil)
+}
+
+func newMongoRaftBridgeTestServerWithRoute(tb testing.TB, admission raftcluster.AdmissionStatus, routeProvider treenativewire.ClusterRouteProvider) *Server {
+	tb.Helper()
 	db, err := backenddb.Open(backenddb.Options{
 		Dir:                          tb.TempDir(),
 		CommandWAL:                   true,
@@ -401,7 +406,11 @@ func newMongoRaftBridgeTestServer(tb testing.TB, admission raftcluster.Admission
 	server := NewServer()
 	server.Collections = collections.NewCollectionManager(db)
 	server.DefaultCollectionOptions = collections.CollectionOptions{DocumentFormat: collections.DocumentFormatBSON}
-	server.ClusterSubmitter = treenativewire.NewRaftClusterSubmitter(bridge, server.Collections)
+	var submitter treenativewire.ClusterSubmitter = treenativewire.NewRaftClusterSubmitter(bridge, server.Collections)
+	if routeProvider != nil {
+		submitter = treenativewire.NewRoutedRaftClusterSubmitter(bridge, routeProvider, server.Collections)
+	}
+	server.ClusterSubmitter = submitter
 	server.ClusterCatalogVersion = func(context.Context) (uint64, error) {
 		state := db.State()
 		if state == nil {
@@ -1395,6 +1404,37 @@ func TestClusterSubmitterConcreteBridgeMajorityInsert(t *testing.T) {
 		t.Fatalf("insert n=%d ok=%v want 1/true", got, ok)
 	}
 	assertMongoUsers(t, server, map[string]string{"u1": "Ada"})
+}
+
+func TestClusterSubmitterConcreteBridgeRouteGroupMismatchNotWritablePrimary(t *testing.T) {
+	provider := &mongoRoutingClusterSubmitter{
+		mongoClusterFakeSubmitter: &mongoClusterFakeSubmitter{},
+		target: treenativewire.ClusterRouteTarget{
+			GroupID:       "group-b",
+			Members:       []string{"node-c", "node-d"},
+			LeaderHint:    "node-c",
+			PlacementMode: "collection",
+		},
+	}
+	server := newMongoRaftBridgeTestServerWithRoute(t, raftcluster.LeaderAdmission(), provider)
+
+	response := serveCommand(t, server, 325808, bson.D{
+		{Key: "insert", Value: "users"},
+		{Key: "documents", Value: bson.A{bson.D{{Key: "_id", Value: "u1"}, {Key: "name", Value: "Ada"}}}},
+		{Key: "$db", Value: "app"},
+	})
+	assertCommandError(t, response, "NotWritablePrimary")
+	assertErrmsgContains(t, response, "route group")
+	if _, err := server.Collections.OpenCollection("app.users"); !errors.Is(err, collections.ErrCollectionNotFound) {
+		t.Fatalf("OpenCollection app.users after route mismatch err=%v want collection not found", err)
+	}
+	routes := provider.snapshotRoutes()
+	if len(routes) != 1 {
+		t.Fatalf("route calls=%d want 1", len(routes))
+	}
+	if got := routes[0]; got.Database != "app" || got.Catalog != "default" || got.Collection != "users" || got.CommandID != iwire.CommandCreateCollection {
+		t.Fatalf("route request=%+v want app/default/users create_collection", got)
+	}
 }
 
 func TestClusterSubmitterRejectsUnsupportedWriteConcernBeforeSubmitOrLocalMutation(t *testing.T) {

--- a/TreeDB/nativewire/cluster_raft_submitter.go
+++ b/TreeDB/nativewire/cluster_raft_submitter.go
@@ -20,12 +20,35 @@ type RaftClusterSubmitter struct {
 	Collections *collections.CollectionManager
 }
 
+// RoutedRaftClusterSubmitter composes the concrete single-group Raft bridge
+// with a catalog-backed route provider. The base RaftClusterSubmitter does not
+// implement ClusterRouteProvider so existing no-provider behavior stays
+// unchanged.
+type RoutedRaftClusterSubmitter struct {
+	*RaftClusterSubmitter
+	RouteProvider ClusterRouteProvider
+}
+
 func NewRaftClusterSubmitter(bridge *raftcluster.SingleGroupSubmitter, managers ...*collections.CollectionManager) *RaftClusterSubmitter {
 	submitter := &RaftClusterSubmitter{Bridge: bridge}
 	if len(managers) > 0 {
 		submitter.Collections = managers[0]
 	}
 	return submitter
+}
+
+func NewRoutedRaftClusterSubmitter(bridge *raftcluster.SingleGroupSubmitter, provider ClusterRouteProvider, managers ...*collections.CollectionManager) *RoutedRaftClusterSubmitter {
+	return &RoutedRaftClusterSubmitter{
+		RaftClusterSubmitter: NewRaftClusterSubmitter(bridge, managers...),
+		RouteProvider:        provider,
+	}
+}
+
+func (s *RoutedRaftClusterSubmitter) ClusterRoute(ctx context.Context, request ClusterRouteRequest) (ClusterRouteTarget, error) {
+	if s == nil || s.RouteProvider == nil {
+		return ClusterRouteTarget{}, protocolError(iwire.ErrReadOnly, "raft cluster route provider is not configured")
+	}
+	return s.RouteProvider.ClusterRoute(ctx, request)
 }
 
 func (s *RaftClusterSubmitter) ClusterAdmissionStatus(ctx context.Context) (ClusterAdmissionStatus, error) {
@@ -156,6 +179,8 @@ func nativeErrorForRaftClusterSubmit(err error) error {
 	case err == nil:
 		return nil
 	case errors.Is(err, raftcluster.ErrNotLeader):
+		return protocolError(iwire.ErrReadOnly, "%v", err)
+	case errors.Is(err, raftcluster.ErrRouteGroupMismatch):
 		return protocolError(iwire.ErrReadOnly, "%v", err)
 	case errors.Is(err, raftcluster.ErrCatalogVersionMismatch):
 		return protocolError(iwire.ErrCatalogVersionMismatch, "%v", err)

--- a/TreeDB/nativewire/cluster_submitter_test.go
+++ b/TreeDB/nativewire/cluster_submitter_test.go
@@ -75,6 +75,31 @@ func (r *routingClusterSubmitter) snapshotRoutes() []ClusterRouteRequest {
 	return append([]ClusterRouteRequest(nil), r.routes...)
 }
 
+type staticClusterRouteProvider struct {
+	mu     sync.Mutex
+	target ClusterRouteTarget
+	err    error
+	routes []ClusterRouteRequest
+}
+
+func (p *staticClusterRouteProvider) ClusterRoute(ctx context.Context, req ClusterRouteRequest) (ClusterRouteTarget, error) {
+	p.mu.Lock()
+	p.routes = append(p.routes, req)
+	p.mu.Unlock()
+	if p.err != nil {
+		return ClusterRouteTarget{}, p.err
+	}
+	target := p.target
+	target.Members = append([]string(nil), target.Members...)
+	return target, nil
+}
+
+func (p *staticClusterRouteProvider) snapshotRoutes() []ClusterRouteRequest {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return append([]ClusterRouteRequest(nil), p.routes...)
+}
+
 type placementRouteClusterSubmitter struct {
 	*fakeClusterSubmitter
 
@@ -1741,6 +1766,13 @@ func TestRaftClusterSubmitterLocalAckUnavailableMapsToNativeError(t *testing.T) 
 	}
 }
 
+func TestRaftClusterSubmitterRouteGroupMismatchMapsToReadOnly(t *testing.T) {
+	err := nativeErrorForRaftClusterSubmit(raftcluster.ErrRouteGroupMismatch)
+	if code, ok := iwire.ErrorCodeOf(err); !ok || code != iwire.ErrReadOnly {
+		t.Fatalf("nativeErrorForRaftClusterSubmit code=%v ok=%v err=%v, want read-only", code, ok, err)
+	}
+}
+
 func TestRaftClusterSubmitterPreservesCollectionConflictCodes(t *testing.T) {
 	tests := []struct {
 		name string
@@ -1770,6 +1802,38 @@ func TestRaftClusterSubmitterPreservesCollectionConflictCodes(t *testing.T) {
 				t.Fatalf("nativeErrorForDeterministicCode code=%v ok=%v err=%v, want %v", code, ok, err, tt.want)
 			}
 		})
+	}
+}
+
+func TestRaftClusterSubmitterRouteGroupMismatchRejectsBeforeLocalMutation(t *testing.T) {
+	provider := &staticClusterRouteProvider{
+		target: ClusterRouteTarget{
+			GroupID:       "group-b",
+			Members:       []string{"node-c", "node-d"},
+			LeaderHint:    "node-c",
+			PlacementMode: "collection",
+		},
+	}
+	client, _, mgr, _ := serveRaftClusterBridgePipeWithRoute(t, raftcluster.LeaderAdmission(), provider)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := client.Hello(ctx); err != nil {
+		t.Fatalf("Hello: %v", err)
+	}
+	version := clientCatalogVersion(t, client, ctx)
+	_, err := client.commandSections(ctx, iwire.CommandCreateCollection, raftClusterCreateCollectionSections("users", version, AckRaftCommitted)...)
+	if !isRemoteError(err, iwire.ErrReadOnly) || !strings.Contains(err.Error(), "route group") {
+		t.Fatalf("CreateCollection route mismatch err=%v want read-only route group mismatch", err)
+	}
+	if _, openErr := mgr.OpenCollection("users"); !errors.Is(openErr, collections.ErrCollectionNotFound) {
+		t.Fatalf("OpenCollection users after route mismatch err=%v want ErrCollectionNotFound", openErr)
+	}
+	routes := provider.snapshotRoutes()
+	if len(routes) != 1 {
+		t.Fatalf("route calls=%d want 1", len(routes))
+	}
+	if got := routes[0]; got.Database != "default" || got.Catalog != "default" || got.Collection != "users" || got.CommandID != iwire.CommandCreateCollection {
+		t.Fatalf("route request=%+v want default/default/users create_collection", got)
 	}
 }
 
@@ -1831,6 +1895,11 @@ func clusterInsertBatchSections(t *testing.T, client *Client, ctx context.Contex
 
 func serveRaftClusterBridgePipe(t testing.TB, admission raftcluster.AdmissionStatus) (*Client, *Server, *collections.CollectionManager, *backenddb.DB) {
 	t.Helper()
+	return serveRaftClusterBridgePipeWithRoute(t, admission, nil)
+}
+
+func serveRaftClusterBridgePipeWithRoute(t testing.TB, admission raftcluster.AdmissionStatus, routeProvider ClusterRouteProvider) (*Client, *Server, *collections.CollectionManager, *backenddb.DB) {
+	t.Helper()
 	db, err := backenddb.Open(backenddb.Options{
 		Dir:                          t.TempDir(),
 		CommandWAL:                   true,
@@ -1879,10 +1948,14 @@ func serveRaftClusterBridgePipe(t testing.TB, admission raftcluster.AdmissionSta
 		_ = db.Close()
 		t.Fatalf("NewSingleGroupSubmitter: %v", err)
 	}
+	var submitter ClusterSubmitter = NewRaftClusterSubmitter(bridge, mgr)
+	if routeProvider != nil {
+		submitter = NewRoutedRaftClusterSubmitter(bridge, routeProvider, mgr)
+	}
 	server := NewServer(ServerOptions{
 		Collections:      mgr,
 		Backend:          db,
-		ClusterSubmitter: NewRaftClusterSubmitter(bridge, mgr),
+		ClusterSubmitter: submitter,
 	})
 	client, _ := servePipe(t, server)
 	t.Cleanup(func() {


### PR DESCRIPTION
## Summary

- Bind `RequestMetadataV1.ClusterRouteGroupID` to the local `raftcluster.SingleGroupSubmitter` group before command decode, preflight, commit source invocation, or local apply.
- Add an opt-in `RoutedRaftClusterSubmitter` wrapper so the concrete Raft bridge can be composed with a route provider without changing default no-provider behavior.
- Map route group mismatches to read-only/not-writable adapter errors and document the binding boundary.

Closes #3396

## Validation

- `TMPDIR=/mnt/fast4tb/tmp/gomap-test-tmp GOCACHE=/mnt/fast4tb/tmp/go-cache GOMODCACHE=/mnt/fast4tb/tmp/go-mod-cache GOWORK=off go test ./TreeDB/internal/raftcluster ./TreeDB/nativewire ./TreeDB/mongo_gateway`
- `TMPDIR=/mnt/fast4tb/tmp/gomap-test-tmp GOCACHE=/mnt/fast4tb/tmp/go-cache GOMODCACHE=/mnt/fast4tb/tmp/go-mod-cache GOWORK=off go test ./TreeDB/internal/raftentry -run TestDigestV1StabilityAcrossMetadataAndApplyEntryID -count=1`

## Notes

- Base is `origin/main` at `e50382fe641349be0cb35a3c88a3a99006e46787`.
- #3394 may also touch submit/admission while adding the quorum provider. This PR keeps the route-binding change isolated to the existing single-group bridge and adapter composition.
- No benchmark run: this is a guard-only admission slice and does not add measurable commit/apply work.
- AI review has not been requested.