### PR TITLE
TreeDB Raft: expose HA write surface metadata

### DIFF
--- a/TreeDB/internal/raftcluster/dispatcher.go
+++ b/TreeDB/internal/raftcluster/dispatcher.go
@@ -113,7 +113,7 @@ func (s *GroupRoutedSubmitter) SubmitCommandEntryV1(ctx context.Context, entry [
 	}
 	submitter, ok := s.registry.Lookup(target.GroupID)
 	if !ok {
-		return SubmitResultV1{}, errors.Join(ErrRouteTargetUnknown, fmt.Errorf("route group %q is not configured locally", target.GroupID))
+		return SubmitResultV1{}, errors.Join(ErrRouteTargetUnknown, routeErrorWithLeaderHint(metadata, "route group %q is not configured locally", target.GroupID))
 	}
 	if ctx == nil {
 		ctx = context.Background()

--- a/TreeDB/internal/raftcluster/submit.go
+++ b/TreeDB/internal/raftcluster/submit.go
@@ -559,9 +559,36 @@ func (s *SingleGroupSubmitter) checkRouteBinding(metadata raftentry.RequestMetad
 		return errors.Join(ErrRouteGroupMismatch, fmt.Errorf("route metadata missing group id for local group %q", localGroup))
 	}
 	if metadata.ClusterRouteGroupID != localGroup {
-		return errors.Join(ErrRouteGroupMismatch, fmt.Errorf("route group %q does not match local group %q", metadata.ClusterRouteGroupID, localGroup))
+		return errors.Join(ErrRouteGroupMismatch, routeErrorWithLeaderHint(metadata, "route group %q does not match local group %q", metadata.ClusterRouteGroupID, localGroup))
 	}
 	return nil
+}
+
+func routeErrorWithLeaderHint(metadata raftentry.RequestMetadataV1, format string, args ...any) error {
+	msg := fmt.Sprintf(format, args...)
+	if metadata.ClusterRouteLeaderHint == "" {
+		return errors.New(msg)
+	}
+	return &routeLeaderHintError{message: msg, leaderHint: metadata.ClusterRouteLeaderHint}
+}
+
+type routeLeaderHintError struct {
+	message    string
+	leaderHint string
+}
+
+func (e *routeLeaderHintError) Error() string {
+	if e == nil {
+		return ""
+	}
+	return e.message + "; leader_hint=" + e.leaderHint
+}
+
+func (e *routeLeaderHintError) ClusterLeaderHint() string {
+	if e == nil {
+		return ""
+	}
+	return e.leaderHint
 }
 
 func (s *SingleGroupSubmitter) validateCommitResult(request CommitCommandEntryV1Request, result CommitCommandEntryV1Result) (CommittedCommandEntryV1, error) {

--- a/TreeDB/internal/raftcluster/submit_test.go
+++ b/TreeDB/internal/raftcluster/submit_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -241,6 +242,9 @@ func TestSingleGroupSubmitterRejectsRouteGroupMismatchBeforePreflightCommitApply
 	_, err := submitter.SubmitCommandEntryV1(context.Background(), entry, routeMetadata("group-b", iwire.AckRaftCommitted))
 	if !errors.Is(err, ErrRouteGroupMismatch) {
 		t.Fatalf("SubmitCommandEntryV1 err=%v want route group mismatch", err)
+	}
+	if !strings.Contains(err.Error(), "leader_hint=node-a") {
+		t.Fatalf("SubmitCommandEntryV1 err=%v want leader hint", err)
 	}
 	if preflightCalls != 0 {
 		t.Fatalf("preflight calls=%d want 0", preflightCalls)

--- a/TreeDB/mongo_gateway/cluster_submitter.go
+++ b/TreeDB/mongo_gateway/cluster_submitter.go
@@ -931,7 +931,7 @@ func mongoClusterMutationCommandError(err error) (wire.Document, error) {
 			code, codeName = commandCodeDuplicateKey, "DuplicateKey"
 		}
 	}
-	if collections.IsDuplicateKeyError(err) {
+	if collections.IsDuplicateKeyError(err) && nativeCode != iwire.ErrCommitAmbiguous && !errors.Is(err, collections.ErrCommitAmbiguous) {
 		code, codeName = commandCodeDuplicateKey, "DuplicateKey"
 	}
 	return commandErrorWithFields(code, codeName, err.Error(), mongoClusterErrorFields(err, nativeCode, codeName))
@@ -957,11 +957,11 @@ func mongoClusterErrorClass(err error, nativeCode iwire.ErrorCode, codeName stri
 	message := strings.ToLower(err.Error())
 	switch nativeCode {
 	case iwire.ErrReadOnly:
-		if mongoClusterLeaderHint(err) != "" || strings.Contains(message, "not leader") {
-			return "not_leader"
-		}
 		if strings.Contains(message, "route group") || strings.Contains(message, "route") {
 			return "route_rejected"
+		}
+		if mongoClusterLeaderHint(err) != "" || strings.Contains(message, "not leader") {
+			return "not_leader"
 		}
 		return "read_only"
 	case iwire.ErrDurabilityUnavailable:
@@ -990,6 +990,14 @@ func mongoClusterErrorClass(err error, nativeCode iwire.ErrorCode, codeName stri
 func mongoClusterLeaderHint(err error) string {
 	if err == nil {
 		return ""
+	}
+	var hinted interface {
+		ClusterLeaderHint() string
+	}
+	if errors.As(err, &hinted) {
+		if leaderHint := strings.TrimSpace(hinted.ClusterLeaderHint()); leaderHint != "" {
+			return leaderHint
+		}
 	}
 	const marker = "leader_hint="
 	message := err.Error()

--- a/TreeDB/mongo_gateway/cluster_submitter.go
+++ b/TreeDB/mongo_gateway/cluster_submitter.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/snissn/gomap/TreeDB/collections"
 	iwire "github.com/snissn/gomap/TreeDB/internal/nativewire"
@@ -909,16 +910,20 @@ func parseClusterWriteConcernW(value bson.RawValue) (iwire.AckPolicy, error) {
 
 func mongoClusterMutationCommandError(err error) (wire.Document, error) {
 	code, codeName := commandCodeBadValue, "BadValue"
+	var nativeCode iwire.ErrorCode
 	var mongoErr mongoCommandError
 	if errors.As(err, &mongoErr) {
 		code, codeName = mongoErr.code, mongoErr.codeName
-	} else if nativeCode, ok := iwire.ErrorCodeOf(err); ok {
+	} else if parsedNativeCode, ok := iwire.ErrorCodeOf(err); ok {
+		nativeCode = parsedNativeCode
 		switch nativeCode {
 		case iwire.ErrUnsupportedFeature:
 			code, codeName = commandCodeBadValue, "BadValue"
 		case iwire.ErrReadOnly:
 			code, codeName = commandCodeNotWritablePrimary, "NotWritablePrimary"
 		case iwire.ErrDurabilityUnavailable:
+			code, codeName = commandCodeShutdownInProgress, "ShutdownInProgress"
+		case iwire.ErrCommitAmbiguous:
 			code, codeName = commandCodeShutdownInProgress, "ShutdownInProgress"
 		case iwire.ErrCatalogVersionMismatch:
 			code, codeName = commandCodeBadValue, "BadValue"
@@ -929,7 +934,80 @@ func mongoClusterMutationCommandError(err error) (wire.Document, error) {
 	if collections.IsDuplicateKeyError(err) {
 		code, codeName = commandCodeDuplicateKey, "DuplicateKey"
 	}
-	return commandError(code, codeName, err.Error())
+	return commandErrorWithFields(code, codeName, err.Error(), mongoClusterErrorFields(err, nativeCode, codeName))
+}
+
+func mongoClusterErrorFields(err error, nativeCode iwire.ErrorCode, codeName string) bson.D {
+	if err == nil {
+		return nil
+	}
+	fields := bson.D{
+		{Key: "treedbClusterError", Value: true},
+	}
+	if class := mongoClusterErrorClass(err, nativeCode, codeName); class != "" {
+		fields = append(fields, bson.E{Key: "treedbErrorClass", Value: class})
+	}
+	if leaderHint := mongoClusterLeaderHint(err); leaderHint != "" {
+		fields = append(fields, bson.E{Key: "treedbLeaderHint", Value: leaderHint})
+	}
+	return fields
+}
+
+func mongoClusterErrorClass(err error, nativeCode iwire.ErrorCode, codeName string) string {
+	message := strings.ToLower(err.Error())
+	switch nativeCode {
+	case iwire.ErrReadOnly:
+		if mongoClusterLeaderHint(err) != "" || strings.Contains(message, "not leader") {
+			return "not_leader"
+		}
+		if strings.Contains(message, "route group") || strings.Contains(message, "route") {
+			return "route_rejected"
+		}
+		return "read_only"
+	case iwire.ErrDurabilityUnavailable:
+		return "durability_unavailable"
+	case iwire.ErrCommitAmbiguous:
+		return "commit_ambiguous"
+	case iwire.ErrCatalogVersionMismatch:
+		return "catalog_version_mismatch"
+	case iwire.ErrDuplicateDocumentID, iwire.ErrDocumentExists, iwire.ErrUniqueIndexConflict:
+		return "write_conflict"
+	}
+	switch codeName {
+	case "WriteConcernFailed":
+		return "write_concern_failed"
+	case "NotWritablePrimary":
+		return "not_leader"
+	case "ShutdownInProgress":
+		return "durability_unavailable"
+	case "DuplicateKey":
+		return "write_conflict"
+	default:
+		return "cluster_error"
+	}
+}
+
+func mongoClusterLeaderHint(err error) string {
+	if err == nil {
+		return ""
+	}
+	const marker = "leader_hint="
+	message := err.Error()
+	start := strings.Index(message, marker)
+	if start < 0 {
+		return ""
+	}
+	start += len(marker)
+	end := start
+	for end < len(message) {
+		switch message[end] {
+		case ';', ',', ' ', '\t', '\n', '\r':
+			return strings.TrimSpace(message[start:end])
+		default:
+			end++
+		}
+	}
+	return strings.TrimSpace(message[start:end])
 }
 
 type mongoCommandError struct {

--- a/TreeDB/mongo_gateway/cluster_submitter.go
+++ b/TreeDB/mongo_gateway/cluster_submitter.go
@@ -1000,7 +1000,9 @@ func mongoClusterErrorClass(err error, nativeCode iwire.ErrorCode, codeName stri
 		if mongoClusterRouteRejectedMessage(message) {
 			return "route_rejected"
 		}
-		if mongoClusterLeaderHint(err) != "" || strings.Contains(message, "not leader") {
+		if mongoClusterLeaderHint(err) != "" ||
+			strings.Contains(message, "not leader") ||
+			strings.Contains(message, "not cluster leader") {
 			return "not_leader"
 		}
 		return "read_only"

--- a/TreeDB/mongo_gateway/cluster_submitter.go
+++ b/TreeDB/mongo_gateway/cluster_submitter.go
@@ -966,7 +966,7 @@ func mongoClusterRouteCommandError(err error) (wire.Document, error) {
 }
 
 func mongoClusterErrorFields(err error, nativeCode iwire.ErrorCode, codeName string) bson.D {
-	if err == nil {
+	if err == nil || !mongoClusterErrorMetadataApplies(err, nativeCode, codeName) {
 		return nil
 	}
 	fields := bson.D{
@@ -979,6 +979,18 @@ func mongoClusterErrorFields(err error, nativeCode iwire.ErrorCode, codeName str
 		fields = append(fields, bson.E{Key: "treedbLeaderHint", Value: leaderHint})
 	}
 	return fields
+}
+
+func mongoClusterErrorMetadataApplies(err error, nativeCode iwire.ErrorCode, codeName string) bool {
+	if err == nil {
+		return false
+	}
+	if nativeCode != 0 ||
+		errors.Is(err, collections.ErrCommitAmbiguous) ||
+		collections.IsDuplicateKeyError(err) {
+		return true
+	}
+	return codeName == "WriteConcernFailed"
 }
 
 func mongoClusterErrorClass(err error, nativeCode iwire.ErrorCode, codeName string) string {

--- a/TreeDB/mongo_gateway/cluster_submitter.go
+++ b/TreeDB/mongo_gateway/cluster_submitter.go
@@ -1032,6 +1032,7 @@ func mongoClusterErrorClass(err error, nativeCode iwire.ErrorCode, codeName stri
 func mongoClusterRouteRejectedMessage(message string) bool {
 	return strings.Contains(message, "route group") ||
 		strings.Contains(message, "cluster route rejected") ||
+		strings.Contains(message, "cluster query route shape") ||
 		strings.Contains(message, "cluster route shape") ||
 		strings.Contains(message, "cluster token route") ||
 		strings.Contains(message, "cluster token batch route") ||

--- a/TreeDB/mongo_gateway/cluster_submitter.go
+++ b/TreeDB/mongo_gateway/cluster_submitter.go
@@ -914,6 +914,9 @@ func mongoClusterMutationCommandError(err error) (wire.Document, error) {
 	var mongoErr mongoCommandError
 	if errors.As(err, &mongoErr) {
 		code, codeName = mongoErr.code, mongoErr.codeName
+	} else if errors.Is(err, collections.ErrCommitAmbiguous) {
+		nativeCode = iwire.ErrCommitAmbiguous
+		code, codeName = commandCodeShutdownInProgress, "ShutdownInProgress"
 	} else if parsedNativeCode, ok := iwire.ErrorCodeOf(err); ok {
 		nativeCode = parsedNativeCode
 		switch nativeCode {
@@ -931,7 +934,7 @@ func mongoClusterMutationCommandError(err error) (wire.Document, error) {
 			code, codeName = commandCodeDuplicateKey, "DuplicateKey"
 		}
 	}
-	if collections.IsDuplicateKeyError(err) && nativeCode != iwire.ErrCommitAmbiguous && !errors.Is(err, collections.ErrCommitAmbiguous) {
+	if collections.IsDuplicateKeyError(err) && nativeCode != iwire.ErrCommitAmbiguous {
 		code, codeName = commandCodeDuplicateKey, "DuplicateKey"
 	}
 	return commandErrorWithFields(code, codeName, err.Error(), mongoClusterErrorFields(err, nativeCode, codeName))
@@ -957,7 +960,7 @@ func mongoClusterErrorClass(err error, nativeCode iwire.ErrorCode, codeName stri
 	message := strings.ToLower(err.Error())
 	switch nativeCode {
 	case iwire.ErrReadOnly:
-		if strings.Contains(message, "route group") || strings.Contains(message, "route") {
+		if mongoClusterRouteRejectedMessage(message) {
 			return "route_rejected"
 		}
 		if mongoClusterLeaderHint(err) != "" || strings.Contains(message, "not leader") {
@@ -985,6 +988,19 @@ func mongoClusterErrorClass(err error, nativeCode iwire.ErrorCode, codeName stri
 	default:
 		return "cluster_error"
 	}
+}
+
+func mongoClusterRouteRejectedMessage(message string) bool {
+	return strings.Contains(message, "route group") ||
+		strings.Contains(message, "cluster route rejected") ||
+		strings.Contains(message, "cluster route shape") ||
+		strings.Contains(message, "cluster token route") ||
+		strings.Contains(message, "cluster token batch route") ||
+		strings.Contains(message, "cluster route target") ||
+		strings.Contains(message, "route target") ||
+		strings.Contains(message, "route request") ||
+		strings.Contains(message, "requires fanout before submit") ||
+		strings.Contains(message, "requires command split before submit")
 }
 
 func mongoClusterLeaderHint(err error) string {

--- a/TreeDB/mongo_gateway/cluster_submitter_test.go
+++ b/TreeDB/mongo_gateway/cluster_submitter_test.go
@@ -1936,6 +1936,17 @@ func TestMongoClusterMutationCommandErrorClassifiesLeaderHintBeforeRouteText(t *
 	assertStringField(t, response, "treedbLeaderHint", "router-1:27017")
 }
 
+func TestMongoClusterMutationCommandErrorClassifiesHintlessFollowerAsNotLeader(t *testing.T) {
+	clusterErr := &iwire.ProtocolError{Code: iwire.ErrReadOnly, Reason: "not cluster leader"}
+	response, err := mongoClusterMutationCommandError(clusterErr)
+	if err != nil {
+		t.Fatalf("mongoClusterMutationCommandError: %v", err)
+	}
+	assertCommandError(t, response, "NotWritablePrimary")
+	assertStringField(t, response, "treedbErrorClass", "not_leader")
+	assertNoField(t, response, "treedbLeaderHint")
+}
+
 func TestMongoClusterLeaderHintUsesStructuredCarrier(t *testing.T) {
 	err := mongoClusterLeaderHintTestError{leaderHint: "node-c"}
 	if got := mongoClusterLeaderHint(err); got != "node-c" {

--- a/TreeDB/mongo_gateway/cluster_submitter_test.go
+++ b/TreeDB/mongo_gateway/cluster_submitter_test.go
@@ -1703,6 +1703,7 @@ func TestClusterSubmitterConcreteBridgeRouteGroupMismatchNotWritablePrimary(t *t
 	assertErrmsgContains(t, response, "route group")
 	assertBool(t, response, "treedbClusterError", true)
 	assertStringField(t, response, "treedbErrorClass", "route_rejected")
+	assertStringField(t, response, "treedbLeaderHint", "node-c")
 	if _, err := server.Collections.OpenCollection("app.users"); !errors.Is(err, collections.ErrCollectionNotFound) {
 		t.Fatalf("OpenCollection app.users after route mismatch err=%v want collection not found", err)
 	}
@@ -1713,6 +1714,38 @@ func TestClusterSubmitterConcreteBridgeRouteGroupMismatchNotWritablePrimary(t *t
 	if got := routes[0]; got.Database != "app" || got.Catalog != "default" || got.Collection != "users" || got.CommandID != iwire.CommandCreateCollection {
 		t.Fatalf("route request=%+v want app/default/users create_collection", got)
 	}
+}
+
+func TestMongoClusterMutationCommandErrorPreservesCommitAmbiguousOverDuplicateKey(t *testing.T) {
+	clusterErr := errors.Join(
+		&iwire.ProtocolError{Code: iwire.ErrCommitAmbiguous, Reason: "commit reached consensus but response failed"},
+		collections.ErrDuplicateDocumentID,
+	)
+	response, err := mongoClusterMutationCommandError(clusterErr)
+	if err != nil {
+		t.Fatalf("mongoClusterMutationCommandError: %v", err)
+	}
+	assertCommandError(t, response, "ShutdownInProgress")
+	assertStringField(t, response, "treedbErrorClass", "commit_ambiguous")
+}
+
+func TestMongoClusterLeaderHintUsesStructuredCarrier(t *testing.T) {
+	err := mongoClusterLeaderHintTestError{leaderHint: "node-c"}
+	if got := mongoClusterLeaderHint(err); got != "node-c" {
+		t.Fatalf("mongoClusterLeaderHint=%q want node-c", got)
+	}
+}
+
+type mongoClusterLeaderHintTestError struct {
+	leaderHint string
+}
+
+func (e mongoClusterLeaderHintTestError) Error() string {
+	return "route group rejected"
+}
+
+func (e mongoClusterLeaderHintTestError) ClusterLeaderHint() string {
+	return e.leaderHint
 }
 
 func TestClusterSubmitterRejectsUnsupportedWriteConcernBeforeSubmitOrLocalMutation(t *testing.T) {

--- a/TreeDB/mongo_gateway/cluster_submitter_test.go
+++ b/TreeDB/mongo_gateway/cluster_submitter_test.go
@@ -350,6 +350,14 @@ func assertErrmsgContains(tb testing.TB, doc wire.Document, want string) {
 	}
 }
 
+func assertStringField(tb testing.TB, doc wire.Document, key, want string) {
+	tb.Helper()
+	got, ok := bson.Raw(doc).Lookup(key).StringValueOK()
+	if !ok || got != want {
+		tb.Fatalf("%s=%q typeOK=%v want %q", key, got, ok, want)
+	}
+}
+
 func assertMongoUsers(tb testing.TB, server *Server, want map[string]string) {
 	tb.Helper()
 	found := serveCommand(tb, server, 326899, bson.D{
@@ -1052,6 +1060,9 @@ func TestClusterAdmissionMongoFollowerRejectsWritesBeforeLocalMutation(t *testin
 	})
 	assertCommandError(t, createResponse, "NotWritablePrimary")
 	assertErrmsgContains(t, createResponse, "node-a:27017")
+	assertBool(t, createResponse, "treedbClusterError", true)
+	assertStringField(t, createResponse, "treedbErrorClass", "not_leader")
+	assertStringField(t, createResponse, "treedbLeaderHint", "node-a:27017")
 	if _, err := server.Collections.OpenCollection("app.admins"); !errors.Is(err, collections.ErrCollectionNotFound) {
 		t.Fatalf("OpenCollection app.admins err=%v want collection not found", err)
 	}
@@ -1690,6 +1701,8 @@ func TestClusterSubmitterConcreteBridgeRouteGroupMismatchNotWritablePrimary(t *t
 	})
 	assertCommandError(t, response, "NotWritablePrimary")
 	assertErrmsgContains(t, response, "route group")
+	assertBool(t, response, "treedbClusterError", true)
+	assertStringField(t, response, "treedbErrorClass", "route_rejected")
 	if _, err := server.Collections.OpenCollection("app.users"); !errors.Is(err, collections.ErrCollectionNotFound) {
 		t.Fatalf("OpenCollection app.users after route mismatch err=%v want collection not found", err)
 	}

--- a/TreeDB/mongo_gateway/cluster_submitter_test.go
+++ b/TreeDB/mongo_gateway/cluster_submitter_test.go
@@ -1729,6 +1729,30 @@ func TestMongoClusterMutationCommandErrorPreservesCommitAmbiguousOverDuplicateKe
 	assertStringField(t, response, "treedbErrorClass", "commit_ambiguous")
 }
 
+func TestMongoClusterMutationCommandErrorPreservesCollectionCommitAmbiguousOverDuplicateKey(t *testing.T) {
+	clusterErr := &collections.CommitAmbiguousError{
+		Operation: "insert",
+		Err:       collections.ErrDuplicateDocumentID,
+	}
+	response, err := mongoClusterMutationCommandError(clusterErr)
+	if err != nil {
+		t.Fatalf("mongoClusterMutationCommandError: %v", err)
+	}
+	assertCommandError(t, response, "ShutdownInProgress")
+	assertStringField(t, response, "treedbErrorClass", "commit_ambiguous")
+}
+
+func TestMongoClusterMutationCommandErrorClassifiesLeaderHintBeforeRouteText(t *testing.T) {
+	clusterErr := &iwire.ProtocolError{Code: iwire.ErrReadOnly, Reason: "not leader; leader_hint=router-1:27017"}
+	response, err := mongoClusterMutationCommandError(clusterErr)
+	if err != nil {
+		t.Fatalf("mongoClusterMutationCommandError: %v", err)
+	}
+	assertCommandError(t, response, "NotWritablePrimary")
+	assertStringField(t, response, "treedbErrorClass", "not_leader")
+	assertStringField(t, response, "treedbLeaderHint", "router-1:27017")
+}
+
 func TestMongoClusterLeaderHintUsesStructuredCarrier(t *testing.T) {
 	err := mongoClusterLeaderHintTestError{leaderHint: "node-c"}
 	if got := mongoClusterLeaderHint(err); got != "node-c" {

--- a/TreeDB/mongo_gateway/cluster_submitter_test.go
+++ b/TreeDB/mongo_gateway/cluster_submitter_test.go
@@ -1936,6 +1936,16 @@ func TestMongoClusterMutationCommandErrorClassifiesLeaderHintBeforeRouteText(t *
 	assertStringField(t, response, "treedbLeaderHint", "router-1:27017")
 }
 
+func TestMongoClusterMutationCommandErrorClassifiesQueryRouteAsRouteRejected(t *testing.T) {
+	clusterErr := &iwire.ProtocolError{Code: iwire.ErrReadOnly, Reason: "cluster query route shape is not supported before scatter planning"}
+	response, err := mongoClusterMutationCommandError(clusterErr)
+	if err != nil {
+		t.Fatalf("mongoClusterMutationCommandError: %v", err)
+	}
+	assertCommandError(t, response, "NotWritablePrimary")
+	assertStringField(t, response, "treedbErrorClass", "route_rejected")
+}
+
 func TestMongoClusterMutationCommandErrorClassifiesHintlessFollowerAsNotLeader(t *testing.T) {
 	clusterErr := &iwire.ProtocolError{Code: iwire.ErrReadOnly, Reason: "not cluster leader"}
 	response, err := mongoClusterMutationCommandError(clusterErr)

--- a/TreeDB/mongo_gateway/cluster_submitter_test.go
+++ b/TreeDB/mongo_gateway/cluster_submitter_test.go
@@ -225,6 +225,14 @@ func assertErrmsgContains(tb testing.TB, doc wire.Document, want string) {
 	}
 }
 
+func assertStringField(tb testing.TB, doc wire.Document, key, want string) {
+	tb.Helper()
+	got, ok := bson.Raw(doc).Lookup(key).StringValueOK()
+	if !ok || got != want {
+		tb.Fatalf("%s=%q typeOK=%v want %q", key, got, ok, want)
+	}
+}
+
 func assertMongoUsers(tb testing.TB, server *Server, want map[string]string) {
 	tb.Helper()
 	found := serveCommand(tb, server, 326899, bson.D{
@@ -787,6 +795,9 @@ func TestClusterAdmissionMongoFollowerRejectsWritesBeforeLocalMutation(t *testin
 	})
 	assertCommandError(t, createResponse, "NotWritablePrimary")
 	assertErrmsgContains(t, createResponse, "node-a:27017")
+	assertBool(t, createResponse, "treedbClusterError", true)
+	assertStringField(t, createResponse, "treedbErrorClass", "not_leader")
+	assertStringField(t, createResponse, "treedbLeaderHint", "node-a:27017")
 	if _, err := server.Collections.OpenCollection("app.admins"); !errors.Is(err, collections.ErrCollectionNotFound) {
 		t.Fatalf("OpenCollection app.admins err=%v want collection not found", err)
 	}
@@ -1425,6 +1436,8 @@ func TestClusterSubmitterConcreteBridgeRouteGroupMismatchNotWritablePrimary(t *t
 	})
 	assertCommandError(t, response, "NotWritablePrimary")
 	assertErrmsgContains(t, response, "route group")
+	assertBool(t, response, "treedbClusterError", true)
+	assertStringField(t, response, "treedbErrorClass", "route_rejected")
 	if _, err := server.Collections.OpenCollection("app.users"); !errors.Is(err, collections.ErrCollectionNotFound) {
 		t.Fatalf("OpenCollection app.users after route mismatch err=%v want collection not found", err)
 	}

--- a/TreeDB/mongo_gateway/cluster_submitter_test.go
+++ b/TreeDB/mongo_gateway/cluster_submitter_test.go
@@ -358,6 +358,13 @@ func assertStringField(tb testing.TB, doc wire.Document, key, want string) {
 	}
 }
 
+func assertNoField(tb testing.TB, doc wire.Document, key string) {
+	tb.Helper()
+	if got := bson.Raw(doc).Lookup(key); got.Type != 0 {
+		tb.Fatalf("%s present with BSON type %v, want absent", key, got.Type)
+	}
+}
+
 func assertMongoUsers(tb testing.TB, server *Server, want map[string]string) {
 	tb.Helper()
 	found := serveCommand(tb, server, 326899, bson.D{
@@ -1934,6 +1941,17 @@ func TestMongoClusterLeaderHintUsesStructuredCarrier(t *testing.T) {
 	if got := mongoClusterLeaderHint(err); got != "node-c" {
 		t.Fatalf("mongoClusterLeaderHint=%q want node-c", got)
 	}
+}
+
+func TestMongoClusterMutationCommandErrorDoesNotLabelLocalConfigError(t *testing.T) {
+	response, err := mongoClusterMutationCommandError(errors.New("Mongo gateway cluster submitter is not configured"))
+	if err != nil {
+		t.Fatalf("mongoClusterMutationCommandError: %v", err)
+	}
+	assertCommandError(t, response, "BadValue")
+	assertNoField(t, response, "treedbClusterError")
+	assertNoField(t, response, "treedbErrorClass")
+	assertNoField(t, response, "treedbLeaderHint")
 }
 
 type mongoClusterLeaderHintTestError struct {

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -4229,14 +4229,24 @@ func validateSupportedValue(path string, value bson.RawValue) error {
 }
 
 func commandError(code int32, codeName, message string) (wire.Document, error) {
+	return commandErrorWithFields(code, codeName, message, nil)
+}
+
+func commandErrorWithFields(code int32, codeName, message string, fields bson.D) (wire.Document, error) {
 	message = strings.TrimSpace(message)
 	if message == "" {
 		message = codeName
 	}
-	return marshalDocument(bson.D{
+	doc := bson.D{
 		{Key: "ok", Value: 0.0},
 		{Key: "errmsg", Value: message},
 		{Key: "code", Value: code},
 		{Key: "codeName", Value: codeName},
-	})
+	}
+	for _, field := range fields {
+		if field.Key != "" {
+			doc = append(doc, field)
+		}
+	}
+	return marshalDocument(doc)
 }

--- a/TreeDB/nativewire/cluster_raft_submitter.go
+++ b/TreeDB/nativewire/cluster_raft_submitter.go
@@ -189,7 +189,7 @@ func nativeErrorForRaftClusterSubmit(err error) error {
 		errors.Is(err, raftcluster.ErrRouteTargetUnknown),
 		errors.Is(err, raftcluster.ErrRouteTargetUnsupported),
 		errors.Is(err, raftcluster.ErrRouteFanoutRequired):
-		return protocolError(iwire.ErrReadOnly, "%v", err)
+		return clusterProtocolError(iwire.ErrReadOnly, err)
 	case errors.Is(err, raftcluster.ErrCatalogVersionMismatch):
 		return protocolError(iwire.ErrCatalogVersionMismatch, "%v", err)
 	case errors.Is(err, raftcluster.ErrCommitAmbiguous):
@@ -213,6 +213,50 @@ func nativeErrorForRaftClusterSubmit(err error) error {
 		return nativeErrorForDeterministicCode(code, err)
 	}
 	return fmt.Errorf("raft cluster submitter: %w", err)
+}
+
+func clusterProtocolError(code iwire.ErrorCode, err error) error {
+	protocolErr := protocolError(code, "%v", err)
+	if leaderHint := clusterLeaderHint(err); leaderHint != "" {
+		return &clusterLeaderHintProtocolError{err: protocolErr, leaderHint: leaderHint}
+	}
+	return protocolErr
+}
+
+type clusterLeaderHintProtocolError struct {
+	err        error
+	leaderHint string
+}
+
+func (e *clusterLeaderHintProtocolError) Error() string {
+	if e == nil || e.err == nil {
+		return ""
+	}
+	return e.err.Error()
+}
+
+func (e *clusterLeaderHintProtocolError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.err
+}
+
+func (e *clusterLeaderHintProtocolError) ClusterLeaderHint() string {
+	if e == nil {
+		return ""
+	}
+	return e.leaderHint
+}
+
+func clusterLeaderHint(err error) string {
+	var hinted interface {
+		ClusterLeaderHint() string
+	}
+	if errors.As(err, &hinted) {
+		return hinted.ClusterLeaderHint()
+	}
+	return ""
 }
 
 func nativeErrorForDeterministicCode(code raftentry.DeterministicErrorCodeV1, err error) error {

--- a/TreeDB/nativewire/cluster_submitter.go
+++ b/TreeDB/nativewire/cluster_submitter.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"strconv"
+	"time"
 
 	iwire "github.com/snissn/gomap/TreeDB/internal/nativewire"
 	"github.com/snissn/gomap/TreeDB/internal/raftentry"
@@ -107,7 +108,15 @@ type ClusterSubmitResult struct {
 	HasCatalogVersion bool
 }
 
-func (s *Server) handleClusterMutation(ctx context.Context, header iwire.Header, cmd iwire.ValidatedCommand) ([]iwire.Section, error) {
+func (s *Server) handleClusterMutation(ctx context.Context, header iwire.Header, cmd iwire.ValidatedCommand) (sections []iwire.Section, err error) {
+	start := time.Now()
+	var actualAck AckPolicy
+	if s != nil {
+		s.counters.inc("cluster_submit.requests_total")
+		defer func() {
+			s.recordClusterSubmitOutcome(err, actualAck, time.Since(start))
+		}()
+	}
 	if s == nil || s.clusterSubmitter == nil {
 		return nil, protocolError(iwire.ErrInvalidCommand, "nativewire cluster submitter is not configured")
 	}
@@ -163,7 +172,40 @@ func (s *Server) handleClusterMutation(ctx context.Context, header iwire.Header,
 	if err := s.updateCatalogVersionFromClusterSubmitResult(result); err != nil {
 		return nil, err
 	}
+	actualAck = result.ActualAck
 	return cloneSections(result.ResponseSections), nil
+}
+
+func (s *Server) recordClusterSubmitOutcome(err error, actualAck AckPolicy, elapsed time.Duration) {
+	if s == nil {
+		return
+	}
+	if elapsed > 0 {
+		s.counters.add("cluster_submit.nanos_total", uint64(elapsed.Nanoseconds()))
+	}
+	if err != nil {
+		s.counters.inc("cluster_submit.errors_total")
+		switch errorCodeFor(err) {
+		case iwire.ErrReadOnly:
+			s.counters.inc("cluster_submit.read_only_total")
+		case iwire.ErrDurabilityUnavailable:
+			s.counters.inc("cluster_submit.durability_unavailable_total")
+		case iwire.ErrCommitAmbiguous:
+			s.counters.inc("cluster_submit.commit_ambiguous_total")
+		}
+		return
+	}
+	s.counters.inc("cluster_submit.success_total")
+	switch actualAck {
+	case iwire.AckVisible:
+		s.counters.inc("cluster_submit.ack_visible_total")
+	case iwire.AckFlushed:
+		s.counters.inc("cluster_submit.ack_flushed_total")
+	case iwire.AckSynced:
+		s.counters.inc("cluster_submit.ack_synced_total")
+	case iwire.AckRaftCommitted:
+		s.counters.inc("cluster_submit.ack_raft_committed_total")
+	}
 }
 
 func (s *Server) updateCatalogVersionFromClusterSubmitResult(result ClusterSubmitResult) error {

--- a/TreeDB/nativewire/cluster_submitter.go
+++ b/TreeDB/nativewire/cluster_submitter.go
@@ -3,6 +3,7 @@ package nativewire
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"strconv"
 	"time"
 
@@ -115,6 +116,10 @@ func (s *Server) handleClusterMutation(ctx context.Context, header iwire.Header,
 	if s != nil {
 		s.counters.inc("cluster_submit.requests_total")
 		defer func() {
+			if recovered := recover(); recovered != nil {
+				s.recordClusterSubmitOutcome(fmt.Errorf("cluster submit panic: %v", recovered), actualAck, time.Since(start))
+				panic(recovered)
+			}
 			s.recordClusterSubmitOutcome(err, actualAck, time.Since(start))
 		}()
 	}

--- a/TreeDB/nativewire/cluster_submitter_test.go
+++ b/TreeDB/nativewire/cluster_submitter_test.go
@@ -1565,6 +1565,71 @@ func TestClusterSubmitterRaftCommittedAdmissionFailsBeforeSubmit(t *testing.T) {
 	}
 }
 
+func TestClusterSubmitterStatsTrackRaftCommittedAndFollowerReject(t *testing.T) {
+	t.Run("raft_committed_success", func(t *testing.T) {
+		submitter := &fakeClusterSubmitter{
+			resultHook: func(entry raftentry.CommandEntryV1, metadata ClusterRequestMetadata, result ClusterSubmitResult) (ClusterSubmitResult, error) {
+				result.ActualAck = AckRaftCommitted
+				result.CommittedRecoverable = true
+				return replaceResponseAckPolicy(result, AckRaftCommitted), nil
+			},
+		}
+		client, server, _, _ := serveCollectionPipeWithServerAndOptions(t, ServerOptions{ClusterSubmitter: submitter})
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		defer cancel()
+		if err := client.Hello(ctx); err != nil {
+			t.Fatalf("Hello: %v", err)
+		}
+		if _, err := client.commandSections(ctx, iwire.CommandInsertBatch, clusterInsertBatchSections(t, client, ctx, AckRaftCommitted, "u1")...); err != nil {
+			t.Fatalf("InsertBatch raft_committed cluster: %v", err)
+		}
+		for key, want := range map[string]uint64{
+			"cluster_submit.requests_total":           1,
+			"cluster_submit.success_total":            1,
+			"cluster_submit.errors_total":             0,
+			"cluster_submit.ack_raft_committed_total": 1,
+			"cluster_submit.read_only_total":          0,
+		} {
+			if got := nativewireTestStatUint64(t, server, key); got != want {
+				t.Fatalf("stat %s=%d want %d", key, got, want)
+			}
+		}
+		if got := nativewireTestStatUint64(t, server, "cluster_submit.nanos_total"); got == 0 {
+			t.Fatalf("cluster_submit.nanos_total=0 want >0")
+		}
+	})
+
+	t.Run("follower_reject", func(t *testing.T) {
+		submitter := &fakeClusterSubmitter{
+			status: ClusterFollowerAdmission("node-a:7000", "not leader"),
+		}
+		client, server, _, _ := serveCollectionPipeWithServerAndOptions(t, ServerOptions{ClusterSubmitter: submitter})
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		defer cancel()
+		if err := client.Hello(ctx); err != nil {
+			t.Fatalf("Hello: %v", err)
+		}
+		_, err := client.commandSections(ctx, iwire.CommandInsertBatch, clusterInsertBatchSections(t, client, ctx, AckRaftCommitted, "u1")...)
+		if !isRemoteError(err, iwire.ErrReadOnly) {
+			t.Fatalf("InsertBatch follower raft_committed err=%v want read-only", err)
+		}
+		for key, want := range map[string]uint64{
+			"cluster_submit.requests_total":           1,
+			"cluster_submit.success_total":            0,
+			"cluster_submit.errors_total":             1,
+			"cluster_submit.read_only_total":          1,
+			"cluster_submit.ack_raft_committed_total": 0,
+		} {
+			if got := nativewireTestStatUint64(t, server, key); got != want {
+				t.Fatalf("stat %s=%d want %d", key, got, want)
+			}
+		}
+		if got := len(submitter.snapshot()); got != 0 {
+			t.Fatalf("submitter calls=%d want 0", got)
+		}
+	})
+}
+
 func TestRaftClusterSubmitterConcreteBridgeCreateInsertRaftCommitted(t *testing.T) {
 	client, server, mgr, _ := serveRaftClusterBridgePipe(t, raftcluster.LeaderAdmission())
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)

--- a/TreeDB/nativewire/cluster_submitter_test.go
+++ b/TreeDB/nativewire/cluster_submitter_test.go
@@ -1764,6 +1764,118 @@ func TestClusterSubmitterStatsTrackRaftCommittedAndFollowerReject(t *testing.T) 
 			t.Fatalf("submitter calls=%d want 0", got)
 		}
 	})
+
+	t.Run("durability_unavailable", func(t *testing.T) {
+		submitter := &fakeClusterSubmitter{
+			status: ClusterUnavailableAdmission("cluster admission unavailable"),
+		}
+		client, server, _, _ := serveCollectionPipeWithServerAndOptions(t, ServerOptions{ClusterSubmitter: submitter})
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		defer cancel()
+		if err := client.Hello(ctx); err != nil {
+			t.Fatalf("Hello: %v", err)
+		}
+		_, err := client.commandSections(ctx, iwire.CommandInsertBatch, clusterInsertBatchSections(t, client, ctx, AckRaftCommitted, "u1")...)
+		if !isRemoteError(err, iwire.ErrDurabilityUnavailable) {
+			t.Fatalf("InsertBatch unavailable raft_committed err=%v want durability unavailable", err)
+		}
+		for key, want := range map[string]uint64{
+			"cluster_submit.requests_total":               1,
+			"cluster_submit.success_total":                0,
+			"cluster_submit.errors_total":                 1,
+			"cluster_submit.durability_unavailable_total": 1,
+			"cluster_submit.commit_ambiguous_total":       0,
+			"cluster_submit.read_only_total":              0,
+			"cluster_submit.ack_raft_committed_total":     0,
+		} {
+			if got := nativewireTestStatUint64(t, server, key); got != want {
+				t.Fatalf("stat %s=%d want %d", key, got, want)
+			}
+		}
+		if got := len(submitter.snapshot()); got != 0 {
+			t.Fatalf("submitter calls=%d want 0", got)
+		}
+	})
+
+	t.Run("commit_ambiguous", func(t *testing.T) {
+		submitter := &fakeClusterSubmitter{
+			resultHook: func(entry raftentry.CommandEntryV1, metadata ClusterRequestMetadata, result ClusterSubmitResult) (ClusterSubmitResult, error) {
+				return ClusterSubmitResult{}, raftcluster.ErrCommitAmbiguous
+			},
+		}
+		client, server, _, _ := serveCollectionPipeWithServerAndOptions(t, ServerOptions{ClusterSubmitter: submitter})
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		defer cancel()
+		if err := client.Hello(ctx); err != nil {
+			t.Fatalf("Hello: %v", err)
+		}
+		_, err := client.commandSections(ctx, iwire.CommandInsertBatch, clusterInsertBatchSections(t, client, ctx, AckRaftCommitted, "u1")...)
+		if !isRemoteError(err, iwire.ErrCommitAmbiguous) {
+			t.Fatalf("InsertBatch ambiguous raft_committed err=%v want commit ambiguous", err)
+		}
+		for key, want := range map[string]uint64{
+			"cluster_submit.requests_total":               1,
+			"cluster_submit.success_total":                0,
+			"cluster_submit.errors_total":                 1,
+			"cluster_submit.commit_ambiguous_total":       1,
+			"cluster_submit.durability_unavailable_total": 0,
+			"cluster_submit.read_only_total":              0,
+			"cluster_submit.ack_raft_committed_total":     0,
+		} {
+			if got := nativewireTestStatUint64(t, server, key); got != want {
+				t.Fatalf("stat %s=%d want %d", key, got, want)
+			}
+		}
+		if got := len(submitter.snapshot()); got != 1 {
+			t.Fatalf("submitter calls=%d want 1", got)
+		}
+	})
+}
+
+func TestClusterSubmitterStatsRecordPanicAsError(t *testing.T) {
+	submitter := &fakeClusterSubmitter{
+		resultHook: func(entry raftentry.CommandEntryV1, metadata ClusterRequestMetadata, result ClusterSubmitResult) (ClusterSubmitResult, error) {
+			panic("submit panic")
+		},
+	}
+	client, server, _, _ := serveCollectionPipeWithServerAndOptions(t, ServerOptions{ClusterSubmitter: submitter})
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := client.Hello(ctx); err != nil {
+		t.Fatalf("Hello: %v", err)
+	}
+	body, err := appendCommandRequestBody(nil, iwire.CommandInsertBatch, clusterInsertBatchSections(t, client, ctx, AckRaftCommitted, "u1")...)
+	if err != nil {
+		t.Fatalf("append request body: %v", err)
+	}
+	sections, err := iwire.DecodeSections(body, server.limits)
+	if err != nil {
+		t.Fatalf("decode request body: %v", err)
+	}
+	cmd, err := server.registry.ValidateRequestSections(sections)
+	if err != nil {
+		t.Fatalf("validate request sections: %v", err)
+	}
+
+	func() {
+		defer func() {
+			if recovered := recover(); recovered == nil {
+				t.Fatal("handleClusterMutation did not re-panic")
+			}
+		}()
+		_, _ = server.handleClusterMutation(ctx, iwire.Header{Type: iwire.FrameRequest, RequestID: 1}, cmd)
+	}()
+
+	for key, want := range map[string]uint64{
+		"cluster_submit.requests_total":           1,
+		"cluster_submit.success_total":            0,
+		"cluster_submit.errors_total":             1,
+		"cluster_submit.ack_raft_committed_total": 0,
+	} {
+		if got := nativewireTestStatUint64(t, server, key); got != want {
+			t.Fatalf("stat %s=%d want %d", key, got, want)
+		}
+	}
 }
 
 func TestRaftClusterSubmitterConcreteBridgeCreateInsertRaftCommitted(t *testing.T) {

--- a/TreeDB/nativewire/cluster_submitter_test.go
+++ b/TreeDB/nativewire/cluster_submitter_test.go
@@ -1569,6 +1569,7 @@ func TestClusterSubmitterStatsTrackRaftCommittedAndFollowerReject(t *testing.T) 
 	t.Run("raft_committed_success", func(t *testing.T) {
 		submitter := &fakeClusterSubmitter{
 			resultHook: func(entry raftentry.CommandEntryV1, metadata ClusterRequestMetadata, result ClusterSubmitResult) (ClusterSubmitResult, error) {
+				time.Sleep(2 * time.Millisecond)
 				result.ActualAck = AckRaftCommitted
 				result.CommittedRecoverable = true
 				return replaceResponseAckPolicy(result, AckRaftCommitted), nil

--- a/TreeDB/nativewire/cluster_submitter_test.go
+++ b/TreeDB/nativewire/cluster_submitter_test.go
@@ -1438,6 +1438,71 @@ func TestClusterSubmitterRaftCommittedAdmissionFailsBeforeSubmit(t *testing.T) {
 	}
 }
 
+func TestClusterSubmitterStatsTrackRaftCommittedAndFollowerReject(t *testing.T) {
+	t.Run("raft_committed_success", func(t *testing.T) {
+		submitter := &fakeClusterSubmitter{
+			resultHook: func(entry raftentry.CommandEntryV1, metadata ClusterRequestMetadata, result ClusterSubmitResult) (ClusterSubmitResult, error) {
+				result.ActualAck = AckRaftCommitted
+				result.CommittedRecoverable = true
+				return replaceResponseAckPolicy(result, AckRaftCommitted), nil
+			},
+		}
+		client, server, _, _ := serveCollectionPipeWithServerAndOptions(t, ServerOptions{ClusterSubmitter: submitter})
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		defer cancel()
+		if err := client.Hello(ctx); err != nil {
+			t.Fatalf("Hello: %v", err)
+		}
+		if _, err := client.commandSections(ctx, iwire.CommandInsertBatch, clusterInsertBatchSections(t, client, ctx, AckRaftCommitted, "u1")...); err != nil {
+			t.Fatalf("InsertBatch raft_committed cluster: %v", err)
+		}
+		for key, want := range map[string]uint64{
+			"cluster_submit.requests_total":           1,
+			"cluster_submit.success_total":            1,
+			"cluster_submit.errors_total":             0,
+			"cluster_submit.ack_raft_committed_total": 1,
+			"cluster_submit.read_only_total":          0,
+		} {
+			if got := nativewireTestStatUint64(t, server, key); got != want {
+				t.Fatalf("stat %s=%d want %d", key, got, want)
+			}
+		}
+		if got := nativewireTestStatUint64(t, server, "cluster_submit.nanos_total"); got == 0 {
+			t.Fatalf("cluster_submit.nanos_total=0 want >0")
+		}
+	})
+
+	t.Run("follower_reject", func(t *testing.T) {
+		submitter := &fakeClusterSubmitter{
+			status: ClusterFollowerAdmission("node-a:7000", "not leader"),
+		}
+		client, server, _, _ := serveCollectionPipeWithServerAndOptions(t, ServerOptions{ClusterSubmitter: submitter})
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		defer cancel()
+		if err := client.Hello(ctx); err != nil {
+			t.Fatalf("Hello: %v", err)
+		}
+		_, err := client.commandSections(ctx, iwire.CommandInsertBatch, clusterInsertBatchSections(t, client, ctx, AckRaftCommitted, "u1")...)
+		if !isRemoteError(err, iwire.ErrReadOnly) {
+			t.Fatalf("InsertBatch follower raft_committed err=%v want read-only", err)
+		}
+		for key, want := range map[string]uint64{
+			"cluster_submit.requests_total":           1,
+			"cluster_submit.success_total":            0,
+			"cluster_submit.errors_total":             1,
+			"cluster_submit.read_only_total":          1,
+			"cluster_submit.ack_raft_committed_total": 0,
+		} {
+			if got := nativewireTestStatUint64(t, server, key); got != want {
+				t.Fatalf("stat %s=%d want %d", key, got, want)
+			}
+		}
+		if got := len(submitter.snapshot()); got != 0 {
+			t.Fatalf("submitter calls=%d want 0", got)
+		}
+	})
+}
+
 func TestRaftClusterSubmitterConcreteBridgeCreateInsertRaftCommitted(t *testing.T) {
 	client, server, mgr, _ := serveRaftClusterBridgePipe(t, raftcluster.LeaderAdmission())
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)

--- a/TreeDB/nativewire/errors.go
+++ b/TreeDB/nativewire/errors.go
@@ -10,6 +10,7 @@ import (
 	"github.com/snissn/gomap/TreeDB/collections"
 	backenddb "github.com/snissn/gomap/TreeDB/db"
 	iwire "github.com/snissn/gomap/TreeDB/internal/nativewire"
+	"github.com/snissn/gomap/TreeDB/internal/raftcluster"
 )
 
 // ErrServerClosed reports that the server is closed or refusing connections.
@@ -64,6 +65,12 @@ func errorCodeFor(err error) iwire.ErrorCode {
 		return iwire.ErrDurabilityUnavailable
 	case errors.Is(err, collections.ErrCommitAmbiguous):
 		return iwire.ErrCommitAmbiguous
+	case errors.Is(err, raftcluster.ErrCommitAmbiguous):
+		return iwire.ErrCommitAmbiguous
+	case errors.Is(err, raftcluster.ErrAdmissionUnavailable):
+		return iwire.ErrDurabilityUnavailable
+	case errors.Is(err, raftcluster.ErrNotLeader):
+		return iwire.ErrReadOnly
 	case errors.Is(err, collections.ErrRecoveryRequired):
 		return iwire.ErrDurabilityUnavailable
 	case errors.Is(err, backenddb.ErrCommandWALRejected):

--- a/TreeDB/nativewire/server.go
+++ b/TreeDB/nativewire/server.go
@@ -964,6 +964,17 @@ func (s *Server) Stats() map[string]string {
 		"insert_batch_combiner.requests_total",
 		"insert_batch_combiner.single_requests_total",
 		"insert_batch_combiner.fallback_requests_total",
+		"cluster_submit.requests_total",
+		"cluster_submit.success_total",
+		"cluster_submit.errors_total",
+		"cluster_submit.read_only_total",
+		"cluster_submit.durability_unavailable_total",
+		"cluster_submit.commit_ambiguous_total",
+		"cluster_submit.ack_visible_total",
+		"cluster_submit.ack_flushed_total",
+		"cluster_submit.ack_synced_total",
+		"cluster_submit.ack_raft_committed_total",
+		"cluster_submit.nanos_total",
 	} {
 		out[nativeStatsPrefix+key] = "0"
 	}

--- a/TreeDB/nativewire/stats.go
+++ b/TreeDB/nativewire/stats.go
@@ -15,19 +15,30 @@ const maxTrackedErrorCode = int(iwire.MaxErrorCode)
 type Stats map[string]string
 
 type counters struct {
-	connectionsOpened atomic.Uint64
-	connectionsClosed atomic.Uint64
-	framesIn          atomic.Uint64
-	framesOut         atomic.Uint64
-	bytesIn           atomic.Uint64
-	bytesOut          atomic.Uint64
-	malformedFrames   atomic.Uint64
-	requestsStarted   atomic.Uint64
-	requestsCompleted atomic.Uint64
-	requestsFailed    atomic.Uint64
-	requestsCanceled  atomic.Uint64
-	errorsTotal       atomic.Uint64
-	dispatchNanos     atomic.Uint64
+	connectionsOpened                  atomic.Uint64
+	connectionsClosed                  atomic.Uint64
+	framesIn                           atomic.Uint64
+	framesOut                          atomic.Uint64
+	bytesIn                            atomic.Uint64
+	bytesOut                           atomic.Uint64
+	malformedFrames                    atomic.Uint64
+	requestsStarted                    atomic.Uint64
+	requestsCompleted                  atomic.Uint64
+	requestsFailed                     atomic.Uint64
+	requestsCanceled                   atomic.Uint64
+	errorsTotal                        atomic.Uint64
+	dispatchNanos                      atomic.Uint64
+	clusterSubmitRequests              atomic.Uint64
+	clusterSubmitSuccess               atomic.Uint64
+	clusterSubmitErrors                atomic.Uint64
+	clusterSubmitReadOnly              atomic.Uint64
+	clusterSubmitDurabilityUnavailable atomic.Uint64
+	clusterSubmitCommitAmbiguous       atomic.Uint64
+	clusterSubmitAckVisible            atomic.Uint64
+	clusterSubmitAckFlushed            atomic.Uint64
+	clusterSubmitAckSynced             atomic.Uint64
+	clusterSubmitAckRaftCommitted      atomic.Uint64
+	clusterSubmitNanos                 atomic.Uint64
 
 	errorCodes [maxTrackedErrorCode + 1]atomic.Uint64
 	commands   [64]commandCounters
@@ -168,6 +179,28 @@ func (c *counters) addHot(key string, delta uint64) bool {
 		c.errorsTotal.Add(delta)
 	case "dispatch_nanos_total":
 		c.dispatchNanos.Add(delta)
+	case "cluster_submit.requests_total":
+		c.clusterSubmitRequests.Add(delta)
+	case "cluster_submit.success_total":
+		c.clusterSubmitSuccess.Add(delta)
+	case "cluster_submit.errors_total":
+		c.clusterSubmitErrors.Add(delta)
+	case "cluster_submit.read_only_total":
+		c.clusterSubmitReadOnly.Add(delta)
+	case "cluster_submit.durability_unavailable_total":
+		c.clusterSubmitDurabilityUnavailable.Add(delta)
+	case "cluster_submit.commit_ambiguous_total":
+		c.clusterSubmitCommitAmbiguous.Add(delta)
+	case "cluster_submit.ack_visible_total":
+		c.clusterSubmitAckVisible.Add(delta)
+	case "cluster_submit.ack_flushed_total":
+		c.clusterSubmitAckFlushed.Add(delta)
+	case "cluster_submit.ack_synced_total":
+		c.clusterSubmitAckSynced.Add(delta)
+	case "cluster_submit.ack_raft_committed_total":
+		c.clusterSubmitAckRaftCommitted.Add(delta)
+	case "cluster_submit.nanos_total":
+		c.clusterSubmitNanos.Add(delta)
 	default:
 		return false
 	}
@@ -223,6 +256,17 @@ func (c *counters) snapshot() map[string]uint64 {
 	addIfNonZero("requests.canceled_total", c.requestsCanceled.Load())
 	addIfNonZero("errors.total", c.errorsTotal.Load())
 	addIfNonZero("dispatch_nanos_total", c.dispatchNanos.Load())
+	addIfNonZero("cluster_submit.requests_total", c.clusterSubmitRequests.Load())
+	addIfNonZero("cluster_submit.success_total", c.clusterSubmitSuccess.Load())
+	addIfNonZero("cluster_submit.errors_total", c.clusterSubmitErrors.Load())
+	addIfNonZero("cluster_submit.read_only_total", c.clusterSubmitReadOnly.Load())
+	addIfNonZero("cluster_submit.durability_unavailable_total", c.clusterSubmitDurabilityUnavailable.Load())
+	addIfNonZero("cluster_submit.commit_ambiguous_total", c.clusterSubmitCommitAmbiguous.Load())
+	addIfNonZero("cluster_submit.ack_visible_total", c.clusterSubmitAckVisible.Load())
+	addIfNonZero("cluster_submit.ack_flushed_total", c.clusterSubmitAckFlushed.Load())
+	addIfNonZero("cluster_submit.ack_synced_total", c.clusterSubmitAckSynced.Load())
+	addIfNonZero("cluster_submit.ack_raft_committed_total", c.clusterSubmitAckRaftCommitted.Load())
+	addIfNonZero("cluster_submit.nanos_total", c.clusterSubmitNanos.Load())
 	for code := iwire.ErrorCode(1); code <= iwire.ErrorCode(maxTrackedErrorCode); code++ {
 		value := c.errorCodes[code].Load()
 		if value != 0 {


### PR DESCRIPTION
Closes #3440

Restacked after #3447 landed. Current base is `origin/main` at `97247676349a94467e27819b38d6cafa0ae34b2d`; current head is `f30277a1b017a52b306b7718c8dd0eed2dbef6e3`. The branch was updated with a no-force merge restack because repository rules reject force-pushes to this PR branch.

## Summary

- Add nativewire cluster-submit counters for HA writes, including total requests, success/error totals, read-only/durability/ambiguous error totals, per-ack success totals, and total submit latency nanos.
- Add Mongo cluster write error metadata fields so client-visible failures identify TreeDB cluster errors, coarse error class, and leader hints when available.
- Keep commit-ambiguous Mongo write failures coherent: `ErrCommitAmbiguous` maps to `ShutdownInProgress` with `treedbErrorClass: "commit_ambiguous"`, and duplicate-key sentinels no longer override that class/code mapping.
- Carry routed write leader hints through structured route errors into Mongo `treedbLeaderHint`, including non-local route-group rejections.
- Extend focused nativewire and Mongo tests for raft-committed/follower observability, direct local-mutation bypass, Mongo not-leader/route-rejected error metadata, commit-ambiguous duplicate wrapping, and structured leader-hint propagation.
- Stabilize the nativewire latency-counter assertion for Windows clock granularity after latest-head CI exposed a zero-duration fast path.

## Validation

Run from `/mnt/fast4tb/tmp/gomap-3440-ha-write-surface` on head `f30277a1b017a52b306b7718c8dd0eed2dbef6e3` with `TMPDIR=/mnt/fast4tb/tmp/gomap-test-tmp GOCACHE=/mnt/fast4tb/tmp/go-cache GOMODCACHE=/mnt/fast4tb/tmp/go-mod-cache GOWORK=off`.

- `env TMPDIR=/mnt/fast4tb/tmp/gomap-test-tmp GOCACHE=/mnt/fast4tb/tmp/go-cache GOMODCACHE=/mnt/fast4tb/tmp/go-mod-cache GOWORK=off go test ./TreeDB/internal/raftcluster ./TreeDB/nativewire ./TreeDB/mongo_gateway -run 'Test(SingleGroupSubmitterRejectsRouteGroupMismatchBeforePreflightCommitApply|ClusterSubmitterStatsTrackRaftCommittedAndFollowerReject|RaftClusterSubmitterRouteGroupMismatch(MapsToReadOnly|RejectsBeforeLocalMutation)|ClusterSubmitterConcreteBridgeRouteGroupMismatchNotWritablePrimary|MongoClusterMutationCommandErrorPreservesCommitAmbiguousOverDuplicateKey|MongoClusterLeaderHintUsesStructuredCarrier)$' -count=1` - pass (`raftcluster 0.004s`, `nativewire 0.058s`, `mongo_gateway 0.020s`)
- `env TMPDIR=/mnt/fast4tb/tmp/gomap-test-tmp GOCACHE=/mnt/fast4tb/tmp/go-cache GOMODCACHE=/mnt/fast4tb/tmp/go-mod-cache GOWORK=off go test ./TreeDB/nativewire -run 'TestClusterSubmitter(RaftCommitted|StatsTrack)|TestRaftClusterSubmitterConcreteBridge(CreateInsertRaftCommitted|FollowerRejectsBeforeApply)|TestRaftClusterSubmitterRouteGroupMismatch(MapsToReadOnly|RejectsBeforeLocalMutation)' -count=1` - pass (`ok github.com/snissn/gomap/TreeDB/nativewire 0.215s`)
- `env TMPDIR=/mnt/fast4tb/tmp/gomap-test-tmp GOCACHE=/mnt/fast4tb/tmp/go-cache GOMODCACHE=/mnt/fast4tb/tmp/go-mod-cache GOWORK=off go test ./TreeDB/mongo_gateway -run 'TestClusterAdmissionMongoFollowerRejectsWritesBeforeLocalMutation|TestClusterSubmitter(ConcreteBridgeMajorityInsert|ConcreteBridgeRouteGroupMismatchNotWritablePrimary|MajorityWriteConcern|RejectsUnsupportedWriteConcern)|TestMongoCluster(MutationCommandErrorPreservesCommitAmbiguousOverDuplicateKey|LeaderHintUsesStructuredCarrier)' -count=1` - pass (`ok github.com/snissn/gomap/TreeDB/mongo_gateway 0.203s`)
- `env TMPDIR=/mnt/fast4tb/tmp/gomap-test-tmp GOCACHE=/mnt/fast4tb/tmp/go-cache GOMODCACHE=/mnt/fast4tb/tmp/go-mod-cache GOWORK=off go test ./TreeDB/nativewire ./TreeDB/mongo_gateway ./TreeDB/internal/raftcluster ./TreeDB/internal/raftfsm -count=1` - pass (`nativewire 2.729s`, `mongo_gateway 9.482s`, `raftcluster 3.802s`, `raftfsm 1.309s`)
- `git diff --check` - pass

## Benchmark Evidence

Existing native Raft bridge write benchmark from the original HA write surface validation, `-benchtime=100x -count=1 -benchmem`:

- Before, `origin/codex/3439-raft-failover-catchup@ef8faa16d`: `7146400 ns/op`, `59696 B/op`, `495 allocs/op`
- After, original PR head `fe6972f1f74ea7c9d4d6ae2ab5067be7a6b22de7`: `7014603 ns/op`, `59697 B/op`, `495 allocs/op`

The restack plus review-thread fixes affect observability/error-shaping paths only; no separate Mongo before/after benchmark was added because the Mongo changes shape error documents on failure paths, while the shared HA submit/apply write path is exercised by the native bridge benchmark and focused tests.

## Risks / Notes

- Latest-head GitHub Actions must complete on `f30277a1b017a52b306b7718c8dd0eed2dbef6e3` before final mergeability can be claimed.
- Mongo TreeDB-specific extension fields do not change `ok` or `errmsg`; `code`/`codeName` follow the cluster error mapping, including `ErrCommitAmbiguous` -> `ShutdownInProgress`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved cluster submit error details, including leader hints and clearer Mongo-style error responses.
  * Added broader cluster submission statistics, including request counts, outcomes, acknowledgement levels, and timing.

* **Bug Fixes**
  * Route mismatch and not-leader errors now preserve more useful context for troubleshooting.
  * Commit-ambiguous and read-only conditions are now reported more consistently.

* **Tests**
  * Expanded coverage for route errors, leader hints, error classification, and submission statistics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->