### PR TITLE
TreeDB: expose direct arena HWM stats

### DIFF
--- a/TreeDB/caching/append_only_direct_writer_pool_test.go
+++ b/TreeDB/caching/append_only_direct_writer_pool_test.go
@@ -42,6 +42,19 @@ func TestAppendOnlyDirectWriterArena_RetainsAcrossRotateCheckpointAndReuse(t *te
 	if got := countMutableAppendOnlyDirectArenaRetainedChunks(shard); got != 0 {
 		t.Fatalf("expected no retained chunks before rotate, got=%d", got)
 	}
+	statsAfterFirstSet := db.Stats()
+	if got := mustStatInt64(t, statsAfterFirstSet, "treedb.cache.append_only_direct_arena.active_chunks"); got == 0 {
+		t.Fatalf("active direct arena chunks stat=0 after first set")
+	}
+	if got := mustStatInt64(t, statsAfterFirstSet, "treedb.cache.append_only_direct_arena.active_bytes"); got == 0 {
+		t.Fatalf("active direct arena bytes stat=0 after first set")
+	}
+	if got := mustStatInt64(t, statsAfterFirstSet, "treedb.cache.append_only_direct_arena.active_used_bytes"); got == 0 {
+		t.Fatalf("active direct arena used bytes stat=0 after first set")
+	}
+	if got := mustStatInt64(t, statsAfterFirstSet, "treedb.cache.append_only_direct_arena.retained_bytes"); got != 0 {
+		t.Fatalf("retained direct arena bytes before rotate=%d want 0", got)
+	}
 
 	db.mu.Lock()
 	err = db.rotateMemtableLocked(false)
@@ -54,6 +67,19 @@ func TestAppendOnlyDirectWriterArena_RetainsAcrossRotateCheckpointAndReuse(t *te
 	}
 	if got := countMutableAppendOnlyDirectArenaActiveChunks(&db.mutableShards[0]); got != 0 {
 		t.Fatalf("expected new mutable writer arena to start empty, got=%d", got)
+	}
+	statsAfterRotate := db.Stats()
+	if got := mustStatInt64(t, statsAfterRotate, "treedb.cache.append_only_direct_arena.active_chunks"); got != 0 {
+		t.Fatalf("active direct arena chunks after rotate=%d want 0", got)
+	}
+	if got := mustStatInt64(t, statsAfterRotate, "treedb.cache.append_only_direct_arena.lease_count"); got != 1 {
+		t.Fatalf("direct arena lease count after rotate=%d want 1", got)
+	}
+	if got := mustStatInt64(t, statsAfterRotate, "treedb.cache.append_only_direct_arena.lease_bytes"); got == 0 {
+		t.Fatalf("direct arena lease bytes after rotate=0")
+	}
+	if got := mustStatInt64(t, statsAfterRotate, "treedb.process.append_only_direct_arena.lease_bytes"); got != mustStatInt64(t, statsAfterRotate, "treedb.cache.append_only_direct_arena.lease_bytes") {
+		t.Fatalf("direct arena process/cache lease bytes mismatch process=%d cache=%d", got, mustStatInt64(t, statsAfterRotate, "treedb.cache.append_only_direct_arena.lease_bytes"))
 	}
 
 	got, err := db.Get(firstKey)
@@ -73,6 +99,13 @@ func TestAppendOnlyDirectWriterArena_RetainsAcrossRotateCheckpointAndReuse(t *te
 	retainedAfterCheckpoint := countMutableAppendOnlyDirectArenaRetainedChunks(&db.mutableShards[0])
 	if retainedAfterCheckpoint == 0 {
 		t.Fatalf("expected checkpoint to return pinned chunks to shard-local retained pool")
+	}
+	statsAfterCheckpoint := db.Stats()
+	if got := mustStatInt64(t, statsAfterCheckpoint, "treedb.cache.append_only_direct_arena.lease_count"); got != 0 {
+		t.Fatalf("direct arena lease count after checkpoint=%d want 0", got)
+	}
+	if got := mustStatInt64(t, statsAfterCheckpoint, "treedb.cache.append_only_direct_arena.retained_bytes"); got == 0 {
+		t.Fatalf("direct arena retained bytes after checkpoint=0")
 	}
 
 	secondKey := []byte("k2")

--- a/TreeDB/caching/append_only_direct_writer_pool_test.go
+++ b/TreeDB/caching/append_only_direct_writer_pool_test.go
@@ -196,6 +196,23 @@ func TestAppendOnlyDirectWriterArena_SkipsPointerOnlyMemtableValues(t *testing.T
 	}
 }
 
+func TestAppendOnlyDirectWriterArenaStatsExcludeAbandonedTail(t *testing.T) {
+	var arena appendOnlyDirectValueArena
+	first := arena.alloc(20 << 10)
+	second := arena.alloc(20 << 10)
+
+	stats := arena.backingStats()
+	wantUsed := int64(len(first) + len(second))
+	if got := stats.activeUsedBytes; got != wantUsed {
+		t.Fatalf("active used bytes=%d want %d", got, wantUsed)
+	}
+	if got := stats.activeBytes; got <= stats.activeUsedBytes {
+		t.Fatalf("active capacity bytes=%d want > used bytes %d to expose abandoned tail", got, stats.activeUsedBytes)
+	}
+
+	arena.recycleAll()
+}
+
 func TestAppendOnlyDirectWriterArena_ReusesRetainedChunksOnReset(t *testing.T) {
 	dir := t.TempDir()
 	db, err := Open(dir, NewMockBackend(), Options{

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -1794,11 +1794,12 @@ func appendOnlyDirectArenaChunksBytes(chunks [][]byte) int64 {
 }
 
 type appendOnlyDirectValueArena struct {
-	retained      [][]byte
-	retainedBytes int64
-	active        [][]byte
-	cur           []byte
-	curPos        int
+	retained        [][]byte
+	retainedBytes   int64
+	active          [][]byte
+	activeUsedBytes int64
+	cur             []byte
+	curPos          int
 }
 
 func (a *appendOnlyDirectValueArena) takeRetainedChunk(length int) []byte {
@@ -1835,12 +1836,14 @@ func (a *appendOnlyDirectValueArena) alloc(length int) []byte {
 	}
 	out := a.cur[a.curPos : a.curPos+length : a.curPos+length]
 	a.curPos += length
+	a.activeUsedBytes += int64(length)
 	return out
 }
 
 func (a *appendOnlyDirectValueArena) drainActiveChunks() [][]byte {
 	chunks := a.active
 	a.active = nil
+	a.activeUsedBytes = 0
 	a.cur = nil
 	a.curPos = 0
 	return chunks
@@ -1851,24 +1854,14 @@ func (a *appendOnlyDirectValueArena) backingStats() appendOnlyDirectArenaBacking
 		return appendOnlyDirectArenaBackingStats{}
 	}
 	stats := appendOnlyDirectArenaBackingStats{
-		activeChunks:   int64(len(a.active)),
-		activeBytes:    appendOnlyDirectArenaChunksBytes(a.active),
-		retainedChunks: int64(len(a.retained)),
-		retainedBytes:  a.retainedBytes,
+		activeChunks:    int64(len(a.active)),
+		activeBytes:     appendOnlyDirectArenaChunksBytes(a.active),
+		activeUsedBytes: a.activeUsedBytes,
+		retainedChunks:  int64(len(a.retained)),
+		retainedBytes:   a.retainedBytes,
 	}
-	for i := range a.active {
-		chunk := a.active[i]
-		if chunk == nil {
-			continue
-		}
-		used := cap(chunk)
-		if i == len(a.active)-1 && a.cur != nil {
-			used = a.curPos
-			if used > cap(chunk) {
-				used = cap(chunk)
-			}
-		}
-		stats.activeUsedBytes += int64(used)
+	if stats.activeUsedBytes > stats.activeBytes {
+		stats.activeUsedBytes = stats.activeBytes
 	}
 	return stats
 }

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -330,6 +330,17 @@ type memtableResidencyBreakdown struct {
 	appendOnly memtableResidencySummary
 }
 
+type appendOnlyDirectArenaBackingStats struct {
+	activeChunks    int64
+	activeBytes     int64
+	activeUsedBytes int64
+	retainedChunks  int64
+	retainedBytes   int64
+	leaseCount      int64
+	leaseChunks     int64
+	leaseBytes      int64
+}
+
 type batchSetCallerSampleStats struct {
 	calls atomic.Uint64
 	bytes atomic.Uint64
@@ -1833,6 +1844,33 @@ func (a *appendOnlyDirectValueArena) drainActiveChunks() [][]byte {
 	a.cur = nil
 	a.curPos = 0
 	return chunks
+}
+
+func (a *appendOnlyDirectValueArena) backingStats() appendOnlyDirectArenaBackingStats {
+	if a == nil {
+		return appendOnlyDirectArenaBackingStats{}
+	}
+	stats := appendOnlyDirectArenaBackingStats{
+		activeChunks:   int64(len(a.active)),
+		activeBytes:    appendOnlyDirectArenaChunksBytes(a.active),
+		retainedChunks: int64(len(a.retained)),
+		retainedBytes:  a.retainedBytes,
+	}
+	for i := range a.active {
+		chunk := a.active[i]
+		if chunk == nil {
+			continue
+		}
+		used := cap(chunk)
+		if i == len(a.active)-1 && a.cur != nil {
+			used = a.curPos
+			if used > cap(chunk) {
+				used = cap(chunk)
+			}
+		}
+		stats.activeUsedBytes += int64(used)
+	}
+	return stats
 }
 
 func (a *appendOnlyDirectValueArena) trimRetained(maxChunks int, maxBytes int64, maxChunkCap int) (droppedBytes int64) {
@@ -10247,6 +10285,35 @@ func (db *DB) appendOnlyMutableShardEntryStats() (count int, entryCapacity int64
 		shard.mu.Unlock()
 	}
 	return count, entryCapacity, entryBackingBytes, valueArena
+}
+
+func (db *DB) appendOnlyDirectArenaBackingStats() appendOnlyDirectArenaBackingStats {
+	if db == nil {
+		return appendOnlyDirectArenaBackingStats{}
+	}
+	var out appendOnlyDirectArenaBackingStats
+	for i := range db.mutableShards {
+		shard := &db.mutableShards[i]
+		shard.mu.Lock()
+		stats := shard.appendOnlyDirectValueArena.backingStats()
+		shard.mu.Unlock()
+		out.activeChunks += stats.activeChunks
+		out.activeBytes += stats.activeBytes
+		out.activeUsedBytes += stats.activeUsedBytes
+		out.retainedChunks += stats.retainedChunks
+		out.retainedBytes += stats.retainedBytes
+	}
+	db.appendOnlyDirectArenaLeaseMu.Lock()
+	for _, lease := range db.appendOnlyDirectArenaLeasesByMem {
+		if lease == nil {
+			continue
+		}
+		out.leaseCount++
+		out.leaseChunks += int64(len(lease.chunks))
+		out.leaseBytes += lease.bytes
+	}
+	db.appendOnlyDirectArenaLeaseMu.Unlock()
+	return out
 }
 
 func (db *DB) trimEmptyAppendOnlyMutableShards(capacity int) int {
@@ -29186,6 +29253,7 @@ func (db *DB) Stats() map[string]string {
 	appendOnlyEntryReserveStats := memtable.AppendOnlyEntryReserveStatsSnapshot()
 	appendOnlyMemLeaseCount, appendOnlyMemLeaseEntryCapacity, appendOnlyMemLeaseEntryBackingBytes, appendOnlyMemLeaseValueArena := db.appendOnlyMemLeaseStats()
 	appendOnlyMutableCount, appendOnlyMutableEntryCapacity, appendOnlyMutableEntryBackingBytes, appendOnlyMutableValueArena := db.appendOnlyMutableShardEntryStats()
+	appendOnlyDirectArenaStats := db.appendOnlyDirectArenaBackingStats()
 	appendOnlyMutableTrimTotal := db.appendOnlyMutableTrimTotal.Load()
 	appendOnlyMutableTrimDropped := db.appendOnlyMutableTrimDropped.Load()
 	appendOnlyMutableSparseTrimTotal := db.appendOnlyMutableSparseTrimTotal.Load()
@@ -29299,6 +29367,14 @@ func (db *DB) Stats() map[string]string {
 	stats["treedb.cache.append_only_direct_arena.retained_hit_bytes_total"] = fmt.Sprintf("%d", appendOnlyDirectArenaRetainedHitBytesTotal.Load())
 	stats["treedb.cache.append_only_direct_arena.fresh_alloc_chunks_total"] = fmt.Sprintf("%d", appendOnlyDirectArenaFreshAllocChunksTotal.Load())
 	stats["treedb.cache.append_only_direct_arena.fresh_alloc_bytes_total"] = fmt.Sprintf("%d", appendOnlyDirectArenaFreshAllocBytesTotal.Load())
+	stats["treedb.cache.append_only_direct_arena.active_chunks"] = fmt.Sprintf("%d", appendOnlyDirectArenaStats.activeChunks)
+	stats["treedb.cache.append_only_direct_arena.active_bytes"] = fmt.Sprintf("%d", appendOnlyDirectArenaStats.activeBytes)
+	stats["treedb.cache.append_only_direct_arena.active_used_bytes"] = fmt.Sprintf("%d", appendOnlyDirectArenaStats.activeUsedBytes)
+	stats["treedb.cache.append_only_direct_arena.retained_chunks"] = fmt.Sprintf("%d", appendOnlyDirectArenaStats.retainedChunks)
+	stats["treedb.cache.append_only_direct_arena.retained_bytes"] = fmt.Sprintf("%d", appendOnlyDirectArenaStats.retainedBytes)
+	stats["treedb.cache.append_only_direct_arena.lease_count"] = fmt.Sprintf("%d", appendOnlyDirectArenaStats.leaseCount)
+	stats["treedb.cache.append_only_direct_arena.lease_chunks"] = fmt.Sprintf("%d", appendOnlyDirectArenaStats.leaseChunks)
+	stats["treedb.cache.append_only_direct_arena.lease_bytes"] = fmt.Sprintf("%d", appendOnlyDirectArenaStats.leaseBytes)
 	stats["treedb.cache.batch_pool.drop_under_pressure.entries_total"] = fmt.Sprintf("%d", batchEntriesPoolDropUnderPressureTotal.Load())
 	stats["treedb.cache.batch_pool.drop_under_pressure.shard_entries_total"] = fmt.Sprintf("%d", batchShardEntriesPoolDropUnderPressureTotal.Load())
 	stats["treedb.cache.batch_pool.drop_under_pressure.int_slices_total"] = fmt.Sprintf("%d", batchIntPoolDropUnderPressureTotal.Load())
@@ -29311,6 +29387,14 @@ func (db *DB) Stats() map[string]string {
 	stats["treedb.process.append_only_direct_arena.retained_hit_bytes_total"] = fmt.Sprintf("%d", appendOnlyDirectArenaRetainedHitBytesTotal.Load())
 	stats["treedb.process.append_only_direct_arena.fresh_alloc_chunks_total"] = fmt.Sprintf("%d", appendOnlyDirectArenaFreshAllocChunksTotal.Load())
 	stats["treedb.process.append_only_direct_arena.fresh_alloc_bytes_total"] = fmt.Sprintf("%d", appendOnlyDirectArenaFreshAllocBytesTotal.Load())
+	stats["treedb.process.append_only_direct_arena.active_chunks"] = fmt.Sprintf("%d", appendOnlyDirectArenaStats.activeChunks)
+	stats["treedb.process.append_only_direct_arena.active_bytes"] = fmt.Sprintf("%d", appendOnlyDirectArenaStats.activeBytes)
+	stats["treedb.process.append_only_direct_arena.active_used_bytes"] = fmt.Sprintf("%d", appendOnlyDirectArenaStats.activeUsedBytes)
+	stats["treedb.process.append_only_direct_arena.retained_chunks"] = fmt.Sprintf("%d", appendOnlyDirectArenaStats.retainedChunks)
+	stats["treedb.process.append_only_direct_arena.retained_bytes"] = fmt.Sprintf("%d", appendOnlyDirectArenaStats.retainedBytes)
+	stats["treedb.process.append_only_direct_arena.lease_count"] = fmt.Sprintf("%d", appendOnlyDirectArenaStats.leaseCount)
+	stats["treedb.process.append_only_direct_arena.lease_chunks"] = fmt.Sprintf("%d", appendOnlyDirectArenaStats.leaseChunks)
+	stats["treedb.process.append_only_direct_arena.lease_bytes"] = fmt.Sprintf("%d", appendOnlyDirectArenaStats.leaseBytes)
 	stats["treedb.process.batch_pool.drop_under_pressure.entries_total"] = fmt.Sprintf("%d", batchEntriesPoolDropUnderPressureTotal.Load())
 	stats["treedb.process.batch_pool.drop_under_pressure.shard_entries_total"] = fmt.Sprintf("%d", batchShardEntriesPoolDropUnderPressureTotal.Load())
 	stats["treedb.process.batch_pool.drop_under_pressure.int_slices_total"] = fmt.Sprintf("%d", batchIntPoolDropUnderPressureTotal.Load())

--- a/TreeDB/caching/expvar_stats.go
+++ b/TreeDB/caching/expvar_stats.go
@@ -163,6 +163,7 @@ func selectTreeDBExpvarStats(stats map[string]string) map[string]any {
 			strings.HasPrefix(k, "treedb.cache.vlog_zombie.") ||
 			strings.HasPrefix(k, "treedb.cache.vlog_payload_kind.") ||
 			strings.HasPrefix(k, "treedb.cache.vlog_outer_leaf_codec.") ||
+			strings.HasPrefix(k, "treedb.cache.append_only_direct_arena.") ||
 			strings.HasPrefix(k, "treedb.cache.batch_arena.") {
 			out[k] = coerceStatsValue(v)
 		}

--- a/TreeDB/caching/expvar_stats_test.go
+++ b/TreeDB/caching/expvar_stats_test.go
@@ -59,6 +59,9 @@ func TestSelectTreeDBExpvarStatsFiltersAndCoerces(t *testing.T) {
 		"treedb.process.memtable_residency.queue.append_only.value_arena_retained_bytes":              "32768",
 		"treedb.process.append_only.mem_lease_value_arena_retained_bytes":                             "65536",
 		"treedb.process.append_only.value_arena_pool_retained_bytes_estimate":                         "33554432",
+		"treedb.cache.append_only_direct_arena.active_bytes":                                          "262144",
+		"treedb.cache.append_only_direct_arena.lease_bytes":                                           "131072",
+		"treedb.process.append_only_direct_arena.retained_bytes":                                      "65536",
 		"treedb.process.read_path.snapshot.backend_bytes_total":                                       "8192",
 		"treedb.process.batch.set.bytes_total":                                                        "4096",
 		"treedb.process.batch.delete_view.calls_total":                                                "5",
@@ -138,6 +141,15 @@ func TestSelectTreeDBExpvarStatsFiltersAndCoerces(t *testing.T) {
 	}
 	if v, ok := got["treedb.process.append_only.value_arena_pool_retained_bytes_estimate"].(int64); !ok || v != 33554432 {
 		t.Fatalf("append_only value arena pool retained=%T(%v) want int64(33554432)", got["treedb.process.append_only.value_arena_pool_retained_bytes_estimate"], got["treedb.process.append_only.value_arena_pool_retained_bytes_estimate"])
+	}
+	if v, ok := got["treedb.cache.append_only_direct_arena.active_bytes"].(int64); !ok || v != 262144 {
+		t.Fatalf("append_only_direct_arena active bytes=%T(%v) want int64(262144)", got["treedb.cache.append_only_direct_arena.active_bytes"], got["treedb.cache.append_only_direct_arena.active_bytes"])
+	}
+	if v, ok := got["treedb.cache.append_only_direct_arena.lease_bytes"].(int64); !ok || v != 131072 {
+		t.Fatalf("append_only_direct_arena lease bytes=%T(%v) want int64(131072)", got["treedb.cache.append_only_direct_arena.lease_bytes"], got["treedb.cache.append_only_direct_arena.lease_bytes"])
+	}
+	if v, ok := got["treedb.process.append_only_direct_arena.retained_bytes"].(int64); !ok || v != 65536 {
+		t.Fatalf("process append_only_direct_arena retained bytes=%T(%v) want int64(65536)", got["treedb.process.append_only_direct_arena.retained_bytes"], got["treedb.process.append_only_direct_arena.retained_bytes"])
 	}
 	if v, ok := got["treedb.cache.vlog_payload_split.raw_bytes.outer_leaf"].(int64); !ok || v != 1024 {
 		t.Fatalf("vlog_payload_split.raw_bytes.outer_leaf=%T(%v) want int64(1024)", got["treedb.cache.vlog_payload_split.raw_bytes.outer_leaf"], got["treedb.cache.vlog_payload_split.raw_bytes.outer_leaf"])

--- a/TreeDB/caching/memory_stats_test.go
+++ b/TreeDB/caching/memory_stats_test.go
@@ -215,6 +215,26 @@ func TestProcessMemoryStatsIncludeRuntimeBreakdown(t *testing.T) {
 			t.Fatalf("%s=%d want >=0", key, got)
 		}
 	}
+	directArenaSuffixes := []string{
+		"active_chunks",
+		"active_bytes",
+		"active_used_bytes",
+		"retained_chunks",
+		"retained_bytes",
+		"lease_count",
+		"lease_chunks",
+		"lease_bytes",
+	}
+	for _, suffix := range directArenaSuffixes {
+		cacheKey := "treedb.cache.append_only_direct_arena." + suffix
+		processKey := "treedb.process.append_only_direct_arena." + suffix
+		if got := mustStatInt64(t, stats, cacheKey); got < 0 {
+			t.Fatalf("%s=%d want >=0", cacheKey, got)
+		}
+		if got := mustStatInt64(t, stats, processKey); got != mustStatInt64(t, stats, cacheKey) {
+			t.Fatalf("append_only_direct_arena %s mismatch process=%d cache=%d", suffix, got, mustStatInt64(t, stats, cacheKey))
+		}
+	}
 	if got := stats["treedb.process.read_path.outer_leaf.cache.write_admission_policy"]; got == "" {
 		t.Fatalf("missing non-empty write admission policy stat")
 	}


### PR DESCRIPTION
## Objective

Expose current append-only direct-arena residency in TreeDB stats so the next strict Celestia run can classify the remaining HWM/RSS lane without guessing from pprof alone.

Refs #3238 and #3131.

## Context

The post-#3402 strict TreeDB Celestia run with merged IAVL view batches proved the earlier public command-WAL visibility blocker is resolved:

- `treedb.command_wal.public_batch.set_view.calls_total=30764325`
- raw span-native point-put candidate/eligible/used all `46146914`, fallbacks `0`
- ordered-root/root-native counters remain `0`, blocked by missing root/version/order publication semantics before TreeDB
- `treedb.flush_apply.apply_ns_total=23077340825`, about `7.8%` of the `296s` sync, with no queue backlog

The only plausible remaining TreeDB-owned lane from that decision pass is HWM/RSS attribution. Peak pprof still has large append-only and entry-slice buckets, but current app vars did not expose whether direct SetView-safe copies are active, retained for reuse, or pinned by retired memtable leases.

## Non-goals

- No retention/tuning behavior change.
- No generic benchmark optimization claim.
- No root-native/ordered-root API work.
- No value-log persistence, GC, mmap, or disk layout changes.

## Design

Adds current direct-arena stats under both cache and process namespaces:

- `treedb.cache.append_only_direct_arena.active_chunks`
- `treedb.cache.append_only_direct_arena.active_bytes`
- `treedb.cache.append_only_direct_arena.active_used_bytes`
- `treedb.cache.append_only_direct_arena.retained_chunks`
- `treedb.cache.append_only_direct_arena.retained_bytes`
- `treedb.cache.append_only_direct_arena.lease_count`
- `treedb.cache.append_only_direct_arena.lease_chunks`
- `treedb.cache.append_only_direct_arena.lease_bytes`

The same keys are mirrored under `treedb.process.append_only_direct_arena.*`.

`active_bytes` follows the existing append-only value-arena convention and reports backing capacity. `active_used_bytes` is separate so tail waste is visible.

The cache prefix is added to the expvar selection path so Celestia app-vars harvesting can see the new stats.

## Scope

Includes:

- `TreeDB/caching/db.go`
- `TreeDB/caching/expvar_stats.go`
- focused stats/export tests
- direct-arena rotate/checkpoint residency test coverage

Excludes:

- write-path behavior changes
- retention cap changes
- Celestia harness changes
- benchmark harness changes

## Correctness

Tests run:

```sh
GOWORK=off GOCACHE=/mnt/fast4tb/tmp/go-build-cache go test ./TreeDB/caching -run 'TestAppendOnlyDirectWriterArena_RetainsAcrossRotateCheckpointAndReuse|TestProcessMemoryStatsIncludeRuntimeBreakdown|TestSelectTreeDBExpvarStatsFiltersAndCoerces' -count=1
GOWORK=off GOCACHE=/mnt/fast4tb/tmp/go-build-cache go test ./TreeDB/caching -count=1
git diff --check
```

All passed.

The default Go build cache under `/home/mikers/.cache/go-build` was full, so validation used `GOCACHE=/mnt/fast4tb/tmp/go-build-cache`.

## Performance

No behavior-affecting performance claim. This is observability-only.

The next evidence gate is a strict TreeDB Celestia rerun after merge, checking the new direct-arena active/used/retained/lease stats alongside RSS/HWM, heap pprof, app/home/data bytes, route counters, apply/backend timers, queue backlog, and value-log GC/rewrite counters.

## Rollout / Toggle Plan

Default setting: stats are always included in `DB.Stats()` and selected expvar/app-vars output.

Rollback: revert this PR. No data or format migration is involved.

## Follow-ups

Use the next strict Celestia run to classify #3238 as one of:

- active mutable/queued data remains material,
- retained direct-arena reuse remains material,
- retired-memtable leases remain material,
- not a current HWM limiter/diminishing returns.
