### PR TITLE
Avoid q2 sorted per-row global-code remap

### DIFF
--- a/TreeDB/collections/column_physical_q2_1950_test.go
+++ b/TreeDB/collections/column_physical_q2_1950_test.go
@@ -569,7 +569,7 @@ func TestTypedColumnQ2SortedGroupedDistinctLocalDictionariesAndEmptyValues1950(t
 		t.Fatalf("PrepareColumnPhysicalQuery(q2 local dictionaries): %v", err)
 	}
 	defer func() { _ = runner.Close() }()
-	assertTypedColumnQ2PreparedGlobalCodes1950(t, runner)
+	assertTypedColumnQ2PreparedGlobalRanksNoRowCodes1950(t, runner)
 	prepared, err := runner.Run()
 	if err != nil {
 		t.Fatalf("prepared q2 local dictionaries: %v", err)
@@ -792,7 +792,7 @@ func flattenColumnPhysicalEvents1950(batches [][]columnPhysicalJSONBenchParityEv
 	return events
 }
 
-func assertTypedColumnQ2PreparedGlobalCodes1950(tb testing.TB, runner *ColumnPhysicalQueryRunner) {
+func assertTypedColumnQ2PreparedGlobalRanksNoRowCodes1950(tb testing.TB, runner *ColumnPhysicalQueryRunner) {
 	tb.Helper()
 	if runner == nil || runner.typedColumn == nil {
 		tb.Fatalf("prepared q2 runner missing typed-column state")
@@ -807,20 +807,38 @@ func assertTypedColumnQ2PreparedGlobalCodes1950(tb testing.TB, runner *ColumnPhy
 		if part == nil {
 			tb.Fatalf("part %d missing sorted grouped-distinct state", partIdx)
 		}
-		if len(part.Group.GlobalCodes) != part.Rows || len(part.Distinct.GlobalCodes) != part.Rows {
-			tb.Fatalf("part %d global code rows group=%d distinct=%d want %d", partIdx, len(part.Group.GlobalCodes), len(part.Distinct.GlobalCodes), part.Rows)
+		if len(part.Group.GlobalCodes) != 0 || len(part.Distinct.GlobalCodes) != 0 {
+			tb.Fatalf("part %d global row codes group=%d distinct=%d want 0", partIdx, len(part.Group.GlobalCodes), len(part.Distinct.GlobalCodes))
 		}
 		if !sort.StringsAreSorted(part.Group.GlobalDictionary) || !sort.StringsAreSorted(part.Distinct.GlobalDictionary) {
 			tb.Fatalf("part %d global dictionaries not lexicographically sorted group=%v distinct=%v", partIdx, part.Group.GlobalDictionary, part.Distinct.GlobalDictionary)
 		}
-		for row, code := range part.Group.GlobalCodes {
-			if int(code) >= len(part.Group.GlobalDictionary) {
-				tb.Fatalf("part %d group global code row=%d code=%d outside cardinality=%d", partIdx, row, code, len(part.Group.GlobalDictionary))
+		if !part.Group.GlobalCardinalityOK || part.Group.GlobalCardinality != len(part.Group.GlobalDictionary) {
+			tb.Fatalf("part %d group global cardinality=%d ok=%t want dictionary=%d", partIdx, part.Group.GlobalCardinality, part.Group.GlobalCardinalityOK, len(part.Group.GlobalDictionary))
+		}
+		if !part.Distinct.GlobalCardinalityOK || part.Distinct.GlobalCardinality != len(part.Distinct.GlobalDictionary) {
+			tb.Fatalf("part %d distinct global cardinality=%d ok=%t want dictionary=%d", partIdx, part.Distinct.GlobalCardinality, part.Distinct.GlobalCardinalityOK, len(part.Distinct.GlobalDictionary))
+		}
+		if len(part.Group.GlobalLocalRanks) != len(part.Group.Dictionary) {
+			tb.Fatalf("part %d group global local ranks=%d want dictionary=%d", partIdx, len(part.Group.GlobalLocalRanks), len(part.Group.Dictionary))
+		}
+		if len(part.Distinct.GlobalLocalRanks) != len(part.Distinct.Dictionary) {
+			tb.Fatalf("part %d distinct global local ranks=%d want dictionary=%d", partIdx, len(part.Distinct.GlobalLocalRanks), len(part.Distinct.Dictionary))
+		}
+		for localCode, rank := range part.Group.GlobalLocalRanks {
+			if int(rank) >= len(part.Group.GlobalDictionary) {
+				tb.Fatalf("part %d group local code=%d rank=%d outside cardinality=%d", partIdx, localCode, rank, len(part.Group.GlobalDictionary))
+			}
+			if got, want := part.Group.GlobalDictionary[rank], part.Group.Dictionary[localCode]; got != want {
+				tb.Fatalf("part %d group local code=%d rank value=%q want %q", partIdx, localCode, got, want)
 			}
 		}
-		for row, code := range part.Distinct.GlobalCodes {
-			if int(code) >= len(part.Distinct.GlobalDictionary) {
-				tb.Fatalf("part %d distinct global code row=%d code=%d outside cardinality=%d", partIdx, row, code, len(part.Distinct.GlobalDictionary))
+		for localCode, rank := range part.Distinct.GlobalLocalRanks {
+			if int(rank) >= len(part.Distinct.GlobalDictionary) {
+				tb.Fatalf("part %d distinct local code=%d rank=%d outside cardinality=%d", partIdx, localCode, rank, len(part.Distinct.GlobalDictionary))
+			}
+			if got, want := part.Distinct.GlobalDictionary[rank], part.Distinct.Dictionary[localCode]; got != want {
+				tb.Fatalf("part %d distinct local code=%d rank value=%q want %q", partIdx, localCode, got, want)
 			}
 		}
 		localDidM := -1
@@ -843,6 +861,13 @@ func assertTypedColumnQ2PreparedGlobalCodes1950(tb testing.TB, runner *ColumnPhy
 		if partDidMRank < 0 {
 			tb.Fatalf("part %d distinct global dictionary missing did:m", partIdx)
 		}
+		if localDidM >= len(part.Distinct.GlobalLocalRanks) {
+			tb.Fatalf("part %d local did:m code=%d outside distinct global local ranks=%d", partIdx, localDidM, len(part.Distinct.GlobalLocalRanks))
+		}
+		localDidMRank := int(part.Distinct.GlobalLocalRanks[localDidM])
+		if localDidMRank != partDidMRank {
+			tb.Fatalf("part %d did:m local rank=%d want dictionary rank %d", partIdx, localDidMRank, partDidMRank)
+		}
 		if didMRank < 0 {
 			didMRank = partDidMRank
 		} else if didMRank != partDidMRank {
@@ -852,8 +877,8 @@ func assertTypedColumnQ2PreparedGlobalCodes1950(tb testing.TB, runner *ColumnPhy
 		for row, localCode := range part.Distinct.Codes {
 			if localCode == int64(localDidM) {
 				seenDidMRow = true
-				if part.Distinct.GlobalCodes[row] != uint32(partDidMRank) {
-					tb.Fatalf("part %d did:m row=%d global code=%d want %d", partIdx, row, part.Distinct.GlobalCodes[row], partDidMRank)
+				if part.Distinct.GlobalLocalRanks[localCode] != uint32(partDidMRank) {
+					tb.Fatalf("part %d did:m row=%d translated rank=%d want %d", partIdx, row, part.Distinct.GlobalLocalRanks[localCode], partDidMRank)
 				}
 			}
 		}

--- a/TreeDB/collections/column_physical_typed_column_query.go
+++ b/TreeDB/collections/column_physical_typed_column_query.go
@@ -125,10 +125,13 @@ type columnTypedColumnDenseInt64SpanPart struct {
 }
 
 type columnTypedColumnSortedGroupedDistinctCodeColumn struct {
-	Codes            []int64
-	Dictionary       []string
-	GlobalCodes      []uint32
-	GlobalDictionary []string
+	Codes               []int64
+	Dictionary          []string
+	GlobalCodes         []uint32
+	GlobalDictionary    []string
+	GlobalCardinality   int
+	GlobalCardinalityOK bool
+	GlobalLocalRanks    []uint32
 }
 
 type columnTypedColumnSortedGroupedDistinctPredicate struct {
@@ -810,7 +813,7 @@ func decodeColumnTypedColumnPhysicalQueryRunnerParts(view columnPhysicalScanSnap
 	}
 	phaseStart = time.Now()
 	if columnTypedColumnPhysicalQueryUseSortedGroupedDistinct(plan, req) {
-		if err := prepareColumnTypedColumnSortedGroupedDistinctGlobalCodesWithDiagnostics(runner.parts, prepareDiagnostics); err != nil {
+		if err := prepareColumnTypedColumnSortedGroupedDistinctGlobalRanksWithDiagnostics(runner.parts, prepareDiagnostics); err != nil {
 			if prepareDiagnostics != nil {
 				prepareDiagnostics.PostPrepareNanos += time.Since(phaseStart).Nanoseconds()
 			}
@@ -1215,11 +1218,11 @@ func buildColumnTypedColumnDenseGroupHourCountSummary(parts []columnTypedColumnP
 	}, nil
 }
 
-func prepareColumnTypedColumnSortedGroupedDistinctGlobalCodes(parts []columnTypedColumnPhysicalQueryPart) error {
-	return prepareColumnTypedColumnSortedGroupedDistinctGlobalCodesWithDiagnostics(parts, nil)
+func prepareColumnTypedColumnSortedGroupedDistinctGlobalRanks(parts []columnTypedColumnPhysicalQueryPart) error {
+	return prepareColumnTypedColumnSortedGroupedDistinctGlobalRanksWithDiagnostics(parts, nil)
 }
 
-func prepareColumnTypedColumnSortedGroupedDistinctGlobalCodesWithDiagnostics(parts []columnTypedColumnPhysicalQueryPart, prepareDiagnostics *columnTypedColumnPhysicalQueryPrepareDiagnostics) error {
+func prepareColumnTypedColumnSortedGroupedDistinctGlobalRanksWithDiagnostics(parts []columnTypedColumnPhysicalQueryPart, prepareDiagnostics *columnTypedColumnPhysicalQueryPrepareDiagnostics) error {
 	phaseStart := time.Now()
 	groupDict, groupRanks, err := columnTypedColumnSortedGroupedDistinctGlobalDictionary(parts, func(part *columnTypedColumnSortedGroupedDistinctPart) *columnTypedColumnSortedGroupedDistinctCodeColumn {
 		return &part.Group
@@ -1246,16 +1249,20 @@ func prepareColumnTypedColumnSortedGroupedDistinctGlobalCodesWithDiagnostics(par
 			return fmt.Errorf("collections: sorted grouped-distinct missing prepared part %d", partIdx)
 		}
 		phaseStart = time.Now()
-		err := prepareColumnTypedColumnSortedGroupedDistinctGlobalColumnCodes(&part.Group, groupDict, groupRanks)
+		err := prepareColumnTypedColumnSortedGroupedDistinctGlobalColumnRanks(&part.Group, groupDict, groupRanks)
 		if prepareDiagnostics != nil {
+			// Keep the existing report bucket name while the implementation now
+			// fills dictionary-level local-to-global ranks instead of row arrays.
 			prepareDiagnostics.Q2GroupGlobalCodeRemapNanos += time.Since(phaseStart).Nanoseconds()
 		}
 		if err != nil {
 			return fmt.Errorf("collections: sorted grouped-distinct group part %d: %w", partIdx, err)
 		}
 		phaseStart = time.Now()
-		err = prepareColumnTypedColumnSortedGroupedDistinctGlobalColumnCodes(&part.Distinct, distinctDict, distinctRanks)
+		err = prepareColumnTypedColumnSortedGroupedDistinctGlobalColumnRanks(&part.Distinct, distinctDict, distinctRanks)
 		if prepareDiagnostics != nil {
+			// Keep the existing report bucket name while the implementation now
+			// fills dictionary-level local-to-global ranks instead of row arrays.
 			prepareDiagnostics.Q2DistinctGlobalCodeRemapNanos += time.Since(phaseStart).Nanoseconds()
 		}
 		if err != nil {
@@ -1292,7 +1299,10 @@ func columnTypedColumnSortedGroupedDistinctGlobalDictionary(parts []columnTypedC
 	return dictionary, ranks, nil
 }
 
-func prepareColumnTypedColumnSortedGroupedDistinctGlobalColumnCodes(column *columnTypedColumnSortedGroupedDistinctCodeColumn, globalDictionary []string, ranks map[string]uint32) error {
+func prepareColumnTypedColumnSortedGroupedDistinctGlobalColumnRanks(column *columnTypedColumnSortedGroupedDistinctCodeColumn, globalDictionary []string, ranks map[string]uint32) error {
+	if len(globalDictionary) != len(ranks) {
+		return fmt.Errorf("global dictionary cardinality=%d want ranks=%d", len(globalDictionary), len(ranks))
+	}
 	localRanks := make([]uint32, len(column.Dictionary))
 	for localCode, value := range column.Dictionary {
 		rank, ok := ranks[value]
@@ -1301,15 +1311,10 @@ func prepareColumnTypedColumnSortedGroupedDistinctGlobalColumnCodes(column *colu
 		}
 		localRanks[localCode] = rank
 	}
-	globalCodes := make([]uint32, len(column.Codes))
-	for row, localCode := range column.Codes {
-		if localCode < 0 || localCode >= int64(len(localRanks)) {
-			return fmt.Errorf("row=%d code=%d outside cardinality=%d", row, localCode, len(localRanks))
-		}
-		globalCodes[row] = localRanks[localCode]
-	}
-	column.GlobalCodes = globalCodes
 	column.GlobalDictionary = globalDictionary
+	column.GlobalCardinality = len(globalDictionary)
+	column.GlobalCardinalityOK = true
+	column.GlobalLocalRanks = localRanks
 	return nil
 }
 
@@ -5731,7 +5736,7 @@ type columnTypedColumnSortedGroupedDistinctIterator struct {
 	currentDistinct     string
 	currentGroupCode    uint32
 	currentDistinctCode uint32
-	globalCodes         bool
+	globalRanks         bool
 	done                bool
 	rowsScanned         int
 	matchedRows         int
@@ -5746,7 +5751,7 @@ func newColumnTypedColumnSortedGroupedDistinctIterator(part *columnTypedColumnPh
 			physicalRows: part.SortedGroupedDistinct.PhysicalRows,
 			visibility:   visibility,
 			codePart:     part.SortedGroupedDistinct,
-			globalCodes:  columnTypedColumnSortedGroupedDistinctPartHasGlobalCodes(part.SortedGroupedDistinct),
+			globalRanks:  columnTypedColumnSortedGroupedDistinctPartHasGlobalRanks(part.SortedGroupedDistinct),
 		}, nil
 	}
 	partRows := len(part.RowIndexes)
@@ -5865,20 +5870,6 @@ func (it *columnTypedColumnSortedGroupedDistinctIterator) advanceCodes() error {
 		if len(it.codePart.Predicates) != 0 {
 			it.matchedRows++
 		}
-		if it.globalCodes {
-			if rowIdx >= len(it.codePart.Group.GlobalCodes) || rowIdx >= len(it.codePart.Distinct.GlobalCodes) {
-				return fmt.Errorf("collections: sorted grouped-distinct row=%d outside global code rows group=%d distinct=%d", rowIdx, len(it.codePart.Group.GlobalCodes), len(it.codePart.Distinct.GlobalCodes))
-			}
-			it.currentGroupCode = it.codePart.Group.GlobalCodes[rowIdx]
-			it.currentDistinctCode = it.codePart.Distinct.GlobalCodes[rowIdx]
-			if int(it.currentGroupCode) >= len(it.codePart.Group.GlobalDictionary) {
-				return fmt.Errorf("collections: sorted grouped-distinct global group code=%d outside cardinality=%d", it.currentGroupCode, len(it.codePart.Group.GlobalDictionary))
-			}
-			if int(it.currentDistinctCode) >= len(it.codePart.Distinct.GlobalDictionary) {
-				return fmt.Errorf("collections: sorted grouped-distinct global distinct code=%d outside cardinality=%d", it.currentDistinctCode, len(it.codePart.Distinct.GlobalDictionary))
-			}
-			return nil
-		}
 		groupCode := it.codePart.Group.Codes[rowIdx]
 		distinctCode := it.codePart.Distinct.Codes[rowIdx]
 		if groupCode < 0 || groupCode >= int64(len(it.codePart.Group.Dictionary)) {
@@ -5886,6 +5877,11 @@ func (it *columnTypedColumnSortedGroupedDistinctIterator) advanceCodes() error {
 		}
 		if distinctCode < 0 || distinctCode >= int64(len(it.codePart.Distinct.Dictionary)) {
 			return fmt.Errorf("collections: sorted grouped-distinct distinct code=%d outside cardinality=%d", distinctCode, len(it.codePart.Distinct.Dictionary))
+		}
+		if it.globalRanks {
+			it.currentGroupCode = it.codePart.Group.GlobalLocalRanks[groupCode]
+			it.currentDistinctCode = it.codePart.Distinct.GlobalLocalRanks[distinctCode]
+			return nil
 		}
 		it.currentGroup = it.codePart.Group.Dictionary[groupCode]
 		it.currentDistinct = it.codePart.Distinct.Dictionary[distinctCode]
@@ -5899,22 +5895,26 @@ func (it *columnTypedColumnSortedGroupedDistinctIterator) advanceCodes() error {
 	return nil
 }
 
-func columnTypedColumnSortedGroupedDistinctPartHasGlobalCodes(part *columnTypedColumnSortedGroupedDistinctPart) bool {
+func columnTypedColumnSortedGroupedDistinctPartHasGlobalRanks(part *columnTypedColumnSortedGroupedDistinctPart) bool {
 	return part != nil &&
-		len(part.Group.GlobalCodes) == part.Rows &&
-		len(part.Distinct.GlobalCodes) == part.Rows &&
 		part.Group.GlobalDictionary != nil &&
-		part.Distinct.GlobalDictionary != nil
+		part.Distinct.GlobalDictionary != nil &&
+		part.Group.GlobalCardinalityOK &&
+		part.Distinct.GlobalCardinalityOK &&
+		part.Group.GlobalCardinality == len(part.Group.GlobalDictionary) &&
+		part.Distinct.GlobalCardinality == len(part.Distinct.GlobalDictionary) &&
+		len(part.Group.GlobalLocalRanks) == len(part.Group.Dictionary) &&
+		len(part.Distinct.GlobalLocalRanks) == len(part.Distinct.Dictionary)
 }
 
 func (r *columnTypedColumnPhysicalQueryRunner) reduceSortedGroupedDistinct(iterators []*columnTypedColumnSortedGroupedDistinctIterator, heap *columnTypedColumnSortedGroupedDistinctHeap) ([]ColumnPhysicalQueryGroup, int, error) {
-	if columnTypedColumnSortedGroupedDistinctHeapUsesGlobalCodes(iterators, heap) {
-		return r.reduceSortedGroupedDistinctGlobalCodes(iterators, heap)
+	if columnTypedColumnSortedGroupedDistinctHeapUsesGlobalRanks(iterators, heap) {
+		return r.reduceSortedGroupedDistinctGlobalRanks(iterators, heap)
 	}
 	return r.reduceSortedGroupedDistinctStrings(iterators, heap)
 }
 
-func (r *columnTypedColumnPhysicalQueryRunner) reduceSortedGroupedDistinctGlobalCodes(iterators []*columnTypedColumnSortedGroupedDistinctIterator, heap *columnTypedColumnSortedGroupedDistinctHeap) ([]ColumnPhysicalQueryGroup, int, error) {
+func (r *columnTypedColumnPhysicalQueryRunner) reduceSortedGroupedDistinctGlobalRanks(iterators []*columnTypedColumnSortedGroupedDistinctIterator, heap *columnTypedColumnSortedGroupedDistinctHeap) ([]ColumnPhysicalQueryGroup, int, error) {
 	groups := r.resultGroups[:0]
 	firstGroup := true
 	var currentGroupCode uint32
@@ -6017,12 +6017,12 @@ func (r *columnTypedColumnPhysicalQueryRunner) reduceSortedGroupedDistinctString
 	return groups, reduceRows, nil
 }
 
-func columnTypedColumnSortedGroupedDistinctHeapUsesGlobalCodes(iterators []*columnTypedColumnSortedGroupedDistinctIterator, heap *columnTypedColumnSortedGroupedDistinctHeap) bool {
+func columnTypedColumnSortedGroupedDistinctHeapUsesGlobalRanks(iterators []*columnTypedColumnSortedGroupedDistinctIterator, heap *columnTypedColumnSortedGroupedDistinctHeap) bool {
 	if heap.len() == 0 {
 		return false
 	}
 	for _, iteratorIdx := range heap.items {
-		if iteratorIdx < 0 || iteratorIdx >= len(iterators) || !iterators[iteratorIdx].globalCodes {
+		if iteratorIdx < 0 || iteratorIdx >= len(iterators) || !iterators[iteratorIdx].globalRanks {
 			return false
 		}
 	}
@@ -6075,7 +6075,7 @@ func (h *columnTypedColumnSortedGroupedDistinctHeap) pop(iterators []*columnType
 }
 
 func columnTypedColumnSortedGroupedDistinctIteratorLess(left, right *columnTypedColumnSortedGroupedDistinctIterator) bool {
-	if left.globalCodes && right.globalCodes {
+	if left.globalRanks && right.globalRanks {
 		if left.currentGroupCode != right.currentGroupCode {
 			return left.currentGroupCode < right.currentGroupCode
 		}


### PR DESCRIPTION
## Summary

- changes the q2 sorted grouped-distinct setup path to build dictionary-level local-code to global-rank maps instead of materializing per-row global-code arrays
- translates local codes to global ranks at sorted iterator boundaries for heap ordering and reduction
- keeps the existing q2 diagnostic field names for report compatibility, but the remap buckets now measure dictionary-level rank-map fill in this path

## Scope / claim boundary

This is no-aggregate one-shot typed-column query setup work for q2 sorted grouped-distinct execution only. It is not metadata acceleration, and it should not be presented as ClickHouse superiority until current side-by-side evidence is regenerated.

The standard JSONBench full-prepared q2 path currently reports `dense_group_count_distinct_used=true`; that dense path remains separate and still uses its existing dense global-code/rank preparation. This PR is therefore still draft until we either attach a standard sorted-path acceptance artifact or explicitly decide to land it as a narrow sorted-path cleanup.

## Evidence so far

Focused tests:

```sh
GOWORK=off go test ./TreeDB/collections -run 'TestTypedColumnQ2SortedGroupedDistinct|TestColumnPhysicalQueryDiagnosticsMerge' -count=1
GOWORK=off go test ./TreeDB/collections -run 'TestTypedColumnQ2' -count=1
GOWORK=off go test ./TreeDB/collections -count=1
git diff --check
```

All passed locally.

Exploratory 1M Bluesky sorted-path probe, using a temporary exported-API probe outside the repo:

- patched setup: 530.284 ms
- patched post-prepare: 178.488 ms
- patched residual run: about 186.562 ms
- patched wall total: 716.847 ms
- origin/main setup: 716.148 ms
- origin/main post-prepare: 242.269 ms
- origin/main residual run: about 203.111 ms
- origin/main wall total: 919.259 ms
- rows scanned: 1,000,000
- rows matched/reduced: 954,611
- result hash: 3ff6801dd9b080cd on both runs

Standard JSONBench q2 1M one-shot/no-metadata artifact against this branch:

- artifact: `/tmp/jsonbench_q2_lazy_rank_1m_20260701_065655/report.json`
- layout: `column-store-full-prepared`
- query mode: `one_shot_end_to_end`
- metadata mode: `no_aggregate_metadata`
- dense path: `dense_group_count_distinct_used=true`
- setup: 45.715 ms
- post-prepare: 20.480 ms
- run: 18.119 ms
- render/hash: 0.053 ms
- total: 63.887 ms
- rows scanned/matched/reduced: 1,000,000 / 954,611 / 954,611
- result hash: `b63b8e1013c918fcda7c299ef64beb20c4988854cf0671a83803b6951d795860`
- dense q2 split: group global rank 0.034 ms, distinct global rank 19.578 ms, part local rank 0.865 ms
- dense distinct split: plan 0.001 ms, collect refs 7.768 ms, build shards 11.809 ms, refs 627,646, global ranks 180,100

This standard artifact is useful q2 context/no-regression evidence, but it does not prove the sorted grouped-distinct change because the standard path is dense.

## Acceptance evidence still required before merge

- standard sorted grouped-distinct q2 artifact, or an explicit decision to land this as a narrow sorted-path cleanup
- preserve rows scanned/matched/reduced and result hash on the affected path
- keep the standard dense q2 follow-up separate, targeting dense distinct rank/ref-build setup cost

Refs #3324
Refs #3070
