### PR TITLE
Use tracker refs for compact fenced reclaim

### DIFF
--- a/TreeDB/db/compact_storage.go
+++ b/TreeDB/db/compact_storage.go
@@ -300,6 +300,11 @@ type CompactStorageStats struct {
 	ByteMinimized        bool `json:"byte_minimized"`
 }
 
+type compactStorageFencedValueLogRefEvent struct {
+	Source             valueLogRefResolutionSource
+	ReferencedSegments int
+}
+
 // CompactStoragePlan reports full storage compaction debt without mutating the
 // database. It is safe for read-only opens.
 func (db *DB) CompactStoragePlan(ctx context.Context, opts CompactStorageOptions) (CompactStorageStats, error) {
@@ -710,8 +715,9 @@ func (db *DB) settleCompactStorageGC(ctx context.Context, opts CompactStorageOpt
 		if len(fencedIDs) > 0 {
 			phaseName := fmt.Sprintf("settle-fenced-value-log-gc-%d", pass+1)
 			if err := db.runCompactStoragePhase(stats, phaseName, func() error {
-				// Fenced IDs are independently proven unreachable by a fresh
-				// root scan below. Cached callers rotate and block writers
+				// Fenced IDs are independently proven unreachable by the
+				// tracker-aware referenced set (strict commit-sequence match) or
+				// its full-scan fallback. Cached callers rotate and block writers
 				// before enabling this path, so ReclaimActive can collect the
 				// formerly-active files that would otherwise reappear as debt
 				// after close/reopen.
@@ -1080,7 +1086,7 @@ func (db *DB) compactStorageFencedUnreferencedValueLogIDs(ctx context.Context, o
 	if db == nil || !opts.UnsafeValueLogReclaimFencedUnreferenced || db.valueLogManager == nil {
 		return nil, 0, nil
 	}
-	referenced, err := db.compactStorageScannedValueLogRefs(ctx)
+	referenced, err := db.compactStorageReferencedValueLogRefs(ctx)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -1134,23 +1140,16 @@ func (db *DB) compactStorageFencedUnreferencedValueLogIDs(ctx context.Context, o
 	return ids, bytes, nil
 }
 
-func (db *DB) compactStorageScannedValueLogRefs(ctx context.Context) (map[uint32]struct{}, error) {
-	counts, _, err := db.scanValueLogRefCounts(ctx)
-	if err != nil && errors.Is(err, valuelog.ErrFileNotFound) {
-		if refreshErr := db.RefreshValueLogSet(); refreshErr != nil {
-			return nil, refreshErr
-		}
-		counts, _, err = db.scanValueLogRefCounts(ctx)
-	}
+func (db *DB) compactStorageReferencedValueLogRefs(ctx context.Context) (map[uint32]struct{}, error) {
+	refs, source, err := db.referencedValueLogSegmentsWithSource(ctx)
 	if err != nil {
 		return nil, err
 	}
-	refs := make(map[uint32]struct{}, len(counts))
-	for fileID, n := range counts {
-		if n == 0 {
-			continue
-		}
-		refs[fileID] = struct{}{}
+	if db != nil && db.compactStorageFencedValueLogRefHook != nil {
+		db.compactStorageFencedValueLogRefHook(compactStorageFencedValueLogRefEvent{
+			Source:             source,
+			ReferencedSegments: len(refs),
+		})
 	}
 	return refs, nil
 }

--- a/TreeDB/db/compact_storage_test.go
+++ b/TreeDB/db/compact_storage_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"runtime"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -579,6 +580,205 @@ func TestCompactStorageFencedReclaimProtectsByFileID(t *testing.T) {
 	if len(ids) != 0 {
 		t.Fatalf("fenced reclaim IDs=%v want none", ids)
 	}
+}
+
+type compactStorageFencedValueLogRefCounters struct {
+	tracker        atomic.Uint64
+	fallbackScan   atomic.Uint64
+	validationScan atomic.Uint64
+	other          atomic.Uint64
+}
+
+func withCompactStorageFencedValueLogRefCounters(t *testing.T, db *DB) *compactStorageFencedValueLogRefCounters {
+	t.Helper()
+	counters := &compactStorageFencedValueLogRefCounters{}
+	prev := db.compactStorageFencedValueLogRefHook
+	db.compactStorageFencedValueLogRefHook = func(event compactStorageFencedValueLogRefEvent) {
+		switch event.Source {
+		case valueLogRefResolutionSourceTracker:
+			counters.tracker.Add(1)
+		case valueLogRefResolutionSourceFallbackScan:
+			counters.fallbackScan.Add(1)
+		case valueLogRefResolutionSourceValidationScan:
+			counters.validationScan.Add(1)
+		default:
+			counters.other.Add(1)
+		}
+		if prev != nil {
+			prev(event)
+		}
+	}
+	t.Cleanup(func() {
+		db.compactStorageFencedValueLogRefHook = prev
+	})
+	return counters
+}
+
+func withValueLogRefFullScanCounter(t *testing.T) *atomic.Uint64 {
+	t.Helper()
+	var counter atomic.Uint64
+	unregister := registerScanValueLogRefCountsHook(func() {
+		counter.Add(1)
+	})
+	t.Cleanup(func() {
+		unregister()
+	})
+	return &counter
+}
+
+func TestCompactStoragePlanFencedReclaimUsesTrackerRefsWhenValid(t *testing.T) {
+	dir := t.TempDir()
+	db, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	fixture := seedValueLogRefIncrementalParityFixture(t, db, dir, true)
+	if err := db.RefreshValueLogSet(); err != nil {
+		t.Fatalf("RefreshValueLogSet: %v", err)
+	}
+	if _, ok := db.valueLogRefTracker.referencedSet(db.currentCommitSeq()); !ok {
+		t.Fatalf("expected valid value-log ref tracker")
+	}
+
+	counters := withCompactStorageFencedValueLogRefCounters(t, db)
+	fullScans := withValueLogRefFullScanCounter(t)
+	stats, err := db.CompactStoragePlan(context.Background(), CompactStorageOptions{
+		UnsafeValueLogReclaimFencedUnreferenced: true,
+	})
+	if err != nil {
+		t.Fatalf("CompactStoragePlan: %v", err)
+	}
+	if counters.tracker.Load() != 1 || counters.fallbackScan.Load() != 0 || counters.validationScan.Load() != 0 || counters.other.Load() != 0 {
+		t.Fatalf("fenced refs counters tracker=%d fallback=%d validation=%d other=%d; want tracker=1 only",
+			counters.tracker.Load(), counters.fallbackScan.Load(), counters.validationScan.Load(), counters.other.Load())
+	}
+	if got := fullScans.Load(); got != 0 {
+		t.Fatalf("scanValueLogRefCounts calls during tracker-valid CompactStoragePlan=%d want 0", got)
+	}
+	if stats.RemainingDebt.ValueLogGCSegments == 0 {
+		// RemainingDebt carries both ordinary GC and fenced debt; the hook and scan
+		// counter assertions above prove the fenced audit used the tracker path.
+		t.Fatalf("expected value-log debt including unreferenced file %d, stats=%+v", fixture.UnreferencedFileID, stats.RemainingDebt)
+	}
+}
+
+func TestCompactStorageFencedReclaimFallsBackWhenTrackerStale(t *testing.T) {
+	dir := t.TempDir()
+	db, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	fixture := seedValueLogRefIncrementalParityFixture(t, db, dir, true)
+	if err := db.RefreshValueLogSet(); err != nil {
+		t.Fatalf("RefreshValueLogSet: %v", err)
+	}
+	opts := CompactStorageOptions{UnsafeValueLogReclaimFencedUnreferenced: true}
+	wantIDs, wantBytes, err := db.compactStorageFencedUnreferencedValueLogIDs(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("compactStorageFencedUnreferencedValueLogIDs tracker path: %v", err)
+	}
+	if !compactStorageIDListContains(wantIDs, fixture.UnreferencedFileID) {
+		t.Fatalf("tracker path fenced IDs=%v want unreferenced file %d", wantIDs, fixture.UnreferencedFileID)
+	}
+
+	seq := db.currentCommitSeq()
+	db.valueLogRefTracker.mu.Lock()
+	db.valueLogRefTracker.commitSeq = seq + 1
+	db.valueLogRefTracker.valid = true
+	db.valueLogRefTracker.mu.Unlock()
+	if _, ok := db.valueLogRefTracker.referencedSet(seq); ok {
+		t.Fatalf("expected stale tracker to be rejected for seq=%d", seq)
+	}
+
+	counters := withCompactStorageFencedValueLogRefCounters(t, db)
+	fullScans := withValueLogRefFullScanCounter(t)
+	gotIDs, gotBytes, err := db.compactStorageFencedUnreferencedValueLogIDs(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("compactStorageFencedUnreferencedValueLogIDs fallback path: %v", err)
+	}
+	if !reflect.DeepEqual(gotIDs, wantIDs) || gotBytes != wantBytes {
+		t.Fatalf("fallback fenced IDs/bytes=(%v,%d) want (%v,%d)", gotIDs, gotBytes, wantIDs, wantBytes)
+	}
+	if counters.tracker.Load() != 0 || counters.fallbackScan.Load() != 1 || counters.validationScan.Load() != 0 || counters.other.Load() != 0 {
+		t.Fatalf("fenced refs counters tracker=%d fallback=%d validation=%d other=%d; want fallback=1 only",
+			counters.tracker.Load(), counters.fallbackScan.Load(), counters.validationScan.Load(), counters.other.Load())
+	}
+	if got := fullScans.Load(); got != 1 {
+		t.Fatalf("scanValueLogRefCounts calls for stale tracker fallback=%d want 1", got)
+	}
+	if _, ok := db.valueLogRefTracker.referencedSet(seq); !ok {
+		t.Fatalf("expected fallback scan to refresh tracker for seq=%d", seq)
+	}
+}
+
+func TestCompactStorageFencedReclaimTrackerFullScanParityBeforeDeletion(t *testing.T) {
+	dir := t.TempDir()
+	db, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	fixture := seedValueLogRefIncrementalParityFixture(t, db, dir, true)
+	if err := db.RefreshValueLogSet(); err != nil {
+		t.Fatalf("RefreshValueLogSet: %v", err)
+	}
+	seq := db.currentCommitSeq()
+	trackerRefs, ok := db.valueLogRefTracker.referencedSet(seq)
+	if !ok {
+		t.Fatalf("expected tracker refs for seq=%d", seq)
+	}
+	fullCounts, fullSeq, err := db.scanValueLogRefCounts(context.Background())
+	if err != nil {
+		t.Fatalf("scanValueLogRefCounts: %v", err)
+	}
+	if fullSeq != seq {
+		t.Fatalf("scan seq mismatch: got=%d want=%d", fullSeq, seq)
+	}
+	fullRefs := valueLogRefSetFromCounts(fullCounts)
+	if !reflect.DeepEqual(trackerRefs, fullRefs) {
+		t.Fatalf("tracker/full-scan refs differ: tracker=%v full=%v", trackerRefs, fullRefs)
+	}
+
+	opts := CompactStorageOptions{UnsafeValueLogReclaimFencedUnreferenced: true}
+	trackerIDs, trackerBytes, err := db.compactStorageFencedUnreferencedValueLogIDs(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("tracker fenced IDs: %v", err)
+	}
+	db.valueLogRefTracker.invalidate()
+	scanIDs, scanBytes, err := db.compactStorageFencedUnreferencedValueLogIDs(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("scan fenced IDs: %v", err)
+	}
+	if !reflect.DeepEqual(scanIDs, trackerIDs) || scanBytes != trackerBytes {
+		t.Fatalf("tracker/scan fenced IDs differ: tracker=(%v,%d) scan=(%v,%d)", trackerIDs, trackerBytes, scanIDs, scanBytes)
+	}
+	fenced := compactStorageIDListSet(scanIDs)
+	for ref := range fullRefs {
+		if _, ok := fenced[ref]; ok {
+			t.Fatalf("referenced file %d appeared in fenced IDs %v", ref, scanIDs)
+		}
+	}
+	if _, ok := fenced[fixture.UnreferencedFileID]; !ok {
+		t.Fatalf("unreferenced file %d missing from fenced IDs %v", fixture.UnreferencedFileID, scanIDs)
+	}
+}
+
+func compactStorageIDListContains(ids []uint32, id uint32) bool {
+	_, ok := compactStorageIDListSet(ids)[id]
+	return ok
+}
+
+func compactStorageIDListSet(ids []uint32) map[uint32]struct{} {
+	out := make(map[uint32]struct{}, len(ids))
+	for _, id := range ids {
+		out[id] = struct{}{}
+	}
+	return out
 }
 
 func TestZeroByteValueLogCleanupProtectsByFileID(t *testing.T) {

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -90,6 +90,9 @@ type DB struct {
 	// Test hook used to release synthetic snapshot pins at exact compaction
 	// phase boundaries.
 	compactStorageAfterPhase func(string)
+	// Test hook used to observe whether fenced value-log reclaim resolved
+	// referenced segments through the tracker or the full-scan fallback.
+	compactStorageFencedValueLogRefHook func(compactStorageFencedValueLogRefEvent)
 
 	// idx is the current index generation (pager + MVCC lifecycle state).
 	idx atomic.Pointer[indexGen]

--- a/TreeDB/db/vlog_gc_incremental.go
+++ b/TreeDB/db/vlog_gc_incremental.go
@@ -39,6 +39,40 @@ var (
 	errValueLogRefCorrupt  = errors.New("treedb: corrupt value-log ref counters metadata")
 )
 
+type valueLogRefResolutionSource string
+
+const (
+	valueLogRefResolutionSourceTracker        valueLogRefResolutionSource = "tracker"
+	valueLogRefResolutionSourceFallbackScan   valueLogRefResolutionSource = "fallback_scan"
+	valueLogRefResolutionSourceValidationScan valueLogRefResolutionSource = "validation_scan"
+)
+
+var scanValueLogRefCountsHook struct {
+	mu sync.Mutex
+	fn func()
+}
+
+func registerScanValueLogRefCountsHook(hook func()) func() {
+	scanValueLogRefCountsHook.mu.Lock()
+	prev := scanValueLogRefCountsHook.fn
+	scanValueLogRefCountsHook.fn = hook
+	scanValueLogRefCountsHook.mu.Unlock()
+	return func() {
+		scanValueLogRefCountsHook.mu.Lock()
+		scanValueLogRefCountsHook.fn = prev
+		scanValueLogRefCountsHook.mu.Unlock()
+	}
+}
+
+func runScanValueLogRefCountsHook() {
+	scanValueLogRefCountsHook.mu.Lock()
+	hook := scanValueLogRefCountsHook.fn
+	scanValueLogRefCountsHook.mu.Unlock()
+	if hook != nil {
+		hook()
+	}
+}
+
 type valueLogRefDelta struct {
 	inline    [16]valueLogRefDeltaEntry
 	inlineN   int
@@ -454,24 +488,29 @@ func (db *DB) persistValueLogRefTrackerBestEffort() {
 }
 
 func (db *DB) referencedValueLogSegments(ctx context.Context) (map[uint32]struct{}, error) {
+	refs, _, err := db.referencedValueLogSegmentsWithSource(ctx)
+	return refs, err
+}
+
+func (db *DB) referencedValueLogSegmentsWithSource(ctx context.Context) (map[uint32]struct{}, valueLogRefResolutionSource, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
 	seq := db.currentCommitSeq()
 	if db.valueLogRefTracker != nil {
 		if refs, ok := db.valueLogRefTracker.referencedSet(seq); ok {
-			return refs, nil
+			return refs, valueLogRefResolutionSourceTracker, nil
 		}
 	}
 	counts, scannedSeq, err := db.scanValueLogRefCounts(ctx)
 	if err != nil && errors.Is(err, valuelog.ErrFileNotFound) {
 		if refreshErr := db.RefreshValueLogSet(); refreshErr != nil {
-			return nil, refreshErr
+			return nil, valueLogRefResolutionSourceFallbackScan, refreshErr
 		}
 		counts, scannedSeq, err = db.scanValueLogRefCounts(ctx)
 	}
 	if err != nil {
-		return nil, err
+		return nil, valueLogRefResolutionSourceFallbackScan, err
 	}
 	if db.valueLogRefTracker != nil {
 		db.valueLogRefTracker.replace(counts, scannedSeq, true)
@@ -483,13 +522,14 @@ func (db *DB) referencedValueLogSegments(ctx context.Context) (map[uint32]struct
 		}
 		refs[fileID] = struct{}{}
 	}
-	return refs, nil
+	return refs, valueLogRefResolutionSourceFallbackScan, nil
 }
 
 func (db *DB) scanValueLogRefCounts(ctx context.Context) (map[uint32]uint64, uint64, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
+	runScanValueLogRefCountsHook()
 	snap := db.AcquireSnapshot()
 	if snap == nil || snap.idx == nil || snap.state == nil {
 		if snap != nil {

--- a/TreeDB/db/vlog_gc_test.go
+++ b/TreeDB/db/vlog_gc_test.go
@@ -681,12 +681,50 @@ func TestValueLogGC_IncrementalParityWithFullScan(t *testing.T) {
 	}
 	defer func() { _ = db.Close() }()
 
+	seedValueLogRefIncrementalParityFixture(t, db, dir, false)
+
+	seq := db.currentCommitSeq()
+	incRefs, ok := db.valueLogRefTracker.referencedSet(seq)
+	if !ok {
+		t.Fatalf("expected incremental ref set for seq=%d", seq)
+	}
+
+	fullCounts, fullSeq, err := db.scanValueLogRefCounts(context.Background())
+	if err != nil {
+		t.Fatalf("scanValueLogRefCounts: %v", err)
+	}
+	if fullSeq != seq {
+		t.Fatalf("scan seq mismatch: got=%d want=%d", fullSeq, seq)
+	}
+
+	fullRefs := valueLogRefSetFromCounts(fullCounts)
+	if !reflect.DeepEqual(incRefs, fullRefs) {
+		t.Fatalf("incremental/full-scan mismatch: incremental=%d full=%d", len(incRefs), len(fullRefs))
+	}
+}
+
+type valueLogRefIncrementalParityFixture struct {
+	SegmentAFileID     uint32
+	SegmentBFileID     uint32
+	UnreferencedFileID uint32
+}
+
+func seedValueLogRefIncrementalParityFixture(t *testing.T, db *DB, dir string, includeUnreferenced bool) valueLogRefIncrementalParityFixture {
+	t.Helper()
+
 	key := func(i int) []byte { return []byte(fmt.Sprintf("k%06d", i)) }
 	valueA := func(i int) []byte { return bytes.Repeat([]byte{byte(i % 251)}, 256) }
 	valueB := func(i int) []byte { return bytes.Repeat([]byte{byte((i + 17) % 251)}, 512) }
 
 	ptrsA := appendPointersInNewSegment(t, dir, 0, 1, 10_000, 320, valueA)
 	ptrsB := appendPointersInNewSegment(t, dir, 0, 2, 20_000, 120, valueB)
+	var unreferencedFileID uint32
+	if includeUnreferenced {
+		unreferenced := appendPointersInNewSegment(t, dir, 0, 3, 30_000, 1, func(int) []byte {
+			return bytes.Repeat([]byte("unreferenced|"), 32)
+		})
+		unreferencedFileID = unreferenced[0].FileID
+	}
 
 	b := db.NewBatch().(*Batch)
 	for i := 0; i < 320; i++ {
@@ -715,23 +753,10 @@ func TestValueLogGC_IncrementalParityWithFullScan(t *testing.T) {
 	}
 	_ = b.Close()
 
-	seq := db.currentCommitSeq()
-	incRefs, ok := db.valueLogRefTracker.referencedSet(seq)
-	if !ok {
-		t.Fatalf("expected incremental ref set for seq=%d", seq)
-	}
-
-	fullCounts, fullSeq, err := db.scanValueLogRefCounts(context.Background())
-	if err != nil {
-		t.Fatalf("scanValueLogRefCounts: %v", err)
-	}
-	if fullSeq != seq {
-		t.Fatalf("scan seq mismatch: got=%d want=%d", fullSeq, seq)
-	}
-
-	fullRefs := valueLogRefSetFromCounts(fullCounts)
-	if !reflect.DeepEqual(incRefs, fullRefs) {
-		t.Fatalf("incremental/full-scan mismatch: incremental=%d full=%d", len(incRefs), len(fullRefs))
+	return valueLogRefIncrementalParityFixture{
+		SegmentAFileID:     ptrsA[0].FileID,
+		SegmentBFileID:     ptrsB[0].FileID,
+		UnreferencedFileID: unreferencedFileID,
 	}
 }
 


### PR DESCRIPTION
## Summary

- Replace the CompactStorage fenced-reclaim referenced-set helper with `referencedValueLogSegmentsWithSource`, so fenced audits use the incremental value-log ref tracker when it is valid for the current commit sequence.
- Preserve fail-closed behavior: missing/stale/invalid/unavailable tracker state falls back to the existing full ref scan and refreshes the tracker.
- Add deterministic test hooks/counters for fenced tracker hits, fallback scans, validation scans (unused/zero in this PR), and direct `scanValueLogRefCounts` calls.

Fixes #3634
Refs #3630

## Scope / non-goals

- Does not implement PL-03 shared CompactStorage audit reachability (#3636) or PL-14 scanner unification (#3644).
- No on-disk format changes.

## Counter semantics and scan-count evidence

- Fenced audit source hook reports one of: `tracker`, `fallback_scan`, `validation_scan`.
- This PR intentionally does not add a validation scan; validation counter remains `0`.
- Tracker-valid `CompactStoragePlan` fixture asserts: fenced `tracker=1`, `fallback_scan=0`, `validation_scan=0`, direct `scanValueLogRefCounts=0`.
- Stale-tracker fenced helper fixture asserts: fenced `tracker=0`, `fallback_scan=1`, `validation_scan=0`, direct `scanValueLogRefCounts=1`.
- Prior code unconditionally called `scanValueLogRefCounts` for every fenced audit; new valid-tracker path has zero full scans for that audit.

## Deletion-safety argument

Fenced IDs are computed from `referencedValueLogSegmentsWithSource`, which only trusts the tracker when `referencedSet(currentCommitSeq())` succeeds with an exact commit-sequence match. Missing, stale, invalid, or nil tracker state (including outer-leaf mode) falls back to the existing full scan path, including the `ErrFileNotFound` refresh retry, before any fenced IDs are trusted. The parity test reuses the existing incremental parity fixture, compares tracker refs with full-scan refs, compares tracker-derived fenced IDs with fallback-scan fenced IDs, and verifies referenced segment IDs are never included while the synthetic unreferenced segment is included.

## Tests

Latest local head: `4ff2640f7bb6e4af2c7cd5d6b962e21df5e13bfd`

```sh
GOWORK=off go test ./TreeDB/db -run 'TestCompactStorage.*Fenced|TestValueLogGC_Incremental|TestValueLogGC_KeepsSegment|TestMaintenanceRoots' -count=1
# ok github.com/snissn/gomap/TreeDB/db 0.262s

GOWORK=off go test ./TreeDB/db -count=1
# ok github.com/snissn/gomap/TreeDB/db 258.017s

GOWORK=off go test ./TreeDB ./TreeDB/freelist -count=1
# ok github.com/snissn/gomap/TreeDB 41.281s
# ok github.com/snissn/gomap/TreeDB/freelist 0.003s

GOWORK=off go test ./TreeDB/db -run '^$' -bench 'BenchmarkCompactStorage.*Fenced|BenchmarkValueLogRef' -benchmem -count=5
# PASS / ok github.com/snissn/gomap/TreeDB/db 0.005s
```

Benchmark note: no matching benchmark functions exist for that pattern on this base; scan-count hook evidence above is the performance evidence for this one-call redirect.

## CI / AI review

- Latest-head CI: all reported checks passing on `4ff2640f7bb6e4af2c7cd5d6b962e21df5e13bfd`.
- Codex: requested after local validation/internal review; completed with no major issues, reviewed commit `4ff2640f7b`.
- CodeRabbit: status check passed, but review comment says rate limit reached; no actionable findings or review threads.


## Final base update

After #3631, #3632, and #3633 merged, this branch was merged with latest `origin/main` and pushed as head `d1a3f915f49acb9489b1177162de0287ea464126`.

Final validation after the base update:

```sh
GOWORK=off go test ./TreeDB/db -run 'TestCompactStorage.*Fenced|TestValueLogGC_Incremental|TestValueLogGC_KeepsSegment|TestMaintenanceRoots' -count=1
# ok github.com/snissn/gomap/TreeDB/db 0.345s

GOWORK=off go test ./TreeDB/db -count=1
# ok github.com/snissn/gomap/TreeDB/db 259.229s
```

Latest-head Codex review was requested after this push.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved value-log cleanup now uses tracked references when available, with automatic fallback to a full scan when tracking is stale.
  * Added internal monitoring for how reference data is resolved during cleanup.

* **Bug Fixes**
  * Fixed fenced cleanup to better match the actual set of referenced and unreferenced value-log segments.
  * Added safeguards so cleanup stays accurate after value-log set changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->