### PR TITLE
TreeDB: reduce append-only reserve growth churn

### DIFF
--- a/TreeDB/internal/memtable/append_only.go
+++ b/TreeDB/internal/memtable/append_only.go
@@ -51,7 +51,10 @@ const (
 	appendOnlyReuseOversizeFactor       = 4
 	appendOnlyResetDropThresholdEntries = 1 << 15
 	appendOnlyAggressiveGrowCutoff      = appendOnlyResetDropThresholdEntries * 2
-	appendOnlyReserveHeadroomDivisor    = 4
+	// Reserve calls usually know the near-term write batch size. Keep amortized
+	// headroom so append-heavy commit paths do not repeatedly grow and copy the
+	// entry slice while filling a large mutable memtable.
+	appendOnlyReserveHeadroomDivisor = 1
 )
 
 var appendOnlyEntryPoolRetainBudgetBytes = uint64(256 << 20)


### PR DESCRIPTION
Closes #3483.

## Summary
- Increase append-only memtable reserve headroom for batch-sized reserve calls.
- Reduce repeated entry-slice growth/copy churn while filling large mutable memtables.
- Keep this scoped to allocation policy only; no durability, command-WAL, checkpoint, or format changes.

## Profile evidence
Focused benchmark: `BenchmarkSyncLatencyCached/BatchWriteSync/wal_on_relaxed_sync_command_wal/128/entry_hint`, 20,000 iterations, `-benchmem -memprofilerate=1`.

Baseline artifact: `/mnt/fast4tb/tmp/gomap-3483-baseline-20260704T072525Z`
- `245508 ns/op`
- `521367 writes/s`
- `126943 B/op`, `155 allocs/op`
- `reserve.grow_calls_total=224`
- `reserve.grow_bytes_total=838746744`
- `getAppendOnlyEntries=1582664kB alloc_space`

Final artifact: `/mnt/fast4tb/tmp/gomap-3483-final-20260704T073021Z`
- `236495 ns/op`
- `541238 writes/s`
- `108759 B/op`, `155 allocs/op`
- `reserve.grow_calls_total=80`
- `reserve.grow_bytes_total=477439072`
- `getAppendOnlyEntries=1229264kB alloc_space`

Net: about 3.7% higher focused write throughput, 14.3% lower B/op, 64% fewer reserve grows, and 22% less `getAppendOnlyEntries` alloc_space.

## Validation
- `env GOWORK=off TMPDIR=/mnt/fast4tb/tmp GOCACHE=/mnt/fast4tb/tmp/go-cache GOMODCACHE=/mnt/fast4tb/tmp/go-mod-cache GOPATH=/mnt/fast4tb/tmp/go-path-cache go test ./TreeDB/internal/memtable -run 'TestAppendOnly' -count=1`
- `env GOWORK=off TMPDIR=/mnt/fast4tb/tmp GOCACHE=/mnt/fast4tb/tmp/go-cache GOMODCACHE=/mnt/fast4tb/tmp/go-mod-cache GOPATH=/mnt/fast4tb/tmp/go-path-cache go test ./TreeDB -run 'TestSyncDurabilityBoundaryDoesNotCheckpoint|TestPublicCommandWALDurableBatchWriteSyncDoesNotCheckpoint' -count=1`
- `env GOWORK=off TMPDIR=/mnt/fast4tb/tmp GOCACHE=/mnt/fast4tb/tmp/go-cache GOMODCACHE=/mnt/fast4tb/tmp/go-mod-cache GOPATH=/mnt/fast4tb/tmp/go-path-cache go test ./TreeDB/caching -run 'TestAppendOnlyEntryHint|TestTrimRetainedArenasAfterFlush|TestAppendOnlyIdleMutableRetainCapacity' -count=1`
- Final focused benchmark above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how the system reserves extra space during append-heavy operations, which should make write and commit paths more reliable under load.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->