### PR TITLE
feat(treedb): make entry revisions durable

### DIFF
--- a/TreeDB/batch/batch.go
+++ b/TreeDB/batch/batch.go
@@ -952,6 +952,60 @@ func (b *Batch) HasDeleteRanges() bool {
 	return b != nil && b.hasDeleteRanges
 }
 
+// AssignLegacyPointRevisions assigns revision to point entries that do not
+// already carry explicit revision metadata. It returns the maximum point
+// revision observed after assignment.
+func (b *Batch) AssignLegacyPointRevisions(revision page.EntryRevision) page.EntryRevision {
+	if b == nil || len(b.entries) == 0 {
+		return page.LegacyEntryRevision
+	}
+	maxRevision := page.LegacyEntryRevision
+	for i := range b.entries {
+		entry := &b.entries[i]
+		if entry.Type == OpDeleteRange {
+			continue
+		}
+		if entry.Revision == page.LegacyEntryRevision && revision != page.LegacyEntryRevision {
+			entry.Revision = revision
+		}
+		if entry.Revision > maxRevision {
+			maxRevision = entry.Revision
+		}
+	}
+	return maxRevision
+}
+
+// PointRevisionStats returns the highest point-entry revision and whether any
+// point entry is still legacy-versioned.
+func (b *Batch) PointRevisionStats() (page.EntryRevision, bool) {
+	if b == nil || len(b.entries) == 0 {
+		return page.LegacyEntryRevision, false
+	}
+	maxRevision := page.LegacyEntryRevision
+	hasLegacy := false
+	for i := range b.entries {
+		entry := &b.entries[i]
+		if entry.Type == OpDeleteRange {
+			continue
+		}
+		if entry.Revision == page.LegacyEntryRevision {
+			hasLegacy = true
+			continue
+		}
+		if entry.Revision > maxRevision {
+			maxRevision = entry.Revision
+		}
+	}
+	return maxRevision, hasLegacy
+}
+
+// MaxPointRevision returns the highest explicit point-entry revision without
+// mutating the batch.
+func (b *Batch) MaxPointRevision() page.EntryRevision {
+	maxRevision, _ := b.PointRevisionStats()
+	return maxRevision
+}
+
 // OrderedEntries returns the submission-order operation stream. The returned
 // slice aliases batch-owned storage and must be treated as read-only.
 func (b *Batch) OrderedEntries() []Entry {

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -7787,6 +7787,22 @@ type BackendDB interface {
 	Stats() map[string]string
 }
 
+type backendStateReader interface {
+	State() *backenddb.DBState
+}
+
+func backendMaxEntryRevision(backend BackendDB) page.EntryRevision {
+	if backend == nil {
+		return page.LegacyEntryRevision
+	}
+	if reader, ok := backend.(backendStateReader); ok {
+		if state := reader.State(); state != nil {
+			return state.MaxEntryRevision
+		}
+	}
+	return page.EntryRevision(parseUintStat(backend.Stats(), "treedb.max_entry_revision"))
+}
+
 type backendCheckpointer interface {
 	Checkpoint() error
 }
@@ -9993,30 +10009,58 @@ func cachedBatchWriteUseSteal(db *DB, mt memtable.Table) (useSteal bool, suppres
 	return true, false
 }
 
-func memtableBatchDelete(mt memtable.Table, useSteal bool, key []byte, revision page.EntryRevision) {
+func memtableBatchDelete(mt memtable.Table, useSteal bool, key []byte, revision page.EntryRevision) error {
 	if revision != page.LegacyEntryRevision {
 		if useSteal {
 			if writer, ok := mt.(memtable.RevisionStealTable); ok {
 				writer.SetEntryStealWithRevision(key, nil, page.ValuePtr{}, node.FlagTombstone, revision)
-				return
+				return nil
 			}
 		}
 		if writer, ok := mt.(memtable.RevisionTable); ok {
 			writer.SetEntryWithRevision(key, nil, page.ValuePtr{}, node.FlagTombstone, revision)
-			return
+			return nil
 		}
 		if useSteal {
 			mt.SetEntrySteal(key, nil, page.ValuePtr{}, node.FlagTombstone)
-			return
+			return nil
 		}
-		mt.SetEntry(key, nil, page.ValuePtr{}, node.FlagTombstone)
-		return
+		return mt.DeleteWithCallback(key, nil)
 	}
 	if useSteal {
 		mt.DeleteSteal(key)
-		return
+		return nil
 	}
 	mt.Delete(key)
+	return nil
+}
+
+func memtableSetDirect(mt memtable.Table, key, value []byte, ptr page.ValuePtr, flags byte, revision page.EntryRevision) {
+	if revision != page.LegacyEntryRevision {
+		if writer, ok := mt.(memtable.RevisionTable); ok {
+			writer.SetEntryWithRevision(key, value, ptr, flags, revision)
+			return
+		}
+	}
+	mt.SetEntry(key, value, ptr, flags)
+}
+
+func memtableSetDirectBorrowValue(mt memtable.Table, key, value []byte, ptr page.ValuePtr, flags byte, revision page.EntryRevision) {
+	if revision != page.LegacyEntryRevision {
+		if borrower, ok := mt.(memtable.RevisionValueBorrower); ok && len(value) > 0 {
+			borrower.SetEntryBorrowValueWithRevision(key, value, ptr, flags, revision)
+			return
+		}
+		if writer, ok := mt.(memtable.RevisionTable); ok {
+			writer.SetEntryWithRevision(key, value, ptr, flags, revision)
+			return
+		}
+	}
+	if borrower, ok := mt.(memtable.ValueBorrower); ok && len(value) > 0 {
+		borrower.SetEntryBorrowValue(key, value, ptr, flags)
+		return
+	}
+	mt.SetEntry(key, value, ptr, flags)
 }
 
 func reserveMemtableEntries(mt memtable.Table, additional int) {
@@ -10101,6 +10145,42 @@ func memtableBatchSet(mt memtable.Table, useSteal bool, allowBorrow bool, storeI
 		}
 	}
 	mt.Set(op.Key, op.Value)
+}
+
+func pointEntryRevisionStats(entries []batch.Entry) (page.EntryRevision, bool) {
+	maxRevision := page.LegacyEntryRevision
+	hasLegacy := false
+	for i := range entries {
+		entry := &entries[i]
+		if entry.Type == batch.OpDeleteRange {
+			continue
+		}
+		if entry.Revision == page.LegacyEntryRevision {
+			hasLegacy = true
+			continue
+		}
+		if entry.Revision > maxRevision {
+			maxRevision = entry.Revision
+		}
+	}
+	return maxRevision, hasLegacy
+}
+
+func assignLegacyPointEntryRevisions(entries []batch.Entry, revision page.EntryRevision) page.EntryRevision {
+	maxRevision := page.LegacyEntryRevision
+	for i := range entries {
+		entry := &entries[i]
+		if entry.Type == batch.OpDeleteRange {
+			continue
+		}
+		if entry.Revision == page.LegacyEntryRevision && revision != page.LegacyEntryRevision {
+			entry.Revision = revision
+		}
+		if entry.Revision > maxRevision {
+			maxRevision = entry.Revision
+		}
+	}
+	return maxRevision
 }
 
 func getBatchArenaLease(refs int, chunks [][]byte) *batchArenaLease {
@@ -12036,6 +12116,7 @@ func Open(dir string, backend BackendDB, opts Options) (*DB, error) {
 	if maxExistingRID > 0 {
 		db.nextRID.Store(maxExistingRID)
 	}
+	db.advanceEntryRevisionFloor(backendMaxEntryRevision(backend))
 	db.rebuildGenerationLaneSets()
 	db.valueLogAutotuneMetrics.init(valuelog.RealClock{})
 	db.vlogGenerationSchedulerState.Store(vlogGenerationSchedulerDisabled)
@@ -13238,6 +13319,35 @@ func (db *DB) assignCommitSeq(records []logRecord) {
 	for i := range records {
 		records[i].Seq = seq
 	}
+}
+
+func (db *DB) advanceEntryRevisionFloor(revision page.EntryRevision) {
+	if db == nil || revision == page.LegacyEntryRevision {
+		return
+	}
+	target := uint64(revision)
+	for {
+		cur := db.nextCommitSeq.Load()
+		if cur >= target {
+			return
+		}
+		if db.nextCommitSeq.CompareAndSwap(cur, target) {
+			return
+		}
+	}
+}
+
+func (db *DB) nextEntryRevision() page.EntryRevision {
+	if db == nil {
+		return page.LegacyEntryRevision
+	}
+	return page.EntryRevision(db.nextCommitSeq.Add(1))
+}
+
+func (db *DB) prepareEntryRevisionAssignment(entries []batch.Entry) (page.EntryRevision, bool) {
+	maxRevision, hasLegacy := pointEntryRevisionStats(entries)
+	db.advanceEntryRevisionFloor(maxRevision)
+	return maxRevision, hasLegacy
 }
 
 func allZeroBytes(p []byte) bool {
@@ -15776,14 +15886,20 @@ func (db *DB) nextWALCoalesceSeqLocked(l *lane) uint64 {
 func (db *DB) appendWALOneChecked(l *lane, record logRecord, durability journalDurability) error {
 	switch durability {
 	case journalDurabilitySync:
-		record.Seq = db.nextCommitSeq.Add(1)
+		if record.Seq == 0 {
+			record.Seq = db.nextCommitSeq.Add(1)
+		}
 		return db.appendWALDirect(l, []logRecord{record}, true)
 	case journalDurabilityFlush:
-		record.Seq = db.nextCommitSeq.Add(1)
+		if record.Seq == 0 {
+			record.Seq = db.nextCommitSeq.Add(1)
+		}
 		return db.appendWALInlineOne(l, record, true)
 	default:
 		if !canCoalesceWALPointRecord(record) {
-			record.Seq = db.nextCommitSeq.Add(1)
+			if record.Seq == 0 {
+				record.Seq = db.nextCommitSeq.Add(1)
+			}
 		}
 		return db.appendWALInlineOne(l, record, false)
 	}
@@ -17663,7 +17779,9 @@ func (db *DB) appendWALFast(l *lane, record logRecord) error {
 		return errWALUnavailable
 	}
 
-	record.Seq = db.nextCommitSeq.Add(1)
+	if record.Seq == 0 {
+		record.Seq = db.nextCommitSeq.Add(1)
+	}
 
 	l.walFastMu.Lock()
 	for !l.walFastClosed && len(l.walFastQueue)-l.walFastHead >= walFastQueueMax {
@@ -24011,10 +24129,25 @@ func (db *DB) SetAfterCommandWALAppend(key, value []byte, appendCommand func() e
 	if appendCommand == nil {
 		return fmt.Errorf("cachingdb: missing command wal append callback")
 	}
+	return db.SetAfterCommandWALAppendWithRevision(key, value, func(page.EntryRevision) error {
+		return appendCommand()
+	})
+}
+
+// SetAfterCommandWALAppendWithRevision applies a point Set after appendCommand
+// succeeds. The assigned revision is passed to appendCommand before the command
+// WAL frame is appended so replay can encode the same entry metadata that will
+// become visible in the mutable table.
+func (db *DB) SetAfterCommandWALAppendWithRevision(key, value []byte, appendCommand func(page.EntryRevision) error) error {
+	key = normalizeRawKVPointKey(key)
+	value = normalizeRawKVValue(value)
+	if appendCommand == nil {
+		return fmt.Errorf("cachingdb: missing command wal append callback")
+	}
 	db.waitForCheckpoint()
 	guard := db.lockUpdateKey(key)
 	defer guard.Unlock()
-	return db.setDirectAfterCommandWALAppend(key, value, appendCommand)
+	return db.setDirectAfterCommandWALAppendWithRevision(key, value, appendCommand)
 }
 
 // Update applies fn to the current value for key and writes the returned
@@ -24232,6 +24365,7 @@ func (db *DB) setDirect(key, value []byte, sync bool) error {
 		}
 	}
 
+	revision := db.nextEntryRevision()
 	if allowPointers {
 		dictID := uint64(0)
 		class := db.valueLogDictClassForValue(value)
@@ -24261,7 +24395,7 @@ func (db *DB) setDirect(key, value []byte, sync bool) error {
 		}
 
 		if !db.disableJournal {
-			rec := logRecord{Op: logOpSetRID, Key: key, RID: walRID}
+			rec := logRecord{Op: logOpSetRID, Key: key, RID: walRID, Seq: uint64(revision)}
 			if err := db.appendWALOne(lane, rec, durability); err != nil {
 				db.writeMu.RUnlock()
 				return err
@@ -24275,7 +24409,7 @@ func (db *DB) setDirect(key, value []byte, sync bool) error {
 				db.debugPtrDenied.Add(1)
 			}
 		}
-		rec := logRecord{Op: logOpSetInline, Key: key, Value: value}
+		rec := logRecord{Op: logOpSetInline, Key: key, Value: value, Seq: uint64(revision)}
 		if err := db.appendWALOne(lane, rec, durability); err != nil {
 			db.writeMu.RUnlock()
 			return err
@@ -24294,20 +24428,20 @@ func (db *DB) setDirect(key, value []byte, sync bool) error {
 		if !db.memtableValueLogPointers {
 			memVal = value
 		}
-		if borrower, ok := shard.mem.(memtable.ValueBorrower); ok && len(memVal) > 0 {
+		if _, ok := shard.mem.(memtable.ValueBorrower); ok && len(memVal) > 0 {
 			owned := shard.appendOnlyDirectValueArena.alloc(len(memVal))
 			copy(owned, memVal)
-			borrower.SetEntryBorrowValue(key, owned, ptr, node.FlagPointer)
+			memtableSetDirectBorrowValue(shard.mem, key, owned, ptr, node.FlagPointer, revision)
 		} else {
-			shard.mem.SetEntry(key, memVal, ptr, node.FlagPointer)
+			memtableSetDirect(shard.mem, key, memVal, ptr, node.FlagPointer, revision)
 		}
 	} else {
-		if borrower, ok := shard.mem.(memtable.ValueBorrower); ok && len(value) > 0 {
+		if _, ok := shard.mem.(memtable.ValueBorrower); ok && len(value) > 0 {
 			owned := shard.appendOnlyDirectValueArena.alloc(len(value))
 			copy(owned, value)
-			borrower.SetEntryBorrowValue(key, owned, page.ValuePtr{}, node.FlagInline)
+			memtableSetDirectBorrowValue(shard.mem, key, owned, page.ValuePtr{}, node.FlagInline, revision)
 		} else {
-			shard.mem.SetEntry(key, value, page.ValuePtr{}, node.FlagInline)
+			memtableSetDirect(shard.mem, key, value, page.ValuePtr{}, node.FlagInline, revision)
 		}
 	}
 	shard.rng.add(key)
@@ -24347,7 +24481,7 @@ func (db *DB) setDirect(key, value []byte, sync bool) error {
 	return nil
 }
 
-func (db *DB) setDirectAfterCommandWALAppend(key, value []byte, appendCommand func() error) error {
+func (db *DB) setDirectAfterCommandWALAppendWithRevision(key, value []byte, appendCommand func(page.EntryRevision) error) error {
 	if !db.disableJournal {
 		return fmt.Errorf("cachingdb: command wal point writes require disabled cached redo log")
 	}
@@ -24431,7 +24565,8 @@ func (db *DB) setDirectAfterCommandWALAppend(key, value []byte, appendCommand fu
 		}
 	}
 
-	if err := appendCommand(); err != nil {
+	revision := db.nextEntryRevision()
+	if err := appendCommand(revision); err != nil {
 		if retainPath != "" {
 			db.markValueLogRetain(retainPath)
 		}
@@ -24445,20 +24580,20 @@ func (db *DB) setDirectAfterCommandWALAppend(key, value []byte, appendCommand fu
 		if !db.memtableValueLogPointers {
 			memVal = value
 		}
-		if borrower, ok := shard.mem.(memtable.ValueBorrower); ok && len(memVal) > 0 {
+		if _, ok := shard.mem.(memtable.ValueBorrower); ok && len(memVal) > 0 {
 			owned := shard.appendOnlyDirectValueArena.alloc(len(memVal))
 			copy(owned, memVal)
-			borrower.SetEntryBorrowValue(key, owned, ptr, node.FlagPointer)
+			memtableSetDirectBorrowValue(shard.mem, key, owned, ptr, node.FlagPointer, revision)
 		} else {
-			shard.mem.SetEntry(key, memVal, ptr, node.FlagPointer)
+			memtableSetDirect(shard.mem, key, memVal, ptr, node.FlagPointer, revision)
 		}
 	} else {
-		if borrower, ok := shard.mem.(memtable.ValueBorrower); ok && len(value) > 0 {
+		if _, ok := shard.mem.(memtable.ValueBorrower); ok && len(value) > 0 {
 			owned := shard.appendOnlyDirectValueArena.alloc(len(value))
 			copy(owned, value)
-			borrower.SetEntryBorrowValue(key, owned, page.ValuePtr{}, node.FlagInline)
+			memtableSetDirectBorrowValue(shard.mem, key, owned, page.ValuePtr{}, node.FlagInline, revision)
 		} else {
-			shard.mem.SetEntry(key, value, page.ValuePtr{}, node.FlagInline)
+			memtableSetDirect(shard.mem, key, value, page.ValuePtr{}, node.FlagInline, revision)
 		}
 	}
 	shard.rng.add(key)
@@ -24680,6 +24815,7 @@ func (db *DB) deleteRange(start, end []byte, appendCommand func() error) (err er
 		defer func() { _ = it.Close() }()
 		db.deleteRangeIterators.Add(1)
 		var visitedKeys, tombstoneKeys uint64
+		rangeRevision := db.nextEntryRevision()
 
 		applyDelete := func(key []byte) error {
 			if maxMemtableBytesPerShard > 0 && int64(len(key)) > maxMemtableBytesPerShard {
@@ -24698,7 +24834,7 @@ func (db *DB) deleteRange(start, end []byte, appendCommand func() error) (err er
 					}
 					continue
 				}
-				if err := shard.mem.DeleteWithCallback(key, nil); err != nil {
+				if err := memtableBatchDelete(shard.mem, false, key, rangeRevision); err != nil {
 					shard.mu.Unlock()
 					return err
 				}
@@ -24777,7 +24913,7 @@ func (db *DB) deleteRange(start, end []byte, appendCommand func() error) (err er
 			if err := preRotate(key); err != nil {
 				return err
 			}
-			if err := db.appendWALOne(lane, logRecord{Op: logOpDelete, Key: key}, journalDurabilityNone); err != nil {
+			if err := db.appendWALOne(lane, logRecord{Op: logOpDelete, Key: key, Seq: uint64(rangeRevision)}, journalDurabilityNone); err != nil {
 				return err
 			}
 			if err := applyDelete(key); err != nil {
@@ -25219,6 +25355,7 @@ func (db *DB) deleteRange(start, end []byte, appendCommand func() error) (err er
 		}
 
 		db.mu.Lock()
+		rangeRevision := db.nextEntryRevision()
 		applyDelete := func(key []byte) error {
 			shard := db.shardForKey(key)
 			shard.mu.Lock()
@@ -25226,7 +25363,10 @@ func (db *DB) deleteRange(start, end []byte, appendCommand func() error) (err er
 				shard.mu.Unlock()
 				return ErrMemtableFull
 			}
-			shard.mem.Delete(key)
+			if err := memtableBatchDelete(shard.mem, false, key, rangeRevision); err != nil {
+				shard.mu.Unlock()
+				return err
+			}
 			shard.rng.add(key)
 			newBytes := shard.mem.Size()
 			delta := newBytes - shard.bytes
@@ -25341,10 +25481,23 @@ func (db *DB) DeleteAfterCommandWALAppend(key []byte, appendCommand func() error
 	if appendCommand == nil {
 		return fmt.Errorf("cachingdb: missing command wal append callback")
 	}
+	return db.DeleteAfterCommandWALAppendWithRevision(key, func(page.EntryRevision) error {
+		return appendCommand()
+	})
+}
+
+// DeleteAfterCommandWALAppendWithRevision applies a point Delete after
+// appendCommand succeeds and passes the assigned tombstone revision to the
+// command-WAL callback before the mutation becomes visible.
+func (db *DB) DeleteAfterCommandWALAppendWithRevision(key []byte, appendCommand func(page.EntryRevision) error) error {
+	key = normalizeRawKVPointKey(key)
+	if appendCommand == nil {
+		return fmt.Errorf("cachingdb: missing command wal append callback")
+	}
 	db.waitForCheckpoint()
 	guard := db.lockUpdateKey(key)
 	defer guard.Unlock()
-	return db.deleteDirectAfterCommandWALAppend(key, appendCommand)
+	return db.deleteDirectAfterCommandWALAppendWithRevision(key, appendCommand)
 }
 
 func (db *DB) lockUpdateKey(key []byte) keyupdate.Guard {
@@ -25377,6 +25530,7 @@ func (db *DB) deleteDirect(key []byte, sync bool) error {
 	}
 	shard.mu.Unlock()
 
+	revision := db.nextEntryRevision()
 	if !db.disableJournal {
 		durability := journalDurabilityNone
 		if sync {
@@ -25394,7 +25548,7 @@ func (db *DB) deleteDirect(key []byte, sync bool) error {
 		if durability == journalDurabilitySync {
 			defer db.releaseLaneSync(lane)
 		}
-		rec := logRecord{Op: logOpDelete, Key: key}
+		rec := logRecord{Op: logOpDelete, Key: key, Seq: uint64(revision)}
 		if err := db.appendWALOne(lane, rec, durability); err != nil {
 			db.writeMu.RUnlock()
 			return err
@@ -25402,7 +25556,17 @@ func (db *DB) deleteDirect(key []byte, sync bool) error {
 	}
 
 	shard.mu.Lock()
-	shard.mem.Delete(key)
+	if err := memtableBatchDelete(shard.mem, false, key, revision); err != nil {
+		shard.mu.Unlock()
+		db.writeMu.RUnlock()
+		db.reportError(fmt.Errorf("cachingdb: WAL apply failed: %w", err))
+		db.walAckMu.Lock()
+		if db.walErr == nil {
+			db.walErr = err
+		}
+		db.walAckMu.Unlock()
+		return err
+	}
 	shard.rng.add(key)
 	newBytes := shard.mem.Size()
 	delta := newBytes - shard.bytes
@@ -25436,7 +25600,7 @@ func (db *DB) deleteDirect(key []byte, sync bool) error {
 	return nil
 }
 
-func (db *DB) deleteDirectAfterCommandWALAppend(key []byte, appendCommand func() error) error {
+func (db *DB) deleteDirectAfterCommandWALAppendWithRevision(key []byte, appendCommand func(page.EntryRevision) error) error {
 	if !db.disableJournal {
 		return fmt.Errorf("cachingdb: command wal point writes require disabled cached redo log")
 	}
@@ -25454,13 +25618,19 @@ func (db *DB) deleteDirectAfterCommandWALAppend(key []byte, appendCommand func()
 	}
 	shard.mu.Unlock()
 
-	if err := appendCommand(); err != nil {
+	revision := db.nextEntryRevision()
+	if err := appendCommand(revision); err != nil {
 		db.writeMu.RUnlock()
 		return err
 	}
 
 	shard.mu.Lock()
-	shard.mem.Delete(key)
+	if err := memtableBatchDelete(shard.mem, false, key, revision); err != nil {
+		shard.mu.Unlock()
+		db.writeMu.RUnlock()
+		db.reportError(fmt.Errorf("cachingdb: post-command-wal delete failed: %w", err))
+		return err
+	}
 	shard.rng.add(key)
 	newBytes := shard.mem.Size()
 	delta := newBytes - shard.bytes
@@ -31841,6 +32011,7 @@ type Batch struct {
 	lastKey          []byte
 	batchRange       keyRange
 	hasDeleteRanges  bool
+	entryRevision    page.EntryRevision
 	commandWALAppend func() error
 
 	commandWALCompactReplay     bool
@@ -32374,6 +32545,7 @@ func (b *Batch) Reset() {
 	b.lastKey = nil
 	b.batchRange = keyRange{}
 	b.hasDeleteRanges = false
+	b.entryRevision = page.LegacyEntryRevision
 	b.maxEntries = 0
 	b.commandWALAppend = nil
 	b.commandWALCompactReplay = false
@@ -32739,6 +32911,36 @@ func (b *Batch) shouldCopyValueToPtrArena(key, value []byte) bool {
 	return b.db.shouldWriteViaValueLogForKeyValue(key, value)
 }
 
+func (b *Batch) assignLegacyPointRevisions(entries []batch.Entry) {
+	if b == nil || b.db == nil || len(entries) == 0 {
+		return
+	}
+	_, hasLegacy := b.db.prepareEntryRevisionAssignment(entries)
+	if !hasLegacy {
+		return
+	}
+	if b.entryRevision == page.LegacyEntryRevision {
+		b.entryRevision = b.db.nextEntryRevision()
+	}
+	assignLegacyPointEntryRevisions(entries, b.entryRevision)
+}
+
+func (b *Batch) revisionForBackendPoint(revision page.EntryRevision) page.EntryRevision {
+	if revision != page.LegacyEntryRevision {
+		if b != nil && b.db != nil {
+			b.db.advanceEntryRevisionFloor(revision)
+		}
+		return revision
+	}
+	if b == nil || b.db == nil {
+		return page.LegacyEntryRevision
+	}
+	if b.entryRevision == page.LegacyEntryRevision {
+		b.entryRevision = b.db.nextEntryRevision()
+	}
+	return b.entryRevision
+}
+
 func (b *Batch) Set(key, value []byte) error {
 	return b.SetWithRevision(key, value, page.LegacyEntryRevision)
 }
@@ -32767,6 +32969,7 @@ func (b *Batch) SetWithRevision(key, value []byte, revision page.EntryRevision) 
 	if b.backend != nil {
 		b.batchRange.add(keyCopy)
 		b.size += len(keyCopy) + len(valCopy)
+		revision = b.revisionForBackendPoint(revision)
 		// Use the backend's view method with owned copies to avoid aliasing.
 		if revision != page.LegacyEntryRevision {
 			if sv, ok := b.backend.(interface {
@@ -32845,6 +33048,7 @@ func (b *Batch) SetViewValidatedWithRevision(key, value []byte, revision page.En
 	if b.backend != nil {
 		b.batchRange.add(key)
 		b.size += len(key) + len(value)
+		revision = b.revisionForBackendPoint(revision)
 		if revision != page.LegacyEntryRevision {
 			if sv, ok := b.backend.(interface {
 				SetViewWithRevision(key, value []byte, revision page.EntryRevision) error
@@ -32904,6 +33108,7 @@ func (b *Batch) DeleteWithRevision(key []byte, revision page.EntryRevision) erro
 	if b.backend != nil {
 		b.batchRange.add(keyCopy)
 		b.size += len(keyCopy)
+		revision = b.revisionForBackendPoint(revision)
 		if revision != page.LegacyEntryRevision {
 			if dv, ok := b.backend.(interface {
 				DeleteViewWithRevision(key []byte, revision page.EntryRevision) error
@@ -33012,6 +33217,7 @@ func (b *Batch) DeleteViewValidatedWithRevision(key []byte, revision page.EntryR
 	if b.backend != nil {
 		b.batchRange.add(key)
 		b.size += len(key)
+		revision = b.revisionForBackendPoint(revision)
 		if revision != page.LegacyEntryRevision {
 			if dv, ok := b.backend.(interface {
 				DeleteViewWithRevision(key []byte, revision page.EntryRevision) error
@@ -33088,6 +33294,7 @@ func (b *Batch) SetOps(ops []batch.Entry) error {
 			b.size += len(copiedOp.Key) + len(copiedOp.Value)
 			b.batchRange.add(copiedOp.Key)
 		}
+		b.assignLegacyPointRevisions(copied)
 		return b.backend.SetOps(copied)
 	}
 	for _, op := range ops {
@@ -33270,6 +33477,7 @@ func (b *Batch) maybeSwitchToStreaming() {
 		b.batchRange.min = cloneKeyRangePointKey(b.firstKey)
 		b.batchRange.max = cloneKeyRangePointKey(b.lastKey)
 	}
+	b.assignLegacyPointRevisions(b.entries)
 	if err := backendBatch.SetOps(b.entries); err != nil {
 		_ = backendBatch.Close()
 		return
@@ -33612,6 +33820,7 @@ func (b *Batch) tryWriteWALOffStreamBypass(sync bool) (bool, error) {
 	ops = append(ops, b.entries...)
 	defer putEntrySlice(ops)
 
+	b.assignLegacyPointRevisions(ops)
 	ops, err := b.db.deferValueLogOps(ops, sync)
 	if err != nil {
 		return false, err
@@ -33664,6 +33873,24 @@ func (b *Batch) writeRegularLocked(syncWrite bool, unlockWriteMu func()) error {
 	needRotate := false
 	needSyncBarrier := false
 	commandWALAppended := false
+	failMemtableApply := func(shard *memShard, err error) error {
+		shard.mu.Unlock()
+		unlockWriteMu()
+		if err == nil {
+			return nil
+		}
+		if !b.db.disableJournal {
+			b.db.reportError(fmt.Errorf("cachingdb: WAL apply failed: %w", err))
+			b.db.walAckMu.Lock()
+			if b.db.walErr == nil {
+				b.db.walErr = err
+			}
+			b.db.walAckMu.Unlock()
+		} else if commandWALAppended {
+			b.db.reportError(fmt.Errorf("cachingdb: post-command-wal batch apply failed: %w", err))
+		}
+		return err
+	}
 
 	// 1. Memtable capacity pre-check
 	shardCount := len(b.db.mutableShards)
@@ -34081,8 +34308,16 @@ func (b *Batch) writeRegularLocked(syncWrite bool, unlockWriteMu func()) error {
 		}
 	}
 
+	_, hasLegacyRevisions := b.db.prepareEntryRevisionAssignment(b.entries)
+	if b.db.disableJournal && hasLegacyRevisions {
+		assignLegacyPointEntryRevisions(b.entries, b.db.nextEntryRevision())
+	}
+
 	if !b.db.disableJournal {
 		seq := b.db.nextCommitSeq.Add(1)
+		if hasLegacyRevisions {
+			assignLegacyPointEntryRevisions(b.entries, page.EntryRevision(seq))
+		}
 		handledZeroInline := false
 		if zeroInlineWALBatch && rids == nil && zeroInlineValueLen > 0 {
 			var err error
@@ -34191,7 +34426,9 @@ func (b *Batch) writeRegularLocked(syncWrite bool, unlockWriteMu func()) error {
 				for _, entryIdx := range idxs {
 					key := b.entries[entryIdx].Key
 					last = key
-					memtableBatchDelete(shard.mem, useSteal, key, b.entries[entryIdx].Revision)
+					if err := memtableBatchDelete(shard.mem, useSteal, key, b.entries[entryIdx].Revision); err != nil {
+						return failMemtableApply(shard, err)
+					}
 				}
 				shard.rng.add(first)
 				if len(idxs) > 1 {
@@ -34201,7 +34438,9 @@ func (b *Batch) writeRegularLocked(syncWrite bool, unlockWriteMu func()) error {
 			} else {
 				for _, entryIdx := range idxs {
 					key := b.entries[entryIdx].Key
-					memtableBatchDelete(shard.mem, useSteal, key, b.entries[entryIdx].Revision)
+					if err := memtableBatchDelete(shard.mem, useSteal, key, b.entries[entryIdx].Revision); err != nil {
+						return failMemtableApply(shard, err)
+					}
 					shard.rng.add(key)
 					b.db.noteWriteKey(key)
 				}
@@ -34272,7 +34511,9 @@ func (b *Batch) writeRegularLocked(syncWrite bool, unlockWriteMu func()) error {
 					} else {
 						for _, op := range entries {
 							if op.Type == batch.OpDelete {
-								memtableBatchDelete(shard.mem, true, op.Key, op.Revision)
+								if err := memtableBatchDelete(shard.mem, true, op.Key, op.Revision); err != nil {
+									return failMemtableApply(shard, err)
+								}
 							} else {
 								memtableBatchSet(shard.mem, true, allowBatchArenaBorrow, storeInlinePtrValues, op)
 							}
@@ -34306,7 +34547,9 @@ func (b *Batch) writeRegularLocked(syncWrite bool, unlockWriteMu func()) error {
 			if !appliedSortedRun {
 				for _, op := range entries {
 					if op.Type == batch.OpDelete {
-						memtableBatchDelete(shard.mem, useSteal, op.Key, op.Revision)
+						if err := memtableBatchDelete(shard.mem, useSteal, op.Key, op.Revision); err != nil {
+							return failMemtableApply(shard, err)
+						}
 					} else {
 						borrowed := false
 						if allowBatchArenaBorrow && !useSteal {
@@ -34827,6 +35070,11 @@ func (b *Batch) writeBypass(sync bool) (err error) {
 		}
 	}()
 
+	_, hasLegacyRevisions := b.db.prepareEntryRevisionAssignment(ops)
+	if hasLegacyRevisions {
+		assignLegacyPointEntryRevisions(ops, b.db.nextEntryRevision())
+	}
+
 	if rewritten, err := b.db.prepareBypassValueLogOps(ops, sync); err != nil {
 		return err
 	} else {
@@ -34938,6 +35186,7 @@ func (b *Batch) Close() error {
 	b.shardIdxSets = nil
 	b.firstKey = nil
 	b.lastKey = nil
+	b.entryRevision = page.LegacyEntryRevision
 	b.ptrValueIdxs = nil
 	b.commandWALCompactReplay = false
 	b.commandWALCompactRanges = nil

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -34314,8 +34314,21 @@ func (b *Batch) writeRegularLocked(syncWrite bool, unlockWriteMu func()) error {
 		if hasLegacyRevisions {
 			assignLegacyPointEntryRevisions(b.entries, page.EntryRevision(seq))
 		}
+		walRecordRevision := func(revision page.EntryRevision) uint64 {
+			if revision != page.LegacyEntryRevision && uint64(revision) != seq {
+				return uint64(revision)
+			}
+			return 0
+		}
+		hasWALRecordRevisions := false
+		for i := range b.entries {
+			if walRecordRevision(b.entries[i].Revision) != 0 {
+				hasWALRecordRevisions = true
+				break
+			}
+		}
 		handledZeroInline := false
-		if zeroInlineWALBatch && rids == nil && zeroInlineValueLen > 0 {
+		if zeroInlineWALBatch && !hasWALRecordRevisions && rids == nil && zeroInlineValueLen > 0 {
 			var err error
 			handledZeroInline, err = b.db.appendWALZeroInlineEntries(lane, b.entries, seq, zeroInlineValueLen, durability)
 			if err != nil {
@@ -34333,14 +34346,15 @@ func (b *Batch) writeRegularLocked(syncWrite bool, unlockWriteMu func()) error {
 			}
 			for i := range b.entries {
 				op := &b.entries[i]
+				recordRevision := walRecordRevision(op.Revision)
 				switch op.Type {
 				case batch.OpDelete:
-					records = append(records, logRecord{Op: logOpDelete, Key: op.Key, Seq: seq})
+					records = append(records, logRecord{Op: logOpDelete, Key: op.Key, Seq: seq, Revision: recordRevision})
 				case batch.OpPut:
 					if rids != nil && rids[i] != 0 {
-						records = append(records, logRecord{Op: logOpSetRID, Key: op.Key, RID: rids[i], Seq: seq})
+						records = append(records, logRecord{Op: logOpSetRID, Key: op.Key, RID: rids[i], Seq: seq, Revision: recordRevision})
 					} else {
-						records = append(records, logRecord{Op: logOpSetInline, Key: op.Key, Value: op.Value, Seq: seq})
+						records = append(records, logRecord{Op: logOpSetInline, Key: op.Key, Value: op.Value, Seq: seq, Revision: recordRevision})
 					}
 				}
 			}

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -10021,11 +10021,7 @@ func memtableBatchDelete(mt memtable.Table, useSteal bool, key []byte, revision 
 			writer.SetEntryWithRevision(key, nil, page.ValuePtr{}, node.FlagTombstone, revision)
 			return nil
 		}
-		if useSteal {
-			mt.SetEntrySteal(key, nil, page.ValuePtr{}, node.FlagTombstone)
-			return nil
-		}
-		return mt.DeleteWithCallback(key, nil)
+		return fmt.Errorf("cachingdb: memtable %T cannot preserve entry revision %d for delete", mt, revision)
 	}
 	if useSteal {
 		mt.DeleteSteal(key)

--- a/TreeDB/caching/delete_range_test.go
+++ b/TreeDB/caching/delete_range_test.go
@@ -2,6 +2,7 @@ package caching
 
 import (
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -854,8 +855,9 @@ func TestCachingDB_DeleteRange_WALApplyFailurePoisonsWrites(t *testing.T) {
 	}
 	db.mu.Unlock()
 
-	if err := db.DeleteRange([]byte("a"), []byte("z")); !errors.Is(err, failErr) {
-		t.Fatalf("expected delete range error %v, got %v", failErr, err)
+	err = db.DeleteRange([]byte("a"), []byte("z"))
+	if err == nil || !strings.Contains(err.Error(), "cannot preserve entry revision") {
+		t.Fatalf("expected delete range revision-preservation error, got %v", err)
 	}
 
 	db.mu.Lock()
@@ -870,8 +872,9 @@ func TestCachingDB_DeleteRange_WALApplyFailurePoisonsWrites(t *testing.T) {
 		t.Fatalf("unexpected AppendBatch calls: %d", stub.batchCalls)
 	}
 
-	if err := db.Set([]byte("c"), []byte("3")); !errors.Is(err, failErr) {
-		t.Fatalf("expected WAL error on Set, got %v", err)
+	err = db.Set([]byte("c"), []byte("3"))
+	if err == nil || !strings.Contains(err.Error(), "cannot preserve entry revision") {
+		t.Fatalf("expected poisoned WAL revision-preservation error on Set, got %v", err)
 	}
 }
 

--- a/TreeDB/caching/flush_build_runs_test.go
+++ b/TreeDB/caching/flush_build_runs_test.go
@@ -46,7 +46,9 @@ func TestMemtableBatchApplyPreservesEntryRevision(t *testing.T) {
 		Value:    []byte("value"),
 		Revision: 44,
 	})
-	memtableBatchDelete(mt, false, []byte("b"), 45)
+	if err := memtableBatchDelete(mt, false, []byte("b"), 45); err != nil {
+		t.Fatalf("memtableBatchDelete: %v", err)
+	}
 
 	revisions := mt.(memtable.RevisionTable)
 	value, _, flags, revision, found := revisions.GetEntryWithRevision([]byte("a"))
@@ -56,6 +58,13 @@ func TestMemtableBatchApplyPreservesEntryRevision(t *testing.T) {
 	_, _, flags, revision, found = revisions.GetEntryWithRevision([]byte("b"))
 	if !found || flags&node.FlagTombstone == 0 || revision != 45 {
 		t.Fatalf("delete entry=(%02x,%d,%v), want tombstone rev 45", flags, revision, found)
+	}
+}
+
+func TestMemtableBatchDeleteRejectsRevisionWithoutRevisionTable(t *testing.T) {
+	mt := &unstableRunTable{}
+	if err := memtableBatchDelete(mt, false, []byte("b"), 45); err == nil {
+		t.Fatalf("memtableBatchDelete succeeded without revision-preserving memtable")
 	}
 }
 

--- a/TreeDB/caching/flush_pool_helpers_test.go
+++ b/TreeDB/caching/flush_pool_helpers_test.go
@@ -72,15 +72,33 @@ func (b *pointerBatch) Set(key, value []byte) error {
 	return nil
 }
 
+func (b *pointerBatch) SetWithRevision(key, value []byte, revision page.EntryRevision) error {
+	b.setCalls++
+	b.entries = append(b.entries, batch.Entry{Type: batch.OpPut, Key: key, Value: value, Revision: revision})
+	return nil
+}
+
 func (b *pointerBatch) SetView(key, value []byte) error {
 	b.setViewCalls++
 	b.entries = append(b.entries, batch.Entry{Type: batch.OpPut, Key: key, Value: value})
 	return nil
 }
 
+func (b *pointerBatch) SetViewWithRevision(key, value []byte, revision page.EntryRevision) error {
+	b.setViewCalls++
+	b.entries = append(b.entries, batch.Entry{Type: batch.OpPut, Key: key, Value: value, Revision: revision})
+	return nil
+}
+
 func (b *pointerBatch) Delete(key []byte) error {
 	b.deleteCalls++
 	b.entries = append(b.entries, batch.Entry{Type: batch.OpDelete, Key: key})
+	return nil
+}
+
+func (b *pointerBatch) DeleteWithRevision(key []byte, revision page.EntryRevision) error {
+	b.deleteCalls++
+	b.entries = append(b.entries, batch.Entry{Type: batch.OpDelete, Key: key, Revision: revision})
 	return nil
 }
 
@@ -95,15 +113,33 @@ func (b *pointerBatch) DeleteView(key []byte) error {
 	return nil
 }
 
+func (b *pointerBatch) DeleteViewWithRevision(key []byte, revision page.EntryRevision) error {
+	b.deleteViewCalls++
+	b.entries = append(b.entries, batch.Entry{Type: batch.OpDelete, Key: key, Revision: revision})
+	return nil
+}
+
 func (b *pointerBatch) SetPointer(key []byte, ptr page.ValuePtr) error {
 	b.setPointerCalls++
 	b.entries = append(b.entries, batch.Entry{Type: batch.OpPut, Key: key, ValuePtr: ptr, IsPtr: true})
 	return nil
 }
 
+func (b *pointerBatch) SetPointerWithRevision(key []byte, ptr page.ValuePtr, revision page.EntryRevision) error {
+	b.setPointerCalls++
+	b.entries = append(b.entries, batch.Entry{Type: batch.OpPut, Key: key, ValuePtr: ptr, IsPtr: true, Revision: revision})
+	return nil
+}
+
 func (b *pointerBatch) SetPointerView(key []byte, ptr page.ValuePtr) error {
 	b.setPointerViewCalls++
 	b.entries = append(b.entries, batch.Entry{Type: batch.OpPut, Key: key, ValuePtr: ptr, IsPtr: true})
+	return nil
+}
+
+func (b *pointerBatch) SetPointerViewWithRevision(key []byte, ptr page.ValuePtr, revision page.EntryRevision) error {
+	b.setPointerViewCalls++
+	b.entries = append(b.entries, batch.Entry{Type: batch.OpPut, Key: key, ValuePtr: ptr, IsPtr: true, Revision: revision})
 	return nil
 }
 

--- a/TreeDB/caching/unified_wal_comprehensive_test.go
+++ b/TreeDB/caching/unified_wal_comprehensive_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 
@@ -188,6 +189,143 @@ func TestUnifiedWAL_CrashRecoveryCompactZeroInlineBatch(t *testing.T) {
 		if !bytes.Equal(got, want) {
 			t.Fatalf("value mismatch for %q: got %x want %x", key, got, want)
 		}
+	}
+}
+
+func runUnifiedWALRevisionCrashWriter(t *testing.T, dir string) {
+	t.Helper()
+
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+
+	cmd := exec.Command(exe, "-test.run=^TestHelperUnifiedWALRevisionCrashWriter$", "-test.v")
+	cmd.Env = append(os.Environ(),
+		"TREEDB_CACHING_WAL_REVISION_CRASH_HELPER=1",
+		"TREEDB_CACHING_WAL_REVISION_CRASH_DIR="+dir,
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("crash writer helper failed: %v\n%s", err, string(out))
+	}
+}
+
+func TestHelperUnifiedWALRevisionCrashWriter(t *testing.T) {
+	if os.Getenv("TREEDB_CACHING_WAL_REVISION_CRASH_HELPER") != "1" {
+		t.Skip("helper")
+	}
+
+	dir := os.Getenv("TREEDB_CACHING_WAL_REVISION_CRASH_DIR")
+	if dir == "" {
+		t.Fatalf("missing TREEDB_CACHING_WAL_REVISION_CRASH_DIR")
+	}
+
+	backend, err := db.Open(db.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("backend open: %v", err)
+	}
+	cache, err := Open(dir, backend, Options{
+		AllowUnsafe:    true,
+		FlushThreshold: 1 << 30,
+		MemtableMode:   "skiplist",
+		MemtableShards: 1,
+	})
+	if err != nil {
+		t.Fatalf("cache open: %v", err)
+	}
+
+	b := cache.NewBatch()
+	if err := b.SetWithRevision([]byte("explicit"), []byte("value"), page.EntryRevision(41)); err != nil {
+		t.Fatalf("SetWithRevision explicit: %v", err)
+	}
+	if err := b.Set([]byte("seq-backed"), []byte("value")); err != nil {
+		t.Fatalf("Set seq-backed: %v", err)
+	}
+	if err := b.DeleteWithRevision([]byte("deleted"), page.EntryRevision(43)); err != nil {
+		t.Fatalf("DeleteWithRevision deleted: %v", err)
+	}
+	if err := b.WriteSync(); err != nil {
+		t.Fatalf("WriteSync: %v", err)
+	}
+	_ = b.Close()
+
+	// Simulate a crash: do not close the cache or backend, because Close drains
+	// memtables and can avoid replaying the cached redo WAL.
+	os.Exit(0)
+}
+
+func TestUnifiedWAL_CrashRecoveryPreservesEntryRevision(t *testing.T) {
+	dir := t.TempDir()
+	runUnifiedWALRevisionCrashWriter(t, dir)
+
+	reader, err := commitlog.NewReader(filepath.Join(dir, "wal", "commit-l0-000001.log"))
+	if err != nil {
+		t.Fatalf("commitlog.NewReader: %v", err)
+	}
+	records, err := reader.ReadBatch()
+	if err != nil {
+		_ = reader.Close()
+		t.Fatalf("ReadBatch: %v", err)
+	}
+	if err := reader.Close(); err != nil {
+		t.Fatalf("reader Close: %v", err)
+	}
+	byKey := make(map[string]commitlog.Record, len(records))
+	for _, rec := range records {
+		byKey[string(rec.Key)] = rec
+	}
+	seqRecord, ok := byKey["seq-backed"]
+	if !ok {
+		t.Fatalf("missing seq-backed record: %+v", records)
+	}
+	if seqRecord.Seq == 0 || seqRecord.Revision != 0 {
+		t.Fatalf("seq-backed record seq=%d revision=%d, want nonzero seq and zero record revision", seqRecord.Seq, seqRecord.Revision)
+	}
+	explicitRecord, ok := byKey["explicit"]
+	if !ok {
+		t.Fatalf("missing explicit record: %+v", records)
+	}
+	if explicitRecord.Seq != seqRecord.Seq || explicitRecord.Revision != 41 {
+		t.Fatalf("explicit record seq=%d revision=%d, want seq %d revision 41", explicitRecord.Seq, explicitRecord.Revision, seqRecord.Seq)
+	}
+	deletedRecord, ok := byKey["deleted"]
+	if !ok {
+		t.Fatalf("missing deleted record: %+v", records)
+	}
+	if deletedRecord.Op != commitlog.OpDelete || deletedRecord.Seq != seqRecord.Seq || deletedRecord.Revision != 43 {
+		t.Fatalf("deleted record op=%d seq=%d revision=%d, want delete seq %d revision 43", deletedRecord.Op, deletedRecord.Seq, deletedRecord.Revision, seqRecord.Seq)
+	}
+
+	opened, err := db.Open(db.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open backend: %v", err)
+	}
+	defer opened.Close()
+
+	explicitValue, explicitRevision, err := opened.GetVersioned([]byte("explicit"))
+	if err != nil {
+		t.Fatalf("GetVersioned explicit: %v", err)
+	}
+	if !bytes.Equal(explicitValue, []byte("value")) || explicitRevision != page.EntryRevision(41) {
+		t.Fatalf("GetVersioned explicit=(%q,%d), want (value,41)", explicitValue, explicitRevision)
+	}
+	seqValue, seqRevision, err := opened.GetVersioned([]byte("seq-backed"))
+	if err != nil {
+		t.Fatalf("GetVersioned seq-backed: %v", err)
+	}
+	if !bytes.Equal(seqValue, []byte("value")) || seqRevision != page.EntryRevision(seqRecord.Seq) {
+		t.Fatalf("GetVersioned seq-backed=(%q,%d), want (value,%d)", seqValue, seqRevision, seqRecord.Seq)
+	}
+	deletedValue, deletedRevision, err := opened.GetVersioned([]byte("deleted"))
+	if err != nil {
+		t.Fatalf("GetVersioned deleted: %v", err)
+	}
+	if deletedValue != nil {
+		t.Fatalf("GetVersioned deleted=(%q,%d), want missing after replayed delete", deletedValue, deletedRevision)
+	}
+	if got := opened.State().MaxEntryRevision; got < page.EntryRevision(43) {
+		t.Fatalf("MaxEntryRevision=%d, want >= 43", got)
 	}
 }
 

--- a/TreeDB/caching/versioned_read_test.go
+++ b/TreeDB/caching/versioned_read_test.go
@@ -89,6 +89,92 @@ func TestGetVersionedPreservesMutableMemtableRevision(t *testing.T) {
 	}
 }
 
+func TestGetVersionedAssignsMutableMemtableRevision(t *testing.T) {
+	db, err := Open(t.TempDir(), NewMockBackend(), Options{
+		FlushThreshold: 1 << 30,
+		MemtableMode:   "skiplist",
+		MemtableShards: 1,
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() {
+		if err := db.Close(); err != nil {
+			t.Fatalf("Close: %v", err)
+		}
+	}()
+
+	if err := db.Set([]byte("k"), []byte("value")); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	val, revision, err := db.GetVersioned([]byte("k"))
+	if err != nil {
+		t.Fatalf("GetVersioned: %v", err)
+	}
+	if !bytes.Equal(val, []byte("value")) || revision == page.LegacyEntryRevision {
+		t.Fatalf("GetVersioned=(%q,%d), want (value,non-legacy)", val, revision)
+	}
+
+	if err := db.Set([]byte("next"), []byte("value")); err != nil {
+		t.Fatalf("Set next: %v", err)
+	}
+	_, nextRevision, err := db.GetVersioned([]byte("next"))
+	if err != nil {
+		t.Fatalf("GetVersioned next: %v", err)
+	}
+	if nextRevision <= revision {
+		t.Fatalf("next revision=%d, want > first revision %d", nextRevision, revision)
+	}
+}
+
+func TestCommandWALPointCallbacksReceiveVisibleRevision(t *testing.T) {
+	db, err := Open(t.TempDir(), NewMockBackend(), Options{
+		DisableWAL:     true,
+		AllowUnsafe:    true,
+		FlushThreshold: 1 << 30,
+		MemtableMode:   "skiplist",
+		MemtableShards: 1,
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() {
+		if err := db.Close(); err != nil {
+			t.Fatalf("Close: %v", err)
+		}
+	}()
+
+	var setRevision page.EntryRevision
+	if err := db.SetAfterCommandWALAppendWithRevision([]byte("k"), []byte("value"), func(revision page.EntryRevision) error {
+		setRevision = revision
+		return nil
+	}); err != nil {
+		t.Fatalf("SetAfterCommandWALAppendWithRevision: %v", err)
+	}
+	val, revision, err := db.GetVersioned([]byte("k"))
+	if err != nil {
+		t.Fatalf("GetVersioned: %v", err)
+	}
+	if !bytes.Equal(val, []byte("value")) || revision == page.LegacyEntryRevision || revision != setRevision {
+		t.Fatalf("GetVersioned=(%q,%d), callback revision=%d; want (value,same non-legacy)", val, revision, setRevision)
+	}
+
+	var deleteRevision page.EntryRevision
+	if err := db.DeleteAfterCommandWALAppendWithRevision([]byte("k"), func(revision page.EntryRevision) error {
+		deleteRevision = revision
+		return nil
+	}); err != nil {
+		t.Fatalf("DeleteAfterCommandWALAppendWithRevision: %v", err)
+	}
+	val, revision, err = db.GetVersioned([]byte("k"))
+	if err != nil {
+		t.Fatalf("GetVersioned after delete: %v", err)
+	}
+	if val != nil || revision == page.LegacyEntryRevision || revision != deleteRevision || revision <= setRevision {
+		t.Fatalf("delete GetVersioned=(%q,%d), callback revision=%d set=%d; want tombstone same higher non-legacy revision", val, revision, deleteRevision, setRevision)
+	}
+}
+
 func TestGetVersionedPreservesMutableMemtableDeleteRevision(t *testing.T) {
 	db, err := Open(t.TempDir(), NewMockBackend(), Options{
 		DisableWAL:     true,

--- a/TreeDB/command_wal_public_cached.go
+++ b/TreeDB/command_wal_public_cached.go
@@ -825,6 +825,13 @@ func (b *commandWALPublicBatch) appendCommandWAL(sync bool) error {
 	if b == nil || b.inner == nil {
 		return ErrClosed
 	}
+	if !b.payloadBypass && b.payload.Count() == b.opCount && b.payload.Count() > 0 {
+		payload, err := b.commandWALPayload()
+		if err != nil {
+			return err
+		}
+		return b.db.appendPublicRawKVCommandPayload(payload, sync)
+	}
 	return b.db.appendPublicRawKVCommandEntryScan(b.inner.Replay, sync)
 }
 

--- a/TreeDB/command_wal_public_cached.go
+++ b/TreeDB/command_wal_public_cached.go
@@ -8,21 +8,22 @@ import (
 	"github.com/snissn/gomap/TreeDB/batch"
 	"github.com/snissn/gomap/TreeDB/db"
 	"github.com/snissn/gomap/TreeDB/internal/commitlog"
+	"github.com/snissn/gomap/TreeDB/page"
 )
 
-func (tdb *DB) appendPublicRawKVPointCommand(op commitlog.RawKVOp, key, value []byte, sync bool) error {
+func (tdb *DB) appendPublicRawKVPointCommand(op commitlog.RawKVOp, key, value []byte, revision EntryRevision, sync bool) error {
 	if tdb == nil || !tdb.commandWALCached {
 		return nil
 	}
 	if tdb.backend == nil {
 		return ErrClosed
 	}
-	lsn, err := tdb.backend.AppendRawKVPointCommandWALTrusted(op, key, value, sync)
+	lsn, err := tdb.backend.AppendRawKVPointCommandWALTrustedWithRevision(op, key, value, page.EntryRevision(revision), sync)
 	if lsn != 0 {
 		tdb.recordPublicCommandWALPendingLSN(lsn)
 	}
 	if err == nil && testAfterPublicCommandWALPointAppend != nil {
-		testAfterPublicCommandWALPointAppend(commitlog.RawKVOperation{Op: op, Key: key, Value: value})
+		testAfterPublicCommandWALPointAppend(commitlog.RawKVOperation{Op: op, Key: key, Value: value, Revision: uint64(revision)})
 	}
 	return err
 }
@@ -803,13 +804,6 @@ func (b *commandWALPublicBatch) commandWALPayload() ([]byte, error) {
 func (b *commandWALPublicBatch) appendCommandWAL(sync bool) error {
 	if b == nil || b.inner == nil {
 		return ErrClosed
-	}
-	if !b.payloadBypass && b.payload.Count() == b.opCount && b.payload.Count() > 0 {
-		payload, err := b.commandWALPayload()
-		if err != nil {
-			return err
-		}
-		return b.db.appendPublicRawKVCommandPayload(payload, sync)
 	}
 	return b.db.appendPublicRawKVCommandEntryScan(b.inner.Replay, sync)
 }

--- a/TreeDB/command_wal_public_cached.go
+++ b/TreeDB/command_wal_public_cached.go
@@ -776,12 +776,49 @@ func commandWALPublicAllZeroBytes(p []byte) bool {
 	return len(p) > 0
 }
 
+var errCommandWALPublicBatchHasEntryRevision = errors.New("treedb: command wal public batch has entry revision")
+
+func (b *commandWALPublicBatch) hasCommandWALPointEntryRevisions() (bool, error) {
+	if b == nil || b.inner == nil {
+		return false, ErrClosed
+	}
+	err := b.inner.Replay(func(entry batch.Entry) error {
+		switch entry.Type {
+		case batch.OpDelete, batch.OpPut:
+			if entry.Revision != page.LegacyEntryRevision {
+				return errCommandWALPublicBatchHasEntryRevision
+			}
+		}
+		return nil
+	})
+	if errors.Is(err, errCommandWALPublicBatchHasEntryRevision) {
+		return true, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return false, nil
+}
+
 func (b *commandWALPublicBatch) commandWALPayload() ([]byte, error) {
 	if b == nil || b.inner == nil {
 		return nil, ErrClosed
 	}
 	if !b.payloadBypass && b.payload.Count() == b.opCount && b.payload.Count() > 0 {
-		return b.payload.Payload(), nil
+		// Stable payloads are built before cached WriteAfterCommandWALAppend assigns
+		// visible entry revisions. Actual DB-backed command-WAL batches must rebuild
+		// once those revisions are present; test wrappers with no DB keep the pure
+		// stable-payload fast path.
+		if b.db == nil {
+			return b.payload.Payload(), nil
+		}
+		hasEntryRevisions, err := b.hasCommandWALPointEntryRevisions()
+		if err != nil {
+			return nil, err
+		}
+		if !hasEntryRevisions {
+			return b.payload.Payload(), nil
+		}
 	}
 	byteHint, _ := b.inner.GetByteSize()
 	sawEntryRevision := false

--- a/TreeDB/command_wal_public_cached.go
+++ b/TreeDB/command_wal_public_cached.go
@@ -1,6 +1,7 @@
 package treedb
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -783,7 +784,8 @@ func (b *commandWALPublicBatch) commandWALPayload() ([]byte, error) {
 		return b.payload.Payload(), nil
 	}
 	byteHint, _ := b.inner.GetByteSize()
-	return commitlog.EncodeRawKVBatchPayloadScanWithHint(func(emit func(commitlog.RawKVOperation) error) error {
+	sawEntryRevision := false
+	scan := func(emit func(commitlog.RawKVOperation) error) error {
 		return b.inner.Replay(func(entry batch.Entry) error {
 			switch entry.Type {
 			case batch.OpDeleteRange:
@@ -792,13 +794,31 @@ func (b *commandWALPublicBatch) commandWALPayload() ([]byte, error) {
 				}
 				return emit(commitlog.RawKVOperation{Op: commitlog.RawKVOpDeleteRange, Key: entry.Key, Value: entry.Value})
 			case batch.OpDelete:
-				return emit(commitlog.RawKVOperation{Op: commitlog.RawKVOpDelete, Key: entry.Key})
+				if entry.Revision != page.LegacyEntryRevision {
+					sawEntryRevision = true
+				}
+				return emit(commitlog.RawKVOperation{Op: commitlog.RawKVOpDelete, Key: entry.Key, Revision: uint64(entry.Revision)})
 			case batch.OpPut:
-				return emit(commitlog.RawKVOperation{Op: commitlog.RawKVOpSet, Key: entry.Key, Value: entry.Value})
+				if entry.Revision != page.LegacyEntryRevision {
+					sawEntryRevision = true
+				}
+				return emit(commitlog.RawKVOperation{Op: commitlog.RawKVOpSet, Key: entry.Key, Value: entry.Value, Revision: uint64(entry.Revision)})
 			}
 			return nil
 		})
-	}, b.opCount, byteHint)
+	}
+	payload, err := commitlog.EncodeRawKVBatchPayloadScanWithHint(scan, b.opCount, byteHint)
+	if err == nil {
+		return payload, nil
+	}
+	if !sawEntryRevision || !errors.Is(err, commitlog.ErrCommandWALUnsupportedVersion) {
+		return nil, err
+	}
+	plan, err := commitlog.PlanRawKVBatchPayloadScan(scan)
+	if err != nil {
+		return nil, err
+	}
+	return commitlog.EncodeRawKVBatchPayloadPlanned(plan, scan)
 }
 
 func (b *commandWALPublicBatch) appendCommandWAL(sync bool) error {

--- a/TreeDB/command_wal_public_test.go
+++ b/TreeDB/command_wal_public_test.go
@@ -1536,6 +1536,111 @@ func TestPublicCommandWALBatchAppendUsesStablePayload(t *testing.T) {
 	}
 }
 
+func TestPublicCommandWALBatchReplayBytesPayloadPreservesAssignedRevision(t *testing.T) {
+	dir := t.TempDir()
+	db, err := Open(Options{
+		Dir:                 dir,
+		Durability:          DurabilityWALOnRelaxed,
+		CommandWAL:          true,
+		CommandWALStatsScan: true,
+		DisableSideStores:   true,
+	})
+	if err != nil {
+		t.Fatalf("Open command WAL: %v", err)
+	}
+
+	b, ok := db.NewBatch().(*commandWALPublicBatch)
+	if !ok {
+		_ = db.Close()
+		t.Fatalf("NewBatch type=%T, want *commandWALPublicBatch", db.NewBatch())
+	}
+	keyView, valueView, err := b.SetViewWithReplayBytes([]byte("k"), []byte("value"))
+	if err != nil {
+		_ = b.Close()
+		_ = db.Close()
+		t.Fatalf("SetViewWithReplayBytes: %v", err)
+	}
+	if b.payloadBypass || b.payload.Count() != b.opCount || b.payload.Count() != 1 {
+		_ = b.Close()
+		_ = db.Close()
+		t.Fatalf("payload state bypass=%t count=%d opCount=%d, want stable count 1", b.payloadBypass, b.payload.Count(), b.opCount)
+	}
+	if string(keyView) != "k" || string(valueView) != "value" {
+		_ = b.Close()
+		_ = db.Close()
+		t.Fatalf("replay views key=%q value=%q, want k/value", keyView, valueView)
+	}
+	if err := b.Write(); err != nil {
+		_ = b.Close()
+		_ = db.Close()
+		t.Fatalf("batch Write: %v", err)
+	}
+	if err := b.Close(); err != nil {
+		_ = db.Close()
+		t.Fatalf("batch Close: %v", err)
+	}
+
+	val, revision, err := db.GetVersioned([]byte("k"))
+	if err != nil {
+		_ = db.Close()
+		t.Fatalf("GetVersioned: %v", err)
+	}
+	if !bytes.Equal(val, []byte("value")) || revision == LegacyEntryRevision {
+		_ = db.Close()
+		t.Fatalf("GetVersioned=(%q,%d), want (value,non-legacy)", val, revision)
+	}
+
+	r, err := commitlog.NewReader(filepath.Join(backenddb.WALDirPath(dir), "commit-l0-000001.log"))
+	if err != nil {
+		_ = db.Close()
+		t.Fatalf("NewReader: %v", err)
+	}
+	env, err := r.ReadCommandFrame()
+	if err != nil {
+		_ = r.Close()
+		_ = db.Close()
+		t.Fatalf("ReadCommandFrame: %v", err)
+	}
+	var gotRevision uint64
+	visits := 0
+	if err := commitlog.ScanRawKVBatchPayloadWithRevision(env.Payload, func(op commitlog.RawKVOp, gotKey, gotValue []byte, revision uint64) error {
+		visits++
+		if op != commitlog.RawKVOpSet || string(gotKey) != "k" || string(gotValue) != "value" {
+			t.Fatalf("decoded op=%v key=%q value=%q", op, gotKey, gotValue)
+		}
+		gotRevision = revision
+		return nil
+	}); err != nil {
+		_ = r.Close()
+		_ = db.Close()
+		t.Fatalf("ScanRawKVBatchPayloadWithRevision: %v", err)
+	}
+	if err := r.Close(); err != nil {
+		_ = db.Close()
+		t.Fatalf("reader Close: %v", err)
+	}
+	if visits != 1 || gotRevision != uint64(revision) {
+		_ = db.Close()
+		t.Fatalf("command WAL visits=%d revision=%d, want 1/%d", visits, gotRevision, revision)
+	}
+
+	if err := db.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	reopen, err := Open(Options{Dir: dir, CommandWALStatsScan: true, DisableSideStores: true})
+	if err != nil {
+		t.Fatalf("Reopen command WAL: %v", err)
+	}
+	defer func() { _ = reopen.Close() }()
+	val, reopenedRevision, err := reopen.GetVersioned([]byte("k"))
+	if err != nil {
+		t.Fatalf("reopen GetVersioned: %v", err)
+	}
+	if !bytes.Equal(val, []byte("value")) || reopenedRevision != revision {
+		t.Fatalf("reopen GetVersioned=(%q,%d), want (value,%d)", val, reopenedRevision, revision)
+	}
+}
+
 func TestPublicCommandWALBatchSetViewBypassesPayloadBuilderWithoutInnerCopy(t *testing.T) {
 	inner := &commandWALPayloadSoftCapBatch{}
 	wrapped := newCommandWALPublicBatch(nil, inner, 0)

--- a/TreeDB/command_wal_public_test.go
+++ b/TreeDB/command_wal_public_test.go
@@ -1472,6 +1472,49 @@ func TestPublicCommandWALBatchOrdinarySetBypassesPayloadBuilder(t *testing.T) {
 	}
 }
 
+func TestPublicCommandWALBatchFallbackPreservesEntryRevisions(t *testing.T) {
+	inner := &commandWALPayloadSoftCapBatch{}
+	wrapped := newCommandWALPublicBatch(nil, inner, 0)
+	inner.entries = append(inner.entries,
+		batch.Entry{Type: batch.OpPut, Key: []byte("alpha"), Value: []byte("one"), Revision: 41},
+		batch.Entry{Type: batch.OpDelete, Key: []byte("bravo"), Revision: 42},
+		batch.Entry{Type: batch.OpDeleteRange, Key: []byte("range-a"), Value: []byte("range-z"), Revision: 99},
+	)
+	wrapped.payloadBypass = true
+	wrapped.opCount = len(inner.entries)
+
+	payload, err := wrapped.commandWALPayload()
+	if err != nil {
+		t.Fatalf("commandWALPayload: %v", err)
+	}
+	type gotOp struct {
+		op       commitlog.RawKVOp
+		key      string
+		value    string
+		revision uint64
+	}
+	var got []gotOp
+	if err := commitlog.ScanRawKVBatchPayloadWithRevision(payload, func(op commitlog.RawKVOp, key, value []byte, revision uint64) error {
+		got = append(got, gotOp{op: op, key: string(key), value: string(value), revision: revision})
+		return nil
+	}); err != nil {
+		t.Fatalf("ScanRawKVBatchPayloadWithRevision: %v", err)
+	}
+	want := []gotOp{
+		{op: commitlog.RawKVOpSet, key: "alpha", value: "one", revision: 41},
+		{op: commitlog.RawKVOpDelete, key: "bravo", revision: 42},
+		{op: commitlog.RawKVOpDeleteRange, key: "range-a", value: "range-z"},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("decoded ops=%+v, want %+v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("decoded op %d=%+v, want %+v", i, got[i], want[i])
+		}
+	}
+}
+
 func TestPublicCommandWALBatchSetViewBypassesPayloadBuilderWithoutInnerCopy(t *testing.T) {
 	inner := &commandWALPayloadSoftCapBatch{}
 	wrapped := newCommandWALPublicBatch(nil, inner, 0)

--- a/TreeDB/command_wal_public_test.go
+++ b/TreeDB/command_wal_public_test.go
@@ -1515,6 +1515,27 @@ func TestPublicCommandWALBatchFallbackPreservesEntryRevisions(t *testing.T) {
 	}
 }
 
+func TestPublicCommandWALBatchAppendUsesStablePayload(t *testing.T) {
+	inner := &commandWALPayloadSoftCapBatch{}
+	wrapped := newCommandWALPublicBatch(nil, inner, 0)
+
+	if _, _, err := wrapped.SetViewWithReplayBytes([]byte("alpha"), []byte("one")); err != nil {
+		t.Fatalf("SetViewWithReplayBytes alpha: %v", err)
+	}
+	if _, _, err := wrapped.SetViewWithReplayBytes([]byte("bravo"), []byte("two")); err != nil {
+		t.Fatalf("SetViewWithReplayBytes bravo: %v", err)
+	}
+	if wrapped.payloadBypass || wrapped.payload.Count() != wrapped.opCount || wrapped.payload.Count() != 2 {
+		t.Fatalf("payload state bypass=%t count=%d opCount=%d, want stable count 2", wrapped.payloadBypass, wrapped.payload.Count(), wrapped.opCount)
+	}
+	if err := wrapped.appendCommandWAL(false); err != nil {
+		t.Fatalf("appendCommandWAL: %v", err)
+	}
+	if inner.replayCalls != 0 {
+		t.Fatalf("inner replay calls=%d, want 0 for stable payload append", inner.replayCalls)
+	}
+}
+
 func TestPublicCommandWALBatchSetViewBypassesPayloadBuilderWithoutInnerCopy(t *testing.T) {
 	inner := &commandWALPayloadSoftCapBatch{}
 	wrapped := newCommandWALPublicBatch(nil, inner, 0)

--- a/TreeDB/command_wal_public_test.go
+++ b/TreeDB/command_wal_public_test.go
@@ -562,6 +562,110 @@ func TestPublicCommandWALPointWritesSerializeLSNWithCachedMutation(t *testing.T)
 	assertPublicCommandWALFrames(t, db, 2)
 }
 
+func TestPublicCommandWALPointWritesUseVisibleRevision(t *testing.T) {
+	db, err := Open(Options{
+		Dir:                 t.TempDir(),
+		Durability:          DurabilityWALOnRelaxed,
+		CommandWAL:          true,
+		CommandWALStatsScan: true,
+		DisableSideStores:   true,
+	})
+	if err != nil {
+		t.Fatalf("Open command WAL: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	var pointOps []commitlog.RawKVOperation
+	prevHook := testAfterPublicCommandWALPointAppend
+	testAfterPublicCommandWALPointAppend = func(op commitlog.RawKVOperation) {
+		pointOps = append(pointOps, op)
+	}
+	defer func() { testAfterPublicCommandWALPointAppend = prevHook }()
+
+	if err := db.Set([]byte("k"), []byte("value")); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	val, revision, err := db.GetVersioned([]byte("k"))
+	if err != nil {
+		t.Fatalf("GetVersioned: %v", err)
+	}
+	if len(pointOps) != 1 || pointOps[0].Revision == 0 {
+		t.Fatalf("point ops after Set=%+v, want one revision-bearing op", pointOps)
+	}
+	if !bytes.Equal(val, []byte("value")) || revision != EntryRevision(pointOps[0].Revision) {
+		t.Fatalf("GetVersioned after Set=(%q,%d), command revision=%d", val, revision, pointOps[0].Revision)
+	}
+
+	if err := db.Delete([]byte("k")); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	val, revision, err = db.GetVersioned([]byte("k"))
+	if err != nil {
+		t.Fatalf("GetVersioned after Delete: %v", err)
+	}
+	if len(pointOps) != 2 || pointOps[1].Revision == 0 {
+		t.Fatalf("point ops after Delete=%+v, want second revision-bearing op", pointOps)
+	}
+	if val != nil || revision != EntryRevision(pointOps[1].Revision) || revision <= EntryRevision(pointOps[0].Revision) {
+		t.Fatalf("GetVersioned after Delete=(%q,%d), command revisions=(%d,%d)", val, revision, pointOps[0].Revision, pointOps[1].Revision)
+	}
+}
+
+func TestPublicCommandWALBatchWritesPreserveVisibleRevisionOnReopen(t *testing.T) {
+	dir := t.TempDir()
+	db, err := Open(Options{
+		Dir:                 dir,
+		Durability:          DurabilityWALOnRelaxed,
+		CommandWAL:          true,
+		CommandWALStatsScan: true,
+		DisableSideStores:   true,
+	})
+	if err != nil {
+		t.Fatalf("Open command WAL: %v", err)
+	}
+
+	b := db.NewBatch()
+	if err := b.Set([]byte("k"), []byte("value")); err != nil {
+		_ = b.Close()
+		_ = db.Close()
+		t.Fatalf("batch Set: %v", err)
+	}
+	if err := b.Write(); err != nil {
+		_ = b.Close()
+		_ = db.Close()
+		t.Fatalf("batch Write: %v", err)
+	}
+	if err := b.Close(); err != nil {
+		_ = db.Close()
+		t.Fatalf("batch Close: %v", err)
+	}
+	val, revision, err := db.GetVersioned([]byte("k"))
+	if err != nil {
+		_ = db.Close()
+		t.Fatalf("GetVersioned: %v", err)
+	}
+	if !bytes.Equal(val, []byte("value")) || revision == LegacyEntryRevision {
+		_ = db.Close()
+		t.Fatalf("GetVersioned=(%q,%d), want (value,non-legacy)", val, revision)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	reopen, err := Open(Options{Dir: dir, CommandWALStatsScan: true})
+	if err != nil {
+		t.Fatalf("Reopen command WAL: %v", err)
+	}
+	defer func() { _ = reopen.Close() }()
+	val, reopenedRevision, err := reopen.GetVersioned([]byte("k"))
+	if err != nil {
+		t.Fatalf("reopen GetVersioned: %v", err)
+	}
+	if !bytes.Equal(val, []byte("value")) || reopenedRevision != revision {
+		t.Fatalf("reopen GetVersioned=(%q,%d), want (value,%d)", val, reopenedRevision, revision)
+	}
+}
+
 func TestPublicCommandWALBatchCloseDiscardsDirtyPayload(t *testing.T) {
 	db, err := Open(Options{
 		Dir:                 t.TempDir(),

--- a/TreeDB/db/api.go
+++ b/TreeDB/db/api.go
@@ -750,6 +750,7 @@ func (db *DB) Stats() map[string]string {
 	stats["treedb.root_page"] = fmt.Sprintf("%d", state.RootPageID)
 	stats["treedb.system_root_page"] = fmt.Sprintf("%d", state.SystemRootPageID)
 	stats["treedb.applied_command_lsn"] = fmt.Sprintf("%d", state.AppliedCommandLSN)
+	stats["treedb.max_entry_revision"] = fmt.Sprintf("%d", state.MaxEntryRevision)
 	stats["treedb.command_wal.enabled"] = fmt.Sprintf("%t", db.commandWAL)
 	writeCommandWALStats(stats, db)
 	db.appendFlushApplyStats(stats)

--- a/TreeDB/db/batch.go
+++ b/TreeDB/db/batch.go
@@ -275,6 +275,7 @@ func (b *Batch) write(sync bool) error {
 		b.db.observeRawSpanNativeApplyResult(b.rawSpanNativeBatchPlan(), zipper.ApplyResult{}, nil, false, false)
 		return b.db.Checkpoint()
 	}
+	maxEntryRevision := b.db.assignBatchEntryRevisions(b.batch)
 	intent := b.commandWALPublishIntent
 	if !b.physicalOnly && b.db.commandWAL {
 		unlockRawPublish := b.db.lockCommandWALRawPublish()
@@ -288,16 +289,16 @@ func (b *Batch) write(sync bool) error {
 			return err
 		}
 	}
-	return b.writeWithCommandWALIntent(sync, intent)
+	return b.writeWithCommandWALIntent(sync, intent, maxEntryRevision)
 }
 
-func (b *Batch) writeWithCommandWALIntent(sync bool, intent *commandWALBatchIntent) error {
+func (b *Batch) writeWithCommandWALIntent(sync bool, intent *commandWALBatchIntent, maxEntryRevision page.EntryRevision) error {
 	// If a command frame is appended but root publication later returns an
 	// error, the durable frame is intentionally left for reopen recovery. Reuse
 	// the same intent across optimistic/serialized attempts so one user batch
 	// keeps one command LSN.
 	for attempt := 0; attempt < optimisticWriteMaxAttempts; attempt++ {
-		committed, err := b.writeOptimistic(sync, intent)
+		committed, err := b.writeOptimistic(sync, intent, maxEntryRevision)
 		if err != nil {
 			return err
 		}
@@ -306,10 +307,10 @@ func (b *Batch) writeWithCommandWALIntent(sync bool, intent *commandWALBatchInte
 		}
 		b.db.observeFlushApplyRetry()
 	}
-	return b.writeSerialized(sync, intent)
+	return b.writeSerialized(sync, intent, maxEntryRevision)
 }
 
-func (b *Batch) writeOptimistic(sync bool, intent *commandWALBatchIntent) (bool, error) {
+func (b *Batch) writeOptimistic(sync bool, intent *commandWALBatchIntent, maxEntryRevision page.EntryRevision) (bool, error) {
 	touchedValueLogSegments := b.batch.TouchedValueLogSegments()
 	rawSpanPlan := b.rawSpanNativeBatchPlan()
 
@@ -463,7 +464,7 @@ func (b *Batch) writeOptimistic(sync bool, intent *commandWALBatchIntent) (bool,
 
 	var post finalizeCommitPost
 	if intent == nil {
-		post, err = b.db.finalizeCommitLockedWithOptions(newRoot, sysRoot, retired, sync, metrics, touchedValueLogSegments, b.db.indexOuterLeavesInValueLog, vlogRefDelta, nil, nil, finalizeCommitOptions{skipPrePublishFlush: true})
+		post, err = b.db.finalizeCommitLockedWithOptions(newRoot, sysRoot, retired, sync, metrics, touchedValueLogSegments, b.db.indexOuterLeavesInValueLog, vlogRefDelta, nil, nil, finalizeCommitOptions{skipPrePublishFlush: true, maxEntryRevision: maxEntryRevision})
 	} else {
 		if _, err = b.db.appendRawKVCommandWALIntent(intent, sync); err != nil {
 			b.db.releasePendingValueLogAppendFileIDsFromBatch(b.batch)
@@ -480,6 +481,7 @@ func (b *Batch) writeOptimistic(sync bool, intent *commandWALBatchIntent) (bool,
 		}
 		opts := commandWALFinalizeOptions(intent)
 		opts.skipPrePublishFlush = true
+		opts.maxEntryRevision = maxEntryRevision
 		post, err = b.db.finalizeCommitLockedWithOptions(newRoot, sysRoot, retired, sync, metrics, touchedValueLogSegments, b.db.indexOuterLeavesInValueLog, vlogRefDelta, nil, nil, opts)
 		// Poison while still holding commitMu so that no concurrent writer can
 		// slip past the poison check in appendRawKVCommandWALIntent and publish a
@@ -509,7 +511,7 @@ func (b *Batch) writeOptimistic(sync bool, intent *commandWALBatchIntent) (bool,
 	return true, nil
 }
 
-func (b *Batch) writeSerialized(sync bool, intent *commandWALBatchIntent) error {
+func (b *Batch) writeSerialized(sync bool, intent *commandWALBatchIntent, maxEntryRevision page.EntryRevision) error {
 	touchedValueLogSegments := b.batch.TouchedValueLogSegments()
 	rawSpanPlan := b.rawSpanNativeBatchPlan()
 
@@ -606,7 +608,7 @@ func (b *Batch) writeSerialized(sync bool, intent *commandWALBatchIntent) error 
 	guardedPublishStart := time.Now()
 	var post finalizeCommitPost
 	if intent == nil {
-		post, err = b.db.finalizeCommitLockedWithOptions(newRoot, sysRoot, retired, sync, metrics, touchedValueLogSegments, b.db.indexOuterLeavesInValueLog, vlogRefDelta, nil, nil, finalizeCommitOptions{skipPrePublishFlush: true})
+		post, err = b.db.finalizeCommitLockedWithOptions(newRoot, sysRoot, retired, sync, metrics, touchedValueLogSegments, b.db.indexOuterLeavesInValueLog, vlogRefDelta, nil, nil, finalizeCommitOptions{skipPrePublishFlush: true, maxEntryRevision: maxEntryRevision})
 	} else {
 		// writeMu is released by the deferred unlock above even if the command
 		// journal append fails and poisons this open handle.
@@ -619,6 +621,7 @@ func (b *Batch) writeSerialized(sync bool, intent *commandWALBatchIntent) error 
 		}
 		opts := commandWALFinalizeOptions(intent)
 		opts.skipPrePublishFlush = true
+		opts.maxEntryRevision = maxEntryRevision
 		post, err = b.db.finalizeCommitLockedWithOptions(newRoot, sysRoot, retired, sync, metrics, touchedValueLogSegments, b.db.indexOuterLeavesInValueLog, vlogRefDelta, nil, nil, opts)
 	}
 	b.db.observeFlushApplyGuardedPublish(time.Since(guardedPublishStart), err == nil)

--- a/TreeDB/db/command_wal_publish.go
+++ b/TreeDB/db/command_wal_publish.go
@@ -29,6 +29,7 @@ type finalizeCommitOptions struct {
 	appliedCommandLSN   uint64
 	appliedRanges       []CommandWALLSNRange
 	skipPrePublishFlush bool
+	maxEntryRevision    page.EntryRevision
 }
 
 func (db *DB) publishCommandWALRoots(newRootID uint64, sysRootID uint64, appliedLSN uint64, covered []CommandWALLSNRange, sync bool) error {

--- a/TreeDB/db/command_wal_raw.go
+++ b/TreeDB/db/command_wal_raw.go
@@ -29,6 +29,7 @@ type commandWALBatchIntent struct {
 	externalRefFileIDs []uint32
 	fromReplay         bool
 	lsn                uint64
+	maxEntryRevision   page.EntryRevision
 	replayToken        uint64
 	coveredRange       [1]CommandWALLSNRange
 	syncOnPublish      bool
@@ -488,7 +489,18 @@ func (db *DB) newRawKVCommandWALIntentFromEntryScan(scanEntries func(func(batchp
 	externalRefs := false
 	var ridCache map[page.ValuePtr]uint64
 	var externalRefFileIDs []uint32
-	planScan := db.rawKVCommandWALOperationScannerFromEntryScan(scanEntries, &ridCache, &externalRefs, &externalRefFileIDs)
+	maxEntryRevision := page.LegacyEntryRevision
+	planScan := db.rawKVCommandWALOperationScannerFromEntryScan(func(emit func(batchpkg.Entry) error) error {
+		if scanEntries == nil {
+			return nil
+		}
+		return scanEntries(func(entry batchpkg.Entry) error {
+			if entry.Type != batchpkg.OpDeleteRange && entry.Revision > maxEntryRevision {
+				maxEntryRevision = entry.Revision
+			}
+			return emit(entry)
+		})
+	}, &ridCache, &externalRefs, &externalRefFileIDs)
 	plan, err := commitlog.PlanRawKVBatchPayloadScan(planScan)
 	if err != nil {
 		return nil, err
@@ -507,6 +519,7 @@ func (db *DB) newRawKVCommandWALIntentFromEntryScan(scanEntries func(func(batchp
 		rawKVDirect:        true,
 		externalRefs:       externalRefs,
 		externalRefFileIDs: externalRefFileIDs,
+		maxEntryRevision:   maxEntryRevision,
 	}, nil
 }
 
@@ -541,7 +554,22 @@ func (db *DB) newRawKVCommandWALPayloadIntentFromEntries(entries []batchpkg.Entr
 		payload:            payload,
 		externalRefs:       externalRefs,
 		externalRefFileIDs: externalRefFileIDs,
+		maxEntryRevision:   maxEntryRevisionFromEntries(entries),
 	}, nil
+}
+
+func maxEntryRevisionFromEntries(entries []batchpkg.Entry) page.EntryRevision {
+	maxRevision := page.LegacyEntryRevision
+	for i := range entries {
+		entry := &entries[i]
+		if entry.Type == batchpkg.OpDeleteRange {
+			continue
+		}
+		if entry.Revision > maxRevision {
+			maxRevision = entry.Revision
+		}
+	}
+	return maxRevision
 }
 
 func (db *DB) rawKVCommandWALOperationScanner(entries []batchpkg.Entry, ridCache *map[page.ValuePtr]uint64, externalRefs *bool) commitlog.RawKVBatchOperationScanner {
@@ -880,6 +908,16 @@ func (db *DB) AppendRawKVSingleCommandWAL(op commitlog.RawKVOperation, sync bool
 // the command as pending and treat subsequent command-WAL appends as
 // recovery-required until the DB is reopened.
 func (db *DB) AppendRawKVPointCommandWALTrusted(op commitlog.RawKVOp, key, value []byte, sync bool) (uint64, error) {
+	return db.appendRawKVPointCommandWALTrustedWithRevision(op, key, value, 0, sync)
+}
+
+// AppendRawKVPointCommandWALTrustedWithRevision appends a caller-validated
+// public raw-KV point command with native entry revision metadata.
+func (db *DB) AppendRawKVPointCommandWALTrustedWithRevision(op commitlog.RawKVOp, key, value []byte, revision page.EntryRevision, sync bool) (uint64, error) {
+	return db.appendRawKVPointCommandWALTrustedWithRevision(op, key, value, uint64(revision), sync)
+}
+
+func (db *DB) appendRawKVPointCommandWALTrustedWithRevision(op commitlog.RawKVOp, key, value []byte, revision uint64, sync bool) (uint64, error) {
 	if db == nil || !db.commandWAL {
 		return 0, nil
 	}
@@ -905,7 +943,13 @@ func (db *DB) AppendRawKVPointCommandWALTrusted(op commitlog.RawKVOp, key, value
 		baseAppliedLSN = state.AppliedCommandLSN
 	}
 	flushSync := sync && db.durability != DurabilityWALOnRelaxed
-	lsn, err := db.commandJournal.AppendRawKVPointCommandTrustedAndFlush(baseAppliedLSN, op, key, value, flushSync)
+	var lsn uint64
+	var err error
+	if revision == 0 {
+		lsn, err = db.commandJournal.AppendRawKVPointCommandTrustedAndFlush(baseAppliedLSN, op, key, value, flushSync)
+	} else {
+		lsn, err = db.commandJournal.AppendRawKVPointCommandTrustedWithRevisionAndFlush(baseAppliedLSN, op, key, value, revision, flushSync)
+	}
 	if err == nil && db.testFailCommandWALFlush.Load() {
 		err = errTestCommandWALFlushFailpoint
 	}
@@ -1153,6 +1197,7 @@ func commandWALFinalizeOptions(intent *commandWALBatchIntent) finalizeCommitOpti
 		commandWALPublish: true,
 		appliedCommandLSN: intent.lsn,
 		appliedRanges:     []CommandWALLSNRange{appliedRange},
+		maxEntryRevision:  intent.maxEntryRevision,
 	}
 }
 
@@ -1305,8 +1350,9 @@ func applyRawKVCommandWALFrame(db *DB, env commitlog.CommandEnvelope, ridMap map
 			return err
 		}
 	}
+	maxEntryRevision := db.assignBatchEntryRevisions(b.batch)
 	return b.writeWithCommandWALIntent(true, &commandWALBatchIntent{
 		lsn:          env.LSN,
 		coveredRange: [1]CommandWALLSNRange{{First: env.LSN, Last: env.LSN}},
-	})
+	}, maxEntryRevision)
 }

--- a/TreeDB/db/command_wal_raw.go
+++ b/TreeDB/db/command_wal_raw.go
@@ -283,11 +283,16 @@ func (db *DB) NewCommandWALIntent(kind commitlog.CommandKind, scope commitlog.Co
 	if db.durability == DurabilityWALOffRelaxed {
 		return nil, fmt.Errorf("%w: WAL-off durability is incompatible with command WAL", ErrCommandWALUnsupported)
 	}
+	maxEntryRevision, err := maxEntryRevisionFromCommandWALPayload(kind, scope, payloadFormat, payload)
+	if err != nil {
+		return nil, err
+	}
 	return &CommandWALIntent{inner: commandWALBatchIntent{
-		kind:          kind,
-		scope:         scope,
-		payloadFormat: payloadFormat,
-		payload:       payload,
+		kind:             kind,
+		scope:            scope,
+		payloadFormat:    payloadFormat,
+		payload:          payload,
+		maxEntryRevision: maxEntryRevision,
 	}}, nil
 }
 
@@ -570,6 +575,27 @@ func maxEntryRevisionFromEntries(entries []batchpkg.Entry) page.EntryRevision {
 		}
 	}
 	return maxRevision
+}
+
+func maxEntryRevisionFromCommandWALPayload(kind commitlog.CommandKind, scope commitlog.CommandScope, payloadFormat commitlog.PayloadFormat, payload []byte) (page.EntryRevision, error) {
+	if kind != commitlog.CommandKindRawKVBatch || scope != commitlog.CommandScopeRawKV || payloadFormat != commitlog.PayloadFormatRawKVBatchV1 {
+		return page.LegacyEntryRevision, nil
+	}
+	maxRevision := page.LegacyEntryRevision
+	err := commitlog.ScanRawKVBatchPayloadWithRevision(payload, func(op commitlog.RawKVOp, _ []byte, _ []byte, revision uint64) error {
+		if op == commitlog.RawKVOpDeleteRange || revision == 0 {
+			return nil
+		}
+		entryRevision := page.EntryRevision(revision)
+		if entryRevision > maxRevision {
+			maxRevision = entryRevision
+		}
+		return nil
+	})
+	if err != nil {
+		return page.LegacyEntryRevision, err
+	}
+	return maxRevision, nil
 }
 
 func (db *DB) rawKVCommandWALOperationScanner(entries []batchpkg.Entry, ridCache *map[page.ValuePtr]uint64, externalRefs *bool) commitlog.RawKVBatchOperationScanner {

--- a/TreeDB/db/command_wal_raw_test.go
+++ b/TreeDB/db/command_wal_raw_test.go
@@ -8,6 +8,7 @@ import (
 
 	batchpkg "github.com/snissn/gomap/TreeDB/batch"
 	"github.com/snissn/gomap/TreeDB/internal/commitlog"
+	"github.com/snissn/gomap/TreeDB/page"
 )
 
 func TestCommandWALIntentZeroValueLSNSentinelsM10C(t *testing.T) {
@@ -25,6 +26,42 @@ func TestCommandWALIntentZeroValueLSNSentinelsM10C(t *testing.T) {
 	}
 	if got, replay := zero.ReplayAssignedLSN(); got != 0 || replay {
 		t.Fatalf("zero ReplayAssignedLSN=(%d,%t), want (0,false)", got, replay)
+	}
+}
+
+func TestCommandWALIntentRawKVPayloadSetsMaxEntryRevision(t *testing.T) {
+	d, err := Open(Options{Dir: t.TempDir(), CommandWAL: true, DisableBackgroundPrune: true})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	payload, err := commitlog.EncodeRawKVBatchPayload([]commitlog.RawKVOperation{
+		{Op: commitlog.RawKVOpSet, Key: []byte("alpha"), Value: []byte("one"), Revision: 17},
+		{Op: commitlog.RawKVOpDelete, Key: []byte("bravo"), Revision: 29},
+		{Op: commitlog.RawKVOpDeleteRange, Key: []byte("range-a"), Value: []byte("range-z")},
+	})
+	if err != nil {
+		t.Fatalf("EncodeRawKVBatchPayload: %v", err)
+	}
+	intent, err := d.NewCommandWALIntent(commitlog.CommandKindRawKVBatch, commitlog.CommandScopeRawKV, commitlog.PayloadFormatRawKVBatchV1, payload)
+	if err != nil {
+		t.Fatalf("NewCommandWALIntent: %v", err)
+	}
+	if got := intent.inner.maxEntryRevision; got != page.EntryRevision(29) {
+		t.Fatalf("intent maxEntryRevision=%d, want 29", got)
+	}
+	intent.inner.lsn = 7
+	if got := commandWALFinalizeOptionsForPublicIntent(intent).maxEntryRevision; got != page.EntryRevision(29) {
+		t.Fatalf("finalize maxEntryRevision=%d, want 29", got)
+	}
+
+	trusted, err := d.NewTrustedCommandWALIntent(commitlog.CommandKindRawKVBatch, commitlog.CommandScopeRawKV, commitlog.PayloadFormatRawKVBatchV1, payload)
+	if err != nil {
+		t.Fatalf("NewTrustedCommandWALIntent: %v", err)
+	}
+	if got := trusted.inner.maxEntryRevision; got != page.EntryRevision(29) {
+		t.Fatalf("trusted maxEntryRevision=%d, want 29", got)
 	}
 }
 

--- a/TreeDB/db/command_wal_recovery_test.go
+++ b/TreeDB/db/command_wal_recovery_test.go
@@ -1568,6 +1568,59 @@ func TestCommandWALRecoveryPreservesEntryRevision(t *testing.T) {
 	if got := reopen.State().AppliedCommandLSN; got != 1 {
 		t.Fatalf("AppliedCommandLSN=%d, want 1", got)
 	}
+	if got := reopen.State().MaxEntryRevision; got < page.EntryRevision(42) {
+		t.Fatalf("MaxEntryRevision=%d, want >= 42", got)
+	}
+}
+
+func TestCommandWALRecoveryAssignsLegacyEntryRevision(t *testing.T) {
+	dir := t.TempDir()
+	enableCommandWALFormat(t, dir)
+	db := openCommandWALDB(t, dir)
+	db.testFailFinalizeCommit.Store(true)
+	b := db.NewBatch().(*Batch)
+	if err := b.Set([]byte("legacy"), []byte("value")); err != nil {
+		t.Fatalf("Set legacy: %v", err)
+	}
+	err := b.WriteSync()
+	if !errors.Is(err, errTestFinalizeCommitFailpoint) {
+		t.Fatalf("crash batch WriteSync error=%v, want failpoint", err)
+	}
+	_ = b.Close()
+	if err := db.Close(); err != nil {
+		t.Fatalf("Close crashed db: %v", err)
+	}
+
+	reopen := openCommandWALDB(t, dir)
+	value, revision, err := reopen.GetVersioned([]byte("legacy"))
+	if err != nil {
+		t.Fatalf("GetVersioned legacy: %v", err)
+	}
+	if !bytes.Equal(value, []byte("value")) || revision == page.LegacyEntryRevision {
+		t.Fatalf("GetVersioned legacy=(%q,%d), want (value,non-legacy)", value, revision)
+	}
+	if got := reopen.State().AppliedCommandLSN; got != 1 {
+		t.Fatalf("AppliedCommandLSN=%d, want 1", got)
+	}
+	if got := reopen.State().MaxEntryRevision; got < revision {
+		t.Fatalf("MaxEntryRevision=%d, want >= assigned revision %d", got, revision)
+	}
+	if err := reopen.Close(); err != nil {
+		t.Fatalf("Close reopen: %v", err)
+	}
+
+	reopen = openCommandWALDB(t, dir)
+	defer reopen.Close()
+	value, reopenedRevision, err := reopen.GetVersioned([]byte("legacy"))
+	if err != nil {
+		t.Fatalf("second reopen GetVersioned legacy: %v", err)
+	}
+	if !bytes.Equal(value, []byte("value")) || reopenedRevision != revision {
+		t.Fatalf("second reopen GetVersioned legacy=(%q,%d), want (value,%d)", value, reopenedRevision, revision)
+	}
+	if got := reopen.State().MaxEntryRevision; got < revision {
+		t.Fatalf("second reopen MaxEntryRevision=%d, want >= assigned revision %d", got, revision)
+	}
 }
 
 func enableCommandWALFormat(t *testing.T, dir string) {

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -54,6 +54,7 @@ type DBState struct {
 	RootPageID                 uint64
 	SystemRootPageID           uint64
 	AppliedCommandLSN          uint64
+	MaxEntryRevision           page.EntryRevision
 	ValueLogSet                *valuelog.Set
 	LeafGenerations            *leafGenerationView
 	LeafGenerationStateVersion uint64
@@ -154,6 +155,7 @@ type DB struct {
 	vacuum                          vacuumRecorder
 	meta                            page.MetaPageBody
 	metaPageID                      uint64
+	entryRevisionFloor              atomic.Uint64
 	commandJournal                  *commitlog.CommandJournal
 
 	state atomic.Pointer[DBState]
@@ -1802,6 +1804,7 @@ func openWithLock(opts Options, lock *lockfile.Lock) (*DB, error) {
 		_ = db.Close()
 		return nil, err
 	}
+	db.seedEntryRevisionFloor()
 
 	segments, err := listRecoverySegments(opts.Dir)
 	if err != nil {
@@ -1949,6 +1952,7 @@ func openWithLock(opts Options, lock *lockfile.Lock) (*DB, error) {
 		RootPageID:                 db.meta.UserRootPageID,
 		SystemRootPageID:           db.meta.SystemRootPageID,
 		AppliedCommandLSN:          db.meta.AppliedCommandLSN,
+		MaxEntryRevision:           page.EntryRevision(db.meta.MaxEntryRevision),
 		ValueLogSet:                vm.CurrentSet(),
 		LeafGenerations:            db.currentLeafGenerationView(),
 		LeafGenerationStateVersion: db.leafGenerationStateVersion,
@@ -2530,6 +2534,9 @@ func (db *DB) finalizeCommitLockedWithOptions(newRootID uint64, sysRootID uint64
 		}
 		nextMeta.AppliedCommandLSN = opts.appliedCommandLSN
 	}
+	if opts.maxEntryRevision != page.LegacyEntryRevision && uint64(opts.maxEntryRevision) > nextMeta.MaxEntryRevision {
+		nextMeta.MaxEntryRevision = uint64(opts.maxEntryRevision)
+	}
 
 	targetPageID := uint64(0)
 	if db.metaPageID == 0 {
@@ -2589,6 +2596,7 @@ func (db *DB) finalizeCommitLockedWithOptions(newRootID uint64, sysRootID uint64
 	watermarkWait += time.Since(lockStart)
 	holdStart = time.Now()
 	db.meta = nextMeta
+	db.advanceEntryRevisionFloor(page.EntryRevision(nextMeta.MaxEntryRevision))
 	db.metaPageID = targetPageID
 	idx.graveyard.Add(nextMeta.CommitSeq-1, retired)
 	post.oldState = db.state.Load()
@@ -2641,6 +2649,7 @@ func (db *DB) finalizeCommitLockedWithOptions(newRootID uint64, sysRootID uint64
 		RootPageID:        nextMeta.UserRootPageID,
 		SystemRootPageID:  nextMeta.SystemRootPageID,
 		AppliedCommandLSN: nextMeta.AppliedCommandLSN,
+		MaxEntryRevision:  page.EntryRevision(nextMeta.MaxEntryRevision),
 		ValueLogSet:       valueLogSet,
 		LeafGenerations:   leafGenerationView,
 	}
@@ -3074,6 +3083,7 @@ func (db *DB) RefreshValueLogSet() error {
 		RootPageID:                 oldState.RootPageID,
 		SystemRootPageID:           oldState.SystemRootPageID,
 		AppliedCommandLSN:          oldState.AppliedCommandLSN,
+		MaxEntryRevision:           oldState.MaxEntryRevision,
 		ValueLogSet:                db.valueLogManager.CurrentSetNoRefresh(),
 		LeafGenerations:            oldState.LeafGenerations,
 		LeafGenerationStateVersion: oldState.LeafGenerationStateVersion,
@@ -3118,6 +3128,7 @@ func (db *DB) publishValueLogSetNoRefresh() error {
 		RootPageID:                 oldState.RootPageID,
 		SystemRootPageID:           oldState.SystemRootPageID,
 		AppliedCommandLSN:          oldState.AppliedCommandLSN,
+		MaxEntryRevision:           oldState.MaxEntryRevision,
 		ValueLogSet:                valueLogSet,
 		LeafGenerations:            oldState.LeafGenerations,
 		LeafGenerationStateVersion: oldState.LeafGenerationStateVersion,

--- a/TreeDB/db/entry_revision.go
+++ b/TreeDB/db/entry_revision.go
@@ -44,8 +44,8 @@ func (db *DB) assignBatchEntryRevisions(batch *batchpkg.Batch) page.EntryRevisio
 		return page.LegacyEntryRevision
 	}
 	maxRevision, hasLegacy := batch.PointRevisionStats()
+	db.advanceEntryRevisionFloor(maxRevision)
 	if hasLegacy {
-		db.advanceEntryRevisionFloor(maxRevision)
 		return batch.AssignLegacyPointRevisions(db.nextEntryRevision())
 	}
 	return maxRevision

--- a/TreeDB/db/entry_revision.go
+++ b/TreeDB/db/entry_revision.go
@@ -1,0 +1,52 @@
+package db
+
+import (
+	batchpkg "github.com/snissn/gomap/TreeDB/batch"
+	"github.com/snissn/gomap/TreeDB/page"
+)
+
+func (db *DB) seedEntryRevisionFloor() {
+	if db == nil {
+		return
+	}
+	floor := db.meta.MaxEntryRevision
+	if db.meta.CommitSeq > floor {
+		floor = db.meta.CommitSeq
+	}
+	db.entryRevisionFloor.Store(floor)
+}
+
+func (db *DB) nextEntryRevision() page.EntryRevision {
+	if db == nil {
+		return page.LegacyEntryRevision
+	}
+	return page.EntryRevision(db.entryRevisionFloor.Add(1))
+}
+
+func (db *DB) advanceEntryRevisionFloor(revision page.EntryRevision) {
+	if db == nil || revision == page.LegacyEntryRevision {
+		return
+	}
+	target := uint64(revision)
+	for {
+		cur := db.entryRevisionFloor.Load()
+		if cur >= target {
+			return
+		}
+		if db.entryRevisionFloor.CompareAndSwap(cur, target) {
+			return
+		}
+	}
+}
+
+func (db *DB) assignBatchEntryRevisions(batch *batchpkg.Batch) page.EntryRevision {
+	if db == nil || batch == nil || batch.Len() == 0 {
+		return page.LegacyEntryRevision
+	}
+	maxRevision, hasLegacy := batch.PointRevisionStats()
+	if hasLegacy {
+		db.advanceEntryRevisionFloor(maxRevision)
+		return batch.AssignLegacyPointRevisions(db.nextEntryRevision())
+	}
+	return maxRevision
+}

--- a/TreeDB/db/leaf_generation_gc.go
+++ b/TreeDB/db/leaf_generation_gc.go
@@ -524,6 +524,7 @@ func (db *DB) publishLeafGenerationState(refreshValueLogSet bool) error {
 		RootPageID:        oldState.RootPageID,
 		SystemRootPageID:  oldState.SystemRootPageID,
 		AppliedCommandLSN: oldState.AppliedCommandLSN,
+		MaxEntryRevision:  oldState.MaxEntryRevision,
 		ValueLogSet:       valueLogSet,
 		LeafGenerations:   db.currentLeafGenerationView(),
 	}

--- a/TreeDB/db/open_readonly.go
+++ b/TreeDB/db/open_readonly.go
@@ -9,6 +9,7 @@ import (
 	"github.com/snissn/gomap/TreeDB/internal/collectionwal"
 	"github.com/snissn/gomap/TreeDB/internal/lockfile"
 	"github.com/snissn/gomap/TreeDB/internal/valuelog"
+	"github.com/snissn/gomap/TreeDB/page"
 	"github.com/snissn/gomap/TreeDB/pager"
 	"github.com/snissn/gomap/TreeDB/zipper"
 )
@@ -137,6 +138,7 @@ func openReadOnly(opts Options) (*DB, error) {
 		_ = db.Close()
 		return nil, err
 	}
+	db.seedEntryRevisionFloor()
 	if err := requireNoUnappliedCommandWALFrames(opts.Dir, db.meta.AppliedCommandLSN, opts.WALMaxSegmentBytes); err != nil {
 		_ = db.Close()
 		return nil, err
@@ -158,6 +160,7 @@ func openReadOnly(opts Options) (*DB, error) {
 		RootPageID:                 db.meta.UserRootPageID,
 		SystemRootPageID:           db.meta.SystemRootPageID,
 		AppliedCommandLSN:          db.meta.AppliedCommandLSN,
+		MaxEntryRevision:           page.EntryRevision(db.meta.MaxEntryRevision),
 		ValueLogSet:                vm.CurrentSet(),
 		LeafGenerations:            db.currentLeafGenerationView(),
 		LeafGenerationStateVersion: db.leafGenerationStateVersion,
@@ -279,6 +282,7 @@ func openReadOnlyNoLock(opts Options) (*DB, error) {
 		_ = db.Close()
 		return nil, err
 	}
+	db.seedEntryRevisionFloor()
 	if err := requireNoUnappliedCommandWALFrames(opts.Dir, db.meta.AppliedCommandLSN, opts.WALMaxSegmentBytes); err != nil {
 		_ = db.Close()
 		return nil, err
@@ -300,6 +304,7 @@ func openReadOnlyNoLock(opts Options) (*DB, error) {
 		RootPageID:                 db.meta.UserRootPageID,
 		SystemRootPageID:           db.meta.SystemRootPageID,
 		AppliedCommandLSN:          db.meta.AppliedCommandLSN,
+		MaxEntryRevision:           page.EntryRevision(db.meta.MaxEntryRevision),
 		ValueLogSet:                vm.CurrentSet(),
 		LeafGenerations:            db.currentLeafGenerationView(),
 		LeafGenerationStateVersion: db.leafGenerationStateVersion,

--- a/TreeDB/db/vacuum_online.go
+++ b/TreeDB/db/vacuum_online.go
@@ -607,6 +607,7 @@ func (db *DB) vacuumIndexOnline(ctx context.Context, lockMaintenance bool) error
 			RootPageID:                 nextMeta.UserRootPageID,
 			SystemRootPageID:           nextMeta.SystemRootPageID,
 			AppliedCommandLSN:          nextMeta.AppliedCommandLSN,
+			MaxEntryRevision:           page.EntryRevision(nextMeta.MaxEntryRevision),
 			ValueLogSet:                valueLogSet,
 			LeafGenerations:            leafGenerationView,
 			LeafGenerationStateVersion: oldState.LeafGenerationStateVersion,

--- a/TreeDB/db/versioned_read_test.go
+++ b/TreeDB/db/versioned_read_test.go
@@ -68,3 +68,101 @@ func TestGetVersionedPreservesBatchEntryRevision(t *testing.T) {
 		t.Fatalf("Snapshot.GetEntry=(%q,%d), want (value,101)", snapEntry.Value, snapEntry.Revision)
 	}
 }
+
+func TestGetVersionedAssignsDurableEntryRevision(t *testing.T) {
+	dir := t.TempDir()
+	db, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+
+	b := db.NewBatch().(*Batch)
+	if err := b.Set([]byte("k"), []byte("value")); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	if err := b.WriteSync(); err != nil {
+		t.Fatalf("WriteSync: %v", err)
+	}
+	if err := b.Close(); err != nil {
+		t.Fatalf("Close batch: %v", err)
+	}
+
+	val, revision, err := db.GetVersioned([]byte("k"))
+	if err != nil {
+		t.Fatalf("GetVersioned: %v", err)
+	}
+	if !bytes.Equal(val, []byte("value")) || revision == page.LegacyEntryRevision {
+		t.Fatalf("GetVersioned=(%q,%d), want (value,non-legacy)", val, revision)
+	}
+	if got := db.State().MaxEntryRevision; got < revision {
+		t.Fatalf("MaxEntryRevision=%d, want >= assigned revision %d", got, revision)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	reopen, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer func() {
+		if err := reopen.Close(); err != nil {
+			t.Fatalf("Close reopen: %v", err)
+		}
+	}()
+	val, reopenedRevision, err := reopen.GetVersioned([]byte("k"))
+	if err != nil {
+		t.Fatalf("reopen GetVersioned: %v", err)
+	}
+	if !bytes.Equal(val, []byte("value")) || reopenedRevision != revision {
+		t.Fatalf("reopen GetVersioned=(%q,%d), want (value,%d)", val, reopenedRevision, revision)
+	}
+	if got := reopen.State().MaxEntryRevision; got < revision {
+		t.Fatalf("reopen MaxEntryRevision=%d, want >= assigned revision %d", got, revision)
+	}
+}
+
+func TestEntryRevisionFloorAdvancesAfterExplicitRevision(t *testing.T) {
+	db, err := Open(Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() {
+		if err := db.Close(); err != nil {
+			t.Fatalf("Close: %v", err)
+		}
+	}()
+
+	b := db.NewBatch().(*Batch)
+	if err := b.SetWithRevision([]byte("explicit"), []byte("value"), page.EntryRevision(100)); err != nil {
+		t.Fatalf("SetWithRevision: %v", err)
+	}
+	if err := b.WriteSync(); err != nil {
+		t.Fatalf("WriteSync explicit: %v", err)
+	}
+	if err := b.Close(); err != nil {
+		t.Fatalf("Close explicit batch: %v", err)
+	}
+
+	b = db.NewBatch().(*Batch)
+	if err := b.Set([]byte("next"), []byte("value")); err != nil {
+		t.Fatalf("Set next: %v", err)
+	}
+	if err := b.WriteSync(); err != nil {
+		t.Fatalf("WriteSync next: %v", err)
+	}
+	if err := b.Close(); err != nil {
+		t.Fatalf("Close next batch: %v", err)
+	}
+
+	_, revision, err := db.GetVersioned([]byte("next"))
+	if err != nil {
+		t.Fatalf("GetVersioned next: %v", err)
+	}
+	if revision <= 100 {
+		t.Fatalf("next revision=%d, want > explicit floor 100", revision)
+	}
+	if got := db.State().MaxEntryRevision; got < revision {
+		t.Fatalf("MaxEntryRevision=%d, want >= next revision %d", got, revision)
+	}
+}

--- a/TreeDB/db/versioned_read_test.go
+++ b/TreeDB/db/versioned_read_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"testing"
 
+	batchpkg "github.com/snissn/gomap/TreeDB/batch"
 	"github.com/snissn/gomap/TreeDB/page"
 )
 
@@ -164,5 +165,21 @@ func TestEntryRevisionFloorAdvancesAfterExplicitRevision(t *testing.T) {
 	}
 	if got := db.State().MaxEntryRevision; got < revision {
 		t.Fatalf("MaxEntryRevision=%d, want >= next revision %d", got, revision)
+	}
+}
+
+func TestAssignBatchEntryRevisionsReservesExplicitOnlyFloor(t *testing.T) {
+	db := &DB{}
+	b := batchpkg.New(nil, -1)
+	defer b.Close()
+	if err := b.SetWithRevision([]byte("explicit"), []byte("value"), page.EntryRevision(100)); err != nil {
+		t.Fatalf("SetWithRevision: %v", err)
+	}
+
+	if got := db.assignBatchEntryRevisions(b); got != page.EntryRevision(100) {
+		t.Fatalf("assignBatchEntryRevisions=%d, want 100", got)
+	}
+	if got := db.nextEntryRevision(); got <= page.EntryRevision(100) {
+		t.Fatalf("nextEntryRevision=%d, want > explicit floor 100", got)
 	}
 }

--- a/TreeDB/db/vlog_rewrite.go
+++ b/TreeDB/db/vlog_rewrite.go
@@ -3805,14 +3805,17 @@ func (w *rewriteWriter) appendLeafPageWithRID(rid uint64, leafPage []byte) (page
 	encodedLeafPage := leafPage
 	if w.leafPagesUseCompactPayload() {
 		var err error
-		encodedLeafPage, _, err = valuelog.MaybeCompactLeafLogPayloadTo(w.leafCompactScratch[:0], leafPage)
+		var compacted bool
+		encodedLeafPage, compacted, err = valuelog.MaybeCompactLeafLogPayloadTo(w.leafCompactScratch[:0], leafPage)
 		if err != nil {
 			return page.LeafLogPtr{}, err
 		}
-		if cap(encodedLeafPage) > page.PageSize*2 {
-			w.leafCompactScratch = nil
-		} else {
-			w.leafCompactScratch = encodedLeafPage[:0]
+		if compacted {
+			if cap(encodedLeafPage) > page.PageSize*2 {
+				w.leafCompactScratch = nil
+			} else {
+				w.leafCompactScratch = encodedLeafPage[:0]
+			}
 		}
 	}
 	if w.leafDir != "" {

--- a/TreeDB/db/vlog_rewrite_test.go
+++ b/TreeDB/db/vlog_rewrite_test.go
@@ -4439,6 +4439,69 @@ func TestRewriteWriter_AppendLeafPageLane0KeepsRawLeafPayload(t *testing.T) {
 	}
 }
 
+func TestRewriteWriter_AppendLeafPageDoesNotRetainCallerPageAsCompactScratch(t *testing.T) {
+	root := t.TempDir()
+	valueDir := filepath.Join(root, "value_vlog")
+	leafDir := filepath.Join(root, "leaf_vlog")
+	if err := os.MkdirAll(valueDir, 0o755); err != nil {
+		t.Fatalf("mkdir value dir: %v", err)
+	}
+	if err := os.MkdirAll(leafDir, 0o755); err != nil {
+		t.Fatalf("mkdir leaf dir: %v", err)
+	}
+
+	w := newRewriteWriter(valueDir, 254, 0, 64<<20)
+	w.blockCompression = false
+	w.ConfigureLeafLog(leafDir, rewriteLeafLogLaneID, 0)
+
+	denseLeaf := buildNonCompactRewriteLeafPage(t)
+	beforeDense := append([]byte(nil), denseLeaf...)
+	if _, err := w.AppendLeafPage(denseLeaf); err != nil {
+		t.Fatalf("AppendLeafPage dense: %v", err)
+	}
+
+	compactLeaf := buildCompactRewriteLeafPage(t)
+	if _, err := w.AppendLeafPage(compactLeaf); err != nil {
+		t.Fatalf("AppendLeafPage compact: %v", err)
+	}
+	if !bytes.Equal(denseLeaf, beforeDense) {
+		t.Fatalf("non-compact caller leaf page was mutated after later compact append: before=%x after=%x", beforeDense[:32], denseLeaf[:32])
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+}
+
+func buildCompactRewriteLeafPage(t *testing.T) []byte {
+	t.Helper()
+	leafBuf := make([]byte, page.PageSize)
+	leafBuilder := node.NewBuilderWithOptions(leafBuf, page.PageTypeLeaf, node.BuilderOptions{
+		LeafPrefixCompression: true,
+		LeafColumnar:          true,
+		PackedValuePtr:        true,
+	})
+	for i := 0; i < 4; i++ {
+		key := []byte(fmt.Sprintf("compact-leaf-key-%04d", i))
+		if err := leafBuilder.AddLeafEntry(key, []byte("value"), node.FlagInline, page.ValuePtr{}); err != nil {
+			t.Fatalf("AddLeafEntry compact %d: %v", i, err)
+		}
+	}
+	leafBuilder.FinishNoNode()
+	if _, compacted := valuelog.MaybeCompactLeafLogPayloadLength(leafBuf); !compacted {
+		t.Fatal("compact leaf fixture did not produce compact payload")
+	}
+	return leafBuf
+}
+
+func buildNonCompactRewriteLeafPage(t *testing.T) []byte {
+	t.Helper()
+	leafBuf := bytes.Repeat([]byte{0x5a}, page.PageSize)
+	if _, compacted := valuelog.MaybeCompactLeafLogPayloadLength(leafBuf); compacted {
+		t.Fatal("non-compact fixture unexpectedly produced compact payload")
+	}
+	return leafBuf
+}
+
 func TestRewriteWriter_AppendLeafPageSkipsLeafDictWhenCompressionDisabled(t *testing.T) {
 	walDir := t.TempDir()
 	leafPage := bytes.Repeat([]byte("rewrite/leaf/page/dict/off/"), 256)

--- a/TreeDB/db/wal_recovery.go
+++ b/TreeDB/db/wal_recovery.go
@@ -1103,20 +1103,56 @@ func applyCommitBatch(db *DB, records []commitlog.Record, ridMap map[uint64]page
 	ptrBatch, hasPtrBatch := batch.(interface {
 		SetPointer(key []byte, ptr page.ValuePtr) error
 	})
+	revisionBatch, hasRevisionBatch := batch.(interface {
+		SetWithRevision(key, value []byte, revision page.EntryRevision) error
+		DeleteWithRevision(key []byte, revision page.EntryRevision) error
+	})
+	ptrRevisionBatch, hasPtrRevisionBatch := batch.(interface {
+		SetPointerWithRevision(key []byte, ptr page.ValuePtr, revision page.EntryRevision) error
+	})
+
+	recordRevision := func(rec commitlog.Record) page.EntryRevision {
+		if rec.Revision != 0 {
+			return page.EntryRevision(rec.Revision)
+		}
+		if rec.Seq != 0 {
+			return page.EntryRevision(rec.Seq)
+		}
+		return page.LegacyEntryRevision
+	}
 
 	for _, rec := range records {
+		revision := recordRevision(rec)
 		switch rec.Op {
 		case commitlog.OpDelete:
-			if err := batch.Delete(rec.Key); err != nil {
-				return err
+			if revision != page.LegacyEntryRevision {
+				if !hasRevisionBatch {
+					return fmt.Errorf("commitlog: revision batch unavailable")
+				}
+				if err := revisionBatch.DeleteWithRevision(rec.Key, revision); err != nil {
+					return err
+				}
+			} else {
+				if err := batch.Delete(rec.Key); err != nil {
+					return err
+				}
 			}
 		case commitlog.OpSetInline:
-			if err := batch.Set(rec.Key, rec.Value); err != nil {
-				if !errors.Is(err, batchpkg.ErrValueTooLarge) {
+			var setErr error
+			if revision != page.LegacyEntryRevision {
+				if !hasRevisionBatch {
+					return fmt.Errorf("commitlog: revision batch unavailable")
+				}
+				setErr = revisionBatch.SetWithRevision(rec.Key, rec.Value, revision)
+			} else {
+				setErr = batch.Set(rec.Key, rec.Value)
+			}
+			if setErr != nil {
+				if !errors.Is(setErr, batchpkg.ErrValueTooLarge) {
 					// Abort this replay attempt on non-placement errors. The
 					// commit batch remains unapplied and the next open retries
 					// from the last published root.
-					return err
+					return setErr
 				}
 				if !hasPtrBatch {
 					return fmt.Errorf("commitlog: pointer batch unavailable")
@@ -1128,8 +1164,17 @@ func applyCommitBatch(db *DB, records []commitlog.Record, ridMap map[uint64]page
 				if err != nil {
 					return err
 				}
-				if err := ptrBatch.SetPointer(rec.Key, ptr); err != nil {
-					return err
+				if revision != page.LegacyEntryRevision {
+					if !hasPtrRevisionBatch {
+						return fmt.Errorf("commitlog: pointer revision batch unavailable")
+					}
+					if err := ptrRevisionBatch.SetPointerWithRevision(rec.Key, ptr, revision); err != nil {
+						return err
+					}
+				} else {
+					if err := ptrBatch.SetPointer(rec.Key, ptr); err != nil {
+						return err
+					}
 				}
 			}
 		case commitlog.OpSetRID:
@@ -1140,8 +1185,17 @@ func applyCommitBatch(db *DB, records []commitlog.Record, ridMap map[uint64]page
 			if !hasPtrBatch {
 				return fmt.Errorf("commitlog: pointer batch unavailable")
 			}
-			if err := ptrBatch.SetPointer(rec.Key, ptr); err != nil {
-				return err
+			if revision != page.LegacyEntryRevision {
+				if !hasPtrRevisionBatch {
+					return fmt.Errorf("commitlog: pointer revision batch unavailable")
+				}
+				if err := ptrRevisionBatch.SetPointerWithRevision(rec.Key, ptr, revision); err != nil {
+					return err
+				}
+			} else {
+				if err := ptrBatch.SetPointer(rec.Key, ptr); err != nil {
+					return err
+				}
 			}
 		default:
 			return fmt.Errorf("commitlog: unknown op %d", rec.Op)

--- a/TreeDB/db/wal_recovery.go
+++ b/TreeDB/db/wal_recovery.go
@@ -537,6 +537,7 @@ func (db *DB) ensureCommandWALRecoverySnapshotView() {
 		RootPageID:                 db.meta.UserRootPageID,
 		SystemRootPageID:           db.meta.SystemRootPageID,
 		AppliedCommandLSN:          db.meta.AppliedCommandLSN,
+		MaxEntryRevision:           page.EntryRevision(db.meta.MaxEntryRevision),
 		LeafGenerations:            db.currentLeafGenerationView(),
 		LeafGenerationStateVersion: db.leafGenerationStateVersion,
 	}

--- a/TreeDB/docs/spec/storage-format.md
+++ b/TreeDB/docs/spec/storage-format.md
@@ -115,16 +115,26 @@ body offset 60 / page offset 76:
 
 body offset 68 / page offset 84:
 u64 AppliedCommandLSN
+
+body offset 76 / page offset 92:
+[8]byte RevisionV1Marker = "TMETAR1\x00"
+
+body offset 84 / page offset 100:
+u64 MaxEntryRevision
 ```
 
-The `command_wal_v1` meta body size is 76 bytes. Bytes after offset 76 are
-reserved and must be written as zero until assigned by a later required feature.
+The `command_wal_v1` meta body size is 76 bytes. The revision-extension meta
+body size is 92 bytes. Bytes after offset 76 are reserved unless the
+`RevisionV1Marker` is present.
 `AppliedCommandLSN` is the physical on-disk field for the logical `AppliedLSN`
 command stream boundary. Alternating meta-page selection must choose roots and
-`AppliedCommandLSN` from the same meta page candidate.
+`AppliedCommandLSN`/`MaxEntryRevision` from the same meta page candidate.
 
 The marker is checksummed with the selected meta page. A decoder must treat
 `AppliedCommandLSN` as zero unless the marker is present in that same page body.
+It must treat `MaxEntryRevision` as zero unless both the command-WAL marker and
+the revision-extension marker are present in that same page body; buffer length
+or full-page padding is not sufficient.
 `format.json`, manifests, stats, or any other sidecar file must not decide
 whether a meta page's `AppliedCommandLSN` bytes are authoritative.
 
@@ -1844,9 +1854,11 @@ executor before serving reads.
 
 The V1 physical storage target for `AppliedLSN` is the in-page-marked meta-page
 field named `AppliedCommandLSN`, encoded by the command-WAL meta extension in
-Section 3.1 at body offset 68 / page offset 84. It must be selected atomically
-with the roots that contain the corresponding command effects. PR1 may document
-a blocking reason to revisit this before PR2 starts, but storage-format
+Section 3.1 at body offset 68 / page offset 84. `MaxEntryRevision` is encoded
+in the same selected meta body only when the revision-extension marker at body
+offset 76 is present. These fields must be selected atomically with the roots
+that contain the corresponding command effects. PR1 may document a blocking
+reason to revisit this before PR2 starts, but storage-format
 implementation must not proceed with both meta-page and system-root storage as
 live options. A sidecar cleanup file, manifest, stats record, format-config
 marker, or post-commit maintenance record is not authoritative state for

--- a/TreeDB/internal/commitlog/command_frame.go
+++ b/TreeDB/internal/commitlog/command_frame.go
@@ -1384,32 +1384,56 @@ func encodeRawKVSingleCommandFrameTo(dst []byte, lsn, baseAppliedLSN uint64, op 
 }
 
 func encodeTrustedRawKVPointCommandFrameTo(dst []byte, lsn, baseAppliedLSN uint64, op RawKVOp, key, value []byte) ([]byte, error) {
+	return encodeTrustedRawKVPointCommandFrameWithRevisionTo(dst, lsn, baseAppliedLSN, op, key, value, 0)
+}
+
+func encodeTrustedRawKVPointCommandFrameWithRevisionTo(dst []byte, lsn, baseAppliedLSN uint64, op RawKVOp, key, value []byte, revision uint64) ([]byte, error) {
 	if lsn == 0 {
 		return nil, fmt.Errorf("%w: zero lsn", ErrCorrupt)
 	}
-	if op != RawKVOpSet && op != RawKVOpDelete {
-		return nil, fmt.Errorf("commitlog: unsupported trusted raw kv point op %d", op)
+	valueLen, payloadLen, total, err := trustedRawKVPointCommandFrameLens(op, key, value, revision)
+	if err != nil {
+		return nil, err
 	}
-	valueLen := len(value)
+	return encodeTrustedRawKVPointCommandFrameWithRevisionSizedTo(dst, lsn, baseAppliedLSN, op, key, value, revision, valueLen, payloadLen, total)
+}
+
+func trustedRawKVPointCommandFrameLens(op RawKVOp, key, value []byte, revision uint64) (valueLen, payloadLen, total int, err error) {
+	if op != RawKVOpSet && op != RawKVOpDelete {
+		return 0, 0, 0, fmt.Errorf("commitlog: unsupported trusted raw kv point op %d", op)
+	}
+	valueLen = len(value)
 	if op == RawKVOpDelete {
 		valueLen = 0
 	}
 	if commandFrameIntExceedsUint32(len(key)) || commandFrameIntExceedsUint32(valueLen) {
-		return nil, ErrRecordTooLarge
+		return 0, 0, 0, ErrRecordTooLarge
 	}
-	payloadLen := rawKVBatchHeaderSize + rawKVOpHeaderSize + len(key) + valueLen
-	total, err := commandFrameEncodedSizeFromLengths(payloadLen, 0, 0, 0)
+	opHeaderSize := rawKVOpHeaderSize
+	if revision != 0 {
+		opHeaderSize = rawKVOpRevisionHeaderSize
+	}
+	payloadLen = rawKVBatchHeaderSize + opHeaderSize + len(key) + valueLen
+	total, err = commandFrameEncodedSizeFromLengths(payloadLen, 0, 0, 0)
 	if err != nil {
-		return nil, err
+		return 0, 0, 0, err
 	}
-	return encodeTrustedRawKVPointCommandFrameSizedTo(dst, lsn, baseAppliedLSN, op, key, value, valueLen, payloadLen, total)
+	return valueLen, payloadLen, total, nil
 }
 
 func encodeTrustedRawKVPointCommandFrameSizedTo(dst []byte, lsn, baseAppliedLSN uint64, op RawKVOp, key, value []byte, valueLen, payloadLen, total int) ([]byte, error) {
-	return encodeTrustedRawKVPointCommandFramePayloadSizedTo(dst, lsn, baseAppliedLSN, op, key, value, valueLen, payloadLen, total), nil
+	return encodeTrustedRawKVPointCommandFrameWithRevisionSizedTo(dst, lsn, baseAppliedLSN, op, key, value, 0, valueLen, payloadLen, total)
+}
+
+func encodeTrustedRawKVPointCommandFrameWithRevisionSizedTo(dst []byte, lsn, baseAppliedLSN uint64, op RawKVOp, key, value []byte, revision uint64, valueLen, payloadLen, total int) ([]byte, error) {
+	return encodeTrustedRawKVPointCommandFramePayloadSizedWithRevisionTo(dst, lsn, baseAppliedLSN, op, key, value, revision, valueLen, payloadLen, total), nil
 }
 
 func encodeTrustedRawKVPointCommandFramePayloadSizedTo(dst []byte, lsn, baseAppliedLSN uint64, op RawKVOp, key, value []byte, valueLen, payloadLen, total int) []byte {
+	return encodeTrustedRawKVPointCommandFramePayloadSizedWithRevisionTo(dst, lsn, baseAppliedLSN, op, key, value, 0, valueLen, payloadLen, total)
+}
+
+func encodeTrustedRawKVPointCommandFramePayloadSizedWithRevisionTo(dst []byte, lsn, baseAppliedLSN uint64, op RawKVOp, key, value []byte, revision uint64, valueLen, payloadLen, total int) []byte {
 	if cap(dst) < total {
 		dst = make([]byte, total)
 	} else {
@@ -1422,13 +1446,22 @@ func encodeTrustedRawKVPointCommandFramePayloadSizedTo(dst []byte, lsn, baseAppl
 	binary.LittleEndian.PutUint32(frame[56:60], uint32(payloadLen))
 
 	off := commandFrameHeaderSize
-	binary.LittleEndian.PutUint16(frame[off:off+2], 1)
+	payloadVersion := rawKVBatchPayloadVersion
+	opHeaderSize := rawKVOpHeaderSize
+	if revision != 0 {
+		payloadVersion = rawKVBatchPayloadVersionWithRevisions
+		opHeaderSize = rawKVOpRevisionHeaderSize
+	}
+	binary.LittleEndian.PutUint16(frame[off:off+2], payloadVersion)
 	binary.LittleEndian.PutUint32(frame[off+2:off+6], 1)
 	off += rawKVBatchHeaderSize
 	frame[off] = byte(op)
 	binary.LittleEndian.PutUint32(frame[off+1:off+5], uint32(len(key)))
 	binary.LittleEndian.PutUint32(frame[off+5:off+9], uint32(valueLen))
-	off += rawKVOpHeaderSize
+	if revision != 0 {
+		binary.LittleEndian.PutUint64(frame[off+9:off+17], revision)
+	}
+	off += opHeaderSize
 	copy(frame[off:], key)
 	off += len(key)
 	if op == RawKVOpSet {

--- a/TreeDB/internal/commitlog/command_frame_test.go
+++ b/TreeDB/internal/commitlog/command_frame_test.go
@@ -1377,6 +1377,36 @@ func TestEncodeRawKVSingleCommandFrameMatchesEnvelopeEncoder(t *testing.T) {
 	}
 }
 
+func TestEncodeTrustedRawKVPointCommandFrameWithRevisionMatchesEnvelopeEncoder(t *testing.T) {
+	for _, op := range []RawKVOperation{
+		{Op: RawKVOpSet, Key: []byte("alpha"), Value: []byte("one"), Revision: 91},
+		{Op: RawKVOpDelete, Key: []byte("bravo"), Revision: 92},
+	} {
+		payload, err := EncodeRawKVBatchPayload([]RawKVOperation{op})
+		if err != nil {
+			t.Fatalf("EncodeRawKVBatchPayload(%v): %v", op.Op, err)
+		}
+		want, err := EncodeCommandFrame(CommandEnvelope{
+			LSN:            7,
+			Kind:           CommandKindRawKVBatch,
+			Scope:          CommandScopeRawKV,
+			BaseAppliedLSN: 3,
+			PayloadFormat:  PayloadFormatRawKVBatchV1,
+			Payload:        payload,
+		})
+		if err != nil {
+			t.Fatalf("EncodeCommandFrame(%v): %v", op.Op, err)
+		}
+		got, err := encodeTrustedRawKVPointCommandFrameWithRevisionTo(nil, 7, 3, op.Op, op.Key, op.Value, op.Revision)
+		if err != nil {
+			t.Fatalf("encodeTrustedRawKVPointCommandFrameWithRevisionTo(%v): %v", op.Op, err)
+		}
+		if !bytes.Equal(got, want) {
+			t.Fatalf("trusted revision point frame mismatch for op %v\ngot  %x\nwant %x", op.Op, got, want)
+		}
+	}
+}
+
 func TestCommandWALRawKVBatchOneLSNAtomic(t *testing.T) {
 	payload, err := EncodeRawKVBatchPayload([]RawKVOperation{
 		{Op: RawKVOpSet, Key: []byte("a"), Value: []byte("1")},

--- a/TreeDB/internal/commitlog/commitlog.go
+++ b/TreeDB/internal/commitlog/commitlog.go
@@ -7,6 +7,9 @@ const (
 	// zeroInlineBatchVersion is a compact batch payload for all-zero inline
 	// values. Readers normalize it to ordinary OpSetInline records.
 	zeroInlineBatchVersion = 2
+	// recordRevisionBatchVersion extends the v1 record header with an optional
+	// per-record entry revision. A zero revision means "use the batch Seq".
+	recordRevisionBatchVersion = 3
 
 	OpSetRID    = byte(0)
 	OpSetInline = byte(1)
@@ -18,6 +21,8 @@ const (
 	segmentHeaderSize = 8
 	batchHeaderSize   = 1 + 4
 	recordHeaderSize  = 1 + 2 + 4 + 8 + 8
+	// recordRevisionHeaderSize appends Revision after the v1 Seq field.
+	recordRevisionHeaderSize = recordHeaderSize + 8
 
 	zeroInlineBatchHeaderSize  = 1 + 4 + 8 + 4
 	zeroInlineRecordHeaderSize = 2
@@ -44,15 +49,16 @@ var (
 )
 
 func isBatchPayloadVersion(version byte) bool {
-	return version == Version || version == zeroInlineBatchVersion
+	return version == Version || version == zeroInlineBatchVersion || version == recordRevisionBatchVersion
 }
 
 type Record struct {
-	Op    byte
-	Key   []byte
-	Value []byte
-	RID   uint64
-	Seq   uint64
+	Op       byte
+	Key      []byte
+	Value    []byte
+	RID      uint64
+	Seq      uint64
+	Revision uint64
 }
 
 type Options struct {

--- a/TreeDB/internal/commitlog/commitlog_test.go
+++ b/TreeDB/internal/commitlog/commitlog_test.go
@@ -75,6 +75,64 @@ func TestCommitLogWriteReadBatch(t *testing.T) {
 	_ = reader.Close()
 }
 
+func TestCommitLogWriteReadBatchWithEntryRevisions(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "commit.log")
+
+	writer, err := NewWriterWithOptions(path, Options{Compress: false})
+	if err != nil {
+		t.Fatalf("new writer: %v", err)
+	}
+	records := []Record{
+		{Op: OpSetRID, Key: []byte("k1"), RID: 1, Seq: 7, Revision: 41},
+		{Op: OpSetInline, Key: []byte("k2"), Value: []byte("v2"), Seq: 7},
+		{Op: OpSetInline, Key: []byte("k3"), Value: make([]byte, 8), Seq: 7, Revision: 42},
+		{Op: OpDelete, Key: []byte("k4"), Seq: 7, Revision: 43},
+	}
+	if err := writer.AppendBatch(records); err != nil {
+		_ = writer.Close()
+		t.Fatalf("append: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read file: %v", err)
+	}
+	if got := data[segmentHeaderSize]; got != recordRevisionBatchVersion {
+		t.Fatalf("raw batch version=%d, want revision batch version %d", got, recordRevisionBatchVersion)
+	}
+
+	reader, err := NewReader(path)
+	if err != nil {
+		t.Fatalf("new reader: %v", err)
+	}
+	got, err := reader.ReadBatch()
+	if err != nil {
+		_ = reader.Close()
+		t.Fatalf("read batch: %v", err)
+	}
+	if len(got) != len(records) {
+		_ = reader.Close()
+		t.Fatalf("record count: got %d want %d", len(got), len(records))
+	}
+	for i := range records {
+		if got[i].Op != records[i].Op || got[i].RID != records[i].RID ||
+			got[i].Seq != records[i].Seq || got[i].Revision != records[i].Revision ||
+			!bytes.Equal(got[i].Key, records[i].Key) || !bytes.Equal(got[i].Value, records[i].Value) {
+			_ = reader.Close()
+			t.Fatalf("record %d=%+v, want %+v", i, got[i], records[i])
+		}
+	}
+	if _, err := reader.ReadBatch(); !errors.Is(err, io.EOF) {
+		_ = reader.Close()
+		t.Fatalf("expected EOF, got %v", err)
+	}
+	_ = reader.Close()
+}
+
 func TestCommitLogAppendCoalescesSameSeqSmallRecords(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "commit.log")

--- a/TreeDB/internal/commitlog/journal_owner.go
+++ b/TreeDB/internal/commitlog/journal_owner.go
@@ -739,19 +739,37 @@ func (j *CommandJournal) AppendRawKVPointCommandTrustedAndFlush(baseAppliedLSN u
 	return lsn, nil
 }
 
+// AppendRawKVPointCommandTrustedWithRevisionAndFlush appends a caller-validated
+// public raw KV point command with native entry revision metadata and
+// flushes/syncs the writer while holding the journal lock.
+func (j *CommandJournal) AppendRawKVPointCommandTrustedWithRevisionAndFlush(baseAppliedLSN uint64, op RawKVOp, key, value []byte, revision uint64, sync bool) (uint64, error) {
+	if j == nil {
+		return 0, errors.New("commitlog: command journal is closed")
+	}
+	if revision == 0 {
+		return j.AppendRawKVPointCommandTrustedAndFlush(baseAppliedLSN, op, key, value, sync)
+	}
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	lsn, err := j.appendRawKVPointCommandTrustedWithRevisionLocked(baseAppliedLSN, op, key, value, revision, sync)
+	if err != nil {
+		return 0, err
+	}
+	if err := j.flushLocked(sync); err != nil {
+		return lsn, err
+	}
+	return lsn, nil
+}
+
 func (j *CommandJournal) appendRawKVPointCommandTrustedLocked(baseAppliedLSN uint64, op RawKVOp, key, value []byte, syncCurrent bool) (uint64, error) {
+	return j.appendRawKVPointCommandTrustedWithRevisionLocked(baseAppliedLSN, op, key, value, 0, syncCurrent)
+}
+
+func (j *CommandJournal) appendRawKVPointCommandTrustedWithRevisionLocked(baseAppliedLSN uint64, op RawKVOp, key, value []byte, revision uint64, syncCurrent bool) (uint64, error) {
 	if j.writer == nil || j.owner == nil {
 		return 0, errors.New("commitlog: command journal is closed")
 	}
-	valueLen := len(value)
-	if op == RawKVOpDelete {
-		valueLen = 0
-	}
-	if commandFrameIntExceedsUint32(len(key)) || commandFrameIntExceedsUint32(valueLen) {
-		return 0, ErrRecordTooLarge
-	}
-	payloadLen := rawKVBatchHeaderSize + rawKVOpHeaderSize + len(key) + valueLen
-	size, err := commandFrameEncodedSizeFromLengths(payloadLen, 0, 0, 0)
+	valueLen, payloadLen, size, err := trustedRawKVPointCommandFrameLens(op, key, value, revision)
 	if err != nil {
 		return 0, err
 	}
@@ -768,7 +786,7 @@ func (j *CommandJournal) appendRawKVPointCommandTrustedLocked(baseAppliedLSN uin
 	if err != nil {
 		return 0, err
 	}
-	if err := j.writer.appendRawKVPointCommandDirectTrustedSized(lsn, baseAppliedLSN, op, key, value, valueLen, payloadLen, size); err != nil {
+	if err := j.writer.appendRawKVPointCommandDirectTrustedSizedWithRevision(lsn, baseAppliedLSN, op, key, value, revision, valueLen, payloadLen, size); err != nil {
 		if rollbackErr := j.owner.rollbackReservedLSN(lsn); rollbackErr != nil {
 			return 0, errors.Join(err, rollbackErr)
 		}

--- a/TreeDB/internal/commitlog/journal_owner_bench_test.go
+++ b/TreeDB/internal/commitlog/journal_owner_bench_test.go
@@ -31,6 +31,40 @@ func BenchmarkCommandJournalAllocateAndAppendRawKVBatch(b *testing.B) {
 	}
 }
 
+func BenchmarkCommandJournalAppendRawKVPointTrustedAndFlush(b *testing.B) {
+	key := []byte("bench-key")
+	value := []byte("bench-value")
+	for _, tc := range []struct {
+		name     string
+		revision uint64
+	}{
+		{name: "no_revision"},
+		{name: "revision", revision: 123},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			j, err := OpenCommandJournal(b.TempDir(), CommandJournalOptions{})
+			if err != nil {
+				b.Fatalf("OpenCommandJournal: %v", err)
+			}
+			b.Cleanup(func() { _ = j.Close() })
+			b.ReportAllocs()
+			b.SetBytes(int64(len(key) + len(value)))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if tc.revision == 0 {
+					if _, err := j.AppendRawKVPointCommandTrustedAndFlush(0, RawKVOpSet, key, value, false); err != nil {
+						b.Fatalf("AppendRawKVPointCommandTrustedAndFlush: %v", err)
+					}
+				} else {
+					if _, err := j.AppendRawKVPointCommandTrustedWithRevisionAndFlush(0, RawKVOpSet, key, value, tc.revision, false); err != nil {
+						b.Fatalf("AppendRawKVPointCommandTrustedWithRevisionAndFlush: %v", err)
+					}
+				}
+			}
+		})
+	}
+}
+
 func BenchmarkCommandJournalAppendCollectionInsertPayload(b *testing.B) {
 	payload, err := EncodeCollectionInsertBatchByIDPayload("usertable", []CollectionDocument{
 		{

--- a/TreeDB/internal/commitlog/journal_owner_test.go
+++ b/TreeDB/internal/commitlog/journal_owner_test.go
@@ -300,6 +300,52 @@ func TestCommandJournalPointAppendAndFlushSyncsRotatedSegment(t *testing.T) {
 	}
 }
 
+func TestCommandJournalPointAppendWithRevisionWritesCanonicalPayload(t *testing.T) {
+	dir := t.TempDir()
+	j, err := OpenCommandJournal(dir, CommandJournalOptions{})
+	if err != nil {
+		t.Fatalf("OpenCommandJournal: %v", err)
+	}
+	defer j.Close()
+
+	lsn, err := j.AppendRawKVPointCommandTrustedWithRevisionAndFlush(44, RawKVOpSet, []byte("k"), []byte("v"), 77, false)
+	if err != nil {
+		t.Fatalf("AppendRawKVPointCommandTrustedWithRevisionAndFlush: %v", err)
+	}
+	if lsn != 1 {
+		t.Fatalf("lsn=%d, want 1", lsn)
+	}
+	if err := j.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+
+	frames, err := ScanCommandFrames(j.Path(), Options{})
+	if err != nil {
+		t.Fatalf("ScanCommandFrames: %v", err)
+	}
+	if len(frames) != 1 {
+		t.Fatalf("frames=%d, want 1", len(frames))
+	}
+	env := frames[0]
+	if env.LSN != 1 || env.BaseAppliedLSN != 44 {
+		t.Fatalf("frame identity lsn=%d base=%d, want 1/44", env.LSN, env.BaseAppliedLSN)
+	}
+	seen := 0
+	err = ScanRawKVBatchPayloadWithRevision(env.Payload, func(op RawKVOp, key, value []byte, revision uint64) error {
+		seen++
+		if op != RawKVOpSet || !bytes.Equal(key, []byte("k")) || !bytes.Equal(value, []byte("v")) || revision != 77 {
+			t.Fatalf("op=(%d,%q,%q,%d), want set k/v rev 77", op, key, value, revision)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("ScanRawKVBatchPayloadWithRevision: %v", err)
+	}
+	if seen != 1 {
+		t.Fatalf("seen=%d, want 1", seen)
+	}
+}
+
 func TestCommandJournalSingleAppendAndFlushSyncsRotatedSegment(t *testing.T) {
 	dir := t.TempDir()
 	j, err := OpenCommandJournal(dir, CommandJournalOptions{SegmentTargetBytes: 1})

--- a/TreeDB/internal/commitlog/reader.go
+++ b/TreeDB/internal/commitlog/reader.go
@@ -103,28 +103,38 @@ func decodeBatch(payload []byte) ([]Record, error) {
 	}
 	switch payload[0] {
 	case Version:
-		return decodeBatchV1(payload)
+		return decodeBatchRecords(payload, false)
 	case zeroInlineBatchVersion:
 		return decodeZeroInlineBatch(payload)
+	case recordRevisionBatchVersion:
+		return decodeBatchRecords(payload, true)
 	default:
 		return nil, ErrCorrupt
 	}
 }
 
 func decodeBatchV1(payload []byte) ([]Record, error) {
+	return decodeBatchRecords(payload, false)
+}
+
+func decodeBatchRecords(payload []byte, withRevision bool) ([]Record, error) {
 	count := binary.LittleEndian.Uint32(payload[1:5])
-	minBytes := int64(count) * int64(recordHeaderSize)
+	headerSize := recordHeaderSize
+	if withRevision {
+		headerSize = recordRevisionHeaderSize
+	}
+	minBytes := int64(count) * int64(headerSize)
 	if minBytes < 0 || minBytes > int64(len(payload)) {
 		return nil, ErrCorrupt
 	}
-	if count > uint32(len(payload)/recordHeaderSize) {
+	if count > uint32(len(payload)/headerSize) {
 		return nil, ErrCorrupt
 	}
 
 	records := make([]Record, 0, count)
 	off := batchHeaderSize
 	for i := uint32(0); i < count; i++ {
-		if off+recordHeaderSize > len(payload) {
+		if off+headerSize > len(payload) {
 			return nil, ErrCorrupt
 		}
 		op := payload[off]
@@ -132,17 +142,21 @@ func decodeBatchV1(payload []byte) ([]Record, error) {
 		valLen := binary.LittleEndian.Uint32(payload[off+3 : off+7])
 		rid := binary.LittleEndian.Uint64(payload[off+7 : off+15])
 		seq := binary.LittleEndian.Uint64(payload[off+15 : off+23])
+		revision := uint64(0)
+		if withRevision {
+			revision = binary.LittleEndian.Uint64(payload[off+23 : off+31])
+		}
 		if recordSizeExceedsMax(keyLen, valLen) {
 			return nil, ErrRecordTooLarge
 		}
-		recSize := recordHeaderSize + int(keyLen) + int(valLen)
+		recSize := headerSize + int(keyLen) + int(valLen)
 		if op == OpSetInlineZero {
-			recSize = recordHeaderSize + int(keyLen)
+			recSize = headerSize + int(keyLen)
 		}
 		if off+recSize > len(payload) {
 			return nil, ErrCorrupt
 		}
-		keyStart := off + recordHeaderSize
+		keyStart := off + headerSize
 		valStart := keyStart + int(keyLen)
 		key := payload[keyStart:valStart]
 		var val []byte
@@ -173,7 +187,7 @@ func decodeBatchV1(payload []byte) ([]Record, error) {
 			return nil, ErrCorrupt
 		}
 
-		records = append(records, Record{Op: op, Key: key, Value: val, RID: rid, Seq: seq})
+		records = append(records, Record{Op: op, Key: key, Value: val, RID: rid, Seq: seq, Revision: revision})
 		off += recSize
 	}
 	if off != len(payload) {

--- a/TreeDB/internal/commitlog/writer.go
+++ b/TreeDB/internal/commitlog/writer.go
@@ -795,12 +795,7 @@ func (w *Writer) AppendRawKVPointCommandDirectTrusted(lsn, baseAppliedLSN uint64
 	if err := w.commandBufferError(); err != nil {
 		return err
 	}
-	valueLen := len(value)
-	if op == RawKVOpDelete {
-		valueLen = 0
-	}
-	payloadLen := rawKVBatchHeaderSize + rawKVOpHeaderSize + len(key) + valueLen
-	size, err := commandFrameEncodedSizeFromLengths(payloadLen, 0, 0, 0)
+	valueLen, payloadLen, size, err := trustedRawKVPointCommandFrameLens(op, key, value, 0)
 	if err != nil {
 		return err
 	}
@@ -814,6 +809,10 @@ func (w *Writer) AppendRawKVPointCommandDirectTrusted(lsn, baseAppliedLSN uint64
 }
 
 func (w *Writer) appendRawKVPointCommandDirectTrustedSized(lsn, baseAppliedLSN uint64, op RawKVOp, key, value []byte, valueLen, payloadLen, size int) error {
+	return w.appendRawKVPointCommandDirectTrustedSizedWithRevision(lsn, baseAppliedLSN, op, key, value, 0, valueLen, payloadLen, size)
+}
+
+func (w *Writer) appendRawKVPointCommandDirectTrustedSizedWithRevision(lsn, baseAppliedLSN uint64, op RawKVOp, key, value []byte, revision uint64, valueLen, payloadLen, size int) error {
 	if w.pendingBatchRecs != 0 {
 		if err := w.flushPendingBatch(); err != nil {
 			return err
@@ -825,7 +824,7 @@ func (w *Writer) appendRawKVPointCommandDirectTrustedSized(lsn, baseAppliedLSN u
 			w.scratch = make([]byte, total)
 		}
 		buf := w.scratch[:total]
-		frame, err := encodeTrustedRawKVPointCommandFrameSizedTo(buf[segmentHeaderSize:segmentHeaderSize+size], lsn, baseAppliedLSN, op, key, value, valueLen, payloadLen, size)
+		frame, err := encodeTrustedRawKVPointCommandFrameWithRevisionSizedTo(buf[segmentHeaderSize:segmentHeaderSize+size], lsn, baseAppliedLSN, op, key, value, revision, valueLen, payloadLen, size)
 		if err != nil {
 			return err
 		}
@@ -843,7 +842,7 @@ func (w *Writer) appendRawKVPointCommandDirectTrustedSized(lsn, baseAppliedLSN u
 	}
 	newLen := off + total
 	buf := w.commandBuf[off:newLen]
-	encodeTrustedRawKVPointCommandFramePayloadSizedTo(buf[segmentHeaderSize:segmentHeaderSize+size], lsn, baseAppliedLSN, op, key, value, valueLen, payloadLen, size)
+	encodeTrustedRawKVPointCommandFramePayloadSizedWithRevisionTo(buf[segmentHeaderSize:segmentHeaderSize+size], lsn, baseAppliedLSN, op, key, value, revision, valueLen, payloadLen, size)
 	binary.LittleEndian.PutUint32(buf[0:4], uint32(size))
 	return nil
 }

--- a/TreeDB/internal/commitlog/writer.go
+++ b/TreeDB/internal/commitlog/writer.go
@@ -430,7 +430,14 @@ func (w *Writer) Append(record Record) error {
 		return ErrRecordTooLarge
 	}
 
-	total := int64(batchHeaderSize) + int64(recordHeaderSize) + int64(len(record.Key)) + int64(len(record.Value))
+	headerSize := recordHeaderSize
+	version := byte(Version)
+	if record.Revision != 0 {
+		headerSize = recordRevisionHeaderSize
+		version = recordRevisionBatchVersion
+	}
+
+	total := int64(batchHeaderSize) + int64(headerSize) + int64(len(record.Key)) + int64(len(record.Value))
 	if w.maxSegmentSize > 0 && total > w.maxSegmentSize {
 		return ErrRecordTooLarge
 	}
@@ -442,7 +449,7 @@ func (w *Writer) Append(record Record) error {
 	if payloadLen > int(segmentLenMask) {
 		return ErrRecordTooLarge
 	}
-	if !w.compress && segmentHeaderSize+payloadLen < directSegmentPayloadMinLen {
+	if record.Revision == 0 && !w.compress && segmentHeaderSize+payloadLen < directSegmentPayloadMinLen {
 		return w.appendPendingRecord(record, keyLen, valLen)
 	}
 
@@ -451,7 +458,7 @@ func (w *Writer) Append(record Record) error {
 	}
 	buf := w.scratch[:payloadLen]
 
-	buf[0] = Version
+	buf[0] = version
 	binary.LittleEndian.PutUint32(buf[1:5], 1)
 
 	off := batchHeaderSize
@@ -460,8 +467,11 @@ func (w *Writer) Append(record Record) error {
 	binary.LittleEndian.PutUint32(buf[off+3:off+7], valLen)
 	binary.LittleEndian.PutUint64(buf[off+7:off+15], record.RID)
 	binary.LittleEndian.PutUint64(buf[off+15:off+23], record.Seq)
-	copy(buf[off+recordHeaderSize:], record.Key)
-	copy(buf[off+recordHeaderSize+len(record.Key):], record.Value)
+	if record.Revision != 0 {
+		binary.LittleEndian.PutUint64(buf[off+23:off+31], record.Revision)
+	}
+	copy(buf[off+headerSize:], record.Key)
+	copy(buf[off+headerSize+len(record.Key):], record.Value)
 
 	if !w.compress {
 		return w.writeRawSegmentWithChecksum(buf, crc.ChecksumParts(buf[:batchHeaderSize], buf[batchHeaderSize:]))
@@ -478,10 +488,23 @@ func (w *Writer) AppendBatch(records []Record) error {
 	}
 
 	batchSeq := records[0].Seq
-	if !w.compress {
+	hasRecordRevisions := false
+	for i := range records {
+		if records[i].Revision != 0 {
+			hasRecordRevisions = true
+			break
+		}
+	}
+	if !hasRecordRevisions && !w.compress {
 		if ok, err := w.appendZeroInlineBatchIfCompact(records, batchSeq); ok || err != nil {
 			return err
 		}
+	}
+	headerSize := recordHeaderSize
+	version := byte(Version)
+	if hasRecordRevisions {
+		headerSize = recordRevisionHeaderSize
+		version = recordRevisionBatchVersion
 	}
 	if cap(w.scratch) < batchHeaderSize {
 		w.scratch = make([]byte, batchHeaderSize)
@@ -490,7 +513,7 @@ func (w *Writer) AppendBatch(records []Record) error {
 	if len(buf) < batchHeaderSize {
 		buf = buf[:batchHeaderSize]
 	}
-	buf[0] = Version
+	buf[0] = version
 	binary.LittleEndian.PutUint32(buf[1:5], uint32(len(records)))
 
 	off := batchHeaderSize
@@ -527,7 +550,7 @@ func (w *Writer) AppendBatch(records []Record) error {
 			}
 		}
 
-		recLen := recordHeaderSize + len(r.Key)
+		recLen := headerSize + len(r.Key)
 		if writeValue {
 			recLen += len(r.Value)
 		}
@@ -557,9 +580,12 @@ func (w *Writer) AppendBatch(records []Record) error {
 		binary.LittleEndian.PutUint32(buf[off+3:off+7], valLen)
 		binary.LittleEndian.PutUint64(buf[off+7:off+15], r.RID)
 		binary.LittleEndian.PutUint64(buf[off+15:off+23], r.Seq)
-		copy(buf[off+recordHeaderSize:], r.Key)
+		if hasRecordRevisions {
+			binary.LittleEndian.PutUint64(buf[off+23:off+31], r.Revision)
+		}
+		copy(buf[off+headerSize:], r.Key)
 		if writeValue {
-			valueStart := off + recordHeaderSize + len(r.Key)
+			valueStart := off + headerSize + len(r.Key)
 			valueEnd := valueStart + len(r.Value)
 			copy(buf[valueStart:valueEnd], r.Value)
 		}
@@ -584,6 +610,9 @@ func (w *Writer) appendZeroInlineBatchIfCompact(records []Record, batchSeq uint6
 	total := int64(zeroInlineBatchHeaderSize)
 	for i := range records {
 		r := &records[i]
+		if r.Revision != 0 {
+			return false, nil
+		}
 		if r.Op != OpSetInline {
 			return false, nil
 		}

--- a/TreeDB/internal/valuelog/leaf_page_payload_test.go
+++ b/TreeDB/internal/valuelog/leaf_page_payload_test.go
@@ -100,15 +100,15 @@ func requireLeafPagesLogicallyEqual(t *testing.T, want, got []byte) {
 		t.Fatalf("page counts differ: got=%d want=%d", gotNode.Count(), wantNode.Count())
 	}
 	for i := uint16(0); i < wantNode.Count(); i++ {
-		wantKey, wantVal, wantPtr, wantFlags, err := wantNode.GetLeafEntryView(i)
+		wantKey, wantVal, wantPtr, wantFlags, wantRevision, err := wantNode.GetLeafEntryViewWithRevision(i)
 		if err != nil {
 			t.Fatalf("want GetLeafEntryView(%d): %v", i, err)
 		}
-		gotKey, gotVal, gotPtr, gotFlags, err := gotNode.GetLeafEntryView(i)
+		gotKey, gotVal, gotPtr, gotFlags, gotRevision, err := gotNode.GetLeafEntryViewWithRevision(i)
 		if err != nil {
 			t.Fatalf("got GetLeafEntryView(%d): %v", i, err)
 		}
-		if !bytes.Equal(gotKey, wantKey) || !bytes.Equal(gotVal, wantVal) || gotPtr != wantPtr || gotFlags != wantFlags {
+		if !bytes.Equal(gotKey, wantKey) || !bytes.Equal(gotVal, wantVal) || gotPtr != wantPtr || gotFlags != wantFlags || gotRevision != wantRevision {
 			t.Fatalf("leaf entry %d mismatch", i)
 		}
 	}
@@ -149,6 +149,49 @@ func TestMaybeCompactLeafLogPayload_SparseLeafRoundTrips(t *testing.T) {
 		t.Fatalf("decoded page checksum mismatch")
 	}
 	requireLeafPagesLogicallyEqual(t, leaf, decoded)
+}
+
+func TestMaybeCompactLeafLogPayload_PreservesEntryRevisions(t *testing.T) {
+	tests := []struct {
+		name string
+		opts node.BuilderOptions
+	}{
+		{name: "columnar_v2", opts: node.BuilderOptions{LeafColumnar: true, EntryRevisions: true}},
+		{name: "columnar_prefix_v2", opts: node.BuilderOptions{LeafPrefixCompression: true, LeafColumnar: true, EntryRevisions: true}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			leaf := make([]byte, page.PageSize)
+			b := node.NewBuilderWithOptions(leaf, page.PageTypeLeaf, tt.opts)
+			b.SetPageID(23)
+			for i := 0; i < 8; i++ {
+				key := []byte(fmt.Sprintf("revision-preserving-leaf-key-%02d", i))
+				value := []byte(fmt.Sprintf("value-%02d", i))
+				revision := page.EntryRevision(10_000 + i)
+				if err := b.AddLeafEntryWithRevision(key, value, node.FlagInline, page.ValuePtr{}, revision); err != nil {
+					t.Fatalf("AddLeafEntryWithRevision(%d): %v", i, err)
+				}
+			}
+			b.FinishNoNode()
+
+			payload, compacted, err := MaybeCompactLeafLogPayload(leaf)
+			if err != nil {
+				t.Fatalf("MaybeCompactLeafLogPayload: %v", err)
+			}
+			if !compacted {
+				t.Fatalf("expected revision-bearing sparse leaf page to compact")
+			}
+			decoded, _, decodedFlag, err := decodeCompactLeafLogPayloadTo(payload, nil)
+			if err != nil {
+				t.Fatalf("decodeCompactLeafLogPayloadTo: %v", err)
+			}
+			if !decodedFlag {
+				t.Fatalf("expected compact payload to decode")
+			}
+			requireLeafPagesLogicallyEqual(t, leaf, decoded)
+		})
+	}
 }
 
 func TestMaybeAppendCompactLeafLogPayloadTo_AppendsStablePayloads(t *testing.T) {

--- a/TreeDB/node/node.go
+++ b/TreeDB/node/node.go
@@ -474,19 +474,27 @@ func (n *Node) liveByteBounds() (dirEnd, heapStart int, ok bool) {
 	}
 	if n.Type() == page.PageTypeLeaf && n.leafColumnar() && n.leafPrefixCompressed() && n.leafPrefixV2() {
 		// Combined columnar+prefix leaves use top-level metadata columns:
-		// KeyOff[u16], ValOff[u16], Flags[u8], PrefixLen[u16].
+		// KeyOff[u16], ValOff[u16], Flags[u8], PrefixLen[u16], and
+		// optionally Revision[u64].
 		dirEnd += int(count) * DirectoryEntrySize
 		dirEnd += int(count)
 		dirEnd += int(count) * DirectoryEntrySize
+		if n.leafEntryRevisions() {
+			dirEnd += int(count) * page.EntryRevisionSize
+		}
 		if dirEnd < NodeHeaderSize || dirEnd > len(n.data) {
 			return 0, 0, false
 		}
 	}
 	if n.Type() == page.PageTypeLeaf && n.leafColumnarV2() && !n.leafPrefixCompressed() {
 		// Columnar v2 leaves store additional per-entry metadata immediately after
-		// the key directory: ValOff (u16) + Flags (u8).
+		// the key directory: ValOff (u16) + Flags (u8), and optionally
+		// Revision[u64].
 		dirEnd += int(count) * DirectoryEntrySize
 		dirEnd += int(count)
+		if n.leafEntryRevisions() {
+			dirEnd += int(count) * page.EntryRevisionSize
+		}
 		if dirEnd < NodeHeaderSize || dirEnd > len(n.data) {
 			return 0, 0, false
 		}

--- a/TreeDB/page/meta.go
+++ b/TreeDB/page/meta.go
@@ -16,12 +16,14 @@ type MetaPageBody struct {
 	ActiveSlabTail    uint64
 	LastCommitHeight  uint64
 	AppliedCommandLSN uint64
+	MaxEntryRevision  uint64
 }
 
 const (
 	MetaPageBodySizeLegacy       = 60
 	MetaPageBodySizeCommandWALV1 = 76
-	MetaPageBodySize             = MetaPageBodySizeCommandWALV1
+	MetaPageBodySizeRevisionV1   = 84
+	MetaPageBodySize             = MetaPageBodySizeRevisionV1
 )
 
 var metaCommandWALV1Magic = [8]byte{'T', 'M', 'E', 'T', 'A', 'W', '1', 0}
@@ -39,6 +41,7 @@ func (m *MetaPageBody) Encode(buf []byte) {
 	binary.LittleEndian.PutUint64(buf[52:60], m.LastCommitHeight)
 	copy(buf[60:68], metaCommandWALV1Magic[:])
 	binary.LittleEndian.PutUint64(buf[68:76], m.AppliedCommandLSN)
+	binary.LittleEndian.PutUint64(buf[76:84], m.MaxEntryRevision)
 }
 
 // DecodeMetaBody decodes the legacy-safe MetaPageBody fields from the provided
@@ -58,13 +61,15 @@ func DecodeMetaBody(buf []byte) MetaPageBody {
 	}
 }
 
-// DecodeMetaBodyCommandWALV1 decodes the command-WAL V1 meta extension only
-// when the in-page V1 marker is present. Legacy pages and unmarked buffers
-// decode as AppliedCommandLSN=0.
+// DecodeMetaBodyCommandWALV1 decodes marked meta extensions. Legacy pages and
+// unmarked buffers decode with zero extension fields.
 func DecodeMetaBodyCommandWALV1(buf []byte) MetaPageBody {
 	m := DecodeMetaBody(buf)
 	if len(buf) >= MetaPageBodySizeCommandWALV1 && bytes.Equal(buf[60:68], metaCommandWALV1Magic[:]) {
 		m.AppliedCommandLSN = binary.LittleEndian.Uint64(buf[68:76])
+		if len(buf) >= MetaPageBodySizeRevisionV1 {
+			m.MaxEntryRevision = binary.LittleEndian.Uint64(buf[76:84])
+		}
 	}
 	return m
 }

--- a/TreeDB/page/meta.go
+++ b/TreeDB/page/meta.go
@@ -22,11 +22,12 @@ type MetaPageBody struct {
 const (
 	MetaPageBodySizeLegacy       = 60
 	MetaPageBodySizeCommandWALV1 = 76
-	MetaPageBodySizeRevisionV1   = 84
+	MetaPageBodySizeRevisionV1   = 92
 	MetaPageBodySize             = MetaPageBodySizeRevisionV1
 )
 
 var metaCommandWALV1Magic = [8]byte{'T', 'M', 'E', 'T', 'A', 'W', '1', 0}
+var metaRevisionV1Magic = [8]byte{'T', 'M', 'E', 'T', 'A', 'R', '1', 0}
 
 // EncodeMetaBody encodes the MetaPageBody into the provided buffer.
 func (m *MetaPageBody) Encode(buf []byte) {
@@ -41,7 +42,8 @@ func (m *MetaPageBody) Encode(buf []byte) {
 	binary.LittleEndian.PutUint64(buf[52:60], m.LastCommitHeight)
 	copy(buf[60:68], metaCommandWALV1Magic[:])
 	binary.LittleEndian.PutUint64(buf[68:76], m.AppliedCommandLSN)
-	binary.LittleEndian.PutUint64(buf[76:84], m.MaxEntryRevision)
+	copy(buf[76:84], metaRevisionV1Magic[:])
+	binary.LittleEndian.PutUint64(buf[84:92], m.MaxEntryRevision)
 }
 
 // DecodeMetaBody decodes the legacy-safe MetaPageBody fields from the provided
@@ -67,8 +69,8 @@ func DecodeMetaBodyCommandWALV1(buf []byte) MetaPageBody {
 	m := DecodeMetaBody(buf)
 	if len(buf) >= MetaPageBodySizeCommandWALV1 && bytes.Equal(buf[60:68], metaCommandWALV1Magic[:]) {
 		m.AppliedCommandLSN = binary.LittleEndian.Uint64(buf[68:76])
-		if len(buf) >= MetaPageBodySizeRevisionV1 {
-			m.MaxEntryRevision = binary.LittleEndian.Uint64(buf[76:84])
+		if len(buf) >= MetaPageBodySizeRevisionV1 && bytes.Equal(buf[76:84], metaRevisionV1Magic[:]) {
+			m.MaxEntryRevision = binary.LittleEndian.Uint64(buf[84:92])
 		}
 	}
 	return m

--- a/TreeDB/page/meta_command_wal_test.go
+++ b/TreeDB/page/meta_command_wal_test.go
@@ -86,4 +86,17 @@ func TestMetaPageBodyCommandWALV1DecodeDefaultsMaxEntryRevision(t *testing.T) {
 	if got.MaxEntryRevision != 0 {
 		t.Fatalf("MaxEntryRevision=%d, want 0 for command-WAL V1 body", got.MaxEntryRevision)
 	}
+
+	legacyFullPage := make([]byte, MetaPageBodySize)
+	copy(legacyFullPage, legacyV1)
+	for i := MetaPageBodySizeCommandWALV1; i < MetaPageBodySize; i++ {
+		legacyFullPage[i] = 0xaa
+	}
+	got = DecodeMetaBodyCommandWALV1(legacyFullPage)
+	if got.AppliedCommandLSN != 12345 {
+		t.Fatalf("AppliedCommandLSN=%d, want 12345 from full command-WAL V1 body", got.AppliedCommandLSN)
+	}
+	if got.MaxEntryRevision != 0 {
+		t.Fatalf("MaxEntryRevision=%d, want 0 for unmarked full command-WAL V1 body", got.MaxEntryRevision)
+	}
 }

--- a/TreeDB/page/meta_command_wal_test.go
+++ b/TreeDB/page/meta_command_wal_test.go
@@ -13,6 +13,7 @@ func TestMetaPageBodyAppliedCommandLSNRoundTrip(t *testing.T) {
 		ActiveSlabTail:    77,
 		LastCommitHeight:  88,
 		AppliedCommandLSN: 99,
+		MaxEntryRevision:  100,
 	}
 	buf := make([]byte, MetaPageBodySize)
 	want.Encode(buf)
@@ -24,7 +25,7 @@ func TestMetaPageBodyAppliedCommandLSNRoundTrip(t *testing.T) {
 
 func TestMetaPageBodyFullLegacyDecodeIgnoresReservedAppliedCommandLSNBytes(t *testing.T) {
 	full := make([]byte, MetaPageBodySize)
-	m := MetaPageBody{CommitSeq: 7, UserRootPageID: 8, SystemRootPageID: 9, AppliedCommandLSN: 12345}
+	m := MetaPageBody{CommitSeq: 7, UserRootPageID: 8, SystemRootPageID: 9, AppliedCommandLSN: 12345, MaxEntryRevision: 67890}
 	m.Encode(full)
 
 	got := DecodeMetaBody(full)
@@ -34,10 +35,13 @@ func TestMetaPageBodyFullLegacyDecodeIgnoresReservedAppliedCommandLSNBytes(t *te
 	if got.AppliedCommandLSN != 0 {
 		t.Fatalf("AppliedCommandLSN=%d, want 0 from legacy decoder", got.AppliedCommandLSN)
 	}
+	if got.MaxEntryRevision != 0 {
+		t.Fatalf("MaxEntryRevision=%d, want 0 from legacy decoder", got.MaxEntryRevision)
+	}
 
 	unmarked := append([]byte(nil), full...)
 	copy(unmarked[60:68], []byte("LEGACY!!"))
-	for i := 68; i < 76; i++ {
+	for i := 68; i < MetaPageBodySize; i++ {
 		unmarked[i] = 0xaa
 	}
 	got = DecodeMetaBodyCommandWALV1(unmarked)
@@ -46,6 +50,9 @@ func TestMetaPageBodyFullLegacyDecodeIgnoresReservedAppliedCommandLSNBytes(t *te
 	}
 	if got.AppliedCommandLSN != 0 {
 		t.Fatalf("AppliedCommandLSN=%d, want 0 without command WAL V1 in-page marker", got.AppliedCommandLSN)
+	}
+	if got.MaxEntryRevision != 0 {
+		t.Fatalf("MaxEntryRevision=%d, want 0 without command WAL V1 in-page marker", got.MaxEntryRevision)
 	}
 }
 
@@ -60,5 +67,23 @@ func TestMetaPageBodyLegacyDecodeDefaultsAppliedCommandLSN(t *testing.T) {
 	}
 	if got.AppliedCommandLSN != 0 {
 		t.Fatalf("AppliedCommandLSN=%d, want 0 for legacy body", got.AppliedCommandLSN)
+	}
+	if got.MaxEntryRevision != 0 {
+		t.Fatalf("MaxEntryRevision=%d, want 0 for legacy body", got.MaxEntryRevision)
+	}
+}
+
+func TestMetaPageBodyCommandWALV1DecodeDefaultsMaxEntryRevision(t *testing.T) {
+	full := make([]byte, MetaPageBodySize)
+	m := MetaPageBody{CommitSeq: 7, UserRootPageID: 8, SystemRootPageID: 9, AppliedCommandLSN: 12345, MaxEntryRevision: 67890}
+	m.Encode(full)
+
+	legacyV1 := append([]byte(nil), full[:MetaPageBodySizeCommandWALV1]...)
+	got := DecodeMetaBodyCommandWALV1(legacyV1)
+	if got.AppliedCommandLSN != 12345 {
+		t.Fatalf("AppliedCommandLSN=%d, want 12345", got.AppliedCommandLSN)
+	}
+	if got.MaxEntryRevision != 0 {
+		t.Fatalf("MaxEntryRevision=%d, want 0 for command-WAL V1 body", got.MaxEntryRevision)
 	}
 }

--- a/TreeDB/public.go
+++ b/TreeDB/public.go
@@ -1629,8 +1629,8 @@ func (db *DB) Set(key, value []byte) error {
 	defer unlock()
 	if db.cached != nil {
 		if db.commandWALCached {
-			return db.cached.SetAfterCommandWALAppend(key, value, func() error {
-				return db.appendPublicRawKVPointCommand(commitlog.RawKVOpSet, key, value, false)
+			return db.cached.SetAfterCommandWALAppendWithRevision(key, value, func(revision page.EntryRevision) error {
+				return db.appendPublicRawKVPointCommand(commitlog.RawKVOpSet, key, value, EntryRevision(revision), false)
 			})
 		}
 		return db.cached.Set(key, value)
@@ -1651,8 +1651,8 @@ func (db *DB) SetSync(key, value []byte) error {
 	defer unlock()
 	if db.cached != nil {
 		if db.commandWALCached {
-			return db.cached.SetAfterCommandWALAppend(key, value, func() error {
-				return db.appendPublicRawKVPointCommand(commitlog.RawKVOpSet, key, value, true)
+			return db.cached.SetAfterCommandWALAppendWithRevision(key, value, func(revision page.EntryRevision) error {
+				return db.appendPublicRawKVPointCommand(commitlog.RawKVOpSet, key, value, EntryRevision(revision), true)
 			})
 		}
 		return db.cached.SetSync(key, value)
@@ -1720,8 +1720,8 @@ func (db *DB) Delete(key []byte) error {
 	defer unlock()
 	if db.cached != nil {
 		if db.commandWALCached {
-			return db.cached.DeleteAfterCommandWALAppend(key, func() error {
-				return db.appendPublicRawKVPointCommand(commitlog.RawKVOpDelete, key, nil, false)
+			return db.cached.DeleteAfterCommandWALAppendWithRevision(key, func(revision page.EntryRevision) error {
+				return db.appendPublicRawKVPointCommand(commitlog.RawKVOpDelete, key, nil, EntryRevision(revision), false)
 			})
 		}
 		return db.cached.Delete(key)
@@ -1792,8 +1792,8 @@ func (db *DB) DeleteSync(key []byte) error {
 	defer unlock()
 	if db.cached != nil {
 		if db.commandWALCached {
-			return db.cached.DeleteAfterCommandWALAppend(key, func() error {
-				return db.appendPublicRawKVPointCommand(commitlog.RawKVOpDelete, key, nil, true)
+			return db.cached.DeleteAfterCommandWALAppendWithRevision(key, func(revision page.EntryRevision) error {
+				return db.appendPublicRawKVPointCommand(commitlog.RawKVOpDelete, key, nil, EntryRevision(revision), true)
 			})
 		}
 		return db.cached.DeleteSync(key)

--- a/TreeDB/zipper/zipper.go
+++ b/TreeDB/zipper/zipper.go
@@ -1484,7 +1484,13 @@ func validateLoadedLeafLogNode(data []byte) (node.Node, error) {
 	}
 	n := node.NewNodeView(data)
 	if n.Type() != page.PageTypeLeaf {
-		return node.Node{}, errors.New("zipper: leafref resolved to non-leaf page")
+		flags := uint16(0)
+		count := uint16(0)
+		if len(data) >= node.NodeHeaderSize {
+			flags = binary.LittleEndian.Uint16(data[12:14])
+			count = binary.LittleEndian.Uint16(data[14:16])
+		}
+		return node.Node{}, fmt.Errorf("zipper: leafref resolved to non-leaf page type=%d flags=0x%04x count=%d", n.Type(), flags, count)
 	}
 	return n, nil
 }
@@ -1736,7 +1742,7 @@ func (z *Zipper) loadNodeRef(ref page.ChildRef, scratchCtx *mergeScratch) (node.
 				if scratch != nil {
 					releaseLeafPageScratch(scratchCtx, scratch)
 				}
-				return node.Node{}, false, nil, false, source, err
+				return node.Node{}, false, nil, false, source, fmt.Errorf("%w ptr=(file=%d off=%d len=0x%08x sub=%d)", err, ptr.FileID, ptr.Offset, ptr.RecordLengthHint, ptr.SubIndex)
 			}
 			if scratch != nil {
 				return n, false, scratch, true, source, nil

--- a/TreeDB/zipper/zipper.go
+++ b/TreeDB/zipper/zipper.go
@@ -2443,6 +2443,7 @@ func (z *Zipper) mergeLeaf(oldNode *node.Node, builder *node.Builder, ops []batc
 			if !z.outerLeavesInValueLog {
 				allocHint = target.PageID()
 			}
+			targetEntryRevisions := target.LeafEntryRevisionsEnabled()
 
 			// 1. Finish the current leaf.
 			if _, err := persistTarget(); err != nil {
@@ -2483,7 +2484,7 @@ func (z *Zipper) mergeLeaf(oldNode *node.Node, builder *node.Builder, ops []batc
 			}
 			splitBuilder := z.newPooledLeafBuilder(sdata, ops[startIdx:])
 			splitBuilder.SetPageID(sid)
-			if target.LeafEntryRevisionsEnabled() {
+			if targetEntryRevisions {
 				z.enableLeafBuilderEntryRevisions(splitBuilder, ops[startIdx:])
 			}
 


### PR DESCRIPTION
## Objective

Land #3423 by making TreeDB entry revisions first-class and durable through native write data, command WAL append/replay, reopen recovery, cached command-WAL mode, and Raft-facing apply ordering boundaries.

Closes #3423. Refs #3418, #3420, #3422.

## Context

#3422 added native revision carriers and explicit revision preservation. This PR turns that substrate into production behavior: ordinary writes receive deterministic non-legacy revisions, the persisted revision floor is recovered, and public/cached command-WAL writes publish the same visible value/revision contract as replay.

## Non-goals

- No adapter-sidecar revision map or secondary per-write metadata tree.
- No full distributed Raft implementation.
- No Badger feature cloning beyond the revision and transaction substrate needed by the TreeDB adapter work.

## Design

- Adds `MaxEntryRevision` to page metadata and seeds the allocator floor on open/recovery.
- Carries revisions through batch entries, cached memtables, snapshots, backend batches, leaf storage/build/copy paths, command-WAL publish, and DB stats.
- Encodes revision-bearing raw-KV point command-WAL writes directly into the canonical RawKVBatch payload frame, avoiding the temporary heap-allocating one-op batch bridge.
- Keeps command-WAL frames logical and replayable: live apply and replay assign/preserve the same visible entry revisions; future Raft apply identity cannot advance ahead of local recoverability.
- Fixes a value-log rewrite scratch aliasing bug found during validation so compact leaf payload scratch cannot mutate caller-owned leaf page bytes.

## Scope

- Includes: `TreeDB/db` revision allocator/floor/recovery/command-WAL apply, `TreeDB/caching` cached public command-WAL revision visibility, `TreeDB/internal/commitlog` revision point frame fast path, native leaf/page/batch metadata plumbing, focused tests/benchmarks.
- Excludes: conditional transaction oracle and downstream adapter proof, which remain #3424 and #3425.

## Correctness

Tests run on rebased head `97298b6` / base `a27af33f9`:

```text
GOWORK=off go test ./TreeDB/db -count=1
GOWORK=off go test ./TreeDB/caching -count=1
GOWORK=off go test ./TreeDB -count=1
GOWORK=off go test ./TreeDB/internal/commitlog ./TreeDB/batch ./TreeDB/page ./TreeDB/node ./TreeDB/internal/valuelog -count=1
GOWORK=off go test -race ./TreeDB/db -run 'Test.*Conditional|Test.*Revision|Test.*Conflict|Test.*CommandWAL' -count=1
GOWORK=off go test ./TreeDB/collections -run 'Test.*Revision|Test.*CommandWAL|TestFreeze|Test.*Root' -count=1
git diff --check
```

Coverage added includes reopen revision floor, command-WAL revision replay, cached public command-WAL callback visibility, point frame canonical bytes, journal replay-visible revision payload, compact leaf payload revision preservation, and the value-log rewrite scratch aliasing regression.

## Performance

Environment: linux/amd64, Intel i5-11400F, `go version go1.25.7 linux/amd64`.

Commands run:

```text
GOWORK=off go test ./TreeDB/internal/commitlog -run '^$' -bench 'BenchmarkCommandJournalAppendRawKVPointTrustedAndFlush' -benchmem -count=3
GOWORK=off go test ./TreeDB/db -run '^$' -bench 'BenchmarkCommandWALRawKVDirectWrite$|BenchmarkCommandWALRawKVDirectWriteRevision$' -benchmem -count=3
GOWORK=off go test ./TreeDB -run '^$' -bench 'BenchmarkPublicCommandWALRawKVSet$|BenchmarkPublicCommandWALRawKVBatchWrite$' -benchmem -count=1
```

Latest-head benchmark summary:

| Benchmark | Result |
| --- | --- |
| commitlog point no revision | median 858.8 ns/op, 0 B/op, 0 allocs/op |
| commitlog point revision | median 811.2 ns/op, 0 B/op, 0 allocs/op |
| DB direct backend no command WAL | median 13.848 us/op, 17,760 B/op, 48 allocs/op |
| DB direct backend revision | median 12.020 us/op, 17,763 B/op, 48 allocs/op |
| DB direct command WAL | median 15.972 us/op, 18,416 B/op, 70 allocs/op |
| DB direct command WAL revision | median 13.630 us/op, 18,416 B/op, 70 allocs/op |
| public point set command_wal=false | 763.1 ns/op, 1.31M sets/s, 504 B/op, 5 allocs/op |
| public point set command_wal=true | 1810 ns/op, 552k sets/s, 734 B/op, 6 allocs/op |
| public batch 64 command_wal=false | 33.014 us/batch, 1.94M sets/s, 32,735 B/op, 92 allocs/op |
| public batch 64 command_wal=true | 40.569 us/batch, 1.58M sets/s, 31,688 B/op, 242 allocs/op |
| public batch 1024 command_wal=false | 337.290 us/batch, 3.04M sets/s, 846,740 B/op, 2070 allocs/op |
| public batch 1024 command_wal=true | 399.343 us/batch, 2.56M sets/s, 825,804 B/op, 4139 allocs/op |

The new revision-bearing commitlog point frame is zero-allocation and on par with the non-revision point frame. DB direct revision paths match the comparable non-revision allocation counts.

## Rollout / Toggle Plan

- Default behavior: native entry revisions are assigned for ordinary writes and recovered from persisted metadata.
- Disable/revert path: revert this PR before #3424 consumes revision tokens for conditional transaction conflicts.

## Follow-ups

- #3424: implement high-throughput conditional transactions and bounded conflict oracle on this native revision substrate.
- #3425: downstream adapter proof and final performance closeout.

## AI Review Loop

- Codex latest-head review: local implementation and validation complete on `97298b6` rebased onto `a27af33f9`.
- Copilot latest-head review: pending after PR creation.
- CodeRabbit latest-head review: pending after PR creation.
- Review comments/threads resolved or explicitly dismissed: pending.
- Re-requested after final meaningful push: pending.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for preserving and reporting entry revisions across writes, reads, recovery, and crash recovery.
  * Public and command-WAL point operations now carry visible revision metadata end-to-end.
  * Database stats now expose the highest entry revision.

* **Bug Fixes**
  * Fixed revision handling during replay, flush, and batch application so revisions stay monotonic.
  * Improved recovery behavior for older writes and ensured deleted entries keep consistent revision state.
  * Refined error reporting for revision-related write failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->