### PR TITLE
treedb: sync empty command WAL batches without checkpoint

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -2548,22 +2548,20 @@ func (db *DB) markLaneValueLogBoundary(l *lane, totalBytes int64, flushedBoundar
 	l.vlogSyncPending.Store(true)
 }
 
-func (db *DB) checkpointFlushValueLogLanes() error {
+func (db *DB) flushPendingValueLogLanes(sync bool) error {
 	if db == nil || !db.splitValueLogEnabled() {
 		return nil
 	}
-	// Checkpoint is a durability boundary for cached mode. Ensure any buffered
-	// value-log bytes are visible before publishing pointers durably to the backend.
-	flushOnly := db.relaxedSync
+	actualSync := sync && !db.relaxedSync
 	for i := range db.lanes {
 		l := &db.lanes[i]
-		if !l.vlogDirty.Load() && !l.vlogSyncPending.Load() {
+		if !l.vlogDirty.Load() && !(actualSync && l.vlogSyncPending.Load()) {
 			continue
 		}
 		l.vlogMu.Lock()
 		w := l.vlog
 		var err error
-		syncBoundary := l.vlogSyncPending.Load() && !flushOnly
+		syncBoundary := actualSync && l.vlogSyncPending.Load()
 		if w != nil {
 			if syncBoundary {
 				err = w.Sync()
@@ -2573,7 +2571,7 @@ func (db *DB) checkpointFlushValueLogLanes() error {
 		}
 		if err == nil {
 			l.vlogDirty.Store(false)
-			if syncBoundary || flushOnly {
+			if syncBoundary || db.relaxedSync {
 				l.vlogSyncPending.Store(false)
 			}
 			l.backendReadFlushedSeq.Store(l.backendReadDirtySeq.Load())
@@ -2584,6 +2582,12 @@ func (db *DB) checkpointFlushValueLogLanes() error {
 		}
 	}
 	return nil
+}
+
+func (db *DB) checkpointFlushValueLogLanes() error {
+	// Checkpoint is a durability boundary for cached mode. Ensure any buffered
+	// value-log bytes are visible before publishing pointers durably to the backend.
+	return db.flushPendingValueLogLanes(true)
 }
 
 func (db *DB) syncDirBestEffort(dir string) {

--- a/TreeDB/caching/value_log_appender.go
+++ b/TreeDB/caching/value_log_appender.go
@@ -85,10 +85,7 @@ func (a *cachingValueLogAppender) FlushValueLogExternalRefs(fileIDs []uint32, sy
 		return errWALUnavailable
 	}
 	if len(fileIDs) == 0 {
-		if sync {
-			return a.Sync()
-		}
-		return a.Flush()
+		return a.db.flushPendingValueLogLanes(sync)
 	}
 	seenLanes := make(map[*lane]struct{}, len(fileIDs))
 	activeFileIDs := make(map[uint32]struct{}, len(fileIDs))

--- a/TreeDB/caching/value_log_appender_test.go
+++ b/TreeDB/caching/value_log_appender_test.go
@@ -41,3 +41,27 @@ func TestCachingValueLogExternalRefFlusherSyncsRotatedSegments(t *testing.T) {
 		t.Fatalf("FlushValueLogExternalRefs rotated segment: %v", err)
 	}
 }
+
+func TestCachingValueLogExternalRefFlusherEmptyIDsSyncsAllPendingLanes(t *testing.T) {
+	db := &DB{lanes: make([]lane, 2)}
+	writers := make([]*vlogDirtyOrderWriter, len(db.lanes))
+	for i := range db.lanes {
+		writers[i] = &vlogDirtyOrderWriter{}
+		db.lanes[i].id = i
+		db.lanes[i].vlog = writers[i]
+		db.lanes[i].vlogSyncPending.Store(true)
+	}
+	appender := &cachingValueLogAppender{db: db, lane: &db.lanes[0]}
+
+	if err := appender.FlushValueLogExternalRefs(nil, true); err != nil {
+		t.Fatalf("FlushValueLogExternalRefs all pending: %v", err)
+	}
+	for i := range db.lanes {
+		if got := writers[i].syncs.Load(); got != 1 {
+			t.Fatalf("lane %d syncs=%d, want 1", i, got)
+		}
+		if db.lanes[i].vlogSyncPending.Load() {
+			t.Fatalf("lane %d still has a pending sync", i)
+		}
+	}
+}

--- a/TreeDB/caching/vlog_dirty_order_test.go
+++ b/TreeDB/caching/vlog_dirty_order_test.go
@@ -15,6 +15,7 @@ import (
 type vlogDirtyOrderWriter struct {
 	size    int64
 	flushes atomic.Int64
+	syncs   atomic.Int64
 }
 
 var _ valueWriter = (*vlogDirtyOrderWriter)(nil)
@@ -65,7 +66,10 @@ func (w *vlogDirtyOrderWriter) Flush() error {
 	w.flushes.Add(1)
 	return nil
 }
-func (w *vlogDirtyOrderWriter) Sync() error  { return nil }
+func (w *vlogDirtyOrderWriter) Sync() error {
+	w.syncs.Add(1)
+	return nil
+}
 func (w *vlogDirtyOrderWriter) Close() error { return nil }
 
 func waitErr(t *testing.T, ch <-chan error, label string) error {

--- a/TreeDB/command_wal_public_cached.go
+++ b/TreeDB/command_wal_public_cached.go
@@ -280,7 +280,7 @@ func (tdb *DB) syncPublicCommandWAL() error {
 	if tdb.backend == nil {
 		return ErrClosed
 	}
-	return tdb.backend.FlushCommandWAL(publicCommandWALPublishSync(tdb.durabilityMode, true))
+	return tdb.backend.FlushCommandWALBarrier(publicCommandWALPublishSync(tdb.durabilityMode, true))
 }
 
 type commandWALPublicBatch struct {

--- a/TreeDB/command_wal_public_cached.go
+++ b/TreeDB/command_wal_public_cached.go
@@ -273,6 +273,16 @@ func publicCommandWALPublishSync(durabilityMode string, sync bool) bool {
 	return sync && strings.HasPrefix(durabilityMode, "wal_on_sync")
 }
 
+func (tdb *DB) syncPublicCommandWAL() error {
+	if tdb == nil || !tdb.commandWALCached {
+		return nil
+	}
+	if tdb.backend == nil {
+		return ErrClosed
+	}
+	return tdb.backend.FlushCommandWAL(publicCommandWALPublishSync(tdb.durabilityMode, true))
+}
+
 type commandWALPublicBatch struct {
 	db                       *DB
 	inner                    Batch
@@ -839,7 +849,7 @@ func (b *commandWALPublicBatch) write(sync bool) (err error) {
 		return nil
 	}
 	if sync {
-		if err := b.inner.WriteSync(); err != nil {
+		if err := b.db.syncPublicCommandWAL(); err != nil {
 			return err
 		}
 	} else {

--- a/TreeDB/command_wal_public_test.go
+++ b/TreeDB/command_wal_public_test.go
@@ -1029,6 +1029,30 @@ func TestPublicCommandWALDurableBatchWriteSyncDoesNotCheckpoint(t *testing.T) {
 	requireRawKVValue(t, reopen, key, want)
 }
 
+func TestPublicCommandWALDurableEmptyBatchWriteSyncOnlySyncsCommandWAL(t *testing.T) {
+	db, err := Open(commandWALDurabilityProofOptions(t.TempDir()))
+	if err != nil {
+		t.Fatalf("Open command WAL durable: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	before := db.Stats()
+	b := db.NewBatchWithSize(1)
+	if err := b.WriteSync(); err != nil {
+		_ = b.Close()
+		t.Fatalf("empty batch WriteSync: %v", err)
+	}
+	if err := b.Close(); err != nil {
+		t.Fatalf("empty batch Close: %v", err)
+	}
+
+	after := db.Stats()
+	requirePublicStatDelta(t, before, after, "treedb.public.batch.write_sync.calls_total", 1)
+	requirePublicStatDelta(t, before, after, "treedb.command_wal.sync.count_total", 1)
+	requirePublicStatDelta(t, before, after, "treedb.command_wal.append.count_total", 0)
+	requirePublicCommandWALNoCheckpointSince(t, db, before)
+}
+
 func TestPublicCommandWALBatchCloseDiscardsDirtyPayload(t *testing.T) {
 	db, err := Open(Options{
 		Dir:                 t.TempDir(),

--- a/TreeDB/db/command_wal_raw.go
+++ b/TreeDB/db/command_wal_raw.go
@@ -179,6 +179,32 @@ func (db *DB) FlushCommandWAL(sync bool) error {
 	return db.flushCommandWAL(sync, true)
 }
 
+// FlushCommandWALBarrier makes value-log bytes referenced by earlier command
+// frames durable before flushing the command WAL itself. It serializes with
+// command-WAL publishers so the two durability boundaries cannot be reordered.
+func (db *DB) FlushCommandWALBarrier(sync bool) error {
+	unlock, err := db.LockCommandWALPublishWithBarriers()
+	if err != nil {
+		return err
+	}
+	defer unlock()
+
+	if appender := db.currentValueLogAppender(); appender != nil {
+		if flusher, ok := appender.(ValueLogExternalRefFlusher); ok {
+			if err := flusher.FlushValueLogExternalRefs(nil, sync); err != nil {
+				return err
+			}
+		} else if sync {
+			if err := appender.Sync(); err != nil {
+				return err
+			}
+		} else if err := appender.Flush(); err != nil {
+			return err
+		}
+	}
+	return db.FlushCommandWAL(sync)
+}
+
 func (db *DB) flushCommandWAL(sync bool, observe bool) error {
 	if db == nil || !db.commandWAL || db.commandJournal == nil {
 		return nil

--- a/TreeDB/db/command_wal_raw_test.go
+++ b/TreeDB/db/command_wal_raw_test.go
@@ -18,6 +18,31 @@ type commandWALCountingValueLogAppender struct {
 	syncs   int
 }
 
+type commandWALBarrierTestAppender struct {
+	externalFlushes int
+	externalSync    bool
+	externalFileIDs []uint32
+	externalErr     error
+}
+
+func (a *commandWALBarrierTestAppender) AppendValues(values [][]byte) ([]page.ValuePtr, error) {
+	return nil, errors.New("unexpected AppendValues")
+}
+
+func (a *commandWALBarrierTestAppender) Flush() error { return nil }
+func (a *commandWALBarrierTestAppender) Sync() error  { return nil }
+
+func (a *commandWALBarrierTestAppender) CurrentValueLogSegment() (string, uint32, bool) {
+	return "", 0, false
+}
+
+func (a *commandWALBarrierTestAppender) FlushValueLogExternalRefs(fileIDs []uint32, sync bool) error {
+	a.externalFlushes++
+	a.externalSync = sync
+	a.externalFileIDs = append(a.externalFileIDs[:0], fileIDs...)
+	return a.externalErr
+}
+
 func (a *commandWALCountingValueLogAppender) AppendValues(values [][]byte) ([]page.ValuePtr, error) {
 	return a.inner.AppendValues(values)
 }
@@ -34,6 +59,41 @@ func (a *commandWALCountingValueLogAppender) Sync() error {
 
 func (a *commandWALCountingValueLogAppender) CurrentValueLogSegment() (string, uint32, bool) {
 	return a.inner.CurrentValueLogSegment()
+}
+
+func TestFlushCommandWALBarrierOrdersExternalRefsBeforeCommandWAL(t *testing.T) {
+	d, err := Open(Options{
+		Dir:                    t.TempDir(),
+		CommandWAL:             true,
+		CommandWALStatsScan:    true,
+		DisableBackgroundPrune: true,
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	externalErr := errors.New("external value-log sync failed")
+	appender := &commandWALBarrierTestAppender{externalErr: externalErr}
+	d.SetValueLogAppender(appender)
+	before := commandWALTestStatUint64(t, d.Stats(), "treedb.command_wal.sync.count_total")
+	if err := d.FlushCommandWALBarrier(true); !errors.Is(err, externalErr) {
+		t.Fatalf("FlushCommandWALBarrier error=%v, want %v", err, externalErr)
+	}
+	if appender.externalFlushes != 1 || !appender.externalSync || len(appender.externalFileIDs) != 0 {
+		t.Fatalf("external barrier calls=%d sync=%t fileIDs=%v, want one all-ref sync", appender.externalFlushes, appender.externalSync, appender.externalFileIDs)
+	}
+	if got := commandWALTestStatUint64(t, d.Stats(), "treedb.command_wal.sync.count_total"); got != before {
+		t.Fatalf("command WAL sync count=%d, want %d when external barrier fails", got, before)
+	}
+
+	appender.externalErr = nil
+	if err := d.FlushCommandWALBarrier(true); err != nil {
+		t.Fatalf("FlushCommandWALBarrier retry: %v", err)
+	}
+	if got := commandWALTestStatUint64(t, d.Stats(), "treedb.command_wal.sync.count_total"); got != before+1 {
+		t.Fatalf("command WAL sync count=%d, want %d", got, before+1)
+	}
 }
 
 func TestCommandWALIntentZeroValueLSNSentinelsM10C(t *testing.T) {

--- a/TreeDB/db/value_log_appender.go
+++ b/TreeDB/db/value_log_appender.go
@@ -25,7 +25,8 @@ type ValueLogAppender interface {
 }
 
 // ValueLogExternalRefFlusher is an optional extension for appenders that can
-// flush the value-log lanes containing specific file IDs. When sync is true,
+// flush the value-log lanes containing specific file IDs. An empty file-ID
+// slice requests a barrier for all pending appender writes. When sync is true,
 // the implementation owns durability for the referenced file IDs: active
 // segments should follow the appender's sync policy, and older referenced
 // segments should be synced directly if needed. Command-WAL SetRID logging uses


### PR DESCRIPTION
## Summary

Closes #3650.

Empty public command-WAL `Batch.WriteSync()` calls now use a dedicated durability barrier instead of invoking the cached batch's strict-sync fallback. The barrier drains pending value-log references before syncing the command WAL. Non-empty batches retain the existing atomic command append and cached apply path.

## Why

The command WAL is the durability boundary for public cached writes, and the cached redo journal is intentionally disabled in this mode. Before this change, an empty synchronous batch had no command append callback, so the inner cached batch interpreted `WriteSync` as requiring a full `Checkpoint()`.

Celestia Core emits empty synchronous blockstore and transaction-index batches. In the instrumented baseline, blockstore made 1,730 synchronous batch writes but only 1,309 command-WAL appends. The approximately 421 empty batches aligned with 436 load-window checkpoints, including only nine normal automatic checkpoints. The transaction-index path had the same shape.

This change preserves the intended contract:

- durable command-WAL mode syncs pending value-log references and then the command WAL to disk;
- relaxed command-WAL mode flushes both layers to the kernel boundary;
- publication ordering prevents a durable command frame from referring to an unsynced value-log payload;
- explicit `Checkpoint()` semantics remain strict and unchanged;
- dirty-batch behavior and on-disk formats are unchanged.

## Scope

Included:

- command-WAL cached public batch behavior for empty `WriteSync`;
- a backend command-WAL barrier with value-log-before-WAL ordering;
- all-pending value-log lane draining for an empty external-reference set;
- focused durability, ordering, and counter regression coverage.

Excluded:

- `Checkpoint()` semantic changes;
- on-disk format changes;
- non-command-WAL batch behavior;
- adapter or CometBFT behavior changes.

## Tests

Exact PR head `138e6dff7ef7805589de64c791e64a8fb1055e94`:

```sh
GOWORK=off go test ./TreeDB/db ./TreeDB/caching ./TreeDB -count=1
GOWORK=off go test -race ./TreeDB/db -run TestFlushCommandWALBarrierOrdersExternalRefsBeforeCommandWAL -count=1
GOWORK=off go test -race ./TreeDB/caching -run TestCachingValueLogExternalRefFlusherEmptyIDsSyncsAllPendingLanes -count=1
GOWORK=off go test -race ./TreeDB -run TestPublicCommandWALDurableEmptyBatchWriteSyncOnlySyncsCommandWAL -count=1
GOWORK=off go vet ./TreeDB/db ./TreeDB/caching ./TreeDB
```

All pass locally. The public regression test verifies one public sync call, one command-WAL sync, no command append, and no checkpoint for an empty durable batch. Backend and caching tests prove that pending value-log references are synced first and that a failed value-log barrier prevents command-WAL sync.

## Accepted performance evidence

The final candidate was built from exact PR head `138e6dff7ef7` (`v0.6.2-0.20260709223945-138e6dff7ef7`). Both rows use the instrumented Ironbird plain-send shape with one validator, TreeDB across app and CometBFT DBs, `kv` tx indexing, 105,000 genesis accounts, 5,000 active wallets, 500 tx/block, a 99.5% transaction gate, and a five-minute minimum accepted window.

| Metric | Baseline `2182e84bd` | Final head `138e6dff7` | Delta |
| --- | ---: | ---: | ---: |
| Successful transactions | 199,630 | 223,995 | larger accepted row |
| Load-window seconds | 337.525 | 315.024 | -6.7% |
| Load-window TPS | 591.45 | 711.04 | +20.2% |
| Blockstore checkpoint runs | 443 | 15 | -96.6% |
| Tx-index checkpoint runs | 440 | 15 | -96.6% |
| Celestia `SaveTxInfo` | 66.90 ms/block | 5.07 ms/block | -92.4% |
| Consensus commit | 284.87 ms/block | 196.22 ms/block | -31.1% |
| State `ApplyVerifiedBlock` | 245.83 ms/block | 168.46 ms/block | -31.5% |
| Async tx-index block total | 247.22 ms/block | 48.88 ms/block | -80.2% |

The candidate processed more blocks while reducing blockstore and tx-index checkpoints to normal automatic/shutdown levels. Empty batches remain visible as `WriteSync` calls without command appends, but now increase command-WAL sync counters rather than checkpoint counters.

For context, the preserved goleveldb row was 663.22 TPS with 189.97 ms/block consensus commit. The candidate's 711.04 TPS and 196.22 ms/block commit remove the prior end-to-end regression, although single-run cross-backend TPS differences remain directional because block cadence and mempool scheduling vary.

Artifacts and full attribution are documented in `snissn/ironbird` on `codex/exact-cadence-spans-next` under `reports/ironbird_empty_command_wal_batch_checkpoint_fix_2026-07-09.md`.

## Gate status

Performance gate: **pass**. The accidental per-block checkpoint path is eliminated, value-log and command-WAL durability ordering is covered, the accepted exact-head workload improves materially, and no measured local regression remains.
