### PR TITLE
[PL-13] Guard valueLogGC after nil refresh set

### DIFF
--- a/TreeDB/db/vlog_gc.go
+++ b/TreeDB/db/vlog_gc.go
@@ -15,6 +15,12 @@ import (
 // deleting freshly rotated segments that may still back in-memory pointers.
 const valueLogKeepRecentSegmentsPerLane = 2
 
+// valueLogGCPostRefreshCurrentSetNoRefresh is a narrow test seam for the
+// second no-refresh read after the fallback Refresh call.
+var valueLogGCPostRefreshCurrentSetNoRefresh = func(vm *valuelog.Manager) *valuelog.Set {
+	return vm.CurrentSetNoRefresh()
+}
+
 // ValueLogGCOptions controls value-log garbage collection.
 type ValueLogGCOptions struct {
 	DryRun bool
@@ -155,7 +161,16 @@ func (db *DB) valueLogGC(ctx context.Context, opts ValueLogGCOptions, lockMainte
 		if err := vm.Refresh(); err != nil {
 			return stats, err
 		}
-		set = vm.CurrentSetNoRefresh()
+		set = valueLogGCPostRefreshCurrentSetNoRefresh(vm)
+	}
+	if set == nil || len(set.Files) == 0 {
+		if set != nil {
+			_ = vm.Release(set)
+		}
+		if !opts.DryRun && !db.readOnly {
+			db.persistValueLogRefTrackerBestEffort()
+		}
+		return stats, nil
 	}
 	files := db.valueOnlyValueLogFiles(set.Files)
 	if len(files) == 0 {

--- a/TreeDB/db/vlog_gc_test.go
+++ b/TreeDB/db/vlog_gc_test.go
@@ -35,7 +35,7 @@ func TestValueLogGC_EmptySet_NoValueLogSegments(t *testing.T) {
 func TestValueLogGC_PostRefreshNilSetReturnsEmptyStats(t *testing.T) {
 	dir := t.TempDir()
 
-	db, err := Open(Options{Dir: dir})
+	db, err := Open(Options{Dir: dir, DisableBackgroundPrune: true})
 	if err != nil {
 		t.Fatalf("open: %v", err)
 	}

--- a/TreeDB/db/vlog_gc_test.go
+++ b/TreeDB/db/vlog_gc_test.go
@@ -32,6 +32,43 @@ func TestValueLogGC_EmptySet_NoValueLogSegments(t *testing.T) {
 	}
 }
 
+func TestValueLogGC_PostRefreshNilSetReturnsEmptyStats(t *testing.T) {
+	dir := t.TempDir()
+
+	db, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	origPostRefreshCurrentSet := valueLogGCPostRefreshCurrentSetNoRefresh
+	calls := 0
+	valueLogGCPostRefreshCurrentSetNoRefresh = func(vm *valuelog.Manager) *valuelog.Set {
+		calls++
+		return nil
+	}
+	defer func() { valueLogGCPostRefreshCurrentSetNoRefresh = origPostRefreshCurrentSet }()
+
+	stats, err := db.ValueLogGC(context.Background(), ValueLogGCOptions{})
+	if err != nil {
+		t.Fatalf("ValueLogGC: %v", err)
+	}
+	if stats != (ValueLogGCStats{}) {
+		t.Fatalf("expected zero stats for nil post-refresh value-log set, got %+v", stats)
+	}
+	if calls != 1 {
+		t.Fatalf("post-refresh current-set hook calls=%d want 1", calls)
+	}
+
+	segments, err := filepath.Glob(filepath.Join(ValueLogDirPath(dir), "*.log"))
+	if err != nil {
+		t.Fatalf("glob value-log segments: %v", err)
+	}
+	if len(segments) != 0 {
+		t.Fatalf("nil-set GC path created or retained unexpected value-log segments: %v", segments)
+	}
+}
+
 func TestValueLogRefTracker_DisabledForOuterLeavesSkipsStaleMetadata(t *testing.T) {
 	dir := t.TempDir()
 	stale := []byte("stale ref-count metadata from an older build")


### PR DESCRIPTION
## Objective

Fixes #3631. Part of parent tracker #3630.

Make `DB.valueLogGC` return zero `ValueLogGCStats` and nil error when the value-log manager still has no usable current set after the refresh fallback, instead of dereferencing a nil set.

## Scope

- Includes:
  - `TreeDB/db/vlog_gc.go`: add the post-refresh nil/empty-set guard before `set.Files` is read.
  - `TreeDB/db/vlog_gc_test.go`: add deterministic regression coverage for a nil post-refresh set.
- Excludes:
  - No value-log deletion eligibility changes.
  - No segment age-based deletion/truncation behavior.
  - No scanner, tracker, rewrite, or GC refactor.
  - No on-disk format or public API changes.

## Correctness / Safety

- The new guard releases a non-nil empty set before returning.
- For writable non-dry-run GC, the guard preserves the existing empty-file branch behavior by calling `persistValueLogRefTrackerBestEffort()` before returning.
- The nil/empty branch returns before candidate classification, mark-zombie, publish, or removal work.
- Regression test uses a narrow post-refresh current-set seam to force the second read to return nil.

## Tests run

Latest local head: `1c2c4ba6caeb77c976d4b2d9fd70551c081f8dac`.

```sh
GOWORK=off go test ./TreeDB/db -run 'TestValueLogGC_(PostRefreshNilSetReturnsEmptyStats|EmptySet_NoValueLogSegments|RemovesUnreferencedSegment)|TestValueLogGC_KeepsSegment' -count=1
GOWORK=off go test ./TreeDB/db -count=1
GOWORK=off go test ./TreeDB ./TreeDB/freelist -count=1
```

## CI / Review status

- Latest-head CI for `1c2c4ba6caeb77c976d4b2d9fd70551c081f8dac`: all GitHub checks passing.
- Codex: reviewed commit `1c2c4ba6ca`; no major issues found.
- CodeRabbit: auto-triggered by repo integration but rate-limited; no actionable findings. Not manually requested.
- Copilot: not requested.

## Performance

Guard-only correctness fix. No benchmark was run and this PR makes no performance claim beyond avoiding a maintenance crash. The added runtime check is only on the empty/no-current-set refresh fallback path.

## Risk

Low. The change is limited to returning through the existing empty-stats path when no refreshed value-log set is available; persistent value-log pointer and deletion semantics are unchanged.
