### PR TITLE
Split q2 dense reference-fill diagnostics

### DIFF
--- a/TreeDB/collections/column_physical_q2_global_rank_prep_bench_test.go
+++ b/TreeDB/collections/column_physical_q2_global_rank_prep_bench_test.go
@@ -238,6 +238,18 @@ func TestTypedColumnQ2DenseGroupCountDistinctShardedReferenceFillNullableEmpty(t
 		diagnostics.Q2DensePartLocalRankNanos != diagnostics.Q2LocalRankNanos {
 		t.Fatalf("reference-fill diagnostics=%+v want dense q2 distinct/local split", diagnostics)
 	}
+	distinctSubphaseTotal := diagnostics.Q2DenseDistinctRankPlanNanos +
+		diagnostics.Q2DenseDistinctRankCollectRefsNanos +
+		diagnostics.Q2DenseDistinctRankBuildShardsNanos
+	if distinctSubphaseTotal != diagnostics.Q2DenseDistinctGlobalRankNanos {
+		t.Fatalf("reference-fill distinct rank subphases=%d want aggregate=%d diagnostics=%+v", distinctSubphaseTotal, diagnostics.Q2DenseDistinctGlobalRankNanos, diagnostics)
+	}
+	if diagnostics.Q2DenseDistinctRankShardCount == 0 ||
+		diagnostics.Q2DenseDistinctRankRefs != 4 ||
+		diagnostics.Q2DenseDistinctRankMaxShardRefs == 0 ||
+		diagnostics.Q2DenseDistinctGlobalRanks != 4 {
+		t.Fatalf("reference-fill count diagnostics=%+v want shard count, 4 refs, max shard refs, 4 global ranks", diagnostics)
+	}
 	distinct0 := parts[0].DenseGroupCountDistinct.Distinct
 	distinct1 := parts[1].DenseGroupCountDistinct.Distinct
 	if distinct0.GlobalDictionary != nil || distinct1.GlobalDictionary != nil {
@@ -451,6 +463,13 @@ func BenchmarkTypedColumnQ2DenseGroupCountDistinctGlobalRankPrep(b *testing.B) {
 						b.ReportMetric(float64(diagnostics.Q2GroupRankNanos)/float64(b.N), "diag_group_rank_ns/op")
 						b.ReportMetric(float64(diagnostics.Q2DistinctRankNanos)/float64(b.N), "diag_distinct_rank_ns/op")
 						b.ReportMetric(float64(diagnostics.Q2LocalRankNanos)/float64(b.N), "diag_local_rank_ns/op")
+						b.ReportMetric(float64(diagnostics.Q2DenseDistinctRankPlanNanos)/float64(b.N), "diag_dense_distinct_rank_plan_ns/op")
+						b.ReportMetric(float64(diagnostics.Q2DenseDistinctRankCollectRefsNanos)/float64(b.N), "diag_dense_distinct_rank_collect_refs_ns/op")
+						b.ReportMetric(float64(diagnostics.Q2DenseDistinctRankBuildShardsNanos)/float64(b.N), "diag_dense_distinct_rank_build_shards_ns/op")
+						b.ReportMetric(float64(diagnostics.Q2DenseDistinctRankShardCount), "diag_dense_distinct_rank_shards/op")
+						b.ReportMetric(float64(diagnostics.Q2DenseDistinctRankRefs)/float64(b.N), "diag_dense_distinct_rank_refs/op")
+						b.ReportMetric(float64(diagnostics.Q2DenseDistinctRankMaxShardRefs), "diag_dense_distinct_rank_max_shard_refs/op")
+						b.ReportMetric(float64(diagnostics.Q2DenseDistinctGlobalRanks), "diag_dense_distinct_global_ranks/op")
 						b.ReportMetric(currentStrategy, "current_strategy/op")
 						b.ReportMetric(shardedStrategy, "sharded_strategy/op")
 					}

--- a/TreeDB/collections/column_physical_q2_global_rank_prep_bench_test.go
+++ b/TreeDB/collections/column_physical_q2_global_rank_prep_bench_test.go
@@ -229,6 +229,24 @@ func TestTypedColumnQ2DenseGroupCountDistinctShardedReferenceFillNullableEmpty(t
 			},
 		},
 	}
+	expectedDistinctRankRefs := 0
+	expectedDistinctValues := make(map[string]struct{})
+	expectedDistinctEmptyRank := false
+	for _, part := range parts {
+		distinct := part.DenseGroupCountDistinct.Distinct
+		expectedDistinctRankRefs += len(distinct.Dictionary)
+		for localCode, value := range distinct.Dictionary {
+			if distinct.Valid != nil && localCode < len(distinct.Valid) && !distinct.Valid[localCode] {
+				expectedDistinctEmptyRank = true
+				continue
+			}
+			expectedDistinctValues[value] = struct{}{}
+		}
+	}
+	expectedDistinctGlobalRanks := len(expectedDistinctValues)
+	if expectedDistinctEmptyRank {
+		expectedDistinctGlobalRanks++
+	}
 
 	var diagnostics columnTypedColumnPhysicalQueryPrepareDiagnostics
 	if err := prepareColumnTypedColumnDenseGroupCountDistinctGlobalRankMapsShardedWithDiagnostics(parts, &diagnostics); err != nil {
@@ -245,20 +263,20 @@ func TestTypedColumnQ2DenseGroupCountDistinctShardedReferenceFillNullableEmpty(t
 		t.Fatalf("reference-fill distinct rank subphases=%d want aggregate=%d diagnostics=%+v", distinctSubphaseTotal, diagnostics.Q2DenseDistinctGlobalRankNanos, diagnostics)
 	}
 	if diagnostics.Q2DenseDistinctRankShardCount == 0 ||
-		diagnostics.Q2DenseDistinctRankRefs != 4 ||
+		diagnostics.Q2DenseDistinctRankRefs != expectedDistinctRankRefs ||
 		diagnostics.Q2DenseDistinctRankMaxShardRefs == 0 ||
-		diagnostics.Q2DenseDistinctGlobalRanks != 4 {
-		t.Fatalf("reference-fill count diagnostics=%+v want shard count, 4 refs, max shard refs, 4 global ranks", diagnostics)
+		diagnostics.Q2DenseDistinctGlobalRanks != expectedDistinctGlobalRanks {
+		t.Fatalf("reference-fill count diagnostics=%+v want shard count, %d refs, max shard refs, %d global ranks", diagnostics, expectedDistinctRankRefs, expectedDistinctGlobalRanks)
 	}
 	distinct0 := parts[0].DenseGroupCountDistinct.Distinct
 	distinct1 := parts[1].DenseGroupCountDistinct.Distinct
 	if distinct0.GlobalDictionary != nil || distinct1.GlobalDictionary != nil {
 		t.Fatalf("distinct global dictionary allocated part0=%v part1=%v", distinct0.GlobalDictionary, distinct1.GlobalDictionary)
 	}
-	if !distinct0.GlobalCardinalityOK || distinct0.GlobalCardinality != 4 || !distinct1.GlobalCardinalityOK || distinct1.GlobalCardinality != 4 {
-		t.Fatalf("distinct cardinality part0=(%d,%t) part1=(%d,%t) want (4,true)", distinct0.GlobalCardinality, distinct0.GlobalCardinalityOK, distinct1.GlobalCardinality, distinct1.GlobalCardinalityOK)
+	if !distinct0.GlobalCardinalityOK || distinct0.GlobalCardinality != expectedDistinctGlobalRanks || !distinct1.GlobalCardinalityOK || distinct1.GlobalCardinality != expectedDistinctGlobalRanks {
+		t.Fatalf("distinct cardinality part0=(%d,%t) part1=(%d,%t) want (%d,true)", distinct0.GlobalCardinality, distinct0.GlobalCardinalityOK, distinct1.GlobalCardinality, distinct1.GlobalCardinalityOK, expectedDistinctGlobalRanks)
 	}
-	if !distinct0.GlobalEmptyRankOK || !distinct1.GlobalEmptyRankOK || distinct0.GlobalEmptyRank != distinct1.GlobalEmptyRank || distinct0.GlobalEmptyRank >= 4 {
+	if !distinct0.GlobalEmptyRankOK || !distinct1.GlobalEmptyRankOK || distinct0.GlobalEmptyRank != distinct1.GlobalEmptyRank || distinct0.GlobalEmptyRank >= uint32(expectedDistinctGlobalRanks) {
 		t.Fatalf("distinct empty ranks part0=(%d,%t) part1=(%d,%t) want shared rank below cardinality", distinct0.GlobalEmptyRank, distinct0.GlobalEmptyRankOK, distinct1.GlobalEmptyRank, distinct1.GlobalEmptyRankOK)
 	}
 	rankByValue := func(column columnTypedColumnDenseStringCodeColumn, value string) (uint32, bool) {
@@ -270,12 +288,12 @@ func TestTypedColumnQ2DenseGroupCountDistinctShardedReferenceFillNullableEmpty(t
 		return 0, false
 	}
 	shared0, ok := rankByValue(distinct0, "did:shared")
-	if !ok || shared0 >= 4 {
-		t.Fatalf("part 0 shared rank=(%d,%t) cardinality=4 ranks=%v", shared0, ok, distinct0.GlobalLocalRanks)
+	if !ok || shared0 >= uint32(expectedDistinctGlobalRanks) {
+		t.Fatalf("part 0 shared rank=(%d,%t) cardinality=%d ranks=%v", shared0, ok, expectedDistinctGlobalRanks, distinct0.GlobalLocalRanks)
 	}
 	shared1, ok := rankByValue(distinct1, "did:shared")
-	if !ok || shared1 >= 4 {
-		t.Fatalf("part 1 shared rank=(%d,%t) cardinality=4 ranks=%v", shared1, ok, distinct1.GlobalLocalRanks)
+	if !ok || shared1 >= uint32(expectedDistinctGlobalRanks) {
+		t.Fatalf("part 1 shared rank=(%d,%t) cardinality=%d ranks=%v", shared1, ok, expectedDistinctGlobalRanks, distinct1.GlobalLocalRanks)
 	}
 	if shared0 != shared1 {
 		t.Fatalf("shared did ranks part0=%d part1=%d want equal", shared0, shared1)

--- a/TreeDB/collections/column_physical_query.go
+++ b/TreeDB/collections/column_physical_query.go
@@ -206,12 +206,19 @@ type ColumnPhysicalQueryDiagnostics struct {
 	TypedColumnPrepareDensePredicateNanos int64
 	TypedColumnPrepareDensePreapplyNanos  int64
 
-	TypedColumnPrepareQ2GroupRankNanos               int64
-	TypedColumnPrepareQ2DistinctRankNanos            int64
-	TypedColumnPrepareQ2LocalRankNanos               int64
-	TypedColumnPrepareQ2DenseGroupGlobalRankNanos    int64
-	TypedColumnPrepareQ2DenseDistinctGlobalRankNanos int64
-	TypedColumnPrepareQ2DensePartLocalRankNanos      int64
+	TypedColumnPrepareQ2GroupRankNanos                    int64
+	TypedColumnPrepareQ2DistinctRankNanos                 int64
+	TypedColumnPrepareQ2LocalRankNanos                    int64
+	TypedColumnPrepareQ2DenseGroupGlobalRankNanos         int64
+	TypedColumnPrepareQ2DenseDistinctGlobalRankNanos      int64
+	TypedColumnPrepareQ2DensePartLocalRankNanos           int64
+	TypedColumnPrepareQ2DenseDistinctRankPlanNanos        int64
+	TypedColumnPrepareQ2DenseDistinctRankCollectRefsNanos int64
+	TypedColumnPrepareQ2DenseDistinctRankBuildShardsNanos int64
+	TypedColumnPrepareQ2DenseDistinctRankShardCount       int
+	TypedColumnPrepareQ2DenseDistinctRankRefs             int
+	TypedColumnPrepareQ2DenseDistinctRankMaxShardRefs     int
+	TypedColumnPrepareQ2DenseDistinctGlobalRanks          int
 
 	TypedColumnPrepareQ2GroupGlobalDictionaryRankNanos    int64
 	TypedColumnPrepareQ2DistinctGlobalDictionaryRankNanos int64
@@ -1494,6 +1501,19 @@ func mergeColumnPhysicalQueryDiagnostics(left, right ColumnPhysicalQueryDiagnost
 	left.TypedColumnPrepareQ2DenseGroupGlobalRankNanos += right.TypedColumnPrepareQ2DenseGroupGlobalRankNanos
 	left.TypedColumnPrepareQ2DenseDistinctGlobalRankNanos += right.TypedColumnPrepareQ2DenseDistinctGlobalRankNanos
 	left.TypedColumnPrepareQ2DensePartLocalRankNanos += right.TypedColumnPrepareQ2DensePartLocalRankNanos
+	left.TypedColumnPrepareQ2DenseDistinctRankPlanNanos += right.TypedColumnPrepareQ2DenseDistinctRankPlanNanos
+	left.TypedColumnPrepareQ2DenseDistinctRankCollectRefsNanos += right.TypedColumnPrepareQ2DenseDistinctRankCollectRefsNanos
+	left.TypedColumnPrepareQ2DenseDistinctRankBuildShardsNanos += right.TypedColumnPrepareQ2DenseDistinctRankBuildShardsNanos
+	if right.TypedColumnPrepareQ2DenseDistinctRankShardCount > left.TypedColumnPrepareQ2DenseDistinctRankShardCount {
+		left.TypedColumnPrepareQ2DenseDistinctRankShardCount = right.TypedColumnPrepareQ2DenseDistinctRankShardCount
+	}
+	left.TypedColumnPrepareQ2DenseDistinctRankRefs += right.TypedColumnPrepareQ2DenseDistinctRankRefs
+	if right.TypedColumnPrepareQ2DenseDistinctRankMaxShardRefs > left.TypedColumnPrepareQ2DenseDistinctRankMaxShardRefs {
+		left.TypedColumnPrepareQ2DenseDistinctRankMaxShardRefs = right.TypedColumnPrepareQ2DenseDistinctRankMaxShardRefs
+	}
+	if right.TypedColumnPrepareQ2DenseDistinctGlobalRanks > left.TypedColumnPrepareQ2DenseDistinctGlobalRanks {
+		left.TypedColumnPrepareQ2DenseDistinctGlobalRanks = right.TypedColumnPrepareQ2DenseDistinctGlobalRanks
+	}
 	left.TypedColumnPrepareQ2GroupGlobalDictionaryRankNanos += right.TypedColumnPrepareQ2GroupGlobalDictionaryRankNanos
 	left.TypedColumnPrepareQ2DistinctGlobalDictionaryRankNanos += right.TypedColumnPrepareQ2DistinctGlobalDictionaryRankNanos
 	left.TypedColumnPrepareQ2GroupGlobalCodeRemapNanos += right.TypedColumnPrepareQ2GroupGlobalCodeRemapNanos

--- a/TreeDB/collections/column_physical_typed_column_query.go
+++ b/TreeDB/collections/column_physical_typed_column_query.go
@@ -257,12 +257,19 @@ type columnTypedColumnPhysicalQueryPrepareDiagnostics struct {
 	DensePredicateNanos int64
 	DensePreapplyNanos  int64
 
-	Q2GroupRankNanos               int64
-	Q2DistinctRankNanos            int64
-	Q2LocalRankNanos               int64
-	Q2DenseGroupGlobalRankNanos    int64
-	Q2DenseDistinctGlobalRankNanos int64
-	Q2DensePartLocalRankNanos      int64
+	Q2GroupRankNanos                    int64
+	Q2DistinctRankNanos                 int64
+	Q2LocalRankNanos                    int64
+	Q2DenseGroupGlobalRankNanos         int64
+	Q2DenseDistinctGlobalRankNanos      int64
+	Q2DensePartLocalRankNanos           int64
+	Q2DenseDistinctRankPlanNanos        int64
+	Q2DenseDistinctRankCollectRefsNanos int64
+	Q2DenseDistinctRankBuildShardsNanos int64
+	Q2DenseDistinctRankShardCount       int
+	Q2DenseDistinctRankRefs             int
+	Q2DenseDistinctRankMaxShardRefs     int
+	Q2DenseDistinctGlobalRanks          int
 
 	Q2GroupGlobalDictionaryRankNanos    int64
 	Q2DistinctGlobalDictionaryRankNanos int64
@@ -302,6 +309,19 @@ func (d columnTypedColumnPhysicalQueryPrepareDiagnostics) applyTo(diag *ColumnPh
 	diag.TypedColumnPrepareQ2DenseGroupGlobalRankNanos += d.Q2DenseGroupGlobalRankNanos
 	diag.TypedColumnPrepareQ2DenseDistinctGlobalRankNanos += d.Q2DenseDistinctGlobalRankNanos
 	diag.TypedColumnPrepareQ2DensePartLocalRankNanos += d.Q2DensePartLocalRankNanos
+	diag.TypedColumnPrepareQ2DenseDistinctRankPlanNanos += d.Q2DenseDistinctRankPlanNanos
+	diag.TypedColumnPrepareQ2DenseDistinctRankCollectRefsNanos += d.Q2DenseDistinctRankCollectRefsNanos
+	diag.TypedColumnPrepareQ2DenseDistinctRankBuildShardsNanos += d.Q2DenseDistinctRankBuildShardsNanos
+	if d.Q2DenseDistinctRankShardCount > diag.TypedColumnPrepareQ2DenseDistinctRankShardCount {
+		diag.TypedColumnPrepareQ2DenseDistinctRankShardCount = d.Q2DenseDistinctRankShardCount
+	}
+	diag.TypedColumnPrepareQ2DenseDistinctRankRefs += d.Q2DenseDistinctRankRefs
+	if d.Q2DenseDistinctRankMaxShardRefs > diag.TypedColumnPrepareQ2DenseDistinctRankMaxShardRefs {
+		diag.TypedColumnPrepareQ2DenseDistinctRankMaxShardRefs = d.Q2DenseDistinctRankMaxShardRefs
+	}
+	if d.Q2DenseDistinctGlobalRanks > diag.TypedColumnPrepareQ2DenseDistinctGlobalRanks {
+		diag.TypedColumnPrepareQ2DenseDistinctGlobalRanks = d.Q2DenseDistinctGlobalRanks
+	}
 	diag.TypedColumnPrepareQ2GroupGlobalDictionaryRankNanos += d.Q2GroupGlobalDictionaryRankNanos
 	diag.TypedColumnPrepareQ2DistinctGlobalDictionaryRankNanos += d.Q2DistinctGlobalDictionaryRankNanos
 	diag.TypedColumnPrepareQ2GroupGlobalCodeRemapNanos += d.Q2GroupGlobalCodeRemapNanos
@@ -340,6 +360,19 @@ func (d *columnTypedColumnPhysicalQueryPrepareDiagnostics) add(src columnTypedCo
 	d.Q2DenseGroupGlobalRankNanos += src.Q2DenseGroupGlobalRankNanos
 	d.Q2DenseDistinctGlobalRankNanos += src.Q2DenseDistinctGlobalRankNanos
 	d.Q2DensePartLocalRankNanos += src.Q2DensePartLocalRankNanos
+	d.Q2DenseDistinctRankPlanNanos += src.Q2DenseDistinctRankPlanNanos
+	d.Q2DenseDistinctRankCollectRefsNanos += src.Q2DenseDistinctRankCollectRefsNanos
+	d.Q2DenseDistinctRankBuildShardsNanos += src.Q2DenseDistinctRankBuildShardsNanos
+	if src.Q2DenseDistinctRankShardCount > d.Q2DenseDistinctRankShardCount {
+		d.Q2DenseDistinctRankShardCount = src.Q2DenseDistinctRankShardCount
+	}
+	d.Q2DenseDistinctRankRefs += src.Q2DenseDistinctRankRefs
+	if src.Q2DenseDistinctRankMaxShardRefs > d.Q2DenseDistinctRankMaxShardRefs {
+		d.Q2DenseDistinctRankMaxShardRefs = src.Q2DenseDistinctRankMaxShardRefs
+	}
+	if src.Q2DenseDistinctGlobalRanks > d.Q2DenseDistinctGlobalRanks {
+		d.Q2DenseDistinctGlobalRanks = src.Q2DenseDistinctGlobalRanks
+	}
 	d.Q2GroupGlobalDictionaryRankNanos += src.Q2GroupGlobalDictionaryRankNanos
 	d.Q2DistinctGlobalDictionaryRankNanos += src.Q2DistinctGlobalDictionaryRankNanos
 	d.Q2GroupGlobalCodeRemapNanos += src.Q2GroupGlobalCodeRemapNanos
@@ -1363,6 +1396,19 @@ func prepareColumnTypedColumnDenseGroupCountDistinctGlobalRankMapsShardedPolicyW
 			prepareDiagnostics.Q2DenseDistinctGlobalRankNanos += timing.distinctRankNanos
 			prepareDiagnostics.Q2LocalRankNanos += timing.localRankNanos
 			prepareDiagnostics.Q2DensePartLocalRankNanos += timing.localRankNanos
+			prepareDiagnostics.Q2DenseDistinctRankPlanNanos += timing.distinctRankPlanNanos
+			prepareDiagnostics.Q2DenseDistinctRankCollectRefsNanos += timing.distinctRankCollectRefsNanos
+			prepareDiagnostics.Q2DenseDistinctRankBuildShardsNanos += timing.distinctRankBuildShardsNanos
+			if timing.distinctRankShardCount > prepareDiagnostics.Q2DenseDistinctRankShardCount {
+				prepareDiagnostics.Q2DenseDistinctRankShardCount = timing.distinctRankShardCount
+			}
+			prepareDiagnostics.Q2DenseDistinctRankRefs += timing.distinctRankRefs
+			if timing.distinctRankMaxShardRefs > prepareDiagnostics.Q2DenseDistinctRankMaxShardRefs {
+				prepareDiagnostics.Q2DenseDistinctRankMaxShardRefs = timing.distinctRankMaxShardRefs
+			}
+			if timing.distinctRankGlobalDistinctRankCount > prepareDiagnostics.Q2DenseDistinctGlobalRanks {
+				prepareDiagnostics.Q2DenseDistinctGlobalRanks = timing.distinctRankGlobalDistinctRankCount
+			}
 		}
 		return err
 	}
@@ -1525,8 +1571,15 @@ func prepareColumnTypedColumnDenseGroupCountDistinctGlobalRankMapsShardedPartsPa
 }
 
 type columnTypedColumnDenseGroupCountDistinctReferenceFillTiming struct {
-	distinctRankNanos int64
-	localRankNanos    int64
+	distinctRankNanos                   int64
+	localRankNanos                      int64
+	distinctRankPlanNanos               int64
+	distinctRankCollectRefsNanos        int64
+	distinctRankBuildShardsNanos        int64
+	distinctRankShardCount              int
+	distinctRankRefs                    int
+	distinctRankMaxShardRefs            int
+	distinctRankGlobalDistinctRankCount int
 }
 
 func columnTypedColumnDenseStringCodeHasMissing(column *columnTypedColumnDenseStringCodeColumn) bool {
@@ -1567,11 +1620,16 @@ func prepareColumnTypedColumnDenseGroupCountDistinctGlobalRankMapsShardedReferen
 		return &part.Distinct
 	})
 	if err != nil {
-		timing.distinctRankNanos += time.Since(phaseStart).Nanoseconds()
+		elapsed := time.Since(phaseStart).Nanoseconds()
+		timing.distinctRankPlanNanos += elapsed
+		timing.distinctRankNanos += elapsed
 		return timing, err
 	}
 	shardCount := columnTypedColumnDenseGroupCountDistinctShardedRankShardCount(capacity, workers)
-	timing.distinctRankNanos += time.Since(phaseStart).Nanoseconds()
+	timing.distinctRankShardCount = shardCount
+	elapsed := time.Since(phaseStart).Nanoseconds()
+	timing.distinctRankPlanNanos += elapsed
+	timing.distinctRankNanos += elapsed
 
 	var shardRefs [][]uint64
 	includeEmpty := false
@@ -1601,10 +1659,15 @@ func prepareColumnTypedColumnDenseGroupCountDistinctGlobalRankMapsShardedReferen
 	phaseStart = time.Now()
 	shardRefs, err = columnTypedColumnDenseGroupCountDistinctCollectShardRankRefs(parts, shardCount, capacity, workers)
 	if err != nil {
-		timing.distinctRankNanos += time.Since(phaseStart).Nanoseconds()
+		elapsed := time.Since(phaseStart).Nanoseconds()
+		timing.distinctRankCollectRefsNanos += elapsed
+		timing.distinctRankNanos += elapsed
 		return timing, err
 	}
-	timing.distinctRankNanos += time.Since(phaseStart).Nanoseconds()
+	timing.distinctRankRefs, timing.distinctRankMaxShardRefs = columnTypedColumnDenseGroupCountDistinctShardRankRefStats(shardRefs)
+	elapsed = time.Since(phaseStart).Nanoseconds()
+	timing.distinctRankCollectRefsNanos += elapsed
+	timing.distinctRankNanos += elapsed
 
 	phaseStart = time.Now()
 	emptyShardIdx := -1
@@ -1613,7 +1676,9 @@ func prepareColumnTypedColumnDenseGroupCountDistinctGlobalRankMapsShardedReferen
 	}
 	shards, err := columnTypedColumnDenseGroupCountDistinctBuildShardedRanksFromRefs(parts, shardRefs, emptyShardIdx, workers)
 	if err != nil {
-		timing.distinctRankNanos += time.Since(phaseStart).Nanoseconds()
+		elapsed := time.Since(phaseStart).Nanoseconds()
+		timing.distinctRankBuildShardsNanos += elapsed
+		timing.distinctRankNanos += elapsed
 		return timing, err
 	}
 	offsets := make([]uint32, len(shards))
@@ -1623,7 +1688,9 @@ func prepareColumnTypedColumnDenseGroupCountDistinctGlobalRankMapsShardedReferen
 			continue
 		}
 		if cardinality > int(^uint32(0)) || len(shard) > int(^uint32(0))-cardinality {
-			timing.distinctRankNanos += time.Since(phaseStart).Nanoseconds()
+			elapsed := time.Since(phaseStart).Nanoseconds()
+			timing.distinctRankBuildShardsNanos += elapsed
+			timing.distinctRankNanos += elapsed
 			return timing, fmt.Errorf("collections: dense grouped count-distinct global dictionary cardinality exceeds uint32")
 		}
 		offsets[shardIdx] = uint32(cardinality)
@@ -1636,10 +1703,15 @@ func prepareColumnTypedColumnDenseGroupCountDistinctGlobalRankMapsShardedReferen
 		emptyRank = offsets[emptyLookupShardIdx] + localRank
 		emptyOK = true
 	} else if includeEmpty {
-		timing.distinctRankNanos += time.Since(phaseStart).Nanoseconds()
+		elapsed := time.Since(phaseStart).Nanoseconds()
+		timing.distinctRankBuildShardsNanos += elapsed
+		timing.distinctRankNanos += elapsed
 		return timing, fmt.Errorf("collections: dense grouped count-distinct empty-string global rank missing")
 	}
-	timing.distinctRankNanos += time.Since(phaseStart).Nanoseconds()
+	timing.distinctRankGlobalDistinctRankCount = cardinality
+	elapsed = time.Since(phaseStart).Nanoseconds()
+	timing.distinctRankBuildShardsNanos += elapsed
+	timing.distinctRankNanos += elapsed
 
 	phaseStart = time.Now()
 	if err := columnTypedColumnDenseGroupCountDistinctAddShardedRankOffsets(parts, shardRefs, offsets, workers); err != nil {
@@ -1743,6 +1815,16 @@ func columnTypedColumnDenseGroupCountDistinctNewShardRankRefs(shardCount, capaci
 		refs[shardIdx] = make([]uint64, 0, shardCapacity)
 	}
 	return refs
+}
+
+func columnTypedColumnDenseGroupCountDistinctShardRankRefStats(shardRefs [][]uint64) (total, maxShard int) {
+	for _, refs := range shardRefs {
+		total += len(refs)
+		if len(refs) > maxShard {
+			maxShard = len(refs)
+		}
+	}
+	return total, maxShard
 }
 
 func columnTypedColumnDenseGroupCountDistinctCollectShardRankRefsPart(parts []columnTypedColumnPhysicalQueryPart, partIdx int, shardRefs [][]uint64) error {

--- a/cmd/unified_bench/suite_column_store.go
+++ b/cmd/unified_bench/suite_column_store.go
@@ -411,6 +411,14 @@ type columnStoreQueryMetric struct {
 	CacheLabel                             string                            `json:"cache_label"`
 	CompressionAttribution                 columnStoreCompressionAttribution `json:"compression_attribution"`
 
+	TypedColumnPrepareQ2DenseDistinctRankPlanMS        float64 `json:"typed_column_prepare_q2_dense_distinct_rank_plan_duration_ms,omitempty"`
+	TypedColumnPrepareQ2DenseDistinctRankCollectRefsMS float64 `json:"typed_column_prepare_q2_dense_distinct_rank_collect_refs_duration_ms,omitempty"`
+	TypedColumnPrepareQ2DenseDistinctRankBuildShardsMS float64 `json:"typed_column_prepare_q2_dense_distinct_rank_build_shards_duration_ms,omitempty"`
+	TypedColumnPrepareQ2DenseDistinctRankShardCount    int     `json:"typed_column_prepare_q2_dense_distinct_rank_shard_count,omitempty"`
+	TypedColumnPrepareQ2DenseDistinctRankRefs          int     `json:"typed_column_prepare_q2_dense_distinct_rank_refs,omitempty"`
+	TypedColumnPrepareQ2DenseDistinctRankMaxShardRefs  int     `json:"typed_column_prepare_q2_dense_distinct_rank_max_shard_refs,omitempty"`
+	TypedColumnPrepareQ2DenseDistinctGlobalRanks       int     `json:"typed_column_prepare_q2_dense_distinct_global_ranks,omitempty"`
+
 	TypedColumnPrepareQ2GroupGlobalDictionaryRankMS    float64 `json:"typed_column_prepare_q2_group_global_dictionary_rank_duration_ms,omitempty"`
 	TypedColumnPrepareQ2DistinctGlobalDictionaryRankMS float64 `json:"typed_column_prepare_q2_distinct_global_dictionary_rank_duration_ms,omitempty"`
 	TypedColumnPrepareQ2GroupGlobalCodeRemapMS         float64 `json:"typed_column_prepare_q2_group_global_code_remap_duration_ms,omitempty"`
@@ -546,6 +554,14 @@ type columnStoreJSONBenchCell struct {
 	CompatibilityStatusReason              string                            `json:"compatibility_status_reason,omitempty"`
 	CompressionAttribution                 columnStoreCompressionAttribution `json:"compression_attribution"`
 
+	TypedColumnPrepareQ2DenseDistinctRankPlanMS        float64 `json:"typed_column_prepare_q2_dense_distinct_rank_plan_duration_ms,omitempty"`
+	TypedColumnPrepareQ2DenseDistinctRankCollectRefsMS float64 `json:"typed_column_prepare_q2_dense_distinct_rank_collect_refs_duration_ms,omitempty"`
+	TypedColumnPrepareQ2DenseDistinctRankBuildShardsMS float64 `json:"typed_column_prepare_q2_dense_distinct_rank_build_shards_duration_ms,omitempty"`
+	TypedColumnPrepareQ2DenseDistinctRankShardCount    int     `json:"typed_column_prepare_q2_dense_distinct_rank_shard_count,omitempty"`
+	TypedColumnPrepareQ2DenseDistinctRankRefs          int     `json:"typed_column_prepare_q2_dense_distinct_rank_refs,omitempty"`
+	TypedColumnPrepareQ2DenseDistinctRankMaxShardRefs  int     `json:"typed_column_prepare_q2_dense_distinct_rank_max_shard_refs,omitempty"`
+	TypedColumnPrepareQ2DenseDistinctGlobalRanks       int     `json:"typed_column_prepare_q2_dense_distinct_global_ranks,omitempty"`
+
 	TypedColumnPrepareQ2GroupGlobalDictionaryRankMS    float64 `json:"typed_column_prepare_q2_group_global_dictionary_rank_duration_ms,omitempty"`
 	TypedColumnPrepareQ2DistinctGlobalDictionaryRankMS float64 `json:"typed_column_prepare_q2_distinct_global_dictionary_rank_duration_ms,omitempty"`
 	TypedColumnPrepareQ2GroupGlobalCodeRemapMS         float64 `json:"typed_column_prepare_q2_group_global_code_remap_duration_ms,omitempty"`
@@ -673,6 +689,14 @@ type columnStoreQueryExecution struct {
 	TypedColumnPrepareQ2DenseGroupRank   time.Duration
 	TypedColumnPrepareQ2DenseDistinct    time.Duration
 	TypedColumnPrepareQ2DensePartLocal   time.Duration
+
+	TypedColumnPrepareQ2DenseDistinctRankPlan         time.Duration
+	TypedColumnPrepareQ2DenseDistinctRankCollectRefs  time.Duration
+	TypedColumnPrepareQ2DenseDistinctRankBuildShards  time.Duration
+	TypedColumnPrepareQ2DenseDistinctRankShardCount   int
+	TypedColumnPrepareQ2DenseDistinctRankRefs         int
+	TypedColumnPrepareQ2DenseDistinctRankMaxShardRefs int
+	TypedColumnPrepareQ2DenseDistinctGlobalRanks      int
 
 	TypedColumnPrepareQ2GroupGlobalDictionaryRank    time.Duration
 	TypedColumnPrepareQ2DistinctGlobalDictionaryRank time.Duration
@@ -2211,7 +2235,16 @@ func runColumnStoreSuiteQueries(collection *collections.Collection, rows int, ra
 			TypedColumnPrepareQ2DenseGroupRankMS:   durationMS(exec.TypedColumnPrepareQ2DenseGroupRank),
 			TypedColumnPrepareQ2DenseDistinctMS:    durationMS(exec.TypedColumnPrepareQ2DenseDistinct),
 			TypedColumnPrepareQ2DensePartLocalMS:   durationMS(exec.TypedColumnPrepareQ2DensePartLocal),
-			CacheLabel:                             "reopened_warm_process",
+
+			TypedColumnPrepareQ2DenseDistinctRankPlanMS:        durationMS(exec.TypedColumnPrepareQ2DenseDistinctRankPlan),
+			TypedColumnPrepareQ2DenseDistinctRankCollectRefsMS: durationMS(exec.TypedColumnPrepareQ2DenseDistinctRankCollectRefs),
+			TypedColumnPrepareQ2DenseDistinctRankBuildShardsMS: durationMS(exec.TypedColumnPrepareQ2DenseDistinctRankBuildShards),
+			TypedColumnPrepareQ2DenseDistinctRankShardCount:    exec.TypedColumnPrepareQ2DenseDistinctRankShardCount,
+			TypedColumnPrepareQ2DenseDistinctRankRefs:          exec.TypedColumnPrepareQ2DenseDistinctRankRefs,
+			TypedColumnPrepareQ2DenseDistinctRankMaxShardRefs:  exec.TypedColumnPrepareQ2DenseDistinctRankMaxShardRefs,
+			TypedColumnPrepareQ2DenseDistinctGlobalRanks:       exec.TypedColumnPrepareQ2DenseDistinctGlobalRanks,
+
+			CacheLabel: "reopened_warm_process",
 			CompressionAttribution: columnStoreQueryCompressionAttribution(
 				planLabel,
 				storageSource,
@@ -2688,12 +2721,21 @@ func executeColumnStoreSuitePhysicalQuery(collection *collections.Collection, qu
 		TypedColumnPrepareQ2DenseGroupRank:   time.Duration(diag.TypedColumnPrepareQ2DenseGroupGlobalRankNanos),
 		TypedColumnPrepareQ2DenseDistinct:    time.Duration(diag.TypedColumnPrepareQ2DenseDistinctGlobalRankNanos),
 		TypedColumnPrepareQ2DensePartLocal:   time.Duration(diag.TypedColumnPrepareQ2DensePartLocalRankNanos),
-		HotRunDuration:                       elapsed,
-		ScanDuration:                         scanDuration,
-		ReduceDuration:                       reduceDuration,
-		AdapterDuration:                      resultShapeDuration,
-		ResultShapeDuration:                  resultShapeDuration,
-		ParityHashDuration:                   parityHashElapsed,
+
+		TypedColumnPrepareQ2DenseDistinctRankPlan:         time.Duration(diag.TypedColumnPrepareQ2DenseDistinctRankPlanNanos),
+		TypedColumnPrepareQ2DenseDistinctRankCollectRefs:  time.Duration(diag.TypedColumnPrepareQ2DenseDistinctRankCollectRefsNanos),
+		TypedColumnPrepareQ2DenseDistinctRankBuildShards:  time.Duration(diag.TypedColumnPrepareQ2DenseDistinctRankBuildShardsNanos),
+		TypedColumnPrepareQ2DenseDistinctRankShardCount:   diag.TypedColumnPrepareQ2DenseDistinctRankShardCount,
+		TypedColumnPrepareQ2DenseDistinctRankRefs:         diag.TypedColumnPrepareQ2DenseDistinctRankRefs,
+		TypedColumnPrepareQ2DenseDistinctRankMaxShardRefs: diag.TypedColumnPrepareQ2DenseDistinctRankMaxShardRefs,
+		TypedColumnPrepareQ2DenseDistinctGlobalRanks:      diag.TypedColumnPrepareQ2DenseDistinctGlobalRanks,
+
+		HotRunDuration:      elapsed,
+		ScanDuration:        scanDuration,
+		ReduceDuration:      reduceDuration,
+		AdapterDuration:     resultShapeDuration,
+		ResultShapeDuration: resultShapeDuration,
+		ParityHashDuration:  parityHashElapsed,
 
 		TypedColumnPrepareQ2GroupGlobalDictionaryRank:    time.Duration(diag.TypedColumnPrepareQ2GroupGlobalDictionaryRankNanos),
 		TypedColumnPrepareQ2DistinctGlobalDictionaryRank: time.Duration(diag.TypedColumnPrepareQ2DistinctGlobalDictionaryRankNanos),
@@ -2829,13 +2871,22 @@ func executeColumnStoreSuitePreparedPhysicalQuery(collection *collections.Collec
 		TypedColumnPrepareQ2DenseGroupRank:   time.Duration(setupDiagnostics.TypedColumnPrepareQ2DenseGroupGlobalRankNanos),
 		TypedColumnPrepareQ2DenseDistinct:    time.Duration(setupDiagnostics.TypedColumnPrepareQ2DenseDistinctGlobalRankNanos),
 		TypedColumnPrepareQ2DensePartLocal:   time.Duration(setupDiagnostics.TypedColumnPrepareQ2DensePartLocalRankNanos),
-		SetupDuration:                        setupElapsed,
-		HotRunDuration:                       hotRunElapsed,
-		ScanDuration:                         scanDuration,
-		ReduceDuration:                       reduceDuration,
-		AdapterDuration:                      resultShapeDuration,
-		ResultShapeDuration:                  resultShapeDuration,
-		ParityHashDuration:                   parityHashElapsed,
+
+		TypedColumnPrepareQ2DenseDistinctRankPlan:         time.Duration(setupDiagnostics.TypedColumnPrepareQ2DenseDistinctRankPlanNanos),
+		TypedColumnPrepareQ2DenseDistinctRankCollectRefs:  time.Duration(setupDiagnostics.TypedColumnPrepareQ2DenseDistinctRankCollectRefsNanos),
+		TypedColumnPrepareQ2DenseDistinctRankBuildShards:  time.Duration(setupDiagnostics.TypedColumnPrepareQ2DenseDistinctRankBuildShardsNanos),
+		TypedColumnPrepareQ2DenseDistinctRankShardCount:   setupDiagnostics.TypedColumnPrepareQ2DenseDistinctRankShardCount,
+		TypedColumnPrepareQ2DenseDistinctRankRefs:         setupDiagnostics.TypedColumnPrepareQ2DenseDistinctRankRefs,
+		TypedColumnPrepareQ2DenseDistinctRankMaxShardRefs: setupDiagnostics.TypedColumnPrepareQ2DenseDistinctRankMaxShardRefs,
+		TypedColumnPrepareQ2DenseDistinctGlobalRanks:      setupDiagnostics.TypedColumnPrepareQ2DenseDistinctGlobalRanks,
+
+		SetupDuration:       setupElapsed,
+		HotRunDuration:      hotRunElapsed,
+		ScanDuration:        scanDuration,
+		ReduceDuration:      reduceDuration,
+		AdapterDuration:     resultShapeDuration,
+		ResultShapeDuration: resultShapeDuration,
+		ParityHashDuration:  parityHashElapsed,
 
 		TypedColumnPrepareQ2GroupGlobalDictionaryRank:    time.Duration(setupDiagnostics.TypedColumnPrepareQ2GroupGlobalDictionaryRankNanos),
 		TypedColumnPrepareQ2DistinctGlobalDictionaryRank: time.Duration(setupDiagnostics.TypedColumnPrepareQ2DistinctGlobalDictionaryRankNanos),
@@ -3290,6 +3341,13 @@ func columnStoreJSONBenchCellFromQueryMetric(q columnStoreQueryMetric, cfg *coll
 	cell.TypedColumnPrepareQ2DenseGroupRankMS = q.TypedColumnPrepareQ2DenseGroupRankMS
 	cell.TypedColumnPrepareQ2DenseDistinctMS = q.TypedColumnPrepareQ2DenseDistinctMS
 	cell.TypedColumnPrepareQ2DensePartLocalMS = q.TypedColumnPrepareQ2DensePartLocalMS
+	cell.TypedColumnPrepareQ2DenseDistinctRankPlanMS = q.TypedColumnPrepareQ2DenseDistinctRankPlanMS
+	cell.TypedColumnPrepareQ2DenseDistinctRankCollectRefsMS = q.TypedColumnPrepareQ2DenseDistinctRankCollectRefsMS
+	cell.TypedColumnPrepareQ2DenseDistinctRankBuildShardsMS = q.TypedColumnPrepareQ2DenseDistinctRankBuildShardsMS
+	cell.TypedColumnPrepareQ2DenseDistinctRankShardCount = q.TypedColumnPrepareQ2DenseDistinctRankShardCount
+	cell.TypedColumnPrepareQ2DenseDistinctRankRefs = q.TypedColumnPrepareQ2DenseDistinctRankRefs
+	cell.TypedColumnPrepareQ2DenseDistinctRankMaxShardRefs = q.TypedColumnPrepareQ2DenseDistinctRankMaxShardRefs
+	cell.TypedColumnPrepareQ2DenseDistinctGlobalRanks = q.TypedColumnPrepareQ2DenseDistinctGlobalRanks
 	cell.TypedColumnPrepareQ2GroupGlobalDictionaryRankMS = q.TypedColumnPrepareQ2GroupGlobalDictionaryRankMS
 	cell.TypedColumnPrepareQ2DistinctGlobalDictionaryRankMS = q.TypedColumnPrepareQ2DistinctGlobalDictionaryRankMS
 	cell.TypedColumnPrepareQ2GroupGlobalCodeRemapMS = q.TypedColumnPrepareQ2GroupGlobalCodeRemapMS
@@ -3421,6 +3479,13 @@ func columnStoreJSONBenchCellFromPreparedExecution(name string, rawHash uint64, 
 	cell.TypedColumnPrepareQ2DenseGroupRankMS = durationMS(exec.TypedColumnPrepareQ2DenseGroupRank)
 	cell.TypedColumnPrepareQ2DenseDistinctMS = durationMS(exec.TypedColumnPrepareQ2DenseDistinct)
 	cell.TypedColumnPrepareQ2DensePartLocalMS = durationMS(exec.TypedColumnPrepareQ2DensePartLocal)
+	cell.TypedColumnPrepareQ2DenseDistinctRankPlanMS = durationMS(exec.TypedColumnPrepareQ2DenseDistinctRankPlan)
+	cell.TypedColumnPrepareQ2DenseDistinctRankCollectRefsMS = durationMS(exec.TypedColumnPrepareQ2DenseDistinctRankCollectRefs)
+	cell.TypedColumnPrepareQ2DenseDistinctRankBuildShardsMS = durationMS(exec.TypedColumnPrepareQ2DenseDistinctRankBuildShards)
+	cell.TypedColumnPrepareQ2DenseDistinctRankShardCount = exec.TypedColumnPrepareQ2DenseDistinctRankShardCount
+	cell.TypedColumnPrepareQ2DenseDistinctRankRefs = exec.TypedColumnPrepareQ2DenseDistinctRankRefs
+	cell.TypedColumnPrepareQ2DenseDistinctRankMaxShardRefs = exec.TypedColumnPrepareQ2DenseDistinctRankMaxShardRefs
+	cell.TypedColumnPrepareQ2DenseDistinctGlobalRanks = exec.TypedColumnPrepareQ2DenseDistinctGlobalRanks
 	cell.TypedColumnPrepareQ2GroupGlobalDictionaryRankMS = durationMS(exec.TypedColumnPrepareQ2GroupGlobalDictionaryRank)
 	cell.TypedColumnPrepareQ2DistinctGlobalDictionaryRankMS = durationMS(exec.TypedColumnPrepareQ2DistinctGlobalDictionaryRank)
 	cell.TypedColumnPrepareQ2GroupGlobalCodeRemapMS = durationMS(exec.TypedColumnPrepareQ2GroupGlobalCodeRemap)
@@ -5014,13 +5079,13 @@ func renderColumnStoreTypedColumnSetupDiagnosticsMarkdown(sb *strings.Builder, r
 		return
 	}
 	sb.WriteString("## Typed Column Setup Diagnostics\n\n")
-	sb.WriteString("| cell | query | mode | query mode | metadata mode | prepare/setup ms | typed prep workers | one-shot build ms | prep plan ms | prep refs ms | prep pair ms | prep decode ms | prep post ms | q2 group rank ms | q2 distinct rank ms | q2 local rank ms | q2 dense group global rank ms | q2 dense distinct global rank ms | q2 dense part local rank ms | q2 group global dict/rank ms | q2 distinct global dict/rank ms | q2 group global-code remap ms | q2 distinct global-code remap ms | prep summary ms | cache store ms | read image ms | state build ms | dictionary ms | pruning ms | sort key ms | stats ms | range read ms | range read B | adapter ms | dense group ms | dense value ms | dense predicate ms | dense preapply ms |\n")
-	sb.WriteString("|---|---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|\n")
+	sb.WriteString("| cell | query | mode | query mode | metadata mode | prepare/setup ms | typed prep workers | one-shot build ms | prep plan ms | prep refs ms | prep pair ms | prep decode ms | prep post ms | q2 group rank ms | q2 distinct rank ms | q2 local rank ms | q2 dense group global rank ms | q2 dense distinct global rank ms | q2 dense part local rank ms | q2 dense distinct rank plan ms | q2 dense distinct rank collect refs ms | q2 dense distinct rank build shards ms | q2 dense distinct rank shards | q2 dense distinct rank refs | q2 dense distinct rank max shard refs | q2 dense distinct global ranks | q2 group global dict/rank ms | q2 distinct global dict/rank ms | q2 group global-code remap ms | q2 distinct global-code remap ms | prep summary ms | cache store ms | read image ms | state build ms | dictionary ms | pruning ms | sort key ms | stats ms | range read ms | range read B | adapter ms | dense group ms | dense value ms | dense predicate ms | dense preapply ms |\n")
+	sb.WriteString("|---|---|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|\n")
 	for _, cell := range report.JSONBenchCells {
 		if !columnStoreJSONBenchCellHasTypedColumnSetupDiagnostics(cell) {
 			continue
 		}
-		sb.WriteString(fmt.Sprintf("| %s | %s | %s | %s | %s | %.3f | %d | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %d | %.3f | %.3f | %.3f | %.3f | %.3f |\n",
+		sb.WriteString(fmt.Sprintf("| %s | %s | %s | %s | %s | %.3f | %d | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %d | %d | %d | %d | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %.3f | %d | %.3f | %.3f | %.3f | %.3f | %.3f |\n",
 			markdownCodeTableText(cell.CellLabel),
 			markdownCodeTableText(cell.Query),
 			markdownCodeTableText(cell.ExecutionMode),
@@ -5040,6 +5105,13 @@ func renderColumnStoreTypedColumnSetupDiagnosticsMarkdown(sb *strings.Builder, r
 			cell.TypedColumnPrepareQ2DenseGroupRankMS,
 			cell.TypedColumnPrepareQ2DenseDistinctMS,
 			cell.TypedColumnPrepareQ2DensePartLocalMS,
+			cell.TypedColumnPrepareQ2DenseDistinctRankPlanMS,
+			cell.TypedColumnPrepareQ2DenseDistinctRankCollectRefsMS,
+			cell.TypedColumnPrepareQ2DenseDistinctRankBuildShardsMS,
+			cell.TypedColumnPrepareQ2DenseDistinctRankShardCount,
+			cell.TypedColumnPrepareQ2DenseDistinctRankRefs,
+			cell.TypedColumnPrepareQ2DenseDistinctRankMaxShardRefs,
+			cell.TypedColumnPrepareQ2DenseDistinctGlobalRanks,
 			cell.TypedColumnPrepareQ2GroupGlobalDictionaryRankMS,
 			cell.TypedColumnPrepareQ2DistinctGlobalDictionaryRankMS,
 			cell.TypedColumnPrepareQ2GroupGlobalCodeRemapMS,
@@ -5092,6 +5164,13 @@ func columnStoreJSONBenchCellHasTypedColumnSetupDiagnostics(cell columnStoreJSON
 		cell.TypedColumnPrepareQ2DenseGroupRankMS != 0 ||
 		cell.TypedColumnPrepareQ2DenseDistinctMS != 0 ||
 		cell.TypedColumnPrepareQ2DensePartLocalMS != 0 ||
+		cell.TypedColumnPrepareQ2DenseDistinctRankPlanMS != 0 ||
+		cell.TypedColumnPrepareQ2DenseDistinctRankCollectRefsMS != 0 ||
+		cell.TypedColumnPrepareQ2DenseDistinctRankBuildShardsMS != 0 ||
+		cell.TypedColumnPrepareQ2DenseDistinctRankShardCount != 0 ||
+		cell.TypedColumnPrepareQ2DenseDistinctRankRefs != 0 ||
+		cell.TypedColumnPrepareQ2DenseDistinctRankMaxShardRefs != 0 ||
+		cell.TypedColumnPrepareQ2DenseDistinctGlobalRanks != 0 ||
 		cell.TypedColumnPrepareQ2GroupGlobalDictionaryRankMS != 0 ||
 		cell.TypedColumnPrepareQ2DistinctGlobalDictionaryRankMS != 0 ||
 		cell.TypedColumnPrepareQ2GroupGlobalCodeRemapMS != 0 ||

--- a/cmd/unified_bench/suite_column_store_test.go
+++ b/cmd/unified_bench/suite_column_store_test.go
@@ -2603,6 +2603,14 @@ func TestColumnStoreJSONBenchCellFromQueryMetricUsesDirectDiagnostics1955(t *tes
 		TypedColumnPrepareQ2DenseDistinctMS:    0.032,
 		TypedColumnPrepareQ2DensePartLocalMS:   0.033,
 
+		TypedColumnPrepareQ2DenseDistinctRankPlanMS:        0.038,
+		TypedColumnPrepareQ2DenseDistinctRankCollectRefsMS: 0.039,
+		TypedColumnPrepareQ2DenseDistinctRankBuildShardsMS: 0.040,
+		TypedColumnPrepareQ2DenseDistinctRankShardCount:    32,
+		TypedColumnPrepareQ2DenseDistinctRankRefs:          123,
+		TypedColumnPrepareQ2DenseDistinctRankMaxShardRefs:  7,
+		TypedColumnPrepareQ2DenseDistinctGlobalRanks:       99,
+
 		TypedColumnPrepareQ2GroupGlobalDictionaryRankMS:    0.034,
 		TypedColumnPrepareQ2DistinctGlobalDictionaryRankMS: 0.035,
 		TypedColumnPrepareQ2GroupGlobalCodeRemapMS:         0.036,
@@ -2725,6 +2733,27 @@ func TestColumnStoreJSONBenchCellFromQueryMetricUsesDirectDiagnostics1955(t *tes
 	if got, want := cell.TypedColumnPrepareQ2DensePartLocalMS, q.TypedColumnPrepareQ2DensePartLocalMS; got != want {
 		t.Fatalf("typed_column_prepare_q2_dense_part_local_rank_duration_ms=%v want %v", got, want)
 	}
+	if got, want := cell.TypedColumnPrepareQ2DenseDistinctRankPlanMS, q.TypedColumnPrepareQ2DenseDistinctRankPlanMS; got != want {
+		t.Fatalf("typed_column_prepare_q2_dense_distinct_rank_plan_duration_ms=%v want %v", got, want)
+	}
+	if got, want := cell.TypedColumnPrepareQ2DenseDistinctRankCollectRefsMS, q.TypedColumnPrepareQ2DenseDistinctRankCollectRefsMS; got != want {
+		t.Fatalf("typed_column_prepare_q2_dense_distinct_rank_collect_refs_duration_ms=%v want %v", got, want)
+	}
+	if got, want := cell.TypedColumnPrepareQ2DenseDistinctRankBuildShardsMS, q.TypedColumnPrepareQ2DenseDistinctRankBuildShardsMS; got != want {
+		t.Fatalf("typed_column_prepare_q2_dense_distinct_rank_build_shards_duration_ms=%v want %v", got, want)
+	}
+	if got, want := cell.TypedColumnPrepareQ2DenseDistinctRankShardCount, q.TypedColumnPrepareQ2DenseDistinctRankShardCount; got != want {
+		t.Fatalf("typed_column_prepare_q2_dense_distinct_rank_shard_count=%d want %d", got, want)
+	}
+	if got, want := cell.TypedColumnPrepareQ2DenseDistinctRankRefs, q.TypedColumnPrepareQ2DenseDistinctRankRefs; got != want {
+		t.Fatalf("typed_column_prepare_q2_dense_distinct_rank_refs=%d want %d", got, want)
+	}
+	if got, want := cell.TypedColumnPrepareQ2DenseDistinctRankMaxShardRefs, q.TypedColumnPrepareQ2DenseDistinctRankMaxShardRefs; got != want {
+		t.Fatalf("typed_column_prepare_q2_dense_distinct_rank_max_shard_refs=%d want %d", got, want)
+	}
+	if got, want := cell.TypedColumnPrepareQ2DenseDistinctGlobalRanks, q.TypedColumnPrepareQ2DenseDistinctGlobalRanks; got != want {
+		t.Fatalf("typed_column_prepare_q2_dense_distinct_global_ranks=%d want %d", got, want)
+	}
 	if got, want := cell.TypedColumnPrepareQ2GroupGlobalDictionaryRankMS, q.TypedColumnPrepareQ2GroupGlobalDictionaryRankMS; got != want {
 		t.Fatalf("typed_column_prepare_q2_group_global_dictionary_rank_duration_ms=%v want %v", got, want)
 	}
@@ -2838,6 +2867,14 @@ func TestRenderColumnStoreTypedColumnSetupDiagnosticsMarkdownQ2Splits3324(t *tes
 				TypedColumnPrepareQ2DenseGroupRankMS: 0.125,
 				TypedColumnPrepareQ2DenseDistinctMS:  0.5,
 				TypedColumnPrepareQ2DensePartLocalMS: 0.75,
+
+				TypedColumnPrepareQ2DenseDistinctRankPlanMS:        0.875,
+				TypedColumnPrepareQ2DenseDistinctRankCollectRefsMS: 1.0,
+				TypedColumnPrepareQ2DenseDistinctRankBuildShardsMS: 1.125,
+				TypedColumnPrepareQ2DenseDistinctRankShardCount:    32,
+				TypedColumnPrepareQ2DenseDistinctRankRefs:          123,
+				TypedColumnPrepareQ2DenseDistinctRankMaxShardRefs:  7,
+				TypedColumnPrepareQ2DenseDistinctGlobalRanks:       99,
 				TypedColumnPrepareQ2GroupGlobalDictionaryRankMS:    1.25,
 				TypedColumnPrepareQ2DistinctGlobalDictionaryRankMS: 2.5,
 				TypedColumnPrepareQ2GroupGlobalCodeRemapMS:         3.75,
@@ -2854,9 +2891,19 @@ func TestRenderColumnStoreTypedColumnSetupDiagnosticsMarkdownQ2Splits3324(t *tes
 		"q2 dense group global rank ms",
 		"q2 dense distinct global rank ms",
 		"q2 dense part local rank ms",
+		"q2 dense distinct rank plan ms",
+		"q2 dense distinct rank collect refs ms",
+		"q2 dense distinct rank build shards ms",
+		"q2 dense distinct rank refs",
+		"q2 dense distinct global ranks",
 		"0.125",
 		"0.500",
 		"0.750",
+		"0.875",
+		"1.000",
+		"1.125",
+		"123",
+		"99",
 		"q2 group global-code remap ms",
 		"q2 distinct global-code remap ms",
 		"1.250",


### PR DESCRIPTION
## Summary

- add q2 dense count-distinct reference-fill diagnostics for distinct-rank plan, ref collection, shard build, shard count, ref counts, max shard refs, and global ranks
- carry those fields through TreeDB column physical diagnostics and unified-bench JSON/markdown setup reporting
- extend q2 dense reference-fill tests and benchmark metrics so the next optimization can target the measured subphase

Linked tracker: #3324. This is no-aggregate one-shot typed-column setup observability only. It is not metadata acceleration, not a load improvement, and not a TreeDB-vs-ClickHouse claim.

## Evidence

Focused tests:

```sh
GOWORK=off /home/mikers/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.26.0.linux-amd64/bin/go test ./TreeDB/collections -run 'TestTypedColumnQ2DenseGroupCountDistinct(GlobalRankPrepHarness|ShardedHashRankPrepEquivalence|AdaptiveRankPrepPolicy|OneShotRankPrepMatchesAdaptivePolicy|ShardedReferenceFillNullableEmpty|ShardRankRefsParallelMatchesSerial|ShardedHashRankRunEquivalence|AdaptiveRankRunEquivalence)$' -count=1
GOWORK=off /home/mikers/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.26.0.linux-amd64/bin/go test ./cmd/unified_bench -count=1
```

Results:

- `ok github.com/snissn/gomap/TreeDB/collections 6.459s`
- `ok github.com/snissn/gomap/cmd/unified_bench 26.925s`
- `git diff --check` clean

Benchmark smoke:

```sh
GOWORK=off /home/mikers/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.26.0.linux-amd64/bin/go test ./TreeDB/collections -run '^$' -bench '^BenchmarkTypedColumnQ2DenseGroupCountDistinctGlobalRankPrep/(adaptive|adaptive_baseline)/(mixed|mostly_disjoint)/parts=(80|160)$' -benchtime=1x -count=1
```

Result: passed. Adaptive/reference-fill rows now report `diag_dense_distinct_rank_plan_ns/op`, `diag_dense_distinct_rank_collect_refs_ns/op`, `diag_dense_distinct_rank_build_shards_ns/op`, `diag_dense_distinct_rank_shards/op`, `diag_dense_distinct_rank_refs/op`, `diag_dense_distinct_rank_max_shard_refs/op`, and `diag_dense_distinct_global_ranks/op`.

End-to-end JSONBench smoke with local JSONBench companion and local gomap replace:

- artifact: `/mnt/fast4tb/gomap-profiles/current-head-jsonbench-20260630_084455/jsonbench_q2_diag_split_smoke_20260630_104027`
- rows: 100,000
- query: q2
- query mode: `one_shot_end_to_end`
- metadata mode: `no_aggregate_metadata`
- result hash from raw result artifact: `cfa9eff36a0fac915d468138952daaf4e9b0eda84afd17491546fcb3130ccb4c`
- total/setup/run/render: 9.075ms / 6.917ms / 2.120ms / 0.037ms
- post-prepare: 3.944ms
- dense distinct rank split: plan 0.001ms, collect refs 0.348ms, build shards 0.996ms
- shard count 32, refs 64,245, max shard refs 2,232, global ranks 37,262
- rows scanned/matched/reduced: 100,000 / 95,245 / 95,245

## Follow-up

Next q2 optimization PR should use this split to decide whether to attack ref collection, shard build, local rank preparation, or an adaptive lazy/local-rank alternative. Any claimed speedup needs before/after 1M q2 `one_shot_end_to_end` / `no_aggregate_metadata` evidence with rows/hash preserved, and q1/q3 samples if shared setup code changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detailed diagnostics for typed-column Q2 dense-distinct ranking, including timing breakdowns and shard/reference counts.
  * Expanded benchmark and report outputs to show the new preparation and reference-fill metrics.
* **Bug Fixes**
  * Improved diagnostics aggregation so new metrics are combined correctly across workers.
  * Added stronger validation for dense-distinct reference-fill results and shard counts.
* **Tests**
  * Updated benchmark and output tests to cover the new metrics and rendered diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->