### PR TITLE
TreeDB: route remote-owner production writes

### DIFF
--- a/TreeDB/mongo_gateway/benchsupport/production_route.go
+++ b/TreeDB/mongo_gateway/benchsupport/production_route.go
@@ -187,9 +187,10 @@ func ProductionRouteProofGroupIDForDocumentID(groupCount, partitionCount int, do
 }
 
 func (h *ProductionRouteProofHarness) ProbeUnknownOwnerReject(ctx context.Context, database, collection string) error {
-	if h == nil || h.dispatcher == nil {
+	if h == nil || h.dispatcher == nil || h.recorder == nil {
 		return errors.New("production route proof dispatcher is not configured")
 	}
+	target := h.recorder.unknownOwnerProbeTarget()
 	unknown := nativewire.ClusterRequestMetadata{
 		AckPolicy:                 nativewire.AckVisible,
 		ClusterRouteKnown:         true,
@@ -197,9 +198,9 @@ func (h *ProductionRouteProofHarness) ProbeUnknownOwnerReject(ctx context.Contex
 		ClusterRouteCatalog:       "default",
 		ClusterRouteCollection:    collection,
 		ClusterRouteShape:         string(nativewire.ClusterRouteShapeToken),
-		ClusterRouteGroupID:       "group-99",
-		ClusterRouteMembers:       []string{"node-99-a"},
-		ClusterRouteLeaderHint:    "node-99-a",
+		ClusterRouteGroupID:       target.GroupID,
+		ClusterRouteMembers:       target.Members,
+		ClusterRouteLeaderHint:    target.LeaderHint,
 		ClusterRoutePlacementMode: "ring",
 		ClusterRouteKey:           "_id",
 		ClusterRouteTokenKnown:    true,
@@ -661,6 +662,14 @@ func (r *productionRouteProofRecorder) groupTarget(group int) nativewire.Cluster
 		Members:    []string{leader, fmt.Sprintf("node-%02d-b", group), fmt.Sprintf("node-%02d-c", group)},
 		LeaderHint: leader,
 	}
+}
+
+func (r *productionRouteProofRecorder) unknownOwnerProbeTarget() nativewire.ClusterRouteTarget {
+	group := 99
+	if r != nil {
+		group = max(group, r.groupCount)
+	}
+	return r.groupTarget(group)
 }
 
 func (r *productionRouteProofRecorder) recordRouteSuccess(target nativewire.ClusterRouteTarget) {

--- a/TreeDB/mongo_gateway/benchsupport/production_route.go
+++ b/TreeDB/mongo_gateway/benchsupport/production_route.go
@@ -1,6 +1,7 @@
 package benchsupport
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -20,11 +21,12 @@ import (
 )
 
 // ProductionRouteProofOptions scopes the bench-only production route proof. It
-// intentionally models only locally configured submitters; nonlocal groups are
-// redirect evidence, not remote execution.
+// defaults to one locally executable group. RemoteOwnerExecution opts the proof
+// harness into static, in-process forwarding to additional registered groups.
 type ProductionRouteProofOptions struct {
-	GroupCount     int
-	PartitionCount int
+	GroupCount           int
+	PartitionCount       int
+	RemoteOwnerExecution bool
 }
 
 // ProductionRouteProofSnapshot is the bench-facing counter snapshot proving
@@ -46,24 +48,35 @@ type ProductionRouteProofSnapshot struct {
 	DirectLocalBypassRejects int64
 }
 
-// ProductionRouteProofHarness owns the local raft FSM and route counters used
-// by mongo_gateway_bench production-route correctness evidence.
+// ProductionRouteProofHarness owns the production-route proof submitters and
+// route counters used by mongo_gateway_bench correctness evidence.
 type ProductionRouteProofHarness struct {
 	fsm        *raftfsm.FSM
+	fsms       []*raftfsm.FSM
 	recorder   *productionRouteProofRecorder
 	dispatcher *raftcluster.GroupRoutedSubmitter
 }
 
 // ConfigureProductionRouteProofHarness wires server.ClusterSubmitter to a
-// single local group routed dispatcher. The commit source is deterministic and
+// routed dispatcher with a local group and, when opted in, registered
+// in-process remote groups. The commit sources are deterministic and
 // in-process, so this is correctness/instrumentation proof for the gateway
 // route boundary, not a multi-node scaleout benchmark.
 func ConfigureProductionRouteProofHarness(opts ProductionRouteProofOptions, db *backenddb.DB, manager *collections.CollectionManager, server *mongogateway.Server) (*ProductionRouteProofHarness, error) {
 	if server == nil {
 		return nil, errors.New("production route proof harness requires Mongo gateway server")
 	}
-	cluster := productionRouteProofClusterConfig(db)
-	recorder := newProductionRouteProofRecorder(opts.GroupCount, opts.PartitionCount, string(cluster.GroupID))
+	if opts.GroupCount < 1 {
+		opts.GroupCount = 1
+	}
+	cluster := productionRouteProofClusterConfig(db, 0)
+	forwardGroups := make([]string, 0, max(0, opts.GroupCount-1))
+	if opts.RemoteOwnerExecution {
+		for group := 1; group < opts.GroupCount; group++ {
+			forwardGroups = append(forwardGroups, productionRouteProofGroupID(group))
+		}
+	}
+	recorder := newProductionRouteProofRecorderWithForwardGroups(opts.GroupCount, opts.PartitionCount, string(cluster.GroupID), forwardGroups...)
 	fsm, err := raftfsm.Open(raftfsm.Options{
 		DB:      db,
 		Cluster: cluster,
@@ -75,16 +88,8 @@ func ConfigureProductionRouteProofHarness(opts ProductionRouteProofOptions, db *
 		return nil, err
 	}
 	catalogVersion := newProductionRouteProofCatalogVersion(db)
-	commit := &productionRouteProofCommitSource{
-		inner: raftcluster.NewSequencedCommitSource(raftcluster.SequencedCommitSourceOptions{
-			GroupID:             cluster.GroupID,
-			NodeID:              cluster.NodeID,
-			LeaderID:            cluster.NodeID,
-			EvidenceKind:        raftcluster.CommitEvidenceProductionConsensusV1,
-			ProductionConsensus: true,
-		}),
-		recorder: recorder,
-	}
+	entries := make([]raftcluster.GroupSubmitterV1, 0, max(1, opts.GroupCount))
+	var openedFSMs []*raftfsm.FSM
 	applier := &productionRouteProofApplier{
 		inner:          fsm,
 		recorder:       recorder,
@@ -93,7 +98,7 @@ func ConfigureProductionRouteProofHarness(opts ProductionRouteProofOptions, db *
 	bridge, err := raftcluster.NewSingleGroupSubmitter(raftcluster.SingleGroupSubmitterOptions{
 		Cluster:                cluster,
 		AdmissionProvider:      raftcluster.StaticAdmissionProvider{Status: raftcluster.LeaderAdmission()},
-		CommitSource:           commit,
+		CommitSource:           newProductionRouteProofCommitSource(cluster, recorder),
 		Preflight:              fsm,
 		Applier:                applier,
 		CatalogVersionProvider: catalogVersion,
@@ -102,29 +107,55 @@ func ConfigureProductionRouteProofHarness(opts ProductionRouteProofOptions, db *
 		_ = fsm.Close()
 		return nil, err
 	}
-	registry, err := raftcluster.NewGroupSubmitterRegistryV1([]raftcluster.GroupSubmitterV1{
-		{GroupID: cluster.GroupID, Submitter: bridge},
-	})
+	openedFSMs = append(openedFSMs, fsm)
+	entries = append(entries, raftcluster.GroupSubmitterV1{GroupID: cluster.GroupID, Submitter: bridge})
+	if opts.RemoteOwnerExecution {
+		for group := 1; group < opts.GroupCount; group++ {
+			remoteCluster := productionRouteProofClusterConfig(db, group)
+			boundary := newProductionRouteProofMemoryApplyBoundary(db, remoteCluster, recorder, catalogVersion)
+			remoteBridge, err := raftcluster.NewSingleGroupSubmitter(raftcluster.SingleGroupSubmitterOptions{
+				Cluster:                remoteCluster,
+				AdmissionProvider:      raftcluster.StaticAdmissionProvider{Status: raftcluster.LeaderAdmission()},
+				CommitSource:           newProductionRouteProofCommitSource(remoteCluster, recorder),
+				Preflight:              boundary,
+				Applier:                boundary,
+				CatalogVersionProvider: catalogVersion,
+			})
+			if err != nil {
+				_ = closeProductionRouteProofFSMs(openedFSMs)
+				return nil, err
+			}
+			entries = append(entries, raftcluster.GroupSubmitterV1{GroupID: remoteCluster.GroupID, Submitter: remoteBridge})
+		}
+	}
+	registry, err := raftcluster.NewGroupSubmitterRegistryV1(entries)
 	if err != nil {
-		_ = fsm.Close()
+		_ = closeProductionRouteProofFSMs(openedFSMs)
 		return nil, err
 	}
 	dispatcher, err := raftcluster.NewGroupRoutedSubmitter(raftcluster.GroupRoutedSubmitterOptions{Registry: registry})
 	if err != nil {
-		_ = fsm.Close()
+		_ = closeProductionRouteProofFSMs(openedFSMs)
 		return nil, err
 	}
 	server.ClusterSubmitter = nativewire.NewRoutedRaftClusterSubmitter(dispatcher, recorder, manager)
 	server.ClusterCatalogVersion = catalogVersion.ServerCatalogVersion
 	return &ProductionRouteProofHarness{
 		fsm:        fsm,
+		fsms:       openedFSMs,
 		recorder:   recorder,
 		dispatcher: dispatcher,
 	}, nil
 }
 
 func (h *ProductionRouteProofHarness) Close() error {
-	if h == nil || h.fsm == nil {
+	if h == nil {
+		return nil
+	}
+	if len(h.fsms) != 0 {
+		return closeProductionRouteProofFSMs(h.fsms)
+	}
+	if h.fsm == nil {
 		return nil
 	}
 	return h.fsm.Close()
@@ -194,20 +225,45 @@ func (h *ProductionRouteProofHarness) ProbeDirectLocalBypassReject(ctx context.C
 	return nil
 }
 
-func productionRouteProofClusterConfig(db *backenddb.DB) raftcluster.Config {
+func productionRouteProofClusterConfig(db *backenddb.DB, group int) raftcluster.Config {
 	dir := ""
 	if db != nil {
 		dir = db.Dir()
 	}
+	groupID := productionRouteProofGroupID(group)
+	basePort := 9701 + group*10
 	return raftcluster.Config{
 		Dir:     dir,
-		NodeID:  "node-00-a",
-		GroupID: raftcluster.GroupID(productionRouteProofGroupID(0)),
+		NodeID:  raftcluster.NodeID(fmt.Sprintf("node-%02d-a", group)),
+		GroupID: raftcluster.GroupID(groupID),
 		Peers: []raftcluster.Peer{
-			{ID: "node-00-a", Address: "127.0.0.1:9701"},
-			{ID: "node-00-b", Address: "127.0.0.1:9702"},
-			{ID: "node-00-c", Address: "127.0.0.1:9703"},
+			{ID: raftcluster.NodeID(fmt.Sprintf("node-%02d-a", group)), Address: fmt.Sprintf("127.0.0.1:%d", basePort)},
+			{ID: raftcluster.NodeID(fmt.Sprintf("node-%02d-b", group)), Address: fmt.Sprintf("127.0.0.1:%d", basePort+1)},
+			{ID: raftcluster.NodeID(fmt.Sprintf("node-%02d-c", group)), Address: fmt.Sprintf("127.0.0.1:%d", basePort+2)},
 		},
+	}
+}
+
+func closeProductionRouteProofFSMs(fsms []*raftfsm.FSM) error {
+	var errs []error
+	for _, fsm := range fsms {
+		if fsm != nil {
+			errs = append(errs, fsm.Close())
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func newProductionRouteProofCommitSource(cluster raftcluster.Config, recorder *productionRouteProofRecorder) *productionRouteProofCommitSource {
+	return &productionRouteProofCommitSource{
+		inner: raftcluster.NewSequencedCommitSource(raftcluster.SequencedCommitSourceOptions{
+			GroupID:             cluster.GroupID,
+			NodeID:              cluster.NodeID,
+			LeaderID:            cluster.NodeID,
+			EvidenceKind:        raftcluster.CommitEvidenceProductionConsensusV1,
+			ProductionConsensus: true,
+		}),
+		recorder: recorder,
 	}
 }
 
@@ -269,6 +325,115 @@ func (a *productionRouteProofApplier) AllowsInitialIndexGapV1() bool {
 	}
 	support, ok := a.inner.(raftcluster.InitialIndexGapSupportV1)
 	return ok && support.AllowsInitialIndexGapV1()
+}
+
+type productionRouteProofMemoryApplyBoundary struct {
+	db             *backenddb.DB
+	cluster        raftcluster.Config
+	recorder       *productionRouteProofRecorder
+	catalogVersion *productionRouteProofCatalogVersion
+	progress       *raftapply.MemoryApplyProgressStore
+	results        *raftapply.MemoryApplyResultStore
+}
+
+func newProductionRouteProofMemoryApplyBoundary(db *backenddb.DB, cluster raftcluster.Config, recorder *productionRouteProofRecorder, catalogVersion *productionRouteProofCatalogVersion) *productionRouteProofMemoryApplyBoundary {
+	return &productionRouteProofMemoryApplyBoundary{
+		db:             db,
+		cluster:        cluster,
+		recorder:       recorder,
+		catalogVersion: catalogVersion,
+		progress:       raftapply.NewMemoryApplyProgressStore(raftentry.MaxProgressRecordsV1, 0),
+		results:        raftapply.NewMemoryApplyResultStore(raftentry.MaxProgressRecordsV1),
+	}
+}
+
+func (b *productionRouteProofMemoryApplyBoundary) PreflightCommandEntryV1(ctx context.Context, req raftcluster.CommandEntryPreflightRequestV1) (raftcluster.CommandEntryPreflightResultV1, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	select {
+	case <-ctx.Done():
+		return raftcluster.CommandEntryPreflightResultV1{}, ctx.Err()
+	default:
+	}
+	if b == nil || b.db == nil {
+		return raftcluster.CommandEntryPreflightResultV1{}, raftcluster.ErrInvalidSubmitter
+	}
+	if req.GroupID != "" && req.GroupID != b.cluster.GroupID {
+		return raftcluster.CommandEntryPreflightResultV1{}, fmt.Errorf("production route proof preflight group %q does not match local group %q", req.GroupID, b.cluster.GroupID)
+	}
+	if req.NodeID != "" && req.NodeID != b.cluster.NodeID {
+		return raftcluster.CommandEntryPreflightResultV1{}, fmt.Errorf("production route proof preflight node %q does not match local node %q", req.NodeID, b.cluster.NodeID)
+	}
+	if len(req.EntryBytes) == 0 {
+		return raftcluster.CommandEntryPreflightResultV1{}, errors.New("production route proof preflight empty command entry")
+	}
+	meta := productionRouteProofApplyMetadata(req.CurrentCatalogVersion, req.HasCurrentCatalogVersion, req.SyncLocalCommandWAL, req.RequestMetadata, req.ExpectedTarget)
+	opts := raftapply.Options{ResultStore: b.results}
+	var result raftapply.PreflightResultV1
+	var err error
+	if len(req.DecodedEntry.Bytes) != 0 {
+		if !bytes.Equal(req.DecodedEntry.Bytes, req.EntryBytes) {
+			return raftcluster.CommandEntryPreflightResultV1{}, errors.New("production route proof preflight decoded command entry does not match raw entry bytes")
+		}
+		result, err = raftapply.PreflightDecodedCommandEntryV1(b.db, req.DecodedEntry, meta, opts)
+	} else {
+		result, err = raftapply.PreflightCommandEntryV1(b.db, req.EntryBytes, meta, opts)
+	}
+	if err != nil {
+		return raftcluster.CommandEntryPreflightResultV1{}, err
+	}
+	return raftcluster.CommandEntryPreflightResultV1{KnownIdempotencyReplay: result.KnownIdempotencyReplay}, nil
+}
+
+func (b *productionRouteProofMemoryApplyBoundary) ApplyCommittedCommandEntryV1(ctx context.Context, entry raftcluster.CommittedCommandEntryV1) (raftentry.ApplyResultV1, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	select {
+	case <-ctx.Done():
+		return raftentry.ApplyResultV1{}, ctx.Err()
+	default:
+	}
+	if b == nil || b.db == nil {
+		return raftentry.ApplyResultV1{}, raftcluster.ErrInvalidSubmitter
+	}
+	if entry.RequestMetadata.ClusterRouteGroupID != "" && entry.RequestMetadata.ClusterRouteGroupID != string(b.cluster.GroupID) {
+		return raftentry.ApplyResultV1{}, fmt.Errorf("production route proof apply route group %q does not match local group %q", entry.RequestMetadata.ClusterRouteGroupID, b.cluster.GroupID)
+	}
+	meta := productionRouteProofApplyMetadata(entry.CurrentCatalogVersion, entry.HasCurrentCatalogVersion, entry.SyncLocalCommandWAL, entry.RequestMetadata, entry.ExpectedTarget)
+	meta.EntryID = raftentry.ApplyEntryID{Term: entry.Term, Index: entry.Index}
+	result, err := raftapply.ApplyCommittedEntryV1(b.db, entry.Bytes, meta, raftapply.Options{
+		ProgressStore: b.progress,
+		ResultStore:   b.results,
+	})
+	if err != nil {
+		return result, err
+	}
+	if result.Status == raftentry.ApplyStatusApplied || result.Status == raftentry.ApplyStatusAlreadyApplied {
+		groupID := entry.RequestMetadata.ClusterRouteGroupID
+		if groupID == "" {
+			groupID = string(b.cluster.GroupID)
+		}
+		if b.recorder != nil {
+			b.recorder.recordAppliedGroup(groupID)
+		}
+		if b.catalogVersion != nil {
+			b.catalogVersion.Refresh()
+		}
+	}
+	return result, nil
+}
+
+func productionRouteProofApplyMetadata(catalogVersion uint64, hasCatalogVersion, syncLocalWAL bool, metadata raftentry.RequestMetadataV1, expectedTarget *raftentry.TargetIdentityV1) raftapply.ApplyMetadataV1 {
+	return raftapply.ApplyMetadataV1{
+		LocalDurabilityBoundary:  raftapply.LocalDurabilityCommandWALV1,
+		SyncLocalCommandWAL:      syncLocalWAL,
+		CurrentCatalogVersion:    catalogVersion,
+		HasCurrentCatalogVersion: hasCatalogVersion,
+		RequestMetadata:          metadata,
+		ExpectedTarget:           expectedTarget,
+	}
 }
 
 type productionRouteProofCatalogVersion struct {
@@ -333,11 +498,13 @@ type productionRouteProofRecorder struct {
 	groupCount     int
 	partitionCount int
 	localGroups    map[string]struct{}
+	forwardGroups  map[string]struct{}
 
 	mu                       sync.Mutex
 	routeAttemptsTotal       int64
 	routeLocalOwnerHits      int64
 	routeRemoteRedirects     int64
+	routeRemoteForwards      int64
 	routeUnknownOwnerRejects int64
 	directLocalBypassRejects int64
 	fanoutSplitAttempts      int64
@@ -350,25 +517,35 @@ type productionRouteProofRecorder struct {
 }
 
 func newProductionRouteProofRecorder(groupCount, partitionCount int, localGroupIDs ...string) *productionRouteProofRecorder {
+	localGroupID := productionRouteProofGroupID(0)
+	if len(localGroupIDs) != 0 {
+		localGroupID = localGroupIDs[0]
+	}
+	return newProductionRouteProofRecorderWithForwardGroups(groupCount, partitionCount, localGroupID)
+}
+
+func newProductionRouteProofRecorderWithForwardGroups(groupCount, partitionCount int, localGroupID string, forwardGroupIDs ...string) *productionRouteProofRecorder {
 	if groupCount < 1 {
 		groupCount = 1
 	}
 	if partitionCount < groupCount {
 		partitionCount = groupCount
 	}
-	if len(localGroupIDs) == 0 {
-		localGroupIDs = []string{productionRouteProofGroupID(0)}
+	if localGroupID == "" {
+		localGroupID = productionRouteProofGroupID(0)
 	}
-	localGroups := make(map[string]struct{}, len(localGroupIDs))
-	for _, groupID := range localGroupIDs {
-		if groupID != "" {
-			localGroups[groupID] = struct{}{}
+	localGroups := map[string]struct{}{localGroupID: {}}
+	forwardGroups := make(map[string]struct{}, len(forwardGroupIDs))
+	for _, groupID := range forwardGroupIDs {
+		if groupID != "" && groupID != localGroupID {
+			forwardGroups[groupID] = struct{}{}
 		}
 	}
 	return &productionRouteProofRecorder{
 		groupCount:              groupCount,
 		partitionCount:          partitionCount,
 		localGroups:             localGroups,
+		forwardGroups:           forwardGroups,
 		routeGroupHits:          make(map[string]int, groupCount),
 		routeLeaderHits:         make(map[string]int, groupCount),
 		routeTokenPartitionHits: make(map[string]int, partitionCount),
@@ -495,6 +672,8 @@ func (r *productionRouteProofRecorder) recordRouteSuccess(target nativewire.Clus
 	r.routeAttemptsTotal++
 	if _, ok := r.localGroups[target.GroupID]; ok {
 		r.routeLocalOwnerHits++
+	} else if _, ok := r.forwardGroups[target.GroupID]; ok {
+		r.routeRemoteForwards++
 	} else if target.GroupID != "" {
 		r.routeRemoteRedirects++
 	}
@@ -564,6 +743,7 @@ func (r *productionRouteProofRecorder) resetCounters() {
 	r.routeAttemptsTotal = 0
 	r.routeLocalOwnerHits = 0
 	r.routeRemoteRedirects = 0
+	r.routeRemoteForwards = 0
 	r.routeUnknownOwnerRejects = 0
 	r.directLocalBypassRejects = 0
 	r.fanoutSplitAttempts = 0
@@ -585,12 +765,13 @@ func (r *productionRouteProofRecorder) snapshot() ProductionRouteProofSnapshot {
 	applyHits := cloneStringIntMap(r.appliedGroupHits)
 	commitTotal := int64(sumIntMap(commitHits))
 	applyTotal := int64(sumIntMap(applyHits))
+	routedOwnerHits := r.routeLocalOwnerHits + r.routeRemoteForwards
 	return ProductionRouteProofSnapshot{
-		RealRoutedCommits:        r.routeAttemptsTotal > 0 && r.routeLocalOwnerHits == r.routeAttemptsTotal && commitTotal == r.routeAttemptsTotal && applyTotal == r.routeAttemptsTotal,
+		RealRoutedCommits:        r.routeAttemptsTotal > 0 && routedOwnerHits == r.routeAttemptsTotal && r.routeRemoteRedirects == 0 && commitTotal == r.routeAttemptsTotal && applyTotal == r.routeAttemptsTotal,
 		RouteAttemptsTotal:       r.routeAttemptsTotal,
 		RouteLocalOwnerHits:      r.routeLocalOwnerHits,
 		RouteRemoteRedirects:     r.routeRemoteRedirects,
-		RouteRemoteForwards:      0,
+		RouteRemoteForwards:      r.routeRemoteForwards,
 		RouteUnknownOwnerRejects: r.routeUnknownOwnerRejects,
 		RouteGroupHits:           cloneStringIntMap(r.routeGroupHits),
 		RouteLeaderHits:          cloneStringIntMap(r.routeLeaderHits),

--- a/TreeDB/mongo_gateway/benchsupport/production_route_test.go
+++ b/TreeDB/mongo_gateway/benchsupport/production_route_test.go
@@ -93,6 +93,27 @@ func TestProductionRouteProofRecorderCountsConfiguredForwardGroups(t *testing.T)
 	}
 }
 
+func TestProductionRouteProofRecorderUnknownOwnerProbeAvoidsConfiguredGroups(t *testing.T) {
+	forwardGroups := make([]string, 0, 99)
+	for group := 1; group < 100; group++ {
+		forwardGroups = append(forwardGroups, productionRouteProofGroupID(group))
+	}
+	recorder := newProductionRouteProofRecorderWithForwardGroups(100, 100, productionRouteProofGroupID(0), forwardGroups...)
+
+	target := recorder.unknownOwnerProbeTarget()
+	if target.GroupID != productionRouteProofGroupID(100) ||
+		target.LeaderHint != "node-100-a" ||
+		len(target.Members) != 3 {
+		t.Fatalf("unknown owner target=%+v want first group beyond configured registry", target)
+	}
+	if _, ok := recorder.localGroups[target.GroupID]; ok {
+		t.Fatalf("unknown owner probe target %q collides with local groups", target.GroupID)
+	}
+	if _, ok := recorder.forwardGroups[target.GroupID]; ok {
+		t.Fatalf("unknown owner probe target %q collides with forward groups", target.GroupID)
+	}
+}
+
 func TestProductionRouteProofRecorderUnconfiguredGroupStillRedirects(t *testing.T) {
 	recorder := newProductionRouteProofRecorderWithForwardGroups(3, 3, productionRouteProofGroupID(0), productionRouteProofGroupID(1))
 

--- a/TreeDB/mongo_gateway/benchsupport/production_route_test.go
+++ b/TreeDB/mongo_gateway/benchsupport/production_route_test.go
@@ -67,15 +67,65 @@ func TestProductionRouteProofRecorderCountsOnlyConfiguredLocalGroups(t *testing.
 	}
 }
 
+func TestProductionRouteProofRecorderCountsConfiguredForwardGroups(t *testing.T) {
+	recorder := newProductionRouteProofRecorderWithForwardGroups(2, 2, productionRouteProofGroupID(0), productionRouteProofGroupID(1))
+
+	recorder.recordRouteSuccess(recorder.groupTarget(1))
+	recorder.recordCommitGroup(productionRouteProofGroupID(1))
+	recorder.recordAppliedGroup(productionRouteProofGroupID(1))
+
+	snapshot := recorder.snapshot()
+	if snapshot.RouteAttemptsTotal != 1 ||
+		snapshot.RouteRemoteForwards != 1 ||
+		snapshot.RouteRemoteRedirects != 0 ||
+		snapshot.RouteLocalOwnerHits != 0 {
+		t.Fatalf("snapshot attempts/forward/redirect/local=%d/%d/%d/%d want 1/1/0/0: %+v",
+			snapshot.RouteAttemptsTotal, snapshot.RouteRemoteForwards, snapshot.RouteRemoteRedirects, snapshot.RouteLocalOwnerHits, snapshot)
+	}
+	if !snapshot.RealRoutedCommits {
+		t.Fatalf("snapshot did not treat forwarded owner commit/apply as real routed commit: %+v", snapshot)
+	}
+	if snapshot.RouteGroupHits[productionRouteProofGroupID(1)] != 1 ||
+		snapshot.RouteLeaderHits["node-01-a"] != 1 ||
+		snapshot.CommitGroupHits[productionRouteProofGroupID(1)] != 1 ||
+		snapshot.AppliedGroupHits[productionRouteProofGroupID(1)] != 1 {
+		t.Fatalf("forwarded route/commit/apply hits not recorded on group-01: %+v", snapshot)
+	}
+}
+
+func TestProductionRouteProofRecorderUnconfiguredGroupStillRedirects(t *testing.T) {
+	recorder := newProductionRouteProofRecorderWithForwardGroups(3, 3, productionRouteProofGroupID(0), productionRouteProofGroupID(1))
+
+	recorder.recordRouteSuccess(recorder.groupTarget(2))
+	snapshot := recorder.snapshot()
+	if snapshot.RouteAttemptsTotal != 1 ||
+		snapshot.RouteRemoteRedirects != 1 ||
+		snapshot.RouteRemoteForwards != 0 ||
+		snapshot.RouteLocalOwnerHits != 0 ||
+		snapshot.RealRoutedCommits {
+		t.Fatalf("snapshot for unconfigured group=%+v, want redirect-only without real routed commit", snapshot)
+	}
+}
+
 func TestProductionRouteProofRecorderResetCountersPreservesLocalGroups(t *testing.T) {
-	recorder := newProductionRouteProofRecorder(2, 2, productionRouteProofGroupID(0))
+	recorder := newProductionRouteProofRecorderWithForwardGroups(2, 2, productionRouteProofGroupID(0), productionRouteProofGroupID(1))
 	recorder.recordRouteSuccess(recorder.groupTarget(1))
 	recorder.recordCommitGroup(productionRouteProofGroupID(0))
 	recorder.recordAppliedGroup(productionRouteProofGroupID(0))
 	recorder.resetCounters()
 
-	recorder.recordRouteSuccess(recorder.groupTarget(0))
+	recorder.recordRouteSuccess(recorder.groupTarget(1))
 	snapshot := recorder.snapshot()
+	if snapshot.RouteAttemptsTotal != 1 || snapshot.RouteRemoteForwards != 1 || snapshot.RouteRemoteRedirects != 0 || snapshot.RouteLocalOwnerHits != 0 {
+		t.Fatalf("snapshot after reset/forward route=%+v want one forwarded route", snapshot)
+	}
+	if snapshot.CommitGroupHits != nil || snapshot.AppliedGroupHits != nil {
+		t.Fatalf("commit/apply hits survived reset: %+v", snapshot)
+	}
+
+	recorder.resetCounters()
+	recorder.recordRouteSuccess(recorder.groupTarget(0))
+	snapshot = recorder.snapshot()
 	if snapshot.RouteAttemptsTotal != 1 || snapshot.RouteLocalOwnerHits != 1 || snapshot.RouteRemoteRedirects != 0 {
 		t.Fatalf("snapshot after reset/local route=%+v want one local route", snapshot)
 	}

--- a/cmd/mongo_gateway_bench/README.md
+++ b/cmd/mongo_gateway_bench/README.md
@@ -159,16 +159,20 @@ distribution evidence only, not as a cluster throughput or scaleout claim.
 
 `-route-mode production` is a fail-closed production route proof. With
 `-route-groups 1`, it proves local-owner routed commits. With
-`-route-groups >1`, it proves remote-owner redirect/no-local-mutation behavior
-only; it does not forward, execute on a remote group, fan out, or claim
-horizontal scale. Production mode uses command WAL and BSON collection storage,
-routes collection creation and each measured `InsertOne` through the production
-cluster submitter boundary, and emits `production_route_evidence` only for the
-supported proof scopes. It does not emit local `route_evidence`. The current
-production proof accepts only the serial insert-only shape: `-batch-size 1`,
-`-insert-producers 1`, `-secondary-indexes 0`, `-reads 0`, `-range-reads 0`,
-`-updates 0`, `-deletes 0`, no range/indexed-update options, and no concurrent
-phases.
+`-route-groups >1`, it defaults to remote-owner redirect/no-local-mutation
+behavior only; it does not forward, execute on a remote group, fan out, or claim
+horizontal scale. Passing `-production-route-remote-execution` with
+`-route-groups >1` opts into a static, in-process remote-owner routed write
+proof: the Mongo/nativewire write enters through the local submit boundary,
+routes to the owning registered group, and records route/commit/apply evidence
+for that owner group. Production mode uses command WAL and BSON collection
+storage, routes collection creation and each measured `InsertOne` through the
+production cluster submitter boundary, and emits `production_route_evidence`
+only for the supported proof scopes. It does not emit local `route_evidence`.
+The current production proof accepts only the serial insert-only shape:
+`-batch-size 1`, `-insert-producers 1`, `-secondary-indexes 0`, `-reads 0`,
+`-range-reads 0`, `-updates 0`, `-deletes 0`, no range/indexed-update options,
+and no concurrent phases.
 
 Use a small production proof run when validating the route boundary:
 
@@ -205,6 +209,14 @@ Production remote-owner redirect proof JSON reports
 `real_routed_commits=false`, remote redirect counters, route group/leader/token
 partition hits, and empty commit/apply group hits. Treat this as redirect and
 zero-local-mutation evidence only, not as remote execution or scale evidence.
+
+Production remote-owner routed proof JSON reports
+`production_route_evidence_status=available_remote_owner_routed_commit` and
+`evidence_scope=production_remote_owner_routed_commit`, with
+`real_routed_commits=true`, remote forward counters, route group/leader/token
+partition hits, and commit/apply group hits on the owner group. Treat this as
+static in-process production-route correctness evidence, not as network leader
+forwarding, HA, rebalance, fanout, routed reads, or horizontal-scale evidence.
 
 Use `-insert-producers N` to split the insert load phase across producer
 goroutines. The effective producer count is capped at the number of insert

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -64,6 +64,7 @@ type config struct {
 	RouteMode                                     string
 	RouteGroupCount                               int
 	RoutePartitionCount                           int
+	ProductionRouteRemoteExecution                bool
 	TreeDBDir                                     string
 	KeepTreeDBDir                                 bool
 	DropBeforeRun                                 bool
@@ -454,8 +455,10 @@ const (
 	routeEvidenceScopeLocalPreflight                 = "local_preflight"
 	routeEvidenceScopeProductionRoutedCommit         = "production_routed_commit"
 	routeEvidenceScopeProductionRemoteOwnerRedirect  = "production_remote_owner_redirect"
+	routeEvidenceScopeProductionRemoteOwnerRouted    = "production_remote_owner_routed_commit"
 	productionRouteEvidenceStatusAvailable           = "available"
 	productionRouteEvidenceStatusRemoteOwnerRedirect = "available_remote_owner_redirect_only"
+	productionRouteEvidenceStatusRemoteOwnerRouted   = "available_remote_owner_routed_commit"
 	productionRouteEvidenceStatusLocalPreflightOnly  = "unavailable_local_preflight_only"
 
 	clientModeDriver             = "driver"
@@ -575,8 +578,9 @@ func parseConfig(args []string) (config, error) {
 	fs.StringVar(&cfg.MongoURI, "mongo-uri", "mongodb://127.0.0.1:27017", "MongoDB URI for -target mongo")
 	fs.BoolVar(&cfg.MongoCompact, "mongo-compact", false, "compact the MongoDB collection before final stats collection")
 	fs.StringVar(&cfg.RouteMode, "route-mode", cfg.RouteMode, "route evidence mode: off, ring, or production")
-	fs.IntVar(&cfg.RouteGroupCount, "route-groups", cfg.RouteGroupCount, "logical route group count for route evidence; production supports local-owner proof with 1 and remote-owner redirect proof with more")
+	fs.IntVar(&cfg.RouteGroupCount, "route-groups", cfg.RouteGroupCount, "logical route group count for route evidence; production supports local-owner proof with 1 and remote-owner redirect proof with more unless remote execution is explicitly enabled")
 	fs.IntVar(&cfg.RoutePartitionCount, "route-partitions", cfg.RoutePartitionCount, "token partition count for route evidence; must be >= route-groups")
+	fs.BoolVar(&cfg.ProductionRouteRemoteExecution, "production-route-remote-execution", cfg.ProductionRouteRemoteExecution, "enable opt-in static in-process remote-owner routed write proof for route-mode production with route-groups > 1")
 	fs.StringVar(&cfg.TreeDBDir, "treedb-dir", "", "TreeDB directory for -target treedb; empty uses a temp dir")
 	fs.BoolVar(&cfg.KeepTreeDBDir, "keep-treedb-dir", false, "keep an auto-created TreeDB temp dir after the run")
 	fs.BoolVar(&cfg.DropBeforeRun, "drop-before-run", true, "drop the MongoDB database before running -target mongo")
@@ -722,6 +726,14 @@ func parseConfig(args []string) (config, error) {
 		}
 		if cfg.RoutePartitionCount < cfg.RouteGroupCount {
 			return config{}, fmt.Errorf("route-partitions must be >= route-groups for route-mode %s", cfg.RouteMode)
+		}
+	}
+	if cfg.ProductionRouteRemoteExecution {
+		if cfg.RouteMode != routeModeProduction {
+			return config{}, errors.New("production-route-remote-execution requires -route-mode production")
+		}
+		if cfg.RouteGroupCount <= 1 {
+			return config{}, errors.New("production-route-remote-execution requires -route-groups > 1")
 		}
 	}
 	if cfg.Documents <= 0 {
@@ -1329,8 +1341,9 @@ func openTreeDBTarget(ctx context.Context, cfg config) (*benchTarget, error) {
 	var productionRoute *benchsupport.ProductionRouteProofHarness
 	if cfg.RouteMode == routeModeProduction {
 		harness, err := benchsupport.ConfigureProductionRouteProofHarness(benchsupport.ProductionRouteProofOptions{
-			GroupCount:     cfg.RouteGroupCount,
-			PartitionCount: cfg.RoutePartitionCount,
+			GroupCount:           cfg.RouteGroupCount,
+			PartitionCount:       cfg.RoutePartitionCount,
+			RemoteOwnerExecution: cfg.ProductionRouteRemoteExecution,
 		}, db, manager, server)
 		if err != nil {
 			_ = backendCleanup()
@@ -1840,7 +1853,9 @@ func runBenchmark(ctx context.Context, cfg config, target *benchTarget, profiler
 		loadProfileName = "load_insert_one_routed_ring"
 	case routeModeProduction:
 		loadProfileName = "load_insert_one_production_routed_commit"
-		if productionRouteRemoteOwnerRedirectProof(cfg) {
+		if productionRouteRemoteOwnerRoutedCommitProof(cfg) {
+			loadProfileName = "load_insert_one_production_remote_owner_routed_commit"
+		} else if productionRouteRemoteOwnerRedirectProof(cfg) {
 			loadProfileName = "load_insert_one_production_remote_owner_redirect"
 		}
 	}
@@ -1879,6 +1894,8 @@ func runBenchmark(ctx context.Context, cfg config, target *benchTarget, profiler
 		result.ProductionRouteEvidenceStatus = productionRouteEvidenceStatusAvailable
 		if productionRouteResult.EvidenceScope == routeEvidenceScopeProductionRemoteOwnerRedirect {
 			result.ProductionRouteEvidenceStatus = productionRouteEvidenceStatusRemoteOwnerRedirect
+		} else if productionRouteResult.EvidenceScope == routeEvidenceScopeProductionRemoteOwnerRouted {
+			result.ProductionRouteEvidenceStatus = productionRouteEvidenceStatusRemoteOwnerRouted
 		}
 		result.ProductionRouteEvidence = productionRouteResult
 	}
@@ -3810,6 +3827,9 @@ func runRoutedRingLoadPhase(ctx context.Context, cfg config, coll *mongo.Collect
 }
 
 func runProductionRoutedLoadPhase(ctx context.Context, cfg config, target *benchTarget, db *mongo.Database, coll *mongo.Collection, prebuilt []bson.D) (phaseResult, *productionRouteEvidence, error) {
+	if productionRouteRemoteOwnerRoutedCommitProof(cfg) {
+		return runProductionRemoteOwnerRoutedCommitLoadPhase(ctx, cfg, target, db, coll)
+	}
 	if productionRouteRemoteOwnerRedirectProof(cfg) {
 		return runProductionRemoteOwnerRedirectLoadPhase(ctx, cfg, target, db, coll)
 	}
@@ -3873,6 +3893,85 @@ func runProductionRoutedLoadPhase(ctx context.Context, cfg config, target *bench
 	return phase, evidence, nil
 }
 
+func runProductionRemoteOwnerRoutedCommitLoadPhase(ctx context.Context, cfg config, target *benchTarget, db *mongo.Database, coll *mongo.Collection) (phaseResult, *productionRouteEvidence, error) {
+	if target == nil || target.productionRoute == nil {
+		return phaseResult{}, nil, errors.New("route-mode production requires production route harness")
+	}
+	if err := ensureProductionRouteCollection(ctx, cfg, target, db); err != nil {
+		return phaseResult{}, nil, err
+	}
+	remoteDocs, remoteKeys, err := productionRemoteOwnerDocuments(cfg)
+	if err != nil {
+		return phaseResult{}, nil, err
+	}
+	target.productionRoute.ResetCounters()
+
+	var beforeDisk diskSnapshot
+	haveBeforeDisk := false
+	if target.treedbDir != "" {
+		if snapshot, err := collectDiskSnapshot(target.treedbDir); err == nil {
+			beforeDisk = snapshot
+			haveBeforeDisk = true
+		}
+	}
+
+	var before, after runtime.MemStats
+	runtime.ReadMemStats(&before)
+	phase, err := measurePhase("load_insert_one_production_remote_owner_routed_commit", cfg.Documents, func(sample func(time.Duration)) error {
+		return runConcurrentOperations(ctx, 1, len(remoteDocs), func(op int) error {
+			begin := time.Now()
+			_, err := coll.InsertOne(ctx, remoteDocs[op])
+			sample(time.Since(begin))
+			if err != nil {
+				return fmt.Errorf("production remote-owner routed proof insert %d: %w", op, err)
+			}
+			return nil
+		})
+	})
+	runtime.ReadMemStats(&after)
+	if cfg.InsertProducers != 1 {
+		phase.EffectiveProducers = 1
+	}
+	if err != nil {
+		return phase, nil, err
+	}
+	if err := assertProductionRemoteOwnerRoutedDocumentsPresent(target, cfg, remoteKeys); err != nil {
+		return phase, nil, err
+	}
+	if err := target.productionRoute.ProbeUnknownOwnerReject(ctx, cfg.Database, cfg.Collection); err != nil {
+		return phase, nil, err
+	}
+	if err := target.productionRoute.ProbeDirectLocalBypassReject(ctx); err != nil {
+		return phase, nil, err
+	}
+	var storageOverhead int64
+	if haveBeforeDisk {
+		if afterDisk, err := collectDiskSnapshot(target.treedbDir); err == nil {
+			storageOverhead = afterDisk.TotalBytes - beforeDisk.TotalBytes
+		}
+	}
+	evidence := productionRouteEvidenceFromSnapshot(target.productionRoute.Snapshot(), phase, cfg.Documents, before, after, storageOverhead)
+	evidence.EvidenceScope = routeEvidenceScopeProductionRemoteOwnerRouted
+	if !evidence.RealRoutedCommits {
+		return phase, evidence, errors.New("production remote-owner routed proof did not prove routed commit/apply")
+	}
+	if evidence.RouteAttemptsTotal != int64(cfg.Documents) ||
+		evidence.RouteRemoteForwards != int64(cfg.Documents) ||
+		evidence.RouteRemoteRedirects != 0 ||
+		evidence.RouteLocalOwnerHits != 0 {
+		return phase, evidence, fmt.Errorf("production remote-owner routed counters attempts/forwards/redirects/local=%d/%d/%d/%d want %d/%d/0/0",
+			evidence.RouteAttemptsTotal, evidence.RouteRemoteForwards, evidence.RouteRemoteRedirects, evidence.RouteLocalOwnerHits, cfg.Documents, cfg.Documents)
+	}
+	if evidence.CommitGroupHits[benchsupport.LocalProductionRouteProofGroupID()] != 0 ||
+		evidence.AppliedGroupHits[benchsupport.LocalProductionRouteProofGroupID()] != 0 {
+		return phase, evidence, fmt.Errorf("production remote-owner routed proof mutated local owner group commit=%v apply=%v", evidence.CommitGroupHits, evidence.AppliedGroupHits)
+	}
+	if sumStringIntValues(evidence.CommitGroupHits) != cfg.Documents || sumStringIntValues(evidence.AppliedGroupHits) != cfg.Documents {
+		return phase, evidence, fmt.Errorf("production remote-owner routed commit/apply totals commit=%v apply=%v want %d", evidence.CommitGroupHits, evidence.AppliedGroupHits, cfg.Documents)
+	}
+	return phase, evidence, nil
+}
+
 func runProductionRemoteOwnerRedirectLoadPhase(ctx context.Context, cfg config, target *benchTarget, db *mongo.Database, coll *mongo.Collection) (phaseResult, *productionRouteEvidence, error) {
 	if target == nil || target.productionRoute == nil {
 		return phaseResult{}, nil, errors.New("route-mode production requires production route harness")
@@ -3880,7 +3979,7 @@ func runProductionRemoteOwnerRedirectLoadPhase(ctx context.Context, cfg config, 
 	if err := ensureProductionRouteCollection(ctx, cfg, target, db); err != nil {
 		return phaseResult{}, nil, err
 	}
-	remoteDocs, remoteKeys, err := productionRemoteOwnerRedirectDocuments(cfg)
+	remoteDocs, remoteKeys, err := productionRemoteOwnerDocuments(cfg)
 	if err != nil {
 		return phaseResult{}, nil, err
 	}
@@ -3943,10 +4042,14 @@ func runProductionRemoteOwnerRedirectLoadPhase(ctx context.Context, cfg config, 
 }
 
 func productionRouteRemoteOwnerRedirectProof(cfg config) bool {
-	return cfg.RouteMode == routeModeProduction && cfg.RouteGroupCount > 1
+	return cfg.RouteMode == routeModeProduction && cfg.RouteGroupCount > 1 && !cfg.ProductionRouteRemoteExecution
 }
 
-func productionRemoteOwnerRedirectDocuments(cfg config) ([]bson.D, [][]byte, error) {
+func productionRouteRemoteOwnerRoutedCommitProof(cfg config) bool {
+	return cfg.RouteMode == routeModeProduction && cfg.RouteGroupCount > 1 && cfg.ProductionRouteRemoteExecution
+}
+
+func productionRemoteOwnerDocuments(cfg config) ([]bson.D, [][]byte, error) {
 	docs := make([]bson.D, 0, cfg.Documents)
 	keys := make([][]byte, 0, cfg.Documents)
 	localGroup := benchsupport.LocalProductionRouteProofGroupID()
@@ -3964,7 +4067,7 @@ func productionRemoteOwnerRedirectDocuments(cfg config) ([]bson.D, [][]byte, err
 		keys = append(keys, key)
 	}
 	if len(docs) != cfg.Documents {
-		return nil, nil, fmt.Errorf("found %d remote-owner documents for production redirect proof, want %d", len(docs), cfg.Documents)
+		return nil, nil, fmt.Errorf("found %d remote-owner documents for production route proof, want %d", len(docs), cfg.Documents)
 	}
 	return docs, keys, nil
 }
@@ -3988,6 +4091,26 @@ func assertProductionRemoteOwnerRedirectNoLocalDocuments(target *benchTarget, cf
 		}
 		if got != nil {
 			return fmt.Errorf("production remote-owner redirect proof state lookup %d found redirected document key %x", i, key)
+		}
+	}
+	return nil
+}
+
+func assertProductionRemoteOwnerRoutedDocumentsPresent(target *benchTarget, cfg config, keys [][]byte) error {
+	if target == nil || target.collections == nil {
+		return errors.New("production remote-owner routed proof requires collection manager for state assertion")
+	}
+	collection, err := target.collections.OpenCollection(cfg.Database + "." + cfg.Collection)
+	if err != nil {
+		return fmt.Errorf("production remote-owner routed proof open collection for state assertion: %w", err)
+	}
+	for i, key := range keys {
+		got, err := collection.Get(key)
+		if err != nil {
+			return fmt.Errorf("production remote-owner routed proof state lookup %d: %w", i, err)
+		}
+		if got == nil {
+			return fmt.Errorf("production remote-owner routed proof state lookup %d missing routed document key %x", i, key)
 		}
 	}
 	return nil
@@ -4296,6 +4419,14 @@ func cloneStringIntMap(src map[string]int) map[string]int {
 		out[key] = value
 	}
 	return out
+}
+
+func sumStringIntValues(values map[string]int) int {
+	total := 0
+	for _, value := range values {
+		total += value
+	}
+	return total
 }
 
 func runDriverLoadPhase(ctx context.Context, cfg config, coll *mongo.Collection, prebuilt []bson.D) (phaseResult, error) {

--- a/cmd/mongo_gateway_bench/main_test.go
+++ b/cmd/mongo_gateway_bench/main_test.go
@@ -1124,6 +1124,31 @@ func TestParseConfigRouteModeRing(t *testing.T) {
 		productionRemoteRedirectCfg.RoutePartitionCount != 4 {
 		t.Fatalf("unexpected production remote redirect route config: %+v", productionRemoteRedirectCfg)
 	}
+	productionRemoteRoutedCfg, err := parseConfig([]string{
+		"-target", "treedb",
+		"-route-mode", "production",
+		"-route-groups", "2",
+		"-route-partitions", "4",
+		"-production-route-remote-execution",
+		"-documents", "4",
+		"-batch-size", "1",
+		"-insert-producers", "1",
+		"-reads", "0",
+		"-range-reads", "0",
+		"-updates", "0",
+		"-deletes", "0",
+		"-secondary-indexes", "0",
+		"-treedb-maintenance", treeDBMaintenanceNone,
+	})
+	if err != nil {
+		t.Fatalf("parse production remote-owner routed route config: %v", err)
+	}
+	if productionRemoteRoutedCfg.RouteMode != routeModeProduction ||
+		productionRemoteRoutedCfg.RouteGroupCount != 2 ||
+		productionRemoteRoutedCfg.RoutePartitionCount != 4 ||
+		!productionRemoteRoutedCfg.ProductionRouteRemoteExecution {
+		t.Fatalf("unexpected production remote routed route config: %+v", productionRemoteRoutedCfg)
+	}
 
 	tests := []struct {
 		name string
@@ -1149,6 +1174,16 @@ func TestParseConfigRouteModeRing(t *testing.T) {
 			name: "production non-BSON format remains fail-closed",
 			args: []string{"-target", "treedb", "-route-mode", "production", "-route-groups", "1", "-treedb-document-format", "template-v1"},
 			want: "route-mode production currently supports only -treedb-document-format bson",
+		},
+		{
+			name: "remote execution requires production mode",
+			args: []string{"-target", "treedb", "-route-mode", "ring", "-route-groups", "2", "-production-route-remote-execution"},
+			want: "production-route-remote-execution requires -route-mode production",
+		},
+		{
+			name: "remote execution requires remote group",
+			args: []string{"-target", "treedb", "-route-mode", "production", "-route-groups", "1", "-production-route-remote-execution"},
+			want: "production-route-remote-execution requires -route-groups > 1",
 		},
 		{
 			name: "production default workload remains fail-closed",
@@ -1361,6 +1396,97 @@ func TestTreeDBProductionRouteModeRemoteOwnerRedirectSmoke(t *testing.T) {
 	}
 }
 
+func TestTreeDBProductionRouteModeRemoteOwnerRoutedCommitSmoke(t *testing.T) {
+	cfg, err := parseConfig([]string{
+		"-target", "treedb",
+		"-route-mode", "production",
+		"-route-groups", "2",
+		"-route-partitions", "4",
+		"-production-route-remote-execution",
+		"-documents", "4",
+		"-batch-size", "1",
+		"-insert-producers", "1",
+		"-reads", "0",
+		"-range-reads", "0",
+		"-updates", "0",
+		"-deletes", "0",
+		"-secondary-indexes", "0",
+		"-treedb-maintenance", treeDBMaintenanceNone,
+		"-prebuild-documents",
+		"-timeout", "0",
+		"-format", "json",
+	})
+	if err != nil {
+		t.Fatalf("parse production route remote routed config: %v", err)
+	}
+	target, err := openTarget(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("open target: %v", err)
+	}
+	defer func() {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		if err := closeBenchTarget(cleanupCtx, target); err != nil {
+			t.Errorf("cleanup target: %v", err)
+		}
+	}()
+
+	runCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	result, err := runBenchmark(runCtx, cfg, target, nil)
+	if err != nil {
+		t.Fatalf("run production route remote routed benchmark: %v", err)
+	}
+	if result.RouteMode != routeModeProduction || result.RouteGroupCount != 2 || result.RoutePartitionCount != 4 {
+		t.Fatalf("unexpected production route result config: %+v", result)
+	}
+	if result.RouteEvidence != nil {
+		t.Fatalf("local route evidence unexpectedly present for production route mode: %+v", result.RouteEvidence)
+	}
+	if result.ProductionRouteEvidenceStatus != productionRouteEvidenceStatusRemoteOwnerRouted {
+		t.Fatalf("production route evidence status=%q want %q", result.ProductionRouteEvidenceStatus, productionRouteEvidenceStatusRemoteOwnerRouted)
+	}
+	evidence := result.ProductionRouteEvidence
+	if evidence == nil {
+		t.Fatalf("production route evidence missing: %+v", result)
+	}
+	if evidence.EvidenceScope != routeEvidenceScopeProductionRemoteOwnerRouted || !evidence.RealRoutedCommits {
+		t.Fatalf("production remote routed evidence scope/real commits=%+v want remote-owner routed commits", evidence)
+	}
+	if evidence.RouteAttemptsTotal != int64(cfg.Documents) ||
+		evidence.RouteRemoteForwards != int64(cfg.Documents) ||
+		evidence.RouteRemoteRedirects != 0 ||
+		evidence.RouteLocalOwnerHits != 0 {
+		t.Fatalf("route attempts/forwards/redirects/local=%d/%d/%d/%d want %d/%d/0/0 evidence=%+v",
+			evidence.RouteAttemptsTotal, evidence.RouteRemoteForwards, evidence.RouteRemoteRedirects, evidence.RouteLocalOwnerHits,
+			cfg.Documents, cfg.Documents, evidence)
+	}
+	if evidence.RouteUnknownOwnerRejects != 1 || evidence.DirectLocalBypassRejects != 1 {
+		t.Fatalf("guardrail rejects unknown/direct=%d/%d want 1/1 evidence=%+v", evidence.RouteUnknownOwnerRejects, evidence.DirectLocalBypassRejects, evidence)
+	}
+	if evidence.RouteGroupHits["group-00"] != 0 ||
+		evidence.RouteGroupHits["group-01"] != cfg.Documents ||
+		evidence.RouteLeaderHits["node-01-a"] != cfg.Documents ||
+		evidence.CommitGroupHits["group-01"] != cfg.Documents ||
+		evidence.AppliedGroupHits["group-01"] != cfg.Documents ||
+		evidence.CommitGroupHits["group-00"] != 0 ||
+		evidence.AppliedGroupHits["group-00"] != 0 {
+		t.Fatalf("route/commit/apply hits do not prove remote-owner routed submit/apply: %+v", evidence)
+	}
+	if got := sumStringIntValues(evidence.RouteTokenPartitionHits); got != cfg.Documents {
+		t.Fatalf("token partition hit total=%d want documents=%d hits=%v", got, cfg.Documents, evidence.RouteTokenPartitionHits)
+	}
+	if result.Phases[0].Name != "load_insert_one_production_remote_owner_routed_commit" {
+		t.Fatalf("load phase name=%q want production remote-owner routed commit boundary", result.Phases[0].Name)
+	}
+	if evidence.WriteLatencyMicros != result.Phases[0].LatencyMicros || evidence.WritesPerSecond != result.Phases[0].OpsPerSecond {
+		t.Fatalf("production remote routed latency/throughput not tied to load phase evidence=%+v phase=%+v", evidence, result.Phases[0])
+	}
+	if evidence.CPUContext == "" || evidence.BytesPerOp <= 0 || evidence.AllocsPerOp <= 0 {
+		t.Fatalf("production remote routed measurement context/allocation fields missing: %+v", evidence)
+	}
+}
+
 func TestEnsureProductionRouteCollectionRejectsReusedNonBSONCollection(t *testing.T) {
 	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {
@@ -1523,14 +1649,6 @@ func TestRouteEvidenceLocalOnlyCannotSatisfyProductionScaleSchema(t *testing.T) 
 			t.Fatalf("local route evidence unexpectedly included production field %q: %v", key, decoded)
 		}
 	}
-}
-
-func sumStringIntValues(values map[string]int) int {
-	var total int
-	for _, value := range values {
-		total += value
-	}
-	return total
 }
 
 func positiveStringIntCount(values map[string]int) int {
@@ -3754,6 +3872,74 @@ func TestProductionRouteEvidenceJSONSchemaRemoteOwnerRedirect(t *testing.T) {
 	} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("text remote redirect production evidence missing %q: %s", want, text)
+		}
+	}
+}
+
+func TestProductionRouteEvidenceJSONSchemaRemoteOwnerRoutedCommit(t *testing.T) {
+	result := &benchmarkResult{
+		Target:                        "treedb",
+		RouteMode:                     routeModeProduction,
+		RouteGroupCount:               2,
+		RoutePartitionCount:           4,
+		Database:                      "bench",
+		Collection:                    "docs",
+		Documents:                     1,
+		BatchSize:                     1,
+		ProductionRouteEvidenceStatus: productionRouteEvidenceStatusRemoteOwnerRouted,
+		ProductionRouteEvidence: &productionRouteEvidence{
+			EvidenceScope:           routeEvidenceScopeProductionRemoteOwnerRouted,
+			RealRoutedCommits:       true,
+			RouteAttemptsTotal:      1,
+			RouteRemoteForwards:     1,
+			RouteGroupHits:          map[string]int{"group-01": 1},
+			RouteLeaderHits:         map[string]int{"node-01-a": 1},
+			RouteTokenPartitionHits: map[string]int{"token-000001": 1},
+			CommitGroupHits:         map[string]int{"group-01": 1},
+			AppliedGroupHits:        map[string]int{"group-01": 1},
+			WriteLatencyMicros:      latencySummary{P50: 10, P95: 20, P99: 30},
+			WritesPerSecond:         123.4,
+			BytesPerOp:              456,
+			AllocsPerOp:             7,
+			CPUContext:              "unit-test",
+		},
+	}
+	var out bytes.Buffer
+	if err := writeResult(&out, "json", result); err != nil {
+		t.Fatalf("writeResult json: %v", err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(out.Bytes(), &decoded); err != nil {
+		t.Fatalf("unmarshal json result: %v", err)
+	}
+	if got := decoded["production_route_evidence_status"]; got != productionRouteEvidenceStatusRemoteOwnerRouted {
+		t.Fatalf("production_route_evidence_status=%v want %q", got, productionRouteEvidenceStatusRemoteOwnerRouted)
+	}
+	productionJSON, ok := decoded["production_route_evidence"].(map[string]any)
+	if !ok {
+		t.Fatalf("production_route_evidence missing or wrong type: %#v", decoded["production_route_evidence"])
+	}
+	if got := productionJSON["evidence_scope"]; got != routeEvidenceScopeProductionRemoteOwnerRouted {
+		t.Fatalf("production evidence_scope=%v want %q", got, routeEvidenceScopeProductionRemoteOwnerRouted)
+	}
+	if got := productionJSON["real_routed_commits"]; got != true {
+		t.Fatalf("real_routed_commits=%v want true for remote routed evidence", got)
+	}
+
+	out.Reset()
+	if err := writeResult(&out, "text", result); err != nil {
+		t.Fatalf("writeResult text: %v", err)
+	}
+	text := out.String()
+	for _, want := range []string{
+		"production_route_evidence_status=available_remote_owner_routed_commit",
+		"production_route_evidence evidence_scope=production_remote_owner_routed_commit",
+		"real_routed_commits=true",
+		"remote_forwards=1",
+		"group-01:1",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("text remote routed production evidence missing %q: %s", want, text)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Implements #3472 after #3471 landed. This adds an opt-in production-route proof mode for remote-owner writes:

- `-production-route-remote-execution` enables static in-process remote group submitters when `-route-mode production` and `-route-groups > 1`.
- The proof harness distinguishes local owner hits, remote redirects, and remote forwards.
- Remote-owner routed-commit mode now asserts remote documents are committed/applied through the owner group, with no group-00 local mutation.
- Existing redirect-only and local-owner routed-commit evidence modes remain covered.
- Unknown-owner probing now derives a group outside the configured group range, including `route-groups >= 100`.

Latest-head base update: branch merged current `origin/main` (`66a7733188b46b4d814bc7290ff33ffd29de79bf`, PR #3491) before final validation.

## Scope Boundary

This is still static in-process proof evidence for production routing. It does not claim network leader forwarding, HA, rebalance, fanout splitting, routed reads, or horizontal scale.

## Validation

Head validated locally: `eab6ab848074387f86656a747ded2e1a848c2000`

Evidence dir: `/mnt/fast4tb/tmp/gomap-3472-evidence-20260704T203441Z`

Focused package test:

```sh
env GOWORK=off \
  GOCACHE=/mnt/fast4tb/tmp/gomap-3472-gocache \
  GOMODCACHE=/mnt/fast4tb/tmp/gomap-3472-gomodcache \
  GOPATH=/mnt/fast4tb/tmp/gomap-3472-gopath \
  go test ./TreeDB/internal/raftplacement ./TreeDB/internal/raftcluster ./TreeDB/nativewire ./TreeDB/mongo_gateway ./TreeDB/mongo_gateway/benchsupport ./cmd/mongo_gateway_bench -count=1
```

Result: passed.

Remote-owner routed commit:

```text
status=available_remote_owner_routed_commit
scope=production_remote_owner_routed_commit
real=true
attempts/local/redirects/forwards=16/0/0/16
unknown/direct rejects=1/1
route_groups={"group-01":16}
leaders={"node-01-a":16}
partitions={"token-000001":7,"token-000003":9}
commit={"group-01":16}
apply={"group-01":16}
phase=load_insert_one_production_remote_owner_routed_commit
p50/p95/p99 us=568/1121/1121
B/op=283261
allocs/op=1876.3125
```

Remote-owner redirect-only mode preserved:

```text
status=available_remote_owner_redirect_only
scope=production_remote_owner_redirect
real=false
attempts/local/redirects/forwards=16/0/16/0
route_groups={"group-01":16}
leaders={"node-01-a":16}
commit=null
apply=null
```

Local-owner routed commit preserved:

```text
status=available
scope=production_routed_commit
real=true
attempts/local/redirects/forwards=17/17/0/0
unknown/direct rejects=1/1
route_groups={"group-00":17}
leaders={"node-00-a":17}
commit={"group-00":17}
apply={"group-00":17}
p50/p95/p99 us=570/1151/1151
B/op=286960
allocs/op=1954.875
```

CI status: rerunning on latest pushed head.
