### PR TITLE
Optimize q3 pair predicate setup

### DIFF
--- a/TreeDB/collections/column_physical_q1_dense_1950_test.go
+++ b/TreeDB/collections/column_physical_q1_dense_1950_test.go
@@ -540,7 +540,7 @@ func assertColumnPhysicalQ1DenseOneShotSetupDiagnostics1950(tb testing.TB, label
 	if targetedRanges && diag.TypedColumnPrepareRangeReadBytes == 0 {
 		tb.Fatalf("%s setup missing targeted range-read bytes diagnostics=%+v", label, diag)
 	}
-	if diag.TypedColumnPreparePartDecodeNanos != 0 && rawSetupNanos == 0 {
+	if diag.TypedColumnPreparePartDecodeNanos != 0 && rawSetupNanos == 0 && !targetedRanges {
 		tb.Fatalf("%s setup missing raw split diagnostics read_image=%d state_build=%d dictionary=%d adapter=%d diagnostics=%+v",
 			label,
 			diag.TypedColumnPrepareReadImageNanos,

--- a/TreeDB/collections/column_physical_q3_dense_1950_test.go
+++ b/TreeDB/collections/column_physical_q3_dense_1950_test.go
@@ -451,7 +451,19 @@ func assertColumnPhysicalQ3DenseOneShotSetupDiagnostics1950(tb testing.TB, label
 		diag.TypedColumnPrepareDenseValueNanos +
 		diag.TypedColumnPrepareDensePredicateNanos +
 		diag.TypedColumnPrepareDensePreapplyNanos
-	if denseNanos != 0 && (diag.TypedColumnPrepareDenseGroupNanos <= 0 || diag.TypedColumnPrepareDenseValueNanos <= 0 || diag.TypedColumnPrepareDensePredicateNanos <= 0) {
+	if diag.TypedColumnPrepareDenseGroupNanos < 0 ||
+		diag.TypedColumnPrepareDenseValueNanos < 0 ||
+		diag.TypedColumnPrepareDensePredicateNanos < 0 ||
+		diag.TypedColumnPrepareDensePreapplyNanos < 0 {
+		tb.Fatalf("%s setup negative dense split diagnostics group=%d value=%d predicate=%d preapply=%d diagnostics=%+v",
+			label,
+			diag.TypedColumnPrepareDenseGroupNanos,
+			diag.TypedColumnPrepareDenseValueNanos,
+			diag.TypedColumnPrepareDensePredicateNanos,
+			diag.TypedColumnPrepareDensePreapplyNanos,
+			diag)
+	}
+	if !targetedRanges && denseNanos != 0 && (diag.TypedColumnPrepareDenseGroupNanos <= 0 || diag.TypedColumnPrepareDenseValueNanos <= 0 || diag.TypedColumnPrepareDensePredicateNanos <= 0) {
 		tb.Fatalf("%s setup dense split diagnostics group=%d value=%d predicate=%d preapply=%d diagnostics=%+v",
 			label,
 			diag.TypedColumnPrepareDenseGroupNanos,

--- a/TreeDB/collections/column_physical_q3_dense_1950_test.go
+++ b/TreeDB/collections/column_physical_q3_dense_1950_test.go
@@ -138,6 +138,20 @@ func TestColumnPhysicalQ3DenseTypedColumnOneShotSetupDiagnostics1950(t *testing.
 	assertColumnPhysicalQ3DenseOneShotSetupDiagnostics1950(t, "q3 one-shot setup", diag)
 }
 
+func TestColumnPhysicalQ3DenseTypedColumnOneShotTargetedSetupDiagnostics1950(t *testing.T) {
+	batches := [][]columnPhysicalJSONBenchParityEventP0{columnPhysicalQ3DenseBatchA1950(), columnPhysicalQ3DenseBatchB1950()}
+	_, col, closeFn := openTypedColumnSortKeyFixtureBatches1950(t, nil, batches)
+	defer closeFn()
+
+	req := columnPhysicalQ3DenseRequest1950()
+	req.ColumnAssetReadIntegrity = ColumnAssetReadIntegritySkipChecksums
+	view, plan, closeView := openColumnPhysicalQ3DenseOneShotSetupView1950(t, col, req)
+	defer closeView()
+
+	diag := prepareColumnPhysicalQ3DenseOneShotSetup1950(t, view, req, plan)
+	assertColumnPhysicalQ3DenseOneShotSetupDiagnostics1950(t, "q3 targeted one-shot setup", diag)
+}
+
 func BenchmarkColumnPhysicalQ3DenseTypedColumnOneShotSetup1950(b *testing.B) {
 	events := columnPhysicalQ3DenseBenchmarkEvents1950(16_384)
 	_, col, closeFn := openTypedColumnSortKeyFixtureBatches1950(b, nil, [][]columnPhysicalJSONBenchParityEventP0{events})
@@ -158,6 +172,30 @@ func BenchmarkColumnPhysicalQ3DenseTypedColumnOneShotSetup1950(b *testing.B) {
 	}
 	b.StopTimer()
 	assertColumnPhysicalQ3DenseOneShotSetupDiagnostics1950(b, "last q3 one-shot setup", last)
+	reportColumnPhysicalQ3DenseOneShotSetupBenchMetrics1950(b, last)
+}
+
+func BenchmarkColumnPhysicalQ3DenseTypedColumnOneShotTargetedSetup1950(b *testing.B) {
+	events := columnPhysicalQ3DenseBenchmarkEvents1950(16_384)
+	_, col, closeFn := openTypedColumnSortKeyFixtureBatches1950(b, nil, [][]columnPhysicalJSONBenchParityEventP0{events})
+	defer closeFn()
+
+	req := columnPhysicalQ3DenseRequest1950()
+	req.ColumnAssetReadIntegrity = ColumnAssetReadIntegritySkipChecksums
+	view, plan, closeView := openColumnPhysicalQ3DenseOneShotSetupView1950(b, col, req)
+	defer closeView()
+
+	preview := prepareColumnPhysicalQ3DenseOneShotSetup1950(b, view, req, plan)
+	assertColumnPhysicalQ3DenseOneShotSetupDiagnostics1950(b, "preview targeted q3 one-shot setup", preview)
+	b.SetBytes(int64(preview.DecodedPayloadBytes))
+	b.ReportAllocs()
+	b.ResetTimer()
+	var last ColumnPhysicalQueryDiagnostics
+	for i := 0; i < b.N; i++ {
+		last = prepareColumnPhysicalQ3DenseOneShotSetup1950(b, view, req, plan)
+	}
+	b.StopTimer()
+	assertColumnPhysicalQ3DenseOneShotSetupDiagnostics1950(b, "last targeted q3 one-shot setup", last)
 	reportColumnPhysicalQ3DenseOneShotSetupBenchMetrics1950(b, last)
 }
 
@@ -397,6 +435,17 @@ func assertColumnPhysicalQ3DenseOneShotSetupDiagnostics1950(tb testing.TB, label
 	}
 	if diag.TypedColumnPrepareSummaryNanos != 0 {
 		tb.Fatalf("%s setup summary nanos=%d want 0 for no-metadata one-shot setup diagnostics=%+v", label, diag.TypedColumnPrepareSummaryNanos, diag)
+	}
+	targetedRanges := typedColumnStringUseTargetedRanges(ColumnAssetReadIntegrity(diag.ColumnAssetReadIntegrity))
+	if !targetedRanges && (diag.TypedColumnPrepareRangeReadNanos != 0 || diag.TypedColumnPrepareRangeReadBytes != 0) {
+		tb.Fatalf("%s setup range-read diagnostics=%d/%d want 0 for raw q3 setup diagnostics=%+v",
+			label,
+			diag.TypedColumnPrepareRangeReadNanos,
+			diag.TypedColumnPrepareRangeReadBytes,
+			diag)
+	}
+	if targetedRanges && diag.TypedColumnPrepareRangeReadBytes == 0 {
+		tb.Fatalf("%s setup missing targeted range-read bytes diagnostics=%+v", label, diag)
 	}
 	denseNanos := diag.TypedColumnPrepareDenseGroupNanos +
 		diag.TypedColumnPrepareDenseValueNanos +

--- a/TreeDB/collections/typed_column_adapter.go
+++ b/TreeDB/collections/typed_column_adapter.go
@@ -3551,6 +3551,51 @@ func appendTypedColumnDenseSingleCodeTriplePredicateRows(selected []uint32, cand
 func appendTypedColumnDenseSingleCodePairPredicateRows(selected []uint32, candidates []columnTypedColumnDenseSingleCodePredicateCandidate, codeScratch [2][]uint32, valueScratch [2][]int64, nullScratch [2][]bool, defaultScratch [2][]bool, rowOffset, blockRows int) ([]uint32, error) {
 	leftCode := candidates[0].predicate.SingleCode
 	rightCode := candidates[1].predicate.SingleCode
+	if candidates[0].nullable && candidates[1].nullable {
+		leftValues := valueScratch[0]
+		rightValues := valueScratch[1]
+		leftNulls := nullScratch[0]
+		rightNulls := nullScratch[1]
+		leftDefaults := defaultScratch[0]
+		rightDefaults := defaultScratch[1]
+		leftCardinality := candidates[0].cardinality
+		rightCardinality := candidates[1].cardinality
+		for row := 0; row < blockRows; row++ {
+			leftValue := leftValues[row]
+			rightValue := rightValues[row]
+			if !leftNulls[row] && !leftDefaults[row] && (leftValue < 0 || uint64(leftValue) >= uint64(leftCardinality) || leftValue > int64(^uint32(0))) {
+				return nil, fmt.Errorf("collections: dense typed-column predicate column %q code[%d]=%d outside cardinality=%d", candidates[0].partColumn.Definition.Name, rowOffset+row, leftValue, leftCardinality)
+			}
+			if !rightNulls[row] && !rightDefaults[row] && (rightValue < 0 || uint64(rightValue) >= uint64(rightCardinality) || rightValue > int64(^uint32(0))) {
+				return nil, fmt.Errorf("collections: dense typed-column predicate column %q code[%d]=%d outside cardinality=%d", candidates[1].partColumn.Definition.Name, rowOffset+row, rightValue, rightCardinality)
+			}
+			if !leftNulls[row] && !leftDefaults[row] && uint32(leftValue) == leftCode &&
+				!rightNulls[row] && !rightDefaults[row] && uint32(rightValue) == rightCode {
+				selected = append(selected, uint32(rowOffset+row))
+			}
+		}
+		return selected, nil
+	}
+	if !candidates[0].nullable && !candidates[1].nullable {
+		left := codeScratch[0]
+		right := codeScratch[1]
+		leftCardinality := candidates[0].cardinality
+		rightCardinality := candidates[1].cardinality
+		for row := 0; row < blockRows; row++ {
+			leftValue := left[row]
+			rightValue := right[row]
+			if uint64(leftValue) >= uint64(leftCardinality) {
+				return nil, fmt.Errorf("collections: dense typed-column predicate column %q code[%d]=%d outside cardinality=%d", candidates[0].partColumn.Definition.Name, rowOffset+row, leftValue, leftCardinality)
+			}
+			if uint64(rightValue) >= uint64(rightCardinality) {
+				return nil, fmt.Errorf("collections: dense typed-column predicate column %q code[%d]=%d outside cardinality=%d", candidates[1].partColumn.Definition.Name, rowOffset+row, rightValue, rightCardinality)
+			}
+			if leftValue == leftCode && rightValue == rightCode {
+				selected = append(selected, uint32(rowOffset+row))
+			}
+		}
+		return selected, nil
+	}
 	for row := 0; row < blockRows; row++ {
 		leftMatch, err := columnTypedColumnDenseSingleCodePredicateCandidateRowMatches(candidates[0], row, rowOffset, leftCode, codeScratch[0], valueScratch[0], nullScratch[0], defaultScratch[0])
 		if err != nil {


### PR DESCRIPTION
## Summary

- specialize q3's dense single-code pair predicate row selection for both non-nullable and both nullable predicate columns
- keep the mixed nullable/non-nullable path on the existing generic matcher
- add a q3 targeted one-shot setup diagnostics test/benchmark so the skip-checksum targeted-range path is covered directly

Refs #3350 and #3070.

## Claim Boundary

This is q3 `one_shot_end_to_end` / `no_aggregate_metadata` typed-column setup work only.

It is not aggregate metadata acceleration, not load-speed evidence, not hot-prepared evidence, and not a TreeDB-vs-ClickHouse superiority claim.

## 1M JSONBench Evidence

Mode: `column-store-full-prepared`, projection `full`, `one_shot_end_to_end` / `no_aggregate_metadata`, q3 only.

Artifacts:

- baseline gomap `389d203a35d91cd6125d6fe10624cd281dda70d9`: `/mnt/fast4tb/gomap-profiles/q3-predicate-jsonbench-baseline-20260630_065227/report.json`
- branch gomap `5802ef1a5`: `/mnt/fast4tb/gomap-profiles/q3-predicate-jsonbench-branch-20260630_065323/report.json`

| metric | baseline | branch |
| --- | ---: | ---: |
| total | `38.303ms` | `35.442ms` |
| setup | `34.756ms` | `30.400ms` |
| run | `3.517ms` | `4.985ms` |
| render/hash | `0.030ms` | `0.057ms` |
| part decode wall | `34.729ms` | `30.327ms` |
| dense predicate setup, summed across workers | `95.499ms` | `65.090ms` |
| dense preapply setup, summed across workers | `13.594ms` | `10.573ms` |
| dense group setup, summed across workers | `27.569ms` | `26.831ms` |
| dense value setup, summed across workers | `16.870ms` | `14.757ms` |
| range-read bytes | `14,541,335` | `14,541,335` |

Preserved:

- rows scanned/matched/reduced: `1,000,000 / 588,328 / 588,328`
- result hash: `cdb6acc4d0d990bdbdab5d2f29df85943490b2cb6b950351cbfa9bd974a182eb`
- storage source: `typed_column_part_section`
- fallback: `none`
- aggregate metadata used: `false`
- document scan fallback: `false`
- row/document materializations: `0 / 0`

## Microbenchmark Evidence

Targeted setup benchmark was added on top of baseline main to isolate benchmark harness from the production helper change.

Baseline helper (`389d203a` plus benchmark harness only):

```text
BenchmarkColumnPhysicalQ3DenseTypedColumnOneShotTargetedSetup1950-12  1518364 ns/op  dense_predicate=646254 ns/op  374 allocs/op
BenchmarkColumnPhysicalQ3DenseTypedColumnOneShotTargetedSetup1950-12   844175 ns/op  dense_predicate=351220 ns/op  374 allocs/op
BenchmarkColumnPhysicalQ3DenseTypedColumnOneShotTargetedSetup1950-12   845167 ns/op  dense_predicate=350143 ns/op  374 allocs/op
```

Branch:

```text
BenchmarkColumnPhysicalQ3DenseTypedColumnOneShotTargetedSetup1950-12   972713 ns/op  dense_predicate=186152 ns/op  374 allocs/op
BenchmarkColumnPhysicalQ3DenseTypedColumnOneShotTargetedSetup1950-12   756551 ns/op  dense_predicate=101780 ns/op  374 allocs/op
BenchmarkColumnPhysicalQ3DenseTypedColumnOneShotTargetedSetup1950-12   774098 ns/op  dense_predicate=175578 ns/op  374 allocs/op
```

Default setup benchmark still does not exercise the targeted predicate-first range path; it is retained as a no-regression sample.

## Local Validation

```sh
TMPDIR=/mnt/fast4tb/tmp GOCACHE=/mnt/fast4tb/tmp/gocache-q3-predicate-test2 GOMODCACHE=/mnt/fast4tb/tmp/gomodcache-next-query GOTMPDIR=/mnt/fast4tb/tmp/go-build-q3-predicate-test2 GOWORK=off \
  go test ./TreeDB/collections -run 'TestColumnPhysicalQ3DenseTypedColumn(OneShotSetupDiagnostics1950|OneShotTargetedSetupDiagnostics1950|DirectPreparedParity1950)$|TestColumnPhysicalTypedColumnOneShotCacheQ1Q3NoMetadata3088|TestColumnPhysicalDenseTypedColumnTargetedRangeReads3090/q3_group_hour_count' -count=1
```

Result: `ok github.com/snissn/gomap/TreeDB/collections 0.665s`.

```sh
TMPDIR=/mnt/fast4tb/tmp GOCACHE=/mnt/fast4tb/tmp/gocache-q3-predicate-broader GOMODCACHE=/mnt/fast4tb/tmp/gomodcache-next-query GOTMPDIR=/mnt/fast4tb/tmp/go-build-q3-predicate-broader GOWORK=off \
  go test ./TreeDB/collections -run 'Q3|DenseGroupHour|ColumnPhysicalTypedColumnOneShotCache' -count=1
```

Result: `ok github.com/snissn/gomap/TreeDB/collections 0.927s`.

```sh
TMPDIR=/mnt/fast4tb/tmp GOCACHE=/mnt/fast4tb/tmp/gocache-q3-nullable GOMODCACHE=/mnt/fast4tb/tmp/gomodcache-next-query GOTMPDIR=/mnt/fast4tb/tmp/go-build-q3-nullable GOWORK=off \
  go test ./TreeDB/collections -run 'TestColumnPhysicalJSONBenchTypedColumnPartNullableFullData(MissingStrings2165|AllMissingQ13075|TopKFastPaths2878)' -count=1
```

Result: `ok github.com/snissn/gomap/TreeDB/collections 0.406s`.

```sh
TMPDIR=/mnt/fast4tb/tmp GOCACHE=/mnt/fast4tb/tmp/gocache-q3-predicate-bench2 GOMODCACHE=/mnt/fast4tb/tmp/gomodcache-next-query GOTMPDIR=/mnt/fast4tb/tmp/go-build-q3-predicate-bench2 GOWORK=off \
  go test ./TreeDB/collections -run '^$' -bench '^BenchmarkColumnPhysicalQ3DenseTypedColumnOneShot(Targeted)?Setup1950$' -benchtime=20x -count=3 -benchmem
```

Result: passed.

```sh
git diff --check
```

Result: clean.
