### PR TITLE
Report retained semantic-stream prepare subphases

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -513,16 +513,25 @@ type CollectionInsertStats struct {
 	DuplicateDocumentPreflight time.Duration
 	// RetainedPayloadPrepare includes retained-payload transforms for column
 	// stores before the primary run is built.
-	RetainedPayloadPrepare              time.Duration
-	RetainedPayloadRows                 int
-	RetainedPayloadDeclaredRows         int
-	RetainedPayloadSemanticStreamBlocks int
-	RetainedPayloadValueLogPointerize   time.Duration
-	RetainedPayloadValueLogValues       int
-	RetainedPayloadValueLogBytes        int64
-	RetainedStreamValueLogPointerize    time.Duration
-	RetainedStreamValueLogValues        int
-	RetainedStreamValueLogBytes         int64
+	RetainedPayloadPrepare                          time.Duration
+	RetainedPayloadRows                             int
+	RetainedPayloadDeclaredRows                     int
+	RetainedPayloadSemanticStreamBlocks             int
+	RetainedPayloadSemanticStreamWorkerCount        int
+	RetainedPayloadSemanticStreamDeclaredRowPrepare time.Duration
+	RetainedPayloadSemanticStreamBlockPrepareWall   time.Duration
+	RetainedPayloadSemanticStreamBlockCollect       time.Duration
+	RetainedPayloadSemanticStreamBlockEncoderSetup  time.Duration
+	RetainedPayloadSemanticStreamBlockRawEncode     time.Duration
+	RetainedPayloadSemanticStreamBlockStoredEncode  time.Duration
+	RetainedPayloadSemanticStreamBlockFinalize      time.Duration
+	RetainedPayloadSemanticStreamTableBuild         time.Duration
+	RetainedPayloadValueLogPointerize               time.Duration
+	RetainedPayloadValueLogValues                   int
+	RetainedPayloadValueLogBytes                    int64
+	RetainedStreamValueLogPointerize                time.Duration
+	RetainedStreamValueLogValues                    int
+	RetainedStreamValueLogBytes                     int64
 	// ColumnPublish* fields are populated for typed-column InsertBatch paths
 	// that route through the command-WAL column manifest publish path.
 	ColumnPublishBuildColumnDelta       time.Duration
@@ -11051,6 +11060,15 @@ func (c *Collection) insertBatchNoIndex(
 		if retainedSemanticStreamBlocks != nil {
 			stats.RetainedPayloadSemanticStreamBlocks = retainedSemanticStreamBlocks.Len()
 		}
+		stats.RetainedPayloadSemanticStreamWorkerCount = prepared.semanticStreamPrepareMetrics.WorkerCount
+		stats.RetainedPayloadSemanticStreamDeclaredRowPrepare = prepared.semanticStreamPrepareMetrics.DeclaredRowPrepare
+		stats.RetainedPayloadSemanticStreamBlockPrepareWall = prepared.semanticStreamPrepareMetrics.BlockPrepareWall
+		stats.RetainedPayloadSemanticStreamBlockCollect = prepared.semanticStreamPrepareMetrics.BlockCollect
+		stats.RetainedPayloadSemanticStreamBlockEncoderSetup = prepared.semanticStreamPrepareMetrics.BlockEncoderSetup
+		stats.RetainedPayloadSemanticStreamBlockRawEncode = prepared.semanticStreamPrepareMetrics.BlockRawEncode
+		stats.RetainedPayloadSemanticStreamBlockStoredEncode = prepared.semanticStreamPrepareMetrics.BlockStoredEncode
+		stats.RetainedPayloadSemanticStreamBlockFinalize = prepared.semanticStreamPrepareMetrics.BlockFinalize
+		stats.RetainedPayloadSemanticStreamTableBuild = prepared.semanticStreamPrepareMetrics.TableBuild
 	}
 
 	phaseStart = time.Now()

--- a/TreeDB/collections/column_reconstruction.go
+++ b/TreeDB/collections/column_reconstruction.go
@@ -95,11 +95,12 @@ func columnRetainedPayloadFromJSONDocument(cfg ColumnStoreConfig, document []byt
 }
 
 type columnRetainedPayloadStorageDocuments struct {
-	documents            [][]byte
-	templateRecords      []templateV1Record
-	semanticStreamBlocks memtable.Table
-	declaredRows         []columnDeclaredRow
-	declaredRowsReady    bool
+	documents                    [][]byte
+	templateRecords              []templateV1Record
+	semanticStreamBlocks         memtable.Table
+	semanticStreamPrepareMetrics columnRetainedSemanticStreamV1PrepareMetrics
+	declaredRows                 []columnDeclaredRow
+	declaredRowsReady            bool
 }
 
 func prepareColumnRetainedPayloadStorageDocuments(cfg ColumnStoreConfig, documents [][]byte, fallback templateV1Resolver) (columnRetainedPayloadStorageDocuments, error) {

--- a/TreeDB/collections/column_retained_semantic_stream.go
+++ b/TreeDB/collections/column_retained_semantic_stream.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/buger/jsonparser"
 	"github.com/golang/snappy"
@@ -141,6 +142,36 @@ type columnRetainedSemanticStreamV1PreparedBlock struct {
 	block    []byte
 	locators [][]byte
 	declared []columnDeclaredRow
+	metrics  columnRetainedSemanticStreamV1PrepareMetrics
+}
+
+type columnRetainedSemanticStreamV1PrepareMetrics struct {
+	WorkerCount        int
+	DeclaredRowPrepare time.Duration
+	BlockPrepareWall   time.Duration
+	BlockCollect       time.Duration
+	BlockEncoderSetup  time.Duration
+	BlockRawEncode     time.Duration
+	BlockStoredEncode  time.Duration
+	BlockFinalize      time.Duration
+	TableBuild         time.Duration
+}
+
+func (m *columnRetainedSemanticStreamV1PrepareMetrics) add(other columnRetainedSemanticStreamV1PrepareMetrics) {
+	if m == nil {
+		return
+	}
+	if other.WorkerCount > m.WorkerCount {
+		m.WorkerCount = other.WorkerCount
+	}
+	m.DeclaredRowPrepare += other.DeclaredRowPrepare
+	m.BlockPrepareWall += other.BlockPrepareWall
+	m.BlockCollect += other.BlockCollect
+	m.BlockEncoderSetup += other.BlockEncoderSetup
+	m.BlockRawEncode += other.BlockRawEncode
+	m.BlockStoredEncode += other.BlockStoredEncode
+	m.BlockFinalize += other.BlockFinalize
+	m.TableBuild += other.TableBuild
 }
 
 type columnRetainedSemanticStreamV1RootFastPathPlan struct {
@@ -451,6 +482,7 @@ func prepareColumnRetainedSemanticStreamV1StorageDocumentsWithIDs(cfg ColumnStor
 	if len(documents) == 0 {
 		return out, nil
 	}
+	var metrics columnRetainedSemanticStreamV1PrepareMetrics
 	rootPlan, useRootFastPath := columnRetainedSemanticStreamV1RootFastPathPlanForConfig(cfg, ids, len(documents))
 	declaredPathTrie, useSemanticParserDeclaredRows := columnRetainedSemanticStreamV1DeclaredPathTrieForConfig(cfg, ids, len(documents))
 	if useRootFastPath && rootPlan.declaredRowsReady {
@@ -463,10 +495,12 @@ func prepareColumnRetainedSemanticStreamV1StorageDocumentsWithIDs(cfg ColumnStor
 	} else if ids != nil && len(ids) == len(documents) {
 		// Keep semantic-stream retained encoding unchanged while preparing
 		// declared rows early enough for column publish to reuse them.
+		declaredStart := time.Now()
 		rows, err := prepareColumnRetainedSemanticStreamV1DeclaredRowsFromJSONDocuments(cfg, ids, documents)
 		if err != nil {
 			return columnRetainedPayloadStorageDocuments{}, err
 		}
+		metrics.DeclaredRowPrepare = time.Since(declaredStart)
 		out.declaredRows = rows
 		out.declaredRowsReady = true
 	}
@@ -497,7 +531,10 @@ func prepareColumnRetainedSemanticStreamV1StorageDocumentsWithIDs(cfg ColumnStor
 		preparedBlocks[blockIdx] = prepared
 		return nil
 	}
-	if workers := columnRetainedSemanticStreamV1PrepareWorkers(blockCount); workers > 1 {
+	workers := columnRetainedSemanticStreamV1PrepareWorkers(blockCount)
+	metrics.WorkerCount = workers
+	blockPrepareStart := time.Now()
+	if workers > 1 {
 		if err := columnRetainedSemanticStreamV1RunPrepareWorkers(blockCount, workers, prepareBlock); err != nil {
 			return columnRetainedPayloadStorageDocuments{}, err
 		}
@@ -508,6 +545,11 @@ func prepareColumnRetainedSemanticStreamV1StorageDocumentsWithIDs(cfg ColumnStor
 			}
 		}
 	}
+	metrics.BlockPrepareWall = time.Since(blockPrepareStart)
+	for blockIdx := range preparedBlocks {
+		metrics.add(preparedBlocks[blockIdx].metrics)
+	}
+	tableStart := time.Now()
 	blockTable := newCollectionRunTable(blockCount)
 	for blockIdx := range preparedBlocks {
 		prepared := preparedBlocks[blockIdx]
@@ -519,6 +561,8 @@ func prepareColumnRetainedSemanticStreamV1StorageDocumentsWithIDs(cfg ColumnStor
 	}
 	blockTable.Freeze()
 	out.semanticStreamBlocks = blockTable
+	metrics.TableBuild = time.Since(tableStart)
+	out.semanticStreamPrepareMetrics = metrics
 	return out, nil
 }
 
@@ -580,6 +624,7 @@ func prepareColumnRetainedSemanticStreamV1StorageBlockWithIDs(
 	useSemanticParserDeclaredRows bool,
 ) (columnRetainedSemanticStreamV1PreparedBlock, error) {
 	rows := end - start
+	var metrics columnRetainedSemanticStreamV1PrepareMetrics
 	streams := newColumnRetainedSemanticStreamStreams()
 	pathInterner := &columnRetainedSemanticStreamV1PathSegmentInterner{}
 	var declaredStringInterner *columnDeclaredStringInterner
@@ -592,6 +637,7 @@ func prepareColumnRetainedSemanticStreamV1StorageBlockWithIDs(
 		declaredValues = make([]columnDeclaredValue, rows*len(cfg.Columns))
 		declaredRowIDBytes = make([]byte, 0, columnRetainedSemanticStreamV1DeclaredRowIDArenaCapacity(ids[start:end]))
 	}
+	collectStart := time.Now()
 	for row, i := 0, start; i < end; row, i = row+1, i+1 {
 		if useRootFastPath {
 			var declaredValuesDest []columnDeclaredValue
@@ -631,15 +677,21 @@ func prepareColumnRetainedSemanticStreamV1StorageBlockWithIDs(
 			}
 		}
 	}
+	metrics.BlockCollect = time.Since(collectStart)
+	encoderStart := time.Now()
 	storedBlockEncoder, err := newColumnRetainedSemanticStreamV1StoredBlockEncoder()
 	if err != nil {
 		return columnRetainedSemanticStreamV1PreparedBlock{}, err
 	}
+	metrics.BlockEncoderSetup = time.Since(encoderStart)
 	defer storedBlockEncoder.close()
-	block, err := encodeColumnRetainedSemanticStreamV1BlockFromStreamsWithEncoder(rows, streams, storedBlockEncoder)
+	block, rawEncode, storedEncode, err := encodeColumnRetainedSemanticStreamV1BlockFromStreamsWithEncoderMeasured(rows, streams, storedBlockEncoder)
 	if err != nil {
 		return columnRetainedSemanticStreamV1PreparedBlock{}, err
 	}
+	metrics.BlockRawEncode = rawEncode
+	metrics.BlockStoredEncode = storedEncode
+	finalizeStart := time.Now()
 	sum := sha256.Sum256(block)
 	blockKey := append([]byte(nil), sum[:]...)
 	locatorArena := make([]byte, 0, columnRetainedSemanticStreamV1LocatorBlockArenaCapacity(rows))
@@ -649,6 +701,7 @@ func prepareColumnRetainedSemanticStreamV1StorageBlockWithIDs(
 		locatorArena = appendColumnRetainedSemanticStreamV1Locator(locatorArena, blockKey, uint64(row))
 		locators[row] = locatorArena[locatorStart:len(locatorArena):len(locatorArena)]
 	}
+	metrics.BlockFinalize = time.Since(finalizeStart)
 	return columnRetainedSemanticStreamV1PreparedBlock{
 		start:    start,
 		rows:     rows,
@@ -656,6 +709,7 @@ func prepareColumnRetainedSemanticStreamV1StorageBlockWithIDs(
 		block:    block,
 		locators: locators,
 		declared: declaredRows,
+		metrics:  metrics,
 	}, nil
 }
 
@@ -1340,14 +1394,23 @@ func encodeColumnRetainedSemanticStreamV1BlockFromStreams(rows int, streams *col
 }
 
 func encodeColumnRetainedSemanticStreamV1BlockFromStreamsWithEncoder(rows int, streams *columnRetainedSemanticStreamStreams, encoder *columnRetainedSemanticStreamV1StoredBlockEncoder) ([]byte, error) {
+	block, _, _, err := encodeColumnRetainedSemanticStreamV1BlockFromStreamsWithEncoderMeasured(rows, streams, encoder)
+	return block, err
+}
+
+func encodeColumnRetainedSemanticStreamV1BlockFromStreamsWithEncoderMeasured(rows int, streams *columnRetainedSemanticStreamStreams, encoder *columnRetainedSemanticStreamV1StoredBlockEncoder) ([]byte, time.Duration, time.Duration, error) {
 	if encoder != nil {
-		return encoder.encodeStreamsWithRawLimit(rows, streams, maxColumnRetainedSemanticStreamV1CompressedRawBlockBytes)
+		return encoder.encodeStreamsWithRawLimitMeasured(rows, streams, maxColumnRetainedSemanticStreamV1CompressedRawBlockBytes)
 	}
+	rawStart := time.Now()
 	raw, err := encodeColumnRetainedSemanticStreamV1RawBlockFromStreams(rows, streams)
 	if err != nil {
-		return nil, err
+		return nil, time.Since(rawStart), 0, err
 	}
-	return encodeColumnRetainedSemanticStreamV1StoredBlock(raw)
+	rawDuration := time.Since(rawStart)
+	storedStart := time.Now()
+	block, err := encodeColumnRetainedSemanticStreamV1StoredBlock(raw)
+	return block, rawDuration, time.Since(storedStart), err
 }
 
 func encodeColumnRetainedSemanticStreamV1RawBlockFromStreams(rows int, streams *columnRetainedSemanticStreamStreams) ([]byte, error) {
@@ -1495,19 +1558,28 @@ func putColumnRetainedSemanticStreamV1RawBlockScratch(scratch []byte) {
 }
 
 func (e *columnRetainedSemanticStreamV1StoredBlockEncoder) encodeStreamsWithRawLimit(rows int, streams *columnRetainedSemanticStreamStreams, compressedRawLimit int) ([]byte, error) {
+	block, _, _, err := e.encodeStreamsWithRawLimitMeasured(rows, streams, compressedRawLimit)
+	return block, err
+}
+
+func (e *columnRetainedSemanticStreamV1StoredBlockEncoder) encodeStreamsWithRawLimitMeasured(rows int, streams *columnRetainedSemanticStreamStreams, compressedRawLimit int) ([]byte, time.Duration, time.Duration, error) {
+	rawStart := time.Now()
 	raw, err := encodeColumnRetainedSemanticStreamV1RawBlockFromStreamsInto(rows, streams, e.rawBlockScratch)
 	if err != nil {
-		return nil, err
+		return nil, time.Since(rawStart), 0, err
 	}
+	rawDuration := time.Since(rawStart)
+	storedStart := time.Now()
 	block, err := e.encodeWithRawLimit(raw, compressedRawLimit)
 	if err != nil {
-		return nil, err
+		return nil, rawDuration, time.Since(storedStart), err
 	}
+	storedDuration := time.Since(storedStart)
 	if columnRetainedSemanticStreamSlicesShareStart(block, raw) {
 		block = append([]byte(nil), block...)
 	}
 	e.retainRawBlockScratch(raw)
-	return block, nil
+	return block, rawDuration, storedDuration, nil
 }
 
 func (e *columnRetainedSemanticStreamV1StoredBlockEncoder) retainRawBlockScratch(raw []byte) {

--- a/TreeDB/collections/column_retained_semantic_stream.go
+++ b/TreeDB/collections/column_retained_semantic_stream.go
@@ -1574,10 +1574,10 @@ func (e *columnRetainedSemanticStreamV1StoredBlockEncoder) encodeStreamsWithRawL
 	if err != nil {
 		return nil, rawDuration, time.Since(storedStart), err
 	}
-	storedDuration := time.Since(storedStart)
 	if columnRetainedSemanticStreamSlicesShareStart(block, raw) {
 		block = append([]byte(nil), block...)
 	}
+	storedDuration := time.Since(storedStart)
 	e.retainRawBlockScratch(raw)
 	return block, rawDuration, storedDuration, nil
 }

--- a/TreeDB/collections/shape_bench_test.go
+++ b/TreeDB/collections/shape_bench_test.go
@@ -36,6 +36,17 @@ func addCollectionInsertStats(dst *collections.CollectionInsertStats, src collec
 	dst.RetainedPayloadRows += src.RetainedPayloadRows
 	dst.RetainedPayloadDeclaredRows += src.RetainedPayloadDeclaredRows
 	dst.RetainedPayloadSemanticStreamBlocks += src.RetainedPayloadSemanticStreamBlocks
+	if src.RetainedPayloadSemanticStreamWorkerCount > dst.RetainedPayloadSemanticStreamWorkerCount {
+		dst.RetainedPayloadSemanticStreamWorkerCount = src.RetainedPayloadSemanticStreamWorkerCount
+	}
+	dst.RetainedPayloadSemanticStreamDeclaredRowPrepare += src.RetainedPayloadSemanticStreamDeclaredRowPrepare
+	dst.RetainedPayloadSemanticStreamBlockPrepareWall += src.RetainedPayloadSemanticStreamBlockPrepareWall
+	dst.RetainedPayloadSemanticStreamBlockCollect += src.RetainedPayloadSemanticStreamBlockCollect
+	dst.RetainedPayloadSemanticStreamBlockEncoderSetup += src.RetainedPayloadSemanticStreamBlockEncoderSetup
+	dst.RetainedPayloadSemanticStreamBlockRawEncode += src.RetainedPayloadSemanticStreamBlockRawEncode
+	dst.RetainedPayloadSemanticStreamBlockStoredEncode += src.RetainedPayloadSemanticStreamBlockStoredEncode
+	dst.RetainedPayloadSemanticStreamBlockFinalize += src.RetainedPayloadSemanticStreamBlockFinalize
+	dst.RetainedPayloadSemanticStreamTableBuild += src.RetainedPayloadSemanticStreamTableBuild
 	dst.RetainedPayloadValueLogPointerize += src.RetainedPayloadValueLogPointerize
 	dst.RetainedPayloadValueLogValues += src.RetainedPayloadValueLogValues
 	dst.RetainedPayloadValueLogBytes += src.RetainedPayloadValueLogBytes
@@ -126,6 +137,14 @@ func benchmarkReportCollectionInsertStats(b *testing.B, docs, batches int, stats
 	reportDuration("index_state_extract_ns/doc", stats.IndexStateExtraction)
 	reportDuration("duplicate_preflight_ns/doc", stats.DuplicateDocumentPreflight)
 	reportDuration("retained_payload_prepare_ns/doc", stats.RetainedPayloadPrepare)
+	reportDuration("retained_payload_semantic_stream_declared_row_prepare_ns/doc", stats.RetainedPayloadSemanticStreamDeclaredRowPrepare)
+	reportDuration("retained_payload_semantic_stream_block_prepare_wall_ns/doc", stats.RetainedPayloadSemanticStreamBlockPrepareWall)
+	reportDuration("retained_payload_semantic_stream_block_collect_ns/doc", stats.RetainedPayloadSemanticStreamBlockCollect)
+	reportDuration("retained_payload_semantic_stream_block_encoder_setup_ns/doc", stats.RetainedPayloadSemanticStreamBlockEncoderSetup)
+	reportDuration("retained_payload_semantic_stream_block_raw_encode_ns/doc", stats.RetainedPayloadSemanticStreamBlockRawEncode)
+	reportDuration("retained_payload_semantic_stream_block_stored_encode_ns/doc", stats.RetainedPayloadSemanticStreamBlockStoredEncode)
+	reportDuration("retained_payload_semantic_stream_block_finalize_ns/doc", stats.RetainedPayloadSemanticStreamBlockFinalize)
+	reportDuration("retained_payload_semantic_stream_table_build_ns/doc", stats.RetainedPayloadSemanticStreamTableBuild)
 	reportDuration("retained_payload_vlog_pointerize_ns/doc", stats.RetainedPayloadValueLogPointerize)
 	reportDuration("retained_stream_vlog_pointerize_ns/doc", stats.RetainedStreamValueLogPointerize)
 	reportDuration("column_publish_build_column_delta_ns/doc", stats.ColumnPublishBuildColumnDelta)
@@ -257,6 +276,9 @@ func benchmarkReportCollectionInsertStats(b *testing.B, docs, batches int, stats
 		if stats.RetainedPayloadSemanticStreamBlocks > 0 {
 			b.ReportMetric(float64(stats.RetainedPayloadSemanticStreamBlocks)/float64(batches), "retained_payload_semantic_stream_blocks/batch")
 		}
+		if stats.RetainedPayloadSemanticStreamWorkerCount > 0 {
+			b.ReportMetric(float64(stats.RetainedPayloadSemanticStreamWorkerCount), "retained_payload_semantic_stream_workers")
+		}
 	}
 }
 
@@ -358,21 +380,52 @@ func TestCollectionShapeInsertStatsAddsSegmentAppendMetrics(t *testing.T) {
 func TestCollectionShapeInsertStatsIncludesRetainedValueLogPointerization(t *testing.T) {
 	var stats collections.CollectionInsertStats
 	addCollectionInsertStats(&stats, collections.CollectionInsertStats{
-		RetainedPayloadValueLogPointerize: 10 * time.Microsecond,
-		RetainedPayloadValueLogValues:     3,
-		RetainedPayloadValueLogBytes:      300,
-		RetainedStreamValueLogPointerize:  20 * time.Microsecond,
-		RetainedStreamValueLogValues:      4,
-		RetainedStreamValueLogBytes:       400,
+		RetainedPayloadSemanticStreamWorkerCount:        2,
+		RetainedPayloadSemanticStreamDeclaredRowPrepare: 11 * time.Microsecond,
+		RetainedPayloadSemanticStreamBlockPrepareWall:   12 * time.Microsecond,
+		RetainedPayloadSemanticStreamBlockCollect:       13 * time.Microsecond,
+		RetainedPayloadSemanticStreamBlockEncoderSetup:  14 * time.Microsecond,
+		RetainedPayloadSemanticStreamBlockRawEncode:     15 * time.Microsecond,
+		RetainedPayloadSemanticStreamBlockStoredEncode:  16 * time.Microsecond,
+		RetainedPayloadSemanticStreamBlockFinalize:      17 * time.Microsecond,
+		RetainedPayloadSemanticStreamTableBuild:         18 * time.Microsecond,
+		RetainedPayloadValueLogPointerize:               10 * time.Microsecond,
+		RetainedPayloadValueLogValues:                   3,
+		RetainedPayloadValueLogBytes:                    300,
+		RetainedStreamValueLogPointerize:                20 * time.Microsecond,
+		RetainedStreamValueLogValues:                    4,
+		RetainedStreamValueLogBytes:                     400,
 	})
 	addCollectionInsertStats(&stats, collections.CollectionInsertStats{
-		RetainedPayloadValueLogPointerize: 5 * time.Microsecond,
-		RetainedPayloadValueLogValues:     2,
-		RetainedPayloadValueLogBytes:      200,
-		RetainedStreamValueLogPointerize:  7 * time.Microsecond,
-		RetainedStreamValueLogValues:      1,
-		RetainedStreamValueLogBytes:       100,
+		RetainedPayloadSemanticStreamWorkerCount:        4,
+		RetainedPayloadSemanticStreamDeclaredRowPrepare: 1 * time.Microsecond,
+		RetainedPayloadSemanticStreamBlockPrepareWall:   2 * time.Microsecond,
+		RetainedPayloadSemanticStreamBlockCollect:       3 * time.Microsecond,
+		RetainedPayloadSemanticStreamBlockEncoderSetup:  4 * time.Microsecond,
+		RetainedPayloadSemanticStreamBlockRawEncode:     5 * time.Microsecond,
+		RetainedPayloadSemanticStreamBlockStoredEncode:  6 * time.Microsecond,
+		RetainedPayloadSemanticStreamBlockFinalize:      7 * time.Microsecond,
+		RetainedPayloadSemanticStreamTableBuild:         8 * time.Microsecond,
+		RetainedPayloadValueLogPointerize:               5 * time.Microsecond,
+		RetainedPayloadValueLogValues:                   2,
+		RetainedPayloadValueLogBytes:                    200,
+		RetainedStreamValueLogPointerize:                7 * time.Microsecond,
+		RetainedStreamValueLogValues:                    1,
+		RetainedStreamValueLogBytes:                     100,
 	})
+	if stats.RetainedPayloadSemanticStreamWorkerCount != 4 {
+		t.Fatalf("semantic-stream workers=%d want max 4", stats.RetainedPayloadSemanticStreamWorkerCount)
+	}
+	if stats.RetainedPayloadSemanticStreamDeclaredRowPrepare != 12*time.Microsecond ||
+		stats.RetainedPayloadSemanticStreamBlockPrepareWall != 14*time.Microsecond ||
+		stats.RetainedPayloadSemanticStreamBlockCollect != 16*time.Microsecond ||
+		stats.RetainedPayloadSemanticStreamBlockEncoderSetup != 18*time.Microsecond ||
+		stats.RetainedPayloadSemanticStreamBlockRawEncode != 20*time.Microsecond ||
+		stats.RetainedPayloadSemanticStreamBlockStoredEncode != 22*time.Microsecond ||
+		stats.RetainedPayloadSemanticStreamBlockFinalize != 24*time.Microsecond ||
+		stats.RetainedPayloadSemanticStreamTableBuild != 26*time.Microsecond {
+		t.Fatalf("semantic-stream timing stats not accumulated: %+v", stats)
+	}
 	if stats.RetainedPayloadValueLogPointerize != 15*time.Microsecond {
 		t.Fatalf("payload pointerize=%s want 15us", stats.RetainedPayloadValueLogPointerize)
 	}

--- a/cmd/unified_bench/suite_column_store.go
+++ b/cmd/unified_bench/suite_column_store.go
@@ -208,56 +208,65 @@ type columnStoreStageMetric struct {
 }
 
 type columnStoreInsertPhaseMetric struct {
-	Documents                                 int     `json:"documents"`
-	Batches                                   int     `json:"batches"`
-	Runs                                      int     `json:"runs"`
-	PrepareDocumentsDurationMS                float64 `json:"prepare_documents_duration_ms,omitempty"`
-	PrepareDocumentsNsPerRow                  float64 `json:"prepare_documents_ns_per_row,omitempty"`
-	DuplicateDocumentPreflightDurationMS      float64 `json:"duplicate_document_preflight_duration_ms,omitempty"`
-	DuplicateDocumentPreflightNsPerRow        float64 `json:"duplicate_document_preflight_ns_per_row,omitempty"`
-	RetainedPayloadPrepareDurationMS          float64 `json:"retained_payload_prepare_duration_ms,omitempty"`
-	RetainedPayloadPrepareNsPerRow            float64 `json:"retained_payload_prepare_ns_per_row,omitempty"`
-	RetainedPayloadRows                       int     `json:"retained_payload_rows,omitempty"`
-	RetainedPayloadDeclaredRows               int     `json:"retained_payload_declared_rows,omitempty"`
-	RetainedPayloadSemanticStreamBlocks       int     `json:"retained_payload_semantic_stream_blocks,omitempty"`
-	RetainedPayloadValueLogPointerizeMS       float64 `json:"retained_payload_value_log_pointerize_duration_ms,omitempty"`
-	RetainedPayloadValueLogPointerizeNsPerRow float64 `json:"retained_payload_value_log_pointerize_ns_per_row,omitempty"`
-	RetainedPayloadValueLogValues             int     `json:"retained_payload_value_log_values,omitempty"`
-	RetainedPayloadValueLogBytes              int64   `json:"retained_payload_value_log_bytes,omitempty"`
-	RetainedStreamValueLogPointerizeMS        float64 `json:"retained_stream_value_log_pointerize_duration_ms,omitempty"`
-	RetainedStreamValueLogPointerizeNsPerRow  float64 `json:"retained_stream_value_log_pointerize_ns_per_row,omitempty"`
-	RetainedStreamValueLogValues              int     `json:"retained_stream_value_log_values,omitempty"`
-	RetainedStreamValueLogBytes               int64   `json:"retained_stream_value_log_bytes,omitempty"`
-	ColumnPublishBuildColumnDeltaDurationMS   float64 `json:"column_publish_build_column_delta_duration_ms,omitempty"`
-	ColumnPublishBuildColumnDeltaNsPerRow     float64 `json:"column_publish_build_column_delta_ns_per_row,omitempty"`
-	ColumnPublishBuildSystemDeltaDurationMS   float64 `json:"column_publish_build_system_delta_duration_ms,omitempty"`
-	ColumnPublishBuildSystemDeltaNsPerRow     float64 `json:"column_publish_build_system_delta_ns_per_row,omitempty"`
-	ColumnPublishCommitDurationMS             float64 `json:"column_publish_commit_duration_ms,omitempty"`
-	ColumnPublishCommitNsPerRow               float64 `json:"column_publish_commit_ns_per_row,omitempty"`
-	ColumnPublishDocumentExtractionDurationMS float64 `json:"column_publish_document_extraction_duration_ms,omitempty"`
-	ColumnPublishDeclaredColumnDurationMS     float64 `json:"column_publish_declared_column_encoding_duration_ms,omitempty"`
-	ColumnPublishAssetPreparationDurationMS   float64 `json:"column_publish_asset_preparation_duration_ms,omitempty"`
-	ColumnPublishRowAssetPrepareDurationMS    float64 `json:"column_publish_row_asset_prepare_duration_ms,omitempty"`
-	ColumnPublishTypedColumnPrepareDurationMS float64 `json:"column_publish_typed_column_prepare_duration_ms,omitempty"`
-	ColumnPublishTypedColumnDictionaryBuildMS float64 `json:"column_publish_typed_column_dictionary_build_duration_ms,omitempty"`
-	ColumnPublishTypedColumnRowMaterializeMS  float64 `json:"column_publish_typed_column_row_materialization_duration_ms,omitempty"`
-	ColumnPublishTypedColumnPartBuildMS       float64 `json:"column_publish_typed_column_part_build_duration_ms,omitempty"`
-	ColumnPublishTypedColumnImageBuildMS      float64 `json:"column_publish_typed_column_image_build_duration_ms,omitempty"`
-	ColumnPublishDictionaryPrepareDurationMS  float64 `json:"column_publish_dictionary_sidecar_prepare_duration_ms,omitempty"`
-	ColumnPublishInt64PrepareDurationMS       float64 `json:"column_publish_int64_sidecar_prepare_duration_ms,omitempty"`
-	ColumnPublishAggregateMetadataDurationMS  float64 `json:"column_publish_aggregate_metadata_prepare_duration_ms,omitempty"`
-	ColumnPublishRowSidecarSharedBuildMS      float64 `json:"column_publish_row_sidecar_shared_build_duration_ms,omitempty"`
-	ColumnPublishAssetAppendDurationMS        float64 `json:"column_publish_asset_append_duration_ms,omitempty"`
-	ColumnPublishAssetAppendOpenDurationMS    float64 `json:"column_publish_asset_append_open_duration_ms,omitempty"`
-	ColumnPublishAssetAppendWriteDurationMS   float64 `json:"column_publish_asset_append_write_duration_ms,omitempty"`
-	ColumnPublishAssetAppendCloseDurationMS   float64 `json:"column_publish_asset_append_close_duration_ms,omitempty"`
-	ColumnPublishAssetAppendFileSyncMS        float64 `json:"column_publish_asset_append_file_sync_duration_ms"`
-	ColumnPublishAssetAppendFileCloseMS       float64 `json:"column_publish_asset_append_file_close_duration_ms"`
-	ColumnPublishAssetAppendDirSyncMS         float64 `json:"column_publish_asset_append_dir_sync_duration_ms"`
-	ColumnPublishAssetAppendCleanupMS         float64 `json:"column_publish_asset_append_cleanup_duration_ms"`
-	ColumnPublishAssetAppenderCloseCount      int     `json:"column_publish_asset_appender_close_count,omitempty"`
-	ColumnPublishAssetAppendFileSyncCount     int     `json:"column_publish_asset_append_file_sync_count,omitempty"`
-	ColumnPublishAssetSyncEpochCount          int     `json:"column_publish_asset_sync_epoch_count,omitempty"`
+	Documents                                  int     `json:"documents"`
+	Batches                                    int     `json:"batches"`
+	Runs                                       int     `json:"runs"`
+	PrepareDocumentsDurationMS                 float64 `json:"prepare_documents_duration_ms,omitempty"`
+	PrepareDocumentsNsPerRow                   float64 `json:"prepare_documents_ns_per_row,omitempty"`
+	DuplicateDocumentPreflightDurationMS       float64 `json:"duplicate_document_preflight_duration_ms,omitempty"`
+	DuplicateDocumentPreflightNsPerRow         float64 `json:"duplicate_document_preflight_ns_per_row,omitempty"`
+	RetainedPayloadPrepareDurationMS           float64 `json:"retained_payload_prepare_duration_ms,omitempty"`
+	RetainedPayloadPrepareNsPerRow             float64 `json:"retained_payload_prepare_ns_per_row,omitempty"`
+	RetainedPayloadRows                        int     `json:"retained_payload_rows,omitempty"`
+	RetainedPayloadDeclaredRows                int     `json:"retained_payload_declared_rows,omitempty"`
+	RetainedPayloadSemanticStreamBlocks        int     `json:"retained_payload_semantic_stream_blocks,omitempty"`
+	RetainedPayloadSemanticStreamWorkers       int     `json:"retained_payload_semantic_stream_worker_count,omitempty"`
+	RetainedPayloadSemanticStreamDeclaredMS    float64 `json:"retained_payload_semantic_stream_declared_row_prepare_duration_ms,omitempty"`
+	RetainedPayloadSemanticStreamBlockWallMS   float64 `json:"retained_payload_semantic_stream_block_prepare_wall_duration_ms,omitempty"`
+	RetainedPayloadSemanticStreamCollectMS     float64 `json:"retained_payload_semantic_stream_block_collect_duration_ms,omitempty"`
+	RetainedPayloadSemanticStreamEncoderMS     float64 `json:"retained_payload_semantic_stream_block_encoder_setup_duration_ms,omitempty"`
+	RetainedPayloadSemanticStreamRawEncodeMS   float64 `json:"retained_payload_semantic_stream_block_raw_encode_duration_ms,omitempty"`
+	RetainedPayloadSemanticStreamStoreEncodeMS float64 `json:"retained_payload_semantic_stream_block_stored_encode_duration_ms,omitempty"`
+	RetainedPayloadSemanticStreamFinalizeMS    float64 `json:"retained_payload_semantic_stream_block_finalize_duration_ms,omitempty"`
+	RetainedPayloadSemanticStreamTableBuildMS  float64 `json:"retained_payload_semantic_stream_table_build_duration_ms,omitempty"`
+	RetainedPayloadValueLogPointerizeMS        float64 `json:"retained_payload_value_log_pointerize_duration_ms,omitempty"`
+	RetainedPayloadValueLogPointerizeNsPerRow  float64 `json:"retained_payload_value_log_pointerize_ns_per_row,omitempty"`
+	RetainedPayloadValueLogValues              int     `json:"retained_payload_value_log_values,omitempty"`
+	RetainedPayloadValueLogBytes               int64   `json:"retained_payload_value_log_bytes,omitempty"`
+	RetainedStreamValueLogPointerizeMS         float64 `json:"retained_stream_value_log_pointerize_duration_ms,omitempty"`
+	RetainedStreamValueLogPointerizeNsPerRow   float64 `json:"retained_stream_value_log_pointerize_ns_per_row,omitempty"`
+	RetainedStreamValueLogValues               int     `json:"retained_stream_value_log_values,omitempty"`
+	RetainedStreamValueLogBytes                int64   `json:"retained_stream_value_log_bytes,omitempty"`
+	ColumnPublishBuildColumnDeltaDurationMS    float64 `json:"column_publish_build_column_delta_duration_ms,omitempty"`
+	ColumnPublishBuildColumnDeltaNsPerRow      float64 `json:"column_publish_build_column_delta_ns_per_row,omitempty"`
+	ColumnPublishBuildSystemDeltaDurationMS    float64 `json:"column_publish_build_system_delta_duration_ms,omitempty"`
+	ColumnPublishBuildSystemDeltaNsPerRow      float64 `json:"column_publish_build_system_delta_ns_per_row,omitempty"`
+	ColumnPublishCommitDurationMS              float64 `json:"column_publish_commit_duration_ms,omitempty"`
+	ColumnPublishCommitNsPerRow                float64 `json:"column_publish_commit_ns_per_row,omitempty"`
+	ColumnPublishDocumentExtractionDurationMS  float64 `json:"column_publish_document_extraction_duration_ms,omitempty"`
+	ColumnPublishDeclaredColumnDurationMS      float64 `json:"column_publish_declared_column_encoding_duration_ms,omitempty"`
+	ColumnPublishAssetPreparationDurationMS    float64 `json:"column_publish_asset_preparation_duration_ms,omitempty"`
+	ColumnPublishRowAssetPrepareDurationMS     float64 `json:"column_publish_row_asset_prepare_duration_ms,omitempty"`
+	ColumnPublishTypedColumnPrepareDurationMS  float64 `json:"column_publish_typed_column_prepare_duration_ms,omitempty"`
+	ColumnPublishTypedColumnDictionaryBuildMS  float64 `json:"column_publish_typed_column_dictionary_build_duration_ms,omitempty"`
+	ColumnPublishTypedColumnRowMaterializeMS   float64 `json:"column_publish_typed_column_row_materialization_duration_ms,omitempty"`
+	ColumnPublishTypedColumnPartBuildMS        float64 `json:"column_publish_typed_column_part_build_duration_ms,omitempty"`
+	ColumnPublishTypedColumnImageBuildMS       float64 `json:"column_publish_typed_column_image_build_duration_ms,omitempty"`
+	ColumnPublishDictionaryPrepareDurationMS   float64 `json:"column_publish_dictionary_sidecar_prepare_duration_ms,omitempty"`
+	ColumnPublishInt64PrepareDurationMS        float64 `json:"column_publish_int64_sidecar_prepare_duration_ms,omitempty"`
+	ColumnPublishAggregateMetadataDurationMS   float64 `json:"column_publish_aggregate_metadata_prepare_duration_ms,omitempty"`
+	ColumnPublishRowSidecarSharedBuildMS       float64 `json:"column_publish_row_sidecar_shared_build_duration_ms,omitempty"`
+	ColumnPublishAssetAppendDurationMS         float64 `json:"column_publish_asset_append_duration_ms,omitempty"`
+	ColumnPublishAssetAppendOpenDurationMS     float64 `json:"column_publish_asset_append_open_duration_ms,omitempty"`
+	ColumnPublishAssetAppendWriteDurationMS    float64 `json:"column_publish_asset_append_write_duration_ms,omitempty"`
+	ColumnPublishAssetAppendCloseDurationMS    float64 `json:"column_publish_asset_append_close_duration_ms,omitempty"`
+	ColumnPublishAssetAppendFileSyncMS         float64 `json:"column_publish_asset_append_file_sync_duration_ms"`
+	ColumnPublishAssetAppendFileCloseMS        float64 `json:"column_publish_asset_append_file_close_duration_ms"`
+	ColumnPublishAssetAppendDirSyncMS          float64 `json:"column_publish_asset_append_dir_sync_duration_ms"`
+	ColumnPublishAssetAppendCleanupMS          float64 `json:"column_publish_asset_append_cleanup_duration_ms"`
+	ColumnPublishAssetAppenderCloseCount       int     `json:"column_publish_asset_appender_close_count,omitempty"`
+	ColumnPublishAssetAppendFileSyncCount      int     `json:"column_publish_asset_append_file_sync_count,omitempty"`
+	ColumnPublishAssetSyncEpochCount           int     `json:"column_publish_asset_sync_epoch_count,omitempty"`
 
 	ColumnPublishSharedSegmentAppenderCloseCount       int `json:"column_publish_shared_segment_appender_close_count,omitempty"`
 	ColumnPublishSharedSegmentAppendFileSyncCount      int `json:"column_publish_shared_segment_append_file_sync_count,omitempty"`
@@ -1608,6 +1617,17 @@ func columnStoreAddCollectionInsertStats(dst *collections.CollectionInsertStats,
 	dst.RetainedPayloadRows += src.RetainedPayloadRows
 	dst.RetainedPayloadDeclaredRows += src.RetainedPayloadDeclaredRows
 	dst.RetainedPayloadSemanticStreamBlocks += src.RetainedPayloadSemanticStreamBlocks
+	if src.RetainedPayloadSemanticStreamWorkerCount > dst.RetainedPayloadSemanticStreamWorkerCount {
+		dst.RetainedPayloadSemanticStreamWorkerCount = src.RetainedPayloadSemanticStreamWorkerCount
+	}
+	dst.RetainedPayloadSemanticStreamDeclaredRowPrepare += src.RetainedPayloadSemanticStreamDeclaredRowPrepare
+	dst.RetainedPayloadSemanticStreamBlockPrepareWall += src.RetainedPayloadSemanticStreamBlockPrepareWall
+	dst.RetainedPayloadSemanticStreamBlockCollect += src.RetainedPayloadSemanticStreamBlockCollect
+	dst.RetainedPayloadSemanticStreamBlockEncoderSetup += src.RetainedPayloadSemanticStreamBlockEncoderSetup
+	dst.RetainedPayloadSemanticStreamBlockRawEncode += src.RetainedPayloadSemanticStreamBlockRawEncode
+	dst.RetainedPayloadSemanticStreamBlockStoredEncode += src.RetainedPayloadSemanticStreamBlockStoredEncode
+	dst.RetainedPayloadSemanticStreamBlockFinalize += src.RetainedPayloadSemanticStreamBlockFinalize
+	dst.RetainedPayloadSemanticStreamTableBuild += src.RetainedPayloadSemanticStreamTableBuild
 	dst.RetainedPayloadValueLogPointerize += src.RetainedPayloadValueLogPointerize
 	dst.RetainedPayloadValueLogValues += src.RetainedPayloadValueLogValues
 	dst.RetainedPayloadValueLogBytes += src.RetainedPayloadValueLogBytes
@@ -1699,6 +1719,15 @@ func columnStoreInsertPhaseMetricFromStats(stats collections.CollectionInsertSta
 		RetainedPayloadRows:                                stats.RetainedPayloadRows,
 		RetainedPayloadDeclaredRows:                        stats.RetainedPayloadDeclaredRows,
 		RetainedPayloadSemanticStreamBlocks:                stats.RetainedPayloadSemanticStreamBlocks,
+		RetainedPayloadSemanticStreamWorkers:               stats.RetainedPayloadSemanticStreamWorkerCount,
+		RetainedPayloadSemanticStreamDeclaredMS:            durationMS(stats.RetainedPayloadSemanticStreamDeclaredRowPrepare),
+		RetainedPayloadSemanticStreamBlockWallMS:           durationMS(stats.RetainedPayloadSemanticStreamBlockPrepareWall),
+		RetainedPayloadSemanticStreamCollectMS:             durationMS(stats.RetainedPayloadSemanticStreamBlockCollect),
+		RetainedPayloadSemanticStreamEncoderMS:             durationMS(stats.RetainedPayloadSemanticStreamBlockEncoderSetup),
+		RetainedPayloadSemanticStreamRawEncodeMS:           durationMS(stats.RetainedPayloadSemanticStreamBlockRawEncode),
+		RetainedPayloadSemanticStreamStoreEncodeMS:         durationMS(stats.RetainedPayloadSemanticStreamBlockStoredEncode),
+		RetainedPayloadSemanticStreamFinalizeMS:            durationMS(stats.RetainedPayloadSemanticStreamBlockFinalize),
+		RetainedPayloadSemanticStreamTableBuildMS:          durationMS(stats.RetainedPayloadSemanticStreamTableBuild),
 		RetainedPayloadValueLogPointerizeMS:                durationMS(stats.RetainedPayloadValueLogPointerize),
 		RetainedPayloadValueLogPointerizeNsPerRow:          nsPerRow(stats.RetainedPayloadValueLogPointerize, rows),
 		RetainedPayloadValueLogValues:                      stats.RetainedPayloadValueLogValues,
@@ -4805,6 +4834,7 @@ func renderColumnStoreInsertStatsMarkdown(sb *strings.Builder, stats columnStore
 	sb.WriteString(fmt.Sprintf("- retained_payload_rows: %d\n", stats.RetainedPayloadRows))
 	sb.WriteString(fmt.Sprintf("- retained_payload_declared_rows: %d\n", stats.RetainedPayloadDeclaredRows))
 	sb.WriteString(fmt.Sprintf("- retained_payload_semantic_stream_blocks: %d\n", stats.RetainedPayloadSemanticStreamBlocks))
+	sb.WriteString(fmt.Sprintf("- retained_payload_semantic_stream_worker_count: %d\n", stats.RetainedPayloadSemanticStreamWorkers))
 	sb.WriteString(fmt.Sprintf("- retained_payload_value_log_values: %d\n", stats.RetainedPayloadValueLogValues))
 	sb.WriteString(fmt.Sprintf("- retained_payload_value_log_bytes: %d\n", stats.RetainedPayloadValueLogBytes))
 	sb.WriteString(fmt.Sprintf("- retained_stream_value_log_values: %d\n", stats.RetainedStreamValueLogValues))
@@ -4846,6 +4876,19 @@ func renderColumnStoreInsertStatsMarkdown(sb *strings.Builder, stats columnStore
 	sb.WriteString(fmt.Sprintf("| `primary_run_build` | %.3f | %.1f |\n", stats.PrimaryRunBuildDurationMS, stats.PrimaryRunBuildNsPerRow))
 	sb.WriteString(fmt.Sprintf("| `publish` | %.3f | %.1f |\n\n", stats.PublishDurationMS, stats.PublishNsPerRow))
 
+	if columnStoreInsertStatsHasRetainedSemanticStreamSubphase(stats) {
+		sb.WriteString("| retained semantic-stream prepare subphase | ms |\n")
+		sb.WriteString("|---|---:|\n")
+		sb.WriteString(fmt.Sprintf("| `declared_row_prepare` | %.3f |\n", stats.RetainedPayloadSemanticStreamDeclaredMS))
+		sb.WriteString(fmt.Sprintf("| `block_prepare_wall` | %.3f |\n", stats.RetainedPayloadSemanticStreamBlockWallMS))
+		sb.WriteString(fmt.Sprintf("| `block_collect_sum` | %.3f |\n", stats.RetainedPayloadSemanticStreamCollectMS))
+		sb.WriteString(fmt.Sprintf("| `block_encoder_setup_sum` | %.3f |\n", stats.RetainedPayloadSemanticStreamEncoderMS))
+		sb.WriteString(fmt.Sprintf("| `block_raw_encode_sum` | %.3f |\n", stats.RetainedPayloadSemanticStreamRawEncodeMS))
+		sb.WriteString(fmt.Sprintf("| `block_stored_encode_sum` | %.3f |\n", stats.RetainedPayloadSemanticStreamStoreEncodeMS))
+		sb.WriteString(fmt.Sprintf("| `block_finalize_sum` | %.3f |\n", stats.RetainedPayloadSemanticStreamFinalizeMS))
+		sb.WriteString(fmt.Sprintf("| `table_build` | %.3f |\n\n", stats.RetainedPayloadSemanticStreamTableBuildMS))
+	}
+
 	if columnStoreInsertStatsHasColumnPublishSubphase(stats) {
 		sb.WriteString("| column publish subphase | ms | ns/row |\n")
 		sb.WriteString("|---|---:|---:|\n")
@@ -4879,6 +4922,17 @@ func renderColumnStoreInsertStatsMarkdown(sb *strings.Builder, stats columnStore
 		sb.WriteString(fmt.Sprintf("| `root_delta_materialization` | %.3f |  |\n", stats.ColumnPublishRootDeltaMaterializeMS))
 		sb.WriteString(fmt.Sprintf("| `system_delta_construction` | %.3f |  |\n\n", stats.ColumnPublishSystemDeltaDurationMS))
 	}
+}
+
+func columnStoreInsertStatsHasRetainedSemanticStreamSubphase(stats columnStoreInsertPhaseMetric) bool {
+	return stats.RetainedPayloadSemanticStreamDeclaredMS > 0 ||
+		stats.RetainedPayloadSemanticStreamBlockWallMS > 0 ||
+		stats.RetainedPayloadSemanticStreamCollectMS > 0 ||
+		stats.RetainedPayloadSemanticStreamEncoderMS > 0 ||
+		stats.RetainedPayloadSemanticStreamRawEncodeMS > 0 ||
+		stats.RetainedPayloadSemanticStreamStoreEncodeMS > 0 ||
+		stats.RetainedPayloadSemanticStreamFinalizeMS > 0 ||
+		stats.RetainedPayloadSemanticStreamTableBuildMS > 0
 }
 
 func columnStoreInsertStatsHasColumnPublishSubphase(stats columnStoreInsertPhaseMetric) bool {

--- a/cmd/unified_bench/suite_column_store_test.go
+++ b/cmd/unified_bench/suite_column_store_test.go
@@ -836,7 +836,7 @@ func TestRunColumnStoreSuiteWritesArtifactsAndMetricsM11A(t *testing.T) {
 			t.Fatalf("column store JSON missing WAL-excluded durable storage field %s:\n%s", want, data)
 		}
 	}
-	for _, want := range []string{`"insert_stats"`, `"retained_payload_prepare_duration_ms"`, `"retained_payload_prepare_ns_per_row"`, `"retained_payload_declared_rows"`, `"column_store_declared_row_reuse_coverage_ratio"`, `"column_publish_build_column_delta_duration_ms"`, `"column_publish_commit_duration_ms"`, `"column_publish_asset_preparation_duration_ms"`, `"column_publish_row_asset_prepare_duration_ms"`, `"column_publish_aggregate_metadata_prepare_duration_ms"`, `"column_publish_asset_append_duration_ms"`, `"column_publish_asset_append_open_duration_ms"`, `"column_publish_asset_append_write_duration_ms"`, `"column_publish_asset_append_close_duration_ms"`, `"column_publish_asset_append_file_sync_duration_ms"`, `"column_publish_asset_append_file_close_duration_ms"`, `"column_publish_asset_append_dir_sync_duration_ms"`, `"column_publish_asset_append_cleanup_duration_ms"`, `"column_publish_aggregate_metadata_bytes"`, `"column_publish_shared_asset_append_bytes"`, `"column_publish_required_asset_bytes"`} {
+	for _, want := range []string{`"insert_stats"`, `"retained_payload_prepare_duration_ms"`, `"retained_payload_prepare_ns_per_row"`, `"retained_payload_declared_rows"`, `"retained_payload_semantic_stream_worker_count"`, `"retained_payload_semantic_stream_block_prepare_wall_duration_ms"`, `"retained_payload_semantic_stream_block_collect_duration_ms"`, `"retained_payload_semantic_stream_block_raw_encode_duration_ms"`, `"retained_payload_semantic_stream_block_stored_encode_duration_ms"`, `"retained_payload_semantic_stream_table_build_duration_ms"`, `"column_store_declared_row_reuse_coverage_ratio"`, `"column_publish_build_column_delta_duration_ms"`, `"column_publish_commit_duration_ms"`, `"column_publish_asset_preparation_duration_ms"`, `"column_publish_row_asset_prepare_duration_ms"`, `"column_publish_aggregate_metadata_prepare_duration_ms"`, `"column_publish_asset_append_duration_ms"`, `"column_publish_asset_append_open_duration_ms"`, `"column_publish_asset_append_write_duration_ms"`, `"column_publish_asset_append_close_duration_ms"`, `"column_publish_asset_append_file_sync_duration_ms"`, `"column_publish_asset_append_file_close_duration_ms"`, `"column_publish_asset_append_dir_sync_duration_ms"`, `"column_publish_asset_append_cleanup_duration_ms"`, `"column_publish_aggregate_metadata_bytes"`, `"column_publish_shared_asset_append_bytes"`, `"column_publish_required_asset_bytes"`} {
 		if !strings.Contains(string(data), want) {
 			t.Fatalf("column store JSON missing insert phase field %s:\n%s", want, data)
 		}
@@ -870,7 +870,7 @@ func TestRunColumnStoreSuiteWritesArtifactsAndMetricsM11A(t *testing.T) {
 			t.Fatalf("column store markdown missing WAL-excluded durable storage field %q:\n%s", want, columnMarkdown)
 		}
 	}
-	for _, want := range []string{"## Insert Phase Stats", "retained_payload_prepare", "retained_payload_declared_rows", "column_store_declared_row_reuse_coverage_ratio", "column_publish_rows", "column_publish_aggregate_metadata_bytes", "column publish subphase", "build_column_delta_callback", "publish_commit_total", "aggregate_metadata_prepare", "asset_append", "asset_append_open", "asset_append_write", "asset_append_close", "asset_append_file_sync", "asset_append_file_close", "asset_append_dir_sync", "asset_append_cleanup"} {
+	for _, want := range []string{"## Insert Phase Stats", "retained_payload_prepare", "retained_payload_declared_rows", "retained_payload_semantic_stream_worker_count", "retained semantic-stream prepare subphase", "block_prepare_wall", "block_raw_encode_sum", "block_stored_encode_sum", "column_store_declared_row_reuse_coverage_ratio", "column_publish_rows", "column_publish_aggregate_metadata_bytes", "column publish subphase", "build_column_delta_callback", "publish_commit_total", "aggregate_metadata_prepare", "asset_append", "asset_append_open", "asset_append_write", "asset_append_close", "asset_append_file_sync", "asset_append_file_close", "asset_append_dir_sync", "asset_append_cleanup"} {
 		if !strings.Contains(string(columnMarkdown), want) {
 			t.Fatalf("column store markdown missing insert phase field %q:\n%s", want, columnMarkdown)
 		}
@@ -2960,39 +2960,48 @@ func TestColumnStoreInsertPhaseMetricFromStatsIncludesAssetFamiliesM3148(t *test
 		ColumnPublishTypedColumnPartBuild:          23 * time.Millisecond,
 		ColumnPublishTypedColumnImageBuild:         24 * time.Millisecond,
 
-		ColumnPublishDictionaryPreparation:    3 * time.Millisecond,
-		ColumnPublishInt64Preparation:         4 * time.Millisecond,
-		ColumnPublishAggregateMetadataPrepare: 5 * time.Millisecond,
-		ColumnPublishRowSidecarSharedBuild:    6 * time.Millisecond,
-		ColumnPublishAssetAppend:              7 * time.Millisecond,
-		ColumnPublishAssetAppendOpen:          2 * time.Millisecond,
-		ColumnPublishAssetAppendWrite:         3 * time.Millisecond,
-		ColumnPublishAssetAppendClose:         4 * time.Millisecond,
-		ColumnPublishAssetAppendFileSync:      11 * time.Millisecond,
-		ColumnPublishAssetAppendFileClose:     12 * time.Millisecond,
-		ColumnPublishAssetAppendDirSync:       13 * time.Millisecond,
-		ColumnPublishAssetAppendCleanup:       14 * time.Millisecond,
-		ColumnPublishAssetAppenderCloseCount:  3,
-		ColumnPublishAssetAppendFileSyncCount: 2,
-		ColumnPublishAssetSyncEpochCount:      1,
-		ColumnPublishRowAssetBytes:            101,
-		ColumnPublishRowAssetCount:            1,
-		ColumnPublishTypedColumnBytes:         202,
-		ColumnPublishTypedColumnCount:         2,
-		ColumnPublishDictionaryBytes:          303,
-		ColumnPublishDictionaryCount:          3,
-		ColumnPublishInt64Bytes:               404,
-		ColumnPublishInt64Count:               4,
-		ColumnPublishAggregateMetadataBytes:   505,
-		ColumnPublishAggregateMetadataCount:   5,
-		ColumnPublishSharedAppendBytes:        606,
-		ColumnPublishSharedAppendCount:        6,
-		RetainedPayloadValueLogPointerize:     8 * time.Millisecond,
-		RetainedPayloadValueLogValues:         7,
-		RetainedPayloadValueLogBytes:          707,
-		RetainedStreamValueLogPointerize:      9 * time.Millisecond,
-		RetainedStreamValueLogValues:          8,
-		RetainedStreamValueLogBytes:           808,
+		ColumnPublishDictionaryPreparation:              3 * time.Millisecond,
+		ColumnPublishInt64Preparation:                   4 * time.Millisecond,
+		ColumnPublishAggregateMetadataPrepare:           5 * time.Millisecond,
+		ColumnPublishRowSidecarSharedBuild:              6 * time.Millisecond,
+		ColumnPublishAssetAppend:                        7 * time.Millisecond,
+		ColumnPublishAssetAppendOpen:                    2 * time.Millisecond,
+		ColumnPublishAssetAppendWrite:                   3 * time.Millisecond,
+		ColumnPublishAssetAppendClose:                   4 * time.Millisecond,
+		ColumnPublishAssetAppendFileSync:                11 * time.Millisecond,
+		ColumnPublishAssetAppendFileClose:               12 * time.Millisecond,
+		ColumnPublishAssetAppendDirSync:                 13 * time.Millisecond,
+		ColumnPublishAssetAppendCleanup:                 14 * time.Millisecond,
+		ColumnPublishAssetAppenderCloseCount:            3,
+		ColumnPublishAssetAppendFileSyncCount:           2,
+		ColumnPublishAssetSyncEpochCount:                1,
+		ColumnPublishRowAssetBytes:                      101,
+		ColumnPublishRowAssetCount:                      1,
+		ColumnPublishTypedColumnBytes:                   202,
+		ColumnPublishTypedColumnCount:                   2,
+		ColumnPublishDictionaryBytes:                    303,
+		ColumnPublishDictionaryCount:                    3,
+		ColumnPublishInt64Bytes:                         404,
+		ColumnPublishInt64Count:                         4,
+		ColumnPublishAggregateMetadataBytes:             505,
+		ColumnPublishAggregateMetadataCount:             5,
+		ColumnPublishSharedAppendBytes:                  606,
+		ColumnPublishSharedAppendCount:                  6,
+		RetainedPayloadSemanticStreamWorkerCount:        4,
+		RetainedPayloadSemanticStreamDeclaredRowPrepare: 31 * time.Millisecond,
+		RetainedPayloadSemanticStreamBlockPrepareWall:   32 * time.Millisecond,
+		RetainedPayloadSemanticStreamBlockCollect:       33 * time.Millisecond,
+		RetainedPayloadSemanticStreamBlockEncoderSetup:  34 * time.Millisecond,
+		RetainedPayloadSemanticStreamBlockRawEncode:     35 * time.Millisecond,
+		RetainedPayloadSemanticStreamBlockStoredEncode:  36 * time.Millisecond,
+		RetainedPayloadSemanticStreamBlockFinalize:      37 * time.Millisecond,
+		RetainedPayloadSemanticStreamTableBuild:         38 * time.Millisecond,
+		RetainedPayloadValueLogPointerize:               8 * time.Millisecond,
+		RetainedPayloadValueLogValues:                   7,
+		RetainedPayloadValueLogBytes:                    707,
+		RetainedStreamValueLogPointerize:                9 * time.Millisecond,
+		RetainedStreamValueLogValues:                    8,
+		RetainedStreamValueLogBytes:                     808,
 	}
 
 	metric := columnStoreInsertPhaseMetricFromStats(stats, 1)
@@ -3059,6 +3068,33 @@ func TestColumnStoreInsertPhaseMetricFromStatsIncludesAssetFamiliesM3148(t *test
 	}
 	if got, want := metric.ColumnPublishAssetSyncEpochCount, 1; got != want {
 		t.Fatalf("shared append sync epoch count=%d want %d", got, want)
+	}
+	if got, want := metric.RetainedPayloadSemanticStreamWorkers, 4; got != want {
+		t.Fatalf("semantic-stream worker count=%d want %d", got, want)
+	}
+	if got, want := metric.RetainedPayloadSemanticStreamDeclaredMS, 31.0; got != want {
+		t.Fatalf("semantic-stream declared rows ms=%v want %v", got, want)
+	}
+	if got, want := metric.RetainedPayloadSemanticStreamBlockWallMS, 32.0; got != want {
+		t.Fatalf("semantic-stream block wall ms=%v want %v", got, want)
+	}
+	if got, want := metric.RetainedPayloadSemanticStreamCollectMS, 33.0; got != want {
+		t.Fatalf("semantic-stream collect ms=%v want %v", got, want)
+	}
+	if got, want := metric.RetainedPayloadSemanticStreamEncoderMS, 34.0; got != want {
+		t.Fatalf("semantic-stream encoder setup ms=%v want %v", got, want)
+	}
+	if got, want := metric.RetainedPayloadSemanticStreamRawEncodeMS, 35.0; got != want {
+		t.Fatalf("semantic-stream raw encode ms=%v want %v", got, want)
+	}
+	if got, want := metric.RetainedPayloadSemanticStreamStoreEncodeMS, 36.0; got != want {
+		t.Fatalf("semantic-stream stored encode ms=%v want %v", got, want)
+	}
+	if got, want := metric.RetainedPayloadSemanticStreamFinalizeMS, 37.0; got != want {
+		t.Fatalf("semantic-stream finalize ms=%v want %v", got, want)
+	}
+	if got, want := metric.RetainedPayloadSemanticStreamTableBuildMS, 38.0; got != want {
+		t.Fatalf("semantic-stream table build ms=%v want %v", got, want)
 	}
 	if got, want := metric.RetainedPayloadValueLogPointerizeMS, 8.0; got != want {
 		t.Fatalf("retained payload pointerize duration ms=%v want %v", got, want)


### PR DESCRIPTION
## Summary

- add retained semantic-stream prepare subphase diagnostics to `CollectionInsertStats`
- split retained-stream load preparation into worker count, declared-row prepare, block wall time, per-block collect/encode/finalize sums, and table build
- surface the fields in unified-bench JSON, markdown, and collection shape benchmark metrics
- include the raw-alias fallback copy in `stored_encode` timing so that metric matches the measured critical path

## Claim boundary

This is reporting-only load/write-path observability for #3099/#3067. It does not improve runtime, does not change durability behavior, and should not be presented as query acceleration or ClickHouse superiority evidence. Worker-summed block subphase timings can exceed wall time by design.

## Validation

- `GOWORK=off go test ./TreeDB/collections -run 'TestCollectionShapeInsertStatsIncludesRetainedValueLogPointerization|TestColumnRetained|TestReopen|TestValueLog|TestColumnStore' -count=1`
- `GOWORK=off go test ./cmd/unified_bench -count=1`
- `git diff --check`

## Smoke Evidence

Using JSONBench main after snissn/JSONBench#41 with a local gomap replace:

- artifact: `/tmp/jsonbench_retained_stream_prep_diag_after_reviewfix_20260701_021443`
- rows: 100,000
- query mode: `one_shot_end_to_end`
- metadata mode: `no_aggregate_metadata`
- query: `q1`
- retained payload prepare: `0.242844197s`
- retained semantic-stream workers: `4`
- block prepare wall: `0.239981387s`
- block collect sum: `0.607599747s`
- raw encode sum: `0.015449847s`
- stored encode sum: `0.140395973s`
- table build: `0.001388716s`

## Current Head

- `8f891f6b2a5829ce3d6cd77394b6a7a5124e211b`
