### PR TITLE
treedb: retain hot entry-slice leases across GC

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -13637,7 +13637,7 @@ const (
 	entrySliceLeaseMinShift      = 4
 	entrySliceLeaseMaxShift      = 20
 	entrySliceLeaseClassCount    = entrySliceLeaseMaxShift - entrySliceLeaseMinShift + 1
-	maxEntrySliceLeasesPerBucket = 128
+	maxEntrySliceLeasesPerBucket = 512
 )
 
 var entrySlicePools [entrySliceLeaseClassCount]sync.Pool

--- a/TreeDB/caching/flush_build_bench_test.go
+++ b/TreeDB/caching/flush_build_bench_test.go
@@ -2,8 +2,11 @@ package caching
 
 import (
 	"encoding/binary"
+	"runtime"
+	"sync"
 	"testing"
 
+	"github.com/snissn/gomap/TreeDB/batch"
 	"github.com/snissn/gomap/TreeDB/internal/memtable"
 )
 
@@ -42,5 +45,61 @@ func BenchmarkBuildOpRunsAllocs(b *testing.B) {
 			putEntrySlice(run)
 		}
 		putEntryRuns(runs)
+	}
+}
+
+func BenchmarkEntrySliceLeaseHotClassAfterGC(b *testing.B) {
+	entrySlicePoolTestMu.Lock()
+	defer entrySlicePoolTestMu.Unlock()
+
+	entrySliceLeaseMu.Lock()
+	savedLeases := entrySliceLeases
+	entrySliceLeases = [entrySliceLeaseClassCount][][]batch.Entry{}
+	entrySliceLeaseMu.Unlock()
+	savedBytes := entrySlicePoolBytes.Load()
+	savedLastGC := entrySlicePoolLastGC.Load()
+	savedBudget := entrySlicePoolBudgetBytes
+	entrySlicePoolBytes.Store(0)
+	entrySlicePoolLastGC.Store(0)
+	entrySlicePoolBudgetBytes = 192 * 8192 * entrySliceEntrySizeBytes
+	for i := range entrySlicePools {
+		entrySlicePools[i] = sync.Pool{}
+	}
+	defer func() {
+		entrySliceLeaseMu.Lock()
+		entrySliceLeases = savedLeases
+		entrySliceLeaseMu.Unlock()
+		entrySlicePoolBytes.Store(savedBytes)
+		entrySlicePoolLastGC.Store(savedLastGC)
+		entrySlicePoolBudgetBytes = savedBudget
+		for i := range entrySlicePools {
+			entrySlicePools[i] = sync.Pool{}
+		}
+	}()
+
+	const (
+		chunkCap  = 8192
+		hotSlices = 192
+	)
+	for i := 0; i < hotSlices; i++ {
+		putEntrySlice(make([]batch.Entry, 0, chunkCap))
+	}
+	runtime.GC()
+	runtime.GC()
+
+	held := make([][]batch.Entry, hotSlices)
+	b.SetBytes(int64(hotSlices * chunkCap * int(entrySliceEntrySizeBytes)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		runtime.GC()
+		runtime.GC()
+		for j := range held {
+			held[j] = getEntrySlice(chunkCap)
+		}
+		for j := range held {
+			putEntrySlice(held[j])
+			held[j] = nil
+		}
 	}
 }


### PR DESCRIPTION
## Summary

- classify `TreeDB/caching.getEntrySlice` Ironbird alloc_space as hot entry-slice pool miss/GC churn during canonical point-unit flush/run materialization, primarily through `buildOpRuns`
- raise the bounded strong lease cap for entry-slice buckets from 128 to 512 so hot 8192-entry chunk buffers survive GC instead of relying on `sync.Pool`
- add a focused benchmark that reproduces the GC-churn path while keeping the existing byte-budget and pressure-trim bounds in force

This does not change WAL, value-log, on-disk format, memtable ownership, zipper, SetView/SetWithRevision, command-WAL frames, or compression behavior.

Fixes #3533.
Part of #3515.

## Classification Evidence

Baseline accepted Ironbird alloc_space profiles:

| Scenario | Total alloc_space | `getEntrySlice` flat | Main caller split |
| --- | ---: | ---: | --- |
| plain-send | 122.12 GiB | 8.35 GiB / 6.83% | `buildOpRuns` 7902.33 MiB / 92.44%; direct `flushCanonicalPointUnitsStreamed` 645.85 MiB / 7.56% |
| small-multisend | 145.72 GiB | 9.84 GiB / 6.76% | `buildOpRuns` 9237.89 MiB / 91.63%; direct `flushCanonicalPointUnitsStreamed` 844.28 MiB / 8.37% |

The pprof traces sampled 704 KiB and 1.38 MiB backing-array allocations, matching 8192/16384 `[]batch.Entry` chunk buffers. Existing warmed `buildOpRuns` microbenchmarks were already near-zero allocation, so the issue is not per-entry copying or duplicate materialization in the steady local loop. It is retention miss/drop around hot chunk classes under long-running GC churn.

## Local Gate

Focused reproduction benchmark, same command before and after the cap change:

```sh
GOWORK=off TMPDIR=/mnt/fast4tb/tmp go test ./TreeDB/caching -run '^$' -bench 'BenchmarkEntrySliceLeaseHotClassAfterGC$' -benchmem -count=5
```

| State | Result |
| --- | --- |
| before | ~46,148,700 B/op, 145 allocs/op |
| after | 299-362 B/op, 1 alloc/op |

Additional after-change benchmark/profile smoke:

```sh
GOWORK=off TMPDIR=/mnt/fast4tb/tmp go test ./TreeDB/caching -run '^$' -bench 'BenchmarkEntrySliceLeaseHotClassAfterGC$' -benchmem -benchtime=20x -memprofile /mnt/fast4tb/gomap-3533-profiles/entryslice-hot-after.mem.pprof
```

Result: `10555103 ns/op`, `646 B/op`, `1 allocs/op`.

Normal warmed build-run benchmarks stayed in the same allocation band as before:

```sh
GOWORK=off TMPDIR=/mnt/fast4tb/tmp go test ./TreeDB/caching -run '^$' -bench 'BenchmarkBuildOpRuns(Allocs|_ModeCompare)$' -benchmem -count=3
```

Representative after-change results: `BenchmarkBuildOpRunsAllocs` remained ~95-98 B/op and 2 allocs/op; mode-compare cases remained in the existing low-allocation bands.

## Tests

```sh
GOWORK=off TMPDIR=/mnt/fast4tb/tmp go test ./TreeDB/caching -run 'Test(EntrySlice|PutEntrySlice|GetEntrySlice|MaybeResetEntrySlice|PoolPressure.*EntrySlice|BuildOpRunsChunking)'
GOWORK=off TMPDIR=/mnt/fast4tb/tmp go test ./TreeDB/caching
```

Both passed.

## Risk / Bounds

Retention remains bounded by `entrySlicePoolBudgetBytes` and existing pressure trimming. Under high pressure, tests still trim entry-slice leases to `maxEntrySliceLeasesPerBucket/8`; under critical pressure they drop to zero. No AI review requested yet per worker instructions.
