### PR TITLE
[PL-12] Prevent background vacuum starvation

### DIFF
--- a/TreeDB/background_vacuum_test.go
+++ b/TreeDB/background_vacuum_test.go
@@ -217,6 +217,41 @@ func TestBackgroundIndexVacuumBacklogClearsResetsSkipCounter(t *testing.T) {
 	}
 }
 
+func TestBackgroundIndexVacuumFreelistDebtInvalidatesUnchangedCommitSkip(t *testing.T) {
+	d := openBackgroundVacuumTestDB(t, Options{BackgroundIndexVacuumInterval: -1})
+	seedBackgroundVacuumUserPages(t, d, 32)
+
+	d.bgVac.spanRatioPPM = ^uint32(0)
+	d.bgVac.freelistReclaimablePages = 1
+	d.bgVac.freelistReclaimableRatioPPM = 1
+	d.bgVac.collectionRootPages = ^uint64(0)
+	d.bgVac.collectionRootSpanRatioPPM = ^uint32(0)
+	counts, restoreCounts := installBackgroundVacuumProbeCounter()
+	defer restoreCounts()
+
+	d.bgVac.runOnce(d)
+	if got := counts[backenddb.FragmentationProbeEventTriggerReport]; got != 1 {
+		t.Fatalf("initial trigger probes=%d want 1", got)
+	}
+	changed := backenddb.IndexVacuumFreelistDebtSnapshot{
+		TotalPages:               128,
+		FreelistHead:             1,
+		FreelistReclaimable:      d.bgVac.lastProbeFreelistReclaimable + 1,
+		FreelistReclaimablePPM:   d.bgVac.lastProbeFreelistReclaimablePPM + 1,
+		FreelistReclaimableValid: true,
+	}
+	restoreDebt := setBackgroundIndexVacuumFreelistDebtSnapshotHookForTest(func(*DB) (backenddb.IndexVacuumFreelistDebtSnapshot, bool) {
+		return changed, true
+	})
+	defer restoreDebt()
+
+	d.bgVac.runOnce(d)
+	if got := counts[backenddb.FragmentationProbeEventTriggerReport]; got != 2 {
+		t.Fatalf("trigger probes after freelist debt change=%d want 2", got)
+	}
+	assertNoBackgroundVacuumFullFragmentationWalks(t, counts)
+}
+
 func TestBackgroundIndexVacuumTriggerPredicatesIndependentDebt(t *testing.T) {
 	w := bgIndexVacuumWorker{
 		spanRatioPPM:                2_000_000,

--- a/TreeDB/background_vacuum_test.go
+++ b/TreeDB/background_vacuum_test.go
@@ -1,13 +1,16 @@
 package treedb
 
 import (
+	"encoding/binary"
 	"fmt"
 	"runtime"
 	"strconv"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
+	"github.com/snissn/gomap/TreeDB/internal/memtable"
 )
 
 func TestBackgroundIndexVacuumIdleUnchangedCommitSkipsStructuralWalks(t *testing.T) {
@@ -123,6 +126,9 @@ func TestBackgroundIndexVacuumChangedCommitUsesCheapTrigger(t *testing.T) {
 	if got := counts[backenddb.FragmentationProbeEventTriggerFreelistCounters]; got != 1 {
 		t.Fatalf("trigger freelist counter reads=%d want 1", got)
 	}
+	if got := counts[backenddb.FragmentationProbeEventTriggerCollectionRootWalk]; got != 1 {
+		t.Fatalf("trigger collection-root walks=%d want 1", got)
+	}
 	if got := d.bgVac.lastPages.Load(); got != expected.UserPages {
 		t.Fatalf("lastPages=%d want %d", got, expected.UserPages)
 	}
@@ -136,6 +142,211 @@ func TestBackgroundIndexVacuumChangedCommitUsesCheapTrigger(t *testing.T) {
 		t.Fatalf("retryProbe left set after successful changed-state trigger")
 	}
 	assertNoBackgroundVacuumFullFragmentationWalks(t, counts)
+}
+
+func TestBackgroundIndexVacuumSustainedBacklogForcesTriggerProbe(t *testing.T) {
+	d := openBackgroundVacuumTestDB(t, Options{BackgroundIndexVacuumInterval: -1})
+	seedBackgroundVacuumUserPages(t, d, 64)
+
+	d.bgVac.maxBacklogSkips = 2
+	d.bgVac.spanRatioPPM = ^uint32(0)
+
+	restoreBacklog := setBackgroundIndexVacuumBacklogBytesHookForTest(func(*DB) int64 { return 4096 })
+	defer restoreBacklog()
+	counts, restoreCounts := installBackgroundVacuumProbeCounter()
+	defer restoreCounts()
+
+	d.bgVac.runOnce(d)
+	d.bgVac.runOnce(d)
+	if got := counts[backenddb.FragmentationProbeEventTriggerReport]; got != 0 {
+		t.Fatalf("trigger probes before skip cap=%d want 0", got)
+	}
+	if got := d.bgVac.backlogConsecutiveSkips.Load(); got != 2 {
+		t.Fatalf("consecutive backlog skips=%d want 2", got)
+	}
+	if got := d.bgVac.backlogSkips.Load(); got != 2 {
+		t.Fatalf("total backlog skips=%d want 2", got)
+	}
+
+	d.bgVac.runOnce(d)
+	if got := counts[backenddb.FragmentationProbeEventTriggerReport]; got != 1 {
+		t.Fatalf("forced trigger probes=%d want 1", got)
+	}
+	if got := d.bgVac.backlogForcedRuns.Load(); got != 1 {
+		t.Fatalf("forced-after-backlog runs=%d want 1", got)
+	}
+	if got := d.bgVac.backlogConsecutiveSkips.Load(); got != 0 {
+		t.Fatalf("consecutive backlog skips after forced probe=%d want 0", got)
+	}
+	if got := d.bgVac.lastBacklogBytes.Load(); got != 4096 {
+		t.Fatalf("last backlog bytes=%d want 4096", got)
+	}
+}
+
+func TestBackgroundIndexVacuumBacklogClearsResetsSkipCounter(t *testing.T) {
+	d := openBackgroundVacuumTestDB(t, Options{BackgroundIndexVacuumInterval: -1})
+	seedBackgroundVacuumUserPages(t, d, 32)
+
+	d.bgVac.maxBacklogSkips = 3
+	d.bgVac.spanRatioPPM = ^uint32(0)
+	var backlog atomic.Int64
+	backlog.Store(2048)
+	restoreBacklog := setBackgroundIndexVacuumBacklogBytesHookForTest(func(*DB) int64 { return backlog.Load() })
+	defer restoreBacklog()
+	counts, restoreCounts := installBackgroundVacuumProbeCounter()
+	defer restoreCounts()
+
+	d.bgVac.runOnce(d)
+	if got := d.bgVac.backlogConsecutiveSkips.Load(); got != 1 {
+		t.Fatalf("consecutive backlog skips=%d want 1", got)
+	}
+
+	backlog.Store(0)
+	d.bgVac.runOnce(d)
+	if got := counts[backenddb.FragmentationProbeEventTriggerReport]; got != 1 {
+		t.Fatalf("trigger probes after backlog cleared=%d want 1", got)
+	}
+	if got := d.bgVac.backlogConsecutiveSkips.Load(); got != 0 {
+		t.Fatalf("consecutive backlog skips after clear=%d want 0", got)
+	}
+	if got := d.bgVac.backlogForcedRuns.Load(); got != 0 {
+		t.Fatalf("forced-after-backlog runs=%d want 0", got)
+	}
+	if got := d.bgVac.lastBacklogBytes.Load(); got != 0 {
+		t.Fatalf("last backlog bytes=%d want 0", got)
+	}
+}
+
+func TestBackgroundIndexVacuumTriggerPredicatesIndependentDebt(t *testing.T) {
+	w := bgIndexVacuumWorker{
+		spanRatioPPM:                2_000_000,
+		freelistReclaimableRatioPPM: 1_000_000,
+		freelistReclaimablePages:    10,
+		collectionRootSpanRatioPPM:  2_000_000,
+		collectionRootPages:         10,
+	}
+
+	tests := []struct {
+		name string
+		rep  backenddb.IndexVacuumTriggerReport
+		want string
+	}{
+		{
+			name: "absent optional debt is none",
+			rep: backenddb.IndexVacuumTriggerReport{
+				UserPages:                    4,
+				UserSpanRatioPPM:             1_000_000,
+				FreelistReclaimablePages:     100,
+				FreelistReclaimableRatioPPM:  4_000_000,
+				CollectionRootPages:          100,
+				CollectionRootSpanRatioPPM:   4_000_000,
+				CollectionRootSpanRatioValid: false,
+				FreelistReclaimableValid:     false,
+			},
+			want: backgroundIndexVacuumDebtReasonNone,
+		},
+		{
+			name: "user tree debt",
+			rep:  backenddb.IndexVacuumTriggerReport{UserPages: 4, UserSpanRatioPPM: 2_000_000},
+			want: backgroundIndexVacuumDebtReasonUser,
+		},
+		{
+			name: "freelist debt",
+			rep: backenddb.IndexVacuumTriggerReport{
+				UserPages:                   4,
+				UserSpanRatioPPM:            1_000_000,
+				FreelistReclaimableValid:    true,
+				FreelistReclaimablePages:    10,
+				FreelistReclaimableRatioPPM: 1_000_000,
+			},
+			want: backgroundIndexVacuumDebtReasonFreelist,
+		},
+		{
+			name: "collection root debt",
+			rep: backenddb.IndexVacuumTriggerReport{
+				UserPages:                    4,
+				UserSpanRatioPPM:             1_000_000,
+				CollectionRootSpanRatioValid: true,
+				CollectionRootPages:          10,
+				CollectionRootSpanRatioPPM:   2_000_000,
+			},
+			want: backgroundIndexVacuumDebtReasonCollectionRoots,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := w.triggerReason(tc.rep); got != tc.want {
+				t.Fatalf("triggerReason=%q want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestBackgroundIndexVacuumFreelistDebtTriggersVacuum(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("online vacuum not supported on windows")
+	}
+	d := openBackgroundVacuumTestDB(t, Options{
+		KeepRecent:                    1,
+		PreferAppendAlloc:             true,
+		BackgroundIndexVacuumInterval: -1,
+	})
+	seedBackgroundVacuumFreelistDebt(t, d)
+
+	rep, err := d.backend.IndexVacuumTriggerReport()
+	if err != nil {
+		t.Fatalf("trigger report: %v", err)
+	}
+	if !rep.FreelistReclaimableValid || rep.FreelistReclaimablePages == 0 || rep.FreelistReclaimableRatioPPM == 0 {
+		t.Fatalf("freelist debt not present in trigger report: %+v", rep)
+	}
+
+	d.bgVac.spanRatioPPM = ^uint32(0)
+	d.bgVac.freelistReclaimablePages = 1
+	d.bgVac.freelistReclaimableRatioPPM = 1
+	d.bgVac.collectionRootPages = ^uint64(0)
+	d.bgVac.collectionRootSpanRatioPPM = ^uint32(0)
+	d.bgVac.runOnce(d)
+
+	if got := d.bgVac.vacuums.Load(); got != 1 {
+		t.Fatalf("vacuums=%d want 1", got)
+	}
+	if got := lastBackgroundVacuumDebtReason(t, &d.bgVac); got != backgroundIndexVacuumDebtReasonFreelist {
+		t.Fatalf("last debt reason=%q want freelist", got)
+	}
+}
+
+func TestBackgroundIndexVacuumCollectionRootDebtTriggersVacuum(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("online vacuum not supported on windows")
+	}
+	d := openBackgroundVacuumTestDB(t, Options{
+		KeepRecent:                    1,
+		BackgroundIndexVacuumInterval: -1,
+	})
+	seedBackgroundVacuumCollectionRootDebt(t, d)
+
+	rep, err := d.backend.IndexVacuumTriggerReport()
+	if err != nil {
+		t.Fatalf("trigger report: %v", err)
+	}
+	if !rep.CollectionRootSpanRatioValid || rep.CollectionRootPages == 0 || rep.CollectionRootSpanRatioPPM == 0 {
+		t.Fatalf("collection root debt not present in trigger report: %+v", rep)
+	}
+
+	d.bgVac.spanRatioPPM = ^uint32(0)
+	d.bgVac.freelistReclaimablePages = ^uint64(0)
+	d.bgVac.freelistReclaimableRatioPPM = ^uint32(0)
+	d.bgVac.collectionRootPages = 1
+	d.bgVac.collectionRootSpanRatioPPM = 1
+	d.bgVac.runOnce(d)
+
+	if got := d.bgVac.vacuums.Load(); got != 1 {
+		t.Fatalf("vacuums=%d want 1", got)
+	}
+	if got := lastBackgroundVacuumDebtReason(t, &d.bgVac); got != backgroundIndexVacuumDebtReasonCollectionRoots {
+		t.Fatalf("last debt reason=%q want collection_roots", got)
+	}
 }
 
 func installBackgroundVacuumProbeCounter() (map[backenddb.FragmentationProbeEvent]int, func()) {
@@ -156,6 +367,9 @@ func assertNoBackgroundVacuumStructuralWalks(t *testing.T, counts map[backenddb.
 	}
 	if got := counts[backenddb.FragmentationProbeEventTriggerFreelistCounters]; got != 0 {
 		t.Fatalf("cheap trigger freelist counter reads=%d want 0", got)
+	}
+	if got := counts[backenddb.FragmentationProbeEventTriggerCollectionRootWalk]; got != 0 {
+		t.Fatalf("cheap trigger collection-root walks=%d want 0", got)
 	}
 	assertNoBackgroundVacuumFullFragmentationWalks(t, counts)
 }
@@ -220,4 +434,126 @@ func TestBackgroundIndexVacuumRunsAndStops(t *testing.T) {
 	if err := d.Close(); err != nil {
 		t.Fatalf("close: %v", err)
 	}
+}
+
+func BenchmarkBackgroundIndexVacuumBacklog(b *testing.B) {
+	d := openBackgroundVacuumTestDB(b, Options{BackgroundIndexVacuumInterval: -1})
+	seedBackgroundVacuumUserPages(b, d, 128)
+	d.bgVac.maxBacklogSkips = ^uint32(0)
+	restoreBacklog := setBackgroundIndexVacuumBacklogBytesHookForTest(func(*DB) int64 { return 1024 })
+	defer restoreBacklog()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		d.bgVac.runOnce(d)
+	}
+}
+
+func BenchmarkBackgroundIndexVacuumTrigger(b *testing.B) {
+	d := openBackgroundVacuumTestDB(b, Options{BackgroundIndexVacuumInterval: -1})
+	seedBackgroundVacuumUserPages(b, d, 2048)
+	d.bgVac.spanRatioPPM = ^uint32(0)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		d.bgVac.lastProbeValid = false
+		d.bgVac.runOnce(d)
+	}
+}
+
+func openBackgroundVacuumTestDB(tb testing.TB, opts Options) *DB {
+	tb.Helper()
+	if opts.Dir == "" {
+		opts.Dir = tb.TempDir()
+	}
+	if opts.BackgroundIndexVacuumInterval == 0 {
+		opts.BackgroundIndexVacuumInterval = -1
+	}
+	d, err := Open(opts)
+	if err != nil {
+		tb.Fatalf("open: %v", err)
+	}
+	tb.Cleanup(func() { _ = d.Close() })
+	return d
+}
+
+func seedBackgroundVacuumUserPages(tb testing.TB, d *DB, n int) {
+	tb.Helper()
+	for i := 0; i < n; i++ {
+		key := []byte(fmt.Sprintf("bg-seed-%04d", i))
+		if err := d.Set(key, []byte("value")); err != nil {
+			tb.Fatalf("set seed: %v", err)
+		}
+	}
+	if err := d.Checkpoint(); err != nil {
+		tb.Fatalf("checkpoint seed: %v", err)
+	}
+}
+
+func seedBackgroundVacuumFreelistDebt(tb testing.TB, d *DB) {
+	tb.Helper()
+	for i := 0; i < 512; i++ {
+		key := []byte(fmt.Sprintf("free-debt-%04d", i))
+		if err := d.backend.Set(key, []byte("value")); err != nil {
+			tb.Fatalf("backend set freelist fixture: %v", err)
+		}
+	}
+	for i := 0; i < 512; i++ {
+		key := []byte(fmt.Sprintf("free-debt-%04d", i))
+		if err := d.backend.Delete(key); err != nil {
+			tb.Fatalf("backend delete freelist fixture: %v", err)
+		}
+	}
+}
+
+func seedBackgroundVacuumCollectionRootDebt(tb testing.TB, d *DB) {
+	tb.Helper()
+	kvs := make([]string, 0, 4096)
+	for i := 0; i < 2048; i++ {
+		kvs = append(kvs, fmt.Sprintf("doc/%04d", i), fmt.Sprintf("value-%04d", i))
+	}
+	rootID, err := d.backend.PublishOrderedRootIterator(0, mustBackgroundVacuumStringMemtable(tb, kvs...).NewIterator(nil, nil))
+	if err != nil {
+		tb.Fatalf("publish collection root fixture: %v", err)
+	}
+	var encoded [8]byte
+	binary.BigEndian.PutUint64(encoded[:], rootID)
+	_, err = d.backend.PublishSystemRootIterator(mustBackgroundVacuumBytesMemtable(tb, "collections/root/bg/primary", encoded[:]).NewIterator(nil, nil))
+	if err != nil {
+		tb.Fatalf("publish collection descriptor fixture: %v", err)
+	}
+}
+
+func mustBackgroundVacuumStringMemtable(tb testing.TB, kvs ...string) memtable.Table {
+	tb.Helper()
+	mt, err := memtable.NewWithCapacityMode(0, memtable.ModeHashSorted)
+	if err != nil {
+		tb.Fatalf("new memtable: %v", err)
+	}
+	for i := 0; i+1 < len(kvs); i += 2 {
+		mt.Set([]byte(kvs[i]), []byte(kvs[i+1]))
+	}
+	mt.Freeze()
+	return mt
+}
+
+func mustBackgroundVacuumBytesMemtable(tb testing.TB, key string, value []byte) memtable.Table {
+	tb.Helper()
+	mt, err := memtable.NewWithCapacityMode(0, memtable.ModeHashSorted)
+	if err != nil {
+		tb.Fatalf("new memtable: %v", err)
+	}
+	mt.Set([]byte(key), value)
+	mt.Freeze()
+	return mt
+}
+
+func lastBackgroundVacuumDebtReason(t *testing.T, w *bgIndexVacuumWorker) string {
+	t.Helper()
+	v := w.lastDebtReason.Load()
+	if v == nil {
+		return ""
+	}
+	reason, _ := v.(string)
+	return reason
 }

--- a/TreeDB/bg_vacuum.go
+++ b/TreeDB/bg_vacuum.go
@@ -6,15 +6,73 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
 )
 
-const defaultBackgroundIndexVacuumSpanRatioPPM uint32 = 1_200_000
+const (
+	defaultBackgroundIndexVacuumSpanRatioPPM                uint32 = 1_200_000
+	defaultBackgroundIndexVacuumMaxBacklogSkips             uint32 = 3
+	defaultBackgroundIndexVacuumFreelistReclaimableRatioPPM uint32 = 250_000
+	defaultBackgroundIndexVacuumFreelistReclaimablePages    uint64 = 64
+	defaultBackgroundIndexVacuumCollectionRootSpanRatioPPM  uint32 = 1_200_000
+	defaultBackgroundIndexVacuumCollectionRootPages         uint64 = 16
+	backgroundIndexVacuumDebtReasonNone                            = "none"
+	backgroundIndexVacuumDebtReasonUser                            = "user"
+	backgroundIndexVacuumDebtReasonFreelist                        = "freelist"
+	backgroundIndexVacuumDebtReasonCollectionRoots                 = "collection_roots"
+)
+
+type bgIndexVacuumConfig struct {
+	Interval time.Duration
+
+	SpanRatioPPM uint32
+
+	MaxBacklogSkips uint32
+
+	FreelistReclaimableRatioPPM uint32
+	FreelistReclaimablePages    uint64
+
+	CollectionRootSpanRatioPPM uint32
+	CollectionRootPages        uint64
+}
+
+func normalizeBGIndexVacuumConfig(cfg bgIndexVacuumConfig) bgIndexVacuumConfig {
+	if cfg.SpanRatioPPM == 0 {
+		cfg.SpanRatioPPM = defaultBackgroundIndexVacuumSpanRatioPPM
+	}
+	if cfg.MaxBacklogSkips == 0 {
+		cfg.MaxBacklogSkips = defaultBackgroundIndexVacuumMaxBacklogSkips
+	}
+	if cfg.FreelistReclaimableRatioPPM == 0 {
+		cfg.FreelistReclaimableRatioPPM = defaultBackgroundIndexVacuumFreelistReclaimableRatioPPM
+	}
+	if cfg.FreelistReclaimablePages == 0 {
+		cfg.FreelistReclaimablePages = defaultBackgroundIndexVacuumFreelistReclaimablePages
+	}
+	if cfg.CollectionRootSpanRatioPPM == 0 {
+		cfg.CollectionRootSpanRatioPPM = defaultBackgroundIndexVacuumCollectionRootSpanRatioPPM
+	}
+	if cfg.CollectionRootPages == 0 {
+		cfg.CollectionRootPages = defaultBackgroundIndexVacuumCollectionRootPages
+	}
+	return cfg
+}
 
 type bgIndexVacuumWorker struct {
 	enabled atomic.Bool
 
-	interval     time.Duration
+	interval time.Duration
+
 	spanRatioPPM uint32
+
+	maxBacklogSkips uint32
+
+	freelistReclaimableRatioPPM uint32
+	freelistReclaimablePages    uint64
+
+	collectionRootSpanRatioPPM uint32
+	collectionRootPages        uint64
 
 	stopOnce sync.Once
 	stopCh   chan struct{}
@@ -23,6 +81,7 @@ type bgIndexVacuumWorker struct {
 
 	runMu          sync.Mutex
 	runs           atomic.Uint64
+	probes         atomic.Uint64
 	vacuums        atomic.Uint64
 	lastRunUnix    atomic.Int64
 	lastVacuumUnix atomic.Int64
@@ -30,33 +89,78 @@ type bgIndexVacuumWorker struct {
 	lastPages      atomic.Uint64
 	lastErr        atomic.Value // string
 
+	backlogConsecutiveSkips atomic.Uint64
+	backlogSkips            atomic.Uint64
+	backlogForcedRuns       atomic.Uint64
+	lastBacklogBytes        atomic.Int64
+
+	lastFreelistReclaimablePages atomic.Uint64
+	lastFreelistReclaimableRatio atomic.Uint64
+	lastCollectionRootPages      atomic.Uint64
+	lastCollectionRootSpanRatio  atomic.Uint64
+	lastDebtReason               atomic.Value // string
+
 	lastProbeCommitSeq uint64
 	lastProbeValid     bool
 	retryProbe         bool
 }
 
+var bgIndexVacuumBacklogBytesHook struct {
+	mu sync.RWMutex
+	fn func(*DB) int64
+}
+
+func setBackgroundIndexVacuumBacklogBytesHookForTest(fn func(*DB) int64) func() {
+	bgIndexVacuumBacklogBytesHook.mu.Lock()
+	prev := bgIndexVacuumBacklogBytesHook.fn
+	bgIndexVacuumBacklogBytesHook.fn = fn
+	bgIndexVacuumBacklogBytesHook.mu.Unlock()
+	return func() {
+		bgIndexVacuumBacklogBytesHook.mu.Lock()
+		bgIndexVacuumBacklogBytesHook.fn = prev
+		bgIndexVacuumBacklogBytesHook.mu.Unlock()
+	}
+}
+
+func backgroundIndexVacuumBacklogBytes(db *DB) int64 {
+	bgIndexVacuumBacklogBytesHook.mu.RLock()
+	hook := bgIndexVacuumBacklogBytesHook.fn
+	bgIndexVacuumBacklogBytesHook.mu.RUnlock()
+	if hook != nil {
+		return hook(db)
+	}
+	if db == nil || db.cached == nil {
+		return 0
+	}
+	return db.cached.QueueBacklogBytes()
+}
+
 // Start launches the background index vacuum loop with the provided interval.
-func (w *bgIndexVacuumWorker) Start(db *DB, interval time.Duration, spanRatioPPM uint32) {
-	if interval <= 0 || db == nil {
+func (w *bgIndexVacuumWorker) Start(db *DB, cfg bgIndexVacuumConfig) {
+	cfg = normalizeBGIndexVacuumConfig(cfg)
+	if cfg.Interval <= 0 || db == nil {
 		w.enabled.Store(false)
 		return
 	}
-	if spanRatioPPM == 0 {
-		spanRatioPPM = defaultBackgroundIndexVacuumSpanRatioPPM
-	}
 
 	w.enabled.Store(true)
-	w.interval = interval
-	w.spanRatioPPM = spanRatioPPM
+	w.interval = cfg.Interval
+	w.spanRatioPPM = cfg.SpanRatioPPM
+	w.maxBacklogSkips = cfg.MaxBacklogSkips
+	w.freelistReclaimableRatioPPM = cfg.FreelistReclaimableRatioPPM
+	w.freelistReclaimablePages = cfg.FreelistReclaimablePages
+	w.collectionRootSpanRatioPPM = cfg.CollectionRootSpanRatioPPM
+	w.collectionRootPages = cfg.CollectionRootPages
 	w.stopCh = make(chan struct{})
 	w.doneCh = make(chan struct{})
 	w.kickCh = make(chan struct{}, 1)
 	w.lastErr.Store("")
+	w.lastDebtReason.Store(backgroundIndexVacuumDebtReasonNone)
 
 	go func() {
 		defer close(w.doneCh)
 
-		ticker := time.NewTicker(interval)
+		ticker := time.NewTicker(cfg.Interval)
 		defer ticker.Stop()
 
 		for {
@@ -114,104 +218,252 @@ func (w *bgIndexVacuumWorker) runOnce(db *DB) {
 		return
 	}
 
-	if w.lastProbeValid && !w.retryProbe && state.CommitSeq == w.lastProbeCommitSeq {
-		w.runs.Add(1)
-		w.lastRunUnix.Store(now.Unix())
-		w.lastErr.Store("")
+	forcedAfterBacklog := false
+	backlogBytes := backgroundIndexVacuumBacklogBytes(db)
+	w.lastBacklogBytes.Store(backlogBytes)
+	if backlogBytes > 0 {
+		consecutive := w.backlogConsecutiveSkips.Load()
+		if consecutive < uint64(w.maxBacklogSkipThreshold()) {
+			consecutive++
+			w.backlogConsecutiveSkips.Store(consecutive)
+			w.backlogSkips.Add(1)
+			w.finishRun(now, "")
+			return
+		}
+		forcedAfterBacklog = true
+		w.backlogForcedRuns.Add(1)
+		w.backlogConsecutiveSkips.Store(0)
+	} else {
+		w.backlogConsecutiveSkips.Store(0)
+	}
+
+	if !forcedAfterBacklog && w.lastProbeValid && !w.retryProbe && state.CommitSeq == w.lastProbeCommitSeq {
+		w.finishRun(now, "")
 		return
 	}
 
-	// Avoid competing with the flush path. If there's any queued backlog, let the
-	// caching layer catch up first. This is not a completed trigger probe, so keep
-	// lastProbeCommitSeq unchanged.
-	if db.cached != nil {
-		if db.cached.QueueBacklogBytes() > 0 {
-			w.runs.Add(1)
-			w.lastRunUnix.Store(now.Unix())
-			w.lastErr.Store("")
-			return
-		}
-	}
-
 	rep, err := db.backend.IndexVacuumTriggerReport()
+	w.probes.Add(1)
 	if err != nil {
 		w.retryProbe = true
-		w.runs.Add(1)
-		w.lastRunUnix.Store(now.Unix())
-		w.lastErr.Store(err.Error())
+		w.finishRun(now, err.Error())
 		db.reportError(err)
 		return
 	}
 
 	w.lastProbeCommitSeq = rep.CommitSeq
 	w.lastProbeValid = true
-	w.lastPages.Store(rep.UserPages)
-	if rep.UserPages == 0 {
-		w.retryProbe = false
-		w.lastSpanRatio.Store(0)
-		w.runs.Add(1)
-		w.lastRunUnix.Store(now.Unix())
-		w.lastErr.Store("")
-		return
-	}
+	w.recordLastTriggerReport(rep)
 
-	spanRatio := rep.UserSpanRatioPPM
-	w.lastSpanRatio.Store(spanRatio)
-
-	if spanRatio < uint64(w.spanRatioPPM) {
+	reason := w.triggerReason(rep)
+	w.lastDebtReason.Store(reason)
+	if reason == backgroundIndexVacuumDebtReasonNone {
 		w.retryProbe = false
-		w.runs.Add(1)
-		w.lastRunUnix.Store(now.Unix())
-		w.lastErr.Store("")
+		w.finishRun(now, "")
 		return
 	}
 
 	if err := db.VacuumIndexOnline(context.Background()); err != nil {
 		w.retryProbe = true
-		w.runs.Add(1)
-		w.lastRunUnix.Store(now.Unix())
-		w.lastErr.Store(err.Error())
+		w.finishRun(now, err.Error())
 		db.reportError(err)
 		return
 	}
 
 	w.retryProbe = false
 	w.vacuums.Add(1)
+	w.finishRun(now, "")
+	w.lastVacuumUnix.Store(now.Unix())
+}
+
+func (w *bgIndexVacuumWorker) finishRun(now time.Time, err string) {
 	w.runs.Add(1)
 	w.lastRunUnix.Store(now.Unix())
-	w.lastVacuumUnix.Store(now.Unix())
-	w.lastErr.Store("")
+	w.lastErr.Store(err)
+}
+
+func (w *bgIndexVacuumWorker) recordLastTriggerReport(rep backenddb.IndexVacuumTriggerReport) {
+	w.lastPages.Store(rep.UserPages)
+	if rep.UserPages > 0 {
+		w.lastSpanRatio.Store(rep.UserSpanRatioPPM)
+	} else {
+		w.lastSpanRatio.Store(0)
+	}
+	w.lastFreelistReclaimablePages.Store(rep.FreelistReclaimablePages)
+	if rep.FreelistReclaimableValid {
+		w.lastFreelistReclaimableRatio.Store(rep.FreelistReclaimableRatioPPM)
+	} else {
+		w.lastFreelistReclaimableRatio.Store(0)
+	}
+	w.lastCollectionRootPages.Store(rep.CollectionRootPages)
+	if rep.CollectionRootSpanRatioValid {
+		w.lastCollectionRootSpanRatio.Store(rep.CollectionRootSpanRatioPPM)
+	} else {
+		w.lastCollectionRootSpanRatio.Store(0)
+	}
+}
+
+func (w *bgIndexVacuumWorker) triggerReason(rep backenddb.IndexVacuumTriggerReport) string {
+	if rep.UserPages > 0 && rep.UserSpanRatioPPM >= uint64(w.userSpanRatioThreshold()) {
+		return backgroundIndexVacuumDebtReasonUser
+	}
+	if rep.FreelistReclaimableValid &&
+		rep.FreelistReclaimablePages >= w.freelistReclaimablePagesThreshold() &&
+		rep.FreelistReclaimableRatioPPM >= uint64(w.freelistReclaimableRatioThreshold()) {
+		return backgroundIndexVacuumDebtReasonFreelist
+	}
+	if rep.CollectionRootSpanRatioValid &&
+		rep.CollectionRootPages >= w.collectionRootPagesThreshold() &&
+		rep.CollectionRootSpanRatioPPM >= uint64(w.collectionRootSpanRatioThreshold()) {
+		return backgroundIndexVacuumDebtReasonCollectionRoots
+	}
+	return backgroundIndexVacuumDebtReasonNone
+}
+
+func (w *bgIndexVacuumWorker) userSpanRatioThreshold() uint32 {
+	if w.spanRatioPPM == 0 {
+		return defaultBackgroundIndexVacuumSpanRatioPPM
+	}
+	return w.spanRatioPPM
+}
+
+func (w *bgIndexVacuumWorker) maxBacklogSkipThreshold() uint32 {
+	if w.maxBacklogSkips == 0 {
+		return defaultBackgroundIndexVacuumMaxBacklogSkips
+	}
+	return w.maxBacklogSkips
+}
+
+func (w *bgIndexVacuumWorker) freelistReclaimableRatioThreshold() uint32 {
+	if w.freelistReclaimableRatioPPM == 0 {
+		return defaultBackgroundIndexVacuumFreelistReclaimableRatioPPM
+	}
+	return w.freelistReclaimableRatioPPM
+}
+
+func (w *bgIndexVacuumWorker) freelistReclaimablePagesThreshold() uint64 {
+	if w.freelistReclaimablePages == 0 {
+		return defaultBackgroundIndexVacuumFreelistReclaimablePages
+	}
+	return w.freelistReclaimablePages
+}
+
+func (w *bgIndexVacuumWorker) collectionRootSpanRatioThreshold() uint32 {
+	if w.collectionRootSpanRatioPPM == 0 {
+		return defaultBackgroundIndexVacuumCollectionRootSpanRatioPPM
+	}
+	return w.collectionRootSpanRatioPPM
+}
+
+func (w *bgIndexVacuumWorker) collectionRootPagesThreshold() uint64 {
+	if w.collectionRootPages == 0 {
+		return defaultBackgroundIndexVacuumCollectionRootPages
+	}
+	return w.collectionRootPages
+}
+
+type bgIndexVacuumStats struct {
+	Enabled  bool
+	Interval time.Duration
+
+	SpanRatioPPM uint32
+
+	MaxBacklogSkips uint32
+
+	FreelistReclaimableRatioPPM uint32
+	FreelistReclaimablePages    uint64
+
+	CollectionRootSpanRatioPPM uint32
+	CollectionRootPages        uint64
+
+	Runs    uint64
+	Probes  uint64
+	Vacuums uint64
+
+	BacklogConsecutiveSkips uint64
+	BacklogSkips            uint64
+	BacklogForcedRuns       uint64
+	LastBacklogBytes        int64
+
+	LastRunUnix    int64
+	LastVacuumUnix int64
+	LastSpanRatio  uint64
+	LastPages      uint64
+	LastErr        string
+
+	LastFreelistReclaimablePages uint64
+	LastFreelistReclaimableRatio uint64
+	LastCollectionRootPages      uint64
+	LastCollectionRootSpanRatio  uint64
+	LastDebtReason               string
 }
 
 // Stats returns a snapshot of background index vacuum state and recent run info.
-func (w *bgIndexVacuumWorker) Stats() (enabled bool, interval time.Duration, spanRatioPPM uint32, runs uint64, vacuums uint64, lastRunUnix int64, lastVacuumUnix int64, lastSpanRatio uint64, lastPages uint64, lastErr string) {
-	enabled = w.Enabled()
-	interval = w.interval
-	spanRatioPPM = w.spanRatioPPM
-	runs = w.runs.Load()
-	vacuums = w.vacuums.Load()
-	lastRunUnix = w.lastRunUnix.Load()
-	lastVacuumUnix = w.lastVacuumUnix.Load()
-	lastSpanRatio = w.lastSpanRatio.Load()
-	lastPages = w.lastPages.Load()
-	if v := w.lastErr.Load(); v != nil {
-		lastErr, _ = v.(string)
+func (w *bgIndexVacuumWorker) Stats() bgIndexVacuumStats {
+	out := bgIndexVacuumStats{
+		Enabled:                      w.Enabled(),
+		Interval:                     w.interval,
+		SpanRatioPPM:                 w.userSpanRatioThreshold(),
+		MaxBacklogSkips:              w.maxBacklogSkipThreshold(),
+		FreelistReclaimableRatioPPM:  w.freelistReclaimableRatioThreshold(),
+		FreelistReclaimablePages:     w.freelistReclaimablePagesThreshold(),
+		CollectionRootSpanRatioPPM:   w.collectionRootSpanRatioThreshold(),
+		CollectionRootPages:          w.collectionRootPagesThreshold(),
+		Runs:                         w.runs.Load(),
+		Probes:                       w.probes.Load(),
+		Vacuums:                      w.vacuums.Load(),
+		BacklogConsecutiveSkips:      w.backlogConsecutiveSkips.Load(),
+		BacklogSkips:                 w.backlogSkips.Load(),
+		BacklogForcedRuns:            w.backlogForcedRuns.Load(),
+		LastBacklogBytes:             w.lastBacklogBytes.Load(),
+		LastRunUnix:                  w.lastRunUnix.Load(),
+		LastVacuumUnix:               w.lastVacuumUnix.Load(),
+		LastSpanRatio:                w.lastSpanRatio.Load(),
+		LastPages:                    w.lastPages.Load(),
+		LastFreelistReclaimablePages: w.lastFreelistReclaimablePages.Load(),
+		LastFreelistReclaimableRatio: w.lastFreelistReclaimableRatio.Load(),
+		LastCollectionRootPages:      w.lastCollectionRootPages.Load(),
+		LastCollectionRootSpanRatio:  w.lastCollectionRootSpanRatio.Load(),
 	}
-	return
+	if v := w.lastErr.Load(); v != nil {
+		out.LastErr, _ = v.(string)
+	}
+	if v := w.lastDebtReason.Load(); v != nil {
+		out.LastDebtReason, _ = v.(string)
+	}
+	if out.LastDebtReason == "" {
+		out.LastDebtReason = backgroundIndexVacuumDebtReasonNone
+	}
+	return out
 }
 
 func bgIndexVacuumStatsInto(out map[string]string, w *bgIndexVacuumWorker) {
-	enabled, interval, spanRatioPPM, runs, vacuums, lastRunUnix, lastVacuumUnix, lastSpanRatio, lastPages, lastErr := w.Stats()
-	out["treedb.bg_vacuum.enabled"] = fmt.Sprintf("%t", enabled)
-	out["treedb.bg_vacuum.interval_ms"] = fmt.Sprintf("%d", interval.Milliseconds())
-	out["treedb.bg_vacuum.span_ratio_ppm_threshold"] = fmt.Sprintf("%d", spanRatioPPM)
-	out["treedb.bg_vacuum.runs"] = fmt.Sprintf("%d", runs)
-	out["treedb.bg_vacuum.vacuums"] = fmt.Sprintf("%d", vacuums)
-	out["treedb.bg_vacuum.last_run_unix"] = fmt.Sprintf("%d", lastRunUnix)
-	out["treedb.bg_vacuum.last_vacuum_unix"] = fmt.Sprintf("%d", lastVacuumUnix)
-	out["treedb.bg_vacuum.last_span_ratio_ppm"] = fmt.Sprintf("%d", lastSpanRatio)
-	out["treedb.bg_vacuum.last_pages"] = fmt.Sprintf("%d", lastPages)
-	if lastErr != "" {
-		out["treedb.bg_vacuum.last_err"] = lastErr
+	stats := w.Stats()
+	out["treedb.bg_vacuum.enabled"] = fmt.Sprintf("%t", stats.Enabled)
+	out["treedb.bg_vacuum.interval_ms"] = fmt.Sprintf("%d", stats.Interval.Milliseconds())
+	out["treedb.bg_vacuum.span_ratio_ppm_threshold"] = fmt.Sprintf("%d", stats.SpanRatioPPM)
+	out["treedb.bg_vacuum.freelist_reclaimable_ratio_ppm_threshold"] = fmt.Sprintf("%d", stats.FreelistReclaimableRatioPPM)
+	out["treedb.bg_vacuum.freelist_reclaimable_pages_threshold"] = fmt.Sprintf("%d", stats.FreelistReclaimablePages)
+	out["treedb.bg_vacuum.collection_roots_span_ratio_ppm_threshold"] = fmt.Sprintf("%d", stats.CollectionRootSpanRatioPPM)
+	out["treedb.bg_vacuum.collection_roots_pages_threshold"] = fmt.Sprintf("%d", stats.CollectionRootPages)
+	out["treedb.bg_vacuum.max_backlog_skips"] = fmt.Sprintf("%d", stats.MaxBacklogSkips)
+	out["treedb.bg_vacuum.runs"] = fmt.Sprintf("%d", stats.Runs)
+	out["treedb.bg_vacuum.trigger_probes"] = fmt.Sprintf("%d", stats.Probes)
+	out["treedb.bg_vacuum.vacuums"] = fmt.Sprintf("%d", stats.Vacuums)
+	out["treedb.bg_vacuum.backlog_skips_consecutive"] = fmt.Sprintf("%d", stats.BacklogConsecutiveSkips)
+	out["treedb.bg_vacuum.backlog_skips_total"] = fmt.Sprintf("%d", stats.BacklogSkips)
+	out["treedb.bg_vacuum.backlog_forced_runs"] = fmt.Sprintf("%d", stats.BacklogForcedRuns)
+	out["treedb.bg_vacuum.last_backlog_bytes"] = fmt.Sprintf("%d", stats.LastBacklogBytes)
+	out["treedb.bg_vacuum.last_run_unix"] = fmt.Sprintf("%d", stats.LastRunUnix)
+	out["treedb.bg_vacuum.last_vacuum_unix"] = fmt.Sprintf("%d", stats.LastVacuumUnix)
+	out["treedb.bg_vacuum.last_span_ratio_ppm"] = fmt.Sprintf("%d", stats.LastSpanRatio)
+	out["treedb.bg_vacuum.last_pages"] = fmt.Sprintf("%d", stats.LastPages)
+	out["treedb.bg_vacuum.last_freelist_reclaimable_pages"] = fmt.Sprintf("%d", stats.LastFreelistReclaimablePages)
+	out["treedb.bg_vacuum.last_freelist_reclaimable_ratio_ppm"] = fmt.Sprintf("%d", stats.LastFreelistReclaimableRatio)
+	out["treedb.bg_vacuum.last_collection_roots_pages"] = fmt.Sprintf("%d", stats.LastCollectionRootPages)
+	out["treedb.bg_vacuum.last_collection_roots_span_ratio_ppm"] = fmt.Sprintf("%d", stats.LastCollectionRootSpanRatio)
+	out["treedb.bg_vacuum.last_debt_reason"] = stats.LastDebtReason
+	if stats.LastErr != "" {
+		out["treedb.bg_vacuum.last_err"] = stats.LastErr
 	}
 }

--- a/TreeDB/bg_vacuum.go
+++ b/TreeDB/bg_vacuum.go
@@ -100,14 +100,22 @@ type bgIndexVacuumWorker struct {
 	lastCollectionRootSpanRatio  atomic.Uint64
 	lastDebtReason               atomic.Value // string
 
-	lastProbeCommitSeq uint64
-	lastProbeValid     bool
-	retryProbe         bool
+	lastProbeCommitSeq              uint64
+	lastProbeFreelistReclaimable    uint64
+	lastProbeFreelistReclaimablePPM uint64
+	lastProbeFreelistValid          bool
+	lastProbeValid                  bool
+	retryProbe                      bool
 }
 
 var bgIndexVacuumBacklogBytesHook struct {
 	mu sync.RWMutex
 	fn func(*DB) int64
+}
+
+var bgIndexVacuumFreelistDebtSnapshotHook struct {
+	mu sync.RWMutex
+	fn func(*DB) (backenddb.IndexVacuumFreelistDebtSnapshot, bool)
 }
 
 func setBackgroundIndexVacuumBacklogBytesHookForTest(fn func(*DB) int64) func() {
@@ -122,6 +130,18 @@ func setBackgroundIndexVacuumBacklogBytesHookForTest(fn func(*DB) int64) func() 
 	}
 }
 
+func setBackgroundIndexVacuumFreelistDebtSnapshotHookForTest(fn func(*DB) (backenddb.IndexVacuumFreelistDebtSnapshot, bool)) func() {
+	bgIndexVacuumFreelistDebtSnapshotHook.mu.Lock()
+	prev := bgIndexVacuumFreelistDebtSnapshotHook.fn
+	bgIndexVacuumFreelistDebtSnapshotHook.fn = fn
+	bgIndexVacuumFreelistDebtSnapshotHook.mu.Unlock()
+	return func() {
+		bgIndexVacuumFreelistDebtSnapshotHook.mu.Lock()
+		bgIndexVacuumFreelistDebtSnapshotHook.fn = prev
+		bgIndexVacuumFreelistDebtSnapshotHook.mu.Unlock()
+	}
+}
+
 func backgroundIndexVacuumBacklogBytes(db *DB) int64 {
 	bgIndexVacuumBacklogBytesHook.mu.RLock()
 	hook := bgIndexVacuumBacklogBytesHook.fn
@@ -133,6 +153,19 @@ func backgroundIndexVacuumBacklogBytes(db *DB) int64 {
 		return 0
 	}
 	return db.cached.QueueBacklogBytes()
+}
+
+func backgroundIndexVacuumFreelistDebtSnapshot(db *DB) (backenddb.IndexVacuumFreelistDebtSnapshot, bool) {
+	bgIndexVacuumFreelistDebtSnapshotHook.mu.RLock()
+	hook := bgIndexVacuumFreelistDebtSnapshotHook.fn
+	bgIndexVacuumFreelistDebtSnapshotHook.mu.RUnlock()
+	if hook != nil {
+		return hook(db)
+	}
+	if db == nil || db.backend == nil {
+		return backenddb.IndexVacuumFreelistDebtSnapshot{}, false
+	}
+	return db.backend.IndexVacuumFreelistDebtSnapshot()
 }
 
 // Start launches the background index vacuum loop with the provided interval.
@@ -237,7 +270,7 @@ func (w *bgIndexVacuumWorker) runOnce(db *DB) {
 		w.backlogConsecutiveSkips.Store(0)
 	}
 
-	if !forcedAfterBacklog && w.lastProbeValid && !w.retryProbe && state.CommitSeq == w.lastProbeCommitSeq {
+	if !forcedAfterBacklog && w.lastProbeValid && !w.retryProbe && state.CommitSeq == w.lastProbeCommitSeq && !w.freelistDebtChangedSinceLastProbe(db) {
 		w.finishRun(now, "")
 		return
 	}
@@ -252,6 +285,9 @@ func (w *bgIndexVacuumWorker) runOnce(db *DB) {
 	}
 
 	w.lastProbeCommitSeq = rep.CommitSeq
+	w.lastProbeFreelistReclaimable = rep.FreelistReclaimablePages
+	w.lastProbeFreelistReclaimablePPM = rep.FreelistReclaimableRatioPPM
+	w.lastProbeFreelistValid = rep.FreelistReclaimableValid
 	w.lastProbeValid = true
 	w.recordLastTriggerReport(rep)
 
@@ -274,6 +310,19 @@ func (w *bgIndexVacuumWorker) runOnce(db *DB) {
 	w.vacuums.Add(1)
 	w.finishRun(now, "")
 	w.lastVacuumUnix.Store(now.Unix())
+}
+
+func (w *bgIndexVacuumWorker) freelistDebtChangedSinceLastProbe(db *DB) bool {
+	if w.freelistReclaimablePages == 0 && w.freelistReclaimableRatioPPM == 0 {
+		return false
+	}
+	snap, ok := backgroundIndexVacuumFreelistDebtSnapshot(db)
+	if !ok {
+		return true
+	}
+	return snap.FreelistReclaimableValid != w.lastProbeFreelistValid ||
+		snap.FreelistReclaimable != w.lastProbeFreelistReclaimable ||
+		snap.FreelistReclaimablePPM != w.lastProbeFreelistReclaimablePPM
 }
 
 func (w *bgIndexVacuumWorker) finishRun(now time.Time, err string) {

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -1243,9 +1243,22 @@ type Options struct {
 	// BackgroundIndexVacuumInterval enables periodic online index vacuum passes.
 	// `0` uses a default; `<0` disables.
 	BackgroundIndexVacuumInterval time.Duration
-	// BackgroundIndexVacuumSpanRatioPPM sets the span ratio threshold that
-	// triggers a vacuum pass (0 uses a default).
+	// BackgroundIndexVacuumSpanRatioPPM sets the user-tree span ratio threshold
+	// that triggers a vacuum pass (0 uses a default).
 	BackgroundIndexVacuumSpanRatioPPM uint32
+	// BackgroundIndexVacuumMaxBacklogSkips bounds consecutive cached-backlog skips
+	// before a trigger probe is forced (0 uses a conservative default).
+	BackgroundIndexVacuumMaxBacklogSkips uint32
+	// BackgroundIndexVacuumFreelistReclaimableRatioPPM and
+	// BackgroundIndexVacuumFreelistReclaimablePages trigger vacuum when both
+	// freelist reclaimable debt thresholds are met (0 uses conservative defaults).
+	BackgroundIndexVacuumFreelistReclaimableRatioPPM uint32
+	BackgroundIndexVacuumFreelistReclaimablePages    uint64
+	// BackgroundIndexVacuumCollectionRootSpanRatioPPM and
+	// BackgroundIndexVacuumCollectionRootPages trigger vacuum when both
+	// collection-root span debt thresholds are met (0 uses conservative defaults).
+	BackgroundIndexVacuumCollectionRootSpanRatioPPM uint32
+	BackgroundIndexVacuumCollectionRootPages        uint64
 	// MaxWALBytes triggers an immediate checkpoint in cached mode when the sum of
 	// WAL segment sizes exceeds this many bytes (0 uses a default; <0 disables the
 	// size trigger). This is an operational safety cap; it does not make each
@@ -2385,8 +2398,12 @@ func (db *DB) recover() error {
 		p.SetPageCount(chosen.meta.TotalPages)
 	}
 
-	// Update Allocator Head
+	// Update Allocator Head and best-effort seed cheap freelist debt counters used
+	// by background vacuum trigger reports. Keep open behavior tolerant: if the
+	// optional seed walk fails, the trigger treats absent reclaimable counts as
+	// no debt and FragmentationReport can still surface the detailed error.
 	idx.allocator.SetHead(chosen.meta.FreelistHeadID)
+	_ = idx.allocator.RefreshStats(chosen.meta.TotalPages)
 
 	return nil
 }

--- a/TreeDB/db/fragmentation.go
+++ b/TreeDB/db/fragmentation.go
@@ -70,6 +70,16 @@ func emitFragmentationProbeEvent(event FragmentationProbeEvent) {
 //   - CollectionRoot* fields are computed by walking collection root descriptors
 //     and their pager-backed roots. Span-ratio fields are valid only when a
 //     pager-backed collection root exists.
+type IndexVacuumFreelistDebtSnapshot struct {
+	TotalPages               uint64
+	FreelistHead             uint64
+	FreelistPages            uint64
+	FreelistFreeIDs          uint64
+	FreelistReclaimable      uint64
+	FreelistReclaimablePPM   uint64
+	FreelistReclaimableValid bool
+}
+
 type IndexVacuumTriggerReport struct {
 	CommitSeq uint64
 
@@ -103,6 +113,36 @@ type IndexVacuumTriggerReport struct {
 	CollectionRootDuplicatePageRefs uint64
 	CollectionRootLeafPages         uint64
 	CollectionRootInternalPages     uint64
+}
+
+// IndexVacuumFreelistDebtSnapshot returns the cheap freelist-debt fields used
+// to invalidate unchanged-CommitSeq background-vacuum trigger caches. It does
+// not walk the user tree, collection roots, or freelist chain.
+func (db *DB) IndexVacuumFreelistDebtSnapshot() (IndexVacuumFreelistDebtSnapshot, bool) {
+	snap := db.AcquireSnapshot()
+	if snap == nil || snap.idx == nil || snap.idx.allocator == nil {
+		if snap != nil {
+			_ = snap.Close()
+		}
+		return IndexVacuumFreelistDebtSnapshot{}, false
+	}
+	defer func() { _ = snap.Close() }()
+
+	out := IndexVacuumFreelistDebtSnapshot{}
+	if snap.idx.pager != nil {
+		out.TotalPages = snap.idx.pager.PageCount()
+	}
+	emitFragmentationProbeEvent(FragmentationProbeEventTriggerFreelistCounters)
+	fs := snap.idx.allocator.Counters()
+	out.FreelistHead = fs.Head
+	out.FreelistPages = fs.Pages
+	out.FreelistFreeIDs = fs.FreeIDs
+	out.FreelistReclaimable = fs.ReclaimablePages()
+	if fs.Head != 0 && out.TotalPages > 0 {
+		out.FreelistReclaimablePPM = (out.FreelistReclaimable * 1_000_000) / out.TotalPages
+		out.FreelistReclaimableValid = true
+	}
+	return out, true
 }
 
 // IndexVacuumTriggerReport returns the trigger report for automatic index

--- a/TreeDB/db/fragmentation.go
+++ b/TreeDB/db/fragmentation.go
@@ -11,19 +11,20 @@ import (
 )
 
 // FragmentationProbeEvent identifies structural maintenance probe phases for
-// deterministic tests. These events are intentionally coarse: the cheap index
-// vacuum trigger may walk the user index, but must not use the full freelist
-// chain or collection-root walks that FragmentationReport performs.
+// deterministic tests. These events are intentionally coarse: the index vacuum
+// trigger walks only the structures included in IndexVacuumTriggerReport, not
+// the fill-percentile/full-report path used by FragmentationReport.
 type FragmentationProbeEvent string
 
 const (
-	FragmentationProbeEventFullReport              FragmentationProbeEvent = "full_report"
-	FragmentationProbeEventFullUserTreeWalk        FragmentationProbeEvent = "full_user_tree_walk"
-	FragmentationProbeEventFullFreelistChainWalk   FragmentationProbeEvent = "full_freelist_chain_walk"
-	FragmentationProbeEventFullCollectionRootWalk  FragmentationProbeEvent = "full_collection_root_walk"
-	FragmentationProbeEventTriggerReport           FragmentationProbeEvent = "index_vacuum_trigger_report"
-	FragmentationProbeEventTriggerUserTreeWalk     FragmentationProbeEvent = "index_vacuum_trigger_user_tree_walk"
-	FragmentationProbeEventTriggerFreelistCounters FragmentationProbeEvent = "index_vacuum_trigger_freelist_counters"
+	FragmentationProbeEventFullReport                FragmentationProbeEvent = "full_report"
+	FragmentationProbeEventFullUserTreeWalk          FragmentationProbeEvent = "full_user_tree_walk"
+	FragmentationProbeEventFullFreelistChainWalk     FragmentationProbeEvent = "full_freelist_chain_walk"
+	FragmentationProbeEventFullCollectionRootWalk    FragmentationProbeEvent = "full_collection_root_walk"
+	FragmentationProbeEventTriggerReport             FragmentationProbeEvent = "index_vacuum_trigger_report"
+	FragmentationProbeEventTriggerUserTreeWalk       FragmentationProbeEvent = "index_vacuum_trigger_user_tree_walk"
+	FragmentationProbeEventTriggerFreelistCounters   FragmentationProbeEvent = "index_vacuum_trigger_freelist_counters"
+	FragmentationProbeEventTriggerCollectionRootWalk FragmentationProbeEvent = "index_vacuum_trigger_collection_root_walk"
 )
 
 var fragmentationProbeHook struct {
@@ -62,10 +63,13 @@ func emitFragmentationProbeEvent(event FragmentationProbeEvent) {
 //   - CommitSeq is the snapshot state used for this report.
 //   - User* fields are computed by one user-index page walk and preserve the
 //     treedb.user.pages.span_ratio_ppm semantics from FragmentationReport.
-//   - Freelist* fields come from allocator.Counters(); they are cheap in-memory
-//     counters and intentionally do not include reclaimable page counts or a
-//     reclaimable ratio, both of which require walking the on-disk freelist chain.
-//   - Collection roots are intentionally not inspected.
+//   - Freelist* fields come from allocator.Counters(); Pages/FreeIDs are seeded
+//     at open and maintained incrementally so the trigger avoids per-probe
+//     freelist-chain walks. Freelist reclaimable fields are valid only when the
+//     allocator reports a non-empty freelist and total pages are known.
+//   - CollectionRoot* fields are computed by walking collection root descriptors
+//     and their pager-backed roots. Span-ratio fields are valid only when a
+//     pager-backed collection root exists.
 type IndexVacuumTriggerReport struct {
 	CommitSeq uint64
 
@@ -75,16 +79,36 @@ type IndexVacuumTriggerReport struct {
 	UserSpan         uint64
 	UserSpanRatioPPM uint64
 
+	TotalPages uint64
+
 	FreelistHead                  uint64
+	FreelistPages                 uint64
+	FreelistFreeIDs               uint64
+	FreelistReclaimablePages      uint64
+	FreelistReclaimableRatioPPM   uint64
+	FreelistReclaimableValid      bool
 	FreelistAllocPagesTotal       uint64
 	FreelistAppendAllocPagesTotal uint64
 	FreelistReuseAllocPagesTotal  uint64
 	FreelistFreePagesTotal        uint64
+
+	CollectionRootCount             uint64
+	CollectionRootPagerRoots        uint64
+	CollectionRootPages             uint64
+	CollectionRootMinPageID         uint64
+	CollectionRootMaxPageID         uint64
+	CollectionRootSpan              uint64
+	CollectionRootSpanRatioPPM      uint64
+	CollectionRootSpanRatioValid    bool
+	CollectionRootDuplicatePageRefs uint64
+	CollectionRootLeafPages         uint64
+	CollectionRootInternalPages     uint64
 }
 
-// IndexVacuumTriggerReport returns the cheap trigger report for automatic index
-// vacuum. Unlike FragmentationReport, it avoids fill-percentile allocation,
-// freelist-chain stats, and collection-root scans.
+// IndexVacuumTriggerReport returns the trigger report for automatic index
+// vacuum. Unlike FragmentationReport, it avoids fill-percentile allocation and
+// full-report map parsing; freelist reclaimable debt uses seeded incremental
+// counters rather than walking the on-disk freelist chain.
 func (db *DB) IndexVacuumTriggerReport() (IndexVacuumTriggerReport, error) {
 	emitFragmentationProbeEvent(FragmentationProbeEventTriggerReport)
 
@@ -98,6 +122,9 @@ func (db *DB) IndexVacuumTriggerReport() (IndexVacuumTriggerReport, error) {
 	defer func() { _ = snap.Close() }()
 
 	out := IndexVacuumTriggerReport{CommitSeq: snap.state.CommitSeq}
+	if snap.idx.pager != nil {
+		out.TotalPages = snap.idx.pager.PageCount()
+	}
 
 	emitFragmentationProbeEvent(FragmentationProbeEventTriggerUserTreeWalk)
 	err := snap.tree.WalkPages(func(pageID uint64, _ node.Node) error {
@@ -127,10 +154,36 @@ func (db *DB) IndexVacuumTriggerReport() (IndexVacuumTriggerReport, error) {
 		emitFragmentationProbeEvent(FragmentationProbeEventTriggerFreelistCounters)
 		fs := snap.idx.allocator.Counters()
 		out.FreelistHead = fs.Head
+		out.FreelistPages = fs.Pages
+		out.FreelistFreeIDs = fs.FreeIDs
+		out.FreelistReclaimablePages = fs.ReclaimablePages()
+		if fs.Head != 0 && out.TotalPages > 0 {
+			out.FreelistReclaimableRatioPPM = (out.FreelistReclaimablePages * 1_000_000) / out.TotalPages
+			out.FreelistReclaimableValid = true
+		}
 		out.FreelistAllocPagesTotal = fs.AllocPages
 		out.FreelistAppendAllocPagesTotal = fs.AppendAllocPages
 		out.FreelistReuseAllocPagesTotal = fs.ReuseAllocPages
 		out.FreelistFreePagesTotal = fs.FreePages
+	}
+
+	emitFragmentationProbeEvent(FragmentationProbeEventTriggerCollectionRootWalk)
+	if collection, err := collectionRootFragmentationStats(snap.idx, snap.state); err == nil {
+		out.CollectionRootCount = collection.roots
+		out.CollectionRootPagerRoots = collection.pagerRoots
+		out.CollectionRootPages = collection.pages
+		out.CollectionRootDuplicatePageRefs = collection.duplicatePages
+		out.CollectionRootLeafPages = collection.leafPages
+		out.CollectionRootInternalPages = collection.internalPages
+		if collection.hasPagerBackedID {
+			out.CollectionRootMinPageID = collection.minPageID
+			out.CollectionRootMaxPageID = collection.maxPageID
+			out.CollectionRootSpan = (collection.maxPageID - collection.minPageID) + 1
+			if collection.pages > 0 {
+				out.CollectionRootSpanRatioPPM = (out.CollectionRootSpan * 1_000_000) / collection.pages
+				out.CollectionRootSpanRatioValid = true
+			}
+		}
 	}
 	return out, nil
 }

--- a/TreeDB/db/fragmentation_trigger_test.go
+++ b/TreeDB/db/fragmentation_trigger_test.go
@@ -61,6 +61,9 @@ func compareTriggerToFullFragmentationReport(t *testing.T, d *DB, label string) 
 	if got := counts[FragmentationProbeEventTriggerFreelistCounters]; got != 1 {
 		t.Fatalf("%s trigger freelist counter reads=%d want 1", label, got)
 	}
+	if got := counts[FragmentationProbeEventTriggerCollectionRootWalk]; got != 1 {
+		t.Fatalf("%s trigger collection-root walks=%d want 1", label, got)
+	}
 	if got := counts[FragmentationProbeEventFullReport]; got != 0 {
 		t.Fatalf("%s full fragmentation reports during trigger=%d want 0", label, got)
 	}
@@ -82,6 +85,7 @@ func compareTriggerToFullFragmentationReport(t *testing.T, d *DB, label string) 
 		t.Fatalf("%s CommitSeq=%d want %d", label, trigger.CommitSeq, state.CommitSeq)
 	}
 
+	assertTriggerFieldMatchesFullReport(t, label, "treedb.pages.total", trigger.TotalPages, full)
 	assertTriggerFieldMatchesFullReport(t, label, "treedb.user.pages", trigger.UserPages, full)
 	if trigger.UserPages > 0 {
 		assertTriggerFieldMatchesFullReport(t, label, "treedb.user.pages.min", trigger.UserMinPageID, full)
@@ -96,14 +100,25 @@ func compareTriggerToFullFragmentationReport(t *testing.T, d *DB, label string) 
 	}
 	counters := idx.allocator.Counters()
 	if trigger.FreelistHead != counters.Head ||
+		trigger.FreelistPages != counters.Pages ||
+		trigger.FreelistFreeIDs != counters.FreeIDs ||
 		trigger.FreelistAllocPagesTotal != counters.AllocPages ||
 		trigger.FreelistAppendAllocPagesTotal != counters.AppendAllocPages ||
 		trigger.FreelistReuseAllocPagesTotal != counters.ReuseAllocPages ||
 		trigger.FreelistFreePagesTotal != counters.FreePages {
-		t.Fatalf("%s freelist counters mismatch: trigger={head:%d alloc:%d append:%d reuse:%d free:%d} counters={head:%d alloc:%d append:%d reuse:%d free:%d}",
+		t.Fatalf("%s freelist counters mismatch: trigger={head:%d pages:%d free_ids:%d alloc:%d append:%d reuse:%d free:%d} counters={head:%d pages:%d free_ids:%d alloc:%d append:%d reuse:%d free:%d}",
 			label,
-			trigger.FreelistHead, trigger.FreelistAllocPagesTotal, trigger.FreelistAppendAllocPagesTotal, trigger.FreelistReuseAllocPagesTotal, trigger.FreelistFreePagesTotal,
-			counters.Head, counters.AllocPages, counters.AppendAllocPages, counters.ReuseAllocPages, counters.FreePages)
+			trigger.FreelistHead, trigger.FreelistPages, trigger.FreelistFreeIDs, trigger.FreelistAllocPagesTotal, trigger.FreelistAppendAllocPagesTotal, trigger.FreelistReuseAllocPagesTotal, trigger.FreelistFreePagesTotal,
+			counters.Head, counters.Pages, counters.FreeIDs, counters.AllocPages, counters.AppendAllocPages, counters.ReuseAllocPages, counters.FreePages)
+	}
+	if trigger.FreelistReclaimableValid {
+		assertTriggerFieldMatchesFullReport(t, label, "treedb.freelist.reclaimable_pages", trigger.FreelistReclaimablePages, full)
+		assertTriggerFieldMatchesFullReport(t, label, "treedb.freelist.reclaimable_ratio_ppm", trigger.FreelistReclaimableRatioPPM, full)
+	}
+	if trigger.CollectionRootSpanRatioValid {
+		assertTriggerFieldMatchesFullReport(t, label, "treedb.collection_roots.pages", trigger.CollectionRootPages, full)
+		assertTriggerFieldMatchesFullReport(t, label, "treedb.collection_roots.pages.span", trigger.CollectionRootSpan, full)
+		assertTriggerFieldMatchesFullReport(t, label, "treedb.collection_roots.pages.span_ratio_ppm", trigger.CollectionRootSpanRatioPPM, full)
 	}
 }
 

--- a/TreeDB/db/fragmentation_trigger_test.go
+++ b/TreeDB/db/fragmentation_trigger_test.go
@@ -112,8 +112,15 @@ func compareTriggerToFullFragmentationReport(t *testing.T, d *DB, label string) 
 			counters.Head, counters.Pages, counters.FreeIDs, counters.AllocPages, counters.AppendAllocPages, counters.ReuseAllocPages, counters.FreePages)
 	}
 	if trigger.FreelistReclaimableValid {
-		assertTriggerFieldMatchesFullReport(t, label, "treedb.freelist.reclaimable_pages", trigger.FreelistReclaimablePages, full)
-		assertTriggerFieldMatchesFullReport(t, label, "treedb.freelist.reclaimable_ratio_ppm", trigger.FreelistReclaimableRatioPPM, full)
+		if got, want := trigger.FreelistReclaimablePages, counters.ReclaimablePages(); got != want {
+			t.Fatalf("%s trigger freelist reclaimable pages=%d want allocator counters %d", label, got, want)
+		}
+		if trigger.TotalPages > 0 {
+			wantRatio := (trigger.FreelistReclaimablePages * 1_000_000) / trigger.TotalPages
+			if got := trigger.FreelistReclaimableRatioPPM; got != wantRatio {
+				t.Fatalf("%s trigger freelist reclaimable ratio=%d want %d", label, got, wantRatio)
+			}
+		}
 	}
 	if trigger.CollectionRootSpanRatioValid {
 		assertTriggerFieldMatchesFullReport(t, label, "treedb.collection_roots.pages", trigger.CollectionRootPages, full)

--- a/TreeDB/freelist/allocator.go
+++ b/TreeDB/freelist/allocator.go
@@ -85,6 +85,23 @@ func (a *Allocator) SetHead(h uint64) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	a.head = h
+	a.stats.Pages = 0
+	a.stats.FreeIDs = 0
+}
+
+// RefreshStats seeds the cheap freelist counters from the on-disk freelist
+// chain. Callers use this after opening an existing DB so Counters can report
+// current reclaimable debt without walking the chain on every maintenance tick.
+func (a *Allocator) RefreshStats(pageLimit uint64) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	out, err := readStatsLocked(a.pager, a.head, pageLimit)
+	if err != nil {
+		return err
+	}
+	a.stats.Pages = out.Pages
+	a.stats.FreeIDs = out.FreeIDs
+	return nil
 }
 
 func (a *Allocator) SetPreferAppend(prefer bool) {
@@ -169,6 +186,9 @@ func (a *Allocator) AllocMany(count int, hint uint64) ([]uint64, error) {
 			a.lastAlloc = recycled
 			a.stats.AllocPages++
 			a.stats.ReuseAllocPages++
+			if a.stats.Pages > 0 {
+				a.stats.Pages--
+			}
 			ids = append(ids, recycled)
 			continue
 		}
@@ -181,6 +201,9 @@ func (a *Allocator) AllocMany(count int, hint uint64) ([]uint64, error) {
 			a.lastAlloc = id
 			a.stats.AllocPages++
 			a.stats.ReuseAllocPages++
+			if a.stats.FreeIDs > 0 {
+				a.stats.FreeIDs--
+			}
 			ids = append(ids, id)
 			countFree--
 		}
@@ -264,6 +287,9 @@ func (a *Allocator) allocLocked(hint uint64) (uint64, error) {
 				a.lastAlloc = id
 				a.stats.AllocPages++
 				a.stats.ReuseAllocPages++
+				if a.stats.FreeIDs > 0 {
+					a.stats.FreeIDs--
+				}
 				return id, nil
 			}
 		}
@@ -277,6 +303,9 @@ func (a *Allocator) allocLocked(hint uint64) (uint64, error) {
 		a.lastAlloc = id
 		a.stats.AllocPages++
 		a.stats.ReuseAllocPages++
+		if a.stats.FreeIDs > 0 {
+			a.stats.FreeIDs--
+		}
 		return id, nil
 	}
 
@@ -289,6 +318,9 @@ func (a *Allocator) allocLocked(hint uint64) (uint64, error) {
 	a.lastAlloc = recycled
 	a.stats.AllocPages++
 	a.stats.ReuseAllocPages++
+	if a.stats.Pages > 0 {
+		a.stats.Pages--
+	}
 	return recycled, nil
 }
 
@@ -317,6 +349,7 @@ func (a *Allocator) Free(id uint64) error {
 			return err
 		}
 		a.stats.FreePages++
+		a.stats.Pages++
 		return nil
 	}
 
@@ -344,6 +377,7 @@ func (a *Allocator) Free(id uint64) error {
 		}
 		n.UpdateChecksum()
 		a.stats.FreePages++
+		a.stats.FreeIDs++
 		return nil
 	}
 
@@ -353,6 +387,7 @@ func (a *Allocator) Free(id uint64) error {
 		return err
 	}
 	a.stats.FreePages++
+	a.stats.Pages++
 	return nil
 }
 
@@ -385,6 +420,10 @@ func (a *Allocator) Stats(pageLimit uint64) (Stats, error) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	out, err := readStatsLocked(a.pager, a.head, pageLimit)
+	if err == nil {
+		a.stats.Pages = out.Pages
+		a.stats.FreeIDs = out.FreeIDs
+	}
 	out.AllocPages = a.stats.AllocPages
 	out.AppendAllocPages = a.stats.AppendAllocPages
 	out.ReuseAllocPages = a.stats.ReuseAllocPages
@@ -399,6 +438,8 @@ func (a *Allocator) Counters() Stats {
 	defer a.mu.Unlock()
 	return Stats{
 		Head:             a.head,
+		Pages:            a.stats.Pages,
+		FreeIDs:          a.stats.FreeIDs,
 		AllocPages:       a.stats.AllocPages,
 		AppendAllocPages: a.stats.AppendAllocPages,
 		ReuseAllocPages:  a.stats.ReuseAllocPages,

--- a/TreeDB/public.go
+++ b/TreeDB/public.go
@@ -911,11 +911,15 @@ func Open(opts Options) (*DB, error) {
 		vacuumInterval = 0
 	}
 	if vacuumInterval > 0 {
-		spanRatioPPM := opts.BackgroundIndexVacuumSpanRatioPPM
-		if spanRatioPPM == 0 {
-			spanRatioPPM = defaultBackgroundIndexVacuumSpanRatioPPM
-		}
-		out.bgVac.Start(out, vacuumInterval, spanRatioPPM)
+		out.bgVac.Start(out, bgIndexVacuumConfig{
+			Interval:                    vacuumInterval,
+			SpanRatioPPM:                opts.BackgroundIndexVacuumSpanRatioPPM,
+			MaxBacklogSkips:             opts.BackgroundIndexVacuumMaxBacklogSkips,
+			FreelistReclaimableRatioPPM: opts.BackgroundIndexVacuumFreelistReclaimableRatioPPM,
+			FreelistReclaimablePages:    opts.BackgroundIndexVacuumFreelistReclaimablePages,
+			CollectionRootSpanRatioPPM:  opts.BackgroundIndexVacuumCollectionRootSpanRatioPPM,
+			CollectionRootPages:         opts.BackgroundIndexVacuumCollectionRootPages,
+		})
 	}
 	cached.SetStatsHook(out.publicCachedExpvarStatsInto)
 


### PR DESCRIPTION
## Summary

Fixes #3633. Part of #3630.

Changes:
- Adds bounded cached-backlog skip handling for background index vacuum.
  - Default cap: `BackgroundIndexVacuumMaxBacklogSkips=3` (0 => default).
  - Existing `treedb.bg_vacuum.runs` continues to count ticks/runOnce completions; `treedb.bg_vacuum.trigger_probes` distinguishes real trigger probes.
  - New stats expose consecutive/total backlog skips, forced-after-backlog runs, and last backlog bytes.
- Extends trigger predicates beyond user-tree span:
  - user-tree span ratio (existing default remains `1_200_000` ppm),
  - freelist reclaimable debt (defaults: ratio `250_000` ppm and pages `64`, both required),
  - collection-root span debt (defaults: ratio `1_200_000` ppm and pages `16`, both required).
- Uses PL-05 trigger plumbing from merged #3647: unchanged `CommitSeq` idle ticks still skip structural walks.
- Freelist reclaimable trigger uses seeded-at-open/incremental allocator counters, avoiding per-probe freelist-chain walks.
- Treats absent/invalid optional freelist or collection-root debt as no-debt.

## Final base / dependency status

- Predecessor #3632 / PR #3647 has merged.
- This PR is retargeted to `main` and includes head `5e31a16d861c5b960714e37aebdd68a6a0f6bc75` after final base update, macOS CI test stabilization, and Codex-requested freelist cache invalidation.
- No longer draft/blocked.

## Validation

Final focused tests after #3647 merged (rerun after macOS CI test stabilization):

```sh
GOWORK=off go test ./TreeDB ./TreeDB/db -run 'TestBackgroundIndexVacuum|TestFragmentationReport|TestValidateFragmentationReport|TestVacuumIndexOnline' -count=1
# ok github.com/snissn/gomap/TreeDB    1.998s
# ok github.com/snissn/gomap/TreeDB/db 77.679s
```

Final broader affected tests after #3647 merged:

```sh
GOWORK=off go test ./TreeDB ./TreeDB/db ./TreeDB/freelist -count=1
# ok github.com/snissn/gomap/TreeDB          49.261s
# ok github.com/snissn/gomap/TreeDB/db       256.241s
# ok github.com/snissn/gomap/TreeDB/freelist 0.004s
```

Earlier focused benchmarks on the same implementation:

```sh
GOWORK=off go test ./TreeDB -run '^$' -bench 'BenchmarkBackgroundIndexVacuumBacklog|BenchmarkBackgroundIndexVacuumTrigger' -benchmem -count=5
```

| Benchmark | ns/op | B/op | allocs/op |
| --- | ---: | ---: | ---: |
| `BenchmarkBackgroundIndexVacuumBacklog` | 85.93-93.52 | 0 | 0 |
| `BenchmarkBackgroundIndexVacuumTrigger` | 5588-5784 | 38540-38541 | 13 |

## Gate status

- Bounded backlog skips eventually force a trigger probe: covered by `TestBackgroundIndexVacuumSustainedBacklogForcesTriggerProbe`.
- Backlog clear resets skip counter: covered by `TestBackgroundIndexVacuumBacklogClearsResetsSkipCounter`.
- Independent trigger predicates: covered by synthetic predicate table plus real freelist/collection-root vacuum attempts.
- Idle unchanged-`CommitSeq` overhead: PL-05 idle test remains passing.
- No extra full `FragmentationReport` path in trigger: probe-hook tests assert no full-report events.
- Freelist debt changes without a `CommitSeq` bump invalidate the unchanged-commit probe cache: `TestBackgroundIndexVacuumFreelistDebtInvalidatesUnchangedCommitSkip`.

## Review status

- Latest-head CI: running for `5e31a16d861c5b960714e37aebdd68a6a0f6bc75`.
- Codex review: requested after final base update.
- CodeRabbit: pending after ready-for-review / latest head.
