### PR TITLE
TreeDB: reduce command-WAL pointer allocation overhead

### DIFF
--- a/TreeDB/command_wal_public_cached.go
+++ b/TreeDB/command_wal_public_cached.go
@@ -58,14 +58,14 @@ func (tdb *DB) appendPublicRawKVCommandEntries(entries []batch.Entry, sync bool)
 	return err
 }
 
-func (tdb *DB) appendPublicRawKVCommandEntryScan(scanEntries func(func(batch.Entry) error) error, sync bool) error {
+func (tdb *DB) appendPublicRawKVCommandEntryScan(scanEntries func(func(batch.Entry) error) error, opHint int, sync bool) error {
 	if tdb == nil || !tdb.commandWALCached || scanEntries == nil {
 		return nil
 	}
 	if tdb.backend == nil {
 		return ErrClosed
 	}
-	lsn, err := tdb.backend.AppendRawKVCommandWALOrderedEntryScan(scanEntries, sync)
+	lsn, err := tdb.backend.AppendRawKVCommandWALOrderedEntryScanWithHint(scanEntries, opHint, sync)
 	if lsn != 0 {
 		tdb.recordPublicCommandWALPendingLSN(lsn)
 	}
@@ -1096,7 +1096,7 @@ func (b *commandWALPublicBatch) appendCommandWAL(sync bool) error {
 		}
 		return b.db.appendPublicRawKVCommandPayload(payload, sync)
 	}
-	return b.db.appendPublicRawKVCommandEntryScan(b.inner.Replay, sync)
+	return b.db.appendPublicRawKVCommandEntryScan(b.inner.Replay, b.opCount, sync)
 }
 
 func (b *commandWALPublicBatch) Replay(fn func(batch.Entry) error) error {

--- a/TreeDB/db/command_wal_raw.go
+++ b/TreeDB/db/command_wal_raw.go
@@ -10,7 +10,6 @@ import (
 	batchpkg "github.com/snissn/gomap/TreeDB/batch"
 	"github.com/snissn/gomap/TreeDB/internal/adaptive"
 	"github.com/snissn/gomap/TreeDB/internal/commitlog"
-	"github.com/snissn/gomap/TreeDB/internal/valuelog"
 	"github.com/snissn/gomap/TreeDB/page"
 )
 
@@ -460,6 +459,13 @@ func (db *DB) AppendRawKVCommandWALOrderedEntries(entries []batchpkg.Entry, sync
 // writing scan it separately. Callers must keep replayed entry buffers immutable
 // until this method returns.
 func (db *DB) AppendRawKVCommandWALOrderedEntryScan(scanEntries func(func(batchpkg.Entry) error) error, sync bool) (uint64, error) {
+	return db.AppendRawKVCommandWALOrderedEntryScanWithHint(scanEntries, 0, sync)
+}
+
+// AppendRawKVCommandWALOrderedEntryScanWithHint appends a raw-KV command frame
+// like AppendRawKVCommandWALOrderedEntryScan, using opHint only to pre-size
+// transient planning caches.
+func (db *DB) AppendRawKVCommandWALOrderedEntryScanWithHint(scanEntries func(func(batchpkg.Entry) error) error, opHint int, sync bool) (uint64, error) {
 	if db == nil || !db.commandWAL {
 		return 0, nil
 	}
@@ -469,7 +475,7 @@ func (db *DB) AppendRawKVCommandWALOrderedEntryScan(scanEntries func(func(batchp
 	if scanEntries == nil {
 		return 0, nil
 	}
-	intent, err := db.newRawKVCommandWALIntentFromEntryScan(scanEntries)
+	intent, err := db.newRawKVCommandWALIntentFromEntryScanWithHint(scanEntries, opHint)
 	if intent == nil || err != nil {
 		return 0, err
 	}
@@ -480,17 +486,21 @@ func (db *DB) newRawKVCommandWALIntentFromEntries(entries []batchpkg.Entry) (*co
 	if len(entries) == 0 {
 		return nil, nil
 	}
-	return db.newRawKVCommandWALIntentFromEntryScan(func(emit func(batchpkg.Entry) error) error {
+	return db.newRawKVCommandWALIntentFromEntryScanWithHint(func(emit func(batchpkg.Entry) error) error {
 		for i := range entries {
 			if err := emit(entries[i]); err != nil {
 				return err
 			}
 		}
 		return nil
-	})
+	}, len(entries))
 }
 
 func (db *DB) newRawKVCommandWALIntentFromEntryScan(scanEntries func(func(batchpkg.Entry) error) error) (*commandWALBatchIntent, error) {
+	return db.newRawKVCommandWALIntentFromEntryScanWithHint(scanEntries, 0)
+}
+
+func (db *DB) newRawKVCommandWALIntentFromEntryScanWithHint(scanEntries func(func(batchpkg.Entry) error) error, opHint int) (*commandWALBatchIntent, error) {
 	externalRefs := false
 	var ridCache map[page.ValuePtr]uint64
 	var externalRefFileIDs []uint32
@@ -505,7 +515,7 @@ func (db *DB) newRawKVCommandWALIntentFromEntryScan(scanEntries func(func(batchp
 			}
 			return emit(entry)
 		})
-	}, &ridCache, &externalRefs, &externalRefFileIDs)
+	}, &ridCache, &externalRefs, &externalRefFileIDs, opHint)
 	plan, err := commitlog.PlanRawKVBatchPayloadScan(planScan)
 	if err != nil {
 		return nil, err
@@ -513,7 +523,7 @@ func (db *DB) newRawKVCommandWALIntentFromEntryScan(scanEntries func(func(batchp
 	if plan.Count == 0 {
 		return nil, nil
 	}
-	writeScan := db.rawKVCommandWALOperationScannerFromEntryScan(scanEntries, &ridCache, nil, nil)
+	writeScan := db.rawKVCommandWALOperationScannerFromEntryScan(scanEntries, &ridCache, nil, nil, opHint)
 	return &commandWALBatchIntent{
 		kind:               commitlog.CommandKindRawKVBatch,
 		scope:              commitlog.CommandScopeRawKV,
@@ -531,7 +541,7 @@ func (db *DB) newRawKVCommandWALIntentFromEntryScan(scanEntries func(func(batchp
 func (db *DB) newRawKVCommandWALPayloadIntentFromEntries(entries []batchpkg.Entry) (*commandWALBatchIntent, error) {
 	externalRefs := false
 	var ridCache map[page.ValuePtr]uint64
-	scan := db.rawKVCommandWALOperationScanner(entries, &ridCache, &externalRefs)
+	scan := db.rawKVCommandWALOperationScannerWithHint(entries, &ridCache, &externalRefs, len(entries))
 	plan, err := commitlog.PlanRawKVBatchPayloadScan(scan)
 	if err != nil {
 		return nil, err
@@ -599,6 +609,10 @@ func maxEntryRevisionFromCommandWALPayload(kind commitlog.CommandKind, scope com
 }
 
 func (db *DB) rawKVCommandWALOperationScanner(entries []batchpkg.Entry, ridCache *map[page.ValuePtr]uint64, externalRefs *bool) commitlog.RawKVBatchOperationScanner {
+	return db.rawKVCommandWALOperationScannerWithHint(entries, ridCache, externalRefs, len(entries))
+}
+
+func (db *DB) rawKVCommandWALOperationScannerWithHint(entries []batchpkg.Entry, ridCache *map[page.ValuePtr]uint64, externalRefs *bool, opHint int) commitlog.RawKVBatchOperationScanner {
 	return db.rawKVCommandWALOperationScannerFromEntryScan(func(emit func(batchpkg.Entry) error) error {
 		for i := range entries {
 			if err := emit(entries[i]); err != nil {
@@ -606,16 +620,16 @@ func (db *DB) rawKVCommandWALOperationScanner(entries []batchpkg.Entry, ridCache
 			}
 		}
 		return nil
-	}, ridCache, externalRefs, nil)
+	}, ridCache, externalRefs, nil, opHint)
 }
 
-func (db *DB) rawKVCommandWALOperationScannerFromEntryScan(scanEntries func(func(batchpkg.Entry) error) error, ridCache *map[page.ValuePtr]uint64, externalRefs *bool, externalRefFileIDs *[]uint32) commitlog.RawKVBatchOperationScanner {
+func (db *DB) rawKVCommandWALOperationScannerFromEntryScan(scanEntries func(func(batchpkg.Entry) error) error, ridCache *map[page.ValuePtr]uint64, externalRefs *bool, externalRefFileIDs *[]uint32, opHint int) commitlog.RawKVBatchOperationScanner {
 	return func(emit func(commitlog.RawKVOperation) error) error {
 		if scanEntries == nil {
 			return nil
 		}
 		return scanEntries(func(entry batchpkg.Entry) error {
-			op, ok, err := db.rawKVCommandWALOperationFromEntry(entry, ridCache, externalRefs, externalRefFileIDs)
+			op, ok, err := db.rawKVCommandWALOperationFromEntry(entry, ridCache, externalRefs, externalRefFileIDs, opHint)
 			if err != nil {
 				return err
 			}
@@ -627,7 +641,7 @@ func (db *DB) rawKVCommandWALOperationScannerFromEntryScan(scanEntries func(func
 	}
 }
 
-func (db *DB) rawKVCommandWALOperationFromEntry(entry batchpkg.Entry, ridCache *map[page.ValuePtr]uint64, externalRefs *bool, externalRefFileIDs *[]uint32) (commitlog.RawKVOperation, bool, error) {
+func (db *DB) rawKVCommandWALOperationFromEntry(entry batchpkg.Entry, ridCache *map[page.ValuePtr]uint64, externalRefs *bool, externalRefFileIDs *[]uint32, opHint int) (commitlog.RawKVOperation, bool, error) {
 	switch entry.Type {
 	case batchpkg.OpDeleteRange:
 		if batchpkg.IsDeleteRangeNoop(entry.Key, entry.Value) {
@@ -648,7 +662,7 @@ func (db *DB) rawKVCommandWALOperationFromEntry(entry batchpkg.Entry, ridCache *
 				return commitlog.RawKVOperation{}, false, fmt.Errorf("treedb: command wal raw kv rid cache unavailable")
 			}
 			if *ridCache == nil {
-				*ridCache = make(map[page.ValuePtr]uint64)
+				*ridCache = makeRawKVCommandWALRIDCache(opHint)
 			}
 			rid, err := db.lookupCommandWALValueLogRID(entry.ValuePtr, *ridCache)
 			if err != nil {
@@ -660,6 +674,13 @@ func (db *DB) rawKVCommandWALOperationFromEntry(entry batchpkg.Entry, ridCache *
 	default:
 		return commitlog.RawKVOperation{}, false, fmt.Errorf("treedb: command wal unknown raw kv batch op %d", entry.Type)
 	}
+}
+
+func makeRawKVCommandWALRIDCache(opHint int) map[page.ValuePtr]uint64 {
+	if opHint <= 0 {
+		return make(map[page.ValuePtr]uint64)
+	}
+	return make(map[page.ValuePtr]uint64, NormalizePublicBatchReserveHint(opHint))
 }
 
 func rawKVCommandWALExternalRefFileIDs(entries []batchpkg.Entry) []uint32 {
@@ -699,28 +720,18 @@ func (db *DB) lookupCommandWALValueLogRID(ptr page.ValuePtr, ridCache map[page.V
 	if rid, ok := ridCache[ptr]; ok {
 		return rid, nil
 	}
-	path := db.valueLogManager.SegmentPath(ptr.FileID)
-	rid, err := readCommandWALValueLogRIDAt(path, ptr)
+	rid, err := db.valueLogManager.ReadRIDUnverified(ptr)
 	if isCommandWALRIDLookupVisibilityError(err) {
 		if flushErr := db.flushCommandWALExternalRefs(false, []uint32{ptr.FileID}); flushErr != nil {
 			return 0, flushErr
 		}
-		rid, err = readCommandWALValueLogRIDAt(path, ptr)
+		rid, err = db.valueLogManager.ReadRIDUnverified(ptr)
 	}
 	if err != nil {
 		return 0, err
 	}
 	ridCache[ptr] = rid
 	return rid, nil
-}
-
-func readCommandWALValueLogRIDAt(path string, ptr page.ValuePtr) (uint64, error) {
-	f, err := os.Open(path)
-	if err != nil {
-		return 0, err
-	}
-	defer func() { _ = f.Close() }()
-	return valuelog.ReadRIDAtUnverified(f, ptr.FileID, ptr)
 }
 
 func isCommandWALRIDLookupVisibilityError(err error) bool {

--- a/TreeDB/db/command_wal_raw_test.go
+++ b/TreeDB/db/command_wal_raw_test.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"bytes"
 	"errors"
 	"path/filepath"
 	"strings"
@@ -10,6 +11,30 @@ import (
 	"github.com/snissn/gomap/TreeDB/internal/commitlog"
 	"github.com/snissn/gomap/TreeDB/page"
 )
+
+type commandWALCountingValueLogAppender struct {
+	inner   ValueLogAppender
+	flushes int
+	syncs   int
+}
+
+func (a *commandWALCountingValueLogAppender) AppendValues(values [][]byte) ([]page.ValuePtr, error) {
+	return a.inner.AppendValues(values)
+}
+
+func (a *commandWALCountingValueLogAppender) Flush() error {
+	a.flushes++
+	return a.inner.Flush()
+}
+
+func (a *commandWALCountingValueLogAppender) Sync() error {
+	a.syncs++
+	return a.inner.Sync()
+}
+
+func (a *commandWALCountingValueLogAppender) CurrentValueLogSegment() (string, uint32, bool) {
+	return a.inner.CurrentValueLogSegment()
+}
 
 func TestCommandWALIntentZeroValueLSNSentinelsM10C(t *testing.T) {
 	var nilIntent *CommandWALIntent
@@ -298,6 +323,96 @@ func TestAppendRawKVCommandWALOrderedEntryScanStreamsReplay(t *testing.T) {
 	}
 	if len(got) != 3 || got[0].Type != batchpkg.OpPut || string(got[0].Key) != "alpha" || string(got[0].Value) != "one" || got[1].Type != batchpkg.OpDelete || string(got[1].Key) != "bravo" || got[2].Type != batchpkg.OpPut || string(got[2].Key) != "charlie" || string(got[2].Value) != strings.Repeat("x", 128) {
 		t.Fatalf("decoded scan ops=%+v", got)
+	}
+}
+
+func TestAppendRawKVCommandWALOrderedEntryScanFlushesFreshValueLogPointer(t *testing.T) {
+	dir := t.TempDir()
+	d, err := Open(Options{Dir: dir, CommandWAL: true, DisableBackgroundPrune: true})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	inner := d.currentValueLogAppender()
+	if inner == nil {
+		_ = d.Close()
+		t.Fatalf("command WAL value-log appender unavailable")
+	}
+	counting := &commandWALCountingValueLogAppender{inner: inner}
+	d.SetValueLogAppender(counting)
+
+	ptrs, err := d.AppendValueLogValues([][]byte{bytes.Repeat([]byte("fresh-pointer-value|"), 16)})
+	if err != nil {
+		_ = d.Close()
+		t.Fatalf("AppendValueLogValues: %v", err)
+	}
+	if len(ptrs) != 1 {
+		_ = d.Close()
+		t.Fatalf("AppendValueLogValues returned %d ptrs, want 1", len(ptrs))
+	}
+	ptr := ptrs[0]
+	path, fileID, ok := counting.CurrentValueLogSegment()
+	if !ok || path == "" || fileID != ptr.FileID {
+		_ = d.Close()
+		t.Fatalf("CurrentValueLogSegment=(%q,%d,%t), ptr file_id=%d", path, fileID, ok, ptr.FileID)
+	}
+	if err := d.RegisterValueLogSegment(path, fileID); err != nil {
+		_ = d.Close()
+		t.Fatalf("RegisterValueLogSegment: %v", err)
+	}
+	if _, err := d.valueLogManager.ReadRIDUnverified(ptr); !isCommandWALRIDLookupVisibilityError(err) {
+		_ = d.Close()
+		t.Fatalf("ReadRIDUnverified before flush error=%v, want short-read visibility error", err)
+	}
+
+	entries := []batchpkg.Entry{{
+		Type:     batchpkg.OpPut,
+		Key:      []byte("fresh-pointer"),
+		IsPtr:    true,
+		ValuePtr: ptr,
+	}}
+	lsn, err := d.AppendRawKVCommandWALOrderedEntryScan(func(emit func(batchpkg.Entry) error) error {
+		for i := range entries {
+			if err := emit(entries[i]); err != nil {
+				return err
+			}
+		}
+		return nil
+	}, false)
+	if err != nil {
+		_ = d.Close()
+		t.Fatalf("AppendRawKVCommandWALOrderedEntryScan: %v", err)
+	}
+	if lsn == 0 {
+		_ = d.Close()
+		t.Fatalf("AppendRawKVCommandWALOrderedEntryScan lsn=0")
+	}
+	if counting.flushes == 0 {
+		_ = d.Close()
+		t.Fatalf("value-log appender flushes=0, want retry path to flush fresh pointer segment")
+	}
+	if counting.syncs != 0 {
+		_ = d.Close()
+		t.Fatalf("value-log appender syncs=%d, want 0 for sync=false", counting.syncs)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	r, err := commitlog.NewReader(filepath.Join(WALDirPath(dir), "commit-l0-000001.log"))
+	if err != nil {
+		t.Fatalf("NewReader: %v", err)
+	}
+	defer r.Close()
+	env, err := r.ReadCommandFrame()
+	if err != nil {
+		t.Fatalf("ReadCommandFrame: %v", err)
+	}
+	ops, err := commitlog.DecodeRawKVBatchPayload(env.Payload)
+	if err != nil {
+		t.Fatalf("DecodeRawKVBatchPayload: %v", err)
+	}
+	if len(ops) != 1 || ops[0].Op != commitlog.RawKVOpSetRID || string(ops[0].Key) != "fresh-pointer" || ops[0].RID == 0 {
+		t.Fatalf("decoded ops=%+v, want single SetRID for fresh-pointer", ops)
 	}
 }
 

--- a/TreeDB/db/value_log_appender.go
+++ b/TreeDB/db/value_log_appender.go
@@ -157,14 +157,34 @@ func (db *DB) releasePendingValueLogAppendFileIDsFromEntries(entries []batchpkg.
 	if db == nil || len(entries) == 0 {
 		return
 	}
-	release := make(map[page.ValuePtr]int64)
+	db.pendingValueLogAppendMu.Lock()
+	defer db.pendingValueLogAppendMu.Unlock()
 	for _, entry := range entries {
 		if entry.Type != batchpkg.OpPut || !entry.IsPtr || entry.ValuePtr.FileID == 0 || !page.IsValueLogFileID(entry.ValuePtr.FileID) {
 			continue
 		}
-		release[entry.ValuePtr]++
+		refs := db.pendingValueLogAppendPtrRefs[entry.ValuePtr]
+		if refs <= 0 {
+			continue
+		}
+		if refs == 1 {
+			delete(db.pendingValueLogAppendPtrRefs, entry.ValuePtr)
+		} else {
+			db.pendingValueLogAppendPtrRefs[entry.ValuePtr] = refs - 1
+		}
+		fileRefs := db.pendingValueLogAppendFileIDRefs[entry.ValuePtr.FileID]
+		if fileRefs <= 1 {
+			delete(db.pendingValueLogAppendFileIDRefs, entry.ValuePtr.FileID)
+		} else {
+			db.pendingValueLogAppendFileIDRefs[entry.ValuePtr.FileID] = fileRefs - 1
+		}
 	}
-	db.releasePendingValueLogAppendPtrCounts(release)
+	if len(db.pendingValueLogAppendPtrRefs) == 0 {
+		db.pendingValueLogAppendPtrRefs = nil
+	}
+	if len(db.pendingValueLogAppendFileIDRefs) == 0 {
+		db.pendingValueLogAppendFileIDRefs = nil
+	}
 }
 
 func (db *DB) releasePendingValueLogAppendFileIDsFromBatch(delta *batchpkg.Batch) {

--- a/TreeDB/db/value_log_appender_test.go
+++ b/TreeDB/db/value_log_appender_test.go
@@ -5,8 +5,10 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/snissn/gomap/TreeDB/batch"
 	"github.com/snissn/gomap/TreeDB/internal/memtable"
 	"github.com/snissn/gomap/TreeDB/node"
+	"github.com/snissn/gomap/TreeDB/page"
 )
 
 func TestAppendValueLogValuesUnavailableReturnsSentinel(t *testing.T) {
@@ -69,5 +71,33 @@ func TestAppendValueLogValuesPublishSystemRootReleasesPendingPin(t *testing.T) {
 	db.pendingValueLogAppendMu.Unlock()
 	if pendingPtrs != 0 || pendingFiles != 0 {
 		t.Fatalf("pending refs after publish ptrs=%d files=%d, want zero", pendingPtrs, pendingFiles)
+	}
+}
+
+func TestReleasePendingValueLogAppendFileIDsFromEntriesDecrementsDuplicateRefs(t *testing.T) {
+	fileID := page.ValueLogFileID(1)
+	ptrA := page.ValuePtr{FileID: fileID, Offset: 11, Length: 3}
+	ptrB := page.ValuePtr{FileID: fileID, Offset: 22, Length: 4}
+	db := &DB{
+		pendingValueLogAppendFileIDRefs: map[uint32]int{fileID: 3},
+		pendingValueLogAppendPtrRefs: map[page.ValuePtr]int{
+			ptrA: 2,
+			ptrB: 1,
+		},
+	}
+
+	db.releasePendingValueLogAppendFileIDsFromEntries([]batch.Entry{
+		{Type: batch.OpPut, IsPtr: true, ValuePtr: ptrA},
+		{Type: batch.OpPut, IsPtr: true, ValuePtr: ptrA},
+		{Type: batch.OpPut, IsPtr: true, ValuePtr: ptrB},
+		{Type: batch.OpPut, Value: []byte("inline")},
+		{Type: batch.OpDelete, Key: []byte("deleted")},
+	})
+
+	if db.pendingValueLogAppendPtrRefs != nil {
+		t.Fatalf("pending ptr refs after release = %v, want nil", db.pendingValueLogAppendPtrRefs)
+	}
+	if db.pendingValueLogAppendFileIDRefs != nil {
+		t.Fatalf("pending file refs after release = %v, want nil", db.pendingValueLogAppendFileIDRefs)
 	}
 }

--- a/TreeDB/internal/valuelog/manager.go
+++ b/TreeDB/internal/valuelog/manager.go
@@ -1107,6 +1107,18 @@ func (f *File) ReadUnsafeAppend(ptr page.ValuePtr, verifyCRC bool, dst []byte) (
 	return f.ReadAppend(ptr, verifyCRC, dst)
 }
 
+// ReadRIDUnverified reads only the record id metadata for a same-process
+// command-WAL reference. It intentionally skips payload verification.
+func (f *File) ReadRIDUnverified(ptr page.ValuePtr) (uint64, error) {
+	if f == nil || f.File == nil {
+		return 0, errors.New("valuelog: nil file")
+	}
+	if err := f.ensureCurrentWritableReadableFor(ptr); err != nil {
+		return 0, err
+	}
+	return ReadRIDAtUnverified(f.File, f.ID, ptr)
+}
+
 func (f *File) appendPayloadFromFile(dst []byte, off int64, payloadLen int) ([]byte, error) {
 	oldLen := len(dst)
 	noteGrowReadAppendPayload(payloadLen)
@@ -1878,6 +1890,16 @@ func (m *Manager) ReadUnsafeAppendBatch(ptrs []page.ValuePtr, dst [][]byte) ([][
 		i++
 	}
 	return dst, nil
+}
+
+// ReadRIDUnverified reads only record id metadata through the manager's
+// registered segment handle, avoiding per-lookup file opens on hot paths.
+func (m *Manager) ReadRIDUnverified(ptr page.ValuePtr) (uint64, error) {
+	f, err := m.fileFor(ptr.FileID)
+	if err != nil {
+		return 0, err
+	}
+	return f.ReadRIDUnverified(ptr)
 }
 
 func (m *Manager) fileFor(id uint32) (*File, error) {

--- a/TreeDB/internal/valuelog/manager_test.go
+++ b/TreeDB/internal/valuelog/manager_test.go
@@ -1336,6 +1336,78 @@ func TestFileReadAppend_CountsGroupedFallbackReadAt(t *testing.T) {
 	}
 }
 
+func TestManagerReadRIDUnverifiedReusesRegisteredSegment(t *testing.T) {
+	dir := t.TempDir()
+	fileID, err := EncodeFileID(0, 1)
+	if err != nil {
+		t.Fatalf("EncodeFileID: %v", err)
+	}
+	path := SegmentPath(dir, fileID)
+
+	writer, err := NewWriter(path, fileID)
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+	ptrs, err := writer.AppendFrame(0, nil, []Record{
+		{RID: 1, Value: []byte("alpha")},
+		{RID: 2, Value: []byte("beta")},
+	})
+	if err != nil {
+		_ = writer.Close()
+		t.Fatalf("AppendFrame: %v", err)
+	}
+	ptr3, err := writer.Append(0, nil, 3, []byte("gamma"))
+	if err != nil {
+		_ = writer.Close()
+		t.Fatalf("Append: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("Close writer: %v", err)
+	}
+
+	origOpen := currentOpenSegmentFile()
+	opens := 0
+	swapOpenSegmentFileForTest(func(path string, id uint32, dictLookup DictLookup, templateLookup TemplateLookup, templateOpts templ.DecodeOptions, templateCache *templateDefCache) (*File, error) {
+		if id == fileID {
+			opens++
+		}
+		return origOpen(path, id, dictLookup, templateLookup, templateOpts, templateCache)
+	})
+	t.Cleanup(func() { swapOpenSegmentFileForTest(origOpen) })
+
+	mgr, err := NewManager(dir)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	defer func() { _ = mgr.Close() }()
+	if opens != 1 {
+		t.Fatalf("NewManager opened segment %d times, want 1", opens)
+	}
+
+	cases := []struct {
+		ptr page.ValuePtr
+		rid uint64
+	}{
+		{ptr: ptrs[0], rid: 1},
+		{ptr: ptrs[1], rid: 2},
+		{ptr: ptr3, rid: 3},
+	}
+	for repeat := 0; repeat < 3; repeat++ {
+		for _, tc := range cases {
+			got, err := mgr.ReadRIDUnverified(tc.ptr)
+			if err != nil {
+				t.Fatalf("ReadRIDUnverified(%+v): %v", tc.ptr, err)
+			}
+			if got != tc.rid {
+				t.Fatalf("ReadRIDUnverified(%+v)=%d, want %d", tc.ptr, got, tc.rid)
+			}
+		}
+	}
+	if opens != 1 {
+		t.Fatalf("ReadRIDUnverified reopened segment: opens=%d, want 1", opens)
+	}
+}
+
 func TestOpenFile_DoesNotEagerlyMap(t *testing.T) {
 	dir := t.TempDir()
 	fileID, err := EncodeFileID(0, 1)


### PR DESCRIPTION
## Summary

Fixes #3504.

This reduces allocation overhead in TreeDB command-WAL pointer-heavy batches by:

- reading SetRID value-log record metadata through the value-log manager's registered segment handle instead of opening the segment path for every pointer lookup;
- threading the public command-WAL batch `opCount` as a bounded, lazy RID-cache capacity hint;
- releasing pending value-log append references directly from committed entries instead of constructing temporary pointer and file-id maps.

## Correctness notes

The value-log metadata read still uses the existing current-writable visibility barrier before reading. The direct pending-ref release path keeps duplicate-entry semantics by decrementing one ref per committed pointer entry and still clamps missing/over-released refs to zero.

## Local validation

Focused tests:

```sh
GOWORK=off TMPDIR=/mnt/fast4tb/tmp GOCACHE=/mnt/fast4tb/go-cache GOMODCACHE=/mnt/fast4tb/go/pkg/mod GOPATH=/mnt/fast4tb/go go test ./TreeDB/internal/valuelog -run 'TestManagerReadRIDUnverifiedReusesRegisteredSegment|TestFileReadAppend_CountsGroupedFallbackReadAt|TestValueLogReaderReadNextMeta' -count=1
GOWORK=off TMPDIR=/mnt/fast4tb/tmp GOCACHE=/mnt/fast4tb/go-cache GOMODCACHE=/mnt/fast4tb/go/pkg/mod GOPATH=/mnt/fast4tb/go go test ./TreeDB/db -run 'Test.*CommandWAL.*RawKV|TestAppendRawKVCommandWALOrderedEntryScanStreamsReplay|TestCommandWALIntentRawKVPayloadSetsMaxEntryRevision|TestAppendRawKVSingleCommandWALSupportsDeleteRange|Test.*ExternalRef.*|TestReleasePendingValueLogAppendFileIDsFromEntriesDecrementsDuplicateRefs|TestAppendValueLogValuesPublishSystemRootReleasesPendingPin' -count=1
GOWORK=off TMPDIR=/mnt/fast4tb/tmp GOCACHE=/mnt/fast4tb/go-cache GOMODCACHE=/mnt/fast4tb/go/pkg/mod GOPATH=/mnt/fast4tb/go go test ./TreeDB -run 'TestPublicCommandWALBatch|TestCommandWAL' -count=1
```

Broad gate:

```sh
git diff --check
GOWORK=off TMPDIR=/mnt/fast4tb/tmp GOCACHE=/mnt/fast4tb/go-cache GOMODCACHE=/mnt/fast4tb/go/pkg/mod GOPATH=/mnt/fast4tb/go go test ./TreeDB/...
```

Unified-bench/profile evidence:

```sh
GOWORK=off TMPDIR=/mnt/fast4tb/gomap-tmp GOCACHE=/mnt/fast4tb/go-cache GOMODCACHE=/mnt/fast4tb/go/pkg/mod GOPATH=/mnt/fast4tb/go GOMAXPROCS=8 ./bin/unified-bench \
  -dbs treedb_public_command_wal \
  -profile durable \
  -test batch_random,dataset_update_fork_choice,batch_write_steady \
  -keys 1000000 \
  -batchsize 256 \
  -valsize 256 \
  -val-pattern medium_compressible_sparse \
  -val-pool-size 4096 \
  -treedb-force-value-pointers \
  -treedb-vlog-compression=block \
  -treedb-vlog-block-codec=lz4 \
  -checkpoint-every-bytes 16777216 \
  -checkpoint-between-tests \
  -profile-dir /mnt/fast4tb/gomap-profiles/alloc-loop-3504-rid-cleanup-1m-20260705T102706HST \
  -path-label native-fastpath \
  -progress=false \
  -format markdown
```

1M durable/LZ4 results on this branch:

- Batch Random: 200,462 ops/s, alloc-space 704.14MB
- Update ForkChoice: 17,522 ops/s, alloc-space 746.39MB
- Batch Write Steady: 261,322 ops/s, alloc-space 517.11MB

Previous 1M baseline artifact was `/mnt/fast4tb/gomap-profiles/alloc-loop-3503-durable-lz4-20260705T201047Z`:

- Batch Random: 115,005 ops/s, alloc-space 1090.74MB
- Update ForkChoice: 17,818 ops/s, alloc-space 1108.61MB
- Batch Write Steady: 128,324 ops/s, alloc-space 938.61MB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved batch append handling for large writes, which can speed up certain ordered operations.

* **Bug Fixes**
  * Made value-log cleanup more reliable, reducing the chance of leftover pending references after writes.
  * Improved record lookup during append and replay to better handle visibility and short-read edge cases.
  * Strengthened internal reuse of open data segments, helping avoid unnecessary reopen operations and improving stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->