### PR TITLE
TreeDB: expose command-WAL batch view counters

### DIFF
--- a/TreeDB/caching/expvar_stats_test.go
+++ b/TreeDB/caching/expvar_stats_test.go
@@ -23,6 +23,7 @@ func TestSelectTreeDBExpvarStatsFiltersAndCoerces(t *testing.T) {
 		"treedb.command_wal.writer.command_buffer.trim_count":                                         "7",
 		"treedb.command_wal.writer.command_buffer.dropped_bytes_total":                                "67108864",
 		"treedb.command_wal.writer.pending_batch.capacity_bytes":                                      "32768",
+		"treedb.command_wal.public_batch.set_view.calls_total":                                        "11",
 		"treedb.vlog.mmap_active_bytes":                                                               "22222",
 		"treedb.vlog.mmap_max_mapped_leaf_sealed_bytes":                                               "1610612736",
 		"treedb.vlog.decode_buffer_grow.read_append_decoded_payload.calls_total":                      "17",
@@ -191,6 +192,9 @@ func TestSelectTreeDBExpvarStatsFiltersAndCoerces(t *testing.T) {
 	}
 	if v, ok := got["treedb.command_wal.writer.pending_batch.capacity_bytes"].(int64); !ok || v != 32768 {
 		t.Fatalf("pending_batch.capacity_bytes=%T(%v) want int64(32768)", got["treedb.command_wal.writer.pending_batch.capacity_bytes"], got["treedb.command_wal.writer.pending_batch.capacity_bytes"])
+	}
+	if v, ok := got["treedb.command_wal.public_batch.set_view.calls_total"].(int64); !ok || v != 11 {
+		t.Fatalf("public_batch.set_view.calls_total=%T(%v) want int64(11)", got["treedb.command_wal.public_batch.set_view.calls_total"], got["treedb.command_wal.public_batch.set_view.calls_total"])
 	}
 	if v, ok := got["treedb.process.memory.pool_pressure_level"].(string); !ok || v != "critical" {
 		t.Fatalf("pool_pressure_level=%T(%v) want string(critical)", got["treedb.process.memory.pool_pressure_level"], got["treedb.process.memory.pool_pressure_level"])

--- a/TreeDB/command_wal_public_cached.go
+++ b/TreeDB/command_wal_public_cached.go
@@ -114,6 +114,20 @@ func (tdb *DB) publicCommandWALLiveStatsInto(stats map[string]string) {
 	publicCommandWALMaxStat(stats, "treedb.command_wal.max_lsn", acceptedMaxLSN)
 }
 
+func (tdb *DB) publicCommandWALBatchStatsInto(stats map[string]string) {
+	if tdb == nil || stats == nil || !tdb.commandWALCached {
+		return
+	}
+	stats["treedb.command_wal.public_batch.set.calls_total"] = fmt.Sprintf("%d", tdb.commandWALPublicBatchSetCalls.Load())
+	stats["treedb.command_wal.public_batch.set.bytes_total"] = fmt.Sprintf("%d", tdb.commandWALPublicBatchSetBytes.Load())
+	stats["treedb.command_wal.public_batch.set_view.calls_total"] = fmt.Sprintf("%d", tdb.commandWALPublicBatchSetViewCalls.Load())
+	stats["treedb.command_wal.public_batch.set_view.bytes_total"] = fmt.Sprintf("%d", tdb.commandWALPublicBatchSetViewBytes.Load())
+	stats["treedb.command_wal.public_batch.delete.calls_total"] = fmt.Sprintf("%d", tdb.commandWALPublicBatchDeleteCalls.Load())
+	stats["treedb.command_wal.public_batch.delete.bytes_total"] = fmt.Sprintf("%d", tdb.commandWALPublicBatchDeleteBytes.Load())
+	stats["treedb.command_wal.public_batch.delete_view.calls_total"] = fmt.Sprintf("%d", tdb.commandWALPublicBatchDeleteViewCalls.Load())
+	stats["treedb.command_wal.public_batch.delete_view.bytes_total"] = fmt.Sprintf("%d", tdb.commandWALPublicBatchDeleteViewBytes.Load())
+}
+
 func publicCommandWALMaxStat(stats map[string]string, key string, value uint64) {
 	if value == 0 {
 		return
@@ -264,6 +278,14 @@ type commandWALPublicBatch struct {
 	opCount             int
 	hasDeleteRange      bool
 	dirty               bool
+	setCalls            int
+	setBytes            int
+	setViewCalls        int
+	setViewBytes        int
+	deleteCalls         int
+	deleteBytes         int
+	deleteViewCalls     int
+	deleteViewBytes     int
 	// retainPayloadAfterWrite is set by adapter-only replay-view helpers. It
 	// keeps payload-owned key/value views valid after a successful Write until
 	// Reset/Close or the next mutation. Ordinary public Batch callers do not use
@@ -399,6 +421,7 @@ func (b *commandWALPublicBatch) setView(key, value []byte, retainReplayViews, us
 		}
 		b.payloadBypass = true
 		b.opCount++
+		b.recordPointIngress(commitlog.RawKVOpSet, len(key)+len(value), useInnerView)
 		b.dirty = true
 		return nil, nil, nil
 	}
@@ -415,6 +438,7 @@ func (b *commandWALPublicBatch) setView(key, value []byte, retainReplayViews, us
 		}
 		b.payloadBypass = true
 		b.opCount++
+		b.recordPointIngress(commitlog.RawKVOpSet, len(key)+len(value), false)
 		b.dirty = true
 		return nil, nil, nil
 	}
@@ -428,6 +452,7 @@ func (b *commandWALPublicBatch) setView(key, value []byte, retainReplayViews, us
 		return nil, nil, err
 	}
 	b.opCount++
+	b.recordPointIngress(commitlog.RawKVOpSet, len(key)+len(value), true)
 	b.dirty = true
 	if retainReplayViews {
 		b.retainPayloadAfterWrite = true
@@ -470,6 +495,7 @@ func (b *commandWALPublicBatch) deleteView(key []byte, retainReplayViews, useInn
 		}
 		b.payloadBypass = true
 		b.opCount++
+		b.recordPointIngress(commitlog.RawKVOpDelete, len(key), useInnerView)
 		b.dirty = true
 		return nil, nil
 	}
@@ -479,6 +505,7 @@ func (b *commandWALPublicBatch) deleteView(key []byte, retainReplayViews, useInn
 		}
 		b.payloadBypass = true
 		b.opCount++
+		b.recordPointIngress(commitlog.RawKVOpDelete, len(key), false)
 		b.dirty = true
 		return nil, nil
 	}
@@ -492,6 +519,7 @@ func (b *commandWALPublicBatch) deleteView(key []byte, retainReplayViews, useInn
 		return nil, err
 	}
 	b.opCount++
+	b.recordPointIngress(commitlog.RawKVOpDelete, len(key), true)
 	b.dirty = true
 	if retainReplayViews {
 		b.retainPayloadAfterWrite = true
@@ -515,6 +543,74 @@ func (b *commandWALPublicBatch) DeleteRange(start, end []byte) error {
 	b.hasDeleteRange = true
 	b.dirty = true
 	return nil
+}
+
+func (b *commandWALPublicBatch) recordPointIngress(op commitlog.RawKVOp, bytes int, view bool) {
+	if b == nil {
+		return
+	}
+	switch op {
+	case commitlog.RawKVOpSet:
+		if view {
+			b.setViewCalls++
+			b.setViewBytes += bytes
+			return
+		}
+		b.setCalls++
+		b.setBytes += bytes
+	case commitlog.RawKVOpDelete:
+		if view {
+			b.deleteViewCalls++
+			b.deleteViewBytes += bytes
+			return
+		}
+		b.deleteCalls++
+		b.deleteBytes += bytes
+	}
+}
+
+func (b *commandWALPublicBatch) publishPointIngressStats() {
+	if b == nil || b.db == nil {
+		return
+	}
+	if b.setCalls != 0 {
+		b.db.commandWALPublicBatchSetCalls.Add(uint64(b.setCalls))
+	}
+	if b.setBytes != 0 {
+		b.db.commandWALPublicBatchSetBytes.Add(uint64(b.setBytes))
+	}
+	if b.setViewCalls != 0 {
+		b.db.commandWALPublicBatchSetViewCalls.Add(uint64(b.setViewCalls))
+	}
+	if b.setViewBytes != 0 {
+		b.db.commandWALPublicBatchSetViewBytes.Add(uint64(b.setViewBytes))
+	}
+	if b.deleteCalls != 0 {
+		b.db.commandWALPublicBatchDeleteCalls.Add(uint64(b.deleteCalls))
+	}
+	if b.deleteBytes != 0 {
+		b.db.commandWALPublicBatchDeleteBytes.Add(uint64(b.deleteBytes))
+	}
+	if b.deleteViewCalls != 0 {
+		b.db.commandWALPublicBatchDeleteViewCalls.Add(uint64(b.deleteViewCalls))
+	}
+	if b.deleteViewBytes != 0 {
+		b.db.commandWALPublicBatchDeleteViewBytes.Add(uint64(b.deleteViewBytes))
+	}
+}
+
+func (b *commandWALPublicBatch) resetPointIngressStats() {
+	if b == nil {
+		return
+	}
+	b.setCalls = 0
+	b.setBytes = 0
+	b.setViewCalls = 0
+	b.setViewBytes = 0
+	b.deleteCalls = 0
+	b.deleteBytes = 0
+	b.deleteViewCalls = 0
+	b.deleteViewBytes = 0
 }
 
 func (b *commandWALPublicBatch) innerSetView(key, value []byte) error {
@@ -590,12 +686,14 @@ func (b *commandWALPublicBatch) write(sync bool) error {
 		}); err != nil {
 			return err
 		}
+		b.publishPointIngressStats()
 		b.disableInnerStreamingBypass()
 		if !b.retainPayloadAfterWrite {
 			b.resetPayloadWithHint()
 		}
 		b.opCount = 0
 		b.hasDeleteRange = false
+		b.resetPointIngressStats()
 		b.dirty = false
 		return nil
 	}
@@ -632,6 +730,7 @@ func (b *commandWALPublicBatch) Close() error {
 	b.resetPayloadWithHint()
 	b.opCount = 0
 	b.hasDeleteRange = false
+	b.resetPointIngressStats()
 	b.dirty = false
 	b.retainPayloadAfterWrite = false
 	b.closed = true
@@ -648,6 +747,7 @@ func (b *commandWALPublicBatch) Reset() {
 		b.resetPayloadWithHint()
 		b.opCount = 0
 		b.hasDeleteRange = false
+		b.resetPointIngressStats()
 		b.dirty = false
 		b.retainPayloadAfterWrite = false
 		b.closed = false
@@ -659,6 +759,7 @@ func (b *commandWALPublicBatch) Reset() {
 	b.resetPayloadWithHint()
 	b.opCount = 0
 	b.hasDeleteRange = false
+	b.resetPointIngressStats()
 	b.dirty = false
 	b.retainPayloadAfterWrite = false
 	b.closed = false

--- a/TreeDB/command_wal_public_test.go
+++ b/TreeDB/command_wal_public_test.go
@@ -358,6 +358,78 @@ func publicCommandWALFrameCount(t *testing.T, db *DB) uint64 {
 	return frames
 }
 
+func publicStatUint64(t *testing.T, db *DB, key string) uint64 {
+	t.Helper()
+	raw := db.Stats()[key]
+	got, err := strconv.ParseUint(raw, 10, 64)
+	if err != nil {
+		t.Fatalf("parse %s=%q: %v", key, raw, err)
+	}
+	return got
+}
+
+func TestPublicCommandWALBatchIngressStatsDistinguishViews(t *testing.T) {
+	db, err := Open(Options{
+		Dir:                 t.TempDir(),
+		Durability:          DurabilityWALOnRelaxed,
+		CommandWAL:          true,
+		CommandWALStatsScan: true,
+	})
+	if err != nil {
+		t.Fatalf("Open command WAL: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	b, ok := db.NewBatch().(*commandWALPublicBatch)
+	if !ok {
+		t.Fatalf("NewBatch type=%T, want *commandWALPublicBatch", db.NewBatch())
+	}
+	if err := b.Set([]byte("plain-set"), []byte("one")); err != nil {
+		_ = b.Close()
+		t.Fatalf("Set: %v", err)
+	}
+	if err := b.SetView([]byte("view-set"), []byte("two")); err != nil {
+		_ = b.Close()
+		t.Fatalf("SetView: %v", err)
+	}
+	if err := b.Delete([]byte("plain-delete")); err != nil {
+		_ = b.Close()
+		t.Fatalf("Delete: %v", err)
+	}
+	if err := b.DeleteView([]byte("view-delete")); err != nil {
+		_ = b.Close()
+		t.Fatalf("DeleteView: %v", err)
+	}
+	if err := b.Write(); err != nil {
+		_ = b.Close()
+		t.Fatalf("Write: %v", err)
+	}
+	if err := b.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	assertPublicCommandWALFrames(t, db, 1)
+
+	tests := []struct {
+		key  string
+		want uint64
+	}{
+		{"treedb.command_wal.public_batch.set.calls_total", 1},
+		{"treedb.command_wal.public_batch.set.bytes_total", uint64(len("plain-set") + len("one"))},
+		{"treedb.command_wal.public_batch.set_view.calls_total", 1},
+		{"treedb.command_wal.public_batch.set_view.bytes_total", uint64(len("view-set") + len("two"))},
+		{"treedb.command_wal.public_batch.delete.calls_total", 1},
+		{"treedb.command_wal.public_batch.delete.bytes_total", uint64(len("plain-delete"))},
+		{"treedb.command_wal.public_batch.delete_view.calls_total", 1},
+		{"treedb.command_wal.public_batch.delete_view.bytes_total", uint64(len("view-delete"))},
+	}
+	for _, tt := range tests {
+		if got := publicStatUint64(t, db, tt.key); got != tt.want {
+			t.Fatalf("%s=%d want %d", tt.key, got, tt.want)
+		}
+	}
+}
+
 func TestPublicCommandWALLiveCountersDoNotRequireStatsScan(t *testing.T) {
 	db, err := Open(Options{
 		Dir:               t.TempDir(),

--- a/TreeDB/public.go
+++ b/TreeDB/public.go
@@ -146,29 +146,37 @@ type UpdateFunc = db.UpdateFunc
 
 // DB is the public TreeDB handle (cached mode by default; read-only opens skip caching).
 type DB struct {
-	cached                              *caching.DB
-	backend                             *db.DB
-	dictdb                              *db.DB
-	templateDB                          *DB
-	writePath                           writePathInfo
-	lifecycleMu                         sync.RWMutex
-	commandWALCached                    bool
-	commandWALPendingMu                 sync.Mutex
-	commandWALFirst                     atomic.Uint64
-	commandWALLast                      atomic.Uint64
-	commandWALCheckpointCutoverLast     atomic.Uint64
-	commandWALCheckpointCutoverErr      error
-	commandWALLiveFrames                atomic.Uint64
-	rawSpanNativePublicUpdateReject     atomic.Uint64
-	rawSpanNativePublicUpdateSyncReject atomic.Uint64
-	bgVac                               bgIndexVacuumWorker
-	notifyError                         func(error)
-	bgErrMu                             sync.Mutex
-	bgErr                               error
-	durabilityMode                      string
-	valueLogReadIntegrity               string
-	dir                                 string
-	maintenance                         maintenanceCoordinator
+	cached                               *caching.DB
+	backend                              *db.DB
+	dictdb                               *db.DB
+	templateDB                           *DB
+	writePath                            writePathInfo
+	lifecycleMu                          sync.RWMutex
+	commandWALCached                     bool
+	commandWALPendingMu                  sync.Mutex
+	commandWALFirst                      atomic.Uint64
+	commandWALLast                       atomic.Uint64
+	commandWALCheckpointCutoverLast      atomic.Uint64
+	commandWALCheckpointCutoverErr       error
+	commandWALLiveFrames                 atomic.Uint64
+	commandWALPublicBatchSetCalls        atomic.Uint64
+	commandWALPublicBatchSetBytes        atomic.Uint64
+	commandWALPublicBatchSetViewCalls    atomic.Uint64
+	commandWALPublicBatchSetViewBytes    atomic.Uint64
+	commandWALPublicBatchDeleteCalls     atomic.Uint64
+	commandWALPublicBatchDeleteBytes     atomic.Uint64
+	commandWALPublicBatchDeleteViewCalls atomic.Uint64
+	commandWALPublicBatchDeleteViewBytes atomic.Uint64
+	rawSpanNativePublicUpdateReject      atomic.Uint64
+	rawSpanNativePublicUpdateSyncReject  atomic.Uint64
+	bgVac                                bgIndexVacuumWorker
+	notifyError                          func(error)
+	bgErrMu                              sync.Mutex
+	bgErr                                error
+	durabilityMode                       string
+	valueLogReadIntegrity                string
+	dir                                  string
+	maintenance                          maintenanceCoordinator
 }
 
 var (
@@ -1857,6 +1865,7 @@ func (db *DB) Stats() map[string]string {
 		}
 		writePathStatsInto(stats, db.writePath)
 		db.publicCommandWALLiveStatsInto(stats)
+		db.publicCommandWALBatchStatsInto(stats)
 		db.publicRawSpanNativeStatsInto(stats)
 		stats["treedb.durability_mode"] = db.durabilityMode
 		stats["treedb.vlog.read_integrity"] = db.valueLogReadIntegrity


### PR DESCRIPTION
## Linked Issues

Refs #3316
Refs #3314

## Summary

- Add always-on TreeDB command-WAL public batch ingress counters for `Set`, `SetView`, `Delete`, and `DeleteView` call/byte totals.
- Publish the counters in `DB.Stats()` under `treedb.command_wal.public_batch.*`, which is already selected by the Celestia expvar/debug-var prefix path.
- Keep mutation hot paths batch-local and aggregate to DB atomics only after a successful `Write`/`WriteSync` command-WAL append/apply.

## Evidence Boundary

This is instrumentation-only for #3316. It does not claim a Celestia performance improvement yet. The intended next Celestia evidence pass should use these counters to distinguish whether view-shaped operations reach the TreeDB public command-WAL wrapper without relying on `TREEDB_HOT_PATH_STATS` process counters.

## Correctness / Safety

- No WAL payload, replay, durability, value-log, root, or flush/apply behavior changes.
- Abandoned or failed batches do not publish global ingress totals; counters describe successfully written command-WAL public batches.
- Existing external view-retention safety remains unchanged.

## Local Validation

- `GOWORK=off go test ./TreeDB -run TestPublicCommandWALBatchIngressStatsDistinguishViews -count=1`
- `GOWORK=off go test ./TreeDB -run TestPublicCommandWAL -count=1`
- `GOWORK=off go test ./TreeDB/caching -run TestSelectTreeDBExpvarStatsFiltersAndCoerces -count=1`
- `git diff --check`
