### PR TITLE
TreeDB: defer untouched read-only separator clones

### DIFF
--- a/TreeDB/zipper/read_only_prepare.go
+++ b/TreeDB/zipper/read_only_prepare.go
@@ -1049,6 +1049,7 @@ func (z *Zipper) prepareReadOnlyRecursive(ref page.ChildRef, ops []batch.Entry, 
 		return nil
 	case page.PageTypeInternal:
 		count := oldNode.Count()
+		baseDeltaInternalKeys := oldNode.InternalBaseDeltaEnabled()
 		opIdx := 0
 		for i := uint16(0); i < count; i++ {
 			key, childRef, err := oldNode.GetInternalEntryRefView(i)
@@ -1058,12 +1059,10 @@ func (z *Zipper) prepareReadOnlyRecursive(ref page.ChildRef, ops []batch.Entry, 
 			if key == nil {
 				key = []byte{}
 			}
-			childLow := low
-			if len(key) != 0 {
-				// Base-delta internal pages may return key views backed by shared
-				// node scratch. Clone the current separator before fetching the
-				// next entry, which can overwrite the view.
-				childLow = result.cloneKey(key)
+			keyNonEmpty := len(key) != 0
+			firstOpBeforeKey := false
+			if keyNonEmpty && opIdx < len(ops) && bytes.Compare(ops[opIdx].Key, key) < 0 {
+				firstOpBeforeKey = true
 			}
 
 			var endKey []byte
@@ -1086,18 +1085,76 @@ func (z *Zipper) prepareReadOnlyRecursive(ref page.ChildRef, ops []batch.Entry, 
 				}
 				break
 			}
-
-			childHigh := high
-			if endKey != nil {
-				childHigh = result.cloneKey(endKey)
-			}
 			childOps := ops[startOpIdx:opIdx]
-			if len(childOps) > 0 && childLow != nil && bytes.Compare(childOps[0].Key, childLow) < 0 {
-				childLow = result.cloneKey(childOps[0].Key)
+
+			childLow := low
+			childLowFromSeparator := false
+			if keyNonEmpty {
+				if len(childOps) > 0 && firstOpBeforeKey {
+					childLow = childOps[0].Key
+				} else {
+					childLow = key
+					childLowFromSeparator = true
+				}
 			}
-			rangeStart, rangeEnd := deleteRangeIndexSpan(ranges, childLow, childHigh)
+			childHigh := high
+			childHighFromSeparator := false
+			if endKey != nil {
+				childHigh = endKey
+				childHighFromSeparator = true
+			}
+
+			rangeStart, rangeEnd := 0, 0
+			if len(ranges) > 0 {
+				if childLowFromSeparator {
+					if baseDeltaInternalKeys {
+						if childHighFromSeparator {
+							childHigh = result.cloneKey(childHigh)
+							childHighFromSeparator = false
+						}
+						key, _, err = oldNode.GetInternalEntryRefView(i)
+						if err != nil {
+							return err
+						}
+						if key == nil {
+							key = []byte{}
+						}
+						childLow = key
+					}
+					childLow = result.cloneKey(childLow)
+					childLowFromSeparator = false
+				}
+				if childHighFromSeparator {
+					childHigh = result.cloneKey(childHigh)
+					childHighFromSeparator = false
+				}
+				rangeStart, rangeEnd = deleteRangeIndexSpan(ranges, childLow, childHigh)
+			}
 			if len(childOps) == 0 && rangeStart == rangeEnd {
 				continue
+			}
+
+			if childLowFromSeparator {
+				if baseDeltaInternalKeys {
+					if childHighFromSeparator {
+						// Base-delta internal keys can share node scratch; keep the
+						// already-decoded high separator stable before refetching low.
+						childHigh = result.cloneKey(childHigh)
+						childHighFromSeparator = false
+					}
+					key, _, err = oldNode.GetInternalEntryRefView(i)
+					if err != nil {
+						return err
+					}
+					if key == nil {
+						key = []byte{}
+					}
+					childLow = key
+				}
+				childLow = result.cloneKey(childLow)
+			}
+			if childHighFromSeparator {
+				childHigh = result.cloneKey(childHigh)
 			}
 			if err := z.prepareReadOnlyRecursive(childRef, childOps, opBase+startOpIdx, ranges[rangeStart:rangeEnd], rangeBase+rangeStart, childLow, childHigh, result, scratch); err != nil {
 				return err

--- a/TreeDB/zipper/read_only_prepare.go
+++ b/TreeDB/zipper/read_only_prepare.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/snissn/gomap/TreeDB/batch"
 	"github.com/snissn/gomap/TreeDB/internal/adaptive"
+	"github.com/snissn/gomap/TreeDB/node"
 	"github.com/snissn/gomap/TreeDB/page"
 )
 
@@ -1106,27 +1107,9 @@ func (z *Zipper) prepareReadOnlyRecursive(ref page.ChildRef, ops []batch.Entry, 
 
 			rangeStart, rangeEnd := 0, 0
 			if len(ranges) > 0 {
-				if childLowFromSeparator {
-					if baseDeltaInternalKeys {
-						if childHighFromSeparator {
-							childHigh = result.cloneKey(childHigh)
-							childHighFromSeparator = false
-						}
-						key, _, err = oldNode.GetInternalEntryRefView(i)
-						if err != nil {
-							return err
-						}
-						if key == nil {
-							key = []byte{}
-						}
-						childLow = key
-					}
-					childLow = result.cloneKey(childLow)
-					childLowFromSeparator = false
-				}
-				if childHighFromSeparator {
-					childHigh = result.cloneKey(childHigh)
-					childHighFromSeparator = false
+				childLow, childHigh, childLowFromSeparator, childHighFromSeparator, err = stabilizeReadOnlyChildSeparatorBounds(oldNode, i, childLow, childHigh, childLowFromSeparator, childHighFromSeparator, baseDeltaInternalKeys, result)
+				if err != nil {
+					return err
 				}
 				rangeStart, rangeEnd = deleteRangeIndexSpan(ranges, childLow, childHigh)
 			}
@@ -1134,27 +1117,9 @@ func (z *Zipper) prepareReadOnlyRecursive(ref page.ChildRef, ops []batch.Entry, 
 				continue
 			}
 
-			if childLowFromSeparator {
-				if baseDeltaInternalKeys {
-					if childHighFromSeparator {
-						// Base-delta internal keys can share node scratch; keep the
-						// already-decoded high separator stable before refetching low.
-						childHigh = result.cloneKey(childHigh)
-						childHighFromSeparator = false
-					}
-					key, _, err = oldNode.GetInternalEntryRefView(i)
-					if err != nil {
-						return err
-					}
-					if key == nil {
-						key = []byte{}
-					}
-					childLow = key
-				}
-				childLow = result.cloneKey(childLow)
-			}
-			if childHighFromSeparator {
-				childHigh = result.cloneKey(childHigh)
+			childLow, childHigh, _, _, err = stabilizeReadOnlyChildSeparatorBounds(oldNode, i, childLow, childHigh, childLowFromSeparator, childHighFromSeparator, baseDeltaInternalKeys, result)
+			if err != nil {
+				return err
 			}
 			if err := z.prepareReadOnlyRecursive(childRef, childOps, opBase+startOpIdx, ranges[rangeStart:rangeEnd], rangeBase+rangeStart, childLow, childHigh, result, scratch); err != nil {
 				return err
@@ -1164,6 +1129,34 @@ func (z *Zipper) prepareReadOnlyRecursive(ref page.ChildRef, ops []batch.Entry, 
 	default:
 		return page.ErrInvalidPageType
 	}
+}
+
+func stabilizeReadOnlyChildSeparatorBounds(oldNode node.Node, childIndex uint16, childLow, childHigh []byte, childLowFromSeparator, childHighFromSeparator, baseDeltaInternalKeys bool, result *ReadOnlyPrepareResult) ([]byte, []byte, bool, bool, error) {
+	if childLowFromSeparator {
+		if baseDeltaInternalKeys {
+			if childHighFromSeparator {
+				// Base-delta internal keys can share node scratch; keep the
+				// already-decoded high separator stable before refetching low.
+				childHigh = result.cloneKey(childHigh)
+				childHighFromSeparator = false
+			}
+			key, _, err := oldNode.GetInternalEntryRefView(childIndex)
+			if err != nil {
+				return nil, nil, false, false, err
+			}
+			if key == nil {
+				key = []byte{}
+			}
+			childLow = key
+		}
+		childLow = result.cloneKey(childLow)
+		childLowFromSeparator = false
+	}
+	if childHighFromSeparator {
+		childHigh = result.cloneKey(childHigh)
+		childHighFromSeparator = false
+	}
+	return childLow, childHigh, childLowFromSeparator, childHighFromSeparator, nil
 }
 
 func deleteRangeIndexSpan(ranges []batch.DeleteRange, low, high []byte) (int, int) {

--- a/TreeDB/zipper/read_only_prepare_test.go
+++ b/TreeDB/zipper/read_only_prepare_test.go
@@ -64,6 +64,44 @@ func buildReadOnlyPrepareRootWithKeys(tb testing.TB, z *Zipper, count int) uint6
 	return newRootID
 }
 
+func buildReadOnlyPrepareWideBaseDeltaRoot(tb testing.TB, z *Zipper, children int) uint64 {
+	tb.Helper()
+	leafID, err := z.pager.Alloc(1)
+	if err != nil {
+		tb.Fatalf("alloc leaf: %v", err)
+	}
+	leafData, err := z.pager.Get(leafID)
+	if err != nil {
+		tb.Fatalf("get leaf: %v", err)
+	}
+	leaf := node.NewNode(leafData)
+	leaf.SetPageID(leafID)
+	leaf.SetType(page.PageTypeLeaf)
+	leaf.UpdateChecksum()
+
+	rootID, err := z.pager.Alloc(1)
+	if err != nil {
+		tb.Fatalf("alloc root: %v", err)
+	}
+	rootData, err := z.pager.Get(rootID)
+	if err != nil {
+		tb.Fatalf("get root: %v", err)
+	}
+	builder := node.NewBuilderWithOptions(rootData, page.PageTypeInternal, node.BuilderOptions{InternalBaseDelta: true})
+	builder.SetPageID(rootID)
+	for i := 0; i < children; i++ {
+		key := []byte(fmt.Sprintf("child-%06d", i))
+		if err := builder.AddInternalChild(key, leafID); err != nil {
+			tb.Fatalf("AddInternalChild(%d): %v", i, err)
+		}
+	}
+	root := builder.Finish()
+	if root.Type() != page.PageTypeInternal || !root.InternalBaseDeltaEnabled() {
+		tb.Fatalf("synthetic root type/base-delta=%v/%v want internal/base-delta", root.Type(), root.InternalBaseDeltaEnabled())
+	}
+	return rootID
+}
+
 func readOnlySpanSignature(prepared ReadOnlyPrepareResult) []string {
 	out := make([]string, len(prepared.LeafSpans))
 	for i, span := range prepared.LeafSpans {
@@ -396,6 +434,34 @@ func TestZipperPrepareReadOnlyOmitKeysSkipsSpanKeyCopies(t *testing.T) {
 	requireValidReadOnlyPrepare(t, reused)
 	if !reused.OmitKeys || len(reused.keyArena) != 0 || cap(reused.keyArena) != 0 {
 		t.Fatalf("reused omit-keys result OmitKeys=%v keyArena len/cap=%d/%d", reused.OmitKeys, len(reused.keyArena), cap(reused.keyArena))
+	}
+}
+
+func TestZipperPrepareReadOnlyPointOnlyDefersUntouchedBaseDeltaSeparatorClones(t *testing.T) {
+	_, z := newReadOnlyPrepareZipper(t)
+	rootID := buildReadOnlyPrepareWideBaseDeltaRoot(t, z, 384)
+
+	const touched = 250
+	key := []byte(fmt.Sprintf("child-%06d", touched))
+	delta := batch.New(panicValueReader{}, page.DefaultInlineThreshold)
+	defer func() { _ = delta.Close() }()
+	if err := delta.Set(key, []byte("new")); err != nil {
+		t.Fatalf("Set delta: %v", err)
+	}
+
+	prepared, err := z.PrepareReadOnly(rootID, delta, ReadOnlyPrepareOptions{})
+	if err != nil {
+		t.Fatalf("PrepareReadOnly: %v", err)
+	}
+	requireValidReadOnlyPrepare(t, prepared)
+	if len(prepared.LeafSpans) != 1 {
+		t.Fatalf("leaf spans=%d want 1", len(prepared.LeafSpans))
+	}
+
+	retainedKeyBytes := readOnlyPrepareSpanBoundaryBytes(prepared.LeafSpans) + readOnlyPrepareSpanOpKeyBytes(prepared.LeafSpans)
+	separatorKeyBytes := len([]byte(fmt.Sprintf("child-%06d", touched))) + len([]byte(fmt.Sprintf("child-%06d", touched+1)))
+	if got, max := len(prepared.keyArena), retainedKeyBytes+separatorKeyBytes; got > max {
+		t.Fatalf("key arena bytes=%d, retained=%d separator temp=%d; likely cloned untouched separators", got, retainedKeyBytes, separatorKeyBytes)
 	}
 }
 
@@ -920,6 +986,45 @@ func BenchmarkZipperPrepareReadOnlyManyLeafRandomKeyModes(b *testing.B) {
 			}
 		})
 	}
+}
+
+func BenchmarkZipperPrepareReadOnlyWideBaseDeltaSparsePoint(b *testing.B) {
+	_, z := newReadOnlyPrepareZipper(b)
+	rootID := buildReadOnlyPrepareWideBaseDeltaRoot(b, z, 384)
+	delta := batch.NewRetainingLargeEntries(panicValueReader{}, page.DefaultInlineThreshold)
+	defer func() { _ = delta.Close() }()
+	if err := delta.Set([]byte("child-000250"), []byte("new-value")); err != nil {
+		b.Fatalf("Set delta: %v", err)
+	}
+	delta.SortedEntries()
+
+	first, err := z.PrepareReadOnly(rootID, delta, ReadOnlyPrepareOptions{})
+	if err != nil {
+		b.Fatalf("initial PrepareReadOnly: %v", err)
+	}
+	requireValidReadOnlyPrepare(b, first)
+	opts := first.ReuseOptions()
+	lastSummary := first.LeafSpanSummary()
+	lastKeyArenaBytes := len(first.keyArena)
+	lastRetainedKeyBytes := readOnlyPrepareSpanBoundaryBytes(first.LeafSpans) + readOnlyPrepareSpanOpKeyBytes(first.LeafSpans)
+	b.ReportAllocs()
+	b.SetBytes(int64(lastSummary.SpanBytes))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		prepared, err := z.PrepareReadOnly(rootID, delta, opts)
+		if err != nil {
+			b.Fatalf("PrepareReadOnly: %v", err)
+		}
+		lastSummary = prepared.LeafSpanSummary()
+		lastKeyArenaBytes = len(prepared.keyArena)
+		lastRetainedKeyBytes = readOnlyPrepareSpanBoundaryBytes(prepared.LeafSpans) + readOnlyPrepareSpanOpKeyBytes(prepared.LeafSpans)
+		opts = prepared.ReuseOptions()
+	}
+	b.StopTimer()
+	b.ReportMetric(float64(lastSummary.Spans), "leaf_spans/op")
+	b.ReportMetric(float64(lastSummary.SpanOps), "span_ops/op")
+	b.ReportMetric(float64(lastKeyArenaBytes), "key_arena_bytes/op")
+	b.ReportMetric(float64(lastRetainedKeyBytes), "retained_key_bytes/op")
 }
 
 func benchmarkZipperPrepareReadOnlyRandom(b *testing.B, keyCount, batchSize int) {


### PR DESCRIPTION
## Summary

Closes #3566.

This PR reduces TreeDB allocation in the read-only prepare path used by span-native flush apply. `prepareReadOnlyRecursive` previously cloned internal separator low/high keys before proving that a child had point or range work. The confirmed Ironbird plain-send hotspot was `zipper.(*ReadOnlyPrepareResult).cloneKey`, mostly from this recursive prepare path during canonical flush writes.

The change keeps delete-range handling conservative and still clones separator views before recursion/retention for touched children, especially base-delta internal pages where key views can be scratch-backed. The allocation win is that untouched point-only internal children no longer clone separator bounds.

## Scope Boundary

Included:
- `TreeDB/zipper/read_only_prepare.go`
- focused tests/benchmarks in `TreeDB/zipper/read_only_prepare_test.go`

Excluded:
- command-WAL changes
- memtable or caching entry-slice changes
- value-log/WAL durability changes
- public API or on-disk format changes

## Local Correctness And Reproducer Evidence

Focused before/after benchmark with identical benchmark body:

| Benchmark | Base `6f2d94d` | Candidate `3848fab` | Delta |
| --- | ---: | ---: | ---: |
| `BenchmarkZipperPrepareReadOnlyWideBaseDeltaSparsePoint` `key_arena_bytes/op` | `9252` | `72` | `-99.22%` |
| same benchmark `ns/op` | `19.2-20.4 us` | `16.3-16.4 us` | faster |
| same benchmark `B/op` | `64` | `64` | neutral |
| same benchmark `allocs/op` | `1` | `1` | neutral |

Dense read-only prepare guard on candidate:

| Benchmark mode | Candidate result |
| --- | ---: |
| `ManyLeafRandomKeyModes/full_keys/reuse` | `0 B/op`, `0 allocs/op`, `2800 key_arena_bytes/op` |
| `ManyLeafRandomKeyModes/omit_op_keys/reuse` | `0 B/op`, `0 allocs/op`, `1860 key_arena_bytes/op` |
| `ManyLeafRandomKeyModes/omit_all_keys/reuse` | `0 B/op`, `0 allocs/op`, `0 key_arena_bytes/op` |

## Ironbird Macro Evidence

Run shape for both plain-send rows:
- scenario: `simapp-treedb-all`
- TreeDB app DB and TreeDB CometBFT node DB
- `preseed-profile=accounts`, `preseed-accounts=100000`, `wallets=5000`
- `400` blocks x `500` txs/block, `MsgSend`, one contained message, one recipient
- `load-window-min-duration=5m`, accepted load window >=300s

Plain-send artifacts:

| Row | Artifact | Gomap |
| --- | --- | --- |
| baseline | `/mnt/fast4tb/ironbird-3566-current-main-plain-20260706T162213Z/plain-send/treedb/attempt-1` | `6f2d94def23551ccb1c6bdb35514bc72733d88e0` |
| candidate macro row | `/mnt/fast4tb/ironbird-3567-clonekey-plain-20260706T165524Z/plain-send/treedb/attempt-1` | `3848fabeb9a1fc1ef570bb1fc39a7fe5c6932c98` |

Plain-send result:

| Metric | Baseline | Candidate | Delta | Gate |
| --- | ---: | ---: | ---: | --- |
| total alloc_space | `118380.47 MB` | `110324.47 MB` | `-6.8%` | pass |
| TreeDB-focused flat alloc_space | `26753.94 MB` | `18948.87 MB` | `-29.2%` | pass |
| `ReadOnlyPrepareResult.cloneKey` alloc_space | `9218.10 MB` | `0 / no focused samples` | effectively removed | pass |
| load-window TPS | `583.29` | `578.45` | `-0.83%` | neutral within 1% guard |
| avg commit seconds | `0.05232` | `0.05300` | `+1.3%` | neutral |
| avg finalize seconds | `0.04540` | `0.05438` | worse/noisy | caveat |
| check_tx seconds | `99.56s` | `111.30s` | worse/noisy | caveat |

Run shape for both small-multisend guard rows:
- scenario: `simapp-treedb-all`
- TreeDB app DB and TreeDB CometBFT node DB
- `preseed-profile=accounts`, `preseed-accounts=100000`, `wallets=5000`
- `500` blocks x `500` txs/block, `MsgMultiSend`, two recipients
- `load-window-min-duration=5m`, accepted load window >=300s

Small-multisend artifacts:

| Row | Artifact | Gomap |
| --- | --- | --- |
| baseline | `/mnt/fast4tb/ironbird-3566-current-main-small-20260706T170901Z/small-multisend/treedb/attempt-1` | `6f2d94def23551ccb1c6bdb35514bc72733d88e0` |
| candidate macro row | `/mnt/fast4tb/ironbird-3567-clonekey-small-20260706T171909Z/small-multisend/treedb/attempt-1` | `3848fabeb9a1fc1ef570bb1fc39a7fe5c6932c98` |

Small-multisend guard result:

| Metric | Baseline | Candidate | Delta | Gate |
| --- | ---: | ---: | ---: | --- |
| total alloc_space | `145843.49 MB` | `145018.05 MB` | `-0.57%` | pass/neutral |
| TreeDB-focused flat alloc_space | `26227.99 MB` | `24923.22 MB` | `-4.97%` | pass/neutral |
| `ReadOnlyPrepareResult.cloneKey` alloc_space | `0 / no focused samples` | `0 / no focused samples` | neutral | pass |
| load-window TPS | `577.68` | `572.38` | `-0.92%` | neutral within 1% guard |
| avg commit seconds | `0.04742` | `0.04745` | neutral | pass |
| avg finalize seconds | `0.05078` | `0.05223` | `+2.9%` | minor caveat |
| application DB bytes delta | `2042953631` | `2009520991` | lower | pass |

Interpretation: this is a real allocation reduction for the confirmed plain-send TreeDB allocator. It is not an observed throughput win. The accepted Ironbird rows are within the neutral throughput guard, with allocation lower and no small-multisend cloneKey regression.

## Tests Run

```sh
GOWORK=off TMPDIR=/mnt/fast4tb/tmp go test ./TreeDB/zipper -run 'TestZipperPrepareReadOnly(PointOnlyDefersUntouchedBaseDeltaSeparatorClones|OmitKeysSkipsSpanKeyCopies|OmitOpKeysKeepsSpanBoundaries|RandomizedPartition|ResultValidateLeafSpansContracts)' -count=1
GOWORK=off TMPDIR=/mnt/fast4tb/tmp go test ./TreeDB/zipper -count=1
GOWORK=off TMPDIR=/mnt/fast4tb/tmp go test ./TreeDB/db ./TreeDB/caching -count=1
GOWORK=off TMPDIR=/mnt/fast4tb/tmp go test ./TreeDB/zipper -run '^$' -bench '^BenchmarkZipperPrepareReadOnlyWideBaseDeltaSparsePoint$' -benchtime=1s -count=5 -benchmem
GOWORK=off TMPDIR=/mnt/fast4tb/tmp go test ./TreeDB/zipper -run '^$' -bench '^(BenchmarkZipperPrepareReadOnlyWideBaseDeltaSparsePoint|BenchmarkZipperPrepareReadOnlyManyLeafRandomKeyModes)$' -benchtime=1s -count=1 -benchmem
```

Latest PR head is `60bdaa97124f820ec6a3caf76f74a4a8da90816a`, a CodeRabbit-requested helper extraction over the macro-validated commit. Local focused tests and the sparse allocation benchmark were rerun on `60bdaa971`; latest-head GitHub CI is pending after the review-fix push.

## Review Status

Internal review completed after macro validation. The main correctness risk is separator key ownership on base-delta internal pages; touched separator bounds are still cloned before recursion or retention, delete-range handling remains conservative, and retained leaf-span keys are still owned by `ReadOnlyPrepareResult`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved read-only preparation for wide internal trees so child key ranges are built more reliably, especially when handling sparse updates and shared separator data.
  * Reduced unnecessary cloning of separator keys for untouched parts of the tree, helping keep memory use lower during preparation.

* **Tests**
  * Added coverage for sparse point updates on wide base-delta trees.
  * Added a benchmark to track performance and allocation behavior for this scenario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Latest-Head Review Fix

After CodeRabbit review, the duplicated separator-bound stabilization sequence was extracted into `stabilizeReadOnlyChildSeparatorBounds` in commit `60bdaa97124f820ec6a3caf76f74a4a8da90816a`. This is intended as a no-behavior-change refactor of the scratch-safety ordering.

Latest-head local validation after that refactor:

```sh
GOWORK=off TMPDIR=/mnt/fast4tb/tmp go test ./TreeDB/zipper -run 'TestZipperPrepareReadOnly(PointOnlyDefersUntouchedBaseDeltaSeparatorClones|OmitKeysSkipsSpanKeyCopies|OmitOpKeysKeepsSpanBoundaries|RandomizedPartition|ResultValidateLeafSpansContracts)' -count=1
GOWORK=off TMPDIR=/mnt/fast4tb/tmp go test ./TreeDB/zipper -count=1
GOWORK=off TMPDIR=/mnt/fast4tb/tmp go test ./TreeDB/zipper -run '^$' -bench '^BenchmarkZipperPrepareReadOnlyWideBaseDeltaSparsePoint$' -benchtime=1s -count=3 -benchmem
```

Latest-head sparse benchmark remains at `72 key_arena_bytes/op`, `64 B/op`, `1 alloc/op`, with `16477-16631 ns/op` across the three repeats.
