### PR TITLE
TreeDB: recycle delete leaf-ref cache pages

### DIFF
--- a/TreeDB/zipper/zipper.go
+++ b/TreeDB/zipper/zipper.go
@@ -89,6 +89,12 @@ type leafRefCachePage struct {
 	buf [page.PageSize]byte
 }
 
+// leafRefCachePageChunk amortizes allocation object count for page-sized cache
+// buffers used during one in-flight leaf-ref cache.
+type leafRefCachePageChunk struct {
+	pages [mergeLeafRefCachePagesPerChunk]leafRefCachePage
+}
+
 // outerLeafBuildPagePool recycles page-sized buffers used to build rewritten
 // outer-leaf pages on non-maintenance apply paths.
 var outerLeafBuildPagePool = sync.Pool{
@@ -198,6 +204,8 @@ const (
 	mergeLeafPageBatchMaxCap          = 512
 	mergeLeafRefCachePageInit         = 16
 	mergeLeafRefCachePageKeep         = 4096
+	mergeLeafRefCachePagesPerChunk    = 64
+	mergeLeafRefCacheGlobalPageKeep   = 16 * 1024
 	mergeChildRefBatchInit            = 8
 	mergeChildRefBatchKeep            = 64
 	mergeChildRefBatchMaxCap          = 512
@@ -215,6 +223,15 @@ const (
 	mergeInternalCriticalPressureMinChildren = 32
 	mergeInternalCriticalPressureMinOps      = 32 * 1024
 )
+
+// globalLeafRefCachePages lets apply scratches hand off overflow pages after
+// cache close instead of allocating fresh page objects on the next apply.
+var globalLeafRefCachePages = struct {
+	mu    sync.Mutex
+	pages []*leafRefCachePage
+}{
+	pages: make([]*leafRefCachePage, 0, mergeLeafRefCachePagesPerChunk),
+}
 
 type mergeScratch struct {
 	mu                        sync.Mutex
@@ -317,9 +334,8 @@ func (s *mergeScratch) reset() {
 	}
 	if n := len(s.leafRefCachePages); n > mergeLeafRefCachePageKeep {
 		extra := s.leafRefCachePages[mergeLeafRefCachePageKeep:]
-		for i := range extra {
-			extra[i] = nil
-		}
+		putGlobalLeafRefCachePages(extra)
+		clear(extra)
 		s.leafRefCachePages = s.leafRefCachePages[:mergeLeafRefCachePageKeep]
 	}
 	clear(s.leafRefCacheActivePages)
@@ -606,15 +622,7 @@ func (s *mergeScratch) cloneLeafRefCachePage(src []byte) []byte {
 		return owned
 	}
 	s.mu.Lock()
-	n := len(s.leafRefCachePages)
-	var p *leafRefCachePage
-	if n > 0 {
-		p = s.leafRefCachePages[n-1]
-		s.leafRefCachePages[n-1] = nil
-		s.leafRefCachePages = s.leafRefCachePages[:n-1]
-	} else {
-		p = &leafRefCachePage{}
-	}
+	p := s.acquireLeafRefCachePageLocked()
 	s.leafRefCacheActivePages = append(s.leafRefCacheActivePages, p)
 	s.mu.Unlock()
 	copy(p.buf[:], src)
@@ -629,19 +637,65 @@ func (s *mergeScratch) acquireLeafRefCacheBuildPage() []byte {
 		return make([]byte, page.PageSize)
 	}
 	s.mu.Lock()
-	n := len(s.leafRefCachePages)
-	var p *leafRefCachePage
-	if n > 0 {
-		p = s.leafRefCachePages[n-1]
-		s.leafRefCachePages[n-1] = nil
-		s.leafRefCachePages = s.leafRefCachePages[:n-1]
-	} else {
-		p = &leafRefCachePage{}
-	}
+	p := s.acquireLeafRefCachePageLocked()
 	s.leafRefCacheActivePages = append(s.leafRefCacheActivePages, p)
 	s.mu.Unlock()
 	clear(p.buf[:])
 	return p.buf[:]
+}
+
+func (s *mergeScratch) acquireLeafRefCachePageLocked() *leafRefCachePage {
+	n := len(s.leafRefCachePages)
+	if n == 0 {
+		s.refillLeafRefCachePagesLocked()
+		n = len(s.leafRefCachePages)
+	}
+	p := s.leafRefCachePages[n-1]
+	s.leafRefCachePages[n-1] = nil
+	s.leafRefCachePages = s.leafRefCachePages[:n-1]
+	return p
+}
+
+func (s *mergeScratch) refillLeafRefCachePagesLocked() {
+	s.leafRefCachePages = takeGlobalLeafRefCachePages(s.leafRefCachePages)
+	if len(s.leafRefCachePages) > 0 {
+		return
+	}
+	chunk := new(leafRefCachePageChunk)
+	for i := range chunk.pages {
+		s.leafRefCachePages = append(s.leafRefCachePages, &chunk.pages[i])
+	}
+}
+
+func takeGlobalLeafRefCachePages(dst []*leafRefCachePage) []*leafRefCachePage {
+	globalLeafRefCachePages.mu.Lock()
+	pages := globalLeafRefCachePages.pages
+	if n := len(pages); n > 0 {
+		take := mergeLeafRefCachePagesPerChunk
+		if take > n {
+			take = n
+		}
+		start := n - take
+		dst = append(dst, pages[start:n]...)
+		clear(pages[start:n])
+		globalLeafRefCachePages.pages = pages[:start]
+	}
+	globalLeafRefCachePages.mu.Unlock()
+	return dst
+}
+
+func putGlobalLeafRefCachePages(pages []*leafRefCachePage) {
+	if len(pages) == 0 {
+		return
+	}
+	globalLeafRefCachePages.mu.Lock()
+	if remaining := mergeLeafRefCacheGlobalPageKeep - len(globalLeafRefCachePages.pages); remaining > 0 {
+		if remaining > len(pages) {
+			remaining = len(pages)
+		}
+		globalLeafRefCachePages.pages = append(globalLeafRefCachePages.pages, pages[:remaining]...)
+	}
+	globalLeafRefCachePages.mu.Unlock()
 }
 
 func (s *mergeScratch) releaseLeafRefCachePages() {
@@ -651,11 +705,17 @@ func (s *mergeScratch) releaseLeafRefCachePages() {
 	s.mu.Lock()
 	active := s.leafRefCacheActivePages
 	keep := mergeLeafRefCachePageKeep - len(s.leafRefCachePages)
+	if keep < 0 {
+		keep = 0
+	}
 	if keep > len(active) {
 		keep = len(active)
 	}
 	if keep > 0 {
 		s.leafRefCachePages = append(s.leafRefCachePages, active[:keep]...)
+	}
+	if keep < len(active) {
+		putGlobalLeafRefCachePages(active[keep:])
 	}
 	clear(active)
 	s.leafRefCacheActivePages = active[:0]

--- a/TreeDB/zipper/zipper_test.go
+++ b/TreeDB/zipper/zipper_test.go
@@ -617,6 +617,54 @@ func TestZipperLeafRefCacheAdoptsBuildPagesUntilCacheClose(t *testing.T) {
 	}
 }
 
+func TestMergeScratchLeafRefCacheSpillsOverflowToGlobalPool(t *testing.T) {
+	globalLeafRefCachePages.mu.Lock()
+	savedGlobal := append([]*leafRefCachePage(nil), globalLeafRefCachePages.pages...)
+	clear(globalLeafRefCachePages.pages)
+	globalLeafRefCachePages.pages = globalLeafRefCachePages.pages[:0]
+	globalLeafRefCachePages.mu.Unlock()
+	t.Cleanup(func() {
+		globalLeafRefCachePages.mu.Lock()
+		clear(globalLeafRefCachePages.pages)
+		globalLeafRefCachePages.pages = append(globalLeafRefCachePages.pages[:0], savedGlobal...)
+		globalLeafRefCachePages.mu.Unlock()
+	})
+
+	source := bytes.Repeat([]byte{0x7b}, page.PageSize)
+	firstScratch := newMergeScratch()
+	pageCount := mergeLeafRefCachePageKeep + mergeLeafRefCachePagesPerChunk
+	seen := make(map[*byte]struct{}, pageCount)
+	overflow := make(map[*byte]struct{}, mergeLeafRefCachePagesPerChunk)
+	for i := 0; i < pageCount; i++ {
+		buf := firstScratch.cloneLeafRefCachePage(source)
+		ptr := &buf[0]
+		if _, ok := seen[ptr]; ok {
+			t.Fatalf("active leaf-ref cache page reused before release at index %d", i)
+		}
+		seen[ptr] = struct{}{}
+		if i >= mergeLeafRefCachePageKeep {
+			overflow[ptr] = struct{}{}
+		}
+	}
+	firstScratch.releaseLeafRefCachePages()
+
+	globalLeafRefCachePages.mu.Lock()
+	globalCount := len(globalLeafRefCachePages.pages)
+	globalLeafRefCachePages.mu.Unlock()
+	if globalCount != mergeLeafRefCachePagesPerChunk {
+		t.Fatalf("global leaf-ref page pool len=%d want %d", globalCount, mergeLeafRefCachePagesPerChunk)
+	}
+
+	secondScratch := newMergeScratch()
+	for i := 0; i < mergeLeafRefCachePagesPerChunk; i++ {
+		buf := secondScratch.acquireLeafRefCacheBuildPage()
+		if _, ok := overflow[&buf[0]]; !ok {
+			t.Fatalf("second scratch page %d did not reuse overflow page", i)
+		}
+	}
+	secondScratch.releaseLeafRefCachePages()
+}
+
 func TestZipperCachePersistedLeafPageNoopAvoidsLockWhenCacheInactive(t *testing.T) {
 	z := &Zipper{}
 	z.leafRefCacheMu.Lock()


### PR DESCRIPTION
Closes #3537.

## Summary

- Allocate leaf-ref cache page buffers in 64-page chunks instead of one page object at a time.
- Recycle overflow leaf-ref cache pages through a bounded global pool after the in-flight cache closes.
- Preserve active-cache ownership semantics with a regression test for overflow reuse across apply scratches.

## Benchmark evidence

Discovery baseline was the post-#3580 full durable all-tests run on `origin/main` (`fe331eea3`):

- Run root: `/private/tmp/gomap_alloc_loop_main_post3580_all_20260706_105010`
- Command shape: `./bin/unified-bench -profile durable -dbs treedb -keys 10000000 -valsize 128 -batchsize 8000 -checkpoint-between-tests -treedb-journal-lanes=1 -progress=false -profile-dir ... -path-label native-fastpath -format markdown` with no `-test` flag.
- `batch_delete`: `allocs_batch_delete_treedb.pprof` had 402,397 total sampled allocation objects; `TreeDB/zipper.(*mergeScratch).acquireLeafRefCacheBuildPage` accounted for 244,908 objects (60.86%) and 965.20MB (15.15%).
- `random_delete`: `allocs_random_delete_treedb.pprof` had 279,917 total sampled allocation objects; `TreeDB/zipper.(*mergeScratch).acquireLeafRefCacheBuildPage` accounted for 184,350 objects (65.86%) and 0.70GB (18.32%).

Focused delete-only reruns did not reproduce the full-run zipper allocation hotspot on either main or this branch, so I am using them as the throughput/no-obvious-regression gate rather than claiming they prove the full all-tests delta:

| run | batch_delete ops/sec | random_delete ops/sec | notes |
| --- | ---: | ---: | --- |
| main focused rerun (`fe331eea3`) | 1,368,481 | 907,368 | `/private/tmp/gomap_3537_leafref_main_focused_rerun_20260706_114540` |
| branch focused rerun (`fef91b6f9`) | 1,307,313 | 1,031,406 | `/private/tmp/gomap_3537_leafref_branch_focused_rerun_20260706_114337` |

Additional focused branch profile check:

- `go tool pprof -top -alloc_objects -focus='TreeDB/zipper'` matched no sampled zipper allocations for both branch focused delete profiles.
- Branch focused total allocated bytes were comparable to main focused: `batch_delete` 3.31GB vs main rerun profile 3.33GB-scale prior focused profile; `random_delete` 2.72GB vs main focused 2.75GB-scale prior focused profile.

## Validation

- `GOWORK=off go test ./TreeDB/zipper -run 'TestZipperLeafRefCache|TestMergeScratchLeafRefCache|TestZipperCachePersistedLeafPageNoop' -count=1`
- `GOWORK=off go test ./TreeDB/zipper -count=1`
- `GOWORK=off go test ./TreeDB -run 'TestReopenVerify_WALOn_Checkpoint|TestReopenVerify_WALOn_WriteSync' -count=1`
- `GOWORK=off go test ./TreeDB/db -run 'TestValueLogGC_RemovesUnreferencedSegment' -count=1`
- `GOWORK=off go build -o ./bin/unified-bench ./cmd/unified_bench`
- `GOWORK=off go build -o ./bin/benchprof ./cmd/benchprof`
- `GOWORK=off go test ./TreeDB/... -count=1` had one transient raftcluster failure: `TestHashicorpRaftProviderSnapshotRejoinsLaggingFollowerAndCompactsLogs` returned `raftcluster: commit ambiguous` after leadership loss.
- Rerun passed: `GOWORK=off go test ./TreeDB/internal/raftcluster -run '^TestHashicorpRaftProviderSnapshotRejoinsLaggingFollowerAndCompactsLogs$' -count=1`
- Package rerun passed: `GOWORK=off go test ./TreeDB/internal/raftcluster -count=1`
