### PR TITLE
Prefer sharded q2 rank prep in parallel

### DIFF
--- a/TreeDB/collections/column_physical_q2_global_rank_prep_bench_test.go
+++ b/TreeDB/collections/column_physical_q2_global_rank_prep_bench_test.go
@@ -3,6 +3,7 @@ package collections
 import (
 	"fmt"
 	"reflect"
+	"runtime"
 	"sort"
 	"testing"
 )
@@ -41,6 +42,13 @@ var q2DenseGlobalRankPrepBenchmarkVariants = []q2DenseGlobalRankPrepVariant{
 		prepare: prepareColumnTypedColumnDenseGroupCountDistinctGlobalRankMapsWithDiagnostics,
 		strategy: func([]columnTypedColumnPhysicalQueryPart) columnTypedColumnDenseGroupCountDistinctRankStrategy {
 			return columnTypedColumnDenseGroupCountDistinctRankStrategyCurrentMap
+		},
+	},
+	{
+		name:    "sharded_hash_rank",
+		prepare: prepareColumnTypedColumnDenseGroupCountDistinctGlobalRankMapsShardedWithDiagnostics,
+		strategy: func([]columnTypedColumnPhysicalQueryPart) columnTypedColumnDenseGroupCountDistinctRankStrategy {
+			return columnTypedColumnDenseGroupCountDistinctRankStrategyShardedHash
 		},
 	},
 	{
@@ -148,9 +156,6 @@ func TestTypedColumnQ2DenseGroupCountDistinctAdaptiveRankPrepPolicy(t *testing.T
 				return &part.Distinct
 			})
 			want := columnTypedColumnDenseGroupCountDistinctRankStrategyShardedHash
-			if shape.name == "shared_heavy" {
-				want = columnTypedColumnDenseGroupCountDistinctRankStrategyCurrentMap
-			}
 			if strategy != want {
 				t.Fatalf("adaptive rank strategy=%v want %v", strategy, want)
 			}
@@ -167,6 +172,19 @@ func TestTypedColumnQ2DenseGroupCountDistinctAdaptiveRankPrepPolicy(t *testing.T
 			assertQ2DenseGlobalRankPrepParts(t, adaptive, stats)
 			assertQ2DenseGlobalRankPrepEquivalent(t, baseline, adaptive, stats)
 		})
+	}
+}
+
+func TestTypedColumnQ2DenseGroupCountDistinctAdaptiveRankPrepPolicySerialSharedFallback(t *testing.T) {
+	oldProcs := runtime.GOMAXPROCS(1)
+	defer runtime.GOMAXPROCS(oldProcs)
+
+	parts := newQ2DenseGlobalRankPrepParts(40, q2DenseGlobalRankPrepDictionaryShape{name: "shared_heavy"})
+	strategy := columnTypedColumnDenseGroupCountDistinctSelectAdaptiveGlobalRankStrategy(parts, func(part *columnTypedColumnDenseGroupCountDistinctPart) *columnTypedColumnDenseStringCodeColumn {
+		return &part.Distinct
+	})
+	if strategy != columnTypedColumnDenseGroupCountDistinctRankStrategyCurrentMap {
+		t.Fatalf("serial shared adaptive rank strategy=%v want %v", strategy, columnTypedColumnDenseGroupCountDistinctRankStrategyCurrentMap)
 	}
 }
 

--- a/TreeDB/collections/column_physical_typed_column_query.go
+++ b/TreeDB/collections/column_physical_typed_column_query.go
@@ -2266,6 +2266,9 @@ func columnTypedColumnDenseGroupCountDistinctSelectAdaptiveGlobalRankStrategy(pa
 		maxUniqueToLocalNumerator = 2
 		uniqueToLocalDenominator  = 5
 	)
+	if columnTypedColumnPhysicalQueryPartDecodeWorkers(len(parts)) > 1 {
+		return columnTypedColumnDenseGroupCountDistinctRankStrategyShardedHash
+	}
 	values := make(map[string]struct{}, minSampleValues/2)
 	localValues := 0
 	limit := min(len(parts), sampleParts)


### PR DESCRIPTION
## Summary

- Prefer the sharded dense q2 global-rank prep path whenever parallel part decode/rank prep workers are available.
- Keep the existing current-map strategy as the serial/shared fallback.
- Add q2 policy coverage for the parallel choice, serial fallback, and an explicit `sharded_hash_rank` benchmark variant.

## Evidence

Claim boundary: this is no-aggregate one-shot typed-column q2 setup work only. It is not metadata acceleration and does not claim TreeDB/ClickHouse superiority.

Baseline current-head artifact after #3410:
`/mnt/fast4tb/gomap-profiles/q2-current-head-evidence-20260630_121425/jsonbench_q1q2q3_main_after3410_noagg_1m/report.json`

New artifact:
`/mnt/fast4tb/gomap-profiles/q2-current-head-evidence-20260630_121425/jsonbench_q1q2q3_adaptive_parallel_policy_1m_20260630_150011/report.json`

1M `one_shot_end_to_end` / `no_aggregate_metadata` / `column-store-full-prepared`:

| query | total | setup | post-prepare | run | hash |
| --- | ---: | ---: | ---: | ---: | --- |
| q2 baseline | 66.660ms | 46.376ms | 19.702ms | 20.244ms | `b63b8e1013c918fcda7c299ef64beb20c4988854cf0671a83803b6951d795860` |
| q2 this PR | 56.915ms | 38.732ms | 12.305ms | 18.151ms | `b63b8e1013c918fcda7c299ef64beb20c4988854cf0671a83803b6951d795860` |

q2 rows preserved: rows scanned 1,000,000; rows matched/reduced 954,611.

q2 post-prepare split in the new artifact:

- dense group global rank: 0.033ms
- dense distinct global rank: 11.354ms
- dense part local rank: 0.917ms
- sharded plan: 0.001ms
- sharded collect refs: 1.959ms
- sharded build shards: 9.394ms
- sharded rank shards: 32
- sharded rank refs: 627,646
- sharded global ranks: 180,100

q1/q3 sample from the same artifact for no-regression context:

| query | total | setup | run | hash |
| --- | ---: | ---: | ---: | --- |
| q1 baseline | 11.856ms | 11.416ms | 0.383ms | `059afea7bfbfb7d188ccc441b326301b063975713996169dfd43563420d11492` |
| q1 this PR | 10.613ms | 10.254ms | 0.328ms | `059afea7bfbfb7d188ccc441b326301b063975713996169dfd43563420d11492` |
| q3 baseline | 30.356ms | 26.790ms | 3.540ms | `cdb6acc4d0d990bdbdab5d2f29df85943490b2cb6b950351cbfa9bd974a182eb` |
| q3 this PR | 29.487ms | 25.915ms | 3.553ms | `cdb6acc4d0d990bdbdab5d2f29df85943490b2cb6b950351cbfa9bd974a182eb` |

Microbench artifact:
`/mnt/fast4tb/gomap-profiles/q2-current-head-evidence-20260630_121425/q2_adaptive_parallel_policy_bench_20260630_145520.txt`

## Validation

- `go test ./TreeDB/collections -run 'TestTypedColumnQ2DenseGroupCountDistinct|TestColumnPhysicalTypedColumnOneShotCacheQ2NoMetadata3123' -count=1`
- `go test ./cmd/unified_bench`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved adaptive rank-prep behavior for dense group count distinct queries, especially for shared-heavy data under single-threaded execution.
  * Added a fallback path so serial runs use the expected strategy when sharded processing is not available.
  * Made strategy selection more consistent by choosing the sharded-hash approach whenever multiple decode workers are used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->