### PR TITLE
TreeDB Raft: make token route key explicit

### DIFF
--- a/TreeDB/internal/raftcluster/dispatcher.go
+++ b/TreeDB/internal/raftcluster/dispatcher.go
@@ -226,8 +226,11 @@ func routeDispatchTargetFromMetadata(metadata raftentry.RequestMetadataV1) (rout
 		if !metadata.ClusterRouteTokenKnown {
 			return routeDispatchTarget{}, errors.Join(ErrRouteTargetMissing, fmt.Errorf("token route missing document token"))
 		}
+		if metadata.ClusterRouteKey == "" {
+			return routeDispatchTarget{}, errors.Join(ErrRouteTargetUnsupported, fmt.Errorf("token route missing route key"))
+		}
 		if metadata.ClusterRouteKey != clusterRouteKeyDocumentIDV1 {
-			return routeDispatchTarget{}, errors.Join(ErrRouteTargetUnsupported, fmt.Errorf("token route uses route key %q", metadata.ClusterRouteKey))
+			return routeDispatchTarget{}, errors.Join(ErrRouteTargetUnsupported, fmt.Errorf("token route uses unsupported route key %q", metadata.ClusterRouteKey))
 		}
 		if metadata.ClusterRoutePartitionID == "" {
 			return routeDispatchTarget{}, errors.Join(ErrRouteTargetMissing, fmt.Errorf("token route missing partition id"))

--- a/TreeDB/internal/raftcluster/dispatcher.go
+++ b/TreeDB/internal/raftcluster/dispatcher.go
@@ -18,6 +18,8 @@ const (
 	clusterRoutePlacementCollectionV1 = "collection"
 	clusterRoutePlacementTokenV1      = "token"
 	clusterRoutePlacementRingV1       = "ring"
+
+	clusterRouteKeyDocumentIDV1 = "_id"
 )
 
 // GroupSubmitterV1 binds a local Raft group ID to the in-process submitter for
@@ -223,6 +225,9 @@ func routeDispatchTargetFromMetadata(metadata raftentry.RequestMetadataV1) (rout
 		}
 		if !metadata.ClusterRouteTokenKnown {
 			return routeDispatchTarget{}, errors.Join(ErrRouteTargetMissing, fmt.Errorf("token route missing document token"))
+		}
+		if metadata.ClusterRouteKey != clusterRouteKeyDocumentIDV1 {
+			return routeDispatchTarget{}, errors.Join(ErrRouteTargetUnsupported, fmt.Errorf("token route uses route key %q", metadata.ClusterRouteKey))
 		}
 		if metadata.ClusterRoutePartitionID == "" {
 			return routeDispatchTarget{}, errors.Join(ErrRouteTargetMissing, fmt.Errorf("token route missing partition id"))

--- a/TreeDB/internal/raftcluster/dispatcher_test.go
+++ b/TreeDB/internal/raftcluster/dispatcher_test.go
@@ -151,9 +151,10 @@ func TestGroupRoutedSubmitterRejectsUnsupportedRoutesBeforeSubmit(t *testing.T) 
 	token.ClusterRoutePartitionID = "p0"
 
 	tests := []struct {
-		name string
-		meta raftentry.RequestMetadataV1
-		want error
+		name    string
+		meta    raftentry.RequestMetadataV1
+		want    error
+		wantMsg string
 	}{
 		{name: "missing_route", meta: raftentry.RequestMetadataV1{AckPolicy: iwire.AckVisible}, want: ErrRouteTargetMissing},
 		{name: "missing_identity", meta: func() raftentry.RequestMetadataV1 {
@@ -188,12 +189,12 @@ func TestGroupRoutedSubmitterRejectsUnsupportedRoutesBeforeSubmit(t *testing.T) 
 			meta := token
 			meta.ClusterRouteKey = ""
 			return meta
-		}(), want: ErrRouteTargetUnsupported},
+		}(), want: ErrRouteTargetUnsupported, wantMsg: "missing route key"},
 		{name: "token_unsupported_route_key", meta: func() raftentry.RequestMetadataV1 {
 			meta := token
 			meta.ClusterRouteKey = "tenant_id"
 			return meta
-		}(), want: ErrRouteTargetUnsupported},
+		}(), want: ErrRouteTargetUnsupported, wantMsg: "unsupported route key \"tenant_id\""},
 		{name: "unsupported_shape", meta: func() raftentry.RequestMetadataV1 {
 			meta := valid
 			meta.ClusterRouteShape = "scatter"
@@ -207,6 +208,9 @@ func TestGroupRoutedSubmitterRejectsUnsupportedRoutesBeforeSubmit(t *testing.T) 
 			_, err := dispatcher.SubmitCommandEntryV1(context.Background(), entry, tt.meta)
 			if !errors.Is(err, tt.want) {
 				t.Fatalf("SubmitCommandEntryV1 err=%v want %v", err, tt.want)
+			}
+			if tt.wantMsg != "" && !strings.Contains(err.Error(), tt.wantMsg) {
+				t.Fatalf("SubmitCommandEntryV1 err=%q want message containing %q", err, tt.wantMsg)
 			}
 			if after := len(groupA.snapshot()); after != before {
 				t.Fatalf("group-a calls after rejection=%d want %d", after, before)

--- a/TreeDB/internal/raftcluster/dispatcher_test.go
+++ b/TreeDB/internal/raftcluster/dispatcher_test.go
@@ -114,6 +114,7 @@ func TestGroupRoutedSubmitterRoutesCollectionAndTokenTargets(t *testing.T) {
 	tokenMeta := routeMetadata("group-a", iwire.AckRaftCommitted)
 	tokenMeta.ClusterRouteShape = clusterRouteShapeTokenV1
 	tokenMeta.ClusterRoutePlacementMode = clusterRoutePlacementTokenV1
+	tokenMeta.ClusterRouteKey = clusterRouteKeyDocumentIDV1
 	tokenMeta.ClusterRouteTokenKnown = true
 	tokenMeta.ClusterRouteToken = 42
 	tokenMeta.ClusterRoutePartitionID = "p0"
@@ -144,6 +145,7 @@ func TestGroupRoutedSubmitterRejectsUnsupportedRoutesBeforeSubmit(t *testing.T) 
 	token := valid
 	token.ClusterRouteShape = clusterRouteShapeTokenV1
 	token.ClusterRoutePlacementMode = clusterRoutePlacementTokenV1
+	token.ClusterRouteKey = clusterRouteKeyDocumentIDV1
 	token.ClusterRouteTokenKnown = true
 	token.ClusterRouteToken = 11
 	token.ClusterRoutePartitionID = "p0"
@@ -182,6 +184,16 @@ func TestGroupRoutedSubmitterRejectsUnsupportedRoutesBeforeSubmit(t *testing.T) 
 			meta.ClusterRoutePartitionID = ""
 			return meta
 		}(), want: ErrRouteTargetMissing},
+		{name: "token_missing_route_key", meta: func() raftentry.RequestMetadataV1 {
+			meta := token
+			meta.ClusterRouteKey = ""
+			return meta
+		}(), want: ErrRouteTargetUnsupported},
+		{name: "token_unsupported_route_key", meta: func() raftentry.RequestMetadataV1 {
+			meta := token
+			meta.ClusterRouteKey = "tenant_id"
+			return meta
+		}(), want: ErrRouteTargetUnsupported},
 		{name: "unsupported_shape", meta: func() raftentry.RequestMetadataV1 {
 			meta := valid
 			meta.ClusterRouteShape = "scatter"

--- a/TreeDB/internal/raftcluster/submit.go
+++ b/TreeDB/internal/raftcluster/submit.go
@@ -814,6 +814,7 @@ func requestMetadataEqual(a, b raftentry.RequestMetadataV1) bool {
 		slices.Equal(a.ClusterRouteMembers, b.ClusterRouteMembers) &&
 		a.ClusterRouteLeaderHint == b.ClusterRouteLeaderHint &&
 		a.ClusterRoutePlacementMode == b.ClusterRoutePlacementMode &&
+		a.ClusterRouteKey == b.ClusterRouteKey &&
 		a.ClusterRouteTokenKnown == b.ClusterRouteTokenKnown &&
 		a.ClusterRouteToken == b.ClusterRouteToken &&
 		a.ClusterRoutePartitionID == b.ClusterRoutePartitionID

--- a/TreeDB/internal/raftentry/contract.go
+++ b/TreeDB/internal/raftentry/contract.go
@@ -60,6 +60,7 @@ type RequestMetadataV1 struct {
 	ClusterRouteMembers       []string
 	ClusterRouteLeaderHint    string
 	ClusterRoutePlacementMode string
+	ClusterRouteKey           string
 	ClusterRouteTokenKnown    bool
 	ClusterRouteToken         uint64
 	ClusterRoutePartitionID   string

--- a/TreeDB/internal/raftharness/harness.go
+++ b/TreeDB/internal/raftharness/harness.go
@@ -779,6 +779,7 @@ func committedEntriesEqual(a, b raftfsm.CommittedEntryV1) bool {
 		a.RequestMetadata.ClusterRouteGroupID != b.RequestMetadata.ClusterRouteGroupID ||
 		a.RequestMetadata.ClusterRouteLeaderHint != b.RequestMetadata.ClusterRouteLeaderHint ||
 		a.RequestMetadata.ClusterRoutePlacementMode != b.RequestMetadata.ClusterRoutePlacementMode ||
+		a.RequestMetadata.ClusterRouteKey != b.RequestMetadata.ClusterRouteKey ||
 		a.RequestMetadata.ClusterRouteTokenKnown != b.RequestMetadata.ClusterRouteTokenKnown ||
 		a.RequestMetadata.ClusterRouteToken != b.RequestMetadata.ClusterRouteToken ||
 		a.RequestMetadata.ClusterRoutePartitionID != b.RequestMetadata.ClusterRoutePartitionID ||

--- a/TreeDB/internal/raftharness/harness_test.go
+++ b/TreeDB/internal/raftharness/harness_test.go
@@ -206,6 +206,7 @@ func TestCommitClonesAndComparesClusterRouteMetadata(t *testing.T) {
 		ClusterRouteMembers:       []string{"node-a", "node-b"},
 		ClusterRouteLeaderHint:    "node-a",
 		ClusterRoutePlacementMode: "collection",
+		ClusterRouteKey:           "_id",
 		ClusterRouteTokenKnown:    true,
 		ClusterRouteToken:         42,
 		ClusterRoutePartitionID:   "token-000042",
@@ -226,6 +227,7 @@ func TestCommitClonesAndComparesClusterRouteMetadata(t *testing.T) {
 		ClusterRouteMembers:       []string{"node-a", "node-b"},
 		ClusterRouteLeaderHint:    "node-a",
 		ClusterRoutePlacementMode: "collection",
+		ClusterRouteKey:           "_id",
 		ClusterRouteTokenKnown:    true,
 		ClusterRouteToken:         42,
 		ClusterRoutePartitionID:   "token-000042",
@@ -240,6 +242,12 @@ func TestCommitClonesAndComparesClusterRouteMetadata(t *testing.T) {
 	divergent.RequestMetadata.ClusterRoutePartitionID = "token-000043"
 	if _, err := h.Commit(divergent); !errors.Is(err, ErrCommittedLogConflict) {
 		t.Fatalf("Commit divergent route metadata err=%v want ErrCommittedLogConflict", err)
+	}
+
+	divergent = want
+	divergent.RequestMetadata.ClusterRouteKey = "tenant_id"
+	if _, err := h.Commit(divergent); !errors.Is(err, ErrCommittedLogConflict) {
+		t.Fatalf("Commit divergent route key err=%v want ErrCommittedLogConflict", err)
 	}
 }
 

--- a/TreeDB/internal/raftplacement/catalog.go
+++ b/TreeDB/internal/raftplacement/catalog.go
@@ -36,6 +36,7 @@ var (
 	ErrUnsupportedFeature       = errors.New("raftplacement: unsupported feature")
 	ErrUnsupportedVersion       = errors.New("raftplacement: unsupported version")
 	ErrUnsupportedPlacementMode = errors.New("raftplacement: unsupported placement mode")
+	ErrUnsupportedRouteKey      = errors.New("raftplacement: unsupported route key")
 )
 
 type PlacementModeV1 string
@@ -44,6 +45,12 @@ const (
 	PlacementModeCollectionV1 PlacementModeV1 = "collection"
 	PlacementModeTokenV1      PlacementModeV1 = "token"
 	PlacementModeRingV1       PlacementModeV1 = "ring"
+)
+
+type RouteKeyV1 string
+
+const (
+	RouteKeyDocumentIDV1 RouteKeyV1 = "_id"
 )
 
 type CollectionRefV1 struct {
@@ -62,6 +69,7 @@ type CollectionPlacementV1 struct {
 	Collection      CollectionRefV1
 	GroupID         raftcluster.GroupID
 	Mode            PlacementModeV1
+	RouteKey        RouteKeyV1
 	TokenPartitions []TokenPartitionV1
 }
 
@@ -81,6 +89,7 @@ type ResolvedCollectionPlacementV1 struct {
 	Collection      CollectionRefV1
 	GroupID         raftcluster.GroupID
 	Mode            PlacementModeV1
+	RouteKey        RouteKeyV1
 	TokenPartitions []ResolvedTokenPartitionV1
 }
 
@@ -371,6 +380,9 @@ func validatePlacements(placements []CollectionPlacementV1, groups map[raftclust
 		}
 		switch mode {
 		case PlacementModeCollectionV1:
+			if placement.RouteKey != "" {
+				return nil, nil, nil, errors.Join(ErrInvalidCatalog, ErrUnsupportedRouteKey, fmt.Errorf("placement[%d] %s/%s/%s collection mode must not set route key %q", i, ref.Database, ref.Catalog, ref.Collection, placement.RouteKey))
+			}
 			if len(placement.TokenPartitions) != 0 {
 				return nil, nil, nil, errors.Join(ErrInvalidCatalog, ErrInvalidTokenRing, fmt.Errorf("placement[%d] %s/%s/%s collection mode includes token partitions", i, ref.Database, ref.Catalog, ref.Collection))
 			}
@@ -382,6 +394,13 @@ func validatePlacements(placements []CollectionPlacementV1, groups map[raftclust
 			}
 			resolved.GroupID = placement.GroupID
 		case PlacementModeTokenV1, PlacementModeRingV1:
+			routeKey := placement.RouteKey
+			if routeKey == "" {
+				routeKey = RouteKeyDocumentIDV1
+			}
+			if routeKey != RouteKeyDocumentIDV1 {
+				return nil, nil, nil, errors.Join(ErrInvalidCatalog, ErrUnsupportedRouteKey, fmt.Errorf("placement[%d] %s/%s/%s mode %q route key %q is not supported", i, ref.Database, ref.Catalog, ref.Collection, mode, routeKey))
+			}
 			if placement.GroupID != "" {
 				return nil, nil, nil, errors.Join(ErrInvalidCatalog, ErrUnsupportedPlacementMode, fmt.Errorf("placement[%d] %s/%s/%s mode %q must not set collection group %q", i, ref.Database, ref.Catalog, ref.Collection, mode, placement.GroupID))
 			}
@@ -392,6 +411,7 @@ func validatePlacements(placements []CollectionPlacementV1, groups map[raftclust
 			if err != nil {
 				return nil, nil, nil, errors.Join(ErrInvalidCatalog, err, fmt.Errorf("placement[%d] %s/%s/%s", i, ref.Database, ref.Catalog, ref.Collection))
 			}
+			resolved.RouteKey = routeKey
 			resolved.TokenPartitions = cloneResolvedTokenPartitions(plan.Partitions)
 			tokens[ref] = cloneResolvedTokenRingPlan(plan)
 		default:

--- a/TreeDB/internal/raftplacement/catalog_test.go
+++ b/TreeDB/internal/raftplacement/catalog_test.go
@@ -260,6 +260,9 @@ func TestValidateAcceptsTokenRingCatalogPlacements(t *testing.T) {
 			if placement.Mode != mode {
 				t.Fatalf("placement mode=%q want %q", placement.Mode, mode)
 			}
+			if placement.RouteKey != RouteKeyDocumentIDV1 {
+				t.Fatalf("route key=%q want %q", placement.RouteKey, RouteKeyDocumentIDV1)
+			}
 			if got := len(placement.TokenPartitions); got != 2 {
 				t.Fatalf("token partitions=%d want 2", got)
 			}
@@ -343,6 +346,21 @@ func TestValidateRejectsInvalidTokenRingCatalogPlacements(t *testing.T) {
 				p.GroupID = "group-a"
 			},
 			want: ErrInvalidTokenRing,
+		},
+		{
+			name: "unsupported token route key",
+			mut:  func(p *CollectionPlacementV1) { p.RouteKey = "tenant_id" },
+			want: ErrUnsupportedRouteKey,
+		},
+		{
+			name: "collection route key",
+			mut: func(p *CollectionPlacementV1) {
+				p.Mode = PlacementModeCollectionV1
+				p.GroupID = "group-a"
+				p.RouteKey = RouteKeyDocumentIDV1
+				p.TokenPartitions = nil
+			},
+			want: ErrUnsupportedRouteKey,
 		},
 	}
 	for _, tc := range tests {

--- a/TreeDB/internal/raftplacement/route.go
+++ b/TreeDB/internal/raftplacement/route.go
@@ -51,6 +51,7 @@ type RouteDecisionV1 struct {
 	Collection    CollectionRefV1
 	Shape         RouteShapeV1
 	PlacementMode PlacementModeV1
+	RouteKey      RouteKeyV1
 	Group         ResolvedGroupV1
 	Token         RouteTokenDecisionV1
 }
@@ -58,6 +59,7 @@ type RouteDecisionV1 struct {
 type RouteTokenBatchDecisionV1 struct {
 	Collection    CollectionRefV1
 	PlacementMode PlacementModeV1
+	RouteKey      RouteKeyV1
 	Class         TokenBatchRouteClassV1
 	Tokens        []uint64
 	Partitions    []ResolvedTokenPartitionV1
@@ -132,6 +134,7 @@ func (c ResolvedCatalogV1) Route(req RouteRequestV1) (RouteDecisionV1, error) {
 			Collection:    req.Collection,
 			Shape:         req.Shape,
 			PlacementMode: placement.Mode,
+			RouteKey:      placement.RouteKey,
 			Group:         group,
 			Token: RouteTokenDecisionV1{
 				Present:   true,
@@ -258,6 +261,7 @@ func (c ResolvedCatalogV1) ClassifyDocumentTokenBatch(database, catalog, collect
 	decision := RouteTokenBatchDecisionV1{
 		Collection:    ref,
 		PlacementMode: placement.Mode,
+		RouteKey:      placement.RouteKey,
 		Class:         class,
 		Tokens:        append([]uint64(nil), tokens...),
 		Partitions:    append([]ResolvedTokenPartitionV1(nil), partitions...),

--- a/TreeDB/internal/raftplacement/route_test.go
+++ b/TreeDB/internal/raftplacement/route_test.go
@@ -73,6 +73,9 @@ func TestRouteTokenDecisionIncludesPartitionAndGroupMetadata(t *testing.T) {
 			if decision.PlacementMode != mode {
 				t.Fatalf("placement mode=%q want %q", decision.PlacementMode, mode)
 			}
+			if decision.RouteKey != RouteKeyDocumentIDV1 {
+				t.Fatalf("route key=%q want %q", decision.RouteKey, RouteKeyDocumentIDV1)
+			}
 			if decision.GroupID() != "group-b" {
 				t.Fatalf("group=%q want group-b", decision.GroupID())
 			}
@@ -210,6 +213,9 @@ func TestRouteTokenBatchClassifiesDocumentTokens(t *testing.T) {
 				}
 				if decision.Collection.Collection != "events" || decision.PlacementMode != mode {
 					t.Fatalf("decision collection/mode=%s/%s want events/%s", decision.Collection.Collection, decision.PlacementMode, mode)
+				}
+				if decision.RouteKey != RouteKeyDocumentIDV1 {
+					t.Fatalf("route key=%q want %q", decision.RouteKey, RouteKeyDocumentIDV1)
 				}
 				if decision.Class != tc.wantClass {
 					t.Fatalf("class=%q want %q", decision.Class, tc.wantClass)

--- a/TreeDB/mongo_gateway/cluster_submitter.go
+++ b/TreeDB/mongo_gateway/cluster_submitter.go
@@ -512,6 +512,7 @@ func (s *Server) submitClusterMutation(ctx context.Context, command iwire.Comman
 		metadata.ClusterRouteMembers = append([]string(nil), route.Members...)
 		metadata.ClusterRouteLeaderHint = route.LeaderHint
 		metadata.ClusterRoutePlacementMode = route.PlacementMode
+		metadata.ClusterRouteKey = route.RouteKey
 		metadata.ClusterRouteTokenKnown = route.TokenKnown
 		metadata.ClusterRouteToken = route.Token
 		metadata.ClusterRoutePartitionID = route.PartitionID

--- a/TreeDB/mongo_gateway/cluster_submitter_test.go
+++ b/TreeDB/mongo_gateway/cluster_submitter_test.go
@@ -453,6 +453,9 @@ func assertMongoClusterTokenRouteMetadata(tb testing.TB, call mongoClusterSubmit
 	if meta.ClusterRouteGroupID != "group-a" || meta.ClusterRouteLeaderHint != "node-a" || meta.ClusterRoutePlacementMode != string(mode) {
 		tb.Fatalf("metadata route target group=%q leader=%q mode=%q", meta.ClusterRouteGroupID, meta.ClusterRouteLeaderHint, meta.ClusterRoutePlacementMode)
 	}
+	if meta.ClusterRouteKey != string(raftplacement.RouteKeyDocumentIDV1) {
+		tb.Fatalf("metadata route key=%q want %q", meta.ClusterRouteKey, raftplacement.RouteKeyDocumentIDV1)
+	}
 	if !meta.ClusterRouteTokenKnown || meta.ClusterRouteToken != token || meta.ClusterRoutePartitionID != partition {
 		tb.Fatalf("metadata token known/token/partition=%v/%d/%q want true/%d/%q", meta.ClusterRouteTokenKnown, meta.ClusterRouteToken, meta.ClusterRoutePartitionID, token, partition)
 	}
@@ -1110,6 +1113,7 @@ func TestMongoGroupRoutedDispatcherRoutesSingleTokenWrite(t *testing.T) {
 			Members:       []string{"node-b", "node-c"},
 			LeaderHint:    "node-b",
 			PlacementMode: "token",
+			RouteKey:      string(raftplacement.RouteKeyDocumentIDV1),
 			Shape:         treenativewire.ClusterRouteShapeToken,
 			TokenKnown:    true,
 			Token:         token,
@@ -1132,7 +1136,7 @@ func TestMongoGroupRoutedDispatcherRoutesSingleTokenWrite(t *testing.T) {
 		t.Fatalf("group-b calls=%d want 1", len(calls))
 	}
 	meta := calls[0].metadata
-	if !meta.ClusterRouteKnown || meta.ClusterRouteShape != string(treenativewire.ClusterRouteShapeToken) || meta.ClusterRouteGroupID != "group-b" || !meta.ClusterRouteTokenKnown || meta.ClusterRouteToken != token || meta.ClusterRoutePartitionID != "p0" {
+	if !meta.ClusterRouteKnown || meta.ClusterRouteShape != string(treenativewire.ClusterRouteShapeToken) || meta.ClusterRouteGroupID != "group-b" || meta.ClusterRouteKey != string(raftplacement.RouteKeyDocumentIDV1) || !meta.ClusterRouteTokenKnown || meta.ClusterRouteToken != token || meta.ClusterRoutePartitionID != "p0" {
 		t.Fatalf("group-b token route metadata=%+v want group-b token=%d p0", meta, token)
 	}
 }
@@ -1180,7 +1184,7 @@ func TestMongoGroupRoutedDispatcherCatalogRoutesSingleTokenOwner(t *testing.T) {
 		t.Fatalf("group-b calls=%d want 1", len(calls))
 	}
 	meta := calls[0].metadata
-	if !meta.ClusterRouteKnown || meta.ClusterRouteShape != string(treenativewire.ClusterRouteShapeToken) || meta.ClusterRouteGroupID != "group-b" || meta.ClusterRouteLeaderHint != "node-c" || !meta.ClusterRouteTokenKnown || meta.ClusterRouteToken != token || meta.ClusterRoutePartitionID != "p1" {
+	if !meta.ClusterRouteKnown || meta.ClusterRouteShape != string(treenativewire.ClusterRouteShapeToken) || meta.ClusterRouteGroupID != "group-b" || meta.ClusterRouteLeaderHint != "node-c" || meta.ClusterRouteKey != string(raftplacement.RouteKeyDocumentIDV1) || !meta.ClusterRouteTokenKnown || meta.ClusterRouteToken != token || meta.ClusterRoutePartitionID != "p1" {
 		t.Fatalf("group-b catalog token route metadata=%+v want group-b/node-c token=%d p1", meta, token)
 	}
 }
@@ -1193,6 +1197,7 @@ func TestMongoGroupRoutedDispatcherRejectsUnknownGroupBeforeSubmit(t *testing.T)
 			Members:       []string{"node-z"},
 			LeaderHint:    "node-z",
 			PlacementMode: "token",
+			RouteKey:      string(raftplacement.RouteKeyDocumentIDV1),
 			Shape:         treenativewire.ClusterRouteShapeToken,
 			TokenKnown:    true,
 			Token:         token,

--- a/TreeDB/nativewire/cluster_route_provider.go
+++ b/TreeDB/nativewire/cluster_route_provider.go
@@ -90,6 +90,7 @@ func clusterRouteTargetFromCatalogDecision(decision raftplacement.RouteDecisionV
 		Members:       clusterRouteGroupMembers(decision.Group.Members),
 		LeaderHint:    string(decision.LeaderHint()),
 		PlacementMode: string(decision.PlacementMode),
+		RouteKey:      string(decision.RouteKey),
 		Shape:         ClusterRouteShape(decision.Shape),
 	}
 	if decision.Token.Present {
@@ -103,6 +104,7 @@ func clusterRouteTargetFromCatalogDecision(decision raftplacement.RouteDecisionV
 func clusterRouteTargetFromCatalogTokenBatch(decision raftplacement.RouteTokenBatchDecisionV1) ClusterRouteTarget {
 	target := ClusterRouteTarget{
 		PlacementMode:   string(decision.PlacementMode),
+		RouteKey:        string(decision.RouteKey),
 		Shape:           ClusterRouteShapeTokenBatch,
 		TokenBatchClass: string(decision.Class),
 	}

--- a/TreeDB/nativewire/cluster_submitter.go
+++ b/TreeDB/nativewire/cluster_submitter.go
@@ -56,6 +56,7 @@ type ClusterRouteTarget struct {
 	Members         []string
 	LeaderHint      string
 	PlacementMode   string
+	RouteKey        string
 	Reason          string
 	Shape           ClusterRouteShape
 	TokenKnown      bool
@@ -360,6 +361,13 @@ func PreflightClusterRoute(ctx context.Context, submitter ClusterSubmitter, requ
 			}
 			return ClusterRouteTarget{}, true, protocolError(iwire.ErrReadOnly, "%s", reason)
 		}
+		if target.RouteKey != string(raftplacement.RouteKeyDocumentIDV1) {
+			reason := target.Reason
+			if reason == "" {
+				reason = "cluster token/ring route target requires _id route key"
+			}
+			return ClusterRouteTarget{}, true, protocolError(iwire.ErrReadOnly, "%s", reason)
+		}
 		if !target.TokenKnown {
 			reason := target.Reason
 			if reason == "" {
@@ -571,6 +579,7 @@ func applyClusterRouteMetadata(metadata *ClusterRequestMetadata, request Cluster
 	metadata.ClusterRouteMembers = append([]string(nil), target.Members...)
 	metadata.ClusterRouteLeaderHint = target.LeaderHint
 	metadata.ClusterRoutePlacementMode = target.PlacementMode
+	metadata.ClusterRouteKey = target.RouteKey
 	metadata.ClusterRouteTokenKnown = target.TokenKnown
 	metadata.ClusterRouteToken = target.Token
 	metadata.ClusterRoutePartitionID = target.PartitionID

--- a/TreeDB/nativewire/cluster_submitter.go
+++ b/TreeDB/nativewire/cluster_submitter.go
@@ -361,10 +361,17 @@ func PreflightClusterRoute(ctx context.Context, submitter ClusterSubmitter, requ
 			}
 			return ClusterRouteTarget{}, true, protocolError(iwire.ErrReadOnly, "%s", reason)
 		}
+		if target.RouteKey == "" {
+			reason := target.Reason
+			if reason == "" {
+				reason = "cluster token/ring route target missing route key"
+			}
+			return ClusterRouteTarget{}, true, protocolError(iwire.ErrReadOnly, "%s", reason)
+		}
 		if target.RouteKey != string(raftplacement.RouteKeyDocumentIDV1) {
 			reason := target.Reason
 			if reason == "" {
-				reason = "cluster token/ring route target requires _id route key"
+				reason = fmt.Sprintf("cluster token/ring route target uses unsupported route key %q; requires _id", target.RouteKey)
 			}
 			return ClusterRouteTarget{}, true, protocolError(iwire.ErrReadOnly, "%s", reason)
 		}

--- a/TreeDB/nativewire/cluster_submitter_test.go
+++ b/TreeDB/nativewire/cluster_submitter_test.go
@@ -382,6 +382,9 @@ func assertNativeClusterTokenRouteMetadata(tb testing.TB, call fakeClusterSubmit
 	if meta.ClusterRouteGroupID != "group-a" || meta.ClusterRouteLeaderHint != "node-a" || meta.ClusterRoutePlacementMode != string(mode) {
 		tb.Fatalf("metadata route target group=%q leader=%q mode=%q", meta.ClusterRouteGroupID, meta.ClusterRouteLeaderHint, meta.ClusterRoutePlacementMode)
 	}
+	if meta.ClusterRouteKey != string(raftplacement.RouteKeyDocumentIDV1) {
+		tb.Fatalf("metadata route key=%q want %q", meta.ClusterRouteKey, raftplacement.RouteKeyDocumentIDV1)
+	}
 	if !meta.ClusterRouteTokenKnown || meta.ClusterRouteToken != token || meta.ClusterRoutePartitionID != partition {
 		tb.Fatalf("metadata token known/token/partition=%v/%d/%q want true/%d/%q", meta.ClusterRouteTokenKnown, meta.ClusterRouteToken, meta.ClusterRoutePartitionID, token, partition)
 	}
@@ -818,6 +821,42 @@ func TestClusterRoutePreflightRejectsUnsupportedQueryShape(t *testing.T) {
 	}
 }
 
+func TestClusterRoutePreflightRejectsUnsupportedTokenRouteKey(t *testing.T) {
+	submitter := &routingClusterSubmitter{
+		fakeClusterSubmitter: &fakeClusterSubmitter{},
+		target: ClusterRouteTarget{
+			GroupID:       "group-a",
+			Members:       []string{"node-a", "node-b"},
+			LeaderHint:    "node-a",
+			PlacementMode: string(raftplacement.PlacementModeRingV1),
+			RouteKey:      "tenant_id",
+			Shape:         ClusterRouteShapeToken,
+			TokenKnown:    true,
+			Token:         11,
+			PartitionID:   "p0",
+		},
+	}
+	request := ClusterRouteRequest{
+		Database:    "default",
+		Catalog:     "default",
+		Collection:  "users",
+		CommandID:   iwire.CommandInsertBatch,
+		CommandName: "insert_batch",
+		Shape:       ClusterRouteShapeToken,
+		TokenKnown:  true,
+		Token:       11,
+	}
+	if _, _, err := PreflightClusterRoute(context.Background(), submitter, request); codeOf(err) != iwire.ErrReadOnly || !strings.Contains(err.Error(), "requires _id route key") {
+		t.Fatalf("unsupported route key preflight err=%v want _id read-only", err)
+	}
+	if routes := submitter.snapshotRoutes(); len(routes) != 1 {
+		t.Fatalf("route calls=%d want 1", len(routes))
+	}
+	if calls := submitter.snapshot(); len(calls) != 0 {
+		t.Fatalf("submitter calls=%d want 0", len(calls))
+	}
+}
+
 func TestCatalogClusterRouteProviderRoutesResolvedCatalog(t *testing.T) {
 	collectionProvider := NewCatalogClusterRouteProvider(mustNativewireRouteTestCatalog(t, raftplacement.PlacementModeCollectionV1))
 	collectionTarget, err := collectionProvider.ClusterRoute(context.Background(), ClusterRouteRequest{
@@ -852,6 +891,9 @@ func TestCatalogClusterRouteProviderRoutesResolvedCatalog(t *testing.T) {
 			}
 			if tokenTarget.GroupID != "group-a" || tokenTarget.LeaderHint != "node-a" || tokenTarget.PlacementMode != string(mode) || tokenTarget.Shape != ClusterRouteShapeToken {
 				t.Fatalf("token target=%+v want group-a/node-a %s token", tokenTarget, mode)
+			}
+			if tokenTarget.RouteKey != string(raftplacement.RouteKeyDocumentIDV1) {
+				t.Fatalf("token route key=%q want %q", tokenTarget.RouteKey, raftplacement.RouteKeyDocumentIDV1)
 			}
 			if !tokenTarget.TokenKnown || tokenTarget.Token != 12 || tokenTarget.PartitionID != "p1" {
 				t.Fatalf("token target token known/token/partition=%v/%d/%q want true/12/p1", tokenTarget.TokenKnown, tokenTarget.Token, tokenTarget.PartitionID)
@@ -895,6 +937,9 @@ func TestCatalogClusterRouteProviderRoutesResolvedCatalog(t *testing.T) {
 					}
 					if target.PlacementMode != string(mode) || target.Shape != ClusterRouteShapeTokenBatch || target.TokenBatchClass != string(tc.wantClass) {
 						t.Fatalf("token batch target=%+v want mode=%s class=%s", target, mode, tc.wantClass)
+					}
+					if target.RouteKey != string(raftplacement.RouteKeyDocumentIDV1) {
+						t.Fatalf("token batch route key=%q want %q", target.RouteKey, raftplacement.RouteKeyDocumentIDV1)
 					}
 					if target.GroupID != tc.wantGroup {
 						t.Fatalf("token batch group=%q want %q", target.GroupID, tc.wantGroup)
@@ -2324,6 +2369,7 @@ func TestRaftClusterSubmitterGroupRoutedDispatcherRoutesSingleTokenWrite(t *test
 			Members:       []string{"node-b", "node-c"},
 			LeaderHint:    "node-b",
 			PlacementMode: "token",
+			RouteKey:      string(raftplacement.RouteKeyDocumentIDV1),
 			Shape:         ClusterRouteShapeToken,
 			TokenKnown:    true,
 			Token:         token,
@@ -2350,7 +2396,7 @@ func TestRaftClusterSubmitterGroupRoutedDispatcherRoutesSingleTokenWrite(t *test
 	if got := calls[0].entry.Decoded.CommandID; got != iwire.CommandInsertBatch {
 		t.Fatalf("group-b command=%d want insert_batch", got)
 	}
-	if !meta.ClusterRouteKnown || meta.ClusterRouteShape != string(ClusterRouteShapeToken) || meta.ClusterRouteGroupID != "group-b" || !meta.ClusterRouteTokenKnown || meta.ClusterRouteToken != token || meta.ClusterRoutePartitionID != "p0" {
+	if !meta.ClusterRouteKnown || meta.ClusterRouteShape != string(ClusterRouteShapeToken) || meta.ClusterRouteGroupID != "group-b" || meta.ClusterRouteKey != string(raftplacement.RouteKeyDocumentIDV1) || !meta.ClusterRouteTokenKnown || meta.ClusterRouteToken != token || meta.ClusterRoutePartitionID != "p0" {
 		t.Fatalf("group-b token route metadata=%+v want group-b token=%d p0", meta, token)
 	}
 }
@@ -2404,7 +2450,7 @@ func TestRaftClusterSubmitterGroupRoutedDispatcherCatalogRoutesSingleTokenOwner(
 		t.Fatalf("group-b calls=%d want 1", len(calls))
 	}
 	meta := calls[0].metadata
-	if !meta.ClusterRouteKnown || meta.ClusterRouteShape != string(ClusterRouteShapeToken) || meta.ClusterRouteGroupID != "group-b" || meta.ClusterRouteLeaderHint != "node-c" || !meta.ClusterRouteTokenKnown || meta.ClusterRouteToken != token || meta.ClusterRoutePartitionID != "p1" {
+	if !meta.ClusterRouteKnown || meta.ClusterRouteShape != string(ClusterRouteShapeToken) || meta.ClusterRouteGroupID != "group-b" || meta.ClusterRouteLeaderHint != "node-c" || meta.ClusterRouteKey != string(raftplacement.RouteKeyDocumentIDV1) || !meta.ClusterRouteTokenKnown || meta.ClusterRouteToken != token || meta.ClusterRoutePartitionID != "p1" {
 		t.Fatalf("group-b catalog token route metadata=%+v want group-b/node-c token=%d p1", meta, token)
 	}
 }
@@ -2417,6 +2463,7 @@ func TestRaftClusterSubmitterGroupRoutedDispatcherRejectsUnknownGroupBeforeSubmi
 			Members:       []string{"node-z"},
 			LeaderHint:    "node-z",
 			PlacementMode: "token",
+			RouteKey:      string(raftplacement.RouteKeyDocumentIDV1),
 			Shape:         ClusterRouteShapeToken,
 			TokenKnown:    true,
 			Token:         token,

--- a/TreeDB/nativewire/cluster_submitter_test.go
+++ b/TreeDB/nativewire/cluster_submitter_test.go
@@ -822,20 +822,6 @@ func TestClusterRoutePreflightRejectsUnsupportedQueryShape(t *testing.T) {
 }
 
 func TestClusterRoutePreflightRejectsUnsupportedTokenRouteKey(t *testing.T) {
-	submitter := &routingClusterSubmitter{
-		fakeClusterSubmitter: &fakeClusterSubmitter{},
-		target: ClusterRouteTarget{
-			GroupID:       "group-a",
-			Members:       []string{"node-a", "node-b"},
-			LeaderHint:    "node-a",
-			PlacementMode: string(raftplacement.PlacementModeRingV1),
-			RouteKey:      "tenant_id",
-			Shape:         ClusterRouteShapeToken,
-			TokenKnown:    true,
-			Token:         11,
-			PartitionID:   "p0",
-		},
-	}
 	request := ClusterRouteRequest{
 		Database:    "default",
 		Catalog:     "default",
@@ -846,14 +832,41 @@ func TestClusterRoutePreflightRejectsUnsupportedTokenRouteKey(t *testing.T) {
 		TokenKnown:  true,
 		Token:       11,
 	}
-	if _, _, err := PreflightClusterRoute(context.Background(), submitter, request); codeOf(err) != iwire.ErrReadOnly || !strings.Contains(err.Error(), "requires _id route key") {
-		t.Fatalf("unsupported route key preflight err=%v want _id read-only", err)
+
+	tests := []struct {
+		name     string
+		routeKey string
+		wantMsg  string
+	}{
+		{name: "missing", routeKey: "", wantMsg: "missing route key"},
+		{name: "unsupported", routeKey: "tenant_id", wantMsg: "unsupported route key \"tenant_id\""},
 	}
-	if routes := submitter.snapshotRoutes(); len(routes) != 1 {
-		t.Fatalf("route calls=%d want 1", len(routes))
-	}
-	if calls := submitter.snapshot(); len(calls) != 0 {
-		t.Fatalf("submitter calls=%d want 0", len(calls))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			submitter := &routingClusterSubmitter{
+				fakeClusterSubmitter: &fakeClusterSubmitter{},
+				target: ClusterRouteTarget{
+					GroupID:       "group-a",
+					Members:       []string{"node-a", "node-b"},
+					LeaderHint:    "node-a",
+					PlacementMode: string(raftplacement.PlacementModeRingV1),
+					RouteKey:      tt.routeKey,
+					Shape:         ClusterRouteShapeToken,
+					TokenKnown:    true,
+					Token:         11,
+					PartitionID:   "p0",
+				},
+			}
+			if _, _, err := PreflightClusterRoute(context.Background(), submitter, request); codeOf(err) != iwire.ErrReadOnly || !strings.Contains(err.Error(), tt.wantMsg) {
+				t.Fatalf("route key preflight err=%v want read-only containing %q", err, tt.wantMsg)
+			}
+			if routes := submitter.snapshotRoutes(); len(routes) != 1 {
+				t.Fatalf("route calls=%d want 1", len(routes))
+			}
+			if calls := submitter.snapshot(); len(calls) != 0 {
+				t.Fatalf("submitter calls=%d want 0", len(calls))
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add an explicit raftplacement route-key contract for token/ring placements; the current supported key is `_id` only.
- Carry the route key through route decisions, nativewire route targets, Mongo/native cluster request metadata, raftharness metadata comparison, and raftcluster group dispatch.
- Fail closed when token/ring route metadata omits the `_id` route key or tries to use an unsupported key, while keeping query and token-batch fanout surfaces rejected before submit.

## Dependency status

- Part of #3445, downstream of #3442 / PR #3452.
- #3452 is merged into `main` at merge commit `10e52975d1ae0cfed44bf6593d3fa9ad114803da`.
- This PR branch was updated onto final `main` without force-pushing, per repository branch rules.
- Current head: `0047450ea211c0b7cd20e23d0ee40aedeac6d0bd`.

## Scope boundary

- Primary: `TreeDB/internal/raftplacement`, `TreeDB/internal/raftcluster/dispatcher.go` and tests.
- Secondary route metadata pass-through/comparison: `TreeDB/nativewire`, `TreeDB/mongo_gateway`, `TreeDB/internal/raftharness` tests.
- This PR does not implement scatter/fanout execution, cross-shard queries, secondary-index sharding, rebalancing, or benchmark scaleout evidence.
- #3445 remains open after this PR for the larger token/ring scaleout and 1-group vs N-group benchmark closeout.

## Validation

- `TMPDIR=/mnt/fast4tb/tmp/gomap-test-tmp GOCACHE=/mnt/fast4tb/tmp/go-cache GOMODCACHE=/mnt/fast4tb/tmp/go-mod-cache GOWORK=off GOMEMLIMIT=4GiB GOMAXPROCS=2 go test -p 1 ./TreeDB/nativewire -run TestClusterRoutePreflightRejectsUnsupportedTokenRouteKey -count=1`
  - Pass on head `0047450ea211c0b7cd20e23d0ee40aedeac6d0bd`: `nativewire 0.003s`.
- `TMPDIR=/mnt/fast4tb/tmp/gomap-test-tmp GOCACHE=/mnt/fast4tb/tmp/go-cache GOMODCACHE=/mnt/fast4tb/tmp/go-mod-cache GOWORK=off GOMEMLIMIT=4GiB GOMAXPROCS=2 go test -p 1 ./TreeDB/internal/raftplacement ./TreeDB/internal/raftcluster ./TreeDB/internal/raftharness ./TreeDB/nativewire ./TreeDB/mongo_gateway -count=1`
  - Pass on head `0047450ea211c0b7cd20e23d0ee40aedeac6d0bd`: `raftplacement 0.005s`, `raftcluster 9.018s`, `raftharness 2.637s`, `nativewire 1.995s`, `mongo_gateway 10.249s`.
- `git diff --check origin/main...HEAD`
  - Pass with no output on head `0047450ea211c0b7cd20e23d0ee40aedeac6d0bd`.

## Benchmark note

No long benchmark was run. This slice only adds route-key metadata validation on admission/control paths and harness evidence comparison. The #3445 scaleout benchmark gate remains open for the later execution slice after fanout/split or benchmark-only routed-distribution evidence exists.

## Review / CI status

- Copilot route-key diagnostic threads have code fixes and tests on the latest head.
- CodeRabbit latest-head status is green; its comment indicates the review request was rate-limited, so it did not provide a fresh substantive review for every latest-head change.
- Latest-head CI for `0047450ea211c0b7cd20e23d0ee40aedeac6d0bd` is running and must pass before merge.

## Risks / follow-up

- Only `_id` token routing is accepted in this slice; tenant-id or explicit application shard keys are intentionally rejected until their extraction and query semantics are specified.
- Fanout and query/index routing still fail closed. That is intentional to avoid unsupported horizontal-scale claims.
