### PR TITLE
Carry q2 sharded rank hashes

### DIFF
--- a/TreeDB/collections/column_physical_q2_global_rank_prep_bench_test.go
+++ b/TreeDB/collections/column_physical_q2_global_rank_prep_bench_test.go
@@ -305,6 +305,36 @@ func TestTypedColumnQ2DenseGroupCountDistinctShardedReferenceFillNullableEmpty(t
 	}
 }
 
+func TestTypedColumnQ2DenseGroupCountDistinctHashRankShardCollision(t *testing.T) {
+	shard := newColumnTypedColumnDenseGroupCountDistinctHashRankShard(3)
+	const hash = uint64(42)
+	first, err := shard.addHash(hash, "did:first")
+	if err != nil {
+		t.Fatalf("add first: %v", err)
+	}
+	second, err := shard.addHash(hash, "did:second")
+	if err != nil {
+		t.Fatalf("add second: %v", err)
+	}
+	firstAgain, err := shard.addHash(hash, "did:first")
+	if err != nil {
+		t.Fatalf("add first again: %v", err)
+	}
+	secondAgain, ok := shard.lookupHash(hash, "did:second")
+	if !ok {
+		t.Fatalf("lookup second collision failed")
+	}
+	if first != 0 || second != 1 || firstAgain != first || secondAgain != second {
+		t.Fatalf("collision ranks first=%d second=%d firstAgain=%d secondAgain=%d", first, second, firstAgain, secondAgain)
+	}
+	if _, ok := shard.lookupHash(hash, "did:third"); ok {
+		t.Fatalf("lookup returned rank for missing colliding value")
+	}
+	if got := shard.cardinality(); got != 2 {
+		t.Fatalf("cardinality=%d want 2", got)
+	}
+}
+
 func TestTypedColumnQ2DenseGroupCountDistinctShardRankRefsParallelMatchesSerial(t *testing.T) {
 	newPart := func(dictionary []string, valid []bool) columnTypedColumnPhysicalQueryPart {
 		return columnTypedColumnPhysicalQueryPart{
@@ -341,8 +371,8 @@ func TestTypedColumnQ2DenseGroupCountDistinctShardRankRefsParallelMatchesSerial(
 	}
 	for shardIdx, refs := range parallelRefs {
 		for refIdx := 1; refIdx < len(refs); refIdx++ {
-			if refs[refIdx] < refs[refIdx-1] {
-				t.Fatalf("shard %d refs not monotonic at %d: %d < %d", shardIdx, refIdx, refs[refIdx], refs[refIdx-1])
+			if refs[refIdx].ref < refs[refIdx-1].ref {
+				t.Fatalf("shard %d refs not monotonic at %d: %d < %d", shardIdx, refIdx, refs[refIdx].ref, refs[refIdx-1].ref)
 			}
 		}
 	}

--- a/TreeDB/collections/column_physical_q2_global_rank_prep_bench_test.go
+++ b/TreeDB/collections/column_physical_q2_global_rank_prep_bench_test.go
@@ -307,7 +307,7 @@ func TestTypedColumnQ2DenseGroupCountDistinctShardedReferenceFillNullableEmpty(t
 
 func TestTypedColumnQ2DenseGroupCountDistinctHashRankShardCollision(t *testing.T) {
 	shard := newColumnTypedColumnDenseGroupCountDistinctHashRankShard(3)
-	const hash = uint64(42)
+	const hash = uint32(42)
 	first, err := shard.addHash(hash, "did:first")
 	if err != nil {
 		t.Fatalf("add first: %v", err)
@@ -371,8 +371,8 @@ func TestTypedColumnQ2DenseGroupCountDistinctShardRankRefsParallelMatchesSerial(
 	}
 	for shardIdx, refs := range parallelRefs {
 		for refIdx := 1; refIdx < len(refs); refIdx++ {
-			if refs[refIdx].ref < refs[refIdx-1].ref {
-				t.Fatalf("shard %d refs not monotonic at %d: %d < %d", shardIdx, refIdx, refs[refIdx].ref, refs[refIdx-1].ref)
+			if refs[refIdx].packed() < refs[refIdx-1].packed() {
+				t.Fatalf("shard %d refs not monotonic at %d: %d < %d", shardIdx, refIdx, refs[refIdx].packed(), refs[refIdx-1].packed())
 			}
 		}
 	}

--- a/TreeDB/collections/column_physical_typed_column_query.go
+++ b/TreeDB/collections/column_physical_typed_column_query.go
@@ -1674,7 +1674,7 @@ func prepareColumnTypedColumnDenseGroupCountDistinctGlobalRankMapsShardedReferen
 	if includeEmpty {
 		emptyShardIdx = int(columnTypedColumnDenseGroupCountDistinctStableRankHash("") & uint64(shardCount-1))
 	}
-	shards, err := columnTypedColumnDenseGroupCountDistinctBuildShardedRanksFromRefPartitions(parts, shardRefPartitions, shardCount, emptyShardIdx, workers)
+	shards, err := columnTypedColumnDenseGroupCountDistinctBuildHashShardedRanksFromRefPartitions(parts, shardRefPartitions, shardCount, emptyShardIdx, workers)
 	if err != nil {
 		elapsed := time.Since(phaseStart).Nanoseconds()
 		timing.distinctRankBuildShardsNanos += elapsed
@@ -1684,22 +1684,24 @@ func prepareColumnTypedColumnDenseGroupCountDistinctGlobalRankMapsShardedReferen
 	offsets := make([]uint32, len(shards))
 	cardinality := 0
 	for shardIdx, shard := range shards {
-		if len(shard) == 0 {
+		if shard.cardinality() == 0 {
 			continue
 		}
-		if cardinality > int(^uint32(0)) || len(shard) > int(^uint32(0))-cardinality {
+		shardCardinality := shard.cardinality()
+		if cardinality > int(^uint32(0)) || shardCardinality > int(^uint32(0))-cardinality {
 			elapsed := time.Since(phaseStart).Nanoseconds()
 			timing.distinctRankBuildShardsNanos += elapsed
 			timing.distinctRankNanos += elapsed
 			return timing, fmt.Errorf("collections: dense grouped count-distinct global dictionary cardinality exceeds uint32")
 		}
 		offsets[shardIdx] = uint32(cardinality)
-		cardinality += len(shard)
+		cardinality += shardCardinality
 	}
 	emptyRank := uint32(0)
 	emptyOK := false
-	emptyLookupShardIdx := int(columnTypedColumnDenseGroupCountDistinctStableRankHash("") & uint64(shardCount-1))
-	if localRank, ok := shards[emptyLookupShardIdx][""]; ok {
+	emptyHash := columnTypedColumnDenseGroupCountDistinctStableRankHash("")
+	emptyLookupShardIdx := int(emptyHash & uint64(shardCount-1))
+	if localRank, ok := shards[emptyLookupShardIdx].lookupHash(emptyHash, ""); ok {
 		emptyRank = offsets[emptyLookupShardIdx] + localRank
 		emptyOK = true
 	} else if includeEmpty {
@@ -1735,9 +1737,14 @@ func prepareColumnTypedColumnDenseGroupCountDistinctGlobalRankMapsShardedReferen
 	return timing, nil
 }
 
-type columnTypedColumnDenseGroupCountDistinctShardRankRefPartitions [][][]uint64
+type columnTypedColumnDenseGroupCountDistinctShardRankRef struct {
+	ref  uint64
+	hash uint64
+}
 
-func columnTypedColumnDenseGroupCountDistinctCollectShardRankRefs(parts []columnTypedColumnPhysicalQueryPart, shardCount, capacity, workers int) ([][]uint64, error) {
+type columnTypedColumnDenseGroupCountDistinctShardRankRefPartitions [][][]columnTypedColumnDenseGroupCountDistinctShardRankRef
+
+func columnTypedColumnDenseGroupCountDistinctCollectShardRankRefs(parts []columnTypedColumnPhysicalQueryPart, shardCount, capacity, workers int) ([][]columnTypedColumnDenseGroupCountDistinctShardRankRef, error) {
 	partitions, err := columnTypedColumnDenseGroupCountDistinctCollectShardRankRefPartitions(parts, shardCount, capacity, workers)
 	if err != nil {
 		return nil, err
@@ -1755,7 +1762,7 @@ func columnTypedColumnDenseGroupCountDistinctCollectShardRankRefPartitions(parts
 	}
 	workerCount := min(workers, len(parts))
 	ranges := columnTypedColumnDenseGroupCountDistinctShardRankRefWorkerRanges(len(parts), workerCount)
-	workerRefs := make([][][]uint64, workerCount)
+	workerRefs := make([][][]columnTypedColumnDenseGroupCountDistinctShardRankRef, workerCount)
 	errs := make([]error, workerCount)
 	var wg sync.WaitGroup
 	for workerIdx := 0; workerIdx < workerCount; workerIdx++ {
@@ -1781,14 +1788,14 @@ func columnTypedColumnDenseGroupCountDistinctCollectShardRankRefPartitions(parts
 	return columnTypedColumnDenseGroupCountDistinctShardRankRefPartitions(workerRefs), nil
 }
 
-func columnTypedColumnDenseGroupCountDistinctMergeShardRankRefPartitions(partitions columnTypedColumnDenseGroupCountDistinctShardRankRefPartitions, shardCount int) [][]uint64 {
-	refs := make([][]uint64, shardCount)
+func columnTypedColumnDenseGroupCountDistinctMergeShardRankRefPartitions(partitions columnTypedColumnDenseGroupCountDistinctShardRankRefPartitions, shardCount int) [][]columnTypedColumnDenseGroupCountDistinctShardRankRef {
+	refs := make([][]columnTypedColumnDenseGroupCountDistinctShardRankRef, shardCount)
 	for shardIdx := 0; shardIdx < shardCount; shardIdx++ {
 		total := 0
 		for partitionIdx := range partitions {
 			total += len(partitions[partitionIdx][shardIdx])
 		}
-		refs[shardIdx] = make([]uint64, 0, total)
+		refs[shardIdx] = make([]columnTypedColumnDenseGroupCountDistinctShardRankRef, 0, total)
 		for partitionIdx := range partitions {
 			refs[shardIdx] = append(refs[shardIdx], partitions[partitionIdx][shardIdx]...)
 		}
@@ -1816,7 +1823,7 @@ func columnTypedColumnDenseGroupCountDistinctShardRankRefWorkerRanges(partCount,
 	return ranges
 }
 
-func columnTypedColumnDenseGroupCountDistinctCollectShardRankRefsSerial(parts []columnTypedColumnPhysicalQueryPart, shardCount, capacity int) ([][]uint64, error) {
+func columnTypedColumnDenseGroupCountDistinctCollectShardRankRefsSerial(parts []columnTypedColumnPhysicalQueryPart, shardCount, capacity int) ([][]columnTypedColumnDenseGroupCountDistinctShardRankRef, error) {
 	refs := columnTypedColumnDenseGroupCountDistinctNewShardRankRefs(shardCount, capacity)
 	for partIdx := range parts {
 		if err := columnTypedColumnDenseGroupCountDistinctCollectShardRankRefsPart(parts, partIdx, refs); err != nil {
@@ -1826,16 +1833,16 @@ func columnTypedColumnDenseGroupCountDistinctCollectShardRankRefsSerial(parts []
 	return refs, nil
 }
 
-func columnTypedColumnDenseGroupCountDistinctNewShardRankRefs(shardCount, capacity int) [][]uint64 {
-	refs := make([][]uint64, shardCount)
+func columnTypedColumnDenseGroupCountDistinctNewShardRankRefs(shardCount, capacity int) [][]columnTypedColumnDenseGroupCountDistinctShardRankRef {
+	refs := make([][]columnTypedColumnDenseGroupCountDistinctShardRankRef, shardCount)
 	shardCapacity := max(1, capacity/shardCount)
 	for shardIdx := range refs {
-		refs[shardIdx] = make([]uint64, 0, shardCapacity)
+		refs[shardIdx] = make([]columnTypedColumnDenseGroupCountDistinctShardRankRef, 0, shardCapacity)
 	}
 	return refs
 }
 
-func columnTypedColumnDenseGroupCountDistinctShardRankRefStats(shardRefs [][]uint64) (total, maxShard int) {
+func columnTypedColumnDenseGroupCountDistinctShardRankRefStats(shardRefs [][]columnTypedColumnDenseGroupCountDistinctShardRankRef) (total, maxShard int) {
 	for _, refs := range shardRefs {
 		total += len(refs)
 		if len(refs) > maxShard {
@@ -1859,7 +1866,7 @@ func columnTypedColumnDenseGroupCountDistinctShardRankRefPartitionStats(partitio
 	return total, maxShard
 }
 
-func columnTypedColumnDenseGroupCountDistinctCollectShardRankRefsPart(parts []columnTypedColumnPhysicalQueryPart, partIdx int, shardRefs [][]uint64) error {
+func columnTypedColumnDenseGroupCountDistinctCollectShardRankRefsPart(parts []columnTypedColumnPhysicalQueryPart, partIdx int, shardRefs [][]columnTypedColumnDenseGroupCountDistinctShardRankRef) error {
 	if partIdx < 0 || partIdx >= len(parts) {
 		return fmt.Errorf("collections: dense grouped count-distinct part index=%d outside parts=%d", partIdx, len(parts))
 	}
@@ -1875,8 +1882,9 @@ func columnTypedColumnDenseGroupCountDistinctCollectShardRankRefsPart(parts []co
 		if err != nil {
 			return err
 		}
-		shardIdx := int(columnTypedColumnDenseGroupCountDistinctStableRankHash(value) & uint64(len(shardRefs)-1))
-		shardRefs[shardIdx] = append(shardRefs[shardIdx], ref)
+		hash := columnTypedColumnDenseGroupCountDistinctStableRankHash(value)
+		shardIdx := int(hash & uint64(len(shardRefs)-1))
+		shardRefs[shardIdx] = append(shardRefs[shardIdx], columnTypedColumnDenseGroupCountDistinctShardRankRef{ref: ref, hash: hash})
 	}
 	return nil
 }
@@ -1892,12 +1900,71 @@ func columnTypedColumnDenseGroupCountDistinctUnpackRankRef(ref uint64) (int, int
 	return int(uint32(ref >> 32)), int(uint32(ref))
 }
 
-func columnTypedColumnDenseGroupCountDistinctBuildShardedRanksFromRefPartitions(parts []columnTypedColumnPhysicalQueryPart, partitions columnTypedColumnDenseGroupCountDistinctShardRankRefPartitions, shardCount, emptyShardIdx int, workers int) ([]map[string]uint32, error) {
-	shards := make([]map[string]uint32, shardCount)
+type columnTypedColumnDenseGroupCountDistinctHashRankShard struct {
+	ranks      map[uint64]uint32
+	values     []string
+	collisions map[uint64][]uint32
+}
+
+func newColumnTypedColumnDenseGroupCountDistinctHashRankShard(capacity int) columnTypedColumnDenseGroupCountDistinctHashRankShard {
+	return columnTypedColumnDenseGroupCountDistinctHashRankShard{
+		ranks:  make(map[uint64]uint32, columnTypedColumnDenseGroupCountDistinctRankMapCapacity(capacity)),
+		values: make([]string, 0, capacity),
+	}
+}
+
+func (s *columnTypedColumnDenseGroupCountDistinctHashRankShard) cardinality() int {
+	if s == nil {
+		return 0
+	}
+	return len(s.values)
+}
+
+func (s *columnTypedColumnDenseGroupCountDistinctHashRankShard) lookupHash(hash uint64, value string) (uint32, bool) {
+	if s == nil || len(s.ranks) == 0 {
+		return 0, false
+	}
+	rank, ok := s.ranks[hash]
+	if !ok {
+		return 0, false
+	}
+	if int(rank) < len(s.values) && s.values[rank] == value {
+		return rank, true
+	}
+	for _, collisionRank := range s.collisions[hash] {
+		if int(collisionRank) < len(s.values) && s.values[collisionRank] == value {
+			return collisionRank, true
+		}
+	}
+	return 0, false
+}
+
+func (s *columnTypedColumnDenseGroupCountDistinctHashRankShard) addHash(hash uint64, value string) (uint32, error) {
+	if rank, ok := s.lookupHash(hash, value); ok {
+		return rank, nil
+	}
+	if uint64(len(s.values)) > uint64(^uint32(0)) {
+		return 0, fmt.Errorf("collections: dense grouped count-distinct global dictionary cardinality exceeds uint32")
+	}
+	rank := uint32(len(s.values))
+	if _, exists := s.ranks[hash]; exists {
+		if s.collisions == nil {
+			s.collisions = make(map[uint64][]uint32)
+		}
+		s.collisions[hash] = append(s.collisions[hash], rank)
+	} else {
+		s.ranks[hash] = rank
+	}
+	s.values = append(s.values, value)
+	return rank, nil
+}
+
+func columnTypedColumnDenseGroupCountDistinctBuildHashShardedRanksFromRefPartitions(parts []columnTypedColumnPhysicalQueryPart, partitions columnTypedColumnDenseGroupCountDistinctShardRankRefPartitions, shardCount, emptyShardIdx int, workers int) ([]columnTypedColumnDenseGroupCountDistinctHashRankShard, error) {
+	shards := make([]columnTypedColumnDenseGroupCountDistinctHashRankShard, shardCount)
 	errs := make([]error, shardCount)
 	if workers < 2 || shardCount < 2 {
 		for shardIdx := 0; shardIdx < shardCount; shardIdx++ {
-			shards[shardIdx], errs[shardIdx] = columnTypedColumnDenseGroupCountDistinctBuildShardRanksFromRefPartitions(parts, partitions, shardIdx, shardIdx == emptyShardIdx)
+			shards[shardIdx], errs[shardIdx] = columnTypedColumnDenseGroupCountDistinctBuildHashShardRanksFromRefPartitions(parts, partitions, shardIdx, shardIdx == emptyShardIdx)
 			if errs[shardIdx] != nil {
 				return nil, errs[shardIdx]
 			}
@@ -1912,7 +1979,7 @@ func columnTypedColumnDenseGroupCountDistinctBuildShardedRanksFromRefPartitions(
 		go func() {
 			defer wg.Done()
 			for shardIdx := range jobs {
-				shards[shardIdx], errs[shardIdx] = columnTypedColumnDenseGroupCountDistinctBuildShardRanksFromRefPartitions(parts, partitions, shardIdx, shardIdx == emptyShardIdx)
+				shards[shardIdx], errs[shardIdx] = columnTypedColumnDenseGroupCountDistinctBuildHashShardRanksFromRefPartitions(parts, partitions, shardIdx, shardIdx == emptyShardIdx)
 			}
 		}()
 	}
@@ -1929,7 +1996,7 @@ func columnTypedColumnDenseGroupCountDistinctBuildShardedRanksFromRefPartitions(
 	return shards, nil
 }
 
-func columnTypedColumnDenseGroupCountDistinctBuildShardRanksFromRefPartitions(parts []columnTypedColumnPhysicalQueryPart, partitions columnTypedColumnDenseGroupCountDistinctShardRankRefPartitions, shardIdx int, includeEmpty bool) (map[string]uint32, error) {
+func columnTypedColumnDenseGroupCountDistinctBuildHashShardRanksFromRefPartitions(parts []columnTypedColumnPhysicalQueryPart, partitions columnTypedColumnDenseGroupCountDistinctShardRankRefPartitions, shardIdx int, includeEmpty bool) (columnTypedColumnDenseGroupCountDistinctHashRankShard, error) {
 	capacity := 0
 	for partitionIdx := range partitions {
 		capacity += len(partitions[partitionIdx][shardIdx])
@@ -1937,38 +2004,32 @@ func columnTypedColumnDenseGroupCountDistinctBuildShardRanksFromRefPartitions(pa
 	if includeEmpty {
 		capacity++
 	}
-	ranks := make(map[string]uint32, columnTypedColumnDenseGroupCountDistinctRankMapCapacity(capacity))
+	ranks := newColumnTypedColumnDenseGroupCountDistinctHashRankShard(capacity)
 	for partitionIdx := range partitions {
 		for _, ref := range partitions[partitionIdx][shardIdx] {
-			partIdx, localCode := columnTypedColumnDenseGroupCountDistinctUnpackRankRef(ref)
+			partIdx, localCode := columnTypedColumnDenseGroupCountDistinctUnpackRankRef(ref.ref)
 			if partIdx < 0 || partIdx >= len(parts) {
-				return nil, fmt.Errorf("collections: dense grouped count-distinct part reference=%d outside parts=%d", partIdx, len(parts))
+				return columnTypedColumnDenseGroupCountDistinctHashRankShard{}, fmt.Errorf("collections: dense grouped count-distinct part reference=%d outside parts=%d", partIdx, len(parts))
 			}
 			part := parts[partIdx].DenseGroupCountDistinct
 			if part == nil {
-				return nil, fmt.Errorf("collections: dense grouped count-distinct missing prepared part %d", partIdx)
+				return columnTypedColumnDenseGroupCountDistinctHashRankShard{}, fmt.Errorf("collections: dense grouped count-distinct missing prepared part %d", partIdx)
 			}
 			if localCode < 0 || localCode >= len(part.Distinct.Dictionary) || localCode >= len(part.Distinct.GlobalLocalRanks) {
-				return nil, fmt.Errorf("collections: dense grouped count-distinct distinct part %d local code=%d outside dictionary=%d ranks=%d", partIdx, localCode, len(part.Distinct.Dictionary), len(part.Distinct.GlobalLocalRanks))
+				return columnTypedColumnDenseGroupCountDistinctHashRankShard{}, fmt.Errorf("collections: dense grouped count-distinct distinct part %d local code=%d outside dictionary=%d ranks=%d", partIdx, localCode, len(part.Distinct.Dictionary), len(part.Distinct.GlobalLocalRanks))
 			}
 			value := part.Distinct.Dictionary[localCode]
-			rank, ok := ranks[value]
-			if !ok {
-				if uint64(len(ranks)) > uint64(^uint32(0)) {
-					return nil, fmt.Errorf("collections: dense grouped count-distinct global dictionary cardinality exceeds uint32")
-				}
-				rank = uint32(len(ranks))
-				ranks[value] = rank
+			rank, err := ranks.addHash(ref.hash, value)
+			if err != nil {
+				return columnTypedColumnDenseGroupCountDistinctHashRankShard{}, err
 			}
 			part.Distinct.GlobalLocalRanks[localCode] = rank
 		}
 	}
 	if includeEmpty {
-		if _, ok := ranks[""]; !ok {
-			if uint64(len(ranks)) > uint64(^uint32(0)) {
-				return nil, fmt.Errorf("collections: dense grouped count-distinct global dictionary cardinality exceeds uint32")
-			}
-			ranks[""] = uint32(len(ranks))
+		emptyHash := columnTypedColumnDenseGroupCountDistinctStableRankHash("")
+		if _, err := ranks.addHash(emptyHash, ""); err != nil {
+			return columnTypedColumnDenseGroupCountDistinctHashRankShard{}, err
 		}
 	}
 	return ranks, nil
@@ -2012,12 +2073,12 @@ func columnTypedColumnDenseGroupCountDistinctAddShardedRankOffsetsFromPartitions
 	return nil
 }
 
-func columnTypedColumnDenseGroupCountDistinctAddShardRankOffset(parts []columnTypedColumnPhysicalQueryPart, refs []uint64, offset uint32) error {
+func columnTypedColumnDenseGroupCountDistinctAddShardRankOffset(parts []columnTypedColumnPhysicalQueryPart, refs []columnTypedColumnDenseGroupCountDistinctShardRankRef, offset uint32) error {
 	if offset == 0 {
 		return nil
 	}
 	for _, ref := range refs {
-		partIdx, localCode := columnTypedColumnDenseGroupCountDistinctUnpackRankRef(ref)
+		partIdx, localCode := columnTypedColumnDenseGroupCountDistinctUnpackRankRef(ref.ref)
 		if partIdx < 0 || partIdx >= len(parts) {
 			return fmt.Errorf("collections: dense grouped count-distinct part reference=%d outside parts=%d", partIdx, len(parts))
 		}

--- a/TreeDB/collections/column_physical_typed_column_query.go
+++ b/TreeDB/collections/column_physical_typed_column_query.go
@@ -1949,7 +1949,7 @@ func (s *columnTypedColumnDenseGroupCountDistinctHashRankShard) addHash(hash uin
 	if rank, ok := s.lookupHash(hash, value); ok {
 		return rank, nil
 	}
-	if uint64(len(s.values)) > uint64(^uint32(0)) {
+	if uint64(len(s.values)) >= uint64(^uint32(0)) {
 		return 0, fmt.Errorf("collections: dense grouped count-distinct global dictionary cardinality exceeds uint32")
 	}
 	rank := uint32(len(s.values))

--- a/TreeDB/collections/column_physical_typed_column_query.go
+++ b/TreeDB/collections/column_physical_typed_column_query.go
@@ -1672,7 +1672,7 @@ func prepareColumnTypedColumnDenseGroupCountDistinctGlobalRankMapsShardedReferen
 	phaseStart = time.Now()
 	emptyShardIdx := -1
 	if includeEmpty {
-		emptyShardIdx = int(columnTypedColumnDenseGroupCountDistinctStableRankHash("") & uint64(shardCount-1))
+		emptyShardIdx = int(uint32(columnTypedColumnDenseGroupCountDistinctStableRankHash("")) & uint32(shardCount-1))
 	}
 	shards, err := columnTypedColumnDenseGroupCountDistinctBuildHashShardedRanksFromRefPartitions(parts, shardRefPartitions, shardCount, emptyShardIdx, workers)
 	if err != nil {
@@ -1699,8 +1699,8 @@ func prepareColumnTypedColumnDenseGroupCountDistinctGlobalRankMapsShardedReferen
 	}
 	emptyRank := uint32(0)
 	emptyOK := false
-	emptyHash := columnTypedColumnDenseGroupCountDistinctStableRankHash("")
-	emptyLookupShardIdx := int(emptyHash & uint64(shardCount-1))
+	emptyHash := uint32(columnTypedColumnDenseGroupCountDistinctStableRankHash(""))
+	emptyLookupShardIdx := int(emptyHash & uint32(shardCount-1))
 	if localRank, ok := shards[emptyLookupShardIdx].lookupHash(emptyHash, ""); ok {
 		emptyRank = offsets[emptyLookupShardIdx] + localRank
 		emptyOK = true
@@ -1738,8 +1738,13 @@ func prepareColumnTypedColumnDenseGroupCountDistinctGlobalRankMapsShardedReferen
 }
 
 type columnTypedColumnDenseGroupCountDistinctShardRankRef struct {
-	ref  uint64
-	hash uint64
+	partIdx   uint32
+	localCode uint32
+	hash      uint32
+}
+
+func (r columnTypedColumnDenseGroupCountDistinctShardRankRef) packed() uint64 {
+	return uint64(r.partIdx)<<32 | uint64(r.localCode)
 }
 
 type columnTypedColumnDenseGroupCountDistinctShardRankRefPartitions [][][]columnTypedColumnDenseGroupCountDistinctShardRankRef
@@ -1878,38 +1883,39 @@ func columnTypedColumnDenseGroupCountDistinctCollectShardRankRefsPart(parts []co
 		return fmt.Errorf("collections: dense grouped count-distinct missing rank shards")
 	}
 	for localCode, value := range part.Distinct.Dictionary {
-		ref, err := columnTypedColumnDenseGroupCountDistinctPackRankRef(partIdx, localCode)
-		if err != nil {
-			return err
+		if uint64(partIdx) > uint64(^uint32(0)) || uint64(localCode) > uint64(^uint32(0)) {
+			return fmt.Errorf("collections: dense grouped count-distinct rank reference exceeds uint32 part=%d local_code=%d", partIdx, localCode)
 		}
-		hash := columnTypedColumnDenseGroupCountDistinctStableRankHash(value)
-		shardIdx := int(hash & uint64(len(shardRefs)-1))
-		shardRefs[shardIdx] = append(shardRefs[shardIdx], columnTypedColumnDenseGroupCountDistinctShardRankRef{ref: ref, hash: hash})
+		hash := uint32(columnTypedColumnDenseGroupCountDistinctStableRankHash(value))
+		shardIdx := int(hash & uint32(len(shardRefs)-1))
+		shardRefs[shardIdx] = append(shardRefs[shardIdx], columnTypedColumnDenseGroupCountDistinctShardRankRef{
+			partIdx:   uint32(partIdx),
+			localCode: uint32(localCode),
+			hash:      hash,
+		})
 	}
 	return nil
 }
 
-func columnTypedColumnDenseGroupCountDistinctPackRankRef(partIdx, localCode int) (uint64, error) {
-	if uint64(partIdx) > uint64(^uint32(0)) || uint64(localCode) > uint64(^uint32(0)) {
-		return 0, fmt.Errorf("collections: dense grouped count-distinct rank reference exceeds uint32 part=%d local_code=%d", partIdx, localCode)
-	}
-	return uint64(uint32(partIdx))<<32 | uint64(uint32(localCode)), nil
-}
-
-func columnTypedColumnDenseGroupCountDistinctUnpackRankRef(ref uint64) (int, int) {
-	return int(uint32(ref >> 32)), int(uint32(ref))
-}
-
 type columnTypedColumnDenseGroupCountDistinctHashRankShard struct {
-	ranks      map[uint64]uint32
+	ranks      map[uint32]uint32
 	values     []string
-	collisions map[uint64][]uint32
+	collisions map[uint32][]uint32
 }
 
 func newColumnTypedColumnDenseGroupCountDistinctHashRankShard(capacity int) columnTypedColumnDenseGroupCountDistinctHashRankShard {
+	return newColumnTypedColumnDenseGroupCountDistinctHashRankShardWithValues(capacity, make([]string, 0, capacity))
+}
+
+func newColumnTypedColumnDenseGroupCountDistinctHashRankShardWithValues(capacity int, values []string) columnTypedColumnDenseGroupCountDistinctHashRankShard {
+	if cap(values) < capacity {
+		values = make([]string, 0, capacity)
+	} else {
+		values = values[:0]
+	}
 	return columnTypedColumnDenseGroupCountDistinctHashRankShard{
-		ranks:  make(map[uint64]uint32, columnTypedColumnDenseGroupCountDistinctRankMapCapacity(capacity)),
-		values: make([]string, 0, capacity),
+		ranks:  make(map[uint32]uint32, columnTypedColumnDenseGroupCountDistinctRankMapCapacity(capacity)),
+		values: values,
 	}
 }
 
@@ -1920,7 +1926,7 @@ func (s *columnTypedColumnDenseGroupCountDistinctHashRankShard) cardinality() in
 	return len(s.values)
 }
 
-func (s *columnTypedColumnDenseGroupCountDistinctHashRankShard) lookupHash(hash uint64, value string) (uint32, bool) {
+func (s *columnTypedColumnDenseGroupCountDistinctHashRankShard) lookupHash(hash uint32, value string) (uint32, bool) {
 	if s == nil || len(s.ranks) == 0 {
 		return 0, false
 	}
@@ -1939,7 +1945,7 @@ func (s *columnTypedColumnDenseGroupCountDistinctHashRankShard) lookupHash(hash 
 	return 0, false
 }
 
-func (s *columnTypedColumnDenseGroupCountDistinctHashRankShard) addHash(hash uint64, value string) (uint32, error) {
+func (s *columnTypedColumnDenseGroupCountDistinctHashRankShard) addHash(hash uint32, value string) (uint32, error) {
 	if rank, ok := s.lookupHash(hash, value); ok {
 		return rank, nil
 	}
@@ -1949,7 +1955,7 @@ func (s *columnTypedColumnDenseGroupCountDistinctHashRankShard) addHash(hash uin
 	rank := uint32(len(s.values))
 	if _, exists := s.ranks[hash]; exists {
 		if s.collisions == nil {
-			s.collisions = make(map[uint64][]uint32)
+			s.collisions = make(map[uint32][]uint32)
 		}
 		s.collisions[hash] = append(s.collisions[hash], rank)
 	} else {
@@ -1961,10 +1967,12 @@ func (s *columnTypedColumnDenseGroupCountDistinctHashRankShard) addHash(hash uin
 
 func columnTypedColumnDenseGroupCountDistinctBuildHashShardedRanksFromRefPartitions(parts []columnTypedColumnPhysicalQueryPart, partitions columnTypedColumnDenseGroupCountDistinctShardRankRefPartitions, shardCount, emptyShardIdx int, workers int) ([]columnTypedColumnDenseGroupCountDistinctHashRankShard, error) {
 	shards := make([]columnTypedColumnDenseGroupCountDistinctHashRankShard, shardCount)
+	capacities := columnTypedColumnDenseGroupCountDistinctHashShardRankCapacities(partitions, shardCount, emptyShardIdx)
+	valueSlices := columnTypedColumnDenseGroupCountDistinctHashShardRankValueSlices(capacities)
 	errs := make([]error, shardCount)
 	if workers < 2 || shardCount < 2 {
 		for shardIdx := 0; shardIdx < shardCount; shardIdx++ {
-			shards[shardIdx], errs[shardIdx] = columnTypedColumnDenseGroupCountDistinctBuildHashShardRanksFromRefPartitions(parts, partitions, shardIdx, shardIdx == emptyShardIdx)
+			shards[shardIdx], errs[shardIdx] = columnTypedColumnDenseGroupCountDistinctBuildHashShardRanksFromRefPartitions(parts, partitions, shardIdx, shardIdx == emptyShardIdx, capacities[shardIdx], valueSlices[shardIdx])
 			if errs[shardIdx] != nil {
 				return nil, errs[shardIdx]
 			}
@@ -1979,7 +1987,7 @@ func columnTypedColumnDenseGroupCountDistinctBuildHashShardedRanksFromRefPartiti
 		go func() {
 			defer wg.Done()
 			for shardIdx := range jobs {
-				shards[shardIdx], errs[shardIdx] = columnTypedColumnDenseGroupCountDistinctBuildHashShardRanksFromRefPartitions(parts, partitions, shardIdx, shardIdx == emptyShardIdx)
+				shards[shardIdx], errs[shardIdx] = columnTypedColumnDenseGroupCountDistinctBuildHashShardRanksFromRefPartitions(parts, partitions, shardIdx, shardIdx == emptyShardIdx, capacities[shardIdx], valueSlices[shardIdx])
 			}
 		}()
 	}
@@ -1996,18 +2004,40 @@ func columnTypedColumnDenseGroupCountDistinctBuildHashShardedRanksFromRefPartiti
 	return shards, nil
 }
 
-func columnTypedColumnDenseGroupCountDistinctBuildHashShardRanksFromRefPartitions(parts []columnTypedColumnPhysicalQueryPart, partitions columnTypedColumnDenseGroupCountDistinctShardRankRefPartitions, shardIdx int, includeEmpty bool) (columnTypedColumnDenseGroupCountDistinctHashRankShard, error) {
-	capacity := 0
-	for partitionIdx := range partitions {
-		capacity += len(partitions[partitionIdx][shardIdx])
+func columnTypedColumnDenseGroupCountDistinctHashShardRankCapacities(partitions columnTypedColumnDenseGroupCountDistinctShardRankRefPartitions, shardCount, emptyShardIdx int) []int {
+	capacities := make([]int, shardCount)
+	for shardIdx := 0; shardIdx < shardCount; shardIdx++ {
+		for partitionIdx := range partitions {
+			capacities[shardIdx] += len(partitions[partitionIdx][shardIdx])
+		}
+		if shardIdx == emptyShardIdx {
+			capacities[shardIdx]++
+		}
 	}
-	if includeEmpty {
-		capacity++
+	return capacities
+}
+
+func columnTypedColumnDenseGroupCountDistinctHashShardRankValueSlices(capacities []int) [][]string {
+	total := 0
+	for _, capacity := range capacities {
+		total += capacity
 	}
-	ranks := newColumnTypedColumnDenseGroupCountDistinctHashRankShard(capacity)
+	storage := make([]string, total)
+	values := make([][]string, len(capacities))
+	offset := 0
+	for shardIdx, capacity := range capacities {
+		values[shardIdx] = storage[offset : offset : offset+capacity]
+		offset += capacity
+	}
+	return values
+}
+
+func columnTypedColumnDenseGroupCountDistinctBuildHashShardRanksFromRefPartitions(parts []columnTypedColumnPhysicalQueryPart, partitions columnTypedColumnDenseGroupCountDistinctShardRankRefPartitions, shardIdx int, includeEmpty bool, capacity int, values []string) (columnTypedColumnDenseGroupCountDistinctHashRankShard, error) {
+	ranks := newColumnTypedColumnDenseGroupCountDistinctHashRankShardWithValues(capacity, values)
 	for partitionIdx := range partitions {
 		for _, ref := range partitions[partitionIdx][shardIdx] {
-			partIdx, localCode := columnTypedColumnDenseGroupCountDistinctUnpackRankRef(ref.ref)
+			partIdx := int(ref.partIdx)
+			localCode := int(ref.localCode)
 			if partIdx < 0 || partIdx >= len(parts) {
 				return columnTypedColumnDenseGroupCountDistinctHashRankShard{}, fmt.Errorf("collections: dense grouped count-distinct part reference=%d outside parts=%d", partIdx, len(parts))
 			}
@@ -2027,7 +2057,7 @@ func columnTypedColumnDenseGroupCountDistinctBuildHashShardRanksFromRefPartition
 		}
 	}
 	if includeEmpty {
-		emptyHash := columnTypedColumnDenseGroupCountDistinctStableRankHash("")
+		emptyHash := uint32(columnTypedColumnDenseGroupCountDistinctStableRankHash(""))
 		if _, err := ranks.addHash(emptyHash, ""); err != nil {
 			return columnTypedColumnDenseGroupCountDistinctHashRankShard{}, err
 		}
@@ -2078,7 +2108,8 @@ func columnTypedColumnDenseGroupCountDistinctAddShardRankOffset(parts []columnTy
 		return nil
 	}
 	for _, ref := range refs {
-		partIdx, localCode := columnTypedColumnDenseGroupCountDistinctUnpackRankRef(ref.ref)
+		partIdx := int(ref.partIdx)
+		localCode := int(ref.localCode)
 		if partIdx < 0 || partIdx >= len(parts) {
 			return fmt.Errorf("collections: dense grouped count-distinct part reference=%d outside parts=%d", partIdx, len(parts))
 		}


### PR DESCRIPTION
## Summary

- carry a compact stable q2 distinct-rank fingerprint with each sharded rank reference so the shard build path avoids rehashing dictionary values while assigning global ranks
- build collision-safe hash-keyed rank shards with value/collision checks and one shared value backing slice across shards
- add direct collision coverage for the hash-rank shard and update shard-ref ordering assertions for the richer ref type

## Scope and claim boundary

This is no-aggregate, one-shot typed-column q2 setup/post-prepare work only. It is not metadata acceleration evidence and is not a ClickHouse comparison claim. q1/q3 setup code is not touched.

## Evidence

Focused correctness:

```sh
env GOROOT=/home/mikers/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.26.0.linux-amd64 \
  GOCACHE=/mnt/fast4tb/gomap-profiles/q2-current-head-evidence-20260630_121425/go-cache/gocache \
  GOMODCACHE=/mnt/fast4tb/gomap-profiles/q2-current-head-evidence-20260630_121425/go-cache/gomodcache \
  GOTMPDIR=/mnt/fast4tb/gomap-profiles/q2-current-head-evidence-20260630_121425/go-cache/tmp \
  TMPDIR=/mnt/fast4tb/gomap-profiles/q2-current-head-evidence-20260630_121425/go-cache/tmp \
  XDG_CONFIG_HOME=/mnt/fast4tb/gomap-profiles/q2-current-head-evidence-20260630_121425/go-cache/config \
  GOFLAGS=-buildvcs=false GOTOOLCHAIN=local GOTELEMETRY=off GOWORK=off \
  /home/mikers/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.26.0.linux-amd64/bin/go test ./TreeDB/collections \
  -run 'TestTypedColumnQ2DenseGroupCountDistinct(GlobalRankPrepHarness|ShardedHashRankPrepEquivalence|AdaptiveRankPrepPolicy|OneShotRankPrepMatchesAdaptivePolicy|ShardedReferenceFillNullableEmpty|HashRankShardCollision|ShardRankRefsParallelMatchesSerial|ShardedHashRankRunEquivalence)|TestTypedColumnQ2DenseGroupCountDistinctNoSortLocalDictionaries1950|TestTypedColumnQ2DenseGroupCountDistinctLocalCodesNullableValues3080'
```

Result: pass.

Broader package:

```sh
GOWORK=off go test ./TreeDB/collections
```

Result: pass (`85.034s`) using the Go 1.26 toolchain/cache env above.

Synthetic q2 adaptive rank-prep benchmark, filtered to matching `adaptive/{mostly_disjoint,mixed}` rows:

- artifact: `/mnt/fast4tb/gomap-profiles/q2-hash-rank-carry-shared-values-20260630_132058/benchstat_main_vs_hash_carry_shared_values_adaptive_filtered.txt`
- `sec/op` geomean: `8.330ms -> 7.796ms` (`-6.41%`)
- `diag_dense_distinct_rank_build_shards_ns/op` geomean: `4.256ms -> 3.186ms` (`-25.13%`)
- `diag_dense_distinct_rank_collect_refs_ns/op` geomean: `840.0us -> 1.313ms` (`+56.26%`)
- `B/op` geomean: `11.12MiB -> 10.56MiB` (`-5.05%`)
- `allocs/op` geomean: `1.325k -> 1.334k` (`+0.64%`)

1M JSONBench q2 production-shape cell (`one_shot_end_to_end` / `no_aggregate_metadata`, tries=1):

- artifact: `/mnt/fast4tb/gomap-profiles/q2-hash-rank-carry-shared-values-20260630_132058/jsonbench_q2_noagg_1m/report.json`
- baseline artifact: `/mnt/fast4tb/gomap-profiles/q2-current-head-evidence-20260630_121425/jsonbench_q1q2q3_noagg_1m/report.json`
- total: `90.565ms -> 78.974ms`
- setup: `64.459ms -> 58.445ms`
- post-prepare: `29.133ms -> 25.110ms`
- run: `26.068ms -> 20.476ms`
- q2 dense distinct global-rank: `24.686ms -> 20.695ms`
- q2 dense distinct build-shards: `21.755ms -> 12.143ms`
- q2 dense distinct collect-refs: `2.929ms -> 8.551ms`
- rows scanned/matched/reduced preserved: `1,000,000 / 954,611 / 954,611`
- result hash preserved: `b63b8e1013c918fcda7c299ef64beb20c4988854cf0671a83803b6951d795860`

Refs #3324.
Refs #3070.
