### PR TITLE
treedb: retain value-log zstd encoders

### DIFF
--- a/TreeDB/internal/valuelog/dict_frame_preparer_alloc_bench_test.go
+++ b/TreeDB/internal/valuelog/dict_frame_preparer_alloc_bench_test.go
@@ -1,0 +1,69 @@
+package valuelog
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/snissn/compress/zstd"
+)
+
+func BenchmarkFramePreparerDictIronbirdLikeHistoryReuse(b *testing.B) {
+	const (
+		dictID      = uint64(3553)
+		valueSize   = 4096
+		recordCount = 8
+		valueCount  = 128
+	)
+
+	values := make([][]byte, valueCount)
+	for i := range values {
+		values[i] = makeSyntheticDictSampleForBench(i, valueSize)
+	}
+	dict, err := buildBenchDictWithHistory(uint32(dictID), values, 32<<10)
+	if err != nil {
+		b.Fatalf("build dict: %v", err)
+	}
+
+	records := make([]Record, recordCount)
+	fillRecords := func(base int) {
+		for i := range records {
+			records[i] = Record{
+				RID:   uint64(base + i + 1),
+				Value: values[(base+i)%len(values)],
+			}
+		}
+	}
+
+	prep := NewFramePreparer()
+	prep.SetDictFrameEncoderOptions(zstd.SpeedFastest, false)
+	fillRecords(0)
+	body, stats, err := prep.PrepareFrameInto(nil, dictID, dict, records)
+	if err != nil {
+		b.Fatalf("warm PrepareFrameInto: %v", err)
+	}
+	if !stats.Attempted || !stats.Kept {
+		b.Fatalf("warm frame stats attempted=%v kept=%v raw=%d stored=%d", stats.Attempted, stats.Kept, stats.RawPayloadBytes, stats.StoredPayloadBytes)
+	}
+
+	b.ReportAllocs()
+	b.SetBytes(int64(valueSize * recordCount))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		// Two GC cycles clear sync.Pool victims, matching the Ironbird profile shape
+		// where pooled zstd encoders were repeatedly recreated between batches.
+		runtime.GC()
+		runtime.GC()
+		fillRecords(i * recordCount)
+		var prepErr error
+		body, stats, prepErr = prep.PrepareFrameInto(body[:0], dictID, dict, records)
+		if prepErr != nil {
+			b.Fatalf("PrepareFrameInto: %v", prepErr)
+		}
+		if !stats.Attempted || !stats.Kept {
+			b.Fatalf("frame stats attempted=%v kept=%v raw=%d stored=%d", stats.Attempted, stats.Kept, stats.RawPayloadBytes, stats.StoredPayloadBytes)
+		}
+	}
+	b.StopTimer()
+	runtime.KeepAlive(prep)
+	runtime.KeepAlive(body)
+}

--- a/TreeDB/internal/valuelog/dict_frame_preparer_alloc_bench_test.go
+++ b/TreeDB/internal/valuelog/dict_frame_preparer_alloc_bench_test.go
@@ -64,6 +64,8 @@ func BenchmarkFramePreparerDictIronbirdLikeHistoryReuse(b *testing.B) {
 		if !stats.Attempted || !stats.Kept {
 			b.Fatalf("frame stats attempted=%v kept=%v raw=%d stored=%d", stats.Attempted, stats.Kept, stats.RawPayloadBytes, stats.StoredPayloadBytes)
 		}
+		prep.TrimScratchForReuse()
+		prep.SetDictFrameEncoderOptions(zstd.SpeedFastest, false)
 	}
 	b.StopTimer()
 	runtime.KeepAlive(prep)

--- a/TreeDB/internal/valuelog/dict_frame_preparer_alloc_bench_test.go
+++ b/TreeDB/internal/valuelog/dict_frame_preparer_alloc_bench_test.go
@@ -1,10 +1,12 @@
 package valuelog
 
 import (
+	"io"
 	"runtime"
 	"testing"
 
 	"github.com/snissn/compress/zstd"
+	"github.com/snissn/gomap/TreeDB/page"
 )
 
 func BenchmarkFramePreparerDictIronbirdLikeHistoryReuse(b *testing.B) {
@@ -66,4 +68,70 @@ func BenchmarkFramePreparerDictIronbirdLikeHistoryReuse(b *testing.B) {
 	b.StopTimer()
 	runtime.KeepAlive(prep)
 	runtime.KeepAlive(body)
+}
+
+func BenchmarkWriterDictIronbirdLikeHistoryReuse(b *testing.B) {
+	const (
+		dictID      = uint64(3554)
+		valueSize   = 4096
+		recordCount = 8
+		valueCount  = 128
+	)
+
+	values := make([][]byte, valueCount)
+	for i := range values {
+		values[i] = makeSyntheticDictSampleForBench(i, valueSize)
+	}
+	dict, err := buildBenchDictWithHistory(uint32(dictID), values, 32<<10)
+	if err != nil {
+		b.Fatalf("build dict: %v", err)
+	}
+
+	records := make([]Record, recordCount)
+	fillRecords := func(base int) {
+		for i := range records {
+			records[i] = Record{
+				RID:   uint64(base + i + 1),
+				Value: values[(base+i)%len(values)],
+			}
+		}
+	}
+
+	writer := NewWriterWithSink(io.Discard, 1)
+	writer.SetDictFrameEncoderOptions(zstd.SpeedFastest, false)
+	defer func() {
+		if err := writer.Close(); err != nil {
+			b.Fatalf("close writer: %v", err)
+		}
+	}()
+
+	ptrs := make([]page.ValuePtr, recordCount)
+	fillRecords(0)
+	_, stats, err := writer.AppendFrameWithStatsInto(dictID, dict, records, ptrs)
+	if err != nil {
+		b.Fatalf("warm AppendFrameWithStatsInto: %v", err)
+	}
+	if !stats.Attempted || !stats.Kept {
+		b.Fatalf("warm frame stats attempted=%v kept=%v raw=%d stored=%d", stats.Attempted, stats.Kept, stats.RawPayloadBytes, stats.StoredPayloadBytes)
+	}
+
+	b.ReportAllocs()
+	b.SetBytes(int64(valueSize * recordCount))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		runtime.GC()
+		runtime.GC()
+		fillRecords(i * recordCount)
+		var appendErr error
+		_, stats, appendErr = writer.AppendFrameWithStatsInto(dictID, dict, records, ptrs)
+		if appendErr != nil {
+			b.Fatalf("AppendFrameWithStatsInto: %v", appendErr)
+		}
+		if !stats.Attempted || !stats.Kept {
+			b.Fatalf("frame stats attempted=%v kept=%v raw=%d stored=%d", stats.Attempted, stats.Kept, stats.RawPayloadBytes, stats.StoredPayloadBytes)
+		}
+	}
+	b.StopTimer()
+	runtime.KeepAlive(writer)
+	runtime.KeepAlive(ptrs)
 }

--- a/TreeDB/internal/valuelog/frame_preparer.go
+++ b/TreeDB/internal/valuelog/frame_preparer.go
@@ -25,6 +25,10 @@ type FramePreparer struct {
 	noBenefit  uint8
 	skipRemain uint16
 
+	dictEncoder       *zstd.Encoder
+	dictEncoderCodecs *dictCodecEntry
+	dictEncoderKey    dictCodecKey
+
 	dictFrameEncodeLevel   zstd.EncoderLevel
 	dictFrameEnableEntropy bool
 	blockCodec             BlockCodec
@@ -56,6 +60,7 @@ func (p *FramePreparer) ResetForReuse() {
 	if p == nil {
 		return
 	}
+	p.releaseDictEncoder()
 	p.TrimScratchForReuse()
 	p.skipDictID = 0
 	p.codecs = nil
@@ -74,9 +79,10 @@ func (p *FramePreparer) ResetForReuse() {
 	p.keepSafetyMargin = DefaultKeepSafetyMargin
 }
 
-// TrimScratchForReuse drops oversized temporary buffers while preserving codec
-// and compression-hint state. Long-lived prepare workers call this between
-// tasks so an occasional large frame does not pin unbounded scratch memory.
+// TrimScratchForReuse drops oversized temporary buffers while preserving codec,
+// active dictionary encoder, and compression-hint state. Long-lived prepare
+// workers call this between tasks so an occasional large frame does not pin
+// unbounded scratch memory.
 func (p *FramePreparer) TrimScratchForReuse() {
 	if p == nil {
 		return
@@ -99,11 +105,45 @@ func (p *FramePreparer) TrimScratchForReuse() {
 	p.encLimiter = limitedSliceWriter{}
 }
 
+func (p *FramePreparer) releaseDictEncoder() {
+	if p == nil || p.dictEncoder == nil {
+		return
+	}
+	if p.dictEncoderCodecs != nil && p.dictEncoderCodecs.encPool != nil {
+		p.dictEncoderCodecs.encPool.Put(p.dictEncoder)
+	}
+	p.dictEncoder = nil
+	p.dictEncoderCodecs = nil
+	p.dictEncoderKey = dictCodecKey{}
+}
+
+func (p *FramePreparer) dictEncoderFor(codecs *dictCodecEntry) (*zstd.Encoder, error) {
+	if p == nil || codecs == nil || codecs.encPool == nil {
+		return nil, ErrMissingDict
+	}
+	if p.dictEncoder != nil && p.dictEncoderCodecs == codecs && p.dictEncoderKey == codecs.key {
+		return p.dictEncoder, nil
+	}
+	p.releaseDictEncoder()
+	enc, ok := codecs.encPool.Get().(*zstd.Encoder)
+	if !ok || enc == nil {
+		return nil, ErrMissingDict
+	}
+	p.dictEncoder = enc
+	p.dictEncoderCodecs = codecs
+	p.dictEncoderKey = codecs.key
+	return enc, nil
+}
+
 func (p *FramePreparer) SetDictFrameEncoderOptions(level zstd.EncoderLevel, enableEntropy bool) {
 	if p == nil {
 		return
 	}
-	p.dictFrameEncodeLevel = normalizeDictFrameEncodeLevel(level)
+	level = normalizeDictFrameEncodeLevel(level)
+	if p.dictFrameEncodeLevel != level || p.dictFrameEnableEntropy != enableEntropy {
+		p.releaseDictEncoder()
+	}
+	p.dictFrameEncodeLevel = level
 	p.dictFrameEnableEntropy = enableEntropy
 	p.codecs = nil
 	p.skipDictID = 0
@@ -315,11 +355,13 @@ func (p *FramePreparer) PrepareFrameInto(dst []byte, dictID uint64, dict []byte,
 			return nil, FrameStats{}, ErrMissingDict
 		}
 
-		enc := codecs.encPool.Get().(*zstd.Encoder)
+		enc, err := p.dictEncoderFor(codecs)
+		if err != nil {
+			return nil, FrameStats{}, err
+		}
 		encodeStart := p.sampleEncodeStart()
 		encoded, encodeErr := p.encodePayload(enc, records, rawPayloadBytes)
 		encodeNs := p.sampleEncodeEnd(encodeStart, rawPayloadBytes, k)
-		codecs.encPool.Put(enc)
 		p.encScratch = p.encScratch[:0]
 
 		keepCompressed := false

--- a/TreeDB/internal/valuelog/valuelog_test.go
+++ b/TreeDB/internal/valuelog/valuelog_test.go
@@ -1743,6 +1743,7 @@ func TestFramePreparer_TrimScratchForReuseKeepsPolicyAndBoundsBuffers(t *testing
 func TestFramePreparer_DictEncoderRetainedAcrossTrimAndSameOptions(t *testing.T) {
 	const dictID = uint64(3553)
 	dict, records := buildLargeDictCompressionFixture(t, dictID)
+	dict2, records2 := buildLargeDictCompressionFixture(t, dictID+1)
 
 	prep := NewFramePreparer()
 	prep.SetDictFrameEncoderOptions(zstd.SpeedFastest, false)
@@ -1777,6 +1778,40 @@ func TestFramePreparer_DictEncoderRetainedAcrossTrimAndSameOptions(t *testing.T)
 	}
 	if prep.dictEncoder != retained || prep.dictEncoderKey != retainedKey {
 		t.Fatalf("second frame did not reuse retained dict encoder")
+	}
+
+	prep.SetDictFrameEncoderOptions(zstd.SpeedDefault, false)
+	if prep.dictEncoder != nil || prep.dictEncoderCodecs != nil || prep.dictEncoderKey != (dictCodecKey{}) {
+		t.Fatalf("option change retained dict encoder state: encoder=%p codecs=%p key=%+v", prep.dictEncoder, prep.dictEncoderCodecs, prep.dictEncoderKey)
+	}
+	body, stats, err = prep.PrepareFrameInto(body[:0], dictID, dict, records)
+	if err != nil {
+		t.Fatalf("third PrepareFrameInto after option change: %v", err)
+	}
+	if !stats.Attempted || !stats.Kept {
+		t.Fatalf("expected third kept dict-compressed frame: attempted=%v kept=%v raw=%d stored=%d", stats.Attempted, stats.Kept, stats.RawPayloadBytes, stats.StoredPayloadBytes)
+	}
+	if prep.dictEncoder == nil || prep.dictEncoderCodecs == nil {
+		t.Fatalf("expected retained dict encoder after option change")
+	}
+	reacquired := prep.dictEncoder
+	reacquiredKey := prep.dictEncoderKey
+	if reacquiredKey == retainedKey {
+		t.Fatalf("option change reused old encoder key: encoder=%p key=%+v", reacquired, reacquiredKey)
+	}
+
+	body, stats, err = prep.PrepareFrameInto(body[:0], dictID+1, dict2, records2)
+	if err != nil {
+		t.Fatalf("fourth PrepareFrameInto after dict change: %v", err)
+	}
+	if !stats.Attempted || !stats.Kept {
+		t.Fatalf("expected fourth kept dict-compressed frame: attempted=%v kept=%v raw=%d stored=%d", stats.Attempted, stats.Kept, stats.RawPayloadBytes, stats.StoredPayloadBytes)
+	}
+	if prep.dictEncoder == nil || prep.dictEncoderCodecs == nil {
+		t.Fatalf("expected retained dict encoder after dict change")
+	}
+	if prep.dictEncoderKey == reacquiredKey {
+		t.Fatalf("dict change reused old encoder key: encoder=%p key=%+v", prep.dictEncoder, prep.dictEncoderKey)
 	}
 
 	prep.ResetForReuse()

--- a/TreeDB/internal/valuelog/valuelog_test.go
+++ b/TreeDB/internal/valuelog/valuelog_test.go
@@ -1740,6 +1740,51 @@ func TestFramePreparer_TrimScratchForReuseKeepsPolicyAndBoundsBuffers(t *testing
 	}
 }
 
+func TestFramePreparer_DictEncoderRetainedAcrossTrimAndSameOptions(t *testing.T) {
+	const dictID = uint64(3553)
+	dict, records := buildLargeDictCompressionFixture(t, dictID)
+
+	prep := NewFramePreparer()
+	prep.SetDictFrameEncoderOptions(zstd.SpeedFastest, false)
+	body, stats, err := prep.PrepareFrame(dictID, dict, records)
+	if err != nil {
+		t.Fatalf("PrepareFrame: %v", err)
+	}
+	if !stats.Attempted || !stats.Kept {
+		t.Fatalf("expected kept dict-compressed frame: attempted=%v kept=%v raw=%d stored=%d", stats.Attempted, stats.Kept, stats.RawPayloadBytes, stats.StoredPayloadBytes)
+	}
+	if prep.dictEncoder == nil || prep.dictEncoderCodecs == nil {
+		t.Fatalf("expected retained dict encoder")
+	}
+	retained := prep.dictEncoder
+	retainedKey := prep.dictEncoderKey
+
+	prep.TrimScratchForReuse()
+	if prep.dictEncoder != retained || prep.dictEncoderKey != retainedKey {
+		t.Fatalf("trim released retained dict encoder")
+	}
+
+	prep.SetDictFrameEncoderOptions(zstd.SpeedFastest, false)
+	if prep.dictEncoder != retained || prep.dictEncoderKey != retainedKey {
+		t.Fatalf("same encoder options released retained dict encoder")
+	}
+	body, stats, err = prep.PrepareFrameInto(body[:0], dictID, dict, records)
+	if err != nil {
+		t.Fatalf("second PrepareFrameInto: %v", err)
+	}
+	if !stats.Attempted || !stats.Kept {
+		t.Fatalf("expected second kept dict-compressed frame: attempted=%v kept=%v raw=%d stored=%d", stats.Attempted, stats.Kept, stats.RawPayloadBytes, stats.StoredPayloadBytes)
+	}
+	if prep.dictEncoder != retained || prep.dictEncoderKey != retainedKey {
+		t.Fatalf("second frame did not reuse retained dict encoder")
+	}
+
+	prep.ResetForReuse()
+	if prep.dictEncoder != nil || prep.dictEncoderCodecs != nil || prep.dictEncoderKey != (dictCodecKey{}) {
+		t.Fatalf("reset retained dict encoder state: encoder=%p codecs=%p key=%+v", prep.dictEncoder, prep.dictEncoderCodecs, prep.dictEncoderKey)
+	}
+}
+
 func TestFramePreparer_KeepPolicySkipsCompression(t *testing.T) {
 	records := []Record{
 		{RID: 1, Value: bytes.Repeat([]byte("alpha-001|"), 32)},

--- a/TreeDB/internal/valuelog/valuelog_test.go
+++ b/TreeDB/internal/valuelog/valuelog_test.go
@@ -1785,6 +1785,64 @@ func TestFramePreparer_DictEncoderRetainedAcrossTrimAndSameOptions(t *testing.T)
 	}
 }
 
+func TestWriter_DictEncoderRetainedAcrossFramesAndReleasedOnClose(t *testing.T) {
+	const dictID = uint64(3554)
+	dict, records := buildLargeDictCompressionFixture(t, dictID)
+
+	w := NewWriterWithSink(io.Discard, page.ValueLogFileID(1))
+	w.SetDictFrameEncoderOptions(zstd.SpeedFastest, false)
+	dst := make([]page.ValuePtr, len(records))
+	_, stats, err := w.AppendFrameWithStatsInto(dictID, dict, records, dst)
+	if err != nil {
+		t.Fatalf("AppendFrameWithStatsInto: %v", err)
+	}
+	if !stats.Attempted || !stats.Kept {
+		t.Fatalf("expected kept dict-compressed frame: attempted=%v kept=%v raw=%d stored=%d", stats.Attempted, stats.Kept, stats.RawPayloadBytes, stats.StoredPayloadBytes)
+	}
+	if w.dictEncoder == nil || w.dictEncoderCodecs == nil {
+		t.Fatalf("expected retained dict encoder")
+	}
+	retained := w.dictEncoder
+	retainedKey := w.dictEncoderKey
+
+	_, stats, err = w.AppendFrameWithStatsInto(dictID, dict, records, dst)
+	if err != nil {
+		t.Fatalf("second AppendFrameWithStatsInto: %v", err)
+	}
+	if !stats.Attempted || !stats.Kept {
+		t.Fatalf("expected second kept dict-compressed frame: attempted=%v kept=%v raw=%d stored=%d", stats.Attempted, stats.Kept, stats.RawPayloadBytes, stats.StoredPayloadBytes)
+	}
+	if w.dictEncoder != retained || w.dictEncoderKey != retainedKey {
+		t.Fatalf("second frame did not reuse retained dict encoder")
+	}
+
+	w.SetDictFrameEncoderOptions(zstd.SpeedFastest, false)
+	if w.dictEncoder != retained || w.dictEncoderKey != retainedKey {
+		t.Fatalf("same encoder options released retained dict encoder")
+	}
+	w.SetDictFrameEncoderOptions(zstd.SpeedDefault, false)
+	if w.dictEncoder != nil || w.dictEncoderCodecs != nil || w.dictEncoderKey != (dictCodecKey{}) {
+		t.Fatalf("option change retained dict encoder state: encoder=%p codecs=%p key=%+v", w.dictEncoder, w.dictEncoderCodecs, w.dictEncoderKey)
+	}
+
+	_, stats, err = w.AppendFrameWithStatsInto(dictID, dict, records, dst)
+	if err != nil {
+		t.Fatalf("third AppendFrameWithStatsInto: %v", err)
+	}
+	if !stats.Attempted || !stats.Kept {
+		t.Fatalf("expected third kept dict-compressed frame: attempted=%v kept=%v raw=%d stored=%d", stats.Attempted, stats.Kept, stats.RawPayloadBytes, stats.StoredPayloadBytes)
+	}
+	if w.dictEncoder == nil || w.dictEncoderCodecs == nil {
+		t.Fatalf("expected retained dict encoder after option change")
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if w.dictEncoder != nil || w.dictEncoderCodecs != nil || w.dictEncoderKey != (dictCodecKey{}) {
+		t.Fatalf("close retained dict encoder state: encoder=%p codecs=%p key=%+v", w.dictEncoder, w.dictEncoderCodecs, w.dictEncoderKey)
+	}
+}
+
 func TestFramePreparer_KeepPolicySkipsCompression(t *testing.T) {
 	records := []Record{
 		{RID: 1, Value: bytes.Repeat([]byte("alpha-001|"), 32)},

--- a/TreeDB/internal/valuelog/writer.go
+++ b/TreeDB/internal/valuelog/writer.go
@@ -77,6 +77,9 @@ type Writer struct {
 	blockCodecScratch      blockCodecScratch
 	skipDictID             uint64
 	codecs                 *dictCodecEntry
+	dictEncoder            *zstd.Encoder
+	dictEncoderCodecs      *dictCodecEntry
+	dictEncoderKey         dictCodecKey
 	dictFrameEncodeLevel   zstd.EncoderLevel
 	dictFrameEnableEntropy bool
 	blockCodec             BlockCodec
@@ -560,12 +563,46 @@ func (w *Writer) SetDictFrameEncoderOptions(level zstd.EncoderLevel, enableEntro
 	if w == nil {
 		return
 	}
-	w.dictFrameEncodeLevel = normalizeDictFrameEncodeLevel(level)
+	level = normalizeDictFrameEncodeLevel(level)
+	if w.dictFrameEncodeLevel != level || w.dictFrameEnableEntropy != enableEntropy {
+		w.releaseDictEncoder()
+	}
+	w.dictFrameEncodeLevel = level
 	w.dictFrameEnableEntropy = enableEntropy
 	w.codecs = nil
 	w.skipDictID = 0
 	w.noBenefit = 0
 	w.skipRemain = 0
+}
+
+func (w *Writer) releaseDictEncoder() {
+	if w == nil || w.dictEncoder == nil {
+		return
+	}
+	if w.dictEncoderCodecs != nil && w.dictEncoderCodecs.encPool != nil {
+		w.dictEncoderCodecs.encPool.Put(w.dictEncoder)
+	}
+	w.dictEncoder = nil
+	w.dictEncoderCodecs = nil
+	w.dictEncoderKey = dictCodecKey{}
+}
+
+func (w *Writer) dictEncoderFor(codecs *dictCodecEntry) (*zstd.Encoder, error) {
+	if w == nil || codecs == nil || codecs.encPool == nil {
+		return nil, ErrMissingDict
+	}
+	if w.dictEncoder != nil && w.dictEncoderCodecs == codecs && w.dictEncoderKey == codecs.key {
+		return w.dictEncoder, nil
+	}
+	w.releaseDictEncoder()
+	enc, ok := codecs.encPool.Get().(*zstd.Encoder)
+	if !ok || enc == nil {
+		return nil, ErrMissingDict
+	}
+	w.dictEncoder = enc
+	w.dictEncoderCodecs = codecs
+	w.dictEncoderKey = codecs.key
+	return enc, nil
 }
 
 // SetBlockCompression configures grouped frame block compression for dictID=0
@@ -1552,7 +1589,10 @@ func (w *Writer) AppendFrameWithStatsInto(dictID uint64, dict []byte, records []
 			max = defaultBufferSize
 		}
 
-		enc := codecs.encPool.Get().(*zstd.Encoder)
+		enc, err := w.dictEncoderFor(codecs)
+		if err != nil {
+			return nil, FrameStats{}, err
+		}
 
 		canDirectEncodeAll := w.f != nil && (k == 1 || rawPayloadBytes <= (1<<20))
 		if canDirectEncodeAll {
@@ -1575,7 +1615,6 @@ func (w *Writer) AppendFrameWithStatsInto(dictID uint64, dict []byte, records []
 			}
 			if len(w.appendBuf)+recordMaxLen > max {
 				if err := w.flushAppendBuf(); err != nil {
-					codecs.encPool.Put(enc)
 					return nil, FrameStats{}, err
 				}
 			}
@@ -1603,7 +1642,6 @@ func (w *Writer) AppendFrameWithStatsInto(dictID uint64, dict []byte, records []
 				rid := records[i].RID
 				if rid == 0 {
 					w.appendBuf = w.appendBuf[:recordStart]
-					codecs.encPool.Put(enc)
 					return nil, FrameStats{}, errors.New("valuelog: missing rid")
 				}
 				binary.LittleEndian.PutUint64(prefix[prefixOff:prefixOff+8], rid)
@@ -1642,7 +1680,6 @@ func (w *Writer) AppendFrameWithStatsInto(dictID uint64, dict []byte, records []
 				w.appendBuf = enc.EncodeAll(payload, w.appendBuf)
 			}
 			encodeNs := w.sampleEncodeEnd(encodeStart, rawPayloadBytes, k)
-			codecs.encPool.Put(enc)
 
 			encodedLen := len(w.appendBuf) - encodedStart
 			keepCompressed := w.shouldKeepCompressed(rawPayloadBytes, encodedLen, encodeNs)
@@ -1765,7 +1802,6 @@ func (w *Writer) AppendFrameWithStatsInto(dictID uint64, dict []byte, records []
 			encoded = w.encLimiter.buf
 		}
 		encodeNs := w.sampleEncodeEnd(encodeStart, rawPayloadBytes, k)
-		codecs.encPool.Put(enc)
 		w.encScratch = w.encScratch[:0]
 
 		keepCompressed := false
@@ -2303,6 +2339,7 @@ func (w *Writer) Close() error {
 	if w == nil {
 		return nil
 	}
+	defer w.releaseDictEncoder()
 	defer w.releaseAppendBuf()
 	defer w.releaseTransientScratchBuffers()
 	if err := w.flushNoTrim(); err != nil {


### PR DESCRIPTION
Refs #3553

## Summary
- Keep one active dictionary zstd encoder strongly reachable on each `FramePreparer` across `TrimScratchForReuse` and repeated same-option setup.
- Keep one active dictionary zstd encoder strongly reachable on each value-log `Writer` across repeated direct append frames.
- Return retained encoders to the existing dict codec pool on `ResetForReuse`, writer `Close`, or encoder option/dict key changes.
- Add focused GC-forced benchmarks that reproduce the value-log dictionary compression allocation shape seen in Ironbird.

## Evidence
Artifacts from the original worker slice: `/mnt/fast4tb/tmp/treedb-3553-vlog-zstd-allocs/`

Original baseline benchmark before frame-preparer retention:
- `BenchmarkFramePreparerDictIronbirdLikeHistoryReuse-12`: 1.07-1.43 ms/op, ~9,315,000 B/op, 48 allocs/op
- baseline alloc profile top: `github.com/snissn/compress/zstd.(*fastBase).ensureHist` 192.25 MB flat / 229.80 MB total

After frame-preparer retention:
- `BenchmarkFramePreparerDictIronbirdLikeHistoryReuse-12`: 0.255-0.271 ms/op, 320 B/op, 0 allocs/op
- after alloc profile total: 42.55 MB, with remaining `ensureHist` from setup/warmup rather than per-iteration allocation as shown by benchmem

After extending the same retention policy to the direct writer path, local rerun on PR head `5d7e6ed5d`:
- `BenchmarkFramePreparerDictIronbirdLikeHistoryReuse-12`: 0.251-0.275 ms/op, 320-325 B/op, 0 allocs/op
- `BenchmarkWriterDictIronbirdLikeHistoryReuse-12`: 0.274-0.297 ms/op, 24-40 B/op, 1 alloc/op

## Tests
- `GOWORK=off TMPDIR=/mnt/fast4tb/tmp go test ./TreeDB/internal/valuelog`
- `GOWORK=off TMPDIR=/mnt/fast4tb/tmp go test ./TreeDB/internal/compression ./TreeDB/caching`
- `GOWORK=off TMPDIR=/mnt/fast4tb/tmp go test ./TreeDB/internal/valuelog -run '^$' -bench 'Benchmark(FramePreparer|Writer)DictIronbirdLikeHistoryReuse$' -benchmem -benchtime=20x -count=3`

## Ironbird Gate
This PR is intentionally not accepted on microbenchmarks alone. Coordinator validation must pin commit `5d7e6ed5d` in Ironbird and compare accepted plain-send first, then small-multisend if plain-send is neutral or better. Required macro checks are total allocation, TreeDB-attributed allocation including value-log compression dependencies, runtime TPS, and commit/finalize/check timing.
