### PR TITLE
TreeDB: reuse batch shard entry scratch

### DIFF
--- a/TreeDB/caching/batch_aux_pool_test.go
+++ b/TreeDB/caching/batch_aux_pool_test.go
@@ -366,6 +366,144 @@ func TestBatchResetRetainsScratchShardEntriesForReuse(t *testing.T) {
 	}
 }
 
+func TestBatchUseSharedShardEntryScratchOnlyForShortSortedBatches(t *testing.T) {
+	b := &Batch{
+		entries:        make([]batch.Entry, batchSharedShardEntryScratchMaxEntries),
+		streamEligible: true,
+	}
+	if !b.useSharedShardEntryScratch() {
+		t.Fatalf("useSharedShardEntryScratch=false for short sorted batch")
+	}
+
+	b.entries = make([]batch.Entry, batchSharedShardEntryScratchMaxEntries+1)
+	if b.useSharedShardEntryScratch() {
+		t.Fatalf("useSharedShardEntryScratch=true for oversized sorted batch")
+	}
+
+	b.entries = b.entries[:100]
+	b.streamEligible = false
+	if b.useSharedShardEntryScratch() {
+		t.Fatalf("useSharedShardEntryScratch=true for random batch")
+	}
+}
+
+func TestBatchPooledShardEntryGroupsReleaseScratchBacking(t *testing.T) {
+	forceNormalPoolPressureForTest(t)
+	db := &DB{}
+	b := &Batch{
+		db:      db,
+		entries: db.getBatchEntries(4),
+	}
+	b.entries = append(b.entries,
+		batch.Entry{Key: []byte("a")},
+		batch.Entry{Key: []byte("b")},
+		batch.Entry{Key: []byte("c")},
+		batch.Entry{Key: []byte("d")},
+	)
+	groups := b.prepareScratchShardEntryGroups([]int{2, 2})
+	for i, op := range b.entries {
+		groups[i%2] = append(groups[i%2], op)
+	}
+	scratchPtr := unsafe.SliceData(b.shardEntryScratch[:cap(b.shardEntryScratch)])
+
+	b.Reset()
+	b.entries = append(b.entries,
+		batch.Entry{Key: []byte("e")},
+		batch.Entry{Key: []byte("f")},
+		batch.Entry{Key: []byte("g")},
+		batch.Entry{Key: []byte("h")},
+	)
+	groups = b.preparePooledShardEntryGroups([]int{2, 2})
+	if b.shardEntriesBackedByScratch {
+		t.Fatalf("preparePooledShardEntryGroups kept scratch-backed marker")
+	}
+	if b.shardEntryScratch != nil {
+		t.Fatalf("preparePooledShardEntryGroups retained scratch len/cap=%d/%d", len(b.shardEntryScratch), cap(b.shardEntryScratch))
+	}
+	for i, op := range b.entries {
+		groups[i%2] = append(groups[i%2], op)
+	}
+	if gotPtr0, gotPtr1 := unsafe.SliceData(groups[0]), unsafe.SliceData(groups[1]); gotPtr0 == gotPtr1 {
+		t.Fatalf("pooled shard groups alias after scratch release: %p", gotPtr0)
+	}
+
+	if err := b.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	gotScratch := db.getBatchShardEntries(4)
+	gotScratch = append(gotScratch, batch.Entry{})
+	if gotPtr := unsafe.SliceData(gotScratch); gotPtr != scratchPtr {
+		t.Fatalf("scratch backing was not returned through pooled path: got=%p want=%p", gotPtr, scratchPtr)
+	}
+	db.putBatchShardEntries(gotScratch)
+}
+
+func TestBatchScratchShardEntryGroupsReleasePooledBacking(t *testing.T) {
+	forceNormalPoolPressureForTest(t)
+	db := &DB{}
+	b := &Batch{
+		db:      db,
+		entries: db.getBatchEntries(4),
+	}
+	b.entries = append(b.entries,
+		batch.Entry{Key: []byte("a")},
+		batch.Entry{Key: []byte("b")},
+		batch.Entry{Key: []byte("c")},
+		batch.Entry{Key: []byte("d")},
+	)
+	groups := b.preparePooledShardEntryGroups([]int{2, 2})
+	for i, op := range b.entries {
+		groups[i%2] = append(groups[i%2], op)
+	}
+	pooled0Ptr := unsafe.SliceData(groups[0])
+	pooled1Ptr := unsafe.SliceData(groups[1])
+
+	b.Reset()
+	b.entries = append(b.entries,
+		batch.Entry{Key: []byte("e")},
+		batch.Entry{Key: []byte("f")},
+		batch.Entry{Key: []byte("g")},
+		batch.Entry{Key: []byte("h")},
+	)
+	groups = b.prepareScratchShardEntryGroups([]int{1, 3})
+	if !b.shardEntriesBackedByScratch {
+		t.Fatalf("prepareScratchShardEntryGroups did not mark scratch-backed groups")
+	}
+	for i, op := range b.entries {
+		idx := 1
+		if i == 0 {
+			idx = 0
+		}
+		groups[idx] = append(groups[idx], op)
+	}
+
+	db.batchAuxMu.Lock()
+	shardEntryLeases := len(db.batchShardEntriesLeases.slices)
+	db.batchAuxMu.Unlock()
+	if shardEntryLeases != 2 {
+		t.Fatalf("prepareScratchShardEntryGroups returned pooled leases=%d want 2", shardEntryLeases)
+	}
+
+	got0 := db.getBatchShardEntries(2)
+	got0 = append(got0, batch.Entry{})
+	got1 := db.getBatchShardEntries(2)
+	got1 = append(got1, batch.Entry{})
+	gotPtrs := map[uintptr]bool{
+		uintptr(unsafe.Pointer(unsafe.SliceData(got0))): true,
+		uintptr(unsafe.Pointer(unsafe.SliceData(got1))): true,
+	}
+	if !gotPtrs[uintptr(unsafe.Pointer(pooled0Ptr))] || !gotPtrs[uintptr(unsafe.Pointer(pooled1Ptr))] {
+		t.Fatalf("pooled shard backings were not returned before scratch reuse: got=%p/%p want=%p/%p",
+			unsafe.SliceData(got0), unsafe.SliceData(got1), pooled0Ptr, pooled1Ptr)
+	}
+	db.putBatchShardEntries(got0)
+	db.putBatchShardEntries(got1)
+
+	if err := b.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+}
+
 func TestBatchArenaChunkListLeaseReuseAndClear(t *testing.T) {
 	db := &DB{}
 

--- a/TreeDB/caching/batch_aux_pool_test.go
+++ b/TreeDB/caching/batch_aux_pool_test.go
@@ -211,6 +211,161 @@ func TestBatchReleaseShardEntryGroupsReturnsOuterAndInnerLeases(t *testing.T) {
 	}
 }
 
+func TestBatchScratchShardEntryGroupsUseSingleBacking(t *testing.T) {
+	db := &DB{}
+	b := &Batch{
+		db:      db,
+		entries: db.getBatchEntries(6),
+	}
+	b.entries = append(b.entries,
+		batch.Entry{Key: []byte("a")},
+		batch.Entry{Key: []byte("b")},
+		batch.Entry{Key: []byte("c")},
+		batch.Entry{Key: []byte("d")},
+		batch.Entry{Key: []byte("e")},
+		batch.Entry{Key: []byte("f")},
+	)
+	shardCounts := []int{2, 0, 3, 1}
+	shardIdxs := []int{0, 2, 0, 3, 2, 2}
+
+	groups := b.prepareScratchShardEntryGroups(shardCounts)
+	for i, op := range b.entries {
+		idx := shardIdxs[i]
+		groups[idx] = append(groups[idx], op)
+	}
+
+	if !b.shardEntriesBackedByScratch {
+		t.Fatalf("scratch shard entry groups not marked as scratch-backed")
+	}
+	if len(groups) != len(shardCounts) {
+		t.Fatalf("groups len=%d want %d", len(groups), len(shardCounts))
+	}
+	scratch := b.shardEntryScratch[:cap(b.shardEntryScratch)]
+	offset := 0
+	for shard, count := range shardCounts {
+		got := groups[shard]
+		if len(got) != count || cap(got) != count {
+			t.Fatalf("group %d len/cap=%d/%d want %d/%d", shard, len(got), cap(got), count, count)
+		}
+		if count == 0 {
+			if got != nil {
+				t.Fatalf("empty group %d = %#v, want nil", shard, got)
+			}
+			continue
+		}
+		if gotPtr, wantPtr := unsafe.SliceData(got), &scratch[offset]; gotPtr != wantPtr {
+			t.Fatalf("group %d backing ptr=%p want scratch offset %d ptr=%p", shard, gotPtr, offset, wantPtr)
+		}
+		offset += count
+	}
+	if offset != len(b.entries) {
+		t.Fatalf("partitioned entries=%d want %d", offset, len(b.entries))
+	}
+}
+
+func TestBatchResetRetainsScratchShardEntriesForReuse(t *testing.T) {
+	forceNormalPoolPressureForTest(t)
+	db := &DB{}
+	b := &Batch{
+		db:      db,
+		entries: db.getBatchEntries(4),
+	}
+	b.entries = append(b.entries,
+		batch.Entry{Key: []byte("a")},
+		batch.Entry{Key: []byte("b")},
+		batch.Entry{Key: []byte("c")},
+		batch.Entry{Key: []byte("d")},
+	)
+	groups := b.prepareScratchShardEntryGroups([]int{2, 2})
+	for i, op := range b.entries {
+		groups[i%2] = append(groups[i%2], op)
+	}
+	scratchPtr := unsafe.SliceData(b.shardEntryScratch[:cap(b.shardEntryScratch)])
+	groupsPtr := unsafe.SliceData(b.shardEntries[:cap(b.shardEntries)])
+
+	b.Reset()
+	if b.shardEntries == nil {
+		t.Fatalf("Reset released shardEntries")
+	}
+	if len(b.shardEntries) != 0 || cap(b.shardEntries) < 2 {
+		t.Fatalf("Reset shardEntries len/cap=%d/%d want 0/>=2", len(b.shardEntries), cap(b.shardEntries))
+	}
+	if b.shardEntryScratch == nil {
+		t.Fatalf("Reset released shardEntryScratch")
+	}
+	if len(b.shardEntryScratch) != 0 || cap(b.shardEntryScratch) < 4 {
+		t.Fatalf("Reset shardEntryScratch len/cap=%d/%d want 0/>=4", len(b.shardEntryScratch), cap(b.shardEntryScratch))
+	}
+	if !b.shardEntriesBackedByScratch {
+		t.Fatalf("Reset cleared scratch-backed marker")
+	}
+
+	db.batchAuxMu.Lock()
+	shardEntryLeases := len(db.batchShardEntriesLeases.slices)
+	shardEntryGroupLeases := len(db.batchShardEntryGroupsLeases.slices)
+	db.batchAuxMu.Unlock()
+	if shardEntryLeases != 0 {
+		t.Fatalf("Reset returned shard entry leases=%d want 0", shardEntryLeases)
+	}
+	if shardEntryGroupLeases != 0 {
+		t.Fatalf("Reset returned shard entry group leases=%d want 0", shardEntryGroupLeases)
+	}
+
+	b.entries = append(b.entries,
+		batch.Entry{Key: []byte("e")},
+		batch.Entry{Key: []byte("f")},
+		batch.Entry{Key: []byte("g")},
+		batch.Entry{Key: []byte("h")},
+	)
+	groups = b.prepareScratchShardEntryGroups([]int{1, 3})
+	if gotPtr := unsafe.SliceData(b.shardEntryScratch[:cap(b.shardEntryScratch)]); gotPtr != scratchPtr {
+		t.Fatalf("scratch backing was not retained: got=%p want=%p", gotPtr, scratchPtr)
+	}
+	if gotPtr := unsafe.SliceData(b.shardEntries[:cap(b.shardEntries)]); gotPtr != groupsPtr {
+		t.Fatalf("outer group backing was not retained: got=%p want=%p", gotPtr, groupsPtr)
+	}
+	for i, op := range b.entries {
+		idx := 1
+		if i == 0 {
+			idx = 0
+		}
+		groups[idx] = append(groups[idx], op)
+	}
+
+	if err := b.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	db.batchAuxMu.Lock()
+	shardEntryLeases = len(db.batchShardEntriesLeases.slices)
+	shardEntryGroupLeases = len(db.batchShardEntryGroupsLeases.slices)
+	db.batchAuxMu.Unlock()
+	if shardEntryLeases != 1 {
+		t.Fatalf("Close shard entry leases=%d want 1 scratch backing only", shardEntryLeases)
+	}
+	if shardEntryGroupLeases != 1 {
+		t.Fatalf("Close shard entry group leases=%d want 1 outer group backing", shardEntryGroupLeases)
+	}
+
+	gotScratch := db.getBatchShardEntries(4)
+	gotScratch = append(gotScratch, batch.Entry{})
+	if gotPtr := unsafe.SliceData(gotScratch); gotPtr != scratchPtr {
+		t.Fatalf("scratch backing was not returned: got=%p want=%p", gotPtr, scratchPtr)
+	}
+	db.putBatchShardEntries(gotScratch)
+
+	gotGroups := db.getBatchShardEntryGroups(2)
+	gotGroups = append(gotGroups, nil)
+	if gotPtr := unsafe.SliceData(gotGroups); gotPtr != groupsPtr {
+		t.Fatalf("outer group backing was not returned: got=%p want=%p", gotPtr, groupsPtr)
+	}
+	for i, entries := range gotGroups[:cap(gotGroups)] {
+		if entries != nil {
+			t.Fatalf("outer group retained inner entries at %d: cap=%d", i, cap(entries))
+		}
+	}
+}
+
 func TestBatchArenaChunkListLeaseReuseAndClear(t *testing.T) {
 	db := &DB{}
 

--- a/TreeDB/caching/batch_aux_pool_test.go
+++ b/TreeDB/caching/batch_aux_pool_test.go
@@ -211,6 +211,119 @@ func TestBatchReleaseShardEntryGroupsReturnsOuterAndInnerLeases(t *testing.T) {
 	}
 }
 
+func TestBatchScratchShardEntryGroupsUseSingleBacking(t *testing.T) {
+	db := &DB{}
+	b := &Batch{
+		db:      db,
+		entries: db.getBatchEntries(6),
+	}
+	b.entries = append(b.entries,
+		batch.Entry{Key: []byte("a")},
+		batch.Entry{Key: []byte("b")},
+		batch.Entry{Key: []byte("c")},
+		batch.Entry{Key: []byte("d")},
+		batch.Entry{Key: []byte("e")},
+		batch.Entry{Key: []byte("f")},
+	)
+	shardCounts := []int{2, 0, 3, 1}
+	shardIdxs := []int{0, 2, 0, 3, 2, 2}
+
+	groups := b.prepareScratchShardEntryGroups(shardCounts)
+	for i, op := range b.entries {
+		idx := shardIdxs[i]
+		groups[idx] = append(groups[idx], op)
+	}
+
+	if !b.shardEntriesBackedByScratch {
+		t.Fatalf("scratch shard entry groups not marked as scratch-backed")
+	}
+	if len(groups) != len(shardCounts) {
+		t.Fatalf("groups len=%d want %d", len(groups), len(shardCounts))
+	}
+	scratch := b.shardEntryScratch[:cap(b.shardEntryScratch)]
+	offset := 0
+	for shard, count := range shardCounts {
+		got := groups[shard]
+		if len(got) != count || cap(got) != count {
+			t.Fatalf("group %d len/cap=%d/%d want %d/%d", shard, len(got), cap(got), count, count)
+		}
+		if count == 0 {
+			if got != nil {
+				t.Fatalf("empty group %d = %#v, want nil", shard, got)
+			}
+			continue
+		}
+		if gotPtr, wantPtr := unsafe.SliceData(got), &scratch[offset]; gotPtr != wantPtr {
+			t.Fatalf("group %d backing ptr=%p want scratch offset %d ptr=%p", shard, gotPtr, offset, wantPtr)
+		}
+		offset += count
+	}
+	if offset != len(b.entries) {
+		t.Fatalf("partitioned entries=%d want %d", offset, len(b.entries))
+	}
+}
+
+func TestBatchResetReturnsScratchShardEntriesWithoutInnerAliases(t *testing.T) {
+	forceNormalPoolPressureForTest(t)
+	db := &DB{}
+	b := &Batch{
+		db:      db,
+		entries: db.getBatchEntries(4),
+	}
+	b.entries = append(b.entries,
+		batch.Entry{Key: []byte("a")},
+		batch.Entry{Key: []byte("b")},
+		batch.Entry{Key: []byte("c")},
+		batch.Entry{Key: []byte("d")},
+	)
+	groups := b.prepareScratchShardEntryGroups([]int{2, 2})
+	for i, op := range b.entries {
+		groups[i%2] = append(groups[i%2], op)
+	}
+	scratchPtr := unsafe.SliceData(b.shardEntryScratch[:cap(b.shardEntryScratch)])
+	groupsPtr := unsafe.SliceData(b.shardEntries[:cap(b.shardEntries)])
+
+	b.Reset()
+	if b.shardEntries != nil {
+		t.Fatalf("Reset retained shardEntries")
+	}
+	if b.shardEntryScratch != nil {
+		t.Fatalf("Reset retained shardEntryScratch")
+	}
+	if b.shardEntriesBackedByScratch {
+		t.Fatalf("Reset left scratch-backed marker set")
+	}
+
+	db.batchAuxMu.Lock()
+	shardEntryLeases := len(db.batchShardEntriesLeases.slices)
+	shardEntryGroupLeases := len(db.batchShardEntryGroupsLeases.slices)
+	db.batchAuxMu.Unlock()
+	if shardEntryLeases != 1 {
+		t.Fatalf("shard entry leases=%d want 1 scratch backing only", shardEntryLeases)
+	}
+	if shardEntryGroupLeases != 1 {
+		t.Fatalf("shard entry group leases=%d want 1 outer group backing", shardEntryGroupLeases)
+	}
+
+	gotScratch := db.getBatchShardEntries(4)
+	gotScratch = append(gotScratch, batch.Entry{})
+	if gotPtr := unsafe.SliceData(gotScratch); gotPtr != scratchPtr {
+		t.Fatalf("scratch backing was not returned: got=%p want=%p", gotPtr, scratchPtr)
+	}
+	db.putBatchShardEntries(gotScratch)
+
+	gotGroups := db.getBatchShardEntryGroups(2)
+	gotGroups = append(gotGroups, nil)
+	if gotPtr := unsafe.SliceData(gotGroups); gotPtr != groupsPtr {
+		t.Fatalf("outer group backing was not returned: got=%p want=%p", gotPtr, groupsPtr)
+	}
+	for i, entries := range gotGroups[:cap(gotGroups)] {
+		if entries != nil {
+			t.Fatalf("outer group retained inner entries at %d: cap=%d", i, cap(entries))
+		}
+	}
+}
+
 func TestBatchArenaChunkListLeaseReuseAndClear(t *testing.T) {
 	db := &DB{}
 

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -33584,6 +33584,10 @@ func (b *Batch) releaseShardEntryScratch() {
 	b.shardEntryScratch = nil
 }
 
+func (b *Batch) useSharedShardEntryScratch() bool {
+	return b != nil && b.streamEligible && len(b.entries) <= batchSharedShardEntryScratchMaxEntries
+}
+
 func (b *Batch) prepareScratchShardEntryGroups(shardCounts []int) [][]batch.Entry {
 	if b == nil || b.db == nil {
 		return nil
@@ -33596,7 +33600,17 @@ func (b *Batch) prepareScratchShardEntryGroups(shardCounts []int) [][]batch.Entr
 		}
 		shardEntries = b.db.getBatchShardEntryGroups(shardCount)
 	} else {
-		b.clearScratchShardEntryGroups()
+		if b.shardEntriesBackedByScratch {
+			b.clearScratchShardEntryGroups()
+		} else {
+			full := shardEntries[:cap(shardEntries)]
+			for i := range full {
+				if full[i] != nil {
+					b.db.putBatchShardEntries(full[i])
+					full[i] = nil
+				}
+			}
+		}
 	}
 	shardEntries = shardEntries[:shardCount]
 
@@ -33619,6 +33633,51 @@ func (b *Batch) prepareScratchShardEntryGroups(shardCounts []int) [][]batch.Entr
 	b.shardEntryScratch = scratch[:0]
 	b.shardEntries = shardEntries
 	b.shardEntriesBackedByScratch = true
+	return shardEntries
+}
+
+func (b *Batch) preparePooledShardEntryGroups(shardCounts []int) [][]batch.Entry {
+	if b == nil || b.db == nil {
+		return nil
+	}
+	if b.shardEntriesBackedByScratch {
+		b.releaseCurrentShardEntryGroups()
+		b.shardEntries = nil
+	}
+	if b.shardEntryScratch != nil {
+		b.releaseShardEntryScratch()
+	}
+
+	shardCount := len(shardCounts)
+	shardEntries := b.shardEntries
+	if cap(shardEntries) < shardCount {
+		if cap(shardEntries) > 0 {
+			b.releaseShardEntryGroups(shardEntries)
+		}
+		shardEntries = b.db.getBatchShardEntryGroups(shardCount)
+		shardEntries = shardEntries[:shardCount]
+	} else {
+		shardEntries = shardEntries[:shardCount]
+		for i := range shardEntries {
+			shardEntries[i] = shardEntries[i][:0]
+		}
+	}
+	b.shardEntries = shardEntries
+	b.shardEntriesBackedByScratch = false
+	for i, count := range shardCounts {
+		if count > 0 {
+			entries := shardEntries[i]
+			if cap(entries) < count {
+				if cap(entries) > 0 {
+					b.db.putBatchShardEntries(entries)
+				}
+				entries = b.db.getBatchShardEntries(count)
+			} else {
+				entries = entries[:0]
+			}
+			shardEntries[i] = entries
+		}
+	}
 	return shardEntries
 }
 
@@ -34434,6 +34493,9 @@ const (
 	batchHintEntriesMax    = 8192
 	streamSwitchMinEntries = 4096
 	streamSwitchMinBytes   = 1 << 20 // 1MiB
+	// Keep shared shard-entry scratch on short sorted batches; larger and random
+	// batches retain per-shard backing to avoid a single hot scratch slice.
+	batchSharedShardEntryScratchMaxEntries = 256
 	// Only fan out value-log appends across multiple lanes when a batch is large
 	// enough to amortize per-lane setup and goroutine overhead.
 	multiLaneValueLogMinRecords = 1024
@@ -35591,7 +35653,12 @@ func (b *Batch) writeRegularLocked(syncWrite bool, unlockWriteMu func()) error {
 			shard.mu.Unlock()
 		}
 	} else {
-		shardEntries := b.prepareScratchShardEntryGroups(shardCounts)
+		var shardEntries [][]batch.Entry
+		if b.useSharedShardEntryScratch() {
+			shardEntries = b.prepareScratchShardEntryGroups(shardCounts)
+		} else {
+			shardEntries = b.preparePooledShardEntryGroups(shardCounts)
+		}
 		for i, op := range b.entries {
 			idx := shardIdxs[i]
 			shardEntries[idx] = append(shardEntries[idx], op)

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -32426,6 +32426,7 @@ type Batch struct {
 	shardAdds                 []int64
 	shardCnts                 []int
 	shardEntries              [][]batch.Entry
+	shardEntryScratch         []batch.Entry
 	shardIdxSets              [][]int
 	maxEntries                int
 
@@ -32446,6 +32447,7 @@ type Batch struct {
 	commandWALAppend             func() error
 	valueCopyShard               *memShard
 	appendOnlyDirectValueCopier  func([]byte) []byte
+	shardEntriesBackedByScratch  bool
 
 	commandWALCompactReplay     bool
 	commandWALCompactRanges     []batch.DeleteRange
@@ -33404,6 +33406,9 @@ func (b *Batch) Reset() {
 	if b.shardEntries != nil {
 		b.shardEntries = b.shardEntries[:0]
 	}
+	if b.shardEntryScratch != nil {
+		b.shardEntryScratch = b.shardEntryScratch[:0]
+	}
 	if b.shardIdxSets != nil {
 		b.shardIdxSets = b.shardIdxSets[:0]
 	}
@@ -33536,6 +33541,85 @@ func (b *Batch) releaseShardEntryGroups(groups [][]batch.Entry) {
 		}
 	}
 	b.db.putBatchShardEntryGroups(full[:0])
+}
+
+func (b *Batch) clearScratchShardEntryGroups() {
+	if b == nil || !b.shardEntriesBackedByScratch {
+		return
+	}
+	if cap(b.shardEntries) > 0 {
+		full := b.shardEntries[:cap(b.shardEntries)]
+		clear(full)
+	}
+	b.shardEntriesBackedByScratch = false
+}
+
+func (b *Batch) releaseCurrentShardEntryGroups() {
+	if b == nil || b.db == nil {
+		return
+	}
+	if cap(b.shardEntries) == 0 {
+		b.shardEntriesBackedByScratch = false
+		return
+	}
+	if b.shardEntriesBackedByScratch {
+		full := b.shardEntries[:cap(b.shardEntries)]
+		clear(full)
+		b.db.putBatchShardEntryGroups(full[:0])
+		b.shardEntriesBackedByScratch = false
+		return
+	}
+	b.releaseShardEntryGroups(b.shardEntries)
+}
+
+func (b *Batch) releaseShardEntryScratch() {
+	if b == nil {
+		return
+	}
+	if b.db == nil || cap(b.shardEntryScratch) == 0 {
+		b.shardEntryScratch = nil
+		return
+	}
+	b.db.putBatchShardEntries(b.shardEntryScratch)
+	b.shardEntryScratch = nil
+}
+
+func (b *Batch) prepareScratchShardEntryGroups(shardCounts []int) [][]batch.Entry {
+	if b == nil || b.db == nil {
+		return nil
+	}
+	shardCount := len(shardCounts)
+	shardEntries := b.shardEntries
+	if cap(shardEntries) < shardCount {
+		if cap(shardEntries) > 0 {
+			b.releaseCurrentShardEntryGroups()
+		}
+		shardEntries = b.db.getBatchShardEntryGroups(shardCount)
+	} else {
+		b.clearScratchShardEntryGroups()
+	}
+	shardEntries = shardEntries[:shardCount]
+
+	entryCount := len(b.entries)
+	if cap(b.shardEntryScratch) < entryCount {
+		b.releaseShardEntryScratch()
+		b.shardEntryScratch = b.db.getBatchShardEntries(entryCount)
+	}
+	scratch := b.shardEntryScratch[:entryCount]
+	offset := 0
+	for i, count := range shardCounts {
+		if count <= 0 {
+			shardEntries[i] = nil
+			continue
+		}
+		next := offset + count
+		shardEntries[i] = scratch[offset:offset:next]
+		offset = next
+	}
+	b.shardEntryScratch = scratch[:0]
+	b.shardEntries = shardEntries
+	b.shardEntriesBackedByScratch = true
+	return shardEntries
 }
 
 func (b *Batch) updateBatchCopyHint() {
@@ -35507,34 +35591,7 @@ func (b *Batch) writeRegularLocked(syncWrite bool, unlockWriteMu func()) error {
 			shard.mu.Unlock()
 		}
 	} else {
-		shardEntries := b.shardEntries
-		if cap(shardEntries) < shardCount {
-			if cap(shardEntries) > 0 {
-				b.releaseShardEntryGroups(shardEntries)
-			}
-			shardEntries = b.db.getBatchShardEntryGroups(shardCount)
-			shardEntries = shardEntries[:shardCount]
-		} else {
-			shardEntries = shardEntries[:shardCount]
-			for i := range shardEntries {
-				shardEntries[i] = shardEntries[i][:0]
-			}
-		}
-		b.shardEntries = shardEntries
-		for i, count := range shardCounts {
-			if count > 0 {
-				entries := shardEntries[i]
-				if cap(entries) < count {
-					if cap(entries) > 0 {
-						b.db.putBatchShardEntries(entries)
-					}
-					entries = b.db.getBatchShardEntries(count)
-				} else {
-					entries = entries[:0]
-				}
-				shardEntries[i] = entries
-			}
-		}
+		shardEntries := b.prepareScratchShardEntryGroups(shardCounts)
 		for i, op := range b.entries {
 			idx := shardIdxs[i]
 			shardEntries[idx] = append(shardEntries[idx], op)
@@ -36244,7 +36301,10 @@ func (b *Batch) Close() error {
 		}
 	}
 	if b.db != nil && b.shardEntries != nil {
-		b.releaseShardEntryGroups(b.shardEntries)
+		b.releaseCurrentShardEntryGroups()
+	}
+	if b.db != nil && b.shardEntryScratch != nil {
+		b.releaseShardEntryScratch()
 	}
 	b.recycleCopyArenaChunks()
 	b.recyclePtrCopyArenaChunks()
@@ -36255,6 +36315,7 @@ func (b *Batch) Close() error {
 	b.shardAdds = nil
 	b.shardCnts = nil
 	b.shardEntries = nil
+	b.shardEntryScratch = nil
 	b.shardIdxSets = nil
 	b.firstKey = nil
 	b.lastKey = nil
@@ -36264,6 +36325,7 @@ func (b *Batch) Close() error {
 	b.conditionalTxnID = 0
 	b.valueCopyShard = nil
 	b.appendOnlyDirectValueCopier = nil
+	b.shardEntriesBackedByScratch = false
 	b.commandWALCompactReplay = false
 	b.commandWALCompactRanges = nil
 	b.commandWALCompactPointStart = 0

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -32426,6 +32426,7 @@ type Batch struct {
 	shardAdds                 []int64
 	shardCnts                 []int
 	shardEntries              [][]batch.Entry
+	shardEntryScratch         []batch.Entry
 	shardIdxSets              [][]int
 	maxEntries                int
 
@@ -32446,6 +32447,7 @@ type Batch struct {
 	commandWALAppend             func() error
 	valueCopyShard               *memShard
 	appendOnlyDirectValueCopier  func([]byte) []byte
+	shardEntriesBackedByScratch  bool
 
 	commandWALCompactReplay     bool
 	commandWALCompactRanges     []batch.DeleteRange
@@ -33402,7 +33404,20 @@ func (b *Batch) Reset() {
 		b.shardCnts = b.shardCnts[:0]
 	}
 	if b.shardEntries != nil {
-		b.shardEntries = b.shardEntries[:0]
+		if b.db != nil {
+			b.releaseCurrentShardEntryGroups()
+			b.shardEntries = nil
+		} else {
+			b.clearScratchShardEntryGroups()
+			b.shardEntries = b.shardEntries[:0]
+		}
+	}
+	if b.shardEntryScratch != nil {
+		if b.db != nil {
+			b.releaseShardEntryScratch()
+		} else {
+			b.shardEntryScratch = nil
+		}
 	}
 	if b.shardIdxSets != nil {
 		b.shardIdxSets = b.shardIdxSets[:0]
@@ -33536,6 +33551,85 @@ func (b *Batch) releaseShardEntryGroups(groups [][]batch.Entry) {
 		}
 	}
 	b.db.putBatchShardEntryGroups(full[:0])
+}
+
+func (b *Batch) clearScratchShardEntryGroups() {
+	if b == nil || !b.shardEntriesBackedByScratch {
+		return
+	}
+	if cap(b.shardEntries) > 0 {
+		full := b.shardEntries[:cap(b.shardEntries)]
+		clear(full)
+	}
+	b.shardEntriesBackedByScratch = false
+}
+
+func (b *Batch) releaseCurrentShardEntryGroups() {
+	if b == nil || b.db == nil {
+		return
+	}
+	if cap(b.shardEntries) == 0 {
+		b.shardEntriesBackedByScratch = false
+		return
+	}
+	if b.shardEntriesBackedByScratch {
+		full := b.shardEntries[:cap(b.shardEntries)]
+		clear(full)
+		b.db.putBatchShardEntryGroups(full[:0])
+		b.shardEntriesBackedByScratch = false
+		return
+	}
+	b.releaseShardEntryGroups(b.shardEntries)
+}
+
+func (b *Batch) releaseShardEntryScratch() {
+	if b == nil {
+		return
+	}
+	if b.db == nil || cap(b.shardEntryScratch) == 0 {
+		b.shardEntryScratch = nil
+		return
+	}
+	b.db.putBatchShardEntries(b.shardEntryScratch)
+	b.shardEntryScratch = nil
+}
+
+func (b *Batch) prepareScratchShardEntryGroups(shardCounts []int) [][]batch.Entry {
+	if b == nil || b.db == nil {
+		return nil
+	}
+	shardCount := len(shardCounts)
+	shardEntries := b.shardEntries
+	if cap(shardEntries) < shardCount {
+		if cap(shardEntries) > 0 {
+			b.releaseCurrentShardEntryGroups()
+		}
+		shardEntries = b.db.getBatchShardEntryGroups(shardCount)
+	} else {
+		b.clearScratchShardEntryGroups()
+	}
+	shardEntries = shardEntries[:shardCount]
+
+	entryCount := len(b.entries)
+	if cap(b.shardEntryScratch) < entryCount {
+		b.releaseShardEntryScratch()
+		b.shardEntryScratch = b.db.getBatchShardEntries(entryCount)
+	}
+	scratch := b.shardEntryScratch[:entryCount]
+	offset := 0
+	for i, count := range shardCounts {
+		if count <= 0 {
+			shardEntries[i] = nil
+			continue
+		}
+		next := offset + count
+		shardEntries[i] = scratch[offset:offset:next]
+		offset = next
+	}
+	b.shardEntryScratch = scratch[:0]
+	b.shardEntries = shardEntries
+	b.shardEntriesBackedByScratch = true
+	return shardEntries
 }
 
 func (b *Batch) updateBatchCopyHint() {
@@ -35507,34 +35601,7 @@ func (b *Batch) writeRegularLocked(syncWrite bool, unlockWriteMu func()) error {
 			shard.mu.Unlock()
 		}
 	} else {
-		shardEntries := b.shardEntries
-		if cap(shardEntries) < shardCount {
-			if cap(shardEntries) > 0 {
-				b.releaseShardEntryGroups(shardEntries)
-			}
-			shardEntries = b.db.getBatchShardEntryGroups(shardCount)
-			shardEntries = shardEntries[:shardCount]
-		} else {
-			shardEntries = shardEntries[:shardCount]
-			for i := range shardEntries {
-				shardEntries[i] = shardEntries[i][:0]
-			}
-		}
-		b.shardEntries = shardEntries
-		for i, count := range shardCounts {
-			if count > 0 {
-				entries := shardEntries[i]
-				if cap(entries) < count {
-					if cap(entries) > 0 {
-						b.db.putBatchShardEntries(entries)
-					}
-					entries = b.db.getBatchShardEntries(count)
-				} else {
-					entries = entries[:0]
-				}
-				shardEntries[i] = entries
-			}
-		}
+		shardEntries := b.prepareScratchShardEntryGroups(shardCounts)
 		for i, op := range b.entries {
 			idx := shardIdxs[i]
 			shardEntries[idx] = append(shardEntries[idx], op)
@@ -36244,7 +36311,10 @@ func (b *Batch) Close() error {
 		}
 	}
 	if b.db != nil && b.shardEntries != nil {
-		b.releaseShardEntryGroups(b.shardEntries)
+		b.releaseCurrentShardEntryGroups()
+	}
+	if b.db != nil && b.shardEntryScratch != nil {
+		b.releaseShardEntryScratch()
 	}
 	b.recycleCopyArenaChunks()
 	b.recyclePtrCopyArenaChunks()
@@ -36255,6 +36325,7 @@ func (b *Batch) Close() error {
 	b.shardAdds = nil
 	b.shardCnts = nil
 	b.shardEntries = nil
+	b.shardEntryScratch = nil
 	b.shardIdxSets = nil
 	b.firstKey = nil
 	b.lastKey = nil
@@ -36264,6 +36335,7 @@ func (b *Batch) Close() error {
 	b.conditionalTxnID = 0
 	b.valueCopyShard = nil
 	b.appendOnlyDirectValueCopier = nil
+	b.shardEntriesBackedByScratch = false
 	b.commandWALCompactReplay = false
 	b.commandWALCompactRanges = nil
 	b.commandWALCompactPointStart = 0

--- a/TreeDB/internal/valuelog/dict_frame_preparer_alloc_bench_test.go
+++ b/TreeDB/internal/valuelog/dict_frame_preparer_alloc_bench_test.go
@@ -1,0 +1,139 @@
+package valuelog
+
+import (
+	"io"
+	"runtime"
+	"testing"
+
+	"github.com/snissn/compress/zstd"
+	"github.com/snissn/gomap/TreeDB/page"
+)
+
+func BenchmarkFramePreparerDictIronbirdLikeHistoryReuse(b *testing.B) {
+	const (
+		dictID      = uint64(3553)
+		valueSize   = 4096
+		recordCount = 8
+		valueCount  = 128
+	)
+
+	values := make([][]byte, valueCount)
+	for i := range values {
+		values[i] = makeSyntheticDictSampleForBench(i, valueSize)
+	}
+	dict, err := buildBenchDictWithHistory(uint32(dictID), values, 32<<10)
+	if err != nil {
+		b.Fatalf("build dict: %v", err)
+	}
+
+	records := make([]Record, recordCount)
+	fillRecords := func(base int) {
+		for i := range records {
+			records[i] = Record{
+				RID:   uint64(base + i + 1),
+				Value: values[(base+i)%len(values)],
+			}
+		}
+	}
+
+	prep := NewFramePreparer()
+	prep.SetDictFrameEncoderOptions(zstd.SpeedFastest, false)
+	fillRecords(0)
+	body, stats, err := prep.PrepareFrameInto(nil, dictID, dict, records)
+	if err != nil {
+		b.Fatalf("warm PrepareFrameInto: %v", err)
+	}
+	if !stats.Attempted || !stats.Kept {
+		b.Fatalf("warm frame stats attempted=%v kept=%v raw=%d stored=%d", stats.Attempted, stats.Kept, stats.RawPayloadBytes, stats.StoredPayloadBytes)
+	}
+
+	b.ReportAllocs()
+	b.SetBytes(int64(valueSize * recordCount))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		// Two GC cycles clear sync.Pool victims, matching the Ironbird profile shape
+		// where pooled zstd encoders were repeatedly recreated between batches.
+		runtime.GC()
+		runtime.GC()
+		fillRecords(i * recordCount)
+		var prepErr error
+		body, stats, prepErr = prep.PrepareFrameInto(body[:0], dictID, dict, records)
+		if prepErr != nil {
+			b.Fatalf("PrepareFrameInto: %v", prepErr)
+		}
+		if !stats.Attempted || !stats.Kept {
+			b.Fatalf("frame stats attempted=%v kept=%v raw=%d stored=%d", stats.Attempted, stats.Kept, stats.RawPayloadBytes, stats.StoredPayloadBytes)
+		}
+		prep.TrimScratchForReuse()
+		prep.SetDictFrameEncoderOptions(zstd.SpeedFastest, false)
+	}
+	b.StopTimer()
+	runtime.KeepAlive(prep)
+	runtime.KeepAlive(body)
+}
+
+func BenchmarkWriterDictIronbirdLikeHistoryReuse(b *testing.B) {
+	const (
+		dictID      = uint64(3554)
+		valueSize   = 4096
+		recordCount = 8
+		valueCount  = 128
+	)
+
+	values := make([][]byte, valueCount)
+	for i := range values {
+		values[i] = makeSyntheticDictSampleForBench(i, valueSize)
+	}
+	dict, err := buildBenchDictWithHistory(uint32(dictID), values, 32<<10)
+	if err != nil {
+		b.Fatalf("build dict: %v", err)
+	}
+
+	records := make([]Record, recordCount)
+	fillRecords := func(base int) {
+		for i := range records {
+			records[i] = Record{
+				RID:   uint64(base + i + 1),
+				Value: values[(base+i)%len(values)],
+			}
+		}
+	}
+
+	writer := NewWriterWithSink(io.Discard, 1)
+	writer.SetDictFrameEncoderOptions(zstd.SpeedFastest, false)
+	defer func() {
+		if err := writer.Close(); err != nil {
+			b.Fatalf("close writer: %v", err)
+		}
+	}()
+
+	ptrs := make([]page.ValuePtr, recordCount)
+	fillRecords(0)
+	_, stats, err := writer.AppendFrameWithStatsInto(dictID, dict, records, ptrs)
+	if err != nil {
+		b.Fatalf("warm AppendFrameWithStatsInto: %v", err)
+	}
+	if !stats.Attempted || !stats.Kept {
+		b.Fatalf("warm frame stats attempted=%v kept=%v raw=%d stored=%d", stats.Attempted, stats.Kept, stats.RawPayloadBytes, stats.StoredPayloadBytes)
+	}
+
+	b.ReportAllocs()
+	b.SetBytes(int64(valueSize * recordCount))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		runtime.GC()
+		runtime.GC()
+		fillRecords(i * recordCount)
+		var appendErr error
+		_, stats, appendErr = writer.AppendFrameWithStatsInto(dictID, dict, records, ptrs)
+		if appendErr != nil {
+			b.Fatalf("AppendFrameWithStatsInto: %v", appendErr)
+		}
+		if !stats.Attempted || !stats.Kept {
+			b.Fatalf("frame stats attempted=%v kept=%v raw=%d stored=%d", stats.Attempted, stats.Kept, stats.RawPayloadBytes, stats.StoredPayloadBytes)
+		}
+	}
+	b.StopTimer()
+	runtime.KeepAlive(writer)
+	runtime.KeepAlive(ptrs)
+}

--- a/TreeDB/internal/valuelog/frame_preparer.go
+++ b/TreeDB/internal/valuelog/frame_preparer.go
@@ -25,6 +25,10 @@ type FramePreparer struct {
 	noBenefit  uint8
 	skipRemain uint16
 
+	dictEncoder       *zstd.Encoder
+	dictEncoderCodecs *dictCodecEntry
+	dictEncoderKey    dictCodecKey
+
 	dictFrameEncodeLevel   zstd.EncoderLevel
 	dictFrameEnableEntropy bool
 	blockCodec             BlockCodec
@@ -56,6 +60,7 @@ func (p *FramePreparer) ResetForReuse() {
 	if p == nil {
 		return
 	}
+	p.releaseDictEncoder()
 	p.TrimScratchForReuse()
 	p.skipDictID = 0
 	p.codecs = nil
@@ -74,9 +79,10 @@ func (p *FramePreparer) ResetForReuse() {
 	p.keepSafetyMargin = DefaultKeepSafetyMargin
 }
 
-// TrimScratchForReuse drops oversized temporary buffers while preserving codec
-// and compression-hint state. Long-lived prepare workers call this between
-// tasks so an occasional large frame does not pin unbounded scratch memory.
+// TrimScratchForReuse drops oversized temporary buffers while preserving codec,
+// active dictionary encoder, and compression-hint state. Long-lived prepare
+// workers call this between tasks so an occasional large frame does not pin
+// unbounded scratch memory.
 func (p *FramePreparer) TrimScratchForReuse() {
 	if p == nil {
 		return
@@ -99,11 +105,45 @@ func (p *FramePreparer) TrimScratchForReuse() {
 	p.encLimiter = limitedSliceWriter{}
 }
 
+func (p *FramePreparer) releaseDictEncoder() {
+	if p == nil || p.dictEncoder == nil {
+		return
+	}
+	if p.dictEncoderCodecs != nil && p.dictEncoderCodecs.encPool != nil {
+		p.dictEncoderCodecs.encPool.Put(p.dictEncoder)
+	}
+	p.dictEncoder = nil
+	p.dictEncoderCodecs = nil
+	p.dictEncoderKey = dictCodecKey{}
+}
+
+func (p *FramePreparer) dictEncoderFor(codecs *dictCodecEntry) (*zstd.Encoder, error) {
+	if p == nil || codecs == nil || codecs.encPool == nil {
+		return nil, ErrMissingDict
+	}
+	if p.dictEncoder != nil && p.dictEncoderCodecs == codecs && p.dictEncoderKey == codecs.key {
+		return p.dictEncoder, nil
+	}
+	p.releaseDictEncoder()
+	enc, ok := codecs.encPool.Get().(*zstd.Encoder)
+	if !ok || enc == nil {
+		return nil, ErrMissingDict
+	}
+	p.dictEncoder = enc
+	p.dictEncoderCodecs = codecs
+	p.dictEncoderKey = codecs.key
+	return enc, nil
+}
+
 func (p *FramePreparer) SetDictFrameEncoderOptions(level zstd.EncoderLevel, enableEntropy bool) {
 	if p == nil {
 		return
 	}
-	p.dictFrameEncodeLevel = normalizeDictFrameEncodeLevel(level)
+	level = normalizeDictFrameEncodeLevel(level)
+	if p.dictFrameEncodeLevel != level || p.dictFrameEnableEntropy != enableEntropy {
+		p.releaseDictEncoder()
+	}
+	p.dictFrameEncodeLevel = level
 	p.dictFrameEnableEntropy = enableEntropy
 	p.codecs = nil
 	p.skipDictID = 0
@@ -315,11 +355,13 @@ func (p *FramePreparer) PrepareFrameInto(dst []byte, dictID uint64, dict []byte,
 			return nil, FrameStats{}, ErrMissingDict
 		}
 
-		enc := codecs.encPool.Get().(*zstd.Encoder)
+		enc, err := p.dictEncoderFor(codecs)
+		if err != nil {
+			return nil, FrameStats{}, err
+		}
 		encodeStart := p.sampleEncodeStart()
 		encoded, encodeErr := p.encodePayload(enc, records, rawPayloadBytes)
 		encodeNs := p.sampleEncodeEnd(encodeStart, rawPayloadBytes, k)
-		codecs.encPool.Put(enc)
 		p.encScratch = p.encScratch[:0]
 
 		keepCompressed := false

--- a/TreeDB/internal/valuelog/valuelog_test.go
+++ b/TreeDB/internal/valuelog/valuelog_test.go
@@ -1740,6 +1740,144 @@ func TestFramePreparer_TrimScratchForReuseKeepsPolicyAndBoundsBuffers(t *testing
 	}
 }
 
+func TestFramePreparer_DictEncoderRetainedAcrossTrimAndSameOptions(t *testing.T) {
+	const dictID = uint64(3553)
+	dict, records := buildLargeDictCompressionFixture(t, dictID)
+	dict2, records2 := buildLargeDictCompressionFixture(t, dictID+1)
+
+	prep := NewFramePreparer()
+	prep.SetDictFrameEncoderOptions(zstd.SpeedFastest, false)
+	body, stats, err := prep.PrepareFrame(dictID, dict, records)
+	if err != nil {
+		t.Fatalf("PrepareFrame: %v", err)
+	}
+	if !stats.Attempted || !stats.Kept {
+		t.Fatalf("expected kept dict-compressed frame: attempted=%v kept=%v raw=%d stored=%d", stats.Attempted, stats.Kept, stats.RawPayloadBytes, stats.StoredPayloadBytes)
+	}
+	if prep.dictEncoder == nil || prep.dictEncoderCodecs == nil {
+		t.Fatalf("expected retained dict encoder")
+	}
+	retained := prep.dictEncoder
+	retainedKey := prep.dictEncoderKey
+
+	prep.TrimScratchForReuse()
+	if prep.dictEncoder != retained || prep.dictEncoderKey != retainedKey {
+		t.Fatalf("trim released retained dict encoder")
+	}
+
+	prep.SetDictFrameEncoderOptions(zstd.SpeedFastest, false)
+	if prep.dictEncoder != retained || prep.dictEncoderKey != retainedKey {
+		t.Fatalf("same encoder options released retained dict encoder")
+	}
+	body, stats, err = prep.PrepareFrameInto(body[:0], dictID, dict, records)
+	if err != nil {
+		t.Fatalf("second PrepareFrameInto: %v", err)
+	}
+	if !stats.Attempted || !stats.Kept {
+		t.Fatalf("expected second kept dict-compressed frame: attempted=%v kept=%v raw=%d stored=%d", stats.Attempted, stats.Kept, stats.RawPayloadBytes, stats.StoredPayloadBytes)
+	}
+	if prep.dictEncoder != retained || prep.dictEncoderKey != retainedKey {
+		t.Fatalf("second frame did not reuse retained dict encoder")
+	}
+
+	prep.SetDictFrameEncoderOptions(zstd.SpeedDefault, false)
+	if prep.dictEncoder != nil || prep.dictEncoderCodecs != nil || prep.dictEncoderKey != (dictCodecKey{}) {
+		t.Fatalf("option change retained dict encoder state: encoder=%p codecs=%p key=%+v", prep.dictEncoder, prep.dictEncoderCodecs, prep.dictEncoderKey)
+	}
+	body, stats, err = prep.PrepareFrameInto(body[:0], dictID, dict, records)
+	if err != nil {
+		t.Fatalf("third PrepareFrameInto after option change: %v", err)
+	}
+	if !stats.Attempted || !stats.Kept {
+		t.Fatalf("expected third kept dict-compressed frame: attempted=%v kept=%v raw=%d stored=%d", stats.Attempted, stats.Kept, stats.RawPayloadBytes, stats.StoredPayloadBytes)
+	}
+	if prep.dictEncoder == nil || prep.dictEncoderCodecs == nil {
+		t.Fatalf("expected retained dict encoder after option change")
+	}
+	reacquired := prep.dictEncoder
+	reacquiredKey := prep.dictEncoderKey
+	if reacquiredKey == retainedKey {
+		t.Fatalf("option change reused old encoder key: encoder=%p key=%+v", reacquired, reacquiredKey)
+	}
+
+	body, stats, err = prep.PrepareFrameInto(body[:0], dictID+1, dict2, records2)
+	if err != nil {
+		t.Fatalf("fourth PrepareFrameInto after dict change: %v", err)
+	}
+	if !stats.Attempted || !stats.Kept {
+		t.Fatalf("expected fourth kept dict-compressed frame: attempted=%v kept=%v raw=%d stored=%d", stats.Attempted, stats.Kept, stats.RawPayloadBytes, stats.StoredPayloadBytes)
+	}
+	if prep.dictEncoder == nil || prep.dictEncoderCodecs == nil {
+		t.Fatalf("expected retained dict encoder after dict change")
+	}
+	if prep.dictEncoderKey == reacquiredKey {
+		t.Fatalf("dict change reused old encoder key: encoder=%p key=%+v", prep.dictEncoder, prep.dictEncoderKey)
+	}
+
+	prep.ResetForReuse()
+	if prep.dictEncoder != nil || prep.dictEncoderCodecs != nil || prep.dictEncoderKey != (dictCodecKey{}) {
+		t.Fatalf("reset retained dict encoder state: encoder=%p codecs=%p key=%+v", prep.dictEncoder, prep.dictEncoderCodecs, prep.dictEncoderKey)
+	}
+}
+
+func TestWriter_DictEncoderRetainedAcrossFramesAndReleasedOnClose(t *testing.T) {
+	const dictID = uint64(3554)
+	dict, records := buildLargeDictCompressionFixture(t, dictID)
+
+	w := NewWriterWithSink(io.Discard, page.ValueLogFileID(1))
+	w.SetDictFrameEncoderOptions(zstd.SpeedFastest, false)
+	dst := make([]page.ValuePtr, len(records))
+	_, stats, err := w.AppendFrameWithStatsInto(dictID, dict, records, dst)
+	if err != nil {
+		t.Fatalf("AppendFrameWithStatsInto: %v", err)
+	}
+	if !stats.Attempted || !stats.Kept {
+		t.Fatalf("expected kept dict-compressed frame: attempted=%v kept=%v raw=%d stored=%d", stats.Attempted, stats.Kept, stats.RawPayloadBytes, stats.StoredPayloadBytes)
+	}
+	if w.dictEncoder == nil || w.dictEncoderCodecs == nil {
+		t.Fatalf("expected retained dict encoder")
+	}
+	retained := w.dictEncoder
+	retainedKey := w.dictEncoderKey
+
+	_, stats, err = w.AppendFrameWithStatsInto(dictID, dict, records, dst)
+	if err != nil {
+		t.Fatalf("second AppendFrameWithStatsInto: %v", err)
+	}
+	if !stats.Attempted || !stats.Kept {
+		t.Fatalf("expected second kept dict-compressed frame: attempted=%v kept=%v raw=%d stored=%d", stats.Attempted, stats.Kept, stats.RawPayloadBytes, stats.StoredPayloadBytes)
+	}
+	if w.dictEncoder != retained || w.dictEncoderKey != retainedKey {
+		t.Fatalf("second frame did not reuse retained dict encoder")
+	}
+
+	w.SetDictFrameEncoderOptions(zstd.SpeedFastest, false)
+	if w.dictEncoder != retained || w.dictEncoderKey != retainedKey {
+		t.Fatalf("same encoder options released retained dict encoder")
+	}
+	w.SetDictFrameEncoderOptions(zstd.SpeedDefault, false)
+	if w.dictEncoder != nil || w.dictEncoderCodecs != nil || w.dictEncoderKey != (dictCodecKey{}) {
+		t.Fatalf("option change retained dict encoder state: encoder=%p codecs=%p key=%+v", w.dictEncoder, w.dictEncoderCodecs, w.dictEncoderKey)
+	}
+
+	_, stats, err = w.AppendFrameWithStatsInto(dictID, dict, records, dst)
+	if err != nil {
+		t.Fatalf("third AppendFrameWithStatsInto: %v", err)
+	}
+	if !stats.Attempted || !stats.Kept {
+		t.Fatalf("expected third kept dict-compressed frame: attempted=%v kept=%v raw=%d stored=%d", stats.Attempted, stats.Kept, stats.RawPayloadBytes, stats.StoredPayloadBytes)
+	}
+	if w.dictEncoder == nil || w.dictEncoderCodecs == nil {
+		t.Fatalf("expected retained dict encoder after option change")
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if w.dictEncoder != nil || w.dictEncoderCodecs != nil || w.dictEncoderKey != (dictCodecKey{}) {
+		t.Fatalf("close retained dict encoder state: encoder=%p codecs=%p key=%+v", w.dictEncoder, w.dictEncoderCodecs, w.dictEncoderKey)
+	}
+}
+
 func TestFramePreparer_KeepPolicySkipsCompression(t *testing.T) {
 	records := []Record{
 		{RID: 1, Value: bytes.Repeat([]byte("alpha-001|"), 32)},

--- a/TreeDB/internal/valuelog/writer.go
+++ b/TreeDB/internal/valuelog/writer.go
@@ -77,6 +77,9 @@ type Writer struct {
 	blockCodecScratch      blockCodecScratch
 	skipDictID             uint64
 	codecs                 *dictCodecEntry
+	dictEncoder            *zstd.Encoder
+	dictEncoderCodecs      *dictCodecEntry
+	dictEncoderKey         dictCodecKey
 	dictFrameEncodeLevel   zstd.EncoderLevel
 	dictFrameEnableEntropy bool
 	blockCodec             BlockCodec
@@ -560,12 +563,46 @@ func (w *Writer) SetDictFrameEncoderOptions(level zstd.EncoderLevel, enableEntro
 	if w == nil {
 		return
 	}
-	w.dictFrameEncodeLevel = normalizeDictFrameEncodeLevel(level)
+	level = normalizeDictFrameEncodeLevel(level)
+	if w.dictFrameEncodeLevel != level || w.dictFrameEnableEntropy != enableEntropy {
+		w.releaseDictEncoder()
+	}
+	w.dictFrameEncodeLevel = level
 	w.dictFrameEnableEntropy = enableEntropy
 	w.codecs = nil
 	w.skipDictID = 0
 	w.noBenefit = 0
 	w.skipRemain = 0
+}
+
+func (w *Writer) releaseDictEncoder() {
+	if w == nil || w.dictEncoder == nil {
+		return
+	}
+	if w.dictEncoderCodecs != nil && w.dictEncoderCodecs.encPool != nil {
+		w.dictEncoderCodecs.encPool.Put(w.dictEncoder)
+	}
+	w.dictEncoder = nil
+	w.dictEncoderCodecs = nil
+	w.dictEncoderKey = dictCodecKey{}
+}
+
+func (w *Writer) dictEncoderFor(codecs *dictCodecEntry) (*zstd.Encoder, error) {
+	if w == nil || codecs == nil || codecs.encPool == nil {
+		return nil, ErrMissingDict
+	}
+	if w.dictEncoder != nil && w.dictEncoderCodecs == codecs && w.dictEncoderKey == codecs.key {
+		return w.dictEncoder, nil
+	}
+	w.releaseDictEncoder()
+	enc, ok := codecs.encPool.Get().(*zstd.Encoder)
+	if !ok || enc == nil {
+		return nil, ErrMissingDict
+	}
+	w.dictEncoder = enc
+	w.dictEncoderCodecs = codecs
+	w.dictEncoderKey = codecs.key
+	return enc, nil
 }
 
 // SetBlockCompression configures grouped frame block compression for dictID=0
@@ -1552,7 +1589,10 @@ func (w *Writer) AppendFrameWithStatsInto(dictID uint64, dict []byte, records []
 			max = defaultBufferSize
 		}
 
-		enc := codecs.encPool.Get().(*zstd.Encoder)
+		enc, err := w.dictEncoderFor(codecs)
+		if err != nil {
+			return nil, FrameStats{}, err
+		}
 
 		canDirectEncodeAll := w.f != nil && (k == 1 || rawPayloadBytes <= (1<<20))
 		if canDirectEncodeAll {
@@ -1575,7 +1615,6 @@ func (w *Writer) AppendFrameWithStatsInto(dictID uint64, dict []byte, records []
 			}
 			if len(w.appendBuf)+recordMaxLen > max {
 				if err := w.flushAppendBuf(); err != nil {
-					codecs.encPool.Put(enc)
 					return nil, FrameStats{}, err
 				}
 			}
@@ -1603,7 +1642,6 @@ func (w *Writer) AppendFrameWithStatsInto(dictID uint64, dict []byte, records []
 				rid := records[i].RID
 				if rid == 0 {
 					w.appendBuf = w.appendBuf[:recordStart]
-					codecs.encPool.Put(enc)
 					return nil, FrameStats{}, errors.New("valuelog: missing rid")
 				}
 				binary.LittleEndian.PutUint64(prefix[prefixOff:prefixOff+8], rid)
@@ -1642,7 +1680,6 @@ func (w *Writer) AppendFrameWithStatsInto(dictID uint64, dict []byte, records []
 				w.appendBuf = enc.EncodeAll(payload, w.appendBuf)
 			}
 			encodeNs := w.sampleEncodeEnd(encodeStart, rawPayloadBytes, k)
-			codecs.encPool.Put(enc)
 
 			encodedLen := len(w.appendBuf) - encodedStart
 			keepCompressed := w.shouldKeepCompressed(rawPayloadBytes, encodedLen, encodeNs)
@@ -1765,7 +1802,6 @@ func (w *Writer) AppendFrameWithStatsInto(dictID uint64, dict []byte, records []
 			encoded = w.encLimiter.buf
 		}
 		encodeNs := w.sampleEncodeEnd(encodeStart, rawPayloadBytes, k)
-		codecs.encPool.Put(enc)
 		w.encScratch = w.encScratch[:0]
 
 		keepCompressed := false
@@ -2303,6 +2339,7 @@ func (w *Writer) Close() error {
 	if w == nil {
 		return nil
 	}
+	defer w.releaseDictEncoder()
 	defer w.releaseAppendBuf()
 	defer w.releaseTransientScratchBuffers()
 	if err := w.flushNoTrim(); err != nil {

--- a/TreeDB/zipper/zipper.go
+++ b/TreeDB/zipper/zipper.go
@@ -621,6 +621,29 @@ func (s *mergeScratch) cloneLeafRefCachePage(src []byte) []byte {
 	return p.buf[:]
 }
 
+// acquireLeafRefCacheBuildPage returns a page buffer whose lifetime is tied to
+// the active in-flight leaf-ref cache. Callers may let the cache adopt it, but
+// must not mutate it after persistence.
+func (s *mergeScratch) acquireLeafRefCacheBuildPage() []byte {
+	if s == nil {
+		return make([]byte, page.PageSize)
+	}
+	s.mu.Lock()
+	n := len(s.leafRefCachePages)
+	var p *leafRefCachePage
+	if n > 0 {
+		p = s.leafRefCachePages[n-1]
+		s.leafRefCachePages[n-1] = nil
+		s.leafRefCachePages = s.leafRefCachePages[:n-1]
+	} else {
+		p = &leafRefCachePage{}
+	}
+	s.leafRefCacheActivePages = append(s.leafRefCacheActivePages, p)
+	s.mu.Unlock()
+	clear(p.buf[:])
+	return p.buf[:]
+}
+
 func (s *mergeScratch) releaseLeafRefCachePages() {
 	if s == nil {
 		return
@@ -2257,6 +2280,10 @@ func (z *Zipper) writeRecursive(ref page.ChildRef, ops []batch.Entry, ranges []b
 				return page.ChildRef{}, nil, errors.New("zipper: outer leaves in value log enabled without leaf page log")
 			}
 			reuseOuterLeafPages := !maintenance
+			// Delete maintenance may reload freshly written leaf-log refs before
+			// Apply ends. Build those leaves into cache-owned pages so the cache
+			// can adopt stable bytes without per-leaf heap allocation here.
+			cacheOwnedOuterLeafPages := maintenance && scratch != nil && z.leafRefCacheActive.Load()
 			var (
 				newData       []byte
 				newDataPooled *outerLeafBuildPage
@@ -2264,6 +2291,8 @@ func (z *Zipper) writeRecursive(ref page.ChildRef, ops []batch.Entry, ranges []b
 			if reuseOuterLeafPages {
 				newDataPooled = scratch.acquireOuterLeafBuildPage()
 				newData = newDataPooled.buf[:]
+			} else if cacheOwnedOuterLeafPages {
+				newData = scratch.acquireLeafRefCacheBuildPage()
 			} else {
 				newData = make([]byte, page.PageSize)
 			}
@@ -2275,7 +2304,7 @@ func (z *Zipper) writeRecursive(ref page.ChildRef, ops []batch.Entry, ranges []b
 				}
 			}()
 			builder.SetPageID(0)
-			return z.mergeLeaf(&oldNode, builder, ops, ranges, metrics, scratch, reuseOuterLeafPages, cfg)
+			return z.mergeLeaf(&oldNode, builder, ops, ranges, metrics, scratch, reuseOuterLeafPages, cacheOwnedOuterLeafPages, cfg)
 		}
 
 		// Pager-backed leaf.
@@ -2290,7 +2319,7 @@ func (z *Zipper) writeRecursive(ref page.ChildRef, ops []batch.Entry, ranges []b
 		builder := z.newPooledLeafBuilder(newData, ops)
 		defer releasePooledBuilder(builder)
 		builder.SetPageID(newPageID)
-		return z.mergeLeaf(&oldNode, builder, ops, ranges, metrics, scratch, false, cfg)
+		return z.mergeLeaf(&oldNode, builder, ops, ranges, metrics, scratch, false, false, cfg)
 
 	case page.PageTypeInternal:
 		// Internal merge is always pager-backed.
@@ -2334,7 +2363,7 @@ func (z *Zipper) writeRecursive(ref page.ChildRef, ops []batch.Entry, ranges []b
 	return page.ChildRef{}, nil, page.ErrInvalidPageType
 }
 
-func (z *Zipper) mergeLeaf(oldNode *node.Node, builder *node.Builder, ops []batch.Entry, ranges []batch.DeleteRange, metrics *adaptive.Metrics, scratch *mergeScratch, reuseOuterLeafPages bool, cfg applyRunConfig) (page.ChildRef, []Split, error) {
+func (z *Zipper) mergeLeaf(oldNode *node.Node, builder *node.Builder, ops []batch.Entry, ranges []batch.DeleteRange, metrics *adaptive.Metrics, scratch *mergeScratch, reuseOuterLeafPages bool, cacheOwnedOuterLeafPages bool, cfg applyRunConfig) (page.ChildRef, []Split, error) {
 	if metrics != nil {
 		metrics.ZipperLeafMerges++
 	}
@@ -2610,6 +2639,8 @@ func (z *Zipper) mergeLeaf(oldNode *node.Node, builder *node.Builder, ops []batc
 				if reuseOuterLeafPages {
 					sdataPooled = scratch.acquireOuterLeafBuildPage()
 					sdata = sdataPooled.buf[:]
+				} else if cacheOwnedOuterLeafPages {
+					sdata = scratch.acquireLeafRefCacheBuildPage()
 				} else {
 					sdata = make([]byte, page.PageSize)
 				}

--- a/TreeDB/zipper/zipper_test.go
+++ b/TreeDB/zipper/zipper_test.go
@@ -538,6 +538,85 @@ func TestZipperLeafRefCacheReusesOwnedPagesWithoutServingScratchMutations(t *tes
 	}
 }
 
+func TestZipperLeafRefCacheAdoptsBuildPagesUntilCacheClose(t *testing.T) {
+	dir := t.TempDir()
+	p, err := pager.Open(filepath.Join(dir, "index.db"), 65536)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer p.Close()
+
+	alloc := &MockAllocator{p: p}
+	z := New(p, alloc)
+	z.SetOuterLeavesInValueLog(true)
+	z.SetLeafPageLog(&stubLeafPageLog{})
+	reader := &countingLeafPageReader{}
+	z.SetLeafPageReader(reader)
+
+	writeLeaf := func(dst []byte, key, val string) {
+		t.Helper()
+		clear(dst)
+		b := node.NewBuilder(dst, page.PageTypeLeaf)
+		b.SetPageID(0)
+		if err := b.AddLeafEntry([]byte(key), []byte(val), node.FlagInline, page.ValuePtr{}); err != nil {
+			t.Fatalf("AddLeafEntry(%q): %v", key, err)
+		}
+		b.FinishNoNode()
+	}
+
+	scratch := z.acquireApplyScratch()
+	z.beginLeafRefCache(scratch)
+
+	pageBuf := scratch.acquireLeafRefCacheBuildPage()
+	writeLeaf(pageBuf, "first", "one")
+	ref, err := z.persistLeafPageDataWithCacheOwnership(pageBuf, nil, leafPageCacheAdoptOwned)
+	if err != nil {
+		t.Fatalf("persist leaf: %v", err)
+	}
+
+	reusedWhileActive := scratch.acquireLeafRefCacheBuildPage()
+	if &reusedWhileActive[0] == &pageBuf[0] {
+		t.Fatalf("active cache build page was reused before cache close")
+	}
+
+	loaded, fromPager, leafScratch, leafScratchRef, loadSource, err := z.loadNodeRef(ref, scratch)
+	if err != nil {
+		t.Fatalf("loadNodeRef: %v", err)
+	}
+	if leafScratchRef {
+		releaseLeafPageScratch(scratch, leafScratch)
+	}
+	if fromPager {
+		t.Fatalf("fromPager=%t want false", fromPager)
+	}
+	if loadSource != zipperNodeLoadLeafLogCache {
+		t.Fatalf("loadSource=%d want leaf-log cache", loadSource)
+	}
+	gotKey, gotVal, _, flags, err := loaded.GetLeafEntryView(0)
+	if err != nil {
+		t.Fatalf("GetLeafEntryView: %v", err)
+	}
+	if flags != node.FlagInline || string(gotKey) != "first" || string(gotVal) != "one" {
+		t.Fatalf("cached leaf entry=(%q,%q flags=0x%x), want (first,one inline)", gotKey, gotVal, flags)
+	}
+
+	z.endLeafRefCache()
+	z.releaseApplyScratch(scratch)
+
+	reusedScratch := z.acquireApplyScratch()
+	z.beginLeafRefCache(reusedScratch)
+	reusedAfterClose := reusedScratch.acquireLeafRefCacheBuildPage()
+	if &reusedAfterClose[0] != &pageBuf[0] && &reusedAfterClose[0] != &reusedWhileActive[0] {
+		t.Fatalf("expected cache-owned build page reuse after cache close")
+	}
+	z.endLeafRefCache()
+	z.releaseApplyScratch(reusedScratch)
+
+	if got := reader.calls.Load(); got != 0 {
+		t.Fatalf("leafPageReader calls=%d want 0", got)
+	}
+}
+
 func TestZipperCachePersistedLeafPageNoopAvoidsLockWhenCacheInactive(t *testing.T) {
 	z := &Zipper{}
 	z.leafRefCacheMu.Lock()
@@ -1100,7 +1179,7 @@ func TestMergeLeaf_SplitKeysDoNotAliasBatchKeys(t *testing.T) {
 	scratch := newMergeScratch()
 
 	var metrics adaptive.Metrics
-	_, splits, err := z.mergeLeaf(oldNode, builder, ops, nil, &metrics, scratch, false, applyRunConfig{})
+	_, splits, err := z.mergeLeaf(oldNode, builder, ops, nil, &metrics, scratch, false, false, applyRunConfig{})
 	if err != nil {
 		t.Fatalf("mergeLeaf failed: %v", err)
 	}
@@ -1581,7 +1660,7 @@ func BenchmarkMergeLeafOuterLeafBatchScratch(b *testing.B) {
 		builder.SetPageID(0)
 		scratch := z.acquireApplyScratch()
 		var metrics adaptive.Metrics
-		_, _, err := z.mergeLeaf(oldNode, builder, ops, nil, &metrics, scratch, true, applyRunConfig{})
+		_, _, err := z.mergeLeaf(oldNode, builder, ops, nil, &metrics, scratch, true, false, applyRunConfig{})
 		z.releaseApplyScratch(scratch)
 		if err != nil {
 			b.Fatalf("mergeLeaf: %v", err)


### PR DESCRIPTION
## Summary

Fixes #3556.

This is now a deliberately narrow batch-helper allocation change in `TreeDB/caching/db.go`:

- short sorted regular batches (`streamEligible` and `<=256` entries) use one reusable `Batch.shardEntryScratch` backing slice partitioned into exact-cap per-shard views;
- larger or random regular batches use the previous per-shard `getBatchShardEntries(count)` behavior;
- mixed reusable-batch transitions are covered so scratch-backed groups and pooled per-shard groups are returned without aliasing or losing ownership.

Key/value backing policy and storage semantics are unchanged; this only changes transient `batch.Entry` helper backing while routing batch entries to mutable shards.

## Scope Boundary

- In scope: `TreeDB/caching/db.go` batch helper pools and regular batch write helper path; focused `TreeDB/caching` tests.
- Out of scope: append-only entry backing policy (#3555), zipper changes (#3557/#3559), benchmark harness changes, storage format changes.
- Current branch head: `924af9a857f21eeb3eedd4015aea08859b74a376`.
- Current `origin/main`: `a43089a3c6e1def40e31afa269104c5e6bf5caf5` (`treedb: retain value-log zstd encoders`).

## Gate History / Diagnosis

The first shared-scratch revision was not merge-ready. It improved `batch_small_seq` but regressed `random_write` badly on the stale-main 10M focused durable gate.

The reset-retention revision at `15dcc97319a75b23bae15ca206bb300150f9048f` was also not merge-ready against current main. User-provided paired artifacts:

- main: `/tmp/gomap_alloc_loop_3563_order_main_a43089a_20260706_054647`
- PR: `/tmp/gomap_alloc_loop_3563_pr_a43089a_20260706_054847`

Throughput:

| Test | main ops/sec | PR ops/sec | Status |
| --- | ---: | ---: | --- |
| `batch_small_seq` | 4,044,096 | 4,705,595 | ok |
| `batch_random` | 497,062 | 385,080 | fail, -22.5% |
| `random_write` | 269,251 | 184,124 | fail, -31.6% |

Allocation totals:

| Test | main allocs | PR allocs | Status |
| --- | --- | --- | --- |
| `batch_small_seq` | 3703 MiB / 585569 objs | 3577 MiB / 504362 objs | ok |
| `batch_random` | 5222 MiB / 730113 objs | 5182 MiB / 707962 objs | ok |
| `random_write` | 4863 MiB / 201984 objs | 4615 MiB / 249719 objs | object count worse |

Focused function movement included `getBatchShardEntries` improvements at `Batch.Reserve`, but worse movement in `getBatchArena`, `getEntrySlice`, and `mergeSplitSegment.append`. The likely lesson is that a single shared shard-entry backing slice is good for the pathological `batch_small_seq` shape, but too disruptive for large/random workloads.

This revision therefore keeps shared scratch only for short sorted batches. `batch_small_seq` hard-codes batch size 100 in `cmd/unified_bench`; `batch_random` uses the configured `-batchsize 8000` and now returns to the older per-shard helper path.

## Tests / Evidence

Commands run locally on revised branch head `924af9a857f21eeb3eedd4015aea08859b74a376`:

```sh
GOWORK=off go test ./TreeDB/caching -run 'Batch.*Arena|BatchAux|BatchFollowup|BatchSize|NewBatch|TestBatchScratchShardEntryGroupsUseSingleBacking|TestBatchResetRetainsScratchShardEntriesForReuse|TestBatchUseSharedShardEntryScratchOnlyForShortSortedBatches|TestBatchPooledShardEntryGroupsReleaseScratchBacking|TestBatchScratchShardEntryGroupsReleasePooledBacking' -count=1
# ok github.com/snissn/gomap/TreeDB/caching 2.010s

git diff --check
# pass
```

A new local 10M gate was not run for this revision; leave that to the main rollout before merge.

## Performance Gate Status

Not merge-ready yet. The narrowed revision needs the focused 10M durable before/after gate rerun against current `origin/main`:

- target: reduce `getBatchShardEntries` allocation count and combined `getEntrySlice`/`getBatchArena`/`getBatchEntries` allocation-space footprint by at least 20%;
- target: no ops/sec drop greater than 5% in `batch_small_seq,batch_random,random_write`.

If this narrowed version still cannot preserve `batch_random` and `random_write` throughput/object counts, #3556 should be closed as plateau/not worth merging.

## Review / Merge Status

- CI: queued/in progress for latest head at PR update.
- AI review: CodeRabbit is pending/rate-limited on latest head; no substantive latest-head AI review findings are being claimed.
- Merge: do not merge yet; pending full focused durable gate validation.
