### PR TITLE
TreeDB: avoid tiny sorted batch shard fan-out

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -33354,6 +33354,115 @@ func appendUniqueMemtable(dst []memtable.Table, mt memtable.Table) []memtable.Ta
 	return append(dst, mt)
 }
 
+func batchShardFirstLast(entries []batch.Entry, shardIdxs []int, shardIndex int) (first, last []byte) {
+	for i := range entries {
+		if i >= len(shardIdxs) || shardIdxs[i] != shardIndex {
+			continue
+		}
+		key := entries[i].Key
+		if first == nil {
+			first = key
+		}
+		last = key
+	}
+	return first, last
+}
+
+func (b *Batch) canApplySmallSelectedSortedShard(shardCounts []int, allowBatchArenaBorrow, allowStableViewValueBorrow bool) bool {
+	if b == nil || b.db == nil || !b.streamEligible || len(b.entries) == 0 || len(b.entries) > batchSelectedSortedShardMaxEntries {
+		return false
+	}
+	for i, count := range shardCounts {
+		if count <= 0 {
+			continue
+		}
+		shard := &b.db.mutableShards[i]
+		useSteal, _ := cachedBatchWriteUseSteal(b.db, shard.mem)
+		useSteal = allowBatchArenaBorrow && useSteal
+		if useSteal {
+			return false
+		}
+		if allowStableViewValueBorrow {
+			if _, ok := shard.mem.(memtable.CopySelectedSortedBatchApplier); !ok {
+				return false
+			}
+			continue
+		}
+		if !allowBatchArenaBorrow {
+			if _, ok := shard.mem.(memtable.CopySelectedSortedBatchValueCopier); !ok {
+				return false
+			}
+			continue
+		}
+		if _, ok := shard.mem.(memtable.CopySelectedSortedBatchApplier); !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func (b *Batch) tryApplySmallSelectedSortedShard(
+	shardCounts []int,
+	shardIdxs []int,
+	allowBatchArenaBorrow bool,
+	allowStableViewValueBorrow bool,
+	retainMainMems *[]memtable.Table,
+	retainStableViewValueMems *[]memtable.Table,
+	failMemtableApply func(*memShard, error) error,
+) (bool, error) {
+	if !b.canApplySmallSelectedSortedShard(shardCounts, allowBatchArenaBorrow, allowStableViewValueBorrow) {
+		return false, nil
+	}
+	storeInlinePtrValues := !b.db.memtableValueLogPointers
+	for i, count := range shardCounts {
+		if count <= 0 {
+			continue
+		}
+		first, last := batchShardFirstLast(b.entries, shardIdxs, i)
+		if first == nil {
+			continue
+		}
+		shard := &b.db.mutableShards[i]
+		shard.mu.Lock()
+		reserveMemtableEntries(b.db, shard.mem, count)
+		if allowStableViewValueBorrow {
+			applier, ok := shard.mem.(memtable.CopySelectedSortedBatchApplier)
+			if !ok {
+				return true, failMemtableApply(shard, fmt.Errorf("cachingdb: memtable %T lost selected sorted batch support", shard.mem))
+			}
+			if borrowed := applier.ApplyCopySelectedSortedBatchTrusted(b.entries, shardIdxs, i, count, first, true, storeInlinePtrValues, nil); borrowed {
+				*retainStableViewValueMems = appendUniqueMemtable(*retainStableViewValueMems, shard.mem)
+			}
+		} else if !allowBatchArenaBorrow {
+			applier, ok := shard.mem.(memtable.CopySelectedSortedBatchValueCopier)
+			if !ok {
+				return true, failMemtableApply(shard, fmt.Errorf("cachingdb: memtable %T lost selected sorted batch value-copier support", shard.mem))
+			}
+			applier.ApplyCopySelectedSortedBatchWithValueCopierTrusted(b.entries, shardIdxs, i, count, first, b.appendOnlyDirectValueCopierForShard(shard), storeInlinePtrValues, nil)
+			b.valueCopyShard = nil
+		} else {
+			applier, ok := shard.mem.(memtable.CopySelectedSortedBatchApplier)
+			if !ok {
+				return true, failMemtableApply(shard, fmt.Errorf("cachingdb: memtable %T lost selected sorted batch support", shard.mem))
+			}
+			if borrowed := applier.ApplyCopySelectedSortedBatchTrusted(b.entries, shardIdxs, i, count, first, allowBatchArenaBorrow, storeInlinePtrValues, nil); borrowed {
+				*retainMainMems = appendUniqueMemtable(*retainMainMems, shard.mem)
+			}
+		}
+		shard.rng.add(first)
+		if count > 1 {
+			shard.rng.add(last)
+		}
+		b.db.noteWriteSortedRun(first, last, count)
+		newBytes := shard.mem.Size()
+		delta := newBytes - shard.bytes
+		shard.bytes = newBytes
+		b.db.mutableBytes.Add(delta)
+		shard.mu.Unlock()
+	}
+	return true, nil
+}
+
 func (b *Batch) appendOnlyDirectValueCopierForShard(shard *memShard) func([]byte) []byte {
 	if b == nil || shard == nil {
 		return nil
@@ -34433,6 +34542,7 @@ const (
 	batchAuxChunkLeaseMaxBytes                    = 1 << 20
 	batchAuxEntryGroupLeaseMaxCount               = 256
 	batchAuxEntryGroupLeaseMaxBytes               = 1 << 20
+	batchSelectedSortedShardMaxEntries            = 128
 	batchArenaChunkListInitialCap                 = 4
 	batchArenaChunkListMaxRetain                  = 256
 	batchShardEntryGroupsMaxRetain                = 1024
@@ -35553,163 +35663,177 @@ func (b *Batch) writeRegularLocked(syncWrite bool, unlockWriteMu func()) error {
 			shard.mu.Unlock()
 		}
 	} else {
-		shardEntries := b.shardEntries
-		if cap(shardEntries) < shardCount {
-			if cap(shardEntries) > 0 {
-				b.releaseShardEntryGroups(shardEntries)
-			}
-			shardEntries = b.db.getBatchShardEntryGroups(shardCount)
-			shardEntries = shardEntries[:shardCount]
-		} else {
-			shardEntries = shardEntries[:shardCount]
-			for i := range shardEntries {
-				shardEntries[i] = shardEntries[i][:0]
-			}
+		appliedSmallSorted, err := b.tryApplySmallSelectedSortedShard(
+			shardCounts,
+			shardIdxs,
+			allowBatchArenaBorrow,
+			allowStableViewValueBorrow,
+			&retainMainMems,
+			&retainStableViewValueMems,
+			failMemtableApply,
+		)
+		if err != nil {
+			return err
 		}
-		b.shardEntries = shardEntries
-		for i, count := range shardCounts {
-			if count > 0 {
-				entries := shardEntries[i]
-				if cap(entries) < count {
-					if cap(entries) > 0 {
-						b.db.putBatchShardEntries(entries)
-					}
-					entries = b.db.getBatchShardEntries(count)
-				} else {
-					entries = entries[:0]
+		if !appliedSmallSorted {
+			shardEntries := b.shardEntries
+			if cap(shardEntries) < shardCount {
+				if cap(shardEntries) > 0 {
+					b.releaseShardEntryGroups(shardEntries)
 				}
-				shardEntries[i] = entries
+				shardEntries = b.db.getBatchShardEntryGroups(shardCount)
+				shardEntries = shardEntries[:shardCount]
+			} else {
+				shardEntries = shardEntries[:shardCount]
+				for i := range shardEntries {
+					shardEntries[i] = shardEntries[i][:0]
+				}
 			}
-		}
-		for i, op := range b.entries {
-			idx := shardIdxs[i]
-			shardEntries[idx] = append(shardEntries[idx], op)
-		}
-
-		// 3. Memtable Update
-		for i := range shardEntries {
-			entries := shardEntries[i]
-			if len(entries) == 0 {
-				continue
-			}
-			shard := &b.db.mutableShards[i]
-			shard.mu.Lock()
-			reserveMemtableEntries(b.db, shard.mem, len(entries))
-			useStream := b.streamEligible
-			useSteal, stealSuppressedDeferred := cachedBatchWriteUseSteal(b.db, shard.mem)
-			useSteal = allowBatchArenaBorrow && useSteal
-			if stealSuppressedDeferred && allowBatchArenaBorrow {
-				batchArenaStealSuppressedDeferredTotal.Add(1)
-				batchArenaStealSuppressedDeferredEntriesTotal.Add(uint64(len(entries)))
-			}
-			if useSteal && cachedBatchWriteNeedsBatchArenaRetention(shard.mem) {
-				retainMainMems = appendUniqueMemtable(retainMainMems, shard.mem)
-			}
-			storeInlinePtrValues := !b.db.memtableValueLogPointers
-			appliedSortedRun := false
-			if useStream {
-				if useSteal {
-					if applier, ok := shard.mem.(memtable.TrustedSortedBatchApplier); ok {
-						applier.ApplyStealSortedBatchTrusted(entries, nil)
-					} else if applier, ok := shard.mem.(memtable.SortedBatchApplier); ok {
-						applier.ApplyStealSortedBatch(entries, nil)
+			b.shardEntries = shardEntries
+			for i, count := range shardCounts {
+				if count > 0 {
+					entries := shardEntries[i]
+					if cap(entries) < count {
+						if cap(entries) > 0 {
+							b.db.putBatchShardEntries(entries)
+						}
+						entries = b.db.getBatchShardEntries(count)
 					} else {
-						for _, op := range entries {
-							if op.Type == batch.OpDelete {
-								if err := memtableBatchDelete(shard.mem, true, op.Key, op.Revision); err != nil {
-									return failMemtableApply(shard, err)
+						entries = entries[:0]
+					}
+					shardEntries[i] = entries
+				}
+			}
+			for i, op := range b.entries {
+				idx := shardIdxs[i]
+				shardEntries[idx] = append(shardEntries[idx], op)
+			}
+
+			// 3. Memtable Update
+			for i := range shardEntries {
+				entries := shardEntries[i]
+				if len(entries) == 0 {
+					continue
+				}
+				shard := &b.db.mutableShards[i]
+				shard.mu.Lock()
+				reserveMemtableEntries(b.db, shard.mem, len(entries))
+				useStream := b.streamEligible
+				useSteal, stealSuppressedDeferred := cachedBatchWriteUseSteal(b.db, shard.mem)
+				useSteal = allowBatchArenaBorrow && useSteal
+				if stealSuppressedDeferred && allowBatchArenaBorrow {
+					batchArenaStealSuppressedDeferredTotal.Add(1)
+					batchArenaStealSuppressedDeferredEntriesTotal.Add(uint64(len(entries)))
+				}
+				if useSteal && cachedBatchWriteNeedsBatchArenaRetention(shard.mem) {
+					retainMainMems = appendUniqueMemtable(retainMainMems, shard.mem)
+				}
+				storeInlinePtrValues := !b.db.memtableValueLogPointers
+				appliedSortedRun := false
+				if useStream {
+					if useSteal {
+						if applier, ok := shard.mem.(memtable.TrustedSortedBatchApplier); ok {
+							applier.ApplyStealSortedBatchTrusted(entries, nil)
+						} else if applier, ok := shard.mem.(memtable.SortedBatchApplier); ok {
+							applier.ApplyStealSortedBatch(entries, nil)
+						} else {
+							for _, op := range entries {
+								if op.Type == batch.OpDelete {
+									if err := memtableBatchDelete(shard.mem, true, op.Key, op.Revision); err != nil {
+										return failMemtableApply(shard, err)
+									}
+								} else {
+									memtableBatchSet(shard.mem, true, allowBatchArenaBorrow, storeInlinePtrValues, op)
 								}
-							} else {
-								memtableBatchSet(shard.mem, true, allowBatchArenaBorrow, storeInlinePtrValues, op)
+							}
+						}
+						appliedSortedRun = true
+					} else {
+						if allowStableViewValueBorrow {
+							if applier, ok := shard.mem.(memtable.CopySortedBatchApplier); ok {
+								if borrowed := applier.ApplyCopySortedBatchTrusted(entries, true, storeInlinePtrValues, nil); borrowed {
+									retainStableViewValueMems = appendUniqueMemtable(retainStableViewValueMems, shard.mem)
+								}
+								appliedSortedRun = true
+							}
+						}
+						if !appliedSortedRun && !allowBatchArenaBorrow {
+							if applier, ok := shard.mem.(memtable.CopySortedBatchValueCopier); ok {
+								applier.ApplyCopySortedBatchWithValueCopierTrusted(entries, b.appendOnlyDirectValueCopierForShard(shard), storeInlinePtrValues, nil)
+								b.valueCopyShard = nil
+								appliedSortedRun = true
+							}
+						}
+						if !appliedSortedRun {
+							if applier, ok := shard.mem.(memtable.CopySortedBatchApplier); ok {
+								if borrowed := applier.ApplyCopySortedBatchTrusted(entries, allowBatchArenaBorrow, storeInlinePtrValues, nil); borrowed {
+									retainMainMems = appendUniqueMemtable(retainMainMems, shard.mem)
+								}
+								appliedSortedRun = true
 							}
 						}
 					}
-					appliedSortedRun = true
-				} else {
-					if allowStableViewValueBorrow {
-						if applier, ok := shard.mem.(memtable.CopySortedBatchApplier); ok {
-							if borrowed := applier.ApplyCopySortedBatchTrusted(entries, true, storeInlinePtrValues, nil); borrowed {
-								retainStableViewValueMems = appendUniqueMemtable(retainStableViewValueMems, shard.mem)
+				}
+				if !appliedSortedRun {
+					for _, op := range entries {
+						if op.Type == batch.OpDelete {
+							if err := memtableBatchDelete(shard.mem, useSteal, op.Key, op.Revision); err != nil {
+								return failMemtableApply(shard, err)
 							}
-							appliedSortedRun = true
-						}
-					}
-					if !appliedSortedRun && !allowBatchArenaBorrow {
-						if applier, ok := shard.mem.(memtable.CopySortedBatchValueCopier); ok {
-							applier.ApplyCopySortedBatchWithValueCopierTrusted(entries, b.appendOnlyDirectValueCopierForShard(shard), storeInlinePtrValues, nil)
-							b.valueCopyShard = nil
-							appliedSortedRun = true
-						}
-					}
-					if !appliedSortedRun {
-						if applier, ok := shard.mem.(memtable.CopySortedBatchApplier); ok {
-							if borrowed := applier.ApplyCopySortedBatchTrusted(entries, allowBatchArenaBorrow, storeInlinePtrValues, nil); borrowed {
+						} else {
+							borrowedMainArena := false
+							borrowedStableViewValue := false
+							allowValueBorrow := allowBatchArenaBorrow
+							if !allowValueBorrow && allowStableViewValueBorrow && !useSteal {
+								allowValueBorrow = true
+								if _, ok := shard.mem.(memtable.ValueBorrower); ok {
+									if op.IsPtr {
+										borrowedStableViewValue = storeInlinePtrValues && len(op.Value) > 0
+									} else {
+										borrowedStableViewValue = len(op.Value) > 0
+									}
+								}
+							}
+							if allowBatchArenaBorrow && !useSteal {
+								if _, ok := shard.mem.(memtable.ValueBorrower); ok {
+									if op.IsPtr {
+										borrowedMainArena = storeInlinePtrValues && len(op.Value) > 0
+									} else {
+										borrowedMainArena = len(op.Value) > 0
+									}
+								}
+							}
+							memtableBatchSet(shard.mem, useSteal, allowValueBorrow, storeInlinePtrValues, op)
+							if borrowedMainArena {
 								retainMainMems = appendUniqueMemtable(retainMainMems, shard.mem)
 							}
-							appliedSortedRun = true
-						}
-					}
-				}
-			}
-			if !appliedSortedRun {
-				for _, op := range entries {
-					if op.Type == batch.OpDelete {
-						if err := memtableBatchDelete(shard.mem, useSteal, op.Key, op.Revision); err != nil {
-							return failMemtableApply(shard, err)
-						}
-					} else {
-						borrowedMainArena := false
-						borrowedStableViewValue := false
-						allowValueBorrow := allowBatchArenaBorrow
-						if !allowValueBorrow && allowStableViewValueBorrow && !useSteal {
-							allowValueBorrow = true
-							if _, ok := shard.mem.(memtable.ValueBorrower); ok {
-								if op.IsPtr {
-									borrowedStableViewValue = storeInlinePtrValues && len(op.Value) > 0
-								} else {
-									borrowedStableViewValue = len(op.Value) > 0
-								}
+							if borrowedStableViewValue {
+								retainStableViewValueMems = appendUniqueMemtable(retainStableViewValueMems, shard.mem)
 							}
 						}
-						if allowBatchArenaBorrow && !useSteal {
-							if _, ok := shard.mem.(memtable.ValueBorrower); ok {
-								if op.IsPtr {
-									borrowedMainArena = storeInlinePtrValues && len(op.Value) > 0
-								} else {
-									borrowedMainArena = len(op.Value) > 0
-								}
-							}
+						if useStream {
+							// Preserve sorted-run accounting even when no sorted batch applier is available.
+							continue
 						}
-						memtableBatchSet(shard.mem, useSteal, allowValueBorrow, storeInlinePtrValues, op)
-						if borrowedMainArena {
-							retainMainMems = appendUniqueMemtable(retainMainMems, shard.mem)
-						}
-						if borrowedStableViewValue {
-							retainStableViewValueMems = appendUniqueMemtable(retainStableViewValueMems, shard.mem)
-						}
+						shard.rng.add(op.Key)
+						b.db.noteWriteKey(op.Key)
 					}
-					if useStream {
-						// Preserve sorted-run accounting even when no sorted batch applier is available.
-						continue
+				}
+				if useStream {
+					first := entries[0].Key
+					last := entries[len(entries)-1].Key
+					shard.rng.add(first)
+					if len(entries) > 1 {
+						shard.rng.add(last)
 					}
-					shard.rng.add(op.Key)
-					b.db.noteWriteKey(op.Key)
+					b.db.noteWriteSortedRun(first, last, len(entries))
 				}
+				newBytes := shard.mem.Size()
+				delta := newBytes - shard.bytes
+				shard.bytes = newBytes
+				b.db.mutableBytes.Add(delta)
+				shard.mu.Unlock()
 			}
-			if useStream {
-				first := entries[0].Key
-				last := entries[len(entries)-1].Key
-				shard.rng.add(first)
-				if len(entries) > 1 {
-					shard.rng.add(last)
-				}
-				b.db.noteWriteSortedRun(first, last, len(entries))
-			}
-			newBytes := shard.mem.Size()
-			delta := newBytes - shard.bytes
-			shard.bytes = newBytes
-			b.db.mutableBytes.Add(delta)
-			shard.mu.Unlock()
 		}
 	}
 

--- a/TreeDB/caching/sorted_write_fastpath_test.go
+++ b/TreeDB/caching/sorted_write_fastpath_test.go
@@ -13,6 +13,7 @@ import (
 type recordingCopySortedMem struct {
 	memtable.Table
 	calls             int
+	selectedCalls     int
 	reserveCalls      int
 	reserveAdditional int
 	hasMax            bool
@@ -108,6 +109,61 @@ func (m *recordingCopySortedMem) ApplyCopySortedBatchTrusted(entries []batch.Ent
 	return borrowed
 }
 
+func batchSelectedEntries(entries []batch.Entry, selectors []int, selector int) []batch.Entry {
+	selected := make([]batch.Entry, 0, len(entries))
+	for i := range entries {
+		if i < len(selectors) && selectors[i] == selector {
+			selected = append(selected, entries[i])
+		}
+	}
+	return selected
+}
+
+func (m *recordingCopySortedMem) ApplyCopySelectedSortedBatchTrusted(entries []batch.Entry, selectors []int, selector int, count int, firstKey []byte, borrowValues bool, storeInlinePtrValues bool, onKey func(key []byte)) bool {
+	selected := batchSelectedEntries(entries, selectors, selector)
+	if len(selected) != count {
+		panic("selected entry count mismatch")
+	}
+	entries = selected
+	orderedAppend := m.canRecordOrderedAppend(entries)
+	applier, ok := m.Table.(memtable.CopySelectedSortedBatchApplier)
+	if !ok {
+		return m.ApplyCopySortedBatchTrusted(entries, borrowValues, storeInlinePtrValues, onKey)
+	}
+	selectors = make([]int, len(entries))
+	borrowed := applier.ApplyCopySelectedSortedBatchTrusted(entries, selectors, 0, count, firstKey, borrowValues, storeInlinePtrValues, onKey)
+	if orderedAppend {
+		m.calls++
+		m.selectedCalls++
+	}
+	m.noteEntries(entries)
+	return borrowed
+}
+
+func (m *recordingCopySortedMem) ApplyCopySelectedSortedBatchWithValueCopierTrusted(entries []batch.Entry, selectors []int, selector int, count int, firstKey []byte, copyValue func(value []byte) []byte, storeInlinePtrValues bool, onKey func(key []byte)) bool {
+	selected := batchSelectedEntries(entries, selectors, selector)
+	if len(selected) != count {
+		panic("selected entry count mismatch")
+	}
+	entries = selected
+	orderedAppend := m.canRecordOrderedAppend(entries)
+	copied := false
+	selectors = make([]int, len(entries))
+	if applier, ok := m.Table.(memtable.CopySelectedSortedBatchValueCopier); ok {
+		copied = applier.ApplyCopySelectedSortedBatchWithValueCopierTrusted(entries, selectors, 0, count, firstKey, copyValue, storeInlinePtrValues, onKey)
+	} else if applier, ok := m.Table.(memtable.CopySortedBatchValueCopier); ok {
+		copied = applier.ApplyCopySortedBatchWithValueCopierTrusted(entries, copyValue, storeInlinePtrValues, onKey)
+	} else {
+		return m.ApplyCopySortedBatchTrusted(entries, false, storeInlinePtrValues, onKey)
+	}
+	if orderedAppend {
+		m.calls++
+		m.selectedCalls++
+	}
+	m.noteEntries(entries)
+	return copied
+}
+
 func newSortedWriteFastPathDB(t *testing.T) (*DB, *recordingCopySortedMem) {
 	t.Helper()
 	db, err := Open(t.TempDir(), NewMockBackend(), Options{
@@ -160,6 +216,32 @@ func TestBatchWriteSortedUniqueUsesCopySortedFastPath(t *testing.T) {
 
 	if rec.calls != 1 {
 		t.Fatalf("copy sorted fast path calls=%d want 1", rec.calls)
+	}
+	requireCachedValue(t, db, []byte("a"), []byte("va"))
+	requireCachedValue(t, db, []byte("b"), []byte("vb"))
+	requireCachedValue(t, db, []byte("c"), []byte("vc"))
+}
+
+func TestBatchWriteSmallSortedUniqueUsesSelectedFastPath(t *testing.T) {
+	db, rec := newSortedWriteFastPathDB(t)
+	defer db.Close()
+
+	b := db.NewBatchWithSize(3)
+	if err := b.Set([]byte("a"), []byte("va")); err != nil {
+		t.Fatalf("Set(a): %v", err)
+	}
+	if err := b.Set([]byte("b"), []byte("vb")); err != nil {
+		t.Fatalf("Set(b): %v", err)
+	}
+	if err := b.Set([]byte("c"), []byte("vc")); err != nil {
+		t.Fatalf("Set(c): %v", err)
+	}
+	if err := b.Write(); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	if rec.selectedCalls != 1 {
+		t.Fatalf("copy selected sorted fast path calls=%d want 1", rec.selectedCalls)
 	}
 	requireCachedValue(t, db, []byte("a"), []byte("va"))
 	requireCachedValue(t, db, []byte("b"), []byte("vb"))

--- a/TreeDB/internal/memtable/append_only.go
+++ b/TreeDB/internal/memtable/append_only.go
@@ -1652,10 +1652,17 @@ func (m *AppendOnly) canAppendTrustedSortedBatchLocked(entries []batchpkg.Entry)
 	if len(entries) == 0 || len(entries[0].Key) == 0 || !m.ordered {
 		return false
 	}
+	return m.canAppendTrustedSortedFirstKeyLocked(entries[0].Key)
+}
+
+func (m *AppendOnly) canAppendTrustedSortedFirstKeyLocked(firstKey []byte) bool {
+	if len(firstKey) == 0 || !m.ordered {
+		return false
+	}
 	if m.count == 0 || !m.hasLast {
 		return true
 	}
-	return bytes.Compare(entries[0].Key, appendOnlyEntryKey(&m.entries[m.lastIdx])) > 0
+	return bytes.Compare(firstKey, appendOnlyEntryKey(&m.entries[m.lastIdx])) > 0
 }
 
 func (m *AppendOnly) ApplyCopySortedBatchTrusted(entries []batchpkg.Entry, borrowValues bool, storeInlinePtrValues bool, onKey func(key []byte)) bool {
@@ -1686,6 +1693,37 @@ func (m *AppendOnly) ApplyCopySortedBatchTrusted(entries []batchpkg.Entry, borro
 	return borrowedValues
 }
 
+func (m *AppendOnly) ApplyCopySelectedSortedBatchTrusted(entries []batchpkg.Entry, selectors []int, selector int, count int, firstKey []byte, borrowValues bool, storeInlinePtrValues bool, onKey func(key []byte)) bool {
+	if count <= 0 {
+		return false
+	}
+	borrowedValues := false
+	m.mu.Lock()
+	m.reserveAdditionalEntriesLocked(count)
+	trustedOrdered := m.canAppendTrustedSortedFirstKeyLocked(firstKey)
+	for i := range entries {
+		if i >= len(selectors) || selectors[i] != selector {
+			continue
+		}
+		op := entries[i]
+		value, ptr, flags := appendOnlyBatchEntryPayload(op, storeInlinePtrValues)
+		borrowValue := borrowValues && len(value) > 0
+		if borrowValue {
+			borrowedValues = true
+		}
+		if trustedOrdered {
+			m.appendEntryTrustedOrderedLocked(op.Key, value, ptr, flags, op.Revision, false, borrowValue)
+		} else {
+			m.appendEntryLocked(op.Key, value, ptr, flags, op.Revision, false, borrowValue)
+		}
+		if onKey != nil {
+			onKey(op.Key)
+		}
+	}
+	m.mu.Unlock()
+	return borrowedValues
+}
+
 func (m *AppendOnly) ApplyCopySortedBatchWithValueCopierTrusted(entries []batchpkg.Entry, copyValue func(value []byte) []byte, storeInlinePtrValues bool, onKey func(key []byte)) bool {
 	if len(entries) == 0 {
 		return false
@@ -1695,6 +1733,41 @@ func (m *AppendOnly) ApplyCopySortedBatchWithValueCopierTrusted(entries []batchp
 	m.reserveAdditionalEntriesLocked(len(entries))
 	trustedOrdered := m.canAppendTrustedSortedBatchLocked(entries)
 	for i := range entries {
+		op := entries[i]
+		value, ptr, flags := appendOnlyBatchEntryPayload(op, storeInlinePtrValues)
+		borrowValue := false
+		if len(value) > 0 && copyValue != nil {
+			if copied := copyValue(value); len(copied) == len(value) {
+				value = copied
+				borrowValue = true
+				copiedValues = true
+			}
+		}
+		if trustedOrdered {
+			m.appendEntryTrustedOrderedLocked(op.Key, value, ptr, flags, op.Revision, false, borrowValue)
+		} else {
+			m.appendEntryLocked(op.Key, value, ptr, flags, op.Revision, false, borrowValue)
+		}
+		if onKey != nil {
+			onKey(op.Key)
+		}
+	}
+	m.mu.Unlock()
+	return copiedValues
+}
+
+func (m *AppendOnly) ApplyCopySelectedSortedBatchWithValueCopierTrusted(entries []batchpkg.Entry, selectors []int, selector int, count int, firstKey []byte, copyValue func(value []byte) []byte, storeInlinePtrValues bool, onKey func(key []byte)) bool {
+	if count <= 0 {
+		return false
+	}
+	copiedValues := false
+	m.mu.Lock()
+	m.reserveAdditionalEntriesLocked(count)
+	trustedOrdered := m.canAppendTrustedSortedFirstKeyLocked(firstKey)
+	for i := range entries {
+		if i >= len(selectors) || selectors[i] != selector {
+			continue
+		}
 		op := entries[i]
 		value, ptr, flags := appendOnlyBatchEntryPayload(op, storeInlinePtrValues)
 		borrowValue := false

--- a/TreeDB/internal/memtable/append_only_sorted_batch_test.go
+++ b/TreeDB/internal/memtable/append_only_sorted_batch_test.go
@@ -88,6 +88,52 @@ func TestAppendOnlyApplyCopySelectedSortedBatchTrusted_AppendKeepsOrderedAndCopi
 	}
 }
 
+func TestAppendOnlyApplyCopySelectedSortedBatchTrusted_FallbackKeepsEntries(t *testing.T) {
+	m := NewAppendOnlyWithCapacity(0)
+	m.Set([]byte("m"), []byte("old"))
+
+	keyA := []byte("a")
+	entries := []batchpkg.Entry{
+		{Type: batchpkg.OpPut, Key: keyA, Value: []byte("va")},
+		{Type: batchpkg.OpPut, Key: []byte("b"), Value: []byte("vb")},
+	}
+	selectors := []int{0, 0}
+	borrowed := m.ApplyCopySelectedSortedBatchTrusted(entries, selectors, 0, len(entries), entries[0].Key, true, true, nil)
+	if !borrowed {
+		t.Fatalf("ApplyCopySelectedSortedBatchTrusted borrowed=false, want true for inline values")
+	}
+
+	keyA[0] = 'z'
+	if got, deleted, ok := m.Get([]byte("a")); !ok || deleted || string(got) != "va" {
+		t.Fatalf("Get(a)=(%q,%v,%v), want (va,false,true)", string(got), deleted, ok)
+	}
+	if got, deleted, ok := m.Get([]byte("b")); !ok || deleted || string(got) != "vb" {
+		t.Fatalf("Get(b)=(%q,%v,%v), want (vb,false,true)", string(got), deleted, ok)
+	}
+	if got, deleted, ok := m.Get([]byte("m")); !ok || deleted || string(got) != "old" {
+		t.Fatalf("Get(m)=(%q,%v,%v), want (old,false,true)", string(got), deleted, ok)
+	}
+
+	m.mu.RLock()
+	ordered := m.ordered
+	latestDirty := m.latestDirty
+	runCount := len(m.sortedRuns)
+	count := m.count
+	m.mu.RUnlock()
+	if ordered {
+		t.Fatalf("ordered=true after selected sorted fallback appended below existing max key")
+	}
+	if latestDirty {
+		t.Fatalf("latestDirty=true after selected sorted fallback; latest lookup should be immediately usable")
+	}
+	if runCount != 2 {
+		t.Fatalf("sorted run count=%d want 2", runCount)
+	}
+	if count != 3 {
+		t.Fatalf("count=%d want 3", count)
+	}
+}
+
 func TestAppendOnlyApplyCopySortedBatchWithValueCopierOwnsValues(t *testing.T) {
 	m := NewAppendOnlyWithCapacity(0)
 	key := []byte("a")
@@ -141,6 +187,62 @@ func TestAppendOnlyApplyCopySelectedSortedBatchWithValueCopierOwnsValues(t *test
 	}
 	if got, deleted, ok := m.Get([]byte("a")); !ok || deleted || string(got) != "mutable-value" {
 		t.Fatalf("Get(a)=(%q,%v,%v), want copied immutable value", string(got), deleted, ok)
+	}
+}
+
+func TestAppendOnlyApplyCopySelectedSortedBatchWithValueCopierTrusted_FallbackKeepsEntries(t *testing.T) {
+	m := NewAppendOnlyWithCapacity(0)
+	m.Set([]byte("m"), []byte("old"))
+
+	key := []byte("a")
+	value := []byte("mutable-value")
+	entries := []batchpkg.Entry{
+		{Type: batchpkg.OpPut, Key: key, Value: value},
+		{Type: batchpkg.OpPut, Key: []byte("b"), Value: []byte("vb")},
+	}
+	selectors := []int{0, 0}
+	var copiedBacking [][]byte
+	copied := m.ApplyCopySelectedSortedBatchWithValueCopierTrusted(entries, selectors, 0, len(entries), key, func(src []byte) []byte {
+		dst := append([]byte(nil), src...)
+		copiedBacking = append(copiedBacking, dst)
+		return dst
+	}, true, nil)
+	if !copied {
+		t.Fatalf("copied=false, want true")
+	}
+
+	key[0] = 'z'
+	value[0] = 'X'
+	if len(copiedBacking) != 2 || string(copiedBacking[0]) != "mutable-value" || string(copiedBacking[1]) != "vb" {
+		t.Fatalf("copied backing mutated or missing: %q", copiedBacking)
+	}
+	if got, deleted, ok := m.Get([]byte("a")); !ok || deleted || string(got) != "mutable-value" {
+		t.Fatalf("Get(a)=(%q,%v,%v), want copied immutable value", string(got), deleted, ok)
+	}
+	if got, deleted, ok := m.Get([]byte("b")); !ok || deleted || string(got) != "vb" {
+		t.Fatalf("Get(b)=(%q,%v,%v), want (vb,false,true)", string(got), deleted, ok)
+	}
+	if got, deleted, ok := m.Get([]byte("m")); !ok || deleted || string(got) != "old" {
+		t.Fatalf("Get(m)=(%q,%v,%v), want (old,false,true)", string(got), deleted, ok)
+	}
+
+	m.mu.RLock()
+	ordered := m.ordered
+	latestDirty := m.latestDirty
+	runCount := len(m.sortedRuns)
+	count := m.count
+	m.mu.RUnlock()
+	if ordered {
+		t.Fatalf("ordered=true after selected value-copier fallback appended below existing max key")
+	}
+	if latestDirty {
+		t.Fatalf("latestDirty=true after selected value-copier fallback; latest lookup should be immediately usable")
+	}
+	if runCount != 2 {
+		t.Fatalf("sorted run count=%d want 2", runCount)
+	}
+	if count != 3 {
+		t.Fatalf("count=%d want 3", count)
 	}
 }
 

--- a/TreeDB/internal/memtable/append_only_sorted_batch_test.go
+++ b/TreeDB/internal/memtable/append_only_sorted_batch_test.go
@@ -48,6 +48,46 @@ func TestAppendOnlyApplyCopySortedBatchTrusted_AppendKeepsOrderedAndCopiesKeys(t
 	}
 }
 
+func TestAppendOnlyApplyCopySelectedSortedBatchTrusted_AppendKeepsOrderedAndCopiesKeys(t *testing.T) {
+	m := NewAppendOnlyWithCapacity(0)
+
+	keyA := []byte("a")
+	keyB := []byte("b")
+	entries := []batchpkg.Entry{
+		{Type: batchpkg.OpPut, Key: keyA, Value: []byte("va")},
+		{Type: batchpkg.OpPut, Key: keyB, Value: []byte("vb")},
+	}
+	selectors := []int{0, 0}
+	borrowed := m.ApplyCopySelectedSortedBatchTrusted(entries, selectors, 0, len(entries), entries[0].Key, true, true, nil)
+	if !borrowed {
+		t.Fatalf("ApplyCopySelectedSortedBatchTrusted borrowed=false, want true for inline values")
+	}
+
+	keyA[0] = 'z'
+	if got, deleted, ok := m.Get([]byte("a")); !ok || deleted || string(got) != "va" {
+		t.Fatalf("Get(a)=(%q,%v,%v), want (va,false,true)", string(got), deleted, ok)
+	}
+	if got, deleted, ok := m.Get([]byte("b")); !ok || deleted || string(got) != "vb" {
+		t.Fatalf("Get(b)=(%q,%v,%v), want (vb,false,true)", string(got), deleted, ok)
+	}
+
+	m.mu.RLock()
+	ordered := m.ordered
+	latestDirty := m.latestDirty
+	latestLen := len(m.latest) + len(m.latest64)
+	count := m.count
+	m.mu.RUnlock()
+	if !ordered {
+		t.Fatalf("ordered=false after trusted selected sorted append")
+	}
+	if latestDirty || latestLen != 0 {
+		t.Fatalf("latest index built for ordered selected append: dirty=%v len=%d", latestDirty, latestLen)
+	}
+	if count != 2 {
+		t.Fatalf("count=%d want 2", count)
+	}
+}
+
 func TestAppendOnlyApplyCopySortedBatchWithValueCopierOwnsValues(t *testing.T) {
 	m := NewAppendOnlyWithCapacity(0)
 	key := []byte("a")
@@ -58,6 +98,35 @@ func TestAppendOnlyApplyCopySortedBatchWithValueCopierOwnsValues(t *testing.T) {
 		Key:   key,
 		Value: value,
 	}}, func(src []byte) []byte {
+		dst := append([]byte(nil), src...)
+		copiedBacking = append(copiedBacking, dst)
+		return dst
+	}, true, nil)
+	if !copied {
+		t.Fatalf("copied=false, want true")
+	}
+	key[0] = 'z'
+	value[0] = 'X'
+	if len(copiedBacking) != 1 || string(copiedBacking[0]) != "mutable-value" {
+		t.Fatalf("copied backing mutated or missing: %q", copiedBacking)
+	}
+	if got, deleted, ok := m.Get([]byte("a")); !ok || deleted || string(got) != "mutable-value" {
+		t.Fatalf("Get(a)=(%q,%v,%v), want copied immutable value", string(got), deleted, ok)
+	}
+}
+
+func TestAppendOnlyApplyCopySelectedSortedBatchWithValueCopierOwnsValues(t *testing.T) {
+	m := NewAppendOnlyWithCapacity(0)
+	key := []byte("a")
+	value := []byte("mutable-value")
+	entries := []batchpkg.Entry{{
+		Type:  batchpkg.OpPut,
+		Key:   key,
+		Value: value,
+	}}
+	selectors := []int{0}
+	var copiedBacking [][]byte
+	copied := m.ApplyCopySelectedSortedBatchWithValueCopierTrusted(entries, selectors, 0, len(entries), key, func(src []byte) []byte {
 		dst := append([]byte(nil), src...)
 		copiedBacking = append(copiedBacking, dst)
 		return dst

--- a/TreeDB/internal/memtable/memtable.go
+++ b/TreeDB/internal/memtable/memtable.go
@@ -179,6 +179,20 @@ type CopySortedBatchValueCopier interface {
 	ApplyCopySortedBatchWithValueCopierTrusted(entries []batchpkg.Entry, copyValue func(value []byte) []byte, storeInlinePtrValues bool, onKey func(key []byte)) (copiedValues bool)
 }
 
+// CopySelectedSortedBatchApplier is the selected-entry form of
+// CopySortedBatchApplier. It lets callers feed a small sorted shard stream from
+// an existing batch plus selector slice without materializing an intermediate
+// []batch.Entry per shard.
+type CopySelectedSortedBatchApplier interface {
+	ApplyCopySelectedSortedBatchTrusted(entries []batchpkg.Entry, selectors []int, selector int, count int, firstKey []byte, borrowValues bool, storeInlinePtrValues bool, onKey func(key []byte)) (borrowedValues bool)
+}
+
+// CopySelectedSortedBatchValueCopier is the selected-entry form of
+// CopySortedBatchValueCopier.
+type CopySelectedSortedBatchValueCopier interface {
+	ApplyCopySelectedSortedBatchWithValueCopierTrusted(entries []batchpkg.Entry, selectors []int, selector int, count int, firstKey []byte, copyValue func(value []byte) []byte, storeInlinePtrValues bool, onKey func(key []byte)) (copiedValues bool)
+}
+
 type Memtable struct {
 	sl *skiplist.SkipList
 	mu sync.RWMutex


### PR DESCRIPTION
Fixes #3579.

## Summary
- Add selected-entry sorted-batch memtable APIs so tiny sorted batch shards can be applied from the original batch plus selector indexes.
- Teach the caching batch write path to use that API for small stream-eligible non-delete batches instead of materializing one `[]batch.Entry` per shard.
- Leave the existing shard-entry materialization/steal path in place for larger batches and unsupported memtables.

## Validation
- `git diff --check`
- `GOWORK=off go test ./TreeDB/caching ./TreeDB/internal/memtable ./kvstore/adapters/treedb -count=1`
- `GOWORK=off go build -o ./bin/unified-bench ./cmd/unified_bench`
- `GOWORK=off go build -o ./bin/benchprof ./cmd/benchprof`

## Durable 10M Benchmark
After artifact: `/tmp/gomap_3579_selected_gate_20260706_100226`
Baseline artifact: `/tmp/gomap_alloc_loop_main_post3573_all_20260706_091637`

Command shape:

```sh
GOWORK=off GOMAXPROCS=8 TMPDIR="$RUN_ROOT/tmp" ./bin/unified-bench \
  -profile durable -dbs treedb -keys 10000000 -valsize 128 -batchsize 8000 \
  -test batch_small_seq,batch_write,batch_write_steady,random_write \
  -checkpoint-between-tests -treedb-journal-lanes=1 -progress=false \
  -profile-dir "$RUN_ROOT/profiles" -path-label native-fastpath -format markdown
GOWORK=off ./bin/benchprof -profiles-dir "$RUN_ROOT/profiles"
```

| Test | Post-#3573 baseline ops/sec | This PR ops/sec | Delta |
| --- | ---: | ---: | ---: |
| `batch_small_seq` | 663,058 | 2,946,668 | +344.4% |
| `batch_write` | 1,258,721 | 3,031,140 | +140.8% |
| `batch_write_steady` | 1,252,849 | 1,504,989 | +20.1% |
| `random_write` | 190,244 | 353,797 | +86.0% |

`batch_small_seq` allocation profile:

| Metric | Post-#3573 baseline | This PR | Delta |
| --- | ---: | ---: | ---: |
| Allocated objects | 2,809,125 | 799,317 | -71.5% |
| Allocated space | 5,845.06 MiB | 3,668.63 MiB | -37.2% |

The removed hotspot was `TreeDB/caching.(*DB).getBatchShardEntries`: baseline `batch_small_seq` pprof showed 1,610,967 objects and 913.09 MiB there; it no longer appears in the top allocation nodes after this PR.

## Caveats / Follow-up
Remaining `batch_small_seq` allocation space is dominated by batch arena and append-only backing storage (`getBatchArena`, `getAppendOnlyEntries`, and direct value arena chunks), so those are better follow-up tickets rather than in-scope for this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Faster writes for small, already-sorted batches on shards with matching entries.
  * Improved handling of selected entries in sorted batches, reducing extra work during batch application.

* **Bug Fixes**
  * Preserves key and value ownership correctly when applying selected sorted batches.
  * Keeps shard accounting and ordering state consistent during optimized batch writes.

* **Tests**
  * Added coverage for the new fast path and selected-batch behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->