### PR TITLE
treedb: retain append-only entry backing

### DIFF
--- a/TreeDB/internal/memtable/append_only.go
+++ b/TreeDB/internal/memtable/append_only.go
@@ -60,10 +60,13 @@ const (
 var appendOnlyEntryPoolRetainBudgetBytes = uint64(256 << 20)
 var appendOnlyValueArenaPoolRetainBudgetBytes = uint64(64 << 20)
 
-// Serializes package-pool replacement with retained-byte accounting. sync.Pool
-// is concurrent, but the estimate is for the currently reachable pool set.
+// Serializes package-pool replacement and retained entry backing accounting.
+// Entry slices are held in bounded strong bins because sync.Pool can discard
+// warm buffers at GC boundaries, which makes durable write-profile reuse
+// unreliable.
 var appendOnlyEntryPoolMu sync.Mutex
 var appendOnlyEntryPoolPtrs [appendOnlyEntryPoolClassCount]atomic.Pointer[sync.Pool]
+var appendOnlyEntryPoolBins [appendOnlyEntryPoolClassCount][][]appendOnlyEntry
 var appendOnlyEntryPoolRetainedBytes atomic.Uint64
 var appendOnlyEntryPoolRetainedBytesMax atomic.Uint64
 var appendOnlyEntryPoolGetTotal atomic.Uint64
@@ -343,6 +346,7 @@ func subtractAppendOnlyEntryPoolRetainedBytes(bytes uint64) {
 func dropAppendOnlyEntryPoolsLocked() {
 	for i := range appendOnlyEntryPoolPtrs {
 		appendOnlyEntryPoolPtrs[i].Store(&sync.Pool{})
+		appendOnlyEntryPoolBins[i] = nil
 	}
 	if dropped := appendOnlyEntryPoolRetainedBytes.Swap(0); dropped > 0 {
 		appendOnlyEntryPoolDropBytesTotal.Add(dropped)
@@ -526,16 +530,18 @@ func getAppendOnlyEntries(length int) []appendOnlyEntry {
 		return make([]appendOnlyEntry, length)
 	}
 	appendOnlyEntryPoolMu.Lock()
-	if pool := appendOnlyEntryPoolForClass(class); pool != nil {
-		if v := pool.Get(); v != nil {
-			if entries, ok := v.([]appendOnlyEntry); ok {
-				appendOnlyEntryPoolGetTotal.Add(1)
-				subtractAppendOnlyEntryPoolRetainedBytes(appendOnlyEntryPoolBytes(cap(entries)))
-				if cap(entries) >= length && cap(entries) <= appendOnlyMaxReuseEntries(length) {
-					appendOnlyEntryPoolMu.Unlock()
-					return entries[:length]
-				}
-			}
+	bin := appendOnlyEntryPoolBins[class]
+	for len(bin) > 0 {
+		last := len(bin) - 1
+		entries := bin[last]
+		bin[last] = nil
+		bin = bin[:last]
+		appendOnlyEntryPoolBins[class] = bin
+		appendOnlyEntryPoolGetTotal.Add(1)
+		subtractAppendOnlyEntryPoolRetainedBytes(appendOnlyEntryPoolBytes(cap(entries)))
+		if cap(entries) >= length && cap(entries) <= appendOnlyMaxReuseEntries(length) {
+			appendOnlyEntryPoolMu.Unlock()
+			return entries[:length]
 		}
 	}
 	appendOnlyEntryPoolMu.Unlock()
@@ -559,7 +565,7 @@ func putAppendOnlyEntries(entries []appendOnlyEntry) {
 	}
 	appendOnlyEntryPoolMu.Lock()
 	defer appendOnlyEntryPoolMu.Unlock()
-	if pool := appendOnlyEntryPoolForClass(class); pool != nil {
+	if appendOnlyEntryPoolForClass(class) != nil {
 		bytes := appendOnlyEntryPoolBytes(cap(full))
 		if !tryAddAppendOnlyEntryPoolRetainedBytes(bytes) {
 			dropAppendOnlyEntryPoolsLocked()
@@ -567,10 +573,9 @@ func putAppendOnlyEntries(entries []appendOnlyEntry) {
 				recordAppendOnlyEntryPoolAdmissionDrop(bytes)
 				return
 			}
-			pool = appendOnlyEntryPoolForClass(class)
 		}
 		appendOnlyEntryPoolPutTotal.Add(1)
-		pool.Put(full[:0])
+		appendOnlyEntryPoolBins[class] = append(appendOnlyEntryPoolBins[class], full[:0])
 	}
 }
 
@@ -2325,7 +2330,7 @@ func (m *AppendOnly) resetLockedWithPolicy(capacity, estimatedBytesPerEntry int,
 
 	if !retainObserved {
 		if cap(m.entries) != retainedEntries {
-			m.replaceEntriesSliceWithPolicy(retainedEntries, false)
+			m.replaceEntriesSliceWithPolicy(retainedEntries, true)
 			return
 		}
 		if len(m.entries) != retainedEntries {

--- a/TreeDB/internal/memtable/append_only_pool_test.go
+++ b/TreeDB/internal/memtable/append_only_pool_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -151,6 +152,32 @@ func TestAppendOnlyEntryPoolStatsTrackRetainedBacking(t *testing.T) {
 	if gotDropBytes := afterDrop.DropBytesTotal; gotDropBytes < beforeDrop.DropBytesTotal+beforeDrop.RetainedBytesEstimate {
 		t.Fatalf("drop bytes total=%d want at least %d", gotDropBytes, beforeDrop.DropBytesTotal+beforeDrop.RetainedBytesEstimate)
 	}
+}
+
+func TestAppendOnlyEntryPoolRetainsBackingAcrossGC(t *testing.T) {
+	DropAppendOnlyEntryPools()
+	t.Cleanup(DropAppendOnlyEntryPools)
+
+	entries := make([]appendOnlyEntry, 0, appendOnlyMinInitialEntries)
+	wantBytes := appendOnlyEntryPoolBytes(cap(entries))
+	putAppendOnlyEntries(entries)
+
+	runtime.GC()
+
+	afterGC := AppendOnlyEntryPoolStatsSnapshot()
+	if got := afterGC.RetainedBytesEstimate; got != wantBytes {
+		t.Fatalf("retained bytes after GC=%d want %d", got, wantBytes)
+	}
+
+	reused := getAppendOnlyEntries(appendOnlyMinInitialEntries)
+	if cap(reused) != cap(entries) {
+		t.Fatalf("reused cap after GC=%d want %d", cap(reused), cap(entries))
+	}
+	afterGet := AppendOnlyEntryPoolStatsSnapshot()
+	if got := afterGet.RetainedBytesEstimate; got != 0 {
+		t.Fatalf("retained bytes after get=%d want 0", got)
+	}
+	putAppendOnlyEntries(reused[:0])
 }
 
 func TestPutAppendOnlyEntriesDropsOversizedRetainedSlice(t *testing.T) {

--- a/TreeDB/internal/memtable/append_only_reset_hard_test.go
+++ b/TreeDB/internal/memtable/append_only_reset_hard_test.go
@@ -64,6 +64,41 @@ func TestAppendOnlyResetWithCapacityHard_ClampsWarmReuseCapacity(t *testing.T) {
 	}
 }
 
+func TestAppendOnlyResetWithCapacityHardPoolsDisplacedBacking(t *testing.T) {
+	DropAppendOnlyEntryPools()
+	t.Cleanup(DropAppendOnlyEntryPools)
+
+	const (
+		capacityBytes          = 4 << 10
+		estimatedBytesPerEntry = 96
+	)
+
+	mt := NewAppendOnlyWithCapacityEstimatedEntryBytes(capacityBytes, estimatedBytesPerEntry)
+	base := appendOnlyInitialEntriesForCapacity(capacityBytes, estimatedBytesPerEntry)
+
+	for i := 0; i < base*2; i++ {
+		key := []byte(fmt.Sprintf("k-%06d", i))
+		mt.Set(key, []byte("value"))
+	}
+	oldCap := cap(mt.entries)
+	if oldCap <= base {
+		t.Fatalf("test setup did not grow enough: cap(entries)=%d want>%d", oldCap, base)
+	}
+	if oldCap > appendOnlyEntryPoolRetainMaxCap {
+		t.Fatalf("test setup cap(entries)=%d exceeds retention max=%d", oldCap, appendOnlyEntryPoolRetainMaxCap)
+	}
+
+	mt.ResetWithCapacityHard(capacityBytes, estimatedBytesPerEntry)
+
+	if got := cap(mt.entries); got != base {
+		t.Fatalf("hard reset cap(entries)=%d want=%d", got, base)
+	}
+	wantRetained := appendOnlyEntryPoolBytes(oldCap)
+	if got := AppendOnlyEntryPoolStatsSnapshot().RetainedBytesEstimate; got != wantRetained {
+		t.Fatalf("retained entry pool bytes=%d want=%d", got, wantRetained)
+	}
+}
+
 func TestAppendOnlyReleaseDropEntries_DropsEntryBacking(t *testing.T) {
 	mt := NewAppendOnlyWithCapacityEstimatedEntryBytes(4<<20, 96)
 	if got := mt.EntryCapacity(); got == 0 {


### PR DESCRIPTION
## Summary

Fixes #3535.

This keeps append-only memtable entry backing in bounded strong size-class bins instead of relying only on `sync.Pool`, which can discard warm buffers at GC boundaries. Hard capacity resets still clamp the active memtable to the capacity-derived baseline, but now return reusable displaced backing to the bounded package pool.

Scope is intentionally limited to `TreeDB/internal/memtable` allocation retention/pooling behavior. This does not change WAL, value-log persistence, pointer encoding, checkpoint semantics, or on-disk format.

## Validation

- `GOWORK=off go test ./TreeDB/internal/memtable -count=1`
- `GOWORK=off go test ./TreeDB/internal/memtable -run '^$' -bench 'AppendOnly|EntryPool|Reserve' -benchmem -benchtime=200ms -count=3`
- `GOWORK=off go build -o bin/unified-bench ./cmd/unified_bench`
- `GOWORK=off go build -o bin/benchprof ./cmd/benchprof`
- Durable profile smoke:

```sh
GOWORK=off GOMAXPROCS=8 TMPDIR=/tmp/gomap_alloc_issue3535_smoke2_Ka8K74/tmp ./bin/unified-bench \
  -profile durable \
  -dbs treedb \
  -keys 10000000 \
  -valsize 128 \
  -batchsize 8000 \
  -checkpoint-between-tests \
  -treedb-journal-lanes=1 \
  -progress=false \
  -test sequential_write,random_write,dataset_write_random,batch_write_steady \
  -profile-dir /tmp/gomap_alloc_issue3535_smoke2_Ka8K74/profiles \
  -path-label native-fastpath \
  -format markdown
```

## Allocation Evidence

Compared against the supplied post-#3532 baseline under `/tmp/gomap_alloc_loop_20260706_post3532/profiles/main_all_tests`.

| test | baseline `getAppendOnlyEntries` alloc-space | PR alloc-space | delta |
| --- | ---: | ---: | ---: |
| `sequential_write` | 2097.27 MB (75.03%) | 692.80 MB (50.50%) | -1404.47 MB / -67.0% |
| `random_write` | 2482.55 MB (48.81%) | 2277.84 MB (45.61%) | -204.71 MB / -8.2% |
| `dataset_write_random` | 2813.51 MB (45.98%) | 2388.53 MB (34.02%) | -424.98 MB / -15.1% |
| `batch_write_steady` | 2760.52 MB (81.12%) | 1741.61 MB (67.89%) | -1018.91 MB / -36.9% |
| **sum** | **10153.85 MB** | **7100.78 MB** | **-3053.07 MB / -30.1%** |

The fresh smoke also reported `entry_pool_gets_total=2318`, `entry_pool_puts_total=3721`, and `entry_pool_retained_bytes_max_estimate=268297656` by the `batch_write_steady` checkpoint snapshot. A same-machine 2M-key sanity check against detached `origin/main` did not reproduce a code-attributable throughput regression; mutex profile focus on `TreeDB/internal/memtable` was ~0.03% of the slow 10M dataset smoke delay.

## Notes

- Existing cold-release/drop paths still drop entry backing.
- Retention remains bounded by the existing entry pool byte budget and `DropAppendOnlyEntryPools` clears strong bins.
- Not merged; this PR is ready for review/CI.
