### PR TITLE
feat(treedb): expose snapshot range iteration

### DIFF
--- a/TreeDB/caching/conditional_txn.go
+++ b/TreeDB/caching/conditional_txn.go
@@ -241,6 +241,17 @@ func (tx *ConditionalTxn) RequireReadVersion(key []byte, revision page.EntryRevi
 	return tx.recordRead(key, revision, found)
 }
 
+// RecordReadVersion records an opening-snapshot read precondition without
+// validating current state. It is for transaction-owned snapshot reads that
+// should keep returning the pinned view and defer conflicts until commit.
+func (tx *ConditionalTxn) RecordReadVersion(key []byte, revision page.EntryRevision, found bool) error {
+	if err := tx.ensureOpen(); err != nil {
+		return err
+	}
+	key = normalizeRawKVPointKey(key)
+	return tx.recordRead(key, revision, found)
+}
+
 func (tx *ConditionalTxn) validateCurrentReadVersion(key []byte, revision page.EntryRevision, found bool) error {
 	currentRevision, currentFound, err := tx.currentReadRevision(key)
 	if err != nil {
@@ -469,15 +480,11 @@ func (tx *ConditionalTxn) finish() error {
 	tx.id = 0
 	var err error
 	if tx.snap != nil {
-		if closeErr := tx.snap.Close(); err == nil {
-			err = closeErr
-		}
+		err = errors.Join(err, tx.snap.Close())
 		tx.snap = nil
 	}
 	if tx.batch != nil {
-		if closeErr := tx.batch.Close(); err == nil {
-			err = closeErr
-		}
+		err = errors.Join(err, tx.batch.Close())
 		tx.batch = nil
 	}
 	if db != nil && id != 0 {

--- a/TreeDB/caching/conditional_txn.go
+++ b/TreeDB/caching/conditional_txn.go
@@ -243,19 +243,22 @@ func (tx *ConditionalTxn) RequireReadVersion(key []byte, revision page.EntryRevi
 func (tx *ConditionalTxn) validateCurrentReadVersion(key []byte, revision page.EntryRevision, found bool) error {
 	_, currentRevision, err := tx.db.GetVersionedAppend(key, nil)
 	if errors.Is(err, tree.ErrKeyNotFound) {
-		return conditionalReadVersionMismatch(revision, found, currentRevision, false)
+		return tx.validateCurrentReadVersionMatch(key, revision, found, currentRevision, false)
 	}
 	if err != nil {
 		return err
 	}
-	return conditionalReadVersionMismatch(revision, found, currentRevision, true)
+	return tx.validateCurrentReadVersionMatch(key, revision, found, currentRevision, true)
 }
 
-func conditionalReadVersionMismatch(wantRevision page.EntryRevision, wantFound bool, gotRevision page.EntryRevision, gotFound bool) error {
-	if wantFound != gotFound || wantRevision != gotRevision {
-		return backenddb.ErrConcurrentModification
+func (tx *ConditionalTxn) validateCurrentReadVersionMatch(key []byte, wantRevision page.EntryRevision, wantFound bool, gotRevision page.EntryRevision, gotFound bool) error {
+	if wantFound == gotFound && wantRevision == gotRevision {
+		return nil
 	}
-	return nil
+	if tx.db.conditionalReadKeyChangedSince(tx.startSeq, key) {
+		return nil
+	}
+	return backenddb.ErrConcurrentModification
 }
 
 func (tx *ConditionalTxn) getCommittedVersionedAppend(key, dst []byte) ([]byte, page.EntryRevision, error) {

--- a/TreeDB/caching/conditional_txn.go
+++ b/TreeDB/caching/conditional_txn.go
@@ -29,6 +29,7 @@ const (
 type ConditionalTxn struct {
 	db       *DB
 	batch    *Batch
+	snap     *Snapshot
 	id       uint64
 	startSeq uint64
 
@@ -74,6 +75,17 @@ func (db *DB) NewConditionalTxn() (*ConditionalTxn, error) {
 // InitConditionalTxn initializes tx as a cached conditional transaction.
 // Callers must pass zero-value or closed transaction storage.
 func (db *DB) InitConditionalTxn(tx *ConditionalTxn) error {
+	return db.initConditionalTxn(tx, false)
+}
+
+// InitConditionalTxnWithSnapshot initializes tx and pins the opening snapshot.
+// Point reads use that snapshot, and Snapshot returns it for caller-owned range
+// scans. The snapshot is owned by the transaction and closed by Commit or Close.
+func (db *DB) InitConditionalTxnWithSnapshot(tx *ConditionalTxn) error {
+	return db.initConditionalTxn(tx, true)
+}
+
+func (db *DB) initConditionalTxn(tx *ConditionalTxn, withSnapshot bool) error {
 	if tx == nil {
 		return backenddb.ErrConditionalTxnClosed
 	}
@@ -94,9 +106,19 @@ func (db *DB) InitConditionalTxn(tx *ConditionalTxn) error {
 	start := db.conditionalSeq.Load()
 	db.conditionalSetTxnStart(id, start)
 
+	var snap *Snapshot
+	if withSnapshot {
+		snap = db.AcquireSnapshot()
+		if snap == nil {
+			db.conditionalUnregisterTxn(id)
+			return backenddb.ErrClosed
+		}
+	}
+
 	*tx = ConditionalTxn{
 		db:       db,
 		batch:    db.NewBatch(),
+		snap:     snap,
 		id:       id,
 		startSeq: start,
 	}
@@ -104,6 +126,16 @@ func (db *DB) InitConditionalTxn(tx *ConditionalTxn) error {
 	tx.keyArena = tx.inlineKeys[:0]
 	db.conditionalTxnStarted.Add(1)
 	return nil
+}
+
+// Snapshot returns the transaction's pinned opening snapshot when this
+// transaction was initialized with InitConditionalTxnWithSnapshot. The
+// transaction owns the snapshot and closes it on Commit or Close.
+func (tx *ConditionalTxn) Snapshot() *Snapshot {
+	if tx == nil || tx.closed {
+		return nil
+	}
+	return tx.snap
 }
 
 // ReserveReadSet reserves read-precondition capacity for high-fanout
@@ -170,12 +202,12 @@ func (tx *ConditionalTxn) GetVersionedAppend(key, dst []byte) ([]byte, page.Entr
 		}
 		return out, revision, nil
 	}
-	out, revision, err := tx.db.GetVersionedAppend(key, dst)
+	out, revision, err := tx.getCommittedVersionedAppend(key, dst)
 	if errors.Is(err, tree.ErrKeyNotFound) {
 		if recErr := tx.recordRead(key, revision, false); recErr != nil {
 			return dst, revision, recErr
 		}
-		if tx.db.conditionalReadKeyChangedSince(tx.startSeq, key) {
+		if tx.snap == nil && tx.db.conditionalReadKeyChangedSince(tx.startSeq, key) {
 			return dst, revision, backenddb.ErrConcurrentModification
 		}
 		return dst, revision, err
@@ -186,10 +218,17 @@ func (tx *ConditionalTxn) GetVersionedAppend(key, dst []byte) ([]byte, page.Entr
 	if recErr := tx.recordRead(key, revision, true); recErr != nil {
 		return dst, revision, recErr
 	}
-	if tx.db.conditionalReadKeyChangedSince(tx.startSeq, key) {
+	if tx.snap == nil && tx.db.conditionalReadKeyChangedSince(tx.startSeq, key) {
 		return dst, revision, backenddb.ErrConcurrentModification
 	}
 	return out, revision, nil
+}
+
+func (tx *ConditionalTxn) getCommittedVersionedAppend(key, dst []byte) ([]byte, page.EntryRevision, error) {
+	if tx.snap != nil {
+		return tx.snap.GetVersionedAppend(key, dst)
+	}
+	return tx.db.GetVersionedAppend(key, dst)
 }
 
 func (tx *ConditionalTxn) stagedReadAppend(key, dst []byte) ([]byte, page.EntryRevision, bool, bool, error) {
@@ -378,6 +417,12 @@ func (tx *ConditionalTxn) finish() error {
 	id := tx.id
 	tx.id = 0
 	var err error
+	if tx.snap != nil {
+		if closeErr := tx.snap.Close(); err == nil {
+			err = closeErr
+		}
+		tx.snap = nil
+	}
 	if tx.batch != nil {
 		if closeErr := tx.batch.Close(); err == nil {
 			err = closeErr

--- a/TreeDB/caching/conditional_txn.go
+++ b/TreeDB/caching/conditional_txn.go
@@ -79,8 +79,10 @@ func (db *DB) InitConditionalTxn(tx *ConditionalTxn) error {
 }
 
 // InitConditionalTxnWithSnapshot initializes tx and pins the opening snapshot.
-// Point reads use that snapshot, and Snapshot returns it for caller-owned range
-// scans. The snapshot is owned by the transaction and closed by Commit or Close.
+// Point reads use that snapshot. Public callers must not rely on range scans as
+// commit preconditions until native conditional range guards are supported. The
+// snapshot is owned by the transaction and closed by Commit, CommitSync, or
+// Close.
 func (db *DB) InitConditionalTxnWithSnapshot(tx *ConditionalTxn) error {
 	return db.initConditionalTxn(tx, true)
 }
@@ -130,7 +132,7 @@ func (db *DB) initConditionalTxn(tx *ConditionalTxn, withSnapshot bool) error {
 
 // Snapshot returns the transaction's pinned opening snapshot when this
 // transaction was initialized with InitConditionalTxnWithSnapshot. The
-// transaction owns the snapshot and closes it on Commit or Close.
+// transaction owns the snapshot and closes it on Commit, CommitSync, or Close.
 func (tx *ConditionalTxn) Snapshot() *Snapshot {
 	if tx == nil || tx.closed {
 		return nil
@@ -232,7 +234,28 @@ func (tx *ConditionalTxn) RequireReadVersion(key []byte, revision page.EntryRevi
 		return err
 	}
 	key = normalizeRawKVPointKey(key)
+	if err := tx.validateCurrentReadVersion(key, revision, found); err != nil {
+		return err
+	}
 	return tx.recordRead(key, revision, found)
+}
+
+func (tx *ConditionalTxn) validateCurrentReadVersion(key []byte, revision page.EntryRevision, found bool) error {
+	_, currentRevision, err := tx.db.GetVersionedAppend(key, nil)
+	if errors.Is(err, tree.ErrKeyNotFound) {
+		return conditionalReadVersionMismatch(revision, found, currentRevision, false)
+	}
+	if err != nil {
+		return err
+	}
+	return conditionalReadVersionMismatch(revision, found, currentRevision, true)
+}
+
+func conditionalReadVersionMismatch(wantRevision page.EntryRevision, wantFound bool, gotRevision page.EntryRevision, gotFound bool) error {
+	if wantFound != gotFound || wantRevision != gotRevision {
+		return backenddb.ErrConcurrentModification
+	}
+	return nil
 }
 
 func (tx *ConditionalTxn) getCommittedVersionedAppend(key, dst []byte) ([]byte, page.EntryRevision, error) {

--- a/TreeDB/caching/conditional_txn.go
+++ b/TreeDB/caching/conditional_txn.go
@@ -224,6 +224,17 @@ func (tx *ConditionalTxn) GetVersionedAppend(key, dst []byte) ([]byte, page.Entr
 	return out, revision, nil
 }
 
+// RequireReadVersion records a caller-observed key revision as a commit
+// precondition. It is intended for values read through an external pinned
+// snapshot owned by the caller.
+func (tx *ConditionalTxn) RequireReadVersion(key []byte, revision page.EntryRevision, found bool) error {
+	if err := tx.ensureOpen(); err != nil {
+		return err
+	}
+	key = normalizeRawKVPointKey(key)
+	return tx.recordRead(key, revision, found)
+}
+
 func (tx *ConditionalTxn) getCommittedVersionedAppend(key, dst []byte) ([]byte, page.EntryRevision, error) {
 	if tx.snap != nil {
 		return tx.snap.GetVersionedAppend(key, dst)

--- a/TreeDB/caching/conditional_txn.go
+++ b/TreeDB/caching/conditional_txn.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/snissn/gomap/TreeDB/batch"
 	backenddb "github.com/snissn/gomap/TreeDB/db"
+	"github.com/snissn/gomap/TreeDB/node"
 	"github.com/snissn/gomap/TreeDB/page"
 	"github.com/snissn/gomap/TreeDB/tree"
 )
@@ -241,14 +242,27 @@ func (tx *ConditionalTxn) RequireReadVersion(key []byte, revision page.EntryRevi
 }
 
 func (tx *ConditionalTxn) validateCurrentReadVersion(key []byte, revision page.EntryRevision, found bool) error {
-	_, currentRevision, err := tx.db.GetVersionedAppend(key, nil)
-	if errors.Is(err, tree.ErrKeyNotFound) {
-		return tx.validateCurrentReadVersionMatch(key, revision, found, currentRevision, false)
-	}
+	currentRevision, currentFound, err := tx.currentReadRevision(key)
 	if err != nil {
 		return err
 	}
-	return tx.validateCurrentReadVersionMatch(key, revision, found, currentRevision, true)
+	return tx.validateCurrentReadVersionMatch(key, revision, found, currentRevision, currentFound)
+}
+
+func (tx *ConditionalTxn) currentReadRevision(key []byte) (page.EntryRevision, bool, error) {
+	snap := tx.db.AcquireSnapshot()
+	if snap == nil {
+		return page.LegacyEntryRevision, false, backenddb.ErrClosed
+	}
+	defer snap.Close()
+	entry, err := snap.GetEntry(key)
+	if errors.Is(err, tree.ErrKeyNotFound) {
+		return page.LegacyEntryRevision, false, nil
+	}
+	if err != nil {
+		return page.LegacyEntryRevision, false, err
+	}
+	return entry.Revision, entry.Flags&node.FlagTombstone == 0, nil
 }
 
 func (tx *ConditionalTxn) validateCurrentReadVersionMatch(key []byte, wantRevision page.EntryRevision, wantFound bool, gotRevision page.EntryRevision, gotFound bool) error {

--- a/TreeDB/caching/snapshot.go
+++ b/TreeDB/caching/snapshot.go
@@ -667,14 +667,11 @@ func (s *Snapshot) ReverseIterate(start, end []byte, fn func(key, value []byte) 
 	return s.iterate(start, end, true, fn)
 }
 
-func (s *Snapshot) iterate(start, end []byte, reverse bool, fn func(key, value []byte) error) error {
+func (s *Snapshot) iterate(start, end []byte, reverse bool, fn func(key, value []byte) error) (err error) {
 	if fn == nil {
-		return errors.New("cachingdb: snapshot iterate nil callback")
+		return errors.New("treedb: snapshot iterate nil callback")
 	}
-	var (
-		it  merging.Iterator
-		err error
-	)
+	var it merging.Iterator
 	if reverse {
 		it, err = s.ReverseIterator(start, end)
 	} else {
@@ -683,6 +680,9 @@ func (s *Snapshot) iterate(start, end []byte, reverse bool, fn func(key, value [
 	if err != nil {
 		return err
 	}
+	defer func() {
+		err = errors.Join(err, it.Close())
+	}()
 	var iterErr error
 	for it.Valid() {
 		key := it.Key()
@@ -700,8 +700,7 @@ func (s *Snapshot) iterate(start, end []byte, reverse bool, fn func(key, value [
 	if iterErr == nil {
 		iterErr = it.Error()
 	}
-	closeErr := it.Close()
-	return errors.Join(iterErr, closeErr)
+	return iterErr
 }
 
 func (s *Snapshot) GetAppend(key, dst []byte) ([]byte, error) {

--- a/TreeDB/caching/snapshot.go
+++ b/TreeDB/caching/snapshot.go
@@ -700,10 +700,8 @@ func (s *Snapshot) iterate(start, end []byte, reverse bool, fn func(key, value [
 	if iterErr == nil {
 		iterErr = it.Error()
 	}
-	if closeErr := it.Close(); iterErr == nil {
-		iterErr = closeErr
-	}
-	return iterErr
+	closeErr := it.Close()
+	return errors.Join(iterErr, closeErr)
 }
 
 func (s *Snapshot) GetAppend(key, dst []byte) ([]byte, error) {

--- a/TreeDB/caching/snapshot.go
+++ b/TreeDB/caching/snapshot.go
@@ -669,7 +669,7 @@ func (s *Snapshot) ReverseIterate(start, end []byte, fn func(key, value []byte) 
 
 func (s *Snapshot) iterate(start, end []byte, reverse bool, fn func(key, value []byte) error) error {
 	if fn == nil {
-		return nil
+		return errors.New("cachingdb: snapshot iterate nil callback")
 	}
 	var (
 		it  merging.Iterator
@@ -684,11 +684,18 @@ func (s *Snapshot) iterate(start, end []byte, reverse bool, fn func(key, value [
 		return err
 	}
 	var iterErr error
-	for ; it.Valid(); it.Next() {
-		if err := fn(it.Key(), it.Value()); err != nil {
+	for it.Valid() {
+		key := it.Key()
+		value := it.Value()
+		if err := it.Error(); err != nil {
 			iterErr = err
 			break
 		}
+		if err := fn(key, value); err != nil {
+			iterErr = err
+			break
+		}
+		it.Next()
 	}
 	if iterErr == nil {
 		iterErr = it.Error()

--- a/TreeDB/caching/snapshot.go
+++ b/TreeDB/caching/snapshot.go
@@ -635,6 +635,14 @@ func (s *Snapshot) Iterator(start, end []byte) (merging.Iterator, error) {
 	return merging.NewMergingIterator(sources, start, end), nil
 }
 
+// Iterate calls fn for each visible key/value pair in [start, end) using this
+// snapshot's pinned memtable and backend view. Key and value are read-only views
+// valid only until fn returns. Returning an error from fn stops iteration and
+// returns that error.
+func (s *Snapshot) Iterate(start, end []byte, fn func(key, value []byte) error) error {
+	return s.iterate(start, end, false, fn)
+}
+
 // ReverseIterator returns a stable reverse iterator over the snapshot's queued
 // memtables plus its backend snapshot.
 func (s *Snapshot) ReverseIterator(start, end []byte) (merging.Iterator, error) {
@@ -649,6 +657,46 @@ func (s *Snapshot) ReverseIterator(start, end []byte) (merging.Iterator, error) 
 		return newSingleSourceIterator(sources[0].Iter, start, end), nil
 	}
 	return merging.NewReverseMergingIterator(sources, start, end), nil
+}
+
+// ReverseIterate calls fn for each visible key/value pair in [start, end) in
+// reverse order using this snapshot's pinned memtable and backend view. Key and
+// value are read-only views valid only until fn returns. Returning an error from
+// fn stops iteration and returns that error.
+func (s *Snapshot) ReverseIterate(start, end []byte, fn func(key, value []byte) error) error {
+	return s.iterate(start, end, true, fn)
+}
+
+func (s *Snapshot) iterate(start, end []byte, reverse bool, fn func(key, value []byte) error) error {
+	if fn == nil {
+		return nil
+	}
+	var (
+		it  merging.Iterator
+		err error
+	)
+	if reverse {
+		it, err = s.ReverseIterator(start, end)
+	} else {
+		it, err = s.Iterator(start, end)
+	}
+	if err != nil {
+		return err
+	}
+	var iterErr error
+	for ; it.Valid(); it.Next() {
+		if err := fn(it.Key(), it.Value()); err != nil {
+			iterErr = err
+			break
+		}
+	}
+	if iterErr == nil {
+		iterErr = it.Error()
+	}
+	if closeErr := it.Close(); iterErr == nil {
+		iterErr = closeErr
+	}
+	return iterErr
 }
 
 func (s *Snapshot) GetAppend(key, dst []byte) ([]byte, error) {

--- a/TreeDB/conditional_txn.go
+++ b/TreeDB/conditional_txn.go
@@ -41,6 +41,13 @@ type conditionalTxnSnapshot struct {
 	tx *ConditionalTxn
 }
 
+// Close is a no-op. The transaction owns the underlying snapshot and closes it
+// on Commit, CommitSync, or Close; callers can safely defer this method without
+// releasing the transaction-owned snapshot prematurely.
+func (s conditionalTxnSnapshot) Close() error {
+	return nil
+}
+
 func (s conditionalTxnSnapshot) Get(key []byte) ([]byte, error) {
 	value, _, err := s.GetVersioned(key)
 	return value, err
@@ -73,7 +80,7 @@ func (s conditionalTxnSnapshot) GetVersionedAppend(key, dst []byte) ([]byte, Ent
 
 func (s conditionalTxnSnapshot) GetManyView(keys [][]byte, fn GetManyViewFunc) error {
 	if fn == nil {
-		return ErrConditionalTxnUnsupported
+		return errors.New("treedb: GetManyView nil callback")
 	}
 	for i, key := range keys {
 		value, _, err := s.tx.GetVersionedAppend(key, nil)

--- a/TreeDB/conditional_txn.go
+++ b/TreeDB/conditional_txn.go
@@ -1,6 +1,11 @@
 package treedb
 
-import "github.com/snissn/gomap/TreeDB/page"
+import (
+	"errors"
+
+	"github.com/snissn/gomap/TreeDB/node"
+	"github.com/snissn/gomap/TreeDB/page"
+)
 
 // Snapshot returns the transaction's pinned opening snapshot when available.
 // NewConditionalTxnWithSnapshot and InitConditionalTxnWithSnapshot always
@@ -19,20 +24,105 @@ func (tx *ConditionalTxn) Snapshot() Snapshot {
 		if snap == nil {
 			return nil
 		}
-		return conditionalTxnSnapshot{Snapshot: snap}
+		return conditionalTxnSnapshot{Snapshot: snap, tx: tx}
 	}
 	if tx.backend != nil {
 		snap := tx.backend.Snapshot()
 		if snap == nil {
 			return nil
 		}
-		return conditionalTxnSnapshot{Snapshot: snap}
+		return conditionalTxnSnapshot{Snapshot: snap, tx: tx}
 	}
 	return nil
 }
 
 type conditionalTxnSnapshot struct {
 	Snapshot
+	tx *ConditionalTxn
+}
+
+func (s conditionalTxnSnapshot) Get(key []byte) ([]byte, error) {
+	value, _, err := s.GetVersioned(key)
+	return value, err
+}
+
+func (s conditionalTxnSnapshot) GetAppend(key, dst []byte) ([]byte, error) {
+	out, _, err := s.GetVersionedAppend(key, dst)
+	return out, err
+}
+
+func (s conditionalTxnSnapshot) GetVersioned(key []byte) ([]byte, EntryRevision, error) {
+	out, revision, err := s.tx.GetVersionedAppend(key, nil)
+	if err != nil {
+		return nil, revision, err
+	}
+	if len(out) == 0 {
+		return []byte{}, revision, nil
+	}
+	if cap(out) == len(out) {
+		return out, revision, nil
+	}
+	owned := make([]byte, len(out))
+	copy(owned, out)
+	return owned, revision, nil
+}
+
+func (s conditionalTxnSnapshot) GetVersionedAppend(key, dst []byte) ([]byte, EntryRevision, error) {
+	return s.tx.GetVersionedAppend(key, dst)
+}
+
+func (s conditionalTxnSnapshot) GetManyView(keys [][]byte, fn GetManyViewFunc) error {
+	if fn == nil {
+		return ErrConditionalTxnUnsupported
+	}
+	for i, key := range keys {
+		value, _, err := s.tx.GetVersionedAppend(key, nil)
+		if errors.Is(err, ErrKeyNotFound) {
+			if err := fn(i, key, nil, false); err != nil {
+				return err
+			}
+			continue
+		}
+		if err != nil {
+			return err
+		}
+		if err := fn(i, key, value, true); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s conditionalTxnSnapshot) GetUnsafe(key []byte) ([]byte, error) {
+	return s.Get(key)
+}
+
+func (s conditionalTxnSnapshot) Has(key []byte) (bool, error) {
+	return s.tx.Has(key)
+}
+
+func (s conditionalTxnSnapshot) HasMany(keys [][]byte) ([]bool, error) {
+	out := make([]bool, len(keys))
+	for i, key := range keys {
+		found, err := s.tx.Has(key)
+		if err != nil {
+			return nil, err
+		}
+		out[i] = found
+	}
+	return out, nil
+}
+
+func (s conditionalTxnSnapshot) HasPrefixes(prefixes [][]byte) ([]bool, error) {
+	return nil, ErrConditionalTxnUnsupported
+}
+
+func (s conditionalTxnSnapshot) GetEntry(key []byte) (node.LeafEntry, error) {
+	return node.LeafEntry{}, ErrConditionalTxnUnsupported
+}
+
+func (s conditionalTxnSnapshot) GetEntryExact(key []byte) (node.LeafEntry, error) {
+	return node.LeafEntry{}, ErrConditionalTxnUnsupported
 }
 
 func (s conditionalTxnSnapshot) Iterate(start, end []byte, fn func(key, value []byte) error) error {

--- a/TreeDB/conditional_txn.go
+++ b/TreeDB/conditional_txn.go
@@ -83,6 +83,7 @@ func (s conditionalTxnSnapshot) GetManyView(keys [][]byte, fn GetManyViewFunc) e
 		return errors.New("treedb: GetManyView nil callback")
 	}
 	for i, key := range keys {
+		key = normalizeRawKVPointKey(key)
 		value, _, err := s.tx.GetVersionedAppend(key, nil)
 		if errors.Is(err, ErrKeyNotFound) {
 			if err := fn(i, key, nil, false); err != nil {

--- a/TreeDB/conditional_txn.go
+++ b/TreeDB/conditional_txn.go
@@ -6,17 +6,41 @@ import "github.com/snissn/gomap/TreeDB/page"
 // NewConditionalTxnWithSnapshot and InitConditionalTxnWithSnapshot always
 // return a transaction with a snapshot. The transaction owns the snapshot and
 // closes it on Commit, CommitSync, or Close.
+//
+// Point and versioned point reads are supported. Range iteration on this
+// transaction-owned snapshot fails closed because conditional range guards are
+// not part of the public transaction contract yet.
 func (tx *ConditionalTxn) Snapshot() Snapshot {
 	if tx == nil {
 		return nil
 	}
 	if tx.cachedActive {
-		return tx.cached.Snapshot()
+		snap := tx.cached.Snapshot()
+		if snap == nil {
+			return nil
+		}
+		return conditionalTxnSnapshot{Snapshot: snap}
 	}
 	if tx.backend != nil {
-		return tx.backend.Snapshot()
+		snap := tx.backend.Snapshot()
+		if snap == nil {
+			return nil
+		}
+		return conditionalTxnSnapshot{Snapshot: snap}
 	}
 	return nil
+}
+
+type conditionalTxnSnapshot struct {
+	Snapshot
+}
+
+func (s conditionalTxnSnapshot) Iterate(start, end []byte, fn func(key, value []byte) error) error {
+	return ErrConditionalTxnUnsupported
+}
+
+func (s conditionalTxnSnapshot) ReverseIterate(start, end []byte, fn func(key, value []byte) error) error {
+	return ErrConditionalTxnUnsupported
 }
 
 // ReserveReadSet reserves read-precondition capacity for high-fanout

--- a/TreeDB/conditional_txn.go
+++ b/TreeDB/conditional_txn.go
@@ -59,7 +59,10 @@ func (s conditionalTxnSnapshot) GetAppend(key, dst []byte) ([]byte, error) {
 }
 
 func (s conditionalTxnSnapshot) GetVersioned(key []byte) ([]byte, EntryRevision, error) {
-	out, revision, err := s.tx.GetVersionedAppend(key, nil)
+	out, revision, err := s.GetVersionedAppend(key, nil)
+	if errors.Is(err, ErrKeyNotFound) {
+		return nil, revision, nil
+	}
 	if err != nil {
 		return nil, revision, err
 	}
@@ -75,7 +78,24 @@ func (s conditionalTxnSnapshot) GetVersioned(key []byte) ([]byte, EntryRevision,
 }
 
 func (s conditionalTxnSnapshot) GetVersionedAppend(key, dst []byte) ([]byte, EntryRevision, error) {
-	return s.tx.GetVersionedAppend(key, dst)
+	if s.tx == nil || s.Snapshot == nil {
+		return dst, LegacyEntryRevision, ErrConditionalTxnClosed
+	}
+	key = normalizeRawKVPointKey(key)
+	out, revision, err := s.Snapshot.GetVersionedAppend(key, dst)
+	if errors.Is(err, ErrKeyNotFound) {
+		if recErr := s.tx.recordSnapshotReadVersion(key, revision, false); recErr != nil {
+			return dst, revision, recErr
+		}
+		return dst, revision, err
+	}
+	if err != nil {
+		return dst, revision, err
+	}
+	if recErr := s.tx.recordSnapshotReadVersion(key, revision, true); recErr != nil {
+		return dst, revision, recErr
+	}
+	return out, revision, nil
 }
 
 func (s conditionalTxnSnapshot) GetManyView(keys [][]byte, fn GetManyViewFunc) error {
@@ -84,7 +104,7 @@ func (s conditionalTxnSnapshot) GetManyView(keys [][]byte, fn GetManyViewFunc) e
 	}
 	for i, key := range keys {
 		key = normalizeRawKVPointKey(key)
-		value, _, err := s.tx.GetVersionedAppend(key, nil)
+		value, _, err := s.GetVersionedAppend(key, nil)
 		if errors.Is(err, ErrKeyNotFound) {
 			if err := fn(i, key, nil, false); err != nil {
 				return err
@@ -109,13 +129,20 @@ func (s conditionalTxnSnapshot) GetUnsafe(key []byte) ([]byte, error) {
 }
 
 func (s conditionalTxnSnapshot) Has(key []byte) (bool, error) {
-	return s.tx.Has(key)
+	_, _, err := s.GetVersionedAppend(key, nil)
+	if errors.Is(err, ErrKeyNotFound) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 func (s conditionalTxnSnapshot) HasMany(keys [][]byte) ([]bool, error) {
 	out := make([]bool, len(keys))
 	for i, key := range keys {
-		found, err := s.tx.Has(key)
+		found, err := s.Has(key)
 		if err != nil {
 			return nil, err
 		}
@@ -142,6 +169,19 @@ func (s conditionalTxnSnapshot) Iterate(start, end []byte, fn func(key, value []
 
 func (s conditionalTxnSnapshot) ReverseIterate(start, end []byte, fn func(key, value []byte) error) error {
 	return ErrConditionalTxnUnsupported
+}
+
+func (tx *ConditionalTxn) recordSnapshotReadVersion(key []byte, revision EntryRevision, found bool) error {
+	if tx == nil {
+		return ErrConditionalTxnClosed
+	}
+	if tx.cachedActive {
+		return tx.cached.RecordReadVersion(key, page.EntryRevision(revision), found)
+	}
+	if tx.backend != nil {
+		return tx.backend.RecordReadVersion(key, page.EntryRevision(revision), found)
+	}
+	return ErrConditionalTxnClosed
 }
 
 // ReserveReadSet reserves read-precondition capacity for high-fanout

--- a/TreeDB/conditional_txn.go
+++ b/TreeDB/conditional_txn.go
@@ -11,7 +11,7 @@ import "github.com/snissn/gomap/TreeDB/page"
 // transaction-owned snapshot fails closed because conditional range guards are
 // not part of the public transaction contract yet.
 func (tx *ConditionalTxn) Snapshot() Snapshot {
-	if tx == nil {
+	if tx == nil || !tx.snapshotExposed {
 		return nil
 	}
 	if tx.cachedActive {
@@ -274,6 +274,7 @@ func (tx *ConditionalTxn) Commit() error {
 			_ = tx.cached.Close()
 		}
 		tx.cachedActive = false
+		tx.snapshotExposed = false
 		return err
 	}
 	if tx.backend != nil {
@@ -282,6 +283,7 @@ func (tx *ConditionalTxn) Commit() error {
 			_ = tx.backend.Close()
 		}
 		tx.backend = nil
+		tx.snapshotExposed = false
 		return err
 	}
 	return ErrConditionalTxnClosed
@@ -299,6 +301,7 @@ func (tx *ConditionalTxn) CommitSync() error {
 			_ = tx.cached.Close()
 		}
 		tx.cachedActive = false
+		tx.snapshotExposed = false
 		return err
 	}
 	if tx.backend != nil {
@@ -307,6 +310,7 @@ func (tx *ConditionalTxn) CommitSync() error {
 			_ = tx.backend.Close()
 		}
 		tx.backend = nil
+		tx.snapshotExposed = false
 		return err
 	}
 	return ErrConditionalTxnClosed
@@ -320,11 +324,13 @@ func (tx *ConditionalTxn) Close() error {
 	if tx.cachedActive {
 		err := tx.cached.Close()
 		tx.cachedActive = false
+		tx.snapshotExposed = false
 		return err
 	}
 	if tx.backend != nil {
 		err := tx.backend.Close()
 		tx.backend = nil
+		tx.snapshotExposed = false
 		return err
 	}
 	return nil

--- a/TreeDB/conditional_txn.go
+++ b/TreeDB/conditional_txn.go
@@ -93,6 +93,22 @@ func (tx *ConditionalTxn) GetVersionedAppend(key, dst []byte) ([]byte, EntryRevi
 	return dst, LegacyEntryRevision, ErrConditionalTxnClosed
 }
 
+// RequireReadVersion records a caller-observed key revision as a commit
+// precondition. It is intended for values read through an external pinned
+// snapshot owned by the caller.
+func (tx *ConditionalTxn) RequireReadVersion(key []byte, revision EntryRevision, found bool) error {
+	if tx == nil {
+		return ErrConditionalTxnClosed
+	}
+	if tx.cachedActive {
+		return tx.cached.RequireReadVersion(key, page.EntryRevision(revision), found)
+	}
+	if tx.backend != nil {
+		return tx.backend.RequireReadVersion(key, page.EntryRevision(revision), found)
+	}
+	return ErrConditionalTxnClosed
+}
+
 // Has reports whether key exists in the transaction-visible state and records
 // the key as a commit precondition.
 func (tx *ConditionalTxn) Has(key []byte) (bool, error) {

--- a/TreeDB/conditional_txn.go
+++ b/TreeDB/conditional_txn.go
@@ -2,6 +2,23 @@ package treedb
 
 import "github.com/snissn/gomap/TreeDB/page"
 
+// Snapshot returns the transaction's pinned opening snapshot when available.
+// NewConditionalTxnWithSnapshot and InitConditionalTxnWithSnapshot always
+// return a transaction with a snapshot. The transaction owns the snapshot and
+// closes it on Commit, CommitSync, or Close.
+func (tx *ConditionalTxn) Snapshot() Snapshot {
+	if tx == nil {
+		return nil
+	}
+	if tx.cachedActive {
+		return tx.cached.Snapshot()
+	}
+	if tx.backend != nil {
+		return tx.backend.Snapshot()
+	}
+	return nil
+}
+
 // ReserveReadSet reserves read-precondition capacity for high-fanout
 // transactions. It is optional and does not change transaction semantics.
 func (tx *ConditionalTxn) ReserveReadSet(n int) {

--- a/TreeDB/conditional_txn.go
+++ b/TreeDB/conditional_txn.go
@@ -93,6 +93,9 @@ func (s conditionalTxnSnapshot) GetManyView(keys [][]byte, fn GetManyViewFunc) e
 		if err != nil {
 			return err
 		}
+		if len(value) == 0 {
+			value = []byte{}
+		}
 		if err := fn(i, key, value, true); err != nil {
 			return err
 		}

--- a/TreeDB/conditional_txn.go
+++ b/TreeDB/conditional_txn.go
@@ -60,9 +60,6 @@ func (s conditionalTxnSnapshot) GetAppend(key, dst []byte) ([]byte, error) {
 
 func (s conditionalTxnSnapshot) GetVersioned(key []byte) ([]byte, EntryRevision, error) {
 	out, revision, err := s.GetVersionedAppend(key, nil)
-	if errors.Is(err, ErrKeyNotFound) {
-		return nil, revision, nil
-	}
 	if err != nil {
 		return nil, revision, err
 	}

--- a/TreeDB/db/api.go
+++ b/TreeDB/db/api.go
@@ -699,6 +699,13 @@ func (s *Snapshot) IteratorWithOptions(start, end []byte, opts IteratorOptions) 
 	return s.tree.IteratorWithOptions(start, end, opts), nil
 }
 
+// Iterate calls fn for each visible key/value pair in [start, end) using this
+// snapshot's pinned view. Key and value are read-only views valid only until fn
+// returns. Returning an error from fn stops iteration and returns that error.
+func (s *Snapshot) Iterate(start, end []byte, fn func(key, value []byte) error) error {
+	return s.iterate(start, end, false, fn)
+}
+
 // ReverseIterator returns a reverse iterator.
 func (db *DB) ReverseIterator(start, end []byte) (iterator.UnsafeIterator, error) {
 	return db.ReverseIteratorWithOptions(start, end, IteratorOptions{})
@@ -727,6 +734,46 @@ func (s *Snapshot) ReverseIteratorWithOptions(start, end []byte, opts IteratorOp
 		return nil, ErrClosed
 	}
 	return s.tree.ReverseIteratorWithOptions(start, end, opts), nil
+}
+
+// ReverseIterate calls fn for each visible key/value pair in [start, end) in
+// reverse order using this snapshot's pinned view. Key and value are read-only
+// views valid only until fn returns. Returning an error from fn stops iteration
+// and returns that error.
+func (s *Snapshot) ReverseIterate(start, end []byte, fn func(key, value []byte) error) error {
+	return s.iterate(start, end, true, fn)
+}
+
+func (s *Snapshot) iterate(start, end []byte, reverse bool, fn func(key, value []byte) error) error {
+	if fn == nil {
+		return nil
+	}
+	var (
+		it  iterator.UnsafeIterator
+		err error
+	)
+	if reverse {
+		it, err = s.ReverseIterator(start, end)
+	} else {
+		it, err = s.Iterator(start, end)
+	}
+	if err != nil {
+		return err
+	}
+	var iterErr error
+	for ; it.Valid(); it.Next() {
+		if err := fn(it.Key(), it.Value()); err != nil {
+			iterErr = err
+			break
+		}
+	}
+	if iterErr == nil {
+		iterErr = it.Error()
+	}
+	if closeErr := it.Close(); iterErr == nil {
+		iterErr = closeErr
+	}
+	return iterErr
 }
 
 // Stats returns database statistics.

--- a/TreeDB/db/api.go
+++ b/TreeDB/db/api.go
@@ -777,10 +777,8 @@ func (s *Snapshot) iterate(start, end []byte, reverse bool, fn func(key, value [
 	if iterErr == nil {
 		iterErr = it.Error()
 	}
-	if closeErr := it.Close(); iterErr == nil {
-		iterErr = closeErr
-	}
-	return iterErr
+	closeErr := it.Close()
+	return errors.Join(iterErr, closeErr)
 }
 
 // Stats returns database statistics.

--- a/TreeDB/db/api.go
+++ b/TreeDB/db/api.go
@@ -744,14 +744,11 @@ func (s *Snapshot) ReverseIterate(start, end []byte, fn func(key, value []byte) 
 	return s.iterate(start, end, true, fn)
 }
 
-func (s *Snapshot) iterate(start, end []byte, reverse bool, fn func(key, value []byte) error) error {
+func (s *Snapshot) iterate(start, end []byte, reverse bool, fn func(key, value []byte) error) (err error) {
 	if fn == nil {
 		return errors.New("treedb: snapshot iterate nil callback")
 	}
-	var (
-		it  iterator.UnsafeIterator
-		err error
-	)
+	var it iterator.UnsafeIterator
 	if reverse {
 		it, err = s.ReverseIterator(start, end)
 	} else {
@@ -760,6 +757,9 @@ func (s *Snapshot) iterate(start, end []byte, reverse bool, fn func(key, value [
 	if err != nil {
 		return err
 	}
+	defer func() {
+		err = errors.Join(err, it.Close())
+	}()
 	var iterErr error
 	for it.Valid() {
 		key := it.Key()
@@ -777,8 +777,7 @@ func (s *Snapshot) iterate(start, end []byte, reverse bool, fn func(key, value [
 	if iterErr == nil {
 		iterErr = it.Error()
 	}
-	closeErr := it.Close()
-	return errors.Join(iterErr, closeErr)
+	return iterErr
 }
 
 // Stats returns database statistics.

--- a/TreeDB/db/api.go
+++ b/TreeDB/db/api.go
@@ -746,7 +746,7 @@ func (s *Snapshot) ReverseIterate(start, end []byte, fn func(key, value []byte) 
 
 func (s *Snapshot) iterate(start, end []byte, reverse bool, fn func(key, value []byte) error) error {
 	if fn == nil {
-		return nil
+		return errors.New("treedb: snapshot iterate nil callback")
 	}
 	var (
 		it  iterator.UnsafeIterator
@@ -761,11 +761,18 @@ func (s *Snapshot) iterate(start, end []byte, reverse bool, fn func(key, value [
 		return err
 	}
 	var iterErr error
-	for ; it.Valid(); it.Next() {
-		if err := fn(it.Key(), it.Value()); err != nil {
+	for it.Valid() {
+		key := it.Key()
+		value := it.Value()
+		if err := it.Error(); err != nil {
 			iterErr = err
 			break
 		}
+		if err := fn(key, value); err != nil {
+			iterErr = err
+			break
+		}
+		it.Next()
 	}
 	if iterErr == nil {
 		iterErr = it.Error()

--- a/TreeDB/db/conditional_txn.go
+++ b/TreeDB/db/conditional_txn.go
@@ -238,19 +238,22 @@ func (tx *ConditionalTxn) RequireReadVersion(key []byte, revision page.EntryRevi
 func (tx *ConditionalTxn) validateCurrentReadVersion(key []byte, revision page.EntryRevision, found bool) error {
 	_, currentRevision, err := tx.db.GetVersionedAppend(key, nil)
 	if errors.Is(err, tree.ErrKeyNotFound) {
-		return conditionalReadVersionMismatch(revision, found, currentRevision, false)
+		return tx.validateCurrentReadVersionMatch(key, revision, found, currentRevision, false)
 	}
 	if err != nil {
 		return err
 	}
-	return conditionalReadVersionMismatch(revision, found, currentRevision, true)
+	return tx.validateCurrentReadVersionMatch(key, revision, found, currentRevision, true)
 }
 
-func conditionalReadVersionMismatch(wantRevision page.EntryRevision, wantFound bool, gotRevision page.EntryRevision, gotFound bool) error {
-	if wantFound != gotFound || wantRevision != gotRevision {
-		return ErrConcurrentModification
+func (tx *ConditionalTxn) validateCurrentReadVersionMatch(key []byte, wantRevision page.EntryRevision, wantFound bool, gotRevision page.EntryRevision, gotFound bool) error {
+	if wantFound == gotFound && wantRevision == gotRevision {
+		return nil
 	}
-	return nil
+	if tx.db.conditionalReadKeyChangedSince(tx.startCommitSeq, key) {
+		return nil
+	}
+	return ErrConcurrentModification
 }
 
 // Has reports whether key exists in the opening snapshot and records the key as
@@ -749,6 +752,27 @@ func (db *DB) conditionalReadSetChangedSince(start uint64, reads []conditionalRe
 			if r.seq > start && conditionalKeyInStringRange(reads[i].key, r.start, r.end) {
 				return true
 			}
+		}
+	}
+	return false
+}
+
+func (db *DB) conditionalReadKeyChangedSince(start uint64, key []byte) bool {
+	if db == nil {
+		return false
+	}
+	db.conditionalOracle.mu.Lock()
+	defer db.conditionalOracle.mu.Unlock()
+	if db.conditionalOracle.rootSeq > start {
+		return true
+	}
+	if db.conditionalOracle.recent[conditionalBytesString(key)] > start {
+		return true
+	}
+	for i := range db.conditionalOracle.ranges {
+		r := db.conditionalOracle.ranges[i]
+		if r.seq > start && conditionalKeyInStringRange(key, r.start, r.end) {
+			return true
 		}
 	}
 	return false

--- a/TreeDB/db/conditional_txn.go
+++ b/TreeDB/db/conditional_txn.go
@@ -236,6 +236,17 @@ func (tx *ConditionalTxn) RequireReadVersion(key []byte, revision page.EntryRevi
 	return tx.recordRead(key, revision, found)
 }
 
+// RecordReadVersion records an opening-snapshot read precondition without
+// validating current state. It is for transaction-owned snapshot reads that
+// should keep returning the pinned view and defer conflicts until commit.
+func (tx *ConditionalTxn) RecordReadVersion(key []byte, revision page.EntryRevision, found bool) error {
+	if err := tx.ensureOpen(); err != nil {
+		return err
+	}
+	key = normalizeRawKVPointKey(key)
+	return tx.recordRead(key, revision, found)
+}
+
 func (tx *ConditionalTxn) validateCurrentReadVersion(key []byte, revision page.EntryRevision, found bool) error {
 	currentRevision, currentFound, err := tx.currentReadRevision(key)
 	if err != nil {

--- a/TreeDB/db/conditional_txn.go
+++ b/TreeDB/db/conditional_txn.go
@@ -229,7 +229,28 @@ func (tx *ConditionalTxn) RequireReadVersion(key []byte, revision page.EntryRevi
 		return err
 	}
 	key = normalizeRawKVPointKey(key)
+	if err := tx.validateCurrentReadVersion(key, revision, found); err != nil {
+		return err
+	}
 	return tx.recordRead(key, revision, found)
+}
+
+func (tx *ConditionalTxn) validateCurrentReadVersion(key []byte, revision page.EntryRevision, found bool) error {
+	_, currentRevision, err := tx.db.GetVersionedAppend(key, nil)
+	if errors.Is(err, tree.ErrKeyNotFound) {
+		return conditionalReadVersionMismatch(revision, found, currentRevision, false)
+	}
+	if err != nil {
+		return err
+	}
+	return conditionalReadVersionMismatch(revision, found, currentRevision, true)
+}
+
+func conditionalReadVersionMismatch(wantRevision page.EntryRevision, wantFound bool, gotRevision page.EntryRevision, gotFound bool) error {
+	if wantFound != gotFound || wantRevision != gotRevision {
+		return ErrConcurrentModification
+	}
+	return nil
 }
 
 // Has reports whether key exists in the opening snapshot and records the key as

--- a/TreeDB/db/conditional_txn.go
+++ b/TreeDB/db/conditional_txn.go
@@ -117,6 +117,15 @@ func (db *DB) NewConditionalTxn() (*ConditionalTxn, error) {
 	return tx, nil
 }
 
+// Snapshot returns the transaction's pinned opening snapshot. The transaction
+// owns the snapshot and closes it on Commit, CommitSync, or Close.
+func (tx *ConditionalTxn) Snapshot() *Snapshot {
+	if tx == nil || tx.closed {
+		return nil
+	}
+	return tx.snap
+}
+
 // ReserveReadSet reserves read-precondition capacity for high-fanout
 // transactions. It is optional and does not change transaction semantics.
 func (tx *ConditionalTxn) ReserveReadSet(n int) {

--- a/TreeDB/db/conditional_txn.go
+++ b/TreeDB/db/conditional_txn.go
@@ -221,6 +221,17 @@ func (tx *ConditionalTxn) GetVersionedAppend(key, dst []byte) ([]byte, page.Entr
 	return out, revision, nil
 }
 
+// RequireReadVersion records a caller-observed key revision as a commit
+// precondition. It is intended for values read through an external pinned
+// snapshot owned by the caller.
+func (tx *ConditionalTxn) RequireReadVersion(key []byte, revision page.EntryRevision, found bool) error {
+	if err := tx.ensureOpen(); err != nil {
+		return err
+	}
+	key = normalizeRawKVPointKey(key)
+	return tx.recordRead(key, revision, found)
+}
+
 // Has reports whether key exists in the opening snapshot and records the key as
 // a commit precondition.
 func (tx *ConditionalTxn) Has(key []byte) (bool, error) {

--- a/TreeDB/db/conditional_txn.go
+++ b/TreeDB/db/conditional_txn.go
@@ -6,6 +6,7 @@ import (
 	"unsafe"
 
 	batchpkg "github.com/snissn/gomap/TreeDB/batch"
+	"github.com/snissn/gomap/TreeDB/node"
 	"github.com/snissn/gomap/TreeDB/page"
 	"github.com/snissn/gomap/TreeDB/tree"
 )
@@ -236,14 +237,27 @@ func (tx *ConditionalTxn) RequireReadVersion(key []byte, revision page.EntryRevi
 }
 
 func (tx *ConditionalTxn) validateCurrentReadVersion(key []byte, revision page.EntryRevision, found bool) error {
-	_, currentRevision, err := tx.db.GetVersionedAppend(key, nil)
-	if errors.Is(err, tree.ErrKeyNotFound) {
-		return tx.validateCurrentReadVersionMatch(key, revision, found, currentRevision, false)
-	}
+	currentRevision, currentFound, err := tx.currentReadRevision(key)
 	if err != nil {
 		return err
 	}
-	return tx.validateCurrentReadVersionMatch(key, revision, found, currentRevision, true)
+	return tx.validateCurrentReadVersionMatch(key, revision, found, currentRevision, currentFound)
+}
+
+func (tx *ConditionalTxn) currentReadRevision(key []byte) (page.EntryRevision, bool, error) {
+	snap := tx.db.AcquireSnapshot()
+	if snap == nil {
+		return page.LegacyEntryRevision, false, ErrClosed
+	}
+	defer snap.Close()
+	entry, err := snap.GetEntry(key)
+	if errors.Is(err, tree.ErrKeyNotFound) {
+		return page.LegacyEntryRevision, false, nil
+	}
+	if err != nil {
+		return page.LegacyEntryRevision, false, err
+	}
+	return entry.Revision, entry.Flags&node.FlagTombstone == 0, nil
 }
 
 func (tx *ConditionalTxn) validateCurrentReadVersionMatch(key []byte, wantRevision page.EntryRevision, wantFound bool, gotRevision page.EntryRevision, gotFound bool) error {

--- a/TreeDB/db/conditional_txn_test.go
+++ b/TreeDB/db/conditional_txn_test.go
@@ -143,6 +143,39 @@ func TestConditionalTxnRejectsAbsentReadInsertDeleteCycle(t *testing.T) {
 	}
 }
 
+func TestConditionalTxnRejectsExternalSnapshotRevisionBeforeTxn(t *testing.T) {
+	d, err := Open(Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer d.Close()
+
+	if err := d.SetSync([]byte("guard"), []byte("before")); err != nil {
+		t.Fatalf("seed guard: %v", err)
+	}
+	snap := d.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("AcquireSnapshot returned nil")
+	}
+	defer snap.Close()
+	_, revision, err := snap.GetVersionedAppend([]byte("guard"), nil)
+	if err != nil {
+		t.Fatalf("snapshot GetVersionedAppend guard: %v", err)
+	}
+	if err := d.SetSync([]byte("guard"), []byte("after")); err != nil {
+		t.Fatalf("concurrent guard write: %v", err)
+	}
+
+	tx, err := d.NewConditionalTxn()
+	if err != nil {
+		t.Fatalf("NewConditionalTxn: %v", err)
+	}
+	defer tx.Close()
+	if err := tx.RequireReadVersion([]byte("guard"), revision, true); !errors.Is(err, ErrConcurrentModification) {
+		t.Fatalf("txn RequireReadVersion error=%v, want ErrConcurrentModification", err)
+	}
+}
+
 func TestConditionalTxnAllowsDisjointConcurrentWrite(t *testing.T) {
 	d, err := Open(Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/internal/merging/merging.go
+++ b/TreeDB/internal/merging/merging.go
@@ -2,6 +2,7 @@ package merging
 
 import (
 	"bytes"
+	"errors"
 
 	"github.com/snissn/gomap/TreeDB/internal/iterator"
 	"github.com/snissn/gomap/TreeDB/page"
@@ -263,6 +264,11 @@ func (mi *MergingIterator) ValueCopy(dst []byte) []byte {
 }
 
 func (mi *MergingIterator) Error() error {
+	if mi.hasCur {
+		if srcErr := mi.cur.iter.Error(); srcErr != nil {
+			return errors.Join(mi.err, srcErr)
+		}
+	}
 	return mi.err
 }
 

--- a/TreeDB/internal/merging/merging.go
+++ b/TreeDB/internal/merging/merging.go
@@ -277,7 +277,7 @@ func (mi *MergingIterator) ValueCopy(dst []byte) []byte {
 
 func (mi *MergingIterator) Error() error {
 	if mi.hasCur {
-		if srcErr := mi.cur.iter.Error(); srcErr != nil {
+		if srcErr := mi.cur.iter.Error(); srcErr != nil && srcErr != mi.err {
 			return errors.Join(mi.err, srcErr)
 		}
 	}

--- a/TreeDB/internal/merging/merging.go
+++ b/TreeDB/internal/merging/merging.go
@@ -155,6 +155,10 @@ func (mi *MergingIterator) Next() {
 	if !mi.valid {
 		panic("merging iterator invalid")
 	}
+	if mi.err != nil {
+		mi.valid = false
+		return
+	}
 
 	if mi.hasCur {
 		mi.cur.iter.Next()
@@ -239,14 +243,22 @@ func (mi *MergingIterator) Value() []byte {
 	if !mi.hasCur {
 		return nil
 	}
-	return mi.cur.iter.UnsafeValue()
+	value := mi.cur.iter.UnsafeValue()
+	if err := mi.cur.iter.Error(); err != nil {
+		mi.err = err
+	}
+	return value
 }
 
 func (mi *MergingIterator) UnsafeEntryWithRevision() ([]byte, page.ValuePtr, byte, page.EntryRevision) {
 	if !mi.valid || !mi.hasCur {
 		return nil, page.ValuePtr{}, 0, page.LegacyEntryRevision
 	}
-	return iterator.UnsafeEntryWithRevision(mi.cur.iter)
+	value, ptr, flags, revision := iterator.UnsafeEntryWithRevision(mi.cur.iter)
+	if err := mi.cur.iter.Error(); err != nil {
+		mi.err = err
+	}
+	return value, ptr, flags, revision
 }
 
 func (mi *MergingIterator) KeyCopy(dst []byte) []byte {

--- a/TreeDB/internal/merging/merging.go
+++ b/TreeDB/internal/merging/merging.go
@@ -2,7 +2,6 @@ package merging
 
 import (
 	"bytes"
-	"errors"
 
 	"github.com/snissn/gomap/TreeDB/internal/iterator"
 	"github.com/snissn/gomap/TreeDB/page"
@@ -276,10 +275,11 @@ func (mi *MergingIterator) ValueCopy(dst []byte) []byte {
 }
 
 func (mi *MergingIterator) Error() error {
+	if mi.err != nil {
+		return mi.err
+	}
 	if mi.hasCur {
-		if srcErr := mi.cur.iter.Error(); srcErr != nil && srcErr != mi.err {
-			return errors.Join(mi.err, srcErr)
-		}
+		return mi.cur.iter.Error()
 	}
 	return mi.err
 }

--- a/TreeDB/internal/merging/merging_test.go
+++ b/TreeDB/internal/merging/merging_test.go
@@ -2,6 +2,7 @@ package merging
 
 import (
 	"bytes"
+	"errors"
 	"reflect"
 	"testing"
 
@@ -53,6 +54,38 @@ func (m *mockUnsafeIter) Seek(key []byte) {
 	m.idx = len(m.data) // Exhausted
 }
 func (m *mockUnsafeIter) Domain() (start, end []byte) { return nil, nil }
+
+type valueErrorUnsafeIter struct {
+	*mockUnsafeIter
+	err         error
+	valueLoaded bool
+	entryLoaded bool
+	valueCopied bool
+}
+
+func (m *valueErrorUnsafeIter) UnsafeValue() []byte {
+	m.valueLoaded = true
+	return nil
+}
+
+func (m *valueErrorUnsafeIter) UnsafeEntry() ([]byte, page.ValuePtr, byte) {
+	m.entryLoaded = true
+	return nil, page.ValuePtr{}, 0
+}
+
+func (m *valueErrorUnsafeIter) Value() []byte { return m.UnsafeValue() }
+
+func (m *valueErrorUnsafeIter) ValueCopy(dst []byte) []byte {
+	m.valueCopied = true
+	return dst[:0]
+}
+
+func (m *valueErrorUnsafeIter) Error() error {
+	if m.valueLoaded || m.entryLoaded || m.valueCopied {
+		return m.err
+	}
+	return nil
+}
 
 type revisionEntry struct {
 	k, v string
@@ -170,6 +203,55 @@ func TestTwoWayMerger(t *testing.T) {
 
 	if !reflect.DeepEqual(results2, expected2) {
 		t.Errorf("Merge results mismatch (domain).\nGot: %v\nWant:%v", results2, expected2)
+	}
+}
+
+func TestTwoWayMergerSurfacesCurrentValueError(t *testing.T) {
+	want := errors.New("value load failed")
+	broken := &valueErrorUnsafeIter{
+		mockUnsafeIter: &mockUnsafeIter{data: []entry{{k: "A", v: "bad"}}},
+		err:            want,
+	}
+	other := &mockUnsafeIter{data: []entry{{k: "B", v: "ok"}}}
+
+	merged := NewTwoWayMerger(broken, other, nil, nil)
+	defer merged.Close()
+	if !merged.Valid() {
+		t.Fatal("merged iterator invalid, want first key A")
+	}
+	if string(merged.Key()) != "A" {
+		t.Fatalf("first key = %q, want A", merged.Key())
+	}
+	_ = merged.Value()
+	if !errors.Is(merged.Error(), want) {
+		t.Fatalf("Error() = %v, want %v", merged.Error(), want)
+	}
+}
+
+func TestHeapMergingIteratorSurfacesCurrentValueError(t *testing.T) {
+	want := errors.New("heap value load failed")
+	broken := &valueErrorUnsafeIter{
+		mockUnsafeIter: &mockUnsafeIter{data: []entry{{k: "A", v: "bad"}}},
+		err:            want,
+	}
+	middle := &mockUnsafeIter{data: []entry{{k: "B", v: "ok"}}}
+	oldest := &mockUnsafeIter{data: []entry{{k: "C", v: "ok"}}}
+
+	merged := NewMergingIterator([]IteratorSource{
+		{Iter: broken, Priority: 0},
+		{Iter: middle, Priority: 1},
+		{Iter: oldest, Priority: 2},
+	}, nil, nil)
+	defer merged.Close()
+	if !merged.Valid() {
+		t.Fatal("merged iterator invalid, want first key A")
+	}
+	if string(merged.Key()) != "A" {
+		t.Fatalf("first key = %q, want A", merged.Key())
+	}
+	_ = merged.Value()
+	if !errors.Is(merged.Error(), want) {
+		t.Fatalf("Error() = %v, want %v", merged.Error(), want)
 	}
 }
 

--- a/TreeDB/internal/merging/merging_test.go
+++ b/TreeDB/internal/merging/merging_test.go
@@ -228,6 +228,29 @@ func TestTwoWayMergerSurfacesCurrentValueError(t *testing.T) {
 	}
 }
 
+func TestTwoWayMergerSurfacesCurrentUnsafeEntryWithRevisionError(t *testing.T) {
+	want := errors.New("entry load failed")
+	broken := &valueErrorUnsafeIter{
+		mockUnsafeIter: &mockUnsafeIter{data: []entry{{k: "A", v: "bad"}}},
+		err:            want,
+	}
+	other := &mockUnsafeIter{data: []entry{{k: "B", v: "ok"}}}
+
+	merged := NewTwoWayMerger(broken, other, nil, nil)
+	defer merged.Close()
+	if !merged.Valid() {
+		t.Fatal("merged iterator invalid, want first key A")
+	}
+	revIt, ok := interface{}(merged).(iterator.RevisionUnsafeIterator)
+	if !ok {
+		t.Fatalf("merged iterator %T does not expose revisions", merged)
+	}
+	_, _, _, _ = revIt.UnsafeEntryWithRevision()
+	if got := merged.Error(); got != want {
+		t.Fatalf("Error() = %v, want direct %v", got, want)
+	}
+}
+
 func TestHeapMergingIteratorSurfacesCurrentValueError(t *testing.T) {
 	want := errors.New("heap value load failed")
 	broken := &valueErrorUnsafeIter{
@@ -252,6 +275,34 @@ func TestHeapMergingIteratorSurfacesCurrentValueError(t *testing.T) {
 	_ = merged.Value()
 	if !errors.Is(merged.Error(), want) {
 		t.Fatalf("Error() = %v, want %v", merged.Error(), want)
+	}
+}
+
+func TestHeapMergingIteratorSurfacesCurrentUnsafeEntryWithRevisionError(t *testing.T) {
+	want := errors.New("heap entry load failed")
+	broken := &valueErrorUnsafeIter{
+		mockUnsafeIter: &mockUnsafeIter{data: []entry{{k: "A", v: "bad"}}},
+		err:            want,
+	}
+	middle := &mockUnsafeIter{data: []entry{{k: "B", v: "ok"}}}
+	oldest := &mockUnsafeIter{data: []entry{{k: "C", v: "ok"}}}
+
+	merged := NewMergingIterator([]IteratorSource{
+		{Iter: broken, Priority: 0},
+		{Iter: middle, Priority: 1},
+		{Iter: oldest, Priority: 2},
+	}, nil, nil)
+	defer merged.Close()
+	if !merged.Valid() {
+		t.Fatal("merged iterator invalid, want first key A")
+	}
+	revIt, ok := merged.(iterator.RevisionUnsafeIterator)
+	if !ok {
+		t.Fatalf("merged iterator %T does not expose revisions", merged)
+	}
+	_, _, _, _ = revIt.UnsafeEntryWithRevision()
+	if got := merged.Error(); got != want {
+		t.Fatalf("Error() = %v, want direct %v", got, want)
 	}
 }
 

--- a/TreeDB/internal/merging/reverse.go
+++ b/TreeDB/internal/merging/reverse.go
@@ -127,6 +127,10 @@ func (mi *ReverseMergingIterator) Next() {
 	if !mi.valid {
 		panic("merging iterator invalid")
 	}
+	if mi.err != nil {
+		mi.valid = false
+		return
+	}
 
 	if mi.hasCur {
 		mi.cur.iter.Next()
@@ -220,7 +224,11 @@ func (mi *ReverseMergingIterator) Value() []byte {
 	if !mi.hasCur {
 		return nil
 	}
-	return mi.cur.iter.UnsafeValue()
+	value := mi.cur.iter.UnsafeValue()
+	if err := mi.cur.iter.Error(); err != nil {
+		mi.err = err
+	}
+	return value
 }
 
 func (mi *ReverseMergingIterator) KeyCopy(dst []byte) []byte {
@@ -237,7 +245,15 @@ func (mi *ReverseMergingIterator) ValueCopy(dst []byte) []byte {
 	return append(dst[:0], mi.Value()...)
 }
 
-func (mi *ReverseMergingIterator) Error() error { return mi.err }
+func (mi *ReverseMergingIterator) Error() error {
+	if mi.err != nil {
+		return mi.err
+	}
+	if mi.hasCur {
+		return mi.cur.iter.Error()
+	}
+	return mi.err
+}
 
 func (mi *ReverseMergingIterator) Close() error {
 	var firstErr error
@@ -285,6 +301,10 @@ func NewReverseTwoWayMerger(src1, src2 iterator.UnsafeIterator, start, end []byt
 func (m *ReverseTwoWayMerger) Next() {
 	if !m.valid {
 		panic("merging iterator invalid")
+	}
+	if m.err != nil {
+		m.valid = false
+		return
 	}
 	if m.cur != nil {
 		m.cur.Next()
@@ -357,7 +377,11 @@ func (m *ReverseTwoWayMerger) Value() []byte {
 	if m.cur == nil {
 		return nil
 	}
-	return m.cur.UnsafeValue()
+	value := m.cur.UnsafeValue()
+	if err := m.cur.Error(); err != nil {
+		m.err = err
+	}
+	return value
 }
 
 func (m *ReverseTwoWayMerger) KeyCopy(dst []byte) []byte {
@@ -374,7 +398,15 @@ func (m *ReverseTwoWayMerger) ValueCopy(dst []byte) []byte {
 	return append(dst[:0], m.Value()...)
 }
 
-func (m *ReverseTwoWayMerger) Error() error { return m.err }
+func (m *ReverseTwoWayMerger) Error() error {
+	if m.err != nil {
+		return m.err
+	}
+	if m.cur != nil {
+		return m.cur.Error()
+	}
+	return m.err
+}
 
 func (m *ReverseTwoWayMerger) Close() error {
 	var firstErr error

--- a/TreeDB/internal/merging/reverse_test.go
+++ b/TreeDB/internal/merging/reverse_test.go
@@ -2,6 +2,7 @@ package merging
 
 import (
 	"bytes"
+	"errors"
 	"reflect"
 	"testing"
 
@@ -59,6 +60,38 @@ func (m *mockUnsafeReverseIter) Seek(key []byte) {
 }
 
 func (m *mockUnsafeReverseIter) Domain() (start, end []byte) { return nil, nil }
+
+type valueErrorUnsafeReverseIter struct {
+	*mockUnsafeReverseIter
+	err         error
+	valueLoaded bool
+	entryLoaded bool
+	valueCopied bool
+}
+
+func (m *valueErrorUnsafeReverseIter) UnsafeValue() []byte {
+	m.valueLoaded = true
+	return nil
+}
+
+func (m *valueErrorUnsafeReverseIter) UnsafeEntry() ([]byte, page.ValuePtr, byte) {
+	m.entryLoaded = true
+	return nil, page.ValuePtr{}, 0
+}
+
+func (m *valueErrorUnsafeReverseIter) Value() []byte { return m.UnsafeValue() }
+
+func (m *valueErrorUnsafeReverseIter) ValueCopy(dst []byte) []byte {
+	m.valueCopied = true
+	return dst[:0]
+}
+
+func (m *valueErrorUnsafeReverseIter) Error() error {
+	if m.valueLoaded || m.entryLoaded || m.valueCopied {
+		return m.err
+	}
+	return nil
+}
 
 func TestReverseTwoWayMerger(t *testing.T) {
 	// Mutable (src1, higher precedence): A:1, B:del, C:1, E:1
@@ -131,6 +164,64 @@ func TestReverseTwoWayMerger(t *testing.T) {
 
 	if !reflect.DeepEqual(results2, expected2) {
 		t.Errorf("Reverse merge results mismatch (domain).\nGot: %v\nWant:%v", results2, expected2)
+	}
+}
+
+func TestReverseTwoWayMergerSurfacesCurrentValueError(t *testing.T) {
+	want := errors.New("reverse value load failed")
+	broken := &valueErrorUnsafeReverseIter{
+		mockUnsafeReverseIter: &mockUnsafeReverseIter{
+			data: []entry{{k: "Z", v: "bad"}},
+			idx:  0,
+		},
+		err: want,
+	}
+	other := &mockUnsafeReverseIter{
+		data: []entry{{k: "A", v: "ok"}},
+		idx:  0,
+	}
+
+	merged := NewReverseTwoWayMerger(broken, other, nil, nil)
+	defer merged.Close()
+	if !merged.Valid() {
+		t.Fatal("merged iterator invalid, want first key Z")
+	}
+	if string(merged.Key()) != "Z" {
+		t.Fatalf("first key = %q, want Z", merged.Key())
+	}
+	_ = merged.Value()
+	if !errors.Is(merged.Error(), want) {
+		t.Fatalf("Error() = %v, want %v", merged.Error(), want)
+	}
+}
+
+func TestReverseHeapMergingIteratorSurfacesCurrentValueError(t *testing.T) {
+	want := errors.New("reverse heap value load failed")
+	broken := &valueErrorUnsafeReverseIter{
+		mockUnsafeReverseIter: &mockUnsafeReverseIter{
+			data: []entry{{k: "Z", v: "bad"}},
+			idx:  0,
+		},
+		err: want,
+	}
+	middle := &mockUnsafeReverseIter{data: []entry{{k: "B", v: "ok"}}, idx: 0}
+	oldest := &mockUnsafeReverseIter{data: []entry{{k: "A", v: "ok"}}, idx: 0}
+
+	merged := NewReverseMergingIterator([]IteratorSource{
+		{Iter: broken, Priority: 0},
+		{Iter: middle, Priority: 1},
+		{Iter: oldest, Priority: 2},
+	}, nil, nil)
+	defer merged.Close()
+	if !merged.Valid() {
+		t.Fatal("merged iterator invalid, want first key Z")
+	}
+	if string(merged.Key()) != "Z" {
+		t.Fatalf("first key = %q, want Z", merged.Key())
+	}
+	_ = merged.Value()
+	if !errors.Is(merged.Error(), want) {
+		t.Fatalf("Error() = %v, want %v", merged.Error(), want)
 	}
 }
 

--- a/TreeDB/internal/merging/twoway.go
+++ b/TreeDB/internal/merging/twoway.go
@@ -2,6 +2,7 @@ package merging
 
 import (
 	"bytes"
+	"errors"
 
 	"github.com/snissn/gomap/TreeDB/internal/iterator"
 	"github.com/snissn/gomap/TreeDB/page"
@@ -140,6 +141,11 @@ func (m *TwoWayMerger) ValueCopy(dst []byte) []byte {
 }
 
 func (m *TwoWayMerger) Error() error {
+	if m.cur != nil {
+		if srcErr := m.cur.Error(); srcErr != nil {
+			return errors.Join(m.err, srcErr)
+		}
+	}
 	return m.err
 }
 

--- a/TreeDB/internal/merging/twoway.go
+++ b/TreeDB/internal/merging/twoway.go
@@ -2,7 +2,6 @@ package merging
 
 import (
 	"bytes"
-	"errors"
 
 	"github.com/snissn/gomap/TreeDB/internal/iterator"
 	"github.com/snissn/gomap/TreeDB/page"
@@ -153,10 +152,11 @@ func (m *TwoWayMerger) ValueCopy(dst []byte) []byte {
 }
 
 func (m *TwoWayMerger) Error() error {
+	if m.err != nil {
+		return m.err
+	}
 	if m.cur != nil {
-		if srcErr := m.cur.Error(); srcErr != nil && srcErr != m.err {
-			return errors.Join(m.err, srcErr)
-		}
+		return m.cur.Error()
 	}
 	return m.err
 }

--- a/TreeDB/internal/merging/twoway.go
+++ b/TreeDB/internal/merging/twoway.go
@@ -154,7 +154,7 @@ func (m *TwoWayMerger) ValueCopy(dst []byte) []byte {
 
 func (m *TwoWayMerger) Error() error {
 	if m.cur != nil {
-		if srcErr := m.cur.Error(); srcErr != nil {
+		if srcErr := m.cur.Error(); srcErr != nil && srcErr != m.err {
 			return errors.Join(m.err, srcErr)
 		}
 	}

--- a/TreeDB/internal/merging/twoway.go
+++ b/TreeDB/internal/merging/twoway.go
@@ -39,6 +39,10 @@ func (m *TwoWayMerger) Next() {
 	if !m.valid {
 		panic("merging iterator invalid")
 	}
+	if m.err != nil {
+		m.valid = false
+		return
+	}
 	if m.cur != nil {
 		m.cur.Next()
 	}
@@ -116,14 +120,22 @@ func (m *TwoWayMerger) Value() []byte {
 	if m.cur == nil {
 		return nil
 	}
-	return m.cur.UnsafeValue()
+	value := m.cur.UnsafeValue()
+	if err := m.cur.Error(); err != nil {
+		m.err = err
+	}
+	return value
 }
 
 func (m *TwoWayMerger) UnsafeEntryWithRevision() ([]byte, page.ValuePtr, byte, page.EntryRevision) {
 	if !m.valid || m.cur == nil {
 		return nil, page.ValuePtr{}, 0, page.LegacyEntryRevision
 	}
-	return iterator.UnsafeEntryWithRevision(m.cur)
+	value, ptr, flags, revision := iterator.UnsafeEntryWithRevision(m.cur)
+	if err := m.cur.Error(); err != nil {
+		m.err = err
+	}
+	return value, ptr, flags, revision
 }
 
 func (m *TwoWayMerger) KeyCopy(dst []byte) []byte {

--- a/TreeDB/internal/raftcluster/hashicorp_raft_test.go
+++ b/TreeDB/internal/raftcluster/hashicorp_raft_test.go
@@ -1028,9 +1028,9 @@ func openHashicorpRaftTestDBAndFSM(tb testing.TB, cfg Config) (*backenddb.DB, *r
 
 func hashicorpRaftFastTestConfig() *hraft.Config {
 	conf := hraft.DefaultConfig()
-	conf.HeartbeatTimeout = 200 * time.Millisecond
-	conf.ElectionTimeout = 200 * time.Millisecond
-	conf.LeaderLeaseTimeout = 100 * time.Millisecond
+	conf.HeartbeatTimeout = 500 * time.Millisecond
+	conf.ElectionTimeout = 500 * time.Millisecond
+	conf.LeaderLeaseTimeout = 250 * time.Millisecond
 	conf.CommitTimeout = 10 * time.Millisecond
 	conf.SnapshotInterval = time.Hour
 	conf.SnapshotThreshold = ^uint64(0)

--- a/TreeDB/public.go
+++ b/TreeDB/public.go
@@ -37,9 +37,10 @@ const LegacyEntryRevision = page.LegacyEntryRevision
 
 // ConditionalTxn is TreeDB's native conditional transaction type.
 type ConditionalTxn struct {
-	backend      *db.ConditionalTxn
-	cached       caching.ConditionalTxn
-	cachedActive bool
+	backend         *db.ConditionalTxn
+	cached          caching.ConditionalTxn
+	cachedActive    bool
+	snapshotExposed bool
 }
 
 type MaintenancePhase = caching.MaintenancePhase
@@ -1755,6 +1756,7 @@ func (db *DB) initConditionalTxn(tx *ConditionalTxn, withSnapshot bool) error {
 		}
 		tx.backend = nil
 		tx.cachedActive = true
+		tx.snapshotExposed = withSnapshot
 		return nil
 	}
 	if db.backend == nil {
@@ -1764,7 +1766,7 @@ func (db *DB) initConditionalTxn(tx *ConditionalTxn, withSnapshot bool) error {
 	if err != nil {
 		return err
 	}
-	*tx = ConditionalTxn{backend: backendTx}
+	*tx = ConditionalTxn{backend: backendTx, snapshotExposed: withSnapshot}
 	return nil
 }
 

--- a/TreeDB/public.go
+++ b/TreeDB/public.go
@@ -1725,6 +1725,8 @@ func (db *DB) InitConditionalTxn(tx *ConditionalTxn) error {
 
 // InitConditionalTxnWithSnapshot initializes tx as a native conditional
 // transaction and exposes its pinned opening snapshot through tx.Snapshot.
+// The transaction-owned snapshot supports point reads; range iteration fails
+// closed until native conditional range guards are part of the public contract.
 // Callers must pass zero-value or closed transaction storage.
 func (db *DB) InitConditionalTxnWithSnapshot(tx *ConditionalTxn) error {
 	return db.initConditionalTxn(tx, true)
@@ -1777,7 +1779,9 @@ func (db *DB) NewConditionalTxn() (*ConditionalTxn, error) {
 
 // NewConditionalTxnWithSnapshot opens a native conditional transaction and
 // exposes its pinned opening snapshot through tx.Snapshot. The transaction owns
-// that snapshot and closes it on Commit, CommitSync, or Close.
+// that snapshot and closes it on Commit, CommitSync, or Close. The snapshot
+// supports point reads; range iteration fails closed until native conditional
+// range guards are part of the public contract.
 func (db *DB) NewConditionalTxnWithSnapshot() (*ConditionalTxn, error) {
 	tx := &ConditionalTxn{}
 	if err := db.InitConditionalTxnWithSnapshot(tx); err != nil {

--- a/TreeDB/public.go
+++ b/TreeDB/public.go
@@ -1720,6 +1720,17 @@ func (db *DB) UpdateSync(key []byte, fn UpdateFunc) error {
 // InitConditionalTxn initializes tx as a native conditional transaction.
 // Callers must pass zero-value or closed transaction storage.
 func (db *DB) InitConditionalTxn(tx *ConditionalTxn) error {
+	return db.initConditionalTxn(tx, false)
+}
+
+// InitConditionalTxnWithSnapshot initializes tx as a native conditional
+// transaction and exposes its pinned opening snapshot through tx.Snapshot.
+// Callers must pass zero-value or closed transaction storage.
+func (db *DB) InitConditionalTxnWithSnapshot(tx *ConditionalTxn) error {
+	return db.initConditionalTxn(tx, true)
+}
+
+func (db *DB) initConditionalTxn(tx *ConditionalTxn, withSnapshot bool) error {
 	if tx == nil || tx.cachedActive || tx.backend != nil {
 		return ErrConditionalTxnClosed
 	}
@@ -1732,7 +1743,12 @@ func (db *DB) InitConditionalTxn(tx *ConditionalTxn) error {
 		if db.commandWALCached {
 			return ErrConditionalTxnUnsupported
 		}
-		if err := db.cached.InitConditionalTxn(&tx.cached); err != nil {
+		if withSnapshot {
+			err = db.cached.InitConditionalTxnWithSnapshot(&tx.cached)
+		} else {
+			err = db.cached.InitConditionalTxn(&tx.cached)
+		}
+		if err != nil {
 			return err
 		}
 		tx.backend = nil
@@ -1754,6 +1770,17 @@ func (db *DB) InitConditionalTxn(tx *ConditionalTxn) error {
 func (db *DB) NewConditionalTxn() (*ConditionalTxn, error) {
 	tx := &ConditionalTxn{}
 	if err := db.InitConditionalTxn(tx); err != nil {
+		return nil, err
+	}
+	return tx, nil
+}
+
+// NewConditionalTxnWithSnapshot opens a native conditional transaction and
+// exposes its pinned opening snapshot through tx.Snapshot. The transaction owns
+// that snapshot and closes it on Commit, CommitSync, or Close.
+func (db *DB) NewConditionalTxnWithSnapshot() (*ConditionalTxn, error) {
+	tx := &ConditionalTxn{}
+	if err := db.InitConditionalTxnWithSnapshot(tx); err != nil {
 		return nil, err
 	}
 	return tx, nil

--- a/TreeDB/snapshot.go
+++ b/TreeDB/snapshot.go
@@ -24,6 +24,8 @@ type Snapshot interface {
 	Has(key []byte) (bool, error)
 	HasMany(keys [][]byte) ([]bool, error)
 	HasPrefixes(prefixes [][]byte) ([]bool, error)
+	Iterate(start, end []byte, fn func(key, value []byte) error) error
+	ReverseIterate(start, end []byte, fn func(key, value []byte) error) error
 
 	GetEntry(key []byte) (node.LeafEntry, error)
 	GetEntryExact(key []byte) (node.LeafEntry, error)

--- a/TreeDB/snapshot_iterate_test.go
+++ b/TreeDB/snapshot_iterate_test.go
@@ -88,7 +88,28 @@ func TestSnapshotIterateBackendFastPathUsesPinnedView(t *testing.T) {
 	}
 }
 
-func TestConditionalTxnSnapshotUsesPinnedPointAndRangeView(t *testing.T) {
+func TestSnapshotIterateNilCallbackFailsClosed(t *testing.T) {
+	d, err := Open(Options{Dir: t.TempDir(), FlushThreshold: 1 << 30})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer d.Close()
+
+	snap := d.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("AcquireSnapshot returned nil")
+	}
+	defer snap.Close()
+
+	if err := snap.Iterate([]byte("snap/"), []byte("snap0"), nil); err == nil {
+		t.Fatal("snapshot Iterate nil callback returned nil error")
+	}
+	if err := snap.ReverseIterate([]byte("snap/"), []byte("snap0"), nil); err == nil {
+		t.Fatal("snapshot ReverseIterate nil callback returned nil error")
+	}
+}
+
+func TestConditionalTxnSnapshotUsesPinnedPointViewAndRangeFailsClosed(t *testing.T) {
 	d, err := Open(Options{Dir: t.TempDir(), FlushThreshold: 1 << 30})
 	if err != nil {
 		t.Fatalf("open: %v", err)
@@ -127,9 +148,10 @@ func TestConditionalTxnSnapshotUsesPinnedPointAndRangeView(t *testing.T) {
 		t.Fatalf("tx.GetVersionedAppend=%q, want 1", gotValue)
 	}
 
-	got := collectSnapshotIteratePairs(t, snap, false)
-	if want := []string{"snap/a=1", "snap/b=2"}; !reflect.DeepEqual(got, want) {
-		t.Fatalf("tx snapshot Iterate=%v want %v", got, want)
+	if err := snap.Iterate([]byte("snap/"), []byte("snap0"), func(key, value []byte) error {
+		return nil
+	}); !errors.Is(err, ErrConditionalTxnUnsupported) {
+		t.Fatalf("tx snapshot Iterate error=%v, want ErrConditionalTxnUnsupported", err)
 	}
 
 	if err := tx.Commit(); !errors.Is(err, ErrConcurrentModification) {
@@ -177,14 +199,41 @@ func TestConditionalTxnRequireReadVersionConflictsAfterSnapshotRead(t *testing.T
 	if !bytes.Equal(gotValue, []byte("1")) {
 		t.Fatalf("snapshot GetVersionedAppend=%q, want 1", gotValue)
 	}
-	if err := tx.RequireReadVersion([]byte("snap/a"), revision, true); err != nil {
-		t.Fatalf("tx.RequireReadVersion: %v", err)
+	if err := tx.RequireReadVersion([]byte("snap/a"), revision, true); !errors.Is(err, ErrConcurrentModification) {
+		t.Fatalf("tx.RequireReadVersion error=%v, want ErrConcurrentModification", err)
 	}
-	if err := tx.Set([]byte("snap/b"), []byte("inside")); err != nil {
-		t.Fatalf("tx.Set: %v", err)
+}
+
+func TestConditionalTxnRequireReadVersionRejectsPreTxnSnapshotRevision(t *testing.T) {
+	d, err := Open(Options{Dir: t.TempDir(), FlushThreshold: 1 << 30})
+	if err != nil {
+		t.Fatalf("open: %v", err)
 	}
-	if err := tx.Commit(); !errors.Is(err, ErrConcurrentModification) {
-		t.Fatalf("tx.Commit error=%v, want ErrConcurrentModification", err)
+	defer d.Close()
+
+	if err := d.Set([]byte("snap/a"), []byte("1")); err != nil {
+		t.Fatalf("set a: %v", err)
+	}
+	snap := d.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("AcquireSnapshot returned nil")
+	}
+	defer snap.Close()
+	_, revision, err := snap.GetVersionedAppend([]byte("snap/a"), nil)
+	if err != nil {
+		t.Fatalf("snapshot GetVersionedAppend: %v", err)
+	}
+
+	if err := d.Set([]byte("snap/a"), []byte("2")); err != nil {
+		t.Fatalf("outside set a: %v", err)
+	}
+	tx, err := d.NewConditionalTxn()
+	if err != nil {
+		t.Fatalf("NewConditionalTxn: %v", err)
+	}
+	defer tx.Close()
+	if err := tx.RequireReadVersion([]byte("snap/a"), revision, true); !errors.Is(err, ErrConcurrentModification) {
+		t.Fatalf("tx.RequireReadVersion error=%v, want ErrConcurrentModification", err)
 	}
 }
 

--- a/TreeDB/snapshot_iterate_test.go
+++ b/TreeDB/snapshot_iterate_test.go
@@ -1,6 +1,8 @@
 package treedb
 
 import (
+	"bytes"
+	"errors"
 	"reflect"
 	"testing"
 )
@@ -83,6 +85,58 @@ func TestSnapshotIterateBackendFastPathUsesPinnedView(t *testing.T) {
 	got := collectSnapshotIteratePairs(t, snap, false)
 	if want := []string{"snap/a=1", "snap/b=2"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("snapshot Iterate=%v want %v", got, want)
+	}
+}
+
+func TestConditionalTxnSnapshotUsesPinnedPointAndRangeView(t *testing.T) {
+	d, err := Open(Options{Dir: t.TempDir(), FlushThreshold: 1 << 30})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer d.Close()
+
+	if err := d.Set([]byte("snap/a"), []byte("1")); err != nil {
+		t.Fatalf("set a: %v", err)
+	}
+	if err := d.Set([]byte("snap/b"), []byte("2")); err != nil {
+		t.Fatalf("set b: %v", err)
+	}
+
+	tx, err := d.NewConditionalTxnWithSnapshot()
+	if err != nil {
+		t.Fatalf("NewConditionalTxnWithSnapshot: %v", err)
+	}
+	defer tx.Close()
+	snap := tx.Snapshot()
+	if snap == nil {
+		t.Fatal("tx.Snapshot returned nil")
+	}
+
+	if err := d.Delete([]byte("snap/a")); err != nil {
+		t.Fatalf("outside delete a: %v", err)
+	}
+	if err := d.Set([]byte("snap/c"), []byte("3")); err != nil {
+		t.Fatalf("outside set c: %v", err)
+	}
+
+	gotValue, _, err := tx.GetVersionedAppend([]byte("snap/a"), nil)
+	if err != nil {
+		t.Fatalf("tx.GetVersionedAppend after outside delete: %v", err)
+	}
+	if !bytes.Equal(gotValue, []byte("1")) {
+		t.Fatalf("tx.GetVersionedAppend=%q, want 1", gotValue)
+	}
+
+	got := collectSnapshotIteratePairs(t, snap, false)
+	if want := []string{"snap/a=1", "snap/b=2"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("tx snapshot Iterate=%v want %v", got, want)
+	}
+
+	if err := tx.Commit(); !errors.Is(err, ErrConcurrentModification) {
+		t.Fatalf("tx.Commit error=%v, want ErrConcurrentModification", err)
+	}
+	if tx.Snapshot() != nil {
+		t.Fatal("tx.Snapshot after Commit returned non-nil")
 	}
 }
 

--- a/TreeDB/snapshot_iterate_test.go
+++ b/TreeDB/snapshot_iterate_test.go
@@ -1,0 +1,106 @@
+package treedb
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSnapshotIterateUsesPinnedView(t *testing.T) {
+	d, err := Open(Options{Dir: t.TempDir(), FlushThreshold: 1 << 30})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer d.Close()
+
+	if err := d.Set([]byte("snap/a"), []byte("1")); err != nil {
+		t.Fatalf("set a: %v", err)
+	}
+	if err := d.Set([]byte("snap/b"), []byte("2")); err != nil {
+		t.Fatalf("set b: %v", err)
+	}
+
+	snap := d.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("AcquireSnapshot returned nil")
+	}
+	defer snap.Close()
+
+	if err := d.Set([]byte("snap/c"), []byte("3")); err != nil {
+		t.Fatalf("set c: %v", err)
+	}
+
+	got := collectSnapshotIteratePairs(t, snap, false)
+	if want := []string{"snap/a=1", "snap/b=2"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("snapshot Iterate=%v want %v", got, want)
+	}
+
+	got = collectSnapshotIteratePairs(t, snap, true)
+	if want := []string{"snap/b=2", "snap/a=1"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("snapshot ReverseIterate=%v want %v", got, want)
+	}
+
+	current := d.AcquireSnapshot()
+	if current == nil {
+		t.Fatal("current AcquireSnapshot returned nil")
+	}
+	defer current.Close()
+	got = collectSnapshotIteratePairs(t, current, false)
+	if want := []string{"snap/a=1", "snap/b=2", "snap/c=3"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("current Iterate=%v want %v", got, want)
+	}
+}
+
+func TestSnapshotIterateBackendFastPathUsesPinnedView(t *testing.T) {
+	d, err := Open(Options{Dir: t.TempDir(), FlushThreshold: 1 << 30})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer d.Close()
+
+	if err := d.SetSync([]byte("snap/a"), []byte("1")); err != nil {
+		t.Fatalf("set a: %v", err)
+	}
+	if err := d.SetSync([]byte("snap/b"), []byte("2")); err != nil {
+		t.Fatalf("set b: %v", err)
+	}
+	if err := d.Checkpoint(); err != nil {
+		t.Fatalf("checkpoint: %v", err)
+	}
+
+	snap := d.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("AcquireSnapshot returned nil")
+	}
+	defer snap.Close()
+
+	if err := d.SetSync([]byte("snap/c"), []byte("3")); err != nil {
+		t.Fatalf("set c: %v", err)
+	}
+	if err := d.Checkpoint(); err != nil {
+		t.Fatalf("checkpoint c: %v", err)
+	}
+
+	got := collectSnapshotIteratePairs(t, snap, false)
+	if want := []string{"snap/a=1", "snap/b=2"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("snapshot Iterate=%v want %v", got, want)
+	}
+}
+
+func collectSnapshotIteratePairs(t *testing.T, snap Snapshot, reverse bool) []string {
+	t.Helper()
+	var got []string
+	fn := func(key, value []byte) error {
+		got = append(got, string(key)+"="+string(value))
+		return nil
+	}
+	var err error
+	if reverse {
+		err = snap.ReverseIterate([]byte("snap/"), []byte("snap0"), fn)
+	} else {
+		err = snap.Iterate([]byte("snap/"), []byte("snap0"), fn)
+	}
+	if err != nil {
+		t.Fatalf("snapshot iterate: %v", err)
+	}
+	return got
+}

--- a/TreeDB/snapshot_iterate_test.go
+++ b/TreeDB/snapshot_iterate_test.go
@@ -145,6 +145,9 @@ func TestConditionalTxnSnapshotUsesPinnedPointViewAndRangeFailsClosed(t *testing
 	if err := d.Set([]byte("snap/c"), []byte("3")); err != nil {
 		t.Fatalf("outside set c: %v", err)
 	}
+	if err := tx.Set([]byte("snap/b"), []byte("staged")); err != nil {
+		t.Fatalf("stage b: %v", err)
+	}
 
 	gotValue, _, err := snap.GetVersionedAppend([]byte("snap/a"), nil)
 	if err != nil {
@@ -159,6 +162,20 @@ func TestConditionalTxnSnapshotUsesPinnedPointViewAndRangeFailsClosed(t *testing
 	}
 	if !bytes.Equal(gotB, []byte("2")) {
 		t.Fatalf("tx snapshot Get b=%q, want 2", gotB)
+	}
+	gotMissing, err := snap.Get([]byte("snap/missing"))
+	if err != nil {
+		t.Fatalf("tx snapshot Get missing: %v", err)
+	}
+	if gotMissing != nil {
+		t.Fatalf("tx snapshot Get missing=%q, want nil", gotMissing)
+	}
+	gotVersionedMissing, _, err := snap.GetVersioned([]byte("snap/missing-versioned"))
+	if err != nil {
+		t.Fatalf("tx snapshot GetVersioned missing: %v", err)
+	}
+	if gotVersionedMissing != nil {
+		t.Fatalf("tx snapshot GetVersioned missing=%q, want nil", gotVersionedMissing)
 	}
 	type seenMany struct {
 		index int

--- a/TreeDB/snapshot_iterate_test.go
+++ b/TreeDB/snapshot_iterate_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"reflect"
+	"strconv"
 	"testing"
 )
 
@@ -140,12 +141,31 @@ func TestConditionalTxnSnapshotUsesPinnedPointViewAndRangeFailsClosed(t *testing
 		t.Fatalf("outside set c: %v", err)
 	}
 
-	gotValue, _, err := tx.GetVersionedAppend([]byte("snap/a"), nil)
+	gotValue, _, err := snap.GetVersionedAppend([]byte("snap/a"), nil)
 	if err != nil {
-		t.Fatalf("tx.GetVersionedAppend after outside delete: %v", err)
+		t.Fatalf("tx snapshot GetVersionedAppend after outside delete: %v", err)
 	}
 	if !bytes.Equal(gotValue, []byte("1")) {
-		t.Fatalf("tx.GetVersionedAppend=%q, want 1", gotValue)
+		t.Fatalf("tx snapshot GetVersionedAppend=%q, want 1", gotValue)
+	}
+	gotB, err := snap.Get([]byte("snap/b"))
+	if err != nil {
+		t.Fatalf("tx snapshot Get b: %v", err)
+	}
+	if !bytes.Equal(gotB, []byte("2")) {
+		t.Fatalf("tx snapshot Get b=%q, want 2", gotB)
+	}
+	var seen []string
+	err = snap.GetManyView([][]byte{[]byte("snap/b"), []byte("snap/missing")}, func(index int, key, value []byte, found bool) error {
+		seen = append(seen, strconv.Itoa(index)+":"+string(key)+":"+string(value)+":"+strconv.FormatBool(found))
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("tx snapshot GetManyView: %v", err)
+	}
+	wantSeen := []string{"0:snap/b:2:true", "1:snap/missing::false"}
+	if !reflect.DeepEqual(seen, wantSeen) {
+		t.Fatalf("tx snapshot GetManyView=%v, want %v", seen, wantSeen)
 	}
 
 	if err := snap.Iterate([]byte("snap/"), []byte("snap0"), func(key, value []byte) error {

--- a/TreeDB/snapshot_iterate_test.go
+++ b/TreeDB/snapshot_iterate_test.go
@@ -164,15 +164,15 @@ func TestConditionalTxnSnapshotUsesPinnedPointViewAndRangeFailsClosed(t *testing
 		t.Fatalf("tx snapshot Get b=%q, want 2", gotB)
 	}
 	gotMissing, err := snap.Get([]byte("snap/missing"))
-	if err != nil {
-		t.Fatalf("tx snapshot Get missing: %v", err)
+	if !errors.Is(err, ErrKeyNotFound) {
+		t.Fatalf("tx snapshot Get missing err=%v, want ErrKeyNotFound", err)
 	}
 	if gotMissing != nil {
 		t.Fatalf("tx snapshot Get missing=%q, want nil", gotMissing)
 	}
 	gotVersionedMissing, _, err := snap.GetVersioned([]byte("snap/missing-versioned"))
-	if err != nil {
-		t.Fatalf("tx snapshot GetVersioned missing: %v", err)
+	if !errors.Is(err, ErrKeyNotFound) {
+		t.Fatalf("tx snapshot GetVersioned missing err=%v, want ErrKeyNotFound", err)
 	}
 	if gotVersionedMissing != nil {
 		t.Fatalf("tx snapshot GetVersioned missing=%q, want nil", gotVersionedMissing)

--- a/TreeDB/snapshot_iterate_test.go
+++ b/TreeDB/snapshot_iterate_test.go
@@ -199,8 +199,14 @@ func TestConditionalTxnRequireReadVersionConflictsAfterSnapshotRead(t *testing.T
 	if !bytes.Equal(gotValue, []byte("1")) {
 		t.Fatalf("snapshot GetVersionedAppend=%q, want 1", gotValue)
 	}
-	if err := tx.RequireReadVersion([]byte("snap/a"), revision, true); !errors.Is(err, ErrConcurrentModification) {
-		t.Fatalf("tx.RequireReadVersion error=%v, want ErrConcurrentModification", err)
+	if err := tx.RequireReadVersion([]byte("snap/a"), revision, true); err != nil {
+		t.Fatalf("tx.RequireReadVersion: %v", err)
+	}
+	if err := tx.Set([]byte("snap/b"), []byte("inside")); err != nil {
+		t.Fatalf("tx.Set: %v", err)
+	}
+	if err := tx.Commit(); !errors.Is(err, ErrConcurrentModification) {
+		t.Fatalf("tx.Commit error=%v, want ErrConcurrentModification", err)
 	}
 }
 

--- a/TreeDB/snapshot_iterate_test.go
+++ b/TreeDB/snapshot_iterate_test.go
@@ -162,6 +162,43 @@ func TestConditionalTxnSnapshotUsesPinnedPointViewAndRangeFailsClosed(t *testing
 	}
 }
 
+func TestConditionalTxnSnapshotRequiresWithSnapshotInitializer(t *testing.T) {
+	cached, err := Open(Options{Dir: t.TempDir(), FlushThreshold: 1 << 30})
+	if err != nil {
+		t.Fatalf("open cached: %v", err)
+	}
+	defer cached.Close()
+
+	tx, err := cached.NewConditionalTxn()
+	if err != nil {
+		t.Fatalf("cached NewConditionalTxn: %v", err)
+	}
+	if snap := tx.Snapshot(); snap != nil {
+		t.Fatalf("cached NewConditionalTxn Snapshot()=%T, want nil", snap)
+	}
+	if err := tx.Close(); err != nil {
+		t.Fatalf("cached tx Close: %v", err)
+	}
+
+	backend, cleanup, err := OpenBackend(Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("OpenBackend: %v", err)
+	}
+	defer cleanup()
+
+	backendWrapper := &DB{backend: backend}
+	tx, err = backendWrapper.NewConditionalTxn()
+	if err != nil {
+		t.Fatalf("backend NewConditionalTxn: %v", err)
+	}
+	if snap := tx.Snapshot(); snap != nil {
+		t.Fatalf("backend NewConditionalTxn Snapshot()=%T, want nil", snap)
+	}
+	if err := tx.Close(); err != nil {
+		t.Fatalf("backend tx Close: %v", err)
+	}
+}
+
 func TestConditionalTxnRequireReadVersionConflictsAfterSnapshotRead(t *testing.T) {
 	d, err := Open(Options{Dir: t.TempDir(), FlushThreshold: 1 << 30})
 	if err != nil {

--- a/TreeDB/snapshot_iterate_test.go
+++ b/TreeDB/snapshot_iterate_test.go
@@ -140,6 +140,54 @@ func TestConditionalTxnSnapshotUsesPinnedPointAndRangeView(t *testing.T) {
 	}
 }
 
+func TestConditionalTxnRequireReadVersionConflictsAfterSnapshotRead(t *testing.T) {
+	d, err := Open(Options{Dir: t.TempDir(), FlushThreshold: 1 << 30})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer d.Close()
+
+	if err := d.Set([]byte("snap/a"), []byte("1")); err != nil {
+		t.Fatalf("set a: %v", err)
+	}
+	if err := d.Set([]byte("snap/b"), []byte("2")); err != nil {
+		t.Fatalf("set b: %v", err)
+	}
+
+	tx, err := d.NewConditionalTxn()
+	if err != nil {
+		t.Fatalf("NewConditionalTxn: %v", err)
+	}
+	defer tx.Close()
+
+	snap := d.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("AcquireSnapshot returned nil")
+	}
+	defer snap.Close()
+
+	if err := d.Delete([]byte("snap/a")); err != nil {
+		t.Fatalf("outside delete a: %v", err)
+	}
+
+	gotValue, revision, err := snap.GetVersionedAppend([]byte("snap/a"), nil)
+	if err != nil {
+		t.Fatalf("snapshot GetVersionedAppend after outside delete: %v", err)
+	}
+	if !bytes.Equal(gotValue, []byte("1")) {
+		t.Fatalf("snapshot GetVersionedAppend=%q, want 1", gotValue)
+	}
+	if err := tx.RequireReadVersion([]byte("snap/a"), revision, true); err != nil {
+		t.Fatalf("tx.RequireReadVersion: %v", err)
+	}
+	if err := tx.Set([]byte("snap/b"), []byte("inside")); err != nil {
+		t.Fatalf("tx.Set: %v", err)
+	}
+	if err := tx.Commit(); !errors.Is(err, ErrConcurrentModification) {
+		t.Fatalf("tx.Commit error=%v, want ErrConcurrentModification", err)
+	}
+}
+
 func collectSnapshotIteratePairs(t *testing.T, snap Snapshot, reverse bool) []string {
 	t.Helper()
 	var got []string

--- a/TreeDB/snapshot_iterate_test.go
+++ b/TreeDB/snapshot_iterate_test.go
@@ -125,6 +125,9 @@ func TestConditionalTxnSnapshotUsesPinnedPointViewAndRangeFailsClosed(t *testing
 	if err := d.Set([]byte("snap/empty"), []byte{}); err != nil {
 		t.Fatalf("set empty: %v", err)
 	}
+	if err := d.Set(nil, []byte("nil-key")); err != nil {
+		t.Fatalf("set nil key: %v", err)
+	}
 
 	tx, err := d.NewConditionalTxnWithSnapshot()
 	if err != nil {
@@ -165,7 +168,7 @@ func TestConditionalTxnSnapshotUsesPinnedPointViewAndRangeFailsClosed(t *testing
 		nil   bool
 	}
 	var seen []seenMany
-	err = snap.GetManyView([][]byte{[]byte("snap/b"), []byte("snap/empty"), []byte("snap/missing")}, func(index int, key, value []byte, found bool) error {
+	err = snap.GetManyView([][]byte{[]byte("snap/b"), []byte("snap/empty"), []byte("snap/missing"), nil}, func(index int, key, value []byte, found bool) error {
 		seen = append(seen, seenMany{
 			index: index,
 			key:   string(key),
@@ -182,6 +185,7 @@ func TestConditionalTxnSnapshotUsesPinnedPointViewAndRangeFailsClosed(t *testing
 		{index: 0, key: "snap/b", value: "2", found: true},
 		{index: 1, key: "snap/empty", value: "", found: true},
 		{index: 2, key: "snap/missing", value: "", found: false, nil: true},
+		{index: 3, key: "", value: "nil-key", found: true},
 	}
 	if !reflect.DeepEqual(seen, wantSeen) {
 		t.Fatalf("tx snapshot GetManyView=%v, want %v", seen, wantSeen)
@@ -198,6 +202,46 @@ func TestConditionalTxnSnapshotUsesPinnedPointViewAndRangeFailsClosed(t *testing
 	}
 	if tx.Snapshot() != nil {
 		t.Fatal("tx.Snapshot after Commit returned non-nil")
+	}
+}
+
+func TestConditionalTxnSnapshotGetManyViewNormalizesMissingNilKey(t *testing.T) {
+	d, err := Open(Options{Dir: t.TempDir(), FlushThreshold: 1 << 30})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer d.Close()
+
+	tx, err := d.NewConditionalTxnWithSnapshot()
+	if err != nil {
+		t.Fatalf("NewConditionalTxnWithSnapshot: %v", err)
+	}
+	defer tx.Close()
+	snap := tx.Snapshot()
+	if snap == nil {
+		t.Fatal("tx.Snapshot returned nil")
+	}
+
+	var callbackKey []byte
+	var callbackValue []byte
+	var callbackFound bool
+	err = snap.GetManyView([][]byte{nil}, func(index int, key, value []byte, found bool) error {
+		if index != 0 {
+			t.Fatalf("callback index=%d want 0", index)
+		}
+		callbackKey = key
+		callbackValue = value
+		callbackFound = found
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("tx snapshot GetManyView nil key: %v", err)
+	}
+	if callbackKey == nil || len(callbackKey) != 0 {
+		t.Fatalf("callback key=%v want normalized empty non-nil slice", callbackKey)
+	}
+	if callbackValue != nil || callbackFound {
+		t.Fatalf("callback value=%v found=%v want missing nil value", callbackValue, callbackFound)
 	}
 }
 

--- a/TreeDB/snapshot_iterate_test.go
+++ b/TreeDB/snapshot_iterate_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"reflect"
-	"strconv"
 	"testing"
 )
 
@@ -123,6 +122,9 @@ func TestConditionalTxnSnapshotUsesPinnedPointViewAndRangeFailsClosed(t *testing
 	if err := d.Set([]byte("snap/b"), []byte("2")); err != nil {
 		t.Fatalf("set b: %v", err)
 	}
+	if err := d.Set([]byte("snap/empty"), []byte{}); err != nil {
+		t.Fatalf("set empty: %v", err)
+	}
 
 	tx, err := d.NewConditionalTxnWithSnapshot()
 	if err != nil {
@@ -155,15 +157,32 @@ func TestConditionalTxnSnapshotUsesPinnedPointViewAndRangeFailsClosed(t *testing
 	if !bytes.Equal(gotB, []byte("2")) {
 		t.Fatalf("tx snapshot Get b=%q, want 2", gotB)
 	}
-	var seen []string
-	err = snap.GetManyView([][]byte{[]byte("snap/b"), []byte("snap/missing")}, func(index int, key, value []byte, found bool) error {
-		seen = append(seen, strconv.Itoa(index)+":"+string(key)+":"+string(value)+":"+strconv.FormatBool(found))
+	type seenMany struct {
+		index int
+		key   string
+		value string
+		found bool
+		nil   bool
+	}
+	var seen []seenMany
+	err = snap.GetManyView([][]byte{[]byte("snap/b"), []byte("snap/empty"), []byte("snap/missing")}, func(index int, key, value []byte, found bool) error {
+		seen = append(seen, seenMany{
+			index: index,
+			key:   string(key),
+			value: string(value),
+			found: found,
+			nil:   value == nil,
+		})
 		return nil
 	})
 	if err != nil {
 		t.Fatalf("tx snapshot GetManyView: %v", err)
 	}
-	wantSeen := []string{"0:snap/b:2:true", "1:snap/missing::false"}
+	wantSeen := []seenMany{
+		{index: 0, key: "snap/b", value: "2", found: true},
+		{index: 1, key: "snap/empty", value: "", found: true},
+		{index: 2, key: "snap/missing", value: "", found: false, nil: true},
+	}
 	if !reflect.DeepEqual(seen, wantSeen) {
 		t.Fatalf("tx snapshot GetManyView=%v, want %v", seen, wantSeen)
 	}


### PR DESCRIPTION
## Summary
- exposes public TreeDB snapshot callback iteration for pinned forward/reverse range reads
- adds conditional transactions with transaction-owned opening snapshots plus explicit read-version preconditions
- preserves pinned snapshot point-read isolation from staged writes and records those observed revisions for commit validation
- hardens merging iterator error propagation and tests revision-aware error paths
- relaxes the in-memory raft test cluster timing after the Windows shard exposed scheduler-sensitive leadership churn

## Validation
- `GOWORK=off GOMODCACHE=/mnt/fast4tb/tmp/gomod GOCACHE=/mnt/fast4tb/tmp/gocache GOPATH=/mnt/fast4tb/tmp/go go test ./TreeDB -run 'TestConditionalTxnSnapshot|TestConditionalTxnRequireReadVersion|TestPublicConditionalTxnCachedHandleConflictsWhenKeyChangesBeforeFirstRead|TestSnapshotIterate|TestGetManyView' -count=1` -> PASS
- `GOWORK=off GOMODCACHE=/mnt/fast4tb/tmp/gomod GOCACHE=/mnt/fast4tb/tmp/gocache GOPATH=/mnt/fast4tb/tmp/go go test ./TreeDB/internal/merging -count=1` -> PASS
- `GOWORK=off GOMODCACHE=/mnt/fast4tb/tmp/gomod GOCACHE=/mnt/fast4tb/tmp/gocache GOPATH=/mnt/fast4tb/tmp/go go test ./TreeDB/internal/raftcluster -run 'TestHashicorpRaftProviderReadIndexReturnsProductionProofForLeader|TestHashicorpRaftProviderReadIndexRejectsTargetMismatch' -count=10` -> PASS
- `GOWORK=off GOMODCACHE=/mnt/fast4tb/tmp/gomod GOCACHE=/mnt/fast4tb/tmp/gocache GOPATH=/mnt/fast4tb/tmp/go go test ./TreeDB/internal/merging ./TreeDB ./TreeDB/db ./TreeDB/caching -count=1` -> PASS

## Review State
- Latest head: 86e766872
- Previous CodeRabbit/Codex findings were fixed or covered by tests; fresh reviews requested after this mature head.
- CI is expected to rerun on the latest head before merge.
