### PR TITLE
treedb: preserve command WAL batch byte hints

### DIFF
--- a/TreeDB/command_wal_public_cached.go
+++ b/TreeDB/command_wal_public_cached.go
@@ -361,11 +361,7 @@ func newCommandWALPublicBatch(tdb *DB, inner Batch, opHint int) *commandWALPubli
 	b := &commandWALPublicBatch{db: tdb, inner: inner, payload: payload}
 	b.disableInnerStreamingBypass()
 	b.rebindInnerViewers()
-	opHint = db.NormalizePublicBatchReserveHint(opHint)
-	byteHint := 0
-	if opHint > 0 && opHint <= int(^uint(0)>>1)/commandWALPublicBatchEstimatedKeyValueBytes {
-		byteHint = opHint * commandWALPublicBatchEstimatedKeyValueBytes
-	}
+	opHint, byteHint := db.NormalizePublicBatchReserveAndByteHints(opHint, commandWALPublicBatchEstimatedKeyValueBytes)
 	b.payloadOpHint = opHint
 	b.payloadByteHint = byteHint
 	b.payloadSoftCapBytes = commandWALPublicBatchPayloadSoftCapBytes

--- a/TreeDB/command_wal_public_test.go
+++ b/TreeDB/command_wal_public_test.go
@@ -2639,6 +2639,57 @@ func BenchmarkPublicCommandWALRawKVBatchWrite(b *testing.B) {
 	}
 }
 
+func BenchmarkPublicCommandWALRawKVBatchWriteFlushThresholdHint(b *testing.B) {
+	const (
+		batchHint = 100_000
+		batchOps  = 512
+		valueSize = 128
+	)
+	db, err := Open(Options{
+		Dir:                 b.TempDir(),
+		Durability:          DurabilityWALOnRelaxed,
+		CommandWAL:          true,
+		CommandWALStatsScan: true,
+		DisableSideStores:   true,
+	})
+	if err != nil {
+		b.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	keys := make([][]byte, batchOps)
+	for i := range keys {
+		keys[i] = []byte(fmt.Sprintf("rawkv-flush-threshold-key-%08d", i))
+	}
+	value := bytes.Repeat([]byte{1}, valueSize)
+
+	b.SetBytes(int64(batchOps * (len(keys[0]) + len(value))))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		batch := db.NewBatchWithSize(batchHint)
+		for j := 0; j < batchOps; j++ {
+			if err := batch.Set(keys[j], value); err != nil {
+				_ = batch.Close()
+				b.Fatalf("batch Set: %v", err)
+			}
+		}
+		if err := batch.Write(); err != nil {
+			_ = batch.Close()
+			b.Fatalf("batch Write: %v", err)
+		}
+		if err := batch.Close(); err != nil {
+			b.Fatalf("batch Close: %v", err)
+		}
+	}
+	b.StopTimer()
+	totalSets := float64(b.N * batchOps)
+	b.ReportMetric(totalSets/b.Elapsed().Seconds(), "sets/s")
+	b.ReportMetric(float64(batchHint), "batch_hint")
+	b.ReportMetric(float64(batchOps), "sets/batch")
+	assertPublicCommandWALFramesB(b, db, uint64(b.N))
+}
+
 func BenchmarkPublicCommandWALDurableTinyBatchWriteSync(b *testing.B) {
 	opts := OptionsFor(ProfileCommandWALDurable, b.TempDir())
 	opts.DisableSideStores = true

--- a/TreeDB/db/batch.go
+++ b/TreeDB/db/batch.go
@@ -148,6 +148,32 @@ func NormalizePublicBatchReserveHint(size int) int {
 	return entries
 }
 
+// NormalizePublicBatchReserveAndByteHints returns the normalized entry reserve
+// together with a bounded byte-capacity hint for callers that also maintain a
+// byte-oriented append buffer. For large public size hints, preserve the
+// original byte budget up to the same conservative cap used by reserve
+// normalization so IAVL-style flush thresholds can avoid append-buffer growth
+// without preallocating one entry per byte.
+func NormalizePublicBatchReserveAndByteHints(size, estimatedBytesPerEntry int) (entryHint, byteHint int) {
+	entryHint = NormalizePublicBatchReserveHint(size)
+	if entryHint <= 0 || estimatedBytesPerEntry <= 0 {
+		return entryHint, 0
+	}
+	if entryHint <= int(^uint(0)>>1)/estimatedBytesPerEntry {
+		byteHint = entryHint * estimatedBytesPerEntry
+	}
+	if size <= publicBatchHintExactEntryReserveMax || size <= byteHint {
+		return entryHint, byteHint
+	}
+	maxByteHint := publicBatchHintNormalizedEntryCap * publicBatchHintApproxBytesPerEntry
+	if size < maxByteHint {
+		byteHint = size
+	} else {
+		byteHint = maxByteHint
+	}
+	return entryHint, byteHint
+}
+
 func (db *DB) newBatchWithEntryReserve(entries int) batch.Interface {
 	return db.newBatchWithReserveHint(entries)
 }

--- a/TreeDB/db/batch_reserve_test.go
+++ b/TreeDB/db/batch_reserve_test.go
@@ -65,6 +65,44 @@ func TestNormalizePublicBatchReserveHint_HandlesEdgeCases(t *testing.T) {
 	}
 }
 
+func TestNormalizePublicBatchReserveAndByteHints_PreservesSmallEntryHints(t *testing.T) {
+	const (
+		sizeHint              = 512
+		estimatedBytesPerHint = 192
+	)
+	entryHint, byteHint := NormalizePublicBatchReserveAndByteHints(sizeHint, estimatedBytesPerHint)
+	if entryHint != sizeHint {
+		t.Fatalf("entryHint=%d want %d", entryHint, sizeHint)
+	}
+	if want := sizeHint * estimatedBytesPerHint; byteHint != want {
+		t.Fatalf("byteHint=%d want %d", byteHint, want)
+	}
+}
+
+func TestNormalizePublicBatchReserveAndByteHints_PreservesLargeByteBudget(t *testing.T) {
+	const (
+		sizeHint              = 100_000
+		estimatedBytesPerHint = 192
+	)
+	entryHint, byteHint := NormalizePublicBatchReserveAndByteHints(sizeHint, estimatedBytesPerHint)
+	if want := NormalizePublicBatchReserveHint(sizeHint); entryHint != want {
+		t.Fatalf("entryHint=%d want %d", entryHint, want)
+	}
+	if byteHint != sizeHint {
+		t.Fatalf("byteHint=%d want preserved byte budget %d", byteHint, sizeHint)
+	}
+}
+
+func TestNormalizePublicBatchReserveAndByteHints_CapsHugeByteBudget(t *testing.T) {
+	entryHint, byteHint := NormalizePublicBatchReserveAndByteHints(math.MaxInt, 192)
+	if entryHint != publicBatchHintNormalizedEntryCap {
+		t.Fatalf("entryHint=%d want %d", entryHint, publicBatchHintNormalizedEntryCap)
+	}
+	if want := publicBatchHintNormalizedEntryCap * publicBatchHintApproxBytesPerEntry; byteHint != want {
+		t.Fatalf("byteHint=%d want capped byte budget %d", byteHint, want)
+	}
+}
+
 func TestNewBatchWithSize_NormalizesLargePublicHint(t *testing.T) {
 	db := &DB{}
 	want := NormalizePublicBatchReserveHint(100_000)


### PR DESCRIPTION
## Summary

- Preserve large public `NewBatchWithSize` byte-budget hints for command-WAL raw-KV payload buffers instead of shrinking them to `normalizedEntryHint * 192`.
- Keep the existing bounded entry-reserve normalization, so IAVL-style `100000` flush thresholds do not preallocate one entry per byte.
- Add a public command-WAL benchmark that reproduces the IAVL flush-threshold hint path.

Fixes #3551

## Static analysis

Accepted Ironbird plain-send reached `RawKVBatchPayloadBuilder.appendRawKVPayloadSpace` through the IAVL `BatchWithFlusher.Set` path. IAVL constructs batches with `db.NewBatchWithSize(flushThreshold)`, and the default flush threshold is `100000` bytes. TreeDB already normalizes that public hint to a bounded entry reserve, but `newCommandWALPublicBatch` then derived the raw-KV payload byte hint from the normalized entry count: `ceil(100000/256) * 192 = 75072`. That under-hints the append buffer for a real 100KB-ish flush batch and can force payload growth/copy.

This patch keeps the bounded entry hint for entry arenas and separately preserves the original byte budget as a capped byte-buffer hint. It is capacity-only: no command-WAL frame bytes, decode ownership semantics, recovery behavior, or value-log persistence semantics change.

## Benchmark evidence

Command run before and after the production change, with the benchmark added locally:

```sh
GOWORK=off TMPDIR=/mnt/fast4tb/tmp go test ./TreeDB -run '^$' -bench 'BenchmarkPublicCommandWALRawKVBatchWriteFlushThresholdHint$' -benchmem -count=5
```

Before:

- ns/op: 165296, 152086, 145644, 156318, 155263
- B/op: 234313, 190082, 185877, 216537, 188993
- allocs/op: 32, 32, 32, 31, 32

After:

- ns/op: 153588, 148338, 151923, 146260, 152376
- B/op: 184430, 185778, 190908, 205441, 190897
- allocs/op: 29, 30, 30, 29, 30

Averages: ~154921 -> ~150497 ns/op, ~203160 -> ~191491 B/op, ~31.8 -> ~29.6 allocs/op. The DB-level benchmark is still noisy, but allocation count consistently drops and average B/op improves on the IAVL-style hint path.

## Tests

```sh
GOWORK=off TMPDIR=/mnt/fast4tb/tmp go test ./TreeDB/internal/commitlog ./TreeDB/caching ./TreeDB/db ./TreeDB
```

Result:

- `ok github.com/snissn/gomap/TreeDB/internal/commitlog (cached)`
- `ok github.com/snissn/gomap/TreeDB/caching (cached)`
- `ok github.com/snissn/gomap/TreeDB/db 240.771s`
- `ok github.com/snissn/gomap/TreeDB (cached)`

## Caveat

This is a small candidate for coordinator Ironbird validation, not a guaranteed macro win. It targets a real under-hint on the accepted profile path and should reduce `appendRawKVPayloadSpace`/growth pressure for IAVL flush-threshold batches, but macro total allocation must still be checked by Ironbird plain-send and small-multisend.
