### PR TITLE
treedb: write command wal scan payloads in place

### DIFF
--- a/TreeDB/internal/commitlog/command_frame.go
+++ b/TreeDB/internal/commitlog/command_frame.go
@@ -2400,6 +2400,9 @@ func writeRawKVOperationPayloadTo(dst []byte, op RawKVOperation, entryRevisions 
 	}
 	switch op.Op {
 	case RawKVOpSetRID:
+		if off > len(dst) || len(dst)-off < 8 {
+			return 0, ErrCorrupt
+		}
 		binary.LittleEndian.PutUint64(dst[off:off+8], op.RID)
 		off += 8
 	default:

--- a/TreeDB/internal/commitlog/command_frame.go
+++ b/TreeDB/internal/commitlog/command_frame.go
@@ -2260,17 +2260,10 @@ func encodeRawKVBatchPayloadPlannedTo(dst []byte, plan RawKVBatchPayloadPlan, sc
 		dst = make([]byte, plan.PayloadLen)
 	} else {
 		dst = dst[:plan.PayloadLen]
-		clear(dst)
 	}
-	off := 0
-	if err := writeRawKVBatchPayloadPieces(plan, scan, func(part []byte) error {
-		copy(dst[off:], part)
-		off += len(part)
-		return nil
-	}); err != nil {
+	if n, err := writeRawKVBatchPayloadTo(dst, plan, scan); err != nil {
 		return nil, err
-	}
-	if off != plan.PayloadLen {
+	} else if n != plan.PayloadLen {
 		return nil, ErrCorrupt
 	}
 	return dst, nil
@@ -2325,8 +2318,100 @@ func writeRawKVBatchPayloadPieces(plan RawKVBatchPayloadPlan, scan RawKVBatchOpe
 	return nil
 }
 
+func writeRawKVBatchPayloadTo(dst []byte, plan RawKVBatchPayloadPlan, scan RawKVBatchOperationScanner) (int, error) {
+	if err := plan.validate(); err != nil {
+		return 0, err
+	}
+	if len(dst) < plan.PayloadLen {
+		return 0, ErrCorrupt
+	}
+	payloadVersion := rawKVBatchPayloadVersion
+	if plan.EntryRevisions {
+		payloadVersion = rawKVBatchPayloadVersionWithRevisions
+	}
+	binary.LittleEndian.PutUint16(dst[0:2], payloadVersion)
+	binary.LittleEndian.PutUint32(dst[2:6], uint32(plan.Count))
+	if scan == nil {
+		if plan.Count != 0 {
+			return 0, ErrCorrupt
+		}
+		return rawKVBatchHeaderSize, nil
+	}
+	count := 0
+	written := rawKVBatchHeaderSize
+	if err := scan(func(op RawKVOperation) error {
+		n, err := writeRawKVOperationPayloadTo(dst[written:], op, plan.EntryRevisions)
+		if err != nil {
+			return err
+		}
+		count++
+		written += n
+		return nil
+	}); err != nil {
+		return 0, err
+	}
+	if count != plan.Count || written != plan.PayloadLen {
+		return 0, ErrCorrupt
+	}
+	return written, nil
+}
+
 func writeRawKVOperationPayloadPieces(op RawKVOperation, write func([]byte) error) (int, error) {
 	return writeRawKVOperationPayloadPiecesWithRevisionFlag(op, false, write)
+}
+
+func writeRawKVOperationPayloadTo(dst []byte, op RawKVOperation, entryRevisions bool) (int, error) {
+	keyBytes, valueBytes, err := rawKVOperationPayloadLens(&op)
+	if err != nil {
+		return 0, err
+	}
+	if op.Revision != 0 && !entryRevisions {
+		return 0, ErrCorrupt
+	}
+	keyLen := uint32(len(op.Key))
+	valueLen := uint32(len(op.Value))
+	if op.Op == RawKVOpSetRID {
+		valueLen = 8
+	} else if op.Op == RawKVOpDeleteRange {
+		keyLen, _, err = rawKVRangeBoundEncodedLen(op.Key)
+		if err != nil {
+			return 0, err
+		}
+		valueLen, _, err = rawKVRangeBoundEncodedLen(op.Value)
+		if err != nil {
+			return 0, err
+		}
+	}
+	headerSize := rawKVOperationHeaderSize(entryRevisions)
+	needed := headerSize + keyBytes + valueBytes
+	if needed < headerSize || needed > len(dst) {
+		return 0, ErrCorrupt
+	}
+	dst[0] = byte(op.Op)
+	binary.LittleEndian.PutUint32(dst[1:5], keyLen)
+	binary.LittleEndian.PutUint32(dst[5:9], valueLen)
+	if entryRevisions {
+		binary.LittleEndian.PutUint64(dst[9:17], op.Revision)
+	}
+	off := headerSize
+	if len(op.Key) > 0 {
+		copy(dst[off:], op.Key)
+		off += len(op.Key)
+	}
+	switch op.Op {
+	case RawKVOpSetRID:
+		binary.LittleEndian.PutUint64(dst[off:off+8], op.RID)
+		off += 8
+	default:
+		if len(op.Value) > 0 {
+			copy(dst[off:], op.Value)
+			off += len(op.Value)
+		}
+	}
+	if off != needed {
+		return 0, ErrCorrupt
+	}
+	return needed, nil
 }
 
 func writeRawKVOperationPayloadPiecesWithRevisionFlag(op RawKVOperation, entryRevisions bool, write func([]byte) error) (int, error) {

--- a/TreeDB/internal/commitlog/command_frame_bench_test.go
+++ b/TreeDB/internal/commitlog/command_frame_bench_test.go
@@ -147,6 +147,34 @@ func BenchmarkWriterAppendCommandRawKVBatch(b *testing.B) {
 	}
 }
 
+func BenchmarkWriterAppendRawKVBatchPayloadScanCommandDirectTrusted(b *testing.B) {
+	for _, opsCount := range []int{1, 16, 32, 128} {
+		b.Run(fmt.Sprintf("setrid_revisions_ops_%d", opsCount), func(b *testing.B) {
+			ops := makeCommandWALBenchRIDOps(opsCount)
+			scan := rawKVOperationSliceScanner(ops)
+			plan, err := PlanRawKVBatchPayloadScan(scan)
+			if err != nil {
+				b.Fatalf("PlanRawKVBatchPayloadScan: %v", err)
+			}
+			path := filepath.Join(b.TempDir(), "commit.log")
+			w, err := NewWriterWithOptions(path, Options{Compress: false, DeferredCommandBufferSize: 1 << 20})
+			if err != nil {
+				b.Fatalf("NewWriterWithOptions: %v", err)
+			}
+			b.Cleanup(func() { _ = w.Close() })
+
+			b.SetBytes(int64(commandFrameHeaderSize + plan.PayloadLen))
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if err := w.AppendRawKVBatchPayloadScanCommandDirectTrusted(uint64(i+1), 0, plan, scan); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
 func BenchmarkWriterAppendBatchLegacyRawKV(b *testing.B) {
 	for _, tc := range commandWALBenchCases() {
 		b.Run(tc.name, func(b *testing.B) {
@@ -208,6 +236,19 @@ func makeCommandWALBenchOps(n, valueSize int) []RawKVOperation {
 			Op:    RawKVOpSet,
 			Key:   []byte(fmt.Sprintf("key-%06d", i)),
 			Value: value,
+		}
+	}
+	return ops
+}
+
+func makeCommandWALBenchRIDOps(n int) []RawKVOperation {
+	ops := make([]RawKVOperation, n)
+	for i := range ops {
+		ops[i] = RawKVOperation{
+			Op:       RawKVOpSetRID,
+			Key:      []byte(fmt.Sprintf("key-%06d", i)),
+			RID:      uint64(i + 1),
+			Revision: uint64(i + 1),
 		}
 	}
 	return ops

--- a/TreeDB/internal/commitlog/command_frame_test.go
+++ b/TreeDB/internal/commitlog/command_frame_test.go
@@ -1023,6 +1023,110 @@ func TestWriteRawKVBatchPayloadToOverwritesReusedBufferPrefix(t *testing.T) {
 	}
 }
 
+func TestWriteRawKVOperationPayloadToDeleteRangeBoundHeaders(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		start        []byte
+		end          []byte
+		wantStartLen uint32
+		wantEndLen   uint32
+		wantStartNil bool
+		wantEndNil   bool
+	}{
+		{
+			name:         "both_unbounded",
+			start:        nil,
+			end:          nil,
+			wantStartLen: rawKVNilRangeBoundLenUint32,
+			wantEndLen:   rawKVNilRangeBoundLenUint32,
+			wantStartNil: true,
+			wantEndNil:   true,
+		},
+		{
+			name:         "nil_start",
+			start:        nil,
+			end:          []byte("omega"),
+			wantStartLen: rawKVNilRangeBoundLenUint32,
+			wantEndLen:   uint32(len("omega")),
+			wantStartNil: true,
+		},
+		{
+			name:         "empty_start",
+			start:        []byte{},
+			end:          []byte("omega"),
+			wantStartLen: 0,
+			wantEndLen:   uint32(len("omega")),
+		},
+		{
+			name:         "nil_end",
+			start:        []byte("prefix"),
+			end:          nil,
+			wantStartLen: uint32(len("prefix")),
+			wantEndLen:   rawKVNilRangeBoundLenUint32,
+			wantEndNil:   true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			op := RawKVOperation{Op: RawKVOpDeleteRange, Key: tc.start, Value: tc.end}
+			keyBytes, valueBytes, err := rawKVOperationPayloadLens(&op)
+			if err != nil {
+				t.Fatalf("rawKVOperationPayloadLens: %v", err)
+			}
+			opLen := rawKVOperationHeaderSize(false) + keyBytes + valueBytes
+			dst := bytes.Repeat([]byte{0xcc}, opLen+8)
+			n, err := writeRawKVOperationPayloadTo(dst[:opLen], op, false)
+			if err != nil {
+				t.Fatalf("writeRawKVOperationPayloadTo: %v", err)
+			}
+			if n != opLen {
+				t.Fatalf("written bytes=%d want %d", n, opLen)
+			}
+			if got := dst[0]; got != byte(RawKVOpDeleteRange) {
+				t.Fatalf("op byte=%d want %d", got, RawKVOpDeleteRange)
+			}
+			if got := binary.LittleEndian.Uint32(dst[1:5]); got != tc.wantStartLen {
+				t.Fatalf("start encoded len=%d want %d", got, tc.wantStartLen)
+			}
+			if got := binary.LittleEndian.Uint32(dst[5:9]); got != tc.wantEndLen {
+				t.Fatalf("end encoded len=%d want %d", got, tc.wantEndLen)
+			}
+			if !bytes.Equal(dst[opLen:], bytes.Repeat([]byte{0xcc}, 8)) {
+				t.Fatalf("writeRawKVOperationPayloadTo wrote beyond operation payload")
+			}
+
+			payload := make([]byte, rawKVBatchHeaderSize+n)
+			binary.LittleEndian.PutUint16(payload[0:2], rawKVBatchPayloadVersion)
+			binary.LittleEndian.PutUint32(payload[2:6], 1)
+			copy(payload[rawKVBatchHeaderSize:], dst[:n])
+			var gotStart, gotEnd []byte
+			if err := ScanRawKVBatchPayload(payload, func(op RawKVOp, key, value []byte) error {
+				if op != RawKVOpDeleteRange {
+					t.Fatalf("scanned op=%v want DeleteRange", op)
+				}
+				gotStart = key
+				gotEnd = value
+				return nil
+			}); err != nil {
+				t.Fatalf("ScanRawKVBatchPayload: %v", err)
+			}
+			if tc.wantStartNil {
+				if gotStart != nil {
+					t.Fatalf("start bound=%q want nil", gotStart)
+				}
+			} else if gotStart == nil || !bytes.Equal(gotStart, tc.start) {
+				t.Fatalf("start bound=%q want %q", gotStart, tc.start)
+			}
+			if tc.wantEndNil {
+				if gotEnd != nil {
+					t.Fatalf("end bound=%q want nil", gotEnd)
+				}
+			} else if gotEnd == nil || !bytes.Equal(gotEnd, tc.end) {
+				t.Fatalf("end bound=%q want %q", gotEnd, tc.end)
+			}
+		})
+	}
+}
+
 func TestRawKVBatchPayloadBuilderMatchesSliceEncoder(t *testing.T) {
 	ops := []RawKVOperation{
 		{Op: RawKVOpSet, Key: []byte("alpha"), Value: []byte("one")},
@@ -1199,6 +1303,49 @@ func TestWriterAppendRawKVBatchPayloadScanCommandDirectBuffered(t *testing.T) {
 		t.Fatalf("Close writer: %v", err)
 	}
 	assertRawKVCommandFramePayload(t, path, 7, 3, payload)
+}
+
+func TestWriterAppendRawKVBatchPayloadScanCommandDirectBufferedRollsBackOnScanMismatch(t *testing.T) {
+	plannedOps := []RawKVOperation{
+		{Op: RawKVOpSet, Key: []byte("alpha"), Value: []byte("one")},
+	}
+	plannedScan := rawKVOperationSliceScanner(plannedOps)
+	plan, err := PlanRawKVBatchPayloadScan(plannedScan)
+	if err != nil {
+		t.Fatalf("PlanRawKVBatchPayloadScan: %v", err)
+	}
+	mismatchedScan := rawKVOperationSliceScanner([]RawKVOperation{
+		{Op: RawKVOpSet, Key: []byte("alpha"), Value: []byte("one")},
+		{Op: RawKVOpDelete, Key: []byte("bravo")},
+	})
+
+	path := filepath.Join(t.TempDir(), "commit-l0-000001.log")
+	w, err := NewWriterWithOptions(path, Options{DeferredCommandBufferSize: 4096})
+	if err != nil {
+		t.Fatalf("NewWriterWithOptions: %v", err)
+	}
+	if err := w.AppendRawKVBatchPayloadScanCommandDirectTrusted(7, 3, plan, mismatchedScan); !errors.Is(err, ErrCorrupt) {
+		_ = w.Close()
+		t.Fatalf("mismatched scan append error=%v, want ErrCorrupt", err)
+	}
+	if got := len(w.commandBuf); got != 0 {
+		_ = w.Close()
+		t.Fatalf("command buffer len after failed append=%d want 0", got)
+	}
+
+	payload, err := EncodeRawKVBatchPayload(plannedOps)
+	if err != nil {
+		_ = w.Close()
+		t.Fatalf("EncodeRawKVBatchPayload: %v", err)
+	}
+	if err := w.AppendRawKVBatchPayloadScanCommandDirectTrusted(8, 4, plan, plannedScan); err != nil {
+		_ = w.Close()
+		t.Fatalf("valid append after rollback: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close writer: %v", err)
+	}
+	assertRawKVCommandFramePayload(t, path, 8, 4, payload)
 }
 
 func TestWriterAppendRawKVBatchPayloadScanCommandDirectLarge(t *testing.T) {

--- a/TreeDB/internal/commitlog/command_frame_test.go
+++ b/TreeDB/internal/commitlog/command_frame_test.go
@@ -955,6 +955,74 @@ func TestEncodeRawKVBatchPayloadScanMatchesSliceEncoder(t *testing.T) {
 	}
 }
 
+func TestWriteRawKVBatchPayloadToMatchesSliceEncoderAndBoundsDestination(t *testing.T) {
+	ops := []RawKVOperation{
+		{Op: RawKVOpSet, Key: []byte("alpha"), Value: []byte("one"), Revision: 11},
+		{Op: RawKVOpDelete, Key: []byte("bravo"), Revision: 12},
+		{Op: RawKVOpSetRID, Key: []byte("external"), RID: 42, Revision: 13},
+		{Op: RawKVOpDeleteRange, Key: nil, Value: []byte("omega")},
+		{Op: RawKVOpDeleteRange, Key: []byte("prefix"), Value: nil},
+	}
+	scan := rawKVOperationSliceScanner(ops)
+	plan, err := PlanRawKVBatchPayloadScan(scan)
+	if err != nil {
+		t.Fatalf("PlanRawKVBatchPayloadScan: %v", err)
+	}
+	want := encodeRawKVBatchPayloadWithPiecesForTest(t, plan, scan)
+	dst := bytes.Repeat([]byte{0xff}, plan.PayloadLen+16)
+	n, err := writeRawKVBatchPayloadTo(dst[:plan.PayloadLen], plan, scan)
+	if err != nil {
+		t.Fatalf("writeRawKVBatchPayloadTo: %v", err)
+	}
+	if n != len(want) {
+		t.Fatalf("written bytes=%d want %d", n, len(want))
+	}
+	if !bytes.Equal(dst[:n], want) {
+		t.Fatalf("payload mismatch\ngot  %x\nwant %x", dst[:n], want)
+	}
+	if !bytes.Equal(dst[plan.PayloadLen:], bytes.Repeat([]byte{0xff}, 16)) {
+		t.Fatalf("writeRawKVBatchPayloadTo wrote beyond planned payload")
+	}
+	if _, err := writeRawKVBatchPayloadTo(make([]byte, plan.PayloadLen-1), plan, scan); !errors.Is(err, ErrCorrupt) {
+		t.Fatalf("short destination error=%v, want ErrCorrupt", err)
+	}
+}
+
+func TestWriteRawKVBatchPayloadToOverwritesReusedBufferPrefix(t *testing.T) {
+	largeOps := []RawKVOperation{
+		{Op: RawKVOpSet, Key: []byte("alpha"), Value: []byte("one")},
+		{Op: RawKVOpSetRID, Key: []byte("external"), RID: 42, Revision: 9},
+	}
+	largeScan := rawKVOperationSliceScanner(largeOps)
+	largePlan, err := PlanRawKVBatchPayloadScan(largeScan)
+	if err != nil {
+		t.Fatalf("PlanRawKVBatchPayloadScan large: %v", err)
+	}
+	largePayload := encodeRawKVBatchPayloadWithPiecesForTest(t, largePlan, largeScan)
+	buf := bytes.Repeat([]byte{0xee}, len(largePayload))
+	if _, err := writeRawKVBatchPayloadTo(buf, largePlan, largeScan); err != nil {
+		t.Fatalf("writeRawKVBatchPayloadTo large: %v", err)
+	}
+
+	smallOps := []RawKVOperation{{Op: RawKVOpDelete, Key: []byte("alpha")}}
+	smallScan := rawKVOperationSliceScanner(smallOps)
+	smallPlan, err := PlanRawKVBatchPayloadScan(smallScan)
+	if err != nil {
+		t.Fatalf("PlanRawKVBatchPayloadScan small: %v", err)
+	}
+	smallPayload := encodeRawKVBatchPayloadWithPiecesForTest(t, smallPlan, smallScan)
+	n, err := writeRawKVBatchPayloadTo(buf[:smallPlan.PayloadLen], smallPlan, smallScan)
+	if err != nil {
+		t.Fatalf("writeRawKVBatchPayloadTo small: %v", err)
+	}
+	if n != len(smallPayload) || !bytes.Equal(buf[:n], smallPayload) {
+		t.Fatalf("reused buffer payload mismatch\ngot  %x\nwant %x", buf[:n], smallPayload)
+	}
+	if !bytes.Equal(buf[n:], largePayload[n:]) {
+		t.Fatalf("writeRawKVBatchPayloadTo touched bytes outside reused prefix")
+	}
+}
+
 func TestRawKVBatchPayloadBuilderMatchesSliceEncoder(t *testing.T) {
 	ops := []RawKVOperation{
 		{Op: RawKVOpSet, Key: []byte("alpha"), Value: []byte("one")},
@@ -1179,6 +1247,23 @@ func rawKVOperationSliceScanner(ops []RawKVOperation) RawKVBatchOperationScanner
 		}
 		return nil
 	}
+}
+
+func encodeRawKVBatchPayloadWithPiecesForTest(t *testing.T, plan RawKVBatchPayloadPlan, scan RawKVBatchOperationScanner) []byte {
+	t.Helper()
+	payload := make([]byte, plan.PayloadLen)
+	off := 0
+	if err := writeRawKVBatchPayloadPieces(plan, scan, func(part []byte) error {
+		copy(payload[off:], part)
+		off += len(part)
+		return nil
+	}); err != nil {
+		t.Fatalf("writeRawKVBatchPayloadPieces: %v", err)
+	}
+	if off != plan.PayloadLen {
+		t.Fatalf("piece payload bytes=%d want %d", off, plan.PayloadLen)
+	}
+	return payload
 }
 
 func assertRawKVCommandFramePayload(t *testing.T, path string, lsn, baseAppliedLSN uint64, payload []byte) {

--- a/TreeDB/internal/commitlog/writer.go
+++ b/TreeDB/internal/commitlog/writer.go
@@ -987,16 +987,12 @@ func (w *Writer) AppendRawKVBatchPayloadScanCommandDirectTrusted(lsn, baseApplie
 		buf := w.commandBuf[off:newLen]
 		frame := buf[segmentHeaderSize : segmentHeaderSize+size]
 		fillRawKVCommandFrameHeader(frame[:commandFrameHeaderSize], lsn, baseAppliedLSN, plan.PayloadLen)
-		payloadOff := commandFrameHeaderSize
-		if err := writeRawKVBatchPayloadPieces(plan, scan, func(part []byte) error {
-			copy(frame[payloadOff:], part)
-			payloadOff += len(part)
-			return nil
-		}); err != nil {
+		n, err := writeRawKVBatchPayloadTo(frame[commandFrameHeaderSize:], plan, scan)
+		if err != nil {
 			w.commandBuf = w.commandBuf[:off]
 			return err
 		}
-		if payloadOff != size {
+		if n != plan.PayloadLen {
 			w.commandBuf = w.commandBuf[:off]
 			return ErrCorrupt
 		}


### PR DESCRIPTION
## Summary

Closes #3497.

This removes the per-operation scratch allocations from command-WAL scan payload serialization by writing planned RawKV batch payloads directly into the destination command frame. The previous scanner path used a piece callback and allocated an 8-byte RID scratch buffer per `SetRID` operation; this path now writes headers, RID values, and key/value bytes in place.

The M3 classification found:

- runtime-bound: command-WAL scan payload writer allocation under timed `WriteSync`;
- cleanup/close-only: `readSegmentPayload` / `DecodeCommandFrame`, intentionally not optimized here;
- value-log append buffer: runtime-visible but only fixed 4 MiB growth samples, not a meaningful per-op target for this issue.

## Evidence

Before/after profile artifacts:

- Before: `/mnt/fast4tb/tmp/gomap-3497-current-classify-20260705T080706Z`
- After: `/mnt/fast4tb/tmp/gomap-3497-after-20260705T081537Z`
- Post-#3500-merge validation: `/mnt/fast4tb/tmp/gomap-3497-postmerge-validation-20260705T082137Z`

Key deltas:

- M3-focused alloc-space in pointer-forced benchmark: `20001.22 KiB` -> `2812.64 KiB` before rebase, and `2.75 MB` after rebase.
- M3-focused alloc-objects: `960062` -> `60003`.
- Pointer-forced `BenchmarkSyncLatencyCached/.../entry_hint_pointer_threshold_1`: `1125908 ns/op, 282 allocs/op` -> `854299 ns/op, 214 allocs/op`; post-merge rerun was `858861 ns/op, 215 allocs/op`.

## Validation

```sh
env GOWORK=off TMPDIR=/mnt/fast4tb/tmp GOCACHE=/mnt/fast4tb/tmp/go-cache GOMODCACHE=/mnt/fast4tb/tmp/go-mod-cache GOPATH=/mnt/fast4tb/tmp/go-path-cache go test ./TreeDB/internal/commitlog
```

```sh
env GOWORK=off TMPDIR=/mnt/fast4tb/tmp GOCACHE=/mnt/fast4tb/tmp/go-cache GOMODCACHE=/mnt/fast4tb/tmp/go-mod-cache GOPATH=/mnt/fast4tb/tmp/go-path-cache go test ./TreeDB -run 'TestPublicCommandWAL|TestReopenVerify_WALOn'
```

```sh
env GOWORK=off TMPDIR=/mnt/fast4tb/tmp GOCACHE=/mnt/fast4tb/tmp/go-cache GOMODCACHE=/mnt/fast4tb/tmp/go-mod-cache GOPATH=/mnt/fast4tb/tmp/go-path-cache go test ./TreeDB/internal/commitlog -run '^$' -bench '^BenchmarkWriterAppendRawKVBatchPayloadScanCommandDirectTrusted$' -benchtime=20000x -count=3 -benchmem
```

```sh
env GOWORK=off TMPDIR=/mnt/fast4tb/tmp GOCACHE=/mnt/fast4tb/tmp/go-cache GOMODCACHE=/mnt/fast4tb/tmp/go-mod-cache GOPATH=/mnt/fast4tb/tmp/go-path-cache go test ./TreeDB -run '^$' -bench '^BenchmarkSyncLatencyCached/BatchWriteSync/wal_on_relaxed_sync_command_wal/32/entry_hint_pointer_threshold_1$' -benchtime=20000x -count=1 -benchmem -memprofile /mnt/fast4tb/tmp/gomap-3497-postmerge-validation-20260705T082137Z/pointer32_allocs.pprof -memprofilerate=1
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of RawKV batch command writing to better prevent buffer overruns and ensure payload sizes match expectations.
  * Added stricter validation when materializing batch payloads, with clearer failure handling for invalid or truncated output.
  * Fixed reused-buffer behavior so only the intended portion is overwritten.
* **Tests**
  * Added coverage for batch payload encoding correctness, destination bounds, and buffer reuse.
  * Added a benchmark for direct RawKV batch payload appends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->