### PR TITLE
treedb: skip redundant zero copy for revision payloads

### DIFF
--- a/TreeDB/command_wal_public_cached.go
+++ b/TreeDB/command_wal_public_cached.go
@@ -461,15 +461,18 @@ func (b *commandWALPublicBatch) setView(key, value []byte, retainReplayViews, us
 		b.dirty = true
 		return nil, nil, nil
 	}
-	if !useInnerView && commandWALPublicAllZeroBytes(value) {
-		// AppendSet compact-zero tracking keys off the first zero value backing
-		// array. Plain Set callers may reuse and mutate their input buffer, so pin
-		// compact-zero identity to an immutable batch-owned copy.
-		value = append([]byte(nil), value...)
-	} else if retainReplayViews && commandWALPublicAllZeroBytes(value) {
-		// Adapter replay-byte callers may also reuse and mutate their value buffer
-		// between Put calls, so keep that compact-zero identity immutable.
-		value = append([]byte(nil), value...)
+	if !b.payload.EntryRevisionsEnabled() && commandWALPublicAllZeroBytes(value) {
+		if !useInnerView {
+			// AppendSet compact-zero tracking keys off the first zero value
+			// backing array. Plain Set callers may reuse and mutate their input
+			// buffer, so pin compact-zero identity to an immutable batch-owned copy.
+			value = append([]byte(nil), value...)
+		} else if retainReplayViews {
+			// Adapter replay-byte callers may also reuse and mutate their value
+			// buffer between Put calls, so keep that compact-zero identity
+			// immutable.
+			value = append([]byte(nil), value...)
+		}
 	}
 	oldLen, oldCount := b.payload.Len(), b.payload.Count()
 	keyView, valueView, err = b.payload.AppendSet(key, value)

--- a/TreeDB/command_wal_public_test.go
+++ b/TreeDB/command_wal_public_test.go
@@ -1501,6 +1501,129 @@ func TestPublicCommandWALBatchResetPreservesCompactZeroScanFallback(t *testing.T
 	}
 }
 
+func TestPublicCommandWALBatchRevisionPayloadSetKeepsMutableAllZeroValue(t *testing.T) {
+	dir := t.TempDir()
+	db, err := Open(Options{
+		Dir:                 dir,
+		Durability:          DurabilityWALOnRelaxed,
+		CommandWAL:          true,
+		CommandWALStatsScan: true,
+		DisableSideStores:   true,
+	})
+	if err != nil {
+		t.Fatalf("Open command WAL: %v", err)
+	}
+
+	b, ok := db.NewBatch().(*commandWALPublicBatch)
+	if !ok {
+		_ = db.Close()
+		t.Fatalf("NewBatch type=%T, want *commandWALPublicBatch", db.NewBatch())
+	}
+	zeroValue := make([]byte, 128)
+	if err := b.Set([]byte("k"), zeroValue); err != nil {
+		_ = b.Close()
+		_ = db.Close()
+		t.Fatalf("Set zero value: %v", err)
+	}
+	for i := range zeroValue {
+		zeroValue[i] = byte(i + 1)
+	}
+	if err := b.Write(); err != nil {
+		_ = b.Close()
+		_ = db.Close()
+		t.Fatalf("batch Write: %v", err)
+	}
+	if err := b.Close(); err != nil {
+		_ = db.Close()
+		t.Fatalf("batch Close: %v", err)
+	}
+
+	val, revision, err := db.GetVersioned([]byte("k"))
+	if err != nil {
+		_ = db.Close()
+		t.Fatalf("GetVersioned: %v", err)
+	}
+	if len(val) != 128 || !commandWALPublicAllZeroBytes(val) || revision == LegacyEntryRevision {
+		_ = db.Close()
+		t.Fatalf("GetVersioned len=%d zero=%t revision=%d, want zero/non-legacy", len(val), commandWALPublicAllZeroBytes(val), revision)
+	}
+
+	r, err := commitlog.NewReader(filepath.Join(backenddb.WALDirPath(dir), "commit-l0-000001.log"))
+	if err != nil {
+		_ = db.Close()
+		t.Fatalf("NewReader: %v", err)
+	}
+	env, err := r.ReadCommandFrame()
+	if err != nil {
+		_ = r.Close()
+		_ = db.Close()
+		t.Fatalf("ReadCommandFrame: %v", err)
+	}
+	var gotRevision uint64
+	visits := 0
+	if err := commitlog.ScanRawKVBatchPayloadWithRevision(env.Payload, func(op commitlog.RawKVOp, gotKey, gotValue []byte, got uint64) error {
+		visits++
+		if op != commitlog.RawKVOpSet || string(gotKey) != "k" || len(gotValue) != 128 || !commandWALPublicAllZeroBytes(gotValue) {
+			t.Fatalf("decoded op=%v key=%q value_len=%d zero=%t", op, gotKey, len(gotValue), commandWALPublicAllZeroBytes(gotValue))
+		}
+		gotRevision = got
+		return nil
+	}); err != nil {
+		_ = r.Close()
+		_ = db.Close()
+		t.Fatalf("ScanRawKVBatchPayloadWithRevision: %v", err)
+	}
+	if err := r.Close(); err != nil {
+		_ = db.Close()
+		t.Fatalf("reader Close: %v", err)
+	}
+	if visits != 1 || gotRevision != uint64(revision) {
+		_ = db.Close()
+		t.Fatalf("command WAL visits=%d revision=%d, want 1/%d", visits, gotRevision, revision)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+}
+
+func TestPublicCommandWALBatchLegacyCompactZeroPinsMutableValueIdentity(t *testing.T) {
+	wrapped := newCommandWALPublicBatch(nil, &commandWALResetBatch{}, 2)
+	zeroValue := make([]byte, 4)
+
+	if err := wrapped.Set([]byte("zero"), zeroValue); err != nil {
+		t.Fatalf("Set zero: %v", err)
+	}
+	for i := range zeroValue {
+		zeroValue[i] = byte(i + 1)
+	}
+	if err := wrapped.Set([]byte("mutated"), zeroValue); err != nil {
+		t.Fatalf("Set mutated: %v", err)
+	}
+	payload, err := wrapped.commandWALPayload()
+	if err != nil {
+		t.Fatalf("commandWALPayload: %v", err)
+	}
+	var got []batch.Entry
+	if err := commitlog.ScanRawKVBatchPayload(payload, func(op commitlog.RawKVOp, key, value []byte) error {
+		if op != commitlog.RawKVOpSet {
+			t.Fatalf("decoded op=%v, want set", op)
+		}
+		got = append(got, batch.Entry{Type: batch.OpPut, Key: append([]byte(nil), key...), Value: append([]byte(nil), value...)})
+		return nil
+	}); err != nil {
+		t.Fatalf("ScanRawKVBatchPayload: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("decoded entries=%d, want 2", len(got))
+	}
+	if string(got[0].Key) != "zero" || len(got[0].Value) != 4 || !commandWALPublicAllZeroBytes(got[0].Value) {
+		t.Fatalf("first decoded entry key=%q value=%v, want zero value", got[0].Key, got[0].Value)
+	}
+	if string(got[1].Key) != "mutated" || !bytes.Equal(got[1].Value, []byte{1, 2, 3, 4}) {
+		t.Fatalf("second decoded entry key=%q value=%v, want mutated value", got[1].Key, got[1].Value)
+	}
+}
+
 func TestPublicCommandWALBatchOrdinarySetUsesPayloadBuilder(t *testing.T) {
 	inner := &commandWALPayloadSoftCapBatch{}
 	wrapped := newCommandWALPublicBatch(nil, inner, 0)


### PR DESCRIPTION
Parent tracker: #3475
Depends on: #3480
Closes #3477 after #3480 merges and this PR is rebased/revalidated on `main`.

## Summary

This is the M1 optimization PR for the plain-send TreeDB profiling loop. It removes one measured allocation source in the command-WAL public batch path:

- entry-revision RawKV payloads already disable compact-zero tracking;
- `AppendSet` already copies caller value bytes into canonical payload-owned storage;
- therefore the extra all-zero defensive `append([]byte(nil), value...)` is redundant when `EntryRevisionsEnabled()` is true.

The defensive copy remains in place for legacy/non-revision compact-zero payloads, where buffer identity is still part of the compact-zero safety model.

## Before / After

Baseline: #3480 head `5b31b4f1b86f8fb6977eb9bb64b6a2757de1f2bc`
Candidate: this branch `eed3f687888decbcc548ba218e46bac7ee947444`
Machine: Intel i5-11400F, Go linux/amd64
Environment: `GOWORK=off TMPDIR=/mnt/fast4tb/tmp GOCACHE=/mnt/fast4tb/tmp/gocache GOMODCACHE=/mnt/fast4tb/tmp/gomodcache GOPATH=/mnt/fast4tb/tmp/gopath`

Command:

```sh
GOWORK=off TMPDIR=/mnt/fast4tb/tmp GOCACHE=/mnt/fast4tb/tmp/gocache \
  GOMODCACHE=/mnt/fast4tb/tmp/gomodcache GOPATH=/mnt/fast4tb/tmp/gopath \
  go test ./TreeDB -run '^$' \
  -bench 'BenchmarkSyncLatencyCached/BatchWriteSync/wal_on_relaxed_sync_command_wal/32/(entry_hint|entry_hint_nonzero_value|byte_hint|byte_hint_nonzero_value)$' \
  -benchtime=1s -count=1 -benchmem
```

| Case | Before ns/op | After ns/op | Before writes/s | After writes/s | Before B/op | After B/op | Before allocs/op | After allocs/op |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| `32/entry_hint` | 30,709 | 25,657 | 1,042,036 | 1,247,212 | 28,539 | 21,249 | 83 | 51 |
| `32/entry_hint_nonzero_value` | 25,430 | 22,711 | 1,258,369 | 1,409,038 | 19,096 | 19,181 | 51 | 51 |
| `32/byte_hint` | 97,222 | 97,481 | 329,143 | 328,269 | 928,753 | 925,234 | 86 | 54 |
| `32/byte_hint_nonzero_value` | 95,128 | 101,366 | 336,390 | 315,686 | 923,324 | 927,105 | 54 | 55 |

Gate status:

- All-zero entry-hint allocs/op: `83 -> 51`, target `<=55`: pass.
- All-zero B/op within 20% of nonzero entry-hint after value: `21,249` vs `19,181`: pass.
- Nonzero entry-hint allocs/op unchanged and B/op essentially unchanged: pass.
- Byte-hint cliff remains and is not claimed fixed by this PR.

## Profiles

Before profile root from M0:

```text
/mnt/fast4tb/treedb-plain-send-profile-m0-20260704T054135Z
```

After all-zero entry-hint allocation profile:

```text
/mnt/fast4tb/treedb-plain-send-profile-m1-20260704T055800Z/entryhint-allzero-after-alloc/heap.pprof
/mnt/fast4tb/treedb-plain-send-profile-m1-20260704T055800Z/entryhint-allzero-after-alloc/alloc_objects_top.txt
```

After 3s profile benchmark result:

| Case | ns/op | writes/s | B/op | allocs/op |
| --- | ---: | ---: | ---: | ---: |
| `32/entry_hint` | 25,182 | 1,270,730 | 23,565 | 50 |

The previous all-zero object hotspot in `commandWALPublicBatch.setView` is gone from the top alloc-object list; `setView` is now cumulative through `AppendSet` rather than a flat all-zero pre-copy source.

## Tests

```sh
GOWORK=off TMPDIR=/mnt/fast4tb/tmp GOCACHE=/mnt/fast4tb/tmp/gocache \
  GOMODCACHE=/mnt/fast4tb/tmp/gomodcache GOPATH=/mnt/fast4tb/tmp/gopath \
  go test ./TreeDB -run 'TestPublicCommandWALBatch(RevisionPayloadSetKeepsMutableAllZeroValue|LegacyCompactZeroPinsMutableValueIdentity|ReplayBytesPayloadPreservesAssignedRevision|ResetPreservesCompactZeroScanFallback)$'
```

Result: pass.

```sh
GOWORK=off TMPDIR=/mnt/fast4tb/tmp GOCACHE=/mnt/fast4tb/tmp/gocache \
  GOMODCACHE=/mnt/fast4tb/tmp/gomodcache GOPATH=/mnt/fast4tb/tmp/gopath \
  go test ./TreeDB -run '^TestPublicCommandWAL'
```

Result: pass.

Benchmark command above: pass.

## Review Notes

This PR is intentionally narrow. It does not change durability semantics, checkpoint semantics, or on-disk format. It must be revalidated after #3480 merges and before final merge into `main`.
