### PR TITLE
[codex] stream raft snapshot archives

### DIFF
--- a/TreeDB/internal/raftcluster/hashicorp_raft.go
+++ b/TreeDB/internal/raftcluster/hashicorp_raft.go
@@ -1040,7 +1040,7 @@ func (s hashicorpRaftSnapshotV1) Persist(sink hraft.SnapshotSink) error {
 	}
 	if closeSrcErr != nil {
 		_ = sink.Cancel()
-		return closeSrcErr
+		return fmt.Errorf("raftcluster: close raft snapshot archive source: %w", closeSrcErr)
 	}
 	if err := sink.Close(); err != nil {
 		_ = sink.Cancel()

--- a/TreeDB/internal/raftcluster/hashicorp_raft.go
+++ b/TreeDB/internal/raftcluster/hashicorp_raft.go
@@ -24,6 +24,7 @@ const (
 	hashicorpRaftMinTrailingLogs       = 1
 	hashicorpRaftReadIndexInitialPoll  = 2 * time.Millisecond
 	hashicorpRaftReadIndexMaxPoll      = 25 * time.Millisecond
+	hashicorpRaftSnapshotCopyBuffer    = 64 << 10
 )
 
 var (
@@ -1026,9 +1027,20 @@ func (s hashicorpRaftSnapshotV1) Persist(sink hraft.SnapshotSink) error {
 			return err
 		}
 	}
-	if _, err := sink.Write(s.snapshot.Payload); err != nil {
+	src, err := s.snapshot.OpenArchive()
+	if err != nil {
 		_ = sink.Cancel()
 		return err
+	}
+	copyErr := copyHashicorpRaftSnapshotArchiveV1(sink, src)
+	closeSrcErr := src.Close()
+	if copyErr != nil {
+		_ = sink.Cancel()
+		return copyErr
+	}
+	if closeSrcErr != nil {
+		_ = sink.Cancel()
+		return closeSrcErr
 	}
 	if err := sink.Close(); err != nil {
 		_ = sink.Cancel()
@@ -1037,7 +1049,15 @@ func (s hashicorpRaftSnapshotV1) Persist(sink hraft.SnapshotSink) error {
 	return nil
 }
 
-func (s hashicorpRaftSnapshotV1) Release() {}
+func copyHashicorpRaftSnapshotArchiveV1(dst io.Writer, src io.Reader) error {
+	buf := make([]byte, hashicorpRaftSnapshotCopyBuffer)
+	_, err := io.CopyBuffer(dst, src, buf)
+	return err
+}
+
+func (s hashicorpRaftSnapshotV1) Release() {
+	_ = s.snapshot.Release()
+}
 
 type hashicorpRaftSnapshotBoundaryV1 struct {
 	Term  uint64

--- a/TreeDB/internal/raftcluster/hashicorp_raft_internal_test.go
+++ b/TreeDB/internal/raftcluster/hashicorp_raft_internal_test.go
@@ -1,10 +1,15 @@
 package raftcluster
 
 import (
+	"archive/tar"
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
+	"io"
 	"math"
+	"os"
+	"runtime"
 	"testing"
 	"time"
 
@@ -134,6 +139,112 @@ func TestHashicorpRaftSnapshotPersistAcceptsMatchingBoundary(t *testing.T) {
 	}
 	if !bytes.Equal(sink.Bytes(), payload) {
 		t.Fatalf("Persist wrote %d bytes, want payload %d bytes", sink.Len(), len(payload))
+	}
+}
+
+func TestHashicorpRaftSnapshotPersistStreamsArchivePathInChunks(t *testing.T) {
+	manifest := validSnapshotManifestV1()
+	payload := validRaftSnapshotArchivePayloadWithBodyV1(t, manifest, hashicorpRaftSnapshotCopyBuffer*3)
+	archivePath := writeRaftSnapshotArchiveFileForTest(t, payload)
+	snapshot := hashicorpRaftSnapshotV1{
+		snapshot: RaftSnapshotV1{
+			Manifest:    manifest,
+			ArchivePath: archivePath,
+		},
+	}
+	sink := &chunkRejectingSnapshotSink{maxWrite: hashicorpRaftSnapshotCopyBuffer}
+
+	if err := snapshot.Persist(sink); err != nil {
+		t.Fatalf("Persist: %v", err)
+	}
+	if !sink.closed {
+		t.Fatal("Persist did not close sink")
+	}
+	if sink.canceled {
+		t.Fatal("Persist canceled sink after successful write")
+	}
+	if sink.writeCount < 2 {
+		t.Fatalf("Persist used %d writes, want chunked streaming", sink.writeCount)
+	}
+	if sink.maxSeen > hashicorpRaftSnapshotCopyBuffer {
+		t.Fatalf("Persist max write=%d want <= %d", sink.maxSeen, hashicorpRaftSnapshotCopyBuffer)
+	}
+	if !bytes.Equal(sink.Bytes(), payload) {
+		t.Fatalf("Persist wrote %d bytes, want archive %d bytes", sink.Len(), len(payload))
+	}
+}
+
+func TestHashicorpRaftSnapshotPersistWriteFailureCancelsNotCloses(t *testing.T) {
+	manifest := validSnapshotManifestV1()
+	payload := validRaftSnapshotArchivePayloadWithBodyV1(t, manifest, hashicorpRaftSnapshotCopyBuffer*2)
+	archivePath := writeRaftSnapshotArchiveFileForTest(t, payload)
+	snapshot := hashicorpRaftSnapshotV1{
+		snapshot: RaftSnapshotV1{
+			Manifest:    manifest,
+			ArchivePath: archivePath,
+		},
+	}
+	writeErr := errors.New("sink write failed")
+	sink := &chunkRejectingSnapshotSink{
+		maxWrite: hashicorpRaftSnapshotCopyBuffer,
+		writeErr: writeErr,
+	}
+
+	err := snapshot.Persist(sink)
+	if !errors.Is(err, writeErr) {
+		t.Fatalf("Persist err=%v want write failure", err)
+	}
+	if !sink.canceled {
+		t.Fatal("Persist did not cancel sink after write failure")
+	}
+	if sink.closed {
+		t.Fatal("Persist closed sink after write failure")
+	}
+}
+
+func TestHashicorpRaftSnapshotReleaseRemovesArchivePath(t *testing.T) {
+	manifest := validSnapshotManifestV1()
+	archivePath := writeRaftSnapshotArchiveFileForTest(t, validRaftSnapshotArchivePayloadV1(t, manifest))
+	snapshot := hashicorpRaftSnapshotV1{
+		snapshot: RaftSnapshotV1{
+			Manifest:    manifest,
+			ArchivePath: archivePath,
+		},
+	}
+
+	snapshot.Release()
+	if _, err := os.Stat(archivePath); !os.IsNotExist(err) {
+		t.Fatalf("Release did not remove staged archive: stat err=%v", err)
+	}
+	snapshot.Release()
+}
+
+func TestHashicorpRaftSnapshotPersistFileSourceAllocationGuard(t *testing.T) {
+	manifest := validSnapshotManifestV1()
+	payload := validRaftSnapshotArchivePayloadWithBodyV1(t, manifest, 4<<20)
+	archivePath := writeRaftSnapshotArchiveFileForTest(t, payload)
+	snapshot := hashicorpRaftSnapshotV1{
+		snapshot: RaftSnapshotV1{
+			Manifest:    manifest,
+			ArchivePath: archivePath,
+		},
+	}
+	sink := &discardSnapshotSink{}
+
+	runtime.GC()
+	var before, after runtime.MemStats
+	runtime.ReadMemStats(&before)
+	if err := snapshot.Persist(sink); err != nil {
+		t.Fatalf("Persist: %v", err)
+	}
+	runtime.ReadMemStats(&after)
+	allocated := after.TotalAlloc - before.TotalAlloc
+	t.Logf("streamed %d byte archive with %d bytes allocated during Persist", len(payload), allocated)
+	if allocated > uint64(len(payload)/2) {
+		t.Fatalf("Persist allocated %d bytes for %d byte archive; want streaming allocation below half archive size", allocated, len(payload))
+	}
+	if !sink.closed || sink.canceled {
+		t.Fatalf("sink closed=%v canceled=%v, want close-only success", sink.closed, sink.canceled)
 	}
 }
 
@@ -394,4 +505,130 @@ func (s *boundaryTestSnapshotSink) Cancel() error {
 
 func (s *boundaryTestSnapshotSink) hashicorpRaftSnapshotBoundaryV1() (hashicorpRaftSnapshotBoundaryV1, bool) {
 	return s.boundary, true
+}
+
+type chunkRejectingSnapshotSink struct {
+	buf        bytes.Buffer
+	id         string
+	maxWrite   int
+	writeErr   error
+	writeCount int
+	maxSeen    int
+	closed     bool
+	canceled   bool
+}
+
+func (s *chunkRejectingSnapshotSink) ID() string {
+	if s.id != "" {
+		return s.id
+	}
+	return "chunk-rejecting-test"
+}
+
+func (s *chunkRejectingSnapshotSink) Write(p []byte) (int, error) {
+	s.writeCount++
+	if len(p) > s.maxSeen {
+		s.maxSeen = len(p)
+	}
+	if s.writeErr != nil {
+		return 0, s.writeErr
+	}
+	if s.maxWrite > 0 && len(p) > s.maxWrite {
+		return 0, fmt.Errorf("write size %d exceeds max %d", len(p), s.maxWrite)
+	}
+	return s.buf.Write(p)
+}
+
+func (s *chunkRejectingSnapshotSink) Bytes() []byte {
+	return s.buf.Bytes()
+}
+
+func (s *chunkRejectingSnapshotSink) Len() int {
+	return s.buf.Len()
+}
+
+func (s *chunkRejectingSnapshotSink) Close() error {
+	s.closed = true
+	return nil
+}
+
+func (s *chunkRejectingSnapshotSink) Cancel() error {
+	s.canceled = true
+	return nil
+}
+
+type discardSnapshotSink struct {
+	closed   bool
+	canceled bool
+}
+
+func (s *discardSnapshotSink) ID() string { return "discard-test" }
+
+func (s *discardSnapshotSink) Write(p []byte) (int, error) { return len(p), nil }
+
+func (s *discardSnapshotSink) Close() error {
+	s.closed = true
+	return nil
+}
+
+func (s *discardSnapshotSink) Cancel() error {
+	s.canceled = true
+	return nil
+}
+
+func validRaftSnapshotArchivePayloadWithBodyV1(t *testing.T, manifest SnapshotManifestV1, bodySize int) []byte {
+	t.Helper()
+	headerBytes, err := EncodeRaftSnapshotArchiveHeaderV1(NewRaftSnapshotArchiveHeaderV1(manifest))
+	if err != nil {
+		t.Fatalf("EncodeRaftSnapshotArchiveHeaderV1: %v", err)
+	}
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	if err := tw.WriteHeader(&tar.Header{
+		Name: RaftSnapshotArchiveManifestPathV1,
+		Mode: 0o600,
+		Size: int64(len(headerBytes)),
+	}); err != nil {
+		t.Fatalf("WriteHeader manifest: %v", err)
+	}
+	if _, err := tw.Write(headerBytes); err != nil {
+		t.Fatalf("Write manifest: %v", err)
+	}
+	if err := tw.WriteHeader(&tar.Header{
+		Name: "db/index.db",
+		Mode: 0o600,
+		Size: int64(bodySize),
+	}); err != nil {
+		t.Fatalf("WriteHeader body: %v", err)
+	}
+	if _, err := io.CopyN(tw, zeroReader{}, int64(bodySize)); err != nil {
+		t.Fatalf("Write body: %v", err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("Close archive: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func writeRaftSnapshotArchiveFileForTest(t *testing.T, payload []byte) string {
+	t.Helper()
+	file, err := os.CreateTemp(t.TempDir(), "snapshot-*.tar")
+	if err != nil {
+		t.Fatalf("CreateTemp archive: %v", err)
+	}
+	if _, err := file.Write(payload); err != nil {
+		_ = file.Close()
+		t.Fatalf("Write archive: %v", err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("Close archive: %v", err)
+	}
+	return file.Name()
+}
+
+type zeroReader struct{}
+
+func (zeroReader) Read(p []byte) (int, error) {
+	clear(p)
+	return len(p), nil
 }

--- a/TreeDB/internal/raftcluster/hashicorp_raft_internal_test.go
+++ b/TreeDB/internal/raftcluster/hashicorp_raft_internal_test.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"math"
 	"os"
+	"path/filepath"
 	"runtime"
 	"testing"
 	"time"
@@ -245,6 +246,104 @@ func TestHashicorpRaftSnapshotPersistFileSourceAllocationGuard(t *testing.T) {
 	}
 	if !sink.closed || sink.canceled {
 		t.Fatalf("sink closed=%v canceled=%v, want close-only success", sink.closed, sink.canceled)
+	}
+}
+
+func TestHashicorpRaftSnapshotPersistCancelsOnInvalidArchivePathSource(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(t *testing.T, archivePath string, manifest SnapshotManifestV1)
+	}{
+		{
+			name: "missing",
+			mutate: func(t *testing.T, archivePath string, _ SnapshotManifestV1) {
+				t.Helper()
+				if err := os.Remove(archivePath); err != nil {
+					t.Fatalf("Remove archive path: %v", err)
+				}
+			},
+		},
+		{
+			name: "replaced manifest",
+			mutate: func(t *testing.T, archivePath string, manifest SnapshotManifestV1) {
+				t.Helper()
+				replacement := manifest
+				replacement.LastIncludedIndex++
+				if err := os.WriteFile(archivePath, validRaftSnapshotArchivePayloadV1(t, replacement), 0o600); err != nil {
+					t.Fatalf("Replace archive path: %v", err)
+				}
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			manifest := validSnapshotManifestV1()
+			archivePath := writeRaftSnapshotArchiveFileForTest(t, validRaftSnapshotArchivePayloadV1(t, manifest))
+			tc.mutate(t, archivePath, manifest)
+			snapshot := hashicorpRaftSnapshotV1{
+				snapshot: RaftSnapshotV1{
+					Manifest:    manifest,
+					ArchivePath: archivePath,
+				},
+			}
+			sink := &boundaryTestSnapshotSink{}
+
+			err := snapshot.Persist(sink)
+			if !errors.Is(err, ErrInvalidSnapshotManifest) {
+				t.Fatalf("Persist err=%v want ErrInvalidSnapshotManifest", err)
+			}
+			if !sink.canceled {
+				t.Fatal("Persist did not cancel sink after invalid archive path source")
+			}
+			if sink.closed {
+				t.Fatal("Persist closed sink after invalid archive path source")
+			}
+			if sink.Len() != 0 {
+				t.Fatalf("Persist wrote %d bytes before rejecting archive path source", sink.Len())
+			}
+		})
+	}
+}
+
+func TestHashicorpRaftFileSnapshotStoreListIgnoresStagedSiblingDirectory(t *testing.T) {
+	baseDir := t.TempDir()
+	store, err := hraft.NewFileSnapshotStore(baseDir, 2, io.Discard)
+	if err != nil {
+		t.Fatalf("NewFileSnapshotStore: %v", err)
+	}
+	stagedDir := filepath.Join(baseDir, "staged")
+	if err := os.MkdirAll(stagedDir, 0o700); err != nil {
+		t.Fatalf("Mkdir staged dir: %v", err)
+	}
+	orphanPath := filepath.Join(stagedDir, "treedb-snapshot-orphan.tar")
+	if err := os.WriteFile(orphanPath, []byte("orphaned staged archive"), 0o600); err != nil {
+		t.Fatalf("Write staged archive: %v", err)
+	}
+
+	sink, err := store.Create(hraft.SnapshotVersionMax, 11, 7, hraft.Configuration{}, 0, nil)
+	if err != nil {
+		t.Fatalf("Create snapshot: %v", err)
+	}
+	if _, err := sink.Write(validRaftSnapshotArchivePayloadV1(t, validSnapshotManifestV1())); err != nil {
+		_ = sink.Cancel()
+		t.Fatalf("Write snapshot: %v", err)
+	}
+	if err := sink.Close(); err != nil {
+		t.Fatalf("Close snapshot: %v", err)
+	}
+
+	snapshots, err := store.List()
+	if err != nil {
+		t.Fatalf("List snapshots with staged sibling dir: %v", err)
+	}
+	if len(snapshots) != 1 {
+		t.Fatalf("List returned %d snapshots, want 1", len(snapshots))
+	}
+	if snapshots[0].Index != 11 || snapshots[0].Term != 7 {
+		t.Fatalf("snapshot meta index=%d term=%d, want index=11 term=7", snapshots[0].Index, snapshots[0].Term)
+	}
+	if _, err := os.Stat(orphanPath); err != nil {
+		t.Fatalf("staged sibling archive should be outside FileSnapshotStore retention/listing path: %v", err)
 	}
 }
 

--- a/TreeDB/internal/raftcluster/hashicorp_raft_test.go
+++ b/TreeDB/internal/raftcluster/hashicorp_raft_test.go
@@ -1110,7 +1110,7 @@ func hashicorpRaftFastTestConfig() *hraft.Config {
 
 func (c *hashicorpRaftTestCluster) waitForLeader(tb testing.TB) *hashicorpRaftTestNode {
 	tb.Helper()
-	deadline := time.Now().Add(5 * time.Second)
+	deadline := time.Now().Add(15 * time.Second)
 	for time.Now().Before(deadline) {
 		var leader *hashicorpRaftTestNode
 		for _, node := range c.nodes {

--- a/TreeDB/internal/raftcluster/snapshot_manifest.go
+++ b/TreeDB/internal/raftcluster/snapshot_manifest.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 	"time"
 
@@ -184,11 +185,13 @@ func validateLogicalDigestV1Hex(digest string) error {
 
 // RaftSnapshotV1 is the production snapshot payload handed to the Raft
 // adapter. The manifest identifies the durable apply boundary and logical
-// digest; Payload is an implementation-owned archive that contains the local
-// TreeDB storage required to restore that boundary on another node.
+// digest. Production snapshots should use ArchivePath so persistence can stream
+// bytes from a stable staged source; Payload is retained for small byte-backed
+// tests and fixtures.
 type RaftSnapshotV1 struct {
-	Manifest SnapshotManifestV1
-	Payload  []byte
+	Manifest    SnapshotManifestV1
+	Payload     []byte
+	ArchivePath string
 }
 
 func (s RaftSnapshotV1) Clone() RaftSnapshotV1 {
@@ -200,15 +203,53 @@ func (s RaftSnapshotV1) Validate() error {
 	if err := s.Manifest.Validate(s.Manifest.Scope); err != nil {
 		return err
 	}
-	if len(s.Payload) == 0 {
-		return fmt.Errorf("%w: empty snapshot payload", ErrInvalidSnapshotManifest)
+	if len(s.Payload) != 0 && s.ArchivePath != "" {
+		return fmt.Errorf("%w: snapshot has both payload and archive path", ErrInvalidSnapshotManifest)
 	}
-	payloadManifest, err := DecodeSnapshotManifestV1FromArchive(s.Payload)
+	if len(s.Payload) == 0 && s.ArchivePath == "" {
+		return fmt.Errorf("%w: empty snapshot archive source", ErrInvalidSnapshotManifest)
+	}
+	src, err := s.OpenArchive()
 	if err != nil {
 		return err
 	}
+	payloadManifest, decodeErr := DecodeSnapshotManifestV1FromArchiveReader(src)
+	closeErr := src.Close()
+	if decodeErr != nil {
+		return decodeErr
+	}
+	if closeErr != nil {
+		return fmt.Errorf("%w: close snapshot archive source: %v", ErrInvalidSnapshotManifest, closeErr)
+	}
 	if !snapshotManifestV1Equal(payloadManifest, s.Manifest) {
 		return fmt.Errorf("%w: snapshot payload manifest does not match outer manifest", ErrInvalidSnapshotManifest)
+	}
+	return nil
+}
+
+func (s RaftSnapshotV1) OpenArchive() (io.ReadCloser, error) {
+	if len(s.Payload) != 0 && s.ArchivePath != "" {
+		return nil, fmt.Errorf("%w: snapshot has both payload and archive path", ErrInvalidSnapshotManifest)
+	}
+	if len(s.Payload) != 0 {
+		return io.NopCloser(bytes.NewReader(s.Payload)), nil
+	}
+	if s.ArchivePath == "" {
+		return nil, fmt.Errorf("%w: empty snapshot archive source", ErrInvalidSnapshotManifest)
+	}
+	file, err := os.Open(s.ArchivePath)
+	if err != nil {
+		return nil, fmt.Errorf("%w: open snapshot archive source: %v", ErrInvalidSnapshotManifest, err)
+	}
+	return file, nil
+}
+
+func (s RaftSnapshotV1) Release() error {
+	if s.ArchivePath == "" {
+		return nil
+	}
+	if err := os.Remove(s.ArchivePath); err != nil && !os.IsNotExist(err) {
+		return err
 	}
 	return nil
 }

--- a/TreeDB/internal/raftcluster/snapshot_manifest_test.go
+++ b/TreeDB/internal/raftcluster/snapshot_manifest_test.go
@@ -4,6 +4,7 @@ import (
 	"archive/tar"
 	"bytes"
 	"errors"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -227,6 +228,41 @@ func TestRaftSnapshotV1ValidateAcceptsMatchingPayloadManifestWithMonotonicCreate
 	}
 	if err := snapshot.Validate(); err != nil {
 		t.Fatalf("Validate matching payload manifest with monotonic CreatedAt: %v", err)
+	}
+}
+
+func TestRaftSnapshotV1ValidateAcceptsMatchingArchivePathManifest(t *testing.T) {
+	manifest := validSnapshotManifestV1()
+	payload := validRaftSnapshotArchivePayloadV1(t, manifest)
+	file, err := os.CreateTemp(t.TempDir(), "snapshot-*.tar")
+	if err != nil {
+		t.Fatalf("CreateTemp: %v", err)
+	}
+	if _, err := file.Write(payload); err != nil {
+		_ = file.Close()
+		t.Fatalf("Write payload: %v", err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("Close payload: %v", err)
+	}
+	snapshot := RaftSnapshotV1{
+		Manifest:    manifest,
+		ArchivePath: file.Name(),
+	}
+	if err := snapshot.Validate(); err != nil {
+		t.Fatalf("Validate matching archive path manifest: %v", err)
+	}
+}
+
+func TestRaftSnapshotV1ValidateRejectsAmbiguousArchiveSources(t *testing.T) {
+	manifest := validSnapshotManifestV1()
+	snapshot := RaftSnapshotV1{
+		Manifest:    manifest,
+		Payload:     validRaftSnapshotArchivePayloadV1(t, manifest),
+		ArchivePath: "snapshot.tar",
+	}
+	if err := snapshot.Validate(); !errors.Is(err, ErrInvalidSnapshotManifest) {
+		t.Fatalf("Validate ambiguous archive source error=%v, want ErrInvalidSnapshotManifest", err)
 	}
 }
 

--- a/TreeDB/internal/raftcluster/snapshot_manifest_test.go
+++ b/TreeDB/internal/raftcluster/snapshot_manifest_test.go
@@ -254,6 +254,45 @@ func TestRaftSnapshotV1ValidateAcceptsMatchingArchivePathManifest(t *testing.T) 
 	}
 }
 
+func TestRaftSnapshotV1ValidateRejectsMissingArchivePath(t *testing.T) {
+	manifest := validSnapshotManifestV1()
+	archivePath := writeRaftSnapshotArchiveFileForTest(t, validRaftSnapshotArchivePayloadV1(t, manifest))
+	if err := os.Remove(archivePath); err != nil {
+		t.Fatalf("Remove archive path: %v", err)
+	}
+	snapshot := RaftSnapshotV1{
+		Manifest:    manifest,
+		ArchivePath: archivePath,
+	}
+	if err := snapshot.Validate(); !errors.Is(err, ErrInvalidSnapshotManifest) {
+		t.Fatalf("Validate missing archive path error=%v, want ErrInvalidSnapshotManifest", err)
+	}
+	reader, err := snapshot.OpenArchive()
+	if reader != nil {
+		_ = reader.Close()
+	}
+	if !errors.Is(err, ErrInvalidSnapshotManifest) {
+		t.Fatalf("OpenArchive missing archive path error=%v, want ErrInvalidSnapshotManifest", err)
+	}
+}
+
+func TestRaftSnapshotV1ValidateRejectsReplacedArchivePathManifest(t *testing.T) {
+	outer := validSnapshotManifestV1()
+	replacement := outer
+	replacement.LastIncludedIndex++
+	archivePath := writeRaftSnapshotArchiveFileForTest(t, validRaftSnapshotArchivePayloadV1(t, outer))
+	if err := os.WriteFile(archivePath, validRaftSnapshotArchivePayloadV1(t, replacement), 0o600); err != nil {
+		t.Fatalf("Replace archive path: %v", err)
+	}
+	snapshot := RaftSnapshotV1{
+		Manifest:    outer,
+		ArchivePath: archivePath,
+	}
+	if err := snapshot.Validate(); !errors.Is(err, ErrInvalidSnapshotManifest) {
+		t.Fatalf("Validate replaced archive path manifest error=%v, want ErrInvalidSnapshotManifest", err)
+	}
+}
+
 func TestRaftSnapshotV1ValidateRejectsAmbiguousArchiveSources(t *testing.T) {
 	manifest := validSnapshotManifestV1()
 	snapshot := RaftSnapshotV1{

--- a/TreeDB/internal/raftfsm/fsm.go
+++ b/TreeDB/internal/raftfsm/fsm.go
@@ -117,7 +117,7 @@ func Open(opts Options) (*FSM, error) {
 		return nil, errors.Join(codedError(raftentry.ErrorUnsafeDurabilityModeV1, "invalid raftcluster config"), err)
 	}
 	if err := cleanupAbandonedRaftSnapshotArchivesV1(cluster.Layout.SnapshotDir); err != nil {
-		return nil, err
+		return nil, errors.Join(codedError(raftentry.ErrorUnsafeDurabilityModeV1, "cleanup abandoned raft snapshot archives"), err)
 	}
 	metadataDir := cluster.Layout.ApplyDir
 	if metadataDir == "" {

--- a/TreeDB/internal/raftfsm/fsm.go
+++ b/TreeDB/internal/raftfsm/fsm.go
@@ -116,6 +116,9 @@ func Open(opts Options) (*FSM, error) {
 	if err != nil {
 		return nil, errors.Join(codedError(raftentry.ErrorUnsafeDurabilityModeV1, "invalid raftcluster config"), err)
 	}
+	if err := cleanupAbandonedRaftSnapshotArchivesV1(cluster.Layout.SnapshotDir); err != nil {
+		return nil, err
+	}
 	metadataDir := cluster.Layout.ApplyDir
 	if metadataDir == "" {
 		return nil, codedError(raftentry.ErrorUnsafeDurabilityModeV1, "missing raftcluster apply dir")

--- a/TreeDB/internal/raftfsm/raft_snapshot.go
+++ b/TreeDB/internal/raftfsm/raft_snapshot.go
@@ -141,11 +141,18 @@ func cleanupAbandonedRaftSnapshotArchivesV1(snapshotDir string) error {
 		return nil
 	}
 	stagingDir := raftSnapshotStagingDirV1(snapshotDir)
-	entries, err := os.ReadDir(stagingDir)
+	info, err := os.Stat(stagingDir)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
 			return nil
 		}
+		return fmt.Errorf("raftfsm: stat snapshot staging directory: %w", err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("raftfsm: snapshot staging path %q is not a directory", stagingDir)
+	}
+	entries, err := os.ReadDir(stagingDir)
+	if err != nil {
 		return fmt.Errorf("raftfsm: read snapshot staging directory: %w", err)
 	}
 	for _, entry := range entries {

--- a/TreeDB/internal/raftfsm/raft_snapshot.go
+++ b/TreeDB/internal/raftfsm/raft_snapshot.go
@@ -23,6 +23,7 @@ const (
 	raftSnapshotApplyPrefixV1 = "apply"
 
 	raftSnapshotFormatConfigFileV1 = "format.json"
+	raftSnapshotStagingDirNameV1   = "staged"
 )
 
 var raftSnapshotMainDBEntriesV1 = []string{
@@ -123,7 +124,7 @@ func createRaftSnapshotArchiveFileV1(snapshotDir string) (*os.File, string, erro
 	if strings.TrimSpace(snapshotDir) == "" {
 		return nil, "", fmt.Errorf("raftfsm: missing snapshot staging directory")
 	}
-	stagingDir := filepath.Join(snapshotDir, "staged")
+	stagingDir := raftSnapshotStagingDirV1(snapshotDir)
 	if err := os.MkdirAll(stagingDir, 0o700); err != nil {
 		return nil, "", fmt.Errorf("raftfsm: create snapshot staging directory: %w", err)
 	}
@@ -132,6 +133,34 @@ func createRaftSnapshotArchiveFileV1(snapshotDir string) (*os.File, string, erro
 		return nil, "", fmt.Errorf("raftfsm: create snapshot archive: %w", err)
 	}
 	return file, file.Name(), nil
+}
+
+func cleanupAbandonedRaftSnapshotArchivesV1(snapshotDir string) error {
+	if strings.TrimSpace(snapshotDir) == "" {
+		return nil
+	}
+	stagingDir := raftSnapshotStagingDirV1(snapshotDir)
+	entries, err := os.ReadDir(stagingDir)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("raftfsm: read snapshot staging directory: %w", err)
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		path := filepath.Join(stagingDir, entry.Name())
+		if err := os.Remove(path); err != nil && !errors.Is(err, fs.ErrNotExist) {
+			return fmt.Errorf("raftfsm: remove abandoned staged snapshot archive %q: %w", path, err)
+		}
+	}
+	return nil
+}
+
+func raftSnapshotStagingDirV1(snapshotDir string) string {
+	return filepath.Join(snapshotDir, raftSnapshotStagingDirNameV1)
 }
 
 // InstallRaftSnapshotV1 discards the local TreeDB state and installs a

--- a/TreeDB/internal/raftfsm/raft_snapshot.go
+++ b/TreeDB/internal/raftfsm/raft_snapshot.go
@@ -24,6 +24,7 @@ const (
 
 	raftSnapshotFormatConfigFileV1 = "format.json"
 	raftSnapshotStagingDirNameV1   = "staged"
+	raftSnapshotArchiveGlobV1      = "treedb-snapshot-*.tar"
 )
 
 var raftSnapshotMainDBEntriesV1 = []string{
@@ -128,7 +129,7 @@ func createRaftSnapshotArchiveFileV1(snapshotDir string) (*os.File, string, erro
 	if err := os.MkdirAll(stagingDir, 0o700); err != nil {
 		return nil, "", fmt.Errorf("raftfsm: create snapshot staging directory: %w", err)
 	}
-	file, err := os.CreateTemp(stagingDir, "treedb-snapshot-*.tar")
+	file, err := os.CreateTemp(stagingDir, raftSnapshotArchiveGlobV1)
 	if err != nil {
 		return nil, "", fmt.Errorf("raftfsm: create snapshot archive: %w", err)
 	}
@@ -151,8 +152,11 @@ func cleanupAbandonedRaftSnapshotArchivesV1(snapshotDir string) error {
 		if entry.IsDir() {
 			continue
 		}
-		matched, err := filepath.Match("treedb-snapshot-*.tar", entry.Name())
-		if err != nil || !matched {
+		matches, err := filepath.Match(raftSnapshotArchiveGlobV1, entry.Name())
+		if err != nil {
+			return fmt.Errorf("raftfsm: match snapshot archive pattern: %w", err)
+		}
+		if !matches {
 			continue
 		}
 		path := filepath.Join(stagingDir, entry.Name())

--- a/TreeDB/internal/raftfsm/raft_snapshot.go
+++ b/TreeDB/internal/raftfsm/raft_snapshot.go
@@ -122,7 +122,7 @@ func (f *FSM) ExportRaftSnapshotV1() (raftcluster.RaftSnapshotV1, error) {
 
 func createRaftSnapshotArchiveFileV1(snapshotDir string) (*os.File, string, error) {
 	if strings.TrimSpace(snapshotDir) == "" {
-		return nil, "", fmt.Errorf("raftfsm: missing snapshot staging directory")
+		return nil, "", fmt.Errorf("raftfsm: missing snapshot directory (SnapshotDir is empty)")
 	}
 	stagingDir := raftSnapshotStagingDirV1(snapshotDir)
 	if err := os.MkdirAll(stagingDir, 0o700); err != nil {
@@ -149,6 +149,10 @@ func cleanupAbandonedRaftSnapshotArchivesV1(snapshotDir string) error {
 	}
 	for _, entry := range entries {
 		if entry.IsDir() {
+			continue
+		}
+		matched, err := filepath.Match("treedb-snapshot-*.tar", entry.Name())
+		if err != nil || !matched {
 			continue
 		}
 		path := filepath.Join(stagingDir, entry.Name())

--- a/TreeDB/internal/raftfsm/raft_snapshot.go
+++ b/TreeDB/internal/raftfsm/raft_snapshot.go
@@ -2,7 +2,6 @@ package raftfsm
 
 import (
 	"archive/tar"
-	"bytes"
 	"errors"
 	"fmt"
 	"io"
@@ -69,33 +68,70 @@ func (f *FSM) ExportRaftSnapshotV1() (raftcluster.RaftSnapshotV1, error) {
 		return raftcluster.RaftSnapshotV1{}, err
 	}
 
-	var buf bytes.Buffer
-	tw := tar.NewWriter(&buf)
+	archiveFile, archivePath, err := createRaftSnapshotArchiveFileV1(f.cluster.Layout.SnapshotDir)
+	if err != nil {
+		return raftcluster.RaftSnapshotV1{}, err
+	}
+	keepArchive := false
+	defer func() {
+		if !keepArchive {
+			_ = os.Remove(archivePath)
+		}
+	}()
+	tw := tar.NewWriter(archiveFile)
 	if err := writeRaftSnapshotFileV1(tw, raftcluster.RaftSnapshotArchiveManifestPathV1, headerBytes, 0o600); err != nil {
+		_ = archiveFile.Close()
 		return raftcluster.RaftSnapshotV1{}, err
 	}
 	if err := appendRaftSnapshotTreeDBStorageV1(tw, raftSnapshotDBPrefixV1, raftcluster.MainDBDir(f.cluster.Dir)); err != nil {
+		_ = archiveFile.Close()
 		return raftcluster.RaftSnapshotV1{}, err
 	}
 	if !f.cluster.DisableSideStores {
 		if err := appendRaftSnapshotTreeDBSideStoresV1(tw, raftSnapshotSidePrefixV1, raftcluster.MainDBDir(f.cluster.Dir)); err != nil {
+			_ = archiveFile.Close()
 			return raftcluster.RaftSnapshotV1{}, err
 		}
 	}
 	if err := appendRaftSnapshotDirV1(tw, raftSnapshotApplyPrefixV1, f.cluster.Layout.ApplyDir); err != nil {
+		_ = archiveFile.Close()
 		return raftcluster.RaftSnapshotV1{}, err
 	}
 	if err := tw.Close(); err != nil {
+		_ = archiveFile.Close()
 		return raftcluster.RaftSnapshotV1{}, fmt.Errorf("raftfsm: close snapshot archive: %w", err)
 	}
+	if err := archiveFile.Sync(); err != nil {
+		_ = archiveFile.Close()
+		return raftcluster.RaftSnapshotV1{}, fmt.Errorf("raftfsm: sync snapshot archive: %w", err)
+	}
+	if err := archiveFile.Close(); err != nil {
+		return raftcluster.RaftSnapshotV1{}, fmt.Errorf("raftfsm: close snapshot archive file: %w", err)
+	}
 	snapshot := raftcluster.RaftSnapshotV1{
-		Manifest: manifest,
-		Payload:  buf.Bytes(),
+		Manifest:    manifest,
+		ArchivePath: archivePath,
 	}
 	if err := snapshot.Validate(); err != nil {
 		return raftcluster.RaftSnapshotV1{}, err
 	}
+	keepArchive = true
 	return snapshot, nil
+}
+
+func createRaftSnapshotArchiveFileV1(snapshotDir string) (*os.File, string, error) {
+	if strings.TrimSpace(snapshotDir) == "" {
+		return nil, "", fmt.Errorf("raftfsm: missing snapshot staging directory")
+	}
+	stagingDir := filepath.Join(snapshotDir, "staged")
+	if err := os.MkdirAll(stagingDir, 0o700); err != nil {
+		return nil, "", fmt.Errorf("raftfsm: create snapshot staging directory: %w", err)
+	}
+	file, err := os.CreateTemp(stagingDir, "treedb-snapshot-*.tar")
+	if err != nil {
+		return nil, "", fmt.Errorf("raftfsm: create snapshot archive: %w", err)
+	}
+	return file, file.Name(), nil
 }
 
 // InstallRaftSnapshotV1 discards the local TreeDB state and installs a

--- a/TreeDB/internal/raftfsm/raft_snapshot_test.go
+++ b/TreeDB/internal/raftfsm/raft_snapshot_test.go
@@ -235,6 +235,40 @@ func TestRaftSnapshotV1ExportStagesArchiveWithoutPayloadAndReleaseCleans(t *test
 	}
 }
 
+func TestRaftSnapshotV1OpenCleansAbandonedStagedArchives(t *testing.T) {
+	root := t.TempDir()
+	sourceDir := filepath.Join(root, "source")
+	sourceDB := openRaftSnapshotFSMTestDB(t, sourceDir, false)
+	defer func() { _ = sourceDB.Close() }()
+
+	resolved, err := raftcluster.Validate(validFSMClusterConfig(sourceDir))
+	if err != nil {
+		t.Fatalf("Validate cluster config: %v", err)
+	}
+	stagingDir := raftSnapshotStagingDirV1(resolved.Layout.SnapshotDir)
+	if err := os.MkdirAll(stagingDir, 0o700); err != nil {
+		t.Fatalf("Mkdir staging dir: %v", err)
+	}
+	orphanPath := filepath.Join(stagingDir, "treedb-snapshot-orphan.tar")
+	if err := os.WriteFile(orphanPath, []byte("abandoned snapshot archive"), 0o600); err != nil {
+		t.Fatalf("Write orphan staged archive: %v", err)
+	}
+	nestedDir := filepath.Join(stagingDir, "nested")
+	if err := os.MkdirAll(nestedDir, 0o700); err != nil {
+		t.Fatalf("Mkdir nested staging dir: %v", err)
+	}
+
+	fsm := openRaftSnapshotFSMForTest(t, sourceDB, sourceDir, false)
+	defer func() { _ = fsm.Close() }()
+
+	if _, err := os.Stat(orphanPath); !os.IsNotExist(err) {
+		t.Fatalf("Open did not remove abandoned staged archive: stat err=%v", err)
+	}
+	if _, err := os.Stat(nestedDir); err != nil {
+		t.Fatalf("Open should leave staged subdirectories alone: %v", err)
+	}
+}
+
 func TestRaftSnapshotV1InstallReplacesStaleReplica(t *testing.T) {
 	root := t.TempDir()
 	sourceDir := filepath.Join(root, "source")

--- a/TreeDB/internal/raftfsm/raft_snapshot_test.go
+++ b/TreeDB/internal/raftfsm/raft_snapshot_test.go
@@ -253,6 +253,14 @@ func TestRaftSnapshotV1OpenCleansAbandonedStagedArchives(t *testing.T) {
 	if err := os.WriteFile(orphanPath, []byte("abandoned snapshot archive"), 0o600); err != nil {
 		t.Fatalf("Write orphan staged archive: %v", err)
 	}
+	unrelatedPath := filepath.Join(stagingDir, "operator-note.txt")
+	if err := os.WriteFile(unrelatedPath, []byte("not a TreeDB snapshot archive"), 0o600); err != nil {
+		t.Fatalf("Write unrelated staged file: %v", err)
+	}
+	wrongSuffixPath := filepath.Join(stagingDir, "treedb-snapshot-manual.tmp")
+	if err := os.WriteFile(wrongSuffixPath, []byte("not a temp snapshot archive"), 0o600); err != nil {
+		t.Fatalf("Write non-archive staged file: %v", err)
+	}
 	nestedDir := filepath.Join(stagingDir, "nested")
 	if err := os.MkdirAll(nestedDir, 0o700); err != nil {
 		t.Fatalf("Mkdir nested staging dir: %v", err)
@@ -263,6 +271,12 @@ func TestRaftSnapshotV1OpenCleansAbandonedStagedArchives(t *testing.T) {
 
 	if _, err := os.Stat(orphanPath); !os.IsNotExist(err) {
 		t.Fatalf("Open did not remove abandoned staged archive: stat err=%v", err)
+	}
+	if _, err := os.Stat(unrelatedPath); err != nil {
+		t.Fatalf("Open should leave unrelated staged files alone: %v", err)
+	}
+	if _, err := os.Stat(wrongSuffixPath); err != nil {
+		t.Fatalf("Open should leave non-archive staged files alone: %v", err)
 	}
 	if _, err := os.Stat(nestedDir); err != nil {
 		t.Fatalf("Open should leave staged subdirectories alone: %v", err)

--- a/TreeDB/internal/raftfsm/raft_snapshot_test.go
+++ b/TreeDB/internal/raftfsm/raft_snapshot_test.go
@@ -169,7 +169,7 @@ func TestRaftSnapshotV1InstallEmptyTargetPreservesDigestAndValueLogPointers(t *t
 	if err != nil {
 		t.Fatalf("ExportRaftSnapshotV1: %v", err)
 	}
-	assertSnapshotArchiveHasNonEmptyApplyMetadata(t, snapshot.Payload)
+	assertSnapshotArchiveHasNonEmptyApplyMetadata(t, readRaftSnapshotArchiveForTest(t, snapshot))
 	assertSnapshotValueLogHasFile(t, raftcluster.ValueLogDir(sourceDir))
 	sourceDigest, err := sourceFSM.LogicalDigestV1(raftapply.LogicalDigestOptionsV1{})
 	if err != nil {
@@ -181,9 +181,7 @@ func TestRaftSnapshotV1InstallEmptyTargetPreservesDigestAndValueLogPointers(t *t
 	targetFSM := openRaftSnapshotFSMForTest(t, targetDB, targetDir, true)
 	defer func() { _ = targetFSM.Close() }()
 
-	if err := targetFSM.InstallRaftSnapshotV1(bytes.NewReader(snapshot.Payload)); err != nil {
-		t.Fatalf("InstallRaftSnapshotV1: %v", err)
-	}
+	installRaftSnapshotForTest(t, targetFSM, snapshot)
 	if err := targetFSM.VerifyInstalledSnapshotManifestV1(snapshot.Manifest); err != nil {
 		t.Fatalf("VerifyInstalledSnapshotManifestV1: %v", err)
 	}
@@ -196,6 +194,45 @@ func TestRaftSnapshotV1InstallEmptyTargetPreservesDigestAndValueLogPointers(t *t
 	}
 	assertSnapshotValueLogHasFile(t, raftcluster.ValueLogDir(targetDir))
 	assertSnapshotDocument(t, targetFSM, "u-large", largeDoc)
+}
+
+func TestRaftSnapshotV1ExportStagesArchiveWithoutPayloadAndReleaseCleans(t *testing.T) {
+	root := t.TempDir()
+	sourceDir := filepath.Join(root, "source")
+	sourceDB := openRaftSnapshotFSMTestDB(t, sourceDir, true)
+	defer func() { _ = sourceDB.Close() }()
+	sourceFSM := openRaftSnapshotFSMForTest(t, sourceDB, sourceDir, true)
+	defer func() { _ = sourceFSM.Close() }()
+
+	largeDoc := []byte(`{"_id":"u-large","name":"staged","payload":"` + stringsRepeatForSnapshotTest("x", 1<<20) + `"}`)
+	applySnapshotSourceEntries(t, sourceFSM, largeDoc)
+
+	snapshot, err := sourceFSM.ExportRaftSnapshotV1()
+	if err != nil {
+		t.Fatalf("ExportRaftSnapshotV1: %v", err)
+	}
+	if len(snapshot.Payload) != 0 {
+		t.Fatalf("production snapshot payload len=%d, want file-backed archive", len(snapshot.Payload))
+	}
+	if snapshot.ArchivePath == "" {
+		t.Fatal("production snapshot missing staged archive path")
+	}
+	info, err := os.Stat(snapshot.ArchivePath)
+	if err != nil {
+		t.Fatalf("Stat staged archive: %v", err)
+	}
+	if info.Size() == 0 {
+		t.Fatal("staged archive is empty")
+	}
+	if err := snapshot.Release(); err != nil {
+		t.Fatalf("Release staged archive: %v", err)
+	}
+	if err := snapshot.Release(); err != nil {
+		t.Fatalf("Release staged archive again: %v", err)
+	}
+	if _, err := os.Stat(snapshot.ArchivePath); !os.IsNotExist(err) {
+		t.Fatalf("staged archive survived Release: stat err=%v", err)
+	}
 }
 
 func TestRaftSnapshotV1InstallReplacesStaleReplica(t *testing.T) {
@@ -224,9 +261,7 @@ func TestRaftSnapshotV1InstallReplacesStaleReplica(t *testing.T) {
 	}
 	assertApplied(t, result, raftentry.ApplyStatusApplied, 1)
 
-	if err := targetFSM.InstallRaftSnapshotV1(bytes.NewReader(snapshot.Payload)); err != nil {
-		t.Fatalf("InstallRaftSnapshotV1 over stale target: %v", err)
-	}
+	installRaftSnapshotForTest(t, targetFSM, snapshot)
 	if err := targetFSM.VerifyInstalledSnapshotManifestV1(snapshot.Manifest); err != nil {
 		t.Fatalf("VerifyInstalledSnapshotManifestV1: %v", err)
 	}
@@ -269,9 +304,7 @@ func TestRaftSnapshotV1InstallReplacesStaleFormatConfig(t *testing.T) {
 		t.Fatalf("WriteFile stale transient file: %v", err)
 	}
 
-	if err := targetFSM.InstallRaftSnapshotV1(bytes.NewReader(snapshot.Payload)); err != nil {
-		t.Fatalf("InstallRaftSnapshotV1 with stale target format config: %v", err)
-	}
+	installRaftSnapshotForTest(t, targetFSM, snapshot)
 	targetFormat, err := os.ReadFile(targetFormatPath)
 	if err != nil {
 		t.Fatalf("ReadFile target format config: %v", err)
@@ -299,7 +332,7 @@ func TestRaftSnapshotV1InstallRejectsCorruptArchiveBeforeReplacingLiveState(t *t
 	if err != nil {
 		t.Fatalf("ExportRaftSnapshotV1: %v", err)
 	}
-	corruptPayload := rewriteRaftSnapshotArchiveHeaderForTest(t, snapshot.Payload, func(header *raftcluster.RaftSnapshotArchiveHeaderV1) {
+	corruptPayload := rewriteRaftSnapshotArchiveHeaderForTest(t, readRaftSnapshotArchiveForTest(t, snapshot), func(header *raftcluster.RaftSnapshotArchiveHeaderV1) {
 		header.Manifest.LogicalDigestV1 = strings.Repeat("f", 64)
 	})
 
@@ -351,9 +384,7 @@ func TestRaftSnapshotV1TailReplayMatchesSourceDigest(t *testing.T) {
 	targetDB := openRaftSnapshotFSMTestDB(t, targetDir, false)
 	targetFSM := openRaftSnapshotFSMForTest(t, targetDB, targetDir, true)
 	defer func() { _ = targetFSM.Close() }()
-	if err := targetFSM.InstallRaftSnapshotV1(bytes.NewReader(snapshot.Payload)); err != nil {
-		t.Fatalf("InstallRaftSnapshotV1: %v", err)
-	}
+	installRaftSnapshotForTest(t, targetFSM, snapshot)
 	result, err = targetFSM.ApplyCommittedEntryV1(tail)
 	if err != nil {
 		t.Fatalf("target tail ApplyCommittedEntryV1: %v result=%+v", err, result)
@@ -403,9 +434,7 @@ func TestRaftSnapshotV1InstallReplacesSideStores(t *testing.T) {
 		t.Fatalf("WriteFile target stale side store: %v", err)
 	}
 
-	if err := targetFSM.InstallRaftSnapshotV1(bytes.NewReader(snapshot.Payload)); err != nil {
-		t.Fatalf("InstallRaftSnapshotV1: %v", err)
-	}
+	installRaftSnapshotForTest(t, targetFSM, snapshot)
 	got, err := os.ReadFile(filepath.Join(targetRoot, "dictdb", "sentinel"))
 	if err != nil {
 		t.Fatalf("ReadFile restored side-store sentinel: %v", err)
@@ -440,9 +469,7 @@ func TestRaftSnapshotV1InstallReopensRestoredMainDBForRootLayout(t *testing.T) {
 	targetFSM := openRaftSnapshotFSMForTestWithClusterDir(t, targetDB, targetRoot, true)
 	defer func() { _ = targetFSM.Close() }()
 
-	if err := targetFSM.InstallRaftSnapshotV1(bytes.NewReader(snapshot.Payload)); err != nil {
-		t.Fatalf("InstallRaftSnapshotV1: %v", err)
-	}
+	installRaftSnapshotForTest(t, targetFSM, snapshot)
 	if err := targetFSM.VerifyInstalledSnapshotManifestV1(snapshot.Manifest); err != nil {
 		t.Fatalf("VerifyInstalledSnapshotManifestV1: %v", err)
 	}
@@ -482,9 +509,7 @@ func TestRaftSnapshotV1InstallPreservesFlatLayoutRaftMetadata(t *testing.T) {
 		t.Fatalf("WriteFile raft sentinel: %v", err)
 	}
 
-	if err := targetFSM.InstallRaftSnapshotV1(bytes.NewReader(snapshot.Payload)); err != nil {
-		t.Fatalf("InstallRaftSnapshotV1: %v", err)
-	}
+	installRaftSnapshotForTest(t, targetFSM, snapshot)
 	if err := targetFSM.VerifyInstalledSnapshotManifestV1(snapshot.Manifest); err != nil {
 		t.Fatalf("VerifyInstalledSnapshotManifestV1: %v", err)
 	}
@@ -526,9 +551,7 @@ func TestRaftSnapshotV1InstallDisabledSideStoresDoesNotTouchParentSideStores(t *
 		t.Fatalf("WriteFile parent side-store sentinel: %v", err)
 	}
 
-	if err := targetFSM.InstallRaftSnapshotV1(bytes.NewReader(snapshot.Payload)); err != nil {
-		t.Fatalf("InstallRaftSnapshotV1: %v", err)
-	}
+	installRaftSnapshotForTest(t, targetFSM, snapshot)
 	assertSnapshotDocument(t, targetFSM, "u-large", sourceDoc)
 	got, err := os.ReadFile(parentSideStoreSentinel)
 	if err != nil {
@@ -730,9 +753,7 @@ func BenchmarkRaftSnapshotV1ExportInstall(b *testing.B) {
 		if err != nil {
 			b.Fatalf("ExportRaftSnapshotV1: %v", err)
 		}
-		if err := targetFSM.InstallRaftSnapshotV1(bytes.NewReader(snapshot.Payload)); err != nil {
-			b.Fatalf("InstallRaftSnapshotV1: %v", err)
-		}
+		installRaftSnapshotForTest(b, targetFSM, snapshot)
 		b.StopTimer()
 		_ = targetFSM.Close()
 	}
@@ -824,6 +845,35 @@ func applySnapshotSourceEntries(tb testing.TB, fsm *FSM, doc []byte) {
 	}
 	assertSnapshotApplyResult(tb, results[0], raftentry.ApplyStatusApplied, 1)
 	assertSnapshotApplyResult(tb, results[1], raftentry.ApplyStatusApplied, 2)
+}
+
+func installRaftSnapshotForTest(tb testing.TB, fsm *FSM, snapshot raftcluster.RaftSnapshotV1) {
+	tb.Helper()
+	reader := openRaftSnapshotArchiveForTest(tb, snapshot)
+	defer func() { _ = reader.Close() }()
+	if err := fsm.InstallRaftSnapshotV1(reader); err != nil {
+		tb.Fatalf("InstallRaftSnapshotV1: %v", err)
+	}
+}
+
+func readRaftSnapshotArchiveForTest(tb testing.TB, snapshot raftcluster.RaftSnapshotV1) []byte {
+	tb.Helper()
+	reader := openRaftSnapshotArchiveForTest(tb, snapshot)
+	defer func() { _ = reader.Close() }()
+	payload, err := io.ReadAll(reader)
+	if err != nil {
+		tb.Fatalf("ReadAll snapshot archive: %v", err)
+	}
+	return payload
+}
+
+func openRaftSnapshotArchiveForTest(tb testing.TB, snapshot raftcluster.RaftSnapshotV1) io.ReadCloser {
+	tb.Helper()
+	reader, err := snapshot.OpenArchive()
+	if err != nil {
+		tb.Fatalf("OpenArchive: %v", err)
+	}
+	return reader
 }
 
 func rewriteRaftSnapshotArchiveHeaderForTest(t testing.TB, payload []byte, mut func(*raftcluster.RaftSnapshotArchiveHeaderV1)) []byte {

--- a/TreeDB/internal/raftfsm/raft_snapshot_test.go
+++ b/TreeDB/internal/raftfsm/raft_snapshot_test.go
@@ -837,6 +837,9 @@ func BenchmarkRaftSnapshotV1ExportInstall(b *testing.B) {
 		}
 		installRaftSnapshotForTest(b, targetFSM, snapshot)
 		b.StopTimer()
+		if err := snapshot.Release(); err != nil {
+			b.Fatalf("Release snapshot: %v", err)
+		}
 		_ = targetFSM.Close()
 	}
 }

--- a/TreeDB/internal/raftfsm/raft_snapshot_test.go
+++ b/TreeDB/internal/raftfsm/raft_snapshot_test.go
@@ -283,6 +283,40 @@ func TestRaftSnapshotV1OpenCleansAbandonedStagedArchives(t *testing.T) {
 	}
 }
 
+func TestRaftSnapshotV1OpenClassifiesStagedCleanupFailure(t *testing.T) {
+	root := t.TempDir()
+	sourceDir := filepath.Join(root, "source")
+	sourceDB := openRaftSnapshotFSMTestDB(t, sourceDir, false)
+	defer func() { _ = sourceDB.Close() }()
+
+	resolved, err := raftcluster.Validate(validFSMClusterConfig(sourceDir))
+	if err != nil {
+		t.Fatalf("Validate cluster config: %v", err)
+	}
+	if err := os.MkdirAll(resolved.Layout.SnapshotDir, 0o700); err != nil {
+		t.Fatalf("Mkdir snapshot dir: %v", err)
+	}
+	stagingPath := raftSnapshotStagingDirV1(resolved.Layout.SnapshotDir)
+	if err := os.WriteFile(stagingPath, []byte("not a staging directory"), 0o600); err != nil {
+		t.Fatalf("Write staging path file: %v", err)
+	}
+
+	fsm, openErr := Open(Options{
+		DB:      sourceDB,
+		Cluster: validFSMClusterConfig(sourceDir),
+		StoreOptions: raftapply.DurableApplyStoreOptions{
+			DisableSync: true,
+		},
+	})
+	if openErr == nil {
+		_ = fsm.Close()
+		t.Fatal("Open with invalid staged snapshot path succeeded, want unsafe durability error")
+	}
+	if code, ok := ErrorCodeOf(openErr); !ok || code != raftentry.ErrorUnsafeDurabilityModeV1 {
+		t.Fatalf("ErrorCodeOf(Open staged cleanup failure)=(%s,%t), want %s err=%v", code, ok, raftentry.ErrorUnsafeDurabilityModeV1, openErr)
+	}
+}
+
 func TestRaftSnapshotV1InstallReplacesStaleReplica(t *testing.T) {
 	root := t.TempDir()
 	sourceDir := filepath.Join(root, "source")


### PR DESCRIPTION
Refs #3454

## Summary

- Add file-backed `RaftSnapshotV1` archive sources so production HashiCorp snapshot persistence streams from a staged archive instead of writing an archive-wide `[]byte` to the sink.
- Stage production FSM snapshot archives under the resolved Raft snapshot directory and clean staged artifacts from `Release`.
- Keep byte-backed payload snapshots for small tests/fixtures while preserving restore's reader-based archive path.
- Add focused coverage for chunked sink writes, write-failure cancel-vs-close behavior, successful close behavior, release cleanup, file-backed manifest validation, staged production exports without payloads, delayed snapshot restore after tail apply, and a bounded allocation guard.

## Validation

- `GOWORK=off GOCACHE=/mnt/fast4tb/tmp/gomap-3454-gocache GOMODCACHE=/mnt/fast4tb/tmp/gomap-3454-gomodcache GOPATH=/mnt/fast4tb/tmp/gomap-3454-gopath TMPDIR=/mnt/fast4tb/tmp/gomap-3454-testtmp go test ./TreeDB/internal/raftcluster ./TreeDB/internal/raftfsm -run 'Snapshot|RaftSnapshot' -count=1`
  - `ok   github.com/snissn/gomap/TreeDB/internal/raftcluster 1.181s`
  - `ok   github.com/snissn/gomap/TreeDB/internal/raftfsm 1.684s`
- `GOWORK=off GOCACHE=/mnt/fast4tb/tmp/gomap-3454-gocache GOMODCACHE=/mnt/fast4tb/tmp/gomap-3454-gomodcache GOPATH=/mnt/fast4tb/tmp/gomap-3454-gopath TMPDIR=/mnt/fast4tb/tmp/gomap-3454-testtmp go test -race ./TreeDB/internal/raftcluster -run TestHashicorpRaftProviderSnapshotRejoinsLaggingFollowerAndCompactsLogs -count=1`
  - `ok   github.com/snissn/gomap/TreeDB/internal/raftcluster 1.784s`
- `GOWORK=off GOCACHE=/mnt/fast4tb/tmp/gomap-3454-gocache GOMODCACHE=/mnt/fast4tb/tmp/gomap-3454-gomodcache GOPATH=/mnt/fast4tb/tmp/gomap-3454-gopath TMPDIR=/mnt/fast4tb/tmp/gomap-3454-testtmp go test -v ./TreeDB/internal/raftcluster -run TestHashicorpRaftSnapshotPersistFileSourceAllocationGuard -count=1`
  - `streamed 4196864 byte archive with 112248 bytes allocated during Persist`
  - `PASS`
- `GOWORK=off GOCACHE=/mnt/fast4tb/tmp/gomap-3454-gocache GOMODCACHE=/mnt/fast4tb/tmp/gomap-3454-gomodcache GOPATH=/mnt/fast4tb/tmp/gomap-3454-gopath TMPDIR=/mnt/fast4tb/tmp/gomap-3454-testtmp go test ./TreeDB/internal/raftcluster ./TreeDB/internal/raftfsm -count=1`
  - `ok   github.com/snissn/gomap/TreeDB/internal/raftcluster 7.882s`
  - `ok   github.com/snissn/gomap/TreeDB/internal/raftfsm 2.109s`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Snapshot exports now stage to disk for more efficient handling of large snapshots.
  * Snapshot files can be opened from a staged archive and cleaned up after use.

* **Bug Fixes**
  * Improved snapshot validation to reject incomplete, mismatched, or ambiguous snapshot sources.
  * Added cleanup for abandoned snapshot files so startup ignores leftovers and removes stale staged archives.
  * Snapshot release now properly removes staged files and can be safely called multiple times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->