### PR TITLE
Batch contiguous q3 typed payload reads

### DIFF
--- a/TreeDB/collections/typed_column_adapter.go
+++ b/TreeDB/collections/typed_column_adapter.go
@@ -2912,8 +2912,9 @@ func typedColumnPhysicalQueryAttachPreparedPayloads(prepared *typedColumnPrepare
 	}
 	decodedBytes := uint64(0)
 	decodedBlocks := 0
-	for blockIdx := range partColumn.Blocks {
+	for blockIdx := 0; blockIdx < len(partColumn.Blocks); {
 		if selectedBlocks != nil && !selectedBlocks[blockIdx] {
+			blockIdx++
 			continue
 		}
 		blockPlan := preparedColumn.BlockPlans[blockIdx]
@@ -2922,18 +2923,60 @@ func typedColumnPhysicalQueryAttachPreparedPayloads(prepared *typedColumnPrepare
 		}
 		block := &partColumn.Blocks[blockIdx]
 		if blockPlan.PayloadLength > 0 && len(block.Granule.Payload) == 0 {
-			payload, err := readRange(blockPlan.PayloadOffset, blockPlan.PayloadLength, false)
+			runEnd := blockIdx + 1
+			runOffset := blockPlan.PayloadOffset
+			runLength := blockPlan.PayloadLength
+			for runEnd < len(partColumn.Blocks) {
+				runEndOffset := runOffset + runLength
+				if runEndOffset < runOffset {
+					return 0, 0, fmt.Errorf("collections: dense typed-column prepared range %s column %q payload run end overflows at block %d", role, columnName, runEnd)
+				}
+				if selectedBlocks != nil && !selectedBlocks[runEnd] {
+					break
+				}
+				nextPlan := preparedColumn.BlockPlans[runEnd]
+				if nextPlan.Index != runEnd {
+					return 0, 0, fmt.Errorf("collections: dense typed-column prepared range %s column %q block plan index=%d want %d", role, columnName, nextPlan.Index, runEnd)
+				}
+				nextBlock := &partColumn.Blocks[runEnd]
+				if nextPlan.PayloadLength <= 0 || len(nextBlock.Granule.Payload) != 0 {
+					break
+				}
+				if nextPlan.PayloadOffset != runEndOffset {
+					break
+				}
+				if nextPlan.PayloadLength > maxCollectionInt-runLength {
+					return 0, 0, fmt.Errorf("collections: dense typed-column prepared range %s column %q payload run length overflows at block %d", role, columnName, runEnd)
+				}
+				runLength += nextPlan.PayloadLength
+				runEnd++
+			}
+			payload, err := readRange(runOffset, runLength, false)
 			if err != nil {
-				return 0, 0, fmt.Errorf("collections: dense typed-column prepared range read %s column %q block %d payload: %w", role, columnName, blockIdx, err)
+				return 0, 0, fmt.Errorf("collections: dense typed-column prepared range read %s column %q blocks %d-%d payload: %w", role, columnName, blockIdx, runEnd-1, err)
 			}
-			if len(payload) != blockPlan.PayloadLength {
-				return 0, 0, fmt.Errorf("collections: dense typed-column prepared range %s column %q block %d payload bytes=%d want %d", role, columnName, blockIdx, len(payload), blockPlan.PayloadLength)
+			if len(payload) != runLength {
+				return 0, 0, fmt.Errorf("collections: dense typed-column prepared range %s column %q blocks %d-%d payload bytes=%d want %d", role, columnName, blockIdx, runEnd-1, len(payload), runLength)
 			}
-			block.Granule.Payload = payload
-			block.Granule.PayloadRef = typedcolumn.PayloadRef{Kind: typedcolumn.PayloadRefInline, Length: len(payload)}
+			for runBlockIdx := blockIdx; runBlockIdx < runEnd; runBlockIdx++ {
+				runBlockPlan := preparedColumn.BlockPlans[runBlockIdx]
+				payloadStart := runBlockPlan.PayloadOffset - runOffset
+				payloadEnd := payloadStart + runBlockPlan.PayloadLength
+				if payloadStart < 0 || payloadEnd < payloadStart || payloadEnd > len(payload) {
+					return 0, 0, fmt.Errorf("collections: dense typed-column prepared range %s column %q block %d payload slice [%d,%d) outside run bytes=%d", role, columnName, runBlockIdx, payloadStart, payloadEnd, len(payload))
+				}
+				runBlock := &partColumn.Blocks[runBlockIdx]
+				runBlock.Granule.Payload = payload[payloadStart:payloadEnd]
+				runBlock.Granule.PayloadRef = typedcolumn.PayloadRef{Kind: typedcolumn.PayloadRefInline, Length: runBlockPlan.PayloadLength}
+				decodedBytes += uint64(runBlock.Granule.RawBytes)
+				decodedBlocks++
+			}
+			blockIdx = runEnd
+			continue
 		}
 		decodedBytes += uint64(block.Granule.RawBytes)
 		decodedBlocks++
+		blockIdx++
 	}
 	adapterPart.Part.Columns[columnName] = partColumn
 	return decodedBytes, decodedBlocks, nil

--- a/TreeDB/collections/typed_column_payload_batch_test.go
+++ b/TreeDB/collections/typed_column_payload_batch_test.go
@@ -1,0 +1,81 @@
+package collections
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/internal/typedcolumn"
+)
+
+func TestTypedColumnPhysicalQueryAttachPreparedPayloadsBatchesContiguousSelectedBlocks(t *testing.T) {
+	data := []byte("aaabbbbXccddeee")
+	partColumn := typedcolumn.ColumnPartColumn{
+		Definition: typedcolumn.ColumnDefinition{Name: "c"},
+		Blocks: []typedcolumn.ColumnBlock{
+			{Granule: typedcolumn.EncodedGranule{RawBytes: 3}},
+			{Granule: typedcolumn.EncodedGranule{RawBytes: 4}},
+			{Granule: typedcolumn.EncodedGranule{RawBytes: 2}},
+			{Granule: typedcolumn.EncodedGranule{RawBytes: 5}},
+		},
+	}
+	prepared := &typedColumnPreparedPartState{
+		Columns: map[string]*typedColumnPreparedColumnState{
+			"c": {
+				Column: partColumn,
+				BlockPlans: []typedColumnPreparedBlockPlan{
+					{Index: 0, PayloadOffset: 10, PayloadLength: 3},
+					{Index: 1, PayloadOffset: 13, PayloadLength: 4},
+					{Index: 2, PayloadOffset: 18, PayloadLength: 2},
+					{Index: 3, PayloadOffset: 20, PayloadLength: 5},
+				},
+			},
+		},
+	}
+	adapterPart := &typedColumnAdapterPart{
+		Part: &typedcolumn.ColumnPart{
+			Columns: map[string]typedcolumn.ColumnPartColumn{"c": partColumn},
+		},
+	}
+
+	type readCall struct {
+		offset int
+		length int
+	}
+	var calls []readCall
+	readRange := func(offset int, length int, section bool) ([]byte, error) {
+		if section {
+			t.Fatalf("payload attach read unexpectedly marked section")
+		}
+		calls = append(calls, readCall{offset: offset, length: length})
+		start := offset - 10
+		return data[start : start+length], nil
+	}
+
+	decodedBytes, decodedBlocks, err := typedColumnPhysicalQueryAttachPreparedPayloads(prepared, adapterPart, "c", "test", []bool{true, true, true, true}, readRange)
+	if err != nil {
+		t.Fatalf("attach prepared payloads: %v", err)
+	}
+	if decodedBytes != 14 || decodedBlocks != 4 {
+		t.Fatalf("decoded bytes/blocks=%d/%d want 14/4", decodedBytes, decodedBlocks)
+	}
+	wantCalls := []readCall{{offset: 10, length: 7}, {offset: 18, length: 7}}
+	if !reflect.DeepEqual(calls, wantCalls) {
+		t.Fatalf("read calls=%+v want %+v", calls, wantCalls)
+	}
+	gotColumn := adapterPart.Part.Columns["c"]
+	gotPayloads := []string{
+		string(gotColumn.Blocks[0].Granule.Payload),
+		string(gotColumn.Blocks[1].Granule.Payload),
+		string(gotColumn.Blocks[2].Granule.Payload),
+		string(gotColumn.Blocks[3].Granule.Payload),
+	}
+	wantPayloads := []string{"aaa", "bbbb", "cc", "ddeee"}
+	if !reflect.DeepEqual(gotPayloads, wantPayloads) {
+		t.Fatalf("payloads=%q want %q", gotPayloads, wantPayloads)
+	}
+	for blockIdx, block := range gotColumn.Blocks {
+		if block.Granule.PayloadRef.Kind != typedcolumn.PayloadRefInline || block.Granule.PayloadRef.Length != len(block.Granule.Payload) {
+			t.Fatalf("block %d payload ref=%+v payload_len=%d", blockIdx, block.Granule.PayloadRef, len(block.Granule.Payload))
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Batch exact-adjacent typed-column payload range reads when attaching prepared payloads for dense typed-column physical queries.
- Preserve per-block payload slices, payload refs, decoded byte/block accounting, and block selection boundaries.
- Add a focused unit test that proves adjacent blocks are coalesced while a payload-offset gap is not overread.

## Claim Boundary

This is `one_shot_end_to_end` / `no_aggregate_metadata` typed-column setup work. It does not add metadata acceleration, does not change load/write behavior, and should not be presented as a ClickHouse comparison until side-by-side current evidence is regenerated.

## Evidence

Current-main baseline artifact:
`/mnt/fast4tb/gomap-profiles/current-head-after3417-noagg-1m-20260630_212340/report.json`

Candidate artifact:
`/tmp/jsonbench_q1q3_payload_readbatch_20260630_230602/report.json`

1M TreeDB `column-store-full-prepared`, `one_shot_end_to_end`, `no_aggregate_metadata`, `projection=full`, `profile=fast`, `data-root=fast`:

| query | metric | main | candidate |
| --- | ---: | ---: | ---: |
| q1 | total | 12.168 ms | 11.085 ms |
| q1 | setup | 11.771 ms | 10.590 ms |
| q1 | run | 0.355 ms | 0.460 ms |
| q1 | range read | 6.120 ms | 4.956 ms |
| q1 | rows scanned/reduced | 1,000,000 / 1,000,000 | 1,000,000 / 1,000,000 |
| q3 | total | 29.555 ms | 22.987 ms |
| q3 | setup | 26.060 ms | 19.878 ms |
| q3 | run | 3.470 ms | 3.092 ms |
| q3 | range read | 8.513 ms | 6.362 ms |
| q3 | rows scanned/matched/reduced | 1,000,000 / 588,328 / 588,328 | 1,000,000 / 588,328 / 588,328 |

The JSONBench aggregate report for this run does not carry a result-hash field in `report.json`; the run still executed normal `render/hash` timing and preserved row/result-count diagnostics.

Microbench smoke on this branch:

`GOWORK=off go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnPhysicalQ3DenseTypedColumn(OneShotSetup1950|OneShotTargetedSetup1950)' -benchmem -benchtime=100x -count=5`

Earlier same-branch benchstat artifact from the worker:
`/tmp/treedb_q3_payload_readbatch_20260701_lVI2jp/benchstat_baseline_vs_candidate.txt`

Key worker benchstat:

| benchmark | main | candidate | delta |
| --- | ---: | ---: | ---: |
| `ColumnPhysicalQ3DenseTypedColumnOneShotSetup1950` | 1028.0 us | 689.1 us | -32.97% |
| `ColumnPhysicalQ3DenseTypedColumnOneShotTargetedSetup1950` | 808.4 us | 551.0 us | -31.84% |
| geomean | 911.6 us | 616.2 us | -32.40% |
| targeted range-read nanos/op | 29.01k | 15.46k | -46.71% |
| targeted range-read bytes/op | 10.27k | 10.27k | unchanged |

## Validation

- `GOWORK=off go test ./TreeDB/collections -run 'TestTypedColumnPhysicalQueryAttachPreparedPayloadsBatchesContiguousSelectedBlocks|TestColumnPhysicalQ3DenseTypedColumn(DirectPreparedParity|OneShotSetupDiagnostics|OneShotTargetedSetupDiagnostics)1950|TestColumnPhysicalTypedColumnOneShotCacheQ1Q3NoMetadata3088' -count=1`
- `GOWORK=off go test ./TreeDB/collections -run 'TestColumnPhysicalQ1DenseTypedColumn(DirectPreparedParity|OneShotSetupDiagnostics|OneShotTargetedSetupDiagnostics)1950|TestColumnPhysicalTypedColumnOneShotCacheQ2NoMetadata3123|TestColumnPhysicalDenseTypedColumnTargetedRangeReads3090' -count=1`
- `GOWORK=off go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnPhysicalQ3DenseTypedColumn(OneShotSetup1950|OneShotTargetedSetup1950)' -benchmem -benchtime=100x -count=5`
- 1M JSONBench q1/q3 candidate run listed above
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved typed-column payload loading to batch contiguous blocks into fewer reads, reducing unnecessary per-block fetches.
* **Bug Fixes**
  * Added stronger boundary and overflow checks during payload attachment for safer handling of selected block ranges.
* **Tests**
  * Added coverage for batched payload loading, including read coalescing and correct payload attachment across multiple blocks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->