### PR TITLE
treedb: reduce command wal rid cache allocs

### DIFF
--- a/TreeDB/db/command_wal_raw.go
+++ b/TreeDB/db/command_wal_raw.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sync"
 
 	batchpkg "github.com/snissn/gomap/TreeDB/batch"
 	"github.com/snissn/gomap/TreeDB/internal/adaptive"
@@ -21,7 +22,7 @@ type commandWALBatchIntent struct {
 	rawKVEntries       []batchpkg.Entry
 	rawKVScan          commitlog.RawKVBatchOperationScanner
 	rawKVPlan          commitlog.RawKVBatchPayloadPlan
-	rawKVRIDCache      map[page.ValuePtr]uint64
+	rawKVRIDCache      *rawKVCommandWALRIDCache
 	rawKVDirect        bool
 	trustedPayload     bool
 	externalRefs       bool
@@ -33,6 +34,91 @@ type commandWALBatchIntent struct {
 	coveredRange       [1]CommandWALLSNRange
 	syncOnPublish      bool
 	staged             bool
+}
+
+const rawKVCommandWALRIDInlineCacheEntries = 4
+const rawKVCommandWALRIDMaxPooledOverflowEntries = 4 * 1024
+
+type rawKVCommandWALRIDCacheEntry struct {
+	ptr page.ValuePtr
+	rid uint64
+}
+
+type rawKVCommandWALRIDCache struct {
+	entries       [rawKVCommandWALRIDInlineCacheEntries]rawKVCommandWALRIDCacheEntry
+	overflow      map[page.ValuePtr]uint64
+	mapHint       int
+	count         int
+	overflowCount int
+}
+
+var rawKVCommandWALRIDCacheMapPool sync.Pool
+
+func (c *rawKVCommandWALRIDCache) lookup(ptr page.ValuePtr) (uint64, bool) {
+	if c == nil {
+		return 0, false
+	}
+	for i := 0; i < c.count; i++ {
+		entry := c.entries[i]
+		if entry.ptr == ptr {
+			return entry.rid, true
+		}
+	}
+	if c.overflow != nil {
+		rid, ok := c.overflow[ptr]
+		return rid, ok
+	}
+	return 0, false
+}
+
+func (c *rawKVCommandWALRIDCache) store(ptr page.ValuePtr, rid uint64) {
+	if c == nil || rid == 0 {
+		return
+	}
+	for i := 0; i < c.count; i++ {
+		if c.entries[i].ptr == ptr {
+			c.entries[i].rid = rid
+			return
+		}
+	}
+	if c.count >= len(c.entries) {
+		if c.overflow == nil {
+			c.overflow = acquireRawKVCommandWALRIDCacheMap(c.mapHint)
+		}
+		c.overflowCount++
+		c.overflow[ptr] = rid
+		return
+	}
+	c.entries[c.count] = rawKVCommandWALRIDCacheEntry{ptr: ptr, rid: rid}
+	c.count++
+}
+
+func (c *rawKVCommandWALRIDCache) release() {
+	if c == nil {
+		return
+	}
+	for i := 0; i < c.count; i++ {
+		c.entries[i] = rawKVCommandWALRIDCacheEntry{}
+	}
+	c.count = 0
+	if c.overflow != nil {
+		if c.mapHint <= rawKVCommandWALRIDMaxPooledOverflowEntries && c.overflowCount <= rawKVCommandWALRIDMaxPooledOverflowEntries {
+			clear(c.overflow)
+			rawKVCommandWALRIDCacheMapPool.Put(c.overflow)
+		}
+		c.overflow = nil
+	}
+	c.overflowCount = 0
+}
+
+func acquireRawKVCommandWALRIDCacheMap(capHint int) map[page.ValuePtr]uint64 {
+	if v := rawKVCommandWALRIDCacheMapPool.Get(); v != nil {
+		return v.(map[page.ValuePtr]uint64)
+	}
+	if capHint <= 0 {
+		return make(map[page.ValuePtr]uint64)
+	}
+	return make(map[page.ValuePtr]uint64, capHint)
 }
 
 func (db *DB) commandWALJournalUnavailableError() error {
@@ -502,7 +588,7 @@ func (db *DB) newRawKVCommandWALIntentFromEntryScan(scanEntries func(func(batchp
 
 func (db *DB) newRawKVCommandWALIntentFromEntryScanWithHint(scanEntries func(func(batchpkg.Entry) error) error, opHint int) (*commandWALBatchIntent, error) {
 	externalRefs := false
-	var ridCache map[page.ValuePtr]uint64
+	var ridCache *rawKVCommandWALRIDCache
 	var externalRefFileIDs []uint32
 	maxEntryRevision := page.LegacyEntryRevision
 	planScan := db.rawKVCommandWALOperationScannerFromEntryScan(func(emit func(batchpkg.Entry) error) error {
@@ -540,7 +626,7 @@ func (db *DB) newRawKVCommandWALIntentFromEntryScanWithHint(scanEntries func(fun
 
 func (db *DB) newRawKVCommandWALPayloadIntentFromEntries(entries []batchpkg.Entry) (*commandWALBatchIntent, error) {
 	externalRefs := false
-	var ridCache map[page.ValuePtr]uint64
+	var ridCache *rawKVCommandWALRIDCache
 	scan := db.rawKVCommandWALOperationScannerWithHint(entries, &ridCache, &externalRefs, len(entries))
 	plan, err := commitlog.PlanRawKVBatchPayloadScan(scan)
 	if err != nil {
@@ -608,11 +694,11 @@ func maxEntryRevisionFromCommandWALPayload(kind commitlog.CommandKind, scope com
 	return maxRevision, nil
 }
 
-func (db *DB) rawKVCommandWALOperationScanner(entries []batchpkg.Entry, ridCache *map[page.ValuePtr]uint64, externalRefs *bool) commitlog.RawKVBatchOperationScanner {
+func (db *DB) rawKVCommandWALOperationScanner(entries []batchpkg.Entry, ridCache **rawKVCommandWALRIDCache, externalRefs *bool) commitlog.RawKVBatchOperationScanner {
 	return db.rawKVCommandWALOperationScannerWithHint(entries, ridCache, externalRefs, len(entries))
 }
 
-func (db *DB) rawKVCommandWALOperationScannerWithHint(entries []batchpkg.Entry, ridCache *map[page.ValuePtr]uint64, externalRefs *bool, opHint int) commitlog.RawKVBatchOperationScanner {
+func (db *DB) rawKVCommandWALOperationScannerWithHint(entries []batchpkg.Entry, ridCache **rawKVCommandWALRIDCache, externalRefs *bool, opHint int) commitlog.RawKVBatchOperationScanner {
 	return db.rawKVCommandWALOperationScannerFromEntryScan(func(emit func(batchpkg.Entry) error) error {
 		for i := range entries {
 			if err := emit(entries[i]); err != nil {
@@ -623,7 +709,7 @@ func (db *DB) rawKVCommandWALOperationScannerWithHint(entries []batchpkg.Entry, 
 	}, ridCache, externalRefs, nil, opHint)
 }
 
-func (db *DB) rawKVCommandWALOperationScannerFromEntryScan(scanEntries func(func(batchpkg.Entry) error) error, ridCache *map[page.ValuePtr]uint64, externalRefs *bool, externalRefFileIDs *[]uint32, opHint int) commitlog.RawKVBatchOperationScanner {
+func (db *DB) rawKVCommandWALOperationScannerFromEntryScan(scanEntries func(func(batchpkg.Entry) error) error, ridCache **rawKVCommandWALRIDCache, externalRefs *bool, externalRefFileIDs *[]uint32, opHint int) commitlog.RawKVBatchOperationScanner {
 	return func(emit func(commitlog.RawKVOperation) error) error {
 		if scanEntries == nil {
 			return nil
@@ -641,7 +727,7 @@ func (db *DB) rawKVCommandWALOperationScannerFromEntryScan(scanEntries func(func
 	}
 }
 
-func (db *DB) rawKVCommandWALOperationFromEntry(entry batchpkg.Entry, ridCache *map[page.ValuePtr]uint64, externalRefs *bool, externalRefFileIDs *[]uint32, opHint int) (commitlog.RawKVOperation, bool, error) {
+func (db *DB) rawKVCommandWALOperationFromEntry(entry batchpkg.Entry, ridCache **rawKVCommandWALRIDCache, externalRefs *bool, externalRefFileIDs *[]uint32, opHint int) (commitlog.RawKVOperation, bool, error) {
 	switch entry.Type {
 	case batchpkg.OpDeleteRange:
 		if batchpkg.IsDeleteRangeNoop(entry.Key, entry.Value) {
@@ -676,11 +762,11 @@ func (db *DB) rawKVCommandWALOperationFromEntry(entry batchpkg.Entry, ridCache *
 	}
 }
 
-func makeRawKVCommandWALRIDCache(opHint int) map[page.ValuePtr]uint64 {
+func makeRawKVCommandWALRIDCache(opHint int) *rawKVCommandWALRIDCache {
 	if opHint <= 0 {
-		return make(map[page.ValuePtr]uint64)
+		return &rawKVCommandWALRIDCache{}
 	}
-	return make(map[page.ValuePtr]uint64, NormalizePublicBatchReserveHint(opHint))
+	return &rawKVCommandWALRIDCache{mapHint: NormalizePublicBatchReserveHint(opHint)}
 }
 
 func rawKVCommandWALExternalRefFileIDs(entries []batchpkg.Entry) []uint32 {
@@ -707,7 +793,7 @@ func appendRawKVCommandWALExternalRefFileID(ids *[]uint32, fileID uint32) {
 	*ids = append(*ids, fileID)
 }
 
-func (db *DB) lookupCommandWALValueLogRID(ptr page.ValuePtr, ridCache map[page.ValuePtr]uint64) (uint64, error) {
+func (db *DB) lookupCommandWALValueLogRID(ptr page.ValuePtr, ridCache *rawKVCommandWALRIDCache) (uint64, error) {
 	if db == nil || db.valueLogManager == nil {
 		return 0, fmt.Errorf("treedb: command wal raw kv pointer rid reader unavailable (file=%d offset=%d len=%d)", ptr.FileID, ptr.Offset, ptr.Length)
 	}
@@ -717,7 +803,7 @@ func (db *DB) lookupCommandWALValueLogRID(ptr page.ValuePtr, ridCache map[page.V
 	if ridCache == nil {
 		return 0, fmt.Errorf("treedb: command wal raw kv rid cache unavailable")
 	}
-	if rid, ok := ridCache[ptr]; ok {
+	if rid, ok := ridCache.lookup(ptr); ok {
 		return rid, nil
 	}
 	rid, err := db.valueLogManager.ReadRIDUnverified(ptr)
@@ -730,7 +816,7 @@ func (db *DB) lookupCommandWALValueLogRID(ptr page.ValuePtr, ridCache map[page.V
 	if err != nil {
 		return 0, err
 	}
-	ridCache[ptr] = rid
+	ridCache.store(ptr, rid)
 	return rid, nil
 }
 
@@ -1168,6 +1254,9 @@ func (db *DB) appendCommandWALIntent(intent *commandWALBatchIntent, sync bool) (
 	}
 	if db.commandWALFlushPoisoned.Load() {
 		return 0, fmt.Errorf("%w: command wal post-append failure; reopen required", ErrRecoveryRequired)
+	}
+	if intent.rawKVDirect && intent.rawKVRIDCache != nil {
+		defer intent.rawKVRIDCache.release()
 	}
 	if intent.externalRefs {
 		// SetRID frames reference value-log positions by offset. The

--- a/TreeDB/db/command_wal_raw_test.go
+++ b/TreeDB/db/command_wal_raw_test.go
@@ -90,6 +90,54 @@ func TestCommandWALIntentRawKVPayloadSetsMaxEntryRevision(t *testing.T) {
 	}
 }
 
+func TestRawKVCommandWALRIDCacheUsesInlinePrefixAndOverflow(t *testing.T) {
+	cache := makeRawKVCommandWALRIDCache(1024)
+	for i := 0; i < rawKVCommandWALRIDInlineCacheEntries+1; i++ {
+		ptr := page.ValuePtr{FileID: page.ValueLogFileID(uint32(i + 1)), Offset: uint64(i + 1), Length: 8}
+		cache.store(ptr, uint64(i+10))
+	}
+
+	first := page.ValuePtr{FileID: page.ValueLogFileID(1), Offset: 1, Length: 8}
+	if got, ok := cache.lookup(first); !ok || got != 10 {
+		t.Fatalf("lookup first=(%d,%t), want (10,true)", got, ok)
+	}
+
+	lastInline := page.ValuePtr{
+		FileID: page.ValueLogFileID(rawKVCommandWALRIDInlineCacheEntries),
+		Offset: uint64(rawKVCommandWALRIDInlineCacheEntries),
+		Length: 8,
+	}
+	if got, ok := cache.lookup(lastInline); !ok || got != uint64(rawKVCommandWALRIDInlineCacheEntries+9) {
+		t.Fatalf("lookup last inline=(%d,%t), want (%d,true)", got, ok, rawKVCommandWALRIDInlineCacheEntries+9)
+	}
+
+	overflow := page.ValuePtr{
+		FileID: page.ValueLogFileID(rawKVCommandWALRIDInlineCacheEntries + 1),
+		Offset: uint64(rawKVCommandWALRIDInlineCacheEntries + 1),
+		Length: 8,
+	}
+	if got, ok := cache.lookup(overflow); !ok || got != uint64(rawKVCommandWALRIDInlineCacheEntries+10) {
+		t.Fatalf("lookup overflow=(%d,%t), want (%d,true)", got, ok, rawKVCommandWALRIDInlineCacheEntries+10)
+	}
+	if cache.overflow == nil {
+		t.Fatal("overflow map is nil after overflow store")
+	}
+	if got := cache.overflowCount; got != 1 {
+		t.Fatalf("overflow count=%d, want 1", got)
+	}
+
+	cache.release()
+	if got, ok := cache.lookup(first); ok || got != 0 {
+		t.Fatalf("lookup after release=(%d,%t), want (0,false)", got, ok)
+	}
+	if cache.overflow != nil {
+		t.Fatal("overflow map retained after release")
+	}
+	if got := cache.overflowCount; got != 0 {
+		t.Fatalf("overflow count after release=%d, want 0", got)
+	}
+}
+
 func TestTrustedCommandWALIntentAppendsCanonicalCollectionPayload(t *testing.T) {
 	dir := t.TempDir()
 	d, err := Open(Options{Dir: dir, CommandWAL: true, DisableBackgroundPrune: true})

--- a/TreeDB/db/command_wal_recovery_bench_test.go
+++ b/TreeDB/db/command_wal_recovery_bench_test.go
@@ -1,10 +1,14 @@
 package db
 
 import (
+	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/snissn/gomap/TreeDB/internal/commitlog"
+	"github.com/snissn/gomap/TreeDB/internal/valuelog"
+	"github.com/snissn/gomap/TreeDB/page"
 )
 
 func BenchmarkCommandWALRawKVDirectWrite(b *testing.B) {
@@ -104,6 +108,54 @@ func BenchmarkCommandWALRawKVPointerDirectWrite(b *testing.B) {
 				batch := db.NewBatch().(*Batch)
 				if err := batch.SetPointer(key, ptr); err != nil {
 					b.Fatalf("SetPointer: %v", err)
+				}
+				if err := batch.Write(); err != nil {
+					b.Fatalf("Write: %v", err)
+				}
+				if err := batch.Close(); err != nil {
+					b.Fatalf("Close batch: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkCommandWALRawKVPointerBatchDirectWrite(b *testing.B) {
+	value := []byte("bench-value-backed-by-value-log")
+	for _, tc := range []struct {
+		name   string
+		unique bool
+	}{
+		{name: "repeated_pointer_256", unique: false},
+		{name: "unique_pointers_256", unique: true},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			dir := b.TempDir()
+			ptrs := writeValueLogRIDBatch(b, dir, 256, value)
+			if !tc.unique {
+				ptr := ptrs[0]
+				for i := range ptrs {
+					ptrs[i] = ptr
+				}
+			}
+			db, err := Open(Options{Dir: dir, CommandWAL: true, DisableBackgroundPrune: true})
+			if err != nil {
+				b.Fatalf("Open: %v", err)
+			}
+			defer db.Close()
+			keys := make([][]byte, len(ptrs))
+			for i := range keys {
+				keys[i] = []byte(fmt.Sprintf("bench-pointer-key-%06d", i))
+			}
+			b.ReportAllocs()
+			b.SetBytes(int64(len(ptrs) * (len(keys[0]) + len(value))))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				batch := db.NewBatch().(*Batch)
+				for j := range ptrs {
+					if err := batch.SetPointer(keys[j], ptrs[j]); err != nil {
+						b.Fatalf("SetPointer: %v", err)
+					}
 				}
 				if err := batch.Write(); err != nil {
 					b.Fatalf("Write: %v", err)
@@ -234,4 +286,34 @@ func commandWALBenchRawKVPayload(b testing.TB, ops int, valueSize int) []byte {
 		b.Fatalf("EncodeRawKVBatchPayload: %v", err)
 	}
 	return payload
+}
+
+func writeValueLogRIDBatch(t testing.TB, dir string, count int, value []byte) []page.ValuePtr {
+	t.Helper()
+	valueLogDir := resolveStorageLayout(dir).valueVLogDir
+	if err := os.MkdirAll(valueLogDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll value_vlog: %v", err)
+	}
+	fileID, err := valuelog.EncodeFileID(0, 1)
+	if err != nil {
+		t.Fatalf("EncodeFileID: %v", err)
+	}
+	path := filepath.Join(valueLogDir, "value-l0-000001.log")
+	w, err := valuelog.NewWriter(path, fileID)
+	if err != nil {
+		t.Fatalf("New value writer: %v", err)
+	}
+	ptrs := make([]page.ValuePtr, count)
+	for i := range ptrs {
+		ptr, err := w.Append(0, nil, uint64(i+1), value)
+		if err != nil {
+			_ = w.Close()
+			t.Fatalf("Append value log: %v", err)
+		}
+		ptrs[i] = ptr
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close value writer: %v", err)
+	}
+	return ptrs
 }

--- a/TreeDB/db/command_wal_recovery_bench_test.go
+++ b/TreeDB/db/command_wal_recovery_bench_test.go
@@ -290,6 +290,11 @@ func commandWALBenchRawKVPayload(b testing.TB, ops int, valueSize int) []byte {
 
 func writeValueLogRIDBatch(t testing.TB, dir string, count int, value []byte) []page.ValuePtr {
 	t.Helper()
+	return writeValueLogRIDBatchFrom(t, dir, 1, count, value)
+}
+
+func writeValueLogRIDBatchFrom(t testing.TB, dir string, firstRID uint64, count int, value []byte) []page.ValuePtr {
+	t.Helper()
 	valueLogDir := resolveStorageLayout(dir).valueVLogDir
 	if err := os.MkdirAll(valueLogDir, 0o755); err != nil {
 		t.Fatalf("MkdirAll value_vlog: %v", err)
@@ -305,7 +310,7 @@ func writeValueLogRIDBatch(t testing.TB, dir string, count int, value []byte) []
 	}
 	ptrs := make([]page.ValuePtr, count)
 	for i := range ptrs {
-		ptr, err := w.Append(0, nil, uint64(i+1), value)
+		ptr, err := w.Append(0, nil, firstRID+uint64(i), value)
 		if err != nil {
 			_ = w.Close()
 			t.Fatalf("Append value log: %v", err)

--- a/TreeDB/db/command_wal_recovery_test.go
+++ b/TreeDB/db/command_wal_recovery_test.go
@@ -13,7 +13,6 @@ import (
 
 	batchpkg "github.com/snissn/gomap/TreeDB/batch"
 	"github.com/snissn/gomap/TreeDB/internal/commitlog"
-	"github.com/snissn/gomap/TreeDB/internal/valuelog"
 	"github.com/snissn/gomap/TreeDB/page"
 )
 
@@ -1703,26 +1702,5 @@ func writeCommandWALRawKVFrameForLane(t testing.TB, dir string, lane int, segmen
 
 func writeValueLogRID(t testing.TB, dir string, rid uint64, value []byte) page.ValuePtr {
 	t.Helper()
-	valueLogDir := resolveStorageLayout(dir).valueVLogDir
-	if err := os.MkdirAll(valueLogDir, 0o755); err != nil {
-		t.Fatalf("MkdirAll value_vlog: %v", err)
-	}
-	fileID, err := valuelog.EncodeFileID(0, 1)
-	if err != nil {
-		t.Fatalf("EncodeFileID: %v", err)
-	}
-	path := filepath.Join(valueLogDir, "value-l0-000001.log")
-	w, err := valuelog.NewWriter(path, fileID)
-	if err != nil {
-		t.Fatalf("New value writer: %v", err)
-	}
-	ptr, err := w.Append(0, nil, rid, value)
-	if err != nil {
-		_ = w.Close()
-		t.Fatalf("Append value log: %v", err)
-	}
-	if err := w.Close(); err != nil {
-		t.Fatalf("Close value writer: %v", err)
-	}
-	return ptr
+	return writeValueLogRIDBatchFrom(t, dir, rid, 1, value)[0]
 }


### PR DESCRIPTION
## Summary

- replaces the raw-KV command-WAL value-log RID cache map with a small inline cache plus pooled overflow map
- releases direct command-WAL RID cache state after the append scanner is consumed
- adds coverage for inline/overflow cache reset behavior
- adds a pointer-batch command-WAL benchmark for repeated and unique value-log pointers

Refs #3505
Parent tracker: #3475

## Scope

This is a focused M7 allocation PR for command-WAL raw-KV pointer batches. It does not change value-log pointer durability, command frame format, replay semantics, or public APIs.

## Tests

```sh
GOWORK=off TMPDIR=/mnt/fast4tb/tmp GOCACHE=/mnt/fast4tb/go-cache GOMODCACHE=/mnt/fast4tb/go/pkg/mod GOPATH=/mnt/fast4tb/go \
  go test ./TreeDB/db -run 'TestRawKVCommandWALRIDCache|TestRawKVCommandWALIntent|TestAppendRawKV|TestTrustedCommandWALIntent|TestCommandWALIntentRawKVPayloadSetsMaxEntryRevision' -count=1
```

Result: passed.

```sh
GOWORK=off TMPDIR=/mnt/fast4tb/tmp GOCACHE=/mnt/fast4tb/go-cache GOMODCACHE=/mnt/fast4tb/go/pkg/mod GOPATH=/mnt/fast4tb/go \
  go test ./TreeDB/internal/commitlog ./TreeDB/db -count=1
```

Result: passed.

## Benchmarks

Baseline: `origin/main` at `01aea5e846b8f29874060ebfbe37381438b02894`.
Candidate: this branch at `083d2620b`.
Host: 11th Gen Intel Core i5-11400F.
Artifact dir: `/mnt/fast4tb/gomap-profiles/alloc-loop-3505-rid-cache-hybrid-20260705T112730HST`.

Command:

```sh
GOWORK=off TMPDIR=/mnt/fast4tb/tmp GOCACHE=/mnt/fast4tb/go-cache GOMODCACHE=/mnt/fast4tb/go/pkg/mod GOPATH=/mnt/fast4tb/go \
  go test ./TreeDB/db -run '^$' \
  -bench 'BenchmarkCommandWALRawKVPointer(DirectWrite|BatchDirectWrite)/(command_wal_raw_kv_pointer|repeated_pointer_256|unique_pointers_256)$' \
  -benchmem -count=7
```

| Benchmark | sec/op delta | B/op delta | allocs/op delta | Notes |
| --- | ---: | ---: | ---: | --- |
| `command_wal_raw_kv_pointer` | -2.03% | -0.67% | -1.37% | single pointer write |
| `repeated_pointer_256` | -6.02% | -22.70% | -2.44% | repeated RID cache hit path |
| `unique_pointers_256` | ~, p=0.318 | -22.66% | -2.44% | unique pointer batch, runtime neutral |
| geomean | -2.49% | -15.95% | -2.08% | final cheap-pool patch |

Steady unified-bench no-profile gate, separate baseline/candidate binaries:

```sh
./unified-bench -dbs treedb_public_command_wal -profile durable \
  -test batch_write_steady -keys 1000000 -batchsize 256 -valsize 256 \
  -val-pattern medium_compressible_sparse -val-pool-size 4096 \
  -treedb-force-value-pointers -treedb-vlog-compression=block \
  -treedb-vlog-block-codec=lz4 -checkpoint-every-bytes 16777216 \
  -checkpoint-between-tests -path-label native-fastpath -progress=false \
  -format markdown -max-wall 10m
```

Result: baseline mean `340,046` ops/s, candidate mean `337,395` ops/s, delta `-0.78%` across three paired runs. Treated as neutral/no material throughput regression for this narrow allocation PR.

## Risk

The main risk is direct command-WAL scanner cache lifetime. The cache is released only after `appendCommandWALIntent` consumes the direct scanner. Payload-backed intents do not retain the direct cache.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command WAL RID caching to handle both small and larger batches more efficiently.
  * Added safer cache cleanup so temporary data is released after use.
  * Preserved existing retry behavior when resolving value-log references.
* **Tests**
  * Added coverage for cache behavior across inline and overflow entries.
  * Added a benchmark for direct batch writes of value-log pointers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->