### PR TITLE
perf(treedb): harden revision WAL payload fast paths

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -2676,6 +2676,19 @@ func (db *DB) shouldWriteViaValueLogForKeyValue(key, value []byte) bool {
 	return db.forceValueLogPointers || len(value) > db.valueLogThresholdForKey(key)
 }
 
+// CommandWALPayloadShouldBypassForValue reports whether the public command-WAL
+// wrapper should let cached write preflight promote this value to a value-log
+// pointer before command-frame encoding.
+func (db *DB) CommandWALPayloadShouldBypassForValue(key, value []byte) bool {
+	if db == nil || len(value) == 0 || !db.valueLogEnabled() || !db.allowValueLogPointers() {
+		return false
+	}
+	if db.disableJournal && !db.memtableValueLogPointers {
+		return false
+	}
+	return db.shouldWriteViaValueLogForKeyValue(key, value)
+}
+
 type outerLeafRecordGroup struct {
 	start int
 	end   int
@@ -10162,6 +10175,24 @@ func pointEntryRevisionStats(entries []batch.Entry) (page.EntryRevision, bool) {
 	return maxRevision, hasLegacy
 }
 
+// PointRevisionStats returns the highest point-entry revision and whether any
+// point entry is still legacy-versioned.
+func (b *Batch) PointRevisionStats() (page.EntryRevision, bool) {
+	if b == nil || len(b.entries) == 0 {
+		return page.LegacyEntryRevision, false
+	}
+	return pointEntryRevisionStats(b.entries)
+}
+
+// OrderedEntries returns the submission-order operation stream. The returned
+// slice aliases batch-owned storage and must be treated as read-only.
+func (b *Batch) OrderedEntries() []batch.Entry {
+	if b == nil || len(b.entries) == 0 {
+		return nil
+	}
+	return b.entries
+}
+
 func assignLegacyPointEntryRevisions(entries []batch.Entry, revision page.EntryRevision) page.EntryRevision {
 	maxRevision := page.LegacyEntryRevision
 	for i := range entries {
@@ -10177,6 +10208,26 @@ func assignLegacyPointEntryRevisions(entries []batch.Entry, revision page.EntryR
 		}
 	}
 	return maxRevision
+}
+
+func batchEntriesNeedWALRevisionEncoding(entries []batch.Entry, seq uint64) bool {
+	for i := range entries {
+		entry := &entries[i]
+		switch entry.Type {
+		case batch.OpDelete, batch.OpPut:
+			if batchEntryWALRevision(entry, seq) != 0 {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func batchEntryWALRevision(entry *batch.Entry, seq uint64) uint64 {
+	if entry == nil || entry.Revision == page.LegacyEntryRevision || uint64(entry.Revision) == seq {
+		return 0
+	}
+	return uint64(entry.Revision)
 }
 
 func getBatchArenaLease(refs int, chunks [][]byte) *batchArenaLease {
@@ -13287,9 +13338,10 @@ func (db *DB) minIdleCheckpointWALBytes() int64 {
 }
 
 const (
-	commitLogSegmentHeaderBytes = 8
-	commitLogBatchHeaderBytes   = 1 + 4
-	commitLogRecordHeaderBytes  = 1 + 2 + 4 + 8 + 8
+	commitLogSegmentHeaderBytes        = 8
+	commitLogBatchHeaderBytes          = 1 + 4
+	commitLogRecordHeaderBytes         = 1 + 2 + 4 + 8 + 8
+	commitLogRevisionRecordHeaderBytes = commitLogRecordHeaderBytes + 8
 )
 
 func (db *DB) logRecordSize(key, value []byte) int64 {
@@ -13302,9 +13354,16 @@ func (db *DB) logBatchSize(records []logRecord) int64 {
 	}
 	total := commitLogSegmentHeaderBytes + commitLogBatchHeaderBytes
 	for _, r := range records {
-		total += commitLogRecordHeaderBytes + len(r.Key) + len(r.Value)
+		total += commitLogRecordHeaderBytesFor(r) + len(r.Key) + len(r.Value)
 	}
 	return int64(total)
+}
+
+func commitLogRecordHeaderBytesFor(record logRecord) int {
+	if record.Revision != 0 && record.Revision != record.Seq {
+		return commitLogRevisionRecordHeaderBytes
+	}
+	return commitLogRecordHeaderBytes
 }
 
 func (db *DB) assignCommitSeq(records []logRecord) {
@@ -34314,21 +34373,9 @@ func (b *Batch) writeRegularLocked(syncWrite bool, unlockWriteMu func()) error {
 		if hasLegacyRevisions {
 			assignLegacyPointEntryRevisions(b.entries, page.EntryRevision(seq))
 		}
-		walRecordRevision := func(revision page.EntryRevision) uint64 {
-			if revision != page.LegacyEntryRevision && uint64(revision) != seq {
-				return uint64(revision)
-			}
-			return 0
-		}
-		hasWALRecordRevisions := false
-		for i := range b.entries {
-			if walRecordRevision(b.entries[i].Revision) != 0 {
-				hasWALRecordRevisions = true
-				break
-			}
-		}
 		handledZeroInline := false
-		if zeroInlineWALBatch && !hasWALRecordRevisions && rids == nil && zeroInlineValueLen > 0 {
+		needsWALRevisionEncoding := batchEntriesNeedWALRevisionEncoding(b.entries, seq)
+		if zeroInlineWALBatch && !needsWALRevisionEncoding && rids == nil && zeroInlineValueLen > 0 {
 			var err error
 			handledZeroInline, err = b.db.appendWALZeroInlineEntries(lane, b.entries, seq, zeroInlineValueLen, durability)
 			if err != nil {
@@ -34346,7 +34393,7 @@ func (b *Batch) writeRegularLocked(syncWrite bool, unlockWriteMu func()) error {
 			}
 			for i := range b.entries {
 				op := &b.entries[i]
-				recordRevision := walRecordRevision(op.Revision)
+				recordRevision := batchEntryWALRevision(op, seq)
 				switch op.Type {
 				case batch.OpDelete:
 					records = append(records, logRecord{Op: logOpDelete, Key: op.Key, Seq: seq, Revision: recordRevision})

--- a/TreeDB/caching/versioned_read_test.go
+++ b/TreeDB/caching/versioned_read_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
+	"github.com/snissn/gomap/TreeDB/internal/commitlog"
 	"github.com/snissn/gomap/TreeDB/page"
 	"github.com/snissn/gomap/TreeDB/tree"
 )
@@ -222,4 +223,87 @@ func TestGetVersionedPreservesMutableMemtableDeleteRevision(t *testing.T) {
 	if !bytes.Equal(out, dst) || revision != 202 {
 		t.Fatalf("GetVersionedAppend after delete=(%q,%d), want (%q,202)", out, revision, dst)
 	}
+}
+
+func TestCachedWALBatchPersistsMixedExplicitEntryRevisions(t *testing.T) {
+	dir := t.TempDir()
+	backend, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("backend Open: %v", err)
+	}
+	db, err := Open(dir, backend, Options{
+		FlushThreshold: 1 << 30,
+		MemtableMode:   "skiplist",
+		MemtableShards: 1,
+		JournalLanes:   1,
+		AllowUnsafe:    true,
+	})
+	if err != nil {
+		_ = backend.Close()
+		t.Fatalf("Open: %v", err)
+	}
+	closed := false
+	defer func() {
+		if !closed {
+			_ = db.Close()
+		}
+	}()
+
+	b := db.NewBatch()
+	if err := b.SetWithRevision([]byte("alpha"), []byte("one"), page.EntryRevision(201)); err != nil {
+		t.Fatalf("SetWithRevision alpha: %v", err)
+	}
+	if err := b.SetWithRevision([]byte("bravo"), []byte("two"), page.EntryRevision(202)); err != nil {
+		t.Fatalf("SetWithRevision bravo: %v", err)
+	}
+	if err := b.WriteSync(); err != nil {
+		t.Fatalf("WriteSync: %v", err)
+	}
+	if err := b.Close(); err != nil {
+		t.Fatalf("Close batch: %v", err)
+	}
+
+	for _, tc := range []struct {
+		key      string
+		value    string
+		revision page.EntryRevision
+	}{
+		{key: "alpha", value: "one", revision: 201},
+		{key: "bravo", value: "two", revision: 202},
+	} {
+		val, revision, err := db.GetVersioned([]byte(tc.key))
+		if err != nil {
+			t.Fatalf("GetVersioned %s: %v", tc.key, err)
+		}
+		if !bytes.Equal(val, []byte(tc.value)) || revision != tc.revision {
+			t.Fatalf("GetVersioned %s=(%q,%d), want (%s,%d)", tc.key, val, revision, tc.value, tc.revision)
+		}
+	}
+
+	reader, err := commitlog.NewReader(filepath.Join(backenddb.WALDirPath(dir), "commit-l0-000001.log"))
+	if err != nil {
+		t.Fatalf("commitlog.NewReader: %v", err)
+	}
+	records, err := reader.ReadBatch()
+	if err != nil {
+		_ = reader.Close()
+		t.Fatalf("ReadBatch: %v", err)
+	}
+	if err := reader.Close(); err != nil {
+		t.Fatalf("reader Close: %v", err)
+	}
+	if len(records) != 2 {
+		t.Fatalf("records=%+v, want 2 point records", records)
+	}
+	if records[0].Seq == 0 || records[0].Seq != records[1].Seq {
+		t.Fatalf("record seqs=%d/%d, want shared non-zero commit fence", records[0].Seq, records[1].Seq)
+	}
+	if records[0].Revision != 201 || records[1].Revision != 202 {
+		t.Fatalf("record revisions=%d/%d, want 201/202", records[0].Revision, records[1].Revision)
+	}
+
+	if err := db.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	closed = true
 }

--- a/TreeDB/command_wal_public_cached.go
+++ b/TreeDB/command_wal_public_cached.go
@@ -1,6 +1,7 @@
 package treedb
 
 import (
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"strconv"
@@ -69,6 +70,10 @@ func (tdb *DB) appendPublicRawKVCommandEntryScan(scanEntries func(func(batch.Ent
 		tdb.recordPublicCommandWALPendingLSN(lsn)
 	}
 	return err
+}
+
+func (tdb *DB) commandWALPayloadShouldBypassForValue(key, value []byte) bool {
+	return tdb != nil && tdb.cached != nil && tdb.cached.CommandWALPayloadShouldBypassForValue(key, value)
 }
 
 func (tdb *DB) appendPublicRawKVDeleteRangeCommand(start, end []byte, sync bool) error {
@@ -304,6 +309,13 @@ const commandWALPublicBatchEstimatedKeyValueBytes = 192
 // large-batch peak while preserving the compact fast path for ordinary batches.
 const commandWALPublicBatchPayloadSoftCapBytes = 128 << 20
 
+const commandWALRawKVBatchHeaderSize = 2 + 4
+
+type commandWALPublicRevisionEntries interface {
+	PointRevisionStats() (page.EntryRevision, bool)
+	OrderedEntries() []batch.Entry
+}
+
 func newCommandWALPublicBatch(tdb *DB, inner Batch, opHint int) *commandWALPublicBatch {
 	b := &commandWALPublicBatch{db: tdb, inner: inner}
 	b.disableInnerStreamingBypass()
@@ -325,8 +337,19 @@ func (b *commandWALPublicBatch) resetPayloadWithHint() {
 		return
 	}
 	_ = b.payload.ResetWithHint(b.payloadOpHint, b.payloadByteHint)
+	if b.payloadShouldCarryEntryRevisions() {
+		_ = b.payload.EnableEntryRevisions()
+	}
 	b.payloadBypass = false
 	b.hasDeleteRange = false
+}
+
+func (b *commandWALPublicBatch) payloadShouldCarryEntryRevisions() bool {
+	if b == nil || b.db == nil || b.inner == nil {
+		return false
+	}
+	_, ok := b.inner.(commandWALPublicRevisionEntries)
+	return ok
 }
 
 func (b *commandWALPublicBatch) preparePayloadForAppend() {
@@ -412,7 +435,18 @@ func (b *commandWALPublicBatch) setView(key, value []byte, retainReplayViews, us
 	b.preparePayloadForAppend()
 	key = normalizeRawKVPointKey(key)
 	value = normalizeRawKVValue(value)
-	if !retainReplayViews {
+	if !retainReplayViews && useInnerView {
+		err = b.innerSetView(key, value)
+		if err != nil {
+			return nil, nil, err
+		}
+		b.payloadBypass = true
+		b.opCount++
+		b.recordPointIngress(commitlog.RawKVOpSet, len(key)+len(value), true)
+		b.dirty = true
+		return nil, nil, nil
+	}
+	if b.shouldBypassPayloadAppendSet(key, value, retainReplayViews) {
 		if useInnerView {
 			err = b.innerSetView(key, value)
 		} else {
@@ -427,22 +461,15 @@ func (b *commandWALPublicBatch) setView(key, value []byte, retainReplayViews, us
 		b.dirty = true
 		return nil, nil, nil
 	}
-	if retainReplayViews && commandWALPublicAllZeroBytes(value) {
-		// The raw-KV payload builder tracks the first zero value by backing-array
-		// identity so repeated immutable zero buffers can avoid rescanning. Adapter
-		// replay-byte callers may reuse and mutate their value buffer between Put
-		// calls, so keep that compact-zero identity tied to an immutable copy.
+	if !useInnerView && commandWALPublicAllZeroBytes(value) {
+		// AppendSet compact-zero tracking keys off the first zero value backing
+		// array. Plain Set callers may reuse and mutate their input buffer, so pin
+		// compact-zero identity to an immutable batch-owned copy.
 		value = append([]byte(nil), value...)
-	}
-	if b.shouldBypassPayloadAppendSet(key, value, retainReplayViews) {
-		if err := b.inner.Set(key, value); err != nil {
-			return nil, nil, err
-		}
-		b.payloadBypass = true
-		b.opCount++
-		b.recordPointIngress(commitlog.RawKVOpSet, len(key)+len(value), false)
-		b.dirty = true
-		return nil, nil, nil
+	} else if retainReplayViews && commandWALPublicAllZeroBytes(value) {
+		// Adapter replay-byte callers may also reuse and mutate their value buffer
+		// between Put calls, so keep that compact-zero identity immutable.
+		value = append([]byte(nil), value...)
 	}
 	oldLen, oldCount := b.payload.Len(), b.payload.Count()
 	keyView, valueView, err = b.payload.AppendSet(key, value)
@@ -454,7 +481,7 @@ func (b *commandWALPublicBatch) setView(key, value []byte, retainReplayViews, us
 		return nil, nil, err
 	}
 	b.opCount++
-	b.recordPointIngress(commitlog.RawKVOpSet, len(key)+len(value), true)
+	b.recordPointIngress(commitlog.RawKVOpSet, len(key)+len(value), useInnerView)
 	b.dirty = true
 	if retainReplayViews {
 		b.retainPayloadAfterWrite = true
@@ -486,7 +513,18 @@ func (b *commandWALPublicBatch) deleteView(key []byte, retainReplayViews, useInn
 	}
 	b.preparePayloadForAppend()
 	key = normalizeRawKVPointKey(key)
-	if !retainReplayViews {
+	if !retainReplayViews && useInnerView {
+		err = b.innerDeleteView(key)
+		if err != nil {
+			return nil, err
+		}
+		b.payloadBypass = true
+		b.opCount++
+		b.recordPointIngress(commitlog.RawKVOpDelete, len(key), true)
+		b.dirty = true
+		return nil, nil
+	}
+	if b.shouldBypassPayloadAppendDelete(key, retainReplayViews) {
 		if useInnerView {
 			err = b.innerDeleteView(key)
 		} else {
@@ -501,16 +539,6 @@ func (b *commandWALPublicBatch) deleteView(key []byte, retainReplayViews, useInn
 		b.dirty = true
 		return nil, nil
 	}
-	if b.shouldBypassPayloadAppendDelete(key, retainReplayViews) {
-		if err := b.inner.Delete(key); err != nil {
-			return nil, err
-		}
-		b.payloadBypass = true
-		b.opCount++
-		b.recordPointIngress(commitlog.RawKVOpDelete, len(key), false)
-		b.dirty = true
-		return nil, nil
-	}
 	oldLen, oldCount := b.payload.Len(), b.payload.Count()
 	keyView, err = b.payload.AppendDelete(key)
 	if err != nil {
@@ -521,7 +549,7 @@ func (b *commandWALPublicBatch) deleteView(key []byte, retainReplayViews, useInn
 		return nil, err
 	}
 	b.opCount++
-	b.recordPointIngress(commitlog.RawKVOpDelete, len(key), true)
+	b.recordPointIngress(commitlog.RawKVOpDelete, len(key), useInnerView)
 	b.dirty = true
 	if retainReplayViews {
 		b.retainPayloadAfterWrite = true
@@ -630,6 +658,9 @@ func (b *commandWALPublicBatch) innerDeleteView(key []byte) error {
 }
 
 func (b *commandWALPublicBatch) shouldBypassPayloadAppendSet(key, value []byte, retainReplayViews bool) bool {
+	if !retainReplayViews && b != nil && b.db != nil && b.db.commandWALPayloadShouldBypassForValue(key, value) {
+		return true
+	}
 	retainedCap, err := b.payload.RetainedCapAfterAppendSet(key, value)
 	return b.shouldBypassPayloadAppendRetainedCap(retainedCap, err, retainReplayViews)
 }
@@ -776,49 +807,18 @@ func commandWALPublicAllZeroBytes(p []byte) bool {
 	return len(p) > 0
 }
 
-var errCommandWALPublicBatchHasEntryRevision = errors.New("treedb: command wal public batch has entry revision")
-
-func (b *commandWALPublicBatch) hasCommandWALPointEntryRevisions() (bool, error) {
-	if b == nil || b.inner == nil {
-		return false, ErrClosed
-	}
-	err := b.inner.Replay(func(entry batch.Entry) error {
-		switch entry.Type {
-		case batch.OpDelete, batch.OpPut:
-			if entry.Revision != page.LegacyEntryRevision {
-				return errCommandWALPublicBatchHasEntryRevision
-			}
-		}
-		return nil
-	})
-	if errors.Is(err, errCommandWALPublicBatchHasEntryRevision) {
-		return true, nil
-	}
-	if err != nil {
-		return false, err
-	}
-	return false, nil
-}
-
 func (b *commandWALPublicBatch) commandWALPayload() ([]byte, error) {
 	if b == nil || b.inner == nil {
 		return nil, ErrClosed
 	}
 	if !b.payloadBypass && b.payload.Count() == b.opCount && b.payload.Count() > 0 {
-		// Stable payloads are built before cached WriteAfterCommandWALAppend assigns
-		// visible entry revisions. Actual DB-backed command-WAL batches must rebuild
-		// once those revisions are present; test wrappers with no DB keep the pure
-		// stable-payload fast path.
-		if b.db == nil {
+		if b.payload.EntryRevisionsEnabled() {
+			if err := b.stampPayloadEntryRevisions(); err != nil {
+				return nil, err
+			}
 			return b.payload.Payload(), nil
 		}
-		hasEntryRevisions, err := b.hasCommandWALPointEntryRevisions()
-		if err != nil {
-			return nil, err
-		}
-		if !hasEntryRevisions {
-			return b.payload.Payload(), nil
-		}
+		return b.payload.Payload(), nil
 	}
 	byteHint, _ := b.inner.GetByteSize()
 	sawEntryRevision := false
@@ -856,6 +856,89 @@ func (b *commandWALPublicBatch) commandWALPayload() ([]byte, error) {
 		return nil, err
 	}
 	return commitlog.EncodeRawKVBatchPayloadPlanned(plan, scan)
+}
+
+func (b *commandWALPublicBatch) stampPayloadEntryRevisions() error {
+	if b == nil || b.inner == nil {
+		return ErrClosed
+	}
+	if entries, ok := b.inner.(interface{ OrderedEntries() []batch.Entry }); ok {
+		return b.stampPayloadEntryRevisionsFromEntries(entries.OrderedEntries())
+	}
+	return b.payload.StampEntryRevisions(func(emit func(uint64) error) error {
+		return b.inner.Replay(func(entry batch.Entry) error {
+			switch entry.Type {
+			case batch.OpDelete, batch.OpPut:
+				if entry.Revision != page.LegacyEntryRevision {
+					return emit(uint64(entry.Revision))
+				}
+				return emit(0)
+			case batch.OpDeleteRange:
+				return emit(0)
+			default:
+				return nil
+			}
+		})
+	})
+}
+
+func (b *commandWALPublicBatch) stampPayloadEntryRevisionsFromEntries(entries []batch.Entry) error {
+	if b == nil {
+		return ErrClosed
+	}
+	payload := b.payload.Payload()
+	offsets := b.payload.RevisionSlotOffsets()
+	if len(offsets) > 0 {
+		seen := 0
+		for i := range entries {
+			entry := &entries[i]
+			revision := uint64(0)
+			switch entry.Type {
+			case batch.OpDelete, batch.OpPut:
+				if entry.Revision != page.LegacyEntryRevision {
+					revision = uint64(entry.Revision)
+				}
+			case batch.OpDeleteRange:
+			default:
+				continue
+			}
+			if seen >= len(offsets) {
+				return commitlog.ErrCorrupt
+			}
+			off := int(offsets[seen])
+			if off < commandWALRawKVBatchHeaderSize || off+8 > len(payload) {
+				return commitlog.ErrCorrupt
+			}
+			binary.LittleEndian.PutUint64(payload[off:off+8], revision)
+			seen++
+		}
+		if seen != len(offsets) {
+			return commitlog.ErrCorrupt
+		}
+		return nil
+	}
+	return b.payload.StampEntryRevisions(func(emit func(uint64) error) error {
+		for i := range entries {
+			entry := &entries[i]
+			switch entry.Type {
+			case batch.OpDelete, batch.OpPut:
+				if entry.Revision != page.LegacyEntryRevision {
+					if err := emit(uint64(entry.Revision)); err != nil {
+						return err
+					}
+					continue
+				}
+				if err := emit(0); err != nil {
+					return err
+				}
+			case batch.OpDeleteRange:
+				if err := emit(0); err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+	})
 }
 
 func (b *commandWALPublicBatch) appendCommandWAL(sync bool) error {

--- a/TreeDB/command_wal_public_test.go
+++ b/TreeDB/command_wal_public_test.go
@@ -1425,18 +1425,26 @@ func TestPublicCommandWALBatchResetPreservesCompactZeroScanFallback(t *testing.T
 	}
 }
 
-func TestPublicCommandWALBatchOrdinarySetBypassesPayloadBuilder(t *testing.T) {
+func TestPublicCommandWALBatchOrdinarySetUsesPayloadBuilder(t *testing.T) {
 	inner := &commandWALPayloadSoftCapBatch{}
 	wrapped := newCommandWALPublicBatch(nil, inner, 0)
 	wrapped.payloadSoftCapBytes = 64
-	initialPayloadLen := wrapped.payload.Len()
-	initialPayloadCap := wrapped.payload.RetainedCap()
 
-	if err := wrapped.Set([]byte("a"), []byte("b")); err != nil {
+	firstKey := []byte("a")
+	firstValue := []byte("b")
+	if err := wrapped.Set(firstKey, firstValue); err != nil {
 		t.Fatalf("Set first: %v", err)
 	}
-	if !wrapped.payloadBypass || wrapped.payload.Count() != 0 || wrapped.payload.Len() != initialPayloadLen || wrapped.payload.RetainedCap() != initialPayloadCap {
-		t.Fatalf("payload after first set: bypass=%t count=%d len/cap=%d/%d, want true/0/%d/%d", wrapped.payloadBypass, wrapped.payload.Count(), wrapped.payload.Len(), wrapped.payload.RetainedCap(), initialPayloadLen, initialPayloadCap)
+	firstKey[0] = 'A'
+	firstValue[0] = 'B'
+	if wrapped.payloadBypass || wrapped.payload.Count() != 1 || wrapped.payload.Len() == 0 {
+		t.Fatalf("payload after first set: bypass=%t count=%d len=%d, want false/1/>0", wrapped.payloadBypass, wrapped.payload.Count(), wrapped.payload.Len())
+	}
+	if inner.setViewCalls != 1 || inner.setCalls != 0 {
+		t.Fatalf("inner calls after first set: setView=%d set=%d, want 1/0", inner.setViewCalls, inner.setCalls)
+	}
+	if got := inner.entries[0]; string(got.Key) != "a" || string(got.Value) != "b" {
+		t.Fatalf("payload-backed entry mutated or not copied: key=%q value=%q", got.Key, got.Value)
 	}
 
 	key := []byte("second")
@@ -1446,11 +1454,11 @@ func TestPublicCommandWALBatchOrdinarySetBypassesPayloadBuilder(t *testing.T) {
 	}
 	key[0] = 'X'
 	value[0] = 'Y'
-	if wrapped.payload.Count() != 0 || wrapped.opCount != 2 || wrapped.payload.Len() != initialPayloadLen || wrapped.payload.RetainedCap() != initialPayloadCap {
-		t.Fatalf("payload count=%d opCount=%d len/cap=%d/%d, want 0/2/%d/%d", wrapped.payload.Count(), wrapped.opCount, wrapped.payload.Len(), wrapped.payload.RetainedCap(), initialPayloadLen, initialPayloadCap)
+	if !wrapped.payloadBypass || wrapped.payload.Count() != 1 || wrapped.opCount != 2 {
+		t.Fatalf("payload state after soft-cap bypass: bypass=%t count=%d opCount=%d, want true/1/2", wrapped.payloadBypass, wrapped.payload.Count(), wrapped.opCount)
 	}
-	if inner.setViewCalls != 0 || inner.setCalls != 2 {
-		t.Fatalf("inner calls: setView=%d set=%d, want 0/2", inner.setViewCalls, inner.setCalls)
+	if inner.setViewCalls != 1 || inner.setCalls != 1 {
+		t.Fatalf("inner calls: setView=%d set=%d, want 1/1", inner.setViewCalls, inner.setCalls)
 	}
 	if got := inner.entries[1]; string(got.Key) != "second" || string(got.Value) != strings.Repeat("x", 128) {
 		t.Fatalf("bypassed entry mutated or not copied: key=%q value_prefix=%q", got.Key, got.Value[:1])
@@ -1758,6 +1766,145 @@ func TestPublicCommandWALBatchBypassStreamsReplayToCommandWAL(t *testing.T) {
 	}
 	if len(got) != 2 || string(got[0].Key) != "alpha" || string(got[0].Value) != "one" || string(got[1].Key) != "bravo" || string(got[1].Value) != strings.Repeat("v", 128) {
 		t.Fatalf("decoded streamed command WAL ops=%+v", got)
+	}
+}
+
+func TestPublicCommandWALBatchStablePayloadAppendsWithoutReplay(t *testing.T) {
+	dir := t.TempDir()
+	db, err := Open(Options{
+		Dir:                 dir,
+		Durability:          DurabilityWALOnRelaxed,
+		CommandWAL:          true,
+		CommandWALStatsScan: true,
+		DisableSideStores:   true,
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	inner := &commandWALPayloadSoftCapBatch{}
+	wrapped := newCommandWALPublicBatch(db, inner, 0)
+	wrapped.payloadSoftCapBytes = 64 << 10
+
+	if _, _, err := wrapped.SetViewWithReplayBytes([]byte("alpha"), []byte("one")); err != nil {
+		t.Fatalf("SetViewWithReplayBytes alpha: %v", err)
+	}
+	if _, _, err := wrapped.SetViewWithReplayBytes([]byte("bravo"), []byte("two")); err != nil {
+		t.Fatalf("SetViewWithReplayBytes bravo: %v", err)
+	}
+	if wrapped.payloadBypass || wrapped.payload.Count() != wrapped.opCount {
+		t.Fatalf("payload state bypass=%t count=%d opCount=%d, want stable payload", wrapped.payloadBypass, wrapped.payload.Count(), wrapped.opCount)
+	}
+	if err := wrapped.appendCommandWAL(false); err != nil {
+		_ = db.Close()
+		t.Fatalf("appendCommandWAL: %v", err)
+	}
+	if inner.replayCalls != 0 {
+		_ = db.Close()
+		t.Fatalf("inner replay calls=%d, want 0 for stable payload append", inner.replayCalls)
+	}
+
+	r, err := commitlog.NewReader(filepath.Join(backenddb.WALDirPath(dir), "commit-l0-000001.log"))
+	if err != nil {
+		_ = db.Close()
+		t.Fatalf("NewReader: %v", err)
+	}
+	env, err := r.ReadCommandFrame()
+	if err != nil {
+		_ = r.Close()
+		_ = db.Close()
+		t.Fatalf("ReadCommandFrame: %v", err)
+	}
+	var got []batch.Entry
+	if err := commitlog.ScanRawKVBatchPayload(env.Payload, func(op commitlog.RawKVOp, key, value []byte) error {
+		got = append(got, batch.Entry{Type: batch.OpPut, Key: append([]byte(nil), key...), Value: append([]byte(nil), value...)})
+		return nil
+	}); err != nil {
+		_ = r.Close()
+		_ = db.Close()
+		t.Fatalf("ScanRawKVBatchPayload: %v", err)
+	}
+	if err := r.Close(); err != nil {
+		_ = db.Close()
+		t.Fatalf("reader Close: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if len(got) != 2 || string(got[0].Key) != "alpha" || string(got[0].Value) != "one" || string(got[1].Key) != "bravo" || string(got[1].Value) != "two" {
+		t.Fatalf("decoded payload command WAL ops=%+v", got)
+	}
+}
+
+func TestPublicCommandWALBatchOrdinarySetStablePayloadAppendsWithoutReplay(t *testing.T) {
+	dir := t.TempDir()
+	db, err := Open(Options{
+		Dir:                 dir,
+		Durability:          DurabilityWALOnRelaxed,
+		CommandWAL:          true,
+		CommandWALStatsScan: true,
+		DisableSideStores:   true,
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	inner := &commandWALPayloadSoftCapBatch{}
+	wrapped := newCommandWALPublicBatch(db, inner, 0)
+	wrapped.payloadSoftCapBytes = 64 << 10
+
+	alphaKey, alphaValue := []byte("alpha"), []byte("one")
+	bravoKey, bravoValue := []byte("bravo"), []byte("two")
+	if err := wrapped.Set(alphaKey, alphaValue); err != nil {
+		t.Fatalf("Set alpha: %v", err)
+	}
+	if err := wrapped.Set(bravoKey, bravoValue); err != nil {
+		t.Fatalf("Set bravo: %v", err)
+	}
+	alphaKey[0], alphaValue[0] = 'A', 'O'
+	bravoKey[0], bravoValue[0] = 'B', 'T'
+	if wrapped.payloadBypass || wrapped.payload.Count() != wrapped.opCount {
+		t.Fatalf("payload state bypass=%t count=%d opCount=%d, want stable payload", wrapped.payloadBypass, wrapped.payload.Count(), wrapped.opCount)
+	}
+	if inner.setViewCalls != 2 || inner.setCalls != 0 {
+		t.Fatalf("inner calls: setView=%d set=%d, want 2/0", inner.setViewCalls, inner.setCalls)
+	}
+	if err := wrapped.appendCommandWAL(false); err != nil {
+		_ = db.Close()
+		t.Fatalf("appendCommandWAL: %v", err)
+	}
+	if inner.replayCalls != 0 {
+		_ = db.Close()
+		t.Fatalf("inner replay calls=%d, want 0 for ordinary stable payload append", inner.replayCalls)
+	}
+
+	r, err := commitlog.NewReader(filepath.Join(backenddb.WALDirPath(dir), "commit-l0-000001.log"))
+	if err != nil {
+		_ = db.Close()
+		t.Fatalf("NewReader: %v", err)
+	}
+	env, err := r.ReadCommandFrame()
+	if err != nil {
+		_ = r.Close()
+		_ = db.Close()
+		t.Fatalf("ReadCommandFrame: %v", err)
+	}
+	var got []batch.Entry
+	if err := commitlog.ScanRawKVBatchPayload(env.Payload, func(op commitlog.RawKVOp, key, value []byte) error {
+		got = append(got, batch.Entry{Type: batch.OpPut, Key: append([]byte(nil), key...), Value: append([]byte(nil), value...)})
+		return nil
+	}); err != nil {
+		_ = r.Close()
+		_ = db.Close()
+		t.Fatalf("ScanRawKVBatchPayload: %v", err)
+	}
+	if err := r.Close(); err != nil {
+		_ = db.Close()
+		t.Fatalf("reader Close: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if len(got) != 2 || string(got[0].Key) != "alpha" || string(got[0].Value) != "one" || string(got[1].Key) != "bravo" || string(got[1].Value) != "two" {
+		t.Fatalf("decoded payload command WAL ops=%+v", got)
 	}
 }
 

--- a/TreeDB/db/versioned_read_test.go
+++ b/TreeDB/db/versioned_read_test.go
@@ -2,9 +2,12 @@ package db
 
 import (
 	"bytes"
+	"os"
+	"path/filepath"
 	"testing"
 
 	batchpkg "github.com/snissn/gomap/TreeDB/batch"
+	"github.com/snissn/gomap/TreeDB/internal/commitlog"
 	"github.com/snissn/gomap/TreeDB/page"
 )
 
@@ -120,6 +123,63 @@ func TestGetVersionedAssignsDurableEntryRevision(t *testing.T) {
 	}
 	if got := reopen.State().MaxEntryRevision; got < revision {
 		t.Fatalf("reopen MaxEntryRevision=%d, want >= assigned revision %d", got, revision)
+	}
+}
+
+func TestCommitLogRecoveryPreservesRecordEntryRevisions(t *testing.T) {
+	dir := t.TempDir()
+	walDir := WALDirPath(dir)
+	if err := os.MkdirAll(walDir, 0755); err != nil {
+		t.Fatalf("mkdir wal: %v", err)
+	}
+	writer, err := commitlog.NewWriter(filepath.Join(walDir, "commit-l0-000001.log"))
+	if err != nil {
+		t.Fatalf("commitlog.NewWriter: %v", err)
+	}
+	records := []commitlog.Record{
+		{Op: commitlog.OpSetInline, Key: []byte("alpha"), Value: []byte("one"), Seq: 300, Revision: 201},
+		{Op: commitlog.OpSetInline, Key: []byte("bravo"), Value: []byte("two"), Seq: 300, Revision: 202},
+	}
+	if err := writer.AppendBatch(records); err != nil {
+		_ = writer.Close()
+		t.Fatalf("AppendBatch: %v", err)
+	}
+	if err := writer.Sync(); err != nil {
+		_ = writer.Close()
+		t.Fatalf("Sync: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("Close writer: %v", err)
+	}
+
+	db, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() {
+		if err := db.Close(); err != nil {
+			t.Fatalf("Close: %v", err)
+		}
+	}()
+
+	for _, tc := range []struct {
+		key      string
+		value    string
+		revision page.EntryRevision
+	}{
+		{key: "alpha", value: "one", revision: 201},
+		{key: "bravo", value: "two", revision: 202},
+	} {
+		val, revision, err := db.GetVersioned([]byte(tc.key))
+		if err != nil {
+			t.Fatalf("GetVersioned %s: %v", tc.key, err)
+		}
+		if !bytes.Equal(val, []byte(tc.value)) || revision != tc.revision {
+			t.Fatalf("GetVersioned %s=(%q,%d), want (%s,%d)", tc.key, val, revision, tc.value, tc.revision)
+		}
+	}
+	if got := db.State().MaxEntryRevision; got < 202 {
+		t.Fatalf("MaxEntryRevision=%d, want >= 202", got)
 	}
 }
 

--- a/TreeDB/internal/commitlog/command_frame.go
+++ b/TreeDB/internal/commitlog/command_frame.go
@@ -27,6 +27,7 @@ const (
 	rawKVOpRevisionHeaderSize             = rawKVOpHeaderSize + 8
 	rawKVZeroOpHeaderSize                 = 4
 	rawKVZeroOpHeaderSizeV3               = 2
+	rawKVRevisionOffsetInlineCap          = 8
 	rawKVNilRangeBoundLenUint32           = uint32(^uint32(0))
 
 	collectionRebuildVectorIndexPayloadVersion      = uint16(1)
@@ -161,6 +162,9 @@ type RawKVBatchPayloadBuilder struct {
 	zeroSetMaxKeyLen      int
 	zeroSetCompactVersion uint16
 	zeroSetValueRef       []byte
+	entryRevisions        bool
+	revisionOffsets       []uint32
+	revisionOffsetInline  [rawKVRevisionOffsetInlineCap]uint32
 }
 
 // NewRawKVBatchPayloadBuilder returns a builder initialized with best-effort
@@ -208,10 +212,80 @@ func (b *RawKVBatchPayloadBuilder) ResetWithHint(opHint, byteHint int) error {
 	b.zeroSetMaxKeyLen = 0
 	b.zeroSetCompactVersion = 0
 	b.zeroSetValueRef = nil
+	b.entryRevisions = false
+	if b.revisionOffsets != nil {
+		b.revisionOffsets = b.revisionOffsets[:0]
+	}
 	if b.zeroPayload != nil {
 		b.zeroPayload = b.zeroPayload[:0]
 	}
 	return err
+}
+
+// EnableEntryRevisions switches the builder to RawKVBatch v4 layout before
+// appending operations, reserving an 8-byte revision slot per operation.
+func (b *RawKVBatchPayloadBuilder) EnableEntryRevisions() error {
+	if b == nil {
+		return ErrCorrupt
+	}
+	if b.payload == nil {
+		_ = b.ResetWithHint(0, 0)
+	}
+	if b.entryRevisions {
+		return nil
+	}
+	if b.count != 0 {
+		return ErrCorrupt
+	}
+	b.entryRevisions = true
+	b.zeroSetCandidate = false
+	b.zeroSetCompactOnly = false
+	b.zeroSetValuesOmitted = false
+	b.zeroSetValueLen = -1
+	b.zeroSetKeyBytes = 0
+	b.zeroSetMaxKeyLen = 0
+	b.zeroSetCompactVersion = 0
+	b.zeroSetValueRef = nil
+	b.resetRevisionOffsetsForHint()
+	if len(b.payload) < rawKVBatchHeaderSize {
+		if cap(b.payload) < rawKVBatchHeaderSize {
+			b.payload = make([]byte, rawKVBatchHeaderSize, rawKVBatchHeaderSize)
+		} else {
+			b.payload = b.payload[:rawKVBatchHeaderSize]
+		}
+	}
+	binary.LittleEndian.PutUint16(b.payload[0:2], rawKVBatchPayloadVersionWithRevisions)
+	return nil
+}
+
+func (b *RawKVBatchPayloadBuilder) resetRevisionOffsetsForHint() {
+	if b == nil {
+		return
+	}
+	if b.opHint > rawKVRevisionOffsetInlineCap {
+		if cap(b.revisionOffsets) < b.opHint {
+			b.revisionOffsets = make([]uint32, 0, b.opHint)
+			return
+		}
+		b.revisionOffsets = b.revisionOffsets[:0]
+		return
+	}
+	b.revisionOffsets = b.revisionOffsetInline[:0]
+}
+
+// EntryRevisionsEnabled reports whether the builder is emitting revision-aware
+// RawKVBatch payloads.
+func (b *RawKVBatchPayloadBuilder) EntryRevisionsEnabled() bool {
+	return b != nil && b.entryRevisions
+}
+
+// RevisionSlotOffsets returns byte offsets of revision slots in the canonical
+// payload. The returned slice aliases builder-owned storage and is read-only.
+func (b *RawKVBatchPayloadBuilder) RevisionSlotOffsets() []uint32 {
+	if b == nil || !b.entryRevisions || len(b.revisionOffsets) == 0 {
+		return nil
+	}
+	return b.revisionOffsets
 }
 
 func (b *RawKVBatchPayloadBuilder) Payload() []byte {
@@ -219,7 +293,15 @@ func (b *RawKVBatchPayloadBuilder) Payload() []byte {
 		return nil
 	}
 	if len(b.payload) >= rawKVBatchHeaderSize {
+		version := rawKVBatchPayloadVersion
+		if b.entryRevisions {
+			version = rawKVBatchPayloadVersionWithRevisions
+		}
+		binary.LittleEndian.PutUint16(b.payload[0:2], version)
 		binary.LittleEndian.PutUint32(b.payload[2:6], uint32(b.count))
+	}
+	if b.entryRevisions {
+		return b.payload
 	}
 	if b.zeroSetCompactOnly && b.zeroSetCandidate && b.count > 0 && b.zeroSetValueLen > 0 && len(b.zeroPayload) >= rawKVZeroBatchHeaderSize {
 		version := b.zeroSetCompactVersion
@@ -244,6 +326,91 @@ func (b *RawKVBatchPayloadBuilder) Payload() []byte {
 	}
 	b.materializeOmittedZeroValues()
 	return b.payload
+}
+
+// StampEntryRevisions writes revision slots in payload order for builders that
+// were initialized with EnableEntryRevisions.
+func (b *RawKVBatchPayloadBuilder) StampEntryRevisions(scan func(func(uint64) error) error) error {
+	if b == nil || scan == nil {
+		return ErrCorrupt
+	}
+	payload := b.Payload()
+	if !b.entryRevisions || len(payload) < rawKVBatchHeaderSize || binary.LittleEndian.Uint16(payload[0:2]) != rawKVBatchPayloadVersionWithRevisions {
+		return ErrCommandWALUnsupportedVersion
+	}
+	count := int(binary.LittleEndian.Uint32(payload[2:6]))
+	if count < 0 || count > (len(payload)-rawKVBatchHeaderSize)/rawKVOpRevisionHeaderSize {
+		return ErrCorrupt
+	}
+	if len(b.revisionOffsets) == count {
+		seen := 0
+		err := scan(func(revision uint64) error {
+			if seen >= count {
+				return ErrCorrupt
+			}
+			off := int(b.revisionOffsets[seen])
+			if off < rawKVBatchHeaderSize || off+8 > len(payload) {
+				return ErrCorrupt
+			}
+			binary.LittleEndian.PutUint64(payload[off:off+8], revision)
+			seen++
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+		if seen != count {
+			return ErrCorrupt
+		}
+		return nil
+	}
+	off := rawKVBatchHeaderSize
+	seen := 0
+	err := scan(func(revision uint64) error {
+		if seen >= count || off+rawKVOpRevisionHeaderSize > len(payload) {
+			return ErrCorrupt
+		}
+		op := RawKVOp(payload[off])
+		keyLen := binary.LittleEndian.Uint32(payload[off+1 : off+5])
+		valueLen := binary.LittleEndian.Uint32(payload[off+5 : off+9])
+		keyBytes := keyLen
+		valueBytes := valueLen
+		if op == RawKVOpDeleteRange {
+			if keyLen == rawKVNilRangeBoundLenUint32 {
+				keyBytes = 0
+			}
+			if valueLen == rawKVNilRangeBoundLenUint32 {
+				valueBytes = 0
+			}
+		}
+		need := uint64(rawKVOpRevisionHeaderSize) + uint64(keyBytes) + uint64(valueBytes)
+		if need > uint64(len(payload)-off) || need > uint64(^uint(0)>>1) {
+			return ErrCorrupt
+		}
+		binary.LittleEndian.PutUint64(payload[off+9:off+17], revision)
+		off += int(need)
+		seen++
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	if seen != count || off != len(payload) {
+		return ErrCorrupt
+	}
+	return nil
+}
+
+func (b *RawKVBatchPayloadBuilder) appendRevisionOffset(headerStart int) error {
+	if b == nil || !b.entryRevisions {
+		return nil
+	}
+	slot := headerStart + rawKVOpHeaderSize
+	if commandFrameIntExceedsUint32(slot + 8) {
+		return ErrRecordTooLarge
+	}
+	b.revisionOffsets = append(b.revisionOffsets, uint32(slot))
+	return nil
 }
 
 func (b *RawKVBatchPayloadBuilder) Count() int {
@@ -296,7 +463,7 @@ func (b *RawKVBatchPayloadBuilder) RetainedCapAfterAppendSet(key, value []byte) 
 	if b.zeroSetCompactOnly && b.canAppendCompactZeroSet(value) {
 		return b.retainedCapAfterCompactZeroSetAppend(key, value)
 	}
-	needed := rawKVOpHeaderSize + len(key) + len(value)
+	needed := rawKVOperationHeaderSize(b.entryRevisions) + len(key) + len(value)
 	if b.zeroSetCompactOnly {
 		return b.retainedCapAfterCompactZeroMaterializeAppend(needed)
 	}
@@ -304,7 +471,11 @@ func (b *RawKVBatchPayloadBuilder) RetainedCapAfterAppendSet(key, value []byte) 
 	if err != nil {
 		return 0, err
 	}
-	return b.retainedPayloadBufferCap(payloadCap, cap(b.zeroPayload), cap(b.zeroSetValueView))
+	revisionOffsetBytes, err := b.retainedRevisionOffsetBytesAfterAppend()
+	if err != nil {
+		return 0, err
+	}
+	return b.retainedPayloadBufferCap(payloadCap, cap(b.zeroPayload), cap(b.zeroSetValueView), revisionOffsetBytes)
 }
 
 // RetainedCapAfterAppendDelete returns the payload-builder backing capacity
@@ -319,7 +490,7 @@ func (b *RawKVBatchPayloadBuilder) RetainedCapAfterAppendDelete(key []byte) (int
 	if commandFrameIntExceedsUint32(b.count+1) || commandFrameIntExceedsUint32(len(key)) {
 		return 0, ErrRecordTooLarge
 	}
-	needed := rawKVOpHeaderSize + len(key)
+	needed := rawKVOperationHeaderSize(b.entryRevisions) + len(key)
 	if b.zeroSetCompactOnly {
 		return b.retainedCapAfterCompactZeroMaterializeAppend(needed)
 	}
@@ -327,7 +498,11 @@ func (b *RawKVBatchPayloadBuilder) RetainedCapAfterAppendDelete(key []byte) (int
 	if err != nil {
 		return 0, err
 	}
-	return b.retainedPayloadBufferCap(payloadCap, cap(b.zeroPayload), cap(b.zeroSetValueView))
+	revisionOffsetBytes, err := b.retainedRevisionOffsetBytesAfterAppend()
+	if err != nil {
+		return 0, err
+	}
+	return b.retainedPayloadBufferCap(payloadCap, cap(b.zeroPayload), cap(b.zeroSetValueView), revisionOffsetBytes)
 }
 
 // RetainedCapAfterAppendDeleteRange returns the payload-builder backing capacity
@@ -350,7 +525,7 @@ func (b *RawKVBatchPayloadBuilder) RetainedCapAfterAppendDeleteRange(start, end 
 	if err != nil {
 		return 0, err
 	}
-	needed := rawKVOpHeaderSize + startBytes + endBytes
+	needed := rawKVOperationHeaderSize(b.entryRevisions) + startBytes + endBytes
 	if b.zeroSetCompactOnly {
 		return b.retainedCapAfterCompactZeroMaterializeAppend(needed)
 	}
@@ -358,7 +533,11 @@ func (b *RawKVBatchPayloadBuilder) RetainedCapAfterAppendDeleteRange(start, end 
 	if err != nil {
 		return 0, err
 	}
-	return b.retainedPayloadBufferCap(payloadCap, cap(b.zeroPayload), cap(b.zeroSetValueView))
+	revisionOffsetBytes, err := b.retainedRevisionOffsetBytesAfterAppend()
+	if err != nil {
+		return 0, err
+	}
+	return b.retainedPayloadBufferCap(payloadCap, cap(b.zeroPayload), cap(b.zeroSetValueView), revisionOffsetBytes)
 }
 
 func (b *RawKVBatchPayloadBuilder) Truncate(payloadLen, count int) {
@@ -372,6 +551,9 @@ func (b *RawKVBatchPayloadBuilder) Truncate(payloadLen, count int) {
 	b.materializeOmittedZeroValues()
 	b.payload = b.payload[:payloadLen]
 	b.count = count
+	if b.entryRevisions && count <= len(b.revisionOffsets) {
+		b.revisionOffsets = b.revisionOffsets[:count]
+	}
 	binary.LittleEndian.PutUint32(b.payload[2:6], uint32(count))
 	b.recomputeZeroSetCandidate()
 }
@@ -389,7 +571,7 @@ func (b *RawKVBatchPayloadBuilder) Append(op RawKVOperation) (keyView, valueView
 	if err := validateRawKVOperation(&op); err != nil {
 		return nil, nil, err
 	}
-	if op.Revision != 0 {
+	if op.Revision != 0 && !b.entryRevisions {
 		return nil, nil, ErrCommandWALUnsupportedVersion
 	}
 	if op.Op == RawKVOpDeleteRange {
@@ -409,7 +591,7 @@ func (b *RawKVBatchPayloadBuilder) Append(op RawKVOperation) (keyView, valueView
 		binary.LittleEndian.PutUint64(ridBuf[:], op.RID)
 		value = ridBuf[:]
 	}
-	return b.appendValidated(op.Op, op.Key, value)
+	return b.appendValidatedWithRevision(op.Op, op.Key, value, op.Revision)
 }
 
 // AppendSet appends a validated RawKV Set operation without materializing a
@@ -443,14 +625,21 @@ func (b *RawKVBatchPayloadBuilder) AppendSet(key, value []byte) (keyView, valueV
 		}
 		b.zeroSetCompactOnly = false
 	}
-	off, err := b.appendRawKVPayloadSpace(rawKVOpHeaderSize + len(key) + len(value))
+	headerSize := rawKVOperationHeaderSize(b.entryRevisions)
+	off, err := b.appendRawKVPayloadSpace(headerSize + len(key) + len(value))
 	if err != nil {
 		return nil, nil, err
 	}
 	b.payload[off] = byte(RawKVOpSet)
 	binary.LittleEndian.PutUint32(b.payload[off+1:off+5], uint32(len(key)))
 	binary.LittleEndian.PutUint32(b.payload[off+5:off+9], uint32(len(value)))
-	off += rawKVOpHeaderSize
+	if b.entryRevisions {
+		binary.LittleEndian.PutUint64(b.payload[off+9:off+17], 0)
+		if err := b.appendRevisionOffset(off); err != nil {
+			return nil, nil, err
+		}
+	}
+	off += headerSize
 	keyStart := off
 	copy(b.payload[off:], key)
 	off += len(key)
@@ -492,14 +681,21 @@ func (b *RawKVBatchPayloadBuilder) AppendDelete(key []byte) (keyView []byte, err
 		}
 		b.zeroSetCompactOnly = false
 	}
-	off, err := b.appendRawKVPayloadSpace(rawKVOpHeaderSize + len(key))
+	headerSize := rawKVOperationHeaderSize(b.entryRevisions)
+	off, err := b.appendRawKVPayloadSpace(headerSize + len(key))
 	if err != nil {
 		return nil, err
 	}
 	b.payload[off] = byte(RawKVOpDelete)
 	binary.LittleEndian.PutUint32(b.payload[off+1:off+5], uint32(len(key)))
 	binary.LittleEndian.PutUint32(b.payload[off+5:off+9], 0)
-	off += rawKVOpHeaderSize
+	if b.entryRevisions {
+		binary.LittleEndian.PutUint64(b.payload[off+9:off+17], 0)
+		if err := b.appendRevisionOffset(off); err != nil {
+			return nil, err
+		}
+	}
+	off += headerSize
 	keyStart := off
 	copy(b.payload[off:], key)
 	off += len(key)
@@ -537,14 +733,21 @@ func (b *RawKVBatchPayloadBuilder) AppendDeleteRange(start, end []byte) (startVi
 		}
 		b.zeroSetCompactOnly = false
 	}
-	off, err := b.appendRawKVPayloadSpace(rawKVOpHeaderSize + startBytes + endBytes)
+	headerSize := rawKVOperationHeaderSize(b.entryRevisions)
+	off, err := b.appendRawKVPayloadSpace(headerSize + startBytes + endBytes)
 	if err != nil {
 		return nil, err
 	}
 	b.payload[off] = byte(RawKVOpDeleteRange)
 	binary.LittleEndian.PutUint32(b.payload[off+1:off+5], startLen)
 	binary.LittleEndian.PutUint32(b.payload[off+5:off+9], endLen)
-	off += rawKVOpHeaderSize
+	if b.entryRevisions {
+		binary.LittleEndian.PutUint64(b.payload[off+9:off+17], 0)
+		if err := b.appendRevisionOffset(off); err != nil {
+			return nil, err
+		}
+	}
+	off += headerSize
 	if startBytes > 0 {
 		startStart := off
 		copy(b.payload[off:], start)
@@ -741,7 +944,35 @@ func (b *RawKVBatchPayloadBuilder) retainedPayloadBufferCap(caps ...int) (int, e
 	return total, nil
 }
 
-func (b *RawKVBatchPayloadBuilder) appendValidated(op RawKVOp, key, value []byte) (keyView, valueView []byte, err error) {
+func (b *RawKVBatchPayloadBuilder) retainedRevisionOffsetBytesAfterAppend() (int, error) {
+	if b == nil || !b.entryRevisions {
+		return 0, nil
+	}
+	newLen := len(b.revisionOffsets) + 1
+	newCap := cap(b.revisionOffsets)
+	if newLen > newCap {
+		newCap *= 2
+		if newCap < newLen {
+			newCap = newLen
+		}
+		if b.opHint > newCap {
+			newCap = b.opHint
+		}
+		if newCap < rawKVRevisionOffsetInlineCap {
+			newCap = rawKVRevisionOffsetInlineCap
+		}
+	}
+	if newCap <= rawKVRevisionOffsetInlineCap {
+		return 0, nil
+	}
+	maxInt := int(^uint(0) >> 1)
+	if newCap > maxInt/4 {
+		return 0, ErrRecordTooLarge
+	}
+	return newCap * 4, nil
+}
+
+func (b *RawKVBatchPayloadBuilder) appendValidatedWithRevision(op RawKVOp, key, value []byte, revision uint64) (keyView, valueView []byte, err error) {
 	if b == nil {
 		return nil, nil, ErrCorrupt
 	}
@@ -764,14 +995,21 @@ func (b *RawKVBatchPayloadBuilder) appendValidated(op RawKVOp, key, value []byte
 		}
 		b.zeroSetCompactOnly = false
 	}
-	off, err := b.appendRawKVPayloadSpace(rawKVOpHeaderSize + len(key) + len(value))
+	headerSize := rawKVOperationHeaderSize(b.entryRevisions)
+	off, err := b.appendRawKVPayloadSpace(headerSize + len(key) + len(value))
 	if err != nil {
 		return nil, nil, err
 	}
 	b.payload[off] = byte(op)
 	binary.LittleEndian.PutUint32(b.payload[off+1:off+5], uint32(len(key)))
 	binary.LittleEndian.PutUint32(b.payload[off+5:off+9], uint32(len(value)))
-	off += rawKVOpHeaderSize
+	if b.entryRevisions {
+		binary.LittleEndian.PutUint64(b.payload[off+9:off+17], revision)
+		if err := b.appendRevisionOffset(off); err != nil {
+			return nil, nil, err
+		}
+	}
+	off += headerSize
 	keyStart := off
 	copy(b.payload[off:], key)
 	off += len(key)

--- a/TreeDB/internal/commitlog/command_frame_test.go
+++ b/TreeDB/internal/commitlog/command_frame_test.go
@@ -820,6 +820,57 @@ func TestRawKVBatchPayloadBuilderMatchesSliceEncoder(t *testing.T) {
 	}
 }
 
+func TestRawKVBatchPayloadBuilderStampsEntryRevisions(t *testing.T) {
+	builder := NewRawKVBatchPayloadBuilder(3, len("alpha")+len("one")+len("bravo")+len("charlie"))
+	if err := builder.EnableEntryRevisions(); err != nil {
+		t.Fatalf("EnableEntryRevisions: %v", err)
+	}
+	if _, _, err := builder.AppendSet([]byte("alpha"), []byte("one")); err != nil {
+		t.Fatalf("AppendSet: %v", err)
+	}
+	if _, err := builder.AppendDelete([]byte("bravo")); err != nil {
+		t.Fatalf("AppendDelete: %v", err)
+	}
+	if _, _, err := builder.Append(RawKVOperation{Op: RawKVOpSetRID, Key: []byte("charlie"), RID: 42, Revision: 33}); err != nil {
+		t.Fatalf("Append SetRID: %v", err)
+	}
+	if err := builder.StampEntryRevisions(func(emit func(uint64) error) error {
+		for _, revision := range []uint64{11, 22, 33} {
+			if err := emit(revision); err != nil {
+				return err
+			}
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("StampEntryRevisions: %v", err)
+	}
+
+	payload := builder.Payload()
+	if got := binary.LittleEndian.Uint16(payload[0:2]); got != rawKVBatchPayloadVersionWithRevisions {
+		t.Fatalf("payload version=%d want %d", got, rawKVBatchPayloadVersionWithRevisions)
+	}
+	var got []RawKVOperation
+	err := ScanRawKVBatchPayloadWithRevision(payload, func(op RawKVOp, key, value []byte, revision uint64) error {
+		entry := RawKVOperation{Op: op, Key: cloneBytesPreserveEmpty(key), Revision: revision}
+		if op == RawKVOpSetRID {
+			entry.RID = binary.LittleEndian.Uint64(value)
+		} else {
+			entry.Value = cloneBytesPreserveEmpty(value)
+		}
+		got = append(got, entry)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("ScanRawKVBatchPayloadWithRevision: %v", err)
+	}
+	if len(got) != 3 ||
+		got[0].Op != RawKVOpSet || string(got[0].Key) != "alpha" || string(got[0].Value) != "one" || got[0].Revision != 11 ||
+		got[1].Op != RawKVOpDelete || string(got[1].Key) != "bravo" || got[1].Revision != 22 ||
+		got[2].Op != RawKVOpSetRID || string(got[2].Key) != "charlie" || got[2].RID != 42 || got[2].Revision != 33 {
+		t.Fatalf("stamped ops=%+v, want revisions preserved", got)
+	}
+}
+
 func TestRawKVBatchPayloadBuilderResetWithHintReportsOverflow(t *testing.T) {
 	var builder RawKVBatchPayloadBuilder
 	if err := builder.ResetWithHint(int(^uint(0)>>1), int(^uint(0)>>1)); !errors.Is(err, ErrRecordTooLarge) {

--- a/TreeDB/internal/commitlog/commitlog_test.go
+++ b/TreeDB/internal/commitlog/commitlog_test.go
@@ -133,6 +133,106 @@ func TestCommitLogWriteReadBatchWithEntryRevisions(t *testing.T) {
 	_ = reader.Close()
 }
 
+func TestCommitLogAppendEntryRevision(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "commit.log")
+
+	writer, err := NewWriterWithOptions(path, Options{Compress: false})
+	if err != nil {
+		t.Fatalf("new writer: %v", err)
+	}
+	record := Record{Op: OpSetInline, Key: []byte("k1"), Value: []byte("v1"), Seq: 300, Revision: 201}
+	if err := writer.Append(record); err != nil {
+		_ = writer.Close()
+		t.Fatalf("append: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read file: %v", err)
+	}
+	if got := data[segmentHeaderSize]; got != recordRevisionBatchVersion {
+		t.Fatalf("raw batch version=%d, want revision batch version %d", got, recordRevisionBatchVersion)
+	}
+
+	reader, err := NewReader(path)
+	if err != nil {
+		t.Fatalf("new reader: %v", err)
+	}
+	got, err := reader.ReadBatch()
+	if err != nil {
+		_ = reader.Close()
+		t.Fatalf("read batch: %v", err)
+	}
+	if len(got) != 1 {
+		_ = reader.Close()
+		t.Fatalf("record count: got %d want 1", len(got))
+	}
+	if got[0].Op != record.Op || got[0].Seq != record.Seq || got[0].Revision != record.Revision ||
+		!bytes.Equal(got[0].Key, record.Key) || !bytes.Equal(got[0].Value, record.Value) {
+		_ = reader.Close()
+		t.Fatalf("record=%+v, want %+v", got[0], record)
+	}
+	if _, err := reader.ReadBatch(); !errors.Is(err, io.EOF) {
+		_ = reader.Close()
+		t.Fatalf("expected EOF, got %v", err)
+	}
+	_ = reader.Close()
+}
+
+func TestCommitLogAppendSeqBackedRevisionUsesCompactVersion(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "commit.log")
+
+	writer, err := NewWriterWithOptions(path, Options{Compress: false})
+	if err != nil {
+		t.Fatalf("new writer: %v", err)
+	}
+	record := Record{Op: OpSetInline, Key: []byte("k1"), Value: []byte("v1"), Seq: 300, Revision: 300}
+	if err := writer.Append(record); err != nil {
+		_ = writer.Close()
+		t.Fatalf("append: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read file: %v", err)
+	}
+	if got := data[segmentHeaderSize]; got != Version {
+		t.Fatalf("raw batch version=%d, want compact version %d", got, Version)
+	}
+
+	reader, err := NewReader(path)
+	if err != nil {
+		t.Fatalf("new reader: %v", err)
+	}
+	got, err := reader.ReadBatch()
+	if err != nil {
+		_ = reader.Close()
+		t.Fatalf("read batch: %v", err)
+	}
+	if len(got) != 1 {
+		_ = reader.Close()
+		t.Fatalf("record count: got %d want 1", len(got))
+	}
+	if got[0].Op != record.Op || got[0].Seq != record.Seq || got[0].Revision != 0 ||
+		!bytes.Equal(got[0].Key, record.Key) || !bytes.Equal(got[0].Value, record.Value) {
+		_ = reader.Close()
+		t.Fatalf("record=%+v, want seq-backed compact revision", got[0])
+	}
+	if _, err := reader.ReadBatch(); !errors.Is(err, io.EOF) {
+		_ = reader.Close()
+		t.Fatalf("expected EOF, got %v", err)
+	}
+	_ = reader.Close()
+}
+
 func TestCommitLogAppendCoalescesSameSeqSmallRecords(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "commit.log")

--- a/TreeDB/internal/commitlog/reader.go
+++ b/TreeDB/internal/commitlog/reader.go
@@ -146,7 +146,7 @@ func decodeBatchRecords(payload []byte, withRevision bool) ([]Record, error) {
 		if withRevision {
 			revision = binary.LittleEndian.Uint64(payload[off+23 : off+31])
 		}
-		if recordSizeExceedsMax(keyLen, valLen) {
+		if recordSizeExceedsMaxWithHeader(headerSize, keyLen, valLen) {
 			return nil, ErrRecordTooLarge
 		}
 		recSize := headerSize + int(keyLen) + int(valLen)

--- a/TreeDB/internal/commitlog/writer.go
+++ b/TreeDB/internal/commitlog/writer.go
@@ -45,12 +45,33 @@ func normalizeBufferSize(size int) int {
 	return size
 }
 
-func recordSizeExceedsMax(keyLen uint16, valueLen uint32) bool {
+func recordSizeExceedsMaxWithHeader(headerSize int, keyLen uint16, valueLen uint32) bool {
 	if limits.MaxRecordSize <= 0 {
 		return false
 	}
-	recordLen := int64(recordHeaderSize) + int64(keyLen) + int64(valueLen)
+	recordLen := int64(headerSize) + int64(keyLen) + int64(valueLen)
 	return recordLen > limits.MaxRecordSize
+}
+
+func recordSizeExceedsMax(keyLen uint16, valueLen uint32) bool {
+	return recordSizeExceedsMaxWithHeader(recordHeaderSize, keyLen, valueLen)
+}
+
+func recordNeedsRevisionEncoding(r *Record, batchSeq uint64) bool {
+	return r != nil && r.Revision != 0 && r.Revision != batchSeq
+}
+
+func batchNeedsRevisionEncoding(records []Record, batchSeq uint64) (bool, error) {
+	needsRevision := false
+	for i := range records {
+		if records[i].Seq != batchSeq {
+			return false, ErrMixedBatchSeq
+		}
+		if recordNeedsRevisionEncoding(&records[i], batchSeq) {
+			needsRevision = true
+		}
+	}
+	return needsRevision, nil
 }
 
 func allZeroBytes(p []byte) bool {
@@ -426,15 +447,15 @@ func (w *Writer) Append(record Record) error {
 
 	keyLen := uint16(len(record.Key))
 	valLen := uint32(len(record.Value))
-	if recordSizeExceedsMax(keyLen, valLen) {
-		return ErrRecordTooLarge
-	}
 
 	headerSize := recordHeaderSize
 	version := byte(Version)
-	if record.Revision != 0 {
+	if recordNeedsRevisionEncoding(&record, record.Seq) {
 		headerSize = recordRevisionHeaderSize
 		version = recordRevisionBatchVersion
+	}
+	if recordSizeExceedsMaxWithHeader(headerSize, keyLen, valLen) {
+		return ErrRecordTooLarge
 	}
 
 	total := int64(batchHeaderSize) + int64(headerSize) + int64(len(record.Key)) + int64(len(record.Value))
@@ -449,7 +470,7 @@ func (w *Writer) Append(record Record) error {
 	if payloadLen > int(segmentLenMask) {
 		return ErrRecordTooLarge
 	}
-	if record.Revision == 0 && !w.compress && segmentHeaderSize+payloadLen < directSegmentPayloadMinLen {
+	if version == Version && !w.compress && segmentHeaderSize+payloadLen < directSegmentPayloadMinLen {
 		return w.appendPendingRecord(record, keyLen, valLen)
 	}
 
@@ -467,7 +488,7 @@ func (w *Writer) Append(record Record) error {
 	binary.LittleEndian.PutUint32(buf[off+3:off+7], valLen)
 	binary.LittleEndian.PutUint64(buf[off+7:off+15], record.RID)
 	binary.LittleEndian.PutUint64(buf[off+15:off+23], record.Seq)
-	if record.Revision != 0 {
+	if version == recordRevisionBatchVersion {
 		binary.LittleEndian.PutUint64(buf[off+23:off+31], record.Revision)
 	}
 	copy(buf[off+headerSize:], record.Key)
@@ -488,21 +509,18 @@ func (w *Writer) AppendBatch(records []Record) error {
 	}
 
 	batchSeq := records[0].Seq
-	hasRecordRevisions := false
-	for i := range records {
-		if records[i].Revision != 0 {
-			hasRecordRevisions = true
-			break
-		}
+	needsRevision, err := batchNeedsRevisionEncoding(records, batchSeq)
+	if err != nil {
+		return err
 	}
-	if !hasRecordRevisions && !w.compress {
+	if !needsRevision && !w.compress {
 		if ok, err := w.appendZeroInlineBatchIfCompact(records, batchSeq); ok || err != nil {
 			return err
 		}
 	}
 	headerSize := recordHeaderSize
 	version := byte(Version)
-	if hasRecordRevisions {
+	if needsRevision {
 		headerSize = recordRevisionHeaderSize
 		version = recordRevisionBatchVersion
 	}
@@ -525,9 +543,6 @@ func (w *Writer) AppendBatch(records []Record) error {
 		if err := validateRecord(r); err != nil {
 			return err
 		}
-		if r.Seq != batchSeq {
-			return ErrMixedBatchSeq
-		}
 		if len(r.Key) > int(^uint16(0)) {
 			return ErrRecordTooLarge
 		}
@@ -536,7 +551,7 @@ func (w *Writer) AppendBatch(records []Record) error {
 		}
 		keyLen := uint16(len(r.Key))
 		valLen := uint32(len(r.Value))
-		if recordSizeExceedsMax(keyLen, valLen) {
+		if recordSizeExceedsMaxWithHeader(headerSize, keyLen, valLen) {
 			return ErrRecordTooLarge
 		}
 
@@ -580,7 +595,7 @@ func (w *Writer) AppendBatch(records []Record) error {
 		binary.LittleEndian.PutUint32(buf[off+3:off+7], valLen)
 		binary.LittleEndian.PutUint64(buf[off+7:off+15], r.RID)
 		binary.LittleEndian.PutUint64(buf[off+15:off+23], r.Seq)
-		if hasRecordRevisions {
+		if needsRevision {
 			binary.LittleEndian.PutUint64(buf[off+23:off+31], r.Revision)
 		}
 		copy(buf[off+headerSize:], r.Key)
@@ -610,7 +625,7 @@ func (w *Writer) appendZeroInlineBatchIfCompact(records []Record, batchSeq uint6
 	total := int64(zeroInlineBatchHeaderSize)
 	for i := range records {
 		r := &records[i]
-		if r.Revision != 0 {
+		if recordNeedsRevisionEncoding(r, batchSeq) {
 			return false, nil
 		}
 		if r.Op != OpSetInline {


### PR DESCRIPTION
## Objective

Land #3434 by hardening the post-#3423 TreeDB revision WAL paths before #3424 consumes revisions for high-throughput conditional transactions.

Closes #3434. Refs #3418, #3423, #3424.

## Context

#3423 merged the first-class entry revision substrate. Follow-up review and benchmark work found remaining production requirements for WAL-on cached batches and public command-WAL stable payloads: explicit/mixed revisions must survive crash recovery, assigned revisions must be encoded into already-built stable payloads, and the common batch append path must stay close to normal write throughput.

## Non-goals

- No conditional transaction oracle here; that remains #3424.
- No distributed Raft implementation work.
- No adapter sidecar or second metadata tree for revisions.

## Design

- Cached WAL records optionally carry per-record revisions when visible entry revisions differ from the batch sequence, and recovery replays through revision-preserving APIs.
- Public command-WAL batches enable RawKVBatch v4 revision slots only for DB-backed batches that expose ordered native entries.
- Stable command-WAL payloads are still built once on append, then stamped after `WriteAfterCommandWALAppend` assigns revisions, using recorded revision-slot offsets and ordered batch entries.
- Bypass/rebuild paths preserve revisions through the planned revision-aware RawKV encoder.
- The payload builder keeps small revision-offset state inline and uses the batch size hint for larger offset storage, keeping allocation overhead per batch small.

## Correctness

Test evidence on head `d685dac9c` over `origin/main` `0a4f04bfa`:

```text
GOWORK=off go test ./TreeDB/internal/commitlog -run 'TestRawKVBatchPayloadBuilder(StampsEntryRevisions|MatchesSliceEncoder)|TestCommandWALRawKVBatchRevisionRoundTrip|TestCommitLogWriteReadBatchWithEntryRevisions|TestCommitLogAppendEntryRevision|TestCommitLogAppendSeqBackedRevisionUsesCompactVersion' -count=1
GOWORK=off go test ./TreeDB -run 'TestPublicCommandWALBatchReplayBytesPayloadPreservesAssignedRevision|TestPublicCommandWALBatchOrdinarySetStablePayloadAppendsWithoutReplay|TestPublicCommandWALBatchStablePayloadAppendsWithoutReplay|TestPublicCommandWALBatchOrdinarySetUsesPayloadBuilder|TestPublicCommandWALBatchValueLogPointersStayBelowFrameCap|TestPublicCommandWALBatchValueLogPointersFlushMultiLaneRefs' -count=1
GOWORK=off go test ./TreeDB/caching -run 'TestCachedWALBatchPersistsMixedExplicitEntryRevisions|TestUnifiedWAL_CrashRecoveryPreservesEntryRevision' -count=1
GOWORK=off go test ./TreeDB/internal/commitlog ./TreeDB/caching ./TreeDB -count=1
git diff --check
```

## Performance

Environment: linux/amd64, Intel i5-11400F.

Commands:

```text
GOWORK=off go test ./TreeDB -run '^$' -bench 'BenchmarkPublicCommandWALRawKVBatchWrite$' -benchmem -count=3
GOWORK=off go test ./TreeDB/internal/commitlog -run '^$' -bench 'BenchmarkCommandJournalAppendRawKVPointTrustedAndFlush' -benchmem -count=3
```

Latest-head benchmark summary:

| Benchmark | Result |
| --- | --- |
| public batch64 command_wal=false | 1.58M-1.77M sets/s, 89-93 allocs/batch |
| public batch64 command_wal=true | 1.40M-1.57M sets/s, 98-99 allocs/batch |
| public batch1024 command_wal=false | 2.57M-2.85M sets/s, 2069-2070 allocs/batch |
| public batch1024 command_wal=true | 2.43M-2.95M sets/s, 2078 allocs/batch |
| commitlog point no revision | 861.8-1528 ns/op, 0 B/op, 0 allocs/op |
| commitlog point revision | 756.7-870.3 ns/op, 0 B/op, 0 allocs/op |

The 1024-entry command-WAL path is in the same throughput band as normal batch writes and adds 8 allocations per 1024-entry batch. The low-level revision frame path remains zero-allocation.

## Rollout / Toggle Plan

- This is a hardening change to the native revision substrate; no runtime toggle is added.
- Revert this PR before #3424 if the revision payload contract needs to change.

## Follow-ups

- #3424 can build the conditional transaction conflict oracle on this hardened revision/WAL substrate.
- #3425 remains the downstream adapter proof and final performance closeout.

## AI Review Loop

- Codex/local: complete on `d685dac9c` with focused tests, affected package sweep, and benchmark evidence above.
- CodeRabbit: pending latest-head review.
- Copilot: pending latest-head review.
- Review comments/threads resolved or explicitly dismissed: pending.
