### PR TITLE
TreeDB: preserve append-only entry pool candidates

### DIFF
--- a/TreeDB/internal/memtable/append_only.go
+++ b/TreeDB/internal/memtable/append_only.go
@@ -525,7 +525,7 @@ func getAppendOnlyEntries(length int) []appendOnlyEntry {
 	if length < 0 {
 		length = 0
 	}
-	class, _, ok := appendOnlyEntryPoolClassForLength(length)
+	class, classCap, ok := appendOnlyEntryPoolClassForLength(length)
 	if !ok {
 		return make([]appendOnlyEntry, length)
 	}
@@ -543,6 +543,40 @@ func getAppendOnlyEntries(length int) []appendOnlyEntry {
 			appendOnlyEntryPoolMu.Unlock()
 			return entries[:length]
 		}
+	}
+	appendOnlyEntryPoolMu.Unlock()
+	return make([]appendOnlyEntry, length, classCap)
+}
+
+// getAppendOnlyEntriesWithMaxCapacity is for trim/reset paths where maxCapacity
+// is a hard retained-backing ceiling rather than pool class headroom.
+func getAppendOnlyEntriesWithMaxCapacity(length, maxCapacity int) []appendOnlyEntry {
+	if length < 0 {
+		length = 0
+	}
+	if maxCapacity < length {
+		maxCapacity = length
+	}
+	class, _, ok := appendOnlyEntryPoolClassForLength(length)
+	if !ok {
+		return make([]appendOnlyEntry, length)
+	}
+	appendOnlyEntryPoolMu.Lock()
+	bin := appendOnlyEntryPoolBins[class]
+	for i := len(bin) - 1; i >= 0; i-- {
+		entries := bin[i]
+		if cap(entries) < length || cap(entries) > maxCapacity || cap(entries) > appendOnlyMaxReuseEntries(length) {
+			continue
+		}
+		last := len(bin) - 1
+		bin[i] = bin[last]
+		bin[last] = nil
+		bin = bin[:last]
+		appendOnlyEntryPoolBins[class] = bin
+		appendOnlyEntryPoolGetTotal.Add(1)
+		subtractAppendOnlyEntryPoolRetainedBytes(appendOnlyEntryPoolBytes(cap(entries)))
+		appendOnlyEntryPoolMu.Unlock()
+		return entries[:length]
 	}
 	appendOnlyEntryPoolMu.Unlock()
 	return make([]appendOnlyEntry, length)
@@ -2085,7 +2119,7 @@ func (m *AppendOnly) TrimEntryCapacity(maxEntries int) (before, after int64) {
 	}
 
 	prev := m.entries
-	next := getAppendOnlyEntries(maxEntries)
+	next := getAppendOnlyEntriesWithMaxCapacity(maxEntries, maxEntries)
 	copy(next, m.entries[:m.count])
 	m.entries = next
 	if m.baseEntriesLen > maxEntries {
@@ -2330,7 +2364,7 @@ func (m *AppendOnly) resetLockedWithPolicy(capacity, estimatedBytesPerEntry int,
 
 	if !retainObserved {
 		if cap(m.entries) != retainedEntries {
-			m.replaceEntriesSliceWithPolicy(retainedEntries, true)
+			m.replaceEntriesSliceWithMaxCapacity(retainedEntries, retainedEntries, true)
 			return
 		}
 		if len(m.entries) != retainedEntries {
@@ -2371,6 +2405,17 @@ func (m *AppendOnly) replaceEntriesSliceWithPolicy(length int, poolPrev bool) {
 	}
 	prev := m.entries
 	m.entries = getAppendOnlyEntries(length)
+	if poolPrev {
+		putAppendOnlyEntries(prev)
+	}
+}
+
+func (m *AppendOnly) replaceEntriesSliceWithMaxCapacity(length, maxCapacity int, poolPrev bool) {
+	if length < 0 {
+		length = 0
+	}
+	prev := m.entries
+	m.entries = getAppendOnlyEntriesWithMaxCapacity(length, maxCapacity)
 	if poolPrev {
 		putAppendOnlyEntries(prev)
 	}

--- a/TreeDB/internal/memtable/append_only.go
+++ b/TreeDB/internal/memtable/append_only.go
@@ -525,51 +525,34 @@ func getAppendOnlyEntries(length int) []appendOnlyEntry {
 	if length < 0 {
 		length = 0
 	}
-	class, classCap, ok := appendOnlyEntryPoolClassForLength(length)
-	if !ok {
-		return make([]appendOnlyEntry, length)
-	}
-	appendOnlyEntryPoolMu.Lock()
-	bin := appendOnlyEntryPoolBins[class]
-	for len(bin) > 0 {
-		last := len(bin) - 1
-		entries := bin[last]
-		bin[last] = nil
-		bin = bin[:last]
-		appendOnlyEntryPoolBins[class] = bin
-		appendOnlyEntryPoolGetTotal.Add(1)
-		subtractAppendOnlyEntryPoolRetainedBytes(appendOnlyEntryPoolBytes(cap(entries)))
-		if cap(entries) >= length && cap(entries) <= appendOnlyMaxReuseEntries(length) {
-			appendOnlyEntryPoolMu.Unlock()
-			return entries[:length]
-		}
-	}
-	appendOnlyEntryPoolMu.Unlock()
-	return make([]appendOnlyEntry, length, classCap)
-}
-
-// getAppendOnlyEntriesWithMaxCapacity is for trim/reset paths where maxCapacity
-// is a hard retained-backing ceiling rather than pool class headroom.
-func getAppendOnlyEntriesWithMaxCapacity(length, maxCapacity int) []appendOnlyEntry {
-	if length < 0 {
-		length = 0
-	}
-	if maxCapacity < length {
-		maxCapacity = length
-	}
 	class, _, ok := appendOnlyEntryPoolClassForLength(length)
 	if !ok {
 		return make([]appendOnlyEntry, length)
 	}
 	appendOnlyEntryPoolMu.Lock()
 	bin := appendOnlyEntryPoolBins[class]
+	best := -1
+	bestCap := 0
+	maxReuse := appendOnlyMaxReuseEntries(length)
+	// Preserve smaller same-class buffers for future smaller requests instead
+	// of popping and discarding them while looking for a larger backing.
 	for i := len(bin) - 1; i >= 0; i-- {
-		entries := bin[i]
-		if cap(entries) < length || cap(entries) > maxCapacity || cap(entries) > appendOnlyMaxReuseEntries(length) {
+		capacity := cap(bin[i])
+		if capacity < length || capacity > maxReuse {
 			continue
 		}
+		if best < 0 || capacity < bestCap {
+			best = i
+			bestCap = capacity
+			if capacity == length {
+				break
+			}
+		}
+	}
+	if best >= 0 {
 		last := len(bin) - 1
-		bin[i] = bin[last]
+		entries := bin[best]
+		bin[best] = bin[last]
 		bin[last] = nil
 		bin = bin[:last]
 		appendOnlyEntryPoolBins[class] = bin
@@ -2119,7 +2102,7 @@ func (m *AppendOnly) TrimEntryCapacity(maxEntries int) (before, after int64) {
 	}
 
 	prev := m.entries
-	next := getAppendOnlyEntriesWithMaxCapacity(maxEntries, maxEntries)
+	next := getAppendOnlyEntries(maxEntries)
 	copy(next, m.entries[:m.count])
 	m.entries = next
 	if m.baseEntriesLen > maxEntries {
@@ -2364,7 +2347,7 @@ func (m *AppendOnly) resetLockedWithPolicy(capacity, estimatedBytesPerEntry int,
 
 	if !retainObserved {
 		if cap(m.entries) != retainedEntries {
-			m.replaceEntriesSliceWithMaxCapacity(retainedEntries, retainedEntries, true)
+			m.replaceEntriesSliceWithPolicy(retainedEntries, true)
 			return
 		}
 		if len(m.entries) != retainedEntries {
@@ -2405,17 +2388,6 @@ func (m *AppendOnly) replaceEntriesSliceWithPolicy(length int, poolPrev bool) {
 	}
 	prev := m.entries
 	m.entries = getAppendOnlyEntries(length)
-	if poolPrev {
-		putAppendOnlyEntries(prev)
-	}
-}
-
-func (m *AppendOnly) replaceEntriesSliceWithMaxCapacity(length, maxCapacity int, poolPrev bool) {
-	if length < 0 {
-		length = 0
-	}
-	prev := m.entries
-	m.entries = getAppendOnlyEntriesWithMaxCapacity(length, maxCapacity)
 	if poolPrev {
 		putAppendOnlyEntries(prev)
 	}

--- a/TreeDB/internal/memtable/append_only_pool_test.go
+++ b/TreeDB/internal/memtable/append_only_pool_test.go
@@ -154,65 +154,46 @@ func TestAppendOnlyEntryPoolStatsTrackRetainedBacking(t *testing.T) {
 	}
 }
 
-func TestGetAppendOnlyEntriesAllocatesReusableClassBacking(t *testing.T) {
+func TestGetAppendOnlyEntriesKeepsSmallerSameClassBacking(t *testing.T) {
 	DropAppendOnlyEntryPools()
 	t.Cleanup(DropAppendOnlyEntryPools)
 
-	length := appendOnlyMinInitialEntries + 1
-	_, classCap, ok := appendOnlyEntryPoolClassForLength(length)
+	smallLen := appendOnlyMinInitialEntries + 1
+	largeLen := appendOnlyMinInitialEntries * 2
+	smallClass, _, ok := appendOnlyEntryPoolClassForLength(smallLen)
 	if !ok {
-		t.Fatalf("test length %d should map to a retained pool class", length)
+		t.Fatalf("small length %d should map to a retained pool class", smallLen)
 	}
-	if classCap <= length {
-		t.Fatalf("test setup needs a rounded class: length=%d classCap=%d", length, classCap)
-	}
-
-	entries := getAppendOnlyEntries(length)
-	if len(entries) != length {
-		t.Fatalf("len(entries)=%d want %d", len(entries), length)
-	}
-	if cap(entries) != classCap {
-		t.Fatalf("cap(entries)=%d want class cap %d", cap(entries), classCap)
-	}
-
-	putAppendOnlyEntries(entries[:0])
-	reused := getAppendOnlyEntries(classCap)
-	if len(reused) != classCap {
-		t.Fatalf("len(reused)=%d want %d", len(reused), classCap)
-	}
-	if cap(reused) != classCap {
-		t.Fatalf("cap(reused)=%d want %d", cap(reused), classCap)
-	}
-	putAppendOnlyEntries(reused[:0])
-}
-
-func TestGetAppendOnlyEntriesWithMaxCapacityAllocatesExactOnMiss(t *testing.T) {
-	DropAppendOnlyEntryPools()
-	t.Cleanup(DropAppendOnlyEntryPools)
-
-	length := appendOnlyMinInitialEntries + 1
-	_, classCap, ok := appendOnlyEntryPoolClassForLength(length)
+	largeClass, _, ok := appendOnlyEntryPoolClassForLength(largeLen)
 	if !ok {
-		t.Fatalf("test length %d should map to a retained pool class", length)
+		t.Fatalf("large length %d should map to a retained pool class", largeLen)
 	}
-	if classCap <= length {
-		t.Fatalf("test setup needs a rounded class: length=%d classCap=%d", length, classCap)
+	if smallClass != largeClass {
+		t.Fatalf("test setup needs one pool class: small=%d large=%d", smallClass, largeClass)
 	}
 
-	entries := getAppendOnlyEntriesWithMaxCapacity(length, length)
-	if len(entries) != length {
-		t.Fatalf("len(entries)=%d want %d", len(entries), length)
-	}
-	if cap(entries) != length {
-		t.Fatalf("cap(entries)=%d want exact cap %d", cap(entries), length)
-	}
-	putAppendOnlyEntries(entries[:0])
+	large := make([]appendOnlyEntry, 0, largeLen)
+	small := make([]appendOnlyEntry, 0, smallLen)
+	putAppendOnlyEntries(large)
+	putAppendOnlyEntries(small)
 
-	reused := getAppendOnlyEntriesWithMaxCapacity(length, length)
-	if cap(reused) != length {
-		t.Fatalf("reused cap=%d want exact cap %d", cap(reused), length)
+	gotLarge := getAppendOnlyEntries(largeLen)
+	if cap(gotLarge) != largeLen {
+		t.Fatalf("large cap=%d want %d", cap(gotLarge), largeLen)
 	}
-	putAppendOnlyEntries(reused[:0])
+	if gotRetained, want := AppendOnlyEntryPoolStatsSnapshot().RetainedBytesEstimate, appendOnlyEntryPoolBytes(smallLen); gotRetained != want {
+		t.Fatalf("retained bytes after large get=%d want smaller backing retained %d", gotRetained, want)
+	}
+
+	gotSmall := getAppendOnlyEntries(smallLen)
+	if cap(gotSmall) != smallLen {
+		t.Fatalf("small cap=%d want %d", cap(gotSmall), smallLen)
+	}
+	if gotRetained := AppendOnlyEntryPoolStatsSnapshot().RetainedBytesEstimate; gotRetained != 0 {
+		t.Fatalf("retained bytes after small get=%d want 0", gotRetained)
+	}
+	putAppendOnlyEntries(gotLarge[:0])
+	putAppendOnlyEntries(gotSmall[:0])
 }
 
 func TestAppendOnlyEntryPoolRetainsBackingAcrossGC(t *testing.T) {

--- a/TreeDB/internal/memtable/append_only_pool_test.go
+++ b/TreeDB/internal/memtable/append_only_pool_test.go
@@ -154,6 +154,67 @@ func TestAppendOnlyEntryPoolStatsTrackRetainedBacking(t *testing.T) {
 	}
 }
 
+func TestGetAppendOnlyEntriesAllocatesReusableClassBacking(t *testing.T) {
+	DropAppendOnlyEntryPools()
+	t.Cleanup(DropAppendOnlyEntryPools)
+
+	length := appendOnlyMinInitialEntries + 1
+	_, classCap, ok := appendOnlyEntryPoolClassForLength(length)
+	if !ok {
+		t.Fatalf("test length %d should map to a retained pool class", length)
+	}
+	if classCap <= length {
+		t.Fatalf("test setup needs a rounded class: length=%d classCap=%d", length, classCap)
+	}
+
+	entries := getAppendOnlyEntries(length)
+	if len(entries) != length {
+		t.Fatalf("len(entries)=%d want %d", len(entries), length)
+	}
+	if cap(entries) != classCap {
+		t.Fatalf("cap(entries)=%d want class cap %d", cap(entries), classCap)
+	}
+
+	putAppendOnlyEntries(entries[:0])
+	reused := getAppendOnlyEntries(classCap)
+	if len(reused) != classCap {
+		t.Fatalf("len(reused)=%d want %d", len(reused), classCap)
+	}
+	if cap(reused) != classCap {
+		t.Fatalf("cap(reused)=%d want %d", cap(reused), classCap)
+	}
+	putAppendOnlyEntries(reused[:0])
+}
+
+func TestGetAppendOnlyEntriesWithMaxCapacityAllocatesExactOnMiss(t *testing.T) {
+	DropAppendOnlyEntryPools()
+	t.Cleanup(DropAppendOnlyEntryPools)
+
+	length := appendOnlyMinInitialEntries + 1
+	_, classCap, ok := appendOnlyEntryPoolClassForLength(length)
+	if !ok {
+		t.Fatalf("test length %d should map to a retained pool class", length)
+	}
+	if classCap <= length {
+		t.Fatalf("test setup needs a rounded class: length=%d classCap=%d", length, classCap)
+	}
+
+	entries := getAppendOnlyEntriesWithMaxCapacity(length, length)
+	if len(entries) != length {
+		t.Fatalf("len(entries)=%d want %d", len(entries), length)
+	}
+	if cap(entries) != length {
+		t.Fatalf("cap(entries)=%d want exact cap %d", cap(entries), length)
+	}
+	putAppendOnlyEntries(entries[:0])
+
+	reused := getAppendOnlyEntriesWithMaxCapacity(length, length)
+	if cap(reused) != length {
+		t.Fatalf("reused cap=%d want exact cap %d", cap(reused), length)
+	}
+	putAppendOnlyEntries(reused[:0])
+}
+
 func TestAppendOnlyEntryPoolRetainsBackingAcrossGC(t *testing.T) {
 	DropAppendOnlyEntryPools()
 	t.Cleanup(DropAppendOnlyEntryPools)

--- a/TreeDB/internal/memtable/append_only_reset_hard_test.go
+++ b/TreeDB/internal/memtable/append_only_reset_hard_test.go
@@ -64,7 +64,7 @@ func TestAppendOnlyResetWithCapacityHard_ClampsWarmReuseCapacity(t *testing.T) {
 	}
 }
 
-func TestAppendOnlyResetWithCapacityHard_BoundsRoundedClassBacking(t *testing.T) {
+func TestAppendOnlyResetWithCapacityHard_BoundsNonClassCapacity(t *testing.T) {
 	const (
 		capacityBytes          = 512 << 10
 		estimatedBytesPerEntry = 96

--- a/TreeDB/internal/memtable/append_only_reset_hard_test.go
+++ b/TreeDB/internal/memtable/append_only_reset_hard_test.go
@@ -64,6 +64,36 @@ func TestAppendOnlyResetWithCapacityHard_ClampsWarmReuseCapacity(t *testing.T) {
 	}
 }
 
+func TestAppendOnlyResetWithCapacityHard_BoundsRoundedClassBacking(t *testing.T) {
+	const (
+		capacityBytes          = 512 << 10
+		estimatedBytesPerEntry = 96
+	)
+
+	retainedEntries := appendOnlyInitialEntriesForCapacity(capacityBytes, estimatedBytesPerEntry)
+	_, classCap, ok := appendOnlyEntryPoolClassForLength(retainedEntries)
+	if !ok {
+		t.Fatalf("retained entry count %d should map to a pool class", retainedEntries)
+	}
+	if classCap <= retainedEntries {
+		t.Fatalf("test setup needs rounded class cap: retained=%d class=%d", retainedEntries, classCap)
+	}
+
+	mt := NewAppendOnlyWithEntryCapacity(classCap)
+	if got := cap(mt.entries); got <= retainedEntries {
+		t.Fatalf("test setup cap(entries)=%d want > %d", got, retainedEntries)
+	}
+
+	mt.ResetWithCapacityHard(capacityBytes, estimatedBytesPerEntry)
+
+	if got := cap(mt.entries); got != retainedEntries {
+		t.Fatalf("hard reset cap(entries)=%d want=%d", got, retainedEntries)
+	}
+	if got := mt.EntryBackingBytes(); got > int64(capacityBytes) {
+		t.Fatalf("hard reset backing bytes=%d want <= capacity %d", got, capacityBytes)
+	}
+}
+
 func TestAppendOnlyResetWithCapacityHardPoolsDisplacedBacking(t *testing.T) {
 	DropAppendOnlyEntryPools()
 	t.Cleanup(DropAppendOnlyEntryPools)


### PR DESCRIPTION
## Summary

Fixes #3555.

- Replace the rejected class-cap cold-miss allocation with exact-size allocation plus best-fit selection from the existing append-only entry pool bins.
- Preserve smaller same-class retained backings instead of popping and discarding them while serving a larger request.
- Keep hard reset/trim memory ceilings on the existing exact-size path; no separate allocation helper remains.

## Evidence

Main rollout evidence showed the first PR version was not acceptable:

```text
getAppendOnlyEntries flat alloc-space: 7649 MiB -> 5892 MiB (-23%)
getAppendOnlyEntriesWithMaxCapacity flat alloc-space: 0 -> 3385 MiB
combined entry-backing allocation: 7649 MiB -> 9277 MiB (+1628 MiB)
random_delete throughput: 1,565,273 -> 1,311,417 ops/sec
```

This revision removes `getAppendOnlyEntriesWithMaxCapacity` and avoids moving allocation into a helper.

Current-main 10M durable focused gate:

```text
base: /tmp/gomap_alloc_loop_main_a43089a_20260706_051531
pr:   /tmp/gomap_alloc_loop_3561_merge_a43089a_20260706_053205
head: 97f4ae4a3e08d3b0c6b1220718a0738dc7062eef
cmd:  GOWORK=off GOMAXPROCS=8 TMPDIR="$RUN_ROOT/tmp" ./bin/unified-bench -profile durable -dbs treedb -keys 10000000 -valsize 128 -batchsize 8000 -test sequential_write,random_write,batch_write_steady,dataset_write_sorted,random_delete -checkpoint-between-tests -treedb-journal-lanes=1 -progress=false -profile-dir "$RUN_ROOT/profiles" -path-label native-fastpath -format markdown
```

Throughput:

```text
test                  main ops/sec  pr ops/sec
sequential_write      2,107,526     2,510,038
random_write            321,246       652,845
batch_write_steady    1,903,769     2,212,983
dataset_write_sorted  1,195,150     1,661,978
random_delete           842,786     1,505,358
```

Allocation totals:

```text
test                  pr MiB  main MiB  delta MiB  pr objects  main objects  delta objects
sequential_write       1281      1196        +85      104778       140564         -35786
random_write           4297      5363      -1066      293764       222925         +70839
batch_write_steady     2294      2622       -328      219180       177882         +41298
dataset_write_sorted   1474      1697       -224      326075       352424         -26349
random_delete          4792      4802        -11      365618       448749         -83131
```

Filtered target-site deltas across the same five tests:

```text
function                                                                                 pr MiB  main MiB  delta MiB  pr objects  main objects  delta objects
TreeDB/internal/memtable.getAppendOnlyEntries                                              6453      7478      -1026          0         1304          -1304
TreeDB/caching.getEntrySlice                                                               1453      1896       -444          0            0              0
TreeDB/internal/memtable.(*AppendOnly).rebuildLatestIndexLocked                             190       172        +17      10826        26920         -16094
TreeDB/internal/memtable.(*AppendOnly).updateLatestIndexLocked                              742       711        +30     124291       105948         +18343
TreeDB/internal/memtable.(*appendOnlyKeyArena).alloc                                        313       311         +2     160312       159094          +1218
TreeDB/caching.getAppendOnlyDirectValueArenaChunk                                           689       598        +90      20383        18699          +1684
```

Net across the five-test gate: allocation space is down about 1.5 GiB, allocation objects are down about 33k, and no tested workload regressed throughput.

Tests run on the current-main merge commit:

```sh
GOWORK=off go test ./TreeDB/internal/memtable ./TreeDB/caching -run 'AppendOnly|MemoryStats|BatchArena|Memtable' -count=1
git diff --check HEAD~1..HEAD
```

Output:

```text
ok  	github.com/snissn/gomap/TreeDB/internal/memtable	0.974s
ok  	github.com/snissn/gomap/TreeDB/caching	1.484s
```

Read-only review found no blockers. Non-blocking coverage note: hard reset exact-cap behavior is covered on a pool miss, but not on a larger same-class pooled hit.

## Residual risk

The new pool lookup scans a retained size-class bin under the existing pool mutex to find the smallest suitable candidate. The 10M gate above did not show a throughput regression, but CI still needs to pass on the pushed merge commit.
