### PR TITLE
Reduce leaf generation view allocation churn

### DIFF
--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -2473,7 +2473,9 @@ type finalizeCommitPost struct {
 	durSync2                          time.Duration
 	persistLeafGenerationManifest     bool
 	persistLeafGenerationManifestView *leafGenerationManifest
+	persistLeafGenerationStateView    *leafGenerationView
 	persistLeafGenerationRawFileIDs   []uint32
+	clearLeafGenerationPendingFileIDs []uint32
 	drainLeafGenerationPending        bool
 }
 
@@ -2644,23 +2646,31 @@ func (db *DB) finalizeCommitLockedWithOptions(newRootID uint64, sysRootID uint64
 			valueLogSet = db.valueLogManager.CurrentSetNoRefresh()
 		}
 	}
-	leafGenerationView := db.currentLeafGenerationView()
+	var leafGenerationView *leafGenerationView
 	if leafManifest != nil {
 		db.leafGenerationManifest = leafManifest
 		post.persistLeafGenerationManifest = true
 		post.persistLeafGenerationManifestView = leafManifest
 		post.persistLeafGenerationRawFileIDs = append(post.persistLeafGenerationRawFileIDs[:0], leafManifestRawFileIDs...)
-		leafGenerationView = newLeafGenerationView(leafManifest)
+		leafGenerationView = db.leafGenerationViewForManifest(leafManifest)
 	}
 	if db.leafPageLog != nil {
-		stagedLeafManifest, changed, err := db.stagedLeafGenerationManifestWithPending(db.leafGenerationManifest, 0, nextMeta.CommitSeq)
+		stagedLeafManifest, err := db.stagedLeafGenerationManifestWithPendingResult(db.leafGenerationManifest, 0, nextMeta.CommitSeq)
 		if err != nil {
 			db.mu.Unlock()
 			return post, err
 		}
-		if changed {
-			leafGenerationView = newLeafGenerationView(stagedLeafManifest)
+		if stagedLeafManifest.changed {
+			leafGenerationView = db.leafGenerationViewForManifest(stagedLeafManifest.manifest)
+			post.persistLeafGenerationManifest = true
+			post.persistLeafGenerationManifestView = stagedLeafManifest.manifest
+			post.persistLeafGenerationStateView = leafGenerationView
+			post.persistLeafGenerationRawFileIDs = append(post.persistLeafGenerationRawFileIDs, stagedLeafManifest.rawFileIDs...)
+			post.clearLeafGenerationPendingFileIDs = append(post.clearLeafGenerationPendingFileIDs[:0], stagedLeafManifest.pendingFileIDs...)
 		}
+	}
+	if leafGenerationView == nil {
+		leafGenerationView = db.currentLeafGenerationView()
 	}
 	newState := &DBState{
 		CommitSeq:         nextMeta.CommitSeq,
@@ -2686,7 +2696,7 @@ func (db *DB) finalizeCommitLockedWithOptions(newRootID uint64, sysRootID uint64
 	db.publishSnapshotView(idx, newState, db.valueLogManager)
 	post.commitSeq = nextMeta.CommitSeq
 	post.vlogRefDelta = vlogRefDelta
-	if db.leafPageLog != nil {
+	if db.leafPageLog != nil && len(post.clearLeafGenerationPendingFileIDs) == 0 {
 		post.drainLeafGenerationPending = true
 	}
 	db.mu.Unlock()
@@ -2741,16 +2751,44 @@ func (db *DB) finalizeCommitPostWork(post finalizeCommitPost) {
 	if post.oldState != nil {
 		_ = db.valueLogManager.Release(post.oldState.ValueLogSet)
 	}
-	if post.persistLeafGenerationManifest || post.drainLeafGenerationPending {
+	if post.persistLeafGenerationManifest || post.drainLeafGenerationPending || len(post.clearLeafGenerationPendingFileIDs) > 0 {
 		var (
-			persistErr error
-			pendingErr error
+			persistErr        error
+			pendingErr        error
+			clearPending      bool
+			assignPersisted   bool
+			manifestPersisted bool
 		)
 		db.commitMu.Lock()
 		currentCommitSeq := db.meta.CommitSeq
 		currentManifest := db.leafGenerationManifest
-		if post.persistLeafGenerationManifest && currentManifest == post.persistLeafGenerationManifestView {
-			persistErr = db.persistLeafGenerationManifestAndRecordLengthIndexes(post.persistLeafGenerationManifestView, post.persistLeafGenerationRawFileIDs)
+		currentState := db.state.Load()
+		if post.persistLeafGenerationManifest {
+			switch {
+			case currentManifest == post.persistLeafGenerationManifestView:
+				manifestPersisted = true
+			case post.persistLeafGenerationStateView != nil && currentState != nil && currentState.LeafGenerations == post.persistLeafGenerationStateView:
+				manifestPersisted = true
+				assignPersisted = true
+			}
+			if manifestPersisted {
+				persistErr = db.persistLeafGenerationManifestAndRecordLengthIndexes(post.persistLeafGenerationManifestView, post.persistLeafGenerationRawFileIDs)
+				if persistErr == nil {
+					clearPending = len(post.clearLeafGenerationPendingFileIDs) > 0
+					if assignPersisted {
+						db.mu.Lock()
+						if state := db.state.Load(); state != nil && state.LeafGenerations == post.persistLeafGenerationStateView {
+							db.leafGenerationManifest = post.persistLeafGenerationManifestView
+						}
+						db.mu.Unlock()
+					}
+				}
+			}
+		} else if len(post.clearLeafGenerationPendingFileIDs) > 0 {
+			clearPending = true
+		}
+		if clearPending {
+			db.clearLeafGenerationPendingFileIDs(post.clearLeafGenerationPendingFileIDs)
 		}
 		if post.drainLeafGenerationPending {
 			pendingErr = db.noteLeafGenerationPendingFileIDs(0, currentCommitSeq)

--- a/TreeDB/db/leaf_generation_manifest.go
+++ b/TreeDB/db/leaf_generation_manifest.go
@@ -315,7 +315,6 @@ func validateLeafGenerationManifest(m *leafGenerationManifest) error {
 		return fmt.Errorf("treedb: %s must contain at least one generation", leafGenerationManifestFileName)
 	}
 
-	seen := make(map[uint64]struct{}, len(m.Generations))
 	currentFound := false
 	writableCount := 0
 	maxID := uint64(0)
@@ -324,10 +323,11 @@ func validateLeafGenerationManifest(m *leafGenerationManifest) error {
 		if gen.GenerationID == 0 {
 			return fmt.Errorf("treedb: %s generation[%d] has zero generation_id", leafGenerationManifestFileName, i)
 		}
-		if _, dup := seen[gen.GenerationID]; dup {
-			return fmt.Errorf("treedb: %s generation_id %d appears more than once", leafGenerationManifestFileName, gen.GenerationID)
+		for j := 0; j < i; j++ {
+			if m.Generations[j].GenerationID == gen.GenerationID {
+				return fmt.Errorf("treedb: %s generation_id %d appears more than once", leafGenerationManifestFileName, gen.GenerationID)
+			}
 		}
-		seen[gen.GenerationID] = struct{}{}
 		if gen.GenerationID > maxID {
 			maxID = gen.GenerationID
 		}
@@ -553,15 +553,31 @@ func noteLeafGenerationWritableFileIDsInManifest(manifest *leafGenerationManifes
 	return out, true, nil
 }
 
+type stagedLeafGenerationManifestResult struct {
+	manifest       *leafGenerationManifest
+	changed        bool
+	rawFileIDs     []uint32
+	pendingFileIDs []uint32
+}
+
 func (db *DB) stagedLeafGenerationManifestWithPending(base *leafGenerationManifest, currentFileID uint32, commitSeq uint64) (*leafGenerationManifest, bool, error) {
+	result, err := db.stagedLeafGenerationManifestWithPendingResult(base, currentFileID, commitSeq)
+	if err != nil {
+		return base, false, err
+	}
+	return result.manifest, result.changed, nil
+}
+
+func (db *DB) stagedLeafGenerationManifestWithPendingResult(base *leafGenerationManifest, currentFileID uint32, commitSeq uint64) (stagedLeafGenerationManifestResult, error) {
+	result := stagedLeafGenerationManifestResult{manifest: base}
 	if db == nil || base == nil {
-		return base, false, nil
+		return result, nil
 	}
 	pending := db.snapshotLeafGenerationPendingFileIDs(currentFileID)
 	if len(pending) == 0 {
-		return base, false, nil
+		return result, nil
 	}
-	working := base.clone()
+	working := base
 	changedAny := false
 	batch := make([]uint32, 0, len(pending))
 	batchCommitSeq := uint64(0)
@@ -569,6 +585,7 @@ func (db *DB) stagedLeafGenerationManifestWithPending(base *leafGenerationManife
 		if len(batch) == 0 {
 			return nil
 		}
+		result.pendingFileIDs = append(result.pendingFileIDs, batch...)
 		registrable, err := db.filterLeafGenerationRegistrableRawFileIDs(working, batch)
 		if err != nil {
 			return err
@@ -578,12 +595,16 @@ func (db *DB) stagedLeafGenerationManifestWithPending(base *leafGenerationManife
 			batchCommitSeq = 0
 			return nil
 		}
-		_, changed, err := noteLeafGenerationWritableFileIDsInManifest(working, registrable, batchCommitSeq)
+		if working == base {
+			working = base.clone()
+		}
+		rawFileIDs, changed, err := noteLeafGenerationWritableFileIDsInManifest(working, registrable, batchCommitSeq)
 		if err != nil {
 			return err
 		}
 		if changed {
 			changedAny = true
+			result.rawFileIDs = append(result.rawFileIDs, rawFileIDs...)
 		}
 		batch = batch[:0]
 		batchCommitSeq = 0
@@ -599,7 +620,7 @@ func (db *DB) stagedLeafGenerationManifestWithPending(base *leafGenerationManife
 		}
 		if batchCommitSeq != 0 && itemCommitSeq != batchCommitSeq {
 			if err := flushBatch(); err != nil {
-				return base, false, err
+				return result, err
 			}
 		}
 		if batchCommitSeq == 0 {
@@ -608,32 +629,36 @@ func (db *DB) stagedLeafGenerationManifestWithPending(base *leafGenerationManife
 		batch = append(batch, item.rawFileID)
 	}
 	if err := flushBatch(); err != nil {
-		return base, false, err
+		return result, err
 	}
 	if !changedAny {
-		return base, false, nil
+		return result, nil
 	}
-	return working, true, nil
+	result.manifest = working
+	result.changed = true
+	result.rawFileIDs = dedupeLeafGenerationRawFileIDs(result.rawFileIDs)
+	result.pendingFileIDs = dedupeLeafGenerationRawFileIDs(result.pendingFileIDs)
+	return result, nil
 }
 
 func (db *DB) noteLeafGenerationWritableFileIDs(fileIDs []uint32, commitSeq uint64) error {
 	if db == nil || db.leafGenerationManifest == nil || commitSeq == 0 || len(fileIDs) == 0 {
 		return nil
 	}
-	db.mu.Lock()
-	if db.leafGenerationManifest == nil {
-		db.mu.Unlock()
+	db.mu.RLock()
+	baseManifest := db.leafGenerationManifest
+	db.mu.RUnlock()
+	if baseManifest == nil {
 		return nil
 	}
-	nextManifest := db.leafGenerationManifest.clone()
-	db.mu.Unlock()
-	registrable, err := db.filterLeafGenerationRegistrableRawFileIDs(nextManifest, fileIDs)
+	registrable, err := db.filterLeafGenerationRegistrableRawFileIDs(baseManifest, fileIDs)
 	if err != nil {
 		return err
 	}
 	if len(registrable) == 0 {
 		return nil
 	}
+	nextManifest := baseManifest.clone()
 	sealedFileIDs, changedAny, err := noteLeafGenerationWritableFileIDsInManifest(nextManifest, registrable, commitSeq)
 	if err != nil {
 		return err

--- a/TreeDB/db/leaf_generation_pack.go
+++ b/TreeDB/db/leaf_generation_pack.go
@@ -428,14 +428,27 @@ func (db *DB) noteCreatedLeafGenerationFileIDs(commitSeq uint64, fileIDs []uint3
 	if db == nil || db.leafGenerationManifest == nil || commitSeq == 0 || len(fileIDs) == 0 {
 		return nil
 	}
-	rawFileIDs, changed, err := noteCreatedLeafGenerationFileIDsInManifest(db.leafGenerationManifest, commitSeq, fileIDs)
+	db.mu.RLock()
+	baseManifest := db.leafGenerationManifest
+	db.mu.RUnlock()
+	if baseManifest == nil {
+		return nil
+	}
+	nextManifest := baseManifest.clone()
+	rawFileIDs, changed, err := noteCreatedLeafGenerationFileIDsInManifest(nextManifest, commitSeq, fileIDs)
 	if err != nil {
 		return err
 	}
 	if !changed {
 		return nil
 	}
-	return db.persistLeafGenerationManifestAndRecordLengthIndexes(db.leafGenerationManifest, rawFileIDs)
+	if err := db.persistLeafGenerationManifestAndRecordLengthIndexes(nextManifest, rawFileIDs); err != nil {
+		return err
+	}
+	db.mu.Lock()
+	db.leafGenerationManifest = nextManifest
+	db.mu.Unlock()
+	return db.publishLeafGenerationState(false)
 }
 
 func dedupeLeafGenerationRawFileIDs(rawFileIDs []uint32) []uint32 {

--- a/TreeDB/db/leaf_generation_runtime.go
+++ b/TreeDB/db/leaf_generation_runtime.go
@@ -7,6 +7,7 @@ import (
 
 type leafGenerationView struct {
 	CurrentGenerationID uint64
+	sourceManifest      *leafGenerationManifest
 	GenerationOrder     []uint64
 	PinRefs             []*leafGenerationPinRef
 	PinSet              *leafGenerationPinSet
@@ -23,19 +24,37 @@ func newLeafGenerationView(manifest *leafGenerationManifest) *leafGenerationView
 	if manifest == nil {
 		return nil
 	}
+	activeGenerations := 0
+	fileIDs := 0
+	for i := range manifest.Generations {
+		gen := manifest.Generations[i]
+		if gen.State == leafGenerationStateDeleted || gen.State == leafGenerationStateRetiring {
+			continue
+		}
+		activeGenerations++
+		fileIDs += len(gen.FileIDs)
+	}
 	view := &leafGenerationView{
 		CurrentGenerationID: manifest.CurrentGenerationID,
-		GenerationOrder:     make([]uint64, 0, len(manifest.Generations)),
-		Generations:         make(map[uint64]leafGenerationViewGeneration, len(manifest.Generations)),
-		FileToGeneration:    make(map[uint32]uint64),
+		sourceManifest:      manifest,
+		GenerationOrder:     make([]uint64, 0, activeGenerations),
+		Generations:         make(map[uint64]leafGenerationViewGeneration, activeGenerations),
+		FileToGeneration:    make(map[uint32]uint64, fileIDs),
 	}
+	var fileBacking []uint32
+	if fileIDs > 0 {
+		fileBacking = make([]uint32, fileIDs)
+	}
+	fileCursor := 0
 	for i := range manifest.Generations {
 		gen := manifest.Generations[i]
 		if gen.State == leafGenerationStateDeleted || gen.State == leafGenerationStateRetiring {
 			continue
 		}
 		view.GenerationOrder = append(view.GenerationOrder, gen.GenerationID)
-		files := append([]uint32(nil), gen.FileIDs...)
+		files := fileBacking[fileCursor : fileCursor+len(gen.FileIDs)]
+		copy(files, gen.FileIDs)
+		fileCursor += len(gen.FileIDs)
 		view.Generations[gen.GenerationID] = leafGenerationViewGeneration{
 			State:   gen.State,
 			FileIDs: files,
@@ -51,7 +70,17 @@ func (db *DB) currentLeafGenerationView() *leafGenerationView {
 	if db == nil || db.leafGenerationManifest == nil {
 		return nil
 	}
-	view := newLeafGenerationView(db.leafGenerationManifest)
+	return db.leafGenerationViewForManifest(db.leafGenerationManifest)
+}
+
+func (db *DB) leafGenerationViewForManifest(manifest *leafGenerationManifest) *leafGenerationView {
+	if db == nil || manifest == nil {
+		return nil
+	}
+	if state := db.state.Load(); state != nil && state.LeafGenerations != nil && state.LeafGenerations.sourceManifest == manifest {
+		return state.LeafGenerations
+	}
+	view := newLeafGenerationView(manifest)
 	if view != nil && len(view.GenerationOrder) > 0 {
 		view.PinRefs = db.leafGenerationPins.refsForGenerationIDs(view.GenerationOrder)
 		view.PinSet = newLeafGenerationPinSet(view.PinRefs)

--- a/TreeDB/db/snapshot_view_test.go
+++ b/TreeDB/db/snapshot_view_test.go
@@ -665,6 +665,78 @@ func TestCurrentLeafGenerationView_DoesNotPruneTrackedRefs(t *testing.T) {
 	}
 }
 
+func TestCurrentLeafGenerationView_ReusesPublishedManifestView(t *testing.T) {
+	manifest := &leafGenerationManifest{
+		CurrentGenerationID: 2,
+		Generations: []leafGenerationRecord{
+			{GenerationID: 1, State: leafGenerationStateSealed, FileIDs: []uint32{111}},
+			{GenerationID: 2, State: leafGenerationStateWritable, FileIDs: []uint32{222}},
+		},
+	}
+	db := &DB{leafGenerationManifest: manifest}
+
+	view := db.currentLeafGenerationView()
+	if view == nil {
+		t.Fatal("expected leaf generation view")
+	}
+	db.state.Store(&DBState{LeafGenerations: view})
+
+	if reused := db.currentLeafGenerationView(); reused != view {
+		t.Fatalf("expected published leaf generation view reuse, got %p want %p", reused, view)
+	}
+}
+
+func TestPublishedLeafGenerationView_DoesNotObserveManifestMutation(t *testing.T) {
+	manifest := &leafGenerationManifest{
+		CurrentGenerationID: 2,
+		Generations: []leafGenerationRecord{
+			{GenerationID: 1, State: leafGenerationStateSealed, FileIDs: []uint32{111, 112}},
+			{GenerationID: 2, State: leafGenerationStateWritable, FileIDs: []uint32{222}},
+		},
+	}
+	db := &DB{leafGenerationManifest: manifest}
+	view := db.currentLeafGenerationView()
+	if view == nil {
+		t.Fatal("expected leaf generation view")
+	}
+	db.state.Store(&DBState{LeafGenerations: view})
+
+	manifest.Generations[0].FileIDs[0] = 999
+	manifest.Generations[0].FileIDs = append(manifest.Generations[0].FileIDs, 113)
+	manifest.Generations[1].State = leafGenerationStateDeleted
+	manifest.Generations = append(manifest.Generations, leafGenerationRecord{
+		GenerationID: 3,
+		State:        leafGenerationStateWritable,
+		FileIDs:      []uint32{333},
+	})
+
+	if got, want := view.GenerationOrder, []uint64{1, 2}; len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("GenerationOrder=%v, want %v", got, want)
+	}
+	if got, want := view.FileToGeneration[111], uint64(1); got != want {
+		t.Fatalf("FileToGeneration[111]=%d, want %d", got, want)
+	}
+	if _, ok := view.FileToGeneration[999]; ok {
+		t.Fatalf("published view observed later replacement file ID")
+	}
+	if _, ok := view.FileToGeneration[113]; ok {
+		t.Fatalf("published view observed later appended file ID")
+	}
+	if _, ok := view.FileToGeneration[333]; ok {
+		t.Fatalf("published view observed later generation")
+	}
+	gen := view.Generations[1]
+	if got, want := gen.FileIDs, []uint32{111, 112}; len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("generation 1 FileIDs=%v, want %v", got, want)
+	}
+	if gen := view.Generations[2]; gen.State != leafGenerationStateWritable {
+		t.Fatalf("generation 2 state=%q, want %q", gen.State, leafGenerationStateWritable)
+	}
+	if reused := db.currentLeafGenerationView(); reused != view {
+		t.Fatalf("expected currentLeafGenerationView to keep published immutable view, got %p want %p", reused, view)
+	}
+}
+
 func TestPublishSnapshotView_SkipsPruneDuringInFlightSnapshotAcquire(t *testing.T) {
 	db := &DB{}
 	idx := &indexGen{}


### PR DESCRIPTION
Fixes #3538.

## Summary

- Reuse already-published immutable `leafGenerationView` snapshots when the active manifest pointer is already represented by the current DB state.
- Stage leaf-generation manifest updates as copy-on-publish immutable views, then let post-commit persistence consume the same staged manifest/view instead of cloning and rebuilding the view again.
- Make leaf-generation writable-file tracking and pack-file registration avoid manifest clones when there is no new registrable state, and publish copied manifests rather than mutating the live manifest in place.
- Remove the `validateLeafGenerationManifest` scratch map allocation by checking duplicate generation IDs against prior entries.
- Add tests that prove published views are reused when safe and remain immutable to readers after later manifest mutation.

## Validation

- `GOWORK=off go test ./TreeDB/db -run 'LeafGeneration|CompactStorage|ValueLogGC' -count=1`
  - clean candidate worktree: `ok github.com/snissn/gomap/TreeDB/db 9.042s`
- `GOWORK=off go test ./TreeDB/caching -run 'LeafGeneration|LeafPageLog|Reopen|RootPublished' -count=1`
  - clean candidate worktree: `ok github.com/snissn/gomap/TreeDB/caching 4.774s`
- `GOWORK=off make unified-bench benchprof`
  - clean candidate worktree: passed
  - baseline `origin/main` comparison worktree: passed

## Allocation evidence

Baseline evidence is the issue artifact at `/tmp/gomap_alloc_loop_20260706_post3532/profiles/main_all_tests` from `origin/main`/`49087c1ff`. Candidate evidence is `/tmp/gomap_issue3538_candidate_10m/profiles` from this branch. Candidate command:

```sh
GOWORK=off GOMAXPROCS=8 TMPDIR=/tmp/gomap_issue3538_candidate_10m/tmp \
  ./bin/unified-bench -profile durable -dbs treedb -keys 10000000 -valsize 128 \
  -batchsize 8000 -checkpoint-between-tests -treedb-journal-lanes=1 \
  -progress=false -profile-dir /tmp/gomap_issue3538_candidate_10m/profiles \
  -path-label native-fastpath -format markdown \
  -test batch_write,batch_write_steady,dataset_write_sorted
```

Extraction command used for both baseline and candidate:

```sh
go tool pprof -top -nodecount=0 -nodefraction=0 -sample_index=alloc_objects \
  ./bin/unified-bench allocs_<test>_treedb.pprof
```

| test | baseline `leafGenerationManifest.clone (inline)` | candidate | baseline `newLeafGenerationView` | candidate | combined sampled reduction |
| --- | ---: | ---: | ---: | ---: | ---: |
| `batch_write` | 99,025 | absent / 0 sampled | 33,696 | absent / 0 sampled | 132,721 sampled objects removed |
| `batch_write_steady` | 66,411 | absent / 0 sampled | 18,049 | absent / 0 sampled | 84,460 sampled objects removed |
| `dataset_write_sorted` | 33,391 | absent / 0 sampled | 34,319 | absent / 0 sampled | 67,710 sampled objects removed |

`validateLeafGenerationManifest` was not present in these three targeted baseline pprof rows; the candidate full-nodefraction pprof output also has no sampled rows for it.

Candidate throughput from the same run:

- `Batch Write / TreeDB = 632,035`
- `Batch Write (Steady) / TreeDB = 683,260`
- `Dataset Write (Sorted) / TreeDB = 531,213`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency when publishing leaf-generation changes, reducing cases where file state or pending updates could be left out of sync.
  * Ensured snapshot views remain stable after they are published, so later changes no longer affect previously generated views.
  * Updated internal handling to better reuse existing published views, which can improve responsiveness in repeated read paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->