### PR TITLE
TreeDB: borrow command WAL payloads on read

### DIFF
--- a/TreeDB/internal/commitlog/command_frame.go
+++ b/TreeDB/internal/commitlog/command_frame.go
@@ -2003,6 +2003,10 @@ func encodeCommandFrameTo(dst []byte, env CommandEnvelope) ([]byte, error) {
 }
 
 func DecodeCommandFrame(frame []byte) (CommandEnvelope, error) {
+	return decodeCommandFrame(frame, true)
+}
+
+func decodeCommandFrame(frame []byte, copyPayload bool) (CommandEnvelope, error) {
 	var env CommandEnvelope
 	if len(frame) >= batchHeaderSize && len(frame) < commandFrameHeaderSize && isBatchPayloadVersion(frame[0]) {
 		return env, ErrCommandWALLegacyPayload
@@ -2048,7 +2052,13 @@ func DecodeCommandFrame(frame []byte) (CommandEnvelope, error) {
 		return env, ErrCorrupt
 	}
 	off := commandFrameHeaderSize
-	env.Payload = append([]byte(nil), frame[off:off+int(payloadLen)]...)
+	if payloadLen != 0 {
+		payload := frame[off : off+int(payloadLen) : off+int(payloadLen)]
+		if copyPayload {
+			payload = append([]byte(nil), payload...)
+		}
+		env.Payload = payload
+	}
 	off += int(payloadLen)
 	extRefs, err := decodeExternalRefs(frame[off : off+int(extRefsLen)])
 	if err != nil {
@@ -3407,7 +3417,7 @@ func (r *Reader) ReadCommandFrame() (CommandEnvelope, error) {
 	if err != nil {
 		return CommandEnvelope{}, err
 	}
-	return DecodeCommandFrame(payload)
+	return decodeCommandFrame(payload, false)
 }
 
 func ScanCommandFrames(path string, opts Options) ([]CommandEnvelope, error) {

--- a/TreeDB/internal/commitlog/command_frame_bench_test.go
+++ b/TreeDB/internal/commitlog/command_frame_bench_test.go
@@ -116,6 +116,24 @@ func BenchmarkCommandWALFrameDecode(b *testing.B) {
 	}
 }
 
+func BenchmarkCommandWALFrameDecodeBorrowed(b *testing.B) {
+	for _, tc := range commandWALBenchCases() {
+		b.Run(tc.name, func(b *testing.B) {
+			frame := mustCommandWALBenchFrame(b, tc.ops, tc.valueSize)
+			b.SetBytes(int64(len(frame)))
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				env, err := decodeCommandFrame(frame, false)
+				if err != nil {
+					b.Fatal(err)
+				}
+				commandWALBenchSink.frame = env.Payload
+			}
+		})
+	}
+}
+
 func BenchmarkWriterAppendCommandRawKVBatch(b *testing.B) {
 	for _, tc := range commandWALBenchCases() {
 		b.Run(tc.name, func(b *testing.B) {

--- a/TreeDB/internal/commitlog/command_frame_test.go
+++ b/TreeDB/internal/commitlog/command_frame_test.go
@@ -68,6 +68,46 @@ func TestCommandWALFormatGoldenV1RawKVBatch(t *testing.T) {
 	}
 }
 
+func TestCommandWALDecodeCommandFramePayloadOwnershipModes(t *testing.T) {
+	payload, err := EncodeRawKVBatchPayload([]RawKVOperation{
+		{Op: RawKVOpSet, Key: []byte("alpha"), Value: []byte("one")},
+	})
+	if err != nil {
+		t.Fatalf("EncodeRawKVBatchPayload: %v", err)
+	}
+	frame, err := EncodeCommandFrame(CommandEnvelope{
+		LSN:           7,
+		Kind:          CommandKindRawKVBatch,
+		Scope:         CommandScopeRawKV,
+		PayloadFormat: PayloadFormatRawKVBatchV1,
+		Payload:       payload,
+	})
+	if err != nil {
+		t.Fatalf("EncodeCommandFrame: %v", err)
+	}
+
+	owned, err := DecodeCommandFrame(frame)
+	if err != nil {
+		t.Fatalf("DecodeCommandFrame: %v", err)
+	}
+	borrowed, err := decodeCommandFrame(frame, false)
+	if err != nil {
+		t.Fatalf("decodeCommandFrame borrowed: %v", err)
+	}
+	if cap(borrowed.Payload) != len(borrowed.Payload) {
+		t.Fatalf("borrowed payload cap=%d want len=%d", cap(borrowed.Payload), len(borrowed.Payload))
+	}
+
+	valueOffset := rawKVBatchHeaderSize + rawKVOpHeaderSize + len("alpha")
+	frame[commandFrameHeaderSize+valueOffset] = 'z'
+	if owned.Payload[valueOffset] != 'o' {
+		t.Fatalf("owned payload observed frame mutation: got %q want %q", owned.Payload[valueOffset], byte('o'))
+	}
+	if borrowed.Payload[valueOffset] != 'z' {
+		t.Fatalf("borrowed payload did not alias frame: got %q want %q", borrowed.Payload[valueOffset], byte('z'))
+	}
+}
+
 func TestCommandWALRawKVBatchPreservesEmptySetValue(t *testing.T) {
 	payload, err := EncodeRawKVBatchPayload([]RawKVOperation{
 		{Op: RawKVOpSet, Key: []byte("empty"), Value: []byte{}},


### PR DESCRIPTION
Refs #3548.

## Summary

- Keep public `DecodeCommandFrame` payload ownership semantics unchanged.
- Add an internal borrowed decode mode for reader-owned command WAL frame buffers.
- Use borrowed decode from `Reader.ReadCommandFrame` so replay/scan paths no longer allocate a second payload-sized copy after `readSegmentPayload` has already materialized the frame.
- Add an ownership-mode test and a focused borrowed decode benchmark.

## Baseline context

Issue #3548 baseline command-WAL/read-decode allocation sites include:

- plain-send: `readSegmentPayload` 1797.26MB, `DecodeCommandFrame` 1750.72MB
- small-multisend: `readSegmentPayload` 2428.86MB, `DecodeCommandFrame` 2366.75MB

This PR targets the `DecodeCommandFrame` copy in `ReadCommandFrame`; it does not remove the frame buffer allocation in `readSegmentPayload`.

## Benchmark evidence

Before change, on `origin/main` (`26b191d078e2752bf57fc39f7920edad3fb3c178`):

```sh
GOWORK=off TMPDIR=/mnt/fast4tb/tmp go test ./TreeDB/internal/commitlog -run '^$' -bench '^BenchmarkCommandWALFrameDecode$' -benchmem -count=5
```

Representative allocation results:

- `ops_1_value_64`: 96 B/op, 1 allocs/op
- `ops_16_value_64`: 1408 B/op, 1 allocs/op
- `ops_128_value_64`: 10880 B/op, 1 allocs/op
- `ops_16_value_1024`: 18432 B/op, 1 allocs/op

After change:

```sh
GOWORK=off TMPDIR=/mnt/fast4tb/tmp go test ./TreeDB/internal/commitlog -run '^$' -bench '^BenchmarkCommandWALFrameDecode(Borrowed)?$' -benchmem -count=5
```

Borrowed decode allocation results:

- `ops_1_value_64`: 0 B/op, 0 allocs/op
- `ops_16_value_64`: 0 B/op, 0 allocs/op
- `ops_128_value_64`: 0 B/op, 0 allocs/op
- `ops_16_value_1024`: 0 B/op, 0 allocs/op

Public `BenchmarkCommandWALFrameDecode` remains payload-copying at the same allocation sizes, preserving caller-owned decode semantics.

## Tests

```sh
GOWORK=off TMPDIR=/mnt/fast4tb/tmp go test ./TreeDB/internal/commitlog -run 'TestCommandWALDecodeCommandFramePayloadOwnershipModes|TestCommandWALFormatGoldenV1RawKVBatch'
GOWORK=off TMPDIR=/mnt/fast4tb/tmp go test ./TreeDB/internal/commitlog ./TreeDB/caching ./TreeDB/db ./TreeDB
```

Both passed locally.

## Risk / validation notes

- Borrowed payload slices are cap-limited to `len(payload)` so accidental append cannot overwrite later frame sections.
- `DecodeCommandFrame` still returns an owned payload copy for direct public callers.
- `ReadCommandFrame` now returns a payload slice backed by its reader-owned segment frame buffer; retaining a command envelope retains that frame buffer until the payload is released.
- Coordinator Ironbird validation is still required for plain-send and small-multisend before merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Reduced unnecessary copying when reading command data, which can lower memory use and improve decoding efficiency.
  * Existing direct decoding behavior remains unchanged, so callers that rely on copied payloads continue to work as before.

* **Tests**
  * Added coverage to verify payload handling stays correct across both copied and borrowed decoding paths.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->