### PR TITLE
treedb: stream stable canonical flush iterators

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -14373,7 +14373,7 @@ func (it *opRunIter) Key() []byte {
 }
 
 type opMergeItem struct {
-	iter     *opRunIter
+	iter     canonicalOpIter
 	priority int
 	key      []byte
 }

--- a/TreeDB/caching/flush_build_runs_test.go
+++ b/TreeDB/caching/flush_build_runs_test.go
@@ -3,6 +3,7 @@ package caching
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -218,6 +219,89 @@ func (it *unstableRunIterator) Error() error             { return nil }
 func (it *unstableRunIterator) Close() error             { return nil }
 func (it *unstableRunIterator) Domain() ([]byte, []byte) { return nil, nil }
 
+type stableRunTable struct {
+	unstableRunTable
+	iterErr    error
+	closeErr   error
+	closeCount *int
+}
+
+func (t *stableRunTable) StableUnsafeIteratorSlices() bool { return true }
+
+func (t *stableRunTable) NewIterator(start, end []byte) iterator.UnsafeIterator {
+	return &stableRunIterator{
+		entries:    t.entries,
+		iterErr:    t.iterErr,
+		closeErr:   t.closeErr,
+		closeCount: t.closeCount,
+	}
+}
+
+func (t *stableRunTable) NewReverseIterator(start, end []byte) iterator.UnsafeIterator {
+	return t.NewIterator(start, end)
+}
+
+type stableRunIterator struct {
+	entries    []batch.Entry
+	idx        int
+	iterErr    error
+	closeErr   error
+	closeCount *int
+}
+
+func (it *stableRunIterator) Valid() bool     { return it.idx < len(it.entries) }
+func (it *stableRunIterator) Next()           { it.idx++ }
+func (it *stableRunIterator) Seek(key []byte) {}
+func (it *stableRunIterator) Key() []byte     { return it.UnsafeKey() }
+func (it *stableRunIterator) Value() []byte   { return it.UnsafeValue() }
+func (it *stableRunIterator) KeyCopy(dst []byte) []byte {
+	return append(dst[:0], it.UnsafeKey()...)
+}
+func (it *stableRunIterator) ValueCopy(dst []byte) []byte {
+	return append(dst[:0], it.UnsafeValue()...)
+}
+func (it *stableRunIterator) UnsafeKey() []byte {
+	if !it.Valid() {
+		return nil
+	}
+	return it.entries[it.idx].Key
+}
+func (it *stableRunIterator) UnsafeValue() []byte {
+	if !it.Valid() || it.entries[it.idx].Type == batch.OpDelete || it.entries[it.idx].IsPtr {
+		return nil
+	}
+	return it.entries[it.idx].Value
+}
+func (it *stableRunIterator) UnsafeEntry() ([]byte, page.ValuePtr, byte) {
+	val, ptr, flags, _ := it.UnsafeEntryWithRevision()
+	return val, ptr, flags
+}
+func (it *stableRunIterator) UnsafeEntryWithRevision() ([]byte, page.ValuePtr, byte, page.EntryRevision) {
+	if !it.Valid() {
+		return nil, page.ValuePtr{}, 0, page.LegacyEntryRevision
+	}
+	entry := it.entries[it.idx]
+	switch {
+	case entry.Type == batch.OpDelete:
+		return nil, page.ValuePtr{}, node.FlagTombstone, entry.Revision
+	case entry.IsPtr:
+		return nil, entry.ValuePtr, node.FlagPointer, entry.Revision
+	default:
+		return entry.Value, page.ValuePtr{}, node.FlagInline, entry.Revision
+	}
+}
+func (it *stableRunIterator) IsDeleted() bool {
+	return it.Valid() && it.entries[it.idx].Type == batch.OpDelete
+}
+func (it *stableRunIterator) Error() error { return it.iterErr }
+func (it *stableRunIterator) Close() error {
+	if it.closeCount != nil {
+		(*it.closeCount)++
+	}
+	return it.closeErr
+}
+func (it *stableRunIterator) Domain() ([]byte, []byte) { return nil, nil }
+
 func TestBuildOpRunsCopiesUnstableIteratorScratch(t *testing.T) {
 	tbl := &unstableRunTable{entries: []batch.Entry{
 		{Type: batch.OpPut, Key: []byte("k1"), Value: []byte("v1")},
@@ -245,6 +329,143 @@ func TestBuildOpRunsCopiesUnstableIteratorScratch(t *testing.T) {
 	copy(it.(*unstableRunIterator).valBuf, []byte("YY"))
 	if string(runs[0][0].Key) != "k1" || string(runs[0][0].Value) != "v1" {
 		t.Fatalf("run retained unstable iterator scratch: key=%q value=%q", runs[0][0].Key, runs[0][0].Value)
+	}
+}
+
+func TestMergeCanonicalStableIteratorUnitsDuplicateTombstonePointer(t *testing.T) {
+	older := memtable.NewAppendOnlyWithEntryCapacity(4)
+	older.Set([]byte("dup"), []byte("old"))
+	older.Set([]byte("old-only"), []byte("kept-old"))
+	older.Freeze()
+
+	ptr := page.ValuePtr{FileID: 7, Offset: 88, Length: 9}
+	newer := memtable.NewAppendOnlyWithEntryCapacity(4)
+	newer.Set([]byte("dup"), []byte("new"))
+	newer.Delete([]byte("gone"))
+	newer.SetEntry([]byte("ptr"), nil, ptr, node.FlagPointer)
+	newer.Freeze()
+
+	units := []flushUnit{{mem: older}, {mem: newer}}
+	db := &DB{}
+	if !db.canStreamCanonicalPointUnitsFromStableIterators(units, 0) {
+		t.Fatalf("stable append-only units were not eligible for iterator streaming")
+	}
+
+	sourcePointOps, sourceDeleteOps, err := countCanonicalStableIteratorUnits(units)
+	if err != nil {
+		t.Fatalf("countCanonicalStableIteratorUnits: %v", err)
+	}
+	if sourcePointOps != 5 || sourceDeleteOps != 1 {
+		t.Fatalf("source counts=(%d,%d) want (5,1)", sourcePointOps, sourceDeleteOps)
+	}
+
+	run := &canonicalFlushRun{
+		sourceMemtables: len(units),
+		sourcePointOps:  sourcePointOps,
+		deletePointOps:  sourceDeleteOps,
+	}
+	var out []batch.Entry
+	if err := mergeCanonicalStableIteratorUnits(units, run, func(entry batch.Entry) error {
+		out = append(out, entry)
+		return nil
+	}); err != nil {
+		t.Fatalf("mergeCanonicalStableIteratorUnits: %v", err)
+	}
+
+	if run.shadowedPointOps != 1 || run.plannedPointOps != 4 || run.deletePointOps != 1 {
+		t.Fatalf("run stats shadowed/planned/deletes=(%d,%d,%d), want (1,4,1)", run.shadowedPointOps, run.plannedPointOps, run.deletePointOps)
+	}
+	if len(out) != 4 {
+		t.Fatalf("merged entries=%d want 4: %+v", len(out), out)
+	}
+	want := []struct {
+		key   string
+		op    batch.OpType
+		value string
+		ptr   page.ValuePtr
+		isPtr bool
+	}{
+		{key: "dup", op: batch.OpPut, value: "new"},
+		{key: "gone", op: batch.OpDelete},
+		{key: "old-only", op: batch.OpPut, value: "kept-old"},
+		{key: "ptr", op: batch.OpPut, ptr: ptr, isPtr: true},
+	}
+	for i := range want {
+		if string(out[i].Key) != want[i].key || out[i].Type != want[i].op {
+			t.Fatalf("entry[%d] key/op=(%q,%d) want (%q,%d)", i, out[i].Key, out[i].Type, want[i].key, want[i].op)
+		}
+		if want[i].isPtr {
+			if !out[i].IsPtr || out[i].ValuePtr != want[i].ptr || out[i].Value != nil {
+				t.Fatalf("entry[%d] ptr=(%v,%+v,%q) want ptr %+v", i, out[i].IsPtr, out[i].ValuePtr, out[i].Value, want[i].ptr)
+			}
+			continue
+		}
+		if out[i].Type == batch.OpPut && string(out[i].Value) != want[i].value {
+			t.Fatalf("entry[%d] value=%q want %q", i, out[i].Value, want[i].value)
+		}
+	}
+}
+
+func TestCanStreamCanonicalPointUnitsFromStableIteratorsRejectsFallbackCases(t *testing.T) {
+	stable := memtable.NewAppendOnlyWithEntryCapacity(1)
+	stable.Set([]byte("k"), []byte("v"))
+	stable.Freeze()
+	unstable := &unstableRunTable{entries: []batch.Entry{{Type: batch.OpPut, Key: []byte("k"), Value: []byte("v")}}}
+
+	db := &DB{}
+	if !db.canStreamCanonicalPointUnitsFromStableIterators([]flushUnit{{mem: stable}}, 0) {
+		t.Fatalf("stable span-free units should be eligible")
+	}
+	if db.canStreamCanonicalPointUnitsFromStableIterators([]flushUnit{{mem: stable}}, 1) {
+		t.Fatalf("range-span units must use the materializing fallback")
+	}
+	if db.canStreamCanonicalPointUnitsFromStableIterators([]flushUnit{{mem: unstable}}, 0) {
+		t.Fatalf("unstable iterator units must use the materializing fallback")
+	}
+	db.flushSpanRunTargetPlanning = true
+	if db.canStreamCanonicalPointUnitsFromStableIterators([]flushUnit{{mem: stable}}, 0) {
+		t.Fatalf("span-target planning must use the materializing fallback")
+	}
+}
+
+func TestMergeCanonicalStableIteratorUnitsClosesIteratorsOnEmitError(t *testing.T) {
+	closeCount := 0
+	units := []flushUnit{
+		{mem: &stableRunTable{
+			unstableRunTable: unstableRunTable{entries: []batch.Entry{{Type: batch.OpPut, Key: []byte("a"), Value: []byte("1")}}},
+			closeCount:       &closeCount,
+		}},
+		{mem: &stableRunTable{
+			unstableRunTable: unstableRunTable{entries: []batch.Entry{{Type: batch.OpPut, Key: []byte("b"), Value: []byte("2")}}},
+			closeCount:       &closeCount,
+		}},
+	}
+	emitErr := errors.New("emit stopped")
+	err := mergeCanonicalStableIteratorUnits(units, &canonicalFlushRun{}, func(batch.Entry) error {
+		return emitErr
+	})
+	if !errors.Is(err, emitErr) {
+		t.Fatalf("merge error=%v want %v", err, emitErr)
+	}
+	if closeCount != len(units) {
+		t.Fatalf("closed iterators=%d want %d", closeCount, len(units))
+	}
+}
+
+func TestMergeCanonicalStableIteratorUnitsReturnsIteratorErrorAndCloses(t *testing.T) {
+	closeCount := 0
+	iterErr := errors.New("iterator failed")
+	units := []flushUnit{{mem: &stableRunTable{
+		unstableRunTable: unstableRunTable{entries: []batch.Entry{{Type: batch.OpPut, Key: []byte("a"), Value: []byte("1")}}},
+		iterErr:          iterErr,
+		closeCount:       &closeCount,
+	}}}
+	err := mergeCanonicalStableIteratorUnits(units, &canonicalFlushRun{}, nil)
+	if !errors.Is(err, iterErr) {
+		t.Fatalf("merge error=%v want %v", err, iterErr)
+	}
+	if closeCount != 1 {
+		t.Fatalf("closed iterators=%d want 1", closeCount)
 	}
 }
 
@@ -302,6 +523,126 @@ func BenchmarkBuildOpRunsAppendOnlyShapes(b *testing.B) {
 			}
 		})
 	}
+}
+
+func benchmarkCanonicalFlushUnits(b *testing.B, unitCount, entriesPerUnit int) ([]flushUnit, int) {
+	b.Helper()
+	units := make([]flushUnit, 0, unitCount)
+	totalLen := 0
+	value := []byte("value-payload")
+	for unit := 0; unit < unitCount; unit++ {
+		m := memtable.NewAppendOnlyWithEntryCapacity(entriesPerUnit)
+		base := unit * entriesPerUnit / 2
+		for i := 0; i < entriesPerUnit; i++ {
+			key := buildRunKey(uint64(base + i))
+			if i%17 == 0 {
+				m.Delete(key)
+				continue
+			}
+			m.Set(key, value)
+		}
+		m.Freeze()
+		units = append(units, flushUnit{mem: m, memLen: m.Len(), memBytes: m.Size()})
+		totalLen += m.Len()
+	}
+	return units, totalLen
+}
+
+func benchmarkEmitCanonicalEntryChunk(b *testing.B, ops *[]batch.Entry, chunkCap int, entry batch.Entry) {
+	b.Helper()
+	if len(*ops) >= chunkCap {
+		putEntrySlice(*ops)
+		*ops = getEntrySlice(chunkCap)
+	}
+	*ops = append(*ops, entry)
+}
+
+func benchmarkMaterializedCanonicalFlushMerge(b *testing.B, db *DB, units []flushUnit, totalLen int, chunkCap int) {
+	b.Helper()
+	build, err := db.buildCanonicalUnitRuns(units, totalLen, 0)
+	if err != nil {
+		b.Fatalf("buildCanonicalUnitRuns: %v", err)
+	}
+	defer build.release()
+
+	run := &canonicalFlushRun{
+		sourceMemtables: len(units),
+		sourcePointOps:  build.sourcePointOps,
+		deletePointOps:  build.sourceDeleteOps,
+	}
+	ops := getEntrySlice(chunkCap)
+	defer func() { putEntrySlice(ops) }()
+	if err := mergeCanonicalUnitRuns(build.unitRuns, run, func(entry batch.Entry) error {
+		benchmarkEmitCanonicalEntryChunk(b, &ops, chunkCap, entry)
+		return nil
+	}); err != nil {
+		b.Fatalf("mergeCanonicalUnitRuns: %v", err)
+	}
+	if run.sourcePointOps != run.plannedPointOps+run.shadowedPointOps {
+		b.Fatalf("materialized source=%d planned=%d shadowed=%d", run.sourcePointOps, run.plannedPointOps, run.shadowedPointOps)
+	}
+}
+
+func benchmarkStableIteratorCanonicalFlushMerge(b *testing.B, units []flushUnit, chunkCap int) {
+	b.Helper()
+	sourcePointOps, sourceDeleteOps, err := countCanonicalStableIteratorUnits(units)
+	if err != nil {
+		b.Fatalf("countCanonicalStableIteratorUnits: %v", err)
+	}
+	run := &canonicalFlushRun{
+		sourceMemtables: len(units),
+		sourcePointOps:  sourcePointOps,
+		deletePointOps:  sourceDeleteOps,
+	}
+	ops := getEntrySlice(chunkCap)
+	defer func() { putEntrySlice(ops) }()
+	if err := mergeCanonicalStableIteratorUnits(units, run, func(entry batch.Entry) error {
+		benchmarkEmitCanonicalEntryChunk(b, &ops, chunkCap, entry)
+		return nil
+	}); err != nil {
+		b.Fatalf("mergeCanonicalStableIteratorUnits: %v", err)
+	}
+	if run.sourcePointOps != run.plannedPointOps+run.shadowedPointOps {
+		b.Fatalf("stable iterator source=%d planned=%d shadowed=%d", run.sourcePointOps, run.plannedPointOps, run.shadowedPointOps)
+	}
+}
+
+func benchmarkDisableEntrySlicePooling(b *testing.B) {
+	b.Helper()
+	lockEntrySlicePoolStateForTest(b)
+	resetEntrySlicePoolStateForTest(b)
+	savedBudget := entrySlicePoolBudgetBytes
+	entrySlicePoolBudgetBytes = 0
+	b.Cleanup(func() {
+		entrySlicePoolBudgetBytes = savedBudget
+	})
+}
+
+func BenchmarkCanonicalFlushStableIteratorVsMaterialized(b *testing.B) {
+	const (
+		unitCount      = 4
+		entriesPerUnit = 4096
+		chunkCap       = 1024
+	)
+	units, totalLen := benchmarkCanonicalFlushUnits(b, unitCount, entriesPerUnit)
+	db := &DB{flushBuildChunkCap: chunkCap}
+
+	b.Run("materialized_unit_runs_cold_descriptor_pool", func(b *testing.B) {
+		benchmarkDisableEntrySlicePooling(b)
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			benchmarkMaterializedCanonicalFlushMerge(b, db, units, totalLen, chunkCap)
+		}
+	})
+	b.Run("stable_iterators_cold_descriptor_pool", func(b *testing.B) {
+		benchmarkDisableEntrySlicePooling(b)
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			benchmarkStableIteratorCanonicalFlushMerge(b, units, chunkCap)
+		}
+	})
 }
 
 func TestOpMergeHeapEightByteDuplicatePriorityAndTombstone(t *testing.T) {

--- a/TreeDB/caching/flush_run_planner.go
+++ b/TreeDB/caching/flush_run_planner.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/snissn/gomap/TreeDB/batch"
 	backenddb "github.com/snissn/gomap/TreeDB/db"
+	"github.com/snissn/gomap/TreeDB/internal/iterator"
+	"github.com/snissn/gomap/TreeDB/node"
 )
 
 type backendFlushSpanRunPlanner interface {
@@ -212,6 +214,94 @@ func (db *DB) buildCanonicalUnitRuns(units []flushUnit, totalLen int, totalSpans
 	return build, nil
 }
 
+func (db *DB) canStreamCanonicalPointUnitsFromStableIterators(units []flushUnit, totalSpans int) bool {
+	if db == nil || db.flushSpanRunTargetPlanning || totalSpans != 0 || len(units) == 0 {
+		return false
+	}
+	for i := range units {
+		if !stableUnsafeIteratorSlices(units[i].mem) {
+			return false
+		}
+	}
+	return true
+}
+
+func closeCanonicalStableIterator(iter iterator.UnsafeIterator) error {
+	if iter == nil {
+		return nil
+	}
+	err := iter.Error()
+	cerr := iter.Close()
+	if err == nil {
+		err = cerr
+	}
+	return err
+}
+
+func closeCanonicalStableIterators(iters []iterator.UnsafeIterator) error {
+	var err error
+	for _, iter := range iters {
+		if cerr := closeCanonicalStableIterator(iter); err == nil {
+			err = cerr
+		}
+	}
+	return err
+}
+
+func countCanonicalStableIteratorUnits(units []flushUnit) (sourcePointOps int, sourceDeleteOps int, err error) {
+	for i := range units {
+		iter := units[i].mem.NewIterator(nil, nil)
+		if iter == nil {
+			return 0, 0, errors.New("cachingdb: nil canonical stable iterator")
+		}
+		for iter.Valid() {
+			_, _, flags, _ := iterator.UnsafeEntryWithRevision(iter)
+			sourcePointOps++
+			if flags&node.FlagTombstone != 0 {
+				sourceDeleteOps++
+			}
+			iter.Next()
+		}
+		if err := closeCanonicalStableIterator(iter); err != nil {
+			return 0, 0, err
+		}
+	}
+	return sourcePointOps, sourceDeleteOps, nil
+}
+
+type canonicalOpIter interface {
+	Valid() bool
+	Next()
+	Entry() batch.Entry
+	Key() []byte
+}
+
+type stableUnsafeOpIter struct {
+	iterator.UnsafeIterator
+}
+
+func (it *stableUnsafeOpIter) Entry() batch.Entry {
+	if it == nil || it.UnsafeIterator == nil || !it.Valid() {
+		return batch.Entry{}
+	}
+	val, ptr, flags, revision := iterator.UnsafeEntryWithRevision(it.UnsafeIterator)
+	key := it.UnsafeKey()
+	if flags&node.FlagTombstone != 0 {
+		return batch.Entry{Type: batch.OpDelete, Key: key, Revision: revision}
+	}
+	if flags&node.FlagPointer != 0 {
+		return batch.Entry{Type: batch.OpPut, Key: key, ValuePtr: ptr, IsPtr: true, Revision: revision}
+	}
+	return batch.Entry{Type: batch.OpPut, Key: key, Value: val, Revision: revision}
+}
+
+func (it *stableUnsafeOpIter) Key() []byte {
+	if it == nil || it.UnsafeIterator == nil || !it.Valid() {
+		return nil
+	}
+	return it.UnsafeKey()
+}
+
 func mergeCanonicalUnitRuns(unitRuns [][][]batch.Entry, out *canonicalFlushRun, emit func(batch.Entry) error) error {
 	if out == nil {
 		return errors.New("cachingdb: missing canonical flush run")
@@ -226,6 +316,80 @@ func mergeCanonicalUnitRuns(unitRuns [][][]batch.Entry, out *canonicalFlushRun, 
 		if it.Valid() {
 			priority := len(unitRuns) - 1 - i
 			heap = append(heap, opMergeItem{iter: it, priority: priority, key: it.Key()})
+		}
+	}
+	for i := len(heap)/2 - 1; i >= 0; i-- {
+		(&heap).down(i, len(heap))
+	}
+
+	plannedDeletes := 0
+	plannedPointOps := 0
+	for len(heap) > 0 {
+		top := heap.pop()
+		currentKey := top.key
+
+		for len(heap) > 0 {
+			next := heap.peek()
+			if next != nil && bytes.Equal(next.key, currentKey) {
+				shadowed := heap.pop()
+				out.shadowedPointOps++
+				shadowed.iter.Next()
+				if shadowed.iter.Valid() {
+					shadowed.key = shadowed.iter.Key()
+					heap.push(shadowed)
+				}
+				continue
+			}
+			break
+		}
+
+		entry := top.iter.Entry()
+		if emit != nil {
+			if err := emit(entry); err != nil {
+				return err
+			}
+		}
+		plannedPointOps++
+		if entry.Type == batch.OpDelete {
+			plannedDeletes++
+		}
+
+		top.iter.Next()
+		if top.iter.Valid() {
+			top.key = top.iter.Key()
+			heap.push(top)
+		}
+	}
+	out.plannedPointOps = plannedPointOps
+	out.deletePointOps = plannedDeletes
+	return nil
+}
+
+func mergeCanonicalStableIteratorUnits(units []flushUnit, out *canonicalFlushRun, emit func(batch.Entry) error) (err error) {
+	if out == nil {
+		return errors.New("cachingdb: missing canonical flush run")
+	}
+	heap := getOpMergeHeap(len(units))
+	defer func() { putOpMergeHeap(heap) }()
+
+	iters := make([]iterator.UnsafeIterator, len(units))
+	wrappers := make([]stableUnsafeOpIter, len(units))
+	defer func() {
+		if cerr := closeCanonicalStableIterators(iters); err == nil {
+			err = cerr
+		}
+	}()
+
+	for i := range units {
+		iter := units[i].mem.NewIterator(nil, nil)
+		if iter == nil {
+			return errors.New("cachingdb: nil canonical stable iterator")
+		}
+		iters[i] = iter
+		wrappers[i] = stableUnsafeOpIter{UnsafeIterator: iter}
+		if iter.Valid() {
+			priority := len(units) - 1 - i
+			heap = append(heap, opMergeItem{iter: &wrappers[i], priority: priority, key: wrappers[i].Key()})
 		}
 	}
 	for i := len(heap)/2 - 1; i >= 0; i-- {
@@ -766,7 +930,151 @@ func (db *DB) writeCanonicalFlushRunChunks(run *canonicalFlushRun, chunks []back
 	return emitted, nil
 }
 
+func (db *DB) flushCanonicalPointUnitsStableIteratorStreamed(syncFlush bool, laneID int, commandPublish *checkpointCommandWALPublish, units []flushUnit, ids []uint64, totalBytes int64, _ int, totalSpans int, mode flushCollectionMode) bool {
+	flushStart := time.Now()
+	buildStart := flushStart
+	sourcePointOps, sourceDeleteOps, err := countCanonicalStableIteratorUnits(units)
+	if err != nil {
+		db.reportError(err)
+		return false
+	}
+	db.observeFlushApplyBuild(time.Since(buildStart))
+
+	runStats := &canonicalFlushRun{
+		sourceMemtables: len(units),
+		sourcePointOps:  sourcePointOps,
+		rangeDeleteOps:  totalSpans,
+		rangeBarriers:   flushUnitRangeBarrierCount(units),
+		deletePointOps:  sourceDeleteOps,
+	}
+	backendEntriesCap := db.flushBackendEntriesCapForOps(sourcePointOps, sourceDeleteOps, syncFlush)
+	if backendEntriesCap <= 0 {
+		backendEntriesCap = sourcePointOps
+		if backendEntriesCap <= 0 {
+			backendEntriesCap = 1
+		}
+	}
+	chunkEntriesCap := backendEntriesCap
+	if sourcePointOps > 0 && chunkEntriesCap > sourcePointOps {
+		chunkEntriesCap = sourcePointOps
+	}
+	if chunkEntriesCap <= 0 {
+		chunkEntriesCap = 1
+	}
+	var emptySplitSummary backenddb.FlushSpanRunChunkSplitSummary
+	db.observeFlushSpanRunTargetLeafSpanSummary(0, 0, 0, 0, emptySplitSummary)
+
+	writeStart := time.Now()
+	ops := getEntrySlice(chunkEntriesCap)
+	defer func() { putEntrySlice(ops) }()
+	valueLogNeedsFlush := db.valueLogEnabled()
+	flushValueLogIfNeeded := func() error {
+		if !valueLogNeedsFlush {
+			return nil
+		}
+		flushStart := time.Now()
+		err := db.flushValueLog(laneID)
+		db.observeFlushApplyVLogFlush(time.Since(flushStart))
+		if err != nil {
+			return err
+		}
+		if syncFlush && !db.relaxedSync {
+			syncStart := time.Now()
+			err := db.syncValueLog(laneID)
+			db.observeFlushApplyVLogSync(time.Since(syncStart))
+			if err != nil {
+				return err
+			}
+		}
+		valueLogNeedsFlush = false
+		return nil
+	}
+	emitChunk := func(last bool) error {
+		if len(ops) == 0 {
+			return nil
+		}
+		materializeStart := time.Now()
+		wrotePointers, err := db.materializeCanonicalOpsDeferredValueLogPointers(ops, syncFlush, laneID)
+		db.observeFlushApplyDeferredVLogPointerMaterialize(time.Since(materializeStart))
+		if err != nil {
+			return fmt.Errorf("defer vlog: %w", err)
+		}
+		if wrotePointers {
+			valueLogNeedsFlush = true
+		}
+		if err := flushValueLogIfNeeded(); err != nil {
+			return fmt.Errorf("vlog: %w", err)
+		}
+		err = db.writeCanonicalFlushRunOpsChunk(ops, syncFlush, commandPublish, last, mode)
+		if err != nil {
+			return err
+		}
+		putEntrySlice(ops)
+		ops = nil
+		if !last {
+			ops = getEntrySlice(chunkEntriesCap)
+		}
+		return nil
+	}
+
+	err = mergeCanonicalStableIteratorUnits(units, runStats, func(entry batch.Entry) error {
+		if len(ops) >= chunkEntriesCap {
+			if err := emitChunk(false); err != nil {
+				return err
+			}
+		}
+		if ops == nil {
+			ops = getEntrySlice(chunkEntriesCap)
+		}
+		ops = append(ops, entry)
+		return nil
+	})
+	if err != nil {
+		db.reportError(fmt.Errorf("cachingdb: flush failed: %w", err))
+		return false
+	}
+
+	if runStats.shadowedPointOps > 0 {
+		flushMergeShadowedOpsTotal.Add(uint64(runStats.shadowedPointOps))
+		flushMergeParallelShadowedOpsTotal.Add(uint64(runStats.shadowedPointOps))
+		db.observeFlushSpanRunShadowedOps(runStats.shadowedPointOps)
+	}
+	if runStats.plannedPointOps > 0 {
+		flushMergeAppliedOpsTotal.Add(uint64(runStats.plannedPointOps))
+		flushMergeParallelAppliedOpsTotal.Add(uint64(runStats.plannedPointOps))
+	}
+	if runStats.sourcePointOps != runStats.plannedPointOps+runStats.shadowedPointOps {
+		db.reportError(fmt.Errorf("cachingdb: canonical flush run source=%d planned=%d shadowed=%d", runStats.sourcePointOps, runStats.plannedPointOps, runStats.shadowedPointOps))
+		return false
+	}
+	db.observeFlushSpanRunPlannedOps(runStats.plannedPointOps, totalSpans)
+
+	if err := emitChunk(true); err != nil {
+		db.reportError(fmt.Errorf("cachingdb: flush failed: %w", err))
+		return false
+	}
+	db.observeFlushApplyBackendWrite(time.Since(writeStart))
+
+	db.finishFlushedCanonicalUnits(syncFlush, units, ids, totalBytes)
+	flushDur := time.Since(flushStart)
+	if flushDur > 0 && totalBytes > 0 {
+		sample := float64(totalBytes) / flushDur.Seconds()
+		db.bpMu.Lock()
+		if db.flushBpsEWMA <= 0 {
+			db.flushBpsEWMA = sample
+		} else {
+			db.flushBpsEWMA = 0.9*db.flushBpsEWMA + 0.1*sample
+		}
+		db.bpCond.Broadcast()
+		db.bpMu.Unlock()
+	}
+	return true
+}
+
 func (db *DB) flushCanonicalPointUnitsStreamed(syncFlush bool, laneID int, commandPublish *checkpointCommandWALPublish, units []flushUnit, ids []uint64, totalBytes int64, totalLen int, totalSpans int, mode flushCollectionMode) bool {
+	if db.canStreamCanonicalPointUnitsFromStableIterators(units, totalSpans) {
+		return db.flushCanonicalPointUnitsStableIteratorStreamed(syncFlush, laneID, commandPublish, units, ids, totalBytes, totalLen, totalSpans, mode)
+	}
 	flushStart := time.Now()
 	buildStart := flushStart
 	build, err := db.buildCanonicalUnitRuns(units, totalLen, totalSpans)

--- a/TreeDB/caching/flush_run_planner.go
+++ b/TreeDB/caching/flush_run_planner.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/snissn/gomap/TreeDB/batch"
 	backenddb "github.com/snissn/gomap/TreeDB/db"
+	"github.com/snissn/gomap/TreeDB/internal/iterator"
+	"github.com/snissn/gomap/TreeDB/node"
 )
 
 type backendFlushSpanRunPlanner interface {
@@ -212,6 +214,163 @@ func (db *DB) buildCanonicalUnitRuns(units []flushUnit, totalLen int, totalSpans
 	return build, nil
 }
 
+func (db *DB) canStreamCanonicalPointUnitsFromStableIterators(units []flushUnit, totalSpans int) bool {
+	if db == nil || db.flushSpanRunTargetPlanning || totalSpans != 0 || len(units) == 0 {
+		return false
+	}
+	for i := range units {
+		if !stableUnsafeIteratorSlices(units[i].mem) {
+			return false
+		}
+	}
+	return true
+}
+
+func closeCanonicalStableIterator(iter iterator.UnsafeIterator) error {
+	if iter == nil {
+		return nil
+	}
+	err := iter.Error()
+	cerr := iter.Close()
+	if err == nil {
+		err = cerr
+	}
+	return err
+}
+
+func closeCanonicalStableIterators(iters []iterator.UnsafeIterator) error {
+	var err error
+	for _, iter := range iters {
+		if cerr := closeCanonicalStableIterator(iter); err == nil {
+			err = cerr
+		}
+	}
+	return err
+}
+
+func countCanonicalStableIteratorUnits(units []flushUnit) (sourcePointOps int, sourceDeleteOps int, err error) {
+	for i := range units {
+		iter := units[i].mem.NewIterator(nil, nil)
+		if iter == nil {
+			return 0, 0, errors.New("cachingdb: nil canonical stable iterator")
+		}
+		for iter.Valid() {
+			_, _, flags, _ := iterator.UnsafeEntryWithRevision(iter)
+			sourcePointOps++
+			if flags&node.FlagTombstone != 0 {
+				sourceDeleteOps++
+			}
+			iter.Next()
+		}
+		if err := closeCanonicalStableIterator(iter); err != nil {
+			return 0, 0, err
+		}
+	}
+	return sourcePointOps, sourceDeleteOps, nil
+}
+
+type stableUnsafeOpIter struct {
+	iterator.UnsafeIterator
+}
+
+func (it *stableUnsafeOpIter) Entry() batch.Entry {
+	if it == nil || it.UnsafeIterator == nil || !it.Valid() {
+		return batch.Entry{}
+	}
+	val, ptr, flags, revision := iterator.UnsafeEntryWithRevision(it.UnsafeIterator)
+	key := it.UnsafeKey()
+	if flags&node.FlagTombstone != 0 {
+		return batch.Entry{Type: batch.OpDelete, Key: key, Revision: revision}
+	}
+	if flags&node.FlagPointer != 0 {
+		return batch.Entry{Type: batch.OpPut, Key: key, ValuePtr: ptr, IsPtr: true, Revision: revision}
+	}
+	return batch.Entry{Type: batch.OpPut, Key: key, Value: val, Revision: revision}
+}
+
+func (it *stableUnsafeOpIter) Key() []byte {
+	if it == nil || it.UnsafeIterator == nil || !it.Valid() {
+		return nil
+	}
+	return it.UnsafeKey()
+}
+
+type stableOpMergeItem struct {
+	iter     *stableUnsafeOpIter
+	priority int
+	key      []byte
+}
+
+type stableOpMergeHeap []stableOpMergeItem
+
+func (h stableOpMergeHeap) Less(i, j int) bool {
+	cmp := bytes.Compare(h[i].key, h[j].key)
+	if cmp != 0 {
+		return cmp < 0
+	}
+	return h[i].priority < h[j].priority
+}
+
+func (h stableOpMergeHeap) Swap(i, j int) {
+	h[i], h[j] = h[j], h[i]
+}
+
+func (h *stableOpMergeHeap) push(x stableOpMergeItem) {
+	*h = append(*h, x)
+	h.up(len(*h) - 1)
+}
+
+func (h *stableOpMergeHeap) pop() stableOpMergeItem {
+	old := *h
+	n := len(old)
+	if n == 0 {
+		return stableOpMergeItem{}
+	}
+	old.Swap(0, n-1)
+	h.down(0, n-1)
+	x := old[n-1]
+	*h = old[:n-1]
+	return x
+}
+
+func (h stableOpMergeHeap) peek() *stableOpMergeItem {
+	if len(h) == 0 {
+		return nil
+	}
+	return &h[0]
+}
+
+func (h *stableOpMergeHeap) up(j int) {
+	for {
+		i := (j - 1) / 2
+		if i == j || !h.Less(j, i) {
+			break
+		}
+		h.Swap(i, j)
+		j = i
+	}
+}
+
+func (h *stableOpMergeHeap) down(i0, n int) bool {
+	i := i0
+	for {
+		j1 := 2*i + 1
+		if j1 >= n || j1 < 0 {
+			break
+		}
+		j := j1
+		if j2 := j1 + 1; j2 < n && h.Less(j2, j1) {
+			j = j2
+		}
+		if !h.Less(j, i) {
+			break
+		}
+		h.Swap(i, j)
+		i = j
+	}
+	return i > i0
+}
+
 func mergeCanonicalUnitRuns(unitRuns [][][]batch.Entry, out *canonicalFlushRun, emit func(batch.Entry) error) error {
 	if out == nil {
 		return errors.New("cachingdb: missing canonical flush run")
@@ -226,6 +385,79 @@ func mergeCanonicalUnitRuns(unitRuns [][][]batch.Entry, out *canonicalFlushRun, 
 		if it.Valid() {
 			priority := len(unitRuns) - 1 - i
 			heap = append(heap, opMergeItem{iter: it, priority: priority, key: it.Key()})
+		}
+	}
+	for i := len(heap)/2 - 1; i >= 0; i-- {
+		(&heap).down(i, len(heap))
+	}
+
+	plannedDeletes := 0
+	plannedPointOps := 0
+	for len(heap) > 0 {
+		top := heap.pop()
+		currentKey := top.key
+
+		for len(heap) > 0 {
+			next := heap.peek()
+			if next != nil && bytes.Equal(next.key, currentKey) {
+				shadowed := heap.pop()
+				out.shadowedPointOps++
+				shadowed.iter.Next()
+				if shadowed.iter.Valid() {
+					shadowed.key = shadowed.iter.Key()
+					heap.push(shadowed)
+				}
+				continue
+			}
+			break
+		}
+
+		entry := top.iter.Entry()
+		if emit != nil {
+			if err := emit(entry); err != nil {
+				return err
+			}
+		}
+		plannedPointOps++
+		if entry.Type == batch.OpDelete {
+			plannedDeletes++
+		}
+
+		top.iter.Next()
+		if top.iter.Valid() {
+			top.key = top.iter.Key()
+			heap.push(top)
+		}
+	}
+	out.plannedPointOps = plannedPointOps
+	out.deletePointOps = plannedDeletes
+	return nil
+}
+
+func mergeCanonicalStableIteratorUnits(units []flushUnit, out *canonicalFlushRun, emit func(batch.Entry) error) (err error) {
+	if out == nil {
+		return errors.New("cachingdb: missing canonical flush run")
+	}
+	heap := make(stableOpMergeHeap, 0, len(units))
+
+	iters := make([]iterator.UnsafeIterator, len(units))
+	wrappers := make([]stableUnsafeOpIter, len(units))
+	defer func() {
+		if cerr := closeCanonicalStableIterators(iters); err == nil {
+			err = cerr
+		}
+	}()
+
+	for i := range units {
+		iter := units[i].mem.NewIterator(nil, nil)
+		if iter == nil {
+			return errors.New("cachingdb: nil canonical stable iterator")
+		}
+		iters[i] = iter
+		wrappers[i] = stableUnsafeOpIter{UnsafeIterator: iter}
+		if iter.Valid() {
+			priority := len(units) - 1 - i
+			heap = append(heap, stableOpMergeItem{iter: &wrappers[i], priority: priority, key: wrappers[i].Key()})
 		}
 	}
 	for i := len(heap)/2 - 1; i >= 0; i-- {
@@ -766,7 +998,151 @@ func (db *DB) writeCanonicalFlushRunChunks(run *canonicalFlushRun, chunks []back
 	return emitted, nil
 }
 
+func (db *DB) flushCanonicalPointUnitsStableIteratorStreamed(syncFlush bool, laneID int, commandPublish *checkpointCommandWALPublish, units []flushUnit, ids []uint64, totalBytes int64, _ int, totalSpans int, mode flushCollectionMode) bool {
+	flushStart := time.Now()
+	buildStart := flushStart
+	sourcePointOps, sourceDeleteOps, err := countCanonicalStableIteratorUnits(units)
+	if err != nil {
+		db.reportError(err)
+		return false
+	}
+	db.observeFlushApplyBuild(time.Since(buildStart))
+
+	runStats := &canonicalFlushRun{
+		sourceMemtables: len(units),
+		sourcePointOps:  sourcePointOps,
+		rangeDeleteOps:  totalSpans,
+		rangeBarriers:   flushUnitRangeBarrierCount(units),
+		deletePointOps:  sourceDeleteOps,
+	}
+	backendEntriesCap := db.flushBackendEntriesCapForOps(sourcePointOps, sourceDeleteOps, syncFlush)
+	if backendEntriesCap <= 0 {
+		backendEntriesCap = sourcePointOps
+		if backendEntriesCap <= 0 {
+			backendEntriesCap = 1
+		}
+	}
+	chunkEntriesCap := backendEntriesCap
+	if sourcePointOps > 0 && chunkEntriesCap > sourcePointOps {
+		chunkEntriesCap = sourcePointOps
+	}
+	if chunkEntriesCap <= 0 {
+		chunkEntriesCap = 1
+	}
+	var emptySplitSummary backenddb.FlushSpanRunChunkSplitSummary
+	db.observeFlushSpanRunTargetLeafSpanSummary(0, 0, 0, 0, emptySplitSummary)
+
+	writeStart := time.Now()
+	ops := getEntrySlice(chunkEntriesCap)
+	defer func() { putEntrySlice(ops) }()
+	valueLogNeedsFlush := db.valueLogEnabled()
+	flushValueLogIfNeeded := func() error {
+		if !valueLogNeedsFlush {
+			return nil
+		}
+		flushStart := time.Now()
+		err := db.flushValueLog(laneID)
+		db.observeFlushApplyVLogFlush(time.Since(flushStart))
+		if err != nil {
+			return err
+		}
+		if syncFlush && !db.relaxedSync {
+			syncStart := time.Now()
+			err := db.syncValueLog(laneID)
+			db.observeFlushApplyVLogSync(time.Since(syncStart))
+			if err != nil {
+				return err
+			}
+		}
+		valueLogNeedsFlush = false
+		return nil
+	}
+	emitChunk := func(last bool) error {
+		if len(ops) == 0 {
+			return nil
+		}
+		materializeStart := time.Now()
+		wrotePointers, err := db.materializeCanonicalOpsDeferredValueLogPointers(ops, syncFlush, laneID)
+		db.observeFlushApplyDeferredVLogPointerMaterialize(time.Since(materializeStart))
+		if err != nil {
+			return fmt.Errorf("defer vlog: %w", err)
+		}
+		if wrotePointers {
+			valueLogNeedsFlush = true
+		}
+		if err := flushValueLogIfNeeded(); err != nil {
+			return fmt.Errorf("vlog: %w", err)
+		}
+		err = db.writeCanonicalFlushRunOpsChunk(ops, syncFlush, commandPublish, last, mode)
+		if err != nil {
+			return err
+		}
+		putEntrySlice(ops)
+		ops = nil
+		if !last {
+			ops = getEntrySlice(chunkEntriesCap)
+		}
+		return nil
+	}
+
+	err = mergeCanonicalStableIteratorUnits(units, runStats, func(entry batch.Entry) error {
+		if len(ops) >= chunkEntriesCap {
+			if err := emitChunk(false); err != nil {
+				return err
+			}
+		}
+		if ops == nil {
+			ops = getEntrySlice(chunkEntriesCap)
+		}
+		ops = append(ops, entry)
+		return nil
+	})
+	if err != nil {
+		db.reportError(fmt.Errorf("cachingdb: flush failed: %w", err))
+		return false
+	}
+
+	if runStats.shadowedPointOps > 0 {
+		flushMergeShadowedOpsTotal.Add(uint64(runStats.shadowedPointOps))
+		flushMergeParallelShadowedOpsTotal.Add(uint64(runStats.shadowedPointOps))
+		db.observeFlushSpanRunShadowedOps(runStats.shadowedPointOps)
+	}
+	if runStats.plannedPointOps > 0 {
+		flushMergeAppliedOpsTotal.Add(uint64(runStats.plannedPointOps))
+		flushMergeParallelAppliedOpsTotal.Add(uint64(runStats.plannedPointOps))
+	}
+	if runStats.sourcePointOps != runStats.plannedPointOps+runStats.shadowedPointOps {
+		db.reportError(fmt.Errorf("cachingdb: canonical flush run source=%d planned=%d shadowed=%d", runStats.sourcePointOps, runStats.plannedPointOps, runStats.shadowedPointOps))
+		return false
+	}
+	db.observeFlushSpanRunPlannedOps(runStats.plannedPointOps, totalSpans)
+
+	if err := emitChunk(true); err != nil {
+		db.reportError(fmt.Errorf("cachingdb: flush failed: %w", err))
+		return false
+	}
+	db.observeFlushApplyBackendWrite(time.Since(writeStart))
+
+	db.finishFlushedCanonicalUnits(syncFlush, units, ids, totalBytes)
+	flushDur := time.Since(flushStart)
+	if flushDur > 0 && totalBytes > 0 {
+		sample := float64(totalBytes) / flushDur.Seconds()
+		db.bpMu.Lock()
+		if db.flushBpsEWMA <= 0 {
+			db.flushBpsEWMA = sample
+		} else {
+			db.flushBpsEWMA = 0.9*db.flushBpsEWMA + 0.1*sample
+		}
+		db.bpCond.Broadcast()
+		db.bpMu.Unlock()
+	}
+	return true
+}
+
 func (db *DB) flushCanonicalPointUnitsStreamed(syncFlush bool, laneID int, commandPublish *checkpointCommandWALPublish, units []flushUnit, ids []uint64, totalBytes int64, totalLen int, totalSpans int, mode flushCollectionMode) bool {
+	if db.canStreamCanonicalPointUnitsFromStableIterators(units, totalSpans) {
+		return db.flushCanonicalPointUnitsStableIteratorStreamed(syncFlush, laneID, commandPublish, units, ids, totalBytes, totalLen, totalSpans, mode)
+	}
 	flushStart := time.Now()
 	buildStart := flushStart
 	build, err := db.buildCanonicalUnitRuns(units, totalLen, totalSpans)

--- a/TreeDB/internal/valuelog/dict_frame_preparer_alloc_bench_test.go
+++ b/TreeDB/internal/valuelog/dict_frame_preparer_alloc_bench_test.go
@@ -1,0 +1,139 @@
+package valuelog
+
+import (
+	"io"
+	"runtime"
+	"testing"
+
+	"github.com/snissn/compress/zstd"
+	"github.com/snissn/gomap/TreeDB/page"
+)
+
+func BenchmarkFramePreparerDictIronbirdLikeHistoryReuse(b *testing.B) {
+	const (
+		dictID      = uint64(3553)
+		valueSize   = 4096
+		recordCount = 8
+		valueCount  = 128
+	)
+
+	values := make([][]byte, valueCount)
+	for i := range values {
+		values[i] = makeSyntheticDictSampleForBench(i, valueSize)
+	}
+	dict, err := buildBenchDictWithHistory(uint32(dictID), values, 32<<10)
+	if err != nil {
+		b.Fatalf("build dict: %v", err)
+	}
+
+	records := make([]Record, recordCount)
+	fillRecords := func(base int) {
+		for i := range records {
+			records[i] = Record{
+				RID:   uint64(base + i + 1),
+				Value: values[(base+i)%len(values)],
+			}
+		}
+	}
+
+	prep := NewFramePreparer()
+	prep.SetDictFrameEncoderOptions(zstd.SpeedFastest, false)
+	fillRecords(0)
+	body, stats, err := prep.PrepareFrameInto(nil, dictID, dict, records)
+	if err != nil {
+		b.Fatalf("warm PrepareFrameInto: %v", err)
+	}
+	if !stats.Attempted || !stats.Kept {
+		b.Fatalf("warm frame stats attempted=%v kept=%v raw=%d stored=%d", stats.Attempted, stats.Kept, stats.RawPayloadBytes, stats.StoredPayloadBytes)
+	}
+
+	b.ReportAllocs()
+	b.SetBytes(int64(valueSize * recordCount))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		// Two GC cycles clear sync.Pool victims, matching the Ironbird profile shape
+		// where pooled zstd encoders were repeatedly recreated between batches.
+		runtime.GC()
+		runtime.GC()
+		fillRecords(i * recordCount)
+		var prepErr error
+		body, stats, prepErr = prep.PrepareFrameInto(body[:0], dictID, dict, records)
+		if prepErr != nil {
+			b.Fatalf("PrepareFrameInto: %v", prepErr)
+		}
+		if !stats.Attempted || !stats.Kept {
+			b.Fatalf("frame stats attempted=%v kept=%v raw=%d stored=%d", stats.Attempted, stats.Kept, stats.RawPayloadBytes, stats.StoredPayloadBytes)
+		}
+		prep.TrimScratchForReuse()
+		prep.SetDictFrameEncoderOptions(zstd.SpeedFastest, false)
+	}
+	b.StopTimer()
+	runtime.KeepAlive(prep)
+	runtime.KeepAlive(body)
+}
+
+func BenchmarkWriterDictIronbirdLikeHistoryReuse(b *testing.B) {
+	const (
+		dictID      = uint64(3554)
+		valueSize   = 4096
+		recordCount = 8
+		valueCount  = 128
+	)
+
+	values := make([][]byte, valueCount)
+	for i := range values {
+		values[i] = makeSyntheticDictSampleForBench(i, valueSize)
+	}
+	dict, err := buildBenchDictWithHistory(uint32(dictID), values, 32<<10)
+	if err != nil {
+		b.Fatalf("build dict: %v", err)
+	}
+
+	records := make([]Record, recordCount)
+	fillRecords := func(base int) {
+		for i := range records {
+			records[i] = Record{
+				RID:   uint64(base + i + 1),
+				Value: values[(base+i)%len(values)],
+			}
+		}
+	}
+
+	writer := NewWriterWithSink(io.Discard, 1)
+	writer.SetDictFrameEncoderOptions(zstd.SpeedFastest, false)
+	defer func() {
+		if err := writer.Close(); err != nil {
+			b.Fatalf("close writer: %v", err)
+		}
+	}()
+
+	ptrs := make([]page.ValuePtr, recordCount)
+	fillRecords(0)
+	_, stats, err := writer.AppendFrameWithStatsInto(dictID, dict, records, ptrs)
+	if err != nil {
+		b.Fatalf("warm AppendFrameWithStatsInto: %v", err)
+	}
+	if !stats.Attempted || !stats.Kept {
+		b.Fatalf("warm frame stats attempted=%v kept=%v raw=%d stored=%d", stats.Attempted, stats.Kept, stats.RawPayloadBytes, stats.StoredPayloadBytes)
+	}
+
+	b.ReportAllocs()
+	b.SetBytes(int64(valueSize * recordCount))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		runtime.GC()
+		runtime.GC()
+		fillRecords(i * recordCount)
+		var appendErr error
+		_, stats, appendErr = writer.AppendFrameWithStatsInto(dictID, dict, records, ptrs)
+		if appendErr != nil {
+			b.Fatalf("AppendFrameWithStatsInto: %v", appendErr)
+		}
+		if !stats.Attempted || !stats.Kept {
+			b.Fatalf("frame stats attempted=%v kept=%v raw=%d stored=%d", stats.Attempted, stats.Kept, stats.RawPayloadBytes, stats.StoredPayloadBytes)
+		}
+	}
+	b.StopTimer()
+	runtime.KeepAlive(writer)
+	runtime.KeepAlive(ptrs)
+}

--- a/TreeDB/internal/valuelog/frame_preparer.go
+++ b/TreeDB/internal/valuelog/frame_preparer.go
@@ -25,6 +25,10 @@ type FramePreparer struct {
 	noBenefit  uint8
 	skipRemain uint16
 
+	dictEncoder       *zstd.Encoder
+	dictEncoderCodecs *dictCodecEntry
+	dictEncoderKey    dictCodecKey
+
 	dictFrameEncodeLevel   zstd.EncoderLevel
 	dictFrameEnableEntropy bool
 	blockCodec             BlockCodec
@@ -56,6 +60,7 @@ func (p *FramePreparer) ResetForReuse() {
 	if p == nil {
 		return
 	}
+	p.releaseDictEncoder()
 	p.TrimScratchForReuse()
 	p.skipDictID = 0
 	p.codecs = nil
@@ -74,9 +79,10 @@ func (p *FramePreparer) ResetForReuse() {
 	p.keepSafetyMargin = DefaultKeepSafetyMargin
 }
 
-// TrimScratchForReuse drops oversized temporary buffers while preserving codec
-// and compression-hint state. Long-lived prepare workers call this between
-// tasks so an occasional large frame does not pin unbounded scratch memory.
+// TrimScratchForReuse drops oversized temporary buffers while preserving codec,
+// active dictionary encoder, and compression-hint state. Long-lived prepare
+// workers call this between tasks so an occasional large frame does not pin
+// unbounded scratch memory.
 func (p *FramePreparer) TrimScratchForReuse() {
 	if p == nil {
 		return
@@ -99,11 +105,45 @@ func (p *FramePreparer) TrimScratchForReuse() {
 	p.encLimiter = limitedSliceWriter{}
 }
 
+func (p *FramePreparer) releaseDictEncoder() {
+	if p == nil || p.dictEncoder == nil {
+		return
+	}
+	if p.dictEncoderCodecs != nil && p.dictEncoderCodecs.encPool != nil {
+		p.dictEncoderCodecs.encPool.Put(p.dictEncoder)
+	}
+	p.dictEncoder = nil
+	p.dictEncoderCodecs = nil
+	p.dictEncoderKey = dictCodecKey{}
+}
+
+func (p *FramePreparer) dictEncoderFor(codecs *dictCodecEntry) (*zstd.Encoder, error) {
+	if p == nil || codecs == nil || codecs.encPool == nil {
+		return nil, ErrMissingDict
+	}
+	if p.dictEncoder != nil && p.dictEncoderCodecs == codecs && p.dictEncoderKey == codecs.key {
+		return p.dictEncoder, nil
+	}
+	p.releaseDictEncoder()
+	enc, ok := codecs.encPool.Get().(*zstd.Encoder)
+	if !ok || enc == nil {
+		return nil, ErrMissingDict
+	}
+	p.dictEncoder = enc
+	p.dictEncoderCodecs = codecs
+	p.dictEncoderKey = codecs.key
+	return enc, nil
+}
+
 func (p *FramePreparer) SetDictFrameEncoderOptions(level zstd.EncoderLevel, enableEntropy bool) {
 	if p == nil {
 		return
 	}
-	p.dictFrameEncodeLevel = normalizeDictFrameEncodeLevel(level)
+	level = normalizeDictFrameEncodeLevel(level)
+	if p.dictFrameEncodeLevel != level || p.dictFrameEnableEntropy != enableEntropy {
+		p.releaseDictEncoder()
+	}
+	p.dictFrameEncodeLevel = level
 	p.dictFrameEnableEntropy = enableEntropy
 	p.codecs = nil
 	p.skipDictID = 0
@@ -315,11 +355,13 @@ func (p *FramePreparer) PrepareFrameInto(dst []byte, dictID uint64, dict []byte,
 			return nil, FrameStats{}, ErrMissingDict
 		}
 
-		enc := codecs.encPool.Get().(*zstd.Encoder)
+		enc, err := p.dictEncoderFor(codecs)
+		if err != nil {
+			return nil, FrameStats{}, err
+		}
 		encodeStart := p.sampleEncodeStart()
 		encoded, encodeErr := p.encodePayload(enc, records, rawPayloadBytes)
 		encodeNs := p.sampleEncodeEnd(encodeStart, rawPayloadBytes, k)
-		codecs.encPool.Put(enc)
 		p.encScratch = p.encScratch[:0]
 
 		keepCompressed := false

--- a/TreeDB/internal/valuelog/valuelog_test.go
+++ b/TreeDB/internal/valuelog/valuelog_test.go
@@ -1740,6 +1740,144 @@ func TestFramePreparer_TrimScratchForReuseKeepsPolicyAndBoundsBuffers(t *testing
 	}
 }
 
+func TestFramePreparer_DictEncoderRetainedAcrossTrimAndSameOptions(t *testing.T) {
+	const dictID = uint64(3553)
+	dict, records := buildLargeDictCompressionFixture(t, dictID)
+	dict2, records2 := buildLargeDictCompressionFixture(t, dictID+1)
+
+	prep := NewFramePreparer()
+	prep.SetDictFrameEncoderOptions(zstd.SpeedFastest, false)
+	body, stats, err := prep.PrepareFrame(dictID, dict, records)
+	if err != nil {
+		t.Fatalf("PrepareFrame: %v", err)
+	}
+	if !stats.Attempted || !stats.Kept {
+		t.Fatalf("expected kept dict-compressed frame: attempted=%v kept=%v raw=%d stored=%d", stats.Attempted, stats.Kept, stats.RawPayloadBytes, stats.StoredPayloadBytes)
+	}
+	if prep.dictEncoder == nil || prep.dictEncoderCodecs == nil {
+		t.Fatalf("expected retained dict encoder")
+	}
+	retained := prep.dictEncoder
+	retainedKey := prep.dictEncoderKey
+
+	prep.TrimScratchForReuse()
+	if prep.dictEncoder != retained || prep.dictEncoderKey != retainedKey {
+		t.Fatalf("trim released retained dict encoder")
+	}
+
+	prep.SetDictFrameEncoderOptions(zstd.SpeedFastest, false)
+	if prep.dictEncoder != retained || prep.dictEncoderKey != retainedKey {
+		t.Fatalf("same encoder options released retained dict encoder")
+	}
+	body, stats, err = prep.PrepareFrameInto(body[:0], dictID, dict, records)
+	if err != nil {
+		t.Fatalf("second PrepareFrameInto: %v", err)
+	}
+	if !stats.Attempted || !stats.Kept {
+		t.Fatalf("expected second kept dict-compressed frame: attempted=%v kept=%v raw=%d stored=%d", stats.Attempted, stats.Kept, stats.RawPayloadBytes, stats.StoredPayloadBytes)
+	}
+	if prep.dictEncoder != retained || prep.dictEncoderKey != retainedKey {
+		t.Fatalf("second frame did not reuse retained dict encoder")
+	}
+
+	prep.SetDictFrameEncoderOptions(zstd.SpeedDefault, false)
+	if prep.dictEncoder != nil || prep.dictEncoderCodecs != nil || prep.dictEncoderKey != (dictCodecKey{}) {
+		t.Fatalf("option change retained dict encoder state: encoder=%p codecs=%p key=%+v", prep.dictEncoder, prep.dictEncoderCodecs, prep.dictEncoderKey)
+	}
+	body, stats, err = prep.PrepareFrameInto(body[:0], dictID, dict, records)
+	if err != nil {
+		t.Fatalf("third PrepareFrameInto after option change: %v", err)
+	}
+	if !stats.Attempted || !stats.Kept {
+		t.Fatalf("expected third kept dict-compressed frame: attempted=%v kept=%v raw=%d stored=%d", stats.Attempted, stats.Kept, stats.RawPayloadBytes, stats.StoredPayloadBytes)
+	}
+	if prep.dictEncoder == nil || prep.dictEncoderCodecs == nil {
+		t.Fatalf("expected retained dict encoder after option change")
+	}
+	reacquired := prep.dictEncoder
+	reacquiredKey := prep.dictEncoderKey
+	if reacquiredKey == retainedKey {
+		t.Fatalf("option change reused old encoder key: encoder=%p key=%+v", reacquired, reacquiredKey)
+	}
+
+	body, stats, err = prep.PrepareFrameInto(body[:0], dictID+1, dict2, records2)
+	if err != nil {
+		t.Fatalf("fourth PrepareFrameInto after dict change: %v", err)
+	}
+	if !stats.Attempted || !stats.Kept {
+		t.Fatalf("expected fourth kept dict-compressed frame: attempted=%v kept=%v raw=%d stored=%d", stats.Attempted, stats.Kept, stats.RawPayloadBytes, stats.StoredPayloadBytes)
+	}
+	if prep.dictEncoder == nil || prep.dictEncoderCodecs == nil {
+		t.Fatalf("expected retained dict encoder after dict change")
+	}
+	if prep.dictEncoderKey == reacquiredKey {
+		t.Fatalf("dict change reused old encoder key: encoder=%p key=%+v", prep.dictEncoder, prep.dictEncoderKey)
+	}
+
+	prep.ResetForReuse()
+	if prep.dictEncoder != nil || prep.dictEncoderCodecs != nil || prep.dictEncoderKey != (dictCodecKey{}) {
+		t.Fatalf("reset retained dict encoder state: encoder=%p codecs=%p key=%+v", prep.dictEncoder, prep.dictEncoderCodecs, prep.dictEncoderKey)
+	}
+}
+
+func TestWriter_DictEncoderRetainedAcrossFramesAndReleasedOnClose(t *testing.T) {
+	const dictID = uint64(3554)
+	dict, records := buildLargeDictCompressionFixture(t, dictID)
+
+	w := NewWriterWithSink(io.Discard, page.ValueLogFileID(1))
+	w.SetDictFrameEncoderOptions(zstd.SpeedFastest, false)
+	dst := make([]page.ValuePtr, len(records))
+	_, stats, err := w.AppendFrameWithStatsInto(dictID, dict, records, dst)
+	if err != nil {
+		t.Fatalf("AppendFrameWithStatsInto: %v", err)
+	}
+	if !stats.Attempted || !stats.Kept {
+		t.Fatalf("expected kept dict-compressed frame: attempted=%v kept=%v raw=%d stored=%d", stats.Attempted, stats.Kept, stats.RawPayloadBytes, stats.StoredPayloadBytes)
+	}
+	if w.dictEncoder == nil || w.dictEncoderCodecs == nil {
+		t.Fatalf("expected retained dict encoder")
+	}
+	retained := w.dictEncoder
+	retainedKey := w.dictEncoderKey
+
+	_, stats, err = w.AppendFrameWithStatsInto(dictID, dict, records, dst)
+	if err != nil {
+		t.Fatalf("second AppendFrameWithStatsInto: %v", err)
+	}
+	if !stats.Attempted || !stats.Kept {
+		t.Fatalf("expected second kept dict-compressed frame: attempted=%v kept=%v raw=%d stored=%d", stats.Attempted, stats.Kept, stats.RawPayloadBytes, stats.StoredPayloadBytes)
+	}
+	if w.dictEncoder != retained || w.dictEncoderKey != retainedKey {
+		t.Fatalf("second frame did not reuse retained dict encoder")
+	}
+
+	w.SetDictFrameEncoderOptions(zstd.SpeedFastest, false)
+	if w.dictEncoder != retained || w.dictEncoderKey != retainedKey {
+		t.Fatalf("same encoder options released retained dict encoder")
+	}
+	w.SetDictFrameEncoderOptions(zstd.SpeedDefault, false)
+	if w.dictEncoder != nil || w.dictEncoderCodecs != nil || w.dictEncoderKey != (dictCodecKey{}) {
+		t.Fatalf("option change retained dict encoder state: encoder=%p codecs=%p key=%+v", w.dictEncoder, w.dictEncoderCodecs, w.dictEncoderKey)
+	}
+
+	_, stats, err = w.AppendFrameWithStatsInto(dictID, dict, records, dst)
+	if err != nil {
+		t.Fatalf("third AppendFrameWithStatsInto: %v", err)
+	}
+	if !stats.Attempted || !stats.Kept {
+		t.Fatalf("expected third kept dict-compressed frame: attempted=%v kept=%v raw=%d stored=%d", stats.Attempted, stats.Kept, stats.RawPayloadBytes, stats.StoredPayloadBytes)
+	}
+	if w.dictEncoder == nil || w.dictEncoderCodecs == nil {
+		t.Fatalf("expected retained dict encoder after option change")
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if w.dictEncoder != nil || w.dictEncoderCodecs != nil || w.dictEncoderKey != (dictCodecKey{}) {
+		t.Fatalf("close retained dict encoder state: encoder=%p codecs=%p key=%+v", w.dictEncoder, w.dictEncoderCodecs, w.dictEncoderKey)
+	}
+}
+
 func TestFramePreparer_KeepPolicySkipsCompression(t *testing.T) {
 	records := []Record{
 		{RID: 1, Value: bytes.Repeat([]byte("alpha-001|"), 32)},

--- a/TreeDB/internal/valuelog/writer.go
+++ b/TreeDB/internal/valuelog/writer.go
@@ -77,6 +77,9 @@ type Writer struct {
 	blockCodecScratch      blockCodecScratch
 	skipDictID             uint64
 	codecs                 *dictCodecEntry
+	dictEncoder            *zstd.Encoder
+	dictEncoderCodecs      *dictCodecEntry
+	dictEncoderKey         dictCodecKey
 	dictFrameEncodeLevel   zstd.EncoderLevel
 	dictFrameEnableEntropy bool
 	blockCodec             BlockCodec
@@ -560,12 +563,46 @@ func (w *Writer) SetDictFrameEncoderOptions(level zstd.EncoderLevel, enableEntro
 	if w == nil {
 		return
 	}
-	w.dictFrameEncodeLevel = normalizeDictFrameEncodeLevel(level)
+	level = normalizeDictFrameEncodeLevel(level)
+	if w.dictFrameEncodeLevel != level || w.dictFrameEnableEntropy != enableEntropy {
+		w.releaseDictEncoder()
+	}
+	w.dictFrameEncodeLevel = level
 	w.dictFrameEnableEntropy = enableEntropy
 	w.codecs = nil
 	w.skipDictID = 0
 	w.noBenefit = 0
 	w.skipRemain = 0
+}
+
+func (w *Writer) releaseDictEncoder() {
+	if w == nil || w.dictEncoder == nil {
+		return
+	}
+	if w.dictEncoderCodecs != nil && w.dictEncoderCodecs.encPool != nil {
+		w.dictEncoderCodecs.encPool.Put(w.dictEncoder)
+	}
+	w.dictEncoder = nil
+	w.dictEncoderCodecs = nil
+	w.dictEncoderKey = dictCodecKey{}
+}
+
+func (w *Writer) dictEncoderFor(codecs *dictCodecEntry) (*zstd.Encoder, error) {
+	if w == nil || codecs == nil || codecs.encPool == nil {
+		return nil, ErrMissingDict
+	}
+	if w.dictEncoder != nil && w.dictEncoderCodecs == codecs && w.dictEncoderKey == codecs.key {
+		return w.dictEncoder, nil
+	}
+	w.releaseDictEncoder()
+	enc, ok := codecs.encPool.Get().(*zstd.Encoder)
+	if !ok || enc == nil {
+		return nil, ErrMissingDict
+	}
+	w.dictEncoder = enc
+	w.dictEncoderCodecs = codecs
+	w.dictEncoderKey = codecs.key
+	return enc, nil
 }
 
 // SetBlockCompression configures grouped frame block compression for dictID=0
@@ -1552,7 +1589,10 @@ func (w *Writer) AppendFrameWithStatsInto(dictID uint64, dict []byte, records []
 			max = defaultBufferSize
 		}
 
-		enc := codecs.encPool.Get().(*zstd.Encoder)
+		enc, err := w.dictEncoderFor(codecs)
+		if err != nil {
+			return nil, FrameStats{}, err
+		}
 
 		canDirectEncodeAll := w.f != nil && (k == 1 || rawPayloadBytes <= (1<<20))
 		if canDirectEncodeAll {
@@ -1575,7 +1615,6 @@ func (w *Writer) AppendFrameWithStatsInto(dictID uint64, dict []byte, records []
 			}
 			if len(w.appendBuf)+recordMaxLen > max {
 				if err := w.flushAppendBuf(); err != nil {
-					codecs.encPool.Put(enc)
 					return nil, FrameStats{}, err
 				}
 			}
@@ -1603,7 +1642,6 @@ func (w *Writer) AppendFrameWithStatsInto(dictID uint64, dict []byte, records []
 				rid := records[i].RID
 				if rid == 0 {
 					w.appendBuf = w.appendBuf[:recordStart]
-					codecs.encPool.Put(enc)
 					return nil, FrameStats{}, errors.New("valuelog: missing rid")
 				}
 				binary.LittleEndian.PutUint64(prefix[prefixOff:prefixOff+8], rid)
@@ -1642,7 +1680,6 @@ func (w *Writer) AppendFrameWithStatsInto(dictID uint64, dict []byte, records []
 				w.appendBuf = enc.EncodeAll(payload, w.appendBuf)
 			}
 			encodeNs := w.sampleEncodeEnd(encodeStart, rawPayloadBytes, k)
-			codecs.encPool.Put(enc)
 
 			encodedLen := len(w.appendBuf) - encodedStart
 			keepCompressed := w.shouldKeepCompressed(rawPayloadBytes, encodedLen, encodeNs)
@@ -1765,7 +1802,6 @@ func (w *Writer) AppendFrameWithStatsInto(dictID uint64, dict []byte, records []
 			encoded = w.encLimiter.buf
 		}
 		encodeNs := w.sampleEncodeEnd(encodeStart, rawPayloadBytes, k)
-		codecs.encPool.Put(enc)
 		w.encScratch = w.encScratch[:0]
 
 		keepCompressed := false
@@ -2303,6 +2339,7 @@ func (w *Writer) Close() error {
 	if w == nil {
 		return nil
 	}
+	defer w.releaseDictEncoder()
 	defer w.releaseAppendBuf()
 	defer w.releaseTransientScratchBuffers()
 	if err := w.flushNoTrim(); err != nil {


### PR DESCRIPTION
## Summary
- add a gated canonical point-unit flush path for span-free, span-target-planning-off flushes where every queued unit has stable unsafe iterator slices
- count source/delete ops with stable iterators for existing backend chunk sizing, then heap-merge `NewIterator` streams directly into the existing chunk buffer
- keep `buildCanonicalUnitRuns` / `buildOpRuns` as fallback for unstable units, range spans, and span target planning

## Scope
- Refs #3562 and parent tracker #3515.
- Head: `9c1b95132324daff1e2443b0166faa91fb6f1669` on current `main` after #3554 merged.
- No value-log, WAL, command-WAL, public API, durability, or on-disk format changes.
- The new path is disabled when span target planning is enabled or range spans are present.

## Validation
Focused local gate:

- `GOWORK=off TMPDIR=/mnt/fast4tb/tmp go test ./TreeDB/caching`
- `GOWORK=off TMPDIR=/mnt/fast4tb/tmp go test ./TreeDB/caching -run '^$' -bench '^BenchmarkCanonicalFlushStableIteratorVsMaterialized$' -benchmem -count=5`

Focused benchmark final observed range:

| Variant | ns/op range | B/op | allocs/op |
| --- | ---: | ---: | ---: |
| materialized unit runs | 3.29-3.44 ms/op | ~2,714,248-2,714,409 | 57 |
| stable iterators | 2.97-3.27 ms/op | ~904,892-905,013 | 23 |

## Ironbird Macro Gate
All rows below are accepted Ironbird rows with heap profile capture and the same workload shape as the current-main baseline.

Plain-send artifacts:

- baseline: `/mnt/fast4tb/ironbird-3554-current-main-baseline-20260706T135857Z/plain-send/treedb/attempt-1`
- candidate: `/mnt/fast4tb/ironbird-3565-streamflush-plain-retry-20260706T152929Z/plain-send/treedb/attempt-1`

| Metric | Current main | Candidate | Delta |
| --- | ---: | ---: | ---: |
| accepted load-window TPS | 583.32 | 583.30 | -0.005% |
| total alloc_space | 135,887.07 MB | 121,991.71 MB | -10.23% |
| TreeDB-focused alloc_space | 46,077.58 MB | 32,034.92 MB | -30.47% |
| `TreeDB/caching.getEntrySlice` | 7,778.82 MB | 4.82 MB | -99.94% |
| `TreeDB/internal/memtable.getAppendOnlyEntries` | 6,877.68 MB | 4,460.58 MB | -35.14% |
| commit observed time | 44.801 s | 44.320 s | -0.480 s |
| finalize observed time | 41.015 s | 42.386 s | +1.371 s |
| check_tx observed time | 100.726 s | 103.130 s | +2.404 s |
| metrics-after RSS | 7.06 GiB | 7.35 GiB | +0.29 GiB |

Small-multisend artifacts:

- baseline: `/mnt/fast4tb/ironbird-3554-current-main-small-long-20260706T141439Z/small-multisend/treedb/attempt-1`
- candidate: `/mnt/fast4tb/ironbird-3565-streamflush-small-20260706T154231Z/small-multisend/treedb/attempt-1`

| Metric | Current main | Candidate | Delta |
| --- | ---: | ---: | ---: |
| accepted load-window TPS | 578.37 | 582.42 | +0.70% |
| effective ops/s | 1,156.73 | 1,164.85 | +0.70% |
| total alloc_space | 161,191.13 MB | 145,800.39 MB | -9.55% |
| TreeDB-focused alloc_space | 44,128.19 MB | 28,127.89 MB | -36.26% |
| `TreeDB/caching.getEntrySlice` | 9,398.05 MB | 4.23 MB | -99.96% |
| `TreeDB/internal/memtable.getAppendOnlyEntries` | 8,180.11 MB | 4,324.92 MB | -47.13% |
| commit observed time | 49.559 s | 49.385 s | -0.174 s |
| finalize observed time | 50.656 s | 49.866 s | -0.790 s |
| check_tx observed time | 130.166 s | 131.410 s | +1.243 s |
| metrics-after RSS | 7.47 GiB | 7.87 GiB | +0.40 GiB |

Gate assessment: accepted. The intended `getEntrySlice` allocation disappears in both macro rows, total and TreeDB-focused allocation drop materially, TPS is neutral/slightly better, and commit/finalize timing is neutral to better except for small check_tx noise. RSS-after is higher by about 0.3-0.4 GiB and should be watched in future rows, but it did not accompany allocation, TPS, or commit/finalize regression in this gate.

## Review Status
- Latest-head CI is still required before merge.
- CodeRabbit skipped while the PR was draft; request review after this evidence update and ready-for-review transition.
