### PR TITLE
TreeDB: expose command-WAL runtime counters

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -8816,6 +8816,10 @@ type DB struct {
 	checkpointActiveBackgroundFlushWaitMaxNs                     atomic.Uint64
 	checkpointActiveBackgroundFlushWaitLastNs                    atomic.Uint64
 	checkpointActiveBackgroundFlushWaitSamples                   atomic.Uint64
+	writeWaitForCheckpointNs                                     atomic.Uint64
+	writeWaitForCheckpointMaxNs                                  atomic.Uint64
+	writeWaitForCheckpointLastNs                                 atomic.Uint64
+	writeWaitForCheckpointSamples                                atomic.Uint64
 	checkpointDebtMemtablesLast                                  atomic.Uint64
 	checkpointDebtMemtablesMax                                   atomic.Uint64
 	checkpointDebtBytesLast                                      atomic.Uint64
@@ -22703,6 +22707,18 @@ func (db *DB) waitForCheckpoint() {
 	db.checkpointMu.Unlock()
 }
 
+func (db *DB) waitForCheckpointForWrite() {
+	if db == nil {
+		return
+	}
+	if !db.checkpointing.Load() && !db.maintenanceActive.Load() {
+		return
+	}
+	start := time.Now()
+	db.waitForCheckpoint()
+	db.observeWriteWaitForCheckpoint(time.Since(start))
+}
+
 func (db *DB) beginDirectWrite() error {
 	for {
 		db.writeMu.RLock()
@@ -29553,6 +29569,7 @@ func (db *DB) Stats() map[string]string {
 	stats["treedb.cache.checkpoint.active_background_flush_wait_ns_max"] = fmt.Sprintf("%d", db.checkpointActiveBackgroundFlushWaitMaxNs.Load())
 	stats["treedb.cache.checkpoint.active_background_flush_wait_ns_last"] = fmt.Sprintf("%d", db.checkpointActiveBackgroundFlushWaitLastNs.Load())
 	stats["treedb.cache.checkpoint.active_background_flush_wait_samples"] = fmt.Sprintf("%d", db.checkpointActiveBackgroundFlushWaitSamples.Load())
+	db.appendWriteWaitForCheckpointStats(stats)
 	stats["treedb.cache.checkpoint.debt_memtables_last"] = fmt.Sprintf("%d", db.checkpointDebtMemtablesLast.Load())
 	stats["treedb.cache.checkpoint.debt_memtables_max"] = fmt.Sprintf("%d", db.checkpointDebtMemtablesMax.Load())
 	stats["treedb.cache.checkpoint.debt_bytes_last"] = fmt.Sprintf("%d", db.checkpointDebtBytesLast.Load())
@@ -34679,7 +34696,7 @@ func (b *Batch) WriteAfterCommandWALAppend(sync bool, appendCommand func() error
 	if !b.db.disableJournal {
 		return fmt.Errorf("cachingdb: command wal batch writes require disabled cached redo log")
 	}
-	b.db.waitForCheckpoint()
+	b.db.waitForCheckpointForWrite()
 	if b.backend != nil {
 		return fmt.Errorf("cachingdb: command wal batch writes require cached memtable path")
 	}
@@ -34699,7 +34716,7 @@ func (b *Batch) write(sync bool) error {
 	if b.closed {
 		return ErrBatchClosed
 	}
-	b.db.waitForCheckpoint()
+	b.db.waitForCheckpointForWrite()
 
 	if b.hasDeleteRanges {
 		return b.writeRangeBatch(sync)

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -8816,6 +8816,10 @@ type DB struct {
 	checkpointActiveBackgroundFlushWaitMaxNs                     atomic.Uint64
 	checkpointActiveBackgroundFlushWaitLastNs                    atomic.Uint64
 	checkpointActiveBackgroundFlushWaitSamples                   atomic.Uint64
+	writeWaitForCheckpointNs                                     atomic.Uint64
+	writeWaitForCheckpointMaxNs                                  atomic.Uint64
+	writeWaitForCheckpointLastNs                                 atomic.Uint64
+	writeWaitForCheckpointSamples                                atomic.Uint64
 	checkpointDebtMemtablesLast                                  atomic.Uint64
 	checkpointDebtMemtablesMax                                   atomic.Uint64
 	checkpointDebtBytesLast                                      atomic.Uint64
@@ -22703,6 +22707,18 @@ func (db *DB) waitForCheckpoint() {
 	db.checkpointMu.Unlock()
 }
 
+func (db *DB) waitForCheckpointForWrite() {
+	if db == nil {
+		return
+	}
+	if !db.checkpointing.Load() && !db.maintenanceActive.Load() {
+		return
+	}
+	start := time.Now()
+	db.waitForCheckpoint()
+	db.observeWriteWaitForCheckpoint(time.Since(start))
+}
+
 func (db *DB) beginDirectWrite() error {
 	for {
 		db.writeMu.RLock()
@@ -29553,6 +29569,7 @@ func (db *DB) Stats() map[string]string {
 	stats["treedb.cache.checkpoint.active_background_flush_wait_ns_max"] = fmt.Sprintf("%d", db.checkpointActiveBackgroundFlushWaitMaxNs.Load())
 	stats["treedb.cache.checkpoint.active_background_flush_wait_ns_last"] = fmt.Sprintf("%d", db.checkpointActiveBackgroundFlushWaitLastNs.Load())
 	stats["treedb.cache.checkpoint.active_background_flush_wait_samples"] = fmt.Sprintf("%d", db.checkpointActiveBackgroundFlushWaitSamples.Load())
+	db.appendWriteWaitForCheckpointStats(stats)
 	stats["treedb.cache.checkpoint.debt_memtables_last"] = fmt.Sprintf("%d", db.checkpointDebtMemtablesLast.Load())
 	stats["treedb.cache.checkpoint.debt_memtables_max"] = fmt.Sprintf("%d", db.checkpointDebtMemtablesMax.Load())
 	stats["treedb.cache.checkpoint.debt_bytes_last"] = fmt.Sprintf("%d", db.checkpointDebtBytesLast.Load())
@@ -34569,7 +34586,7 @@ func (b *Batch) WriteAfterCommandWALAppend(sync bool, appendCommand func() error
 	if !b.db.disableJournal {
 		return fmt.Errorf("cachingdb: command wal batch writes require disabled cached redo log")
 	}
-	b.db.waitForCheckpoint()
+	b.db.waitForCheckpointForWrite()
 	if b.backend != nil {
 		return fmt.Errorf("cachingdb: command wal batch writes require cached memtable path")
 	}
@@ -34589,7 +34606,7 @@ func (b *Batch) write(sync bool) error {
 	if b.closed {
 		return ErrBatchClosed
 	}
-	b.db.waitForCheckpoint()
+	b.db.waitForCheckpointForWrite()
 
 	if b.hasDeleteRanges {
 		return b.writeRangeBatch(sync)

--- a/TreeDB/caching/expvar_stats.go
+++ b/TreeDB/caching/expvar_stats.go
@@ -147,6 +147,7 @@ func selectTreeDBExpvarStats(stats map[string]string) map[string]any {
 			strings.HasPrefix(k, "treedb.cache.flush_span_run.") ||
 			strings.HasPrefix(k, "treedb.cache.flush_backlog_coalescing.") ||
 			strings.HasPrefix(k, "treedb.cache.command_wal.") ||
+			strings.HasPrefix(k, "treedb.cache.write.") ||
 			strings.HasPrefix(k, "treedb.cache.vlog_mmap.") ||
 			strings.HasPrefix(k, "treedb.cache.vlog_grouped_frame_cache.") ||
 			strings.HasPrefix(k, "treedb.cache.vlog_decode_buffer_grow.") ||

--- a/TreeDB/caching/expvar_stats_test.go
+++ b/TreeDB/caching/expvar_stats_test.go
@@ -81,6 +81,7 @@ func TestSelectTreeDBExpvarStatsFiltersAndCoerces(t *testing.T) {
 		"treedb.cache.flush_backlog_coalescing.skip.reason.not_enough_backlog_total":                  "6",
 		"treedb.cache.command_wal.checkpoint_publish.piggybacked":                                     "2",
 		"treedb.cache.command_wal.checkpoint_publish.separate":                                        "1",
+		"treedb.cache.write.wait_for_checkpoint.count_total":                                          "4",
 		"treedb.cache.backpressure_mode":                                                              "adaptive",
 		"treedb.cache.entry_slice.trim_runs_total":                                                    "77",
 		"treedb.process.memory.pool_pressure_high_pct":                                                "85.5",
@@ -285,6 +286,9 @@ func TestSelectTreeDBExpvarStatsFiltersAndCoerces(t *testing.T) {
 	}
 	if v, ok := got["treedb.cache.command_wal.checkpoint_publish.separate"].(int64); !ok || v != 1 {
 		t.Fatalf("command WAL checkpoint separate=%T(%v) want int64(1)", got["treedb.cache.command_wal.checkpoint_publish.separate"], got["treedb.cache.command_wal.checkpoint_publish.separate"])
+	}
+	if v, ok := got["treedb.cache.write.wait_for_checkpoint.count_total"].(int64); !ok || v != 4 {
+		t.Fatalf("write wait-for-checkpoint count=%T(%v) want int64(4)", got["treedb.cache.write.wait_for_checkpoint.count_total"], got["treedb.cache.write.wait_for_checkpoint.count_total"])
 	}
 	if _, ok := got["treedb.cache.backpressure_mode"]; ok {
 		t.Fatalf("unexpected backpressure_mode key in expvar selection")

--- a/TreeDB/caching/flush_apply_stats.go
+++ b/TreeDB/caching/flush_apply_stats.go
@@ -268,6 +268,31 @@ func (db *DB) observeCheckpointActiveBackgroundFlushWait(wait time.Duration) {
 	updateAtomicMaxUint64(&db.checkpointActiveBackgroundFlushWaitMaxNs, ns)
 }
 
+func (db *DB) observeWriteWaitForCheckpoint(wait time.Duration) {
+	if db == nil {
+		return
+	}
+	if wait <= 0 {
+		db.writeWaitForCheckpointLastNs.Store(0)
+		return
+	}
+	ns := uint64(wait.Nanoseconds())
+	db.writeWaitForCheckpointNs.Add(ns)
+	db.writeWaitForCheckpointLastNs.Store(ns)
+	db.writeWaitForCheckpointSamples.Add(1)
+	updateAtomicMaxUint64(&db.writeWaitForCheckpointMaxNs, ns)
+}
+
+func (db *DB) appendWriteWaitForCheckpointStats(stats map[string]string) {
+	if db == nil || stats == nil {
+		return
+	}
+	stats["treedb.cache.write.wait_for_checkpoint.ns_total"] = fmt.Sprintf("%d", db.writeWaitForCheckpointNs.Load())
+	stats["treedb.cache.write.wait_for_checkpoint.ns_max"] = fmt.Sprintf("%d", db.writeWaitForCheckpointMaxNs.Load())
+	stats["treedb.cache.write.wait_for_checkpoint.ns_last"] = fmt.Sprintf("%d", db.writeWaitForCheckpointLastNs.Load())
+	stats["treedb.cache.write.wait_for_checkpoint.count_total"] = fmt.Sprintf("%d", db.writeWaitForCheckpointSamples.Load())
+}
+
 const flushCoordinatorProgressWait = 10 * time.Millisecond
 
 func (db *DB) beginFlushCoordinatorPass() {

--- a/TreeDB/caching/flush_apply_stats_test.go
+++ b/TreeDB/caching/flush_apply_stats_test.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"runtime"
 	"strconv"
+	"sync"
 	"testing"
 	"time"
 
@@ -94,6 +95,8 @@ func TestFlushApplyStatsExposeStageCounters(t *testing.T) {
 		"treedb.cache.flush_apply.leaf_log_encode_compress_ns_total",
 		"treedb.flush_apply.apply_ns_total",
 		"treedb.cache.checkpoint.active_background_flush_wait_ns_total",
+		"treedb.cache.write.wait_for_checkpoint.ns_total",
+		"treedb.cache.write.wait_for_checkpoint.count_total",
 		"treedb.cache.checkpoint.flush_preempt_requests_total",
 		"treedb.cache.flush_apply.coordinator.checkpoint_preemptions_total",
 		"treedb.cache.checkpoint.debt_memtables_last",
@@ -152,6 +155,58 @@ func TestFlushApplyStatsExposeStageCounters(t *testing.T) {
 	}
 	if got := requireStatUint64(t, stats, "treedb.cache.flush_apply.leaf_log_append_frames_total"); got == 0 {
 		t.Fatalf("leaf log append frames = 0, want >0")
+	}
+}
+
+func TestWriteWaitForCheckpointStatsIncrement(t *testing.T) {
+	db := &DB{}
+	db.checkpointCond = sync.NewCond(&db.checkpointMu)
+
+	stats := map[string]string{}
+	db.appendWriteWaitForCheckpointStats(stats)
+	for _, key := range []string{
+		"treedb.cache.write.wait_for_checkpoint.ns_total",
+		"treedb.cache.write.wait_for_checkpoint.ns_max",
+		"treedb.cache.write.wait_for_checkpoint.ns_last",
+		"treedb.cache.write.wait_for_checkpoint.count_total",
+	} {
+		if got := requireStatUint64(t, stats, key); got != 0 {
+			t.Fatalf("%s before wait=%d, want 0 (stats=%#v)", key, got, stats)
+		}
+	}
+
+	db.checkpointing.Store(true)
+	done := make(chan struct{})
+	go func() {
+		db.waitForCheckpointForWrite()
+		close(done)
+	}()
+
+	time.Sleep(10 * time.Millisecond)
+	db.checkpointMu.Lock()
+	db.checkpointing.Store(false)
+	db.checkpointCond.Broadcast()
+	db.checkpointMu.Unlock()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("waitForCheckpointForWrite did not unblock")
+	}
+
+	stats = map[string]string{}
+	db.appendWriteWaitForCheckpointStats(stats)
+	if got := requireStatUint64(t, stats, "treedb.cache.write.wait_for_checkpoint.count_total"); got != 1 {
+		t.Fatalf("wait_for_checkpoint.count_total=%d, want 1 (stats=%#v)", got, stats)
+	}
+	for _, key := range []string{
+		"treedb.cache.write.wait_for_checkpoint.ns_total",
+		"treedb.cache.write.wait_for_checkpoint.ns_max",
+		"treedb.cache.write.wait_for_checkpoint.ns_last",
+	} {
+		if got := requireStatUint64(t, stats, key); got == 0 {
+			t.Fatalf("%s=0, want >0 (stats=%#v)", key, stats)
+		}
 	}
 }
 

--- a/TreeDB/command_wal_public_test.go
+++ b/TreeDB/command_wal_public_test.go
@@ -373,6 +373,72 @@ func publicStatUint64(t *testing.T, db *DB, key string) uint64 {
 	return statMapUint64(t, db.Stats(), key)
 }
 
+func TestPublicCommandWALRuntimeStatsExposeAppendAndSyncCounters(t *testing.T) {
+	db, err := Open(Options{
+		Dir:                 t.TempDir(),
+		Durability:          DurabilityDurable,
+		CommandWAL:          true,
+		CommandWALStatsScan: true,
+	})
+	if err != nil {
+		t.Fatalf("Open command WAL: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	before := db.Stats()
+	for _, key := range []string{
+		"treedb.command_wal.append.count_total",
+		"treedb.command_wal.append.point.count_total",
+		"treedb.command_wal.append.payload.count_total",
+		"treedb.command_wal.flush.count_total",
+		"treedb.command_wal.sync.count_total",
+	} {
+		if got := statMapUint64(t, before, key); got != 0 {
+			t.Fatalf("%s before writes=%d, want 0 (stats=%#v)", key, got, before)
+		}
+	}
+
+	if err := db.Set([]byte("point"), []byte("one")); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	b := db.NewBatch()
+	if err := b.Set([]byte("payload"), []byte("two")); err != nil {
+		_ = b.Close()
+		t.Fatalf("batch Set: %v", err)
+	}
+	if err := b.WriteSync(); err != nil {
+		_ = b.Close()
+		t.Fatalf("batch WriteSync: %v", err)
+	}
+	if err := b.Close(); err != nil {
+		t.Fatalf("batch Close: %v", err)
+	}
+
+	stats := db.Stats()
+	for key, want := range map[string]uint64{
+		"treedb.command_wal.append.count_total":         2,
+		"treedb.command_wal.append.point.count_total":   1,
+		"treedb.command_wal.append.payload.count_total": 1,
+		"treedb.command_wal.flush.count_total":          1,
+		"treedb.command_wal.sync.count_total":           1,
+	} {
+		if got := statMapUint64(t, stats, key); got != want {
+			t.Fatalf("%s=%d, want %d (stats=%#v)", key, got, want, stats)
+		}
+	}
+	for _, key := range []string{
+		"treedb.command_wal.append.ns_total",
+		"treedb.command_wal.append.point.ns_total",
+		"treedb.command_wal.append.payload.ns_total",
+		"treedb.command_wal.flush.ns_total",
+		"treedb.command_wal.sync.ns_total",
+	} {
+		if got := statMapUint64(t, stats, key); got == 0 {
+			t.Fatalf("%s=0, want >0 (stats=%#v)", key, stats)
+		}
+	}
+}
+
 func TestPublicCommandWALBatchIngressStatsDistinguishViews(t *testing.T) {
 	db, err := Open(Options{
 		Dir:                 t.TempDir(),
@@ -1082,6 +1148,18 @@ func TestPublicCommandWALCheckpointCleansCoveredCommandJournalSegment(t *testing
 	stats := db.Stats()
 	if got := stats["treedb.command_wal.cleanup.removed_segments"]; got != "1" {
 		t.Fatalf("cleanup.removed_segments=%q, want 1 (stats=%#v)", got, stats)
+	}
+	if got := statMapUint64(t, stats, "treedb.command_wal.cleanup.scan.count_total"); got == 0 {
+		t.Fatalf("cleanup.scan.count_total=0, want >0")
+	}
+	for _, key := range []string{
+		"treedb.command_wal.cleanup.scan.ns_total",
+		"treedb.command_wal.cleanup.scanned_bytes_total",
+		"treedb.command_wal.cleanup.scanned_frames_total",
+	} {
+		if got := statMapUint64(t, stats, key); got == 0 {
+			t.Fatalf("%s=0, want >0", key)
+		}
 	}
 	if got := stats["treedb.command_wal.segments.active"]; got != "1" {
 		t.Fatalf("segments.active=%q, want 1 (stats=%#v)", got, stats)

--- a/TreeDB/db/command_wal_publish.go
+++ b/TreeDB/db/command_wal_publish.go
@@ -166,6 +166,7 @@ func validateContiguousAppliedCommandLSN(current, next uint64, covered []Command
 type commandWALSegmentCleanupDecision struct {
 	Path    string
 	Size    int64
+	Frames  uint64
 	MaxLSN  uint64
 	Active  bool
 	Covered bool
@@ -176,6 +177,7 @@ type commandWALSegmentCleanupDecision struct {
 type commandWALSegmentScanResult struct {
 	maxLSN       uint64
 	minLSN       uint64
+	frames       uint64
 	typed        bool
 	terminalTail bool
 }
@@ -290,6 +292,7 @@ func scanCommandWALSegmentWithOptions(path string, maxSegmentBytes int64, allowT
 		}
 		lastLSN = frame.LSN
 		scan.typed = true
+		scan.frames++
 		if scan.minLSN == 0 || frame.LSN < scan.minLSN {
 			scan.minLSN = frame.LSN
 		}
@@ -398,6 +401,7 @@ func cleanupCommandWALSegmentsCoveredByAppliedLSN(dir string, appliedLSN uint64,
 		decision := commandWALSegmentCleanupDecision{
 			Path:    seg.path,
 			Size:    seg.size,
+			Frames:  scan.frames,
 			MaxLSN:  scan.maxLSN,
 			Active:  active,
 			Covered: scan.maxLSN <= appliedLSN,

--- a/TreeDB/db/command_wal_raw.go
+++ b/TreeDB/db/command_wal_raw.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"time"
 
 	batchpkg "github.com/snissn/gomap/TreeDB/batch"
 	"github.com/snissn/gomap/TreeDB/internal/adaptive"
@@ -175,6 +176,10 @@ func (db *DB) CommandWALEnabled() bool {
 // modes fsync the command WAL; DurabilityWALOnRelaxed intentionally downgrades
 // this to a flush-to-kernel boundary to preserve relaxed-sync semantics.
 func (db *DB) FlushCommandWAL(sync bool) error {
+	return db.flushCommandWAL(sync, true)
+}
+
+func (db *DB) flushCommandWAL(sync bool, observe bool) error {
 	if db == nil || !db.commandWAL || db.commandJournal == nil {
 		return nil
 	}
@@ -182,13 +187,21 @@ func (db *DB) FlushCommandWAL(sync bool) error {
 		return err
 	}
 	var err error
-	if sync && db.durability != DurabilityWALOnRelaxed {
+	actualSync := sync && db.durability != DurabilityWALOnRelaxed
+	start := time.Time{}
+	if observe {
+		start = time.Now()
+	}
+	if actualSync {
 		err = db.commandJournal.Sync()
 	} else {
 		err = db.commandJournal.Flush()
 	}
 	if err == nil && db.testFailCommandWALFlush.Load() {
 		err = errTestCommandWALFlushFailpoint
+	}
+	if observe {
+		db.observeCommandWALFlush(actualSync, time.Since(start))
 	}
 	if err != nil {
 		db.commandWALFlushPoisoned.Store(true)
@@ -320,11 +333,21 @@ func (db *DB) CleanupCommandWALCoveredSegments(sync bool) error {
 	if state == nil || state.AppliedCommandLSN == 0 {
 		return nil
 	}
+	scanStart := time.Now()
 	decisions, err := cleanupCommandWALSegmentsCoveredByAppliedLSN(db.dir, state.AppliedCommandLSN, db.walMaxSegmentBytes)
 	db.commandWALCleanupScans.Add(1)
+	if scanNs := commandWALDurationNs(time.Since(scanStart)); scanNs > 0 {
+		db.commandWALCleanupScanNs.Add(scanNs)
+	}
 	removed := uint64(0)
 	removedBytes := uint64(0)
+	scannedBytes := uint64(0)
+	scannedFrames := uint64(0)
 	for _, decision := range decisions {
+		if decision.Size > 0 {
+			scannedBytes += uint64(decision.Size)
+		}
+		scannedFrames += decision.Frames
 		if !decision.Removed {
 			continue
 		}
@@ -332,6 +355,12 @@ func (db *DB) CleanupCommandWALCoveredSegments(sync bool) error {
 		if decision.Size > 0 {
 			removedBytes += uint64(decision.Size)
 		}
+	}
+	if scannedBytes > 0 {
+		db.commandWALCleanupScanBytes.Add(scannedBytes)
+	}
+	if scannedFrames > 0 {
+		db.commandWALCleanupScanFrames.Add(scannedFrames)
 	}
 	if removed > 0 {
 		db.commandWALCleanupRemoved.Add(removed)
@@ -1008,9 +1037,15 @@ func (db *DB) AppendRawKVSingleCommandWAL(op commitlog.RawKVOperation, sync bool
 		baseAppliedLSN = state.AppliedCommandLSN
 	}
 	flushSync := sync && db.durability != DurabilityWALOnRelaxed
+	appendStart := time.Now()
 	lsn, err := db.commandJournal.AppendRawKVSingleCommandAndFlush(baseAppliedLSN, op, flushSync)
 	if err == nil && db.testFailCommandWALFlush.Load() {
 		err = errTestCommandWALFlushFailpoint
+	}
+	if lsn != 0 || err == nil {
+		elapsed := time.Since(appendStart)
+		db.observeCommandWALAppend(commandWALAppendStatsPoint, elapsed)
+		db.observeCommandWALFlush(flushSync, elapsed)
 	}
 	if err != nil {
 		if lsn != 0 {
@@ -1068,6 +1103,7 @@ func (db *DB) appendRawKVPointCommandWALTrustedWithRevision(op commitlog.RawKVOp
 	flushSync := sync && db.durability != DurabilityWALOnRelaxed
 	var lsn uint64
 	var err error
+	appendStart := time.Now()
 	if revision == 0 {
 		lsn, err = db.commandJournal.AppendRawKVPointCommandTrustedAndFlush(baseAppliedLSN, op, key, value, flushSync)
 	} else {
@@ -1075,6 +1111,11 @@ func (db *DB) appendRawKVPointCommandWALTrustedWithRevision(op commitlog.RawKVOp
 	}
 	if err == nil && db.testFailCommandWALFlush.Load() {
 		err = errTestCommandWALFlushFailpoint
+	}
+	if lsn != 0 || err == nil {
+		elapsed := time.Since(appendStart)
+		db.observeCommandWALAppend(commandWALAppendStatsPoint, elapsed)
+		db.observeCommandWALFlush(flushSync, elapsed)
 	}
 	if err != nil {
 		if lsn != 0 {
@@ -1133,19 +1174,25 @@ func (db *DB) appendRawKVBatchPayloadCommandWAL(payload []byte, sync bool, trust
 	var err error
 	flushSync := sync && db.durability != DurabilityWALOnRelaxed
 	if trusted {
+		appendStart := time.Now()
 		lsn, err = db.commandJournal.AppendRawKVBatchPayloadCommandTrustedAndFlush(baseAppliedLSN, payload, flushSync)
-	} else {
-		lsn, err = db.commandJournal.AppendRawKVBatchPayloadCommand(baseAppliedLSN, payload)
-		if err == nil {
-			if flushSync {
-				err = db.commandJournal.Sync()
-			} else {
-				err = db.commandJournal.Flush()
-			}
+		if err == nil && db.testFailCommandWALFlush.Load() {
+			err = errTestCommandWALFlushFailpoint
 		}
-	}
-	if err == nil && db.testFailCommandWALFlush.Load() {
-		err = errTestCommandWALFlushFailpoint
+		if lsn != 0 || err == nil {
+			elapsed := time.Since(appendStart)
+			db.observeCommandWALAppend(commandWALAppendStatsPayload, elapsed)
+			db.observeCommandWALFlush(flushSync, elapsed)
+		}
+	} else {
+		appendStart := time.Now()
+		lsn, err = db.commandJournal.AppendRawKVBatchPayloadCommand(baseAppliedLSN, payload)
+		if lsn != 0 || err == nil {
+			db.observeCommandWALAppend(commandWALAppendStatsPayload, time.Since(appendStart))
+		}
+		if err == nil {
+			err = db.flushCommandWAL(sync, true)
+		}
 	}
 	if err != nil {
 		if lsn != 0 {
@@ -1273,13 +1320,17 @@ func (db *DB) appendCommandWALIntent(intent *commandWALBatchIntent, sync bool) (
 	db.mu.RUnlock()
 	var lsn uint64
 	var err error
+	appendPath := commandWALAppendStatsIntent
+	appendStart := time.Now()
 	if intent.rawKVDirect {
+		appendPath = commandWALAppendStatsEntryScan
 		scan := intent.rawKVScan
 		if scan == nil {
 			scan = db.rawKVCommandWALOperationScanner(intent.rawKVEntries, &intent.rawKVRIDCache, nil)
 		}
 		lsn, err = db.commandJournal.AppendRawKVBatchPayloadScanCommandTrusted(baseAppliedLSN, intent.rawKVPlan, scan)
 	} else if intent.trustedPayload && !intent.externalRefs {
+		appendPath = commandWALAppendStatsPayload
 		lsn, err = db.commandJournal.AppendCommandPayloadTrusted(intent.kind, intent.scope, intent.payloadFormat, baseAppliedLSN, intent.payload)
 	} else {
 		lsn, err = db.commandJournal.AppendCommand(commitlog.CommandEnvelope{
@@ -1289,6 +1340,9 @@ func (db *DB) appendCommandWALIntent(intent *commandWALBatchIntent, sync bool) (
 			PayloadFormat:  intent.payloadFormat,
 			Payload:        intent.payload,
 		})
+	}
+	if lsn != 0 || err == nil {
+		db.observeCommandWALAppend(appendPath, time.Since(appendStart))
 	}
 	if err != nil {
 		return 0, err

--- a/TreeDB/db/command_wal_stats.go
+++ b/TreeDB/db/command_wal_stats.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"path/filepath"
 	"sync/atomic"
+	"time"
 
 	"github.com/snissn/gomap/TreeDB/internal/commitlog"
 )
@@ -20,6 +21,15 @@ type commandWALStatsSummary struct {
 	ActiveBytes    int64
 	ActiveName     string
 }
+
+type commandWALAppendStatsPath uint8
+
+const (
+	commandWALAppendStatsPoint commandWALAppendStatsPath = iota
+	commandWALAppendStatsPayload
+	commandWALAppendStatsEntryScan
+	commandWALAppendStatsIntent
+)
 
 func writeCommandWALStats(stats map[string]string, db *DB) {
 	if stats == nil || db == nil {
@@ -87,7 +97,25 @@ func writeCommandWALStatsZeroCounters(stats map[string]string) {
 	stats["treedb.command_wal.live_accepted_max_lsn"] = "0"
 	stats["treedb.command_wal.live_covered_frames"] = "0"
 	stats["treedb.command_wal.live_covered_max_lsn"] = "0"
+	stats["treedb.command_wal.append.count_total"] = "0"
+	stats["treedb.command_wal.append.ns_total"] = "0"
+	stats["treedb.command_wal.append.point.count_total"] = "0"
+	stats["treedb.command_wal.append.point.ns_total"] = "0"
+	stats["treedb.command_wal.append.payload.count_total"] = "0"
+	stats["treedb.command_wal.append.payload.ns_total"] = "0"
+	stats["treedb.command_wal.append.entry_scan.count_total"] = "0"
+	stats["treedb.command_wal.append.entry_scan.ns_total"] = "0"
+	stats["treedb.command_wal.append.intent.count_total"] = "0"
+	stats["treedb.command_wal.append.intent.ns_total"] = "0"
+	stats["treedb.command_wal.flush.count_total"] = "0"
+	stats["treedb.command_wal.flush.ns_total"] = "0"
+	stats["treedb.command_wal.sync.count_total"] = "0"
+	stats["treedb.command_wal.sync.ns_total"] = "0"
 	stats["treedb.command_wal.cleanup.scans"] = "0"
+	stats["treedb.command_wal.cleanup.scan.count_total"] = "0"
+	stats["treedb.command_wal.cleanup.scan.ns_total"] = "0"
+	stats["treedb.command_wal.cleanup.scanned_bytes_total"] = "0"
+	stats["treedb.command_wal.cleanup.scanned_frames_total"] = "0"
 	stats["treedb.command_wal.cleanup.removed_segments"] = "0"
 	stats["treedb.command_wal.cleanup.removed_bytes"] = "0"
 	stats["treedb.command_wal.writer.buffer_size_bytes"] = "0"
@@ -118,7 +146,25 @@ func writeCommandWALLifecycleStats(stats map[string]string, db *DB) {
 	stats["treedb.command_wal.applied_lsn"] = fmt.Sprintf("%d", appliedLSN)
 	stats["treedb.command_wal.next_lsn"] = fmt.Sprintf("%d", db.CommandWALNextLSN())
 	stats["treedb.command_wal.bytes.active"] = fmt.Sprintf("%d", db.CommandWALActiveBytes())
+	stats["treedb.command_wal.append.count_total"] = fmt.Sprintf("%d", db.commandWALAppendCount.Load())
+	stats["treedb.command_wal.append.ns_total"] = fmt.Sprintf("%d", db.commandWALAppendNs.Load())
+	stats["treedb.command_wal.append.point.count_total"] = fmt.Sprintf("%d", db.commandWALAppendPointCount.Load())
+	stats["treedb.command_wal.append.point.ns_total"] = fmt.Sprintf("%d", db.commandWALAppendPointNs.Load())
+	stats["treedb.command_wal.append.payload.count_total"] = fmt.Sprintf("%d", db.commandWALAppendPayloadCount.Load())
+	stats["treedb.command_wal.append.payload.ns_total"] = fmt.Sprintf("%d", db.commandWALAppendPayloadNs.Load())
+	stats["treedb.command_wal.append.entry_scan.count_total"] = fmt.Sprintf("%d", db.commandWALAppendEntryScanCount.Load())
+	stats["treedb.command_wal.append.entry_scan.ns_total"] = fmt.Sprintf("%d", db.commandWALAppendEntryScanNs.Load())
+	stats["treedb.command_wal.append.intent.count_total"] = fmt.Sprintf("%d", db.commandWALAppendIntentCount.Load())
+	stats["treedb.command_wal.append.intent.ns_total"] = fmt.Sprintf("%d", db.commandWALAppendIntentNs.Load())
+	stats["treedb.command_wal.flush.count_total"] = fmt.Sprintf("%d", db.commandWALFlushCount.Load())
+	stats["treedb.command_wal.flush.ns_total"] = fmt.Sprintf("%d", db.commandWALFlushNs.Load())
+	stats["treedb.command_wal.sync.count_total"] = fmt.Sprintf("%d", db.commandWALSyncCount.Load())
+	stats["treedb.command_wal.sync.ns_total"] = fmt.Sprintf("%d", db.commandWALSyncNs.Load())
 	stats["treedb.command_wal.cleanup.scans"] = fmt.Sprintf("%d", db.commandWALCleanupScans.Load())
+	stats["treedb.command_wal.cleanup.scan.count_total"] = fmt.Sprintf("%d", db.commandWALCleanupScans.Load())
+	stats["treedb.command_wal.cleanup.scan.ns_total"] = fmt.Sprintf("%d", db.commandWALCleanupScanNs.Load())
+	stats["treedb.command_wal.cleanup.scanned_bytes_total"] = fmt.Sprintf("%d", db.commandWALCleanupScanBytes.Load())
+	stats["treedb.command_wal.cleanup.scanned_frames_total"] = fmt.Sprintf("%d", db.commandWALCleanupScanFrames.Load())
 	stats["treedb.command_wal.cleanup.removed_segments"] = fmt.Sprintf("%d", db.commandWALCleanupRemoved.Load())
 	stats["treedb.command_wal.cleanup.removed_bytes"] = fmt.Sprintf("%d", db.commandWALCleanupBytes.Load())
 	writeCommandWALWriterBufferStats(stats, db)
@@ -158,6 +204,64 @@ func (db *DB) observeCommandWALCovered(previous, next uint64) {
 	commandWALStoreMax(&db.commandWALLiveCoveredMax, next)
 }
 
+func (db *DB) observeCommandWALAppend(path commandWALAppendStatsPath, elapsed time.Duration) {
+	if db == nil {
+		return
+	}
+	ns := commandWALDurationNs(elapsed)
+	db.commandWALAppendCount.Add(1)
+	if ns > 0 {
+		db.commandWALAppendNs.Add(ns)
+	}
+	switch path {
+	case commandWALAppendStatsPoint:
+		db.commandWALAppendPointCount.Add(1)
+		if ns > 0 {
+			db.commandWALAppendPointNs.Add(ns)
+		}
+	case commandWALAppendStatsPayload:
+		db.commandWALAppendPayloadCount.Add(1)
+		if ns > 0 {
+			db.commandWALAppendPayloadNs.Add(ns)
+		}
+	case commandWALAppendStatsEntryScan:
+		db.commandWALAppendEntryScanCount.Add(1)
+		if ns > 0 {
+			db.commandWALAppendEntryScanNs.Add(ns)
+		}
+	case commandWALAppendStatsIntent:
+		db.commandWALAppendIntentCount.Add(1)
+		if ns > 0 {
+			db.commandWALAppendIntentNs.Add(ns)
+		}
+	}
+}
+
+func (db *DB) observeCommandWALFlush(sync bool, elapsed time.Duration) {
+	if db == nil {
+		return
+	}
+	ns := commandWALDurationNs(elapsed)
+	if sync {
+		db.commandWALSyncCount.Add(1)
+		if ns > 0 {
+			db.commandWALSyncNs.Add(ns)
+		}
+		return
+	}
+	db.commandWALFlushCount.Add(1)
+	if ns > 0 {
+		db.commandWALFlushNs.Add(ns)
+	}
+}
+
+func commandWALDurationNs(d time.Duration) uint64 {
+	if d <= 0 {
+		return 0
+	}
+	return uint64(d.Nanoseconds())
+}
+
 func commandWALStoreMax(dst *atomic.Uint64, value uint64) {
 	for {
 		current := dst.Load()
@@ -171,7 +275,7 @@ func commandWALStoreMax(dst *atomic.Uint64, value uint64) {
 }
 
 func (db *DB) cachedCommandWALStatsSummary() (commandWALStatsSummary, error) {
-	if err := db.FlushCommandWAL(false); err != nil {
+	if err := db.flushCommandWAL(false, false); err != nil {
 		return commandWALStatsSummary{}, err
 	}
 	state := db.state.Load()

--- a/TreeDB/db/command_wal_stats_test.go
+++ b/TreeDB/db/command_wal_stats_test.go
@@ -7,8 +7,22 @@ import (
 	"strconv"
 	"testing"
 
+	batchpkg "github.com/snissn/gomap/TreeDB/batch"
 	"github.com/snissn/gomap/TreeDB/internal/commitlog"
 )
+
+func commandWALTestStatUint64(t *testing.T, stats map[string]string, key string) uint64 {
+	t.Helper()
+	raw, ok := stats[key]
+	if !ok {
+		t.Fatalf("missing stat %s", key)
+	}
+	got, err := strconv.ParseUint(raw, 10, 64)
+	if err != nil {
+		t.Fatalf("parse %s=%q: %v", key, raw, err)
+	}
+	return got
+}
 
 func TestCommandWALStatsProveModeAndFrames(t *testing.T) {
 	db, err := Open(Options{Dir: t.TempDir(), CommandWAL: true, CommandWALStatsScan: true, DisableBackgroundPrune: true, WALMaxSegmentBytes: 1024})
@@ -51,6 +65,21 @@ func TestCommandWALStatsProveModeAndFrames(t *testing.T) {
 	if got := stats["treedb.command_wal.live_covered_frames"]; got != "1" {
 		t.Fatalf("live covered frame stat=%q, want 1 (stats=%#v)", got, stats)
 	}
+	if got := commandWALTestStatUint64(t, stats, "treedb.command_wal.append.count_total"); got != 1 {
+		t.Fatalf("append.count_total=%d, want 1 (stats=%#v)", got, stats)
+	}
+	if got := commandWALTestStatUint64(t, stats, "treedb.command_wal.append.entry_scan.count_total"); got != 1 {
+		t.Fatalf("append.entry_scan.count_total=%d, want 1", got)
+	}
+	if got := commandWALTestStatUint64(t, stats, "treedb.command_wal.append.ns_total"); got == 0 {
+		t.Fatalf("append.ns_total=0, want >0")
+	}
+	if got := commandWALTestStatUint64(t, stats, "treedb.command_wal.sync.count_total"); got != 1 {
+		t.Fatalf("sync.count_total=%d, want 1 (stats=%#v)", got, stats)
+	}
+	if got := commandWALTestStatUint64(t, stats, "treedb.command_wal.sync.ns_total"); got == 0 {
+		t.Fatalf("sync.ns_total=0, want >0 (stats=%#v)", stats)
+	}
 	if got := stats["treedb.command_wal.typed_segments"]; got != "1" {
 		t.Fatalf("command WAL typed segment stat=%q, want 1 (stats=%#v)", got, stats)
 	}
@@ -70,6 +99,77 @@ func TestCommandWALStatsProveModeAndFrames(t *testing.T) {
 		t.Fatalf("Close: %v", err)
 	}
 	dbClosed = true
+}
+
+func TestCommandWALRuntimeStatsExposeAppendPaths(t *testing.T) {
+	db, err := Open(Options{Dir: t.TempDir(), CommandWAL: true, CommandWALStatsScan: true, DisableBackgroundPrune: true})
+	if err != nil {
+		t.Fatalf("Open command WAL: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	before := db.Stats()
+	for _, key := range []string{
+		"treedb.command_wal.append.count_total",
+		"treedb.command_wal.append.point.count_total",
+		"treedb.command_wal.append.payload.count_total",
+		"treedb.command_wal.append.entry_scan.count_total",
+		"treedb.command_wal.flush.count_total",
+		"treedb.command_wal.sync.count_total",
+	} {
+		if got := commandWALTestStatUint64(t, before, key); got != 0 {
+			t.Fatalf("%s before writes=%d, want 0 (stats=%#v)", key, got, before)
+		}
+	}
+
+	if _, err := db.AppendRawKVPointCommandWALTrusted(commitlog.RawKVOpSet, []byte("point"), []byte("one"), false); err != nil {
+		t.Fatalf("AppendRawKVPointCommandWALTrusted: %v", err)
+	}
+	payload, err := commitlog.EncodeRawKVBatchPayload([]commitlog.RawKVOperation{{
+		Op:    commitlog.RawKVOpSet,
+		Key:   []byte("payload"),
+		Value: []byte("two"),
+	}})
+	if err != nil {
+		t.Fatalf("EncodeRawKVBatchPayload: %v", err)
+	}
+	if _, err := db.AppendRawKVBatchPayloadCommandWALTrusted(payload, false); err != nil {
+		t.Fatalf("AppendRawKVBatchPayloadCommandWALTrusted: %v", err)
+	}
+	if _, err := db.AppendRawKVCommandWALOrderedEntries([]batchpkg.Entry{{
+		Type:  batchpkg.OpPut,
+		Key:   []byte("entry-scan"),
+		Value: []byte("three"),
+	}}, true); err != nil {
+		t.Fatalf("AppendRawKVCommandWALOrderedEntries: %v", err)
+	}
+
+	stats := db.Stats()
+	for key, want := range map[string]uint64{
+		"treedb.command_wal.append.count_total":            3,
+		"treedb.command_wal.append.point.count_total":      1,
+		"treedb.command_wal.append.payload.count_total":    1,
+		"treedb.command_wal.append.entry_scan.count_total": 1,
+		"treedb.command_wal.append.intent.count_total":     0,
+		"treedb.command_wal.flush.count_total":             2,
+		"treedb.command_wal.sync.count_total":              1,
+	} {
+		if got := commandWALTestStatUint64(t, stats, key); got != want {
+			t.Fatalf("%s=%d, want %d (stats=%#v)", key, got, want, stats)
+		}
+	}
+	for _, key := range []string{
+		"treedb.command_wal.append.ns_total",
+		"treedb.command_wal.append.point.ns_total",
+		"treedb.command_wal.append.payload.ns_total",
+		"treedb.command_wal.append.entry_scan.ns_total",
+		"treedb.command_wal.flush.ns_total",
+		"treedb.command_wal.sync.ns_total",
+	} {
+		if got := commandWALTestStatUint64(t, stats, key); got == 0 {
+			t.Fatalf("%s=0, want >0 (stats=%#v)", key, stats)
+		}
+	}
 }
 
 func TestCommandWALStatsDefaultDoesNotScanWAL(t *testing.T) {
@@ -277,5 +377,18 @@ func TestCommandWALStatsDisabledDoesNotScanWAL(t *testing.T) {
 	}
 	if got := stats["treedb.command_wal.stats_scan"]; got != "false" {
 		t.Fatalf("stats_scan=%q, want false for disabled command WAL", got)
+	}
+	for _, key := range []string{
+		"treedb.command_wal.append.count_total",
+		"treedb.command_wal.flush.count_total",
+		"treedb.command_wal.sync.count_total",
+		"treedb.command_wal.cleanup.scan.count_total",
+		"treedb.command_wal.cleanup.scan.ns_total",
+		"treedb.command_wal.cleanup.scanned_bytes_total",
+		"treedb.command_wal.cleanup.scanned_frames_total",
+	} {
+		if got := commandWALTestStatUint64(t, stats, key); got != 0 {
+			t.Fatalf("%s=%d, want 0 for disabled command WAL (stats=%#v)", key, got, stats)
+		}
 	}
 }

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -460,7 +460,24 @@ type DB struct {
 	commandWALLiveAcceptedMax        atomic.Uint64
 	commandWALLiveCovered            atomic.Uint64
 	commandWALLiveCoveredMax         atomic.Uint64
+	commandWALAppendCount            atomic.Uint64
+	commandWALAppendNs               atomic.Uint64
+	commandWALAppendPointCount       atomic.Uint64
+	commandWALAppendPointNs          atomic.Uint64
+	commandWALAppendPayloadCount     atomic.Uint64
+	commandWALAppendPayloadNs        atomic.Uint64
+	commandWALAppendEntryScanCount   atomic.Uint64
+	commandWALAppendEntryScanNs      atomic.Uint64
+	commandWALAppendIntentCount      atomic.Uint64
+	commandWALAppendIntentNs         atomic.Uint64
+	commandWALFlushCount             atomic.Uint64
+	commandWALFlushNs                atomic.Uint64
+	commandWALSyncCount              atomic.Uint64
+	commandWALSyncNs                 atomic.Uint64
 	commandWALCleanupScans           atomic.Uint64
+	commandWALCleanupScanNs          atomic.Uint64
+	commandWALCleanupScanBytes       atomic.Uint64
+	commandWALCleanupScanFrames      atomic.Uint64
 	commandWALCleanupRemoved         atomic.Uint64
 	commandWALCleanupBytes           atomic.Uint64
 	commandWALClosedBytes            atomic.Int64


### PR DESCRIPTION
## Objective

Add cheap TreeDB runtime counters for command-WAL append/sync/cleanup work and cached write wait-for-checkpoint attribution.

Closes #3583. Part of #3581.

## Context

The low-fanout Ironbird attribution work needs stable counters in existing `Stats()` plumbing so durability, background, and write-path costs can be separated without changing checkpoint or durability behavior.

## Non-goals

- No Ironbird harness changes; #3582 owns harness/report wiring.
- No durability semantic changes and no checkpoint policy changes.
- No on-disk format changes.
- No legacy slab path changes or value-log persistence changes.
- No invasive value-log encode/compress timing inside ordinary value-log batching in this PR.

## Design

- Formats/flags/APIs changed: no format, flag, or public API changes; this only extends stats maps and expvar selection.
- Invariants that must hold: command WAL remains redo durability; persistent value-log pointers and segment lifetime rules are unchanged.
- Fail-closed behavior: command-WAL append/flush/sync failure handling is unchanged; stats are atomic counters only.

Stats added:

- `treedb.command_wal.append.count_total`
- `treedb.command_wal.append.ns_total`
- `treedb.command_wal.append.point.count_total`
- `treedb.command_wal.append.point.ns_total`
- `treedb.command_wal.append.payload.count_total`
- `treedb.command_wal.append.payload.ns_total`
- `treedb.command_wal.append.entry_scan.count_total`
- `treedb.command_wal.append.entry_scan.ns_total`
- `treedb.command_wal.append.intent.count_total`
- `treedb.command_wal.append.intent.ns_total`
- `treedb.command_wal.flush.count_total`
- `treedb.command_wal.flush.ns_total`
- `treedb.command_wal.sync.count_total`
- `treedb.command_wal.sync.ns_total`
- `treedb.command_wal.cleanup.scan.count_total`
- `treedb.command_wal.cleanup.scan.ns_total`
- `treedb.command_wal.cleanup.scanned_bytes_total`
- `treedb.command_wal.cleanup.scanned_frames_total`
- `treedb.cache.write.wait_for_checkpoint.ns_total`
- `treedb.cache.write.wait_for_checkpoint.ns_max`
- `treedb.cache.write.wait_for_checkpoint.ns_last`
- `treedb.cache.write.wait_for_checkpoint.count_total`

Existing checkpoint/flush overlap stats remain the primary background overlap attribution surface, including `treedb.cache.checkpoint.active_background_flush_wait_*`, `treedb.cache.checkpoint.stage.*`, and `treedb.cache.flush_apply.*` counters.

For value-log timing, this PR relies on existing exposed stats such as `treedb.cache.flush_apply.vlog_flush_ns_total`, `treedb.cache.flush_apply.vlog_sync_ns_total`, and `treedb.cache.flush_apply.leaf_log_encode_compress_ns_total`. Exact ordinary value-log write/encode/compress timing crosses lane batching and frame preparation internals, so adding it precisely should be a follow-up rather than a risky hot-path expansion here.

## Scope

- Includes: `TreeDB/db` command-WAL runtime stats, cleanup scan summary counters, cached write wait-for-checkpoint stats, `treedb.cache.write.*` expvar selection, focused tests.
- Excludes: Ironbird benchmark harness, command-WAL replay semantics, value-log GC/rewrite policy, checkpoint scheduling, on-disk formats.

## Correctness

- Tests run (exact commands):
  - `GOWORK=off go test ./TreeDB/db -run 'TestCommandWALStats|TestCommandWALRuntimeStats'`
  - `GOWORK=off go test ./TreeDB -run 'TestPublicCommandWALRuntimeStats|TestPublicCommandWALCheckpointCleansCoveredCommandJournalSegment'`
  - `GOWORK=off go test ./TreeDB/caching -run 'TestWriteWaitForCheckpointStatsIncrement|TestBeginDirectWriteRecordsCheckpointWait|TestBeginExclusiveWriteRecordsCheckpointWait|TestFlushApplyStatsExposeStageCounters|TestSelectTreeDBExpvarStats'`
  - `GOWORK=off go test ./TreeDB/...`
- Corruption/edge cases covered: disabled command-WAL zero stats remain stable and do not scan WAL; cleanup scan counters reuse existing cleanup scan results and do not add a second segment pass.
- Concurrency/race coverage: counters are atomics; cached write wait timing only runs when checkpoint/maintenance state is active.

## Performance

- Benchmarks run (exact commands):
  - `GOWORK=off go test ./TreeDB -run '^$' -bench 'BenchmarkSyncLatencyCached/BatchWriteSync/wal_on_relaxed_sync_command_wal/32/entry_hint$' -benchtime=100ms -count=3`
- Results table from rebased head:
  - 21,626 ns/op, 1,479,680 writes/s, 32,462 B/op, 45 allocs/op
  - 20,563 ns/op, 1,556,229 writes/s, 32,841 B/op, 44 allocs/op
  - 19,292 ns/op, 1,658,728 writes/s, 32,380 B/op, 45 allocs/op
- Regressions: no before/after baseline was collected on this branch. Expected overhead is one wall-clock timer and atomic increments on command-WAL append/flush/sync boundaries. Cached write wait keeps the existing fast-path state check and only starts a timer when checkpoint/maintenance is active. Cleanup counters reuse the existing cleanup segment scan and add no extra WAL scan.
- Caveat: combined command-journal append-and-flush APIs do not expose separate append and fsync timings without changing the internal commitlog API, so those paths record the observed DB-level boundary duration for both append-path and flush/sync attribution.

## Rollout / Toggle Plan

- Default setting: counters are always present through existing `Stats()` plumbing and default to zero when the path is inactive.
- How to disable quickly: no behavior toggle required; this is observability only. Existing command-WAL configuration still controls whether command-WAL paths execute.

## Follow-ups

- Add precise ordinary value-log write/encode/compress attribution if needed, likely at value-log lane/frame-preparer boundaries.
- Add internal commitlog timing hooks if exact append-vs-fsync split becomes necessary for combined append-and-flush calls.

## AI Review Loop

- Codex latest-head review: not requested.
- Copilot latest-head review: not requested.
- CodeRabbit latest-head review: not requested by this worker; GitHub shows an automatic CodeRabbit success status.
- Review comments/threads resolved or explicitly dismissed: none seen.
- Re-requested after final meaningful push: no.

## Optimization PR Checklist (TreeDB)

### Scope
- [x] Single, clear objective for this PR (not a bundle)
- [x] Explicit include list (files/symbols touched): TreeDB command-WAL stats and cached write wait stats only
- [x] Explicit exclude list (files/symbols NOT touched): Ironbird harness, checkpoint policy, durability semantics, on-disk formats
- [x] No unwanted feature reintroduction (e.g. async slab writer, hard zones, ValueIndex) unless explicitly stated in the PR objective

### Safety / Correctness
- [x] Clear written-vs-durable semantics for any `*Sync` path touched
- [x] No new mmap usage on mutable/truncating files
- [x] All new length fields are capped before allocation (no new length fields)
- [x] CRC/checksum behavior is fail-closed (unchanged)
- [x] Any concurrency change has a defined state machine and invariants

### Tests
- [x] Added deterministic regression tests for the targeted failure mode
- [ ] Tests avoid sleeps where possible (three bounded wait-counter tests use short sleeps plus timeouts)
- [x] Added corruption/edge-case tests when format/parsing changes (not applicable: no format/parsing change)
- [x] Ran locally:
  - [ ] `go test ./... -count=1`
  - [x] `GOWORK=off go test ./TreeDB/...`
  - [x] Targeted packages/benchmarks listed above

### Benchmarks / Measurements
- [ ] Added or updated a benchmark relevant to the change (reused existing benchmark)
- [x] Reported current-run results in PR description; no before/after baseline collected
- [ ] Included “incompressible” results if compression is involved (not compression-related)

### Docs
- [ ] Updated `docs/OPT_SPRINT_NEXT.md` milestone status (not applicable)
- [ ] Documented any new config knobs + defaults (not applicable)
- [x] Called out any format change in PR description (none)

### Rollout / Toggle Plan (if behavior-affecting)
- [x] Safe defaults: zero-valued observability counters
- [x] Clear knobs to disable/revert behavior quickly: revert PR; command-WAL path remains controlled by existing options
- [x] Observability: counters/logs to verify effectiveness

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added more detailed Command WAL and cache statistics, including write checkpoint wait metrics and append/flush/sync breakdowns.
  * Expanded cleanup stats to include scanned bytes and frames during segment cleanup.

* **Bug Fixes**
  * Improved checkpoint waiting behavior for writes so it only waits when needed, reducing unnecessary delays.
  * Exposed additional runtime stats in the public stats output for better visibility into WAL activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
