### PR TITLE
Avoid typed-column image payload preconcat

### DIFF
--- a/TreeDB/internal/typedcolumn/layout_contract.go
+++ b/TreeDB/internal/typedcolumn/layout_contract.go
@@ -356,7 +356,7 @@ func encodeColumnPartLayoutContract(part *ColumnPart, opts ColumnPartImageOption
 	enc.u16(columnPartImageVersion)
 	enc.u16(0)
 	enc.i64(int64(manifestBytes))
-	encodeColumnPartLayoutContractSection(&enc, ColumnPartLayoutContractSection{Offset: descriptorData.section.Offset, Length: len(descriptorData.data), Checksum: crc.Checksum(descriptorData.data)})
+	encodeColumnPartLayoutContractSection(&enc, ColumnPartLayoutContractSection{Offset: descriptorData.section.Offset, Length: descriptorData.payloadLen(), Checksum: descriptorData.payloadChecksum()})
 	enc.u32(uint32(len(part.Descriptor.Columns)))
 	for _, columnDesc := range part.Descriptor.Columns {
 		column, ok := part.Columns[columnDesc.Name]
@@ -409,7 +409,7 @@ func buildColumnPartLayoutContractColumn(opts ColumnPartImageOptions, columnDesc
 		sectionRows = sections.data.section.Rows
 		sectionEncoding = sections.data.section.Encoding
 		sectionCompression = sections.data.section.Compression
-		sectionContract = ColumnPartLayoutContractSection{Offset: sections.data.section.Offset, Length: len(sections.data.data), Checksum: crc.Checksum(sections.data.data)}
+		sectionContract = ColumnPartLayoutContractSection{Offset: sections.data.section.Offset, Length: sections.data.payloadLen(), Checksum: sections.data.payloadChecksum()}
 	}
 	contractDef := column.Definition
 	contractDef.Encoding = sectionEncoding
@@ -441,13 +441,13 @@ func buildColumnPartLayoutContractColumn(opts ColumnPartImageOptions, columnDesc
 		Blocks:              make([]ColumnPartLayoutContractBlock, 0, len(column.Blocks)),
 	}
 	if column.Definition.Encoding == EncodingRawUint32OffsetsList || column.Definition.Encoding == EncodingRawBytesOffsets {
-		contract.OffsetsSection = ColumnPartLayoutContractSection{Offset: sections.offsets.section.Offset, Length: len(sections.offsets.data), Checksum: crc.Checksum(sections.offsets.data)}
-		contract.ValuesSection = ColumnPartLayoutContractSection{Offset: sections.values.section.Offset, Length: len(sections.values.data), Checksum: crc.Checksum(sections.values.data)}
-		contract.OffsetsBytes = len(sections.offsets.data)
-		contract.ValuesBytes = len(sections.values.data)
+		contract.OffsetsSection = ColumnPartLayoutContractSection{Offset: sections.offsets.section.Offset, Length: sections.offsets.payloadLen(), Checksum: sections.offsets.payloadChecksum()}
+		contract.ValuesSection = ColumnPartLayoutContractSection{Offset: sections.values.section.Offset, Length: sections.values.payloadLen(), Checksum: sections.values.payloadChecksum()}
+		contract.OffsetsBytes = sections.offsets.payloadLen()
+		contract.ValuesBytes = sections.values.payloadLen()
 	}
 	if contract.Dictionary && dictionaryData.section.Kind == ColumnPartImageSectionDictionaries {
-		contract.DictionarySection = ColumnPartLayoutContractSection{Offset: dictionaryData.section.Offset, Length: len(dictionaryData.data), Checksum: crc.Checksum(dictionaryData.data)}
+		contract.DictionarySection = ColumnPartLayoutContractSection{Offset: dictionaryData.section.Offset, Length: dictionaryData.payloadLen(), Checksum: dictionaryData.payloadChecksum()}
 	} else if contract.Dictionary {
 		contract.StreamingCertified = false
 		contract.StatsCertified = false
@@ -497,6 +497,13 @@ func buildColumnPartLayoutContractColumn(opts ColumnPartImageOptions, columnDesc
 		}
 	}
 	return contract, nil
+}
+
+func (s columnPartImageSectionData) payloadChecksum() uint32 {
+	if len(s.chunks) == 0 {
+		return crc.Checksum(s.data)
+	}
+	return crc.ChecksumParts(s.chunks...)
 }
 
 type columnPartContractLayout struct {

--- a/TreeDB/internal/typedcolumn/layout_contract_test.go
+++ b/TreeDB/internal/typedcolumn/layout_contract_test.go
@@ -4,7 +4,30 @@ import (
 	"encoding/binary"
 	"strings"
 	"testing"
+
+	"github.com/snissn/gomap/TreeDB/internal/crc"
 )
+
+func TestColumnPartImageSectionDataChunkedPayloadHelpers(t *testing.T) {
+	chunks := [][]byte{
+		[]byte("alpha"),
+		[]byte(""),
+		[]byte("beta"),
+		[]byte("gamma"),
+	}
+	section := columnPartImageSectionData{chunks: chunks}
+	if got, want := section.payloadLen(), len("alphabetagamma"); got != want {
+		t.Fatalf("payloadLen=%d want %d", got, want)
+	}
+	got := section.appendPayloadTo([]byte("prefix:"))
+	want := []byte("prefix:alphabetagamma")
+	if string(got) != string(want) {
+		t.Fatalf("appendPayloadTo=%q want %q", got, want)
+	}
+	if got, want := section.payloadChecksum(), crc.Checksum([]byte("alphabetagamma")); got != want {
+		t.Fatalf("payloadChecksum=%08x want %08x", got, want)
+	}
+}
 
 func TestColumnPartLayoutContractCertifiesAlignedFixedWidthSections(t *testing.T) {
 	image := mustLayoutContractFixedWidthImage(t)

--- a/TreeDB/internal/typedcolumn/part_image.go
+++ b/TreeDB/internal/typedcolumn/part_image.go
@@ -389,6 +389,7 @@ type columnPartImageBuilder struct {
 type columnPartImageSectionData struct {
 	section ColumnPartImageSection
 	data    []byte
+	chunks  [][]byte
 }
 
 func (b *columnPartImageBuilder) build() (ColumnPartImage, error) {
@@ -434,7 +435,7 @@ func (b *columnPartImageBuilder) build() (ColumnPartImage, error) {
 			return ColumnPartImage{}, fmt.Errorf("typedcolumn: section %s offset=%d overlaps image bytes=%d", section.section.Kind, section.section.Offset, len(out))
 		}
 		out = append(out, make([]byte, section.section.Offset-len(out))...)
-		out = append(out, section.data...)
+		out = section.appendPayloadTo(out)
 	}
 	image := ColumnPartImage{
 		Version:       columnPartImageVersion,
@@ -465,9 +466,9 @@ func (b *columnPartImageBuilder) layoutManifestAndSections() ([]ColumnPartImageS
 		for i := range b.sections {
 			offset = alignColumnPartImageOffset(offset)
 			b.sections[i].section.Offset = offset
-			b.sections[i].section.Length = len(b.sections[i].data)
+			b.sections[i].section.Length = b.sections[i].payloadLen()
 			sections[i] = b.sections[i].section
-			offset += len(b.sections[i].data)
+			offset += b.sections[i].payloadLen()
 		}
 		if err := b.refreshLayoutContractSection(sections, len(manifest)); err != nil {
 			return nil, nil, err
@@ -977,17 +978,15 @@ func (b *columnPartImageBuilder) addColumnDataSections() error {
 			continue
 		}
 		totalPayloadBytes := 0
+		payloadChunks := make([][]byte, 0, len(column.Blocks))
 		for i, block := range column.Blocks {
 			if len(block.Granule.Payload) != block.Descriptor.StoredBytes {
 				return fmt.Errorf("typedcolumn: column %s block %d payload bytes=%d descriptor stored bytes=%d", columnDescriptor.Name, i, len(block.Granule.Payload), block.Descriptor.StoredBytes)
 			}
 			totalPayloadBytes += block.Descriptor.StoredBytes
+			payloadChunks = append(payloadChunks, block.Granule.Payload)
 		}
-		data := make([]byte, 0, totalPayloadBytes)
-		for _, block := range column.Blocks {
-			data = append(data, block.Granule.Payload...)
-		}
-		b.appendSection(ColumnPartImageSection{
+		b.appendChunkedSection(ColumnPartImageSection{
 			Kind:        ColumnPartImageSectionColumnData,
 			Category:    ColumnPartImageCategoryDeclaredColumns,
 			Column:      columnDescriptor.Name,
@@ -996,7 +995,7 @@ func (b *columnPartImageBuilder) addColumnDataSections() error {
 			Blocks:      len(column.Blocks),
 			Encoding:    column.Definition.Encoding,
 			Compression: column.Definition.Compression,
-		}, data)
+		}, payloadChunks, totalPayloadBytes)
 	}
 	return nil
 }
@@ -1182,6 +1181,17 @@ func (b *columnPartImageBuilder) appendSection(section ColumnPartImageSection, d
 	b.sections = append(b.sections, columnPartImageSectionData{
 		section: section,
 		data:    data,
+	})
+}
+
+func (b *columnPartImageBuilder) appendChunkedSection(section ColumnPartImageSection, chunks [][]byte, payloadBytes int) {
+	section.Length = payloadBytes
+	if section.RawBytes == 0 && (section.Compression == CompressionNone || section.Kind != ColumnPartImageSectionColumnData) {
+		section.RawBytes = payloadBytes
+	}
+	b.sections = append(b.sections, columnPartImageSectionData{
+		section: section,
+		chunks:  chunks,
 	})
 }
 
@@ -1413,9 +1423,30 @@ func countColumnBlocks(desc ColumnPartDescriptor) int {
 func sumImageSectionDataBytes(sections []columnPartImageSectionData) int {
 	total := 0
 	for _, section := range sections {
-		total += len(section.data)
+		total += section.payloadLen()
 	}
 	return total
+}
+
+func (s columnPartImageSectionData) payloadLen() int {
+	if len(s.chunks) == 0 {
+		return len(s.data)
+	}
+	total := 0
+	for _, chunk := range s.chunks {
+		total += len(chunk)
+	}
+	return total
+}
+
+func (s columnPartImageSectionData) appendPayloadTo(dst []byte) []byte {
+	if len(s.chunks) == 0 {
+		return append(dst, s.data...)
+	}
+	for _, chunk := range s.chunks {
+		dst = append(dst, chunk...)
+	}
+	return dst
 }
 
 func alignColumnPartImageOffset(offset int) int {


### PR DESCRIPTION
## Summary

- Avoid pre-concatenating normal typed-column data-section payloads before the final column-part image append.
- Keep manifest offsets/lengths, layout-contract checksums, final image bytes, and storage accounting semantics unchanged by making section payload length/checksum chunk-aware.
- Add a focused internal test for chunk-backed section payload length, append, and checksum helpers.

## Claim Boundary

This is load/write-path allocation and image-build work. It does not change query execution semantics, does not add metadata acceleration, and does not weaken WAL, value-log durability, or filesystem sync boundaries.

## Evidence

100k durable repeat from the worker using `-column-store-typed-compression none` to exercise typed-column image build:

Artifacts:
- Baseline main: `/tmp/treedb_jsonbench_load_typed_image_main_baseline_repeat_20260630_230533`
- Candidate: `/tmp/treedb_jsonbench_load_typed_image_candidate_repeat_20260630_230543`

Key counters, baseline -> candidate:

| metric | baseline | candidate |
| --- | ---: | ---: |
| load / insert | 1164.806 ms | 1077.135 ms |
| publish | 1000.803 ms | 920.209 ms |
| typed prepare | 141.820 ms | 129.169 ms |
| typed rows | 46.910 ms | 42.112 ms |
| typed image | 45.495 ms | 41.651 ms |
| typed part | 32.060 ms | 29.950 ms |
| typed dictionary | 11.338 ms | 9.838 ms |
| retained payload prepare | 136.993 ms | 131.849 ms |

Storage/parity stayed unchanged:

| counter | baseline | candidate |
| --- | ---: | ---: |
| typed column bytes | 8,024,300 | 8,024,300 |
| required / column asset bytes | 18,521,400 | 18,521,400 |
| command WAL before checkpoint | 11,179,605 | 11,179,605 |
| value vlog | 388,427 | 388,427 |
| leaf vlog | 1,577,961 | 1,577,961 |
| WAL-excluded durable storage | 21,274,671 | 21,274,671 |
| direct query parity | true | true |

## Validation

- `GOWORK=off go test ./TreeDB/internal/typedcolumn -count=1`
- `GOWORK=off go test ./TreeDB/collections -run 'Test.*TypedColumn.*|TestColumnPublish|TestPrepareColumnPhysicalAssetRows' -count=1`
- `GOWORK=off go build -o ./bin/unified-bench ./cmd/unified_bench`
- `git diff --check`
