### PR TITLE
[PL-05] Make background vacuum trigger cheap on unchanged commits

### DIFF
--- a/TreeDB/background_vacuum_test.go
+++ b/TreeDB/background_vacuum_test.go
@@ -6,7 +6,175 @@ import (
 	"strconv"
 	"testing"
 	"time"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
 )
+
+func TestBackgroundIndexVacuumIdleUnchangedCommitSkipsStructuralWalks(t *testing.T) {
+	dir := t.TempDir()
+
+	d, err := Open(Options{
+		Dir:                           dir,
+		KeepRecent:                    1,
+		BackgroundIndexVacuumInterval: -1,
+	})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer d.Close()
+
+	for i := 0; i < 128; i++ {
+		key := []byte(fmt.Sprintf("idle-k%04d", i))
+		if err := d.Set(key, []byte("value")); err != nil {
+			t.Fatalf("set: %v", err)
+		}
+	}
+	if err := d.Checkpoint(); err != nil {
+		t.Fatalf("checkpoint: %v", err)
+	}
+
+	expected, err := d.backend.IndexVacuumTriggerReport()
+	if err != nil {
+		t.Fatalf("trigger report: %v", err)
+	}
+	d.bgVac.spanRatioPPM = ^uint32(0)
+	d.bgVac.runOnce(d)
+	if got := d.bgVac.lastPages.Load(); got != expected.UserPages {
+		t.Fatalf("first probe lastPages=%d want %d", got, expected.UserPages)
+	}
+	if got := d.bgVac.lastSpanRatio.Load(); got != expected.UserSpanRatioPPM {
+		t.Fatalf("first probe lastSpanRatio=%d want %d", got, expected.UserSpanRatioPPM)
+	}
+
+	counts, restore := installBackgroundVacuumProbeCounter()
+	defer restore()
+
+	d.bgVac.runOnce(d)
+	assertNoBackgroundVacuumStructuralWalks(t, counts)
+
+	allocs := testing.AllocsPerRun(100, func() {
+		d.bgVac.runOnce(d)
+	})
+	if allocs > 1 {
+		t.Fatalf("unchanged CommitSeq tick allocations = %.2f, want <= 1", allocs)
+	}
+	assertNoBackgroundVacuumStructuralWalks(t, counts)
+}
+
+func TestBackgroundIndexVacuumChangedCommitUsesCheapTrigger(t *testing.T) {
+	dir := t.TempDir()
+
+	d, err := Open(Options{
+		Dir:                           dir,
+		KeepRecent:                    1,
+		BackgroundIndexVacuumInterval: -1,
+	})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer d.Close()
+
+	for i := 0; i < 128; i++ {
+		key := []byte(fmt.Sprintf("changed-k%04d", i))
+		if err := d.Set(key, []byte("value")); err != nil {
+			t.Fatalf("set: %v", err)
+		}
+	}
+	if err := d.Checkpoint(); err != nil {
+		t.Fatalf("checkpoint: %v", err)
+	}
+
+	d.bgVac.spanRatioPPM = ^uint32(0)
+	d.bgVac.runOnce(d)
+	firstProbeSeq := d.bgVac.lastProbeCommitSeq
+	if firstProbeSeq == 0 {
+		t.Fatalf("first probe did not record commit seq")
+	}
+
+	if err := d.Set([]byte("changed-new-key"), []byte("value")); err != nil {
+		t.Fatalf("set changed: %v", err)
+	}
+	if err := d.Checkpoint(); err != nil {
+		t.Fatalf("checkpoint changed: %v", err)
+	}
+	state := d.backend.State()
+	if state == nil {
+		t.Fatalf("missing backend state")
+	}
+	if state.CommitSeq == firstProbeSeq {
+		t.Fatalf("write did not advance CommitSeq: %d", state.CommitSeq)
+	}
+
+	expected, err := d.backend.IndexVacuumTriggerReport()
+	if err != nil {
+		t.Fatalf("trigger report after change: %v", err)
+	}
+	counts, restore := installBackgroundVacuumProbeCounter()
+	defer restore()
+
+	d.bgVac.runOnce(d)
+
+	if got := counts[backenddb.FragmentationProbeEventTriggerReport]; got != 1 {
+		t.Fatalf("trigger report calls=%d want 1", got)
+	}
+	if got := counts[backenddb.FragmentationProbeEventTriggerUserTreeWalk]; got != 1 {
+		t.Fatalf("trigger user-tree walks=%d want 1", got)
+	}
+	if got := counts[backenddb.FragmentationProbeEventTriggerFreelistCounters]; got != 1 {
+		t.Fatalf("trigger freelist counter reads=%d want 1", got)
+	}
+	if got := d.bgVac.lastPages.Load(); got != expected.UserPages {
+		t.Fatalf("lastPages=%d want %d", got, expected.UserPages)
+	}
+	if got := d.bgVac.lastSpanRatio.Load(); got != expected.UserSpanRatioPPM {
+		t.Fatalf("lastSpanRatio=%d want %d", got, expected.UserSpanRatioPPM)
+	}
+	if got := d.bgVac.lastProbeCommitSeq; got != expected.CommitSeq {
+		t.Fatalf("lastProbeCommitSeq=%d want %d", got, expected.CommitSeq)
+	}
+	if d.bgVac.retryProbe {
+		t.Fatalf("retryProbe left set after successful changed-state trigger")
+	}
+	assertNoBackgroundVacuumFullFragmentationWalks(t, counts)
+}
+
+func installBackgroundVacuumProbeCounter() (map[backenddb.FragmentationProbeEvent]int, func()) {
+	counts := make(map[backenddb.FragmentationProbeEvent]int)
+	restore := backenddb.SetFragmentationProbeHookForTest(func(event backenddb.FragmentationProbeEvent) {
+		counts[event]++
+	})
+	return counts, restore
+}
+
+func assertNoBackgroundVacuumStructuralWalks(t *testing.T, counts map[backenddb.FragmentationProbeEvent]int) {
+	t.Helper()
+	if got := counts[backenddb.FragmentationProbeEventTriggerReport]; got != 0 {
+		t.Fatalf("cheap trigger reports=%d want 0", got)
+	}
+	if got := counts[backenddb.FragmentationProbeEventTriggerUserTreeWalk]; got != 0 {
+		t.Fatalf("cheap trigger user-tree walks=%d want 0", got)
+	}
+	if got := counts[backenddb.FragmentationProbeEventTriggerFreelistCounters]; got != 0 {
+		t.Fatalf("cheap trigger freelist counter reads=%d want 0", got)
+	}
+	assertNoBackgroundVacuumFullFragmentationWalks(t, counts)
+}
+
+func assertNoBackgroundVacuumFullFragmentationWalks(t *testing.T, counts map[backenddb.FragmentationProbeEvent]int) {
+	t.Helper()
+	if got := counts[backenddb.FragmentationProbeEventFullReport]; got != 0 {
+		t.Fatalf("full fragmentation reports=%d want 0", got)
+	}
+	if got := counts[backenddb.FragmentationProbeEventFullUserTreeWalk]; got != 0 {
+		t.Fatalf("full user-tree walks=%d want 0", got)
+	}
+	if got := counts[backenddb.FragmentationProbeEventFullFreelistChainWalk]; got != 0 {
+		t.Fatalf("full freelist-chain walks=%d want 0", got)
+	}
+	if got := counts[backenddb.FragmentationProbeEventFullCollectionRootWalk]; got != 0 {
+		t.Fatalf("full collection-root walks=%d want 0", got)
+	}
+}
 
 func TestBackgroundIndexVacuumRunsAndStops(t *testing.T) {
 	if runtime.GOOS == "windows" {

--- a/TreeDB/bg_vacuum.go
+++ b/TreeDB/bg_vacuum.go
@@ -2,9 +2,7 @@ package treedb
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -31,6 +29,10 @@ type bgIndexVacuumWorker struct {
 	lastSpanRatio  atomic.Uint64
 	lastPages      atomic.Uint64
 	lastErr        atomic.Value // string
+
+	lastProbeCommitSeq uint64
+	lastProbeValid     bool
+	retryProbe         bool
 }
 
 // Start launches the background index vacuum loop with the provided interval.
@@ -107,9 +109,21 @@ func (w *bgIndexVacuumWorker) runOnce(db *DB) {
 	defer w.runMu.Unlock()
 
 	now := time.Now()
+	state := db.backend.State()
+	if state == nil || db.backend.IsClosing() {
+		return
+	}
+
+	if w.lastProbeValid && !w.retryProbe && state.CommitSeq == w.lastProbeCommitSeq {
+		w.runs.Add(1)
+		w.lastRunUnix.Store(now.Unix())
+		w.lastErr.Store("")
+		return
+	}
 
 	// Avoid competing with the flush path. If there's any queued backlog, let the
-	// caching layer catch up first.
+	// caching layer catch up first. This is not a completed trigger probe, so keep
+	// lastProbeCommitSeq unchanged.
 	if db.cached != nil {
 		if db.cached.QueueBacklogBytes() > 0 {
 			w.runs.Add(1)
@@ -119,8 +133,9 @@ func (w *bgIndexVacuumWorker) runOnce(db *DB) {
 		}
 	}
 
-	rep, err := db.backend.FragmentationReport()
+	rep, err := db.backend.IndexVacuumTriggerReport()
 	if err != nil {
+		w.retryProbe = true
 		w.runs.Add(1)
 		w.lastRunUnix.Store(now.Unix())
 		w.lastErr.Store(err.Error())
@@ -128,25 +143,11 @@ func (w *bgIndexVacuumWorker) runOnce(db *DB) {
 		return
 	}
 
-	pagesStr := rep["treedb.user.pages"]
-	if pagesStr == "" {
-		w.runs.Add(1)
-		w.lastRunUnix.Store(now.Unix())
-		msg := "fragmentation report missing treedb.user.pages"
-		w.lastErr.Store(msg)
-		db.reportError(errors.New(msg))
-		return
-	}
-	pages, err := strconv.ParseUint(pagesStr, 10, 64)
-	if err != nil {
-		w.runs.Add(1)
-		w.lastRunUnix.Store(now.Unix())
-		w.lastErr.Store(fmt.Sprintf("parse treedb.user.pages: %v", err))
-		db.reportError(fmt.Errorf("parse treedb.user.pages: %w", err))
-		return
-	}
-	w.lastPages.Store(pages)
-	if pages == 0 {
+	w.lastProbeCommitSeq = rep.CommitSeq
+	w.lastProbeValid = true
+	w.lastPages.Store(rep.UserPages)
+	if rep.UserPages == 0 {
+		w.retryProbe = false
 		w.lastSpanRatio.Store(0)
 		w.runs.Add(1)
 		w.lastRunUnix.Store(now.Unix())
@@ -154,26 +155,11 @@ func (w *bgIndexVacuumWorker) runOnce(db *DB) {
 		return
 	}
 
-	spanStr := rep["treedb.user.pages.span_ratio_ppm"]
-	if spanStr == "" {
-		w.runs.Add(1)
-		w.lastRunUnix.Store(now.Unix())
-		msg := "fragmentation report missing treedb.user.pages.span_ratio_ppm"
-		w.lastErr.Store(msg)
-		db.reportError(errors.New(msg))
-		return
-	}
-	spanRatio, err := strconv.ParseUint(spanStr, 10, 64)
-	if err != nil {
-		w.runs.Add(1)
-		w.lastRunUnix.Store(now.Unix())
-		w.lastErr.Store(fmt.Sprintf("parse treedb.user.pages.span_ratio_ppm: %v", err))
-		db.reportError(fmt.Errorf("parse treedb.user.pages.span_ratio_ppm: %w", err))
-		return
-	}
+	spanRatio := rep.UserSpanRatioPPM
 	w.lastSpanRatio.Store(spanRatio)
 
 	if spanRatio < uint64(w.spanRatioPPM) {
+		w.retryProbe = false
 		w.runs.Add(1)
 		w.lastRunUnix.Store(now.Unix())
 		w.lastErr.Store("")
@@ -181,6 +167,7 @@ func (w *bgIndexVacuumWorker) runOnce(db *DB) {
 	}
 
 	if err := db.VacuumIndexOnline(context.Background()); err != nil {
+		w.retryProbe = true
 		w.runs.Add(1)
 		w.lastRunUnix.Store(now.Unix())
 		w.lastErr.Store(err.Error())
@@ -188,6 +175,7 @@ func (w *bgIndexVacuumWorker) runOnce(db *DB) {
 		return
 	}
 
+	w.retryProbe = false
 	w.vacuums.Add(1)
 	w.runs.Add(1)
 	w.lastRunUnix.Store(now.Unix())

--- a/TreeDB/db/fragmentation.go
+++ b/TreeDB/db/fragmentation.go
@@ -3,15 +3,142 @@ package db
 import (
 	"fmt"
 	"sort"
+	"sync"
 
 	"github.com/snissn/gomap/TreeDB/node"
 	"github.com/snissn/gomap/TreeDB/page"
 	"github.com/snissn/gomap/TreeDB/tree"
 )
 
+// FragmentationProbeEvent identifies structural maintenance probe phases for
+// deterministic tests. These events are intentionally coarse: the cheap index
+// vacuum trigger may walk the user index, but must not use the full freelist
+// chain or collection-root walks that FragmentationReport performs.
+type FragmentationProbeEvent string
+
+const (
+	FragmentationProbeEventFullReport              FragmentationProbeEvent = "full_report"
+	FragmentationProbeEventFullUserTreeWalk        FragmentationProbeEvent = "full_user_tree_walk"
+	FragmentationProbeEventFullFreelistChainWalk   FragmentationProbeEvent = "full_freelist_chain_walk"
+	FragmentationProbeEventFullCollectionRootWalk  FragmentationProbeEvent = "full_collection_root_walk"
+	FragmentationProbeEventTriggerReport           FragmentationProbeEvent = "index_vacuum_trigger_report"
+	FragmentationProbeEventTriggerUserTreeWalk     FragmentationProbeEvent = "index_vacuum_trigger_user_tree_walk"
+	FragmentationProbeEventTriggerFreelistCounters FragmentationProbeEvent = "index_vacuum_trigger_freelist_counters"
+)
+
+var fragmentationProbeHook struct {
+	mu sync.RWMutex
+	fn func(FragmentationProbeEvent)
+}
+
+// SetFragmentationProbeHookForTest installs a process-wide fragmentation probe
+// hook and returns a restore function. It is intended for deterministic tests;
+// callers must serialize installation and should not use it in production code.
+func SetFragmentationProbeHookForTest(fn func(FragmentationProbeEvent)) func() {
+	fragmentationProbeHook.mu.Lock()
+	prev := fragmentationProbeHook.fn
+	fragmentationProbeHook.fn = fn
+	fragmentationProbeHook.mu.Unlock()
+	return func() {
+		fragmentationProbeHook.mu.Lock()
+		fragmentationProbeHook.fn = prev
+		fragmentationProbeHook.mu.Unlock()
+	}
+}
+
+func emitFragmentationProbeEvent(event FragmentationProbeEvent) {
+	fragmentationProbeHook.mu.RLock()
+	fn := fragmentationProbeHook.fn
+	fragmentationProbeHook.mu.RUnlock()
+	if fn != nil {
+		fn(event)
+	}
+}
+
+// IndexVacuumTriggerReport is the cheap subset of FragmentationReport used by
+// automatic index-vacuum trigger decisions.
+//
+// Contract for background maintenance callers:
+//   - CommitSeq is the snapshot state used for this report.
+//   - User* fields are computed by one user-index page walk and preserve the
+//     treedb.user.pages.span_ratio_ppm semantics from FragmentationReport.
+//   - Freelist* fields come from allocator.Counters(); they are cheap in-memory
+//     counters and intentionally do not include reclaimable page counts or a
+//     reclaimable ratio, both of which require walking the on-disk freelist chain.
+//   - Collection roots are intentionally not inspected.
+type IndexVacuumTriggerReport struct {
+	CommitSeq uint64
+
+	UserPages        uint64
+	UserMinPageID    uint64
+	UserMaxPageID    uint64
+	UserSpan         uint64
+	UserSpanRatioPPM uint64
+
+	FreelistHead                  uint64
+	FreelistAllocPagesTotal       uint64
+	FreelistAppendAllocPagesTotal uint64
+	FreelistReuseAllocPagesTotal  uint64
+	FreelistFreePagesTotal        uint64
+}
+
+// IndexVacuumTriggerReport returns the cheap trigger report for automatic index
+// vacuum. Unlike FragmentationReport, it avoids fill-percentile allocation,
+// freelist-chain stats, and collection-root scans.
+func (db *DB) IndexVacuumTriggerReport() (IndexVacuumTriggerReport, error) {
+	emitFragmentationProbeEvent(FragmentationProbeEventTriggerReport)
+
+	snap := db.AcquireSnapshot()
+	if snap == nil || snap.idx == nil || snap.state == nil {
+		if snap != nil {
+			_ = snap.Close()
+		}
+		return IndexVacuumTriggerReport{}, fmt.Errorf("missing index")
+	}
+	defer func() { _ = snap.Close() }()
+
+	out := IndexVacuumTriggerReport{CommitSeq: snap.state.CommitSeq}
+
+	emitFragmentationProbeEvent(FragmentationProbeEventTriggerUserTreeWalk)
+	err := snap.tree.WalkPages(func(pageID uint64, _ node.Node) error {
+		if out.UserPages == 0 {
+			out.UserMinPageID = pageID
+			out.UserMaxPageID = pageID
+		} else {
+			if pageID < out.UserMinPageID {
+				out.UserMinPageID = pageID
+			}
+			if pageID > out.UserMaxPageID {
+				out.UserMaxPageID = pageID
+			}
+		}
+		out.UserPages++
+		return nil
+	})
+	if err != nil {
+		return out, err
+	}
+	if out.UserPages > 0 {
+		out.UserSpan = (out.UserMaxPageID - out.UserMinPageID) + 1
+		out.UserSpanRatioPPM = (out.UserSpan * 1_000_000) / out.UserPages
+	}
+
+	if snap.idx.allocator != nil {
+		emitFragmentationProbeEvent(FragmentationProbeEventTriggerFreelistCounters)
+		fs := snap.idx.allocator.Counters()
+		out.FreelistHead = fs.Head
+		out.FreelistAllocPagesTotal = fs.AllocPages
+		out.FreelistAppendAllocPagesTotal = fs.AppendAllocPages
+		out.FreelistReuseAllocPagesTotal = fs.ReuseAllocPages
+		out.FreelistFreePagesTotal = fs.FreePages
+	}
+	return out, nil
+}
+
 // FragmentationReport returns best-effort structural stats about the user index
 // that help diagnose scan regressions after churn.
 func (db *DB) FragmentationReport() (map[string]string, error) {
+	emitFragmentationProbeEvent(FragmentationProbeEventFullReport)
 	snap := db.AcquireSnapshot()
 	if snap == nil || snap.idx == nil || snap.state == nil {
 		if snap != nil {
@@ -37,6 +164,7 @@ func (db *DB) FragmentationReport() (map[string]string, error) {
 	var leafFillPPM []uint32
 	var internalFillPPM []uint32
 
+	emitFragmentationProbeEvent(FragmentationProbeEventFullUserTreeWalk)
 	err := tr.WalkPages(func(pageID uint64, n node.Node) error {
 		if pages == 0 {
 			minID = pageID
@@ -105,6 +233,7 @@ func (db *DB) FragmentationReport() (map[string]string, error) {
 		out["treedb.user.internal_fill_ppm_max"] = fmt.Sprintf("%d", p.max)
 	}
 
+	emitFragmentationProbeEvent(FragmentationProbeEventFullFreelistChainWalk)
 	fs, err := idx.allocator.Stats(totalPages)
 	out["treedb.freelist.head"] = fmt.Sprintf("%d", fs.Head)
 	out["treedb.freelist.alloc_pages_total"] = fmt.Sprintf("%d", fs.AllocPages)
@@ -128,6 +257,7 @@ func (db *DB) FragmentationReport() (map[string]string, error) {
 	out["treedb.graveyard.min_seq"] = fmt.Sprintf("%d", graveyard.MinSeq)
 	out["treedb.graveyard.max_seq"] = fmt.Sprintf("%d", graveyard.MaxSeq)
 
+	emitFragmentationProbeEvent(FragmentationProbeEventFullCollectionRootWalk)
 	if collection, err := collectionRootFragmentationStats(idx, snap.state); err != nil {
 		out["treedb.collection_roots.error"] = err.Error()
 	} else {

--- a/TreeDB/db/fragmentation_trigger_test.go
+++ b/TreeDB/db/fragmentation_trigger_test.go
@@ -1,0 +1,171 @@
+package db
+
+import (
+	"bytes"
+	"fmt"
+	"strconv"
+	"testing"
+)
+
+func TestIndexVacuumTriggerReportMatchesFragmentationSpan(t *testing.T) {
+	d := openFragmentationTriggerFixture(t)
+
+	compareTriggerToFullFragmentationReport(t, d, "initial")
+
+	for i := 0; i < 512; i++ {
+		key := []byte(fmt.Sprintf("churn-%04d", i))
+		if err := d.Set(key, bytes.Repeat([]byte{byte(i)}, 32)); err != nil {
+			t.Fatalf("set churn: %v", err)
+		}
+	}
+	for i := 0; i < 512; i += 2 {
+		key := []byte(fmt.Sprintf("churn-%04d", i))
+		if err := d.Delete(key); err != nil {
+			t.Fatalf("delete churn: %v", err)
+		}
+	}
+	for i := 0; i < 512; i += 2 {
+		key := []byte(fmt.Sprintf("churn-%04d", i))
+		if err := d.Set(key, bytes.Repeat([]byte("z"), 32)); err != nil {
+			t.Fatalf("set churn2: %v", err)
+		}
+	}
+
+	compareTriggerToFullFragmentationReport(t, d, "after churn")
+}
+
+func compareTriggerToFullFragmentationReport(t *testing.T, d *DB, label string) {
+	t.Helper()
+
+	full, err := d.FragmentationReport()
+	if err != nil {
+		t.Fatalf("%s FragmentationReport: %v", label, err)
+	}
+
+	counts := make(map[FragmentationProbeEvent]int)
+	restore := SetFragmentationProbeHookForTest(func(event FragmentationProbeEvent) {
+		counts[event]++
+	})
+	trigger, err := d.IndexVacuumTriggerReport()
+	restore()
+	if err != nil {
+		t.Fatalf("%s IndexVacuumTriggerReport: %v", label, err)
+	}
+
+	if got := counts[FragmentationProbeEventTriggerReport]; got != 1 {
+		t.Fatalf("%s trigger reports=%d want 1", label, got)
+	}
+	if got := counts[FragmentationProbeEventTriggerUserTreeWalk]; got != 1 {
+		t.Fatalf("%s trigger user-tree walks=%d want 1", label, got)
+	}
+	if got := counts[FragmentationProbeEventTriggerFreelistCounters]; got != 1 {
+		t.Fatalf("%s trigger freelist counter reads=%d want 1", label, got)
+	}
+	if got := counts[FragmentationProbeEventFullReport]; got != 0 {
+		t.Fatalf("%s full fragmentation reports during trigger=%d want 0", label, got)
+	}
+	if got := counts[FragmentationProbeEventFullUserTreeWalk]; got != 0 {
+		t.Fatalf("%s full user-tree walks during trigger=%d want 0", label, got)
+	}
+	if got := counts[FragmentationProbeEventFullFreelistChainWalk]; got != 0 {
+		t.Fatalf("%s full freelist-chain walks during trigger=%d want 0", label, got)
+	}
+	if got := counts[FragmentationProbeEventFullCollectionRootWalk]; got != 0 {
+		t.Fatalf("%s full collection-root walks during trigger=%d want 0", label, got)
+	}
+
+	state := d.State()
+	if state == nil {
+		t.Fatalf("%s missing state", label)
+	}
+	if trigger.CommitSeq != state.CommitSeq {
+		t.Fatalf("%s CommitSeq=%d want %d", label, trigger.CommitSeq, state.CommitSeq)
+	}
+
+	assertTriggerFieldMatchesFullReport(t, label, "treedb.user.pages", trigger.UserPages, full)
+	if trigger.UserPages > 0 {
+		assertTriggerFieldMatchesFullReport(t, label, "treedb.user.pages.min", trigger.UserMinPageID, full)
+		assertTriggerFieldMatchesFullReport(t, label, "treedb.user.pages.max", trigger.UserMaxPageID, full)
+		assertTriggerFieldMatchesFullReport(t, label, "treedb.user.pages.span", trigger.UserSpan, full)
+		assertTriggerFieldMatchesFullReport(t, label, "treedb.user.pages.span_ratio_ppm", trigger.UserSpanRatioPPM, full)
+	}
+
+	idx := d.idx.Load()
+	if idx == nil || idx.allocator == nil {
+		t.Fatalf("%s missing allocator", label)
+	}
+	counters := idx.allocator.Counters()
+	if trigger.FreelistHead != counters.Head ||
+		trigger.FreelistAllocPagesTotal != counters.AllocPages ||
+		trigger.FreelistAppendAllocPagesTotal != counters.AppendAllocPages ||
+		trigger.FreelistReuseAllocPagesTotal != counters.ReuseAllocPages ||
+		trigger.FreelistFreePagesTotal != counters.FreePages {
+		t.Fatalf("%s freelist counters mismatch: trigger={head:%d alloc:%d append:%d reuse:%d free:%d} counters={head:%d alloc:%d append:%d reuse:%d free:%d}",
+			label,
+			trigger.FreelistHead, trigger.FreelistAllocPagesTotal, trigger.FreelistAppendAllocPagesTotal, trigger.FreelistReuseAllocPagesTotal, trigger.FreelistFreePagesTotal,
+			counters.Head, counters.AllocPages, counters.AppendAllocPages, counters.ReuseAllocPages, counters.FreePages)
+	}
+}
+
+func assertTriggerFieldMatchesFullReport(t *testing.T, label, key string, got uint64, full map[string]string) {
+	t.Helper()
+	want, err := strconv.ParseUint(full[key], 10, 64)
+	if err != nil {
+		t.Fatalf("%s parse %s=%q: %v", label, key, full[key], err)
+	}
+	if got != want {
+		t.Fatalf("%s %s=%d want %d", label, key, got, want)
+	}
+}
+
+func BenchmarkBackgroundIndexVacuumTrigger(b *testing.B) {
+	d := openFragmentationTriggerFixture(b)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := d.IndexVacuumTriggerReport(); err != nil {
+			b.Fatalf("IndexVacuumTriggerReport: %v", err)
+		}
+	}
+}
+
+func BenchmarkFragmentationReport(b *testing.B) {
+	d := openFragmentationTriggerFixture(b)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := d.FragmentationReport(); err != nil {
+			b.Fatalf("FragmentationReport: %v", err)
+		}
+	}
+}
+
+func openFragmentationTriggerFixture(tb testing.TB) *DB {
+	tb.Helper()
+	d, err := Open(Options{Dir: tb.TempDir(), KeepRecent: 1})
+	if err != nil {
+		tb.Fatalf("open: %v", err)
+	}
+	tb.Cleanup(func() { _ = d.Close() })
+
+	value := bytes.Repeat([]byte("v"), 64)
+	for i := 0; i < 2048; i++ {
+		key := []byte(fmt.Sprintf("bench-%04d", i))
+		if err := d.Set(key, value); err != nil {
+			tb.Fatalf("set fixture: %v", err)
+		}
+	}
+	for i := 0; i < 2048; i += 3 {
+		key := []byte(fmt.Sprintf("bench-%04d", i))
+		if err := d.Delete(key); err != nil {
+			tb.Fatalf("delete fixture: %v", err)
+		}
+	}
+	for i := 0; i < 2048; i += 5 {
+		key := []byte(fmt.Sprintf("bench-%04d", i))
+		if err := d.Set(key, bytes.Repeat([]byte("w"), 64)); err != nil {
+			tb.Fatalf("set fixture2: %v", err)
+		}
+	}
+	return d
+}


### PR DESCRIPTION
## Objective

Fixes #3632. Part of #3630 (PL-05): make background index-vacuum ticks cheap when the backend `CommitSeq` has not changed since the last completed probe.

## Context

Before this PR, every background vacuum tick called full `FragmentationReport()`, which walks the user index, the on-disk freelist chain, and collection roots. Idle cached DBs with an unchanged durable backend state should not repeat those structural walks.

Base: `origin/main` / `2182e84bd668f6ea610726717d90e09a86a17a32`.

## Design / Trigger contract

- `bgIndexVacuumWorker` now records the last completed probe `CommitSeq`.
- At the start of `runOnce`, it cheaply reads `db.backend.State()` and returns after normal run bookkeeping when:
  - the state is present/open;
  - `CommitSeq` equals the last completed probe; and
  - no prior probe/vacuum error requires retry.
- Changed states use `db.IndexVacuumTriggerReport()` instead of full `FragmentationReport()`.
- `IndexVacuumTriggerReport` contract for PL-12 consumers:
  - fields: `CommitSeq`, `UserPages`, `UserMinPageID`, `UserMaxPageID`, `UserSpan`, `UserSpanRatioPPM`, and cheap freelist allocation/free counters from `allocator.Counters()`;
  - preserves the `treedb.user.pages.span_ratio_ppm` decision semantics;
  - performs one user-index page walk for changed states;
  - does **not** walk the freelist chain, does **not** compute reclaimable ratio, and does **not** scan collection roots.
- Full `FragmentationReport()` output and explicit validation behavior are unchanged.

## Non-goals

- No changes to online vacuum rewrite/cutover behavior.
- No freelist-debt or collection-root trigger semantics; #3633 owns widening the skip key if PL-12 needs freelist changes that occur without `CommitSeq` bumps.
- No on-disk format or public Stats key removal.

## Scope

- Includes: `TreeDB/bg_vacuum.go`, `TreeDB/db/fragmentation.go`, deterministic tests/hooks, trigger benchmarks.
- Excludes: vacuum rewrite/cutover, backlog-starvation policy, non-user-tree triggers.

## Correctness / scan-count evidence

New deterministic hook tests:

- `TestBackgroundIndexVacuumIdleUnchangedCommitSkipsStructuralWalks`
  - runs two `runOnce` ticks after a completed probe on a cached DB with unchanged `CommitSeq`;
  - asserts the unchanged tick performs **0** full reports, **0** cheap trigger reports, **0** user-tree walks, **0** freelist-chain walks, and **0** collection-root walks;
  - also asserts unchanged ticks allocate `<= 1` alloc/run across `testing.AllocsPerRun(100, ...)`.
- `TestBackgroundIndexVacuumChangedCommitUsesCheapTrigger`
  - after a write/checkpoint bumps `CommitSeq`, the next tick performs exactly **1** cheap trigger report, **1** user-tree walk, **1** cheap freelist counter read, and **0** full-report/freelist-chain/collection-root walks;
  - verifies `lastPages`, `lastSpanRatio`, and `lastProbeCommitSeq` match the trigger report.
- `TestIndexVacuumTriggerReportMatchesFragmentationSpan`
  - compares cheap trigger fields to full `FragmentationReport()` user-page span fields before/after churn;
  - verifies trigger path does not call full fragmentation/freelist-chain/collection-root phases.

## Tests run

```sh
GOWORK=off go test ./TreeDB ./TreeDB/db -run 'TestBackgroundIndexVacuum|TestValidateFragmentationReport|TestFragmentationReport' -count=1
# ok github.com/snissn/gomap/TreeDB    0.417s
# ok github.com/snissn/gomap/TreeDB/db 44.177s

GOWORK=off go test ./TreeDB ./TreeDB/db -run 'TestBackgroundIndexVacuum|TestIndexVacuumTriggerReport|TestValidateFragmentationReport|TestFragmentationReport' -count=1
# ok github.com/snissn/gomap/TreeDB    0.450s
# ok github.com/snissn/gomap/TreeDB/db 48.744s

GOWORK=off go test ./TreeDB ./TreeDB/db -count=1
# ok github.com/snissn/gomap/TreeDB    60.546s
# ok github.com/snissn/gomap/TreeDB/db 304.118s
```

Logs saved under `/tmp/gomap-graph-3630/`.

## Performance

Command:

```sh
GOWORK=off go test ./TreeDB/db -run '^$' -bench 'BenchmarkBackgroundIndexVacuumTrigger|BenchmarkFragmentationReport' -benchmem -count=5
```

Machine: linux/amd64, Intel i5-11400F.

| Benchmark | median ns/op | ops/sec | median B/op | median allocs/op |
| --- | ---: | ---: | ---: | ---: |
| `BenchmarkBackgroundIndexVacuumTrigger` | 8,118 | 123,183 | 37,988 | 6 |
| `BenchmarkFragmentationReport` | 20,867 | 47,923 | 47,401 | 78 |

Idle unchanged ticks are gated by deterministic hook/allocation tests rather than benchmark timing: they short-circuit before any report or structural walk.

## Regression assessment

- Vacuum fire/no-fire parity for user-tree debt is preserved by comparing cheap trigger span fields against full report fields.
- Idle unchanged-`CommitSeq` gate passes with zero structural walks.
- Changed-state trigger removes full report, freelist-chain, and collection-root work from background ticks.
- Existing background-vacuum and fragmentation validation tests remain green.
- No known local blockers. CI pending after PR open.

## Rollout / Toggle Plan

Default behavior only. Existing `BackgroundIndexVacuumInterval < 0` remains the disable switch.

## AI Review Loop

- Codex latest-head review: requested for head `7648f0d44c24ae5fccb08d39453f4c22ce462380` in https://github.com/snissn/gomap/pull/3647#issuecomment-4927190468; pending response.
- CodeRabbit: queued automatically by repo status; pending/no findings yet.
- Copilot: not requested.
