### PR TITLE
treedb: remove leaf lane lookup allocation

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -3041,18 +3041,51 @@ func (db *DB) valueLogLaneForFileID(fileID uint32) *lane {
 	if laneID != leafLogLaneID || !db.indexOuterLeavesInValueLog {
 		return db.valueLogLaneByID(int(laneID))
 	}
-	for _, l := range db.leafLogAppendLanesSnapshot() {
-		if l == nil {
-			continue
+	if view := db.leafLogAppendLanesView.Load(); view != nil {
+		for _, l := range *view {
+			if db.leafLogAppendLaneMatchesSeq(l, seq) {
+				return l
+			}
 		}
-		l.vlogMu.Lock()
-		matches := l.vlogSeq == int(seq) && (l.vlogPath != "" || l.vlog != nil)
-		l.vlogMu.Unlock()
-		if matches {
+		return nil
+	}
+	for idx := 0; ; idx++ {
+		l, ok := db.leafLogAppendLaneAtIndex(idx)
+		if !ok {
+			return nil
+		}
+		if db.leafLogAppendLaneMatchesSeq(l, seq) {
 			return l
 		}
 	}
-	return nil
+}
+
+func (db *DB) leafLogAppendLaneMatchesSeq(l *lane, seq uint32) bool {
+	if l == nil {
+		return false
+	}
+	l.vlogMu.Lock()
+	matches := l.vlogSeq == int(seq) && (l.vlogPath != "" || l.vlog != nil)
+	l.vlogMu.Unlock()
+	return matches
+}
+
+func (db *DB) leafLogAppendLaneAtIndex(idx int) (*lane, bool) {
+	if db == nil || !db.indexOuterLeavesInValueLog || idx < 0 {
+		return nil, false
+	}
+	db.leafLogAppendMu.RLock()
+	defer db.leafLogAppendMu.RUnlock()
+	if len(db.leafLogAppendLanes) == 0 {
+		if idx == 0 {
+			return &db.leafLog, true
+		}
+		return nil, false
+	}
+	if idx >= len(db.leafLogAppendLanes) {
+		return nil, false
+	}
+	return db.leafLogAppendLanes[idx], true
 }
 
 func (db *DB) isLeafLogAppendLane(l *lane) bool {
@@ -3096,6 +3129,15 @@ func (db *DB) initLeafLogAppendState(maxLeafVlogSeq int) {
 	defer db.leafLogAppendMu.Unlock()
 	db.leafLogAppendSeq.Store(uint32(maxLeafVlogSeq))
 	db.leafLogAppendLanes = []*lane{&db.leafLog}
+	db.publishLeafLogAppendLanesLocked()
+}
+
+func (db *DB) publishLeafLogAppendLanesLocked() {
+	if db == nil || !db.indexOuterLeavesInValueLog || len(db.leafLogAppendLanes) == 0 {
+		return
+	}
+	view := append([]*lane(nil), db.leafLogAppendLanes...)
+	db.leafLogAppendLanesView.Store(&view)
 }
 
 func (db *DB) leafLogAppendLanesSnapshot() []*lane {
@@ -3134,6 +3176,7 @@ func (db *DB) leafLogAppendLaneForWorkerIndex(workerIndex int) *lane {
 		}
 		db.startVlogWriter(l)
 		db.leafLogAppendLanes[workerIndex] = l
+		db.publishLeafLogAppendLanesLocked()
 	}
 	db.leafLogAppendMu.Unlock()
 	return l
@@ -8381,6 +8424,7 @@ type DB struct {
 	leafLogAppendMu           sync.RWMutex
 	leafLogAppendLanes        []*lane
 	leafLogAppendSeq          atomic.Uint32
+	leafLogAppendLanesView    atomic.Pointer[[]*lane]
 	laneMu                    sync.Mutex
 	laneCond                  *sync.Cond
 	nextLane                  int

--- a/TreeDB/caching/leaf_page_log_lanes_lifecycle_test.go
+++ b/TreeDB/caching/leaf_page_log_lanes_lifecycle_test.go
@@ -3,9 +3,13 @@ package caching
 import (
 	"strings"
 	"testing"
+
+	"github.com/snissn/gomap/TreeDB/internal/valuelog"
 )
 
 const leafLogMaxSegmentSeqForTest = 1<<23 - 1
+
+var valueLogLaneForFileIDTestSink *lane
 
 func TestNextLeafLogAppendSeqRejectsSegmentIDExhaustion(t *testing.T) {
 	db := &DB{indexOuterLeavesInValueLog: true}
@@ -25,4 +29,81 @@ func TestNextLeafLogAppendSeqRejectsSegmentIDExhaustion(t *testing.T) {
 	if seq != leafLogMaxSegmentSeqForTest {
 		t.Fatalf("seq=%d want max %d", seq, uint32(leafLogMaxSegmentSeqForTest))
 	}
+}
+
+func TestValueLogLaneForFileID_LeafAppendLookupSkipsNilLanes(t *testing.T) {
+	db, fileID, want := newValueLogLaneLookupTestDB(t, 8, 5)
+	db.leafLogAppendLanes[2] = nil
+	publishLeafLogAppendLanesForTest(db)
+
+	got := db.valueLogLaneForFileID(fileID)
+	if got != want {
+		t.Fatalf("valueLogLaneForFileID matched lane %p want %p", got, want)
+	}
+}
+
+func TestValueLogLaneForFileID_LeafAppendLookupRequiresActiveSegment(t *testing.T) {
+	db, fileID, _ := newValueLogLaneLookupTestDB(t, 4, 3)
+	db.leafLogAppendLanes[3].vlogPath = ""
+	db.leafLogAppendLanes[3].vlog = nil
+
+	if got := db.valueLogLaneForFileID(fileID); got != nil {
+		t.Fatalf("valueLogLaneForFileID matched inactive lane %p, want nil", got)
+	}
+}
+
+func TestValueLogLaneForFileID_LeafAppendLookupDoesNotAllocate(t *testing.T) {
+	db, fileID, want := newValueLogLaneLookupTestDB(t, 8, 5)
+	if got := db.valueLogLaneForFileID(fileID); got != want {
+		t.Fatalf("valueLogLaneForFileID matched lane %p want %p", got, want)
+	}
+
+	allocs := testing.AllocsPerRun(1000, func() {
+		valueLogLaneForFileIDTestSink = db.valueLogLaneForFileID(fileID)
+	})
+	if allocs != 0 {
+		t.Fatalf("valueLogLaneForFileID allocations/run=%v want 0", allocs)
+	}
+}
+
+func BenchmarkValueLogLaneForFileID_LeafAppendLookup(b *testing.B) {
+	db, fileID, want := newValueLogLaneLookupTestDB(b, 8, 5)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		valueLogLaneForFileIDTestSink = db.valueLogLaneForFileID(fileID)
+	}
+	b.StopTimer()
+	if valueLogLaneForFileIDTestSink != want {
+		b.Fatalf("valueLogLaneForFileID matched lane %p want %p", valueLogLaneForFileIDTestSink, want)
+	}
+}
+
+func newValueLogLaneLookupTestDB(tb testing.TB, laneCount, matchIndex int) (*DB, uint32, *lane) {
+	tb.Helper()
+	if laneCount <= 0 || matchIndex < 0 || matchIndex >= laneCount {
+		tb.Fatalf("invalid lane lookup fixture: laneCount=%d matchIndex=%d", laneCount, matchIndex)
+	}
+	db := &DB{indexOuterLeavesInValueLog: true}
+	db.leafLog.id = leafLogLaneID
+	db.leafLogAppendLanes = make([]*lane, laneCount)
+	for i := 0; i < laneCount; i++ {
+		db.leafLogAppendLanes[i] = &lane{
+			id:       leafLogLaneID,
+			vlogSeq:  100 + i,
+			vlogPath: "leaf-active",
+		}
+	}
+	publishLeafLogAppendLanesForTest(db)
+	fileID, err := valuelog.EncodeFileID(uint32(leafLogLaneID), uint32(db.leafLogAppendLanes[matchIndex].vlogSeq))
+	if err != nil {
+		tb.Fatalf("EncodeFileID: %v", err)
+	}
+	return db, fileID, db.leafLogAppendLanes[matchIndex]
+}
+
+func publishLeafLogAppendLanesForTest(db *DB) {
+	db.leafLogAppendMu.Lock()
+	defer db.leafLogAppendMu.Unlock()
+	db.publishLeafLogAppendLanesLocked()
 }


### PR DESCRIPTION
## Summary

Fixes #3519.
Parent tracker: #3518.

This removes the per-read slice clone from the leaf value-log lane lookup path. `valueLogLaneForFileID` now reads an immutable published append-lane view for leaf-log file IDs instead of calling `leafLogAppendLanesSnapshot()` on the hot path. The mutable lane slice remains guarded by `leafLogAppendMu`; the published view is copy-on-publish when leaf append lanes are initialized or extended. Per-lane state checks still take each lane's `vlogMu` and still require the target sequence plus an active path/writer.

Scope boundary honored: only `TreeDB/caching` changed. No edits to `TreeDB/public.go` or `TreeDB/command_wal_public_cached.go`.

## Baseline

Base: `origin/main` / `914b7f1d028de1b03b25b5d0df4555467d102e32`.

Baseline command, run in `/tmp/gomap-3519-readlane-baseline` with only the benchmark fixture added and the production lookup code unchanged:

```sh
GOWORK=off go test ./TreeDB/caching -run '^$' -bench '^BenchmarkValueLogLaneForFileID_LeafAppendLookup$' -benchmem -count=5
```

| Branch | ns/op samples | B/op | allocs/op |
| --- | ---: | ---: | ---: |
| baseline `914b7f1` | `138.6`, `167.7`, `148.8`, `136.2`, `107.6` | `64` | `1` |
| this PR `f800123` | `116.5`, `96.43`, `52.70`, `87.54`, `88.64` | `0` | `0` |

Focused allocation gate: pass. The lookup benchmark removes the old one slice allocation per call.

## Tests

```sh
GOWORK=off go test ./TreeDB/caching -run 'TestValueLogLaneForFileID|TestNextLeafLogAppendSeq' -count=1
# ok github.com/snissn/gomap/TreeDB/caching 0.483s
```

```sh
GOWORK=off go test ./TreeDB/caching -run '^$' -bench '^BenchmarkValueLogLaneForFileID_LeafAppendLookup$' -benchmem -count=5
# 0 B/op, 0 allocs/op on all five samples
```

```sh
GOWORK=off go test ./TreeDB/caching -count=1
# ok github.com/snissn/gomap/TreeDB/caching 68.607s
```

```sh
GOWORK=off go test -race ./TreeDB/caching -run 'TestValueLogLaneForFileID' -count=1
# ok github.com/snissn/gomap/TreeDB/caching 1.977s
```

```sh
git diff --check
# passed
```

## Race / Locking Notes

The hot path does not hold `leafLogAppendMu` while acquiring `vlogMu`. This avoids creating an opposite lock order against existing rotation code that can hold `vlogMu` and ask whether a lane is a leaf-log append lane. The immutable view means readers do not access the mutable lane slice directly; lane object state remains protected by each lane's `vlogMu`.

The fallback path still reads individual lane indexes under short `leafLogAppendMu.RLock` windows for uninitialized/test-only states, then releases that lock before checking `vlogMu`.

## Regression Assessment

No storage format, value-log persistence, WAL, sync, flush, rotate, or close semantics changed. The only new allocation is on lane publication/extension, not per read. Focused lookup benchmark improved allocation from `64 B/op, 1 alloc/op` to `0 B/op, 0 allocs/op`; ns/op samples are neutral-to-better under local benchmark noise.

Full durable all-tests profile confirmation is still a coordinator-level follow-up for #3518 after this PR head is selected; this PR provides the focused package gate requested by #3519.

## CI / Review Status

Latest-head CI: pending after PR creation.
AI reviews: not requested by this worker per coordinator instruction; leave Codex/Copilot/CodeRabbit requests to the coordinator after CI/review maturity.
Merge status: do not merge by worker; coordinator owns merge authorization.
