### PR TITLE
Prove public command-WAL durable sync boundary

### DIFF
--- a/TreeDB/command_wal_public_test.go
+++ b/TreeDB/command_wal_public_test.go
@@ -427,6 +427,44 @@ func publicStatUint64(t *testing.T, db *DB, key string) uint64 {
 	return statMapUint64(t, db.Stats(), key)
 }
 
+func requirePublicStatDelta(t *testing.T, before, after map[string]string, key string, want uint64) {
+	t.Helper()
+	got := statMapUint64(t, after, key) - statMapUint64(t, before, key)
+	if got != want {
+		t.Fatalf("%s delta=%d, want %d (before=%#v after=%#v)", key, got, want, before, after)
+	}
+}
+
+func requirePublicCommandWALNoCheckpointSince(t *testing.T, db *DB, before map[string]string) {
+	t.Helper()
+	after := db.Stats()
+	for _, key := range []string{
+		"treedb.commit_seq",
+		"treedb.public.checkpoint.calls_total",
+		"treedb.cache.checkpoint.runs",
+	} {
+		if got, want := after[key], before[key]; got != want {
+			t.Fatalf("%s after public write=%q, want unchanged %q (before=%#v after=%#v)", key, got, want, before, after)
+		}
+	}
+}
+
+func commandWALDurabilityProofOptions(dir string) Options {
+	opts := OptionsFor(ProfileCommandWALDurable, dir)
+	opts.CommandWALStatsScan = true
+	opts.DisableSideStores = true
+	opts.BackgroundCheckpointInterval = -1
+	opts.BackgroundCheckpointIdleDuration = -1
+	opts.BackgroundIndexVacuumInterval = -1
+	opts.DisableBackgroundPrune = true
+	opts.FlushThreshold = 1 << 30
+	opts.MaxQueuedMemtables = -1
+	opts.WriterFlushMaxMemtables = 0
+	opts.WriterFlushMaxDuration = 0
+	opts.ValueLog.Generational.Policy = ValueLogGenerationOff
+	return opts
+}
+
 func TestPublicCommandWALRuntimeStatsExposeAppendAndSyncCounters(t *testing.T) {
 	db, err := Open(Options{
 		Dir:                 t.TempDir(),
@@ -495,6 +533,119 @@ func TestPublicCommandWALRuntimeStatsExposeAppendAndSyncCounters(t *testing.T) {
 	} {
 		_ = statMapUint64(t, stats, key)
 	}
+}
+
+func TestPublicCommandWALDurableSyncBoundaryMatrixDoesNotCheckpoint(t *testing.T) {
+	db, err := Open(commandWALDurabilityProofOptions(t.TempDir()))
+	if err != nil {
+		t.Fatalf("Open command WAL durable: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	before := db.Stats()
+	for _, key := range []string{
+		"treedb.command_wal.append.count_total",
+		"treedb.command_wal.append.point.count_total",
+		"treedb.command_wal.append.payload.count_total",
+		"treedb.command_wal.append.entry_scan.count_total",
+		"treedb.command_wal.flush.count_total",
+		"treedb.command_wal.sync.count_total",
+		"treedb.public.batch.write.calls_total",
+		"treedb.public.batch.write_sync.calls_total",
+		"treedb.public.checkpoint.calls_total",
+	} {
+		if got := statMapUint64(t, before, key); got != 0 {
+			t.Fatalf("%s before writes=%d, want 0 (stats=%#v)", key, got, before)
+		}
+	}
+	if got := before["treedb.cache.redo_log.mode"]; got != "external_command_wal" {
+		t.Fatalf("redo_log.mode=%q, want external_command_wal", got)
+	}
+	if got := before["treedb.cache.redo_log.enabled"]; got != "false" {
+		t.Fatalf("redo_log.enabled=%q, want false", got)
+	}
+	if got := before["treedb.cache.command_wal.external_durability"]; got != "true" {
+		t.Fatalf("command_wal.external_durability=%q, want true", got)
+	}
+
+	if err := db.SetSync([]byte("point-sync"), []byte("v1")); err != nil {
+		t.Fatalf("SetSync: %v", err)
+	}
+	afterSetSync := db.Stats()
+	requirePublicStatDelta(t, before, afterSetSync, "treedb.command_wal.append.count_total", 1)
+	requirePublicStatDelta(t, before, afterSetSync, "treedb.command_wal.append.point.count_total", 1)
+	requirePublicStatDelta(t, before, afterSetSync, "treedb.command_wal.sync.count_total", 1)
+	requirePublicCommandWALNoCheckpointSince(t, db, before)
+
+	if err := db.DeleteSync([]byte("point-sync")); err != nil {
+		t.Fatalf("DeleteSync: %v", err)
+	}
+	afterDeleteSync := db.Stats()
+	requirePublicStatDelta(t, before, afterDeleteSync, "treedb.command_wal.append.count_total", 2)
+	requirePublicStatDelta(t, before, afterDeleteSync, "treedb.command_wal.append.point.count_total", 2)
+	requirePublicStatDelta(t, before, afterDeleteSync, "treedb.command_wal.sync.count_total", 2)
+	requirePublicCommandWALNoCheckpointSince(t, db, before)
+
+	writeBatch := db.NewBatch()
+	if err := writeBatch.Set([]byte("batch-write"), []byte("v2")); err != nil {
+		_ = writeBatch.Close()
+		t.Fatalf("batch Write Set: %v", err)
+	}
+	if err := writeBatch.Write(); err != nil {
+		_ = writeBatch.Close()
+		t.Fatalf("batch Write: %v", err)
+	}
+	if err := writeBatch.Close(); err != nil {
+		t.Fatalf("batch Write Close: %v", err)
+	}
+	afterBatchWrite := db.Stats()
+	requirePublicStatDelta(t, before, afterBatchWrite, "treedb.command_wal.append.count_total", 3)
+	requirePublicStatDelta(t, before, afterBatchWrite, "treedb.command_wal.append.payload.count_total", 1)
+	requirePublicStatDelta(t, before, afterBatchWrite, "treedb.command_wal.flush.count_total", 1)
+	requirePublicStatDelta(t, before, afterBatchWrite, "treedb.command_wal.sync.count_total", 2)
+	requirePublicStatDelta(t, before, afterBatchWrite, "treedb.public.batch.write.calls_total", 1)
+	requirePublicCommandWALNoCheckpointSince(t, db, before)
+
+	syncBatch := db.NewBatch()
+	if err := syncBatch.Set([]byte("batch-sync"), []byte("v3")); err != nil {
+		_ = syncBatch.Close()
+		t.Fatalf("batch WriteSync Set: %v", err)
+	}
+	if err := syncBatch.WriteSync(); err != nil {
+		_ = syncBatch.Close()
+		t.Fatalf("batch WriteSync: %v", err)
+	}
+	if err := syncBatch.Close(); err != nil {
+		t.Fatalf("batch WriteSync Close: %v", err)
+	}
+	afterBatchWriteSync := db.Stats()
+	requirePublicStatDelta(t, before, afterBatchWriteSync, "treedb.command_wal.append.count_total", 4)
+	requirePublicStatDelta(t, before, afterBatchWriteSync, "treedb.command_wal.append.payload.count_total", 2)
+	requirePublicStatDelta(t, before, afterBatchWriteSync, "treedb.command_wal.flush.count_total", 1)
+	requirePublicStatDelta(t, before, afterBatchWriteSync, "treedb.command_wal.sync.count_total", 3)
+	requirePublicStatDelta(t, before, afterBatchWriteSync, "treedb.public.batch.write_sync.calls_total", 1)
+	requirePublicCommandWALNoCheckpointSince(t, db, before)
+
+	if err := db.DeleteRange([]byte("batch-"), []byte("batch-\xff")); err != nil {
+		t.Fatalf("DeleteRange: %v", err)
+	}
+	afterRangeDelete := db.Stats()
+	requirePublicStatDelta(t, before, afterRangeDelete, "treedb.command_wal.append.count_total", 5)
+	requirePublicStatDelta(t, before, afterRangeDelete, "treedb.command_wal.append.entry_scan.count_total", 1)
+	requirePublicStatDelta(t, before, afterRangeDelete, "treedb.command_wal.flush.count_total", 2)
+	requirePublicStatDelta(t, before, afterRangeDelete, "treedb.command_wal.sync.count_total", 3)
+	requirePublicCommandWALNoCheckpointSince(t, db, before)
+
+	for _, key := range []string{"point-sync", "batch-write", "batch-sync"} {
+		has, err := db.Has([]byte(key))
+		if err != nil {
+			t.Fatalf("Has(%s): %v", key, err)
+		}
+		if has {
+			t.Fatalf("%s remains visible after delete/delete-range", key)
+		}
+	}
+	assertPublicCommandWALFrames(t, db, 5)
 }
 
 func TestPublicCommandWALBatchIngressStatsDistinguishViews(t *testing.T) {

--- a/TreeDB/recovery_spec_test.go
+++ b/TreeDB/recovery_spec_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -109,6 +110,25 @@ func runCrashRecoveryDurabilityWriter(t *testing.T, dir string, extraEnv ...stri
 	}
 }
 
+func runCommandWALDurableUncheckpointedWriter(t *testing.T, dir string) {
+	t.Helper()
+
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+
+	cmd := exec.Command(exe, "-test.run=^TestHelperTreeDBCommandWALDurableUncheckpointedWriter$", "-test.v")
+	cmd.Env = append(os.Environ(),
+		"TREEDB_CRASH_HELPER=1",
+		"TREEDB_CRASH_DIR="+dir,
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("crash writer helper failed: %v\n%s", err, string(out))
+	}
+}
+
 func TestHelperTreeDBCrashRecoveryWriter(t *testing.T) {
 	if os.Getenv("TREEDB_CRASH_HELPER") != "1" {
 		t.Skip("helper")
@@ -173,6 +193,78 @@ func TestHelperTreeDBCrashRecoveryDurabilityWriter(t *testing.T) {
 	if err := db.SetSync([]byte("k"), val); err != nil {
 		t.Fatalf("SetSync: %v", err)
 	}
+	os.Exit(0)
+}
+
+func TestHelperTreeDBCommandWALDurableUncheckpointedWriter(t *testing.T) {
+	if os.Getenv("TREEDB_CRASH_HELPER") != "1" {
+		t.Skip("helper")
+	}
+
+	dir := os.Getenv("TREEDB_CRASH_DIR")
+	if dir == "" {
+		t.Fatalf("missing TREEDB_CRASH_DIR")
+	}
+
+	opts := treedb.OptionsFor(treedb.ProfileCommandWALDurable, dir)
+	opts.CommandWALStatsScan = true
+	opts.BackgroundCheckpointInterval = -1
+	opts.BackgroundCheckpointIdleDuration = -1
+	opts.BackgroundIndexVacuumInterval = -1
+	opts.DisableBackgroundPrune = true
+	opts.FlushThreshold = 1 << 30
+	opts.MaxQueuedMemtables = -1
+	opts.WriterFlushMaxMemtables = 0
+	opts.WriterFlushMaxDuration = 0
+	opts.ValueLog.Generational.Policy = treedb.ValueLogGenerationOff
+
+	db, err := treedb.Open(opts)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+
+	if err := db.SetSync([]byte("point-sync"), []byte("keep-point")); err != nil {
+		t.Fatalf("SetSync point-sync: %v", err)
+	}
+	if err := db.SetSync([]byte("deleted-sync"), []byte("remove-me")); err != nil {
+		t.Fatalf("SetSync deleted-sync: %v", err)
+	}
+	if err := db.DeleteSync([]byte("deleted-sync")); err != nil {
+		t.Fatalf("DeleteSync deleted-sync: %v", err)
+	}
+
+	b := db.NewBatch()
+	if err := b.Set([]byte("batch-sync"), []byte("keep-batch")); err != nil {
+		_ = b.Close()
+		t.Fatalf("batch Set batch-sync: %v", err)
+	}
+	if err := b.Set([]byte("range-delete"), []byte("remove-me")); err != nil {
+		_ = b.Close()
+		t.Fatalf("batch Set range-delete: %v", err)
+	}
+	if err := b.WriteSync(); err != nil {
+		_ = b.Close()
+		t.Fatalf("batch WriteSync: %v", err)
+	}
+	if err := b.Close(); err != nil {
+		t.Fatalf("batch Close: %v", err)
+	}
+	if err := db.DeleteRange([]byte("range-"), []byte("range-\xff")); err != nil {
+		t.Fatalf("DeleteRange: %v", err)
+	}
+
+	stats := db.Stats()
+	if stats["treedb.cache.redo_log.mode"] != "external_command_wal" ||
+		stats["treedb.cache.redo_log.enabled"] != "false" ||
+		stats["treedb.cache.command_wal.external_durability"] != "true" {
+		t.Fatalf("unexpected command-WAL cached durability stats: %#v", stats)
+	}
+	if stats["treedb.commit_seq"] != "0" {
+		t.Fatalf("commit_seq=%q, want 0 before crash without checkpoint", stats["treedb.commit_seq"])
+	}
+
+	// Simulate a crash by exiting without Close(), so no close-time checkpoint can
+	// publish the pending command-WAL LSNs.
 	os.Exit(0)
 }
 
@@ -401,6 +493,58 @@ func TestCrashRecovery_DeleteRangeWithoutTrailingSync_ReplaysCorrectKeys(t *test
 			}
 
 		})
+	}
+}
+
+func TestCrashRecovery_CommandWALDurableSyncedUncheckpointedFramesReplay(t *testing.T) {
+	dir := t.TempDir()
+	runCommandWALDurableUncheckpointedWriter(t, dir)
+
+	opts := treedb.OptionsFor(treedb.ProfileCommandWALDurable, dir)
+	opts.CommandWALStatsScan = true
+	db, err := treedb.Open(opts)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer db.Close()
+
+	tests := []struct {
+		key     string
+		want    string
+		wantNil bool
+	}{
+		{key: "point-sync", want: "keep-point"},
+		{key: "batch-sync", want: "keep-batch"},
+		{key: "deleted-sync", wantNil: true},
+		{key: "range-delete", wantNil: true},
+	}
+	for _, tt := range tests {
+		got, err := db.Get([]byte(tt.key))
+		if err != nil {
+			t.Fatalf("Get(%s): %v", tt.key, err)
+		}
+		if tt.wantNil {
+			if got != nil {
+				t.Fatalf("Get(%s)=%q, want nil", tt.key, string(got))
+			}
+			continue
+		}
+		if string(got) != tt.want {
+			t.Fatalf("Get(%s)=%q, want %q", tt.key, string(got), tt.want)
+		}
+	}
+
+	stats := db.Stats()
+	applied, err := strconv.ParseUint(stats["treedb.applied_command_lsn"], 10, 64)
+	if err != nil {
+		t.Fatalf("parse applied_command_lsn=%q: %v", stats["treedb.applied_command_lsn"], err)
+	}
+	if applied < 5 {
+		t.Fatalf("applied_command_lsn=%d, want at least 5 after command-WAL replay (stats=%#v)", applied, stats)
+	}
+	if stats["treedb.cache.redo_log.mode"] != "external_command_wal" ||
+		stats["treedb.cache.redo_log.enabled"] != "false" {
+		t.Fatalf("unexpected command-WAL cached durability stats after reopen: %#v", stats)
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes #3617.
Part of #3612.

This PR adds focused proof coverage for the public TreeDB command-WAL durable sync boundary. It does not change production runtime code.

What it proves:

- `ProfileCommandWALDurable` opens the public path in external command-WAL cached mode.
- `SetSync`, `DeleteSync`, and batch `WriteSync` advance command-WAL sync counters.
- non-sync batch writes and `DeleteRange` append command-WAL payloads without forcing sync.
- public sync writes do not call `Checkpoint()` and do not advance `treedb.commit_seq`.
- synced command-WAL frames recover after a crash-style subprocess exit without `Close()` or checkpoint.

## Tests

```sh
GOWORK=off go test ./TreeDB -run 'TestPublicCommandWALDurableSyncBoundaryMatrixDoesNotCheckpoint|TestCrashRecovery_CommandWALDurableSyncedUncheckpointedFramesReplay' -count=1
GOWORK=off go test ./TreeDB -run 'TestPublicCommandWAL.*(SyncBoundary|DurableSynced|RuntimeStats|Durable.*WriteSync|DeleteRange|Recovery)|TestCrashRecovery_CommandWALDurableSyncedUncheckpointedFramesReplay' -count=1
GOWORK=off go test ./TreeDB -run 'TestPublicCommandWAL|TestCrashRecovery|TestRecovery_' -count=1
git diff --check origin/main..HEAD
```

All passed locally on head `715fffc1a`.

## Benchmark / Counter Evidence

Command:

```sh
GOWORK=off go test ./TreeDB -run '^$' -bench 'BenchmarkPublicCommandWALDurableTinyBatchWriteSync|BenchmarkSyncLatencyCached/BatchWriteSync/wal_on_sync_command_wal/32/entry_hint' -benchmem -count=3
```

Representative output from head `715fffc1a`:

| Benchmark | ns/op | throughput | B/op | allocs/op |
| --- | ---: | ---: | ---: | ---: |
| `BenchmarkPublicCommandWALDurableTinyBatchWriteSync` | 12,492,804 | 84.22 batches/s | 83,441 | 22 |
| `BenchmarkPublicCommandWALDurableTinyBatchWriteSync` | 12,110,080 | 89.27 batches/s | 117,256 | 23 |
| `BenchmarkPublicCommandWALDurableTinyBatchWriteSync` | 6,734,928 | 155.2 batches/s | 69,593 | 20 |
| `BenchmarkSyncLatencyCached/.../wal_on_sync_command_wal/32/entry_hint` | 6,500,998 | 4,922 writes/s | 4,557 | 41 |
| `BenchmarkSyncLatencyCached/.../wal_on_sync_command_wal/32/entry_hint` | 6,505,402 | 4,919 writes/s | 4,570 | 41 |
| `BenchmarkSyncLatencyCached/.../wal_on_sync_command_wal/32/entry_hint` | 4,931,329 | 6,489 writes/s | 4,535 | 41 |

The benchmark logs confirm:

- `treedb.write_path.mode=command_wal_cached`
- `treedb.write_path.redo_log=command_wal`
- `treedb.cache.checkpoint.runs=0`
- `treedb.cache.checkpoint.total_ms=0.000`
- `treedb.cache.checkpoint.max_ms=0.000`

## Scope / Risk

This is proof coverage only. The durable sync semantics were introduced by the predecessor PRs; this PR locks the public counter/recovery contract so later adapter work can rely on command-WAL sync without per-write checkpointing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added broader coverage for durable command-write behavior, including sync boundaries, deletes, batch writes, and range deletes.
  * Added crash-recovery coverage to verify data is replayed correctly after an unexpected shutdown.
* **Bug Fixes**
  * Confirmed synced changes remain visible after recovery, while deleted records stay removed.
  * Verified checkpoint-related counters do not change during these durable write scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->