### PR TITLE
raftcluster: add group-routed submit dispatcher

### DIFF
--- a/TreeDB/internal/raftcluster/dispatcher.go
+++ b/TreeDB/internal/raftcluster/dispatcher.go
@@ -1,0 +1,234 @@
+package raftcluster
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+
+	"github.com/snissn/gomap/TreeDB/internal/raftentry"
+)
+
+const (
+	clusterRouteShapeCollectionV1 = "collection"
+	clusterRouteShapeTokenV1      = "token"
+	clusterRouteShapeTokenBatchV1 = "token_batch"
+
+	clusterRoutePlacementCollectionV1 = "collection"
+	clusterRoutePlacementTokenV1      = "token"
+	clusterRoutePlacementRingV1       = "ring"
+)
+
+// GroupSubmitterV1 binds a local Raft group ID to the in-process submitter for
+// that group.
+type GroupSubmitterV1 struct {
+	GroupID   GroupID
+	Submitter CommandSubmitterV1
+}
+
+// GroupSubmitterRegistryV1 is an immutable registry of local group submitters.
+// It is deliberately in-process only; it does not forward to remote leaders.
+type GroupSubmitterRegistryV1 struct {
+	byGroup map[GroupID]CommandSubmitterV1
+	groups  []GroupID
+}
+
+// NewGroupSubmitterRegistryV1 validates and copies the configured local group
+// submitters. If a submitter exposes Config(), its configured group must match
+// the registry key.
+func NewGroupSubmitterRegistryV1(entries []GroupSubmitterV1) (GroupSubmitterRegistryV1, error) {
+	if len(entries) == 0 {
+		return GroupSubmitterRegistryV1{}, errors.Join(ErrInvalidSubmitter, fmt.Errorf("at least one group submitter is required"))
+	}
+	byGroup := make(map[GroupID]CommandSubmitterV1, len(entries))
+	groups := make([]GroupID, 0, len(entries))
+	for i, entry := range entries {
+		if entry.GroupID == "" {
+			return GroupSubmitterRegistryV1{}, errors.Join(ErrInvalidSubmitter, fmt.Errorf("group submitter[%d] missing group id", i))
+		}
+		if entry.Submitter == nil {
+			return GroupSubmitterRegistryV1{}, errors.Join(ErrInvalidSubmitter, fmt.Errorf("group submitter[%d] for group %q is nil", i, entry.GroupID))
+		}
+		if _, exists := byGroup[entry.GroupID]; exists {
+			return GroupSubmitterRegistryV1{}, errors.Join(ErrInvalidSubmitter, fmt.Errorf("group submitter for group %q is duplicated", entry.GroupID))
+		}
+		if provider, ok := entry.Submitter.(Provider); ok {
+			cfg := provider.Config()
+			if cfg.GroupID != "" && cfg.GroupID != entry.GroupID {
+				return GroupSubmitterRegistryV1{}, errors.Join(ErrInvalidSubmitter, fmt.Errorf("group submitter key %q does not match submitter group %q", entry.GroupID, cfg.GroupID))
+			}
+		}
+		byGroup[entry.GroupID] = entry.Submitter
+		groups = append(groups, entry.GroupID)
+	}
+	slices.Sort(groups)
+	return GroupSubmitterRegistryV1{byGroup: byGroup, groups: groups}, nil
+}
+
+func (r GroupSubmitterRegistryV1) Lookup(groupID GroupID) (CommandSubmitterV1, bool) {
+	if r.byGroup == nil || groupID == "" {
+		return nil, false
+	}
+	submitter, ok := r.byGroup[groupID]
+	return submitter, ok
+}
+
+func (r GroupSubmitterRegistryV1) GroupIDs() []GroupID {
+	return slices.Clone(r.groups)
+}
+
+func (r GroupSubmitterRegistryV1) empty() bool {
+	return len(r.byGroup) == 0
+}
+
+// GroupRoutedSubmitterOptions configures an in-process dispatcher over local
+// group submitters.
+type GroupRoutedSubmitterOptions struct {
+	Registry GroupSubmitterRegistryV1
+}
+
+// GroupRoutedSubmitter dispatches collection and single-token routed writes to
+// the configured local group submitter. Unsupported, missing, unknown, and
+// fanout-required route metadata is rejected before any group submitter sees
+// the entry.
+type GroupRoutedSubmitter struct {
+	registry GroupSubmitterRegistryV1
+}
+
+func NewGroupRoutedSubmitter(opts GroupRoutedSubmitterOptions) (*GroupRoutedSubmitter, error) {
+	if opts.Registry.empty() {
+		return nil, errors.Join(ErrInvalidSubmitter, fmt.Errorf("group submitter registry is required"))
+	}
+	return &GroupRoutedSubmitter{registry: opts.Registry}, nil
+}
+
+func (s *GroupRoutedSubmitter) SubmitCommandEntryV1(ctx context.Context, entry []byte, metadata raftentry.RequestMetadataV1) (SubmitResultV1, error) {
+	if s == nil || s.registry.empty() {
+		return SubmitResultV1{}, ErrInvalidSubmitter
+	}
+	target, err := routeDispatchTargetFromMetadata(metadata)
+	if err != nil {
+		return SubmitResultV1{}, err
+	}
+	submitter, ok := s.registry.Lookup(target.GroupID)
+	if !ok {
+		return SubmitResultV1{}, errors.Join(ErrRouteTargetUnknown, fmt.Errorf("route group %q is not configured locally", target.GroupID))
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return submitter.SubmitCommandEntryV1(ctx, bytes.Clone(entry), cloneRequestMetadataV1(metadata))
+}
+
+func (s *GroupRoutedSubmitter) ClusterAdmissionStatus(ctx context.Context) (AdmissionStatus, error) {
+	if s == nil || s.registry.empty() {
+		return AdmissionStatus{}, ErrInvalidSubmitter
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	var firstFollower AdmissionStatus
+	var sawFollower bool
+	var firstUnavailable AdmissionStatus
+	var sawUnavailable bool
+	var firstLeader AdmissionStatus
+	var sawLeader bool
+	var missingAdmission AdmissionStatus
+	var sawMissingAdmission bool
+	for _, groupID := range s.registry.GroupIDs() {
+		submitter, ok := s.registry.Lookup(groupID)
+		if !ok {
+			continue
+		}
+		provider, ok := submitter.(AdmissionProvider)
+		if !ok {
+			if !sawMissingAdmission {
+				missingAdmission = UnavailableAdmission(fmt.Sprintf("group %q admission provider is unavailable", groupID))
+				sawMissingAdmission = true
+			}
+			continue
+		}
+		status, err := provider.ClusterAdmissionStatus(ctx)
+		if err != nil {
+			return AdmissionStatus{}, err
+		}
+		if status.Leader {
+			if !sawLeader {
+				firstLeader = status
+				sawLeader = true
+			}
+			continue
+		}
+		if status.Unavailable {
+			if !sawUnavailable {
+				firstUnavailable = status
+				sawUnavailable = true
+			}
+			continue
+		}
+		if !sawFollower {
+			firstFollower = status
+			sawFollower = true
+		}
+	}
+	if sawMissingAdmission {
+		return missingAdmission, nil
+	}
+	if sawLeader {
+		return firstLeader, nil
+	}
+	if sawFollower {
+		return firstFollower, nil
+	}
+	if sawUnavailable {
+		return firstUnavailable, nil
+	}
+	return AdmissionStatus{Unavailable: true, Reason: "no configured group admission provider is available"}, nil
+}
+
+type routeDispatchTarget struct {
+	GroupID GroupID
+}
+
+func routeDispatchTargetFromMetadata(metadata raftentry.RequestMetadataV1) (routeDispatchTarget, error) {
+	if !metadata.ClusterRouteKnown {
+		return routeDispatchTarget{}, errors.Join(ErrRouteTargetMissing, fmt.Errorf("cluster route metadata is required for group-routed submit"))
+	}
+	if metadata.ClusterRouteDatabase == "" || metadata.ClusterRouteCatalog == "" || metadata.ClusterRouteCollection == "" {
+		return routeDispatchTarget{}, errors.Join(ErrRouteTargetMissing, fmt.Errorf("cluster route identity is incomplete"))
+	}
+	if metadata.ClusterRouteShape == "" {
+		return routeDispatchTarget{}, errors.Join(ErrRouteTargetMissing, fmt.Errorf("cluster route shape is required"))
+	}
+	if metadata.ClusterRoutePlacementMode == "" {
+		return routeDispatchTarget{}, errors.Join(ErrRouteTargetMissing, fmt.Errorf("cluster route placement mode is required"))
+	}
+	if metadata.ClusterRouteShape == clusterRouteShapeTokenBatchV1 {
+		return routeDispatchTarget{}, errors.Join(ErrRouteFanoutRequired, fmt.Errorf("cluster route shape %q requires split/fanout before group dispatch", metadata.ClusterRouteShape))
+	}
+	if metadata.ClusterRouteGroupID == "" {
+		return routeDispatchTarget{}, errors.Join(ErrRouteTargetMissing, fmt.Errorf("cluster route group id is required"))
+	}
+	switch metadata.ClusterRouteShape {
+	case clusterRouteShapeCollectionV1:
+		if metadata.ClusterRoutePlacementMode != clusterRoutePlacementCollectionV1 {
+			return routeDispatchTarget{}, errors.Join(ErrRouteGroupMismatch, fmt.Errorf("collection route uses placement mode %q", metadata.ClusterRoutePlacementMode))
+		}
+	case clusterRouteShapeTokenV1:
+		switch metadata.ClusterRoutePlacementMode {
+		case clusterRoutePlacementTokenV1, clusterRoutePlacementRingV1:
+		default:
+			return routeDispatchTarget{}, errors.Join(ErrRouteGroupMismatch, fmt.Errorf("token route uses placement mode %q", metadata.ClusterRoutePlacementMode))
+		}
+		if !metadata.ClusterRouteTokenKnown {
+			return routeDispatchTarget{}, errors.Join(ErrRouteTargetMissing, fmt.Errorf("token route missing document token"))
+		}
+		if metadata.ClusterRoutePartitionID == "" {
+			return routeDispatchTarget{}, errors.Join(ErrRouteTargetMissing, fmt.Errorf("token route missing partition id"))
+		}
+	default:
+		return routeDispatchTarget{}, errors.Join(ErrRouteTargetUnsupported, fmt.Errorf("cluster route shape %q is not supported", metadata.ClusterRouteShape))
+	}
+	return routeDispatchTarget{GroupID: GroupID(metadata.ClusterRouteGroupID)}, nil
+}

--- a/TreeDB/internal/raftcluster/dispatcher_test.go
+++ b/TreeDB/internal/raftcluster/dispatcher_test.go
@@ -1,0 +1,252 @@
+package raftcluster
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	iwire "github.com/snissn/gomap/TreeDB/internal/nativewire"
+	"github.com/snissn/gomap/TreeDB/internal/raftentry"
+)
+
+type recordingGroupSubmitter struct {
+	groupID GroupID
+	status  AdmissionStatus
+	err     error
+	calls   []recordingGroupSubmitCall
+}
+
+type recordingGroupSubmitCall struct {
+	entry    []byte
+	metadata raftentry.RequestMetadataV1
+}
+
+type submitOnlyGroupSubmitter struct {
+	groupID GroupID
+}
+
+func (s *submitOnlyGroupSubmitter) Config() ResolvedConfig {
+	return ResolvedConfig{GroupID: s.groupID}
+}
+
+func (s *submitOnlyGroupSubmitter) SubmitCommandEntryV1(context.Context, []byte, raftentry.RequestMetadataV1) (SubmitResultV1, error) {
+	panic("unexpected submit")
+}
+
+func (s *recordingGroupSubmitter) Config() ResolvedConfig {
+	return ResolvedConfig{GroupID: s.groupID}
+}
+
+func (s *recordingGroupSubmitter) ClusterAdmissionStatus(context.Context) (AdmissionStatus, error) {
+	if s.status == (AdmissionStatus{}) {
+		return LeaderAdmission(), nil
+	}
+	return s.status, nil
+}
+
+func (s *recordingGroupSubmitter) SubmitCommandEntryV1(_ context.Context, entry []byte, metadata raftentry.RequestMetadataV1) (SubmitResultV1, error) {
+	s.calls = append(s.calls, recordingGroupSubmitCall{
+		entry:    bytes.Clone(entry),
+		metadata: cloneRequestMetadataV1(metadata),
+	})
+	if s.err != nil {
+		return SubmitResultV1{}, s.err
+	}
+	return SubmitResultV1{
+		ActualAck: metadata.AckPolicy,
+		CommittedEntry: CommittedCommandEntryV1{
+			Term:            1,
+			Index:           uint64(len(s.calls)),
+			Bytes:           bytes.Clone(entry),
+			RequestMetadata: cloneRequestMetadataV1(metadata),
+		},
+		Evidence: CommitEvidenceV1{
+			Kind:                CommitEvidenceProductionConsensusV1,
+			GroupID:             s.groupID,
+			Term:                1,
+			Index:               uint64(len(s.calls)),
+			Committed:           true,
+			ProductionConsensus: true,
+		},
+	}, nil
+}
+
+func (s *recordingGroupSubmitter) snapshot() []recordingGroupSubmitCall {
+	out := make([]recordingGroupSubmitCall, len(s.calls))
+	for i := range s.calls {
+		out[i] = recordingGroupSubmitCall{
+			entry:    bytes.Clone(s.calls[i].entry),
+			metadata: cloneRequestMetadataV1(s.calls[i].metadata),
+		}
+	}
+	return out
+}
+
+func TestGroupRoutedSubmitterRoutesCollectionAndTokenTargets(t *testing.T) {
+	groupA := &recordingGroupSubmitter{groupID: "group-a"}
+	groupB := &recordingGroupSubmitter{groupID: "group-b"}
+	dispatcher := newTestGroupRoutedSubmitter(t, groupA, groupB)
+	entry := testClusterCommandEntry(t, 7)
+
+	collectionMeta := routeMetadata("group-b", iwire.AckVisible)
+	collectionMeta.RequestID = 101
+	collectionMeta.TraceContext = []byte("trace-b")
+	collectionResult, err := dispatcher.SubmitCommandEntryV1(context.Background(), entry, collectionMeta)
+	if err != nil {
+		t.Fatalf("SubmitCommandEntryV1 collection route: %v", err)
+	}
+	if calls := groupA.snapshot(); len(calls) != 0 {
+		t.Fatalf("group-a calls=%d want 0 before token route", len(calls))
+	}
+	groupBCalls := groupB.snapshot()
+	if len(groupBCalls) != 1 {
+		t.Fatalf("group-b calls=%d want 1", len(groupBCalls))
+	}
+	if groupBCalls[0].metadata.ClusterRouteGroupID != "group-b" || groupBCalls[0].metadata.RequestID != 101 || string(groupBCalls[0].metadata.TraceContext) != "trace-b" {
+		t.Fatalf("group-b metadata=%+v want group-b request metadata preserved", groupBCalls[0].metadata)
+	}
+	if collectionResult.CommittedEntry.RequestMetadata.ClusterRouteGroupID != "group-b" {
+		t.Fatalf("committed collection route group=%q want group-b", collectionResult.CommittedEntry.RequestMetadata.ClusterRouteGroupID)
+	}
+
+	tokenMeta := routeMetadata("group-a", iwire.AckRaftCommitted)
+	tokenMeta.ClusterRouteShape = clusterRouteShapeTokenV1
+	tokenMeta.ClusterRoutePlacementMode = clusterRoutePlacementTokenV1
+	tokenMeta.ClusterRouteTokenKnown = true
+	tokenMeta.ClusterRouteToken = 42
+	tokenMeta.ClusterRoutePartitionID = "p0"
+	tokenMeta.ClusterRouteLeaderHint = "node-a"
+	tokenMeta.TraceContext = []byte("trace-a")
+	tokenResult, err := dispatcher.SubmitCommandEntryV1(context.Background(), entry, tokenMeta)
+	if err != nil {
+		t.Fatalf("SubmitCommandEntryV1 token route: %v", err)
+	}
+	groupACalls := groupA.snapshot()
+	if len(groupACalls) != 1 {
+		t.Fatalf("group-a calls=%d want 1", len(groupACalls))
+	}
+	if got := groupACalls[0].metadata; got.ClusterRouteShape != clusterRouteShapeTokenV1 || !got.ClusterRouteTokenKnown || got.ClusterRouteToken != 42 || got.ClusterRoutePartitionID != "p0" {
+		t.Fatalf("group-a token metadata=%+v want token route p0 token=42", got)
+	}
+	if tokenResult.ActualAck != iwire.AckRaftCommitted || tokenResult.CommittedEntry.RequestMetadata.ClusterRouteToken != 42 {
+		t.Fatalf("token result ack/token=%d/%d want raft_committed/42", tokenResult.ActualAck, tokenResult.CommittedEntry.RequestMetadata.ClusterRouteToken)
+	}
+}
+
+func TestGroupRoutedSubmitterRejectsUnsupportedRoutesBeforeSubmit(t *testing.T) {
+	groupA := &recordingGroupSubmitter{groupID: "group-a"}
+	dispatcher := newTestGroupRoutedSubmitter(t, groupA)
+	entry := testClusterCommandEntry(t, 7)
+
+	valid := routeMetadata("group-a", iwire.AckVisible)
+	token := valid
+	token.ClusterRouteShape = clusterRouteShapeTokenV1
+	token.ClusterRoutePlacementMode = clusterRoutePlacementTokenV1
+	token.ClusterRouteTokenKnown = true
+	token.ClusterRouteToken = 11
+	token.ClusterRoutePartitionID = "p0"
+
+	tests := []struct {
+		name string
+		meta raftentry.RequestMetadataV1
+		want error
+	}{
+		{name: "missing_route", meta: raftentry.RequestMetadataV1{AckPolicy: iwire.AckVisible}, want: ErrRouteTargetMissing},
+		{name: "missing_identity", meta: func() raftentry.RequestMetadataV1 {
+			meta := valid
+			meta.ClusterRouteCollection = ""
+			return meta
+		}(), want: ErrRouteTargetMissing},
+		{name: "missing_group", meta: routeMetadata("", iwire.AckVisible), want: ErrRouteTargetMissing},
+		{name: "unknown_group", meta: routeMetadata("group-z", iwire.AckVisible), want: ErrRouteTargetUnknown},
+		{name: "fanout_required", meta: func() raftentry.RequestMetadataV1 {
+			meta := valid
+			meta.ClusterRouteShape = clusterRouteShapeTokenBatchV1
+			meta.ClusterRoutePlacementMode = clusterRoutePlacementTokenV1
+			return meta
+		}(), want: ErrRouteFanoutRequired},
+		{name: "collection_mode_mismatch", meta: func() raftentry.RequestMetadataV1 {
+			meta := valid
+			meta.ClusterRoutePlacementMode = clusterRoutePlacementTokenV1
+			return meta
+		}(), want: ErrRouteGroupMismatch},
+		{name: "token_missing_token", meta: func() raftentry.RequestMetadataV1 {
+			meta := token
+			meta.ClusterRouteTokenKnown = false
+			return meta
+		}(), want: ErrRouteTargetMissing},
+		{name: "token_missing_partition", meta: func() raftentry.RequestMetadataV1 {
+			meta := token
+			meta.ClusterRoutePartitionID = ""
+			return meta
+		}(), want: ErrRouteTargetMissing},
+		{name: "unsupported_shape", meta: func() raftentry.RequestMetadataV1 {
+			meta := valid
+			meta.ClusterRouteShape = "scatter"
+			return meta
+		}(), want: ErrRouteTargetUnsupported},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			before := len(groupA.snapshot())
+			_, err := dispatcher.SubmitCommandEntryV1(context.Background(), entry, tt.meta)
+			if !errors.Is(err, tt.want) {
+				t.Fatalf("SubmitCommandEntryV1 err=%v want %v", err, tt.want)
+			}
+			if after := len(groupA.snapshot()); after != before {
+				t.Fatalf("group-a calls after rejection=%d want %d", after, before)
+			}
+		})
+	}
+}
+
+func TestGroupSubmitterRegistryRejectsMismatchedConfiguredGroup(t *testing.T) {
+	_, err := NewGroupSubmitterRegistryV1([]GroupSubmitterV1{
+		{GroupID: "group-a", Submitter: &recordingGroupSubmitter{groupID: "group-b"}},
+	})
+	if !errors.Is(err, ErrInvalidSubmitter) {
+		t.Fatalf("NewGroupSubmitterRegistryV1 err=%v want invalid submitter", err)
+	}
+}
+
+func TestGroupRoutedSubmitterAdmissionMissingProviderFailsClosed(t *testing.T) {
+	groupA := &recordingGroupSubmitter{groupID: "group-a", status: LeaderAdmission()}
+	registry, err := NewGroupSubmitterRegistryV1([]GroupSubmitterV1{
+		{GroupID: "group-a", Submitter: groupA},
+		{GroupID: "group-b", Submitter: &submitOnlyGroupSubmitter{groupID: "group-b"}},
+	})
+	if err != nil {
+		t.Fatalf("NewGroupSubmitterRegistryV1: %v", err)
+	}
+	dispatcher, err := NewGroupRoutedSubmitter(GroupRoutedSubmitterOptions{Registry: registry})
+	if err != nil {
+		t.Fatalf("NewGroupRoutedSubmitter: %v", err)
+	}
+	status, err := dispatcher.ClusterAdmissionStatus(context.Background())
+	if err != nil {
+		t.Fatalf("ClusterAdmissionStatus: %v", err)
+	}
+	if !status.Unavailable || !strings.Contains(status.Reason, "group \"group-b\" admission provider is unavailable") {
+		t.Fatalf("ClusterAdmissionStatus=%+v want unavailable missing group-b admission provider", status)
+	}
+}
+
+func newTestGroupRoutedSubmitter(tb testing.TB, submitters ...*recordingGroupSubmitter) *GroupRoutedSubmitter {
+	tb.Helper()
+	entries := make([]GroupSubmitterV1, len(submitters))
+	for i, submitter := range submitters {
+		entries[i] = GroupSubmitterV1{GroupID: submitter.groupID, Submitter: submitter}
+	}
+	registry, err := NewGroupSubmitterRegistryV1(entries)
+	if err != nil {
+		tb.Fatalf("NewGroupSubmitterRegistryV1: %v", err)
+	}
+	dispatcher, err := NewGroupRoutedSubmitter(GroupRoutedSubmitterOptions{Registry: registry})
+	if err != nil {
+		tb.Fatalf("NewGroupRoutedSubmitter: %v", err)
+	}
+	return dispatcher
+}

--- a/TreeDB/internal/raftcluster/submit.go
+++ b/TreeDB/internal/raftcluster/submit.go
@@ -27,6 +27,10 @@ var (
 	ErrCatalogVersionMismatch    = errors.New("raftcluster: catalog version mismatch")
 	ErrUnexpectedCommittedTarget = errors.New("raftcluster: committed target mismatch")
 	ErrRouteGroupMismatch        = errors.New("raftcluster: route group mismatch")
+	ErrRouteTargetMissing        = errors.New("raftcluster: route target missing")
+	ErrRouteTargetUnknown        = errors.New("raftcluster: route target unknown")
+	ErrRouteTargetUnsupported    = errors.New("raftcluster: route target unsupported")
+	ErrRouteFanoutRequired       = errors.New("raftcluster: route fanout required")
 )
 
 // AdmissionProvider exposes the single-group write-admission state. Returning
@@ -301,6 +305,13 @@ type SubmitResultV1 struct {
 	Evidence             CommitEvidenceV1
 	CatalogVersion       uint64
 	HasCatalogVersion    bool
+}
+
+// CommandSubmitterV1 is the in-process boundary for submitting deterministic
+// command entries. Single-group submitters and group-routed dispatchers both
+// implement this interface.
+type CommandSubmitterV1 interface {
+	SubmitCommandEntryV1(context.Context, []byte, raftentry.RequestMetadataV1) (SubmitResultV1, error)
 }
 
 func NewSingleGroupSubmitter(opts SingleGroupSubmitterOptions) (*SingleGroupSubmitter, error) {

--- a/TreeDB/mongo_gateway/cluster_submitter_test.go
+++ b/TreeDB/mongo_gateway/cluster_submitter_test.go
@@ -45,6 +45,125 @@ type mongoClusterAdmissionSubmitter struct {
 	err    error
 }
 
+type mongoRecordingRaftCommandSubmitter struct {
+	groupID raftcluster.GroupID
+	status  raftcluster.AdmissionStatus
+	err     error
+	mu      sync.Mutex
+	calls   []mongoRecordingRaftCommandSubmitCall
+}
+
+type mongoRecordingRaftCommandSubmitCall struct {
+	entry    raftentry.CommandEntryV1
+	metadata raftentry.RequestMetadataV1
+}
+
+func (s *mongoRecordingRaftCommandSubmitter) Config() raftcluster.ResolvedConfig {
+	return raftcluster.ResolvedConfig{GroupID: s.groupID}
+}
+
+func (s *mongoRecordingRaftCommandSubmitter) ClusterAdmissionStatus(context.Context) (raftcluster.AdmissionStatus, error) {
+	if s.status == (raftcluster.AdmissionStatus{}) {
+		return raftcluster.LeaderAdmission(), nil
+	}
+	return s.status, nil
+}
+
+func (s *mongoRecordingRaftCommandSubmitter) SubmitCommandEntryV1(ctx context.Context, entry []byte, metadata raftentry.RequestMetadataV1) (raftcluster.SubmitResultV1, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	select {
+	case <-ctx.Done():
+		return raftcluster.SubmitResultV1{}, ctx.Err()
+	default:
+	}
+	decoded, err := raftentry.DecodeCommandEntryV1(entry, raftentry.DecodeOptions{RequestMetadata: metadata})
+	if err != nil {
+		return raftcluster.SubmitResultV1{}, err
+	}
+	s.mu.Lock()
+	index := uint64(len(s.calls) + 1)
+	s.calls = append(s.calls, mongoRecordingRaftCommandSubmitCall{entry: decoded, metadata: cloneMongoClusterRequestMetadata(metadata)})
+	s.mu.Unlock()
+	if s.err != nil {
+		return raftcluster.SubmitResultV1{}, s.err
+	}
+	actualAck := metadata.AckPolicy
+	if actualAck == 0 {
+		actualAck = iwire.AckVisible
+	}
+	ids := mongoClusterTestIDs(decoded.Decoded.Sections)
+	affected := int64(len(ids))
+	if affected == 0 {
+		affected = 1
+	}
+	expectedTarget := decoded.Target.Clone()
+	return raftcluster.SubmitResultV1{
+		ActualAck:            actualAck,
+		CommittedRecoverable: actualAck == iwire.AckRaftCommitted,
+		DecodedEntry:         decoded,
+		ApplyResult: raftentry.ApplyResultV1{
+			Status:        raftentry.ApplyStatusApplied,
+			AffectedCount: affected,
+			MatchedCount:  affected,
+		},
+		CommittedEntry: raftcluster.CommittedCommandEntryV1{
+			Term:                     1,
+			Index:                    index,
+			Bytes:                    append([]byte(nil), entry...),
+			CurrentCatalogVersion:    60,
+			HasCurrentCatalogVersion: true,
+			SyncLocalCommandWAL:      true,
+			RequestMetadata:          cloneMongoClusterRequestMetadata(metadata),
+			ExpectedTarget:           &expectedTarget,
+		},
+		Evidence: raftcluster.CommitEvidenceV1{
+			Kind:                raftcluster.CommitEvidenceProductionConsensusV1,
+			GroupID:             s.groupID,
+			Term:                1,
+			Index:               index,
+			Committed:           true,
+			ProductionConsensus: true,
+		},
+		CatalogVersion:    60,
+		HasCatalogVersion: true,
+	}, nil
+}
+
+func (s *mongoRecordingRaftCommandSubmitter) snapshotCalls() []mongoRecordingRaftCommandSubmitCall {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]mongoRecordingRaftCommandSubmitCall, len(s.calls))
+	copy(out, s.calls)
+	return out
+}
+
+type mongoStaticClusterRouteProvider struct {
+	mu     sync.Mutex
+	target treenativewire.ClusterRouteTarget
+	err    error
+	routes []treenativewire.ClusterRouteRequest
+}
+
+func (p *mongoStaticClusterRouteProvider) ClusterRoute(ctx context.Context, req treenativewire.ClusterRouteRequest) (treenativewire.ClusterRouteTarget, error) {
+	p.mu.Lock()
+	p.routes = append(p.routes, req)
+	p.mu.Unlock()
+	if p.err != nil {
+		return treenativewire.ClusterRouteTarget{}, p.err
+	}
+	target := p.target
+	target.Members = append([]string(nil), target.Members...)
+	return target, nil
+}
+
+func (p *mongoStaticClusterRouteProvider) snapshotRoutes() []treenativewire.ClusterRouteRequest {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return append([]treenativewire.ClusterRouteRequest(nil), p.routes...)
+}
+
 type mongoRoutingClusterSubmitter struct {
 	*mongoClusterFakeSubmitter
 
@@ -201,6 +320,12 @@ func mongoClusterTestIDs(sections []iwire.Section) [][]byte {
 	return nil
 }
 
+func cloneMongoClusterRequestMetadata(metadata treenativewire.ClusterRequestMetadata) treenativewire.ClusterRequestMetadata {
+	metadata.TraceContext = append([]byte(nil), metadata.TraceContext...)
+	metadata.ClusterRouteMembers = append([]string(nil), metadata.ClusterRouteMembers...)
+	return metadata
+}
+
 func mongoClusterStaticCatalogVersion(version uint64) ClusterCatalogVersionProvider {
 	return func(context.Context) (uint64, error) {
 		return version, nil
@@ -347,6 +472,37 @@ func newMongoPlacementRouteTestServer(tb testing.TB, mode raftplacement.Placemen
 	server.ClusterSubmitter = submitter
 	server.ClusterCatalogVersion = mongoClusterStaticCatalogVersion(60)
 	return server, submitter
+}
+
+func newMongoGroupRoutedDispatcherTestServer(tb testing.TB, provider treenativewire.ClusterRouteProvider) (*Server, *mongoRecordingRaftCommandSubmitter, *mongoRecordingRaftCommandSubmitter) {
+	tb.Helper()
+	db, err := backenddb.Open(backenddb.Options{Dir: tb.TempDir()})
+	if err != nil {
+		tb.Fatalf("open db: %v", err)
+	}
+	tb.Cleanup(func() { _ = db.Close() })
+	server := NewServer()
+	server.Collections = collections.NewCollectionManager(db)
+	server.DefaultCollectionOptions = collections.CollectionOptions{DocumentFormat: collections.DocumentFormatBSON}
+	if _, err := server.Collections.CreateCollection(server.defaultCollectionMeta("app.users")); err != nil {
+		tb.Fatalf("create app.users: %v", err)
+	}
+	groupA := &mongoRecordingRaftCommandSubmitter{groupID: "group-a"}
+	groupB := &mongoRecordingRaftCommandSubmitter{groupID: "group-b"}
+	registry, err := raftcluster.NewGroupSubmitterRegistryV1([]raftcluster.GroupSubmitterV1{
+		{GroupID: "group-a", Submitter: groupA},
+		{GroupID: "group-b", Submitter: groupB},
+	})
+	if err != nil {
+		tb.Fatalf("NewGroupSubmitterRegistryV1: %v", err)
+	}
+	dispatcher, err := raftcluster.NewGroupRoutedSubmitter(raftcluster.GroupRoutedSubmitterOptions{Registry: registry})
+	if err != nil {
+		tb.Fatalf("NewGroupRoutedSubmitter: %v", err)
+	}
+	server.ClusterSubmitter = treenativewire.NewRoutedRaftClusterSubmitter(dispatcher, provider, server.Collections)
+	server.ClusterCatalogVersion = mongoClusterStaticCatalogVersion(60)
+	return server, groupA, groupB
 }
 
 func newMongoRaftBridgeTestServer(tb testing.TB, admission raftcluster.AdmissionStatus) *Server {
@@ -756,6 +912,115 @@ func TestClusterRoutePreflightMongoTokenPlacementRejectsMultiIDWrites(t *testing
 				t.Fatalf("submit calls=%d want 0", len(calls))
 			}
 		})
+	}
+}
+
+func TestMongoGroupRoutedDispatcherRoutesCollectionBatchWrite(t *testing.T) {
+	provider := &mongoStaticClusterRouteProvider{
+		target: treenativewire.ClusterRouteTarget{
+			GroupID:       "group-b",
+			Members:       []string{"node-b", "node-c"},
+			LeaderHint:    "node-b",
+			PlacementMode: "collection",
+			Shape:         treenativewire.ClusterRouteShapeCollection,
+		},
+	}
+	server, groupA, groupB := newMongoGroupRoutedDispatcherTestServer(t, provider)
+	response := serveCommand(t, server, 336301, bson.D{
+		{Key: "insert", Value: "users"},
+		{Key: "documents", Value: bson.A{
+			bson.D{{Key: "_id", Value: "u1"}, {Key: "name", Value: "Ada"}},
+			bson.D{{Key: "_id", Value: "u2"}, {Key: "name", Value: "Grace"}},
+		}},
+		{Key: "$db", Value: "app"},
+	})
+	assertOK(t, response)
+	assertInt32(t, response, "n", 2)
+	if calls := groupA.snapshotCalls(); len(calls) != 0 {
+		t.Fatalf("group-a calls=%d want 0", len(calls))
+	}
+	calls := groupB.snapshotCalls()
+	if len(calls) != 1 {
+		t.Fatalf("group-b calls=%d want 1", len(calls))
+	}
+	if got := calls[0].entry.Decoded.CommandID; got != iwire.CommandInsertBatch {
+		t.Fatalf("group-b command=%d want insert_batch", got)
+	}
+	meta := calls[0].metadata
+	if !meta.ClusterRouteKnown || meta.ClusterRouteShape != string(treenativewire.ClusterRouteShapeCollection) || meta.ClusterRouteGroupID != "group-b" || meta.ClusterRouteLeaderHint != "node-b" || meta.ClusterRoutePlacementMode != "collection" {
+		t.Fatalf("group-b collection route metadata=%+v want collection route to group-b/node-b", meta)
+	}
+	routes := provider.snapshotRoutes()
+	if len(routes) != 1 {
+		t.Fatalf("route calls=%d want 1", len(routes))
+	}
+	if got := routes[0]; got.Shape != treenativewire.ClusterRouteShapeTokenBatch || len(got.Tokens) != 2 {
+		t.Fatalf("route request=%+v want token_batch classification for two IDs", got)
+	}
+}
+
+func TestMongoGroupRoutedDispatcherRoutesSingleTokenWrite(t *testing.T) {
+	token := mongoClusterRouteTokenForValue(t, "u1")
+	provider := &mongoStaticClusterRouteProvider{
+		target: treenativewire.ClusterRouteTarget{
+			GroupID:       "group-b",
+			Members:       []string{"node-b", "node-c"},
+			LeaderHint:    "node-b",
+			PlacementMode: "token",
+			Shape:         treenativewire.ClusterRouteShapeToken,
+			TokenKnown:    true,
+			Token:         token,
+			PartitionID:   "p0",
+		},
+	}
+	server, groupA, groupB := newMongoGroupRoutedDispatcherTestServer(t, provider)
+	response := serveCommand(t, server, 336302, bson.D{
+		{Key: "insert", Value: "users"},
+		{Key: "documents", Value: bson.A{bson.D{{Key: "_id", Value: "u1"}, {Key: "name", Value: "Ada"}}}},
+		{Key: "$db", Value: "app"},
+	})
+	assertOK(t, response)
+	assertInt32(t, response, "n", 1)
+	if calls := groupA.snapshotCalls(); len(calls) != 0 {
+		t.Fatalf("group-a calls=%d want 0", len(calls))
+	}
+	calls := groupB.snapshotCalls()
+	if len(calls) != 1 {
+		t.Fatalf("group-b calls=%d want 1", len(calls))
+	}
+	meta := calls[0].metadata
+	if !meta.ClusterRouteKnown || meta.ClusterRouteShape != string(treenativewire.ClusterRouteShapeToken) || meta.ClusterRouteGroupID != "group-b" || !meta.ClusterRouteTokenKnown || meta.ClusterRouteToken != token || meta.ClusterRoutePartitionID != "p0" {
+		t.Fatalf("group-b token route metadata=%+v want group-b token=%d p0", meta, token)
+	}
+}
+
+func TestMongoGroupRoutedDispatcherRejectsUnknownGroupBeforeSubmit(t *testing.T) {
+	token := mongoClusterRouteTokenForValue(t, "u1")
+	provider := &mongoStaticClusterRouteProvider{
+		target: treenativewire.ClusterRouteTarget{
+			GroupID:       "group-z",
+			Members:       []string{"node-z"},
+			LeaderHint:    "node-z",
+			PlacementMode: "token",
+			Shape:         treenativewire.ClusterRouteShapeToken,
+			TokenKnown:    true,
+			Token:         token,
+			PartitionID:   "p0",
+		},
+	}
+	server, groupA, groupB := newMongoGroupRoutedDispatcherTestServer(t, provider)
+	response := serveCommand(t, server, 336303, bson.D{
+		{Key: "insert", Value: "users"},
+		{Key: "documents", Value: bson.A{bson.D{{Key: "_id", Value: "u1"}, {Key: "name", Value: "Ada"}}}},
+		{Key: "$db", Value: "app"},
+	})
+	assertCommandError(t, response, "NotWritablePrimary")
+	assertErrmsgContains(t, response, "route target unknown")
+	if calls := groupA.snapshotCalls(); len(calls) != 0 {
+		t.Fatalf("group-a calls=%d want 0", len(calls))
+	}
+	if calls := groupB.snapshotCalls(); len(calls) != 0 {
+		t.Fatalf("group-b calls=%d want 0", len(calls))
 	}
 }
 

--- a/TreeDB/nativewire/cluster_raft_submitter.go
+++ b/TreeDB/nativewire/cluster_raft_submitter.go
@@ -16,7 +16,7 @@ import (
 // RaftClusterSubmitter adapts the internal single-group raftcluster bridge to
 // the public nativewire ClusterSubmitter contract.
 type RaftClusterSubmitter struct {
-	Bridge      *raftcluster.SingleGroupSubmitter
+	Bridge      raftcluster.CommandSubmitterV1
 	Collections *collections.CollectionManager
 }
 
@@ -29,7 +29,7 @@ type RoutedRaftClusterSubmitter struct {
 	RouteProvider ClusterRouteProvider
 }
 
-func NewRaftClusterSubmitter(bridge *raftcluster.SingleGroupSubmitter, managers ...*collections.CollectionManager) *RaftClusterSubmitter {
+func NewRaftClusterSubmitter(bridge raftcluster.CommandSubmitterV1, managers ...*collections.CollectionManager) *RaftClusterSubmitter {
 	submitter := &RaftClusterSubmitter{Bridge: bridge}
 	if len(managers) > 0 {
 		submitter.Collections = managers[0]
@@ -37,7 +37,7 @@ func NewRaftClusterSubmitter(bridge *raftcluster.SingleGroupSubmitter, managers 
 	return submitter
 }
 
-func NewRoutedRaftClusterSubmitter(bridge *raftcluster.SingleGroupSubmitter, provider ClusterRouteProvider, managers ...*collections.CollectionManager) *RoutedRaftClusterSubmitter {
+func NewRoutedRaftClusterSubmitter(bridge raftcluster.CommandSubmitterV1, provider ClusterRouteProvider, managers ...*collections.CollectionManager) *RoutedRaftClusterSubmitter {
 	return &RoutedRaftClusterSubmitter{
 		RaftClusterSubmitter: NewRaftClusterSubmitter(bridge, managers...),
 		RouteProvider:        provider,
@@ -55,7 +55,11 @@ func (s *RaftClusterSubmitter) ClusterAdmissionStatus(ctx context.Context) (Clus
 	if s == nil || s.Bridge == nil {
 		return ClusterAdmissionStatus{}, raftcluster.ErrInvalidSubmitter
 	}
-	status, err := s.Bridge.ClusterAdmissionStatus(ctx)
+	provider, ok := s.Bridge.(raftcluster.AdmissionProvider)
+	if !ok {
+		return ClusterAdmissionStatus{}, raftcluster.ErrAdmissionUnavailable
+	}
+	status, err := provider.ClusterAdmissionStatus(ctx)
 	if err != nil {
 		return ClusterAdmissionStatus{}, err
 	}
@@ -180,7 +184,11 @@ func nativeErrorForRaftClusterSubmit(err error) error {
 		return nil
 	case errors.Is(err, raftcluster.ErrNotLeader):
 		return protocolError(iwire.ErrReadOnly, "%v", err)
-	case errors.Is(err, raftcluster.ErrRouteGroupMismatch):
+	case errors.Is(err, raftcluster.ErrRouteGroupMismatch),
+		errors.Is(err, raftcluster.ErrRouteTargetMissing),
+		errors.Is(err, raftcluster.ErrRouteTargetUnknown),
+		errors.Is(err, raftcluster.ErrRouteTargetUnsupported),
+		errors.Is(err, raftcluster.ErrRouteFanoutRequired):
 		return protocolError(iwire.ErrReadOnly, "%v", err)
 	case errors.Is(err, raftcluster.ErrCatalogVersionMismatch):
 		return protocolError(iwire.ErrCatalogVersionMismatch, "%v", err)

--- a/TreeDB/nativewire/cluster_submitter_test.go
+++ b/TreeDB/nativewire/cluster_submitter_test.go
@@ -48,6 +48,133 @@ func (noAdmissionClusterSubmitter) SubmitCommandEntryV1(context.Context, []byte,
 	panic("unexpected submit")
 }
 
+type recordingRaftCommandSubmitter struct {
+	groupID raftcluster.GroupID
+	manager *collections.CollectionManager
+	status  raftcluster.AdmissionStatus
+	err     error
+	mu      sync.Mutex
+	calls   []recordingRaftCommandSubmitCall
+}
+
+type recordingRaftCommandSubmitCall struct {
+	entry    raftentry.CommandEntryV1
+	metadata raftentry.RequestMetadataV1
+}
+
+func (s *recordingRaftCommandSubmitter) Config() raftcluster.ResolvedConfig {
+	return raftcluster.ResolvedConfig{GroupID: s.groupID}
+}
+
+func (s *recordingRaftCommandSubmitter) ClusterAdmissionStatus(context.Context) (raftcluster.AdmissionStatus, error) {
+	if s.status == (raftcluster.AdmissionStatus{}) {
+		return raftcluster.LeaderAdmission(), nil
+	}
+	return s.status, nil
+}
+
+func (s *recordingRaftCommandSubmitter) SubmitCommandEntryV1(ctx context.Context, entry []byte, metadata raftentry.RequestMetadataV1) (raftcluster.SubmitResultV1, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	select {
+	case <-ctx.Done():
+		return raftcluster.SubmitResultV1{}, ctx.Err()
+	default:
+	}
+	decoded, err := raftentry.DecodeCommandEntryV1(entry, raftentry.DecodeOptions{RequestMetadata: metadata})
+	if err != nil {
+		return raftcluster.SubmitResultV1{}, err
+	}
+	s.mu.Lock()
+	index := uint64(len(s.calls) + 1)
+	s.calls = append(s.calls, recordingRaftCommandSubmitCall{entry: decoded, metadata: cloneClusterRequestMetadata(metadata)})
+	s.mu.Unlock()
+	if s.err != nil {
+		return raftcluster.SubmitResultV1{}, s.err
+	}
+	applyResult, err := s.applyForTest(decoded)
+	if err != nil {
+		return raftcluster.SubmitResultV1{}, err
+	}
+	actualAck := metadata.AckPolicy
+	if actualAck == 0 {
+		actualAck = iwire.AckVisible
+	}
+	expectedTarget := decoded.Target.Clone()
+	committed := raftcluster.CommittedCommandEntryV1{
+		Term:                     1,
+		Index:                    index,
+		Bytes:                    bytes.Clone(entry),
+		CurrentCatalogVersion:    7,
+		HasCurrentCatalogVersion: true,
+		SyncLocalCommandWAL:      true,
+		RequestMetadata:          cloneClusterRequestMetadata(metadata),
+		ExpectedTarget:           &expectedTarget,
+	}
+	return raftcluster.SubmitResultV1{
+		ActualAck:            actualAck,
+		CommittedRecoverable: actualAck == iwire.AckRaftCommitted,
+		DecodedEntry:         decoded,
+		ApplyResult:          applyResult,
+		CommittedEntry:       committed,
+		Evidence: raftcluster.CommitEvidenceV1{
+			Kind:                raftcluster.CommitEvidenceProductionConsensusV1,
+			GroupID:             s.groupID,
+			Term:                1,
+			Index:               index,
+			Committed:           true,
+			ProductionConsensus: true,
+		},
+		CatalogVersion:    7,
+		HasCatalogVersion: true,
+	}, nil
+}
+
+func (s *recordingRaftCommandSubmitter) applyForTest(entry raftentry.CommandEntryV1) (raftentry.ApplyResultV1, error) {
+	switch entry.Decoded.CommandID {
+	case iwire.CommandCreateCollection:
+		if s.manager != nil {
+			rawMeta, err := metadataSection(entry.Decoded.Sections, iwire.SectionCollectionMeta)
+			if err != nil {
+				return raftentry.ApplyResultV1{}, err
+			}
+			meta, err := decodeCollectionMeta(rawMeta)
+			if err != nil {
+				return raftentry.ApplyResultV1{}, err
+			}
+			meta, err = normalizeClientCollectionMeta(meta)
+			if err != nil {
+				return raftentry.ApplyResultV1{}, err
+			}
+			if _, err := s.manager.CreateCollection(&meta); err != nil {
+				return raftentry.ApplyResultV1{}, err
+			}
+		}
+		return raftentry.ApplyResultV1{Status: raftentry.ApplyStatusApplied, AffectedCount: 1, MatchedCount: 1}, nil
+	case iwire.CommandInsertBatch:
+		rawIDs, err := metadataSection(entry.Decoded.Sections, iwire.SectionDocumentIDs)
+		if err != nil {
+			return raftentry.ApplyResultV1{}, err
+		}
+		ids, err := iwire.DecodeByteVectorItems(rawIDs, iwire.Limits{})
+		if err != nil {
+			return raftentry.ApplyResultV1{}, err
+		}
+		return raftentry.ApplyResultV1{Status: raftentry.ApplyStatusApplied, AffectedCount: int64(len(ids)), MatchedCount: int64(len(ids))}, nil
+	default:
+		return raftentry.ApplyResultV1{Status: raftentry.ApplyStatusApplied, AffectedCount: 1, MatchedCount: 1}, nil
+	}
+}
+
+func (s *recordingRaftCommandSubmitter) snapshotCalls() []recordingRaftCommandSubmitCall {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]recordingRaftCommandSubmitCall, len(s.calls))
+	copy(out, s.calls)
+	return out
+}
+
 type routingClusterSubmitter struct {
 	*fakeClusterSubmitter
 
@@ -1837,6 +1964,116 @@ func TestRaftClusterSubmitterRouteGroupMismatchRejectsBeforeLocalMutation(t *tes
 	}
 }
 
+func TestRaftClusterSubmitterGroupRoutedDispatcherRoutesCollectionWrite(t *testing.T) {
+	provider := &staticClusterRouteProvider{
+		target: ClusterRouteTarget{
+			GroupID:       "group-b",
+			Members:       []string{"node-b", "node-c"},
+			LeaderHint:    "node-b",
+			PlacementMode: "collection",
+			Shape:         ClusterRouteShapeCollection,
+		},
+	}
+	client, groupA, groupB, mgr, _ := serveGroupRoutedRaftClusterBridgePipe(t, provider)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := client.Hello(ctx); err != nil {
+		t.Fatalf("Hello: %v", err)
+	}
+	version := clientCatalogVersion(t, client, ctx)
+	if _, err := client.commandSections(ctx, iwire.CommandCreateCollection, raftClusterCreateCollectionSections("users", version, AckVisible)...); err != nil {
+		t.Fatalf("CreateCollection group-routed dispatcher: %v", err)
+	}
+	if _, err := mgr.OpenCollection("users"); err != nil {
+		t.Fatalf("OpenCollection users after routed create: %v", err)
+	}
+	if calls := groupA.snapshotCalls(); len(calls) != 0 {
+		t.Fatalf("group-a calls=%d want 0", len(calls))
+	}
+	calls := groupB.snapshotCalls()
+	if len(calls) != 1 {
+		t.Fatalf("group-b calls=%d want 1", len(calls))
+	}
+	if got := calls[0].entry.Decoded.CommandID; got != iwire.CommandCreateCollection {
+		t.Fatalf("group-b command=%d want create_collection", got)
+	}
+	meta := calls[0].metadata
+	if !meta.ClusterRouteKnown || meta.ClusterRouteShape != string(ClusterRouteShapeCollection) || meta.ClusterRouteGroupID != "group-b" || meta.ClusterRouteLeaderHint != "node-b" || meta.ClusterRoutePlacementMode != "collection" {
+		t.Fatalf("group-b route metadata=%+v want collection route to group-b/node-b", meta)
+	}
+}
+
+func TestRaftClusterSubmitterGroupRoutedDispatcherRoutesSingleTokenWrite(t *testing.T) {
+	token := raftplacement.DocumentIDTokenV1([]byte("u1"))
+	provider := &staticClusterRouteProvider{
+		target: ClusterRouteTarget{
+			GroupID:       "group-b",
+			Members:       []string{"node-b", "node-c"},
+			LeaderHint:    "node-b",
+			PlacementMode: "token",
+			Shape:         ClusterRouteShapeToken,
+			TokenKnown:    true,
+			Token:         token,
+			PartitionID:   "p0",
+		},
+	}
+	client, groupA, groupB, _, _ := serveGroupRoutedRaftClusterBridgePipe(t, provider)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := client.Hello(ctx); err != nil {
+		t.Fatalf("Hello: %v", err)
+	}
+	if _, err := client.InsertBatch(ctx, "users", collections.DocumentFormatJSON, [][]byte{[]byte("u1")}, [][]byte{[]byte(`{"name":"Ada"}`)}, AckVisible); err != nil {
+		t.Fatalf("InsertBatch group-routed dispatcher: %v", err)
+	}
+	if calls := groupA.snapshotCalls(); len(calls) != 0 {
+		t.Fatalf("group-a calls=%d want 0", len(calls))
+	}
+	calls := groupB.snapshotCalls()
+	if len(calls) != 1 {
+		t.Fatalf("group-b calls=%d want 1", len(calls))
+	}
+	meta := calls[0].metadata
+	if got := calls[0].entry.Decoded.CommandID; got != iwire.CommandInsertBatch {
+		t.Fatalf("group-b command=%d want insert_batch", got)
+	}
+	if !meta.ClusterRouteKnown || meta.ClusterRouteShape != string(ClusterRouteShapeToken) || meta.ClusterRouteGroupID != "group-b" || !meta.ClusterRouteTokenKnown || meta.ClusterRouteToken != token || meta.ClusterRoutePartitionID != "p0" {
+		t.Fatalf("group-b token route metadata=%+v want group-b token=%d p0", meta, token)
+	}
+}
+
+func TestRaftClusterSubmitterGroupRoutedDispatcherRejectsUnknownGroupBeforeSubmit(t *testing.T) {
+	token := raftplacement.DocumentIDTokenV1([]byte("u1"))
+	provider := &staticClusterRouteProvider{
+		target: ClusterRouteTarget{
+			GroupID:       "group-z",
+			Members:       []string{"node-z"},
+			LeaderHint:    "node-z",
+			PlacementMode: "token",
+			Shape:         ClusterRouteShapeToken,
+			TokenKnown:    true,
+			Token:         token,
+			PartitionID:   "p0",
+		},
+	}
+	client, groupA, groupB, _, _ := serveGroupRoutedRaftClusterBridgePipe(t, provider)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := client.Hello(ctx); err != nil {
+		t.Fatalf("Hello: %v", err)
+	}
+	_, err := client.InsertBatch(ctx, "users", collections.DocumentFormatJSON, [][]byte{[]byte("u1")}, [][]byte{[]byte(`{"name":"Ada"}`)}, AckVisible)
+	if !isRemoteError(err, iwire.ErrReadOnly) || !strings.Contains(err.Error(), "route target unknown") {
+		t.Fatalf("InsertBatch unknown group err=%v want read-only route target unknown", err)
+	}
+	if calls := groupA.snapshotCalls(); len(calls) != 0 {
+		t.Fatalf("group-a calls=%d want 0", len(calls))
+	}
+	if calls := groupB.snapshotCalls(); len(calls) != 0 {
+		t.Fatalf("group-b calls=%d want 0", len(calls))
+	}
+}
+
 func TestRaftClusterSubmitterConcreteBridgeFollowerRejectsBeforeApply(t *testing.T) {
 	client, _, mgr, _ := serveRaftClusterBridgePipe(t, raftcluster.FollowerAdmission("node-b", "not leader"))
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
@@ -1963,6 +2200,38 @@ func serveRaftClusterBridgePipeWithRoute(t testing.TB, admission raftcluster.Adm
 		_ = db.Close()
 	})
 	return client, server, mgr, db
+}
+
+func serveGroupRoutedRaftClusterBridgePipe(t testing.TB, routeProvider ClusterRouteProvider) (*Client, *recordingRaftCommandSubmitter, *recordingRaftCommandSubmitter, *collections.CollectionManager, *backenddb.DB) {
+	t.Helper()
+	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	mgr := collections.NewCollectionManager(db)
+	groupA := &recordingRaftCommandSubmitter{groupID: "group-a", manager: mgr}
+	groupB := &recordingRaftCommandSubmitter{groupID: "group-b", manager: mgr}
+	registry, err := raftcluster.NewGroupSubmitterRegistryV1([]raftcluster.GroupSubmitterV1{
+		{GroupID: "group-a", Submitter: groupA},
+		{GroupID: "group-b", Submitter: groupB},
+	})
+	if err != nil {
+		_ = db.Close()
+		t.Fatalf("NewGroupSubmitterRegistryV1: %v", err)
+	}
+	dispatcher, err := raftcluster.NewGroupRoutedSubmitter(raftcluster.GroupRoutedSubmitterOptions{Registry: registry})
+	if err != nil {
+		_ = db.Close()
+		t.Fatalf("NewGroupRoutedSubmitter: %v", err)
+	}
+	server := NewServer(ServerOptions{
+		Collections:      mgr,
+		Backend:          db,
+		ClusterSubmitter: NewRoutedRaftClusterSubmitter(dispatcher, routeProvider, mgr),
+	})
+	client, _ := servePipe(t, server)
+	t.Cleanup(func() { _ = db.Close() })
+	return client, groupA, groupB, mgr, db
 }
 
 type recordingRaftClusterApplier struct {


### PR DESCRIPTION
## Summary
- Add a local group submitter registry and group-routed dispatcher for collection and single-token routes.
- Fail closed for missing, unknown, unsupported, mismatched, or fanout-required route metadata before any group submitter sees the entry.
- Preserve route/request metadata through dispatch and committed-entry evidence, and add nativewire plus Mongo routed-write coverage.

Fixes #3443
Refs #3046

## Validation
- `GOWORK=off go test ./TreeDB/internal/raftcluster ./TreeDB/nativewire ./TreeDB/mongo_gateway ./TreeDB/internal/raftentry -count=1`
- `git diff --check`

## Benchmark rationale
No standalone benchmark was run. This is an opt-in in-process dispatcher over already configured local group submitters; the existing single-group submit path is not replaced. Dispatch work is bounded route metadata validation, one registry lookup, and defensive cloning before delegating to the selected submitter. Any measured dispatch overhead regression in downstream multi-group integration should remain a blocker.

## Non-goals
- No network forwarding.
- No meta-group replication.
- No token-batch fanout.
- No rebalance or horizontal-scale claim.
- No #3439 failure/restart lifecycle harness work.
- No #3441 read-index/read policy work.

## Risks
- Cluster admission remains target-agnostic until a route-specific admission surface exists. The dispatcher still fails closed for missing group admission providers, and the selected group submitter rejects not-leader/unavailable targets at submit time.