### PR TITLE
test(treedb): prove conditional adapter readiness

### DIFF
--- a/TreeDB/docs/conditional_kv_contract_test.go
+++ b/TreeDB/docs/conditional_kv_contract_test.go
@@ -107,4 +107,28 @@ func TestConditionalKVContractDocsPinNativeRevisionAndTxnGates(t *testing.T) {
 		"does not add a second ordered-root write or lookup per operation",
 		"`TreeDB/db/conditional_kv_contract_bench_test.go`; #3424/#3425 must replace them with non-skipped benchmarks",
 	)
+
+	adapterReadiness := collapseWhitespace(readRepoText(t, "TreeDB/docs/spec/conditional-kv-adapter-readiness.md"))
+	assertContainsAll(t, adapterReadiness, "conditional raw KV adapter readiness",
+		"Use `DB.GetVersioned` or `DB.GetVersionedAppend` as the cache-token read path",
+		"Map `ErrConcurrentModification` to the downstream conflict error",
+		"Do not add a second metadata tree, system-root sidecar, or adapter-private revision map for this feature",
+		"TreeDB native supported",
+		"public cached conditional transactions when public command WAL is not enabled",
+		"backend command-WAL accepted conditional commits with deterministic raw-KV payloads and explicit entry revisions",
+		"TreeDB native fail-closed",
+		"Public cached command-WAL conditional transactions return `ErrConditionalTxnUnsupported`",
+		"Adapter-level hard error",
+		"Badger-style encryption and in-memory-only mode are rejected",
+		"`ErrUnsupportedAdapterFeature`",
+		"Future raft-facing apply consumes accepted deterministic native write payloads",
+		"TestAdapterReadinessUsesNativeRevisionsAndConditionalConflicts",
+		"TestAdapterReadinessCommandWALReopenPreservesRevisionAndFailsClosedConditional",
+	)
+
+	specReadme := collapseWhitespace(readRepoText(t, "TreeDB/docs/spec/README.md"))
+	assertContainsAll(t, specReadme, "conditional raw KV adapter readiness index",
+		"`TreeDB/docs/spec/conditional-kv-adapter-readiness.md`",
+		"downstream adapter closeout for native `EntryRevision` cache tokens",
+	)
 }

--- a/TreeDB/docs/spec/README.md
+++ b/TreeDB/docs/spec/README.md
@@ -74,6 +74,10 @@ Given pre-alpha status, this is a living spec that tracks implementation.
   - system model, components, directory layout, side stores, lock model.
 - `TreeDB/docs/spec/contracts.md`
   - API-level behavioral contracts (reads/writes, iteration, snapshots, concurrency, locking).
+- `TreeDB/docs/spec/conditional-kv-adapter-readiness.md`
+  - downstream adapter closeout for native `EntryRevision` cache tokens,
+    conditional transaction conflict mapping, command-WAL/fail-closed surfaces,
+    and unsupported Badger-style feature errors.
 - `TreeDB/docs/spec/concurrency-paradigms.md`
   - complete concurrency mechanism inventory, lock/worker topology, and option/flag matrix for perf/refactor audits.
 - `TreeDB/docs/spec/storage-format.md`

--- a/TreeDB/docs/spec/conditional-kv-adapter-readiness.md
+++ b/TreeDB/docs/spec/conditional-kv-adapter-readiness.md
@@ -1,0 +1,72 @@
+# Conditional KV Adapter Readiness
+
+This closeout document records the downstream adapter contract for native
+`EntryRevision` and conditional raw-KV transactions. It applies to
+Badger-replacement adapters that want TreeDB revision tokens and optimistic
+point-conflict semantics without maintaining an adapter sidecar.
+
+## Adapter Contract
+
+Downstream adapters should use TreeDB's native APIs directly:
+
+- Use `DB.GetVersioned` or `DB.GetVersionedAppend` as the cache-token read path.
+  The returned `EntryRevision` is native entry metadata from the same lookup
+  that found the visible value.
+- Use `DB.NewConditionalTxn` or reusable `DB.InitConditionalTxn` for optimistic
+  point transactions. Map `ErrConcurrentModification` to the downstream
+  conflict error.
+- Stage transaction writes with the TreeDB transaction methods, then call
+  `Commit` or `CommitSync`. The commit publishes through TreeDB's native
+  batch, memtable, root-publish, revision, and WAL machinery for the selected
+  supported profile.
+- Do not add a second metadata tree, system-root sidecar, or adapter-private
+  revision map for this feature.
+
+## Compatibility Table
+
+| Class | Behavior |
+| --- | --- |
+| TreeDB native supported | Raw KV `Get`/`Set`/`Delete`/batch operations; versioned entry reads; backend conditional transactions; public cached conditional transactions when public command WAL is not enabled; backend command-WAL accepted conditional commits with deterministic raw-KV payloads and explicit entry revisions; public command-WAL ordinary raw KV writes with revision-preserving reopen. |
+| TreeDB native fail-closed | Public cached command-WAL conditional transactions return `ErrConditionalTxnUnsupported` until accepted conditional command framing is implemented for that public cached path; public command-WAL `Update`/`UpdateSync` return `ErrCommandWALRejected`; unsupported conditional range guards must fail closed rather than under-detect conflicts. |
+| Adapter-level hard error | Badger-style encryption and in-memory-only mode are rejected by `TreeDB/integration/kvstoreadapter.OpenConfig` before opening a DB directory, using `ErrUnsupportedAdapterFeature`. |
+| Explicitly out of scope | Full Badger API parity, managed timestamps, sequences, TTL, user meta, stream APIs, a full NornicDB adapter, and a distributed Raft implementation. |
+
+## Command WAL And Raft Boundary
+
+Backend command-WAL conditional transactions validate optimistic read
+preconditions before LSN assignment. Accepted commits serialize deterministic
+raw-KV batch payloads that carry the assigned `EntryRevision`; recovery replay
+reinstalls the same value/revision contract. Future raft-facing apply consumes
+accepted deterministic native write payloads and must not rerun nondeterministic
+optimistic validation.
+
+The public cached command-WAL wrapper has ordinary raw-KV revision/reopen
+coverage today, but conditional transactions intentionally fail closed there.
+That keeps downstream adapters from observing a mixed pending-memtable/backend
+transaction contract before accepted conditional command frames exist for the
+public cached path.
+
+## Verification
+
+The adapter-readiness harness lives in
+`TreeDB/integration/kvstoreadapter/conditional_readiness_test.go` and proves:
+
+- `TestAdapterReadinessUsesNativeRevisionsAndConditionalConflicts` covers the
+  non-command-WAL public cached transaction path a downstream wrapper can use
+  for native cache-token reads and conflict mapping.
+- `TestAdapterReadinessCommandWALReopenPreservesRevisionAndFailsClosedConditional`
+  covers public command-WAL revision/reopen behavior plus the current
+  conditional transaction hard error.
+- a downstream adapter can read native `EntryRevision` cache tokens;
+- a downstream adapter can map `ErrConcurrentModification` to its conflict
+  error without a metadata sidecar;
+- public command-WAL ordinary writes preserve revisions across reopen;
+- public cached command-WAL conditional transactions fail closed with
+  `ErrConditionalTxnUnsupported`;
+- unsupported adapter feature requests fail before storage is created.
+
+Engine-level command-WAL conditional replay coverage remains in
+`TestConditionalTxnCommandWALReplayMatchesLiveRevisionContract`. Performance
+evidence for the final M3/M4 gate is reported on issues #3424, #3425, and the
+corresponding PRs with `BenchmarkConditionalTxnReadSet{1,10,100,10000}` plus
+normal raw write baselines.

--- a/TreeDB/docs/spec/verification.md
+++ b/TreeDB/docs/spec/verification.md
@@ -223,6 +223,10 @@ Required coverage:
 - `TestConditionalTxnAllowsDisjointConcurrentCommit`
 - `TestConditionalTxnRejectsUnsupportedRangeGuard`
 - `TestConditionalTxnCommandWALReplayMatchesLiveRevisionContract`
+- `TestAdapterReadinessUsesNativeRevisionsAndConditionalConflicts`
+- `TestAdapterReadinessCommandWALReopenPreservesRevisionAndFailsClosedConditional`
+- `TestResolveOptionsRejectsUnsupportedAdapterFeatures`
+- `TestOpenRejectsUnsupportedAdapterFeaturesBeforeCreatingDB`
 
 Required performance evidence:
 - `BenchmarkGetVersioned`

--- a/TreeDB/integration/kvstoreadapter/conditional_readiness_test.go
+++ b/TreeDB/integration/kvstoreadapter/conditional_readiness_test.go
@@ -1,0 +1,162 @@
+package kvstoreadapter
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	treedb "github.com/snissn/gomap/TreeDB"
+)
+
+var errDownstreamConflict = errors.New("downstream adapter: conflict")
+
+type conditionalProofAdapter struct {
+	db *treedb.DB
+}
+
+func (a conditionalProofAdapter) readCacheToken(key []byte) ([]byte, treedb.EntryRevision, error) {
+	return a.db.GetVersioned(key)
+}
+
+func (a conditionalProofAdapter) mapCommitError(err error) error {
+	if errors.Is(err, treedb.ErrConcurrentModification) {
+		return errDownstreamConflict
+	}
+	return err
+}
+
+func TestAdapterReadinessUsesNativeRevisionsAndConditionalConflicts(t *testing.T) {
+	t.Parallel()
+
+	opened, err := Open(OpenConfig{
+		ParentDir:      t.TempDir(),
+		Name:           "application",
+		AdapterName:    "TreeDB Conditional Proof",
+		DefaultProfile: treedb.ProfileBench,
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = opened.DB.Close() }()
+	if opened.Options.CommandWAL {
+		t.Fatalf("profile opened command WAL; current public cached command-WAL conditionals should be tested separately")
+	}
+
+	proof := conditionalProofAdapter{db: opened.DB}
+	if err := opened.KV.Set([]byte("guard"), []byte("before")); err != nil {
+		t.Fatalf("adapter Set guard: %v", err)
+	}
+	value, token, err := proof.readCacheToken([]byte("guard"))
+	if err != nil {
+		t.Fatalf("readCacheToken: %v", err)
+	}
+	if !bytes.Equal(value, []byte("before")) || token == treedb.LegacyEntryRevision {
+		t.Fatalf("readCacheToken=(%q,%d), want before/non-legacy token", value, token)
+	}
+
+	tx, err := opened.DB.NewConditionalTxn()
+	if err != nil {
+		t.Fatalf("NewConditionalTxn: %v", err)
+	}
+	if got, gotToken, err := tx.GetVersioned([]byte("guard")); err != nil {
+		_ = tx.Close()
+		t.Fatalf("tx.GetVersioned guard: %v", err)
+	} else if !bytes.Equal(got, value) || gotToken != token {
+		_ = tx.Close()
+		t.Fatalf("tx.GetVersioned=(%q,%d), want cached token (%q,%d)", got, gotToken, value, token)
+	}
+	if err := tx.Set([]byte("guard"), []byte("after")); err != nil {
+		_ = tx.Close()
+		t.Fatalf("tx.Set guard: %v", err)
+	}
+	if err := proof.mapCommitError(tx.Commit()); err != nil {
+		t.Fatalf("tx.Commit mapped error: %v", err)
+	}
+	after, afterToken, err := proof.readCacheToken([]byte("guard"))
+	if err != nil {
+		t.Fatalf("readCacheToken after commit: %v", err)
+	}
+	if !bytes.Equal(after, []byte("after")) || afterToken <= token {
+		t.Fatalf("after token=(%q,%d), want after with newer token than %d", after, afterToken, token)
+	}
+
+	conflictTx, err := opened.DB.NewConditionalTxn()
+	if err != nil {
+		t.Fatalf("NewConditionalTxn conflict: %v", err)
+	}
+	if _, _, err := conflictTx.GetVersioned([]byte("guard")); err != nil {
+		_ = conflictTx.Close()
+		t.Fatalf("conflict tx GetVersioned: %v", err)
+	}
+	if err := opened.KV.Set([]byte("guard"), []byte("outside")); err != nil {
+		_ = conflictTx.Close()
+		t.Fatalf("adapter outside Set: %v", err)
+	}
+	if err := conflictTx.Set([]byte("target"), []byte("inside")); err != nil {
+		_ = conflictTx.Close()
+		t.Fatalf("conflict tx Set target: %v", err)
+	}
+	if err := proof.mapCommitError(conflictTx.Commit()); !errors.Is(err, errDownstreamConflict) {
+		t.Fatalf("mapped conflict error=%v, want errDownstreamConflict", err)
+	}
+	if got, err := opened.KV.Get([]byte("target")); err != nil || got != nil {
+		t.Fatalf("target after rejected conflict=(%q,%v), want missing", got, err)
+	}
+}
+
+func TestAdapterReadinessCommandWALReopenPreservesRevisionAndFailsClosedConditional(t *testing.T) {
+	t.Parallel()
+
+	parent := t.TempDir()
+	opened, err := Open(OpenConfig{
+		ParentDir:         parent,
+		Name:              "application",
+		DefaultProfile:    treedb.ProfileCommandWALRelaxed,
+		DefaultKeepRecent: 1,
+	})
+	if err != nil {
+		t.Fatalf("Open command WAL adapter: %v", err)
+	}
+	if got := opened.DB.Stats()["treedb.write_path.mode"]; got != "command_wal_cached" {
+		_ = opened.DB.Close()
+		t.Fatalf("write_path.mode=%q, want command_wal_cached", got)
+	}
+	if err := opened.KV.Set([]byte("k"), []byte("v1")); err != nil {
+		_ = opened.DB.Close()
+		t.Fatalf("adapter Set command WAL: %v", err)
+	}
+	value, revision, err := opened.DB.GetVersioned([]byte("k"))
+	if err != nil {
+		_ = opened.DB.Close()
+		t.Fatalf("GetVersioned command WAL: %v", err)
+	}
+	if !bytes.Equal(value, []byte("v1")) || revision == treedb.LegacyEntryRevision {
+		_ = opened.DB.Close()
+		t.Fatalf("command WAL token=(%q,%d), want v1/non-legacy", value, revision)
+	}
+	if _, err := opened.DB.NewConditionalTxn(); !errors.Is(err, treedb.ErrConditionalTxnUnsupported) {
+		_ = opened.DB.Close()
+		t.Fatalf("command WAL NewConditionalTxn error=%v, want ErrConditionalTxnUnsupported", err)
+	}
+	if err := opened.DB.Close(); err != nil {
+		t.Fatalf("Close command WAL adapter: %v", err)
+	}
+
+	reopened, err := Open(OpenConfig{
+		ParentDir:         parent,
+		Name:              "application",
+		DefaultProfile:    treedb.ProfileCommandWALRelaxed,
+		DefaultKeepRecent: 1,
+	})
+	if err != nil {
+		t.Fatalf("reopen command WAL adapter: %v", err)
+	}
+	defer func() { _ = reopened.DB.Close() }()
+	reopenedValue, reopenedRevision, err := reopened.DB.GetVersioned([]byte("k"))
+	if err != nil {
+		t.Fatalf("reopen GetVersioned: %v", err)
+	}
+	if !bytes.Equal(reopenedValue, value) || reopenedRevision != revision {
+		t.Fatalf("reopen token=(%q,%d), want (%q,%d)", reopenedValue, reopenedRevision, value, revision)
+	}
+}

--- a/TreeDB/integration/kvstoreadapter/open.go
+++ b/TreeDB/integration/kvstoreadapter/open.go
@@ -1,6 +1,7 @@
 package kvstoreadapter
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -19,6 +20,10 @@ const (
 	// EnvMemtableMode overrides the wrapper's memtable mode.
 	EnvMemtableMode = "TREEDB_MEMTABLE_MODE"
 )
+
+// ErrUnsupportedAdapterFeature is returned when a downstream wrapper requests
+// a Badger-style feature that TreeDB does not implement natively.
+var ErrUnsupportedAdapterFeature = errors.New("treedb adapter: unsupported feature")
 
 // OpenConfig standardizes the common "TreeDB behind a kvstore-style wrapper"
 // open path used by downstream integrations such as cosmos-db/cometbft-db.
@@ -54,6 +59,13 @@ type OpenConfig struct {
 
 	// ReadWorkers overrides adapter read worker count when > 0.
 	ReadWorkers int
+
+	// RequireEncryption fails closed when a downstream Badger-compatible wrapper
+	// requires per-DB encryption. TreeDB does not expose native encryption here.
+	RequireEncryption bool
+	// RequireInMemory fails closed when a downstream wrapper requests an
+	// in-memory-only TreeDB backend. This adapter opens persistent TreeDB dirs.
+	RequireInMemory bool
 }
 
 // Opened is the standardized result returned to downstream wrappers.
@@ -102,6 +114,13 @@ func ParsePublicProfile(raw string, fallback treedb.Profile) (treedb.Profile, er
 // ResolveOptions converts downstream wrapper defaults and standard TREEDB_*
 // environment overrides into TreeDB Options.
 func ResolveOptions(cfg OpenConfig) (treedb.Options, string, error) {
+	if cfg.RequireEncryption {
+		return treedb.Options{}, "", unsupportedAdapterFeature("encryption")
+	}
+	if cfg.RequireInMemory {
+		return treedb.Options{}, "", unsupportedAdapterFeature("in-memory mode")
+	}
+
 	parentDir := strings.TrimSpace(cfg.ParentDir)
 	if parentDir == "" {
 		return treedb.Options{}, "", fmt.Errorf("parent directory must be non-empty")
@@ -167,6 +186,10 @@ func ResolveOptions(cfg OpenConfig) (treedb.Options, string, error) {
 	}
 
 	return opts, dbPath, nil
+}
+
+func unsupportedAdapterFeature(feature string) error {
+	return fmt.Errorf("%w: %s", ErrUnsupportedAdapterFeature, feature)
 }
 
 // Open resolves standardized wrapper options, opens TreeDB, and returns the

--- a/TreeDB/integration/kvstoreadapter/open_test.go
+++ b/TreeDB/integration/kvstoreadapter/open_test.go
@@ -1,6 +1,7 @@
 package kvstoreadapter
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -225,6 +226,46 @@ func TestResolveOptionsRejectsInvalidPathInputs(t *testing.T) {
 	}
 }
 
+func TestResolveOptionsRejectsUnsupportedAdapterFeatures(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		cfg     OpenConfig
+		wantMsg string
+	}{
+		{
+			name: "encryption",
+			cfg: OpenConfig{
+				ParentDir:         t.TempDir(),
+				Name:              "application",
+				DefaultProfile:    treedb.ProfileCommandWALRelaxed,
+				RequireEncryption: true,
+			},
+			wantMsg: "encryption",
+		},
+		{
+			name: "in memory",
+			cfg: OpenConfig{
+				ParentDir:       t.TempDir(),
+				Name:            "application",
+				DefaultProfile:  treedb.ProfileCommandWALRelaxed,
+				RequireInMemory: true,
+			},
+			wantMsg: "in-memory",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, _, err := ResolveOptions(tc.cfg); !errors.Is(err, ErrUnsupportedAdapterFeature) {
+				t.Fatalf("ResolveOptions error=%v, want ErrUnsupportedAdapterFeature", err)
+			} else if !strings.Contains(err.Error(), tc.wantMsg) {
+				t.Fatalf("ResolveOptions error=%v, want %q context", err, tc.wantMsg)
+			}
+		})
+	}
+}
+
 func TestResolveOptionsIsSideEffectFreeOnError(t *testing.T) {
 	t.Setenv(EnvKeepRecent, "not-a-number")
 
@@ -239,6 +280,25 @@ func TestResolveOptionsIsSideEffectFreeOnError(t *testing.T) {
 	}
 	if _, err := os.Stat(dbPath); !os.IsNotExist(err) {
 		t.Fatalf("ResolveOptions created %q on error, stat err=%v", dbPath, err)
+	}
+}
+
+func TestOpenRejectsUnsupportedAdapterFeaturesBeforeCreatingDB(t *testing.T) {
+	t.Parallel()
+
+	parentDir := t.TempDir()
+	dbPath := filepath.Join(parentDir, "application.db")
+	_, err := Open(OpenConfig{
+		ParentDir:         parentDir,
+		Name:              "application",
+		DefaultProfile:    treedb.ProfileCommandWALRelaxed,
+		RequireEncryption: true,
+	})
+	if !errors.Is(err, ErrUnsupportedAdapterFeature) {
+		t.Fatalf("Open error=%v, want ErrUnsupportedAdapterFeature", err)
+	}
+	if _, statErr := os.Stat(dbPath); !os.IsNotExist(statErr) {
+		t.Fatalf("Open created %q on unsupported feature error, stat err=%v", dbPath, statErr)
 	}
 }
 


### PR DESCRIPTION
## Objective

Close #3425 by proving downstream adapter readiness for TreeDB-native `EntryRevision` cache tokens and conditional raw-KV conflict mapping, with explicit fail-closed behavior for unsupported Badger-style features.

Closes #3425.
Refs #3418, #3420, #3422, #3423, #3434, #3424.

## Context

The predecessor stack has already landed native revision metadata and production conditional transactions. This PR adds the M4 adapter-facing proof and closeout documentation: adapters can consume the native substrate directly without a metadata sidecar, while unsupported feature requests hard-error before storage is opened.

## Non-goals

- No full NornicDB adapter implementation.
- No broad Badger API clone.
- No new public cached command-WAL conditional transaction support; that path remains fail-closed with `ErrConditionalTxnUnsupported` until accepted conditional command framing exists for that public cached wrapper.
- No storage hot-path changes beyond adapter option validation.

## Design

- Adds `kvstoreadapter.ErrUnsupportedAdapterFeature` plus `OpenConfig.RequireEncryption` and `OpenConfig.RequireInMemory` so downstream wrappers fail closed before directory creation.
- Adds an adapter-readiness harness in `TreeDB/integration/kvstoreadapter` that:
  - opens through the canonical adapter path;
  - uses native `DB.GetVersioned` as the cache-token read path;
  - commits a public cached conditional transaction on the supported non-command-WAL profile;
  - maps `ErrConcurrentModification` to a downstream conflict error;
  - verifies public command-WAL ordinary writes preserve revisions across reopen;
  - verifies public cached command-WAL conditionals fail closed.
- Adds `TreeDB/docs/spec/conditional-kv-adapter-readiness.md` with the compatibility table required by #3425 and pins it through docs tests.

### Compatibility table

| Class | Behavior |
| --- | --- |
| TreeDB native supported | Raw KV reads/writes/batches, versioned entry reads, backend conditionals, public cached conditionals when public command WAL is not enabled, backend command-WAL accepted conditional commits, public command-WAL ordinary raw KV revision/reopen behavior. |
| TreeDB native fail-closed | Public cached command-WAL conditionals return `ErrConditionalTxnUnsupported`; public command-WAL update helpers return `ErrCommandWALRejected`; unsupported conditional range guards must fail closed. |
| Adapter-level hard error | Encryption and in-memory-only mode return `ErrUnsupportedAdapterFeature` before TreeDB opens a directory. |
| Explicitly out of scope | Full Badger parity, managed timestamps, sequences, TTL, user meta, stream APIs, full NornicDB adapter, distributed Raft implementation. |

## Scope

Includes:
- `TreeDB/integration/kvstoreadapter/open.go`
- `TreeDB/integration/kvstoreadapter/open_test.go`
- `TreeDB/integration/kvstoreadapter/conditional_readiness_test.go`
- `TreeDB/docs/spec/conditional-kv-adapter-readiness.md`
- `TreeDB/docs/conditional_kv_contract_test.go`
- `TreeDB/docs/spec/README.md`
- `TreeDB/docs/spec/verification.md`

Excludes:
- `TreeDB/db` and `TreeDB/caching` implementation changes.
- Any new command-WAL frame format.
- Any adapter-private revision storage.

## Correctness

Tests run:

```text
GOWORK=off go test ./TreeDB/integration/kvstoreadapter -run 'Test(AdapterReadiness|ResolveOptionsRejectsUnsupportedAdapterFeatures|OpenRejectsUnsupportedAdapterFeaturesBeforeCreatingDB)' -count=1
GOWORK=off go test ./TreeDB/docs -run TestConditionalKVContractDocsPinNativeRevisionAndTxnGates -count=1
GOWORK=off go test ./TreeDB/integration/kvstoreadapter -count=1
GOWORK=off go test ./TreeDB/docs -count=1
GOWORK=off go test -race ./TreeDB/db -run 'Test.*Conditional|Test.*Revision|Test.*Conflict|Test.*CommandWAL' -count=1
GOWORK=off go test ./TreeDB -count=1
GOWORK=off go test ./TreeDB/db -count=1
git diff --check
```

Results:
- `./TreeDB/integration/kvstoreadapter`: passed.
- `./TreeDB/docs`: passed.
- `./TreeDB`: passed in 51.322s.
- `./TreeDB/db`: passed in 258.411s.
- backend race slice: passed.

## Performance

Benchmarks run on linux/amd64, Intel i5-11400F, Go `go1.25.7`:

```text
GOWORK=off go test ./TreeDB/db -run '^$' -bench 'Benchmark(GetVersioned|ConditionalTxn(ReadSet1|ReadSet10|ReadSet100|ReadSet10000|BaselineBatchWrite|BaselineGet1BatchWrite|BaselineGet10BatchWrite|BaselineGet100BatchWrite|BaselineGet10000BatchWrite))$' -benchmem -benchtime=2000x -count=3
GOWORK=off go test ./TreeDB/db -run '^$' -bench 'BenchmarkCommandWALRawKVDirectWrite' -benchmem -benchtime=2000x -count=3
```

Artifacts:
- `/tmp/gomap-3425-evidence/conditional_adapter_closeout_bench_3x.txt`
- `/tmp/gomap-3425-evidence/conditional_adapter_closeout_benchstat.txt`
- `/tmp/gomap-3425-evidence/raw_command_wal_write_bench_3x.txt`
- `/tmp/gomap-3425-evidence/raw_command_wal_write_benchstat.txt`

Key current-head benchstat rows:

| Benchmark | sec/op | B/op | allocs/op |
| --- | ---: | ---: | ---: |
| `BenchmarkGetVersioned` | `280.3ns` | `42` | `0` |
| `BenchmarkConditionalTxnBaselineGet1BatchWrite` | `41.49us` | `17.61Ki` | `53` |
| `BenchmarkConditionalTxnReadSet1` | `47.04us` | `18.60Ki` | `54` |
| `BenchmarkConditionalTxnBaselineGet10BatchWrite` | `46.70us` | `17.68Ki` | `53` |
| `BenchmarkConditionalTxnReadSet10` | `48.05us` | `19.04Ki` | `55` |
| `BenchmarkCommandWALRawKVDirectWrite/backend_no_command_wal` | `12.60us` | `17.37Ki` | `48` |
| `BenchmarkCommandWALRawKVDirectWriteRevision/backend_no_command_wal_revision` | `12.94us` | `17.37Ki` | `48` |
| `BenchmarkCommandWALRawKVDirectWrite/command_wal_raw_kv` | `16.96us` | `18.02Ki` | `69` |
| `BenchmarkCommandWALRawKVDirectWriteRevision/command_wal_raw_kv_revision` | `18.52us` | `18.02Ki` | `69` |

No new hot-path implementation is introduced in this PR; allocation counts remain aligned with #3424 evidence shape.

## Rollout / Toggle Plan

Default behavior is unchanged unless a downstream wrapper opts into `RequireEncryption` or `RequireInMemory`, which now fail closed. Revert is localized to `OpenConfig` validation and the adapter proof/docs.

## Follow-ups

No blocker follow-up is required for #3418 closure from this PR. Public cached command-WAL conditional transactions remain a documented fail-closed future feature, not claimed as supported here.

## Optimization PR Checklist (TreeDB)

### Scope
- [x] Single, clear objective for this PR.
- [x] Explicit include list documented above.
- [x] Explicit exclude list documented above.

### Safety / Correctness
- [x] No written-vs-durable semantic changes to `*Sync` paths.
- [x] No new mmap usage.
- [x] No new length-field allocation/parsing surface.
- [x] Fail-closed behavior is explicit for unsupported adapter features.

### Tests
- [x] Added deterministic adapter-readiness and fail-closed tests.
- [x] Ran targeted packages and required TreeDB gates locally.

### Benchmarks / Measurements
- [x] Reported relevant current-head benchmark rows and artifact paths.

### Docs
- [x] Added closeout compatibility table and verification matrix entries.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added documentation and verification coverage for conditional KV adapter readiness, including supported and unsupported behaviors.
  * Added clearer handling for unsupported adapter feature requests, with fail-closed behavior.

* **Bug Fixes**
  * Improved conditional transaction conflict handling so conflicts are reported consistently and do not apply unintended changes.
  * Preserved versioned value and revision behavior across reopen in supported modes.

* **Tests**
  * Added integration tests covering native revisions, conditional conflicts, fail-closed behavior, and unsupported feature rejection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->