### PR TITLE
treedb: borrow stable hash-sorted batch values

### DIFF
--- a/TreeDB/caching/batch_arena_ownership_test.go
+++ b/TreeDB/caching/batch_arena_ownership_test.go
@@ -66,7 +66,7 @@ func TestBatchArenaLeases_CopiedMemtablesMatchOwnershipMode(t *testing.T) {
 		wantLeases bool
 	}{
 		{mode: "append_only", wantLeases: true},
-		{mode: "hash_sorted", wantLeases: false},
+		{mode: "hash_sorted", wantLeases: true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.mode, func(t *testing.T) {
@@ -119,7 +119,7 @@ func TestBatchArenaLeases_CopiedMemtablesMatchOwnershipMode(t *testing.T) {
 }
 
 func TestBatchArenaLeases_ReleasedAfterCheckpoint(t *testing.T) {
-	for _, mode := range []string{"btree", "append_only"} {
+	for _, mode := range []string{"btree", "append_only", "hash_sorted"} {
 		t.Run(mode, func(t *testing.T) {
 			dir := t.TempDir()
 			db, err := Open(dir, NewMockBackend(), Options{

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -9997,12 +9997,12 @@ func (db *DB) releaseClosingEmptyMemtable(mt memtable.Table) {
 
 func cachedBatchWriteNeedsBatchArenaRetention(mt memtable.Table) bool {
 	// This helper is only used for the cached batch write path, where
-	// cachedBatchWriteUsesSteal governs whether a memtable receives borrowed
-	// batch slices or copied writes. append_only and hash_sorted are forced onto
-	// copy writes there, so they do not need batch-arena leases. Skiplist is the
-	// other non-retained case: it accepts Steal calls, but still copies key/value
-	// bytes into its own arena, so batch-owned buffers can be released
-	// immediately after the write.
+	// cachedBatchWriteUsesSteal governs whether a memtable receives stolen batch
+	// slices. append_only and hash_sorted are forced onto copy writes for this
+	// Steal-path decision; CopySortedBatchApplier value borrowing records its
+	// own leases separately. Skiplist is the other non-retained case: it accepts
+	// Steal calls, but still copies key/value bytes into its own arena, so
+	// batch-owned buffers can be released immediately after the write.
 	if !cachedBatchWriteUsesSteal(mt) {
 		return false
 	}
@@ -32233,7 +32233,7 @@ func (b *Batch) DisableStreamingBypass() {
 }
 
 // AttachStableViewValueLease declares that current SetView value slices are
-// backed by owner-managed buffers that may be retained by append-only memtables.
+// backed by owner-managed buffers that may be retained by borrowing memtables.
 // The buffers are never returned to TreeDB's batch arena pool; the caller must
 // also stop reusing them if StableViewValueLeaseConsumed reports true after a
 // write attempt. A zero-cap chunk is a borrow-permission signal for values with

--- a/TreeDB/command_wal_public_test.go
+++ b/TreeDB/command_wal_public_test.go
@@ -1527,6 +1527,91 @@ func TestPublicCommandWALBatchReplayBytesAppendOnlyLeaseAvoidsDirectArena(t *tes
 	}
 }
 
+func TestPublicCommandWALBatchHashSortedLeaseProtectsCallerMutation(t *testing.T) {
+	dir := t.TempDir()
+	db, err := Open(Options{
+		Dir:                 dir,
+		Durability:          DurabilityWALOnRelaxed,
+		CommandWAL:          true,
+		CommandWALStatsScan: true,
+		DisableSideStores:   true,
+		MemtableMode:        "hash_sorted",
+		MemtableShards:      1,
+		FlushThreshold:      1 << 30,
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer db.Close()
+
+	const entries = 32
+	b, ok := db.NewBatchWithSize(entries).(*commandWALPublicBatch)
+	if !ok {
+		t.Fatalf("NewBatchWithSize type=%T, want *commandWALPublicBatch", db.NewBatchWithSize(entries))
+	}
+	wantKeys := make([][]byte, entries)
+	values := make([][]byte, entries)
+	wantValues := make([][]byte, entries)
+	for i := 0; i < entries; i++ {
+		key := []byte(fmt.Sprintf("hash-sorted-stable-key-%02d", i))
+		values[i] = bytes.Repeat([]byte{byte(0x51 + i)}, 128)
+		keyView, valueView, err := b.SetViewWithReplayBytes(key, values[i])
+		if err != nil {
+			_ = b.Close()
+			t.Fatalf("SetViewWithReplayBytes(%d): %v", i, err)
+		}
+		wantKeys[i] = bytes.Clone(keyView)
+		wantValues[i] = bytes.Clone(valueView)
+		key[0] = 'X'
+		values[i][0] = 0x7f
+	}
+	if err := b.WriteSync(); err != nil {
+		_ = b.Close()
+		t.Fatalf("WriteSync: %v", err)
+	}
+	if !b.payloadLeasedToMemtable {
+		_ = b.Close()
+		t.Fatalf("command-WAL payload was not marked leased to the hash-sorted memtable: attached_mask=%d leased_mask=%d", b.payloadLeaseAttachedMask, b.payloadLeasedBufferMask)
+	}
+	if !b.retainPayloadAfterWrite {
+		_ = b.Close()
+		t.Fatal("replay payload was not retained after write")
+	}
+	if got := db.Stats()["treedb.cache.batch_arena.leased_bytes"]; got == "0" || got == "" {
+		_ = b.Close()
+		t.Fatalf("batch arena leased bytes=%q want >0 for hash-sorted payload lease", got)
+	}
+	for i := 0; i < entries; i++ {
+		got, err := db.Get(wantKeys[i])
+		if err != nil {
+			_ = b.Close()
+			t.Fatalf("Get(%d): %v", i, err)
+		}
+		if !bytes.Equal(got, wantValues[i]) {
+			_ = b.Close()
+			t.Fatalf("stored value %d after caller mutation=%x want %x", i, got, wantValues[i])
+		}
+	}
+	if err := b.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if err := db.Checkpoint(); err != nil {
+		t.Fatalf("Checkpoint: %v", err)
+	}
+	if got := db.Stats()["treedb.cache.batch_arena.leased_bytes"]; got != "0" {
+		t.Fatalf("batch arena leased bytes after checkpoint=%q want 0", got)
+	}
+	for i := 0; i < entries; i++ {
+		got, err := db.Get(wantKeys[i])
+		if err != nil {
+			t.Fatalf("Get(%d) after checkpoint: %v", i, err)
+		}
+		if !bytes.Equal(got, wantValues[i]) {
+			t.Fatalf("stored value %d after checkpoint=%x want %x", i, got, wantValues[i])
+		}
+	}
+}
+
 func TestPublicCommandWALBatchZeroValueAppendOnlyLeaseAvoidsDirectArena(t *testing.T) {
 	dir := t.TempDir()
 	db, err := Open(Options{

--- a/TreeDB/internal/memtable/hash_sorted.go
+++ b/TreeDB/internal/memtable/hash_sorted.go
@@ -221,7 +221,7 @@ func (m *HashSorted) ApplyStealSortedBatchTrusted(entries []batchpkg.Entry, onKe
 }
 
 func (m *HashSorted) ApplyCopySortedBatchTrusted(entries []batchpkg.Entry, borrowValues bool, storeInlinePtrValues bool, onKey func(key []byte)) bool {
-	_ = borrowValues // HashSorted owns values in its arena; it never borrows batch value storage.
+	borrowedValues := false
 	var chunks []hashSortedIndexWork
 
 	m.mu.Lock()
@@ -229,9 +229,10 @@ func (m *HashSorted) ApplyCopySortedBatchTrusted(entries []batchpkg.Entry, borro
 		keys := make([]string, 0, len(entries))
 		keyBytes := 0
 		for _, op := range entries {
-			if keyStored, n, ok := m.setEntryNewCopyNoChunkLocked(op, storeInlinePtrValues); ok {
+			if keyStored, n, borrowed, ok := m.setEntryNewCopyNoChunkLocked(op, borrowValues, storeInlinePtrValues); ok {
 				keys = append(keys, keyStored)
 				keyBytes += n
+				borrowedValues = borrowedValues || borrowed
 			}
 			if onKey != nil {
 				onKey(op.Key)
@@ -243,9 +244,11 @@ func (m *HashSorted) ApplyCopySortedBatchTrusted(entries []batchpkg.Entry, borro
 	} else {
 		for _, op := range entries {
 			value, ptr, flags := hashSortedBatchEntryPayload(op, storeInlinePtrValues)
-			if chunk, seq := m.setEntryLocked(op.Key, value, ptr, flags, op.Revision, false); seq != 0 {
+			borrowValue := borrowValues && hashSortedCanBorrowEntryValue(value, flags)
+			if chunk, seq := m.setEntryCopyKeyLocked(op.Key, value, ptr, flags, op.Revision, borrowValue); seq != 0 {
 				chunks = append(chunks, hashSortedIndexWork{mt: m, seq: seq, keys: chunk})
 			}
+			borrowedValues = borrowedValues || borrowValue
 			if onKey != nil {
 				onKey(op.Key)
 			}
@@ -256,7 +259,7 @@ func (m *HashSorted) ApplyCopySortedBatchTrusted(entries []batchpkg.Entry, borro
 	for _, c := range chunks {
 		c.mt.indexer.enqueue(c.mt, c.seq, c.keys, c.sorted)
 	}
-	return false
+	return borrowedValues
 }
 
 func (m *HashSorted) applyStealSortedBatch(entries []batchpkg.Entry, onKey func(key []byte), trustedOrder bool) {
@@ -1000,13 +1003,21 @@ func (m *HashSorted) noteNewKeysBatchLocked(keys []string, keyBytes int, keysSor
 }
 
 func (m *HashSorted) setEntryLocked(key, value []byte, ptr page.ValuePtr, flags byte, revision page.EntryRevision, steal bool) ([]string, uint64) {
+	return m.setEntryLockedWithOwnership(key, value, ptr, flags, revision, steal, steal)
+}
+
+func (m *HashSorted) setEntryCopyKeyLocked(key, value []byte, ptr page.ValuePtr, flags byte, revision page.EntryRevision, borrowValue bool) ([]string, uint64) {
+	return m.setEntryLockedWithOwnership(key, value, ptr, flags, revision, false, borrowValue)
+}
+
+func (m *HashSorted) setEntryLockedWithOwnership(key, value []byte, ptr page.ValuePtr, flags byte, revision page.EntryRevision, stealKey bool, borrowValue bool) ([]string, uint64) {
 	if key == nil {
 		return nil, 0
 	}
 	keyLookup := bytesToStringNoCopy(key)
 	if ent, ok := m.entryForWriteLocked(keyLookup); ok {
 		oldLen := hashEntryValueSize(ent.flags, ent.value)
-		ent.value = m.encodeEntryValueLocked(value, ptr, flags, steal)
+		ent.value = m.encodeEntryValueLocked(value, ptr, flags, borrowValue)
 		if flags&node.FlagPointer != 0 {
 			ent.ptr = ptr
 		} else {
@@ -1022,13 +1033,13 @@ func (m *HashSorted) setEntryLocked(key, value []byte, ptr page.ValuePtr, flags 
 	}
 
 	var keyCopy []byte
-	if steal {
+	if stealKey {
 		keyCopy = key
 	} else {
 		keyCopy = m.arena.copyBytes(key)
 	}
 	keyStored := bytesToStringNoCopy(keyCopy)
-	valCopy := m.encodeEntryValueLocked(value, ptr, flags, steal)
+	valCopy := m.encodeEntryValueLocked(value, ptr, flags, borrowValue)
 	ent := hashEntry{value: valCopy, flags: flags, revision: revision}
 	if flags&node.FlagPointer != 0 {
 		ent.ptr = ptr
@@ -1047,14 +1058,15 @@ func hashSortedBatchEntryPayload(op batchpkg.Entry, storeInlinePtrValues bool) (
 	return batchEntryPayload(op, storeInlinePtrValues)
 }
 
-func (m *HashSorted) setEntryNewCopyNoChunkLocked(op batchpkg.Entry, storeInlinePtrValues bool) (string, int, bool) {
+func (m *HashSorted) setEntryNewCopyNoChunkLocked(op batchpkg.Entry, borrowValues bool, storeInlinePtrValues bool) (string, int, bool, bool) {
 	if op.Key == nil {
-		return "", 0, false
+		return "", 0, false, false
 	}
 	keyCopy := m.arena.copyBytes(op.Key)
 	keyStored := bytesToStringNoCopy(keyCopy)
 	value, ptr, flags := hashSortedBatchEntryPayload(op, storeInlinePtrValues)
-	valCopy := m.encodeEntryValueLocked(value, ptr, flags, false)
+	borrowValue := borrowValues && hashSortedCanBorrowEntryValue(value, flags)
+	valCopy := m.encodeEntryValueLocked(value, ptr, flags, borrowValue)
 	ent := hashEntry{value: valCopy, flags: flags, revision: op.Revision}
 	if flags&node.FlagPointer != 0 {
 		ent.ptr = ptr
@@ -1068,7 +1080,7 @@ func (m *HashSorted) setEntryNewCopyNoChunkLocked(op batchpkg.Entry, storeInline
 	// The fast path is append-only and entries are strictly increasing.
 	m.maxKey = keyStored
 	m.hasMaxKey = true
-	return keyStored, len(keyCopy), true
+	return keyStored, len(keyCopy), borrowValue, true
 }
 
 func (m *HashSorted) setEntryNewStealNoChunkLocked(op batchpkg.Entry) (string, int, bool) {
@@ -1162,6 +1174,10 @@ func (m *HashSorted) encodeEntryValueLocked(value []byte, ptr page.ValuePtr, fla
 		return value
 	}
 	return m.arena.copyBytes(value)
+}
+
+func hashSortedCanBorrowEntryValue(value []byte, flags byte) bool {
+	return len(value) > 0 && flags&node.FlagTombstone == 0
 }
 
 func (m *HashSorted) setStealLocked(key, value []byte) ([]string, uint64) {

--- a/TreeDB/internal/memtable/hash_sorted_fastpath_test.go
+++ b/TreeDB/internal/memtable/hash_sorted_fastpath_test.go
@@ -1,6 +1,8 @@
 package memtable
 
 import (
+	"bytes"
+	"encoding/binary"
 	"fmt"
 	"sort"
 	"testing"
@@ -45,16 +47,18 @@ func TestHashSortedApplyCopySortedBatchTrusted_AppendAndFallback(t *testing.T) {
 	m.Set([]byte("b"), []byte("v1"))
 
 	keyC := []byte("c")
+	valueC := []byte("v2")
 	entries := []batchpkg.Entry{
-		{Type: batchpkg.OpPut, Key: keyC, Value: []byte("v2")},
+		{Type: batchpkg.OpPut, Key: keyC, Value: valueC},
 		{Type: batchpkg.OpDelete, Key: []byte("d")},
 	}
-	if borrowed := m.ApplyCopySortedBatchTrusted(entries, true, true, nil); borrowed {
-		t.Fatalf("HashSorted reported borrowed values")
+	if borrowed := m.ApplyCopySortedBatchTrusted(entries, true, true, nil); !borrowed {
+		t.Fatalf("HashSorted did not report borrowed values")
 	}
 	keyC[0] = 'z'
+	valueC[0] = 'V'
 
-	if got, del, ok := m.Get([]byte("c")); !ok || del || string(got) != "v2" {
+	if got, del, ok := m.Get([]byte("c")); !ok || del || string(got) != "V2" {
 		t.Fatalf("key c mismatch: ok=%v del=%v val=%q", ok, del, string(got))
 	}
 	if got, del, ok := m.Get([]byte("d")); !ok || !del || got != nil {
@@ -65,13 +69,37 @@ func TestHashSortedApplyCopySortedBatchTrusted_AppendAndFallback(t *testing.T) {
 		{Type: batchpkg.OpPut, Key: []byte("a"), Value: []byte("va")},
 		{Type: batchpkg.OpPut, Key: []byte("b"), Value: []byte("vb")},
 	}
-	m.ApplyCopySortedBatchTrusted(fallbackEntries, true, true, nil)
+	if borrowed := m.ApplyCopySortedBatchTrusted(fallbackEntries, true, true, nil); !borrowed {
+		t.Fatalf("fallback path did not report borrowed values")
+	}
 
 	if got, del, ok := m.Get([]byte("a")); !ok || del || string(got) != "va" {
 		t.Fatalf("key a mismatch: ok=%v del=%v val=%q", ok, del, string(got))
 	}
 	if got, del, ok := m.Get([]byte("b")); !ok || del || string(got) != "vb" {
 		t.Fatalf("key b mismatch after update: ok=%v del=%v val=%q", ok, del, string(got))
+	}
+}
+
+func TestHashSortedApplyCopySortedBatchTrusted_CopyModeProtectsCallerMutation(t *testing.T) {
+	m := NewHashSorted()
+	key := []byte("a")
+	value := []byte("value")
+	want := bytes.Clone(value)
+
+	if borrowed := m.ApplyCopySortedBatchTrusted([]batchpkg.Entry{{
+		Type:  batchpkg.OpPut,
+		Key:   key,
+		Value: value,
+	}}, false, true, nil); borrowed {
+		t.Fatalf("HashSorted reported borrowed values with borrowValues=false")
+	}
+	key[0] = 'z'
+	value[0] = 'X'
+
+	got, del, ok := m.Get([]byte("a"))
+	if !ok || del || !bytes.Equal(got, want) {
+		t.Fatalf("stored value mismatch after caller mutation: ok=%v del=%v got=%q want=%q", ok, del, got, want)
 	}
 }
 
@@ -152,5 +180,39 @@ func TestHashSortedApplyCopySortedBatchTrusted_ConsecutiveSortedPendingChunkMark
 		}
 	default:
 		t.Fatalf("expected sealed sorted pending chunk")
+	}
+}
+
+func BenchmarkHashSortedApplyCopySortedBatchTrusted(b *testing.B) {
+	const batchSize = 32
+	const valueSize = 128
+	var keyBufs [batchSize][8]byte
+	entries := make([]batchpkg.Entry, batchSize)
+	value := bytes.Repeat([]byte{0x7a}, valueSize)
+
+	for _, tc := range []struct {
+		name         string
+		borrowValues bool
+	}{
+		{name: "copy_values", borrowValues: false},
+		{name: "borrow_values", borrowValues: true},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			m := NewHashSorted()
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				base := uint64(i * batchSize)
+				for j := 0; j < batchSize; j++ {
+					binary.BigEndian.PutUint64(keyBufs[j][:], base+uint64(j))
+					entries[j] = batchpkg.Entry{
+						Type:  batchpkg.OpPut,
+						Key:   keyBufs[j][:],
+						Value: value,
+					}
+				}
+				m.ApplyCopySortedBatchTrusted(entries, tc.borrowValues, true, nil)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

Closes #3496.

This teaches the `hash_sorted` memtable copy-sorted fast path to borrow stable batch value slices when the caller explicitly allows value borrowing. Keys are still copied into hash-sorted-owned storage. Borrowed values are retained through the existing batch-arena lease machinery and released when the mutable memtable is checkpointed/retired.

This targets the steady low-fanout write-loop allocation found after M1 showed that `getAppendOnlyEntries`/`getEntrySlice` were mostly setup/cleanup rather than TPS-window allocation.

## Evidence

Manager same-run pprof/benchmark artifacts:

- Baseline: `/mnt/fast4tb/tmp/gomap-3496-main-before-20260704_215509`
- After: `/mnt/fast4tb/tmp/gomap-3496-rebased-after-20260704_215509`
- Focused memtable bench: `/mnt/fast4tb/tmp/gomap-3496-rebased-memtable-bench-20260704_215509`

Key deltas from those artifacts:

- `BenchmarkSyncLatencyCached/.../entry_hint`: `21873 B/op` -> `15574 B/op` with the same `46 allocs/op`.
- Total alloc-space profile: `794148.15 kB` -> `672471.86 kB`.
- `HashSorted.setEntryNewCopyNoChunkLocked`: `130053.62 kB` -> `7170.62 kB`.
- `HashSorted.ApplyCopySortedBatchTrusted` cumulative: `142974 kB` -> `20091 kB`.
- Focused `BenchmarkHashSortedApplyCopySortedBatchTrusted`: copy mode `20529 B/op`; borrow mode `14237 B/op`.

Coordinator validation artifacts:

- `/mnt/fast4tb/tmp/gomap-3496-coordinator-validation-20260705T080219Z`

## Validation

```sh
env GOWORK=off TMPDIR=/mnt/fast4tb/tmp GOCACHE=/mnt/fast4tb/tmp/go-cache GOMODCACHE=/mnt/fast4tb/tmp/go-mod-cache GOPATH=/mnt/fast4tb/tmp/go-path-cache go test ./TreeDB/internal/memtable ./TreeDB/caching ./TreeDB -run 'TestHashSortedApplyCopySortedBatchTrusted|TestBatchArenaLeases|TestBatchReset_DoesNotCorruptPriorBorrowedWrites|TestPublicCommandWALBatchHashSortedLeaseProtectsCallerMutation'
```

```sh
env GOWORK=off TMPDIR=/mnt/fast4tb/tmp GOCACHE=/mnt/fast4tb/tmp/go-cache GOMODCACHE=/mnt/fast4tb/tmp/go-mod-cache GOPATH=/mnt/fast4tb/tmp/go-path-cache go test ./TreeDB/internal/memtable -run '^$' -bench '^BenchmarkHashSortedApplyCopySortedBatchTrusted$' -benchtime=20000x -count=3 -benchmem
```

```sh
env GOWORK=off TMPDIR=/mnt/fast4tb/tmp GOCACHE=/mnt/fast4tb/tmp/go-cache GOMODCACHE=/mnt/fast4tb/tmp/go-mod-cache GOPATH=/mnt/fast4tb/tmp/go-path-cache go test ./TreeDB -run '^$' -bench '^BenchmarkSyncLatencyCached/BatchWriteSync/wal_on_relaxed_sync_command_wal/32/entry_hint$' -benchtime=20000x -count=3 -benchmem
```
