### PR TITLE
treedb: retain more value-log append buffers

### DIFF
--- a/TreeDB/internal/memtable/append_only_test.go
+++ b/TreeDB/internal/memtable/append_only_test.go
@@ -65,6 +65,38 @@ func TestAppendOnlyInlineGrowthSkipsIntermediateDoublingBelowCutoff(t *testing.T
 	}
 }
 
+func BenchmarkAppendOnlyBatchReserveGrowth(b *testing.B) {
+	const (
+		batchEntries = 500
+		batches      = 400
+	)
+
+	b.ReportAllocs()
+	before := AppendOnlyEntryReserveStatsSnapshot()
+	for i := 0; i < b.N; i++ {
+		DropAppendOnlyEntryPools()
+		mt := NewAppendOnlyWithEntryCapacity(appendOnlyMinInitialEntries)
+		var key [appendOnlyInlineKeyLen]byte
+		seq := uint64(0)
+		for batch := 0; batch < batches; batch++ {
+			mt.mu.Lock()
+			mt.reserveAdditionalEntriesLocked(batchEntries)
+			for j := 0; j < batchEntries; j++ {
+				binary.BigEndian.PutUint64(key[:], seq)
+				mt.appendEntryLocked(key[:], nil, page.ValuePtr{}, node.FlagInline, page.EntryRevision(seq+1), false, true)
+				seq++
+			}
+			mt.mu.Unlock()
+		}
+		mt.ReleaseDropEntries()
+	}
+	after := AppendOnlyEntryReserveStatsSnapshot()
+	if b.N > 0 {
+		b.ReportMetric(float64(after.GrowCallsTotal-before.GrowCallsTotal)/float64(b.N), "reserve_grows/op")
+		b.ReportMetric(float64(after.GrowBytesTotal-before.GrowBytesTotal)/float64(b.N)/(1<<20), "reserve_grow_MiB/op")
+	}
+}
+
 func TestAppendOnlyInitialEntriesForCapacity(t *testing.T) {
 	t.Run("pointer-estimate", func(t *testing.T) {
 		capacity := defaultMemtableCapacity

--- a/TreeDB/internal/valuelog/writer.go
+++ b/TreeDB/internal/valuelog/writer.go
@@ -35,7 +35,7 @@ const (
 	// Keep a hard cap on retained multi-MiB append buffers. Unlike sync.Pool,
 	// this prevents a burst of short-lived writers from retaining unbounded
 	// defaultBufferSize slices between GC cycles.
-	writerAppendBufPoolEntries = 8
+	writerAppendBufPoolEntries = 16
 )
 
 var syncDirFn = syncDir

--- a/TreeDB/internal/valuelog/writer_memory_test.go
+++ b/TreeDB/internal/valuelog/writer_memory_test.go
@@ -258,7 +258,7 @@ func TestWriterAppendBufStats_PoolAndDropCounters(t *testing.T) {
 	}
 }
 
-func BenchmarkWriterAppendBufPoolConcurrentSyncCycles(b *testing.B) {
+func BenchmarkWriterAppendBufPoolMultiWriterSyncCycles(b *testing.B) {
 	const writers = 16
 
 	drainWriterAppendBufPoolForTest()

--- a/TreeDB/internal/valuelog/writer_memory_test.go
+++ b/TreeDB/internal/valuelog/writer_memory_test.go
@@ -3,6 +3,7 @@ package valuelog
 import (
 	"bytes"
 	"io"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -254,6 +255,54 @@ func TestWriterAppendBufStats_PoolAndDropCounters(t *testing.T) {
 	}
 	if got, want := afterDrop.DroppedBytesTotal-afterGet.DroppedBytesTotal, uint64(defaultBufferSize+1); got != want {
 		t.Fatalf("dropped bytes delta=%d want=%d", got, want)
+	}
+}
+
+func BenchmarkWriterAppendBufPoolConcurrentSyncCycles(b *testing.B) {
+	const writers = 16
+
+	drainWriterAppendBufPoolForTest()
+	b.Cleanup(drainWriterAppendBufPoolForTest)
+
+	dir := b.TempDir()
+	ws := make([]*Writer, 0, writers)
+	for i := 0; i < writers; i++ {
+		path := filepath.Join(dir, "value-"+string(rune('a'+i))+".log")
+		w, err := NewWriter(path, page.ValueLogFileID(uint32(i+1)))
+		if err != nil {
+			b.Fatalf("NewWriter(%d): %v", i, err)
+		}
+		w.syncFn = func(*os.File) error { return nil }
+		ws = append(ws, w)
+	}
+	defer func() {
+		for _, w := range ws {
+			_ = w.Close()
+		}
+	}()
+
+	payload := []byte("x")
+	before := WriterAppendBufferStatsSnapshot()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, w := range ws {
+			if err := w.writeBytes(payload); err != nil {
+				b.Fatal(err)
+			}
+		}
+		for _, w := range ws {
+			if err := w.Sync(); err != nil {
+				b.Fatal(err)
+			}
+		}
+	}
+	b.StopTimer()
+	after := WriterAppendBufferStatsSnapshot()
+	if b.N > 0 {
+		b.ReportMetric(float64(after.AllocCallsTotal-before.AllocCallsTotal)/float64(b.N), "appendbuf_allocs/op")
+		b.ReportMetric(float64(after.AllocatedBytesTotal-before.AllocatedBytesTotal)/float64(b.N)/(1<<20), "appendbuf_alloc_MiB/op")
+		b.ReportMetric(float64(after.DropsTotal-before.DropsTotal)/float64(b.N), "appendbuf_drops/op")
 	}
 }
 


### PR DESCRIPTION
## Summary

- increase the bounded TreeDB value-log append-buffer pool from 8 to 16 entries
- add a focused multi-writer sync-cycle benchmark that reproduces append-buffer pool churn
- add an append-only reserve-growth benchmark to keep the rejected memtable growth candidate measurable without changing production policy

Linked tracker: #3515

## Why

Ironbird app heap profiles showed `TreeDB/internal/valuelog.getWriterAppendBuf` as a multi-GB alloc_space site in plain-send and small-multisend runs. The hot path is leaf/value-log writer reuse across sync boundaries, not user payload value-log writes. With 16 active writers, the previous pool cap of 8 dropped half of the default 4 MiB append buffers every sync cycle.

This PR is intentionally narrow allocation hygiene. It does not claim a large end-to-end TPS win.

## Exact-branch test evidence

Branch: `codex/3515-vlogpool16-allocs`
Commit: `3918327915e13f6b4bf09d5a4b01925e3b1b1ea1`

```sh
GOWORK=off TMPDIR=/mnt/fast4tb/tmp go test ./TreeDB/internal/valuelog \
  -run '^$' \
  -bench '^BenchmarkWriterAppendBufPoolMultiWriterSyncCycles$' \
  -benchtime=100x -benchmem -count=3
```

Result:

```text
BenchmarkWriterAppendBufPoolMultiWriterSyncCycles-12  100  49533 ns/op  0.6400 appendbuf_alloc_MiB/op  0.1600 appendbuf_allocs/op  0 appendbuf_drops/op  671195 B/op  0 allocs/op
BenchmarkWriterAppendBufPoolMultiWriterSyncCycles-12  100  20423 ns/op  0.6400 appendbuf_alloc_MiB/op  0.1600 appendbuf_allocs/op  0 appendbuf_drops/op  671088 B/op  0 allocs/op
BenchmarkWriterAppendBufPoolMultiWriterSyncCycles-12  100  28146 ns/op  0.6400 appendbuf_alloc_MiB/op  0.1600 appendbuf_allocs/op  0 appendbuf_drops/op  671088 B/op  0 allocs/op
```

The remaining `0.1600 appendbuf_allocs/op` is first-cycle warmup: 16 initial 4 MiB buffers amortized over 100 sync cycles. The important regression guard is `0 appendbuf_drops/op`.

Focused tests:

```sh
GOWORK=off TMPDIR=/mnt/fast4tb/tmp go test ./TreeDB/internal/memtable ./TreeDB/internal/valuelog ./TreeDB/caching -count=1
```

Result:

```text
ok github.com/snissn/gomap/TreeDB/internal/memtable 0.680s
ok github.com/snissn/gomap/TreeDB/internal/valuelog 2.710s
ok github.com/snissn/gomap/TreeDB/caching 59.816s
```

## Directional Ironbird evidence

A full Ironbird run was completed with this same value-log pool diff on the prior stacked validation branch, pinned as gomap `76878fbc61bc9d86a9d3ec5882d75c9e4b07f9c5`. Because that branch also contained earlier local commits, treat this as directional evidence only, not exact-branch merge evidence.

Artifact root:

```text
/mnt/fast4tb/ironbird-normal-workload-sweep-gomap-76878f-20260706T064704Z
```

Allocation comparison vs the previous accepted `aed1053` Ironbird baseline:

| Workload | Baseline total alloc | Candidate total alloc | `getWriterAppendBuf` baseline | Candidate `getWriterAppendBuf` | Runtime TPS |
| --- | ---: | ---: | ---: | ---: | ---: |
| plain-send | 115,880 MB | 111,336 MB | 3,677 MB | not in top 240 | 574.9 -> 572.6 |
| small-multisend | 144,442 MB | 138,571 MB | 4,734 MB | not in top 240 | 577.0 -> 572.0 |

In-use heap did not regress in the captured profiles:

| Workload | Baseline in-use heap | Candidate in-use heap |
| --- | ---: | ---: |
| plain-send | 1.64 GiB | 1.64 GiB |
| small-multisend | 1.80 GiB | 1.74 GiB |

## Regression assessment

This raises the bounded default append-buffer pool from 8 to 16 entries. The retained-buffer ceiling increases from 32 MiB to 64 MiB for default-sized append buffers. That is a deliberate bounded tradeoff to avoid multi-GB allocation churn across repeated sync cycles.

Full exact-branch Ironbird validation was started and stopped to avoid spending more wall time on a small, already localized hygiene PR. This PR should be evaluated primarily on the deterministic package benchmark and tests above.