### PR TITLE
treedb: reduce append-only memtable allocations

### DIFF
--- a/TreeDB/internal/memtable/append_only.go
+++ b/TreeDB/internal/memtable/append_only.go
@@ -28,7 +28,7 @@ const (
 	appendOnlyEntryPoolMaxShift      = 20
 	appendOnlyEntryPoolClassCount    = appendOnlyEntryPoolMaxShift - appendOnlyEntryPoolMinShift + 1
 	appendOnlyEntryPoolMaxCap        = 1 << appendOnlyEntryPoolMaxShift // 1 << 20
-	appendOnlyEntryPoolRetainMaxCap  = 1 << 16
+	appendOnlyEntryPoolRetainMaxCap  = 1 << 17
 	appendOnlyMinInitialEntries      = 1 << appendOnlyEntryPoolMinShift // 128
 	appendOnlyMaxInitialEntries      = 1 << appendOnlyEntryPoolMaxShift // 1 << 20
 	appendOnlyIteratorPoolMaxCap     = 1 << 20
@@ -1441,8 +1441,14 @@ func (m *AppendOnly) appendEntryCoreLocked(key, value []byte, ptr page.ValuePtr,
 			ent.keyInline = true
 			ent.key = nil
 		} else {
-			ent.key = cloneOrReuseBytes(ent.key, key, appendOnlyReusableKeyMaxCap)
-			ent.keyReusable = true
+			if len(key) > 0 && len(key) <= appendOnlyReusableKeyMaxCap {
+				ent.key = m.keyArena.alloc(len(key))
+				copy(ent.key, key)
+				ent.keyArena = true
+			} else {
+				ent.key = cloneOrReuseBytes(ent.key, key, appendOnlyReusableKeyMaxCap)
+				ent.keyReusable = true
+			}
 		}
 		if len(value) > 0 {
 			if borrowValue {

--- a/TreeDB/internal/memtable/append_only_pool_test.go
+++ b/TreeDB/internal/memtable/append_only_pool_test.go
@@ -1,6 +1,7 @@
 package memtable
 
 import (
+	"bytes"
 	"encoding/binary"
 	"fmt"
 	"sync"
@@ -175,6 +176,36 @@ func TestPutAppendOnlyEntriesDropsOversizedRetainedSlice(t *testing.T) {
 	if got := after.AdmissionDropBytesTotal - before.AdmissionDropBytesTotal; got != wantBytes {
 		t.Fatalf("admission drop bytes delta=%d want %d", got, wantBytes)
 	}
+}
+
+func TestAppendOnlyEntryPoolRetainsLargeBatchHintClass(t *testing.T) {
+	DropAppendOnlyEntryPools()
+	t.Cleanup(DropAppendOnlyEntryPools)
+
+	const entries = 1 << 17
+	_, classCap, ok := appendOnlyEntryPoolClassForLength(entries)
+	if !ok {
+		t.Fatalf("entry count %d should map to a retained pool class", entries)
+	}
+	if classCap != entries {
+		t.Fatalf("class cap=%d want %d", classCap, entries)
+	}
+
+	before := AppendOnlyEntryPoolStatsSnapshot()
+	putAppendOnlyEntries(make([]appendOnlyEntry, 0, entries))
+	afterPut := AppendOnlyEntryPoolStatsSnapshot()
+	if got := afterPut.AdmissionDropsTotal - before.AdmissionDropsTotal; got != 0 {
+		t.Fatalf("admission drops delta=%d want 0", got)
+	}
+	if got := afterPut.PutsTotal - before.PutsTotal; got != 1 {
+		t.Fatalf("puts delta=%d want 1", got)
+	}
+
+	reused := getAppendOnlyEntries(entries)
+	if cap(reused) != entries {
+		t.Fatalf("reused cap=%d want %d", cap(reused), entries)
+	}
+	putAppendOnlyEntries(reused[:0])
 }
 
 func TestPutAppendOnlyEntriesRecyclesPoolsOnRetainBudgetPressure(t *testing.T) {
@@ -482,7 +513,7 @@ func TestAppendOnlyFrozenUnorderedIteratorBlocksResetUntilClose(t *testing.T) {
 	}
 }
 
-func TestAppendOnlyResetReusesEntryBuffers(t *testing.T) {
+func TestAppendOnlyResetReusesValueBuffersAndDropsArenaKeys(t *testing.T) {
 	m := NewAppendOnlyWithCapacity(0)
 	key1 := []byte("long-key-01")
 	val1 := []byte("value-aaaaaa")
@@ -490,8 +521,10 @@ func TestAppendOnlyResetReusesEntryBuffers(t *testing.T) {
 	if m.count != 1 {
 		t.Fatalf("count=%d want=1", m.count)
 	}
-	keyBufPtr := &m.entries[0].key[0]
 	valBufPtr := &m.entries[0].value[0]
+	if !m.entries[0].keyArena {
+		t.Fatalf("expected small non-inline key to use key arena")
+	}
 
 	m.Reset()
 	key2 := []byte("long-key-02")
@@ -500,8 +533,8 @@ func TestAppendOnlyResetReusesEntryBuffers(t *testing.T) {
 	if m.count != 1 {
 		t.Fatalf("count after reset=%d want=1", m.count)
 	}
-	if &m.entries[0].key[0] != keyBufPtr {
-		t.Fatalf("expected key buffer reuse across reset")
+	if !m.entries[0].keyArena {
+		t.Fatalf("expected small non-inline key to use key arena after reset")
 	}
 	if m.entries[0].value == nil || cap(m.entries[0].value) < len(val2) {
 		t.Fatalf("expected value buffer capacity reuse across reset")
@@ -519,23 +552,45 @@ func TestAppendOnlySetCopiesIntoArenaForNonSteal(t *testing.T) {
 		t.Fatalf("count=%d want=1", m.count)
 	}
 	ent := &m.entries[0]
+	if !ent.keyArena {
+		t.Fatalf("expected non-inline key to be copied into key arena")
+	}
 	if !ent.valueOwned {
 		t.Fatalf("expected non-steal set to mark valueOwned")
 	}
 	if len(ent.value) != len(src) {
 		t.Fatalf("entry value len=%d want=%d", len(ent.value), len(src))
 	}
+	key[0] = 'X'
 	if &ent.value[0] == &src[0] {
 		t.Fatalf("entry value unexpectedly aliases caller buffer")
 	}
 	src[0] = 'X'
 
-	got, tombstone, ok := m.Get(key)
+	got, tombstone, ok := m.Get([]byte("long-key-arena"))
 	if !ok || tombstone {
-		t.Fatalf("Get(%q) = ok=%v tombstone=%v; want ok=true tombstone=false", key, ok, tombstone)
+		t.Fatalf("Get(long-key-arena) = ok=%v tombstone=%v; want ok=true tombstone=false", ok, tombstone)
 	}
 	if string(got) != "value-arena-copy" {
 		t.Fatalf("stored value changed via source mutation: got=%q", got)
+	}
+}
+
+func TestAppendOnlyLargeNonInlineKeyUsesReusableSlice(t *testing.T) {
+	m := NewAppendOnlyWithCapacity(0)
+	key := bytes.Repeat([]byte("k"), appendOnlyReusableKeyMaxCap+1)
+
+	m.Set(key, []byte("value"))
+
+	if m.count != 1 {
+		t.Fatalf("count=%d want=1", m.count)
+	}
+	ent := &m.entries[0]
+	if ent.keyArena {
+		t.Fatalf("large key unexpectedly used key arena")
+	}
+	if !ent.keyReusable {
+		t.Fatalf("large key should keep reusable slice metadata")
 	}
 }
 

--- a/TreeDB/internal/memtable/append_only_test.go
+++ b/TreeDB/internal/memtable/append_only_test.go
@@ -97,6 +97,38 @@ func BenchmarkAppendOnlyBatchReserveGrowth(b *testing.B) {
 	}
 }
 
+func BenchmarkAppendOnlyEntryPoolLargeHintReuse(b *testing.B) {
+	const entries = 1 << 17
+
+	DropAppendOnlyEntryPools()
+	b.Cleanup(DropAppendOnlyEntryPools)
+	putAppendOnlyEntries(make([]appendOnlyEntry, 0, entries))
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		reused := getAppendOnlyEntries(entries)
+		putAppendOnlyEntries(reused[:0])
+	}
+}
+
+func BenchmarkAppendOnlySetBorrowValueSmallKeyAllocs(b *testing.B) {
+	DropAppendOnlyEntryPools()
+	b.Cleanup(DropAppendOnlyEntryPools)
+
+	mt := NewAppendOnlyWithEntryCapacity(b.N)
+	mt.ReserveAdditionalEntries(b.N)
+	value := []byte("borrowed-value")
+	var key [16]byte
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		binary.BigEndian.PutUint64(key[8:], uint64(i))
+		mt.SetEntryBorrowValue(key[:], value, page.ValuePtr{}, node.FlagInline)
+	}
+}
+
 func TestAppendOnlyInitialEntriesForCapacity(t *testing.T) {
 	t.Run("pointer-estimate", func(t *testing.T) {
 		capacity := defaultMemtableCapacity


### PR DESCRIPTION
Part of #3518.
Refs #3515.
Addresses #3529.

## Summary

- Retain the 131,072-entry append-only entry backing class in the existing bounded entry pool. The 10M post-#3523 artifact showed `batch_small_seq` reaching a 119,245-entry hint and recording entry-pool admission drops; this class rounds to 131,072 entries.
- Copy small non-inline public/memtable keys into the existing append-only key arena instead of allocating one Go slice object per key. This preserves public `Set` aliasing safety because keys are still copied into memtable-owned storage.
- Keep 8-byte keys on the inline path and oversized keys on the previous reusable-slice path to avoid arena rounding for large keys.
- Add focused tests/benchmarks for the retained entry-pool class, small-key arena ownership, large-key fallback, and allocation behavior.

## Allocation evidence

Baseline before key-arena change, same branch with only the benchmark added:

```text
go test ./TreeDB/internal/memtable -run '^$' -bench 'BenchmarkAppendOnlySetBorrowValueSmallKeyAllocs' -benchmem -benchtime=100000x -count=5
BenchmarkAppendOnlySetBorrowValueSmallKeyAllocs-8  100000  23.27 ns/op  16 B/op  1 allocs/op
BenchmarkAppendOnlySetBorrowValueSmallKeyAllocs-8  100000  21.58 ns/op  16 B/op  1 allocs/op
BenchmarkAppendOnlySetBorrowValueSmallKeyAllocs-8  100000  21.88 ns/op  16 B/op  1 allocs/op
BenchmarkAppendOnlySetBorrowValueSmallKeyAllocs-8  100000  20.96 ns/op  16 B/op  1 allocs/op
BenchmarkAppendOnlySetBorrowValueSmallKeyAllocs-8  100000  22.12 ns/op  16 B/op  1 allocs/op
```

After:

```text
go test ./TreeDB/internal/memtable -run '^$' -bench 'BenchmarkAppendOnlySetBorrowValueSmallKeyAllocs' -benchmem -benchtime=100000x -count=5
BenchmarkAppendOnlySetBorrowValueSmallKeyAllocs-8  100000  25.74 ns/op  16 B/op  0 allocs/op
BenchmarkAppendOnlySetBorrowValueSmallKeyAllocs-8  100000  16.07 ns/op  16 B/op  0 allocs/op
BenchmarkAppendOnlySetBorrowValueSmallKeyAllocs-8  100000  15.62 ns/op  16 B/op  0 allocs/op
BenchmarkAppendOnlySetBorrowValueSmallKeyAllocs-8  100000  15.71 ns/op  16 B/op  0 allocs/op
BenchmarkAppendOnlySetBorrowValueSmallKeyAllocs-8  100000  15.58 ns/op  16 B/op  0 allocs/op
```

Entry backing pool baseline before retain-cap change, same branch with only the benchmark added:

```text
go test ./TreeDB/internal/memtable -run '^$' -bench 'BenchmarkAppendOnlyEntryPoolLargeHintReuse' -benchmem -benchtime=1000x -count=5
BenchmarkAppendOnlyEntryPoolLargeHintReuse-8  1000  192229 ns/op  11534355 B/op  1 allocs/op
BenchmarkAppendOnlyEntryPoolLargeHintReuse-8  1000  186821 ns/op  11534346 B/op  1 allocs/op
BenchmarkAppendOnlyEntryPoolLargeHintReuse-8  1000  187654 ns/op  11534338 B/op  1 allocs/op
BenchmarkAppendOnlyEntryPoolLargeHintReuse-8  1000  206718 ns/op  11534344 B/op  1 allocs/op
BenchmarkAppendOnlyEntryPoolLargeHintReuse-8  1000  193473 ns/op  11534340 B/op  1 allocs/op
```

After:

```text
go test ./TreeDB/internal/memtable -run '^$' -bench 'BenchmarkAppendOnlyEntryPoolLargeHintReuse' -benchmem -benchtime=1000x -count=5
BenchmarkAppendOnlyEntryPoolLargeHintReuse-8  1000  139078 ns/op      24 B/op  1 allocs/op
BenchmarkAppendOnlyEntryPoolLargeHintReuse-8  1000  154085 ns/op      24 B/op  1 allocs/op
BenchmarkAppendOnlyEntryPoolLargeHintReuse-8  1000  145222 ns/op   11559 B/op  1 allocs/op
BenchmarkAppendOnlyEntryPoolLargeHintReuse-8  1000  156387 ns/op      24 B/op  1 allocs/op
BenchmarkAppendOnlyEntryPoolLargeHintReuse-8  1000  149202 ns/op   11559 B/op  1 allocs/op
```

The remaining allocation in the entry-pool benchmark is not one backing array per operation; the high samples are one 11.5 MiB backing allocation amortized across the 1000 fixed iterations after `sync.Pool` behavior, versus one 11.5 MiB backing allocation per operation before.

## Validation

```text
go test ./TreeDB/internal/memtable -run 'TestAppendOnlyResetReusesValueBuffersAndDropsArenaKeys|TestAppendOnlySetCopiesIntoArenaForNonSteal|TestAppendOnlyLargeNonInlineKeyUsesReusableSlice|TestAppendOnlyEntryPoolRetainsLargeBatchHintClass|TestPutAppendOnlyEntriesDropsOversizedRetainedSlice|TestAppendOnlyResetWithCapacityHard' -count=1
ok  github.com/snissn/gomap/TreeDB/internal/memtable  0.786s
```

```text
go test ./TreeDB/internal/memtable -count=1
ok  github.com/snissn/gomap/TreeDB/internal/memtable  0.789s
```

```text
go test ./TreeDB/caching -count=1
ok  github.com/snissn/gomap/TreeDB/caching  55.076s
```

```text
go test ./TreeDB -count=1
ok  github.com/snissn/gomap/TreeDB  37.182s
```

```text
go run ./cmd/unified_bench -profile durable -dbs treedb -keys 100000 -valsize 128 -batchsize 8000 -checkpoint-between-tests -treedb-journal-lanes=1 -progress=false -test batch_small_seq,dataset_write_random -path-label native-fastpath -format markdown
Batch Small Seq / TreeDB = 3,222,632
Dataset Write (Random) / TreeDB = 1,913,854
```

## Notes

- Public `Set` aliasing safety is preserved: keys are still copied before entering the table, and the focused tests mutate caller buffers after `Set`.
- I did not change `TreeDB/caching.getEntrySlice` in this PR. The focused local `BenchmarkBuildOpRunsAllocs` baseline was already at 90-97 B/op and 2 allocs/op, so this branch targets the memtable-owned allocation sites with a clear reproduction.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved append-only memtable reuse behavior for keys and values, reducing unnecessary allocations and preserving stored data correctly after resets.
  * Increased the maximum retained pool capacity so larger batches can be reused more reliably.

* **Tests**
  * Expanded coverage for pool reuse, key ownership, value buffering, and reset behavior.
  * Added benchmarks to track reuse performance and allocation behavior for common write paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->