### PR TITLE
TreeDB Raft: install snapshots for rejoin and log truncation

### DIFF
--- a/TreeDB/internal/raftapply/durable_stores.go
+++ b/TreeDB/internal/raftapply/durable_stores.go
@@ -200,6 +200,23 @@ func (s *DurableApplyResultStore) Close() error {
 	return err
 }
 
+// Sync flushes the durable result metadata file even when the store was opened
+// with DisableSync for per-append writes.
+func (s *DurableApplyResultStore) Sync() error {
+	if s == nil {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err := s.checkOpenLocked("sync apply result"); err != nil {
+		return err
+	}
+	if err := s.file.Sync(); err != nil {
+		return codedError(raftentry.ErrorUnsafeDurabilityModeV1, "raftapply: sync result metadata %s: %v", s.path, err)
+	}
+	return nil
+}
+
 func (s *DurableApplyResultStore) Len() int {
 	if s == nil {
 		return 0
@@ -438,6 +455,23 @@ func (s *DurableApplyProgressStore) Close() error {
 	err := s.file.Close()
 	s.file = nil
 	return err
+}
+
+// Sync flushes the durable progress metadata file even when the store was opened
+// with DisableSync for per-append writes.
+func (s *DurableApplyProgressStore) Sync() error {
+	if s == nil {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err := s.checkOpenLocked("sync applied progress"); err != nil {
+		return err
+	}
+	if err := s.file.Sync(); err != nil {
+		return codedError(raftentry.ErrorUnsafeDurabilityModeV1, "raftapply: sync progress metadata %s: %v", s.path, err)
+	}
+	return nil
 }
 
 func (s *DurableApplyProgressStore) Len() int {

--- a/TreeDB/internal/raftcluster/config.go
+++ b/TreeDB/internal/raftcluster/config.go
@@ -96,13 +96,14 @@ type Config struct {
 }
 
 type ResolvedConfig struct {
-	Dir        string
-	ClusterDir string
-	NodeID     NodeID
-	GroupID    GroupID
-	Peers      []Peer
-	Features   FeatureSet
-	Layout     StorageLayout
+	Dir               string
+	ClusterDir        string
+	DisableSideStores bool
+	NodeID            NodeID
+	GroupID           GroupID
+	Peers             []Peer
+	Features          FeatureSet
+	Layout            StorageLayout
 }
 
 type PeerStorageDir struct {
@@ -178,13 +179,14 @@ func Validate(cfg Config) (ResolvedConfig, error) {
 	}
 	layout := storageLayout(clusterDir, cfg.NodeID, cfg.GroupID, peers)
 	return ResolvedConfig{
-		Dir:        dir,
-		ClusterDir: clusterDir,
-		NodeID:     cfg.NodeID,
-		GroupID:    cfg.GroupID,
-		Peers:      peers,
-		Features:   features,
-		Layout:     layout,
+		Dir:               dir,
+		ClusterDir:        clusterDir,
+		DisableSideStores: cfg.DisableSideStores,
+		NodeID:            cfg.NodeID,
+		GroupID:           cfg.GroupID,
+		Peers:             peers,
+		Features:          features,
+		Layout:            layout,
 	}, nil
 }
 

--- a/TreeDB/internal/raftcluster/hashicorp_raft.go
+++ b/TreeDB/internal/raftcluster/hashicorp_raft.go
@@ -21,6 +21,7 @@ const (
 	hashicorpRaftDefaultApplyTimeout   = 5 * time.Second
 	hashicorpRaftDefaultSnapshotRetain = 2
 	hashicorpRaftSnapshotCheckInterval = 24 * time.Hour
+	hashicorpRaftMinTrailingLogs       = 1
 	hashicorpRaftReadIndexInitialPoll  = 2 * time.Millisecond
 	hashicorpRaftReadIndexMaxPoll      = 25 * time.Millisecond
 )
@@ -776,6 +777,9 @@ func hashicorpRaftConfig(nodeID NodeID, src *hraft.Config) *hraft.Config {
 	conf.NoLegacyTelemetry = true
 	if conf.SnapshotInterval < 5*time.Millisecond {
 		conf.SnapshotInterval = hashicorpRaftSnapshotCheckInterval
+	}
+	if conf.TrailingLogs < hashicorpRaftMinTrailingLogs {
+		conf.TrailingLogs = hashicorpRaftMinTrailingLogs
 	}
 	return &conf
 }

--- a/TreeDB/internal/raftcluster/hashicorp_raft.go
+++ b/TreeDB/internal/raftcluster/hashicorp_raft.go
@@ -60,6 +60,7 @@ type HashicorpRaftProviderOptions struct {
 type HashicorpRaftProvider struct {
 	cluster         ResolvedConfig
 	raft            *hraft.Raft
+	logStore        hraft.LogStore
 	appliedProgress AppliedProgressReader
 	applyTimeout    time.Duration
 	owned           []io.Closer
@@ -128,6 +129,7 @@ func OpenHashicorpRaftProvider(opts HashicorpRaftProviderOptions) (*HashicorpRaf
 	return &HashicorpRaftProvider{
 		cluster:         cluster,
 		raft:            r,
+		logStore:        stores.log,
 		appliedProgress: progressReader,
 		applyTimeout:    applyTimeout,
 		owned:           stores.owned,
@@ -474,6 +476,84 @@ func (s *hashicorpRaftStores) closeOnError(errp *error) {
 	}
 }
 
+// HashicorpRaftSnapshotResultV1 reports the persisted HashiCorp snapshot and
+// local log range observed around the snapshot operation. Log compaction is
+// performed by HashiCorp Raft only after the FSM snapshot is durably persisted.
+type HashicorpRaftSnapshotResultV1 struct {
+	ID                string
+	LastIncludedTerm  uint64
+	LastIncludedIndex uint64
+	SizeBytes         int64
+
+	FirstLogIndexBefore uint64
+	LastLogIndexBefore  uint64
+	FirstLogIndexAfter  uint64
+	LastLogIndexAfter   uint64
+	LogCompacted        bool
+
+	Manifest SnapshotManifestV1
+}
+
+// Snapshot asks HashiCorp Raft to persist an FSM snapshot and compact logs
+// according to the active Raft configuration.
+func (p *HashicorpRaftProvider) Snapshot(ctx context.Context) (HashicorpRaftSnapshotResultV1, error) {
+	if p == nil || p.raft == nil || p.logStore == nil {
+		return HashicorpRaftSnapshotResultV1{}, ErrInvalidHashicorpRaftProvider
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return HashicorpRaftSnapshotResultV1{}, err
+	}
+	firstBefore, firstBeforeErr := p.logStore.FirstIndex()
+	lastBefore, lastBeforeErr := p.logStore.LastIndex()
+	if firstBeforeErr != nil {
+		return HashicorpRaftSnapshotResultV1{}, errors.Join(ErrHashicorpRaftUnavailable, firstBeforeErr)
+	}
+	if lastBeforeErr != nil {
+		return HashicorpRaftSnapshotResultV1{}, errors.Join(ErrHashicorpRaftUnavailable, lastBeforeErr)
+	}
+	future := p.raft.Snapshot()
+	if err := waitHashicorpRaftFuture(ctx, future); err != nil {
+		return HashicorpRaftSnapshotResultV1{}, errors.Join(ErrHashicorpRaftUnavailable, err)
+	}
+	meta, snapshot, err := future.Open()
+	if err != nil {
+		return HashicorpRaftSnapshotResultV1{}, errors.Join(ErrHashicorpRaftUnavailable, err)
+	}
+	defer snapshot.Close()
+	payload, err := io.ReadAll(snapshot)
+	if err != nil {
+		return HashicorpRaftSnapshotResultV1{}, errors.Join(ErrHashicorpRaftUnavailable, err)
+	}
+	raftSnapshot, err := decodeHashicorpRaftSnapshotPayloadV1(payload)
+	if err != nil {
+		return HashicorpRaftSnapshotResultV1{}, err
+	}
+	firstAfter, firstAfterErr := p.logStore.FirstIndex()
+	lastAfter, lastAfterErr := p.logStore.LastIndex()
+	if firstAfterErr != nil {
+		return HashicorpRaftSnapshotResultV1{}, errors.Join(ErrHashicorpRaftUnavailable, firstAfterErr)
+	}
+	if lastAfterErr != nil {
+		return HashicorpRaftSnapshotResultV1{}, errors.Join(ErrHashicorpRaftUnavailable, lastAfterErr)
+	}
+	result := HashicorpRaftSnapshotResultV1{
+		ID:                  meta.ID,
+		LastIncludedTerm:    meta.Term,
+		LastIncludedIndex:   meta.Index,
+		SizeBytes:           meta.Size,
+		FirstLogIndexBefore: firstBefore,
+		LastLogIndexBefore:  lastBefore,
+		FirstLogIndexAfter:  firstAfter,
+		LastLogIndexAfter:   lastAfter,
+		LogCompacted:        firstAfter > firstBefore || (firstAfter == 0 && lastAfter == 0 && lastBefore > 0),
+		Manifest:            raftSnapshot.Manifest,
+	}
+	return result, nil
+}
+
 func (s *hashicorpRaftStores) closeOwned() {
 	for _, closer := range s.owned {
 		if closer != nil {
@@ -491,6 +571,7 @@ func hashicorpRaftConfig(nodeID NodeID, src *hraft.Config) *hraft.Config {
 		conf.CommitTimeout = 10 * time.Millisecond
 		conf.LeaderLeaseTimeout = 50 * time.Millisecond
 		conf.SnapshotInterval = hashicorpRaftSnapshotCheckInterval
+		conf.SnapshotThreshold = ^uint64(0)
 	} else {
 		conf = *src
 	}
@@ -505,10 +586,6 @@ func hashicorpRaftConfig(nodeID NodeID, src *hraft.Config) *hraft.Config {
 	if conf.SnapshotInterval < 5*time.Millisecond {
 		conf.SnapshotInterval = hashicorpRaftSnapshotCheckInterval
 	}
-	// HashiCorp Raft v1.7.3 rejects SnapshotInterval=0, so this provider
-	// suppresses unsupported snapshot attempts by making shouldSnapshot false for
-	// any practical log index instead of letting Snapshot() be scheduled.
-	conf.SnapshotThreshold = ^uint64(0)
 	return &conf
 }
 
@@ -710,9 +787,68 @@ func hashicorpRaftLogEntryError(err error) error {
 }
 
 func (f hashicorpRaftFSM) Snapshot() (hraft.FSMSnapshot, error) {
-	return nil, ErrRaftSnapshotUnsupported
+	exporter, ok := f.applier.(RaftSnapshotExporterV1)
+	if !ok {
+		return nil, ErrRaftSnapshotUnsupported
+	}
+	snapshot, err := exporter.ExportRaftSnapshotV1()
+	if err != nil {
+		return nil, err
+	}
+	if err := snapshot.Validate(); err != nil {
+		return nil, err
+	}
+	return hashicorpRaftSnapshotV1{snapshot: snapshot.Clone()}, nil
 }
 
-func (f hashicorpRaftFSM) Restore(io.ReadCloser) error {
-	return ErrRaftSnapshotUnsupported
+func (f hashicorpRaftFSM) Restore(src io.ReadCloser) error {
+	if src == nil {
+		return ErrRaftSnapshotUnsupported
+	}
+	defer src.Close()
+	installer, ok := f.applier.(RaftSnapshotInstallerV1)
+	if !ok {
+		return ErrRaftSnapshotUnsupported
+	}
+	return installer.InstallRaftSnapshotV1(src)
+}
+
+type hashicorpRaftSnapshotV1 struct {
+	snapshot RaftSnapshotV1
+}
+
+func (s hashicorpRaftSnapshotV1) Persist(sink hraft.SnapshotSink) error {
+	if sink == nil {
+		return ErrInvalidSnapshotManifest
+	}
+	if err := s.snapshot.Validate(); err != nil {
+		_ = sink.Cancel()
+		return err
+	}
+	if _, err := sink.Write(s.snapshot.Payload); err != nil {
+		_ = sink.Cancel()
+		return err
+	}
+	if err := sink.Close(); err != nil {
+		_ = sink.Cancel()
+		return err
+	}
+	return nil
+}
+
+func (s hashicorpRaftSnapshotV1) Release() {}
+
+func decodeHashicorpRaftSnapshotPayloadV1(payload []byte) (RaftSnapshotV1, error) {
+	if len(payload) == 0 {
+		return RaftSnapshotV1{}, fmt.Errorf("%w: empty persisted snapshot payload", ErrInvalidSnapshotManifest)
+	}
+	manifest, err := DecodeSnapshotManifestV1FromArchive(payload)
+	if err != nil {
+		return RaftSnapshotV1{}, err
+	}
+	snapshot := RaftSnapshotV1{Manifest: manifest, Payload: bytes.Clone(payload)}
+	if err := snapshot.Validate(); err != nil {
+		return RaftSnapshotV1{}, err
+	}
+	return snapshot, nil
 }

--- a/TreeDB/internal/raftcluster/hashicorp_raft.go
+++ b/TreeDB/internal/raftcluster/hashicorp_raft.go
@@ -526,6 +526,84 @@ func (s *hashicorpRaftStores) closeOnError(errp *error) {
 	}
 }
 
+// HashicorpRaftSnapshotResultV1 reports the persisted HashiCorp snapshot and
+// local log range observed around the snapshot operation. Log compaction is
+// performed by HashiCorp Raft only after the FSM snapshot is durably persisted.
+type HashicorpRaftSnapshotResultV1 struct {
+	ID                string
+	LastIncludedTerm  uint64
+	LastIncludedIndex uint64
+	SizeBytes         int64
+
+	FirstLogIndexBefore uint64
+	LastLogIndexBefore  uint64
+	FirstLogIndexAfter  uint64
+	LastLogIndexAfter   uint64
+	LogCompacted        bool
+
+	Manifest SnapshotManifestV1
+}
+
+// Snapshot asks HashiCorp Raft to persist an FSM snapshot and compact logs
+// according to the active Raft configuration.
+func (p *HashicorpRaftProvider) Snapshot(ctx context.Context) (HashicorpRaftSnapshotResultV1, error) {
+	if p == nil || p.raft == nil || p.logStore == nil {
+		return HashicorpRaftSnapshotResultV1{}, ErrInvalidHashicorpRaftProvider
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return HashicorpRaftSnapshotResultV1{}, err
+	}
+	firstBefore, firstBeforeErr := p.logStore.FirstIndex()
+	lastBefore, lastBeforeErr := p.logStore.LastIndex()
+	if firstBeforeErr != nil {
+		return HashicorpRaftSnapshotResultV1{}, errors.Join(ErrHashicorpRaftUnavailable, firstBeforeErr)
+	}
+	if lastBeforeErr != nil {
+		return HashicorpRaftSnapshotResultV1{}, errors.Join(ErrHashicorpRaftUnavailable, lastBeforeErr)
+	}
+	future := p.raft.Snapshot()
+	if err := waitHashicorpRaftFuture(ctx, future); err != nil {
+		return HashicorpRaftSnapshotResultV1{}, errors.Join(ErrHashicorpRaftUnavailable, err)
+	}
+	meta, snapshot, err := future.Open()
+	if err != nil {
+		return HashicorpRaftSnapshotResultV1{}, errors.Join(ErrHashicorpRaftUnavailable, err)
+	}
+	defer snapshot.Close()
+	payload, err := io.ReadAll(snapshot)
+	if err != nil {
+		return HashicorpRaftSnapshotResultV1{}, errors.Join(ErrHashicorpRaftUnavailable, err)
+	}
+	raftSnapshot, err := decodeHashicorpRaftSnapshotPayloadV1(payload)
+	if err != nil {
+		return HashicorpRaftSnapshotResultV1{}, err
+	}
+	firstAfter, firstAfterErr := p.logStore.FirstIndex()
+	lastAfter, lastAfterErr := p.logStore.LastIndex()
+	if firstAfterErr != nil {
+		return HashicorpRaftSnapshotResultV1{}, errors.Join(ErrHashicorpRaftUnavailable, firstAfterErr)
+	}
+	if lastAfterErr != nil {
+		return HashicorpRaftSnapshotResultV1{}, errors.Join(ErrHashicorpRaftUnavailable, lastAfterErr)
+	}
+	result := HashicorpRaftSnapshotResultV1{
+		ID:                  meta.ID,
+		LastIncludedTerm:    meta.Term,
+		LastIncludedIndex:   meta.Index,
+		SizeBytes:           meta.Size,
+		FirstLogIndexBefore: firstBefore,
+		LastLogIndexBefore:  lastBefore,
+		FirstLogIndexAfter:  firstAfter,
+		LastLogIndexAfter:   lastAfter,
+		LogCompacted:        firstAfter > firstBefore || (firstAfter == 0 && lastAfter == 0 && lastBefore > 0),
+		Manifest:            raftSnapshot.Manifest,
+	}
+	return result, nil
+}
+
 func (s *hashicorpRaftStores) closeOwned() {
 	for _, closer := range s.owned {
 		if closer != nil {
@@ -543,6 +621,7 @@ func hashicorpRaftConfig(nodeID NodeID, src *hraft.Config) *hraft.Config {
 		conf.CommitTimeout = 10 * time.Millisecond
 		conf.LeaderLeaseTimeout = 50 * time.Millisecond
 		conf.SnapshotInterval = hashicorpRaftSnapshotCheckInterval
+		conf.SnapshotThreshold = ^uint64(0)
 	} else {
 		conf = *src
 	}
@@ -557,10 +636,6 @@ func hashicorpRaftConfig(nodeID NodeID, src *hraft.Config) *hraft.Config {
 	if conf.SnapshotInterval < 5*time.Millisecond {
 		conf.SnapshotInterval = hashicorpRaftSnapshotCheckInterval
 	}
-	// HashiCorp Raft v1.7.3 rejects SnapshotInterval=0, so this provider
-	// suppresses unsupported snapshot attempts by making shouldSnapshot false for
-	// any practical log index instead of letting Snapshot() be scheduled.
-	conf.SnapshotThreshold = ^uint64(0)
 	return &conf
 }
 
@@ -762,9 +837,68 @@ func hashicorpRaftLogEntryError(err error) error {
 }
 
 func (f hashicorpRaftFSM) Snapshot() (hraft.FSMSnapshot, error) {
-	return nil, ErrRaftSnapshotUnsupported
+	exporter, ok := f.applier.(RaftSnapshotExporterV1)
+	if !ok {
+		return nil, ErrRaftSnapshotUnsupported
+	}
+	snapshot, err := exporter.ExportRaftSnapshotV1()
+	if err != nil {
+		return nil, err
+	}
+	if err := snapshot.Validate(); err != nil {
+		return nil, err
+	}
+	return hashicorpRaftSnapshotV1{snapshot: snapshot.Clone()}, nil
 }
 
-func (f hashicorpRaftFSM) Restore(io.ReadCloser) error {
-	return ErrRaftSnapshotUnsupported
+func (f hashicorpRaftFSM) Restore(src io.ReadCloser) error {
+	if src == nil {
+		return ErrRaftSnapshotUnsupported
+	}
+	defer src.Close()
+	installer, ok := f.applier.(RaftSnapshotInstallerV1)
+	if !ok {
+		return ErrRaftSnapshotUnsupported
+	}
+	return installer.InstallRaftSnapshotV1(src)
+}
+
+type hashicorpRaftSnapshotV1 struct {
+	snapshot RaftSnapshotV1
+}
+
+func (s hashicorpRaftSnapshotV1) Persist(sink hraft.SnapshotSink) error {
+	if sink == nil {
+		return ErrInvalidSnapshotManifest
+	}
+	if err := s.snapshot.Validate(); err != nil {
+		_ = sink.Cancel()
+		return err
+	}
+	if _, err := sink.Write(s.snapshot.Payload); err != nil {
+		_ = sink.Cancel()
+		return err
+	}
+	if err := sink.Close(); err != nil {
+		_ = sink.Cancel()
+		return err
+	}
+	return nil
+}
+
+func (s hashicorpRaftSnapshotV1) Release() {}
+
+func decodeHashicorpRaftSnapshotPayloadV1(payload []byte) (RaftSnapshotV1, error) {
+	if len(payload) == 0 {
+		return RaftSnapshotV1{}, fmt.Errorf("%w: empty persisted snapshot payload", ErrInvalidSnapshotManifest)
+	}
+	manifest, err := DecodeSnapshotManifestV1FromArchive(payload)
+	if err != nil {
+		return RaftSnapshotV1{}, err
+	}
+	snapshot := RaftSnapshotV1{Manifest: manifest, Payload: bytes.Clone(payload)}
+	if err := snapshot.Validate(); err != nil {
+		return RaftSnapshotV1{}, err
+	}
+	return snapshot, nil
 }

--- a/TreeDB/internal/raftcluster/hashicorp_raft.go
+++ b/TreeDB/internal/raftcluster/hashicorp_raft.go
@@ -715,12 +715,11 @@ func (p *HashicorpRaftProvider) Snapshot(ctx context.Context) (HashicorpRaftSnap
 		return HashicorpRaftSnapshotResultV1{}, errors.Join(ErrHashicorpRaftUnavailable, err)
 	}
 	defer snapshot.Close()
-	payload, err := io.ReadAll(snapshot)
+	manifest, err := DecodeSnapshotManifestV1FromArchiveReader(snapshot)
 	if err != nil {
-		return HashicorpRaftSnapshotResultV1{}, errors.Join(ErrHashicorpRaftUnavailable, err)
+		return HashicorpRaftSnapshotResultV1{}, err
 	}
-	raftSnapshot, err := decodeHashicorpRaftSnapshotPayloadV1(payload)
-	if err != nil {
+	if err := validateHashicorpRaftSnapshotManifestV1(meta, manifest); err != nil {
 		return HashicorpRaftSnapshotResultV1{}, err
 	}
 	firstAfter, firstAfterErr := p.logStore.FirstIndex()
@@ -741,7 +740,7 @@ func (p *HashicorpRaftProvider) Snapshot(ctx context.Context) (HashicorpRaftSnap
 		FirstLogIndexAfter:  firstAfter,
 		LastLogIndexAfter:   lastAfter,
 		LogCompacted:        firstAfter > firstBefore || (firstAfter == 0 && lastAfter == 0 && lastBefore > 0),
-		Manifest:            raftSnapshot.Manifest,
+		Manifest:            manifest,
 	}
 	return result, nil
 }
@@ -1033,17 +1032,15 @@ func (s hashicorpRaftSnapshotV1) Persist(sink hraft.SnapshotSink) error {
 
 func (s hashicorpRaftSnapshotV1) Release() {}
 
-func decodeHashicorpRaftSnapshotPayloadV1(payload []byte) (RaftSnapshotV1, error) {
-	if len(payload) == 0 {
-		return RaftSnapshotV1{}, fmt.Errorf("%w: empty persisted snapshot payload", ErrInvalidSnapshotManifest)
+func validateHashicorpRaftSnapshotManifestV1(meta *hraft.SnapshotMeta, manifest SnapshotManifestV1) error {
+	if meta == nil {
+		return fmt.Errorf("%w: missing hashicorp snapshot metadata", ErrInvalidSnapshotManifest)
 	}
-	manifest, err := DecodeSnapshotManifestV1FromArchive(payload)
-	if err != nil {
-		return RaftSnapshotV1{}, err
+	if meta.Term != manifest.LastIncludedTerm {
+		return fmt.Errorf("%w: hashicorp snapshot term %d does not match manifest term %d", ErrInvalidSnapshotManifest, meta.Term, manifest.LastIncludedTerm)
 	}
-	snapshot := RaftSnapshotV1{Manifest: manifest, Payload: bytes.Clone(payload)}
-	if err := snapshot.Validate(); err != nil {
-		return RaftSnapshotV1{}, err
+	if meta.Index != manifest.LastIncludedIndex {
+		return fmt.Errorf("%w: hashicorp snapshot index %d does not match manifest index %d", ErrInvalidSnapshotManifest, meta.Index, manifest.LastIncludedIndex)
 	}
-	return snapshot, nil
+	return nil
 }

--- a/TreeDB/internal/raftcluster/hashicorp_raft.go
+++ b/TreeDB/internal/raftcluster/hashicorp_raft.go
@@ -658,6 +658,7 @@ func openHashicorpRaftStores(layout StorageLayout, opts HashicorpRaftProviderOpt
 			return hashicorpRaftStores{}, errors.Join(ErrInvalidHashicorpRaftProvider, err)
 		}
 	}
+	stores.snapshots = wrapHashicorpRaftSnapshotStoreV1(stores.snapshots)
 	return stores, nil
 }
 
@@ -992,7 +993,7 @@ func (f hashicorpRaftFSM) Snapshot() (hraft.FSMSnapshot, error) {
 	if err := snapshot.Validate(); err != nil {
 		return nil, err
 	}
-	return hashicorpRaftSnapshotV1{snapshot: snapshot.Clone()}, nil
+	return hashicorpRaftSnapshotV1{snapshot: snapshot}, nil
 }
 
 func (f hashicorpRaftFSM) Restore(src io.ReadCloser) error {
@@ -1019,6 +1020,12 @@ func (s hashicorpRaftSnapshotV1) Persist(sink hraft.SnapshotSink) error {
 		_ = sink.Cancel()
 		return err
 	}
+	if boundary, ok := hashicorpRaftSnapshotBoundaryFromSinkV1(sink); ok {
+		if err := validateHashicorpRaftSnapshotBoundaryV1(boundary, s.snapshot.Manifest); err != nil {
+			_ = sink.Cancel()
+			return err
+		}
+	}
 	if _, err := sink.Write(s.snapshot.Payload); err != nil {
 		_ = sink.Cancel()
 		return err
@@ -1032,15 +1039,87 @@ func (s hashicorpRaftSnapshotV1) Persist(sink hraft.SnapshotSink) error {
 
 func (s hashicorpRaftSnapshotV1) Release() {}
 
+type hashicorpRaftSnapshotBoundaryV1 struct {
+	Term  uint64
+	Index uint64
+}
+
+type hashicorpRaftSnapshotBoundarySinkV1 interface {
+	hashicorpRaftSnapshotBoundaryV1() (hashicorpRaftSnapshotBoundaryV1, bool)
+}
+
+type hashicorpRaftSnapshotStoreV1 struct {
+	inner hraft.SnapshotStore
+}
+
+func wrapHashicorpRaftSnapshotStoreV1(inner hraft.SnapshotStore) hraft.SnapshotStore {
+	if inner == nil {
+		return nil
+	}
+	if _, ok := inner.(hashicorpRaftSnapshotStoreV1); ok {
+		return inner
+	}
+	return hashicorpRaftSnapshotStoreV1{inner: inner}
+}
+
+func (s hashicorpRaftSnapshotStoreV1) Create(version hraft.SnapshotVersion, index, term uint64, configuration hraft.Configuration, configurationIndex uint64, trans hraft.Transport) (hraft.SnapshotSink, error) {
+	sink, err := s.inner.Create(version, index, term, configuration, configurationIndex, trans)
+	if err != nil || sink == nil {
+		return sink, err
+	}
+	return hashicorpRaftSnapshotSinkV1{
+		SnapshotSink: sink,
+		boundary: hashicorpRaftSnapshotBoundaryV1{
+			Term:  term,
+			Index: index,
+		},
+	}, nil
+}
+
+func (s hashicorpRaftSnapshotStoreV1) List() ([]*hraft.SnapshotMeta, error) {
+	return s.inner.List()
+}
+
+func (s hashicorpRaftSnapshotStoreV1) Open(id string) (*hraft.SnapshotMeta, io.ReadCloser, error) {
+	return s.inner.Open(id)
+}
+
+type hashicorpRaftSnapshotSinkV1 struct {
+	hraft.SnapshotSink
+	boundary hashicorpRaftSnapshotBoundaryV1
+}
+
+func (s hashicorpRaftSnapshotSinkV1) hashicorpRaftSnapshotBoundaryV1() (hashicorpRaftSnapshotBoundaryV1, bool) {
+	return s.boundary, true
+}
+
+func hashicorpRaftSnapshotBoundaryFromSinkV1(sink hraft.SnapshotSink) (hashicorpRaftSnapshotBoundaryV1, bool) {
+	if sink == nil {
+		return hashicorpRaftSnapshotBoundaryV1{}, false
+	}
+	boundarySink, ok := sink.(hashicorpRaftSnapshotBoundarySinkV1)
+	if !ok {
+		return hashicorpRaftSnapshotBoundaryV1{}, false
+	}
+	return boundarySink.hashicorpRaftSnapshotBoundaryV1()
+}
+
 func validateHashicorpRaftSnapshotManifestV1(meta *hraft.SnapshotMeta, manifest SnapshotManifestV1) error {
 	if meta == nil {
 		return fmt.Errorf("%w: missing hashicorp snapshot metadata", ErrInvalidSnapshotManifest)
 	}
-	if meta.Term != manifest.LastIncludedTerm {
-		return fmt.Errorf("%w: hashicorp snapshot term %d does not match manifest term %d", ErrInvalidSnapshotManifest, meta.Term, manifest.LastIncludedTerm)
+	return validateHashicorpRaftSnapshotBoundaryV1(hashicorpRaftSnapshotBoundaryV1{
+		Term:  meta.Term,
+		Index: meta.Index,
+	}, manifest)
+}
+
+func validateHashicorpRaftSnapshotBoundaryV1(boundary hashicorpRaftSnapshotBoundaryV1, manifest SnapshotManifestV1) error {
+	if boundary.Term != manifest.LastIncludedTerm {
+		return fmt.Errorf("%w: hashicorp snapshot term %d does not match manifest term %d", ErrInvalidSnapshotManifest, boundary.Term, manifest.LastIncludedTerm)
 	}
-	if meta.Index != manifest.LastIncludedIndex {
-		return fmt.Errorf("%w: hashicorp snapshot index %d does not match manifest index %d", ErrInvalidSnapshotManifest, meta.Index, manifest.LastIncludedIndex)
+	if boundary.Index != manifest.LastIncludedIndex {
+		return fmt.Errorf("%w: hashicorp snapshot index %d does not match manifest index %d", ErrInvalidSnapshotManifest, boundary.Index, manifest.LastIncludedIndex)
 	}
 	return nil
 }

--- a/TreeDB/internal/raftcluster/hashicorp_raft_internal_test.go
+++ b/TreeDB/internal/raftcluster/hashicorp_raft_internal_test.go
@@ -62,6 +62,19 @@ func TestHashicorpRaftConfigDefaultsAvoidAutomaticSnapshots(t *testing.T) {
 	}
 }
 
+func TestHashicorpRaftConfigFloorsTrailingLogsForReadIndex(t *testing.T) {
+	src := hraft.DefaultConfig()
+	src.TrailingLogs = 0
+
+	conf := hashicorpRaftConfig("node-a", src)
+	if conf.TrailingLogs != hashicorpRaftMinTrailingLogs {
+		t.Fatalf("TrailingLogs=%d want %d", conf.TrailingLogs, hashicorpRaftMinTrailingLogs)
+	}
+	if err := hraft.ValidateConfig(conf); err != nil {
+		t.Fatalf("ValidateConfig: %v", err)
+	}
+}
+
 func TestHashicorpRaftReadIndexGapHasNoCommands(t *testing.T) {
 	store := hraft.NewInmemStore()
 	if err := store.StoreLogs([]*hraft.Log{

--- a/TreeDB/internal/raftcluster/hashicorp_raft_internal_test.go
+++ b/TreeDB/internal/raftcluster/hashicorp_raft_internal_test.go
@@ -1,6 +1,7 @@
 package raftcluster
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"math"
@@ -72,6 +73,84 @@ func TestHashicorpRaftConfigFloorsTrailingLogsForReadIndex(t *testing.T) {
 	}
 	if err := hraft.ValidateConfig(conf); err != nil {
 		t.Fatalf("ValidateConfig: %v", err)
+	}
+}
+
+func TestHashicorpRaftSnapshotPersistRejectsMismatchedBoundary(t *testing.T) {
+	manifest := validSnapshotManifestV1()
+	payload := validRaftSnapshotArchivePayloadV1(t, manifest)
+	snapshot := hashicorpRaftSnapshotV1{
+		snapshot: RaftSnapshotV1{
+			Manifest: manifest,
+			Payload:  payload,
+		},
+	}
+	sink := &boundaryTestSnapshotSink{
+		boundary: hashicorpRaftSnapshotBoundaryV1{
+			Term:  manifest.LastIncludedTerm,
+			Index: manifest.LastIncludedIndex + 1,
+		},
+	}
+
+	err := snapshot.Persist(sink)
+	if !errors.Is(err, ErrInvalidSnapshotManifest) {
+		t.Fatalf("Persist err=%v want ErrInvalidSnapshotManifest", err)
+	}
+	if !sink.canceled {
+		t.Fatal("Persist did not cancel sink after boundary mismatch")
+	}
+	if sink.closed {
+		t.Fatal("Persist closed sink after boundary mismatch")
+	}
+	if sink.Len() != 0 {
+		t.Fatalf("Persist wrote %d bytes before rejecting boundary", sink.Len())
+	}
+}
+
+func TestHashicorpRaftSnapshotPersistAcceptsMatchingBoundary(t *testing.T) {
+	manifest := validSnapshotManifestV1()
+	payload := validRaftSnapshotArchivePayloadV1(t, manifest)
+	snapshot := hashicorpRaftSnapshotV1{
+		snapshot: RaftSnapshotV1{
+			Manifest: manifest,
+			Payload:  payload,
+		},
+	}
+	sink := &boundaryTestSnapshotSink{
+		boundary: hashicorpRaftSnapshotBoundaryV1{
+			Term:  manifest.LastIncludedTerm,
+			Index: manifest.LastIncludedIndex,
+		},
+	}
+
+	if err := snapshot.Persist(sink); err != nil {
+		t.Fatalf("Persist: %v", err)
+	}
+	if !sink.closed {
+		t.Fatal("Persist did not close sink")
+	}
+	if sink.canceled {
+		t.Fatal("Persist canceled sink after successful write")
+	}
+	if !bytes.Equal(sink.Bytes(), payload) {
+		t.Fatalf("Persist wrote %d bytes, want payload %d bytes", sink.Len(), len(payload))
+	}
+}
+
+func TestHashicorpRaftSnapshotStoreWrapsCreateBoundary(t *testing.T) {
+	store := wrapHashicorpRaftSnapshotStoreV1(hraft.NewInmemSnapshotStore())
+	sink, err := store.Create(hraft.SnapshotVersionMax, 11, 7, hraft.Configuration{}, 0, nil)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	defer func() { _ = sink.Cancel() }()
+
+	boundary, ok := hashicorpRaftSnapshotBoundaryFromSinkV1(sink)
+	if !ok {
+		t.Fatal("wrapped snapshot sink did not expose boundary")
+	}
+	if boundary.Term != 7 || boundary.Index != 11 {
+		t.Fatalf("boundary={Term:%d Index:%d} want {Term:7 Index:11}", boundary.Term, boundary.Index)
 	}
 }
 
@@ -286,4 +365,33 @@ type countingReadIndexLogStore struct {
 func (s *countingReadIndexLogStore) GetLog(index uint64, log *hraft.Log) error {
 	s.getLogCount++
 	return s.LogStore.GetLog(index, log)
+}
+
+type boundaryTestSnapshotSink struct {
+	bytes.Buffer
+	id       string
+	boundary hashicorpRaftSnapshotBoundaryV1
+	closed   bool
+	canceled bool
+}
+
+func (s *boundaryTestSnapshotSink) ID() string {
+	if s.id != "" {
+		return s.id
+	}
+	return "boundary-test"
+}
+
+func (s *boundaryTestSnapshotSink) Close() error {
+	s.closed = true
+	return nil
+}
+
+func (s *boundaryTestSnapshotSink) Cancel() error {
+	s.canceled = true
+	return nil
+}
+
+func (s *boundaryTestSnapshotSink) hashicorpRaftSnapshotBoundaryV1() (hashicorpRaftSnapshotBoundaryV1, bool) {
+	return s.boundary, true
 }

--- a/TreeDB/internal/raftcluster/hashicorp_raft_internal_test.go
+++ b/TreeDB/internal/raftcluster/hashicorp_raft_internal_test.go
@@ -30,17 +30,31 @@ func TestHashicorpRaftLeadershipLostIsCommitAmbiguous(t *testing.T) {
 	}
 }
 
-func TestHashicorpRaftConfigSuppressesSnapshots(t *testing.T) {
+func TestHashicorpRaftConfigPreservesConfiguredSnapshots(t *testing.T) {
 	src := hraft.DefaultConfig()
 	src.SnapshotInterval = time.Millisecond
 	src.SnapshotThreshold = 1
+	src.TrailingLogs = 3
 
 	conf := hashicorpRaftConfig("node-a", src)
 	if conf.SnapshotInterval < 5*time.Millisecond {
 		t.Fatalf("SnapshotInterval=%s is invalid for hashicorp raft", conf.SnapshotInterval)
 	}
+	if conf.SnapshotThreshold != src.SnapshotThreshold {
+		t.Fatalf("SnapshotThreshold=%d want configured %d", conf.SnapshotThreshold, src.SnapshotThreshold)
+	}
+	if conf.TrailingLogs != src.TrailingLogs {
+		t.Fatalf("TrailingLogs=%d want configured %d", conf.TrailingLogs, src.TrailingLogs)
+	}
+	if err := hraft.ValidateConfig(conf); err != nil {
+		t.Fatalf("ValidateConfig: %v", err)
+	}
+}
+
+func TestHashicorpRaftConfigDefaultsAvoidAutomaticSnapshots(t *testing.T) {
+	conf := hashicorpRaftConfig("node-a", nil)
 	if conf.SnapshotThreshold != ^uint64(0) {
-		t.Fatalf("SnapshotThreshold=%d want max uint64", conf.SnapshotThreshold)
+		t.Fatalf("default SnapshotThreshold=%d want max uint64", conf.SnapshotThreshold)
 	}
 	if err := hraft.ValidateConfig(conf); err != nil {
 		t.Fatalf("ValidateConfig: %v", err)

--- a/TreeDB/internal/raftcluster/hashicorp_raft_test.go
+++ b/TreeDB/internal/raftcluster/hashicorp_raft_test.go
@@ -360,6 +360,64 @@ func TestHashicorpRaftProviderReadIndexRejectsTargetMismatch(t *testing.T) {
 	}
 }
 
+func TestHashicorpRaftProviderSnapshotRejoinsLaggingFollowerAndCompactsLogs(t *testing.T) {
+	cluster := newHashicorpRaftDBCluster(t)
+	leader := cluster.waitForLeader(t)
+	lagging := cluster.firstFollower(t, leader.id)
+	healthy := cluster.firstFollowerExcept(t, leader.id, lagging.id)
+	cluster.disconnectNode(t, lagging.id)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	createResult, err := leader.submitter.SubmitCommandEntryV1(ctx, testClusterCreateCollectionEntry(t, 7), raftentry.RequestMetadataV1{
+		RequestID: 705,
+		AckPolicy: iwire.AckRaftCommitted,
+	})
+	if err != nil {
+		t.Fatalf("Submit create: %v", err)
+	}
+	cluster.waitAppliedOn(t, createResult.CommittedEntry.EntryID(), leader, healthy)
+	insertResult, err := leader.submitter.SubmitCommandEntryV1(ctx, testClusterCommandEntry(t, 7), raftentry.RequestMetadataV1{
+		RequestID: 706,
+		AckPolicy: iwire.AckRaftCommitted,
+	})
+	if err != nil {
+		t.Fatalf("Submit insert: %v", err)
+	}
+	cluster.waitAppliedOn(t, insertResult.CommittedEntry.EntryID(), leader, healthy)
+	if got, ok := lagging.fsm.LastApplied(); ok && got.Index >= insertResult.CommittedEntry.Index {
+		t.Fatalf("lagging follower applied %d/%d while disconnected", got.Term, got.Index)
+	}
+
+	snapshot, err := leader.provider.Snapshot(ctx)
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	if snapshot.LastIncludedIndex < insertResult.CommittedEntry.Index ||
+		snapshot.Manifest.LastIncludedIndex != insertResult.CommittedEntry.Index ||
+		snapshot.Manifest.GroupID != "group-a" ||
+		snapshot.SizeBytes == 0 {
+		t.Fatalf("snapshot result=%+v insert=%+v", snapshot, insertResult.CommittedEntry)
+	}
+	if !snapshot.LogCompacted || (snapshot.FirstLogIndexAfter != 0 && snapshot.FirstLogIndexAfter <= snapshot.FirstLogIndexBefore) {
+		t.Fatalf("snapshot did not compact logs: %+v", snapshot)
+	}
+
+	cluster.reconnectAll()
+	cluster.waitApplied(t, insertResult.CommittedEntry.EntryID())
+	leaderDigest, err := leader.fsm.LogicalDigestV1(raftapply.LogicalDigestOptionsV1{})
+	if err != nil {
+		t.Fatalf("leader LogicalDigestV1: %v", err)
+	}
+	laggingDigest, err := lagging.fsm.LogicalDigestV1(raftapply.LogicalDigestOptionsV1{})
+	if err != nil {
+		t.Fatalf("lagging LogicalDigestV1: %v", err)
+	}
+	if laggingDigest != leaderDigest {
+		t.Fatalf("lagging digest=%s leader=%s after snapshot rejoin", laggingDigest.Hex(), leaderDigest.Hex())
+	}
+}
+
 func BenchmarkHashicorpRaftProviderReadIndex(b *testing.B) {
 	cluster := newHashicorpRaftDBCluster(b)
 	leader := cluster.waitForLeader(b)
@@ -714,6 +772,7 @@ func hashicorpRaftFastTestConfig() *hraft.Config {
 	conf.CommitTimeout = 10 * time.Millisecond
 	conf.SnapshotInterval = time.Hour
 	conf.SnapshotThreshold = ^uint64(0)
+	conf.TrailingLogs = 0
 	conf.LogOutput = io.Discard
 	conf.LogLevel = "ERROR"
 	conf.NoLegacyTelemetry = true
@@ -757,6 +816,40 @@ func (c *hashicorpRaftTestCluster) firstFollower(tb testing.TB, leaderID NodeID)
 	return nil
 }
 
+func (c *hashicorpRaftTestCluster) firstFollowerExcept(tb testing.TB, leaderID, excludedID NodeID) *hashicorpRaftTestNode {
+	tb.Helper()
+	for _, node := range c.nodes {
+		if node.id != leaderID && node.id != excludedID {
+			return node
+		}
+	}
+	tb.Fatalf("no follower found for leader %q excluding %q", leaderID, excludedID)
+	return nil
+}
+
+func (c *hashicorpRaftTestCluster) disconnectNode(tb testing.TB, id NodeID) {
+	tb.Helper()
+	target := c.nodes[id]
+	if target == nil {
+		tb.Fatalf("unknown node %q", id)
+	}
+	targetAddr := peerAddressForHashicorpRaftTest(tb, target, id)
+	for _, node := range c.nodes {
+		node.transport.Disconnect(hraft.ServerAddress(targetAddr))
+	}
+	target.transport.DisconnectAll()
+}
+
+func (c *hashicorpRaftTestCluster) reconnectAll() {
+	for _, from := range c.nodes {
+		for _, peer := range from.cfg.Peers {
+			if to := c.nodes[peer.ID]; to != nil {
+				from.transport.Connect(hraft.ServerAddress(peer.Address), to.transport)
+			}
+		}
+	}
+}
+
 func (c *hashicorpRaftTestCluster) waitFollowerHint(tb testing.TB, node *hashicorpRaftTestNode, leaderID NodeID) {
 	tb.Helper()
 	deadline := time.Now().Add(3 * time.Second)
@@ -771,6 +864,31 @@ func (c *hashicorpRaftTestCluster) waitFollowerHint(tb testing.TB, node *hashico
 		time.Sleep(20 * time.Millisecond)
 	}
 	tb.Fatalf("%s did not report leader hint %q; states=%s", node.id, leaderID, c.admissionSummary())
+}
+
+func (c *hashicorpRaftTestCluster) waitAppliedOn(tb testing.TB, id raftentry.ApplyEntryID, nodes ...*hashicorpRaftTestNode) {
+	tb.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		allApplied := true
+		for _, node := range nodes {
+			got, ok := node.fsm.LastApplied()
+			if !ok || got.Index < id.Index || got.Term != id.Term {
+				allApplied = false
+				break
+			}
+		}
+		if allApplied {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	var states []string
+	for _, node := range nodes {
+		got, ok := node.fsm.LastApplied()
+		states = append(states, fmt.Sprintf("%s=%d/%d ok=%t", node.id, got.Term, got.Index, ok))
+	}
+	tb.Fatalf("timed out waiting for apply %d/%d; applied=%s", id.Term, id.Index, strings.Join(states, ", "))
 }
 
 func (c *hashicorpRaftTestCluster) waitApplied(tb testing.TB, id raftentry.ApplyEntryID) {
@@ -809,6 +927,17 @@ func (c *hashicorpRaftTestCluster) admissionSummary() string {
 		states = append(states, fmt.Sprintf("%s leader=%t unavailable=%t hint=%q reason=%q", node.id, status.Leader, status.Unavailable, status.LeaderHint, status.Reason))
 	}
 	return strings.Join(states, "; ")
+}
+
+func peerAddressForHashicorpRaftTest(tb testing.TB, node *hashicorpRaftTestNode, id NodeID) string {
+	tb.Helper()
+	for _, peer := range node.cfg.Peers {
+		if peer.ID == id {
+			return peer.Address
+		}
+	}
+	tb.Fatalf("%s has no peer address for %q", node.id, id)
+	return ""
 }
 
 func staticCatalogVersion(version uint64) CatalogVersionProvider {

--- a/TreeDB/internal/raftcluster/hashicorp_raft_test.go
+++ b/TreeDB/internal/raftcluster/hashicorp_raft_test.go
@@ -526,6 +526,15 @@ func TestHashicorpRaftProviderSnapshotRejoinsLaggingFollowerAndCompactsLogs(t *t
 	if !snapshot.LogCompacted || (snapshot.FirstLogIndexAfter != 0 && snapshot.FirstLogIndexAfter <= snapshot.FirstLogIndexBefore) {
 		t.Fatalf("snapshot did not compact logs: %+v", snapshot)
 	}
+	proof, err := leader.provider.ReadIndex(ctx, ReadIndexBarrier{NodeID: leader.id, GroupID: "group-a"})
+	if err != nil {
+		t.Fatalf("ReadIndex after snapshot compaction: %v", err)
+	}
+	if proof.Index < insertResult.CommittedEntry.Index ||
+		proof.EvidenceKind != ReadIndexEvidenceProduction ||
+		!proof.HasQuorum {
+		t.Fatalf("post-snapshot read-index proof=%+v want production proof at or beyond %d", proof, insertResult.CommittedEntry.Index)
+	}
 
 	cluster.connectAllTransports(t)
 	cluster.waitApplied(t, insertResult.CommittedEntry.EntryID())

--- a/TreeDB/internal/raftcluster/hashicorp_raft_test.go
+++ b/TreeDB/internal/raftcluster/hashicorp_raft_test.go
@@ -409,6 +409,64 @@ func TestHashicorpRaftProviderReadIndexRejectsTargetMismatch(t *testing.T) {
 	}
 }
 
+func TestHashicorpRaftProviderSnapshotRejoinsLaggingFollowerAndCompactsLogs(t *testing.T) {
+	cluster := newHashicorpRaftDBCluster(t)
+	leader := cluster.waitForLeader(t)
+	lagging := cluster.firstFollower(t, leader.id)
+	healthy := cluster.firstFollowerExcept(t, leader.id, lagging.id)
+	cluster.disconnectNode(t, lagging.id)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	createResult, err := leader.submitter.SubmitCommandEntryV1(ctx, testClusterCreateCollectionEntry(t, 7), raftentry.RequestMetadataV1{
+		RequestID: 705,
+		AckPolicy: iwire.AckRaftCommitted,
+	})
+	if err != nil {
+		t.Fatalf("Submit create: %v", err)
+	}
+	cluster.waitAppliedOn(t, createResult.CommittedEntry.EntryID(), leader, healthy)
+	insertResult, err := leader.submitter.SubmitCommandEntryV1(ctx, testClusterCommandEntry(t, 7), raftentry.RequestMetadataV1{
+		RequestID: 706,
+		AckPolicy: iwire.AckRaftCommitted,
+	})
+	if err != nil {
+		t.Fatalf("Submit insert: %v", err)
+	}
+	cluster.waitAppliedOn(t, insertResult.CommittedEntry.EntryID(), leader, healthy)
+	if got, ok := lagging.fsm.LastApplied(); ok && got.Index >= insertResult.CommittedEntry.Index {
+		t.Fatalf("lagging follower applied %d/%d while disconnected", got.Term, got.Index)
+	}
+
+	snapshot, err := leader.provider.Snapshot(ctx)
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	if snapshot.LastIncludedIndex < insertResult.CommittedEntry.Index ||
+		snapshot.Manifest.LastIncludedIndex != insertResult.CommittedEntry.Index ||
+		snapshot.Manifest.GroupID != "group-a" ||
+		snapshot.SizeBytes == 0 {
+		t.Fatalf("snapshot result=%+v insert=%+v", snapshot, insertResult.CommittedEntry)
+	}
+	if !snapshot.LogCompacted || (snapshot.FirstLogIndexAfter != 0 && snapshot.FirstLogIndexAfter <= snapshot.FirstLogIndexBefore) {
+		t.Fatalf("snapshot did not compact logs: %+v", snapshot)
+	}
+
+	cluster.reconnectAll()
+	cluster.waitApplied(t, insertResult.CommittedEntry.EntryID())
+	leaderDigest, err := leader.fsm.LogicalDigestV1(raftapply.LogicalDigestOptionsV1{})
+	if err != nil {
+		t.Fatalf("leader LogicalDigestV1: %v", err)
+	}
+	laggingDigest, err := lagging.fsm.LogicalDigestV1(raftapply.LogicalDigestOptionsV1{})
+	if err != nil {
+		t.Fatalf("lagging LogicalDigestV1: %v", err)
+	}
+	if laggingDigest != leaderDigest {
+		t.Fatalf("lagging digest=%s leader=%s after snapshot rejoin", laggingDigest.Hex(), leaderDigest.Hex())
+	}
+}
+
 func BenchmarkHashicorpRaftProviderReadIndex(b *testing.B) {
 	cluster := newHashicorpRaftDBCluster(b)
 	leader := cluster.waitForLeader(b)
@@ -763,6 +821,7 @@ func hashicorpRaftFastTestConfig() *hraft.Config {
 	conf.CommitTimeout = 10 * time.Millisecond
 	conf.SnapshotInterval = time.Hour
 	conf.SnapshotThreshold = ^uint64(0)
+	conf.TrailingLogs = 0
 	conf.LogOutput = io.Discard
 	conf.LogLevel = "ERROR"
 	conf.NoLegacyTelemetry = true
@@ -806,6 +865,40 @@ func (c *hashicorpRaftTestCluster) firstFollower(tb testing.TB, leaderID NodeID)
 	return nil
 }
 
+func (c *hashicorpRaftTestCluster) firstFollowerExcept(tb testing.TB, leaderID, excludedID NodeID) *hashicorpRaftTestNode {
+	tb.Helper()
+	for _, node := range c.nodes {
+		if node.id != leaderID && node.id != excludedID {
+			return node
+		}
+	}
+	tb.Fatalf("no follower found for leader %q excluding %q", leaderID, excludedID)
+	return nil
+}
+
+func (c *hashicorpRaftTestCluster) disconnectNode(tb testing.TB, id NodeID) {
+	tb.Helper()
+	target := c.nodes[id]
+	if target == nil {
+		tb.Fatalf("unknown node %q", id)
+	}
+	targetAddr := peerAddressForHashicorpRaftTest(tb, target, id)
+	for _, node := range c.nodes {
+		node.transport.Disconnect(hraft.ServerAddress(targetAddr))
+	}
+	target.transport.DisconnectAll()
+}
+
+func (c *hashicorpRaftTestCluster) reconnectAll() {
+	for _, from := range c.nodes {
+		for _, peer := range from.cfg.Peers {
+			if to := c.nodes[peer.ID]; to != nil {
+				from.transport.Connect(hraft.ServerAddress(peer.Address), to.transport)
+			}
+		}
+	}
+}
+
 func (c *hashicorpRaftTestCluster) waitFollowerHint(tb testing.TB, node *hashicorpRaftTestNode, leaderID NodeID) {
 	tb.Helper()
 	deadline := time.Now().Add(3 * time.Second)
@@ -820,6 +913,31 @@ func (c *hashicorpRaftTestCluster) waitFollowerHint(tb testing.TB, node *hashico
 		time.Sleep(20 * time.Millisecond)
 	}
 	tb.Fatalf("%s did not report leader hint %q; states=%s", node.id, leaderID, c.admissionSummary())
+}
+
+func (c *hashicorpRaftTestCluster) waitAppliedOn(tb testing.TB, id raftentry.ApplyEntryID, nodes ...*hashicorpRaftTestNode) {
+	tb.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		allApplied := true
+		for _, node := range nodes {
+			got, ok := node.fsm.LastApplied()
+			if !ok || got.Index < id.Index || got.Term != id.Term {
+				allApplied = false
+				break
+			}
+		}
+		if allApplied {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	var states []string
+	for _, node := range nodes {
+		got, ok := node.fsm.LastApplied()
+		states = append(states, fmt.Sprintf("%s=%d/%d ok=%t", node.id, got.Term, got.Index, ok))
+	}
+	tb.Fatalf("timed out waiting for apply %d/%d; applied=%s", id.Term, id.Index, strings.Join(states, ", "))
 }
 
 func (c *hashicorpRaftTestCluster) waitApplied(tb testing.TB, id raftentry.ApplyEntryID) {
@@ -858,6 +976,17 @@ func (c *hashicorpRaftTestCluster) admissionSummary() string {
 		states = append(states, fmt.Sprintf("%s leader=%t unavailable=%t hint=%q reason=%q", node.id, status.Leader, status.Unavailable, status.LeaderHint, status.Reason))
 	}
 	return strings.Join(states, "; ")
+}
+
+func peerAddressForHashicorpRaftTest(tb testing.TB, node *hashicorpRaftTestNode, id NodeID) string {
+	tb.Helper()
+	for _, peer := range node.cfg.Peers {
+		if peer.ID == id {
+			return peer.Address
+		}
+	}
+	tb.Fatalf("%s has no peer address for %q", node.id, id)
+	return ""
 }
 
 func staticCatalogVersion(version uint64) CatalogVersionProvider {

--- a/TreeDB/internal/raftcluster/snapshot_manifest.go
+++ b/TreeDB/internal/raftcluster/snapshot_manifest.go
@@ -1,6 +1,7 @@
 package raftcluster
 
 import (
+	"archive/tar"
 	"bytes"
 	"encoding/hex"
 	"encoding/json"
@@ -16,6 +17,10 @@ import (
 const (
 	SnapshotManifestFormatV1 = "treedb.raftcluster.snapshot-manifest"
 	SnapshotManifestVersion1 = uint16(1)
+
+	RaftSnapshotArchiveFormatV1       = "treedb.raftcluster.raft-snapshot-archive"
+	RaftSnapshotArchiveVersion1       = uint16(1)
+	RaftSnapshotArchiveManifestPathV1 = "manifest.json"
 )
 
 var ErrInvalidSnapshotManifest = errors.New("raftcluster: invalid snapshot manifest")
@@ -174,4 +179,118 @@ func validateLogicalDigestV1Hex(digest string) error {
 		return fmt.Errorf("%w: non-canonical logical digest", ErrInvalidSnapshotManifest)
 	}
 	return nil
+}
+
+// RaftSnapshotV1 is the production snapshot payload handed to the Raft
+// adapter. The manifest identifies the durable apply boundary and logical
+// digest; Payload is an implementation-owned archive that contains the local
+// TreeDB storage required to restore that boundary on another node.
+type RaftSnapshotV1 struct {
+	Manifest SnapshotManifestV1
+	Payload  []byte
+}
+
+func (s RaftSnapshotV1) Clone() RaftSnapshotV1 {
+	s.Payload = bytes.Clone(s.Payload)
+	return s
+}
+
+func (s RaftSnapshotV1) Validate() error {
+	if err := s.Manifest.Validate(s.Manifest.Scope); err != nil {
+		return err
+	}
+	if len(s.Payload) == 0 {
+		return fmt.Errorf("%w: empty snapshot payload", ErrInvalidSnapshotManifest)
+	}
+	return nil
+}
+
+// RaftSnapshotExporterV1 is implemented by FSMs that can export a production
+// snapshot payload for the HashiCorp Raft adapter.
+type RaftSnapshotExporterV1 interface {
+	ExportRaftSnapshotV1() (RaftSnapshotV1, error)
+}
+
+// RaftSnapshotInstallerV1 is implemented by FSMs that can discard local state
+// and install a production snapshot payload from the HashiCorp Raft adapter.
+type RaftSnapshotInstallerV1 interface {
+	InstallRaftSnapshotV1(io.Reader) error
+}
+
+// RaftSnapshotArchiveHeaderV1 is stored as manifest.json at the root of the
+// production snapshot archive. The remaining archive layout is producer-owned.
+type RaftSnapshotArchiveHeaderV1 struct {
+	Format   string             `json:"format"`
+	Version  uint16             `json:"version"`
+	Manifest SnapshotManifestV1 `json:"manifest"`
+}
+
+func NewRaftSnapshotArchiveHeaderV1(manifest SnapshotManifestV1) RaftSnapshotArchiveHeaderV1 {
+	return RaftSnapshotArchiveHeaderV1{
+		Format:   RaftSnapshotArchiveFormatV1,
+		Version:  RaftSnapshotArchiveVersion1,
+		Manifest: manifest,
+	}
+}
+
+func (h RaftSnapshotArchiveHeaderV1) Validate(expectedScope SnapshotScopeIdentityV1) error {
+	if h.Format != RaftSnapshotArchiveFormatV1 {
+		return fmt.Errorf("%w: unsupported snapshot archive format %q", ErrInvalidSnapshotManifest, h.Format)
+	}
+	if h.Version != RaftSnapshotArchiveVersion1 {
+		return fmt.Errorf("%w: unsupported snapshot archive version %d", ErrInvalidSnapshotManifest, h.Version)
+	}
+	return h.Manifest.Validate(expectedScope)
+}
+
+func EncodeRaftSnapshotArchiveHeaderV1(header RaftSnapshotArchiveHeaderV1) ([]byte, error) {
+	if err := header.Validate(header.Manifest.Scope); err != nil {
+		return nil, err
+	}
+	return json.Marshal(header)
+}
+
+func DecodeRaftSnapshotArchiveHeaderV1(src []byte, expectedScope SnapshotScopeIdentityV1) (RaftSnapshotArchiveHeaderV1, error) {
+	dec := json.NewDecoder(bytes.NewReader(src))
+	dec.DisallowUnknownFields()
+	var header RaftSnapshotArchiveHeaderV1
+	if err := dec.Decode(&header); err != nil {
+		return RaftSnapshotArchiveHeaderV1{}, fmt.Errorf("%w: decode snapshot archive header JSON: %v", ErrInvalidSnapshotManifest, err)
+	}
+	if dec.Decode(&struct{}{}) != io.EOF {
+		return RaftSnapshotArchiveHeaderV1{}, fmt.Errorf("%w: trailing snapshot archive header JSON content", ErrInvalidSnapshotManifest)
+	}
+	if expectedScope == (SnapshotScopeIdentityV1{}) {
+		expectedScope = header.Manifest.Scope
+	}
+	if err := header.Validate(expectedScope); err != nil {
+		return RaftSnapshotArchiveHeaderV1{}, err
+	}
+	return header, nil
+}
+
+func DecodeSnapshotManifestV1FromArchive(payload []byte) (SnapshotManifestV1, error) {
+	tr := tar.NewReader(bytes.NewReader(payload))
+	for {
+		header, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return SnapshotManifestV1{}, fmt.Errorf("%w: read snapshot archive: %v", ErrInvalidSnapshotManifest, err)
+		}
+		if header == nil || header.Name != RaftSnapshotArchiveManifestPathV1 {
+			continue
+		}
+		raw, err := io.ReadAll(tr)
+		if err != nil {
+			return SnapshotManifestV1{}, fmt.Errorf("%w: read snapshot archive header: %v", ErrInvalidSnapshotManifest, err)
+		}
+		decoded, err := DecodeRaftSnapshotArchiveHeaderV1(raw, SnapshotScopeIdentityV1{})
+		if err != nil {
+			return SnapshotManifestV1{}, err
+		}
+		return decoded.Manifest, nil
+	}
+	return SnapshotManifestV1{}, fmt.Errorf("%w: missing snapshot archive header", ErrInvalidSnapshotManifest)
 }

--- a/TreeDB/internal/raftcluster/snapshot_manifest.go
+++ b/TreeDB/internal/raftcluster/snapshot_manifest.go
@@ -21,6 +21,7 @@ const (
 	RaftSnapshotArchiveFormatV1       = "treedb.raftcluster.raft-snapshot-archive"
 	RaftSnapshotArchiveVersion1       = uint16(1)
 	RaftSnapshotArchiveManifestPathV1 = "manifest.json"
+	RaftSnapshotArchiveHeaderMaxBytes = 1 << 20
 )
 
 var ErrInvalidSnapshotManifest = errors.New("raftcluster: invalid snapshot manifest")
@@ -296,9 +297,9 @@ func DecodeSnapshotManifestV1FromArchiveReader(reader io.Reader) (SnapshotManife
 		if header == nil || header.Name != RaftSnapshotArchiveManifestPathV1 {
 			continue
 		}
-		raw, err := io.ReadAll(tr)
+		raw, err := readRaftSnapshotArchiveHeaderBytesV1(tr, header.Size)
 		if err != nil {
-			return SnapshotManifestV1{}, fmt.Errorf("%w: read snapshot archive header: %v", ErrInvalidSnapshotManifest, err)
+			return SnapshotManifestV1{}, err
 		}
 		decoded, err := DecodeRaftSnapshotArchiveHeaderV1(raw, SnapshotScopeIdentityV1{})
 		if err != nil {
@@ -307,4 +308,18 @@ func DecodeSnapshotManifestV1FromArchiveReader(reader io.Reader) (SnapshotManife
 		return decoded.Manifest, nil
 	}
 	return SnapshotManifestV1{}, fmt.Errorf("%w: missing snapshot archive header", ErrInvalidSnapshotManifest)
+}
+
+func readRaftSnapshotArchiveHeaderBytesV1(reader io.Reader, size int64) ([]byte, error) {
+	if size > RaftSnapshotArchiveHeaderMaxBytes {
+		return nil, fmt.Errorf("%w: snapshot archive header is %d bytes, max %d", ErrInvalidSnapshotManifest, size, RaftSnapshotArchiveHeaderMaxBytes)
+	}
+	raw, err := io.ReadAll(io.LimitReader(reader, RaftSnapshotArchiveHeaderMaxBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("%w: read snapshot archive header: %v", ErrInvalidSnapshotManifest, err)
+	}
+	if len(raw) > RaftSnapshotArchiveHeaderMaxBytes {
+		return nil, fmt.Errorf("%w: snapshot archive header exceeds %d bytes", ErrInvalidSnapshotManifest, RaftSnapshotArchiveHeaderMaxBytes)
+	}
+	return raw, nil
 }

--- a/TreeDB/internal/raftcluster/snapshot_manifest.go
+++ b/TreeDB/internal/raftcluster/snapshot_manifest.go
@@ -207,10 +207,23 @@ func (s RaftSnapshotV1) Validate() error {
 	if err != nil {
 		return err
 	}
-	if payloadManifest != s.Manifest {
+	if !snapshotManifestV1Equal(payloadManifest, s.Manifest) {
 		return fmt.Errorf("%w: snapshot payload manifest does not match outer manifest", ErrInvalidSnapshotManifest)
 	}
 	return nil
+}
+
+func snapshotManifestV1Equal(a, b SnapshotManifestV1) bool {
+	return a.Format == b.Format &&
+		a.Version == b.Version &&
+		a.GroupID == b.GroupID &&
+		a.NodeID == b.NodeID &&
+		a.LastIncludedTerm == b.LastIncludedTerm &&
+		a.LastIncludedIndex == b.LastIncludedIndex &&
+		a.AppliedCommandLSN == b.AppliedCommandLSN &&
+		a.LogicalDigestV1 == b.LogicalDigestV1 &&
+		a.Scope == b.Scope &&
+		a.CreatedAt.Equal(b.CreatedAt)
 }
 
 // RaftSnapshotExporterV1 is implemented by FSMs that can export a production

--- a/TreeDB/internal/raftcluster/snapshot_manifest.go
+++ b/TreeDB/internal/raftcluster/snapshot_manifest.go
@@ -202,6 +202,13 @@ func (s RaftSnapshotV1) Validate() error {
 	if len(s.Payload) == 0 {
 		return fmt.Errorf("%w: empty snapshot payload", ErrInvalidSnapshotManifest)
 	}
+	payloadManifest, err := DecodeSnapshotManifestV1FromArchive(s.Payload)
+	if err != nil {
+		return err
+	}
+	if payloadManifest != s.Manifest {
+		return fmt.Errorf("%w: snapshot payload manifest does not match outer manifest", ErrInvalidSnapshotManifest)
+	}
 	return nil
 }
 
@@ -270,7 +277,14 @@ func DecodeRaftSnapshotArchiveHeaderV1(src []byte, expectedScope SnapshotScopeId
 }
 
 func DecodeSnapshotManifestV1FromArchive(payload []byte) (SnapshotManifestV1, error) {
-	tr := tar.NewReader(bytes.NewReader(payload))
+	return DecodeSnapshotManifestV1FromArchiveReader(bytes.NewReader(payload))
+}
+
+func DecodeSnapshotManifestV1FromArchiveReader(reader io.Reader) (SnapshotManifestV1, error) {
+	if reader == nil {
+		return SnapshotManifestV1{}, fmt.Errorf("%w: nil snapshot archive reader", ErrInvalidSnapshotManifest)
+	}
+	tr := tar.NewReader(reader)
 	for {
 		header, err := tr.Next()
 		if errors.Is(err, io.EOF) {

--- a/TreeDB/internal/raftcluster/snapshot_manifest_test.go
+++ b/TreeDB/internal/raftcluster/snapshot_manifest_test.go
@@ -1,6 +1,7 @@
 package raftcluster
 
 import (
+	"archive/tar"
 	"bytes"
 	"errors"
 	"strings"
@@ -193,6 +194,30 @@ func TestSnapshotManifestV1DecodeRejectsPaddedExpectedScope(t *testing.T) {
 	}
 }
 
+func TestRaftSnapshotV1ValidateRejectsMismatchedPayloadManifest(t *testing.T) {
+	outer := validSnapshotManifestV1()
+	embedded := outer
+	embedded.LastIncludedIndex++
+	snapshot := RaftSnapshotV1{
+		Manifest: outer,
+		Payload:  validRaftSnapshotArchivePayloadV1(t, embedded),
+	}
+	if err := snapshot.Validate(); !errors.Is(err, ErrInvalidSnapshotManifest) {
+		t.Fatalf("Validate mismatched payload manifest error=%v, want ErrInvalidSnapshotManifest", err)
+	}
+}
+
+func TestRaftSnapshotV1ValidateAcceptsMatchingPayloadManifest(t *testing.T) {
+	manifest := validSnapshotManifestV1()
+	snapshot := RaftSnapshotV1{
+		Manifest: manifest,
+		Payload:  validRaftSnapshotArchivePayloadV1(t, manifest),
+	}
+	if err := snapshot.Validate(); err != nil {
+		t.Fatalf("Validate matching payload manifest: %v", err)
+	}
+}
+
 func validSnapshotManifestV1() SnapshotManifestV1 {
 	return SnapshotManifestV1{
 		Format:            SnapshotManifestFormatV1,
@@ -210,4 +235,28 @@ func validSnapshotManifestV1() SnapshotManifestV1 {
 		},
 		CreatedAt: time.Unix(1700000000, 123).UTC(),
 	}
+}
+
+func validRaftSnapshotArchivePayloadV1(t *testing.T, manifest SnapshotManifestV1) []byte {
+	t.Helper()
+	headerBytes, err := EncodeRaftSnapshotArchiveHeaderV1(NewRaftSnapshotArchiveHeaderV1(manifest))
+	if err != nil {
+		t.Fatalf("EncodeRaftSnapshotArchiveHeaderV1: %v", err)
+	}
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	if err := tw.WriteHeader(&tar.Header{
+		Name: RaftSnapshotArchiveManifestPathV1,
+		Mode: 0o600,
+		Size: int64(len(headerBytes)),
+	}); err != nil {
+		t.Fatalf("WriteHeader manifest: %v", err)
+	}
+	if _, err := tw.Write(headerBytes); err != nil {
+		t.Fatalf("Write manifest: %v", err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("Close archive: %v", err)
+	}
+	return buf.Bytes()
 }

--- a/TreeDB/internal/raftcluster/snapshot_manifest_test.go
+++ b/TreeDB/internal/raftcluster/snapshot_manifest_test.go
@@ -218,6 +218,29 @@ func TestRaftSnapshotV1ValidateAcceptsMatchingPayloadManifest(t *testing.T) {
 	}
 }
 
+func TestDecodeSnapshotManifestV1FromArchiveReaderRejectsOversizedHeader(t *testing.T) {
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	headerSize := int64(RaftSnapshotArchiveHeaderMaxBytes + 1)
+	if err := tw.WriteHeader(&tar.Header{
+		Name: RaftSnapshotArchiveManifestPathV1,
+		Mode: 0o600,
+		Size: headerSize,
+	}); err != nil {
+		t.Fatalf("WriteHeader oversized manifest: %v", err)
+	}
+	if _, err := tw.Write(bytes.Repeat([]byte("x"), int(headerSize))); err != nil {
+		t.Fatalf("Write oversized manifest: %v", err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("Close archive: %v", err)
+	}
+
+	if _, err := DecodeSnapshotManifestV1FromArchiveReader(bytes.NewReader(buf.Bytes())); !errors.Is(err, ErrInvalidSnapshotManifest) {
+		t.Fatalf("DecodeSnapshotManifestV1FromArchiveReader err=%v want ErrInvalidSnapshotManifest", err)
+	}
+}
+
 func validSnapshotManifestV1() SnapshotManifestV1 {
 	return SnapshotManifestV1{
 		Format:            SnapshotManifestFormatV1,

--- a/TreeDB/internal/raftcluster/snapshot_manifest_test.go
+++ b/TreeDB/internal/raftcluster/snapshot_manifest_test.go
@@ -218,6 +218,18 @@ func TestRaftSnapshotV1ValidateAcceptsMatchingPayloadManifest(t *testing.T) {
 	}
 }
 
+func TestRaftSnapshotV1ValidateAcceptsMatchingPayloadManifestWithMonotonicCreatedAt(t *testing.T) {
+	manifest := validSnapshotManifestV1()
+	manifest.CreatedAt = time.Now()
+	snapshot := RaftSnapshotV1{
+		Manifest: manifest,
+		Payload:  validRaftSnapshotArchivePayloadV1(t, manifest),
+	}
+	if err := snapshot.Validate(); err != nil {
+		t.Fatalf("Validate matching payload manifest with monotonic CreatedAt: %v", err)
+	}
+}
+
 func TestDecodeSnapshotManifestV1FromArchiveReaderRejectsOversizedHeader(t *testing.T) {
 	var buf bytes.Buffer
 	tw := tar.NewWriter(&buf)

--- a/TreeDB/internal/raftfsm/cluster_adapter.go
+++ b/TreeDB/internal/raftfsm/cluster_adapter.go
@@ -23,6 +23,8 @@ func (f *FSM) PreflightCommandEntryV1(ctx context.Context, req raftcluster.Comma
 	if f == nil {
 		return raftcluster.CommandEntryPreflightResultV1{}, codedError(raftentry.ErrorUnsafeDurabilityModeV1, "FSM is not open")
 	}
+	f.mu.RLock()
+	defer f.mu.RUnlock()
 	if f.closed {
 		return raftcluster.CommandEntryPreflightResultV1{}, codedError(raftentry.ErrorUnsafeDurabilityModeV1, "FSM is closed")
 	}

--- a/TreeDB/internal/raftfsm/fsm.go
+++ b/TreeDB/internal/raftfsm/fsm.go
@@ -44,6 +44,11 @@ type Options struct {
 	DecodeLimits nativewire.Limits
 	StoreOptions raftapply.DurableApplyStoreOptions
 
+	// SnapshotRestoreDBOptions is used when InstallRaftSnapshotV1 has to
+	// discard the current local DB handle and reopen the restored snapshot.
+	// Dir is always replaced with Cluster.Dir.
+	SnapshotRestoreDBOptions backenddb.Options
+
 	ScopeRule     raftentry.ScopeRuleV1
 	DatabaseScope string
 	CatalogScope  string
@@ -56,6 +61,7 @@ type FSM struct {
 
 	decodeLimits nativewire.Limits
 	storeOptions raftapply.DurableApplyStoreOptions
+	restoreDB    backenddb.Options
 	scopeRule    raftentry.ScopeRuleV1
 	database     string
 	catalog      string
@@ -63,6 +69,7 @@ type FSM struct {
 
 	progress *raftapply.DurableApplyProgressStore
 	results  *raftapply.DurableApplyResultStore
+	ownsDB   bool
 	closed   bool
 }
 
@@ -127,6 +134,7 @@ func Open(opts Options) (*FSM, error) {
 		metadataDir:  metadataDir,
 		decodeLimits: opts.DecodeLimits,
 		storeOptions: opts.StoreOptions,
+		restoreDB:    opts.SnapshotRestoreDBOptions,
 		scopeRule:    opts.ScopeRule,
 		database:     opts.DatabaseScope,
 		catalog:      opts.CatalogScope,
@@ -147,6 +155,9 @@ func (f *FSM) Close() error {
 	}
 	if f.results != nil {
 		errs = append(errs, f.results.Close())
+	}
+	if f.ownsDB && f.db != nil {
+		errs = append(errs, f.db.Close())
 	}
 	return errors.Join(errs...)
 }

--- a/TreeDB/internal/raftfsm/fsm.go
+++ b/TreeDB/internal/raftfsm/fsm.go
@@ -72,6 +72,7 @@ type FSM struct {
 
 	progress *raftapply.DurableApplyProgressStore
 	results  *raftapply.DurableApplyResultStore
+	sideDBs  func() error
 	ownsDB   bool
 	closed   bool
 }
@@ -166,6 +167,10 @@ func (f *FSM) Close() error {
 	}
 	if f.ownsDB && f.db != nil {
 		errs = append(errs, f.db.Close())
+	}
+	if f.sideDBs != nil {
+		errs = append(errs, f.sideDBs())
+		f.sideDBs = nil
 	}
 	return errors.Join(errs...)
 }
@@ -293,6 +298,9 @@ func (f *FSM) LogicalDigestV1(opts raftapply.LogicalDigestOptionsV1) (raftapply.
 }
 
 func (f *FSM) logicalDigestV1Locked(opts raftapply.LogicalDigestOptionsV1) (raftapply.LogicalDigestV1, error) {
+	if f != nil && f.closed {
+		return raftapply.LogicalDigestV1{}, codedError(raftentry.ErrorUnsafeDurabilityModeV1, "FSM is closed")
+	}
 	if f == nil || f.db == nil {
 		return raftapply.LogicalDigestV1{}, codedError(raftentry.ErrorUnsafeDurabilityModeV1, "nil FSM DB")
 	}

--- a/TreeDB/internal/raftfsm/fsm.go
+++ b/TreeDB/internal/raftfsm/fsm.go
@@ -47,7 +47,7 @@ type Options struct {
 
 	// SnapshotRestoreDBOptions is used when InstallRaftSnapshotV1 has to
 	// discard the current local DB handle and reopen the restored snapshot.
-	// Dir is always replaced with Cluster.Dir.
+	// Dir is always replaced with Cluster.Dir's resolved main DB directory.
 	SnapshotRestoreDBOptions backenddb.Options
 
 	ScopeRule     raftentry.ScopeRuleV1

--- a/TreeDB/internal/raftfsm/fsm.go
+++ b/TreeDB/internal/raftfsm/fsm.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"sync"
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
 	"github.com/snissn/gomap/TreeDB/internal/nativewire"
@@ -56,6 +57,8 @@ type Options struct {
 
 // FSM applies committed deterministic entries to one local DB.
 type FSM struct {
+	mu sync.RWMutex
+
 	db          *backenddb.DB
 	metadataDir string
 
@@ -145,7 +148,12 @@ func Open(opts Options) (*FSM, error) {
 }
 
 func (f *FSM) Close() error {
-	if f == nil || f.closed {
+	if f == nil {
+		return nil
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.closed {
 		return nil
 	}
 	f.closed = true
@@ -167,6 +175,11 @@ func (f *FSM) AllowsInitialIndexGapV1() bool {
 }
 
 func (f *FSM) LastApplied() (raftentry.ApplyEntryID, bool) {
+	if f == nil {
+		return raftentry.ApplyEntryID{}, false
+	}
+	f.mu.RLock()
+	defer f.mu.RUnlock()
 	if f == nil || f.progress == nil {
 		return raftentry.ApplyEntryID{}, false
 	}
@@ -181,6 +194,8 @@ func (f *FSM) ValidateAppliedPrefixV1(entries []CommittedEntryV1) (raftentry.App
 	if f == nil {
 		return reject(raftentry.CommandDigestV1{}, raftentry.ErrorUnsafeDurabilityModeV1, fmt.Errorf("FSM is not open"))
 	}
+	f.mu.RLock()
+	defer f.mu.RUnlock()
 	if f.closed {
 		return reject(raftentry.CommandDigestV1{}, raftentry.ErrorUnsafeDurabilityModeV1, fmt.Errorf("FSM is closed"))
 	}
@@ -269,6 +284,15 @@ func (f *FSM) ValidateAppliedPrefixV1(entries []CommittedEntryV1) (raftentry.App
 }
 
 func (f *FSM) LogicalDigestV1(opts raftapply.LogicalDigestOptionsV1) (raftapply.LogicalDigestV1, error) {
+	if f == nil {
+		return raftapply.LogicalDigestV1{}, codedError(raftentry.ErrorUnsafeDurabilityModeV1, "nil FSM DB")
+	}
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	return f.logicalDigestV1Locked(opts)
+}
+
+func (f *FSM) logicalDigestV1Locked(opts raftapply.LogicalDigestOptionsV1) (raftapply.LogicalDigestV1, error) {
 	if f == nil || f.db == nil {
 		return raftapply.LogicalDigestV1{}, codedError(raftentry.ErrorUnsafeDurabilityModeV1, "nil FSM DB")
 	}
@@ -293,6 +317,8 @@ func (f *FSM) ApplyCommittedEntryV1(entry CommittedEntryV1) (raftentry.ApplyResu
 	if f == nil {
 		return reject(raftentry.CommandDigestV1{}, raftentry.ErrorUnsafeDurabilityModeV1, fmt.Errorf("FSM is not open"))
 	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	if f.closed {
 		return reject(raftentry.CommandDigestV1{}, raftentry.ErrorUnsafeDurabilityModeV1, fmt.Errorf("FSM is closed"))
 	}

--- a/TreeDB/internal/raftfsm/fsm_test.go
+++ b/TreeDB/internal/raftfsm/fsm_test.go
@@ -86,6 +86,24 @@ func TestSingleGroupApplyLoopCloseReopenDurableProgressResult(t *testing.T) {
 	assertLastApplied(t, reopenedFSM, raftentry.ApplyEntryID{Term: 2, Index: 2})
 }
 
+func TestSingleGroupFSMLogicalDigestRejectsClosedFSM(t *testing.T) {
+	root := t.TempDir()
+	dbDir := filepath.Join(root, "db")
+
+	db := openFSMTestDB(t, dbDir)
+	defer func() { _ = db.Close() }()
+	fsm := openFSMForTest(t, db, dbDir)
+	if err := fsm.Close(); err != nil {
+		t.Fatalf("Close FSM: %v", err)
+	}
+
+	if _, err := fsm.LogicalDigestV1(raftapply.LogicalDigestOptionsV1{}); err == nil {
+		t.Fatal("LogicalDigestV1 on closed FSM succeeded, want unsafe durability error")
+	} else if code, ok := ErrorCodeOf(err); !ok || code != raftentry.ErrorUnsafeDurabilityModeV1 {
+		t.Fatalf("ErrorCodeOf(LogicalDigestV1 closed)=(%s,%t), want %s err=%v", code, ok, raftentry.ErrorUnsafeDurabilityModeV1, err)
+	}
+}
+
 func TestSingleGroupApplyLoopRejectsProgressAheadOfLocalCoverage(t *testing.T) {
 	root := t.TempDir()
 	dbDir := filepath.Join(root, "db")

--- a/TreeDB/internal/raftfsm/fsm_test.go
+++ b/TreeDB/internal/raftfsm/fsm_test.go
@@ -899,7 +899,7 @@ func committedCommand(term, index uint64, raw []byte) CommittedEntryV1 {
 	}
 }
 
-func deterministicCreateCollectionEntry(t *testing.T, collection, idempotency string) []byte {
+func deterministicCreateCollectionEntry(t testing.TB, collection, idempotency string) []byte {
 	t.Helper()
 	return deterministicCreateCollectionEntryWithOptions(t, collection, idempotency, testCreateCollectionMetaOptions{})
 }
@@ -908,7 +908,7 @@ type testCreateCollectionMetaOptions struct {
 	documentFormat uint64
 }
 
-func deterministicCreateCollectionEntryWithOptions(t *testing.T, collection, idempotency string, opts testCreateCollectionMetaOptions) []byte {
+func deterministicCreateCollectionEntryWithOptions(t testing.TB, collection, idempotency string, opts testCreateCollectionMetaOptions) []byte {
 	t.Helper()
 	sections := []nativewire.Section{
 		{ID: nativewire.SectionCommandHeader, Bytes: nativewire.AppendCommandHeader(nil, nativewire.CommandHeader{ID: nativewire.CommandCreateCollection, Version: 1})},
@@ -946,18 +946,18 @@ func testCreateCollectionMetaPayload(collection string, opts testCreateCollectio
 	return dst
 }
 
-func deterministicInsertBatchEntry(t *testing.T, collection, idempotency string, format nativewire.DocumentFormat, ids, documents [][]byte) []byte {
+func deterministicInsertBatchEntry(t testing.TB, collection, idempotency string, format nativewire.DocumentFormat, ids, documents [][]byte) []byte {
 	t.Helper()
 	return deterministicMutationEntry(t, nativewire.CommandInsertBatch, collection, idempotency, format, ids, documents, nil)
 }
 
-func deterministicReplaceBatchEntry(t *testing.T, collection, idempotency string, format nativewire.DocumentFormat, ids, documents [][]byte) []byte {
+func deterministicReplaceBatchEntry(t testing.TB, collection, idempotency string, format nativewire.DocumentFormat, ids, documents [][]byte) []byte {
 	t.Helper()
 	extra := []nativewire.Section{{ID: nativewire.SectionReplacementMode, Bytes: binary.AppendUvarint(nil, 1)}}
 	return deterministicMutationEntry(t, nativewire.CommandReplaceBatch, collection, idempotency, format, ids, documents, extra)
 }
 
-func deterministicDeleteBatchEntry(t *testing.T, collection, idempotency string, ids [][]byte) []byte {
+func deterministicDeleteBatchEntry(t testing.TB, collection, idempotency string, ids [][]byte) []byte {
 	t.Helper()
 	sections := []nativewire.Section{
 		{ID: nativewire.SectionCommandHeader, Bytes: nativewire.AppendCommandHeader(nil, nativewire.CommandHeader{ID: nativewire.CommandDeleteBatch, Version: 1})},
@@ -977,7 +977,7 @@ func deterministicDeleteBatchEntry(t *testing.T, collection, idempotency string,
 	return entry
 }
 
-func deterministicMutationEntry(t *testing.T, command nativewire.CommandID, collection, idempotency string, format nativewire.DocumentFormat, ids, documents [][]byte, extra []nativewire.Section) []byte {
+func deterministicMutationEntry(t testing.TB, command nativewire.CommandID, collection, idempotency string, format nativewire.DocumentFormat, ids, documents [][]byte, extra []nativewire.Section) []byte {
 	t.Helper()
 	sections := []nativewire.Section{
 		{ID: nativewire.SectionCommandHeader, Bytes: nativewire.AppendCommandHeader(nil, nativewire.CommandHeader{ID: command, Version: 1})},

--- a/TreeDB/internal/raftfsm/raft_snapshot.go
+++ b/TreeDB/internal/raftfsm/raft_snapshot.go
@@ -22,10 +22,13 @@ const (
 	raftSnapshotDBPrefixV1    = "db"
 	raftSnapshotSidePrefixV1  = "side"
 	raftSnapshotApplyPrefixV1 = "apply"
+
+	raftSnapshotFormatConfigFileV1 = "format.json"
 )
 
 var raftSnapshotMainDBEntriesV1 = []string{
 	"index.db",
+	raftSnapshotFormatConfigFileV1,
 	"wal",
 	"value_vlog",
 	"leaf_vlog",
@@ -142,6 +145,9 @@ func (f *FSM) InstallRaftSnapshotV1(reader io.Reader) error {
 	}
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	if err := f.requireRaftSnapshotOpenV1(); err != nil {
+		return err
+	}
 	if err := header.Validate(f.snapshotScopeIdentityV1()); err != nil {
 		return codedError(raftentry.ErrorRejectedConflictV1, "snapshot archive is not valid for FSM scope: %v", err)
 	}

--- a/TreeDB/internal/raftfsm/raft_snapshot.go
+++ b/TreeDB/internal/raftfsm/raft_snapshot.go
@@ -360,7 +360,7 @@ func appendRaftSnapshotDirV1(tw *tar.Writer, prefix, root string) error {
 			_ = file.Close()
 			return err
 		}
-		_, copyErr := io.Copy(tw, file)
+		copyErr := copyRaftSnapshotFileContentV1(tw, file, header.Size)
 		closeErr := file.Close()
 		return errors.Join(copyErr, closeErr)
 	})
@@ -427,9 +427,20 @@ func appendRaftSnapshotStoragePathV1(tw *tar.Writer, archiveName, src string) er
 		_ = file.Close()
 		return err
 	}
-	_, copyErr := io.Copy(tw, file)
+	copyErr := copyRaftSnapshotFileContentV1(tw, file, info.Size())
 	closeErr := file.Close()
 	return errors.Join(copyErr, closeErr)
+}
+
+func copyRaftSnapshotFileContentV1(dst io.Writer, src io.Reader, size int64) error {
+	if size < 0 {
+		return fmt.Errorf("raftfsm: negative snapshot file size %d", size)
+	}
+	copied, err := io.CopyN(dst, src, size)
+	if errors.Is(err, io.EOF) {
+		return fmt.Errorf("raftfsm: snapshot file changed while exporting: copied %d of %d bytes", copied, size)
+	}
+	return err
 }
 
 func writeRaftSnapshotDirHeaderV1(tw *tar.Writer, name string) error {

--- a/TreeDB/internal/raftfsm/raft_snapshot.go
+++ b/TreeDB/internal/raftfsm/raft_snapshot.go
@@ -1,0 +1,496 @@
+package raftfsm
+
+import (
+	"archive/tar"
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	pathpkg "path"
+	"path/filepath"
+	"strings"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+	"github.com/snissn/gomap/TreeDB/internal/raftapply"
+	"github.com/snissn/gomap/TreeDB/internal/raftcluster"
+	"github.com/snissn/gomap/TreeDB/internal/raftentry"
+)
+
+const (
+	raftSnapshotDBPrefixV1    = "db"
+	raftSnapshotApplyPrefixV1 = "apply"
+)
+
+var raftSnapshotMainDBEntriesV1 = []string{
+	"index.db",
+	"wal",
+	"value_vlog",
+	"leaf_vlog",
+	"column_assets",
+}
+
+// ExportRaftSnapshotV1 exports a production snapshot archive for HashiCorp
+// Raft. The archive contains TreeDB main storage, including persistent
+// value-log segments, plus durable Raft apply metadata. It intentionally
+// excludes HashiCorp Raft log/stable/snapshot directories.
+func (f *FSM) ExportRaftSnapshotV1() (raftcluster.RaftSnapshotV1, error) {
+	if err := f.requireRaftSnapshotOpenV1(); err != nil {
+		return raftcluster.RaftSnapshotV1{}, err
+	}
+	if err := f.db.Checkpoint(); err != nil {
+		return raftcluster.RaftSnapshotV1{}, codedError(raftentry.ErrorUnsafeDurabilityModeV1, "checkpoint before snapshot export: %v", err)
+	}
+	manifest, err := f.ExportSnapshotManifestV1(SnapshotManifestExportOptionsV1{})
+	if err != nil {
+		return raftcluster.RaftSnapshotV1{}, err
+	}
+	header := raftcluster.NewRaftSnapshotArchiveHeaderV1(manifest)
+	headerBytes, err := raftcluster.EncodeRaftSnapshotArchiveHeaderV1(header)
+	if err != nil {
+		return raftcluster.RaftSnapshotV1{}, err
+	}
+
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	if err := writeRaftSnapshotFileV1(tw, raftcluster.RaftSnapshotArchiveManifestPathV1, headerBytes, 0o600); err != nil {
+		return raftcluster.RaftSnapshotV1{}, err
+	}
+	if err := appendRaftSnapshotTreeDBStorageV1(tw, raftSnapshotDBPrefixV1, raftcluster.MainDBDir(f.cluster.Dir)); err != nil {
+		return raftcluster.RaftSnapshotV1{}, err
+	}
+	if err := appendRaftSnapshotDirV1(tw, raftSnapshotApplyPrefixV1, f.cluster.Layout.ApplyDir); err != nil {
+		return raftcluster.RaftSnapshotV1{}, err
+	}
+	if err := tw.Close(); err != nil {
+		return raftcluster.RaftSnapshotV1{}, fmt.Errorf("raftfsm: close snapshot archive: %w", err)
+	}
+	snapshot := raftcluster.RaftSnapshotV1{
+		Manifest: manifest,
+		Payload:  bytes.Clone(buf.Bytes()),
+	}
+	if err := snapshot.Validate(); err != nil {
+		return raftcluster.RaftSnapshotV1{}, err
+	}
+	return snapshot, nil
+}
+
+// InstallRaftSnapshotV1 discards the local TreeDB state and installs a
+// production snapshot archive. HashiCorp Raft calls Restore without concurrent
+// Apply calls, so the FSM can safely close and reopen its local stores here.
+func (f *FSM) InstallRaftSnapshotV1(reader io.Reader) error {
+	if err := f.requireRaftSnapshotOpenV1(); err != nil {
+		return err
+	}
+	if reader == nil {
+		return codedError(raftentry.ErrorUnsafeDurabilityModeV1, "nil snapshot reader")
+	}
+	mainDir := raftcluster.MainDBDir(f.cluster.Dir)
+	applyDir := f.cluster.Layout.ApplyDir
+	if mainDir == "" || applyDir == "" {
+		return codedError(raftentry.ErrorUnsafeDurabilityModeV1, "missing snapshot install directories")
+	}
+
+	tmpMain, err := os.MkdirTemp(filepath.Dir(mainDir), ".raft-snapshot-main-*")
+	if err != nil {
+		return err
+	}
+	tmpApply, err := os.MkdirTemp(filepath.Dir(applyDir), ".raft-snapshot-apply-*")
+	if err != nil {
+		_ = os.RemoveAll(tmpMain)
+		return err
+	}
+	cleanupMain := true
+	cleanupApply := true
+	defer func() {
+		if cleanupMain {
+			_ = os.RemoveAll(tmpMain)
+		}
+		if cleanupApply {
+			_ = os.RemoveAll(tmpApply)
+		}
+	}()
+
+	header, err := extractRaftSnapshotArchiveV1(reader, tmpMain, tmpApply)
+	if err != nil {
+		return err
+	}
+	if err := header.Validate(f.snapshotScopeIdentityV1()); err != nil {
+		return codedError(raftentry.ErrorRejectedConflictV1, "snapshot archive is not valid for FSM scope: %v", err)
+	}
+	if header.Manifest.GroupID != f.cluster.GroupID {
+		return codedError(raftentry.ErrorRejectedConflictV1, "snapshot archive group %q does not match FSM group %q", header.Manifest.GroupID, f.cluster.GroupID)
+	}
+	if err := f.closeForRaftSnapshotRestoreV1(); err != nil {
+		return err
+	}
+	if err := replaceSnapshotMainDBV1(mainDir, tmpMain); err != nil {
+		return err
+	}
+	if err := replaceSnapshotDirV1(applyDir, tmpApply); err != nil {
+		return err
+	}
+	cleanupApply = false
+	if err := f.reopenAfterRaftSnapshotRestoreV1(); err != nil {
+		return err
+	}
+	return f.VerifyInstalledSnapshotManifestV1(header.Manifest)
+}
+
+func (f *FSM) requireRaftSnapshotOpenV1() error {
+	if f == nil {
+		return codedError(raftentry.ErrorUnsafeDurabilityModeV1, "FSM is not open")
+	}
+	if f.closed {
+		return codedError(raftentry.ErrorUnsafeDurabilityModeV1, "FSM is closed")
+	}
+	if f.db == nil || f.progress == nil || f.results == nil {
+		return codedError(raftentry.ErrorUnsafeDurabilityModeV1, "FSM is not open")
+	}
+	return nil
+}
+
+func (f *FSM) closeForRaftSnapshotRestoreV1() error {
+	var errs []error
+	if f.progress != nil {
+		errs = append(errs, f.progress.Close())
+		f.progress = nil
+	}
+	if f.results != nil {
+		errs = append(errs, f.results.Close())
+		f.results = nil
+	}
+	if f.db != nil {
+		errs = append(errs, f.db.Close())
+		f.db = nil
+	}
+	f.ownsDB = false
+	return errors.Join(errs...)
+}
+
+func (f *FSM) reopenAfterRaftSnapshotRestoreV1() error {
+	opts := f.restoreDB
+	opts.Dir = f.cluster.Dir
+	opts.CommandWAL = true
+	opts.CommandWALStatsScan = true
+	if opts.CommandWALSegmentTargetBytes <= 0 {
+		opts.CommandWALSegmentTargetBytes = 1 << 20
+	}
+	opts.DisableBackgroundPrune = true
+	db, err := backenddb.Open(opts)
+	if err != nil {
+		return err
+	}
+	progress, err := raftapply.OpenDurableApplyProgressStore(f.metadataDir, f.storeOptions)
+	if err != nil {
+		_ = db.Close()
+		return err
+	}
+	results, err := raftapply.OpenDurableApplyResultStore(f.metadataDir, f.storeOptions)
+	if err != nil {
+		_ = errors.Join(progress.Close(), db.Close())
+		return err
+	}
+	if err := validateProgressCoverage(db, progress, results); err != nil {
+		_ = errors.Join(progress.Close(), results.Close(), db.Close())
+		return err
+	}
+	f.db = db
+	f.progress = progress
+	f.results = results
+	f.ownsDB = true
+	return nil
+}
+
+func appendRaftSnapshotDirV1(tw *tar.Writer, prefix, root string) error {
+	if tw == nil {
+		return fmt.Errorf("raftfsm: nil snapshot archive writer")
+	}
+	root = filepath.Clean(root)
+	info, err := os.Stat(root)
+	if err != nil {
+		return fmt.Errorf("raftfsm: stat snapshot directory %q: %w", root, err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("raftfsm: snapshot path %q is not a directory", root)
+	}
+	return filepath.WalkDir(root, func(filePath string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		rel, err := filepath.Rel(root, filePath)
+		if err != nil {
+			return err
+		}
+		if rel == "." {
+			return writeRaftSnapshotDirHeaderV1(tw, prefix)
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		if info.Mode()&fs.ModeSymlink != 0 {
+			return fmt.Errorf("raftfsm: snapshot path %q is a symlink", filePath)
+		}
+		name := pathpkg.Join(prefix, filepath.ToSlash(rel))
+		if entry.IsDir() {
+			return writeRaftSnapshotDirHeaderV1(tw, name)
+		}
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("raftfsm: snapshot path %q is not a regular file", filePath)
+		}
+		file, err := os.Open(filePath)
+		if err != nil {
+			return err
+		}
+		header := &tar.Header{
+			Name:    name,
+			Mode:    int64(info.Mode().Perm()),
+			Size:    info.Size(),
+			ModTime: info.ModTime(),
+		}
+		if err := tw.WriteHeader(header); err != nil {
+			_ = file.Close()
+			return err
+		}
+		_, copyErr := io.Copy(tw, file)
+		closeErr := file.Close()
+		return errors.Join(copyErr, closeErr)
+	})
+}
+
+func appendRaftSnapshotTreeDBStorageV1(tw *tar.Writer, prefix, mainDir string) error {
+	if err := writeRaftSnapshotDirHeaderV1(tw, prefix); err != nil {
+		return err
+	}
+	for _, name := range raftSnapshotMainDBEntriesV1 {
+		src := filepath.Join(mainDir, name)
+		if err := appendRaftSnapshotStoragePathV1(tw, pathpkg.Join(prefix, name), src); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func appendRaftSnapshotStoragePathV1(tw *tar.Writer, archiveName, src string) error {
+	info, err := os.Stat(src)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	if info.IsDir() {
+		return appendRaftSnapshotDirV1(tw, archiveName, src)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("raftfsm: snapshot path %q is not a regular file", src)
+	}
+	file, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	if err := tw.WriteHeader(&tar.Header{
+		Name:    pathpkg.Clean(archiveName),
+		Mode:    int64(info.Mode().Perm()),
+		Size:    info.Size(),
+		ModTime: info.ModTime(),
+	}); err != nil {
+		_ = file.Close()
+		return err
+	}
+	_, copyErr := io.Copy(tw, file)
+	closeErr := file.Close()
+	return errors.Join(copyErr, closeErr)
+}
+
+func writeRaftSnapshotDirHeaderV1(tw *tar.Writer, name string) error {
+	return tw.WriteHeader(&tar.Header{
+		Name:     pathpkg.Clean(name),
+		Typeflag: tar.TypeDir,
+		Mode:     0o700,
+	})
+}
+
+func writeRaftSnapshotFileV1(tw *tar.Writer, name string, payload []byte, mode int64) error {
+	if err := tw.WriteHeader(&tar.Header{
+		Name: pathpkg.Clean(name),
+		Mode: mode,
+		Size: int64(len(payload)),
+	}); err != nil {
+		return err
+	}
+	_, err := tw.Write(payload)
+	return err
+}
+
+func extractRaftSnapshotArchiveV1(reader io.Reader, mainDir, applyDir string) (raftcluster.RaftSnapshotArchiveHeaderV1, error) {
+	tr := tar.NewReader(reader)
+	var (
+		header       raftcluster.RaftSnapshotArchiveHeaderV1
+		sawHeader    bool
+		sawDBFile    bool
+		sawApplyFile bool
+	)
+	for {
+		tarHeader, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return raftcluster.RaftSnapshotArchiveHeaderV1{}, fmt.Errorf("raftfsm: read snapshot archive: %w", err)
+		}
+		if tarHeader == nil {
+			continue
+		}
+		name := cleanSnapshotArchiveNameV1(tarHeader.Name)
+		if name == raftcluster.RaftSnapshotArchiveManifestPathV1 {
+			if tarHeader.Typeflag != tar.TypeReg && tarHeader.Typeflag != tar.TypeRegA {
+				return raftcluster.RaftSnapshotArchiveHeaderV1{}, fmt.Errorf("raftfsm: snapshot archive header is not a regular file")
+			}
+			raw, err := io.ReadAll(tr)
+			if err != nil {
+				return raftcluster.RaftSnapshotArchiveHeaderV1{}, err
+			}
+			decoded, err := raftcluster.DecodeRaftSnapshotArchiveHeaderV1(raw, raftcluster.SnapshotScopeIdentityV1{})
+			if err != nil {
+				return raftcluster.RaftSnapshotArchiveHeaderV1{}, err
+			}
+			header = decoded
+			sawHeader = true
+			continue
+		}
+		if rel, ok, err := snapshotArchiveRelV1(name, raftSnapshotDBPrefixV1); err != nil {
+			return raftcluster.RaftSnapshotArchiveHeaderV1{}, err
+		} else if ok {
+			file, err := extractRaftSnapshotEntryV1(tr, tarHeader, mainDir, rel)
+			if err != nil {
+				return raftcluster.RaftSnapshotArchiveHeaderV1{}, err
+			}
+			sawDBFile = sawDBFile || file
+			continue
+		}
+		if rel, ok, err := snapshotArchiveRelV1(name, raftSnapshotApplyPrefixV1); err != nil {
+			return raftcluster.RaftSnapshotArchiveHeaderV1{}, err
+		} else if ok {
+			file, err := extractRaftSnapshotEntryV1(tr, tarHeader, applyDir, rel)
+			if err != nil {
+				return raftcluster.RaftSnapshotArchiveHeaderV1{}, err
+			}
+			sawApplyFile = sawApplyFile || file
+			continue
+		}
+		return raftcluster.RaftSnapshotArchiveHeaderV1{}, fmt.Errorf("raftfsm: unsupported snapshot archive path %q", tarHeader.Name)
+	}
+	if !sawHeader {
+		return raftcluster.RaftSnapshotArchiveHeaderV1{}, fmt.Errorf("raftfsm: missing snapshot archive header")
+	}
+	if !sawDBFile {
+		return raftcluster.RaftSnapshotArchiveHeaderV1{}, fmt.Errorf("raftfsm: snapshot archive has no TreeDB files")
+	}
+	if !sawApplyFile {
+		return raftcluster.RaftSnapshotArchiveHeaderV1{}, fmt.Errorf("raftfsm: snapshot archive has no Raft apply metadata files")
+	}
+	return header, nil
+}
+
+func cleanSnapshotArchiveNameV1(name string) string {
+	name = strings.TrimSpace(strings.ReplaceAll(name, "\\", "/"))
+	name = strings.TrimPrefix(name, "/")
+	return pathpkg.Clean(name)
+}
+
+func snapshotArchiveRelV1(name, prefix string) (string, bool, error) {
+	if name == prefix {
+		return "", true, nil
+	}
+	prefixSlash := prefix + "/"
+	if !strings.HasPrefix(name, prefixSlash) {
+		return "", false, nil
+	}
+	rel := strings.TrimPrefix(name, prefixSlash)
+	if rel == "" || rel == "." || strings.HasPrefix(rel, "../") || strings.Contains(rel, "/../") {
+		return "", false, fmt.Errorf("raftfsm: unsafe snapshot archive path %q", name)
+	}
+	return filepath.FromSlash(rel), true, nil
+}
+
+func extractRaftSnapshotEntryV1(tr *tar.Reader, header *tar.Header, root, rel string) (bool, error) {
+	if rel == "" {
+		if header.Typeflag == tar.TypeDir {
+			return false, nil
+		}
+		return false, fmt.Errorf("raftfsm: snapshot archive root entry %q is not a directory", header.Name)
+	}
+	dest := filepath.Join(root, rel)
+	if !sameOrUnderSnapshotDirV1(root, dest) {
+		return false, fmt.Errorf("raftfsm: unsafe snapshot archive destination %q", dest)
+	}
+	switch header.Typeflag {
+	case tar.TypeDir:
+		return false, os.MkdirAll(dest, 0o700)
+	case tar.TypeReg, tar.TypeRegA:
+		if err := os.MkdirAll(filepath.Dir(dest), 0o700); err != nil {
+			return false, err
+		}
+		file, err := os.OpenFile(dest, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+		if err != nil {
+			return false, err
+		}
+		_, copyErr := io.Copy(file, tr)
+		closeErr := file.Close()
+		return true, errors.Join(copyErr, closeErr)
+	default:
+		return false, fmt.Errorf("raftfsm: unsupported snapshot archive entry type %d for %q", header.Typeflag, header.Name)
+	}
+}
+
+func sameOrUnderSnapshotDirV1(parent, child string) bool {
+	parent = filepath.Clean(parent)
+	child = filepath.Clean(child)
+	if parent == child {
+		return true
+	}
+	rel, err := filepath.Rel(parent, child)
+	return err == nil && rel != "." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator)) && rel != ".."
+}
+
+func replaceSnapshotDirV1(dest, src string) error {
+	if dest == "" || src == "" {
+		return fmt.Errorf("raftfsm: empty snapshot restore path")
+	}
+	if err := os.MkdirAll(filepath.Dir(dest), 0o700); err != nil {
+		return err
+	}
+	if err := os.RemoveAll(dest); err != nil {
+		return err
+	}
+	return os.Rename(src, dest)
+}
+
+func replaceSnapshotMainDBV1(destMain, srcMain string) error {
+	if destMain == "" || srcMain == "" {
+		return fmt.Errorf("raftfsm: empty snapshot restore DB path")
+	}
+	if err := os.MkdirAll(destMain, 0o700); err != nil {
+		return err
+	}
+	for _, name := range raftSnapshotMainDBEntriesV1 {
+		src := filepath.Join(srcMain, name)
+		dest := filepath.Join(destMain, name)
+		if err := os.RemoveAll(dest); err != nil {
+			return err
+		}
+		if _, err := os.Stat(src); err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return err
+		}
+		if err := os.Rename(src, dest); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/TreeDB/internal/raftfsm/raft_snapshot.go
+++ b/TreeDB/internal/raftfsm/raft_snapshot.go
@@ -321,9 +321,12 @@ func appendRaftSnapshotDirV1(tw *tar.Writer, prefix, root string) error {
 		return fmt.Errorf("raftfsm: nil snapshot archive writer")
 	}
 	root = filepath.Clean(root)
-	info, err := os.Stat(root)
+	info, err := os.Lstat(root)
 	if err != nil {
 		return fmt.Errorf("raftfsm: stat snapshot directory %q: %w", root, err)
+	}
+	if info.Mode()&fs.ModeSymlink != 0 {
+		return fmt.Errorf("raftfsm: snapshot path %q is a symlink", root)
 	}
 	if !info.IsDir() {
 		return fmt.Errorf("raftfsm: snapshot path %q is not a directory", root)

--- a/TreeDB/internal/raftfsm/raft_snapshot.go
+++ b/TreeDB/internal/raftfsm/raft_snapshot.go
@@ -56,6 +56,9 @@ func (f *FSM) ExportRaftSnapshotV1() (raftcluster.RaftSnapshotV1, error) {
 	if err := f.db.Checkpoint(); err != nil {
 		return raftcluster.RaftSnapshotV1{}, codedError(raftentry.ErrorUnsafeDurabilityModeV1, "checkpoint before snapshot export: %v", err)
 	}
+	if err := f.syncDurableApplyMetadataForRaftSnapshotV1(); err != nil {
+		return raftcluster.RaftSnapshotV1{}, err
+	}
 	manifest, err := f.exportSnapshotManifestV1Locked(SnapshotManifestExportOptionsV1{})
 	if err != nil {
 		return raftcluster.RaftSnapshotV1{}, err
@@ -193,6 +196,13 @@ func (f *FSM) requireRaftSnapshotOpenV1() error {
 		return codedError(raftentry.ErrorUnsafeDurabilityModeV1, "FSM is not open")
 	}
 	return nil
+}
+
+func (f *FSM) syncDurableApplyMetadataForRaftSnapshotV1() error {
+	if f == nil || f.progress == nil || f.results == nil {
+		return codedError(raftentry.ErrorUnsafeDurabilityModeV1, "FSM has no durable apply metadata")
+	}
+	return errors.Join(f.progress.Sync(), f.results.Sync())
 }
 
 func (f *FSM) closeForRaftSnapshotRestoreV1() error {
@@ -484,6 +494,9 @@ func extractRaftSnapshotArchiveV1(reader io.Reader, mainDir, sideDir, applyDir s
 		}
 		name := cleanSnapshotArchiveNameV1(tarHeader.Name)
 		if name == raftcluster.RaftSnapshotArchiveManifestPathV1 {
+			if sawHeader {
+				return raftcluster.RaftSnapshotArchiveHeaderV1{}, fmt.Errorf("raftfsm: duplicate snapshot archive header")
+			}
 			if tarHeader.Typeflag != tar.TypeReg && tarHeader.Typeflag != tar.TypeRegA {
 				return raftcluster.RaftSnapshotArchiveHeaderV1{}, fmt.Errorf("raftfsm: snapshot archive header is not a regular file")
 			}

--- a/TreeDB/internal/raftfsm/raft_snapshot.go
+++ b/TreeDB/internal/raftfsm/raft_snapshot.go
@@ -206,7 +206,7 @@ func (f *FSM) closeForRaftSnapshotRestoreV1() error {
 
 func (f *FSM) reopenAfterRaftSnapshotRestoreV1() error {
 	opts := f.restoreDB
-	opts.Dir = f.cluster.Dir
+	opts.Dir = raftcluster.MainDBDir(f.cluster.Dir)
 	opts.CommandWAL = true
 	opts.CommandWALStatsScan = true
 	if opts.CommandWALSegmentTargetBytes <= 0 {

--- a/TreeDB/internal/raftfsm/raft_snapshot.go
+++ b/TreeDB/internal/raftfsm/raft_snapshot.go
@@ -152,10 +152,13 @@ func (f *FSM) InstallRaftSnapshotV1(reader io.Reader) error {
 	if header.Manifest.GroupID != f.cluster.GroupID {
 		return codedError(raftentry.ErrorRejectedConflictV1, "snapshot archive group %q does not match FSM group %q", header.Manifest.GroupID, f.cluster.GroupID)
 	}
+	if err := f.verifyExtractedRaftSnapshotV1(header.Manifest, tmpMain, tmpSide, tmpApply); err != nil {
+		return err
+	}
 	if err := f.closeForRaftSnapshotRestoreV1(); err != nil {
 		return err
 	}
-	if err := replaceSnapshotMainDBV1(mainDir, tmpMain); err != nil {
+	if err := replaceSnapshotMainDBV1(mainDir, tmpMain, f.cluster.Layout.RootDir); err != nil {
 		return err
 	}
 	cleanupMain = false
@@ -246,6 +249,53 @@ func (f *FSM) reopenAfterRaftSnapshotRestoreV1() error {
 	f.sideDBs = sideDBs
 	f.ownsDB = true
 	return nil
+}
+
+func (f *FSM) verifyExtractedRaftSnapshotV1(manifest raftcluster.SnapshotManifestV1, mainDir, sideDir, applyDir string) error {
+	opts := f.restoreDB
+	opts.Dir = mainDir
+	opts.CommandWAL = true
+	opts.CommandWALStatsScan = true
+	if opts.CommandWALSegmentTargetBytes <= 0 {
+		opts.CommandWALSegmentTargetBytes = 1 << 20
+	}
+	opts.DisableBackgroundPrune = true
+	sideDBs, err := wireRaftSnapshotSideStoreLookupsV1(sideDir, &opts)
+	if err != nil {
+		return err
+	}
+	db, err := backenddb.Open(opts)
+	if err != nil {
+		_ = sideDBs()
+		return err
+	}
+	progress, err := raftapply.OpenDurableApplyProgressStore(applyDir, f.storeOptions)
+	if err != nil {
+		_ = errors.Join(db.Close(), sideDBs())
+		return err
+	}
+	results, err := raftapply.OpenDurableApplyResultStore(applyDir, f.storeOptions)
+	if err != nil {
+		_ = errors.Join(progress.Close(), db.Close(), sideDBs())
+		return err
+	}
+	verifyFSM := &FSM{
+		db:           db,
+		progress:     progress,
+		results:      results,
+		cluster:      f.cluster,
+		scopeRule:    f.scopeRule,
+		database:     f.database,
+		catalog:      f.catalog,
+		storeOptions: f.storeOptions,
+		restoreDB:    f.restoreDB,
+	}
+	verifyErr := verifyFSM.verifyInstalledSnapshotManifestV1Locked(manifest)
+	closeErr := errors.Join(progress.Close(), results.Close(), db.Close(), sideDBs())
+	if verifyErr != nil {
+		return verifyErr
+	}
+	return closeErr
 }
 
 func appendRaftSnapshotDirV1(tw *tar.Writer, prefix, root string) error {
@@ -589,17 +639,74 @@ func replaceSnapshotDirV1(dest, src string) error {
 	return os.Rename(src, dest)
 }
 
-func replaceSnapshotMainDBV1(destMain, srcMain string) error {
+func replaceSnapshotMainDBV1(destMain, srcMain, preserveRoot string) error {
 	if destMain == "" || srcMain == "" {
 		return fmt.Errorf("raftfsm: empty snapshot restore DB path")
 	}
 	if err := os.MkdirAll(filepath.Dir(destMain), 0o700); err != nil {
 		return err
 	}
+	if preserveRoot != "" && sameOrUnderSnapshotDirV1(destMain, preserveRoot) {
+		return replaceSnapshotMainDBEntriesV1(destMain, srcMain, preserveRoot)
+	}
 	if err := os.RemoveAll(destMain); err != nil {
 		return err
 	}
 	return os.Rename(srcMain, destMain)
+}
+
+func replaceSnapshotMainDBEntriesV1(destMain, srcMain, preserveRoot string) error {
+	if err := os.MkdirAll(destMain, 0o700); err != nil {
+		return err
+	}
+	defer func() { _ = os.RemoveAll(srcMain) }()
+	preserveName, hasPreserveName := snapshotTopLevelPreserveNameV1(destMain, preserveRoot)
+	entries, err := os.ReadDir(destMain)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return err
+		}
+	} else {
+		for _, entry := range entries {
+			if hasPreserveName && entry.Name() == preserveName {
+				continue
+			}
+			if err := os.RemoveAll(filepath.Join(destMain, entry.Name())); err != nil {
+				return err
+			}
+		}
+	}
+	for _, name := range raftSnapshotMainDBEntriesV1 {
+		src := filepath.Join(srcMain, name)
+		dest := filepath.Join(destMain, name)
+		if err := os.RemoveAll(dest); err != nil {
+			return err
+		}
+		if _, err := os.Stat(src); err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return err
+		}
+		if err := os.Rename(src, dest); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func snapshotTopLevelPreserveNameV1(parent, preserveRoot string) (string, bool) {
+	rel, err := filepath.Rel(filepath.Clean(parent), filepath.Clean(preserveRoot))
+	if err != nil || rel == "." || rel == "" || rel == ".." || filepath.IsAbs(rel) || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		return "", false
+	}
+	if i := strings.IndexRune(rel, os.PathSeparator); i >= 0 {
+		rel = rel[:i]
+	}
+	if rel == "" || rel == "." || rel == ".." {
+		return "", false
+	}
+	return rel, true
 }
 
 func replaceSnapshotSideStoresV1(mainDir, srcSide string) error {

--- a/TreeDB/internal/raftfsm/raft_snapshot.go
+++ b/TreeDB/internal/raftfsm/raft_snapshot.go
@@ -74,8 +74,10 @@ func (f *FSM) ExportRaftSnapshotV1() (raftcluster.RaftSnapshotV1, error) {
 	if err := appendRaftSnapshotTreeDBStorageV1(tw, raftSnapshotDBPrefixV1, raftcluster.MainDBDir(f.cluster.Dir)); err != nil {
 		return raftcluster.RaftSnapshotV1{}, err
 	}
-	if err := appendRaftSnapshotTreeDBSideStoresV1(tw, raftSnapshotSidePrefixV1, raftcluster.MainDBDir(f.cluster.Dir)); err != nil {
-		return raftcluster.RaftSnapshotV1{}, err
+	if !f.cluster.DisableSideStores {
+		if err := appendRaftSnapshotTreeDBSideStoresV1(tw, raftSnapshotSidePrefixV1, raftcluster.MainDBDir(f.cluster.Dir)); err != nil {
+			return raftcluster.RaftSnapshotV1{}, err
+		}
 	}
 	if err := appendRaftSnapshotDirV1(tw, raftSnapshotApplyPrefixV1, f.cluster.Layout.ApplyDir); err != nil {
 		return raftcluster.RaftSnapshotV1{}, err
@@ -96,6 +98,8 @@ func (f *FSM) ExportRaftSnapshotV1() (raftcluster.RaftSnapshotV1, error) {
 // InstallRaftSnapshotV1 discards the local TreeDB state and installs a
 // production snapshot archive. HashiCorp Raft calls Restore without concurrent
 // Apply calls, so the FSM can safely close and reopen its local stores here.
+// Any caller-owned DB handle passed to Open is closed by a successful install
+// and must be recreated before direct use.
 func (f *FSM) InstallRaftSnapshotV1(reader io.Reader) error {
 	if f == nil {
 		return codedError(raftentry.ErrorUnsafeDurabilityModeV1, "FSM is not open")
@@ -162,8 +166,11 @@ func (f *FSM) InstallRaftSnapshotV1(reader io.Reader) error {
 		return err
 	}
 	cleanupMain = false
-	if err := replaceSnapshotSideStoresV1(mainDir, tmpSide); err != nil {
-		return err
+	if !f.cluster.DisableSideStores {
+		if err := replaceSnapshotSideStoresV1(mainDir, tmpSide); err != nil {
+			return err
+		}
+		cleanupSide = false
 	}
 	if err := replaceSnapshotDirV1(applyDir, tmpApply); err != nil {
 		return err
@@ -211,15 +218,8 @@ func (f *FSM) closeForRaftSnapshotRestoreV1() error {
 }
 
 func (f *FSM) reopenAfterRaftSnapshotRestoreV1() error {
-	opts := f.restoreDB
 	mainDir := raftcluster.MainDBDir(f.cluster.Dir)
-	opts.Dir = mainDir
-	opts.CommandWAL = true
-	opts.CommandWALStatsScan = true
-	if opts.CommandWALSegmentTargetBytes <= 0 {
-		opts.CommandWALSegmentTargetBytes = 1 << 20
-	}
-	opts.DisableBackgroundPrune = true
+	opts := f.snapshotRestoreDBOptionsV1(mainDir)
 	sideDBs, err := wireRaftSnapshotSideStoreLookupsV1(snapshotSideStoreRootV1(mainDir), &opts)
 	if err != nil {
 		return err
@@ -252,14 +252,7 @@ func (f *FSM) reopenAfterRaftSnapshotRestoreV1() error {
 }
 
 func (f *FSM) verifyExtractedRaftSnapshotV1(manifest raftcluster.SnapshotManifestV1, mainDir, sideDir, applyDir string) error {
-	opts := f.restoreDB
-	opts.Dir = mainDir
-	opts.CommandWAL = true
-	opts.CommandWALStatsScan = true
-	if opts.CommandWALSegmentTargetBytes <= 0 {
-		opts.CommandWALSegmentTargetBytes = 1 << 20
-	}
-	opts.DisableBackgroundPrune = true
+	opts := f.snapshotRestoreDBOptionsV1(mainDir)
 	sideDBs, err := wireRaftSnapshotSideStoreLookupsV1(sideDir, &opts)
 	if err != nil {
 		return err
@@ -296,6 +289,21 @@ func (f *FSM) verifyExtractedRaftSnapshotV1(manifest raftcluster.SnapshotManifes
 		return verifyErr
 	}
 	return closeErr
+}
+
+func (f *FSM) snapshotRestoreDBOptionsV1(dir string) backenddb.Options {
+	opts := f.restoreDB
+	opts.Dir = dir
+	opts.CommandWAL = true
+	opts.CommandWALStatsScan = true
+	if opts.CommandWALSegmentTargetBytes <= 0 {
+		opts.CommandWALSegmentTargetBytes = 1 << 20
+	}
+	opts.DisableBackgroundPrune = true
+	if f.cluster.DisableSideStores {
+		opts.DisableSideStores = true
+	}
+	return opts
 }
 
 func appendRaftSnapshotDirV1(tw *tar.Writer, prefix, root string) error {
@@ -468,7 +476,7 @@ func extractRaftSnapshotArchiveV1(reader io.Reader, mainDir, sideDir, applyDir s
 			if tarHeader.Typeflag != tar.TypeReg && tarHeader.Typeflag != tar.TypeRegA {
 				return raftcluster.RaftSnapshotArchiveHeaderV1{}, fmt.Errorf("raftfsm: snapshot archive header is not a regular file")
 			}
-			raw, err := io.ReadAll(tr)
+			raw, err := readRaftSnapshotArchiveHeaderBytesV1(tr, tarHeader.Size)
 			if err != nil {
 				return raftcluster.RaftSnapshotArchiveHeaderV1{}, err
 			}
@@ -520,6 +528,20 @@ func extractRaftSnapshotArchiveV1(reader io.Reader, mainDir, sideDir, applyDir s
 		return raftcluster.RaftSnapshotArchiveHeaderV1{}, fmt.Errorf("raftfsm: snapshot archive has no Raft apply metadata files")
 	}
 	return header, nil
+}
+
+func readRaftSnapshotArchiveHeaderBytesV1(reader io.Reader, size int64) ([]byte, error) {
+	if size > raftcluster.RaftSnapshotArchiveHeaderMaxBytes {
+		return nil, fmt.Errorf("raftfsm: snapshot archive header is %d bytes, max %d", size, raftcluster.RaftSnapshotArchiveHeaderMaxBytes)
+	}
+	raw, err := io.ReadAll(io.LimitReader(reader, raftcluster.RaftSnapshotArchiveHeaderMaxBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("raftfsm: read snapshot archive header: %w", err)
+	}
+	if len(raw) > raftcluster.RaftSnapshotArchiveHeaderMaxBytes {
+		return nil, fmt.Errorf("raftfsm: snapshot archive header exceeds %d bytes", raftcluster.RaftSnapshotArchiveHeaderMaxBytes)
+	}
+	return raw, nil
 }
 
 func cleanSnapshotArchiveNameV1(name string) string {

--- a/TreeDB/internal/raftfsm/raft_snapshot.go
+++ b/TreeDB/internal/raftfsm/raft_snapshot.go
@@ -20,6 +20,7 @@ import (
 
 const (
 	raftSnapshotDBPrefixV1    = "db"
+	raftSnapshotSidePrefixV1  = "side"
 	raftSnapshotApplyPrefixV1 = "apply"
 )
 
@@ -29,6 +30,11 @@ var raftSnapshotMainDBEntriesV1 = []string{
 	"value_vlog",
 	"leaf_vlog",
 	"column_assets",
+}
+
+var raftSnapshotSideStoreEntriesV1 = []string{
+	"dictdb",
+	"templatedb",
 }
 
 // ExportRaftSnapshotV1 exports a production snapshot archive for HashiCorp
@@ -58,6 +64,9 @@ func (f *FSM) ExportRaftSnapshotV1() (raftcluster.RaftSnapshotV1, error) {
 		return raftcluster.RaftSnapshotV1{}, err
 	}
 	if err := appendRaftSnapshotTreeDBStorageV1(tw, raftSnapshotDBPrefixV1, raftcluster.MainDBDir(f.cluster.Dir)); err != nil {
+		return raftcluster.RaftSnapshotV1{}, err
+	}
+	if err := appendRaftSnapshotTreeDBSideStoresV1(tw, raftSnapshotSidePrefixV1, raftcluster.MainDBDir(f.cluster.Dir)); err != nil {
 		return raftcluster.RaftSnapshotV1{}, err
 	}
 	if err := appendRaftSnapshotDirV1(tw, raftSnapshotApplyPrefixV1, f.cluster.Layout.ApplyDir); err != nil {
@@ -101,18 +110,28 @@ func (f *FSM) InstallRaftSnapshotV1(reader io.Reader) error {
 		_ = os.RemoveAll(tmpMain)
 		return err
 	}
+	tmpSide, err := os.MkdirTemp(filepath.Dir(mainDir), ".raft-snapshot-side-*")
+	if err != nil {
+		_ = os.RemoveAll(tmpMain)
+		_ = os.RemoveAll(tmpApply)
+		return err
+	}
 	cleanupMain := true
 	cleanupApply := true
+	cleanupSide := true
 	defer func() {
 		if cleanupMain {
 			_ = os.RemoveAll(tmpMain)
+		}
+		if cleanupSide {
+			_ = os.RemoveAll(tmpSide)
 		}
 		if cleanupApply {
 			_ = os.RemoveAll(tmpApply)
 		}
 	}()
 
-	header, err := extractRaftSnapshotArchiveV1(reader, tmpMain, tmpApply)
+	header, err := extractRaftSnapshotArchiveV1(reader, tmpMain, tmpSide, tmpApply)
 	if err != nil {
 		return err
 	}
@@ -126,6 +145,9 @@ func (f *FSM) InstallRaftSnapshotV1(reader io.Reader) error {
 		return err
 	}
 	if err := replaceSnapshotMainDBV1(mainDir, tmpMain); err != nil {
+		return err
+	}
+	if err := replaceSnapshotSideStoresV1(mainDir, tmpSide); err != nil {
 		return err
 	}
 	if err := replaceSnapshotDirV1(applyDir, tmpApply); err != nil {
@@ -273,6 +295,20 @@ func appendRaftSnapshotTreeDBStorageV1(tw *tar.Writer, prefix, mainDir string) e
 	return nil
 }
 
+func appendRaftSnapshotTreeDBSideStoresV1(tw *tar.Writer, prefix, mainDir string) error {
+	if err := writeRaftSnapshotDirHeaderV1(tw, prefix); err != nil {
+		return err
+	}
+	root := snapshotSideStoreRootV1(mainDir)
+	for _, name := range raftSnapshotSideStoreEntriesV1 {
+		src := filepath.Join(root, name)
+		if err := appendRaftSnapshotStoragePathV1(tw, pathpkg.Join(prefix, name), src); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func appendRaftSnapshotStoragePathV1(tw *tar.Writer, archiveName, src string) error {
 	info, err := os.Stat(src)
 	if err != nil {
@@ -325,7 +361,7 @@ func writeRaftSnapshotFileV1(tw *tar.Writer, name string, payload []byte, mode i
 	return err
 }
 
-func extractRaftSnapshotArchiveV1(reader io.Reader, mainDir, applyDir string) (raftcluster.RaftSnapshotArchiveHeaderV1, error) {
+func extractRaftSnapshotArchiveV1(reader io.Reader, mainDir, sideDir, applyDir string) (raftcluster.RaftSnapshotArchiveHeaderV1, error) {
 	tr := tar.NewReader(reader)
 	var (
 		header       raftcluster.RaftSnapshotArchiveHeaderV1
@@ -369,6 +405,14 @@ func extractRaftSnapshotArchiveV1(reader io.Reader, mainDir, applyDir string) (r
 				return raftcluster.RaftSnapshotArchiveHeaderV1{}, err
 			}
 			sawDBFile = sawDBFile || file
+			continue
+		}
+		if rel, ok, err := snapshotArchiveRelV1(name, raftSnapshotSidePrefixV1); err != nil {
+			return raftcluster.RaftSnapshotArchiveHeaderV1{}, err
+		} else if ok {
+			if _, err := extractRaftSnapshotEntryV1(tr, tarHeader, sideDir, rel); err != nil {
+				return raftcluster.RaftSnapshotArchiveHeaderV1{}, err
+			}
 			continue
 		}
 		if rel, ok, err := snapshotArchiveRelV1(name, raftSnapshotApplyPrefixV1); err != nil {
@@ -493,4 +537,39 @@ func replaceSnapshotMainDBV1(destMain, srcMain string) error {
 		}
 	}
 	return nil
+}
+
+func replaceSnapshotSideStoresV1(mainDir, srcSide string) error {
+	root := snapshotSideStoreRootV1(mainDir)
+	if root == "" || srcSide == "" {
+		return fmt.Errorf("raftfsm: empty snapshot restore side-store path")
+	}
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		return err
+	}
+	for _, name := range raftSnapshotSideStoreEntriesV1 {
+		src := filepath.Join(srcSide, name)
+		dest := filepath.Join(root, name)
+		if err := os.RemoveAll(dest); err != nil {
+			return err
+		}
+		if _, err := os.Stat(src); err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return err
+		}
+		if err := os.Rename(src, dest); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func snapshotSideStoreRootV1(mainDir string) string {
+	mainDir = filepath.Clean(mainDir)
+	if filepath.Base(mainDir) == "maindb" {
+		return filepath.Dir(mainDir)
+	}
+	return mainDir
 }

--- a/TreeDB/internal/raftfsm/raft_snapshot.go
+++ b/TreeDB/internal/raftfsm/raft_snapshot.go
@@ -42,13 +42,18 @@ var raftSnapshotSideStoreEntriesV1 = []string{
 // value-log segments, plus durable Raft apply metadata. It intentionally
 // excludes HashiCorp Raft log/stable/snapshot directories.
 func (f *FSM) ExportRaftSnapshotV1() (raftcluster.RaftSnapshotV1, error) {
+	if f == nil {
+		return raftcluster.RaftSnapshotV1{}, codedError(raftentry.ErrorUnsafeDurabilityModeV1, "FSM is not open")
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	if err := f.requireRaftSnapshotOpenV1(); err != nil {
 		return raftcluster.RaftSnapshotV1{}, err
 	}
 	if err := f.db.Checkpoint(); err != nil {
 		return raftcluster.RaftSnapshotV1{}, codedError(raftentry.ErrorUnsafeDurabilityModeV1, "checkpoint before snapshot export: %v", err)
 	}
-	manifest, err := f.ExportSnapshotManifestV1(SnapshotManifestExportOptionsV1{})
+	manifest, err := f.exportSnapshotManifestV1Locked(SnapshotManifestExportOptionsV1{})
 	if err != nil {
 		return raftcluster.RaftSnapshotV1{}, err
 	}
@@ -135,6 +140,8 @@ func (f *FSM) InstallRaftSnapshotV1(reader io.Reader) error {
 	if err != nil {
 		return err
 	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	if err := header.Validate(f.snapshotScopeIdentityV1()); err != nil {
 		return codedError(raftentry.ErrorRejectedConflictV1, "snapshot archive is not valid for FSM scope: %v", err)
 	}
@@ -157,7 +164,7 @@ func (f *FSM) InstallRaftSnapshotV1(reader io.Reader) error {
 	if err := f.reopenAfterRaftSnapshotRestoreV1(); err != nil {
 		return err
 	}
-	return f.VerifyInstalledSnapshotManifestV1(header.Manifest)
+	return f.verifyInstalledSnapshotManifestV1Locked(header.Manifest)
 }
 
 func (f *FSM) requireRaftSnapshotOpenV1() error {
@@ -248,6 +255,9 @@ func appendRaftSnapshotDirV1(tw *tar.Writer, prefix, root string) error {
 		if rel == "." {
 			return writeRaftSnapshotDirHeaderV1(tw, prefix)
 		}
+		if shouldSkipRaftSnapshotTreeDBFileV1(rel) {
+			return nil
+		}
 		info, err := entry.Info()
 		if err != nil {
 			return err
@@ -280,6 +290,10 @@ func appendRaftSnapshotDirV1(tw *tar.Writer, prefix, root string) error {
 		closeErr := file.Close()
 		return errors.Join(copyErr, closeErr)
 	})
+}
+
+func shouldSkipRaftSnapshotTreeDBFileV1(rel string) bool {
+	return filepath.Base(rel) == "command-wal-journal-owner.lock"
 }
 
 func appendRaftSnapshotTreeDBStorageV1(tw *tar.Writer, prefix, mainDir string) error {

--- a/TreeDB/internal/raftfsm/raft_snapshot.go
+++ b/TreeDB/internal/raftfsm/raft_snapshot.go
@@ -97,28 +97,35 @@ func (f *FSM) ExportRaftSnapshotV1() (raftcluster.RaftSnapshotV1, error) {
 // production snapshot archive. HashiCorp Raft calls Restore without concurrent
 // Apply calls, so the FSM can safely close and reopen its local stores here.
 func (f *FSM) InstallRaftSnapshotV1(reader io.Reader) error {
-	if err := f.requireRaftSnapshotOpenV1(); err != nil {
-		return err
+	if f == nil {
+		return codedError(raftentry.ErrorUnsafeDurabilityModeV1, "FSM is not open")
 	}
 	if reader == nil {
 		return codedError(raftentry.ErrorUnsafeDurabilityModeV1, "nil snapshot reader")
 	}
+	f.mu.RLock()
+	if err := f.requireRaftSnapshotOpenV1(); err != nil {
+		f.mu.RUnlock()
+		return err
+	}
 	mainDir := raftcluster.MainDBDir(f.cluster.Dir)
 	applyDir := f.cluster.Layout.ApplyDir
+	f.mu.RUnlock()
 	if mainDir == "" || applyDir == "" {
 		return codedError(raftentry.ErrorUnsafeDurabilityModeV1, "missing snapshot install directories")
 	}
 
-	tmpMain, err := os.MkdirTemp(filepath.Dir(mainDir), ".raft-snapshot-main-*")
+	scratchParent := filepath.Dir(mainDir)
+	tmpMain, err := os.MkdirTemp(scratchParent, ".raft-snapshot-main-*")
 	if err != nil {
 		return err
 	}
-	tmpApply, err := os.MkdirTemp(filepath.Dir(applyDir), ".raft-snapshot-apply-*")
+	tmpApply, err := os.MkdirTemp(scratchParent, ".raft-snapshot-apply-*")
 	if err != nil {
 		_ = os.RemoveAll(tmpMain)
 		return err
 	}
-	tmpSide, err := os.MkdirTemp(filepath.Dir(mainDir), ".raft-snapshot-side-*")
+	tmpSide, err := os.MkdirTemp(scratchParent, ".raft-snapshot-side-*")
 	if err != nil {
 		_ = os.RemoveAll(tmpMain)
 		_ = os.RemoveAll(tmpApply)
@@ -160,6 +167,7 @@ func (f *FSM) InstallRaftSnapshotV1(reader io.Reader) error {
 	if err := replaceSnapshotMainDBV1(mainDir, tmpMain); err != nil {
 		return err
 	}
+	cleanupMain = false
 	if err := replaceSnapshotSideStoresV1(mainDir, tmpSide); err != nil {
 		return err
 	}
@@ -330,12 +338,15 @@ func appendRaftSnapshotTreeDBSideStoresV1(tw *tar.Writer, prefix, mainDir string
 }
 
 func appendRaftSnapshotStoragePathV1(tw *tar.Writer, archiveName, src string) error {
-	info, err := os.Stat(src)
+	info, err := os.Lstat(src)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil
 		}
 		return err
+	}
+	if info.Mode()&fs.ModeSymlink != 0 {
+		return fmt.Errorf("raftfsm: snapshot path %q is a symlink", src)
 	}
 	if info.IsDir() {
 		return appendRaftSnapshotDirV1(tw, archiveName, src)
@@ -537,26 +548,13 @@ func replaceSnapshotMainDBV1(destMain, srcMain string) error {
 	if destMain == "" || srcMain == "" {
 		return fmt.Errorf("raftfsm: empty snapshot restore DB path")
 	}
-	if err := os.MkdirAll(destMain, 0o700); err != nil {
+	if err := os.MkdirAll(filepath.Dir(destMain), 0o700); err != nil {
 		return err
 	}
-	for _, name := range raftSnapshotMainDBEntriesV1 {
-		src := filepath.Join(srcMain, name)
-		dest := filepath.Join(destMain, name)
-		if err := os.RemoveAll(dest); err != nil {
-			return err
-		}
-		if _, err := os.Stat(src); err != nil {
-			if os.IsNotExist(err) {
-				continue
-			}
-			return err
-		}
-		if err := os.Rename(src, dest); err != nil {
-			return err
-		}
+	if err := os.RemoveAll(destMain); err != nil {
+		return err
 	}
-	return nil
+	return os.Rename(srcMain, destMain)
 }
 
 func replaceSnapshotSideStoresV1(mainDir, srcSide string) error {

--- a/TreeDB/internal/raftfsm/raft_snapshot.go
+++ b/TreeDB/internal/raftfsm/raft_snapshot.go
@@ -208,40 +208,51 @@ func (f *FSM) closeForRaftSnapshotRestoreV1() error {
 		errs = append(errs, f.db.Close())
 		f.db = nil
 	}
+	if f.sideDBs != nil {
+		errs = append(errs, f.sideDBs())
+		f.sideDBs = nil
+	}
 	f.ownsDB = false
 	return errors.Join(errs...)
 }
 
 func (f *FSM) reopenAfterRaftSnapshotRestoreV1() error {
 	opts := f.restoreDB
-	opts.Dir = raftcluster.MainDBDir(f.cluster.Dir)
+	mainDir := raftcluster.MainDBDir(f.cluster.Dir)
+	opts.Dir = mainDir
 	opts.CommandWAL = true
 	opts.CommandWALStatsScan = true
 	if opts.CommandWALSegmentTargetBytes <= 0 {
 		opts.CommandWALSegmentTargetBytes = 1 << 20
 	}
 	opts.DisableBackgroundPrune = true
+	sideDBs, err := wireRaftSnapshotSideStoreLookupsV1(snapshotSideStoreRootV1(mainDir), &opts)
+	if err != nil {
+		return err
+	}
 	db, err := backenddb.Open(opts)
 	if err != nil {
+		_ = sideDBs()
 		return err
 	}
 	progress, err := raftapply.OpenDurableApplyProgressStore(f.metadataDir, f.storeOptions)
 	if err != nil {
-		_ = db.Close()
+		_ = errors.Join(db.Close(), sideDBs())
 		return err
 	}
 	results, err := raftapply.OpenDurableApplyResultStore(f.metadataDir, f.storeOptions)
 	if err != nil {
-		_ = errors.Join(progress.Close(), db.Close())
+		_ = errors.Join(progress.Close(), db.Close(), sideDBs())
 		return err
 	}
 	if err := validateProgressCoverage(db, progress, results); err != nil {
-		_ = errors.Join(progress.Close(), results.Close(), db.Close())
+		_ = errors.Join(progress.Close(), results.Close(), db.Close(), sideDBs())
 		return err
 	}
 	f.db = db
 	f.progress = progress
 	f.results = results
+	f.sideDBs = sideDBs
 	f.ownsDB = true
 	return nil
 }

--- a/TreeDB/internal/raftfsm/raft_snapshot.go
+++ b/TreeDB/internal/raftfsm/raft_snapshot.go
@@ -85,7 +85,7 @@ func (f *FSM) ExportRaftSnapshotV1() (raftcluster.RaftSnapshotV1, error) {
 	}
 	snapshot := raftcluster.RaftSnapshotV1{
 		Manifest: manifest,
-		Payload:  bytes.Clone(buf.Bytes()),
+		Payload:  buf.Bytes(),
 	}
 	if err := snapshot.Validate(); err != nil {
 		return raftcluster.RaftSnapshotV1{}, err
@@ -115,22 +115,13 @@ func (f *FSM) InstallRaftSnapshotV1(reader io.Reader) error {
 		return codedError(raftentry.ErrorUnsafeDurabilityModeV1, "missing snapshot install directories")
 	}
 
-	scratchParent := filepath.Dir(mainDir)
-	tmpMain, err := os.MkdirTemp(scratchParent, ".raft-snapshot-main-*")
+	scratch, err := createRaftSnapshotScratchDirsV1(mainDir, applyDir)
 	if err != nil {
 		return err
 	}
-	tmpApply, err := os.MkdirTemp(scratchParent, ".raft-snapshot-apply-*")
-	if err != nil {
-		_ = os.RemoveAll(tmpMain)
-		return err
-	}
-	tmpSide, err := os.MkdirTemp(scratchParent, ".raft-snapshot-side-*")
-	if err != nil {
-		_ = os.RemoveAll(tmpMain)
-		_ = os.RemoveAll(tmpApply)
-		return err
-	}
+	tmpMain := scratch.main
+	tmpApply := scratch.apply
+	tmpSide := scratch.side
 	cleanupMain := true
 	cleanupApply := true
 	cleanupSide := true
@@ -540,6 +531,49 @@ func sameOrUnderSnapshotDirV1(parent, child string) bool {
 	}
 	rel, err := filepath.Rel(parent, child)
 	return err == nil && rel != "." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator)) && rel != ".."
+}
+
+type raftSnapshotScratchDirsV1 struct {
+	main  string
+	side  string
+	apply string
+}
+
+func createRaftSnapshotScratchDirsV1(mainDir, applyDir string) (raftSnapshotScratchDirsV1, error) {
+	if mainDir == "" || applyDir == "" {
+		return raftSnapshotScratchDirsV1{}, fmt.Errorf("raftfsm: empty snapshot scratch path")
+	}
+	mainParent := filepath.Dir(mainDir)
+	applyParent := filepath.Dir(applyDir)
+	if sameOrUnderSnapshotDirV1(mainDir, applyDir) {
+		applyParent = mainParent
+	}
+	if err := os.MkdirAll(mainParent, 0o700); err != nil {
+		return raftSnapshotScratchDirsV1{}, err
+	}
+	if err := os.MkdirAll(applyParent, 0o700); err != nil {
+		return raftSnapshotScratchDirsV1{}, err
+	}
+	tmpMain, err := os.MkdirTemp(mainParent, ".raft-snapshot-main-*")
+	if err != nil {
+		return raftSnapshotScratchDirsV1{}, err
+	}
+	tmpApply, err := os.MkdirTemp(applyParent, ".raft-snapshot-apply-*")
+	if err != nil {
+		_ = os.RemoveAll(tmpMain)
+		return raftSnapshotScratchDirsV1{}, err
+	}
+	tmpSide, err := os.MkdirTemp(mainParent, ".raft-snapshot-side-*")
+	if err != nil {
+		_ = os.RemoveAll(tmpMain)
+		_ = os.RemoveAll(tmpApply)
+		return raftSnapshotScratchDirsV1{}, err
+	}
+	return raftSnapshotScratchDirsV1{
+		main:  tmpMain,
+		side:  tmpSide,
+		apply: tmpApply,
+	}, nil
 }
 
 func replaceSnapshotDirV1(dest, src string) error {

--- a/TreeDB/internal/raftfsm/raft_snapshot_side_stores.go
+++ b/TreeDB/internal/raftfsm/raft_snapshot_side_stores.go
@@ -7,9 +7,11 @@ import (
 	"path/filepath"
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
+	"github.com/snissn/gomap/TreeDB/internal/compression"
 	"github.com/snissn/gomap/TreeDB/internal/dictdb"
 	"github.com/snissn/gomap/TreeDB/internal/limits"
 	"github.com/snissn/gomap/TreeDB/internal/templatedb"
+	"github.com/snissn/gomap/TreeDB/internal/valuelog"
 	"github.com/snissn/gomap/TreeDB/template"
 )
 
@@ -107,12 +109,7 @@ func wireRaftSnapshotDictLookupV1(rootDir string, opts *backenddb.Options, close
 	dictOpts.DisableBackgroundPrune = true
 	dictOpts.IgnoreFormatConfig = false
 	dictOpts.CommandWAL = false
-	dictOpts.IndexOuterLeavesInValueLog = false
-	dictOpts.ValueLog.DictLookup = nil
-	dictOpts.ValueLog.Compression = backenddb.ValueLogCompressionOff
-	dictOpts.ValueLog.TemplateMode = template.TemplateOff
-	dictOpts.ValueLog.TemplateLookup = nil
-	dictOpts.ValueLog.TemplateDecodeOptions = template.DecodeOptions{}
+	scrubRaftSnapshotSideStoreOptionsV1(&dictOpts)
 
 	dictBackend, err := backenddb.Open(dictOpts)
 	if err != nil {
@@ -170,12 +167,7 @@ func wireRaftSnapshotTemplateLookupV1(rootDir string, opts *backenddb.Options, c
 	templateOpts.DisableBackgroundPrune = true
 	templateOpts.IgnoreFormatConfig = false
 	templateOpts.CommandWAL = false
-	templateOpts.IndexOuterLeavesInValueLog = false
-	templateOpts.ValueLog.DictLookup = nil
-	templateOpts.ValueLog.Compression = backenddb.ValueLogCompressionOff
-	templateOpts.ValueLog.TemplateMode = template.TemplateOff
-	templateOpts.ValueLog.TemplateLookup = nil
-	templateOpts.ValueLog.TemplateDecodeOptions = template.DecodeOptions{}
+	scrubRaftSnapshotSideStoreOptionsV1(&templateOpts)
 
 	templateBackend, err := backenddb.Open(templateOpts)
 	if err != nil {
@@ -198,4 +190,18 @@ func wireRaftSnapshotTemplateLookupV1(rootDir string, opts *backenddb.Options, c
 		return store.GetTemplateDef(context.Background(), templateID)
 	}
 	return nil
+}
+
+func scrubRaftSnapshotSideStoreOptionsV1(opts *backenddb.Options) {
+	opts.IndexOuterLeavesInValueLog = false
+	opts.ValueLog.DictLookup = nil
+	opts.ValueLog.DictTrain = compression.TrainConfig{TrainBytes: -1}
+	opts.ValueLog.ForcePointers = false
+	opts.ValueLog.PointerThreshold = 0
+	opts.ValueLog.DomainInlineThresholds = nil
+	opts.ValueLog.Compression = backenddb.ValueLogCompressionOff
+	opts.ValueLog.CompressionAutotune = valuelog.AutotuneOptions{Mode: valuelog.AutotuneOff}
+	opts.ValueLog.TemplateMode = template.TemplateOff
+	opts.ValueLog.TemplateLookup = nil
+	opts.ValueLog.TemplateDecodeOptions = template.DecodeOptions{}
 }

--- a/TreeDB/internal/raftfsm/raft_snapshot_side_stores.go
+++ b/TreeDB/internal/raftfsm/raft_snapshot_side_stores.go
@@ -1,0 +1,201 @@
+package raftfsm
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+	"github.com/snissn/gomap/TreeDB/internal/dictdb"
+	"github.com/snissn/gomap/TreeDB/internal/limits"
+	"github.com/snissn/gomap/TreeDB/internal/templatedb"
+	"github.com/snissn/gomap/TreeDB/template"
+)
+
+const raftSnapshotSideStoreChunkSizeV1 = 64 * 1024
+
+type raftSnapshotTemplateBackendKVV1 struct {
+	db *backenddb.DB
+}
+
+func (kv raftSnapshotTemplateBackendKVV1) Get(key []byte) ([]byte, error) {
+	if kv.db == nil {
+		return nil, nil
+	}
+	return kv.db.Get(key)
+}
+
+func (kv raftSnapshotTemplateBackendKVV1) SetSync(key, value []byte) error {
+	if kv.db == nil {
+		return nil
+	}
+	return kv.db.SetSync(key, value)
+}
+
+func (kv raftSnapshotTemplateBackendKVV1) DeleteSync(key []byte) error {
+	if kv.db == nil {
+		return nil
+	}
+	return kv.db.DeleteSync(key)
+}
+
+func (kv raftSnapshotTemplateBackendKVV1) NewBatch() templatedb.Batch {
+	if kv.db == nil {
+		return nil
+	}
+	b := kv.db.NewBatch()
+	if b == nil {
+		return nil
+	}
+	return b
+}
+
+func wireRaftSnapshotSideStoreLookupsV1(rootDir string, opts *backenddb.Options) (func() error, error) {
+	if opts == nil || opts.DisableSideStores {
+		return func() error { return nil }, nil
+	}
+	if rootDir == "" {
+		return nil, fmt.Errorf("raftfsm: missing root dir for restored side-store lookup wiring")
+	}
+
+	var closers []func() error
+	cleanup := func() error {
+		var first error
+		for i := len(closers) - 1; i >= 0; i-- {
+			if err := closers[i](); err != nil && first == nil {
+				first = err
+			}
+		}
+		return first
+	}
+
+	if err := wireRaftSnapshotDictLookupV1(rootDir, opts, &closers); err != nil {
+		_ = cleanup()
+		return nil, err
+	}
+	if err := wireRaftSnapshotTemplateLookupV1(rootDir, opts, &closers); err != nil {
+		_ = cleanup()
+		return nil, err
+	}
+	return cleanup, nil
+}
+
+func wireRaftSnapshotDictLookupV1(rootDir string, opts *backenddb.Options, closers *[]func() error) error {
+	dictDir := filepath.Join(rootDir, "dictdb")
+	indexPath := filepath.Join(dictDir, "index.db")
+	indexInfo, err := os.Stat(indexPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("raftfsm: stat restored dictdb index: %w", err)
+	}
+	if indexInfo.IsDir() {
+		return fmt.Errorf("raftfsm: restored dictdb index path is a directory: %s", indexPath)
+	}
+
+	dictOpts := *opts
+	dictOpts.Dir = dictDir
+	dictOpts.ReadOnly = opts.ReadOnly
+	if dictOpts.ChunkSize <= 0 {
+		dictOpts.ChunkSize = raftSnapshotSideStoreChunkSizeV1
+	}
+	if opts.DictDBChunkSize > 0 {
+		dictOpts.ChunkSize = opts.DictDBChunkSize
+	}
+	dictOpts.DisableBackgroundPrune = true
+	dictOpts.IgnoreFormatConfig = false
+	dictOpts.CommandWAL = false
+	dictOpts.IndexOuterLeavesInValueLog = false
+	dictOpts.ValueLog.DictLookup = nil
+	dictOpts.ValueLog.Compression = backenddb.ValueLogCompressionOff
+	dictOpts.ValueLog.TemplateMode = template.TemplateOff
+	dictOpts.ValueLog.TemplateLookup = nil
+	dictOpts.ValueLog.TemplateDecodeOptions = template.DecodeOptions{}
+
+	dictBackend, err := backenddb.Open(dictOpts)
+	if err != nil {
+		return fmt.Errorf("raftfsm: open restored dictdb: %w", err)
+	}
+	*closers = append(*closers, dictBackend.Close)
+	store := dictdb.New(dictBackend)
+	opts.ValueLog.DictLookup = func(dictID uint64) ([]byte, error) {
+		return store.GetDictBytes(context.Background(), dictID)
+	}
+	opts.ValueLog.DictCurrentForClass = func(ctx context.Context, class string) (uint64, error) {
+		return store.GetCurrentForClass(ctx, class)
+	}
+	opts.ValueLog.DictLeafPayloadMode = func(ctx context.Context, dictID uint64) (bool, bool, error) {
+		return store.GetLeafPayloadMode(ctx, dictID)
+	}
+	if !dictOpts.ReadOnly {
+		opts.ValueLog.DictPut = func(ctx context.Context, dictBytes []byte) (uint64, error) {
+			return store.PutDictBytes(ctx, dictBytes)
+		}
+		opts.ValueLog.DictSetCurrentForClass = func(ctx context.Context, class string, dictID uint64) error {
+			return store.SetCurrentForClass(ctx, class, dictID)
+		}
+		opts.ValueLog.DictSetLeafPayloadMode = func(ctx context.Context, dictID uint64, useRawPages bool) error {
+			return store.SetLeafPayloadMode(ctx, dictID, useRawPages)
+		}
+	}
+	return nil
+}
+
+func wireRaftSnapshotTemplateLookupV1(rootDir string, opts *backenddb.Options, closers *[]func() error) error {
+	templateDir := filepath.Join(rootDir, "templatedb")
+	indexPath := filepath.Join(templateDir, "index.db")
+	indexInfo, err := os.Stat(indexPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("raftfsm: stat restored templatedb index: %w", err)
+	}
+	if indexInfo.IsDir() {
+		return fmt.Errorf("raftfsm: restored templatedb index path is a directory: %s", indexPath)
+	}
+
+	templateOpts := *opts
+	templateOpts.Dir = templateDir
+	templateReadOnly := opts.ReadOnly || opts.ValueLog.TemplateMode == template.TemplateOff
+	templateOpts.ReadOnly = templateReadOnly
+	if templateOpts.ChunkSize <= 0 {
+		templateOpts.ChunkSize = raftSnapshotSideStoreChunkSizeV1
+	}
+	if opts.TemplateDBChunkSize > 0 {
+		templateOpts.ChunkSize = opts.TemplateDBChunkSize
+	}
+	templateOpts.DisableBackgroundPrune = true
+	templateOpts.IgnoreFormatConfig = false
+	templateOpts.CommandWAL = false
+	templateOpts.IndexOuterLeavesInValueLog = false
+	templateOpts.ValueLog.DictLookup = nil
+	templateOpts.ValueLog.Compression = backenddb.ValueLogCompressionOff
+	templateOpts.ValueLog.TemplateMode = template.TemplateOff
+	templateOpts.ValueLog.TemplateLookup = nil
+	templateOpts.ValueLog.TemplateDecodeOptions = template.DecodeOptions{}
+
+	templateBackend, err := backenddb.Open(templateOpts)
+	if err != nil {
+		return fmt.Errorf("raftfsm: open restored templatedb: %w", err)
+	}
+	*closers = append(*closers, templateBackend.Close)
+	store := templatedb.New(raftSnapshotTemplateBackendKVV1{db: templateBackend}, templatedb.Config{})
+	if !templateReadOnly && opts.ValueLog.TemplateMode != template.TemplateOff {
+		opts.ValueLog.TemplateStore = store
+	}
+	if opts.ValueLog.TemplateDecodeOptions == (template.DecodeOptions{}) {
+		tcfg := template.NormalizeConfig(opts.ValueLog.TemplateConfig)
+		decodeOpts := template.DecodeOptions{MaxGaps: tcfg.MaxGaps, MaxDecodedBytes: tcfg.MaxDecodedBytes, DefCacheSize: tcfg.DefCacheSize}
+		if decodeOpts.MaxDecodedBytes <= 0 && limits.MaxRecordSize > 0 {
+			decodeOpts.MaxDecodedBytes = int(limits.MaxRecordSize)
+		}
+		opts.ValueLog.TemplateDecodeOptions = decodeOpts
+	}
+	opts.ValueLog.TemplateLookup = func(templateID uint64) ([]byte, error) {
+		return store.GetTemplateDef(context.Background(), templateID)
+	}
+	return nil
+}

--- a/TreeDB/internal/raftfsm/raft_snapshot_test.go
+++ b/TreeDB/internal/raftfsm/raft_snapshot_test.go
@@ -21,6 +21,52 @@ import (
 	"github.com/snissn/gomap/TreeDB/template"
 )
 
+func TestRaftSnapshotV1ScratchDirsUseDestinationParents(t *testing.T) {
+	root := t.TempDir()
+	tests := []struct {
+		name        string
+		mainDir     string
+		applyDir    string
+		applyParent string
+	}{
+		{
+			name:        "external apply dir",
+			mainDir:     filepath.Join(root, "external", "data", "treedb"),
+			applyDir:    filepath.Join(root, "external", "raft", "apply"),
+			applyParent: filepath.Join(root, "external", "raft"),
+		},
+		{
+			name:        "apply dir under main dir",
+			mainDir:     filepath.Join(root, "internal", "treedb"),
+			applyDir:    filepath.Join(root, "internal", "treedb", "raftcluster", "nodes", "node-a", "groups", "default", "apply"),
+			applyParent: filepath.Join(root, "internal"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scratch, err := createRaftSnapshotScratchDirsV1(tt.mainDir, tt.applyDir)
+			if err != nil {
+				t.Fatalf("createRaftSnapshotScratchDirsV1: %v", err)
+			}
+			defer func() {
+				_ = os.RemoveAll(scratch.main)
+				_ = os.RemoveAll(scratch.side)
+				_ = os.RemoveAll(scratch.apply)
+			}()
+
+			if got, want := filepath.Dir(scratch.main), filepath.Dir(tt.mainDir); got != want {
+				t.Fatalf("main scratch parent=%q want %q", got, want)
+			}
+			if got, want := filepath.Dir(scratch.side), filepath.Dir(tt.mainDir); got != want {
+				t.Fatalf("side scratch parent=%q want %q", got, want)
+			}
+			if got := filepath.Dir(scratch.apply); got != tt.applyParent {
+				t.Fatalf("apply scratch parent=%q want %q", got, tt.applyParent)
+			}
+		})
+	}
+}
+
 func TestRaftSnapshotV1InstallEmptyTargetPreservesDigestAndValueLogPointers(t *testing.T) {
 	root := t.TempDir()
 	sourceDir := filepath.Join(root, "source")

--- a/TreeDB/internal/raftfsm/raft_snapshot_test.go
+++ b/TreeDB/internal/raftfsm/raft_snapshot_test.go
@@ -97,6 +97,48 @@ func TestRaftSnapshotV1InstallReplacesStaleReplica(t *testing.T) {
 	}
 }
 
+func TestRaftSnapshotV1InstallReplacesStaleFormatConfig(t *testing.T) {
+	root := t.TempDir()
+	sourceDir := filepath.Join(root, "source")
+	sourceDB := openRaftSnapshotFSMTestDB(t, sourceDir, false)
+	defer func() { _ = sourceDB.Close() }()
+	sourceFSM := openRaftSnapshotFSMForTest(t, sourceDB, sourceDir, true)
+	defer func() { _ = sourceFSM.Close() }()
+
+	sourceDoc := []byte(`{"_id":"u-large","name":"source-format"}`)
+	applySnapshotSourceEntries(t, sourceFSM, sourceDoc)
+	snapshot, err := sourceFSM.ExportRaftSnapshotV1()
+	if err != nil {
+		t.Fatalf("ExportRaftSnapshotV1: %v", err)
+	}
+	sourceFormatPath := filepath.Join(raftcluster.MainDBDir(sourceDir), raftSnapshotFormatConfigFileV1)
+	sourceFormat, err := os.ReadFile(sourceFormatPath)
+	if err != nil {
+		t.Fatalf("ReadFile source format config: %v", err)
+	}
+
+	targetDir := filepath.Join(root, "target")
+	targetDB := openRaftSnapshotFSMTestDB(t, targetDir, false)
+	targetFSM := openRaftSnapshotFSMForTest(t, targetDB, targetDir, true)
+	defer func() { _ = targetFSM.Close() }()
+	targetFormatPath := filepath.Join(raftcluster.MainDBDir(targetDir), raftSnapshotFormatConfigFileV1)
+	if err := os.WriteFile(targetFormatPath, []byte(`{"version":999}`), 0o600); err != nil {
+		t.Fatalf("WriteFile stale target format config: %v", err)
+	}
+
+	if err := targetFSM.InstallRaftSnapshotV1(bytes.NewReader(snapshot.Payload)); err != nil {
+		t.Fatalf("InstallRaftSnapshotV1 with stale target format config: %v", err)
+	}
+	targetFormat, err := os.ReadFile(targetFormatPath)
+	if err != nil {
+		t.Fatalf("ReadFile target format config: %v", err)
+	}
+	if !bytes.Equal(targetFormat, sourceFormat) {
+		t.Fatalf("target format config=%s want source %s", targetFormat, sourceFormat)
+	}
+	assertSnapshotDocument(t, targetFSM, "u-large", sourceDoc)
+}
+
 func TestRaftSnapshotV1TailReplayMatchesSourceDigest(t *testing.T) {
 	root := t.TempDir()
 	sourceDir := filepath.Join(root, "source")

--- a/TreeDB/internal/raftfsm/raft_snapshot_test.go
+++ b/TreeDB/internal/raftfsm/raft_snapshot_test.go
@@ -1,6 +1,7 @@
 package raftfsm
 
 import (
+	"archive/tar"
 	"bytes"
 	"os"
 	"path/filepath"
@@ -125,6 +126,10 @@ func TestRaftSnapshotV1InstallReplacesStaleFormatConfig(t *testing.T) {
 	if err := os.WriteFile(targetFormatPath, []byte(`{"version":999}`), 0o600); err != nil {
 		t.Fatalf("WriteFile stale target format config: %v", err)
 	}
+	staleTransientPath := filepath.Join(targetDir, "index.db.bak")
+	if err := os.WriteFile(staleTransientPath, []byte("stale-index-backup"), 0o600); err != nil {
+		t.Fatalf("WriteFile stale transient file: %v", err)
+	}
 
 	if err := targetFSM.InstallRaftSnapshotV1(bytes.NewReader(snapshot.Payload)); err != nil {
 		t.Fatalf("InstallRaftSnapshotV1 with stale target format config: %v", err)
@@ -135,6 +140,9 @@ func TestRaftSnapshotV1InstallReplacesStaleFormatConfig(t *testing.T) {
 	}
 	if !bytes.Equal(targetFormat, sourceFormat) {
 		t.Fatalf("target format config=%s want source %s", targetFormat, sourceFormat)
+	}
+	if _, err := os.Stat(staleTransientPath); !os.IsNotExist(err) {
+		t.Fatalf("stale transient file survived snapshot restore: err=%v", err)
 	}
 	assertSnapshotDocument(t, targetFSM, "u-large", sourceDoc)
 }
@@ -270,6 +278,26 @@ func TestRaftSnapshotV1InstallReopensRestoredMainDBForRootLayout(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(targetDir, "index.db")); err != nil {
 		t.Fatalf("restored main DB index missing: %v", err)
+	}
+}
+
+func TestRaftSnapshotV1ExportRejectsTopLevelSymlink(t *testing.T) {
+	root := t.TempDir()
+	target := filepath.Join(root, "outside")
+	if err := os.WriteFile(target, []byte("outside"), 0o600); err != nil {
+		t.Fatalf("WriteFile symlink target: %v", err)
+	}
+	link := filepath.Join(root, "value_vlog")
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlink unsupported on this platform: %v", err)
+	}
+
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	err := appendRaftSnapshotStoragePathV1(tw, "value_vlog", link)
+	_ = tw.Close()
+	if err == nil || !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("appendRaftSnapshotStoragePathV1 symlink error=%v, want symlink rejection", err)
 	}
 }
 

--- a/TreeDB/internal/raftfsm/raft_snapshot_test.go
+++ b/TreeDB/internal/raftfsm/raft_snapshot_test.go
@@ -93,6 +93,40 @@ func TestRaftSnapshotV1ExtractRejectsOversizedArchiveHeader(t *testing.T) {
 	}
 }
 
+func TestRaftSnapshotV1CopyFileContentDoesNotOverrunHeaderSize(t *testing.T) {
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	if err := tw.WriteHeader(&tar.Header{
+		Name: "db/index.db",
+		Mode: 0o600,
+		Size: 4,
+	}); err != nil {
+		t.Fatalf("WriteHeader: %v", err)
+	}
+	if err := copyRaftSnapshotFileContentV1(tw, strings.NewReader("abcdef"), 4); err != nil {
+		t.Fatalf("copyRaftSnapshotFileContentV1: %v", err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("Close archive: %v", err)
+	}
+
+	tr := tar.NewReader(bytes.NewReader(buf.Bytes()))
+	header, err := tr.Next()
+	if err != nil {
+		t.Fatalf("Next archive entry: %v", err)
+	}
+	if header.Size != 4 {
+		t.Fatalf("archive entry size=%d want 4", header.Size)
+	}
+	raw, err := io.ReadAll(tr)
+	if err != nil {
+		t.Fatalf("ReadAll archive entry: %v", err)
+	}
+	if got, want := string(raw), "abcd"; got != want {
+		t.Fatalf("archive content=%q want %q", got, want)
+	}
+}
+
 func TestRaftSnapshotV1InstallEmptyTargetPreservesDigestAndValueLogPointers(t *testing.T) {
 	root := t.TempDir()
 	sourceDir := filepath.Join(root, "source")

--- a/TreeDB/internal/raftfsm/raft_snapshot_test.go
+++ b/TreeDB/internal/raftfsm/raft_snapshot_test.go
@@ -3,6 +3,7 @@ package raftfsm
 import (
 	"archive/tar"
 	"bytes"
+	"context"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -11,10 +12,13 @@ import (
 
 	"github.com/snissn/gomap/TreeDB/collections"
 	backenddb "github.com/snissn/gomap/TreeDB/db"
+	"github.com/snissn/gomap/TreeDB/internal/dictdb"
 	"github.com/snissn/gomap/TreeDB/internal/nativewire"
 	"github.com/snissn/gomap/TreeDB/internal/raftapply"
 	"github.com/snissn/gomap/TreeDB/internal/raftcluster"
 	"github.com/snissn/gomap/TreeDB/internal/raftentry"
+	"github.com/snissn/gomap/TreeDB/internal/templatedb"
+	"github.com/snissn/gomap/TreeDB/template"
 )
 
 func TestRaftSnapshotV1InstallEmptyTargetPreservesDigestAndValueLogPointers(t *testing.T) {
@@ -278,6 +282,80 @@ func TestRaftSnapshotV1InstallReopensRestoredMainDBForRootLayout(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(targetDir, "index.db")); err != nil {
 		t.Fatalf("restored main DB index missing: %v", err)
+	}
+}
+
+func TestRaftSnapshotV1RestoreWiresRestoredSideStoreLookups(t *testing.T) {
+	root := t.TempDir()
+	mainDir := filepath.Join(root, "maindb")
+	sideRoot := snapshotSideStoreRootV1(mainDir)
+	ctx := context.Background()
+
+	dictBackend, err := backenddb.Open(backenddb.Options{
+		Dir:                    filepath.Join(sideRoot, "dictdb"),
+		DisableBackgroundPrune: true,
+	})
+	if err != nil {
+		t.Fatalf("Open dictdb: %v", err)
+	}
+	dictStore := dictdb.New(dictBackend)
+	dictBytes := []byte("restored-dict")
+	dictID, err := dictStore.PutDictBytes(ctx, dictBytes)
+	if err != nil {
+		t.Fatalf("PutDictBytes: %v", err)
+	}
+	if err := dictBackend.Close(); err != nil {
+		t.Fatalf("Close dictdb: %v", err)
+	}
+
+	templateBackend, err := backenddb.Open(backenddb.Options{
+		Dir:                    filepath.Join(sideRoot, "templatedb"),
+		DisableBackgroundPrune: true,
+	})
+	if err != nil {
+		t.Fatalf("Open templatedb: %v", err)
+	}
+	templateStore := templatedb.New(raftSnapshotTemplateBackendKVV1{db: templateBackend}, templatedb.Config{})
+	templateBytes := []byte("restored-template")
+	templateID, err := templateStore.PutTemplateDef(ctx, templateBytes, nil)
+	if err != nil {
+		t.Fatalf("PutTemplateDef: %v", err)
+	}
+	if err := templateBackend.Close(); err != nil {
+		t.Fatalf("Close templatedb: %v", err)
+	}
+
+	opts := backenddb.Options{
+		ReadOnly: true,
+		ValueLog: backenddb.ValueLogOptions{
+			TemplateMode: template.TemplateOff,
+		},
+	}
+	cleanup, err := wireRaftSnapshotSideStoreLookupsV1(sideRoot, &opts)
+	if err != nil {
+		t.Fatalf("wireRaftSnapshotSideStoreLookupsV1: %v", err)
+	}
+	defer func() { _ = cleanup() }()
+
+	if opts.ValueLog.DictLookup == nil {
+		t.Fatal("DictLookup was not wired from restored side store")
+	}
+	gotDict, err := opts.ValueLog.DictLookup(dictID)
+	if err != nil {
+		t.Fatalf("DictLookup(%d): %v", dictID, err)
+	}
+	if !bytes.Equal(gotDict, dictBytes) {
+		t.Fatalf("DictLookup(%d)=%q want %q", dictID, gotDict, dictBytes)
+	}
+	if opts.ValueLog.TemplateLookup == nil {
+		t.Fatal("TemplateLookup was not wired from restored side store")
+	}
+	gotTemplate, err := opts.ValueLog.TemplateLookup(templateID)
+	if err != nil {
+		t.Fatalf("TemplateLookup(%d): %v", templateID, err)
+	}
+	if !bytes.Equal(gotTemplate, templateBytes) {
+		t.Fatalf("TemplateLookup(%d)=%q want %q", templateID, gotTemplate, templateBytes)
 	}
 }
 

--- a/TreeDB/internal/raftfsm/raft_snapshot_test.go
+++ b/TreeDB/internal/raftfsm/raft_snapshot_test.go
@@ -305,6 +305,7 @@ func TestRaftSnapshotV1InstallRejectsCorruptArchiveBeforeReplacingLiveState(t *t
 
 	targetDir := filepath.Join(root, "target")
 	targetDB := openRaftSnapshotFSMTestDB(t, targetDir, false)
+	defer func() { _ = targetDB.Close() }()
 	targetFSM := openRaftSnapshotFSMForTest(t, targetDB, targetDir, true)
 	defer func() { _ = targetFSM.Close() }()
 	targetDoc := []byte(`{"_id":"u-large","name":"target-before-corrupt"}`)
@@ -612,6 +613,61 @@ func TestRaftSnapshotV1RestoreWiresRestoredSideStoreLookups(t *testing.T) {
 	}
 }
 
+func TestRaftSnapshotV1RestoreScrubsMainPlacementOptionsForSideStores(t *testing.T) {
+	opts := backenddb.Options{
+		IndexOuterLeavesInValueLog: true,
+		ValueLog: backenddb.ValueLogOptions{
+			PointerThreshold: 1,
+			ForcePointers:    true,
+			DomainInlineThresholds: []backenddb.ValueLogDomainThreshold{
+				{Prefix: []byte("main/"), InlineThreshold: 0},
+			},
+			Compression: backenddb.ValueLogCompressionAuto,
+			DictLookup: func(uint64) ([]byte, error) {
+				return nil, nil
+			},
+			TemplateMode: template.TemplatePrepass,
+			TemplateLookup: func(uint64) ([]byte, error) {
+				return nil, nil
+			},
+			TemplateDecodeOptions: template.DecodeOptions{MaxDecodedBytes: 32, MaxGaps: 4, DefCacheSize: 2},
+		},
+	}
+
+	scrubRaftSnapshotSideStoreOptionsV1(&opts)
+
+	if opts.IndexOuterLeavesInValueLog {
+		t.Fatal("IndexOuterLeavesInValueLog was not cleared")
+	}
+	if opts.ValueLog.ForcePointers {
+		t.Fatal("ForcePointers was not cleared")
+	}
+	if opts.ValueLog.PointerThreshold != 0 {
+		t.Fatalf("PointerThreshold=%d want 0", opts.ValueLog.PointerThreshold)
+	}
+	if opts.ValueLog.DomainInlineThresholds != nil {
+		t.Fatalf("DomainInlineThresholds=%v want nil", opts.ValueLog.DomainInlineThresholds)
+	}
+	if opts.ValueLog.Compression != backenddb.ValueLogCompressionOff {
+		t.Fatalf("Compression=%v want off", opts.ValueLog.Compression)
+	}
+	if opts.ValueLog.DictLookup != nil {
+		t.Fatal("DictLookup was not cleared")
+	}
+	if opts.ValueLog.DictTrain.TrainBytes != -1 {
+		t.Fatalf("DictTrain.TrainBytes=%d want -1", opts.ValueLog.DictTrain.TrainBytes)
+	}
+	if opts.ValueLog.TemplateMode != template.TemplateOff {
+		t.Fatalf("TemplateMode=%v want off", opts.ValueLog.TemplateMode)
+	}
+	if opts.ValueLog.TemplateLookup != nil {
+		t.Fatal("TemplateLookup was not cleared")
+	}
+	if opts.ValueLog.TemplateDecodeOptions != (template.DecodeOptions{}) {
+		t.Fatalf("TemplateDecodeOptions=%+v want zero", opts.ValueLog.TemplateDecodeOptions)
+	}
+}
+
 func TestRaftSnapshotV1ExportRejectsTopLevelSymlink(t *testing.T) {
 	root := t.TempDir()
 	target := filepath.Join(root, "outside")
@@ -629,6 +685,26 @@ func TestRaftSnapshotV1ExportRejectsTopLevelSymlink(t *testing.T) {
 	_ = tw.Close()
 	if err == nil || !strings.Contains(err.Error(), "symlink") {
 		t.Fatalf("appendRaftSnapshotStoragePathV1 symlink error=%v, want symlink rejection", err)
+	}
+}
+
+func TestRaftSnapshotV1ExportRejectsDirectoryRootSymlink(t *testing.T) {
+	root := t.TempDir()
+	target := filepath.Join(root, "outside")
+	if err := os.MkdirAll(target, 0o700); err != nil {
+		t.Fatalf("MkdirAll symlink target: %v", err)
+	}
+	link := filepath.Join(root, "maindb")
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlink unsupported on this platform: %v", err)
+	}
+
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	err := appendRaftSnapshotDirV1(tw, "db", link)
+	_ = tw.Close()
+	if err == nil || !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("appendRaftSnapshotDirV1 symlink root error=%v, want symlink rejection", err)
 	}
 }
 

--- a/TreeDB/internal/raftfsm/raft_snapshot_test.go
+++ b/TreeDB/internal/raftfsm/raft_snapshot_test.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/snissn/gomap/TreeDB/collections"
 	backenddb "github.com/snissn/gomap/TreeDB/db"
@@ -93,6 +94,32 @@ func TestRaftSnapshotV1ExtractRejectsOversizedArchiveHeader(t *testing.T) {
 	}
 }
 
+func TestRaftSnapshotV1ExtractRejectsDuplicateArchiveHeader(t *testing.T) {
+	headerBytes := validRaftSnapshotArchiveHeaderBytesForTest(t)
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	for i := 0; i < 2; i++ {
+		if err := tw.WriteHeader(&tar.Header{
+			Name: raftcluster.RaftSnapshotArchiveManifestPathV1,
+			Mode: 0o600,
+			Size: int64(len(headerBytes)),
+		}); err != nil {
+			t.Fatalf("WriteHeader manifest %d: %v", i, err)
+		}
+		if _, err := tw.Write(headerBytes); err != nil {
+			t.Fatalf("Write manifest %d: %v", i, err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("Close archive: %v", err)
+	}
+
+	_, err := extractRaftSnapshotArchiveV1(bytes.NewReader(buf.Bytes()), t.TempDir(), t.TempDir(), t.TempDir())
+	if err == nil || !strings.Contains(err.Error(), "duplicate snapshot archive header") {
+		t.Fatalf("extractRaftSnapshotArchiveV1 err=%v, want duplicate header rejection", err)
+	}
+}
+
 func TestRaftSnapshotV1CopyFileContentDoesNotOverrunHeaderSize(t *testing.T) {
 	var buf bytes.Buffer
 	tw := tar.NewWriter(&buf)
@@ -142,6 +169,7 @@ func TestRaftSnapshotV1InstallEmptyTargetPreservesDigestAndValueLogPointers(t *t
 	if err != nil {
 		t.Fatalf("ExportRaftSnapshotV1: %v", err)
 	}
+	assertSnapshotArchiveHasNonEmptyApplyMetadata(t, snapshot.Payload)
 	assertSnapshotValueLogHasFile(t, raftcluster.ValueLogDir(sourceDir))
 	sourceDigest, err := sourceFSM.LogicalDigestV1(raftapply.LogicalDigestOptionsV1{})
 	if err != nil {
@@ -768,6 +796,61 @@ func rewriteRaftSnapshotArchiveHeaderForTest(t testing.TB, payload []byte, mut f
 		t.Fatalf("archive missing %s", raftcluster.RaftSnapshotArchiveManifestPathV1)
 	}
 	return out.Bytes()
+}
+
+func validRaftSnapshotArchiveHeaderBytesForTest(t testing.TB) []byte {
+	t.Helper()
+	manifest := raftcluster.SnapshotManifestV1{
+		Format:            raftcluster.SnapshotManifestFormatV1,
+		Version:           raftcluster.SnapshotManifestVersion1,
+		GroupID:           "group-a",
+		NodeID:            "node-a",
+		LastIncludedTerm:  1,
+		LastIncludedIndex: 1,
+		AppliedCommandLSN: 1,
+		LogicalDigestV1:   "0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20",
+		Scope: raftcluster.SnapshotScopeIdentityV1{
+			ScopeRule:     string(raftentry.ScopeRuleSingleGroupV1),
+			DatabaseScope: raftentry.DatabaseScopeDefaultV1,
+			CatalogScope:  raftentry.CatalogScopeDefaultV1,
+		},
+		CreatedAt: time.Unix(1700000000, 0).UTC(),
+	}
+	headerBytes, err := raftcluster.EncodeRaftSnapshotArchiveHeaderV1(raftcluster.NewRaftSnapshotArchiveHeaderV1(manifest))
+	if err != nil {
+		t.Fatalf("EncodeRaftSnapshotArchiveHeaderV1: %v", err)
+	}
+	return headerBytes
+}
+
+func assertSnapshotArchiveHasNonEmptyApplyMetadata(t testing.TB, payload []byte) {
+	t.Helper()
+	tr := tar.NewReader(bytes.NewReader(payload))
+	want := map[string]bool{
+		raftSnapshotApplyPrefixV1 + "/apply-progress-v1.log": false,
+		raftSnapshotApplyPrefixV1 + "/apply-results-v1.log":  false,
+	}
+	for {
+		header, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			t.Fatalf("Next archive entry: %v", err)
+		}
+		if _, ok := want[header.Name]; !ok {
+			continue
+		}
+		if header.Size == 0 {
+			t.Fatalf("snapshot archive apply metadata %q is zero-length", header.Name)
+		}
+		want[header.Name] = true
+	}
+	for name, found := range want {
+		if !found {
+			t.Fatalf("snapshot archive missing apply metadata %q", name)
+		}
+	}
 }
 
 func assertSnapshotApplyResult(tb testing.TB, result raftentry.ApplyResultV1, wantStatus raftentry.ApplyStatusV1, wantAffected int64) {

--- a/TreeDB/internal/raftfsm/raft_snapshot_test.go
+++ b/TreeDB/internal/raftfsm/raft_snapshot_test.go
@@ -236,6 +236,43 @@ func TestRaftSnapshotV1InstallReplacesSideStores(t *testing.T) {
 	}
 }
 
+func TestRaftSnapshotV1InstallReopensRestoredMainDBForRootLayout(t *testing.T) {
+	root := t.TempDir()
+	sourceRoot := filepath.Join(root, "source")
+	sourceDir := filepath.Join(sourceRoot, "maindb")
+	sourceDB := openRaftSnapshotFSMTestDB(t, sourceDir, true)
+	defer func() { _ = sourceDB.Close() }()
+	sourceFSM := openRaftSnapshotFSMForTestWithClusterDir(t, sourceDB, sourceRoot, true)
+	defer func() { _ = sourceFSM.Close() }()
+
+	sourceDoc := []byte(`{"_id":"u-large","name":"root-layout","payload":"` + stringsRepeatForSnapshotTest("x", 8192) + `"}`)
+	applySnapshotSourceEntries(t, sourceFSM, sourceDoc)
+	snapshot, err := sourceFSM.ExportRaftSnapshotV1()
+	if err != nil {
+		t.Fatalf("ExportRaftSnapshotV1: %v", err)
+	}
+
+	targetRoot := filepath.Join(root, "target")
+	targetDir := filepath.Join(targetRoot, "maindb")
+	targetDB := openRaftSnapshotFSMTestDB(t, targetDir, false)
+	targetFSM := openRaftSnapshotFSMForTestWithClusterDir(t, targetDB, targetRoot, true)
+	defer func() { _ = targetFSM.Close() }()
+
+	if err := targetFSM.InstallRaftSnapshotV1(bytes.NewReader(snapshot.Payload)); err != nil {
+		t.Fatalf("InstallRaftSnapshotV1: %v", err)
+	}
+	if err := targetFSM.VerifyInstalledSnapshotManifestV1(snapshot.Manifest); err != nil {
+		t.Fatalf("VerifyInstalledSnapshotManifestV1: %v", err)
+	}
+	assertSnapshotDocument(t, targetFSM, "u-large", sourceDoc)
+	if _, err := os.Stat(filepath.Join(targetRoot, "index.db")); !os.IsNotExist(err) {
+		t.Fatalf("restore reopened TreeDB root as backend DB: index.db stat err=%v", err)
+	}
+	if _, err := os.Stat(filepath.Join(targetDir, "index.db")); err != nil {
+		t.Fatalf("restored main DB index missing: %v", err)
+	}
+}
+
 func BenchmarkRaftSnapshotV1ExportInstall(b *testing.B) {
 	root := b.TempDir()
 	sourceDir := filepath.Join(root, "source")
@@ -290,6 +327,11 @@ func openRaftSnapshotFSMTestDB(t testing.TB, dir string, forceValuePointers bool
 
 func openRaftSnapshotFSMForTest(t testing.TB, db *backenddb.DB, dbDir string, forceValuePointers bool) *FSM {
 	t.Helper()
+	return openRaftSnapshotFSMForTestWithClusterDir(t, db, dbDir, forceValuePointers)
+}
+
+func openRaftSnapshotFSMForTestWithClusterDir(t testing.TB, db *backenddb.DB, clusterDir string, forceValuePointers bool) *FSM {
+	t.Helper()
 	restoreOpts := backenddb.Options{
 		CommandWAL:                   true,
 		CommandWALStatsScan:          true,
@@ -304,7 +346,7 @@ func openRaftSnapshotFSMForTest(t testing.TB, db *backenddb.DB, dbDir string, fo
 	}
 	fsm, err := Open(Options{
 		DB:                       db,
-		Cluster:                  validFSMClusterConfig(dbDir),
+		Cluster:                  validFSMClusterConfig(clusterDir),
 		SnapshotRestoreDBOptions: restoreOpts,
 		StoreOptions: raftapply.DurableApplyStoreOptions{
 			DisableSync:          true,

--- a/TreeDB/internal/raftfsm/raft_snapshot_test.go
+++ b/TreeDB/internal/raftfsm/raft_snapshot_test.go
@@ -1,0 +1,290 @@
+package raftfsm
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/collections"
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+	"github.com/snissn/gomap/TreeDB/internal/nativewire"
+	"github.com/snissn/gomap/TreeDB/internal/raftapply"
+	"github.com/snissn/gomap/TreeDB/internal/raftcluster"
+	"github.com/snissn/gomap/TreeDB/internal/raftentry"
+)
+
+func TestRaftSnapshotV1InstallEmptyTargetPreservesDigestAndValueLogPointers(t *testing.T) {
+	root := t.TempDir()
+	sourceDir := filepath.Join(root, "source")
+	sourceDB := openRaftSnapshotFSMTestDB(t, sourceDir, true)
+	defer func() { _ = sourceDB.Close() }()
+	sourceFSM := openRaftSnapshotFSMForTest(t, sourceDB, sourceDir, true)
+	defer func() { _ = sourceFSM.Close() }()
+
+	largeDoc := []byte(`{"_id":"u-large","name":"Ada","payload":"` + stringsRepeatForSnapshotTest("x", 8192) + `"}`)
+	applySnapshotSourceEntries(t, sourceFSM, largeDoc)
+	assertSnapshotValueLogHasFile(t, raftcluster.ValueLogDir(sourceDir))
+
+	snapshot, err := sourceFSM.ExportRaftSnapshotV1()
+	if err != nil {
+		t.Fatalf("ExportRaftSnapshotV1: %v", err)
+	}
+	sourceDigest, err := sourceFSM.LogicalDigestV1(raftapply.LogicalDigestOptionsV1{})
+	if err != nil {
+		t.Fatalf("source LogicalDigestV1: %v", err)
+	}
+
+	targetDir := filepath.Join(root, "target")
+	targetDB := openRaftSnapshotFSMTestDB(t, targetDir, false)
+	targetFSM := openRaftSnapshotFSMForTest(t, targetDB, targetDir, true)
+	defer func() { _ = targetFSM.Close() }()
+
+	if err := targetFSM.InstallRaftSnapshotV1(bytes.NewReader(snapshot.Payload)); err != nil {
+		t.Fatalf("InstallRaftSnapshotV1: %v", err)
+	}
+	if err := targetFSM.VerifyInstalledSnapshotManifestV1(snapshot.Manifest); err != nil {
+		t.Fatalf("VerifyInstalledSnapshotManifestV1: %v", err)
+	}
+	targetDigest, err := targetFSM.LogicalDigestV1(raftapply.LogicalDigestOptionsV1{})
+	if err != nil {
+		t.Fatalf("target LogicalDigestV1: %v", err)
+	}
+	if targetDigest != sourceDigest {
+		t.Fatalf("digest mismatch after snapshot install: target=%s source=%s", targetDigest.Hex(), sourceDigest.Hex())
+	}
+	assertSnapshotValueLogHasFile(t, raftcluster.ValueLogDir(targetDir))
+	assertSnapshotDocument(t, targetFSM, "u-large", largeDoc)
+}
+
+func TestRaftSnapshotV1InstallReplacesStaleReplica(t *testing.T) {
+	root := t.TempDir()
+	sourceDir := filepath.Join(root, "source")
+	sourceDB := openRaftSnapshotFSMTestDB(t, sourceDir, false)
+	defer func() { _ = sourceDB.Close() }()
+	sourceFSM := openRaftSnapshotFSMForTest(t, sourceDB, sourceDir, true)
+	defer func() { _ = sourceFSM.Close() }()
+
+	sourceDoc := []byte(`{"_id":"u-large","name":"source"}`)
+	applySnapshotSourceEntries(t, sourceFSM, sourceDoc)
+	snapshot, err := sourceFSM.ExportRaftSnapshotV1()
+	if err != nil {
+		t.Fatalf("ExportRaftSnapshotV1: %v", err)
+	}
+
+	targetDir := filepath.Join(root, "target")
+	targetDB := openRaftSnapshotFSMTestDB(t, targetDir, false)
+	targetFSM := openRaftSnapshotFSMForTest(t, targetDB, targetDir, true)
+	defer func() { _ = targetFSM.Close() }()
+	staleCreate := deterministicCreateCollectionEntry(t, "stale", "fsm:snapshot:stale:create")
+	result, err := targetFSM.ApplyCommittedEntryV1(committedCommand(1, 1, staleCreate))
+	if err != nil {
+		t.Fatalf("target stale ApplyCommittedEntryV1: %v result=%+v", err, result)
+	}
+	assertApplied(t, result, raftentry.ApplyStatusApplied, 1)
+
+	if err := targetFSM.InstallRaftSnapshotV1(bytes.NewReader(snapshot.Payload)); err != nil {
+		t.Fatalf("InstallRaftSnapshotV1 over stale target: %v", err)
+	}
+	if err := targetFSM.VerifyInstalledSnapshotManifestV1(snapshot.Manifest); err != nil {
+		t.Fatalf("VerifyInstalledSnapshotManifestV1: %v", err)
+	}
+	assertSnapshotDocument(t, targetFSM, "u-large", sourceDoc)
+	if _, err := collections.NewCollectionManager(targetFSM.db).OpenCollection("stale"); err == nil {
+		t.Fatalf("stale collection survived snapshot restore")
+	}
+}
+
+func TestRaftSnapshotV1TailReplayMatchesSourceDigest(t *testing.T) {
+	root := t.TempDir()
+	sourceDir := filepath.Join(root, "source")
+	sourceDB := openRaftSnapshotFSMTestDB(t, sourceDir, false)
+	defer func() { _ = sourceDB.Close() }()
+	sourceFSM := openRaftSnapshotFSMForTest(t, sourceDB, sourceDir, true)
+	defer func() { _ = sourceFSM.Close() }()
+
+	initialDoc := []byte(`{"_id":"u1","name":"before"}`)
+	applySnapshotSourceEntries(t, sourceFSM, initialDoc)
+	snapshot, err := sourceFSM.ExportRaftSnapshotV1()
+	if err != nil {
+		t.Fatalf("ExportRaftSnapshotV1: %v", err)
+	}
+	tailDoc := []byte(`{"_id":"u1","name":"after"}`)
+	tail := committedCommand(3, snapshot.Manifest.LastIncludedIndex+1, deterministicReplaceBatchEntry(t, "users", "fsm:snapshot:tail:replace", nativewire.DocumentFormatJSON, [][]byte{[]byte("u1")}, [][]byte{tailDoc}))
+	result, err := sourceFSM.ApplyCommittedEntryV1(tail)
+	if err != nil {
+		t.Fatalf("source tail ApplyCommittedEntryV1: %v result=%+v", err, result)
+	}
+	assertApplied(t, result, raftentry.ApplyStatusApplied, 1)
+	sourceDigest, err := sourceFSM.LogicalDigestV1(raftapply.LogicalDigestOptionsV1{})
+	if err != nil {
+		t.Fatalf("source LogicalDigestV1 after tail: %v", err)
+	}
+
+	targetDir := filepath.Join(root, "target")
+	targetDB := openRaftSnapshotFSMTestDB(t, targetDir, false)
+	targetFSM := openRaftSnapshotFSMForTest(t, targetDB, targetDir, true)
+	defer func() { _ = targetFSM.Close() }()
+	if err := targetFSM.InstallRaftSnapshotV1(bytes.NewReader(snapshot.Payload)); err != nil {
+		t.Fatalf("InstallRaftSnapshotV1: %v", err)
+	}
+	result, err = targetFSM.ApplyCommittedEntryV1(tail)
+	if err != nil {
+		t.Fatalf("target tail ApplyCommittedEntryV1: %v result=%+v", err, result)
+	}
+	assertApplied(t, result, raftentry.ApplyStatusApplied, 1)
+	targetDigest, err := targetFSM.LogicalDigestV1(raftapply.LogicalDigestOptionsV1{})
+	if err != nil {
+		t.Fatalf("target LogicalDigestV1 after tail: %v", err)
+	}
+	if targetDigest != sourceDigest {
+		t.Fatalf("digest mismatch after tail replay: target=%s source=%s", targetDigest.Hex(), sourceDigest.Hex())
+	}
+	assertSnapshotDocument(t, targetFSM, "u1", tailDoc)
+}
+
+func BenchmarkRaftSnapshotV1ExportInstall(b *testing.B) {
+	root := b.TempDir()
+	sourceDir := filepath.Join(root, "source")
+	sourceDB := openRaftSnapshotFSMTestDB(b, sourceDir, true)
+	defer func() { _ = sourceDB.Close() }()
+	sourceFSM := openRaftSnapshotFSMForTest(b, sourceDB, sourceDir, true)
+	defer func() { _ = sourceFSM.Close() }()
+	largeDoc := []byte(`{"_id":"u-large","name":"Ada","payload":"` + stringsRepeatForSnapshotTest("x", 8192) + `"}`)
+	applySnapshotSourceEntries(b, sourceFSM, largeDoc)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		targetDir := filepath.Join(root, "target", strconv.Itoa(i))
+		targetDB := openRaftSnapshotFSMTestDB(b, targetDir, true)
+		targetFSM := openRaftSnapshotFSMForTest(b, targetDB, targetDir, true)
+		b.StartTimer()
+		snapshot, err := sourceFSM.ExportRaftSnapshotV1()
+		if err != nil {
+			b.Fatalf("ExportRaftSnapshotV1: %v", err)
+		}
+		if err := targetFSM.InstallRaftSnapshotV1(bytes.NewReader(snapshot.Payload)); err != nil {
+			b.Fatalf("InstallRaftSnapshotV1: %v", err)
+		}
+		b.StopTimer()
+		_ = targetFSM.Close()
+	}
+}
+
+func openRaftSnapshotFSMTestDB(t testing.TB, dir string, forceValuePointers bool) *backenddb.DB {
+	t.Helper()
+	opts := backenddb.Options{
+		Dir:                          dir,
+		CommandWAL:                   true,
+		CommandWALStatsScan:          true,
+		CommandWALSegmentTargetBytes: 1 << 20,
+		DisableBackgroundPrune:       true,
+	}
+	if forceValuePointers {
+		opts.ValueLog = backenddb.ValueLogOptions{
+			PointerThreshold: 1,
+			ForcePointers:    true,
+		}
+	}
+	db, err := backenddb.Open(opts)
+	if err != nil {
+		t.Fatalf("Open DB: %v", err)
+	}
+	return db
+}
+
+func openRaftSnapshotFSMForTest(t testing.TB, db *backenddb.DB, dbDir string, forceValuePointers bool) *FSM {
+	t.Helper()
+	restoreOpts := backenddb.Options{
+		CommandWAL:                   true,
+		CommandWALStatsScan:          true,
+		CommandWALSegmentTargetBytes: 1 << 20,
+		DisableBackgroundPrune:       true,
+	}
+	if forceValuePointers {
+		restoreOpts.ValueLog = backenddb.ValueLogOptions{
+			PointerThreshold: 1,
+			ForcePointers:    true,
+		}
+	}
+	fsm, err := Open(Options{
+		DB:                       db,
+		Cluster:                  validFSMClusterConfig(dbDir),
+		SnapshotRestoreDBOptions: restoreOpts,
+		StoreOptions: raftapply.DurableApplyStoreOptions{
+			DisableSync:          true,
+			AllowInitialIndexGap: true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Open FSM: %v", err)
+	}
+	return fsm
+}
+
+func applySnapshotSourceEntries(tb testing.TB, fsm *FSM, doc []byte) {
+	tb.Helper()
+	create := deterministicCreateCollectionEntry(tb, "users", "fsm:snapshot:create:users")
+	insert := deterministicInsertBatchEntry(tb, "users", "fsm:snapshot:insert:users", nativewire.DocumentFormatJSON, [][]byte{[]byte("u1"), []byte("u-large")}, [][]byte{[]byte(`{"_id":"u1","name":"small"}`), doc})
+	results, err := fsm.ApplyCommittedEntriesV1([]CommittedEntryV1{
+		committedCommand(2, 1, create),
+		committedCommand(2, 2, insert),
+	})
+	if err != nil {
+		tb.Fatalf("ApplyCommittedEntriesV1: %v results=%+v", err, results)
+	}
+	if len(results) != 2 {
+		tb.Fatalf("results=%d, want 2", len(results))
+	}
+	assertSnapshotApplyResult(tb, results[0], raftentry.ApplyStatusApplied, 1)
+	assertSnapshotApplyResult(tb, results[1], raftentry.ApplyStatusApplied, 2)
+}
+
+func assertSnapshotApplyResult(tb testing.TB, result raftentry.ApplyResultV1, wantStatus raftentry.ApplyStatusV1, wantAffected int64) {
+	tb.Helper()
+	if result.Status != wantStatus || result.AffectedCount != wantAffected {
+		tb.Fatalf("apply result=%+v want status=%s affected=%d", result, wantStatus, wantAffected)
+	}
+}
+
+func assertSnapshotDocument(t *testing.T, fsm *FSM, id string, want []byte) {
+	t.Helper()
+	coll, err := collections.NewCollectionManager(fsm.db).OpenCollection("users")
+	if err != nil {
+		t.Fatalf("OpenCollection users: %v", err)
+	}
+	got, err := coll.Get([]byte(id))
+	if err != nil {
+		t.Fatalf("Get %s: %v", id, err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("document %s=%s want %s", id, got, want)
+	}
+}
+
+func assertSnapshotValueLogHasFile(t *testing.T, dir string) {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir value log %s: %v", dir, err)
+	}
+	for _, entry := range entries {
+		info, err := entry.Info()
+		if err == nil && info.Mode().IsRegular() && info.Size() > 0 {
+			return
+		}
+	}
+	t.Fatalf("value log %s has no non-empty segment files", dir)
+}
+
+func stringsRepeatForSnapshotTest(value string, count int) string {
+	var b strings.Builder
+	for i := 0; i < count; i++ {
+		b.WriteString(value)
+	}
+	return b.String()
+}

--- a/TreeDB/internal/raftfsm/raft_snapshot_test.go
+++ b/TreeDB/internal/raftfsm/raft_snapshot_test.go
@@ -4,6 +4,8 @@ import (
 	"archive/tar"
 	"bytes"
 	"context"
+	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -197,6 +199,41 @@ func TestRaftSnapshotV1InstallReplacesStaleFormatConfig(t *testing.T) {
 	assertSnapshotDocument(t, targetFSM, "u-large", sourceDoc)
 }
 
+func TestRaftSnapshotV1InstallRejectsCorruptArchiveBeforeReplacingLiveState(t *testing.T) {
+	root := t.TempDir()
+	sourceDir := filepath.Join(root, "source")
+	sourceDB := openRaftSnapshotFSMTestDB(t, sourceDir, false)
+	defer func() { _ = sourceDB.Close() }()
+	sourceFSM := openRaftSnapshotFSMForTest(t, sourceDB, sourceDir, true)
+	defer func() { _ = sourceFSM.Close() }()
+
+	sourceDoc := []byte(`{"_id":"u-large","name":"source-corrupt"}`)
+	applySnapshotSourceEntries(t, sourceFSM, sourceDoc)
+	snapshot, err := sourceFSM.ExportRaftSnapshotV1()
+	if err != nil {
+		t.Fatalf("ExportRaftSnapshotV1: %v", err)
+	}
+	corruptPayload := rewriteRaftSnapshotArchiveHeaderForTest(t, snapshot.Payload, func(header *raftcluster.RaftSnapshotArchiveHeaderV1) {
+		header.Manifest.LogicalDigestV1 = strings.Repeat("f", 64)
+	})
+
+	targetDir := filepath.Join(root, "target")
+	targetDB := openRaftSnapshotFSMTestDB(t, targetDir, false)
+	targetFSM := openRaftSnapshotFSMForTest(t, targetDB, targetDir, true)
+	defer func() { _ = targetFSM.Close() }()
+	targetDoc := []byte(`{"_id":"u-large","name":"target-before-corrupt"}`)
+	applySnapshotSourceEntries(t, targetFSM, targetDoc)
+
+	err = targetFSM.InstallRaftSnapshotV1(bytes.NewReader(corruptPayload))
+	if err == nil {
+		t.Fatal("InstallRaftSnapshotV1 accepted corrupt archive")
+	}
+	if code, ok := ErrorCodeOf(err); !ok || code != raftentry.ErrorRejectedConflictV1 {
+		t.Fatalf("InstallRaftSnapshotV1 err=%v code=%s, want rejected conflict", err, code)
+	}
+	assertSnapshotDocument(t, targetFSM, "u-large", targetDoc)
+}
+
 func TestRaftSnapshotV1TailReplayMatchesSourceDigest(t *testing.T) {
 	root := t.TempDir()
 	sourceDir := filepath.Join(root, "source")
@@ -328,6 +365,49 @@ func TestRaftSnapshotV1InstallReopensRestoredMainDBForRootLayout(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(targetDir, "index.db")); err != nil {
 		t.Fatalf("restored main DB index missing: %v", err)
+	}
+}
+
+func TestRaftSnapshotV1InstallPreservesFlatLayoutRaftMetadata(t *testing.T) {
+	root := t.TempDir()
+	sourceDir := filepath.Join(root, "source")
+	sourceDB := openRaftSnapshotFSMTestDB(t, sourceDir, true)
+	defer func() { _ = sourceDB.Close() }()
+	sourceFSM := openRaftSnapshotFSMForTest(t, sourceDB, sourceDir, true)
+	defer func() { _ = sourceFSM.Close() }()
+
+	sourceDoc := []byte(`{"_id":"u-large","name":"flat-layout","payload":"` + stringsRepeatForSnapshotTest("x", 8192) + `"}`)
+	applySnapshotSourceEntries(t, sourceFSM, sourceDoc)
+	snapshot, err := sourceFSM.ExportRaftSnapshotV1()
+	if err != nil {
+		t.Fatalf("ExportRaftSnapshotV1: %v", err)
+	}
+
+	targetDir := filepath.Join(root, "target")
+	targetDB := openRaftSnapshotFSMTestDB(t, targetDir, false)
+	targetFSM := openRaftSnapshotFSMForTest(t, targetDB, targetDir, true)
+	defer func() { _ = targetFSM.Close() }()
+	raftSentinel := filepath.Join(targetDir, "raftcluster", "nodes", "node-a", "groups", "default", "log", "sentinel")
+	if err := os.MkdirAll(filepath.Dir(raftSentinel), 0o700); err != nil {
+		t.Fatalf("MkdirAll raft sentinel: %v", err)
+	}
+	if err := os.WriteFile(raftSentinel, []byte("local-raft-log"), 0o600); err != nil {
+		t.Fatalf("WriteFile raft sentinel: %v", err)
+	}
+
+	if err := targetFSM.InstallRaftSnapshotV1(bytes.NewReader(snapshot.Payload)); err != nil {
+		t.Fatalf("InstallRaftSnapshotV1: %v", err)
+	}
+	if err := targetFSM.VerifyInstalledSnapshotManifestV1(snapshot.Manifest); err != nil {
+		t.Fatalf("VerifyInstalledSnapshotManifestV1: %v", err)
+	}
+	assertSnapshotDocument(t, targetFSM, "u-large", sourceDoc)
+	got, err := os.ReadFile(raftSentinel)
+	if err != nil {
+		t.Fatalf("ReadFile raft sentinel after restore: %v", err)
+	}
+	if string(got) != "local-raft-log" {
+		t.Fatalf("raft sentinel=%q want local-raft-log", got)
 	}
 }
 
@@ -527,6 +607,54 @@ func applySnapshotSourceEntries(tb testing.TB, fsm *FSM, doc []byte) {
 	}
 	assertSnapshotApplyResult(tb, results[0], raftentry.ApplyStatusApplied, 1)
 	assertSnapshotApplyResult(tb, results[1], raftentry.ApplyStatusApplied, 2)
+}
+
+func rewriteRaftSnapshotArchiveHeaderForTest(t testing.TB, payload []byte, mut func(*raftcluster.RaftSnapshotArchiveHeaderV1)) []byte {
+	t.Helper()
+	tr := tar.NewReader(bytes.NewReader(payload))
+	var out bytes.Buffer
+	tw := tar.NewWriter(&out)
+	found := false
+	for {
+		header, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			t.Fatalf("Next archive entry: %v", err)
+		}
+		raw, err := io.ReadAll(tr)
+		if err != nil {
+			t.Fatalf("ReadAll archive entry %q: %v", header.Name, err)
+		}
+		next := *header
+		if header.Name == raftcluster.RaftSnapshotArchiveManifestPathV1 {
+			decoded, err := raftcluster.DecodeRaftSnapshotArchiveHeaderV1(raw, raftcluster.SnapshotScopeIdentityV1{})
+			if err != nil {
+				t.Fatalf("DecodeRaftSnapshotArchiveHeaderV1: %v", err)
+			}
+			mut(&decoded)
+			raw, err = raftcluster.EncodeRaftSnapshotArchiveHeaderV1(decoded)
+			if err != nil {
+				t.Fatalf("EncodeRaftSnapshotArchiveHeaderV1: %v", err)
+			}
+			next.Size = int64(len(raw))
+			found = true
+		}
+		if err := tw.WriteHeader(&next); err != nil {
+			t.Fatalf("WriteHeader archive entry %q: %v", next.Name, err)
+		}
+		if _, err := tw.Write(raw); err != nil {
+			t.Fatalf("Write archive entry %q: %v", next.Name, err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("Close rewritten archive: %v", err)
+	}
+	if !found {
+		t.Fatalf("archive missing %s", raftcluster.RaftSnapshotArchiveManifestPathV1)
+	}
+	return out.Bytes()
 }
 
 func assertSnapshotApplyResult(tb testing.TB, result raftentry.ApplyResultV1, wantStatus raftentry.ApplyStatusV1, wantAffected int64) {

--- a/TreeDB/internal/raftfsm/raft_snapshot_test.go
+++ b/TreeDB/internal/raftfsm/raft_snapshot_test.go
@@ -69,6 +69,30 @@ func TestRaftSnapshotV1ScratchDirsUseDestinationParents(t *testing.T) {
 	}
 }
 
+func TestRaftSnapshotV1ExtractRejectsOversizedArchiveHeader(t *testing.T) {
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	headerSize := int64(raftcluster.RaftSnapshotArchiveHeaderMaxBytes + 1)
+	if err := tw.WriteHeader(&tar.Header{
+		Name: raftcluster.RaftSnapshotArchiveManifestPathV1,
+		Mode: 0o600,
+		Size: headerSize,
+	}); err != nil {
+		t.Fatalf("WriteHeader oversized manifest: %v", err)
+	}
+	if _, err := tw.Write(bytes.Repeat([]byte("x"), int(headerSize))); err != nil {
+		t.Fatalf("Write oversized manifest: %v", err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("Close archive: %v", err)
+	}
+
+	_, err := extractRaftSnapshotArchiveV1(bytes.NewReader(buf.Bytes()), t.TempDir(), t.TempDir(), t.TempDir())
+	if err == nil || !strings.Contains(err.Error(), "snapshot archive header") {
+		t.Fatalf("extractRaftSnapshotArchiveV1 err=%v want oversized header rejection", err)
+	}
+}
+
 func TestRaftSnapshotV1InstallEmptyTargetPreservesDigestAndValueLogPointers(t *testing.T) {
 	root := t.TempDir()
 	sourceDir := filepath.Join(root, "source")
@@ -411,6 +435,47 @@ func TestRaftSnapshotV1InstallPreservesFlatLayoutRaftMetadata(t *testing.T) {
 	}
 }
 
+func TestRaftSnapshotV1InstallDisabledSideStoresDoesNotTouchParentSideStores(t *testing.T) {
+	root := t.TempDir()
+	sourceDir := filepath.Join(root, "source", "maindb")
+	sourceDB := openRaftSnapshotFSMTestDBWithOptions(t, sourceDir, false, true)
+	defer func() { _ = sourceDB.Close() }()
+	sourceFSM := openRaftSnapshotFSMForTestWithOptions(t, sourceDB, sourceDir, false, true)
+	defer func() { _ = sourceFSM.Close() }()
+
+	sourceDoc := []byte(`{"_id":"u-large","name":"disabled-side-stores"}`)
+	applySnapshotSourceEntries(t, sourceFSM, sourceDoc)
+	snapshot, err := sourceFSM.ExportRaftSnapshotV1()
+	if err != nil {
+		t.Fatalf("ExportRaftSnapshotV1: %v", err)
+	}
+
+	targetParent := filepath.Join(root, "target")
+	targetDir := filepath.Join(targetParent, "maindb")
+	targetDB := openRaftSnapshotFSMTestDBWithOptions(t, targetDir, false, true)
+	targetFSM := openRaftSnapshotFSMForTestWithOptions(t, targetDB, targetDir, false, true)
+	defer func() { _ = targetFSM.Close() }()
+	parentSideStoreSentinel := filepath.Join(targetParent, "dictdb", "sentinel")
+	if err := os.MkdirAll(filepath.Dir(parentSideStoreSentinel), 0o700); err != nil {
+		t.Fatalf("MkdirAll parent side-store sentinel: %v", err)
+	}
+	if err := os.WriteFile(parentSideStoreSentinel, []byte("parent-side-store"), 0o600); err != nil {
+		t.Fatalf("WriteFile parent side-store sentinel: %v", err)
+	}
+
+	if err := targetFSM.InstallRaftSnapshotV1(bytes.NewReader(snapshot.Payload)); err != nil {
+		t.Fatalf("InstallRaftSnapshotV1: %v", err)
+	}
+	assertSnapshotDocument(t, targetFSM, "u-large", sourceDoc)
+	got, err := os.ReadFile(parentSideStoreSentinel)
+	if err != nil {
+		t.Fatalf("ReadFile parent side-store sentinel after restore: %v", err)
+	}
+	if string(got) != "parent-side-store" {
+		t.Fatalf("parent side-store sentinel=%q want parent-side-store", got)
+	}
+}
+
 func TestRaftSnapshotV1RestoreWiresRestoredSideStoreLookups(t *testing.T) {
 	root := t.TempDir()
 	mainDir := filepath.Join(root, "maindb")
@@ -537,12 +602,18 @@ func BenchmarkRaftSnapshotV1ExportInstall(b *testing.B) {
 
 func openRaftSnapshotFSMTestDB(t testing.TB, dir string, forceValuePointers bool) *backenddb.DB {
 	t.Helper()
+	return openRaftSnapshotFSMTestDBWithOptions(t, dir, forceValuePointers, false)
+}
+
+func openRaftSnapshotFSMTestDBWithOptions(t testing.TB, dir string, forceValuePointers, disableSideStores bool) *backenddb.DB {
+	t.Helper()
 	opts := backenddb.Options{
 		Dir:                          dir,
 		CommandWAL:                   true,
 		CommandWALStatsScan:          true,
 		CommandWALSegmentTargetBytes: 1 << 20,
 		DisableBackgroundPrune:       true,
+		DisableSideStores:            disableSideStores,
 	}
 	if forceValuePointers {
 		opts.ValueLog = backenddb.ValueLogOptions{
@@ -564,11 +635,17 @@ func openRaftSnapshotFSMForTest(t testing.TB, db *backenddb.DB, dbDir string, fo
 
 func openRaftSnapshotFSMForTestWithClusterDir(t testing.TB, db *backenddb.DB, clusterDir string, forceValuePointers bool) *FSM {
 	t.Helper()
+	return openRaftSnapshotFSMForTestWithOptions(t, db, clusterDir, forceValuePointers, false)
+}
+
+func openRaftSnapshotFSMForTestWithOptions(t testing.TB, db *backenddb.DB, clusterDir string, forceValuePointers, disableSideStores bool) *FSM {
+	t.Helper()
 	restoreOpts := backenddb.Options{
 		CommandWAL:                   true,
 		CommandWALStatsScan:          true,
 		CommandWALSegmentTargetBytes: 1 << 20,
 		DisableBackgroundPrune:       true,
+		DisableSideStores:            disableSideStores,
 	}
 	if forceValuePointers {
 		restoreOpts.ValueLog = backenddb.ValueLogOptions{
@@ -576,9 +653,11 @@ func openRaftSnapshotFSMForTestWithClusterDir(t testing.TB, db *backenddb.DB, cl
 			ForcePointers:    true,
 		}
 	}
+	cluster := validFSMClusterConfig(clusterDir)
+	cluster.DisableSideStores = disableSideStores
 	fsm, err := Open(Options{
 		DB:                       db,
-		Cluster:                  validFSMClusterConfig(clusterDir),
+		Cluster:                  cluster,
 		SnapshotRestoreDBOptions: restoreOpts,
 		StoreOptions: raftapply.DurableApplyStoreOptions{
 			DisableSync:          true,

--- a/TreeDB/internal/raftfsm/raft_snapshot_test.go
+++ b/TreeDB/internal/raftfsm/raft_snapshot_test.go
@@ -145,6 +145,55 @@ func TestRaftSnapshotV1TailReplayMatchesSourceDigest(t *testing.T) {
 	assertSnapshotDocument(t, targetFSM, "u1", tailDoc)
 }
 
+func TestRaftSnapshotV1InstallReplacesSideStores(t *testing.T) {
+	root := t.TempDir()
+	sourceRoot := filepath.Join(root, "source")
+	sourceDir := filepath.Join(sourceRoot, "maindb")
+	sourceDB := openRaftSnapshotFSMTestDB(t, sourceDir, false)
+	defer func() { _ = sourceDB.Close() }()
+	sourceFSM := openRaftSnapshotFSMForTest(t, sourceDB, sourceDir, true)
+	defer func() { _ = sourceFSM.Close() }()
+	applySnapshotSourceEntries(t, sourceFSM, []byte(`{"_id":"u-large","name":"source"}`))
+	sourceDict := filepath.Join(sourceRoot, "dictdb")
+	if err := os.MkdirAll(sourceDict, 0o700); err != nil {
+		t.Fatalf("MkdirAll source dictdb: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sourceDict, "sentinel"), []byte("source-side-store"), 0o600); err != nil {
+		t.Fatalf("WriteFile source sentinel: %v", err)
+	}
+	snapshot, err := sourceFSM.ExportRaftSnapshotV1()
+	if err != nil {
+		t.Fatalf("ExportRaftSnapshotV1: %v", err)
+	}
+
+	targetRoot := filepath.Join(root, "target")
+	targetDir := filepath.Join(targetRoot, "maindb")
+	targetDB := openRaftSnapshotFSMTestDB(t, targetDir, false)
+	targetFSM := openRaftSnapshotFSMForTest(t, targetDB, targetDir, true)
+	defer func() { _ = targetFSM.Close() }()
+	staleTemplate := filepath.Join(targetRoot, "templatedb")
+	if err := os.MkdirAll(staleTemplate, 0o700); err != nil {
+		t.Fatalf("MkdirAll target templatedb: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(staleTemplate, "stale"), []byte("stale-side-store"), 0o600); err != nil {
+		t.Fatalf("WriteFile target stale side store: %v", err)
+	}
+
+	if err := targetFSM.InstallRaftSnapshotV1(bytes.NewReader(snapshot.Payload)); err != nil {
+		t.Fatalf("InstallRaftSnapshotV1: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(targetRoot, "dictdb", "sentinel"))
+	if err != nil {
+		t.Fatalf("ReadFile restored side-store sentinel: %v", err)
+	}
+	if string(got) != "source-side-store" {
+		t.Fatalf("restored side-store sentinel=%q", got)
+	}
+	if _, err := os.Stat(staleTemplate); !os.IsNotExist(err) {
+		t.Fatalf("stale target side store exists after restore: err=%v", err)
+	}
+}
+
 func BenchmarkRaftSnapshotV1ExportInstall(b *testing.B) {
 	root := b.TempDir()
 	sourceDir := filepath.Join(root, "source")

--- a/TreeDB/internal/raftfsm/raft_snapshot_test.go
+++ b/TreeDB/internal/raftfsm/raft_snapshot_test.go
@@ -26,12 +26,12 @@ func TestRaftSnapshotV1InstallEmptyTargetPreservesDigestAndValueLogPointers(t *t
 
 	largeDoc := []byte(`{"_id":"u-large","name":"Ada","payload":"` + stringsRepeatForSnapshotTest("x", 8192) + `"}`)
 	applySnapshotSourceEntries(t, sourceFSM, largeDoc)
-	assertSnapshotValueLogHasFile(t, raftcluster.ValueLogDir(sourceDir))
 
 	snapshot, err := sourceFSM.ExportRaftSnapshotV1()
 	if err != nil {
 		t.Fatalf("ExportRaftSnapshotV1: %v", err)
 	}
+	assertSnapshotValueLogHasFile(t, raftcluster.ValueLogDir(sourceDir))
 	sourceDigest, err := sourceFSM.LogicalDigestV1(raftapply.LogicalDigestOptionsV1{})
 	if err != nil {
 		t.Fatalf("source LogicalDigestV1: %v", err)

--- a/TreeDB/internal/raftfsm/read_barrier.go
+++ b/TreeDB/internal/raftfsm/read_barrier.go
@@ -14,6 +14,11 @@ func (f *FSM) AppliedProgress(ctx context.Context) (raftcluster.AppliedProgress,
 	if err := ctx.Err(); err != nil {
 		return progress, err
 	}
+	if f == nil {
+		return progress, codedError(raftentry.ErrorUnsafeDurabilityModeV1, "FSM is not open")
+	}
+	f.mu.RLock()
+	defer f.mu.RUnlock()
 	if f == nil || f.db == nil || f.progress == nil {
 		return progress, codedError(raftentry.ErrorUnsafeDurabilityModeV1, "FSM is not open")
 	}

--- a/TreeDB/internal/raftfsm/read_barrier.go
+++ b/TreeDB/internal/raftfsm/read_barrier.go
@@ -19,6 +19,11 @@ func (f *FSM) AppliedProgress(ctx context.Context) (raftcluster.AppliedProgress,
 	}
 	f.mu.RLock()
 	defer f.mu.RUnlock()
+	return f.appliedProgressLocked()
+}
+
+func (f *FSM) appliedProgressLocked() (raftcluster.AppliedProgress, error) {
+	progress := f.appliedProgressIdentity()
 	if f == nil || f.db == nil || f.progress == nil {
 		return progress, codedError(raftentry.ErrorUnsafeDurabilityModeV1, "FSM is not open")
 	}

--- a/TreeDB/internal/raftfsm/recovery_status.go
+++ b/TreeDB/internal/raftfsm/recovery_status.go
@@ -32,13 +32,15 @@ func (f *FSM) RecoveryStatusV1(ctx context.Context, opts RecoveryStatusOptionsV1
 	if f == nil {
 		return status, codedError(raftentry.ErrorUnsafeDurabilityModeV1, "FSM is not open")
 	}
+	f.mu.RLock()
+	defer f.mu.RUnlock()
 	if f.closed {
 		return status, codedError(raftentry.ErrorUnsafeDurabilityModeV1, "FSM is closed")
 	}
 	if f.db == nil || f.progress == nil || f.results == nil {
 		return status, codedError(raftentry.ErrorUnsafeDurabilityModeV1, "FSM is not open")
 	}
-	progress, err := f.AppliedProgress(ctx)
+	progress, err := f.appliedProgressLocked()
 	if err != nil {
 		return status, err
 	}
@@ -63,7 +65,7 @@ func (f *FSM) RecoveryStatusV1(ctx context.Context, opts RecoveryStatusOptionsV1
 	}
 	status.TailTargetIndex = opts.TailTargetIndex
 
-	if err := f.verifyRecoverySnapshotManifestV1(manifest); err != nil {
+	if err := f.verifyRecoverySnapshotManifestV1Locked(manifest); err != nil {
 		status.SnapshotState = raftcluster.RecoverySnapshotStateManifestRejectedV1
 		status.TailState = raftcluster.RecoveryTailStateUnknownV1
 		status.Errors = append(status.Errors, err.Error())
@@ -86,8 +88,8 @@ func (f *FSM) RecoveryStatusV1(ctx context.Context, opts RecoveryStatusOptionsV1
 	return finalizeRecoveryStatus(status), nil
 }
 
-func (f *FSM) verifyRecoverySnapshotManifestV1(manifest raftcluster.SnapshotManifestV1) error {
-	if err := f.VerifyInstalledSnapshotManifestV1(manifest); err == nil {
+func (f *FSM) verifyRecoverySnapshotManifestV1Locked(manifest raftcluster.SnapshotManifestV1) error {
+	if err := f.verifyInstalledSnapshotManifestV1Locked(manifest); err == nil {
 		return nil
 	}
 	if err := manifest.Validate(f.snapshotScopeIdentityV1()); err != nil {

--- a/TreeDB/internal/raftfsm/snapshot_install.go
+++ b/TreeDB/internal/raftfsm/snapshot_install.go
@@ -13,6 +13,15 @@ func (f *FSM) VerifyInstalledSnapshotManifestV1(manifest raftcluster.SnapshotMan
 	if f == nil {
 		return codedError(raftentry.ErrorUnsafeDurabilityModeV1, "FSM is not open")
 	}
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	return f.verifyInstalledSnapshotManifestV1Locked(manifest)
+}
+
+func (f *FSM) verifyInstalledSnapshotManifestV1Locked(manifest raftcluster.SnapshotManifestV1) error {
+	if f == nil {
+		return codedError(raftentry.ErrorUnsafeDurabilityModeV1, "FSM is not open")
+	}
 	if f.closed {
 		return codedError(raftentry.ErrorUnsafeDurabilityModeV1, "FSM is closed")
 	}
@@ -45,7 +54,7 @@ func (f *FSM) VerifyInstalledSnapshotManifestV1(manifest raftcluster.SnapshotMan
 	if localLSN != manifest.AppliedCommandLSN {
 		return codedError(raftentry.ErrorRejectedConflictV1, "snapshot manifest AppliedCommandLSN %d does not match local coverage %d", manifest.AppliedCommandLSN, localLSN)
 	}
-	digest, err := f.LogicalDigestV1(raftapply.LogicalDigestOptionsV1{
+	digest, err := f.logicalDigestV1Locked(raftapply.LogicalDigestOptionsV1{
 		ScopeRule:     f.scopeRule,
 		DatabaseScope: f.database,
 		CatalogScope:  f.catalog,

--- a/TreeDB/internal/raftfsm/snapshot_manifest.go
+++ b/TreeDB/internal/raftfsm/snapshot_manifest.go
@@ -21,6 +21,15 @@ func (f *FSM) ExportSnapshotManifestV1(opts SnapshotManifestExportOptionsV1) (ra
 	if f == nil {
 		return raftcluster.SnapshotManifestV1{}, codedError(raftentry.ErrorUnsafeDurabilityModeV1, "FSM is not open")
 	}
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	return f.exportSnapshotManifestV1Locked(opts)
+}
+
+func (f *FSM) exportSnapshotManifestV1Locked(opts SnapshotManifestExportOptionsV1) (raftcluster.SnapshotManifestV1, error) {
+	if f == nil {
+		return raftcluster.SnapshotManifestV1{}, codedError(raftentry.ErrorUnsafeDurabilityModeV1, "FSM is not open")
+	}
 	if f.closed {
 		return raftcluster.SnapshotManifestV1{}, codedError(raftentry.ErrorUnsafeDurabilityModeV1, "FSM is closed")
 	}
@@ -41,7 +50,7 @@ func (f *FSM) ExportSnapshotManifestV1(opts SnapshotManifestExportOptionsV1) (ra
 	if localLSN != record.AppliedCommandLSN {
 		return raftcluster.SnapshotManifestV1{}, codedError(raftentry.ErrorUnsafeDurabilityModeV1, "local AppliedCommandLSN coverage %d does not match snapshot progress metadata %d", localLSN, record.AppliedCommandLSN)
 	}
-	digest, err := f.LogicalDigestV1(raftapply.LogicalDigestOptionsV1{
+	digest, err := f.logicalDigestV1Locked(raftapply.LogicalDigestOptionsV1{
 		ScopeRule:     f.scopeRule,
 		DatabaseScope: f.database,
 		CatalogScope:  f.catalog,


### PR DESCRIPTION
## Summary

- Add the production TreeDB Raft snapshot path for HashiCorp Raft rejoin/log truncation: export/install TreeDB main storage, persistent value-log state, side stores, and durable apply metadata while excluding Raft log/stable/snapshot storage.
- Harden snapshot restore safety: side-store lookups are rewired after restore, main placement knobs are scrubbed from side-store reopen options, apply scratch dirs are filesystem-local, flat TreeDB layouts preserve local Raft metadata, disabled side-store layouts do not touch sibling side-store directories, and extracted scratch state is verified before live files are swapped.
- Harden snapshot consistency: payload headers must match outer manifests, CreatedAt equality ignores monotonic-clock encoding differences, persisted HashiCorp snapshot term/index boundaries must match the TreeDB manifest, archive manifest reads are bounded, duplicate archive manifests are rejected, durable apply metadata is flushed before archiving, and mismatches fail closed with sink cancellation.

## Dependency gates

- Closes #3442. Part of the #3045 / #3044 Raft graph.
- Predecessors #3443, #3440, #3441, and #3444 are merged into `main`.
- Current base: `main` at `eeb6bd16280575e84de042cf66872ba58f06c79f`.
- Current head: `02bde93aa0924f16fee02e3ad1001f6e2764af1e`.
- Follow-up #3454 tracks full streaming snapshot archives without archive-wide buffering. This PR removes redundant archive clones and adds boundary/pre-swap/header/apply-metadata safety, but intentionally does not change the production archive lifecycle enough to close #3454.

## Validation

- `TMPDIR=/mnt/fast4tb/tmp/gomap-test-tmp GOCACHE=/mnt/fast4tb/tmp/go-cache GOMODCACHE=/mnt/fast4tb/tmp/go-mod-cache GOWORK=off GOMEMLIMIT=4GiB GOMAXPROCS=2 go test -p 1 ./TreeDB/internal/raftapply ./TreeDB/internal/raftfsm ./TreeDB/internal/raftcluster -run 'Test(RaftSnapshotV1|HashicorpRaftProviderSnapshotRejoinsLaggingFollowerAndCompactsLogs|DurableApply|RecoveryStatusV1BeforeSnapshotInstallIsUnsafe)' -count=1`
  - Pass: `raftapply 0.197s`, `raftfsm 1.434s`, `raftcluster 0.688s`.
- `TMPDIR=/mnt/fast4tb/tmp/gomap-test-tmp GOCACHE=/mnt/fast4tb/tmp/go-cache GOMODCACHE=/mnt/fast4tb/tmp/go-mod-cache GOWORK=off GOMEMLIMIT=4GiB GOMAXPROCS=2 go test -p 1 ./TreeDB/internal/raftcluster ./TreeDB/internal/raftfsm -run 'Test(RaftSnapshotV1Validate|RaftSnapshotV1ExportRejects|RaftSnapshotV1RestoreScrubs|RaftSnapshotV1InstallRejectsCorruptArchiveBeforeReplacingLiveState|RaftSnapshotV1InstallEmptyTargetPreservesDigestAndValueLogPointers|RaftSnapshotV1RestoreWiresRestoredSideStoreLookups)' -count=1`
  - Pass: `raftcluster 0.004s`, `raftfsm 0.689s`.
- `TMPDIR=/mnt/fast4tb/tmp/gomap-test-tmp GOCACHE=/mnt/fast4tb/tmp/go-cache GOMODCACHE=/mnt/fast4tb/tmp/go-mod-cache GOWORK=off GOMEMLIMIT=4GiB GOMAXPROCS=2 go test -p 1 ./TreeDB/internal/raftfsm ./TreeDB/internal/raftcluster ./TreeDB/internal/raftharness ./TreeDB/nativewire ./TreeDB/mongo_gateway ./TreeDB/internal/raftplacement -count=1`
  - Pass: `raftfsm 4.255s`, `raftcluster 10.333s`, `raftharness 4.980s`, `nativewire 3.414s`, `mongo_gateway 11.094s`, `raftplacement 0.004s`.
- `TMPDIR=/mnt/fast4tb/tmp/gomap-test-tmp GOCACHE=/mnt/fast4tb/tmp/go-cache GOMODCACHE=/mnt/fast4tb/tmp/go-mod-cache GOWORK=off GOMEMLIMIT=4GiB GOMAXPROCS=2 go test -race -p 1 ./TreeDB/internal/raftcluster -run TestHashicorpRaftProviderSnapshotRejoinsLaggingFollowerAndCompactsLogs -count=1`
  - Pass: `raftcluster 2.190s`.
- `TMPDIR=/mnt/fast4tb/tmp/gomap-test-tmp GOCACHE=/mnt/fast4tb/tmp/go-cache GOMODCACHE=/mnt/fast4tb/tmp/go-mod-cache GOWORK=off GOMEMLIMIT=4GiB GOMAXPROCS=2 go test -p 1 ./TreeDB/internal/raftfsm -run '^$' -bench '^BenchmarkRaftSnapshotV1ExportInstall$' -benchtime=5x -count=1 -benchmem`
  - Pass: `BenchmarkRaftSnapshotV1ExportInstall-2`, `91,731,533 ns/op`, `37,438,905 B/op`, `4,243 allocs/op`.
- `gofmt -w TreeDB/internal/raftcluster/snapshot_manifest.go TreeDB/internal/raftcluster/snapshot_manifest_test.go TreeDB/internal/raftfsm/raft_snapshot.go TreeDB/internal/raftfsm/raft_snapshot_side_stores.go TreeDB/internal/raftfsm/raft_snapshot_test.go && git diff --check`
  - Pass with no output.

## CI and review status

- Latest-head CI is running for `02bde93aa0924f16fee02e3ad1001f6e2764af1e`.
- Previous head `2f3bc3a4a5f136926a39b04d68061b2a8ff0c015` had only `windows-core-2` failing. The failure was `TestRaftSnapshotV1InstallRejectsCorruptArchiveBeforeReplacingLiveState` TempDir cleanup on Windows because the test kept a caller-owned target DB open after failed install. The latest head adds the missing close and the focused regression passed locally.
- Codex/Copilot/CodeRabbit findings through the latest local review pass are fixed or explicitly tracked by follow-up #3454.

## Notes

- Snapshot export explicitly syncs durable apply metadata before archiving so an open FSM cannot export zero-length apply metadata on platforms with stricter file visibility semantics.
- Snapshot install verifies extracted scratch state before closing/replacing the live FSM, then verifies again after reopen.
- No TreeDB on-disk format changes were made.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for creating, exporting, and restoring Raft snapshots.
  * Snapshot restores now preserve cluster state, durable progress, and supported side data.
  * Added snapshot status reporting, including whether log compaction occurred.

* **Bug Fixes**
  * Improved safety when handling snapshots and recovery under concurrent access.
  * Strengthened validation to reject corrupted or mismatched snapshots.
  * Fixed follower recovery so lagging nodes can rejoin cleanly after snapshot compaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->