### PR TITLE
TreeDB: expose public command-WAL batch counters in expvar

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -62,6 +62,10 @@ type autoCheckpointBytesHookBox struct {
 	fn func() int64
 }
 
+type statsHookBox struct {
+	fn func(map[string]string)
+}
+
 var ErrKeyEmpty = fmt.Errorf("key cannot be empty")
 var ErrValueNil = fmt.Errorf("value cannot be nil")
 var ErrBatchClosed = fmt.Errorf("batch has been written or closed")
@@ -4019,6 +4023,20 @@ func (db *DB) SetCommandWALCheckpointCleanupHook(h func(sync bool) error) {
 		return
 	}
 	db.commandWALCheckpointCleanup.Store(&commandWALCheckpointCleanupHookBox{fn: h})
+}
+
+// SetStatsHook installs an optional stats decorator for outer wrappers that own
+// counters not stored on the cached layer itself. The hook must not call
+// DB.Stats.
+func (db *DB) SetStatsHook(h func(map[string]string)) {
+	if db == nil {
+		return
+	}
+	if h == nil {
+		db.statsHook.Store(nil)
+		return
+	}
+	db.statsHook.Store(&statsHookBox{fn: h})
 }
 
 // SetTemplateStore installs the template store used for template compression.
@@ -8114,6 +8132,7 @@ type DB struct {
 	commandWALCheckpointPublish        atomic.Pointer[commandWALCheckpointPublishHookBox]
 	commandWALCheckpointCutover        atomic.Pointer[commandWALCheckpointCutoverHookBox]
 	commandWALCheckpointCleanup        atomic.Pointer[commandWALCheckpointCleanupHookBox]
+	statsHook                          atomic.Pointer[statsHookBox]
 	dirtyRootPublishGroupID            uint64
 	dirtyRootPublishGroupPending       bool
 	rootPublishRetryPending            bool
@@ -23159,6 +23178,17 @@ func (db *DB) loadAutoCheckpointBytesHook() func() int64 {
 	return box.fn
 }
 
+func (db *DB) loadStatsHook() func(map[string]string) {
+	if db == nil {
+		return nil
+	}
+	box := db.statsHook.Load()
+	if box == nil {
+		return nil
+	}
+	return box.fn
+}
+
 func (db *DB) snapshotCommandWALCheckpointCutover() {
 	cutoverHook := db.loadCommandWALCheckpointCutoverHook()
 	if cutoverHook == nil {
@@ -30740,6 +30770,9 @@ func (db *DB) Stats() map[string]string {
 		stats["treedb.cache.vlog_autotune.io_ns_per_stored_byte"] = fmt.Sprintf("%.3f", snap.IoNsPerStoredByte)
 		stats["treedb.cache.vlog_autotune.throughput_raw_MBps"] = fmt.Sprintf("%.3f", snap.ThroughputRawMBps)
 		stats["treedb.cache.vlog_autotune.observed_ratio"] = fmt.Sprintf("%.6f", snap.ObservedRatio)
+	}
+	if hook := db.loadStatsHook(); hook != nil {
+		hook(stats)
 	}
 	return stats
 }

--- a/TreeDB/caching/expvar_stats_test.go
+++ b/TreeDB/caching/expvar_stats_test.go
@@ -385,6 +385,43 @@ func TestCurrentTreeDBExpvarStatsIncludesInstances(t *testing.T) {
 	}
 }
 
+func TestCurrentTreeDBExpvarStatsIncludesStatsHook(t *testing.T) {
+	resetTreeDBExpvarRegistryForTest(t)
+
+	db := &DB{
+		dir: "/tmp/hook/wal",
+		backend: &mockBackendWithStats{
+			MockBackend: NewMockBackend(),
+			stats: map[string]string{
+				"treedb.process.identity.wal_dir":        "/tmp/hook/wal",
+				"treedb.process.memory.heap_inuse_bytes": "333",
+			},
+		},
+	}
+	db.SetStatsHook(func(stats map[string]string) {
+		stats["treedb.command_wal.public_batch.set_view.calls_total"] = "13"
+		stats["treedb.command_wal.public_batch.delete_view.calls_total"] = "5"
+	})
+
+	registerTreeDBExpvarStatsDB(db)
+
+	got := currentTreeDBExpvarStats()
+	if got["treedb.command_wal.public_batch.set_view.calls_total"] != int64(13) {
+		t.Fatalf("current set_view calls=%T(%v) want int64(13)", got["treedb.command_wal.public_batch.set_view.calls_total"], got["treedb.command_wal.public_batch.set_view.calls_total"])
+	}
+	instances, ok := got["instances"].(map[string]any)
+	if !ok {
+		t.Fatalf("instances=%T want map[string]any", got["instances"])
+	}
+	inst, ok := findExpvarInstanceByWalDir(instances, "/tmp/hook/wal")
+	if !ok {
+		t.Fatalf("instance /tmp/hook/wal missing")
+	}
+	if inst["treedb.command_wal.public_batch.delete_view.calls_total"] != int64(5) {
+		t.Fatalf("instance delete_view calls=%T(%v) want int64(5)", inst["treedb.command_wal.public_batch.delete_view.calls_total"], inst["treedb.command_wal.public_batch.delete_view.calls_total"])
+	}
+}
+
 func TestCurrentTreeDBExpvarStatsDuplicateWalDirKeepsDistinctInstances(t *testing.T) {
 	resetTreeDBExpvarRegistryForTest(t)
 

--- a/TreeDB/command_wal_public_test.go
+++ b/TreeDB/command_wal_public_test.go
@@ -358,14 +358,19 @@ func publicCommandWALFrameCount(t *testing.T, db *DB) uint64 {
 	return frames
 }
 
-func publicStatUint64(t *testing.T, db *DB, key string) uint64 {
+func statMapUint64(t *testing.T, stats map[string]string, key string) uint64 {
 	t.Helper()
-	raw := db.Stats()[key]
+	raw := stats[key]
 	got, err := strconv.ParseUint(raw, 10, 64)
 	if err != nil {
 		t.Fatalf("parse %s=%q: %v", key, raw, err)
 	}
 	return got
+}
+
+func publicStatUint64(t *testing.T, db *DB, key string) uint64 {
+	t.Helper()
+	return statMapUint64(t, db.Stats(), key)
 }
 
 func TestPublicCommandWALBatchIngressStatsDistinguishViews(t *testing.T) {
@@ -426,6 +431,12 @@ func TestPublicCommandWALBatchIngressStatsDistinguishViews(t *testing.T) {
 	for _, tt := range tests {
 		if got := publicStatUint64(t, db, tt.key); got != tt.want {
 			t.Fatalf("%s=%d want %d", tt.key, got, tt.want)
+		}
+	}
+	cachedStats := db.cached.Stats()
+	for _, tt := range tests {
+		if got := statMapUint64(t, cachedStats, tt.key); got != tt.want {
+			t.Fatalf("cached stats %s=%d want %d", tt.key, got, tt.want)
 		}
 	}
 }

--- a/TreeDB/public.go
+++ b/TreeDB/public.go
@@ -815,6 +815,7 @@ func Open(opts Options) (*DB, error) {
 		cached.SetCommandWALCheckpointPublishHook(out.preparePublicCommandWALPendingPublish)
 		cached.SetCommandWALCheckpointCleanupHook(out.cleanupPublicCommandWALCheckpoint)
 		cached.SetAutoCheckpointWALBytesHook(out.publicCommandWALAutoCheckpointBytes)
+		cached.SetStatsHook(out.publicCommandWALBatchStatsInto)
 	}
 
 	// Cached-mode auto checkpointing is enabled by default to keep `wal/` growth


### PR DESCRIPTION
## Summary

- add a cached-layer stats decorator hook for outer wrappers that own counters outside `caching.DB`
- wire the public command-WAL wrapper so `treedb.command_wal.public_batch.*` appears in the cached stats path scraped by Celestia expvar/debug vars
- extend tests to require the public batch counters through both `DB.Stats()` and `db.cached.Stats()`, plus expvar selection through the new hook

## Why

PR #3401 added first-class public command-WAL batch ingress counters, but the post-merge Celestia evidence run at `b1cf3a199c0053a222102da8074be421a908913c` showed no `treedb.command_wal.public_batch.*` keys in the final harvested app vars. The selector already admits `treedb.command_wal.*`; the missing bridge is that Celestia scrapes the cached DB expvar path, which called `caching.DB.Stats()` directly instead of public `DB.Stats()`.

This is instrumentation-only. It does not change write, WAL, replay, apply, root, or value-log behavior.

## Validation

- `GOWORK=off go test ./TreeDB -run TestPublicCommandWALBatchIngressStatsDistinguishViews -count=1`
- `GOWORK=off go test ./TreeDB/caching -run 'TestCurrentTreeDBExpvarStatsIncludesStatsHook|TestSelectTreeDBExpvarStatsFiltersAndCoerces' -count=1`\n- `GOWORK=off go test ./TreeDB -run TestPublicCommandWAL -count=1`\n- `GOWORK=off go test ./TreeDB/caching -run TestCurrentTreeDBExpvarStats -count=1`\n- `git diff --check`\n\n## Tracker\n\nRefs #3316.\nRefs #3314.\nRefs #3320.