### PR TITLE
Refresh command-WAL docs and downstream validation

### DIFF
--- a/TreeDB/docs/command_wal_docs_test.go
+++ b/TreeDB/docs/command_wal_docs_test.go
@@ -122,6 +122,63 @@ func TestCommandWALLegacySurfaceInventoryCoversRemovalStack(t *testing.T) {
 	}
 }
 
+func TestCommandWALCurrentDocsStateDurabilityContract(t *testing.T) {
+	_, repoRoot := repoRoots(t)
+	for _, tc := range []struct {
+		rel   string
+		wants []string
+	}{
+		{
+			rel: filepath.Join("docs", "contracts", "DURABILITY.md"),
+			wants: []string{
+				"TreeDB provides explicit durability calls (`SetSync`, `DeleteSync`,",
+				"`*Sync` means command-WAL/value-log sync",
+				"it does not require a full backend `Checkpoint()` per write",
+				"`Checkpoint()` and `Close()` are backend publication/drain boundaries",
+				"Current command-WAL directories fail closed on replayable legacy redo",
+			},
+		},
+		{
+			rel: filepath.Join("docs", "TREEDB_RECOVERY.md"),
+			wants: []string{
+				"Public command-WAL profiles persist command frames",
+				"Legacy cached redo-journal replay is a compatibility path",
+				"`AllowLegacyCachedRedoJournalReplay`",
+				"`DeleteRange`, `Batch.Write`, and `Batch.WriteSync`",
+				"Read-only opens do not perform mutating recovery",
+			},
+		},
+		{
+			rel: filepath.Join("docs", "TREEDB_WRITE_PATHS.md"),
+			wants: []string{
+				"`SetSync`, `Delete`, `DeleteSync`, `DeleteRange`",
+				"today that includes callback-based `Update`",
+				"legacy cached redo-journal",
+			},
+		},
+		{
+			rel: filepath.Join("docs", "TREEDB_DOWNSTREAM_VALIDATION.md"),
+			wants: []string{
+				"Pin the gomap commit or tag",
+				"`treedb.cache.redo_log.mode=external_command_wal`",
+				"Treat `WriteSync` / `Batch.WriteSync` as command-WAL sync boundaries",
+				"`DeleteRange`, `Batch.Write`, and `Batch.WriteSync` are",
+				"benchmark scripts fail if the accepted load window is too short to interpret",
+			},
+		},
+	} {
+		text, err := os.ReadFile(filepath.Join(repoRoot, tc.rel))
+		if err != nil {
+			t.Fatalf("read %s: %v", tc.rel, err)
+		}
+		for _, want := range tc.wants {
+			if !strings.Contains(string(text), want) {
+				t.Fatalf("%s missing current command-WAL contract wording %q", tc.rel, want)
+			}
+		}
+	}
+}
+
 func TestCommandWALLegacyTermsInCurrentDocsNeedContext(t *testing.T) {
 	treeRoot, repoRoot := repoRoots(t)
 	paths := []string{

--- a/cmd/benchprof/README.md
+++ b/cmd/benchprof/README.md
@@ -90,6 +90,11 @@ splits, and per-workload counters) into a "Collection Workload Metadata" table.
   `treedb.cache.vlog_outer_leaf_codec.*`, and `treedb.cache.vlog_block.*`
   counters so actual auto codec selection, outer-leaf codec distribution, and
   frame-K distribution remain available in benchprof output.
+- For command-WAL adapter evidence, keep `treedb.command_wal.*`,
+  `treedb.applied_command_lsn`, and `treedb.cache.checkpoint.*` counters
+  together. The first group proves accepted/covered command frames; the
+  checkpoint group measures explicit backend publication work and should not be
+  conflated with `WriteSync`/`Batch.WriteSync` command-WAL sync cost.
 - `benchprof_results.json` also preserves collection-storage suite metadata
   under `runs[].collection_workloads` when `unified-bench -suite
   collection_storage` is used. `benchprof` keeps those stable mode/workload names

--- a/cmd/unified_bench/README.md
+++ b/cmd/unified_bench/README.md
@@ -80,6 +80,11 @@ GOWORK=off GOMEMLIMIT=4GiB GOMAXPROCS=2 go test -json -p 1 . \
     typed frames were accepted and covered. Use
     `-treedb-command-wal-stats-scan` only when segment inventory counters such
     as `treedb.command_wal.typed_segments` are required.
+  - Downstream adapter evidence should record the resolved TreeDB profile and
+    include command-WAL counters plus checkpoint counters. In particular,
+    distinguish `*Sync` command-WAL sync cost from explicit
+    `Checkpoint()`/`Close()` publication cost; see
+    `docs/TREEDB_DOWNSTREAM_VALIDATION.md`.
 - `-test` (`all` or CSV): see list above
 - `-keys` number of keys (default 100000)
 - `-keycounts` comma-separated key counts to sweep over (overrides `-keys`)

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,8 +17,9 @@ TreeDB is a persistent B+Tree with a high-throughput cached write-back layer.
 - **[Storage Format](TREEDB_STORAGE_FORMAT.md)**: On-disk layout, `ValuePtr`, and value-log lifecycle (GC/rewrite).
 - **[Write Paths](TREEDB_WRITE_PATHS.md)**: command-WAL write semantics and legacy compatibility notes.
 - **[Cached vs Backend](TREEDB_CACHED_VS_BACKEND.md)**: Legacy note (backend-only removed).
-- **[Recovery](TREEDB_RECOVERY.md)**: Crash consistency and journal replay details.
-- **[Profiles](TREEDB_PROFILES.md)**: High-level command-WAL, legacy-WAL, no-WAL, and benchmark option presets.
+- **[Recovery](TREEDB_RECOVERY.md)**: Crash consistency, command-WAL replay, and legacy compatibility boundaries.
+- **[Profiles](TREEDB_PROFILES.md)**: Public command-WAL profiles plus the explicit benchmark-only ceiling.
+- **[Downstream Validation](TREEDB_DOWNSTREAM_VALIDATION.md)**: Adapter benchmark checklist for command-WAL counters, checkpoint separation, and load-window evidence.
 - **[Tuning](TREEDB_TUNING.md)**: Configuration knobs for performance.
 - **[Typed-Storage Guides](../TreeDB/docs/guides/README.md)**: Collection layout quickstarts, typed-storage benchmark/profile guide, and vector typed-column guidance.
 - **[Document Service API](TREEDB_DOCUMENT_SERVICE_API.md)**: Pre-alpha Haystack-style HTTP/JSON contract for documents, metadata filters, and exact dense-vector search.

--- a/docs/TREEDB_DOWNSTREAM_VALIDATION.md
+++ b/docs/TREEDB_DOWNSTREAM_VALIDATION.md
@@ -1,0 +1,109 @@
+# TreeDB Downstream Validation Checklist
+
+Use this checklist before opening or updating downstream adapter PRs in
+`cosmos-db`, Ironbird, Celestia, Cosmos SDK, or similar forks.
+
+## Required Inputs
+
+- Pin the gomap commit or tag in the downstream module and record it in the
+  report. Do not rely on a floating branch name.
+- State the TreeDB public profile used by the adapter:
+  `command_wal_durable`, `command_wal_relaxed`, or benchmark-only `bench`.
+- State any adapter overrides after applying the profile, including value-log
+  pointer threshold, compression policy, background maintenance, flush
+  threshold, cache size, and memory limits.
+- Confirm the adapter reaches the current public command-WAL path. Expected
+  counters include:
+  - `treedb.command_wal.enabled=true`
+  - `treedb.cache.redo_log.mode=external_command_wal`
+  - `treedb.cache.redo_log.enabled=false`
+  - `treedb.cache.command_wal.external_durability=true` for durable public
+    sync coverage
+  - `treedb.command_wal.live_accepted_*`
+  - `treedb.command_wal.live_covered_*`
+  - `treedb.applied_command_lsn`
+
+## Required Semantics
+
+- Treat `WriteSync` / `Batch.WriteSync` as command-WAL sync boundaries. They
+  should sync command-WAL/value-log durability input, not force a backend
+  `Checkpoint()` per write.
+- Treat `Checkpoint()` as backend publication/settling work. It is useful for
+  settled disk-footprint measurements and explicit recovery coverage, but it is
+  not the normal per-transaction durability barrier.
+- Treat `Close()` as a final drain/cleanup boundary. A benchmark that times
+  close should report that separately from the steady-state load window.
+- For public raw key/value command-WAL coverage, `Set`, `SetSync`, `Delete`,
+  `DeleteSync`, `DeleteRange`, `Batch.Write`, and `Batch.WriteSync` are
+  supported. Callback-based `Update` / `UpdateSync` still fail closed under
+  command WAL.
+- Legacy cached redo-journal replay is compatibility/forensic behavior only.
+  Current command-WAL directories should fail closed on replayable legacy redo
+  unless explicit legacy replay is requested.
+
+## Required Report Counters
+
+Include these counter groups in every TreeDB-vs-LevelDB benchmark report:
+
+- Command-WAL frame coverage:
+  - `treedb.command_wal.enabled`
+  - `treedb.command_wal.required_feature`
+  - `treedb.command_wal.live_accepted_frames`
+  - `treedb.command_wal.live_accepted_max_lsn`
+  - `treedb.command_wal.live_covered_frames`
+  - `treedb.command_wal.live_covered_max_lsn`
+  - `treedb.applied_command_lsn`
+- Checkpoint/backend publication:
+  - `treedb.commit_seq`
+  - `treedb.public.checkpoint.calls_total`
+  - `treedb.cache.checkpoint.runs`
+  - `treedb.cache.checkpoint.total_ms`
+  - `treedb.cache.checkpoint.max_ms`
+  - `treedb.cache.checkpoint.stage.*`
+- Load-window resource counters:
+  - wall time
+  - effective ops/s and runtime TPS, when both are available
+  - RSS/high-water memory
+  - DB directory bytes
+  - command-WAL bytes before checkpoint when reported
+  - durable storage bytes with command-WAL bytes excluded when the report
+    claims settled storage footprint
+
+## Minimum Benchmark Rows
+
+Do not claim TreeDB-vs-LevelDB behavior from one short row.
+
+At minimum include:
+
+- A low-fanout or plain-send row that represents fixed per-operation overhead.
+- A moderate/high-fanout row that puts real pressure on storage write/read
+  amplification.
+- A settled-state row where explicit checkpoint/close/reopen work is separated
+  from the measured load window.
+- A long enough load window that startup, genesis, seeding, final checkpoint,
+  and close do not dominate. For Ironbird-style TPS reports this should normally
+  be minutes, not a one-second burst.
+- Matching LevelDB and TreeDB rows with the same validator/node count, wallet
+  count, transaction shape, value size, batching, and duration gates.
+
+## Minimum Test Evidence
+
+Before opening an upstream adapter PR, run the downstream test or benchmark
+suite that proves:
+
+- the adapter chooses the expected TreeDB profile;
+- `WriteSync` / `Batch.WriteSync` survive reopen without requiring a checkpoint;
+- `DeleteRange` either routes to the supported TreeDB command-WAL raw-KV path
+  or is intentionally not exposed by the adapter;
+- report output includes command-WAL and checkpoint counter groups; and
+- benchmark scripts fail if the accepted load window is too short to interpret.
+
+## Non-Claims
+
+- A benchmark-only `bench` profile result is an unsafe ceiling, not production
+  durability evidence.
+- Lower checkpoint time does not by itself prove better transaction throughput.
+- Higher TPS without command-WAL counters does not prove the adapter actually
+  exercised TreeDB command-WAL.
+- Historical `fast`, `durable`, or `wal_on_fast` unified-bench presets are
+  cross-DB benchmark-runner labels, not public TreeDB server profile names.

--- a/docs/TREEDB_PROFILES.md
+++ b/docs/TREEDB_PROFILES.md
@@ -199,6 +199,15 @@ pack/GC, index vacuum, and zero-byte value-log cleanup. Do not manually chain
 `vlog-gc`, `vlog-rewrite`, `leafgen-pack`, `leafgen-gc`, and index vacuum unless
 you are debugging TreeDB internals.
 
+## Downstream Validation
+
+Downstream adapters should not claim TreeDB-vs-LevelDB evidence from a partial
+profile switch alone. Before publishing adapter benchmark evidence, follow the
+checklist in `docs/TREEDB_DOWNSTREAM_VALIDATION.md`: pin the gomap commit/tag,
+state the selected public profile, preserve command-WAL and checkpoint counters,
+and include enough load-window rows to separate command-WAL sync cost from
+checkpoint/close cost.
+
 ## Important Notes
 
 ### Profiles do not prevent overrides

--- a/docs/TREEDB_RECOVERY.md
+++ b/docs/TREEDB_RECOVERY.md
@@ -1,4 +1,4 @@
-# TreeDB Crash Recovery (Cached + Backend)
+# TreeDB Crash Recovery (Command-WAL + Backend)
 
 This is a supporting crash-recovery explainer.
 
@@ -9,14 +9,18 @@ For the canonical TreeDB recovery spec, see:
 ## TL;DR
 
 - TreeDB takes an **exclusive directory lock** on `Open` (one process at a time).
-- Cached mode persists redo records to `Dir/maindb/wal/`.
+- Public command-WAL profiles persist command frames to `Dir/maindb/wal/`.
 - Cached mode persists value-log records to `Dir/maindb/value_vlog/` and
   optional split leaf-log records to
   `Dir/maindb/leaf_vlog/`, then flushes them into the backend in the background.
 - On open, TreeDB always performs a single coherent recovery path:
   1) backend recovery (meta validation + torn-tail handling)
-  2) cached journal discovery + replay into the backend (synced commits)
-  3) journal cleanup (segments removed after successful replay)
+  2) command-WAL discovery + replay into the backend for command-WAL directories
+  3) command-WAL cleanup only after replay/coverage proves the segment is safe
+     to remove
+- Legacy cached redo-journal replay is a compatibility path. Current public
+  command-WAL directories reject old raw redo records by default instead of
+  silently replaying them.
 
 This makes “last writer was cached vs backend” unambiguous: the next opener (either mode) recovers fully.
 
@@ -25,10 +29,13 @@ This makes “last writer was cached vs backend” unambiguous: the next opener 
 Depending on timing, after an unclean shutdown the DB directory may contain:
 
 - A consistent backend state (index pages), possibly missing the most recent cached writes that hadn’t flushed yet.
-- One or more journal segments in `Dir/maindb/wal/`.
+- One or more command-WAL segments in `Dir/maindb/wal/`.
 - Referenced value-log segments in `Dir/maindb/value_vlog/` representing cached
   writes that are not yet reflected in the backend.
-- A torn/partial final journal record (e.g. crash mid-write).
+- A torn/partial final command-WAL frame (e.g. crash mid-write).
+- Legacy cached redo segments from old compatibility fixtures. Current public
+  command-WAL opens fail closed on replayable legacy redo unless the caller
+  explicitly opts into legacy replay for forensic recovery.
 
 ## Recovery Pipeline
 
@@ -39,28 +46,55 @@ On open, the backend engine:
 - validates redundant meta pages (so it can pick the newest consistent state),
 - and truncates torn tail data where necessary (avoid partial-record corruption).
 
-### 2) Cached journal discovery + replay (always)
+### 2) Command-WAL discovery + replay
 
-Regardless of the mode you open in, TreeDB scans `Dir/maindb/wal/` for journal segments (sorted by sequence).
-Each segment is replayed into the backend using `Batch.WriteSync`, so replay is durable. Large values
-already stored in the value log are referenced by the replayed records.
+For current command-WAL directories, TreeDB scans `Dir/maindb/wal/` for typed
+command-WAL frames. Complete frames above the durable applied command LSN are
+replayed through the normal command executor and then covered by the backend
+state. Truncated/corrupt terminal tails are treated as terminal tails only when
+they are the active final segment. Non-terminal corruption fails closed.
 
-Truncated/corrupt tails are treated as “stop replay for this segment” (safe best-effort for the final partial record).
+Point/batch/range raw key/value commands replay as `RawKVBatch` frames. That is
+the same public surface used by `Set`, `SetSync`, `Delete`, `DeleteSync`,
+`DeleteRange`, `Batch.Write`, and `Batch.WriteSync`.
 
-### 3) Journal cleanup
+### 3) Legacy cached redo-journal compatibility
 
-After a journal segment is successfully replayed, it is removed.
+The old cached redo journal used raw `commitlog.Record` batches in the same
+segment directory. That path is no longer the normal public recovery contract.
+Replayable legacy redo is quarantined by default; compatibility tests and
+forensic recovery code must opt in explicitly with
+`AllowLegacyCachedRedoJournalReplay`.
 
-Additionally, cached mode’s background flusher removes journal segments after it flushes the corresponding memtable.
+When explicit legacy replay is enabled, TreeDB scans `Dir/maindb/wal/` for
+legacy journal segments sorted by sequence. Each segment is replayed into the
+backend using `Batch.WriteSync`, so replay is durable. Large values already
+stored in the value log are referenced by the replayed records. Truncated or
+corrupt tails are treated as “stop replay for this segment” only for the final
+partial record.
+
+### 4) Command-WAL / journal cleanup
+
+After a command-WAL segment is replayed and covered by backend/applied-LSN
+state, it may be removed. Legacy compatibility journal segments are removed
+only after explicit replay succeeds.
+
+Additionally, cached mode’s background flusher/checkpoint path removes covered
+segments after it flushes the corresponding memtable and publishes the matching
+coverage boundary.
 
 ## Safety Notes
 
 - Two processes must not open the same directory concurrently. The lock enforces this.
-- Benchmark/compatibility WAL-off mode (journal disabled) still uses the value
-  log; there is no backend-only mode.
+- Benchmark-only no-WAL mode still uses the persistent value log, but recent
+  writes are not recoverable through command-WAL until a checkpoint/close
+  publishes them.
+- Read-only opens do not perform mutating recovery. If committed command-WAL
+  frames require replay, read-only open fails with recovery-required behavior
+  instead of serving silent stale state.
 
 ## Where To Look in Code
 
-- Journal segment discovery/replay: `TreeDB/db/wal_recovery.go`
-- Cached journal writer/rotation/flush: `TreeDB/caching/db.go`
+- Command-WAL / legacy segment discovery and replay: `TreeDB/db/wal_recovery.go`
+- Cached command-WAL append/rotation/flush: `TreeDB/caching/db.go`
 - Directory lock: `TreeDB/internal/lockfile/*`

--- a/docs/TREEDB_STRESS_TEST_PLAN.md
+++ b/docs/TREEDB_STRESS_TEST_PLAN.md
@@ -319,35 +319,41 @@ Additional criteria:
 - Error injection tests validate error propagation and no silent stalls.
 
 ## Open Questions
-- Should stress tests run against both WAL on/off variants (`DurabilityDurable` vs `DurabilityWALOffRelaxed`)?
+- Should stress tests run against both command-WAL public profiles
+  (`command_wal_durable` vs `command_wal_relaxed`) plus a smaller
+  benchmark-only no-WAL ceiling subset?
 - Should we gate "heavy" tests on an env var or a build tag?
-- Which WAL modes must be covered in each stress test?
+- Which command-WAL profiles must be covered in each stress test?
 
 ## Appendix: Config Matrix (Recommended)
 For each stress suite, consider these variants:
-- WAL: on vs off (`Options.Durability`).
+- Public command-WAL profile: durable vs relaxed.
+- Benchmark-only no-WAL ceiling: opt-in unsafe subset only.
 - Background tasks: enabled vs disabled (`TREEDB_BENCH_DISABLE_BG=1` parity).
 
 Example matrix for `TestConcurrentMixedOpsProgress`:
-- WAL on + BG on
-- WAL on + BG off
-- WAL off + BG off (unsafe mode)
+- command-WAL durable + BG on
+- command-WAL durable + BG off
+- command-WAL relaxed + BG off
+- benchmark-only no-WAL + BG off (unsafe ceiling)
 
 Tier selection rule (recommended):
 - `pr`: minimal critical path
-  - WAL on + BG on
-  - cached + journal + value log + BG off
+  - command-WAL durable + BG on
+  - command-WAL durable + value log + BG off
 - `daily`: expanded coverage
-  - cached + journal + value log + BG on
-  - cached + journal + value log + BG off
-  - cached + no journal + no vlog + BG off
-  - backend + journal off (backend mode)
+  - command-WAL durable + value log + BG on
+  - command-WAL durable + value log + BG off
+  - command-WAL relaxed + value log + BG off
+  - benchmark-only no-WAL + value log + BG off
 - `nightly`: full matrix
-  - cached/backend × journal on/off × value log on/off × BG on/off
-  - Skip invalid combos (value log on with journal off).
+  - command-WAL durable/relaxed plus benchmark-only no-WAL ceiling × value log
+    pointer policy × BG on/off
+  - Skip invalid legacy compatibility combinations unless a test explicitly opts
+    into forensic legacy replay.
 
 Implementation sketch:
-- Define `type testVariant struct { mode, wal, vlog, bg string }`.
+- Define `type testVariant struct { profile, valueLogPolicy, bg string }`.
 - Build `variants := variantsForTier(os.Getenv("TREEDB_TEST_TIER"))`.
 - Each stress test loops over `variants`, runs subtests, and applies per-tier timeouts.
 

--- a/docs/TREEDB_WRITE_PATHS.md
+++ b/docs/TREEDB_WRITE_PATHS.md
@@ -46,12 +46,12 @@ low-level tests, but current server, collection, Mongo gateway, and YCSB
 guidance should use `command_wal_durable`, `command_wal_relaxed`, or
 benchmark-only `bench`.
 
-Raw TreeDB command-WAL support currently covers point and batch key/value
-writes: `Set`, `SetSync`, `Delete`, `DeleteSync`, `Batch.Write`, and
-`Batch.WriteSync` are represented as typed `RawKVBatch` command frames. Raw
-public operations that cannot be replayed as typed commands yet fail closed
-under command WAL; today that includes callback-based `Update`, `UpdateSync`,
-and range `DeleteRange`.
+Raw TreeDB command-WAL support currently covers point, batch, and range
+key/value writes: `Set`, `SetSync`, `Delete`, `DeleteSync`, `DeleteRange`,
+`Batch.Write`, and `Batch.WriteSync` are represented as typed `RawKVBatch`
+command frames. Raw public operations that cannot be replayed as typed commands
+yet fail closed under command WAL; today that includes callback-based `Update`
+and `UpdateSync`.
 
 ## Legacy Compatibility Migration (old -> new)
 
@@ -85,7 +85,9 @@ TreeDB `Options.Dir` is a *root* directory. `treedb.Open` manages:
 
 - `Dir/maindb/`: main DB (index + journal + value log)
   - `Dir/maindb/index.db`: B+Tree pages + metadata.
-  - `Dir/maindb/wal/`: commit journal segments and future collection WAL segments.
+  - `Dir/maindb/wal/`: current command-WAL segments; legacy cached redo-journal
+    segments may exist only in compatibility/recovery fixtures and fail closed
+    by default unless explicitly opted in.
   - `Dir/maindb/value_vlog/`: value-log segments for large values.
   - `Dir/maindb/leaf_vlog/`: optional split leaf-log segments.
   - `Dir/maindb/LOCK`: cross-process exclusive-open lock.
@@ -108,6 +110,7 @@ TREEDB_WRITE_PATH_LOG=1
 ## Related docs
 
 - `docs/TREEDB_PROFILES.md`
+- `docs/TREEDB_DOWNSTREAM_VALIDATION.md`
 - `docs/TREEDB_VALUELOG_AUTOTUNE.md`
 - `docs/TREEDB_RECOVERY.md`
 - `docs/contracts/DURABILITY.md`

--- a/docs/contracts/DURABILITY.md
+++ b/docs/contracts/DURABILITY.md
@@ -2,7 +2,12 @@
 
 ## TL;DR
 
-- TreeDB provides explicit durability calls (`SetSync`, `Batch.WriteSync`) for current command-WAL profiles and legacy compatibility WAL-on/off modes.
+- TreeDB provides explicit durability calls (`SetSync`, `DeleteSync`,
+  `Batch.WriteSync`) for current command-WAL profiles.
+- In the durable command-WAL profile, `*Sync` means command-WAL/value-log sync;
+  it does not require a full backend `Checkpoint()` per write.
+- `Checkpoint()` and `Close()` are backend publication/drain boundaries, not the
+  normal per-transaction durability barrier for command-WAL writes.
 - HashDB provides explicit durability calls (`PutSync`, `DeleteSync`) backed by the slab value log and crash recovery; non-sync writes may be lost on power loss.
 
 ## Who Is This For?
@@ -13,38 +18,55 @@
 ## TreeDB
 
 TreeDB exposes a single cached-mode engine with selectable durability semantics
-via `Options.Durability`.
+via public profiles and `Options.Durability`. Public server and adapter code
+should use `command_wal_durable` or `command_wal_relaxed`; `bench` is an
+explicit no-WAL benchmark ceiling.
 
-### Durable (default) (`Durability = DurabilityDurable`)
+### Command-WAL durable (`ProfileCommandWALDurable`, `Durability = DurabilityDurable`)
 
-Cached mode writes to the journal (and the value log for large values), then
-eventually flushes to the backend.
+Cached mode writes command frames to the command WAL and writes large values to
+the persistent value log, then eventually flushes to the backend.
 
-- `Set`: appends to the journal (and value log if needed) but does not `fsync`; not guaranteed durable on power loss.
-- `Batch.Write`: appends to the journal (and value log if needed) but does not `fsync`; not guaranteed durable on power loss.
-- `SetSync`: appends to the journal and `fsync`s it; durable.
-- `Batch.WriteSync`: appends the entire batch to the journal as a single checksummed segment and `fsync`s it; **atomic and durable**. On recovery, either the entire batch is applied or none of it is.
+- `Set`, `Delete`, `DeleteRange`, `Batch.Write`: append recoverable
+  command-WAL input, but do not establish a power-loss fsync boundary.
+- `SetSync`, `DeleteSync`: append the point command-WAL frame and sync the
+  command-WAL/value-log boundary; durable.
+- `Batch.WriteSync`: appends the entire batch as a typed `RawKVBatch` command
+  frame and syncs the command-WAL/value-log boundary; **atomic and durable**.
+  On recovery, either the entire batch is applied or none of it is.
+- None of these `*Sync` calls need a backend `Checkpoint()` or `treedb.commit_seq`
+  advance per write. The backend root is published later by flush/checkpoint.
 
 Crash recovery:
-- On open, any journal segments in `Dir/maindb/wal/` are replayed into the backend with synced commits, then removed.
+- On open, command-WAL segments in `Dir/maindb/wal/` are replayed through the
+  normal command executor, covered by the backend/applied-LSN state, then
+  cleaned only after coverage is proven.
 
-### Legacy compatibility WAL on, relaxed (`Durability = DurabilityWALOnRelaxed`)
+### Command-WAL relaxed (`ProfileCommandWALRelaxed`, `Durability = DurabilityWALOnRelaxed`)
 
-WAL stays enabled, but `*Sync` operations do not `fsync`. This is
-crash-consistent (process crash) but not guaranteed durable on power loss.
+Command-WAL frames remain the local recovery source, but `*Sync` operations do
+not `fsync`. This is crash-consistent for process-failure style recovery, but
+not guaranteed durable on power loss.
 
 - `Set` / `Batch.Write`: not guaranteed durable on power loss.
 - `SetSync` / `Batch.WriteSync`: crash-consistent only (no `fsync`).
 
-### Legacy compatibility WAL off (`Durability = DurabilityWALOffRelaxed`)
+### Benchmark-only no WAL (`ProfileBench`, `Durability = DurabilityWALOffRelaxed`)
 
-Benchmark/compatibility WAL-off mode disables the journal/redo log while keeping
-the value log enabled. This improves write throughput but sacrifices durability
-for the most recent writes since the last checkpoint.
+Benchmark-only no-WAL mode disables command-WAL/redo recovery while keeping the
+persistent value log enabled. This improves write throughput but sacrifices
+durability for the most recent writes since the last checkpoint/close boundary.
 
 - `Set` / `Batch.Write`: not guaranteed durable (no redo log).
 - `SetSync` / `Batch.WriteSync`: crash-consistent only (no redo log + no `fsync`).
 - Use `Checkpoint()` to establish a durable boundary.
+
+### Legacy compatibility replay
+
+Old cached redo-journal segments are not the current public durability path.
+Current command-WAL directories fail closed on replayable legacy redo by
+default. Compatibility tests or forensic recovery flows must opt in explicitly
+with `AllowLegacyCachedRedoJournalReplay`.
 
 ### Operational notes
 


### PR DESCRIPTION
## Summary

Closes #3618.
Part of #3612.

This is the final closeout node for the command-WAL cleanup graph after #3623 landed. It updates the current TreeDB docs and benchmark/reporting guidance so downstream adapter work has a concrete validation contract for command-WAL semantics.

Changes:

- reframes recovery docs around current command-WAL replay, legacy cached redo quarantine, and read-only recovery-required behavior;
- updates durability docs to state that `*Sync` is a command-WAL/value-log sync boundary, not a per-write backend `Checkpoint()` requirement;
- updates write-path docs now that raw command-WAL coverage includes `DeleteRange`;
- adds `docs/TREEDB_DOWNSTREAM_VALIDATION.md` with required downstream profile, counter, load-window, and report evidence;
- updates unified-bench/benchprof docs to keep command-WAL counters and checkpoint/backend-publication counters together;
- adds a docs guardrail test for the current command-WAL durability contract wording.

## Scope Boundaries

This PR is documentation and docs-test coverage only. It does not change runtime behavior, public APIs, on-disk formats, or benchmark code paths.

## Validation

Final-base local validation after rebasing onto #3623 merge commit `b51b7360b9bad83f651ea68e3ba1930b3249cc7d`:

```sh
GOWORK=off go test ./TreeDB/docs ./cmd/benchprof ./cmd/unified_bench ./cmd/internal/treedbstats -count=1
```

Result:

```text
ok   	github.com/snissn/gomap/TreeDB/docs	1.091s
?   	github.com/snissn/gomap/cmd/benchprof	[no test files]
ok   	github.com/snissn/gomap/cmd/unified_bench	17.810s
ok   	github.com/snissn/gomap/cmd/internal/treedbstats	0.001s
```

Whitespace check:

```sh
git diff --check origin/main..HEAD
```

Result: passed.

Terminology scan:

```sh
rg -n 'WAL off|WAL-on|wal_on_fast|legacy_wal|no_wal_fast|DisableWAL|DurabilityWAL|legacy-WAL|backend mode|journal off' \
  docs/README.md docs/TREEDB_*.md docs/contracts/DURABILITY.md \
  cmd/unified_bench/README.md cmd/benchprof/README.md \
  TreeDB/docs/command_wal_docs_test.go
```

Remaining hits are either archived RFC evidence, explicit compatibility/benchmark-only contexts, or the docs guardrail test itself.

## Review Notes

The intended current contract is:

- downstream adapters should use public command-WAL profiles, not raw legacy toggles;
- `WriteSync` / `Batch.WriteSync` should sync command-WAL/value-log durability input;
- explicit `Checkpoint()` and `Close()` are backend publication/drain boundaries and must be reported separately from steady-state load-window throughput;
- benchmark reports must include command-WAL counters and checkpoint counters so Ironbird/Celestia-style adapter evidence can prove it exercised the intended path.
