### PR TITLE
TreeDB: lease command-WAL values into append-only memtables

### DIFF
--- a/TreeDB/caching/batch_arena_ownership_test.go
+++ b/TreeDB/caching/batch_arena_ownership_test.go
@@ -558,6 +558,13 @@ func TestBatchStableViewValueLease_AppendOnlyBorrowsWithoutDirectArena(t *testin
 	if got := mustStatInt64(t, db.Stats(), "treedb.cache.batch_arena.leased_bytes"); got != 0 {
 		t.Fatalf("stable external lease bytes after checkpoint=%d want 0", got)
 	}
+	got, err = db.Get(key)
+	if err != nil {
+		t.Fatalf("get after checkpoint: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("value mismatch after checkpoint: got=%x want=%x", got, want)
+	}
 }
 
 func TestBatchStableViewValueLease_ZeroByteSignalBorrowsWithoutDirectArena(t *testing.T) {

--- a/TreeDB/caching/batch_arena_ownership_test.go
+++ b/TreeDB/caching/batch_arena_ownership_test.go
@@ -560,6 +560,54 @@ func TestBatchStableViewValueLease_AppendOnlyBorrowsWithoutDirectArena(t *testin
 	}
 }
 
+func TestBatchStableViewValueLease_ZeroByteSignalBorrowsWithoutDirectArena(t *testing.T) {
+	dir := t.TempDir()
+	db, err := Open(dir, NewMockBackend(), Options{
+		AllowUnsafe:    true,
+		DisableWAL:     true,
+		MemtableMode:   "append_only",
+		MemtableShards: 1,
+		FlushThreshold: 1 << 30,
+	})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer db.Close()
+
+	key := []byte("stable-zero-signal-key")
+	value := bytes.Repeat([]byte{0x24}, 128)
+	want := bytes.Clone(value)
+	stableSignal := make([]byte, 0)
+
+	b := db.NewBatchWithSize(1)
+	defer func() { _ = b.Close() }()
+	if err := b.SetView(key, value); err != nil {
+		t.Fatalf("set view: %v", err)
+	}
+	b.AttachStableViewValueLease([][]byte{stableSignal[:0:0]})
+	if err := b.Write(); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if !b.StableViewValueLeaseConsumed() {
+		t.Fatal("stable view value lease was not consumed")
+	}
+
+	stats := db.Stats()
+	if got := mustStatInt64(t, stats, "treedb.cache.append_only_direct_arena.active_used_bytes"); got != 0 {
+		t.Fatalf("direct arena active used bytes=%d want 0", got)
+	}
+	if got := mustStatInt64(t, stats, "treedb.cache.batch_arena.leased_bytes"); got != 0 {
+		t.Fatalf("stable zero-signal lease bytes=%d want 0", got)
+	}
+	got, err := db.Get(key)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("value mismatch: got=%x want=%x", got, want)
+	}
+}
+
 func TestBatchDeleteViewStats(t *testing.T) {
 	oldHotPathStatsEnabled := hotPathStatsEnabled
 	hotPathStatsEnabled = true

--- a/TreeDB/caching/batch_arena_ownership_test.go
+++ b/TreeDB/caching/batch_arena_ownership_test.go
@@ -506,6 +506,60 @@ func TestBatchSetView_MutationAfterWriteDoesNotCorruptStoredValue(t *testing.T) 
 	}
 }
 
+func TestBatchStableViewValueLease_AppendOnlyBorrowsWithoutDirectArena(t *testing.T) {
+	dir := t.TempDir()
+	db, err := Open(dir, NewMockBackend(), Options{
+		AllowUnsafe:    true,
+		DisableWAL:     true,
+		MemtableMode:   "append_only",
+		MemtableShards: 1,
+		FlushThreshold: 1 << 30,
+	})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer db.Close()
+
+	key := []byte("stable-view-key")
+	value := bytes.Repeat([]byte{0x42}, 128)
+	want := bytes.Clone(value)
+
+	b := db.NewBatchWithSize(1)
+	defer func() { _ = b.Close() }()
+	if err := b.SetView(key, value); err != nil {
+		t.Fatalf("set view: %v", err)
+	}
+	b.AttachStableViewValueLease([][]byte{value[:0]})
+	if err := b.Write(); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if !b.StableViewValueLeaseConsumed() {
+		t.Fatal("stable view value lease was not consumed")
+	}
+
+	stats := db.Stats()
+	if got := mustStatInt64(t, stats, "treedb.cache.append_only_direct_arena.active_used_bytes"); got != 0 {
+		t.Fatalf("direct arena active used bytes=%d want 0", got)
+	}
+	if got := mustStatInt64(t, stats, "treedb.cache.batch_arena.leased_bytes"); got == 0 {
+		t.Fatal("expected stable view value bytes to be retained as an external lease")
+	}
+	got, err := db.Get(key)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("value mismatch: got=%x want=%x", got, want)
+	}
+
+	if err := db.Checkpoint(); err != nil {
+		t.Fatalf("checkpoint: %v", err)
+	}
+	if got := mustStatInt64(t, db.Stats(), "treedb.cache.batch_arena.leased_bytes"); got != 0 {
+		t.Fatalf("stable external lease bytes after checkpoint=%d want 0", got)
+	}
+}
+
 func TestBatchDeleteViewStats(t *testing.T) {
 	oldHotPathStatsEnabled := hotPathStatsEnabled
 	hotPathStatsEnabled = true

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -8192,6 +8192,7 @@ type batchArenaLease struct {
 	refs   int
 	chunks [][]byte
 	bytes  int64
+	noPool bool
 }
 
 type appendOnlyDirectArenaLease struct {
@@ -10270,12 +10271,17 @@ func batchEntryWALRevision(entry *batch.Entry, seq uint64) uint64 {
 }
 
 func getBatchArenaLease(refs int, chunks [][]byte) *batchArenaLease {
+	return getBatchArenaLeaseWithPolicy(refs, chunks, false)
+}
+
+func getBatchArenaLeaseWithPolicy(refs int, chunks [][]byte, noPool bool) *batchArenaLease {
 	lease, _ := batchArenaLeasePool.Get().(*batchArenaLease)
 	if lease == nil {
 		lease = &batchArenaLease{}
 	}
 	lease.refs = refs
 	lease.chunks = chunks
+	lease.noPool = noPool
 	var bytes int64
 	for i := range chunks {
 		if chunks[i] != nil {
@@ -10293,18 +10299,29 @@ func putBatchArenaLease(lease *batchArenaLease) {
 	lease.refs = 0
 	lease.chunks = nil
 	lease.bytes = 0
+	lease.noPool = false
 	batchArenaLeasePool.Put(lease)
 }
 
 func (db *DB) retainBatchArenaChunksForMemtables(chunks [][]byte, mems []memtable.Table) {
+	db.retainBatchArenaChunksForMemtablesWithPolicy(chunks, mems, false)
+}
+
+func (db *DB) retainExternalViewValueChunksForMemtables(chunks [][]byte, mems []memtable.Table) {
+	db.retainBatchArenaChunksForMemtablesWithPolicy(chunks, mems, true)
+}
+
+func (db *DB) retainBatchArenaChunksForMemtablesWithPolicy(chunks [][]byte, mems []memtable.Table, noPool bool) {
 	if len(chunks) == 0 {
 		return
 	}
 	if db == nil || len(mems) == 0 {
-		putBatchArenas(chunks)
+		if !noPool {
+			putBatchArenas(chunks)
+		}
 		return
 	}
-	lease := getBatchArenaLease(len(mems), chunks)
+	lease := getBatchArenaLeaseWithPolicy(len(mems), chunks, noPool)
 	if lease.bytes > 0 {
 		cur := db.batchArenaLeaseBytes.Add(lease.bytes)
 		updateInt64Max(&db.batchArenaLeaseBytesMax, cur)
@@ -10337,6 +10354,7 @@ func (db *DB) releaseBatchArenaLeasesForMemtable(mt memtable.Table) {
 			}
 			lease.refs--
 			if lease.refs == 0 && len(lease.chunks) > 0 {
+				noPool := lease.noPool
 				if lease.bytes > 0 {
 					db.batchArenaLeaseBytes.Add(-lease.bytes)
 					if next := batchArenaLeasedBytesGlobal.Add(-lease.bytes); next < 0 {
@@ -10344,7 +10362,9 @@ func (db *DB) releaseBatchArenaLeasesForMemtable(mt memtable.Table) {
 					}
 					lease.bytes = 0
 				}
-				release = append(release, lease.chunks...)
+				if !noPool {
+					release = append(release, lease.chunks...)
+				}
 				lease.chunks = nil
 				putBatchArenaLease(lease)
 			}
@@ -32150,16 +32170,18 @@ type Batch struct {
 	closed bool
 	// SetView/DeleteView keep caller-owned bytes until Write/Close, so memtables
 	// must not borrow the batch arena when any view op is present.
-	hasViewOps       bool
-	streamEligible   bool
-	streamTried      bool
-	streamBypassOff  bool
-	firstKey         []byte
-	lastKey          []byte
-	batchRange       keyRange
-	hasDeleteRanges  bool
-	entryRevision    page.EntryRevision
-	commandWALAppend func() error
+	hasViewOps                   bool
+	stableViewValueLeaseChunks   [][]byte
+	stableViewValueLeaseConsumed bool
+	streamEligible               bool
+	streamTried                  bool
+	streamBypassOff              bool
+	firstKey                     []byte
+	lastKey                      []byte
+	batchRange                   keyRange
+	hasDeleteRanges              bool
+	entryRevision                page.EntryRevision
+	commandWALAppend             func() error
 
 	commandWALCompactReplay     bool
 	commandWALCompactRanges     []batch.DeleteRange
@@ -32208,6 +32230,25 @@ func (b *Batch) DisableStreamingBypass() {
 		return
 	}
 	b.streamBypassOff = true
+}
+
+// AttachStableViewValueLease declares that current SetView value slices are
+// backed by owner-managed buffers that may be retained by append-only memtables.
+// The buffers are never returned to TreeDB's batch arena pool; the caller must
+// also stop reusing them if StableViewValueLeaseConsumed reports true after a
+// write attempt.
+func (b *Batch) AttachStableViewValueLease(chunks [][]byte) {
+	if b == nil {
+		return
+	}
+	b.stableViewValueLeaseChunks = chunks
+	b.stableViewValueLeaseConsumed = false
+}
+
+// StableViewValueLeaseConsumed reports whether the most recent write retained
+// attached stable view buffers for mutable memtable ownership.
+func (b *Batch) StableViewValueLeaseConsumed() bool {
+	return b != nil && b.stableViewValueLeaseConsumed
 }
 
 func clampAppendOnlyEntryHint(entries int) int {
@@ -32742,6 +32783,7 @@ func (b *Batch) Reset() {
 	b.streamTried = false
 	b.streamBypassOff = false
 	b.hasViewOps = false
+	b.stableViewValueLeaseChunks = nil
 	b.firstKey = nil
 	b.lastKey = nil
 	b.batchRange = keyRange{}
@@ -34287,6 +34329,11 @@ func (b *Batch) writeRegularLocked(syncWrite bool, unlockWriteMu func()) error {
 	if shardCount > len(retainMainMemStack) {
 		retainMainMems = make([]memtable.Table, 0, shardCount)
 	}
+	var retainStableViewValueMemStack [batchMemtableRetainStackCap]memtable.Table
+	retainStableViewValueMems := retainStableViewValueMemStack[:0]
+	if shardCount > len(retainStableViewValueMemStack) {
+		retainStableViewValueMems = make([]memtable.Table, 0, shardCount)
+	}
 	for i, add := range shardAdds {
 		if add == 0 {
 			continue
@@ -34300,15 +34347,19 @@ func (b *Batch) writeRegularLocked(syncWrite bool, unlockWriteMu func()) error {
 			return ErrMemtableFull
 		}
 	}
-	prospectiveRetainBytes := batchArenaChunksCapBytes(b.copyArenaChunks) + batchArenaChunksCapBytes(b.ptrCopyArenaChunks)
+	stableViewValueLeaseBytes := batchArenaChunksCapBytes(b.stableViewValueLeaseChunks)
+	prospectiveRetainBytes := batchArenaChunksCapBytes(b.copyArenaChunks) + batchArenaChunksCapBytes(b.ptrCopyArenaChunks) + stableViewValueLeaseBytes
 	allowBatchArenaBorrow, preflightBlocked := shouldBorrowBatchArenaBytesForWriteWithHardCap(
 		prospectiveRetainBytes,
 		b.db.currentBatchArenaRetainedHardCapEffectiveBytes(),
 	)
+	allowStableViewValueBorrow := false
 	// SetView/DeleteView callers provide externally-owned slices that are only
 	// guaranteed immutable until Write/Close returns. Do not retain or steal
-	// those slices into memtables.
+	// those slices into memtables unless the owner attaches an explicit stable
+	// value lease that can outlive this batch.
 	if b.hasViewOps {
+		allowStableViewValueBorrow = stableViewValueLeaseBytes > 0 && allowBatchArenaBorrow
 		allowBatchArenaBorrow = false
 		batchArenaBorrowViewOpsBlockedTotal.Add(1)
 	}
@@ -34837,7 +34888,15 @@ func (b *Batch) writeRegularLocked(syncWrite bool, unlockWriteMu func()) error {
 					}
 					appliedSortedRun = true
 				} else {
-					if !allowBatchArenaBorrow {
+					if allowStableViewValueBorrow {
+						if applier, ok := shard.mem.(memtable.CopySortedBatchApplier); ok {
+							if borrowed := applier.ApplyCopySortedBatchTrusted(entries, true, storeInlinePtrValues, nil); borrowed {
+								retainStableViewValueMems = appendUniqueMemtable(retainStableViewValueMems, shard.mem)
+							}
+							appliedSortedRun = true
+						}
+					}
+					if !appliedSortedRun && !allowBatchArenaBorrow {
 						if applier, ok := shard.mem.(memtable.CopySortedBatchValueCopier); ok {
 							applier.ApplyCopySortedBatchWithValueCopierTrusted(entries, func(value []byte) []byte {
 								if len(value) == 0 {
@@ -34867,19 +34926,34 @@ func (b *Batch) writeRegularLocked(syncWrite bool, unlockWriteMu func()) error {
 							return failMemtableApply(shard, err)
 						}
 					} else {
-						borrowed := false
-						if allowBatchArenaBorrow && !useSteal {
+						borrowedMainArena := false
+						borrowedStableViewValue := false
+						allowValueBorrow := allowBatchArenaBorrow
+						if !allowValueBorrow && allowStableViewValueBorrow && !useSteal {
+							allowValueBorrow = true
 							if _, ok := shard.mem.(memtable.ValueBorrower); ok {
 								if op.IsPtr {
-									borrowed = storeInlinePtrValues && len(op.Value) > 0
+									borrowedStableViewValue = storeInlinePtrValues && len(op.Value) > 0
 								} else {
-									borrowed = len(op.Value) > 0
+									borrowedStableViewValue = len(op.Value) > 0
 								}
 							}
 						}
-						memtableBatchSet(shard.mem, useSteal, allowBatchArenaBorrow, storeInlinePtrValues, op)
-						if borrowed {
+						if allowBatchArenaBorrow && !useSteal {
+							if _, ok := shard.mem.(memtable.ValueBorrower); ok {
+								if op.IsPtr {
+									borrowedMainArena = storeInlinePtrValues && len(op.Value) > 0
+								} else {
+									borrowedMainArena = len(op.Value) > 0
+								}
+							}
+						}
+						memtableBatchSet(shard.mem, useSteal, allowValueBorrow, storeInlinePtrValues, op)
+						if borrowedMainArena {
 							retainMainMems = appendUniqueMemtable(retainMainMems, shard.mem)
+						}
+						if borrowedStableViewValue {
+							retainStableViewValueMems = appendUniqueMemtable(retainStableViewValueMems, shard.mem)
 						}
 					}
 					if useStream {
@@ -34950,6 +35024,11 @@ func (b *Batch) writeRegularLocked(syncWrite bool, unlockWriteMu func()) error {
 	}
 	ptrChunks := b.drainPtrCopyArenaChunks()
 	b.db.retainBatchArenaChunksForMemtables(mainChunks, retainMainMems)
+	if len(retainStableViewValueMems) > 0 {
+		b.db.retainExternalViewValueChunksForMemtables(b.stableViewValueLeaseChunks, retainStableViewValueMems)
+		b.stableViewValueLeaseConsumed = true
+	}
+	b.stableViewValueLeaseChunks = nil
 	if retainPtrArena {
 		b.db.retainBatchArenaChunksForMemtables(ptrChunks, ptrTouchedMems)
 	} else {
@@ -35501,6 +35580,7 @@ func (b *Batch) Close() error {
 	b.lastKey = nil
 	b.entryRevision = page.LegacyEntryRevision
 	b.ptrValueIdxs = nil
+	b.stableViewValueLeaseChunks = nil
 	b.conditionalTxnID = 0
 	b.commandWALCompactReplay = false
 	b.commandWALCompactRanges = nil

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -32236,7 +32236,8 @@ func (b *Batch) DisableStreamingBypass() {
 // backed by owner-managed buffers that may be retained by append-only memtables.
 // The buffers are never returned to TreeDB's batch arena pool; the caller must
 // also stop reusing them if StableViewValueLeaseConsumed reports true after a
-// write attempt.
+// write attempt. A zero-cap chunk is a borrow-permission signal for values with
+// process-lifetime storage; it is not retained as a batch-arena lease.
 func (b *Batch) AttachStableViewValueLease(chunks [][]byte) {
 	if b == nil {
 		return
@@ -34359,7 +34360,7 @@ func (b *Batch) writeRegularLocked(syncWrite bool, unlockWriteMu func()) error {
 	// those slices into memtables unless the owner attaches an explicit stable
 	// value lease that can outlive this batch.
 	if b.hasViewOps {
-		allowStableViewValueBorrow = stableViewValueLeaseBytes > 0 && allowBatchArenaBorrow
+		allowStableViewValueBorrow = len(b.stableViewValueLeaseChunks) > 0 && allowBatchArenaBorrow
 		allowBatchArenaBorrow = false
 		batchArenaBorrowViewOpsBlockedTotal.Add(1)
 	}
@@ -35025,7 +35026,9 @@ func (b *Batch) writeRegularLocked(syncWrite bool, unlockWriteMu func()) error {
 	ptrChunks := b.drainPtrCopyArenaChunks()
 	b.db.retainBatchArenaChunksForMemtables(mainChunks, retainMainMems)
 	if len(retainStableViewValueMems) > 0 {
-		b.db.retainExternalViewValueChunksForMemtables(b.stableViewValueLeaseChunks, retainStableViewValueMems)
+		if stableViewValueLeaseBytes > 0 {
+			b.db.retainExternalViewValueChunksForMemtables(b.stableViewValueLeaseChunks, retainStableViewValueMems)
+		}
 		b.stableViewValueLeaseConsumed = true
 	}
 	b.stableViewValueLeaseChunks = nil

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -34229,7 +34229,22 @@ func (b *Batch) writeRegularLocked(syncWrite bool, unlockWriteMu func()) error {
 	needRotate := false
 	needSyncBarrier := false
 	commandWALAppended := false
+	var retainStableViewValueMems []memtable.Table
+	var stableViewValueLeaseBytes int64
+	stableViewValueLeaseFinalized := false
+	finalizeStableViewValueLease := func() {
+		if stableViewValueLeaseFinalized || len(retainStableViewValueMems) == 0 {
+			return
+		}
+		if stableViewValueLeaseBytes > 0 {
+			b.db.retainExternalViewValueChunksForMemtables(b.stableViewValueLeaseChunks, retainStableViewValueMems)
+		}
+		b.stableViewValueLeaseConsumed = true
+		b.stableViewValueLeaseChunks = nil
+		stableViewValueLeaseFinalized = true
+	}
 	failMemtableApply := func(shard *memShard, err error) error {
+		finalizeStableViewValueLease()
 		shard.mu.Unlock()
 		unlockWriteMu()
 		if err == nil {
@@ -34331,7 +34346,7 @@ func (b *Batch) writeRegularLocked(syncWrite bool, unlockWriteMu func()) error {
 		retainMainMems = make([]memtable.Table, 0, shardCount)
 	}
 	var retainStableViewValueMemStack [batchMemtableRetainStackCap]memtable.Table
-	retainStableViewValueMems := retainStableViewValueMemStack[:0]
+	retainStableViewValueMems = retainStableViewValueMemStack[:0]
 	if shardCount > len(retainStableViewValueMemStack) {
 		retainStableViewValueMems = make([]memtable.Table, 0, shardCount)
 	}
@@ -34348,7 +34363,7 @@ func (b *Batch) writeRegularLocked(syncWrite bool, unlockWriteMu func()) error {
 			return ErrMemtableFull
 		}
 	}
-	stableViewValueLeaseBytes := batchArenaChunksCapBytes(b.stableViewValueLeaseChunks)
+	stableViewValueLeaseBytes = batchArenaChunksCapBytes(b.stableViewValueLeaseChunks)
 	prospectiveRetainBytes := batchArenaChunksCapBytes(b.copyArenaChunks) + batchArenaChunksCapBytes(b.ptrCopyArenaChunks) + stableViewValueLeaseBytes
 	allowBatchArenaBorrow, preflightBlocked := shouldBorrowBatchArenaBytesForWriteWithHardCap(
 		prospectiveRetainBytes,
@@ -35025,13 +35040,10 @@ func (b *Batch) writeRegularLocked(syncWrite bool, unlockWriteMu func()) error {
 	}
 	ptrChunks := b.drainPtrCopyArenaChunks()
 	b.db.retainBatchArenaChunksForMemtables(mainChunks, retainMainMems)
-	if len(retainStableViewValueMems) > 0 {
-		if stableViewValueLeaseBytes > 0 {
-			b.db.retainExternalViewValueChunksForMemtables(b.stableViewValueLeaseChunks, retainStableViewValueMems)
-		}
-		b.stableViewValueLeaseConsumed = true
+	finalizeStableViewValueLease()
+	if !stableViewValueLeaseFinalized {
+		b.stableViewValueLeaseChunks = nil
 	}
-	b.stableViewValueLeaseChunks = nil
 	if retainPtrArena {
 		b.db.retainBatchArenaChunksForMemtables(ptrChunks, ptrTouchedMems)
 	} else {

--- a/TreeDB/command_wal_public_cached.go
+++ b/TreeDB/command_wal_public_cached.go
@@ -284,6 +284,7 @@ type commandWALPublicBatch struct {
 	payloadByteHint          int
 	payloadSoftCapBytes      int
 	payloadBypass            bool
+	payloadLeasedToMemtable  bool
 	opCount                  int
 	hasDeleteRange           bool
 	dirty                    bool
@@ -338,6 +339,11 @@ type commandWALPublicInnerDeleteViewer interface {
 	DeleteView(key []byte) error
 }
 
+type commandWALPublicInnerStableViewValueLease interface {
+	AttachStableViewValueLease(chunks [][]byte)
+	StableViewValueLeaseConsumed() bool
+}
+
 func newCommandWALPublicBatch(tdb *DB, inner Batch, opHint int) *commandWALPublicBatch {
 	var payload commitlog.RawKVBatchPayloadBuilder
 	if tdb != nil {
@@ -374,6 +380,17 @@ func (b *commandWALPublicBatch) resetPayloadWithHint() {
 	b.hasDeleteRange = false
 }
 
+func (b *commandWALPublicBatch) resetPayloadForReuse() {
+	if b == nil {
+		return
+	}
+	if b.payloadLeasedToMemtable {
+		b.payload.DetachRetainedByteBuffers()
+		b.payloadLeasedToMemtable = false
+	}
+	b.resetPayloadWithHint()
+}
+
 func (b *commandWALPublicBatch) payloadShouldCarryEntryRevisions() bool {
 	if b == nil || b.db == nil || b.inner == nil {
 		return false
@@ -391,10 +408,36 @@ func (b *commandWALPublicBatch) preparePayloadForAppend() {
 	// explicit Reset, drop those retained bytes before appending a fresh command
 	// payload. The geth adapter detaches borrowed replay views before taking this
 	// path after Write.
-	b.resetPayloadWithHint()
+	b.resetPayloadForReuse()
 	b.opCount = 0
 	b.hasDeleteRange = false
 	b.retainPayloadAfterWrite = false
+}
+
+func (b *commandWALPublicBatch) attachStableViewValueLease() bool {
+	if b == nil || b.inner == nil || b.payloadBypass || b.payload.Count() == 0 || b.payload.Count() != b.opCount {
+		return false
+	}
+	leaser, ok := b.inner.(commandWALPublicInnerStableViewValueLease)
+	if !ok {
+		return false
+	}
+	chunks := b.payload.RetainedByteBuffers()
+	if len(chunks) == 0 {
+		return false
+	}
+	leaser.AttachStableViewValueLease(chunks)
+	return true
+}
+
+func (b *commandWALPublicBatch) noteStableViewValueLeaseConsumed() {
+	if b == nil || b.inner == nil {
+		return
+	}
+	leaser, ok := b.inner.(commandWALPublicInnerStableViewValueLease)
+	if ok && leaser.StableViewValueLeaseConsumed() {
+		b.payloadLeasedToMemtable = true
+	}
 }
 
 func (b *commandWALPublicBatch) rebindInnerViewers() {
@@ -747,15 +790,22 @@ func (b *commandWALPublicBatch) write(sync bool) error {
 		if !ok {
 			return fmt.Errorf("treedb: command wal batch requires cached command append hook")
 		}
+		leaseAttached := b.attachStableViewValueLease()
 		if err := writer.WriteAfterCommandWALAppend(sync, func() error {
 			return b.appendCommandWAL(sync)
 		}); err != nil {
+			if leaseAttached {
+				b.noteStableViewValueLeaseConsumed()
+			}
 			return err
+		}
+		if leaseAttached {
+			b.noteStableViewValueLeaseConsumed()
 		}
 		b.publishPointIngressStats()
 		b.disableInnerStreamingBypass()
 		if !b.retainPayloadAfterWrite {
-			b.resetPayloadWithHint()
+			b.resetPayloadForReuse()
 		}
 		b.opCount = 0
 		b.hasDeleteRange = false
@@ -774,7 +824,7 @@ func (b *commandWALPublicBatch) write(sync bool) error {
 	}
 	b.disableInnerStreamingBypass()
 	if !b.retainPayloadAfterWrite {
-		b.resetPayloadWithHint()
+		b.resetPayloadForReuse()
 	}
 	b.opCount = 0
 	b.hasDeleteRange = false
@@ -791,9 +841,13 @@ func (b *commandWALPublicBatch) Close() error {
 	// payload bytes, matching ordinary batch semantics: only Write/WriteSync
 	// appends and publishes a RawKVBatch command frame.
 	err := b.inner.Close()
-	b.resetPayloadWithHint()
 	payload := b.payload
-	keepPayload := payload.PrepareForReuse(commandWALPublicBatchPayloadPoolRetainMaxBytes)
+	keepPayload := false
+	if b.payloadLeasedToMemtable {
+		payload.DetachRetainedByteBuffers()
+	} else {
+		keepPayload = payload.PrepareForReuse(commandWALPublicBatchPayloadPoolRetainMaxBytes)
+	}
 	b.inner = nil
 	b.innerSetViewValidated = nil
 	b.innerSetViewer = nil
@@ -806,6 +860,7 @@ func (b *commandWALPublicBatch) Close() error {
 	b.payloadSoftCapBytes = 0
 	b.opCount = 0
 	b.hasDeleteRange = false
+	b.payloadLeasedToMemtable = false
 	b.resetPointIngressStats()
 	b.dirty = false
 	b.retainPayloadAfterWrite = false
@@ -823,7 +878,7 @@ func (b *commandWALPublicBatch) Reset() {
 	resetter, ok := b.inner.(interface{ Reset() })
 	if !ok {
 		b.disableInnerStreamingBypass()
-		b.resetPayloadWithHint()
+		b.resetPayloadForReuse()
 		b.opCount = 0
 		b.hasDeleteRange = false
 		b.resetPointIngressStats()
@@ -835,7 +890,7 @@ func (b *commandWALPublicBatch) Reset() {
 	resetter.Reset()
 	b.rebindInnerViewers()
 	b.disableInnerStreamingBypass()
-	b.resetPayloadWithHint()
+	b.resetPayloadForReuse()
 	b.opCount = 0
 	b.hasDeleteRange = false
 	b.resetPointIngressStats()

--- a/TreeDB/command_wal_public_cached.go
+++ b/TreeDB/command_wal_public_cached.go
@@ -285,6 +285,11 @@ type commandWALPublicBatch struct {
 	payloadSoftCapBytes      int
 	payloadBypass            bool
 	payloadLeasedToMemtable  bool
+	payloadLeasedBufferMask  commitlog.RawKVBatchPayloadBufferMask
+	payloadLeaseAttachedMask commitlog.RawKVBatchPayloadBufferMask
+	knownZeroValueRef        []byte
+	knownZeroValueLen        int
+	knownZeroValueValid      bool
 	opCount                  int
 	hasDeleteRange           bool
 	dirty                    bool
@@ -378,6 +383,9 @@ func (b *commandWALPublicBatch) resetPayloadWithHint() {
 	}
 	b.payloadBypass = false
 	b.hasDeleteRange = false
+	b.knownZeroValueRef = nil
+	b.knownZeroValueLen = 0
+	b.knownZeroValueValid = false
 }
 
 func (b *commandWALPublicBatch) resetPayloadForReuse() {
@@ -385,9 +393,11 @@ func (b *commandWALPublicBatch) resetPayloadForReuse() {
 		return
 	}
 	if b.payloadLeasedToMemtable {
-		b.payload.DetachRetainedByteBuffers()
+		b.payload.DetachRetainedValueByteBuffers(b.payloadLeasedBufferMask)
 		b.payloadLeasedToMemtable = false
+		b.payloadLeasedBufferMask = 0
 	}
+	b.payloadLeaseAttachedMask = 0
 	b.resetPayloadWithHint()
 }
 
@@ -422,11 +432,15 @@ func (b *commandWALPublicBatch) attachStableViewValueLease() bool {
 	if !ok {
 		return false
 	}
-	chunks := b.payload.RetainedByteBuffers()
+	if b.setCalls+b.setViewCalls == 0 {
+		return false
+	}
+	chunks, mask := b.payload.RetainedValueByteBuffers()
 	if len(chunks) == 0 {
 		return false
 	}
 	leaser.AttachStableViewValueLease(chunks)
+	b.payloadLeaseAttachedMask = mask
 	return true
 }
 
@@ -435,8 +449,9 @@ func (b *commandWALPublicBatch) noteStableViewValueLeaseConsumed() {
 		return
 	}
 	leaser, ok := b.inner.(commandWALPublicInnerStableViewValueLease)
-	if ok && leaser.StableViewValueLeaseConsumed() {
+	if ok && leaser.StableViewValueLeaseConsumed() && b.payloadLeaseAttachedMask != 0 {
 		b.payloadLeasedToMemtable = true
+		b.payloadLeasedBufferMask |= b.payloadLeaseAttachedMask
 	}
 }
 
@@ -542,7 +557,11 @@ func (b *commandWALPublicBatch) setView(key, value []byte, retainReplayViews, us
 		}
 	}
 	oldLen, oldCount := b.payload.Len(), b.payload.Count()
-	keyView, valueView, err = b.payload.AppendSet(key, value)
+	if b.payload.EntryRevisionsEnabled() && b.knownZeroValue(value) {
+		keyView, valueView, err = b.payload.AppendSetKnownZeroValue(key, value)
+	} else {
+		keyView, valueView, err = b.payload.AppendSet(key, value)
+	}
 	if err != nil {
 		return nil, nil, err
 	}
@@ -844,7 +863,7 @@ func (b *commandWALPublicBatch) Close() error {
 	payload := b.payload
 	keepPayload := false
 	if b.payloadLeasedToMemtable {
-		payload.DetachRetainedByteBuffers()
+		payload.DetachRetainedValueByteBuffers(b.payloadLeasedBufferMask)
 	} else {
 		keepPayload = payload.PrepareForReuse(commandWALPublicBatchPayloadPoolRetainMaxBytes)
 	}
@@ -861,6 +880,8 @@ func (b *commandWALPublicBatch) Close() error {
 	b.opCount = 0
 	b.hasDeleteRange = false
 	b.payloadLeasedToMemtable = false
+	b.payloadLeasedBufferMask = 0
+	b.payloadLeaseAttachedMask = 0
 	b.resetPointIngressStats()
 	b.dirty = false
 	b.retainPayloadAfterWrite = false
@@ -906,6 +927,28 @@ func commandWALPublicAllZeroBytes(p []byte) bool {
 		}
 	}
 	return len(p) > 0
+}
+
+func commandWALPublicSameNonEmptyBytesData(a, b []byte) bool {
+	return len(a) > 0 && len(b) > 0 && &a[0] == &b[0]
+}
+
+func (b *commandWALPublicBatch) knownZeroValue(value []byte) bool {
+	if b == nil || len(value) == 0 {
+		return false
+	}
+	if b.knownZeroValueValid &&
+		b.knownZeroValueLen == len(value) &&
+		commandWALPublicSameNonEmptyBytesData(value, b.knownZeroValueRef) {
+		return true
+	}
+	if !commandWALPublicAllZeroBytes(value) {
+		return false
+	}
+	b.knownZeroValueRef = value
+	b.knownZeroValueLen = len(value)
+	b.knownZeroValueValid = true
+	return true
 }
 
 func (b *commandWALPublicBatch) commandWALPayload() ([]byte, error) {

--- a/TreeDB/command_wal_public_test.go
+++ b/TreeDB/command_wal_public_test.go
@@ -1446,6 +1446,63 @@ func TestPublicCommandWALBatchReplayBytesSurviveWriteUntilReset(t *testing.T) {
 	}
 }
 
+func TestPublicCommandWALBatchReplayBytesAppendOnlyLeaseAvoidsDirectArena(t *testing.T) {
+	dir := t.TempDir()
+	db, err := Open(Options{
+		Dir:                 dir,
+		Durability:          DurabilityWALOnRelaxed,
+		CommandWAL:          true,
+		CommandWALStatsScan: true,
+		DisableSideStores:   true,
+		MemtableMode:        "append_only",
+		MemtableShards:      1,
+		FlushThreshold:      1 << 30,
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer db.Close()
+
+	b, ok := db.NewBatchWithSize(1).(*commandWALPublicBatch)
+	if !ok {
+		t.Fatalf("NewBatchWithSize type=%T, want *commandWALPublicBatch", db.NewBatchWithSize(1))
+	}
+	keyView, valueView, err := b.SetViewWithReplayBytes([]byte("alpha"), bytes.Repeat([]byte{0x33}, 128))
+	if err != nil {
+		t.Fatalf("SetViewWithReplayBytes: %v", err)
+	}
+	wantKey := bytes.Clone(keyView)
+	wantValue := bytes.Clone(valueView)
+	if err := b.Write(); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if !b.payloadLeasedToMemtable {
+		t.Fatal("command-WAL payload was not marked leased to the append-only memtable")
+	}
+	if !b.retainPayloadAfterWrite {
+		t.Fatal("replay payload was not retained after write")
+	}
+	stats := db.Stats()
+	if got := stats["treedb.cache.append_only_direct_arena.active_used_bytes"]; got != "0" {
+		t.Fatalf("direct arena active used bytes=%q want 0", got)
+	}
+	if got := stats["treedb.cache.batch_arena.leased_bytes"]; got == "0" || got == "" {
+		t.Fatalf("batch arena leased bytes=%q want >0 for external payload lease", got)
+	}
+	got, err := db.Get(wantKey)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !bytes.Equal(got, wantValue) {
+		t.Fatalf("stored value=%x want %x", got, wantValue)
+	}
+
+	b.Reset()
+	if b.payloadLeasedToMemtable {
+		t.Fatal("Reset left payload marked leased to memtable")
+	}
+}
+
 func TestPublicCommandWALBatchResetPreservesCompactZeroScanFallback(t *testing.T) {
 	wrapped := newCommandWALPublicBatch(nil, &commandWALResetBatch{}, 8000)
 	zeroValue := make([]byte, 128)

--- a/TreeDB/command_wal_public_test.go
+++ b/TreeDB/command_wal_public_test.go
@@ -1503,6 +1503,53 @@ func TestPublicCommandWALBatchReplayBytesAppendOnlyLeaseAvoidsDirectArena(t *tes
 	}
 }
 
+func TestPublicCommandWALBatchZeroValueAppendOnlyLeaseAvoidsDirectArena(t *testing.T) {
+	dir := t.TempDir()
+	db, err := Open(Options{
+		Dir:                 dir,
+		Durability:          DurabilityWALOnRelaxed,
+		CommandWAL:          true,
+		CommandWALStatsScan: true,
+		DisableSideStores:   true,
+		MemtableMode:        "append_only",
+		MemtableShards:      1,
+		FlushThreshold:      1 << 30,
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer db.Close()
+
+	b := db.NewBatchWithSize(1)
+	value := make([]byte, 128)
+	if err := b.Set([]byte("zero-value-key"), value); err != nil {
+		_ = b.Close()
+		t.Fatalf("Set: %v", err)
+	}
+	if err := b.Write(); err != nil {
+		_ = b.Close()
+		t.Fatalf("Write: %v", err)
+	}
+	if err := b.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	stats := db.Stats()
+	if got := stats["treedb.cache.append_only_direct_arena.active_used_bytes"]; got != "0" {
+		t.Fatalf("direct arena active used bytes=%q want 0", got)
+	}
+	if got := stats["treedb.cache.batch_arena.leased_bytes"]; got != "0" {
+		t.Fatalf("batch arena leased bytes=%q want 0 for shared zero view", got)
+	}
+	got, err := db.Get([]byte("zero-value-key"))
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !bytes.Equal(got, value) {
+		t.Fatalf("stored value=%x want %x", got, value)
+	}
+}
+
 func TestPublicCommandWALBatchResetPreservesCompactZeroScanFallback(t *testing.T) {
 	wrapped := newCommandWALPublicBatch(nil, &commandWALResetBatch{}, 8000)
 	zeroValue := make([]byte, 128)

--- a/TreeDB/command_wal_public_test.go
+++ b/TreeDB/command_wal_public_test.go
@@ -1501,6 +1501,30 @@ func TestPublicCommandWALBatchReplayBytesAppendOnlyLeaseAvoidsDirectArena(t *tes
 	if b.payloadLeasedToMemtable {
 		t.Fatal("Reset left payload marked leased to memtable")
 	}
+
+	secondKeyView, secondValueView, err := b.SetViewWithReplayBytes([]byte("bravo"), bytes.Repeat([]byte{0x44}, 128))
+	if err != nil {
+		t.Fatalf("second SetViewWithReplayBytes: %v", err)
+	}
+	secondWantKey := bytes.Clone(secondKeyView)
+	secondWantValue := bytes.Clone(secondValueView)
+	if err := b.Write(); err != nil {
+		t.Fatalf("second Write: %v", err)
+	}
+	got, err = db.Get(wantKey)
+	if err != nil {
+		t.Fatalf("Get original after batch reuse: %v", err)
+	}
+	if !bytes.Equal(got, wantValue) {
+		t.Fatalf("original stored value after batch reuse=%x want %x", got, wantValue)
+	}
+	got, err = db.Get(secondWantKey)
+	if err != nil {
+		t.Fatalf("Get second: %v", err)
+	}
+	if !bytes.Equal(got, secondWantValue) {
+		t.Fatalf("second stored value=%x want %x", got, secondWantValue)
+	}
 }
 
 func TestPublicCommandWALBatchZeroValueAppendOnlyLeaseAvoidsDirectArena(t *testing.T) {

--- a/TreeDB/internal/commitlog/command_frame.go
+++ b/TreeDB/internal/commitlog/command_frame.go
@@ -44,6 +44,8 @@ const (
 )
 
 var commandFrameMagic = [4]byte{'T', 'C', 'W', '1'}
+var rawKVEmptyByteView = make([]byte, 0)
+var rawKVSharedZeroValueView = make([]byte, 64<<10)
 var rawKVCommandFrameHeaderTemplate = func() [commandFrameHeaderSize]byte {
 	var h [commandFrameHeaderSize]byte
 	copy(h[0:4], commandFrameMagic[:])
@@ -148,24 +150,35 @@ type RawKVBatchPayloadPlan struct {
 // RawKVBatchPayloadBuilder incrementally constructs a canonical RawKVBatch
 // payload while returning stable key/value views into the owned payload bytes.
 type RawKVBatchPayloadBuilder struct {
-	payload               []byte
-	zeroPayload           []byte
-	zeroSetValueView      []byte
-	payloadCapHint        int
-	opHint                int
-	count                 int
-	zeroSetCandidate      bool
-	zeroSetCompactOnly    bool
-	zeroSetValuesOmitted  bool
-	zeroSetValueLen       int
-	zeroSetKeyBytes       int
-	zeroSetMaxKeyLen      int
-	zeroSetCompactVersion uint16
-	zeroSetValueRef       []byte
-	entryRevisions        bool
-	revisionOffsets       []uint32
-	revisionOffsetInline  [rawKVRevisionOffsetInlineCap]uint32
+	payload                []byte
+	zeroPayload            []byte
+	zeroSetValueView       []byte
+	payloadCapHint         int
+	opHint                 int
+	count                  int
+	zeroSetCandidate       bool
+	zeroSetCompactOnly     bool
+	zeroSetValuesOmitted   bool
+	zeroSetValueLen        int
+	zeroSetKeyBytes        int
+	zeroSetMaxKeyLen       int
+	zeroSetCompactVersion  uint16
+	zeroSetValueRef        []byte
+	payloadValueViews      bool
+	zeroSetValueViewGlobal bool
+	entryRevisions         bool
+	revisionOffsets        []uint32
+	revisionOffsetInline   [rawKVRevisionOffsetInlineCap]uint32
 }
+
+// RawKVBatchPayloadBufferMask identifies builder-owned buffers whose byte
+// slices were handed to another owner.
+type RawKVBatchPayloadBufferMask uint8
+
+const (
+	RawKVBatchPayloadBufferPayload RawKVBatchPayloadBufferMask = 1 << iota
+	RawKVBatchPayloadBufferZeroValue
+)
 
 // NewRawKVBatchPayloadBuilder returns a builder initialized with best-effort
 // capacity hints. Invalid or overflowing hints intentionally fall back to the
@@ -212,6 +225,8 @@ func (b *RawKVBatchPayloadBuilder) ResetWithHint(opHint, byteHint int) error {
 	b.zeroSetMaxKeyLen = 0
 	b.zeroSetCompactVersion = 0
 	b.zeroSetValueRef = nil
+	b.payloadValueViews = false
+	b.zeroSetValueViewGlobal = false
 	b.entryRevisions = false
 	if b.revisionOffsets != nil {
 		b.revisionOffsets = b.revisionOffsets[:0]
@@ -514,6 +529,31 @@ func (b *RawKVBatchPayloadBuilder) RetainedByteBuffers() [][]byte {
 	return out
 }
 
+// RetainedValueByteBuffers returns builder-owned buffers that may back value
+// views returned by AppendSet. It intentionally excludes compact-zero key
+// payload buffers, since append-only memtables copy keys and only retain values.
+// When value views point at the process-global zero view, it returns one
+// zero-cap sentinel chunk as a stable-borrow permission signal and no mask.
+func (b *RawKVBatchPayloadBuilder) RetainedValueByteBuffers() ([][]byte, RawKVBatchPayloadBufferMask) {
+	if b == nil {
+		return nil, 0
+	}
+	var out [][]byte
+	var mask RawKVBatchPayloadBufferMask
+	if b.zeroSetValueViewGlobal {
+		out = append(out, rawKVEmptyByteView[:0:0])
+	}
+	if cap(b.zeroSetValueView) > 0 {
+		out = append(out, b.zeroSetValueView[:0])
+		mask |= RawKVBatchPayloadBufferZeroValue
+	}
+	if b.payloadValueViews && cap(b.payload) > 0 {
+		out = append(out, b.payload[:0])
+		mask |= RawKVBatchPayloadBufferPayload
+	}
+	return out, mask
+}
+
 // DetachRetainedByteBuffers drops builder references to payload buffers without
 // returning them to the builder's reuse path. Use this when those buffers were
 // handed to another owner with a longer lifetime, such as a mutable memtable.
@@ -526,6 +566,21 @@ func (b *RawKVBatchPayloadBuilder) DetachRetainedByteBuffers() {
 	*b = RawKVBatchPayloadBuilder{}
 	if keepRevisionOffsets {
 		b.revisionOffsets = revisionOffsets[:0]
+	}
+}
+
+// DetachRetainedValueByteBuffers drops only the value buffers selected by mask.
+// This lets compact-zero command payload/key buffers remain reusable when the
+// only memtable-retained data is the separate zero-value view buffer.
+func (b *RawKVBatchPayloadBuilder) DetachRetainedValueByteBuffers(mask RawKVBatchPayloadBufferMask) {
+	if b == nil || mask == 0 {
+		return
+	}
+	if mask&RawKVBatchPayloadBufferPayload != 0 {
+		b.payload = nil
+	}
+	if mask&RawKVBatchPayloadBufferZeroValue != 0 {
+		b.zeroSetValueView = nil
 	}
 }
 
@@ -691,6 +746,18 @@ func (b *RawKVBatchPayloadBuilder) Append(op RawKVOperation) (keyView, valueView
 // AppendSet appends a validated RawKV Set operation without materializing a
 // RawKVOperation wrapper. The key and value must be non-nil.
 func (b *RawKVBatchPayloadBuilder) AppendSet(key, value []byte) (keyView, valueView []byte, err error) {
+	return b.appendSet(key, value, false)
+}
+
+// AppendSetKnownZeroValue is like AppendSet but the caller has already verified
+// that value is non-empty and all zero bytes. The canonical command-WAL payload
+// still receives the supplied value bytes; the returned value view can use the
+// shared zero buffer without rescanning.
+func (b *RawKVBatchPayloadBuilder) AppendSetKnownZeroValue(key, value []byte) (keyView, valueView []byte, err error) {
+	return b.appendSet(key, value, true)
+}
+
+func (b *RawKVBatchPayloadBuilder) appendSet(key, value []byte, knownZeroValue bool) (keyView, valueView []byte, err error) {
 	if b == nil {
 		return nil, nil, ErrCorrupt
 	}
@@ -744,7 +811,12 @@ func (b *RawKVBatchPayloadBuilder) AppendSet(key, value []byte) (keyView, valueV
 		valueView = b.zeroSetValueViewForLen(len(value))
 	} else {
 		copy(b.payload[off:], value)
-		valueView = b.payload[valueStart : valueStart+len(value) : valueStart+len(value)]
+		if knownZeroValue || allZeroBytes(value) {
+			valueView = b.zeroSetValueViewForLen(len(value))
+		} else {
+			valueView = b.payload[valueStart : valueStart+len(value) : valueStart+len(value)]
+			b.payloadValueViews = true
+		}
 	}
 	off += len(value)
 	b.count++
@@ -1120,7 +1192,12 @@ func (b *RawKVBatchPayloadBuilder) appendValidatedWithRevision(op RawKVOp, key, 
 	} else {
 		copy(b.payload[off:], value)
 		if op == RawKVOpSet {
-			valueView = b.payload[valueStart : valueStart+len(value) : valueStart+len(value)]
+			if allZeroBytes(value) {
+				valueView = b.zeroSetValueViewForLen(len(value))
+			} else {
+				valueView = b.payload[valueStart : valueStart+len(value) : valueStart+len(value)]
+				b.payloadValueViews = true
+			}
 		}
 	}
 	off += len(value)
@@ -1381,6 +1458,7 @@ func (b *RawKVBatchPayloadBuilder) truncateCompactZeroSetPayload(count int) {
 		b.zeroSetMaxKeyLen = 0
 		b.zeroSetCompactVersion = 0
 		b.zeroSetValueRef = nil
+		b.payloadValueViews = false
 		if b.zeroPayload != nil {
 			b.zeroPayload = b.zeroPayload[:0]
 		}
@@ -1460,8 +1538,15 @@ func (b *RawKVBatchPayloadBuilder) disableZeroSetCandidate() {
 }
 
 func (b *RawKVBatchPayloadBuilder) zeroSetValueViewForLen(n int) []byte {
-	if b == nil || n <= 0 {
+	if n == 0 {
+		return rawKVEmptyByteView
+	}
+	if b == nil || n < 0 {
 		return nil
+	}
+	if n <= len(rawKVSharedZeroValueView) {
+		b.zeroSetValueViewGlobal = true
+		return rawKVSharedZeroValueView[:n:n]
 	}
 	if cap(b.zeroSetValueView) < n {
 		b.zeroSetValueView = make([]byte, n)

--- a/TreeDB/internal/commitlog/command_frame.go
+++ b/TreeDB/internal/commitlog/command_frame.go
@@ -494,6 +494,41 @@ func (b *RawKVBatchPayloadBuilder) PrepareForReuse(maxRetainedBytes int) bool {
 	return b.RetainedBytes() > 0
 }
 
+// RetainedByteBuffers returns the builder-owned byte buffers that may back
+// key/value views returned by AppendSet/AppendDelete. Callers must not mutate,
+// pool, or reuse these buffers while any returned view can still be observed.
+func (b *RawKVBatchPayloadBuilder) RetainedByteBuffers() [][]byte {
+	if b == nil {
+		return nil
+	}
+	var out [][]byte
+	if cap(b.payload) > 0 {
+		out = append(out, b.payload[:0])
+	}
+	if cap(b.zeroPayload) > 0 {
+		out = append(out, b.zeroPayload[:0])
+	}
+	if cap(b.zeroSetValueView) > 0 {
+		out = append(out, b.zeroSetValueView[:0])
+	}
+	return out
+}
+
+// DetachRetainedByteBuffers drops builder references to payload buffers without
+// returning them to the builder's reuse path. Use this when those buffers were
+// handed to another owner with a longer lifetime, such as a mutable memtable.
+func (b *RawKVBatchPayloadBuilder) DetachRetainedByteBuffers() {
+	if b == nil {
+		return
+	}
+	revisionOffsets := b.revisionOffsets
+	keepRevisionOffsets := cap(revisionOffsets) > rawKVRevisionOffsetInlineCap
+	*b = RawKVBatchPayloadBuilder{}
+	if keepRevisionOffsets {
+		b.revisionOffsets = revisionOffsets[:0]
+	}
+}
+
 // RetainedCapAfterAppend returns the backing capacity that would be retained
 // after appending needed bytes with the same growth rule used by Append.
 func (b *RawKVBatchPayloadBuilder) RetainedCapAfterAppend(needed int) (int, error) {

--- a/TreeDB/internal/commitlog/command_frame_test.go
+++ b/TreeDB/internal/commitlog/command_frame_test.go
@@ -297,7 +297,8 @@ func TestRawKVBatchPayloadBuilderRetainedBytesIncludesCompactZeroBuffers(t *test
 	if err := builder.ResetWithHint(0, 0); err != nil {
 		t.Fatalf("ResetWithHint: %v", err)
 	}
-	if _, _, err := builder.AppendSet([]byte("zero"), make([]byte, 128)); err != nil {
+	largeZero := make([]byte, len(rawKVSharedZeroValueView)+1)
+	if _, _, err := builder.AppendSet([]byte("zero"), largeZero); err != nil {
 		t.Fatalf("AppendSet compact zero: %v", err)
 	}
 	if cap(builder.zeroPayload) == 0 || cap(builder.zeroSetValueView) == 0 {
@@ -309,6 +310,74 @@ func TestRawKVBatchPayloadBuilderRetainedBytesIncludesCompactZeroBuffers(t *test
 	}
 	if got := builder.RetainedCap(); got >= builder.RetainedBytes() {
 		t.Fatalf("RetainedCap=%d should not account for compact-zero side buffers retainedBytes=%d", got, builder.RetainedBytes())
+	}
+}
+
+func TestRawKVBatchPayloadBuilderCompactZeroValueLeaseDetachesOnlyValueView(t *testing.T) {
+	var builder RawKVBatchPayloadBuilder
+	if err := builder.ResetWithHint(4, 0); err != nil {
+		t.Fatalf("ResetWithHint: %v", err)
+	}
+	largeZero := make([]byte, len(rawKVSharedZeroValueView)+1)
+	if _, _, err := builder.AppendSet([]byte("zero-1"), largeZero); err != nil {
+		t.Fatalf("AppendSet zero-1: %v", err)
+	}
+	if _, _, err := builder.AppendSet([]byte("zero-2"), largeZero); err != nil {
+		t.Fatalf("AppendSet zero-2: %v", err)
+	}
+	payloadCap := cap(builder.payload)
+	zeroPayloadCap := cap(builder.zeroPayload)
+	if payloadCap == 0 || zeroPayloadCap == 0 || cap(builder.zeroSetValueView) == 0 {
+		t.Fatalf("unexpected compact-zero caps: payload=%d zeroPayload=%d zeroSetValueView=%d", payloadCap, zeroPayloadCap, cap(builder.zeroSetValueView))
+	}
+
+	chunks, mask := builder.RetainedValueByteBuffers()
+	if mask != RawKVBatchPayloadBufferZeroValue {
+		t.Fatalf("value lease mask=%b, want zero-value only", mask)
+	}
+	if len(chunks) != 1 || cap(chunks[0]) != cap(builder.zeroSetValueView) {
+		t.Fatalf("value lease chunks=%d cap=%d, want one zero-value chunk cap=%d", len(chunks), cap(chunks[0]), cap(builder.zeroSetValueView))
+	}
+	builder.DetachRetainedValueByteBuffers(mask)
+	if cap(builder.zeroSetValueView) != 0 {
+		t.Fatalf("zeroSetValueView cap after detach=%d, want 0", cap(builder.zeroSetValueView))
+	}
+	if cap(builder.payload) != payloadCap {
+		t.Fatalf("payload cap after value detach=%d, want retained %d", cap(builder.payload), payloadCap)
+	}
+	if cap(builder.zeroPayload) != zeroPayloadCap {
+		t.Fatalf("zeroPayload cap after value detach=%d, want retained %d", cap(builder.zeroPayload), zeroPayloadCap)
+	}
+}
+
+func TestRawKVBatchPayloadBuilderRevisionZeroValueLeaseUsesSharedZeroView(t *testing.T) {
+	var builder RawKVBatchPayloadBuilder
+	if err := builder.ResetWithHint(4, 1024); err != nil {
+		t.Fatalf("ResetWithHint: %v", err)
+	}
+	if err := builder.EnableEntryRevisions(); err != nil {
+		t.Fatalf("EnableEntryRevisions: %v", err)
+	}
+	if _, valueView, err := builder.AppendSet([]byte("zero-1"), make([]byte, 128)); err != nil {
+		t.Fatalf("AppendSet zero-1: %v", err)
+	} else if len(valueView) != 128 || !allZeroBytes(valueView) {
+		t.Fatalf("zero value view len=%d allZero=%v", len(valueView), allZeroBytes(valueView))
+	}
+	payloadCap := cap(builder.payload)
+	if payloadCap == 0 || cap(builder.zeroSetValueView) != 0 {
+		t.Fatalf("unexpected revision-zero caps: payload=%d zeroSetValueView=%d", payloadCap, cap(builder.zeroSetValueView))
+	}
+
+	chunks, mask := builder.RetainedValueByteBuffers()
+	if mask != 0 {
+		t.Fatalf("value lease mask=%b, want no owned value buffers", mask)
+	}
+	if len(chunks) != 1 || cap(chunks[0]) != 0 {
+		t.Fatalf("value lease chunks=%d cap=%d, want one zero-cap stable signal", len(chunks), cap(chunks[0]))
+	}
+	builder.DetachRetainedValueByteBuffers(mask)
+	if cap(builder.payload) != payloadCap {
+		t.Fatalf("revision payload cap after value detach=%d, want retained %d", cap(builder.payload), payloadCap)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #3490.
Part of parent tracker #3475.

This PR adds a narrow stable view-value lease path for public command-WAL batches so append-only memtables can retain command-WAL-owned value bytes without copying them through the append-only direct value arena.

The ownership boundary is intentionally small:

- ordinary `SetView` values remain caller-owned and are not borrowed by append-only memtables;
- command-WAL payload-builder value bytes may be leased only when the payload is stable, non-bypassed, and exactly matches the batch operations;
- once a memtable consumes a builder-owned value lease, the payload builder detaches those buffers from reset/close/reuse paths;
- short zero-value command-WAL payloads use a process-lifetime shared zero view and a zero-cap stable-borrow signal, so synthetic zero-value workloads do not pay direct-arena or retained-lease allocation cost;
- if a later memtable apply error happens after a stable value borrow, the borrowed stable lease is finalized before returning the error.

## Scope

Changed:

- `TreeDB/internal/commitlog`: expose value-only retained payload buffers, detach selected value buffers after external ownership transfer, and add a known-zero append path for entry-revision payloads.
- `TreeDB/caching`: add explicit stable view-value lease support, including zero-byte stable-borrow signals that avoid direct arena allocation without retaining external chunks; harden the memtable-apply failure path after a stable borrow.
- `TreeDB`: wire the public command-WAL batch wrapper into the stable lease path and cache repeated known-zero value detection inside a batch.
- Focused tests for cached batch lease behavior, public command-WAL replay-byte retention, compact-zero/revision-zero payload ownership, read-after-checkpoint, and read-after-batch-reuse.

Not changed:

- WAL, `WriteSync`, `Checkpoint`, value-log, crash-recovery, or on-disk format semantics.
- Reserve-growth tuning or global pool-cap policy.
- Legacy slab/value-store behavior.

## Local Tests

Passed on PR head `b7440550197a2c17ac86ed273c3323fb7a6d09ed`:

```sh
GOWORK=off TMPDIR=/mnt/fast4tb/tmp GOCACHE=/mnt/fast4tb/tmp/go-cache GOMODCACHE=/mnt/fast4tb/tmp/go-mod-cache GOPATH=/mnt/fast4tb/tmp/go-path-cache go test ./TreeDB/caching -run 'TestBatchStableViewValueLease|TestBatchSetView_MutationAfterWriteDoesNotCorruptStoredValue|TestBatchArenaLeases|TestAppendOnlyDirectWriterArena' -count=1

GOWORK=off TMPDIR=/mnt/fast4tb/tmp GOCACHE=/mnt/fast4tb/tmp/go-cache GOMODCACHE=/mnt/fast4tb/tmp/go-mod-cache GOPATH=/mnt/fast4tb/tmp/go-path-cache go test ./TreeDB -run 'TestPublicCommandWALBatchReplayBytesSurviveWriteUntilReset|TestPublicCommandWALBatchReplayBytesAppendOnlyLeaseAvoidsDirectArena|TestPublicCommandWALBatchZeroValueAppendOnlyLeaseAvoidsDirectArena|TestPublicCommandWALBatchAppendUsesStablePayload|TestPublicCommandWALBatchStablePayloadAppendsWithoutReplay|TestPublicCommandWALBatchOrdinarySetStablePayloadAppendsWithoutReplay|TestPublicCommandWALBatchPayloadPool' -count=1

GOWORK=off TMPDIR=/mnt/fast4tb/tmp GOCACHE=/mnt/fast4tb/tmp/go-cache GOMODCACHE=/mnt/fast4tb/tmp/go-mod-cache GOPATH=/mnt/fast4tb/tmp/go-path-cache go test ./TreeDB ./TreeDB/caching ./TreeDB/internal/commitlog -count=1

git diff --check
```

## Performance Evidence

Baseline: post-#3488 commit `619b025b03df2239dadc746e35b31f11d5c86c10`.
PR head: `b7440550197a2c17ac86ed273c3323fb7a6d09ed`.

Hot path, no checkpoint window, `BenchmarkSyncLatencyCached/BatchWriteSync/wal_on_relaxed_sync_command_wal/128/entry_hint`, `-benchtime=20000x -count=8 -benchmem`:

- `sec/op`: `56.83us` baseline -> `50.02us` PR, `-11.99%` (`p=0.001`, `n=8`).
- `writes/s`: `2.252M` baseline -> `2.559M` PR, `+13.62%` (`p=0.001`, `n=8`).
- `B/op`: `59.18Ki` baseline -> `43.60Ki` PR, `-26.32%` (`p=0.000`, `n=8`).
- `allocs/op`: `153.0` baseline -> `138.0` PR, `-9.80%` (`p=0.000`, `n=8`).

Checkpoint-inclusive longer window, same benchmark, `-benchtime=100000x -count=5 -benchmem`:

- `sec/op`: `98.91us` baseline -> `91.61us` PR, `-7.38%` (`p=0.008`, `n=5`; benchstat reports no 95% CI with fewer than 6 samples).
- `writes/s`: `1.294M` baseline -> `1.397M` PR, `+7.97%` (`p=0.008`, `n=5`).
- `B/op`: `72.14Ki` baseline -> `58.78Ki` PR, `-18.51%` (`p=0.008`, `n=5`).
- `allocs/op`: `155.0` baseline -> `140.0` PR, `-9.68%` (`p=0.008`, `n=5`).

Profile spot check from the earlier equivalent candidate tree still explains the allocation shift:

- `getAppendOnlyDirectValueArenaChunk` no longer appears in alloc-space top for the zero-value lease shape.
- Top allocation sites move to entry/replay decode structures (`memtable.getAppendOnlyEntries`, `commitlog.Reader.readSegmentPayload`, `commitlog.DecodeCommandFrame`, `caching.getEntrySlice`).

Artifacts:

- Latest pre-merge A/B rerun on `b74405501`: `/mnt/fast4tb/tmp/gomap-3491-reviewfix-20260704T193434Z`
- Profile spot check: `/mnt/fast4tb/tmp/gomap-3490-candidate-knownzero-20260704T192107Z/profile_final`

## Risk Notes

The main risk is buffer lifetime: append-only memtables can outlive public batch reset/close, so consumed payload-owned value buffers must be detached from builder reuse. The tests assert retained values remain readable, ordinary caller-owned `SetView` values are not borrowed, consumed owned buffers detach, zero-cap stable-borrow signals avoid false retained-byte accounting, checkpoint release preserves readable values, and reusing the public command-WAL batch does not corrupt previously leased memtable bytes.

## Post-Merge Follow-Up

After this merges, rerun the full Ironbird benchmark matrix using the merged gomap commit everywhere, then compare against the previous post-#3488 baseline for `allocs/op`, `B/op`, append-only direct arena used bytes, effective ops/s, runtime TPS, and commit/write timing buckets.
