### PR TITLE
TreeDB: reduce zipper delete writeRecursive allocations

### DIFF
--- a/TreeDB/zipper/zipper.go
+++ b/TreeDB/zipper/zipper.go
@@ -621,6 +621,29 @@ func (s *mergeScratch) cloneLeafRefCachePage(src []byte) []byte {
 	return p.buf[:]
 }
 
+// acquireLeafRefCacheBuildPage returns a page buffer whose lifetime is tied to
+// the active in-flight leaf-ref cache. Callers may let the cache adopt it, but
+// must not mutate it after persistence.
+func (s *mergeScratch) acquireLeafRefCacheBuildPage() []byte {
+	if s == nil {
+		return make([]byte, page.PageSize)
+	}
+	s.mu.Lock()
+	n := len(s.leafRefCachePages)
+	var p *leafRefCachePage
+	if n > 0 {
+		p = s.leafRefCachePages[n-1]
+		s.leafRefCachePages[n-1] = nil
+		s.leafRefCachePages = s.leafRefCachePages[:n-1]
+	} else {
+		p = &leafRefCachePage{}
+	}
+	s.leafRefCacheActivePages = append(s.leafRefCacheActivePages, p)
+	s.mu.Unlock()
+	clear(p.buf[:])
+	return p.buf[:]
+}
+
 func (s *mergeScratch) releaseLeafRefCachePages() {
 	if s == nil {
 		return
@@ -2257,6 +2280,10 @@ func (z *Zipper) writeRecursive(ref page.ChildRef, ops []batch.Entry, ranges []b
 				return page.ChildRef{}, nil, errors.New("zipper: outer leaves in value log enabled without leaf page log")
 			}
 			reuseOuterLeafPages := !maintenance
+			// Delete maintenance may reload freshly written leaf-log refs before
+			// Apply ends. Build those leaves into cache-owned pages so the cache
+			// can adopt stable bytes without per-leaf heap allocation here.
+			cacheOwnedOuterLeafPages := maintenance && scratch != nil && z.leafRefCacheActive.Load()
 			var (
 				newData       []byte
 				newDataPooled *outerLeafBuildPage
@@ -2264,6 +2291,8 @@ func (z *Zipper) writeRecursive(ref page.ChildRef, ops []batch.Entry, ranges []b
 			if reuseOuterLeafPages {
 				newDataPooled = scratch.acquireOuterLeafBuildPage()
 				newData = newDataPooled.buf[:]
+			} else if cacheOwnedOuterLeafPages {
+				newData = scratch.acquireLeafRefCacheBuildPage()
 			} else {
 				newData = make([]byte, page.PageSize)
 			}
@@ -2275,7 +2304,7 @@ func (z *Zipper) writeRecursive(ref page.ChildRef, ops []batch.Entry, ranges []b
 				}
 			}()
 			builder.SetPageID(0)
-			return z.mergeLeaf(&oldNode, builder, ops, ranges, metrics, scratch, reuseOuterLeafPages, cfg)
+			return z.mergeLeaf(&oldNode, builder, ops, ranges, metrics, scratch, reuseOuterLeafPages, cacheOwnedOuterLeafPages, cfg)
 		}
 
 		// Pager-backed leaf.
@@ -2290,7 +2319,7 @@ func (z *Zipper) writeRecursive(ref page.ChildRef, ops []batch.Entry, ranges []b
 		builder := z.newPooledLeafBuilder(newData, ops)
 		defer releasePooledBuilder(builder)
 		builder.SetPageID(newPageID)
-		return z.mergeLeaf(&oldNode, builder, ops, ranges, metrics, scratch, false, cfg)
+		return z.mergeLeaf(&oldNode, builder, ops, ranges, metrics, scratch, false, false, cfg)
 
 	case page.PageTypeInternal:
 		// Internal merge is always pager-backed.
@@ -2334,7 +2363,7 @@ func (z *Zipper) writeRecursive(ref page.ChildRef, ops []batch.Entry, ranges []b
 	return page.ChildRef{}, nil, page.ErrInvalidPageType
 }
 
-func (z *Zipper) mergeLeaf(oldNode *node.Node, builder *node.Builder, ops []batch.Entry, ranges []batch.DeleteRange, metrics *adaptive.Metrics, scratch *mergeScratch, reuseOuterLeafPages bool, cfg applyRunConfig) (page.ChildRef, []Split, error) {
+func (z *Zipper) mergeLeaf(oldNode *node.Node, builder *node.Builder, ops []batch.Entry, ranges []batch.DeleteRange, metrics *adaptive.Metrics, scratch *mergeScratch, reuseOuterLeafPages bool, cacheOwnedOuterLeafPages bool, cfg applyRunConfig) (page.ChildRef, []Split, error) {
 	if metrics != nil {
 		metrics.ZipperLeafMerges++
 	}
@@ -2610,6 +2639,8 @@ func (z *Zipper) mergeLeaf(oldNode *node.Node, builder *node.Builder, ops []batc
 				if reuseOuterLeafPages {
 					sdataPooled = scratch.acquireOuterLeafBuildPage()
 					sdata = sdataPooled.buf[:]
+				} else if cacheOwnedOuterLeafPages {
+					sdata = scratch.acquireLeafRefCacheBuildPage()
 				} else {
 					sdata = make([]byte, page.PageSize)
 				}

--- a/TreeDB/zipper/zipper_test.go
+++ b/TreeDB/zipper/zipper_test.go
@@ -538,6 +538,85 @@ func TestZipperLeafRefCacheReusesOwnedPagesWithoutServingScratchMutations(t *tes
 	}
 }
 
+func TestZipperLeafRefCacheAdoptsBuildPagesUntilCacheClose(t *testing.T) {
+	dir := t.TempDir()
+	p, err := pager.Open(filepath.Join(dir, "index.db"), 65536)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer p.Close()
+
+	alloc := &MockAllocator{p: p}
+	z := New(p, alloc)
+	z.SetOuterLeavesInValueLog(true)
+	z.SetLeafPageLog(&stubLeafPageLog{})
+	reader := &countingLeafPageReader{}
+	z.SetLeafPageReader(reader)
+
+	writeLeaf := func(dst []byte, key, val string) {
+		t.Helper()
+		clear(dst)
+		b := node.NewBuilder(dst, page.PageTypeLeaf)
+		b.SetPageID(0)
+		if err := b.AddLeafEntry([]byte(key), []byte(val), node.FlagInline, page.ValuePtr{}); err != nil {
+			t.Fatalf("AddLeafEntry(%q): %v", key, err)
+		}
+		b.FinishNoNode()
+	}
+
+	scratch := z.acquireApplyScratch()
+	z.beginLeafRefCache(scratch)
+
+	pageBuf := scratch.acquireLeafRefCacheBuildPage()
+	writeLeaf(pageBuf, "first", "one")
+	ref, err := z.persistLeafPageDataWithCacheOwnership(pageBuf, nil, leafPageCacheAdoptOwned)
+	if err != nil {
+		t.Fatalf("persist leaf: %v", err)
+	}
+
+	reusedWhileActive := scratch.acquireLeafRefCacheBuildPage()
+	if &reusedWhileActive[0] == &pageBuf[0] {
+		t.Fatalf("active cache build page was reused before cache close")
+	}
+
+	loaded, fromPager, leafScratch, leafScratchRef, loadSource, err := z.loadNodeRef(ref, scratch)
+	if err != nil {
+		t.Fatalf("loadNodeRef: %v", err)
+	}
+	if leafScratchRef {
+		releaseLeafPageScratch(scratch, leafScratch)
+	}
+	if fromPager {
+		t.Fatalf("fromPager=%t want false", fromPager)
+	}
+	if loadSource != zipperNodeLoadLeafLogCache {
+		t.Fatalf("loadSource=%d want leaf-log cache", loadSource)
+	}
+	gotKey, gotVal, _, flags, err := loaded.GetLeafEntryView(0)
+	if err != nil {
+		t.Fatalf("GetLeafEntryView: %v", err)
+	}
+	if flags != node.FlagInline || string(gotKey) != "first" || string(gotVal) != "one" {
+		t.Fatalf("cached leaf entry=(%q,%q flags=0x%x), want (first,one inline)", gotKey, gotVal, flags)
+	}
+
+	z.endLeafRefCache()
+	z.releaseApplyScratch(scratch)
+
+	reusedScratch := z.acquireApplyScratch()
+	z.beginLeafRefCache(reusedScratch)
+	reusedAfterClose := reusedScratch.acquireLeafRefCacheBuildPage()
+	if &reusedAfterClose[0] != &pageBuf[0] && &reusedAfterClose[0] != &reusedWhileActive[0] {
+		t.Fatalf("expected cache-owned build page reuse after cache close")
+	}
+	z.endLeafRefCache()
+	z.releaseApplyScratch(reusedScratch)
+
+	if got := reader.calls.Load(); got != 0 {
+		t.Fatalf("leafPageReader calls=%d want 0", got)
+	}
+}
+
 func TestZipperCachePersistedLeafPageNoopAvoidsLockWhenCacheInactive(t *testing.T) {
 	z := &Zipper{}
 	z.leafRefCacheMu.Lock()
@@ -1100,7 +1179,7 @@ func TestMergeLeaf_SplitKeysDoNotAliasBatchKeys(t *testing.T) {
 	scratch := newMergeScratch()
 
 	var metrics adaptive.Metrics
-	_, splits, err := z.mergeLeaf(oldNode, builder, ops, nil, &metrics, scratch, false, applyRunConfig{})
+	_, splits, err := z.mergeLeaf(oldNode, builder, ops, nil, &metrics, scratch, false, false, applyRunConfig{})
 	if err != nil {
 		t.Fatalf("mergeLeaf failed: %v", err)
 	}
@@ -1581,7 +1660,7 @@ func BenchmarkMergeLeafOuterLeafBatchScratch(b *testing.B) {
 		builder.SetPageID(0)
 		scratch := z.acquireApplyScratch()
 		var metrics adaptive.Metrics
-		_, _, err := z.mergeLeaf(oldNode, builder, ops, nil, &metrics, scratch, true, applyRunConfig{})
+		_, _, err := z.mergeLeaf(oldNode, builder, ops, nil, &metrics, scratch, true, false, applyRunConfig{})
 		z.releaseApplyScratch(scratch)
 		if err != nil {
 			b.Fatalf("mergeLeaf: %v", err)


### PR DESCRIPTION
## Summary

- Add cache-owned leaf build pages to `mergeScratch`, with lifetime tied to the active in-flight leaf-ref cache.
- Route delete-maintenance outer-leaf rewrites through those cache-owned pages so `writeRecursive` no longer allocates a fresh `make([]byte, page.PageSize)` per rewritten leaf when the leaf-ref cache is active.
- Keep the existing scratch isolation model: cache-owned pages stay active until `endLeafRefCache`, and span-native parallel workers still use separate apply scratch.
- Add a regression test that verifies cache-owned build pages are not reused while cache entries may serve them, but are reusable after the cache closes.

## Evidence

Required tests:

```sh
GOWORK=off go test ./TreeDB/zipper -run 'Zipper|MergeScratch|Split|Delete' -count=1
GOWORK=off go test ./TreeDB/caching -run 'Delete|Checkpoint|VLog|LeafRef' -count=1
```

Additional zipper package pass:

```sh
GOWORK=off go test ./TreeDB/zipper -count=1
```

Profile tool builds:

```sh
GOWORK=off go build -o ./bin/unified-bench ./cmd/unified_bench
GOWORK=off go build -o ./bin/benchprof ./cmd/benchprof
```

Short durable delete smoke, reduced to 100k keys because the machine was busy and the full 10M gate should be left to the main rollout:

```sh
RUN_ROOT=/tmp/gomap_alloc_loop_zipper_delete_smoke_20260706_044155
GOWORK=off GOMAXPROCS=8 TMPDIR="$RUN_ROOT/tmp" ./bin/unified-bench \
  -profile durable \
  -dbs treedb \
  -keys 100000 \
  -valsize 128 \
  -batchsize 8000 \
  -test batch_delete,random_delete \
  -checkpoint-between-tests \
  -treedb-journal-lanes=1 \
  -progress=false \
  -profile-dir "$RUN_ROOT/profiles" \
  -path-label native-fastpath \
  -format markdown | tee "$RUN_ROOT/unified_bench.md"
GOWORK=off ./bin/benchprof -profiles-dir "$RUN_ROOT/profiles" | tee "$RUN_ROOT/benchprof.txt"
```

Smoke artifacts:

- `/tmp/gomap_alloc_loop_zipper_delete_smoke_20260706_044155/unified_bench.md`
- `/tmp/gomap_alloc_loop_zipper_delete_smoke_20260706_044155/benchprof.txt`
- `/tmp/gomap_alloc_loop_zipper_delete_smoke_20260706_044155/profiles/insights.md`
- `/tmp/gomap_alloc_loop_zipper_delete_smoke_20260706_044155/profiles/allocs_batch_delete_treedb.pprof`
- `/tmp/gomap_alloc_loop_zipper_delete_smoke_20260706_044155/profiles/allocs_random_delete_treedb.pprof`

Smoke allocation top tables did not show `zipper.(*Zipper).writeRecursive` in the alloc_objects or alloc_space top entries for either delete test. Top entries were memtable/profile-writing paths at this reduced scale.

## Main rollout 10M durable allocation gate

Command: `GOWORK=off GOMAXPROCS=8 TMPDIR="/tmp" ./bin/unified-bench -profile durable -dbs treedb -keys 10000000 -valsize 128 -batchsize 8000 -test batch_delete,random_delete -checkpoint-between-tests -treedb-journal-lanes=1 -progress=false -profile-dir "/profiles" -path-label native-fastpath -format markdown` followed by `GOWORK=off ./bin/benchprof -profiles-dir "/profiles"`.

Artifacts:

- Baseline main: `/tmp/gomap_alloc_loop_3557_main_20260706_044654`
- PR head: `/tmp/gomap_alloc_loop_3557_pr_20260706_045012`

Throughput:

```text
Test           main ops/sec  PR ops/sec
batch_delete     2,415,812   4,032,227
random_delete      678,324   2,109,053
```

Allocation totals:

```text
Test           PR MiB  main MiB  delta MiB  PR objects  main objects  delta objects
batch_delete    3849      3974       -126      38,698        78,105       -39,407
random_delete   3543      5724     -2,181      41,399       469,368      -427,969
```

Top allocation-site movement:

```text
zipper.(*Zipper).writeRecursive alloc space: 1495 MiB -> 0 MiB in the focused top table
zipper.(*Zipper).cachePersistedLeafPage alloc space: 51 MiB -> 0 MiB
zipper.(*ReadOnlyPrepareResult).addLeafSpan alloc space: 143 MiB -> 0 MiB
```

## Residual risk

- The 10M durable gate was run by the main rollout and satisfies #3557 acceptance for the targeted delete workloads.
- This intentionally preserves the leaf-ref cache lifetime boundary: cache-owned build pages are retained until cache close, so the change targets allocation site/count in `writeRecursive` without sharing mutable scratch across concurrent workers.

Fixes #3557



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how recently written data is handled during updates and deletions, reducing the chance of stale or incorrectly reused page data.
  * Made cached page reuse safer and more consistent while leaf caching is active, which should improve reliability for write-heavy operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->