### PR TITLE
Coalesce typed-column prepared metadata reads

### DIFF
--- a/TreeDB/collections/typed_column_adapter.go
+++ b/TreeDB/collections/typed_column_adapter.go
@@ -1667,7 +1667,9 @@ func decodeTypedColumnPhysicalQueryDensePartFromRanges(plan columnTypedColumnPhy
 	if err := reader.ensureFullAssetValidated(); err != nil {
 		return columnTypedColumnPhysicalQueryPart{}, true, err
 	}
-	prepared, diag, err := typedColumnPreparePartStateFromRanges(typedRef.Ref, physical.Ref, typedRef.Rows, physical.Rows, plan.Fields, schemaHash, requests, reader.readRange, nil)
+	prepared, diag, err := typedColumnPreparePartStateFromRangesWithOptions(typedRef.Ref, physical.Ref, typedRef.Rows, physical.Rows, plan.Fields, schemaHash, requests, reader.readRange, nil, typedColumnPreparePartStateOptions{
+		CoalescePreparedMetadataReads: true,
+	})
 	if prepareDiagnostics != nil {
 		prepareDiagnostics.ReadImageNanos += diag.ReadImageNanos
 		prepareDiagnostics.StateBuildNanos += diag.StateBuildNanos

--- a/TreeDB/collections/typed_column_prepared_state.go
+++ b/TreeDB/collections/typed_column_prepared_state.go
@@ -539,28 +539,38 @@ func typedColumnPreparedPrefetchMetadataSections(image typedcolumn.ColumnPartIma
 	}
 	var sections [maxTypedColumnPreparedMetadataBatchSections]typedcolumn.ColumnPartImageSection
 	sectionN := 0
-	appendSection := func(section typedcolumn.ColumnPartImageSection) {
+	appendSection := func(section typedcolumn.ColumnPartImageSection) error {
+		if sectionN >= len(sections) {
+			return fmt.Errorf("collections: typed-column prepared metadata prefetch section count exceeds %d", len(sections))
+		}
 		sections[sectionN] = section
 		sectionN++
+		return nil
 	}
 	descriptorSection, err := typedColumnAdapterImageSingleSection(image, typedcolumn.ColumnPartImageSectionDescriptor)
 	if err != nil {
 		return err
 	}
-	appendSection(descriptorSection)
+	if err := appendSection(descriptorSection); err != nil {
+		return err
+	}
 	if typedColumnPreparedRequestsIncludeSortKeyMetadata(requests) {
 		metadataSection, err := typedColumnAdapterImageSingleSection(image, typedcolumn.ColumnPartImageSectionSortKeyMetadata)
 		if err != nil {
 			return err
 		}
-		appendSection(metadataSection)
+		if err := appendSection(metadataSection); err != nil {
+			return err
+		}
 	}
 	if typedColumnPreparedRequestsIncludeSortKeyMarks(requests) {
 		marksSection, err := typedColumnAdapterImageSingleSection(image, typedcolumn.ColumnPartImageSectionSortKeyMarks)
 		if err != nil {
 			return err
 		}
-		appendSection(marksSection)
+		if err := appendSection(marksSection); err != nil {
+			return err
+		}
 	}
 	if typedColumnPreparedRequestsIncludeStats(requests) {
 		statsSection, ok, err := image.ColumnStatsSection()
@@ -568,7 +578,9 @@ func typedColumnPreparedPrefetchMetadataSections(image typedcolumn.ColumnPartIma
 			return err
 		}
 		if ok {
-			appendSection(statsSection)
+			if err := appendSection(statsSection); err != nil {
+				return err
+			}
 		}
 	}
 	if typedColumnPreparedRequestsIncludePruning(requests) {
@@ -577,7 +589,9 @@ func typedColumnPreparedPrefetchMetadataSections(image typedcolumn.ColumnPartIma
 			return err
 		}
 		if ok {
-			appendSection(pruningSection)
+			if err := appendSection(pruningSection); err != nil {
+				return err
+			}
 		}
 	}
 	if typedColumnPreparedRequestsIncludeDictionaries(requests) {
@@ -586,7 +600,9 @@ func typedColumnPreparedPrefetchMetadataSections(image typedcolumn.ColumnPartIma
 			return err
 		}
 		if dictionarySection.Length <= maxTypedColumnPreparedRangeCacheEntryBytes {
-			appendSection(dictionarySection)
+			if err := appendSection(dictionarySection); err != nil {
+				return err
+			}
 		}
 	}
 	return readCache.prefetchSections(sections[:sectionN])

--- a/TreeDB/collections/typed_column_prepared_state.go
+++ b/TreeDB/collections/typed_column_prepared_state.go
@@ -24,6 +24,7 @@ const (
 	maxTypedColumnPreparedMetadataBatchSpanBytes     = 64 << 10
 	maxTypedColumnPreparedMetadataBatchSections      = 6
 	maxTypedColumnPreparedRangeCacheEntries          = 8
+	maxTypedColumnPreparedRangeCacheEntryBytes       = maxTypedColumnPreparedMetadataBatchSpanBytes
 )
 
 // typedColumnPreparedRangeReader is the caller-owned byte access boundary used
@@ -40,7 +41,6 @@ type typedColumnPreparedRangeReadCache struct {
 	readRange typedColumnPreparedRangeReader
 	entries   [maxTypedColumnPreparedRangeCacheEntries]typedColumnPreparedRangeReadCacheEntry
 	entryN    int
-	overflow  []typedColumnPreparedRangeReadCacheEntry
 }
 
 type typedColumnPreparedRangeReadCacheEntry struct {
@@ -70,16 +70,6 @@ func (c *typedColumnPreparedRangeReadCache) read(offset int, length int, section
 		}
 		return entry.raw[start : start+length], nil
 	}
-	for _, entry := range c.overflow {
-		if entry.raw == nil || offset < entry.offset {
-			continue
-		}
-		start := offset - entry.offset
-		if start > len(entry.raw) || length > len(entry.raw)-start {
-			continue
-		}
-		return entry.raw[start : start+length], nil
-	}
 	return c.readAndStore(offset, length, section)
 }
 
@@ -94,13 +84,12 @@ func (c *typedColumnPreparedRangeReadCache) readAndStore(offset int, length int,
 	if len(raw) != length {
 		return nil, fmt.Errorf("collections: typed-column prepared range offset=%d length=%d returned bytes=%d", offset, length, len(raw))
 	}
-	entry := typedColumnPreparedRangeReadCacheEntry{offset: offset, raw: raw}
-	if c.entryN < len(c.entries) {
-		c.entries[c.entryN] = entry
-		c.entryN++
-	} else {
-		c.overflow = append(c.overflow, entry)
+	if length > maxTypedColumnPreparedRangeCacheEntryBytes || c.entryN >= len(c.entries) {
+		return raw, nil
 	}
+	entry := typedColumnPreparedRangeReadCacheEntry{offset: offset, raw: raw}
+	c.entries[c.entryN] = entry
+	c.entryN++
 	return raw, nil
 }
 
@@ -596,7 +585,9 @@ func typedColumnPreparedPrefetchMetadataSections(image typedcolumn.ColumnPartIma
 		if err != nil {
 			return err
 		}
-		appendSection(dictionarySection)
+		if dictionarySection.Length <= maxTypedColumnPreparedRangeCacheEntryBytes {
+			appendSection(dictionarySection)
+		}
 	}
 	return readCache.prefetchSections(sections[:sectionN])
 }

--- a/TreeDB/collections/typed_column_prepared_state.go
+++ b/TreeDB/collections/typed_column_prepared_state.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"sort"
 	"time"
 
 	"github.com/golang/snappy"
@@ -17,11 +18,161 @@ import (
 
 const maxTypedColumnPreparedCompressedDictionarySectionRawBytes = 256 << 20
 
+const (
+	maxTypedColumnPreparedMetadataBatchGapBytes      = 8 << 10
+	maxTypedColumnPreparedMetadataBatchOverreadBytes = 8 << 10
+	maxTypedColumnPreparedMetadataBatchSpanBytes     = 64 << 10
+	maxTypedColumnPreparedMetadataBatchSections      = 6
+	maxTypedColumnPreparedRangeCacheEntries          = 8
+)
+
 // typedColumnPreparedRangeReader is the caller-owned byte access boundary used
 // while preparing immutable typed-column state. It deliberately has no package
 // global cache; prepared callers decide how long returned metadata and mapped
 // resources stay alive.
 type typedColumnPreparedRangeReader func(offset int, length int, section bool) ([]byte, error)
+
+type typedColumnPreparePartStateOptions struct {
+	CoalescePreparedMetadataReads bool
+}
+
+type typedColumnPreparedRangeReadCache struct {
+	readRange typedColumnPreparedRangeReader
+	entries   [maxTypedColumnPreparedRangeCacheEntries]typedColumnPreparedRangeReadCacheEntry
+	entryN    int
+	overflow  []typedColumnPreparedRangeReadCacheEntry
+}
+
+type typedColumnPreparedRangeReadCacheEntry struct {
+	offset int
+	raw    []byte
+}
+
+func newTypedColumnPreparedRangeReadCache(readRange typedColumnPreparedRangeReader) *typedColumnPreparedRangeReadCache {
+	return &typedColumnPreparedRangeReadCache{readRange: readRange}
+}
+
+func (c *typedColumnPreparedRangeReadCache) read(offset int, length int, section bool) ([]byte, error) {
+	if c == nil || c.readRange == nil {
+		return nil, errors.New("collections: typed-column prepared range cache missing reader")
+	}
+	if err := validateTypedColumnPreparedRange(offset, length); err != nil {
+		return nil, err
+	}
+	for i := 0; i < c.entryN; i++ {
+		entry := c.entries[i]
+		if entry.raw == nil || offset < entry.offset {
+			continue
+		}
+		start := offset - entry.offset
+		if start > len(entry.raw) || length > len(entry.raw)-start {
+			continue
+		}
+		return entry.raw[start : start+length], nil
+	}
+	for _, entry := range c.overflow {
+		if entry.raw == nil || offset < entry.offset {
+			continue
+		}
+		start := offset - entry.offset
+		if start > len(entry.raw) || length > len(entry.raw)-start {
+			continue
+		}
+		return entry.raw[start : start+length], nil
+	}
+	return c.readAndStore(offset, length, section)
+}
+
+func (c *typedColumnPreparedRangeReadCache) readAndStore(offset int, length int, section bool) ([]byte, error) {
+	if c == nil || c.readRange == nil {
+		return nil, errors.New("collections: typed-column prepared range cache missing reader")
+	}
+	raw, err := c.readRange(offset, length, section)
+	if err != nil {
+		return nil, err
+	}
+	if len(raw) != length {
+		return nil, fmt.Errorf("collections: typed-column prepared range offset=%d length=%d returned bytes=%d", offset, length, len(raw))
+	}
+	entry := typedColumnPreparedRangeReadCacheEntry{offset: offset, raw: raw}
+	if c.entryN < len(c.entries) {
+		c.entries[c.entryN] = entry
+		c.entryN++
+	} else {
+		c.overflow = append(c.overflow, entry)
+	}
+	return raw, nil
+}
+
+func (c *typedColumnPreparedRangeReadCache) prefetchSections(sections []typedcolumn.ColumnPartImageSection) error {
+	if c == nil || len(sections) <= 1 {
+		return nil
+	}
+	var ordered [maxTypedColumnPreparedMetadataBatchSections]typedcolumn.ColumnPartImageSection
+	if len(sections) > len(ordered) {
+		return fmt.Errorf("collections: typed-column prepared metadata sections=%d exceed batch cap=%d", len(sections), len(ordered))
+	}
+	n := 0
+	for _, section := range sections {
+		if err := validateTypedColumnPreparedRange(section.Offset, section.Length); err != nil {
+			return err
+		}
+		ordered[n] = section
+		n++
+	}
+	sort.Slice(ordered[:n], func(i, j int) bool {
+		if ordered[i].Offset != ordered[j].Offset {
+			return ordered[i].Offset < ordered[j].Offset
+		}
+		return ordered[i].Length < ordered[j].Length
+	})
+
+	groupStart := ordered[0].Offset
+	groupEnd := ordered[0].Offset + ordered[0].Length
+	groupPayloadBytes := ordered[0].Length
+	flush := func() error {
+		_, err := c.read(groupStart, groupEnd-groupStart, true)
+		return err
+	}
+	for _, section := range ordered[1:n] {
+		sectionStart := section.Offset
+		sectionEnd := section.Offset + section.Length
+		if sectionStart < groupEnd {
+			if sectionEnd > groupEnd {
+				groupPayloadBytes += sectionEnd - groupEnd
+				groupEnd = sectionEnd
+			}
+			continue
+		}
+		gap := sectionStart - groupEnd
+		span := sectionEnd - groupStart
+		overread := span - (groupPayloadBytes + section.Length)
+		if gap <= maxTypedColumnPreparedMetadataBatchGapBytes &&
+			overread <= maxTypedColumnPreparedMetadataBatchOverreadBytes &&
+			span <= maxTypedColumnPreparedMetadataBatchSpanBytes {
+			groupEnd = sectionEnd
+			groupPayloadBytes += section.Length
+			continue
+		}
+		if err := flush(); err != nil {
+			return err
+		}
+		groupStart = sectionStart
+		groupEnd = sectionEnd
+		groupPayloadBytes = section.Length
+	}
+	return flush()
+}
+
+func validateTypedColumnPreparedRange(offset int, length int) error {
+	if offset < 0 || length <= 0 {
+		return fmt.Errorf("collections: typed-column prepared range offset=%d length=%d is invalid", offset, length)
+	}
+	if offset > maxCollectionInt-length {
+		return fmt.Errorf("collections: typed-column prepared range offset=%d length=%d overflows int", offset, length)
+	}
+	return nil
+}
 
 // typedColumnPreparedColumnRequest describes one logical column role needed by a
 // prepared operation. It separates collection semantics from typedcolumn
@@ -393,7 +544,68 @@ func typedColumnPreparedDependenciesForRequest(req typedColumnPreparedColumnRequ
 	return deps, nil
 }
 
+func typedColumnPreparedPrefetchMetadataSections(image typedcolumn.ColumnPartImage, requests []typedColumnPreparedColumnRequest, readCache *typedColumnPreparedRangeReadCache) error {
+	if readCache == nil {
+		return nil
+	}
+	var sections [maxTypedColumnPreparedMetadataBatchSections]typedcolumn.ColumnPartImageSection
+	sectionN := 0
+	appendSection := func(section typedcolumn.ColumnPartImageSection) {
+		sections[sectionN] = section
+		sectionN++
+	}
+	descriptorSection, err := typedColumnAdapterImageSingleSection(image, typedcolumn.ColumnPartImageSectionDescriptor)
+	if err != nil {
+		return err
+	}
+	appendSection(descriptorSection)
+	if typedColumnPreparedRequestsIncludeSortKeyMetadata(requests) {
+		metadataSection, err := typedColumnAdapterImageSingleSection(image, typedcolumn.ColumnPartImageSectionSortKeyMetadata)
+		if err != nil {
+			return err
+		}
+		appendSection(metadataSection)
+	}
+	if typedColumnPreparedRequestsIncludeSortKeyMarks(requests) {
+		marksSection, err := typedColumnAdapterImageSingleSection(image, typedcolumn.ColumnPartImageSectionSortKeyMarks)
+		if err != nil {
+			return err
+		}
+		appendSection(marksSection)
+	}
+	if typedColumnPreparedRequestsIncludeStats(requests) {
+		statsSection, ok, err := image.ColumnStatsSection()
+		if err != nil {
+			return err
+		}
+		if ok {
+			appendSection(statsSection)
+		}
+	}
+	if typedColumnPreparedRequestsIncludePruning(requests) {
+		pruningSection, ok, err := image.PruningMetadataSection()
+		if err != nil {
+			return err
+		}
+		if ok {
+			appendSection(pruningSection)
+		}
+	}
+	if typedColumnPreparedRequestsIncludeDictionaries(requests) {
+		dictionarySection, err := typedColumnAdapterImageSingleSection(image, typedcolumn.ColumnPartImageSectionDictionaries)
+		if err != nil {
+			return err
+		}
+		appendSection(dictionarySection)
+	}
+	return readCache.prefetchSections(sections[:sectionN])
+}
+
 func typedColumnPreparedReadImageAndDescriptor(ref ColumnAssetRef, readRange typedColumnPreparedRangeReader) (typedcolumn.ColumnPartImage, typedcolumn.ColumnPartDescriptor, map[string]typedcolumn.ColumnPartColumn, int, []byte, []byte, error) {
+	return typedColumnPreparedReadImageAndDescriptorWithPrefetch(ref, readRange, nil, nil)
+}
+
+func typedColumnPreparedReadImageAndDescriptorWithPrefetch(ref ColumnAssetRef, readRange typedColumnPreparedRangeReader, readCache *typedColumnPreparedRangeReadCache, requests []typedColumnPreparedColumnRequest) (typedcolumn.ColumnPartImage, typedcolumn.ColumnPartDescriptor, map[string]typedcolumn.ColumnPartColumn, int, []byte, []byte, error) {
 	if readRange == nil {
 		return typedcolumn.ColumnPartImage{}, typedcolumn.ColumnPartDescriptor{}, nil, 0, nil, nil, errors.New("collections: typed-column prepared state requires range reader")
 	}
@@ -424,6 +636,9 @@ func typedColumnPreparedReadImageAndDescriptor(ref ColumnAssetRef, readRange typ
 	if err != nil {
 		return typedcolumn.ColumnPartImage{}, typedcolumn.ColumnPartDescriptor{}, nil, 0, nil, nil, err
 	}
+	if err := typedColumnPreparedPrefetchMetadataSections(image, requests, readCache); err != nil {
+		return typedcolumn.ColumnPartImage{}, typedcolumn.ColumnPartDescriptor{}, nil, 0, nil, nil, err
+	}
 	descriptorSection, err := typedColumnAdapterImageSingleSection(image, typedcolumn.ColumnPartImageSectionDescriptor)
 	if err != nil {
 		return typedcolumn.ColumnPartImage{}, typedcolumn.ColumnPartDescriptor{}, nil, 0, nil, nil, err
@@ -448,8 +663,18 @@ func typedColumnPreparedReadImageAndDescriptor(ref ColumnAssetRef, readRange typ
 }
 
 func typedColumnPreparePartStateFromRanges(ref ColumnAssetRef, physical ColumnAssetRef, typedRows int, physicalRows int, fields []TypedStorageField, schemaHash uint64, columnRequests []typedColumnPreparedColumnRequest, readRange typedColumnPreparedRangeReader, blockSelection func(typedcolumn.EncodedGranule, int) (typedcolumn.RowSelection, bool, error)) (*typedColumnPreparedPartState, typedColumnPreparedStateDiagnostics, error) {
+	return typedColumnPreparePartStateFromRangesWithOptions(ref, physical, typedRows, physicalRows, fields, schemaHash, columnRequests, readRange, blockSelection, typedColumnPreparePartStateOptions{})
+}
+
+func typedColumnPreparePartStateFromRangesWithOptions(ref ColumnAssetRef, physical ColumnAssetRef, typedRows int, physicalRows int, fields []TypedStorageField, schemaHash uint64, columnRequests []typedColumnPreparedColumnRequest, readRange typedColumnPreparedRangeReader, blockSelection func(typedcolumn.EncodedGranule, int) (typedcolumn.RowSelection, bool, error), opts typedColumnPreparePartStateOptions) (*typedColumnPreparedPartState, typedColumnPreparedStateDiagnostics, error) {
+	preparedReadRange := readRange
+	var readCache *typedColumnPreparedRangeReadCache
+	if opts.CoalescePreparedMetadataReads {
+		readCache = newTypedColumnPreparedRangeReadCache(readRange)
+		preparedReadRange = readCache.read
+	}
 	phaseStart := time.Now()
-	image, desc, columns, manifestBytes, descriptorRaw, contractRaw, err := typedColumnPreparedReadImageAndDescriptor(ref, readRange)
+	image, desc, columns, manifestBytes, descriptorRaw, contractRaw, err := typedColumnPreparedReadImageAndDescriptorWithPrefetch(ref, preparedReadRange, readCache, columnRequests)
 	readImageNanos := time.Since(phaseStart).Nanoseconds()
 	if err != nil {
 		return nil, typedColumnPreparedStateDiagnostics{ReadImageNanos: readImageNanos}, err
@@ -463,7 +688,7 @@ func typedColumnPreparePartStateFromRanges(ref ColumnAssetRef, physical ColumnAs
 	}
 	if typedColumnPreparedRequestsIncludeDictionaries(columnRequests) {
 		phaseStart = time.Now()
-		dictDiag, err := typedColumnAttachPreparedDictionaries(part, image, readRange, columnRequests)
+		dictDiag, err := typedColumnAttachPreparedDictionaries(part, image, preparedReadRange, columnRequests)
 		dictDiag.DictionaryNanos += time.Since(phaseStart).Nanoseconds()
 		typedColumnPreparedStateDiagnosticsAdd(&diag, dictDiag)
 		if err != nil {
@@ -472,7 +697,7 @@ func typedColumnPreparePartStateFromRanges(ref ColumnAssetRef, physical ColumnAs
 	}
 	if typedColumnPreparedRequestsIncludePruning(columnRequests) {
 		phaseStart = time.Now()
-		pruningDiag, err := typedColumnAttachPreparedPruning(part, image, readRange, columnRequests)
+		pruningDiag, err := typedColumnAttachPreparedPruning(part, image, preparedReadRange, columnRequests)
 		pruningDiag.PruningNanos += time.Since(phaseStart).Nanoseconds()
 		typedColumnPreparedStateDiagnosticsAdd(&diag, pruningDiag)
 		if err != nil {
@@ -483,7 +708,7 @@ func typedColumnPreparePartStateFromRanges(ref ColumnAssetRef, physical ColumnAs
 	}
 	if typedColumnPreparedRequestsIncludeSortKeyMetadata(columnRequests) || typedColumnPreparedRequestsIncludeSortKeyMarks(columnRequests) {
 		phaseStart = time.Now()
-		sortKeyDiag, err := typedColumnAttachPreparedSortKey(part, image, readRange, typedColumnPreparedRequestsIncludeSortKeyMarks(columnRequests))
+		sortKeyDiag, err := typedColumnAttachPreparedSortKey(part, image, preparedReadRange, typedColumnPreparedRequestsIncludeSortKeyMarks(columnRequests))
 		sortKeyDiag.SortKeyNanos += time.Since(phaseStart).Nanoseconds()
 		typedColumnPreparedStateDiagnosticsAdd(&diag, sortKeyDiag)
 		if err != nil {
@@ -494,7 +719,7 @@ func typedColumnPreparePartStateFromRanges(ref ColumnAssetRef, physical ColumnAs
 		return part, diag, nil
 	}
 	phaseStart = time.Now()
-	if err := typedColumnAttachPreparedStats(part, image, readRange); err != nil {
+	if err := typedColumnAttachPreparedStats(part, image, preparedReadRange); err != nil {
 		diag.StatsNanos += time.Since(phaseStart).Nanoseconds()
 		diag.StatsValidationFailures++
 		diag.StatsValidationFailureReason = err.Error()

--- a/TreeDB/collections/typed_column_prepared_state.go
+++ b/TreeDB/collections/typed_column_prepared_state.go
@@ -106,8 +106,14 @@ func (c *typedColumnPreparedRangeReadCache) prefetchSections(sections []typedcol
 		if err := validateTypedColumnPreparedRange(section.Offset, section.Length); err != nil {
 			return err
 		}
+		if section.Length > maxTypedColumnPreparedRangeCacheEntryBytes {
+			continue
+		}
 		ordered[n] = section
 		n++
+	}
+	if n <= 1 {
+		return nil
 	}
 	sort.Slice(ordered[:n], func(i, j int) bool {
 		if ordered[i].Offset != ordered[j].Offset {

--- a/TreeDB/collections/typed_column_prepared_state_test.go
+++ b/TreeDB/collections/typed_column_prepared_state_test.go
@@ -454,6 +454,49 @@ func TestTypedColumnPreparedMetadataPrefetchCoalescesSmallDictionary3417(t *test
 	}
 }
 
+func TestTypedColumnPreparedMetadataPrefetchUsesFullSectionBudget3417(t *testing.T) {
+	raw := make([]byte, 512)
+	for i := range raw {
+		raw[i] = byte(i)
+	}
+	image := typedcolumn.ColumnPartImage{Sections: []typedcolumn.ColumnPartImageSection{
+		{Kind: typedcolumn.ColumnPartImageSectionDescriptor, Offset: 100, Length: 8},
+		{Kind: typedcolumn.ColumnPartImageSectionSortKeyMetadata, Offset: 108, Length: 8},
+		{Kind: typedcolumn.ColumnPartImageSectionSortKeyMarks, Offset: 116, Length: 8},
+		{Kind: typedcolumn.ColumnPartImageSectionColumnStats, Offset: 124, Length: 8},
+		{Kind: typedcolumn.ColumnPartImageSectionPruningMetadata, Offset: 132, Length: 8},
+		{Kind: typedcolumn.ColumnPartImageSectionDictionaries, Offset: 140, Length: 8},
+	}}
+	type readCall struct {
+		offset int
+		length int
+	}
+	var calls []readCall
+	cache := newTypedColumnPreparedRangeReadCache(func(offset int, length int, section bool) ([]byte, error) {
+		if !section {
+			t.Fatalf("section=%v want true", section)
+		}
+		if offset < 0 || length <= 0 || offset+length > len(raw) {
+			t.Fatalf("range offset=%d length=%d outside bytes=%d", offset, length, len(raw))
+		}
+		calls = append(calls, readCall{offset: offset, length: length})
+		return raw[offset : offset+length], nil
+	})
+	requests := []typedColumnPreparedColumnRequest{{
+		IncludeDictionaries:    true,
+		IncludeStats:           true,
+		IncludePruning:         true,
+		IncludeSortKeyMetadata: true,
+		IncludeSortKeyMarks:    true,
+	}}
+	if err := typedColumnPreparedPrefetchMetadataSections(image, requests, cache); err != nil {
+		t.Fatalf("prefetch metadata: %v", err)
+	}
+	if len(calls) != 1 || calls[0] != (readCall{offset: 100, length: 48}) {
+		t.Fatalf("prefetch calls=%+v want one full-budget coalesced metadata read", calls)
+	}
+}
+
 func TestTypedColumnPreparedMetadataPrefetchSkipsLargeDictionary3417(t *testing.T) {
 	dictLen := maxTypedColumnPreparedRangeCacheEntryBytes + 1
 	raw := make([]byte, 140+dictLen)

--- a/TreeDB/collections/typed_column_prepared_state_test.go
+++ b/TreeDB/collections/typed_column_prepared_state_test.go
@@ -546,6 +546,48 @@ func TestTypedColumnPreparedMetadataPrefetchSkipsLargeDictionary3417(t *testing.
 	}
 }
 
+func TestTypedColumnPreparedMetadataPrefetchSkipsUncacheableSortMarks3417(t *testing.T) {
+	marksLen := maxTypedColumnPreparedRangeCacheEntryBytes + 1
+	raw := make([]byte, 156+marksLen)
+	for i := range raw {
+		raw[i] = byte(i)
+	}
+	image := typedcolumn.ColumnPartImage{Sections: []typedcolumn.ColumnPartImageSection{
+		{Kind: typedcolumn.ColumnPartImageSectionDescriptor, Offset: 100, Length: 32},
+		{Kind: typedcolumn.ColumnPartImageSectionSortKeyMetadata, Offset: 140, Length: 16},
+		{Kind: typedcolumn.ColumnPartImageSectionSortKeyMarks, Offset: 156, Length: marksLen},
+	}}
+	type readCall struct {
+		offset int
+		length int
+	}
+	var calls []readCall
+	cache := newTypedColumnPreparedRangeReadCache(func(offset int, length int, section bool) ([]byte, error) {
+		if offset < 0 || length <= 0 || offset+length > len(raw) {
+			t.Fatalf("range offset=%d length=%d outside bytes=%d", offset, length, len(raw))
+		}
+		calls = append(calls, readCall{offset: offset, length: length})
+		return raw[offset : offset+length], nil
+	})
+	requests := []typedColumnPreparedColumnRequest{{IncludeSortKeyMarks: true}}
+	if err := typedColumnPreparedPrefetchMetadataSections(image, requests, cache); err != nil {
+		t.Fatalf("prefetch metadata: %v", err)
+	}
+	if len(calls) != 1 || calls[0] != (readCall{offset: 100, length: 56}) {
+		t.Fatalf("prefetch calls=%+v want descriptor+sort metadata only", calls)
+	}
+	callsBefore := len(calls)
+	if _, err := cache.read(156, marksLen, true); err != nil {
+		t.Fatalf("large sort marks read: %v", err)
+	}
+	if _, err := cache.read(156, marksLen, true); err != nil {
+		t.Fatalf("large sort marks second read: %v", err)
+	}
+	if len(calls) != callsBefore+2 {
+		t.Fatalf("large sort marks calls=%d want %d uncached reads", len(calls), callsBefore+2)
+	}
+}
+
 func TestTypedColumnPreparedPruningComposedSelectionsDoNotAliasScratch(t *testing.T) {
 	field := TypedStorageField{Name: "score", Path: "score", Owner: TypedStorageOwnerColumnPart, ValueType: "int64"}
 	values := []int64{

--- a/TreeDB/collections/typed_column_prepared_state_test.go
+++ b/TreeDB/collections/typed_column_prepared_state_test.go
@@ -343,6 +343,166 @@ func TestTypedColumnPreparedStateMultiColumnMismatchFailsClosed(t *testing.T) {
 	}
 }
 
+func TestTypedColumnPreparedRangeReadCacheBounds3417(t *testing.T) {
+	raw := make([]byte, maxTypedColumnPreparedRangeCacheEntryBytes+4096)
+	for i := range raw {
+		raw[i] = byte(i)
+	}
+	calls := 0
+	readRange := func(offset int, length int, section bool) ([]byte, error) {
+		calls++
+		if !section {
+			t.Fatalf("section=%v want true", section)
+		}
+		if offset < 0 || length <= 0 || offset+length > len(raw) {
+			t.Fatalf("range offset=%d length=%d outside bytes=%d", offset, length, len(raw))
+		}
+		return raw[offset : offset+length], nil
+	}
+	cache := newTypedColumnPreparedRangeReadCache(readRange)
+	for i := 0; i < maxTypedColumnPreparedRangeCacheEntries+4; i++ {
+		offset := i*16 + 1
+		got, err := cache.read(offset, 4, true)
+		if err != nil {
+			t.Fatalf("cache read %d: %v", i, err)
+		}
+		if string(got) != string(raw[offset:offset+4]) {
+			t.Fatalf("cache read %d returned wrong bytes", i)
+		}
+	}
+	if cache.entryN != maxTypedColumnPreparedRangeCacheEntries {
+		t.Fatalf("cache entries=%d want hard cap %d", cache.entryN, maxTypedColumnPreparedRangeCacheEntries)
+	}
+	callsBefore := calls
+	if _, err := cache.read(1, 4, true); err != nil {
+		t.Fatalf("cached first range: %v", err)
+	}
+	if calls != callsBefore {
+		t.Fatalf("cached range caused read calls=%d want %d", calls, callsBefore)
+	}
+	uncachedOffset := (maxTypedColumnPreparedRangeCacheEntries+1)*16 + 1
+	if _, err := cache.read(uncachedOffset, 4, true); err != nil {
+		t.Fatalf("uncached overflow range: %v", err)
+	}
+	if calls != callsBefore+1 {
+		t.Fatalf("uncached overflow calls=%d want %d", calls, callsBefore+1)
+	}
+
+	largeCalls := 0
+	largeCache := newTypedColumnPreparedRangeReadCache(func(offset int, length int, section bool) ([]byte, error) {
+		largeCalls++
+		if offset < 0 || length <= 0 || offset+length > len(raw) {
+			t.Fatalf("large range offset=%d length=%d outside bytes=%d", offset, length, len(raw))
+		}
+		return raw[offset : offset+length], nil
+	})
+	largeLen := maxTypedColumnPreparedRangeCacheEntryBytes + 1
+	if _, err := largeCache.read(0, largeLen, true); err != nil {
+		t.Fatalf("large first read: %v", err)
+	}
+	if largeCache.entryN != 0 {
+		t.Fatalf("large read cached entries=%d want 0", largeCache.entryN)
+	}
+	if _, err := largeCache.read(0, largeLen, true); err != nil {
+		t.Fatalf("large second read: %v", err)
+	}
+	if largeCalls != 2 {
+		t.Fatalf("large read calls=%d want 2 uncached reads", largeCalls)
+	}
+}
+
+func TestTypedColumnPreparedMetadataPrefetchCoalescesSmallDictionary3417(t *testing.T) {
+	raw := make([]byte, 512)
+	for i := range raw {
+		raw[i] = byte(i)
+	}
+	image := typedcolumn.ColumnPartImage{Sections: []typedcolumn.ColumnPartImageSection{
+		{Kind: typedcolumn.ColumnPartImageSectionDescriptor, Offset: 100, Length: 32},
+		{Kind: typedcolumn.ColumnPartImageSectionDictionaries, Offset: 140, Length: 16},
+	}}
+	type readCall struct {
+		offset int
+		length int
+	}
+	var calls []readCall
+	cache := newTypedColumnPreparedRangeReadCache(func(offset int, length int, section bool) ([]byte, error) {
+		if !section {
+			t.Fatalf("section=%v want true", section)
+		}
+		if offset < 0 || length <= 0 || offset+length > len(raw) {
+			t.Fatalf("range offset=%d length=%d outside bytes=%d", offset, length, len(raw))
+		}
+		calls = append(calls, readCall{offset: offset, length: length})
+		return raw[offset : offset+length], nil
+	})
+	requests := []typedColumnPreparedColumnRequest{{IncludeDictionaries: true}}
+	if err := typedColumnPreparedPrefetchMetadataSections(image, requests, cache); err != nil {
+		t.Fatalf("prefetch metadata: %v", err)
+	}
+	if len(calls) != 1 || calls[0] != (readCall{offset: 100, length: 56}) {
+		t.Fatalf("prefetch calls=%+v want one coalesced descriptor+dictionary read", calls)
+	}
+	callsBefore := len(calls)
+	if _, err := cache.read(100, 32, true); err != nil {
+		t.Fatalf("cached descriptor read: %v", err)
+	}
+	if _, err := cache.read(140, 16, true); err != nil {
+		t.Fatalf("cached dictionary read: %v", err)
+	}
+	if len(calls) != callsBefore {
+		t.Fatalf("cached sections caused calls=%d want %d", len(calls), callsBefore)
+	}
+}
+
+func TestTypedColumnPreparedMetadataPrefetchSkipsLargeDictionary3417(t *testing.T) {
+	dictLen := maxTypedColumnPreparedRangeCacheEntryBytes + 1
+	raw := make([]byte, 140+dictLen)
+	for i := range raw {
+		raw[i] = byte(i)
+	}
+	image := typedcolumn.ColumnPartImage{Sections: []typedcolumn.ColumnPartImageSection{
+		{Kind: typedcolumn.ColumnPartImageSectionDescriptor, Offset: 100, Length: 32},
+		{Kind: typedcolumn.ColumnPartImageSectionDictionaries, Offset: 140, Length: dictLen},
+	}}
+	type readCall struct {
+		offset int
+		length int
+	}
+	var calls []readCall
+	cache := newTypedColumnPreparedRangeReadCache(func(offset int, length int, section bool) ([]byte, error) {
+		if offset < 0 || length <= 0 || offset+length > len(raw) {
+			t.Fatalf("range offset=%d length=%d outside bytes=%d", offset, length, len(raw))
+		}
+		calls = append(calls, readCall{offset: offset, length: length})
+		return raw[offset : offset+length], nil
+	})
+	requests := []typedColumnPreparedColumnRequest{{IncludeDictionaries: true}}
+	if err := typedColumnPreparedPrefetchMetadataSections(image, requests, cache); err != nil {
+		t.Fatalf("prefetch metadata: %v", err)
+	}
+	if len(calls) != 0 {
+		t.Fatalf("prefetch calls=%+v want no prefetch when dictionary exceeds cache entry cap", calls)
+	}
+	if _, err := cache.read(100, 32, true); err != nil {
+		t.Fatalf("descriptor read: %v", err)
+	}
+	if cache.entryN != 1 {
+		t.Fatalf("cache entries after descriptor=%d want 1", cache.entryN)
+	}
+	if _, err := cache.read(140, dictLen, true); err != nil {
+		t.Fatalf("large dictionary read: %v", err)
+	}
+	if cache.entryN != 1 {
+		t.Fatalf("cache entries after large dictionary=%d want descriptor only", cache.entryN)
+	}
+	if _, err := cache.read(140, dictLen, true); err != nil {
+		t.Fatalf("large dictionary second read: %v", err)
+	}
+	if len(calls) != 3 {
+		t.Fatalf("calls=%+v want descriptor plus two uncached large dictionary reads", calls)
+	}
+}
+
 func TestTypedColumnPreparedPruningComposedSelectionsDoNotAliasScratch(t *testing.T) {
 	field := TypedStorageField{Name: "score", Path: "score", Owner: TypedStorageOwnerColumnPart, ValueType: "int64"}
 	values := []int64{


### PR DESCRIPTION
## Scope

Coalesces dense typed-column prepared metadata reads for the physical range decode path used by no-metadata one-shot q1/q3 setup.

This is query setup work only. It is not aggregate metadata acceleration, not a ClickHouse comparison claim, and not evidence of broader SQL superiority. The change is opt-in at `decodeTypedColumnPhysicalQueryDensePartFromRanges`; existing prepared-state callers keep the previous read behavior.

## Implementation

- Adds a bounded prepared metadata read cache for typed-column setup.
- Prefetches adjacent descriptor/metadata/stats/pruning/dictionary sections when gap, overread, span, and section-count caps allow it.
- Keeps payload/data reads, layout contract reads, value-log/WAL behavior, durability boundaries, and checksum validation unchanged.

## 1M TreeDB-Only Evidence

Artifact:

- `/mnt/fast4tb/gomap-profiles/q1q3-read-coalesce-1m-20260630_192859/report.json`
- `/mnt/fast4tb/gomap-profiles/q1q3-read-coalesce-1m-20260630_192859/report.md`
- `/mnt/fast4tb/gomap-profiles/q1q3-read-coalesce-1m-20260630_192859/rows1000000_column-store-full-prepared_one_shot_end_to_end_no_aggregate_metadata_json_full_q1q3/result.json`

Baseline artifact:

- `/mnt/fast4tb/gomap-profiles/current-head-after3412-noagg-1m-20260630_183241/report.json`

Scope: TreeDB only, 1M rows, `one_shot_end_to_end`, `no_aggregate_metadata`, full retained JSON projection. This is not side-by-side ClickHouse evidence.

| query | baseline total | candidate total | total delta | baseline setup | candidate setup | setup delta | run baseline -> candidate |
|---|---:|---:|---:|---:|---:|---:|---:|
| q1 | 14.047ms | 11.701ms | -16.70% | 13.676ms | 11.297ms | -17.39% | 0.332ms -> 0.372ms |
| q3 | 25.187ms | 23.597ms | -6.31% | 22.709ms | 21.091ms | -7.12% | 2.463ms -> 2.490ms |

Guardrails:

| query | range bytes | rows scanned | reduce rows | fallback | row/doc materializations | result hash |
|---|---:|---:|---:|---|---:|---|
| q1 | 12,212,532 unchanged | 1,000,000 | 1,000,000 | none | 0 / 0 | `059afea7bfbfb7d188ccc441b326301b063975713996169dfd43563420d11492` |
| q3 | 14,541,335 unchanged | 1,000,000 | 588,328 | none | 0 / 0 | `cdb6acc4d0d990bdbdab5d2f29df85943490b2cb6b950351cbfa9bd974a182eb` |

## Focused Setup Bench

Artifacts:

- `/tmp/gomap_3350_q1q3_read_coalesce/baseline_bench.txt`
- `/tmp/gomap_3350_q1q3_read_coalesce/after_bench.txt`
- `/tmp/gomap_3350_q1q3_read_coalesce/benchstat.txt`
- `/tmp/gomap_3350_q1q3_read_coalesce/after_tests.txt`

Focused setup benchmark:

```text
ColumnPhysicalQ1DenseTypedColumnOneShotTargetedSetup1950 395.8us -> 246.7us (-37.68%)
ColumnPhysicalQ3DenseTypedColumnOneShotTargetedSetup1950 785.6us -> 524.1us (-33.30%)
geomean 557.7us -> 359.6us (-35.53%)
```

Diagnostics:

```text
q1 range_read_bytes unchanged: 24.29k -> 24.29k
q3 range_read_bytes unchanged: 10.27k -> 10.27k
q1 range_read_nanos: 75.92us -> 58.70us
q3 range_read_nanos: 32.66us -> 19.55us (-40.13%)
```

Cost:

```text
B/op geomean: +0.32%
allocs/op geomean: +1.93%
```

Validation:

```sh
GOWORK=off go test ./TreeDB/collections -run 'TestColumnPhysicalQ1DenseTypedColumnOneShotTargetedSetupDiagnostics1950|TestColumnPhysicalQ3DenseTypedColumnOneShotTargetedSetupDiagnostics1950|TestColumnPhysicalTypedColumnOneShotCacheQ1Q3NoMetadata3088' -count=1
GOWORK=off go test ./TreeDB/collections -bench 'BenchmarkColumnPhysicalQ(1|3)DenseTypedColumnOneShotTargetedSetup1950' -run '^$' -benchtime=100x -count=5
```

JSONBench command used with a temporary local gomap replace:

```sh
go run ./cmd/jsonbench_treedb run \
  -data-dir /home/mikers/data/bluesky \
  -db-dir "$CELL/db" \
  -reset \
  -scale subset \
  -rows 1000000 \
  -format json \
  -storage-layout column-store-full-prepared \
  -query-mode one_shot_end_to_end \
  -metadata-mode no_aggregate_metadata \
  -projection full \
  -queries q1,q3 \
  -batch-size 16000 \
  -tries 1 \
  -profile fast \
  -data-root fast \
  -out "$CELL/result.json"
```

## Tracker

Part of #3350 and #3070. Side-by-side ClickHouse evidence, auto-metadata cost evidence, and full benchmark-gate reporting remain separate work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved typed-column loading by coalescing metadata reads during dense-range preparation.
  * Added smarter prefetching and caching for overlapping metadata ranges, reducing repeated reads.

* **Bug Fixes**
  * Preserved existing error handling while making metadata reads more efficient.
  * Improved handling of range validation and overflow when serving cached metadata slices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->