### PR TITLE
[codex] Add local ring route evidence matrix

### DIFF
--- a/cmd/mongo_gateway_bench/README.md
+++ b/cmd/mongo_gateway_bench/README.md
@@ -99,28 +99,49 @@ BSON-derived stored documents for direct collection inserts.
 
 ### Local Route Evidence Mode
 
-`-route-mode ring` is a TreeDB-only, official-driver smoke mode for deterministic
-local token-ring routing evidence. It does not enable network forwarding,
-fanout/splitting, cross-shard transactions, or production horizontal scaleout.
-The benchmark still performs local Mongo gateway `InsertOne` calls; before each
-single-document insert it runs route preflight against a bench-local token/ring
-catalog and records which logical group and token partition the explicit `_id`
-would route to. A single multi-token preflight probe is expected to fail with the
-existing fanout rejection so token/ring multi-ID writes remain rejected before
-submit.
+`-route-mode ring` is a TreeDB-only, official-driver evidence mode for
+deterministic local token-ring routing. It does not enable network forwarding,
+fanout/splitting, remote leader forwarding, scatter-gather reads,
+cross-shard transactions, global unique-index semantics, shard keys beyond
+explicit `_id`, or production horizontal scaleout. The benchmark still performs
+local Mongo gateway `InsertOne` calls; before each single-document insert it
+runs route preflight against a bench-local token/ring catalog and records which
+logical group, leader hint, and token partition the explicit `_id` would route
+to. N-group runs also issue a multi-token preflight probe that is expected to
+fail with the existing fanout rejection before submit.
+
+Use a 1-group/1-partition run as the local baseline:
 
 ```sh
 GOWORK=off go run ./cmd/mongo_gateway_bench \
   -target treedb \
   -route-mode ring \
-  -route-groups 2 \
-  -route-partitions 8 \
-  -documents 256 \
-  -reads 0 \
-  -range-reads 0 \
-  -updates 0 \
-  -deletes 0 \
+  -route-groups 1 \
+  -route-partitions 1 \
+  -documents 10000 \
+  -batch-size 100 \
+  -insert-producers 4 \
+  -reads 0 -range-reads 0 -updates 0 -deletes 0 \
   -secondary-indexes 0 \
+  -prebuild-documents \
+  -treedb-maintenance none \
+  -format json
+```
+
+Compare it with an N-group/N-partition local route run:
+
+```sh
+GOWORK=off go run ./cmd/mongo_gateway_bench \
+  -target treedb \
+  -route-mode ring \
+  -route-groups 4 \
+  -route-partitions 16 \
+  -documents 10000 \
+  -batch-size 100 \
+  -insert-producers 4 \
+  -reads 0 -range-reads 0 -updates 0 -deletes 0 \
+  -secondary-indexes 0 \
+  -prebuild-documents \
   -treedb-maintenance none \
   -format json
 ```
@@ -128,9 +149,10 @@ GOWORK=off go run ./cmd/mongo_gateway_bench \
 JSON output includes top-level `route_mode`, `route_group_count`, and
 `route_partition_count` fields. When ring mode is enabled, `route_evidence`
 contains `write_shape=single_document_insert`, `local_only=true`,
-`preflight_success`, `fanout_rejected`, `group_hits`, `partition_hits`, and the
-fanout rejection text. Treat those fields as local deterministic routing
-distribution evidence only, not as a cluster throughput or scaleout claim.
+`preflight_success`, `fanout_rejected`, `group_hits`, `leader_hits`,
+`partition_hits`, and any fanout rejection text. Treat those fields as local
+deterministic routing distribution evidence only, not as a cluster throughput or
+scaleout claim.
 
 Use `-insert-producers N` to split the insert load phase across producer
 goroutines. The effective producer count is capped at the number of insert

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -252,6 +252,7 @@ type routeEvidence struct {
 	PreflightSuccess     int            `json:"preflight_success"`
 	FanoutRejected       int            `json:"fanout_rejected"`
 	GroupHits            map[string]int `json:"group_hits,omitempty"`
+	LeaderHits           map[string]int `json:"leader_hits,omitempty"`
 	PartitionHits        map[string]int `json:"partition_hits,omitempty"`
 	UnsupportedFanoutErr string         `json:"unsupported_fanout_error,omitempty"`
 }
@@ -534,7 +535,7 @@ func parseConfig(args []string) (config, error) {
 	fs.StringVar(&cfg.MongoURI, "mongo-uri", "mongodb://127.0.0.1:27017", "MongoDB URI for -target mongo")
 	fs.BoolVar(&cfg.MongoCompact, "mongo-compact", false, "compact the MongoDB collection before final stats collection")
 	fs.StringVar(&cfg.RouteMode, "route-mode", cfg.RouteMode, "local route evidence mode: off or ring")
-	fs.IntVar(&cfg.RouteGroupCount, "route-groups", cfg.RouteGroupCount, "logical route group count for -route-mode ring; must be >= 2")
+	fs.IntVar(&cfg.RouteGroupCount, "route-groups", cfg.RouteGroupCount, "logical route group count for -route-mode ring; must be >= 1")
 	fs.IntVar(&cfg.RoutePartitionCount, "route-partitions", cfg.RoutePartitionCount, "token partition count for -route-mode ring; must be >= route-groups")
 	fs.StringVar(&cfg.TreeDBDir, "treedb-dir", "", "TreeDB directory for -target treedb; empty uses a temp dir")
 	fs.BoolVar(&cfg.KeepTreeDBDir, "keep-treedb-dir", false, "keep an auto-created TreeDB temp dir after the run")
@@ -664,8 +665,8 @@ func parseConfig(args []string) (config, error) {
 		if cfg.ClientMode != clientModeDriver {
 			return config{}, errors.New("route-mode ring is only supported with -client-mode driver")
 		}
-		if cfg.RouteGroupCount < 2 {
-			return config{}, errors.New("route-groups must be >= 2 for route-mode ring")
+		if cfg.RouteGroupCount < 1 {
+			return config{}, errors.New("route-groups must be >= 1 for route-mode ring")
 		}
 		if cfg.RoutePartitionCount < cfg.RouteGroupCount {
 			return config{}, errors.New("route-partitions must be >= route-groups for route-mode ring")
@@ -3660,6 +3661,7 @@ type benchmarkRingRouter struct {
 	fanoutRejected       int
 	unsupportedFanoutErr string
 	groupHits            map[string]int
+	leaderHits           map[string]int
 	partitionHits        map[string]int
 }
 
@@ -3668,6 +3670,7 @@ func newBenchmarkRingRouter(groupCount, partitionCount int) *benchmarkRingRouter
 		groupCount:     groupCount,
 		partitionCount: partitionCount,
 		groupHits:      make(map[string]int, groupCount),
+		leaderHits:     make(map[string]int, groupCount),
 		partitionHits:  make(map[string]int, partitionCount),
 	}
 }
@@ -3788,6 +3791,7 @@ func (r *benchmarkRingRouter) recordPreflightSuccess(target nativewire.ClusterRo
 	defer r.mu.Unlock()
 	r.preflightSuccess++
 	r.groupHits[target.GroupID]++
+	r.leaderHits[target.LeaderHint]++
 	r.partitionHits[target.PartitionID]++
 }
 
@@ -3795,9 +3799,9 @@ func (r *benchmarkRingRouter) probeFanoutRejection(ctx context.Context, cfg conf
 	if r == nil {
 		return errors.New("missing benchmark ring router")
 	}
-	tokens := []uint64{
-		benchmarkRingPartitionMidpointToken(0, r.partitionCount),
-		benchmarkRingPartitionMidpointToken(1, r.partitionCount),
+	tokens, ok := r.fanoutProbeTokens()
+	if !ok {
+		return nil
 	}
 	_, _, err := nativewire.PreflightClusterRoute(ctx, r, nativewire.ClusterRouteRequest{
 		Database:    cfg.Database,
@@ -3815,6 +3819,24 @@ func (r *benchmarkRingRouter) probeFanoutRejection(ctx context.Context, cfg conf
 	r.unsupportedFanoutErr = err.Error()
 	r.mu.Unlock()
 	return nil
+}
+
+func (r *benchmarkRingRouter) fanoutProbeTokens() ([]uint64, bool) {
+	if r == nil || r.groupCount < 2 || r.partitionCount < 2 {
+		return nil, false
+	}
+	firstPartition := 0
+	firstGroup := r.groupForPartition(firstPartition)
+	for partition := 1; partition < r.partitionCount; partition++ {
+		if r.groupForPartition(partition) == firstGroup {
+			continue
+		}
+		return []uint64{
+			benchmarkRingPartitionMidpointToken(firstPartition, r.partitionCount),
+			benchmarkRingPartitionMidpointToken(partition, r.partitionCount),
+		}, true
+	}
+	return nil, false
 }
 
 func (r *benchmarkRingRouter) evidence(writes int) *routeEvidence {
@@ -3835,6 +3857,7 @@ func (r *benchmarkRingRouter) evidence(writes int) *routeEvidence {
 		PreflightSuccess:     r.preflightSuccess,
 		FanoutRejected:       r.fanoutRejected,
 		GroupHits:            cloneStringIntMap(r.groupHits),
+		LeaderHits:           cloneStringIntMap(r.leaderHits),
 		PartitionHits:        cloneStringIntMap(r.partitionHits),
 		UnsupportedFanoutErr: r.unsupportedFanoutErr,
 	}
@@ -6971,11 +6994,11 @@ func writeResult(out io.Writer, format string, result *benchmarkResult) error {
 		}
 		fmt.Fprintln(out)
 		if result.RouteEvidence != nil {
-			fmt.Fprintf(out, "route_evidence mode=%s placement=%s route_key=%s write_shape=%s local_only=%t writes=%d preflight_success=%d fanout_rejected=%d group_hits=%v partition_hits=%v\n",
+			fmt.Fprintf(out, "route_evidence mode=%s placement=%s route_key=%s write_shape=%s local_only=%t writes=%d preflight_success=%d fanout_rejected=%d group_hits=%v leader_hits=%v partition_hits=%v\n",
 				result.RouteEvidence.Mode, result.RouteEvidence.PlacementMode, result.RouteEvidence.RouteKey,
 				result.RouteEvidence.WriteShape, result.RouteEvidence.LocalOnly, result.RouteEvidence.Writes,
 				result.RouteEvidence.PreflightSuccess, result.RouteEvidence.FanoutRejected,
-				result.RouteEvidence.GroupHits, result.RouteEvidence.PartitionHits)
+				result.RouteEvidence.GroupHits, result.RouteEvidence.LeaderHits, result.RouteEvidence.PartitionHits)
 			if result.RouteEvidence.UnsupportedFanoutErr != "" {
 				fmt.Fprintf(out, "route_fanout_rejection=%q\n", result.RouteEvidence.UnsupportedFanoutErr)
 			}

--- a/cmd/mongo_gateway_bench/main_test.go
+++ b/cmd/mongo_gateway_bench/main_test.go
@@ -1060,6 +1060,23 @@ func TestParseConfigRouteModeRing(t *testing.T) {
 	if cfg.RouteMode != routeModeRing || cfg.RouteGroupCount != 3 || cfg.RoutePartitionCount != 9 {
 		t.Fatalf("unexpected route config: %+v", cfg)
 	}
+	oneGroupCfg, err := parseConfig([]string{
+		"-route-mode", "ring",
+		"-route-groups", "1",
+		"-route-partitions", "1",
+		"-documents", "12",
+		"-reads", "0",
+		"-range-reads", "0",
+		"-updates", "0",
+		"-secondary-indexes", "0",
+		"-treedb-maintenance", treeDBMaintenanceNone,
+	})
+	if err != nil {
+		t.Fatalf("parse 1-group/1-partition route-mode ring config: %v", err)
+	}
+	if oneGroupCfg.RouteMode != routeModeRing || oneGroupCfg.RouteGroupCount != 1 || oneGroupCfg.RoutePartitionCount != 1 {
+		t.Fatalf("unexpected 1-group route config: %+v", oneGroupCfg)
+	}
 
 	tests := []struct {
 		name string
@@ -1083,8 +1100,8 @@ func TestParseConfigRouteModeRing(t *testing.T) {
 		},
 		{
 			name: "too few groups",
-			args: []string{"-target", "treedb", "-route-mode", "ring", "-route-groups", "1"},
-			want: "route-groups must be >= 2",
+			args: []string{"-target", "treedb", "-route-mode", "ring", "-route-groups", "0"},
+			want: "route-groups must be >= 1",
 		},
 		{
 			name: "too few partitions",
@@ -1134,6 +1151,13 @@ func TestBenchmarkRingRouterPreflightDistributionAndFanout(t *testing.T) {
 		if got, want := target.GroupID, benchmarkRingGroupID(partition%2); got != want {
 			t.Fatalf("group id=%q want %q", got, want)
 		}
+		wantLeader := map[int]string{
+			0: "node-00-a",
+			1: "node-01-a",
+		}[partition%2]
+		if got := target.LeaderHint; got != wantLeader {
+			t.Fatalf("leader hint=%q want %q", got, wantLeader)
+		}
 		router.recordPreflightSuccess(target)
 	}
 
@@ -1164,6 +1188,13 @@ func TestBenchmarkRingRouterPreflightDistributionAndFanout(t *testing.T) {
 	if !reflect.DeepEqual(evidence.GroupHits, wantGroupHits) {
 		t.Fatalf("group hits=%v want %v", evidence.GroupHits, wantGroupHits)
 	}
+	wantLeaderHits := map[string]int{"node-00-a": 2, "node-01-a": 2}
+	if !reflect.DeepEqual(evidence.LeaderHits, wantLeaderHits) {
+		t.Fatalf("leader hits=%v want %v", evidence.LeaderHits, wantLeaderHits)
+	}
+	if got := sumStringIntValues(evidence.LeaderHits); got != evidence.PreflightSuccess {
+		t.Fatalf("leader hit total=%d want preflight_success=%d hits=%v", got, evidence.PreflightSuccess, evidence.LeaderHits)
+	}
 	wantPartitionHits := map[string]int{
 		"token-000000": 1,
 		"token-000001": 1,
@@ -1176,6 +1207,24 @@ func TestBenchmarkRingRouterPreflightDistributionAndFanout(t *testing.T) {
 	if !strings.Contains(evidence.UnsupportedFanoutErr, "requires fanout before submit") {
 		t.Fatalf("fanout rejection=%q want fanout rejection", evidence.UnsupportedFanoutErr)
 	}
+}
+
+func sumStringIntValues(values map[string]int) int {
+	var total int
+	for _, value := range values {
+		total += value
+	}
+	return total
+}
+
+func positiveStringIntCount(values map[string]int) int {
+	var total int
+	for _, value := range values {
+		if value > 0 {
+			total++
+		}
+	}
+	return total
 }
 
 func TestConcurrentUpdateOperationVariesByWriterSweepCell(t *testing.T) {
@@ -1934,73 +1983,126 @@ func TestTreeDBRoutedRingModeSmoke(t *testing.T) {
 	if testing.Short() {
 		t.Skip("routed ring mode smoke skipped in short mode")
 	}
-	cfg, err := parseConfig([]string{
-		"-target", "treedb",
-		"-route-mode", "ring",
-		"-route-groups", "2",
-		"-route-partitions", "4",
-		"-documents", "64",
-		"-batch-size", "16",
-		"-insert-producers", "2",
-		"-reads", "0",
-		"-range-reads", "0",
-		"-updates", "0",
-		"-deletes", "0",
-		"-secondary-indexes", "0",
-		"-treedb-maintenance", treeDBMaintenanceNone,
-		"-prebuild-documents",
-		"-timeout", "0",
-		"-format", "json",
-	})
-	if err != nil {
-		t.Fatalf("parse routed ring smoke config: %v", err)
+	tests := []struct {
+		name              string
+		groups            int
+		partitions        int
+		documents         int
+		wantSingleRoute   bool
+		wantFanoutReject  bool
+		wantMultipleRoute bool
+	}{
+		{
+			name:            "one_group_one_partition",
+			groups:          1,
+			partitions:      1,
+			documents:       32,
+			wantSingleRoute: true,
+		},
+		{
+			name:              "n_group",
+			groups:            4,
+			partitions:        16,
+			documents:         128,
+			wantFanoutReject:  true,
+			wantMultipleRoute: true,
+		},
 	}
-	target, err := openTarget(context.Background(), cfg)
-	if err != nil {
-		t.Fatalf("open target: %v", err)
-	}
-	defer func() {
-		cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer cancel()
-		if err := closeBenchTarget(cleanupCtx, target); err != nil {
-			t.Errorf("cleanup target: %v", err)
-		}
-	}()
-	result, err := runBenchmark(context.Background(), cfg, target, nil)
-	if err != nil {
-		t.Fatalf("run routed ring benchmark: %v", err)
-	}
-	if result.RouteMode != routeModeRing || result.RouteGroupCount != 2 || result.RoutePartitionCount != 4 {
-		t.Fatalf("unexpected route result config: %+v", result)
-	}
-	if result.RouteEvidence == nil {
-		t.Fatalf("route evidence missing: %+v", result)
-	}
-	evidence := result.RouteEvidence
-	if evidence.PreflightSuccess != cfg.Documents || evidence.Writes != cfg.Documents || evidence.FanoutRejected != 1 {
-		t.Fatalf("unexpected route evidence: %+v", evidence)
-	}
-	if evidence.WriteShape != "single_document_insert" || !evidence.LocalOnly {
-		t.Fatalf("unexpected route evidence shape/boundary: %+v", evidence)
-	}
-	if got := evidence.GroupHits["group-00"] + evidence.GroupHits["group-01"]; got != cfg.Documents {
-		t.Fatalf("group hit total=%d want %d hits=%v", got, cfg.Documents, evidence.GroupHits)
-	}
-	if evidence.GroupHits["group-00"] == 0 || evidence.GroupHits["group-01"] == 0 {
-		t.Fatalf("route smoke did not hit both groups: %+v", evidence)
-	}
-	if !strings.Contains(evidence.UnsupportedFanoutErr, "requires fanout before submit") {
-		t.Fatalf("fanout rejection=%q want fanout rejection", evidence.UnsupportedFanoutErr)
-	}
-	for _, phase := range result.Phases {
-		if phase.Name == "load_insert_one_routed_ring" {
-			if phase.OpsPerSecond <= 0 || phase.SampledNsPerOp <= 0 {
-				t.Fatalf("routed load phase metrics missing: %+v", phase)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, err := parseConfig([]string{
+				"-target", "treedb",
+				"-route-mode", "ring",
+				"-route-groups", strconv.Itoa(tt.groups),
+				"-route-partitions", strconv.Itoa(tt.partitions),
+				"-documents", strconv.Itoa(tt.documents),
+				"-batch-size", "16",
+				"-insert-producers", "2",
+				"-reads", "0",
+				"-range-reads", "0",
+				"-updates", "0",
+				"-deletes", "0",
+				"-secondary-indexes", "0",
+				"-treedb-maintenance", treeDBMaintenanceNone,
+				"-prebuild-documents",
+				"-timeout", "0",
+				"-format", "json",
+			})
+			if err != nil {
+				t.Fatalf("parse routed ring smoke config: %v", err)
 			}
-			return
-		}
+			target, err := openTarget(context.Background(), cfg)
+			if err != nil {
+				t.Fatalf("open target: %v", err)
+			}
+			defer func() {
+				cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+				defer cancel()
+				if err := closeBenchTarget(cleanupCtx, target); err != nil {
+					t.Errorf("cleanup target: %v", err)
+				}
+			}()
+			result, err := runBenchmark(context.Background(), cfg, target, nil)
+			if err != nil {
+				t.Fatalf("run routed ring benchmark: %v", err)
+			}
+			if result.RouteMode != routeModeRing || result.RouteGroupCount != tt.groups || result.RoutePartitionCount != tt.partitions {
+				t.Fatalf("unexpected route result config: %+v", result)
+			}
+			if result.RouteEvidence == nil {
+				t.Fatalf("route evidence missing: %+v", result)
+			}
+			evidence := result.RouteEvidence
+			if evidence.PreflightSuccess != cfg.Documents || evidence.Writes != cfg.Documents {
+				t.Fatalf("unexpected route evidence counters: %+v", evidence)
+			}
+			if evidence.WriteShape != "single_document_insert" || !evidence.LocalOnly {
+				t.Fatalf("unexpected route evidence shape/boundary: %+v", evidence)
+			}
+			if got := sumStringIntValues(evidence.GroupHits); got != evidence.PreflightSuccess {
+				t.Fatalf("group hit total=%d want preflight_success=%d hits=%v", got, evidence.PreflightSuccess, evidence.GroupHits)
+			}
+			if got := sumStringIntValues(evidence.LeaderHits); got != evidence.PreflightSuccess {
+				t.Fatalf("leader hit total=%d want preflight_success=%d hits=%v", got, evidence.PreflightSuccess, evidence.LeaderHits)
+			}
+			if got := sumStringIntValues(evidence.PartitionHits); got != evidence.PreflightSuccess {
+				t.Fatalf("partition hit total=%d want preflight_success=%d hits=%v", got, evidence.PreflightSuccess, evidence.PartitionHits)
+			}
+			if tt.wantSingleRoute {
+				if len(evidence.GroupHits) != 1 || evidence.GroupHits["group-00"] != cfg.Documents {
+					t.Fatalf("1-group run group hits=%v want only group-00=%d", evidence.GroupHits, cfg.Documents)
+				}
+				if len(evidence.LeaderHits) != 1 || evidence.LeaderHits["node-00-a"] != cfg.Documents {
+					t.Fatalf("1-group run leader hits=%v want only node-00-a=%d", evidence.LeaderHits, cfg.Documents)
+				}
+				if len(evidence.PartitionHits) != 1 || evidence.PartitionHits["token-000000"] != cfg.Documents {
+					t.Fatalf("1-group run partition hits=%v want only token-000000=%d", evidence.PartitionHits, cfg.Documents)
+				}
+			}
+			if tt.wantMultipleRoute {
+				if positiveStringIntCount(evidence.GroupHits) < 2 || positiveStringIntCount(evidence.LeaderHits) < 2 || positiveStringIntCount(evidence.PartitionHits) < 2 {
+					t.Fatalf("N-group route smoke did not hit multiple groups/leaders/partitions: %+v", evidence)
+				}
+			}
+			if tt.wantFanoutReject {
+				if evidence.FanoutRejected != 1 {
+					t.Fatalf("fanout rejected=%d want 1 evidence=%+v", evidence.FanoutRejected, evidence)
+				}
+				if !strings.Contains(evidence.UnsupportedFanoutErr, "requires fanout before submit") {
+					t.Fatalf("fanout rejection=%q want fanout rejection", evidence.UnsupportedFanoutErr)
+				}
+			}
+			for _, phase := range result.Phases {
+				if phase.Name == "load_insert_one_routed_ring" {
+					if phase.OpsPerSecond <= 0 || phase.SampledNsPerOp <= 0 {
+						t.Fatalf("routed load phase metrics missing: %+v", phase)
+					}
+					return
+				}
+			}
+			t.Fatalf("load_insert_one_routed_ring phase missing: %+v", result.Phases)
+		})
 	}
-	t.Fatalf("load_insert_one_routed_ring phase missing: %+v", result.Phases)
 }
 
 func TestTreeDBClientModeSmoke(t *testing.T) {

--- a/cmd/mongo_gateway_bench/main_test.go
+++ b/cmd/mongo_gateway_bench/main_test.go
@@ -2078,6 +2078,9 @@ func TestTreeDBRoutedRingModeSmoke(t *testing.T) {
 				if len(evidence.PartitionHits) != 1 || evidence.PartitionHits["token-000000"] != cfg.Documents {
 					t.Fatalf("1-group run partition hits=%v want only token-000000=%d", evidence.PartitionHits, cfg.Documents)
 				}
+				if evidence.FanoutRejected != 0 || evidence.UnsupportedFanoutErr != "" {
+					t.Fatalf("1-group run fanout rejected=%d err=%q, want no fanout probe", evidence.FanoutRejected, evidence.UnsupportedFanoutErr)
+				}
 			}
 			if tt.wantMultipleRoute {
 				if positiveStringIntCount(evidence.GroupHits) < 2 || positiveStringIntCount(evidence.LeaderHits) < 2 || positiveStringIntCount(evidence.PartitionHits) < 2 {
@@ -3122,6 +3125,20 @@ func TestWriteResultIncludesTreeDBBufferedIndexedThresholds(t *testing.T) {
 		TreeDBBufferedIndexedAsyncFlush:        true,
 		TreeDBBufferedIndexedAsyncFlushMaxQueuedUnits: 3,
 		TreeDBMaintenanceMode:                         "none",
+		RouteEvidence: &routeEvidence{
+			Mode:             routeModeRing,
+			PlacementMode:    "ring",
+			RouteKey:         "_id",
+			WriteShape:       "single_document_insert",
+			LocalOnly:        true,
+			GroupCount:       1,
+			PartitionCount:   1,
+			Writes:           1,
+			PreflightSuccess: 1,
+			GroupHits:        map[string]int{"group-00": 1},
+			LeaderHits:       map[string]int{"node-00-a": 1},
+			PartitionHits:    map[string]int{"token-000000": 1},
+		},
 	}
 	var out bytes.Buffer
 	if err := writeResult(&out, "text", result); err != nil {
@@ -3135,6 +3152,7 @@ func TestWriteResultIncludesTreeDBBufferedIndexedThresholds(t *testing.T) {
 		"buffered_indexed_max_root_runs=90",
 		"buffered_indexed_async_flush=true",
 		"buffered_indexed_async_max_queued_units=3",
+		"leader_hits=map[node-00-a:1]",
 	} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("text output missing %s: %q", want, text)
@@ -3166,7 +3184,9 @@ func TestWriteResultIncludesTreeDBBufferedIndexedThresholds(t *testing.T) {
 		decoded.TreeDBBufferedIndexedWriteMaxRootRuns != 90 ||
 		!decoded.TreeDBCommandWAL ||
 		!decoded.TreeDBBufferedIndexedAsyncFlush ||
-		decoded.TreeDBBufferedIndexedAsyncFlushMaxQueuedUnits != 3 {
+		decoded.TreeDBBufferedIndexedAsyncFlushMaxQueuedUnits != 3 ||
+		decoded.RouteEvidence == nil ||
+		!reflect.DeepEqual(decoded.RouteEvidence.LeaderHits, map[string]int{"node-00-a": 1}) {
 		t.Fatalf("json thresholds docs=%d bytes=%d rootRuns=%d commandWAL=%t async=%t asyncMax=%d want 1234/5678/90/true/true/3",
 			decoded.TreeDBBufferedIndexedWriteMaxDocuments,
 			decoded.TreeDBBufferedIndexedWriteMaxBytes,
@@ -3174,6 +3194,21 @@ func TestWriteResultIncludesTreeDBBufferedIndexedThresholds(t *testing.T) {
 			decoded.TreeDBCommandWAL,
 			decoded.TreeDBBufferedIndexedAsyncFlush,
 			decoded.TreeDBBufferedIndexedAsyncFlushMaxQueuedUnits)
+	}
+	var decodedWithRoute map[string]any
+	if err := json.Unmarshal(out.Bytes(), &decodedWithRoute); err != nil {
+		t.Fatalf("unmarshal json result map: %v", err)
+	}
+	routeJSON, ok := decodedWithRoute["route_evidence"].(map[string]any)
+	if !ok {
+		t.Fatalf("json route_evidence missing or wrong type: %#v", decodedWithRoute["route_evidence"])
+	}
+	leaderHitsJSON, ok := routeJSON["leader_hits"].(map[string]any)
+	if !ok {
+		t.Fatalf("json route_evidence leader_hits missing or wrong type: %#v", routeJSON["leader_hits"])
+	}
+	if got := leaderHitsJSON["node-00-a"]; got != float64(1) {
+		t.Fatalf("json route_evidence leader_hits node-00-a=%v want 1", got)
 	}
 
 	result.TreeDBCommandWAL = false


### PR DESCRIPTION
Fixes #3457.
Refs #3445.

## Summary

- Allows `cmd/mongo_gateway_bench -route-mode ring` to accept a 1-group/1-partition local baseline while keeping invalid `-route-groups 0` rejected.
- Adds `leader_hits` to ring route evidence next to `group_hits` and `partition_hits`.
- Keeps route evidence explicitly `local_only=true` and preserves the N-group fanout-required fail-closed probe.
- Updates the benchmark README with local-only 1g/1p and 4g/16p commands and the non-production boundary.

## Local-only boundary

This PR records deterministic in-process route preflight evidence only. It does not implement production horizontal scaleout, remote leader forwarding, real multi-group submit routing, command split/fanout execution, routed reads/read-index or bounded scatter, global unique-index semantics, or shard keys beyond explicit `_id`.

## Evidence

Head SHA: `5c4299f705f2925764a6fd9f39357ae1448d878e`

Artifacts:

- `/mnt/fast4tb/tmp/gomap-3457-ring-evidence-5c4299f7/ring-1g-1p.json`
- `/mnt/fast4tb/tmp/gomap-3457-ring-evidence-5c4299f7/ring-4g-16p.json`

1-group/1-partition local baseline:

- `local_only=true`
- `writes=10000`, `preflight_success=10000`
- `group_hits={"group-00":10000}`
- `leader_hits={"node-00-a":10000}`
- `partition_hits={"token-000000":10000}`
- `fanout_rejected=0` because this single-partition baseline has no cross-group fanout class to probe.

4-group/16-partition local candidate:

- `local_only=true`
- `writes=10000`, `preflight_success=10000`
- `group_hits={"group-00":2489,"group-01":2516,"group-02":2479,"group-03":2516}`
- `leader_hits={"node-00-a":2489,"node-01-a":2516,"node-02-a":2479,"node-03-a":2516}`
- `partition_hits` covers all `token-000000` through `token-000015`
- `fanout_rejected=1`
- `unsupported_fanout_error="nativewire: error code 13: cluster token/ring multi-id write requires fanout before submit: route_class=fanout_required token_count=2"`

Evidence commands:

```sh
TMPDIR=/mnt/fast4tb/tmp/gomap-test-tmp GOCACHE=/mnt/fast4tb/tmp/go-cache GOMODCACHE=/mnt/fast4tb/tmp/go-mod-cache GOPATH=/mnt/fast4tb/tmp/go-path GOWORK=off GOMEMLIMIT=4GiB GOMAXPROCS=2 go run ./cmd/mongo_gateway_bench -target treedb -route-mode ring -route-groups 1 -route-partitions 1 -documents 10000 -batch-size 100 -insert-producers 4 -reads 0 -range-reads 0 -updates 0 -deletes 0 -secondary-indexes 0 -treedb-dir /mnt/fast4tb/tmp/gomap-3457-ring-evidence-5c4299f7/treedb-1g -treedb-maintenance none -prebuild-documents -timeout 60s -format json | tee /mnt/fast4tb/tmp/gomap-3457-ring-evidence-5c4299f7/ring-1g-1p.json

TMPDIR=/mnt/fast4tb/tmp/gomap-test-tmp GOCACHE=/mnt/fast4tb/tmp/go-cache GOMODCACHE=/mnt/fast4tb/tmp/go-mod-cache GOPATH=/mnt/fast4tb/tmp/go-path GOWORK=off GOMEMLIMIT=4GiB GOMAXPROCS=2 go run ./cmd/mongo_gateway_bench -target treedb -route-mode ring -route-groups 4 -route-partitions 16 -documents 10000 -batch-size 100 -insert-producers 4 -reads 0 -range-reads 0 -updates 0 -deletes 0 -secondary-indexes 0 -treedb-dir /mnt/fast4tb/tmp/gomap-3457-ring-evidence-5c4299f7/treedb-4g -treedb-maintenance none -prebuild-documents -timeout 60s -format json | tee /mnt/fast4tb/tmp/gomap-3457-ring-evidence-5c4299f7/ring-4g-16p.json >/dev/null
```

## Validation

```sh
TMPDIR=/mnt/fast4tb/tmp/gomap-test-tmp GOCACHE=/mnt/fast4tb/tmp/go-cache GOMODCACHE=/mnt/fast4tb/tmp/go-mod-cache GOPATH=/mnt/fast4tb/tmp/go-path GOWORK=off GOMEMLIMIT=4GiB GOMAXPROCS=2 go test -p 1 ./cmd/mongo_gateway_bench -count=1
# ok github.com/snissn/gomap/cmd/mongo_gateway_bench 1.797s

TMPDIR=/mnt/fast4tb/tmp/gomap-test-tmp GOCACHE=/mnt/fast4tb/tmp/go-cache GOMODCACHE=/mnt/fast4tb/tmp/go-mod-cache GOPATH=/mnt/fast4tb/tmp/go-path GOWORK=off GOMEMLIMIT=4GiB GOMAXPROCS=2 go test -p 1 ./TreeDB/internal/raftplacement ./TreeDB/internal/raftcluster ./TreeDB/nativewire ./TreeDB/mongo_gateway ./cmd/mongo_gateway_bench -count=1
# ok github.com/snissn/gomap/TreeDB/internal/raftplacement 0.005s
# ok github.com/snissn/gomap/TreeDB/internal/raftcluster 8.754s
# ok github.com/snissn/gomap/TreeDB/nativewire 3.132s
# ok github.com/snissn/gomap/TreeDB/mongo_gateway 9.524s
# ok github.com/snissn/gomap/cmd/mongo_gateway_bench 1.421s

git diff --check origin/main...HEAD
# pass
```
