### PR TITLE
TreeDB: defer read-only prepare separator clones

### DIFF
--- a/TreeDB/zipper/read_only_prepare.go
+++ b/TreeDB/zipper/read_only_prepare.go
@@ -1049,6 +1049,85 @@ func (z *Zipper) prepareReadOnlyRecursive(ref page.ChildRef, ops []batch.Entry, 
 		return nil
 	case page.PageTypeInternal:
 		count := oldNode.Count()
+		if len(ranges) == 0 {
+			opIdx := 0
+			copyKeys := oldNode.InternalBaseDeltaEnabled()
+			for i := uint16(0); i < count; i++ {
+				key, childRef, err := oldNode.GetInternalEntryRefView(i)
+				if err != nil {
+					return err
+				}
+				if key == nil {
+					key = []byte{}
+				}
+				keyNonEmpty := len(key) != 0
+				keyView := key
+				firstOpBeforeKey := false
+				if keyNonEmpty && opIdx < len(ops) && bytes.Compare(ops[opIdx].Key, key) < 0 {
+					firstOpBeforeKey = true
+				}
+
+				var endKey []byte
+				if i+1 < count {
+					nextKey, _, err := oldNode.GetInternalEntryRefView(i + 1)
+					if err != nil {
+						return err
+					}
+					if nextKey == nil {
+						nextKey = []byte{}
+					}
+					endKey = nextKey
+				}
+
+				startOpIdx := opIdx
+				for opIdx < len(ops) {
+					if endKey == nil || bytes.Compare(ops[opIdx].Key, endKey) < 0 {
+						opIdx++
+						continue
+					}
+					break
+				}
+				childOps := ops[startOpIdx:opIdx]
+				if len(childOps) == 0 {
+					continue
+				}
+
+				childHigh := high
+				if endKey != nil {
+					childHigh = endKey
+				}
+				childLow := low
+				if keyNonEmpty {
+					if firstOpBeforeKey {
+						childLow = childOps[0].Key
+					} else if copyKeys {
+						if endKey != nil {
+							// Internal base-delta keys share one node scratch buffer. If
+							// this touched middle child needs both separator bounds, keep
+							// the already-decoded high bound stable while refetching the
+							// low bound below.
+							childHigh = result.cloneKey(endKey)
+						}
+						key, _, err = oldNode.GetInternalEntryRefView(i)
+						if err != nil {
+							return err
+						}
+						if key == nil {
+							key = []byte{}
+						}
+						if len(key) != 0 {
+							childLow = key
+						}
+					} else {
+						childLow = keyView
+					}
+				}
+				if err := z.prepareReadOnlyRecursive(childRef, childOps, opBase+startOpIdx, nil, rangeBase, childLow, childHigh, result, scratch); err != nil {
+					return err
+				}
+			}
+			return nil
+		}
 		opIdx := 0
 		for i := uint16(0); i < count; i++ {
 			key, childRef, err := oldNode.GetInternalEntryRefView(i)

--- a/TreeDB/zipper/read_only_prepare_test.go
+++ b/TreeDB/zipper/read_only_prepare_test.go
@@ -64,6 +64,44 @@ func buildReadOnlyPrepareRootWithKeys(tb testing.TB, z *Zipper, count int) uint6
 	return newRootID
 }
 
+func buildReadOnlyPrepareWideBaseDeltaRoot(tb testing.TB, z *Zipper, children int) uint64 {
+	tb.Helper()
+	leafID, err := z.pager.Alloc(1)
+	if err != nil {
+		tb.Fatalf("alloc leaf: %v", err)
+	}
+	leafData, err := z.pager.Get(leafID)
+	if err != nil {
+		tb.Fatalf("get leaf: %v", err)
+	}
+	leaf := node.NewNode(leafData)
+	leaf.SetPageID(leafID)
+	leaf.SetType(page.PageTypeLeaf)
+	leaf.UpdateChecksum()
+
+	rootID, err := z.pager.Alloc(1)
+	if err != nil {
+		tb.Fatalf("alloc root: %v", err)
+	}
+	rootData, err := z.pager.Get(rootID)
+	if err != nil {
+		tb.Fatalf("get root: %v", err)
+	}
+	builder := node.NewBuilderWithOptions(rootData, page.PageTypeInternal, node.BuilderOptions{InternalBaseDelta: true})
+	builder.SetPageID(rootID)
+	for i := 0; i < children; i++ {
+		key := []byte(fmt.Sprintf("child-%06d", i))
+		if err := builder.AddInternalChild(key, leafID); err != nil {
+			tb.Fatalf("AddInternalChild(%d): %v", i, err)
+		}
+	}
+	root := builder.Finish()
+	if root.Type() != page.PageTypeInternal || !root.InternalBaseDeltaEnabled() {
+		tb.Fatalf("synthetic root type/base-delta=%v/%v want internal/base-delta", root.Type(), root.InternalBaseDeltaEnabled())
+	}
+	return rootID
+}
+
 func readOnlySpanSignature(prepared ReadOnlyPrepareResult) []string {
 	out := make([]string, len(prepared.LeafSpans))
 	for i, span := range prepared.LeafSpans {
@@ -396,6 +434,33 @@ func TestZipperPrepareReadOnlyOmitKeysSkipsSpanKeyCopies(t *testing.T) {
 	requireValidReadOnlyPrepare(t, reused)
 	if !reused.OmitKeys || len(reused.keyArena) != 0 || cap(reused.keyArena) != 0 {
 		t.Fatalf("reused omit-keys result OmitKeys=%v keyArena len/cap=%d/%d", reused.OmitKeys, len(reused.keyArena), cap(reused.keyArena))
+	}
+}
+
+func TestZipperPrepareReadOnlyPointOnlyDefersUntouchedBaseDeltaSeparatorClones(t *testing.T) {
+	_, z := newReadOnlyPrepareZipper(t)
+	rootID := buildReadOnlyPrepareWideBaseDeltaRoot(t, z, 384)
+
+	const touched = 250
+	key := []byte(fmt.Sprintf("child-%06d", touched))
+	delta := batch.New(panicValueReader{}, page.DefaultInlineThreshold)
+	defer func() { _ = delta.Close() }()
+	if err := delta.Set(key, []byte("new")); err != nil {
+		t.Fatalf("Set delta: %v", err)
+	}
+
+	prepared, err := z.PrepareReadOnly(rootID, delta, ReadOnlyPrepareOptions{})
+	if err != nil {
+		t.Fatalf("PrepareReadOnly: %v", err)
+	}
+	requireValidReadOnlyPrepare(t, prepared)
+	if len(prepared.LeafSpans) != 1 {
+		t.Fatalf("leaf spans=%d want 1", len(prepared.LeafSpans))
+	}
+	retainedKeyBytes := readOnlyPrepareSpanBoundaryBytes(prepared.LeafSpans) + readOnlyPrepareSpanOpKeyBytes(prepared.LeafSpans)
+	maxTemporaryBytes := len([]byte(fmt.Sprintf("child-%06d", touched+1)))
+	if got, max := len(prepared.keyArena), retainedKeyBytes+maxTemporaryBytes; got > max {
+		t.Fatalf("key arena bytes=%d, retained=%d max temporary=%d; likely cloned untouched separators", got, retainedKeyBytes, maxTemporaryBytes)
 	}
 }
 
@@ -920,6 +985,45 @@ func BenchmarkZipperPrepareReadOnlyManyLeafRandomKeyModes(b *testing.B) {
 			}
 		})
 	}
+}
+
+func BenchmarkZipperPrepareReadOnlyWideBaseDeltaSparsePoint(b *testing.B) {
+	_, z := newReadOnlyPrepareZipper(b)
+	rootID := buildReadOnlyPrepareWideBaseDeltaRoot(b, z, 384)
+	delta := batch.NewRetainingLargeEntries(panicValueReader{}, page.DefaultInlineThreshold)
+	defer func() { _ = delta.Close() }()
+	if err := delta.Set([]byte("child-000250"), []byte("new-value")); err != nil {
+		b.Fatalf("Set delta: %v", err)
+	}
+	delta.SortedEntries()
+
+	first, err := z.PrepareReadOnly(rootID, delta, ReadOnlyPrepareOptions{})
+	if err != nil {
+		b.Fatalf("initial PrepareReadOnly: %v", err)
+	}
+	requireValidReadOnlyPrepare(b, first)
+	opts := first.ReuseOptions()
+	lastSummary := first.LeafSpanSummary()
+	lastKeyArenaBytes := len(first.keyArena)
+	lastRetainedKeyBytes := readOnlyPrepareSpanBoundaryBytes(first.LeafSpans) + readOnlyPrepareSpanOpKeyBytes(first.LeafSpans)
+	b.ReportAllocs()
+	b.SetBytes(int64(lastSummary.SpanBytes))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		prepared, err := z.PrepareReadOnly(rootID, delta, opts)
+		if err != nil {
+			b.Fatalf("PrepareReadOnly: %v", err)
+		}
+		lastSummary = prepared.LeafSpanSummary()
+		lastKeyArenaBytes = len(prepared.keyArena)
+		lastRetainedKeyBytes = readOnlyPrepareSpanBoundaryBytes(prepared.LeafSpans) + readOnlyPrepareSpanOpKeyBytes(prepared.LeafSpans)
+		opts = prepared.ReuseOptions()
+	}
+	b.StopTimer()
+	b.ReportMetric(float64(lastSummary.Spans), "leaf_spans/op")
+	b.ReportMetric(float64(lastSummary.SpanOps), "span_ops/op")
+	b.ReportMetric(float64(lastKeyArenaBytes), "key_arena_bytes/op")
+	b.ReportMetric(float64(lastRetainedKeyBytes), "retained_key_bytes/op")
 }
 
 func benchmarkZipperPrepareReadOnlyRandom(b *testing.B, keyCount, batchSize int) {


### PR DESCRIPTION
Refs #3544
Parent tracker: #3515

## Summary

- Defer point-only read-only prepare separator-bound copies until an internal child is known to contain point ops.
- Preserve scratch-backed base-delta key safety by using borrowed views only within the current recursive lifetime and copying the decoded high bound before refetching a touched middle child low bound.
- Leave delete-range traversal on the existing eager-copy path because range overlap checks need exact simultaneous span bounds.
- Add a focused wide base-delta sparse-point test and benchmark for the previously hot untouched-child clone pattern.

## Baseline / Start Evidence

Accepted Ironbird baseline from #3544:

- Baseline root: `/mnt/fast4tb/ironbird-3531-memtable-allocs-20260706T094142Z`
- Plain-send heap: `plain-send/treedb/attempt-1/pprof/simapp-treedb-all-validator-0-heap.pprof`
- Accepted plain-send metrics: total alloc_space `125047.02MB`, TreeDB flat sum `36012.36MB`, `ReadOnlyPrepareResult.cloneKey` `7833.05MB`, TPS `585.96`, commit `36.716s`, finalize `34.758s`, check_tx `101.048s`
- Coordinator pprof split: `prepareReadOnlyRecursive` direct path `7356.32MB / 93.91%`; `addLeafSpan` path `476.73MB / 6.09%`

Local benchmark before this change on `origin/main` (`26b191d07`), same command below:

- `BenchmarkZipperPrepareReadOnlyManyLeafRandomKeyModes/full_keys/reuse`: `key_arena_bytes/op=3030`, `boundary_key_bytes/op=930`, `op_key_bytes/op=940`, `0 B/op`, `0 allocs/op`
- `BenchmarkZipperPrepareReadOnlyManyLeafRandomKeyModes/omit_op_keys/reuse`: `key_arena_bytes/op=2090`, `boundary_key_bytes/op=930`, `op_key_bytes/op=0`, `0 B/op`, `0 allocs/op`
- `BenchmarkZipperPrepareReadOnlyManyLeafRandomFresh`: about `237573 B/op`, `2 allocs/op`

## Candidate / Close Evidence

Candidate gomap ref: `9a292ceb5` (`codex/3515-3544-readonly-clonekey-allocs`)

Local benchmark after this change:

- `BenchmarkZipperPrepareReadOnlyManyLeafRandomKeyModes/full_keys/reuse`: `key_arena_bytes/op=1870`, matching retained boundary+op key bytes (`930+940`), `0 B/op`, `0 allocs/op`
- `BenchmarkZipperPrepareReadOnlyManyLeafRandomKeyModes/omit_op_keys/reuse`: `key_arena_bytes/op=930`, matching retained boundary key bytes, `0 B/op`, `0 allocs/op`
- `BenchmarkZipperPrepareReadOnlyWideBaseDeltaSparsePoint`: `key_arena_bytes/op=60`, `retained_key_bytes/op=48`, `64 B/op`, `1 allocs/op`

Benchmark command:

```sh
GOWORK=off TMPDIR=/mnt/fast4tb/tmp go test ./TreeDB/zipper -run '^$' -bench 'BenchmarkZipperPrepareReadOnlyManyLeafRandomKeyModes/(full_keys|omit_op_keys)/reuse$|BenchmarkZipperPrepareReadOnlyManyLeafRandomFresh$|BenchmarkZipperPrepareReadOnlyWideBaseDeltaSparsePoint$' -benchtime=20x -count=3
```

## Tests

```sh
GOWORK=off TMPDIR=/mnt/fast4tb/tmp go test ./TreeDB/zipper
GOWORK=off TMPDIR=/mnt/fast4tb/tmp go test ./TreeDB/db
```

`./TreeDB/db` completed in `236.000s` locally.

## Ironbird Validation Status

Ironbird validation remains pending by coordinator. No candidate Ironbird branch/commit, artifact root, accepted row, or small-multisend guard row has been produced in this PR yet.

Expected next validation: pin gomap ref `9a292ceb5` into Ironbird and compare accepted plain-send against `/mnt/fast4tb/ironbird-3531-memtable-allocs-20260706T094142Z`, with small-multisend as a regression guard per #3544.

## Risk Notes

- This intentionally does not remove leaf-span result ownership copies; retained span/op keys are still owned by `ReadOnlyPrepareResult`.
- Delete-range planning keeps the previous eager separator clone path.
- The point-only path borrows current-node separator views only while the parent frame is not decoding another entry; base-delta touched middle children copy one bound before refetching the other.