### PR TITLE
TreeDB: prove production remote-owner redirects

### DIFF
--- a/TreeDB/mongo_gateway/benchsupport/production_route.go
+++ b/TreeDB/mongo_gateway/benchsupport/production_route.go
@@ -14,13 +14,14 @@ import (
 	"github.com/snissn/gomap/TreeDB/internal/raftcluster"
 	"github.com/snissn/gomap/TreeDB/internal/raftentry"
 	"github.com/snissn/gomap/TreeDB/internal/raftfsm"
+	"github.com/snissn/gomap/TreeDB/internal/raftplacement"
 	mongogateway "github.com/snissn/gomap/TreeDB/mongo_gateway"
 	"github.com/snissn/gomap/TreeDB/nativewire"
 )
 
-// ProductionRouteProofOptions scopes the bench-only local-owner routed commit
-// proof. It intentionally models only locally configured groups; it does not
-// perform remote forwarding or fanout execution.
+// ProductionRouteProofOptions scopes the bench-only production route proof. It
+// intentionally models only locally configured submitters; nonlocal groups are
+// redirect evidence, not remote execution.
 type ProductionRouteProofOptions struct {
 	GroupCount     int
 	PartitionCount int
@@ -62,7 +63,7 @@ func ConfigureProductionRouteProofHarness(opts ProductionRouteProofOptions, db *
 		return nil, errors.New("production route proof harness requires Mongo gateway server")
 	}
 	cluster := productionRouteProofClusterConfig(db)
-	recorder := newProductionRouteProofRecorder(opts.GroupCount, opts.PartitionCount)
+	recorder := newProductionRouteProofRecorder(opts.GroupCount, opts.PartitionCount, string(cluster.GroupID))
 	fsm, err := raftfsm.Open(raftfsm.Options{
 		DB:      db,
 		Cluster: cluster,
@@ -134,6 +135,24 @@ func (h *ProductionRouteProofHarness) Snapshot() ProductionRouteProofSnapshot {
 		return ProductionRouteProofSnapshot{}
 	}
 	return h.recorder.snapshot()
+}
+
+func (h *ProductionRouteProofHarness) ResetCounters() {
+	if h == nil || h.recorder == nil {
+		return
+	}
+	h.recorder.resetCounters()
+}
+
+func LocalProductionRouteProofGroupID() string {
+	return productionRouteProofGroupID(0)
+}
+
+func ProductionRouteProofGroupIDForDocumentID(groupCount, partitionCount int, documentID []byte) string {
+	recorder := newProductionRouteProofRecorder(groupCount, partitionCount)
+	token := raftplacement.DocumentIDTokenV1(documentID)
+	partition := recorder.partitionForToken(token)
+	return productionRouteProofGroupID(recorder.groupForPartition(partition))
 }
 
 func (h *ProductionRouteProofHarness) ProbeUnknownOwnerReject(ctx context.Context, database, collection string) error {
@@ -318,6 +337,7 @@ type productionRouteProofRecorder struct {
 	mu                       sync.Mutex
 	routeAttemptsTotal       int64
 	routeLocalOwnerHits      int64
+	routeRemoteRedirects     int64
 	routeUnknownOwnerRejects int64
 	directLocalBypassRejects int64
 	fanoutSplitAttempts      int64
@@ -329,16 +349,21 @@ type productionRouteProofRecorder struct {
 	appliedGroupHits         map[string]int
 }
 
-func newProductionRouteProofRecorder(groupCount, partitionCount int) *productionRouteProofRecorder {
+func newProductionRouteProofRecorder(groupCount, partitionCount int, localGroupIDs ...string) *productionRouteProofRecorder {
 	if groupCount < 1 {
 		groupCount = 1
 	}
 	if partitionCount < groupCount {
 		partitionCount = groupCount
 	}
-	localGroups := make(map[string]struct{}, groupCount)
-	for group := 0; group < groupCount; group++ {
-		localGroups[productionRouteProofGroupID(group)] = struct{}{}
+	if len(localGroupIDs) == 0 {
+		localGroupIDs = []string{productionRouteProofGroupID(0)}
+	}
+	localGroups := make(map[string]struct{}, len(localGroupIDs))
+	for _, groupID := range localGroupIDs {
+		if groupID != "" {
+			localGroups[groupID] = struct{}{}
+		}
 	}
 	return &productionRouteProofRecorder{
 		groupCount:              groupCount,
@@ -470,6 +495,8 @@ func (r *productionRouteProofRecorder) recordRouteSuccess(target nativewire.Clus
 	r.routeAttemptsTotal++
 	if _, ok := r.localGroups[target.GroupID]; ok {
 		r.routeLocalOwnerHits++
+	} else if target.GroupID != "" {
+		r.routeRemoteRedirects++
 	}
 	if target.GroupID != "" {
 		r.routeGroupHits[target.GroupID]++
@@ -528,6 +555,26 @@ func (r *productionRouteProofRecorder) recordFanoutSplitAttempt() {
 	r.mu.Unlock()
 }
 
+func (r *productionRouteProofRecorder) resetCounters() {
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.routeAttemptsTotal = 0
+	r.routeLocalOwnerHits = 0
+	r.routeRemoteRedirects = 0
+	r.routeUnknownOwnerRejects = 0
+	r.directLocalBypassRejects = 0
+	r.fanoutSplitAttempts = 0
+	r.fanoutSplitFailures = 0
+	r.routeGroupHits = make(map[string]int, r.groupCount)
+	r.routeLeaderHits = make(map[string]int, r.groupCount)
+	r.routeTokenPartitionHits = make(map[string]int, r.partitionCount)
+	r.commitGroupHits = make(map[string]int, r.groupCount)
+	r.appliedGroupHits = make(map[string]int, r.groupCount)
+}
+
 func (r *productionRouteProofRecorder) snapshot() ProductionRouteProofSnapshot {
 	if r == nil {
 		return ProductionRouteProofSnapshot{}
@@ -542,7 +589,7 @@ func (r *productionRouteProofRecorder) snapshot() ProductionRouteProofSnapshot {
 		RealRoutedCommits:        r.routeAttemptsTotal > 0 && r.routeLocalOwnerHits == r.routeAttemptsTotal && commitTotal == r.routeAttemptsTotal && applyTotal == r.routeAttemptsTotal,
 		RouteAttemptsTotal:       r.routeAttemptsTotal,
 		RouteLocalOwnerHits:      r.routeLocalOwnerHits,
-		RouteRemoteRedirects:     0,
+		RouteRemoteRedirects:     r.routeRemoteRedirects,
 		RouteRemoteForwards:      0,
 		RouteUnknownOwnerRejects: r.routeUnknownOwnerRejects,
 		RouteGroupHits:           cloneStringIntMap(r.routeGroupHits),

--- a/TreeDB/mongo_gateway/benchsupport/production_route_test.go
+++ b/TreeDB/mongo_gateway/benchsupport/production_route_test.go
@@ -45,3 +45,41 @@ func TestProductionRouteProofRecorderClusterRouteTokenBatchRequiresTokens(t *tes
 		t.Fatalf("ClusterRoute empty token batch err=%v want missing token(s)", err)
 	}
 }
+
+func TestProductionRouteProofRecorderCountsOnlyConfiguredLocalGroups(t *testing.T) {
+	recorder := newProductionRouteProofRecorder(2, 2, productionRouteProofGroupID(0))
+
+	recorder.recordRouteSuccess(recorder.groupTarget(1))
+	snapshot := recorder.snapshot()
+	if snapshot.RouteAttemptsTotal != 1 || snapshot.RouteRemoteRedirects != 1 || snapshot.RouteLocalOwnerHits != 0 {
+		t.Fatalf("snapshot attempts/remote/local=%d/%d/%d want 1/1/0: %+v",
+			snapshot.RouteAttemptsTotal, snapshot.RouteRemoteRedirects, snapshot.RouteLocalOwnerHits, snapshot)
+	}
+	if snapshot.RouteGroupHits[productionRouteProofGroupID(1)] != 1 || snapshot.RouteLeaderHits["node-01-a"] != 1 {
+		t.Fatalf("remote route hits not recorded: %+v", snapshot)
+	}
+
+	recorder.recordRouteSuccess(recorder.groupTarget(0))
+	snapshot = recorder.snapshot()
+	if snapshot.RouteAttemptsTotal != 2 || snapshot.RouteRemoteRedirects != 1 || snapshot.RouteLocalOwnerHits != 1 {
+		t.Fatalf("snapshot after local route attempts/remote/local=%d/%d/%d want 2/1/1: %+v",
+			snapshot.RouteAttemptsTotal, snapshot.RouteRemoteRedirects, snapshot.RouteLocalOwnerHits, snapshot)
+	}
+}
+
+func TestProductionRouteProofRecorderResetCountersPreservesLocalGroups(t *testing.T) {
+	recorder := newProductionRouteProofRecorder(2, 2, productionRouteProofGroupID(0))
+	recorder.recordRouteSuccess(recorder.groupTarget(1))
+	recorder.recordCommitGroup(productionRouteProofGroupID(0))
+	recorder.recordAppliedGroup(productionRouteProofGroupID(0))
+	recorder.resetCounters()
+
+	recorder.recordRouteSuccess(recorder.groupTarget(0))
+	snapshot := recorder.snapshot()
+	if snapshot.RouteAttemptsTotal != 1 || snapshot.RouteLocalOwnerHits != 1 || snapshot.RouteRemoteRedirects != 0 {
+		t.Fatalf("snapshot after reset/local route=%+v want one local route", snapshot)
+	}
+	if snapshot.CommitGroupHits != nil || snapshot.AppliedGroupHits != nil {
+		t.Fatalf("commit/apply hits survived reset: %+v", snapshot)
+	}
+}

--- a/cmd/mongo_gateway_bench/README.md
+++ b/cmd/mongo_gateway_bench/README.md
@@ -157,17 +157,18 @@ The result also emits
 `production_route_evidence`. Treat those fields as local deterministic routing
 distribution evidence only, not as a cluster throughput or scaleout claim.
 
-`-route-mode production` is a fail-closed local-owner routed-commit proof. It
-currently supports only `-route-groups 1`; multi-group production routing stays
-disabled until remote-owner forwarding, fanout/split, and stable redirect/error
-contracts are wired. Production mode uses command WAL and BSON collection
-storage, routes collection creation and each measured `InsertOne` through the
-production cluster submitter boundary, and emits `production_route_evidence`
-only after routed submit, commit, and apply counters prove the local-owner path.
-It does not emit local `route_evidence`. The current production proof accepts
-only the serial insert-only shape: `-batch-size 1`, `-insert-producers 1`,
-`-secondary-indexes 0`, `-reads 0`, `-range-reads 0`, `-updates 0`,
-`-deletes 0`, no range/indexed-update options, and no concurrent phases.
+`-route-mode production` is a fail-closed production route proof. With
+`-route-groups 1`, it proves local-owner routed commits. With
+`-route-groups >1`, it proves remote-owner redirect/no-local-mutation behavior
+only; it does not forward, execute on a remote group, fan out, or claim
+horizontal scale. Production mode uses command WAL and BSON collection storage,
+routes collection creation and each measured `InsertOne` through the production
+cluster submitter boundary, and emits `production_route_evidence` only for the
+supported proof scopes. It does not emit local `route_evidence`. The current
+production proof accepts only the serial insert-only shape: `-batch-size 1`,
+`-insert-producers 1`, `-secondary-indexes 0`, `-reads 0`, `-range-reads 0`,
+`-updates 0`, `-deletes 0`, no range/indexed-update options, and no concurrent
+phases.
 
 Use a small production proof run when validating the route boundary:
 
@@ -187,9 +188,9 @@ GOWORK=off go run ./cmd/mongo_gateway_bench \
   -format json
 ```
 
-Production proof JSON reports `production_route_evidence_status=available` and
-`production_route_evidence` with
-`evidence_scope=production_routed_commit`, `real_routed_commits`,
+Production local-owner proof JSON reports
+`production_route_evidence_status=available` and `production_route_evidence`
+with `evidence_scope=production_routed_commit`, `real_routed_commits=true`,
 route-attempt/local-owner/remote-redirect/remote-forward/unknown-owner counters,
 route group/leader/token-partition hits, commit and applied group hits,
 fanout/split attempts and failures, direct-local-bypass rejects, write
@@ -197,6 +198,13 @@ p50/p95/p99 latency, writes/sec, `B/op`, `allocs/op`, CPU context,
 storage/snapshot overhead, and artifact pointers. Treat this as
 correctness/instrumentation evidence for the local-owner production route
 boundary, not as cluster throughput or horizontal-scale evidence.
+
+Production remote-owner redirect proof JSON reports
+`production_route_evidence_status=available_remote_owner_redirect_only` and
+`evidence_scope=production_remote_owner_redirect`, with
+`real_routed_commits=false`, remote redirect counters, route group/leader/token
+partition hits, and empty commit/apply group hits. Treat this as redirect and
+zero-local-mutation evidence only, not as remote execution or scale evidence.
 
 Use `-insert-producers N` to split the insert load phase across producer
 goroutines. The effective producer count is capped at the number of insert

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -451,10 +451,12 @@ const (
 	routeModeRing       = "ring"
 	routeModeProduction = "production"
 
-	routeEvidenceScopeLocalPreflight                = "local_preflight"
-	routeEvidenceScopeProductionRoutedCommit        = "production_routed_commit"
-	productionRouteEvidenceStatusAvailable          = "available"
-	productionRouteEvidenceStatusLocalPreflightOnly = "unavailable_local_preflight_only"
+	routeEvidenceScopeLocalPreflight                 = "local_preflight"
+	routeEvidenceScopeProductionRoutedCommit         = "production_routed_commit"
+	routeEvidenceScopeProductionRemoteOwnerRedirect  = "production_remote_owner_redirect"
+	productionRouteEvidenceStatusAvailable           = "available"
+	productionRouteEvidenceStatusRemoteOwnerRedirect = "available_remote_owner_redirect_only"
+	productionRouteEvidenceStatusLocalPreflightOnly  = "unavailable_local_preflight_only"
 
 	clientModeDriver             = "driver"
 	clientModeDriverFindRaw      = "driver-find-raw"
@@ -573,7 +575,7 @@ func parseConfig(args []string) (config, error) {
 	fs.StringVar(&cfg.MongoURI, "mongo-uri", "mongodb://127.0.0.1:27017", "MongoDB URI for -target mongo")
 	fs.BoolVar(&cfg.MongoCompact, "mongo-compact", false, "compact the MongoDB collection before final stats collection")
 	fs.StringVar(&cfg.RouteMode, "route-mode", cfg.RouteMode, "route evidence mode: off, ring, or production")
-	fs.IntVar(&cfg.RouteGroupCount, "route-groups", cfg.RouteGroupCount, "logical route group count for route evidence; production currently supports 1")
+	fs.IntVar(&cfg.RouteGroupCount, "route-groups", cfg.RouteGroupCount, "logical route group count for route evidence; production supports local-owner proof with 1 and remote-owner redirect proof with more")
 	fs.IntVar(&cfg.RoutePartitionCount, "route-partitions", cfg.RoutePartitionCount, "token partition count for route evidence; must be >= route-groups")
 	fs.StringVar(&cfg.TreeDBDir, "treedb-dir", "", "TreeDB directory for -target treedb; empty uses a temp dir")
 	fs.BoolVar(&cfg.KeepTreeDBDir, "keep-treedb-dir", false, "keep an auto-created TreeDB temp dir after the run")
@@ -720,9 +722,6 @@ func parseConfig(args []string) (config, error) {
 		}
 		if cfg.RoutePartitionCount < cfg.RouteGroupCount {
 			return config{}, fmt.Errorf("route-partitions must be >= route-groups for route-mode %s", cfg.RouteMode)
-		}
-		if cfg.RouteMode == routeModeProduction && cfg.RouteGroupCount != 1 {
-			return config{}, errors.New("route-mode production currently supports only local-owner proof with route-groups=1")
 		}
 	}
 	if cfg.Documents <= 0 {
@@ -949,7 +948,7 @@ func validateProductionRouteProofShape(cfg config) error {
 	if len(unsupported) == 0 {
 		return nil
 	}
-	return fmt.Errorf("route-mode production currently supports only serial insert-only local-owner proof; set %s", strings.Join(unsupported, ", "))
+	return fmt.Errorf("route-mode production currently supports only serial insert-only local-owner or remote-owner redirect proof; set %s", strings.Join(unsupported, ", "))
 }
 
 func parseTreeDBProfile(raw string) (treedb.Profile, error) {
@@ -1841,6 +1840,9 @@ func runBenchmark(ctx context.Context, cfg config, target *benchTarget, profiler
 		loadProfileName = "load_insert_one_routed_ring"
 	case routeModeProduction:
 		loadProfileName = "load_insert_one_production_routed_commit"
+		if productionRouteRemoteOwnerRedirectProof(cfg) {
+			loadProfileName = "load_insert_one_production_remote_owner_redirect"
+		}
 	}
 	if cfg.RouteMode == routeModeProduction {
 		// Keep the production route allocation reset outside the profiled load
@@ -1875,6 +1877,9 @@ func runBenchmark(ctx context.Context, cfg config, target *benchTarget, profiler
 		productionRouteResult.WriteLatencyMicros = loadPhase.LatencyMicros
 		productionRouteResult.WritesPerSecond = loadPhase.OpsPerSecond
 		result.ProductionRouteEvidenceStatus = productionRouteEvidenceStatusAvailable
+		if productionRouteResult.EvidenceScope == routeEvidenceScopeProductionRemoteOwnerRedirect {
+			result.ProductionRouteEvidenceStatus = productionRouteEvidenceStatusRemoteOwnerRedirect
+		}
 		result.ProductionRouteEvidence = productionRouteResult
 	}
 	if target.poolStats != nil {
@@ -3805,6 +3810,9 @@ func runRoutedRingLoadPhase(ctx context.Context, cfg config, coll *mongo.Collect
 }
 
 func runProductionRoutedLoadPhase(ctx context.Context, cfg config, target *benchTarget, db *mongo.Database, coll *mongo.Collection, prebuilt []bson.D) (phaseResult, *productionRouteEvidence, error) {
+	if productionRouteRemoteOwnerRedirectProof(cfg) {
+		return runProductionRemoteOwnerRedirectLoadPhase(ctx, cfg, target, db, coll)
+	}
 	if target == nil || target.productionRoute == nil {
 		return phaseResult{}, nil, errors.New("route-mode production requires production route harness")
 	}
@@ -3863,6 +3871,126 @@ func runProductionRoutedLoadPhase(ctx context.Context, cfg config, target *bench
 		return phase, evidence, errors.New("production route evidence did not prove routed local-owner commit/apply")
 	}
 	return phase, evidence, nil
+}
+
+func runProductionRemoteOwnerRedirectLoadPhase(ctx context.Context, cfg config, target *benchTarget, db *mongo.Database, coll *mongo.Collection) (phaseResult, *productionRouteEvidence, error) {
+	if target == nil || target.productionRoute == nil {
+		return phaseResult{}, nil, errors.New("route-mode production requires production route harness")
+	}
+	if err := ensureProductionRouteCollection(ctx, cfg, target, db); err != nil {
+		return phaseResult{}, nil, err
+	}
+	remoteDocs, remoteKeys, err := productionRemoteOwnerRedirectDocuments(cfg)
+	if err != nil {
+		return phaseResult{}, nil, err
+	}
+	target.productionRoute.ResetCounters()
+
+	var beforeDisk diskSnapshot
+	haveBeforeDisk := false
+	if target.treedbDir != "" {
+		if snapshot, err := collectDiskSnapshot(target.treedbDir); err == nil {
+			beforeDisk = snapshot
+			haveBeforeDisk = true
+		}
+	}
+
+	var before, after runtime.MemStats
+	runtime.ReadMemStats(&before)
+	phase, err := measurePhase("load_insert_one_production_remote_owner_redirect", cfg.Documents, func(sample func(time.Duration)) error {
+		return runConcurrentOperations(ctx, 1, len(remoteDocs), func(op int) error {
+			begin := time.Now()
+			_, err := coll.InsertOne(ctx, remoteDocs[op])
+			sample(time.Since(begin))
+			if err == nil {
+				return fmt.Errorf("production remote-owner redirect proof insert %d unexpectedly succeeded", op)
+			}
+			if !productionRouteRemoteOwnerRedirectError(err) {
+				return fmt.Errorf("production remote-owner redirect proof insert %d err=%w want remote_owner_redirect", op, err)
+			}
+			return nil
+		})
+	})
+	runtime.ReadMemStats(&after)
+	if cfg.InsertProducers != 1 {
+		phase.EffectiveProducers = 1
+	}
+	if err != nil {
+		return phase, nil, err
+	}
+	if err := assertProductionRemoteOwnerRedirectNoLocalDocuments(target, cfg, remoteKeys); err != nil {
+		return phase, nil, err
+	}
+	var storageOverhead int64
+	if haveBeforeDisk {
+		if afterDisk, err := collectDiskSnapshot(target.treedbDir); err == nil {
+			storageOverhead = afterDisk.TotalBytes - beforeDisk.TotalBytes
+		}
+	}
+	evidence := productionRouteEvidenceFromSnapshot(target.productionRoute.Snapshot(), phase, cfg.Documents, before, after, storageOverhead)
+	evidence.EvidenceScope = routeEvidenceScopeProductionRemoteOwnerRedirect
+	if evidence.RealRoutedCommits {
+		return phase, evidence, errors.New("production remote-owner redirect proof unexpectedly proved routed commits")
+	}
+	if evidence.RouteAttemptsTotal != int64(cfg.Documents) || evidence.RouteRemoteRedirects != int64(cfg.Documents) || evidence.RouteLocalOwnerHits != 0 {
+		return phase, evidence, fmt.Errorf("production remote-owner redirect counters attempts/redirects/local=%d/%d/%d want %d/%d/0",
+			evidence.RouteAttemptsTotal, evidence.RouteRemoteRedirects, evidence.RouteLocalOwnerHits, cfg.Documents, cfg.Documents)
+	}
+	if len(evidence.CommitGroupHits) != 0 || len(evidence.AppliedGroupHits) != 0 {
+		return phase, evidence, fmt.Errorf("production remote-owner redirect mutated local commit/apply groups commit=%v apply=%v", evidence.CommitGroupHits, evidence.AppliedGroupHits)
+	}
+	return phase, evidence, nil
+}
+
+func productionRouteRemoteOwnerRedirectProof(cfg config) bool {
+	return cfg.RouteMode == routeModeProduction && cfg.RouteGroupCount > 1
+}
+
+func productionRemoteOwnerRedirectDocuments(cfg config) ([]bson.D, [][]byte, error) {
+	docs := make([]bson.D, 0, cfg.Documents)
+	keys := make([][]byte, 0, cfg.Documents)
+	localGroup := benchsupport.LocalProductionRouteProofGroupID()
+	maxCandidates := cfg.Documents*64 + 1024
+	for i := 0; i < maxCandidates && len(docs) < cfg.Documents; i++ {
+		key, _, err := directBenchmarkDocumentKey(cfg.DocumentShape, i)
+		if err != nil {
+			return nil, nil, fmt.Errorf("remote-owner route key %d: %w", i, err)
+		}
+		groupID := benchsupport.ProductionRouteProofGroupIDForDocumentID(cfg.RouteGroupCount, cfg.RoutePartitionCount, key)
+		if groupID == "" || groupID == localGroup {
+			continue
+		}
+		docs = append(docs, benchmarkDocumentForShape(cfg.DocumentShape, i))
+		keys = append(keys, key)
+	}
+	if len(docs) != cfg.Documents {
+		return nil, nil, fmt.Errorf("found %d remote-owner documents for production redirect proof, want %d", len(docs), cfg.Documents)
+	}
+	return docs, keys, nil
+}
+
+func productionRouteRemoteOwnerRedirectError(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "remote_owner_redirect")
+}
+
+func assertProductionRemoteOwnerRedirectNoLocalDocuments(target *benchTarget, cfg config, keys [][]byte) error {
+	if target == nil || target.collections == nil {
+		return errors.New("production remote-owner redirect proof requires collection manager for state assertion")
+	}
+	collection, err := target.collections.OpenCollection(cfg.Database + "." + cfg.Collection)
+	if err != nil {
+		return fmt.Errorf("production remote-owner redirect proof open collection for state assertion: %w", err)
+	}
+	for i, key := range keys {
+		got, err := collection.Get(key)
+		if err != nil {
+			return fmt.Errorf("production remote-owner redirect proof state lookup %d: %w", i, err)
+		}
+		if got != nil {
+			return fmt.Errorf("production remote-owner redirect proof state lookup %d found redirected document key %x", i, key)
+		}
+	}
+	return nil
 }
 
 func ensureProductionRouteCollection(ctx context.Context, cfg config, target *benchTarget, db *mongo.Database) error {

--- a/cmd/mongo_gateway_bench/main_test.go
+++ b/cmd/mongo_gateway_bench/main_test.go
@@ -1101,6 +1101,29 @@ func TestParseConfigRouteModeRing(t *testing.T) {
 	if productionCfg.TreeDBDocumentFormat != collections.DocumentFormatBSON {
 		t.Fatalf("production route document format=%q want %q", productionCfg.TreeDBDocumentFormat, collections.DocumentFormatBSON)
 	}
+	productionRemoteRedirectCfg, err := parseConfig([]string{
+		"-target", "treedb",
+		"-route-mode", "production",
+		"-route-groups", "2",
+		"-route-partitions", "4",
+		"-documents", "4",
+		"-batch-size", "1",
+		"-insert-producers", "1",
+		"-reads", "0",
+		"-range-reads", "0",
+		"-updates", "0",
+		"-deletes", "0",
+		"-secondary-indexes", "0",
+		"-treedb-maintenance", treeDBMaintenanceNone,
+	})
+	if err != nil {
+		t.Fatalf("parse production remote-owner redirect route config: %v", err)
+	}
+	if productionRemoteRedirectCfg.RouteMode != routeModeProduction ||
+		productionRemoteRedirectCfg.RouteGroupCount != 2 ||
+		productionRemoteRedirectCfg.RoutePartitionCount != 4 {
+		t.Fatalf("unexpected production remote redirect route config: %+v", productionRemoteRedirectCfg)
+	}
 
 	tests := []struct {
 		name string
@@ -1113,9 +1136,9 @@ func TestParseConfigRouteModeRing(t *testing.T) {
 			want: "unknown route-mode",
 		},
 		{
-			name: "production n-group remains fail-closed",
+			name: "production n-group default workload remains fail-closed",
 			args: []string{"-target", "treedb", "-route-mode", "production", "-route-groups", "2"},
-			want: "route-mode production currently supports only local-owner proof with route-groups=1",
+			want: "serial insert-only local-owner or remote-owner redirect proof",
 		},
 		{
 			name: "production explicit command-wal false remains fail-closed",
@@ -1130,7 +1153,7 @@ func TestParseConfigRouteModeRing(t *testing.T) {
 		{
 			name: "production default workload remains fail-closed",
 			args: []string{"-target", "treedb", "-route-mode", "production", "-route-groups", "1"},
-			want: "serial insert-only local-owner proof",
+			want: "serial insert-only local-owner or remote-owner redirect proof",
 		},
 		{
 			name: "mongo target",
@@ -1251,6 +1274,90 @@ func TestTreeDBProductionRouteModeLocalOwnerRoutedCommitSmoke(t *testing.T) {
 	}
 	if evidence.CPUContext == "" || evidence.BytesPerOp <= 0 || evidence.AllocsPerOp <= 0 {
 		t.Fatalf("production measurement context/allocation fields missing: %+v", evidence)
+	}
+}
+
+func TestTreeDBProductionRouteModeRemoteOwnerRedirectSmoke(t *testing.T) {
+	cfg, err := parseConfig([]string{
+		"-target", "treedb",
+		"-route-mode", "production",
+		"-route-groups", "2",
+		"-route-partitions", "4",
+		"-documents", "4",
+		"-batch-size", "1",
+		"-insert-producers", "1",
+		"-reads", "0",
+		"-range-reads", "0",
+		"-updates", "0",
+		"-deletes", "0",
+		"-secondary-indexes", "0",
+		"-treedb-maintenance", treeDBMaintenanceNone,
+		"-prebuild-documents",
+		"-timeout", "0",
+		"-format", "json",
+	})
+	if err != nil {
+		t.Fatalf("parse production route remote redirect config: %v", err)
+	}
+	target, err := openTarget(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("open target: %v", err)
+	}
+	defer func() {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		if err := closeBenchTarget(cleanupCtx, target); err != nil {
+			t.Errorf("cleanup target: %v", err)
+		}
+	}()
+
+	runCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	result, err := runBenchmark(runCtx, cfg, target, nil)
+	if err != nil {
+		t.Fatalf("run production route remote redirect benchmark: %v", err)
+	}
+	if result.RouteMode != routeModeProduction || result.RouteGroupCount != 2 || result.RoutePartitionCount != 4 {
+		t.Fatalf("unexpected production route result config: %+v", result)
+	}
+	if result.RouteEvidence != nil {
+		t.Fatalf("local route evidence unexpectedly present for production route mode: %+v", result.RouteEvidence)
+	}
+	if result.ProductionRouteEvidenceStatus != productionRouteEvidenceStatusRemoteOwnerRedirect {
+		t.Fatalf("production route evidence status=%q want %q", result.ProductionRouteEvidenceStatus, productionRouteEvidenceStatusRemoteOwnerRedirect)
+	}
+	evidence := result.ProductionRouteEvidence
+	if evidence == nil {
+		t.Fatalf("production route evidence missing: %+v", result)
+	}
+	if evidence.EvidenceScope != routeEvidenceScopeProductionRemoteOwnerRedirect || evidence.RealRoutedCommits {
+		t.Fatalf("production remote redirect evidence scope/real commits=%+v want redirect-only without routed commits", evidence)
+	}
+	if evidence.RouteAttemptsTotal != int64(cfg.Documents) ||
+		evidence.RouteRemoteRedirects != int64(cfg.Documents) ||
+		evidence.RouteLocalOwnerHits != 0 {
+		t.Fatalf("route attempts/remote/local=%d/%d/%d want %d/%d/0 evidence=%+v",
+			evidence.RouteAttemptsTotal, evidence.RouteRemoteRedirects, evidence.RouteLocalOwnerHits,
+			cfg.Documents, cfg.Documents, evidence)
+	}
+	if evidence.RouteGroupHits["group-00"] != 0 || evidence.RouteGroupHits["group-01"] != cfg.Documents ||
+		evidence.RouteLeaderHits["node-01-a"] != cfg.Documents {
+		t.Fatalf("route group/leader hits do not prove remote owner redirect: %+v", evidence)
+	}
+	if len(evidence.CommitGroupHits) != 0 || len(evidence.AppliedGroupHits) != 0 {
+		t.Fatalf("remote redirect evidence has local commit/apply hits: %+v", evidence)
+	}
+	if got := sumStringIntValues(evidence.RouteTokenPartitionHits); got != cfg.Documents {
+		t.Fatalf("token partition hit total=%d want documents=%d hits=%v", got, cfg.Documents, evidence.RouteTokenPartitionHits)
+	}
+	if result.Phases[0].Name != "load_insert_one_production_remote_owner_redirect" {
+		t.Fatalf("load phase name=%q want production remote-owner redirect boundary", result.Phases[0].Name)
+	}
+	if evidence.WriteLatencyMicros != result.Phases[0].LatencyMicros || evidence.WritesPerSecond != result.Phases[0].OpsPerSecond {
+		t.Fatalf("production remote redirect latency/throughput not tied to load phase evidence=%+v phase=%+v", evidence, result.Phases[0])
+	}
+	if evidence.CPUContext == "" || evidence.BytesPerOp <= 0 || evidence.AllocsPerOp <= 0 {
+		t.Fatalf("production remote redirect measurement context/allocation fields missing: %+v", evidence)
 	}
 }
 
@@ -3581,6 +3688,72 @@ func TestProductionRouteEvidenceJSONSchemaPlaceholder(t *testing.T) {
 	} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("text production evidence missing %q: %s", want, text)
+		}
+	}
+}
+
+func TestProductionRouteEvidenceJSONSchemaRemoteOwnerRedirect(t *testing.T) {
+	result := &benchmarkResult{
+		Target:                        "treedb",
+		RouteMode:                     routeModeProduction,
+		RouteGroupCount:               2,
+		RoutePartitionCount:           4,
+		Database:                      "bench",
+		Collection:                    "docs",
+		Documents:                     1,
+		BatchSize:                     1,
+		ProductionRouteEvidenceStatus: productionRouteEvidenceStatusRemoteOwnerRedirect,
+		ProductionRouteEvidence: &productionRouteEvidence{
+			EvidenceScope:           routeEvidenceScopeProductionRemoteOwnerRedirect,
+			RealRoutedCommits:       false,
+			RouteAttemptsTotal:      1,
+			RouteRemoteRedirects:    1,
+			RouteGroupHits:          map[string]int{"group-01": 1},
+			RouteLeaderHits:         map[string]int{"node-01-a": 1},
+			RouteTokenPartitionHits: map[string]int{"token-000001": 1},
+			WriteLatencyMicros:      latencySummary{P50: 10, P95: 20, P99: 30},
+			WritesPerSecond:         123.4,
+			BytesPerOp:              456,
+			AllocsPerOp:             7,
+			CPUContext:              "unit-test",
+		},
+	}
+	var out bytes.Buffer
+	if err := writeResult(&out, "json", result); err != nil {
+		t.Fatalf("writeResult json: %v", err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(out.Bytes(), &decoded); err != nil {
+		t.Fatalf("unmarshal json result: %v", err)
+	}
+	if got := decoded["production_route_evidence_status"]; got != productionRouteEvidenceStatusRemoteOwnerRedirect {
+		t.Fatalf("production_route_evidence_status=%v want %q", got, productionRouteEvidenceStatusRemoteOwnerRedirect)
+	}
+	productionJSON, ok := decoded["production_route_evidence"].(map[string]any)
+	if !ok {
+		t.Fatalf("production_route_evidence missing or wrong type: %#v", decoded["production_route_evidence"])
+	}
+	if got := productionJSON["evidence_scope"]; got != routeEvidenceScopeProductionRemoteOwnerRedirect {
+		t.Fatalf("production evidence_scope=%v want %q", got, routeEvidenceScopeProductionRemoteOwnerRedirect)
+	}
+	if got := productionJSON["real_routed_commits"]; got != false {
+		t.Fatalf("real_routed_commits=%v want false for redirect-only evidence", got)
+	}
+
+	out.Reset()
+	if err := writeResult(&out, "text", result); err != nil {
+		t.Fatalf("writeResult text: %v", err)
+	}
+	text := out.String()
+	for _, want := range []string{
+		"production_route_evidence_status=available_remote_owner_redirect_only",
+		"production_route_evidence evidence_scope=production_remote_owner_redirect",
+		"real_routed_commits=false",
+		"remote_redirects=1",
+		"group-01:1",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("text remote redirect production evidence missing %q: %s", want, text)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Closes #3471.
Part of #3460.

This adds the M2A production remote-owner redirect proof for `cmd/mongo_gateway_bench`:

- allows the narrow production proof shape with `-route-groups >1`
- records remote-owner redirects separately from local-owner routed commits
- proves redirected inserts do not mutate the local collection
- keeps `route-groups 1` as the existing local-owner routed-commit proof
- documents the boundary: redirect/no-local-mutation only, no forwarding, no remote execution, no fanout, no horizontal-scale claim

## Evidence

Head SHA tested: `af80dfab1eabb5fbb27a0425b8664077f07bf55b`

Focused affected package suite:

```sh
env GOWORK=off GOCACHE=/mnt/fast4tb/tmp/gomap-3471-gocache GOMODCACHE=/mnt/fast4tb/tmp/gomap-3471-gomodcache GOPATH=/mnt/fast4tb/tmp/gomap-3471-gopath \
  go test ./TreeDB/internal/raftplacement ./TreeDB/internal/raftcluster ./TreeDB/nativewire ./TreeDB/mongo_gateway ./TreeDB/mongo_gateway/benchsupport ./cmd/mongo_gateway_bench -count=1
```

Result: PASS.

Evidence artifacts:

- `/mnt/fast4tb/tmp/gomap-3471-evidence-20260704T185842Z/remote_owner_redirect.json`
- `/mnt/fast4tb/tmp/gomap-3471-evidence-20260704T185842Z/local_owner_routed_commit.json`

Remote-owner redirect run:

```text
status=available_remote_owner_redirect_only
scope=production_remote_owner_redirect
real_routed_commits=false
route_attempts_total=16
route_local_owner_hits=0
route_remote_redirects=16
route_remote_forwards=0
route_unknown_owner_rejects=0
direct_local_bypass_rejects=0
route_group_hits={"group-01":16}
commit_group_hits=null
applied_group_hits=null
writes_per_sec=2.136669418996902
b_per_op=104205
allocs_per_op=596.6875
```

Local-owner routed commit regression run:

```text
status=available
scope=production_routed_commit
real_routed_commits=true
route_attempts_total=17
route_local_owner_hits=17
route_remote_redirects=0
route_remote_forwards=0
route_unknown_owner_rejects=1
direct_local_bypass_rejects=1
route_group_hits={"group-00":17}
commit_group_hits={"group-00":17}
applied_group_hits={"group-00":17}
```

## Boundary

This PR intentionally does not implement M2B remote execution. It makes the production boundary explicit and measurable so #3472 can add the first remote-owner routed write on top of a fail-closed redirect proof.
