### PR TITLE
TreeDB Raft: lock M0A fail-closed route contracts

### DIFF
--- a/TreeDB/internal/raftcluster/dispatcher_test.go
+++ b/TreeDB/internal/raftcluster/dispatcher_test.go
@@ -219,6 +219,31 @@ func TestGroupRoutedSubmitterRejectsUnsupportedRoutesBeforeSubmit(t *testing.T) 
 	}
 }
 
+func TestGroupRoutedSubmitterRejectsUnknownRemoteOwnerWithStableHintBeforeSubmit(t *testing.T) {
+	groupA := &recordingGroupSubmitter{groupID: "group-a"}
+	groupB := &recordingGroupSubmitter{groupID: "group-b"}
+	dispatcher := newTestGroupRoutedSubmitter(t, groupA, groupB)
+
+	meta := routeMetadata("group-z", iwire.AckRaftCommitted)
+	meta.ClusterRouteLeaderHint = "node-z"
+	_, err := dispatcher.SubmitCommandEntryV1(context.Background(), testClusterCommandEntry(t, 7), meta)
+	if !errors.Is(err, ErrRouteTargetUnknown) {
+		t.Fatalf("SubmitCommandEntryV1 err=%v want route target unknown", err)
+	}
+	if !strings.Contains(err.Error(), `route group "group-z" is not configured locally`) {
+		t.Fatalf("SubmitCommandEntryV1 err=%q want stable unknown-owner text", err)
+	}
+	if !strings.Contains(err.Error(), "leader_hint=node-z") {
+		t.Fatalf("SubmitCommandEntryV1 err=%q want leader hint", err)
+	}
+	if calls := groupA.snapshot(); len(calls) != 0 {
+		t.Fatalf("group-a calls=%d want 0", len(calls))
+	}
+	if calls := groupB.snapshot(); len(calls) != 0 {
+		t.Fatalf("group-b calls=%d want 0", len(calls))
+	}
+}
+
 func TestGroupSubmitterRegistryRejectsMismatchedConfiguredGroup(t *testing.T) {
 	_, err := NewGroupSubmitterRegistryV1([]GroupSubmitterV1{
 		{GroupID: "group-a", Submitter: &recordingGroupSubmitter{groupID: "group-b"}},

--- a/TreeDB/internal/raftplacement/route_test.go
+++ b/TreeDB/internal/raftplacement/route_test.go
@@ -310,6 +310,14 @@ func TestRouteFailsClosed(t *testing.T) {
 			want: ErrUnsupportedRouteShape,
 		},
 		{
+			name: "query shape unsupported for token placement",
+			req: RouteRequestV1{
+				Collection: ref,
+				Shape:      RouteShapeQueryV1,
+			},
+			want: ErrUnsupportedRouteShape,
+		},
+		{
 			name: "scatter gather unsupported",
 			req: RouteRequestV1{
 				Collection: CollectionRefV1{Database: DefaultDatabase, Catalog: DefaultCatalog, Collection: "users"},

--- a/TreeDB/mongo_gateway/cluster_submitter_test.go
+++ b/TreeDB/mongo_gateway/cluster_submitter_test.go
@@ -807,6 +807,8 @@ func TestClusterRoutePreflightMongoRejectsBeforeSubmitter(t *testing.T) {
 	})
 	assertCommandError(t, response, "NotWritablePrimary")
 	assertErrmsgContains(t, response, "token placement requires explicit token")
+	assertBool(t, response, "treedbClusterError", true)
+	assertStringField(t, response, "treedbErrorClass", "route_rejected")
 	if routes := submitter.snapshotRoutes(); len(routes) != 1 {
 		t.Fatalf("route calls=%d want 1", len(routes))
 	}
@@ -976,6 +978,9 @@ func TestClusterRoutePreflightMongoTokenPlacementRejectsMultiIDWrites(t *testing
 			response := tc.run(t, server)
 			assertCommandError(t, response, "NotWritablePrimary")
 			assertErrmsgContains(t, response, "requires command split before submit")
+			assertErrmsgContains(t, response, "route_class=same_partition")
+			assertBool(t, response, "treedbClusterError", true)
+			assertStringField(t, response, "treedbErrorClass", "route_rejected")
 			routes := submitter.snapshotRoutes()
 			if len(routes) != 1 {
 				t.Fatalf("route calls=%d want 1", len(routes))
@@ -999,6 +1004,8 @@ func TestClusterRoutePreflightMongoRejectsUnsupportedFindRoute(t *testing.T) {
 	})
 	assertCommandError(t, response, "NotWritablePrimary")
 	assertErrmsgContains(t, response, "query route shape is not supported")
+	assertBool(t, response, "treedbClusterError", true)
+	assertStringField(t, response, "treedbErrorClass", "route_rejected")
 	if routes := submitter.snapshotRoutes(); len(routes) != 0 {
 		t.Fatalf("route calls=%d want 0 before unsupported query provider call", len(routes))
 	}
@@ -1051,6 +1058,8 @@ func TestClusterRoutePreflightMongoRejectsNonShardKeyWrites(t *testing.T) {
 			response := tc.run(t, server)
 			assertCommandError(t, response, "NotWritablePrimary")
 			assertErrmsgContains(t, response, "query route shape is not supported")
+			assertBool(t, response, "treedbClusterError", true)
+			assertStringField(t, response, "treedbErrorClass", "route_rejected")
 			if routes := submitter.snapshotRoutes(); len(routes) != 0 {
 				t.Fatalf("route calls=%d want 0 before unsupported query provider call", len(routes))
 			}
@@ -1212,6 +1221,20 @@ func TestMongoGroupRoutedDispatcherRejectsUnknownGroupBeforeSubmit(t *testing.T)
 	})
 	assertCommandError(t, response, "NotWritablePrimary")
 	assertErrmsgContains(t, response, "route target unknown")
+	assertBool(t, response, "treedbClusterError", true)
+	assertStringField(t, response, "treedbErrorClass", "route_rejected")
+	assertStringField(t, response, "treedbLeaderHint", "node-z")
+	users, err := server.Collections.OpenCollection("app.users")
+	if err != nil {
+		t.Fatalf("OpenCollection app.users: %v", err)
+	}
+	key, err := encodePrimaryKey(mustRawValue(t, "u1"))
+	if err != nil {
+		t.Fatalf("encode primary key: %v", err)
+	}
+	if got, err := users.Get(key); err != nil || got != nil {
+		t.Fatalf("local app.users Get(u1)=%v err=%v want missing document", bson.Raw(got), err)
+	}
 	if calls := groupA.snapshotCalls(); len(calls) != 0 {
 		t.Fatalf("group-a calls=%d want 0", len(calls))
 	}

--- a/TreeDB/nativewire/cluster_submitter_test.go
+++ b/TreeDB/nativewire/cluster_submitter_test.go
@@ -764,32 +764,77 @@ func TestClusterRoutePreflightRejectsMissingPlacementMode(t *testing.T) {
 	}
 }
 
-func TestClusterRoutePreflightRejectsFanoutTokenBatch(t *testing.T) {
-	submitter := &routingClusterSubmitter{
-		fakeClusterSubmitter: &fakeClusterSubmitter{},
-		target: ClusterRouteTarget{
-			PlacementMode:   string(raftplacement.PlacementModeRingV1),
-			Shape:           ClusterRouteShapeTokenBatch,
-			TokenBatchClass: string(raftplacement.TokenBatchRouteFanoutRequiredV1),
+func TestClusterRoutePreflightRejectsTokenBatchClassesBeforeSubmit(t *testing.T) {
+	tests := []struct {
+		name      string
+		class     raftplacement.TokenBatchRouteClassV1
+		target    ClusterRouteTarget
+		wantText  string
+		wantClass string
+	}{
+		{
+			name:  "same_partition_requires_command_split",
+			class: raftplacement.TokenBatchRouteSamePartitionV1,
+			target: ClusterRouteTarget{
+				GroupID:         "group-a",
+				LeaderHint:      "node-a",
+				PlacementMode:   string(raftplacement.PlacementModeRingV1),
+				Shape:           ClusterRouteShapeTokenBatch,
+				TokenBatchClass: string(raftplacement.TokenBatchRouteSamePartitionV1),
+			},
+			wantText:  "requires command split before submit",
+			wantClass: "route_class=same_partition",
+		},
+		{
+			name:  "same_group_multi_partition_requires_command_split",
+			class: raftplacement.TokenBatchRouteSameGroupV1,
+			target: ClusterRouteTarget{
+				GroupID:         "group-a",
+				LeaderHint:      "node-a",
+				PlacementMode:   string(raftplacement.PlacementModeRingV1),
+				Shape:           ClusterRouteShapeTokenBatch,
+				TokenBatchClass: string(raftplacement.TokenBatchRouteSameGroupV1),
+			},
+			wantText:  "requires command split before submit",
+			wantClass: "route_class=same_group_multi_partition",
+		},
+		{
+			name:  "cross_group_requires_fanout",
+			class: raftplacement.TokenBatchRouteFanoutRequiredV1,
+			target: ClusterRouteTarget{
+				PlacementMode:   string(raftplacement.PlacementModeRingV1),
+				Shape:           ClusterRouteShapeTokenBatch,
+				TokenBatchClass: string(raftplacement.TokenBatchRouteFanoutRequiredV1),
+			},
+			wantText:  "requires fanout before submit",
+			wantClass: "route_class=fanout_required",
 		},
 	}
-	request := ClusterRouteRequest{
-		Database:    "default",
-		Catalog:     "default",
-		Collection:  "users",
-		CommandID:   iwire.CommandInsertBatch,
-		CommandName: "insert_batch",
-		Shape:       ClusterRouteShapeTokenBatch,
-		Tokens:      []uint64{1, 2},
-	}
-	if _, _, err := PreflightClusterRoute(context.Background(), submitter, request); codeOf(err) != iwire.ErrReadOnly || !strings.Contains(err.Error(), "requires fanout before submit") {
-		t.Fatalf("token batch fanout preflight err=%v want fanout read-only", err)
-	}
-	if routes := submitter.snapshotRoutes(); len(routes) != 1 {
-		t.Fatalf("route calls=%d want 1", len(routes))
-	}
-	if calls := submitter.snapshot(); len(calls) != 0 {
-		t.Fatalf("submitter calls=%d want 0", len(calls))
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			submitter := &routingClusterSubmitter{
+				fakeClusterSubmitter: &fakeClusterSubmitter{},
+				target:               tc.target,
+			}
+			request := ClusterRouteRequest{
+				Database:    "default",
+				Catalog:     "default",
+				Collection:  "users",
+				CommandID:   iwire.CommandInsertBatch,
+				CommandName: "insert_batch",
+				Shape:       ClusterRouteShapeTokenBatch,
+				Tokens:      []uint64{1, 2},
+			}
+			if _, _, err := PreflightClusterRoute(context.Background(), submitter, request); codeOf(err) != iwire.ErrReadOnly || !strings.Contains(err.Error(), tc.wantText) || !strings.Contains(err.Error(), tc.wantClass) {
+				t.Fatalf("token batch class %s preflight err=%v want read-only containing %q and %q", tc.class, err, tc.wantText, tc.wantClass)
+			}
+			if routes := submitter.snapshotRoutes(); len(routes) != 1 {
+				t.Fatalf("route calls=%d want 1", len(routes))
+			}
+			if calls := submitter.snapshot(); len(calls) != 0 {
+				t.Fatalf("submitter calls=%d want 0", len(calls))
+			}
+		})
 	}
 }
 
@@ -918,6 +963,12 @@ func TestCatalogClusterRouteProviderRoutesResolvedCatalog(t *testing.T) {
 				wantClass raftplacement.TokenBatchRouteClassV1
 				wantGroup string
 			}{
+				{
+					name:      "single_token",
+					tokens:    []uint64{1},
+					wantClass: raftplacement.TokenBatchRouteSingleTokenV1,
+					wantGroup: "group-a",
+				},
 				{
 					name:      "same_partition",
 					tokens:    []uint64{1, 2},


### PR DESCRIPTION
## Summary

Closes #3462.
References #3460.

This is correctness/contract-only M0A coverage for current fail-closed routing behavior. It does not implement remote forwarding, fanout/split execution, routed reads, catalog/meta ownership, or production scale claims.

Changes:

- Tighten raftcluster unknown remote-owner rejection with stable unknown-target text, leader hint propagation, and no local group submit.
- Extend placement query-route fail-closed coverage to token/ring placement.
- Expand nativewire token-batch contract coverage across single-token provider classification, same-partition command-split rejection, same-group multi-partition command-split rejection, and cross-group fanout-required rejection.
- Tighten Mongo route-rejected user-facing fields for route preflight errors, multi-ID token/ring writes, query routes, non-shard-key routed writes, and unknown local group rejection with no local document mutation.

## Tests

```sh
env GOWORK=off GOCACHE=/mnt/fast4tb/tmp/gomap-3462-gocache GOMODCACHE=/mnt/fast4tb/tmp/gomap-3462-gomodcache GOPATH=/mnt/fast4tb/tmp/gomap-3462-gopath go test ./TreeDB/internal/raftplacement ./TreeDB/internal/raftcluster ./TreeDB/nativewire ./TreeDB/mongo_gateway -run 'TestRouteTokenBatchClassifiesDocumentTokens|TestRouteFailsClosed|TestGroupRoutedSubmitter|TestSingleGroupSubmitter|TestClusterRoute|TestRaftClusterSubmitterGroupRoutedDispatcher|TestRaftClusterSubmitterRouteGroupMismatch|TestClusterRoutePreflightRejectsNative|Test.*Cluster.*Route|Test.*Cluster.*Submit|TestMongoGroupRoutedDispatcher' -count=1

env GOWORK=off GOCACHE=/mnt/fast4tb/tmp/gomap-3462-gocache GOMODCACHE=/mnt/fast4tb/tmp/gomap-3462-gomodcache GOPATH=/mnt/fast4tb/tmp/gomap-3462-gopath go test ./TreeDB/internal/raftplacement ./TreeDB/internal/raftcluster ./TreeDB/internal/raftharness ./TreeDB/nativewire ./TreeDB/mongo_gateway ./cmd/mongo_gateway_bench -count=1

env GOWORK=off GOCACHE=/mnt/fast4tb/tmp/gomap-3462-gocache GOMODCACHE=/mnt/fast4tb/tmp/gomap-3462-gomodcache GOPATH=/mnt/fast4tb/tmp/gomap-3462-gopath go test ./TreeDB/internal/raftcluster -run 'TestGroupRoutedSubmitter|TestSingleGroupSubmitter' -count=1

env GOWORK=off GOCACHE=/mnt/fast4tb/tmp/gomap-3462-gocache GOMODCACHE=/mnt/fast4tb/tmp/gomap-3462-gomodcache GOPATH=/mnt/fast4tb/tmp/gomap-3462-gopath go test ./TreeDB/nativewire -run 'TestClusterRoute|TestRaftClusterSubmitterGroupRoutedDispatcher|TestRaftClusterSubmitterRouteGroupMismatch|TestClusterRoutePreflightRejectsNative' -count=1

env GOWORK=off GOCACHE=/mnt/fast4tb/tmp/gomap-3462-gocache GOMODCACHE=/mnt/fast4tb/tmp/gomap-3462-gomodcache GOPATH=/mnt/fast4tb/tmp/gomap-3462-gopath go test ./TreeDB/mongo_gateway -run 'Test.*Cluster.*Route|Test.*Cluster.*Submit|TestMongoGroupRoutedDispatcher' -count=1
```

## Benchmarks

No benchmark evidence is required. This PR changes tests only and does not touch hot-path, storage, routing, benchmark, or production execution code.

## Review Status

AI reviews have not been requested. This PR is ready for coordinator review after latest-head CI starts/completes.
