### PR TITLE
treedb: omit span-native prepare op key copies

### DIFF
--- a/TreeDB/zipper/read_only_prepare.go
+++ b/TreeDB/zipper/read_only_prepare.go
@@ -123,6 +123,11 @@ type ReadOnlyPrepareOptions struct {
 	// because range-overlap planning needs exact span bounds.
 	OmitKeys bool
 
+	// OmitOpKeys skips copying FirstOpKey/LastOpKey while retaining LowKey/HighKey.
+	// It is for execution paths that need exact span boundaries plus point index
+	// ranges but do not consume the duplicated point key metadata.
+	OmitOpKeys bool
+
 	// DiscardLeafSpans streams spans to LeafSpanCallback without retaining them in
 	// the result. It is only for aggregate/chunk planning callers that do not need
 	// ValidateLeafSpans or exact span ownership after PrepareReadOnlyPlan returns.
@@ -150,7 +155,8 @@ type ReadOnlyLeafSpan struct {
 
 	// LowKey is the inclusive lower bound for the leaf span. HighKey is the
 	// exclusive upper bound. A nil bound is open-ended. Non-nil bound slices and
-	// op-key slices are owned by ReadOnlyPrepareResult until ReuseOptions is used.
+	// op-key slices are owned by ReadOnlyPrepareResult until ReuseOptions is used,
+	// except that OmitOpKeys may intentionally leave FirstOpKey/LastOpKey nil.
 	LowKey  []byte
 	HighKey []byte
 
@@ -245,6 +251,7 @@ type ReadOnlyPrepareResult struct {
 	ColdBuild    bool
 	Maintenance  bool
 	OmitKeys     bool
+	OmitOpKeys   bool
 
 	// ExactLeafSpans is true when LeafSpans fully describe the existing leaves
 	// touched by the delta. Delete-containing maintenance can merge/rebalance
@@ -413,9 +420,10 @@ func readOnlyPrepareCeilDiv64(n, d int64) int64 {
 // The returned options must not be used while r's LeafSpans are still needed.
 func (r ReadOnlyPrepareResult) ReuseOptions() ReadOnlyPrepareOptions {
 	return ReadOnlyPrepareOptions{
-		OmitKeys:  r.OmitKeys,
-		leafSpans: clearReadOnlyLeafSpanBuffer(r.LeafSpans),
-		keyArena:  r.keyArena[:0],
+		OmitKeys:   r.OmitKeys,
+		OmitOpKeys: r.OmitOpKeys,
+		leafSpans:  clearReadOnlyLeafSpanBuffer(r.LeafSpans),
+		keyArena:   r.keyArena[:0],
 	}
 }
 
@@ -439,9 +447,10 @@ func (r *ReadOnlyPrepareResult) ResetForReuse() {
 		return
 	}
 	omitKeys := r.OmitKeys
+	omitOpKeys := r.OmitOpKeys
 	leafSpans := r.LeafSpans
 	keyArena := r.keyArena
-	*r = ReadOnlyPrepareResult{OmitKeys: omitKeys}
+	*r = ReadOnlyPrepareResult{OmitKeys: omitKeys, OmitOpKeys: omitOpKeys}
 	leafSpanKeepCap := readOnlyPrepareResultReuseLeafSpanKeepCap
 	if omitKeys {
 		leafSpanKeepCap = readOnlyPrepareResultReuseOmitKeysLeafSpanKeepCap
@@ -487,6 +496,8 @@ func (r ReadOnlyPrepareResult) ValidateLeafSpans() error {
 	var prevHigh []byte
 	prevPointEnd := -1
 	prevRangeStart := -1
+	omitSpanKeys := r.OmitKeys
+	omitOpKeys := r.OmitKeys || r.OmitOpKeys
 	for i, span := range r.LeafSpans {
 		if span.OpCount <= 0 {
 			return readOnlyPrepareSpanError(i, "has non-positive op count %d", span.OpCount)
@@ -505,7 +516,7 @@ func (r ReadOnlyPrepareResult) ValidateLeafSpans() error {
 		if pointCount+rangeCount != span.OpCount {
 			return readOnlyPrepareSpanError(i, "op count %d does not match point/range counts %d/%d", span.OpCount, span.PointOpCount, span.DeleteRangeCount)
 		}
-		if pointCount > 0 && !r.OmitKeys {
+		if pointCount > 0 && !omitOpKeys {
 			if span.FirstOpKey == nil {
 				return readOnlyPrepareSpanError(i, "has nil first op key")
 			}
@@ -519,7 +530,7 @@ func (r ReadOnlyPrepareResult) ValidateLeafSpans() error {
 				return readOnlyPrepareSpanError(i, "first op key %s is not after previous last op key %s", readOnlyPrepareKeyForError(span.FirstOpKey), readOnlyPrepareKeyForError(prevLastOp))
 			}
 		}
-		if !r.OmitKeys {
+		if !omitSpanKeys {
 			if span.LowKey != nil && span.HighKey != nil && bytes.Compare(span.LowKey, span.HighKey) >= 0 {
 				return readOnlyPrepareSpanError(i, "low key %s is not before high key %s", readOnlyPrepareKeyForError(span.LowKey), readOnlyPrepareKeyForError(span.HighKey))
 			}
@@ -532,21 +543,21 @@ func (r ReadOnlyPrepareResult) ValidateLeafSpans() error {
 			if i > 0 && bytes.Compare(span.LowKey, prevHigh) < 0 {
 				return readOnlyPrepareSpanError(i, "low key %s is before previous high key %s", readOnlyPrepareKeyForError(span.LowKey), readOnlyPrepareKeyForError(prevHigh))
 			}
-			if pointCount > 0 && span.LowKey != nil && bytes.Compare(span.FirstOpKey, span.LowKey) < 0 {
+			if pointCount > 0 && !omitOpKeys && span.LowKey != nil && bytes.Compare(span.FirstOpKey, span.LowKey) < 0 {
 				return readOnlyPrepareSpanError(i, "first op key %s is before low key %s", readOnlyPrepareKeyForError(span.FirstOpKey), readOnlyPrepareKeyForError(span.LowKey))
 			}
-			if pointCount > 0 && span.HighKey != nil && bytes.Compare(span.LastOpKey, span.HighKey) >= 0 {
+			if pointCount > 0 && !omitOpKeys && span.HighKey != nil && bytes.Compare(span.LastOpKey, span.HighKey) >= 0 {
 				return readOnlyPrepareSpanError(i, "last op key %s is not before high key %s", readOnlyPrepareKeyForError(span.LastOpKey), readOnlyPrepareKeyForError(span.HighKey))
 			}
 		}
 		if pointCount > 0 {
 			pointWidth := span.PointOpEnd - span.PointOpStart
-			if r.OmitKeys {
+			if omitOpKeys {
 				if span.PointOpStart < 0 || span.PointOpEnd < 0 {
 					return readOnlyPrepareSpanError(i, "point index range [%d,%d) has negative bound", span.PointOpStart, span.PointOpEnd)
 				}
 				if pointWidth <= 0 {
-					return readOnlyPrepareSpanError(i, "point index range [%d,%d) is empty under omit-keys planning", span.PointOpStart, span.PointOpEnd)
+					return readOnlyPrepareSpanError(i, "point index range [%d,%d) is empty under omitted op-key planning", span.PointOpStart, span.PointOpEnd)
 				}
 				if pointWidth != pointCount {
 					return readOnlyPrepareSpanError(i, "point index range [%d,%d) does not match point count %d", span.PointOpStart, span.PointOpEnd, pointCount)
@@ -556,7 +567,7 @@ func (r ReadOnlyPrepareResult) ValidateLeafSpans() error {
 					expectedStart = prevPointEnd
 				}
 				if span.PointOpStart != expectedStart {
-					return readOnlyPrepareSpanError(i, "point index range [%d,%d) starts at %d, want %d under omit-keys planning", span.PointOpStart, span.PointOpEnd, span.PointOpStart, expectedStart)
+					return readOnlyPrepareSpanError(i, "point index range [%d,%d) starts at %d, want %d under omitted op-key planning", span.PointOpStart, span.PointOpEnd, span.PointOpStart, expectedStart)
 				}
 				prevPointEnd = span.PointOpEnd
 			} else if pointWidth > 0 {
@@ -583,15 +594,17 @@ func (r ReadOnlyPrepareResult) ValidateLeafSpans() error {
 		}
 		totalPointOps += pointCount
 		totalSpanOps += span.OpCount
-		if !r.OmitKeys {
+		if !omitOpKeys {
 			if pointCount > 0 {
 				prevLastOp = span.LastOpKey
 			}
+		}
+		if !omitSpanKeys {
 			prevHigh = span.HighKey
 		}
 	}
-	if r.OmitKeys && totalPointOps > 0 && prevPointEnd != r.PointOps {
-		return fmt.Errorf("zipper: read-only omit-keys leaf spans end at point op %d, want %d", prevPointEnd, r.PointOps)
+	if omitOpKeys && totalPointOps > 0 && prevPointEnd != r.PointOps {
+		return fmt.Errorf("zipper: read-only omitted op-key leaf spans end at point op %d, want %d", prevPointEnd, r.PointOps)
 	}
 	if r.PointOps > 0 {
 		if totalPointOps != r.PointOps {
@@ -637,6 +650,13 @@ func (r *ReadOnlyPrepareResult) cloneKey(src []byte) []byte {
 	return r.keyArena[start : start+len(src)]
 }
 
+func (r *ReadOnlyPrepareResult) cloneOpKey(src []byte) []byte {
+	if r != nil && (r.OmitKeys || r.OmitOpKeys) {
+		return nil
+	}
+	return r.cloneKey(src)
+}
+
 func readOnlyPrepareEntryBytes(op batch.Entry) int {
 	n := len(op.Key)
 	if op.IsPtr {
@@ -670,6 +690,15 @@ func (r *ReadOnlyPrepareResult) ensureInitialCapacity(ops []batch.Entry, ranges 
 	}
 	if !r.OmitKeys {
 		keyHintUnits := len(ops) + len(ranges)
+		if r.OmitOpKeys {
+			keyHintUnits = len(ranges)
+			if len(ops) > 0 {
+				// Boundary copies scale with touched leaf/internal span count rather
+				// than point-op count. Keep the hint below the full op-key path while
+				// avoiding repeated arena growth for sparse many-leaf plans.
+				keyHintUnits += len(ops)/16 + 2
+			}
+		}
 		keyHint := 0
 		if keyHintUnits > 0 {
 			if keyHintUnits > readOnlyPrepareResultReuseKeyArenaKeepCap/32 {
@@ -701,8 +730,8 @@ func (r *ReadOnlyPrepareResult) addLeafSpan(ref page.ChildRef, low, high []byte,
 		DeleteRangeEnd:   rangeBase + len(ranges),
 	}
 	if len(ops) > 0 {
-		span.FirstOpKey = r.cloneKey(ops[0].Key)
-		span.LastOpKey = r.cloneKey(ops[len(ops)-1].Key)
+		span.FirstOpKey = r.cloneOpKey(ops[0].Key)
+		span.LastOpKey = r.cloneOpKey(ops[len(ops)-1].Key)
 		for i := range ops {
 			span.ByteCount += readOnlyPrepareEntryBytes(ops[i])
 		}
@@ -854,8 +883,11 @@ func (z *Zipper) ApplyWithOptions(rootID uint64, b *batch.Batch, opts ApplyOptio
 		if opts.SpanNativeApply {
 			// Span-native apply consumes exact leaf span boundaries to distinguish
 			// whole-root from sparse/partial replacement sets. OmitKeys plans use nil
-			// bounds for point-only spans and are planning-only, not execution-safe.
+			// bounds for point-only spans and are planning-only, not execution-safe,
+			// but the execution engine uses canonical point index ranges rather than
+			// duplicated FirstOpKey/LastOpKey metadata.
 			opts.ReadOnlyPrepare.OmitKeys = false
+			opts.ReadOnlyPrepare.OmitOpKeys = true
 			if opts.SpanNativeAllowMaintenancePointOps {
 				opts.ReadOnlyPrepare.AllowMaintenancePointLeafSpans = true
 			}
@@ -930,7 +962,7 @@ func (z *Zipper) ApplyWithOptions(rootID uint64, b *batch.Batch, opts ApplyOptio
 // that future prepared-output paths can run before the final install section.
 func (z *Zipper) PrepareReadOnly(rootID uint64, b *batch.Batch, opts ReadOnlyPrepareOptions) (ReadOnlyPrepareResult, error) {
 	if b == nil {
-		return ReadOnlyPrepareResult{OmitKeys: opts.OmitKeys, LeafSpans: opts.leafSpans[:0], keyArena: opts.keyArena[:0]}, errors.New("zipper: nil batch")
+		return ReadOnlyPrepareResult{OmitKeys: opts.OmitKeys, OmitOpKeys: opts.OmitOpKeys || opts.OmitKeys, LeafSpans: opts.leafSpans[:0], keyArena: opts.keyArena[:0]}, errors.New("zipper: nil batch")
 	}
 	var ops []batch.Entry
 	var ranges []batch.DeleteRange
@@ -951,6 +983,7 @@ func (z *Zipper) PrepareReadOnly(rootID uint64, b *batch.Batch, opts ReadOnlyPre
 func (z *Zipper) PrepareReadOnlyPlan(rootID uint64, ops []batch.Entry, ranges []batch.DeleteRange, opts ReadOnlyPrepareOptions) (ReadOnlyPrepareResult, error) {
 	result := ReadOnlyPrepareResult{
 		OmitKeys:         opts.OmitKeys,
+		OmitOpKeys:       opts.OmitOpKeys || opts.OmitKeys,
 		LeafSpans:        opts.leafSpans[:0],
 		keyArena:         opts.keyArena[:0],
 		discardLeafSpans: opts.DiscardLeafSpans,
@@ -961,6 +994,7 @@ func (z *Zipper) PrepareReadOnlyPlan(rootID uint64, ops []batch.Entry, ranges []
 		// partitioning relies on exact leaf span bounds, so retain keys and report
 		// the effective mode in the result.
 		result.OmitKeys = false
+		result.OmitOpKeys = false
 	}
 	result.RootID = rootID
 	result.PointOps = len(ops)

--- a/TreeDB/zipper/read_only_prepare_test.go
+++ b/TreeDB/zipper/read_only_prepare_test.go
@@ -399,6 +399,79 @@ func TestZipperPrepareReadOnlyOmitKeysSkipsSpanKeyCopies(t *testing.T) {
 	}
 }
 
+func TestZipperPrepareReadOnlyOmitOpKeysKeepsSpanBoundaries(t *testing.T) {
+	_, z := newReadOnlyPrepareZipper(t)
+	rootID := buildReadOnlyPrepareRootWithKeys(t, z, 768)
+
+	delta := batch.New(panicValueReader{}, page.DefaultInlineThreshold)
+	defer func() { _ = delta.Close() }()
+	for _, idx := range []int{0, 127, 128, 255, 256, 511, 767} {
+		if err := delta.Set([]byte(fmt.Sprintf("key-%06d", idx)), []byte("new")); err != nil {
+			t.Fatalf("Set delta: %v", err)
+		}
+	}
+
+	full, err := z.PrepareReadOnly(rootID, delta, ReadOnlyPrepareOptions{})
+	if err != nil {
+		t.Fatalf("PrepareReadOnly full: %v", err)
+	}
+	requireValidReadOnlyPrepare(t, full)
+
+	prepared, err := z.PrepareReadOnly(rootID, delta, ReadOnlyPrepareOptions{OmitOpKeys: true})
+	if err != nil {
+		t.Fatalf("PrepareReadOnly omit op keys: %v", err)
+	}
+	requireValidReadOnlyPrepare(t, prepared)
+	if prepared.OmitKeys {
+		t.Fatalf("prepared OmitKeys=%v want false", prepared.OmitKeys)
+	}
+	if !prepared.OmitOpKeys {
+		t.Fatalf("prepared OmitOpKeys=%v want true", prepared.OmitOpKeys)
+	}
+	if len(prepared.LeafSpans) != len(full.LeafSpans) {
+		t.Fatalf("leaf spans=%d want %d", len(prepared.LeafSpans), len(full.LeafSpans))
+	}
+	var boundaryBytes int
+	pointEnd := 0
+	for i, span := range prepared.LeafSpans {
+		want := full.LeafSpans[i]
+		if !bytes.Equal(span.LowKey, want.LowKey) || !bytes.Equal(span.HighKey, want.HighKey) {
+			t.Fatalf("span %d boundaries mismatch got low/high=%q/%q want %q/%q", i, span.LowKey, span.HighKey, want.LowKey, want.HighKey)
+		}
+		boundaryBytes += len(span.LowKey) + len(span.HighKey)
+		if span.FirstOpKey != nil || span.LastOpKey != nil {
+			t.Fatalf("span %d retained op keys under OmitOpKeys: first=%q last=%q", i, span.FirstOpKey, span.LastOpKey)
+		}
+		if span.PointOpCount <= 0 || span.DeleteRangeCount != 0 {
+			t.Fatalf("span %d counts=%d/%d want point-only", i, span.PointOpCount, span.DeleteRangeCount)
+		}
+		if span.PointOpStart != pointEnd || span.PointOpEnd <= span.PointOpStart {
+			t.Fatalf("span %d point range=[%d,%d) after end %d", i, span.PointOpStart, span.PointOpEnd, pointEnd)
+		}
+		pointEnd = span.PointOpEnd
+	}
+	if boundaryBytes == 0 || len(prepared.keyArena) == 0 {
+		t.Fatalf("omit-op-keys retained boundary bytes=%d keyArena=%d, want exact boundaries", boundaryBytes, len(prepared.keyArena))
+	}
+	if pointEnd != prepared.PointOps {
+		t.Fatalf("omit-op-keys spans cover %d point ops, want %d", pointEnd, prepared.PointOps)
+	}
+
+	reused, err := z.PrepareReadOnly(rootID, delta, prepared.ReuseOptions())
+	if err != nil {
+		t.Fatalf("PrepareReadOnly with reuse options: %v", err)
+	}
+	requireValidReadOnlyPrepare(t, reused)
+	if reused.OmitKeys || !reused.OmitOpKeys {
+		t.Fatalf("reused omit-op-keys result OmitKeys/OmitOpKeys=%v/%v", reused.OmitKeys, reused.OmitOpKeys)
+	}
+	for i, span := range reused.LeafSpans {
+		if span.FirstOpKey != nil || span.LastOpKey != nil {
+			t.Fatalf("reused span %d retained op keys under OmitOpKeys", i)
+		}
+	}
+}
+
 func TestZipperPrepareReadOnlyPlanCallbackCanDiscardSpans(t *testing.T) {
 	_, z := newReadOnlyPrepareZipper(t)
 	rootID := buildReadOnlyPrepareRootWithKeys(t, z, 256)
@@ -774,6 +847,81 @@ func BenchmarkZipperPrepareReadOnlyManyLeafRandomFresh(b *testing.B) {
 	benchmarkZipperPrepareReadOnlyRandomFresh(b, 8192, 1024)
 }
 
+func BenchmarkZipperPrepareReadOnlyManyLeafRandomKeyModes(b *testing.B) {
+	_, z := newReadOnlyPrepareZipper(b)
+	rootID := buildReadOnlyPrepareRootWithKeys(b, z, 8192)
+	delta := batch.NewRetainingLargeEntries(panicValueReader{}, page.DefaultInlineThreshold)
+	defer func() { _ = delta.Close() }()
+	for i := 0; i < 1024; i++ {
+		idx := (i*7919 + 17) % 8192
+		if err := delta.Set([]byte(fmt.Sprintf("key-%06d", idx)), []byte("new-value")); err != nil {
+			b.Fatalf("Set delta: %v", err)
+		}
+	}
+	delta.SortedEntries()
+
+	cases := []struct {
+		name string
+		opts ReadOnlyPrepareOptions
+	}{
+		{name: "full_keys"},
+		{name: "omit_op_keys", opts: ReadOnlyPrepareOptions{OmitOpKeys: true}},
+		{name: "omit_all_keys", opts: ReadOnlyPrepareOptions{OmitKeys: true}},
+	}
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			for _, reusePrepareBuffers := range []bool{true, false} {
+				name := "reuse"
+				if !reusePrepareBuffers {
+					name = "fresh"
+				}
+				b.Run(name, func(b *testing.B) {
+					first, err := z.PrepareReadOnly(rootID, delta, tc.opts)
+					if err != nil {
+						b.Fatalf("initial PrepareReadOnly: %v", err)
+					}
+					requireValidReadOnlyPrepare(b, first)
+					initialSummary := first.LeafSpanSummary()
+					if initialSummary.Spans == 0 || initialSummary.SpanOps == 0 {
+						b.Fatalf("initial prepare spans/ops=%d/%d want non-zero", initialSummary.Spans, initialSummary.SpanOps)
+					}
+					opts := tc.opts
+					if reusePrepareBuffers {
+						opts = first.ReuseOptions()
+					}
+					lastSummary := initialSummary
+					lastKeyArenaBytes := len(first.keyArena)
+					lastBoundaryKeyBytes := readOnlyPrepareSpanBoundaryBytes(first.LeafSpans)
+					lastOpKeyBytes := readOnlyPrepareSpanOpKeyBytes(first.LeafSpans)
+					b.ReportAllocs()
+					b.SetBytes(int64(initialSummary.SpanBytes))
+					b.ResetTimer()
+					for i := 0; i < b.N; i++ {
+						prepared, err := z.PrepareReadOnly(rootID, delta, opts)
+						if err != nil {
+							b.Fatalf("PrepareReadOnly: %v", err)
+						}
+						lastSummary = prepared.LeafSpanSummary()
+						lastKeyArenaBytes = len(prepared.keyArena)
+						lastBoundaryKeyBytes = readOnlyPrepareSpanBoundaryBytes(prepared.LeafSpans)
+						lastOpKeyBytes = readOnlyPrepareSpanOpKeyBytes(prepared.LeafSpans)
+						if reusePrepareBuffers {
+							opts = prepared.ReuseOptions()
+						}
+					}
+					b.StopTimer()
+					b.ReportMetric(float64(lastSummary.Spans), "leaf_spans/op")
+					b.ReportMetric(float64(lastSummary.SpanOps), "span_ops/op")
+					b.ReportMetric(float64(lastSummary.SpanBytes), "span_bytes/op")
+					b.ReportMetric(float64(lastKeyArenaBytes), "key_arena_bytes/op")
+					b.ReportMetric(float64(lastBoundaryKeyBytes), "boundary_key_bytes/op")
+					b.ReportMetric(float64(lastOpKeyBytes), "op_key_bytes/op")
+				})
+			}
+		})
+	}
+}
+
 func benchmarkZipperPrepareReadOnlyRandom(b *testing.B, keyCount, batchSize int) {
 	benchmarkZipperPrepareReadOnlyRandomImpl(b, keyCount, batchSize, true)
 }
@@ -808,7 +956,8 @@ func benchmarkZipperPrepareReadOnlyRandomImpl(b *testing.B, keyCount, batchSize 
 	if reusePrepareBuffers {
 		opts = first.ReuseOptions()
 	}
-	last := first
+	lastSummary := first.LeafSpanSummary()
+	lastWorkerSummary := first.LeafSpanWorkerRangeSummary(4)
 	b.ReportAllocs()
 	b.SetBytes(int64(summary.SpanBytes))
 	b.ResetTimer()
@@ -817,19 +966,34 @@ func benchmarkZipperPrepareReadOnlyRandomImpl(b *testing.B, keyCount, batchSize 
 		if err != nil {
 			b.Fatalf("PrepareReadOnly: %v", err)
 		}
-		last = prepared
+		lastSummary = prepared.LeafSpanSummary()
+		lastWorkerSummary = prepared.LeafSpanWorkerRangeSummary(4)
 		if reusePrepareBuffers {
 			opts = prepared.ReuseOptions()
 		}
 	}
 	b.StopTimer()
-	lastSummary := last.LeafSpanSummary()
-	lastWorkerSummary := last.LeafSpanWorkerRangeSummary(4)
 	b.ReportMetric(float64(lastSummary.Spans), "leaf_spans/op")
 	b.ReportMetric(float64(lastSummary.SpanOps), "span_ops/op")
 	b.ReportMetric(float64(lastSummary.SpanBytes), "span_bytes/op")
 	b.ReportMetric(float64(lastWorkerSummary.Ranges), "worker_ranges/op")
 	b.ReportMetric(float64(lastWorkerSummary.MaxRangeOps), "max_worker_ops/op")
+}
+
+func readOnlyPrepareSpanBoundaryBytes(spans []ReadOnlyLeafSpan) int {
+	total := 0
+	for i := range spans {
+		total += len(spans[i].LowKey) + len(spans[i].HighKey)
+	}
+	return total
+}
+
+func readOnlyPrepareSpanOpKeyBytes(spans []ReadOnlyLeafSpan) int {
+	total := 0
+	for i := range spans {
+		total += len(spans[i].FirstOpKey) + len(spans[i].LastOpKey)
+	}
+	return total
 }
 
 func BenchmarkZipperApplyWarmRandomManyLeaf(b *testing.B) {

--- a/TreeDB/zipper/span_native_apply_engine_test.go
+++ b/TreeDB/zipper/span_native_apply_engine_test.go
@@ -114,6 +114,19 @@ func TestSpanNativeApplyOmitKeysOptionKeepsBoundariesForPartialSpan(t *testing.T
 	if result.ReadOnlyPrepare.OmitKeys {
 		t.Fatalf("span-native prepare kept OmitKeys=true; execution needs exact boundaries")
 	}
+	if !result.ReadOnlyPrepare.OmitOpKeys {
+		t.Fatalf("span-native prepare OmitOpKeys=%v want true", result.ReadOnlyPrepare.OmitOpKeys)
+	}
+	var boundaryBytes int
+	for i, span := range result.ReadOnlyPrepare.LeafSpans {
+		boundaryBytes += len(span.LowKey) + len(span.HighKey)
+		if span.FirstOpKey != nil || span.LastOpKey != nil {
+			t.Fatalf("span-native span %d retained op keys under OmitOpKeys", i)
+		}
+	}
+	if boundaryBytes == 0 {
+		t.Fatalf("span-native prepare retained no boundary bytes")
+	}
 	if !result.SpanNativeEligible || !result.SpanNativeUsed {
 		t.Fatalf("span-native flags eligible/used=%v/%v", result.SpanNativeEligible, result.SpanNativeUsed)
 	}


### PR DESCRIPTION
## Summary

- add `ReadOnlyPrepareOptions.OmitOpKeys` / `ReadOnlyPrepareResult.OmitOpKeys`
- let span-native apply retain exact span boundaries while skipping duplicated `FirstOpKey`/`LastOpKey` copies
- update read-only prepare validation to require contiguous point-index ranges when op keys are omitted
- add focused tests and a key-mode benchmark for the read-only prepare allocation path

Fixes #3513
Parent tracker: #3512

## Measurement Boundary

The focused benchmark exercises `TreeDB/zipper.PrepareReadOnly` on the many-leaf random point-update shape. It reports both Go allocation metrics and logical key bytes retained in the read-only prepare result.

The macro gate pins this gomap commit into the Ironbird simapp TreeDB image and reruns accepted TreeDB plain-send/small-multisend rows. The plain-send row is the target macro gate because `ReadOnlyPrepareResult.cloneKey` was the top TreeDB allocation site there. Small-multisend is included as a no-throughput-regression guard, but this PR does not claim to reduce its dominant SDK/cache allocations.

## Benchmark Evidence

Command:

```sh
GOWORK=off TMPDIR=/mnt/fast4tb/tmp go test ./TreeDB/zipper \
  -run '^$' \
  -bench 'BenchmarkZipperPrepareReadOnlyManyLeafRandomKeyModes' \
  -benchtime=1000x -count=5 -benchmem
```

Representative results from this branch:

| Mode | B/op | allocs/op | op_key_bytes/op | key_arena_bytes/op | Notes |
| --- | ---: | ---: | ---: | ---: | --- |
| `full_keys/fresh` | ~237568 | 2 | 940 | 3030 | existing full metadata path |
| `omit_op_keys/fresh` | ~207105 | 2 | 0 | 2090 | keeps boundaries, removes duplicated op keys |
| `full_keys/reuse` | 0 | 0 | 940 | 3030 | pooled/reused buffers |
| `omit_op_keys/reuse` | 0 | 0 | 0 | 2090 | pooled/reused buffers |

Ironbird macro artifact roots:

- Baseline: `/mnt/fast4tb/ironbird-normal-workload-sweep-gomap-74862a9-20260705T230312Z`
- Candidate: `/mnt/fast4tb/ironbird-normal-workload-sweep-gomap-3513-omit-opkeys-20260706T013552Z`
- Candidate gomap commit: `96f33b56f04e85a64c15fb24a61c0d9243f37693`

| Workload | Baseline | Candidate | Delta | Allocation signal |
| --- | ---: | ---: | ---: | --- |
| plain-send TreeDB load-window TPS | 562.73 | 557.88 | -0.86% | total alloc_space 136.82GB -> 134.19GB; `ReadOnlyPrepareResult.cloneKey` 11.28GB -> 8.90GB (-21.1%) |
| small-multisend TreeDB load-window TPS, attempt 1 | 570.87 | 585.03 | +2.48% | total alloc_space 154.80GB -> 157.85GB; target clone-key site not a visible small-multisend hotspot |
| small-multisend TreeDB load-window TPS, attempt 2 | 570.87 | 575.50 | +0.81% | total alloc_space 154.80GB -> 159.14GB; remaining top sites are `caching.getEntrySlice`, `memtable.getAppendOnlyEntries`, SDK JSON/protobuf/cache allocations |

Timing buckets for accepted candidate rows:

| Workload | Attempt | Load window | Commit seconds | Finalize seconds | CheckTx seconds | Non-ABCI seconds |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| plain-send | 1 | 357.020s | 46.587s | 40.325s | 102.315s | 166.066s |
| small-multisend | 1 | 408.521s | 48.449s | 48.095s | 126.822s | 182.656s |
| small-multisend | 2 | 415.026s | 49.461s | 49.591s | 127.237s | 186.274s |

## Test Evidence

```sh
GOWORK=off TMPDIR=/mnt/fast4tb/tmp go test ./TreeDB/zipper -run 'TestZipperPrepareReadOnlyOmit|TestSpanNativeApplyOmitKeysOptionKeepsBoundariesForPartialSpan'
GOWORK=off TMPDIR=/mnt/fast4tb/tmp go test ./TreeDB/zipper
GOWORK=off TMPDIR=/mnt/fast4tb/tmp go test ./TreeDB/db ./TreeDB/zipper ./TreeDB/caching
```

All three commands passed locally.

Latest-head CI is green for commit `96f33b56f04e85a64c15fb24a61c0d9243f37693`.

## Performance Regression Assessment

The targeted plain-send allocation site moved in the intended direction: `ReadOnlyPrepareResult.cloneKey` fell by about 2.38GB / 21.1%, and total plain-send alloc_space fell by about 1.9%. Plain-send load-window TPS was neutral within the gate at -0.86%.

Small-multisend runtime did not regress in either accepted candidate row. Its total alloc_space profile is modestly higher than the previous baseline row, but the increase is not in the modified op-key-copy path; the remaining top allocation sites are now the next alloc-loop targets (`caching.getEntrySlice`, `memtable.getAppendOnlyEntries`, value-log append buffers, command-WAL frame paths, and SDK JSON/protobuf/cache allocations). This PR should not claim small-multisend allocation improvement.

## AI Review Status

CodeRabbit completed on the latest head and reported no actionable comments. No Codex/Copilot GitHub review bot convention is configured in this repo checkout; local internal review was completed before mergeability.
