### PR TITLE
feat(treedb): store native entry revisions

### DIFF
--- a/TreeDB/batch/batch.go
+++ b/TreeDB/batch/batch.go
@@ -33,6 +33,7 @@ type Entry struct {
 	Value    []byte        // Inline value, or DeleteRange exclusive end bound (nil means unbounded)
 	ValuePtr page.ValuePtr // For large values
 	IsPtr    bool          // True if ValuePtr is valid
+	Revision page.EntryRevision
 }
 
 // DeleteRange describes a half-open range delete [Start, End). Nil Start or
@@ -424,6 +425,10 @@ func (b *Batch) EntriesCap() int {
 // key/value bytes. Callers must treat key/value as immutable until the batch is
 // committed (Write/WriteSync) or closed.
 func (b *Batch) SetView(key, value []byte) error {
+	return b.SetViewWithRevision(key, value, page.LegacyEntryRevision)
+}
+
+func (b *Batch) SetViewWithRevision(key, value []byte, revision page.EntryRevision) error {
 	if err := b.ensureOpen(); err != nil {
 		return err
 	}
@@ -431,8 +436,9 @@ func (b *Batch) SetView(key, value []byte) error {
 	value = normalizeRawKVValue(value)
 
 	entry := Entry{
-		Type: OpPut,
-		Key:  key,
+		Type:     OpPut,
+		Key:      key,
+		Revision: revision,
 	}
 
 	if len(value) > b.inlineThresholdForKey(key) {
@@ -452,6 +458,10 @@ func (b *Batch) SetView(key, value []byte) error {
 // zero-length byte strings. Caller must guarantee key/value remain immutable
 // until commit/close, and appended keys are strictly increasing with no duplicates.
 func (b *Batch) AppendViewTrustedSortedUnique(key, value []byte) error {
+	return b.AppendViewTrustedSortedUniqueWithRevision(key, value, page.LegacyEntryRevision)
+}
+
+func (b *Batch) AppendViewTrustedSortedUniqueWithRevision(key, value []byte, revision page.EntryRevision) error {
 	if err := b.ensureOpen(); err != nil {
 		return err
 	}
@@ -461,9 +471,10 @@ func (b *Batch) AppendViewTrustedSortedUnique(key, value []byte) error {
 		return ErrValueTooLarge
 	}
 	b.entries = append(b.entries, Entry{
-		Type:  OpPut,
-		Key:   key,
-		Value: value,
+		Type:     OpPut,
+		Key:      key,
+		Value:    value,
+		Revision: revision,
 	})
 	b.byteSize += len(key) + len(value)
 	if b.sorted {
@@ -474,6 +485,10 @@ func (b *Batch) AppendViewTrustedSortedUnique(key, value []byte) error {
 
 // Set adds or replaces a key/value operation.
 func (b *Batch) Set(key, value []byte) error {
+	return b.SetWithRevision(key, value, page.LegacyEntryRevision)
+}
+
+func (b *Batch) SetWithRevision(key, value []byte, revision page.EntryRevision) error {
 	if err := b.ensureOpen(); err != nil {
 		return err
 	}
@@ -491,8 +506,9 @@ func (b *Batch) Set(key, value []byte) error {
 	k, valCopy := b.arenaCopyPair(key, value)
 
 	entry := Entry{
-		Type: OpPut,
-		Key:  k,
+		Type:     OpPut,
+		Key:      k,
+		Revision: revision,
 	}
 
 	// Store inline
@@ -510,14 +526,19 @@ func (b *Batch) Set(key, value []byte) error {
 // copying the key bytes. Callers must treat key as immutable until the batch is
 // committed (Write/WriteSync) or closed.
 func (b *Batch) DeleteView(key []byte) error {
+	return b.DeleteViewWithRevision(key, page.LegacyEntryRevision)
+}
+
+func (b *Batch) DeleteViewWithRevision(key []byte, revision page.EntryRevision) error {
 	if err := b.ensureOpen(); err != nil {
 		return err
 	}
 	key = normalizeRawKVPointKey(key)
 
 	b.entries = append(b.entries, Entry{
-		Type: OpDelete,
-		Key:  key,
+		Type:     OpDelete,
+		Key:      key,
+		Revision: revision,
 	})
 	b.byteSize += len(key)
 	b.compacted = false
@@ -530,13 +551,18 @@ func (b *Batch) DeleteView(key []byte) error {
 // empty key. Caller must guarantee key remains immutable until commit/close,
 // and appended keys are strictly increasing with no duplicates.
 func (b *Batch) AppendDeleteViewTrustedSortedUnique(key []byte) error {
+	return b.AppendDeleteViewTrustedSortedUniqueWithRevision(key, page.LegacyEntryRevision)
+}
+
+func (b *Batch) AppendDeleteViewTrustedSortedUniqueWithRevision(key []byte, revision page.EntryRevision) error {
 	if err := b.ensureOpen(); err != nil {
 		return err
 	}
 	key = normalizeRawKVPointKey(key)
 	b.entries = append(b.entries, Entry{
-		Type: OpDelete,
-		Key:  key,
+		Type:     OpDelete,
+		Key:      key,
+		Revision: revision,
 	})
 	b.byteSize += len(key)
 	if b.sorted {
@@ -547,6 +573,10 @@ func (b *Batch) AppendDeleteViewTrustedSortedUnique(key []byte) error {
 
 // SetPointer adds a pointer directly to the batch (used by Compaction).
 func (b *Batch) SetPointer(key []byte, ptr page.ValuePtr) error {
+	return b.SetPointerWithRevision(key, ptr, page.LegacyEntryRevision)
+}
+
+func (b *Batch) SetPointerWithRevision(key []byte, ptr page.ValuePtr, revision page.EntryRevision) error {
 	if err := b.ensureOpen(); err != nil {
 		return err
 	}
@@ -562,6 +592,7 @@ func (b *Batch) SetPointer(key []byte, ptr page.ValuePtr) error {
 		Key:      k,
 		ValuePtr: ptr,
 		IsPtr:    true,
+		Revision: revision,
 	}
 	b.entries = append(b.entries, entry)
 	b.hasValueLogPointers = true
@@ -579,7 +610,11 @@ func (b *Batch) SetPointer(key []byte, ptr page.ValuePtr) error {
 // best-effort optimization used by higher-level layers (e.g. cached flush
 // streaming).
 func (b *Batch) SetPointerView(key []byte, ptr page.ValuePtr) error {
-	return b.setPointerViewInternal(key, ptr, true)
+	return b.SetPointerViewWithRevision(key, ptr, page.LegacyEntryRevision)
+}
+
+func (b *Batch) SetPointerViewWithRevision(key []byte, ptr page.ValuePtr, revision page.EntryRevision) error {
+	return b.setPointerViewInternal(key, ptr, true, revision)
 }
 
 // SetPointerViewNoTouch is an internal-performance helper that records a
@@ -587,7 +622,11 @@ func (b *Batch) SetPointerView(key []byte, ptr page.ValuePtr) error {
 // segments. Callers must separately provide touched segment hints when commit
 // publication needs them.
 func (b *Batch) SetPointerViewNoTouch(key []byte, ptr page.ValuePtr) error {
-	return b.setPointerViewInternal(key, ptr, false)
+	return b.SetPointerViewNoTouchWithRevision(key, ptr, page.LegacyEntryRevision)
+}
+
+func (b *Batch) SetPointerViewNoTouchWithRevision(key []byte, ptr page.ValuePtr, revision page.EntryRevision) error {
+	return b.setPointerViewInternal(key, ptr, false, revision)
 }
 
 // AppendPointerViewTrustedSortedUnique records a pointer Put without copying key
@@ -596,6 +635,10 @@ func (b *Batch) SetPointerViewNoTouch(key []byte, ptr page.ValuePtr) error {
 // ptr is a value-log pointer, and appended keys are strictly increasing with no
 // duplicates.
 func (b *Batch) AppendPointerViewTrustedSortedUnique(key []byte, ptr page.ValuePtr) error {
+	return b.AppendPointerViewTrustedSortedUniqueWithRevision(key, ptr, page.LegacyEntryRevision)
+}
+
+func (b *Batch) AppendPointerViewTrustedSortedUniqueWithRevision(key []byte, ptr page.ValuePtr, revision page.EntryRevision) error {
 	if err := b.ensureOpen(); err != nil {
 		return err
 	}
@@ -608,6 +651,7 @@ func (b *Batch) AppendPointerViewTrustedSortedUnique(key []byte, ptr page.ValueP
 		Key:      key,
 		ValuePtr: ptr,
 		IsPtr:    true,
+		Revision: revision,
 	})
 	b.hasValueLogPointers = true
 	b.noteTouchedValueLog(ptr)
@@ -622,6 +666,10 @@ func (b *Batch) AppendPointerViewTrustedSortedUnique(key []byte, ptr page.ValueP
 // guarantee: batch is open, key is canonicalized if nil, ptr is a value-log
 // pointer, and appended keys are already non-decreasing.
 func (b *Batch) AppendPointerViewNoTouchTrustedSorted(key []byte, ptr page.ValuePtr) {
+	b.AppendPointerViewNoTouchTrustedSortedWithRevision(key, ptr, page.LegacyEntryRevision)
+}
+
+func (b *Batch) AppendPointerViewNoTouchTrustedSortedWithRevision(key []byte, ptr page.ValuePtr, revision page.EntryRevision) {
 	if b == nil {
 		return
 	}
@@ -630,6 +678,7 @@ func (b *Batch) AppendPointerViewNoTouchTrustedSorted(key []byte, ptr page.Value
 		Key:      key,
 		ValuePtr: ptr,
 		IsPtr:    true,
+		Revision: revision,
 	})
 	b.hasValueLogPointers = true
 	b.compacted = false
@@ -648,7 +697,7 @@ func (b *Batch) NoteTouchedValueLogFileID(fileID uint32) {
 	b.noteTouchedValueLogFileID(fileID)
 }
 
-func (b *Batch) setPointerViewInternal(key []byte, ptr page.ValuePtr, noteTouched bool) error {
+func (b *Batch) setPointerViewInternal(key []byte, ptr page.ValuePtr, noteTouched bool, revision page.EntryRevision) error {
 	if err := b.ensureOpen(); err != nil {
 		return err
 	}
@@ -661,6 +710,7 @@ func (b *Batch) setPointerViewInternal(key []byte, ptr page.ValuePtr, noteTouche
 		Key:      key,
 		ValuePtr: ptr,
 		IsPtr:    true,
+		Revision: revision,
 	})
 	b.hasValueLogPointers = true
 	if noteTouched {
@@ -673,6 +723,10 @@ func (b *Batch) setPointerViewInternal(key []byte, ptr page.ValuePtr, noteTouche
 
 // Delete adds or replaces a delete operation.
 func (b *Batch) Delete(key []byte) error {
+	return b.DeleteWithRevision(key, page.LegacyEntryRevision)
+}
+
+func (b *Batch) DeleteWithRevision(key []byte, revision page.EntryRevision) error {
 	if err := b.ensureOpen(); err != nil {
 		return err
 	}
@@ -681,8 +735,9 @@ func (b *Batch) Delete(key []byte) error {
 	k := b.arenaCopy(key)
 
 	b.entries = append(b.entries, Entry{
-		Type: OpDelete,
-		Key:  k,
+		Type:     OpDelete,
+		Key:      k,
+		Revision: revision,
 	})
 	b.byteSize += len(k)
 	b.compacted = false

--- a/TreeDB/batch/batch_test.go
+++ b/TreeDB/batch/batch_test.go
@@ -241,6 +241,37 @@ func TestBatchAppendPointerViewTrustedSortedUniqueTracksTouchedSegment(t *testin
 	}
 }
 
+func TestBatchRevisionFastHelpers(t *testing.T) {
+	reader := newMapValueReader()
+	b := New(reader, page.DefaultInlineThreshold)
+	t.Cleanup(func() { _ = b.Close() })
+
+	ptr := reader.Add([]byte("large-value"))
+	if err := b.SetViewWithRevision([]byte("a"), []byte("value-a"), 11); err != nil {
+		t.Fatalf("SetViewWithRevision: %v", err)
+	}
+	if err := b.SetPointerViewWithRevision([]byte("b"), ptr, 12); err != nil {
+		t.Fatalf("SetPointerViewWithRevision: %v", err)
+	}
+	if err := b.DeleteViewWithRevision([]byte("c"), 13); err != nil {
+		t.Fatalf("DeleteViewWithRevision: %v", err)
+	}
+
+	entries := b.SortedEntries()
+	if len(entries) != 3 {
+		t.Fatalf("entries=%d want 3", len(entries))
+	}
+	if entries[0].Revision != 11 || entries[0].Type != OpPut || string(entries[0].Value) != "value-a" {
+		t.Fatalf("entry[0]=%+v, want inline rev 11", entries[0])
+	}
+	if entries[1].Revision != 12 || !entries[1].IsPtr || entries[1].ValuePtr != ptr {
+		t.Fatalf("entry[1]=%+v, want pointer rev 12", entries[1])
+	}
+	if entries[2].Revision != 13 || entries[2].Type != OpDelete {
+		t.Fatalf("entry[2]=%+v, want delete rev 13", entries[2])
+	}
+}
+
 func TestBatchSetOps_UsesSlabPointersForLargeValues(t *testing.T) {
 	reader := newMapValueReader()
 	b := New(reader, page.DefaultInlineThreshold)

--- a/TreeDB/batch/revision_bench_test.go
+++ b/TreeDB/batch/revision_bench_test.go
@@ -1,0 +1,94 @@
+package batch
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/page"
+)
+
+func benchmarkBatchSetViewRevisionOverhead(b *testing.B, withRevision bool) {
+	const keyCount = 1024
+	keys := make([][]byte, keyCount)
+	for i := range keys {
+		key := make([]byte, 8)
+		binary.BigEndian.PutUint64(key, uint64(i))
+		keys[i] = key
+	}
+	value := []byte("0123456789abcdef")
+
+	bt := New(newMapValueReader(), page.DefaultInlineThreshold)
+	bt.Reserve(keyCount)
+	b.Cleanup(func() { _ = bt.Close() })
+
+	b.ReportAllocs()
+	b.SetBytes(int64(len(value)))
+	b.ResetTimer()
+	for n := 0; n < b.N; {
+		bt.Reset()
+		for i := 0; i < keyCount && n < b.N; i++ {
+			var err error
+			if withRevision {
+				err = bt.SetViewWithRevision(keys[i], value, page.EntryRevision(n+1))
+			} else {
+				err = bt.SetView(keys[i], value)
+			}
+			if err != nil {
+				b.Fatal(err)
+			}
+			n++
+		}
+	}
+}
+
+func BenchmarkBatchSetViewRevisionOverhead(b *testing.B) {
+	b.Run("legacy", func(b *testing.B) {
+		benchmarkBatchSetViewRevisionOverhead(b, false)
+	})
+	b.Run("revision", func(b *testing.B) {
+		benchmarkBatchSetViewRevisionOverhead(b, true)
+	})
+}
+
+func benchmarkBatchAppendViewTrustedSortedUniqueRevisionOverhead(b *testing.B, withRevision bool) {
+	const keyCount = 1024
+	keys := make([][]byte, keyCount)
+	for i := range keys {
+		key := make([]byte, 8)
+		binary.BigEndian.PutUint64(key, uint64(i))
+		keys[i] = key
+	}
+	value := []byte("0123456789abcdef")
+
+	bt := New(newMapValueReader(), page.DefaultInlineThreshold)
+	bt.Reserve(keyCount)
+	b.Cleanup(func() { _ = bt.Close() })
+
+	b.ReportAllocs()
+	b.SetBytes(int64(len(value)))
+	b.ResetTimer()
+	for n := 0; n < b.N; {
+		bt.Reset()
+		for i := 0; i < keyCount && n < b.N; i++ {
+			var err error
+			if withRevision {
+				err = bt.AppendViewTrustedSortedUniqueWithRevision(keys[i], value, page.EntryRevision(n+1))
+			} else {
+				err = bt.AppendViewTrustedSortedUnique(keys[i], value)
+			}
+			if err != nil {
+				b.Fatal(err)
+			}
+			n++
+		}
+	}
+}
+
+func BenchmarkBatchAppendViewTrustedSortedUniqueRevisionOverhead(b *testing.B) {
+	b.Run("legacy", func(b *testing.B) {
+		benchmarkBatchAppendViewTrustedSortedUniqueRevisionOverhead(b, false)
+	})
+	b.Run("revision", func(b *testing.B) {
+		benchmarkBatchAppendViewTrustedSortedUniqueRevisionOverhead(b, true)
+	})
+}

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -3426,8 +3426,126 @@ type backendBatchPointerSetterView interface {
 	SetPointerView(key []byte, ptr page.ValuePtr) error
 }
 
+type backendBatchSetRevision interface {
+	SetWithRevision(key, value []byte, revision page.EntryRevision) error
+}
+
+type backendBatchSetViewRevision interface {
+	SetViewWithRevision(key, value []byte, revision page.EntryRevision) error
+}
+
+type backendBatchDeleteRevision interface {
+	DeleteWithRevision(key []byte, revision page.EntryRevision) error
+}
+
+type backendBatchDeleteViewRevision interface {
+	DeleteViewWithRevision(key []byte, revision page.EntryRevision) error
+}
+
+type backendBatchPointerSetterRevision interface {
+	SetPointerWithRevision(key []byte, ptr page.ValuePtr, revision page.EntryRevision) error
+}
+
+type backendBatchPointerSetterViewRevision interface {
+	SetPointerViewWithRevision(key []byte, ptr page.ValuePtr, revision page.EntryRevision) error
+}
+
+type backendBatchRevisionOps struct {
+	set     backendBatchSetRevision
+	setView backendBatchSetViewRevision
+	del     backendBatchDeleteRevision
+	delView backendBatchDeleteViewRevision
+	ptr     backendBatchPointerSetterRevision
+	ptrView backendBatchPointerSetterViewRevision
+}
+
+func resolveBackendBatchRevisionOps(backendBatch batch.Interface) backendBatchRevisionOps {
+	ops := backendBatchRevisionOps{}
+	ops.set, _ = backendBatch.(backendBatchSetRevision)
+	ops.setView, _ = backendBatch.(backendBatchSetViewRevision)
+	ops.del, _ = backendBatch.(backendBatchDeleteRevision)
+	ops.delView, _ = backendBatch.(backendBatchDeleteViewRevision)
+	ops.ptr, _ = backendBatch.(backendBatchPointerSetterRevision)
+	ops.ptrView, _ = backendBatch.(backendBatchPointerSetterViewRevision)
+	return ops
+}
+
 type backendBatchCommandWALPublisher interface {
 	SetCommandWALPublish(appliedLSN uint64, covered []backenddb.CommandWALLSNRange) error
+}
+
+func appendBackendBatchPointOp(
+	backendBatch batch.Interface,
+	op batch.Entry,
+	stableView bool,
+	sv backendBatchSetViewer,
+	dv backendBatchDeleteViewer,
+	psv backendBatchPointerSetterView,
+	ps backendBatchPointerSetter,
+	revOps backendBatchRevisionOps,
+) error {
+	if backendBatch == nil {
+		return errors.New("cachingdb: missing backend batch")
+	}
+	if op.Revision != page.LegacyEntryRevision {
+		switch {
+		case op.Type == batch.OpDelete:
+			if stableView && revOps.delView != nil {
+				return revOps.delView.DeleteViewWithRevision(op.Key, op.Revision)
+			}
+			if revOps.del != nil {
+				return revOps.del.DeleteWithRevision(op.Key, op.Revision)
+			}
+		case op.IsPtr:
+			if stableView && revOps.ptrView != nil {
+				return revOps.ptrView.SetPointerViewWithRevision(op.Key, op.ValuePtr, op.Revision)
+			}
+			if revOps.ptr != nil {
+				return revOps.ptr.SetPointerWithRevision(op.Key, op.ValuePtr, op.Revision)
+			}
+		default:
+			if stableView && revOps.setView != nil {
+				return revOps.setView.SetViewWithRevision(op.Key, op.Value, op.Revision)
+			}
+			if revOps.set != nil {
+				return revOps.set.SetWithRevision(op.Key, op.Value, op.Revision)
+			}
+		}
+		if !stableView {
+			op.Key = append([]byte(nil), op.Key...)
+			if op.Type == batch.OpPut && !op.IsPtr && op.Value != nil {
+				op.Value = append([]byte(nil), op.Value...)
+			}
+		}
+		var single [1]batch.Entry
+		single[0] = op
+		return backendBatch.SetOps(single[:])
+	}
+	switch {
+	case op.Type == batch.OpDelete:
+		if stableView && dv != nil {
+			return dv.DeleteView(op.Key)
+		}
+		return backendBatch.Delete(op.Key)
+	case op.IsPtr:
+		if stableView && psv != nil {
+			return psv.SetPointerView(op.Key, op.ValuePtr)
+		}
+		if ps != nil {
+			return ps.SetPointer(op.Key, op.ValuePtr)
+		}
+		if !stableView {
+			op.Key = append([]byte(nil), op.Key...)
+		}
+		var single [1]batch.Entry
+		single[0] = op
+		return backendBatch.SetOps(single[:])
+	default:
+		if stableView && sv != nil {
+			return sv.SetView(op.Key, op.Value)
+		}
+		return backendBatch.Set(op.Key, op.Value)
+	}
 }
 
 type checkpointCommandWALPublish struct {
@@ -3465,6 +3583,7 @@ func (db *DB) flushDeferredValueLogMemtable(
 	memLen int,
 	sync bool,
 	laneID int,
+	stableUnsafe bool,
 ) (int, error) {
 	if db == nil {
 		return 0, nil
@@ -3482,6 +3601,7 @@ func (db *DB) flushDeferredValueLogMemtable(
 	dv, _ := backendBatch.(backendBatchDeleteViewer)
 	psv, _ := backendBatch.(backendBatchPointerSetterView)
 	ps, _ := backendBatch.(backendBatchPointerSetter)
+	revOps := resolveBackendBatchRevisionOps(backendBatch)
 	reserveHint := memLen
 	if db.flushBackendMaxEntries > 0 && reserveHint > db.flushBackendMaxEntries {
 		reserveHint = db.flushBackendMaxEntries
@@ -3490,6 +3610,7 @@ func (db *DB) flushDeferredValueLogMemtable(
 
 	var ptrKeys [][]byte
 	var ptrVals [][]byte
+	var ptrRevisions []page.EntryRevision
 	defer func() {
 		putValueLogKeys(ptrKeys)
 		putValueLogKeys(ptrVals)
@@ -3516,14 +3637,10 @@ func (db *DB) flushDeferredValueLogMemtable(
 
 	for iter.Valid() {
 		key := iter.UnsafeKey()
-		if iter.IsDeleted() {
-			var err error
-			if dv != nil {
-				err = dv.DeleteView(key)
-			} else {
-				err = backendBatch.Delete(key)
-			}
-			if err != nil {
+		val, ptr, flags, revision := iterator.UnsafeEntryWithRevision(iter)
+		if flags&node.FlagTombstone != 0 {
+			op := batch.Entry{Type: batch.OpDelete, Key: key, Revision: revision}
+			if err := appendBackendBatchPointOp(backendBatch, op, stableUnsafe, sv, dv, psv, ps, revOps); err != nil {
 				return 0, err
 			}
 			emittedOps++
@@ -3531,17 +3648,9 @@ func (db *DB) flushDeferredValueLogMemtable(
 			continue
 		}
 
-		val, ptr, flags := iter.UnsafeEntry()
 		if flags&node.FlagPointer != 0 {
-			var err error
-			if psv != nil {
-				err = psv.SetPointerView(key, ptr)
-			} else if ps != nil {
-				err = ps.SetPointer(key, ptr)
-			} else {
-				return 0, errors.New("cachingdb: backend batch missing SetPointer")
-			}
-			if err != nil {
+			op := batch.Entry{Type: batch.OpPut, Key: key, ValuePtr: ptr, IsPtr: true, Revision: revision}
+			if err := appendBackendBatchPointOp(backendBatch, op, stableUnsafe, sv, dv, psv, ps, revOps); err != nil {
 				return 0, err
 			}
 			emittedOps++
@@ -3569,17 +3678,18 @@ func (db *DB) flushDeferredValueLogMemtable(
 			valCopy := append([]byte(nil), val...)
 			ptrKeys = append(ptrKeys, keyCopy)
 			ptrVals = append(ptrVals, valCopy)
+			if revision != page.LegacyEntryRevision || ptrRevisions != nil {
+				if ptrRevisions == nil {
+					ptrRevisions = make([]page.EntryRevision, len(ptrKeys)-1, cap(ptrKeys))
+				}
+				ptrRevisions = append(ptrRevisions, revision)
+			}
 			iter.Next()
 			continue
 		}
 
-		var err error
-		if sv != nil {
-			err = sv.SetView(key, val)
-		} else {
-			err = backendBatch.Set(key, val)
-		}
-		if err != nil {
+		op := batch.Entry{Type: batch.OpPut, Key: key, Value: val, Revision: revision}
+		if err := appendBackendBatchPointOp(backendBatch, op, stableUnsafe, sv, dv, psv, ps, revOps); err != nil {
 			return 0, err
 		}
 		emittedOps++
@@ -3594,6 +3704,9 @@ func (db *DB) flushDeferredValueLogMemtable(
 	}
 	if len(ptrKeys) != len(ptrVals) {
 		return 0, errors.New("cachingdb: internal deferred value-log mismatch")
+	}
+	if ptrRevisions != nil && len(ptrRevisions) != len(ptrKeys) {
+		return 0, errors.New("cachingdb: internal deferred value-log revision mismatch")
 	}
 	if err := ensureVlogLane(); err != nil {
 		return 0, err
@@ -3637,16 +3750,13 @@ func (db *DB) flushDeferredValueLogMemtable(
 		}
 		for srcPos := group.start; srcPos < group.end; srcPos++ {
 			key := ptrKeys[srcPos]
-			if psv != nil {
-				if err := psv.SetPointerView(key, ptr); err != nil {
-					return 0, err
-				}
-			} else if ps != nil {
-				if err := ps.SetPointer(key, ptr); err != nil {
-					return 0, err
-				}
-			} else {
-				return 0, errors.New("cachingdb: backend batch missing SetPointer")
+			revision := page.LegacyEntryRevision
+			if ptrRevisions != nil {
+				revision = ptrRevisions[srcPos]
+			}
+			op := batch.Entry{Type: batch.OpPut, Key: key, ValuePtr: ptr, IsPtr: true, Revision: revision}
+			if err := appendBackendBatchPointOp(backendBatch, op, true, sv, dv, psv, ps, revOps); err != nil {
+				return 0, err
 			}
 			emittedOps++
 		}
@@ -3674,6 +3784,7 @@ func (db *DB) flushDeferredValueLogUnits(units []flushUnit, backendBatch batch.I
 	dv, _ := backendBatch.(backendBatchDeleteViewer)
 	psv, _ := backendBatch.(backendBatchPointerSetterView)
 	ps, _ := backendBatch.(backendBatchPointerSetter)
+	revOps := resolveBackendBatchRevisionOps(backendBatch)
 
 	chunkCap := db.flushBuildChunkCap
 	if chunkCap <= 0 {
@@ -3733,6 +3844,7 @@ func (db *DB) flushDeferredValueLogUnits(units []flushUnit, backendBatch batch.I
 	}
 	ptrKeys := getValueLogKeys(ptrCap)
 	ptrVals := getValueLogKeys(ptrCap)
+	var ptrRevisions []page.EntryRevision
 	defer func() {
 		putValueLogKeys(ptrKeys)
 		putValueLogKeys(ptrVals)
@@ -3752,17 +3864,10 @@ func (db *DB) flushDeferredValueLogUnits(units []flushUnit, backendBatch batch.I
 		return nil
 	}
 
-	emitPointer := func(key []byte, ptr page.ValuePtr) error {
-		if psv != nil {
-			if err := psv.SetPointerView(key, ptr); err != nil {
-				return err
-			}
-		} else if ps != nil {
-			if err := ps.SetPointer(key, ptr); err != nil {
-				return err
-			}
-		} else {
-			return errors.New("cachingdb: backend batch missing SetPointer")
+	emitPointer := func(key []byte, ptr page.ValuePtr, revision page.EntryRevision) error {
+		op := batch.Entry{Type: batch.OpPut, Key: key, ValuePtr: ptr, IsPtr: true, Revision: revision}
+		if err := appendBackendBatchPointOp(backendBatch, op, true, sv, dv, psv, ps, revOps); err != nil {
+			return err
 		}
 		backendPendingOps++
 		return nil
@@ -3775,10 +3880,16 @@ func (db *DB) flushDeferredValueLogUnits(units []flushUnit, backendBatch batch.I
 		if !allowPointers {
 			ptrKeys = ptrKeys[:0]
 			ptrVals = ptrVals[:0]
+			if ptrRevisions != nil {
+				ptrRevisions = ptrRevisions[:0]
+			}
 			return nil
 		}
 		if len(ptrKeys) != len(ptrVals) {
 			return errors.New("cachingdb: deferred inline pointer grouping mismatch")
+		}
+		if ptrRevisions != nil && len(ptrRevisions) != len(ptrKeys) {
+			return errors.New("cachingdb: deferred inline pointer revision mismatch")
 		}
 		if err := ensureVlogLane(); err != nil {
 			return err
@@ -3791,6 +3902,10 @@ func (db *DB) flushDeferredValueLogUnits(units []flushUnit, backendBatch batch.I
 			}
 			chunkKeys := ptrKeys[chunkStart:chunkEnd]
 			chunkVals := ptrVals[chunkStart:chunkEnd]
+			var chunkRevisions []page.EntryRevision
+			if ptrRevisions != nil {
+				chunkRevisions = ptrRevisions[chunkStart:chunkEnd]
+			}
 
 			records, groups, outerArena, err := db.buildOuterLeafValueRecords(chunkKeys, chunkVals)
 			if err != nil {
@@ -3829,7 +3944,11 @@ func (db *DB) flushDeferredValueLogUnits(units []flushUnit, backendBatch batch.I
 					return errors.New("cachingdb: deferred inline pointer source group out of range")
 				}
 				for srcPos := group.start; srcPos < group.end; srcPos++ {
-					if err := emitPointer(chunkKeys[srcPos], ptr); err != nil {
+					revision := page.LegacyEntryRevision
+					if chunkRevisions != nil {
+						revision = chunkRevisions[srcPos]
+					}
+					if err := emitPointer(chunkKeys[srcPos], ptr, revision); err != nil {
 						putValueLogPtrs(ptrs)
 						return err
 					}
@@ -3843,6 +3962,9 @@ func (db *DB) flushDeferredValueLogUnits(units []flushUnit, backendBatch batch.I
 
 		ptrKeys = ptrKeys[:0]
 		ptrVals = ptrVals[:0]
+		if ptrRevisions != nil {
+			ptrRevisions = ptrRevisions[:0]
+		}
 		return nil
 	}
 
@@ -3873,13 +3995,7 @@ func (db *DB) flushDeferredValueLogUnits(units []flushUnit, backendBatch batch.I
 			if err := flushInlinePointerGroup(); err != nil {
 				return 0, err
 			}
-			var err error
-			if dv != nil {
-				err = dv.DeleteView(entry.Key)
-			} else {
-				err = backendBatch.Delete(entry.Key)
-			}
-			if err != nil {
+			if err := appendBackendBatchPointOp(backendBatch, entry, true, sv, dv, psv, ps, revOps); err != nil {
 				return 0, err
 			}
 			backendPendingOps++
@@ -3888,7 +4004,7 @@ func (db *DB) flushDeferredValueLogUnits(units []flushUnit, backendBatch batch.I
 			if err := flushInlinePointerGroup(); err != nil {
 				return 0, err
 			}
-			if err := emitPointer(entry.Key, entry.ValuePtr); err != nil {
+			if err := emitPointer(entry.Key, entry.ValuePtr, entry.Revision); err != nil {
 				return 0, err
 			}
 		default:
@@ -3902,17 +4018,17 @@ func (db *DB) flushDeferredValueLogUnits(units []flushUnit, backendBatch batch.I
 				valCopy := append([]byte(nil), entry.Value...)
 				ptrKeys = append(ptrKeys, keyCopy)
 				ptrVals = append(ptrVals, valCopy)
+				if entry.Revision != page.LegacyEntryRevision || ptrRevisions != nil {
+					if ptrRevisions == nil {
+						ptrRevisions = make([]page.EntryRevision, len(ptrKeys)-1, cap(ptrKeys))
+					}
+					ptrRevisions = append(ptrRevisions, entry.Revision)
+				}
 			} else {
 				if err := flushInlinePointerGroup(); err != nil {
 					return 0, err
 				}
-				var err error
-				if sv != nil {
-					err = sv.SetView(entry.Key, entry.Value)
-				} else {
-					err = backendBatch.Set(entry.Key, entry.Value)
-				}
-				if err != nil {
+				if err := appendBackendBatchPointOp(backendBatch, entry, true, sv, dv, psv, ps, revOps); err != nil {
 					return 0, err
 				}
 				backendPendingOps++
@@ -9877,7 +9993,25 @@ func cachedBatchWriteUseSteal(db *DB, mt memtable.Table) (useSteal bool, suppres
 	return true, false
 }
 
-func memtableBatchDelete(mt memtable.Table, useSteal bool, key []byte) {
+func memtableBatchDelete(mt memtable.Table, useSteal bool, key []byte, revision page.EntryRevision) {
+	if revision != page.LegacyEntryRevision {
+		if useSteal {
+			if writer, ok := mt.(memtable.RevisionStealTable); ok {
+				writer.SetEntryStealWithRevision(key, nil, page.ValuePtr{}, node.FlagTombstone, revision)
+				return
+			}
+		}
+		if writer, ok := mt.(memtable.RevisionTable); ok {
+			writer.SetEntryWithRevision(key, nil, page.ValuePtr{}, node.FlagTombstone, revision)
+			return
+		}
+		if useSteal {
+			mt.SetEntrySteal(key, nil, page.ValuePtr{}, node.FlagTombstone)
+			return
+		}
+		mt.SetEntry(key, nil, page.ValuePtr{}, node.FlagTombstone)
+		return
+	}
 	if useSteal {
 		mt.DeleteSteal(key)
 		return
@@ -9904,12 +10038,30 @@ func memtableBatchSet(mt memtable.Table, useSteal bool, allowBorrow bool, storeI
 			memVal = op.Value
 		}
 		if useSteal {
+			if op.Revision != page.LegacyEntryRevision {
+				if writer, ok := mt.(memtable.RevisionStealTable); ok {
+					writer.SetEntryStealWithRevision(op.Key, memVal, op.ValuePtr, node.FlagPointer, op.Revision)
+					return
+				}
+			}
 			mt.SetEntrySteal(op.Key, memVal, op.ValuePtr, node.FlagPointer)
 			return
 		}
 		if allowBorrow {
+			if op.Revision != page.LegacyEntryRevision {
+				if borrower, ok := mt.(memtable.RevisionValueBorrower); ok && len(memVal) > 0 {
+					borrower.SetEntryBorrowValueWithRevision(op.Key, memVal, op.ValuePtr, node.FlagPointer, op.Revision)
+					return
+				}
+			}
 			if borrower, ok := mt.(memtable.ValueBorrower); ok && len(memVal) > 0 {
 				borrower.SetEntryBorrowValue(op.Key, memVal, op.ValuePtr, node.FlagPointer)
+				return
+			}
+		}
+		if op.Revision != page.LegacyEntryRevision {
+			if writer, ok := mt.(memtable.RevisionTable); ok {
+				writer.SetEntryWithRevision(op.Key, memVal, op.ValuePtr, node.FlagPointer, op.Revision)
 				return
 			}
 		}
@@ -9917,12 +10069,34 @@ func memtableBatchSet(mt memtable.Table, useSteal bool, allowBorrow bool, storeI
 		return
 	}
 	if useSteal {
+		if op.Revision != page.LegacyEntryRevision {
+			if writer, ok := mt.(memtable.RevisionStealTable); ok {
+				writer.SetEntryStealWithRevision(op.Key, op.Value, page.ValuePtr{}, node.FlagInline, op.Revision)
+				return
+			}
+			if writer, ok := mt.(memtable.RevisionTable); ok {
+				writer.SetEntryWithRevision(op.Key, op.Value, page.ValuePtr{}, node.FlagInline, op.Revision)
+				return
+			}
+		}
 		mt.SetSteal(op.Key, op.Value)
 		return
 	}
 	if allowBorrow {
+		if op.Revision != page.LegacyEntryRevision {
+			if borrower, ok := mt.(memtable.RevisionValueBorrower); ok && len(op.Value) > 0 {
+				borrower.SetEntryBorrowValueWithRevision(op.Key, op.Value, page.ValuePtr{}, node.FlagInline, op.Revision)
+				return
+			}
+		}
 		if borrower, ok := mt.(memtable.ValueBorrower); ok && len(op.Value) > 0 {
 			borrower.SetEntryBorrowValue(op.Key, op.Value, page.ValuePtr{}, node.FlagInline)
+			return
+		}
+	}
+	if op.Revision != page.LegacyEntryRevision {
+		if writer, ok := mt.(memtable.RevisionTable); ok {
+			writer.SetEntryWithRevision(op.Key, op.Value, page.ValuePtr{}, node.FlagInline, op.Revision)
 			return
 		}
 	}
@@ -12073,11 +12247,12 @@ func (job flushBuildJob) run(closeCh <-chan struct{}) {
 	ops := getEntrySlice(chunkCap)
 	ops = ops[:0]
 	for iter.Valid() {
-		val, ptr, flags := iter.UnsafeEntry()
+		val, ptr, flags, revision := iterator.UnsafeEntryWithRevision(iter)
 		if flags&node.FlagTombstone != 0 {
 			ops = append(ops, batch.Entry{
-				Type: batch.OpDelete,
-				Key:  iter.UnsafeKey(),
+				Type:     batch.OpDelete,
+				Key:      iter.UnsafeKey(),
+				Revision: revision,
 			})
 		} else if flags&node.FlagPointer != 0 {
 			ops = append(ops, batch.Entry{
@@ -12085,12 +12260,14 @@ func (job flushBuildJob) run(closeCh <-chan struct{}) {
 				Key:      iter.UnsafeKey(),
 				ValuePtr: ptr,
 				IsPtr:    true,
+				Revision: revision,
 			})
 		} else {
 			ops = append(ops, batch.Entry{
-				Type:  batch.OpPut,
-				Key:   iter.UnsafeKey(),
-				Value: val,
+				Type:     batch.OpPut,
+				Key:      iter.UnsafeKey(),
+				Value:    val,
+				Revision: revision,
 			})
 		}
 		iter.Next()
@@ -13643,11 +13820,12 @@ func collectOpsInto(mem memtable.Table, dst []batch.Entry) (int, error) {
 		if i >= len(dst) {
 			return 0, fmt.Errorf("cachingdb: collectOpsInto overflow (have=%d need>=%d)", len(dst), i+1)
 		}
-		val, ptr, flags := iter.UnsafeEntry()
+		val, ptr, flags, revision := iterator.UnsafeEntryWithRevision(iter)
 		if flags&node.FlagTombstone != 0 {
 			dst[i] = batch.Entry{
-				Type: batch.OpDelete,
-				Key:  iter.UnsafeKey(),
+				Type:     batch.OpDelete,
+				Key:      iter.UnsafeKey(),
+				Revision: revision,
 			}
 		} else if flags&node.FlagPointer != 0 {
 			dst[i] = batch.Entry{
@@ -13655,12 +13833,14 @@ func collectOpsInto(mem memtable.Table, dst []batch.Entry) (int, error) {
 				Key:      iter.UnsafeKey(),
 				ValuePtr: ptr,
 				IsPtr:    true,
+				Revision: revision,
 			}
 		} else {
 			dst[i] = batch.Entry{
-				Type:  batch.OpPut,
-				Key:   iter.UnsafeKey(),
-				Value: val,
+				Type:     batch.OpPut,
+				Key:      iter.UnsafeKey(),
+				Value:    val,
+				Revision: revision,
 			}
 		}
 		i++
@@ -13816,21 +13996,21 @@ func buildOpRuns(mem memtable.Table, chunkCap int) ([][]batch.Entry, int, error)
 	ops = ops[:0]
 	stableUnsafe := stableUnsafeIteratorSlices(mem)
 	for iter.Valid() {
-		val, ptr, flags := iter.UnsafeEntry()
+		val, ptr, flags, revision := iterator.UnsafeEntryWithRevision(iter)
 		key := iter.UnsafeKey()
 		if !stableUnsafe {
 			key = append([]byte(nil), key...)
 		}
 		if flags&node.FlagTombstone != 0 {
-			ops = append(ops, batch.Entry{Type: batch.OpDelete, Key: key})
+			ops = append(ops, batch.Entry{Type: batch.OpDelete, Key: key, Revision: revision})
 			deleteOps++
 		} else if flags&node.FlagPointer != 0 {
-			ops = append(ops, batch.Entry{Type: batch.OpPut, Key: key, ValuePtr: ptr, IsPtr: true})
+			ops = append(ops, batch.Entry{Type: batch.OpPut, Key: key, ValuePtr: ptr, IsPtr: true, Revision: revision})
 		} else {
 			if !stableUnsafe && val != nil {
 				val = append([]byte(nil), val...)
 			}
-			ops = append(ops, batch.Entry{Type: batch.OpPut, Key: key, Value: val})
+			ops = append(ops, batch.Entry{Type: batch.OpPut, Key: key, Value: val, Revision: revision})
 		}
 		iter.Next()
 		if len(ops) >= cap(ops) {
@@ -26908,7 +27088,7 @@ func (db *DB) flushOneLocked(sync bool) bool {
 		if db.deferredValueLogEnabled() {
 			t0 := time.Now()
 			var err error
-			backendPendingOps, err = db.flushDeferredValueLogMemtable(iter, backendBatch, memLen, sync, laneID)
+			backendPendingOps, err = db.flushDeferredValueLogMemtable(iter, backendBatch, memLen, sync, laneID, stableUnsafeIteratorSlices(mem))
 			if err != nil {
 				db.reportError(fmt.Errorf("cachingdb: flush failed (defer vlog): %w", err))
 				_ = iter.Close()
@@ -26957,7 +27137,7 @@ func (db *DB) flushOneLocked(sync bool) bool {
 			dv, _ := backendBatch.(backendBatchDeleteViewer)
 			psv, _ := backendBatch.(backendBatchPointerSetterView)
 			ps, _ := backendBatch.(backendBatchPointerSetter)
-			var single [1]batch.Entry
+			revOps := resolveBackendBatchRevisionOps(backendBatch)
 
 			flushBackendChunk := func() error {
 				if !chunkBackend || backendPendingOps < backendEntriesCap {
@@ -26984,6 +27164,7 @@ func (db *DB) flushOneLocked(sync bool) bool {
 				dv, _ = backendBatch.(backendBatchDeleteViewer)
 				psv, _ = backendBatch.(backendBatchPointerSetterView)
 				ps, _ = backendBatch.(backendBatchPointerSetter)
+				revOps = resolveBackendBatchRevisionOps(backendBatch)
 				backendPendingOps = 0
 				return nil
 			}
@@ -26991,15 +27172,10 @@ func (db *DB) flushOneLocked(sync bool) bool {
 			stableUnsafe := stableUnsafeIteratorSlices(mem)
 			for iter.Valid() {
 				key := iter.UnsafeKey()
-				val, ptr, flags := iter.UnsafeEntry()
+				val, ptr, flags, revision := iterator.UnsafeEntryWithRevision(iter)
 				if flags&node.FlagTombstone != 0 {
-					var err error
-					if stableUnsafe && dv != nil {
-						err = dv.DeleteView(key)
-					} else {
-						err = backendBatch.Delete(key)
-					}
-					if err != nil {
+					op := batch.Entry{Type: batch.OpDelete, Key: key, Revision: revision}
+					if err := appendBackendBatchPointOp(backendBatch, op, stableUnsafe, sv, dv, psv, ps, revOps); err != nil {
 						db.reportError(fmt.Errorf("cachingdb: flush failed (delete): %w", err))
 						_ = iter.Close()
 						_ = backendBatch.Close()
@@ -27013,32 +27189,12 @@ func (db *DB) flushOneLocked(sync bool) bool {
 						return false
 					}
 				} else if flags&node.FlagPointer != 0 {
-					if stableUnsafe && psv != nil {
-						if err := psv.SetPointerView(key, ptr); err != nil {
-							db.reportError(fmt.Errorf("cachingdb: flush failed (set ptr): %w", err))
-							_ = iter.Close()
-							_ = backendBatch.Close()
-							return false
-						}
-					} else if ps != nil {
-						if err := ps.SetPointer(key, ptr); err != nil {
-							db.reportError(fmt.Errorf("cachingdb: flush failed (set ptr): %w", err))
-							_ = iter.Close()
-							_ = backendBatch.Close()
-							return false
-						}
-					} else {
-						entryKey := key
-						if !stableUnsafe {
-							entryKey = append([]byte(nil), key...)
-						}
-						single[0] = batch.Entry{Type: batch.OpPut, Key: entryKey, ValuePtr: ptr, IsPtr: true}
-						if err := backendBatch.SetOps(single[:]); err != nil {
-							db.reportError(fmt.Errorf("cachingdb: flush failed (setops ptr): %w", err))
-							_ = iter.Close()
-							_ = backendBatch.Close()
-							return false
-						}
+					op := batch.Entry{Type: batch.OpPut, Key: key, ValuePtr: ptr, IsPtr: true, Revision: revision}
+					if err := appendBackendBatchPointOp(backendBatch, op, stableUnsafe, sv, dv, psv, ps, revOps); err != nil {
+						db.reportError(fmt.Errorf("cachingdb: flush failed (set ptr): %w", err))
+						_ = iter.Close()
+						_ = backendBatch.Close()
+						return false
 					}
 					backendPendingOps++
 					if err := flushBackendChunk(); err != nil {
@@ -27048,13 +27204,8 @@ func (db *DB) flushOneLocked(sync bool) bool {
 						return false
 					}
 				} else {
-					var err error
-					if stableUnsafe && sv != nil {
-						err = sv.SetView(key, val)
-					} else {
-						err = backendBatch.Set(key, val)
-					}
-					if err != nil {
+					op := batch.Entry{Type: batch.OpPut, Key: key, Value: val, Revision: revision}
+					if err := appendBackendBatchPointOp(backendBatch, op, stableUnsafe, sv, dv, psv, ps, revOps); err != nil {
 						db.reportError(fmt.Errorf("cachingdb: flush failed (set): %w", err))
 						_ = iter.Close()
 						_ = backendBatch.Close()
@@ -27788,6 +27939,64 @@ func (db *DB) getMemtableAppend(key, dst []byte) ([]byte, bool, error) {
 	return dst, false, nil
 }
 
+func (db *DB) appendMemtableEntryValueWithRevision(key, dst []byte, val []byte, ptr page.ValuePtr, flags byte, revision page.EntryRevision) ([]byte, page.EntryRevision, error) {
+	if flags&node.FlagTombstone != 0 {
+		return dst, revision, tree.ErrKeyNotFound
+	}
+	if flags&node.FlagPointer != 0 {
+		if val == nil {
+			out, err := db.readValueLogAppend(key, ptr, dst)
+			if err != nil {
+				return dst, revision, err
+			}
+			return out, revision, nil
+		}
+		return append(dst, val...), revision, nil
+	}
+	if val == nil {
+		return dst, revision, nil
+	}
+	return append(dst, val...), revision, nil
+}
+
+func (db *DB) getMemtableAppendWithRevision(key, dst []byte) ([]byte, page.EntryRevision, bool, error) {
+	view := db.retainMemtableView()
+	if view != nil {
+		defer db.releaseMemtableView(view)
+		if memtableViewHasRangeSpans(view) {
+			rootSnap, haveRootSnap := livePointRootDomainSnapshot(view, db, key)
+			val, ptr, flags, revision, found, _ := db.lookupViewEntryWithRangeSpansAndRootRevisionSource(view, key, true, rootSnap, haveRootSnap)
+			if found {
+				out, revision, err := db.appendMemtableEntryValueWithRevision(key, dst, val, ptr, flags, revision)
+				return out, revision, true, err
+			}
+			return dst, page.LegacyEntryRevision, false, nil
+		}
+		snap, haveSnapshot := livePointRootDomainSnapshot(view, db, key)
+		if db.canBypassMemtableReadWithSnapshot(view, key, snap, haveSnapshot) {
+			return dst, page.LegacyEntryRevision, false, nil
+		}
+		if haveSnapshot {
+			val, ptr, flags, revision, found := snap.getEntryWithRevision(key)
+			if found {
+				out, revision, err := db.appendMemtableEntryValueWithRevision(key, dst, val, ptr, flags, revision)
+				return out, revision, true, err
+			}
+			return dst, page.LegacyEntryRevision, false, nil
+		}
+	}
+	val, ptr, flags, revision, found := db.rawPointRootDomainEntryWithRevision(key)
+	if found {
+		out, revision, err := db.appendMemtableEntryValueWithRevision(key, dst, val, ptr, flags, revision)
+		return out, revision, true, err
+	}
+	return dst, page.LegacyEntryRevision, false, nil
+}
+
+type backendVersionedAppender interface {
+	GetVersionedAppend(key, dst []byte) ([]byte, page.EntryRevision, error)
+}
+
 type backendManyGetter interface {
 	GetMany(keys [][]byte) ([][]byte, error)
 }
@@ -27923,6 +28132,25 @@ func (db *DB) Get(key []byte) ([]byte, error) {
 		maybeRecordDBGetCallerSample(len(val))
 	}
 	return val, err
+}
+
+func (db *DB) GetVersioned(key []byte) ([]byte, page.EntryRevision, error) {
+	key = normalizeRawKVPointKey(key)
+	scratch := getOwnedReadScratch()
+	defer putOwnedReadScratch(scratch)
+
+	val, revision, err := db.GetVersionedAppend(key, scratch.buf[:0])
+	if err != nil {
+		if err == tree.ErrKeyNotFound {
+			return nil, revision, nil
+		}
+		return nil, revision, err
+	}
+	if len(val) == 0 {
+		return []byte{}, revision, nil
+	}
+	maybeRecordDBGetCallerSample(len(val))
+	return ownedReadResult(val, scratch), revision, nil
 }
 
 // GetMany returns safe copies of values for keys.
@@ -28115,6 +28343,27 @@ func (db *DB) GetAppend(key, dst []byte) ([]byte, error) {
 		return dst, err
 	}
 	return db.backend.GetAppend(key, dst)
+}
+
+func (db *DB) GetVersionedAppend(key, dst []byte) ([]byte, page.EntryRevision, error) {
+	key = normalizeRawKVPointKey(key)
+	db.noteRead()
+	out, revision, found, err := db.getMemtableAppendWithRevision(key, dst)
+	if err != nil {
+		return dst, revision, err
+	}
+	if found {
+		return out, revision, nil
+	}
+
+	if err := db.flushValueLogForBackendRead(); err != nil {
+		return dst, page.LegacyEntryRevision, err
+	}
+	if versioned, ok := db.backend.(backendVersionedAppender); ok {
+		return versioned.GetVersionedAppend(key, dst)
+	}
+	out, err = db.backend.GetAppend(key, dst)
+	return out, page.LegacyEntryRevision, err
 }
 
 func (db *DB) Has(key []byte) (bool, error) {
@@ -32491,6 +32740,10 @@ func (b *Batch) shouldCopyValueToPtrArena(key, value []byte) bool {
 }
 
 func (b *Batch) Set(key, value []byte) error {
+	return b.SetWithRevision(key, value, page.LegacyEntryRevision)
+}
+
+func (b *Batch) SetWithRevision(key, value []byte, revision page.EntryRevision) error {
 	if b.closed {
 		return ErrBatchClosed
 	}
@@ -32515,6 +32768,20 @@ func (b *Batch) Set(key, value []byte) error {
 		b.batchRange.add(keyCopy)
 		b.size += len(keyCopy) + len(valCopy)
 		// Use the backend's view method with owned copies to avoid aliasing.
+		if revision != page.LegacyEntryRevision {
+			if sv, ok := b.backend.(interface {
+				SetViewWithRevision(key, value []byte, revision page.EntryRevision) error
+			}); ok {
+				return sv.SetViewWithRevision(keyCopy, valCopy, revision)
+			}
+			if s, ok := b.backend.(interface {
+				SetWithRevision(key, value []byte, revision page.EntryRevision) error
+			}); ok {
+				return s.SetWithRevision(keyCopy, valCopy, revision)
+			}
+			single := [1]batch.Entry{{Type: batch.OpPut, Key: keyCopy, Value: valCopy, Revision: revision}}
+			return b.backend.SetOps(single[:])
+		}
 		if sv, ok := b.backend.(interface{ SetView(key, value []byte) error }); ok {
 			return sv.SetView(keyCopy, valCopy)
 		}
@@ -32536,9 +32803,10 @@ func (b *Batch) Set(key, value []byte) error {
 	// The backend will handle promotion to the value log if needed during
 	// writeBypass, or standard write will handle it via the journal/memtable.
 	b.entries = append(b.entries, batch.Entry{
-		Type:  batch.OpPut,
-		Key:   keyCopy,
-		Value: valCopy,
+		Type:     batch.OpPut,
+		Key:      keyCopy,
+		Value:    valCopy,
+		Revision: revision,
 	})
 	b.noteEntryAppend()
 	b.size += len(keyCopy) + len(valCopy)
@@ -32550,17 +32818,25 @@ func (b *Batch) Set(key, value []byte) error {
 // SetView records a Put without copying key/value bytes. Callers must treat
 // key/value as immutable until the batch is written or closed.
 func (b *Batch) SetView(key, value []byte) error {
+	return b.SetViewWithRevision(key, value, page.LegacyEntryRevision)
+}
+
+func (b *Batch) SetViewWithRevision(key, value []byte, revision page.EntryRevision) error {
 	if b.closed {
 		return ErrBatchClosed
 	}
 	key = normalizeRawKVPointKey(key)
 	value = normalizeRawKVValue(value)
-	return b.SetViewValidated(key, value)
+	return b.SetViewValidatedWithRevision(key, value, revision)
 }
 
 // SetViewValidated is SetView for callers that already performed public input
 // validation. The caller must still keep key/value immutable until Write/Close.
 func (b *Batch) SetViewValidated(key, value []byte) error {
+	return b.SetViewValidatedWithRevision(key, value, page.LegacyEntryRevision)
+}
+
+func (b *Batch) SetViewValidatedWithRevision(key, value []byte, revision page.EntryRevision) error {
 	if hotPathStatsEnabled {
 		batchSetViewCallsTotal.Add(1)
 		batchSetViewBytesTotal.Add(uint64(len(key) + len(value)))
@@ -32569,6 +32845,20 @@ func (b *Batch) SetViewValidated(key, value []byte) error {
 	if b.backend != nil {
 		b.batchRange.add(key)
 		b.size += len(key) + len(value)
+		if revision != page.LegacyEntryRevision {
+			if sv, ok := b.backend.(interface {
+				SetViewWithRevision(key, value []byte, revision page.EntryRevision) error
+			}); ok {
+				return sv.SetViewWithRevision(key, value, revision)
+			}
+			if s, ok := b.backend.(interface {
+				SetWithRevision(key, value []byte, revision page.EntryRevision) error
+			}); ok {
+				return s.SetWithRevision(key, value, revision)
+			}
+			single := [1]batch.Entry{{Type: batch.OpPut, Key: key, Value: value, Revision: revision}}
+			return b.backend.SetOps(single[:])
+		}
 		if sv, ok := b.backend.(interface{ SetView(key, value []byte) error }); ok {
 			return sv.SetView(key, value)
 		}
@@ -32587,9 +32877,10 @@ func (b *Batch) SetViewValidated(key, value []byte) error {
 		}
 	}
 	b.entries = append(b.entries, batch.Entry{
-		Type:  batch.OpPut,
-		Key:   key,
-		Value: value,
+		Type:     batch.OpPut,
+		Key:      key,
+		Value:    value,
+		Revision: revision,
 	})
 	b.hasViewOps = true
 	b.noteEntryAppend()
@@ -32600,6 +32891,10 @@ func (b *Batch) SetViewValidated(key, value []byte) error {
 }
 
 func (b *Batch) Delete(key []byte) error {
+	return b.DeleteWithRevision(key, page.LegacyEntryRevision)
+}
+
+func (b *Batch) DeleteWithRevision(key []byte, revision page.EntryRevision) error {
 	if b.closed {
 		return ErrBatchClosed
 	}
@@ -32609,6 +32904,20 @@ func (b *Batch) Delete(key []byte) error {
 	if b.backend != nil {
 		b.batchRange.add(keyCopy)
 		b.size += len(keyCopy)
+		if revision != page.LegacyEntryRevision {
+			if dv, ok := b.backend.(interface {
+				DeleteViewWithRevision(key []byte, revision page.EntryRevision) error
+			}); ok {
+				return dv.DeleteViewWithRevision(keyCopy, revision)
+			}
+			if d, ok := b.backend.(interface {
+				DeleteWithRevision(key []byte, revision page.EntryRevision) error
+			}); ok {
+				return d.DeleteWithRevision(keyCopy, revision)
+			}
+			single := [1]batch.Entry{{Type: batch.OpDelete, Key: keyCopy, Revision: revision}}
+			return b.backend.SetOps(single[:])
+		}
 		if dv, ok := b.backend.(interface{ DeleteView(key []byte) error }); ok {
 			return dv.DeleteView(keyCopy)
 		}
@@ -32627,8 +32936,9 @@ func (b *Batch) Delete(key []byte) error {
 		}
 	}
 	b.entries = append(b.entries, batch.Entry{
-		Type: batch.OpDelete,
-		Key:  keyCopy,
+		Type:     batch.OpDelete,
+		Key:      keyCopy,
+		Revision: revision,
 	})
 	b.noteEntryAppend()
 	b.size += len(keyCopy)
@@ -32676,16 +32986,24 @@ func (b *Batch) DeleteRange(start, end []byte) error {
 // DeleteView records a Delete without copying key bytes. Callers must treat
 // key as immutable until the batch is written or closed.
 func (b *Batch) DeleteView(key []byte) error {
+	return b.DeleteViewWithRevision(key, page.LegacyEntryRevision)
+}
+
+func (b *Batch) DeleteViewWithRevision(key []byte, revision page.EntryRevision) error {
 	if b.closed {
 		return ErrBatchClosed
 	}
 	key = normalizeRawKVPointKey(key)
-	return b.DeleteViewValidated(key)
+	return b.DeleteViewValidatedWithRevision(key, revision)
 }
 
 // DeleteViewValidated is DeleteView for callers that already performed public
 // input validation. The caller must keep key immutable until Write/Close.
 func (b *Batch) DeleteViewValidated(key []byte) error {
+	return b.DeleteViewValidatedWithRevision(key, page.LegacyEntryRevision)
+}
+
+func (b *Batch) DeleteViewValidatedWithRevision(key []byte, revision page.EntryRevision) error {
 	if hotPathStatsEnabled {
 		batchDeleteViewCallsTotal.Add(1)
 		batchDeleteViewBytesTotal.Add(uint64(len(key)))
@@ -32694,6 +33012,20 @@ func (b *Batch) DeleteViewValidated(key []byte) error {
 	if b.backend != nil {
 		b.batchRange.add(key)
 		b.size += len(key)
+		if revision != page.LegacyEntryRevision {
+			if dv, ok := b.backend.(interface {
+				DeleteViewWithRevision(key []byte, revision page.EntryRevision) error
+			}); ok {
+				return dv.DeleteViewWithRevision(key, revision)
+			}
+			if d, ok := b.backend.(interface {
+				DeleteWithRevision(key []byte, revision page.EntryRevision) error
+			}); ok {
+				return d.DeleteWithRevision(key, revision)
+			}
+			single := [1]batch.Entry{{Type: batch.OpDelete, Key: key, Revision: revision}}
+			return b.backend.SetOps(single[:])
+		}
 		if dv, ok := b.backend.(interface{ DeleteView(key []byte) error }); ok {
 			return dv.DeleteView(key)
 		}
@@ -32712,8 +33044,9 @@ func (b *Batch) DeleteViewValidated(key []byte) error {
 		}
 	}
 	b.entries = append(b.entries, batch.Entry{
-		Type: batch.OpDelete,
-		Key:  key,
+		Type:     batch.OpDelete,
+		Key:      key,
+		Revision: revision,
 	})
 	b.hasViewOps = true
 	b.noteEntryAppend()
@@ -33858,7 +34191,7 @@ func (b *Batch) writeRegularLocked(syncWrite bool, unlockWriteMu func()) error {
 				for _, entryIdx := range idxs {
 					key := b.entries[entryIdx].Key
 					last = key
-					memtableBatchDelete(shard.mem, useSteal, key)
+					memtableBatchDelete(shard.mem, useSteal, key, b.entries[entryIdx].Revision)
 				}
 				shard.rng.add(first)
 				if len(idxs) > 1 {
@@ -33868,7 +34201,7 @@ func (b *Batch) writeRegularLocked(syncWrite bool, unlockWriteMu func()) error {
 			} else {
 				for _, entryIdx := range idxs {
 					key := b.entries[entryIdx].Key
-					memtableBatchDelete(shard.mem, useSteal, key)
+					memtableBatchDelete(shard.mem, useSteal, key, b.entries[entryIdx].Revision)
 					shard.rng.add(key)
 					b.db.noteWriteKey(key)
 				}
@@ -33939,7 +34272,7 @@ func (b *Batch) writeRegularLocked(syncWrite bool, unlockWriteMu func()) error {
 					} else {
 						for _, op := range entries {
 							if op.Type == batch.OpDelete {
-								memtableBatchDelete(shard.mem, true, op.Key)
+								memtableBatchDelete(shard.mem, true, op.Key, op.Revision)
 							} else {
 								memtableBatchSet(shard.mem, true, allowBatchArenaBorrow, storeInlinePtrValues, op)
 							}
@@ -33973,7 +34306,7 @@ func (b *Batch) writeRegularLocked(syncWrite bool, unlockWriteMu func()) error {
 			if !appliedSortedRun {
 				for _, op := range entries {
 					if op.Type == batch.OpDelete {
-						memtableBatchDelete(shard.mem, useSteal, op.Key)
+						memtableBatchDelete(shard.mem, useSteal, op.Key, op.Revision)
 					} else {
 						borrowed := false
 						if allowBatchArenaBorrow && !useSteal {
@@ -34714,6 +35047,13 @@ func (it *singleSourceIterator) UnsafeValue() []byte {
 		return nil
 	}
 	return it.iter.UnsafeValue()
+}
+
+func (it *singleSourceIterator) UnsafeEntryWithRevision() ([]byte, page.ValuePtr, byte, page.EntryRevision) {
+	if it == nil || !it.valid {
+		return nil, page.ValuePtr{}, 0, page.LegacyEntryRevision
+	}
+	return iterator.UnsafeEntryWithRevision(it.iter)
 }
 
 func (it *singleSourceIterator) Valid() bool               { return it.valid }

--- a/TreeDB/caching/flush_build_runs_test.go
+++ b/TreeDB/caching/flush_build_runs_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/snissn/gomap/TreeDB/batch"
 	"github.com/snissn/gomap/TreeDB/internal/iterator"
 	"github.com/snissn/gomap/TreeDB/internal/memtable"
+	"github.com/snissn/gomap/TreeDB/node"
 	"github.com/snissn/gomap/TreeDB/page"
 )
 
@@ -35,6 +36,27 @@ func collectRunEntriesForTest(t *testing.T, m memtable.Table, chunkCap int) ([]b
 		out = append(out, run...)
 	}
 	return out, deletes
+}
+
+func TestMemtableBatchApplyPreservesEntryRevision(t *testing.T) {
+	var mt memtable.Table = memtable.NewAppendOnlyWithEntryCapacity(4)
+	memtableBatchSet(mt, false, false, false, batch.Entry{
+		Type:     batch.OpPut,
+		Key:      []byte("a"),
+		Value:    []byte("value"),
+		Revision: 44,
+	})
+	memtableBatchDelete(mt, false, []byte("b"), 45)
+
+	revisions := mt.(memtable.RevisionTable)
+	value, _, flags, revision, found := revisions.GetEntryWithRevision([]byte("a"))
+	if !found || flags != node.FlagInline || string(value) != "value" || revision != 44 {
+		t.Fatalf("put entry=(%q,%02x,%d,%v), want value inline rev 44", value, flags, revision, found)
+	}
+	_, _, flags, revision, found = revisions.GetEntryWithRevision([]byte("b"))
+	if !found || flags&node.FlagTombstone == 0 || revision != 45 {
+		t.Fatalf("delete entry=(%02x,%d,%v), want tombstone rev 45", flags, revision, found)
+	}
 }
 
 func TestBuildOpRunsAppendOnlySortedDuplicateTombstoneDeleteShapes(t *testing.T) {

--- a/TreeDB/caching/flush_pool_helpers_test.go
+++ b/TreeDB/caching/flush_pool_helpers_test.go
@@ -368,7 +368,7 @@ func TestFlushDeferredValueLogMemtableReservesBackendBatch(t *testing.T) {
 	db := &DB{valueLogThreshold: page.DefaultInlineThreshold}
 	const reserveHint = 7
 
-	if emitted, err := db.flushDeferredValueLogMemtable(iter, backendBatch, reserveHint, false, 0); err != nil {
+	if emitted, err := db.flushDeferredValueLogMemtable(iter, backendBatch, reserveHint, false, 0, true); err != nil {
 		_ = iter.Close()
 		t.Fatalf("flushDeferredValueLogMemtable: %v", err)
 	} else if emitted != 2 {

--- a/TreeDB/caching/flush_run_planner.go
+++ b/TreeDB/caching/flush_run_planner.go
@@ -679,41 +679,11 @@ func appendCanonicalFlushRunChunkToBackendBatch(backendBatch batch.Interface, op
 	dv, _ := backendBatch.(backendBatchDeleteViewer)
 	psv, _ := backendBatch.(backendBatchPointerSetterView)
 	ps, _ := backendBatch.(backendBatchPointerSetter)
-	var single [1]batch.Entry
+	revOps := resolveBackendBatchRevisionOps(backendBatch)
 	for i := range ops {
 		op := ops[i]
-		switch {
-		case op.Type == batch.OpDelete:
-			if dv != nil {
-				if err := dv.DeleteView(op.Key); err != nil {
-					return err
-				}
-			} else if err := backendBatch.Delete(op.Key); err != nil {
-				return err
-			}
-		case op.IsPtr:
-			if psv != nil {
-				if err := psv.SetPointerView(op.Key, op.ValuePtr); err != nil {
-					return err
-				}
-			} else if ps != nil {
-				if err := ps.SetPointer(op.Key, op.ValuePtr); err != nil {
-					return err
-				}
-			} else {
-				single[0] = op
-				if err := backendBatch.SetOps(single[:]); err != nil {
-					return err
-				}
-			}
-		default:
-			if sv != nil {
-				if err := sv.SetView(op.Key, op.Value); err != nil {
-					return err
-				}
-			} else if err := backendBatch.Set(op.Key, op.Value); err != nil {
-				return err
-			}
+		if err := appendBackendBatchPointOp(backendBatch, op, true, sv, dv, psv, ps, revOps); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/TreeDB/caching/range_spans.go
+++ b/TreeDB/caching/range_spans.go
@@ -188,6 +188,10 @@ func (it *rangeSpanFilteringIterator) Next() {
 	it.advance()
 }
 
+func (it *rangeSpanFilteringIterator) UnsafeEntryWithRevision() ([]byte, page.ValuePtr, byte, page.EntryRevision) {
+	return iterator.UnsafeEntryWithRevision(it.UnsafeIterator)
+}
+
 func (it *rangeSpanFilteringIterator) Seek(key []byte) {
 	it.UnsafeIterator.Seek(key)
 	it.advance()
@@ -199,18 +203,23 @@ func memtableViewHasRangeSpans(view *memtableView) bool {
 
 func (db *DB) lookupViewEntryWithRangeSpans(view *memtableView, key []byte, includeMutable bool) (val []byte, ptr page.ValuePtr, flags byte, found bool) {
 	rootSnap, haveRootSnap := livePointRootDomainSnapshot(view, db, key)
-	val, ptr, flags, found, _ = db.lookupViewEntryWithRangeSpansAndRootSource(view, key, includeMutable, rootSnap, haveRootSnap)
+	val, ptr, flags, _, found, _ = db.lookupViewEntryWithRangeSpansAndRootRevisionSource(view, key, includeMutable, rootSnap, haveRootSnap)
 	return val, ptr, flags, found
 }
 
 func (db *DB) lookupViewEntryWithRangeSpansAndRoot(view *memtableView, key []byte, includeMutable bool, rootSnap rootDomainSnapshot, haveRootSnap bool) (val []byte, ptr page.ValuePtr, flags byte, found bool) {
-	val, ptr, flags, found, _ = db.lookupViewEntryWithRangeSpansAndRootSource(view, key, includeMutable, rootSnap, haveRootSnap)
+	val, ptr, flags, _, found, _ = db.lookupViewEntryWithRangeSpansAndRootRevisionSource(view, key, includeMutable, rootSnap, haveRootSnap)
 	return val, ptr, flags, found
 }
 
 func (db *DB) lookupViewEntryWithRangeSpansAndRootSource(view *memtableView, key []byte, includeMutable bool, rootSnap rootDomainSnapshot, haveRootSnap bool) (val []byte, ptr page.ValuePtr, flags byte, found bool, source rootDomainEntrySource) {
+	val, ptr, flags, _, found, source = db.lookupViewEntryWithRangeSpansAndRootRevisionSource(view, key, includeMutable, rootSnap, haveRootSnap)
+	return val, ptr, flags, found, source
+}
+
+func (db *DB) lookupViewEntryWithRangeSpansAndRootRevisionSource(view *memtableView, key []byte, includeMutable bool, rootSnap rootDomainSnapshot, haveRootSnap bool) (val []byte, ptr page.ValuePtr, flags byte, revision page.EntryRevision, found bool, source rootDomainEntrySource) {
 	if db == nil || view == nil {
-		return nil, page.ValuePtr{}, 0, false, rootDomainEntrySourceNone
+		return nil, page.ValuePtr{}, 0, page.LegacyEntryRevision, false, rootDomainEntrySourceNone
 	}
 	shardIdx := 0
 	if len(db.mutableShards) > 1 {
@@ -218,12 +227,12 @@ func (db *DB) lookupViewEntryWithRangeSpansAndRootSource(view *memtableView, key
 	}
 	if includeMutable && shardIdx >= 0 && shardIdx < len(view.mutables) {
 		if mt := view.mutables[shardIdx]; mt != nil {
-			if val, ptr, flags, found = mt.GetEntry(key); found {
+			if val, ptr, flags, revision, found = memtableEntryWithRevision(mt, key); found {
 				if db != nil {
 					db.rangeSpanPointProbes.Add(1)
 					db.rangeSpanPointHits.Add(1)
 				}
-				return val, ptr, flags, true, rootDomainEntrySourceCached
+				return val, ptr, flags, revision, true, rootDomainEntrySourceCached
 			}
 		}
 	}
@@ -234,16 +243,16 @@ func (db *DB) lookupViewEntryWithRangeSpansAndRootSource(view *memtableView, key
 				if db != nil {
 					db.rangeSpanPointProbes.Add(1)
 				}
-				if val, ptr, flags, found = mt.GetEntry(key); found {
+				if val, ptr, flags, revision, found = memtableEntryWithRevision(mt, key); found {
 					if db != nil {
 						db.rangeSpanPointHits.Add(1)
 					}
-					return val, ptr, flags, true, rootDomainEntrySourceCached
+					return val, ptr, flags, revision, true, rootDomainEntrySourceCached
 				}
 			}
 		}
 		if idx < len(view.queueRangeSpans) && rangeSpansContainKey(view.queueRangeSpans[idx], key) {
-			return nil, page.ValuePtr{}, node.FlagTombstone, true, rootDomainEntrySourceCached
+			return nil, page.ValuePtr{}, node.FlagTombstone, page.LegacyEntryRevision, true, rootDomainEntrySourceCached
 		}
 	}
 	if haveRootSnap && rootDomainSnapshotHasPublishedState(rootSnap) {
@@ -255,33 +264,38 @@ func (db *DB) lookupViewEntryWithRangeSpansAndRootSource(view *memtableView, key
 			if db != nil {
 				db.rangeSpanPointProbes.Add(1)
 			}
-			if val, ptr, flags, found = resolvedSnap.published.GetEntry(key); found {
+			if val, ptr, flags, revision, found = rootDomainLookupEntryWithRevision(resolvedSnap.published, key); found {
 				if db != nil {
 					db.rangeSpanPointHits.Add(1)
 				}
-				return val, ptr, flags, true, rootDomainEntrySourcePublished
+				return val, ptr, flags, revision, true, rootDomainEntrySourcePublished
 			}
 		}
 		// The applicable published root is authoritative for this view/snapshot.
 		// Treat its miss (or an unresolvable root ID) as a terminal not-found marker
 		// so active-span paths do not fall through to the default backend root and
 		// cross root domains.
-		return nil, page.ValuePtr{}, node.FlagTombstone, true, rootDomainEntrySourcePublished
+		return nil, page.ValuePtr{}, node.FlagTombstone, page.LegacyEntryRevision, true, rootDomainEntrySourcePublished
 	}
-	return nil, page.ValuePtr{}, 0, false, rootDomainEntrySourceNone
+	return nil, page.ValuePtr{}, 0, page.LegacyEntryRevision, false, rootDomainEntrySourceNone
 }
 
 func (s *Snapshot) lookupEntryWithRangeSpans(key []byte) (val []byte, ptr page.ValuePtr, flags byte, found bool) {
-	val, ptr, flags, found, _ = s.lookupEntryWithRangeSpansSource(key)
+	val, ptr, flags, _, found, _ = s.lookupEntryWithRangeSpansRevisionSource(key)
 	return val, ptr, flags, found
 }
 
 func (s *Snapshot) lookupEntryWithRangeSpansSource(key []byte) (val []byte, ptr page.ValuePtr, flags byte, found bool, source rootDomainEntrySource) {
+	val, ptr, flags, _, found, source = s.lookupEntryWithRangeSpansRevisionSource(key)
+	return val, ptr, flags, found, source
+}
+
+func (s *Snapshot) lookupEntryWithRangeSpansRevisionSource(key []byte) (val []byte, ptr page.ValuePtr, flags byte, revision page.EntryRevision, found bool, source rootDomainEntrySource) {
 	if s == nil || s.view == nil || s.db == nil {
-		return nil, page.ValuePtr{}, 0, false, rootDomainEntrySourceNone
+		return nil, page.ValuePtr{}, 0, page.LegacyEntryRevision, false, rootDomainEntrySourceNone
 	}
 	rootSnap := rootDomainSnapshotFromCachedSnapshot(s, key)
-	return s.db.lookupViewEntryWithRangeSpansAndRootSource(s.view, key, false, rootSnap, true)
+	return s.db.lookupViewEntryWithRangeSpansAndRootRevisionSource(s.view, key, false, rootSnap, true)
 }
 
 func rangeSpanPrefixEnd(prefix []byte) []byte {

--- a/TreeDB/caching/root_domain.go
+++ b/TreeDB/caching/root_domain.go
@@ -20,6 +20,10 @@ type rootDomainLookup interface {
 	GetEntry(key []byte) (val []byte, ptr page.ValuePtr, flags byte, found bool)
 }
 
+type rootDomainRevisionLookup interface {
+	GetEntryWithRevision(key []byte) (val []byte, ptr page.ValuePtr, flags byte, revision page.EntryRevision, found bool)
+}
+
 type rootDomainIteratorFactory interface {
 	Iterator(start, end []byte) (iterator.UnsafeIterator, error)
 }
@@ -95,6 +99,28 @@ type rootDomainPublishStats struct {
 	retrySuccesses        uint64
 	nativeSystemPublishes uint64
 	batchReplayFallbacks  uint64
+}
+
+func rootDomainLookupEntryWithRevision(src rootDomainLookup, key []byte) (val []byte, ptr page.ValuePtr, flags byte, revision page.EntryRevision, found bool) {
+	if src == nil {
+		return nil, page.ValuePtr{}, 0, page.LegacyEntryRevision, false
+	}
+	if revisions, ok := src.(rootDomainRevisionLookup); ok {
+		return revisions.GetEntryWithRevision(key)
+	}
+	val, ptr, flags, found = src.GetEntry(key)
+	return val, ptr, flags, page.LegacyEntryRevision, found
+}
+
+func memtableEntryWithRevision(mt memtable.Table, key []byte) (val []byte, ptr page.ValuePtr, flags byte, revision page.EntryRevision, found bool) {
+	if mt == nil {
+		return nil, page.ValuePtr{}, 0, page.LegacyEntryRevision, false
+	}
+	if revisions, ok := mt.(memtable.RevisionTable); ok {
+		return revisions.GetEntryWithRevision(key)
+	}
+	val, ptr, flags, found = mt.GetEntry(key)
+	return val, ptr, flags, page.LegacyEntryRevision, found
 }
 
 var (
@@ -704,12 +730,17 @@ type backendSnapshotLookup struct {
 func (backendSnapshotLookup) rootDomainPublishedBackendLookupMarker() {}
 
 func (l backendSnapshotLookup) GetEntry(key []byte) (val []byte, ptr page.ValuePtr, flags byte, found bool) {
+	val, ptr, flags, _, found = l.GetEntryWithRevision(key)
+	return val, ptr, flags, found
+}
+
+func (l backendSnapshotLookup) GetEntryWithRevision(key []byte) (val []byte, ptr page.ValuePtr, flags byte, revision page.EntryRevision, found bool) {
 	if l.snapshot == nil {
-		return nil, page.ValuePtr{}, 0, false
+		return nil, page.ValuePtr{}, 0, page.LegacyEntryRevision, false
 	}
 	if l.db != nil {
 		if err := l.db.flushValueLogForBackendRead(); err != nil {
-			return nil, page.ValuePtr{}, 0, false
+			return nil, page.ValuePtr{}, 0, page.LegacyEntryRevision, false
 		}
 	}
 	var (
@@ -723,11 +754,11 @@ func (l backendSnapshotLookup) GetEntry(key []byte) (val []byte, ptr page.ValueP
 	}
 	if err != nil {
 		if errors.Is(err, tree.ErrKeyNotFound) {
-			return nil, page.ValuePtr{}, 0, false
+			return nil, page.ValuePtr{}, 0, page.LegacyEntryRevision, false
 		}
-		return nil, page.ValuePtr{}, 0, false
+		return nil, page.ValuePtr{}, 0, page.LegacyEntryRevision, false
 	}
-	return entry.Value, entry.ValuePtr, entry.Flags, true
+	return entry.Value, entry.ValuePtr, entry.Flags, entry.Revision, true
 }
 
 func (l backendSnapshotLookup) GetValueAppend(key, dst []byte) ([]byte, error) {
@@ -1069,8 +1100,13 @@ func rootDomainQueueRangesForTables(queue []memtable.Table, ranges []keyRange) [
 // newest-wins precedence under db.mu without constructing a synthetic snapshot,
 // keeping the fallback zero-allocation on queued-shard hits.
 func (db *DB) rawPointRootDomainEntry(key []byte) (val []byte, ptr page.ValuePtr, flags byte, found bool) {
+	val, ptr, flags, _, found = db.rawPointRootDomainEntryWithRevision(key)
+	return val, ptr, flags, found
+}
+
+func (db *DB) rawPointRootDomainEntryWithRevision(key []byte) (val []byte, ptr page.ValuePtr, flags byte, revision page.EntryRevision, found bool) {
 	if db == nil {
-		return nil, page.ValuePtr{}, 0, false
+		return nil, page.ValuePtr{}, 0, page.LegacyEntryRevision, false
 	}
 	db.mu.RLock()
 	defer db.mu.RUnlock()
@@ -1081,8 +1117,8 @@ func (db *DB) rawPointRootDomainEntry(key []byte) (val []byte, ptr page.ValuePtr
 	}
 	if shardIdx >= 0 && shardIdx < len(db.mutableShards) {
 		if mt := db.mutableShards[shardIdx].mem; mt != nil {
-			if val, ptr, flags, found = mt.GetEntry(key); found {
-				return val, ptr, flags, true
+			if val, ptr, flags, revision, found = memtableEntryWithRevision(mt, key); found {
+				return val, ptr, flags, revision, true
 			}
 		}
 	}
@@ -1094,11 +1130,11 @@ func (db *DB) rawPointRootDomainEntry(key []byte) (val []byte, ptr page.ValuePtr
 		if len(db.queueShardIDs) > idx && int(db.queueShardIDs[idx]) != shardIdx {
 			continue
 		}
-		if val, ptr, flags, found = mt.GetEntry(key); found {
-			return val, ptr, flags, true
+		if val, ptr, flags, revision, found = memtableEntryWithRevision(mt, key); found {
+			return val, ptr, flags, revision, true
 		}
 	}
-	return nil, page.ValuePtr{}, 0, false
+	return nil, page.ValuePtr{}, 0, page.LegacyEntryRevision, false
 }
 
 func (db *DB) rawIteratorRootDomainSnapshot() (rootDomainSnapshot, []keyRange) {
@@ -1146,28 +1182,38 @@ func (s *rootDomainState) sealMutable(next memtable.Table) {
 }
 
 func (s rootDomainSnapshot) getEntry(key []byte) (val []byte, ptr page.ValuePtr, flags byte, found bool) {
-	val, ptr, flags, found, _ = s.getEntryWithSource(key)
+	val, ptr, flags, _, found, _ = s.getEntryWithRevisionSource(key)
 	return val, ptr, flags, found
 }
 
 func (s rootDomainSnapshot) getEntryWithSource(key []byte) (val []byte, ptr page.ValuePtr, flags byte, found bool, source rootDomainEntrySource) {
+	val, ptr, flags, _, found, source = s.getEntryWithRevisionSource(key)
+	return val, ptr, flags, found, source
+}
+
+func (s rootDomainSnapshot) getEntryWithRevision(key []byte) (val []byte, ptr page.ValuePtr, flags byte, revision page.EntryRevision, found bool) {
+	val, ptr, flags, revision, found, _ = s.getEntryWithRevisionSource(key)
+	return val, ptr, flags, revision, found
+}
+
+func (s rootDomainSnapshot) getEntryWithRevisionSource(key []byte) (val []byte, ptr page.ValuePtr, flags byte, revision page.EntryRevision, found bool, source rootDomainEntrySource) {
 	if s.mutable != nil {
-		if val, ptr, flags, found = s.mutable.GetEntry(key); found {
-			return val, ptr, flags, true, rootDomainEntrySourceCached
+		if val, ptr, flags, revision, found = memtableEntryWithRevision(s.mutable, key); found {
+			return val, ptr, flags, revision, true, rootDomainEntrySourceCached
 		}
 	}
 	for idx := len(s.immutables) - 1; idx >= 0; idx-- {
-		if val, ptr, flags, found = s.immutables[idx].GetEntry(key); found {
-			return val, ptr, flags, true, rootDomainEntrySourceCached
+		if val, ptr, flags, revision, found = memtableEntryWithRevision(s.immutables[idx], key); found {
+			return val, ptr, flags, revision, true, rootDomainEntrySourceCached
 		}
 	}
 	if s.published != nil {
-		val, ptr, flags, found = s.published.GetEntry(key)
+		val, ptr, flags, revision, found = rootDomainLookupEntryWithRevision(s.published, key)
 		if found {
-			return val, ptr, flags, true, rootDomainEntrySourcePublished
+			return val, ptr, flags, revision, true, rootDomainEntrySourcePublished
 		}
 	}
-	return nil, page.ValuePtr{}, 0, false, rootDomainEntrySourceNone
+	return nil, page.ValuePtr{}, 0, page.LegacyEntryRevision, false, rootDomainEntrySourceNone
 }
 
 func (s rootDomainSnapshot) visibleValue(key []byte) ([]byte, bool) {
@@ -1302,6 +1348,13 @@ type leasedUnsafeIterator struct {
 	closeOnce sync.Once
 	closeErr  error
 	release   func()
+}
+
+func (it *leasedUnsafeIterator) UnsafeEntryWithRevision() ([]byte, page.ValuePtr, byte, page.EntryRevision) {
+	if it == nil {
+		return nil, page.ValuePtr{}, 0, page.LegacyEntryRevision
+	}
+	return iterator.UnsafeEntryWithRevision(it.UnsafeIterator)
 }
 
 func (it *leasedUnsafeIterator) Close() error {
@@ -1621,6 +1674,13 @@ func (it *rootDomainUnsafeIterator) UnsafeEntry() ([]byte, page.ValuePtr, byte) 
 	return it.cur.iter.UnsafeEntry()
 }
 
+func (it *rootDomainUnsafeIterator) UnsafeEntryWithRevision() ([]byte, page.ValuePtr, byte, page.EntryRevision) {
+	if !it.valid {
+		return nil, page.ValuePtr{}, 0, page.LegacyEntryRevision
+	}
+	return iterator.UnsafeEntryWithRevision(it.cur.iter)
+}
+
 func (it *rootDomainUnsafeIterator) Key() []byte {
 	if !it.valid {
 		panic("iterator invalid")
@@ -1690,6 +1750,10 @@ func (it *rootDomainEmptyUnsafeIterator) UnsafeKey() []byte   { return nil }
 func (it *rootDomainEmptyUnsafeIterator) UnsafeValue() []byte { return nil }
 func (it *rootDomainEmptyUnsafeIterator) UnsafeEntry() ([]byte, page.ValuePtr, byte) {
 	return nil, page.ValuePtr{}, 0
+}
+
+func (it *rootDomainEmptyUnsafeIterator) UnsafeEntryWithRevision() ([]byte, page.ValuePtr, byte, page.EntryRevision) {
+	return nil, page.ValuePtr{}, 0, page.LegacyEntryRevision
 }
 func (it *rootDomainEmptyUnsafeIterator) Key() []byte                 { panic("iterator invalid") }
 func (it *rootDomainEmptyUnsafeIterator) Value() []byte               { panic("iterator invalid") }

--- a/TreeDB/caching/snapshot.go
+++ b/TreeDB/caching/snapshot.go
@@ -341,53 +341,74 @@ func (s *Snapshot) Close() error {
 }
 
 func (s *Snapshot) lookupQueueEntry(key []byte) (val []byte, ptr page.ValuePtr, flags byte, found bool) {
-	val, ptr, flags, found, _ = s.lookupRootDomainEntry(key)
+	val, ptr, flags, _, found, _ = s.lookupRootDomainEntryWithRevision(key)
 	return val, ptr, flags, found
 }
 
+func (s *Snapshot) lookupQueueEntryWithRevision(key []byte) (val []byte, ptr page.ValuePtr, flags byte, revision page.EntryRevision, found bool) {
+	val, ptr, flags, revision, found, _ = s.lookupRootDomainEntryWithRevision(key)
+	return val, ptr, flags, revision, found
+}
+
 func (s *Snapshot) lookupRootDomainSnapshotEntry(key []byte) (snap rootDomainSnapshot, val []byte, ptr page.ValuePtr, flags byte, found bool, source rootDomainEntrySource) {
-	if s == nil {
-		return rootDomainSnapshot{}, nil, page.ValuePtr{}, 0, false, rootDomainEntrySourceNone
-	}
-	if memtableViewHasRangeSpans(s.view) {
-		snap = rootDomainSnapshotFromCachedSnapshot(s, key)
-		val, ptr, flags, found, source = s.db.lookupViewEntryWithRangeSpansAndRootSource(s.view, key, false, snap, true)
-		if found {
-			return snap, val, ptr, flags, true, source
-		}
-		return snap, nil, page.ValuePtr{}, 0, false, rootDomainEntrySourceNone
-	}
-	snap = rootDomainSnapshotFromCachedSnapshot(s, key)
-	val, ptr, flags, found, source = snap.getEntryWithSource(key)
+	snap, val, ptr, flags, _, found, source = s.lookupRootDomainSnapshotEntryWithRevision(key)
 	return snap, val, ptr, flags, found, source
 }
 
+func (s *Snapshot) lookupRootDomainSnapshotEntryWithRevision(key []byte) (snap rootDomainSnapshot, val []byte, ptr page.ValuePtr, flags byte, revision page.EntryRevision, found bool, source rootDomainEntrySource) {
+	if s == nil {
+		return rootDomainSnapshot{}, nil, page.ValuePtr{}, 0, page.LegacyEntryRevision, false, rootDomainEntrySourceNone
+	}
+	if memtableViewHasRangeSpans(s.view) {
+		snap = rootDomainSnapshotFromCachedSnapshot(s, key)
+		val, ptr, flags, revision, found, source = s.db.lookupViewEntryWithRangeSpansAndRootRevisionSource(s.view, key, false, snap, true)
+		if found {
+			return snap, val, ptr, flags, revision, true, source
+		}
+		return snap, nil, page.ValuePtr{}, 0, page.LegacyEntryRevision, false, rootDomainEntrySourceNone
+	}
+	snap = rootDomainSnapshotFromCachedSnapshot(s, key)
+	val, ptr, flags, revision, found, source = snap.getEntryWithRevisionSource(key)
+	return snap, val, ptr, flags, revision, found, source
+}
+
 func (s *Snapshot) lookupRootDomainEntry(key []byte) (val []byte, ptr page.ValuePtr, flags byte, found bool, source rootDomainEntrySource) {
-	_, val, ptr, flags, found, source = s.lookupRootDomainSnapshotEntry(key)
+	_, val, ptr, flags, _, found, source = s.lookupRootDomainSnapshotEntryWithRevision(key)
 	return val, ptr, flags, found, source
 }
 
+func (s *Snapshot) lookupRootDomainEntryWithRevision(key []byte) (val []byte, ptr page.ValuePtr, flags byte, revision page.EntryRevision, found bool, source rootDomainEntrySource) {
+	_, val, ptr, flags, revision, found, source = s.lookupRootDomainSnapshotEntryWithRevision(key)
+	return val, ptr, flags, revision, found, source
+}
+
 func (s *Snapshot) lookupCachedRootDomainEntry(key []byte) (val []byte, ptr page.ValuePtr, flags byte, found bool) {
+	val, ptr, flags, _, found = s.lookupCachedRootDomainEntryWithRevision(key)
+	return val, ptr, flags, found
+}
+
+func (s *Snapshot) lookupCachedRootDomainEntryWithRevision(key []byte) (val []byte, ptr page.ValuePtr, flags byte, revision page.EntryRevision, found bool) {
 	if s == nil {
-		return nil, page.ValuePtr{}, 0, false
+		return nil, page.ValuePtr{}, 0, page.LegacyEntryRevision, false
 	}
 	if memtableViewHasRangeSpans(s.view) {
-		return s.lookupEntryWithRangeSpans(key)
+		val, ptr, flags, revision, found, _ = s.lookupEntryWithRangeSpansRevisionSource(key)
+		return val, ptr, flags, revision, found
 	}
 	if len(s.rootPointShards) == 0 {
-		return nil, page.ValuePtr{}, 0, false
+		return nil, page.ValuePtr{}, 0, page.LegacyEntryRevision, false
 	}
 	shardIdx := 0
 	if s.db != nil {
 		shardIdx = s.db.shardIndex(key)
 	}
 	if shardIdx < 0 || shardIdx >= len(s.rootPointShards) {
-		return nil, page.ValuePtr{}, 0, false
+		return nil, page.ValuePtr{}, 0, page.LegacyEntryRevision, false
 	}
 	snap := s.rootPointShards[shardIdx]
 	snap.published = nil
 	snap.publishedRootID = 0
-	return snap.getEntry(key)
+	return snap.getEntryWithRevision(key)
 }
 
 func recordSnapshotRootDomainRead(source rootDomainEntrySource, pointer bool, bytes int) {
@@ -499,6 +520,42 @@ func (s *Snapshot) getAppendFromEntryWithSource(snap rootDomainSnapshot, key, ds
 	}
 	recordSnapshotRootDomainRead(source, false, len(val))
 	return append(dst, val...), true, nil
+}
+
+func (s *Snapshot) appendVersionedEntryValue(key, dst []byte, oldLen int, val []byte, ptr page.ValuePtr, flags byte, revision page.EntryRevision, source rootDomainEntrySource) ([]byte, page.EntryRevision, error) {
+	if flags&node.FlagTombstone != 0 {
+		return dst, revision, tree.ErrKeyNotFound
+	}
+	if flags&node.FlagPointer != 0 {
+		var valueLogDB *DB
+		if s != nil {
+			valueLogDB = s.db
+		}
+		if valueLogDB == nil {
+			return dst, revision, ErrSnapshotValueLogReaderUnavailable
+		}
+		out, err := valueLogDB.readValueLogAppend(key, ptr, dst)
+		if err != nil {
+			return dst, revision, err
+		}
+		recordSnapshotRootDomainRead(source, true, len(out)-oldLen)
+		return out, revision, nil
+	}
+	if val == nil {
+		recordSnapshotRootDomainRead(source, false, 0)
+		return dst, revision, nil
+	}
+	recordSnapshotRootDomainRead(source, false, len(val))
+	return append(dst, val...), revision, nil
+}
+
+func (s *Snapshot) getVersionedAppendFromEntryWithSource(snap rootDomainSnapshot, key, dst []byte, oldLen int) ([]byte, page.EntryRevision, bool, error) {
+	val, ptr, flags, revision, found, source := snap.getEntryWithRevisionSource(key)
+	if !found {
+		return dst, page.LegacyEntryRevision, false, nil
+	}
+	out, revision, err := s.appendVersionedEntryValue(key, dst, oldLen, val, ptr, flags, revision, source)
+	return out, revision, true, err
 }
 
 func (s *Snapshot) iteratorSources(start, end []byte, reverse bool) ([]merging.IteratorSource, error) {
@@ -711,6 +768,67 @@ func (s *Snapshot) GetAppend(key, dst []byte) ([]byte, error) {
 		}
 	}
 	return out, nil
+}
+
+func (s *Snapshot) GetVersionedAppend(key, dst []byte) ([]byte, page.EntryRevision, error) {
+	key = normalizeRawKVPointKey(key)
+	if s == nil {
+		return dst, page.LegacyEntryRevision, tree.ErrKeyNotFound
+	}
+	oldLen := len(dst)
+	val, ptr, flags, revision, found := s.lookupCachedRootDomainEntryWithRevision(key)
+	if found {
+		return s.appendVersionedEntryValue(key, dst, oldLen, val, ptr, flags, revision, rootDomainEntrySourceCached)
+	}
+	if memtableViewHasRangeSpans(s.view) {
+		if s.backend == nil || s.db == nil {
+			return dst, page.LegacyEntryRevision, tree.ErrKeyNotFound
+		}
+		if err := s.db.flushValueLogForBackendRead(); err != nil {
+			return dst, page.LegacyEntryRevision, err
+		}
+		return s.backend.GetVersionedAppend(key, dst)
+	}
+	snap := rootDomainSnapshotFromCachedSnapshot(s, key)
+	if out, entryRevision, found, err := s.getVersionedAppendFromEntryWithSource(snap, key, dst, oldLen); found {
+		return out, entryRevision, err
+	}
+	if shouldShortCircuitPublishedAppendMiss(true, s.publishedRoots, snap) {
+		return dst, page.LegacyEntryRevision, tree.ErrKeyNotFound
+	}
+	if s.backend == nil || s.db == nil {
+		return dst, page.LegacyEntryRevision, tree.ErrKeyNotFound
+	}
+	if err := s.db.flushValueLogForBackendRead(); err != nil {
+		return dst, page.LegacyEntryRevision, err
+	}
+	out, entryRevision, err := s.backend.GetVersionedAppend(key, dst)
+	if err != nil {
+		return dst, entryRevision, err
+	}
+	if hotPathStatsEnabled {
+		snapshotReadBackendHitsTotal.Add(1)
+		if n := len(out) - oldLen; n > 0 {
+			snapshotReadBackendBytesTotal.Add(uint64(n))
+		}
+	}
+	return out, entryRevision, nil
+}
+
+func (s *Snapshot) GetVersioned(key []byte) ([]byte, page.EntryRevision, error) {
+	out, revision, err := s.GetVersionedAppend(key, nil)
+	if err != nil {
+		return nil, revision, err
+	}
+	if len(out) == 0 {
+		return []byte{}, revision, nil
+	}
+	if cap(out) == len(out) {
+		return out, revision, nil
+	}
+	owned := make([]byte, len(out))
+	copy(owned, out)
+	return owned, revision, nil
 }
 
 func (s *Snapshot) Get(key []byte) ([]byte, error) {
@@ -1075,6 +1193,10 @@ func (s *Snapshot) HasPrefixes(prefixes [][]byte) ([]bool, error) {
 }
 
 func snapshotRawKVLeafEntry(key []byte, val []byte, ptr page.ValuePtr, flags byte) node.LeafEntry {
+	return snapshotRawKVLeafEntryWithRevision(key, val, ptr, flags, page.LegacyEntryRevision)
+}
+
+func snapshotRawKVLeafEntryWithRevision(key []byte, val []byte, ptr page.ValuePtr, flags byte, revision page.EntryRevision) node.LeafEntry {
 	if flags&(node.FlagPointer|node.FlagTombstone) == 0 {
 		val = normalizeRawKVValue(val)
 	}
@@ -1083,14 +1205,15 @@ func snapshotRawKVLeafEntry(key []byte, val []byte, ptr page.ValuePtr, flags byt
 		Value:    val,
 		ValuePtr: ptr,
 		Flags:    flags,
+		Revision: revision,
 	}
 }
 
 func (s *Snapshot) GetEntry(key []byte) (node.LeafEntry, error) {
 	key = normalizeRawKVPointKey(key)
-	val, ptr, flags, found := s.lookupQueueEntry(key)
+	val, ptr, flags, revision, found := s.lookupQueueEntryWithRevision(key)
 	if found {
-		return snapshotRawKVLeafEntry(key, val, ptr, flags), nil
+		return snapshotRawKVLeafEntryWithRevision(key, val, ptr, flags, revision), nil
 	}
 
 	if s == nil || s.backend == nil || s.db == nil {
@@ -1104,9 +1227,9 @@ func (s *Snapshot) GetEntry(key []byte) (node.LeafEntry, error) {
 
 func (s *Snapshot) GetEntryExact(key []byte) (node.LeafEntry, error) {
 	key = normalizeRawKVPointKey(key)
-	val, ptr, flags, found := s.lookupQueueEntry(key)
+	val, ptr, flags, revision, found := s.lookupQueueEntryWithRevision(key)
 	if found {
-		return snapshotRawKVLeafEntry(key, val, ptr, flags), nil
+		return snapshotRawKVLeafEntryWithRevision(key, val, ptr, flags, revision), nil
 	}
 
 	if s == nil || s.backend == nil || s.db == nil {

--- a/TreeDB/caching/value_log_iterator.go
+++ b/TreeDB/caching/value_log_iterator.go
@@ -62,7 +62,10 @@ func (it *valueLogIterator) UnsafeEntry() ([]byte, page.ValuePtr, byte) {
 }
 
 func (it *valueLogIterator) UnsafeEntryWithRevision() ([]byte, page.ValuePtr, byte, page.EntryRevision) {
-	_, _, _, revision := iterator.UnsafeEntryWithRevision(it.iter)
+	revision := page.LegacyEntryRevision
+	if revIter, ok := it.iter.(iterator.RevisionUnsafeIterator); ok {
+		_, _, _, revision = revIter.UnsafeEntryWithRevision()
+	}
 	if it.iter.IsDeleted() {
 		return nil, page.ValuePtr{}, node.FlagTombstone, revision
 	}

--- a/TreeDB/caching/value_log_iterator.go
+++ b/TreeDB/caching/value_log_iterator.go
@@ -57,15 +57,21 @@ func (it *valueLogIterator) UnsafeValue() []byte {
 }
 
 func (it *valueLogIterator) UnsafeEntry() ([]byte, page.ValuePtr, byte) {
+	val, ptr, flags, _ := it.UnsafeEntryWithRevision()
+	return val, ptr, flags
+}
+
+func (it *valueLogIterator) UnsafeEntryWithRevision() ([]byte, page.ValuePtr, byte, page.EntryRevision) {
+	_, _, _, revision := iterator.UnsafeEntryWithRevision(it.iter)
 	if it.iter.IsDeleted() {
-		return nil, page.ValuePtr{}, node.FlagTombstone
+		return nil, page.ValuePtr{}, node.FlagTombstone, revision
 	}
 	it.loadValue()
 	if it.cachedHasPtr {
 		// Value-log pointers are materialized here; report inline semantics.
-		return it.cachedValue, page.ValuePtr{}, node.FlagInline
+		return it.cachedValue, page.ValuePtr{}, node.FlagInline, revision
 	}
-	return it.cachedValue, page.ValuePtr{}, node.FlagInline
+	return it.cachedValue, page.ValuePtr{}, node.FlagInline, revision
 }
 
 func (it *valueLogIterator) Key() []byte {

--- a/TreeDB/caching/versioned_read_test.go
+++ b/TreeDB/caching/versioned_read_test.go
@@ -1,0 +1,139 @@
+package caching
+
+import (
+	"bytes"
+	"path/filepath"
+	"testing"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+	"github.com/snissn/gomap/TreeDB/page"
+	"github.com/snissn/gomap/TreeDB/tree"
+)
+
+func TestGetVersionedPreservesMutableMemtableRevision(t *testing.T) {
+	dir := t.TempDir()
+	backend, err := backenddb.Open(backenddb.Options{Dir: filepath.Join(dir, "backend")})
+	if err != nil {
+		t.Fatalf("backend Open: %v", err)
+	}
+	defer func() {
+		if err := backend.Close(); err != nil {
+			t.Fatalf("backend Close: %v", err)
+		}
+	}()
+
+	db, err := Open(filepath.Join(dir, "cache"), backend, Options{
+		DisableWAL:     true,
+		AllowUnsafe:    true,
+		FlushThreshold: 1 << 30,
+		MemtableMode:   "skiplist",
+		MemtableShards: 1,
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() {
+		if err := db.Close(); err != nil {
+			t.Fatalf("Close: %v", err)
+		}
+	}()
+
+	b := db.NewBatch()
+	if err := b.SetWithRevision([]byte("k"), []byte("value"), page.EntryRevision(201)); err != nil {
+		t.Fatalf("SetWithRevision: %v", err)
+	}
+	if err := b.Write(); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if err := b.Close(); err != nil {
+		t.Fatalf("Close batch: %v", err)
+	}
+
+	val, revision, err := db.GetVersioned([]byte("k"))
+	if err != nil {
+		t.Fatalf("GetVersioned: %v", err)
+	}
+	if !bytes.Equal(val, []byte("value")) || revision != 201 {
+		t.Fatalf("GetVersioned=(%q,%d), want (value,201)", val, revision)
+	}
+
+	dst := []byte("prefix:")
+	out, revision, err := db.GetVersionedAppend([]byte("k"), dst)
+	if err != nil {
+		t.Fatalf("GetVersionedAppend: %v", err)
+	}
+	if !bytes.Equal(out, []byte("prefix:value")) || revision != 201 {
+		t.Fatalf("GetVersionedAppend=(%q,%d), want (prefix:value,201)", out, revision)
+	}
+
+	snap := db.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("AcquireSnapshot returned nil")
+	}
+	defer snap.Close()
+
+	snapVal, snapRevision, err := snap.GetVersioned([]byte("k"))
+	if err != nil {
+		t.Fatalf("Snapshot.GetVersioned: %v", err)
+	}
+	if !bytes.Equal(snapVal, []byte("value")) || snapRevision != 201 {
+		t.Fatalf("Snapshot.GetVersioned=(%q,%d), want (value,201)", snapVal, snapRevision)
+	}
+
+	snapEntry, err := snap.GetEntry([]byte("k"))
+	if err != nil {
+		t.Fatalf("Snapshot.GetEntry: %v", err)
+	}
+	if !bytes.Equal(snapEntry.Value, []byte("value")) || snapEntry.Revision != 201 {
+		t.Fatalf("Snapshot.GetEntry=(%q,%d), want (value,201)", snapEntry.Value, snapEntry.Revision)
+	}
+}
+
+func TestGetVersionedPreservesMutableMemtableDeleteRevision(t *testing.T) {
+	db, err := Open(t.TempDir(), NewMockBackend(), Options{
+		DisableWAL:     true,
+		AllowUnsafe:    true,
+		FlushThreshold: 1 << 30,
+		MemtableMode:   "skiplist",
+		MemtableShards: 1,
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() {
+		if err := db.Close(); err != nil {
+			t.Fatalf("Close: %v", err)
+		}
+	}()
+
+	b := db.NewBatch()
+	if err := b.SetWithRevision([]byte("k"), []byte("value"), page.EntryRevision(201)); err != nil {
+		t.Fatalf("SetWithRevision: %v", err)
+	}
+	if err := b.DeleteWithRevision([]byte("k"), page.EntryRevision(202)); err != nil {
+		t.Fatalf("DeleteWithRevision: %v", err)
+	}
+	if err := b.Write(); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if err := b.Close(); err != nil {
+		t.Fatalf("Close batch: %v", err)
+	}
+
+	val, revision, err := db.GetVersioned([]byte("k"))
+	if err != nil {
+		t.Fatalf("GetVersioned: %v", err)
+	}
+	if val != nil || revision != 202 {
+		t.Fatalf("GetVersioned after delete=(%q,%d), want (nil,202)", val, revision)
+	}
+
+	dst := []byte("prefix:")
+	out, revision, err := db.GetVersionedAppend([]byte("k"), dst)
+	if err != tree.ErrKeyNotFound {
+		t.Fatalf("GetVersionedAppend err=%v, want ErrKeyNotFound", err)
+	}
+	if !bytes.Equal(out, dst) || revision != 202 {
+		t.Fatalf("GetVersionedAppend after delete=(%q,%d), want (%q,202)", out, revision, dst)
+	}
+}

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -5422,6 +5422,34 @@ func compactTableRunMap(runs map[string][]memtable.Table) (map[string][]memtable
 	return out, obsolete, changed, nil
 }
 
+func setCollectionRunEntryStealWithRevision(table memtable.Table, key, value []byte, ptr page.ValuePtr, flags byte, revision page.EntryRevision) {
+	if revision != page.LegacyEntryRevision {
+		if writer, ok := table.(memtable.RevisionStealTable); ok {
+			writer.SetEntryStealWithRevision(key, value, ptr, flags, revision)
+			return
+		}
+		if writer, ok := table.(memtable.RevisionTable); ok {
+			writer.SetEntryWithRevision(key, value, ptr, flags, revision)
+			return
+		}
+	}
+	table.SetEntrySteal(key, value, ptr, flags)
+}
+
+func deleteCollectionRunEntryStealWithRevision(table memtable.Table, key []byte, revision page.EntryRevision) {
+	if revision != page.LegacyEntryRevision {
+		if writer, ok := table.(memtable.RevisionStealTable); ok {
+			writer.SetEntryStealWithRevision(key, nil, page.ValuePtr{}, node.FlagTombstone, revision)
+			return
+		}
+		if writer, ok := table.(memtable.RevisionTable); ok {
+			writer.SetEntryWithRevision(key, nil, page.ValuePtr{}, node.FlagTombstone, revision)
+			return
+		}
+	}
+	table.DeleteSteal(key)
+}
+
 func compactTableRuns(runs []memtable.Table) (memtable.Table, error) {
 	entryCapacity := 0
 	for _, table := range runs {
@@ -5434,12 +5462,12 @@ func compactTableRuns(runs []memtable.Table) (memtable.Table, error) {
 	defer func() { _ = iter.Close() }()
 	for ; iter.Valid(); iter.Next() {
 		key := bytes.Clone(iter.UnsafeKey())
-		value, ptr, flags := iter.UnsafeEntry()
+		value, ptr, flags, revision := iterator.UnsafeEntryWithRevision(iter)
 		var valueCopy []byte
 		if value != nil {
 			valueCopy = bytes.Clone(value)
 		}
-		table.SetEntrySteal(key, valueCopy, ptr, flags)
+		setCollectionRunEntryStealWithRevision(table, key, valueCopy, ptr, flags, revision)
 	}
 	if err := iter.Error(); err != nil {
 		resetCollectionRunTable(table)
@@ -5450,10 +5478,11 @@ func compactTableRuns(runs []memtable.Table) (memtable.Table, error) {
 }
 
 type collectionPointerizedRunEntry struct {
-	key   []byte
-	value []byte
-	ptr   page.ValuePtr
-	flags byte
+	key      []byte
+	value    []byte
+	ptr      page.ValuePtr
+	flags    byte
+	revision page.EntryRevision
 }
 
 const (
@@ -5617,11 +5646,12 @@ func pointerizeCollectionRunTableValuesWithOptionsAndStats(db *backenddb.DB, tab
 	it := table.NewIterator(nil, nil)
 	defer func() { _ = it.Close() }()
 	for it.Valid() {
-		value, ptr, flags := it.UnsafeEntry()
+		value, ptr, flags, revision := iterator.UnsafeEntryWithRevision(it)
 		entry := collectionPointerizedRunEntry{
-			key:   bytes.Clone(it.UnsafeKey()),
-			ptr:   ptr,
-			flags: flags,
+			key:      bytes.Clone(it.UnsafeKey()),
+			ptr:      ptr,
+			flags:    flags,
+			revision: revision,
 		}
 		if flags&node.FlagTombstone == 0 &&
 			flags&node.FlagPointer == 0 &&
@@ -5661,7 +5691,7 @@ func pointerizeCollectionRunTableValuesWithOptionsAndStats(db *backenddb.DB, tab
 	out := newCollectionRunTable(len(entries))
 	for i := range entries {
 		entry := entries[i]
-		out.SetEntrySteal(entry.key, entry.value, entry.ptr, entry.flags)
+		setCollectionRunEntryStealWithRevision(out, entry.key, entry.value, entry.ptr, entry.flags, entry.revision)
 	}
 	out.Freeze()
 	success = true
@@ -7840,8 +7870,8 @@ func cloneCollectionRunTable(run memtable.Table) (memtable.Table, error) {
 
 func cloneCollectionRunTableFromIterator(table memtable.Table, it iterator.UnsafeIterator) (memtable.Table, error) {
 	for it.Valid() {
-		value, ptr, flags := it.UnsafeEntry()
-		table.SetEntrySteal(bytes.Clone(it.UnsafeKey()), bytes.Clone(value), ptr, flags)
+		value, ptr, flags, revision := iterator.UnsafeEntryWithRevision(it)
+		setCollectionRunEntryStealWithRevision(table, bytes.Clone(it.UnsafeKey()), bytes.Clone(value), ptr, flags, revision)
 		it.Next()
 	}
 	if err := it.Error(); err != nil {
@@ -8149,10 +8179,15 @@ func (it *bufferedRootRunsIterator) UnsafeValue() []byte {
 }
 
 func (it *bufferedRootRunsIterator) UnsafeEntry() ([]byte, page.ValuePtr, byte) {
+	val, ptr, flags, _ := it.UnsafeEntryWithRevision()
+	return val, ptr, flags
+}
+
+func (it *bufferedRootRunsIterator) UnsafeEntryWithRevision() ([]byte, page.ValuePtr, byte, page.EntryRevision) {
 	if !it.Valid() {
-		return nil, page.ValuePtr{}, node.FlagInline
+		return nil, page.ValuePtr{}, node.FlagInline, page.LegacyEntryRevision
 	}
-	return it.iters[it.cur.idx].UnsafeEntry()
+	return iterator.UnsafeEntryWithRevision(it.iters[it.cur.idx])
 }
 
 func (it *bufferedRootRunsIterator) Key() []byte {
@@ -8768,11 +8803,11 @@ func mergeCollectionRootDeltaTables(tables []memtable.Table) (memtable.Table, er
 		iter := table.NewIterator(nil, nil)
 		for iter.Valid() {
 			key := bytes.Clone(iter.UnsafeKey())
-			value, ptr, flags := iter.UnsafeEntry()
+			value, ptr, flags, revision := iterator.UnsafeEntryWithRevision(iter)
 			if flags&node.FlagTombstone != 0 {
-				merged.DeleteSteal(key)
+				deleteCollectionRunEntryStealWithRevision(merged, key, revision)
 			} else {
-				merged.SetEntrySteal(key, bytes.Clone(value), ptr, flags)
+				setCollectionRunEntryStealWithRevision(merged, key, bytes.Clone(value), ptr, flags, revision)
 			}
 			iter.Next()
 		}
@@ -21435,18 +21470,23 @@ func (it *systemTargetIterator) UnsafeValue() []byte {
 }
 
 func (it *systemTargetIterator) UnsafeEntry() ([]byte, page.ValuePtr, byte) {
+	val, ptr, flags, _ := it.UnsafeEntryWithRevision()
+	return val, ptr, flags
+}
+
+func (it *systemTargetIterator) UnsafeEntryWithRevision() ([]byte, page.ValuePtr, byte, page.EntryRevision) {
 	if !it.Valid() {
-		return nil, page.ValuePtr{}, node.FlagInline
+		return nil, page.ValuePtr{}, node.FlagInline, page.LegacyEntryRevision
 	}
 	entry := it.entries[it.idx]
 	if entry.flags&node.FlagTombstone != 0 {
-		return nil, page.ValuePtr{}, node.FlagTombstone
+		return nil, page.ValuePtr{}, node.FlagTombstone, page.LegacyEntryRevision
 	}
 	flags := entry.flags
 	if flags == 0 {
 		flags = node.FlagInline
 	}
-	return entry.value, page.ValuePtr{}, flags
+	return entry.value, page.ValuePtr{}, flags, page.LegacyEntryRevision
 }
 
 func (it *systemTargetIterator) Key() []byte {

--- a/TreeDB/collections/freeze_sort_run_table.go
+++ b/TreeDB/collections/freeze_sort_run_table.go
@@ -14,11 +14,12 @@ import (
 )
 
 type freezeSortRunEntry struct {
-	key   []byte
-	value []byte
-	ptr   page.ValuePtr
-	seq   uint64
-	flags byte
+	key      []byte
+	value    []byte
+	ptr      page.ValuePtr
+	seq      uint64
+	flags    byte
+	revision page.EntryRevision
 }
 
 type freezeSortRunTable struct {
@@ -84,7 +85,11 @@ func (h freezeSortRunTableHandle) SetSteal(key, value []byte) {
 }
 
 func (h freezeSortRunTableHandle) SetEntry(key, value []byte, ptr page.ValuePtr, flags byte) {
-	h.SetEntrySteal(bytes.Clone(key), bytes.Clone(value), ptr, flags)
+	h.SetEntryWithRevision(key, value, ptr, flags, page.LegacyEntryRevision)
+}
+
+func (h freezeSortRunTableHandle) SetEntryWithRevision(key, value []byte, ptr page.ValuePtr, flags byte, revision page.EntryRevision) {
+	h.SetEntryStealWithRevision(bytes.Clone(key), bytes.Clone(value), ptr, flags, revision)
 }
 
 func (h freezeSortRunTableHandle) PutWithCallback(key, value []byte, cb func(k, v []byte) error) error {
@@ -100,10 +105,14 @@ func (h freezeSortRunTableHandle) PutWithCallback(key, value []byte, cb func(k, 
 }
 
 func (h freezeSortRunTableHandle) SetEntrySteal(key, value []byte, ptr page.ValuePtr, flags byte) {
+	h.SetEntryStealWithRevision(key, value, ptr, flags, page.LegacyEntryRevision)
+}
+
+func (h freezeSortRunTableHandle) SetEntryStealWithRevision(key, value []byte, ptr page.ValuePtr, flags byte, revision page.EntryRevision) {
 	if h.table == nil {
 		return
 	}
-	h.table.setEntryStealOwned(h.ownerGeneration, key, value, ptr, flags)
+	h.table.setEntryStealOwned(h.ownerGeneration, key, value, ptr, flags, revision)
 }
 
 func (h freezeSortRunTableHandle) ApplyStealEntryFunc(count int, emit func(i int) (key, value []byte, ptr page.ValuePtr, flags byte, err error)) error {
@@ -111,6 +120,13 @@ func (h freezeSortRunTableHandle) ApplyStealEntryFunc(count int, emit func(i int
 		return nil
 	}
 	return h.table.applyStealEntryFuncOwned(h.ownerGeneration, count, emit)
+}
+
+func (h freezeSortRunTableHandle) ApplyStealEntryFuncWithRevision(count int, emit func(i int) (key, value []byte, ptr page.ValuePtr, flags byte, revision page.EntryRevision, err error)) error {
+	if h.table == nil {
+		return nil
+	}
+	return h.table.applyStealEntryFuncWithRevisionOwned(h.ownerGeneration, count, emit)
 }
 
 func (h freezeSortRunTableHandle) Delete(key []byte) {
@@ -158,6 +174,13 @@ func (h freezeSortRunTableHandle) GetEntry(key []byte) ([]byte, page.ValuePtr, b
 		return nil, page.ValuePtr{}, 0, false
 	}
 	return h.table.getEntryOwned(h.ownerGeneration, key)
+}
+
+func (h freezeSortRunTableHandle) GetEntryWithRevision(key []byte) ([]byte, page.ValuePtr, byte, page.EntryRevision, bool) {
+	if h.table == nil {
+		return nil, page.ValuePtr{}, 0, page.LegacyEntryRevision, false
+	}
+	return h.table.getEntryWithRevisionOwned(h.ownerGeneration, key)
 }
 
 func (h freezeSortRunTableHandle) Size() int64 {
@@ -217,7 +240,11 @@ func (t *freezeSortRunTable) SetSteal(key, value []byte) {
 }
 
 func (t *freezeSortRunTable) SetEntry(key, value []byte, ptr page.ValuePtr, flags byte) {
-	t.SetEntrySteal(bytes.Clone(key), bytes.Clone(value), ptr, flags)
+	t.SetEntryWithRevision(key, value, ptr, flags, page.LegacyEntryRevision)
+}
+
+func (t *freezeSortRunTable) SetEntryWithRevision(key, value []byte, ptr page.ValuePtr, flags byte, revision page.EntryRevision) {
+	t.SetEntryStealWithRevision(bytes.Clone(key), bytes.Clone(value), ptr, flags, revision)
 }
 
 func (t *freezeSortRunTable) PutWithCallback(key, value []byte, cb func(k, v []byte) error) error {
@@ -233,10 +260,14 @@ func (t *freezeSortRunTable) PutWithCallback(key, value []byte, cb func(k, v []b
 }
 
 func (t *freezeSortRunTable) SetEntrySteal(key, value []byte, ptr page.ValuePtr, flags byte) {
-	t.setEntryStealOwned(0, key, value, ptr, flags)
+	t.SetEntryStealWithRevision(key, value, ptr, flags, page.LegacyEntryRevision)
 }
 
-func (t *freezeSortRunTable) setEntryStealOwned(ownerGeneration uint64, key, value []byte, ptr page.ValuePtr, flags byte) {
+func (t *freezeSortRunTable) SetEntryStealWithRevision(key, value []byte, ptr page.ValuePtr, flags byte, revision page.EntryRevision) {
+	t.setEntryStealOwned(0, key, value, ptr, flags, revision)
+}
+
+func (t *freezeSortRunTable) setEntryStealOwned(ownerGeneration uint64, key, value []byte, ptr page.ValuePtr, flags byte, revision page.EntryRevision) {
 	if t == nil || len(key) == 0 {
 		return
 	}
@@ -249,11 +280,12 @@ func (t *freezeSortRunTable) setEntryStealOwned(ownerGeneration uint64, key, val
 	t.mustOwnedLocked(ownerGeneration)
 	idx := len(t.entries)
 	t.entries = append(t.entries, freezeSortRunEntry{
-		key:   key,
-		value: value,
-		ptr:   ptr,
-		seq:   t.nextSeq,
-		flags: flags,
+		key:      key,
+		value:    value,
+		ptr:      ptr,
+		seq:      t.nextSeq,
+		flags:    flags,
+		revision: revision,
 	})
 	t.nextSeq++
 	t.sizeBytes += int64(len(key) + entryLogicalValueSize(flags, value))
@@ -267,6 +299,20 @@ func (t *freezeSortRunTable) ApplyStealEntryFunc(count int, emit func(i int) (ke
 }
 
 func (t *freezeSortRunTable) applyStealEntryFuncOwned(ownerGeneration uint64, count int, emit func(i int) (key, value []byte, ptr page.ValuePtr, flags byte, err error)) error {
+	if emit == nil {
+		return errors.New("collections: nil freeze-sort entry emitter")
+	}
+	return t.applyStealEntryFuncWithRevisionOwned(ownerGeneration, count, func(i int) (key, value []byte, ptr page.ValuePtr, flags byte, revision page.EntryRevision, err error) {
+		key, value, ptr, flags, err = emit(i)
+		return key, value, ptr, flags, page.LegacyEntryRevision, err
+	})
+}
+
+func (t *freezeSortRunTable) ApplyStealEntryFuncWithRevision(count int, emit func(i int) (key, value []byte, ptr page.ValuePtr, flags byte, revision page.EntryRevision, err error)) error {
+	return t.applyStealEntryFuncWithRevisionOwned(0, count, emit)
+}
+
+func (t *freezeSortRunTable) applyStealEntryFuncWithRevisionOwned(ownerGeneration uint64, count int, emit func(i int) (key, value []byte, ptr page.ValuePtr, flags byte, revision page.EntryRevision, err error)) error {
 	if count <= 0 {
 		return nil
 	}
@@ -281,7 +327,7 @@ func (t *freezeSortRunTable) applyStealEntryFuncOwned(ownerGeneration uint64, co
 	t.mustOwnedLocked(ownerGeneration)
 	t.entries = growFreezeSortRunEntries(t.entries, count)
 	for i := 0; i < count; i++ {
-		key, value, ptr, flags, err := emit(i)
+		key, value, ptr, flags, revision, err := emit(i)
 		if err != nil {
 			return err
 		}
@@ -294,11 +340,12 @@ func (t *freezeSortRunTable) applyStealEntryFuncOwned(ownerGeneration uint64, co
 		}
 		idx := len(t.entries)
 		t.entries = append(t.entries, freezeSortRunEntry{
-			key:   key,
-			value: value,
-			ptr:   ptr,
-			seq:   t.nextSeq,
-			flags: flags,
+			key:      key,
+			value:    value,
+			ptr:      ptr,
+			seq:      t.nextSeq,
+			flags:    flags,
+			revision: revision,
 		})
 		t.nextSeq++
 		t.sizeBytes += int64(len(key) + entryLogicalValueSize(flags, value))
@@ -358,9 +405,18 @@ func (t *freezeSortRunTable) GetEntry(key []byte) ([]byte, page.ValuePtr, byte, 
 	return t.getEntryOwned(0, key)
 }
 
+func (t *freezeSortRunTable) GetEntryWithRevision(key []byte) ([]byte, page.ValuePtr, byte, page.EntryRevision, bool) {
+	return t.getEntryWithRevisionOwned(0, key)
+}
+
 func (t *freezeSortRunTable) getEntryOwned(ownerGeneration uint64, key []byte) ([]byte, page.ValuePtr, byte, bool) {
+	value, ptr, flags, _, found := t.getEntryWithRevisionOwned(ownerGeneration, key)
+	return value, ptr, flags, found
+}
+
+func (t *freezeSortRunTable) getEntryWithRevisionOwned(ownerGeneration uint64, key []byte) ([]byte, page.ValuePtr, byte, page.EntryRevision, bool) {
 	if t == nil || len(key) == 0 {
-		return nil, page.ValuePtr{}, 0, false
+		return nil, page.ValuePtr{}, 0, page.LegacyEntryRevision, false
 	}
 	t.mu.RLock()
 	if !t.ownedLocked(ownerGeneration) {
@@ -371,9 +427,9 @@ func (t *freezeSortRunTable) getEntryOwned(ownerGeneration uint64, key []byte) (
 		entry, found := t.getFrozenEntryLocked(key)
 		t.mu.RUnlock()
 		if !found {
-			return nil, page.ValuePtr{}, 0, false
+			return nil, page.ValuePtr{}, 0, page.LegacyEntryRevision, false
 		}
-		return entry.value, entry.ptr, entry.flags, true
+		return entry.value, entry.ptr, entry.flags, entry.revision, true
 	}
 	t.mu.RUnlock()
 
@@ -383,20 +439,20 @@ func (t *freezeSortRunTable) getEntryOwned(ownerGeneration uint64, key []byte) (
 	if t.frozen {
 		entry, found := t.getFrozenEntryLocked(key)
 		if !found {
-			return nil, page.ValuePtr{}, 0, false
+			return nil, page.ValuePtr{}, 0, page.LegacyEntryRevision, false
 		}
-		return entry.value, entry.ptr, entry.flags, true
+		return entry.value, entry.ptr, entry.flags, entry.revision, true
 	}
 	t.rebuildLatestLocked()
 	idx, ok := t.latest[unsafe.String(&key[0], len(key))]
 	if !ok || idx < 0 || idx >= len(t.entries) {
-		return nil, page.ValuePtr{}, 0, false
+		return nil, page.ValuePtr{}, 0, page.LegacyEntryRevision, false
 	}
 	entry := t.entries[idx]
 	if !bytes.Equal(entry.key, key) {
-		return nil, page.ValuePtr{}, 0, false
+		return nil, page.ValuePtr{}, 0, page.LegacyEntryRevision, false
 	}
-	return entry.value, entry.ptr, entry.flags, true
+	return entry.value, entry.ptr, entry.flags, entry.revision, true
 }
 
 func (t *freezeSortRunTable) getFrozenEntryLocked(key []byte) (freezeSortRunEntry, bool) {
@@ -777,11 +833,16 @@ func (it *freezeSortRunIterator) UnsafeValue() []byte {
 }
 
 func (it *freezeSortRunIterator) UnsafeEntry() ([]byte, page.ValuePtr, byte) {
+	value, ptr, flags, _ := it.UnsafeEntryWithRevision()
+	return value, ptr, flags
+}
+
+func (it *freezeSortRunIterator) UnsafeEntryWithRevision() ([]byte, page.ValuePtr, byte, page.EntryRevision) {
 	if !it.Valid() {
-		return nil, page.ValuePtr{}, 0
+		return nil, page.ValuePtr{}, 0, page.LegacyEntryRevision
 	}
 	entry := it.entries[it.idx]
-	return entry.value, entry.ptr, entry.flags
+	return entry.value, entry.ptr, entry.flags, entry.revision
 }
 
 func (it *freezeSortRunIterator) Key() []byte { return it.UnsafeKey() }

--- a/TreeDB/collections/freeze_sort_run_table_test.go
+++ b/TreeDB/collections/freeze_sort_run_table_test.go
@@ -6,6 +6,7 @@ import (
 	"unsafe"
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
+	"github.com/snissn/gomap/TreeDB/internal/iterator"
 	"github.com/snissn/gomap/TreeDB/node"
 	"github.com/snissn/gomap/TreeDB/page"
 )
@@ -133,6 +134,40 @@ func TestFreezeSortRunTableApplyStealEntryFunc(t *testing.T) {
 	requireFreezeSortRunIterator(t, table.NewIterator(nil, nil), []string{"a", "b", "c"})
 	if got := table.Len(); got != 3 {
 		t.Fatalf("frozen Len=%d want 3", got)
+	}
+}
+
+func TestFreezeSortRunTableRevisionRoundTrip(t *testing.T) {
+	table := newFreezeSortRunTable()
+	revisions, ok := table.(interface {
+		SetEntryWithRevision(key, value []byte, ptr page.ValuePtr, flags byte, revision page.EntryRevision)
+		GetEntryWithRevision(key []byte) ([]byte, page.ValuePtr, byte, page.EntryRevision, bool)
+	})
+	if !ok {
+		t.Fatal("freeze-sort run table does not expose revision table contract")
+	}
+	revisions.SetEntryWithRevision([]byte("a"), []byte("old"), page.ValuePtr{}, node.FlagInline, 1)
+	revisions.SetEntryWithRevision([]byte("a"), []byte("new"), page.ValuePtr{}, node.FlagInline, 7)
+	revisions.SetEntryWithRevision([]byte("b"), nil, page.ValuePtr{}, node.FlagTombstone, 8)
+
+	if got, _, flags, rev, ok := revisions.GetEntryWithRevision([]byte("a")); !ok || flags&node.FlagTombstone != 0 || !bytes.Equal(got, []byte("new")) || rev != 7 {
+		t.Fatalf("mutable a=(%q,%02x,%d,%v), want new inline rev 7", got, flags, rev, ok)
+	}
+	table.Freeze()
+	if _, _, flags, rev, ok := revisions.GetEntryWithRevision([]byte("b")); !ok || flags&node.FlagTombstone == 0 || rev != 8 {
+		t.Fatalf("frozen b=(%02x,%d,%v), want tombstone rev 8", flags, rev, ok)
+	}
+
+	it := table.NewIterator(nil, nil)
+	defer func() { _ = it.Close() }()
+	_, _, _, rev := iterator.UnsafeEntryWithRevision(it)
+	if rev != 7 {
+		t.Fatalf("iterator first revision=%d want 7", rev)
+	}
+	it.Next()
+	_, _, flags, rev := iterator.UnsafeEntryWithRevision(it)
+	if flags&node.FlagTombstone == 0 || rev != 8 {
+		t.Fatalf("iterator second flags/rev=(%02x,%d), want tombstone rev 8", flags, rev)
 	}
 }
 

--- a/TreeDB/db/api.go
+++ b/TreeDB/db/api.go
@@ -178,6 +178,34 @@ func (db *DB) Get(key []byte) ([]byte, error) {
 	return val, err
 }
 
+// GetVersioned returns the value for key plus the native entry revision stored
+// beside that value. Missing keys return a nil value, LegacyEntryRevision, and
+// nil error; tombstones return a nil value with their tombstone revision.
+func (db *DB) GetVersioned(key []byte) ([]byte, page.EntryRevision, error) {
+	key = normalizeRawKVPointKey(key)
+	readOnce := func() ([]byte, page.EntryRevision, error) {
+		snap, err := db.acquireSnapshotOrErr()
+		if err != nil {
+			return nil, page.LegacyEntryRevision, err
+		}
+		defer snap.Close()
+		return snap.GetVersioned(key)
+	}
+
+	retryEpoch := db.readRetryRefreshEpoch.Load()
+	val, revision, err := readOnce()
+	if db.refreshOnValueLogFileNotFound(err) {
+		if refreshErr := db.refreshValueLogSetForReadRetry(retryEpoch); refreshErr != nil {
+			return nil, page.LegacyEntryRevision, refreshErr
+		}
+		val, revision, err = readOnce()
+	}
+	if err == tree.ErrKeyNotFound {
+		return nil, revision, nil
+	}
+	return val, revision, err
+}
+
 // DurabilityMode reports the backend durability mode configured at open.
 func (db *DB) DurabilityMode() DurabilityMode {
 	if db == nil {
@@ -431,6 +459,34 @@ func (db *DB) GetAppend(key, dst []byte) ([]byte, error) {
 	return val, nil
 }
 
+// GetVersionedAppend appends the value for key to dst and returns the native
+// entry revision stored with the visible entry. Missing/tombstoned keys return
+// dst and tree.ErrKeyNotFound; tombstones preserve their stored revision.
+func (db *DB) GetVersionedAppend(key, dst []byte) ([]byte, page.EntryRevision, error) {
+	key = normalizeRawKVPointKey(key)
+	readOnce := func(base []byte) ([]byte, page.EntryRevision, error) {
+		snap, err := db.acquireSnapshotOrErr()
+		if err != nil {
+			return base, page.LegacyEntryRevision, err
+		}
+		defer snap.Close()
+		return snap.GetVersionedAppend(key, base)
+	}
+
+	retryEpoch := db.readRetryRefreshEpoch.Load()
+	val, revision, err := readOnce(dst)
+	if db.refreshOnValueLogFileNotFound(err) {
+		if refreshErr := db.refreshValueLogSetForReadRetry(retryEpoch); refreshErr != nil {
+			return dst, page.LegacyEntryRevision, refreshErr
+		}
+		val, revision, err = readOnce(dst)
+	}
+	if err != nil {
+		return dst, revision, err
+	}
+	return val, revision, nil
+}
+
 // Has checks if a key exists.
 func (db *DB) Has(key []byte) (bool, error) {
 	key = normalizeRawKVPointKey(key)
@@ -599,6 +655,10 @@ func (it *DBIterator) UnsafeValue() []byte {
 
 func (it *DBIterator) UnsafeEntry() ([]byte, page.ValuePtr, byte) {
 	return it.iter.UnsafeEntry()
+}
+
+func (it *DBIterator) UnsafeEntryWithRevision() ([]byte, page.ValuePtr, byte, page.EntryRevision) {
+	return iterator.UnsafeEntryWithRevision(it.iter)
 }
 
 func (it *DBIterator) IsDeleted() bool {

--- a/TreeDB/db/batch.go
+++ b/TreeDB/db/batch.go
@@ -184,6 +184,10 @@ func (b *Batch) Set(key, value []byte) error {
 	return b.batch.Set(key, value)
 }
 
+func (b *Batch) SetWithRevision(key, value []byte, revision page.EntryRevision) error {
+	return b.batch.SetWithRevision(key, value, revision)
+}
+
 // SetView records a Put without copying key/value bytes. Callers must treat
 // key/value as immutable until the batch is written or closed.
 //
@@ -193,8 +197,16 @@ func (b *Batch) SetView(key, value []byte) error {
 	return b.batch.SetView(key, value)
 }
 
+func (b *Batch) SetViewWithRevision(key, value []byte, revision page.EntryRevision) error {
+	return b.batch.SetViewWithRevision(key, value, revision)
+}
+
 func (b *Batch) Delete(key []byte) error {
 	return b.batch.Delete(key)
+}
+
+func (b *Batch) DeleteWithRevision(key []byte, revision page.EntryRevision) error {
+	return b.batch.DeleteWithRevision(key, revision)
 }
 
 func (b *Batch) DeleteRange(start, end []byte) error {
@@ -207,14 +219,26 @@ func (b *Batch) DeleteView(key []byte) error {
 	return b.batch.DeleteView(key)
 }
 
+func (b *Batch) DeleteViewWithRevision(key []byte, revision page.EntryRevision) error {
+	return b.batch.DeleteViewWithRevision(key, revision)
+}
+
 // SetPointer records a pointer without copying the value bytes.
 func (b *Batch) SetPointer(key []byte, ptr page.ValuePtr) error {
 	return b.batch.SetPointer(key, ptr)
 }
 
+func (b *Batch) SetPointerWithRevision(key []byte, ptr page.ValuePtr, revision page.EntryRevision) error {
+	return b.batch.SetPointerWithRevision(key, ptr, revision)
+}
+
 // SetPointerView records a pointer without copying the key bytes.
 func (b *Batch) SetPointerView(key []byte, ptr page.ValuePtr) error {
 	return b.batch.SetPointerView(key, ptr)
+}
+
+func (b *Batch) SetPointerViewWithRevision(key []byte, ptr page.ValuePtr, revision page.EntryRevision) error {
+	return b.batch.SetPointerViewWithRevision(key, ptr, revision)
 }
 
 func (b *Batch) SetOps(ops []batch.Entry) error {

--- a/TreeDB/db/command_wal_raw.go
+++ b/TreeDB/db/command_wal_raw.go
@@ -521,7 +521,12 @@ func (db *DB) newRawKVCommandWALPayloadIntentFromEntries(entries []batchpkg.Entr
 	if plan.Count == 0 {
 		return nil, nil
 	}
-	payload, err := commitlog.EncodeRawKVBatchPayloadScanWithHint(scan, plan.Count, 0)
+	var payload []byte
+	if plan.EntryRevisions {
+		payload, err = commitlog.EncodeRawKVBatchPayloadPlanned(plan, scan)
+	} else {
+		payload, err = commitlog.EncodeRawKVBatchPayloadScanWithHint(scan, plan.Count, 0)
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -576,7 +581,7 @@ func (db *DB) rawKVCommandWALOperationFromEntry(entry batchpkg.Entry, ridCache *
 		}
 		return commitlog.RawKVOperation{Op: commitlog.RawKVOpDeleteRange, Key: entry.Key, Value: entry.Value}, true, nil
 	case batchpkg.OpDelete:
-		return commitlog.RawKVOperation{Op: commitlog.RawKVOpDelete, Key: entry.Key}, true, nil
+		return commitlog.RawKVOperation{Op: commitlog.RawKVOpDelete, Key: entry.Key, Revision: uint64(entry.Revision)}, true, nil
 	case batchpkg.OpPut:
 		if entry.IsPtr {
 			if externalRefs != nil {
@@ -595,9 +600,9 @@ func (db *DB) rawKVCommandWALOperationFromEntry(entry batchpkg.Entry, ridCache *
 			if err != nil {
 				return commitlog.RawKVOperation{}, false, err
 			}
-			return commitlog.RawKVOperation{Op: commitlog.RawKVOpSetRID, Key: entry.Key, RID: rid}, true, nil
+			return commitlog.RawKVOperation{Op: commitlog.RawKVOpSetRID, Key: entry.Key, RID: rid, Revision: uint64(entry.Revision)}, true, nil
 		}
-		return commitlog.RawKVOperation{Op: commitlog.RawKVOpSet, Key: entry.Key, Value: entry.Value}, true, nil
+		return commitlog.RawKVOperation{Op: commitlog.RawKVOpSet, Key: entry.Key, Value: entry.Value, Revision: uint64(entry.Revision)}, true, nil
 	default:
 		return commitlog.RawKVOperation{}, false, fmt.Errorf("treedb: command wal unknown raw kv batch op %d", entry.Type)
 	}
@@ -1230,9 +1235,10 @@ func applyRawKVCommandWALFrame(db *DB, env commitlog.CommandEnvelope, ridMap map
 	defer func() { _ = b.Close() }()
 	for i := range ops {
 		entry := ops[i]
+		revision := page.EntryRevision(entry.Revision)
 		switch entry.Op {
 		case commitlog.RawKVOpSet:
-			if err := b.Set(entry.Key, entry.Value); err != nil {
+			if err := b.SetWithRevision(entry.Key, entry.Value, revision); err != nil {
 				if !errors.Is(err, batchpkg.ErrValueTooLarge) {
 					// Non-ErrValueTooLarge errors abort frame replay entirely.
 					// The caller will propagate the error; recovery will retry
@@ -1260,12 +1266,12 @@ func applyRawKVCommandWALFrame(db *DB, env commitlog.CommandEnvelope, ridMap map
 				if err != nil {
 					return err
 				}
-				if err := b.SetPointer(entry.Key, ptr); err != nil {
+				if err := b.SetPointerWithRevision(entry.Key, ptr, revision); err != nil {
 					return err
 				}
 			}
 		case commitlog.RawKVOpDelete:
-			if err := b.Delete(entry.Key); err != nil {
+			if err := b.DeleteWithRevision(entry.Key, revision); err != nil {
 				return err
 			}
 		case commitlog.RawKVOpDeleteRange:
@@ -1287,7 +1293,7 @@ func applyRawKVCommandWALFrame(db *DB, env commitlog.CommandEnvelope, ridMap map
 			if !ok {
 				return fmt.Errorf("%w: %d", ErrCommandWALMissingValueLogRID, entry.RID)
 			}
-			if err := b.SetPointer(entry.Key, ptr); err != nil {
+			if err := b.SetPointerWithRevision(entry.Key, ptr, revision); err != nil {
 				return err
 			}
 		default:

--- a/TreeDB/db/command_wal_recovery_bench_test.go
+++ b/TreeDB/db/command_wal_recovery_bench_test.go
@@ -43,6 +43,42 @@ func BenchmarkCommandWALRawKVDirectWrite(b *testing.B) {
 	}
 }
 
+func BenchmarkCommandWALRawKVDirectWriteRevision(b *testing.B) {
+	for _, tc := range []struct {
+		name       string
+		commandWAL bool
+	}{
+		{name: "backend_no_command_wal_revision", commandWAL: false},
+		{name: "command_wal_raw_kv_revision", commandWAL: true},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			dir := b.TempDir()
+			db, err := Open(Options{Dir: dir, CommandWAL: tc.commandWAL, DisableBackgroundPrune: true})
+			if err != nil {
+				b.Fatalf("Open: %v", err)
+			}
+			defer db.Close()
+			key := []byte("bench-key")
+			value := []byte("bench-value-0123456789-0123456789-0123456789")
+			b.ReportAllocs()
+			b.SetBytes(int64(len(key) + len(value)))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				batch := db.NewBatch().(*Batch)
+				if err := batch.SetWithRevision(key, value, 1); err != nil {
+					b.Fatalf("SetWithRevision: %v", err)
+				}
+				if err := batch.Write(); err != nil {
+					b.Fatalf("Write: %v", err)
+				}
+				if err := batch.Close(); err != nil {
+					b.Fatalf("Close batch: %v", err)
+				}
+			}
+		})
+	}
+}
+
 func BenchmarkCommandWALRawKVPointerDirectWrite(b *testing.B) {
 	value := []byte("bench-value-backed-by-value-log")
 	for _, tc := range []struct {

--- a/TreeDB/db/command_wal_recovery_test.go
+++ b/TreeDB/db/command_wal_recovery_test.go
@@ -1521,6 +1521,55 @@ func TestCommandWALExistingRIDFenceTestsMappedToExternalRefFence(t *testing.T) {
 	assertDBValue(t, reopen, "b", "two")
 }
 
+func TestCommandWALRecoveryPreservesEntryRevision(t *testing.T) {
+	dir := t.TempDir()
+	enableCommandWALFormat(t, dir)
+	db := openCommandWALDB(t, dir)
+	if err := db.Close(); err != nil {
+		t.Fatalf("Close bootstrap db: %v", err)
+	}
+	largeValue := strings.Repeat("large-value-", 1024)
+	ptr := writeValueLogRID(t, dir, 31, []byte(largeValue))
+
+	db = openCommandWALDB(t, dir)
+	db.testFailFinalizeCommit.Store(true)
+	b := db.NewBatch().(*Batch)
+	if err := b.SetWithRevision([]byte("inline"), []byte("value"), page.EntryRevision(41)); err != nil {
+		t.Fatalf("SetWithRevision inline: %v", err)
+	}
+	if err := b.SetPointerWithRevision([]byte("ptr"), ptr, page.EntryRevision(42)); err != nil {
+		t.Fatalf("SetPointerWithRevision ptr: %v", err)
+	}
+	err := b.WriteSync()
+	if !errors.Is(err, errTestFinalizeCommitFailpoint) {
+		t.Fatalf("crash batch WriteSync error=%v, want failpoint", err)
+	}
+	_ = b.Close()
+	if err := db.Close(); err != nil {
+		t.Fatalf("Close crashed db: %v", err)
+	}
+
+	reopen := openCommandWALDB(t, dir)
+	defer reopen.Close()
+	inlineValue, inlineRevision, err := reopen.GetVersioned([]byte("inline"))
+	if err != nil {
+		t.Fatalf("GetVersioned inline: %v", err)
+	}
+	if !bytes.Equal(inlineValue, []byte("value")) || inlineRevision != page.EntryRevision(41) {
+		t.Fatalf("GetVersioned inline=(%q,%d), want (value,41)", inlineValue, inlineRevision)
+	}
+	ptrValue, ptrRevision, err := reopen.GetVersioned([]byte("ptr"))
+	if err != nil {
+		t.Fatalf("GetVersioned ptr: %v", err)
+	}
+	if !bytes.Equal(ptrValue, []byte(largeValue)) || ptrRevision != page.EntryRevision(42) {
+		t.Fatalf("GetVersioned ptr=(len=%d,%d), want (len=%d,42)", len(ptrValue), ptrRevision, len(largeValue))
+	}
+	if got := reopen.State().AppliedCommandLSN; got != 1 {
+		t.Fatalf("AppliedCommandLSN=%d, want 1", got)
+	}
+}
+
 func enableCommandWALFormat(t *testing.T, dir string) {
 	t.Helper()
 	if err := os.MkdirAll(dir, 0o755); err != nil {

--- a/TreeDB/db/conditional_kv_contract_bench_test.go
+++ b/TreeDB/db/conditional_kv_contract_bench_test.go
@@ -1,10 +1,62 @@
 package db
 
-import "testing"
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/snissn/gomap/TreeDB/page"
+)
 
 func BenchmarkGetVersioned(b *testing.B) {
+	d, err := Open(Options{Dir: b.TempDir()})
+	if err != nil {
+		b.Fatalf("Open: %v", err)
+	}
+	defer func() {
+		if err := d.Close(); err != nil {
+			b.Fatalf("Close: %v", err)
+		}
+	}()
+
+	const count = 10000
+	val := make([]byte, 100)
+	keys := make([][]byte, count)
+	for i := 0; i < count; i++ {
+		keys[i] = []byte(fmt.Sprintf("key-%09d", i))
+	}
+	for i := 0; i < count; i += 1000 {
+		batch := d.NewBatch().(*Batch)
+		for j := 0; j < 1000 && i+j < count; j++ {
+			revision := page.EntryRevision(i + j + 1)
+			if err := batch.SetWithRevision(keys[i+j], val, revision); err != nil {
+				b.Fatalf("SetWithRevision: %v", err)
+			}
+		}
+		if err := batch.WriteSync(); err != nil {
+			b.Fatalf("WriteSync: %v", err)
+		}
+		if err := batch.Close(); err != nil {
+			b.Fatalf("Close batch: %v", err)
+		}
+	}
+
 	b.ReportAllocs()
-	b.Skip("planned by #3424/#3425: replace with native versioned point-read benchmark once EntryRevision APIs land")
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		r := rand.New(rand.NewSource(time.Now().UnixNano()))
+		dst := make([]byte, 0, len(val))
+		for pb.Next() {
+			out, revision, err := d.GetVersionedAppend(keys[r.Intn(count)], dst[:0])
+			if err != nil {
+				b.Fatalf("GetVersionedAppend: %v", err)
+			}
+			if len(out) != len(val) || revision == page.LegacyEntryRevision {
+				b.Fatalf("GetVersionedAppend len=%d revision=%d, want len=%d non-legacy revision", len(out), revision, len(val))
+			}
+		}
+	})
 }
 
 func BenchmarkConditionalTxnReadSet1(b *testing.B) {

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -2902,6 +2902,30 @@ func (s *Snapshot) GetAppend(key, dst []byte) ([]byte, error) {
 	return s.tree.GetAppend(normalizeRawKVPointKey(key), dst)
 }
 
+// GetVersionedAppend appends the value for key to dst and returns the native
+// entry revision stored with the visible leaf entry.
+func (s *Snapshot) GetVersionedAppend(key, dst []byte) ([]byte, page.EntryRevision, error) {
+	return s.tree.GetVersionedAppend(normalizeRawKVPointKey(key), dst)
+}
+
+// GetVersioned returns a safe value copy plus the native entry revision stored
+// with the visible leaf entry.
+func (s *Snapshot) GetVersioned(key []byte) ([]byte, page.EntryRevision, error) {
+	out, revision, err := s.GetVersionedAppend(key, nil)
+	if err != nil {
+		return nil, revision, err
+	}
+	if len(out) == 0 {
+		return []byte{}, revision, nil
+	}
+	if cap(out) == len(out) {
+		return out, revision, nil
+	}
+	owned := make([]byte, len(out))
+	copy(owned, out)
+	return owned, revision, nil
+}
+
 // GetManyView calls fn once for each key with a read-only value view.
 // Values are valid until fn returns and must be copied before retaining.
 func (s *Snapshot) GetManyView(keys [][]byte, fn GetManyViewFunc) error {

--- a/TreeDB/db/ordered_root_publish.go
+++ b/TreeDB/db/ordered_root_publish.go
@@ -461,8 +461,8 @@ func materializeOrderedRootTable(iter iterator.UnsafeIterator) (memtable.Table, 
 	}
 	table := memtable.NewAppendOnlyWithEntryCapacity(entries)
 	for iter.Valid() {
-		val, ptr, flags := iter.UnsafeEntry()
-		table.SetEntry(iter.UnsafeKey(), val, ptr, flags)
+		val, ptr, flags, revision := iterator.UnsafeEntryWithRevision(iter)
+		table.SetEntryWithRevision(iter.UnsafeKey(), val, ptr, flags, revision)
 		iter.Next()
 	}
 	if err := iter.Error(); err != nil {
@@ -567,8 +567,11 @@ func (s orderedRootPublishStats) collectionRootDescriptorReachabilityMayChange()
 }
 
 func orderedRootEntryEqual(baseIter, targetIter iterator.UnsafeIterator) bool {
-	baseVal, basePtr, baseFlags := baseIter.UnsafeEntry()
-	targetVal, targetPtr, targetFlags := targetIter.UnsafeEntry()
+	baseVal, basePtr, baseFlags, baseRevision := iterator.UnsafeEntryWithRevision(baseIter)
+	targetVal, targetPtr, targetFlags, targetRevision := iterator.UnsafeEntryWithRevision(targetIter)
+	if baseRevision != targetRevision {
+		return false
+	}
 	if baseFlags != targetFlags {
 		return false
 	}
@@ -682,23 +685,32 @@ func orderedRootBatchPut(delta *batch.Batch, iter iterator.UnsafeIterator, borro
 	if delta == nil || iter == nil || !iter.Valid() {
 		return nil
 	}
-	val, ptr, flags := iter.UnsafeEntry()
-	if flags&node.FlagPointer != 0 && page.IsValueLogFileID(ptr.FileID) {
+	val, ptr, flags, revision := iterator.UnsafeEntryWithRevision(iter)
+	if flags&node.FlagTombstone != 0 {
 		if borrowEntryViews && trustedSortedUnique {
-			return delta.AppendPointerViewTrustedSortedUnique(iter.UnsafeKey(), ptr)
+			return delta.AppendDeleteViewTrustedSortedUniqueWithRevision(iter.UnsafeKey(), revision)
 		}
 		if borrowEntryViews {
-			return delta.SetPointerView(iter.UnsafeKey(), ptr)
+			return delta.DeleteViewWithRevision(iter.UnsafeKey(), revision)
 		}
-		return delta.SetPointer(iter.UnsafeKey(), ptr)
+		return delta.DeleteWithRevision(iter.UnsafeKey(), revision)
+	}
+	if flags&node.FlagPointer != 0 && page.IsValueLogFileID(ptr.FileID) {
+		if borrowEntryViews && trustedSortedUnique {
+			return delta.AppendPointerViewTrustedSortedUniqueWithRevision(iter.UnsafeKey(), ptr, revision)
+		}
+		if borrowEntryViews {
+			return delta.SetPointerViewWithRevision(iter.UnsafeKey(), ptr, revision)
+		}
+		return delta.SetPointerWithRevision(iter.UnsafeKey(), ptr, revision)
 	}
 	if borrowEntryViews && trustedSortedUnique {
-		return delta.AppendViewTrustedSortedUnique(iter.UnsafeKey(), val)
+		return delta.AppendViewTrustedSortedUniqueWithRevision(iter.UnsafeKey(), val, revision)
 	}
 	if borrowEntryViews {
-		return delta.SetView(iter.UnsafeKey(), val)
+		return delta.SetViewWithRevision(iter.UnsafeKey(), val, revision)
 	}
-	return delta.Set(iter.UnsafeKey(), val)
+	return delta.SetWithRevision(iter.UnsafeKey(), val, revision)
 }
 
 func orderedRootDeltaBatchFromIterator(iter iterator.UnsafeIterator) (*batch.Batch, error) {
@@ -803,17 +815,22 @@ func (it *orderedRootDeltaBatchIterator) UnsafeValue() []byte {
 }
 
 func (it *orderedRootDeltaBatchIterator) UnsafeEntry() ([]byte, page.ValuePtr, byte) {
+	val, ptr, flags, _ := it.UnsafeEntryWithRevision()
+	return val, ptr, flags
+}
+
+func (it *orderedRootDeltaBatchIterator) UnsafeEntryWithRevision() ([]byte, page.ValuePtr, byte, page.EntryRevision) {
 	if !it.Valid() {
-		return nil, page.ValuePtr{}, node.FlagInline
+		return nil, page.ValuePtr{}, node.FlagInline, page.LegacyEntryRevision
 	}
 	entry := it.entries[it.idx]
 	if entry.Type == batch.OpDelete {
-		return nil, page.ValuePtr{}, node.FlagTombstone
+		return nil, page.ValuePtr{}, node.FlagTombstone, entry.Revision
 	}
 	if entry.IsPtr {
-		return entry.Value, entry.ValuePtr, node.FlagPointer
+		return entry.Value, entry.ValuePtr, node.FlagPointer, entry.Revision
 	}
-	return entry.Value, page.ValuePtr{}, node.FlagInline
+	return entry.Value, page.ValuePtr{}, node.FlagInline, entry.Revision
 }
 
 func (it *orderedRootDeltaBatchIterator) Key() []byte {

--- a/TreeDB/db/vacuum_collection_roots.go
+++ b/TreeDB/db/vacuum_collection_roots.go
@@ -447,6 +447,13 @@ func (it *vacuumSystemRootRewriteIterator) UnsafeEntry() ([]byte, page.ValuePtr,
 	return it.base.UnsafeEntry()
 }
 
+func (it *vacuumSystemRootRewriteIterator) UnsafeEntryWithRevision() ([]byte, page.ValuePtr, byte, page.EntryRevision) {
+	if val, ok := it.replacement(); ok {
+		return val, page.ValuePtr{}, node.FlagInline, page.LegacyEntryRevision
+	}
+	return iterator.UnsafeEntryWithRevision(it.base)
+}
+
 func (it *vacuumSystemRootRewriteIterator) Key() []byte {
 	return it.UnsafeKey()
 }

--- a/TreeDB/db/value_log_appender.go
+++ b/TreeDB/db/value_log_appender.go
@@ -204,6 +204,12 @@ func (iter *pendingValueLogAppendPtrCollectingIterator) UnsafeEntry() (val []byt
 	return val, ptr, flags
 }
 
+func (iter *pendingValueLogAppendPtrCollectingIterator) UnsafeEntryWithRevision() (val []byte, ptr page.ValuePtr, flags byte, revision page.EntryRevision) {
+	val, ptr, flags, revision = iterator.UnsafeEntryWithRevision(iter.UnsafeIterator)
+	iter.ptrCounts = collectPendingValueLogAppendPtrCount(iter.ptrCounts, ptr, flags)
+	return val, ptr, flags, revision
+}
+
 func (db *DB) releasePendingValueLogAppendPtrCollector(collector *pendingValueLogAppendPtrCollectingIterator) {
 	if db == nil || collector == nil || len(collector.ptrCounts) == 0 {
 		return

--- a/TreeDB/db/versioned_read_test.go
+++ b/TreeDB/db/versioned_read_test.go
@@ -1,0 +1,70 @@
+package db
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/page"
+)
+
+func TestGetVersionedPreservesBatchEntryRevision(t *testing.T) {
+	db, err := Open(Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() {
+		if err := db.Close(); err != nil {
+			t.Fatalf("Close: %v", err)
+		}
+	}()
+
+	b := db.NewBatch().(*Batch)
+	if err := b.SetWithRevision([]byte("k"), []byte("value"), page.EntryRevision(101)); err != nil {
+		t.Fatalf("SetWithRevision: %v", err)
+	}
+	if err := b.Write(); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if err := b.Close(); err != nil {
+		t.Fatalf("Close batch: %v", err)
+	}
+
+	val, revision, err := db.GetVersioned([]byte("k"))
+	if err != nil {
+		t.Fatalf("GetVersioned: %v", err)
+	}
+	if !bytes.Equal(val, []byte("value")) || revision != 101 {
+		t.Fatalf("GetVersioned=(%q,%d), want (value,101)", val, revision)
+	}
+
+	dst := []byte("prefix:")
+	out, revision, err := db.GetVersionedAppend([]byte("k"), dst)
+	if err != nil {
+		t.Fatalf("GetVersionedAppend: %v", err)
+	}
+	if !bytes.Equal(out, []byte("prefix:value")) || revision != 101 {
+		t.Fatalf("GetVersionedAppend=(%q,%d), want (prefix:value,101)", out, revision)
+	}
+
+	snap := db.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("AcquireSnapshot returned nil")
+	}
+	defer snap.Close()
+
+	snapVal, snapRevision, err := snap.GetVersioned([]byte("k"))
+	if err != nil {
+		t.Fatalf("Snapshot.GetVersioned: %v", err)
+	}
+	if !bytes.Equal(snapVal, []byte("value")) || snapRevision != 101 {
+		t.Fatalf("Snapshot.GetVersioned=(%q,%d), want (value,101)", snapVal, snapRevision)
+	}
+
+	snapEntry, err := snap.GetEntry([]byte("k"))
+	if err != nil {
+		t.Fatalf("Snapshot.GetEntry: %v", err)
+	}
+	if !bytes.Equal(snapEntry.Value, []byte("value")) || snapEntry.Revision != 101 {
+		t.Fatalf("Snapshot.GetEntry=(%q,%d), want (value,101)", snapEntry.Value, snapEntry.Revision)
+	}
+}

--- a/TreeDB/db/vlog_rewrite.go
+++ b/TreeDB/db/vlog_rewrite.go
@@ -4745,6 +4745,7 @@ type rewriteIterator struct {
 	cached     bool
 	val        []byte
 	ptr        page.ValuePtr
+	revision   page.EntryRevision
 	flags      byte
 
 	preferredDictByFile map[uint32]uint64
@@ -4793,7 +4794,7 @@ func (it *rewriteIterator) ensure() {
 	if !it.inner.Valid() {
 		return
 	}
-	val, ptr, flags := it.inner.UnsafeEntry()
+	val, ptr, flags, revision := iterator.UnsafeEntryWithRevision(it.inner)
 	if flags&node.FlagPointer != 0 {
 		newPtr, err := it.rewritePtr(ptr)
 		if err != nil {
@@ -4804,6 +4805,7 @@ func (it *rewriteIterator) ensure() {
 	}
 	it.val = val
 	it.ptr = ptr
+	it.revision = revision
 	it.flags = flags
 	it.cached = true
 }
@@ -5267,6 +5269,11 @@ func (it *rewriteIterator) ValueCopy(dst []byte) []byte {
 func (it *rewriteIterator) UnsafeEntry() ([]byte, page.ValuePtr, byte) {
 	it.ensure()
 	return it.val, it.ptr, it.flags
+}
+
+func (it *rewriteIterator) UnsafeEntryWithRevision() ([]byte, page.ValuePtr, byte, page.EntryRevision) {
+	it.ensure()
+	return it.val, it.ptr, it.flags, it.revision
 }
 
 func (it *rewriteIterator) Error() error {

--- a/TreeDB/docs/conditional_kv_contract_test.go
+++ b/TreeDB/docs/conditional_kv_contract_test.go
@@ -23,7 +23,11 @@ func TestConditionalKVContractDocsPinNativeRevisionAndTxnGates(t *testing.T) {
 	storageFormat := collapseWhitespace(readRepoText(t, "TreeDB/docs/spec/storage-format.md"))
 	assertContainsAll(t, storageFormat, "conditional raw KV storage format",
 		"Target entry revisions are native entry metadata for raw key/value leaves",
-		"Issue #3422 owns the exact byte layout and required feature gate",
+		"They are enabled per leaf by page header flag `0x0040`",
+		"every entry in the page carries one fixed-width little-endian `u64` revision",
+		"plain, legacy-prefix, prefix-v2, and columnar-v1 leaf entries store the revision directly after the visible key/value or pointer bytes",
+		"columnar-v2 leaves store `RevisionLE[Count]` immediately after `Flags[Count]`",
+		"columnar+prefix-v2 leaves store `RevisionLE[Count]` immediately after `PrefixLen[Count]`",
 		"A per-write system-root sidecar, separate persistent revision map, or adapter-private metadata tree is not an accepted storage format",
 		"Revision `0` is a legacy/no-revision sentinel",
 		"The stored revision is the mutation revision assigned from the directory's shared raw-KV revision domain",

--- a/TreeDB/docs/spec/storage-format.md
+++ b/TreeDB/docs/spec/storage-format.md
@@ -606,6 +606,7 @@ Leaf encoding flags in page header:
 - `0x2000`: prefix v2 compact header enabled
 - `0x1000`: packed `ValuePtr` payload enabled
 - `0x0400`: columnar v2 layout enabled
+- `0x0040`: native per-entry `EntryRevision` metadata enabled
 
 Entry flags in payload (node flags) include inline/pointer/tombstone semantics.
 
@@ -617,6 +618,7 @@ u32 ValueLen        // ignored for pointer entries
 u8  EntryFlags
 bytes Key
 bytes Value | ValuePtr(16) | PackedValuePtr(12)
+u64 EntryRevisionLE // present only when page flag 0x0040 is set
 ```
 
 ### 5.2 Prefix-compressed leaf v1
@@ -628,6 +630,7 @@ u32 ValueLen
 u8  EntryFlags
 bytes KeySuffix
 bytes Value | Pointer
+u64 EntryRevisionLE // present only when page flag 0x0040 is set
 ```
 
 ### 5.3 Prefix-compressed leaf v2
@@ -640,6 +643,7 @@ u8 EntryFlags
 (optional) uvarint ValueLen for inline non-tombstone values
 bytes KeySuffix
 bytes Value | Pointer
+u64 EntryRevisionLE // present only when page flag 0x0040 is set
 ```
 
 Notes:
@@ -647,12 +651,27 @@ Notes:
 - Pointer/tombstone entries omit inline value length field.
 - Restart interval for prefix reconstruction: 16 entries.
 
-### 5.4 Columnar leaf v2 (non-prefix)
+### 5.4 Columnar leaf encodings
+
+Columnar v1 stores a compact per-entry header and keeps the key after the
+entry's visible value/pointer bytes:
+
+```text
+u16 KeyLen
+u32 ValueLen        // ignored for pointer entries
+u8  EntryFlags
+bytes Value | ValuePtr(16) | PackedValuePtr(12)
+bytes Key
+u64 EntryRevisionLE // present only when page flag 0x0040 is set
+```
+
+Columnar v2 stores per-entry metadata in top-of-page columns:
 
 ```text
 u16 KeyOff[Count]
 u16 ValOff[Count]
 u8  Flags[Count]
+u64 RevisionLE[Count] // present only when page flag 0x0040 is set
 bytes ValueBlob
 bytes KeyBlob
 ```
@@ -664,6 +683,7 @@ u16 KeyOff[Count]
 u16 ValOff[Count]
 u8  Flags[Count]
 u16 PrefixLen[Count]
+u64 RevisionLE[Count] // present only when page flag 0x0040 is set
 bytes ValueBlob
 bytes KeySuffixBlob
 ```
@@ -673,8 +693,15 @@ Keys reconstruct using previous key prefix within restart blocks.
 ### 5.6 Target raw-KV entry revisions
 
 Target entry revisions are native entry metadata for raw key/value leaves.
-Issue #3422 owns the exact byte layout and required feature gate. This section
-defines the storage constraints that layout must satisfy.
+They are enabled per leaf by page header flag `0x0040`. When the flag is clear,
+all entries in that page decode as revision `0`. When the flag is set, every
+entry in the page carries one fixed-width little-endian `u64` revision:
+
+- plain, legacy-prefix, prefix-v2, and columnar-v1 leaf entries store the
+  revision directly after the visible key/value or pointer bytes for that entry;
+- columnar-v2 leaves store `RevisionLE[Count]` immediately after `Flags[Count]`;
+- columnar+prefix-v2 leaves store `RevisionLE[Count]` immediately after
+  `PrefixLen[Count]`.
 
 - A live raw-KV entry may carry an `EntryRevision` token. Older entries without
   revision metadata decode as revision `0` until the format gate requires

--- a/TreeDB/internal/bulk/builder.go
+++ b/TreeDB/internal/bulk/builder.go
@@ -37,6 +37,7 @@ type BuildOptions struct {
 	LeafColumnar          bool
 	InternalBaseDelta     bool
 	PackedValuePtr        bool
+	EntryRevisions        bool
 	LeafPageLog           LeafPageAppender
 }
 
@@ -249,14 +250,14 @@ func BuildWithOptions(iter iterator.UnsafeIterator, alloc Allocator, p *pager.Pa
 
 	for iter.Valid() {
 		key := iter.UnsafeKey()
-		val, ptr, flags := iter.UnsafeEntry()
+		val, ptr, flags, revision := iterator.UnsafeEntryWithRevision(iter)
 
 		lb := levels[0]
 		if lb.startKey == nil {
 			lb.startKey = append([]byte(nil), key...)
 		}
 
-		err := lb.builder.AddLeafEntry(key, val, flags, ptr)
+		err := lb.builder.AddLeafEntryWithRevision(key, val, flags, ptr, revision)
 		if err == node.ErrNodeFull {
 			if err := flush(0); err != nil {
 				return 0, err
@@ -265,7 +266,7 @@ func BuildWithOptions(iter iterator.UnsafeIterator, alloc Allocator, p *pager.Pa
 			if lb.startKey == nil {
 				lb.startKey = append([]byte(nil), key...)
 			}
-			err = lb.builder.AddLeafEntry(key, val, flags, ptr)
+			err = lb.builder.AddLeafEntryWithRevision(key, val, flags, ptr, revision)
 		}
 
 		if err != nil {
@@ -360,12 +361,13 @@ func buildSingleLeafLogRoot(alloc Allocator, p *pager.Pager, key []byte, ptr pag
 }
 
 func newLeafBuilder(buf []byte, opts BuildOptions) *node.Builder {
-	if opts.LeafPrefixCompression || opts.LeafColumnar || opts.InternalBaseDelta || opts.PackedValuePtr {
+	if opts.LeafPrefixCompression || opts.LeafColumnar || opts.InternalBaseDelta || opts.PackedValuePtr || opts.EntryRevisions {
 		return node.NewBuilderWithOptions(buf, page.PageTypeLeaf, node.BuilderOptions{
 			LeafPrefixCompression: opts.LeafPrefixCompression,
 			LeafColumnar:          opts.LeafColumnar,
 			InternalBaseDelta:     opts.InternalBaseDelta,
 			PackedValuePtr:        opts.PackedValuePtr,
+			EntryRevisions:        opts.EntryRevisions,
 		})
 	}
 	return node.NewBuilder(buf, page.PageTypeLeaf)

--- a/TreeDB/internal/bulk/builder_test.go
+++ b/TreeDB/internal/bulk/builder_test.go
@@ -158,6 +158,60 @@ func (m *mockKVIterator) Error() error                { return nil }
 func (m *mockKVIterator) Close() error                { return nil }
 func (m *mockKVIterator) Domain() (start, end []byte) { return nil, nil }
 
+type mockRevisionKVIterator struct {
+	mockKVIterator
+	revisions []page.EntryRevision
+}
+
+func (m *mockRevisionKVIterator) UnsafeEntryWithRevision() ([]byte, page.ValuePtr, byte, page.EntryRevision) {
+	revision := page.LegacyEntryRevision
+	if m.idx >= 0 && m.idx < len(m.revisions) {
+		revision = m.revisions[m.idx]
+	}
+	return m.UnsafeValue(), page.ValuePtr{}, node.FlagInline, revision
+}
+
+func TestBuildWithOptionsSparseEntryRevisionsDoNotVersionLegacyLeaves(t *testing.T) {
+	dir := t.TempDir()
+	p, err := pager.Open(filepath.Join(dir, "index.db"), 65536)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer p.Close()
+
+	iter := &mockRevisionKVIterator{}
+	const n = 128
+	for i := 0; i < n; i++ {
+		iter.keys = append(iter.keys, []byte(fmt.Sprintf("key-%04d", i)))
+		iter.values = append(iter.values, bytes.Repeat([]byte{byte('a' + i%26)}, 96))
+		iter.revisions = append(iter.revisions, page.LegacyEntryRevision)
+	}
+	iter.revisions[96] = 12345
+
+	leafLog := &mockLeafPageLog{}
+	if _, err := BuildWithOptions(iter, &MockAllocator{p: p}, p, BuildOptions{LeafPageLog: leafLog}); err != nil {
+		t.Fatalf("BuildWithOptions: %v", err)
+	}
+	if len(leafLog.pages) < 2 {
+		t.Fatalf("leaf pages=%d want at least 2", len(leafLog.pages))
+	}
+	first := node.NewNodeView(leafLog.pages[0])
+	if first.LeafEntryRevisionsEnabled() {
+		t.Fatal("first legacy-only leaf unexpectedly encoded entry revisions")
+	}
+	foundRevisionLeaf := false
+	for _, data := range leafLog.pages {
+		n := node.NewNodeView(data)
+		if n.LeafEntryRevisionsEnabled() {
+			foundRevisionLeaf = true
+			break
+		}
+	}
+	if !foundRevisionLeaf {
+		t.Fatal("no leaf encoded the non-legacy entry revision")
+	}
+}
+
 func TestBuildWithOptions_EmptyIteratorLeafPageLogReturnsLeafRefRoot(t *testing.T) {
 	dir := t.TempDir()
 	p, err := pager.Open(filepath.Join(dir, "index.db"), 65536)

--- a/TreeDB/internal/commitlog/command_frame.go
+++ b/TreeDB/internal/commitlog/command_frame.go
@@ -16,16 +16,18 @@ const (
 
 	CommandWALNonCriticalFlagStart uint64 = 1 << 32
 
-	commandFrameHeaderSize      = 4 + 2 + 2 + 2 + 2 + 8 + 8 + 8 + 8 + 8 + 2 + 2 + 4 + 4 + 4 + 4
-	rawKVBatchPayloadVersion    = uint16(1)
-	rawKVZeroBatchPayloadV2     = uint16(2)
-	rawKVZeroBatchPayloadV3     = uint16(3)
-	rawKVBatchHeaderSize        = 2 + 4
-	rawKVZeroBatchHeaderSize    = 2 + 4 + 4
-	rawKVOpHeaderSize           = 1 + 4 + 4
-	rawKVZeroOpHeaderSize       = 4
-	rawKVZeroOpHeaderSizeV3     = 2
-	rawKVNilRangeBoundLenUint32 = uint32(^uint32(0))
+	commandFrameHeaderSize                = 4 + 2 + 2 + 2 + 2 + 8 + 8 + 8 + 8 + 8 + 2 + 2 + 4 + 4 + 4 + 4
+	rawKVBatchPayloadVersion              = uint16(1)
+	rawKVZeroBatchPayloadV2               = uint16(2)
+	rawKVZeroBatchPayloadV3               = uint16(3)
+	rawKVBatchPayloadVersionWithRevisions = uint16(4)
+	rawKVBatchHeaderSize                  = 2 + 4
+	rawKVZeroBatchHeaderSize              = 2 + 4 + 4
+	rawKVOpHeaderSize                     = 1 + 4 + 4
+	rawKVOpRevisionHeaderSize             = rawKVOpHeaderSize + 8
+	rawKVZeroOpHeaderSize                 = 4
+	rawKVZeroOpHeaderSizeV3               = 2
+	rawKVNilRangeBoundLenUint32           = uint32(^uint32(0))
 
 	collectionRebuildVectorIndexPayloadVersion      = uint16(1)
 	collectionRebuildVectorIndexVersionEnd          = 2
@@ -116,11 +118,16 @@ const (
 //   - RawKVOpDeleteRange: Key is the start bound and Value is the exclusive
 //     end bound. Nil bounds are unbounded and are encoded with a sentinel
 //     length; bounded empty/reversed ranges are invalid in command frames.
+//
+// Revision is optional per-entry metadata. Zero is the legacy/no-revision
+// value. Revision is valid on point Set/Delete/SetRID operations; range deletes
+// do not carry per-item revision metadata.
 type RawKVOperation struct {
-	Op    RawKVOp
-	Key   []byte
-	Value []byte
-	RID   uint64
+	Op       RawKVOp
+	Key      []byte
+	Value    []byte
+	RID      uint64
+	Revision uint64
 }
 
 // RawKVBatchOperationScanner replays RawKV operations in deterministic command
@@ -132,8 +139,9 @@ type RawKVBatchOperationScanner func(func(RawKVOperation) error) error
 // RawKVBatchPayloadPlan is the exact RawKVBatchV1 payload shape for a replayable
 // operation source.
 type RawKVBatchPayloadPlan struct {
-	Count      int
-	PayloadLen int
+	Count          int
+	PayloadLen     int
+	EntryRevisions bool
 }
 
 // RawKVBatchPayloadBuilder incrementally constructs a canonical RawKVBatch
@@ -380,6 +388,9 @@ func (b *RawKVBatchPayloadBuilder) Append(op RawKVOperation) (keyView, valueView
 	}
 	if err := validateRawKVOperation(&op); err != nil {
 		return nil, nil, err
+	}
+	if op.Revision != 0 {
+		return nil, nil, ErrCommandWALUnsupportedVersion
 	}
 	if op.Op == RawKVOpDeleteRange {
 		keyView, err := b.AppendDeleteRange(op.Key, op.Value)
@@ -1701,7 +1712,7 @@ func EncodeRawKVBatchPayload(ops []RawKVOperation) ([]byte, error) {
 }
 
 // PlanRawKVBatchPayloadScan validates a replayable operation source and returns
-// the exact RawKVBatchV1 payload length needed to encode it.
+// the exact RawKVBatch payload length needed to encode it.
 func PlanRawKVBatchPayloadScan(scan RawKVBatchOperationScanner) (RawKVBatchPayloadPlan, error) {
 	plan := RawKVBatchPayloadPlan{PayloadLen: rawKVBatchHeaderSize}
 	if scan == nil {
@@ -1715,8 +1726,19 @@ func PlanRawKVBatchPayloadScan(scan RawKVBatchOperationScanner) (RawKVBatchPaylo
 		if commandFrameIntExceedsUint32(plan.Count + 1) {
 			return ErrRecordTooLarge
 		}
-		needed := rawKVOpHeaderSize + keyBytes + valueBytes
-		if needed < rawKVOpHeaderSize || plan.PayloadLen > int(^uint(0)>>1)-needed {
+		if op.Revision != 0 && !plan.EntryRevisions {
+			if plan.Count > (int(^uint(0)>>1)-plan.PayloadLen)/8 {
+				return ErrRecordTooLarge
+			}
+			plan.PayloadLen += plan.Count * 8
+			plan.EntryRevisions = true
+			if commandFrameIntExceedsUint32(plan.PayloadLen) {
+				return ErrRecordTooLarge
+			}
+		}
+		opHeaderSize := rawKVOperationHeaderSize(plan.EntryRevisions)
+		needed := opHeaderSize + keyBytes + valueBytes
+		if needed < opHeaderSize || plan.PayloadLen > int(^uint(0)>>1)-needed {
 			return ErrRecordTooLarge
 		}
 		plan.Count++
@@ -1729,6 +1751,13 @@ func PlanRawKVBatchPayloadScan(scan RawKVBatchOperationScanner) (RawKVBatchPaylo
 		return RawKVBatchPayloadPlan{}, err
 	}
 	return plan, nil
+}
+
+func rawKVOperationHeaderSize(entryRevisions bool) int {
+	if entryRevisions {
+		return rawKVOpRevisionHeaderSize
+	}
+	return rawKVOpHeaderSize
 }
 
 func rawKVOperationPayloadLens(op *RawKVOperation) (keyBytes, valueBytes int, err error) {
@@ -1797,6 +1826,13 @@ func encodeRawKVBatchPayloadPlannedTo(dst []byte, plan RawKVBatchPayloadPlan, sc
 	return dst, nil
 }
 
+// EncodeRawKVBatchPayloadPlanned encodes a caller-planned RawKVBatch scan. It is
+// for callers that already validated the scan with PlanRawKVBatchPayloadScan and
+// need the exact planned format, including revision-bearing payloads.
+func EncodeRawKVBatchPayloadPlanned(plan RawKVBatchPayloadPlan, scan RawKVBatchOperationScanner) ([]byte, error) {
+	return encodeRawKVBatchPayloadPlannedTo(nil, plan, scan)
+}
+
 func writeRawKVBatchPayloadPieces(plan RawKVBatchPayloadPlan, scan RawKVBatchOperationScanner, write func([]byte) error) error {
 	if err := plan.validate(); err != nil {
 		return err
@@ -1805,7 +1841,11 @@ func writeRawKVBatchPayloadPieces(plan RawKVBatchPayloadPlan, scan RawKVBatchOpe
 		return ErrCorrupt
 	}
 	var header [rawKVBatchHeaderSize]byte
-	binary.LittleEndian.PutUint16(header[0:2], rawKVBatchPayloadVersion)
+	payloadVersion := rawKVBatchPayloadVersion
+	if plan.EntryRevisions {
+		payloadVersion = rawKVBatchPayloadVersionWithRevisions
+	}
+	binary.LittleEndian.PutUint16(header[0:2], payloadVersion)
 	binary.LittleEndian.PutUint32(header[2:6], uint32(plan.Count))
 	if err := write(header[:]); err != nil {
 		return err
@@ -1819,7 +1859,7 @@ func writeRawKVBatchPayloadPieces(plan RawKVBatchPayloadPlan, scan RawKVBatchOpe
 	count := 0
 	written := rawKVBatchHeaderSize
 	if err := scan(func(op RawKVOperation) error {
-		n, err := writeRawKVOperationPayloadPieces(op, write)
+		n, err := writeRawKVOperationPayloadPiecesWithRevisionFlag(op, plan.EntryRevisions, write)
 		if err != nil {
 			return err
 		}
@@ -1836,9 +1876,16 @@ func writeRawKVBatchPayloadPieces(plan RawKVBatchPayloadPlan, scan RawKVBatchOpe
 }
 
 func writeRawKVOperationPayloadPieces(op RawKVOperation, write func([]byte) error) (int, error) {
+	return writeRawKVOperationPayloadPiecesWithRevisionFlag(op, false, write)
+}
+
+func writeRawKVOperationPayloadPiecesWithRevisionFlag(op RawKVOperation, entryRevisions bool, write func([]byte) error) (int, error) {
 	keyBytes, valueBytes, err := rawKVOperationPayloadLens(&op)
 	if err != nil {
 		return 0, err
+	}
+	if op.Revision != 0 && !entryRevisions {
+		return 0, ErrCorrupt
 	}
 	key := op.Key
 	value := op.Value
@@ -1859,11 +1906,15 @@ func writeRawKVOperationPayloadPieces(op RawKVOperation, write func([]byte) erro
 			return 0, err
 		}
 	}
-	var header [rawKVOpHeaderSize]byte
+	var header [rawKVOpRevisionHeaderSize]byte
 	header[0] = byte(op.Op)
 	binary.LittleEndian.PutUint32(header[1:5], keyLen)
 	binary.LittleEndian.PutUint32(header[5:9], valueLen)
-	if err := write(header[:]); err != nil {
+	headerSize := rawKVOperationHeaderSize(entryRevisions)
+	if entryRevisions {
+		binary.LittleEndian.PutUint64(header[9:17], op.Revision)
+	}
+	if err := write(header[:headerSize]); err != nil {
 		return 0, err
 	}
 	if len(key) > 0 {
@@ -1876,7 +1927,7 @@ func writeRawKVOperationPayloadPieces(op RawKVOperation, write func([]byte) erro
 			return 0, err
 		}
 	}
-	return rawKVOpHeaderSize + keyBytes + valueBytes, nil
+	return headerSize + keyBytes + valueBytes, nil
 }
 
 // EncodeRawKVSingleOperationPayload encodes the common one-op RawKVBatch
@@ -1956,8 +2007,8 @@ func DecodeRawKVBatchPayload(payload []byte) ([]RawKVOperation, error) {
 	}
 	count := binary.LittleEndian.Uint32(payload[2:6])
 	ops := make([]RawKVOperation, 0, count)
-	if err := ScanRawKVBatchPayload(payload, func(op RawKVOp, key, value []byte) error {
-		entry := RawKVOperation{Op: op, Key: cloneBytesPreserveEmpty(key)}
+	if err := ScanRawKVBatchPayloadWithRevision(payload, func(op RawKVOp, key, value []byte, revision uint64) error {
+		entry := RawKVOperation{Op: op, Key: cloneBytesPreserveEmpty(key), Revision: revision}
 		if op == RawKVOpSetRID {
 			entry.RID = binary.LittleEndian.Uint64(value)
 		} else {
@@ -1980,29 +2031,56 @@ func validateRawKVBatchPayload(payload []byte) error {
 // little-endian RID payload. Use DecodeRawKVBatchPayload when callers need
 // owned copies or typed RID fields.
 func ScanRawKVBatchPayload(payload []byte, visit func(op RawKVOp, key, value []byte) error) error {
+	if visit == nil {
+		return ScanRawKVBatchPayloadWithRevision(payload, nil)
+	}
+	return ScanRawKVBatchPayloadWithRevision(payload, func(op RawKVOp, key, value []byte, _ uint64) error {
+		return visit(op, key, value)
+	})
+}
+
+// ScanRawKVBatchPayloadWithRevision is ScanRawKVBatchPayload plus the optional
+// per-entry revision carried by revision-aware RawKV payloads. Legacy and
+// compact-zero payloads report revision zero for every operation.
+func ScanRawKVBatchPayloadWithRevision(payload []byte, visit func(op RawKVOp, key, value []byte, revision uint64) error) error {
 	if len(payload) < rawKVBatchHeaderSize {
 		return ErrCorrupt
 	}
 	version := binary.LittleEndian.Uint16(payload[0:2])
 	if version == rawKVZeroBatchPayloadV2 || version == rawKVZeroBatchPayloadV3 {
-		return scanRawKVZeroBatchPayload(payload, visit)
+		if visit == nil {
+			return scanRawKVZeroBatchPayload(payload, nil)
+		}
+		return scanRawKVZeroBatchPayload(payload, func(op RawKVOp, key, value []byte) error {
+			return visit(op, key, value, 0)
+		})
 	}
-	if version != rawKVBatchPayloadVersion {
+	entryRevisions := false
+	switch version {
+	case rawKVBatchPayloadVersion:
+	case rawKVBatchPayloadVersionWithRevisions:
+		entryRevisions = true
+	default:
 		return ErrCommandWALUnsupportedVersion
 	}
 	count := binary.LittleEndian.Uint32(payload[2:6])
-	if count > uint32((len(payload)-rawKVBatchHeaderSize)/rawKVOpHeaderSize) {
+	opHeaderSize := rawKVOperationHeaderSize(entryRevisions)
+	if count > uint32((len(payload)-rawKVBatchHeaderSize)/opHeaderSize) {
 		return ErrCorrupt
 	}
 	off := rawKVBatchHeaderSize
 	for i := uint32(0); i < count; i++ {
-		if off+rawKVOpHeaderSize > len(payload) {
+		if off+opHeaderSize > len(payload) {
 			return ErrCorrupt
 		}
 		op := RawKVOp(payload[off])
 		keyLen := binary.LittleEndian.Uint32(payload[off+1 : off+5])
 		valueLen := binary.LittleEndian.Uint32(payload[off+5 : off+9])
-		off += rawKVOpHeaderSize
+		revision := uint64(0)
+		if entryRevisions {
+			revision = binary.LittleEndian.Uint64(payload[off+9 : off+17])
+		}
+		off += opHeaderSize
 		keyBytes := keyLen
 		valueBytes := valueLen
 		keyNil := false
@@ -2049,9 +2127,12 @@ func ScanRawKVBatchPayload(payload []byte, visit func(op RawKVOp, key, value []b
 			if err := validateRawKVDeleteRangeBounds(key, value); err != nil {
 				return err
 			}
+			if revision != 0 {
+				return ErrCorrupt
+			}
 		}
 		if visit != nil {
-			if err := visit(op, key, value); err != nil {
+			if err := visit(op, key, value, revision); err != nil {
 				return err
 			}
 		}
@@ -2116,6 +2197,9 @@ func validateRawKVOperation(op *RawKVOperation) error {
 		return ErrCorrupt
 	}
 	if op.Op == RawKVOpDeleteRange {
+		if op.Revision != 0 {
+			return ErrCorrupt
+		}
 		return validateRawKVDeleteRangeBounds(op.Key, op.Value)
 	}
 	if op.Key == nil {

--- a/TreeDB/internal/commitlog/command_frame_test.go
+++ b/TreeDB/internal/commitlog/command_frame_test.go
@@ -1446,6 +1446,50 @@ func TestCommandWALRawKVBatchSetRIDRoundTrip(t *testing.T) {
 	}
 }
 
+func TestCommandWALRawKVBatchRevisionRoundTrip(t *testing.T) {
+	payload, err := EncodeRawKVBatchPayload([]RawKVOperation{
+		{Op: RawKVOpSet, Key: []byte("a"), Value: []byte("1"), Revision: 11},
+		{Op: RawKVOpDelete, Key: []byte("b"), Revision: 12},
+		{Op: RawKVOpSetRID, Key: []byte("c"), RID: 42, Revision: 13},
+	})
+	if err != nil {
+		t.Fatalf("EncodeRawKVBatchPayload revisions: %v", err)
+	}
+	if got := binary.LittleEndian.Uint16(payload[0:2]); got != rawKVBatchPayloadVersionWithRevisions {
+		t.Fatalf("payload version=%d want revision payload version %d", got, rawKVBatchPayloadVersionWithRevisions)
+	}
+
+	var scanned []RawKVOperation
+	err = ScanRawKVBatchPayloadWithRevision(payload, func(op RawKVOp, key, value []byte, revision uint64) error {
+		entry := RawKVOperation{Op: op, Key: cloneBytesPreserveEmpty(key), Revision: revision}
+		if op == RawKVOpSetRID {
+			entry.RID = binary.LittleEndian.Uint64(value)
+		} else {
+			entry.Value = cloneBytesPreserveEmpty(value)
+		}
+		scanned = append(scanned, entry)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("ScanRawKVBatchPayloadWithRevision: %v", err)
+	}
+	decoded, err := DecodeRawKVBatchPayload(payload)
+	if err != nil {
+		t.Fatalf("DecodeRawKVBatchPayload revisions: %v", err)
+	}
+	for name, got := range map[string][]RawKVOperation{"scanned": scanned, "decoded": decoded} {
+		if len(got) != 3 ||
+			got[0].Op != RawKVOpSet || string(got[0].Key) != "a" || string(got[0].Value) != "1" || got[0].Revision != 11 ||
+			got[1].Op != RawKVOpDelete || string(got[1].Key) != "b" || len(got[1].Value) != 0 || got[1].Revision != 12 ||
+			got[2].Op != RawKVOpSetRID || string(got[2].Key) != "c" || got[2].RID != 42 || len(got[2].Value) != 0 || got[2].Revision != 13 {
+			t.Fatalf("%s ops=%+v, want revisions preserved", name, got)
+		}
+	}
+	if _, err := EncodeRawKVBatchPayload([]RawKVOperation{{Op: RawKVOpDeleteRange, Key: []byte("a"), Value: []byte("z"), Revision: 1}}); !errors.Is(err, ErrCorrupt) {
+		t.Fatalf("EncodeRawKVBatchPayload revision range delete error=%v, want ErrCorrupt", err)
+	}
+}
+
 func TestCommandWALFeatureGateRejectsLegacyRawPayload(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "commit-l0-000001.log")
 	w, err := NewWriter(path)

--- a/TreeDB/internal/iterator/iterator.go
+++ b/TreeDB/internal/iterator/iterator.go
@@ -26,3 +26,22 @@ type UnsafeIterator interface {
 	Close() error
 	Domain() (start, end []byte)
 }
+
+// RevisionUnsafeIterator is implemented by iterators whose entries carry native
+// per-entry revision metadata.
+type RevisionUnsafeIterator interface {
+	UnsafeEntryWithRevision() (val []byte, ptr page.ValuePtr, flags byte, revision page.EntryRevision)
+}
+
+// UnsafeEntryWithRevision returns native revision metadata when the iterator
+// supports it and legacy revision zero otherwise.
+func UnsafeEntryWithRevision(it UnsafeIterator) (val []byte, ptr page.ValuePtr, flags byte, revision page.EntryRevision) {
+	if it == nil {
+		return nil, page.ValuePtr{}, 0, page.LegacyEntryRevision
+	}
+	if rit, ok := it.(RevisionUnsafeIterator); ok {
+		return rit.UnsafeEntryWithRevision()
+	}
+	val, ptr, flags = it.UnsafeEntry()
+	return val, ptr, flags, page.LegacyEntryRevision
+}

--- a/TreeDB/internal/memtable/append_only.go
+++ b/TreeDB/internal/memtable/append_only.go
@@ -91,6 +91,7 @@ type appendOnlyEntry struct {
 	key         []byte
 	value       []byte
 	ptr         page.ValuePtr
+	revision    page.EntryRevision
 	inlineKey   [appendOnlyInlineKeyLen]byte
 	flags       byte
 	keyInline   bool
@@ -1413,7 +1414,7 @@ func (m *AppendOnly) updateLatestIndexLocked(key []byte, idx int) {
 	m.latest[appendOnlyKeyString(key)] = idx
 }
 
-func (m *AppendOnly) appendEntryCoreLocked(key, value []byte, ptr page.ValuePtr, flags byte, steal bool, borrowValue bool) (idx int, ent *appendOnlyEntry, storedKey []byte) {
+func (m *AppendOnly) appendEntryCoreLocked(key, value []byte, ptr page.ValuePtr, flags byte, revision page.EntryRevision, steal bool, borrowValue bool) (idx int, ent *appendOnlyEntry, storedKey []byte) {
 	if m.count == len(m.entries) {
 		nextCap := appendOnlyNextCapacity(len(m.entries))
 		m.growEntriesLocked(nextCap, true)
@@ -1422,6 +1423,7 @@ func (m *AppendOnly) appendEntryCoreLocked(key, value []byte, ptr page.ValuePtr,
 	m.count++
 	ent = &m.entries[idx]
 	ent.ptr = ptr
+	ent.revision = revision
 	ent.flags = flags
 	ent.keyInline = false
 	ent.keyArena = false
@@ -1461,8 +1463,8 @@ func (m *AppendOnly) appendEntryCoreLocked(key, value []byte, ptr page.ValuePtr,
 	return idx, ent, storedKey
 }
 
-func (m *AppendOnly) appendEntryLocked(key, value []byte, ptr page.ValuePtr, flags byte, steal bool, borrowValue bool) *appendOnlyEntry {
-	idx, ent, k := m.appendEntryCoreLocked(key, value, ptr, flags, steal, borrowValue)
+func (m *AppendOnly) appendEntryLocked(key, value []byte, ptr page.ValuePtr, flags byte, revision page.EntryRevision, steal bool, borrowValue bool) *appendOnlyEntry {
+	idx, ent, k := m.appendEntryCoreLocked(key, value, ptr, flags, revision, steal, borrowValue)
 
 	if !m.hasLast {
 		m.lastIdx = idx
@@ -1491,8 +1493,8 @@ func (m *AppendOnly) appendEntryLocked(key, value []byte, ptr page.ValuePtr, fla
 	return ent
 }
 
-func (m *AppendOnly) appendEntryTrustedOrderedLocked(key, value []byte, ptr page.ValuePtr, flags byte, steal bool, borrowValue bool) *appendOnlyEntry {
-	idx, ent, _ := m.appendEntryCoreLocked(key, value, ptr, flags, steal, borrowValue)
+func (m *AppendOnly) appendEntryTrustedOrderedLocked(key, value []byte, ptr page.ValuePtr, flags byte, revision page.EntryRevision, steal bool, borrowValue bool) *appendOnlyEntry {
+	idx, ent, _ := m.appendEntryCoreLocked(key, value, ptr, flags, revision, steal, borrowValue)
 	m.lastIdx = idx
 	m.hasLast = true
 	return ent
@@ -1507,14 +1509,22 @@ func (m *AppendOnly) SetSteal(key, value []byte) {
 }
 
 func (m *AppendOnly) SetEntry(key, value []byte, ptr page.ValuePtr, flags byte) {
+	m.SetEntryWithRevision(key, value, ptr, flags, page.LegacyEntryRevision)
+}
+
+func (m *AppendOnly) SetEntryWithRevision(key, value []byte, ptr page.ValuePtr, flags byte, revision page.EntryRevision) {
 	m.mu.Lock()
-	m.appendEntryLocked(key, value, ptr, flags, false, false)
+	m.appendEntryLocked(key, value, ptr, flags, revision, false, false)
 	m.mu.Unlock()
 }
 
 func (m *AppendOnly) SetEntrySteal(key, value []byte, ptr page.ValuePtr, flags byte) {
+	m.SetEntryStealWithRevision(key, value, ptr, flags, page.LegacyEntryRevision)
+}
+
+func (m *AppendOnly) SetEntryStealWithRevision(key, value []byte, ptr page.ValuePtr, flags byte, revision page.EntryRevision) {
 	m.mu.Lock()
-	m.appendEntryLocked(key, value, ptr, flags, true, false)
+	m.appendEntryLocked(key, value, ptr, flags, revision, true, false)
 	m.mu.Unlock()
 }
 
@@ -1535,14 +1545,18 @@ func (m *AppendOnly) copyKeyPartsLocked(first, second []byte) []byte {
 func (m *AppendOnly) SetInlineNilKeyParts(first, second []byte) {
 	m.mu.Lock()
 	key := m.copyKeyPartsLocked(first, second)
-	ent := m.appendEntryLocked(key, nil, page.ValuePtr{}, node.FlagInline, true, false)
+	ent := m.appendEntryLocked(key, nil, page.ValuePtr{}, node.FlagInline, page.LegacyEntryRevision, true, false)
 	ent.keyArena = true
 	m.mu.Unlock()
 }
 
 func (m *AppendOnly) SetEntryBorrowValue(key, value []byte, ptr page.ValuePtr, flags byte) {
+	m.SetEntryBorrowValueWithRevision(key, value, ptr, flags, page.LegacyEntryRevision)
+}
+
+func (m *AppendOnly) SetEntryBorrowValueWithRevision(key, value []byte, ptr page.ValuePtr, flags byte, revision page.EntryRevision) {
 	m.mu.Lock()
-	m.appendEntryLocked(key, value, ptr, flags, false, true)
+	m.appendEntryLocked(key, value, ptr, flags, revision, false, true)
 	m.mu.Unlock()
 }
 
@@ -1559,7 +1573,7 @@ func (m *AppendOnly) DeleteSteal(key []byte) {
 func (m *AppendOnly) DeleteKeyParts(first, second []byte) {
 	m.mu.Lock()
 	key := m.copyKeyPartsLocked(first, second)
-	ent := m.appendEntryLocked(key, nil, page.ValuePtr{}, node.FlagTombstone, true, false)
+	ent := m.appendEntryLocked(key, nil, page.ValuePtr{}, node.FlagTombstone, page.LegacyEntryRevision, true, false)
 	ent.keyArena = true
 	m.mu.Unlock()
 }
@@ -1573,7 +1587,7 @@ func (m *AppendOnly) PutWithCallback(key, value []byte, cb func(k, v []byte) err
 		}
 	}
 	m.mu.Lock()
-	m.appendEntryLocked(k, v, page.ValuePtr{}, node.FlagInline, true, false)
+	m.appendEntryLocked(k, v, page.ValuePtr{}, node.FlagInline, page.LegacyEntryRevision, true, false)
 	m.mu.Unlock()
 	return nil
 }
@@ -1586,7 +1600,7 @@ func (m *AppendOnly) DeleteWithCallback(key []byte, cb func(k, v []byte) error) 
 		}
 	}
 	m.mu.Lock()
-	m.appendEntryLocked(k, nil, page.ValuePtr{}, node.FlagTombstone, true, false)
+	m.appendEntryLocked(k, nil, page.ValuePtr{}, node.FlagTombstone, page.LegacyEntryRevision, true, false)
 	m.mu.Unlock()
 	return nil
 }
@@ -1629,9 +1643,9 @@ func (m *AppendOnly) ApplyCopySortedBatchTrusted(entries []batchpkg.Entry, borro
 			borrowedValues = true
 		}
 		if trustedOrdered {
-			m.appendEntryTrustedOrderedLocked(op.Key, value, ptr, flags, false, borrowValue)
+			m.appendEntryTrustedOrderedLocked(op.Key, value, ptr, flags, op.Revision, false, borrowValue)
 		} else {
-			m.appendEntryLocked(op.Key, value, ptr, flags, false, borrowValue)
+			m.appendEntryLocked(op.Key, value, ptr, flags, op.Revision, false, borrowValue)
 		}
 		if onKey != nil {
 			onKey(op.Key)
@@ -1661,9 +1675,9 @@ func (m *AppendOnly) ApplyCopySortedBatchWithValueCopierTrusted(entries []batchp
 			}
 		}
 		if trustedOrdered {
-			m.appendEntryTrustedOrderedLocked(op.Key, value, ptr, flags, false, borrowValue)
+			m.appendEntryTrustedOrderedLocked(op.Key, value, ptr, flags, op.Revision, false, borrowValue)
 		} else {
-			m.appendEntryLocked(op.Key, value, ptr, flags, false, borrowValue)
+			m.appendEntryLocked(op.Key, value, ptr, flags, op.Revision, false, borrowValue)
 		}
 		if onKey != nil {
 			onKey(op.Key)
@@ -1688,7 +1702,27 @@ func (m *AppendOnly) ApplyStealEntryFunc(count int, emit func(i int) (key, value
 		if err != nil {
 			return err
 		}
-		m.appendEntryLocked(key, value, ptr, flags, true, false)
+		m.appendEntryLocked(key, value, ptr, flags, page.LegacyEntryRevision, true, false)
+	}
+	return nil
+}
+
+func (m *AppendOnly) ApplyStealEntryFuncWithRevision(count int, emit func(i int) (key, value []byte, ptr page.ValuePtr, flags byte, revision page.EntryRevision, err error)) error {
+	if count <= 0 {
+		return nil
+	}
+	if emit == nil {
+		return errors.New("memtable: nil entry emitter")
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.reserveAdditionalEntriesLocked(count)
+	for i := 0; i < count; i++ {
+		key, value, ptr, flags, revision, err := emit(i)
+		if err != nil {
+			return err
+		}
+		m.appendEntryLocked(key, value, ptr, flags, revision, true, false)
 	}
 	return nil
 }
@@ -1702,21 +1736,21 @@ func (m *AppendOnly) applyStealBatch(entries []batchpkg.Entry, onKey func(key []
 		switch {
 		case op.Type == batchpkg.OpDelete:
 			if trustedOrdered {
-				m.appendEntryTrustedOrderedLocked(op.Key, nil, page.ValuePtr{}, node.FlagTombstone, true, false)
+				m.appendEntryTrustedOrderedLocked(op.Key, nil, page.ValuePtr{}, node.FlagTombstone, op.Revision, true, false)
 			} else {
-				m.appendEntryLocked(op.Key, nil, page.ValuePtr{}, node.FlagTombstone, true, false)
+				m.appendEntryLocked(op.Key, nil, page.ValuePtr{}, node.FlagTombstone, op.Revision, true, false)
 			}
 		case op.IsPtr:
 			if trustedOrdered {
-				m.appendEntryTrustedOrderedLocked(op.Key, op.Value, op.ValuePtr, node.FlagPointer, true, false)
+				m.appendEntryTrustedOrderedLocked(op.Key, op.Value, op.ValuePtr, node.FlagPointer, op.Revision, true, false)
 			} else {
-				m.appendEntryLocked(op.Key, op.Value, op.ValuePtr, node.FlagPointer, true, false)
+				m.appendEntryLocked(op.Key, op.Value, op.ValuePtr, node.FlagPointer, op.Revision, true, false)
 			}
 		default:
 			if trustedOrdered {
-				m.appendEntryTrustedOrderedLocked(op.Key, op.Value, page.ValuePtr{}, node.FlagInline, true, false)
+				m.appendEntryTrustedOrderedLocked(op.Key, op.Value, page.ValuePtr{}, node.FlagInline, op.Revision, true, false)
 			} else {
-				m.appendEntryLocked(op.Key, op.Value, page.ValuePtr{}, node.FlagInline, true, false)
+				m.appendEntryLocked(op.Key, op.Value, page.ValuePtr{}, node.FlagInline, op.Revision, true, false)
 			}
 		}
 		if onKey != nil {
@@ -1775,32 +1809,32 @@ func (m *AppendOnly) orderedLookupEntryLocked(key []byte) *appendOnlyEntry {
 	return ent
 }
 
-func (m *AppendOnly) getEntryFrozen(key []byte) ([]byte, page.ValuePtr, byte, bool, bool) {
+func (m *AppendOnly) getEntryFrozen(key []byte) ([]byte, page.ValuePtr, byte, page.EntryRevision, bool, bool) {
 	if m == nil {
-		return nil, page.ValuePtr{}, 0, false, true
+		return nil, page.ValuePtr{}, 0, page.LegacyEntryRevision, false, true
 	}
 	if m.ordered {
 		ent := m.orderedLookupEntryLocked(key)
 		if ent == nil {
-			return nil, page.ValuePtr{}, 0, false, true
+			return nil, page.ValuePtr{}, 0, page.LegacyEntryRevision, false, true
 		}
-		return ent.value, ent.ptr, ent.flags, true, true
+		return ent.value, ent.ptr, ent.flags, ent.revision, true, true
 	}
 	if len(m.sortedRuns) > 0 {
 		ent := m.lookupSortedRunsEntryLocked(key)
 		if ent == nil {
-			return nil, page.ValuePtr{}, 0, false, true
+			return nil, page.ValuePtr{}, 0, page.LegacyEntryRevision, false, true
 		}
-		return ent.value, ent.ptr, ent.flags, true, true
+		return ent.value, ent.ptr, ent.flags, ent.revision, true, true
 	}
 	if m.latestDirty {
-		return nil, page.ValuePtr{}, 0, false, false
+		return nil, page.ValuePtr{}, 0, page.LegacyEntryRevision, false, false
 	}
 	if k64, ok := appendOnlyKeyU64(key); ok && m.latest64 != nil {
 		if idx, ok := m.latest64[k64]; ok && idx >= 0 && idx < m.count {
 			ent := &m.entries[idx]
 			if bytes.Equal(appendOnlyEntryKey(ent), key) {
-				return ent.value, ent.ptr, ent.flags, true, true
+				return ent.value, ent.ptr, ent.flags, ent.revision, true, true
 			}
 		}
 	}
@@ -1808,16 +1842,16 @@ func (m *AppendOnly) getEntryFrozen(key []byte) ([]byte, page.ValuePtr, byte, bo
 		if idx, ok := m.latest[appendOnlyKeyString(key)]; ok && idx >= 0 && idx < m.count {
 			ent := &m.entries[idx]
 			if bytes.Equal(appendOnlyEntryKey(ent), key) {
-				return ent.value, ent.ptr, ent.flags, true, true
+				return ent.value, ent.ptr, ent.flags, ent.revision, true, true
 			}
 		}
 	}
-	return nil, page.ValuePtr{}, 0, false, true
+	return nil, page.ValuePtr{}, 0, page.LegacyEntryRevision, false, true
 }
 
 func (m *AppendOnly) Get(key []byte) ([]byte, bool, bool) {
 	if m.frozenFast.Load() {
-		val, _, flags, found, ok := m.getEntryFrozen(key)
+		val, _, flags, _, found, ok := m.getEntryFrozen(key)
 		if ok {
 			if !found {
 				return nil, false, false
@@ -1902,10 +1936,15 @@ func (m *AppendOnly) Get(key []byte) ([]byte, bool, bool) {
 }
 
 func (m *AppendOnly) GetEntry(key []byte) ([]byte, page.ValuePtr, byte, bool) {
+	val, ptr, flags, _, found := m.GetEntryWithRevision(key)
+	return val, ptr, flags, found
+}
+
+func (m *AppendOnly) GetEntryWithRevision(key []byte) ([]byte, page.ValuePtr, byte, page.EntryRevision, bool) {
 	if m.frozenFast.Load() {
-		val, ptr, flags, found, ok := m.getEntryFrozen(key)
+		val, ptr, flags, revision, found, ok := m.getEntryFrozen(key)
 		if ok {
-			return val, ptr, flags, found
+			return val, ptr, flags, revision, found
 		}
 	}
 	for {
@@ -1914,12 +1953,13 @@ func (m *AppendOnly) GetEntry(key []byte) ([]byte, page.ValuePtr, byte, bool) {
 			val := ent.value
 			ptr := ent.ptr
 			flags := ent.flags
+			revision := ent.revision
 			m.mu.RUnlock()
-			return val, ptr, flags, true
+			return val, ptr, flags, revision, true
 		}
 		if m.ordered {
 			m.mu.RUnlock()
-			return nil, page.ValuePtr{}, 0, false
+			return nil, page.ValuePtr{}, 0, page.LegacyEntryRevision, false
 		}
 
 		if len(m.sortedRuns) > 0 {
@@ -1927,11 +1967,12 @@ func (m *AppendOnly) GetEntry(key []byte) ([]byte, page.ValuePtr, byte, bool) {
 				val := ent.value
 				ptr := ent.ptr
 				flags := ent.flags
+				revision := ent.revision
 				m.mu.RUnlock()
-				return val, ptr, flags, true
+				return val, ptr, flags, revision, true
 			}
 			m.mu.RUnlock()
-			return nil, page.ValuePtr{}, 0, false
+			return nil, page.ValuePtr{}, 0, page.LegacyEntryRevision, false
 		}
 
 		if !m.latestDirty {
@@ -1942,8 +1983,9 @@ func (m *AppendOnly) GetEntry(key []byte) ([]byte, page.ValuePtr, byte, bool) {
 						val := ent.value
 						ptr := ent.ptr
 						flags := ent.flags
+						revision := ent.revision
 						m.mu.RUnlock()
-						return val, ptr, flags, true
+						return val, ptr, flags, revision, true
 					}
 				}
 			}
@@ -1954,13 +1996,14 @@ func (m *AppendOnly) GetEntry(key []byte) ([]byte, page.ValuePtr, byte, bool) {
 						val := ent.value
 						ptr := ent.ptr
 						flags := ent.flags
+						revision := ent.revision
 						m.mu.RUnlock()
-						return val, ptr, flags, true
+						return val, ptr, flags, revision, true
 					}
 				}
 			}
 			m.mu.RUnlock()
-			return nil, page.ValuePtr{}, 0, false
+			return nil, page.ValuePtr{}, 0, page.LegacyEntryRevision, false
 		}
 		m.mu.RUnlock()
 
@@ -2214,6 +2257,7 @@ func (m *AppendOnly) resetLockedWithPolicy(capacity, estimatedBytesPerEntry int,
 	for i := 0; i < m.count; i++ {
 		ent := &m.entries[i]
 		ent.ptr = page.ValuePtr{}
+		ent.revision = page.LegacyEntryRevision
 		ent.flags = 0
 		if ent.keyArena {
 			ent.key = nil
@@ -2620,11 +2664,16 @@ func (it *appendOnlyIterator) UnsafeValue() []byte {
 }
 
 func (it *appendOnlyIterator) UnsafeEntry() ([]byte, page.ValuePtr, byte) {
+	val, ptr, flags, _ := it.UnsafeEntryWithRevision()
+	return val, ptr, flags
+}
+
+func (it *appendOnlyIterator) UnsafeEntryWithRevision() ([]byte, page.ValuePtr, byte, page.EntryRevision) {
 	ent := it.entryAt(it.idx)
 	if ent == nil || !it.validIndex() {
-		return nil, page.ValuePtr{}, 0
+		return nil, page.ValuePtr{}, 0, page.LegacyEntryRevision
 	}
-	return ent.value, ent.ptr, ent.flags
+	return ent.value, ent.ptr, ent.flags, ent.revision
 }
 
 func (it *appendOnlyIterator) IsDeleted() bool {

--- a/TreeDB/internal/memtable/btree.go
+++ b/TreeDB/internal/memtable/btree.go
@@ -16,9 +16,10 @@ const btreeUseLoadFastPath = false
 const btreeArenaChunkSize = 1 << 20
 
 type btreeEntry struct {
-	value []byte // inline bytes (if pointer, may store inline tail bytes)
-	ptr   page.ValuePtr
-	flags byte
+	value    []byte // inline bytes (if pointer, may store inline tail bytes)
+	ptr      page.ValuePtr
+	revision page.EntryRevision
+	flags    byte
 }
 
 func canonicalizeBTreePointerValue(flags byte, value []byte) []byte {
@@ -85,7 +86,7 @@ func (m *BTree) ApplyStealSortedBatch(entries []batchpkg.Entry, onKey func(key [
 		var replaced bool
 
 		if op.Type == batchpkg.OpDelete {
-			entry := btreeEntry{flags: node.FlagTombstone}
+			entry := btreeEntry{flags: node.FlagTombstone, revision: op.Revision}
 			if m.hasLast && keyStr > m.lastKey {
 				prev, replaced = m.tree.Load(keyStr, entry)
 			} else {
@@ -99,7 +100,7 @@ func (m *BTree) ApplyStealSortedBatch(entries []batchpkg.Entry, onKey func(key [
 				m.sizeBytes += int64(len(op.Key))
 			}
 		} else if op.IsPtr {
-			entry := btreeEntry{value: canonicalizeBTreePointerValue(node.FlagPointer, op.Value), ptr: op.ValuePtr, flags: node.FlagPointer}
+			entry := btreeEntry{value: canonicalizeBTreePointerValue(node.FlagPointer, op.Value), ptr: op.ValuePtr, flags: node.FlagPointer, revision: op.Revision}
 			if m.hasLast && keyStr > m.lastKey {
 				prev, replaced = m.tree.Load(keyStr, entry)
 			} else {
@@ -113,7 +114,7 @@ func (m *BTree) ApplyStealSortedBatch(entries []batchpkg.Entry, onKey func(key [
 				m.sizeBytes += int64(len(op.Key) + newSize)
 			}
 		} else {
-			entry := btreeEntry{value: canonicalizeBTreeInlineValue(op.Value), flags: node.FlagInline}
+			entry := btreeEntry{value: canonicalizeBTreeInlineValue(op.Value), flags: node.FlagInline, revision: op.Revision}
 			if m.hasLast && keyStr > m.lastKey {
 				prev, replaced = m.tree.Load(keyStr, entry)
 			} else {
@@ -211,6 +212,10 @@ func (m *BTree) SetSteal(key, value []byte) {
 }
 
 func (m *BTree) SetEntry(key, value []byte, ptr page.ValuePtr, flags byte) {
+	m.SetEntryWithRevision(key, value, ptr, flags, page.LegacyEntryRevision)
+}
+
+func (m *BTree) SetEntryWithRevision(key, value []byte, ptr page.ValuePtr, flags byte, revision page.EntryRevision) {
 	if key == nil {
 		return
 	}
@@ -219,7 +224,7 @@ func (m *BTree) SetEntry(key, value []byte, ptr page.ValuePtr, flags byte) {
 
 	keyCopy := m.arena.Copy(key)
 	keyStr := bytesToStringNoCopy(keyCopy)
-	entry := btreeEntry{flags: normalizeBTreeEntryFlags(flags)}
+	entry := btreeEntry{flags: normalizeBTreeEntryFlags(flags), revision: revision}
 	switch {
 	case entry.flags&node.FlagTombstone != 0:
 		entry.value = nil
@@ -251,6 +256,10 @@ func (m *BTree) SetEntry(key, value []byte, ptr page.ValuePtr, flags byte) {
 }
 
 func (m *BTree) SetEntrySteal(key, value []byte, ptr page.ValuePtr, flags byte) {
+	m.SetEntryStealWithRevision(key, value, ptr, flags, page.LegacyEntryRevision)
+}
+
+func (m *BTree) SetEntryStealWithRevision(key, value []byte, ptr page.ValuePtr, flags byte, revision page.EntryRevision) {
 	if key == nil {
 		return
 	}
@@ -259,7 +268,7 @@ func (m *BTree) SetEntrySteal(key, value []byte, ptr page.ValuePtr, flags byte) 
 	defer m.mu.Unlock()
 
 	keyStr := bytesToStringNoCopy(key)
-	entry := btreeEntry{flags: normalizeBTreeEntryFlags(flags)}
+	entry := btreeEntry{flags: normalizeBTreeEntryFlags(flags), revision: revision}
 	switch {
 	case entry.flags&node.FlagTombstone != 0:
 		entry.value = nil
@@ -334,16 +343,21 @@ func (m *BTree) Get(key []byte) ([]byte, bool, bool) {
 }
 
 func (m *BTree) GetEntry(key []byte) ([]byte, page.ValuePtr, byte, bool) {
+	val, ptr, flags, _, found := m.GetEntryWithRevision(key)
+	return val, ptr, flags, found
+}
+
+func (m *BTree) GetEntryWithRevision(key []byte) ([]byte, page.ValuePtr, byte, page.EntryRevision, bool) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	val, ok := m.tree.Get(bytesToStringNoCopy(key))
 	if !ok {
-		return nil, page.ValuePtr{}, 0, false
+		return nil, page.ValuePtr{}, 0, page.LegacyEntryRevision, false
 	}
 	if val.flags&node.FlagPointer != 0 {
-		return canonicalizeBTreePointerValue(val.flags, val.value), val.ptr, val.flags, true
+		return canonicalizeBTreePointerValue(val.flags, val.value), val.ptr, val.flags, val.revision, true
 	}
-	return val.value, page.ValuePtr{}, val.flags, true
+	return val.value, page.ValuePtr{}, val.flags, val.revision, true
 }
 
 func (m *BTree) Size() int64 {
@@ -486,16 +500,21 @@ func (it *btreeIterator) UnsafeValue() []byte {
 }
 
 func (it *btreeIterator) UnsafeEntry() ([]byte, page.ValuePtr, byte) {
+	val, ptr, flags, _ := it.UnsafeEntryWithRevision()
+	return val, ptr, flags
+}
+
+func (it *btreeIterator) UnsafeEntryWithRevision() ([]byte, page.ValuePtr, byte, page.EntryRevision) {
 	if !it.hasCur {
-		return nil, page.ValuePtr{}, node.FlagTombstone
+		return nil, page.ValuePtr{}, node.FlagTombstone, page.LegacyEntryRevision
 	}
 	if it.cur.flags&node.FlagTombstone != 0 {
-		return nil, page.ValuePtr{}, node.FlagTombstone
+		return nil, page.ValuePtr{}, node.FlagTombstone, it.cur.revision
 	}
 	if it.cur.flags&node.FlagPointer != 0 {
-		return it.cur.value, it.cur.ptr, it.cur.flags
+		return it.cur.value, it.cur.ptr, it.cur.flags, it.cur.revision
 	}
-	return it.cur.value, page.ValuePtr{}, it.cur.flags
+	return it.cur.value, page.ValuePtr{}, it.cur.flags, it.cur.revision
 }
 
 func (it *btreeIterator) Key() []byte {
@@ -649,16 +668,21 @@ func (it *btreeReverseIterator) UnsafeValue() []byte {
 }
 
 func (it *btreeReverseIterator) UnsafeEntry() ([]byte, page.ValuePtr, byte) {
+	val, ptr, flags, _ := it.UnsafeEntryWithRevision()
+	return val, ptr, flags
+}
+
+func (it *btreeReverseIterator) UnsafeEntryWithRevision() ([]byte, page.ValuePtr, byte, page.EntryRevision) {
 	if !it.hasCur {
-		return nil, page.ValuePtr{}, node.FlagTombstone
+		return nil, page.ValuePtr{}, node.FlagTombstone, page.LegacyEntryRevision
 	}
 	if it.cur.flags&node.FlagTombstone != 0 {
-		return nil, page.ValuePtr{}, node.FlagTombstone
+		return nil, page.ValuePtr{}, node.FlagTombstone, it.cur.revision
 	}
 	if it.cur.flags&node.FlagPointer != 0 {
-		return it.cur.value, it.cur.ptr, it.cur.flags
+		return it.cur.value, it.cur.ptr, it.cur.flags, it.cur.revision
 	}
-	return it.cur.value, page.ValuePtr{}, it.cur.flags
+	return it.cur.value, page.ValuePtr{}, it.cur.flags, it.cur.revision
 }
 
 func (it *btreeReverseIterator) Key() []byte {

--- a/TreeDB/internal/memtable/hash_sorted.go
+++ b/TreeDB/internal/memtable/hash_sorted.go
@@ -13,9 +13,10 @@ import (
 )
 
 type hashEntry struct {
-	value []byte // inline bytes (pointer bytes stored separately in ptr)
-	ptr   page.ValuePtr
-	flags byte
+	value    []byte // inline bytes (pointer bytes stored separately in ptr)
+	ptr      page.ValuePtr
+	revision page.EntryRevision
+	flags    byte
 }
 
 const (
@@ -242,7 +243,7 @@ func (m *HashSorted) ApplyCopySortedBatchTrusted(entries []batchpkg.Entry, borro
 	} else {
 		for _, op := range entries {
 			value, ptr, flags := hashSortedBatchEntryPayload(op, storeInlinePtrValues)
-			if chunk, seq := m.setEntryLocked(op.Key, value, ptr, flags, false); seq != 0 {
+			if chunk, seq := m.setEntryLocked(op.Key, value, ptr, flags, op.Revision, false); seq != 0 {
 				chunks = append(chunks, hashSortedIndexWork{mt: m, seq: seq, keys: chunk})
 			}
 			if onKey != nil {
@@ -286,15 +287,15 @@ func (m *HashSorted) applyStealSortedBatch(entries []batchpkg.Entry, onKey func(
 	} else {
 		for _, op := range entries {
 			if op.Type == batchpkg.OpDelete {
-				if chunk, seq := m.setEntryLocked(op.Key, nil, page.ValuePtr{}, node.FlagTombstone, true); seq != 0 {
+				if chunk, seq := m.setEntryLocked(op.Key, nil, page.ValuePtr{}, node.FlagTombstone, op.Revision, true); seq != 0 {
 					chunks = append(chunks, hashSortedIndexWork{mt: m, seq: seq, keys: chunk})
 				}
 			} else if op.IsPtr {
-				if chunk, seq := m.setEntryLocked(op.Key, nil, op.ValuePtr, node.FlagPointer, true); seq != 0 {
+				if chunk, seq := m.setEntryLocked(op.Key, nil, op.ValuePtr, node.FlagPointer, op.Revision, true); seq != 0 {
 					chunks = append(chunks, hashSortedIndexWork{mt: m, seq: seq, keys: chunk})
 				}
 			} else {
-				if chunk, seq := m.setEntryLocked(op.Key, op.Value, page.ValuePtr{}, node.FlagInline, true); seq != 0 {
+				if chunk, seq := m.setEntryLocked(op.Key, op.Value, page.ValuePtr{}, node.FlagInline, op.Revision, true); seq != 0 {
 					chunks = append(chunks, hashSortedIndexWork{mt: m, seq: seq, keys: chunk})
 				}
 			}
@@ -323,8 +324,12 @@ func (m *HashSorted) SetSteal(key, value []byte) {
 }
 
 func (m *HashSorted) SetEntry(key, value []byte, ptr page.ValuePtr, flags byte) {
+	m.SetEntryWithRevision(key, value, ptr, flags, page.LegacyEntryRevision)
+}
+
+func (m *HashSorted) SetEntryWithRevision(key, value []byte, ptr page.ValuePtr, flags byte, revision page.EntryRevision) {
 	m.mu.Lock()
-	chunk, seq := m.setEntryLocked(key, value, ptr, flags, false)
+	chunk, seq := m.setEntryLocked(key, value, ptr, flags, revision, false)
 	m.mu.Unlock()
 	if seq != 0 {
 		m.indexer.enqueue(m, seq, chunk, false)
@@ -332,8 +337,12 @@ func (m *HashSorted) SetEntry(key, value []byte, ptr page.ValuePtr, flags byte) 
 }
 
 func (m *HashSorted) SetEntrySteal(key, value []byte, ptr page.ValuePtr, flags byte) {
+	m.SetEntryStealWithRevision(key, value, ptr, flags, page.LegacyEntryRevision)
+}
+
+func (m *HashSorted) SetEntryStealWithRevision(key, value []byte, ptr page.ValuePtr, flags byte, revision page.EntryRevision) {
 	m.mu.Lock()
-	chunk, seq := m.setEntryLocked(key, value, ptr, flags, true)
+	chunk, seq := m.setEntryLocked(key, value, ptr, flags, revision, true)
 	m.mu.Unlock()
 	if seq != 0 {
 		m.indexer.enqueue(m, seq, chunk, false)
@@ -394,6 +403,7 @@ func (m *HashSorted) PutWithCallback(key, value []byte, cb func(k, v []byte) err
 		ent.value = valCopy
 		ent.ptr = page.ValuePtr{}
 		ent.flags = node.FlagInline
+		ent.revision = page.LegacyEntryRevision
 		m.sizeBytes += int64(hashEntryValueSize(ent.flags, ent.value) - oldLen)
 		m.mu.Unlock()
 		return nil
@@ -457,6 +467,7 @@ func (m *HashSorted) DeleteWithCallback(key []byte, cb func(k, v []byte) error) 
 			ent.ptr = page.ValuePtr{}
 			ent.flags = node.FlagTombstone
 		}
+		ent.revision = page.LegacyEntryRevision
 		m.mu.Unlock()
 		return nil
 	}
@@ -510,13 +521,18 @@ func (m *HashSorted) Get(key []byte) ([]byte, bool, bool) {
 }
 
 func (m *HashSorted) GetEntry(key []byte) ([]byte, page.ValuePtr, byte, bool) {
+	val, ptr, flags, _, found := m.GetEntryWithRevision(key)
+	return val, ptr, flags, found
+}
+
+func (m *HashSorted) GetEntryWithRevision(key []byte) ([]byte, page.ValuePtr, byte, page.EntryRevision, bool) {
 	keyLookup := bytesToStringNoCopy(key)
 
 	m.mu.RLock()
 	idx, ok := m.items[keyLookup]
 	if !ok {
 		m.mu.RUnlock()
-		return nil, page.ValuePtr{}, 0, false
+		return nil, page.ValuePtr{}, 0, page.LegacyEntryRevision, false
 	}
 	i := int(idx)
 	if i < 0 || i >= len(m.entries) {
@@ -525,19 +541,19 @@ func (m *HashSorted) GetEntry(key []byte) ([]byte, page.ValuePtr, byte, bool) {
 		ent, ok := m.entryForReadLocked(keyLookup)
 		m.mu.Unlock()
 		if !ok {
-			return nil, page.ValuePtr{}, 0, false
+			return nil, page.ValuePtr{}, 0, page.LegacyEntryRevision, false
 		}
 		if ent.flags&node.FlagPointer != 0 {
-			return ent.value, ent.ptr, ent.flags, true
+			return ent.value, ent.ptr, ent.flags, ent.revision, true
 		}
-		return ent.value, page.ValuePtr{}, ent.flags, true
+		return ent.value, page.ValuePtr{}, ent.flags, ent.revision, true
 	}
 	ent := m.entries[i]
 	m.mu.RUnlock()
 	if ent.flags&node.FlagPointer != 0 {
-		return ent.value, ent.ptr, ent.flags, true
+		return ent.value, ent.ptr, ent.flags, ent.revision, true
 	}
-	return ent.value, page.ValuePtr{}, ent.flags, true
+	return ent.value, page.ValuePtr{}, ent.flags, ent.revision, true
 }
 
 func (m *HashSorted) Size() int64 {
@@ -983,7 +999,7 @@ func (m *HashSorted) noteNewKeysBatchLocked(keys []string, keyBytes int, keysSor
 	return chunk, m.nextSeq, sorted
 }
 
-func (m *HashSorted) setEntryLocked(key, value []byte, ptr page.ValuePtr, flags byte, steal bool) ([]string, uint64) {
+func (m *HashSorted) setEntryLocked(key, value []byte, ptr page.ValuePtr, flags byte, revision page.EntryRevision, steal bool) ([]string, uint64) {
 	if key == nil {
 		return nil, 0
 	}
@@ -997,6 +1013,7 @@ func (m *HashSorted) setEntryLocked(key, value []byte, ptr page.ValuePtr, flags 
 			ent.ptr = page.ValuePtr{}
 		}
 		ent.flags = flags
+		ent.revision = revision
 		m.sizeBytes += int64(hashEntryValueSize(ent.flags, ent.value) - oldLen)
 		if flags&node.FlagTombstone != 0 {
 			m.hasDeletes = true
@@ -1012,7 +1029,7 @@ func (m *HashSorted) setEntryLocked(key, value []byte, ptr page.ValuePtr, flags 
 	}
 	keyStored := bytesToStringNoCopy(keyCopy)
 	valCopy := m.encodeEntryValueLocked(value, ptr, flags, steal)
-	ent := hashEntry{value: valCopy, flags: flags}
+	ent := hashEntry{value: valCopy, flags: flags, revision: revision}
 	if flags&node.FlagPointer != 0 {
 		ent.ptr = ptr
 	}
@@ -1038,7 +1055,7 @@ func (m *HashSorted) setEntryNewCopyNoChunkLocked(op batchpkg.Entry, storeInline
 	keyStored := bytesToStringNoCopy(keyCopy)
 	value, ptr, flags := hashSortedBatchEntryPayload(op, storeInlinePtrValues)
 	valCopy := m.encodeEntryValueLocked(value, ptr, flags, false)
-	ent := hashEntry{value: valCopy, flags: flags}
+	ent := hashEntry{value: valCopy, flags: flags, revision: op.Revision}
 	if flags&node.FlagPointer != 0 {
 		ent.ptr = ptr
 	}
@@ -1072,7 +1089,7 @@ func (m *HashSorted) setEntryNewStealNoChunkLocked(op batchpkg.Entry) (string, i
 		ptr = op.ValuePtr
 	}
 
-	ent := hashEntry{value: val, flags: flags}
+	ent := hashEntry{value: val, flags: flags, revision: op.Revision}
 	if flags&node.FlagPointer != 0 {
 		ent.ptr = ptr
 	}
@@ -1148,11 +1165,11 @@ func (m *HashSorted) encodeEntryValueLocked(value []byte, ptr page.ValuePtr, fla
 }
 
 func (m *HashSorted) setStealLocked(key, value []byte) ([]string, uint64) {
-	return m.setEntryLocked(key, value, page.ValuePtr{}, node.FlagInline, true)
+	return m.setEntryLocked(key, value, page.ValuePtr{}, node.FlagInline, page.LegacyEntryRevision, true)
 }
 
 func (m *HashSorted) deleteStealLocked(key []byte) ([]string, uint64) {
-	return m.setEntryLocked(key, nil, page.ValuePtr{}, node.FlagTombstone, true)
+	return m.setEntryLocked(key, nil, page.ValuePtr{}, node.FlagTombstone, page.LegacyEntryRevision, true)
 }
 
 func (idx *hashSortedIndex) reset() {
@@ -1424,17 +1441,22 @@ func (it *hashReverseIterator) UnsafeValue() []byte {
 }
 
 func (it *hashReverseIterator) UnsafeEntry() ([]byte, page.ValuePtr, byte) {
+	val, ptr, flags, _ := it.UnsafeEntryWithRevision()
+	return val, ptr, flags
+}
+
+func (it *hashReverseIterator) UnsafeEntryWithRevision() ([]byte, page.ValuePtr, byte, page.EntryRevision) {
 	if !it.valid {
-		return nil, page.ValuePtr{}, node.FlagTombstone
+		return nil, page.ValuePtr{}, node.FlagTombstone, page.LegacyEntryRevision
 	}
 	it.ensureLoaded()
 	if it.cur.flags&node.FlagTombstone != 0 {
-		return nil, page.ValuePtr{}, node.FlagTombstone
+		return nil, page.ValuePtr{}, node.FlagTombstone, it.cur.revision
 	}
 	if it.cur.flags&node.FlagPointer != 0 {
-		return it.cur.value, it.cur.ptr, it.cur.flags
+		return it.cur.value, it.cur.ptr, it.cur.flags, it.cur.revision
 	}
-	return it.cur.value, page.ValuePtr{}, node.FlagInline
+	return it.cur.value, page.ValuePtr{}, node.FlagInline, it.cur.revision
 }
 
 func (it *hashReverseIterator) Key() []byte {
@@ -1587,17 +1609,22 @@ func (it *hashIterator) UnsafeValue() []byte {
 }
 
 func (it *hashIterator) UnsafeEntry() ([]byte, page.ValuePtr, byte) {
+	val, ptr, flags, _ := it.UnsafeEntryWithRevision()
+	return val, ptr, flags
+}
+
+func (it *hashIterator) UnsafeEntryWithRevision() ([]byte, page.ValuePtr, byte, page.EntryRevision) {
 	if !it.valid {
-		return nil, page.ValuePtr{}, node.FlagTombstone
+		return nil, page.ValuePtr{}, node.FlagTombstone, page.LegacyEntryRevision
 	}
 	it.ensureLoaded()
 	if it.cur.flags&node.FlagTombstone != 0 {
-		return nil, page.ValuePtr{}, node.FlagTombstone
+		return nil, page.ValuePtr{}, node.FlagTombstone, it.cur.revision
 	}
 	if it.cur.flags&node.FlagPointer != 0 {
-		return it.cur.value, it.cur.ptr, it.cur.flags
+		return it.cur.value, it.cur.ptr, it.cur.flags, it.cur.revision
 	}
-	return it.cur.value, page.ValuePtr{}, node.FlagInline
+	return it.cur.value, page.ValuePtr{}, node.FlagInline, it.cur.revision
 }
 
 func (it *hashIterator) Key() []byte {

--- a/TreeDB/internal/memtable/memtable.go
+++ b/TreeDB/internal/memtable/memtable.go
@@ -78,6 +78,19 @@ type Table interface {
 	Freeze()
 }
 
+// RevisionTable is implemented by memtables that carry native entry revisions
+// beside value/pointer/flags metadata.
+type RevisionTable interface {
+	SetEntryWithRevision(key, value []byte, ptr page.ValuePtr, flags byte, revision page.EntryRevision)
+	GetEntryWithRevision(key []byte) (val []byte, ptr page.ValuePtr, flags byte, revision page.EntryRevision, found bool)
+}
+
+// RevisionStealTable is implemented by memtables that can accept caller-owned
+// key/value buffers while preserving native entry revisions.
+type RevisionStealTable interface {
+	SetEntryStealWithRevision(key, value []byte, ptr page.ValuePtr, flags byte, revision page.EntryRevision)
+}
+
 // SortedBatchApplier is an optional fast path for applying a strictly-increasing
 // batch under a single memtable lock.
 //
@@ -93,6 +106,12 @@ type StealEntryFuncApplier interface {
 	ApplyStealEntryFunc(count int, emit func(i int) (key, value []byte, ptr page.ValuePtr, flags byte, err error)) error
 }
 
+// RevisionStealEntryFuncApplier is the revision-preserving variant of
+// StealEntryFuncApplier.
+type RevisionStealEntryFuncApplier interface {
+	ApplyStealEntryFuncWithRevision(count int, emit func(i int) (key, value []byte, ptr page.ValuePtr, flags byte, revision page.EntryRevision, err error)) error
+}
+
 // ValueBorrower marks memtables that can safely retain caller-owned value
 // slices while still copying keys into their own storage.
 //
@@ -100,6 +119,11 @@ type StealEntryFuncApplier interface {
 // retired or reset.
 type ValueBorrower interface {
 	SetEntryBorrowValue(key, value []byte, ptr page.ValuePtr, flags byte)
+}
+
+// RevisionValueBorrower is the revision-preserving variant of ValueBorrower.
+type RevisionValueBorrower interface {
+	SetEntryBorrowValueWithRevision(key, value []byte, ptr page.ValuePtr, flags byte, revision page.EntryRevision)
 }
 
 // EntryCapacityReserver marks memtables that can pre-size entry metadata before
@@ -210,9 +234,13 @@ func (m *Memtable) Set(key, value []byte) {
 }
 
 func (m *Memtable) SetEntry(key, value []byte, ptr page.ValuePtr, flags byte) {
+	m.SetEntryWithRevision(key, value, ptr, flags, page.LegacyEntryRevision)
+}
+
+func (m *Memtable) SetEntryWithRevision(key, value []byte, ptr page.ValuePtr, flags byte, revision page.EntryRevision) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.sl.PutEntry(key, value, ptr, flags)
+	m.sl.PutEntryWithRevision(key, value, ptr, flags, revision)
 }
 
 func (m *Memtable) PutWithCallback(key, value []byte, cb func(k, v []byte) error) error {
@@ -245,20 +273,20 @@ func (m *Memtable) ApplyStealSortedBatch(entries []batchpkg.Entry, onKey func(ke
 		if last == nil || bytes.Compare(entries[0].Key, last) > 0 {
 			for _, op := range entries {
 				if op.Type == batchpkg.OpDelete {
-					m.sl.AppendDelete(op.Key)
+					_ = m.sl.AppendDeleteWithRevision(op.Key, op.Revision)
 				} else if op.IsPtr {
 					if len(op.Value) > 0 {
 						buf := make([]byte, page.ValuePtrSize+len(op.Value))
 						op.ValuePtr.Encode(buf[:page.ValuePtrSize])
 						copy(buf[page.ValuePtrSize:], op.Value)
-						_ = m.sl.AppendWithCallback(op.Key, buf, node.FlagPointer, nil)
+						_ = m.sl.AppendWithCallbackRevision(op.Key, buf, node.FlagPointer, op.Revision, nil)
 					} else {
 						var buf [page.ValuePtrSize]byte
 						op.ValuePtr.Encode(buf[:])
-						_ = m.sl.AppendWithCallback(op.Key, buf[:], node.FlagPointer, nil)
+						_ = m.sl.AppendWithCallbackRevision(op.Key, buf[:], node.FlagPointer, op.Revision, nil)
 					}
 				} else {
-					m.sl.Append(op.Key, op.Value)
+					_ = m.sl.AppendWithCallbackRevision(op.Key, op.Value, node.FlagInline, op.Revision, nil)
 				}
 				if onKey != nil {
 					onKey(op.Key)
@@ -270,11 +298,11 @@ func (m *Memtable) ApplyStealSortedBatch(entries []batchpkg.Entry, onKey func(ke
 
 	for _, op := range entries {
 		if op.Type == batchpkg.OpDelete {
-			m.sl.Delete(op.Key)
+			m.sl.PutEntryWithRevision(op.Key, nil, page.ValuePtr{}, node.FlagTombstone, op.Revision)
 		} else if op.IsPtr {
-			m.sl.PutEntry(op.Key, op.Value, op.ValuePtr, node.FlagPointer)
+			m.sl.PutEntryWithRevision(op.Key, op.Value, op.ValuePtr, node.FlagPointer, op.Revision)
 		} else {
-			m.sl.Put(op.Key, op.Value)
+			m.sl.PutEntryWithRevision(op.Key, op.Value, page.ValuePtr{}, node.FlagInline, op.Revision)
 		}
 		if onKey != nil {
 			onKey(op.Key)
@@ -292,6 +320,10 @@ func (m *Memtable) SetEntrySteal(key, value []byte, ptr page.ValuePtr, flags byt
 	m.SetEntry(key, value, ptr, flags)
 }
 
+func (m *Memtable) SetEntryStealWithRevision(key, value []byte, ptr page.ValuePtr, flags byte, revision page.EntryRevision) {
+	m.SetEntryWithRevision(key, value, ptr, flags, revision)
+}
+
 // DeleteSteal - SkipList copies data, so Steal is same as Delete.
 func (m *Memtable) DeleteSteal(key []byte) {
 	m.Delete(key)
@@ -304,9 +336,14 @@ func (m *Memtable) Get(key []byte) ([]byte, bool, bool) {
 }
 
 func (m *Memtable) GetEntry(key []byte) ([]byte, page.ValuePtr, byte, bool) {
+	val, ptr, flags, _, found := m.GetEntryWithRevision(key)
+	return val, ptr, flags, found
+}
+
+func (m *Memtable) GetEntryWithRevision(key []byte) ([]byte, page.ValuePtr, byte, page.EntryRevision, bool) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
-	return m.sl.GetEntry(key)
+	return m.sl.GetEntryWithRevision(key)
 }
 
 // Size returns the total memory usage (arena size).
@@ -393,6 +430,10 @@ func (it *Iterator) UnsafeValue() []byte {
 
 func (it *Iterator) UnsafeEntry() ([]byte, page.ValuePtr, byte) {
 	return it.iter.UnsafeEntry()
+}
+
+func (it *Iterator) UnsafeEntryWithRevision() ([]byte, page.ValuePtr, byte, page.EntryRevision) {
+	return it.iter.UnsafeEntryWithRevision()
 }
 
 func (it *Iterator) IsDeleted() bool {
@@ -483,6 +524,10 @@ func (it *ReverseIterator) UnsafeValue() []byte {
 
 func (it *ReverseIterator) UnsafeEntry() ([]byte, page.ValuePtr, byte) {
 	return it.iter.UnsafeEntry()
+}
+
+func (it *ReverseIterator) UnsafeEntryWithRevision() ([]byte, page.ValuePtr, byte, page.EntryRevision) {
+	return it.iter.UnsafeEntryWithRevision()
 }
 
 func (it *ReverseIterator) IsDeleted() bool {

--- a/TreeDB/internal/memtable/mode_compare_bench_test.go
+++ b/TreeDB/internal/memtable/mode_compare_bench_test.go
@@ -5,6 +5,9 @@ import (
 	"fmt"
 	"sync/atomic"
 	"testing"
+
+	"github.com/snissn/gomap/TreeDB/node"
+	"github.com/snissn/gomap/TreeDB/page"
 )
 
 func benchModeTable(b *testing.B, mode Mode) Table {
@@ -56,6 +59,49 @@ func BenchmarkMemtableSetParallel_ModeCompare(b *testing.B) {
 						mt.Set(keys[int(n%uint64(pattern.keySpace))], value)
 					}
 				})
+			})
+		}
+	}
+}
+
+func BenchmarkMemtableSetEntryRevisionOverhead_ModeCompare(b *testing.B) {
+	const (
+		keySpace  = 1 << 14
+		valueSize = 16
+	)
+	modes := []Mode{ModeAppendOnly, ModeHashSorted, ModeBTree, ModeSkiplist}
+
+	for _, mode := range modes {
+		for _, withRevision := range []bool{false, true} {
+			name := "legacy"
+			if withRevision {
+				name = "revision"
+			}
+			b.Run(fmt.Sprintf("%s/%s", mode.String(), name), func(b *testing.B) {
+				mt := benchModeTable(b, mode)
+				keys := make([][]byte, keySpace)
+				for i := 0; i < keySpace; i++ {
+					k := make([]byte, 8)
+					binary.BigEndian.PutUint64(k, uint64(i))
+					keys[i] = k
+				}
+				value := make([]byte, valueSize)
+				for i := range value {
+					value[i] = byte(i)
+				}
+
+				revisions, _ := mt.(RevisionTable)
+				b.ReportAllocs()
+				b.SetBytes(int64(valueSize))
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					key := keys[i&(keySpace-1)]
+					if withRevision {
+						revisions.SetEntryWithRevision(key, value, page.ValuePtr{}, node.FlagInline, page.EntryRevision(i+1))
+					} else {
+						mt.SetEntry(key, value, page.ValuePtr{}, node.FlagInline)
+					}
+				}
 			})
 		}
 	}

--- a/TreeDB/internal/merging/merging.go
+++ b/TreeDB/internal/merging/merging.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 
 	"github.com/snissn/gomap/TreeDB/internal/iterator"
+	"github.com/snissn/gomap/TreeDB/page"
 )
 
 // Iterator represents a generic iterator that yields key-value pairs.
@@ -238,6 +239,13 @@ func (mi *MergingIterator) Value() []byte {
 		return nil
 	}
 	return mi.cur.iter.UnsafeValue()
+}
+
+func (mi *MergingIterator) UnsafeEntryWithRevision() ([]byte, page.ValuePtr, byte, page.EntryRevision) {
+	if !mi.valid || !mi.hasCur {
+		return nil, page.ValuePtr{}, 0, page.LegacyEntryRevision
+	}
+	return iterator.UnsafeEntryWithRevision(mi.cur.iter)
 }
 
 func (mi *MergingIterator) KeyCopy(dst []byte) []byte {

--- a/TreeDB/internal/merging/merging_test.go
+++ b/TreeDB/internal/merging/merging_test.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/snissn/gomap/TreeDB/internal/iterator"
 	"github.com/snissn/gomap/TreeDB/page"
 )
 
@@ -52,6 +53,55 @@ func (m *mockUnsafeIter) Seek(key []byte) {
 	m.idx = len(m.data) // Exhausted
 }
 func (m *mockUnsafeIter) Domain() (start, end []byte) { return nil, nil }
+
+type revisionEntry struct {
+	k, v string
+	del  bool
+	rev  page.EntryRevision
+}
+
+type mockRevisionUnsafeIter struct {
+	data      []revisionEntry
+	idx       int
+	seekedKey []byte
+}
+
+func (m *mockRevisionUnsafeIter) Next()               { m.idx++ }
+func (m *mockRevisionUnsafeIter) Valid() bool         { return m.idx < len(m.data) }
+func (m *mockRevisionUnsafeIter) UnsafeKey() []byte   { return []byte(m.data[m.idx].k) }
+func (m *mockRevisionUnsafeIter) UnsafeValue() []byte { return []byte(m.data[m.idx].v) }
+func (m *mockRevisionUnsafeIter) UnsafeEntry() ([]byte, page.ValuePtr, byte) {
+	return m.UnsafeValue(), page.ValuePtr{}, 0
+}
+func (m *mockRevisionUnsafeIter) UnsafeEntryWithRevision() ([]byte, page.ValuePtr, byte, page.EntryRevision) {
+	return m.UnsafeValue(), page.ValuePtr{}, 0, m.data[m.idx].rev
+}
+func (m *mockRevisionUnsafeIter) Key() []byte   { return m.UnsafeKey() }
+func (m *mockRevisionUnsafeIter) Value() []byte { return m.UnsafeValue() }
+func (m *mockRevisionUnsafeIter) KeyCopy(dst []byte) []byte {
+	return append(dst[:0], m.UnsafeKey()...)
+}
+func (m *mockRevisionUnsafeIter) ValueCopy(dst []byte) []byte {
+	return append(dst[:0], m.UnsafeValue()...)
+}
+func (m *mockRevisionUnsafeIter) Error() error    { return nil }
+func (m *mockRevisionUnsafeIter) Close() error    { return nil }
+func (m *mockRevisionUnsafeIter) IsDeleted() bool { return m.data[m.idx].del }
+func (m *mockRevisionUnsafeIter) Seek(key []byte) {
+	m.seekedKey = key
+	if key == nil {
+		m.idx = 0
+		return
+	}
+	for i, e := range m.data {
+		if bytes.Compare([]byte(e.k), key) >= 0 {
+			m.idx = i
+			return
+		}
+	}
+	m.idx = len(m.data)
+}
+func (m *mockRevisionUnsafeIter) Domain() (start, end []byte) { return nil, nil }
 
 func TestTwoWayMerger(t *testing.T) {
 	// Mutable (src1, higher precedence): A:1, B:del, C:1, E:1
@@ -120,5 +170,108 @@ func TestTwoWayMerger(t *testing.T) {
 
 	if !reflect.DeepEqual(results2, expected2) {
 		t.Errorf("Merge results mismatch (domain).\nGot: %v\nWant:%v", results2, expected2)
+	}
+}
+
+func TestTwoWayMergerUnsafeEntryWithRevisionPreservesWinner(t *testing.T) {
+	mut := &mockRevisionUnsafeIter{
+		data: []revisionEntry{
+			{k: "A", v: "new", rev: 11},
+			{k: "B", v: "mut", rev: 12},
+		},
+	}
+	disk := &mockRevisionUnsafeIter{
+		data: []revisionEntry{
+			{k: "A", v: "old", rev: 7},
+			{k: "C", v: "disk", rev: 8},
+		},
+	}
+
+	merged := NewMergingIterator([]IteratorSource{
+		{Iter: mut, Priority: 0},
+		{Iter: disk, Priority: 1},
+	}, nil, nil)
+	defer merged.Close()
+
+	revIt, ok := merged.(iterator.RevisionUnsafeIterator)
+	if !ok {
+		t.Fatalf("merged iterator %T does not expose revisions", merged)
+	}
+	if !merged.Valid() || string(merged.Key()) != "A" {
+		if !merged.Valid() {
+			t.Fatal("merged iterator invalid, want first key A")
+		}
+		t.Fatalf("first key=%q, want A", merged.Key())
+	}
+	val, _, _, revision := revIt.UnsafeEntryWithRevision()
+	if string(val) != "new" || revision != 11 {
+		t.Fatalf("UnsafeEntryWithRevision=(%q,%d), want (new,11)", val, revision)
+	}
+
+	merged.Next()
+	if !merged.Valid() || string(merged.Key()) != "B" {
+		if !merged.Valid() {
+			t.Fatal("merged iterator invalid, want second key B")
+		}
+		t.Fatalf("second key=%q, want B", merged.Key())
+	}
+	val, _, _, revision = revIt.UnsafeEntryWithRevision()
+	if string(val) != "mut" || revision != 12 {
+		t.Fatalf("second UnsafeEntryWithRevision=(%q,%d), want (mut,12)", val, revision)
+	}
+}
+
+func TestHeapMergingIteratorUnsafeEntryWithRevisionPreservesWinner(t *testing.T) {
+	newest := &mockRevisionUnsafeIter{
+		data: []revisionEntry{
+			{k: "A", v: "new", rev: 31},
+			{k: "D", v: "new-d", rev: 34},
+		},
+	}
+	middle := &mockRevisionUnsafeIter{
+		data: []revisionEntry{
+			{k: "A", v: "middle", rev: 21},
+			{k: "B", v: "middle-b", rev: 22},
+		},
+	}
+	oldest := &mockRevisionUnsafeIter{
+		data: []revisionEntry{
+			{k: "A", v: "old", rev: 11},
+			{k: "C", v: "old-c", rev: 13},
+		},
+	}
+
+	merged := NewMergingIterator([]IteratorSource{
+		{Iter: newest, Priority: 0},
+		{Iter: middle, Priority: 1},
+		{Iter: oldest, Priority: 2},
+	}, nil, nil)
+	defer merged.Close()
+
+	revIt, ok := merged.(iterator.RevisionUnsafeIterator)
+	if !ok {
+		t.Fatalf("merged iterator %T does not expose revisions", merged)
+	}
+	if !merged.Valid() || string(merged.Key()) != "A" {
+		if !merged.Valid() {
+			t.Fatal("merged iterator invalid, want first key A")
+		}
+		t.Fatalf("first key=%q, want A", merged.Key())
+	}
+	val, _, _, revision := revIt.UnsafeEntryWithRevision()
+	if string(val) != "new" || revision != 31 {
+		t.Fatalf("UnsafeEntryWithRevision=(%q,%d), want (new,31)", val, revision)
+	}
+
+	merged.Next()
+	if !merged.Valid() || string(merged.Key()) != "B" {
+		if !merged.Valid() {
+			t.Fatal("merged iterator invalid, want second key B")
+		}
+		t.Fatalf("second key=%q, want B", merged.Key())
+	}
+	val, _, _, revision = revIt.UnsafeEntryWithRevision()
+	if string(val) != "middle-b" || revision != 22 {
+		t.Fatalf("second UnsafeEntryWithRevision=(%q,%d), want (middle-b,22)", val, revision)
 	}
 }

--- a/TreeDB/internal/merging/twoway.go
+++ b/TreeDB/internal/merging/twoway.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 
 	"github.com/snissn/gomap/TreeDB/internal/iterator"
+	"github.com/snissn/gomap/TreeDB/page"
 )
 
 // TwoWayMerger implements MergingIterator for two sources (Memtable and Disk).
@@ -115,6 +116,13 @@ func (m *TwoWayMerger) Value() []byte {
 		return nil
 	}
 	return m.cur.UnsafeValue()
+}
+
+func (m *TwoWayMerger) UnsafeEntryWithRevision() ([]byte, page.ValuePtr, byte, page.EntryRevision) {
+	if !m.valid || m.cur == nil {
+		return nil, page.ValuePtr{}, 0, page.LegacyEntryRevision
+	}
+	return iterator.UnsafeEntryWithRevision(m.cur)
 }
 
 func (m *TwoWayMerger) KeyCopy(dst []byte) []byte {

--- a/TreeDB/internal/skiplist/skiplist.go
+++ b/TreeDB/internal/skiplist/skiplist.go
@@ -13,11 +13,12 @@ import (
 const (
 	maxHeight = 20
 
-	nodeHeightOff  = 0
-	nodeKeyLenOff  = 1
-	nodeValLenOff  = 3
-	nodeFlagsOff   = 7
-	nodeHeaderBase = 8 // Height + KeyLen + ValLen + Flags
+	nodeHeightOff   = 0
+	nodeKeyLenOff   = 1
+	nodeValLenOff   = 3
+	nodeFlagsOff    = 7
+	nodeRevisionOff = 8
+	nodeHeaderBase  = 16 // Height + KeyLen + ValLen + Flags + Revision
 
 	flagPointer = node.FlagPointer
 	flagDeleted = node.FlagTombstone
@@ -288,6 +289,14 @@ func (s *SkipList) setFlags(node uint32, f uint8) {
 	s.setValAt(node, nodeFlagsOff, f)
 }
 
+func (s *SkipList) getRevision(node uint32) page.EntryRevision {
+	return page.EntryRevision(binary.LittleEndian.Uint64(s.bytesAt(node+nodeRevisionOff, page.EntryRevisionSize)))
+}
+
+func (s *SkipList) setRevision(node uint32, revision page.EntryRevision) {
+	binary.LittleEndian.PutUint64(s.bytesAt(node+nodeRevisionOff, page.EntryRevisionSize), uint64(revision))
+}
+
 func (s *SkipList) getNext(node uint32, level int) uint32 {
 	offset := node + uint32(nodeHeaderBase) + uint32(4*level)
 	return binary.LittleEndian.Uint32(s.bytesAt(offset, 4))
@@ -302,36 +311,42 @@ func (s *SkipList) setNext(node uint32, level int, next uint32) {
 
 // Put inserts or updates a key.
 func (s *SkipList) Put(key, value []byte) {
-	s.put(key, value, 0, nil)
+	s.put(key, value, 0, page.LegacyEntryRevision, nil)
 }
 
 // PutWithCallback inserts key/value, calling cb with views into the arena before linking.
 func (s *SkipList) PutWithCallback(key, value []byte, cb func(k, v []byte) error) error {
-	return s.put(key, value, 0, cb)
+	return s.put(key, value, 0, page.LegacyEntryRevision, cb)
 }
 
 // PutEntry inserts key/value with explicit flags and optional value pointer.
 // When flags include FlagPointer, ptr is encoded into the value area; if value is
 // non-nil, it is appended after the pointer bytes.
 func (s *SkipList) PutEntry(key, value []byte, ptr page.ValuePtr, flags byte) {
+	s.PutEntryWithRevision(key, value, ptr, flags, page.LegacyEntryRevision)
+}
+
+// PutEntryWithRevision inserts key/value with explicit flags, pointer metadata,
+// and native entry revision.
+func (s *SkipList) PutEntryWithRevision(key, value []byte, ptr page.ValuePtr, flags byte, revision page.EntryRevision) {
 	if flags&flagPointer != 0 {
 		if len(value) > 0 {
 			buf := make([]byte, page.ValuePtrSize+len(value))
 			ptr.Encode(buf[:page.ValuePtrSize])
 			copy(buf[page.ValuePtrSize:], value)
-			_ = s.put(key, buf, flags, nil)
+			_ = s.put(key, buf, flags, revision, nil)
 			return
 		}
 		var buf [page.ValuePtrSize]byte
 		ptr.Encode(buf[:])
-		_ = s.put(key, buf[:], flags, nil)
+		_ = s.put(key, buf[:], flags, revision, nil)
 		return
 	}
 	if flags&flagDeleted != 0 {
-		_ = s.put(key, nil, flags, nil)
+		_ = s.put(key, nil, flags, revision, nil)
 		return
 	}
-	_ = s.put(key, value, flags, nil)
+	_ = s.put(key, value, flags, revision, nil)
 }
 
 // LastKey returns the largest key currently in the skiplist, or nil if empty.
@@ -346,11 +361,17 @@ func (s *SkipList) LastKey() []byte {
 // AppendWithCallback inserts a new entry assuming the key is strictly greater
 // than the current maximum key in the skiplist.
 func (s *SkipList) AppendWithCallback(key, value []byte, flags uint8, cb func(k, v []byte) error) error {
+	return s.AppendWithCallbackRevision(key, value, flags, page.LegacyEntryRevision, cb)
+}
+
+// AppendWithCallbackRevision inserts a new strictly-increasing entry with a
+// native revision token.
+func (s *SkipList) AppendWithCallbackRevision(key, value []byte, flags uint8, revision page.EntryRevision, cb func(k, v []byte) error) error {
 	var prev [maxHeight]uint32
 	for i := 0; i < maxHeight; i++ {
 		prev[i] = s.tail[i]
 	}
-	return s.insertNew(key, value, flags, cb, &prev)
+	return s.insertNew(key, value, flags, revision, cb, &prev)
 }
 
 // Append inserts a new key/value entry assuming the key is strictly greater
@@ -362,20 +383,25 @@ func (s *SkipList) Append(key, value []byte) {
 // AppendDelete inserts a tombstone for key assuming the key is strictly greater
 // than the current maximum key in the skiplist.
 func (s *SkipList) AppendDelete(key []byte) {
-	_ = s.AppendWithCallback(key, nil, flagDeleted, nil)
+	_ = s.AppendDeleteWithRevision(key, page.LegacyEntryRevision)
+}
+
+// AppendDeleteWithRevision appends a tombstone with a native revision token.
+func (s *SkipList) AppendDeleteWithRevision(key []byte, revision page.EntryRevision) error {
+	return s.AppendWithCallbackRevision(key, nil, flagDeleted, revision, nil)
 }
 
 // Delete marks a key as deleted (tombstone).
 func (s *SkipList) Delete(key []byte) {
-	s.put(key, nil, flagDeleted, nil)
+	s.put(key, nil, flagDeleted, page.LegacyEntryRevision, nil)
 }
 
 // DeleteWithCallback marks deleted with callback.
 func (s *SkipList) DeleteWithCallback(key []byte, cb func(k, v []byte) error) error {
-	return s.put(key, nil, flagDeleted, cb)
+	return s.put(key, nil, flagDeleted, page.LegacyEntryRevision, cb)
 }
 
-func (s *SkipList) insertNew(key, value []byte, flags uint8, cb func(k, v []byte) error, prev *[maxHeight]uint32) error {
+func (s *SkipList) insertNew(key, value []byte, flags uint8, revision page.EntryRevision, cb func(k, v []byte) error, prev *[maxHeight]uint32) error {
 	h := s.randomHeight()
 	if h > s.height {
 		s.height = h
@@ -384,6 +410,7 @@ func (s *SkipList) insertNew(key, value []byte, flags uint8, cb func(k, v []byte
 	copy(s.getKey(newNode), key)
 	copy(s.getValue(newNode), value)
 	s.setFlags(newNode, flags)
+	s.setRevision(newNode, revision)
 
 	// Callback (Before linking)
 	if cb != nil {
@@ -408,13 +435,13 @@ func (s *SkipList) insertNew(key, value []byte, flags uint8, cb func(k, v []byte
 	return nil
 }
 
-func (s *SkipList) put(key, value []byte, flags uint8, cb func(k, v []byte) error) error {
+func (s *SkipList) put(key, value []byte, flags uint8, revision page.EntryRevision, cb func(k, v []byte) error) error {
 	if s.count == 0 {
 		var prev [maxHeight]uint32
 		for i := 0; i < maxHeight; i++ {
 			prev[i] = s.tail[i]
 		}
-		return s.insertNew(key, value, flags, cb, &prev)
+		return s.insertNew(key, value, flags, revision, cb, &prev)
 	}
 
 	last := s.tail[0]
@@ -424,7 +451,7 @@ func (s *SkipList) put(key, value []byte, flags uint8, cb func(k, v []byte) erro
 			for i := 0; i < maxHeight; i++ {
 				prev[i] = s.tail[i]
 			}
-			return s.insertNew(key, value, flags, cb, &prev)
+			return s.insertNew(key, value, flags, revision, cb, &prev)
 		}
 	}
 
@@ -476,7 +503,7 @@ func (s *SkipList) put(key, value []byte, flags uint8, cb func(k, v []byte) erro
 		// Now OldNode is gone.
 	}
 
-	return s.insertNew(key, value, flags, cb, &prev)
+	return s.insertNew(key, value, flags, revision, cb, &prev)
 }
 
 func (s *SkipList) randomHeight() int {
@@ -520,6 +547,12 @@ func (s *SkipList) Get(key []byte) ([]byte, bool, bool) {
 
 // GetEntry returns the raw entry, including pointer and flags, if present.
 func (s *SkipList) GetEntry(key []byte) ([]byte, page.ValuePtr, byte, bool) {
+	val, ptr, flags, _, found := s.GetEntryWithRevision(key)
+	return val, ptr, flags, found
+}
+
+// GetEntryWithRevision returns the raw entry plus native revision metadata.
+func (s *SkipList) GetEntryWithRevision(key []byte) ([]byte, page.ValuePtr, byte, page.EntryRevision, bool) {
 	x := s.head
 	for i := maxHeight - 1; i >= 0; i-- {
 		for {
@@ -534,6 +567,7 @@ func (s *SkipList) GetEntry(key []byte) ([]byte, page.ValuePtr, byte, bool) {
 			}
 			if cmp == 0 {
 				flags := s.getFlags(next)
+				revision := s.getRevision(next)
 				val := s.getValue(next)
 				if flags&flagPointer != 0 {
 					if len(val) >= page.ValuePtrSize {
@@ -541,16 +575,16 @@ func (s *SkipList) GetEntry(key []byte) ([]byte, page.ValuePtr, byte, bool) {
 						if len(val) > page.ValuePtrSize {
 							inline = val[page.ValuePtrSize:]
 						}
-						return inline, page.DecodeValuePtr(val[:page.ValuePtrSize]), flags, true
+						return inline, page.DecodeValuePtr(val[:page.ValuePtrSize]), flags, revision, true
 					}
-					return nil, page.ValuePtr{}, flags, true
+					return nil, page.ValuePtr{}, flags, revision, true
 				}
-				return val, page.ValuePtr{}, flags, true
+				return val, page.ValuePtr{}, flags, revision, true
 			}
 			x = next
 		}
 	}
-	return nil, page.ValuePtr{}, 0, false
+	return nil, page.ValuePtr{}, 0, page.LegacyEntryRevision, false
 }
 
 func (s *SkipList) Size() int64 {
@@ -669,19 +703,26 @@ func (it *Iterator) UnsafeValue() []byte {
 }
 
 func (it *Iterator) UnsafeEntry() ([]byte, page.ValuePtr, byte) {
+	val, ptr, flags, _ := it.UnsafeEntryWithRevision()
+	return val, ptr, flags
+}
+
+// UnsafeEntryWithRevision returns raw entry details plus native revision.
+func (it *Iterator) UnsafeEntryWithRevision() ([]byte, page.ValuePtr, byte, page.EntryRevision) {
 	val := it.sl.getValue(it.curr)
 	flags := it.sl.getFlags(it.curr)
+	revision := it.sl.getRevision(it.curr)
 	if flags&flagPointer != 0 {
 		if len(val) >= page.ValuePtrSize {
 			inline := []byte(nil)
 			if len(val) > page.ValuePtrSize {
 				inline = val[page.ValuePtrSize:]
 			}
-			return inline, page.DecodeValuePtr(val[:page.ValuePtrSize]), flags
+			return inline, page.DecodeValuePtr(val[:page.ValuePtrSize]), flags, revision
 		}
-		return nil, page.ValuePtr{}, flags
+		return nil, page.ValuePtr{}, flags, revision
 	}
-	return val, page.ValuePtr{}, flags
+	return val, page.ValuePtr{}, flags, revision
 }
 
 func (it *Iterator) IsDeleted() bool {
@@ -806,22 +847,29 @@ func (it *ReverseIterator) UnsafeValue() []byte {
 }
 
 func (it *ReverseIterator) UnsafeEntry() ([]byte, page.ValuePtr, byte) {
+	val, ptr, flags, _ := it.UnsafeEntryWithRevision()
+	return val, ptr, flags
+}
+
+// UnsafeEntryWithRevision returns raw entry details plus native revision.
+func (it *ReverseIterator) UnsafeEntryWithRevision() ([]byte, page.ValuePtr, byte, page.EntryRevision) {
 	if !it.valid || it.curr == 0 {
-		return nil, page.ValuePtr{}, 0
+		return nil, page.ValuePtr{}, 0, page.LegacyEntryRevision
 	}
 	val := it.sl.getValue(it.curr)
 	flags := it.sl.getFlags(it.curr)
+	revision := it.sl.getRevision(it.curr)
 	if flags&flagPointer != 0 {
 		if len(val) >= page.ValuePtrSize {
 			inline := []byte(nil)
 			if len(val) > page.ValuePtrSize {
 				inline = val[page.ValuePtrSize:]
 			}
-			return inline, page.DecodeValuePtr(val[:page.ValuePtrSize]), flags
+			return inline, page.DecodeValuePtr(val[:page.ValuePtrSize]), flags, revision
 		}
-		return nil, page.ValuePtr{}, flags
+		return nil, page.ValuePtr{}, flags, revision
 	}
-	return val, page.ValuePtr{}, flags
+	return val, page.ValuePtr{}, flags, revision
 }
 
 func (it *ReverseIterator) IsDeleted() bool {

--- a/TreeDB/node/builder.go
+++ b/TreeDB/node/builder.go
@@ -24,6 +24,7 @@ type Builder struct {
 	leafColumnar          bool
 	leafColumnarV2        bool
 	leafPackedValuePtr    bool
+	leafEntryRevisions    bool
 	internalBaseDelta     bool
 	internalLeafLogRefs   bool
 	internalBaseChildID   uint64
@@ -142,6 +143,7 @@ type BuilderOptions struct {
 	LeafColumnar          bool
 	InternalBaseDelta     bool
 	PackedValuePtr        bool
+	EntryRevisions        bool
 }
 
 // LeafHeuristicEntry describes one logical leaf entry for adaptive encoding
@@ -249,6 +251,7 @@ type leafColumnarV2Entry struct {
 	valueLen uint16
 	valPtr   page.ValuePtr
 	flags    byte
+	revision page.EntryRevision
 }
 
 type leafColumnarPrefixV2Entry struct {
@@ -259,6 +262,7 @@ type leafColumnarPrefixV2Entry struct {
 	valPtr    page.ValuePtr
 	flags     byte
 	prefixLen uint16
+	revision  page.EntryRevision
 }
 
 type internalBaseDeltaEntry struct {
@@ -294,6 +298,7 @@ func (b *Builder) ResetWithOptions(data []byte, pType page.PageType, opts Builde
 		leafColumnar:          opts.LeafColumnar,
 		leafColumnarV2:        leafColumnarV2,
 		leafPackedValuePtr:    opts.PackedValuePtr,
+		leafEntryRevisions:    pType == page.PageTypeLeaf && opts.EntryRevisions,
 		internalBaseDelta:     opts.InternalBaseDelta,
 	}
 	if pType == page.PageTypeLeaf && opts.LeafColumnar {
@@ -364,6 +369,12 @@ func (b *Builder) Count() uint16 {
 	return b.count
 }
 
+// LeafEntryRevisionsEnabled reports whether this leaf builder will encode
+// native per-entry revision metadata.
+func (b *Builder) LeafEntryRevisionsEnabled() bool {
+	return b != nil && b.pType == page.PageTypeLeaf && b.leafEntryRevisions
+}
+
 // SetInternalFenceBounds configures exact subtree bounds for internal pages.
 // low is inclusive and high is exclusive; nil high means unbounded.
 func (b *Builder) SetInternalFenceBounds(low, high []byte) {
@@ -411,6 +422,17 @@ func (b *Builder) LeafEntrySizeWithPrefix(key, value []byte, flags byte) (entryS
 	return b.leafEntrySize(key, value, flags)
 }
 
+// LeafEntrySizeWithRevision returns the encoded size for a revision-bearing
+// leaf entry. Callers that use this must build the page with EntryRevisions.
+func (b *Builder) LeafEntrySizeWithRevision(key, value []byte, flags byte, revision page.EntryRevision) int {
+	_ = revision
+	entrySize, _, _ := b.leafEntrySize(key, value, flags)
+	if !b.leafEntryRevisions {
+		entrySize += page.EntryRevisionSize
+	}
+	return entrySize
+}
+
 func (b *Builder) leafEntrySize(key, value []byte, flags byte) (entrySize int, prefixLen int, suffixLen int) {
 	valPtrSize := page.ValuePtrSize
 	if b.leafPackedValuePtr {
@@ -433,6 +455,9 @@ func (b *Builder) leafEntrySize(key, value []byte, flags byte) (entrySize int, p
 			valSize = len(value)
 		}
 		entrySize = suffixLen + valSize + leafColumnarPrefixV2MetaSize
+		if b.leafEntryRevisions {
+			entrySize += page.EntryRevisionSize
+		}
 		return entrySize, prefixLen, suffixLen
 	}
 	if b.leafColumnar && !b.leafPrefixCompression {
@@ -447,6 +472,9 @@ func (b *Builder) leafEntrySize(key, value []byte, flags byte) (entrySize int, p
 		// Columnar v2 stores key/value bytes in separate blobs and writes
 		// per-entry metadata (val offset + flags) in a columnar header region.
 		entrySize = suffixLen + valSize + leafColumnarV2MetaSize
+		if b.leafEntryRevisions {
+			entrySize += page.EntryRevisionSize
+		}
 		return entrySize, prefixLen, suffixLen
 	}
 	prefixLen = 0
@@ -482,28 +510,53 @@ func (b *Builder) leafEntrySize(key, value []byte, flags byte) (entrySize int, p
 	}
 
 	entrySize = headerSize + suffixLen + valSize
+	if b.leafEntryRevisions {
+		entrySize += page.EntryRevisionSize
+	}
 	return entrySize, prefixLen, suffixLen
 }
 
 // AddLeafEntry appends a leaf entry. Assumes keys are added in sorted order.
 func (b *Builder) AddLeafEntry(key, value []byte, flags byte, valPtr page.ValuePtr) error {
+	return b.AddLeafEntryWithRevision(key, value, flags, valPtr, page.LegacyEntryRevision)
+}
+
+// AddLeafEntryWithRevision appends a native revision-bearing leaf entry.
+func (b *Builder) AddLeafEntryWithRevision(key, value []byte, flags byte, valPtr page.ValuePtr, revision page.EntryRevision) error {
 	if b.pType != page.PageTypeLeaf {
 		return ErrInvalidType
 	}
+	if err := b.requireLeafEntryRevisions(revision); err != nil {
+		return err
+	}
 	if b.leafColumnar && !b.leafPrefixCompression {
 		if b.leafColumnarV2 {
-			return b.addLeafEntryColumnarV2(key, value, flags, valPtr)
+			return b.addLeafEntryColumnarV2(key, value, flags, valPtr, revision)
 		}
-		return b.addLeafEntryColumnar(key, value, flags, valPtr)
+		return b.addLeafEntryColumnar(key, value, flags, valPtr, revision)
 	}
 
 	// 1. Calculate Entry Size
 	// KeyPrefixLen(2) + KeySuffixLen(2) + ValLen(4) + Flags(1) + KeySuffix + Value/Ptr
 	entrySize, prefixLen, suffixLen := b.leafEntrySize(key, value, flags)
-	return b.AddLeafEntryWithPrefix(key, value, flags, valPtr, entrySize, prefixLen, suffixLen)
+	return b.AddLeafEntryWithPrefixRevision(key, value, flags, valPtr, revision, entrySize, prefixLen, suffixLen)
 }
 
-func (b *Builder) addLeafEntryColumnar(key, value []byte, flags byte, valPtr page.ValuePtr) error {
+func (b *Builder) requireLeafEntryRevisions(revision page.EntryRevision) error {
+	if revision == page.LegacyEntryRevision || b.leafEntryRevisions {
+		return nil
+	}
+	if b.pType == page.PageTypeLeaf && b.count == 0 {
+		b.leafEntryRevisions = true
+		return nil
+	}
+	if b.pType == page.PageTypeLeaf {
+		return ErrNodeFull
+	}
+	return ErrInvalidType
+}
+
+func (b *Builder) addLeafEntryColumnar(key, value []byte, flags byte, valPtr page.ValuePtr, revision page.EntryRevision) error {
 	valPtrSize := page.ValuePtrSize
 	if b.leafPackedValuePtr {
 		valPtrSize = page.PackedValuePtrSize
@@ -518,6 +571,9 @@ func (b *Builder) addLeafEntryColumnar(key, value []byte, flags byte, valPtr pag
 		valLen = len(value)
 		valSize = valLen
 		entrySize += valSize
+	}
+	if b.leafEntryRevisions {
+		entrySize += page.EntryRevisionSize
 	}
 
 	required := entrySize + DirectoryEntrySize
@@ -542,6 +598,10 @@ func (b *Builder) addLeafEntryColumnar(key, value []byte, flags byte, valPtr pag
 
 	keyStart := valueStart + valSize
 	copy(b.data[keyStart:keyStart+len(key)], key)
+	if b.leafEntryRevisions {
+		revisionStart := keyStart + len(key)
+		binary.LittleEndian.PutUint64(b.data[revisionStart:revisionStart+page.EntryRevisionSize], uint64(revision))
+	}
 
 	b.data[b.dirEnd] = byte(entryStart)
 	b.data[b.dirEnd+1] = byte(entryStart >> 8)
@@ -553,7 +613,7 @@ func (b *Builder) addLeafEntryColumnar(key, value []byte, flags byte, valPtr pag
 	return nil
 }
 
-func (b *Builder) addLeafEntryColumnarV2(key, value []byte, flags byte, valPtr page.ValuePtr) error {
+func (b *Builder) addLeafEntryColumnarV2(key, value []byte, flags byte, valPtr page.ValuePtr, revision page.EntryRevision) error {
 	valPtrSize := page.ValuePtrSize
 	if b.leafPackedValuePtr {
 		valPtrSize = page.PackedValuePtrSize
@@ -567,6 +627,9 @@ func (b *Builder) addLeafEntryColumnarV2(key, value []byte, flags byte, valPtr p
 	}
 
 	entrySize := leafColumnarV2MetaSize + len(key) + valSize
+	if b.leafEntryRevisions {
+		entrySize += page.EntryRevisionSize
+	}
 	required := entrySize + DirectoryEntrySize // key offset slot
 	freeSpace := b.heapStart - b.dirEnd
 	if freeSpace < required {
@@ -586,18 +649,22 @@ func (b *Builder) addLeafEntryColumnarV2(key, value []byte, flags byte, valPtr p
 		valueLen: valueLen,
 		valPtr:   valPtr,
 		flags:    flags,
+		revision: revision,
 	})
 	b.leafColumnarV2KeyBytes += len(key)
 	b.leafColumnarV2ValBytes += valSize
 
 	b.dirEnd += DirectoryEntrySize + leafColumnarV2MetaSize
+	if b.leafEntryRevisions {
+		b.dirEnd += page.EntryRevisionSize
+	}
 	b.heapStart -= len(key) + valSize
 	b.count++
 	b.leafIndex++
 	return nil
 }
 
-func (b *Builder) addLeafEntryColumnarPrefixV2(key, value []byte, flags byte, valPtr page.ValuePtr, entrySize, prefixLen, suffixLen int) error {
+func (b *Builder) addLeafEntryColumnarPrefixV2(key, value []byte, flags byte, valPtr page.ValuePtr, revision page.EntryRevision, entrySize, prefixLen, suffixLen int) error {
 	valPtrSize := page.ValuePtrSize
 	if b.leafPackedValuePtr {
 		valPtrSize = page.PackedValuePtrSize
@@ -626,6 +693,9 @@ func (b *Builder) addLeafEntryColumnarPrefixV2(key, value []byte, flags byte, va
 	nextKeyBytes := b.leafColumnarPrefixV2KeyBytes + suffixLen
 	nextValBytes := b.leafColumnarPrefixV2ValBytes + valSize
 	dirEnd := NodeHeaderSize + nextCount*leafColumnarPrefixV2MetaSize
+	if b.leafEntryRevisions {
+		dirEnd += nextCount * page.EntryRevisionSize
+	}
 	heapStart := len(b.data) - (nextKeyBytes + nextValBytes)
 	if heapStart < dirEnd {
 		return ErrNodeFull
@@ -650,6 +720,7 @@ func (b *Builder) addLeafEntryColumnarPrefixV2(key, value []byte, flags byte, va
 		valPtr:    valPtr,
 		flags:     flags,
 		prefixLen: uint16(prefixLen),
+		revision:  revision,
 	})
 	b.leafColumnarPrefixV2KeyBytes = nextKeyBytes
 	b.leafColumnarPrefixV2ValBytes = nextValBytes
@@ -673,18 +744,27 @@ func (b *Builder) addLeafEntryColumnarPrefixV2(key, value []byte, flags byte, va
 // AddLeafEntryWithPrefix appends a leaf entry using precomputed size/prefix data.
 // The caller must ensure prefixLen/suffixLen are computed for this builder state.
 func (b *Builder) AddLeafEntryWithPrefix(key, value []byte, flags byte, valPtr page.ValuePtr, entrySize, prefixLen, suffixLen int) error {
+	return b.AddLeafEntryWithPrefixRevision(key, value, flags, valPtr, page.LegacyEntryRevision, entrySize, prefixLen, suffixLen)
+}
+
+// AddLeafEntryWithPrefixRevision appends a native revision-bearing leaf entry
+// using precomputed size/prefix data.
+func (b *Builder) AddLeafEntryWithPrefixRevision(key, value []byte, flags byte, valPtr page.ValuePtr, revision page.EntryRevision, entrySize, prefixLen, suffixLen int) error {
 	if b.pType != page.PageTypeLeaf {
 		return ErrInvalidType
+	}
+	if err := b.requireLeafEntryRevisions(revision); err != nil {
+		return err
 	}
 
 	if b.leafColumnar {
 		if b.leafPrefixCompression {
-			return b.addLeafEntryColumnarPrefixV2(key, value, flags, valPtr, entrySize, prefixLen, suffixLen)
+			return b.addLeafEntryColumnarPrefixV2(key, value, flags, valPtr, revision, entrySize, prefixLen, suffixLen)
 		}
 		if b.leafColumnarV2 {
-			return b.addLeafEntryColumnarV2(key, value, flags, valPtr)
+			return b.addLeafEntryColumnarV2(key, value, flags, valPtr, revision)
 		}
-		return b.addLeafEntryColumnar(key, value, flags, valPtr)
+		return b.addLeafEntryColumnar(key, value, flags, valPtr, revision)
 	}
 
 	headerSize := 7
@@ -772,6 +852,20 @@ func (b *Builder) AddLeafEntryWithPrefix(key, value []byte, flags byte, valPtr p
 		}
 	} else {
 		copy(b.data[valueStart:valueStart+len(value)], value)
+	}
+	if b.leafEntryRevisions {
+		valSize := 0
+		if flags&FlagPointer != 0 {
+			if b.leafPackedValuePtr {
+				valSize = page.PackedValuePtrSize
+			} else {
+				valSize = page.ValuePtrSize
+			}
+		} else if flags&FlagTombstone == 0 {
+			valSize = len(value)
+		}
+		revisionStart := valueStart + valSize
+		binary.LittleEndian.PutUint64(b.data[revisionStart:revisionStart+page.EntryRevisionSize], uint64(revision))
 	}
 
 	// 5. Write Directory Offset (Grow Up)
@@ -962,6 +1056,9 @@ func (b *Builder) finalize() {
 		if b.leafPackedValuePtr {
 			flags |= leafPackedValuePtrFlag
 		}
+		if b.leafEntryRevisions {
+			flags |= leafEntryRevisionFlag
+		}
 	} else if b.pType == page.PageTypeInternal {
 		if b.internalLeafLogRefs {
 			flags |= internalLeafLogRefsFlag
@@ -1015,7 +1112,11 @@ func (b *Builder) finishLeafColumnarV2() {
 	keyDirStart := NodeHeaderSize
 	valDirStart := keyDirStart + count*DirectoryEntrySize
 	flagsStart := valDirStart + count*DirectoryEntrySize
-	metaEnd := flagsStart + count
+	revisionsStart := flagsStart + count
+	metaEnd := revisionsStart
+	if b.leafEntryRevisions {
+		metaEnd += count * page.EntryRevisionSize
+	}
 
 	keysStart := len(b.data) - b.leafColumnarV2KeyBytes
 	valuesStart := keysStart - b.leafColumnarV2ValBytes
@@ -1033,6 +1134,9 @@ func (b *Builder) finishLeafColumnarV2() {
 		putUint16At(b.data, keyDirPos, uint16(keyOff))
 		putUint16At(b.data, valDirPos, uint16(valOff))
 		b.data[flagsStart+i] = e.flags
+		if b.leafEntryRevisions {
+			binary.LittleEndian.PutUint64(b.data[revisionsStart+i*page.EntryRevisionSize:], uint64(e.revision))
+		}
 
 		if e.flags&FlagPointer != 0 {
 			if b.leafPackedValuePtr {
@@ -1082,7 +1186,11 @@ func (b *Builder) finishLeafColumnarPrefixV2() {
 	valDirStart := keyDirStart + count*DirectoryEntrySize
 	flagsStart := valDirStart + count*DirectoryEntrySize
 	prefixStart := flagsStart + count
-	metaEnd := prefixStart + count*DirectoryEntrySize
+	revisionsStart := prefixStart + count*DirectoryEntrySize
+	metaEnd := revisionsStart
+	if b.leafEntryRevisions {
+		metaEnd += count * page.EntryRevisionSize
+	}
 
 	suffixStart := len(b.data) - b.leafColumnarPrefixV2KeyBytes
 	valuesStart := suffixStart - b.leafColumnarPrefixV2ValBytes
@@ -1096,7 +1204,12 @@ func (b *Builder) finishLeafColumnarPrefixV2() {
 	allInline := b.leafColumnarPrefixV2AllInline
 	allPointer := b.leafColumnarPrefixV2AllPointer
 	flagsCol := b.data[flagsStart:prefixStart]
-	prefixCol := b.data[prefixStart:metaEnd]
+	prefixCol := b.data[prefixStart:revisionsStart]
+	writeRevision := func(i int, revision page.EntryRevision) {
+		if b.leafEntryRevisions {
+			binary.LittleEndian.PutUint64(b.data[revisionsStart+i*page.EntryRevisionSize:], uint64(revision))
+		}
+	}
 
 	if allInline {
 		if len(valueArena) != b.leafColumnarPrefixV2ValBytes || len(suffixArena) != b.leafColumnarPrefixV2KeyBytes {
@@ -1116,6 +1229,7 @@ func (b *Builder) finishLeafColumnarPrefixV2() {
 					valDirU16[i] = uint16(valuesStart + int(e.valueOff))
 					flagsCol[i] = e.flags
 					prefixDirU16[i] = e.prefixLen
+					writeRevision(i, e.revision)
 				}
 			} else {
 				for i := 0; i < count; i++ {
@@ -1124,6 +1238,7 @@ func (b *Builder) finishLeafColumnarPrefixV2() {
 					valDirU16[i] = uint16(valuesStart + int(e.valueOff))
 					flagsCol[i] = e.flags
 					putUint16At(prefixCol, i*2, e.prefixLen)
+					writeRevision(i, e.revision)
 				}
 			}
 		} else {
@@ -1133,6 +1248,7 @@ func (b *Builder) finishLeafColumnarPrefixV2() {
 				putUint16At(b.data, valDirStart+i*2, uint16(valuesStart+int(e.valueOff)))
 				flagsCol[i] = e.flags
 				putUint16At(b.data, prefixStart+i*2, e.prefixLen)
+				writeRevision(i, e.revision)
 			}
 		}
 
@@ -1160,6 +1276,7 @@ func (b *Builder) finishLeafColumnarPrefixV2() {
 					valDirU16[i] = uint16(valOff)
 					flagsCol[i] = e.flags
 					prefixDirU16[i] = e.prefixLen
+					writeRevision(i, e.revision)
 					if b.leafPackedValuePtr {
 						encodePackedValuePtrAt(b.data, valOff, e.valPtr)
 					} else {
@@ -1174,6 +1291,7 @@ func (b *Builder) finishLeafColumnarPrefixV2() {
 					valDirU16[i] = uint16(valOff)
 					flagsCol[i] = e.flags
 					putUint16At(prefixCol, i*2, e.prefixLen)
+					writeRevision(i, e.revision)
 					if b.leafPackedValuePtr {
 						encodePackedValuePtrAt(b.data, valOff, e.valPtr)
 					} else {
@@ -1189,6 +1307,7 @@ func (b *Builder) finishLeafColumnarPrefixV2() {
 				putUint16At(b.data, valDirStart+i*2, uint16(valOff))
 				flagsCol[i] = e.flags
 				putUint16At(b.data, prefixStart+i*2, e.prefixLen)
+				writeRevision(i, e.revision)
 				if b.leafPackedValuePtr {
 					encodePackedValuePtrAt(b.data, valOff, e.valPtr)
 				} else {
@@ -1223,6 +1342,7 @@ func (b *Builder) finishLeafColumnarPrefixV2() {
 				valDirU16[i] = uint16(valOff)
 				flagsCol[i] = e.flags
 				prefixDirU16[i] = e.prefixLen
+				writeRevision(i, e.revision)
 
 				if e.flags&FlagPointer != 0 {
 					if b.leafPackedValuePtr {
@@ -1250,6 +1370,7 @@ func (b *Builder) finishLeafColumnarPrefixV2() {
 				valDirU16[i] = uint16(valOff)
 				flagsCol[i] = e.flags
 				putUint16At(prefixCol, i*2, e.prefixLen)
+				writeRevision(i, e.revision)
 
 				if e.flags&FlagPointer != 0 {
 					if b.leafPackedValuePtr {
@@ -1281,6 +1402,7 @@ func (b *Builder) finishLeafColumnarPrefixV2() {
 			putUint16At(b.data, valDirPos, uint16(valOff))
 			flagsCol[i] = e.flags
 			putUint16At(b.data, prefixPos, e.prefixLen)
+			writeRevision(i, e.revision)
 
 			if e.flags&FlagPointer != 0 {
 				if b.leafPackedValuePtr {

--- a/TreeDB/node/compact.go
+++ b/TreeDB/node/compact.go
@@ -26,15 +26,16 @@ func (n *Node) Compact() error {
 		b := NewBuilderWithOptions(buf, page.PageTypeLeaf, BuilderOptions{
 			LeafColumnar:   true,
 			PackedValuePtr: n.leafPackedValuePtr(),
+			EntryRevisions: n.leafEntryRevisions(),
 		})
 		b.SetPageID(n.PageID())
 
 		for i := uint16(0); i < count; i++ {
-			k, v, ptr, f, err := n.GetLeafEntryView(i)
+			k, v, ptr, f, rev, err := n.GetLeafEntryViewWithRevision(i)
 			if err != nil {
 				return err
 			}
-			if err := b.AddLeafEntry(k, v, f, ptr); err != nil {
+			if err := b.AddLeafEntryWithRevision(k, v, f, ptr, rev); err != nil {
 				return err
 			}
 		}
@@ -51,15 +52,16 @@ func (n *Node) Compact() error {
 			LeafPrefixCompression: true,
 			LeafColumnar:          true,
 			PackedValuePtr:        n.leafPackedValuePtr(),
+			EntryRevisions:        n.leafEntryRevisions(),
 		})
 		b.SetPageID(n.PageID())
 
 		for i := uint16(0); i < count; i++ {
-			k, v, ptr, f, err := n.GetLeafEntryView(i)
+			k, v, ptr, f, rev, err := n.GetLeafEntryViewWithRevision(i)
 			if err != nil {
 				return err
 			}
-			if err := b.AddLeafEntry(k, v, f, ptr); err != nil {
+			if err := b.AddLeafEntryWithRevision(k, v, f, ptr, rev); err != nil {
 				return err
 			}
 		}
@@ -143,6 +145,9 @@ func entryLength(n *Node, offset int) (int, error) {
 		entryLen := keyEnd
 		if valEnd > entryLen {
 			entryLen = valEnd
+		}
+		if n.leafEntryRevisions() {
+			entryLen += page.EntryRevisionSize
 		}
 		if offset+entryLen > len(n.data) {
 			return 0, ErrCorruptedNode

--- a/TreeDB/node/leaf.go
+++ b/TreeDB/node/leaf.go
@@ -20,6 +20,7 @@ type LeafEntry struct {
 	Value    []byte
 	ValuePtr page.ValuePtr // Valid if Flags & FlagPointer
 	Flags    byte
+	Revision page.EntryRevision
 }
 
 type leafEntryLayout struct {
@@ -29,8 +30,19 @@ type leafEntryLayout struct {
 	keyLen     int
 	valLen     int
 	flags      byte
+	revision   page.EntryRevision
 	keyOff     int
 	valOff     int
+}
+
+func decodeEntryRevision(data []byte, off int, enabled bool) (page.EntryRevision, error) {
+	if !enabled {
+		return page.LegacyEntryRevision, nil
+	}
+	if off < 0 || off+page.EntryRevisionSize > len(data) {
+		return page.LegacyEntryRevision, ErrCorruptedNode
+	}
+	return page.EntryRevision(binary.LittleEndian.Uint64(data[off : off+page.EntryRevisionSize])), nil
 }
 
 func compareLeafKey(a, b []byte) int {
@@ -129,7 +141,7 @@ func (n *Node) leafEntryLayoutAt(offset int) (leafEntryLayout, error) {
 				// key offsets; key/value metadata is stored in top-level columns.
 				return leafEntryLayout{}, ErrCorruptedNode
 			}
-			return parseLeafPrefixV2Layout(n.data, offset)
+			return parseLeafPrefixV2Layout(n.data, offset, n.leafEntryRevisions())
 		}
 		if n.leafColumnar() {
 			return leafEntryLayout{}, ErrCorruptedNode
@@ -145,7 +157,21 @@ func (n *Node) leafEntryLayoutAt(offset int) (leafEntryLayout, error) {
 		if keyStart+suffixLen > len(n.data) {
 			return leafEntryLayout{}, ErrCorruptedNode
 		}
+		valSize := valLen
+		if flags&FlagPointer != 0 {
+			if n.leafPackedValuePtr() {
+				valSize = page.PackedValuePtrSize
+			} else {
+				valSize = page.ValuePtrSize
+			}
+		} else if flags&FlagTombstone != 0 {
+			valSize = 0
+		}
 		keyOff := 9
+		revision, err := decodeEntryRevision(n.data, offset+keyOff+suffixLen+valSize, n.leafEntryRevisions())
+		if err != nil {
+			return leafEntryLayout{}, err
+		}
 		return leafEntryLayout{
 			headerSize: 9,
 			prefixLen:  prefixLen,
@@ -153,6 +179,7 @@ func (n *Node) leafEntryLayoutAt(offset int) (leafEntryLayout, error) {
 			keyLen:     prefixLen + suffixLen,
 			valLen:     valLen,
 			flags:      flags,
+			revision:   revision,
 			keyOff:     keyOff,
 			valOff:     keyOff + suffixLen,
 		}, nil
@@ -166,7 +193,7 @@ func (n *Node) leafEntryLayoutAt(offset int) (leafEntryLayout, error) {
 		if n.leafPackedValuePtr() {
 			valPtrSize = page.PackedValuePtrSize
 		}
-		return parseLeafColumnarLayout(n.data, offset, valPtrSize)
+		return parseLeafColumnarLayout(n.data, offset, valPtrSize, n.leafEntryRevisions())
 	}
 
 	if offset+7 > len(n.data) {
@@ -179,13 +206,28 @@ func (n *Node) leafEntryLayoutAt(offset int) (leafEntryLayout, error) {
 	if keyStart+keyLen > len(n.data) {
 		return leafEntryLayout{}, ErrCorruptedNode
 	}
+	valSize := valLen
+	if flags&FlagPointer != 0 {
+		if n.leafPackedValuePtr() {
+			valSize = page.PackedValuePtrSize
+		} else {
+			valSize = page.ValuePtrSize
+		}
+	} else if flags&FlagTombstone != 0 {
+		valSize = 0
+	}
 	keyOff := 7
+	revision, err := decodeEntryRevision(n.data, offset+keyOff+keyLen+valSize, n.leafEntryRevisions())
+	if err != nil {
+		return leafEntryLayout{}, err
+	}
 	return leafEntryLayout{
 		headerSize: 7,
 		suffixLen:  keyLen,
 		keyLen:     keyLen,
 		valLen:     valLen,
 		flags:      flags,
+		revision:   revision,
 		keyOff:     keyOff,
 		valOff:     keyOff + keyLen,
 	}, nil
@@ -344,22 +386,40 @@ func (n *Node) leafEntryKeyAt(index uint16) (key []byte, layout leafEntryLayout,
 // prefix-compressed. For prefix-compressed nodes, Key is reconstructed into a
 // scratch buffer owned by the node and is only valid until the next call.
 func (n *Node) GetLeafEntryView(index uint16) (key []byte, val []byte, valPtr page.ValuePtr, flags byte, err error) {
+	key, val, valPtr, flags, _, err = n.GetLeafEntryViewWithRevision(index)
+	return key, val, valPtr, flags, err
+}
+
+// GetLeafEntryViewWithRevision returns a zero-copy leaf entry view plus the
+// native entry revision stored in the same leaf entry.
+func (n *Node) GetLeafEntryViewWithRevision(index uint16) (key []byte, val []byte, valPtr page.ValuePtr, flags byte, revision page.EntryRevision, err error) {
 	if n.leafColumnar() && n.leafPrefixCompressed() && n.leafPrefixV2() {
-		return n.getLeafEntryViewColumnarPrefixV2(index)
+		key, val, valPtr, flags, err = n.getLeafEntryViewColumnarPrefixV2(index)
+		if err != nil {
+			return nil, nil, page.ValuePtr{}, 0, page.LegacyEntryRevision, err
+		}
+		revision, err = n.leafColumnarPrefixV2RevisionAt(index)
+		return key, val, valPtr, flags, revision, err
 	}
 	if n.leafColumnar() && n.leafColumnarV2() && !n.leafPrefixCompressed() {
-		return n.getLeafEntryViewColumnarV2(index)
+		key, val, valPtr, flags, err = n.getLeafEntryViewColumnarV2(index)
+		if err != nil {
+			return nil, nil, page.ValuePtr{}, 0, page.LegacyEntryRevision, err
+		}
+		revision, err = n.leafColumnarV2RevisionAt(index)
+		return key, val, valPtr, flags, revision, err
 	}
 
 	layout, entryStart := leafEntryLayout{}, 0
 	key, layout, entryStart, err = n.leafEntryKeyAt(index)
 	if err != nil {
-		return nil, nil, page.ValuePtr{}, 0, err
+		return nil, nil, page.ValuePtr{}, 0, page.LegacyEntryRevision, err
 	}
 	flags = layout.flags
+	revision = layout.revision
 
 	if flags&FlagTombstone != 0 {
-		return key, nil, page.ValuePtr{}, flags, nil
+		return key, nil, page.ValuePtr{}, flags, revision, nil
 	}
 
 	valueStart := entryStart + layout.valOff
@@ -369,22 +429,22 @@ func (n *Node) GetLeafEntryView(index uint16) (key []byte, val []byte, valPtr pa
 			valPtrSize = page.PackedValuePtrSize
 		}
 		if valueStart+valPtrSize > len(n.data) {
-			return nil, nil, page.ValuePtr{}, 0, ErrCorruptedNode
+			return nil, nil, page.ValuePtr{}, 0, page.LegacyEntryRevision, ErrCorruptedNode
 		}
 		if n.leafPackedValuePtr() {
 			valPtr = page.DecodePackedValuePtr(n.data[valueStart : valueStart+valPtrSize])
 		} else {
 			valPtr = page.DecodeValuePtr(n.data[valueStart : valueStart+valPtrSize])
 		}
-		return key, nil, valPtr, flags, nil
+		return key, nil, valPtr, flags, revision, nil
 	}
 
 	// Inline
 	if valueStart+layout.valLen > len(n.data) {
-		return nil, nil, page.ValuePtr{}, 0, ErrCorruptedNode
+		return nil, nil, page.ValuePtr{}, 0, page.LegacyEntryRevision, ErrCorruptedNode
 	}
 	val = n.data[valueStart : valueStart+layout.valLen]
-	return key, val, page.ValuePtr{}, flags, nil
+	return key, val, page.ValuePtr{}, flags, revision, nil
 }
 
 // GetLeafKeyFlagsView returns the key and flags for the entry at index without
@@ -558,12 +618,7 @@ func (n *Node) UpdateLeafValuePtr(index uint16, oldPtr, newPtr page.ValuePtr) (b
 		}
 
 		data := n.data
-		keyDirStart := NodeHeaderSize
-		keyDirEnd := keyDirStart + int(count)*DirectoryEntrySize
-		valDirStart := keyDirEnd
-		valDirEnd := valDirStart + int(count)*DirectoryEntrySize
-		flagsStart := valDirEnd
-		headerEnd := flagsStart + int(count)
+		keyDirStart, valDirStart, flagsStart, _, headerEnd := n.leafColumnarV2MetaOffsets(count)
 		if headerEnd > len(data) {
 			return false, ErrCorruptedNode
 		}
@@ -681,7 +736,7 @@ func (n *Node) UpdateLeafValuePtr(index uint16, oldPtr, newPtr page.ValuePtr) (b
 
 // GetLeafEntry reads the entry at the given index.
 func (n *Node) GetLeafEntry(index uint16) (LeafEntry, error) {
-	keyView, valView, valPtr, flags, err := n.GetLeafEntryView(index)
+	keyView, valView, valPtr, flags, revision, err := n.GetLeafEntryViewWithRevision(index)
 	if err != nil {
 		return LeafEntry{}, err
 	}
@@ -701,6 +756,7 @@ func (n *Node) GetLeafEntry(index uint16) (LeafEntry, error) {
 		Value:    val,
 		ValuePtr: valPtr,
 		Flags:    flags,
+		Revision: revision,
 	}, nil
 }
 
@@ -832,6 +888,34 @@ func (n *Node) SearchLeaf(key []byte) (uint16, bool, error) {
 	return uint16(i), false, nil
 }
 
+func (n *Node) leafColumnarV2MetaOffsets(count uint16) (keyDirStart, valDirStart, flagsStart, revisionsStart, headerEnd int) {
+	c := int(count)
+	keyDirStart = NodeHeaderSize
+	valDirStart = keyDirStart + c*DirectoryEntrySize
+	flagsStart = valDirStart + c*DirectoryEntrySize
+	revisionsStart = flagsStart + c
+	headerEnd = revisionsStart
+	if n.leafEntryRevisions() {
+		headerEnd += c * page.EntryRevisionSize
+	}
+	return keyDirStart, valDirStart, flagsStart, revisionsStart, headerEnd
+}
+
+func (n *Node) leafColumnarV2RevisionAt(index uint16) (page.EntryRevision, error) {
+	if !n.leafEntryRevisions() {
+		return page.LegacyEntryRevision, nil
+	}
+	count := n.Count()
+	if index >= count {
+		return page.LegacyEntryRevision, ErrCorruptedNode
+	}
+	_, _, _, revisionsStart, headerEnd := n.leafColumnarV2MetaOffsets(count)
+	if headerEnd > len(n.data) {
+		return page.LegacyEntryRevision, ErrCorruptedNode
+	}
+	return decodeEntryRevision(n.data, revisionsStart+int(index)*page.EntryRevisionSize, true)
+}
+
 func (n *Node) leafColumnarKeyViewAtIndex(idx int) ([]byte, error) {
 	data := n.data
 	if n.leafColumnarV2() {
@@ -839,12 +923,14 @@ func (n *Node) leafColumnarKeyViewAtIndex(idx int) ([]byte, error) {
 		if idx < 0 || idx >= int(count) {
 			return nil, ErrCorruptedNode
 		}
+		keyDirStart, _, _, _, headerEnd := n.leafColumnarV2MetaOffsets(count)
 		keyDirOff := NodeHeaderSize + idx*2
 		nextDirOff := keyDirOff + 2
-		headerEnd := NodeHeaderSize + int(count)*DirectoryEntrySize + int(count)*DirectoryEntrySize + int(count)
 		if headerEnd > len(data) || nextDirOff > len(data) {
 			return nil, ErrCorruptedNode
 		}
+		keyDirOff = keyDirStart + idx*DirectoryEntrySize
+		nextDirOff = keyDirOff + DirectoryEntrySize
 
 		keyStart := int(getUint16(data[keyDirOff : keyDirOff+2]))
 		keyEnd := len(data)
@@ -898,12 +984,7 @@ func (n *Node) getLeafEntryViewColumnarV2(index uint16) (key []byte, val []byte,
 	}
 
 	data := n.data
-	keyDirStart := NodeHeaderSize
-	keyDirEnd := keyDirStart + int(count)*DirectoryEntrySize
-	valDirStart := keyDirEnd
-	valDirEnd := valDirStart + int(count)*DirectoryEntrySize
-	flagsStart := valDirEnd
-	headerEnd := flagsStart + int(count)
+	keyDirStart, valDirStart, flagsStart, _, headerEnd := n.leafColumnarV2MetaOffsets(count)
 	if headerEnd > len(data) {
 		return nil, nil, page.ValuePtr{}, 0, ErrCorruptedNode
 	}
@@ -984,12 +1065,7 @@ func (n *Node) getLeafValueViewColumnarV2(index uint16) (val []byte, valPtr page
 	}
 
 	data := n.data
-	keyDirStart := NodeHeaderSize
-	keyDirEnd := keyDirStart + int(count)*DirectoryEntrySize
-	valDirStart := keyDirEnd
-	valDirEnd := valDirStart + int(count)*DirectoryEntrySize
-	flagsStart := valDirEnd
-	headerEnd := flagsStart + int(count)
+	keyDirStart, valDirStart, flagsStart, _, headerEnd := n.leafColumnarV2MetaOffsets(count)
 	if headerEnd > len(data) {
 		return nil, page.ValuePtr{}, 0, ErrCorruptedNode
 	}
@@ -1053,6 +1129,7 @@ func (n *Node) leafColumnarPrefixV2EnsureMeta() error {
 		n.leafColPrefixValDirStart = NodeHeaderSize
 		n.leafColPrefixFlagsStart = NodeHeaderSize
 		n.leafColPrefixPrefixStart = NodeHeaderSize
+		n.leafColPrefixRevisionStart = NodeHeaderSize
 		n.leafColPrefixHeaderEnd = NodeHeaderSize
 		n.leafColPrefixKeysBlobBase = len(n.data)
 		return nil
@@ -1063,7 +1140,11 @@ func (n *Node) leafColumnarPrefixV2EnsureMeta() error {
 	valDirStart := NodeHeaderSize + int(count)*DirectoryEntrySize
 	flagsStart := valDirStart + int(count)*DirectoryEntrySize
 	prefixStart := flagsStart + int(count)
-	headerEnd := prefixStart + int(count)*DirectoryEntrySize
+	revisionStart := prefixStart + int(count)*DirectoryEntrySize
+	headerEnd := revisionStart
+	if n.leafEntryRevisions() {
+		headerEnd += int(count) * page.EntryRevisionSize
+	}
 	if headerEnd > len(n.data) {
 		return ErrCorruptedNode
 	}
@@ -1076,9 +1157,24 @@ func (n *Node) leafColumnarPrefixV2EnsureMeta() error {
 	n.leafColPrefixValDirStart = valDirStart
 	n.leafColPrefixFlagsStart = flagsStart
 	n.leafColPrefixPrefixStart = prefixStart
+	n.leafColPrefixRevisionStart = revisionStart
 	n.leafColPrefixHeaderEnd = headerEnd
 	n.leafColPrefixKeysBlobBase = keysStart
 	return nil
+}
+
+func (n *Node) leafColumnarPrefixV2RevisionAt(index uint16) (page.EntryRevision, error) {
+	if !n.leafEntryRevisions() {
+		return page.LegacyEntryRevision, nil
+	}
+	count := n.Count()
+	if index >= count {
+		return page.LegacyEntryRevision, ErrCorruptedNode
+	}
+	if err := n.leafColumnarPrefixV2EnsureMeta(); err != nil {
+		return page.LegacyEntryRevision, err
+	}
+	return decodeEntryRevision(n.data, n.leafColPrefixRevisionStart+int(index)*page.EntryRevisionSize, true)
 }
 
 func (n *Node) leafColumnarPrefixV2KeyMetaAt(index uint16) (prefixLen int, suffix []byte, flags byte, err error) {
@@ -1378,10 +1474,7 @@ func (n *Node) searchLeafColumnarV2(key []byte) (uint16, bool, error) {
 	}
 
 	data := n.data
-	keyDirStart := NodeHeaderSize
-	keyDirEnd := keyDirStart + count*DirectoryEntrySize
-	valDirEnd := keyDirEnd + count*DirectoryEntrySize
-	headerEnd := valDirEnd + count // flags[]
+	keyDirStart, _, _, _, headerEnd := n.leafColumnarV2MetaOffsets(uint16(count))
 	if headerEnd > len(data) {
 		return 0, false, ErrCorruptedNode
 	}
@@ -1957,20 +2050,32 @@ func (n *Node) searchLeafColumnarPrefixV2Block(blockStart, blockEnd uint16, targ
 // It DOES NOT handle fragmentation (holes in heap) yet.
 // A full implementation would compact the heap if FreeSpace check fails but logical space exists.
 func (n *Node) AddLeafEntry(key, value []byte, flags byte, valPtr page.ValuePtr) error {
+	return n.AddLeafEntryWithRevision(key, value, flags, valPtr, page.LegacyEntryRevision)
+}
+
+// AddLeafEntryWithRevision inserts a leaf entry and stores the native entry
+// revision when this page uses revision-bearing leaf format.
+func (n *Node) AddLeafEntryWithRevision(key, value []byte, flags byte, valPtr page.ValuePtr, revision page.EntryRevision) error {
 	if n.Type() != page.PageTypeLeaf {
 		return ErrInvalidType
 	}
+	if revision != page.LegacyEntryRevision && !n.leafEntryRevisions() {
+		if n.Count() != 0 {
+			return ErrInvalidType
+		}
+		n.setLeafEntryRevisions(true)
+	}
 	if n.leafColumnar() && n.leafPrefixCompressed() {
-		return n.addLeafEntryColumnarPrefixV2Rebuild(key, value, flags, valPtr)
+		return n.addLeafEntryColumnarPrefixV2Rebuild(key, value, flags, valPtr, revision)
 	}
 	if n.leafColumnar() {
 		if n.leafColumnarV2() {
-			return n.addLeafEntryColumnarV2Rebuild(key, value, flags, valPtr)
+			return n.addLeafEntryColumnarV2Rebuild(key, value, flags, valPtr, revision)
 		}
-		return n.addLeafEntryColumnar(key, value, flags, valPtr)
+		return n.addLeafEntryColumnar(key, value, flags, valPtr, revision)
 	}
 	if n.leafPrefixCompressed() {
-		return n.addLeafEntryPrefixCompressed(key, value, flags, valPtr)
+		return n.addLeafEntryPrefixCompressed(key, value, flags, valPtr, revision)
 	}
 
 	// Calculate size needed
@@ -1984,6 +2089,9 @@ func (n *Node) AddLeafEntry(key, value []byte, flags byte, valPtr page.ValuePtr)
 		entrySize += valPtrSize
 	} else {
 		entrySize += len(value)
+	}
+	if n.leafEntryRevisions() {
+		entrySize += page.EntryRevisionSize
 	}
 
 	// Check directory space (2 bytes) + Entry space
@@ -2040,6 +2148,16 @@ func (n *Node) AddLeafEntry(key, value []byte, flags byte, valPtr page.ValuePtr)
 		buf[6] = flags
 		copy(buf[7:], key)
 		copy(buf[7+len(key):], value)
+	}
+	if n.leafEntryRevisions() {
+		valSize := len(value)
+		if flags&FlagPointer != 0 {
+			valSize = valPtrSize
+		} else if flags&FlagTombstone != 0 {
+			valSize = 0
+		}
+		revisionOff := 7 + len(key) + valSize
+		binary.LittleEndian.PutUint64(buf[revisionOff:revisionOff+page.EntryRevisionSize], uint64(revision))
 	}
 
 	// Allocate in Heap
@@ -2104,7 +2222,7 @@ func (n *Node) AddLeafEntry(key, value []byte, flags byte, valPtr page.ValuePtr)
 	return nil
 }
 
-func (n *Node) addLeafEntryColumnarV2Rebuild(key, value []byte, flags byte, valPtr page.ValuePtr) error {
+func (n *Node) addLeafEntryColumnarV2Rebuild(key, value []byte, flags byte, valPtr page.ValuePtr, revision page.EntryRevision) error {
 	idx, found, err := n.SearchLeaf(key)
 	if err != nil {
 		return err
@@ -2115,13 +2233,14 @@ func (n *Node) addLeafEntryColumnarV2Rebuild(key, value []byte, flags byte, valP
 	b := NewBuilderWithOptions(buf, page.PageTypeLeaf, BuilderOptions{
 		LeafColumnar:   true,
 		PackedValuePtr: n.leafPackedValuePtr(),
+		EntryRevisions: n.leafEntryRevisions(),
 	})
 	b.SetPageID(n.PageID())
 
 	inserted := false
 	for i := uint16(0); i < count; i++ {
 		if !inserted && i == idx {
-			if err := b.AddLeafEntry(key, value, flags, valPtr); err != nil {
+			if err := b.AddLeafEntryWithRevision(key, value, flags, valPtr, revision); err != nil {
 				return err
 			}
 			inserted = true
@@ -2130,16 +2249,16 @@ func (n *Node) addLeafEntryColumnarV2Rebuild(key, value []byte, flags byte, valP
 			}
 		}
 
-		k, v, ptr, f, err := n.GetLeafEntryView(i)
+		k, v, ptr, f, rev, err := n.GetLeafEntryViewWithRevision(i)
 		if err != nil {
 			return err
 		}
-		if err := b.AddLeafEntry(k, v, f, ptr); err != nil {
+		if err := b.AddLeafEntryWithRevision(k, v, f, ptr, rev); err != nil {
 			return err
 		}
 	}
 	if !inserted {
-		if err := b.AddLeafEntry(key, value, flags, valPtr); err != nil {
+		if err := b.AddLeafEntryWithRevision(key, value, flags, valPtr, revision); err != nil {
 			return err
 		}
 	}
@@ -2153,7 +2272,7 @@ func (n *Node) addLeafEntryColumnarV2Rebuild(key, value []byte, flags byte, valP
 	return nil
 }
 
-func (n *Node) addLeafEntryColumnarPrefixV2Rebuild(key, value []byte, flags byte, valPtr page.ValuePtr) error {
+func (n *Node) addLeafEntryColumnarPrefixV2Rebuild(key, value []byte, flags byte, valPtr page.ValuePtr, revision page.EntryRevision) error {
 	idx, found, err := n.SearchLeaf(key)
 	if err != nil {
 		return err
@@ -2165,13 +2284,14 @@ func (n *Node) addLeafEntryColumnarPrefixV2Rebuild(key, value []byte, flags byte
 		LeafPrefixCompression: true,
 		LeafColumnar:          true,
 		PackedValuePtr:        n.leafPackedValuePtr(),
+		EntryRevisions:        n.leafEntryRevisions(),
 	})
 	b.SetPageID(n.PageID())
 
 	inserted := false
 	for i := uint16(0); i < count; i++ {
 		if !inserted && i == idx {
-			if err := b.AddLeafEntry(key, value, flags, valPtr); err != nil {
+			if err := b.AddLeafEntryWithRevision(key, value, flags, valPtr, revision); err != nil {
 				return err
 			}
 			inserted = true
@@ -2180,16 +2300,16 @@ func (n *Node) addLeafEntryColumnarPrefixV2Rebuild(key, value []byte, flags byte
 			}
 		}
 
-		k, v, ptr, f, err := n.GetLeafEntryView(i)
+		k, v, ptr, f, rev, err := n.GetLeafEntryViewWithRevision(i)
 		if err != nil {
 			return err
 		}
-		if err := b.AddLeafEntry(k, v, f, ptr); err != nil {
+		if err := b.AddLeafEntryWithRevision(k, v, f, ptr, rev); err != nil {
 			return err
 		}
 	}
 	if !inserted {
-		if err := b.AddLeafEntry(key, value, flags, valPtr); err != nil {
+		if err := b.AddLeafEntryWithRevision(key, value, flags, valPtr, revision); err != nil {
 			return err
 		}
 	}
@@ -2203,7 +2323,7 @@ func (n *Node) addLeafEntryColumnarPrefixV2Rebuild(key, value []byte, flags byte
 	return nil
 }
 
-func (n *Node) addLeafEntryColumnar(key, value []byte, flags byte, valPtr page.ValuePtr) error {
+func (n *Node) addLeafEntryColumnar(key, value []byte, flags byte, valPtr page.ValuePtr, revision page.EntryRevision) error {
 	valPtrSize := page.ValuePtrSize
 	if n.leafPackedValuePtr() {
 		valPtrSize = page.PackedValuePtrSize
@@ -2218,6 +2338,9 @@ func (n *Node) addLeafEntryColumnar(key, value []byte, flags byte, valPtr page.V
 		valLen = len(value)
 		valSize = valLen
 		entrySize += valSize
+	}
+	if n.leafEntryRevisions() {
+		entrySize += page.EntryRevisionSize
 	}
 
 	idx, found, err := n.SearchLeaf(key)
@@ -2255,6 +2378,10 @@ func (n *Node) addLeafEntryColumnar(key, value []byte, flags byte, valPtr page.V
 
 	keyStart := valueStart + valSize
 	copy(buf[keyStart:keyStart+len(key)], key)
+	if n.leafEntryRevisions() {
+		revisionOff := keyStart + len(key)
+		binary.LittleEndian.PutUint64(buf[revisionOff:revisionOff+page.EntryRevisionSize], uint64(revision))
+	}
 
 	heapStart := int(page.PageSize)
 	count := n.Count()
@@ -2296,11 +2423,12 @@ func (n *Node) addLeafEntryColumnar(key, value []byte, flags byte, valPtr page.V
 	return nil
 }
 
-func (n *Node) addLeafEntryPrefixCompressed(key, value []byte, flags byte, valPtr page.ValuePtr) error {
+func (n *Node) addLeafEntryPrefixCompressed(key, value []byte, flags byte, valPtr page.ValuePtr, revision page.EntryRevision) error {
 	newEntry := LeafEntry{
 		Key:      append([]byte(nil), key...),
 		ValuePtr: valPtr,
 		Flags:    flags,
+		Revision: revision,
 	}
 	if flags&FlagPointer == 0 && flags&FlagTombstone == 0 {
 		newEntry.Value = append([]byte(nil), value...)
@@ -2309,7 +2437,7 @@ func (n *Node) addLeafEntryPrefixCompressed(key, value []byte, flags byte, valPt
 	entries := make([]LeafEntry, 0, int(n.Count())+1)
 	inserted := false
 	for i := uint16(0); i < n.Count(); i++ {
-		k, v, ptr, f, err := n.GetLeafEntryView(i)
+		k, v, ptr, f, rev, err := n.GetLeafEntryViewWithRevision(i)
 		if err != nil {
 			return err
 		}
@@ -2329,6 +2457,7 @@ func (n *Node) addLeafEntryPrefixCompressed(key, value []byte, flags byte, valPt
 			Key:      append([]byte(nil), k...),
 			ValuePtr: ptr,
 			Flags:    f,
+			Revision: rev,
 		}
 		if f&FlagPointer == 0 && f&FlagTombstone == 0 {
 			entry.Value = append([]byte(nil), v...)
@@ -2342,10 +2471,11 @@ func (n *Node) addLeafEntryPrefixCompressed(key, value []byte, flags byte, valPt
 	b := NewBuilderWithOptions(n.data, page.PageTypeLeaf, BuilderOptions{
 		LeafPrefixCompression: true,
 		PackedValuePtr:        n.leafPackedValuePtr(),
+		EntryRevisions:        n.leafEntryRevisions(),
 	})
 	b.SetPageID(n.PageID())
 	for _, entry := range entries {
-		if err := b.AddLeafEntry(entry.Key, entry.Value, entry.Flags, entry.ValuePtr); err != nil {
+		if err := b.AddLeafEntryWithRevision(entry.Key, entry.Value, entry.Flags, entry.ValuePtr, entry.Revision); err != nil {
 			return err
 		}
 	}

--- a/TreeDB/node/leaf_columnar.go
+++ b/TreeDB/node/leaf_columnar.go
@@ -33,7 +33,7 @@ const leafColumnarV2MetaSize = 3
 // Layout: keyOff(u16) | valOff(u16) | flags(u8) | prefixLen(u16)
 const leafColumnarPrefixV2MetaSize = 7
 
-func parseLeafColumnarLayout(data []byte, offset int, valPtrSize int) (leafEntryLayout, error) {
+func parseLeafColumnarLayout(data []byte, offset int, valPtrSize int, entryRevisions bool) (leafEntryLayout, error) {
 	if offset+leafColumnarHeaderSize > len(data) {
 		return leafEntryLayout{}, ErrCorruptedNode
 	}
@@ -60,6 +60,10 @@ func parseLeafColumnarLayout(data []byte, offset int, valPtrSize int) (leafEntry
 	if valStart+valSize > len(data) {
 		return leafEntryLayout{}, ErrCorruptedNode
 	}
+	revision, err := decodeEntryRevision(data, keyStart+keyLen, entryRevisions)
+	if err != nil {
+		return leafEntryLayout{}, err
+	}
 
 	return leafEntryLayout{
 		headerSize: leafColumnarHeaderSize,
@@ -67,6 +71,7 @@ func parseLeafColumnarLayout(data []byte, offset int, valPtrSize int) (leafEntry
 		keyLen:     keyLen,
 		valLen:     valLen,
 		flags:      flags,
+		revision:   revision,
 		keyOff:     keyOff,
 		valOff:     valOff,
 	}, nil

--- a/TreeDB/node/leaf_prefix_v2.go
+++ b/TreeDB/node/leaf_prefix_v2.go
@@ -49,7 +49,7 @@ func leafPrefixHeaderSizeV2(prefixLen, suffixLen int, flags byte, valLen int) in
 	return headerSize
 }
 
-func parseLeafPrefixV2Layout(data []byte, offset int) (leafEntryLayout, error) {
+func parseLeafPrefixV2Layout(data []byte, offset int, entryRevisions bool) (leafEntryLayout, error) {
 	if offset+leafPrefixV2HeaderBaseSize > len(data) {
 		return leafEntryLayout{}, ErrCorruptedNode
 	}
@@ -107,6 +107,10 @@ func parseLeafPrefixV2Layout(data []byte, offset int) (leafEntryLayout, error) {
 	if valStart+valSize > len(data) {
 		return leafEntryLayout{}, ErrCorruptedNode
 	}
+	revision, err := decodeEntryRevision(data, valStart+valSize, entryRevisions)
+	if err != nil {
+		return leafEntryLayout{}, err
+	}
 
 	return leafEntryLayout{
 		headerSize: headerSize,
@@ -115,6 +119,7 @@ func parseLeafPrefixV2Layout(data []byte, offset int) (leafEntryLayout, error) {
 		keyLen:     prefixLen + suffixLen,
 		valLen:     valLen,
 		flags:      flags,
+		revision:   revision,
 		keyOff:     headerSize,
 		valOff:     headerSize + suffixLen,
 	}, nil

--- a/TreeDB/node/leaf_revision_test.go
+++ b/TreeDB/node/leaf_revision_test.go
@@ -1,0 +1,125 @@
+package node
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/page"
+)
+
+func TestLeafEntryRevisionRoundTripAcrossEncodings(t *testing.T) {
+	tests := []struct {
+		name string
+		opts BuilderOptions
+	}{
+		{name: "plain", opts: BuilderOptions{EntryRevisions: true}},
+		{name: "prefix_v2", opts: BuilderOptions{LeafPrefixCompression: true, EntryRevisions: true}},
+		{name: "columnar_v2", opts: BuilderOptions{LeafColumnar: true, EntryRevisions: true}},
+		{name: "columnar_prefix_v2", opts: BuilderOptions{LeafPrefixCompression: true, LeafColumnar: true, EntryRevisions: true}},
+		{name: "packed_pointer", opts: BuilderOptions{PackedValuePtr: true, EntryRevisions: true}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data := make([]byte, page.PageSize)
+			b := NewBuilderWithOptions(data, page.PageTypeLeaf, tt.opts)
+			b.SetPageID(7)
+
+			ptr := page.ValuePtr{Offset: 42, Length: 99, FileID: 3}
+			if err := b.AddLeafEntryWithRevision([]byte("a"), []byte("inline"), FlagInline, page.ValuePtr{}, 11); err != nil {
+				t.Fatalf("add inline: %v", err)
+			}
+			if err := b.AddLeafEntryWithRevision([]byte("b"), nil, FlagPointer, ptr, 12); err != nil {
+				t.Fatalf("add pointer: %v", err)
+			}
+			if err := b.AddLeafEntryWithRevision([]byte("c"), nil, FlagTombstone, page.ValuePtr{}, 13); err != nil {
+				t.Fatalf("add tombstone: %v", err)
+			}
+
+			n := b.Finish()
+			if !n.leafEntryRevisions() {
+				t.Fatalf("expected revision leaf flag")
+			}
+
+			assertRevisionEntry(t, n, "a", []byte("inline"), page.ValuePtr{}, FlagInline, 11)
+			assertRevisionEntry(t, n, "b", nil, ptr, FlagPointer, 12)
+			assertRevisionEntry(t, n, "c", nil, page.ValuePtr{}, FlagTombstone, 13)
+		})
+	}
+}
+
+func TestLeafEntryRevisionPreservedBySplitAndCompact(t *testing.T) {
+	data := make([]byte, page.PageSize)
+	b := NewBuilderWithOptions(data, page.PageTypeLeaf, BuilderOptions{LeafPrefixCompression: true, LeafColumnar: true, EntryRevisions: true})
+	b.SetPageID(1)
+
+	for i, key := range []string{"a", "b", "c", "d"} {
+		if err := b.AddLeafEntryWithRevision([]byte(key), []byte("value-"+key), FlagInline, page.ValuePtr{}, page.EntryRevision(100+i)); err != nil {
+			t.Fatalf("add %s: %v", key, err)
+		}
+	}
+	left := b.Finish()
+
+	right := NewNode(make([]byte, page.PageSize))
+	right.SetPageID(2)
+	pivot, err := left.Split(right)
+	if err != nil {
+		t.Fatalf("split: %v", err)
+	}
+	if !bytes.Equal(pivot, []byte("c")) {
+		t.Fatalf("pivot=%q, want c", pivot)
+	}
+
+	assertRevisionEntry(t, left, "a", []byte("value-a"), page.ValuePtr{}, FlagInline, 100)
+	assertRevisionEntry(t, left, "b", []byte("value-b"), page.ValuePtr{}, FlagInline, 101)
+	assertRevisionEntry(t, right, "c", []byte("value-c"), page.ValuePtr{}, FlagInline, 102)
+	assertRevisionEntry(t, right, "d", []byte("value-d"), page.ValuePtr{}, FlagInline, 103)
+
+	if err := left.Compact(); err != nil {
+		t.Fatalf("compact: %v", err)
+	}
+	assertRevisionEntry(t, left, "a", []byte("value-a"), page.ValuePtr{}, FlagInline, 100)
+	assertRevisionEntry(t, left, "b", []byte("value-b"), page.ValuePtr{}, FlagInline, 101)
+}
+
+func TestLeafEntryRevisionLegacyPagesReturnZero(t *testing.T) {
+	data := make([]byte, page.PageSize)
+	b := NewBuilderWithOptions(data, page.PageTypeLeaf, BuilderOptions{})
+	b.SetPageID(1)
+	if err := b.AddLeafEntry([]byte("a"), []byte("value"), FlagInline, page.ValuePtr{}); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	n := b.Finish()
+
+	_, value, _, flags, revision, err := n.GetLeafEntryViewWithRevision(0)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if flags != FlagInline || !bytes.Equal(value, []byte("value")) || revision != page.LegacyEntryRevision {
+		t.Fatalf("entry=(%q,%#x,%d), want value/inline/legacy", value, flags, revision)
+	}
+}
+
+func assertRevisionEntry(t *testing.T, n *Node, key string, wantValue []byte, wantPtr page.ValuePtr, wantFlags byte, wantRevision page.EntryRevision) {
+	t.Helper()
+	idx, found, err := n.SearchLeaf([]byte(key))
+	if err != nil || !found {
+		t.Fatalf("search %q: found=%v err=%v", key, found, err)
+	}
+	gotKey, gotValue, gotPtr, gotFlags, gotRevision, err := n.GetLeafEntryViewWithRevision(idx)
+	if err != nil {
+		t.Fatalf("get %q: %v", key, err)
+	}
+	if !bytes.Equal(gotKey, []byte(key)) || !bytes.Equal(gotValue, wantValue) || gotPtr != wantPtr || gotFlags&wantFlags != wantFlags || gotRevision != wantRevision {
+		t.Fatalf("entry %q=(key=%q value=%q ptr=%+v flags=%#x rev=%d), want value=%q ptr=%+v flags contains %#x rev=%d",
+			key, gotKey, gotValue, gotPtr, gotFlags, gotRevision, wantValue, wantPtr, wantFlags, wantRevision)
+	}
+
+	entry, err := n.GetLeafEntry(idx)
+	if err != nil {
+		t.Fatalf("GetLeafEntry %q: %v", key, err)
+	}
+	if entry.Revision != wantRevision {
+		t.Fatalf("safe entry %q revision=%d, want %d", key, entry.Revision, wantRevision)
+	}
+}

--- a/TreeDB/node/node.go
+++ b/TreeDB/node/node.go
@@ -36,10 +36,11 @@ const (
 	internalBaseDeltaU16Flag uint16 = 0x0200
 	internalFenceBoundsFlag  uint16 = 0x0100
 	internalLeafLogRefsFlag  uint16 = 0x0080
+	leafEntryRevisionFlag    uint16 = 0x0040
 
 	// NOTE: TreeDB is currently pre-alpha; on-disk formats are not yet stable and
 	// backward compatibility is not guaranteed. Leaf/internal flags may change.
-	leafNodeFlagMask     = leafPrefixCompressedFlag | leafColumnarFlag | leafPrefixV2Flag | leafPackedValuePtrFlag | leafColumnarV2Flag
+	leafNodeFlagMask     = leafPrefixCompressedFlag | leafColumnarFlag | leafPrefixV2Flag | leafPackedValuePtrFlag | leafColumnarV2Flag | leafEntryRevisionFlag
 	internalNodeFlagMask = internalBaseDeltaFlag | internalBaseDeltaU16Flag | internalFenceBoundsFlag | internalLeafLogRefsFlag
 	nodeFlagMask         = leafNodeFlagMask | internalNodeFlagMask
 	pageTypeMask         = ^nodeFlagMask
@@ -98,13 +99,14 @@ type Node struct {
 	leafFlags  byte
 	leafValid  bool
 
-	leafColPrefixMetaValid    bool
-	leafColPrefixMetaCount    uint16
-	leafColPrefixValDirStart  int
-	leafColPrefixFlagsStart   int
-	leafColPrefixPrefixStart  int
-	leafColPrefixHeaderEnd    int
-	leafColPrefixKeysBlobBase int
+	leafColPrefixMetaValid     bool
+	leafColPrefixMetaCount     uint16
+	leafColPrefixValDirStart   int
+	leafColPrefixFlagsStart    int
+	leafColPrefixPrefixStart   int
+	leafColPrefixRevisionStart int
+	leafColPrefixHeaderEnd     int
+	leafColPrefixKeysBlobBase  int
 
 	internalMetaValid bool
 	internalMetaCount uint16
@@ -268,6 +270,19 @@ func (n *Node) leafPackedValuePtr() bool {
 	return n.rawFlags()&leafPackedValuePtrFlag != 0
 }
 
+func (n *Node) leafEntryRevisions() bool {
+	if n.ptype != page.PageTypeLeaf {
+		return false
+	}
+	return n.rawFlags()&leafEntryRevisionFlag != 0
+}
+
+// LeafEntryRevisionsEnabled reports whether this leaf stores native per-entry
+// revision metadata.
+func (n *Node) LeafEntryRevisionsEnabled() bool {
+	return n.leafEntryRevisions()
+}
+
 func (n *Node) internalBaseDelta() bool {
 	if n.ptype != page.PageTypeInternal {
 		return false
@@ -377,6 +392,16 @@ func (n *Node) setLeafPackedValuePtr(enabled bool) {
 		flags |= leafPackedValuePtrFlag
 	} else {
 		flags &^= leafPackedValuePtrFlag
+	}
+	n.setRawFlags(flags)
+}
+
+func (n *Node) setLeafEntryRevisions(enabled bool) {
+	flags := n.rawFlags()
+	if enabled {
+		flags |= leafEntryRevisionFlag
+	} else {
+		flags &^= leafEntryRevisionFlag
 	}
 	n.setRawFlags(flags)
 }

--- a/TreeDB/node/split.go
+++ b/TreeDB/node/split.go
@@ -73,6 +73,7 @@ func (n *Node) Split(newNode *Node) ([]byte, error) {
 					LeafPrefixCompression: n.leafPrefixCompressed(),
 					LeafColumnar:          n.leafColumnar(),
 					PackedValuePtr:        n.leafPackedValuePtr(),
+					EntryRevisions:        n.leafEntryRevisions(),
 				}
 				leafBuilder = NewBuilderWithOptions(newNode.data, page.PageTypeLeaf, opts)
 				leafBuilder.SetPageID(newNode.PageID())
@@ -97,7 +98,7 @@ func (n *Node) Split(newNode *Node) ([]byte, error) {
 		// High-level requires decoding.
 
 		if n.Type() == page.PageTypeLeaf {
-			key, val, ptr, flags, err := n.GetLeafEntryView(srcIdx)
+			key, val, ptr, flags, revision, err := n.GetLeafEntryViewWithRevision(srcIdx)
 			if err != nil {
 				return nil, err
 			}
@@ -105,7 +106,7 @@ func (n *Node) Split(newNode *Node) ([]byte, error) {
 				pivotKey = append([]byte(nil), key...)
 			}
 			// AddLeafEntry copies data, so Views are safe here.
-			err = leafBuilder.AddLeafEntry(key, val, flags, ptr)
+			err = leafBuilder.AddLeafEntryWithRevision(key, val, flags, ptr, revision)
 			if err != nil {
 				return nil, err
 			}
@@ -185,6 +186,7 @@ func (n *Node) splitLeafColumnarV2Rebuild(newNode *Node) ([]byte, error) {
 		LeafPrefixCompression: n.leafPrefixCompressed(),
 		LeafColumnar:          n.leafColumnar(),
 		PackedValuePtr:        n.leafPackedValuePtr(),
+		EntryRevisions:        n.leafEntryRevisions(),
 	}
 	leftBuilder := NewBuilderWithOptions(n.data, page.PageTypeLeaf, opts)
 	leftBuilder.SetPageID(n.PageID())
@@ -192,25 +194,25 @@ func (n *Node) splitLeafColumnarV2Rebuild(newNode *Node) ([]byte, error) {
 	rightBuilder.SetPageID(newNode.PageID())
 
 	for i := uint16(0); i < splitIndex; i++ {
-		key, val, ptr, flags, err := src.GetLeafEntryView(i)
+		key, val, ptr, flags, revision, err := src.GetLeafEntryViewWithRevision(i)
 		if err != nil {
 			return nil, err
 		}
-		if err := leftBuilder.AddLeafEntry(key, val, flags, ptr); err != nil {
+		if err := leftBuilder.AddLeafEntryWithRevision(key, val, flags, ptr, revision); err != nil {
 			return nil, err
 		}
 	}
 
 	var pivotKey []byte
 	for i := splitIndex; i < count; i++ {
-		key, val, ptr, flags, err := src.GetLeafEntryView(i)
+		key, val, ptr, flags, revision, err := src.GetLeafEntryViewWithRevision(i)
 		if err != nil {
 			return nil, err
 		}
 		if i == splitIndex {
 			pivotKey = append([]byte(nil), key...)
 		}
-		if err := rightBuilder.AddLeafEntry(key, val, flags, ptr); err != nil {
+		if err := rightBuilder.AddLeafEntryWithRevision(key, val, flags, ptr, revision); err != nil {
 			return nil, err
 		}
 	}
@@ -244,6 +246,7 @@ func (n *Node) splitLeafColumnarPrefixV2Rebuild(newNode *Node) ([]byte, error) {
 		LeafPrefixCompression: true,
 		LeafColumnar:          true,
 		PackedValuePtr:        n.leafPackedValuePtr(),
+		EntryRevisions:        n.leafEntryRevisions(),
 	}
 	leftBuilder := NewBuilderWithOptions(n.data, page.PageTypeLeaf, opts)
 	leftBuilder.SetPageID(n.PageID())
@@ -251,25 +254,25 @@ func (n *Node) splitLeafColumnarPrefixV2Rebuild(newNode *Node) ([]byte, error) {
 	rightBuilder.SetPageID(newNode.PageID())
 
 	for i := uint16(0); i < splitIndex; i++ {
-		key, val, ptr, flags, err := src.GetLeafEntryView(i)
+		key, val, ptr, flags, revision, err := src.GetLeafEntryViewWithRevision(i)
 		if err != nil {
 			return nil, err
 		}
-		if err := leftBuilder.AddLeafEntry(key, val, flags, ptr); err != nil {
+		if err := leftBuilder.AddLeafEntryWithRevision(key, val, flags, ptr, revision); err != nil {
 			return nil, err
 		}
 	}
 
 	var pivotKey []byte
 	for i := splitIndex; i < count; i++ {
-		key, val, ptr, flags, err := src.GetLeafEntryView(i)
+		key, val, ptr, flags, revision, err := src.GetLeafEntryViewWithRevision(i)
 		if err != nil {
 			return nil, err
 		}
 		if i == splitIndex {
 			pivotKey = append([]byte(nil), key...)
 		}
-		if err := rightBuilder.AddLeafEntry(key, val, flags, ptr); err != nil {
+		if err := rightBuilder.AddLeafEntryWithRevision(key, val, flags, ptr, revision); err != nil {
 			return nil, err
 		}
 	}

--- a/TreeDB/page/page.go
+++ b/TreeDB/page/page.go
@@ -28,6 +28,9 @@ const (
 	// Layout: Offset32 (u32 LE) | Length (u32 LE) | FileID (u32 LE).
 	// This is used by experimental leaf encodings to reduce pointer payload.
 	PackedValuePtrSize = 12
+
+	// EntryRevisionSize is the on-page size of a native raw-KV entry revision.
+	EntryRevisionSize = 8
 )
 
 var nativeLittleEndian = func() bool {
@@ -66,6 +69,14 @@ type ValuePtr struct {
 	Length uint32
 	FileID uint32
 }
+
+// EntryRevision is TreeDB's monotonic visible-entry token for raw KV values.
+//
+// A zero revision means legacy/no-revision metadata. Non-zero revisions travel
+// with native write data and leaf entries instead of through a side index.
+type EntryRevision uint64
+
+const LegacyEntryRevision EntryRevision = 0
 
 var checksumZeroField = [4]byte{}
 var checksumZeroBlock = [1024]byte{}

--- a/TreeDB/public.go
+++ b/TreeDB/public.go
@@ -22,11 +22,18 @@ import (
 	"github.com/snissn/gomap/TreeDB/internal/dictdb"
 	"github.com/snissn/gomap/TreeDB/internal/limits"
 	"github.com/snissn/gomap/TreeDB/internal/templatedb"
+	"github.com/snissn/gomap/TreeDB/page"
 	"github.com/snissn/gomap/TreeDB/template"
 )
 
 // Options configures TreeDB. It is re-exported from TreeDB/db for convenience.
 type Options = db.Options
+
+// EntryRevision is TreeDB's native per-entry revision metadata. Revision zero is
+// reserved for legacy entries that do not carry revision metadata.
+type EntryRevision = page.EntryRevision
+
+const LegacyEntryRevision = page.LegacyEntryRevision
 
 type MaintenancePhase = caching.MaintenancePhase
 
@@ -1460,6 +1467,19 @@ func (db *DB) Get(key []byte) ([]byte, error) {
 	return db.backend.Get(key)
 }
 
+// GetVersioned returns the value for a key plus TreeDB's native per-entry
+// revision. Missing keys return a nil value and nil error, matching Get.
+func (db *DB) GetVersioned(key []byte) ([]byte, EntryRevision, error) {
+	key = normalizeRawKVPointKey(key)
+	if err := db.ensureOpen(); err != nil {
+		return nil, LegacyEntryRevision, err
+	}
+	if db.cached != nil {
+		return db.cached.GetVersioned(key)
+	}
+	return db.backend.GetVersioned(key)
+}
+
 // GetMany returns values for keys.
 //
 // Semantics: Returns safe copies of values. Missing keys are returned as nil
@@ -1539,6 +1559,19 @@ func (db *DB) GetAppend(key, dst []byte) ([]byte, error) {
 		return db.cached.GetAppend(key, dst)
 	}
 	return db.backend.GetAppend(key, dst)
+}
+
+// GetVersionedAppend appends the value for key to dst and returns TreeDB's
+// native per-entry revision. Missing/tombstoned keys return dst and
+// ErrKeyNotFound; tombstones preserve their stored revision.
+func (db *DB) GetVersionedAppend(key, dst []byte) ([]byte, EntryRevision, error) {
+	if err := db.ensureOpen(); err != nil {
+		return dst, LegacyEntryRevision, err
+	}
+	if db.cached != nil {
+		return db.cached.GetVersionedAppend(key, dst)
+	}
+	return db.backend.GetVersionedAppend(key, dst)
 }
 
 // Has reports whether a key exists in the database.

--- a/TreeDB/snapshot.go
+++ b/TreeDB/snapshot.go
@@ -17,6 +17,8 @@ type Snapshot interface {
 
 	Get(key []byte) ([]byte, error)
 	GetAppend(key, dst []byte) ([]byte, error)
+	GetVersioned(key []byte) ([]byte, EntryRevision, error)
+	GetVersionedAppend(key, dst []byte) ([]byte, EntryRevision, error)
 	GetManyView(keys [][]byte, fn GetManyViewFunc) error
 	GetUnsafe(key []byte) ([]byte, error)
 	Has(key []byte) (bool, error)

--- a/TreeDB/tree/iterator.go
+++ b/TreeDB/tree/iterator.go
@@ -995,6 +995,24 @@ func (it *Iterator) UnsafeEntry() ([]byte, page.ValuePtr, byte) {
 	return it.currVal, it.currPtr, it.flags
 }
 
+func (it *Iterator) UnsafeEntryWithRevision() ([]byte, page.ValuePtr, byte, page.EntryRevision) {
+	val, ptr, flags := it.UnsafeEntry()
+	if it == nil || !it.valid || len(it.stack) == 0 {
+		return val, ptr, flags, page.LegacyEntryRevision
+	}
+	top := &it.stack[len(it.stack)-1]
+	if top.Node.Type() != page.PageTypeLeaf || top.Index < 0 || top.Index >= int(top.Node.Count()) {
+		return val, ptr, flags, page.LegacyEntryRevision
+	}
+	_, _, _, _, revision, err := top.Node.GetLeafEntryViewWithRevision(uint16(top.Index))
+	if err != nil {
+		it.err = err
+		it.valid = false
+		return val, ptr, flags, page.LegacyEntryRevision
+	}
+	return val, ptr, flags, revision
+}
+
 func (it *Iterator) Key() []byte {
 	return it.UnsafeKey()
 }

--- a/TreeDB/tree/iterator.go
+++ b/TreeDB/tree/iterator.go
@@ -996,8 +996,11 @@ func (it *Iterator) UnsafeEntry() ([]byte, page.ValuePtr, byte) {
 }
 
 func (it *Iterator) UnsafeEntryWithRevision() ([]byte, page.ValuePtr, byte, page.EntryRevision) {
+	if it == nil {
+		return nil, page.ValuePtr{}, 0, page.LegacyEntryRevision
+	}
 	val, ptr, flags := it.UnsafeEntry()
-	if it == nil || !it.valid || len(it.stack) == 0 {
+	if !it.valid || len(it.stack) == 0 {
 		return val, ptr, flags, page.LegacyEntryRevision
 	}
 	top := &it.stack[len(it.stack)-1]

--- a/TreeDB/tree/tree.go
+++ b/TreeDB/tree/tree.go
@@ -597,7 +597,7 @@ func (t *Tree) GetEntry(key []byte) (node.LeafEntry, error) {
 			}
 
 			// Zero-copy view
-			k, v, ptr, flags, err := n.GetLeafEntryView(idx)
+			k, v, ptr, flags, revision, err := n.GetLeafEntryViewWithRevision(idx)
 			if err != nil {
 				return node.LeafEntry{}, err
 			}
@@ -607,6 +607,7 @@ func (t *Tree) GetEntry(key []byte) (node.LeafEntry, error) {
 				Value:    v,
 				ValuePtr: ptr,
 				Flags:    flags,
+				Revision: revision,
 			}, nil
 
 		default:
@@ -621,7 +622,7 @@ func (t *Tree) GetEntryExact(key []byte) (node.LeafEntry, error) {
 	return t.GetEntry(key)
 }
 
-func (t *Tree) lookupLeafValueView(key []byte, dst []byte, appendMode bool) ([]byte, page.ValuePtr, byte, bool, error) {
+func (t *Tree) lookupLeafValueView(key []byte, dst []byte, appendMode bool) ([]byte, page.ValuePtr, byte, page.EntryRevision, bool, error) {
 	currRef := page.PageChildRef(t.rootPageID)
 	verifyAlways := false
 	if t.pager != nil {
@@ -649,7 +650,7 @@ func (t *Tree) lookupLeafValueView(key []byte, dst []byte, appendMode bool) ([]b
 					var ok bool
 					data, leafViewLease, ok, state, err = t.leafLogViewState.ReadLeafLogPageUnsafeViewWithState(ptr)
 					if err != nil {
-						return nil, page.ValuePtr{}, 0, false, err
+						return nil, page.ValuePtr{}, 0, page.LegacyEntryRevision, false, err
 					}
 					if ok {
 						loadedLeafRef = true
@@ -658,7 +659,7 @@ func (t *Tree) lookupLeafValueView(key []byte, dst []byte, appendMode bool) ([]b
 					var ok bool
 					data, leafViewLease, ok, err = t.leafLogView.ReadLeafLogPageUnsafeView(ptr)
 					if err != nil {
-						return nil, page.ValuePtr{}, 0, false, err
+						return nil, page.ValuePtr{}, 0, page.LegacyEntryRevision, false, err
 					}
 					if ok {
 						loadedLeafRef = true
@@ -671,7 +672,7 @@ func (t *Tree) lookupLeafValueView(key []byte, dst []byte, appendMode bool) ([]b
 						data, usedDst, state, err = t.leafLogToState.ReadLeafLogPageUnsafeToWithState(ptr, leafScratch.buf)
 						if err != nil {
 							putLeafRefPageScratch(leafScratch)
-							return nil, page.ValuePtr{}, 0, false, err
+							return nil, page.ValuePtr{}, 0, page.LegacyEntryRevision, false, err
 						}
 						loadedLeafRef = true
 						leafScratchOwned = usedDst
@@ -684,7 +685,7 @@ func (t *Tree) lookupLeafValueView(key []byte, dst []byte, appendMode bool) ([]b
 						data, usedDst, err = t.leafLogToReader.ReadLeafLogPageUnsafeTo(ptr, leafScratch.buf)
 						if err != nil {
 							putLeafRefPageScratch(leafScratch)
-							return nil, page.ValuePtr{}, 0, false, err
+							return nil, page.ValuePtr{}, 0, page.LegacyEntryRevision, false, err
 						}
 						loadedLeafRef = true
 						leafScratchOwned = usedDst
@@ -697,7 +698,7 @@ func (t *Tree) lookupLeafValueView(key []byte, dst []byte, appendMode bool) ([]b
 						data, usedDst, err = t.slabToReader.ReadUnsafeTo(ptr.ValuePtr(), leafScratch.buf)
 						if err != nil {
 							putLeafRefPageScratch(leafScratch)
-							return nil, page.ValuePtr{}, 0, false, err
+							return nil, page.ValuePtr{}, 0, page.LegacyEntryRevision, false, err
 						}
 						loadedLeafRef = true
 						leafScratchOwned = usedDst
@@ -709,7 +710,7 @@ func (t *Tree) lookupLeafValueView(key []byte, dst []byte, appendMode bool) ([]b
 						data, err = t.slabAppender.ReadUnsafeAppend(ptr.ValuePtr(), leafScratch.buf[:0])
 						if err != nil {
 							putLeafRefPageScratch(leafScratch)
-							return nil, page.ValuePtr{}, 0, false, err
+							return nil, page.ValuePtr{}, 0, page.LegacyEntryRevision, false, err
 						}
 						loadedLeafRef = true
 						leafScratchOwned = true
@@ -727,7 +728,7 @@ func (t *Tree) lookupLeafValueView(key []byte, dst []byte, appendMode bool) ([]b
 						if leafScratchOwned {
 							putLeafRefPageScratch(leafScratch)
 						}
-						return nil, page.ValuePtr{}, 0, false, err
+						return nil, page.ValuePtr{}, 0, page.LegacyEntryRevision, false, err
 					}
 					if verifiedNow && state.RecordChecksumVerified && state.CacheEntryPresent {
 						if leafViewLease != nil {
@@ -744,7 +745,7 @@ func (t *Tree) lookupLeafValueView(key []byte, dst []byte, appendMode bool) ([]b
 
 		if !loadedLeafRef {
 			if err := t.loadChildRefViewInto(&n, currRef, verifyAlways, false); err != nil {
-				return nil, page.ValuePtr{}, 0, false, err
+				return nil, page.ValuePtr{}, 0, page.LegacyEntryRevision, false, err
 			}
 		}
 
@@ -752,26 +753,26 @@ func (t *Tree) lookupLeafValueView(key []byte, dst []byte, appendMode bool) ([]b
 		case page.PageTypeInternal:
 			if depth == 0 {
 				if low, high, ok, err := n.InternalFenceBounds(); err != nil {
-					return nil, page.ValuePtr{}, 0, false, err
+					return nil, page.ValuePtr{}, 0, page.LegacyEntryRevision, false, err
 				} else if ok {
 					if len(low) > 0 && compareTreeKey(key, low) < 0 {
-						return nil, page.ValuePtr{}, 0, false, ErrKeyNotFound
+						return nil, page.ValuePtr{}, 0, page.LegacyEntryRevision, false, ErrKeyNotFound
 					}
 					if len(high) > 0 && compareTreeKey(key, high) >= 0 {
-						return nil, page.ValuePtr{}, 0, false, ErrKeyNotFound
+						return nil, page.ValuePtr{}, 0, page.LegacyEntryRevision, false, ErrKeyNotFound
 					}
 				}
 			}
 			if n.InternalLeafLogRefsEnabled() {
 				childRef, _, err := n.SearchInternalChildRef(key)
 				if err != nil {
-					return nil, page.ValuePtr{}, 0, false, err
+					return nil, page.ValuePtr{}, 0, page.LegacyEntryRevision, false, err
 				}
 				currRef = childRef
 			} else {
 				childID, _, err := n.SearchInternalChildID(key)
 				if err != nil {
-					return nil, page.ValuePtr{}, 0, false, err
+					return nil, page.ValuePtr{}, 0, page.LegacyEntryRevision, false, err
 				}
 				currRef = page.PageChildRef(childID)
 			}
@@ -785,7 +786,7 @@ func (t *Tree) lookupLeafValueView(key []byte, dst []byte, appendMode bool) ([]b
 				if leafScratchOwned {
 					putLeafRefPageScratch(leafScratch)
 				}
-				return nil, page.ValuePtr{}, 0, false, err
+				return nil, page.ValuePtr{}, 0, page.LegacyEntryRevision, false, err
 			}
 			if !found {
 				if leafViewLease != nil {
@@ -794,10 +795,10 @@ func (t *Tree) lookupLeafValueView(key []byte, dst []byte, appendMode bool) ([]b
 				if leafScratchOwned {
 					putLeafRefPageScratch(leafScratch)
 				}
-				return nil, page.ValuePtr{}, 0, false, ErrKeyNotFound
+				return nil, page.ValuePtr{}, 0, page.LegacyEntryRevision, false, ErrKeyNotFound
 			}
 
-			val, ptr, flags, err := n.GetLeafValueView(idx)
+			_, val, ptr, flags, revision, err := n.GetLeafEntryViewWithRevision(idx)
 			if err != nil {
 				if leafViewLease != nil {
 					leafViewLease.ReleaseLeafLogPageView()
@@ -805,7 +806,7 @@ func (t *Tree) lookupLeafValueView(key []byte, dst []byte, appendMode bool) ([]b
 				if leafScratchOwned {
 					putLeafRefPageScratch(leafScratch)
 				}
-				return nil, page.ValuePtr{}, 0, false, err
+				return nil, page.ValuePtr{}, 0, page.LegacyEntryRevision, false, err
 			}
 			if appendMode && flags&(node.FlagPointer|node.FlagTombstone) == 0 {
 				out := dst
@@ -818,7 +819,7 @@ func (t *Tree) lookupLeafValueView(key []byte, dst []byte, appendMode bool) ([]b
 				if leafScratchOwned {
 					putLeafRefPageScratch(leafScratch)
 				}
-				return out, ptr, flags, true, nil
+				return out, ptr, flags, revision, true, nil
 			}
 			if leafViewLease != nil {
 				leafViewLease.ReleaseLeafLogPageView()
@@ -826,7 +827,7 @@ func (t *Tree) lookupLeafValueView(key []byte, dst []byte, appendMode bool) ([]b
 			if leafScratchOwned {
 				putLeafRefPageScratch(leafScratch)
 			}
-			return val, ptr, flags, false, nil
+			return val, ptr, flags, revision, false, nil
 
 		default:
 			if leafViewLease != nil {
@@ -835,15 +836,15 @@ func (t *Tree) lookupLeafValueView(key []byte, dst []byte, appendMode bool) ([]b
 			if leafScratchOwned {
 				putLeafRefPageScratch(leafScratch)
 			}
-			return nil, page.ValuePtr{}, 0, false, fmt.Errorf("invalid page type %d", n.Type())
+			return nil, page.ValuePtr{}, 0, page.LegacyEntryRevision, false, fmt.Errorf("invalid page type %d", n.Type())
 		}
 	}
 
-	return nil, page.ValuePtr{}, 0, false, errors.New("tree too deep")
+	return nil, page.ValuePtr{}, 0, page.LegacyEntryRevision, false, errors.New("tree too deep")
 }
 
 func (t *Tree) GetUnsafe(key []byte) ([]byte, error) {
-	val, ptr, flags, _, err := t.lookupLeafValueView(key, nil, false)
+	val, ptr, flags, _, _, err := t.lookupLeafValueView(key, nil, false)
 	if err != nil {
 		return nil, err
 	}
@@ -943,7 +944,7 @@ func (t *Tree) appendPointerValueForKey(key []byte, ptr page.ValuePtr, dst []byt
 // GetAppend appends the value for key to dst and returns the grown slice.
 // If key is missing/tombstoned, it returns dst and ErrKeyNotFound.
 func (t *Tree) GetAppend(key, dst []byte) ([]byte, error) {
-	val, ptr, flags, appendedDirect, err := t.lookupLeafValueView(key, dst, true)
+	val, ptr, flags, _, appendedDirect, err := t.lookupLeafValueView(key, dst, true)
 	if err != nil {
 		return dst, err
 	}
@@ -963,6 +964,34 @@ func (t *Tree) GetAppend(key, dst []byte) ([]byte, error) {
 	}
 	recordTreeGetAppendInline(len(val))
 	return append(dst, val...), nil
+}
+
+// GetVersionedAppend appends the value for key to dst and returns the entry
+// revision stored beside the value/pointer metadata. Missing keys return
+// ErrKeyNotFound and LegacyEntryRevision; tombstones return ErrKeyNotFound with
+// their stored tombstone revision.
+func (t *Tree) GetVersionedAppend(key, dst []byte) ([]byte, page.EntryRevision, error) {
+	val, ptr, flags, revision, appendedDirect, err := t.lookupLeafValueView(key, dst, true)
+	if err != nil {
+		return dst, revision, err
+	}
+	if appendedDirect {
+		recordTreeGetAppendInline(len(val) - len(dst))
+		return val, revision, nil
+	}
+	if flags&node.FlagTombstone != 0 {
+		return dst, revision, ErrKeyNotFound
+	}
+	if flags&node.FlagPointer != 0 {
+		out, err := t.appendPointerValueForKey(key, ptr, dst)
+		return out, revision, err
+	}
+	if val == nil {
+		recordTreeGetAppendInline(0)
+		return dst, revision, nil
+	}
+	recordTreeGetAppendInline(len(val))
+	return append(dst, val...), revision, nil
 }
 
 type getManyLeafProbe struct {

--- a/TreeDB/zipper/zipper.go
+++ b/TreeDB/zipper/zipper.go
@@ -1203,6 +1203,7 @@ func (z *Zipper) leafBuilderOptions(ops []batch.Entry) node.BuilderOptions {
 		LeafColumnar:          z != nil && z.indexColumnarLeaves,
 		PackedValuePtr:        z != nil && z.indexPackedValuePtr,
 		InternalBaseDelta:     z != nil && z.indexInternalBaseDelta,
+		EntryRevisions:        batchHasEntryRevisions(ops),
 	}
 	if z == nil || !z.adaptiveLeafEncoding {
 		return base
@@ -1253,6 +1254,26 @@ func (z *Zipper) leafBuilderOptions(ops []batch.Entry) node.BuilderOptions {
 		})
 	}
 	return node.AdaptiveLeafBuilderOptions(base, entries)
+}
+
+func batchHasEntryRevisions(ops []batch.Entry) bool {
+	for i := range ops {
+		if ops[i].Revision != page.LegacyEntryRevision {
+			return true
+		}
+	}
+	return false
+}
+
+func (z *Zipper) enableLeafBuilderEntryRevisions(b *node.Builder, ops []batch.Entry) {
+	if b == nil || b.LeafEntryRevisionsEnabled() {
+		return
+	}
+	pageID := b.PageID()
+	opts := z.leafBuilderOptions(ops)
+	opts.EntryRevisions = true
+	b.ResetWithOptions(b.Data(), page.PageTypeLeaf, opts)
+	b.SetPageID(pageID)
 }
 
 func (z *Zipper) newPooledBuilderForType(data []byte, typ page.PageType, ops []batch.Entry) *node.Builder {
@@ -2173,6 +2194,9 @@ func (z *Zipper) mergeLeaf(oldNode *node.Node, builder *node.Builder, ops []batc
 	oldIdx := uint16(0)
 	oldCount := oldNode.Count()
 	opIdx := 0
+	if oldNode.LeafEntryRevisionsEnabled() {
+		z.enableLeafBuilderEntryRevisions(builder, ops)
+	}
 
 	var (
 		splits                  []Split
@@ -2284,6 +2308,13 @@ func (z *Zipper) mergeLeaf(oldNode *node.Node, builder *node.Builder, ops []batc
 		}
 		metrics.SlabDeadBytesByFile[ptr.FileID] += int64(ptr.Length)
 	}
+	leafEntrySizeWithRevision := func(b *node.Builder, key, val []byte, flags byte, revision page.EntryRevision) (entrySize, prefixLen, suffixLen int) {
+		entrySize, prefixLen, suffixLen = b.LeafEntrySizeWithPrefix(key, val, flags)
+		if revision != page.LegacyEntryRevision && !b.LeafEntryRevisionsEnabled() {
+			entrySize = b.LeafEntrySizeWithRevision(key, val, flags, revision)
+		}
+		return entrySize, prefixLen, suffixLen
+	}
 
 	for {
 		// Pick next key: min(oldNode[oldIdx], ops[opIdx])
@@ -2291,6 +2322,7 @@ func (z *Zipper) mergeLeaf(oldNode *node.Node, builder *node.Builder, ops []batc
 		var oldLoaded bool
 		var oldKey, oldVal []byte
 		var oldPtr page.ValuePtr
+		var oldRevision page.EntryRevision
 		var oldFlags byte
 
 		if oldIdx >= oldCount && opIdx >= len(ops) {
@@ -2305,7 +2337,7 @@ func (z *Zipper) mergeLeaf(oldNode *node.Node, builder *node.Builder, ops []batc
 			// Compare
 			// Optimization: decode old entry once; reuse it below when we
 			// consume from oldNode in the same loop iteration.
-			k, v, ptr, f, err := oldNode.GetLeafEntryView(oldIdx)
+			k, v, ptr, f, rev, err := oldNode.GetLeafEntryViewWithRevision(oldIdx)
 			if err != nil {
 				return page.ChildRef{}, nil, err
 			}
@@ -2313,6 +2345,7 @@ func (z *Zipper) mergeLeaf(oldNode *node.Node, builder *node.Builder, ops []batc
 			oldKey = k
 			oldVal = v
 			oldPtr = ptr
+			oldRevision = rev
 			oldFlags = f
 			batchKey := ops[opIdx].Key
 
@@ -2335,6 +2368,7 @@ func (z *Zipper) mergeLeaf(oldNode *node.Node, builder *node.Builder, ops []batc
 		var key, val []byte
 		var flags byte
 		var valPtr page.ValuePtr
+		revision := page.LegacyEntryRevision
 		insertedFromBatch := false
 
 		if useBatch {
@@ -2345,6 +2379,7 @@ func (z *Zipper) mergeLeaf(oldNode *node.Node, builder *node.Builder, ops []batc
 			}
 			insertedFromBatch = true
 			key = op.Key
+			revision = op.Revision
 			if op.IsPtr {
 				flags = node.FlagPointer
 				valPtr = op.ValuePtr
@@ -2357,6 +2392,7 @@ func (z *Zipper) mergeLeaf(oldNode *node.Node, builder *node.Builder, ops []batc
 			if oldLoaded {
 				key = oldKey
 				flags = oldFlags
+				revision = oldRevision
 				if oldFlags&node.FlagPointer != 0 {
 					valPtr = oldPtr
 				} else {
@@ -2364,12 +2400,13 @@ func (z *Zipper) mergeLeaf(oldNode *node.Node, builder *node.Builder, ops []batc
 				}
 			} else {
 				// Optimization: View
-				k, v, ptr, f, err := oldNode.GetLeafEntryView(oldIdx)
+				k, v, ptr, f, rev, err := oldNode.GetLeafEntryViewWithRevision(oldIdx)
 				if err != nil {
 					return page.ChildRef{}, nil, err
 				}
 				key = k
 				flags = f
+				revision = rev
 				if f&node.FlagPointer != 0 {
 					valPtr = ptr
 				} else {
@@ -2387,12 +2424,12 @@ func (z *Zipper) mergeLeaf(oldNode *node.Node, builder *node.Builder, ops []batc
 		}
 
 		// Insert into target builder
-		entrySize, prefixLen, suffixLen := target.LeafEntrySizeWithPrefix(key, val, flags)
+		entrySize, prefixLen, suffixLen := leafEntrySizeWithRevision(target, key, val, flags, revision)
 		var err error
 		if z.leafSoftFull(target, entrySize) {
 			err = node.ErrNodeFull
 		} else {
-			err = target.AddLeafEntryWithPrefix(key, val, flags, valPtr, entrySize, prefixLen, suffixLen)
+			err = target.AddLeafEntryWithPrefixRevision(key, val, flags, valPtr, revision, entrySize, prefixLen, suffixLen)
 		}
 		if err == node.ErrNodeFull {
 			// SPLIT!
@@ -2440,6 +2477,9 @@ func (z *Zipper) mergeLeaf(oldNode *node.Node, builder *node.Builder, ops []batc
 			}
 			splitBuilder := z.newPooledLeafBuilder(sdata, ops[startIdx:])
 			splitBuilder.SetPageID(sid)
+			if target.LeafEntryRevisionsEnabled() {
+				z.enableLeafBuilderEntryRevisions(splitBuilder, ops[startIdx:])
+			}
 
 			// Record split
 			// Use the full first key of the right node as the parent separator.
@@ -2466,8 +2506,8 @@ func (z *Zipper) mergeLeaf(oldNode *node.Node, builder *node.Builder, ops []batc
 			targetOuterLeafDataPooled = z.outerLeavesInValueLog && reuseOuterLeafPages
 
 			// Retry insert
-			entrySize, prefixLen, suffixLen = target.LeafEntrySizeWithPrefix(key, val, flags)
-			err = target.AddLeafEntryWithPrefix(key, val, flags, valPtr, entrySize, prefixLen, suffixLen)
+			entrySize, prefixLen, suffixLen = leafEntrySizeWithRevision(target, key, val, flags, revision)
+			err = target.AddLeafEntryWithPrefixRevision(key, val, flags, valPtr, revision, entrySize, prefixLen, suffixLen)
 			if err != nil {
 				return page.ChildRef{}, nil, err
 			}
@@ -3188,27 +3228,31 @@ func (z *Zipper) coalesceLeafChildren(entries []internalEntry, budget *maintenan
 	const underfullPPM = 350_000
 	pageCap := page.PageSize - node.NodeHeaderSize
 
-	leafEntryBytes := func(key, val []byte, ptr page.ValuePtr, flags byte) int {
+	leafEntryBytes := func(key, val []byte, ptr page.ValuePtr, flags byte, entryRevisions bool) int {
 		entrySize := 7 + len(key)
 		if flags&node.FlagPointer != 0 {
 			entrySize += page.ValuePtrSize
 		} else {
 			entrySize += len(val)
 		}
+		if entryRevisions {
+			entrySize += page.EntryRevisionSize
+		}
 		return entrySize + node.DirectoryEntrySize
 	}
 
 	leafRequiredBytes := func(n *node.Node) (int, error) {
 		sum := 0
+		entryRevisions := n.LeafEntryRevisionsEnabled()
 		for i := uint16(0); i < n.Count(); i++ {
-			k, v, ptr, flags, err := n.GetLeafEntryView(i)
+			k, v, ptr, flags, _, err := n.GetLeafEntryViewWithRevision(i)
 			if err != nil {
 				return 0, err
 			}
 			if flags&node.FlagTombstone != 0 {
 				continue
 			}
-			sum += leafEntryBytes(k, v, ptr, flags)
+			sum += leafEntryBytes(k, v, ptr, flags, entryRevisions)
 			if sum > pageCap {
 				return sum, nil
 			}
@@ -3241,17 +3285,20 @@ func (z *Zipper) coalesceLeafChildren(entries []internalEntry, budget *maintenan
 		}
 		b := z.newLeafBuilder(data, nil)
 		b.SetPageID(pid)
+		if left.LeafEntryRevisionsEnabled() || right.LeafEntryRevisionsEnabled() {
+			z.enableLeafBuilderEntryRevisions(b, nil)
+		}
 
 		addAll := func(n *node.Node) error {
 			for i := uint16(0); i < n.Count(); i++ {
-				k, v, ptr, flags, err := n.GetLeafEntryView(i)
+				k, v, ptr, flags, revision, err := n.GetLeafEntryViewWithRevision(i)
 				if err != nil {
 					return err
 				}
 				if flags&node.FlagTombstone != 0 {
 					continue
 				}
-				if err := b.AddLeafEntry(k, v, flags, ptr); err != nil {
+				if err := b.AddLeafEntryWithRevision(k, v, flags, ptr, revision); err != nil {
 					return err
 				}
 			}
@@ -3325,16 +3372,19 @@ func (z *Zipper) coalesceLeafChildren(entries []internalEntry, budget *maintenan
 		}
 		b := z.newLeafBuilder(data, nil)
 		b.SetPageID(pid)
+		if n.LeafEntryRevisionsEnabled() {
+			z.enableLeafBuilderEntryRevisions(b, nil)
+		}
 
 		for i := uint16(0); i < n.Count(); i++ {
-			k, v, ptr, flags, err := n.GetLeafEntryView(i)
+			k, v, ptr, flags, revision, err := n.GetLeafEntryViewWithRevision(i)
 			if err != nil {
 				return page.ChildRef{}, err
 			}
 			if flags&node.FlagTombstone != 0 {
 				continue
 			}
-			if err := b.AddLeafEntry(k, v, flags, ptr); err != nil {
+			if err := b.AddLeafEntryWithRevision(k, v, flags, ptr, revision); err != nil {
 				return page.ChildRef{}, err
 			}
 		}
@@ -3402,19 +3452,24 @@ func (z *Zipper) coalesceLeafChildren(entries []internalEntry, budget *maintenan
 		}
 		lb := z.newLeafBuilder(ldata, nil)
 		lb.SetPageID(lid)
+		entryRevisions := left.LeafEntryRevisionsEnabled() || right.LeafEntryRevisionsEnabled()
+		if entryRevisions {
+			z.enableLeafBuilderEntryRevisions(lb, nil)
+		}
 
 		// Collect combined entries in-order without copying.
 		type ev struct {
-			k     []byte
-			v     []byte
-			ptr   page.ValuePtr
-			flags byte
-			size  int
+			k        []byte
+			v        []byte
+			ptr      page.ValuePtr
+			revision page.EntryRevision
+			flags    byte
+			size     int
 		}
 		combined := make([]ev, 0, int(left.Count()+right.Count()))
 		for _, src := range []*node.Node{left, right} {
 			for i := uint16(0); i < src.Count(); i++ {
-				k, v, ptr, flags, err := src.GetLeafEntryView(i)
+				k, v, ptr, flags, revision, err := src.GetLeafEntryViewWithRevision(i)
 				if err != nil {
 					if !z.outerLeavesInValueLog {
 						retired = append(retired, lid, rid)
@@ -3427,7 +3482,7 @@ func (z *Zipper) coalesceLeafChildren(entries []internalEntry, budget *maintenan
 				if z.leafPrefixCompression {
 					k = append([]byte(nil), k...)
 				}
-				combined = append(combined, ev{k: k, v: v, ptr: ptr, flags: flags, size: leafEntryBytes(k, v, ptr, flags)})
+				combined = append(combined, ev{k: k, v: v, ptr: ptr, revision: revision, flags: flags, size: leafEntryBytes(k, v, ptr, flags, entryRevisions)})
 			}
 		}
 		if len(combined) < 2 {
@@ -3478,9 +3533,12 @@ func (z *Zipper) coalesceLeafChildren(entries []internalEntry, budget *maintenan
 
 		rb := z.newLeafBuilder(rdata, nil)
 		rb.SetPageID(rid)
+		if entryRevisions {
+			z.enableLeafBuilderEntryRevisions(rb, nil)
+		}
 
 		for i := 0; i < bestSplitAt; i++ {
-			if err := lb.AddLeafEntry(combined[i].k, combined[i].v, combined[i].flags, combined[i].ptr); err != nil {
+			if err := lb.AddLeafEntryWithRevision(combined[i].k, combined[i].v, combined[i].flags, combined[i].ptr, combined[i].revision); err != nil {
 				if !z.outerLeavesInValueLog {
 					retired = append(retired, lid, rid)
 				}
@@ -3489,7 +3547,7 @@ func (z *Zipper) coalesceLeafChildren(entries []internalEntry, budget *maintenan
 		}
 		rightStart = append([]byte(nil), combined[bestSplitAt].k...)
 		for i := bestSplitAt; i < len(combined); i++ {
-			if err := rb.AddLeafEntry(combined[i].k, combined[i].v, combined[i].flags, combined[i].ptr); err != nil {
+			if err := rb.AddLeafEntryWithRevision(combined[i].k, combined[i].v, combined[i].flags, combined[i].ptr, combined[i].revision); err != nil {
 				if !z.outerLeavesInValueLog {
 					retired = append(retired, lid, rid)
 				}


### PR DESCRIPTION
## Objective

Store TreeDB entry revisions in native write/read data instead of a sidecar, preserve explicit revisions through command-WAL payload/replay, and expose versioned point reads from the same lookup path. Closes #3422.

## Context

This is the M1 substrate for #3418 after the M0 contract in #3420. It makes revisions travel through `batch.Entry`, memtables, iterators, leaf encodings, builders, zipper rebuild/copy paths, snapshots, command-WAL raw KV frames, and public versioned reads so #3423/#3424 can add durable deterministic assignment and conditional transaction validation without adapter emulation.

## Non-goals

Automatic revision assignment, durable `MaxEntryRevision`/revision floor persistence, Raft apply identity, and conditional transaction conflict validation remain in #3423/#3424. This PR preserves explicit revisions and keeps legacy revision zero for old/ordinary entries.

## Design

- Adds `page.EntryRevision`, `LegacyEntryRevision`, and a leaf revision flag with fixed-width little-endian revision columns/trailers documented in `TreeDB/docs/spec/storage-format.md`.
- Adds revision-aware batch helpers and optional revision iterator interfaces so hot paths carry metadata without side maps.
- Extends skiplist, append-only, hash-sorted, and btree memtables to store revisions alongside existing entry payloads.
- Preserves revisions through flush planning, value-log pointer publication, bulk build, zipper apply/split/rebuild/rebalance, collection freeze-sort runs, root-domain wrappers, and merge wrappers.
- Adds a revision-bearing raw KV command-WAL payload version for point set/delete/SetRID operations and replays it through revision-aware batch methods. Range deletes remain range operations and do not carry a per-item revision.
- Adds `GetVersioned` / `GetVersionedAppend` on backend, cached, snapshot, DB, and top-level TreeDB APIs.

## Scope

- Includes: `TreeDB/batch`, `TreeDB/internal/memtable`, `TreeDB/internal/skiplist`, `TreeDB/internal/iterator`, `TreeDB/internal/merging`, `TreeDB/internal/commitlog`, `TreeDB/node`, `TreeDB/tree`, `TreeDB/zipper`, `TreeDB/db`, `TreeDB/caching`, `TreeDB/collections`, public API, docs/tests/benchmarks.
- Excludes: automatic revision allocator, durable revision floor, Raft apply identity, and conditional transaction API.

## Correctness

Tests run:

```text
GOWORK=off go test ./TreeDB/db ./TreeDB/caching ./TreeDB/internal/merging -run 'Test.*Versioned|Test.*Revision' -count=1
GOWORK=off go test ./TreeDB/batch ./TreeDB/node ./TreeDB/internal/skiplist ./TreeDB/internal/memtable ./TreeDB/internal/bulk ./TreeDB/tree ./TreeDB/zipper ./TreeDB/caching ./TreeDB/db ./TreeDB/collections ./TreeDB/internal/merging -run 'TestBatchRevisionFastHelpers|TestLeafEntryRevision|Test.*Revision|Test.*Versioned|TestHashSortedApplyStealSortedBatch|TestAppendOnlyApplyStealSortedBatch|TestBTree|TestBuild|TestZipper|TestIterator|TestFreezeSort' -count=1
GOWORK=off go test ./TreeDB/internal/commitlog ./TreeDB/db ./TreeDB/tree ./TreeDB/caching -run 'TestCommandWALRawKVBatchRevisionRoundTrip|TestCommandWALRecoveryPreservesEntryRevision|TestCommandWALPointerBatchReplaysThroughRIDFence|TestCommandWALRawKVBatchSetRIDRoundTrip|TestCommandWALFormatGoldenV1RawKVBatch|TestGetVersionedPreservesBatchEntryRevision|Test.*Versioned|Test.*Revision' -count=1
GOWORK=off go test ./TreeDB/... -count=1
git diff --check
```

Added coverage for leaf revision format round trips, sparse revision leaf builds, batch fast helpers, memtable flush preservation, freeze-sort collection preservation, public/backend/cached versioned reads, merge iterator revision forwarding, command-WAL payload revision round trips, and crash/reopen replay of inline plus value-log pointer revisions.

## Performance

Benchmarks run:

```text
GOWORK=off go test ./TreeDB/db -run '^$' -bench 'BenchmarkGetVersioned' -benchmem -benchtime=300ms -count=3
GOWORK=off go test ./TreeDB/batch ./TreeDB/internal/memtable -run '^$' -bench 'BenchmarkBatch(SetView|AppendViewTrustedSortedUnique)RevisionOverhead|BenchmarkMemtableSetEntryRevisionOverhead_ModeCompare' -benchmem -benchtime=300ms -count=3
GOWORK=off go test ./TreeDB/db -run '^$' -bench 'BenchmarkCommandWALRawKVDirectWrite' -benchmem -benchtime=300ms -count=3
```

Key results on this host:

```text
BenchmarkGetVersioned-12: 69.32 / 72.08 / 75.32 ns/op, 0 B/op, 0 allocs/op
BenchmarkBatchSetViewRevisionOverhead legacy: 15.49-16.85 ns/op, 0 B/op, 0 allocs/op
BenchmarkBatchSetViewRevisionOverhead revision: 15.92-16.88 ns/op, 0 B/op, 0 allocs/op
BenchmarkBatchAppendViewTrustedSortedUniqueRevisionOverhead legacy: 13.65-13.89 ns/op, 0 B/op, 0 allocs/op
BenchmarkBatchAppendViewTrustedSortedUniqueRevisionOverhead revision: 13.77-14.80 ns/op, 0 B/op, 0 allocs/op
BenchmarkMemtableSetEntryRevisionOverhead_ModeCompare: all legacy/revision modes reported 0 allocs/op
BenchmarkCommandWALRawKVDirectWrite backend_no_command_wal: 11495-11986 ns/op, 17755-17758 B/op, 48 allocs/op
BenchmarkCommandWALRawKVDirectWrite command_wal_raw_kv: 12691-13695 ns/op, 18369 B/op, 69 allocs/op
BenchmarkCommandWALRawKVDirectWriteRevision backend_no_command_wal_revision: 11538-13037 ns/op, 17764-17771 B/op, 48 allocs/op
BenchmarkCommandWALRawKVDirectWriteRevision command_wal_raw_kv_revision: 13115-13816 ns/op, 18369-18371 B/op, 69 allocs/op
```

No Go allocation was added to the explicit batch revision helpers, memtable revision modes, versioned append point-read path, or command-WAL point-write path relative to the matching legacy command-WAL benchmark.

## Rollout / Toggle Plan

Default behavior remains compatible: ordinary entries keep `LegacyEntryRevision` until #3423 assigns durable revisions. Revision columns are only enabled for leaves that need them, and legacy reads keep returning user values without exposing revision bytes. Revision-bearing command-WAL payloads are only emitted when an operation carries a nonzero explicit revision.

## Follow-ups

- #3423: deterministic revision assignment through WAL append/replay/reopen and Raft-facing apply ordering.
- #3424: high-throughput conditional transactions using native revisions.
- #3425: downstream adapter readiness and final benchmark closeout.

## Optimization PR Checklist (TreeDB)

### Scope
- [x] Single, clear objective for this PR
- [x] Explicit include list documented above
- [x] Explicit exclude list documented above

### Safety / Correctness
- [x] Format change documented
- [x] Length/format parsing remains bounded by existing leaf entry validation
- [x] No new mmap usage on mutable/truncating files

### Tests
- [x] Added deterministic regression tests for revision propagation
- [x] Ran full TreeDB test suite locally

### Benchmarks / Measurements
- [x] Added/updated revision hot-path benchmarks
- [x] Reported benchmark results in this PR description

### Docs
- [x] Updated storage format docs
