### PR TITLE
TreeDB: pool command WAL payload builders

### DIFF
--- a/TreeDB/command_wal_public_cached.go
+++ b/TreeDB/command_wal_public_cached.go
@@ -311,6 +311,10 @@ const commandWALPublicBatchEstimatedKeyValueBytes = 192
 // large-batch peak while preserving the compact fast path for ordinary batches.
 const commandWALPublicBatchPayloadSoftCapBytes = 128 << 20
 
+// Pool only ordinary payload buffers. Reusing the public batch wrapper itself is
+// unsafe because callers may still hold a closed batch value.
+const commandWALPublicBatchPayloadPoolRetainMaxBytes = 1 << 20
+
 const commandWALRawKVBatchHeaderSize = 2 + 4
 
 type commandWALPublicRevisionEntries interface {
@@ -335,7 +339,15 @@ type commandWALPublicInnerDeleteViewer interface {
 }
 
 func newCommandWALPublicBatch(tdb *DB, inner Batch, opHint int) *commandWALPublicBatch {
-	b := &commandWALPublicBatch{db: tdb, inner: inner}
+	var payload commitlog.RawKVBatchPayloadBuilder
+	if tdb != nil {
+		if pooled := tdb.commandWALPublicPayloadPool.Get(); pooled != nil {
+			if p, ok := pooled.(commitlog.RawKVBatchPayloadBuilder); ok {
+				payload = p
+			}
+		}
+	}
+	b := &commandWALPublicBatch{db: tdb, inner: inner, payload: payload}
 	b.disableInnerStreamingBypass()
 	b.rebindInnerViewers()
 	opHint = db.NormalizePublicBatchReserveHint(opHint)
@@ -774,22 +786,33 @@ func (b *commandWALPublicBatch) Close() error {
 	if b == nil || b.inner == nil {
 		return nil
 	}
+	owner := b.db
 	// Closing an uncommitted batch intentionally discards staged command-WAL
 	// payload bytes, matching ordinary batch semantics: only Write/WriteSync
 	// appends and publishes a RawKVBatch command frame.
 	err := b.inner.Close()
+	b.resetPayloadWithHint()
+	payload := b.payload
+	keepPayload := payload.PrepareForReuse(commandWALPublicBatchPayloadPoolRetainMaxBytes)
 	b.inner = nil
 	b.innerSetViewValidated = nil
 	b.innerSetViewer = nil
 	b.innerDeleteViewValidated = nil
 	b.innerDeleteViewer = nil
-	b.resetPayloadWithHint()
+	b.payload = commitlog.RawKVBatchPayloadBuilder{}
+	b.payloadBypass = false
+	b.payloadOpHint = 0
+	b.payloadByteHint = 0
+	b.payloadSoftCapBytes = 0
 	b.opCount = 0
 	b.hasDeleteRange = false
 	b.resetPointIngressStats()
 	b.dirty = false
 	b.retainPayloadAfterWrite = false
 	b.closed = true
+	if owner != nil && keepPayload {
+		owner.commandWALPublicPayloadPool.Put(payload)
+	}
 	return err
 }
 

--- a/TreeDB/command_wal_public_test.go
+++ b/TreeDB/command_wal_public_test.go
@@ -3141,3 +3141,132 @@ func TestPublicCommandWALBatchWriteAfterCloseReturnsErrClosed(t *testing.T) {
 		t.Fatalf("batch Close: %v", err)
 	}
 }
+
+func TestPublicCommandWALBatchPayloadPoolAcquisitionKeepsClosedHandlesIsolated(t *testing.T) {
+	db, err := Open(Options{
+		Dir:                 t.TempDir(),
+		Durability:          DurabilityWALOnRelaxed,
+		CommandWAL:          true,
+		CommandWALStatsScan: true,
+		DisableSideStores:   true,
+	})
+	if err != nil {
+		t.Fatalf("Open command WAL: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	var seededPayload commitlog.RawKVBatchPayloadBuilder
+	if err := seededPayload.ResetWithHint(0, 0); err != nil {
+		t.Fatalf("seeded ResetWithHint: %v", err)
+	}
+	if _, _, err := seededPayload.AppendSet([]byte("seed"), bytes.Repeat([]byte{7}, 128)); err != nil {
+		t.Fatalf("seeded AppendSet: %v", err)
+	}
+	seededRetained := seededPayload.RetainedCap()
+	db.commandWALPublicPayloadPool.New = func() any {
+		return seededPayload
+	}
+
+	const entries = 128
+	value := bytes.Repeat([]byte{7}, 128)
+	first, ok := db.NewBatchWithSize(entries).(*commandWALPublicBatch)
+	if !ok {
+		t.Fatalf("NewBatchWithSize type=%T, want *commandWALPublicBatch", first)
+	}
+	if got := first.payload.RetainedCap(); got != seededRetained {
+		_ = first.Close()
+		t.Fatalf("first payload retained cap=%d, want seeded cap %d", got, seededRetained)
+	}
+	for i := 0; i < entries; i++ {
+		key := []byte(fmt.Sprintf("first-%03d", i))
+		if err := first.Set(key, value); err != nil {
+			_ = first.Close()
+			t.Fatalf("first Set %d: %v", i, err)
+		}
+	}
+	retained := first.payload.RetainedCap()
+	if retained <= commandWALRawKVBatchHeaderSize {
+		_ = first.Close()
+		t.Fatalf("first payload retained cap=%d, want payload allocation", retained)
+	}
+	if err := first.WriteSync(); err != nil {
+		_ = first.Close()
+		t.Fatalf("first WriteSync: %v", err)
+	}
+	if err := first.Close(); err != nil {
+		t.Fatalf("first Close: %v", err)
+	}
+	if err := first.Set([]byte("stale"), value); !errors.Is(err, ErrClosed) {
+		t.Fatalf("first Set after Close error=%v, want ErrClosed", err)
+	}
+
+	second, ok := db.NewBatchWithSize(entries).(*commandWALPublicBatch)
+	if !ok {
+		t.Fatalf("second NewBatchWithSize type=%T, want *commandWALPublicBatch", second)
+	}
+	if err := second.Set([]byte("second"), []byte("value")); err != nil {
+		_ = second.Close()
+		t.Fatalf("second Set: %v", err)
+	}
+	if err := second.WriteSync(); err != nil {
+		_ = second.Close()
+		t.Fatalf("second WriteSync: %v", err)
+	}
+	if err := second.Close(); err != nil {
+		t.Fatalf("second Close: %v", err)
+	}
+	got, err := db.Get([]byte("second"))
+	if err != nil {
+		t.Fatalf("Get(second): %v", err)
+	}
+	if string(got) != "value" {
+		t.Fatalf("Get(second)=%q, want value", got)
+	}
+	if err := first.WriteSync(); !errors.Is(err, ErrClosed) {
+		t.Fatalf("first WriteSync after second batch error=%v, want ErrClosed", err)
+	}
+}
+
+func TestPublicCommandWALBatchPayloadPoolDropsOversizeBuffer(t *testing.T) {
+	db, err := Open(Options{
+		Dir:                 t.TempDir(),
+		Durability:          DurabilityWALOnRelaxed,
+		CommandWAL:          true,
+		CommandWALStatsScan: true,
+		DisableSideStores:   true,
+	})
+	if err != nil {
+		t.Fatalf("Open command WAL: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	oversizeHint := commandWALPublicBatchPayloadPoolRetainMaxBytes/commandWALPublicBatchEstimatedKeyValueBytes + 128
+	large, ok := db.NewBatchWithSize(oversizeHint).(*commandWALPublicBatch)
+	if !ok {
+		t.Fatalf("NewBatchWithSize type=%T, want *commandWALPublicBatch", large)
+	}
+	if err := large.Set([]byte("large"), bytes.Repeat([]byte{9}, 128)); err != nil {
+		_ = large.Close()
+		t.Fatalf("large Set: %v", err)
+	}
+	if got := large.payload.RetainedCap(); got <= commandWALPublicBatchPayloadPoolRetainMaxBytes {
+		_ = large.Close()
+		t.Fatalf("large payload retained cap=%d, want > pool retain max %d", got, commandWALPublicBatchPayloadPoolRetainMaxBytes)
+	}
+	if err := large.WriteSync(); err != nil {
+		_ = large.Close()
+		t.Fatalf("large WriteSync: %v", err)
+	}
+	if err := large.Close(); err != nil {
+		t.Fatalf("large Close: %v", err)
+	}
+
+	small, ok := db.NewBatchWithSize(1).(*commandWALPublicBatch)
+	if !ok {
+		t.Fatalf("small NewBatchWithSize type=%T, want *commandWALPublicBatch", small)
+	}
+	defer func() { _ = small.Close() }()
+	if got := small.payload.RetainedCap(); got > commandWALPublicBatchPayloadPoolRetainMaxBytes {
+		t.Fatalf("small payload retained cap=%d, oversized buffer leaked through pool", got)
+	}
+}

--- a/TreeDB/internal/commitlog/command_frame.go
+++ b/TreeDB/internal/commitlog/command_frame.go
@@ -435,6 +435,65 @@ func (b *RawKVBatchPayloadBuilder) RetainedCap() int {
 	return cap(b.payload)
 }
 
+// RetainedBytes returns the total builder-owned backing capacity retained across
+// canonical, compact-zero, zero-value-view, and heap revision-offset buffers.
+func (b *RawKVBatchPayloadBuilder) RetainedBytes() int {
+	if b == nil {
+		return 0
+	}
+	total := 0
+	maxInt := int(^uint(0) >> 1)
+	add := func(n int) {
+		if n < 0 || n > maxInt-total {
+			total = maxInt
+			return
+		}
+		total += n
+	}
+	add(cap(b.payload))
+	add(cap(b.zeroPayload))
+	add(cap(b.zeroSetValueView))
+	if cap(b.revisionOffsets) > rawKVRevisionOffsetInlineCap {
+		if cap(b.revisionOffsets) > maxInt/4 {
+			return maxInt
+		}
+		add(cap(b.revisionOffsets) * 4)
+	}
+	return total
+}
+
+// PrepareForReuse clears logical state while retaining bounded backing buffers.
+// It also drops inline-sized revision-offset slices because a copied builder may
+// have that slice pointing at another builder's embedded inline array.
+func (b *RawKVBatchPayloadBuilder) PrepareForReuse(maxRetainedBytes int) bool {
+	if b == nil {
+		return false
+	}
+	if maxRetainedBytes >= 0 && b.RetainedBytes() > maxRetainedBytes {
+		*b = RawKVBatchPayloadBuilder{}
+		return false
+	}
+	payload := b.payload
+	zeroPayload := b.zeroPayload
+	zeroSetValueView := b.zeroSetValueView
+	revisionOffsets := b.revisionOffsets
+	keepRevisionOffsets := cap(revisionOffsets) > rawKVRevisionOffsetInlineCap
+	*b = RawKVBatchPayloadBuilder{}
+	if cap(payload) > 0 {
+		b.payload = payload[:0]
+	}
+	if cap(zeroPayload) > 0 {
+		b.zeroPayload = zeroPayload[:0]
+	}
+	if cap(zeroSetValueView) > 0 {
+		b.zeroSetValueView = zeroSetValueView[:0]
+	}
+	if keepRevisionOffsets {
+		b.revisionOffsets = revisionOffsets[:0]
+	}
+	return b.RetainedBytes() > 0
+}
+
 // RetainedCapAfterAppend returns the backing capacity that would be retained
 // after appending needed bytes with the same growth rule used by Append.
 func (b *RawKVBatchPayloadBuilder) RetainedCapAfterAppend(needed int) (int, error) {

--- a/TreeDB/internal/commitlog/command_frame_test.go
+++ b/TreeDB/internal/commitlog/command_frame_test.go
@@ -292,6 +292,111 @@ func TestRawKVBatchPayloadBuilderRetainedCapPredictsCompactZeroBuffers(t *testin
 	}
 }
 
+func TestRawKVBatchPayloadBuilderRetainedBytesIncludesCompactZeroBuffers(t *testing.T) {
+	var builder RawKVBatchPayloadBuilder
+	if err := builder.ResetWithHint(0, 0); err != nil {
+		t.Fatalf("ResetWithHint: %v", err)
+	}
+	if _, _, err := builder.AppendSet([]byte("zero"), make([]byte, 128)); err != nil {
+		t.Fatalf("AppendSet compact zero: %v", err)
+	}
+	if cap(builder.zeroPayload) == 0 || cap(builder.zeroSetValueView) == 0 {
+		t.Fatalf("compact-zero append did not retain side buffers: zeroPayload cap=%d zeroSetValueView cap=%d", cap(builder.zeroPayload), cap(builder.zeroSetValueView))
+	}
+	want := cap(builder.payload) + cap(builder.zeroPayload) + cap(builder.zeroSetValueView)
+	if got := builder.RetainedBytes(); got != want {
+		t.Fatalf("RetainedBytes=%d, want payload+zero buffers=%d", got, want)
+	}
+	if got := builder.RetainedCap(); got >= builder.RetainedBytes() {
+		t.Fatalf("RetainedCap=%d should not account for compact-zero side buffers retainedBytes=%d", got, builder.RetainedBytes())
+	}
+}
+
+func TestRawKVBatchPayloadBuilderPrepareForReuseDropsOversizeRetainedBuffers(t *testing.T) {
+	var builder RawKVBatchPayloadBuilder
+	if err := builder.ResetWithHint(0, 0); err != nil {
+		t.Fatalf("ResetWithHint: %v", err)
+	}
+	if _, _, err := builder.AppendSet([]byte("large"), bytes.Repeat([]byte{1}, 64<<10)); err != nil {
+		t.Fatalf("AppendSet large: %v", err)
+	}
+	retained := builder.RetainedBytes()
+	if retained < 64<<10 {
+		t.Fatalf("retained bytes=%d, want large payload retained", retained)
+	}
+	if builder.PrepareForReuse(retained - 1) {
+		t.Fatalf("PrepareForReuse returned true for retained=%d with max=%d", retained, retained-1)
+	}
+	if got := builder.RetainedBytes(); got != 0 {
+		t.Fatalf("RetainedBytes after oversize drop=%d, want 0", got)
+	}
+	if got := builder.RetainedCap(); got != 0 {
+		t.Fatalf("RetainedCap after oversize drop=%d, want 0", got)
+	}
+}
+
+func TestRawKVBatchPayloadBuilderPrepareForReuseDropsInlineRevisionOffsets(t *testing.T) {
+	var builder RawKVBatchPayloadBuilder
+	if err := builder.ResetWithHint(2, 64); err != nil {
+		t.Fatalf("ResetWithHint: %v", err)
+	}
+	if err := builder.EnableEntryRevisions(); err != nil {
+		t.Fatalf("EnableEntryRevisions: %v", err)
+	}
+	if cap(builder.revisionOffsets) != rawKVRevisionOffsetInlineCap {
+		t.Fatalf("revision offset cap=%d, want inline cap %d", cap(builder.revisionOffsets), rawKVRevisionOffsetInlineCap)
+	}
+
+	pooled := builder
+	if !pooled.PrepareForReuse(1 << 20) {
+		t.Fatal("PrepareForReuse returned false for bounded inline-revision builder")
+	}
+	if pooled.revisionOffsets != nil {
+		t.Fatalf("pooled inline revision offsets retained with cap=%d; copied builders must drop inline aliases", cap(pooled.revisionOffsets))
+	}
+	if err := pooled.ResetWithHint(2, 64); err != nil {
+		t.Fatalf("pooled ResetWithHint: %v", err)
+	}
+	if err := pooled.EnableEntryRevisions(); err != nil {
+		t.Fatalf("pooled EnableEntryRevisions: %v", err)
+	}
+	if cap(pooled.revisionOffsets) != rawKVRevisionOffsetInlineCap {
+		t.Fatalf("pooled revision offset cap=%d, want inline cap %d", cap(pooled.revisionOffsets), rawKVRevisionOffsetInlineCap)
+	}
+	gotBacking := &pooled.revisionOffsets[:cap(pooled.revisionOffsets)][0]
+	wantBacking := &pooled.revisionOffsetInline[0]
+	if gotBacking != wantBacking {
+		t.Fatalf("pooled revision offsets do not point at pooled builder inline array")
+	}
+	if _, _, err := pooled.AppendSet([]byte("key"), []byte("value")); err != nil {
+		t.Fatalf("pooled AppendSet: %v", err)
+	}
+	if len(pooled.revisionOffsets) != 1 {
+		t.Fatalf("pooled revision offsets len=%d, want 1 after append", len(pooled.revisionOffsets))
+	}
+}
+
+func TestRawKVBatchPayloadBuilderPrepareForReuseKeepsHeapRevisionOffsets(t *testing.T) {
+	var builder RawKVBatchPayloadBuilder
+	opHint := rawKVRevisionOffsetInlineCap + 1
+	if err := builder.ResetWithHint(opHint, 64); err != nil {
+		t.Fatalf("ResetWithHint: %v", err)
+	}
+	if err := builder.EnableEntryRevisions(); err != nil {
+		t.Fatalf("EnableEntryRevisions: %v", err)
+	}
+	if cap(builder.revisionOffsets) <= rawKVRevisionOffsetInlineCap {
+		t.Fatalf("revision offset cap=%d, want heap allocation larger than inline cap %d", cap(builder.revisionOffsets), rawKVRevisionOffsetInlineCap)
+	}
+	heapCap := cap(builder.revisionOffsets)
+	if !builder.PrepareForReuse(1 << 20) {
+		t.Fatal("PrepareForReuse returned false for bounded heap-revision builder")
+	}
+	if cap(builder.revisionOffsets) != heapCap || len(builder.revisionOffsets) != 0 {
+		t.Fatalf("heap revision offsets len/cap=%d/%d, want 0/%d", len(builder.revisionOffsets), cap(builder.revisionOffsets), heapCap)
+	}
+}
+
 func TestCommandWALCollectionPayloadDecodeBoundsCountBeforeAllocation(t *testing.T) {
 	payload := make([]byte, 10+len("users"))
 	encodeCollectionBatchHeader(payload, "users", int(^uint32(0)))

--- a/TreeDB/public.go
+++ b/TreeDB/public.go
@@ -169,6 +169,7 @@ type DB struct {
 	lifecycleMu                          sync.RWMutex
 	commandWALCached                     bool
 	commandWALPendingMu                  sync.Mutex
+	commandWALPublicPayloadPool          sync.Pool
 	commandWALFirst                      atomic.Uint64
 	commandWALLast                       atomic.Uint64
 	commandWALCheckpointCutoverLast      atomic.Uint64


### PR DESCRIPTION
## Summary

Closes #3485.

This PR reduces command-WAL public-batch allocation pressure by pooling only the `RawKVBatchPayloadBuilder` backing buffers owned by TreeDB. It deliberately does not pool `commandWALPublicBatch` wrapper objects because callers can retain closed batch handles; wrapper reuse would risk stale handles mutating or closing a later batch.

Implementation details:

- Adds a `DB`-owned payload-builder `sync.Pool` for the command-WAL cached public batch path.
- Returns only bounded ordinary payload builders to the pool on `Close`.
- Adds `RawKVBatchPayloadBuilder.RetainedBytes` and `PrepareForReuse` so pooled retention accounts for canonical payload, compact-zero side buffers, zero-value view buffers, and heap revision-offset buffers.
- Drops inline-sized revision-offset slices before pooling because copied builders must not retain another builder's embedded inline array.
- Adds focused tests for pool acquisition, closed-handle isolation, oversize drop behavior, compact-zero retained accounting, inline revision alias safety, heap revision reuse, and geth replay-byte lifetime.

## Scope Boundary

Non-goals in this PR:

- no durability semantic change;
- no public batch wrapper pooling;
- no `SetView` lifetime contract change;
- no command-WAL view-owned arena borrowing change;
- no cleanup/checkpoint decode optimization.

## Test Evidence

All commands used:

```sh
GOWORK=off TMPDIR=/mnt/fast4tb/tmp GOCACHE=/mnt/fast4tb/tmp/go-cache GOMODCACHE=/mnt/fast4tb/tmp/go-mod-cache GOPATH=/mnt/fast4tb/tmp/go-path-cache go test ./TreeDB/internal/commitlog -count=1
GOWORK=off TMPDIR=/mnt/fast4tb/tmp GOCACHE=/mnt/fast4tb/tmp/go-cache GOMODCACHE=/mnt/fast4tb/tmp/go-mod-cache GOPATH=/mnt/fast4tb/tmp/go-path-cache go test ./TreeDB -run '^TestPublicCommandWAL' -count=1
GOWORK=off TMPDIR=/mnt/fast4tb/tmp GOCACHE=/mnt/fast4tb/tmp/go-cache GOMODCACHE=/mnt/fast4tb/tmp/go-mod-cache GOPATH=/mnt/fast4tb/tmp/go-path-cache go test ./TreeDB -count=1
GOWORK=off TMPDIR=/mnt/fast4tb/tmp GOCACHE=/mnt/fast4tb/tmp/go-cache GOMODCACHE=/mnt/fast4tb/tmp/go-mod-cache GOPATH=/mnt/fast4tb/tmp/go-path-cache go test . -run 'TestBatch(BorrowedReplayBytesHandleReusedZeroValueBuffer|RepeatedWriteDetachesCommandWALBorrowedReplayBytes|ReplayAfterCloseDetachesCommandWALBorrowedReplayBytes)$' -count=1
```

Result: all passed locally.

## Benchmark Evidence

Baseline artifact root:

```text
/mnt/fast4tb/tmp/gomap-3483-postmerge-20260704T074744Z
```

Candidate artifact root:

```text
/mnt/fast4tb/tmp/gomap-3485-final2-20260704T080424Z
```

Benchmark command shape:

```sh
GOWORK=off TMPDIR=/mnt/fast4tb/tmp \
  GOCACHE=/mnt/fast4tb/tmp/go-cache \
  GOMODCACHE=/mnt/fast4tb/tmp/go-mod-cache \
  GOPATH=/mnt/fast4tb/tmp/go-path-cache \
  go test -v ./TreeDB -run '^$' \
  -bench '^BenchmarkSyncLatencyCached/BatchWriteSync/wal_on_relaxed_sync_command_wal/128/entry_hint$' \
  -benchtime=20000x -count=1 -benchmem \
  -memprofile "$OUT/sync_latency_allocs.pprof" -memprofilerate=1 -timeout=10m
```

| Metric | Post-#3484 baseline | This PR | Delta |
| --- | ---: | ---: | ---: |
| `ns/op` | `238431` | `223600` | `-6.2%` |
| writes/s | `536843` | `572451` | `+6.6%` |
| `B/op` | `108805` | `81183` | `-25.4%` |
| `allocs/op` | `155` | `153` | `-2` |
| `appendRawKVPayloadSpace` alloc_space | `532526.62kB` | not in top 30 | removed from profile top |

Measurement boundary: the benchmark times repeated public-batch `WriteSync` operations through the command-WAL cached path. It reports zero checkpoint runs inside the timed window.

## Final Profile Summary

Top remaining alloc_space nodes in the candidate profile:

| Path | alloc_space | Classification |
| --- | ---: | --- |
| `TreeDB/internal/memtable.getAppendOnlyEntries` | `1229264kB` / `44.81%` | Existing memtable entry backing cost. |
| `TreeDB/internal/commitlog.(*Reader).readSegmentPayload` | `400176.33kB` / `14.59%` | Cleanup/decode path visible in alloc profile; not the first timed write-path target unless separately timed. |
| `TreeDB/internal/commitlog.DecodeCommandFrame` | `400020kB` / `14.58%` | Cleanup/decode path visible in alloc profile. |
| `TreeDB/caching.getAppendOnlyDirectValueArenaChunk` | `305536kB` / `11.14%` | Next likely timed write-path target. |
| `TreeDB/caching.getEntrySlice` | `191500kB` / `6.98%` | Remaining entry-slice allocation target. |

## Performance Regression Assessment

No local regression was observed on the targeted benchmark. The intended allocation target is removed from the profile top list, `B/op` improves materially, and throughput improves modestly. Remaining dominant allocation nodes are pre-existing or outside this PR's scope and should be handled by follow-up issues after post-merge measurement.

## AI Review Status

Not requested yet. This PR is now mature for review: coherent implementation, focused tests, benchmark evidence, and current PR body are present. Request Codex/Copilot/CodeRabbit review only on this pushed head or a later mature head.
