### PR TITLE
treedb: threshold full value-log rewrites

### DIFF
--- a/TreeDB/db/compact_storage.go
+++ b/TreeDB/db/compact_storage.go
@@ -168,7 +168,19 @@ type CompactStorageOptions struct {
 	// Value-log rewrite knobs.
 	ValueLogRewriteBatchSize       int
 	ValueLogRewriteMaxSegmentBytes int64
-	ValueLogProtectedPaths         []string
+	// ValueLogRewriteMinSegmentStaleRatio and
+	// ValueLogRewriteMinSegmentStaleBytes control non-exhaustive sparse
+	// value-log rewrite admission. Both thresholds are conjunctive when set:
+	// full/quick mode selects a segment only when stale ratio and stale bytes
+	// both meet the mode policy. The default byte floor is capped at the
+	// configured stale ratio for small segments, so a small segment that is
+	// sufficiently stale is not permanently exempt; an explicit byte override
+	// remains an exact conjunctive floor. Zero uses mode defaults. Exhaustive
+	// mode ignores these knobs and rewrites any partially-live segment with
+	// stale bytes so it remains the byte-minimizing mode.
+	ValueLogRewriteMinSegmentStaleRatio float64
+	ValueLogRewriteMinSegmentStaleBytes int64
+	ValueLogProtectedPaths              []string
 	// ValueLogProtectedPathsFunc refreshes online protected paths before each
 	// value-log rewrite/GC audit or applied phase. Live cached-mode callers use
 	// this so foreground writer rotations that happen during a multi-phase
@@ -293,8 +305,12 @@ type CompactStorageStats struct {
 
 	RemainingDebt CompactStorageDebt `json:"remaining_debt"`
 
-	// FullyCompacted is the legacy policy-oriented compacted flag. For
-	// exhaustive mode, ByteMinimized reports the stricter benchmark contract.
+	// FullyCompacted is the legacy policy-oriented compacted flag and matches
+	// PolicyFullyCompacted. Non-exhaustive modes compute value-log rewrite debt
+	// against their stale-ratio/stale-byte policy, so they can be policy compacted
+	// while ByteMinimized remains false. Exhaustive mode keeps the stricter
+	// byte-minimizing rewrite policy and is the only mode that asserts
+	// ByteMinimized.
 	FullyCompacted       bool `json:"fully_compacted"`
 	PolicyFullyCompacted bool `json:"policy_fully_compacted"`
 	ByteMinimized        bool `json:"byte_minimized"`
@@ -371,9 +387,7 @@ func (db *DB) compactStorage(ctx context.Context, opts CompactStorageOptions) (s
 	stats.RemainingDebt = initialDebt
 	if opts.DryRun {
 		stats.After = before
-		stats.FullyCompacted = initialDebt.Empty()
-		stats.PolicyFullyCompacted = stats.FullyCompacted
-		stats.ByteMinimized = false
+		stats.FullyCompacted, stats.PolicyFullyCompacted, stats.ByteMinimized = compactStorageCompactionFlags(opts, initialDebt)
 		return stats, nil
 	}
 
@@ -446,7 +460,7 @@ func (db *DB) compactStorage(ctx context.Context, opts CompactStorageOptions) (s
 	if err := db.runCompactStoragePhase(&stats, "value-log-rewrite", func() error {
 		protectedPaths := compactStorageOnlineRewriteProtectedPaths(opts)
 		protectedRootIDs, protectedSystemRootIDs := db.compactStorageLeafGenerationProtectedRootIDPair(opts)
-		rewriteOpts := compactStorageRewritePlanOptions(protectedPaths)
+		rewriteOpts := compactStorageRewritePlanOptions(opts, protectedPaths)
 		rewriteOpts.LeafGenerationProtectedRootIDs = protectedRootIDs
 		rewriteOpts.LeafGenerationProtectedSystemRootIDs = protectedSystemRootIDs
 		rewriteOpts.BatchSize = opts.ValueLogRewriteBatchSize
@@ -620,10 +634,15 @@ func (db *DB) compactStorage(ctx context.Context, opts CompactStorageOptions) (s
 		}
 	}
 	cleanupLeafLogDone = true
-	stats.FullyCompacted = finalDebt.Empty()
-	stats.PolicyFullyCompacted = stats.FullyCompacted
-	stats.ByteMinimized = opts.Mode == CompactStorageExhaustive && finalDebt.Empty()
+	stats.FullyCompacted, stats.PolicyFullyCompacted, stats.ByteMinimized = compactStorageCompactionFlags(opts, finalDebt)
 	return stats, nil
+}
+
+func compactStorageCompactionFlags(opts CompactStorageOptions, debt CompactStorageDebt) (fullyCompacted bool, policyFullyCompacted bool, byteMinimized bool) {
+	policyFullyCompacted = debt.Empty()
+	fullyCompacted = policyFullyCompacted
+	byteMinimized = opts.Mode == CompactStorageExhaustive && debt.Empty()
+	return fullyCompacted, policyFullyCompacted, byteMinimized
 }
 
 func (db *DB) sealCompactStorageCurrentLeafGeneration(compactLeafLog *rewriteWriter) (bool, error) {
@@ -823,6 +842,12 @@ func normalizeCompactStorageOptions(opts CompactStorageOptions) CompactStorageOp
 	if opts.ValueLogRewriteBatchSize < 0 {
 		opts.ValueLogRewriteBatchSize = 0
 	}
+	if opts.ValueLogRewriteMinSegmentStaleRatio < 0 {
+		opts.ValueLogRewriteMinSegmentStaleRatio = 0
+	}
+	if opts.ValueLogRewriteMinSegmentStaleBytes < 0 {
+		opts.ValueLogRewriteMinSegmentStaleBytes = 0
+	}
 	if opts.Mode == CompactStorageExhaustive {
 		opts.LeafPackForce = true
 	}
@@ -869,10 +894,34 @@ func normalizeCompactStorageOptions(opts CompactStorageOptions) CompactStorageOp
 	return opts
 }
 
-func compactStorageRewritePlanOptions(protectedPaths []string) ValueLogRewriteOnlineOptions {
+const (
+	compactStoragePolicyValueLogRewriteMinStaleRatio = 0.30
+	compactStoragePolicyValueLogRewriteMinStaleBytes = 8 << 20
+)
+
+func compactStorageRewritePlanOptions(opts CompactStorageOptions, protectedPaths []string) ValueLogRewriteOnlineOptions {
+	ratio := float64(0)
+	staleBytes := int64(1)
+	staleBytesCapRatio := float64(0)
+	if opts.Mode != CompactStorageExhaustive {
+		ratio = compactStoragePolicyValueLogRewriteMinStaleRatio
+		staleBytes = compactStoragePolicyValueLogRewriteMinStaleBytes
+		if opts.ValueLogRewriteMinSegmentStaleRatio > 0 {
+			ratio = opts.ValueLogRewriteMinSegmentStaleRatio
+		}
+		if opts.ValueLogRewriteMinSegmentStaleBytes > 0 {
+			staleBytes = opts.ValueLogRewriteMinSegmentStaleBytes
+		} else {
+			// Keep the 8 MiB default meaningful for normal segments without
+			// permanently excluding a small segment that meets the ratio policy.
+			staleBytesCapRatio = ratio
+		}
+	}
 	return ValueLogRewriteOnlineOptions{
-		MinSegmentStaleBytes: 1,
-		ProtectedPaths:       protectedPaths,
+		MinSegmentStaleRatio:         ratio,
+		MinSegmentStaleBytes:         staleBytes,
+		MinSegmentStaleBytesCapRatio: staleBytesCapRatio,
+		ProtectedPaths:               protectedPaths,
 	}
 }
 
@@ -1010,7 +1059,7 @@ func compactStorageRememberLeafPackCreatedFileIDs(ignoredRawFileIDs map[uint32]s
 func (db *DB) populateCompactStorageAudit(ctx context.Context, opts CompactStorageOptions, stats *CompactStorageStats, lockMaintenance bool, fencedIDsOut *[]uint32, ignoredLeafPackRawFileIDs map[uint32]struct{}) (CompactStorageDebt, error) {
 	var debt CompactStorageDebt
 	protectedPaths := compactStorageFencedValueLogProtectedPaths(opts)
-	rewritePlan, err := db.ValueLogRewritePlan(ctx, compactStorageRewritePlanOptions(protectedPaths))
+	rewritePlan, err := db.ValueLogRewritePlan(ctx, compactStorageRewritePlanOptions(opts, protectedPaths))
 	if err != nil {
 		return debt, err
 	}

--- a/TreeDB/db/compact_storage_bench_test.go
+++ b/TreeDB/db/compact_storage_bench_test.go
@@ -1,0 +1,123 @@
+package db
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"testing"
+)
+
+func BenchmarkCompactStorageRewritePolicyMostlyLivePlan(b *testing.B) {
+	db := openCompactStorageRewritePolicyBenchmarkFixture(b, 2047, 1, 1024)
+	defer func() { _ = db.Close() }()
+
+	opts := CompactStorageOptions{
+		Mode:                           CompactStorageFull,
+		DisableZeroByteValueLogCleanup: true,
+	}
+	var selectedBytes, copiedBytes, staleBytes, selectedStaleBytes int64
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		plan, err := db.CompactStoragePlan(context.Background(), opts)
+		if err != nil {
+			b.Fatalf("CompactStoragePlan: %v", err)
+		}
+		selectedBytes += plan.ValueLogRewritePlan.SelectedBytesTotal
+		copiedBytes += plan.ValueLogRewritePlan.SelectedBytesLive
+		staleBytes += plan.ValueLogRewritePlan.BytesStale
+		selectedStaleBytes += plan.ValueLogRewritePlan.SelectedBytesStale
+	}
+	if b.N > 0 {
+		b.ReportMetric(float64(selectedBytes)/float64(b.N), "selected_bytes/op")
+		b.ReportMetric(float64(copiedBytes)/float64(b.N), "copied_bytes/op")
+		b.ReportMetric(float64(staleBytes)/float64(b.N), "stale_bytes/op")
+		b.ReportMetric(float64(selectedStaleBytes)/float64(b.N), "selected_stale_bytes/op")
+	}
+}
+
+func BenchmarkCompactStorageRewritePolicyMostlyLiveApply(b *testing.B) {
+	var selectedBytes, copiedBytes, staleBytes, selectedStaleBytes int64
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		db := openCompactStorageRewritePolicyBenchmarkFixture(b, 2047, 1, 1024)
+		beforePlan, err := db.CompactStoragePlan(context.Background(), CompactStorageOptions{
+			Mode:                           CompactStorageFull,
+			DisableZeroByteValueLogCleanup: true,
+		})
+		if err != nil {
+			_ = db.Close()
+			b.Fatalf("CompactStoragePlan before apply: %v", err)
+		}
+		b.StartTimer()
+
+		stats, err := db.CompactStorage(context.Background(), CompactStorageOptions{
+			Mode:                           CompactStorageFull,
+			DisableZeroByteValueLogCleanup: true,
+		})
+		b.StopTimer()
+		if err != nil {
+			_ = db.Close()
+			b.Fatalf("CompactStorage: %v", err)
+		}
+		selectedBytes += stats.ValueLogRewrite.SourceBytesRequested
+		copiedBytes += stats.ValueLogRewrite.ValueBytesCopied
+		staleBytes += beforePlan.ValueLogRewritePlan.BytesStale
+		selectedStaleBytes += beforePlan.ValueLogRewritePlan.SelectedBytesStale
+		if err := db.Close(); err != nil {
+			b.Fatalf("close: %v", err)
+		}
+		b.StartTimer()
+	}
+	if b.N > 0 {
+		b.ReportMetric(float64(selectedBytes)/float64(b.N), "selected_bytes/op")
+		b.ReportMetric(float64(copiedBytes)/float64(b.N), "copied_bytes/op")
+		b.ReportMetric(float64(staleBytes)/float64(b.N), "stale_bytes/op")
+		b.ReportMetric(float64(selectedStaleBytes)/float64(b.N), "selected_stale_bytes/op")
+	}
+}
+
+func openCompactStorageRewritePolicyBenchmarkFixture(tb testing.TB, liveRecords, staleRecords, valueSize int) *DB {
+	tb.Helper()
+	db, err := Open(Options{Dir: tb.TempDir()})
+	if err != nil {
+		tb.Fatalf("open: %v", err)
+	}
+	total := liveRecords + staleRecords
+	ptrs := appendPointersInNewSegmentBench(tb, db.dir, 0, 1, 560_000, total, func(i int) []byte {
+		return bytes.Repeat([]byte{byte('a' + i%23)}, valueSize)
+	})
+	activePtrs := appendPointersInNewSegmentBench(tb, db.dir, 0, 2, 660_000, 1, func(i int) []byte {
+		return bytes.Repeat([]byte("z"), valueSize)
+	})
+	b, ok := db.NewBatch().(*Batch)
+	if !ok {
+		_ = db.Close()
+		tb.Fatalf("NewBatch type assertion failed")
+	}
+	for i := 0; i < liveRecords; i++ {
+		if err := b.SetPointer([]byte(fmt.Sprintf("source-live-%06d", i)), ptrs[i]); err != nil {
+			_ = b.Close()
+			_ = db.Close()
+			tb.Fatalf("SetPointer source %d: %v", i, err)
+		}
+	}
+	if err := b.SetPointer([]byte("active-live"), activePtrs[0]); err != nil {
+		_ = b.Close()
+		_ = db.Close()
+		tb.Fatalf("SetPointer active: %v", err)
+	}
+	if err := b.Write(); err != nil {
+		_ = b.Close()
+		_ = db.Close()
+		tb.Fatalf("batch write: %v", err)
+	}
+	if err := b.Close(); err != nil {
+		_ = db.Close()
+		tb.Fatalf("batch close: %v", err)
+	}
+	if err := db.RefreshValueLogSet(); err != nil {
+		_ = db.Close()
+		tb.Fatalf("RefreshValueLogSet: %v", err)
+	}
+	return db
+}

--- a/TreeDB/db/compact_storage_test.go
+++ b/TreeDB/db/compact_storage_test.go
@@ -367,6 +367,316 @@ func TestCompactStoragePlanMatchesAppliedRewriteScopeForLiveOnlySegments(t *test
 	}
 }
 
+func TestCompactStorageFullRewriteSkipsMostlyLiveValueLogSegment(t *testing.T) {
+	db := openCompactStorageRewritePolicyFixture(t, 9, 1, 1024)
+	defer func() { _ = db.Close() }()
+
+	opts := CompactStorageOptions{
+		Mode:                                CompactStorageFull,
+		ValueLogRewriteMinSegmentStaleRatio: 0.30,
+		ValueLogRewriteMinSegmentStaleBytes: 1,
+		DisableZeroByteValueLogCleanup:      true,
+	}
+	plan, err := db.CompactStoragePlan(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("CompactStoragePlan: %v", err)
+	}
+	if plan.ValueLogRewritePlan.BytesStale <= 0 {
+		t.Fatalf("expected byte-minimization stale bytes in mostly-live fixture, plan=%+v", plan.ValueLogRewritePlan)
+	}
+	if got := plan.ValueLogRewritePlan.SegmentsSelected; got != 0 {
+		t.Fatalf("full policy selected mostly-live segment=%d want 0, plan=%+v", got, plan.ValueLogRewritePlan)
+	}
+	if got := plan.RemainingDebt.ValueLogRewriteSegments; got != 0 {
+		t.Fatalf("policy rewrite debt=%d want 0, debt=%+v plan=%+v", got, plan.RemainingDebt, plan.ValueLogRewritePlan)
+	}
+	if !plan.FullyCompacted || !plan.PolicyFullyCompacted || plan.ByteMinimized {
+		t.Fatalf("plan flags fully=%t policy=%t byte=%t debt=%+v plan=%+v", plan.FullyCompacted, plan.PolicyFullyCompacted, plan.ByteMinimized, plan.RemainingDebt, plan.ValueLogRewritePlan)
+	}
+
+	stats, err := db.CompactStorage(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("CompactStorage: %v", err)
+	}
+	if got := stats.ValueLogRewrite.SourceSegmentsRequested; got != 0 {
+		t.Fatalf("applied rewrite source segments=%d want 0, stats=%+v", got, stats.ValueLogRewrite)
+	}
+	if got := stats.ValueLogRewrite.ValueBytesCopied; got != 0 {
+		t.Fatalf("applied rewrite copied bytes=%d want 0, stats=%+v", got, stats.ValueLogRewrite)
+	}
+	if !stats.FullyCompacted || !stats.PolicyFullyCompacted || stats.ByteMinimized {
+		t.Fatalf("stats flags fully=%t policy=%t byte=%t debt=%+v plan=%+v", stats.FullyCompacted, stats.PolicyFullyCompacted, stats.ByteMinimized, stats.RemainingDebt, stats.ValueLogRewritePlan)
+	}
+}
+
+func TestCompactStorageFullRewritePolicyRequiresStaleRatioAndBytes(t *testing.T) {
+	cases := []struct {
+		name         string
+		opts         CompactStorageOptions
+		wantSelected int
+	}{
+		{
+			name: "below_ratio",
+			opts: CompactStorageOptions{
+				Mode:                                CompactStorageFull,
+				ValueLogRewriteMinSegmentStaleRatio: 0.30,
+				ValueLogRewriteMinSegmentStaleBytes: 1,
+			},
+			wantSelected: 0,
+		},
+		{
+			name: "below_bytes",
+			opts: CompactStorageOptions{
+				Mode:                                CompactStorageFull,
+				ValueLogRewriteMinSegmentStaleRatio: 0.01,
+				ValueLogRewriteMinSegmentStaleBytes: 1 << 20,
+			},
+			wantSelected: 0,
+		},
+		{
+			name: "clears_both",
+			opts: CompactStorageOptions{
+				Mode:                                CompactStorageFull,
+				ValueLogRewriteMinSegmentStaleRatio: 0.01,
+				ValueLogRewriteMinSegmentStaleBytes: 1,
+			},
+			wantSelected: 1,
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			db := openCompactStorageRewritePolicyFixture(t, 9, 1, 1024)
+			defer func() { _ = db.Close() }()
+			plan, err := db.CompactStoragePlan(context.Background(), tt.opts)
+			if err != nil {
+				t.Fatalf("CompactStoragePlan: %v", err)
+			}
+			if got := plan.ValueLogRewritePlan.SegmentsSelected; got != tt.wantSelected {
+				t.Fatalf("segments selected=%d want %d, rewrite plan=%+v debt=%+v", got, tt.wantSelected, plan.ValueLogRewritePlan, plan.RemainingDebt)
+			}
+			if got := plan.RemainingDebt.ValueLogRewriteSegments; got != tt.wantSelected {
+				t.Fatalf("rewrite debt segments=%d want %d, rewrite plan=%+v debt=%+v", got, tt.wantSelected, plan.ValueLogRewritePlan, plan.RemainingDebt)
+			}
+		})
+	}
+}
+
+func TestCompactStorageFullRewriteRewritesHighStaleValueLogSegment(t *testing.T) {
+	db := openCompactStorageRewritePolicyFixture(t, 2, 8, 1024)
+	defer func() { _ = db.Close() }()
+
+	opts := CompactStorageOptions{
+		Mode:                                CompactStorageFull,
+		ValueLogRewriteMinSegmentStaleRatio: 0.30,
+		ValueLogRewriteMinSegmentStaleBytes: 1,
+	}
+	plan, err := db.CompactStoragePlan(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("CompactStoragePlan: %v", err)
+	}
+	if got := plan.ValueLogRewritePlan.SegmentsSelected; got != 1 {
+		t.Fatalf("full policy selected segments=%d want 1, plan=%+v debt=%+v", got, plan.ValueLogRewritePlan, plan.RemainingDebt)
+	}
+	if got := plan.RemainingDebt.ValueLogRewriteSegments; got != 1 {
+		t.Fatalf("policy rewrite debt=%d want 1, debt=%+v plan=%+v", got, plan.RemainingDebt, plan.ValueLogRewritePlan)
+	}
+	if plan.FullyCompacted || plan.PolicyFullyCompacted || plan.ByteMinimized {
+		t.Fatalf("plan flags fully=%t policy=%t byte=%t want all false before rewrite", plan.FullyCompacted, plan.PolicyFullyCompacted, plan.ByteMinimized)
+	}
+
+	stats, err := db.CompactStorage(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("CompactStorage: %v", err)
+	}
+	if got := stats.ValueLogRewrite.SourceSegmentsRequested; got != 1 {
+		t.Fatalf("applied rewrite source segments=%d want 1, stats=%+v", got, stats.ValueLogRewrite)
+	}
+	if got := stats.ValueLogRewrite.ValueRecordsCopied; got != 2 {
+		t.Fatalf("applied rewrite copied records=%d want 2, stats=%+v", got, stats.ValueLogRewrite)
+	}
+	if got := stats.ValueLogRewrite.ValueBytesCopied; got <= 0 {
+		t.Fatalf("applied rewrite copied bytes=%d want >0, stats=%+v", got, stats.ValueLogRewrite)
+	}
+	if stats.RemainingDebt.ValueLogRewriteSegments != 0 || stats.RemainingDebt.ValueLogRewriteBytes != 0 {
+		t.Fatalf("remaining policy rewrite debt=%+v want none", stats.RemainingDebt)
+	}
+	if !stats.FullyCompacted || !stats.PolicyFullyCompacted || stats.ByteMinimized {
+		t.Fatalf("stats flags fully=%t policy=%t byte=%t debt=%+v", stats.FullyCompacted, stats.PolicyFullyCompacted, stats.ByteMinimized, stats.RemainingDebt)
+	}
+}
+
+func TestCompactStorageFullRewriteDoesNotExemptSmallHighStaleValueLogSegment(t *testing.T) {
+	db := openCompactStorageRewritePolicyFixture(t, 2, 8, 128)
+	defer func() { _ = db.Close() }()
+
+	// The source segment is far below the default 8 MiB absolute floor, but it
+	// is 80% stale. Full mode caps that floor at its 30% ratio threshold so this
+	// high-stale small segment remains actionable.
+	opts := CompactStorageOptions{Mode: CompactStorageFull}
+	plan, err := db.CompactStoragePlan(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("CompactStoragePlan: %v", err)
+	}
+	if got := plan.ValueLogRewritePlan.SegmentsSelected; got != 1 {
+		t.Fatalf("full policy selected segments=%d want 1, plan=%+v debt=%+v", got, plan.ValueLogRewritePlan, plan.RemainingDebt)
+	}
+	if got := plan.RemainingDebt.ValueLogRewriteSegments; got != 1 {
+		t.Fatalf("policy rewrite debt=%d want 1, debt=%+v plan=%+v", got, plan.RemainingDebt, plan.ValueLogRewritePlan)
+	}
+
+	stats, err := db.CompactStorage(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("CompactStorage: %v", err)
+	}
+	if got := stats.ValueLogRewrite.SourceSegmentsRequested; got != 1 {
+		t.Fatalf("applied rewrite source segments=%d want 1, stats=%+v", got, stats.ValueLogRewrite)
+	}
+	if got := stats.ValueLogRewrite.ValueBytesCopied; got <= 0 {
+		t.Fatalf("applied rewrite copied bytes=%d want >0, stats=%+v", got, stats.ValueLogRewrite)
+	}
+	if !stats.FullyCompacted || !stats.PolicyFullyCompacted || stats.ByteMinimized {
+		t.Fatalf("stats flags fully=%t policy=%t byte=%t debt=%+v", stats.FullyCompacted, stats.PolicyFullyCompacted, stats.ByteMinimized, stats.RemainingDebt)
+	}
+}
+
+func TestCompactStorageExhaustiveRewriteSelectsAnyStaleValueLogSegment(t *testing.T) {
+	db := openCompactStorageRewritePolicyFixture(t, 9, 1, 128)
+	defer func() { _ = db.Close() }()
+
+	fullPlan, err := db.CompactStoragePlan(context.Background(), CompactStorageOptions{
+		Mode:                                CompactStorageFull,
+		ValueLogRewriteMinSegmentStaleRatio: 0.30,
+		ValueLogRewriteMinSegmentStaleBytes: 1,
+	})
+	if err != nil {
+		t.Fatalf("CompactStoragePlan full: %v", err)
+	}
+	if got := fullPlan.ValueLogRewritePlan.SegmentsSelected; got != 0 {
+		t.Fatalf("full policy selected mostly-live segment=%d want 0, plan=%+v", got, fullPlan.ValueLogRewritePlan)
+	}
+
+	exhaustivePlan, err := db.CompactStoragePlan(context.Background(), CompactStorageOptions{Mode: CompactStorageExhaustive})
+	if err != nil {
+		t.Fatalf("CompactStoragePlan exhaustive: %v", err)
+	}
+	if got := exhaustivePlan.ValueLogRewritePlan.SegmentsSelected; got != 1 {
+		t.Fatalf("exhaustive selected segments=%d want 1 for stale bytes, plan=%+v debt=%+v", got, exhaustivePlan.ValueLogRewritePlan, exhaustivePlan.RemainingDebt)
+	}
+	if exhaustivePlan.FullyCompacted || exhaustivePlan.PolicyFullyCompacted || exhaustivePlan.ByteMinimized {
+		t.Fatalf("exhaustive plan flags fully=%t policy=%t byte=%t want all false before rewrite", exhaustivePlan.FullyCompacted, exhaustivePlan.PolicyFullyCompacted, exhaustivePlan.ByteMinimized)
+	}
+
+	stats, err := db.CompactStorage(context.Background(), CompactStorageOptions{Mode: CompactStorageExhaustive})
+	if err != nil {
+		t.Fatalf("CompactStorage exhaustive: %v", err)
+	}
+	if got := stats.ValueLogRewrite.SourceSegmentsRequested; got != 1 {
+		t.Fatalf("exhaustive rewrite source segments=%d want 1, stats=%+v", got, stats.ValueLogRewrite)
+	}
+	if got := stats.ValueLogRewrite.ValueRecordsCopied; got != 9 {
+		t.Fatalf("exhaustive rewrite copied records=%d want 9, stats=%+v", got, stats.ValueLogRewrite)
+	}
+	if !stats.FullyCompacted || !stats.PolicyFullyCompacted || !stats.ByteMinimized {
+		t.Fatalf("exhaustive stats flags fully=%t policy=%t byte=%t debt=%+v", stats.FullyCompacted, stats.PolicyFullyCompacted, stats.ByteMinimized, stats.RemainingDebt)
+	}
+}
+
+func TestCompactStorageCompactedFlagsTruthTable(t *testing.T) {
+	debt := CompactStorageDebt{ValueLogRewriteSegments: 1, ValueLogRewriteBytes: 1}
+	for _, tt := range []struct {
+		name       string
+		opts       CompactStorageOptions
+		debt       CompactStorageDebt
+		wantFully  bool
+		wantPolicy bool
+		wantByte   bool
+	}{
+		{name: "full_empty_policy_only", opts: CompactStorageOptions{Mode: CompactStorageFull}, wantFully: true, wantPolicy: true, wantByte: false},
+		{name: "full_policy_debt", opts: CompactStorageOptions{Mode: CompactStorageFull}, debt: debt, wantFully: false, wantPolicy: false, wantByte: false},
+		{name: "quick_empty_policy_only", opts: CompactStorageOptions{Mode: CompactStorageQuick}, wantFully: true, wantPolicy: true, wantByte: false},
+		{name: "exhaustive_empty_byte_minimized", opts: CompactStorageOptions{Mode: CompactStorageExhaustive}, wantFully: true, wantPolicy: true, wantByte: true},
+		{name: "exhaustive_byte_debt", opts: CompactStorageOptions{Mode: CompactStorageExhaustive}, debt: debt, wantFully: false, wantPolicy: false, wantByte: false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			fully, policy, byteMinimized := compactStorageCompactionFlags(tt.opts, tt.debt)
+			if fully != tt.wantFully || policy != tt.wantPolicy || byteMinimized != tt.wantByte {
+				t.Fatalf("flags fully=%t policy=%t byte=%t want fully=%t policy=%t byte=%t", fully, policy, byteMinimized, tt.wantFully, tt.wantPolicy, tt.wantByte)
+			}
+		})
+	}
+}
+
+func TestCompactStorageRewritePolicyDefaultsAndOverrides(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		opts      CompactStorageOptions
+		wantRatio float64
+		wantBytes int64
+		wantCap   float64
+	}{
+		{name: "default_is_full_policy", opts: normalizeCompactStorageOptions(CompactStorageOptions{}), wantRatio: compactStoragePolicyValueLogRewriteMinStaleRatio, wantBytes: compactStoragePolicyValueLogRewriteMinStaleBytes, wantCap: compactStoragePolicyValueLogRewriteMinStaleRatio},
+		{name: "quick_uses_policy", opts: normalizeCompactStorageOptions(CompactStorageOptions{Mode: CompactStorageQuick}), wantRatio: compactStoragePolicyValueLogRewriteMinStaleRatio, wantBytes: compactStoragePolicyValueLogRewriteMinStaleBytes, wantCap: compactStoragePolicyValueLogRewriteMinStaleRatio},
+		{name: "full_override", opts: normalizeCompactStorageOptions(CompactStorageOptions{Mode: CompactStorageFull, ValueLogRewriteMinSegmentStaleRatio: 0.42, ValueLogRewriteMinSegmentStaleBytes: 4096}), wantRatio: 0.42, wantBytes: 4096, wantCap: 0},
+		{name: "exhaustive_byte_minimizing", opts: normalizeCompactStorageOptions(CompactStorageOptions{Mode: CompactStorageExhaustive, ValueLogRewriteMinSegmentStaleRatio: 0.99, ValueLogRewriteMinSegmentStaleBytes: 1 << 30}), wantRatio: 0, wantBytes: 1, wantCap: 0},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			rewriteOpts := compactStorageRewritePlanOptions(tt.opts, nil)
+			if rewriteOpts.MinSegmentStaleRatio != tt.wantRatio || rewriteOpts.MinSegmentStaleBytes != tt.wantBytes || rewriteOpts.MinSegmentStaleBytesCapRatio != tt.wantCap {
+				t.Fatalf("rewrite policy ratio=%v bytes=%d cap=%v want ratio=%v bytes=%d cap=%v", rewriteOpts.MinSegmentStaleRatio, rewriteOpts.MinSegmentStaleBytes, rewriteOpts.MinSegmentStaleBytesCapRatio, tt.wantRatio, tt.wantBytes, tt.wantCap)
+			}
+		})
+	}
+}
+
+func openCompactStorageRewritePolicyFixture(t *testing.T, liveRecords, staleRecords, valueSize int) *DB {
+	t.Helper()
+	if liveRecords <= 0 || staleRecords <= 0 {
+		t.Fatalf("liveRecords and staleRecords must be positive: live=%d stale=%d", liveRecords, staleRecords)
+	}
+	db, err := Open(Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	total := liveRecords + staleRecords
+	ptrs := appendPointersInNewSegment(t, db.dir, 0, 1, 360_000, total, func(i int) []byte {
+		return bytes.Repeat([]byte{byte('a' + i%23)}, valueSize)
+	})
+	activePtrs := appendPointersInNewSegment(t, db.dir, 0, 2, 460_000, 1, func(i int) []byte {
+		return bytes.Repeat([]byte("z"), valueSize)
+	})
+	b, ok := db.NewBatch().(*Batch)
+	if !ok {
+		_ = db.Close()
+		t.Fatalf("NewBatch type assertion failed")
+	}
+	for i := 0; i < liveRecords; i++ {
+		if err := b.SetPointer([]byte(fmt.Sprintf("source-live-%06d", i)), ptrs[i]); err != nil {
+			_ = b.Close()
+			_ = db.Close()
+			t.Fatalf("SetPointer source %d: %v", i, err)
+		}
+	}
+	if err := b.SetPointer([]byte("active-live"), activePtrs[0]); err != nil {
+		_ = b.Close()
+		_ = db.Close()
+		t.Fatalf("SetPointer active: %v", err)
+	}
+	if err := b.Write(); err != nil {
+		_ = b.Close()
+		_ = db.Close()
+		t.Fatalf("batch write: %v", err)
+	}
+	if err := b.Close(); err != nil {
+		_ = db.Close()
+		t.Fatalf("batch close: %v", err)
+	}
+	if err := db.RefreshValueLogSet(); err != nil {
+		_ = db.Close()
+		t.Fatalf("RefreshValueLogSet: %v", err)
+	}
+	return db
+}
+
 func TestCompactStorageReportsAppliedValueLogGCStats(t *testing.T) {
 	dir := t.TempDir()
 

--- a/TreeDB/db/compact_storage_test.go
+++ b/TreeDB/db/compact_storage_test.go
@@ -409,6 +409,56 @@ func TestCompactStorageFullRewriteSkipsMostlyLiveValueLogSegment(t *testing.T) {
 	}
 }
 
+func TestCompactStorageQuickAndDefaultRewriteSkipMostlyLiveValueLogSegment(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		opts     CompactStorageOptions
+		wantMode CompactStorageMode
+	}{
+		{name: "quick", opts: CompactStorageOptions{Mode: CompactStorageQuick}, wantMode: CompactStorageQuick},
+		{name: "zero_value_default", opts: CompactStorageOptions{}, wantMode: CompactStorageFull},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			db := openCompactStorageRewritePolicyFixture(t, 9, 1, 1024)
+			defer func() { _ = db.Close() }()
+
+			plan, err := db.CompactStoragePlan(context.Background(), tt.opts)
+			if err != nil {
+				t.Fatalf("CompactStoragePlan: %v", err)
+			}
+			if plan.Mode != tt.wantMode {
+				t.Fatalf("plan mode=%q want %q", plan.Mode, tt.wantMode)
+			}
+			if plan.ValueLogRewritePlan.BytesStale <= 0 {
+				t.Fatalf("expected physical stale bytes in mostly-live fixture, plan=%+v", plan.ValueLogRewritePlan)
+			}
+			if plan.ValueLogRewritePlan.SegmentsSelected != 0 || plan.RemainingDebt.ValueLogRewriteSegments != 0 || plan.RemainingDebt.ValueLogRewriteBytes != 0 {
+				t.Fatalf("plan reported rewrite work for policy-skipped segment: plan=%+v debt=%+v", plan.ValueLogRewritePlan, plan.RemainingDebt)
+			}
+			if !plan.FullyCompacted || !plan.PolicyFullyCompacted || plan.ByteMinimized {
+				t.Fatalf("plan flags fully=%t policy=%t byte=%t debt=%+v", plan.FullyCompacted, plan.PolicyFullyCompacted, plan.ByteMinimized, plan.RemainingDebt)
+			}
+
+			stats, err := db.CompactStorage(context.Background(), tt.opts)
+			if err != nil {
+				t.Fatalf("CompactStorage: %v", err)
+			}
+			if stats.Mode != tt.wantMode {
+				t.Fatalf("stats mode=%q want %q", stats.Mode, tt.wantMode)
+			}
+			if stats.ValueLogRewrite.SourceSegmentsRequested != 0 || stats.ValueLogRewrite.ValueRecordsCopied != 0 || stats.ValueLogRewrite.ValueBytesCopied != 0 {
+				t.Fatalf("applied rewrite copied policy-skipped segment: stats=%+v", stats.ValueLogRewrite)
+			}
+			if stats.RemainingDebt.ValueLogRewriteSegments != 0 || stats.RemainingDebt.ValueLogRewriteBytes != 0 {
+				t.Fatalf("remaining policy rewrite debt=%+v want none", stats.RemainingDebt)
+			}
+			if !stats.FullyCompacted || !stats.PolicyFullyCompacted || stats.ByteMinimized {
+				t.Fatalf("stats flags fully=%t policy=%t byte=%t debt=%+v", stats.FullyCompacted, stats.PolicyFullyCompacted, stats.ByteMinimized, stats.RemainingDebt)
+			}
+		})
+	}
+}
+
 func TestCompactStorageFullRewritePolicyRequiresStaleRatioAndBytes(t *testing.T) {
 	cases := []struct {
 		name         string
@@ -625,6 +675,59 @@ func TestCompactStorageRewritePolicyDefaultsAndOverrides(t *testing.T) {
 				t.Fatalf("rewrite policy ratio=%v bytes=%d cap=%v want ratio=%v bytes=%d cap=%v", rewriteOpts.MinSegmentStaleRatio, rewriteOpts.MinSegmentStaleBytes, rewriteOpts.MinSegmentStaleBytesCapRatio, tt.wantRatio, tt.wantBytes, tt.wantCap)
 			}
 		})
+	}
+}
+
+func TestCompactStorageRewritePolicyRatioOnlyOverrideCapsDefaultByteFloor(t *testing.T) {
+	opts := normalizeCompactStorageOptions(CompactStorageOptions{
+		Mode:                                CompactStorageFull,
+		ValueLogRewriteMinSegmentStaleRatio: 0.10,
+	})
+	rewriteOpts := compactStorageRewritePlanOptions(opts, nil)
+	if rewriteOpts.MinSegmentStaleRatio != 0.10 || rewriteOpts.MinSegmentStaleBytes != compactStoragePolicyValueLogRewriteMinStaleBytes || rewriteOpts.MinSegmentStaleBytesCapRatio != 0.10 {
+		t.Fatalf("ratio-only rewrite policy=%+v", rewriteOpts)
+	}
+
+	files := map[uint32]*valuelog.File{
+		1: rewriteSelectorTestFile(t, "ratio-equal.log", 100),
+		2: rewriteSelectorTestFile(t, "ratio-below.log", 100),
+	}
+	selected := selectRewriteSourceSegments(rewriteOpts, files, map[uint32]struct{}{}, map[uint32]int64{
+		1: 90, // 10 stale bytes: ratio and capped byte-floor equality.
+		2: 91, // 9 stale bytes: below both effective thresholds.
+	})
+	if _, ok := selected[1]; !ok {
+		t.Fatalf("ratio-only override did not select equality candidate: selected=%v", selected)
+	}
+	if _, ok := selected[2]; ok {
+		t.Fatalf("ratio-only override selected below-threshold candidate: selected=%v", selected)
+	}
+}
+
+func TestCompactStorageRewritePolicyBytesOnlyOverrideKeepsExactFloor(t *testing.T) {
+	const customStaleBytes = int64(40)
+	opts := normalizeCompactStorageOptions(CompactStorageOptions{
+		Mode:                                CompactStorageFull,
+		ValueLogRewriteMinSegmentStaleBytes: customStaleBytes,
+	})
+	rewriteOpts := compactStorageRewritePlanOptions(opts, nil)
+	if rewriteOpts.MinSegmentStaleRatio != compactStoragePolicyValueLogRewriteMinStaleRatio || rewriteOpts.MinSegmentStaleBytes != customStaleBytes || rewriteOpts.MinSegmentStaleBytesCapRatio != 0 {
+		t.Fatalf("bytes-only rewrite policy=%+v", rewriteOpts)
+	}
+
+	files := map[uint32]*valuelog.File{
+		1: rewriteSelectorTestFile(t, "bytes-below.log", 100),
+		2: rewriteSelectorTestFile(t, "bytes-equal.log", 100),
+	}
+	selected := selectRewriteSourceSegments(rewriteOpts, files, map[uint32]struct{}{}, map[uint32]int64{
+		1: 61, // 39% stale clears the default ratio but misses the exact byte floor.
+		2: 60, // 40% stale clears both thresholds at byte-floor equality.
+	})
+	if _, ok := selected[1]; ok {
+		t.Fatalf("bytes-only override selected below exact byte floor: selected=%v", selected)
+	}
+	if _, ok := selected[2]; !ok {
+		t.Fatalf("bytes-only override did not select equality candidate: selected=%v", selected)
 	}
 }
 

--- a/TreeDB/db/vlog_rewrite.go
+++ b/TreeDB/db/vlog_rewrite.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -221,6 +222,11 @@ type ValueLogRewriteOnlineOptions struct {
 	// MinSegmentStaleBytes requires estimated stale bytes to be at least this
 	// threshold when sparse segment selection is used.
 	MinSegmentStaleBytes int64
+	// MinSegmentStaleBytesCapRatio caps MinSegmentStaleBytes to this fraction of
+	// each candidate segment's size. It lets callers retain an absolute floor
+	// for large segments without permanently excluding a small segment that
+	// already meets its stale-ratio policy. <=0 disables the cap.
+	MinSegmentStaleBytesCapRatio float64
 	// MinSegmentAge excludes very recent source segments from sparse selection.
 	// This is useful for cached maintenance so freshly-written segments are not
 	// immediately churned by rewrite during sustained ingest.
@@ -1366,6 +1372,7 @@ func selectRewriteSourceSegmentsWithStats(opts ValueLogRewriteOnlineOptions, fil
 
 	minStaleRatio := normalizeStaleRatio(opts.MinSegmentStaleRatio)
 	minStaleBytes := opts.MinSegmentStaleBytes
+	minStaleBytesCapRatio := normalizeStaleRatio(opts.MinSegmentStaleBytesCapRatio)
 	maxSourceSegments := opts.MaxSourceSegments
 	maxSourceBytes := opts.MaxSourceBytes
 	minSegmentAge := opts.MinSegmentAge
@@ -1497,7 +1504,17 @@ func selectRewriteSourceSegmentsWithStats(opts ValueLogRewriteOnlineOptions, fil
 		if minStaleRatio > 0 && staleRatio < minStaleRatio {
 			continue
 		}
-		if minStaleBytes > 0 && staleBytes < minStaleBytes {
+		effectiveMinStaleBytes := minStaleBytes
+		if minStaleBytesCapRatio > 0 {
+			capBytes := int64(math.Ceil(float64(size) * minStaleBytesCapRatio))
+			if capBytes < 1 {
+				capBytes = 1
+			}
+			if effectiveMinStaleBytes > capBytes {
+				effectiveMinStaleBytes = capBytes
+			}
+		}
+		if effectiveMinStaleBytes > 0 && staleBytes < effectiveMinStaleBytes {
 			continue
 		}
 		candidates = append(candidates, rewriteSourceSegment{

--- a/TreeDB/db/vlog_rewrite_test.go
+++ b/TreeDB/db/vlog_rewrite_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -5794,6 +5795,91 @@ func TestSelectRewriteSourceSegments_OversizeCandidates_SelectsOne(t *testing.T)
 	if _, ok := selected[2]; !ok {
 		t.Fatalf("expected segment 2 selected by stale priority, got=%v", selected)
 	}
+}
+
+func TestSelectRewriteSourceSegments_StaleBytesFloorRemainsUncappedForLargeSegment(t *testing.T) {
+	const (
+		segmentSize = int64(32 << 20)
+		staleBytes  = int64(6 << 20)
+	)
+	file := rewriteSelectorTestFile(t, "large.log", segmentSize)
+	files := map[uint32]*valuelog.File{1: file}
+	liveByID := map[uint32]int64{1: segmentSize - staleBytes}
+	if capBytes := int64(math.Ceil(float64(segmentSize) * 0.30)); capBytes <= 8<<20 {
+		t.Fatalf("fixture cap=%d want > 8 MiB", capBytes)
+	}
+
+	selected := selectRewriteSourceSegments(ValueLogRewriteOnlineOptions{
+		MinSegmentStaleRatio:         0.10,
+		MinSegmentStaleBytes:         8 << 20,
+		MinSegmentStaleBytesCapRatio: 0.30,
+	}, files, map[uint32]struct{}{}, liveByID)
+
+	if got := float64(staleBytes) / float64(segmentSize); got < 0.10 {
+		t.Fatalf("fixture stale ratio=%v want >= 0.10", got)
+	}
+	if _, ok := selected[1]; ok {
+		t.Fatalf("large segment selected below uncapped 8 MiB floor: selected=%v", selected)
+	}
+}
+
+func TestSelectRewriteSourceSegments_StaleBytesCapCrossoverAndEquality(t *testing.T) {
+	const (
+		staleFloor = int64(8 << 20)
+		capRatio   = 0.30
+	)
+	// This is the largest integer segment size whose rounded-up cap is exactly
+	// the absolute floor. One byte larger crosses to the uncapped side.
+	equalitySize := staleFloor * 10 / 3
+	if got := int64(math.Ceil(float64(equalitySize) * capRatio)); got != staleFloor {
+		t.Fatalf("equality cap=%d want %d for segment size %d", got, staleFloor, equalitySize)
+	}
+	if got := int64(math.Ceil(float64(equalitySize+1) * capRatio)); got <= staleFloor {
+		t.Fatalf("post-crossover cap=%d want > %d", got, staleFloor)
+	}
+	belowSize := (staleFloor - 1) * 10 / 3
+	belowCap := int64(math.Ceil(float64(belowSize) * capRatio))
+	if belowCap >= staleFloor {
+		t.Fatalf("pre-crossover cap=%d want < %d", belowCap, staleFloor)
+	}
+
+	files := map[uint32]*valuelog.File{
+		1: rewriteSelectorTestFile(t, "below.log", belowSize),
+		2: rewriteSelectorTestFile(t, "equal.log", equalitySize),
+		3: rewriteSelectorTestFile(t, "above-below-floor.log", equalitySize+1),
+		4: rewriteSelectorTestFile(t, "above-at-floor.log", equalitySize+1),
+	}
+	liveByID := map[uint32]int64{
+		1: belowSize - belowCap,
+		2: equalitySize - staleFloor,
+		3: equalitySize + 1 - (staleFloor - 1),
+		4: equalitySize + 1 - staleFloor,
+	}
+	selected := selectRewriteSourceSegments(ValueLogRewriteOnlineOptions{
+		MinSegmentStaleBytes:         staleFloor,
+		MinSegmentStaleBytesCapRatio: capRatio,
+	}, files, map[uint32]struct{}{}, liveByID)
+
+	for _, id := range []uint32{1, 2, 4} {
+		if _, ok := selected[id]; !ok {
+			t.Fatalf("segment %d not selected at effective floor equality: selected=%v", id, selected)
+		}
+	}
+	if _, ok := selected[3]; ok {
+		t.Fatalf("post-crossover segment selected below uncapped floor: selected=%v", selected)
+	}
+}
+
+func rewriteSelectorTestFile(t *testing.T, name string, size int64) *valuelog.File {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(path, nil, 0o600); err != nil {
+		t.Fatalf("create selector fixture %s: %v", path, err)
+	}
+	if err := os.Truncate(path, size); err != nil {
+		t.Fatalf("truncate selector fixture %s to %d: %v", path, size, err)
+	}
+	return &valuelog.File{Path: path}
 }
 
 func TestGroupedRecordKeyForPtr_UsesFullOffsetWidth(t *testing.T) {


### PR DESCRIPTION
Fixes #3635
Parent: #3630

## Summary

- Give default, full, and quick `CompactStorage` a shared conjunctive value-log rewrite policy: stale ratio >= 0.30 and stale bytes >= 8 MiB.
- Preserve `CompactStorageExhaustive` as byte-minimizing: it selects every partially-live segment with at least one stale byte.
- Cap the *default* 8 MiB floor at the active stale-ratio fraction of each small candidate segment. This avoids permanently exempting a small segment that is sufficiently stale. Explicit `ValueLogRewriteMinSegmentStaleBytes` overrides remain exact conjunctive floors.
- Route the applied rewrite phase and every initial, settle, and final debt audit through the same normalized mode-derived options.
- Add TDD coverage for mostly-live skip, ratio/bytes conjunction, high-stale rewrite, small-segment behavior, exhaustive behavior, status flags, defaults/overrides, selector cap crossover/equality, uncapped large-segment behavior, and end-to-end Quick/zero-value-default parity. Add a focused baseline/current benchmark.

## Threshold Rationale

The normal value-log segment size is 128 MiB. At 30% stale, a segment has about 38.4 MiB of reclaimable bytes, so the 8 MiB floor is conservative for normal segments. For a small segment, the default effective floor is `min(8 MiB, ceil(segment_size * stale_ratio))`; thus the 30% ratio remains the controlling threshold below the absolute-floor crossover. This applies only when the byte floor is defaulted. A caller that supplies a byte override retains the documented strict ratio-and-bytes conjunction.

## Status Semantics

`FullyCompacted` remains the legacy policy flag and equals `PolicyFullyCompacted`.

- Default/full/quick: rewrite debt is selected with the shared policy. They can be policy-compacted while `ByteMinimized` is false because sub-threshold stale bytes remain.
- Exhaustive: rewrite policy is stale >= 1; `ByteMinimized` is true only when that final debt is empty.

No value-log format, pointer encoding, WAL, or persistence behavior changed.

## Validation

Validated head: `e07d523a3e448af78e788f8f721bc9bb5f1bf331`.

```sh
GOWORK=off go test ./TreeDB/db -run 'TestCompactStorage.*Rewrite|TestCompactStorage.*Compacted|TestValueLogRewrite.*Stale|TestCompactStorageExhaustive|TestSelectRewriteSourceSegments_StaleBytes' -count=1
GOWORK=off go test ./TreeDB/db -count=1
GOWORK=off go test -race ./TreeDB/db -run 'TestCompactStorage.*Rewrite|TestCompactStorage.*Compacted|TestValueLogRewrite.*Stale|TestCompactStorageExhaustive|TestSelectRewriteSourceSegments_StaleBytes' -count=1
GOWORK=off go test ./TreeDB/... -count=1
GOWORK=off go vet ./TreeDB/db
```

All passed locally on the validated head. The added follow-up commit is test-only; latest-head CI started automatically after push.

## Same-Host Benchmark Evidence

Host: 11th Gen Intel Core i5-11400F @ 2.60GHz. Baseline: clean detached `origin/main` worktree at `9cd9c6874860d2988002701bef042e50ba142cd0`. PR head: `e07d523a3e448af78e788f8f721bc9bb5f1bf331`; the production implementation and benchmark harness remain code-identical to measured implementation head `da3ababda219babad37c451db623dd357e0a0c8b` because the follow-up commit changes tests only. Each benchmark was run on the same host with `-count=5`; table values are sample medians. `ops/sec` is derived from median `ns/op`.

Fixture: one mostly-live, non-active value-log segment with 2,047 live 1 KiB records and one stale record, plus one active segment. It contains 9,264 total physical stale bytes after frame compression. The baseline selects the source segment; the PR policy does not. The high-stale rewrite test independently proves actionable segments still rewrite.

```sh
# Run in each worktree; baseline has the same untracked benchmark harness only.
GOWORK=off go test ./TreeDB/db -run '^$' -bench '^BenchmarkCompactStorageRewritePolicyMostlyLivePlan$' -benchmem -benchtime=100x -count=5
GOWORK=off go test ./TreeDB/db -run '^$' -bench '^BenchmarkCompactStorageRewritePolicyMostlyLiveApply$' -benchmem -benchtime=1x -count=5
```

| Benchmark | Revision | ns/op | ops/sec | B/op | allocs/op | selected bytes/op | copied bytes/op | selected stale bytes/op | total stale bytes/op |
| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Plan | main | 71,658 | 13,954.46 | 19,406 | 174 | 2,195,456 | 2,186,196 | 9,260 | 9,264 |
| Plan | PR | 68,955 | 14,502.94 | 18,804 | 167 | 0 | 0 | 0 | 9,264 |
| Apply | main | 48,311,359 | 20.70 | 2,709,496 | 1,435 | 2,195,456 | 2,096,128 | 9,260 | 9,264 |
| Apply | PR | 24,912,553 | 40.14 | 618,704 | 876 | 0 | 0 | 0 | 9,264 |

Result: selected and copied bytes fall 100%, exceeding the >=80% gate. Planning median time improves 3.8%, planning B/op improves 3.1%, and planning allocs/op improves 4.0%; there is no >5% planning regression. Applied median time improves 48.4% and allocations improve 39.0% on this fixture.

## Caveats

- The focused fixture uses deterministic, compressible 1 KiB values. The domain counters reflect actual on-disk frame sizes, not raw payload bytes; broader workload shape may have different absolute copy volumes.
- The new cap is intentionally limited to the default floor. Explicit policy overrides can still deliberately defer small segments.
- Codex completed review of implementation head `da3ababda219babad37c451db623dd357e0a0c8b`. No review was requested after the test-only follow-up, per coordinator instruction.
