### PR TITLE
treedb: reduce zipper split allocation churn

### DIFF
--- a/TreeDB/node/builder.go
+++ b/TreeDB/node/builder.go
@@ -394,6 +394,26 @@ func (b *Builder) SetInternalFenceBounds(low, high []byte) {
 	}
 }
 
+// SetInternalFenceBoundsBorrowed configures exact subtree bounds without
+// copying the key slices. Callers must keep low and high immutable until
+// Finish or FinishNoNode copies the bounds into the encoded page.
+func (b *Builder) SetInternalFenceBoundsBorrowed(low, high []byte) {
+	if b.pType != page.PageTypeInternal {
+		return
+	}
+	b.internalFenceBounds = true
+	if len(low) == 0 {
+		b.internalFenceLow = nil
+	} else {
+		b.internalFenceLow = low
+	}
+	if len(high) == 0 {
+		b.internalFenceHigh = nil
+	} else {
+		b.internalFenceHigh = high
+	}
+}
+
 func (b *Builder) FreeSpace() int {
 	return b.heapStart - b.dirEnd
 }

--- a/TreeDB/node/internal_base_delta_test.go
+++ b/TreeDB/node/internal_base_delta_test.go
@@ -217,6 +217,44 @@ func TestInternalBaseDelta_CompactPreservesFooter(t *testing.T) {
 	}
 }
 
+func TestInternalBaseDelta_BorrowedFenceBoundsCopiedOnFinish(t *testing.T) {
+	buf := make([]byte, page.PageSize)
+	low := []byte("user:00000000")
+	high := []byte("user:00000099")
+	wantLow := append([]byte(nil), low...)
+	wantHigh := append([]byte(nil), high...)
+
+	b := NewBuilderWithOptions(buf, page.PageTypeInternal, BuilderOptions{InternalBaseDelta: true})
+	b.SetPageID(1)
+	b.SetInternalFenceBoundsBorrowed(low, high)
+	for i := 0; i < 16; i++ {
+		key := []byte(fmt.Sprintf("user:%08d", i))
+		if err := b.AddInternalChild(key, uint64(1_000+i)); err != nil {
+			t.Fatalf("AddInternalChild: %v", err)
+		}
+	}
+	b.FinishNoNode()
+
+	for i := range low {
+		low[i] = 'x'
+	}
+	for i := range high {
+		high[i] = 'y'
+	}
+
+	n := NewNode(buf)
+	gotLow, gotHigh, ok, err := n.InternalFenceBounds()
+	if err != nil {
+		t.Fatalf("InternalFenceBounds: %v", err)
+	}
+	if !ok {
+		t.Fatalf("expected persisted fence bounds")
+	}
+	if !bytes.Equal(gotLow, wantLow) || !bytes.Equal(gotHigh, wantHigh) {
+		t.Fatalf("unexpected fence bounds low=%q high=%q want low=%q high=%q", gotLow, gotHigh, wantLow, wantHigh)
+	}
+}
+
 func TestInternalBaseDelta_SplitRoundTrip(t *testing.T) {
 	const nKeys = 32
 

--- a/TreeDB/zipper/span_native_apply.go
+++ b/TreeDB/zipper/span_native_apply.go
@@ -903,7 +903,7 @@ func (z *Zipper) reduceSpanNativeRootWithContext(rootID uint64, replacements spa
 			if len(out.splits) == 0 {
 				var one [1]Split
 				one[0] = spanNativeReplacementHeadSplit(replacements.spans[0], out)
-				return z.reduceSpanNativeRoot(one[:], metrics)
+				return z.reduceSpanNativeRootWithScratch(one[:], metrics, scratch)
 			}
 		}
 		refCap := replacements.len()
@@ -917,7 +917,7 @@ func (z *Zipper) reduceSpanNativeRootWithContext(rootID uint64, replacements spa
 			refs = append(refs, spanNativeReplacementHeadSplit(replacements.spans[i], out))
 			refs = append(refs, out.splits...)
 		}
-		return z.reduceSpanNativeRoot(refs, metrics)
+		return z.reduceSpanNativeRootWithScratch(refs, metrics, scratch)
 	}
 	ref, splits, changed, err := z.stitchSpanNativeRecursive(page.PageChildRef(rootID), nil, nil, replacements, metrics, retired, scratch)
 	if err != nil {
@@ -929,13 +929,13 @@ func (z *Zipper) reduceSpanNativeRootWithContext(rootID uint64, replacements spa
 	if len(splits) == 0 {
 		var one [1]Split
 		one[0] = Split{Key: []byte{}, Ref: ref}
-		return z.reduceSpanNativeRoot(one[:], metrics)
+		return z.reduceSpanNativeRootWithScratch(one[:], metrics, scratch)
 	}
 	refs := scratch.acquireSpanRootRefs(len(splits) + 1)
 	defer scratch.releaseSpanRootRefs(refs)
 	refs = append(refs, Split{Key: []byte{}, Ref: ref})
 	refs = append(refs, splits...)
-	return z.reduceSpanNativeRoot(refs, metrics)
+	return z.reduceSpanNativeRootWithScratch(refs, metrics, scratch)
 }
 
 func spanNativeReplacementHeadSplit(span ReadOnlyLeafSpan, output spanNativeLeafOutput) Split {
@@ -1047,7 +1047,7 @@ func (z *Zipper) stitchSpanNativeRecursive(ref page.ChildRef, low, high []byte, 
 	case page.PageTypeInternal:
 		count := oldNode.Count()
 		copyKeys := oldNode.InternalBaseDeltaEnabled()
-		writer := spanNativeSplitLevelWriter{z: z, metrics: metrics}
+		writer := spanNativeSplitLevelWriter{z: z, metrics: metrics, scratch: scratch}
 		defer writer.abort()
 		changed := false
 		replacementIdx := 0
@@ -1146,11 +1146,13 @@ func (z *Zipper) stitchSpanNativeRecursive(ref page.ChildRef, low, high []byte, 
 }
 
 type spanNativeSplitLevelWriter struct {
-	z               *Zipper
-	metrics         *adaptive.Metrics
-	nextLevelNodes  []Split
-	currentBuilder  *node.Builder
-	currentStartKey []byte
+	z                *Zipper
+	metrics          *adaptive.Metrics
+	scratch          *mergeScratch
+	nextLevelSegment mergeSplitSegment
+	nextLevelNodes   []Split
+	currentBuilder   *node.Builder
+	currentStartKey  []byte
 }
 
 func (w *spanNativeSplitLevelWriter) append(child Split) error {
@@ -1170,7 +1172,7 @@ func (w *spanNativeSplitLevelWriter) append(child Split) error {
 		w.currentBuilder = w.z.newPooledBuilderForType(data, page.PageTypeInternal, nil)
 		w.currentBuilder.SetPageID(pid)
 		w.currentStartKey = child.Key
-		w.currentBuilder.SetInternalFenceBounds(w.currentStartKey, nil)
+		w.currentBuilder.SetInternalFenceBoundsBorrowed(w.currentStartKey, nil)
 	}
 
 	childKey := child.Key
@@ -1206,7 +1208,7 @@ func (w *spanNativeSplitLevelWriter) append(child Split) error {
 		w.currentBuilder = w.z.newPooledBuilderForType(data, page.PageTypeInternal, nil)
 		w.currentBuilder.SetPageID(pid)
 		w.currentStartKey = child.Key
-		w.currentBuilder.SetInternalFenceBounds(w.currentStartKey, nil)
+		w.currentBuilder.SetInternalFenceBoundsBorrowed(w.currentStartKey, nil)
 
 		if addErr := w.currentBuilder.AddInternalChildRef(childKey, child.Ref); addErr != nil {
 			return addErr
@@ -1222,7 +1224,11 @@ func (w *spanNativeSplitLevelWriter) finishCurrent() uint64 {
 	pageID := w.currentBuilder.PageID()
 	w.currentBuilder.FinishNoNode()
 	recordZipperInternalPageWrite(w.metrics)
-	w.nextLevelNodes = append(w.nextLevelNodes, Split{Key: w.currentStartKey, Ref: page.PageChildRef(pageID)})
+	if w.nextLevelNodes == nil {
+		w.nextLevelSegment = newMergeSplitSegment(w.scratch)
+		w.nextLevelNodes = w.nextLevelSegment.data
+	}
+	w.nextLevelNodes = w.nextLevelSegment.append(Split{Key: w.currentStartKey, Ref: page.PageChildRef(pageID)})
 	releasePooledBuilder(w.currentBuilder)
 	w.currentBuilder = nil
 	return pageID
@@ -1257,6 +1263,10 @@ func spanNativeReplacementOverlapsRange(span ReadOnlyLeafSpan, low, high []byte)
 }
 
 func (z *Zipper) reduceSpanNativeRoot(currentLevelNodes []Split, metrics *adaptive.Metrics) (uint64, error) {
+	return z.reduceSpanNativeRootWithScratch(currentLevelNodes, metrics, nil)
+}
+
+func (z *Zipper) reduceSpanNativeRootWithScratch(currentLevelNodes []Split, metrics *adaptive.Metrics, scratch *mergeScratch) (uint64, error) {
 	if err := validateSpanNativeReducerRefs(currentLevelNodes); err != nil {
 		return 0, fmt.Errorf("%w: %v", ErrSpanNativeReducerValidation, err)
 	}
@@ -1265,7 +1275,7 @@ func (z *Zipper) reduceSpanNativeRoot(currentLevelNodes []Split, metrics *adapti
 			return z.ensureRootPage(currentLevelNodes[0].Key, currentLevelNodes[0].Ref, metrics)
 		}
 		metrics.ZipperRootSplitLevels++
-		nextLevelNodes, err := z.reduceSpanNativeSplitLevel(currentLevelNodes, metrics)
+		nextLevelNodes, err := z.reduceSpanNativeSplitLevel(currentLevelNodes, metrics, scratch)
 		if err != nil {
 			return 0, err
 		}
@@ -1290,8 +1300,9 @@ func validateSpanNativeReducerRefs(refs []Split) error {
 	return nil
 }
 
-func (z *Zipper) reduceSpanNativeSplitLevel(currentLevelNodes []Split, metrics *adaptive.Metrics) ([]Split, error) {
-	var nextLevelNodes []Split
+func (z *Zipper) reduceSpanNativeSplitLevel(currentLevelNodes []Split, metrics *adaptive.Metrics, scratch *mergeScratch) ([]Split, error) {
+	nextLevelSegment := newMergeSplitSegment(scratch)
+	nextLevelNodes := nextLevelSegment.data
 	var currentBuilder *node.Builder
 	var currentStartKey []byte
 
@@ -1312,7 +1323,7 @@ func (z *Zipper) reduceSpanNativeSplitLevel(currentLevelNodes []Split, metrics *
 			currentBuilder = z.newBuilderForType(data, page.PageTypeInternal, nil)
 			currentBuilder.SetPageID(pid)
 			currentStartKey = child.Key
-			currentBuilder.SetInternalFenceBounds(currentStartKey, nil)
+			currentBuilder.SetInternalFenceBoundsBorrowed(currentStartKey, nil)
 		}
 
 		childKey := child.Key
@@ -1337,7 +1348,7 @@ func (z *Zipper) reduceSpanNativeSplitLevel(currentLevelNodes []Split, metrics *
 		if err == node.ErrNodeFull {
 			currentBuilder.FinishNoNode()
 			recordZipperInternalPageWrite(metrics)
-			nextLevelNodes = append(nextLevelNodes, Split{Key: currentStartKey, Ref: page.PageChildRef(currentBuilder.PageID())})
+			nextLevelNodes = nextLevelSegment.append(Split{Key: currentStartKey, Ref: page.PageChildRef(currentBuilder.PageID())})
 
 			pid, allocErr := z.allocator.Alloc(currentBuilder.PageID())
 			if allocErr != nil {
@@ -1350,7 +1361,7 @@ func (z *Zipper) reduceSpanNativeSplitLevel(currentLevelNodes []Split, metrics *
 			currentBuilder = z.newBuilderForType(data, page.PageTypeInternal, nil)
 			currentBuilder.SetPageID(pid)
 			currentStartKey = child.Key
-			currentBuilder.SetInternalFenceBounds(currentStartKey, nil)
+			currentBuilder.SetInternalFenceBoundsBorrowed(currentStartKey, nil)
 
 			if addErr := currentBuilder.AddInternalChildRef(childKey, child.Ref); addErr != nil {
 				return nil, addErr
@@ -1363,7 +1374,7 @@ func (z *Zipper) reduceSpanNativeSplitLevel(currentLevelNodes []Split, metrics *
 		if i == len(currentLevelNodes)-1 {
 			currentBuilder.FinishNoNode()
 			recordZipperInternalPageWrite(metrics)
-			nextLevelNodes = append(nextLevelNodes, Split{Key: currentStartKey, Ref: page.PageChildRef(currentBuilder.PageID())})
+			nextLevelNodes = nextLevelSegment.append(Split{Key: currentStartKey, Ref: page.PageChildRef(currentBuilder.PageID())})
 			currentBuilder = nil
 		}
 	}

--- a/TreeDB/zipper/zipper.go
+++ b/TreeDB/zipper/zipper.go
@@ -176,6 +176,8 @@ type pendingLeafPagePersist struct {
 const (
 	mergeSplitKeyArenaInitCap         = page.PageSize
 	mergeSplitKeyArenaKeepCap         = 1 << 20
+	mergeSplitArenaInitCap            = 64
+	mergeSplitArenaKeepCap            = 1 << 15
 	mergeOuterLeafPageInitCap         = 16
 	mergeOuterLeafPageKeepCap         = 128
 	mergeLeafPageScratchInit          = 16
@@ -210,6 +212,7 @@ const (
 type mergeScratch struct {
 	mu                        sync.Mutex
 	splitKeyArena             []byte
+	splitArena                []Split
 	outerLeafBuildPages       []*outerLeafBuildPage
 	leafPageScratch           [][]byte
 	nodeKeyScratch            [][]byte
@@ -227,6 +230,7 @@ type mergeScratch struct {
 func newMergeScratch() *mergeScratch {
 	return &mergeScratch{
 		splitKeyArena:             make([]byte, 0, mergeSplitKeyArenaInitCap),
+		splitArena:                make([]Split, 0, mergeSplitArenaInitCap),
 		outerLeafBuildPages:       make([]*outerLeafBuildPage, 0, mergeOuterLeafPageInitCap),
 		leafPageScratch:           make([][]byte, 0, mergeLeafPageScratchInit),
 		nodeKeyScratch:            make([][]byte, 0, mergeNodeKeyScratchInit),
@@ -261,6 +265,12 @@ func (s *mergeScratch) reset() {
 		s.splitKeyArena = make([]byte, 0, mergeSplitKeyArenaInitCap)
 	} else {
 		s.splitKeyArena = s.splitKeyArena[:0]
+	}
+	if cap(s.splitArena) > mergeSplitArenaKeepCap {
+		s.splitArena = make([]Split, 0, mergeSplitArenaInitCap)
+	} else {
+		clear(s.splitArena)
+		s.splitArena = s.splitArena[:0]
 	}
 	if cap(s.outerLeafBuildPages) > mergeOuterLeafPageKeepCap {
 		s.outerLeafBuildPages = make([]*outerLeafBuildPage, 0, mergeOuterLeafPageInitCap)
@@ -336,6 +346,48 @@ func (s *mergeScratch) reset() {
 		clear(s.spanRootRefsScratch)
 		s.spanRootRefsScratch = s.spanRootRefsScratch[:0]
 	}
+}
+
+type mergeSplitSegment struct {
+	scratch *mergeScratch
+	start   int
+	data    []Split
+}
+
+func newMergeSplitSegment(s *mergeScratch) mergeSplitSegment {
+	if s == nil {
+		return mergeSplitSegment{}
+	}
+	s.mu.Lock()
+	start := len(s.splitArena)
+	data := s.splitArena[start:start:start]
+	s.mu.Unlock()
+	return mergeSplitSegment{scratch: s, start: start, data: data}
+}
+
+func (seg *mergeSplitSegment) append(split Split) []Split {
+	if seg.scratch == nil {
+		seg.data = append(seg.data, split)
+		return seg.data
+	}
+	s := seg.scratch
+	s.mu.Lock()
+	if len(s.splitArena) == seg.start+len(seg.data) {
+		s.splitArena = append(s.splitArena, split)
+		seg.data = s.splitArena[seg.start:len(s.splitArena):len(s.splitArena)]
+		s.mu.Unlock()
+		return seg.data
+	}
+	s.mu.Unlock()
+
+	// This should only happen if a caller appends to an older returned segment.
+	// Fall back to an owned slice so previously returned split ranges stay stable.
+	owned := make([]Split, len(seg.data), len(seg.data)+1)
+	copy(owned, seg.data)
+	owned = append(owned, split)
+	seg.scratch = nil
+	seg.data = owned
+	return seg.data
 }
 
 func (s *mergeScratch) acquireOuterLeafBuildPage() *outerLeafBuildPage {
@@ -1619,7 +1671,7 @@ func (z *Zipper) applyWithConfig(rootID uint64, b *batch.Batch, cfg applyRunConf
 					currentBuilder.SetPageID(pid)
 
 					currentStartKey = child.Key
-					currentBuilder.SetInternalFenceBounds(currentStartKey, nil)
+					currentBuilder.SetInternalFenceBoundsBorrowed(currentStartKey, nil)
 				}
 
 				// Add child
@@ -1661,7 +1713,7 @@ func (z *Zipper) applyWithConfig(rootID uint64, b *batch.Batch, cfg applyRunConf
 					currentBuilder = z.newBuilderForType(data, page.PageTypeInternal, nil)
 					currentBuilder.SetPageID(pid)
 					currentStartKey = child.Key
-					currentBuilder.SetInternalFenceBounds(currentStartKey, nil)
+					currentBuilder.SetInternalFenceBoundsBorrowed(currentStartKey, nil)
 
 					if err := currentBuilder.AddInternalChildRef(childKey, child.Ref); err != nil {
 						return 0, nil, metrics, err // Should fit in empty node
@@ -2084,7 +2136,7 @@ func (z *Zipper) ensureRootPage(key []byte, ref page.ChildRef, metrics *adaptive
 	if key == nil {
 		key = []byte{}
 	}
-	b.SetInternalFenceBounds(key, nil)
+	b.SetInternalFenceBoundsBorrowed(key, nil)
 	if err := b.AddInternalChildRef(key, ref); err != nil {
 		return 0, err
 	}
@@ -2164,7 +2216,7 @@ func (z *Zipper) writeRecursive(ref page.ChildRef, ops []batch.Entry, ranges []b
 		builder := z.newPooledBuilderForType(newData, page.PageTypeInternal, ops)
 		defer releasePooledBuilder(builder)
 		builder.SetPageID(newPageID)
-		builder.SetInternalFenceBounds(low, high)
+		builder.SetInternalFenceBoundsBorrowed(low, high)
 		nr, splits, err := z.mergeInternal(&oldNode, builder, ops, ranges, maintenance, budget, metrics, retired, low, high, scratch, cfg)
 		if err != nil {
 			return page.ChildRef{}, nil, err
@@ -2210,6 +2262,7 @@ func (z *Zipper) mergeLeaf(oldNode *node.Node, builder *node.Builder, ops []batc
 		rootPersisted           bool
 		pendingSplitIdx         int
 		pendingLeafPagePersists []pendingLeafPagePersist
+		splitSegment            mergeSplitSegment
 	)
 	pendingSplitIdx = -1
 	batchLeafPagePersists := z.outerLeavesInValueLog && reuseOuterLeafPages
@@ -2496,15 +2549,10 @@ func (z *Zipper) mergeLeaf(oldNode *node.Node, builder *node.Builder, ops []batc
 			// from source buffers into apply-lifetime scratch.
 			splitE.Key = scratch.cloneSplitKey(key)
 			if splits == nil {
-				hint := len(ops) / 16
-				if hint < 1 {
-					hint = 1
-				} else if hint > 512 {
-					hint = 512
-				}
-				splits = make([]Split, 0, hint)
+				splitSegment = newMergeSplitSegment(scratch)
+				splits = splitSegment.data
 			}
-			splits = append(splits, splitE)
+			splits = splitSegment.append(splitE)
 			pendingSplitIdx = len(splits) - 1
 
 			target = splitBuilder
@@ -4110,7 +4158,7 @@ func (z *Zipper) createNewSplitInternal(currentTarget, rootBuilder *node.Builder
 
 	sb := z.newBuilderForType(sdata, page.PageTypeInternal, nil)
 	sb.SetPageID(sid)
-	sb.SetInternalFenceBounds(key, nil)
+	sb.SetInternalFenceBoundsBorrowed(key, nil)
 
 	*splits = append(*splits, Split{Key: scratch.cloneSplitKey(key), Ref: page.PageChildRef(sid)})
 

--- a/TreeDB/zipper/zipper_test.go
+++ b/TreeDB/zipper/zipper_test.go
@@ -30,6 +30,24 @@ func (m *MockAllocator) Alloc(hint uint64) (uint64, error) {
 	return m.p.Alloc(1)
 }
 
+type benchmarkCyclingAllocator struct {
+	ids  []uint64
+	next int
+}
+
+func (a *benchmarkCyclingAllocator) reset() {
+	a.next = 0
+}
+
+func (a *benchmarkCyclingAllocator) Alloc(hint uint64) (uint64, error) {
+	if len(a.ids) == 0 {
+		return 0, fmt.Errorf("zipper benchmark allocator has no page IDs")
+	}
+	id := a.ids[a.next%len(a.ids)]
+	a.next++
+	return id, nil
+}
+
 type panicValueReader struct{}
 
 func (panicValueReader) Read(ptr page.ValuePtr) ([]byte, error) {
@@ -1101,6 +1119,52 @@ func TestZipperMergeScratch_ReusesAndClearsLeafPageBatchScratch(t *testing.T) {
 	s.releaseLeafPageBatch(reused)
 }
 
+func TestZipperMergeScratch_ReusesSplitArenaSegments(t *testing.T) {
+	s := newMergeScratch()
+	firstSegment := newMergeSplitSegment(s)
+	first := firstSegment.append(Split{Key: []byte("a"), Ref: page.PageChildRef(1)})
+	if len(first) != 1 || !bytes.Equal(first[0].Key, []byte("a")) {
+		t.Fatalf("unexpected first split segment: %+v", first)
+	}
+
+	secondSegment := newMergeSplitSegment(s)
+	second := secondSegment.append(Split{Key: []byte("b"), Ref: page.PageChildRef(2)})
+	if len(second) != 1 || !bytes.Equal(second[0].Key, []byte("b")) {
+		t.Fatalf("unexpected second split segment: %+v", second)
+	}
+	if len(first) != 1 || !bytes.Equal(first[0].Key, []byte("a")) {
+		t.Fatalf("first segment changed after second segment append: %+v", first)
+	}
+
+	extendedFirst := firstSegment.append(Split{Key: []byte("c"), Ref: page.PageChildRef(3)})
+	if len(extendedFirst) != 2 {
+		t.Fatalf("extended first segment len=%d want 2", len(extendedFirst))
+	}
+	if !bytes.Equal(extendedFirst[0].Key, []byte("a")) || !bytes.Equal(extendedFirst[1].Key, []byte("c")) {
+		t.Fatalf("extended first segment mismatch: %+v", extendedFirst)
+	}
+	if len(s.splitArena) != 2 {
+		t.Fatalf("fallback append should not grow arena, len=%d", len(s.splitArena))
+	}
+
+	arena := s.splitArena
+	s.reset()
+	if len(s.splitArena) != 0 {
+		t.Fatalf("split arena len=%d want 0 after reset", len(s.splitArena))
+	}
+	for i, split := range arena[:2] {
+		if split.Key != nil || split.Ref != (page.ChildRef{}) {
+			t.Fatalf("split arena retained slot %d: %+v", i, split)
+		}
+	}
+
+	s.splitArena = make([]Split, 0, mergeSplitArenaKeepCap+1)
+	s.reset()
+	if cap(s.splitArena) > mergeSplitArenaKeepCap {
+		t.Fatalf("oversized split arena cap=%d exceeds keep %d", cap(s.splitArena), mergeSplitArenaKeepCap)
+	}
+}
+
 func TestZipperMergeScratch_ReusesChildRefBatchScratchWithoutClearing(t *testing.T) {
 	s := newMergeScratch()
 	buf := s.acquireChildRefBatch(2)
@@ -1399,6 +1463,71 @@ func BenchmarkMergeLeafOuterLeafBatchScratch(b *testing.B) {
 			b.Fatalf("mergeLeaf: %v", err)
 		}
 	}
+}
+
+func BenchmarkReduceSpanNativeSplitLevelScratch(b *testing.B) {
+	const (
+		refCount      = 4096
+		scratchPages  = 128
+		benchmarkSeed = 0x3524
+	)
+
+	dir := b.TempDir()
+	p, err := pager.Open(filepath.Join(dir, "index.db"), 65536)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer p.Close()
+
+	ids := make([]uint64, scratchPages)
+	for i := range ids {
+		id, err := p.Alloc(1)
+		if err != nil {
+			b.Fatalf("alloc scratch page: %v", err)
+		}
+		ids[i] = id
+	}
+	alloc := &benchmarkCyclingAllocator{ids: ids}
+	z := New(p, alloc)
+
+	refs := make([]Split, refCount)
+	for i := range refs {
+		key := make([]byte, 16)
+		binary.BigEndian.PutUint64(key[:8], benchmarkSeed)
+		binary.BigEndian.PutUint64(key[8:], uint64(i))
+		refs[i] = Split{Key: key, Ref: page.PageChildRef(uint64(i + 1))}
+	}
+
+	b.Run("heap", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			alloc.reset()
+			var metrics adaptive.Metrics
+			out, err := z.reduceSpanNativeSplitLevel(refs, &metrics, nil)
+			if err != nil {
+				b.Fatalf("reduceSpanNativeSplitLevel: %v", err)
+			}
+			if len(out) == 0 {
+				b.Fatalf("empty reducer output")
+			}
+		}
+	})
+	b.Run("scratch", func(b *testing.B) {
+		scratch := newMergeScratch()
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			alloc.reset()
+			var metrics adaptive.Metrics
+			out, err := z.reduceSpanNativeSplitLevel(refs, &metrics, scratch)
+			if err != nil {
+				b.Fatalf("reduceSpanNativeSplitLevel: %v", err)
+			}
+			if len(out) == 0 {
+				b.Fatalf("empty reducer output")
+			}
+			scratch.reset()
+		}
+	})
 }
 
 func BenchmarkZipperApplyOuterLeafRandomOverwrite(b *testing.B) {


### PR DESCRIPTION
Part of #3518.
Closes #3530.
Refs #3524.

## Summary

- Add a scratch-backed `[]Split` arena for zipper split lists and use it in `mergeLeaf`, span-native parent stitching, and span-native root/split reduction.
- Add `node.Builder.SetInternalFenceBoundsBorrowed` for zipper-owned builder lifetimes so hot internal-page paths do not clone fence keys before `Finish`/`FinishNoNode` encodes them.
- Add focused tests for split arena reset/stability and borrowed fence-bound persistence, plus a reducer allocation benchmark.

## Allocation evidence

Baseline worktree: `/tmp/gomap-3524-3530-baseline` at `18937354c2129970024c911aafcdc9d3ce6ea616`.
Feature branch worktree: `/tmp/gomap-3524-3530-zipper` at `9521f86c7`.

Command:

```sh
GOWORK=off go test ./TreeDB/zipper -run '^$' -bench 'BenchmarkMergeLeafOuterLeafBatchScratch|BenchmarkZipperApplyOuterLeafRandomOverwrite' -benchmem -count=5
benchstat /tmp/gomap_3524_3530_bench_before.txt /tmp/gomap_3524_3530_bench_after.txt
```

Key `benchstat` results:

- `BenchmarkMergeLeafOuterLeafBatchScratch`: `8068 B/op -> 5763 B/op` (`-28.57%`), `4 allocs/op -> 3 allocs/op` (`-25.00%`).
- `BenchmarkZipperApplyOuterLeafRandomOverwrite`: `~361.9 KiB/op -> ~238.6 KiB/op` (`-34.08%`), `~4.325k allocs/op -> ~2.312k allocs/op` (`-46.54%`).
- Runtime did not show a statistically significant improvement in this local run, so this PR only claims allocation reduction.

New focused reducer benchmark:

```sh
GOWORK=off go test ./TreeDB/zipper -run '^$' -bench 'BenchmarkReduceSpanNativeSplitLevelScratch' -benchmem -count=5
```

- Heap split-list path: `19264 B/op`, `35 allocs/op`.
- Scratch split-list path: `14848 B/op`, `29 allocs/op`.

## Validation

```sh
GOWORK=off go test ./TreeDB/zipper ./TreeDB/node
# ok github.com/snissn/gomap/TreeDB/zipper 0.662s
# ok github.com/snissn/gomap/TreeDB/node cached

GOWORK=off go test ./TreeDB -run 'TestReopenVerify_WALOn_Checkpoint|TestReopenVerify_WALOn_WriteSync'
# ok github.com/snissn/gomap/TreeDB 3.172s

GOWORK=off go test ./TreeDB/db -run 'TestValueLogGC_RemovesUnreferencedSegment'
# ok github.com/snissn/gomap/TreeDB/db 0.506s

GOWORK=off go test ./TreeDB -run 'Test.*Delete|Test.*WAL|Test.*Recovery'
# ok github.com/snissn/gomap/TreeDB 7.529s

GOWORK=off go test ./TreeDB/zipper -run '^$' -bench 'BenchmarkMergeLeafOuterLeafBatchScratch|BenchmarkZipperApplyOuterLeafRandomOverwrite' -benchmem -count=5
# PASS, see benchstat evidence above

GOWORK=off go test ./TreeDB/zipper -run '^$' -bench 'BenchmarkReduceSpanNativeSplitLevelScratch' -benchmem -count=5
# PASS, see reducer evidence above

GOWORK=off go test ./TreeDB/...
# ok sweep, including TreeDB, TreeDB/caching, TreeDB/collections, TreeDB/db, TreeDB/node, TreeDB/zipper
```

## #3524 classification

This branch intentionally keeps `cachePersistedLeafPage` as an owning copy. The leaf-ref cache is active only for in-flight maintenance/apply windows, and persist paths can pass builder or scratch buffers that are reused later in the same `Apply` call. Aliasing those buffers would risk serving mutated page bytes back through the cache. The PR reduces adjacent delete/writeRecursive fence-bound allocation, but does not replace that page-cache ownership copy.

No on-disk format, WAL, or persistent value-log behavior is changed. This branch does not touch `TreeDB/internal/memtable` or `TreeDB/caching` memtable/flush pools.
