### PR TITLE
treedb: reduce command wal batch setup allocations

### DIFF
--- a/TreeDB/command_wal_public_cached.go
+++ b/TreeDB/command_wal_public_cached.go
@@ -273,26 +273,28 @@ func publicCommandWALPublishSync(durabilityMode string, sync bool) bool {
 }
 
 type commandWALPublicBatch struct {
-	db                  *DB
-	inner               Batch
-	innerSetViewFn      func(key, value []byte) error
-	innerDeleteViewFn   func(key []byte) error
-	payload             commitlog.RawKVBatchPayloadBuilder
-	payloadOpHint       int
-	payloadByteHint     int
-	payloadSoftCapBytes int
-	payloadBypass       bool
-	opCount             int
-	hasDeleteRange      bool
-	dirty               bool
-	setCalls            int
-	setBytes            int
-	setViewCalls        int
-	setViewBytes        int
-	deleteCalls         int
-	deleteBytes         int
-	deleteViewCalls     int
-	deleteViewBytes     int
+	db                       *DB
+	inner                    Batch
+	innerSetViewValidated    commandWALPublicInnerSetViewValidated
+	innerSetViewer           commandWALPublicInnerSetViewer
+	innerDeleteViewValidated commandWALPublicInnerDeleteViewValidated
+	innerDeleteViewer        commandWALPublicInnerDeleteViewer
+	payload                  commitlog.RawKVBatchPayloadBuilder
+	payloadOpHint            int
+	payloadByteHint          int
+	payloadSoftCapBytes      int
+	payloadBypass            bool
+	opCount                  int
+	hasDeleteRange           bool
+	dirty                    bool
+	setCalls                 int
+	setBytes                 int
+	setViewCalls             int
+	setViewBytes             int
+	deleteCalls              int
+	deleteBytes              int
+	deleteViewCalls          int
+	deleteViewBytes          int
 	// retainPayloadAfterWrite is set by adapter-only replay-view helpers. It
 	// keeps payload-owned key/value views valid after a successful Write until
 	// Reset/Close or the next mutation. Ordinary public Batch callers do not use
@@ -314,6 +316,22 @@ const commandWALRawKVBatchHeaderSize = 2 + 4
 type commandWALPublicRevisionEntries interface {
 	PointRevisionStats() (page.EntryRevision, bool)
 	OrderedEntries() []batch.Entry
+}
+
+type commandWALPublicInnerSetViewValidated interface {
+	SetViewValidated(key, value []byte) error
+}
+
+type commandWALPublicInnerSetViewer interface {
+	SetView(key, value []byte) error
+}
+
+type commandWALPublicInnerDeleteViewValidated interface {
+	DeleteViewValidated(key []byte) error
+}
+
+type commandWALPublicInnerDeleteViewer interface {
+	DeleteView(key []byte) error
 }
 
 func newCommandWALPublicBatch(tdb *DB, inner Batch, opHint int) *commandWALPublicBatch {
@@ -371,28 +389,22 @@ func (b *commandWALPublicBatch) rebindInnerViewers() {
 	if b == nil {
 		return
 	}
-	b.innerSetViewFn = nil
-	b.innerDeleteViewFn = nil
+	b.innerSetViewValidated = nil
+	b.innerSetViewer = nil
+	b.innerDeleteViewValidated = nil
+	b.innerDeleteViewer = nil
 	if b.inner == nil {
 		return
 	}
-	if setter, ok := b.inner.(interface {
-		SetViewValidated(key, value []byte) error
-	}); ok {
-		b.innerSetViewFn = setter.SetViewValidated
-	} else if setter, ok := b.inner.(interface {
-		SetView(key, value []byte) error
-	}); ok {
-		b.innerSetViewFn = setter.SetView
+	if setter, ok := b.inner.(commandWALPublicInnerSetViewValidated); ok {
+		b.innerSetViewValidated = setter
+	} else if setter, ok := b.inner.(commandWALPublicInnerSetViewer); ok {
+		b.innerSetViewer = setter
 	}
-	if deleter, ok := b.inner.(interface {
-		DeleteViewValidated(key []byte) error
-	}); ok {
-		b.innerDeleteViewFn = deleter.DeleteViewValidated
-	} else if deleter, ok := b.inner.(interface {
-		DeleteView(key []byte) error
-	}); ok {
-		b.innerDeleteViewFn = deleter.DeleteView
+	if deleter, ok := b.inner.(commandWALPublicInnerDeleteViewValidated); ok {
+		b.innerDeleteViewValidated = deleter
+	} else if deleter, ok := b.inner.(commandWALPublicInnerDeleteViewer); ok {
+		b.innerDeleteViewer = deleter
 	}
 }
 
@@ -647,15 +659,21 @@ func (b *commandWALPublicBatch) resetPointIngressStats() {
 }
 
 func (b *commandWALPublicBatch) innerSetView(key, value []byte) error {
-	if b.innerSetViewFn != nil {
-		return b.innerSetViewFn(key, value)
+	if b.innerSetViewValidated != nil {
+		return b.innerSetViewValidated.SetViewValidated(key, value)
+	}
+	if b.innerSetViewer != nil {
+		return b.innerSetViewer.SetView(key, value)
 	}
 	return b.inner.Set(key, value)
 }
 
 func (b *commandWALPublicBatch) innerDeleteView(key []byte) error {
-	if b.innerDeleteViewFn != nil {
-		return b.innerDeleteViewFn(key)
+	if b.innerDeleteViewValidated != nil {
+		return b.innerDeleteViewValidated.DeleteViewValidated(key)
+	}
+	if b.innerDeleteViewer != nil {
+		return b.innerDeleteViewer.DeleteView(key)
 	}
 	return b.inner.Delete(key)
 }
@@ -761,8 +779,10 @@ func (b *commandWALPublicBatch) Close() error {
 	// appends and publishes a RawKVBatch command frame.
 	err := b.inner.Close()
 	b.inner = nil
-	b.innerSetViewFn = nil
-	b.innerDeleteViewFn = nil
+	b.innerSetViewValidated = nil
+	b.innerSetViewer = nil
+	b.innerDeleteViewValidated = nil
+	b.innerDeleteViewer = nil
 	b.resetPayloadWithHint()
 	b.opCount = 0
 	b.hasDeleteRange = false

--- a/TreeDB/internal/commitlog/command_frame.go
+++ b/TreeDB/internal/commitlog/command_frame.go
@@ -27,7 +27,7 @@ const (
 	rawKVOpRevisionHeaderSize             = rawKVOpHeaderSize + 8
 	rawKVZeroOpHeaderSize                 = 4
 	rawKVZeroOpHeaderSizeV3               = 2
-	rawKVRevisionOffsetInlineCap          = 8
+	rawKVRevisionOffsetInlineCap          = 32
 	rawKVNilRangeBoundLenUint32           = uint32(^uint32(0))
 
 	collectionRebuildVectorIndexPayloadVersion      = uint16(1)


### PR DESCRIPTION
Closes #3478.
Depends on #3481. This PR is intentionally stacked on `codex/3477-command-wal-allzero-copy` and must be retargeted/revalidated on `main` after #3481 merges.

## Start-Phase Test Plan

- Preserve command-WAL public batch ownership and replay semantics.
- Keep the benchmark harness unchanged from #3480/#3481.
- Target only the post-M1 allocation sites measured in the focused profile: per-batch bound method values and revision-offset heap allocation for 32-op revision-aware command-WAL batches.

## Start-Phase Performance Plan

Baseline profile source:

- `/mnt/fast4tb/treedb-plain-send-profile-m1-20260704T055800Z/entryhint-allzero-after-alloc/heap.pprof`

Baseline post-M1 `alloc_objects` targets:

| Path | Flat objects | Flat % |
| --- | ---: | ---: |
| `(*commandWALPublicBatch).rebindInnerViewers` | 283,995 | 5.63% |
| `RawKVBatchPayloadBuilder.resetRevisionOffsetsForHint` | 167,956 | 3.33% |
| `newCommandWALPublicBatch` | 139,315 flat / 591,266 cum | 2.76% flat / 11.73% cum |

## Changes

- Replaced stored bound method values in `commandWALPublicBatch` with stored typed interface receivers, so `rebindInnerViewers` no longer allocates method values per public batch.
- Increased the revision-offset inline capacity from 8 to 32 so the common 32-op revision-aware command-WAL batch does not allocate a separate revision-offset slice.

## Close-Phase Test Evidence

Environment:

```sh
GOWORK=off TMPDIR=/mnt/fast4tb/tmp GOCACHE=/mnt/fast4tb/tmp/gocache \
  GOMODCACHE=/mnt/fast4tb/tmp/gomodcache GOPATH=/mnt/fast4tb/tmp/gopath
```

Passed locally:

```sh
go test ./TreeDB -run '^TestPublicCommandWAL'
go test ./TreeDB ./TreeDB/internal/commitlog
```

## Close-Phase Benchmark/Profile Evidence

Artifact root:

```text
/mnt/fast4tb/treedb-plain-send-profile-m2-20260704T061055Z
```

Files:

- `bench_matrix_3s.txt`
- `heap.pprof`
- `alloc_objects_top.txt`
- `alloc_space_top.txt`
- `cpu.pprof`
- `cpu_top.txt`

3s normal benchmem matrix:

| Case | ns/op | writes/s | B/op | allocs/op |
| --- | ---: | ---: | ---: | ---: |
| `32/entry_hint` | 25,647 | 1,247,721 | 22,385 | 47 |
| `32/entry_hint_nonzero_value` | 24,743 | 1,293,317 | 24,409 | 47 |
| `32/byte_hint` | 90,475 | 353,688 | 912,017 | 49 |
| `32/byte_hint_nonzero_value` | 93,753 | 341,323 | 912,157 | 49 |

M2 allocation profile result:

- `(*commandWALPublicBatch).rebindInnerViewers` is no longer present in the allocation top list.
- `RawKVBatchPayloadBuilder.resetRevisionOffsetsForHint` is no longer present in the allocation top list.
- Remaining `alloc_objects` leaders are benchmark harness batch/key allocation, memtable apply, cached batch write, public operation bookkeeping, commitlog read/decode, and one wrapper allocation in `newCommandWALPublicBatch`.

## Before/After Summary

Relative to M1 local benchmark evidence from #3481:

| Case | M1 allocs/op | M2 allocs/op | M1 B/op | M2 B/op | Notes |
| --- | ---: | ---: | ---: | ---: | --- |
| `32/entry_hint` | 51 | 47 | 21,249 | 22,385 | target allocators removed; B/op slightly noisy/higher in 3s run |
| `32/entry_hint_nonzero_value` | 51 | 47 | 19,181 | 24,409 | allocs improved; B/op noisy and should be watched in CI/follow-up |
| `32/byte_hint` | 54 | 49 | 925,234 | 912,017 | byte-hint cliff remains separate from this issue |
| `32/byte_hint_nonzero_value` | 55 | 49 | 927,105 | 912,157 | byte-hint cliff remains separate from this issue |

## Performance Regression Assessment

This removes the intended allocation-object hot spots and reduces allocs/op in the focused matrix. The profile now points to larger remaining buckets in memtable rotation/apply, command-WAL cleanup replay/decode, canonical payload allocation, and benchmark/harness batch setup.

The B/op comparison is noisy across 1s/3s runs and should not be overclaimed as a memory-space win. The objective here is allocation-object churn; the next loop should use the post-merge Ironbird/current-main measurement to decide whether memtable rotation, cleanup replay/decode, or wrapper pooling is worth another issue.

## Measurement Boundary

The normal benchmem matrix measures the benchmark's full loop for 32 writes per `WriteSync`, including batch construction, command-WAL append/publish, cached batch write, and close/cleanup behavior. The `-memprofilerate=1` profile run is intentionally slower and is used only for allocation attribution.

## AI Review Status

No review-credit-consuming AI review requested yet. This PR is stacked and should wait until #3481 lands, then be retargeted to `main`, revalidated, and allowed to run normal mature-review/CI gates.
