### PR TITLE
treedb: right-size hash sorted pending keys

### DIFF
--- a/TreeDB/internal/memtable/hash_sorted.go
+++ b/TreeDB/internal/memtable/hash_sorted.go
@@ -953,8 +953,9 @@ func (m *HashSorted) notePendingKeyOrderLocked(key string) {
 func (m *HashSorted) noteNewKeyLocked(key string) (chunk []string, seq uint64) {
 	m.sortedValid = false
 	if m.pendingKeys == nil {
-		m.pendingKeys = make([]string, 0, hashSortedSealKeysThreshold)
+		m.pendingKeys = make([]string, 0, hashSortedPendingKeysInitialCap(1))
 	}
+	m.maybeUpgradePendingKeysLocked(1)
 	m.notePendingKeyOrderLocked(key)
 	m.pendingKeys = append(m.pendingKeys, key)
 	m.pendingBytes += len(key)
@@ -976,11 +977,9 @@ func (m *HashSorted) noteNewKeysBatchLocked(keys []string, keyBytes int, keysSor
 	}
 	m.sortedValid = false
 	if m.pendingKeys == nil {
-		c := hashSortedSealKeysThreshold
-		if len(keys) > c {
-			c = len(keys)
-		}
-		m.pendingKeys = make([]string, 0, c)
+		m.pendingKeys = make([]string, 0, hashSortedPendingKeysInitialCap(len(keys)))
+	} else {
+		m.maybeUpgradePendingKeysLocked(len(keys))
 	}
 	if len(m.pendingKeys) == 0 {
 		m.pendingSorted = keysSorted
@@ -1000,6 +999,46 @@ func (m *HashSorted) noteNewKeysBatchLocked(keys []string, keyBytes int, keysSor
 	m.pendingSorted = false
 	m.nextSeq++
 	return chunk, m.nextSeq, sorted
+}
+
+func hashSortedPendingKeysInitialCap(keys int) int {
+	if keys >= hashSortedPendingKeysUpgradeThreshold {
+		if keys > hashSortedSealKeysThreshold {
+			return keys
+		}
+		return hashSortedSealKeysThreshold
+	}
+	if keys > hashSortedPendingKeysInitCap {
+		return keys
+	}
+	return hashSortedPendingKeysInitCap
+}
+
+func (m *HashSorted) maybeUpgradePendingKeysLocked(additional int) {
+	if additional <= 0 {
+		return
+	}
+	required := len(m.pendingKeys) + additional
+	if required >= hashSortedPendingKeysUpgradeThreshold {
+		if cap(m.pendingKeys) >= hashSortedSealKeysThreshold {
+			return
+		}
+		nextCap := hashSortedSealKeysThreshold
+		if required > nextCap {
+			nextCap = required
+		}
+		next := make([]string, len(m.pendingKeys), nextCap)
+		copy(next, m.pendingKeys)
+		m.pendingKeys = next
+		return
+	}
+	if required <= cap(m.pendingKeys) {
+		return
+	}
+	nextCap := hashSortedPendingKeysUpgradeThreshold
+	next := make([]string, len(m.pendingKeys), nextCap)
+	copy(next, m.pendingKeys)
+	m.pendingKeys = next
 }
 
 func (m *HashSorted) setEntryLocked(key, value []byte, ptr page.ValuePtr, flags byte, revision page.EntryRevision, steal bool) ([]string, uint64) {

--- a/TreeDB/internal/memtable/hash_sorted_fastpath_test.go
+++ b/TreeDB/internal/memtable/hash_sorted_fastpath_test.go
@@ -183,6 +183,99 @@ func TestHashSortedApplyCopySortedBatchTrusted_ConsecutiveSortedPendingChunkMark
 	}
 }
 
+func TestHashSortedPendingKeysSmallSingleStartsSmall(t *testing.T) {
+	m := NewHashSorted()
+	m.Set([]byte("key"), []byte("value"))
+
+	m.mu.RLock()
+	gotLen := len(m.pendingKeys)
+	gotCap := cap(m.pendingKeys)
+	m.mu.RUnlock()
+
+	if gotLen != 1 {
+		t.Fatalf("pending len=%d want 1", gotLen)
+	}
+	if gotCap != hashSortedPendingKeysInitCap {
+		t.Fatalf("pending cap=%d want %d", gotCap, hashSortedPendingKeysInitCap)
+	}
+}
+
+func TestHashSortedPendingKeysSmallBatchStartsSmall(t *testing.T) {
+	const batchSize = 32
+	m := NewHashSorted()
+	m.ApplyCopySortedBatchTrusted(hashSortedTestEntries(batchSize), false, true, nil)
+
+	m.mu.RLock()
+	gotLen := len(m.pendingKeys)
+	gotCap := cap(m.pendingKeys)
+	m.mu.RUnlock()
+
+	if gotLen != batchSize {
+		t.Fatalf("pending len=%d want %d", gotLen, batchSize)
+	}
+	if gotCap != hashSortedPendingKeysInitCap {
+		t.Fatalf("pending cap=%d want %d", gotCap, hashSortedPendingKeysInitCap)
+	}
+}
+
+func TestHashSortedPendingKeysUpgradeThresholdPreallocatesSealCap(t *testing.T) {
+	const batchSize = hashSortedPendingKeysUpgradeThreshold
+	m := NewHashSorted()
+	m.ApplyCopySortedBatchTrusted(hashSortedTestEntries(batchSize), false, true, nil)
+
+	m.mu.RLock()
+	gotLen := len(m.pendingKeys)
+	gotCap := cap(m.pendingKeys)
+	m.mu.RUnlock()
+
+	if gotLen != batchSize {
+		t.Fatalf("pending len=%d want %d", gotLen, batchSize)
+	}
+	if gotCap != hashSortedSealKeysThreshold {
+		t.Fatalf("pending cap=%d want %d", gotCap, hashSortedSealKeysThreshold)
+	}
+}
+
+func TestHashSortedPendingKeysSealHandoffUsesFreshBackingArray(t *testing.T) {
+	indexer := &HashSortedIndexer{ch: make(chan hashSortedIndexWork, 1)}
+	m := NewHashSortedWithCapacityAndIndexer(0, indexer)
+
+	m.ApplyCopySortedBatchTrusted(hashSortedTestEntries(hashSortedSealKeysThreshold), false, true, nil)
+
+	var work hashSortedIndexWork
+	select {
+	case work = <-indexer.ch:
+	default:
+		t.Fatalf("expected sealed pending-key chunk")
+	}
+	if len(work.keys) != hashSortedSealKeysThreshold {
+		t.Fatalf("sealed chunk len=%d want %d", len(work.keys), hashSortedSealKeysThreshold)
+	}
+	sealedFirst := work.keys[0]
+	sealedLast := work.keys[len(work.keys)-1]
+	sealedBacking := &work.keys[0]
+
+	m.Set([]byte("z-next"), []byte("value"))
+
+	m.mu.RLock()
+	pendingLen := len(m.pendingKeys)
+	var pendingBacking *string
+	if pendingLen > 0 {
+		pendingBacking = &m.pendingKeys[0]
+	}
+	m.mu.RUnlock()
+
+	if pendingLen != 1 {
+		t.Fatalf("pending len after post-seal append=%d want 1", pendingLen)
+	}
+	if pendingBacking == sealedBacking {
+		t.Fatalf("post-seal append reused sealed chunk backing array")
+	}
+	if work.keys[0] != sealedFirst || work.keys[len(work.keys)-1] != sealedLast {
+		t.Fatalf("sealed chunk mutated after post-seal append: first=%q/%q last=%q/%q", work.keys[0], sealedFirst, work.keys[len(work.keys)-1], sealedLast)
+	}
+}
+
 func BenchmarkHashSortedApplyCopySortedBatchTrusted(b *testing.B) {
 	const batchSize = 32
 	const valueSize = 128
@@ -215,4 +308,52 @@ func BenchmarkHashSortedApplyCopySortedBatchTrusted(b *testing.B) {
 			}
 		})
 	}
+}
+
+func BenchmarkHashSortedPendingKeys(b *testing.B) {
+	value := []byte("value")
+
+	b.Run("single_key", func(b *testing.B) {
+		key := []byte("key")
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			m := NewHashSorted()
+			m.Set(key, value)
+		}
+	})
+
+	for _, tc := range []struct {
+		name string
+		n    int
+	}{
+		{name: "small_batch_32", n: 32},
+		{name: "upgrade_threshold_4096", n: hashSortedPendingKeysUpgradeThreshold},
+		{name: "seal_threshold_32768", n: hashSortedSealKeysThreshold},
+	} {
+		tc := tc
+		b.Run(tc.name, func(b *testing.B) {
+			entries := hashSortedTestEntries(tc.n)
+			indexer := &HashSortedIndexer{ch: make(chan hashSortedIndexWork, 1)}
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				m := NewHashSortedWithCapacityAndIndexer(0, indexer)
+				m.ApplyCopySortedBatchTrusted(entries, false, true, nil)
+				if tc.n >= hashSortedSealKeysThreshold {
+					<-indexer.ch
+				}
+			}
+		})
+	}
+}
+
+func hashSortedTestEntries(n int) []batchpkg.Entry {
+	entries := make([]batchpkg.Entry, n)
+	for i := range entries {
+		entries[i] = batchpkg.Entry{
+			Type:  batchpkg.OpPut,
+			Key:   []byte(fmt.Sprintf("k%08d", i)),
+			Value: []byte("value"),
+		}
+	}
+	return entries
 }


### PR DESCRIPTION
## Linked Issues

- Fixes #3509
- Parent tracker: #3475
- Predecessor #3505 / PR #3508 merged into `main` as `51755c4b3cbf54e665afd54a28fe211bf670923f`.

## Scope

Right-sizes `HashSorted.pendingKeys` allocation so small single-key and small batch paths no longer allocate the full `hashSortedSealKeysThreshold` buffer on first use.

The async indexer ownership boundary is preserved: sealed chunks are handed off by backing array, and later appends allocate fresh pending-key storage rather than mutating the sealed chunk.

## Changed Files

- `TreeDB/internal/memtable/hash_sorted.go`
- `TreeDB/internal/memtable/hash_sorted_fastpath_test.go`

## Tests

```sh
GOWORK=off TMPDIR=/mnt/fast4tb/tmp GOCACHE=/mnt/fast4tb/go-cache GOMODCACHE=/mnt/fast4tb/go/pkg/mod GOPATH=/mnt/fast4tb/go \
  go test ./TreeDB/internal/memtable \
  -run 'TestHashSortedPendingKeys|TestHashSortedApplyCopySortedBatchTrusted_(MixedPendingChunkNotMarkedSorted|ConsecutiveSortedPendingChunkMarkedSorted)' \
  -count=1
```

Passed after updating the branch onto post-#3508 `main`.

```sh
GOWORK=off TMPDIR=/mnt/fast4tb/tmp GOCACHE=/mnt/fast4tb/go-cache GOMODCACHE=/mnt/fast4tb/go/pkg/mod GOPATH=/mnt/fast4tb/go \
  go test ./TreeDB/internal/memtable -count=1
```

Passed after updating the branch onto post-#3508 `main`.

```sh
GOWORK=off TMPDIR=/mnt/fast4tb/tmp GOCACHE=/mnt/fast4tb/go-cache GOMODCACHE=/mnt/fast4tb/go/pkg/mod GOPATH=/mnt/fast4tb/go \
  go test ./cmd/unified_bench -run 'Test.*Profile|Test.*Flag|Test.*Suite' -count=1
```

Passed after updating the branch onto post-#3508 `main`.

```sh
git diff --check
```

Passed.

## Focused Benchmark Evidence

Post-#3508 rerun artifact:

- `/mnt/fast4tb/gomap-profiles/hashsorted-3509-post3508-rerun2-20260705T223022Z`

The baseline is `origin/main` at `51755c4b3cbf54e665afd54a28fe211bf670923f` with only the benchmark/test file overlaid. Candidate is this PR head `0fe938394`.

| Benchmark | sec/op | B/op | allocs/op |
| --- | ---: | ---: | ---: |
| `PendingKeys/single_key` | -37.60% | -87.95% | ~ |
| `PendingKeys/small_batch_32` | -59.33% | -86.84% | ~ |
| `PendingKeys/upgrade_threshold_4096` | -5.13% | ~ | ~ |
| `PendingKeys/seal_threshold_32768` | -2.46% | ~ | ~ |
| `ApplyCopySortedBatchTrusted/copy_values` | ~ | ~ | ~ |
| `ApplyCopySortedBatchTrusted/borrow_values` | ~ | ~ | ~ |
| geomean | -21.63% | -49.82% | ~ |

## Unified-Bench Throughput Gate

Post-#3508 artifact root:

- `/mnt/fast4tb/gomap-profiles/hashsorted-3509-post3508-unified-20260705T223355Z`

One-shot full row:

| Workload | Baseline ops/s | Candidate ops/s | Notes |
| --- | ---: | ---: | --- |
| Batch Random | 247,193 | 246,872 | neutral |
| Update ForkChoice | 19,342 | 18,604 | noisy; isolated reverse repeats are neutral |
| Batch Write Steady | 311,943 | 271,706 | noisy; isolated repeats are order-dependent/neutral |

Follow-up isolated repeats:

| Workload | Repeat shape | Baseline | Candidate | Assessment |
| --- | --- | ---: | ---: | --- |
| Batch Write Steady | reverse-order median, 5 pairs | 338,295 | 338,754 | neutral |
| Batch Write Steady | combined median, 8 pairs | 347,737 | 340,591 | small/noisy |
| Update ForkChoice | reverse-order median, 3 pairs | 18,662 | 18,565 | neutral (-0.5%) |

A two-row sequence, `dataset_update_fork_choice,batch_write_steady`, failed for both baseline and candidate with:

```text
batch_write_steady checkpoint: cachingdb: flush failed: zipper: span-native reducer validation failed: no replacement changed root
```

That sequence failure is not candidate-specific, so it is recorded as a separate validation/harness finding rather than a #3510 regression.

Assessment: the focused allocation win is large and stable. The representative throughput gate does not show an accepted material candidate-specific regression after isolated repeats; the remaining noisy/failing sequence should be tracked separately.

## Review / Merge Status

- Branch has been updated onto post-#3508 `main` without force-push.
- Local tests and focused benchmarks passed on the final base.
- Latest-head CI is green on `0fe938394`.
- CodeRabbit status check is passing on the final head; a manual CodeRabbit review request was rate-limited earlier.
- Codex and Copilot reviews are being requested after this mature evidence update.
