### PR TITLE
TreeDB Raft: stabilize remote-owner route errors

### DIFF
--- a/TreeDB/internal/raftcluster/dispatcher.go
+++ b/TreeDB/internal/raftcluster/dispatcher.go
@@ -115,7 +115,7 @@ func (s *GroupRoutedSubmitter) SubmitCommandEntryV1(ctx context.Context, entry [
 	}
 	submitter, ok := s.registry.Lookup(target.GroupID)
 	if !ok {
-		return SubmitResultV1{}, errors.Join(ErrRouteTargetUnknown, routeErrorWithLeaderHint(metadata, "route group %q is not configured locally", target.GroupID))
+		return SubmitResultV1{}, errors.Join(ErrRouteTargetUnknown, routeErrorWithMetadata(metadata, "route group %q is not configured locally", target.GroupID))
 	}
 	if ctx == nil {
 		ctx = context.Background()

--- a/TreeDB/internal/raftcluster/dispatcher.go
+++ b/TreeDB/internal/raftcluster/dispatcher.go
@@ -210,7 +210,7 @@ func routeDispatchTargetFromMetadata(metadata raftentry.RequestMetadataV1) (rout
 		return routeDispatchTarget{}, errors.Join(ErrRouteFanoutRequired, fmt.Errorf("cluster route shape %q requires split/fanout before group dispatch", metadata.ClusterRouteShape))
 	}
 	if metadata.ClusterRouteGroupID == "" {
-		return routeDispatchTarget{}, errors.Join(ErrRouteTargetMissing, fmt.Errorf("cluster route group id is required"))
+		return routeDispatchTarget{}, errors.Join(ErrRouteTargetMissing, routeErrorWithMetadata(metadata, "cluster route group id is required"))
 	}
 	switch metadata.ClusterRouteShape {
 	case clusterRouteShapeCollectionV1:

--- a/TreeDB/internal/raftcluster/dispatcher_test.go
+++ b/TreeDB/internal/raftcluster/dispatcher_test.go
@@ -295,6 +295,27 @@ func TestGroupRoutedSubmitterUnknownOwnerHasStableRouteClassBeforeSubmit(t *test
 	}
 }
 
+func TestGroupRoutedSubmitterMissingOwnerHasStableRouteClassBeforeSubmit(t *testing.T) {
+	groupA := &recordingGroupSubmitter{groupID: "group-a"}
+	dispatcher := newTestGroupRoutedSubmitter(t, groupA)
+
+	meta := routeMetadata("", iwire.AckVisible)
+	_, err := dispatcher.SubmitCommandEntryV1(context.Background(), testClusterCommandEntry(t, 7), meta)
+	if !errors.Is(err, ErrRouteTargetMissing) {
+		t.Fatalf("SubmitCommandEntryV1 err=%v want route target missing", err)
+	}
+	route, ok := RouteErrorMetadataOf(err)
+	if !ok {
+		t.Fatalf("RouteErrorMetadataOf ok=false err=%v", err)
+	}
+	if route.Class != RouteErrorClassMissingOwner || route.GroupID != "" || route.Collection != "users" {
+		t.Fatalf("route metadata=%+v want missing owner for users route", route)
+	}
+	if calls := groupA.snapshot(); len(calls) != 0 {
+		t.Fatalf("group-a calls=%d want 0", len(calls))
+	}
+}
+
 func TestGroupSubmitterRegistryRejectsMismatchedConfiguredGroup(t *testing.T) {
 	_, err := NewGroupSubmitterRegistryV1([]GroupSubmitterV1{
 		{GroupID: "group-a", Submitter: &recordingGroupSubmitter{groupID: "group-b"}},

--- a/TreeDB/internal/raftcluster/dispatcher_test.go
+++ b/TreeDB/internal/raftcluster/dispatcher_test.go
@@ -225,6 +225,13 @@ func TestGroupRoutedSubmitterRejectsUnknownRemoteOwnerWithStableHintBeforeSubmit
 	dispatcher := newTestGroupRoutedSubmitter(t, groupA, groupB)
 
 	meta := routeMetadata("group-z", iwire.AckRaftCommitted)
+	meta.ClusterRouteShape = clusterRouteShapeTokenV1
+	meta.ClusterRoutePlacementMode = clusterRoutePlacementRingV1
+	meta.ClusterRouteKey = clusterRouteKeyDocumentIDV1
+	meta.ClusterRouteTokenKnown = true
+	meta.ClusterRouteToken = 99
+	meta.ClusterRoutePartitionID = "p9"
+	meta.ClusterRouteMembers = []string{"node-z", "node-y"}
 	meta.ClusterRouteLeaderHint = "node-z"
 	_, err := dispatcher.SubmitCommandEntryV1(context.Background(), testClusterCommandEntry(t, 7), meta)
 	if !errors.Is(err, ErrRouteTargetUnknown) {
@@ -236,11 +243,55 @@ func TestGroupRoutedSubmitterRejectsUnknownRemoteOwnerWithStableHintBeforeSubmit
 	if !strings.Contains(err.Error(), "leader_hint=node-z") {
 		t.Fatalf("SubmitCommandEntryV1 err=%q want leader hint", err)
 	}
+	route, ok := RouteErrorMetadataOf(err)
+	if !ok {
+		t.Fatalf("RouteErrorMetadataOf ok=false err=%v", err)
+	}
+	if route.Class != RouteErrorClassRemoteOwnerRedirect ||
+		route.GroupID != "group-z" ||
+		route.LeaderHint != "node-z" ||
+		route.Database != "default" ||
+		route.Catalog != "default" ||
+		route.Collection != "users" ||
+		route.Shape != clusterRouteShapeTokenV1 ||
+		route.PlacementMode != clusterRoutePlacementRingV1 ||
+		route.RouteKey != clusterRouteKeyDocumentIDV1 ||
+		!route.TokenKnown ||
+		route.Token != 99 ||
+		route.PartitionID != "p9" {
+		t.Fatalf("route metadata=%+v want remote owner redirect for group-z/node-z token p9", route)
+	}
+	if len(route.Members) != 2 || route.Members[0] != "node-z" || route.Members[1] != "node-y" {
+		t.Fatalf("route members=%v want [node-z node-y]", route.Members)
+	}
 	if calls := groupA.snapshot(); len(calls) != 0 {
 		t.Fatalf("group-a calls=%d want 0", len(calls))
 	}
 	if calls := groupB.snapshot(); len(calls) != 0 {
 		t.Fatalf("group-b calls=%d want 0", len(calls))
+	}
+}
+
+func TestGroupRoutedSubmitterUnknownOwnerHasStableRouteClassBeforeSubmit(t *testing.T) {
+	groupA := &recordingGroupSubmitter{groupID: "group-a"}
+	dispatcher := newTestGroupRoutedSubmitter(t, groupA)
+
+	meta := routeMetadata("group-z", iwire.AckVisible)
+	meta.ClusterRouteLeaderHint = ""
+	meta.ClusterRouteMembers = nil
+	_, err := dispatcher.SubmitCommandEntryV1(context.Background(), testClusterCommandEntry(t, 7), meta)
+	if !errors.Is(err, ErrRouteTargetUnknown) {
+		t.Fatalf("SubmitCommandEntryV1 err=%v want route target unknown", err)
+	}
+	route, ok := RouteErrorMetadataOf(err)
+	if !ok {
+		t.Fatalf("RouteErrorMetadataOf ok=false err=%v", err)
+	}
+	if route.Class != RouteErrorClassUnknownOwner || route.GroupID != "group-z" || route.LeaderHint != "" {
+		t.Fatalf("route metadata=%+v want unknown owner group-z without leader hint", route)
+	}
+	if calls := groupA.snapshot(); len(calls) != 0 {
+		t.Fatalf("group-a calls=%d want 0", len(calls))
 	}
 }
 

--- a/TreeDB/internal/raftcluster/submit.go
+++ b/TreeDB/internal/raftcluster/submit.go
@@ -612,7 +612,10 @@ func (s *SingleGroupSubmitter) checkRouteBinding(metadata raftentry.RequestMetad
 	}
 	localGroup := string(s.cluster.GroupID)
 	if metadata.ClusterRouteGroupID == "" {
-		return errors.Join(ErrRouteGroupMismatch, fmt.Errorf("route metadata missing group id for local group %q", localGroup))
+		return errors.Join(ErrRouteGroupMismatch, &routeError{
+			message:  fmt.Sprintf("route metadata missing group id for local group %q", localGroup),
+			metadata: routeErrorMetadataFromRequest(metadata, localGroup),
+		})
 	}
 	if metadata.ClusterRouteGroupID != localGroup {
 		return errors.Join(ErrRouteGroupMismatch, &routeError{

--- a/TreeDB/internal/raftcluster/submit.go
+++ b/TreeDB/internal/raftcluster/submit.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"strings"
 	"sync"
 
 	iwire "github.com/snissn/gomap/TreeDB/internal/nativewire"
@@ -45,6 +46,61 @@ type AdmissionStatus struct {
 	Unavailable bool
 	LeaderHint  NodeID
 	Reason      string
+}
+
+// RouteErrorClass identifies the stable routing failure class clients can use
+// to decide whether to redirect or retry discovery.
+type RouteErrorClass string
+
+const (
+	// RouteErrorClassRemoteOwnerRedirect means the owner is known but not local.
+	RouteErrorClassRemoteOwnerRedirect RouteErrorClass = "remote_owner_redirect"
+	// RouteErrorClassUnknownOwner means the route target names a group without
+	// enough owner metadata for a redirect.
+	RouteErrorClassUnknownOwner RouteErrorClass = "unknown_owner"
+	// RouteErrorClassMissingOwner means the route target did not include an
+	// owning group id.
+	RouteErrorClassMissingOwner RouteErrorClass = "missing_owner"
+)
+
+// RouteErrorMetadata is stable client-facing metadata for route failures that
+// must reject before local mutation. It intentionally mirrors request metadata
+// instead of introducing a forwarding protocol.
+type RouteErrorMetadata struct {
+	Class         RouteErrorClass
+	Database      string
+	Catalog       string
+	Collection    string
+	Shape         string
+	GroupID       string
+	Members       []string
+	LeaderHint    string
+	PlacementMode string
+	RouteKey      string
+	TokenKnown    bool
+	Token         uint64
+	PartitionID   string
+	LocalGroupID  string
+}
+
+// Clone returns an independent copy of the metadata.
+func (m RouteErrorMetadata) Clone() RouteErrorMetadata {
+	m.Members = slices.Clone(m.Members)
+	return m
+}
+
+// RouteErrorMetadataOf returns stable route metadata carried by err.
+func RouteErrorMetadataOf(err error) (RouteErrorMetadata, bool) {
+	if err == nil {
+		return RouteErrorMetadata{}, false
+	}
+	var routed interface {
+		RouteErrorMetadata() RouteErrorMetadata
+	}
+	if errors.As(err, &routed) {
+		return routed.RouteErrorMetadata().Clone(), true
+	}
+	return RouteErrorMetadata{}, false
 }
 
 func LeaderAdmission() AdmissionStatus {
@@ -559,36 +615,103 @@ func (s *SingleGroupSubmitter) checkRouteBinding(metadata raftentry.RequestMetad
 		return errors.Join(ErrRouteGroupMismatch, fmt.Errorf("route metadata missing group id for local group %q", localGroup))
 	}
 	if metadata.ClusterRouteGroupID != localGroup {
-		return errors.Join(ErrRouteGroupMismatch, routeErrorWithLeaderHint(metadata, "route group %q does not match local group %q", metadata.ClusterRouteGroupID, localGroup))
+		return errors.Join(ErrRouteGroupMismatch, &routeError{
+			message:  fmt.Sprintf("route group %q does not match local group %q", metadata.ClusterRouteGroupID, localGroup),
+			metadata: routeErrorMetadataFromRequest(metadata, localGroup),
+		})
 	}
 	return nil
 }
 
-func routeErrorWithLeaderHint(metadata raftentry.RequestMetadataV1, format string, args ...any) error {
+func routeErrorWithMetadata(metadata raftentry.RequestMetadataV1, format string, args ...any) error {
 	msg := fmt.Sprintf(format, args...)
-	if metadata.ClusterRouteLeaderHint == "" {
-		return errors.New(msg)
+	return &routeError{message: msg, metadata: routeErrorMetadataFromRequest(metadata, "")}
+}
+
+func routeErrorMetadataFromRequest(metadata raftentry.RequestMetadataV1, localGroupID string) RouteErrorMetadata {
+	class := RouteErrorClassUnknownOwner
+	if metadata.ClusterRouteGroupID == "" {
+		class = RouteErrorClassMissingOwner
+	} else if metadata.ClusterRouteLeaderHint != "" || len(metadata.ClusterRouteMembers) != 0 {
+		class = RouteErrorClassRemoteOwnerRedirect
 	}
-	return &routeLeaderHintError{message: msg, leaderHint: metadata.ClusterRouteLeaderHint}
+	return RouteErrorMetadata{
+		Class:         class,
+		Database:      metadata.ClusterRouteDatabase,
+		Catalog:       metadata.ClusterRouteCatalog,
+		Collection:    metadata.ClusterRouteCollection,
+		Shape:         metadata.ClusterRouteShape,
+		GroupID:       metadata.ClusterRouteGroupID,
+		Members:       slices.Clone(metadata.ClusterRouteMembers),
+		LeaderHint:    metadata.ClusterRouteLeaderHint,
+		PlacementMode: metadata.ClusterRoutePlacementMode,
+		RouteKey:      metadata.ClusterRouteKey,
+		TokenKnown:    metadata.ClusterRouteTokenKnown,
+		Token:         metadata.ClusterRouteToken,
+		PartitionID:   metadata.ClusterRoutePartitionID,
+		LocalGroupID:  localGroupID,
+	}
 }
 
-type routeLeaderHintError struct {
-	message    string
-	leaderHint string
+type routeError struct {
+	message  string
+	metadata RouteErrorMetadata
 }
 
-func (e *routeLeaderHintError) Error() string {
+func (e *routeError) Error() string {
 	if e == nil {
 		return ""
 	}
-	return e.message + "; leader_hint=" + e.leaderHint
+	fields := routeErrorFields(e.metadata)
+	if fields == "" {
+		return e.message
+	}
+	if e.message == "" {
+		return fields
+	}
+	return e.message + "; " + fields
 }
 
-func (e *routeLeaderHintError) ClusterLeaderHint() string {
+func (e *routeError) ClusterLeaderHint() string {
 	if e == nil {
 		return ""
 	}
-	return e.leaderHint
+	return e.metadata.LeaderHint
+}
+
+func (e *routeError) RouteErrorMetadata() RouteErrorMetadata {
+	if e == nil {
+		return RouteErrorMetadata{}
+	}
+	return e.metadata.Clone()
+}
+
+func routeErrorFields(metadata RouteErrorMetadata) string {
+	var fields []string
+	appendField := func(key, value string) {
+		if value != "" {
+			fields = append(fields, key+"="+value)
+		}
+	}
+	appendField("route_error_class", string(metadata.Class))
+	appendField("route_group", metadata.GroupID)
+	appendField("leader_hint", metadata.LeaderHint)
+	if len(metadata.Members) != 0 {
+		appendField("route_members", strings.Join(metadata.Members, ","))
+	}
+	appendField("route_database", metadata.Database)
+	appendField("route_catalog", metadata.Catalog)
+	appendField("route_collection", metadata.Collection)
+	appendField("route_shape", metadata.Shape)
+	appendField("route_placement", metadata.PlacementMode)
+	appendField("route_key", metadata.RouteKey)
+	if metadata.TokenKnown {
+		appendField("route_token_known", "true")
+		appendField("route_token", fmt.Sprint(metadata.Token))
+	}
+	appendField("route_partition", metadata.PartitionID)
+	appendField("local_group", metadata.LocalGroupID)
+	return strings.Join(fields, " ")
 }
 
 func (s *SingleGroupSubmitter) validateCommitResult(request CommitCommandEntryV1Request, result CommitCommandEntryV1Result) (CommittedCommandEntryV1, error) {

--- a/TreeDB/internal/raftcluster/submit.go
+++ b/TreeDB/internal/raftcluster/submit.go
@@ -6,6 +6,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"net/url"
 	"slices"
 	"strings"
 	"sync"
@@ -693,14 +694,22 @@ func routeErrorFields(metadata RouteErrorMetadata) string {
 	var fields []string
 	appendField := func(key, value string) {
 		if value != "" {
-			fields = append(fields, key+"="+value)
+			fields = append(fields, key+"="+url.QueryEscape(value))
 		}
 	}
 	appendField("route_error_class", string(metadata.Class))
 	appendField("route_group", metadata.GroupID)
 	appendField("leader_hint", metadata.LeaderHint)
 	if len(metadata.Members) != 0 {
-		appendField("route_members", strings.Join(metadata.Members, ","))
+		escaped := make([]string, 0, len(metadata.Members))
+		for _, member := range metadata.Members {
+			if member != "" {
+				escaped = append(escaped, url.QueryEscape(member))
+			}
+		}
+		if len(escaped) != 0 {
+			fields = append(fields, "route_members="+strings.Join(escaped, ","))
+		}
 	}
 	appendField("route_database", metadata.Database)
 	appendField("route_catalog", metadata.Catalog)

--- a/TreeDB/internal/raftcluster/submit_test.go
+++ b/TreeDB/internal/raftcluster/submit_test.go
@@ -257,6 +257,47 @@ func TestSingleGroupSubmitterRejectsRouteGroupMismatchBeforePreflightCommitApply
 	}
 }
 
+func TestSingleGroupSubmitterMissingRouteOwnerCarriesStableMetadata(t *testing.T) {
+	entry := testClusterCommandEntry(t, 7)
+	preflightCalls := 0
+	commitCalls := 0
+	applier := &recordingClusterApplier{result: raftentry.ApplyResultV1{Status: raftentry.ApplyStatusApplied, AffectedCount: 1}}
+	submitter := newTestSingleGroupSubmitter(t, SingleGroupSubmitterOptions{
+		AdmissionProvider: StaticAdmissionProvider{Status: LeaderAdmission()},
+		CommitSource: CommitSourceFunc(func(context.Context, CommitCommandEntryV1Request) (CommitCommandEntryV1Result, error) {
+			commitCalls++
+			return CommitCommandEntryV1Result{}, nil
+		}),
+		Preflight: CommandEntryPreflightFunc(func(context.Context, CommandEntryPreflightRequestV1) (CommandEntryPreflightResultV1, error) {
+			preflightCalls++
+			return CommandEntryPreflightResultV1{}, nil
+		}),
+		Applier:                applier,
+		CatalogVersionProvider: staticCatalogVersion(7),
+	})
+
+	_, err := submitter.SubmitCommandEntryV1(context.Background(), entry, routeMetadata("", iwire.AckRaftCommitted))
+	if !errors.Is(err, ErrRouteGroupMismatch) {
+		t.Fatalf("SubmitCommandEntryV1 err=%v want route group mismatch", err)
+	}
+	route, ok := RouteErrorMetadataOf(err)
+	if !ok {
+		t.Fatalf("RouteErrorMetadataOf ok=false err=%v", err)
+	}
+	if route.Class != RouteErrorClassMissingOwner || route.LocalGroupID != "group-a" || route.GroupID != "" {
+		t.Fatalf("route metadata=%+v want missing owner for local group-a", route)
+	}
+	if preflightCalls != 0 {
+		t.Fatalf("preflight calls=%d want 0", preflightCalls)
+	}
+	if commitCalls != 0 {
+		t.Fatalf("commit calls=%d want 0", commitCalls)
+	}
+	if got := len(applier.snapshot()); got != 0 {
+		t.Fatalf("apply calls=%d want 0", got)
+	}
+}
+
 func TestSingleGroupSubmitterAllowsMatchingRouteGroup(t *testing.T) {
 	entry := testClusterCommandEntry(t, 7)
 	applier := &recordingClusterApplier{result: raftentry.ApplyResultV1{Status: raftentry.ApplyStatusApplied, AffectedCount: 1}}

--- a/TreeDB/internal/raftcluster/submit_test.go
+++ b/TreeDB/internal/raftcluster/submit_test.go
@@ -257,6 +257,50 @@ func TestSingleGroupSubmitterRejectsRouteGroupMismatchBeforePreflightCommitApply
 	}
 }
 
+func TestSingleGroupSubmitterMissingRouteGroupIDHasStableRouteClassBeforeSubmit(t *testing.T) {
+	entry := testClusterCommandEntry(t, 7)
+	preflightCalls := 0
+	commitCalls := 0
+	applier := &recordingClusterApplier{result: raftentry.ApplyResultV1{Status: raftentry.ApplyStatusApplied, AffectedCount: 1}}
+	submitter := newTestSingleGroupSubmitter(t, SingleGroupSubmitterOptions{
+		AdmissionProvider: StaticAdmissionProvider{Status: LeaderAdmission()},
+		CommitSource: CommitSourceFunc(func(context.Context, CommitCommandEntryV1Request) (CommitCommandEntryV1Result, error) {
+			commitCalls++
+			return CommitCommandEntryV1Result{}, nil
+		}),
+		Preflight: CommandEntryPreflightFunc(func(context.Context, CommandEntryPreflightRequestV1) (CommandEntryPreflightResultV1, error) {
+			preflightCalls++
+			return CommandEntryPreflightResultV1{}, nil
+		}),
+		Applier:                applier,
+		CatalogVersionProvider: staticCatalogVersion(7),
+	})
+
+	_, err := submitter.SubmitCommandEntryV1(context.Background(), entry, routeMetadata("", iwire.AckRaftCommitted))
+	if !errors.Is(err, ErrRouteGroupMismatch) {
+		t.Fatalf("SubmitCommandEntryV1 err=%v want route group mismatch", err)
+	}
+	route, ok := RouteErrorMetadataOf(err)
+	if !ok {
+		t.Fatalf("RouteErrorMetadataOf ok=false err=%v", err)
+	}
+	if route.Class != RouteErrorClassMissingOwner {
+		t.Fatalf("route.Class=%q want missing_owner; err=%v", route.Class, err)
+	}
+	if route.Collection != "users" {
+		t.Fatalf("route.Collection=%q want users; err=%v", route.Collection, err)
+	}
+	if preflightCalls != 0 {
+		t.Fatalf("preflight calls=%d want 0", preflightCalls)
+	}
+	if commitCalls != 0 {
+		t.Fatalf("commit calls=%d want 0", commitCalls)
+	}
+	if got := len(applier.snapshot()); got != 0 {
+		t.Fatalf("apply calls=%d want 0", got)
+	}
+}
+
 func TestSingleGroupSubmitterAllowsMatchingRouteGroup(t *testing.T) {
 	entry := testClusterCommandEntry(t, 7)
 	applier := &recordingClusterApplier{result: raftentry.ApplyResultV1{Status: raftentry.ApplyStatusApplied, AffectedCount: 1}}

--- a/TreeDB/mongo_gateway/cluster_submitter.go
+++ b/TreeDB/mongo_gateway/cluster_submitter.go
@@ -979,6 +979,9 @@ func mongoClusterErrorFields(err error, nativeCode iwire.ErrorCode, codeName str
 	if leaderHint := mongoClusterLeaderHint(err); leaderHint != "" {
 		fields = append(fields, bson.E{Key: "treedbLeaderHint", Value: leaderHint})
 	}
+	if route, ok := treenativewire.ClusterRouteErrorMetadataOf(err); ok {
+		fields = appendMongoClusterRouteErrorFields(fields, route)
+	}
 	return fields
 }
 
@@ -995,6 +998,9 @@ func mongoClusterErrorMetadataApplies(err error, nativeCode iwire.ErrorCode, cod
 }
 
 func mongoClusterErrorClass(err error, nativeCode iwire.ErrorCode, codeName string) string {
+	if route, ok := treenativewire.ClusterRouteErrorMetadataOf(err); ok && route.Class != "" {
+		return route.Class
+	}
 	message := strings.ToLower(err.Error())
 	switch nativeCode {
 	case iwire.ErrReadOnly:
@@ -1030,8 +1036,40 @@ func mongoClusterErrorClass(err error, nativeCode iwire.ErrorCode, codeName stri
 	}
 }
 
+func appendMongoClusterRouteErrorFields(fields bson.D, route treenativewire.ClusterRouteErrorMetadata) bson.D {
+	appendString := func(key, value string) {
+		if value != "" {
+			fields = append(fields, bson.E{Key: key, Value: value})
+		}
+	}
+	appendString("treedbRouteGroup", route.GroupID)
+	appendString("treedbRouteLeaderHint", route.LeaderHint)
+	appendString("treedbRouteDatabase", route.Database)
+	appendString("treedbRouteCatalog", route.Catalog)
+	appendString("treedbRouteCollection", route.Collection)
+	appendString("treedbRouteShape", route.Shape)
+	appendString("treedbRoutePlacementMode", route.PlacementMode)
+	appendString("treedbRouteKey", route.RouteKey)
+	appendString("treedbRoutePartitionId", route.PartitionID)
+	appendString("treedbRouteLocalGroup", route.LocalGroupID)
+	if len(route.Members) != 0 {
+		members := make(bson.A, len(route.Members))
+		for i, member := range route.Members {
+			members[i] = member
+		}
+		fields = append(fields, bson.E{Key: "treedbRouteMembers", Value: members})
+	}
+	if route.TokenKnown {
+		fields = append(fields, bson.E{Key: "treedbRouteTokenKnown", Value: true})
+		fields = append(fields, bson.E{Key: "treedbRouteToken", Value: strconv.FormatUint(route.Token, 10)})
+	}
+	return fields
+}
+
 func mongoClusterRouteRejectedMessage(message string) bool {
 	return strings.Contains(message, "route group") ||
+		strings.Contains(message, "route_error_class=") ||
+		strings.Contains(message, "route_class=") ||
 		strings.Contains(message, "cluster route rejected") ||
 		strings.Contains(message, "cluster query route shape") ||
 		strings.Contains(message, "cluster route shape") ||

--- a/TreeDB/mongo_gateway/cluster_submitter.go
+++ b/TreeDB/mongo_gateway/cluster_submitter.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"net/url"
 	"strconv"
 	"strings"
 
@@ -1105,12 +1106,21 @@ func mongoClusterLeaderHint(err error) string {
 	for end < len(message) {
 		switch message[end] {
 		case ';', ',', ' ', '\t', '\n', '\r':
-			return strings.TrimSpace(message[start:end])
+			return decodeMongoClusterLeaderHint(message[start:end])
 		default:
 			end++
 		}
 	}
-	return strings.TrimSpace(message[start:end])
+	return decodeMongoClusterLeaderHint(message[start:end])
+}
+
+func decodeMongoClusterLeaderHint(value string) string {
+	value = strings.TrimSpace(value)
+	decoded, err := url.QueryUnescape(value)
+	if err != nil {
+		return value
+	}
+	return decoded
 }
 
 func mongoClusterMutationCommandError(err error) (wire.Document, error) {

--- a/TreeDB/mongo_gateway/cluster_submitter.go
+++ b/TreeDB/mongo_gateway/cluster_submitter.go
@@ -943,7 +943,7 @@ func mongoClusterRouteCommandError(err error) (wire.Document, error) {
 	} else if errors.Is(err, collections.ErrCommitAmbiguous) {
 		nativeCode = iwire.ErrCommitAmbiguous
 		code, codeName = commandCodeShutdownInProgress, "ShutdownInProgress"
-	} else if parsedNativeCode, ok := iwire.ErrorCodeOf(err); ok {
+	} else if parsedNativeCode, ok := mongoClusterNativeErrorCodeOf(err); ok {
 		nativeCode = parsedNativeCode
 		switch nativeCode {
 		case iwire.ErrUnsupportedFeature:
@@ -964,6 +964,17 @@ func mongoClusterRouteCommandError(err error) (wire.Document, error) {
 		code, codeName = commandCodeDuplicateKey, "DuplicateKey"
 	}
 	return commandErrorWithFields(code, codeName, err.Error(), mongoClusterErrorFields(err, nativeCode, codeName))
+}
+
+func mongoClusterNativeErrorCodeOf(err error) (iwire.ErrorCode, bool) {
+	if code, ok := iwire.ErrorCodeOf(err); ok {
+		return code, true
+	}
+	var wireErr *treenativewire.WireError
+	if errors.As(err, &wireErr) {
+		return wireErr.Code, true
+	}
+	return 0, false
 }
 
 func mongoClusterErrorFields(err error, nativeCode iwire.ErrorCode, codeName string) bson.D {
@@ -992,6 +1003,9 @@ func mongoClusterErrorMetadataApplies(err error, nativeCode iwire.ErrorCode, cod
 	if nativeCode != 0 ||
 		errors.Is(err, collections.ErrCommitAmbiguous) ||
 		collections.IsDuplicateKeyError(err) {
+		return true
+	}
+	if route, ok := treenativewire.ClusterRouteErrorMetadataOf(err); ok && route.Class != "" {
 		return true
 	}
 	return codeName == "WriteConcernFailed"

--- a/TreeDB/mongo_gateway/cluster_submitter.go
+++ b/TreeDB/mongo_gateway/cluster_submitter.go
@@ -5,7 +5,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"net/url"
 	"strconv"
 	"strings"
 
@@ -1087,6 +1086,11 @@ func mongoClusterLeaderHint(err error) string {
 	if err == nil {
 		return ""
 	}
+	if route, ok := treenativewire.ClusterRouteErrorMetadataOf(err); ok {
+		if leaderHint := strings.TrimSpace(route.LeaderHint); leaderHint != "" {
+			return leaderHint
+		}
+	}
 	var hinted interface {
 		ClusterLeaderHint() string
 	}
@@ -1106,21 +1110,12 @@ func mongoClusterLeaderHint(err error) string {
 	for end < len(message) {
 		switch message[end] {
 		case ';', ',', ' ', '\t', '\n', '\r':
-			return decodeMongoClusterLeaderHint(message[start:end])
+			return strings.TrimSpace(message[start:end])
 		default:
 			end++
 		}
 	}
-	return decodeMongoClusterLeaderHint(message[start:end])
-}
-
-func decodeMongoClusterLeaderHint(value string) string {
-	value = strings.TrimSpace(value)
-	decoded, err := url.QueryUnescape(value)
-	if err != nil {
-		return value
-	}
-	return decoded
+	return strings.TrimSpace(message[start:end])
 }
 
 func mongoClusterMutationCommandError(err error) (wire.Document, error) {

--- a/TreeDB/mongo_gateway/cluster_submitter_test.go
+++ b/TreeDB/mongo_gateway/cluster_submitter_test.go
@@ -2221,6 +2221,23 @@ func TestMongoClusterMutationCommandErrorDecodesRouteMetadataLeaderHint(t *testi
 	assertStringField(t, response, "treedbRouteLeaderHint", "node z")
 }
 
+func TestMongoClusterMutationCommandErrorSurfacesRemoteWireRouteMetadata(t *testing.T) {
+	clusterErr := &treenativewire.WireError{
+		Code:    iwire.ErrReadOnly,
+		Message: "cluster route rejected; route_error_class=remote_owner_redirect route_group=group+z leader_hint=node+z",
+	}
+	response, err := mongoClusterMutationCommandError(clusterErr)
+	if err != nil {
+		t.Fatalf("mongoClusterMutationCommandError: %v", err)
+	}
+	assertCommandError(t, response, "NotWritablePrimary")
+	assertBool(t, response, "treedbClusterError", true)
+	assertStringField(t, response, "treedbErrorClass", "remote_owner_redirect")
+	assertStringField(t, response, "treedbLeaderHint", "node z")
+	assertStringField(t, response, "treedbRouteGroup", "group z")
+	assertStringField(t, response, "treedbRouteLeaderHint", "node z")
+}
+
 func TestMongoClusterMutationCommandErrorClassifiesQueryRouteAsRouteRejected(t *testing.T) {
 	clusterErr := &iwire.ProtocolError{Code: iwire.ErrReadOnly, Reason: "cluster query route shape is not supported before scatter planning"}
 	response, err := mongoClusterMutationCommandError(clusterErr)

--- a/TreeDB/mongo_gateway/cluster_submitter_test.go
+++ b/TreeDB/mongo_gateway/cluster_submitter_test.go
@@ -1,6 +1,7 @@
 package mongogateway
 
 import (
+	"bytes"
 	"context"
 	"encoding/binary"
 	"errors"
@@ -159,6 +160,38 @@ func (p *mongoStaticClusterRouteProvider) ClusterRoute(ctx context.Context, req 
 }
 
 func (p *mongoStaticClusterRouteProvider) snapshotRoutes() []treenativewire.ClusterRouteRequest {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return append([]treenativewire.ClusterRouteRequest(nil), p.routes...)
+}
+
+type mongoRemoteOwnerRouteProvider struct {
+	mu     sync.Mutex
+	err    error
+	routes []treenativewire.ClusterRouteRequest
+}
+
+func (p *mongoRemoteOwnerRouteProvider) ClusterRoute(ctx context.Context, req treenativewire.ClusterRouteRequest) (treenativewire.ClusterRouteTarget, error) {
+	p.mu.Lock()
+	p.routes = append(p.routes, req)
+	p.mu.Unlock()
+	if p.err != nil {
+		return treenativewire.ClusterRouteTarget{}, p.err
+	}
+	return treenativewire.ClusterRouteTarget{
+		GroupID:       "group-z",
+		Members:       []string{"node-z", "node-y"},
+		LeaderHint:    "node-z",
+		PlacementMode: string(raftplacement.PlacementModeRingV1),
+		RouteKey:      string(raftplacement.RouteKeyDocumentIDV1),
+		Shape:         treenativewire.ClusterRouteShapeToken,
+		TokenKnown:    req.TokenKnown,
+		Token:         req.Token,
+		PartitionID:   "p9",
+	}, nil
+}
+
+func (p *mongoRemoteOwnerRouteProvider) snapshotRoutes() []treenativewire.ClusterRouteRequest {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	return append([]treenativewire.ClusterRouteRequest(nil), p.routes...)
@@ -356,6 +389,22 @@ func assertStringField(tb testing.TB, doc wire.Document, key, want string) {
 	if !ok || got != want {
 		tb.Fatalf("%s=%q typeOK=%v want %q", key, got, ok, want)
 	}
+}
+
+func assertMongoRemoteOwnerRouteFields(tb testing.TB, doc wire.Document) {
+	tb.Helper()
+	assertBool(tb, doc, "treedbClusterError", true)
+	assertStringField(tb, doc, "treedbErrorClass", "remote_owner_redirect")
+	assertStringField(tb, doc, "treedbLeaderHint", "node-z")
+	assertStringField(tb, doc, "treedbRouteGroup", "group-z")
+	assertStringField(tb, doc, "treedbRouteLeaderHint", "node-z")
+	assertStringField(tb, doc, "treedbRouteDatabase", "app")
+	assertStringField(tb, doc, "treedbRouteCatalog", "default")
+	assertStringField(tb, doc, "treedbRouteCollection", "users")
+	assertStringField(tb, doc, "treedbRouteShape", string(treenativewire.ClusterRouteShapeToken))
+	assertStringField(tb, doc, "treedbRoutePlacementMode", string(raftplacement.PlacementModeRingV1))
+	assertStringField(tb, doc, "treedbRouteKey", string(raftplacement.RouteKeyDocumentIDV1))
+	assertStringField(tb, doc, "treedbRoutePartitionId", "p9")
 }
 
 func assertNoField(tb testing.TB, doc wire.Document, key string) {
@@ -1222,8 +1271,9 @@ func TestMongoGroupRoutedDispatcherRejectsUnknownGroupBeforeSubmit(t *testing.T)
 	assertCommandError(t, response, "NotWritablePrimary")
 	assertErrmsgContains(t, response, "route target unknown")
 	assertBool(t, response, "treedbClusterError", true)
-	assertStringField(t, response, "treedbErrorClass", "route_rejected")
+	assertStringField(t, response, "treedbErrorClass", "remote_owner_redirect")
 	assertStringField(t, response, "treedbLeaderHint", "node-z")
+	assertStringField(t, response, "treedbRouteGroup", "group-z")
 	users, err := server.Collections.OpenCollection("app.users")
 	if err != nil {
 		t.Fatalf("OpenCollection app.users: %v", err)
@@ -1240,6 +1290,120 @@ func TestMongoGroupRoutedDispatcherRejectsUnknownGroupBeforeSubmit(t *testing.T)
 	}
 	if calls := groupB.snapshotCalls(); len(calls) != 0 {
 		t.Fatalf("group-b calls=%d want 0", len(calls))
+	}
+}
+
+func TestMongoGroupRoutedDispatcherUnknownOwnerErrorsBeforeSubmit(t *testing.T) {
+	token := mongoClusterRouteTokenForValue(t, "u1")
+	provider := &mongoStaticClusterRouteProvider{
+		target: treenativewire.ClusterRouteTarget{
+			GroupID:       "group-z",
+			PlacementMode: string(raftplacement.PlacementModeRingV1),
+			RouteKey:      string(raftplacement.RouteKeyDocumentIDV1),
+			Shape:         treenativewire.ClusterRouteShapeToken,
+			TokenKnown:    true,
+			Token:         token,
+			PartitionID:   "p0",
+		},
+	}
+	server, groupA, groupB := newMongoGroupRoutedDispatcherTestServer(t, provider)
+	response := serveCommand(t, server, 336313, bson.D{
+		{Key: "insert", Value: "users"},
+		{Key: "documents", Value: bson.A{bson.D{{Key: "_id", Value: "u1"}, {Key: "name", Value: "Ada"}}}},
+		{Key: "$db", Value: "app"},
+	})
+	assertCommandError(t, response, "NotWritablePrimary")
+	assertErrmsgContains(t, response, "route target unknown")
+	assertBool(t, response, "treedbClusterError", true)
+	assertStringField(t, response, "treedbErrorClass", "unknown_owner")
+	assertStringField(t, response, "treedbRouteGroup", "group-z")
+	assertNoField(t, response, "treedbLeaderHint")
+	assertNoField(t, response, "treedbRouteLeaderHint")
+	users, err := server.Collections.OpenCollection("app.users")
+	if err != nil {
+		t.Fatalf("OpenCollection app.users: %v", err)
+	}
+	key, err := encodePrimaryKey(mustRawValue(t, "u1"))
+	if err != nil {
+		t.Fatalf("encode primary key: %v", err)
+	}
+	if got, err := users.Get(key); err != nil || got != nil {
+		t.Fatalf("local app.users Get(u1)=%v err=%v want missing document", bson.Raw(got), err)
+	}
+	if calls := groupA.snapshotCalls(); len(calls) != 0 {
+		t.Fatalf("group-a calls=%d want 0", len(calls))
+	}
+	if calls := groupB.snapshotCalls(); len(calls) != 0 {
+		t.Fatalf("group-b calls=%d want 0", len(calls))
+	}
+}
+
+func TestMongoGroupRoutedDispatcherRemoteOwnerErrorsForMutations(t *testing.T) {
+	provider := &mongoRemoteOwnerRouteProvider{}
+	server, groupA, groupB := newMongoGroupRoutedDispatcherTestServer(t, provider)
+	users, err := server.Collections.OpenCollection("app.users")
+	if err != nil {
+		t.Fatalf("OpenCollection app.users: %v", err)
+	}
+	key1, err := encodePrimaryKey(mustRawValue(t, "u1"))
+	if err != nil {
+		t.Fatalf("encode u1 primary key: %v", err)
+	}
+	original := mustDocument(t, bson.D{{Key: "_id", Value: "u1"}, {Key: "name", Value: "Ada"}})
+	if _, err := users.InsertBatchValidatedBSON([][]byte{key1}, [][]byte{original}); err != nil {
+		t.Fatalf("seed InsertBatchValidatedBSON: %v", err)
+	}
+
+	insertResponse := serveCommand(t, server, 336304, bson.D{
+		{Key: "insert", Value: "users"},
+		{Key: "documents", Value: bson.A{bson.D{{Key: "_id", Value: "u2"}, {Key: "name", Value: "Grace"}}}},
+		{Key: "$db", Value: "app"},
+	})
+	assertCommandError(t, insertResponse, "NotWritablePrimary")
+	assertErrmsgContains(t, insertResponse, "route target unknown")
+	assertMongoRemoteOwnerRouteFields(t, insertResponse)
+	key2, err := encodePrimaryKey(mustRawValue(t, "u2"))
+	if err != nil {
+		t.Fatalf("encode u2 primary key: %v", err)
+	}
+	if got, err := users.Get(key2); err != nil || got != nil {
+		t.Fatalf("local app.users Get(u2)=%v err=%v want missing document", bson.Raw(got), err)
+	}
+
+	updateResponse := serveCommand(t, server, 336305, bson.D{
+		{Key: "update", Value: "users"},
+		{Key: "updates", Value: bson.A{bson.D{
+			{Key: "q", Value: bson.D{{Key: "_id", Value: "u1"}}},
+			{Key: "u", Value: bson.D{{Key: "$set", Value: bson.D{{Key: "name", Value: "Grace"}}}}},
+		}}},
+		{Key: "$db", Value: "app"},
+	})
+	assertCommandError(t, updateResponse, "NotWritablePrimary")
+	assertMongoRemoteOwnerRouteFields(t, updateResponse)
+
+	deleteResponse := serveCommand(t, server, 336306, bson.D{
+		{Key: "delete", Value: "users"},
+		{Key: "deletes", Value: bson.A{bson.D{{Key: "q", Value: bson.D{{Key: "_id", Value: "u1"}}}, {Key: "limit", Value: int32(1)}}}},
+		{Key: "$db", Value: "app"},
+	})
+	assertCommandError(t, deleteResponse, "NotWritablePrimary")
+	assertMongoRemoteOwnerRouteFields(t, deleteResponse)
+
+	got, err := users.Get(key1)
+	if err != nil {
+		t.Fatalf("local app.users Get(u1): %v", err)
+	}
+	if !bytes.Equal(got, original) {
+		t.Fatalf("local app.users u1 changed after remote-owner mutations: got %v want %v", bson.Raw(got), bson.Raw(original))
+	}
+	if calls := groupA.snapshotCalls(); len(calls) != 0 {
+		t.Fatalf("group-a calls=%d want 0", len(calls))
+	}
+	if calls := groupB.snapshotCalls(); len(calls) != 0 {
+		t.Fatalf("group-b calls=%d want 0", len(calls))
+	}
+	if routes := provider.snapshotRoutes(); len(routes) != 3 {
+		t.Fatalf("route calls=%d want insert+update+delete", len(routes))
 	}
 }
 
@@ -1913,8 +2077,9 @@ func TestClusterSubmitterConcreteBridgeRouteGroupMismatchNotWritablePrimary(t *t
 	assertCommandError(t, response, "NotWritablePrimary")
 	assertErrmsgContains(t, response, "route group")
 	assertBool(t, response, "treedbClusterError", true)
-	assertStringField(t, response, "treedbErrorClass", "route_rejected")
+	assertStringField(t, response, "treedbErrorClass", "remote_owner_redirect")
 	assertStringField(t, response, "treedbLeaderHint", "node-c")
+	assertStringField(t, response, "treedbRouteGroup", "group-b")
 	if _, err := server.Collections.OpenCollection("app.users"); !errors.Is(err, collections.ErrCollectionNotFound) {
 		t.Fatalf("OpenCollection app.users after route mismatch err=%v want collection not found", err)
 	}

--- a/TreeDB/mongo_gateway/cluster_submitter_test.go
+++ b/TreeDB/mongo_gateway/cluster_submitter_test.go
@@ -2197,7 +2197,7 @@ func TestMongoClusterMutationCommandErrorClassifiesLeaderHintBeforeRouteText(t *
 	assertStringField(t, response, "treedbLeaderHint", "router-1:27017")
 }
 
-func TestMongoClusterMutationCommandErrorDecodesEscapedLeaderHint(t *testing.T) {
+func TestMongoClusterMutationCommandErrorPreservesRawLeaderHint(t *testing.T) {
 	clusterErr := &iwire.ProtocolError{Code: iwire.ErrReadOnly, Reason: "not leader; leader_hint=node+z"}
 	response, err := mongoClusterMutationCommandError(clusterErr)
 	if err != nil {
@@ -2205,7 +2205,20 @@ func TestMongoClusterMutationCommandErrorDecodesEscapedLeaderHint(t *testing.T) 
 	}
 	assertCommandError(t, response, "NotWritablePrimary")
 	assertStringField(t, response, "treedbErrorClass", "not_leader")
+	assertStringField(t, response, "treedbLeaderHint", "node+z")
+}
+
+func TestMongoClusterMutationCommandErrorDecodesRouteMetadataLeaderHint(t *testing.T) {
+	clusterErr := &iwire.ProtocolError{Code: iwire.ErrReadOnly, Reason: "cluster route rejected; route_error_class=remote_owner_redirect route_group=group+z leader_hint=node+z"}
+	response, err := mongoClusterMutationCommandError(clusterErr)
+	if err != nil {
+		t.Fatalf("mongoClusterMutationCommandError: %v", err)
+	}
+	assertCommandError(t, response, "NotWritablePrimary")
+	assertStringField(t, response, "treedbErrorClass", "remote_owner_redirect")
 	assertStringField(t, response, "treedbLeaderHint", "node z")
+	assertStringField(t, response, "treedbRouteGroup", "group z")
+	assertStringField(t, response, "treedbRouteLeaderHint", "node z")
 }
 
 func TestMongoClusterMutationCommandErrorClassifiesQueryRouteAsRouteRejected(t *testing.T) {

--- a/TreeDB/mongo_gateway/cluster_submitter_test.go
+++ b/TreeDB/mongo_gateway/cluster_submitter_test.go
@@ -1338,6 +1338,50 @@ func TestMongoGroupRoutedDispatcherUnknownOwnerErrorsBeforeSubmit(t *testing.T) 
 	}
 }
 
+func TestMongoGroupRoutedDispatcherMissingOwnerErrorsBeforeSubmit(t *testing.T) {
+	token := mongoClusterRouteTokenForValue(t, "u1")
+	provider := &mongoStaticClusterRouteProvider{
+		target: treenativewire.ClusterRouteTarget{
+			PlacementMode: string(raftplacement.PlacementModeRingV1),
+			RouteKey:      string(raftplacement.RouteKeyDocumentIDV1),
+			Shape:         treenativewire.ClusterRouteShapeToken,
+			TokenKnown:    true,
+			Token:         token,
+			PartitionID:   "p0",
+		},
+	}
+	server, groupA, groupB := newMongoGroupRoutedDispatcherTestServer(t, provider)
+	response := serveCommand(t, server, 336314, bson.D{
+		{Key: "insert", Value: "users"},
+		{Key: "documents", Value: bson.A{bson.D{{Key: "_id", Value: "u1"}, {Key: "name", Value: "Ada"}}}},
+		{Key: "$db", Value: "app"},
+	})
+	assertCommandError(t, response, "NotWritablePrimary")
+	assertErrmsgContains(t, response, "route target missing")
+	assertBool(t, response, "treedbClusterError", true)
+	assertStringField(t, response, "treedbErrorClass", "missing_owner")
+	assertNoField(t, response, "treedbRouteGroup")
+	assertNoField(t, response, "treedbLeaderHint")
+	assertNoField(t, response, "treedbRouteLeaderHint")
+	users, err := server.Collections.OpenCollection("app.users")
+	if err != nil {
+		t.Fatalf("OpenCollection app.users: %v", err)
+	}
+	key, err := encodePrimaryKey(mustRawValue(t, "u1"))
+	if err != nil {
+		t.Fatalf("encode primary key: %v", err)
+	}
+	if got, err := users.Get(key); err != nil || got != nil {
+		t.Fatalf("local app.users Get(u1)=%v err=%v want missing document", bson.Raw(got), err)
+	}
+	if calls := groupA.snapshotCalls(); len(calls) != 0 {
+		t.Fatalf("group-a calls=%d want 0", len(calls))
+	}
+	if calls := groupB.snapshotCalls(); len(calls) != 0 {
+		t.Fatalf("group-b calls=%d want 0", len(calls))
+	}
+}
+
 func TestMongoGroupRoutedDispatcherRemoteOwnerErrorsForMutations(t *testing.T) {
 	provider := &mongoRemoteOwnerRouteProvider{}
 	server, groupA, groupB := newMongoGroupRoutedDispatcherTestServer(t, provider)

--- a/TreeDB/mongo_gateway/cluster_submitter_test.go
+++ b/TreeDB/mongo_gateway/cluster_submitter_test.go
@@ -2197,6 +2197,17 @@ func TestMongoClusterMutationCommandErrorClassifiesLeaderHintBeforeRouteText(t *
 	assertStringField(t, response, "treedbLeaderHint", "router-1:27017")
 }
 
+func TestMongoClusterMutationCommandErrorDecodesEscapedLeaderHint(t *testing.T) {
+	clusterErr := &iwire.ProtocolError{Code: iwire.ErrReadOnly, Reason: "not leader; leader_hint=node+z"}
+	response, err := mongoClusterMutationCommandError(clusterErr)
+	if err != nil {
+		t.Fatalf("mongoClusterMutationCommandError: %v", err)
+	}
+	assertCommandError(t, response, "NotWritablePrimary")
+	assertStringField(t, response, "treedbErrorClass", "not_leader")
+	assertStringField(t, response, "treedbLeaderHint", "node z")
+}
+
 func TestMongoClusterMutationCommandErrorClassifiesQueryRouteAsRouteRejected(t *testing.T) {
 	clusterErr := &iwire.ProtocolError{Code: iwire.ErrReadOnly, Reason: "cluster query route shape is not supported before scatter planning"}
 	response, err := mongoClusterMutationCommandError(clusterErr)

--- a/TreeDB/mongo_gateway/cluster_submitter_test.go
+++ b/TreeDB/mongo_gateway/cluster_submitter_test.go
@@ -391,7 +391,28 @@ func assertStringField(tb testing.TB, doc wire.Document, key, want string) {
 	}
 }
 
-func assertMongoRemoteOwnerRouteFields(tb testing.TB, doc wire.Document) {
+func assertStringArrayField(tb testing.TB, doc wire.Document, key string, want []string) {
+	tb.Helper()
+	raw, ok := bson.Raw(doc).Lookup(key).ArrayOK()
+	if !ok {
+		tb.Fatalf("%s missing or non-array", key)
+	}
+	values, err := raw.Values()
+	if err != nil {
+		tb.Fatalf("%s values: %v", key, err)
+	}
+	if len(values) != len(want) {
+		tb.Fatalf("%s len=%d want %d", key, len(values), len(want))
+	}
+	for i, value := range values {
+		got, ok := value.StringValueOK()
+		if !ok || got != want[i] {
+			tb.Fatalf("%s[%d]=%q typeOK=%v want %q", key, i, got, ok, want[i])
+		}
+	}
+}
+
+func assertMongoRemoteOwnerRouteFields(tb testing.TB, doc wire.Document, wantToken uint64) {
 	tb.Helper()
 	assertBool(tb, doc, "treedbClusterError", true)
 	assertStringField(tb, doc, "treedbErrorClass", "remote_owner_redirect")
@@ -405,6 +426,9 @@ func assertMongoRemoteOwnerRouteFields(tb testing.TB, doc wire.Document) {
 	assertStringField(tb, doc, "treedbRoutePlacementMode", string(raftplacement.PlacementModeRingV1))
 	assertStringField(tb, doc, "treedbRouteKey", string(raftplacement.RouteKeyDocumentIDV1))
 	assertStringField(tb, doc, "treedbRoutePartitionId", "p9")
+	assertStringArrayField(tb, doc, "treedbRouteMembers", []string{"node-z", "node-y"})
+	assertBool(tb, doc, "treedbRouteTokenKnown", true)
+	assertStringField(tb, doc, "treedbRouteToken", fmt.Sprintf("%d", wantToken))
 }
 
 func assertNoField(tb testing.TB, doc wire.Document, key string) {
@@ -1405,7 +1429,7 @@ func TestMongoGroupRoutedDispatcherRemoteOwnerErrorsForMutations(t *testing.T) {
 	})
 	assertCommandError(t, insertResponse, "NotWritablePrimary")
 	assertErrmsgContains(t, insertResponse, "route target unknown")
-	assertMongoRemoteOwnerRouteFields(t, insertResponse)
+	assertMongoRemoteOwnerRouteFields(t, insertResponse, mongoClusterRouteTokenForValue(t, "u2"))
 	key2, err := encodePrimaryKey(mustRawValue(t, "u2"))
 	if err != nil {
 		t.Fatalf("encode u2 primary key: %v", err)
@@ -1423,7 +1447,7 @@ func TestMongoGroupRoutedDispatcherRemoteOwnerErrorsForMutations(t *testing.T) {
 		{Key: "$db", Value: "app"},
 	})
 	assertCommandError(t, updateResponse, "NotWritablePrimary")
-	assertMongoRemoteOwnerRouteFields(t, updateResponse)
+	assertMongoRemoteOwnerRouteFields(t, updateResponse, mongoClusterRouteTokenForValue(t, "u1"))
 
 	deleteResponse := serveCommand(t, server, 336306, bson.D{
 		{Key: "delete", Value: "users"},
@@ -1431,7 +1455,7 @@ func TestMongoGroupRoutedDispatcherRemoteOwnerErrorsForMutations(t *testing.T) {
 		{Key: "$db", Value: "app"},
 	})
 	assertCommandError(t, deleteResponse, "NotWritablePrimary")
-	assertMongoRemoteOwnerRouteFields(t, deleteResponse)
+	assertMongoRemoteOwnerRouteFields(t, deleteResponse, mongoClusterRouteTokenForValue(t, "u1"))
 
 	got, err := users.Get(key1)
 	if err != nil {

--- a/TreeDB/nativewire/cluster_raft_submitter.go
+++ b/TreeDB/nativewire/cluster_raft_submitter.go
@@ -217,36 +217,55 @@ func nativeErrorForRaftClusterSubmit(err error) error {
 
 func clusterProtocolError(code iwire.ErrorCode, err error) error {
 	protocolErr := protocolError(code, "%v", err)
-	if leaderHint := clusterLeaderHint(err); leaderHint != "" {
-		return &clusterLeaderHintProtocolError{err: protocolErr, leaderHint: leaderHint}
+	route, hasRoute := ClusterRouteErrorMetadataOf(err)
+	leaderHint := clusterLeaderHint(err)
+	if leaderHint == "" {
+		leaderHint = route.LeaderHint
+	}
+	if hasRoute || leaderHint != "" {
+		return &clusterRouteProtocolError{
+			err:        protocolErr,
+			leaderHint: leaderHint,
+			route:      route,
+			hasRoute:   hasRoute,
+		}
 	}
 	return protocolErr
 }
 
-type clusterLeaderHintProtocolError struct {
+type clusterRouteProtocolError struct {
 	err        error
 	leaderHint string
+	route      ClusterRouteErrorMetadata
+	hasRoute   bool
 }
 
-func (e *clusterLeaderHintProtocolError) Error() string {
+func (e *clusterRouteProtocolError) Error() string {
 	if e == nil || e.err == nil {
 		return ""
 	}
 	return e.err.Error()
 }
 
-func (e *clusterLeaderHintProtocolError) Unwrap() error {
+func (e *clusterRouteProtocolError) Unwrap() error {
 	if e == nil {
 		return nil
 	}
 	return e.err
 }
 
-func (e *clusterLeaderHintProtocolError) ClusterLeaderHint() string {
+func (e *clusterRouteProtocolError) ClusterLeaderHint() string {
 	if e == nil {
 		return ""
 	}
 	return e.leaderHint
+}
+
+func (e *clusterRouteProtocolError) ClusterRouteErrorMetadata() ClusterRouteErrorMetadata {
+	if e == nil || !e.hasRoute {
+		return ClusterRouteErrorMetadata{}
+	}
+	return e.route.Clone()
 }
 
 func clusterLeaderHint(err error) string {

--- a/TreeDB/nativewire/cluster_submitter.go
+++ b/TreeDB/nativewire/cluster_submitter.go
@@ -335,7 +335,7 @@ func PreflightClusterRoute(ctx context.Context, submitter ClusterSubmitter, requ
 		if reason == "" {
 			reason = "cluster route target missing group id"
 		}
-		return ClusterRouteTarget{}, true, protocolError(iwire.ErrReadOnly, "%s", reason)
+		return ClusterRouteTarget{}, true, clusterRouteTargetProtocolError(iwire.ErrReadOnly, request, target, "missing_owner", reason)
 	}
 	switch target.PlacementMode {
 	case "collection":
@@ -417,6 +417,47 @@ func clusterTokenBatchRouteRejection(request ClusterRouteRequest, target Cluster
 		action = "fanout"
 	}
 	return "cluster token/ring multi-id write requires " + action + " before submit: route_class=" + class + " token_count=" + strconv.Itoa(len(request.Tokens))
+}
+
+func clusterRouteTargetProtocolError(code iwire.ErrorCode, request ClusterRouteRequest, target ClusterRouteTarget, class, reason string) error {
+	route := clusterRouteErrorMetadataFromTarget(request, target, class)
+	if fields := clusterRouteErrorMetadataFields(route); fields != "" {
+		reason += "; " + fields
+	}
+	return &clusterRouteProtocolError{
+		err:        protocolError(code, "%s", reason),
+		leaderHint: route.LeaderHint,
+		route:      route,
+		hasRoute:   true,
+	}
+}
+
+func clusterRouteErrorMetadataFromTarget(request ClusterRouteRequest, target ClusterRouteTarget, class string) ClusterRouteErrorMetadata {
+	shape := string(target.Shape)
+	if shape == "" {
+		shape = string(request.Shape)
+	}
+	tokenKnown := target.TokenKnown
+	token := target.Token
+	if !tokenKnown && request.TokenKnown {
+		tokenKnown = true
+		token = request.Token
+	}
+	return ClusterRouteErrorMetadata{
+		Class:         class,
+		Database:      request.Database,
+		Catalog:       request.Catalog,
+		Collection:    request.Collection,
+		Shape:         shape,
+		GroupID:       target.GroupID,
+		Members:       append([]string(nil), target.Members...),
+		LeaderHint:    target.LeaderHint,
+		PlacementMode: target.PlacementMode,
+		RouteKey:      target.RouteKey,
+		TokenKnown:    tokenKnown,
+		Token:         token,
+		PartitionID:   target.PartitionID,
+	}
 }
 
 func normalizeClusterRouteShape(shape ClusterRouteShape) ClusterRouteShape {

--- a/TreeDB/nativewire/cluster_submitter_test.go
+++ b/TreeDB/nativewire/cluster_submitter_test.go
@@ -500,6 +500,7 @@ func TestClusterRouteErrorMetadataOfIgnoresLeaderOnlyProtocolWrapper(t *testing.
 func TestClusterRouteErrorMetadataOfFallsThroughLeaderOnlyProtocolWrapper(t *testing.T) {
 	err := &clusterRouteProtocolError{
 		err: &WireError{
+			Code:    iwire.ErrReadOnly,
 			Message: "cluster route rejected; route_error_class=remote_owner_redirect route_group=group+z leader_hint=node+z",
 		},
 		leaderHint: "node-z",
@@ -514,6 +515,16 @@ func TestClusterRouteErrorMetadataOfFallsThroughLeaderOnlyProtocolWrapper(t *tes
 	}
 }
 
+func TestClusterRouteErrorMetadataOfIgnoresNonReadOnlyWireRouteMetadata(t *testing.T) {
+	err := &WireError{
+		Code:    iwire.ErrDuplicateDocumentID,
+		Message: "duplicate key route_error_class=remote_owner_redirect route_group=group-z leader_hint=node-z",
+	}
+	if metadata, ok := ClusterRouteErrorMetadataOf(err); ok {
+		t.Fatalf("ClusterRouteErrorMetadataOf ok=true metadata=%+v want false for non-read-only wire error", metadata)
+	}
+}
+
 func TestClusterRouteErrorMetadataOfParsesProtocolRouteMetadata(t *testing.T) {
 	err := &iwire.ProtocolError{
 		Code:   iwire.ErrReadOnly,
@@ -525,6 +536,16 @@ func TestClusterRouteErrorMetadataOfParsesProtocolRouteMetadata(t *testing.T) {
 	}
 	if metadata.Class != "remote_owner_redirect" || metadata.GroupID != "group z" || metadata.LeaderHint != "node z" {
 		t.Fatalf("ClusterRouteErrorMetadataOf metadata=%+v want parsed protocol route metadata", metadata)
+	}
+}
+
+func TestClusterRouteErrorMetadataOfIgnoresNonReadOnlyProtocolRouteMetadata(t *testing.T) {
+	err := &iwire.ProtocolError{
+		Code:   iwire.ErrDuplicateDocumentID,
+		Reason: "duplicate key route_error_class=remote_owner_redirect route_group=group-z leader_hint=node-z",
+	}
+	if metadata, ok := ClusterRouteErrorMetadataOf(err); ok {
+		t.Fatalf("ClusterRouteErrorMetadataOf ok=true metadata=%+v want false for non-read-only protocol error", metadata)
 	}
 }
 

--- a/TreeDB/nativewire/cluster_submitter_test.go
+++ b/TreeDB/nativewire/cluster_submitter_test.go
@@ -449,6 +449,43 @@ func assertNativeRemoteOwnerRouteError(tb testing.TB, err error, collection stri
 	}
 }
 
+func TestClusterRouteErrorMetadataFieldsPreserveWhitespaceAcrossWireText(t *testing.T) {
+	want := ClusterRouteErrorMetadata{
+		Class:         "remote_owner_redirect",
+		Database:      "sales db",
+		Catalog:       "default catalog",
+		Collection:    "sales archive",
+		Shape:         string(ClusterRouteShapeToken),
+		GroupID:       "group z",
+		Members:       []string{"node z", "node y"},
+		LeaderHint:    "node z",
+		PlacementMode: string(raftplacement.PlacementModeRingV1),
+		RouteKey:      string(raftplacement.RouteKeyDocumentIDV1),
+		TokenKnown:    true,
+		Token:         42,
+		PartitionID:   "partition 9",
+		LocalGroupID:  "group local",
+	}
+	fields := clusterRouteErrorMetadataFields(want)
+	got, ok := parseClusterRouteErrorMetadata("cluster route rejected; " + fields)
+	if !ok {
+		t.Fatalf("parseClusterRouteErrorMetadata ok=false fields=%q", fields)
+	}
+	if got.Class != want.Class ||
+		got.Database != want.Database ||
+		got.Catalog != want.Catalog ||
+		got.Collection != want.Collection ||
+		got.GroupID != want.GroupID ||
+		got.LeaderHint != want.LeaderHint ||
+		got.PartitionID != want.PartitionID ||
+		got.LocalGroupID != want.LocalGroupID ||
+		len(got.Members) != len(want.Members) ||
+		got.Members[0] != want.Members[0] ||
+		got.Members[1] != want.Members[1] {
+		t.Fatalf("route metadata roundtrip=%+v want %+v fields=%q", got, want, fields)
+	}
+}
+
 func TestClusterAdmissionMissingProviderFailsClosed(t *testing.T) {
 	err := AdmitClusterMutation(context.Background(), noAdmissionClusterSubmitter{})
 	if nativeCodeOf(err) != iwire.ErrDurabilityUnavailable {

--- a/TreeDB/nativewire/cluster_submitter_test.go
+++ b/TreeDB/nativewire/cluster_submitter_test.go
@@ -227,6 +227,38 @@ func (p *staticClusterRouteProvider) snapshotRoutes() []ClusterRouteRequest {
 	return append([]ClusterRouteRequest(nil), p.routes...)
 }
 
+type remoteOwnerRouteProvider struct {
+	mu     sync.Mutex
+	err    error
+	routes []ClusterRouteRequest
+}
+
+func (p *remoteOwnerRouteProvider) ClusterRoute(ctx context.Context, req ClusterRouteRequest) (ClusterRouteTarget, error) {
+	p.mu.Lock()
+	p.routes = append(p.routes, req)
+	p.mu.Unlock()
+	if p.err != nil {
+		return ClusterRouteTarget{}, p.err
+	}
+	return ClusterRouteTarget{
+		GroupID:       "group-z",
+		Members:       []string{"node-z", "node-y"},
+		LeaderHint:    "node-z",
+		PlacementMode: string(raftplacement.PlacementModeRingV1),
+		RouteKey:      string(raftplacement.RouteKeyDocumentIDV1),
+		Shape:         ClusterRouteShapeToken,
+		TokenKnown:    req.TokenKnown,
+		Token:         req.Token,
+		PartitionID:   "p9",
+	}, nil
+}
+
+func (p *remoteOwnerRouteProvider) snapshotRoutes() []ClusterRouteRequest {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return append([]ClusterRouteRequest(nil), p.routes...)
+}
+
 type placementRouteClusterSubmitter struct {
 	*fakeClusterSubmitter
 
@@ -387,6 +419,33 @@ func assertNativeClusterTokenRouteMetadata(tb testing.TB, call fakeClusterSubmit
 	}
 	if !meta.ClusterRouteTokenKnown || meta.ClusterRouteToken != token || meta.ClusterRoutePartitionID != partition {
 		tb.Fatalf("metadata token known/token/partition=%v/%d/%q want true/%d/%q", meta.ClusterRouteTokenKnown, meta.ClusterRouteToken, meta.ClusterRoutePartitionID, token, partition)
+	}
+}
+
+func assertNativeRemoteOwnerRouteError(tb testing.TB, err error, collection string) {
+	tb.Helper()
+	if !isRemoteError(err, iwire.ErrReadOnly) {
+		tb.Fatalf("err=%v want read-only remote route error", err)
+	}
+	route, ok := ClusterRouteErrorMetadataOf(err)
+	if !ok {
+		tb.Fatalf("ClusterRouteErrorMetadataOf ok=false err=%v", err)
+	}
+	if route.Class != "remote_owner_redirect" ||
+		route.GroupID != "group-z" ||
+		route.LeaderHint != "node-z" ||
+		route.Database != "default" ||
+		route.Catalog != "default" ||
+		route.Collection != collection ||
+		route.Shape != string(ClusterRouteShapeToken) ||
+		route.PlacementMode != string(raftplacement.PlacementModeRingV1) ||
+		route.RouteKey != string(raftplacement.RouteKeyDocumentIDV1) ||
+		!route.TokenKnown ||
+		route.PartitionID != "p9" {
+		tb.Fatalf("route metadata=%+v want remote owner redirect for group-z/node-z %s token p9", route, collection)
+	}
+	if len(route.Members) != 2 || route.Members[0] != "node-z" || route.Members[1] != "node-y" {
+		tb.Fatalf("route members=%v want [node-z node-y]", route.Members)
 	}
 }
 
@@ -2549,6 +2608,103 @@ func TestRaftClusterSubmitterGroupRoutedDispatcherRejectsUnknownGroupBeforeSubmi
 	}
 	if calls := groupB.snapshotCalls(); len(calls) != 0 {
 		t.Fatalf("group-b calls=%d want 0", len(calls))
+	}
+}
+
+func TestRaftClusterSubmitterGroupRoutedDispatcherUnknownOwnerErrorsBeforeSubmit(t *testing.T) {
+	token := raftplacement.DocumentIDTokenV1([]byte("u1"))
+	provider := &staticClusterRouteProvider{
+		target: ClusterRouteTarget{
+			GroupID:       "group-z",
+			PlacementMode: string(raftplacement.PlacementModeRingV1),
+			RouteKey:      string(raftplacement.RouteKeyDocumentIDV1),
+			Shape:         ClusterRouteShapeToken,
+			TokenKnown:    true,
+			Token:         token,
+			PartitionID:   "p0",
+		},
+	}
+	client, groupA, groupB, _, _ := serveGroupRoutedRaftClusterBridgePipe(t, provider)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := client.Hello(ctx); err != nil {
+		t.Fatalf("Hello: %v", err)
+	}
+	_, err := client.InsertBatch(ctx, "users", collections.DocumentFormatJSON, [][]byte{[]byte("u1")}, [][]byte{[]byte(`{"name":"Ada"}`)}, AckVisible)
+	if !isRemoteError(err, iwire.ErrReadOnly) || !strings.Contains(err.Error(), "route target unknown") {
+		t.Fatalf("InsertBatch unknown owner err=%v want read-only route target unknown", err)
+	}
+	route, ok := ClusterRouteErrorMetadataOf(err)
+	if !ok {
+		t.Fatalf("ClusterRouteErrorMetadataOf ok=false err=%v", err)
+	}
+	if route.Class != "unknown_owner" || route.GroupID != "group-z" || route.LeaderHint != "" {
+		t.Fatalf("route metadata=%+v want unknown owner group-z without leader hint", route)
+	}
+	if calls := groupA.snapshotCalls(); len(calls) != 0 {
+		t.Fatalf("group-a calls=%d want 0", len(calls))
+	}
+	if calls := groupB.snapshotCalls(); len(calls) != 0 {
+		t.Fatalf("group-b calls=%d want 0", len(calls))
+	}
+}
+
+func TestRaftClusterSubmitterGroupRoutedDispatcherRemoteOwnerErrorsForMutations(t *testing.T) {
+	provider := &remoteOwnerRouteProvider{}
+	client, groupA, groupB, mgr, _ := serveGroupRoutedRaftClusterBridgePipe(t, provider)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := client.Hello(ctx); err != nil {
+		t.Fatalf("Hello: %v", err)
+	}
+	meta := collections.CollectionMeta{
+		Name: "users",
+		Options: collections.CollectionOptions{
+			DocumentFormat: collections.DocumentFormatBSON,
+		},
+	}
+	if _, err := mgr.CreateCollection(&meta); err != nil {
+		t.Fatalf("direct CreateCollection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("OpenCollection users: %v", err)
+	}
+	original := mustBSONDocument(t, bson.D{{Key: "_id", Value: "u1"}, {Key: "name", Value: "Ada"}})
+	if _, err := col.InsertBatchValidatedBSON([][]byte{[]byte("u1")}, [][]byte{original}); err != nil {
+		t.Fatalf("seed InsertBatchValidatedBSON: %v", err)
+	}
+
+	insertDoc := mustBSONDocument(t, bson.D{{Key: "_id", Value: "u2"}, {Key: "name", Value: "Grace"}})
+	_, err = client.InsertBatch(ctx, "users", collections.DocumentFormatBSON, [][]byte{[]byte("u2")}, [][]byte{insertDoc}, AckVisible)
+	assertNativeRemoteOwnerRouteError(t, err, "users")
+	if got, err := col.Get([]byte("u2")); err != nil || got != nil {
+		t.Fatalf("u2 after remote-owner insert got=%v err=%v want missing", got, err)
+	}
+
+	_, _, err = client.UpdateBSONSet(ctx, "users", []byte("u1"), []collections.BSONSetField{
+		{Key: "name", Value: mustNativewireBSONRawValue(t, "Grace")},
+	}, AckVisible)
+	assertNativeRemoteOwnerRouteError(t, err, "users")
+
+	_, err = client.DeleteBatch(ctx, "users", [][]byte{[]byte("u1")}, AckVisible)
+	assertNativeRemoteOwnerRouteError(t, err, "users")
+
+	got, err := col.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("Get u1 after remote-owner mutations: %v", err)
+	}
+	if !bytes.Equal(got, original) {
+		t.Fatalf("u1 changed after remote-owner mutations: got %v want %v", got, original)
+	}
+	if calls := groupA.snapshotCalls(); len(calls) != 0 {
+		t.Fatalf("group-a calls=%d want 0", len(calls))
+	}
+	if calls := groupB.snapshotCalls(); len(calls) != 0 {
+		t.Fatalf("group-b calls=%d want 0", len(calls))
+	}
+	if routes := provider.snapshotRoutes(); len(routes) != 3 {
+		t.Fatalf("route calls=%d want insert+update+delete", len(routes))
 	}
 }
 

--- a/TreeDB/nativewire/cluster_submitter_test.go
+++ b/TreeDB/nativewire/cluster_submitter_test.go
@@ -2649,6 +2649,43 @@ func TestRaftClusterSubmitterGroupRoutedDispatcherUnknownOwnerErrorsBeforeSubmit
 	}
 }
 
+func TestRaftClusterSubmitterGroupRoutedDispatcherMissingOwnerErrorsBeforeSubmit(t *testing.T) {
+	token := raftplacement.DocumentIDTokenV1([]byte("u1"))
+	provider := &staticClusterRouteProvider{
+		target: ClusterRouteTarget{
+			PlacementMode: string(raftplacement.PlacementModeRingV1),
+			RouteKey:      string(raftplacement.RouteKeyDocumentIDV1),
+			Shape:         ClusterRouteShapeToken,
+			TokenKnown:    true,
+			Token:         token,
+			PartitionID:   "p0",
+		},
+	}
+	client, groupA, groupB, _, _ := serveGroupRoutedRaftClusterBridgePipe(t, provider)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := client.Hello(ctx); err != nil {
+		t.Fatalf("Hello: %v", err)
+	}
+	_, err := client.InsertBatch(ctx, "users", collections.DocumentFormatJSON, [][]byte{[]byte("u1")}, [][]byte{[]byte(`{"name":"Ada"}`)}, AckVisible)
+	if !isRemoteError(err, iwire.ErrReadOnly) || !strings.Contains(err.Error(), "route target missing") {
+		t.Fatalf("InsertBatch missing owner err=%v want read-only route target missing", err)
+	}
+	route, ok := ClusterRouteErrorMetadataOf(err)
+	if !ok {
+		t.Fatalf("ClusterRouteErrorMetadataOf ok=false err=%v", err)
+	}
+	if route.Class != "missing_owner" || route.GroupID != "" || route.LeaderHint != "" {
+		t.Fatalf("route metadata=%+v want missing owner without group/leader", route)
+	}
+	if calls := groupA.snapshotCalls(); len(calls) != 0 {
+		t.Fatalf("group-a calls=%d want 0", len(calls))
+	}
+	if calls := groupB.snapshotCalls(); len(calls) != 0 {
+		t.Fatalf("group-b calls=%d want 0", len(calls))
+	}
+}
+
 func TestRaftClusterSubmitterGroupRoutedDispatcherRemoteOwnerErrorsForMutations(t *testing.T) {
 	provider := &remoteOwnerRouteProvider{}
 	client, groupA, groupB, mgr, _ := serveGroupRoutedRaftClusterBridgePipe(t, provider)

--- a/TreeDB/nativewire/cluster_submitter_test.go
+++ b/TreeDB/nativewire/cluster_submitter_test.go
@@ -486,6 +486,34 @@ func TestClusterRouteErrorMetadataFieldsPreserveWhitespaceAcrossWireText(t *test
 	}
 }
 
+func TestClusterRouteErrorMetadataOfIgnoresLeaderOnlyProtocolWrapper(t *testing.T) {
+	err := &clusterRouteProtocolError{
+		err:        errors.New("nativewire: remote error code 8: leader unavailable"),
+		leaderHint: "node-z",
+		hasRoute:   false,
+	}
+	if metadata, ok := ClusterRouteErrorMetadataOf(err); ok {
+		t.Fatalf("ClusterRouteErrorMetadataOf ok=true metadata=%+v want false for leader-only wrapper", metadata)
+	}
+}
+
+func TestClusterRouteErrorMetadataOfFallsThroughLeaderOnlyProtocolWrapper(t *testing.T) {
+	err := &clusterRouteProtocolError{
+		err: &WireError{
+			Message: "cluster route rejected; route_error_class=remote_owner_redirect route_group=group+z leader_hint=node+z",
+		},
+		leaderHint: "node-z",
+		hasRoute:   false,
+	}
+	metadata, ok := ClusterRouteErrorMetadataOf(err)
+	if !ok {
+		t.Fatal("ClusterRouteErrorMetadataOf ok=false want parsed route metadata from wrapped wire error")
+	}
+	if metadata.Class != "remote_owner_redirect" || metadata.GroupID != "group z" || metadata.LeaderHint != "node z" {
+		t.Fatalf("ClusterRouteErrorMetadataOf metadata=%+v want parsed wrapped wire route metadata", metadata)
+	}
+}
+
 func TestClusterAdmissionMissingProviderFailsClosed(t *testing.T) {
 	err := AdmitClusterMutation(context.Background(), noAdmissionClusterSubmitter{})
 	if nativeCodeOf(err) != iwire.ErrDurabilityUnavailable {

--- a/TreeDB/nativewire/cluster_submitter_test.go
+++ b/TreeDB/nativewire/cluster_submitter_test.go
@@ -514,6 +514,27 @@ func TestClusterRouteErrorMetadataOfFallsThroughLeaderOnlyProtocolWrapper(t *tes
 	}
 }
 
+func TestClusterRouteErrorMetadataOfParsesProtocolRouteMetadata(t *testing.T) {
+	err := &iwire.ProtocolError{
+		Code:   iwire.ErrReadOnly,
+		Reason: "cluster route rejected; route_error_class=remote_owner_redirect route_group=group+z leader_hint=node+z",
+	}
+	metadata, ok := ClusterRouteErrorMetadataOf(err)
+	if !ok {
+		t.Fatal("ClusterRouteErrorMetadataOf ok=false want parsed protocol route metadata")
+	}
+	if metadata.Class != "remote_owner_redirect" || metadata.GroupID != "group z" || metadata.LeaderHint != "node z" {
+		t.Fatalf("ClusterRouteErrorMetadataOf metadata=%+v want parsed protocol route metadata", metadata)
+	}
+}
+
+func TestClusterRouteErrorMetadataOfIgnoresGenericTextTokens(t *testing.T) {
+	err := errors.New("duplicate key route_error_class=remote_owner_redirect route_group=group-z leader_hint=node-z")
+	if metadata, ok := ClusterRouteErrorMetadataOf(err); ok {
+		t.Fatalf("ClusterRouteErrorMetadataOf ok=true metadata=%+v want false for generic error text", metadata)
+	}
+}
+
 func TestClusterAdmissionMissingProviderFailsClosed(t *testing.T) {
 	err := AdmitClusterMutation(context.Background(), noAdmissionClusterSubmitter{})
 	if nativeCodeOf(err) != iwire.ErrDurabilityUnavailable {

--- a/TreeDB/nativewire/errors.go
+++ b/TreeDB/nativewire/errors.go
@@ -86,10 +86,16 @@ func ClusterRouteErrorMetadataOf(err error) (ClusterRouteErrorMetadata, bool) {
 	}
 	var wireErr *WireError
 	if errors.As(err, &wireErr) {
+		if wireErr.Code != iwire.ErrReadOnly {
+			return ClusterRouteErrorMetadata{}, false
+		}
 		return parseClusterRouteErrorMetadata(wireErr.Message)
 	}
 	var protocolErr *iwire.ProtocolError
 	if errors.As(err, &protocolErr) {
+		if protocolErr.Code != iwire.ErrReadOnly {
+			return ClusterRouteErrorMetadata{}, false
+		}
 		return parseClusterRouteErrorMetadata(protocolErr.Reason)
 	}
 	return ClusterRouteErrorMetadata{}, false

--- a/TreeDB/nativewire/errors.go
+++ b/TreeDB/nativewire/errors.go
@@ -76,7 +76,10 @@ func ClusterRouteErrorMetadataOf(err error) (ClusterRouteErrorMetadata, bool) {
 		ClusterRouteErrorMetadata() ClusterRouteErrorMetadata
 	}
 	if errors.As(err, &routed) {
-		return routed.ClusterRouteErrorMetadata().Clone(), true
+		metadata := routed.ClusterRouteErrorMetadata()
+		if clusterRouteErrorMetadataPresent(metadata) {
+			return metadata.Clone(), true
+		}
 	}
 	if route, ok := raftcluster.RouteErrorMetadataOf(err); ok {
 		return clusterRouteErrorMetadataFromRaft(route), true
@@ -86,6 +89,10 @@ func ClusterRouteErrorMetadataOf(err error) (ClusterRouteErrorMetadata, bool) {
 		return parseClusterRouteErrorMetadata(wireErr.Message)
 	}
 	return parseClusterRouteErrorMetadata(err.Error())
+}
+
+func clusterRouteErrorMetadataPresent(metadata ClusterRouteErrorMetadata) bool {
+	return metadata.Class != ""
 }
 
 func clusterRouteErrorMetadataFromRaft(route raftcluster.RouteErrorMetadata) ClusterRouteErrorMetadata {

--- a/TreeDB/nativewire/errors.go
+++ b/TreeDB/nativewire/errors.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"strconv"
+	"strings"
 
 	"github.com/snissn/gomap/TreeDB/collections"
 	backenddb "github.com/snissn/gomap/TreeDB/db"
@@ -37,6 +39,115 @@ func (e *WireError) Error() string {
 // guard failure.
 func IsCatalogVersionMismatch(err error) bool {
 	return isRemoteError(err, iwire.ErrCatalogVersionMismatch)
+}
+
+// ClusterRouteErrorMetadata is the nativewire projection of stable route-error
+// metadata returned for redirect-first cluster write failures.
+type ClusterRouteErrorMetadata struct {
+	Class         string
+	Database      string
+	Catalog       string
+	Collection    string
+	Shape         string
+	GroupID       string
+	Members       []string
+	LeaderHint    string
+	PlacementMode string
+	RouteKey      string
+	TokenKnown    bool
+	Token         uint64
+	PartitionID   string
+	LocalGroupID  string
+}
+
+// Clone returns an independent copy of the metadata.
+func (m ClusterRouteErrorMetadata) Clone() ClusterRouteErrorMetadata {
+	m.Members = append([]string(nil), m.Members...)
+	return m
+}
+
+// ClusterRouteErrorMetadataOf returns stable route metadata carried by err.
+func ClusterRouteErrorMetadataOf(err error) (ClusterRouteErrorMetadata, bool) {
+	if err == nil {
+		return ClusterRouteErrorMetadata{}, false
+	}
+	var routed interface {
+		ClusterRouteErrorMetadata() ClusterRouteErrorMetadata
+	}
+	if errors.As(err, &routed) {
+		return routed.ClusterRouteErrorMetadata().Clone(), true
+	}
+	if route, ok := raftcluster.RouteErrorMetadataOf(err); ok {
+		return clusterRouteErrorMetadataFromRaft(route), true
+	}
+	var wireErr *WireError
+	if errors.As(err, &wireErr) {
+		return parseClusterRouteErrorMetadata(wireErr.Message)
+	}
+	return parseClusterRouteErrorMetadata(err.Error())
+}
+
+func clusterRouteErrorMetadataFromRaft(route raftcluster.RouteErrorMetadata) ClusterRouteErrorMetadata {
+	return ClusterRouteErrorMetadata{
+		Class:         string(route.Class),
+		Database:      route.Database,
+		Catalog:       route.Catalog,
+		Collection:    route.Collection,
+		Shape:         route.Shape,
+		GroupID:       route.GroupID,
+		Members:       append([]string(nil), route.Members...),
+		LeaderHint:    route.LeaderHint,
+		PlacementMode: route.PlacementMode,
+		RouteKey:      route.RouteKey,
+		TokenKnown:    route.TokenKnown,
+		Token:         route.Token,
+		PartitionID:   route.PartitionID,
+		LocalGroupID:  route.LocalGroupID,
+	}
+}
+
+func parseClusterRouteErrorMetadata(message string) (ClusterRouteErrorMetadata, bool) {
+	if message == "" || !strings.Contains(message, "route_error_class=") {
+		return ClusterRouteErrorMetadata{}, false
+	}
+	fields := make(map[string]string)
+	for _, field := range strings.Fields(message) {
+		field = strings.Trim(field, " ;,\t\r\n")
+		key, value, ok := strings.Cut(field, "=")
+		if !ok {
+			continue
+		}
+		fields[key] = strings.Trim(value, " ;,\t\r\n")
+	}
+	class := fields["route_error_class"]
+	if class == "" {
+		return ClusterRouteErrorMetadata{}, false
+	}
+	metadata := ClusterRouteErrorMetadata{
+		Class:         class,
+		Database:      fields["route_database"],
+		Catalog:       fields["route_catalog"],
+		Collection:    fields["route_collection"],
+		Shape:         fields["route_shape"],
+		GroupID:       fields["route_group"],
+		LeaderHint:    fields["leader_hint"],
+		PlacementMode: fields["route_placement"],
+		RouteKey:      fields["route_key"],
+		PartitionID:   fields["route_partition"],
+		LocalGroupID:  fields["local_group"],
+	}
+	if rawMembers := fields["route_members"]; rawMembers != "" {
+		metadata.Members = strings.Split(rawMembers, ",")
+	}
+	if fields["route_token_known"] == "true" {
+		metadata.TokenKnown = true
+	}
+	if rawToken := fields["route_token"]; rawToken != "" {
+		if token, err := strconv.ParseUint(rawToken, 10, 64); err == nil {
+			metadata.Token = token
+		}
+	}
+	return metadata, true
 }
 
 func errorCodeFor(err error) iwire.ErrorCode {

--- a/TreeDB/nativewire/errors.go
+++ b/TreeDB/nativewire/errors.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"net/url"
 	"strconv"
 	"strings"
 
@@ -117,7 +118,11 @@ func parseClusterRouteErrorMetadata(message string) (ClusterRouteErrorMetadata, 
 		if !ok {
 			continue
 		}
-		fields[key] = strings.Trim(value, " ;,\t\r\n")
+		value = strings.Trim(value, " ;,\t\r\n")
+		if key != "route_members" {
+			value = decodeClusterRouteErrorField(value)
+		}
+		fields[key] = value
 	}
 	class := fields["route_error_class"]
 	if class == "" {
@@ -137,7 +142,13 @@ func parseClusterRouteErrorMetadata(message string) (ClusterRouteErrorMetadata, 
 		LocalGroupID:  fields["local_group"],
 	}
 	if rawMembers := fields["route_members"]; rawMembers != "" {
-		metadata.Members = strings.Split(rawMembers, ",")
+		rawMembers := strings.Split(rawMembers, ",")
+		metadata.Members = make([]string, 0, len(rawMembers))
+		for _, member := range rawMembers {
+			if member != "" {
+				metadata.Members = append(metadata.Members, decodeClusterRouteErrorField(member))
+			}
+		}
 	}
 	if fields["route_token_known"] == "true" {
 		metadata.TokenKnown = true
@@ -150,18 +161,34 @@ func parseClusterRouteErrorMetadata(message string) (ClusterRouteErrorMetadata, 
 	return metadata, true
 }
 
+func decodeClusterRouteErrorField(value string) string {
+	decoded, err := url.QueryUnescape(value)
+	if err != nil {
+		return value
+	}
+	return decoded
+}
+
 func clusterRouteErrorMetadataFields(metadata ClusterRouteErrorMetadata) string {
 	var fields []string
 	appendField := func(key, value string) {
 		if value != "" {
-			fields = append(fields, key+"="+value)
+			fields = append(fields, key+"="+url.QueryEscape(value))
 		}
 	}
 	appendField("route_error_class", metadata.Class)
 	appendField("route_group", metadata.GroupID)
 	appendField("leader_hint", metadata.LeaderHint)
 	if len(metadata.Members) != 0 {
-		appendField("route_members", strings.Join(metadata.Members, ","))
+		escaped := make([]string, 0, len(metadata.Members))
+		for _, member := range metadata.Members {
+			if member != "" {
+				escaped = append(escaped, url.QueryEscape(member))
+			}
+		}
+		if len(escaped) != 0 {
+			fields = append(fields, "route_members="+strings.Join(escaped, ","))
+		}
 	}
 	appendField("route_database", metadata.Database)
 	appendField("route_catalog", metadata.Catalog)

--- a/TreeDB/nativewire/errors.go
+++ b/TreeDB/nativewire/errors.go
@@ -88,7 +88,11 @@ func ClusterRouteErrorMetadataOf(err error) (ClusterRouteErrorMetadata, bool) {
 	if errors.As(err, &wireErr) {
 		return parseClusterRouteErrorMetadata(wireErr.Message)
 	}
-	return parseClusterRouteErrorMetadata(err.Error())
+	var protocolErr *iwire.ProtocolError
+	if errors.As(err, &protocolErr) {
+		return parseClusterRouteErrorMetadata(protocolErr.Reason)
+	}
+	return ClusterRouteErrorMetadata{}, false
 }
 
 func clusterRouteErrorMetadataPresent(metadata ClusterRouteErrorMetadata) bool {

--- a/TreeDB/nativewire/errors.go
+++ b/TreeDB/nativewire/errors.go
@@ -150,6 +150,34 @@ func parseClusterRouteErrorMetadata(message string) (ClusterRouteErrorMetadata, 
 	return metadata, true
 }
 
+func clusterRouteErrorMetadataFields(metadata ClusterRouteErrorMetadata) string {
+	var fields []string
+	appendField := func(key, value string) {
+		if value != "" {
+			fields = append(fields, key+"="+value)
+		}
+	}
+	appendField("route_error_class", metadata.Class)
+	appendField("route_group", metadata.GroupID)
+	appendField("leader_hint", metadata.LeaderHint)
+	if len(metadata.Members) != 0 {
+		appendField("route_members", strings.Join(metadata.Members, ","))
+	}
+	appendField("route_database", metadata.Database)
+	appendField("route_catalog", metadata.Catalog)
+	appendField("route_collection", metadata.Collection)
+	appendField("route_shape", metadata.Shape)
+	appendField("route_placement", metadata.PlacementMode)
+	appendField("route_key", metadata.RouteKey)
+	if metadata.TokenKnown {
+		appendField("route_token_known", "true")
+		appendField("route_token", strconv.FormatUint(metadata.Token, 10))
+	}
+	appendField("route_partition", metadata.PartitionID)
+	appendField("local_group", metadata.LocalGroupID)
+	return strings.Join(fields, " ")
+}
+
 func errorCodeFor(err error) iwire.ErrorCode {
 	if err == nil {
 		return 0


### PR DESCRIPTION
Part of #3460.
Closes #3466.

## Summary
- Add stable `raftcluster` route-error metadata/classes for redirect-first route failures: `remote_owner_redirect`, `unknown_owner`, and `missing_owner`.
- Preserve route metadata through nativewire read-only protocol errors, including route-preflight missing-owner errors, so clients can recover group, leader hint, members, namespace, placement, route key, token, and partition metadata from remote errors.
- URL-escape route metadata values in wire-text fields and decode them only through the structured route-metadata parser, so spaces and delimiters do not corrupt stable metadata.
- Surface route metadata in Mongo command errors (`treedbErrorClass`, route group/leader/member/namespace/token fields); raw non-route `leader_hint=` text is preserved for legacy/not-leader emitters, and remote read-only `nativewire.WireError` route metadata is surfaced before mutation.
- Restrict route-metadata text parsing to structured route carriers plus read-only nativewire `WireError` messages or typed internal protocol errors so arbitrary user-controlled/non-route error text cannot spoof redirect metadata.
- Add focused remote-owner, unknown-owner, missing-owner, wrapper-fallback, leader-hint, remote-wire, spoofed-token, and Mongo metadata assertions proving write paths reject before local submit/mutation across raftcluster/nativewire/Mongo.

## Scope boundaries
- No network forwarding, cross-group fanout/split execution, catalog/meta ownership, or production horizontal-scale claims.
- No `cmd/mongo_gateway_bench` schema/harness changes; #3467 remains the production evidence/counter boundary.

## Latest head
- `6823f4a79` after preserving raw Mongo leader-hint fallback text, decoding escaped leader hints only from structured route metadata, surfacing remote read-only `nativewire.WireError` route metadata through Mongo errors, ignoring generic error text, and rejecting non-read-only spoofed route metadata in structured nativewire/protocol errors.

## Tests
- `env GOWORK=off GOCACHE=/mnt/fast4tb/tmp/gomap-3466-gocache GOMODCACHE=/mnt/fast4tb/tmp/gomap-3466-gomodcache GOPATH=/mnt/fast4tb/tmp/gomap-3466-gopath GOTMPDIR=/mnt/fast4tb/tmp TMPDIR=/mnt/fast4tb/tmp go test ./TreeDB/nativewire ./TreeDB/mongo_gateway -run 'Test(ClusterRouteErrorMetadataFieldsPreserveWhitespaceAcrossWireText|ClusterRouteErrorMetadataOfIgnoresLeaderOnlyProtocolWrapper|ClusterRouteErrorMetadataOfFallsThroughLeaderOnlyProtocolWrapper|ClusterRouteErrorMetadataOfIgnoresNonReadOnlyWireRouteMetadata|ClusterRouteErrorMetadataOfParsesProtocolRouteMetadata|ClusterRouteErrorMetadataOfIgnoresNonReadOnlyProtocolRouteMetadata|ClusterRouteErrorMetadataOfIgnoresGenericTextTokens|MongoClusterMutationCommandErrorSurfacesRemoteWireRouteMetadata|MongoClusterMutationCommandErrorDecodesRouteMetadataLeaderHint|MongoClusterMutationCommandErrorPreservesRawLeaderHint)$' -count=1`
- `env GOWORK=off GOCACHE=/mnt/fast4tb/tmp/gomap-3466-gocache GOMODCACHE=/mnt/fast4tb/tmp/gomap-3466-gomodcache GOPATH=/mnt/fast4tb/tmp/gomap-3466-gopath GOTMPDIR=/mnt/fast4tb/tmp TMPDIR=/mnt/fast4tb/tmp go test ./TreeDB/internal/raftplacement ./TreeDB/internal/raftcluster ./TreeDB/nativewire ./TreeDB/mongo_gateway ./cmd/mongo_gateway_bench -count=1`

## Benchmark rationale
Correctness/contract-only change. This PR does not change benchmark schema/harness and does not claim production throughput. No before/after microbenchmark was run.

## AI review disposition
- Copilot missing-owner review finding was fixed by carrying stable missing-owner metadata from the single-group binding path and nativewire preflight missing-target path, with raftcluster/nativewire/Mongo regression coverage.
- Codex and CodeRabbit whitespace metadata findings were fixed by escaping route metadata text fields and adding an across-wire whitespace roundtrip regression test.
- CodeRabbit empty-wrapper metadata finding was fixed by requiring real route metadata before the generic method path returns `ok=true`, then falling through to wrapped wire-error parsing.
- CodeRabbit Mongo metadata assertion nit was fixed by asserting route members, token-known, and token across the shared remote-owner mutation helper.
- Copilot escaped leader-hint review was revised after Codex found raw fallback drift: Mongo now preserves raw not-leader hints such as `node+z` and decodes `node+z` to `node z` only when it comes from structured route metadata.
- Codex remote `WireError` metadata finding was fixed by reading `treenativewire.WireError.Code` and allowing decoded route metadata through the Mongo cluster-field applicability gate.
- Codex generic-text spoofing finding was fixed by parsing route metadata only from structured route carriers, nativewire `WireError` messages, and typed internal protocol errors; generic `err.Error()` strings are ignored with a spoofed-token regression.
- Copilot non-read-only structured-error spoofing finding was fixed by only parsing route metadata from read-only nativewire `WireError`/internal `ProtocolError` messages; non-read-only wire/protocol errors with route tokens are ignored with regressions.
