### PR TITLE
Speed retained semantic-stream path interning

### DIFF
--- a/TreeDB/collections/column_retained_semantic_stream.go
+++ b/TreeDB/collections/column_retained_semantic_stream.go
@@ -159,22 +159,54 @@ type columnRetainedSemanticStreamV1DeclaredPathTrie struct {
 }
 
 type columnRetainedSemanticStreamV1PathSegmentInterner struct {
+	values   []string
 	segments map[string]string
 }
+
+const columnRetainedSemanticStreamV1PathSegmentInternerLinearLimit = 16
 
 func (i *columnRetainedSemanticStreamV1PathSegmentInterner) intern(key []byte) string {
 	if i == nil {
 		return string(key)
 	}
-	if value, ok := i.segments[string(key)]; ok {
+	if len(key) == 0 {
+		return ""
+	}
+	if i.segments != nil {
+		if value, ok := i.segments[string(key)]; ok {
+			return value
+		}
+		value := string(key)
+		i.segments[value] = value
 		return value
 	}
-	value := string(key)
-	if i.segments == nil {
-		i.segments = make(map[string]string)
+	for _, value := range i.values {
+		if columnRetainedSemanticStreamV1StringBytesEqual(value, key) {
+			return value
+		}
 	}
-	i.segments[value] = value
+	value := string(key)
+	i.values = append(i.values, value)
+	if len(i.values) > columnRetainedSemanticStreamV1PathSegmentInternerLinearLimit {
+		i.segments = make(map[string]string, len(i.values)*2)
+		for _, value := range i.values {
+			i.segments[value] = value
+		}
+		i.values = nil
+	}
 	return value
+}
+
+func columnRetainedSemanticStreamV1StringBytesEqual(value string, key []byte) bool {
+	if len(value) != len(key) {
+		return false
+	}
+	for i := range key {
+		if value[i] != key[i] {
+			return false
+		}
+	}
+	return true
 }
 
 type columnRetainedSemanticStreamV1DecodeCache struct {

--- a/TreeDB/collections/column_retained_semantic_stream.go
+++ b/TreeDB/collections/column_retained_semantic_stream.go
@@ -173,12 +173,12 @@ func (i *columnRetainedSemanticStreamV1PathSegmentInterner) intern(key []byte) s
 		return ""
 	}
 	if i.segments != nil {
-		keyStr := string(key)
-		if value, ok := i.segments[keyStr]; ok {
+		if value, ok := i.segments[string(key)]; ok {
 			return value
 		}
-		i.segments[keyStr] = keyStr
-		return keyStr
+		value := string(key)
+		i.segments[value] = value
+		return value
 	}
 	for _, value := range i.values {
 		if columnRetainedSemanticStreamV1StringBytesEqual(value, key) {

--- a/TreeDB/collections/column_retained_semantic_stream.go
+++ b/TreeDB/collections/column_retained_semantic_stream.go
@@ -173,12 +173,12 @@ func (i *columnRetainedSemanticStreamV1PathSegmentInterner) intern(key []byte) s
 		return ""
 	}
 	if i.segments != nil {
-		if value, ok := i.segments[string(key)]; ok {
+		keyStr := string(key)
+		if value, ok := i.segments[keyStr]; ok {
 			return value
 		}
-		value := string(key)
-		i.segments[value] = value
-		return value
+		i.segments[keyStr] = keyStr
+		return keyStr
 	}
 	for _, value := range i.values {
 		if columnRetainedSemanticStreamV1StringBytesEqual(value, key) {

--- a/TreeDB/collections/column_retained_semantic_stream_raw_test.go
+++ b/TreeDB/collections/column_retained_semantic_stream_raw_test.go
@@ -348,6 +348,54 @@ func TestColumnRetainedSemanticStreamV1PathSegmentInternerOwnsAndReusesSegments3
 	}
 }
 
+func TestColumnRetainedSemanticStreamV1PathSegmentInternerTransitionsToMap3067(t *testing.T) {
+	interner := &columnRetainedSemanticStreamV1PathSegmentInterner{}
+	sources := make([][]byte, columnRetainedSemanticStreamV1PathSegmentInternerLinearLimit+1)
+	values := make([]string, len(sources))
+	for i := range sources {
+		source := []byte{byte('a' + i)}
+		sources[i] = source
+		values[i] = interner.intern(source)
+		source[0] = byte('A' + i)
+	}
+	if interner.segments == nil {
+		t.Fatal("path segment interner did not transition to map after linear limit")
+	}
+	if len(interner.values) != 0 {
+		t.Fatalf("path segment interner retained %d linear values after map transition", len(interner.values))
+	}
+	if len(interner.segments) != len(sources) {
+		t.Fatalf("path segment interner map entries=%d want %d", len(interner.segments), len(sources))
+	}
+	for i, value := range values {
+		want := string([]byte{byte('a' + i)})
+		if value != want {
+			t.Fatalf("value %d=%q want %q", i, value, want)
+		}
+		got := interner.intern([]byte{byte('a' + i)})
+		if got != want {
+			t.Fatalf("reused value %d=%q want %q", i, got, want)
+		}
+		if !columnRetainedSemanticStreamV1TestStringsShareBacking(value, got) {
+			t.Fatalf("reused value %d does not share backing after map transition", i)
+		}
+		if columnRetainedSemanticStreamV1TestStringAliasesBytes(got, sources[i]) {
+			t.Fatalf("reused value %d aliases mutable source bytes after map transition", i)
+		}
+	}
+
+	postTransition := []byte("post")
+	first := interner.intern(postTransition)
+	copy(postTransition, []byte("mut!"))
+	second := interner.intern([]byte("post"))
+	if first != "post" || second != "post" {
+		t.Fatalf("post-transition values=(%q, %q) want post", first, second)
+	}
+	if !columnRetainedSemanticStreamV1TestStringsShareBacking(first, second) {
+		t.Fatal("post-transition repeated segment does not reuse string backing")
+	}
+}
+
 func TestColumnRetainedSemanticStreamV1PathSegmentInternerReusesRetainedTraversalSegments3206(t *testing.T) {
 	cfg := ColumnStoreConfig{
 		Enabled: true,


### PR DESCRIPTION
## Scope

Load/write-path preparation only. This does not change query execution, aggregate metadata, ClickHouse comparison framing, value-log durability, WAL behavior, sync policy, or on-disk format.

Linked trackers: #3067, #3099, #3151, #3070.

## Change

Adds a small linear cache in the retained semantic-stream path segment interner before falling back to the existing map. This avoids block-local map churn for the common tiny path-segment set while preserving the existing map path for larger segment sets.

## Performance Evidence

Focused retained semantic-stream prepare benchstat:

- baseline: `/tmp/treedb_retained_root_prepare_baseline_MQaoNl/focused_bench_baseline.txt`
- candidate: `/tmp/treedb_retained_root_prepare_after_gz2vw1/focused_bench_after.txt`
- benchstat: `/tmp/treedb_retained_root_prepare_after_gz2vw1/focused_bench_benchstat.txt`

Results:

| benchmark | before | after | change |
| --- | ---: | ---: | ---: |
| RootFastPath | `15.03ms/op` | `13.13ms/op` | `-12.62%` |
| RootFastPathMultiBlock | `22.20ms/op` | `19.11ms/op` | `-13.91%` |
| NestedDeclaredPaths | `16.57ms/op` | `14.99ms/op` | `-9.55%` |
| geomean | `17.68ms/op` | `15.55ms/op` | `-12.05%` |

Stored block bytes, stored/input, and alloc counts were stable in the benchstat output.

100k durable unified-bench gate:

- artifact dir: `/tmp/treedb_jsonbench_load_retained_20260630_191539`
- `ingest_insert_batch`: `1111.452ms`
- `retained_payload_prepare`: `132.703ms`, `1327.0 ns/row`
- `retained_payload_declared_rows`: `100000`
- `retained_payload_semantic_stream_blocks`: `100`
- `retained_stream_value_log_values`: `100`
- q1 parity: pass

## Validation

```sh
GOWORK=off go test ./TreeDB/collections -run 'TestColumnRetainedSemanticStreamV1(InsertFastPathMatchesRetainedJSONPipeline3067|RootFastPathPreparesDeclaredRows|NestedDeclaredPathsMatchRetainedJSONPipeline|InsertBatchRoundTripReopen|SideRootRewrite|ReclaimsSideBlockAfterDelete|ReclaimsSideBlockAfterUpdateBatch)' -count=1
GOWORK=off go test ./TreeDB/collections -run 'TestColumnRetainedSemanticStreamV1' -count=1
GOWORK=off go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnRetainedPayloadSemanticStreamV1Prepare(RootFastPath|RootFastPathMultiBlock|NestedDeclaredPaths)' -benchmem -count=5
GOWORK=off go build -o ./bin/unified-bench ./cmd/unified_bench
```