### PR TITLE
TreeDB: add low-fanout allocation repro benchmarks

### DIFF
--- a/TreeDB/sync_latency_bench_test.go
+++ b/TreeDB/sync_latency_bench_test.go
@@ -48,12 +48,14 @@ func TestSyncDurabilityBoundaryDoesNotCheckpoint(t *testing.T) {
 
 func BenchmarkSyncLatencyCached(b *testing.B) {
 	tests := []struct {
-		name         string
-		durability   DurabilityMode
-		commandWAL   bool
-		batchSize    int
-		byteHint     bool
-		nonZeroValue bool
+		name                     string
+		durability               DurabilityMode
+		commandWAL               bool
+		batchSize                int
+		byteHint                 bool
+		nonZeroValue             bool
+		valueSize                int
+		valueLogPointerThreshold int
 	}{
 		{name: "SetSync/wal_on_sync", durability: DurabilityDurable},
 		{name: "SetSync/wal_on_sync_command_wal", durability: DurabilityDurable, commandWAL: true},
@@ -64,6 +66,10 @@ func BenchmarkSyncLatencyCached(b *testing.B) {
 		{name: "BatchWriteSync/wal_on_relaxed_sync/32/entry_hint", durability: DurabilityWALOnRelaxed, batchSize: 32},
 		{name: "BatchWriteSync/wal_on_relaxed_sync_command_wal/32/entry_hint", durability: DurabilityWALOnRelaxed, commandWAL: true, batchSize: 32},
 		{name: "BatchWriteSync/wal_on_relaxed_sync_command_wal/32/entry_hint_nonzero_value", durability: DurabilityWALOnRelaxed, commandWAL: true, batchSize: 32, nonZeroValue: true},
+		// Force 128B values onto the value-log path so allocation profiles expose
+		// append-buffer behavior without changing the rest of the low-fanout batch
+		// shape.
+		{name: "BatchWriteSync/wal_on_relaxed_sync_command_wal/32/entry_hint_pointer_threshold_1", durability: DurabilityWALOnRelaxed, commandWAL: true, batchSize: 32, valueLogPointerThreshold: 1},
 		{name: "BatchWriteSync/wal_on_relaxed_sync_command_wal/32/byte_hint", durability: DurabilityWALOnRelaxed, commandWAL: true, batchSize: 32, byteHint: true},
 		{name: "BatchWriteSync/wal_on_relaxed_sync_command_wal/32/byte_hint_nonzero_value", durability: DurabilityWALOnRelaxed, commandWAL: true, batchSize: 32, byteHint: true, nonZeroValue: true},
 		{name: "BatchWriteSync/wal_on_sync_command_wal/128/entry_hint", durability: DurabilityDurable, commandWAL: true, batchSize: 128},
@@ -76,13 +82,20 @@ func BenchmarkSyncLatencyCached(b *testing.B) {
 				Dir:        b.TempDir(),
 				Durability: tt.durability,
 				CommandWAL: tt.commandWAL,
+				ValueLog: ValueLogOptions{
+					PointerThreshold: tt.valueLogPointerThreshold,
+				},
 			})
 			if err != nil {
 				b.Fatalf("open: %v", err)
 			}
 			defer func() { _ = d.Close() }()
 
-			val := make([]byte, 128)
+			valueSize := tt.valueSize
+			if valueSize <= 0 {
+				valueSize = 128
+			}
+			val := make([]byte, valueSize)
 			if tt.nonZeroValue {
 				for i := range val {
 					val[i] = byte(i + 1)

--- a/TreeDB/zipper/read_only_prepare_test.go
+++ b/TreeDB/zipper/read_only_prepare_test.go
@@ -775,6 +775,14 @@ func BenchmarkZipperPrepareReadOnlyManyLeafRandomFresh(b *testing.B) {
 }
 
 func benchmarkZipperPrepareReadOnlyRandom(b *testing.B, keyCount, batchSize int) {
+	benchmarkZipperPrepareReadOnlyRandomImpl(b, keyCount, batchSize, true)
+}
+
+func benchmarkZipperPrepareReadOnlyRandomFresh(b *testing.B, keyCount, batchSize int) {
+	benchmarkZipperPrepareReadOnlyRandomImpl(b, keyCount, batchSize, false)
+}
+
+func benchmarkZipperPrepareReadOnlyRandomImpl(b *testing.B, keyCount, batchSize int, reusePrepareBuffers bool) {
 	_, z := newReadOnlyPrepareZipper(b)
 	rootID := buildReadOnlyPrepareRootWithKeys(b, z, keyCount)
 	delta := batch.NewRetainingLargeEntries(panicValueReader{}, page.DefaultInlineThreshold)
@@ -796,7 +804,10 @@ func benchmarkZipperPrepareReadOnlyRandom(b *testing.B, keyCount, batchSize int)
 	if summary.Spans == 0 || summary.SpanOps == 0 {
 		b.Fatalf("initial prepare spans/ops=%d/%d want non-zero", summary.Spans, summary.SpanOps)
 	}
-	opts := first.ReuseOptions()
+	opts := ReadOnlyPrepareOptions{}
+	if reusePrepareBuffers {
+		opts = first.ReuseOptions()
+	}
 	last := first
 	b.ReportAllocs()
 	b.SetBytes(int64(summary.SpanBytes))
@@ -807,50 +818,9 @@ func benchmarkZipperPrepareReadOnlyRandom(b *testing.B, keyCount, batchSize int)
 			b.Fatalf("PrepareReadOnly: %v", err)
 		}
 		last = prepared
-		opts = prepared.ReuseOptions()
-	}
-	b.StopTimer()
-	lastSummary := last.LeafSpanSummary()
-	lastWorkerSummary := last.LeafSpanWorkerRangeSummary(4)
-	b.ReportMetric(float64(lastSummary.Spans), "leaf_spans/op")
-	b.ReportMetric(float64(lastSummary.SpanOps), "span_ops/op")
-	b.ReportMetric(float64(lastSummary.SpanBytes), "span_bytes/op")
-	b.ReportMetric(float64(lastWorkerSummary.Ranges), "worker_ranges/op")
-	b.ReportMetric(float64(lastWorkerSummary.MaxRangeOps), "max_worker_ops/op")
-}
-
-func benchmarkZipperPrepareReadOnlyRandomFresh(b *testing.B, keyCount, batchSize int) {
-	_, z := newReadOnlyPrepareZipper(b)
-	rootID := buildReadOnlyPrepareRootWithKeys(b, z, keyCount)
-	delta := batch.NewRetainingLargeEntries(panicValueReader{}, page.DefaultInlineThreshold)
-	defer func() { _ = delta.Close() }()
-	for i := 0; i < batchSize; i++ {
-		idx := (i*7919 + 17) % keyCount
-		if err := delta.Set([]byte(fmt.Sprintf("key-%06d", idx)), []byte("new-value")); err != nil {
-			b.Fatalf("Set delta: %v", err)
+		if reusePrepareBuffers {
+			opts = prepared.ReuseOptions()
 		}
-	}
-	delta.SortedEntries()
-
-	first, err := z.PrepareReadOnly(rootID, delta, ReadOnlyPrepareOptions{})
-	if err != nil {
-		b.Fatalf("initial PrepareReadOnly: %v", err)
-	}
-	requireValidReadOnlyPrepare(b, first)
-	summary := first.LeafSpanSummary()
-	if summary.Spans == 0 || summary.SpanOps == 0 {
-		b.Fatalf("initial prepare spans/ops=%d/%d want non-zero", summary.Spans, summary.SpanOps)
-	}
-	last := first
-	b.ReportAllocs()
-	b.SetBytes(int64(summary.SpanBytes))
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		prepared, err := z.PrepareReadOnly(rootID, delta, ReadOnlyPrepareOptions{})
-		if err != nil {
-			b.Fatalf("PrepareReadOnly: %v", err)
-		}
-		last = prepared
 	}
 	b.StopTimer()
 	lastSummary := last.LeafSpanSummary()

--- a/TreeDB/zipper/read_only_prepare_test.go
+++ b/TreeDB/zipper/read_only_prepare_test.go
@@ -770,6 +770,10 @@ func BenchmarkZipperPrepareReadOnlyManyLeafRandom(b *testing.B) {
 	benchmarkZipperPrepareReadOnlyRandom(b, 8192, 1024)
 }
 
+func BenchmarkZipperPrepareReadOnlyManyLeafRandomFresh(b *testing.B) {
+	benchmarkZipperPrepareReadOnlyRandomFresh(b, 8192, 1024)
+}
+
 func benchmarkZipperPrepareReadOnlyRandom(b *testing.B, keyCount, batchSize int) {
 	_, z := newReadOnlyPrepareZipper(b)
 	rootID := buildReadOnlyPrepareRootWithKeys(b, z, keyCount)
@@ -804,6 +808,49 @@ func benchmarkZipperPrepareReadOnlyRandom(b *testing.B, keyCount, batchSize int)
 		}
 		last = prepared
 		opts = prepared.ReuseOptions()
+	}
+	b.StopTimer()
+	lastSummary := last.LeafSpanSummary()
+	lastWorkerSummary := last.LeafSpanWorkerRangeSummary(4)
+	b.ReportMetric(float64(lastSummary.Spans), "leaf_spans/op")
+	b.ReportMetric(float64(lastSummary.SpanOps), "span_ops/op")
+	b.ReportMetric(float64(lastSummary.SpanBytes), "span_bytes/op")
+	b.ReportMetric(float64(lastWorkerSummary.Ranges), "worker_ranges/op")
+	b.ReportMetric(float64(lastWorkerSummary.MaxRangeOps), "max_worker_ops/op")
+}
+
+func benchmarkZipperPrepareReadOnlyRandomFresh(b *testing.B, keyCount, batchSize int) {
+	_, z := newReadOnlyPrepareZipper(b)
+	rootID := buildReadOnlyPrepareRootWithKeys(b, z, keyCount)
+	delta := batch.NewRetainingLargeEntries(panicValueReader{}, page.DefaultInlineThreshold)
+	defer func() { _ = delta.Close() }()
+	for i := 0; i < batchSize; i++ {
+		idx := (i*7919 + 17) % keyCount
+		if err := delta.Set([]byte(fmt.Sprintf("key-%06d", idx)), []byte("new-value")); err != nil {
+			b.Fatalf("Set delta: %v", err)
+		}
+	}
+	delta.SortedEntries()
+
+	first, err := z.PrepareReadOnly(rootID, delta, ReadOnlyPrepareOptions{})
+	if err != nil {
+		b.Fatalf("initial PrepareReadOnly: %v", err)
+	}
+	requireValidReadOnlyPrepare(b, first)
+	summary := first.LeafSpanSummary()
+	if summary.Spans == 0 || summary.SpanOps == 0 {
+		b.Fatalf("initial prepare spans/ops=%d/%d want non-zero", summary.Spans, summary.SpanOps)
+	}
+	last := first
+	b.ReportAllocs()
+	b.SetBytes(int64(summary.SpanBytes))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		prepared, err := z.PrepareReadOnly(rootID, delta, ReadOnlyPrepareOptions{})
+		if err != nil {
+			b.Fatalf("PrepareReadOnly: %v", err)
+		}
+		last = prepared
 	}
 	b.StopTimer()
 	lastSummary := last.LeafSpanSummary()


### PR DESCRIPTION
## Summary

- add a low-fanout sync-latency benchmark shape that forces 128B values onto the value-log pointer path without changing the surrounding command-WAL cached batch shape
- add a fresh zipper prepare benchmark shape that reruns `PrepareReadOnly` without result reuse so `ReadOnlyPrepareResult` allocation paths become measurable on current main
- record the current-main allocation map and successor ordering recommendation for `#3494` under `/mnt/fast4tb/tmp/gomap-3494-m0-20260705T051330Z`

Refs `#3494`  
Parent `#3475`

## Base And Artifacts

- Base `origin/main`: `cd9ae772d4f7cb445470d37e40c97b35b9efadcb`
- Branch: `codex/3494-lowfanout-alloc-map`
- Artifact root: `/mnt/fast4tb/tmp/gomap-3494-m0-20260705T051330Z`

## Validation

`git diff --check`

```sh
TMPDIR=/mnt/fast4tb/tmp GOCACHE=/mnt/fast4tb/tmp/go-cache GOMODCACHE=/mnt/fast4tb/tmp/go-mod-cache GOPATH=/mnt/fast4tb/tmp/go-path-cache GOWORK=off \
  go test ./TreeDB -run '^TestSyncDurabilityBoundaryDoesNotCheckpoint$|^TestDefaultValueLogPointerThreshold_(RelaxedDurability|Durable)_Keeps128BInline$' -count=1

TMPDIR=/mnt/fast4tb/tmp GOCACHE=/mnt/fast4tb/tmp/go-cache GOMODCACHE=/mnt/fast4tb/tmp/go-mod-cache GOPATH=/mnt/fast4tb/tmp/go-path-cache GOWORK=off \
  go test ./TreeDB/zipper -run '^TestReadOnlyPrepareResult|^TestZipperPrepareReadOnlyRandomizedPartition$' -count=1
```

## Benchmark And Profile Commands

```sh
TMPDIR=/mnt/fast4tb/tmp GOCACHE=/mnt/fast4tb/tmp/go-cache GOMODCACHE=/mnt/fast4tb/tmp/go-mod-cache GOPATH=/mnt/fast4tb/tmp/go-path-cache GOWORK=off \
  go test ./TreeDB -run '^$' -bench '^BenchmarkSyncLatencyCached/BatchWriteSync/wal_on_relaxed_sync_command_wal/32/(entry_hint|entry_hint_nonzero_value|byte_hint|byte_hint_nonzero_value)$' -benchtime=20000x -count=1 -benchmem

TMPDIR=/mnt/fast4tb/tmp GOCACHE=/mnt/fast4tb/tmp/go-cache GOMODCACHE=/mnt/fast4tb/tmp/go-mod-cache GOPATH=/mnt/fast4tb/tmp/go-path-cache GOWORK=off \
  go test ./TreeDB -run '^$' -bench '^BenchmarkSyncLatencyCached/BatchWriteSync/wal_on_relaxed_sync_command_wal/32/entry_hint_pointer_threshold_1$' -benchtime=20000x -count=1 -benchmem -cpuprofile /mnt/fast4tb/tmp/gomap-3494-m0-20260705T051330Z/sync_latency/pointer_threshold_1_cpu.pprof -memprofile /mnt/fast4tb/tmp/gomap-3494-m0-20260705T051330Z/sync_latency/pointer_threshold_1_allocs.pprof -memprofilerate=1

TMPDIR=/mnt/fast4tb/tmp GOCACHE=/mnt/fast4tb/tmp/go-cache GOMODCACHE=/mnt/fast4tb/tmp/go-mod-cache GOPATH=/mnt/fast4tb/tmp/go-path-cache GOWORK=off \
  go test ./TreeDB/zipper -run '^$' -bench '^BenchmarkZipperPrepareReadOnly(MultiLeafRandom|ManyLeafRandom|ManyLeafRandomFresh)$' -benchtime=3s -count=1 -benchmem

TMPDIR=/mnt/fast4tb/tmp GOCACHE=/mnt/fast4tb/tmp/go-cache GOMODCACHE=/mnt/fast4tb/tmp/go-mod-cache GOPATH=/mnt/fast4tb/tmp/go-path-cache GOWORK=off \
  go test ./TreeDB/zipper -run '^$' -bench '^BenchmarkZipperPrepareReadOnlyManyLeafRandomFresh$' -benchtime=5s -count=1 -benchmem -cpuprofile /mnt/fast4tb/tmp/gomap-3494-m0-20260705T051330Z/zipper/fresh_cpu.pprof -memprofile /mnt/fast4tb/tmp/gomap-3494-m0-20260705T051330Z/zipper/fresh_allocs.pprof -memprofilerate=1

TMPDIR=/mnt/fast4tb/tmp GOCACHE=/mnt/fast4tb/tmp/go-cache GOMODCACHE=/mnt/fast4tb/tmp/go-mod-cache GOPATH=/mnt/fast4tb/tmp/go-path-cache GOWORK=off \
  go test ./TreeDB/internal/commitlog -run '^$' -bench '^BenchmarkCommandWAL(FrameDecode|RawKVBatchPayloadDecode)$' -benchtime=5s -count=1 -benchmem

TMPDIR=/mnt/fast4tb/tmp GOCACHE=/mnt/fast4tb/tmp/go-cache GOMODCACHE=/mnt/fast4tb/tmp/go-mod-cache GOPATH=/mnt/fast4tb/tmp/go-path-cache GOWORK=off \
  go test ./TreeDB/db -run '^$' -bench '^BenchmarkCommandWAL(ReadReplayFrames|ReplayFrameClassification|RawKVDirectWriteRevision)$' -benchtime=3s -count=1 -benchmem
```

## Result Table

| Shape | Result | Main alloc/profile signal | Evidence |
| --- | --- | --- | --- |
| `BenchmarkSyncLatencyCached/.../entry_hint` | `22517 ns/op`, `21900 B/op`, `47 allocs/op` | `caching.getEntrySlice` and `memtable.getAppendOnlyEntries` are both visible on current main, but the alloc top is dominated by mutable memtable materialization plus command-WAL read/decode during close/replay boundary work | `sync_latency/bench.txt`, `sync_latency/entry_hint_allocs_top.txt` |
| `BenchmarkSyncLatencyCached/.../byte_hint` | `36206 ns/op`, `21817 B/op`, `46 allocs/op` | same broad shape as `entry_hint`; byte hint does not remove the `getEntrySlice` or append-only entry pressure and still carries command-WAL read/decode cost | `sync_latency/bench.txt`, `sync_latency/byte_hint_allocs_top.txt` |
| `BenchmarkSyncLatencyCached/.../entry_hint_pointer_threshold_1` | `1494050 ns/op`, `151145 B/op`, `282 allocs/op`, `21418 writes/s` | forced pointer placement enters append-only + value-log write path; `internal/valuelog.getWriterAppendBuf` is present but secondary under default compression, while zstd dict training plus value-log RID lookup / command-WAL boundary work dominate | `sync_latency/pointer_threshold_1_profile.txt`, `sync_latency/pointer_threshold_1_allocs_top_full.txt`, `sync_latency/pointer_threshold_1_allocs_cum_top_full.txt` |
| `BenchmarkZipperPrepareReadOnlyManyLeafRandom` | `20854 ns/op`, `0 B/op`, `0 allocs/op` | reuse suppresses the M2 allocation signal; this shape is not suitable for `ReadOnlyPrepareResult` allocation classification | `zipper/bench.txt` |
| `BenchmarkZipperPrepareReadOnlyManyLeafRandomFresh` | `55317 ns/op`, `237568 B/op`, `2 allocs/op` | `ReadOnlyPrepareResult.ensureInitialCapacity` dominates alloc space and `ReadOnlyPrepareResult.cloneKey` is visible in CPU, giving a direct fresh-prepare repro for the M2 path | `zipper/fresh_profile.txt`, `zipper/fresh_allocs_top_full.txt`, `zipper/fresh_cpu_top_full.txt` |
| `BenchmarkCommandWALRawKVBatchPayloadDecode/ops_128_value_64` | `9096 ns/op`, `19712 B/op`, `257 allocs/op` | decode/build cost is significant on its own and remains part of the low-fanout command-WAL story | `commitlog/bench.txt` |
| `BenchmarkCommandWALFrameDecode/ops_128_value_64` | `1609 ns/op`, `10880 B/op`, `1 allocs/op` | frame decode is cheaper than payload decode but still material | `commitlog/bench.txt` |
| `BenchmarkCommandWALReadReplayFrames` | `317059 ns/op`, `56112 B/op`, `661 allocs/op` | replay/read boundary work is heavy and explains why some sync-latency alloc tops skew toward close/reopen style materialization instead of steady-state writes | `db_replay/bench.txt` |
| `BenchmarkCommandWALRawKVDirectWriteRevision/command_wal_raw_kv_revision` | `14354 ns/op`, `18415 B/op`, `70 allocs/op` | direct raw-KV command-WAL write still carries build/scan overhead that needs to be considered alongside any value-log writer optimization | `db_replay/bench.txt` |

## Allocation Map

- `zipper.(*ReadOnlyPrepareResult).cloneKey` and `zipper.(*ReadOnlyPrepareResult).ensureInitialCapacity`
  - code path: `TreeDB/zipper/read_only_prepare.go`
  - ownership: `PrepareReadOnly` copies span boundary keys into `ReadOnlyPrepareResult.keyArena`; the arena and `LeafSpans` slices are owned by the result until `ResetForReuse` / `ReuseOptions`
  - benchmark contract: the new fresh benchmark intentionally discards reuse each iteration so this per-call ownership cost becomes measurable

- `caching.getEntrySlice`
  - code path: `TreeDB/caching/db.go`
  - ownership: returns a leased `[]batch.Entry` slice for canonicalization / flush planning; caller owns it until the matching pool return path
  - constraint: reuse is bounded by pool-pressure classing and max-cap checks, so close/checkpoint materialization can still fall back to fresh allocation

- `memtable.getAppendOnlyEntries`
  - code path: `TreeDB/internal/memtable/append_only.go`
  - ownership: allocates or reuses the `[]appendOnlyEntry` backing for append-only mutable memtables and related scanners; lifetime is tied to the mutable structure until rotation / pool return
  - constraint: large retained slices are intentionally rejected from reuse when they exceed the class-specific cap window

- `valuelog.getWriterAppendBuf`
  - code path: `TreeDB/internal/valuelog/writer.go`
  - ownership: obtains the per-writer append buffer used by grouped frame writes; the writer owns the slice until flush / close / pool return
  - constraint: default writer buffers are 4 MiB and are pooled in a small fixed channel, so the path is real on forced-pointer writes but can be secondary when compression setup dominates

- `caching.(*Batch).SetWithRevision`
  - code path: `TreeDB/caching/db.go`
  - ownership: clones keys and either inline values or pointer-arena values into the batch-owned buffers before batching
  - constraint: the batch does not know final value-log placement, so it must own conservative copies until write time

- command-WAL read/decode/build
  - code paths: `TreeDB/internal/commitlog/reader.go` `(*Reader).readSegmentPayload`, `TreeDB/internal/commitlog/command_frame.go` `DecodeCommandFrame`, `TreeDB/db/command_wal_raw.go` `newRawKVCommandWALIntentFromEntryScan`, `rawKVCommandWALOperationFromEntry`, `lookupCommandWALValueLogRID`, `readCommandWALValueLogRIDAt`
  - ownership: replay/scan allocates payload buffers, decoded frames, and raw-KV operation materialization that live for the scan/decode/build boundary
  - constraint: current sync-latency profiles include meaningful cleanup/replay boundary work, so these allocations are partly adjacent to steady-state writes rather than purely in-loop append cost

## Successor Recommendation

- `#3495`
  - M1 has current-main signal and can proceed.
  - The important caveat is that the current signal is mostly close/checkpoint materialization in the cached command-WAL path, not a pure steady-state writer hot loop.
  - Target the existing `BenchmarkSyncLatencyCached` `entry_hint` / `byte_hint` shapes and treat `caching.getEntrySlice` plus `memtable.getAppendOnlyEntries` as the core contract.

- `#3496`
  - M2 is now directly unblocked.
  - `BenchmarkZipperPrepareReadOnlyManyLeafRandomFresh` provides the missing fresh-prepare benchmark signal for `ReadOnlyPrepareResult` allocation behavior on current main.

- `#3497`
  - M3 should proceed with a narrower claim than "dominant allocator on current main."
  - The new forced-pointer shape proves `internal/valuelog.getWriterAppendBuf` is real, but secondary under forced pointer plus default compression.
  - Command-WAL read/decode/build remains significant and is partly a cleanup/replay boundary effect, so `#3497` should either carry an explicit compression-off comparison in its own scope or frame itself as a broader value-log plus command-WAL allocation investigation.

- `#3498`
  - keep blocked on the post-M1/M2/M3 contract rather than claiming this issue solved the downstream optimization ordering

## Bottom Line

- M1 has current-main signal but is mostly close/checkpoint materialization.
- M2 now has fresh-prepare benchmark signal.
- M3 value-log writer is secondary under forced pointer plus default compression, while command-WAL read/decode is significant and partly cleanup/replay boundary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded sync latency benchmark coverage with configurable value sizes and an additional scenario to exercise an alternate value-log behavior.
  * Added a new read-only prepare benchmark variant targeting fresh random many-leaf workloads.
  * Improved benchmark setup to allocate values based on the selected size and to run each iteration using fresh prepare options (no reuse).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->