### PR TITLE
Reuse q1 one-shot typed-column plan

### DIFF
--- a/TreeDB/collections/column_physical_q1_dense_1950_test.go
+++ b/TreeDB/collections/column_physical_q1_dense_1950_test.go
@@ -79,6 +79,8 @@ func TestColumnPhysicalQ1DenseTypedColumnOneShotSummaryUsesCounts1950(t *testing
 
 	runner, candidate, err := prepareColumnTypedColumnPhysicalQueryRunnerWithOptions(view, req, &readCache, columnTypedColumnPhysicalQueryRunnerPrepareOptions{
 		prepareAggregateSummaries: columnTypedColumnPhysicalQueryUseDenseGroupCount(plan, req),
+		plannedQuery:              plan,
+		hasPlannedQuery:           true,
 	})
 	if err != nil {
 		if runner != nil {
@@ -202,6 +204,36 @@ func TestColumnPhysicalQ1DenseTypedColumnOneShotSetupDiagnostics1950(t *testing.
 
 	diag := prepareColumnPhysicalQ1DenseOneShotSetup1950(t, view, req, plan)
 	assertColumnPhysicalQ1DenseOneShotSetupDiagnostics1950(t, "q1 one-shot setup", diag)
+}
+
+func TestColumnPhysicalQ1DenseTypedColumnOneShotReusesPlannedQuery1950(t *testing.T) {
+	batches := columnPhysicalQ1DenseEventBatches1950([][]string{
+		{"app.m", "app.z", "app.m", "app.z"},
+		{"app.a", "app.m", "app.a", "app.m"},
+	})
+	_, col, closeFn := openTypedColumnSortKeyFixtureBatches1950(t, nil, batches)
+	defer closeFn()
+
+	req := ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCount, GroupColumn: "collection"}
+	totalRows := totalQ1DenseRows1950(batches)
+	want := rowScanCollectionCounts1950(t, col, totalRows)
+	result, err := col.RunColumnPhysicalQuery(req)
+	if err != nil {
+		t.Fatalf("RunColumnPhysicalQuery(q1 dense one-shot): %v", err)
+	}
+	assertColumnPhysicalQ1DenseResult1950(t, "q1 one-shot planned-query reuse", result, want, totalRows, totalRows)
+	if !result.Diagnostics.TypedColumnOneShotCacheMiss || !result.Diagnostics.TypedColumnOneShotCacheBuild || result.Diagnostics.TypedColumnOneShotCacheHit {
+		t.Fatalf("q1 one-shot cache diagnostics hit/miss/build=%t/%t/%t want false/true/true diagnostics=%+v",
+			result.Diagnostics.TypedColumnOneShotCacheHit,
+			result.Diagnostics.TypedColumnOneShotCacheMiss,
+			result.Diagnostics.TypedColumnOneShotCacheBuild,
+			result.Diagnostics)
+	}
+	if result.Diagnostics.TypedColumnPreparePlanNanos != 0 {
+		t.Fatalf("q1 one-shot prepare plan nanos=%d want 0 when reusing already planned query diagnostics=%+v",
+			result.Diagnostics.TypedColumnPreparePlanNanos,
+			result.Diagnostics)
+	}
 }
 
 func TestColumnPhysicalQ1DenseTypedColumnOneShotTargetedSetupDiagnostics1950(t *testing.T) {
@@ -405,6 +437,8 @@ func prepareColumnPhysicalQ1DenseOneShotSetup1950(tb testing.TB, view columnPhys
 	buildStart := time.Now()
 	runner, candidate, err := prepareColumnTypedColumnPhysicalQueryRunnerWithOptions(view, req, &readCache, columnTypedColumnPhysicalQueryRunnerPrepareOptions{
 		prepareDenseGroupCountDistinctGlobalRanks: columnTypedColumnPhysicalQueryUseDenseGroupCountDistinct(plan, req),
+		plannedQuery:    plan,
+		hasPlannedQuery: true,
 	})
 	buildNanos := time.Since(buildStart).Nanoseconds()
 	if err != nil {
@@ -509,6 +543,12 @@ func assertColumnPhysicalQ1DenseOneShotSetupDiagnostics1950(tb testing.TB, label
 			label,
 			diag.TypedColumnOneShotBuildNanos,
 			diag.TypedColumnPreparePartDecodeNanos,
+			diag)
+	}
+	if diag.TypedColumnPreparePlanNanos != 0 {
+		tb.Fatalf("%s setup prepare plan nanos=%d want 0 for reused typed-column query plan diagnostics=%+v",
+			label,
+			diag.TypedColumnPreparePlanNanos,
 			diag)
 	}
 	if diag.TypedColumnPrepareSummaryNanos != 0 {

--- a/TreeDB/collections/column_physical_typed_column_cache.go
+++ b/TreeDB/collections/column_physical_typed_column_cache.go
@@ -107,6 +107,8 @@ func (c *Collection) runColumnTypedColumnOneShotWithCache(view columnPhysicalSca
 	runner, candidate, err := prepareColumnTypedColumnPhysicalQueryRunnerWithOptions(view, req, &readCache, columnTypedColumnPhysicalQueryRunnerPrepareOptions{
 		prepareAggregateSummaries:                 columnTypedColumnPhysicalQueryUseDenseGroupCount(plan, req),
 		prepareDenseGroupCountDistinctGlobalRanks: columnTypedColumnPhysicalQueryUseDenseGroupCountDistinct(plan, req),
+		plannedQuery:    plan,
+		hasPlannedQuery: true,
 	})
 	buildNanos := time.Since(buildStart).Nanoseconds()
 	if err != nil || !candidate {

--- a/TreeDB/collections/column_physical_typed_column_one_shot_cache_3088_test.go
+++ b/TreeDB/collections/column_physical_typed_column_one_shot_cache_3088_test.go
@@ -532,6 +532,9 @@ func assertTypedColumnOneShotCacheDiagnostics3158(tb testing.TB, label string, d
 	if !wantBuild && diag.TypedColumnOneShotBuildNanos != 0 {
 		tb.Fatalf("%s typed-column one-shot build nanos=%d want 0 diagnostics=%+v", label, diag.TypedColumnOneShotBuildNanos, diag)
 	}
+	if wantBuild && diag.TypedColumnPreparePlanNanos != 0 {
+		tb.Fatalf("%s typed-column one-shot prepare plan nanos=%d want 0 for reused query plan diagnostics=%+v", label, diag.TypedColumnPreparePlanNanos, diag)
+	}
 	prepareNanos := diag.TypedColumnPreparePlanNanos +
 		diag.TypedColumnPrepareRefsNanos +
 		diag.TypedColumnPreparePairingNanos +

--- a/TreeDB/collections/column_physical_typed_column_query.go
+++ b/TreeDB/collections/column_physical_typed_column_query.go
@@ -644,6 +644,8 @@ type columnTypedColumnPhysicalQueryRunnerPrepareOptions struct {
 	prepareDenseInt64SpanGlobalCodes          bool
 	prepareDenseGroupCountDistinctGlobalCodes bool
 	prepareDenseGroupCountDistinctGlobalRanks bool
+	plannedQuery                              columnTypedColumnPhysicalQueryPlan
+	hasPlannedQuery                           bool
 }
 
 func prepareColumnTypedColumnPhysicalQueryRunner(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest, readCache *columnPhysicalAssetReadCache, prepareSummaries bool) (*columnTypedColumnPhysicalQueryRunner, bool, error) {
@@ -659,11 +661,18 @@ func prepareColumnTypedColumnPhysicalQueryRunnerWithOptions(view columnPhysicalS
 		return nil, false, nil
 	}
 	var prepareDiagnostics columnTypedColumnPhysicalQueryPrepareDiagnostics
-	phaseStart := time.Now()
-	plan, candidate, err := planColumnTypedColumnPhysicalQuery(view.FullConfig, req)
-	prepareDiagnostics.PlanNanos = time.Since(phaseStart).Nanoseconds()
-	if err != nil || !candidate {
-		return nil, candidate, err
+	var plan columnTypedColumnPhysicalQueryPlan
+	candidate := true
+	if opts.hasPlannedQuery {
+		plan = opts.plannedQuery
+	} else {
+		phaseStart := time.Now()
+		var err error
+		plan, candidate, err = planColumnTypedColumnPhysicalQuery(view.FullConfig, req)
+		prepareDiagnostics.PlanNanos = time.Since(phaseStart).Nanoseconds()
+		if err != nil || !candidate {
+			return nil, candidate, err
+		}
 	}
 	if view.MutationParts != 0 {
 		return nil, true, fmt.Errorf("%w: typed-column part physical query requires insert-only manifest", ErrColumnQueryPlanUnsupported)
@@ -671,7 +680,7 @@ func prepareColumnTypedColumnPhysicalQueryRunnerWithOptions(view columnPhysicalS
 	if readCache == nil {
 		return nil, true, errors.New("collections: typed-column part physical query missing read cache")
 	}
-	phaseStart = time.Now()
+	phaseStart := time.Now()
 	refsByGeneration, err := typedColumnPhysicalQueryRefsByGeneration(view)
 	prepareDiagnostics.RefsNanos = time.Since(phaseStart).Nanoseconds()
 	if err != nil {


### PR DESCRIPTION
Refs #3350

## Summary
- Reuses the typed-column physical query plan already computed before the no-metadata one-shot cache lookup when building the cache-miss prepared runner.
- Leaves default prepared-runner behavior unchanged when no preplanned query is supplied.
- Adds focused q1 coverage plus one-shot cache diagnostics coverage so cache builds report zero inner prepare-plan time after reuse.

## Claim boundary
This is limited to no-aggregate one-shot typed-column cache-miss setup, with the q1 setup target as the motivating path. It does not add aggregate metadata acceleration and does not make any ClickHouse superiority or broader JSONBench throughput claim. The benchmark evidence does not show a statistically reliable wall-clock setup win; the confirmed win is removing the duplicate inner planning phase and a small allocation reduction.

## Changed files
- `TreeDB/collections/column_physical_typed_column_query.go`
- `TreeDB/collections/column_physical_typed_column_cache.go`
- `TreeDB/collections/column_physical_typed_column_one_shot_cache_3088_test.go`
- `TreeDB/collections/column_physical_q1_dense_1950_test.go`

## Validation
- `GOWORK=off go test ./TreeDB/collections -run '^(TestColumnPhysicalQ1DenseTypedColumn|TestColumnPhysicalQ3DenseTypedColumn|TestColumnPhysicalTypedColumnOneShotCacheQ1Q3NoMetadata3088|TestColumnPhysicalTypedColumnOneShotCacheQ2NoMetadata3123|TestColumnPhysicalTypedColumnParallelPartDecodeShapes3158|TestTypedColumnQ2(DenseGroupCountDistinct|SortedGroupedDistinct))'`
- Baseline q1 setup benchmark from clean `origin/main` worktree: `/tmp/q1-plan-reuse-baseline.txt`
- Candidate q1 setup benchmark from this branch: `/tmp/q1-plan-reuse-candidate-final.txt`
- `benchstat /tmp/q1-plan-reuse-baseline.txt /tmp/q1-plan-reuse-candidate-final.txt`
  - `sec/op`: 1043.6 us vs 938.4 us, not significant (`p=0.841`, `n=5`)
  - `typed_column_prepare_plan_nanos/op`: 2.617k -> 0.000k (`-100.00%`, `p=0.008`, `n=5`)
  - `B/op`: 1.299 MiB -> 1.298 MiB (`-0.08%`, `p=0.008`, `n=5`)
  - `allocs/op`: 4.980k -> 4.975k (`-0.10%`, `p=0.008`, `n=5`)
