### PR TITLE
Tighten q2 dense rank hash insertion

### DIFF
--- a/TreeDB/collections/column_physical_q2_global_rank_prep_bench_test.go
+++ b/TreeDB/collections/column_physical_q2_global_rank_prep_bench_test.go
@@ -79,7 +79,7 @@ var q2DenseGlobalRankPrepDictionaryShapes = []q2DenseGlobalRankPrepDictionarySha
 	{name: "mixed"},
 }
 
-var q2DenseGlobalRankPrepPartCounts = []int{40, 80, 160}
+var q2DenseGlobalRankPrepPartCounts = []int{40, 80, 160, 320}
 
 const (
 	q2DenseGlobalRankPrepGroupValuesPerPart    = 128

--- a/TreeDB/collections/column_physical_typed_column_query.go
+++ b/TreeDB/collections/column_physical_typed_column_query.go
@@ -1946,21 +1946,31 @@ func (s *columnTypedColumnDenseGroupCountDistinctHashRankShard) lookupHash(hash 
 }
 
 func (s *columnTypedColumnDenseGroupCountDistinctHashRankShard) addHash(hash uint32, value string) (uint32, error) {
-	if rank, ok := s.lookupHash(hash, value); ok {
+	if existingRank, exists := s.ranks[hash]; exists {
+		if int(existingRank) < len(s.values) && s.values[existingRank] == value {
+			return existingRank, nil
+		}
+		for _, collisionRank := range s.collisions[hash] {
+			if int(collisionRank) < len(s.values) && s.values[collisionRank] == value {
+				return collisionRank, nil
+			}
+		}
+		if uint64(len(s.values)) >= uint64(^uint32(0)) {
+			return 0, fmt.Errorf("collections: dense grouped count-distinct global dictionary cardinality exceeds uint32")
+		}
+		rank := uint32(len(s.values))
+		if s.collisions == nil {
+			s.collisions = make(map[uint32][]uint32)
+		}
+		s.collisions[hash] = append(s.collisions[hash], rank)
+		s.values = append(s.values, value)
 		return rank, nil
 	}
 	if uint64(len(s.values)) >= uint64(^uint32(0)) {
 		return 0, fmt.Errorf("collections: dense grouped count-distinct global dictionary cardinality exceeds uint32")
 	}
 	rank := uint32(len(s.values))
-	if _, exists := s.ranks[hash]; exists {
-		if s.collisions == nil {
-			s.collisions = make(map[uint32][]uint32)
-		}
-		s.collisions[hash] = append(s.collisions[hash], rank)
-	} else {
-		s.ranks[hash] = rank
-	}
+	s.ranks[hash] = rank
 	s.values = append(s.values, value)
 	return rank, nil
 }


### PR DESCRIPTION
## Summary
- avoid a duplicate hash-rank map lookup in the q2 dense grouped-count-distinct rank shard insertion path
- keep collision-list behavior and cardinality checks intact
- extend the q2 dense global-rank prep benchmark with the 320-part case used by the production-scale evidence command

Refs #3324 and #3070.

## Scope / claim boundary
This is q2 `one_shot_end_to_end` / `no_aggregate_metadata` typed-column setup subphase work only. It is not aggregate metadata acceleration, not a ClickHouse comparison, and not a durability, load-path, or on-disk-format change.

This PR is draft because the targeted post-prepare/dense-rank subphase improved, but the single 1M one-shot sample did not improve total/setup/run. Do not present it as a production q2 end-to-end win unless follow-up evidence changes that.

## Local validation
- `GOWORK=off go test ./TreeDB/collections -run 'TestTypedColumnQ2DenseGroupCountDistinct|TestTypedColumnQ2|Q2|q2' -count=1`
- `GOWORK=off go test ./TreeDB/collections -run 'TestTypedColumnQ2DenseGroupCountDistinct(HashRankShardCollision|ShardedHashRankPrepEquivalence|ShardedReferenceFillNullableEmpty|ShardRankRefsParallelMatchesSerial|AdaptiveRankRunEquivalence)$' -count=1`
- `GOWORK=off go test ./TreeDB/collections -count=1`
- `git diff --check`

## Microbench evidence
Artifact: `/mnt/fast4tb/gomap-profiles/q2-addhash-single-lookup-eval-20260630_175841/benchstat.txt`

Current main vs this branch, 320-part q2 dense global-rank prep:

- rank-prep `sec/op` geomean: `20.11ms -> 19.56ms` (`-2.73%`)
- dense distinct rank build shards geomean: `10.03ms -> 9.445ms` (`-5.82%`)
- q2 distinct rank geomean: `12.61ms -> 12.06ms` (`-4.41%`)
- `B/op`: flat (`37.89Mi -> 37.89Mi`)
- `allocs/op`: flat (`3.434k -> 3.434k`)

Significant rows included:

- `sharded_hash_rank/mostly_disjoint/parts=320`: `25.57ms -> 24.53ms` (`-4.06%`, p=0.026)
- `adaptive/mostly_disjoint/parts=320`: `25.56ms -> 24.27ms` (`-5.04%`, p=0.001)
- `adaptive/mixed/parts=320`: `20.56ms -> 20.09ms` (`-2.28%`, p=0.004)

## 1M JSONBench evidence
Artifact: `/mnt/fast4tb/gomap-profiles/q2-addhash-single-lookup-jsonbench-20260630_180328/report.json`

Both rows are q2 `one_shot_end_to_end` / `no_aggregate_metadata` / `column-store-full-prepared`; baseline row first, candidate row second.

Targeted subphase movement:

- post-prepare: `13.678ms -> 13.293ms`
- dense distinct global rank: `12.687ms -> 12.236ms`
- dense distinct collect refs: `2.428ms -> 1.973ms`
- dense distinct build shards: `10.258ms -> 10.262ms`

Preserved query shape/correctness signals:

- rows scanned/matched/reduced: `1,000,000 / 954,611 / 954,611` in both rows
- result hash: `b63b8e1013c918fcda7c299ef64beb20c4988854cf0671a83803b6951d795860` in both raw results
- physical bytes scanned: `15,991,989` in both rows
- decoded payload bytes: `32,925,252` in both rows
- row/document materializations: `0 / 0` in both rows
- aggregate metadata used: `false`
- fallback reason: `none`

Primary metric caveat from the same 1M sample:

- total: `56.426ms -> 59.769ms`
- setup: `38.508ms -> 39.955ms`
- run: `17.868ms -> 19.766ms`
- render/hash: `0.050ms -> 0.047ms`

Interpretation: this is a narrow setup-subphase improvement with stable counters and no added allocation cost, but it did not show a one-shot total/setup/run win in the single 1M cell.
