### PR TITLE
cmd/mongo_gateway_bench: guard production route evidence

### DIFF
--- a/cmd/mongo_gateway_bench/README.md
+++ b/cmd/mongo_gateway_bench/README.md
@@ -148,11 +148,25 @@ GOWORK=off go run ./cmd/mongo_gateway_bench \
 
 JSON output includes top-level `route_mode`, `route_group_count`, and
 `route_partition_count` fields. When ring mode is enabled, `route_evidence`
-contains `write_shape=single_document_insert`, `local_only=true`,
-`preflight_success`, `fanout_rejected`, `group_hits`, `leader_hits`,
-`partition_hits`, and any fanout rejection text. Treat those fields as local
-deterministic routing distribution evidence only, not as a cluster throughput or
-scaleout claim.
+contains `evidence_scope=local_preflight`,
+`write_shape=single_document_insert`, `local_only=true`,
+`production_scale_eligible=false`, `preflight_success`, `fanout_rejected`,
+`group_hits`, `leader_hits`, `partition_hits`, and any fanout rejection text.
+The result also emits
+`production_route_evidence_status=unavailable_local_preflight_only` and omits
+`production_route_evidence`. Treat those fields as local deterministic routing
+distribution evidence only, not as a cluster throughput or scaleout claim.
+
+`-route-mode production` is reserved and intentionally fails closed until the
+benchmark exercises real production routed commits. Future production route
+results must use the separate `production_route_evidence` object instead of
+reusing local `route_evidence`. That production schema is reserved for
+`evidence_scope=production_routed_commit`, `real_routed_commits`,
+route-attempt/local-owner/remote-redirect/remote-forward/unknown-owner counters,
+route group/leader/token-partition hits, commit and applied group hits,
+fanout/split attempts and failures, direct-local-bypass rejects, write
+p50/p95/p99 latency, writes/sec, `B/op`, `allocs/op`, CPU context,
+storage/snapshot overhead, and artifact pointers.
 
 Use `-insert-producers N` to split the insert load phase across producer
 goroutines. The effective producer count is capped at the number of insert

--- a/cmd/mongo_gateway_bench/README.md
+++ b/cmd/mongo_gateway_bench/README.md
@@ -146,9 +146,9 @@ GOWORK=off go run ./cmd/mongo_gateway_bench \
   -format json
 ```
 
-JSON output includes top-level `route_mode`, `route_group_count`, and
-`route_partition_count` fields. When ring mode is enabled, `route_evidence`
-contains `evidence_scope=local_preflight`,
+JSON output always includes a top-level `route_mode` field. When ring mode is
+enabled, `route_group_count` and `route_partition_count` are also emitted and
+`route_evidence` contains `evidence_scope=local_preflight`,
 `write_shape=single_document_insert`, `local_only=true`,
 `production_scale_eligible=false`, `preflight_success`, `fanout_rejected`,
 `group_hits`, `leader_hits`, `partition_hits`, and any fanout rejection text.

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -119,38 +119,40 @@ type config struct {
 }
 
 type benchmarkResult struct {
-	Target                     string         `json:"target"`
-	MongoURI                   string         `json:"mongo_uri,omitempty"`
-	MongoCompact               bool           `json:"mongo_compact,omitempty"`
-	RouteMode                  string         `json:"route_mode"`
-	RouteGroupCount            int            `json:"route_group_count,omitempty"`
-	RoutePartitionCount        int            `json:"route_partition_count,omitempty"`
-	RouteEvidence              *routeEvidence `json:"route_evidence,omitempty"`
-	TreeDBDir                  string         `json:"treedb_dir,omitempty"`
-	Database                   string         `json:"database"`
-	Collection                 string         `json:"collection"`
-	Documents                  int            `json:"documents"`
-	BatchSize                  int            `json:"batch_size"`
-	InsertProducers            int            `json:"insert_producers"`
-	MongoMaxPoolSize           int            `json:"mongo_max_pool_size,omitempty"`
-	MongoMinPoolSize           int            `json:"mongo_min_pool_size,omitempty"`
-	MongoMaxConnecting         int            `json:"mongo_max_connecting,omitempty"`
-	SecondaryIndexes           int            `json:"secondary_indexes"`
-	ClientMode                 string         `json:"client_mode"`
-	ConcurrentReadKinds        []string       `json:"concurrent_read_kinds,omitempty"`
-	SkippedConcurrentReadKinds []string       `json:"skipped_concurrent_read_kinds,omitempty"`
-	ConcurrentReaders          int            `json:"concurrent_readers,omitempty"`
-	ConcurrentReaderSweep      []int          `json:"concurrent_reader_sweep,omitempty"`
-	ConcurrentReads            int            `json:"concurrent_reads,omitempty"`
-	ConcurrentRangeReaders     int            `json:"concurrent_range_readers,omitempty"`
-	ConcurrentRangeReaderSweep []int          `json:"concurrent_range_reader_sweep,omitempty"`
-	ConcurrentRangeReads       int            `json:"concurrent_range_reads,omitempty"`
-	RawWireTCPPipelineDepth    int            `json:"raw_wire_tcp_pipeline_depth,omitempty"`
-	ConcurrentWriters          int            `json:"concurrent_writers,omitempty"`
-	ConcurrentWriterSweep      []int          `json:"concurrent_writer_sweep,omitempty"`
-	ConcurrentWrites           int            `json:"concurrent_writes,omitempty"`
-	DocumentShape              string         `json:"document_shape,omitempty"`
-	PointReadProjection        string         `json:"point_read_projection,omitempty"`
+	Target                        string                   `json:"target"`
+	MongoURI                      string                   `json:"mongo_uri,omitempty"`
+	MongoCompact                  bool                     `json:"mongo_compact,omitempty"`
+	RouteMode                     string                   `json:"route_mode"`
+	RouteGroupCount               int                      `json:"route_group_count,omitempty"`
+	RoutePartitionCount           int                      `json:"route_partition_count,omitempty"`
+	RouteEvidence                 *routeEvidence           `json:"route_evidence,omitempty"`
+	ProductionRouteEvidenceStatus string                   `json:"production_route_evidence_status,omitempty"`
+	ProductionRouteEvidence       *productionRouteEvidence `json:"production_route_evidence,omitempty"`
+	TreeDBDir                     string                   `json:"treedb_dir,omitempty"`
+	Database                      string                   `json:"database"`
+	Collection                    string                   `json:"collection"`
+	Documents                     int                      `json:"documents"`
+	BatchSize                     int                      `json:"batch_size"`
+	InsertProducers               int                      `json:"insert_producers"`
+	MongoMaxPoolSize              int                      `json:"mongo_max_pool_size,omitempty"`
+	MongoMinPoolSize              int                      `json:"mongo_min_pool_size,omitempty"`
+	MongoMaxConnecting            int                      `json:"mongo_max_connecting,omitempty"`
+	SecondaryIndexes              int                      `json:"secondary_indexes"`
+	ClientMode                    string                   `json:"client_mode"`
+	ConcurrentReadKinds           []string                 `json:"concurrent_read_kinds,omitempty"`
+	SkippedConcurrentReadKinds    []string                 `json:"skipped_concurrent_read_kinds,omitempty"`
+	ConcurrentReaders             int                      `json:"concurrent_readers,omitempty"`
+	ConcurrentReaderSweep         []int                    `json:"concurrent_reader_sweep,omitempty"`
+	ConcurrentReads               int                      `json:"concurrent_reads,omitempty"`
+	ConcurrentRangeReaders        int                      `json:"concurrent_range_readers,omitempty"`
+	ConcurrentRangeReaderSweep    []int                    `json:"concurrent_range_reader_sweep,omitempty"`
+	ConcurrentRangeReads          int                      `json:"concurrent_range_reads,omitempty"`
+	RawWireTCPPipelineDepth       int                      `json:"raw_wire_tcp_pipeline_depth,omitempty"`
+	ConcurrentWriters             int                      `json:"concurrent_writers,omitempty"`
+	ConcurrentWriterSweep         []int                    `json:"concurrent_writer_sweep,omitempty"`
+	ConcurrentWrites              int                      `json:"concurrent_writes,omitempty"`
+	DocumentShape                 string                   `json:"document_shape,omitempty"`
+	PointReadProjection           string                   `json:"point_read_projection,omitempty"`
 
 	// Always emit this knob in JSON so benchmark artifacts distinguish default
 	// false runs from older runs that predate indexed-field update coverage.
@@ -241,20 +243,47 @@ type maintenanceResult struct {
 }
 
 type routeEvidence struct {
-	Mode                 string         `json:"mode"`
-	PlacementMode        string         `json:"placement_mode"`
-	RouteKey             string         `json:"route_key"`
-	WriteShape           string         `json:"write_shape"`
-	LocalOnly            bool           `json:"local_only"`
-	GroupCount           int            `json:"group_count"`
-	PartitionCount       int            `json:"partition_count"`
-	Writes               int            `json:"writes"`
-	PreflightSuccess     int            `json:"preflight_success"`
-	FanoutRejected       int            `json:"fanout_rejected"`
-	GroupHits            map[string]int `json:"group_hits,omitempty"`
-	LeaderHits           map[string]int `json:"leader_hits,omitempty"`
-	PartitionHits        map[string]int `json:"partition_hits,omitempty"`
-	UnsupportedFanoutErr string         `json:"unsupported_fanout_error,omitempty"`
+	Mode                    string         `json:"mode"`
+	EvidenceScope           string         `json:"evidence_scope"`
+	PlacementMode           string         `json:"placement_mode"`
+	RouteKey                string         `json:"route_key"`
+	WriteShape              string         `json:"write_shape"`
+	LocalOnly               bool           `json:"local_only"`
+	ProductionScaleEligible bool           `json:"production_scale_eligible"`
+	GroupCount              int            `json:"group_count"`
+	PartitionCount          int            `json:"partition_count"`
+	Writes                  int            `json:"writes"`
+	PreflightSuccess        int            `json:"preflight_success"`
+	FanoutRejected          int            `json:"fanout_rejected"`
+	GroupHits               map[string]int `json:"group_hits,omitempty"`
+	LeaderHits              map[string]int `json:"leader_hits,omitempty"`
+	PartitionHits           map[string]int `json:"partition_hits,omitempty"`
+	UnsupportedFanoutErr    string         `json:"unsupported_fanout_error,omitempty"`
+}
+
+type productionRouteEvidence struct {
+	EvidenceScope                string            `json:"evidence_scope"`
+	RealRoutedCommits            bool              `json:"real_routed_commits"`
+	RouteAttemptsTotal           int64             `json:"route_attempts_total"`
+	RouteLocalOwnerHits          int64             `json:"route_local_owner_hits"`
+	RouteRemoteRedirects         int64             `json:"route_remote_redirects"`
+	RouteRemoteForwards          int64             `json:"route_remote_forwards"`
+	RouteUnknownOwnerRejects     int64             `json:"route_unknown_owner_rejects"`
+	RouteGroupHits               map[string]int    `json:"route_group_hits"`
+	RouteLeaderHits              map[string]int    `json:"route_leader_hits"`
+	RouteTokenPartitionHits      map[string]int    `json:"route_token_partition_hits"`
+	CommitGroupHits              map[string]int    `json:"commit_group_hits"`
+	AppliedGroupHits             map[string]int    `json:"applied_group_hits"`
+	FanoutSplitAttempts          int64             `json:"fanout_split_attempts"`
+	FanoutSplitFailures          int64             `json:"fanout_split_failures"`
+	DirectLocalBypassRejects     int64             `json:"direct_local_bypass_rejects"`
+	WriteLatencyMicros           latencySummary    `json:"write_latency_micros"`
+	WritesPerSecond              float64           `json:"writes_per_sec"`
+	BytesPerOp                   float64           `json:"b_per_op"`
+	AllocsPerOp                  float64           `json:"allocs_per_op"`
+	CPUContext                   string            `json:"cpu_context"`
+	StorageSnapshotOverheadBytes int64             `json:"storage_snapshot_overhead_bytes"`
+	ArtifactPointers             map[string]string `json:"artifact_pointers,omitempty"`
 }
 
 type latencySummary struct {
@@ -415,8 +444,13 @@ const (
 	treeDBReadStateSettled   = "settled"
 	treeDBReadStateUnsettled = "unsettled"
 
-	routeModeOff  = "off"
-	routeModeRing = "ring"
+	routeModeOff        = "off"
+	routeModeRing       = "ring"
+	routeModeProduction = "production"
+
+	routeEvidenceScopeLocalPreflight                = "local_preflight"
+	routeEvidenceScopeProductionRoutedCommit        = "production_routed_commit"
+	productionRouteEvidenceStatusLocalPreflightOnly = "unavailable_local_preflight_only"
 
 	clientModeDriver             = "driver"
 	clientModeDriverFindRaw      = "driver-find-raw"
@@ -534,7 +568,7 @@ func parseConfig(args []string) (config, error) {
 	fs.StringVar(&cfg.Target, "target", "treedb", "benchmark target: treedb or mongo")
 	fs.StringVar(&cfg.MongoURI, "mongo-uri", "mongodb://127.0.0.1:27017", "MongoDB URI for -target mongo")
 	fs.BoolVar(&cfg.MongoCompact, "mongo-compact", false, "compact the MongoDB collection before final stats collection")
-	fs.StringVar(&cfg.RouteMode, "route-mode", cfg.RouteMode, "local route evidence mode: off or ring")
+	fs.StringVar(&cfg.RouteMode, "route-mode", cfg.RouteMode, "route evidence mode: off, ring, or reserved production")
 	fs.IntVar(&cfg.RouteGroupCount, "route-groups", cfg.RouteGroupCount, "logical route group count for -route-mode ring; must be >= 1")
 	fs.IntVar(&cfg.RoutePartitionCount, "route-partitions", cfg.RoutePartitionCount, "token partition count for -route-mode ring; must be >= route-groups")
 	fs.StringVar(&cfg.TreeDBDir, "treedb-dir", "", "TreeDB directory for -target treedb; empty uses a temp dir")
@@ -661,6 +695,9 @@ func parseConfig(args []string) (config, error) {
 	if cfg.RouteMode != routeModeOff {
 		if cfg.Target != "treedb" {
 			return config{}, errors.New("route-mode is only supported with -target treedb")
+		}
+		if cfg.RouteMode == routeModeProduction {
+			return config{}, errors.New("route-mode production is reserved until real production routed commits exist")
 		}
 		if cfg.ClientMode != clientModeDriver {
 			return config{}, errors.New("route-mode ring is only supported with -client-mode driver")
@@ -956,6 +993,8 @@ func parseRouteMode(raw string) (string, error) {
 		return routeModeOff, nil
 	case routeModeRing:
 		return routeModeRing, nil
+	case routeModeProduction:
+		return routeModeProduction, nil
 	default:
 		return "", fmt.Errorf("unknown route-mode %q", raw)
 	}
@@ -1645,6 +1684,7 @@ func runBenchmark(ctx context.Context, cfg config, target *benchTarget, profiler
 	if cfg.RouteMode == routeModeRing {
 		result.RouteGroupCount = cfg.RouteGroupCount
 		result.RoutePartitionCount = cfg.RoutePartitionCount
+		result.ProductionRouteEvidenceStatus = productionRouteEvidenceStatusLocalPreflightOnly
 	}
 	if cfg.ClientMode == clientModeRawWireTCPPipeline {
 		result.RawWireTCPPipelineDepth = cfg.RawWireTCPPipelineDepth
@@ -1940,6 +1980,7 @@ func runDirectTreeDBBenchmark(ctx context.Context, cfg config, target *benchTarg
 	if cfg.RouteMode == routeModeRing {
 		result.RouteGroupCount = cfg.RouteGroupCount
 		result.RoutePartitionCount = cfg.RoutePartitionCount
+		result.ProductionRouteEvidenceStatus = productionRouteEvidenceStatusLocalPreflightOnly
 	}
 	if cfg.TreeDBDir != "" || cfg.KeepTreeDBDir {
 		result.TreeDBDir = target.treedbDir
@@ -3846,20 +3887,22 @@ func (r *benchmarkRingRouter) evidence(writes int) *routeEvidence {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	return &routeEvidence{
-		Mode:                 routeModeRing,
-		PlacementMode:        routeModeRing,
-		RouteKey:             "_id",
-		WriteShape:           "single_document_insert",
-		LocalOnly:            true,
-		GroupCount:           r.groupCount,
-		PartitionCount:       r.partitionCount,
-		Writes:               writes,
-		PreflightSuccess:     r.preflightSuccess,
-		FanoutRejected:       r.fanoutRejected,
-		GroupHits:            cloneStringIntMap(r.groupHits),
-		LeaderHits:           cloneStringIntMap(r.leaderHits),
-		PartitionHits:        cloneStringIntMap(r.partitionHits),
-		UnsupportedFanoutErr: r.unsupportedFanoutErr,
+		Mode:                    routeModeRing,
+		EvidenceScope:           routeEvidenceScopeLocalPreflight,
+		PlacementMode:           routeModeRing,
+		RouteKey:                "_id",
+		WriteShape:              "single_document_insert",
+		LocalOnly:               true,
+		ProductionScaleEligible: false,
+		GroupCount:              r.groupCount,
+		PartitionCount:          r.partitionCount,
+		Writes:                  writes,
+		PreflightSuccess:        r.preflightSuccess,
+		FanoutRejected:          r.fanoutRejected,
+		GroupHits:               cloneStringIntMap(r.groupHits),
+		LeaderHits:              cloneStringIntMap(r.leaderHits),
+		PartitionHits:           cloneStringIntMap(r.partitionHits),
+		UnsupportedFanoutErr:    r.unsupportedFanoutErr,
 	}
 }
 
@@ -6994,14 +7037,17 @@ func writeResult(out io.Writer, format string, result *benchmarkResult) error {
 		}
 		fmt.Fprintln(out)
 		if result.RouteEvidence != nil {
-			fmt.Fprintf(out, "route_evidence mode=%s placement=%s route_key=%s write_shape=%s local_only=%t writes=%d preflight_success=%d fanout_rejected=%d group_hits=%v leader_hits=%v partition_hits=%v\n",
-				result.RouteEvidence.Mode, result.RouteEvidence.PlacementMode, result.RouteEvidence.RouteKey,
-				result.RouteEvidence.WriteShape, result.RouteEvidence.LocalOnly, result.RouteEvidence.Writes,
+			fmt.Fprintf(out, "route_evidence mode=%s evidence_scope=%s placement=%s route_key=%s write_shape=%s local_only=%t production_scale_eligible=%t writes=%d preflight_success=%d fanout_rejected=%d group_hits=%v leader_hits=%v partition_hits=%v\n",
+				result.RouteEvidence.Mode, result.RouteEvidence.EvidenceScope, result.RouteEvidence.PlacementMode, result.RouteEvidence.RouteKey,
+				result.RouteEvidence.WriteShape, result.RouteEvidence.LocalOnly, result.RouteEvidence.ProductionScaleEligible, result.RouteEvidence.Writes,
 				result.RouteEvidence.PreflightSuccess, result.RouteEvidence.FanoutRejected,
 				result.RouteEvidence.GroupHits, result.RouteEvidence.LeaderHits, result.RouteEvidence.PartitionHits)
 			if result.RouteEvidence.UnsupportedFanoutErr != "" {
 				fmt.Fprintf(out, "route_fanout_rejection=%q\n", result.RouteEvidence.UnsupportedFanoutErr)
 			}
+		}
+		if result.ProductionRouteEvidenceStatus != "" {
+			fmt.Fprintf(out, "production_route_evidence_status=%s\n", result.ProductionRouteEvidenceStatus)
 		}
 		if result.TreeDBDir != "" {
 			fmt.Fprintf(out, "treedb_dir=%s\n", result.TreeDBDir)

--- a/cmd/mongo_gateway_bench/main_test.go
+++ b/cmd/mongo_gateway_bench/main_test.go
@@ -1089,6 +1089,11 @@ func TestParseConfigRouteModeRing(t *testing.T) {
 			want: "unknown route-mode",
 		},
 		{
+			name: "production mode reserved",
+			args: []string{"-target", "treedb", "-route-mode", "production"},
+			want: "route-mode production is reserved until real production routed commits exist",
+		},
+		{
 			name: "mongo target",
 			args: []string{"-target", "mongo", "-route-mode", "ring"},
 			want: "route-mode is only supported with -target treedb",
@@ -1184,6 +1189,9 @@ func TestBenchmarkRingRouterPreflightDistributionAndFanout(t *testing.T) {
 	if evidence.PreflightSuccess != 4 || evidence.FanoutRejected != 1 {
 		t.Fatalf("unexpected evidence counters: %+v", evidence)
 	}
+	if evidence.EvidenceScope != routeEvidenceScopeLocalPreflight || !evidence.LocalOnly || evidence.ProductionScaleEligible {
+		t.Fatalf("unexpected local evidence boundary: %+v", evidence)
+	}
 	wantGroupHits := map[string]int{"group-00": 2, "group-01": 2}
 	if !reflect.DeepEqual(evidence.GroupHits, wantGroupHits) {
 		t.Fatalf("group hits=%v want %v", evidence.GroupHits, wantGroupHits)
@@ -1206,6 +1214,51 @@ func TestBenchmarkRingRouterPreflightDistributionAndFanout(t *testing.T) {
 	}
 	if !strings.Contains(evidence.UnsupportedFanoutErr, "requires fanout before submit") {
 		t.Fatalf("fanout rejection=%q want fanout rejection", evidence.UnsupportedFanoutErr)
+	}
+}
+
+func TestRouteEvidenceLocalOnlyCannotSatisfyProductionScaleSchema(t *testing.T) {
+	router := newBenchmarkRingRouter(2, 4)
+	target := router.routeToken(benchmarkRingPartitionMidpointToken(0, 4))
+	router.recordPreflightSuccess(target)
+	evidence := router.evidence(1)
+	if evidence == nil {
+		t.Fatal("route evidence missing")
+	}
+	if evidence.EvidenceScope != routeEvidenceScopeLocalPreflight || !evidence.LocalOnly || evidence.ProductionScaleEligible {
+		t.Fatalf("local route evidence boundary=%+v, want local preflight and production_scale_eligible=false", evidence)
+	}
+	raw, err := json.Marshal(evidence)
+	if err != nil {
+		t.Fatalf("marshal route evidence: %v", err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("unmarshal route evidence: %v", err)
+	}
+	if got := decoded["evidence_scope"]; got != routeEvidenceScopeLocalPreflight {
+		t.Fatalf("evidence_scope=%v want %q", got, routeEvidenceScopeLocalPreflight)
+	}
+	if got := decoded["production_scale_eligible"]; got != false {
+		t.Fatalf("production_scale_eligible=%v want false", got)
+	}
+	for _, key := range []string{
+		"real_routed_commits",
+		"route_attempts_total",
+		"route_remote_redirects",
+		"route_remote_forwards",
+		"commit_group_hits",
+		"applied_group_hits",
+		"fanout_split_attempts",
+		"direct_local_bypass_rejects",
+		"write_latency_micros",
+		"writes_per_sec",
+		"b_per_op",
+		"allocs_per_op",
+	} {
+		if _, ok := decoded[key]; ok {
+			t.Fatalf("local route evidence unexpectedly included production field %q: %v", key, decoded)
+		}
 	}
 }
 
@@ -2052,9 +2105,18 @@ func TestTreeDBRoutedRingModeSmoke(t *testing.T) {
 			if result.RouteEvidence == nil {
 				t.Fatalf("route evidence missing: %+v", result)
 			}
+			if result.ProductionRouteEvidence != nil {
+				t.Fatalf("production route evidence unexpectedly present for local ring mode: %+v", result.ProductionRouteEvidence)
+			}
+			if result.ProductionRouteEvidenceStatus != productionRouteEvidenceStatusLocalPreflightOnly {
+				t.Fatalf("production route evidence status=%q want %q", result.ProductionRouteEvidenceStatus, productionRouteEvidenceStatusLocalPreflightOnly)
+			}
 			evidence := result.RouteEvidence
 			if evidence.PreflightSuccess != cfg.Documents || evidence.Writes != cfg.Documents {
 				t.Fatalf("unexpected route evidence counters: %+v", evidence)
+			}
+			if evidence.EvidenceScope != routeEvidenceScopeLocalPreflight || evidence.ProductionScaleEligible {
+				t.Fatalf("unexpected route evidence production boundary: %+v", evidence)
 			}
 			if evidence.WriteShape != "single_document_insert" || !evidence.LocalOnly {
 				t.Fatalf("unexpected route evidence shape/boundary: %+v", evidence)
@@ -3110,6 +3172,10 @@ func TestDirectBenchmarkDocumentKeyUsesGatewayEncoding(t *testing.T) {
 func TestWriteResultIncludesTreeDBBufferedIndexedThresholds(t *testing.T) {
 	result := &benchmarkResult{
 		Target:                                 "treedb",
+		RouteMode:                              routeModeRing,
+		RouteGroupCount:                        1,
+		RoutePartitionCount:                    1,
+		ProductionRouteEvidenceStatus:          productionRouteEvidenceStatusLocalPreflightOnly,
 		Database:                               "bench",
 		Collection:                             "docs",
 		Documents:                              1,
@@ -3126,18 +3192,20 @@ func TestWriteResultIncludesTreeDBBufferedIndexedThresholds(t *testing.T) {
 		TreeDBBufferedIndexedAsyncFlushMaxQueuedUnits: 3,
 		TreeDBMaintenanceMode:                         "none",
 		RouteEvidence: &routeEvidence{
-			Mode:             routeModeRing,
-			PlacementMode:    "ring",
-			RouteKey:         "_id",
-			WriteShape:       "single_document_insert",
-			LocalOnly:        true,
-			GroupCount:       1,
-			PartitionCount:   1,
-			Writes:           1,
-			PreflightSuccess: 1,
-			GroupHits:        map[string]int{"group-00": 1},
-			LeaderHits:       map[string]int{"node-00-a": 1},
-			PartitionHits:    map[string]int{"token-000000": 1},
+			Mode:                    routeModeRing,
+			EvidenceScope:           routeEvidenceScopeLocalPreflight,
+			PlacementMode:           "ring",
+			RouteKey:                "_id",
+			WriteShape:              "single_document_insert",
+			LocalOnly:               true,
+			ProductionScaleEligible: false,
+			GroupCount:              1,
+			PartitionCount:          1,
+			Writes:                  1,
+			PreflightSuccess:        1,
+			GroupHits:               map[string]int{"group-00": 1},
+			LeaderHits:              map[string]int{"node-00-a": 1},
+			PartitionHits:           map[string]int{"token-000000": 1},
 		},
 	}
 	var out bytes.Buffer
@@ -3152,6 +3220,9 @@ func TestWriteResultIncludesTreeDBBufferedIndexedThresholds(t *testing.T) {
 		"buffered_indexed_max_root_runs=90",
 		"buffered_indexed_async_flush=true",
 		"buffered_indexed_async_max_queued_units=3",
+		"evidence_scope=local_preflight",
+		"production_scale_eligible=false",
+		"production_route_evidence_status=unavailable_local_preflight_only",
 		"leader_hits=map[node-00-a:1]",
 	} {
 		if !strings.Contains(text, want) {
@@ -3185,15 +3256,21 @@ func TestWriteResultIncludesTreeDBBufferedIndexedThresholds(t *testing.T) {
 		!decoded.TreeDBCommandWAL ||
 		!decoded.TreeDBBufferedIndexedAsyncFlush ||
 		decoded.TreeDBBufferedIndexedAsyncFlushMaxQueuedUnits != 3 ||
+		decoded.ProductionRouteEvidenceStatus != productionRouteEvidenceStatusLocalPreflightOnly ||
+		decoded.ProductionRouteEvidence != nil ||
 		decoded.RouteEvidence == nil ||
+		decoded.RouteEvidence.EvidenceScope != routeEvidenceScopeLocalPreflight ||
+		decoded.RouteEvidence.ProductionScaleEligible ||
 		!reflect.DeepEqual(decoded.RouteEvidence.LeaderHits, map[string]int{"node-00-a": 1}) {
-		t.Fatalf("json thresholds docs=%d bytes=%d rootRuns=%d commandWAL=%t async=%t asyncMax=%d want 1234/5678/90/true/true/3",
+		t.Fatalf("json thresholds docs=%d bytes=%d rootRuns=%d commandWAL=%t async=%t asyncMax=%d routeStatus=%q routeEvidence=%+v want 1234/5678/90/true/true/3 with local-only route evidence",
 			decoded.TreeDBBufferedIndexedWriteMaxDocuments,
 			decoded.TreeDBBufferedIndexedWriteMaxBytes,
 			decoded.TreeDBBufferedIndexedWriteMaxRootRuns,
 			decoded.TreeDBCommandWAL,
 			decoded.TreeDBBufferedIndexedAsyncFlush,
-			decoded.TreeDBBufferedIndexedAsyncFlushMaxQueuedUnits)
+			decoded.TreeDBBufferedIndexedAsyncFlushMaxQueuedUnits,
+			decoded.ProductionRouteEvidenceStatus,
+			decoded.RouteEvidence)
 	}
 	var decodedWithRoute map[string]any
 	if err := json.Unmarshal(out.Bytes(), &decodedWithRoute); err != nil {
@@ -3210,6 +3287,18 @@ func TestWriteResultIncludesTreeDBBufferedIndexedThresholds(t *testing.T) {
 	if got := leaderHitsJSON["node-00-a"]; got != float64(1) {
 		t.Fatalf("json route_evidence leader_hits node-00-a=%v want 1", got)
 	}
+	if got := routeJSON["evidence_scope"]; got != routeEvidenceScopeLocalPreflight {
+		t.Fatalf("json route_evidence evidence_scope=%v want %q", got, routeEvidenceScopeLocalPreflight)
+	}
+	if got := routeJSON["production_scale_eligible"]; got != false {
+		t.Fatalf("json route_evidence production_scale_eligible=%v want false", got)
+	}
+	if got := decodedWithRoute["production_route_evidence_status"]; got != productionRouteEvidenceStatusLocalPreflightOnly {
+		t.Fatalf("json production_route_evidence_status=%v want %q", got, productionRouteEvidenceStatusLocalPreflightOnly)
+	}
+	if _, ok := decodedWithRoute["production_route_evidence"]; ok {
+		t.Fatalf("json unexpectedly included production_route_evidence for local route evidence: %v", decodedWithRoute["production_route_evidence"])
+	}
 
 	result.TreeDBCommandWAL = false
 	out.Reset()
@@ -3223,6 +3312,94 @@ func TestWriteResultIncludesTreeDBBufferedIndexedThresholds(t *testing.T) {
 	got, ok := decodedMap["treedb_command_wal"]
 	if !ok || got != false {
 		t.Fatalf("json treedb_command_wal=%v present=%t, want false and present", got, ok)
+	}
+}
+
+func TestProductionRouteEvidenceJSONSchemaPlaceholder(t *testing.T) {
+	result := &benchmarkResult{
+		Target:                        "treedb",
+		RouteMode:                     routeModeProduction,
+		Database:                      "bench",
+		Collection:                    "docs",
+		Documents:                     1,
+		BatchSize:                     1,
+		ProductionRouteEvidenceStatus: "available",
+		ProductionRouteEvidence: &productionRouteEvidence{
+			EvidenceScope:                routeEvidenceScopeProductionRoutedCommit,
+			RealRoutedCommits:            true,
+			RouteAttemptsTotal:           11,
+			RouteLocalOwnerHits:          7,
+			RouteRemoteRedirects:         2,
+			RouteRemoteForwards:          1,
+			RouteUnknownOwnerRejects:     1,
+			RouteGroupHits:               map[string]int{"group-00": 7, "group-01": 4},
+			RouteLeaderHits:              map[string]int{"node-00-a": 7, "node-01-a": 4},
+			RouteTokenPartitionHits:      map[string]int{"token-000000": 7, "token-000001": 4},
+			CommitGroupHits:              map[string]int{"group-00": 6, "group-01": 3},
+			AppliedGroupHits:             map[string]int{"group-00": 6, "group-01": 3},
+			FanoutSplitAttempts:          5,
+			FanoutSplitFailures:          1,
+			DirectLocalBypassRejects:     3,
+			WriteLatencyMicros:           latencySummary{P50: 10, P95: 20, P99: 30},
+			WritesPerSecond:              1234.5,
+			BytesPerOp:                   456,
+			AllocsPerOp:                  7,
+			CPUContext:                   "unit-test",
+			StorageSnapshotOverheadBytes: 89,
+			ArtifactPointers:             map[string]string{"cpu": "profiles/cpu.pprof"},
+		},
+	}
+	var out bytes.Buffer
+	if err := writeResult(&out, "json", result); err != nil {
+		t.Fatalf("writeResult json: %v", err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(out.Bytes(), &decoded); err != nil {
+		t.Fatalf("unmarshal json result: %v", err)
+	}
+	productionJSON, ok := decoded["production_route_evidence"].(map[string]any)
+	if !ok {
+		t.Fatalf("production_route_evidence missing or wrong type: %#v", decoded["production_route_evidence"])
+	}
+	if _, ok := decoded["route_evidence"]; ok {
+		t.Fatalf("production schema placeholder should not populate local route_evidence: %v", decoded["route_evidence"])
+	}
+	for _, key := range []string{
+		"evidence_scope",
+		"real_routed_commits",
+		"route_attempts_total",
+		"route_local_owner_hits",
+		"route_remote_redirects",
+		"route_remote_forwards",
+		"route_unknown_owner_rejects",
+		"route_group_hits",
+		"route_leader_hits",
+		"route_token_partition_hits",
+		"commit_group_hits",
+		"applied_group_hits",
+		"fanout_split_attempts",
+		"fanout_split_failures",
+		"direct_local_bypass_rejects",
+		"write_latency_micros",
+		"writes_per_sec",
+		"b_per_op",
+		"allocs_per_op",
+		"cpu_context",
+		"storage_snapshot_overhead_bytes",
+		"artifact_pointers",
+	} {
+		if _, ok := productionJSON[key]; !ok {
+			t.Fatalf("production_route_evidence missing key %q: %v", key, productionJSON)
+		}
+	}
+	if got := productionJSON["evidence_scope"]; got != routeEvidenceScopeProductionRoutedCommit {
+		t.Fatalf("production evidence_scope=%v want %q", got, routeEvidenceScopeProductionRoutedCommit)
+	}
+	if got := productionJSON["real_routed_commits"]; got != true {
+		t.Fatalf("real_routed_commits=%v want true", got)
+	}
+	if got := decoded["production_route_evidence_status"]; got != "available" {
+		t.Fatalf("production_route_evidence_status=%v want available", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- reserve `-route-mode production` and reject it until real production routed commits exist
- mark local ring route evidence as `evidence_scope=local_preflight` with `production_scale_eligible=false`
- add a separate `production_route_evidence` placeholder schema and README semantics for future production routed-commit evidence

Closes #3461
Refs #3460

## Scope

Instrumentation/guardrail-only. This PR only changes `cmd/mongo_gateway_bench` CLI/schema/tests/docs. It does not change core TreeDB, nativewire, Mongo gateway, raftcluster, forwarding, fanout/split execution, routed reads, catalog/meta ownership, or production scale behavior.

## Tests

- `env GOWORK=off GOCACHE=/mnt/fast4tb/tmp/go-cache GOPATH=/mnt/fast4tb/tmp/go-path GOMODCACHE=/mnt/fast4tb/tmp/go-mod TMPDIR=/mnt/fast4tb/tmp/go-test-tmp go test ./cmd/mongo_gateway_bench -run 'TestParseConfigRouteModeRing|TestBenchmarkRingRouterPreflightDistributionAndFanout|TestRouteEvidenceLocalOnlyCannotSatisfyProductionScaleSchema|TestWriteResultIncludesTreeDBBufferedIndexedThresholds|TestProductionRouteEvidenceJSONSchemaPlaceholder|TestTreeDBRoutedRingModeSmoke' -count=1`
- `env GOWORK=off GOCACHE=/mnt/fast4tb/tmp/go-cache GOPATH=/mnt/fast4tb/tmp/go-path GOMODCACHE=/mnt/fast4tb/tmp/go-mod TMPDIR=/mnt/fast4tb/tmp/go-test-tmp go test ./cmd/mongo_gateway_bench -count=1`
- `env GOWORK=off GOCACHE=/mnt/fast4tb/tmp/go-cache GOPATH=/mnt/fast4tb/tmp/go-path GOMODCACHE=/mnt/fast4tb/tmp/go-mod TMPDIR=/mnt/fast4tb/tmp/go-test-tmp go test ./TreeDB/internal/raftcluster ./TreeDB/nativewire ./TreeDB/mongo_gateway ./cmd/mongo_gateway_bench -count=1`

## Benchmark / Performance Rationale

Benchmark execution is not required for this PR beyond focused tests. The change is instrumentation/guardrail-only and does not add hot-path counters or modify production TreeDB/nativewire/Mongo execution paths. The only runtime benchmark-path change is result metadata/text output for local route evidence; production route mode intentionally fails closed.

## Risks / Follow-ups

- `production_route_evidence` is a schema placeholder only; future production-route work must populate it from real routed commits.
- Local `route_evidence` remains local preflight evidence and cannot satisfy production-scale fields.
- `-route-mode production` is deliberately unavailable until the production routed commit path exists.
