### PR TITLE
[PL-02] Move leaf-generation GC scan outside writeMu

### DIFF
--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -143,6 +143,7 @@ type DB struct {
 
 	mu                              sync.RWMutex
 	writeMu                         sync.RWMutex
+	teardownMu                      sync.RWMutex // Pins Close-sensitive resources outside writeMu.
 	commitMu                        sync.Mutex
 	publishPrepareMu                sync.RWMutex
 	pendingValueLogAppendMu         sync.Mutex
@@ -2193,6 +2194,10 @@ func (db *DB) Close() error {
 	}
 	db.clearFlushApplyReadOnlyPrepareBuffers()
 	db.writeMu.Unlock()
+	// Operations using teardownMu may briefly take writeMu while preparing or
+	// revalidating work. Never wait for them while holding writeMu.
+	db.teardownMu.Lock()
+	defer db.teardownMu.Unlock()
 	db.stopCommitCombiner()
 	db.pruner.Stop()
 	if db.valueLogRefTracker != nil {

--- a/TreeDB/db/errors.go
+++ b/TreeDB/db/errors.go
@@ -17,6 +17,9 @@ var (
 	// ErrConcurrentModification indicates a publish or maintenance operation
 	// observed that a root changed after its validation point.
 	ErrConcurrentModification = errors.New("treedb: concurrent modification")
+	// ErrLeafGenerationGCStaleScan indicates both bounded dry-run attempts were
+	// invalidated by concurrent publishes before their results could be used.
+	ErrLeafGenerationGCStaleScan = errors.New("treedb: leaf generation gc scan invalidated")
 	// ErrConditionalTxnClosed indicates a conditional transaction was used after
 	// Commit, CommitSync, or Close.
 	ErrConditionalTxnClosed = errors.New("treedb: conditional transaction is closed")

--- a/TreeDB/db/leaf_generation_gc.go
+++ b/TreeDB/db/leaf_generation_gc.go
@@ -58,30 +58,9 @@ func (db *DB) leafGenerationGC(ctx context.Context, opts LeafGenerationGCOptions
 		db.maintenanceMu.Lock()
 		defer db.maintenanceMu.Unlock()
 	}
-	db.writeMu.Lock()
-	defer db.writeMu.Unlock()
 
-	if db.leafGenerationManifest == nil || db.valueLogManager == nil {
-		return stats, nil
-	}
-	if err := db.valueLogManager.Refresh(); err != nil {
-		return stats, err
-	}
-	commitSeq := uint64(1)
-	if state := db.State(); state != nil && state.CommitSeq != 0 {
-		commitSeq = state.CommitSeq
-	}
-	if _, err := db.reconcileLeafGenerationManifestWithDirLocked(commitSeq); err != nil {
-		return stats, err
-	}
-
-	manifest := db.leafGenerationManifest.clone()
-	if manifest == nil {
-		return stats, nil
-	}
-	filePaths := db.leafGenerationFilePaths(manifest)
-	currentLeafLogRawFileIDs, err := db.currentLeafPageLogRawFileIDSet()
-	if err != nil {
+	prepared, err := db.prepareLeafGenerationGCScan()
+	if err != nil || !prepared {
 		return stats, err
 	}
 
@@ -97,19 +76,181 @@ func (db *DB) leafGenerationGC(ctx context.Context, opts LeafGenerationGCOptions
 		return stats, nil
 	}
 
+	basis, ok := db.captureLeafGenerationGCScanBasis(snap)
+	if !ok {
+		_ = snap.Close()
+		return stats, nil
+	}
+
 	liveGenerations, err := collectLiveLeafGenerationIDs(ctx, snap, opts.ProtectedRootIDs, opts.ProtectedSystemRootIDs)
 	if err != nil {
 		_ = snap.Close()
 		return stats, err
 	}
-
-	currentCommitSeq := snap.state.CommitSeq
 	if err := snap.Close(); err != nil {
 		return stats, err
 	}
 	snap = nil
-	intermediateChanged := false
-	zombieFileIDs := make(map[uint32]struct{})
+
+	if opts.DryRun {
+		return db.leafGenerationGCDryRunFromScan(basis, liveGenerations)
+	}
+	return db.leafGenerationGCApplyScan(basis, liveGenerations)
+}
+
+type leafGenerationGCScanBasis struct {
+	commitSeq                  uint64
+	leafGenerationStateVersion uint64
+	manifest                   *leafGenerationManifest
+}
+
+type leafGenerationGCDecision struct {
+	stats               LeafGenerationGCStats
+	intermediateChanged bool
+	zombieFileIDs       map[uint32]struct{}
+}
+
+func (db *DB) prepareLeafGenerationGCScan() (bool, error) {
+	db.writeMu.RLock()
+	if db.leafGenerationManifest == nil || db.valueLogManager == nil {
+		db.writeMu.RUnlock()
+		return false, nil
+	}
+	valueLogManager := db.valueLogManager
+	db.writeMu.RUnlock()
+
+	if err := valueLogManager.Refresh(); err != nil {
+		return false, err
+	}
+
+	db.writeMu.Lock()
+	defer db.writeMu.Unlock()
+
+	if db.leafGenerationManifest == nil || db.valueLogManager == nil {
+		return false, nil
+	}
+	commitSeq := uint64(1)
+	if state := db.State(); state != nil && state.CommitSeq != 0 {
+		commitSeq = state.CommitSeq
+	}
+	if _, err := db.reconcileLeafGenerationManifestWithDirLocked(commitSeq); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func (db *DB) captureLeafGenerationGCScanBasis(snap *Snapshot) (leafGenerationGCScanBasis, bool) {
+	var basis leafGenerationGCScanBasis
+	if snap == nil || snap.state == nil || snap.state.LeafGenerations == nil {
+		return basis, false
+	}
+
+	db.writeMu.RLock()
+	defer db.writeMu.RUnlock()
+
+	current := db.State()
+	if current == nil || current.CommitSeq != snap.state.CommitSeq || current.LeafGenerationStateVersion != snap.state.LeafGenerationStateVersion {
+		return basis, false
+	}
+	manifest := db.leafGenerationManifest.clone()
+	if manifest == nil {
+		return basis, false
+	}
+	basis.commitSeq = snap.state.CommitSeq
+	basis.leafGenerationStateVersion = snap.state.LeafGenerationStateVersion
+	basis.manifest = manifest
+	return basis, true
+}
+
+func (db *DB) leafGenerationGCScanBasisStillCurrent(basis leafGenerationGCScanBasis) bool {
+	current := db.State()
+	if current == nil || current.CommitSeq != basis.commitSeq || current.LeafGenerationStateVersion != basis.leafGenerationStateVersion {
+		return false
+	}
+	return leafGenerationManifestsEqualForGC(basis.manifest, db.leafGenerationManifest)
+}
+
+func (db *DB) leafGenerationGCDryRunFromScan(basis leafGenerationGCScanBasis, liveGenerations map[uint64]struct{}) (LeafGenerationGCStats, error) {
+	var stats LeafGenerationGCStats
+
+	db.writeMu.RLock()
+	if !db.leafGenerationGCScanBasisStillCurrent(basis) {
+		db.writeMu.RUnlock()
+		return stats, nil
+	}
+	manifest := db.leafGenerationManifest.clone()
+	currentLeafLogRawFileIDs, err := db.currentLeafPageLogRawFileIDSet()
+	if err != nil {
+		db.writeMu.RUnlock()
+		return stats, err
+	}
+	filePaths := db.leafGenerationFilePaths(manifest)
+	db.writeMu.RUnlock()
+
+	decision := db.buildLeafGenerationGCDecision(manifest, filePaths, currentLeafLogRawFileIDs, liveGenerations, basis.commitSeq, true)
+	return decision.stats, nil
+}
+
+func (db *DB) leafGenerationGCApplyScan(basis leafGenerationGCScanBasis, liveGenerations map[uint64]struct{}) (LeafGenerationGCStats, error) {
+	var stats LeafGenerationGCStats
+
+	db.writeMu.Lock()
+	defer db.writeMu.Unlock()
+
+	if !db.leafGenerationGCScanBasisStillCurrent(basis) {
+		return stats, nil
+	}
+	manifest := db.leafGenerationManifest.clone()
+	if manifest == nil {
+		return stats, nil
+	}
+	currentLeafLogRawFileIDs, err := db.currentLeafPageLogRawFileIDSet()
+	if err != nil {
+		return stats, err
+	}
+	filePaths := db.leafGenerationFilePaths(manifest)
+	decision := db.buildLeafGenerationGCDecision(manifest, filePaths, currentLeafLogRawFileIDs, liveGenerations, basis.commitSeq, false)
+	stats = decision.stats
+
+	if len(decision.zombieFileIDs) > 0 {
+		for fileID := range decision.zombieFileIDs {
+			if err := db.valueLogManager.MarkZombie(fileID); err != nil && !errors.Is(err, valuelog.ErrFileNotFound) {
+				return stats, err
+			}
+		}
+	}
+
+	if decision.intermediateChanged {
+		if err := saveLeafGenerationManifest(LeafLogDirPath(db.dir), manifest); err != nil {
+			return stats, err
+		}
+		db.leafGenerationManifest = manifest
+	}
+	if decision.intermediateChanged || len(decision.zombieFileIDs) > 0 {
+		if err := db.publishLeafGenerationState(len(decision.zombieFileIDs) > 0); err != nil {
+			return stats, err
+		}
+	}
+
+	prePrune := manifest.clone()
+	manifest, pruned, filesDeleted, err := db.pruneDeletedLeafGenerationRecords(manifest, filePaths)
+	if err != nil {
+		return stats, fmt.Errorf("leaf generation gc: prune deleted generation records: %w", err)
+	}
+	if !pruned {
+		return stats, nil
+	}
+	stats.GenerationsDeleted = countPrunedLeafGenerations(prePrune, manifest)
+	stats.FilesDeleted = filesDeleted
+	if err := saveLeafGenerationManifest(LeafLogDirPath(db.dir), manifest); err != nil {
+		return stats, err
+	}
+	db.leafGenerationManifest = manifest
+	return stats, nil
+}
+
+func (db *DB) buildLeafGenerationGCDecision(manifest *leafGenerationManifest, filePaths map[uint32]string, currentLeafLogRawFileIDs map[uint32]struct{}, liveGenerations map[uint64]struct{}, currentCommitSeq uint64, dryRun bool) leafGenerationGCDecision {
+	decision := leafGenerationGCDecision{zombieFileIDs: make(map[uint32]struct{})}
 	activeFileRefs := leafGenerationActiveFileRefCounts(manifest)
 	for i := range manifest.Generations {
 		gen := &manifest.Generations[i]
@@ -122,7 +263,7 @@ func (db *DB) leafGenerationGC(ctx context.Context, opts LeafGenerationGCOptions
 			}
 			return genBytes
 		}
-		stats.GenerationsTotal++
+		decision.stats.GenerationsTotal++
 		if gen.State == leafGenerationStateDeleted {
 			// Zombie state is in-memory only. After a reopen, deleted manifest records
 			// whose files are still present must be marked zombie again so deletion is
@@ -142,12 +283,12 @@ func (db *DB) leafGenerationGC(ctx context.Context, opts LeafGenerationGCOptions
 				if _, current := currentLeafLogRawFileIDs[fileID]; current {
 					continue
 				}
-				zombieFileIDs[page.ValueLogFileID(fileID)] = struct{}{}
+				decision.zombieFileIDs[page.ValueLogFileID(fileID)] = struct{}{}
 			}
 			continue
 		}
 		if gen.State == leafGenerationStateWritable {
-			stats.GenerationsWritable++
+			decision.stats.GenerationsWritable++
 			continue
 		}
 		// Multiple physical leaf-log append writers can be current at once while
@@ -156,37 +297,37 @@ func (db *DB) leafGenerationGC(ctx context.Context, opts LeafGenerationGCOptions
 		// because the current root no longer references its older pages; future
 		// appends may still land in that file until the lane rotates or closes.
 		if leafGenerationRecordIntersectsFileIDSet(*gen, currentLeafLogRawFileIDs) {
-			stats.GenerationsLive++
+			decision.stats.GenerationsLive++
 			if gen.State != leafGenerationStateSealed {
 				gen.State = leafGenerationStateSealed
-				intermediateChanged = true
+				decision.intermediateChanged = true
 			}
 			continue
 		}
 		if _, ok := liveGenerations[gen.GenerationID]; ok {
-			stats.GenerationsLive++
+			decision.stats.GenerationsLive++
 			if gen.State != leafGenerationStateSealed {
 				gen.State = leafGenerationStateSealed
-				intermediateChanged = true
+				decision.intermediateChanged = true
 			}
 			continue
 		}
 		if db.leafGenerationPins.count(gen.GenerationID) > 0 {
-			stats.GenerationsRetiring++
+			decision.stats.GenerationsRetiring++
 			if gen.State != leafGenerationStateRetiring {
 				gen.State = leafGenerationStateRetiring
 				if currentCommitSeq > gen.RetiredCommitSeq {
 					gen.RetiredCommitSeq = currentCommitSeq
 				}
-				intermediateChanged = true
+				decision.intermediateChanged = true
 			}
 			continue
 		}
-		stats.GenerationsEligible++
+		decision.stats.GenerationsEligible++
 		if bytes := loadGenBytes(); bytes > 0 {
-			stats.BytesEligible += bytes
+			decision.stats.BytesEligible += bytes
 		}
-		if opts.DryRun {
+		if dryRun {
 			continue
 		}
 		if gen.State != leafGenerationStateDeleted {
@@ -195,7 +336,7 @@ func (db *DB) leafGenerationGC(ctx context.Context, opts LeafGenerationGCOptions
 				gen.DeletedCommitSeq = currentCommitSeq
 			}
 			if bytes := loadGenBytes(); bytes > 0 {
-				stats.BytesDeleted += bytes
+				decision.stats.BytesDeleted += bytes
 			}
 			seenFiles := make(map[uint32]struct{}, len(gen.FileIDs))
 			for _, fileID := range gen.FileIDs {
@@ -217,51 +358,43 @@ func (db *DB) leafGenerationGC(ctx context.Context, opts LeafGenerationGCOptions
 				if activeFileRefs[fileID] > 0 {
 					continue
 				}
-				zombieFileIDs[page.ValueLogFileID(fileID)] = struct{}{}
+				decision.zombieFileIDs[page.ValueLogFileID(fileID)] = struct{}{}
 			}
-			intermediateChanged = true
+			decision.intermediateChanged = true
 		}
 	}
+	return decision
+}
 
-	if opts.DryRun {
-		return stats, nil
+func leafGenerationManifestsEqualForGC(a, b *leafGenerationManifest) bool {
+	if a == nil || b == nil {
+		return a == b
 	}
-
-	if len(zombieFileIDs) > 0 {
-		for fileID := range zombieFileIDs {
-			if err := db.valueLogManager.MarkZombie(fileID); err != nil && !errors.Is(err, valuelog.ErrFileNotFound) {
-				return stats, err
-			}
+	if a.Version != b.Version || a.CurrentGenerationID != b.CurrentGenerationID || a.NextGenerationID != b.NextGenerationID || len(a.Generations) != len(b.Generations) {
+		return false
+	}
+	for i := range a.Generations {
+		ag, bg := a.Generations[i], b.Generations[i]
+		if ag.GenerationID != bg.GenerationID || ag.State != bg.State || ag.CreatedCommitSeq != bg.CreatedCommitSeq || ag.SealedCommitSeq != bg.SealedCommitSeq || ag.RetiredCommitSeq != bg.RetiredCommitSeq || ag.DeletedCommitSeq != bg.DeletedCommitSeq || ag.PublishedCommitSeq != bg.PublishedCommitSeq {
+			return false
+		}
+		if !leafGenerationFileIDsEqualForGC(ag.FileIDs, bg.FileIDs) {
+			return false
 		}
 	}
+	return true
+}
 
-	if intermediateChanged {
-		if err := saveLeafGenerationManifest(LeafLogDirPath(db.dir), manifest); err != nil {
-			return stats, err
-		}
-		db.leafGenerationManifest = manifest
+func leafGenerationFileIDsEqualForGC(a, b []uint32) bool {
+	if len(a) != len(b) {
+		return false
 	}
-	if intermediateChanged || len(zombieFileIDs) > 0 {
-		if err := db.publishLeafGenerationState(len(zombieFileIDs) > 0); err != nil {
-			return stats, err
+	for i := range a {
+		if a[i] != b[i] {
+			return false
 		}
 	}
-
-	prePrune := manifest.clone()
-	manifest, pruned, filesDeleted, err := db.pruneDeletedLeafGenerationRecords(manifest, filePaths)
-	if err != nil {
-		return stats, fmt.Errorf("leaf generation gc: prune deleted generation records: %w", err)
-	}
-	if !pruned {
-		return stats, nil
-	}
-	stats.GenerationsDeleted = countPrunedLeafGenerations(prePrune, manifest)
-	stats.FilesDeleted = filesDeleted
-	if err := saveLeafGenerationManifest(LeafLogDirPath(db.dir), manifest); err != nil {
-		return stats, err
-	}
-	db.leafGenerationManifest = manifest
-	return stats, nil
+	return true
 }
 
 func (db *DB) currentLeafPageLogRawFileIDSet() (map[uint32]struct{}, error) {

--- a/TreeDB/db/leaf_generation_gc.go
+++ b/TreeDB/db/leaf_generation_gc.go
@@ -112,11 +112,14 @@ type leafGenerationGCDecision struct {
 
 func (db *DB) prepareLeafGenerationGCScan() (bool, error) {
 	db.writeMu.RLock()
+	db.mu.RLock()
 	if db.leafGenerationManifest == nil || db.valueLogManager == nil {
+		db.mu.RUnlock()
 		db.writeMu.RUnlock()
 		return false, nil
 	}
 	valueLogManager := db.valueLogManager
+	db.mu.RUnlock()
 	db.writeMu.RUnlock()
 
 	if err := valueLogManager.Refresh(); err != nil {
@@ -146,13 +149,15 @@ func (db *DB) captureLeafGenerationGCScanBasis(snap *Snapshot) (leafGenerationGC
 	}
 
 	db.writeMu.RLock()
-	defer db.writeMu.RUnlock()
+	db.mu.RLock()
+	current := db.state.Load()
+	manifest := db.leafGenerationManifest.clone()
+	db.mu.RUnlock()
+	db.writeMu.RUnlock()
 
-	current := db.State()
 	if current == nil || current.CommitSeq != snap.state.CommitSeq || current.LeafGenerationStateVersion != snap.state.LeafGenerationStateVersion {
 		return basis, false
 	}
-	manifest := db.leafGenerationManifest.clone()
 	if manifest == nil {
 		return basis, false
 	}
@@ -162,30 +167,40 @@ func (db *DB) captureLeafGenerationGCScanBasis(snap *Snapshot) (leafGenerationGC
 	return basis, true
 }
 
-func (db *DB) leafGenerationGCScanBasisStillCurrent(basis leafGenerationGCScanBasis) bool {
-	current := db.State()
+func (db *DB) leafGenerationGCValidatedManifestClone(basis leafGenerationGCScanBasis) (*leafGenerationManifest, bool) {
+	db.mu.RLock()
+	defer db.mu.RUnlock()
+
+	current := db.state.Load()
 	if current == nil || current.CommitSeq != basis.commitSeq || current.LeafGenerationStateVersion != basis.leafGenerationStateVersion {
-		return false
+		return nil, false
 	}
-	return leafGenerationManifestsEqualForGC(basis.manifest, db.leafGenerationManifest)
+	if !leafGenerationManifestsEqualForGC(basis.manifest, db.leafGenerationManifest) {
+		return nil, false
+	}
+	manifest := db.leafGenerationManifest.clone()
+	if manifest == nil {
+		return nil, false
+	}
+	return manifest, true
 }
 
 func (db *DB) leafGenerationGCDryRunFromScan(basis leafGenerationGCScanBasis, liveGenerations map[uint64]struct{}) (LeafGenerationGCStats, error) {
 	var stats LeafGenerationGCStats
 
-	db.writeMu.RLock()
-	if !db.leafGenerationGCScanBasisStillCurrent(basis) {
-		db.writeMu.RUnlock()
+	db.writeMu.Lock()
+	manifest, ok := db.leafGenerationGCValidatedManifestClone(basis)
+	if !ok {
+		db.writeMu.Unlock()
 		return stats, nil
 	}
-	manifest := db.leafGenerationManifest.clone()
 	currentLeafLogRawFileIDs, err := db.currentLeafPageLogRawFileIDSet()
 	if err != nil {
-		db.writeMu.RUnlock()
+		db.writeMu.Unlock()
 		return stats, err
 	}
 	filePaths := db.leafGenerationFilePaths(manifest)
-	db.writeMu.RUnlock()
+	db.writeMu.Unlock()
 
 	decision := db.buildLeafGenerationGCDecision(manifest, filePaths, currentLeafLogRawFileIDs, liveGenerations, basis.commitSeq, true)
 	return decision.stats, nil
@@ -197,11 +212,8 @@ func (db *DB) leafGenerationGCApplyScan(basis leafGenerationGCScanBasis, liveGen
 	db.writeMu.Lock()
 	defer db.writeMu.Unlock()
 
-	if !db.leafGenerationGCScanBasisStillCurrent(basis) {
-		return stats, nil
-	}
-	manifest := db.leafGenerationManifest.clone()
-	if manifest == nil {
+	manifest, ok := db.leafGenerationGCValidatedManifestClone(basis)
+	if !ok {
 		return stats, nil
 	}
 	currentLeafLogRawFileIDs, err := db.currentLeafPageLogRawFileIDSet()

--- a/TreeDB/db/leaf_generation_gc.go
+++ b/TreeDB/db/leaf_generation_gc.go
@@ -216,6 +216,10 @@ func (db *DB) leafGenerationGCDryRunFromScan(basis leafGenerationGCScanBasis, li
 	var stats LeafGenerationGCStats
 
 	db.writeMu.Lock()
+	if db.closing.Load() {
+		db.writeMu.Unlock()
+		return stats, nil
+	}
 	manifest, ok := db.leafGenerationGCValidatedManifestClone(basis)
 	if !ok {
 		db.writeMu.Unlock()
@@ -238,6 +242,9 @@ func (db *DB) leafGenerationGCApplyScan(basis leafGenerationGCScanBasis, liveGen
 
 	db.writeMu.Lock()
 	defer db.writeMu.Unlock()
+	if db.closing.Load() {
+		return stats, nil
+	}
 
 	manifest, ok := db.leafGenerationGCValidatedManifestClone(basis)
 	if !ok {

--- a/TreeDB/db/leaf_generation_gc.go
+++ b/TreeDB/db/leaf_generation_gc.go
@@ -169,7 +169,11 @@ func (db *DB) prepareLeafGenerationGCScan() (bool, error) {
 	db.writeMu.RUnlock()
 
 	db.writeMu.Lock()
-	defer db.writeMu.Unlock()
+	runLeafGenerationGCExclusivePhaseHook(true)
+	defer func() {
+		runLeafGenerationGCExclusivePhaseHook(false)
+		db.writeMu.Unlock()
+	}()
 
 	if db.closing.Load() || db.leafGenerationManifest == nil || db.valueLogManager == nil {
 		return false, nil
@@ -239,21 +243,26 @@ func (db *DB) leafGenerationGCDryRunFromScan(basis leafGenerationGCScanBasis, li
 	var stats LeafGenerationGCStats
 
 	db.writeMu.Lock()
+	runLeafGenerationGCExclusivePhaseHook(true)
 	if db.closing.Load() {
+		runLeafGenerationGCExclusivePhaseHook(false)
 		db.writeMu.Unlock()
 		return stats, false, nil
 	}
 	manifest, ok := db.leafGenerationGCValidatedManifestClone(basis)
 	if !ok {
+		runLeafGenerationGCExclusivePhaseHook(false)
 		db.writeMu.Unlock()
 		return stats, true, nil
 	}
 	currentLeafLogRawFileIDs, err := db.currentLeafPageLogRawFileIDSet()
 	if err != nil {
+		runLeafGenerationGCExclusivePhaseHook(false)
 		db.writeMu.Unlock()
 		return stats, false, err
 	}
 	filePaths := db.leafGenerationFilePaths(manifest)
+	runLeafGenerationGCExclusivePhaseHook(false)
 	db.writeMu.Unlock()
 
 	decision := db.buildLeafGenerationGCDecision(manifest, filePaths, currentLeafLogRawFileIDs, liveGenerations, basis.commitSeq, true)
@@ -264,7 +273,11 @@ func (db *DB) leafGenerationGCApplyScan(basis leafGenerationGCScanBasis, liveGen
 	var stats LeafGenerationGCStats
 
 	db.writeMu.Lock()
-	defer db.writeMu.Unlock()
+	runLeafGenerationGCExclusivePhaseHook(true)
+	defer func() {
+		runLeafGenerationGCExclusivePhaseHook(false)
+		db.writeMu.Unlock()
+	}()
 	if db.closing.Load() {
 		return stats, nil
 	}

--- a/TreeDB/db/leaf_generation_gc.go
+++ b/TreeDB/db/leaf_generation_gc.go
@@ -59,9 +59,31 @@ func (db *DB) leafGenerationGC(ctx context.Context, opts LeafGenerationGCOptions
 		defer db.maintenanceMu.Unlock()
 	}
 
+	attempts := 1
+	if opts.DryRun {
+		attempts++
+	}
+	for attempt := 0; attempt < attempts; attempt++ {
+		stats, stale, err := db.leafGenerationGCAttempt(ctx, opts)
+		if err != nil {
+			return stats, err
+		}
+		if !stale {
+			return stats, nil
+		}
+		if err := ctx.Err(); err != nil {
+			return LeafGenerationGCStats{}, err
+		}
+	}
+	return LeafGenerationGCStats{}, ErrLeafGenerationGCStaleScan
+}
+
+func (db *DB) leafGenerationGCAttempt(ctx context.Context, opts LeafGenerationGCOptions) (LeafGenerationGCStats, bool, error) {
+	var stats LeafGenerationGCStats
+
 	prepared, err := db.prepareLeafGenerationGCScan()
 	if err != nil || !prepared {
-		return stats, err
+		return stats, false, err
 	}
 
 	// Hold a shared writer gate only for the unlocked scan window. Ordinary
@@ -72,7 +94,7 @@ func (db *DB) leafGenerationGC(ctx context.Context, opts LeafGenerationGCOptions
 	snap := db.AcquireSnapshot()
 	if snap == nil {
 		db.writeMu.RUnlock()
-		return stats, ErrClosed
+		return stats, false, ErrClosed
 	}
 	if len(snap.leafGenerationIDs) > 0 {
 		snap.releaseLeafGenerationPins()
@@ -80,25 +102,25 @@ func (db *DB) leafGenerationGC(ctx context.Context, opts LeafGenerationGCOptions
 	if snap.state == nil || snap.state.LeafGenerations == nil {
 		_ = snap.Close()
 		db.writeMu.RUnlock()
-		return stats, nil
+		return stats, false, nil
 	}
 
 	basis, ok := db.captureLeafGenerationGCScanBasis(snap)
 	if !ok {
 		_ = snap.Close()
 		db.writeMu.RUnlock()
-		return stats, nil
+		return stats, opts.DryRun, nil
 	}
 
 	liveGenerations, err := collectLiveLeafGenerationIDs(ctx, snap, opts.ProtectedRootIDs, opts.ProtectedSystemRootIDs)
 	if err != nil {
 		_ = snap.Close()
 		db.writeMu.RUnlock()
-		return stats, err
+		return stats, false, err
 	}
 	if err := snap.Close(); err != nil {
 		db.writeMu.RUnlock()
-		return stats, err
+		return stats, false, err
 	}
 	db.writeMu.RUnlock()
 	snap = nil
@@ -106,7 +128,8 @@ func (db *DB) leafGenerationGC(ctx context.Context, opts LeafGenerationGCOptions
 	if opts.DryRun {
 		return db.leafGenerationGCDryRunFromScan(basis, liveGenerations)
 	}
-	return db.leafGenerationGCApplyScan(basis, liveGenerations)
+	stats, err = db.leafGenerationGCApplyScan(basis, liveGenerations)
+	return stats, false, err
 }
 
 type leafGenerationGCScanBasis struct {
@@ -212,29 +235,29 @@ func (db *DB) leafGenerationGCValidatedManifestClone(basis leafGenerationGCScanB
 	return manifest, true
 }
 
-func (db *DB) leafGenerationGCDryRunFromScan(basis leafGenerationGCScanBasis, liveGenerations map[uint64]struct{}) (LeafGenerationGCStats, error) {
+func (db *DB) leafGenerationGCDryRunFromScan(basis leafGenerationGCScanBasis, liveGenerations map[uint64]struct{}) (LeafGenerationGCStats, bool, error) {
 	var stats LeafGenerationGCStats
 
 	db.writeMu.Lock()
 	if db.closing.Load() {
 		db.writeMu.Unlock()
-		return stats, nil
+		return stats, false, nil
 	}
 	manifest, ok := db.leafGenerationGCValidatedManifestClone(basis)
 	if !ok {
 		db.writeMu.Unlock()
-		return stats, nil
+		return stats, true, nil
 	}
 	currentLeafLogRawFileIDs, err := db.currentLeafPageLogRawFileIDSet()
 	if err != nil {
 		db.writeMu.Unlock()
-		return stats, err
+		return stats, false, err
 	}
 	filePaths := db.leafGenerationFilePaths(manifest)
 	db.writeMu.Unlock()
 
 	decision := db.buildLeafGenerationGCDecision(manifest, filePaths, currentLeafLogRawFileIDs, liveGenerations, basis.commitSeq, true)
-	return decision.stats, nil
+	return decision.stats, false, nil
 }
 
 func (db *DB) leafGenerationGCApplyScan(basis leafGenerationGCScanBasis, liveGenerations map[uint64]struct{}) (LeafGenerationGCStats, error) {

--- a/TreeDB/db/leaf_generation_gc.go
+++ b/TreeDB/db/leaf_generation_gc.go
@@ -81,19 +81,29 @@ func (db *DB) leafGenerationGC(ctx context.Context, opts LeafGenerationGCOptions
 func (db *DB) leafGenerationGCAttempt(ctx context.Context, opts LeafGenerationGCOptions) (LeafGenerationGCStats, bool, error) {
 	var stats LeafGenerationGCStats
 
+	// Refresh, snapshot acquisition, and the live scan intentionally run outside
+	// writeMu. Pin their backing resources against Close without joining the lock
+	// used by checkpoints and foreground publishes.
+	db.teardownMu.RLock()
+	teardownHeld := true
+	releaseTeardown := func() {
+		if teardownHeld {
+			db.teardownMu.RUnlock()
+			teardownHeld = false
+		}
+	}
+	defer releaseTeardown()
+	if db.closing.Load() {
+		return stats, false, nil
+	}
+
 	prepared, err := db.prepareLeafGenerationGCScan()
 	if err != nil || !prepared {
 		return stats, false, err
 	}
 
-	// Hold a shared writer gate only for the unlocked scan window. Ordinary
-	// foreground commits can still proceed through their shared-lock publish path,
-	// but Close and other exclusive teardown/cutover paths cannot close the pager
-	// or value-log manager while the pinned snapshot is being walked.
-	db.writeMu.RLock()
 	snap := db.AcquireSnapshot()
 	if snap == nil {
-		db.writeMu.RUnlock()
 		return stats, false, ErrClosed
 	}
 	if len(snap.leafGenerationIDs) > 0 {
@@ -101,29 +111,25 @@ func (db *DB) leafGenerationGCAttempt(ctx context.Context, opts LeafGenerationGC
 	}
 	if snap.state == nil || snap.state.LeafGenerations == nil {
 		_ = snap.Close()
-		db.writeMu.RUnlock()
 		return stats, false, nil
 	}
 
 	basis, ok := db.captureLeafGenerationGCScanBasis(snap)
 	if !ok {
 		_ = snap.Close()
-		db.writeMu.RUnlock()
 		return stats, opts.DryRun, nil
 	}
 
 	liveGenerations, err := collectLiveLeafGenerationIDs(ctx, snap, opts.ProtectedRootIDs, opts.ProtectedSystemRootIDs)
 	if err != nil {
 		_ = snap.Close()
-		db.writeMu.RUnlock()
 		return stats, false, err
 	}
 	if err := snap.Close(); err != nil {
-		db.writeMu.RUnlock()
 		return stats, false, err
 	}
-	db.writeMu.RUnlock()
 	snap = nil
+	releaseTeardown()
 
 	if opts.DryRun {
 		return db.leafGenerationGCDryRunFromScan(basis, liveGenerations)
@@ -145,28 +151,22 @@ type leafGenerationGCDecision struct {
 }
 
 func (db *DB) prepareLeafGenerationGCScan() (bool, error) {
-	db.writeMu.RLock()
 	if db.closing.Load() {
-		db.writeMu.RUnlock()
 		return false, nil
 	}
 	db.mu.RLock()
 	if db.leafGenerationManifest == nil || db.valueLogManager == nil {
 		db.mu.RUnlock()
-		db.writeMu.RUnlock()
 		return false, nil
 	}
 	valueLogManager := db.valueLogManager
 	db.mu.RUnlock()
 
-	// Refresh may touch value-log manager state/files. Keep the shared writer
-	// gate while it runs so Close cannot clear/close the manager underneath it;
-	// ordinary shared-lock foreground publishes can still proceed.
+	// The caller's teardown read lock keeps Close from clearing or closing this
+	// manager. Manager synchronization handles concurrent normal DB activity.
 	if err := valueLogManager.Refresh(); err != nil {
-		db.writeMu.RUnlock()
 		return false, err
 	}
-	db.writeMu.RUnlock()
 
 	db.writeMu.Lock()
 	runLeafGenerationGCExclusivePhaseHook(true)
@@ -194,11 +194,9 @@ func (db *DB) captureLeafGenerationGCScanBasis(snap *Snapshot) (leafGenerationGC
 		return basis, false
 	}
 
-	// The caller holds writeMu.RLock for the scan window. Optimistic publishers can
-	// share that lock while swapping the manifest under db.mu, so capture the
-	// state/manifest basis under db.mu as a coherent pair. Do not reacquire
-	// writeMu here: Go's RWMutex blocks recursive read locks when an exclusive
-	// waiter is pending.
+	// Optimistic publishers swap the state and manifest under db.mu, so capture
+	// the pair under that lock. The teardown read lock protects backing resources
+	// from Close; snapshot references handle normal index-generation cutovers.
 	db.mu.RLock()
 	current := db.state.Load()
 	var manifest *leafGenerationManifest

--- a/TreeDB/db/leaf_generation_gc.go
+++ b/TreeDB/db/leaf_generation_gc.go
@@ -123,6 +123,10 @@ type leafGenerationGCDecision struct {
 
 func (db *DB) prepareLeafGenerationGCScan() (bool, error) {
 	db.writeMu.RLock()
+	if db.closing.Load() {
+		db.writeMu.RUnlock()
+		return false, nil
+	}
 	db.mu.RLock()
 	if db.leafGenerationManifest == nil || db.valueLogManager == nil {
 		db.mu.RUnlock()
@@ -131,16 +135,20 @@ func (db *DB) prepareLeafGenerationGCScan() (bool, error) {
 	}
 	valueLogManager := db.valueLogManager
 	db.mu.RUnlock()
-	db.writeMu.RUnlock()
 
+	// Refresh may touch value-log manager state/files. Keep the shared writer
+	// gate while it runs so Close cannot clear/close the manager underneath it;
+	// ordinary shared-lock foreground publishes can still proceed.
 	if err := valueLogManager.Refresh(); err != nil {
+		db.writeMu.RUnlock()
 		return false, err
 	}
+	db.writeMu.RUnlock()
 
 	db.writeMu.Lock()
 	defer db.writeMu.Unlock()
 
-	if db.leafGenerationManifest == nil || db.valueLogManager == nil {
+	if db.closing.Load() || db.leafGenerationManifest == nil || db.valueLogManager == nil {
 		return false, nil
 	}
 	commitSeq := uint64(1)
@@ -159,15 +167,18 @@ func (db *DB) captureLeafGenerationGCScanBasis(snap *Snapshot) (leafGenerationGC
 		return basis, false
 	}
 
-	db.writeMu.RLock()
-	// Optimistic publishers can also hold writeMu.RLock while swapping the
-	// manifest under db.mu, so capture the state/manifest basis under db.mu as a
-	// coherent pair.
+	// The caller holds writeMu.RLock for the scan window. Optimistic publishers can
+	// share that lock while swapping the manifest under db.mu, so capture the
+	// state/manifest basis under db.mu as a coherent pair. Do not reacquire
+	// writeMu here: Go's RWMutex blocks recursive read locks when an exclusive
+	// waiter is pending.
 	db.mu.RLock()
 	current := db.state.Load()
-	manifest := db.leafGenerationManifest.clone()
+	var manifest *leafGenerationManifest
+	if db.leafGenerationManifest != nil {
+		manifest = db.leafGenerationManifest.clone()
+	}
 	db.mu.RUnlock()
-	db.writeMu.RUnlock()
 
 	if current == nil || current.CommitSeq != snap.state.CommitSeq || current.LeafGenerationStateVersion != snap.state.LeafGenerationStateVersion {
 		return basis, false

--- a/TreeDB/db/leaf_generation_gc.go
+++ b/TreeDB/db/leaf_generation_gc.go
@@ -64,8 +64,14 @@ func (db *DB) leafGenerationGC(ctx context.Context, opts LeafGenerationGCOptions
 		return stats, err
 	}
 
+	// Hold a shared writer gate only for the unlocked scan window. Ordinary
+	// foreground commits can still proceed through their shared-lock publish path,
+	// but Close and other exclusive teardown/cutover paths cannot close the pager
+	// or value-log manager while the pinned snapshot is being walked.
+	db.writeMu.RLock()
 	snap := db.AcquireSnapshot()
 	if snap == nil {
+		db.writeMu.RUnlock()
 		return stats, ErrClosed
 	}
 	if len(snap.leafGenerationIDs) > 0 {
@@ -73,23 +79,28 @@ func (db *DB) leafGenerationGC(ctx context.Context, opts LeafGenerationGCOptions
 	}
 	if snap.state == nil || snap.state.LeafGenerations == nil {
 		_ = snap.Close()
+		db.writeMu.RUnlock()
 		return stats, nil
 	}
 
 	basis, ok := db.captureLeafGenerationGCScanBasis(snap)
 	if !ok {
 		_ = snap.Close()
+		db.writeMu.RUnlock()
 		return stats, nil
 	}
 
 	liveGenerations, err := collectLiveLeafGenerationIDs(ctx, snap, opts.ProtectedRootIDs, opts.ProtectedSystemRootIDs)
 	if err != nil {
 		_ = snap.Close()
+		db.writeMu.RUnlock()
 		return stats, err
 	}
 	if err := snap.Close(); err != nil {
+		db.writeMu.RUnlock()
 		return stats, err
 	}
+	db.writeMu.RUnlock()
 	snap = nil
 
 	if opts.DryRun {
@@ -149,6 +160,9 @@ func (db *DB) captureLeafGenerationGCScanBasis(snap *Snapshot) (leafGenerationGC
 	}
 
 	db.writeMu.RLock()
+	// Optimistic publishers can also hold writeMu.RLock while swapping the
+	// manifest under db.mu, so capture the state/manifest basis under db.mu as a
+	// coherent pair.
 	db.mu.RLock()
 	current := db.state.Load()
 	manifest := db.leafGenerationManifest.clone()
@@ -168,6 +182,8 @@ func (db *DB) captureLeafGenerationGCScanBasis(snap *Snapshot) (leafGenerationGC
 }
 
 func (db *DB) leafGenerationGCValidatedManifestClone(basis leafGenerationGCScanBasis) (*leafGenerationManifest, bool) {
+	// See captureLeafGenerationGCScanBasis: db.mu serializes manifest swaps from
+	// optimistic publishers that share writeMu.RLock with this maintenance path.
 	db.mu.RLock()
 	defer db.mu.RUnlock()
 

--- a/TreeDB/db/leaf_generation_gc_bench_test.go
+++ b/TreeDB/db/leaf_generation_gc_bench_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sort"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -13,6 +14,17 @@ const leafGenerationGCContentionFixtureKeys = 16 * 1024
 const leafGenerationGCContentionScanWindow = 50 * time.Millisecond
 
 type leafGenerationGCBenchmarkWriteResult struct {
+	duration time.Duration
+	err      error
+}
+
+type leafGenerationGCBenchmarkWrite struct {
+	start   chan struct{}
+	started chan struct{}
+	done    chan leafGenerationGCBenchmarkWriteResult
+}
+
+type leafGenerationGCBenchmarkGCResult struct {
 	duration time.Duration
 	err      error
 }
@@ -41,33 +53,84 @@ func leafGenerationGCBenchmarkPercentile(samples []time.Duration, percentile int
 	return sorted[index-1]
 }
 
+func launchLeafGenerationGCBenchmarkWrite(db *DB, key []byte) leafGenerationGCBenchmarkWrite {
+	write := leafGenerationGCBenchmarkWrite{
+		start:   make(chan struct{}),
+		started: make(chan struct{}),
+		done:    make(chan leafGenerationGCBenchmarkWriteResult, 1),
+	}
+	go func() {
+		<-write.start
+		start := time.Now()
+		close(write.started)
+		err := db.Set(key, []byte("value"))
+		write.done <- leafGenerationGCBenchmarkWriteResult{duration: time.Since(start), err: err}
+	}()
+	return write
+}
+
+func (write leafGenerationGCBenchmarkWrite) begin() {
+	close(write.start)
+	<-write.started
+}
+
+func TestLeafGenerationGCBenchmarkPercentile(t *testing.T) {
+	samples := make([]time.Duration, 100)
+	for i := range samples {
+		samples[i] = time.Duration(i+1) * time.Millisecond
+	}
+	if got, want := leafGenerationGCBenchmarkPercentile(samples, 95), 95*time.Millisecond; got != want {
+		t.Fatalf("p95=%s, want %s", got, want)
+	}
+	if got, want := leafGenerationGCBenchmarkPercentile(samples, 99), 99*time.Millisecond; got != want {
+		t.Fatalf("p99=%s, want %s", got, want)
+	}
+	if got := leafGenerationGCBenchmarkPercentile(nil, 99); got != 0 {
+		t.Fatalf("empty p99=%s, want 0", got)
+	}
+}
+
 func BenchmarkLeafGenerationGCWriterContention(b *testing.B) {
 	db, _ := openLeafGenerationGCContentionBenchDB(b)
 	idleWrites := make([]time.Duration, 0, b.N)
 	gcWrites := make([]time.Duration, 0, b.N)
+	gcDurations := make([]time.Duration, 0, b.N)
+	var scannedPages atomic.Uint64
+	unregisterPageCounter := registerLeafGenerationSubtreeCacheMissHook(func(uint64) {
+		scannedPages.Add(1)
+	})
+	b.Cleanup(unregisterPageCounter)
+	var totalScans uint64
+	var totalScannedPages uint64
 
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		idleStart := time.Now()
-		if err := db.Set([]byte(fmt.Sprintf("leaf-gc-idle-%08d", i)), []byte("value")); err != nil {
-			b.Fatalf("idle Set: %v", err)
+		idleWrite := launchLeafGenerationGCBenchmarkWrite(db, []byte(fmt.Sprintf("leaf-gc-write-i-%08d", i)))
+		idleWrite.begin()
+		idleResult := <-idleWrite.done
+		if idleResult.err != nil {
+			b.Fatalf("idle Set: %v", idleResult.err)
 		}
-		idleWrites = append(idleWrites, time.Since(idleStart))
+		idleWrites = append(idleWrites, idleResult.duration)
 
 		enteredScan := make(chan struct{})
 		releaseScan := make(chan struct{})
 		var scanOnce sync.Once
+		var scanCount atomic.Uint64
 		unregister := registerLeafGenerationLiveScanHook(func() {
+			scanCount.Add(1)
 			scanOnce.Do(func() {
 				close(enteredScan)
 				<-releaseScan
 			})
 		})
-		gcDone := make(chan error, 1)
+		pagesBefore := scannedPages.Load()
+		gcDone := make(chan leafGenerationGCBenchmarkGCResult, 1)
 		go func() {
+			start := time.Now()
 			_, err := db.LeafGenerationGC(context.Background(), LeafGenerationGCOptions{DryRun: true})
-			gcDone <- err
+			gcDone <- leafGenerationGCBenchmarkGCResult{duration: time.Since(start), err: err}
 		}()
 		select {
 		case <-enteredScan:
@@ -76,27 +139,24 @@ func BenchmarkLeafGenerationGCWriterContention(b *testing.B) {
 			b.Fatal("LeafGenerationGC did not enter live scan")
 		}
 
-		writeStarted := make(chan struct{})
-		writeDone := make(chan leafGenerationGCBenchmarkWriteResult, 1)
-		writeStart := time.Now()
-		go func() {
-			close(writeStarted)
-			err := db.Set([]byte(fmt.Sprintf("leaf-gc-during-%08d", i)), []byte("value"))
-			writeDone <- leafGenerationGCBenchmarkWriteResult{duration: time.Since(writeStart), err: err}
-		}()
-		<-writeStarted
+		gcWrite := launchLeafGenerationGCBenchmarkWrite(db, []byte(fmt.Sprintf("leaf-gc-write-g-%08d", i)))
+		gcWrite.begin()
 		time.Sleep(leafGenerationGCContentionScanWindow)
 		close(releaseScan)
-		writeResult := <-writeDone
+		writeResult := <-gcWrite.done
 		if writeResult.err != nil {
 			unregister()
 			b.Fatalf("Set during leaf GC: %v", writeResult.err)
 		}
 		gcWrites = append(gcWrites, writeResult.duration)
-		if err := <-gcDone; err != nil {
+		gcResult := <-gcDone
+		if gcResult.err != nil {
 			unregister()
-			b.Fatalf("LeafGenerationGC dry run: %v", err)
+			b.Fatalf("LeafGenerationGC dry run: %v", gcResult.err)
 		}
+		gcDurations = append(gcDurations, gcResult.duration)
+		totalScans += scanCount.Load()
+		totalScannedPages += scannedPages.Load() - pagesBefore
 		unregister()
 	}
 	b.StopTimer()
@@ -109,19 +169,21 @@ func BenchmarkLeafGenerationGCWriterContention(b *testing.B) {
 	b.ReportMetric(float64(idleP99.Nanoseconds()), "idle-write-p99-ns")
 	b.ReportMetric(float64(gcP95.Nanoseconds()), "gc-write-p95-ns")
 	b.ReportMetric(float64(gcP99.Nanoseconds()), "gc-write-p99-ns")
-	if gcP95 > idleP95 {
-		b.ReportMetric(float64((gcP95 - idleP95).Nanoseconds()), "scan-block-p95-ns")
-	} else {
-		b.ReportMetric(0, "scan-block-p95-ns")
-	}
-	if gcP99 > idleP99 {
-		b.ReportMetric(float64((gcP99 - idleP99).Nanoseconds()), "scan-block-p99-ns")
-	} else {
-		b.ReportMetric(0, "scan-block-p99-ns")
-	}
 	b.ReportMetric(float64(leafGenerationGCContentionScanWindow.Nanoseconds()), "scan-window-ns")
+	if idleP95 > 0 {
+		b.ReportMetric(float64(gcP95)/float64(idleP95), "gc/idle-p95")
+	}
 	if idleP99 > 0 {
 		b.ReportMetric(float64(gcP99)/float64(idleP99), "gc/idle-p99")
+	}
+	b.ReportMetric(float64(leafGenerationGCBenchmarkPercentile(gcDurations, 95).Nanoseconds()), "gc-wall-p95-ns")
+	b.ReportMetric(float64(leafGenerationGCBenchmarkPercentile(gcDurations, 99).Nanoseconds()), "gc-wall-p99-ns")
+	if b.N > 0 {
+		b.ReportMetric(float64(totalScans)/float64(b.N), "live-scans/op")
+		b.ReportMetric(float64(totalScannedPages)/float64(b.N), "live-scan-pages/op")
+	}
+	if totalScans > 0 {
+		b.ReportMetric(float64(totalScannedPages)/float64(totalScans), "live-scan-pages/scan")
 	}
 	if elapsed := b.Elapsed(); elapsed > 0 {
 		b.ReportMetric(float64(b.N)/elapsed.Seconds(), "ops/s")

--- a/TreeDB/db/leaf_generation_gc_bench_test.go
+++ b/TreeDB/db/leaf_generation_gc_bench_test.go
@@ -12,6 +12,7 @@ import (
 
 const leafGenerationGCContentionFixtureKeys = 16 * 1024
 const leafGenerationGCContentionScanWindow = 50 * time.Millisecond
+const leafGenerationGCExclusiveQueueWindow = time.Millisecond
 
 type leafGenerationGCBenchmarkWriteResult struct {
 	duration time.Duration
@@ -27,6 +28,11 @@ type leafGenerationGCBenchmarkWrite struct {
 type leafGenerationGCBenchmarkGCResult struct {
 	duration time.Duration
 	err      error
+}
+
+type leafGenerationGCBenchmarkExclusiveWaiter struct {
+	started chan struct{}
+	done    chan leafGenerationGCBenchmarkWriteResult
 }
 
 func openLeafGenerationGCContentionBenchDB(b *testing.B) (*DB, *rewriteWriter) {
@@ -74,6 +80,22 @@ func (write leafGenerationGCBenchmarkWrite) begin() {
 	<-write.started
 }
 
+func launchLeafGenerationGCBenchmarkExclusiveWaiter(db *DB) leafGenerationGCBenchmarkExclusiveWaiter {
+	waiter := leafGenerationGCBenchmarkExclusiveWaiter{
+		started: make(chan struct{}),
+		done:    make(chan leafGenerationGCBenchmarkWriteResult, 1),
+	}
+	go func() {
+		close(waiter.started)
+		start := time.Now()
+		db.writeMu.Lock()
+		duration := time.Since(start)
+		db.writeMu.Unlock()
+		waiter.done <- leafGenerationGCBenchmarkWriteResult{duration: duration}
+	}()
+	return waiter
+}
+
 func TestLeafGenerationGCBenchmarkPercentile(t *testing.T) {
 	samples := make([]time.Duration, 100)
 	for i := range samples {
@@ -95,6 +117,7 @@ func BenchmarkLeafGenerationGCWriterContention(b *testing.B) {
 	idleWrites := make([]time.Duration, 0, b.N)
 	gcWrites := make([]time.Duration, 0, b.N)
 	gcDurations := make([]time.Duration, 0, b.N)
+	exclusiveWaiterDurations := make([]time.Duration, 0, b.N)
 	var scannedPages atomic.Uint64
 	unregisterPageCounter := registerLeafGenerationSubtreeCacheMissHook(func(uint64) {
 		scannedPages.Add(1)
@@ -139,10 +162,18 @@ func BenchmarkLeafGenerationGCWriterContention(b *testing.B) {
 			b.Fatal("LeafGenerationGC did not enter live scan")
 		}
 
+		exclusiveWaiter := launchLeafGenerationGCBenchmarkExclusiveWaiter(db)
+		<-exclusiveWaiter.started
+		// Give the exclusive request a stable opportunity to queue behind the
+		// paused scan before launching the later foreground write.
+		time.Sleep(leafGenerationGCExclusiveQueueWindow)
+
 		gcWrite := launchLeafGenerationGCBenchmarkWrite(db, []byte(fmt.Sprintf("leaf-gc-write-g-%08d", i)))
 		gcWrite.begin()
 		time.Sleep(leafGenerationGCContentionScanWindow)
 		close(releaseScan)
+		exclusiveWaiterResult := <-exclusiveWaiter.done
+		exclusiveWaiterDurations = append(exclusiveWaiterDurations, exclusiveWaiterResult.duration)
 		writeResult := <-gcWrite.done
 		if writeResult.err != nil {
 			unregister()
@@ -169,7 +200,10 @@ func BenchmarkLeafGenerationGCWriterContention(b *testing.B) {
 	b.ReportMetric(float64(idleP99.Nanoseconds()), "idle-write-p99-ns")
 	b.ReportMetric(float64(gcP95.Nanoseconds()), "gc-write-p95-ns")
 	b.ReportMetric(float64(gcP99.Nanoseconds()), "gc-write-p99-ns")
+	b.ReportMetric(float64(leafGenerationGCBenchmarkPercentile(exclusiveWaiterDurations, 95).Nanoseconds()), "exclusive-waiter-p95-ns")
+	b.ReportMetric(float64(leafGenerationGCBenchmarkPercentile(exclusiveWaiterDurations, 99).Nanoseconds()), "exclusive-waiter-p99-ns")
 	b.ReportMetric(float64(leafGenerationGCContentionScanWindow.Nanoseconds()), "scan-window-ns")
+	b.ReportMetric(float64(leafGenerationGCExclusiveQueueWindow.Nanoseconds()), "exclusive-queue-window-ns")
 	if idleP95 > 0 {
 		b.ReportMetric(float64(gcP95)/float64(idleP95), "gc/idle-p95")
 	}

--- a/TreeDB/db/leaf_generation_gc_bench_test.go
+++ b/TreeDB/db/leaf_generation_gc_bench_test.go
@@ -1,0 +1,164 @@
+package db
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"sync"
+	"testing"
+	"time"
+)
+
+const leafGenerationGCContentionFixtureKeys = 16 * 1024
+const leafGenerationGCContentionScanWindow = 50 * time.Millisecond
+
+type leafGenerationGCBenchmarkWriteResult struct {
+	duration time.Duration
+	err      error
+}
+
+func openLeafGenerationGCContentionBenchDB(b *testing.B) (*DB, *rewriteWriter) {
+	b.Helper()
+	db, leafLog := openLeafGenerationPlanRootChurnBenchDB(b)
+	writeLeafGenerationBenchKeyRange(b, db, "leaf-gc-contention", 0, leafGenerationGCContentionFixtureKeys, 'a')
+	if err := leafLog.rotateLeaf(); err != nil {
+		b.Fatalf("rotateLeaf: %v", err)
+	}
+	writeLeafGenerationBenchKeyRange(b, db, "leaf-gc-contention", 0, leafGenerationGCContentionFixtureKeys, 'b')
+	return db, leafLog
+}
+
+func leafGenerationGCBenchmarkPercentile(samples []time.Duration, percentile int) time.Duration {
+	if len(samples) == 0 {
+		return 0
+	}
+	sorted := append([]time.Duration(nil), samples...)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })
+	index := (len(sorted)*percentile + 99) / 100
+	if index < 1 {
+		index = 1
+	}
+	return sorted[index-1]
+}
+
+func BenchmarkLeafGenerationGCWriterContention(b *testing.B) {
+	db, _ := openLeafGenerationGCContentionBenchDB(b)
+	idleWrites := make([]time.Duration, 0, b.N)
+	gcWrites := make([]time.Duration, 0, b.N)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		idleStart := time.Now()
+		if err := db.Set([]byte(fmt.Sprintf("leaf-gc-idle-%08d", i)), []byte("value")); err != nil {
+			b.Fatalf("idle Set: %v", err)
+		}
+		idleWrites = append(idleWrites, time.Since(idleStart))
+
+		enteredScan := make(chan struct{})
+		releaseScan := make(chan struct{})
+		var scanOnce sync.Once
+		unregister := registerLeafGenerationLiveScanHook(func() {
+			scanOnce.Do(func() {
+				close(enteredScan)
+				<-releaseScan
+			})
+		})
+		gcDone := make(chan error, 1)
+		go func() {
+			_, err := db.LeafGenerationGC(context.Background(), LeafGenerationGCOptions{DryRun: true})
+			gcDone <- err
+		}()
+		select {
+		case <-enteredScan:
+		case <-time.After(30 * time.Second):
+			unregister()
+			b.Fatal("LeafGenerationGC did not enter live scan")
+		}
+
+		writeStarted := make(chan struct{})
+		writeDone := make(chan leafGenerationGCBenchmarkWriteResult, 1)
+		writeStart := time.Now()
+		go func() {
+			close(writeStarted)
+			err := db.Set([]byte(fmt.Sprintf("leaf-gc-during-%08d", i)), []byte("value"))
+			writeDone <- leafGenerationGCBenchmarkWriteResult{duration: time.Since(writeStart), err: err}
+		}()
+		<-writeStarted
+		time.Sleep(leafGenerationGCContentionScanWindow)
+		close(releaseScan)
+		writeResult := <-writeDone
+		if writeResult.err != nil {
+			unregister()
+			b.Fatalf("Set during leaf GC: %v", writeResult.err)
+		}
+		gcWrites = append(gcWrites, writeResult.duration)
+		if err := <-gcDone; err != nil {
+			unregister()
+			b.Fatalf("LeafGenerationGC dry run: %v", err)
+		}
+		unregister()
+	}
+	b.StopTimer()
+
+	idleP95 := leafGenerationGCBenchmarkPercentile(idleWrites, 95)
+	idleP99 := leafGenerationGCBenchmarkPercentile(idleWrites, 99)
+	gcP95 := leafGenerationGCBenchmarkPercentile(gcWrites, 95)
+	gcP99 := leafGenerationGCBenchmarkPercentile(gcWrites, 99)
+	b.ReportMetric(float64(idleP95.Nanoseconds()), "idle-write-p95-ns")
+	b.ReportMetric(float64(idleP99.Nanoseconds()), "idle-write-p99-ns")
+	b.ReportMetric(float64(gcP95.Nanoseconds()), "gc-write-p95-ns")
+	b.ReportMetric(float64(gcP99.Nanoseconds()), "gc-write-p99-ns")
+	if gcP95 > idleP95 {
+		b.ReportMetric(float64((gcP95 - idleP95).Nanoseconds()), "scan-block-p95-ns")
+	} else {
+		b.ReportMetric(0, "scan-block-p95-ns")
+	}
+	if gcP99 > idleP99 {
+		b.ReportMetric(float64((gcP99 - idleP99).Nanoseconds()), "scan-block-p99-ns")
+	} else {
+		b.ReportMetric(0, "scan-block-p99-ns")
+	}
+	b.ReportMetric(float64(leafGenerationGCContentionScanWindow.Nanoseconds()), "scan-window-ns")
+	if idleP99 > 0 {
+		b.ReportMetric(float64(gcP99)/float64(idleP99), "gc/idle-p99")
+	}
+	if elapsed := b.Elapsed(); elapsed > 0 {
+		b.ReportMetric(float64(b.N)/elapsed.Seconds(), "ops/s")
+	}
+}
+
+func BenchmarkLeafGenerationGCExclusivePhases(b *testing.B) {
+	db, _ := openLeafGenerationGCContentionBenchDB(b)
+	phaseDurations := make([]time.Duration, 0, 2*b.N)
+	var phaseStart time.Time
+	unregister := registerLeafGenerationGCExclusivePhaseHook(func(entering bool) {
+		if entering {
+			phaseStart = time.Now()
+			return
+		}
+		phaseDurations = append(phaseDurations, time.Since(phaseStart))
+	})
+	b.Cleanup(unregister)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := db.LeafGenerationGC(context.Background(), LeafGenerationGCOptions{}); err != nil {
+			b.Fatalf("LeafGenerationGC: %v", err)
+		}
+	}
+	b.StopTimer()
+
+	b.ReportMetric(float64(leafGenerationGCBenchmarkPercentile(phaseDurations, 99).Nanoseconds()), "exclusive-p99-ns")
+	var maxPhase time.Duration
+	for _, duration := range phaseDurations {
+		if duration > maxPhase {
+			maxPhase = duration
+		}
+	}
+	b.ReportMetric(float64(maxPhase.Nanoseconds()), "exclusive-max-ns")
+	if elapsed := b.Elapsed(); elapsed > 0 {
+		b.ReportMetric(float64(b.N)/elapsed.Seconds(), "ops/s")
+	}
+}

--- a/TreeDB/db/leaf_generation_gc_test.go
+++ b/TreeDB/db/leaf_generation_gc_test.go
@@ -3,6 +3,7 @@ package db
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"sort"
@@ -422,6 +423,146 @@ func TestLeafGenerationGC_DryRunLiveScanDoesNotBlockForegroundWrite(t *testing.T
 	}
 	if !bytes.Equal(got, []byte("ok")) {
 		t.Fatalf("concurrent dry-run write value=%q want ok", got)
+	}
+}
+
+func TestLeafGenerationGC_DryRunRetriesInvalidatedScan(t *testing.T) {
+	db, leafLog := openLeafGenerationGCTestDB(t)
+
+	writeLeafGenerationKeys(t, db, "dry-retry-old", 64, 'a')
+	if err := leafLog.rotateLeaf(); err != nil {
+		t.Fatalf("rotateLeaf: %v", err)
+	}
+	writeLeafGenerationKeys(t, db, "dry-retry-new", 64, 'b')
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	var mu sync.Mutex
+	scans := 0
+	unregister := registerLeafGenerationLiveScanHook(func() {
+		mu.Lock()
+		scans++
+		scan := scans
+		mu.Unlock()
+		if scan == 1 {
+			close(entered)
+			<-release
+		}
+	})
+	t.Cleanup(unregister)
+
+	done := make(chan leafGenerationGCTestResult, 1)
+	go func() {
+		stats, err := db.LeafGenerationGC(context.Background(), LeafGenerationGCOptions{DryRun: true})
+		done <- leafGenerationGCTestResult{stats: stats, err: err}
+	}()
+	select {
+	case <-entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("dry-run GC did not enter first live scan")
+	}
+	if err := db.SetSync([]byte("dry-retry-concurrent"), []byte("ok")); err != nil {
+		t.Fatalf("SetSync invalidating first dry-run scan: %v", err)
+	}
+	close(release)
+
+	stats := requireLeafGenerationGCResult(t, done)
+	mu.Lock()
+	gotScans := scans
+	mu.Unlock()
+	if gotScans != 2 {
+		t.Fatalf("live scans=%d, want 2 after one invalidation", gotScans)
+	}
+	if stats.GenerationsEligible == 0 || stats.BytesEligible == 0 {
+		t.Fatalf("retried dry-run reported zero actionable debt: %+v", stats)
+	}
+}
+
+func TestLeafGenerationGC_DryRunRetryExhaustionReturnsStale(t *testing.T) {
+	db, leafLog := openLeafGenerationGCTestDB(t)
+
+	writeLeafGenerationKeys(t, db, "dry-stale-old", 64, 'a')
+	if err := leafLog.rotateLeaf(); err != nil {
+		t.Fatalf("rotateLeaf: %v", err)
+	}
+	writeLeafGenerationKeys(t, db, "dry-stale-new", 64, 'b')
+
+	entered := make(chan int, 2)
+	release := make(chan struct{})
+	var mu sync.Mutex
+	scans := 0
+	unregister := registerLeafGenerationLiveScanHook(func() {
+		mu.Lock()
+		scans++
+		scan := scans
+		mu.Unlock()
+		entered <- scan
+		<-release
+	})
+	t.Cleanup(unregister)
+
+	done := make(chan leafGenerationGCTestResult, 1)
+	go func() {
+		stats, err := db.LeafGenerationGC(context.Background(), LeafGenerationGCOptions{DryRun: true})
+		done <- leafGenerationGCTestResult{stats: stats, err: err}
+	}()
+	for attempt := 1; attempt <= 2; attempt++ {
+		select {
+		case scan := <-entered:
+			if scan != attempt {
+				t.Fatalf("live scan=%d, want attempt %d", scan, attempt)
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatalf("dry-run GC did not enter live scan attempt %d", attempt)
+		}
+		key := fmt.Sprintf("dry-stale-concurrent-%d", attempt)
+		if err := db.SetSync([]byte(key), []byte("ok")); err != nil {
+			t.Fatalf("SetSync invalidating dry-run attempt %d: %v", attempt, err)
+		}
+		release <- struct{}{}
+	}
+	select {
+	case result := <-done:
+		if !errors.Is(result.err, ErrLeafGenerationGCStaleScan) {
+			t.Fatalf("LeafGenerationGC error=%v, want ErrLeafGenerationGCStaleScan", result.err)
+		}
+		if result.stats != (LeafGenerationGCStats{}) {
+			t.Fatalf("stale dry-run stats=%+v, want zero with explicit error", result.stats)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("dry-run GC did not return after bounded stale retries")
+	}
+}
+
+func TestLeafGenerationGC_CloseWaitsForUnlockedScan(t *testing.T) {
+	db, leafLog := openLeafGenerationGCTestDB(t)
+
+	writeLeafGenerationKeys(t, db, "close-scan-old", 64, 'a')
+	if err := leafLog.rotateLeaf(); err != nil {
+		t.Fatalf("rotateLeaf: %v", err)
+	}
+	writeLeafGenerationKeys(t, db, "close-scan-new", 64, 'b')
+
+	releaseScan, gcDone := startLeafGenerationGCPausedAtLiveScan(t, db, LeafGenerationGCOptions{})
+	closeDone := make(chan error, 1)
+	go func() {
+		closeDone <- db.Close()
+	}()
+	select {
+	case err := <-closeDone:
+		t.Fatalf("Close returned before live scan released: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	releaseScan()
+	_ = requireLeafGenerationGCResult(t, gcDone)
+	select {
+	case err := <-closeDone:
+		if err != nil {
+			t.Fatalf("Close after live scan: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Close did not finish after live scan released")
 	}
 }
 

--- a/TreeDB/db/leaf_generation_gc_test.go
+++ b/TreeDB/db/leaf_generation_gc_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"sort"
+	"sync"
 	"testing"
 	"time"
 
@@ -243,6 +244,72 @@ func loadLeafGenerationManifestOrFatal(t *testing.T, dir string) *leafGeneration
 	return manifest
 }
 
+type leafGenerationGCTestResult struct {
+	stats LeafGenerationGCStats
+	err   error
+}
+
+func startLeafGenerationGCPausedAtLiveScan(t *testing.T, db *DB, opts LeafGenerationGCOptions) (func(), <-chan leafGenerationGCTestResult) {
+	t.Helper()
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	var enterOnce sync.Once
+	var releaseOnce sync.Once
+	unregister := registerLeafGenerationLiveScanHook(func() {
+		enterOnce.Do(func() { close(entered) })
+		<-release
+	})
+	done := make(chan leafGenerationGCTestResult, 1)
+	go func() {
+		stats, err := db.LeafGenerationGC(context.Background(), opts)
+		done <- leafGenerationGCTestResult{stats: stats, err: err}
+	}()
+	select {
+	case <-entered:
+	case <-time.After(5 * time.Second):
+		unregister()
+		t.Fatal("LeafGenerationGC did not enter live scan")
+	}
+	releaseScan := func() {
+		releaseOnce.Do(func() { close(release) })
+	}
+	t.Cleanup(func() {
+		releaseScan()
+		unregister()
+	})
+	return releaseScan, done
+}
+
+func requireLeafGenerationForegroundSetCompletes(t *testing.T, db *DB, key string) {
+	t.Helper()
+	done := make(chan error, 1)
+	go func() {
+		done <- db.SetSync([]byte(key), []byte("ok"))
+	}()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("SetSync while leaf-generation GC scan paused: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("SetSync blocked while leaf-generation GC scan was paused")
+	}
+}
+
+func requireLeafGenerationGCResult(t *testing.T, done <-chan leafGenerationGCTestResult) LeafGenerationGCStats {
+	t.Helper()
+	select {
+	case result := <-done:
+		if result.err != nil {
+			t.Fatalf("LeafGenerationGC: %v", result.err)
+		}
+		return result.stats
+	case <-time.After(5 * time.Second):
+		t.Fatal("LeafGenerationGC did not finish after releasing live scan")
+	}
+	return LeafGenerationGCStats{}
+}
+
 func TestLeafGenerationView_SkipsRetiringAndDeletedGenerations(t *testing.T) {
 	manifest := &leafGenerationManifest{
 		Version:             leafGenerationManifestVersion,
@@ -276,6 +343,85 @@ func TestLeafGenerationView_SkipsRetiringAndDeletedGenerations(t *testing.T) {
 	}
 	if got, want := view.FileToGeneration[303], uint64(3); got != want {
 		t.Fatalf("FileToGeneration[303]=%d, want %d", got, want)
+	}
+}
+
+func TestLeafGenerationGC_LiveScanDoesNotBlockForegroundWrite(t *testing.T) {
+	db, leafLog := openLeafGenerationGCTestDB(t)
+
+	writeLeafGenerationKeys(t, db, "scan-old", 64, 'a')
+	if err := leafLog.rotateLeaf(); err != nil {
+		t.Fatalf("rotateLeaf: %v", err)
+	}
+	writeLeafGenerationKeys(t, db, "scan-new", 64, 'b')
+
+	releaseScan, done := startLeafGenerationGCPausedAtLiveScan(t, db, LeafGenerationGCOptions{})
+	requireLeafGenerationForegroundSetCompletes(t, db, "scan-concurrent")
+	releaseScan()
+	_ = requireLeafGenerationGCResult(t, done)
+
+	got, err := db.Get([]byte("scan-concurrent"))
+	if err != nil {
+		t.Fatalf("Get concurrent write: %v", err)
+	}
+	if !bytes.Equal(got, []byte("ok")) {
+		t.Fatalf("concurrent write value=%q want ok", got)
+	}
+}
+
+func TestLeafGenerationGC_RevalidationFailureSkipsStalePublish(t *testing.T) {
+	db, leafLog := openLeafGenerationGCTestDB(t)
+
+	writeLeafGenerationKeys(t, db, "revalidate", 64, 'a')
+	path1, fileID1 := currentLeafSegmentOrFatal(t, leafLog)
+	rawFileID1 := page.ValueLogSegmentID(fileID1)
+	if err := leafLog.rotateLeaf(); err != nil {
+		t.Fatalf("rotateLeaf: %v", err)
+	}
+	writeLeafGenerationKeys(t, db, "revalidate", 64, 'b')
+	before := db.State()
+
+	releaseScan, done := startLeafGenerationGCPausedAtLiveScan(t, db, LeafGenerationGCOptions{})
+	requireLeafGenerationForegroundSetCompletes(t, db, "revalidate-concurrent")
+	afterWrite := db.State()
+	if before == nil || afterWrite == nil || afterWrite.CommitSeq == before.CommitSeq {
+		t.Fatalf("concurrent write did not advance CommitSeq: before=%+v after=%+v", before, afterWrite)
+	}
+	releaseScan()
+	stats := requireLeafGenerationGCResult(t, done)
+	if stats.GenerationsDeleted != 0 || stats.FilesDeleted != 0 {
+		t.Fatalf("stale scan applied deletion: stats=%+v", stats)
+	}
+	if _, err := os.Stat(path1); err != nil {
+		t.Fatalf("stale scan removed candidate leaf segment: %v", err)
+	}
+	manifestAfter := loadLeafGenerationManifestOrFatal(t, db.dir)
+	gen1 := findLeafGenerationByFileID(t, manifestAfter, rawFileID1)
+	if gen1.State == leafGenerationStateDeleted {
+		t.Fatalf("stale scan marked generation deleted: %+v", gen1)
+	}
+}
+
+func TestLeafGenerationGC_DryRunLiveScanDoesNotBlockForegroundWrite(t *testing.T) {
+	db, leafLog := openLeafGenerationGCTestDB(t)
+
+	writeLeafGenerationKeys(t, db, "dry-scan-old", 64, 'a')
+	if err := leafLog.rotateLeaf(); err != nil {
+		t.Fatalf("rotateLeaf: %v", err)
+	}
+	writeLeafGenerationKeys(t, db, "dry-scan-new", 64, 'b')
+
+	releaseScan, done := startLeafGenerationGCPausedAtLiveScan(t, db, LeafGenerationGCOptions{DryRun: true})
+	requireLeafGenerationForegroundSetCompletes(t, db, "dry-scan-concurrent")
+	releaseScan()
+	_ = requireLeafGenerationGCResult(t, done)
+
+	got, err := db.Get([]byte("dry-scan-concurrent"))
+	if err != nil {
+		t.Fatalf("Get concurrent dry-run write: %v", err)
+	}
+	if !bytes.Equal(got, []byte("ok")) {
+		t.Fatalf("concurrent dry-run write value=%q want ok", got)
 	}
 }
 

--- a/TreeDB/db/leaf_generation_gc_test.go
+++ b/TreeDB/db/leaf_generation_gc_test.go
@@ -297,6 +297,49 @@ func requireLeafGenerationForegroundSetCompletes(t *testing.T, db *DB, key strin
 	}
 }
 
+func queueLeafGenerationCheckpointBehindReadLock(t *testing.T, db *DB) (func(), <-chan error) {
+	t.Helper()
+	db.writeMu.RLock()
+	var releaseOnce sync.Once
+	release := func() {
+		releaseOnce.Do(db.writeMu.RUnlock)
+	}
+	t.Cleanup(release)
+
+	started := make(chan struct{})
+	done := make(chan error, 1)
+	go func() {
+		close(started)
+		done <- db.Checkpoint()
+	}()
+	<-started
+
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if !db.writeMu.TryRLock() {
+			break
+		}
+		db.writeMu.RUnlock()
+		if time.Now().After(deadline) {
+			t.Fatal("Checkpoint did not queue for writeMu")
+		}
+		time.Sleep(100 * time.Microsecond)
+	}
+	return release, done
+}
+
+func requireLeafGenerationOperationCompletes(t *testing.T, name string, done <-chan error) {
+	t.Helper()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("%s: %v", name, err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatalf("%s did not complete", name)
+	}
+}
+
 func requireLeafGenerationGCResult(t *testing.T, done <-chan leafGenerationGCTestResult) LeafGenerationGCStats {
 	t.Helper()
 	select {
@@ -367,6 +410,85 @@ func TestLeafGenerationGC_LiveScanDoesNotBlockForegroundWrite(t *testing.T) {
 	}
 	if !bytes.Equal(got, []byte("ok")) {
 		t.Fatalf("concurrent write value=%q want ok", got)
+	}
+}
+
+func TestLeafGenerationGC_QueuedCheckpointDoesNotGateLaterWrite(t *testing.T) {
+	db, leafLog := openLeafGenerationGCTestDB(t)
+
+	writeLeafGenerationKeys(t, db, "checkpoint-scan-old", 64, 'a')
+	if err := leafLog.rotateLeaf(); err != nil {
+		t.Fatalf("rotateLeaf: %v", err)
+	}
+	writeLeafGenerationKeys(t, db, "checkpoint-scan-new", 64, 'b')
+
+	releaseScan, gcDone := startLeafGenerationGCPausedAtLiveScan(t, db, LeafGenerationGCOptions{})
+	releaseCheckpointBlocker, checkpointDone := queueLeafGenerationCheckpointBehindReadLock(t, db)
+
+	setStarted := make(chan struct{})
+	setDone := make(chan error, 1)
+	go func() {
+		close(setStarted)
+		setDone <- db.SetSync([]byte("checkpoint-scan-concurrent"), []byte("ok"))
+	}()
+	<-setStarted
+	releaseCheckpointBlocker()
+
+	requireLeafGenerationOperationCompletes(t, "Checkpoint while live scan paused", checkpointDone)
+	requireLeafGenerationOperationCompletes(t, "SetSync queued after Checkpoint", setDone)
+	releaseScan()
+	_ = requireLeafGenerationGCResult(t, gcDone)
+
+	got, err := db.Get([]byte("checkpoint-scan-concurrent"))
+	if err != nil {
+		t.Fatalf("Get concurrent write: %v", err)
+	}
+	if !bytes.Equal(got, []byte("ok")) {
+		t.Fatalf("concurrent write value=%q want ok", got)
+	}
+}
+
+func TestLeafGenerationGC_LifetimeGateLockOrderStress(t *testing.T) {
+	db, leafLog := openLeafGenerationGCTestDB(t)
+
+	writeLeafGenerationKeys(t, db, "lifetime-stress-old", 64, 'a')
+	if err := leafLog.rotateLeaf(); err != nil {
+		t.Fatalf("rotateLeaf: %v", err)
+	}
+	writeLeafGenerationKeys(t, db, "lifetime-stress-new", 64, 'b')
+
+	for round := 0; round < 24; round++ {
+		start := make(chan struct{})
+		errs := make(chan error, 3)
+		go func() {
+			<-start
+			_, err := db.LeafGenerationGC(context.Background(), LeafGenerationGCOptions{DryRun: true})
+			if errors.Is(err, ErrLeafGenerationGCStaleScan) {
+				err = nil
+			}
+			errs <- err
+		}()
+		go func() {
+			<-start
+			errs <- db.Checkpoint()
+		}()
+		go func(round int) {
+			<-start
+			key := []byte(fmt.Sprintf("lifetime-stress-write-%02d", round))
+			errs <- db.SetSync(key, []byte("ok"))
+		}(round)
+		close(start)
+
+		for operation := 0; operation < 3; operation++ {
+			select {
+			case err := <-errs:
+				if err != nil {
+					t.Fatalf("round %d operation %d: %v", round, operation, err)
+				}
+			case <-time.After(10 * time.Second):
+				t.Fatalf("round %d operation %d timed out", round, operation)
+			}
+		}
 	}
 }
 

--- a/TreeDB/db/leaf_generation_plan.go
+++ b/TreeDB/db/leaf_generation_plan.go
@@ -132,6 +132,11 @@ var leafGenerationLiveScanHook struct {
 	fn func()
 }
 
+var leafGenerationGCExclusivePhaseHook struct {
+	mu sync.Mutex
+	fn func(bool)
+}
+
 var leafGenerationPlanCallHook struct {
 	mu sync.Mutex
 	fn func()
@@ -181,6 +186,27 @@ func runLeafGenerationLiveScanHook() {
 	leafGenerationLiveScanHook.mu.Unlock()
 	if hook != nil {
 		hook()
+	}
+}
+
+func registerLeafGenerationGCExclusivePhaseHook(hook func(bool)) func() {
+	leafGenerationGCExclusivePhaseHook.mu.Lock()
+	prev := leafGenerationGCExclusivePhaseHook.fn
+	leafGenerationGCExclusivePhaseHook.fn = hook
+	leafGenerationGCExclusivePhaseHook.mu.Unlock()
+	return func() {
+		leafGenerationGCExclusivePhaseHook.mu.Lock()
+		leafGenerationGCExclusivePhaseHook.fn = prev
+		leafGenerationGCExclusivePhaseHook.mu.Unlock()
+	}
+}
+
+func runLeafGenerationGCExclusivePhaseHook(entering bool) {
+	leafGenerationGCExclusivePhaseHook.mu.Lock()
+	hook := leafGenerationGCExclusivePhaseHook.fn
+	leafGenerationGCExclusivePhaseHook.mu.Unlock()
+	if hook != nil {
+		hook(entering)
 	}
 }
 

--- a/TreeDB/errors.go
+++ b/TreeDB/errors.go
@@ -38,6 +38,9 @@ var (
 	// ErrConcurrentModification indicates a conditional publish observed a read
 	// precondition that changed after the transaction opened.
 	ErrConcurrentModification = db.ErrConcurrentModification
+	// ErrLeafGenerationGCStaleScan indicates both bounded dry-run attempts were
+	// invalidated by concurrent publication and the caller should retry.
+	ErrLeafGenerationGCStaleScan = db.ErrLeafGenerationGCStaleScan
 	// ErrConditionalTxnUnsupported indicates the selected TreeDB mode cannot
 	// provide native conditional transaction semantics.
 	ErrConditionalTxnUnsupported = db.ErrConditionalTxnUnsupported

--- a/TreeDB/errors.go
+++ b/TreeDB/errors.go
@@ -39,7 +39,7 @@ var (
 	// precondition that changed after the transaction opened.
 	ErrConcurrentModification = db.ErrConcurrentModification
 	// ErrLeafGenerationGCStaleScan indicates both bounded dry-run attempts were
-	// invalidated by concurrent publication and the caller should retry.
+	// invalidated by concurrent publishes before their results could be used.
 	ErrLeafGenerationGCStaleScan = db.ErrLeafGenerationGCStaleScan
 	// ErrConditionalTxnUnsupported indicates the selected TreeDB mode cannot
 	// provide native conditional transaction semantics.

--- a/TreeDB/errors_test.go
+++ b/TreeDB/errors_test.go
@@ -1,0 +1,15 @@
+package treedb_test
+
+import (
+	"errors"
+	"testing"
+
+	treedb "github.com/snissn/gomap/TreeDB"
+	treedbdb "github.com/snissn/gomap/TreeDB/db"
+)
+
+func TestErrLeafGenerationGCStaleScanReexportsBackendSentinel(t *testing.T) {
+	if !errors.Is(treedbdb.ErrLeafGenerationGCStaleScan, treedb.ErrLeafGenerationGCStaleScan) {
+		t.Fatal("public ErrLeafGenerationGCStaleScan does not match backend sentinel")
+	}
+}


### PR DESCRIPTION
## Objective

Fixes #3637 (PL-02). Part of #3630.

Move the leaf-generation GC live scan out of <code>writeMu</code> without allowing <code>Close</code> to tear down the snapshot or value-log manager used by an active scan.

## Current Revision

- Branch: <code>codex/pl02-leaf-gc-scan-outside-writemu</code>
- Head: <code>deb27092c45772b1e5efea0f933a169429953b0a</code>
- Current base: <code>main@7d210c971ed3df543d9fe00fd5016b5d82cc7c0d</code>
- Blocking lock/lifetime fix: <code>ddda6b3c377f65e685ab6eb42754bf5571368ee6</code>
- Sentinel documentation alignment: <code>deb27092c45772b1e5efea0f933a169429953b0a</code>

## Design and Invariants

- A dedicated <code>teardownMu</code> lifetime gate pins Close-sensitive resources during value-log refresh, coherent state/manifest capture, the pinned snapshot scan, and snapshot release.
- <code>Close</code> marks the DB closing under <code>writeMu</code>, releases <code>writeMu</code>, then takes the exclusive teardown gate before clearing or closing snapshot/value-log resources. It never waits on <code>teardownMu</code> while holding <code>writeMu</code>.
- Normal Checkpoint and other exclusive maintenance do not use <code>teardownMu</code>; a queued <code>writeMu</code> writer therefore cannot convert the O(P) scan into a reader-preference stall for later foreground writes.
- The live scan holds no <code>writeMu</code> read or write lock. Short exclusive sections remain for reconcile and revalidation/apply.
- The scan basis captures commit sequence, leaf-generation state version, and exact manifest generation/file mapping coherently. Apply revalidates all three and recomputes current raw leaf-log IDs before any transition.
- A stale apply is rejected without mutation. Dry-run retries once from a fresh basis and then returns the public <code>ErrLeafGenerationGCStaleScan</code> sentinel; context cancellation retains precedence.
- The snapshot is closed before releasing the teardown read gate, so Close cannot invalidate snapshot/value-log lifetime while Refresh or scanning is active.

## Scope

Changed files:

- <code>TreeDB/db/db.go</code>
- <code>TreeDB/db/errors.go</code>
- <code>TreeDB/db/leaf_generation_gc.go</code>
- <code>TreeDB/db/leaf_generation_gc_bench_test.go</code>
- <code>TreeDB/db/leaf_generation_gc_test.go</code>
- <code>TreeDB/db/leaf_generation_plan.go</code>
- <code>TreeDB/errors.go</code>
- <code>TreeDB/errors_test.go</code>

No on-disk format, pointer encoding, value-log persistence, or unrelated GC policy changes.

## Correctness Coverage

New deterministic coverage:

- pauses a live leaf scan;
- holds a temporary read lock, starts a real <code>Checkpoint</code>, and uses <code>TryRLock</code> to prove the exclusive waiter is queued;
- starts a later <code>SetSync</code>;
- proves both Checkpoint and the later foreground write complete before the scan is released.

The retained Close regression proves Close waits for the active scan lifetime gate. A 24-round lock-order/race stress test runs GC, Checkpoint, and SetSync concurrently with bounded completion and accepts only the explicit stale sentinel where applicable.

Existing tests continue to cover coherent basis capture, stale apply rejection, bounded dry-run retry/exhaustion, protected roots, pinned generations, current multi-lane raw-ID retention, CompactStorage behavior, reopen durability, and persistent value-log pointers.

## Validation

Final-head focused correctness:

~~~sh
GOWORK=off go test ./TreeDB/db ./TreeDB -run 'TestValueLogGC_RemovesUnreferencedSegment|TestLeafGenerationGC_(QueuedCheckpointDoesNotGateLaterWrite|LifetimeGateLockOrderStress|DryRunRetriesInvalidatedScan|DryRunRetryExhaustionReturnsStale|CloseWaitsForUnlockedScan|DryRunLiveScanDoesNotBlockForegroundWrite|RevalidationFailureSkipsStalePublish|LiveScanDoesNotBlockForegroundWrite|RetainsCurrentUnreachableLeafLogLaneSegment|RetiresPinnedGenerationUntilSnapshotCloses)|TestCompactStorageSettlesLeafGenerationGC|TestReopenVerify_(WALOn_Checkpoint|WALOn_WriteSync)|TestLeafGenerationGCBenchmarkPercentile|TestLeafGenerationGCStaleSentinel' -count=3
# ok github.com/snissn/gomap/TreeDB/db 8.257s
# ok github.com/snissn/gomap/TreeDB    11.355s
~~~

Final-head focused race:

~~~sh
GOWORK=off go test -race ./TreeDB/db -run 'TestLeafGenerationGC_(QueuedCheckpointDoesNotGateLaterWrite|LifetimeGateLockOrderStress|DryRunRetriesInvalidatedScan|DryRunRetryExhaustionReturnsStale|CloseWaitsForUnlockedScan|DryRunLiveScanDoesNotBlockForegroundWrite|RevalidationFailureSkipsStalePublish|LiveScanDoesNotBlockForegroundWrite|DeletesFullyDeadGeneration|RetiresPinnedGenerationUntilSnapshotCloses)$|TestLeafGenerationGCBenchmarkPercentile' -count=3
# ok github.com/snissn/gomap/TreeDB/db 6.875s
~~~

Full package and static validation ran on <code>ddda6b3c377f65e685ab6eb42754bf5571368ee6</code>; the only later change is the public sentinel comment alignment in <code>deb27092c45772b1e5efea0f933a169429953b0a</code>.

~~~sh
GOWORK=off go test ./TreeDB/db ./TreeDB
# ok github.com/snissn/gomap/TreeDB/db 322.698s
# ok github.com/snissn/gomap/TreeDB     53.262s

GOWORK=off go vet ./TreeDB/db ./TreeDB
git diff --check origin/main...HEAD
~~~

All passed.

## Performance Evidence

Baseline was an isolated detached worktree at exact current base <code>7d210c971ed3df543d9fe00fd5016b5d82cc7c0d</code>, with only the benchmark and timing hooks applied uncommitted. Candidate was <code>ddda6b3c377f65e685ab6eb42754bf5571368ee6</code>; final head differs only by a comment.

Both sides ran sequentially on the same Linux amd64 host:

~~~sh
GOWORK=off go test ./TreeDB/db -run '^$' \
  -bench '^BenchmarkLeafGenerationGC(WriterContention|ExclusivePhases)$' \
  -benchtime=100x -count=5 -benchmem \
  -mutexprofile=/tmp/pl02-3645-{baseline|candidate}-combined-mutex.pprof \
  -mutexprofilefraction=1
~~~

The contention topology pauses the live scan, queues a minimal exclusive <code>writeMu</code> waiter, then launches a later foreground Set. The correctness test uses a real Checkpoint; the benchmark uses the minimal waiter to isolate GC lock topology from checkpoint fsync cost.

Ranges across five runs:

| Metric | Baseline <code>7d210c971</code> | Candidate <code>ddda6b3c3</code> |
| --- | ---: | ---: |
| Idle write p95 | 1.182-1.207 ms | 1.196-1.219 ms |
| Later write p95 | 50.808-50.951 ms | 1.168-1.203 ms |
| Later/idle p95 | 42.22x-43.09x | 0.9764x-1.000x |
| Idle write p99 | 1.225-1.386 ms | 1.222-1.355 ms |
| Later write p99 | 50.908-51.028 ms | 1.199-1.334 ms |
| Later/idle p99 | 36.74x-41.65x | 0.9715x-1.067x |
| Exclusive waiter p95 | 51.917-52.023 ms | 97-109 ns |
| Exclusive waiter p99 | 51.995-52.123 ms | 109-126 ns |
| GC wall p95 | 51.858-51.975 ms | 52.322-52.500 ms |
| GC wall p99 | 51.957-52.063 ms | 52.436-52.723 ms |
| Live scans/op | 1 | 2 |
| Live pages/scan | 5 | 5 |
| Live pages/op | 5 | 10 |
| Exclusive phase max | 0.612-0.710 ms | 0.275-0.320 ms |
| Exclusive phase p99 | 0.307-0.483 ms | 10.279-15.352 us |
| Contention ns/op | 53.041-53.116 ms | 53.233-53.305 ms |
| Contention B/op | 107,230-108,721 | 157,425-158,164 |
| Contention allocs/op | 510-512 | 843-844 |
| Exclusive ns/op | 265,000-277,337 ns | 273,183-284,598 ns |
| Exclusive B/op | 47,758-48,146 | 47,959-48,270 |
| Exclusive allocs/op | 308 | 312 |

Candidate dry runs scan twice because the benchmark write deliberately invalidates attempt one and exercises the bounded retry. The fixed approximately 52 ms wall time confirms the live scan remains active while the later write is no longer gated.

Gate disposition:

- Candidate p95/p99 is at most 1.067x idle: passes the <code>&lt;=2x</code> gate.
- Baseline is 36.74x-43.09x idle while candidate is approximately idle: also exceeds the alternate <code>&gt;=10x</code> baseline-improvement gate.
- Candidate worst observed exclusive phase is 0.320 ms: passes the <code>&lt;50 ms</code> gate.

Mutex evidence from the combined benchmark profiles:

- Baseline: 51.17 s total delay; 51.12 s (99.91%) is in the <code>leafGenerationGC</code> stack, split between Mutex and RWMutex unlock sites.
- Candidate: 944.74 us total process-wide delay.
- Candidate focused with <code>-focus='db\.\(\*DB\)\.leafGenerationGC'</code>: no matching samples.

Artifacts on the benchmark host:

- <code>/tmp/pl02-3645-baseline-combined-mutex.pprof</code>
- <code>/tmp/pl02-3645-candidate-combined-mutex.pprof</code>

## Review and CI State

- Live head/base: <code>deb27092c45772b1e5efea0f933a169429953b0a</code> / <code>7d210c971ed3df543d9fe00fd5016b5d82cc7c0d</code>.
- All 12 live review threads are resolved.
- The blocking lifetime-gate thread has an exact response for <code>ddda6b3c377f65e685ab6eb42754bf5571368ee6</code>.
- The sentinel-doc thread has an exact response for <code>deb27092c45772b1e5efea0f933a169429953b0a</code>.
- The latest substantive Codex artifact predates this final head. No Codex review was requested, per coordinator direction; exact-head AI review remains coordinator-owned.
- At handoff, exact-head GitHub Actions show 22 successful, 3 pending, 1 skipped, and no failures. Per coordinator direction, no further CI wait was performed; remaining new-head CI and Codex review are coordinator-owned.
- No merge is requested or performed.

## Risks

- Sustained publishers can invalidate both dry-run attempts; callers then receive the explicit retryable stale sentinel.
- Manifest persistence and mutation still occur in the exclusive apply phase. The measured maximum is well below the issue gate, but production filesystem latency may differ.
- The controlled scan pause measures lock topology, not production scan duration.

