### PR TITLE
treedb: profile sync batch allocation paths

### DIFF
--- a/TreeDB/sync_latency_bench_test.go
+++ b/TreeDB/sync_latency_bench_test.go
@@ -48,11 +48,12 @@ func TestSyncDurabilityBoundaryDoesNotCheckpoint(t *testing.T) {
 
 func BenchmarkSyncLatencyCached(b *testing.B) {
 	tests := []struct {
-		name       string
-		durability DurabilityMode
-		commandWAL bool
-		batchSize  int
-		byteHint   bool
+		name         string
+		durability   DurabilityMode
+		commandWAL   bool
+		batchSize    int
+		byteHint     bool
+		nonZeroValue bool
 	}{
 		{name: "SetSync/wal_on_sync", durability: DurabilityDurable},
 		{name: "SetSync/wal_on_sync_command_wal", durability: DurabilityDurable, commandWAL: true},
@@ -62,7 +63,9 @@ func BenchmarkSyncLatencyCached(b *testing.B) {
 		{name: "BatchWriteSync/wal_on_sync_command_wal/32/entry_hint", durability: DurabilityDurable, commandWAL: true, batchSize: 32},
 		{name: "BatchWriteSync/wal_on_relaxed_sync/32/entry_hint", durability: DurabilityWALOnRelaxed, batchSize: 32},
 		{name: "BatchWriteSync/wal_on_relaxed_sync_command_wal/32/entry_hint", durability: DurabilityWALOnRelaxed, commandWAL: true, batchSize: 32},
+		{name: "BatchWriteSync/wal_on_relaxed_sync_command_wal/32/entry_hint_nonzero_value", durability: DurabilityWALOnRelaxed, commandWAL: true, batchSize: 32, nonZeroValue: true},
 		{name: "BatchWriteSync/wal_on_relaxed_sync_command_wal/32/byte_hint", durability: DurabilityWALOnRelaxed, commandWAL: true, batchSize: 32, byteHint: true},
+		{name: "BatchWriteSync/wal_on_relaxed_sync_command_wal/32/byte_hint_nonzero_value", durability: DurabilityWALOnRelaxed, commandWAL: true, batchSize: 32, byteHint: true, nonZeroValue: true},
 		{name: "BatchWriteSync/wal_on_sync_command_wal/128/entry_hint", durability: DurabilityDurable, commandWAL: true, batchSize: 128},
 		{name: "BatchWriteSync/wal_on_relaxed_sync_command_wal/128/entry_hint", durability: DurabilityWALOnRelaxed, commandWAL: true, batchSize: 128},
 	}
@@ -80,6 +83,11 @@ func BenchmarkSyncLatencyCached(b *testing.B) {
 			defer func() { _ = d.Close() }()
 
 			val := make([]byte, 128)
+			if tt.nonZeroValue {
+				for i := range val {
+					val[i] = byte(i + 1)
+				}
+			}
 
 			batchSize := tt.batchSize
 			if batchSize <= 0 {

--- a/TreeDB/sync_latency_bench_test.go
+++ b/TreeDB/sync_latency_bench_test.go
@@ -2,32 +2,190 @@ package treedb
 
 import (
 	"encoding/binary"
-	"os"
 	"testing"
 )
 
+func TestSyncDurabilityBoundaryDoesNotCheckpoint(t *testing.T) {
+	tests := []struct {
+		name       string
+		durability DurabilityMode
+		commandWAL bool
+	}{
+		{name: "wal_on_sync", durability: DurabilityDurable},
+		{name: "wal_on_sync_command_wal", durability: DurabilityDurable, commandWAL: true},
+		{name: "wal_on_relaxed_sync", durability: DurabilityWALOnRelaxed},
+		{name: "wal_on_relaxed_sync_command_wal", durability: DurabilityWALOnRelaxed, commandWAL: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d, err := Open(Options{
+				Dir:        t.TempDir(),
+				Durability: tt.durability,
+				CommandWAL: tt.commandWAL,
+			})
+			if err != nil {
+				t.Fatalf("open: %v", err)
+			}
+			defer func() { _ = d.Close() }()
+
+			val := make([]byte, 128)
+			var key [8]byte
+			for i := 0; i < 16; i++ {
+				binary.BigEndian.PutUint64(key[:], uint64(i))
+				if err := d.SetSync(key[:], val); err != nil {
+					t.Fatalf("SetSync(%d): %v", i, err)
+				}
+			}
+
+			stats := d.Stats()
+			if got := mustStatUint64(t, stats, "treedb.cache.checkpoint.runs"); got != 0 {
+				t.Fatalf("checkpoint.runs=%d, want 0 before explicit Checkpoint/Close", got)
+			}
+		})
+	}
+}
+
 func BenchmarkSyncLatencyCached(b *testing.B) {
-	tmpDir, err := os.MkdirTemp("", "treedb-bench-sync-cached-*")
-	if err != nil {
-		b.Fatal(err)
+	tests := []struct {
+		name       string
+		durability DurabilityMode
+		commandWAL bool
+		batchSize  int
+		byteHint   bool
+	}{
+		{name: "SetSync/wal_on_sync", durability: DurabilityDurable},
+		{name: "SetSync/wal_on_sync_command_wal", durability: DurabilityDurable, commandWAL: true},
+		{name: "SetSync/wal_on_relaxed_sync", durability: DurabilityWALOnRelaxed},
+		{name: "SetSync/wal_on_relaxed_sync_command_wal", durability: DurabilityWALOnRelaxed, commandWAL: true},
+		{name: "BatchWriteSync/wal_on_sync/32/entry_hint", durability: DurabilityDurable, batchSize: 32},
+		{name: "BatchWriteSync/wal_on_sync_command_wal/32/entry_hint", durability: DurabilityDurable, commandWAL: true, batchSize: 32},
+		{name: "BatchWriteSync/wal_on_relaxed_sync/32/entry_hint", durability: DurabilityWALOnRelaxed, batchSize: 32},
+		{name: "BatchWriteSync/wal_on_relaxed_sync_command_wal/32/entry_hint", durability: DurabilityWALOnRelaxed, commandWAL: true, batchSize: 32},
+		{name: "BatchWriteSync/wal_on_relaxed_sync_command_wal/32/byte_hint", durability: DurabilityWALOnRelaxed, commandWAL: true, batchSize: 32, byteHint: true},
+		{name: "BatchWriteSync/wal_on_sync_command_wal/128/entry_hint", durability: DurabilityDurable, commandWAL: true, batchSize: 128},
+		{name: "BatchWriteSync/wal_on_relaxed_sync_command_wal/128/entry_hint", durability: DurabilityWALOnRelaxed, commandWAL: true, batchSize: 128},
 	}
-	defer os.RemoveAll(tmpDir)
 
-	d, err := Open(Options{Dir: tmpDir})
-	if err != nil {
-		b.Fatalf("open: %v", err)
+	for _, tt := range tests {
+		b.Run(tt.name, func(b *testing.B) {
+			d, err := Open(Options{
+				Dir:        b.TempDir(),
+				Durability: tt.durability,
+				CommandWAL: tt.commandWAL,
+			})
+			if err != nil {
+				b.Fatalf("open: %v", err)
+			}
+			defer func() { _ = d.Close() }()
+
+			val := make([]byte, 128)
+
+			batchSize := tt.batchSize
+			if batchSize <= 0 {
+				batchSize = 1
+			}
+			batchHint := batchSize
+			if tt.byteHint {
+				batchHint = batchSize * (8 + len(val))
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if batchSize == 1 {
+					var key [8]byte
+					binary.BigEndian.PutUint64(key[:], uint64(i))
+					if err := d.SetSync(key[:], val); err != nil {
+						b.Fatalf("SetSync: %v", err)
+					}
+					continue
+				}
+
+				batch := d.NewBatchWithSize(batchHint)
+				if batch == nil {
+					b.Fatal("NewBatchWithSize returned nil")
+				}
+				base := uint64(i * batchSize)
+				for j := 0; j < batchSize; j++ {
+					var key [8]byte
+					binary.BigEndian.PutUint64(key[:], base+uint64(j))
+					if err := batch.Set(key[:], val); err != nil {
+						_ = batch.Close()
+						b.Fatalf("batch Set(%d): %v", j, err)
+					}
+				}
+				if err := batch.WriteSync(); err != nil {
+					_ = batch.Close()
+					b.Fatalf("batch WriteSync: %v", err)
+				}
+				if err := batch.Close(); err != nil {
+					b.Fatalf("batch Close: %v", err)
+				}
+			}
+			b.StopTimer()
+
+			totalOps := b.N * batchSize
+			if elapsed := b.Elapsed(); elapsed > 0 {
+				b.ReportMetric(float64(totalOps)/elapsed.Seconds(), "writes/s")
+			}
+			b.ReportMetric(float64(batchHint), "batch_hint")
+			b.ReportMetric(float64(batchSize), "writes/op")
+			reportSyncLatencyStats(b, d)
+		})
 	}
-	defer d.Close()
+}
 
-	val := make([]byte, 128)
-	var key [8]byte
-
-	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		binary.BigEndian.PutUint64(key[:], uint64(i))
-		if err := d.SetSync(key[:], val); err != nil {
-			b.Fatalf("setsync: %v", err)
+func reportSyncLatencyStats(b *testing.B, d *DB) {
+	b.Helper()
+	if b.N <= 1 {
+		return
+	}
+	stats := d.Stats()
+	for _, key := range []string{
+		"treedb.durability_mode",
+		"treedb.write_path.mode",
+		"treedb.write_path.redo_log",
+		"treedb.cache.memtable_mode",
+		"treedb.cache.queue_len",
+		"treedb.cache.mutable_bytes",
+		"treedb.cache.checkpoint.runs",
+		"treedb.cache.checkpoint.total_ms",
+		"treedb.cache.checkpoint.max_ms",
+		"treedb.cache.checkpoint.stage.flush_all.samples",
+		"treedb.cache.checkpoint.stage.flush_all.total_ns",
+		"treedb.cache.checkpoint.stage.value_log_flush.samples",
+		"treedb.cache.checkpoint.stage.value_log_flush.total_ns",
+		"treedb.cache.checkpoint.stage.command_wal_publish.samples",
+		"treedb.cache.checkpoint.stage.command_wal_publish.total_ns",
+		"treedb.cache.checkpoint.stage.backend_boundary.samples",
+		"treedb.cache.checkpoint.stage.backend_boundary.total_ns",
+		"treedb.cache.append_only.entry_pool_gets_total",
+		"treedb.cache.append_only.entry_pool_puts_total",
+		"treedb.cache.append_only.entry_pool_drops_total",
+		"treedb.cache.append_only.entry_pool_drop_bytes_total",
+		"treedb.cache.append_only.entry_pool_admission_drops_total",
+		"treedb.cache.append_only.entry_pool_retained_bytes_estimate",
+		"treedb.cache.append_only.mutable_from_pool_total",
+		"treedb.cache.append_only.mutable_from_lease_total",
+		"treedb.cache.append_only.mutable_new_alloc_total",
+		"treedb.cache.append_only.mutable_pool_entry_backing_dropped_bytes_total",
+		"treedb.cache.append_only.reserve.calls_total",
+		"treedb.cache.append_only.reserve.grow_calls_total",
+		"treedb.cache.append_only.reserve.grow_bytes_total",
+		"treedb.cache.append_only.value_arena_pool_gets_total",
+		"treedb.cache.append_only.value_arena_pool_puts_total",
+		"treedb.cache.append_only.value_arena_pool_drop_bytes_total",
+		"treedb.cache.vlog_shape.segments_total",
+		"treedb.cache.vlog_shape.bytes_total",
+		"treedb.cache.vlog_queue.depth_max",
+		"treedb.cache.vlog_queue.lag_max_ms",
+		"treedb.process.memory.rss_peak_bytes",
+		"treedb.process.memory.heap_alloc_peak_bytes",
+	} {
+		if value, ok := stats[key]; ok {
+			b.Logf("%s=%s", key, value)
 		}
 	}
+	b.Logf("sync_latency_summary=stats_keys=%d", len(stats))
 }


### PR DESCRIPTION
Parent tracker: #3475
Closes #3476

## Summary

This is the M0 profiling/instrumentation PR for the TreeDB plain-send optimization loop. It does not claim a production performance win. It adds a focused sync-boundary regression test and expands `BenchmarkSyncLatencyCached` so current profiles can distinguish:

- single `SetSync` from batched `WriteSync`;
- durable vs `wal_on_relaxed_sync`;
- command-WAL cached vs regular write paths;
- entry-count batch hints from byte-sized batch hints;
- all-zero values from nonzero values, because all-zero payloads exercise compact-zero ownership logic.

## Current Evidence

Baseline branch: `origin/main` at `da12bb7db6f09777da986957b030e17c03fb5675`
Candidate branch: `codex/3476-plain-send-profile` at `5b31b4f1b3dc6c7dd59b235d49796805f605823b`
Machine: Intel i5-11400F, Go linux/amd64
Environment: `GOWORK=off TMPDIR=/mnt/fast4tb/tmp GOCACHE=/mnt/fast4tb/tmp/gocache GOMODCACHE=/mnt/fast4tb/tmp/gomodcache GOPATH=/mnt/fast4tb/tmp/gopath`

Focused command:

```sh
GOWORK=off TMPDIR=/mnt/fast4tb/tmp GOCACHE=/mnt/fast4tb/tmp/gocache \
  GOMODCACHE=/mnt/fast4tb/tmp/gomodcache GOPATH=/mnt/fast4tb/tmp/gopath \
  go test ./TreeDB -run '^$' \
  -bench 'BenchmarkSyncLatencyCached/BatchWriteSync/wal_on_relaxed_sync_command_wal/32/(entry_hint|entry_hint_nonzero_value|byte_hint|byte_hint_nonzero_value)$' \
  -benchtime=1s -count=1 -benchmem
```

| Case | ns/op | writes/s | B/op | allocs/op | Checkpoint runs | Notes |
| --- | ---: | ---: | ---: | ---: | ---: | --- |
| `32/entry_hint` | 30,709 | 1,042,036 | 28,539 | 83 | 0 | All-zero value, entry-count hint |
| `32/entry_hint_nonzero_value` | 25,430 | 1,258,369 | 19,096 | 51 | 0 | Nonzero value, entry-count hint |
| `32/byte_hint` | 97,222 | 329,143 | 928,753 | 86 | 0 | All-zero value, byte-sized hint under the small-hint cutoff |
| `32/byte_hint_nonzero_value` | 95,128 | 336,390 | 923,324 | 54 | 0 | Nonzero value, byte-sized hint under the small-hint cutoff |

Profile artifact root from the M0 investigation:

```text
/mnt/fast4tb/treedb-plain-send-profile-m0-20260704T054135Z
```

Most useful current profile files:

```text
/mnt/fast4tb/treedb-plain-send-profile-m0-20260704T054135Z/relaxed-commandwal-32-entryhint-cpu/cpu.pprof
/mnt/fast4tb/treedb-plain-send-profile-m0-20260704T054135Z/relaxed-commandwal-32-entryhint-alloc/heap.pprof
/mnt/fast4tb/treedb-plain-send-profile-m0-20260704T054135Z/relaxed-commandwal-32-entryhint-nonzero-alloc/heap.pprof
/mnt/fast4tb/treedb-plain-send-profile-m0-20260704T054135Z/relaxed-commandwal-32-cpu-clean/cpu.pprof
```

Nonzero entry-hint allocation profile command:

```sh
OUT=/mnt/fast4tb/treedb-plain-send-profile-m0-20260704T054135Z/relaxed-commandwal-32-entryhint-nonzero-alloc
GOWORK=off TMPDIR=/mnt/fast4tb/tmp GOCACHE=/mnt/fast4tb/tmp/gocache \
  GOMODCACHE=/mnt/fast4tb/tmp/gomodcache GOPATH=/mnt/fast4tb/tmp/gopath \
  go test ./TreeDB -run '^$' \
  -bench 'BenchmarkSyncLatencyCached/BatchWriteSync/wal_on_relaxed_sync_command_wal/32/entry_hint_nonzero_value$' \
  -benchtime=3s -count=1 -benchmem -memprofile "$OUT/heap.pprof"
```

Top nonzero alloc-space buckets from that run:

| Function | Flat alloc_space | Share |
| --- | ---: | ---: |
| `commitlog.(*RawKVBatchPayloadBuilder).appendRawKVPayloadSpace` | 839.71MB | 16.82% |
| `memtable.NewHashSortedWithCapacityAndIndexer` | 774.29MB | 15.51% |
| `memtable.(*hashArena).alloc` | 763.87MB | 15.31% |
| `commitlog.(*Reader).readSegmentPayload` | 707.11MB | 14.17% |
| `commitlog.DecodeCommandFrame` | 701.58MB | 14.06% |
| `caching.getEntrySlice` | 321.82MB | 6.45% |
| `memtable.getAppendOnlyEntries` | 136.46MB | 2.73% |

## Current Classification

- Sync writes in the tested durable and WAL-relaxed paths do not force checkpoints; `treedb.cache.checkpoint.runs=0` before close/explicit checkpoint.
- All-zero values add a measurable command-WAL public batch allocation cost. That should be treated as a specific value-shape optimization candidate, not as the whole plain-send explanation.
- Byte-sized hints below the small-hint cutoff produce a severe allocation cliff. Repo-local scripts/adapters must be checked before claiming this is an Ironbird production path.
- The nonzero entry-hint profile shifts the next work toward command-WAL payload sizing/replay allocation, memtable allocation churn, and entry-slice reuse rather than full checkpoint cost.

## Tests

```sh
GOWORK=off TMPDIR=/mnt/fast4tb/tmp GOCACHE=/mnt/fast4tb/tmp/gocache \
  GOMODCACHE=/mnt/fast4tb/tmp/gomodcache GOPATH=/mnt/fast4tb/tmp/gopath \
  go test ./TreeDB -run '^TestSyncDurabilityBoundaryDoesNotCheckpoint$'
```

Result: pass.

```sh
GOWORK=off TMPDIR=/mnt/fast4tb/tmp GOCACHE=/mnt/fast4tb/tmp/gocache \
  GOMODCACHE=/mnt/fast4tb/tmp/gomodcache GOPATH=/mnt/fast4tb/tmp/gopath \
  go test ./TreeDB -run '^$' \
  -bench 'BenchmarkSyncLatencyCached/BatchWriteSync/wal_on_relaxed_sync_command_wal/32/(entry_hint|entry_hint_nonzero_value|byte_hint|byte_hint_nonzero_value)$' \
  -benchtime=1s -count=1 -benchmem
```

Result: pass; numbers in table above.

## Review Notes

No production hot path behavior is changed. This PR is instrumentation-only and intended to unblock #3477/#3478 with current profile evidence.
