### PR TITLE
treedb: remove public operation lifecycle allocation

### DIFF
--- a/TreeDB/command_wal_public_cached.go
+++ b/TreeDB/command_wal_public_cached.go
@@ -796,11 +796,10 @@ func (b *commandWALPublicBatch) write(sync bool) error {
 		return ErrClosed
 	}
 	if b.db != nil {
-		unlock, err := b.db.beginPublicOperation()
-		if err != nil {
+		if err := b.db.beginPublicOperation(); err != nil {
 			return err
 		}
-		defer unlock()
+		defer b.db.lifecycleMu.RUnlock()
 	}
 	if b.dirty {
 		writer, ok := b.inner.(interface {

--- a/TreeDB/public.go
+++ b/TreeDB/public.go
@@ -323,16 +323,16 @@ func (db *DB) ensureOpen() error {
 	return nil
 }
 
-func (db *DB) beginPublicOperation() (func(), error) {
+func (db *DB) beginPublicOperation() error {
 	if db == nil {
-		return nil, ErrClosed
+		return ErrClosed
 	}
 	db.lifecycleMu.RLock()
 	if db.cached == nil && db.backend == nil {
 		db.lifecycleMu.RUnlock()
-		return nil, ErrClosed
+		return ErrClosed
 	}
-	return db.lifecycleMu.RUnlock, nil
+	return nil
 }
 
 func (db *DB) beginFullScanMaintenance(op string) (time.Duration, func(success bool)) {
@@ -1631,11 +1631,10 @@ func (db *DB) HasPrefixes(prefixes [][]byte) ([]bool, error) {
 func (db *DB) Set(key, value []byte) error {
 	key = normalizeRawKVPointKey(key)
 	value = normalizeRawKVValue(value)
-	unlock, err := db.beginPublicOperation()
-	if err != nil {
+	if err := db.beginPublicOperation(); err != nil {
 		return err
 	}
-	defer unlock()
+	defer db.lifecycleMu.RUnlock()
 	if db.cached != nil {
 		if db.commandWALCached {
 			return db.cached.SetAfterCommandWALAppendWithRevision(key, value, func(revision page.EntryRevision) error {
@@ -1653,11 +1652,10 @@ func (db *DB) Set(key, value []byte) error {
 func (db *DB) SetSync(key, value []byte) error {
 	key = normalizeRawKVPointKey(key)
 	value = normalizeRawKVValue(value)
-	unlock, err := db.beginPublicOperation()
-	if err != nil {
+	if err := db.beginPublicOperation(); err != nil {
 		return err
 	}
-	defer unlock()
+	defer db.lifecycleMu.RUnlock()
 	if db.cached != nil {
 		if db.commandWALCached {
 			return db.cached.SetAfterCommandWALAppendWithRevision(key, value, func(revision page.EntryRevision) error {
@@ -1679,11 +1677,10 @@ func (db *DB) SetSync(key, value []byte) error {
 // Because fn may be retried, it should avoid externally visible side effects.
 func (db *DB) Update(key []byte, fn UpdateFunc) error {
 	key = normalizeRawKVPointKey(key)
-	unlock, err := db.beginPublicOperation()
-	if err != nil {
+	if err := db.beginPublicOperation(); err != nil {
 		return err
 	}
-	defer unlock()
+	defer db.lifecycleMu.RUnlock()
 	if db.commandWALCached {
 		db.rawSpanNativePublicUpdateReject.Add(1)
 		return ErrCommandWALRejected
@@ -1704,11 +1701,10 @@ func (db *DB) Update(key []byte, fn UpdateFunc) error {
 // externally visible side effects.
 func (db *DB) UpdateSync(key []byte, fn UpdateFunc) error {
 	key = normalizeRawKVPointKey(key)
-	unlock, err := db.beginPublicOperation()
-	if err != nil {
+	if err := db.beginPublicOperation(); err != nil {
 		return err
 	}
-	defer unlock()
+	defer db.lifecycleMu.RUnlock()
 	if db.commandWALCached {
 		db.rawSpanNativePublicUpdateSyncReject.Add(1)
 		return ErrCommandWALRejected
@@ -1738,15 +1734,15 @@ func (db *DB) initConditionalTxn(tx *ConditionalTxn, withSnapshot bool) error {
 	if tx == nil || tx.cachedActive || tx.backend != nil {
 		return ErrConditionalTxnClosed
 	}
-	unlock, err := db.beginPublicOperation()
-	if err != nil {
+	if err := db.beginPublicOperation(); err != nil {
 		return err
 	}
-	defer unlock()
+	defer db.lifecycleMu.RUnlock()
 	if db.cached != nil {
 		if db.commandWALCached {
 			return ErrConditionalTxnUnsupported
 		}
+		var err error
 		if withSnapshot {
 			err = db.cached.InitConditionalTxnWithSnapshot(&tx.cached)
 		} else {
@@ -1796,11 +1792,10 @@ func (db *DB) NewConditionalTxnWithSnapshot() (*ConditionalTxn, error) {
 // Delete removes a key without forcing an fsync boundary.
 func (db *DB) Delete(key []byte) error {
 	key = normalizeRawKVPointKey(key)
-	unlock, err := db.beginPublicOperation()
-	if err != nil {
+	if err := db.beginPublicOperation(); err != nil {
 		return err
 	}
-	defer unlock()
+	defer db.lifecycleMu.RUnlock()
 	if db.cached != nil {
 		if db.commandWALCached {
 			return db.cached.DeleteAfterCommandWALAppendWithRevision(key, func(revision page.EntryRevision) error {
@@ -1817,11 +1812,10 @@ func (db *DB) Delete(key []byte) error {
 // This is primarily used by benchmark suites and maintenance tooling. In cached
 // mode, it may use fast paths that avoid per-key tombstones when safe.
 func (db *DB) DeleteRange(start, end []byte) error {
-	unlock, err := db.beginPublicOperation()
-	if err != nil {
+	if err := db.beginPublicOperation(); err != nil {
 		return err
 	}
-	defer unlock()
+	defer db.lifecycleMu.RUnlock()
 	if db.commandWALCached {
 		if batch.IsDeleteRangeNoop(start, end) {
 			return nil
@@ -1868,11 +1862,10 @@ func (db *DB) DeleteRange(start, end []byte) error {
 // DeleteSync removes a key and forces a durability boundary.
 func (db *DB) DeleteSync(key []byte) error {
 	key = normalizeRawKVPointKey(key)
-	unlock, err := db.beginPublicOperation()
-	if err != nil {
+	if err := db.beginPublicOperation(); err != nil {
 		return err
 	}
-	defer unlock()
+	defer db.lifecycleMu.RUnlock()
 	if db.cached != nil {
 		if db.commandWALCached {
 			return db.cached.DeleteAfterCommandWALAppendWithRevision(key, func(revision page.EntryRevision) error {
@@ -1908,11 +1901,10 @@ func (db *DB) ReverseIterator(start, end []byte) (Iterator, error) {
 
 // NewBatch creates a new batch for buffered writes.
 func (db *DB) NewBatch() Batch {
-	unlock, err := db.beginPublicOperation()
-	if err != nil {
+	if err := db.beginPublicOperation(); err != nil {
 		return nil
 	}
-	defer unlock()
+	defer db.lifecycleMu.RUnlock()
 	if db.cached != nil {
 		inner := db.cached.NewBatch()
 		if db.commandWALCached {
@@ -1933,11 +1925,10 @@ func (db *DB) NewBatch() Batch {
 // Callers must not rely on an exact 1:1 mapping between size and the number of
 // entries or bytes that can be written to the batch.
 func (db *DB) NewBatchWithSize(size int) Batch {
-	unlock, err := db.beginPublicOperation()
-	if err != nil {
+	if err := db.beginPublicOperation(); err != nil {
 		return nil
 	}
-	defer unlock()
+	defer db.lifecycleMu.RUnlock()
 	if db.cached != nil {
 		inner := db.cached.NewBatchWithSize(size)
 		if db.commandWALCached {
@@ -2063,11 +2054,10 @@ func (db *DB) Print() error {
 // Checkpoint returning nil must also cover pre-cut collection WAL transactions
 // or return/report explicit collection WAL debt.
 func (db *DB) Checkpoint() error {
-	unlock, err := db.beginPublicOperation()
-	if err != nil {
+	if err := db.beginPublicOperation(); err != nil {
 		return err
 	}
-	defer unlock()
+	defer db.lifecycleMu.RUnlock()
 	if db.cached != nil {
 		return db.checkpointCachedForPublicCommandWAL()
 	}

--- a/TreeDB/public_lifecycle_alloc_test.go
+++ b/TreeDB/public_lifecycle_alloc_test.go
@@ -1,0 +1,44 @@
+package treedb
+
+import "testing"
+
+func TestBeginPublicOperationWithDeferNoAlloc(t *testing.T) {
+	db, err := Open(Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	allocs := testing.AllocsPerRun(1000, func() {
+		if err := beginPublicOperationWithDeferForAllocTest(db); err != nil {
+			panic(err)
+		}
+	})
+	if allocs != 0 {
+		t.Fatalf("beginPublicOperation with direct deferred RUnlock allocs = %v, want 0", allocs)
+	}
+}
+
+func BenchmarkBeginPublicOperationWithDefer(b *testing.B) {
+	db, err := Open(Options{Dir: b.TempDir()})
+	if err != nil {
+		b.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := beginPublicOperationWithDeferForAllocTest(db); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func beginPublicOperationWithDeferForAllocTest(db *DB) error {
+	if err := db.beginPublicOperation(); err != nil {
+		return err
+	}
+	defer db.lifecycleMu.RUnlock()
+	return nil
+}


### PR DESCRIPTION
Fixes #3520
Parent tracker: #3518

## Summary

- Changed `DB.beginPublicOperation` to acquire/check the lifecycle read lock and return only `error`, removing the escaping returned `RUnlock` method value.
- Updated every successful public-operation call site to immediately `defer db.lifecycleMu.RUnlock()` after `beginPublicOperation` succeeds.
- Added a focused allocation guard and benchmark for the direct-defer lifecycle pattern.

## Scope Boundary

Changed files:

- `TreeDB/public.go`
- `TreeDB/command_wal_public_cached.go`
- `TreeDB/public_lifecycle_alloc_test.go`

No changes to public API semantics, close ordering, WAL/value-log durability, batch commit semantics, or `TreeDB/caching/db.go`.

## Call-Site Inventory

Inventory command:

```sh
rg -n "beginPublicOperation|defer .*RUnlock\(\)|defer unlock\(\)|unlock, err := .*beginPublicOperation" TreeDB/public.go TreeDB/command_wal_public_cached.go TreeDB/public_lifecycle_alloc_test.go
```

Result: production has 11 successful `beginPublicOperation` paths: 10 in `TreeDB/public.go` and 1 in `TreeDB/command_wal_public_cached.go`. Each success path has an immediate direct `defer ...lifecycleMu.RUnlock()` before any later return path. There are no remaining `defer unlock()` or `unlock, err := ...beginPublicOperation` production call sites.

## Tests

```sh
GOWORK=off go test ./TreeDB -run 'TestBeginPublicOperationWithDeferNoAlloc|TestPublicCommandWALCloseRejectsLateSetSyncWithErrClosed|TestPublicCommandWALBatchWriteAfterCloseReturnsErrClosed' -count=1
# ok   github.com/snissn/gomap/TreeDB  0.955s
```

```sh
GOWORK=off go test ./TreeDB/integration/gethethdb -run 'TestOperationsAfterClose' -count=1
# setup failed from repo root because TreeDB/integration/gethethdb is a nested module when GOWORK=off
```

Equivalent nested-module command:

```sh
(cd TreeDB/integration/gethethdb && GOWORK=off go test . -run 'TestOperationsAfterClose' -count=1)
# ok   github.com/snissn/gomap/TreeDB/integration/gethethdb  0.773s
```

```sh
GOWORK=off go test ./TreeDB -count=1
# ok   github.com/snissn/gomap/TreeDB  76.030s
```

```sh
git diff --check
# pass
```

## Escape Diagnostics

Baseline throwaway worktree at `914b7f1d028de1b03b25b5d0df4555467d102e32`, with a temporary old-pattern benchmark file:

```sh
GOWORK=off go test -run '^$' ./TreeDB -gcflags='-m=2' 2>&1 | rg 'beginPublicOperation|RUnlock escapes'
```

Baseline included:

```text
TreeDB/public.go:335:23: db.lifecycleMu.RUnlock escapes to heap
```

Current branch:

```sh
GOWORK=off go test -run '^$' ./TreeDB -gcflags='-m=2' 2>&1 | rg 'beginPublicOperation|RUnlock escapes'
```

Result: compiler still emits `beginPublicOperation` notes because the filter includes the helper name, but there is no `RUnlock escapes` line. A stricter check confirms no matches:

```sh
GOWORK=off go test -run '^$' ./TreeDB -gcflags='-m=2' 2>&1 | rg 'RUnlock escapes'
# no matches; rg exits 1
```

## Allocation Benchmark

Machine: darwin/arm64, Apple M3.

Baseline command, in a throwaway baseline worktree with a temporary benchmark matching the old returned-unlock pattern:

```sh
GOWORK=off go test ./TreeDB -run '^$' -bench '^BenchmarkBeginPublicOperationWithReturnedUnlockBaseline$' -benchmem -count=5
```

Current branch command:

```sh
GOWORK=off go test ./TreeDB -run '^$' -bench '^BenchmarkBeginPublicOperationWithDefer$' -benchmem -count=5
```

| Path | Median ns/op | Approx ops/sec | B/op | allocs/op |
| --- | ---: | ---: | ---: | ---: |
| baseline returned unlock | 71.24 | 14.0M | 16 | 1 |
| current direct defer | 19.44 | 51.4M | 0 | 0 |

Raw current runs:

```text
28.57 ns/op  0 B/op  0 allocs/op
16.88 ns/op  0 B/op  0 allocs/op
19.44 ns/op  0 B/op  0 allocs/op
22.29 ns/op  0 B/op  0 allocs/op
12.32 ns/op  0 B/op  0 allocs/op
```

Raw baseline runs:

```text
99.63 ns/op  16 B/op  1 allocs/op
73.51 ns/op  16 B/op  1 allocs/op
50.23 ns/op  16 B/op  1 allocs/op
63.53 ns/op  16 B/op  1 allocs/op
71.24 ns/op  16 B/op  1 allocs/op
```

## Regression Assessment

- Close-safety behavior is preserved by keeping the lifecycle read-lock window identical: begin acquires/checks, and callers defer unlock immediately after success.
- No WAL/value-log durability or batch commit behavior changed.
- Focused benchmark improves allocation from `1 allocs/op` and `16 B/op` to `0 allocs/op` and `0 B/op`; no local performance regression was observed in the targeted lifecycle guard.
- Full durable `unified-bench` profile was not rerun in this worker PR; this PR provides the focused allocation proof for the helper and leaves graph-level full-profile confirmation to the coordinator loop.

## CI / AI Review

- CI status for head `37011129315c7cfae8e12fa4ca4632eb6efdc69f`: started. `gofmt` and `redisserver: protocol bench` are passing; TreeDB/root/unified-bench/read-snapshot/Windows checks are still pending or running at PR creation time.
- AI reviews: not requested by this worker. CodeRabbit appeared automatically as a pending status; coordinator can decide whether to request any further Codex/Copilot/CodeRabbit review after latest-head CI policy is satisfied.
- Merge status: do not merge from this worker branch; coordinator owns merge authorization.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability of public write and maintenance operations by tightening how database access is locked and released.
  * Reduced the chance of unnecessary overhead during these operations.

* **Tests**
  * Added coverage to verify the public-operation path runs without extra allocations.
  * Added a benchmark to track performance of the same workflow over time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->