### PR TITLE
treedb: retain append-only recycle capacity

### DIFF
--- a/TreeDB/caching/append_only_hint_test.go
+++ b/TreeDB/caching/append_only_hint_test.go
@@ -1,6 +1,7 @@
 package caching
 
 import (
+	"fmt"
 	"runtime"
 	"testing"
 	"time"
@@ -151,6 +152,108 @@ func TestAppendOnlyReserveDemandTeachesFutureCapacityHint(t *testing.T) {
 	}
 	if got := appendOnly.EntryCapacity(); got < hint {
 		t.Fatalf("future mutable capacity=%d want >= learned hint %d", got, hint)
+	}
+}
+
+func TestAppendOnlyRotateWithCapacityObservesMutableEntryHint(t *testing.T) {
+	cache, err := Open(t.TempDir(), NewMockBackend(), Options{
+		AllowUnsafe:    true,
+		DisableWAL:     true,
+		MemtableMode:   "append_only",
+		MemtableShards: 1,
+		FlushThreshold: 1 << 30,
+	})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = cache.Close() }()
+
+	cache.appendOnlyEntryHint.Store(0)
+	const entries = 4096
+	for i := 0; i < entries; i++ {
+		key := []byte(fmt.Sprintf("k-%06d", i))
+		if err := cache.Set(key, []byte("value")); err != nil {
+			t.Fatalf("set %d: %v", i, err)
+		}
+	}
+
+	cache.mu.Lock()
+	err = cache.rotateMemtableLockedWithCapacity(false, minMemtablePrealloc)
+	cache.mu.Unlock()
+	if err != nil {
+		t.Fatalf("rotate with capacity: %v", err)
+	}
+
+	if got := int(cache.appendOnlyEntryHint.Load()); got < entries {
+		t.Fatalf("entry hint after rotate=%d want >=%d", got, entries)
+	}
+}
+
+func TestRecycleAppendOnlyMemtableRetainsSteadyForegroundCapacity(t *testing.T) {
+	var cache DB
+	cache.storeMemtableMode(memtable.ModeAppendOnly)
+	cache.memtableCap = 64 << 20
+	cache.mutableThreshold.Store(int64(cache.memtableCap))
+
+	mt := memtable.NewAppendOnlyWithEntryCapacity(appendOnlyEntryHintMinEntries)
+	const entries = 200_000
+	reserveAppendOnlyMemtableEntries(&cache, mt, entries)
+	warmCap := mt.EntryCapacity()
+	if warmCap < entries {
+		t.Fatalf("test setup capacity=%d want >=%d", warmCap, entries)
+	}
+
+	cache.recycleMemtables([]memtable.Table{mt})
+	if got := len(cache.appendOnlyMemLeases); got != 1 {
+		t.Fatalf("append-only mem leases=%d want 1", got)
+	}
+	if got := mt.EntryCapacity(); got < entries {
+		t.Fatalf("recycled capacity=%d want >=%d", got, entries)
+	}
+
+	next, err := cache.newMutableMemtableWithCapacityMode(cache.memtableCap, memtable.ModeAppendOnly)
+	if err != nil {
+		t.Fatalf("new mutable: %v", err)
+	}
+	appendOnly, ok := next.(*memtable.AppendOnly)
+	if !ok {
+		t.Fatalf("new mutable type=%T, want append-only", next)
+	}
+	if appendOnly != mt {
+		t.Fatalf("new mutable did not reuse recycled append-only table")
+	}
+	if got := appendOnly.EntryCapacity(); got < entries {
+		t.Fatalf("reused capacity=%d want >=%d", got, entries)
+	}
+
+	before := memtable.AppendOnlyEntryReserveStatsSnapshot()
+	reserveAppendOnlyMemtableEntries(&cache, appendOnly, entries)
+	after := memtable.AppendOnlyEntryReserveStatsSnapshot()
+	if got := after.GrowCallsTotal - before.GrowCallsTotal; got != 0 {
+		t.Fatalf("reserve grow calls after reuse=%d want 0", got)
+	}
+}
+
+func BenchmarkRecycleAppendOnlyMemtableSteadyForegroundCapacity(b *testing.B) {
+	const entries = 200_000
+	b.ReportAllocs()
+	b.StopTimer()
+	for i := 0; i < b.N; i++ {
+		var cache DB
+		cache.storeMemtableMode(memtable.ModeAppendOnly)
+		cache.memtableCap = 64 << 20
+		cache.mutableThreshold.Store(int64(cache.memtableCap))
+		mt := memtable.NewAppendOnlyWithEntryCapacity(appendOnlyEntryHintMinEntries)
+		reserveAppendOnlyMemtableEntries(&cache, mt, entries)
+		b.StartTimer()
+		cache.recycleMemtables([]memtable.Table{mt})
+		next, err := cache.newMutableMemtableWithCapacityMode(cache.memtableCap, memtable.ModeAppendOnly)
+		if err != nil {
+			b.Fatalf("new mutable: %v", err)
+		}
+		appendOnly := next.(*memtable.AppendOnly)
+		reserveAppendOnlyMemtableEntries(&cache, appendOnly, entries)
+		b.StopTimer()
 	}
 }
 

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -10572,13 +10572,29 @@ func (db *DB) putAppendOnlyMemPoolDropEntries(mt *memtable.AppendOnly) {
 	}
 }
 
+func (db *DB) appendOnlyRecycleResetCapacity(estimatedBytesPerEntry int) int {
+	if estimatedBytesPerEntry <= 0 {
+		estimatedBytesPerEntry = appendOnlyEstimatedBytesPerEntryDefault
+	}
+	capacity := 0
+	if db != nil {
+		capacity = db.memtableCap
+		if capacity <= 0 {
+			capacity = db.checkpointRotateCapacity()
+		}
+	}
+	if capacity <= 0 {
+		capacity = minMemtablePrealloc
+	}
+	return db.appendOnlyMemtableCapacityHint(capacity, estimatedBytesPerEntry)
+}
+
 func (db *DB) recycleMemtables(mems []memtable.Table) {
 	if db == nil || len(mems) == 0 {
 		return
 	}
-	resetCapacity := db.checkpointRotateCapacity()
 	estimate := appendOnlyEstimatedBytesPerEntryDefault
-	appendOnlyResetCapacity := db.appendOnlyMemtableCapacityHint(resetCapacity, estimate)
+	appendOnlyResetCapacity := db.appendOnlyRecycleResetCapacity(estimate)
 	retainAppendOnly := db.currentMemtableMode() == memtable.ModeAppendOnly
 	for _, mt := range mems {
 		switch typed := mt.(type) {
@@ -25899,6 +25915,9 @@ func (db *DB) rotateMemtableLockedWithCapacity(triggerFlush bool, newCapacity in
 		oldLen := oldMem.Len()
 		if debugRotate {
 			oldMode = debugMemtableModeLabel(oldMem)
+		}
+		if _, ok := oldMem.(*memtable.AppendOnly); ok {
+			db.observeAppendOnlyMutableEntries(oldLen)
 		}
 		oldShardBytes := shard.bytes
 		db.retainMutableShardAppendOnlyArenaLocked(i, shard)


### PR DESCRIPTION
## Summary

- reset recycled append-only memtables against the foreground mutable capacity hint instead of the smaller checkpoint cutover cap
- teach the capacity-rotate path to observe append-only mutable entry demand before freezing/replacing the shard
- add focused recycle-capacity tests and a benchmark for the reset/recycle/reuse path

Fixes #3539.
Part of #3515.

This does not change value-log, command-WAL, zipper, public API, or on-disk format behavior.

## Classification Evidence

Accepted post-#3531 baseline profiles:

| Scenario | Total alloc_space | `getAppendOnlyEntries` flat | Dominant focused callers |
| --- | ---: | ---: | --- |
| plain-send | 125047.02 MB | 5736.39 MB / 4.59% | `resetLockedWithPolicy` / `replaceEntriesSliceWithPolicy` 3965.37 MB; `ResetWithCapacityHard` 2991.84 MB; `ReserveAdditionalEntries` / `growEntriesLocked` 1623.20 MB; `newMutableMemtableWithCapacityMode` 1043.46 MB; trim/recycle paths 939.13-2052.71 MB |
| small-multisend | 149213.51 MB | 7427.27 MB / 4.98% | `resetLockedWithPolicy` / `replaceEntriesSliceWithPolicy` 5136.60 MB; `ResetWithCapacityHard` 3736.37 MB; `ReserveAdditionalEntries` / `growEntriesLocked` 2113.84 MB; `newMutableMemtableWithCapacityMode` 1504 MB; trim/recycle paths 1138.13-2598.24 MB |

The allocation is not constructor-only. The profile points primarily at reset/replacement churn: recycled append-only memtables are hard-reset down to the checkpoint cutover cap, then foreground writes/reserve paths grow them back toward the learned steady capacity. Pooling helps individual classes, but the macro shape still pays repeated replacement and reserve growth.

This patch classifies the cause as hard-reset shrink/regrow churn around append-only recycle and capacity-hint learning, with remaining allocation still requiring Ironbird validation because retaining recycle capacity can trade alloc_space for higher retained backing.

## Local Gate

Focused before/after benchmark, same fixed-count command with the benchmark added to current `origin/main` for the before run:

```sh
GOWORK=off TMPDIR=/mnt/fast4tb/tmp go test ./TreeDB/caching -run '^$' -bench 'BenchmarkRecycleAppendOnlyMemtableSteadyForegroundCapacity$' -benchmem -benchtime=100x -count=5
```

| State | Result |
| --- | --- |
| before | 1.11-1.21 ms/op, 23.1-23.6 MB/op, 5-7 allocs/op |
| after | 1.03-1.45 us/op, 8 B/op, 1 alloc/op |

## Tests

```sh
GOWORK=off TMPDIR=/mnt/fast4tb/tmp go test ./TreeDB/caching -run 'Test(AppendOnlyRotateWithCapacityObservesMutableEntryHint|RecycleAppendOnlyMemtableRetainsSteadyForegroundCapacity|AppendOnlyReserveDemand|AppendOnlyEntryHint|TrimRetainedArenasAfterFlush|TrimAppendOnlyMemLeases|RecycleAppendOnlyMemtables)' -count=1
GOWORK=off TMPDIR=/mnt/fast4tb/tmp go test ./TreeDB/internal/memtable -count=1
GOWORK=off TMPDIR=/mnt/fast4tb/tmp go test ./TreeDB/caching -count=1
```

All passed.

## Ironbird Gate

This is ready for main-thread Ironbird validation, not merge-ready on local evidence alone. Compare against baseline artifact root:

`/mnt/fast4tb/ironbird-3531-memtable-allocs-20260706T094142Z`

Required accepted rows:

- plain-send
- small-multisend

Reject this PR if `getAppendOnlyEntries` improves but TreeDB flat allocation, total alloc_space, load-window TPS, commit seconds, finalize seconds, or check_tx seconds regress outside normal run noise.
