### PR TITLE
treedb: retain more leaf-ref build pages

### DIFF
--- a/TreeDB/zipper/zipper.go
+++ b/TreeDB/zipper/zipper.go
@@ -197,7 +197,7 @@ const (
 	mergeLeafPageBatchKeep            = 64
 	mergeLeafPageBatchMaxCap          = 512
 	mergeLeafRefCachePageInit         = 16
-	mergeLeafRefCachePageKeep         = 4096
+	mergeLeafRefCachePageKeep         = 8192
 	mergeChildRefBatchInit            = 8
 	mergeChildRefBatchKeep            = 64
 	mergeChildRefBatchMaxCap          = 512

--- a/TreeDB/zipper/zipper_test.go
+++ b/TreeDB/zipper/zipper_test.go
@@ -617,6 +617,109 @@ func TestZipperLeafRefCacheAdoptsBuildPagesUntilCacheClose(t *testing.T) {
 	}
 }
 
+func TestZipperLeafRefCacheOverflowBuildPagesStayPinnedUntilClose(t *testing.T) {
+	dir := t.TempDir()
+	p, err := pager.Open(filepath.Join(dir, "index.db"), 65536)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer p.Close()
+
+	alloc := &MockAllocator{p: p}
+	z := New(p, alloc)
+	z.SetOuterLeavesInValueLog(true)
+	z.SetLeafPageLog(&stubLeafPageLog{})
+	reader := &countingLeafPageReader{}
+	z.SetLeafPageReader(reader)
+
+	writeLeaf := func(dst []byte, key, val string) {
+		t.Helper()
+		clear(dst)
+		b := node.NewBuilder(dst, page.PageTypeLeaf)
+		b.SetPageID(0)
+		if err := b.AddLeafEntry([]byte(key), []byte(val), node.FlagInline, page.ValuePtr{}); err != nil {
+			t.Fatalf("AddLeafEntry(%q): %v", key, err)
+		}
+		b.FinishNoNode()
+	}
+	mutateInternal := func(dst []byte) {
+		t.Helper()
+		clear(dst)
+		n := node.NewNode(dst)
+		n.SetType(page.PageTypeInternal)
+		n.UpdateChecksum()
+	}
+	assertCachedLeaf := func(ref page.ChildRef, wantKey, wantVal string) {
+		t.Helper()
+		loaded, fromPager, leafScratch, leafScratchRef, loadSource, err := z.loadNodeRef(ref, nil)
+		if err != nil {
+			t.Fatalf("loadNodeRef(%q): %v", wantKey, err)
+		}
+		if leafScratchRef {
+			putLeafPageScratch(leafScratch)
+		}
+		if fromPager {
+			t.Fatalf("fromPager=%t want false", fromPager)
+		}
+		if loadSource != zipperNodeLoadLeafLogCache {
+			t.Fatalf("loadSource=%d want leaf-log cache", loadSource)
+		}
+		gotKey, gotVal, _, flags, err := loaded.GetLeafEntryView(0)
+		if err != nil {
+			t.Fatalf("GetLeafEntryView: %v", err)
+		}
+		if flags != node.FlagInline || string(gotKey) != wantKey || string(gotVal) != wantVal {
+			t.Fatalf("cached leaf entry=(%q,%q flags=0x%x), want (%q,%q inline)", gotKey, gotVal, flags, wantKey, wantVal)
+		}
+	}
+
+	scratch := z.acquireApplyScratch()
+	z.beginLeafRefCache(scratch)
+
+	active := make([][]byte, mergeLeafRefCachePageKeep+1)
+	activePtrs := make(map[*byte]struct{}, len(active)+1)
+	for i := range active {
+		active[i] = scratch.acquireLeafRefCacheBuildPage()
+		ptr := &active[i][0]
+		if _, ok := activePtrs[ptr]; ok {
+			t.Fatalf("active build page %d reused before cache close", i)
+		}
+		activePtrs[ptr] = struct{}{}
+	}
+
+	writeLeaf(active[0], "first", "one")
+	firstRef, err := z.persistLeafPageDataWithCacheOwnership(active[0], nil, leafPageCacheAdoptOwned)
+	if err != nil {
+		t.Fatalf("persist first leaf: %v", err)
+	}
+	overflowIdx := len(active) - 1
+	writeLeaf(active[overflowIdx], "overflow", "two")
+	overflowRef, err := z.persistLeafPageDataWithCacheOwnership(active[overflowIdx], nil, leafPageCacheAdoptOwned)
+	if err != nil {
+		t.Fatalf("persist overflow leaf: %v", err)
+	}
+
+	extra := scratch.acquireLeafRefCacheBuildPage()
+	if _, ok := activePtrs[&extra[0]]; ok {
+		t.Fatalf("new active build page reused a cache-pinned page before cache close")
+	}
+
+	for i := 1; i < overflowIdx; i++ {
+		mutateInternal(active[i])
+	}
+	mutateInternal(extra)
+
+	assertCachedLeaf(firstRef, "first", "one")
+	assertCachedLeaf(overflowRef, "overflow", "two")
+
+	z.endLeafRefCache()
+	z.releaseApplyScratch(scratch)
+
+	if got := reader.calls.Load(); got != 0 {
+		t.Fatalf("leafPageReader calls=%d want 0", got)
+	}
+}
+
 func TestZipperCachePersistedLeafPageNoopAvoidsLockWhenCacheInactive(t *testing.T) {
 	z := &Zipper{}
 	z.leafRefCacheMu.Lock()


### PR DESCRIPTION
## Objective

Prepare the focused #3537 leaf-ref cache slice by reducing persisted leaf-ref build-page churn in the zipper scratch cache while preserving the cache-owned byte lifetime invariant.

Fixes #3537 after the deferred benchmark gate passes.

## Context

Post-#3561/#3565 main evidence reported `TreeDB/zipper.(*mergeScratch).acquireLeafRefCacheBuildPage` as a current full-run allocation surface in `/tmp/gomap_alloc_loop_main_post3561_all_20260706_060625` at commit `6f2d94def23551ccb1c6bdb35514bc72733d88e0`.

This PR intentionally does not claim performance validation yet. A local 10M gate attempt was stopped because another worker was running a concurrent 10M gate on the same machine, contaminating benchmark evidence. Those partial artifacts must not be used for merge decisions.

## Non-goals

- No changes to TreeDB memtable append-only arenas.
- No changes to TreeDB caching batch helper ownership.
- No changes to durable persistence, value-log pointer semantics, WAL behavior, or GC/rewrite policy.
- No weakening of the documented rule that cached leaf page bytes must not alias scratch buffers that can be mutated later.

## Design

- Increase `mergeLeafRefCachePageKeep` from `4096` to `8192`.
- Reuse remains scratch-local and lifetime-gated: cache-owned build pages are returned to scratch reuse only after `endLeafRefCache` clears the active leaf-ref cache map.
- No global hot-path pool is introduced.

## Scope

Includes:

- `TreeDB/zipper/zipper.go`: leaf-ref cache build-page retention cap.
- `TreeDB/zipper/zipper_test.go`: overflow lifetime regression coverage.

Excludes:

- `TreeDB/internal/memtable`
- `TreeDB/caching`
- Benchmark harness changes

## Correctness

Tests run locally:

```sh
GOWORK=off go test ./TreeDB/zipper -count=1
# pass: ok github.com/snissn/gomap/TreeDB/zipper 1.071s

GOWORK=off go test ./TreeDB -run 'TestReopenVerify_WALOn_Checkpoint|TestReopenVerify_WALOn_WriteSync' -count=1
# pass: ok github.com/snissn/gomap/TreeDB 4.847s

GOWORK=off go test ./TreeDB/db -run 'TestValueLogGC_RemovesUnreferencedSegment' -count=1
# pass: ok github.com/snissn/gomap/TreeDB/db 0.537s

git diff --check
# pass
```

Focused coverage added:

- `TestZipperLeafRefCacheOverflowBuildPagesStayPinnedUntilClose` forces more active cache build pages than the retention cap, persists both retained and overflow pages through `leafPageCacheAdoptOwned`, mutates later active build buffers, and verifies cached leaf-log loads still return the original leaf entries without using the leaf page reader.

## Performance

Benchmarks run:

- Deferred. The required clean 10M sequential paired gate is delegated to the main orchestrator.

Invalidated local attempt:

- A local 10M gate was stopped after cross-load was detected from another worker running a concurrent 10M gate on the same machine. Do not use those partial artifacts for merge decisions.

Required before merge:

```sh
GOWORK=off GOMAXPROCS=8 ./bin/unified-bench \
  -profile durable -dbs treedb -keys 10000000 -valsize 128 -batchsize 8000 \
  -test batch_delete,random_delete,batch_random -checkpoint-between-tests \
  -treedb-journal-lanes=1 -progress=false \
  -profile-dir "$OUT" -path-label native-fastpath
GOWORK=off ./bin/benchprof -profiles-dir "$OUT"
```

Gate status:

- Not merge-ready until the main orchestrator records clean before/after throughput, total allocation totals, and `acquireLeafRefCacheBuildPage` flat bytes/objects with no material throughput regression.

## Rollout / Toggle Plan

- No runtime toggle. The change is a bounded scratch-local retention cap.
- Revert path is the single constant change plus the test.

## AI Review Loop

- Codex latest-head review: not requested yet; wait until benchmark gate evidence is attached.
- Copilot latest-head review: not requested yet; wait until benchmark gate evidence is attached.
- CodeRabbit latest-head review: not requested yet; wait until benchmark gate evidence is attached.
