### PR TITLE
TreeDB Raft: land multi-group routing ownership guards

### DIFF
--- a/TreeDB/internal/raftplacement/catalog_test.go
+++ b/TreeDB/internal/raftplacement/catalog_test.go
@@ -165,6 +165,18 @@ func TestValidateFeatureFloorFailsClosed(t *testing.T) {
 			},
 			want: ErrUnsupportedVersion,
 		},
+		{
+			name: "unsupported feature minor",
+			mut: func(c *CatalogV1) {
+				c.Features = raftcluster.FeatureSet{
+					ConfigVersion: SupportedCatalogVersion,
+					Required: []raftcluster.RequiredFeature{
+						{Name: FeatureCollectionGroups, Version: raftcluster.Version{Major: 1, Minor: 1}},
+					},
+				}
+			},
+			want: ErrUnsupportedVersion,
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/TreeDB/mongo_gateway/cluster_submitter.go
+++ b/TreeDB/mongo_gateway/cluster_submitter.go
@@ -546,6 +546,13 @@ func (s *Server) preflightClusterRoute(ctx context.Context, routeReq *treenative
 	return err
 }
 
+func (s *Server) preflightClusterFindRoute(ctx context.Context, db, collection string) error {
+	if !s.clusterRouteProviderConfigured() {
+		return nil
+	}
+	return s.preflightClusterRoute(ctx, mongoClusterQueryRouteRequest(db, collection, 0, "find"))
+}
+
 func mongoClusterRouteRequest(db, collection string, command iwire.CommandID, commandName string) *treenativewire.ClusterRouteRequest {
 	return &treenativewire.ClusterRouteRequest{
 		Database:    db,
@@ -555,6 +562,12 @@ func mongoClusterRouteRequest(db, collection string, command iwire.CommandID, co
 		CommandName: commandName,
 		Shape:       treenativewire.ClusterRouteShapeCollection,
 	}
+}
+
+func mongoClusterQueryRouteRequest(db, collection string, command iwire.CommandID, commandName string) *treenativewire.ClusterRouteRequest {
+	req := mongoClusterRouteRequest(db, collection, command, commandName)
+	req.Shape = treenativewire.ClusterRouteShapeQuery
+	return req
 }
 
 func mongoClusterDocumentIDRouteRequest(db, collection string, command iwire.CommandID, commandName string, id []byte) *treenativewire.ClusterRouteRequest {
@@ -583,11 +596,23 @@ func mongoClusterDocumentIDsRouteRequest(db, collection string, command iwire.Co
 func mongoClusterUpdateBatchRouteRequest(db, collection string, updates []wire.Document) *treenativewire.ClusterRouteRequest {
 	ids := make([][]byte, 0, len(updates))
 	for i, update := range updates {
+		filter, err := requiredDocumentField(update, "q")
+		if err != nil {
+			return mongoClusterRouteRequest(db, collection, iwire.CommandUpdateBSONSet, "update_bson_set")
+		}
+		id, err := idEqualityFilterValue(filter, "update")
+		if err != nil {
+			return mongoClusterQueryRouteRequest(db, collection, iwire.CommandUpdateBSONSet, "update_bson_set")
+		}
+		key, err := encodePrimaryKey(id)
+		if err != nil {
+			return mongoClusterRouteRequest(db, collection, iwire.CommandUpdateBSONSet, "update_bson_set")
+		}
 		item, err := parseMongoUpdateItem(i, update)
 		if err != nil || !item.bsonSetFieldsOK {
 			return mongoClusterRouteRequest(db, collection, iwire.CommandUpdateBSONSet, "update_bson_set")
 		}
-		ids = append(ids, item.key)
+		ids = append(ids, key)
 	}
 	return mongoClusterDocumentIDsRouteRequest(db, collection, iwire.CommandUpdateBSONSet, "update_bson_set", ids)
 }
@@ -602,7 +627,7 @@ func mongoClusterDeleteBatchRouteRequest(db, collection string, deletes []wire.D
 		}
 		id, err := idEqualityFilterValue(filter, "delete")
 		if err != nil {
-			return mongoClusterRouteRequest(db, collection, iwire.CommandDeleteBatch, "delete_batch")
+			return mongoClusterQueryRouteRequest(db, collection, iwire.CommandDeleteBatch, "delete_batch")
 		}
 		if limit, err := optionalInt32Field(deleteItem, "limit"); err != nil || (limit != 0 && limit != 1) {
 			return mongoClusterRouteRequest(db, collection, iwire.CommandDeleteBatch, "delete_batch")

--- a/TreeDB/mongo_gateway/cluster_submitter.go
+++ b/TreeDB/mongo_gateway/cluster_submitter.go
@@ -932,7 +932,7 @@ func parseClusterWriteConcernW(value bson.RawValue) (iwire.AckPolicy, error) {
 	return 0, errors.New("Mongo command field \"writeConcern.w\" must be integer 1 or string \"majority\"")
 }
 
-func mongoClusterMutationCommandError(err error) (wire.Document, error) {
+func mongoClusterRouteCommandError(err error) (wire.Document, error) {
 	code, codeName := commandCodeBadValue, "BadValue"
 	var mongoErr mongoCommandError
 	if errors.As(err, &mongoErr) {
@@ -955,6 +955,10 @@ func mongoClusterMutationCommandError(err error) (wire.Document, error) {
 		code, codeName = commandCodeDuplicateKey, "DuplicateKey"
 	}
 	return commandError(code, codeName, err.Error())
+}
+
+func mongoClusterMutationCommandError(err error) (wire.Document, error) {
+	return mongoClusterRouteCommandError(err)
 }
 
 type mongoCommandError struct {

--- a/TreeDB/mongo_gateway/cluster_submitter_test.go
+++ b/TreeDB/mongo_gateway/cluster_submitter_test.go
@@ -637,6 +637,63 @@ func mustMongoRouteTestCatalog(tb testing.TB, mode raftplacement.PlacementModeV1
 	return catalog
 }
 
+func mustMongoCollectionGroupRouteCatalog(tb testing.TB) raftplacement.ResolvedCatalogV1 {
+	tb.Helper()
+	catalog, err := raftplacement.Validate(raftplacement.CatalogV1{
+		Features: raftplacement.DefaultFeatureSet(),
+		Groups: []raftplacement.GroupV1{
+			{ID: "group-a", Members: []raftcluster.NodeID{"node-a", "node-b"}, LeaderHint: "node-a"},
+			{ID: "group-b", Members: []raftcluster.NodeID{"node-c", "node-d"}, LeaderHint: "node-c"},
+		},
+		Placements: []raftplacement.CollectionPlacementV1{
+			{
+				Collection: raftplacement.CollectionRefV1{
+					Database:   "app",
+					Catalog:    "default",
+					Collection: "users",
+				},
+				Mode:    raftplacement.PlacementModeCollectionV1,
+				GroupID: "group-b",
+			},
+		},
+	})
+	if err != nil {
+		tb.Fatalf("Validate Mongo collection group route catalog: %v", err)
+	}
+	return catalog
+}
+
+func mustMongoTokenGroupRouteCatalog(tb testing.TB, mode raftplacement.PlacementModeV1, groupBStart uint64) raftplacement.ResolvedCatalogV1 {
+	tb.Helper()
+	partitions := make([]raftplacement.TokenPartitionV1, 0, 2)
+	if groupBStart > 0 {
+		partitions = append(partitions, raftplacement.TokenPartitionV1{ID: "p0", GroupID: "group-a", Start: 0, End: groupBStart - 1})
+	}
+	partitions = append(partitions, raftplacement.TokenPartitionV1{ID: "p1", GroupID: "group-b", Start: groupBStart, End: ^uint64(0)})
+	catalog, err := raftplacement.Validate(raftplacement.CatalogV1{
+		Features: raftplacement.DefaultFeatureSet(),
+		Groups: []raftplacement.GroupV1{
+			{ID: "group-a", Members: []raftcluster.NodeID{"node-a", "node-b"}, LeaderHint: "node-a"},
+			{ID: "group-b", Members: []raftcluster.NodeID{"node-c", "node-d"}, LeaderHint: "node-c"},
+		},
+		Placements: []raftplacement.CollectionPlacementV1{
+			{
+				Collection: raftplacement.CollectionRefV1{
+					Database:   "app",
+					Catalog:    "default",
+					Collection: "users",
+				},
+				Mode:            mode,
+				TokenPartitions: partitions,
+			},
+		},
+	})
+	if err != nil {
+		tb.Fatalf("Validate Mongo token group route catalog: %v", err)
+	}
+	return catalog
+}
+
 func TestClusterAdmissionMongoLeaderRoutesThroughSubmitter(t *testing.T) {
 	submitter := &mongoClusterAdmissionSubmitter{
 		mongoClusterFakeSubmitter: &mongoClusterFakeSubmitter{},
@@ -915,6 +972,77 @@ func TestClusterRoutePreflightMongoTokenPlacementRejectsMultiIDWrites(t *testing
 	}
 }
 
+func TestClusterRoutePreflightMongoRejectsUnsupportedFindRoute(t *testing.T) {
+	server, submitter := newMongoPlacementRouteTestServer(t, raftplacement.PlacementModeRingV1)
+	response := serveCommand(t, server, 336108, bson.D{
+		{Key: "find", Value: "users"},
+		{Key: "filter", Value: bson.D{{Key: "name", Value: "Ada"}}},
+		{Key: "$db", Value: "app"},
+	})
+	assertCommandError(t, response, "NotWritablePrimary")
+	assertErrmsgContains(t, response, "query route shape is not supported")
+	if routes := submitter.snapshotRoutes(); len(routes) != 0 {
+		t.Fatalf("route calls=%d want 0 before unsupported query provider call", len(routes))
+	}
+	if calls := submitter.snapshotCalls(); len(calls) != 0 {
+		t.Fatalf("submit calls=%d want 0", len(calls))
+	}
+}
+
+func TestClusterRoutePreflightMongoRejectsNonShardKeyWrites(t *testing.T) {
+	tests := []struct {
+		name string
+		run  func(testing.TB, *Server) wire.Document
+	}{
+		{
+			name: "update",
+			run: func(tb testing.TB, server *Server) wire.Document {
+				return serveCommand(tb, server, 336109, bson.D{
+					{Key: "update", Value: "users"},
+					{Key: "updates", Value: bson.A{
+						bson.D{
+							{Key: "q", Value: bson.D{{Key: "name", Value: "Ada"}}},
+							{Key: "u", Value: bson.D{{Key: "$set", Value: bson.D{{Key: "city", Value: "hnl"}}}}},
+						},
+						bson.D{
+							{Key: "q", Value: bson.D{{Key: "_id", Value: "u2"}}},
+							{Key: "u", Value: bson.D{{Key: "$set", Value: bson.D{{Key: "city", Value: "hnl"}}}}},
+						},
+					}},
+					{Key: "$db", Value: "app"},
+				})
+			},
+		},
+		{
+			name: "delete",
+			run: func(tb testing.TB, server *Server) wire.Document {
+				return serveCommand(tb, server, 336110, bson.D{
+					{Key: "delete", Value: "users"},
+					{Key: "deletes", Value: bson.A{
+						bson.D{{Key: "q", Value: bson.D{{Key: "name", Value: "Ada"}}}, {Key: "limit", Value: int32(1)}},
+						bson.D{{Key: "q", Value: bson.D{{Key: "_id", Value: "u2"}}}, {Key: "limit", Value: int32(1)}},
+					}},
+					{Key: "$db", Value: "app"},
+				})
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			server, submitter := newMongoPlacementRouteTestServer(t, raftplacement.PlacementModeRingV1)
+			response := tc.run(t, server)
+			assertCommandError(t, response, "NotWritablePrimary")
+			assertErrmsgContains(t, response, "query route shape is not supported")
+			if routes := submitter.snapshotRoutes(); len(routes) != 0 {
+				t.Fatalf("route calls=%d want 0 before unsupported query provider call", len(routes))
+			}
+			if calls := submitter.snapshotCalls(); len(calls) != 0 {
+				t.Fatalf("submit calls=%d want 0", len(calls))
+			}
+		})
+	}
+}
+
 func TestMongoGroupRoutedDispatcherRoutesCollectionBatchWrite(t *testing.T) {
 	provider := &mongoStaticClusterRouteProvider{
 		target: treenativewire.ClusterRouteTarget{
@@ -991,6 +1119,54 @@ func TestMongoGroupRoutedDispatcherRoutesSingleTokenWrite(t *testing.T) {
 	meta := calls[0].metadata
 	if !meta.ClusterRouteKnown || meta.ClusterRouteShape != string(treenativewire.ClusterRouteShapeToken) || meta.ClusterRouteGroupID != "group-b" || !meta.ClusterRouteTokenKnown || meta.ClusterRouteToken != token || meta.ClusterRoutePartitionID != "p0" {
 		t.Fatalf("group-b token route metadata=%+v want group-b token=%d p0", meta, token)
+	}
+}
+
+func TestMongoGroupRoutedDispatcherCatalogRoutesCollectionOwner(t *testing.T) {
+	provider := treenativewire.NewCatalogClusterRouteProvider(mustMongoCollectionGroupRouteCatalog(t))
+	server, groupA, groupB := newMongoGroupRoutedDispatcherTestServer(t, provider)
+	response := serveCommand(t, server, 336304, bson.D{
+		{Key: "insert", Value: "users"},
+		{Key: "documents", Value: bson.A{
+			bson.D{{Key: "_id", Value: "u1"}, {Key: "name", Value: "Ada"}},
+			bson.D{{Key: "_id", Value: "u2"}, {Key: "name", Value: "Grace"}},
+		}},
+		{Key: "$db", Value: "app"},
+	})
+	assertOK(t, response)
+	if calls := groupA.snapshotCalls(); len(calls) != 0 {
+		t.Fatalf("group-a calls=%d want 0", len(calls))
+	}
+	calls := groupB.snapshotCalls()
+	if len(calls) != 1 {
+		t.Fatalf("group-b calls=%d want 1", len(calls))
+	}
+	meta := calls[0].metadata
+	if !meta.ClusterRouteKnown || meta.ClusterRouteShape != string(treenativewire.ClusterRouteShapeCollection) || meta.ClusterRouteGroupID != "group-b" || meta.ClusterRouteLeaderHint != "node-c" || meta.ClusterRoutePlacementMode != string(raftplacement.PlacementModeCollectionV1) {
+		t.Fatalf("group-b catalog route metadata=%+v want collection owner group-b/node-c", meta)
+	}
+}
+
+func TestMongoGroupRoutedDispatcherCatalogRoutesSingleTokenOwner(t *testing.T) {
+	token := mongoClusterRouteTokenForValue(t, "u1")
+	provider := treenativewire.NewCatalogClusterRouteProvider(mustMongoTokenGroupRouteCatalog(t, raftplacement.PlacementModeRingV1, token))
+	server, groupA, groupB := newMongoGroupRoutedDispatcherTestServer(t, provider)
+	response := serveCommand(t, server, 336305, bson.D{
+		{Key: "insert", Value: "users"},
+		{Key: "documents", Value: bson.A{bson.D{{Key: "_id", Value: "u1"}, {Key: "name", Value: "Ada"}}}},
+		{Key: "$db", Value: "app"},
+	})
+	assertOK(t, response)
+	if calls := groupA.snapshotCalls(); len(calls) != 0 {
+		t.Fatalf("group-a calls=%d want 0", len(calls))
+	}
+	calls := groupB.snapshotCalls()
+	if len(calls) != 1 {
+		t.Fatalf("group-b calls=%d want 1", len(calls))
+	}
+	meta := calls[0].metadata
+	if !meta.ClusterRouteKnown || meta.ClusterRouteShape != string(treenativewire.ClusterRouteShapeToken) || meta.ClusterRouteGroupID != "group-b" || meta.ClusterRouteLeaderHint != "node-c" || !meta.ClusterRouteTokenKnown || meta.ClusterRouteToken != token || meta.ClusterRoutePartitionID != "p1" {
+		t.Fatalf("group-b catalog token route metadata=%+v want group-b/node-c token=%d p1", meta, token)
 	}
 }
 

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -674,6 +674,10 @@ func (s *Server) findResponsePayload(command wire.Document, cursorOwner int64) (
 		doc, err := commandError(commandCodeBadValue, "BadValue", err.Error())
 		return findResponsePayload{document: doc}, err
 	}
+	if err := s.preflightClusterFindRoute(context.Background(), db, collection); err != nil {
+		doc, err := mongoClusterMutationCommandError(err)
+		return findResponsePayload{document: doc}, err
+	}
 	col, err := s.openCollectionCached(name)
 	if errors.Is(err, collections.ErrCollectionNotFound) {
 		doc, err := marshalCursorResponse(db, collection, bson.A{})

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -675,7 +675,7 @@ func (s *Server) findResponsePayload(ctx context.Context, command wire.Document,
 		return findResponsePayload{document: doc}, err
 	}
 	if err := s.preflightClusterFindRoute(ctx, db, collection); err != nil {
-		doc, err := mongoClusterMutationCommandError(err)
+		doc, err := mongoClusterRouteCommandError(err)
 		return findResponsePayload{document: doc}, err
 	}
 	col, err := s.openCollectionCached(name)

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -605,8 +605,8 @@ func zeroIndexRangeOptions(opts collections.IndexRangeOptions) bool {
 		opts.Upper.Value == nil && !opts.Upper.Inclusive && !opts.Upper.Unbounded
 }
 
-func (s *Server) findResponse(command wire.Document, cursorOwner int64) (wire.Document, error) {
-	payload, err := s.findResponsePayload(command, cursorOwner)
+func (s *Server) findResponse(ctx context.Context, command wire.Document, cursorOwner int64) (wire.Document, error) {
+	payload, err := s.findResponsePayload(ctx, command, cursorOwner)
 	if err != nil {
 		return nil, err
 	}
@@ -617,12 +617,12 @@ func (s *Server) findResponse(command wire.Document, cursorOwner int64) (wire.Do
 	return doc, err
 }
 
-func (s *Server) findMsgResponse(command wire.Document, requestID, responseTo int32, cursorOwner int64) ([]byte, error) {
-	return s.findMsgResponseInto(nil, command, requestID, responseTo, cursorOwner)
+func (s *Server) findMsgResponse(ctx context.Context, command wire.Document, requestID, responseTo int32, cursorOwner int64) ([]byte, error) {
+	return s.findMsgResponseInto(ctx, nil, command, requestID, responseTo, cursorOwner)
 }
 
-func (s *Server) findMsgResponseInto(dst []byte, command wire.Document, requestID, responseTo int32, cursorOwner int64) ([]byte, error) {
-	payload, err := s.findResponsePayload(command, cursorOwner)
+func (s *Server) findMsgResponseInto(ctx context.Context, dst []byte, command wire.Document, requestID, responseTo int32, cursorOwner int64) ([]byte, error) {
+	payload, err := s.findResponsePayload(ctx, command, cursorOwner)
 	if err != nil {
 		return nil, err
 	}
@@ -638,7 +638,7 @@ func (s *Server) findMsgResponseInto(dst []byte, command wire.Document, requestI
 	return msg, err
 }
 
-func (s *Server) findResponsePayload(command wire.Document, cursorOwner int64) (findResponsePayload, error) {
+func (s *Server) findResponsePayload(ctx context.Context, command wire.Document, cursorOwner int64) (findResponsePayload, error) {
 	if doc, rejected, err := rejectUnsupportedReadConcern(command); rejected {
 		return findResponsePayload{document: doc}, err
 	}
@@ -674,7 +674,7 @@ func (s *Server) findResponsePayload(command wire.Document, cursorOwner int64) (
 		doc, err := commandError(commandCodeBadValue, "BadValue", err.Error())
 		return findResponsePayload{document: doc}, err
 	}
-	if err := s.preflightClusterFindRoute(context.Background(), db, collection); err != nil {
+	if err := s.preflightClusterFindRoute(ctx, db, collection); err != nil {
 		doc, err := mongoClusterMutationCommandError(err)
 		return findResponsePayload{document: doc}, err
 	}

--- a/TreeDB/mongo_gateway/server_core.go
+++ b/TreeDB/mongo_gateway/server_core.go
@@ -708,7 +708,7 @@ func (s *Server) handleMsgInto(ctx context.Context, dst []byte, h wire.Header, b
 			return nil, retainRequestBody, fmt.Errorf("%w: find with document sequences", wire.ErrUnsupported)
 		}
 		responseID := s.nextID()
-		response, err := s.findMsgResponseInto(dst, msg.Body, responseID, h.RequestID, cursorOwner)
+		response, err := s.findMsgResponseInto(ctx, dst, msg.Body, responseID, h.RequestID, cursorOwner)
 		if err != nil {
 			return nil, retainRequestBody, err
 		}
@@ -750,7 +750,7 @@ func (s *Server) commandResponse(ctx context.Context, name string, command wire.
 	case "insert":
 		return s.insertResponse(ctx, command, sequences)
 	case "find":
-		return s.findResponse(command, cursorOwner)
+		return s.findResponse(ctx, command, cursorOwner)
 	case "getMore":
 		return s.getMoreResponse(command, cursorOwner)
 	case "killCursors":

--- a/TreeDB/nativewire/cluster_route_provider.go
+++ b/TreeDB/nativewire/cluster_route_provider.go
@@ -49,6 +49,12 @@ func (p CatalogClusterRouteProvider) ClusterRoute(_ context.Context, request Clu
 		return clusterRouteTargetFromCatalogDecision(decision), nil
 	case ClusterRouteShapeTokenBatch:
 		return p.clusterRouteTokenBatch(request)
+	case ClusterRouteShapeQuery:
+		return ClusterRouteTarget{}, errors.Join(
+			raftplacement.ErrInvalidRouteRequest,
+			raftplacement.ErrUnsupportedRouteShape,
+			fmt.Errorf("%s/%s/%s query route requires bounded scatter/read-index routing", request.Database, request.Catalog, request.Collection),
+		)
 	default:
 		return ClusterRouteTarget{}, errors.Join(
 			raftplacement.ErrInvalidRouteRequest,

--- a/TreeDB/nativewire/cluster_submitter.go
+++ b/TreeDB/nativewire/cluster_submitter.go
@@ -34,6 +34,7 @@ const (
 	ClusterRouteShapeCollection ClusterRouteShape = "collection"
 	ClusterRouteShapeToken      ClusterRouteShape = "token"
 	ClusterRouteShapeTokenBatch ClusterRouteShape = "token_batch"
+	ClusterRouteShapeQuery      ClusterRouteShape = "query"
 )
 
 type ClusterRouteRequest struct {
@@ -237,7 +238,8 @@ func AdmitClusterMutation(ctx context.Context, submitter ClusterSubmitter) error
 // provider preserves existing submitter behavior; a configured provider must
 // return a supported route target with a group ID. Token/ring targets require
 // an exactly-one-ID token route request; multi-ID token batches are classified
-// only so adapters can fail closed until split/fanout execution exists.
+// only so adapters can fail closed until split/fanout execution exists. Query
+// routes fail closed until bounded scatter/read-index execution is implemented.
 func PreflightClusterRoute(ctx context.Context, submitter ClusterSubmitter, request ClusterRouteRequest) (ClusterRouteTarget, bool, error) {
 	provider, ok := submitter.(ClusterRouteProvider)
 	if !ok {
@@ -255,6 +257,8 @@ func PreflightClusterRoute(ctx context.Context, submitter ClusterSubmitter, requ
 			return ClusterRouteTarget{}, true, protocolError(iwire.ErrReadOnly, "cluster token batch route request requires multiple document tokens")
 		}
 		request.Tokens = append([]uint64(nil), request.Tokens...)
+	case ClusterRouteShapeQuery:
+		return ClusterRouteTarget{}, true, protocolError(iwire.ErrReadOnly, "cluster query route shape is not supported without bounded scatter/read-index routing")
 	default:
 		return ClusterRouteTarget{}, true, protocolError(iwire.ErrReadOnly, "cluster route shape %q is not supported", request.Shape)
 	}

--- a/TreeDB/nativewire/cluster_submitter_test.go
+++ b/TreeDB/nativewire/cluster_submitter_test.go
@@ -1214,6 +1214,31 @@ func TestClusterRoutePreflightRejectsNativeQueryRouteBeforeLocalRead(t *testing.
 	}
 }
 
+func TestClusterRoutePreflightRejectsNativeGetManyBeforeLocalRead(t *testing.T) {
+	catalog := mustNativewireRouteTestCatalog(t, raftplacement.PlacementModeRingV1)
+	submitter := &placementRouteClusterSubmitter{
+		fakeClusterSubmitter: &fakeClusterSubmitter{},
+		provider:             NewCatalogClusterRouteProvider(catalog),
+	}
+	client, _, mgr, _ := serveCollectionPipeWithServerAndOptions(t, ServerOptions{ClusterSubmitter: submitter})
+	seedReadCollection(t, mgr)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := client.Hello(ctx); err != nil {
+		t.Fatalf("Hello: %v", err)
+	}
+	_, _, err := client.GetMany(ctx, "users", [][]byte{[]byte("u1")})
+	if !isRemoteError(err, iwire.ErrReadOnly) || !strings.Contains(err.Error(), "query route shape is not supported") {
+		t.Fatalf("GetMany cluster route err=%v want unsupported query read-only", err)
+	}
+	if routes := submitter.snapshotRoutes(); len(routes) != 0 {
+		t.Fatalf("route calls=%d want 0 before unsupported query provider call", len(routes))
+	}
+	if calls := submitter.snapshot(); len(calls) != 0 {
+		t.Fatalf("submitter calls=%d want 0", len(calls))
+	}
+}
+
 func mustNativewireRouteTestCatalog(tb testing.TB, mode raftplacement.PlacementModeV1) raftplacement.ResolvedCatalogV1 {
 	tb.Helper()
 	catalog, err := raftplacement.Validate(raftplacement.CatalogV1{

--- a/TreeDB/nativewire/cluster_submitter_test.go
+++ b/TreeDB/nativewire/cluster_submitter_test.go
@@ -790,6 +790,34 @@ func TestClusterRoutePreflightRejectsFanoutTokenBatch(t *testing.T) {
 	}
 }
 
+func TestClusterRoutePreflightRejectsUnsupportedQueryShape(t *testing.T) {
+	submitter := &routingClusterSubmitter{
+		fakeClusterSubmitter: &fakeClusterSubmitter{},
+		target: ClusterRouteTarget{
+			GroupID:       "group-a",
+			PlacementMode: string(raftplacement.PlacementModeCollectionV1),
+			Shape:         ClusterRouteShapeCollection,
+		},
+	}
+	request := ClusterRouteRequest{
+		Database:    "default",
+		Catalog:     "default",
+		Collection:  "users",
+		CommandID:   iwire.CommandIndexLookup,
+		CommandName: "index_lookup",
+		Shape:       ClusterRouteShapeQuery,
+	}
+	if _, _, err := PreflightClusterRoute(context.Background(), submitter, request); codeOf(err) != iwire.ErrReadOnly || !strings.Contains(err.Error(), "query route shape is not supported") {
+		t.Fatalf("query preflight err=%v want unsupported query read-only", err)
+	}
+	if routes := submitter.snapshotRoutes(); len(routes) != 0 {
+		t.Fatalf("route calls=%d want 0 before unsupported query provider call", len(routes))
+	}
+	if calls := submitter.snapshot(); len(calls) != 0 {
+		t.Fatalf("submitter calls=%d want 0", len(calls))
+	}
+}
+
 func TestCatalogClusterRouteProviderRoutesResolvedCatalog(t *testing.T) {
 	collectionProvider := NewCatalogClusterRouteProvider(mustNativewireRouteTestCatalog(t, raftplacement.PlacementModeCollectionV1))
 	collectionTarget, err := collectionProvider.ClusterRoute(context.Background(), ClusterRouteRequest{
@@ -1161,6 +1189,31 @@ func TestClusterRoutePreflightTokenPlacementRejectsMultiID(t *testing.T) {
 	}
 }
 
+func TestClusterRoutePreflightRejectsNativeQueryRouteBeforeLocalRead(t *testing.T) {
+	catalog := mustNativewireRouteTestCatalog(t, raftplacement.PlacementModeRingV1)
+	submitter := &placementRouteClusterSubmitter{
+		fakeClusterSubmitter: &fakeClusterSubmitter{},
+		provider:             NewCatalogClusterRouteProvider(catalog),
+	}
+	client, _, mgr, _ := serveCollectionPipeWithServerAndOptions(t, ServerOptions{ClusterSubmitter: submitter})
+	seedReadCollection(t, mgr)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := client.Hello(ctx); err != nil {
+		t.Fatalf("Hello: %v", err)
+	}
+	_, _, err := client.IndexLookup(ctx, "users", "email", "ada@example.com", CursorLimits{})
+	if !isRemoteError(err, iwire.ErrReadOnly) || !strings.Contains(err.Error(), "query route shape is not supported") {
+		t.Fatalf("IndexLookup cluster route err=%v want unsupported query read-only", err)
+	}
+	if routes := submitter.snapshotRoutes(); len(routes) != 0 {
+		t.Fatalf("route calls=%d want 0 before unsupported query provider call", len(routes))
+	}
+	if calls := submitter.snapshot(); len(calls) != 0 {
+		t.Fatalf("submitter calls=%d want 0", len(calls))
+	}
+}
+
 func mustNativewireRouteTestCatalog(tb testing.TB, mode raftplacement.PlacementModeV1) raftplacement.ResolvedCatalogV1 {
 	tb.Helper()
 	catalog, err := raftplacement.Validate(raftplacement.CatalogV1{
@@ -1216,6 +1269,63 @@ func mustNativewireRouteBatchTestCatalog(tb testing.TB, mode raftplacement.Place
 	})
 	if err != nil {
 		tb.Fatalf("Validate batch route test catalog: %v", err)
+	}
+	return catalog
+}
+
+func mustNativewireCollectionGroupRouteCatalog(tb testing.TB) raftplacement.ResolvedCatalogV1 {
+	tb.Helper()
+	catalog, err := raftplacement.Validate(raftplacement.CatalogV1{
+		Features: raftplacement.DefaultFeatureSet(),
+		Groups: []raftplacement.GroupV1{
+			{ID: "group-a", Members: []raftcluster.NodeID{"node-a", "node-b"}, LeaderHint: "node-a"},
+			{ID: "group-b", Members: []raftcluster.NodeID{"node-c", "node-d"}, LeaderHint: "node-c"},
+		},
+		Placements: []raftplacement.CollectionPlacementV1{
+			{
+				Collection: raftplacement.CollectionRefV1{
+					Database:   "default",
+					Catalog:    "default",
+					Collection: "users",
+				},
+				Mode:    raftplacement.PlacementModeCollectionV1,
+				GroupID: "group-b",
+			},
+		},
+	})
+	if err != nil {
+		tb.Fatalf("Validate collection group route catalog: %v", err)
+	}
+	return catalog
+}
+
+func mustNativewireTokenGroupRouteCatalog(tb testing.TB, mode raftplacement.PlacementModeV1, groupBStart uint64) raftplacement.ResolvedCatalogV1 {
+	tb.Helper()
+	partitions := make([]raftplacement.TokenPartitionV1, 0, 2)
+	if groupBStart > 0 {
+		partitions = append(partitions, raftplacement.TokenPartitionV1{ID: "p0", GroupID: "group-a", Start: 0, End: groupBStart - 1})
+	}
+	partitions = append(partitions, raftplacement.TokenPartitionV1{ID: "p1", GroupID: "group-b", Start: groupBStart, End: ^uint64(0)})
+	catalog, err := raftplacement.Validate(raftplacement.CatalogV1{
+		Features: raftplacement.DefaultFeatureSet(),
+		Groups: []raftplacement.GroupV1{
+			{ID: "group-a", Members: []raftcluster.NodeID{"node-a", "node-b"}, LeaderHint: "node-a"},
+			{ID: "group-b", Members: []raftcluster.NodeID{"node-c", "node-d"}, LeaderHint: "node-c"},
+		},
+		Placements: []raftplacement.CollectionPlacementV1{
+			{
+				Collection: raftplacement.CollectionRefV1{
+					Database:   "default",
+					Catalog:    "default",
+					Collection: "users",
+				},
+				Mode:            mode,
+				TokenPartitions: partitions,
+			},
+		},
+	})
+	if err != nil {
+		tb.Fatalf("Validate token group route catalog: %v", err)
 	}
 	return catalog
 }
@@ -2039,6 +2149,60 @@ func TestRaftClusterSubmitterGroupRoutedDispatcherRoutesSingleTokenWrite(t *test
 	}
 	if !meta.ClusterRouteKnown || meta.ClusterRouteShape != string(ClusterRouteShapeToken) || meta.ClusterRouteGroupID != "group-b" || !meta.ClusterRouteTokenKnown || meta.ClusterRouteToken != token || meta.ClusterRoutePartitionID != "p0" {
 		t.Fatalf("group-b token route metadata=%+v want group-b token=%d p0", meta, token)
+	}
+}
+
+func TestRaftClusterSubmitterGroupRoutedDispatcherCatalogRoutesCollectionOwner(t *testing.T) {
+	provider := NewCatalogClusterRouteProvider(mustNativewireCollectionGroupRouteCatalog(t))
+	client, groupA, groupB, mgr, _ := serveGroupRoutedRaftClusterBridgePipe(t, provider)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := client.Hello(ctx); err != nil {
+		t.Fatalf("Hello: %v", err)
+	}
+	version := clientCatalogVersion(t, client, ctx)
+	if _, err := client.commandSections(ctx, iwire.CommandCreateCollection, raftClusterCreateCollectionSections("users", version, AckVisible)...); err != nil {
+		t.Fatalf("CreateCollection catalog group-routed dispatcher: %v", err)
+	}
+	if _, err := mgr.OpenCollection("users"); err != nil {
+		t.Fatalf("OpenCollection users after catalog routed create: %v", err)
+	}
+	if calls := groupA.snapshotCalls(); len(calls) != 0 {
+		t.Fatalf("group-a calls=%d want 0", len(calls))
+	}
+	calls := groupB.snapshotCalls()
+	if len(calls) != 1 {
+		t.Fatalf("group-b calls=%d want 1", len(calls))
+	}
+	meta := calls[0].metadata
+	if !meta.ClusterRouteKnown || meta.ClusterRouteShape != string(ClusterRouteShapeCollection) || meta.ClusterRouteGroupID != "group-b" || meta.ClusterRouteLeaderHint != "node-c" || meta.ClusterRoutePlacementMode != string(raftplacement.PlacementModeCollectionV1) {
+		t.Fatalf("group-b catalog route metadata=%+v want collection owner group-b/node-c", meta)
+	}
+}
+
+func TestRaftClusterSubmitterGroupRoutedDispatcherCatalogRoutesSingleTokenOwner(t *testing.T) {
+	id := []byte("u1")
+	token := raftplacement.DocumentIDTokenV1(id)
+	provider := NewCatalogClusterRouteProvider(mustNativewireTokenGroupRouteCatalog(t, raftplacement.PlacementModeRingV1, token))
+	client, groupA, groupB, _, _ := serveGroupRoutedRaftClusterBridgePipe(t, provider)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := client.Hello(ctx); err != nil {
+		t.Fatalf("Hello: %v", err)
+	}
+	if _, err := client.InsertBatch(ctx, "users", collections.DocumentFormatJSON, [][]byte{id}, [][]byte{[]byte(`{"name":"Ada"}`)}, AckVisible); err != nil {
+		t.Fatalf("InsertBatch catalog group-routed dispatcher: %v", err)
+	}
+	if calls := groupA.snapshotCalls(); len(calls) != 0 {
+		t.Fatalf("group-a calls=%d want 0", len(calls))
+	}
+	calls := groupB.snapshotCalls()
+	if len(calls) != 1 {
+		t.Fatalf("group-b calls=%d want 1", len(calls))
+	}
+	meta := calls[0].metadata
+	if !meta.ClusterRouteKnown || meta.ClusterRouteShape != string(ClusterRouteShapeToken) || meta.ClusterRouteGroupID != "group-b" || meta.ClusterRouteLeaderHint != "node-c" || !meta.ClusterRouteTokenKnown || meta.ClusterRouteToken != token || meta.ClusterRoutePartitionID != "p1" {
+		t.Fatalf("group-b catalog token route metadata=%+v want group-b/node-c token=%d p1", meta, token)
 	}
 }
 

--- a/TreeDB/nativewire/server_read.go
+++ b/TreeDB/nativewire/server_read.go
@@ -12,6 +12,9 @@ func (s *Server) handleRead(ctx context.Context, header iwire.Header, state *con
 	var readMeta ReadMetadata
 	var err error
 	if cmd.Header.ID != iwire.CommandCursorNext {
+		if err := s.preflightClusterReadRoute(ctx, state, cmd); err != nil {
+			return nil, nil, false, err
+		}
 		readMeta, err = s.readMetadataForCommand(ctx, header, cmd)
 		if err != nil {
 			return nil, nil, false, err
@@ -127,6 +130,49 @@ func coordinatedReadCommand(commandID iwire.CommandID) bool {
 	default:
 		return false
 	}
+}
+
+func (s *Server) preflightClusterReadRoute(ctx context.Context, state *connState, cmd iwire.ValidatedCommand) error {
+	if s == nil || s.clusterSubmitter == nil {
+		return nil
+	}
+	if _, ok := s.clusterSubmitter.(ClusterRouteProvider); !ok {
+		return nil
+	}
+	switch cmd.Header.ID {
+	case iwire.CommandIndexLookup, iwire.CommandIndexRange, iwire.CommandOpenScan:
+	default:
+		return nil
+	}
+	collection, err := clusterReadRouteCollection(state, cmd.Known)
+	if err != nil {
+		return err
+	}
+	name := ""
+	if cmd.Schema != nil {
+		name = cmd.Schema.Name
+	}
+	_, _, err = PreflightClusterRoute(ctx, s.clusterSubmitter, ClusterRouteRequest{
+		Database:    "default",
+		Catalog:     "default",
+		Collection:  collection,
+		CommandID:   cmd.Header.ID,
+		CommandName: name,
+		Shape:       ClusterRouteShapeQuery,
+	})
+	return err
+}
+
+func clusterReadRouteCollection(state *connState, sections []iwire.Section) (string, error) {
+	raw, err := metadataSection(sections, iwire.SectionCollectionRef)
+	if err != nil {
+		return "", err
+	}
+	collection, _, err := decodeCollectionRef(state, raw)
+	if err != nil {
+		return "", err
+	}
+	return collection, nil
 }
 
 func rejectUnsupportedReadConsistencyPolicy(cmd iwire.ValidatedCommand) error {

--- a/TreeDB/nativewire/server_read.go
+++ b/TreeDB/nativewire/server_read.go
@@ -140,7 +140,7 @@ func (s *Server) preflightClusterReadRoute(ctx context.Context, state *connState
 		return nil
 	}
 	switch cmd.Header.ID {
-	case iwire.CommandIndexLookup, iwire.CommandIndexRange, iwire.CommandOpenScan:
+	case iwire.CommandGetMany, iwire.CommandIndexLookup, iwire.CommandIndexRange, iwire.CommandOpenScan:
 	default:
 		return nil
 	}


### PR DESCRIPTION
Refs #3444.
Parent: #3046.

Base: `main` at `97247676349a94467e27819b38d6cafa0ae34b2d` after #3447 / #3439 merged. Latest head: `7de6f9ee9dc37e23d9e079725c6533f838db369f`.

## Summary

- Adds an explicit `query` cluster route shape that fails closed until bounded scatter/read-index routing exists.
- Wires nativewire `GetMany`, index/range/scan reads, and Mongo `find` through that fail-closed route guard when a cluster route provider is configured.
- Rejects Mongo multi-write batches with non-`_id` filters before submitter dispatch.
- Adds catalog-backed multi-group ownership tests proving collection and single-token writes route to the owning group via the group-routed dispatcher.
- Extends placement feature-floor refusal coverage for unsupported minor versions.
- Keeps Mongo cluster route error mapping in a route-level helper, with mutation paths delegating through the compatibility wrapper.

## Validation

Post-#3447 restack validation on the candidate tree for head `7de6f9ee9dc37e23d9e079725c6533f838db369f`, with `TMPDIR=/mnt/fast4tb/tmp/gomap-test-tmp GOCACHE=/mnt/fast4tb/tmp/go-cache GOMODCACHE=/mnt/fast4tb/tmp/go-mod-cache GOWORK=off`:

- `git diff --check`
- `go test ./TreeDB/nativewire -run 'TestClusterRoutePreflightRejectsUnsupportedQueryShape|TestClusterRoutePreflightRejectsNative(QueryRoute|GetMany)BeforeLocalRead|TestRaftClusterSubmitterGroupRoutedDispatcherCatalogRoutes(CollectionOwner|SingleTokenOwner)' -count=1`
- `go test ./TreeDB/mongo_gateway -run 'TestClusterRoutePreflightMongoRejectsUnsupportedFindRoute|TestClusterRoutePreflightMongoRejectsNonShardKeyWrites|TestMongoGroupRoutedDispatcherCatalogRoutes(CollectionOwner|SingleTokenOwner)' -count=1`
- `go test ./TreeDB/internal/raftplacement -run TestValidateFeatureFloorFailsClosed -count=1`
- `go test ./TreeDB/internal/raftplacement ./TreeDB/internal/raftcluster ./TreeDB/nativewire ./TreeDB/mongo_gateway -count=1`

## Performance

No route-overhead benchmark was run. This patch does not change the group dispatcher lookup/submission hot path or add fanout/scatter execution; it adds fail-closed query-shape guards, Mongo preflight classification for unsupported non-shard-key batch writes, ownership tests, and a naming-only review fix for shared Mongo route error mapping.

## Dependency And Merge Gates

- #3449 / #3443 is merged.
- #3447 / #3439 is merged into `main` as `97247676349a94467e27819b38d6cafa0ae34b2d`, and this branch has been updated onto that base by a non-rewriting merge commit.
- Latest-head CI for `7de6f9ee9dc37e23d9e079725c6533f838db369f` is running.
- #3448 remains open and `DIRTY`; previous live stack comments treated #3448 as a coordinator merge gate. Leave final mergeability to the coordinator after #3448 and latest-head CI/reviews clear.
- Do not merge from this PR; coordinator owns merge decisions.
