### PR TITLE
TreeDB: learn append-only reserve capacity hints

### DIFF
--- a/TreeDB/caching/append_only_hint_test.go
+++ b/TreeDB/caching/append_only_hint_test.go
@@ -4,6 +4,8 @@ import (
 	"runtime"
 	"testing"
 	"time"
+
+	"github.com/snissn/gomap/TreeDB/internal/memtable"
 )
 
 func TestAppendOnlyEntryHint_AdaptiveDecayAndCapacityClamp(t *testing.T) {
@@ -123,5 +125,48 @@ func TestAppendOnlyEntryHint_CapacityTracksPressureScaledMutableThreshold(t *tes
 
 	if !(critical < high && high < normal) {
 		t.Fatalf("expected stricter caps under pressure: normal=%d high=%d critical=%d", normal, high, critical)
+	}
+}
+
+func TestAppendOnlyReserveDemandTeachesFutureCapacityHint(t *testing.T) {
+	var cache DB
+	cache.memtableCap = 8 << 20
+	cache.mutableThreshold.Store(int64(cache.memtableCap))
+
+	first := memtable.NewAppendOnlyWithEntryCapacity(appendOnlyEntryHintMinEntries)
+	const demand = 4096
+	reserveMemtableEntries(&cache, first, demand)
+	hint := int(cache.appendOnlyEntryHint.Load())
+	if hint < demand {
+		t.Fatalf("reserve demand hint=%d want >=%d", hint, demand)
+	}
+
+	next, err := cache.newMutableMemtableWithCapacityMode(cache.memtableCap, memtable.ModeAppendOnly)
+	if err != nil {
+		t.Fatalf("new mutable: %v", err)
+	}
+	appendOnly, ok := next.(*memtable.AppendOnly)
+	if !ok {
+		t.Fatalf("new mutable type=%T, want append-only", next)
+	}
+	if got := appendOnly.EntryCapacity(); got < hint {
+		t.Fatalf("future mutable capacity=%d want >= learned hint %d", got, hint)
+	}
+}
+
+func TestAppendOnlyReserveDemandHintClampsToPressureCapacity(t *testing.T) {
+	var cache DB
+	cache.memtableCap = 256 << 20
+	const threshold = 512 << 10
+	cache.mutableThreshold.Store(threshold)
+
+	cache.observeAppendOnlyReserveDemandEntries(appendOnlyEntryHintMaxEntries)
+	hint := int(cache.appendOnlyEntryHint.Load())
+	wantMax := appendOnlyEntryCapacityForBytes(memtableCapacity(threshold), appendOnlyEstimatedBytesPerEntryDefault)
+	if hint > wantMax {
+		t.Fatalf("reserve demand hint=%d want <= pressure capacity entries %d", hint, wantMax)
+	}
+	if hint < appendOnlyEntryHintMinEntries {
+		t.Fatalf("reserve demand hint=%d want >=%d", hint, appendOnlyEntryHintMinEntries)
 	}
 }

--- a/TreeDB/caching/append_only_hint_test.go
+++ b/TreeDB/caching/append_only_hint_test.go
@@ -170,3 +170,31 @@ func TestAppendOnlyReserveDemandHintClampsToPressureCapacity(t *testing.T) {
 		t.Fatalf("reserve demand hint=%d want >=%d", hint, appendOnlyEntryHintMinEntries)
 	}
 }
+
+func TestAppendOnlyReserveDemandHintClampsToShardScaledPressureCapacity(t *testing.T) {
+	var cache DB
+	const shards = 16
+	const baseThreshold = int64(256 << 20)
+	const pressureThreshold = int64(64 << 20)
+	cache.mutableShards = make([]memShard, shards)
+	cache.memtableCap = shardCapacity(memtableCapacity(baseThreshold), shards)
+	cache.mutableThreshold.Store(pressureThreshold)
+	cache.appendOnlyEntryHint.Store(appendOnlyEntryHintMaxEntries)
+
+	gotCapacity := cache.appendOnlyMemtableCapacityHint(cache.memtableCap, appendOnlyEstimatedBytesPerEntryDefault)
+	wantCapacity := shardCapacity(memtableCapacity(pressureThreshold), shards)
+	if wantCapacity >= cache.memtableCap {
+		t.Fatalf("test setup invalid: pressure capacity=%d base shard capacity=%d", wantCapacity, cache.memtableCap)
+	}
+	if gotCapacity != wantCapacity {
+		t.Fatalf("pressure-limited capacity=%d want shard-scaled %d", gotCapacity, wantCapacity)
+	}
+
+	cache.appendOnlyEntryHint.Store(0)
+	cache.observeAppendOnlyReserveDemandEntries(appendOnlyEntryHintMaxEntries)
+	hint := int(cache.appendOnlyEntryHint.Load())
+	wantMax := appendOnlyEntryCapacityForBytes(wantCapacity, appendOnlyEstimatedBytesPerEntryDefault)
+	if hint > wantMax {
+		t.Fatalf("reserve demand hint=%d want <= shard-scaled pressure entries %d", hint, wantMax)
+	}
+}

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -10089,12 +10089,34 @@ func memtableSetDirectBorrowValue(mt memtable.Table, key, value []byte, ptr page
 	mt.SetEntry(key, value, ptr, flags)
 }
 
-func reserveMemtableEntries(mt memtable.Table, additional int) {
+func reserveMemtableEntries(db *DB, mt memtable.Table, additional int) {
 	if additional <= 0 {
+		return
+	}
+	if appendOnly, ok := mt.(*memtable.AppendOnly); ok {
+		reserveAppendOnlyMemtableEntries(db, appendOnly, additional)
 		return
 	}
 	if reserver, ok := mt.(memtable.EntryCapacityReserver); ok {
 		reserver.ReserveAdditionalEntries(additional)
+	}
+}
+
+func reserveAppendOnlyMemtableEntries(db *DB, mt *memtable.AppendOnly, additional int) {
+	if mt == nil || additional <= 0 {
+		return
+	}
+	current := mt.Len()
+	demand := current + additional
+	if demand < current {
+		demand = int(^uint(0) >> 1)
+	}
+	if db != nil {
+		db.observeAppendOnlyReserveDemandEntries(demand)
+	}
+	mt.ReserveAdditionalEntries(additional)
+	if db != nil {
+		db.observeAppendOnlyReserveDemandEntries(mt.EntryCapacity())
 	}
 }
 
@@ -10835,6 +10857,7 @@ func (db *DB) trimRetainedArenasAfterFlush(checkpoint bool) {
 func (db *DB) newMutableMemtableWithCapacityMode(capacity int, mode memtable.Mode) (memtable.Table, error) {
 	if db != nil && mode == memtable.ModeAppendOnly {
 		estimate := appendOnlyEstimatedBytesPerEntryDefault
+		capacity = db.appendOnlyMemtableCapacityHint(capacity, estimate)
 		if mt := db.popAppendOnlyMemLease(); mt != nil {
 			db.appendOnlyMemLeaseHitTotal.Add(1)
 			mt.ResetWithCapacity(capacity, estimate)
@@ -32225,6 +32248,41 @@ func (db *DB) observeAppendOnlyMutableEntries(entries int) {
 	}
 }
 
+func (db *DB) appendOnlyEntryHintCapacityLimit(capacity, estimatedBytesPerEntry int) int {
+	if db == nil {
+		return appendOnlyEntryHintMaxEntries
+	}
+	if threshold := db.mutableFlushThreshold(); threshold > 0 {
+		if effectiveCap := memtableCapacity(threshold); effectiveCap > 0 && (capacity <= 0 || effectiveCap < capacity) {
+			capacity = effectiveCap
+		}
+	}
+	if capacity <= 0 {
+		return appendOnlyEntryHintMaxEntries
+	}
+	entries := appendOnlyEntryCapacityForBytes(capacity, estimatedBytesPerEntry)
+	return clampAppendOnlyEntryHint(entries)
+}
+
+func (db *DB) observeAppendOnlyReserveDemandEntries(entries int) {
+	if db == nil || entries <= 0 {
+		return
+	}
+	n := clampAppendOnlyEntryHint(entries)
+	if limit := db.appendOnlyEntryHintCapacityLimit(db.memtableCap, appendOnlyEstimatedBytesPerEntryDefault); n > limit {
+		n = limit
+	}
+	for {
+		old := int(db.appendOnlyEntryHint.Load())
+		if n <= old {
+			return
+		}
+		if db.appendOnlyEntryHint.CompareAndSwap(int32(old), int32(n)) {
+			return
+		}
+	}
+}
+
 func appendOnlyEntriesToCapacity(entries, estimatedBytesPerEntry int) int {
 	if entries <= 0 {
 		return 0
@@ -34660,7 +34718,7 @@ func (b *Batch) writeRegularLocked(syncWrite bool, unlockWriteMu func()) error {
 			}
 			shard := &b.db.mutableShards[i]
 			shard.mu.Lock()
-			reserveMemtableEntries(shard.mem, len(idxs))
+			reserveMemtableEntries(b.db, shard.mem, len(idxs))
 			useSteal, stealSuppressedDeferred := cachedBatchWriteUseSteal(b.db, shard.mem)
 			useSteal = allowBatchArenaBorrow && useSteal
 			if stealSuppressedDeferred && allowBatchArenaBorrow {
@@ -34739,7 +34797,7 @@ func (b *Batch) writeRegularLocked(syncWrite bool, unlockWriteMu func()) error {
 			}
 			shard := &b.db.mutableShards[i]
 			shard.mu.Lock()
-			reserveMemtableEntries(shard.mem, len(entries))
+			reserveMemtableEntries(b.db, shard.mem, len(entries))
 			useStream := b.streamEligible
 			useSteal, stealSuppressedDeferred := cachedBatchWriteUseSteal(b.db, shard.mem)
 			useSteal = allowBatchArenaBorrow && useSteal

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -32248,15 +32248,27 @@ func (db *DB) observeAppendOnlyMutableEntries(entries int) {
 	}
 }
 
+func (db *DB) appendOnlyPressureLimitedCapacity(capacity int) int {
+	if db == nil {
+		return capacity
+	}
+	if threshold := db.mutableFlushThreshold(); threshold > 0 {
+		effectiveCap := memtableCapacity(threshold)
+		if shards := len(db.mutableShards); shards > 1 {
+			effectiveCap = shardCapacity(effectiveCap, shards)
+		}
+		if effectiveCap > 0 && (capacity <= 0 || effectiveCap < capacity) {
+			capacity = effectiveCap
+		}
+	}
+	return capacity
+}
+
 func (db *DB) appendOnlyEntryHintCapacityLimit(capacity, estimatedBytesPerEntry int) int {
 	if db == nil {
 		return appendOnlyEntryHintMaxEntries
 	}
-	if threshold := db.mutableFlushThreshold(); threshold > 0 {
-		if effectiveCap := memtableCapacity(threshold); effectiveCap > 0 && (capacity <= 0 || effectiveCap < capacity) {
-			capacity = effectiveCap
-		}
-	}
+	capacity = db.appendOnlyPressureLimitedCapacity(capacity)
 	if capacity <= 0 {
 		return appendOnlyEntryHintMaxEntries
 	}
@@ -32305,11 +32317,7 @@ func (db *DB) appendOnlyMemtableCapacityHint(capacity, estimatedBytesPerEntry in
 	// threshold under process pressure. Without this, we can still preallocate
 	// near static memtableCap even after pressure logic has lowered rotation
 	// thresholds, inflating peak RSS during restore workloads.
-	if threshold := db.mutableFlushThreshold(); threshold > 0 {
-		if effectiveCap := memtableCapacity(threshold); effectiveCap > 0 && effectiveCap < capacity {
-			capacity = effectiveCap
-		}
-	}
+	capacity = db.appendOnlyPressureLimitedCapacity(capacity)
 	hintEntries := int(db.appendOnlyEntryHint.Load())
 	if hintEntries <= 0 {
 		return capacity


### PR DESCRIPTION
## Summary

- learns append-only entry capacity hints from reserve demand on the cached write path
- applies the learned hint when creating or resetting future append-only mutable memtables
- clamps learned hints and new mutable capacity by the shard-scaled effective mutable threshold, preserving pressure limits under multi-shard configs

Closes #3487. Updates #3475.

## Tests

- `GOWORK=off TMPDIR=/mnt/fast4tb/tmp GOCACHE=/mnt/fast4tb/tmp/go-cache GOMODCACHE=/mnt/fast4tb/tmp/go-mod-cache GOPATH=/mnt/fast4tb/tmp/go-path-cache go test ./TreeDB/caching -run 'AppendOnly|Retained|Reserve|Trim' -count=1`\n- `GOWORK=off TMPDIR=/mnt/fast4tb/tmp GOCACHE=/mnt/fast4tb/tmp/go-cache GOMODCACHE=/mnt/fast4tb/tmp/go-mod-cache GOPATH=/mnt/fast4tb/tmp/go-path-cache go test ./TreeDB/caching -count=1`\n- `GOWORK=off TMPDIR=/mnt/fast4tb/tmp GOCACHE=/mnt/fast4tb/tmp/go-cache GOMODCACHE=/mnt/fast4tb/tmp/go-mod-cache GOPATH=/mnt/fast4tb/tmp/go-path-cache go test ./TreeDB -run '^TestSyncDurabilityBoundaryDoesNotCheckpoint$|^TestPublicCommandWALDurableBatchWriteSyncDoesNotCheckpoint$' -count=1`\n\n## Benchmark\n\nFresh-process A/B against post-#3486 baseline `74e2f73fb`, 6 alternating samples, `BenchmarkSyncLatencyCached/BatchWriteSync/wal_on_relaxed_sync_command_wal/128/entry_hint`, `-benchtime=20000x`. Artifact: `/mnt/fast4tb/tmp/gomap-3487-reviewfix-ab-20260704T091120Z/benchstat.txt`.\n\n| metric | baseline | candidate | result |\n| --- | ---: | ---: | ---: |\n| sec/op | 54.47us ± 33% | 54.49us ± 6% | no significant change, p=0.818 |\n| writes/s | 2.350M ± 25% | 2.349M ± 6% | no significant change, p=0.818 |\n| B/op | 79.62Ki ± 11% | 68.72Ki ± 9% | -13.69%, p=0.026 |\n| allocs/op | 153.0 ± 0% | 153.0 ± 0% | no change |\n\n## Gate Status\n\nThis is a scoped allocation-pressure reduction. It does not claim to fully resolve the remaining reserve/trim allocation profile. The original reserve-grow counter gate was too narrow because the counter also reflects reserve/reuse pressure; the next loop should use narrower in-window profile evidence if we continue optimizing this path.\n