### PR TITLE
TreeDB Raft: wire production read-index reads

### DIFF
--- a/TreeDB/docs/spec/raftcluster.md
+++ b/TreeDB/docs/spec/raftcluster.md
@@ -6,7 +6,7 @@ This document records the single-group Raft storage/configuration boundary,
 recovery-status reporting boundary, first submit/apply bridge, and first
 HashiCorp Raft backed quorum provider that later issue `#3044` slices may
 depend on. It does not implement production snapshot transfer, truncate logs,
-rejoin nodes, provide read-index routing, or route multiple groups.
+rejoin nodes, follower read routing, lease reads, or route multiple groups.
 
 ## Scope
 
@@ -182,8 +182,14 @@ log coverage or translate the proof to the latest TreeDB command index at or
 below the proof; it must not assume the FSM's last applied TreeDB command index
 is identical to the provider's latest applied Raft log index.
 
-This is only a contract. It does not implement a real Raft read-index provider,
-leader transfer handling, lease reads, follower reads, or production routing.
+`HashicorpRaftProvider.ReadIndex` implements the first production leader-local
+provider for this contract. It uses HashiCorp Raft leader/quorum evidence,
+checks the committed prefix has the current term, scans command-free gaps, and
+waits for TreeDB applied progress before returning
+`ReadIndexEvidenceProduction`. It fails closed on follower state, leadership
+loss, target mismatch, missing applied progress, or missing log evidence. This
+does not add leader transfer handling, lease reads, follower reads, or
+production routing.
 
 `raftharness.ReadIndexProvider` is the in-process test adapter for this
 contract. It derives read-index proofs from an injected committed-entry log so
@@ -267,7 +273,8 @@ unreachable.
 
 - no bespoke consensus implementation beyond the narrow HashiCorp Raft adapter;
 - no leader transfer, redirect handling, or lease reads;
-- no real read-index provider, lease-read provider, or follower read routing;
+- no lease-read provider, follower read routing, or read-index routing beyond
+  the leader-local `HashicorpRaftProvider.ReadIndex` proof;
 - no production snapshot transfer/install beyond metadata contracts and injected
   harness evidence; `HashicorpRaftProvider` snapshots currently fail closed;
 - no Raft log truncation;

--- a/TreeDB/internal/raftcluster/hashicorp_raft.go
+++ b/TreeDB/internal/raftcluster/hashicorp_raft.go
@@ -204,36 +204,35 @@ func (p *HashicorpRaftProvider) ReadIndex(ctx context.Context, target ReadIndexB
 	if err := p.requireHashicorpReadIndexLeader(); err != nil {
 		return ReadIndexProof{}, err
 	}
+	if _, err := p.readIndexAppliedProgress(ctx); err != nil {
+		return ReadIndexProof{}, err
+	}
+	if err := p.requireHashicorpReadIndexLeader(); err != nil {
+		return ReadIndexProof{}, err
+	}
 	if err := waitHashicorpRaftFuture(ctx, p.raft.VerifyLeader()); err != nil {
 		return ReadIndexProof{}, p.mapHashicorpRaftReadIndexError(err)
 	}
 	if err := p.requireHashicorpReadIndexLeader(); err != nil {
 		return ReadIndexProof{}, err
 	}
-	if err := waitHashicorpRaftFuture(ctx, p.raft.Barrier(p.applyTimeout)); err != nil {
-		return ReadIndexProof{}, p.mapHashicorpRaftReadIndexError(err)
-	}
-	if err := p.requireHashicorpReadIndexLeader(); err != nil {
+	readCommitIndex := p.raft.CommitIndex()
+	if err := p.waitHashicorpAppliedIndex(ctx, readCommitIndex); err != nil {
 		return ReadIndexProof{}, err
 	}
-	if p.appliedProgress == nil {
-		return ReadIndexProof{}, fmt.Errorf("%w: applied progress reader is not configured", ErrReadBarrierNotSatisfied)
-	}
-	progress, err := p.appliedProgress.AppliedProgress(ctx)
+	progress, err := p.readIndexAppliedProgress(ctx)
 	if err != nil {
-		return ReadIndexProof{}, err
-	}
-	if err := p.validateReadIndexAppliedProgress(progress); err != nil {
 		return ReadIndexProof{}, err
 	}
 	if err := p.requireHashicorpReadIndexLeader(); err != nil {
 		return ReadIndexProof{}, err
 	}
 	// HashiCorp Raft v1.7 has no native ReadIndex API. VerifyLeader sends an
-	// immediate heartbeat to voting peers and Barrier waits until preceding
-	// Raft logs have reached the local FSM. HashiCorp no-op/barrier indexes are
-	// not recorded by TreeDB's FSM, so the proof index is the latest TreeDB
-	// command index the applied-index waiter can actually prove.
+	// immediate heartbeat to voting peers; CommitIndex then captures the
+	// leader's committed prefix for that quorum-verified point. Wait for the
+	// local HashiCorp FSM to receive that prefix without appending LogBarrier
+	// entries, then return the latest TreeDB command index the applied-index
+	// waiter can actually prove.
 	proof := ReadIndexProof{
 		NodeID:       p.cluster.NodeID,
 		GroupID:      p.cluster.GroupID,
@@ -246,6 +245,61 @@ func (p *HashicorpRaftProvider) ReadIndex(ctx context.Context, target ReadIndexB
 		return ReadIndexProof{}, err
 	}
 	return proof, nil
+}
+
+func (p *HashicorpRaftProvider) readIndexAppliedProgress(ctx context.Context) (AppliedProgress, error) {
+	if p == nil {
+		return AppliedProgress{}, ErrInvalidHashicorpRaftProvider
+	}
+	if p.appliedProgress == nil {
+		return AppliedProgress{}, fmt.Errorf("%w: applied progress reader is not configured", ErrReadBarrierNotSatisfied)
+	}
+	progress, err := p.appliedProgress.AppliedProgress(ctx)
+	if err != nil {
+		return AppliedProgress{}, err
+	}
+	if err := p.validateReadIndexAppliedProgress(progress); err != nil {
+		return AppliedProgress{}, err
+	}
+	return progress, nil
+}
+
+func (p *HashicorpRaftProvider) waitHashicorpAppliedIndex(ctx context.Context, minIndex uint64) error {
+	if p == nil || p.raft == nil {
+		return ErrInvalidHashicorpRaftProvider
+	}
+	if err := p.requireHashicorpReadIndexLeader(); err != nil {
+		return err
+	}
+	if minIndex == 0 || p.raft.AppliedIndex() >= minIndex {
+		return nil
+	}
+	timeout := p.applyTimeout
+	if timeout <= 0 {
+		timeout = hashicorpRaftDefaultApplyTimeout
+	}
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	ticker := time.NewTicker(time.Millisecond)
+	defer ticker.Stop()
+	for {
+		if err := p.requireHashicorpReadIndexLeader(); err != nil {
+			return err
+		}
+		if p.raft.AppliedIndex() >= minIndex {
+			return nil
+		}
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-timer.C:
+			return fmt.Errorf("%w: hashicorp raft applied index %d below read-index commit index %d", ErrReadBarrierNotSatisfied, p.raft.AppliedIndex(), minIndex)
+		case <-ticker.C:
+		}
+	}
 }
 
 func (p *HashicorpRaftProvider) requireHashicorpReadIndexLeader() error {

--- a/TreeDB/internal/raftcluster/hashicorp_raft.go
+++ b/TreeDB/internal/raftcluster/hashicorp_raft.go
@@ -417,7 +417,10 @@ func (p *HashicorpRaftProvider) readIndexCommitIndexHasCurrentTerm(commitIndex, 
 	}
 	var entry hraft.Log
 	if err := p.logStore.GetLog(commitIndex, &entry); err != nil {
-		return false, fmt.Errorf("%w: unable to inspect committed raft log %d for read-index term gate: %v", ErrReadBarrierNotSatisfied, commitIndex, err)
+		return false, errors.Join(
+			ErrReadBarrierNotSatisfied,
+			fmt.Errorf("unable to inspect committed raft log %d for read-index term gate: %w", commitIndex, err),
+		)
 	}
 	if entry.Term > term {
 		return false, fmt.Errorf("%w: committed raft log %d has future term %d above current term %d", ErrReadBarrierNotSatisfied, commitIndex, entry.Term, term)

--- a/TreeDB/internal/raftcluster/hashicorp_raft.go
+++ b/TreeDB/internal/raftcluster/hashicorp_raft.go
@@ -418,13 +418,19 @@ func (p *HashicorpRaftProvider) readIndexGapHasNoCommands(firstIndex, lastIndex 
 		return false, 0, fmt.Errorf("%w: hashicorp raft log store is not configured", ErrReadBarrierNotSatisfied)
 	}
 	var entry hraft.Log
-	for index := firstIndex; index <= lastIndex; index++ {
+	for index := firstIndex; ; index++ {
 		entry = hraft.Log{}
 		if err := p.logStore.GetLog(index, &entry); err != nil {
-			return false, 0, fmt.Errorf("%w: unable to inspect committed raft log %d for read-index gap: %v", ErrReadBarrierNotSatisfied, index, err)
+			return false, 0, errors.Join(
+				ErrReadBarrierNotSatisfied,
+				fmt.Errorf("unable to inspect committed raft log %d for read-index gap: %w", index, err),
+			)
 		}
 		if entry.Type == hraft.LogCommand {
 			return false, index, nil
+		}
+		if index == lastIndex {
+			break
 		}
 	}
 	return true, 0, nil

--- a/TreeDB/internal/raftcluster/hashicorp_raft.go
+++ b/TreeDB/internal/raftcluster/hashicorp_raft.go
@@ -285,7 +285,7 @@ func (p *HashicorpRaftProvider) waitTreeDBAppliedReadPrefix(ctx context.Context,
 	if minIndex == 0 || progress.Index >= minIndex {
 		return progress, nil
 	}
-	noCommands, err := p.readIndexGapHasNoCommands(progress.Index+1, minIndex)
+	noCommands, firstCmd, err := p.readIndexGapHasNoCommands(progress.Index+1, minIndex)
 	if err != nil {
 		return AppliedProgress{}, err
 	}
@@ -299,13 +299,15 @@ func (p *HashicorpRaftProvider) waitTreeDBAppliedReadPrefix(ctx context.Context,
 	timer := time.NewTimer(timeout)
 	defer timer.Stop()
 	delay := hashicorpRaftReadIndexInitialPoll
+	pollTimer := time.NewTimer(delay)
+	defer pollTimer.Stop()
 	for {
 		select {
 		case <-ctx.Done():
 			return AppliedProgress{}, ctx.Err()
 		case <-timer.C:
 			return AppliedProgress{}, fmt.Errorf("%w: TreeDB applied index %d below read-index commit prefix %d", ErrReadBarrierNotSatisfied, progress.Index, minIndex)
-		case <-time.After(delay):
+		case <-pollTimer.C:
 		}
 		if delay < hashicorpRaftReadIndexMaxPoll {
 			delay *= 2
@@ -313,6 +315,7 @@ func (p *HashicorpRaftProvider) waitTreeDBAppliedReadPrefix(ctx context.Context,
 				delay = hashicorpRaftReadIndexMaxPoll
 			}
 		}
+		pollTimer.Reset(delay)
 		if err := p.requireHashicorpReadIndexLeader(); err != nil {
 			return AppliedProgress{}, err
 		}
@@ -323,7 +326,12 @@ func (p *HashicorpRaftProvider) waitTreeDBAppliedReadPrefix(ctx context.Context,
 		if progress.Index >= minIndex {
 			return progress, nil
 		}
-		noCommands, err = p.readIndexGapHasNoCommands(progress.Index+1, minIndex)
+		// Skip the gap rescan if the previously found command is still ahead of
+		// applied progress: the gap still has commands and no log I/O is needed.
+		if firstCmd != 0 && progress.Index < firstCmd {
+			continue
+		}
+		noCommands, firstCmd, err = p.readIndexGapHasNoCommands(progress.Index+1, minIndex)
 		if err != nil {
 			return AppliedProgress{}, err
 		}
@@ -344,6 +352,8 @@ func (p *HashicorpRaftProvider) waitHashicorpReadIndexCurrentTermCommit(ctx cont
 	timer := time.NewTimer(timeout)
 	defer timer.Stop()
 	delay := hashicorpRaftReadIndexInitialPoll
+	pollTimer := time.NewTimer(delay)
+	defer pollTimer.Stop()
 	for {
 		if err := p.requireHashicorpReadIndexLeader(); err != nil {
 			return 0, 0, err
@@ -362,7 +372,7 @@ func (p *HashicorpRaftProvider) waitHashicorpReadIndexCurrentTermCommit(ctx cont
 			return 0, 0, ctx.Err()
 		case <-timer.C:
 			return 0, 0, fmt.Errorf("%w: leader term %d has no committed read-index prefix at commit index %d", ErrReadBarrierNotSatisfied, term, commitIndex)
-		case <-time.After(delay):
+		case <-pollTimer.C:
 		}
 		if delay < hashicorpRaftReadIndexMaxPoll {
 			delay *= 2
@@ -370,6 +380,7 @@ func (p *HashicorpRaftProvider) waitHashicorpReadIndexCurrentTermCommit(ctx cont
 				delay = hashicorpRaftReadIndexMaxPoll
 			}
 		}
+		pollTimer.Reset(delay)
 	}
 }
 
@@ -393,30 +404,30 @@ func (p *HashicorpRaftProvider) readIndexCommitIndexHasCurrentTerm(commitIndex, 
 	return entry.Term == term, nil
 }
 
-func (p *HashicorpRaftProvider) readIndexGapHasNoCommands(firstIndex, lastIndex uint64) (bool, error) {
+func (p *HashicorpRaftProvider) readIndexGapHasNoCommands(firstIndex, lastIndex uint64) (bool, uint64, error) {
 	if p == nil {
-		return false, ErrInvalidHashicorpRaftProvider
+		return false, 0, ErrInvalidHashicorpRaftProvider
 	}
 	if firstIndex == 0 {
 		firstIndex = 1
 	}
 	if lastIndex < firstIndex {
-		return true, nil
+		return true, 0, nil
 	}
 	if p.logStore == nil {
-		return false, fmt.Errorf("%w: hashicorp raft log store is not configured", ErrReadBarrierNotSatisfied)
+		return false, 0, fmt.Errorf("%w: hashicorp raft log store is not configured", ErrReadBarrierNotSatisfied)
 	}
 	var entry hraft.Log
 	for index := firstIndex; index <= lastIndex; index++ {
 		entry = hraft.Log{}
 		if err := p.logStore.GetLog(index, &entry); err != nil {
-			return false, fmt.Errorf("%w: unable to inspect committed raft log %d for read-index gap: %v", ErrReadBarrierNotSatisfied, index, err)
+			return false, 0, fmt.Errorf("%w: unable to inspect committed raft log %d for read-index gap: %v", ErrReadBarrierNotSatisfied, index, err)
 		}
 		if entry.Type == hraft.LogCommand {
-			return false, nil
+			return false, index, nil
 		}
 	}
-	return true, nil
+	return true, 0, nil
 }
 
 func (p *HashicorpRaftProvider) requireHashicorpReadIndexLeader() error {

--- a/TreeDB/internal/raftcluster/hashicorp_raft.go
+++ b/TreeDB/internal/raftcluster/hashicorp_raft.go
@@ -204,6 +204,12 @@ func (p *HashicorpRaftProvider) ReadIndex(ctx context.Context, target ReadIndexB
 	if err := waitHashicorpRaftFuture(ctx, p.raft.VerifyLeader()); err != nil {
 		return ReadIndexProof{}, p.mapHashicorpRaftReadIndexError(err)
 	}
+	if state := p.raft.State(); state != hraft.Leader {
+		return ReadIndexProof{}, p.hashicorpReadIndexNotLeader(state)
+	}
+	// HashiCorp Raft v1.7 has no native ReadIndex API. VerifyLeader sends an
+	// immediate heartbeat to voting peers; CommitIndex is the local barrier
+	// index the applied-index waiter must reach before the read is served.
 	proof := ReadIndexProof{
 		NodeID:       p.cluster.NodeID,
 		GroupID:      p.cluster.GroupID,

--- a/TreeDB/internal/raftcluster/hashicorp_raft.go
+++ b/TreeDB/internal/raftcluster/hashicorp_raft.go
@@ -300,7 +300,11 @@ func (p *HashicorpRaftProvider) waitTreeDBAppliedReadPrefix(ctx context.Context,
 	if progress.HasApplied && progress.Index != 0 && (minIndex == 0 || progress.Index >= minIndex) {
 		return progress, nil
 	}
-	noCommands, firstCmd, err := p.readIndexGapHasNoCommands(progress.Index+1, minIndex)
+	firstIndex, err := readIndexGapFirstIndexAfterApplied(progress.Index)
+	if err != nil {
+		return AppliedProgress{}, err
+	}
+	noCommands, firstCmd, err := p.readIndexGapHasNoCommands(firstIndex, minIndex)
 	if err != nil {
 		return AppliedProgress{}, err
 	}
@@ -349,7 +353,11 @@ func (p *HashicorpRaftProvider) waitTreeDBAppliedReadPrefix(ctx context.Context,
 		if firstCmd != 0 && progress.Index < firstCmd {
 			continue
 		}
-		noCommands, firstCmd, err = p.readIndexGapHasNoCommands(progress.Index+1, minIndex)
+		firstIndex, err := readIndexGapFirstIndexAfterApplied(progress.Index)
+		if err != nil {
+			return AppliedProgress{}, err
+		}
+		noCommands, firstCmd, err = p.readIndexGapHasNoCommands(firstIndex, minIndex)
 		if err != nil {
 			return AppliedProgress{}, err
 		}
@@ -426,6 +434,13 @@ func (p *HashicorpRaftProvider) readIndexCommitIndexHasCurrentTerm(commitIndex, 
 		return false, fmt.Errorf("%w: committed raft log %d has future term %d above current term %d", ErrReadBarrierNotSatisfied, commitIndex, entry.Term, term)
 	}
 	return entry.Term == term, nil
+}
+
+func readIndexGapFirstIndexAfterApplied(appliedIndex uint64) (uint64, error) {
+	if appliedIndex == ^uint64(0) {
+		return 0, fmt.Errorf("%w: applied raft index %d cannot advance read-index gap scan", ErrReadBarrierNotSatisfied, appliedIndex)
+	}
+	return appliedIndex + 1, nil
 }
 
 func (p *HashicorpRaftProvider) readIndexGapHasNoCommands(firstIndex, lastIndex uint64) (bool, uint64, error) {

--- a/TreeDB/internal/raftcluster/hashicorp_raft.go
+++ b/TreeDB/internal/raftcluster/hashicorp_raft.go
@@ -21,6 +21,8 @@ const (
 	hashicorpRaftDefaultApplyTimeout   = 5 * time.Second
 	hashicorpRaftDefaultSnapshotRetain = 2
 	hashicorpRaftSnapshotCheckInterval = 24 * time.Hour
+	hashicorpRaftReadIndexInitialPoll  = 2 * time.Millisecond
+	hashicorpRaftReadIndexMaxPoll      = 25 * time.Millisecond
 )
 
 var (
@@ -60,6 +62,7 @@ type HashicorpRaftProviderOptions struct {
 type HashicorpRaftProvider struct {
 	cluster         ResolvedConfig
 	raft            *hraft.Raft
+	logStore        hraft.LogStore
 	appliedProgress AppliedProgressReader
 	applyTimeout    time.Duration
 	owned           []io.Closer
@@ -128,6 +131,7 @@ func OpenHashicorpRaftProvider(opts HashicorpRaftProviderOptions) (*HashicorpRaf
 	return &HashicorpRaftProvider{
 		cluster:         cluster,
 		raft:            r,
+		logStore:        stores.log,
 		appliedProgress: progressReader,
 		applyTimeout:    applyTimeout,
 		owned:           stores.owned,
@@ -217,10 +221,7 @@ func (p *HashicorpRaftProvider) ReadIndex(ctx context.Context, target ReadIndexB
 		return ReadIndexProof{}, err
 	}
 	readCommitIndex := p.raft.CommitIndex()
-	if err := p.waitHashicorpAppliedIndex(ctx, readCommitIndex); err != nil {
-		return ReadIndexProof{}, err
-	}
-	progress, err := p.readIndexAppliedProgress(ctx)
+	progress, err := p.waitTreeDBAppliedReadPrefix(ctx, readCommitIndex)
 	if err != nil {
 		return ReadIndexProof{}, err
 	}
@@ -230,9 +231,10 @@ func (p *HashicorpRaftProvider) ReadIndex(ctx context.Context, target ReadIndexB
 	// HashiCorp Raft v1.7 has no native ReadIndex API. VerifyLeader sends an
 	// immediate heartbeat to voting peers; CommitIndex then captures the
 	// leader's committed prefix for that quorum-verified point. Wait for the
-	// local HashiCorp FSM to receive that prefix without appending LogBarrier
-	// entries, then return the latest TreeDB command index the applied-index
-	// waiter can actually prove.
+	// local TreeDB applier to consume command entries in that prefix without
+	// appending LogBarrier entries. If TreeDB applied progress is behind, the
+	// provider inspects the committed log gap and accepts only command-free gaps
+	// (no-op/configuration/barrier entries do not mutate TreeDB state).
 	proof := ReadIndexProof{
 		NodeID:       p.cluster.NodeID,
 		GroupID:      p.cluster.GroupID,
@@ -264,15 +266,26 @@ func (p *HashicorpRaftProvider) readIndexAppliedProgress(ctx context.Context) (A
 	return progress, nil
 }
 
-func (p *HashicorpRaftProvider) waitHashicorpAppliedIndex(ctx context.Context, minIndex uint64) error {
+func (p *HashicorpRaftProvider) waitTreeDBAppliedReadPrefix(ctx context.Context, minIndex uint64) (AppliedProgress, error) {
 	if p == nil || p.raft == nil {
-		return ErrInvalidHashicorpRaftProvider
+		return AppliedProgress{}, ErrInvalidHashicorpRaftProvider
 	}
 	if err := p.requireHashicorpReadIndexLeader(); err != nil {
-		return err
+		return AppliedProgress{}, err
 	}
-	if minIndex == 0 || p.raft.AppliedIndex() >= minIndex {
-		return nil
+	progress, err := p.readIndexAppliedProgress(ctx)
+	if err != nil {
+		return AppliedProgress{}, err
+	}
+	if minIndex == 0 || progress.Index >= minIndex {
+		return progress, nil
+	}
+	noCommands, err := p.readIndexGapHasNoCommands(progress.Index+1, minIndex)
+	if err != nil {
+		return AppliedProgress{}, err
+	}
+	if noCommands {
+		return progress, nil
 	}
 	timeout := p.applyTimeout
 	if timeout <= 0 {
@@ -280,26 +293,65 @@ func (p *HashicorpRaftProvider) waitHashicorpAppliedIndex(ctx context.Context, m
 	}
 	timer := time.NewTimer(timeout)
 	defer timer.Stop()
-	ticker := time.NewTicker(time.Millisecond)
-	defer ticker.Stop()
+	delay := hashicorpRaftReadIndexInitialPoll
 	for {
-		if err := p.requireHashicorpReadIndexLeader(); err != nil {
-			return err
-		}
-		if p.raft.AppliedIndex() >= minIndex {
-			return nil
-		}
-		if err := ctx.Err(); err != nil {
-			return err
-		}
 		select {
 		case <-ctx.Done():
-			return ctx.Err()
+			return AppliedProgress{}, ctx.Err()
 		case <-timer.C:
-			return fmt.Errorf("%w: hashicorp raft applied index %d below read-index commit index %d", ErrReadBarrierNotSatisfied, p.raft.AppliedIndex(), minIndex)
-		case <-ticker.C:
+			return AppliedProgress{}, fmt.Errorf("%w: TreeDB applied index %d below read-index commit prefix %d", ErrReadBarrierNotSatisfied, progress.Index, minIndex)
+		case <-time.After(delay):
+		}
+		if delay < hashicorpRaftReadIndexMaxPoll {
+			delay *= 2
+			if delay > hashicorpRaftReadIndexMaxPoll {
+				delay = hashicorpRaftReadIndexMaxPoll
+			}
+		}
+		if err := p.requireHashicorpReadIndexLeader(); err != nil {
+			return AppliedProgress{}, err
+		}
+		progress, err = p.readIndexAppliedProgress(ctx)
+		if err != nil {
+			return AppliedProgress{}, err
+		}
+		if progress.Index >= minIndex {
+			return progress, nil
+		}
+		noCommands, err = p.readIndexGapHasNoCommands(progress.Index+1, minIndex)
+		if err != nil {
+			return AppliedProgress{}, err
+		}
+		if noCommands {
+			return progress, nil
 		}
 	}
+}
+
+func (p *HashicorpRaftProvider) readIndexGapHasNoCommands(firstIndex, lastIndex uint64) (bool, error) {
+	if p == nil {
+		return false, ErrInvalidHashicorpRaftProvider
+	}
+	if firstIndex == 0 {
+		firstIndex = 1
+	}
+	if lastIndex < firstIndex {
+		return true, nil
+	}
+	if p.logStore == nil {
+		return false, fmt.Errorf("%w: hashicorp raft log store is not configured", ErrReadBarrierNotSatisfied)
+	}
+	var entry hraft.Log
+	for index := firstIndex; index <= lastIndex; index++ {
+		entry = hraft.Log{}
+		if err := p.logStore.GetLog(index, &entry); err != nil {
+			return false, fmt.Errorf("%w: unable to inspect committed raft log %d for read-index gap: %v", ErrReadBarrierNotSatisfied, index, err)
+		}
+		if entry.Type == hraft.LogCommand {
+			return false, nil
+		}
+	}
+	return true, nil
 }
 
 func (p *HashicorpRaftProvider) requireHashicorpReadIndexLeader() error {

--- a/TreeDB/internal/raftcluster/hashicorp_raft.go
+++ b/TreeDB/internal/raftcluster/hashicorp_raft.go
@@ -220,25 +220,30 @@ func (p *HashicorpRaftProvider) ReadIndex(ctx context.Context, target ReadIndexB
 	if err := p.requireHashicorpReadIndexLeader(); err != nil {
 		return ReadIndexProof{}, err
 	}
-	readCommitIndex := p.raft.CommitIndex()
+	readTerm, readCommitIndex, err := p.waitHashicorpReadIndexCurrentTermCommit(ctx)
+	if err != nil {
+		return ReadIndexProof{}, err
+	}
 	progress, err := p.waitTreeDBAppliedReadPrefix(ctx, readCommitIndex)
 	if err != nil {
 		return ReadIndexProof{}, err
 	}
-	if err := p.requireHashicorpReadIndexLeader(); err != nil {
+	if err := p.requireHashicorpReadIndexLeaderTerm(readTerm); err != nil {
 		return ReadIndexProof{}, err
 	}
 	// HashiCorp Raft v1.7 has no native ReadIndex API. VerifyLeader sends an
-	// immediate heartbeat to voting peers; CommitIndex then captures the
-	// leader's committed prefix for that quorum-verified point. Wait for the
-	// local TreeDB applier to consume command entries in that prefix without
-	// appending LogBarrier entries. If TreeDB applied progress is behind, the
-	// provider inspects the committed log gap and accepts only command-free gaps
-	// (no-op/configuration/barrier entries do not mutate TreeDB state).
+	// immediate heartbeat to voting peers. Before trusting CommitIndex, wait for
+	// the leader's startup no-op/current-term entry to be committed; otherwise a
+	// newly elected leader can under-report the committed prefix learned from the
+	// previous term. Then wait for the local TreeDB applier to consume command
+	// entries in that prefix without appending LogBarrier entries. If TreeDB
+	// applied progress is behind, the provider inspects the committed log gap and
+	// accepts only command-free gaps (no-op/configuration/barrier entries do not
+	// mutate TreeDB state).
 	proof := ReadIndexProof{
 		NodeID:       p.cluster.NodeID,
 		GroupID:      p.cluster.GroupID,
-		Term:         p.raft.CurrentTerm(),
+		Term:         readTerm,
 		Index:        progress.Index,
 		HasQuorum:    true,
 		EvidenceKind: ReadIndexEvidenceProduction,
@@ -328,6 +333,66 @@ func (p *HashicorpRaftProvider) waitTreeDBAppliedReadPrefix(ctx context.Context,
 	}
 }
 
+func (p *HashicorpRaftProvider) waitHashicorpReadIndexCurrentTermCommit(ctx context.Context) (uint64, uint64, error) {
+	if p == nil || p.raft == nil {
+		return 0, 0, ErrInvalidHashicorpRaftProvider
+	}
+	timeout := p.applyTimeout
+	if timeout <= 0 {
+		timeout = hashicorpRaftDefaultApplyTimeout
+	}
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	delay := hashicorpRaftReadIndexInitialPoll
+	for {
+		if err := p.requireHashicorpReadIndexLeader(); err != nil {
+			return 0, 0, err
+		}
+		term := p.raft.CurrentTerm()
+		commitIndex := p.raft.CommitIndex()
+		ok, err := p.readIndexCommitIndexHasCurrentTerm(commitIndex, term)
+		if err != nil {
+			return 0, 0, err
+		}
+		if ok {
+			return term, commitIndex, nil
+		}
+		select {
+		case <-ctx.Done():
+			return 0, 0, ctx.Err()
+		case <-timer.C:
+			return 0, 0, fmt.Errorf("%w: leader term %d has no committed read-index prefix at commit index %d", ErrReadBarrierNotSatisfied, term, commitIndex)
+		case <-time.After(delay):
+		}
+		if delay < hashicorpRaftReadIndexMaxPoll {
+			delay *= 2
+			if delay > hashicorpRaftReadIndexMaxPoll {
+				delay = hashicorpRaftReadIndexMaxPoll
+			}
+		}
+	}
+}
+
+func (p *HashicorpRaftProvider) readIndexCommitIndexHasCurrentTerm(commitIndex, term uint64) (bool, error) {
+	if p == nil {
+		return false, ErrInvalidHashicorpRaftProvider
+	}
+	if commitIndex == 0 || term == 0 {
+		return false, nil
+	}
+	if p.logStore == nil {
+		return false, fmt.Errorf("%w: hashicorp raft log store is not configured", ErrReadBarrierNotSatisfied)
+	}
+	var entry hraft.Log
+	if err := p.logStore.GetLog(commitIndex, &entry); err != nil {
+		return false, fmt.Errorf("%w: unable to inspect committed raft log %d for read-index term gate: %v", ErrReadBarrierNotSatisfied, commitIndex, err)
+	}
+	if entry.Term > term {
+		return false, fmt.Errorf("%w: committed raft log %d has future term %d above current term %d", ErrReadBarrierNotSatisfied, commitIndex, entry.Term, term)
+	}
+	return entry.Term == term, nil
+}
+
 func (p *HashicorpRaftProvider) readIndexGapHasNoCommands(firstIndex, lastIndex uint64) (bool, error) {
 	if p == nil {
 		return false, ErrInvalidHashicorpRaftProvider
@@ -360,6 +425,16 @@ func (p *HashicorpRaftProvider) requireHashicorpReadIndexLeader() error {
 	}
 	if state := p.raft.State(); state != hraft.Leader {
 		return p.hashicorpReadIndexNotLeader(state)
+	}
+	return nil
+}
+
+func (p *HashicorpRaftProvider) requireHashicorpReadIndexLeaderTerm(term uint64) error {
+	if err := p.requireHashicorpReadIndexLeader(); err != nil {
+		return err
+	}
+	if got := p.raft.CurrentTerm(); got != term {
+		return fmt.Errorf("%w: read-index leader term changed from %d to %d before proof", ErrReadBarrierNotSatisfied, term, got)
 	}
 	return nil
 }

--- a/TreeDB/internal/raftcluster/hashicorp_raft.go
+++ b/TreeDB/internal/raftcluster/hashicorp_raft.go
@@ -201,17 +201,20 @@ func (p *HashicorpRaftProvider) ReadIndex(ctx context.Context, target ReadIndexB
 	if err := ctx.Err(); err != nil {
 		return ReadIndexProof{}, err
 	}
-	if state := p.raft.State(); state != hraft.Leader {
-		return ReadIndexProof{}, p.hashicorpReadIndexNotLeader(state)
+	if err := p.requireHashicorpReadIndexLeader(); err != nil {
+		return ReadIndexProof{}, err
 	}
 	if err := waitHashicorpRaftFuture(ctx, p.raft.VerifyLeader()); err != nil {
 		return ReadIndexProof{}, p.mapHashicorpRaftReadIndexError(err)
 	}
-	if state := p.raft.State(); state != hraft.Leader {
-		return ReadIndexProof{}, p.hashicorpReadIndexNotLeader(state)
+	if err := p.requireHashicorpReadIndexLeader(); err != nil {
+		return ReadIndexProof{}, err
 	}
 	if err := waitHashicorpRaftFuture(ctx, p.raft.Barrier(p.applyTimeout)); err != nil {
 		return ReadIndexProof{}, p.mapHashicorpRaftReadIndexError(err)
+	}
+	if err := p.requireHashicorpReadIndexLeader(); err != nil {
+		return ReadIndexProof{}, err
 	}
 	if p.appliedProgress == nil {
 		return ReadIndexProof{}, fmt.Errorf("%w: applied progress reader is not configured", ErrReadBarrierNotSatisfied)
@@ -220,8 +223,11 @@ func (p *HashicorpRaftProvider) ReadIndex(ctx context.Context, target ReadIndexB
 	if err != nil {
 		return ReadIndexProof{}, err
 	}
-	if !progress.HasApplied {
-		return ReadIndexProof{}, fmt.Errorf("%w: no applied TreeDB command index", ErrReadBarrierNotSatisfied)
+	if err := p.validateReadIndexAppliedProgress(progress); err != nil {
+		return ReadIndexProof{}, err
+	}
+	if err := p.requireHashicorpReadIndexLeader(); err != nil {
+		return ReadIndexProof{}, err
 	}
 	// HashiCorp Raft v1.7 has no native ReadIndex API. VerifyLeader sends an
 	// immediate heartbeat to voting peers and Barrier waits until preceding
@@ -240,6 +246,32 @@ func (p *HashicorpRaftProvider) ReadIndex(ctx context.Context, target ReadIndexB
 		return ReadIndexProof{}, err
 	}
 	return proof, nil
+}
+
+func (p *HashicorpRaftProvider) requireHashicorpReadIndexLeader() error {
+	if p == nil || p.raft == nil {
+		return ErrInvalidHashicorpRaftProvider
+	}
+	if state := p.raft.State(); state != hraft.Leader {
+		return p.hashicorpReadIndexNotLeader(state)
+	}
+	return nil
+}
+
+func (p *HashicorpRaftProvider) validateReadIndexAppliedProgress(progress AppliedProgress) error {
+	if p == nil {
+		return ErrInvalidHashicorpRaftProvider
+	}
+	if progress.NodeID != p.cluster.NodeID {
+		return fmt.Errorf("%w: applied progress node %q does not match local node %q", ErrReadBarrierTargetMismatch, progress.NodeID, p.cluster.NodeID)
+	}
+	if progress.GroupID != p.cluster.GroupID {
+		return fmt.Errorf("%w: applied progress group %q does not match local group %q", ErrReadBarrierTargetMismatch, progress.GroupID, p.cluster.GroupID)
+	}
+	if !progress.HasApplied || progress.Index == 0 {
+		return fmt.Errorf("%w: no applied TreeDB command index", ErrReadBarrierNotSatisfied)
+	}
+	return nil
 }
 
 func (p *HashicorpRaftProvider) CommitCommandEntryV1(ctx context.Context, req CommitCommandEntryV1Request) (CommitCommandEntryV1Result, error) {

--- a/TreeDB/internal/raftcluster/hashicorp_raft.go
+++ b/TreeDB/internal/raftcluster/hashicorp_raft.go
@@ -208,12 +208,6 @@ func (p *HashicorpRaftProvider) ReadIndex(ctx context.Context, target ReadIndexB
 	if err := p.requireHashicorpReadIndexLeader(); err != nil {
 		return ReadIndexProof{}, err
 	}
-	if _, err := p.readIndexAppliedProgress(ctx); err != nil {
-		return ReadIndexProof{}, err
-	}
-	if err := p.requireHashicorpReadIndexLeader(); err != nil {
-		return ReadIndexProof{}, err
-	}
 	if err := waitHashicorpRaftFuture(ctx, p.raft.VerifyLeader()); err != nil {
 		return ReadIndexProof{}, p.mapHashicorpRaftReadIndexError(err)
 	}
@@ -271,6 +265,27 @@ func (p *HashicorpRaftProvider) readIndexAppliedProgress(ctx context.Context) (A
 	return progress, nil
 }
 
+func (p *HashicorpRaftProvider) readIndexAppliedProgressSnapshot(ctx context.Context) (AppliedProgress, error) {
+	if p == nil {
+		return AppliedProgress{}, ErrInvalidHashicorpRaftProvider
+	}
+	if p.appliedProgress == nil {
+		return AppliedProgress{}, fmt.Errorf("%w: applied progress reader is not configured", ErrReadBarrierNotSatisfied)
+	}
+	progress, err := p.appliedProgress.AppliedProgress(ctx)
+	if err != nil {
+		return AppliedProgress{}, err
+	}
+	if err := p.validateReadIndexAppliedProgressIdentity(progress); err != nil {
+		return AppliedProgress{}, err
+	}
+	if !progress.HasApplied {
+		progress.Index = 0
+		progress.Term = 0
+	}
+	return progress, nil
+}
+
 func (p *HashicorpRaftProvider) waitTreeDBAppliedReadPrefix(ctx context.Context, minIndex uint64) (AppliedProgress, error) {
 	if p == nil || p.raft == nil {
 		return AppliedProgress{}, ErrInvalidHashicorpRaftProvider
@@ -278,11 +293,11 @@ func (p *HashicorpRaftProvider) waitTreeDBAppliedReadPrefix(ctx context.Context,
 	if err := p.requireHashicorpReadIndexLeader(); err != nil {
 		return AppliedProgress{}, err
 	}
-	progress, err := p.readIndexAppliedProgress(ctx)
+	progress, err := p.readIndexAppliedProgressSnapshot(ctx)
 	if err != nil {
 		return AppliedProgress{}, err
 	}
-	if minIndex == 0 || progress.Index >= minIndex {
+	if progress.HasApplied && progress.Index != 0 && (minIndex == 0 || progress.Index >= minIndex) {
 		return progress, nil
 	}
 	noCommands, firstCmd, err := p.readIndexGapHasNoCommands(progress.Index+1, minIndex)
@@ -290,7 +305,10 @@ func (p *HashicorpRaftProvider) waitTreeDBAppliedReadPrefix(ctx context.Context,
 		return AppliedProgress{}, err
 	}
 	if noCommands {
-		return progress, nil
+		if progress.HasApplied && progress.Index != 0 {
+			return progress, nil
+		}
+		return AppliedProgress{}, fmt.Errorf("%w: no applied TreeDB command index", ErrReadBarrierNotSatisfied)
 	}
 	timeout := p.applyTimeout
 	if timeout <= 0 {
@@ -319,11 +337,11 @@ func (p *HashicorpRaftProvider) waitTreeDBAppliedReadPrefix(ctx context.Context,
 		if err := p.requireHashicorpReadIndexLeader(); err != nil {
 			return AppliedProgress{}, err
 		}
-		progress, err = p.readIndexAppliedProgress(ctx)
+		progress, err = p.readIndexAppliedProgressSnapshot(ctx)
 		if err != nil {
 			return AppliedProgress{}, err
 		}
-		if progress.Index >= minIndex {
+		if progress.HasApplied && progress.Index != 0 && progress.Index >= minIndex {
 			return progress, nil
 		}
 		// Skip the gap rescan if the previously found command is still ahead of
@@ -336,7 +354,10 @@ func (p *HashicorpRaftProvider) waitTreeDBAppliedReadPrefix(ctx context.Context,
 			return AppliedProgress{}, err
 		}
 		if noCommands {
-			return progress, nil
+			if progress.HasApplied && progress.Index != 0 {
+				return progress, nil
+			}
+			return AppliedProgress{}, fmt.Errorf("%w: no applied TreeDB command index", ErrReadBarrierNotSatisfied)
 		}
 	}
 }
@@ -460,14 +481,24 @@ func (p *HashicorpRaftProvider) validateReadIndexAppliedProgress(progress Applie
 	if p == nil {
 		return ErrInvalidHashicorpRaftProvider
 	}
+	if err := p.validateReadIndexAppliedProgressIdentity(progress); err != nil {
+		return err
+	}
+	if !progress.HasApplied || progress.Index == 0 {
+		return fmt.Errorf("%w: no applied TreeDB command index", ErrReadBarrierNotSatisfied)
+	}
+	return nil
+}
+
+func (p *HashicorpRaftProvider) validateReadIndexAppliedProgressIdentity(progress AppliedProgress) error {
+	if p == nil {
+		return ErrInvalidHashicorpRaftProvider
+	}
 	if progress.NodeID != p.cluster.NodeID {
 		return fmt.Errorf("%w: applied progress node %q does not match local node %q", ErrReadBarrierTargetMismatch, progress.NodeID, p.cluster.NodeID)
 	}
 	if progress.GroupID != p.cluster.GroupID {
 		return fmt.Errorf("%w: applied progress group %q does not match local group %q", ErrReadBarrierTargetMismatch, progress.GroupID, p.cluster.GroupID)
-	}
-	if !progress.HasApplied || progress.Index == 0 {
-		return fmt.Errorf("%w: no applied TreeDB command index", ErrReadBarrierNotSatisfied)
 	}
 	return nil
 }

--- a/TreeDB/internal/raftcluster/hashicorp_raft.go
+++ b/TreeDB/internal/raftcluster/hashicorp_raft.go
@@ -58,10 +58,11 @@ type HashicorpRaftProviderOptions struct {
 // ReadIndexProvider on top of github.com/hashicorp/raft for one TreeDB Raft
 // group.
 type HashicorpRaftProvider struct {
-	cluster      ResolvedConfig
-	raft         *hraft.Raft
-	applyTimeout time.Duration
-	owned        []io.Closer
+	cluster         ResolvedConfig
+	raft            *hraft.Raft
+	appliedProgress AppliedProgressReader
+	applyTimeout    time.Duration
+	owned           []io.Closer
 }
 
 func OpenHashicorpRaftProvider(opts HashicorpRaftProviderOptions) (*HashicorpRaftProvider, error) {
@@ -123,11 +124,13 @@ func OpenHashicorpRaftProvider(opts HashicorpRaftProviderOptions) (*HashicorpRaf
 	if applyTimeout <= 0 {
 		applyTimeout = hashicorpRaftDefaultApplyTimeout
 	}
+	progressReader, _ := opts.Applier.(AppliedProgressReader)
 	return &HashicorpRaftProvider{
-		cluster:      cluster,
-		raft:         r,
-		applyTimeout: applyTimeout,
-		owned:        stores.owned,
+		cluster:         cluster,
+		raft:            r,
+		appliedProgress: progressReader,
+		applyTimeout:    applyTimeout,
+		owned:           stores.owned,
 	}, nil
 }
 
@@ -207,14 +210,29 @@ func (p *HashicorpRaftProvider) ReadIndex(ctx context.Context, target ReadIndexB
 	if state := p.raft.State(); state != hraft.Leader {
 		return ReadIndexProof{}, p.hashicorpReadIndexNotLeader(state)
 	}
+	if err := waitHashicorpRaftFuture(ctx, p.raft.Barrier(p.applyTimeout)); err != nil {
+		return ReadIndexProof{}, p.mapHashicorpRaftReadIndexError(err)
+	}
+	if p.appliedProgress == nil {
+		return ReadIndexProof{}, fmt.Errorf("%w: applied progress reader is not configured", ErrReadBarrierNotSatisfied)
+	}
+	progress, err := p.appliedProgress.AppliedProgress(ctx)
+	if err != nil {
+		return ReadIndexProof{}, err
+	}
+	if !progress.HasApplied {
+		return ReadIndexProof{}, fmt.Errorf("%w: no applied TreeDB command index", ErrReadBarrierNotSatisfied)
+	}
 	// HashiCorp Raft v1.7 has no native ReadIndex API. VerifyLeader sends an
-	// immediate heartbeat to voting peers; CommitIndex is the local barrier
-	// index the applied-index waiter must reach before the read is served.
+	// immediate heartbeat to voting peers and Barrier waits until preceding
+	// Raft logs have reached the local FSM. HashiCorp no-op/barrier indexes are
+	// not recorded by TreeDB's FSM, so the proof index is the latest TreeDB
+	// command index the applied-index waiter can actually prove.
 	proof := ReadIndexProof{
 		NodeID:       p.cluster.NodeID,
 		GroupID:      p.cluster.GroupID,
 		Term:         p.raft.CurrentTerm(),
-		Index:        p.raft.CommitIndex(),
+		Index:        progress.Index,
 		HasQuorum:    true,
 		EvidenceKind: ReadIndexEvidenceProduction,
 	}
@@ -291,9 +309,9 @@ func (p *HashicorpRaftProvider) hashicorpReadIndexNotLeader(state hraft.RaftStat
 		}
 	}
 	if state == hraft.Shutdown {
-		return errors.Join(ErrHashicorpRaftUnavailable, fmt.Errorf("%s", reason))
+		return errors.Join(ErrHashicorpRaftUnavailable, errors.New(reason))
 	}
-	return errors.Join(ErrNotLeader, fmt.Errorf("%s", reason))
+	return errors.Join(ErrNotLeader, errors.New(reason))
 }
 
 func validateHashicorpRaftApplier(applier CommittedCommandApplierV1) error {

--- a/TreeDB/internal/raftcluster/hashicorp_raft.go
+++ b/TreeDB/internal/raftcluster/hashicorp_raft.go
@@ -54,8 +54,9 @@ type HashicorpRaftProviderOptions struct {
 	ApplyFailureHandler func(error)
 }
 
-// HashicorpRaftProvider implements AdmissionProvider and CommitSource on top
-// of github.com/hashicorp/raft for one TreeDB Raft group.
+// HashicorpRaftProvider implements AdmissionProvider, CommitSource, and
+// ReadIndexProvider on top of github.com/hashicorp/raft for one TreeDB Raft
+// group.
 type HashicorpRaftProvider struct {
 	cluster      ResolvedConfig
 	raft         *hraft.Raft
@@ -181,6 +182,42 @@ func (p *HashicorpRaftProvider) ClusterAdmissionStatus(ctx context.Context) (Adm
 	return UnavailableAdmission(reason + " without known leader"), nil
 }
 
+func (p *HashicorpRaftProvider) ReadIndex(ctx context.Context, target ReadIndexBarrier) (ReadIndexProof, error) {
+	if p == nil || p.raft == nil {
+		return ReadIndexProof{}, ErrInvalidHashicorpRaftProvider
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if target.NodeID != "" && target.NodeID != p.cluster.NodeID {
+		return ReadIndexProof{}, fmt.Errorf("%w: read-index target node %q does not match local node %q", ErrReadBarrierTargetMismatch, target.NodeID, p.cluster.NodeID)
+	}
+	if target.GroupID != "" && target.GroupID != p.cluster.GroupID {
+		return ReadIndexProof{}, fmt.Errorf("%w: read-index target group %q does not match local group %q", ErrReadBarrierTargetMismatch, target.GroupID, p.cluster.GroupID)
+	}
+	if err := ctx.Err(); err != nil {
+		return ReadIndexProof{}, err
+	}
+	if state := p.raft.State(); state != hraft.Leader {
+		return ReadIndexProof{}, p.hashicorpReadIndexNotLeader(state)
+	}
+	if err := waitHashicorpRaftFuture(ctx, p.raft.VerifyLeader()); err != nil {
+		return ReadIndexProof{}, p.mapHashicorpRaftReadIndexError(err)
+	}
+	proof := ReadIndexProof{
+		NodeID:       p.cluster.NodeID,
+		GroupID:      p.cluster.GroupID,
+		Term:         p.raft.CurrentTerm(),
+		Index:        p.raft.CommitIndex(),
+		HasQuorum:    true,
+		EvidenceKind: ReadIndexEvidenceProduction,
+	}
+	if err := target.Check(proof); err != nil {
+		return ReadIndexProof{}, err
+	}
+	return proof, nil
+}
+
 func (p *HashicorpRaftProvider) CommitCommandEntryV1(ctx context.Context, req CommitCommandEntryV1Request) (CommitCommandEntryV1Result, error) {
 	if p == nil || p.raft == nil {
 		return CommitCommandEntryV1Result{}, ErrInvalidHashicorpRaftProvider
@@ -238,6 +275,19 @@ func (p *HashicorpRaftProvider) CommitCommandEntryV1(ctx context.Context, req Co
 			ProductionConsensus: true,
 		},
 	}, nil
+}
+
+func (p *HashicorpRaftProvider) hashicorpReadIndexNotLeader(state hraft.RaftState) error {
+	reason := "read-index requires leader; hashicorp raft state " + state.String()
+	if p != nil && p.raft != nil {
+		if _, leaderID := p.raft.LeaderWithID(); leaderID != "" {
+			reason += "; leader_hint=" + string(leaderID)
+		}
+	}
+	if state == hraft.Shutdown {
+		return errors.Join(ErrHashicorpRaftUnavailable, fmt.Errorf("%s", reason))
+	}
+	return errors.Join(ErrNotLeader, fmt.Errorf("%s", reason))
 }
 
 func validateHashicorpRaftApplier(applier CommittedCommandApplierV1) error {
@@ -377,6 +427,29 @@ func waitHashicorpRaftFuture(ctx context.Context, future hraft.Future) error {
 		return err
 	case <-ctx.Done():
 		return ctx.Err()
+	}
+}
+
+func (p *HashicorpRaftProvider) mapHashicorpRaftReadIndexError(err error) error {
+	switch {
+	case err == nil:
+		return nil
+	case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
+		return err
+	case errors.Is(err, hraft.ErrNotLeader),
+		errors.Is(err, hraft.ErrLeadershipLost),
+		errors.Is(err, hraft.ErrLeadershipTransferInProgress):
+		state := hraft.Shutdown
+		if p != nil && p.raft != nil {
+			state = p.raft.State()
+		}
+		return errors.Join(p.hashicorpReadIndexNotLeader(state), err)
+	case errors.Is(err, hraft.ErrAbortedByRestore),
+		errors.Is(err, hraft.ErrRaftShutdown),
+		errors.Is(err, hraft.ErrEnqueueTimeout):
+		return errors.Join(ErrHashicorpRaftUnavailable, err)
+	default:
+		return errors.Join(ErrHashicorpRaftUnavailable, err)
 	}
 }
 

--- a/TreeDB/internal/raftcluster/hashicorp_raft_internal_test.go
+++ b/TreeDB/internal/raftcluster/hashicorp_raft_internal_test.go
@@ -197,6 +197,9 @@ func TestHashicorpRaftReadIndexCommitIndexMissingLogFailsClosed(t *testing.T) {
 	if !errors.Is(err, ErrReadBarrierNotSatisfied) {
 		t.Fatalf("readIndexCommitIndexHasCurrentTerm err=%v want ErrReadBarrierNotSatisfied", err)
 	}
+	if !errors.Is(err, hraft.ErrLogNotFound) {
+		t.Fatalf("readIndexCommitIndexHasCurrentTerm err=%v want raft ErrLogNotFound", err)
+	}
 }
 
 func TestHashicorpRaftFSMApplyFailureDefaultPanics(t *testing.T) {

--- a/TreeDB/internal/raftcluster/hashicorp_raft_internal_test.go
+++ b/TreeDB/internal/raftcluster/hashicorp_raft_internal_test.go
@@ -93,6 +93,34 @@ func TestHashicorpRaftReadIndexGapDetectsCommand(t *testing.T) {
 	}
 }
 
+func TestHashicorpRaftReadIndexGapStopsAtFirstCommand(t *testing.T) {
+	inner := hraft.NewInmemStore()
+	if err := inner.StoreLogs([]*hraft.Log{
+		{Index: 2, Term: 1, Type: hraft.LogNoop},
+		{Index: 3, Term: 1, Type: hraft.LogConfiguration},
+		{Index: 4, Term: 1, Type: hraft.LogCommand, Data: []byte("first")},
+		{Index: 5, Term: 1, Type: hraft.LogCommand, Data: []byte("second")},
+	}); err != nil {
+		t.Fatalf("StoreLogs: %v", err)
+	}
+	store := &countingReadIndexLogStore{LogStore: inner}
+	provider := &HashicorpRaftProvider{logStore: store}
+
+	noCommands, firstCmd, err := provider.readIndexGapHasNoCommands(2, 5)
+	if err != nil {
+		t.Fatalf("readIndexGapHasNoCommands: %v", err)
+	}
+	if noCommands {
+		t.Fatalf("readIndexGapHasNoCommands=true, want false for command gap")
+	}
+	if firstCmd != 4 {
+		t.Fatalf("readIndexGapHasNoCommands firstCmd=%d, want 4", firstCmd)
+	}
+	if store.getLogCount != 3 {
+		t.Fatalf("GetLog count=%d, want scan through first command only", store.getLogCount)
+	}
+}
+
 func TestHashicorpRaftReadIndexGapMissingLogFailsClosed(t *testing.T) {
 	provider := &HashicorpRaftProvider{logStore: hraft.NewInmemStore()}
 
@@ -178,4 +206,14 @@ func TestHashicorpRaftFSMApplyFailureDefaultPanics(t *testing.T) {
 	}()
 
 	_ = fsm.Apply(&hraft.Log{Type: hraft.LogCommand, Term: 1, Index: 1, Data: payload})
+}
+
+type countingReadIndexLogStore struct {
+	hraft.LogStore
+	getLogCount int
+}
+
+func (s *countingReadIndexLogStore) GetLog(index uint64, log *hraft.Log) error {
+	s.getLogCount++
+	return s.LogStore.GetLog(index, log)
 }

--- a/TreeDB/internal/raftcluster/hashicorp_raft_internal_test.go
+++ b/TreeDB/internal/raftcluster/hashicorp_raft_internal_test.go
@@ -130,6 +130,30 @@ func TestHashicorpRaftReadIndexGapMissingLogFailsClosed(t *testing.T) {
 	}
 }
 
+func TestHashicorpRaftReadIndexGapMaxIndexNoOverflow(t *testing.T) {
+	store := hraft.NewInmemStore()
+	lastIndex := ^uint64(0)
+	if err := store.StoreLog(&hraft.Log{Index: lastIndex, Term: 1, Type: hraft.LogNoop}); err != nil {
+		t.Fatalf("StoreLog: %v", err)
+	}
+	counting := &countingReadIndexLogStore{LogStore: store}
+	provider := &HashicorpRaftProvider{logStore: counting}
+
+	noCommands, firstCmd, err := provider.readIndexGapHasNoCommands(lastIndex, lastIndex)
+	if err != nil {
+		t.Fatalf("readIndexGapHasNoCommands: %v", err)
+	}
+	if !noCommands {
+		t.Fatalf("readIndexGapHasNoCommands=false, want true")
+	}
+	if firstCmd != 0 {
+		t.Fatalf("readIndexGapHasNoCommands firstCmd=%d, want 0", firstCmd)
+	}
+	if counting.getLogCount != 1 {
+		t.Fatalf("GetLog count=%d, want 1", counting.getLogCount)
+	}
+}
+
 func TestHashicorpRaftReadIndexCommitIndexHasCurrentTerm(t *testing.T) {
 	store := hraft.NewInmemStore()
 	if err := store.StoreLogs([]*hraft.Log{

--- a/TreeDB/internal/raftcluster/hashicorp_raft_internal_test.go
+++ b/TreeDB/internal/raftcluster/hashicorp_raft_internal_test.go
@@ -58,12 +58,15 @@ func TestHashicorpRaftReadIndexGapHasNoCommands(t *testing.T) {
 	}
 	provider := &HashicorpRaftProvider{logStore: store}
 
-	noCommands, err := provider.readIndexGapHasNoCommands(1, 3)
+	noCommands, firstCmd, err := provider.readIndexGapHasNoCommands(1, 3)
 	if err != nil {
 		t.Fatalf("readIndexGapHasNoCommands: %v", err)
 	}
 	if !noCommands {
 		t.Fatalf("readIndexGapHasNoCommands=false, want true for non-command gap")
+	}
+	if firstCmd != 0 {
+		t.Fatalf("readIndexGapHasNoCommands firstCmd=%d, want 0 for non-command gap", firstCmd)
 	}
 }
 
@@ -78,19 +81,22 @@ func TestHashicorpRaftReadIndexGapDetectsCommand(t *testing.T) {
 	}
 	provider := &HashicorpRaftProvider{logStore: store}
 
-	noCommands, err := provider.readIndexGapHasNoCommands(1, 3)
+	noCommands, firstCmd, err := provider.readIndexGapHasNoCommands(1, 3)
 	if err != nil {
 		t.Fatalf("readIndexGapHasNoCommands: %v", err)
 	}
 	if noCommands {
 		t.Fatalf("readIndexGapHasNoCommands=true, want false for command gap")
 	}
+	if firstCmd != 2 {
+		t.Fatalf("readIndexGapHasNoCommands firstCmd=%d, want 2", firstCmd)
+	}
 }
 
 func TestHashicorpRaftReadIndexGapMissingLogFailsClosed(t *testing.T) {
 	provider := &HashicorpRaftProvider{logStore: hraft.NewInmemStore()}
 
-	_, err := provider.readIndexGapHasNoCommands(1, 1)
+	_, _, err := provider.readIndexGapHasNoCommands(1, 1)
 	if !errors.Is(err, ErrReadBarrierNotSatisfied) {
 		t.Fatalf("readIndexGapHasNoCommands err=%v want ErrReadBarrierNotSatisfied", err)
 	}

--- a/TreeDB/internal/raftcluster/hashicorp_raft_internal_test.go
+++ b/TreeDB/internal/raftcluster/hashicorp_raft_internal_test.go
@@ -96,6 +96,50 @@ func TestHashicorpRaftReadIndexGapMissingLogFailsClosed(t *testing.T) {
 	}
 }
 
+func TestHashicorpRaftReadIndexCommitIndexHasCurrentTerm(t *testing.T) {
+	store := hraft.NewInmemStore()
+	if err := store.StoreLogs([]*hraft.Log{
+		{Index: 1, Term: 1, Type: hraft.LogCommand},
+		{Index: 2, Term: 2, Type: hraft.LogNoop},
+	}); err != nil {
+		t.Fatalf("StoreLogs: %v", err)
+	}
+	provider := &HashicorpRaftProvider{logStore: store}
+
+	ok, err := provider.readIndexCommitIndexHasCurrentTerm(2, 2)
+	if err != nil {
+		t.Fatalf("readIndexCommitIndexHasCurrentTerm current term: %v", err)
+	}
+	if !ok {
+		t.Fatal("readIndexCommitIndexHasCurrentTerm=false, want true for current-term committed entry")
+	}
+}
+
+func TestHashicorpRaftReadIndexCommitIndexPreviousTermNotEnough(t *testing.T) {
+	store := hraft.NewInmemStore()
+	if err := store.StoreLog(&hraft.Log{Index: 1, Term: 1, Type: hraft.LogCommand}); err != nil {
+		t.Fatalf("StoreLog: %v", err)
+	}
+	provider := &HashicorpRaftProvider{logStore: store}
+
+	ok, err := provider.readIndexCommitIndexHasCurrentTerm(1, 2)
+	if err != nil {
+		t.Fatalf("readIndexCommitIndexHasCurrentTerm previous term: %v", err)
+	}
+	if ok {
+		t.Fatal("readIndexCommitIndexHasCurrentTerm=true, want false for previous-term committed prefix")
+	}
+}
+
+func TestHashicorpRaftReadIndexCommitIndexMissingLogFailsClosed(t *testing.T) {
+	provider := &HashicorpRaftProvider{logStore: hraft.NewInmemStore()}
+
+	_, err := provider.readIndexCommitIndexHasCurrentTerm(2, 2)
+	if !errors.Is(err, ErrReadBarrierNotSatisfied) {
+		t.Fatalf("readIndexCommitIndexHasCurrentTerm err=%v want ErrReadBarrierNotSatisfied", err)
+	}
+}
+
 func TestHashicorpRaftFSMApplyFailureDefaultPanics(t *testing.T) {
 	applyErr := errors.New("command WAL fsync failed")
 	fsm := hashicorpRaftFSM{

--- a/TreeDB/internal/raftcluster/hashicorp_raft_internal_test.go
+++ b/TreeDB/internal/raftcluster/hashicorp_raft_internal_test.go
@@ -155,6 +155,21 @@ func TestHashicorpRaftReadIndexGapMaxIndexNoOverflow(t *testing.T) {
 	}
 }
 
+func TestHashicorpRaftReadIndexGapFirstIndexAfterAppliedMaxFailsClosed(t *testing.T) {
+	_, err := readIndexGapFirstIndexAfterApplied(uint64(math.MaxUint64))
+	if !errors.Is(err, ErrReadBarrierNotSatisfied) {
+		t.Fatalf("readIndexGapFirstIndexAfterApplied err=%v want ErrReadBarrierNotSatisfied", err)
+	}
+
+	firstIndex, err := readIndexGapFirstIndexAfterApplied(41)
+	if err != nil {
+		t.Fatalf("readIndexGapFirstIndexAfterApplied: %v", err)
+	}
+	if firstIndex != 42 {
+		t.Fatalf("firstIndex=%d want 42", firstIndex)
+	}
+}
+
 func TestHashicorpRaftReadIndexCommitIndexHasCurrentTerm(t *testing.T) {
 	store := hraft.NewInmemStore()
 	if err := store.StoreLogs([]*hraft.Log{

--- a/TreeDB/internal/raftcluster/hashicorp_raft_internal_test.go
+++ b/TreeDB/internal/raftcluster/hashicorp_raft_internal_test.go
@@ -47,6 +47,55 @@ func TestHashicorpRaftConfigSuppressesSnapshots(t *testing.T) {
 	}
 }
 
+func TestHashicorpRaftReadIndexGapHasNoCommands(t *testing.T) {
+	store := hraft.NewInmemStore()
+	if err := store.StoreLogs([]*hraft.Log{
+		{Index: 1, Term: 1, Type: hraft.LogNoop},
+		{Index: 2, Term: 1, Type: hraft.LogConfiguration},
+		{Index: 3, Term: 1, Type: hraft.LogBarrier},
+	}); err != nil {
+		t.Fatalf("StoreLogs: %v", err)
+	}
+	provider := &HashicorpRaftProvider{logStore: store}
+
+	noCommands, err := provider.readIndexGapHasNoCommands(1, 3)
+	if err != nil {
+		t.Fatalf("readIndexGapHasNoCommands: %v", err)
+	}
+	if !noCommands {
+		t.Fatalf("readIndexGapHasNoCommands=false, want true for non-command gap")
+	}
+}
+
+func TestHashicorpRaftReadIndexGapDetectsCommand(t *testing.T) {
+	store := hraft.NewInmemStore()
+	if err := store.StoreLogs([]*hraft.Log{
+		{Index: 1, Term: 1, Type: hraft.LogNoop},
+		{Index: 2, Term: 1, Type: hraft.LogCommand, Data: []byte("entry")},
+		{Index: 3, Term: 1, Type: hraft.LogBarrier},
+	}); err != nil {
+		t.Fatalf("StoreLogs: %v", err)
+	}
+	provider := &HashicorpRaftProvider{logStore: store}
+
+	noCommands, err := provider.readIndexGapHasNoCommands(1, 3)
+	if err != nil {
+		t.Fatalf("readIndexGapHasNoCommands: %v", err)
+	}
+	if noCommands {
+		t.Fatalf("readIndexGapHasNoCommands=true, want false for command gap")
+	}
+}
+
+func TestHashicorpRaftReadIndexGapMissingLogFailsClosed(t *testing.T) {
+	provider := &HashicorpRaftProvider{logStore: hraft.NewInmemStore()}
+
+	_, err := provider.readIndexGapHasNoCommands(1, 1)
+	if !errors.Is(err, ErrReadBarrierNotSatisfied) {
+		t.Fatalf("readIndexGapHasNoCommands err=%v want ErrReadBarrierNotSatisfied", err)
+	}
+}
+
 func TestHashicorpRaftFSMApplyFailureDefaultPanics(t *testing.T) {
 	applyErr := errors.New("command WAL fsync failed")
 	fsm := hashicorpRaftFSM{

--- a/TreeDB/internal/raftcluster/hashicorp_raft_internal_test.go
+++ b/TreeDB/internal/raftcluster/hashicorp_raft_internal_test.go
@@ -3,6 +3,7 @@ package raftcluster
 import (
 	"context"
 	"errors"
+	"math"
 	"testing"
 	"time"
 
@@ -132,7 +133,7 @@ func TestHashicorpRaftReadIndexGapMissingLogFailsClosed(t *testing.T) {
 
 func TestHashicorpRaftReadIndexGapMaxIndexNoOverflow(t *testing.T) {
 	store := hraft.NewInmemStore()
-	lastIndex := ^uint64(0)
+	lastIndex := uint64(math.MaxUint64)
 	if err := store.StoreLog(&hraft.Log{Index: lastIndex, Term: 1, Type: hraft.LogNoop}); err != nil {
 		t.Fatalf("StoreLog: %v", err)
 	}

--- a/TreeDB/internal/raftcluster/hashicorp_raft_test.go
+++ b/TreeDB/internal/raftcluster/hashicorp_raft_test.go
@@ -293,6 +293,55 @@ func TestHashicorpRaftProviderReadIndexDoesNotAppendBarrierLog(t *testing.T) {
 	}
 }
 
+func TestHashicorpRaftProviderReadIndexWaitsForTreeDBCommandProgressInGap(t *testing.T) {
+	applier := &progressReportingApplier{
+		progress: AppliedProgress{
+			NodeID:     "node-a",
+			GroupID:    "group-a",
+			Term:       1,
+			Index:      1,
+			HasApplied: true,
+		},
+	}
+	cluster := newHashicorpRaftProviderOnlyCluster(t, applier)
+	leader := cluster.waitForLeader(t)
+	applier.progress.NodeID = leader.id
+
+	commitCtx, commitCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer commitCancel()
+	result, err := leader.provider.CommitCommandEntryV1(commitCtx, CommitCommandEntryV1Request{
+		GroupID:                  "group-a",
+		NodeID:                   leader.id,
+		EntryBytes:               testClusterCreateCollectionEntry(t, 7),
+		CurrentCatalogVersion:    7,
+		HasCurrentCatalogVersion: true,
+		SyncLocalCommandWAL:      true,
+	})
+	if err != nil {
+		t.Fatalf("CommitCommandEntryV1: %v", err)
+	}
+	if result.Entry.Index < 2 {
+		t.Fatalf("committed command index=%d, want room for stale progress", result.Entry.Index)
+	}
+	applier.progress = AppliedProgress{
+		NodeID:     leader.id,
+		GroupID:    "group-a",
+		Term:       result.Entry.Term,
+		Index:      result.Entry.Index - 1,
+		HasApplied: true,
+	}
+
+	readCtx, readCancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer readCancel()
+	_, err = leader.provider.ReadIndex(readCtx, ReadIndexBarrier{NodeID: leader.id, GroupID: "group-a"})
+	if err == nil {
+		t.Fatalf("ReadIndex succeeded with committed command index %d ahead of TreeDB progress %d", result.Entry.Index, applier.progress.Index)
+	}
+	if !errors.Is(err, context.DeadlineExceeded) && !errors.Is(err, ErrReadBarrierNotSatisfied) {
+		t.Fatalf("ReadIndex err=%v want fail-closed deadline or ErrReadBarrierNotSatisfied", err)
+	}
+}
+
 func TestHashicorpRaftProviderReadIndexRejectsLeadershipLostBeforeProof(t *testing.T) {
 	applier := &progressReportingApplier{
 		progress: AppliedProgress{

--- a/TreeDB/internal/raftcluster/hashicorp_raft_test.go
+++ b/TreeDB/internal/raftcluster/hashicorp_raft_test.go
@@ -76,6 +76,120 @@ func TestHashicorpRaftProviderThreeNodeLeaderSubmitAppliesFollowers(t *testing.T
 	}
 }
 
+func TestHashicorpRaftProviderReadIndexReturnsProductionProofForLeader(t *testing.T) {
+	cluster := newHashicorpRaftDBCluster(t)
+	leader := cluster.waitForLeader(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	result, err := leader.submitter.SubmitCommandEntryV1(ctx, testClusterCreateCollectionEntry(t, 7), raftentry.RequestMetadataV1{
+		RequestID: 703,
+		AckPolicy: iwire.AckRaftCommitted,
+	})
+	if err != nil {
+		t.Fatalf("SubmitCommandEntryV1: %v", err)
+	}
+	cluster.waitApplied(t, result.CommittedEntry.EntryID())
+
+	target := ReadIndexBarrier{NodeID: leader.id, GroupID: "group-a"}
+	proof, err := leader.provider.ReadIndex(ctx, target)
+	if err != nil {
+		t.Fatalf("ReadIndex: %v", err)
+	}
+	if proof.NodeID != leader.id ||
+		proof.GroupID != "group-a" ||
+		proof.EvidenceKind != ReadIndexEvidenceProduction ||
+		!proof.HasQuorum ||
+		proof.Term == 0 ||
+		proof.Index < result.CommittedEntry.Index {
+		t.Fatalf("proof=%+v committed=%+v", proof, result.CommittedEntry)
+	}
+	if err := target.Check(proof); err != nil {
+		t.Fatalf("target.Check: %v", err)
+	}
+	progress, err := leader.fsm.WaitAppliedIndex(ctx, proof.AppliedIndexBarrier())
+	if err != nil {
+		t.Fatalf("WaitAppliedIndex(%+v): %v progress=%+v", proof.AppliedIndexBarrier(), err, progress)
+	}
+	if progress.NodeID != leader.id || progress.GroupID != "group-a" || progress.Index < proof.Index || !progress.HasApplied {
+		t.Fatalf("progress=%+v proof=%+v", progress, proof)
+	}
+}
+
+func TestHashicorpRaftProviderReadIndexRejectsFollowerStrongRead(t *testing.T) {
+	cluster := newHashicorpRaftDBCluster(t)
+	leader := cluster.waitForLeader(t)
+	follower := cluster.firstFollower(t, leader.id)
+	cluster.waitFollowerHint(t, follower, leader.id)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, err := follower.provider.ReadIndex(ctx, ReadIndexBarrier{NodeID: follower.id, GroupID: "group-a"})
+	if !errors.Is(err, ErrNotLeader) {
+		t.Fatalf("follower ReadIndex err=%v want ErrNotLeader", err)
+	}
+	if !strings.Contains(err.Error(), "leader_hint="+string(leader.id)) {
+		t.Fatalf("follower ReadIndex err=%v missing leader hint %q", err, leader.id)
+	}
+}
+
+func TestHashicorpRaftProviderReadIndexRejectsTargetMismatch(t *testing.T) {
+	cluster := newHashicorpRaftDBCluster(t)
+	leader := cluster.waitForLeader(t)
+
+	tests := []struct {
+		name   string
+		target ReadIndexBarrier
+	}{
+		{name: "node", target: ReadIndexBarrier{NodeID: "node-z", GroupID: "group-a"}},
+		{name: "group", target: ReadIndexBarrier{NodeID: leader.id, GroupID: "group-b"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := leader.provider.ReadIndex(context.Background(), tt.target)
+			if !errors.Is(err, ErrReadBarrierTargetMismatch) {
+				t.Fatalf("ReadIndex err=%v want ErrReadBarrierTargetMismatch", err)
+			}
+		})
+	}
+}
+
+func BenchmarkHashicorpRaftProviderReadIndex(b *testing.B) {
+	cluster := newHashicorpRaftDBCluster(b)
+	leader := cluster.waitForLeader(b)
+	ctx := context.Background()
+	result, err := leader.submitter.SubmitCommandEntryV1(ctx, testClusterCreateCollectionEntry(b, 7), raftentry.RequestMetadataV1{
+		RequestID: 704,
+		AckPolicy: iwire.AckRaftCommitted,
+	})
+	if err != nil {
+		b.Fatalf("SubmitCommandEntryV1: %v", err)
+	}
+	cluster.waitApplied(b, result.CommittedEntry.EntryID())
+
+	target := ReadIndexBarrier{NodeID: leader.id, GroupID: "group-a"}
+	proof, err := leader.provider.ReadIndex(ctx, target)
+	if err != nil {
+		b.Fatalf("warm ReadIndex: %v", err)
+	}
+	if proof.Index < result.CommittedEntry.Index {
+		b.Fatalf("warm proof=%+v committed=%+v", proof, result.CommittedEntry)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		proof, err := leader.provider.ReadIndex(ctx, target)
+		if err != nil {
+			b.Fatalf("ReadIndex: %v", err)
+		}
+		if proof.Index < result.CommittedEntry.Index {
+			b.Fatalf("proof=%+v committed=%+v", proof, result.CommittedEntry)
+		}
+	}
+	b.ReportMetric(float64(b.N), "read_indexes_total")
+}
+
 func TestHashicorpRaftProviderLocalRecoverabilityFailureDoesNotReportCommittedRecoverable(t *testing.T) {
 	applyErr := errors.New("local command WAL sync failed")
 	failingApplier := CommittedCommandApplierFunc(func(context.Context, CommittedCommandEntryV1) (raftentry.ApplyResultV1, error) {
@@ -239,11 +353,11 @@ type hashicorpRaftTestNode struct {
 	transport *hraft.InmemTransport
 }
 
-func newHashicorpRaftDBCluster(t *testing.T) *hashicorpRaftTestCluster {
-	t.Helper()
-	cluster := newHashicorpRaftCluster(t, func(t *testing.T, cfg Config) (*backenddb.DB, CommittedCommandApplierV1, CommandEntryPreflightV1) {
-		t.Helper()
-		db, fsm := openHashicorpRaftTestDBAndFSM(t, cfg)
+func newHashicorpRaftDBCluster(tb testing.TB) *hashicorpRaftTestCluster {
+	tb.Helper()
+	cluster := newHashicorpRaftCluster(tb, func(tb testing.TB, cfg Config) (*backenddb.DB, CommittedCommandApplierV1, CommandEntryPreflightV1) {
+		tb.Helper()
+		db, fsm := openHashicorpRaftTestDBAndFSM(tb, cfg)
 		return db, fsm, fsm
 	})
 	for _, node := range cluster.nodes {
@@ -256,24 +370,24 @@ func newHashicorpRaftDBCluster(t *testing.T) *hashicorpRaftTestCluster {
 			CatalogVersionProvider: staticCatalogVersion(7),
 		})
 		if err != nil {
-			t.Fatalf("%s NewSingleGroupSubmitter: %v", node.id, err)
+			tb.Fatalf("%s NewSingleGroupSubmitter: %v", node.id, err)
 		}
 		node.submitter = submitter
 	}
 	return cluster
 }
 
-func newHashicorpRaftProviderOnlyCluster(t *testing.T, applier CommittedCommandApplierV1) *hashicorpRaftTestCluster {
-	t.Helper()
-	return newHashicorpRaftCluster(t, func(t *testing.T, _ Config) (*backenddb.DB, CommittedCommandApplierV1, CommandEntryPreflightV1) {
-		t.Helper()
+func newHashicorpRaftProviderOnlyCluster(tb testing.TB, applier CommittedCommandApplierV1) *hashicorpRaftTestCluster {
+	tb.Helper()
+	return newHashicorpRaftCluster(tb, func(tb testing.TB, _ Config) (*backenddb.DB, CommittedCommandApplierV1, CommandEntryPreflightV1) {
+		tb.Helper()
 		return nil, applier, nil
 	})
 }
 
-func newHashicorpRaftCluster(t *testing.T, nodeStores func(*testing.T, Config) (*backenddb.DB, CommittedCommandApplierV1, CommandEntryPreflightV1)) *hashicorpRaftTestCluster {
-	t.Helper()
-	root := t.TempDir()
+func newHashicorpRaftCluster(tb testing.TB, nodeStores func(testing.TB, Config) (*backenddb.DB, CommittedCommandApplierV1, CommandEntryPreflightV1)) *hashicorpRaftTestCluster {
+	tb.Helper()
+	root := tb.TempDir()
 	peers := []Peer{
 		{ID: "node-a", Address: "node-a"},
 		{ID: "node-b", Address: "node-b"},
@@ -297,7 +411,7 @@ func newHashicorpRaftCluster(t *testing.T, nodeStores func(*testing.T, Config) (
 			GroupID: "group-a",
 			Peers:   peers,
 		}
-		db, applier, _ := nodeStores(t, cfg)
+		db, applier, _ := nodeStores(tb, cfg)
 		var applyFailureHandler func(error)
 		if db == nil {
 			applyFailureHandler = func(error) {}
@@ -312,7 +426,7 @@ func newHashicorpRaftCluster(t *testing.T, nodeStores func(*testing.T, Config) (
 			ApplyFailureHandler: applyFailureHandler,
 		})
 		if err != nil {
-			t.Fatalf("%s OpenHashicorpRaftProvider: %v", peer.ID, err)
+			tb.Fatalf("%s OpenHashicorpRaftProvider: %v", peer.ID, err)
 		}
 		node := &hashicorpRaftTestNode{
 			id:        peer.ID,
@@ -326,7 +440,7 @@ func newHashicorpRaftCluster(t *testing.T, nodeStores func(*testing.T, Config) (
 		}
 		cluster.nodes[peer.ID] = node
 	}
-	t.Cleanup(func() {
+	tb.Cleanup(func() {
 		for _, node := range cluster.nodes {
 			if node.provider != nil {
 				_ = node.provider.Close()
@@ -347,8 +461,8 @@ func newHashicorpRaftCluster(t *testing.T, nodeStores func(*testing.T, Config) (
 	return cluster
 }
 
-func openHashicorpRaftTestDBAndFSM(t *testing.T, cfg Config) (*backenddb.DB, *raftfsm.FSM) {
-	t.Helper()
+func openHashicorpRaftTestDBAndFSM(tb testing.TB, cfg Config) (*backenddb.DB, *raftfsm.FSM) {
+	tb.Helper()
 	db, err := backenddb.Open(backenddb.Options{
 		Dir:                          cfg.Dir,
 		CommandWAL:                   true,
@@ -357,7 +471,7 @@ func openHashicorpRaftTestDBAndFSM(t *testing.T, cfg Config) (*backenddb.DB, *ra
 		DisableBackgroundPrune:       true,
 	})
 	if err != nil {
-		t.Fatalf("%s Open DB: %v", cfg.NodeID, err)
+		tb.Fatalf("%s Open DB: %v", cfg.NodeID, err)
 	}
 	fsm, err := raftfsm.Open(raftfsm.Options{
 		DB:      db,
@@ -369,7 +483,7 @@ func openHashicorpRaftTestDBAndFSM(t *testing.T, cfg Config) (*backenddb.DB, *ra
 	})
 	if err != nil {
 		_ = db.Close()
-		t.Fatalf("%s Open FSM: %v", cfg.NodeID, err)
+		tb.Fatalf("%s Open FSM: %v", cfg.NodeID, err)
 	}
 	return db, fsm
 }
@@ -388,19 +502,19 @@ func hashicorpRaftFastTestConfig() *hraft.Config {
 	return conf
 }
 
-func (c *hashicorpRaftTestCluster) waitForLeader(t *testing.T) *hashicorpRaftTestNode {
-	t.Helper()
+func (c *hashicorpRaftTestCluster) waitForLeader(tb testing.TB) *hashicorpRaftTestNode {
+	tb.Helper()
 	deadline := time.Now().Add(5 * time.Second)
 	for time.Now().Before(deadline) {
 		var leader *hashicorpRaftTestNode
 		for _, node := range c.nodes {
 			status, err := node.provider.ClusterAdmissionStatus(context.Background())
 			if err != nil {
-				t.Fatalf("%s ClusterAdmissionStatus: %v", node.id, err)
+				tb.Fatalf("%s ClusterAdmissionStatus: %v", node.id, err)
 			}
 			if status.Leader {
 				if leader != nil {
-					t.Fatalf("multiple leaders: %s and %s", leader.id, node.id)
+					tb.Fatalf("multiple leaders: %s and %s", leader.id, node.id)
 				}
 				leader = node
 			}
@@ -410,39 +524,39 @@ func (c *hashicorpRaftTestCluster) waitForLeader(t *testing.T) *hashicorpRaftTes
 		}
 		time.Sleep(20 * time.Millisecond)
 	}
-	t.Fatalf("timed out waiting for leader; states=%s", c.admissionSummary())
+	tb.Fatalf("timed out waiting for leader; states=%s", c.admissionSummary())
 	return nil
 }
 
-func (c *hashicorpRaftTestCluster) firstFollower(t *testing.T, leaderID NodeID) *hashicorpRaftTestNode {
-	t.Helper()
+func (c *hashicorpRaftTestCluster) firstFollower(tb testing.TB, leaderID NodeID) *hashicorpRaftTestNode {
+	tb.Helper()
 	for _, node := range c.nodes {
 		if node.id != leaderID {
 			return node
 		}
 	}
-	t.Fatalf("no follower found for leader %q", leaderID)
+	tb.Fatalf("no follower found for leader %q", leaderID)
 	return nil
 }
 
-func (c *hashicorpRaftTestCluster) waitFollowerHint(t *testing.T, node *hashicorpRaftTestNode, leaderID NodeID) {
-	t.Helper()
+func (c *hashicorpRaftTestCluster) waitFollowerHint(tb testing.TB, node *hashicorpRaftTestNode, leaderID NodeID) {
+	tb.Helper()
 	deadline := time.Now().Add(3 * time.Second)
 	for time.Now().Before(deadline) {
 		status, err := node.provider.ClusterAdmissionStatus(context.Background())
 		if err != nil {
-			t.Fatalf("%s ClusterAdmissionStatus: %v", node.id, err)
+			tb.Fatalf("%s ClusterAdmissionStatus: %v", node.id, err)
 		}
 		if !status.Leader && status.LeaderHint == leaderID {
 			return
 		}
 		time.Sleep(20 * time.Millisecond)
 	}
-	t.Fatalf("%s did not report leader hint %q; states=%s", node.id, leaderID, c.admissionSummary())
+	tb.Fatalf("%s did not report leader hint %q; states=%s", node.id, leaderID, c.admissionSummary())
 }
 
-func (c *hashicorpRaftTestCluster) waitApplied(t *testing.T, id raftentry.ApplyEntryID) {
-	t.Helper()
+func (c *hashicorpRaftTestCluster) waitApplied(tb testing.TB, id raftentry.ApplyEntryID) {
+	tb.Helper()
 	deadline := time.Now().Add(5 * time.Second)
 	for time.Now().Before(deadline) {
 		allApplied := true
@@ -463,7 +577,7 @@ func (c *hashicorpRaftTestCluster) waitApplied(t *testing.T, id raftentry.ApplyE
 		got, ok := node.fsm.LastApplied()
 		states = append(states, fmt.Sprintf("%s=%d/%d ok=%t", node.id, got.Term, got.Index, ok))
 	}
-	t.Fatalf("timed out waiting for apply %d/%d; applied=%s", id.Term, id.Index, strings.Join(states, ", "))
+	tb.Fatalf("timed out waiting for apply %d/%d; applied=%s", id.Term, id.Index, strings.Join(states, ", "))
 }
 
 func (c *hashicorpRaftTestCluster) admissionSummary() string {

--- a/TreeDB/internal/raftcluster/hashicorp_raft_test.go
+++ b/TreeDB/internal/raftcluster/hashicorp_raft_test.go
@@ -130,8 +130,9 @@ func TestHashicorpRaftProviderReadIndexUsesAppliedProgressIndex(t *testing.T) {
 	cluster := newHashicorpRaftProviderOnlyCluster(t, applier)
 	leader := cluster.waitForLeader(t)
 	if leader.id != "node-a" {
-		applier.progress.NodeID = leader.id
+		applier.setProgressNodeID(leader.id)
 	}
+	wantIndex := applier.progressIndex()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
@@ -139,8 +140,8 @@ func TestHashicorpRaftProviderReadIndexUsesAppliedProgressIndex(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReadIndex: %v", err)
 	}
-	if proof.Index != applier.progress.Index {
-		t.Fatalf("proof index=%d want applied progress index %d", proof.Index, applier.progress.Index)
+	if proof.Index != wantIndex {
+		t.Fatalf("proof index=%d want applied progress index %d", proof.Index, wantIndex)
 	}
 	if !proof.HasQuorum || proof.EvidenceKind != ReadIndexEvidenceProduction {
 		t.Fatalf("proof=%+v want production quorum proof", proof)
@@ -179,7 +180,7 @@ func TestHashicorpRaftProviderReadIndexRejectsAppliedProgressIdentityMismatch(t 
 			cluster := newHashicorpRaftProviderOnlyCluster(t, applier)
 			leader := cluster.waitForLeader(t)
 			if tt.name == "group" {
-				applier.progress.NodeID = leader.id
+				applier.setProgressNodeID(leader.id)
 			}
 
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -203,7 +204,7 @@ func TestHashicorpRaftProviderReadIndexRejectsMissingAppliedProgressIndex(t *tes
 	}
 	cluster := newHashicorpRaftProviderOnlyCluster(t, applier)
 	leader := cluster.waitForLeader(t)
-	applier.progress.NodeID = leader.id
+	applier.setProgressNodeID(leader.id)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
@@ -237,7 +238,7 @@ func TestHashicorpRaftProviderReadIndexRejectsWithoutBarrierWhenAppliedProgressU
 			cluster := newHashicorpRaftProviderOnlyCluster(t, tt.applier)
 			leader := cluster.waitForLeader(t)
 			if applier, ok := tt.applier.(*progressReportingApplier); ok {
-				applier.progress.NodeID = leader.id
+				applier.setProgressNodeID(leader.id)
 			}
 			if leader.barrierLogStore == nil {
 				t.Fatalf("%s has no barrier-counting log store", leader.id)
@@ -269,11 +270,12 @@ func TestHashicorpRaftProviderReadIndexDoesNotAppendBarrierLog(t *testing.T) {
 	}
 	cluster := newHashicorpRaftProviderOnlyCluster(t, applier)
 	leader := cluster.waitForLeader(t)
-	applier.progress.NodeID = leader.id
+	applier.setProgressNodeID(leader.id)
 	if leader.barrierLogStore == nil {
 		t.Fatalf("%s has no barrier-counting log store", leader.id)
 	}
 	before := leader.barrierLogStore.barrierLogCount()
+	wantIndex := applier.progressIndex()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
@@ -283,10 +285,10 @@ func TestHashicorpRaftProviderReadIndexDoesNotAppendBarrierLog(t *testing.T) {
 		if err != nil {
 			t.Fatalf("ReadIndex #%d: %v", i+1, err)
 		}
-		if proof.Index != applier.progress.Index ||
+		if proof.Index != wantIndex ||
 			proof.EvidenceKind != ReadIndexEvidenceProduction ||
 			!proof.HasQuorum {
-			t.Fatalf("ReadIndex #%d proof=%+v want production proof at applied progress index %d", i+1, proof, applier.progress.Index)
+			t.Fatalf("ReadIndex #%d proof=%+v want production proof at applied progress index %d", i+1, proof, wantIndex)
 		}
 	}
 	if after := leader.barrierLogStore.barrierLogCount(); after != before {
@@ -306,7 +308,7 @@ func TestHashicorpRaftProviderReadIndexWaitsForTreeDBCommandProgressInGap(t *tes
 	}
 	cluster := newHashicorpRaftProviderOnlyCluster(t, applier)
 	leader := cluster.waitForLeader(t)
-	applier.progress.NodeID = leader.id
+	applier.setProgressNodeID(leader.id)
 
 	commitCtx, commitCancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer commitCancel()
@@ -324,19 +326,20 @@ func TestHashicorpRaftProviderReadIndexWaitsForTreeDBCommandProgressInGap(t *tes
 	if result.Entry.Index < 2 {
 		t.Fatalf("committed command index=%d, want room for stale progress", result.Entry.Index)
 	}
-	applier.progress = AppliedProgress{
+	staleProgress := AppliedProgress{
 		NodeID:     leader.id,
 		GroupID:    "group-a",
 		Term:       result.Entry.Term,
 		Index:      result.Entry.Index - 1,
 		HasApplied: true,
 	}
+	applier.setProgress(staleProgress)
 
 	readCtx, readCancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer readCancel()
 	_, err = leader.provider.ReadIndex(readCtx, ReadIndexBarrier{NodeID: leader.id, GroupID: "group-a"})
 	if err == nil {
-		t.Fatalf("ReadIndex succeeded with committed command index %d ahead of TreeDB progress %d", result.Entry.Index, applier.progress.Index)
+		t.Fatalf("ReadIndex succeeded with committed command index %d ahead of TreeDB progress %d", result.Entry.Index, staleProgress.Index)
 	}
 	if !errors.Is(err, context.DeadlineExceeded) && !errors.Is(err, ErrReadBarrierNotSatisfied) {
 		t.Fatalf("ReadIndex err=%v want fail-closed deadline or ErrReadBarrierNotSatisfied", err)
@@ -355,14 +358,14 @@ func TestHashicorpRaftProviderReadIndexRejectsLeadershipLostBeforeProof(t *testi
 	}
 	cluster := newHashicorpRaftProviderOnlyCluster(t, applier)
 	leader := cluster.waitForLeader(t)
-	applier.progress.NodeID = leader.id
+	applier.setProgressNodeID(leader.id)
 
 	var closeOnce sync.Once
-	applier.beforeReport = func() {
+	applier.setBeforeReport(func() {
 		closeOnce.Do(func() {
 			_ = leader.provider.Close()
 		})
-	}
+	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
@@ -1375,6 +1378,7 @@ func (a *recordingClusterApplier) snapshot() []CommittedCommandEntryV1 {
 }
 
 type progressReportingApplier struct {
+	mu           sync.Mutex
 	progress     AppliedProgress
 	beforeReport func()
 }
@@ -1384,13 +1388,45 @@ func (a *progressReportingApplier) ApplyCommittedCommandEntryV1(context.Context,
 }
 
 func (a *progressReportingApplier) AppliedProgress(ctx context.Context) (AppliedProgress, error) {
+	progress, beforeReport := a.snapshot()
 	if err := ctx.Err(); err != nil {
-		return a.progress, err
+		return progress, err
 	}
-	if a.beforeReport != nil {
-		a.beforeReport()
+	if beforeReport != nil {
+		beforeReport()
 	}
-	return a.progress, nil
+	progress, _ = a.snapshot()
+	return progress, nil
+}
+
+func (a *progressReportingApplier) setProgress(progress AppliedProgress) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.progress = progress
+}
+
+func (a *progressReportingApplier) setProgressNodeID(id NodeID) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.progress.NodeID = id
+}
+
+func (a *progressReportingApplier) progressIndex() uint64 {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.progress.Index
+}
+
+func (a *progressReportingApplier) setBeforeReport(fn func()) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.beforeReport = fn
+}
+
+func (a *progressReportingApplier) snapshot() (AppliedProgress, func()) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.progress, a.beforeReport
 }
 
 type barrierCountingLogStore struct {
@@ -1414,12 +1450,15 @@ func (s *barrierCountingLogStore) StoreLogs(logs []*hraft.Log) error {
 			barriers++
 		}
 	}
+	if err := s.InmemStore.StoreLogs(logs); err != nil {
+		return err
+	}
 	if barriers > 0 {
 		s.mu.Lock()
 		s.barrierLogs += barriers
 		s.mu.Unlock()
 	}
-	return s.InmemStore.StoreLogs(logs)
+	return nil
 }
 
 func (s *barrierCountingLogStore) barrierLogCount() int {

--- a/TreeDB/internal/raftcluster/hashicorp_raft_test.go
+++ b/TreeDB/internal/raftcluster/hashicorp_raft_test.go
@@ -212,7 +212,88 @@ func TestHashicorpRaftProviderReadIndexRejectsMissingAppliedProgressIndex(t *tes
 	}
 }
 
-func TestHashicorpRaftProviderReadIndexRejectsLeadershipLostAfterBarrier(t *testing.T) {
+func TestHashicorpRaftProviderReadIndexRejectsWithoutBarrierWhenAppliedProgressUnavailable(t *testing.T) {
+	tests := []struct {
+		name    string
+		applier CommittedCommandApplierV1
+	}{
+		{
+			name:    "reader-missing",
+			applier: &recordingClusterApplier{},
+		},
+		{
+			name: "no-applied-command",
+			applier: &progressReportingApplier{
+				progress: AppliedProgress{
+					NodeID:  "node-a",
+					GroupID: "group-a",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cluster := newHashicorpRaftProviderOnlyCluster(t, tt.applier)
+			leader := cluster.waitForLeader(t)
+			if applier, ok := tt.applier.(*progressReportingApplier); ok {
+				applier.progress.NodeID = leader.id
+			}
+			if leader.barrierLogStore == nil {
+				t.Fatalf("%s has no barrier-counting log store", leader.id)
+			}
+			before := leader.barrierLogStore.barrierLogCount()
+
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			_, err := leader.provider.ReadIndex(ctx, ReadIndexBarrier{NodeID: leader.id, GroupID: "group-a"})
+			if !errors.Is(err, ErrReadBarrierNotSatisfied) {
+				t.Fatalf("ReadIndex err=%v want ErrReadBarrierNotSatisfied", err)
+			}
+			if after := leader.barrierLogStore.barrierLogCount(); after != before {
+				t.Fatalf("ReadIndex appended %d barrier logs before proving applied progress", after-before)
+			}
+		})
+	}
+}
+
+func TestHashicorpRaftProviderReadIndexDoesNotAppendBarrierLog(t *testing.T) {
+	applier := &progressReportingApplier{
+		progress: AppliedProgress{
+			NodeID:     "node-a",
+			GroupID:    "group-a",
+			Term:       3,
+			Index:      42,
+			HasApplied: true,
+		},
+	}
+	cluster := newHashicorpRaftProviderOnlyCluster(t, applier)
+	leader := cluster.waitForLeader(t)
+	applier.progress.NodeID = leader.id
+	if leader.barrierLogStore == nil {
+		t.Fatalf("%s has no barrier-counting log store", leader.id)
+	}
+	before := leader.barrierLogStore.barrierLogCount()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	target := ReadIndexBarrier{NodeID: leader.id, GroupID: "group-a"}
+	for i := 0; i < 3; i++ {
+		proof, err := leader.provider.ReadIndex(ctx, target)
+		if err != nil {
+			t.Fatalf("ReadIndex #%d: %v", i+1, err)
+		}
+		if proof.Index != applier.progress.Index ||
+			proof.EvidenceKind != ReadIndexEvidenceProduction ||
+			!proof.HasQuorum {
+			t.Fatalf("ReadIndex #%d proof=%+v want production proof at applied progress index %d", i+1, proof, applier.progress.Index)
+		}
+	}
+	if after := leader.barrierLogStore.barrierLogCount(); after != before {
+		t.Fatalf("ReadIndex appended %d barrier logs", after-before)
+	}
+}
+
+func TestHashicorpRaftProviderReadIndexRejectsLeadershipLostBeforeProof(t *testing.T) {
 	applier := &progressReportingApplier{
 		progress: AppliedProgress{
 			NodeID:     "node-a",
@@ -468,13 +549,14 @@ type hashicorpRaftTestCluster struct {
 }
 
 type hashicorpRaftTestNode struct {
-	id        NodeID
-	cfg       Config
-	db        *backenddb.DB
-	fsm       *raftfsm.FSM
-	provider  *HashicorpRaftProvider
-	submitter *SingleGroupSubmitter
-	transport *hraft.InmemTransport
+	id              NodeID
+	cfg             Config
+	db              *backenddb.DB
+	fsm             *raftfsm.FSM
+	provider        *HashicorpRaftProvider
+	submitter       *SingleGroupSubmitter
+	transport       *hraft.InmemTransport
+	barrierLogStore *barrierCountingLogStore
 }
 
 func newHashicorpRaftDBCluster(tb testing.TB) *hashicorpRaftTestCluster {
@@ -537,14 +619,25 @@ func newHashicorpRaftCluster(tb testing.TB, nodeStores func(testing.TB, Config) 
 		}
 		db, applier, _ := nodeStores(tb, cfg)
 		var applyFailureHandler func(error)
+		var logStore hraft.LogStore
+		var stableStore hraft.StableStore
+		var snapshotStore hraft.SnapshotStore
+		var barrierLogStore *barrierCountingLogStore
 		if db == nil {
 			applyFailureHandler = func(error) {}
+			barrierLogStore = newBarrierCountingLogStore()
+			logStore = barrierLogStore
+			stableStore = hraft.NewInmemStore()
+			snapshotStore = hraft.NewInmemSnapshotStore()
 		}
 		provider, err := OpenHashicorpRaftProvider(HashicorpRaftProviderOptions{
 			Cluster:             cfg,
 			Applier:             applier,
 			Transport:           transports[peer.ID],
 			RaftConfig:          hashicorpRaftFastTestConfig(),
+			LogStore:            logStore,
+			StableStore:         stableStore,
+			SnapshotStore:       snapshotStore,
 			Bootstrap:           true,
 			ApplyTimeout:        2 * time.Second,
 			ApplyFailureHandler: applyFailureHandler,
@@ -553,11 +646,12 @@ func newHashicorpRaftCluster(tb testing.TB, nodeStores func(testing.TB, Config) 
 			tb.Fatalf("%s OpenHashicorpRaftProvider: %v", peer.ID, err)
 		}
 		node := &hashicorpRaftTestNode{
-			id:        peer.ID,
-			cfg:       cfg,
-			db:        db,
-			provider:  provider,
-			transport: transports[peer.ID],
+			id:              peer.ID,
+			cfg:             cfg,
+			db:              db,
+			provider:        provider,
+			transport:       transports[peer.ID],
+			barrierLogStore: barrierLogStore,
 		}
 		if fsm, ok := applier.(*raftfsm.FSM); ok {
 			node.fsm = fsm
@@ -806,6 +900,41 @@ func (a *progressReportingApplier) AppliedProgress(ctx context.Context) (Applied
 		a.beforeReport()
 	}
 	return a.progress, nil
+}
+
+type barrierCountingLogStore struct {
+	*hraft.InmemStore
+	mu          sync.Mutex
+	barrierLogs int
+}
+
+func newBarrierCountingLogStore() *barrierCountingLogStore {
+	return &barrierCountingLogStore{InmemStore: hraft.NewInmemStore()}
+}
+
+func (s *barrierCountingLogStore) StoreLog(log *hraft.Log) error {
+	return s.StoreLogs([]*hraft.Log{log})
+}
+
+func (s *barrierCountingLogStore) StoreLogs(logs []*hraft.Log) error {
+	var barriers int
+	for _, log := range logs {
+		if log != nil && log.Type == hraft.LogBarrier {
+			barriers++
+		}
+	}
+	if barriers > 0 {
+		s.mu.Lock()
+		s.barrierLogs += barriers
+		s.mu.Unlock()
+	}
+	return s.InmemStore.StoreLogs(logs)
+}
+
+func (s *barrierCountingLogStore) barrierLogCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.barrierLogs
 }
 
 type countingClusterApplier struct {

--- a/TreeDB/internal/raftcluster/hashicorp_raft_test.go
+++ b/TreeDB/internal/raftcluster/hashicorp_raft_test.go
@@ -346,6 +346,77 @@ func TestHashicorpRaftProviderReadIndexWaitsForTreeDBCommandProgressInGap(t *tes
 	}
 }
 
+func TestHashicorpRaftProviderReadIndexWaitsForInitialAppliedProgress(t *testing.T) {
+	applier := &progressReportingApplier{
+		progress: AppliedProgress{
+			NodeID:  "node-a",
+			GroupID: "group-a",
+		},
+	}
+	cluster := newHashicorpRaftProviderOnlyCluster(t, applier)
+	leader := cluster.waitForLeader(t)
+	applier.setProgress(AppliedProgress{
+		NodeID:  leader.id,
+		GroupID: "group-a",
+	})
+
+	commitCtx, commitCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer commitCancel()
+	result, err := leader.provider.CommitCommandEntryV1(commitCtx, CommitCommandEntryV1Request{
+		GroupID:                  "group-a",
+		NodeID:                   leader.id,
+		EntryBytes:               testClusterCreateCollectionEntry(t, 7),
+		CurrentCatalogVersion:    7,
+		HasCurrentCatalogVersion: true,
+		SyncLocalCommandWAL:      true,
+	})
+	if err != nil {
+		t.Fatalf("CommitCommandEntryV1: %v", err)
+	}
+	if leader.barrierLogStore == nil {
+		t.Fatalf("%s has no barrier-counting log store", leader.id)
+	}
+	before := leader.barrierLogStore.barrierLogCount()
+
+	var mu sync.Mutex
+	progressReports := 0
+	applier.setBeforeReport(func() {
+		mu.Lock()
+		progressReports++
+		current := progressReports
+		mu.Unlock()
+		if current < 2 {
+			return
+		}
+		applier.setProgress(AppliedProgress{
+			NodeID:     leader.id,
+			GroupID:    "group-a",
+			Term:       result.Entry.Term,
+			Index:      result.Entry.Index,
+			HasApplied: true,
+		})
+	})
+
+	readCtx, readCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer readCancel()
+	proof, err := leader.provider.ReadIndex(readCtx, ReadIndexBarrier{NodeID: leader.id, GroupID: "group-a"})
+	if err != nil {
+		t.Fatalf("ReadIndex: %v", err)
+	}
+	if proof.Index != result.Entry.Index {
+		t.Fatalf("proof index=%d want first applied command index %d", proof.Index, result.Entry.Index)
+	}
+	mu.Lock()
+	gotReports := progressReports
+	mu.Unlock()
+	if gotReports < 2 {
+		t.Fatalf("AppliedProgress reports=%d want at least 2", gotReports)
+	}
+	if after := leader.barrierLogStore.barrierLogCount(); after != before {
+		t.Fatalf("ReadIndex appended %d barrier logs while waiting for initial progress", after-before)
+	}
+}
+
 func TestHashicorpRaftProviderReadIndexRejectsLeadershipLostBeforeProof(t *testing.T) {
 	applier := &progressReportingApplier{
 		progress: AppliedProgress{

--- a/TreeDB/internal/raftcluster/hashicorp_raft_test.go
+++ b/TreeDB/internal/raftcluster/hashicorp_raft_test.go
@@ -146,6 +146,101 @@ func TestHashicorpRaftProviderReadIndexUsesAppliedProgressIndex(t *testing.T) {
 	}
 }
 
+func TestHashicorpRaftProviderReadIndexRejectsAppliedProgressIdentityMismatch(t *testing.T) {
+	tests := []struct {
+		name     string
+		progress AppliedProgress
+	}{
+		{
+			name: "node",
+			progress: AppliedProgress{
+				NodeID:     "node-z",
+				GroupID:    "group-a",
+				Term:       3,
+				Index:      42,
+				HasApplied: true,
+			},
+		},
+		{
+			name: "group",
+			progress: AppliedProgress{
+				NodeID:     "node-a",
+				GroupID:    "group-z",
+				Term:       3,
+				Index:      42,
+				HasApplied: true,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			applier := &progressReportingApplier{progress: tt.progress}
+			cluster := newHashicorpRaftProviderOnlyCluster(t, applier)
+			leader := cluster.waitForLeader(t)
+			if tt.name == "group" {
+				applier.progress.NodeID = leader.id
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			_, err := leader.provider.ReadIndex(ctx, ReadIndexBarrier{NodeID: leader.id, GroupID: "group-a"})
+			if !errors.Is(err, ErrReadBarrierTargetMismatch) {
+				t.Fatalf("ReadIndex err=%v want ErrReadBarrierTargetMismatch", err)
+			}
+		})
+	}
+}
+
+func TestHashicorpRaftProviderReadIndexRejectsMissingAppliedProgressIndex(t *testing.T) {
+	applier := &progressReportingApplier{
+		progress: AppliedProgress{
+			NodeID:     "node-a",
+			GroupID:    "group-a",
+			Term:       3,
+			HasApplied: true,
+		},
+	}
+	cluster := newHashicorpRaftProviderOnlyCluster(t, applier)
+	leader := cluster.waitForLeader(t)
+	applier.progress.NodeID = leader.id
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, err := leader.provider.ReadIndex(ctx, ReadIndexBarrier{NodeID: leader.id, GroupID: "group-a"})
+	if !errors.Is(err, ErrReadBarrierNotSatisfied) {
+		t.Fatalf("ReadIndex err=%v want ErrReadBarrierNotSatisfied", err)
+	}
+}
+
+func TestHashicorpRaftProviderReadIndexRejectsLeadershipLostAfterBarrier(t *testing.T) {
+	applier := &progressReportingApplier{
+		progress: AppliedProgress{
+			NodeID:     "node-a",
+			GroupID:    "group-a",
+			Term:       3,
+			Index:      42,
+			HasApplied: true,
+		},
+	}
+	cluster := newHashicorpRaftProviderOnlyCluster(t, applier)
+	leader := cluster.waitForLeader(t)
+	applier.progress.NodeID = leader.id
+
+	var closeOnce sync.Once
+	applier.beforeReport = func() {
+		closeOnce.Do(func() {
+			_ = leader.provider.Close()
+		})
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, err := leader.provider.ReadIndex(ctx, ReadIndexBarrier{NodeID: leader.id, GroupID: "group-a"})
+	if !errors.Is(err, ErrNotLeader) && !errors.Is(err, ErrHashicorpRaftUnavailable) {
+		t.Fatalf("ReadIndex err=%v want not-leader or unavailable after leadership loss", err)
+	}
+}
+
 func TestHashicorpRaftProviderReadIndexRejectsFollowerStrongRead(t *testing.T) {
 	cluster := newHashicorpRaftDBCluster(t)
 	leader := cluster.waitForLeader(t)
@@ -695,7 +790,8 @@ func (a *recordingClusterApplier) snapshot() []CommittedCommandEntryV1 {
 }
 
 type progressReportingApplier struct {
-	progress AppliedProgress
+	progress     AppliedProgress
+	beforeReport func()
 }
 
 func (a *progressReportingApplier) ApplyCommittedCommandEntryV1(context.Context, CommittedCommandEntryV1) (raftentry.ApplyResultV1, error) {
@@ -705,6 +801,9 @@ func (a *progressReportingApplier) ApplyCommittedCommandEntryV1(context.Context,
 func (a *progressReportingApplier) AppliedProgress(ctx context.Context) (AppliedProgress, error) {
 	if err := ctx.Err(); err != nil {
 		return a.progress, err
+	}
+	if a.beforeReport != nil {
+		a.beforeReport()
 	}
 	return a.progress, nil
 }

--- a/TreeDB/internal/raftcluster/hashicorp_raft_test.go
+++ b/TreeDB/internal/raftcluster/hashicorp_raft_test.go
@@ -116,6 +116,36 @@ func TestHashicorpRaftProviderReadIndexReturnsProductionProofForLeader(t *testin
 	}
 }
 
+func TestHashicorpRaftProviderReadIndexUsesAppliedProgressIndex(t *testing.T) {
+	applier := &progressReportingApplier{
+		progress: AppliedProgress{
+			NodeID:     "node-a",
+			GroupID:    "group-a",
+			Term:       3,
+			Index:      42,
+			HasApplied: true,
+		},
+	}
+	cluster := newHashicorpRaftProviderOnlyCluster(t, applier)
+	leader := cluster.waitForLeader(t)
+	if leader.id != "node-a" {
+		applier.progress.NodeID = leader.id
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	proof, err := leader.provider.ReadIndex(ctx, ReadIndexBarrier{NodeID: leader.id, GroupID: "group-a"})
+	if err != nil {
+		t.Fatalf("ReadIndex: %v", err)
+	}
+	if proof.Index != applier.progress.Index {
+		t.Fatalf("proof index=%d want applied progress index %d", proof.Index, applier.progress.Index)
+	}
+	if !proof.HasQuorum || proof.EvidenceKind != ReadIndexEvidenceProduction {
+		t.Fatalf("proof=%+v want production quorum proof", proof)
+	}
+}
+
 func TestHashicorpRaftProviderReadIndexRejectsFollowerStrongRead(t *testing.T) {
 	cluster := newHashicorpRaftDBCluster(t)
 	leader := cluster.waitForLeader(t)
@@ -187,7 +217,6 @@ func BenchmarkHashicorpRaftProviderReadIndex(b *testing.B) {
 			b.Fatalf("proof=%+v committed=%+v", proof, result.CommittedEntry)
 		}
 	}
-	b.ReportMetric(float64(b.N), "read_indexes_total")
 }
 
 func TestHashicorpRaftProviderLocalRecoverabilityFailureDoesNotReportCommittedRecoverable(t *testing.T) {
@@ -663,6 +692,21 @@ func (a *recordingClusterApplier) ApplyCommittedCommandEntryV1(_ context.Context
 
 func (a *recordingClusterApplier) snapshot() []CommittedCommandEntryV1 {
 	return append([]CommittedCommandEntryV1(nil), a.entries...)
+}
+
+type progressReportingApplier struct {
+	progress AppliedProgress
+}
+
+func (a *progressReportingApplier) ApplyCommittedCommandEntryV1(context.Context, CommittedCommandEntryV1) (raftentry.ApplyResultV1, error) {
+	return raftentry.ApplyResultV1{Status: raftentry.ApplyStatusApplied}, nil
+}
+
+func (a *progressReportingApplier) AppliedProgress(ctx context.Context) (AppliedProgress, error) {
+	if err := ctx.Err(); err != nil {
+		return a.progress, err
+	}
+	return a.progress, nil
 }
 
 type countingClusterApplier struct {

--- a/TreeDB/nativewire/cluster_read_barrier_test.go
+++ b/TreeDB/nativewire/cluster_read_barrier_test.go
@@ -315,6 +315,74 @@ func TestAppliedIndexReadCoordinatorLinearizableRejectsHarnessReadIndexEvidence(
 	}
 }
 
+func TestAppliedIndexReadCoordinatorLinearizableRejectsFollowerReadIndexWithoutWaiting(t *testing.T) {
+	readIndex := &fakeReadIndexProvider{err: raftcluster.ErrNotLeader}
+	waiter := &fakeAppliedIndexWaiter{
+		progress: raftcluster.AppliedProgress{
+			NodeID:     "node-b",
+			GroupID:    "group-a",
+			Term:       7,
+			Index:      44,
+			HasApplied: true,
+		},
+	}
+	client, mgr, _ := serveCollectionPipeWithOptions(t, ServerOptions{
+		ClusterReadCoordinator: AppliedIndexReadCoordinator{
+			Waiter:            waiter,
+			ReadIndexTarget:   raftcluster.ReadIndexBarrier{NodeID: "node-b", GroupID: "group-a"},
+			ReadIndexProvider: readIndex,
+		},
+	})
+	seedReadCollection(t, mgr)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := client.Hello(ctx); err != nil {
+		t.Fatalf("Hello: %v", err)
+	}
+
+	_, err := client.GetManyWithOptions(ctx, "users", [][]byte{[]byte("u1")}, ReadOptions{ConsistencyPolicy: ConsistencyLinearizable})
+	if !isRemoteError(err, iwire.ErrConsistencyUnavailable) {
+		t.Fatalf("GetManyWithOptions err=%v want consistency_unavailable", err)
+	}
+	if len(readIndex.calls) != 1 {
+		t.Fatalf("read index calls=%d want 1", len(readIndex.calls))
+	}
+	if len(waiter.calls) != 0 {
+		t.Fatalf("waiter calls=%d want none after follower read-index rejection", len(waiter.calls))
+	}
+}
+
+func TestAppliedIndexReadCoordinatorLocalStaleReadIsLabeledWithoutReadIndex(t *testing.T) {
+	readIndex := &fakeReadIndexProvider{err: raftcluster.ErrNotLeader}
+	waiter := &fakeAppliedIndexWaiter{}
+	client, mgr, _ := serveCollectionPipeWithOptions(t, ServerOptions{
+		ClusterReadCoordinator: AppliedIndexReadCoordinator{
+			Waiter:            waiter,
+			ReadIndexProvider: readIndex,
+		},
+	})
+	seedReadCollection(t, mgr)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := client.Hello(ctx); err != nil {
+		t.Fatalf("Hello: %v", err)
+	}
+
+	result, err := client.GetManyWithOptions(ctx, "users", [][]byte{[]byte("u1")}, ReadOptions{ConsistencyPolicy: ConsistencyLocalStale})
+	if err != nil {
+		t.Fatalf("GetManyWithOptions local stale: %v", err)
+	}
+	if !result.ReadMeta.Valid || result.ReadMeta.ActualConsistency != ConsistencyLocalStale {
+		t.Fatalf("read meta=%+v want local-stale", result.ReadMeta)
+	}
+	if result.ReadMeta.ServingNode != "" || result.ReadMeta.LeaderNode != "" || result.ReadMeta.HasAppliedIndex {
+		t.Fatalf("local stale read meta unexpectedly reported strong-read fields: %+v", result.ReadMeta)
+	}
+	if len(readIndex.calls) != 0 || len(waiter.calls) != 0 {
+		t.Fatalf("read index calls=%d waiter calls=%d want none for local-stale", len(readIndex.calls), len(waiter.calls))
+	}
+}
+
 func TestAppliedIndexReadCoordinatorLinearizableFailsClosedWithoutReadIndexProvider(t *testing.T) {
 	waiter := &fakeAppliedIndexWaiter{
 		progress: raftcluster.AppliedProgress{


### PR DESCRIPTION
Refs #3441.
Parent: #3045.

## Summary

- Wires a production `ReadIndexProvider` into the HashiCorp Raft single-group provider.
- Uses `VerifyLeader`, then requires the leader to have a committed current-term entry before trusting `CommitIndex()` as the read prefix.
- Waits for TreeDB applied progress through the committed command prefix, or proves the committed gap contains no `LogCommand` entries; missing/compacted logs fail closed.
- Keeps steady-state successful reads from appending HashiCorp `LogBarrier` entries.
- Extends nativewire read-coordination tests so production linearizable reads require production read-index evidence, while local-stale reads remain explicitly labeled.
- Final-base merge includes #3447 failover/restart tests and preserves both failover and read-index coverage.

## Validation

Latest-head validation on `a95793c79` after merging `origin/main` at `97247676349a94467e27819b38d6cafa0ae34b2d`:

- `TMPDIR=/mnt/fast4tb/tmp/gomap-test-tmp GOCACHE=/mnt/fast4tb/tmp/go-cache GOMODCACHE=/mnt/fast4tb/tmp/go-mod-cache GOWORK=off go test ./TreeDB/internal/raftcluster -run 'TestHashicorpRaftProvider(ReadIndex|FollowerRejectsWithoutDirectMutation|LeaderCrashAfterCommitRestartCatchUpConverges|LeaderCrashBeforeCommitDoesNotReportSuccessOrMutate)|TestHashicorpRaft(ReadIndexCommitIndex)' -count=1`
- `TMPDIR=/mnt/fast4tb/tmp/gomap-test-tmp GOCACHE=/mnt/fast4tb/tmp/go-cache GOMODCACHE=/mnt/fast4tb/tmp/go-mod-cache GOWORK=off go test ./TreeDB/internal/raftcluster ./TreeDB/internal/raftfsm ./TreeDB/internal/raftharness ./TreeDB/nativewire -count=1`
- `git diff --check`

Earlier latest-head read-index benchmark on this branch:

- `TMPDIR=/mnt/fast4tb/tmp/gomap-test-tmp GOCACHE=/mnt/fast4tb/tmp/go-cache GOMODCACHE=/mnt/fast4tb/tmp/go-mod-cache GOWORK=off go test ./TreeDB/internal/raftcluster -run '^$' -bench '^BenchmarkHashicorpRaftProviderReadIndex$' -benchtime=10x -count=1 -benchmem`
- Result before the current-term gate: `BenchmarkHashicorpRaftProviderReadIndex-12 10 18113 ns/op 2972 B/op 47 allocs/op`.

## Review Notes

- The previous Codex P1 about new leaders under-reporting the committed prefix is addressed by requiring the committed read prefix to be in the current leader term before returning production evidence.
- This remains no-steady-state-`LogBarrier`: the current-term entry is HashiCorp Raft's leader startup no-op, not a read-path barrier append.
- The final-base conflict with #3447 was limited to `TreeDB/internal/raftcluster/hashicorp_raft_test.go`; resolution keeps #3448 read-index tests and #3447 failover/follower tests with shared `testing.TB` helpers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for stronger read barriers in clustered reads, improving consistency guarantees for leader-based reads.

* **Bug Fixes**
  * Read requests now fail more reliably when leadership changes, targets don’t match, or required progress information is unavailable.
  * Improved handling of lagging read state so requests wait for safe progress instead of returning stale results.
  * Local-stale reads now return without strong-read metadata, matching their expected behavior.

* **Tests**
  * Expanded coverage for read consistency, leader validation, and barrier behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->