### PR TITLE
TreeDB: reduce batch scratch allocation churn

### DIFF
--- a/TreeDB/caching/batch_arena_budget_test.go
+++ b/TreeDB/caching/batch_arena_budget_test.go
@@ -20,10 +20,14 @@ func resetBatchArenaPoolsForTest() {
 	batchArenaLeasedBytesGlobal.Store(0)
 	batchArenaRetainedHardCapOverride.Store(0)
 	batchArenaPoolBudgetState.Store(batchArenaPoolBudgetCache{})
+	batchArenaPoolDropBytesTotal.Store(0)
 	batchArenaPoolDropHardCapBytesTotal.Store(0)
 	batchArenaBorrowBlockedTotal.Store(0)
 	batchArenaBorrowPreflightBlockedTotal.Store(0)
 	batchArenaBorrowPreflightBlockedBytesTotal.Store(0)
+	batchArenaFreeLeaseMu.Lock()
+	batchArenaFreeLeases = [batchArenaClassCount][][]byte{}
+	batchArenaFreeLeaseMu.Unlock()
 	for i := range batchArenaPools {
 		batchArenaPools[i] = sync.Pool{}
 	}
@@ -54,6 +58,82 @@ func TestBatchArenaPoolAccountingRecoversOnUnexpectedCap(t *testing.T) {
 	if got := batchArenaPoolBytes.Load(); got != 0 {
 		t.Fatalf("batchArenaPoolBytes after wrong-cap recovery=%d want 0", got)
 	}
+}
+
+func TestBatchArenaFreeLeaseRoundTripAccounting(t *testing.T) {
+	batchArenaPoolTestMu.Lock()
+	defer batchArenaPoolTestMu.Unlock()
+	resetBatchArenaPoolsForTest()
+
+	_, classCap, ok := batchArenaClassForLen(1 << batchArenaMinShift)
+	if !ok {
+		t.Fatal("batchArenaClassForLen failed")
+	}
+	buf := make([]byte, 1, classCap)
+	wantPtr := unsafe.SliceData(buf)
+
+	putBatchArena(buf)
+	if got := batchArenaPoolBytes.Load(); got != int64(classCap) {
+		t.Fatalf("batchArenaPoolBytes after put=%d want %d", got, classCap)
+	}
+
+	got := getBatchArena(classCap)
+	if cap(got) != classCap {
+		t.Fatalf("getBatchArena cap=%d want %d", cap(got), classCap)
+	}
+	got = append(got, 0)
+	if gotPtr := unsafe.SliceData(got); gotPtr != wantPtr {
+		t.Fatalf("getBatchArena did not reuse free lease backing")
+	}
+	if gotBytes := batchArenaPoolBytes.Load(); gotBytes != 0 {
+		t.Fatalf("batchArenaPoolBytes after get=%d want 0", gotBytes)
+	}
+}
+
+func TestBatchArenaFreeLeaseDropsAfterBucketCap(t *testing.T) {
+	batchArenaPoolTestMu.Lock()
+	defer batchArenaPoolTestMu.Unlock()
+	resetBatchArenaPoolsForTest()
+
+	_, classCap, ok := batchArenaClassForLen(1 << batchArenaMinShift)
+	if !ok {
+		t.Fatal("batchArenaClassForLen failed")
+	}
+
+	for i := 0; i < maxBatchArenaFreeLeasesPerBucket+1; i++ {
+		putBatchArena(make([]byte, 0, classCap))
+	}
+	if got, want := batchArenaPoolBytes.Load(), int64(maxBatchArenaFreeLeasesPerBucket*classCap); got != want {
+		t.Fatalf("batchArenaPoolBytes after capped puts=%d want %d", got, want)
+	}
+	if got := batchArenaPoolDropBytesTotal.Load(); got < uint64(classCap) {
+		t.Fatalf("batchArenaPoolDropBytesTotal=%d want >= %d", got, classCap)
+	}
+}
+
+func TestBatchArenaLeaseStaticHeaderRoundTrip(t *testing.T) {
+	batchArenaPoolTestMu.Lock()
+	defer batchArenaPoolTestMu.Unlock()
+
+	chunk := make([]byte, 0, 1<<batchArenaMinShift)
+	chunks := [][]byte{chunk}
+	lease := getBatchArenaLease(1, chunks)
+	if lease == nil {
+		t.Fatal("getBatchArenaLease returned nil")
+	}
+	if !lease.staticPool {
+		t.Fatal("getBatchArenaLease did not use static lease header")
+	}
+	if got, want := lease.bytes, int64(cap(chunk)); got != want {
+		t.Fatalf("lease bytes=%d want %d", got, want)
+	}
+	putBatchArenaLease(lease)
+
+	got := getBatchArenaLease(1, chunks)
+	if got != lease {
+		t.Fatal("getBatchArenaLease did not reuse static lease header")
+	}
+	putBatchArenaLease(got)
 }
 
 func TestBatchArenaPoolAccountingMissWithoutGCDoesNotReset(t *testing.T) {
@@ -201,6 +281,46 @@ func TestDrainBatchArenaPoolToTargetBytes(t *testing.T) {
 	maxAllowedAfter := before - int64(classCap)
 	if after > maxAllowedAfter {
 		t.Fatalf("batchArenaPoolBytes after drain=%d want <= %d (before=%d target=%d classCap=%d)", after, maxAllowedAfter, before, target, classCap)
+	}
+}
+
+func BenchmarkBatchArenaFreeLeaseRoundTrip(b *testing.B) {
+	batchArenaPoolTestMu.Lock()
+	resetBatchArenaPoolsForTest()
+	b.Cleanup(batchArenaPoolTestMu.Unlock)
+
+	_, classCap, ok := batchArenaClassForLen(1 << batchArenaMinShift)
+	if !ok {
+		b.Fatal("batchArenaClassForLen failed")
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		buf := getBatchArena(classCap)
+		if cap(buf) != classCap {
+			b.Fatalf("getBatchArena cap=%d want %d", cap(buf), classCap)
+		}
+		putBatchArena(buf)
+	}
+}
+
+func BenchmarkBatchArenaLeaseHeaderRoundTrip(b *testing.B) {
+	batchArenaPoolTestMu.Lock()
+	b.Cleanup(batchArenaPoolTestMu.Unlock)
+
+	chunk := make([]byte, 0, 1<<batchArenaMinShift)
+	chunks := [][]byte{chunk}
+	lease := getBatchArenaLease(1, chunks)
+	putBatchArenaLease(lease)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		lease := getBatchArenaLease(1, chunks)
+		if lease == nil {
+			b.Fatal("getBatchArenaLease returned nil")
+		}
+		putBatchArenaLease(lease)
 	}
 }
 
@@ -372,6 +492,45 @@ func TestBatchArenaLeaseBytesTracksRetainReleaseLifecycle(t *testing.T) {
 	}
 	if got := db.batchArenaLeaseBytesMax.Load(); got != want {
 		t.Fatalf("leased bytes max after final release=%d want=%d", got, want)
+	}
+}
+
+func TestBatchArenaSingleMemtableRetainCoalescesLeaseHeaders(t *testing.T) {
+	batchArenaPoolTestMu.Lock()
+	defer batchArenaPoolTestMu.Unlock()
+	resetBatchArenaPoolsForTest()
+
+	db := &DB{}
+	mt := memtable.NewBTree()
+	chunkA := make([]byte, 0, 1<<batchArenaMinShift)
+	chunkB := make([]byte, 0, 1<<batchArenaMinShift)
+
+	db.retainBatchArenaChunksForMemtables([][]byte{chunkA}, []memtable.Table{mt})
+	db.retainBatchArenaChunksForMemtables([][]byte{chunkB}, []memtable.Table{mt})
+
+	wantBytes := int64(cap(chunkA) + cap(chunkB))
+	if got := db.batchArenaLeaseBytes.Load(); got != wantBytes {
+		t.Fatalf("leased bytes after coalesced retain=%d want=%d", got, wantBytes)
+	}
+	db.batchArenaLeaseMu.Lock()
+	leases := append([]*batchArenaLease(nil), db.batchArenaLeasesByMem[mt]...)
+	db.batchArenaLeaseMu.Unlock()
+	if got := len(leases); got != 1 {
+		t.Fatalf("lease headers for one memtable=%d want 1", got)
+	}
+	if got := len(leases[0].chunks); got != 2 {
+		t.Fatalf("coalesced lease chunks=%d want 2", got)
+	}
+	if got := leases[0].bytes; got != wantBytes {
+		t.Fatalf("coalesced lease bytes=%d want=%d", got, wantBytes)
+	}
+
+	db.releaseBatchArenaLeasesForMemtable(mt)
+	if got := db.batchArenaLeaseBytes.Load(); got != 0 {
+		t.Fatalf("leased bytes after release=%d want=0", got)
+	}
+	if got := batchArenaLeasedBytesGlobal.Load(); got != 0 {
+		t.Fatalf("global leased bytes after release=%d want=0", got)
 	}
 }
 

--- a/TreeDB/caching/batch_arena_ownership_test.go
+++ b/TreeDB/caching/batch_arena_ownership_test.go
@@ -168,6 +168,39 @@ func TestBatchArenaLeases_ReleasedAfterCheckpoint(t *testing.T) {
 	}
 }
 
+func TestBatchArenaLeases_RetiredMemtableReleaseWaitsForRecycle(t *testing.T) {
+	batchArenaPoolTestMu.Lock()
+	defer batchArenaPoolTestMu.Unlock()
+	resetBatchArenaPoolsForTest()
+	forceNormalPoolPressureForTest(t)
+
+	db := &DB{}
+	mt := memtable.NewAppendOnlyWithCapacityEstimatedEntryBytes(1024, 64)
+	chunk := make([]byte, 0, batchCopyArenaMinChunk)
+	chunkBytes := int64(cap(chunk))
+
+	db.retainBatchArenaChunksForMemtables([][]byte{chunk}, []memtable.Table{mt})
+	if got := db.batchArenaLeaseBytes.Load(); got != chunkBytes {
+		t.Fatalf("leased bytes after retain=%d want %d", got, chunkBytes)
+	}
+
+	db.queueRetiredMemtableLocked(mt)
+	if got := batchArenaPoolBytes.Load(); got != 0 {
+		t.Fatalf("retired queue returned live arena bytes=%d want 0", got)
+	}
+	if got := db.batchArenaLeaseBytes.Load(); got != chunkBytes {
+		t.Fatalf("leased bytes after retired queue=%d want %d", got, chunkBytes)
+	}
+
+	db.recycleMemtables([]memtable.Table{mt})
+	if got := db.batchArenaLeaseBytes.Load(); got != 0 {
+		t.Fatalf("leased bytes after recycle=%d want 0", got)
+	}
+	if got := batchArenaPoolBytes.Load(); got == 0 {
+		t.Fatalf("expected recycled arena chunk to return to pool")
+	}
+}
+
 func TestBatchArenaRetainedHardCap_BoundsLeaseGrowthAcrossSustainedWrites(t *testing.T) {
 	batchArenaPoolTestMu.Lock()
 	defer batchArenaPoolTestMu.Unlock()

--- a/TreeDB/caching/batch_aux_pool_test.go
+++ b/TreeDB/caching/batch_aux_pool_test.go
@@ -2,10 +2,23 @@ package caching
 
 import (
 	"testing"
+	"unsafe"
 
 	"github.com/snissn/gomap/TreeDB/batch"
 	"github.com/snissn/gomap/TreeDB/internal/memtable"
 )
+
+func forceNormalPoolPressureForTest(tb testing.TB) {
+	tb.Helper()
+	saved, _ := poolPressureState.Load().(poolPressureSnapshot)
+	poolPressureState.Store(poolPressureSnapshot{
+		sampledUnixNano: poolPressureNow().UnixNano(),
+		level:           poolPressureNormal,
+	})
+	tb.Cleanup(func() {
+		poolPressureState.Store(saved)
+	})
+}
 
 func TestAppendUniqueMemtableDeduplicates(t *testing.T) {
 	mt1 := memtable.NewAppendOnlyWithCapacityEstimatedEntryBytes(1024, 64)
@@ -58,4 +71,309 @@ func TestBatchCloseReleasesAuxiliaryIndexSlices(t *testing.T) {
 		t.Fatalf("getBatchInt64Slice cap=%d want >= 4", cap(adds))
 	}
 	db.putBatchInt64Slice(adds)
+}
+
+func TestBatchAuxScratchLeasesReuseOneShotSlices(t *testing.T) {
+	forceNormalPoolPressureForTest(t)
+	db := &DB{}
+
+	entries := make([]batch.Entry, 1, 4)
+	entriesPtr := unsafe.SliceData(entries)
+	db.putBatchEntries(entries)
+	gotEntries := db.getBatchEntries(4)
+	gotEntries = append(gotEntries, batch.Entry{})
+	if gotPtr := unsafe.SliceData(gotEntries); gotPtr != entriesPtr {
+		t.Fatalf("getBatchEntries did not reuse leased backing")
+	}
+
+	shardEntries := make([]batch.Entry, 1, 4)
+	shardEntriesPtr := unsafe.SliceData(shardEntries)
+	db.putBatchShardEntries(shardEntries)
+	gotShardEntries := db.getBatchShardEntries(4)
+	gotShardEntries = append(gotShardEntries, batch.Entry{})
+	if gotPtr := unsafe.SliceData(gotShardEntries); gotPtr != shardEntriesPtr {
+		t.Fatalf("getBatchShardEntries did not reuse leased backing")
+	}
+
+	idxs := make([]int, 1, 4)
+	idxsPtr := unsafe.SliceData(idxs)
+	db.putBatchIntSlice(idxs)
+	gotIdxs := db.getBatchIntSlice(4)
+	gotIdxs = append(gotIdxs, 0)
+	if gotPtr := unsafe.SliceData(gotIdxs); gotPtr != idxsPtr {
+		t.Fatalf("getBatchIntSlice did not reuse leased backing")
+	}
+
+	adds := make([]int64, 1, 4)
+	addsPtr := unsafe.SliceData(adds)
+	db.putBatchInt64Slice(adds)
+	gotAdds := db.getBatchInt64Slice(4)
+	gotAdds = append(gotAdds, 0)
+	if gotPtr := unsafe.SliceData(gotAdds); gotPtr != addsPtr {
+		t.Fatalf("getBatchInt64Slice did not reuse leased backing")
+	}
+}
+
+func TestBatchAuxScratchLeasesBoundRetention(t *testing.T) {
+	forceNormalPoolPressureForTest(t)
+	db := &DB{}
+
+	for i := 0; i < batchAuxEntryLeaseMaxCount+16; i++ {
+		db.putBatchShardEntries(make([]batch.Entry, 0, 1))
+	}
+	for i := 0; i < batchAuxEntryGroupLeaseMaxCount+16; i++ {
+		db.putBatchShardEntryGroups(make([][]batch.Entry, 0, 1))
+	}
+	for i := 0; i < batchAuxIntLeaseMaxCount+16; i++ {
+		db.putBatchIntSlice(make([]int, 0, 1))
+		db.putBatchInt64Slice(make([]int64, 0, 1))
+	}
+
+	db.batchAuxMu.Lock()
+	shardEntriesCount := len(db.batchShardEntriesLeases.slices)
+	shardEntriesBytes := db.batchShardEntriesLeases.bytes
+	shardEntryGroupsCount := len(db.batchShardEntryGroupsLeases.slices)
+	shardEntryGroupsBytes := db.batchShardEntryGroupsLeases.bytes
+	intCount := len(db.batchIntLeases.slices)
+	intBytes := db.batchIntLeases.bytes
+	int64Count := len(db.batchInt64Leases.slices)
+	int64Bytes := db.batchInt64Leases.bytes
+	db.batchAuxMu.Unlock()
+
+	if shardEntriesCount > batchAuxEntryLeaseMaxCount || shardEntriesBytes > batchAuxEntryLeaseMaxBytes {
+		t.Fatalf("batch shard entry leases count=%d bytes=%d exceed limits count=%d bytes=%d",
+			shardEntriesCount, shardEntriesBytes, batchAuxEntryLeaseMaxCount, batchAuxEntryLeaseMaxBytes)
+	}
+	if shardEntryGroupsCount > batchAuxEntryGroupLeaseMaxCount || shardEntryGroupsBytes > batchAuxEntryGroupLeaseMaxBytes {
+		t.Fatalf("batch shard entry group leases count=%d bytes=%d exceed limits count=%d bytes=%d",
+			shardEntryGroupsCount, shardEntryGroupsBytes, batchAuxEntryGroupLeaseMaxCount, batchAuxEntryGroupLeaseMaxBytes)
+	}
+	if intCount > batchAuxIntLeaseMaxCount || intBytes > batchAuxIntLeaseMaxBytes {
+		t.Fatalf("batch int leases count=%d bytes=%d exceed limits count=%d bytes=%d",
+			intCount, intBytes, batchAuxIntLeaseMaxCount, batchAuxIntLeaseMaxBytes)
+	}
+	if int64Count > batchAuxIntLeaseMaxCount || int64Bytes > batchAuxIntLeaseMaxBytes {
+		t.Fatalf("batch int64 leases count=%d bytes=%d exceed limits count=%d bytes=%d",
+			int64Count, int64Bytes, batchAuxIntLeaseMaxCount, batchAuxIntLeaseMaxBytes)
+	}
+}
+
+func TestBatchShardEntryGroupLeaseReuseAndClear(t *testing.T) {
+	db := &DB{}
+
+	groups := make([][]batch.Entry, 1, 4)
+	groups[0] = make([]batch.Entry, 1, 2)
+	groupsPtr := unsafe.SliceData(groups)
+
+	db.putBatchShardEntryGroups(groups)
+	got := db.getBatchShardEntryGroups(2)
+	if cap(got) < 2 {
+		t.Fatalf("getBatchShardEntryGroups cap=%d want >= 2", cap(got))
+	}
+	got = append(got, nil)
+	if gotPtr := unsafe.SliceData(got); gotPtr != groupsPtr {
+		t.Fatalf("getBatchShardEntryGroups did not reuse backing")
+	}
+	for i, entries := range got[:cap(got)] {
+		if entries != nil {
+			t.Fatalf("leased shard entry group retained entries at %d: cap=%d", i, cap(entries))
+		}
+	}
+}
+
+func TestBatchReleaseShardEntryGroupsReturnsOuterAndInnerLeases(t *testing.T) {
+	forceNormalPoolPressureForTest(t)
+	db := &DB{}
+	b := &Batch{db: db}
+	entries := make([]batch.Entry, 1, 4)
+	entriesPtr := unsafe.SliceData(entries)
+	groups := make([][]batch.Entry, 1, 4)
+	groups[0] = entries
+	groupsPtr := unsafe.SliceData(groups)
+
+	b.releaseShardEntryGroups(groups)
+
+	gotGroups := db.getBatchShardEntryGroups(1)
+	gotGroups = append(gotGroups, nil)
+	if gotPtr := unsafe.SliceData(gotGroups); gotPtr != groupsPtr {
+		t.Fatalf("releaseShardEntryGroups did not return outer group backing")
+	}
+	for i, gotEntries := range gotGroups[:cap(gotGroups)] {
+		if gotEntries != nil {
+			t.Fatalf("outer group retained inner entries at %d: cap=%d", i, cap(gotEntries))
+		}
+	}
+
+	gotEntries := db.getBatchShardEntries(4)
+	gotEntries = append(gotEntries, batch.Entry{})
+	if gotPtr := unsafe.SliceData(gotEntries); gotPtr != entriesPtr {
+		t.Fatalf("releaseShardEntryGroups did not return inner entry backing")
+	}
+}
+
+func TestBatchArenaChunkListLeaseReuseAndClear(t *testing.T) {
+	db := &DB{}
+
+	chunks := make([][]byte, 1, 4)
+	chunks[0] = make([]byte, 0, 8)
+	chunksPtr := unsafe.SliceData(chunks)
+
+	if !db.putBatchArenaChunkListLease(chunks) {
+		t.Fatalf("putBatchArenaChunkListLease returned false")
+	}
+	got := db.takeBatchArenaChunkListLease(2)
+	if cap(got) < 2 {
+		t.Fatalf("takeBatchArenaChunkListLease cap=%d want >= 2", cap(got))
+	}
+	got = append(got, nil)
+	if gotPtr := unsafe.SliceData(got); gotPtr != chunksPtr {
+		t.Fatalf("takeBatchArenaChunkListLease did not reuse backing")
+	}
+	for i, chunk := range got[:cap(got)] {
+		if chunk != nil {
+			t.Fatalf("leased chunk list retained chunk at %d: cap=%d", i, cap(chunk))
+		}
+	}
+}
+
+func TestBatchArenaChunkListLeaseReturnedAfterMemtableRelease(t *testing.T) {
+	db := &DB{}
+	mt := memtable.NewAppendOnlyWithCapacityEstimatedEntryBytes(1024, 64)
+	chunks := make([][]byte, 1, 4)
+	chunks[0] = make([]byte, 0, batchCopyArenaMinChunk)
+	chunksPtr := unsafe.SliceData(chunks)
+
+	db.retainBatchArenaChunksForMemtables(chunks, []memtable.Table{mt})
+	db.releaseBatchArenaLeasesForMemtable(mt)
+
+	got := db.takeBatchArenaChunkListLease(1)
+	if cap(got) < 1 {
+		t.Fatalf("takeBatchArenaChunkListLease cap=%d want >= 1", cap(got))
+	}
+	got = append(got, nil)
+	if gotPtr := unsafe.SliceData(got); gotPtr != chunksPtr {
+		t.Fatalf("memtable release did not return chunk-list backing")
+	}
+	for i, chunk := range got[:cap(got)] {
+		if chunk != nil {
+			t.Fatalf("leased chunk list retained chunk at %d: cap=%d", i, cap(chunk))
+		}
+	}
+}
+
+func TestBatchArenaChunkListEnsureAppendCapGrowsThroughLease(t *testing.T) {
+	db := &DB{}
+	oldChunk := make([]byte, 0, 8)
+	chunks := make([][]byte, 1, 1)
+	chunks[0] = oldChunk
+	chunksPtr := unsafe.SliceData(chunks)
+	grown := make([][]byte, 0, batchArenaChunkListInitialCap)
+	grownPtr := unsafe.SliceData(grown)
+	db.putBatchArenaChunkListLease(grown)
+
+	got := db.ensureBatchArenaChunkListAppendCap(chunks)
+	if cap(got) < batchArenaChunkListInitialCap {
+		t.Fatalf("ensureBatchArenaChunkListAppendCap cap=%d want >= %d", cap(got), batchArenaChunkListInitialCap)
+	}
+	if gotPtr := unsafe.SliceData(got); gotPtr != grownPtr {
+		t.Fatalf("ensureBatchArenaChunkListAppendCap did not reuse grown lease")
+	}
+	if len(got) != 1 || cap(got[0]) != cap(oldChunk) {
+		t.Fatalf("ensureBatchArenaChunkListAppendCap lost existing chunk: len=%d cap0=%d", len(got), cap(got[0]))
+	}
+
+	returned := db.takeBatchArenaChunkListLease(1)
+	if cap(returned) < 1 {
+		t.Fatalf("takeBatchArenaChunkListLease cap=%d want >= 1", cap(returned))
+	}
+	returned = append(returned, nil)
+	if returnedPtr := unsafe.SliceData(returned); returnedPtr != chunksPtr {
+		t.Fatalf("ensureBatchArenaChunkListAppendCap did not return old backing")
+	}
+	for i, chunk := range returned[:cap(returned)] {
+		if chunk != nil {
+			t.Fatalf("returned chunk list retained chunk at %d: cap=%d", i, cap(chunk))
+		}
+	}
+}
+
+func BenchmarkBatchAuxScratchLeaseRoundTrip(b *testing.B) {
+	forceNormalPoolPressureForTest(b)
+	db := &DB{}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		entries := db.getBatchEntries(100)
+		entries = entries[:100]
+		shardEntries := db.getBatchShardEntries(16)
+		shardEntries = shardEntries[:16]
+		idxs := db.getBatchIntSlice(100)
+		idxs = idxs[:100]
+		adds := db.getBatchInt64Slice(16)
+		adds = adds[:16]
+
+		db.putBatchEntries(entries)
+		db.putBatchShardEntries(shardEntries)
+		db.putBatchIntSlice(idxs)
+		db.putBatchInt64Slice(adds)
+	}
+}
+
+func BenchmarkBatchArenaChunkListLeaseRoundTrip(b *testing.B) {
+	db := &DB{}
+	chunks := make([][]byte, 0, 8)
+	db.putBatchArenaChunkListLease(chunks)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		chunks = db.takeBatchArenaChunkListLease(4)
+		chunks = append(chunks, nil, nil, nil, nil)
+		db.putBatchArenaChunkListLease(chunks)
+	}
+}
+
+func BenchmarkBatchArenaChunkListEnsureAppendCapRoundTrip(b *testing.B) {
+	db := &DB{}
+	chunks := make([][]byte, 0, batchArenaChunkListInitialCap)
+	db.putBatchArenaChunkListLease(chunks)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		chunks = db.ensureBatchArenaChunkListAppendCap(nil)
+		chunks = append(chunks, nil)
+		db.putBatchArenaChunkListLease(chunks)
+	}
+}
+
+func BenchmarkZeroInlineKeyProviderRoundTrip(b *testing.B) {
+	entries := []batch.Entry{{Key: []byte("key")}}
+	var provider zeroInlineBatchKeyProvider
+	provider.keyAt = provider.keyAtEntry
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		keyAt := provider.keyAtEntries(entries)
+		if len(keyAt(0)) == 0 {
+			b.Fatal("empty key")
+		}
+		provider.entries = nil
+	}
+}
+
+func BenchmarkBatchShardEntryGroupLeaseRoundTrip(b *testing.B) {
+	db := &DB{}
+	groups := make([][]batch.Entry, 0, 8)
+	db.putBatchShardEntryGroups(groups)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		groups = db.getBatchShardEntryGroups(8)
+		groups = groups[:8]
+		db.putBatchShardEntryGroups(groups)
+	}
 }

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -80,7 +80,14 @@ var iteratorDebugEnabled atomic.Bool
 var valueLogEligiblePool sync.Pool                  // stores []int
 var valueLogKeyPool sync.Pool                       // stores [][]byte
 var batchArenaPools [batchArenaClassCount]sync.Pool // stores []byte
-var batchArenaLeasePool sync.Pool                   // stores *batchArenaLease
+var batchArenaFreeLeaseMu sync.Mutex
+var batchArenaFreeLeases [batchArenaClassCount][][]byte
+var batchArenaLeasePool sync.Pool // stores *batchArenaLease
+var batchArenaLeaseStaticOnce sync.Once
+var batchArenaLeaseStaticMu sync.Mutex
+var batchArenaLeaseStaticHeaders [maxBatchArenaStaticLeaseHeaders]batchArenaLease
+var batchArenaLeaseStaticFree [maxBatchArenaStaticLeaseHeaders]*batchArenaLease
+var batchArenaLeaseStaticFreeCount int
 var appendOnlyDirectValueArenaPools [appendOnlyDirectValueArenaClassCount]sync.Pool
 var batchEntrySliceRefPool sync.Pool                        // stores *batchEntrySliceRef
 var batchIntSliceRefPool sync.Pool                          // stores *batchIntSliceRef
@@ -222,11 +229,15 @@ var batchSetCallerSampleMod = loadUintEnvDefault("TREEDB_DEBUG_BATCH_SET_CALLER_
 var dbGetCallerSampleMod = loadUintEnvDefault("TREEDB_DEBUG_DB_GET_CALLER_SAMPLE_MOD", 0)
 var snapshotGetCallerSampleMod = loadUintEnvDefault("TREEDB_DEBUG_SNAPSHOT_GET_CALLER_SAMPLE_MOD", 0)
 
+var runtimeNumGCMu sync.Mutex
+var runtimeNumGCSamples = [1]metrics.Sample{{Name: "/gc/cycles/total:gc-cycles"}}
 var runtimeNumGC = func() uint64 {
-	samples := []metrics.Sample{{Name: "/gc/cycles/total:gc-cycles"}}
-	metrics.Read(samples)
-	if samples[0].Value.Kind() == metrics.KindUint64 {
-		return samples[0].Value.Uint64()
+	runtimeNumGCMu.Lock()
+	metrics.Read(runtimeNumGCSamples[:])
+	value := runtimeNumGCSamples[0].Value
+	runtimeNumGCMu.Unlock()
+	if value.Kind() == metrics.KindUint64 {
+		return value.Uint64()
 	}
 	var ms runtime.MemStats
 	runtime.ReadMemStats(&ms)
@@ -1144,6 +1155,18 @@ func currentBatchArenaPoolBudgetBytes() int64 {
 	return budget
 }
 
+func batchArenaFreeLeaseBytes() int64 {
+	var bytes int64
+	batchArenaFreeLeaseMu.Lock()
+	for i := range batchArenaFreeLeases {
+		for _, buf := range batchArenaFreeLeases[i] {
+			bytes += int64(cap(buf))
+		}
+	}
+	batchArenaFreeLeaseMu.Unlock()
+	return bytes
+}
+
 func maybeResetBatchArenaPoolBytesAfterGC() {
 	if batchArenaPoolBytes.Load() <= 0 {
 		return
@@ -1153,14 +1176,15 @@ func maybeResetBatchArenaPoolBytesAfterGC() {
 	if last == numGC {
 		return
 	}
+	leaseBytes := batchArenaFreeLeaseBytes()
 	if last == 0 {
 		if batchArenaPoolLastGC.CompareAndSwap(0, numGC) {
-			batchArenaPoolBytes.Store(0)
+			batchArenaPoolBytes.Store(leaseBytes)
 		}
 		return
 	}
 	if batchArenaPoolLastGC.CompareAndSwap(last, numGC) {
-		batchArenaPoolBytes.Store(0)
+		batchArenaPoolBytes.Store(leaseBytes)
 	}
 }
 
@@ -1206,6 +1230,8 @@ const (
 	// mostly-empty tail chunks during big restore batches.
 	batchArenaMaxShift                       = 21
 	batchArenaClassCount                     = batchArenaMaxShift - batchArenaMinShift + 1
+	maxBatchArenaFreeLeasesPerBucket         = 64
+	maxBatchArenaStaticLeaseHeaders          = 4096
 	appendOnlyDirectValueArenaMinShift       = 15
 	appendOnlyDirectValueArenaMaxShift       = 20
 	appendOnlyDirectValueArenaClassCount     = appendOnlyDirectValueArenaMaxShift - appendOnlyDirectValueArenaMinShift + 1
@@ -1580,6 +1606,75 @@ func batchArenaClassForCap(capacity int) (idx int, ok bool) {
 	return idx, true
 }
 
+func releaseBatchArenaPoolBytes(bytes int64) {
+	if bytes <= 0 {
+		return
+	}
+	if next := batchArenaPoolBytes.Add(-bytes); next < 0 {
+		batchArenaPoolBytes.Store(0)
+	}
+}
+
+func takeBatchArenaFreeLease(idx, classCap int) []byte {
+	for {
+		batchArenaFreeLeaseMu.Lock()
+		leases := batchArenaFreeLeases[idx]
+		n := len(leases)
+		if n == 0 {
+			batchArenaFreeLeaseMu.Unlock()
+			return nil
+		}
+		buf := leases[n-1]
+		batchArenaFreeLeases[idx][n-1] = nil
+		batchArenaFreeLeases[idx] = leases[:n-1]
+		batchArenaFreeLeaseMu.Unlock()
+
+		size := int64(cap(buf))
+		releaseBatchArenaPoolBytes(size)
+		if cap(buf) == classCap {
+			return buf[:0]
+		}
+	}
+}
+
+func putBatchArenaFreeLease(idx int, buf []byte) bool {
+	batchArenaFreeLeaseMu.Lock()
+	if len(batchArenaFreeLeases[idx]) >= maxBatchArenaFreeLeasesPerBucket {
+		batchArenaFreeLeaseMu.Unlock()
+		return false
+	}
+	batchArenaFreeLeases[idx] = append(batchArenaFreeLeases[idx], buf[:0])
+	batchArenaFreeLeaseMu.Unlock()
+	return true
+}
+
+func drainBatchArenaFreeLeasesToTargetBytes(target int64) int64 {
+	var dropped int64
+	for classIdx := len(batchArenaFreeLeases) - 1; classIdx >= 0 && batchArenaPoolBytes.Load() > target; classIdx-- {
+		for batchArenaPoolBytes.Load() > target {
+			batchArenaFreeLeaseMu.Lock()
+			leases := batchArenaFreeLeases[classIdx]
+			n := len(leases)
+			if n == 0 {
+				batchArenaFreeLeaseMu.Unlock()
+				break
+			}
+			buf := leases[n-1]
+			batchArenaFreeLeases[classIdx][n-1] = nil
+			batchArenaFreeLeases[classIdx] = leases[:n-1]
+			batchArenaFreeLeaseMu.Unlock()
+
+			size := int64(cap(buf))
+			if size <= 0 {
+				continue
+			}
+			dropped += size
+			releaseBatchArenaPoolBytes(size)
+		}
+	}
+	return dropped
+}
+
 func getBatchArena(capacity int) []byte {
 	if capacity < 0 {
 		capacity = 0
@@ -1588,15 +1683,15 @@ func getBatchArena(capacity int) []byte {
 	if !ok {
 		return make([]byte, 0, capacity)
 	}
+	if buf := takeBatchArenaFreeLease(idx, classCap); buf != nil {
+		return buf
+	}
 	if v := batchArenaPools[idx].Get(); v != nil {
 		if buf, ok := v.([]byte); ok {
 			size := int64(cap(buf))
-			next := batchArenaPoolBytes.Add(-size)
-			if next < 0 {
-				// Counter can drift if sync.Pool drops objects at GC or a caller
-				// inserts an unexpected buffer.
-				batchArenaPoolBytes.Store(0)
-			}
+			// Counter can drift if sync.Pool drops objects at GC or a caller
+			// inserts an unexpected buffer.
+			releaseBatchArenaPoolBytes(size)
 			if cap(buf) == classCap {
 				return buf[:0]
 			}
@@ -1658,7 +1753,11 @@ func putBatchArena(buf []byte) {
 	if noteEpoch {
 		noteBatchArenaPoolGC(batchArenaPoolNumGC())
 	}
-	batchArenaPools[idx].Put(buf[:0])
+	if putBatchArenaFreeLease(idx, buf) {
+		return
+	}
+	releaseBatchArenaPoolBytes(size)
+	batchArenaPoolDropBytesTotal.Add(uint64(size))
 }
 
 func putBatchArenas(chunks [][]byte) {
@@ -1677,7 +1776,7 @@ func drainBatchArenaPoolToTargetBytes(target int64) int64 {
 	if batchArenaPoolBytes.Load() <= target {
 		return 0
 	}
-	var dropped int64
+	dropped := drainBatchArenaFreeLeasesToTargetBytes(target)
 	for classIdx := len(batchArenaPools) - 1; classIdx >= 0 && batchArenaPoolBytes.Load() > target; classIdx-- {
 		for batchArenaPoolBytes.Load() > target {
 			v := batchArenaPools[classIdx].Get()
@@ -1693,10 +1792,7 @@ func drainBatchArenaPoolToTargetBytes(target int64) int64 {
 				continue
 			}
 			dropped += size
-			next := batchArenaPoolBytes.Add(-size)
-			if next < 0 {
-				batchArenaPoolBytes.Store(0)
-			}
+			releaseBatchArenaPoolBytes(size)
 		}
 	}
 	if dropped > 0 {
@@ -8232,10 +8328,36 @@ type dictStoreWriterByClass interface {
 }
 
 type batchArenaLease struct {
-	refs   int
-	chunks [][]byte
+	refs       int
+	chunks     [][]byte
+	bytes      int64
+	noPool     bool
+	staticPool bool
+}
+
+type batchEntrySliceLeasePool struct {
+	slices [][]batch.Entry
 	bytes  int64
-	noPool bool
+}
+
+type batchIntSliceLeasePool struct {
+	slices [][]int
+	bytes  int64
+}
+
+type batchInt64SliceLeasePool struct {
+	slices [][]int64
+	bytes  int64
+}
+
+type batchByteChunksLeasePool struct {
+	slices [][][]byte
+	bytes  int64
+}
+
+type batchEntryGroupsLeasePool struct {
+	slices [][][]batch.Entry
+	bytes  int64
 }
 
 type appendOnlyDirectArenaLease struct {
@@ -8334,6 +8456,13 @@ type DB struct {
 	batchArenaTailCompactRuns     atomic.Uint64
 	batchArenaTailCompactCopied   atomic.Uint64
 	batchArenaTailCompactSaved    atomic.Uint64
+	batchAuxMu                    sync.Mutex
+	batchEntriesLeases            batchEntrySliceLeasePool
+	batchShardEntriesLeases       batchEntrySliceLeasePool
+	batchIntLeases                batchIntSliceLeasePool
+	batchInt64Leases              batchInt64SliceLeasePool
+	batchArenaChunkLeases         batchByteChunksLeasePool
+	batchShardEntryGroupsLeases   batchEntryGroupsLeasePool
 	batchEntriesPool              sync.Pool
 	batchShardEntriesPool         sync.Pool
 	batchIntPool                  sync.Pool
@@ -10314,24 +10443,48 @@ func batchEntryWALRevision(entry *batch.Entry, seq uint64) uint64 {
 	return uint64(entry.Revision)
 }
 
+func initBatchArenaStaticLeaseHeaders() {
+	for i := range batchArenaLeaseStaticHeaders {
+		lease := &batchArenaLeaseStaticHeaders[i]
+		lease.staticPool = true
+		batchArenaLeaseStaticFree[i] = lease
+	}
+	batchArenaLeaseStaticFreeCount = len(batchArenaLeaseStaticFree)
+}
+
+func takeBatchArenaLeaseHeader() *batchArenaLease {
+	batchArenaLeaseStaticOnce.Do(initBatchArenaStaticLeaseHeaders)
+
+	batchArenaLeaseStaticMu.Lock()
+	if batchArenaLeaseStaticFreeCount > 0 {
+		batchArenaLeaseStaticFreeCount--
+		lease := batchArenaLeaseStaticFree[batchArenaLeaseStaticFreeCount]
+		batchArenaLeaseStaticFree[batchArenaLeaseStaticFreeCount] = nil
+		batchArenaLeaseStaticMu.Unlock()
+		return lease
+	}
+	batchArenaLeaseStaticMu.Unlock()
+
+	lease, _ := batchArenaLeasePool.Get().(*batchArenaLease)
+	if lease != nil {
+		return lease
+	}
+	return &batchArenaLease{}
+}
+
 func getBatchArenaLease(refs int, chunks [][]byte) *batchArenaLease {
 	return getBatchArenaLeaseWithPolicy(refs, chunks, false)
 }
 
 func getBatchArenaLeaseWithPolicy(refs int, chunks [][]byte, noPool bool) *batchArenaLease {
-	lease, _ := batchArenaLeasePool.Get().(*batchArenaLease)
-	if lease == nil {
-		lease = &batchArenaLease{}
-	}
+	return getBatchArenaLeaseWithPolicyAndBytes(refs, chunks, noPool, batchArenaChunksCapBytes(chunks))
+}
+
+func getBatchArenaLeaseWithPolicyAndBytes(refs int, chunks [][]byte, noPool bool, bytes int64) *batchArenaLease {
+	lease := takeBatchArenaLeaseHeader()
 	lease.refs = refs
 	lease.chunks = chunks
 	lease.noPool = noPool
-	var bytes int64
-	for i := range chunks {
-		if chunks[i] != nil {
-			bytes += int64(cap(chunks[i]))
-		}
-	}
 	lease.bytes = bytes
 	return lease
 }
@@ -10344,6 +10497,16 @@ func putBatchArenaLease(lease *batchArenaLease) {
 	lease.chunks = nil
 	lease.bytes = 0
 	lease.noPool = false
+	if lease.staticPool {
+		batchArenaLeaseStaticOnce.Do(initBatchArenaStaticLeaseHeaders)
+		batchArenaLeaseStaticMu.Lock()
+		if batchArenaLeaseStaticFreeCount < len(batchArenaLeaseStaticFree) {
+			batchArenaLeaseStaticFree[batchArenaLeaseStaticFreeCount] = lease
+			batchArenaLeaseStaticFreeCount++
+		}
+		batchArenaLeaseStaticMu.Unlock()
+		return
+	}
 	batchArenaLeasePool.Put(lease)
 }
 
@@ -10362,14 +10525,17 @@ func (db *DB) retainBatchArenaChunksForMemtablesWithPolicy(chunks [][]byte, mems
 	if db == nil || len(mems) == 0 {
 		if !noPool {
 			putBatchArenas(chunks)
+			if db != nil {
+				db.putBatchArenaChunkListLease(chunks)
+			}
 		}
 		return
 	}
-	lease := getBatchArenaLeaseWithPolicy(len(mems), chunks, noPool)
-	if lease.bytes > 0 {
-		cur := db.batchArenaLeaseBytes.Add(lease.bytes)
+	bytes := batchArenaChunksCapBytes(chunks)
+	if bytes > 0 {
+		cur := db.batchArenaLeaseBytes.Add(bytes)
 		updateInt64Max(&db.batchArenaLeaseBytesMax, cur)
-		globalLeased := batchArenaLeasedBytesGlobal.Add(lease.bytes)
+		globalLeased := batchArenaLeasedBytesGlobal.Add(bytes)
 		noteBatchArenaLeasedBytesGlobalMax(globalLeased)
 		noteBatchArenaRetainedBytesMax()
 	}
@@ -10377,6 +10543,33 @@ func (db *DB) retainBatchArenaChunksForMemtablesWithPolicy(chunks [][]byte, mems
 	if db.batchArenaLeasesByMem == nil {
 		db.batchArenaLeasesByMem = make(map[memtable.Table][]*batchArenaLease, len(mems))
 	}
+	if len(mems) == 1 {
+		mt := mems[0]
+		leases := db.batchArenaLeasesByMem[mt]
+		if n := len(leases); n > 0 {
+			lease := leases[n-1]
+			if lease != nil && lease.refs == 1 && lease.noPool == noPool {
+				lease.chunks = append(lease.chunks, chunks...)
+				if bytes > 0 {
+					if lease.bytes > math.MaxInt64-bytes {
+						lease.bytes = math.MaxInt64
+					} else {
+						lease.bytes += bytes
+					}
+				}
+				db.batchArenaLeaseMu.Unlock()
+				if !noPool {
+					db.putBatchArenaChunkListLease(chunks)
+				}
+				return
+			}
+		}
+		lease := getBatchArenaLeaseWithPolicyAndBytes(1, chunks, noPool, bytes)
+		db.batchArenaLeasesByMem[mt] = append(leases, lease)
+		db.batchArenaLeaseMu.Unlock()
+		return
+	}
+	lease := getBatchArenaLeaseWithPolicyAndBytes(len(mems), chunks, noPool, bytes)
 	for _, mt := range mems {
 		db.batchArenaLeasesByMem[mt] = append(db.batchArenaLeasesByMem[mt], lease)
 	}
@@ -10387,7 +10580,7 @@ func (db *DB) releaseBatchArenaLeasesForMemtable(mt memtable.Table) {
 	if db == nil || mt == nil {
 		return
 	}
-	var release [][]byte
+	var releaseLists [][][]byte
 	db.batchArenaLeaseMu.Lock()
 	leases := db.batchArenaLeasesByMem[mt]
 	if len(leases) > 0 {
@@ -10407,7 +10600,7 @@ func (db *DB) releaseBatchArenaLeasesForMemtable(mt memtable.Table) {
 					lease.bytes = 0
 				}
 				if !noPool {
-					release = append(release, lease.chunks...)
+					releaseLists = append(releaseLists, lease.chunks)
 				}
 				lease.chunks = nil
 				putBatchArenaLease(lease)
@@ -10415,8 +10608,9 @@ func (db *DB) releaseBatchArenaLeasesForMemtable(mt memtable.Table) {
 		}
 	}
 	db.batchArenaLeaseMu.Unlock()
-	if len(release) > 0 {
-		putBatchArenas(release)
+	for _, chunks := range releaseLists {
+		putBatchArenas(chunks)
+		db.putBatchArenaChunkListLease(chunks)
 	}
 }
 
@@ -12123,6 +12317,7 @@ func Open(dir string, backend BackendDB, opts Options) (*DB, error) {
 		lanes[i].walSeq = maxWALSeq[i]
 		lanes[i].vlogSeq = maxVlogSeq[i]
 		lanes[i].vlogGenerationClass = vlogGenerationClassHot
+		lanes[i].walZeroInlineKeyProvider.keyAt = lanes[i].walZeroInlineKeyProvider.keyAtEntry
 		lanes[i].vlogCompressionSelector = newVlogCompressionSelectorWithSeed(
 			valueLogAutoPolicy,
 			uint64(valueLogIncompressibleHold),
@@ -15933,11 +16128,29 @@ type zeroInlineBatchCommitWriter interface {
 	AppendZeroInlineBatchFunc(count int, seq uint64, valueLen int, keyAt func(int) []byte) error
 }
 
+type zeroInlineBatchKeyProvider struct {
+	entries []batch.Entry
+	keyAt   func(int) []byte
+}
+
+func (p *zeroInlineBatchKeyProvider) keyAtEntry(i int) []byte {
+	return p.entries[i].Key
+}
+
+func (p *zeroInlineBatchKeyProvider) keyAtEntries(entries []batch.Entry) func(int) []byte {
+	if p.keyAt == nil {
+		p.keyAt = p.keyAtEntry
+	}
+	p.entries = entries
+	return p.keyAt
+}
+
 func (db *DB) appendWALZeroInlineEntries(l *lane, entries []batch.Entry, seq uint64, valueLen int, durability journalDurability) (bool, error) {
 	if db.disableJournal {
 		return true, nil
 	}
-	if len(entries) == 0 {
+	entryCount := len(entries)
+	if entryCount == 0 {
 		return true, nil
 	}
 	if l == nil {
@@ -15973,9 +16186,9 @@ func (db *DB) appendWALZeroInlineEntries(l *lane, entries []batch.Entry, seq uin
 		l.walMu.Unlock()
 		return false, nil
 	}
-	err = zw.AppendZeroInlineBatchFunc(len(entries), seq, valueLen, func(i int) []byte {
-		return entries[i].Key
-	})
+	keyAt := l.walZeroInlineKeyProvider.keyAtEntries(entries)
+	err = zw.AppendZeroInlineBatchFunc(entryCount, seq, valueLen, keyAt)
+	l.walZeroInlineKeyProvider.entries = nil
 	if err == nil {
 		switch durability {
 		case journalDurabilitySync:
@@ -32226,6 +32439,8 @@ type Batch struct {
 	hasDeleteRanges              bool
 	entryRevision                page.EntryRevision
 	commandWALAppend             func() error
+	valueCopyShard               *memShard
+	appendOnlyDirectValueCopier  func([]byte) []byte
 
 	commandWALCompactReplay     bool
 	commandWALCompactRanges     []batch.DeleteRange
@@ -32235,23 +32450,31 @@ type Batch struct {
 
 func (db *DB) NewBatch() *Batch {
 	capHint := batchDefaultEntriesCap
+	shardGroupCap := 0
 	if db != nil {
 		capHint = db.batchEntriesCapHint(capHint)
+		shardGroupCap = len(db.mutableShards)
 	}
 	return &Batch{
 		db:             db,
 		entries:        db.getBatchEntries(capHint),
 		copyArenaCap:   db.batchCopyArenaInitCap(0),
+		shardEntries:   db.getBatchShardEntryGroups(shardGroupCap),
 		streamEligible: true,
 	}
 }
 
 func (db *DB) NewBatchWithSize(size int) *Batch {
 	reserveHint := backenddb.NormalizePublicBatchReserveHint(size)
+	shardGroupCap := 0
+	if db != nil {
+		shardGroupCap = len(db.mutableShards)
+	}
 	return &Batch{
 		db:             db,
 		entries:        db.getBatchEntries(reserveHint),
 		copyArenaCap:   db.batchCopyArenaInitCap(reserveHint),
+		shardEntries:   db.getBatchShardEntryGroups(shardGroupCap),
 		streamEligible: true,
 	}
 }
@@ -32595,11 +32818,341 @@ func (db *DB) noteBatchArenaTailCompact(copiedBytes, classCap int) {
 	}
 }
 
+func batchEntrySliceBytes(entries []batch.Entry) int64 {
+	return int64(cap(entries)) * entrySliceEntrySizeBytes
+}
+
+func batchIntSliceBytes(idxs []int) int64 {
+	return int64(cap(idxs)) * int64(unsafe.Sizeof(int(0)))
+}
+
+func batchInt64SliceBytes(idxs []int64) int64 {
+	return int64(cap(idxs)) * int64(unsafe.Sizeof(int64(0)))
+}
+
+func batchByteChunksSliceBytes(chunks [][]byte) int64 {
+	return int64(cap(chunks)) * int64(unsafe.Sizeof([]byte(nil)))
+}
+
+func batchEntryGroupsSliceBytes(groups [][]batch.Entry) int64 {
+	return int64(cap(groups)) * int64(unsafe.Sizeof([]batch.Entry(nil)))
+}
+
+func (p *batchEntrySliceLeasePool) take(minCap int) []batch.Entry {
+	for i := len(p.slices) - 1; i >= 0; i-- {
+		entries := p.slices[i]
+		if cap(entries) < minCap {
+			continue
+		}
+		last := len(p.slices) - 1
+		p.slices[i] = p.slices[last]
+		p.slices[last] = nil
+		p.slices = p.slices[:last]
+		p.bytes -= batchEntrySliceBytes(entries)
+		if p.bytes < 0 {
+			p.bytes = 0
+		}
+		return entries[:0]
+	}
+	return nil
+}
+
+func (p *batchEntrySliceLeasePool) put(entries []batch.Entry, maxCount int, maxBytes int64) bool {
+	size := batchEntrySliceBytes(entries)
+	if size <= 0 || len(p.slices) >= maxCount || p.bytes+size > maxBytes {
+		return false
+	}
+	p.slices = append(p.slices, entries[:0])
+	p.bytes += size
+	return true
+}
+
+func (p *batchIntSliceLeasePool) take(minCap int) []int {
+	for i := len(p.slices) - 1; i >= 0; i-- {
+		idxs := p.slices[i]
+		if cap(idxs) < minCap {
+			continue
+		}
+		last := len(p.slices) - 1
+		p.slices[i] = p.slices[last]
+		p.slices[last] = nil
+		p.slices = p.slices[:last]
+		p.bytes -= batchIntSliceBytes(idxs)
+		if p.bytes < 0 {
+			p.bytes = 0
+		}
+		return idxs[:0]
+	}
+	return nil
+}
+
+func (p *batchIntSliceLeasePool) put(idxs []int, maxCount int, maxBytes int64) bool {
+	size := batchIntSliceBytes(idxs)
+	if size <= 0 || len(p.slices) >= maxCount || p.bytes+size > maxBytes {
+		return false
+	}
+	p.slices = append(p.slices, idxs[:0])
+	p.bytes += size
+	return true
+}
+
+func (p *batchInt64SliceLeasePool) take(minCap int) []int64 {
+	for i := len(p.slices) - 1; i >= 0; i-- {
+		idxs := p.slices[i]
+		if cap(idxs) < minCap {
+			continue
+		}
+		last := len(p.slices) - 1
+		p.slices[i] = p.slices[last]
+		p.slices[last] = nil
+		p.slices = p.slices[:last]
+		p.bytes -= batchInt64SliceBytes(idxs)
+		if p.bytes < 0 {
+			p.bytes = 0
+		}
+		return idxs[:0]
+	}
+	return nil
+}
+
+func (p *batchInt64SliceLeasePool) put(idxs []int64, maxCount int, maxBytes int64) bool {
+	size := batchInt64SliceBytes(idxs)
+	if size <= 0 || len(p.slices) >= maxCount || p.bytes+size > maxBytes {
+		return false
+	}
+	p.slices = append(p.slices, idxs[:0])
+	p.bytes += size
+	return true
+}
+
+func (p *batchByteChunksLeasePool) take(minCap int) [][]byte {
+	for i := len(p.slices) - 1; i >= 0; i-- {
+		chunks := p.slices[i]
+		if cap(chunks) < minCap {
+			continue
+		}
+		last := len(p.slices) - 1
+		p.slices[i] = p.slices[last]
+		p.slices[last] = nil
+		p.slices = p.slices[:last]
+		p.bytes -= batchByteChunksSliceBytes(chunks)
+		if p.bytes < 0 {
+			p.bytes = 0
+		}
+		return chunks[:0]
+	}
+	return nil
+}
+
+func (p *batchByteChunksLeasePool) put(chunks [][]byte, maxCount int, maxBytes int64) bool {
+	size := batchByteChunksSliceBytes(chunks)
+	if size <= 0 || cap(chunks) > batchArenaChunkListMaxRetain || len(p.slices) >= maxCount || p.bytes+size > maxBytes {
+		return false
+	}
+	clear(chunks[:cap(chunks)])
+	p.slices = append(p.slices, chunks[:0])
+	p.bytes += size
+	return true
+}
+
+func (p *batchEntryGroupsLeasePool) take(minCap int) [][]batch.Entry {
+	for i := len(p.slices) - 1; i >= 0; i-- {
+		groups := p.slices[i]
+		if cap(groups) < minCap {
+			continue
+		}
+		last := len(p.slices) - 1
+		p.slices[i] = p.slices[last]
+		p.slices[last] = nil
+		p.slices = p.slices[:last]
+		p.bytes -= batchEntryGroupsSliceBytes(groups)
+		if p.bytes < 0 {
+			p.bytes = 0
+		}
+		return groups[:0]
+	}
+	return nil
+}
+
+func (p *batchEntryGroupsLeasePool) put(groups [][]batch.Entry, maxCount int, maxBytes int64) bool {
+	size := batchEntryGroupsSliceBytes(groups)
+	if size <= 0 || cap(groups) > batchShardEntryGroupsMaxRetain || len(p.slices) >= maxCount || p.bytes+size > maxBytes {
+		return false
+	}
+	clear(groups[:cap(groups)])
+	p.slices = append(p.slices, groups[:0])
+	p.bytes += size
+	return true
+}
+
+func (db *DB) takeBatchEntriesLease(minCap int) []batch.Entry {
+	if db == nil {
+		return nil
+	}
+	db.batchAuxMu.Lock()
+	entries := db.batchEntriesLeases.take(minCap)
+	db.batchAuxMu.Unlock()
+	return entries
+}
+
+func (db *DB) putBatchEntriesLease(entries []batch.Entry) bool {
+	if db == nil {
+		return false
+	}
+	db.batchAuxMu.Lock()
+	ok := db.batchEntriesLeases.put(entries, batchAuxEntryLeaseMaxCount, batchAuxEntryLeaseMaxBytes)
+	db.batchAuxMu.Unlock()
+	return ok
+}
+
+func (db *DB) takeBatchShardEntriesLease(minCap int) []batch.Entry {
+	if db == nil {
+		return nil
+	}
+	db.batchAuxMu.Lock()
+	entries := db.batchShardEntriesLeases.take(minCap)
+	db.batchAuxMu.Unlock()
+	return entries
+}
+
+func (db *DB) putBatchShardEntriesLease(entries []batch.Entry) bool {
+	if db == nil {
+		return false
+	}
+	db.batchAuxMu.Lock()
+	ok := db.batchShardEntriesLeases.put(entries, batchAuxEntryLeaseMaxCount, batchAuxEntryLeaseMaxBytes)
+	db.batchAuxMu.Unlock()
+	return ok
+}
+
+func (db *DB) takeBatchIntLease(minCap int) []int {
+	if db == nil {
+		return nil
+	}
+	db.batchAuxMu.Lock()
+	idxs := db.batchIntLeases.take(minCap)
+	db.batchAuxMu.Unlock()
+	return idxs
+}
+
+func (db *DB) putBatchIntLease(idxs []int) bool {
+	if db == nil {
+		return false
+	}
+	db.batchAuxMu.Lock()
+	ok := db.batchIntLeases.put(idxs, batchAuxIntLeaseMaxCount, batchAuxIntLeaseMaxBytes)
+	db.batchAuxMu.Unlock()
+	return ok
+}
+
+func (db *DB) takeBatchInt64Lease(minCap int) []int64 {
+	if db == nil {
+		return nil
+	}
+	db.batchAuxMu.Lock()
+	idxs := db.batchInt64Leases.take(minCap)
+	db.batchAuxMu.Unlock()
+	return idxs
+}
+
+func (db *DB) putBatchInt64Lease(idxs []int64) bool {
+	if db == nil {
+		return false
+	}
+	db.batchAuxMu.Lock()
+	ok := db.batchInt64Leases.put(idxs, batchAuxIntLeaseMaxCount, batchAuxIntLeaseMaxBytes)
+	db.batchAuxMu.Unlock()
+	return ok
+}
+
+func (db *DB) takeBatchArenaChunkListLease(minCap int) [][]byte {
+	if db == nil {
+		return nil
+	}
+	db.batchAuxMu.Lock()
+	chunks := db.batchArenaChunkLeases.take(minCap)
+	db.batchAuxMu.Unlock()
+	return chunks
+}
+
+func (db *DB) putBatchArenaChunkListLease(chunks [][]byte) bool {
+	if db == nil {
+		return false
+	}
+	db.batchAuxMu.Lock()
+	ok := db.batchArenaChunkLeases.put(chunks, batchAuxChunkLeaseMaxCount, batchAuxChunkLeaseMaxBytes)
+	db.batchAuxMu.Unlock()
+	return ok
+}
+
+func (db *DB) ensureBatchArenaChunkListAppendCap(chunks [][]byte) [][]byte {
+	if db == nil || len(chunks) < cap(chunks) {
+		return chunks
+	}
+	minCap := len(chunks) + 1
+	targetCap := cap(chunks) * 2
+	if targetCap < batchArenaChunkListInitialCap {
+		targetCap = batchArenaChunkListInitialCap
+	}
+	if targetCap < minCap {
+		targetCap = minCap
+	}
+	grown := db.takeBatchArenaChunkListLease(targetCap)
+	if cap(grown) < targetCap {
+		grown = make([][]byte, 0, targetCap)
+	}
+	grown = append(grown, chunks...)
+	if cap(chunks) > 0 {
+		db.putBatchArenaChunkListLease(chunks)
+	}
+	return grown
+}
+
+func (db *DB) takeBatchShardEntryGroupsLease(minCap int) [][]batch.Entry {
+	if db == nil {
+		return nil
+	}
+	db.batchAuxMu.Lock()
+	groups := db.batchShardEntryGroupsLeases.take(minCap)
+	db.batchAuxMu.Unlock()
+	return groups
+}
+
+func (db *DB) putBatchShardEntryGroupsLease(groups [][]batch.Entry) bool {
+	if db == nil {
+		return false
+	}
+	db.batchAuxMu.Lock()
+	ok := db.batchShardEntryGroupsLeases.put(groups, batchAuxEntryGroupLeaseMaxCount, batchAuxEntryGroupLeaseMaxBytes)
+	db.batchAuxMu.Unlock()
+	return ok
+}
+
+func (db *DB) getBatchShardEntryGroups(minCap int) [][]batch.Entry {
+	if minCap < 0 {
+		minCap = 0
+	}
+	if groups := db.takeBatchShardEntryGroupsLease(minCap); groups != nil {
+		return groups
+	}
+	return make([][]batch.Entry, minCap)
+}
+
+func (db *DB) putBatchShardEntryGroups(groups [][]batch.Entry) {
+	if db == nil || cap(groups) == 0 || cap(groups) > batchShardEntryGroupsMaxRetain {
+		return
+	}
+	db.putBatchShardEntryGroupsLease(groups)
+}
+
 func (db *DB) getBatchEntries(minCap int) []batch.Entry {
 	if minCap < 0 {
 		minCap = 0
 	}
 	if db != nil {
+		if entries := db.takeBatchEntriesLease(minCap); entries != nil {
+			return entries
+		}
 		if pooled := db.batchEntriesPool.Get(); pooled != nil {
 			switch v := pooled.(type) {
 			case *batchEntrySliceRef:
@@ -32609,7 +33162,7 @@ func (db *DB) getBatchEntries(minCap int) []batch.Entry {
 					return entries[:0]
 				}
 				if c := cap(entries); c > 0 && c <= batchEntriesPoolMaxRetain {
-					db.batchEntriesPool.Put(getBatchEntrySliceRef(entries[:0]))
+					db.putBatchEntries(entries)
 				}
 			case []batch.Entry:
 				// Backward-compatible fallback for any legacy pooled shape.
@@ -32617,7 +33170,7 @@ func (db *DB) getBatchEntries(minCap int) []batch.Entry {
 					return v[:0]
 				}
 				if c := cap(v); c > 0 && c <= batchEntriesPoolMaxRetain {
-					db.batchEntriesPool.Put(getBatchEntrySliceRef(v[:0]))
+					db.putBatchEntries(v)
 				}
 			}
 		}
@@ -32638,7 +33191,7 @@ func (db *DB) putBatchEntries(entries []batch.Entry) {
 	}
 	full := entries[:cap(entries)]
 	clear(full)
-	db.batchEntriesPool.Put(getBatchEntrySliceRef(full[:0]))
+	db.putBatchEntriesLease(full[:0])
 }
 
 func (db *DB) getBatchShardEntries(minCap int) []batch.Entry {
@@ -32646,6 +33199,9 @@ func (db *DB) getBatchShardEntries(minCap int) []batch.Entry {
 		minCap = 0
 	}
 	if db != nil {
+		if entries := db.takeBatchShardEntriesLease(minCap); entries != nil {
+			return entries
+		}
 		if pooled := db.batchShardEntriesPool.Get(); pooled != nil {
 			switch v := pooled.(type) {
 			case *batchEntrySliceRef:
@@ -32654,10 +33210,16 @@ func (db *DB) getBatchShardEntries(minCap int) []batch.Entry {
 				if cap(entries) >= minCap {
 					return entries[:0]
 				}
+				if c := cap(entries); c > 0 && c <= batchEntriesPoolMaxRetain {
+					db.putBatchShardEntries(entries)
+				}
 			case []batch.Entry:
 				// Backward-compatible fallback for any legacy pooled shape.
 				if cap(v) >= minCap {
 					return v[:0]
+				}
+				if c := cap(v); c > 0 && c <= batchEntriesPoolMaxRetain {
+					db.putBatchShardEntries(v)
 				}
 			}
 		}
@@ -32678,7 +33240,7 @@ func (db *DB) putBatchShardEntries(entries []batch.Entry) {
 	}
 	full := entries[:cap(entries)]
 	clear(full)
-	db.batchShardEntriesPool.Put(getBatchEntrySliceRef(full[:0]))
+	db.putBatchShardEntriesLease(full[:0])
 }
 
 func (db *DB) getBatchIntSlice(minCap int) []int {
@@ -32686,6 +33248,9 @@ func (db *DB) getBatchIntSlice(minCap int) []int {
 		minCap = 0
 	}
 	if db != nil {
+		if idxs := db.takeBatchIntLease(minCap); idxs != nil {
+			return idxs
+		}
 		if pooled := db.batchIntPool.Get(); pooled != nil {
 			switch v := pooled.(type) {
 			case *batchIntSliceRef:
@@ -32695,7 +33260,7 @@ func (db *DB) getBatchIntSlice(minCap int) []int {
 					return idxs[:0]
 				}
 				if c := cap(idxs); c > 0 && c <= batchIntSlicePoolMaxRetain {
-					db.batchIntPool.Put(getBatchIntSliceRef(idxs[:0]))
+					db.putBatchIntSlice(idxs)
 				}
 			case []int:
 				// Backward-compatible fallback for any legacy pooled shape.
@@ -32703,7 +33268,7 @@ func (db *DB) getBatchIntSlice(minCap int) []int {
 					return v[:0]
 				}
 				if c := cap(v); c > 0 && c <= batchIntSlicePoolMaxRetain {
-					db.batchIntPool.Put(getBatchIntSliceRef(v[:0]))
+					db.putBatchIntSlice(v)
 				}
 			}
 		}
@@ -32722,7 +33287,7 @@ func (db *DB) putBatchIntSlice(idxs []int) {
 		batchIntPoolDropUnderPressureTotal.Add(1)
 		return
 	}
-	db.batchIntPool.Put(getBatchIntSliceRef(idxs[:0]))
+	db.putBatchIntLease(idxs[:0])
 }
 
 func (db *DB) getBatchInt64Slice(minCap int) []int64 {
@@ -32730,6 +33295,9 @@ func (db *DB) getBatchInt64Slice(minCap int) []int64 {
 		minCap = 0
 	}
 	if db != nil {
+		if idxs := db.takeBatchInt64Lease(minCap); idxs != nil {
+			return idxs
+		}
 		if pooled := db.batchInt64Pool.Get(); pooled != nil {
 			switch v := pooled.(type) {
 			case *batchInt64SliceRef:
@@ -32739,7 +33307,7 @@ func (db *DB) getBatchInt64Slice(minCap int) []int64 {
 					return idxs[:0]
 				}
 				if c := cap(idxs); c > 0 && c <= batchIntSlicePoolMaxRetain {
-					db.batchInt64Pool.Put(getBatchInt64SliceRef(idxs[:0]))
+					db.putBatchInt64Slice(idxs)
 				}
 			case []int64:
 				// Backward-compatible fallback for any legacy pooled shape.
@@ -32747,7 +33315,7 @@ func (db *DB) getBatchInt64Slice(minCap int) []int64 {
 					return v[:0]
 				}
 				if c := cap(v); c > 0 && c <= batchIntSlicePoolMaxRetain {
-					db.batchInt64Pool.Put(getBatchInt64SliceRef(v[:0]))
+					db.putBatchInt64Slice(v)
 				}
 			}
 		}
@@ -32766,7 +33334,7 @@ func (db *DB) putBatchInt64Slice(idxs []int64) {
 		batchInt64PoolDropUnderPressureTotal.Add(1)
 		return
 	}
-	db.batchInt64Pool.Put(getBatchInt64SliceRef(idxs[:0]))
+	db.putBatchInt64Lease(idxs[:0])
 }
 
 func appendUniqueMemtable(dst []memtable.Table, mt memtable.Table) []memtable.Table {
@@ -32779,6 +33347,26 @@ func appendUniqueMemtable(dst []memtable.Table, mt memtable.Table) []memtable.Ta
 		}
 	}
 	return append(dst, mt)
+}
+
+func (b *Batch) appendOnlyDirectValueCopierForShard(shard *memShard) func([]byte) []byte {
+	if b == nil || shard == nil {
+		return nil
+	}
+	b.valueCopyShard = shard
+	if b.appendOnlyDirectValueCopier == nil {
+		b.appendOnlyDirectValueCopier = b.copyValueToAppendOnlyDirectArena
+	}
+	return b.appendOnlyDirectValueCopier
+}
+
+func (b *Batch) copyValueToAppendOnlyDirectArena(value []byte) []byte {
+	if b == nil || b.valueCopyShard == nil || len(value) == 0 {
+		return nil
+	}
+	owned := b.valueCopyShard.appendOnlyDirectValueArena.alloc(len(value))
+	copy(owned, value)
+	return owned
 }
 
 // Reset clears the batch for reuse without closing it.
@@ -32837,6 +33425,7 @@ func (b *Batch) Reset() {
 	b.entryRevision = page.LegacyEntryRevision
 	b.maxEntries = 0
 	b.commandWALAppend = nil
+	b.valueCopyShard = nil
 	b.commandWALCompactReplay = false
 	b.commandWALCompactRanges = nil
 	b.commandWALCompactPointStart = 0
@@ -32894,6 +33483,9 @@ func (b *Batch) recycleCopyArenaChunks() {
 		return
 	}
 	putBatchArenas(chunks)
+	if b.db != nil {
+		b.db.putBatchArenaChunkListLease(chunks)
+	}
 }
 
 func (b *Batch) drainPtrCopyArenaChunks() [][]byte {
@@ -32922,6 +33514,23 @@ func (b *Batch) recyclePtrCopyArenaChunks() {
 		return
 	}
 	putBatchArenas(chunks)
+	if b.db != nil {
+		b.db.putBatchArenaChunkListLease(chunks)
+	}
+}
+
+func (b *Batch) releaseShardEntryGroups(groups [][]batch.Entry) {
+	if b == nil || b.db == nil || cap(groups) == 0 {
+		return
+	}
+	full := groups[:cap(groups)]
+	for i := range full {
+		if full[i] != nil {
+			b.db.putBatchShardEntries(full[i])
+			full[i] = nil
+		}
+	}
+	b.db.putBatchShardEntryGroups(full[:0])
 }
 
 func (b *Batch) updateBatchCopyHint() {
@@ -33008,6 +33617,9 @@ func (b *Batch) arenaCopyInto(kind batchArenaKind, arena *[]byte, chunks *[][]by
 			b.db.noteBatchArenaChunkAlloc(kind, chunkCap, cap(chunk))
 		}
 		*arena = chunk[:0]
+		if b != nil && b.db != nil {
+			*chunks = b.db.ensureBatchArenaChunkListAppendCap(*chunks)
+		}
 		*chunks = append(*chunks, *arena)
 	}
 	start := len(*arena)
@@ -33762,6 +34374,17 @@ const (
 	batchArenaTailCompactPinnedMaxFillDenominator = 4
 	batchEntriesPoolMaxRetain                     = 16 << 10
 	batchIntSlicePoolMaxRetain                    = 16 << 10
+	batchAuxEntryLeaseMaxCount                    = 256
+	batchAuxEntryLeaseMaxBytes                    = 8 << 20
+	batchAuxIntLeaseMaxCount                      = 256
+	batchAuxIntLeaseMaxBytes                      = 1 << 20
+	batchAuxChunkLeaseMaxCount                    = 256
+	batchAuxChunkLeaseMaxBytes                    = 1 << 20
+	batchAuxEntryGroupLeaseMaxCount               = 256
+	batchAuxEntryGroupLeaseMaxBytes               = 1 << 20
+	batchArenaChunkListInitialCap                 = 4
+	batchArenaChunkListMaxRetain                  = 256
+	batchShardEntryGroupsMaxRetain                = 1024
 	batchMemtableRetainStackCap                   = 64
 	// When deferred iterator views pin retired memtables, reduce retained
 	// batch-arena headroom to limit extra lease growth under that pressure.
@@ -34881,7 +35504,11 @@ func (b *Batch) writeRegularLocked(syncWrite bool, unlockWriteMu func()) error {
 	} else {
 		shardEntries := b.shardEntries
 		if cap(shardEntries) < shardCount {
-			shardEntries = make([][]batch.Entry, shardCount)
+			if cap(shardEntries) > 0 {
+				b.releaseShardEntryGroups(shardEntries)
+			}
+			shardEntries = b.db.getBatchShardEntryGroups(shardCount)
+			shardEntries = shardEntries[:shardCount]
 		} else {
 			shardEntries = shardEntries[:shardCount]
 			for i := range shardEntries {
@@ -34958,14 +35585,8 @@ func (b *Batch) writeRegularLocked(syncWrite bool, unlockWriteMu func()) error {
 					}
 					if !appliedSortedRun && !allowBatchArenaBorrow {
 						if applier, ok := shard.mem.(memtable.CopySortedBatchValueCopier); ok {
-							applier.ApplyCopySortedBatchWithValueCopierTrusted(entries, func(value []byte) []byte {
-								if len(value) == 0 {
-									return nil
-								}
-								owned := shard.appendOnlyDirectValueArena.alloc(len(value))
-								copy(owned, value)
-								return owned
-							}, storeInlinePtrValues, nil)
+							applier.ApplyCopySortedBatchWithValueCopierTrusted(entries, b.appendOnlyDirectValueCopierForShard(shard), storeInlinePtrValues, nil)
+							b.valueCopyShard = nil
 							appliedSortedRun = true
 						}
 					}
@@ -35092,6 +35713,7 @@ func (b *Batch) writeRegularLocked(syncWrite bool, unlockWriteMu func()) error {
 		b.db.retainBatchArenaChunksForMemtables(ptrChunks, ptrTouchedMems)
 	} else {
 		putBatchArenas(ptrChunks)
+		b.db.putBatchArenaChunkListLease(ptrChunks)
 	}
 	unlockWriteMu()
 
@@ -35616,14 +36238,8 @@ func (b *Batch) Close() error {
 			}
 		}
 	}
-	if b.db != nil && b.shardEntries != nil && cap(b.shardEntries) > 0 {
-		full := b.shardEntries[:cap(b.shardEntries)]
-		for i := range full {
-			if full[i] != nil {
-				b.db.putBatchShardEntries(full[i])
-				full[i] = nil
-			}
-		}
+	if b.db != nil && b.shardEntries != nil {
+		b.releaseShardEntryGroups(b.shardEntries)
 	}
 	b.recycleCopyArenaChunks()
 	b.recyclePtrCopyArenaChunks()
@@ -35641,6 +36257,8 @@ func (b *Batch) Close() error {
 	b.ptrValueIdxs = nil
 	b.stableViewValueLeaseChunks = nil
 	b.conditionalTxnID = 0
+	b.valueCopyShard = nil
+	b.appendOnlyDirectValueCopier = nil
 	b.commandWALCompactReplay = false
 	b.commandWALCompactRanges = nil
 	b.commandWALCompactPointStart = 0

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -10686,7 +10686,6 @@ func (db *DB) queueRetiredMemtableLocked(mem memtable.Table) {
 	if db == nil || mem == nil {
 		return
 	}
-	db.releaseBatchArenaLeasesForMemtable(mem)
 	db.pendingRetiredMems = append(db.pendingRetiredMems, mem)
 }
 
@@ -10780,13 +10779,17 @@ func (db *DB) recycleMemtables(mems []memtable.Table) {
 			if !retainAppendOnly {
 				db.releaseAppendOnlyDirectArenaLeaseForMemtableWithPolicy(typed, false)
 				typed.ReleaseDropEntries()
+				db.releaseBatchArenaLeasesForMemtable(typed)
 				continue
 			}
 			typed.ResetWithCapacityHard(appendOnlyResetCapacity, estimate)
+			db.releaseBatchArenaLeasesForMemtable(typed)
 			db.releaseAppendOnlyDirectArenaLeaseForMemtableWithPolicy(typed, true)
 			if !db.putAppendOnlyMemLease(typed) {
 				db.putAppendOnlyMemPoolDropEntries(typed)
 			}
+		default:
+			db.releaseBatchArenaLeasesForMemtable(mt)
 		}
 	}
 }
@@ -11466,6 +11469,8 @@ func (db *DB) resetMutableShardsLocked(nextMode memtable.Mode, reuse bool) error
 		if reuse {
 			if r, ok := any(shard.mem).(interface{ Reset() }); ok {
 				r.Reset()
+				db.releaseBatchArenaLeasesForMemtable(shard.mem)
+				db.releaseAppendOnlyDirectArenaLeaseForMemtable(shard.mem)
 				shard.appendOnlyDirectValueArena.recycleActive()
 				reused = true
 			}

--- a/TreeDB/caching/flush_pool_helpers_test.go
+++ b/TreeDB/caching/flush_pool_helpers_test.go
@@ -60,10 +60,10 @@ func (b *viewCountingBackend) pointerTotals() (setPointerCalls, setPointerViewCa
 
 var entrySlicePoolTestMu sync.Mutex
 
-func lockEntrySlicePoolStateForTest(t *testing.T) {
-	t.Helper()
+func lockEntrySlicePoolStateForTest(tb testing.TB) {
+	tb.Helper()
 	entrySlicePoolTestMu.Lock()
-	t.Cleanup(entrySlicePoolTestMu.Unlock)
+	tb.Cleanup(entrySlicePoolTestMu.Unlock)
 }
 
 func (b *pointerBatch) Set(key, value []byte) error {
@@ -535,8 +535,8 @@ func TestOuterLeafArenaReuseBoundCapsOversizedArena(t *testing.T) {
 	}
 }
 
-func resetEntrySlicePoolStateForTest(t *testing.T) {
-	t.Helper()
+func resetEntrySlicePoolStateForTest(tb testing.TB) {
+	tb.Helper()
 	entrySliceLeaseMu.Lock()
 	saved := entrySliceLeases
 	entrySliceLeases = [entrySliceLeaseClassCount][][]batch.Entry{}
@@ -548,7 +548,7 @@ func resetEntrySlicePoolStateForTest(t *testing.T) {
 	for i := range entrySlicePools {
 		entrySlicePools[i] = sync.Pool{}
 	}
-	t.Cleanup(func() {
+	tb.Cleanup(func() {
 		entrySliceLeaseMu.Lock()
 		entrySliceLeases = saved
 		entrySliceLeaseMu.Unlock()
@@ -568,6 +568,19 @@ func resetEntrySlicePoolsForTest(t *testing.T) {
 	t.Cleanup(func() {
 		entrySlicePoolBudgetBytes = savedBudget
 	})
+}
+
+func BenchmarkEntrySliceLeaseRoundTrip(b *testing.B) {
+	lockEntrySlicePoolStateForTest(b)
+	resetEntrySlicePoolStateForTest(b)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		entries := getEntrySlice(256)
+		entries = entries[:256]
+		putEntrySlice(entries)
+	}
 }
 
 func TestEntrySliceLeaseRoundTrip(t *testing.T) {

--- a/TreeDB/caching/lane.go
+++ b/TreeDB/caching/lane.go
@@ -29,7 +29,8 @@ type lane struct {
 	walClosedSizes map[string]int64
 	// walCoalesceSeq is protected by walMu and groups adjacent unsynced
 	// inline point records into one recovery commit-fence sequence.
-	walCoalesceSeq uint64
+	walCoalesceSeq           uint64
+	walZeroInlineKeyProvider zeroInlineBatchKeyProvider
 
 	vlog                           valueWriter
 	vlogPath                       string

--- a/TreeDB/caching/rcu_snapshot_test.go
+++ b/TreeDB/caching/rcu_snapshot_test.go
@@ -322,7 +322,6 @@ func TestDB_IteratorAllocsIndependentOfQueueLen(t *testing.T) {
 	if view == nil || len(view.queue) != 2 {
 		t.Fatalf("expected snapshot queue len 2; got %v", view)
 	}
-
 	runtime.GC()
 	allocsQueued := testing.AllocsPerRun(1000, func() {
 		it, err := db.Iterator(start, end)
@@ -462,19 +461,25 @@ func TestDB_BatchWriteBypassAllocsIndependentOfQueueLen(t *testing.T) {
 	val := []byte("vz")
 
 	b := db.NewBatchWithSize(1)
-
-	if err := b.Set(key, val); err != nil {
-		t.Fatalf("batch set: %v", err)
+	entry := batch.Entry{Type: batch.OpPut, Key: key, Value: val}
+	prepareBatch := func() {
+		if cap(b.entries) == 0 {
+			b.entries = make([]batch.Entry, 1)
+		} else {
+			b.entries = b.entries[:1]
+		}
+		b.entries[0] = entry
+		b.size = len(key) + len(val)
 	}
+
+	prepareBatch()
 	if err := b.writeBypass(false); err != nil {
 		t.Fatalf("writeBypass warmup: %v", err)
 	}
 
 	runtime.GC()
 	allocsEmpty := testing.AllocsPerRun(1000, func() {
-		if err := b.Set(key, val); err != nil {
-			panic(err)
-		}
+		prepareBatch()
 		if err := b.writeBypass(false); err != nil {
 			panic(err)
 		}
@@ -506,9 +511,7 @@ func TestDB_BatchWriteBypassAllocsIndependentOfQueueLen(t *testing.T) {
 
 	runtime.GC()
 	allocsQueued := testing.AllocsPerRun(1000, func() {
-		if err := b.Set(key, val); err != nil {
-			panic(err)
-		}
+		prepareBatch()
 		if err := b.writeBypass(false); err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
## Objective

Reduce residual TreeDB batch scratch allocation churn in the hot batch paths called out by #3536, especially `batch_small_seq` object churn and allocation space around batch arenas, batch entry slices, shard entry slices, chunk-list scratch, and zero-inline WAL key callbacks.

Refs #3536.

## Context

The post-#3532 allocation profiles under `/tmp/gomap_alloc_loop_20260706_post3532` still showed avoidable churn in `getEntrySlice`, `getBatchArena`, `getBatchEntries`, and `getBatchShardEntries`, with sampled object churn in `batch_small_seq`. This PR keeps the work narrowly in `TreeDB/caching` scratch lifetime and pooling.

## Non-goals

- No WAL format or durable WAL behavior change.
- No value-log pointer persistence or value-log storage semantic change.
- No command ordering change.
- No public API change.
- No `Batch.Write` ownership change; batch objects remain caller-owned/reusable after `Write`.
- No unbounded retained pool growth.

## Design

- Add deterministic bounded batch-arena free leases ahead of the legacy `sync.Pool`; surplus arenas are dropped once the per-bucket lease cap is full.
- Add bounded static `batchArenaLease` headers and coalesce retained single-memtable arena leases when compatible.
- Add DB-local bounded scratch leases for batch entries, shard entries, int slices, int64 slices, arena chunk-list backing, and shard entry groups.
- Return arena chunk-list backing after write and memtable reclaim paths.
- Keep retired memtable batch-arena leases live until actual recycle/reclaim, so retained views/snapshots cannot observe arena storage that has been returned to the pool.
- Release stale batch-arena leases when a mutable memtable is reset in place, so same-memtable reuse does not accumulate unreachable retained bytes.
- Reuse the append-only direct value-copy callback per `Batch` instead of allocating a new closure in the write path.
- Reuse a per-lane zero-inline WAL key provider instead of allocating a per-call closure.
- Make `runtimeNumGC` reuse a package-level metrics sample.

Pool retention remains bounded by count/byte caps; rejected scratch is dropped instead of retained.

## Scope

- Includes: `TreeDB/caching` batch scratch helpers, arena lease helpers, lane zero-inline key provider, focused tests and microbenchmarks.
- Excludes: non-TreeDB packages, value-log storage, WAL record format, batch write semantics, durable reopen behavior.

## Correctness

Latest local tests after the retired-memtable lease lifetime fix:

```sh
GOWORK=off go test ./TreeDB/caching -run 'TestBatchArenaLeases_RetiredMemtableReleaseWaitsForRecycle|TestBatchArenaLeases_ReleasedAfterCheckpoint|TestBatchArenaLeases_CopiedMemtablesMatchOwnershipMode|TestBatchArenaRetainedHardCap' -count=1
GOWORK=off go test ./TreeDB/caching -count=1
```

Results:

- Targeted ownership tests: pass, `ok github.com/snissn/gomap/TreeDB/caching 0.657s`.
- Full caching package: pass, `ok github.com/snissn/gomap/TreeDB/caching 44.847s`.

Edge coverage added/updated:

- deterministic arena free-lease accounting and bucket-cap drop behavior
- static arena lease header round trip
- single-memtable retained arena lease coalescing
- retired memtable lease release waits for actual recycle/reclaim
- same-memtable reset releases stale retained batch-arena leases
- DB-local scratch lease reuse and bounded retention
- shard entry group outer/inner slice return and clearing
- arena chunk-list lease reuse, grow-through-lease behavior, and memtable release return
- zero-inline key provider round trip

## Performance

Focused benchmark command:

```sh
GOWORK=off go test ./TreeDB/caching -run '^$' -bench 'Batch|EntrySlice|Arena|ZeroInline' -benchmem -benchtime=200ms -count=3
```

Latest result after the lifetime fix: pass, `ok github.com/snissn/gomap/TreeDB/caching 7.372s`.

Selected allocation-free focused results:

| Benchmark | Result |
| --- | --- |
| `BenchmarkBatchArenaFreeLeaseRoundTrip` | `0 B/op`, `0 allocs/op` |
| `BenchmarkBatchArenaLeaseHeaderRoundTrip` | `0 B/op`, `0 allocs/op` |
| `BenchmarkBatchAuxScratchLeaseRoundTrip` | `0 B/op`, `0 allocs/op` |
| `BenchmarkBatchArenaChunkListLeaseRoundTrip` | `0 B/op`, `0 allocs/op` |
| `BenchmarkBatchArenaChunkListEnsureAppendCapRoundTrip` | `0 B/op`, `0 allocs/op` |
| `BenchmarkZeroInlineKeyProviderRoundTrip` | `0 B/op`, `0 allocs/op` |
| `BenchmarkBatchShardEntryGroupLeaseRoundTrip` | `0 B/op`, `0 allocs/op` |
| `BenchmarkEntrySliceLeaseRoundTrip` | `0 B/op`, `0 allocs/op` |

Short durable unified-bench smoke command:

```sh
GOWORK=off GOMAXPROCS=8 TMPDIR=/tmp/gomap_alloc_loop_20260706_issue3536_branch_smoke_final8_nZptIf/tmp ./bin/unified-bench \
  -profile durable \
  -dbs treedb \
  -keys 200000 \
  -valsize 128 \
  -batchsize 8000 \
  -checkpoint-between-tests \
  -treedb-journal-lanes=1 \
  -test batch_small_seq,batch_random,batch_delete,batch_write \
  -progress=false \
  -profile-dir /tmp/gomap_alloc_loop_20260706_issue3536_branch_smoke_final8_nZptIf/profiles \
  -path-label native-fastpath \
  -format markdown
```

Smoke result: pass. Profile artifact dir: `/tmp/gomap_alloc_loop_20260706_issue3536_branch_smoke_final8_nZptIf/profiles`.
Baseline artifact dir from `origin/main` at `26b191d07`: `/tmp/gomap_alloc_loop_20260706_issue3536_origin_main_smoke_final_014404`.
Targeted pprof comparison: `/tmp/gomap_alloc_loop_20260706_issue3536_branch_smoke_final8_nZptIf/alloc_compare_targeted.txt`.

Smoke throughput:

| Test | origin/main | branch |
| --- | ---: | ---: |
| Batch Small Seq | 1,881,260 | 4,055,527 |
| Batch Random | 3,303,903 | 4,029,283 |
| Batch Delete | 2,615,455 | 7,177,216 |
| Batch Write | 8,128,071 | 13,308,527 |

Allocation profile evidence from the targeted pprof comparison:

| Test | alloc_objects | alloc_space | Targeted notes |
| --- | ---: | ---: | --- |
| `batch_small_seq` | `30131 -> 22711` | `155.60MB -> 150.02MB` | `DB.NewBatch` objects `5737 -> 2235`; `getBatchArena` space `34.53MB -> 27.42MB`; `writeRegularLocked` cumulative objects `1491 -> 175`. |
| `batch_random` | `28108 -> 12280` | `105.62MB -> 93.11MB` | `getBatchShardEntries` objects `78 -> 22`, space `3.67MB -> 1.05MB`; `getBatchIntSlice` objects `16 -> 8`. |
| `batch_delete` | `41667 -> 9504` | `95.88MB -> 88.85MB` | `getBatchIntSlice` and `getBatchEntries` drop out of targeted branch output; `writeRegularLocked` space `81.91MB -> 75.91MB`. |
| `batch_write` | `1023 -> 1328` | `79.32MB -> 71.85MB` | `getBatchShardEntries` objects `57 -> 9`; space `2.61MB -> 0.53MB`; closure-shaped `writeRegularLocked.func5` drops out of branch output. |

Caveat: these pprof comparisons are short smoke runs and allocation profiles are sampled. `batch_write` total sampled objects rose slightly (`1023 -> 1328`), while sampled allocation space dropped. `batch_small_seq` sampled `getEntrySlice` space was noisy/worse (`11.96MB -> 15.64MB`), so this PR does not claim a clean `getEntrySlice` space win from that short smoke.

## Rollout / Toggle Plan

- Default setting: always-on bounded scratch reuse in `TreeDB/caching`.
- Disable quickly: revert this PR. No new runtime knob was added.

## Follow-ups

- If #3536 needs another pass, focus on remaining sampled `getEntrySlice` space in `batch_small_seq` and any residual adapter-level `NewBatch` churn that is outside this PR's batch scratch scope.

## AI Review Loop

- Codex latest-head review: requested on `7818ce176`.
- Copilot latest-head review: requested on `7818ce176`.
- CodeRabbit latest-head review: automatic/rate-limited status expected.
- Merge status: not merged; waiting for latest-head CI and review.
